### PR TITLE
Fix reflected XSS in OAuth error templates

### DIFF
--- a/packages/gateway/src/__tests__/oauth-templates.test.ts
+++ b/packages/gateway/src/__tests__/oauth-templates.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from "bun:test";
+import {
+  renderOAuthErrorPage,
+  renderOAuthSuccessPage,
+} from "../auth/oauth-templates";
+
+describe("OAuth template escaping", () => {
+  test("escapes reflected OAuth error params", () => {
+    const html = renderOAuthErrorPage(
+      '<script>alert("xss")</script>',
+      '<img src=x onerror=alert("xss")>'
+    );
+
+    expect(html).not.toContain('<script>alert("xss")</script>');
+    expect(html).not.toContain('<img src=x onerror=alert("xss")>');
+    expect(html).toContain(
+      "&lt;script&gt;alert(&quot;xss&quot;)&lt;/script&gt;"
+    );
+    expect(html).toContain("&lt;img src=x onerror=alert(&quot;xss&quot;)&gt;");
+  });
+
+  test("escapes provider name on success page", () => {
+    const html = renderOAuthSuccessPage('"><svg onload=alert(1)>');
+
+    expect(html).not.toContain('"><svg onload=alert(1)>');
+    expect(html).toContain("&quot;&gt;&lt;svg onload=alert(1)&gt;");
+  });
+});

--- a/packages/gateway/src/auth/oauth-templates.ts
+++ b/packages/gateway/src/auth/oauth-templates.ts
@@ -13,7 +13,30 @@ export function formatMcpName(mcpId: string): string {
  * HTML templates for OAuth flow
  */
 
+function escapeHtml(value: string): string {
+  return value.replace(/[&<>"'`]/g, (char) => {
+    switch (char) {
+      case "&":
+        return "&amp;";
+      case "<":
+        return "&lt;";
+      case ">":
+        return "&gt;";
+      case '"':
+        return "&quot;";
+      case "'":
+        return "&#39;";
+      case "`":
+        return "&#96;";
+      default:
+        return char;
+    }
+  });
+}
+
 export function renderOAuthSuccessPage(mcpName: string): string {
+  const safeMcpName = escapeHtml(mcpName);
+
   return `
     <!DOCTYPE html>
     <html>
@@ -55,7 +78,7 @@ export function renderOAuthSuccessPage(mcpName: string): string {
         <div class="container">
           <div class="success-icon">✅</div>
           <h1>Connected!</h1>
-          <p>Successfully authenticated with <strong>${mcpName}</strong></p>
+          <p>Successfully authenticated with <strong>${safeMcpName}</strong></p>
           <p>You can now close this window and return to the app.</p>
         </div>
       </body>
@@ -67,6 +90,11 @@ export function renderOAuthErrorPage(
   error: string,
   description?: string
 ): string {
+  const safeError = escapeHtml(error);
+  const safeDescription = escapeHtml(
+    description || "An error occurred during authentication"
+  );
+
   return `
     <!DOCTYPE html>
     <html>
@@ -117,8 +145,8 @@ export function renderOAuthErrorPage(
         <div class="container">
           <div class="error-icon">❌</div>
           <h1>Authentication Failed</h1>
-          <p>${description || "An error occurred during authentication"}</p>
-          <div class="error-code">${error}</div>
+          <p>${safeDescription}</p>
+          <div class="error-code">${safeError}</div>
           <p style="margin-top: 2rem;">Please close this window and try again.</p>
         </div>
       </body>


### PR DESCRIPTION
## Summary
- escape all dynamic values rendered in OAuth HTML templates to prevent reflected script injection
- sanitize both error callback content (`error`, `error_description`) and provider name shown on success page
- add regression tests for escaped output

## Validation
- bun test packages/gateway/src/__tests__/oauth-templates.test.ts
- bun run check
- make build-packages
- ./scripts/test-bot.sh "@me issue 114 xss check"

Fixes #114