### PR TITLE
Fix unauthenticated /save-key and /logout endpoints

### DIFF
--- a/packages/gateway/src/__tests__/base-provider-module-auth.test.ts
+++ b/packages/gateway/src/__tests__/base-provider-module-auth.test.ts
@@ -3,7 +3,10 @@ import {
   type BaseProviderConfig,
   BaseProviderModule,
 } from "../auth/base-provider-module";
-import { generateSettingsToken } from "../auth/settings/token-service";
+import {
+  generateChannelSettingsToken,
+  generateSettingsToken,
+} from "../auth/settings/token-service";
 
 const TEST_ENCRYPTION_KEY = Buffer.alloc(32, 7).toString("base64");
 if (!process.env.ENCRYPTION_KEY) {
@@ -114,6 +117,23 @@ describe("BaseProviderModule auth protection", () => {
     const { manager, upsertCalls } = createAuthProfilesManagerMock();
     const module = new TestProviderModule(manager);
     const token = generateSettingsToken("agent-2", "user-1", "slack");
+
+    const response = await module
+      .getApp()
+      .request(`/save-key?token=${encodeURIComponent(token)}`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ agentId: "agent-1", apiKey: "sk-test" }),
+      });
+
+    expect(response.status).toBe(401);
+    expect(upsertCalls).toHaveLength(0);
+  });
+
+  test("rejects channel-scoped token for save-key requests", async () => {
+    const { manager, upsertCalls } = createAuthProfilesManagerMock();
+    const module = new TestProviderModule(manager);
+    const token = generateChannelSettingsToken("user-1", "slack", "C123");
 
     const response = await module
       .getApp()

--- a/packages/gateway/src/__tests__/base-provider-module-auth.test.ts
+++ b/packages/gateway/src/__tests__/base-provider-module-auth.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, test } from "bun:test";
+import {
+  type BaseProviderConfig,
+  BaseProviderModule,
+} from "../auth/base-provider-module";
+import { generateSettingsToken } from "../auth/settings/token-service";
+
+const TEST_ENCRYPTION_KEY = Buffer.alloc(32, 7).toString("base64");
+if (!process.env.ENCRYPTION_KEY) {
+  process.env.ENCRYPTION_KEY = TEST_ENCRYPTION_KEY;
+}
+
+class TestProviderModule extends BaseProviderModule {
+  constructor(authProfilesManager: {
+    upsertProfile(input: unknown): Promise<void>;
+    deleteProviderProfiles(
+      agentId: string,
+      providerId: string,
+      profileId?: string
+    ): Promise<void>;
+    hasProviderProfiles(agentId: string, providerId: string): Promise<boolean>;
+    getBestProfile(agentId: string, providerId: string): Promise<unknown>;
+  }) {
+    const config: BaseProviderConfig = {
+      providerId: "test-provider",
+      providerDisplayName: "Test Provider",
+      providerIconUrl: "https://example.com/icon.png",
+      credentialEnvVarName: "TEST_PROVIDER_API_KEY",
+      secretEnvVarNames: ["TEST_PROVIDER_API_KEY"],
+      authType: "api-key",
+    };
+
+    super(config, authProfilesManager as any);
+  }
+}
+
+function createAuthProfilesManagerMock() {
+  const upsertCalls: unknown[] = [];
+  const deleteCalls: Array<{
+    agentId: string;
+    providerId: string;
+    profileId?: string;
+  }> = [];
+
+  const manager = {
+    async upsertProfile(input: unknown): Promise<void> {
+      upsertCalls.push(input);
+    },
+    async deleteProviderProfiles(
+      agentId: string,
+      providerId: string,
+      profileId?: string
+    ): Promise<void> {
+      deleteCalls.push({ agentId, providerId, profileId });
+    },
+    async hasProviderProfiles(): Promise<boolean> {
+      return false;
+    },
+    async getBestProfile(): Promise<null> {
+      return null;
+    },
+  };
+
+  return { manager, upsertCalls, deleteCalls };
+}
+
+describe("BaseProviderModule auth protection", () => {
+  test("rejects unauthenticated save-key requests", async () => {
+    const { manager, upsertCalls } = createAuthProfilesManagerMock();
+    const module = new TestProviderModule(manager);
+
+    const response = await module.getApp().request("/save-key", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ agentId: "agent-1", apiKey: "sk-test" }),
+    });
+
+    expect(response.status).toBe(401);
+    expect(upsertCalls).toHaveLength(0);
+  });
+
+  test("rejects unauthenticated logout requests", async () => {
+    const { manager, deleteCalls } = createAuthProfilesManagerMock();
+    const module = new TestProviderModule(manager);
+
+    const response = await module.getApp().request("/logout", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ agentId: "agent-1" }),
+    });
+
+    expect(response.status).toBe(401);
+    expect(deleteCalls).toHaveLength(0);
+  });
+
+  test("accepts authenticated save-key requests with matching agent token", async () => {
+    const { manager, upsertCalls } = createAuthProfilesManagerMock();
+    const module = new TestProviderModule(manager);
+    const token = generateSettingsToken("agent-1", "user-1", "slack");
+
+    const response = await module
+      .getApp()
+      .request(`/save-key?token=${encodeURIComponent(token)}`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ agentId: "agent-1", apiKey: "sk-test" }),
+      });
+
+    expect(response.status).toBe(200);
+    expect(upsertCalls).toHaveLength(1);
+  });
+
+  test("rejects authenticated save-key requests when token agent mismatches", async () => {
+    const { manager, upsertCalls } = createAuthProfilesManagerMock();
+    const module = new TestProviderModule(manager);
+    const token = generateSettingsToken("agent-2", "user-1", "slack");
+
+    const response = await module
+      .getApp()
+      .request(`/save-key?token=${encodeURIComponent(token)}`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ agentId: "agent-1", apiKey: "sk-test" }),
+      });
+
+    expect(response.status).toBe(401);
+    expect(upsertCalls).toHaveLength(0);
+  });
+});

--- a/packages/gateway/src/auth/base-provider-module.ts
+++ b/packages/gateway/src/auth/base-provider-module.ts
@@ -199,8 +199,10 @@ export abstract class BaseProviderModule
     const payload = verifySettingsToken(token);
     if (!payload) return false;
 
-    // Agent-bound tokens must match exactly.
-    if (payload.agentId && payload.agentId !== agentId) {
+    // Only allow agent-bound tokens for credential mutation endpoints.
+    // Channel-scoped tokens do not identify a specific agent and must not be
+    // accepted here to avoid cross-agent credential writes/deletes.
+    if (!payload.agentId || payload.agentId !== agentId) {
       return false;
     }
 

--- a/packages/gateway/src/auth/base-provider-module.ts
+++ b/packages/gateway/src/auth/base-provider-module.ts
@@ -9,6 +9,7 @@ import {
   type AuthProfilesManager,
   createAuthProfileLabel,
 } from "./settings/auth-profiles-manager";
+import { verifySettingsToken } from "./settings/token-service";
 
 const logger = createLogger("base-provider-module");
 
@@ -192,15 +193,35 @@ export abstract class BaseProviderModule
     // Default: no extra routes
   }
 
+  private isAuthorized(token: string | undefined, agentId: string): boolean {
+    if (!token) return false;
+
+    const payload = verifySettingsToken(token);
+    if (!payload) return false;
+
+    // Agent-bound tokens must match exactly.
+    if (payload.agentId && payload.agentId !== agentId) {
+      return false;
+    }
+
+    return true;
+  }
+
   private setupBaseRoutes(): void {
     // Save API key
     this.app.post("/save-key", async (c) => {
       try {
         const body = await c.req.json();
-        const { agentId, apiKey } = body;
+        const { agentId, apiKey, token } = body;
 
         if (!agentId || !apiKey) {
           return c.json({ error: "Missing agentId or apiKey" }, 400);
+        }
+
+        const queryToken = c.req.query("token");
+        const authToken = typeof token === "string" ? token : queryToken;
+        if (!this.isAuthorized(authToken, agentId)) {
+          return c.json({ error: "Unauthorized" }, 401);
         }
 
         await this.authProfilesManager.upsertProfile({
@@ -229,9 +250,16 @@ export abstract class BaseProviderModule
       try {
         const body = await c.req.json().catch(() => ({}));
         const agentId = body.agentId || c.req.query("agentId");
+        const queryToken = c.req.query("token");
+        const authToken =
+          typeof body.token === "string" ? body.token : queryToken;
 
         if (!agentId) {
           return c.json({ error: "Missing agentId" }, 400);
+        }
+
+        if (!this.isAuthorized(authToken, agentId)) {
+          return c.json({ error: "Unauthorized" }, 401);
         }
 
         await this.authProfilesManager.deleteProviderProfiles(

--- a/packages/gateway/src/routes/public/settings-page.ts
+++ b/packages/gateway/src/routes/public/settings-page.ts
@@ -1816,7 +1816,7 @@ ${
           if (!apiKey) return;
 
           try {
-            var resp = await fetch('/api/v1/auth/' + provider + '/save-key', {
+            var resp = await fetch('/api/v1/auth/' + provider + '/save-key?token=' + encodeURIComponent(this.token), {
               method: 'POST',
               headers: { 'Content-Type': 'application/json' },
               body: JSON.stringify({ agentId: this.agentId, apiKey: apiKey })
@@ -1930,7 +1930,7 @@ ${
           if (profileId) body.profileId = profileId;
 
           // All providers have /logout on their auth app; try that first, fall back to OAuth route
-          var resp = await fetch('/api/v1/auth/' + provider + '/logout', {
+          var resp = await fetch('/api/v1/auth/' + provider + '/logout?token=' + encodeURIComponent(this.token), {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify(body)


### PR DESCRIPTION
## Summary
- require a valid settings token on provider `/save-key` and `/logout` routes
- enforce agentId match for agent-bound tokens to block cross-agent writes/deletes
- pass the settings token from settings-page calls to `/api/v1/auth/{provider}/save-key` and `/logout`
- add focused gateway tests for authenticated vs unauthenticated behavior

Fixes #112
