### PR TITLE
fix: stop logging WhatsApp credential material

### DIFF
--- a/packages/gateway/src/whatsapp/connection/auth-state.ts
+++ b/packages/gateway/src/whatsapp/connection/auth-state.ts
@@ -192,11 +192,13 @@ export function createAuthState(initialState: AuthState | null): {
 }
 
 /**
- * Log credentials update instruction for the user.
+ * Log credentials update without emitting credential material.
  */
-export function logCredentialsUpdateInstruction(serialized: string): void {
+export function logCredentialsUpdateInstruction(
+  serializedLength: number
+): void {
   logger.info(
-    "WhatsApp credentials updated. To persist, update your environment:"
+    { serializedLength },
+    "WhatsApp credentials updated in memory; persist via secure secret storage (WHATSAPP_CREDENTIALS)."
   );
-  logger.info(`WHATSAPP_CREDENTIALS=${serialized}`);
 }

--- a/packages/gateway/src/whatsapp/connection/baileys-client.ts
+++ b/packages/gateway/src/whatsapp/connection/baileys-client.ts
@@ -177,7 +177,7 @@ export class BaileysClient extends EventEmitter<BaileysClientEvents> {
       if (this.authState) {
         const serialized = await this.authState.saveCreds();
         this.emit("credentialsUpdated", serialized);
-        logCredentialsUpdateInstruction(serialized);
+        logCredentialsUpdateInstruction(serialized.length);
       }
     });
 


### PR DESCRIPTION
## Summary
- remove runtime log output that printed full `WHATSAPP_CREDENTIALS` values from WhatsApp auth state handling
- keep observability by logging a non-sensitive `serializedLength` metadata field when credentials rotate
- update the Baileys credential-update callsite to pass only sanitized metadata to logging helper

## Validation
- `bun run check`
- `make build-packages`
- `./scripts/test-bot.sh "@me issue 119 logging check"` (fails in this environment: no platform configured / WhatsApp not enabled in running stack)

Fixes #119
