### PR TITLE
fix(gateway): remove settings token from URL query flow

### DIFF
--- a/packages/gateway/src/auth/settings/token-service.ts
+++ b/packages/gateway/src/auth/settings/token-service.ts
@@ -281,8 +281,10 @@ export function verifySettingsToken(
 /**
  * Build the full settings URL with token
  */
+export const SETTINGS_TOKEN_HASH_PARAM = "st";
+
 export function buildSettingsUrl(token: string): string {
   const baseUrl = process.env.PUBLIC_GATEWAY_URL || "http://localhost:8080";
-  // URL-encode the token since it contains special characters
-  return `${baseUrl}/settings?token=${encodeURIComponent(token)}`;
+  // Keep the token in URL hash so it never appears in server logs/referrers.
+  return `${baseUrl}/settings#${SETTINGS_TOKEN_HASH_PARAM}=${encodeURIComponent(token)}`;
 }

--- a/packages/gateway/src/routes/public/agent-config.ts
+++ b/packages/gateway/src/routes/public/agent-config.ts
@@ -12,18 +12,16 @@ import { collectModelValues } from "../../auth/provider-model-options";
 import type { ProviderStatus } from "../../auth/provider-status";
 import type { AgentSettings, AgentSettingsStore } from "../../auth/settings";
 import type { AuthProfilesManager } from "../../auth/settings/auth-profiles-manager";
-import {
-  type SettingsTokenPayload,
-  verifySettingsToken,
-} from "../../auth/settings/token-service";
+import type { SettingsTokenPayload } from "../../auth/settings/token-service";
 import type { UserAgentsStore } from "../../auth/user-agents-store";
 import type { WorkerConnectionManager } from "../../gateway/connection-manager";
 import type { IMessageQueue } from "../../infrastructure/queue";
 import type { GrantStore } from "../../permissions/grant-store";
+import { verifySettingsSession } from "./settings-auth";
 
 const TAG = "Agents";
 const ErrorResponse = z.object({ error: z.string() });
-const TokenQuery = z.object({ token: z.string() });
+const TokenQuery = z.object({ token: z.string().optional() });
 const logger = createLogger("agent-config-routes");
 
 // --- Route Definitions ---
@@ -182,11 +180,9 @@ export function createAgentConfigRoutes(
    * verify user owns the agent via userAgentsStore or it's a workspace agent.
    */
   const verifyToken = async (
-    token: string | undefined,
+    payload: SettingsTokenPayload | null,
     agentId: string
   ): Promise<SettingsTokenPayload | null> => {
-    if (!token) return null;
-    const payload = verifySettingsToken(token);
     if (!payload) return null;
 
     if (payload.agentId) {
@@ -217,7 +213,7 @@ export function createAgentConfigRoutes(
 
   app.openapi(getConfigRoute, async (c): Promise<any> => {
     const agentId = c.req.param("agentId") || "";
-    const payload = await verifyToken(c.req.valid("query").token, agentId);
+    const payload = await verifyToken(verifySettingsSession(c), agentId);
     if (!payload) return c.json({ error: "Unauthorized" }, 401);
 
     const settings = await config.agentSettingsStore.getSettings(agentId);
@@ -273,7 +269,7 @@ export function createAgentConfigRoutes(
 
   app.openapi(updateConfigRoute, async (c): Promise<any> => {
     const agentId = c.req.param("agentId") || "";
-    const payload = await verifyToken(c.req.valid("query").token, agentId);
+    const payload = await verifyToken(verifySettingsSession(c), agentId);
     if (!payload) return c.json({ error: "Unauthorized" }, 401);
 
     try {
@@ -329,8 +325,7 @@ export function createAgentConfigRoutes(
   // GET /packages/search?q=python
   app.get("/packages/search", async (c): Promise<any> => {
     const agentId = c.req.param("agentId") || "";
-    const token = c.req.query("token");
-    const payload = await verifyToken(token, agentId);
+    const payload = await verifyToken(verifySettingsSession(c), agentId);
     if (!payload) return c.json({ error: "Unauthorized" }, 401);
 
     const query = (c.req.query("q") || "").trim();
@@ -352,8 +347,7 @@ export function createAgentConfigRoutes(
   // GET /providers/catalog
   app.get("/providers/catalog", async (c): Promise<any> => {
     const agentId = c.req.param("agentId") || "";
-    const token = c.req.query("token");
-    const payload = await verifyToken(token, agentId);
+    const payload = await verifyToken(verifySettingsSession(c), agentId);
     if (!payload) return c.json({ error: "Unauthorized" }, 401);
 
     if (!config.providerCatalogService) {
@@ -380,8 +374,7 @@ export function createAgentConfigRoutes(
   // POST /providers/install
   app.post("/providers/install", async (c): Promise<any> => {
     const agentId = c.req.param("agentId") || "";
-    const token = c.req.query("token");
-    const payload = await verifyToken(token, agentId);
+    const payload = await verifyToken(verifySettingsSession(c), agentId);
     if (!payload) return c.json({ error: "Unauthorized" }, 401);
 
     if (!config.providerCatalogService) {
@@ -413,8 +406,7 @@ export function createAgentConfigRoutes(
   // POST /providers/uninstall
   app.post("/providers/uninstall", async (c): Promise<any> => {
     const agentId = c.req.param("agentId") || "";
-    const token = c.req.query("token");
-    const payload = await verifyToken(token, agentId);
+    const payload = await verifyToken(verifySettingsSession(c), agentId);
     if (!payload) return c.json({ error: "Unauthorized" }, 401);
 
     if (!config.providerCatalogService) {
@@ -445,8 +437,7 @@ export function createAgentConfigRoutes(
   // PATCH /providers/reorder
   app.patch("/providers/reorder", async (c): Promise<any> => {
     const agentId = c.req.param("agentId") || "";
-    const token = c.req.query("token");
-    const payload = await verifyToken(token, agentId);
+    const payload = await verifyToken(verifySettingsSession(c), agentId);
     if (!payload) return c.json({ error: "Unauthorized" }, 401);
 
     if (!config.providerCatalogService) {
@@ -482,8 +473,7 @@ export function createAgentConfigRoutes(
     // GET /grants - List all active grants
     app.get("/grants", async (c) => {
       const agentId = c.req.param("agentId") || "";
-      const token = c.req.query("token");
-      const payload = await verifyToken(token, agentId);
+      const payload = await verifyToken(verifySettingsSession(c), agentId);
       if (!payload) return c.json({ error: "Unauthorized" }, 401);
 
       const grants = await grantStore.listGrants(agentId);
@@ -493,8 +483,7 @@ export function createAgentConfigRoutes(
     // POST /grants - Create a grant
     app.post("/grants", async (c) => {
       const agentId = c.req.param("agentId") || "";
-      const token = c.req.query("token");
-      const payload = await verifyToken(token, agentId);
+      const payload = await verifyToken(verifySettingsSession(c), agentId);
       if (!payload) return c.json({ error: "Unauthorized" }, 401);
 
       const body = await c.req.json<{
@@ -524,8 +513,7 @@ export function createAgentConfigRoutes(
     app.delete("/grants/:pattern", async (c) => {
       const agentId = c.req.param("agentId") || "";
       const pattern = decodeURIComponent(c.req.param("pattern") || "");
-      const token = c.req.query("token");
-      const payload = await verifyToken(token, agentId);
+      const payload = await verifyToken(verifySettingsSession(c), agentId);
       if (!payload) return c.json({ error: "Unauthorized" }, 401);
 
       await grantStore.revoke(agentId, pattern);

--- a/packages/gateway/src/routes/public/agent-schedules.ts
+++ b/packages/gateway/src/routes/public/agent-schedules.ts
@@ -6,16 +6,14 @@
 
 import { createRoute, OpenAPIHono, z } from "@hono/zod-openapi";
 import type { AgentMetadataStore } from "../../auth/agent-metadata-store";
-import {
-  type SettingsTokenPayload,
-  verifySettingsToken,
-} from "../../auth/settings/token-service";
+import type { SettingsTokenPayload } from "../../auth/settings/token-service";
 import type { UserAgentsStore } from "../../auth/user-agents-store";
 import type { ScheduledWakeupService } from "../../orchestration/scheduled-wakeup";
+import { verifySettingsSession } from "./settings-auth";
 
 const TAG = "Agents";
 const ErrorResponse = z.object({ error: z.string() });
-const TokenQuery = z.object({ token: z.string() });
+const TokenQuery = z.object({ token: z.string().optional() });
 
 // --- Route Definitions ---
 
@@ -92,11 +90,9 @@ export function createAgentSchedulesRoutes(
   const app = new OpenAPIHono();
 
   const verifyToken = async (
-    token: string | undefined,
+    payload: SettingsTokenPayload | null,
     agentId: string
   ): Promise<SettingsTokenPayload | null> => {
-    if (!token) return null;
-    const payload = verifySettingsToken(token);
     if (!payload) return null;
 
     if (payload.agentId) {
@@ -121,7 +117,7 @@ export function createAgentSchedulesRoutes(
 
   app.openapi(listSchedulesRoute, async (c): Promise<any> => {
     const agentId = c.req.param("agentId") || "";
-    const payload = await verifyToken(c.req.valid("query").token, agentId);
+    const payload = await verifyToken(verifySettingsSession(c), agentId);
     if (!payload) return c.json({ error: "Unauthorized" }, 401);
 
     if (!config.scheduledWakeupService) return c.json({ schedules: [] });
@@ -142,7 +138,7 @@ export function createAgentSchedulesRoutes(
 
   app.openapi(cancelScheduleRoute, async (c): Promise<any> => {
     const agentId = c.req.param("agentId") || "";
-    const payload = await verifyToken(c.req.valid("query").token, agentId);
+    const payload = await verifyToken(verifySettingsSession(c), agentId);
     if (!payload) return c.json({ error: "Unauthorized" }, 401);
 
     if (!config.scheduledWakeupService) {

--- a/packages/gateway/src/routes/public/agents.ts
+++ b/packages/gateway/src/routes/public/agents.ts
@@ -11,9 +11,9 @@ import { createLogger } from "@lobu/core";
 import { Hono } from "hono";
 import type { AgentMetadataStore } from "../../auth/agent-metadata-store";
 import type { AgentSettingsStore } from "../../auth/settings";
-import { verifySettingsToken } from "../../auth/settings/token-service";
 import type { UserAgentsStore } from "../../auth/user-agents-store";
 import type { ChannelBindingService } from "../../channels";
+import { verifySettingsSession } from "./settings-auth";
 
 const logger = createLogger("agent-routes");
 
@@ -46,12 +46,7 @@ export function createAgentRoutes(config: AgentRoutesConfig): Hono {
 
   // POST /api/v1/agents - Create a new agent
   router.post("/", async (c) => {
-    const token = c.req.query("token");
-    if (!token) {
-      return c.json({ error: "Missing token" }, 401);
-    }
-
-    const payload = verifySettingsToken(token);
+    const payload = verifySettingsSession(c);
     if (!payload) {
       return c.json({ error: "Invalid or expired token" }, 401);
     }
@@ -142,12 +137,7 @@ export function createAgentRoutes(config: AgentRoutesConfig): Hono {
 
   // GET /api/v1/agents - List user's agents
   router.get("/", async (c) => {
-    const token = c.req.query("token");
-    if (!token) {
-      return c.json({ error: "Missing token" }, 401);
-    }
-
-    const payload = verifySettingsToken(token);
+    const payload = verifySettingsSession(c);
     if (!payload) {
       return c.json({ error: "Invalid or expired token" }, 401);
     }
@@ -185,12 +175,7 @@ export function createAgentRoutes(config: AgentRoutesConfig): Hono {
 
   // DELETE /api/v1/agents/{agentId} - Delete an agent
   router.delete("/:agentId", async (c) => {
-    const token = c.req.query("token");
-    if (!token) {
-      return c.json({ error: "Missing token" }, 401);
-    }
-
-    const payload = verifySettingsToken(token);
+    const payload = verifySettingsSession(c);
     if (!payload) {
       return c.json({ error: "Invalid or expired token" }, 401);
     }

--- a/packages/gateway/src/routes/public/integrations.ts
+++ b/packages/gateway/src/routes/public/integrations.ts
@@ -6,9 +6,9 @@
  */
 
 import { createRoute, OpenAPIHono, z } from "@hono/zod-openapi";
-import { verifySettingsToken } from "../../auth/settings/token-service";
 import { McpRegistryService } from "../../services/mcp-registry";
 import { SkillsFetcherService } from "../../services/skills-fetcher";
+import { verifySettingsSession } from "./settings-auth";
 
 const TAG = "Integrations";
 const ErrorResponse = z.object({ error: z.string() });
@@ -22,7 +22,7 @@ const registryRoute = createRoute({
     "Returns curated skills and MCPs if no query, or searches both registries in parallel if q provided",
   request: {
     query: z.object({
-      token: z.string(),
+      token: z.string().optional(),
       q: z
         .string()
         .optional()
@@ -70,7 +70,7 @@ const skillFetchRoute = createRoute({
   summary: "Fetch skill metadata from ClawHub",
   description: "Fetches skill name, description, and content by slug",
   request: {
-    query: z.object({ token: z.string() }),
+    query: z.object({ token: z.string().optional() }),
     body: {
       content: {
         "application/json": {
@@ -121,7 +121,7 @@ const mcpByIdRoute = createRoute({
   description:
     "Returns full MCP server configuration including setup instructions",
   request: {
-    query: z.object({ token: z.string() }),
+    query: z.object({ token: z.string().optional() }),
     params: z.object({ id: z.string() }),
   },
   responses: {
@@ -156,12 +156,10 @@ export function createIntegrationsRoutes(): OpenAPIHono {
   const skillsFetcher = new SkillsFetcherService();
   const mcpRegistry = new McpRegistryService();
 
-  const verifyToken = (token: string | undefined) =>
-    token ? verifySettingsToken(token) : null;
-
   app.openapi(registryRoute, async (c): Promise<any> => {
-    const { token, q, limit } = c.req.valid("query");
-    if (!verifyToken(token)) return c.json({ error: "Unauthorized" }, 401);
+    const { q, limit } = c.req.valid("query");
+    if (!verifySettingsSession(c))
+      return c.json({ error: "Unauthorized" }, 401);
 
     const maxLimit = Math.min(parseInt(limit || "20", 10), 50);
 
@@ -196,8 +194,8 @@ export function createIntegrationsRoutes(): OpenAPIHono {
   });
 
   app.openapi(skillFetchRoute, async (c): Promise<any> => {
-    const { token } = c.req.valid("query");
-    if (!verifyToken(token)) return c.json({ error: "Unauthorized" }, 401);
+    if (!verifySettingsSession(c))
+      return c.json({ error: "Unauthorized" }, 401);
 
     const { repo, refresh } = c.req.valid("json");
     if (!repo?.trim()) return c.json({ error: "Missing skill slug" }, 400);
@@ -218,8 +216,8 @@ export function createIntegrationsRoutes(): OpenAPIHono {
   });
 
   app.openapi(mcpByIdRoute, async (c): Promise<any> => {
-    const { token } = c.req.valid("query");
-    if (!verifyToken(token)) return c.json({ error: "Unauthorized" }, 401);
+    if (!verifySettingsSession(c))
+      return c.json({ error: "Unauthorized" }, 401);
 
     const { id } = c.req.valid("param");
     const mcp = mcpRegistry.getById(id);

--- a/packages/gateway/src/routes/public/oauth.ts
+++ b/packages/gateway/src/routes/public/oauth.ts
@@ -7,7 +7,8 @@
 import { createRoute, OpenAPIHono, z } from "@hono/zod-openapi";
 import type { ClaudeOAuthStateStore } from "../../auth/oauth/state-store";
 import type { AgentSettingsStore } from "../../auth/settings";
-import { verifySettingsToken } from "../../auth/settings/token-service";
+import type { SettingsTokenPayload } from "../../auth/settings/token-service";
+import { verifySettingsSession } from "./settings-auth";
 
 const TAG = "OAuth";
 const ErrorResponse = z.object({ error: z.string() });
@@ -36,7 +37,7 @@ const codeExchangeRoute = createRoute({
   tags: [TAG],
   summary: "Exchange OAuth code for token",
   request: {
-    query: z.object({ token: z.string() }),
+    query: z.object({ token: z.string().optional() }),
     params: z.object({ provider: z.string() }),
     body: {
       content: {
@@ -68,7 +69,7 @@ const providerLogoutRoute = createRoute({
   tags: [TAG],
   summary: "Disconnect OAuth provider",
   request: {
-    query: z.object({ token: z.string() }),
+    query: z.object({ token: z.string().optional() }),
     params: z.object({ provider: z.string() }),
   },
   responses: {
@@ -98,21 +99,15 @@ export function createOAuthRoutes(config: OAuthRoutesConfig): OpenAPIHono {
   const app = new OpenAPIHono();
 
   const verifyToken = (
-    token: string | undefined
-  ):
-    | (import("../../auth/settings/token-service").SettingsTokenPayload & {
-        agentId: string;
-      })
-    | null => {
-    if (!token) return null;
-    const payload = verifySettingsToken(token);
+    payload: SettingsTokenPayload | null
+  ): (SettingsTokenPayload & { agentId: string }) | null => {
     if (!payload || !payload.agentId) return null;
     return payload as typeof payload & { agentId: string };
   };
 
   // --- Provider login redirect (excluded from docs) ---
   app.get("/providers/:provider/login", async (c) => {
-    const payload = verifyToken(c.req.query("token"));
+    const payload = verifyToken(verifySettingsSession(c));
     if (!payload) return c.json({ error: "Unauthorized" }, 401);
 
     const provider = c.req.param("provider");
@@ -134,8 +129,7 @@ export function createOAuthRoutes(config: OAuthRoutesConfig): OpenAPIHono {
 
   // --- Provider code exchange ---
   app.openapi(codeExchangeRoute, async (c): Promise<any> => {
-    const { token } = c.req.valid("query");
-    const payload = verifyToken(token);
+    const payload = verifyToken(verifySettingsSession(c));
     if (!payload) return c.json({ error: "Unauthorized" }, 401);
 
     const { provider } = c.req.valid("param");
@@ -176,7 +170,7 @@ export function createOAuthRoutes(config: OAuthRoutesConfig): OpenAPIHono {
 
   // --- Provider logout ---
   app.openapi(providerLogoutRoute, async (c): Promise<any> => {
-    const payload = verifyToken(c.req.valid("query").token);
+    const payload = verifyToken(verifySettingsSession(c));
     if (!payload) return c.json({ error: "Unauthorized" }, 401);
 
     const { provider } = c.req.valid("param");

--- a/packages/gateway/src/routes/public/settings-auth.ts
+++ b/packages/gateway/src/routes/public/settings-auth.ts
@@ -1,0 +1,67 @@
+import type { Context } from "hono";
+import { deleteCookie, getCookie, setCookie } from "hono/cookie";
+import {
+  type SettingsTokenPayload,
+  verifySettingsToken,
+} from "../../auth/settings/token-service";
+
+export const SETTINGS_TOKEN_QUERY_PARAM = "token";
+export const SETTINGS_SESSION_COOKIE_NAME = "lobu_settings_session";
+
+function getTokenFromQuery(c: Context): string | undefined {
+  const token = c.req.query(SETTINGS_TOKEN_QUERY_PARAM);
+  if (!token || token.trim().length === 0) return undefined;
+  return token;
+}
+
+function getTokenFromCookie(c: Context): string | undefined {
+  const token = getCookie(c, SETTINGS_SESSION_COOKIE_NAME);
+  if (!token || token.trim().length === 0) return undefined;
+  return token;
+}
+
+function isSecureRequest(c: Context): boolean {
+  const forwardedProto = c.req.header("x-forwarded-proto");
+  if (forwardedProto) {
+    return forwardedProto.split(",")[0]?.trim().toLowerCase() === "https";
+  }
+  return new URL(c.req.url).protocol === "https:";
+}
+
+export function resolveSettingsToken(c: Context): string | undefined {
+  return getTokenFromQuery(c) ?? getTokenFromCookie(c);
+}
+
+export function verifySettingsSession(c: Context): SettingsTokenPayload | null {
+  const token = resolveSettingsToken(c);
+  if (!token) return null;
+  return verifySettingsToken(token);
+}
+
+export function setSettingsSessionCookie(
+  c: Context,
+  token: string,
+  payload?: SettingsTokenPayload
+): boolean {
+  const verifiedPayload = payload ?? verifySettingsToken(token);
+  if (!verifiedPayload) return false;
+
+  const maxAgeSeconds = Math.max(
+    1,
+    Math.floor((verifiedPayload.exp - Date.now()) / 1000)
+  );
+
+  setCookie(c, SETTINGS_SESSION_COOKIE_NAME, token, {
+    path: "/",
+    httpOnly: true,
+    sameSite: "Lax",
+    secure: isSecureRequest(c),
+    maxAge: maxAgeSeconds,
+  });
+
+  return true;
+}
+
+export function clearSettingsSessionCookie(c: Context): void {
+  deleteCookie(c, SETTINGS_SESSION_COOKIE_NAME, { path: "/" });
+}

--- a/packages/gateway/src/routes/public/settings-page.ts
+++ b/packages/gateway/src/routes/public/settings-page.ts
@@ -5,7 +5,10 @@
 import type { ModelOption } from "@lobu/core";
 import type { AgentMetadata } from "../../auth/agent-metadata-store";
 import type { AgentSettings } from "../../auth/settings";
-import type { SettingsTokenPayload } from "../../auth/settings/token-service";
+import {
+  SETTINGS_TOKEN_HASH_PARAM,
+  type SettingsTokenPayload,
+} from "../../auth/settings/token-service";
 import { platformRegistry } from "../../platform";
 import { settingsPageCSS } from "./settings-page-styles";
 
@@ -89,7 +92,6 @@ export interface SettingsPageOptions {
 export function renderSettingsPage(
   payload: SettingsTokenPayload,
   settings: AgentSettings | null,
-  token: string,
   options?: SettingsPageOptions
 ): string {
   const s: Partial<AgentSettings> = settings || {};
@@ -153,7 +155,6 @@ export function renderSettingsPage(
   })();
 
   const initialState = {
-    token,
     agentId: payload.agentId,
     PROVIDERS: Object.fromEntries(
       providers.map((p) => [
@@ -201,6 +202,7 @@ export function renderSettingsPage(
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="referrer" content="no-referrer">
   <title>Agent Settings - Lobu</title>
   <style>${settingsPageCSS}</style>
   <script defer src="https://cdn.jsdelivr.net/npm/alpinejs@3.14.9/dist/cdn.min.js"></script>
@@ -527,7 +529,7 @@ ${agents
             html += `
 						          <div x-show="${showCond}" x-transition>
 						            <div class="mb-3 text-center">
-						              <a :href="'/api/v1/oauth/providers/${p.id}/login?token=' + encodeURIComponent(token)" target="_blank" class="inline-block px-4 py-2 text-xs font-medium rounded-lg bg-slate-600 text-white hover:bg-slate-700 transition-all">
+						              <a :href="'/api/v1/oauth/providers/${p.id}/login'" target="_blank" class="inline-block px-4 py-2 text-xs font-medium rounded-lg bg-slate-600 text-white hover:bg-slate-700 transition-all">
 						                Login with ${escapeHtml(p.name)}
 						              </a>
 						            </div>
@@ -661,7 +663,7 @@ ${agents
               <template x-if="pendingProvider && !pendingProvider.success && providerState[pendingProvider.id]?.activeAuthTab !== 'api-key' && (providerState[pendingProvider.id]?.showCodeInput || ((pendingProvider.supportedAuthTypes || [pendingProvider.authType]).length === 1 && pendingProvider.authType === 'oauth'))">
                 <div>
                   <div class="mb-3 text-center">
-                    <a :href="'/api/v1/oauth/providers/' + pendingProvider.id + '/login?token=' + encodeURIComponent(token)" target="_blank" class="inline-block px-4 py-2 text-xs font-medium rounded-lg bg-slate-600 text-white hover:bg-slate-700 transition-all" x-text="'Login with ' + pendingProvider.name">
+                    <a :href="'/api/v1/oauth/providers/' + pendingProvider.id + '/login'" target="_blank" class="inline-block px-4 py-2 text-xs font-medium rounded-lg bg-slate-600 text-white hover:bg-slate-700 transition-all" x-text="'Login with ' + pendingProvider.name">
                     </a>
                   </div>
                   <p class="text-xs text-gray-600 mb-2" x-text="'Paste the authentication code from ' + pendingProvider.name + ':'"></p>
@@ -1063,7 +1065,6 @@ ${agents
     function settingsApp() {
       return {
         // Config
-        token: __STATE__.token,
         agentId: __STATE__.agentId,
         PROVIDERS: __STATE__.PROVIDERS,
 
@@ -1352,7 +1353,7 @@ ${
           this.nixPackageSearchLoading = true;
           try {
             var response = await fetch(
-              this.apiUrl('/config/packages/search') + '&q=' + encodeURIComponent(query)
+              this.apiUrl('/config/packages/search') + '?q=' + encodeURIComponent(query)
             );
             var data = await response.json().catch(function() { return {}; });
             if (!response.ok) throw new Error(data.error || 'Failed to search packages');
@@ -1423,12 +1424,12 @@ ${
         },
 
         apiUrl(path) {
-          return '/api/v1/agents/' + encodeURIComponent(this.agentId) + path + '?token=' + encodeURIComponent(this.token);
+          return '/api/v1/agents/' + encodeURIComponent(this.agentId) + path;
         },
 
         async switchAgent(agentId) {
           try {
-            var resp = await fetch('/settings/switch-agent?token=' + encodeURIComponent(this.token), {
+            var resp = await fetch('/settings/switch-agent', {
               method: 'POST',
               headers: { 'Content-Type': 'application/json' },
               body: JSON.stringify({ agentId: agentId })
@@ -1455,7 +1456,7 @@ ${
             if (this.agentName !== this._initialAgentName) body.name = this.agentName;
             if (this.agentDescription !== this._initialAgentDescription) body.description = this.agentDescription;
 
-            var resp = await fetch('/settings/update-agent?token=' + encodeURIComponent(this.token), {
+            var resp = await fetch('/settings/update-agent', {
               method: 'PATCH',
               headers: { 'Content-Type': 'application/json' },
               body: JSON.stringify(body)
@@ -1487,7 +1488,7 @@ ${
           }
 
           try {
-            var resp = await fetch('/settings/create-agent?token=' + encodeURIComponent(this.token), {
+            var resp = await fetch('/settings/create-agent', {
               method: 'POST',
               headers: { 'Content-Type': 'application/json' },
               body: JSON.stringify({ agentId: agentId, name: name.trim() })
@@ -1505,7 +1506,7 @@ ${
 
         async deleteAgent() {
           try {
-            var resp = await fetch('/api/v1/agent-management/agents/' + encodeURIComponent(this.agentId) + '?token=' + encodeURIComponent(this.token), {
+            var resp = await fetch('/api/v1/agent-management/agents/' + encodeURIComponent(this.agentId), {
               method: 'DELETE'
             });
             var result = await resp.json();
@@ -1777,7 +1778,7 @@ ${
           }
 
           try {
-            var resp = await fetch('/api/v1/oauth/providers/' + provider + '/code?token=' + encodeURIComponent(this.token), {
+            var resp = await fetch('/api/v1/oauth/providers/' + provider + '/code', {
               method: 'POST',
               headers: { 'Content-Type': 'application/json' },
               body: JSON.stringify({ code: code })
@@ -1936,7 +1937,7 @@ ${
             body: JSON.stringify(body)
           });
           if (!resp.ok && info?.authType === 'oauth') {
-            await fetch('/api/v1/oauth/providers/' + provider + '/logout?token=' + encodeURIComponent(this.token), { method: 'POST' });
+            await fetch('/api/v1/oauth/providers/' + provider + '/logout', { method: 'POST' });
           }
           // Reset auth flow state
           var ps = this.providerState[provider];
@@ -1952,7 +1953,7 @@ ${
         // === Integrations (Skills + MCPs) ===
         async initIntegrations() {
           try {
-            var resp = await fetch('/api/v1/integrations/registry?token=' + encodeURIComponent(this.token));
+            var resp = await fetch('/api/v1/integrations/registry');
             var data = await resp.json();
             this.curatedSkills = data.skills || [];
             this.curatedMcps = data.mcps || [];
@@ -1972,7 +1973,7 @@ ${
           this.skillsError = '';
 
           try {
-            var fetchResp = await fetch('/api/v1/integrations/skills/fetch?token=' + encodeURIComponent(this.token), {
+            var fetchResp = await fetch('/api/v1/integrations/skills/fetch', {
               method: 'POST',
               headers: { 'Content-Type': 'application/json' },
               body: JSON.stringify({ repo: repo })
@@ -2100,7 +2101,7 @@ ${
           this.integrationSearchResults = [];
 
           try {
-            var resp = await fetch('/api/v1/integrations/registry?token=' + encodeURIComponent(this.token) + '&q=' + encodeURIComponent(q));
+            var resp = await fetch('/api/v1/integrations/registry?q=' + encodeURIComponent(q));
             var data = await resp.json();
             var skillResults = (data.skills || []).map(function(s) {
               return { id: s.id, name: s.name, description: s.description, installs: s.installs, type: 'skill' };
@@ -2258,7 +2259,7 @@ ${
           this.schedulesLoading = true;
 
           try {
-            var resp = await fetch('/api/v1/agents/' + encodeURIComponent(this.agentId) + '/schedules/' + encodeURIComponent(scheduleId) + '?token=' + encodeURIComponent(this.token), {
+            var resp = await fetch('/api/v1/agents/' + encodeURIComponent(this.agentId) + '/schedules/' + encodeURIComponent(scheduleId), {
               method: 'DELETE'
             });
 
@@ -2289,7 +2290,7 @@ ${
           if (!skill) return;
 
           try {
-            var fetchResp = await fetch('/api/v1/integrations/skills/fetch?token=' + encodeURIComponent(this.token), {
+            var fetchResp = await fetch('/api/v1/integrations/skills/fetch', {
               method: 'POST',
               headers: { 'Content-Type': 'application/json' },
               body: JSON.stringify({ repo: skill.repo })
@@ -2522,7 +2523,7 @@ ${
         },
 
         apiUrl(path) {
-          return '/api/v1/agents/' + encodeURIComponent(__STATE__.agentId) + '/config' + path + '?token=' + encodeURIComponent(__STATE__.token);
+          return '/api/v1/agents/' + encodeURIComponent(__STATE__.agentId) + '/config' + path;
         },
 
         async loadPermissions() {
@@ -2609,14 +2610,14 @@ ${
  */
 export function renderPickerPage(
   payload: SettingsTokenPayload,
-  agents: (AgentMetadata & { channelCount: number })[],
-  token: string
+  agents: (AgentMetadata & { channelCount: number })[]
 ): string {
   return `<!DOCTYPE html>
 <html lang="en">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="referrer" content="no-referrer">
   <title>Configure Agent - Lobu</title>
   <style>${settingsPageCSS}</style>
 </head>
@@ -2686,7 +2687,6 @@ ${agents
   </div>
 
   <script>
-    var token = ${JSON.stringify(token)};
     var idManuallyEdited = false;
 
     document.getElementById('agentId').addEventListener('input', function() {
@@ -2704,7 +2704,7 @@ ${agents
     async function selectAgent(agentId) {
       hideMessages();
       try {
-        var resp = await fetch('/settings/switch-agent?token=' + encodeURIComponent(token), {
+        var resp = await fetch('/settings/switch-agent', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ agentId: agentId })
@@ -2740,7 +2740,7 @@ ${agents
       hideMessages();
 
       try {
-        var resp = await fetch('/settings/create-agent?token=' + encodeURIComponent(token), {
+        var resp = await fetch('/settings/create-agent', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ agentId: agentId, name: name })
@@ -2776,6 +2776,76 @@ ${agents
       document.getElementById('success-msg').classList.add('hidden');
       document.getElementById('error-msg').classList.add('hidden');
     }
+  </script>
+</body>
+</html>`;
+}
+
+export function renderSessionBootstrapPage(): string {
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="referrer" content="no-referrer">
+  <title>Loading Settings - Lobu</title>
+  <style>
+    body { margin: 0; min-height: 100vh; display: flex; align-items: center; justify-content: center; padding: 1.25rem; font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; background: linear-gradient(to bottom right, #334155, #0f172a); color: #e2e8f0; }
+    .card { background: #0f172a; border: 1px solid #334155; border-radius: 1rem; box-shadow: 0 20px 25px -5px rgb(0 0 0 / 0.35); padding: 1.5rem; max-width: 28rem; width: 100%; text-align: center; }
+    .spinner { width: 1.25rem; height: 1.25rem; border: 2px solid #475569; border-top-color: #cbd5e1; border-radius: 9999px; margin: 0 auto 0.75rem; animation: spin 0.8s linear infinite; }
+    .error { display: none; margin-top: 0.75rem; font-size: 0.875rem; color: #fca5a5; }
+    @keyframes spin { to { transform: rotate(360deg); } }
+  </style>
+</head>
+<body>
+  <div class="card">
+    <div id="spinner" class="spinner"></div>
+    <p id="status">Securing your settings session...</p>
+    <p id="error" class="error"></p>
+  </div>
+  <script>
+    (async function () {
+      var hash = window.location.hash ? window.location.hash.slice(1) : '';
+      var params = new URLSearchParams(hash);
+      var token = params.get('${SETTINGS_TOKEN_HASH_PARAM}') || params.get('token');
+      var errorEl = document.getElementById('error');
+      var statusEl = document.getElementById('status');
+      var spinnerEl = document.getElementById('spinner');
+
+      function showError(message) {
+        statusEl.textContent = 'Unable to open settings.';
+        errorEl.textContent = message;
+        errorEl.style.display = 'block';
+        spinnerEl.style.display = 'none';
+      }
+
+      if (!token) {
+        showError('Missing settings link token. Request a new link with /configure.');
+        return;
+      }
+
+      try {
+        var resp = await fetch('/settings/session', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ token: token })
+        });
+
+        if (!resp.ok) {
+          var result = await resp.json().catch(function () { return {}; });
+          showError(result.error || 'Invalid or expired settings link.');
+          return;
+        }
+
+        var url = new URL(window.location.href);
+        url.hash = '';
+        url.search = '';
+        window.history.replaceState({}, '', url.pathname);
+        window.location.replace('/settings');
+      } catch (error) {
+        showError('Network error while securing session.');
+      }
+    })();
   </script>
 </body>
 </html>`;

--- a/packages/gateway/src/routes/public/settings.ts
+++ b/packages/gateway/src/routes/public/settings.ts
@@ -20,10 +20,16 @@ import type { AgentSettingsStore } from "../../auth/settings";
 import { verifySettingsToken } from "../../auth/settings/token-service";
 import type { UserAgentsStore } from "../../auth/user-agents-store";
 import type { ChannelBindingService } from "../../channels";
+import {
+  clearSettingsSessionCookie,
+  setSettingsSessionCookie,
+  verifySettingsSession,
+} from "./settings-auth";
 import type { ProviderMeta } from "./settings-page";
 import {
   renderErrorPage,
   renderPickerPage,
+  renderSessionBootstrapPage,
   renderSettingsPage,
 } from "./settings-page";
 
@@ -59,24 +65,54 @@ export function createSettingsPageRoutes(
 ): OpenAPIHono {
   const app = new OpenAPIHono();
 
-  // HTML Settings Page
-  app.get("/settings", async (c) => {
-    const token = c.req.query("token");
-    if (!token) {
-      return c.html(
-        renderErrorPage("Missing token. Please use the link sent to you."),
-        400
-      );
-    }
+  app.post("/settings/session", async (c) => {
+    const body = await c.req
+      .json<{ token?: string }>()
+      .catch((): { token?: string } => ({}));
+    const token = (body.token ?? "").trim();
+    if (!token) return c.json({ error: "Missing token" }, 400);
 
     const payload = verifySettingsToken(token);
     if (!payload) {
-      return c.html(
-        renderErrorPage(
-          "Invalid or expired link. Use /configure to request a new settings link."
-        ),
-        401
-      );
+      clearSettingsSessionCookie(c);
+      return c.json({ error: "Invalid or expired token" }, 401);
+    }
+
+    const sessionSet = setSettingsSessionCookie(c, token, payload);
+    if (!sessionSet) {
+      clearSettingsSessionCookie(c);
+      return c.json({ error: "Invalid or expired token" }, 401);
+    }
+
+    return c.json({ success: true });
+  });
+
+  // HTML Settings Page
+  app.get("/settings", async (c) => {
+    c.header("Referrer-Policy", "no-referrer");
+    c.header("Cache-Control", "no-store, max-age=0");
+    c.header("Pragma", "no-cache");
+
+    const legacyToken = c.req.query("token");
+    if (legacyToken) {
+      const payload = verifySettingsToken(legacyToken);
+      if (!payload) {
+        clearSettingsSessionCookie(c);
+        return c.html(
+          renderErrorPage(
+            "Invalid or expired link. Use /configure to request a new settings link."
+          ),
+          401
+        );
+      }
+
+      setSettingsSessionCookie(c, legacyToken, payload);
+      return c.redirect("/settings", 303);
+    }
+
+    const payload = verifySettingsSession(c);
+    if (!payload) {
+      return c.html(renderSessionBootstrapPage());
     }
 
     // Determine the agentId to show settings for
@@ -110,7 +146,7 @@ export function createSettingsPageRoutes(
         }
       }
 
-      return c.html(renderPickerPage(payload, agents, token));
+      return c.html(renderPickerPage(payload, agents));
     }
 
     // We have an agentId: render settings page
@@ -179,7 +215,7 @@ export function createSettingsPageRoutes(
     const effectivePayload = { ...payload, agentId };
 
     return c.html(
-      renderSettingsPage(effectivePayload, settings, token, {
+      renderSettingsPage(effectivePayload, settings, {
         providers: installedProviders,
         catalogProviders,
         providerModelOptions,
@@ -194,10 +230,7 @@ export function createSettingsPageRoutes(
 
   // PATCH /settings/update-agent - Update agent name/description
   app.patch("/settings/update-agent", async (c) => {
-    const token = c.req.query("token");
-    if (!token) return c.json({ error: "Missing token" }, 401);
-
-    const payload = verifySettingsToken(token);
+    const payload = verifySettingsSession(c);
     if (!payload) return c.json({ error: "Invalid or expired token" }, 401);
 
     let agentId = payload.agentId;
@@ -249,10 +282,7 @@ export function createSettingsPageRoutes(
 
   // POST /settings/switch-agent - Switch channel binding to a different agent
   app.post("/settings/switch-agent", async (c) => {
-    const token = c.req.query("token");
-    if (!token) return c.json({ error: "Missing token" }, 401);
-
-    const payload = verifySettingsToken(token);
+    const payload = verifySettingsSession(c);
     if (!payload) return c.json({ error: "Invalid or expired token" }, 401);
 
     if (!payload.channelId) {
@@ -335,10 +365,7 @@ export function createSettingsPageRoutes(
 
   // POST /settings/create-agent - Create new agent and optionally bind to channel
   app.post("/settings/create-agent", async (c) => {
-    const token = c.req.query("token");
-    if (!token) return c.json({ error: "Missing token" }, 401);
-
-    const payload = verifySettingsToken(token);
+    const payload = verifySettingsSession(c);
     if (!payload) return c.json({ error: "Invalid or expired token" }, 401);
 
     try {


### PR DESCRIPTION
## Summary
- stop generating settings links with `?token=` and switch to hash-based delivery (`/settings#st=...`)
- add `/settings/session` bootstrap exchange that validates the link token and sets an HTTP-only settings session cookie
- make `/settings` consume legacy query tokens only for backward compatibility, immediately sanitize via cookie + `303 /settings`
- move settings UI/API calls to cookie-backed auth (no token in query strings)
- keep backward compatibility for existing API callers by still accepting `token` query fallback in auth resolution

## Security impact
- prevents settings bearer token leakage through URL query, redirects, server/access logs, referrer headers, and common URL sharing surfaces
- reduces browser exposure by removing token from rendered settings page state and API URL construction
- applies `Referrer-Policy: no-referrer` to settings pages and uses `HttpOnly`, `SameSite=Lax` cookie sessions

## Validation
- `bun run check`
- `make build-packages`
- `set -a; source /Users/burakemre/Code/termos-dev/termos/.env; set +a; TEST_PLATFORM=slack ./scripts/test-bot.sh "@me issue 120 token check"`

Fixes #120
