### PR TITLE
fix(proxy): swap placeholder secrets in auth headers unconditionally

### DIFF
--- a/packages/gateway/src/proxy/secret-proxy.ts
+++ b/packages/gateway/src/proxy/secret-proxy.ts
@@ -189,8 +189,20 @@ export class SecretProxy {
       }
     }
 
-    // Resolve credentials: prefer URL-based agentId (no header parsing needed),
-    // fall back to marker/placeholder swap for backward compatibility.
+    // Credential resolution is a two-step process:
+    //
+    // 1. Auth profile lookup (when agentId is in the URL path). Sets
+    //    Authorization: Bearer from per-user OAuth/API-key profiles stored
+    //    in agent settings.
+    //
+    // 2. Placeholder swap for any auth headers that still contain UUID
+    //    placeholders (lobu_secret_*). This covers system keys injected via
+    //    env vars (e.g. ANTHROPIC_API_KEY from .env) which are stored in
+    //    Redis as placeholder→real-value mappings. Runs unconditionally so
+    //    providers using x-api-key (Anthropic) or Authorization: Bearer are
+    //    handled regardless of whether an auth profile was found.
+
+    // Step 1: Resolve credentials from auth profiles when agentId is in the URL
     if (urlAgentId && resolvedSlug && this.authProfilesManager) {
       const providerId = this.slugToProviderId.get(resolvedSlug);
       if (providerId) {
@@ -208,23 +220,23 @@ export class SecretProxy {
       } else {
         logger.warn(`No providerId mapping for slug "${resolvedSlug}"`);
       }
-    } else {
-      // Legacy path: swap UUID placeholders in auth headers (non-provider secrets)
-      const apiKey = headers["x-api-key"];
-      if (apiKey) {
-        headers["x-api-key"] = await this.swap(apiKey);
-      }
+    }
 
-      const auth = headers.authorization || headers.Authorization;
-      if (auth) {
-        const parts = auth.split(" ");
-        if (parts.length === 2 && parts[0]?.toLowerCase() === "bearer") {
-          const swapped = await this.swap(parts[1]!);
-          const headerName = headers.authorization
-            ? "authorization"
-            : "Authorization";
-          headers[headerName] = `Bearer ${swapped}`;
-        }
+    // Step 2: Swap any remaining UUID placeholders in auth headers
+    const apiKey = headers["x-api-key"];
+    if (apiKey?.includes(PLACEHOLDER_PREFIX)) {
+      headers["x-api-key"] = await this.swap(apiKey);
+    }
+
+    const auth = headers.authorization || headers.Authorization;
+    if (auth?.includes(PLACEHOLDER_PREFIX)) {
+      const parts = auth.split(" ");
+      if (parts.length === 2 && parts[0]?.toLowerCase() === "bearer") {
+        const swapped = await this.swap(parts[1]!);
+        const headerName = headers.authorization
+          ? "authorization"
+          : "Authorization";
+        headers[headerName] = `Bearer ${swapped}`;
       }
     }
 


### PR DESCRIPTION
## Summary

- Fix proxy credential resolution for API key authentication (both system keys from `.env` and keys entered through the settings UI)
- The URL-based credential path (added in 1dbcb8c) only looked up per-user auth profiles and set `Authorization: Bearer`. When the credential was an API key (not OAuth), the `x-api-key` header still contained the `lobu_secret_*` placeholder, which was sent to the upstream provider and rejected as invalid.
- Split credential resolution into two unconditional steps: (1) auth profile lookup, then (2) placeholder swap for any remaining `lobu_secret_*` values in auth headers

## Problem

The `else` branch guarding the placeholder swap meant it only ran when the URL-based path was *not* taken. Since all modern deployments include `/a/{agentId}` in the proxy URL, the URL-based path was always entered and the placeholder swap was always skipped.

This affected:
- System API keys set via `ANTHROPIC_API_KEY` / `ANTHROPIC_AUTH_TOKEN` in `.env`
- API keys entered through the settings UI (`authType: "api-key"`)

OAuth users were unaffected because OAuth credentials flow through `CLAUDE_CODE_OAUTH_TOKEN` which uses the `"lobu-proxy"` marker and `Authorization: Bearer` header (resolved in step 1).

## Test plan

- [ ] Deploy with `ANTHROPIC_API_KEY` in `.env` (no OAuth), send a message via REST API, verify the agent responds
- [ ] Deploy with API key entered through settings UI, send a message, verify the agent responds
- [ ] Deploy with OAuth authentication, send a message, verify no regression


Made with [Cursor](https://cursor.com)