### PR TITLE
feat(settings): add generic OpenAI provider

### DIFF
--- a/config/system-skills.json
+++ b/config/system-skills.json
@@ -495,6 +495,24 @@
           "modelsEndpoint": "/v1/models"
         }
       ]
+    },
+    {
+      "id": "openai",
+      "name": "OpenAI",
+      "description": "OpenAI Models",
+      "providers": [
+        {
+          "displayName": "OpenAI",
+          "iconUrl": "https://www.google.com/s2/favicons?domain=openai.com&sz=128",
+          "envVarName": "OPENAI_API_KEY",
+          "upstreamBaseUrl": "https://api.openai.com",
+          "apiKeyInstructions": "Get your API key from <a href=\"https://platform.openai.com/api-keys\" target=\"_blank\" class=\"text-blue-600 hover:underline\">OpenAI Dashboard</a>",
+          "apiKeyPlaceholder": "sk-...",
+          "sdkCompat": "openai",
+          "defaultModel": "gpt-4o",
+          "modelsEndpoint": "/v1/models"
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Description
Addresses the worker crash: `Failed to extract accountId from token` when using standard OpenAI API keys with the default "ChatGPT" platform connection. 

Currently, the "ChatGPT" integration (`chatgpt` provider ID) is hardcoded to use the `openai-codex` engine from `@mariozechner/pi-ai`, which explicitly expects OAuth JWT Device-Code flow tokens. Supplying standard API keys (`sk-...`) causes a parsing error when the `pi-ai` library tries to extract the `accountId`.

This PR appends a new generic `OpenAI` provider configuration block to `config/system-skills.json`. This registers a distinct "OpenAI" connection option in the dashboard that safely routes to the standard `openai` provider slug in `pi-ai` (`"sdkCompat": "openai"`), bypassing the JWT decoding.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Refactoring

## Testing
- [x] Ran `bun test` and all tests pass
- [x] Ran `bun run format` and `bun run lint` 
- [ ] Verified changes work in Docker Compose (`make dev`)

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Related Issues
Closes #(issue number)

## Additional Notes
The `system-skills.json` patch adds the new generic provider while preserving all existing integrations. 
*(Note: `bun run lint` surfaced a few pre-existing a11y and key index warnings in `packages/landing/...` which are unrelated to this JSON patch).*
