### PR TITLE
fix(ci): reconcile release-please config + Chart.yaml appVersion

### DIFF
--- a/charts/lobu/Chart.yaml
+++ b/charts/lobu/Chart.yaml
@@ -3,7 +3,7 @@ name: lobu
 description: Lobu - Kubernetes deployment for thread-based AI conversations
 type: application
 version: 3.1.0
-appVersion: 3.1.0
+appVersion: "3.1.0"
 keywords:
   - claude
   - slack

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -157,6 +157,26 @@ workspace was added without updating the script. Open
 `scripts/publish-packages.mjs`, add the new package to the `PACKAGES`
 array or allow the ref.
 
+## Chart.yaml `appVersion` is updated manually
+
+release-please bumps `charts/lobu/Chart.yaml` `version:` in the
+release PR automatically via its YAML updater, but does **not**
+bump `appVersion:`. The YAML updater strips string quotes from any
+value it touches, and Helm convention (and artifacthub.io) wants
+`appVersion` quoted (`appVersion: "3.1.0"`), so it's left out of
+the automation.
+
+When you review the release PR, update `appVersion` manually to
+match the new `version`:
+
+```yaml
+version: 3.1.0
+appVersion: "3.1.0"
+```
+
+Amend the PR branch with a follow-up commit or edit the file in the
+GitHub UI before merging.
+
 ## Adding release-please to a new package
 
 If you add a new `packages/*` workspace that should be published, two

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -9,7 +9,6 @@
   "prerelease": false,
   "separate-pull-requests": false,
   "changelog-path": "CHANGELOG.md",
-  "pull-request-title-pattern": "chore(release): ${version}",
   "packages": {
     ".": {
       "package-name": "@lobu/gateway",
@@ -39,11 +38,6 @@
           "type": "yaml",
           "path": "charts/lobu/Chart.yaml",
           "jsonpath": "$.version"
-        },
-        {
-          "type": "yaml",
-          "path": "charts/lobu/Chart.yaml",
-          "jsonpath": "$.appVersion"
         }
       ]
     }


### PR DESCRIPTION
## Summary

- Drop the custom \`pull-request-title-pattern\` that was missing \`\${scope}\`/\`\${component}\` placeholders and muddled release-please's own PR matching.
- Document that \`charts/lobu/Chart.yaml\` \`appVersion\` is updated manually (release-please's yaml updater strips string quotes; Helm wants it quoted).
- Remove \`appVersion\` from release-please's extra-files so it stops flipping the quotes.
- Restore \`appVersion: \"3.1.0\"\` in Chart.yaml after the quote-strip from 3.1.0.

Unblocks release-please so the next \`feat:\`/\`fix:\` commit triggers a release PR normally instead of aborting with \"untagged, merged release PRs outstanding\". Stale component tags (\`helm-v1.0.1\`, \`peerbot-1.0.1\`) were also deleted from origin in a separate step.

## Test plan

- [x] \`bun run check\` clean
- [x] \`bun run typecheck:packages\` clean
- [ ] After merge: release-please opens a release PR for 3.1.1 (this PR contains a \`fix:\` commit, so it should trigger a patch bump)
- [ ] Merging the release PR triggers \`publish-packages.yml\` → publishes 3.1.1 via OIDC trusted publishing