### PR TITLE
fix(ci): put version in release-please PR title

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 permissions:
   contents: write

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -9,6 +9,7 @@
   "prerelease": false,
   "separate-pull-requests": false,
   "changelog-path": "CHANGELOG.md",
+  "pull-request-title-pattern": "chore(main): release ${version}",
   "packages": {
     ".": {
       "package-name": "@lobu/gateway",


### PR DESCRIPTION
## Summary

release-please v4 without a custom \`pull-request-title-pattern\` generates release PRs titled \`chore: release main\` — the version is NOT in the title. On merge, release-please can't extract the version from its own PR and aborts with \"untagged, merged release PRs outstanding\", preventing the publish job from firing automatically.

Set \`pull-request-title-pattern\` to \`chore(main): release \${version}\` to match the old working format. Add \`workflow_dispatch\` so the workflow can be re-triggered without a dummy commit.

After this lands, the next \`feat:\` / \`fix:\` will produce a release PR titled \`chore(main): release X.Y.Z\`, and merging it will tag + trigger \`publish-packages.yml\` automatically.

## Test plan

- [x] Biome + typecheck green
- [ ] After merge: release-please opens PR titled \`chore(main): release 3.1.2\`
- [ ] Merging that PR triggers the \`publish\` job → publishes 3.1.2 via OIDC trusted publishing