### PR TITLE
fix(ci): use default release-please title pattern variables

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -9,7 +9,7 @@
   "prerelease": false,
   "separate-pull-requests": false,
   "changelog-path": "CHANGELOG.md",
-  "pull-request-title-pattern": "chore(main): release ${version}",
+  "pull-request-title-pattern": "chore${scope}: release${component} ${version}",
   "packages": {
     ".": {
       "package-name": "@lobu/gateway",


### PR DESCRIPTION
Fix the title pattern so release-please actually applies it. Evaluates to `chore(main): release X.Y.Z` for single-component root packages.