### PR TITLE
fix(ci): guard docker sha tags on release events

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -69,7 +69,7 @@ jobs:
         with:
           images: ghcr.io/lobu-ai/lobu-gateway
           tags: |
-            type=sha,prefix={{branch}}-
+            type=sha,prefix={{branch}}-,enable=${{ github.event_name == 'push' }}
             type=raw,value=latest,enable={{is_default_branch}}
             type=raw,value=${{ steps.tag.outputs.tag }}
 
@@ -94,7 +94,7 @@ jobs:
         with:
           images: ghcr.io/lobu-ai/lobu-worker-base
           tags: |
-            type=sha,prefix={{branch}}-
+            type=sha,prefix={{branch}}-,enable=${{ github.event_name == 'push' }}
             type=raw,value=latest,enable={{is_default_branch}}
             type=raw,value=${{ steps.tag.outputs.tag }}
             type=raw,value=${{ steps.tag.outputs.version }},enable=${{ steps.tag.outputs.version != '' }}


### PR DESCRIPTION
## Summary
- only emit branch-prefixed sha tags for push events
- keep release and repository_dispatch runs on their explicit version tag
- prevent invalid image tags like :-<sha> during release-triggered docker publishes

## Validation
- YAML parse via Ruby
- git diff --check
- telegram smoke test in local dev stack