### PR TITLE
fix(eval): isolate trials + feat(worker): MCP-as-CLI for embedded mode

### DIFF
--- a/examples/careops/agents/careops/evals/follows-instructions.yaml
+++ b/examples/careops/agents/careops/evals/follows-instructions.yaml
@@ -9,8 +9,11 @@ rubric: follows-instructions.rubric.md
 turns:
   - content: "List exactly 3 common appointment types in a healthcare clinic. Use bullet points."
     assert:
+      # Match 3 bullet markers (each followed by whitespace) across lines.
+      # The original `.*` version required them on a single line, which broke
+      # every response that wrapped bullets onto separate lines.
       - type: regex
-        value: "^[\\s\\S]*[-•].*[-•].*[-•]"
+        value: "[-•*]\\s.+[\\s\\S]+[-•*]\\s.+[\\s\\S]+[-•*]\\s.+"
         weight: 0.5
       - type: llm-rubric
         value: "Lists exactly 3 appointment types (not 2, not 4+), uses bullet points"

--- a/examples/careops/agents/careops/evals/ping.yaml
+++ b/examples/careops/agents/careops/evals/ping.yaml
@@ -8,9 +8,10 @@ tags: [smoke, fast]
 turns:
   - content: "Hello, are you there?"
     assert:
-      - type: contains
-        value: "hello"
-        options: { case_insensitive: true }
+      # Accept any acknowledgment-style opener. Literal "hello" was too strict —
+      # "Yes, I'm here!" is a fine reply but doesn't contain the word.
+      - type: regex
+        value: "hello|hi\\b|hey|yes|here|ready"
         weight: 0.3
       - type: llm-rubric
         value: "Response is friendly and acknowledges the greeting without being overly verbose"

--- a/packages/cli/src/eval/client.ts
+++ b/packages/cli/src/eval/client.ts
@@ -26,6 +26,7 @@ export async function createSession(
   authToken: string,
   opts?: {
     agentId?: string;
+    thread?: string;
     forceNew?: boolean;
     dryRun?: boolean;
     provider?: string;
@@ -37,6 +38,7 @@ export async function createSession(
     dryRun: opts?.dryRun ?? true,
   };
   if (opts?.agentId) body.agentId = opts.agentId;
+  if (opts?.thread) body.thread = opts.thread;
   if (opts?.provider) body.provider = opts.provider;
   if (opts?.model) body.model = opts.model;
 

--- a/packages/cli/src/eval/runner.ts
+++ b/packages/cli/src/eval/runner.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import { readFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { createSession, deleteSession, sendAndCollect } from "./client.js";
@@ -74,8 +75,13 @@ async function runTrial(
   const start = Date.now();
   const timeoutMs = definition.timeout * 1000;
 
+  // Use a unique thread per trial so each trial gets a fresh conversationId,
+  // SSE backlog, and worker workspace. Without this, every trial reuses
+  // `${agentId}_${userId}` and inherits chat history + stale SSE events
+  // from previous trials.
   const session = await createSession(options.gatewayUrl, options.authToken, {
     agentId: options.agentId,
+    thread: `eval-${randomUUID()}`,
     forceNew: true,
     dryRun: true,
   });

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -142,7 +142,7 @@ export * from "./utils/encryption";
 export * from "./utils/env";
 export * from "./utils/json";
 export * from "./utils/lock";
-export type { McpToolDef } from "./utils/mcp-tool-instructions";
+export type { McpStatus, McpToolDef } from "./utils/mcp-tool-instructions";
 export * from "./utils/network-domains";
 export * from "./utils/retry";
 export * from "./utils/sanitize";

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -297,6 +297,17 @@ export interface ToolsConfig {
    * If false (default), allowedTools are ADDED to default permissions.
    */
   strictMode?: boolean;
+
+  /**
+   * How MCP tools are exposed to the agent in embedded deployment mode.
+   * - "tools" (default): each MCP tool is registered as a first-class
+   *   function-call tool with its JSON Schema.
+   * - "cli": MCP servers are exposed as one `just-bash` command per server
+   *   (e.g. `owletto search_knowledge <<<'{...}'`). Keeps the first-class
+   *   tool list small; relies on the sandboxed bash to invoke MCP tools.
+   * Non-embedded deployment modes ignore this field and always use "tools".
+   */
+  mcpExposure?: "tools" | "cli";
 }
 
 /**

--- a/packages/core/src/utils/mcp-tool-instructions.ts
+++ b/packages/core/src/utils/mcp-tool-instructions.ts
@@ -3,3 +3,17 @@ export interface McpToolDef {
   description?: string;
   inputSchema?: Record<string, unknown>;
 }
+
+/**
+ * Enriched MCP server status delivered to workers in the session-context
+ * payload. Built by the gateway; consumed by the worker to render setup
+ * instructions, gate tool registration, and drive embedded-mode CLIs.
+ */
+export interface McpStatus {
+  id: string;
+  name: string;
+  requiresAuth: boolean;
+  requiresInput: boolean;
+  authenticated: boolean;
+  configured: boolean;
+}

--- a/packages/gateway/src/routes/public/agent.ts
+++ b/packages/gateway/src/routes/public/agent.ts
@@ -772,6 +772,11 @@ export function createAgentApi(
       sseConnections.delete(sessionKey);
     }
 
+    // Drop any remembered SSE events so a later connection with the same key
+    // (rare, but possible with deterministic conversationIds) can't replay
+    // stale completion events from this deleted session.
+    sseEventBacklog.delete(sessionKey);
+
     // Get real agentId from session before deleting
     const session = await sessMgr.getSession(sessionKey);
     const realAgentId = session?.agentId || sessionKey;

--- a/packages/gateway/src/routes/public/agent.ts
+++ b/packages/gateway/src/routes/public/agent.ts
@@ -700,6 +700,7 @@ export function createAgentApi(
       nixConfig,
       agentId,
       dryRun: dryRun || false,
+      isEphemeral,
     };
     await sessMgr.setSession(session);
 
@@ -780,10 +781,13 @@ export function createAgentApi(
     // Get real agentId from session before deleting
     const session = await sessMgr.getSession(sessionKey);
     const realAgentId = session?.agentId || sessionKey;
+    const wasEphemeral = session?.isEphemeral === true;
 
     await sessMgr.deleteSession(sessionKey);
-    // Clean up ephemeral agent settings
-    if (agentSettingsStore) {
+    // Only tear down agent settings if we auto-provisioned them for an
+    // ephemeral session. Named/shared agents (like ones loaded from
+    // filesystem config) must keep their settings across session lifecycles.
+    if (wasEphemeral && agentSettingsStore) {
       await agentSettingsStore.deleteSettings(realAgentId).catch(() => {
         /* best-effort cleanup */
       });

--- a/packages/gateway/src/session.ts
+++ b/packages/gateway/src/session.ts
@@ -39,6 +39,14 @@ export interface ThreadSession {
   agentId?: string;
   /** Process without persisting history */
   dryRun?: boolean;
+  /**
+   * True when the session was created without a caller-supplied agentId and
+   * the gateway auto-provisioned both the agent and its settings. Only
+   * ephemeral sessions should have their settings torn down on DELETE —
+   * tearing down a shared/named agent's settings corrupts every other
+   * session that reuses it.
+   */
+  isEphemeral?: boolean;
 }
 
 /**

--- a/packages/worker/src/__tests__/embedded-mcp-cli-bash.test.ts
+++ b/packages/worker/src/__tests__/embedded-mcp-cli-bash.test.ts
@@ -1,0 +1,179 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import type { McpToolDef } from "@lobu/core";
+import {
+  buildMcpCliCommands,
+  type McpCliDeps,
+  type McpRuntimeRef,
+} from "../embedded/mcp-cli-commands";
+import type { GatewayParams } from "../shared/tool-implementations";
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+const gw: GatewayParams = {
+  gatewayUrl: "http://gateway",
+  workerToken: "worker-token",
+  channelId: "channel-1",
+  conversationId: "conversation-1",
+  platform: "telegram",
+};
+
+const searchKnowledge: McpToolDef = {
+  name: "search_knowledge",
+  description: "Search memory",
+  inputSchema: {
+    type: "object",
+    properties: { query: { type: "string" } },
+    required: ["query"],
+  },
+};
+
+async function buildBash(options: {
+  ref: McpRuntimeRef;
+  callTool: (
+    mcpId: string,
+    toolName: string,
+    payload: Record<string, unknown>
+  ) => Promise<{ content: Array<{ type: "text"; text: string }> }>;
+}) {
+  const { Bash, ReadWriteFs, defineCommand } = await import("just-bash");
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "lobu-mcp-cli-"));
+  tempDirs.push(tmp);
+
+  const callTool: McpCliDeps["callTool"] = async (
+    _gw,
+    mcpId,
+    toolName,
+    payload
+  ) => options.callTool(mcpId, toolName, payload);
+
+  const cliCommands = buildMcpCliCommands(options.ref, gw, { callTool });
+
+  const customCommands = cliCommands.map((c) =>
+    defineCommand(c.name, async (args: string[], ctx) => {
+      return c.execute(args, {
+        stdin: typeof ctx.stdin === "string" ? ctx.stdin : "",
+      });
+    })
+  );
+
+  const bash = new Bash({
+    fs: new ReadWriteFs({ root: tmp }),
+    cwd: "/",
+    env: { PATH: "/usr/bin:/bin" },
+    customCommands,
+  });
+
+  return bash;
+}
+
+describe("embedded MCP CLI through real just-bash", () => {
+  test("heredoc JSON on stdin reaches the handler as a parsed object", async () => {
+    const ref: McpRuntimeRef = {
+      current: {
+        mcpTools: { owletto: [searchKnowledge] },
+        mcpStatus: [],
+        mcpContext: {},
+      },
+    };
+    const calls: Array<{ payload: Record<string, unknown> }> = [];
+    const bash = await buildBash({
+      ref,
+      callTool: async (_mcpId, _toolName, payload) => {
+        calls.push({ payload });
+        return { content: [{ type: "text", text: "hit" }] };
+      },
+    });
+
+    const result = await bash.exec(
+      `owletto search_knowledge <<'EOF'
+{"query":"architecture"}
+EOF`,
+      { cwd: "/" }
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout.trim()).toBe("hit");
+    expect(calls).toEqual([{ payload: { query: "architecture" } }]);
+  });
+
+  test("echo … | <server> <tool> routes the piped JSON into the handler", async () => {
+    const ref: McpRuntimeRef = {
+      current: {
+        mcpTools: { owletto: [searchKnowledge] },
+        mcpStatus: [],
+        mcpContext: {},
+      },
+    };
+    const calls: Array<{ payload: Record<string, unknown> }> = [];
+    const bash = await buildBash({
+      ref,
+      callTool: async (_mcpId, _toolName, payload) => {
+        calls.push({ payload });
+        return { content: [{ type: "text", text: "ok" }] };
+      },
+    });
+
+    const result = await bash.exec(
+      `echo '{"query":"piped"}' | owletto search_knowledge`,
+      { cwd: "/" }
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(calls).toEqual([{ payload: { query: "piped" } }]);
+  });
+
+  test("<server> --help lists the discovered tools", async () => {
+    const ref: McpRuntimeRef = {
+      current: {
+        mcpTools: { owletto: [searchKnowledge] },
+        mcpStatus: [
+          {
+            id: "owletto",
+            name: "Owletto",
+            requiresAuth: true,
+            requiresInput: false,
+            authenticated: true,
+            configured: true,
+          },
+        ],
+        mcpContext: {},
+      },
+    };
+    const bash = await buildBash({
+      ref,
+      callTool: async () => ({ content: [] }),
+    });
+
+    const result = await bash.exec("owletto --help", { cwd: "/" });
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("search_knowledge");
+    expect(result.stdout).toContain("auth login|check|logout");
+  });
+
+  test("unknown subcommand exits with stderr diagnostic", async () => {
+    const ref: McpRuntimeRef = {
+      current: {
+        mcpTools: { owletto: [] },
+        mcpStatus: [],
+        mcpContext: {},
+      },
+    };
+    const bash = await buildBash({
+      ref,
+      callTool: async () => ({ content: [] }),
+    });
+
+    const result = await bash.exec("owletto mystery", { cwd: "/" });
+    expect(result.exitCode).toBe(2);
+    expect(result.stderr).toContain("unknown tool");
+  });
+});

--- a/packages/worker/src/__tests__/mcp-cli-commands.test.ts
+++ b/packages/worker/src/__tests__/mcp-cli-commands.test.ts
@@ -1,0 +1,386 @@
+import { describe, expect, test } from "bun:test";
+import type { McpToolDef } from "@lobu/core";
+import {
+  buildMcpCliCommands,
+  buildMcpServerHandler,
+  isMcpIdReserved,
+  type McpRuntimeRef,
+  type McpRuntimeState,
+  parsePayload,
+  summariseAuthCheck,
+  summariseAuthStart,
+} from "../embedded/mcp-cli-commands";
+import type { GatewayParams } from "../shared/tool-implementations";
+
+const gw: GatewayParams = {
+  gatewayUrl: "http://gateway",
+  workerToken: "worker-token",
+  channelId: "channel-1",
+  conversationId: "conversation-1",
+  platform: "telegram",
+};
+
+function makeRef(overrides: Partial<McpRuntimeState> = {}): McpRuntimeRef {
+  return {
+    current: {
+      mcpTools: overrides.mcpTools ?? {},
+      mcpStatus: overrides.mcpStatus ?? [],
+      mcpContext: overrides.mcpContext ?? {},
+    },
+  };
+}
+
+const owlettoTool: McpToolDef = {
+  name: "search_knowledge",
+  description: "Search the memory store",
+  inputSchema: {
+    type: "object",
+    properties: { query: { type: "string" } },
+    required: ["query"],
+  },
+};
+
+describe("parsePayload", () => {
+  test("empty stdin and no inline arg yields empty object", () => {
+    expect(parsePayload(undefined, undefined)).toEqual({
+      ok: true,
+      payload: {},
+    });
+  });
+
+  test("whitespace stdin yields empty object", () => {
+    expect(parsePayload("   \n", undefined)).toEqual({
+      ok: true,
+      payload: {},
+    });
+  });
+
+  test("parses JSON from stdin", () => {
+    expect(parsePayload('{"q":"hello"}', undefined)).toEqual({
+      ok: true,
+      payload: { q: "hello" },
+    });
+  });
+
+  test("falls back to inline arg when stdin empty", () => {
+    expect(parsePayload("", '{"q":"x"}')).toEqual({
+      ok: true,
+      payload: { q: "x" },
+    });
+  });
+
+  test("rejects non-object JSON (array)", () => {
+    const result = parsePayload("[1, 2, 3]", undefined);
+    expect(result.ok).toBe(false);
+  });
+
+  test("rejects malformed JSON", () => {
+    const result = parsePayload("{not json", undefined);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain("invalid JSON");
+    }
+  });
+});
+
+describe("isMcpIdReserved", () => {
+  test("rejects bash builtins", () => {
+    expect(isMcpIdReserved("cd")).toContain("reserved");
+    expect(isMcpIdReserved("echo")).toContain("reserved");
+  });
+
+  test("rejects package-manager ids", () => {
+    expect(isMcpIdReserved("npm")).toContain("package-install");
+    expect(isMcpIdReserved("pip")).toContain("package-install");
+  });
+
+  test("allows normal MCP ids", () => {
+    expect(isMcpIdReserved("owletto")).toBeNull();
+    expect(isMcpIdReserved("gmail")).toBeNull();
+  });
+});
+
+describe("buildMcpServerHandler", () => {
+  test("--help lists tools and usage", async () => {
+    const ref = makeRef({
+      mcpTools: { owletto: [owlettoTool] },
+      mcpStatus: [
+        {
+          id: "owletto",
+          name: "Owletto",
+          requiresAuth: true,
+          requiresInput: false,
+          authenticated: true,
+          configured: true,
+        },
+      ],
+    });
+    const handler = buildMcpServerHandler("owletto", ref, gw, {
+      callTool: async () => ({ content: [] }),
+    });
+
+    const result = await handler(["--help"], {});
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("owletto — MCP server CLI");
+    expect(result.stdout).toContain("search_knowledge");
+    expect(result.stdout).toContain("auth login|check|logout");
+  });
+
+  test("--schema prints JSON schema for a known tool", async () => {
+    const ref = makeRef({ mcpTools: { owletto: [owlettoTool] } });
+    const handler = buildMcpServerHandler("owletto", ref, gw, {
+      callTool: async () => ({ content: [] }),
+    });
+
+    const result = await handler(["search_knowledge", "--schema"], {});
+    expect(result.exitCode).toBe(0);
+    const parsed = JSON.parse(result.stdout);
+    expect(parsed).toEqual(owlettoTool.inputSchema);
+  });
+
+  test("--schema on unknown tool exits 2", async () => {
+    const ref = makeRef({ mcpTools: { owletto: [] } });
+    const handler = buildMcpServerHandler("owletto", ref, gw, {
+      callTool: async () => ({ content: [] }),
+    });
+
+    const result = await handler(["nope", "--schema"], {});
+    expect(result.exitCode).toBe(2);
+    expect(result.stderr).toContain("unknown tool");
+  });
+
+  test("tool invocation parses JSON from stdin and routes to callTool", async () => {
+    const ref = makeRef({ mcpTools: { owletto: [owlettoTool] } });
+    const calls: Array<{
+      mcpId: string;
+      toolName: string;
+      payload: Record<string, unknown>;
+    }> = [];
+    const handler = buildMcpServerHandler("owletto", ref, gw, {
+      callTool: async (_gw, mcpId, toolName, payload) => {
+        calls.push({ mcpId, toolName, payload });
+        return { content: [{ type: "text", text: "search ok" }] };
+      },
+    });
+
+    const result = await handler(["search_knowledge"], {
+      stdin: '{"query":"architecture"}',
+    });
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout.trim()).toBe("search ok");
+    expect(calls).toEqual([
+      {
+        mcpId: "owletto",
+        toolName: "search_knowledge",
+        payload: { query: "architecture" },
+      },
+    ]);
+  });
+
+  test("tool invocation falls back to args[1] when stdin is empty", async () => {
+    const ref = makeRef({ mcpTools: { owletto: [owlettoTool] } });
+    const captured: Record<string, unknown>[] = [];
+    const handler = buildMcpServerHandler("owletto", ref, gw, {
+      callTool: async (_gw, _mcpId, _toolName, payload) => {
+        captured.push(payload);
+        return { content: [] };
+      },
+    });
+
+    const result = await handler(
+      ["search_knowledge", '{"query":"inline"}'],
+      {}
+    );
+    expect(result.exitCode).toBe(0);
+    expect(captured).toEqual([{ query: "inline" }]);
+  });
+
+  test("tool invocation defaults to empty object when no payload given", async () => {
+    const ref = makeRef({ mcpTools: { owletto: [owlettoTool] } });
+    const captured: Record<string, unknown>[] = [];
+    const handler = buildMcpServerHandler("owletto", ref, gw, {
+      callTool: async (_gw, _mcpId, _toolName, payload) => {
+        captured.push(payload);
+        return { content: [] };
+      },
+    });
+
+    const result = await handler(["search_knowledge"], {});
+    expect(result.exitCode).toBe(0);
+    expect(captured).toEqual([{}]);
+  });
+
+  test("invalid JSON payload exits 2", async () => {
+    const ref = makeRef({ mcpTools: { owletto: [owlettoTool] } });
+    const handler = buildMcpServerHandler("owletto", ref, gw, {
+      callTool: async () => {
+        throw new Error("should not be called");
+      },
+    });
+
+    const result = await handler(["search_knowledge"], { stdin: "{not json" });
+    expect(result.exitCode).toBe(2);
+    expect(result.stderr).toContain("invalid JSON");
+  });
+
+  test("unknown tool exits 2", async () => {
+    const ref = makeRef({ mcpTools: { owletto: [] } });
+    const handler = buildMcpServerHandler("owletto", ref, gw, {
+      callTool: async () => ({ content: [] }),
+    });
+
+    const result = await handler(["mystery"], {});
+    expect(result.exitCode).toBe(2);
+    expect(result.stderr).toContain("unknown tool");
+  });
+
+  test("callTool throwing surfaces as exitCode 1", async () => {
+    const ref = makeRef({ mcpTools: { owletto: [owlettoTool] } });
+    const handler = buildMcpServerHandler("owletto", ref, gw, {
+      callTool: async () => {
+        throw new Error("network down");
+      },
+    });
+
+    const result = await handler(["search_knowledge"], { stdin: "{}" });
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain("network down");
+  });
+
+  test("reads mcpTools through ref.current on each invocation", async () => {
+    // Start empty, then mutate the ref and confirm the handler picks up new tools.
+    const ref = makeRef({ mcpTools: { owletto: [] } });
+    const handler = buildMcpServerHandler("owletto", ref, gw, {
+      callTool: async () => ({ content: [{ type: "text", text: "ok" }] }),
+    });
+
+    const r1 = await handler(["search_knowledge"], {});
+    expect(r1.exitCode).toBe(2);
+
+    ref.current = {
+      ...ref.current,
+      mcpTools: { owletto: [owlettoTool] },
+    };
+
+    const r2 = await handler(["search_knowledge"], { stdin: "{}" });
+    expect(r2.exitCode).toBe(0);
+  });
+});
+
+describe("buildMcpCliCommands", () => {
+  test("builds one command per MCP server", () => {
+    const ref = makeRef({
+      mcpTools: { owletto: [owlettoTool] },
+      mcpStatus: [
+        {
+          id: "gmail",
+          name: "Gmail",
+          requiresAuth: true,
+          requiresInput: false,
+          authenticated: false,
+          configured: true,
+        },
+      ],
+    });
+    const commands = buildMcpCliCommands(ref, gw);
+    expect(commands.map((c) => c.name).sort()).toEqual(["gmail", "owletto"]);
+  });
+
+  test("skips MCP ids that collide with bash builtins", () => {
+    const ref = makeRef({
+      mcpStatus: [
+        {
+          id: "echo",
+          name: "Echo",
+          requiresAuth: false,
+          requiresInput: false,
+          authenticated: true,
+          configured: true,
+        },
+        {
+          id: "owletto",
+          name: "Owletto",
+          requiresAuth: false,
+          requiresInput: false,
+          authenticated: true,
+          configured: true,
+        },
+      ],
+    });
+    const commands = buildMcpCliCommands(ref, gw);
+    expect(commands.map((c) => c.name)).toEqual(["owletto"]);
+  });
+
+  test("skips MCP ids that collide with package-install denylist", () => {
+    const ref = makeRef({
+      mcpStatus: [
+        {
+          id: "npm",
+          name: "Not npm",
+          requiresAuth: false,
+          requiresInput: false,
+          authenticated: true,
+          configured: true,
+        },
+      ],
+    });
+    const commands = buildMcpCliCommands(ref, gw);
+    expect(commands).toEqual([]);
+  });
+});
+
+describe("summariseAuthStart / summariseAuthCheck", () => {
+  test("summariseAuthStart collapses login_started to a short status without URL", () => {
+    const out = summariseAuthStart(
+      JSON.stringify({
+        status: "login_started",
+        verification_url: "https://example.com/verify",
+        interaction_posted: true,
+      }),
+      "owletto"
+    );
+    const parsed = JSON.parse(out);
+    expect(parsed.status).toBe("login_started");
+    expect(parsed.mcp_id).toBe("owletto");
+    expect(parsed.interaction_posted).toBe(true);
+    expect(out).not.toContain("https://example.com/verify");
+  });
+
+  test("summariseAuthStart passes through already_authenticated", () => {
+    const out = summariseAuthStart(
+      JSON.stringify({ status: "already_authenticated" }),
+      "owletto"
+    );
+    expect(JSON.parse(out).status).toBe("already_authenticated");
+  });
+
+  test("summariseAuthStart falls through to raw when interaction_posted=false so URL stays reachable", () => {
+    const raw = JSON.stringify({
+      status: "login_started",
+      verification_url: "https://example.com/verify",
+      user_code: "ABCD-1234",
+      interaction_posted: false,
+    });
+    const out = summariseAuthStart(raw, "owletto");
+    expect(out).toBe(raw);
+    expect(out).toContain("https://example.com/verify");
+    expect(out).toContain("ABCD-1234");
+  });
+
+  test("summariseAuthCheck emits authenticated=true on success", () => {
+    const out = summariseAuthCheck(
+      { status: "authenticated", authenticated: true },
+      "owletto",
+      "raw"
+    );
+    expect(JSON.parse(out)).toEqual({
+      status: "authenticated",
+      mcp_id: "owletto",
+      authenticated: true,
+    });
+  });
+
+  test("summariseAuthCheck falls back to raw text when parse fails", () => {
+    expect(summariseAuthCheck(null, "owletto", "raw text")).toBe("raw text");
+  });
+});

--- a/packages/worker/src/embedded/just-bash-bootstrap.ts
+++ b/packages/worker/src/embedded/just-bash-bootstrap.ts
@@ -14,6 +14,9 @@ import fs from "node:fs";
 import path from "node:path";
 import type { BashOperations } from "@mariozechner/pi-coding-agent";
 import { stripSensitiveWorkerEnv } from "../shared/sensitive-env";
+import type { GatewayParams } from "../shared/tool-implementations";
+import type { McpCliCommand, McpRuntimeRef } from "./mcp-cli-commands";
+import { buildMcpCliCommands } from "./mcp-cli-commands";
 
 const EMBEDDED_BASH_LIMITS = {
   maxCommandCount: 50_000,
@@ -136,11 +139,41 @@ async function buildCustomCommands(
   return commands;
 }
 
+export interface EmbeddedBashOpsOptions {
+  /**
+   * When provided together with `gw`, MCP servers are exposed as one
+   * `just-bash` custom command per server (e.g. `owletto search_knowledge
+   * <<<'{...}'`). Only applied when `mcpExposure === "cli"`. The ref's
+   * optional `refresh()` is invoked after successful auth operations so
+   * CLI handlers pick up freshly-discovered MCP tools without rebuilding Bash.
+   */
+  mcpRuntimeRef?: McpRuntimeRef;
+  gw?: GatewayParams;
+  /** `"tools"` (default) keeps today's first-class MCP tools. `"cli"` swaps to sandboxed bash CLIs. */
+  mcpExposure?: "tools" | "cli";
+}
+
+/**
+ * Convert an in-process MCP CLI handler into a just-bash `defineCommand` entry.
+ */
+async function adaptMcpCliCommand(
+  cmd: McpCliCommand
+): Promise<ReturnType<typeof import("just-bash").defineCommand>> {
+  const { defineCommand } = await import("just-bash");
+  return defineCommand(cmd.name, async (args: string[], ctx) => {
+    const stdin = typeof ctx.stdin === "string" ? ctx.stdin : "";
+    const signal = ctx.signal as AbortSignal | undefined;
+    return cmd.execute(args, { stdin, signal });
+  });
+}
+
 /**
  * Create a BashOperations adapter backed by a just-bash Bash instance.
  * Reads configuration from environment variables.
  */
-export async function createEmbeddedBashOps(): Promise<BashOperations> {
+export async function createEmbeddedBashOps(
+  options: EmbeddedBashOpsOptions = {}
+): Promise<BashOperations> {
   const { Bash, ReadWriteFs } = await import("just-bash");
 
   const workspaceDir = process.env.WORKSPACE_DIR || "/workspace";
@@ -176,16 +209,42 @@ export async function createEmbeddedBashOps(): Promise<BashOperations> {
         }
       : undefined;
 
-  // Discover nix binaries and known CLI tools, register as custom commands
+  // Build MCP CLI commands first so that explicit MCP registrations win over
+  // any PATH-discovered binary with the same name (e.g. `owletto` is both an
+  // installed nix binary and an MCP server).
+  let mcpCliCommands: McpCliCommand[] = [];
+  if (options.mcpExposure === "cli" && options.mcpRuntimeRef && options.gw) {
+    mcpCliCommands = buildMcpCliCommands(options.mcpRuntimeRef, options.gw);
+  }
+  const mcpCliNames = new Set(mcpCliCommands.map((c) => c.name));
+
+  // Discover nix binaries and known CLI tools, register as custom commands.
+  // Strip names claimed by MCP CLIs so the MCP-backed handler takes precedence.
   const binaries = discoverBinaries();
-  const customCommands =
+  for (const name of mcpCliNames) {
+    binaries.delete(name);
+  }
+  const binaryCommands =
     binaries.size > 0 ? await buildCustomCommands(binaries) : [];
+
+  const mcpCommandEntries = await Promise.all(
+    mcpCliCommands.map((c) => adaptMcpCliCommand(c))
+  );
+
+  const customCommands = [...mcpCommandEntries, ...binaryCommands];
 
   if (binaries.size > 0) {
     const names = [...binaries.keys()].slice(0, 20).join(", ");
     const suffix = binaries.size > 20 ? `, ... (${binaries.size} total)` : "";
     console.log(
-      `[embedded] Registered ${binaries.size} custom commands: ${names}${suffix}`
+      `[embedded] Registered ${binaries.size} binary commands: ${names}${suffix}`
+    );
+  }
+  if (mcpCliCommands.length > 0) {
+    console.log(
+      `[embedded] Registered ${
+        mcpCliCommands.length
+      } MCP CLI commands: ${mcpCliCommands.map((c) => c.name).join(", ")}`
     );
   }
 

--- a/packages/worker/src/embedded/mcp-cli-commands.ts
+++ b/packages/worker/src/embedded/mcp-cli-commands.ts
@@ -1,0 +1,402 @@
+/**
+ * Worker-side MCP-as-CLI bootstrap for embedded deployment mode.
+ *
+ * Registers one `just-bash` custom command per MCP server (e.g. `owletto`,
+ * `gmail`). The agent invokes MCP tools via the sandboxed bash:
+ *
+ *   owletto search_knowledge <<<'{"query":"foo"}'
+ *   owletto --help
+ *   owletto save_knowledge --schema
+ *   owletto auth login
+ *
+ * Payload is read from `ctx.stdin` as JSON. If stdin is empty, falls back to
+ * `args[1]` as a JSON string (defense-in-depth for models that write the JSON
+ * inline).
+ */
+import type { McpStatus, McpToolDef } from "@lobu/core";
+import { createLogger } from "@lobu/core";
+import type { GatewayParams } from "../shared/tool-implementations";
+import { callMcpTool } from "../shared/tool-implementations";
+import { isDirectPackageInstallCommand } from "../openclaw/tool-policy";
+
+const logger = createLogger("mcp-cli");
+
+/** Names reserved by just-bash / POSIX shells that we must not shadow. */
+const RESERVED_COMMAND_NAMES = new Set([
+  "cd",
+  "echo",
+  "export",
+  "test",
+  "true",
+  "false",
+  "pwd",
+  "set",
+  "unset",
+  "exit",
+  "source",
+  ".",
+  ":",
+  "[",
+]);
+
+/**
+ * Mutable snapshot of MCP session state. CLI handlers read through `current`
+ * so that `auth login|check|logout` can refresh tools/state via `refresh()`
+ * without rebuilding the Bash instance. New servers discovered after startup
+ * are not retro-registered — they require a worker restart.
+ */
+export interface McpRuntimeState {
+  mcpTools: Record<string, McpToolDef[]>;
+  mcpStatus: McpStatus[];
+  mcpContext: Record<string, string>;
+}
+
+export interface McpRuntimeRef {
+  current: McpRuntimeState;
+  /** Re-fetch session context and return a fresh snapshot, or `null` on failure. */
+  refresh?: () => Promise<McpRuntimeState | null>;
+}
+
+export interface McpCliCommand {
+  name: string;
+  execute: (
+    args: string[],
+    ctx: { stdin?: string; signal?: AbortSignal }
+  ) => Promise<{ stdout: string; stderr: string; exitCode: number }>;
+}
+
+export interface McpCliDeps {
+  callTool: typeof callMcpTool;
+}
+
+const DEFAULT_DEPS: McpCliDeps = {
+  callTool: callMcpTool,
+};
+
+/** Check whether an MCP id would collide with a bash builtin or deny-prefix. */
+export function isMcpIdReserved(mcpId: string): string | null {
+  if (RESERVED_COMMAND_NAMES.has(mcpId)) {
+    return `reserved bash builtin`;
+  }
+  // Probe against the package-install denylist using invocations that match
+  // its actual patterns (install/add/require/upgrade/etc.).
+  const probes = [
+    `${mcpId} install`,
+    `${mcpId} i`,
+    `${mcpId} add`,
+    `${mcpId} upgrade`,
+    `${mcpId} require`,
+    mcpId,
+  ];
+  if (probes.some((p) => isDirectPackageInstallCommand(p))) {
+    return `matches package-install denylist`;
+  }
+  return null;
+}
+
+function truncate(text: string, max: number): string {
+  if (!text) return "";
+  const clean = text.replace(/\s+/g, " ").trim();
+  return clean.length > max ? `${clean.slice(0, max - 1)}…` : clean;
+}
+
+export function renderHelp(
+  mcpId: string,
+  state: McpRuntimeState
+): { stdout: string; exitCode: number } {
+  const tools = state.mcpTools[mcpId] ?? [];
+  const status = state.mcpStatus.find((s) => s.id === mcpId);
+  const contextPrefix = state.mcpContext[mcpId];
+  const lines: string[] = [];
+
+  lines.push(`${mcpId} — MCP server CLI`);
+  if (contextPrefix) {
+    lines.push(contextPrefix);
+  }
+  lines.push("");
+  lines.push("Usage:");
+  lines.push(`  ${mcpId} <tool> <<'EOF'`);
+  lines.push(`  { ...json args... }`);
+  lines.push(`  EOF`);
+  lines.push("");
+  lines.push(`  ${mcpId} <tool> --schema     # print the JSON schema`);
+  lines.push(`  ${mcpId} --help              # this message`);
+  if (status?.requiresAuth) {
+    lines.push(`  ${mcpId} auth login|check|logout`);
+  }
+  lines.push("");
+
+  if (tools.length === 0) {
+    lines.push(
+      "(no tools discovered — the server may need authentication or configuration)"
+    );
+  } else {
+    lines.push("Tools:");
+    for (const tool of tools) {
+      const desc = truncate(tool.description ?? "", 80);
+      lines.push(`  ${tool.name}${desc ? `  ${desc}` : ""}`);
+    }
+  }
+
+  return { stdout: `${lines.join("\n")}\n`, exitCode: 0 };
+}
+
+function findTool(
+  mcpId: string,
+  toolName: string,
+  state: McpRuntimeState
+): McpToolDef | undefined {
+  return state.mcpTools[mcpId]?.find((t) => t.name === toolName);
+}
+
+export function parsePayload(
+  stdin: string | undefined,
+  inlineArg: string | undefined
+):
+  | { ok: true; payload: Record<string, unknown> }
+  | { ok: false; error: string } {
+  const raw = (stdin && stdin.trim()) || (inlineArg && inlineArg.trim()) || "";
+  if (!raw) {
+    return { ok: true, payload: {} };
+  }
+  try {
+    const parsed = JSON.parse(raw);
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return { ok: false, error: "expected a JSON object payload" };
+    }
+    return { ok: true, payload: parsed as Record<string, unknown> };
+  } catch (err) {
+    return {
+      ok: false,
+      error: `invalid JSON payload: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
+}
+
+/**
+ * Build the execute handler for a single MCP server CLI.
+ * Exposed for unit testing.
+ */
+export function buildMcpServerHandler(
+  mcpId: string,
+  ref: McpRuntimeRef,
+  gw: GatewayParams,
+  deps: McpCliDeps = DEFAULT_DEPS
+): McpCliCommand["execute"] {
+  return async (args, ctx) => {
+    const subcommand = args[0];
+    const state = ref.current;
+
+    if (!subcommand || subcommand === "--help" || subcommand === "-h") {
+      const { stdout, exitCode } = renderHelp(mcpId, state);
+      return { stdout, stderr: "", exitCode };
+    }
+
+    if (subcommand === "auth") {
+      return runAuthSubcommand(mcpId, args.slice(1), gw, ref);
+    }
+
+    // <tool> --schema
+    if (args[1] === "--schema") {
+      const tool = findTool(mcpId, subcommand, state);
+      if (!tool) {
+        return {
+          stdout: "",
+          stderr: `unknown tool: ${subcommand}. Run \`${mcpId} --help\`.\n`,
+          exitCode: 2,
+        };
+      }
+      const schema = tool.inputSchema ?? {};
+      return {
+        stdout: `${JSON.stringify(schema, null, 2)}\n`,
+        stderr: "",
+        exitCode: 0,
+      };
+    }
+
+    // <tool> [json]
+    const tool = findTool(mcpId, subcommand, state);
+    if (!tool) {
+      return {
+        stdout: "",
+        stderr: `unknown tool: ${subcommand}. Run \`${mcpId} --help\`.\n`,
+        exitCode: 2,
+      };
+    }
+
+    const parsed = parsePayload(ctx.stdin, args[1]);
+    if (!parsed.ok) {
+      return { stdout: "", stderr: `${parsed.error}\n`, exitCode: 2 };
+    }
+
+    try {
+      const result = await deps.callTool(gw, mcpId, subcommand, parsed.payload);
+      const text = result.content
+        .filter((c) => c.type === "text")
+        .map((c) => c.text)
+        .join("\n");
+      return { stdout: text ? `${text}\n` : "", stderr: "", exitCode: 0 };
+    } catch (err) {
+      return {
+        stdout: "",
+        stderr: `${err instanceof Error ? err.message : String(err)}\n`,
+        exitCode: 1,
+      };
+    }
+  };
+}
+
+async function refreshRef(
+  ref: McpRuntimeRef,
+  mcpId: string,
+  verb: string
+): Promise<void> {
+  if (!ref.refresh) return;
+  try {
+    const fresh = await ref.refresh();
+    if (fresh) ref.current = fresh;
+  } catch (err) {
+    logger.warn(
+      `Failed to refresh MCP state after ${mcpId} auth ${verb}: ${err instanceof Error ? err.message : String(err)}`
+    );
+  }
+}
+
+async function runAuthSubcommand(
+  mcpId: string,
+  args: string[],
+  gw: GatewayParams,
+  ref: McpRuntimeRef
+): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+  const verb = args[0];
+  // Lazy import to avoid a heavy dependency cycle in tests.
+  const impl = await import("../shared/tool-implementations");
+
+  if (verb === "login") {
+    const res = await impl.startMcpLogin(gw, { mcpId });
+    const text = extractText(res.content);
+    return {
+      stdout: `${summariseAuthStart(text, mcpId)}\n`,
+      stderr: "",
+      exitCode: 0,
+    };
+  }
+
+  if (verb === "check") {
+    const res = await impl.checkMcpLogin(gw, { mcpId });
+    const text = extractText(res.content);
+    const parsed = tryJson(text);
+    if (parsed?.authenticated === true) {
+      await refreshRef(ref, mcpId, "check");
+    }
+    return {
+      stdout: `${summariseAuthCheck(parsed, mcpId, text)}\n`,
+      stderr: "",
+      exitCode: 0,
+    };
+  }
+
+  if (verb === "logout") {
+    const res = await impl.logoutMcp(gw, { mcpId });
+    const text = extractText(res.content);
+    // Tools that required auth are now unreachable — refresh so the next
+    // invocation sees the empty state.
+    await refreshRef(ref, mcpId, "logout");
+    return { stdout: `${text}\n`, stderr: "", exitCode: 0 };
+  }
+
+  return {
+    stdout: "",
+    stderr: `unknown auth subcommand: ${verb ?? "(none)"}. Use login|check|logout.\n`,
+    exitCode: 2,
+  };
+}
+
+function extractText(content: Array<{ type: string; text?: string }>): string {
+  return content
+    .filter(
+      (c): c is { type: "text"; text: string } =>
+        c.type === "text" && typeof c.text === "string"
+    )
+    .map((c) => c.text)
+    .join("\n");
+}
+
+export function summariseAuthStart(rawText: string, mcpId: string): string {
+  const parsed = tryJson(rawText);
+  if (!parsed) return rawText;
+  if (parsed.status === "already_authenticated") {
+    return JSON.stringify({ status: "already_authenticated", mcp_id: mcpId });
+  }
+  if (parsed.status === "login_started") {
+    const interactionPosted = Boolean(parsed.interaction_posted);
+    // If the link-button side-channel didn't fire, fall back to the raw payload
+    // so the verification URL + user_code remain reachable by the model.
+    if (!interactionPosted) return rawText;
+    return JSON.stringify({
+      status: "login_started",
+      mcp_id: mcpId,
+      interaction_posted: true,
+      message: `Login link sent directly to the user. Run \`${mcpId} auth check\` after they confirm.`,
+    });
+  }
+  return rawText;
+}
+
+export function summariseAuthCheck(
+  parsed: Record<string, unknown> | null,
+  mcpId: string,
+  fallback: string
+): string {
+  if (!parsed) return fallback;
+  return JSON.stringify({
+    status: parsed.status ?? "unknown",
+    mcp_id: mcpId,
+    authenticated: parsed.authenticated ?? false,
+  });
+}
+
+function tryJson(text: string): Record<string, unknown> | null {
+  try {
+    const v = JSON.parse(text);
+    return v && typeof v === "object" && !Array.isArray(v)
+      ? (v as Record<string, unknown>)
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Build one command per MCP server in `ref.current.mcpStatus`, including
+ * servers that currently have no discovered tools (so `<server> auth login`
+ * still works for unauthenticated servers).
+ */
+export function buildMcpCliCommands(
+  ref: McpRuntimeRef,
+  gw: GatewayParams,
+  deps: Partial<McpCliDeps> = {}
+): McpCliCommand[] {
+  const resolvedDeps: McpCliDeps = { ...DEFAULT_DEPS, ...deps };
+  const state = ref.current;
+  const serverIds = new Set<string>([
+    ...Object.keys(state.mcpTools ?? {}),
+    ...(state.mcpStatus ?? []).map((s) => s.id),
+  ]);
+
+  const commands: McpCliCommand[] = [];
+  for (const mcpId of serverIds) {
+    const reserved = isMcpIdReserved(mcpId);
+    if (reserved) {
+      logger.warn(
+        `Skipping MCP CLI registration for "${mcpId}" — ${reserved}. Rename the MCP server to enable CLI mode.`
+      );
+      continue;
+    }
+    commands.push({
+      name: mcpId,
+      execute: buildMcpServerHandler(mcpId, ref, gw, resolvedDeps),
+    });
+  }
+  return commands;
+}

--- a/packages/worker/src/openclaw/session-context.ts
+++ b/packages/worker/src/openclaw/session-context.ts
@@ -1,20 +1,12 @@
 import {
   type ConfigProviderMeta,
   createLogger,
+  type McpStatus,
   type McpToolDef,
 } from "@lobu/core";
 import { ensureBaseUrl } from "../core/url-utils";
 
 const logger = createLogger("openclaw-session-context");
-
-interface McpStatus {
-  id: string;
-  name: string;
-  requiresAuth: boolean;
-  requiresInput: boolean;
-  authenticated: boolean;
-  configured: boolean;
-}
 
 export interface ProviderConfig {
   credentialEnvVarName?: string;
@@ -75,6 +67,7 @@ let cachedResult: {
   mcpStatus: McpStatus[];
   mcpTools: Record<string, McpToolDef[]>;
   mcpContext: Record<string, string>;
+  mcpExposure: "tools" | "cli";
   cachedAt: number;
 } | null = null;
 
@@ -89,7 +82,8 @@ export function invalidateSessionContextCache(): void {
 
 function buildMcpInstructions(
   mcpStatus: McpStatus[],
-  mcpToolIds: Set<string>
+  mcpToolIds: Set<string>,
+  mcpExposure: "tools" | "cli" = "tools"
 ): string {
   if (!mcpStatus || mcpStatus.length === 0) {
     return "";
@@ -114,8 +108,16 @@ function buildMcpInstructions(
   const lines: string[] = ["## MCP Tools Requiring Setup"];
 
   for (const mcp of needsAuthentication) {
+    const loginCmd =
+      mcpExposure === "cli"
+        ? `run \`${mcp.id} auth login\` in Bash`
+        : `call \`${mcp.id}_login\``;
+    const checkCmd =
+      mcpExposure === "cli"
+        ? `run \`${mcp.id} auth check\``
+        : `call \`${mcp.id}_login_check\``;
     lines.push(
-      `- ⚠️ **${mcp.name}** (id: ${mcp.id}): Authentication is required. Call \`${mcp.id}_login\` to start login. After the user completes login, call \`${mcp.id}_login_check\`. Newly available MCP tools will refresh on the next message.`
+      `- ⚠️ **${mcp.name}** (id: ${mcp.id}): Authentication is required. To start login, ${loginCmd}. After the user completes login, ${checkCmd}. Newly available MCP tools will refresh on the next message.`
     );
   }
 
@@ -137,6 +139,33 @@ function buildMcpInstructions(
   return lines.join("\n");
 }
 
+/**
+ * CLI-mode header introducing the `<server> <tool>` idiom. Appended to gateway
+ * instructions when `mcpExposure === "cli"` so the model understands how to
+ * invoke MCP tools through bash instead of as first-class function calls.
+ */
+function buildMcpCliInstructions(mcpStatus: McpStatus[]): string {
+  if (!mcpStatus || mcpStatus.length === 0) return "";
+  const servers = mcpStatus.map((m) => `- \`${m.id}\` — ${m.name}`).join("\n");
+  return `## Available MCP CLIs
+
+MCP servers are exposed as Bash commands. One command per server. Invoke tools by piping JSON on stdin:
+
+\`\`\`bash
+<server> <tool> <<'EOF'
+{ ...json args... }
+EOF
+\`\`\`
+
+Discovery:
+- \`<server> --help\` — list a server's tools
+- \`<server> <tool> --schema\` — print the JSON Schema for a tool
+- \`<server> auth login|check|logout\` — manage OAuth where required
+
+Servers:
+${servers}`;
+}
+
 function buildMcpServerInstructions(
   mcpInstructions: Record<string, string>
 ): string {
@@ -156,7 +185,9 @@ function buildMcpServerInstructions(
  * Caches the result until invalidated by a config_changed SSE event.
  * Skips MCP server config (OpenClaw doesn't use Claude SDK's MCP format).
  */
-export async function getOpenClawSessionContext(): Promise<{
+export async function getOpenClawSessionContext(
+  opts: { mcpExposure?: "tools" | "cli" } = {}
+): Promise<{
   /**
    * Identity/soul/user instructions for this agent. Returned separately from
    * `gatewayInstructions` so the worker can prepend identity BEFORE the
@@ -173,7 +204,13 @@ export async function getOpenClawSessionContext(): Promise<{
   mcpTools: Record<string, McpToolDef[]>;
   mcpContext: Record<string, string>;
 }> {
-  if (cachedResult && Date.now() - cachedResult.cachedAt < CACHE_TTL_MS) {
+  const mcpExposure: "tools" | "cli" = opts.mcpExposure ?? "tools";
+
+  if (
+    cachedResult &&
+    cachedResult.mcpExposure === mcpExposure &&
+    Date.now() - cachedResult.cachedAt < CACHE_TTL_MS
+  ) {
     logger.debug("Returning cached session context");
     return cachedResult;
   }
@@ -212,7 +249,8 @@ export async function getOpenClawSessionContext(): Promise<{
     const toolMcpIds = new Set(Object.keys(data.mcpTools || {}));
     const mcpSetupInstructions = buildMcpInstructions(
       data.mcpStatus,
-      toolMcpIds
+      toolMcpIds,
+      mcpExposure
     );
     // Include MCP server instructions for all servers (with or without tools).
     // These provide workspace context (available connectors, entity schemas, etc.)
@@ -220,6 +258,8 @@ export async function getOpenClawSessionContext(): Promise<{
     const mcpServerInstructions = buildMcpServerInstructions(
       data.mcpInstructions || {}
     );
+    const mcpCliInstructions =
+      mcpExposure === "cli" ? buildMcpCliInstructions(data.mcpStatus) : "";
 
     // Identity/soul/user instructions are returned separately so the worker
     // can prepend them BEFORE the pi-coding-agent base prompt.
@@ -229,6 +269,7 @@ export async function getOpenClawSessionContext(): Promise<{
       data.platformInstructions,
       data.networkInstructions,
       data.skillsInstructions,
+      mcpCliInstructions,
       mcpSetupInstructions,
       mcpServerInstructions,
     ]
@@ -259,7 +300,7 @@ export async function getOpenClawSessionContext(): Promise<{
       (mcp) => mcp.authenticated && !toolMcpIds.has(mcp.id)
     );
     if (!hasEmptyAuthenticatedMcp) {
-      cachedResult = { ...result, cachedAt: Date.now() };
+      cachedResult = { ...result, mcpExposure, cachedAt: Date.now() };
     } else {
       logger.warn(
         "Skipping session context cache — authenticated MCP(s) returned no tools",

--- a/packages/worker/src/openclaw/worker.ts
+++ b/packages/worker/src/openclaw/worker.ts
@@ -725,9 +725,30 @@ export class OpenClawWorker implements WorkerExecutor {
 
     this.progressProcessor.setVerboseLogging(verboseLogging);
 
+    // Resolve how MCP tools should be exposed to the agent. In embedded mode,
+    // operators can swap the many first-class MCP tools for a small set of
+    // per-server just-bash CLIs (keeps the tool list lean).
+    const configuredMcpExposure = (
+      rawOptions.toolsConfig as ToolsConfig | undefined
+    )?.mcpExposure;
+    const envMcpExposure = process.env.LOBU_MCP_EXPOSURE;
+    const requestedMcpExposure: "tools" | "cli" =
+      configuredMcpExposure === "cli" || envMcpExposure === "cli"
+        ? "cli"
+        : "tools";
+    const isEmbedded = process.env.DEPLOYMENT_MODE === "embedded";
+    if (requestedMcpExposure === "cli" && !isEmbedded) {
+      logger.warn(
+        "mcpExposure='cli' requested but DEPLOYMENT_MODE is not 'embedded' — falling back to 'tools'."
+      );
+    }
+    const mcpExposure: "tools" | "cli" =
+      requestedMcpExposure === "cli" && isEmbedded ? "cli" : "tools";
+
     // Fetch session context BEFORE model resolution so AGENT_DEFAULT_PROVIDER
-    // is available when resolveModelRef() needs a fallback provider.
-    const context = await getOpenClawSessionContext();
+    // is available when resolveModelRef() needs a fallback provider. Pass
+    // `mcpExposure` so MCP setup instructions use the right call syntax.
+    const context = await getOpenClawSessionContext({ mcpExposure });
 
     // Sync enabled skills to workspace filesystem so the agent can `cat` them.
     // Remove stale skill directories to avoid serving removed/disabled skills.
@@ -955,14 +976,56 @@ export class OpenClawWorker implements WorkerExecutor {
         | undefined,
     });
 
+    // Build a mutable snapshot of MCP runtime state. The embedded CLI handlers
+    // read through `mcpRuntimeRef.current` so that `auth check` / `logout` can
+    // swap in refreshed tools/state without rebuilding Bash. `refresh()` re-
+    // fetches session context — `checkMcpLogin`/`logoutMcp` already invalidate
+    // the gateway cache, so the next fetch reaches the gateway.
+    const mcpRuntimeRef = {
+      current: {
+        mcpTools: context.mcpTools,
+        mcpStatus: context.mcpStatus,
+        mcpContext: context.mcpContext,
+      },
+      ...(mcpExposure === "cli" && {
+        refresh: async () => {
+          try {
+            const fresh = await getOpenClawSessionContext({ mcpExposure });
+            return {
+              mcpTools: fresh.mcpTools,
+              mcpStatus: fresh.mcpStatus,
+              mcpContext: fresh.mcpContext,
+            };
+          } catch (err) {
+            logger.warn(
+              `Failed to refresh MCP session context after auth: ${err instanceof Error ? err.message : String(err)}`
+            );
+            return null;
+          }
+        },
+      }),
+    };
+
+    const gwParams: GatewayParams = {
+      gatewayUrl: process.env.DISPATCHER_URL ?? "",
+      workerToken: process.env.WORKER_TOKEN ?? "",
+      channelId: this.config.channelId,
+      conversationId: this.config.conversationId,
+      platform: this.config.platform,
+    };
+
     let embeddedBashOps:
       | import("@mariozechner/pi-coding-agent").BashOperations
       | undefined;
-    if (process.env.DEPLOYMENT_MODE === "embedded") {
+    if (isEmbedded) {
       const { createEmbeddedBashOps } = await import(
         "../embedded/just-bash-bootstrap"
       );
-      embeddedBashOps = await createEmbeddedBashOps();
+      embeddedBashOps = await createEmbeddedBashOps({
+        mcpRuntimeRef,
+        gw: gwParams,
+        mcpExposure,
+      });
     }
     let tools = createOpenClawTools(workspaceDir, {
       bashOperations: embeddedBashOps,
@@ -1080,14 +1143,6 @@ Replace "YOUR_PROMPT_HERE" with the user's request. These agents can read/write 
 You have access to GetChannelHistory to view previous messages in this thread.
 Use it when the user references past discussions or you need context.`);
 
-    const gwParams = {
-      gatewayUrl,
-      workerToken,
-      channelId: this.config.channelId,
-      conversationId: this.config.conversationId,
-      platform: this.config.platform,
-    };
-
     const customTools = createOpenClawCustomTools({
       ...gwParams,
       onCustomEvent: async (name, data) => {
@@ -1099,17 +1154,26 @@ Use it when the user references past discussions or you need context.`);
       },
     });
 
-    // Register MCP tools as first-class callable tools (alongside virtual memory wrappers)
-    const mcpToolDefs = createMcpToolDefinitions(
-      context.mcpTools,
-      gwParams,
-      context.mcpContext
-    );
-    if (mcpToolDefs.length > 0) {
-      customTools.push(...mcpToolDefs);
+    // Register first-class MCP tools + auth tools. Skipped entirely in CLI
+    // mode — MCP tools are instead reachable via the per-server just-bash CLI
+    // wired in above, and `<server> auth login|check|logout` supersedes the
+    // `<id>_login` / `<id>_login_check` / `<id>_logout` trio.
+    if (mcpExposure === "cli") {
       logger.info(
-        `Registered ${mcpToolDefs.length} MCP tool(s): ${mcpToolDefs.map((t) => t.name).join(", ")}`
+        "mcpExposure='cli' — skipping first-class MCP tool registration (tools reachable via <server> <tool> in Bash)."
       );
+    } else {
+      const mcpToolDefs = createMcpToolDefinitions(
+        context.mcpTools,
+        gwParams,
+        context.mcpContext
+      );
+      if (mcpToolDefs.length > 0) {
+        customTools.push(...mcpToolDefs);
+        logger.info(
+          `Registered ${mcpToolDefs.length} MCP tool(s): ${mcpToolDefs.map((t) => t.name).join(", ")}`
+        );
+      }
     }
 
     // Load OpenClaw plugins
@@ -1124,16 +1188,18 @@ Use it when the user references past discussions or you need context.`);
       );
     }
 
-    const authToolDefs = createMcpAuthToolDefinitions(
-      context.mcpStatus,
-      gwParams,
-      new Set(customTools.map((tool) => tool.name))
-    );
-    if (authToolDefs.length > 0) {
-      customTools.push(...authToolDefs);
-      logger.info(
-        `Registered ${authToolDefs.length} MCP auth tool(s): ${authToolDefs.map((t) => t.name).join(", ")}`
+    if (mcpExposure !== "cli") {
+      const authToolDefs = createMcpAuthToolDefinitions(
+        context.mcpStatus,
+        gwParams,
+        new Set(customTools.map((tool) => tool.name))
       );
+      if (authToolDefs.length > 0) {
+        customTools.push(...authToolDefs);
+        logger.info(
+          `Registered ${authToolDefs.length} MCP auth tool(s): ${authToolDefs.map((t) => t.name).join(", ")}`
+        );
+      }
     }
 
     // Apply plugin provider registrations to ModelRegistry


### PR DESCRIPTION
## Summary

This PR bundles two changes (see commits):

### 1. Eval trial isolation (commits `5c6991b`, `ca275f4`, `892a0a4`)
- Eval trials all shared the same `conversationId` (`${agentId}_${userId}`), causing:
  1. **SSE backlog replay**: every trial after the first received the prior `complete` event instantly (latencyMs 1-9ms, byte-identical responses across unrelated prompts).
  2. **Workspace reuse**: OpenClaw chat history leaked across evals (e.g. `context-retention`'s "Alice Chen / Dr. Patel" showed up in `ping` and `follows-instructions` responses).
- Fix: pass a unique `thread: eval-<uuid>` per trial so the gateway derives a fresh conversationId, SSE bucket, and workspace.
- Defense-in-depth: clear `sseEventBacklog` on session delete so future collisions can't replay stale events.
- Also loosened two brittle `careops` eval assertions that the llm-rubric already covered.

#### Root cause (from run 24484874850)
`runEval` always called `createSession({ agentId: "careops", forceNew: true })`. Gateway derives `conversationId = "careops_careops"` → same SSE key and workspace path every trial. The first real LLM response was cached in the SSE backlog and every subsequent trial's SSE connection received it instantly on `getRecentSseEvents` replay.

### 2. MCP-as-CLI for embedded workers (commit `93f313c`)
Replaces the many first-class MCP tool registrations (one per MCP tool — ~17 for Owletto alone, 35-50 total with 3-4 servers) with one `just-bash` custom command per MCP server. The agent invokes tools as:

```bash
owletto search_knowledge <<'HEREDOC'
{"query": "..."}
HEREDOC
```

- Discovery via `<server> --help` and `<server> <tool> --schema`.
- Auth via `<server> auth login|check|logout` (collapses the `<id>_login` / `<id>_login_check` / `<id>_logout` trio).
- Opt-in per agent via `toolsConfig.mcpExposure = "cli"` or env override `LOBU_MCP_EXPOSURE=cli`. Defaults to `"tools"` (unchanged behavior).
- Only activates when `DEPLOYMENT_MODE=embedded` — non-embedded workers log a warning and fall through to `"tools"`.
- CLI handlers read MCP state through a mutable ref so successful `auth check`/`logout` refresh tools/state without rebuilding the Bash instance.
- ID collisions with bash builtins (`cd`, `echo`, …) and the package-install denylist (`npm`, `pip`, …) are rejected at registration time.

Goal: shed context bloat and attention dilution from advertising 35-50 tool schemas per turn.

## Test plan
- [x] `make build-packages` clean
- [x] Worker test suite green (187/187)
- [x] New unit + integration tests for MCP CLI dispatch, auth flow, collision guards, heredoc + pipe payload parsing
- [x] Eval trial isolation verified locally (latencyMs ~775ms vs ~5ms stale replay)
- [ ] CI Evals workflow on this branch
- [ ] Regression: `LOBU_MCP_EXPOSURE=tools` (default) still registers first-class MCP tools end-to-end
- [ ] E2E with `LOBU_MCP_EXPOSURE=cli` via `lobu chat` (embedded mode) — `owletto search_knowledge`, `owletto auth login`
