### PR TITLE
fix(ci): restore release-please pull-request-title-pattern

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -9,6 +9,7 @@
   "prerelease": false,
   "separate-pull-requests": false,
   "changelog-path": "CHANGELOG.md",
+  "pull-request-title-pattern": "chore${scope}: release${component} ${version}",
   "packages": {
     ".": {
       "package-name": "@lobu/gateway",


### PR DESCRIPTION
## Summary
- Restores `pull-request-title-pattern` that was dropped in #179, so release-please can parse its own merged PR's component and cut the tag + GitHub release.
- Without this, every release PR silently lands at step 1 (manifest + CHANGELOG bumped, PR merged) but never progresses to step 2 (tag + release + npm publish + Docker). Observed on both v3.3.0 and v3.4.0 — each required manual recovery.

## Root cause
Log from release-please after merging v3.4.0's release PR:
```
✔ Building release for path: .
❯ Found pull request #185: 'chore: release main'
⚠ PR component: undefined does not match configured component: gateway
```
createReleases bails, then the next run sees the merged PR still carrying `autorelease: pending` and aborts with "untagged, merged release PRs outstanding".

Restoring the pattern makes release-please title PRs `chore(main): release 3.4.1` — matches `${scope}` / `${component}` / `${version}` — and round-trips cleanly.

## Test plan
- [ ] Next feature merge → release PR titled `chore(main): release X.Y.Z`
- [ ] Merge release PR → `v*` tag + GitHub release created automatically
- [ ] `publish-packages.yml` + Docker dispatched without manual intervention