### PR TITLE
fix(ci): use simpler release-please title pattern that actually works

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -9,7 +9,7 @@
   "prerelease": false,
   "separate-pull-requests": false,
   "changelog-path": "CHANGELOG.md",
-  "pull-request-title-pattern": "chore${scope}: release${component} ${version}",
+  "pull-request-title-pattern": "chore(main): release ${version}",
   "packages": {
     ".": {
       "package-name": "@lobu/gateway",

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -9,6 +9,7 @@
   "prerelease": false,
   "separate-pull-requests": false,
   "changelog-path": "CHANGELOG.md",
+  "pull-request-title-pattern": "chore${scope}: release${component} ${version}",
   "packages": {
     ".": {
       "package-name": "@lobu/gateway",


### PR DESCRIPTION
Follow-up to #186 — the canonical `chore${scope}: release${component} ${version}` pattern trips release-please v4's own 'miss the part of' warnings and falls back to `chore: release main`. Use the same simple pattern as #176 that produced working titles in #175/#177.