### PR TITLE
fix(ci): drop package-name to fix release-please auto-tagging

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -12,7 +12,6 @@
   "pull-request-title-pattern": "chore(main): release ${version}",
   "packages": {
     ".": {
-      "package-name": "@lobu/gateway",
       "release-type": "node",
       "extra-files": [
         {


### PR DESCRIPTION
## Summary
- Removes `package-name: "@lobu/gateway"` from `release-please-config.json`
- This was the root cause of every release since v3.3.0 needing manual recovery

## Root cause
release-please v4 derives expected component `gateway` from `package-name`. The Merge plugin creates titles like `chore: release main` (no component). createReleases then fails:
```
⚠ PR component: undefined does not match configured component: gateway
```
No tag, no GitHub release, no publish workflow. Every release needed manual `gh release create` + label swap + `workflow_dispatch`.

`package-name` was cosmetic — npm publish uses each `packages/*/package.json` name, not this config key.

## Test plan
- [ ] Merge this PR → release-please opens a v3.4.2 release PR
- [ ] Merge the release PR → v3.4.2 tag + GitHub release created **automatically**
- [ ] publish-packages + Docker dispatched without manual intervention