### PR TITLE
fix(ci): include component in title pattern to fix auto-tagging

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -9,10 +9,10 @@
   "prerelease": false,
   "separate-pull-requests": false,
   "changelog-path": "CHANGELOG.md",
-  "pull-request-title-pattern": "chore(main): release ${version}",
+  "pull-request-title-pattern": "chore(main): release${component} ${version}",
   "packages": {
     ".": {
-      "component": "",
+      "package-name": "lobu",
       "release-type": "node",
       "extra-files": [
         {


### PR DESCRIPTION
## Summary
Root cause found by reading release-please source. `buildRelease()` in `strategies/base.ts` does a hard `return;` (not just a warning) when PR title component doesn't match the configured component. Previous fixes (#186, #188, #190, #192) addressed symptoms but not the actual check.

**The fix:**
- Set `package-name: "lobu"` → controls `getBranchComponent()` return value
- Include `${component}` in `pull-request-title-pattern` → parser can extract component from title
- Result: titles like `chore(main): release lobu 3.4.4`, component check passes

`include-component-in-tag: false` stays, so tags remain `v3.4.4`.

## Test plan
- [ ] Merge → release-please opens PR with title containing "lobu" + version
- [ ] Merge release PR → v3.4.4 tag + release created automatically (no manual recovery)
- [ ] publish + docker workflows dispatched