### PR TITLE
fix(ci): enable include-component-in-tag to fix auto-tagging

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "release-type": "node",
-  "include-component-in-tag": false,
+  "include-component-in-tag": true,
   "include-v-in-tag": true,
   "bump-minor-pre-major": false,
   "bump-patch-for-minor-pre-major": false,
@@ -9,10 +9,10 @@
   "prerelease": false,
   "separate-pull-requests": false,
   "changelog-path": "CHANGELOG.md",
-  "pull-request-title-pattern": "chore(main): release ${version}",
+  "pull-request-title-pattern": "chore(main): release${component} ${version}",
   "packages": {
     ".": {
-      "component": "",
+      "package-name": "lobu",
       "release-type": "node",
       "extra-files": [
         {


### PR DESCRIPTION
## Summary
The actual root cause: release-please's `getComponent()` returns `""` when `include-component-in-tag: false`, so component never appears in PR titles. But `getBranchComponent()` ignores that flag and returns the real component from package.json. The `buildRelease()` check compares these two values and `return;`s on mismatch — silently skipping release creation.

**Fix:** Set `include-component-in-tag: true` + `package-name: "lobu"`. This makes both `getComponent()` and `getBranchComponent()` return `"lobu"`, the title includes it, and the check passes.

**Tag format changes:** `v3.4.4` → `lobu-v3.4.4`. All downstream workflows (publish, Docker) use the tag_name output, not a hardcoded format.

**Title format:** `chore(main): release lobu 3.4.4`

## Test plan
- [ ] Merge → release PR with "lobu" in title
- [ ] Merge release PR → tag + release created automatically
- [ ] publish + docker dispatched