### PR TITLE
fix(ci): add group-pull-request-title-pattern for merge plugin

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -10,6 +10,7 @@
   "separate-pull-requests": false,
   "changelog-path": "CHANGELOG.md",
   "pull-request-title-pattern": "chore(main): release${component} ${version}",
+  "group-pull-request-title-pattern": "chore(main): release${component} ${version}",
   "packages": {
     ".": {
       "package-name": "lobu",


### PR DESCRIPTION
## Summary
- The Merge plugin ignores `pull-request-title-pattern` and uses its own default pattern which drops `${component}` and `${version}` from the title
- This causes `buildRelease()` to fail the component match check (parses empty component from title vs expected `lobu`)
- Adding `group-pull-request-title-pattern` ensures the merged PR title includes the component, allowing auto-tagging to succeed