### PR TITLE
feat(landing): per-use-case chat switcher on platform pages

### DIFF
--- a/packages/landing/src/components/Chip.tsx
+++ b/packages/landing/src/components/Chip.tsx
@@ -1,0 +1,60 @@
+import { darkBase, textColor } from "./memory/styles";
+
+const primaryAccent = "var(--color-tg-accent)";
+const primaryAccentSoft = "rgba(var(--color-tg-accent-rgb), 0.08)";
+
+export interface ChipProps {
+  label: string;
+  active?: boolean;
+  onClick?: () => void;
+  color?: string;
+}
+
+export function Chip({
+  label,
+  active = false,
+  onClick,
+  color = primaryAccent,
+}: ChipProps) {
+  const isPrimaryAccent = color === primaryAccent;
+  const style = {
+    color: active ? darkBase : textColor,
+    backgroundColor: active
+      ? color
+      : isPrimaryAccent
+        ? primaryAccentSoft
+        : `${color}14`,
+    borderColor: active
+      ? isPrimaryAccent
+        ? "rgba(var(--color-tg-accent-rgb), 0.72)"
+        : `${color}b8`
+      : isPrimaryAccent
+        ? "rgba(var(--color-tg-accent-rgb), 0.28)"
+        : `${color}47`,
+    boxShadow: active
+      ? isPrimaryAccent
+        ? "0 8px 24px rgba(var(--color-tg-accent-rgb), 0.16)"
+        : `0 8px 24px ${color}29`
+      : "none",
+  };
+
+  if (!onClick) {
+    return (
+      <span class="px-3 py-1 rounded-full text-xs border" style={style}>
+        {label}
+      </span>
+    );
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      class="px-3 py-1 rounded-full text-xs border transition-all hover:-translate-y-0.5 cursor-pointer"
+      style={style}
+      aria-pressed={active}
+    >
+      {label}
+    </button>
+  );
+}

--- a/packages/landing/src/components/HeroSection.tsx
+++ b/packages/landing/src/components/HeroSection.tsx
@@ -77,7 +77,7 @@ export function HeroSection(props: {
           <HighlightedText
             text={
               props.heroCopy?.title ??
-              "Your AI team, running in your infrastructure"
+              "Your AI team, running on your infrastructure"
             }
             highlight={props.heroCopy?.highlight ?? "AI team"}
           />

--- a/packages/landing/src/components/PlatformChatExamples.tsx
+++ b/packages/landing/src/components/PlatformChatExamples.tsx
@@ -1,10 +1,14 @@
 /**
  * Renders a full chat-grid showcase for a platform docs page.
- * Picks the right theme for the platform and renders the canonical
- * Lobu chat scenarios (permission, skill install, settings link).
+ * A use-case chip row at the top lets the visitor re-skin the three chat
+ * windows with use-case-appropriate transcripts (devops, support, legal, …).
+ * The platform-specific theme (colors, chrome) stays fixed.
  */
 
+import { useMemo, useState } from "preact/hooks";
 import { PLATFORM_SCENARIOS } from "../chat-scenarios";
+import type { UseCase } from "../types";
+import { landingUseCaseShowcases } from "../use-case-showcases";
 import {
   type ChatTheme,
   DISCORD_THEME,
@@ -15,6 +19,7 @@ import {
   TELEGRAM_THEME,
   WHATSAPP_THEME,
 } from "./SampleChat";
+import { UseCaseTabs } from "./UseCaseTabs";
 
 const THEMES: Record<string, ChatTheme> = {
   telegram: TELEGRAM_THEME,
@@ -25,6 +30,8 @@ const THEMES: Record<string, ChatTheme> = {
   gchat: GCHAT_THEME,
 };
 
+const GENERAL_TAB_ID = "general";
+
 interface Props {
   platform: keyof typeof THEMES | string;
 }
@@ -32,11 +39,34 @@ interface Props {
 export function PlatformChatExamples({ platform }: Props) {
   const theme = THEMES[platform] ?? TELEGRAM_THEME;
 
+  const tabs = useMemo(
+    () => [
+      { id: GENERAL_TAB_ID, label: "General" },
+      ...landingUseCaseShowcases
+        .filter((showcase) => showcase.chatScenarios !== undefined)
+        .map((showcase) => ({ id: showcase.id, label: showcase.label })),
+    ],
+    []
+  );
+
+  const [activeId, setActiveId] = useState<string>(GENERAL_TAB_ID);
+
+  const scenarios: UseCase[] = useMemo(() => {
+    if (activeId === GENERAL_TAB_ID) return PLATFORM_SCENARIOS;
+    const showcase = landingUseCaseShowcases.find((s) => s.id === activeId);
+    const scenarioSet = showcase?.chatScenarios;
+    if (!scenarioSet) return PLATFORM_SCENARIOS;
+    return [scenarioSet.permission, scenarioSet.skill, scenarioSet.settings];
+  }, [activeId]);
+
   return (
-    <div class="not-content chat-grid-fullwidth grid gap-6 my-6 md:grid-cols-3">
-      {PLATFORM_SCENARIOS.map((scenario) => (
-        <SampleChat key={scenario.id} useCase={scenario} theme={theme} />
-      ))}
+    <div class="not-content my-8 flex flex-col gap-10">
+      <UseCaseTabs tabs={tabs} activeId={activeId} onSelect={setActiveId} />
+      <div class="chat-grid-fullwidth grid gap-6 md:grid-cols-3">
+        {scenarios.map((scenario) => (
+          <SampleChat key={scenario.id} useCase={scenario} theme={theme} />
+        ))}
+      </div>
     </div>
   );
 }

--- a/packages/landing/src/components/SkillsSection.tsx
+++ b/packages/landing/src/components/SkillsSection.tsx
@@ -698,9 +698,9 @@ export function SkillsSection(props: {
             <HighlightedText
               text={
                 props.heroCopy?.title ??
-                "Build reliable agents with CLI-like skills"
+                "Build reliable agents with Lobu skills"
               }
-              highlight={props.heroCopy?.highlight ?? "CLI-like skills"}
+              highlight={props.heroCopy?.highlight ?? "Lobu skills"}
             />
           }
           description={

--- a/packages/landing/src/components/connect-from/ConnectFromDocContent.astro
+++ b/packages/landing/src/components/connect-from/ConnectFromDocContent.astro
@@ -61,6 +61,7 @@ const relatedLinks = client.docsRelated.map((link) => {
   mcpBaseUrl={owlettoMcpUrl}
   owlettoBaseUrl={owlettoBaseUrl}
   workspaces={landingUseCaseWorkspaceOptions}
+  initialUseCaseId={useCaseId}
 />
 
 {client.npmPackage ? (

--- a/packages/landing/src/components/connect-from/ConnectFromDocContent.astro
+++ b/packages/landing/src/components/connect-from/ConnectFromDocContent.astro
@@ -6,13 +6,13 @@ import {
 } from "../../connect-from-config";
 import {
   getLandingUseCaseShowcase,
+  getOwlettoBaseUrl,
   getOwlettoMcpUrl,
-  getOwlettoOrgSlug,
-  getOwlettoScopedMcpUrl,
-  getOwlettoUrl,
+  landingUseCaseWorkspaceOptions,
 } from "../../use-case-showcases";
 import type { LandingUseCaseId } from "../../use-case-definitions";
-import ConnectFromUseCaseLinks from "./ConnectFromUseCaseLinks.astro";
+import { CopyableSnippet } from "./CopyableSnippet";
+import { TryItSection } from "./TryItSection";
 
 const { clientId, useCaseId } = Astro.props as {
   clientId: ConnectFromClientId;
@@ -20,12 +20,8 @@ const { clientId, useCaseId } = Astro.props as {
 };
 const client = getConnectFromClientConfig(clientId);
 const showcase = useCaseId ? getLandingUseCaseShowcase(useCaseId) : undefined;
-const owlettoUrl = showcase ? getOwlettoUrl(showcase.id) : undefined;
 const owlettoMcpUrl = getOwlettoMcpUrl();
-const owlettoOrgSlug = showcase ? getOwlettoOrgSlug(showcase.id) : undefined;
-const owlettoScopedMcpUrl = showcase
-  ? getOwlettoScopedMcpUrl(showcase.id)
-  : owlettoMcpUrl;
+const owlettoBaseUrl = getOwlettoBaseUrl();
 
 const clientSwitcherLinks = connectFromClientIds
   .filter((id) => id !== clientId)
@@ -57,73 +53,52 @@ const relatedLinks = client.docsRelated.map((link) => {
 });
 ---
 
-{client.docsIntro.map((paragraph) => (
-  <p>{paragraph}</p>
-))}
+<p>{client.valueProp}</p>
 
-<h2>Try it</h2>
-<p>
-  {showcase
-    ? `Use the org-scoped Owletto MCP endpoint for the ${showcase.label.toLowerCase()} example so the connected client stays pinned to that workspace.`
-    : "Pick a use case to see the project context, memory model, and the Owletto connection path for that example."}
-</p>
+<TryItSection
+  client:load
+  clientLabel={client.label}
+  mcpBaseUrl={owlettoMcpUrl}
+  owlettoBaseUrl={owlettoBaseUrl}
+  workspaces={landingUseCaseWorkspaceOptions}
+/>
 
-<ConnectFromUseCaseLinks clientId={clientId} activeUseCaseId={showcase?.id} />
-
-{showcase ? (
+{client.npmPackage ? (
   <>
-    <ul>
-      <li>
-        <strong>MCP URL:</strong> <code>{owlettoScopedMcpUrl}</code>
-      </li>
-      {owlettoOrgSlug ? (
-        <li>
-          <strong>Fixed organization:</strong> <code>{owlettoOrgSlug}</code>
-        </li>
-      ) : null}
-      <li>
-        <strong>Memory model:</strong> {showcase.memory.entityTypes.join(", ")}
-      </li>
-    </ul>
-
-    {owlettoOrgSlug ? (
-      <p>
-        This scoped endpoint should not expose organization switching tools.
-      </p>
-    ) : null}
-
-    <details>
-      <summary>Suggested instructions for {client.label}</summary>
-      <pre><code>{client.prompt(showcase)}</code></pre>
-    </details>
-
+    <h2>Install the plugin</h2>
     <p>
-      <a href={`/memory/for/${showcase.id}/`}>
-        View the {showcase.label} memory example
-      </a>
-      {" · "}
-      <a href={owlettoUrl} target="_blank" rel="noopener noreferrer">
-        Open the {showcase.label} Owletto workspace
-      </a>
+      Source: <a href={client.npmPackage.sourceUrl} target="_blank" rel="noopener noreferrer">{client.npmPackage.sourceUrl.replace("https://", "")}</a>
+      {" · "}<br />
+      npm: <a href={client.npmPackage.registryUrl} target="_blank" rel="noopener noreferrer"><code>{client.npmPackage.name}</code></a>
     </p>
+    <CopyableSnippet
+      client:load
+      code={client.npmPackage.installCommand}
+      label="Install command"
+    />
   </>
 ) : null}
 
-<h2>What You Need</h2>
-<ul>
-  {client.docsNeeds.map((item) => (
-    <li>{item}</li>
-  ))}
-</ul>
+<h2>{client.installPromptLabel}</h2>
+<p>
+  Paste this into {client.label} and it will install Owletto memory for you.
+</p>
+<CopyableSnippet
+  client:load
+  code={client.installPrompt}
+  label={`Prompt for ${client.label}`}
+/>
 
 <h2>{client.docsSetupTitle}</h2>
 <ol>
   {client.docsSetupSteps.map((step) => (
-    <li>{step}</li>
+    <li set:html={step.replace(/`([^`]+)`/g, "<code>$1</code>")} />
   ))}
 </ol>
 
-{client.docsSetupNote ? <p>{client.docsSetupNote}</p> : null}
+{client.docsSetupNote ? (
+  <p set:html={client.docsSetupNote.replace(/`([^`]+)`/g, "<code>$1</code>")} />
+) : null}
 
 {client.docsExtraSection ? (
   <>

--- a/packages/landing/src/components/connect-from/CopyableSnippet.tsx
+++ b/packages/landing/src/components/connect-from/CopyableSnippet.tsx
@@ -29,12 +29,10 @@ export function CopyableSnippet({
     <div
       style={{
         borderRadius: "0.5rem",
-        border:
-          "1px solid var(--sl-color-hairline, rgba(255,255,255,0.1))",
+        border: "1px solid var(--sl-color-hairline, rgba(255,255,255,0.1))",
         margin: "0.75rem 0",
         overflow: "hidden",
-        backgroundColor:
-          "var(--sl-color-bg-inline-code, rgba(0,0,0,0.2))",
+        backgroundColor: "var(--sl-color-bg-inline-code, rgba(0,0,0,0.2))",
       }}
     >
       <div

--- a/packages/landing/src/components/connect-from/CopyableSnippet.tsx
+++ b/packages/landing/src/components/connect-from/CopyableSnippet.tsx
@@ -1,0 +1,96 @@
+import { useState } from "preact/hooks";
+
+type CopyableSnippetProps = {
+  code: string;
+  label?: string;
+};
+
+export function CopyableSnippet({
+  code,
+  label = "Copy",
+}: CopyableSnippetProps) {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = () => {
+    if (typeof navigator === "undefined" || !navigator.clipboard) {
+      return;
+    }
+
+    navigator.clipboard
+      .writeText(code)
+      .then(() => {
+        setCopied(true);
+        setTimeout(() => setCopied(false), 2000);
+      })
+      .catch(() => undefined);
+  };
+
+  return (
+    <div
+      style={{
+        borderRadius: "0.5rem",
+        border:
+          "1px solid var(--sl-color-hairline, rgba(255,255,255,0.1))",
+        margin: "0.75rem 0",
+        overflow: "hidden",
+        backgroundColor:
+          "var(--sl-color-bg-inline-code, rgba(0,0,0,0.2))",
+      }}
+    >
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          gap: "0.75rem",
+          padding: "0.5rem 0.75rem",
+          borderBottom:
+            "1px solid var(--sl-color-hairline, rgba(255,255,255,0.1))",
+        }}
+      >
+        <span
+          style={{
+            fontSize: "10px",
+            textTransform: "uppercase",
+            letterSpacing: "0.18em",
+            color: "var(--sl-color-gray-3, #888)",
+          }}
+        >
+          {label}
+        </span>
+        <button
+          type="button"
+          onClick={handleCopy}
+          style={{
+            fontSize: "11px",
+            fontWeight: 500,
+            padding: "0.25rem 0.5rem",
+            borderRadius: "0.375rem",
+            cursor: "pointer",
+            transition: "color 0.15s",
+            color: copied
+              ? "var(--sl-color-accent, #7aa2f7)"
+              : "var(--sl-color-text, #fff)",
+            backgroundColor: "transparent",
+            border:
+              "1px solid var(--sl-color-hairline, rgba(255,255,255,0.15))",
+          }}
+        >
+          {copied ? "Copied" : "Copy"}
+        </button>
+      </div>
+      <pre
+        style={{
+          margin: 0,
+          padding: "0.75rem",
+          fontSize: "12px",
+          lineHeight: "1.25rem",
+          overflowX: "auto",
+          backgroundColor: "transparent",
+        }}
+      >
+        <code style={{ background: "transparent" }}>{code}</code>
+      </pre>
+    </div>
+  );
+}

--- a/packages/landing/src/components/connect-from/TryItSection.tsx
+++ b/packages/landing/src/components/connect-from/TryItSection.tsx
@@ -50,12 +50,12 @@ export function TryItSection({
   return (
     <div>
       <p>
-        Lobu is open-source but we also have a managed cloud. If you'd like to try, sign in at{" "}
+        Lobu is open-source but we also have a managed cloud. If you'd like to
+        try, sign in at{" "}
         <a href={signInHref} target="_blank" rel="noopener noreferrer">
           {signInLabel}
         </a>
-        , then point {clientLabel} at <code>{mcpUrl}</code> as the MCP
-        endpoint.{" "}
+        , then point {clientLabel} at <code>{mcpUrl}</code> as the MCP endpoint.{" "}
         {selected ? (
           <>
             This URL is scoped to the <strong>{selected.label}</strong>{" "}

--- a/packages/landing/src/components/connect-from/TryItSection.tsx
+++ b/packages/landing/src/components/connect-from/TryItSection.tsx
@@ -1,0 +1,81 @@
+import { useMemo, useState } from "preact/hooks";
+import type { LandingUseCaseWorkspaceOption } from "../../use-case-showcases";
+import { UseCaseTabs } from "../UseCaseTabs";
+
+type TryItSectionProps = {
+  clientLabel: string;
+  mcpBaseUrl: string;
+  owlettoBaseUrl: string;
+  workspaces: LandingUseCaseWorkspaceOption[];
+  initialUseCaseId?: string;
+};
+
+export function TryItSection({
+  clientLabel,
+  mcpBaseUrl,
+  owlettoBaseUrl,
+  workspaces,
+  initialUseCaseId,
+}: TryItSectionProps) {
+  const [selectedId, setSelectedId] = useState<string | undefined>(
+    initialUseCaseId
+  );
+
+  const selected = useMemo(
+    () => workspaces.find((w) => w.id === selectedId),
+    [workspaces, selectedId]
+  );
+
+  const mcpUrl = selected?.orgSlug
+    ? `${mcpBaseUrl}/${selected.orgSlug}`
+    : mcpBaseUrl;
+
+  const signInHref = selected?.orgSlug
+    ? `${owlettoBaseUrl}/${selected.orgSlug}`
+    : owlettoBaseUrl;
+
+  const signInLabel = selected?.orgSlug
+    ? `owletto.com/${selected.orgSlug}`
+    : "owletto.com";
+
+  const tabs = useMemo(
+    () => workspaces.map((w) => ({ id: w.id, label: w.label })),
+    [workspaces]
+  );
+
+  const handleSelect = (id: string) => {
+    setSelectedId((current) => (current === id ? undefined : id));
+  };
+
+  return (
+    <div>
+      <p>
+        Lobu is open-source but we also have a managed cloud. If you'd like to try, sign in at{" "}
+        <a href={signInHref} target="_blank" rel="noopener noreferrer">
+          {signInLabel}
+        </a>
+        , then point {clientLabel} at <code>{mcpUrl}</code> as the MCP
+        endpoint.{" "}
+        {selected ? (
+          <>
+            This URL is scoped to the <strong>{selected.label}</strong>{" "}
+            workspace.
+          </>
+        ) : (
+          <>
+            The same URL works for every workspace — pick one below to scope it
+            to that example.
+          </>
+        )}
+      </p>
+
+      <div class="not-content my-6">
+        <UseCaseTabs
+          tabs={tabs}
+          activeId={selectedId ?? ""}
+          onSelect={handleSelect}
+        />
+      </div>
+    </div>
+  );
+}

--- a/packages/landing/src/components/memory/ExampleShowcase.tsx
+++ b/packages/landing/src/components/memory/ExampleShowcase.tsx
@@ -2,6 +2,7 @@ import type { ComponentChildren } from "preact";
 import { useEffect, useMemo, useState } from "preact/hooks";
 import { examples, type RecordNode } from "../../memory-examples";
 import { landingUseCaseOptions } from "../../use-case-showcases";
+import { Chip } from "../Chip";
 import { CompactContentRail } from "../CompactContentRail";
 import { SectionHeader } from "../SectionHeader";
 import { UseCaseTabs } from "../UseCaseTabs";
@@ -236,59 +237,6 @@ function DetailCard({ children }: { children: ComponentChildren }) {
     >
       {children}
     </div>
-  );
-}
-
-function StepChip({
-  label,
-  active = false,
-  onClick,
-  color,
-}: {
-  label: string;
-  active?: boolean;
-  onClick?: () => void;
-  color: string;
-}) {
-  const isPrimaryAccent = color === primaryAccent;
-  const style = {
-    color: active ? darkBase : textColor,
-    backgroundColor: active
-      ? color
-      : isPrimaryAccent
-        ? primaryAccentSoft
-        : `${color}14`,
-    borderColor: active
-      ? isPrimaryAccent
-        ? "rgba(var(--color-tg-accent-rgb), 0.72)"
-        : `${color}b8`
-      : isPrimaryAccent
-        ? "rgba(var(--color-tg-accent-rgb), 0.28)"
-        : `${color}47`,
-    boxShadow: active
-      ? isPrimaryAccent
-        ? "0 8px 24px rgba(var(--color-tg-accent-rgb), 0.16)"
-        : `0 8px 24px ${color}29`
-      : "none",
-  };
-
-  if (!onClick) {
-    return (
-      <span class="px-3 py-1 rounded-full text-xs border" style={style}>
-        {label}
-      </span>
-    );
-  }
-
-  return (
-    <button
-      type="button"
-      onClick={onClick}
-      class="px-3 py-1 rounded-full text-xs border transition-all hover:-translate-y-0.5"
-      style={style}
-    >
-      {label}
-    </button>
   );
 }
 
@@ -673,7 +621,7 @@ export function ExampleShowcase(props: {
                                 activeExample.entitySelections?.[type];
 
                               return (
-                                <StepChip
+                                <Chip
                                   key={type}
                                   label={type}
                                   active={targetNodeId === selectedNodeId}
@@ -1097,7 +1045,7 @@ export function ExampleShowcase(props: {
                     ) : step.chips?.length ? (
                       <div class="flex flex-wrap gap-1.5 mb-4">
                         {step.chips.map((chip) => (
-                          <StepChip key={chip} label={chip} color={color} />
+                          <Chip key={chip} label={chip} color={color} />
                         ))}
                       </div>
                     ) : null}

--- a/packages/landing/src/connect-from-config.ts
+++ b/packages/landing/src/connect-from-config.ts
@@ -12,17 +12,35 @@ type ConnectFromDocSection = {
   paragraphs: string[];
 };
 
+export type ConnectFromNpmPackage = {
+  name: string;
+  registryUrl: string;
+  sourceUrl: string;
+  installCommand: string;
+};
+
 type ConnectFromClientConfig = {
   id: ConnectFromClientId;
   label: string;
   docsHref: string;
   docsLabel: string;
-  command: string;
   startTitle: string;
+  /**
+   * One-liner shown directly under the page title that explains what Owletto
+   * adds to this agent.
+   */
+  valueProp: string;
+  /**
+   * The text the user copies into their agent (or assistant) so it can install
+   * Owletto memory for them.
+   */
+  installPrompt: string;
+  installPromptLabel: string;
+  /**
+   * Optional npm package to surface as the canonical install path.
+   */
+  npmPackage?: ConnectFromNpmPackage;
   describe: (showcase: LandingUseCaseShowcase) => string;
-  prompt: (showcase: LandingUseCaseShowcase) => string;
-  docsIntro: string[];
-  docsNeeds: string[];
   docsSetupTitle: string;
   docsSetupSteps: string[];
   docsSetupNote?: string;
@@ -30,25 +48,9 @@ type ConnectFromClientConfig = {
   docsRelated: ConnectFromDocLink[];
 };
 
-const MCP_CLIENT_NEEDS = [
-  "An Owletto MCP endpoint (shared or org-scoped)",
-  "A valid Owletto login",
-  "A workspace or organization selected in Owletto",
-];
-
-const mcpClientSteps = (label: string) => [
-  `Open ${label}'s MCP connection flow.`,
-  "Add your Owletto MCP endpoint.",
-  "Complete the normal Owletto auth flow.",
-  `Verify ${label} can access the memory tools you expect.`,
-];
-
 const mcpClientDescribe =
   (label: string) => (showcase: LandingUseCaseShowcase) =>
-    `Use the ${showcase.label.toLowerCase()} Owletto workspace as the shared memory layer for ${label}, then reuse the same entities, relations, and watcher outputs from this example.`;
-
-const mcpClientPrompt = (label: string) => (showcase: LandingUseCaseShowcase) =>
-  `Connect ${label} to Owletto for ${showcase.label}. Reuse the same memory model shown here: ${showcase.memory.entityTypes.join(", ")}. Keep ${label} pointed at the Owletto workspace for this project so it can search, read, and save shared memory.`;
+    `Use ${label} on top of the ${showcase.label.toLowerCase()} workspace so it can read and write the same shared memory shown in this example.`;
 
 export const connectFromClientConfigs: Record<
   ConnectFromClientId,
@@ -59,18 +61,22 @@ export const connectFromClientConfigs: Record<
     label: "ChatGPT",
     docsHref: "/connect-from/chatgpt/",
     docsLabel: "ChatGPT setup docs",
-    command: "npx owletto@latest init",
-    startTitle: "Connect ChatGPT in seconds",
+    startTitle: "Connect ChatGPT to Owletto",
+    valueProp:
+      "Add structured, queryable long-term memory to ChatGPT — the same graph other agents share, recalled and updated through one MCP endpoint.",
+    installPromptLabel: "Copy install prompt",
+    installPrompt:
+      "Connect ChatGPT to Owletto: open Settings → Integrations → Model Context Protocol → Add Server, name it `Owletto`, and paste the MCP URL https://owletto.com/mcp. Sign in with your Owletto account when prompted, then point ChatGPT at the workspace I want it to use.",
     describe: mcpClientDescribe("ChatGPT"),
-    prompt: mcpClientPrompt("ChatGPT"),
-    docsIntro: [
-      "Use your Owletto MCP endpoint (or an org-scoped endpoint for fixed workspaces) as the memory source when connecting from ChatGPT.",
-    ],
-    docsNeeds: MCP_CLIENT_NEEDS,
     docsSetupTitle: "Connect ChatGPT",
-    docsSetupSteps: mcpClientSteps("ChatGPT"),
+    docsSetupSteps: [
+      "Open Settings → Integrations → Model Context Protocol → Add Server in ChatGPT.",
+      "Name the server `Owletto` and paste https://owletto.com/mcp as the URL.",
+      "Complete the Owletto sign-in flow in the popup.",
+      "Pick the workspace ChatGPT should read and write.",
+    ],
     docsSetupNote:
-      "Start with the same endpoint and auth flow described in the Owletto CLI Reference.",
+      "ChatGPT discovers the available memory tools automatically once the MCP connection is approved.",
     docsRelated: [
       { label: "Memory", href: "/getting-started/memory/" },
       { label: "Owletto CLI Reference", href: "/reference/owletto-cli/" },
@@ -81,24 +87,27 @@ export const connectFromClientConfigs: Record<
     label: "Claude",
     docsHref: "/connect-from/claude/",
     docsLabel: "Claude setup docs",
-    command: "npx owletto@latest init",
-    startTitle: "Connect Claude in seconds",
+    startTitle: "Connect Claude to Owletto",
+    valueProp:
+      "Give Claude durable, structured memory it can search and append to — so the same recall is available across Claude, ChatGPT, and your own agents.",
+    installPromptLabel: "Copy install prompt",
+    installPrompt:
+      "Connect Claude to Owletto: open Settings → Connectors → Add Custom Connector, paste the MCP URL https://owletto.com/mcp, complete the Owletto sign-in, then enable the connector. Pick the workspace I want Claude to read and write.",
     describe: mcpClientDescribe("Claude"),
-    prompt: mcpClientPrompt("Claude"),
-    docsIntro: [
-      "Use the same Owletto MCP endpoint (or an org-scoped endpoint for fixed workspaces) from Claude when you want Claude-based workflows to read and write shared memory.",
-    ],
-    docsNeeds: MCP_CLIENT_NEEDS,
     docsSetupTitle: "Connect Claude",
-    docsSetupSteps: mcpClientSteps("Claude"),
+    docsSetupSteps: [
+      "Open Settings → Connectors → Add Custom Connector in Claude Desktop or claude.ai.",
+      "Paste https://owletto.com/mcp as the MCP URL.",
+      "Complete the Owletto sign-in flow.",
+      "Enable the connector and choose the workspace Claude should use.",
+    ],
     docsSetupNote:
-      "In practice, this uses Claude's MCP connection flow with your Owletto endpoint and standard Owletto auth.",
+      "For Claude Code, run `claude mcp add --transport http owletto https://owletto.com/mcp` instead and complete the OAuth flow when prompted.",
     docsExtraSection: {
-      title: "Claude Code And Claude Desktop",
+      title: "Claude Code and Claude Desktop",
       paragraphs: [
-        "If you are using Claude Code or the Claude Desktop app instead of the hosted Claude client, the setup is usually a mix of local client configuration and project-level instructions.",
-        "A practical setup is to run owletto init, run owletto login, then add a local skill or instruction file that tells the agent when to search, read, and save knowledge in Owletto.",
-        "That gives you both pieces: MCP or client wiring through the Owletto CLI, plus skill-style instructions for how the coding agent should use memory during work.",
+        "Claude Code uses the same MCP endpoint, registered through `claude mcp add`. The OAuth flow is handled in your browser the first time you call a memory tool.",
+        "Pair the connector with a project-level instruction file (or a small skill) that tells Claude when to search memory before answering and when to save what it just learned.",
       ],
     },
     docsRelated: [
@@ -112,30 +121,36 @@ export const connectFromClientConfigs: Record<
     label: "OpenClaw",
     docsHref: "/connect-from/openclaw/",
     docsLabel: "OpenClaw setup docs",
-    command: "npx owletto@latest configure",
-    startTitle: "Install OpenClaw memory in seconds",
+    startTitle: "Install Owletto memory in OpenClaw",
+    valueProp:
+      "Layer structured, shareable memory on top of OpenClaw's built-in filesystem memory — the plugin extends OpenClaw's filesystem plugin and can optionally take over its memory slot, so different OpenClaw agents can talk to each other through the same Owletto graph.",
+    installPromptLabel: "Copy install prompt",
+    installPrompt:
+      "Install Owletto memory in OpenClaw. Run:\n\n  openclaw plugins install owletto-openclaw-plugin\n  owletto login https://owletto.com/mcp\n  owletto configure\n  owletto health\n\nThe plugin extends OpenClaw's filesystem plugin and can replace its memory slot. After install, point me at the Owletto workspace I should use as shared memory across my OpenClaw agents.",
+    npmPackage: {
+      name: "@lobu/owletto-openclaw",
+      registryUrl: "https://www.npmjs.com/package/@lobu/owletto-openclaw",
+      sourceUrl:
+        "https://github.com/lobu-ai/owletto/tree/main/packages/openclaw-plugin",
+      installCommand: "openclaw plugins install owletto-openclaw-plugin",
+    },
     describe: (showcase) =>
-      `Install Owletto into OpenClaw for the ${showcase.label.toLowerCase()} example so OpenClaw can read and write the same shared memory graph shown on this page.`,
-    prompt: (showcase) =>
-      `Install Owletto memory in OpenClaw for ${showcase.label}. Reuse the same memory model shown here: ${showcase.memory.entityTypes.join(", ")}. Configure OpenClaw to read and write the Owletto workspace for this project.`,
-    docsIntro: [
-      "For OpenClaw, install and configure the @lobu/owletto-openclaw memory plugin so OpenClaw can read and write Owletto directly.",
-      "You can use a shared endpoint or an org-scoped endpoint for fixed workspaces.",
-    ],
-    docsNeeds: [
-      "OpenClaw installed",
-      "An Owletto MCP endpoint (shared or org-scoped)",
-      "A valid Owletto login",
-    ],
-    docsSetupTitle: "Install to OpenClaw",
+      `Install Owletto into OpenClaw and point it at the ${showcase.label.toLowerCase()} workspace so multiple OpenClaw agents share the same memory shown in this example.`,
+    docsSetupTitle: "Install in OpenClaw",
     docsSetupSteps: [
-      "Run owletto configure.",
-      "Review the generated memory plugin configuration.",
-      "Point OpenClaw at the Owletto workspace for your project.",
-      "Verify OpenClaw can read and write shared memory.",
+      "Install the plugin: `openclaw plugins install owletto-openclaw-plugin`.",
+      "Log in to Owletto: `owletto login https://owletto.com/mcp`.",
+      "Wire it into OpenClaw: `owletto configure` (writes the plugin config and, if you opt in, takes over the filesystem memory slot).",
+      "Verify: `owletto health`.",
     ],
     docsSetupNote:
-      "The fastest path is owletto configure, which writes the plugin config for you.",
+      "The plugin extends OpenClaw's filesystem plugin. Leave that plugin enabled if you want both, or let `owletto configure` swap Owletto in as the memory slot.",
+    docsExtraSection: {
+      title: "Cross-agent memory",
+      paragraphs: [
+        "Once two OpenClaw agents point at the same Owletto workspace, they read and write the same entities, observations, and decisions — that is how a team of OpenClaw agents stays coherent without copy-pasting context.",
+      ],
+    },
     docsRelated: [
       { label: "Memory", href: "/getting-started/memory/" },
       { label: "Owletto CLI Reference", href: "/reference/owletto-cli/" },

--- a/packages/landing/src/content/docs/getting-started/index.mdx
+++ b/packages/landing/src/content/docs/getting-started/index.mdx
@@ -3,8 +3,6 @@ title: Getting Started
 description: Choose between managed community access and self-hosted deployment.
 ---
 
-import { ArchitectureDiagram } from "../../../components/ArchitectureDiagram";
-
 Deploy sandboxed, persistent AI agents to your infrastructure — one isolated agent per user and channel, from a single deploy.
 
 ## Quick start
@@ -17,16 +15,41 @@ cd my-agent && npx @lobu/cli@latest run -d
 # 2. Chat with your agent
 npx @lobu/cli@latest chat "Hello, what can you do?"
 
-# 3. Customize behavior (edit prompt files)
-#    agents/my-agent/IDENTITY.md  — who the agent is
-#    agents/my-agent/SOUL.md      — instructions and rules
-#    agents/my-agent/USER.md      — user context
-
-# 4. Run evals to measure quality
+# 3. Run evals to measure quality
 npx @lobu/cli@latest eval
 ```
 
-The `init` wizard walks you through deployment mode, AI provider, skills, messaging platform, and memory configuration. All choices are saved to `lobu.toml` and `.env`.
+## Project structure
+
+```
+my-agent/
+├── lobu.toml                  # agents, providers, skills, network
+├── .env                       # secrets (API keys, OAuth tokens)
+├── docker-compose.yml         # Redis + gateway + optional Owletto
+├── AGENTS.md                  # briefing for coding agents
+├── README.md
+├── TESTING.md
+├── agents/my-agent/
+│   ├── IDENTITY.md            # who the agent is
+│   ├── SOUL.md                # instructions, rules, workflows
+│   ├── USER.md                # per-user context and preferences
+│   ├── skills/                # skills scoped to this agent only
+│   └── evals/
+│       └── ping.yaml          # test cases for agent quality
+├── skills/                    # skills shared across all agents
+├── models/                    # Owletto entity schemas (if memory enabled)
+├── data/                      # Owletto seed entities and relationships
+└── owletto.yaml               # Owletto project config (if memory enabled)
+```
+
+| Path | Docs |
+|------|------|
+| `lobu.toml` | [lobu.toml reference](/reference/lobu-toml/) |
+| `agents/*/IDENTITY.md`, `SOUL.md`, `USER.md` | [Agent Workspace](/guides/agent-prompts/) |
+| `agents/*/skills/`, `skills/` | [SKILL.md reference](/reference/skill-md/), [Skills](/getting-started/skills/) |
+| `agents/*/evals/` | [Evaluations](/guides/evals/) |
+| `models/`, `data/`, `owletto.yaml` | [Memory](/getting-started/memory/) |
+| `docker-compose.yml`, `Dockerfile.worker` | [Deployment](/deployment/docker/) |
 
 ## Develop your agent
 
@@ -45,15 +68,7 @@ Please:
 Explain what you change and why.
 ```
 
-The coding agent will read your project structure and help you:
-
-- **Shape the personality** — edit `IDENTITY.md` to define who the agent is
-- **Write instructions** — edit `SOUL.md` with rules, workflows, and constraints
-- **Add skills** — enable GitHub, Google Workspace, Linear, or custom MCP servers in `lobu.toml`
-- **Configure network access** — set which domains the agent can reach
-- **Write evals** — create test cases in `agents/my-agent/evals/` to verify quality
-
-### What to give the coding agent
+### What to ask for
 
 | File | What to ask for |
 |------|----------------|
@@ -70,8 +85,6 @@ After each change, test with:
 npx @lobu/cli@latest chat "Hello, can you cancel my subscription?"
 npx @lobu/cli@latest eval
 ```
-
-See [Agent Workspace](/guides/agent-prompts/), [SKILL.md Reference](/reference/skill-md/), and [Evaluations](/guides/evals/) for details on each file.
 
 ## Configuration
 

--- a/packages/landing/src/content/docs/platforms/discord.mdx
+++ b/packages/landing/src/content/docs/platforms/discord.mdx
@@ -9,6 +9,8 @@ import { PlatformConfigTable } from "../../../components/PlatformConfigTable";
 Lobu's Discord adapter supports direct messages, server channels, and interactive workflows.
 Under the hood, Lobu uses the Chat SDK Discord adapter to handle DMs and server messaging.
 
+<PlatformChatExamples platform="discord" client:visible />
+
 ## Setup
 
 1. Create a Discord application at the [Discord Developer Portal](https://discord.com/developers/applications).
@@ -17,9 +19,6 @@ Under the hood, Lobu uses the Chat SDK Discord adapter to handle DMs and server 
 4. Under **OAuth2 → URL Generator**, select the `bot` scope with `Send Messages`, `Read Message History`, and `Use Slash Commands` permissions. Use the generated URL to invite the bot to your server.
 5. Run `lobu connections add discord` to add the connection (prompts for the bot token), or run `lobu init` to scaffold a new project and pick Discord in the wizard.
 
-## Interactive Examples
-
-<PlatformChatExamples platform="discord" />
 
 ## Configuration
 

--- a/packages/landing/src/content/docs/platforms/google-chat.mdx
+++ b/packages/landing/src/content/docs/platforms/google-chat.mdx
@@ -9,6 +9,9 @@ import { PlatformConfigTable } from "../../../components/PlatformConfigTable";
 Lobu's Google Chat adapter supports direct messages, space mentions, and interactive workflows.
 Under the hood, Lobu uses `@chat-adapter/gchat` with the Google Chat API and Workspace Events.
 
+<PlatformChatExamples platform="gchat" client:visible />
+
+
 ## Setup
 
 1. Create a Google Cloud project and enable the **Google Chat API** and **Workspace Events API**.
@@ -17,10 +20,6 @@ Under the hood, Lobu uses `@chat-adapter/gchat` with the Google Chat API and Wor
    - Set the **App URL** to your gateway's webhook endpoint: `https://your-gateway/api/v1/webhooks/{connectionId}`
    - Enable **Interactive features** and configure the connection settings.
 4. Run `lobu connections add gchat` to add the connection (prompts for the service account JSON), or run `lobu init` to scaffold a new project and pick Google Chat in the wizard.
-
-## Interactive Examples
-
-<PlatformChatExamples platform="gchat" />
 
 ## Configuration
 

--- a/packages/landing/src/content/docs/platforms/slack.mdx
+++ b/packages/landing/src/content/docs/platforms/slack.mdx
@@ -8,6 +8,8 @@ import { PlatformConfigTable } from "../../../components/PlatformConfigTable";
 
 Lobu's Slack adapter supports assistant threads, rich UI, and interactive workflows.
 
+<PlatformChatExamples platform="slack" client:visible />
+
 ## Setup
 
 ### Single-workspace setup
@@ -45,12 +47,6 @@ Minimum setup:
 
 When a user completes the Slack install flow, Lobu exchanges the OAuth code, stores the workspace installation, and creates or updates the Lobu Slack connection for that workspace automatically.
 
-## Interactive Examples
-
-Three common Slack thread interactions: network permission, skill install, and settings link.
-
-<PlatformChatExamples platform="slack" />
-
 ## Configuration
 
 <PlatformConfigTable platform="slack" />
@@ -64,24 +60,6 @@ Three common Slack thread interactions: network permission, skill install, and s
 - **MCP tool access** — workers discover MCP tools at startup and call them through the gateway proxy; responses render inline as system messages.
 - **Settings/auth links** rendered as platform-scoped link buttons.
 - **Thread status indicator** (`is running..`) with rotating progress messages.
-
-## Arbitrary MCP Servers
-
-Lobu supports any MCP server — Owletto's built-ins, community-published servers, or your own. MCP servers are declared in `lobu.toml` under `[agents.<id>.skills.mcp.<name>]`:
-
-```toml
-[agents.support.skills.mcp.gmail]
-url = "https://gmail-mcp.example.com"
-
-[agents.support.skills.mcp.gmail.oauth]
-auth_url = "https://auth.example.com/authorize"
-token_url = "https://auth.example.com/token"
-client_id = "$OAUTH_CLIENT_ID"
-client_secret = "$OAUTH_CLIENT_SECRET"
-scopes = ["gmail.readonly", "gmail.send"]
-```
-
-Workers discover tools at startup and call them through the gateway MCP proxy. The proxy handles credential injection, SSRF protection, and approval policy. Workers never see OAuth tokens directly.
 
 ## Destructive Tool Approval
 

--- a/packages/landing/src/content/docs/platforms/teams.mdx
+++ b/packages/landing/src/content/docs/platforms/teams.mdx
@@ -9,16 +9,14 @@ import { PlatformConfigTable } from "../../../components/PlatformConfigTable";
 Lobu's Microsoft Teams adapter supports direct chats, channel mentions, and interactive workflows.
 Under the hood, Lobu uses the Chat SDK Teams adapter with Azure Bot Framework.
 
+<PlatformChatExamples platform="teams" client:visible />
+
 ## Setup
 
 1. Register a bot in the [Azure Portal](https://portal.azure.com) under **Azure Bot** (or **Bot Framework Registration**).
 2. Note the **App ID**, **App Password** (client secret), and **Tenant ID**.
 3. In the Azure Bot's **Channels** section, enable the **Microsoft Teams** channel.
 4. Run `lobu connections add teams` to add the connection (prompts for the app ID and app password), or run `lobu init` to scaffold a new project and pick Microsoft Teams in the wizard.
-
-## Interactive Examples
-
-<PlatformChatExamples platform="teams" />
 
 ## Configuration
 

--- a/packages/landing/src/content/docs/platforms/telegram.mdx
+++ b/packages/landing/src/content/docs/platforms/telegram.mdx
@@ -9,15 +9,13 @@ import { PlatformConfigTable } from "../../../components/PlatformConfigTable";
 Lobu's Telegram adapter supports direct chats, group interactions, and interactive workflows.
 Under the hood, Lobu uses the Telegram Bot API via `@chat-adapter/telegram`.
 
+<PlatformChatExamples platform="telegram" client:visible />
+
 ## Setup
 
 1. Create a bot with [@BotFather](https://t.me/BotFather) on Telegram and copy the bot token.
 2. Run `lobu connections add telegram` to add the connection (prompts for the bot token), or run `lobu init` to scaffold a new project and pick Telegram in the wizard.
 3. Start the stack with `lobu run -d` — the bot starts receiving messages immediately.
-
-## Interactive Examples
-
-<PlatformChatExamples platform="telegram" />
 
 ## Configuration
 

--- a/packages/landing/src/content/docs/platforms/whatsapp.mdx
+++ b/packages/landing/src/content/docs/platforms/whatsapp.mdx
@@ -9,16 +9,14 @@ import { PlatformConfigTable } from "../../../components/PlatformConfigTable";
 Lobu's WhatsApp adapter supports direct chats, group controls, and media-aware workflows.
 Under the hood, Lobu uses the WhatsApp Business Cloud API for message delivery and media handling.
 
+<PlatformChatExamples platform="whatsapp" client:visible />
+
 ## Setup
 
 1. Obtain a WhatsApp Business **access token**, **phone number ID**, **app secret**, and **verify token** from the [Meta Developer Portal](https://developers.facebook.com/).
 2. Run `lobu connections add whatsapp` to add the connection (prompts for the access token and phone number ID), or run `lobu init` to scaffold a new project and pick WhatsApp in the wizard.
 3. Configure the webhook URL in the Meta Developer Portal to point to your gateway's webhook endpoint.
 4. Start the stack with `lobu run -d` — the bot starts handling messages on the configured phone number.
-
-## Interactive Examples
-
-<PlatformChatExamples platform="whatsapp" />
 
 ## Configuration
 

--- a/packages/landing/src/use-case-showcases.ts
+++ b/packages/landing/src/use-case-showcases.ts
@@ -1,3 +1,4 @@
+import type { UseCase } from "./types";
 import {
   landingUseCases,
   technicalLinks,
@@ -62,6 +63,12 @@ export type ShowcaseMemoryExample = MemoryExample & {
   examplePath: string;
 };
 
+export type LandingUseCaseChatScenarios = {
+  permission: UseCase;
+  skill: UseCase;
+  settings: UseCase;
+};
+
 export type LandingUseCaseShowcase = {
   id: LandingUseCaseId;
   label: string;
@@ -70,6 +77,7 @@ export type LandingUseCaseShowcase = {
   runtime: RuntimeJourney;
   skills: ShowcaseSkillWorkspacePreview;
   memory: ShowcaseMemoryExample;
+  chatScenarios?: LandingUseCaseChatScenarios;
 };
 
 const docsLinks = {
@@ -1705,7 +1713,7 @@ function toCampaignMeta(
   runtime: RuntimeJourneyInput
 ): CampaignMeta {
   return {
-    title: `Deploy secure ${useCase.label.toLowerCase()} agents in your infrastructure`,
+    title: `Deploy secure ${useCase.label.toLowerCase()} agents on your infrastructure`,
     description: runtime.summary,
     seoTitle: `${useCase.label} AI agents on your infrastructure - Lobu`,
     seoDescription: runtime.summary,
@@ -1713,6 +1721,900 @@ function toCampaignMeta(
     ctaLabel: `Open ${useCase.label} page`,
   };
 }
+
+const chatScenarioContent: Partial<
+  Record<LandingUseCaseId, LandingUseCaseChatScenarios>
+> = {
+  devops: {
+    permission: {
+      id: "devops-permission",
+      tabLabel: "Permission",
+      title: "Pull live incident state",
+      description: "Agent asks to reach PagerDuty before querying incidents.",
+      settingsLabel: "Domains and tool permissions",
+      chatLabel: "Allow api.pagerduty.com",
+      botName: "DevOps",
+      botInitial: "D",
+      botColor: "#f97316",
+      messages: [
+        { role: "user", text: "What's on fire right now?" },
+        {
+          role: "bot",
+          text: "Can't reach api.pagerduty.com — not in the agent's allowed domains.\n\nGrant access?",
+          buttons: [{ label: "Allow api.pagerduty.com", action: "link" }],
+        },
+        { role: "user", text: "Allow for 1 hour" },
+        {
+          role: "bot",
+          text: "2 open incidents:\n• INC-4821 P1 checkout-api 5xx (12m)\n• INC-4820 P2 redis-cache latency (28m)\n\nBoth started after deploy #3491.",
+        },
+      ],
+    },
+    skill: {
+      id: "devops-skill",
+      tabLabel: "Skill",
+      title: "Install the devops skill",
+      description: "Bundles PagerDuty, GitHub, and k8s tools with safe rollback.",
+      settingsLabel: "Skills and integrations",
+      chatLabel: "Agent installs devops skill",
+      botName: "DevOps",
+      botInitial: "D",
+      botColor: "#f97316",
+      messages: [
+        { role: "user", text: "Roll back the checkout service" },
+        {
+          role: "bot",
+          text: "I need the `devops` skill to run rollbacks.\n\nBundles PagerDuty, GitHub, and k8s with an approval step before any write.",
+          buttons: [{ label: "Install devops", action: "link" }],
+        },
+        { role: "user", text: "Go ahead" },
+        {
+          role: "bot",
+          text: "Installed. Ready to roll checkout-api back to deploy #3490. Confirm?",
+          buttons: [{ label: "Approve rollback", action: "link" }],
+        },
+      ],
+    },
+    settings: {
+      id: "devops-settings",
+      tabLabel: "Settings",
+      title: "Set on-call routing",
+      description: "Point non-critical pages away from chat during off-hours.",
+      settingsLabel: "Schedules, models, and routing",
+      chatLabel: "Agent opens settings page",
+      botName: "DevOps",
+      botInitial: "D",
+      botColor: "#f97316",
+      messages: [
+        { role: "user", text: "Mute P3 pings overnight" },
+        {
+          role: "bot",
+          text: "Open settings to set quiet hours per severity — current on-call schedule is shown there.",
+          buttons: [{ label: "Open Settings", action: "settings" }],
+        },
+        { role: "user", text: "Set 22:00–07:00 PT for P3" },
+        {
+          role: "bot",
+          text: "Quiet hours saved. P3 stays in the incident log; only P1/P2 page during that window.",
+        },
+      ],
+    },
+  },
+  support: {
+    permission: {
+      id: "support-permission",
+      tabLabel: "Permission",
+      title: "Read ticket history",
+      description: "Agent asks to reach Zendesk before pulling account context.",
+      settingsLabel: "Domains and tool permissions",
+      chatLabel: "Allow yourco.zendesk.com",
+      botName: "Support",
+      botInitial: "S",
+      botColor: "#8b5cf6",
+      messages: [
+        { role: "user", text: "Draft a reply for Alex Kim at Redwood" },
+        {
+          role: "bot",
+          text: "Can't reach yourco.zendesk.com — not in the agent's allowed domains.\n\nGrant access?",
+          buttons: [{ label: "Allow yourco.zendesk.com", action: "link" }],
+        },
+        { role: "user", text: "Allow" },
+        {
+          role: "bot",
+          text: "Alex last wrote Tuesday — open ticket #7732 on webhook retries. Draft ready, flagged for your review before I send.",
+        },
+      ],
+    },
+    skill: {
+      id: "support-skill",
+      tabLabel: "Skill",
+      title: "Install the support skill",
+      description: "Ticketing, knowledge base, and escalation in one bundle.",
+      settingsLabel: "Skills and integrations",
+      chatLabel: "Agent installs support skill",
+      botName: "Support",
+      botInitial: "S",
+      botColor: "#8b5cf6",
+      messages: [
+        { role: "user", text: "Who owns enterprise escalations this week?" },
+        {
+          role: "bot",
+          text: "I need the `support` skill — it bundles Zendesk, the KB, and your rotation config.",
+          buttons: [{ label: "Install support", action: "link" }],
+        },
+        { role: "user", text: "Install it" },
+        {
+          role: "bot",
+          text: "Enterprise escalations this week: Priya (primary), Marcus (backup).\nP0 SLA: 15 min response.",
+        },
+      ],
+    },
+    settings: {
+      id: "support-settings",
+      tabLabel: "Settings",
+      title: "Pick a canned-response voice",
+      description: "Switch tone presets without editing the system prompt in chat.",
+      settingsLabel: "Voice, tone, and templates",
+      chatLabel: "Agent opens settings page",
+      botName: "Support",
+      botInitial: "S",
+      botColor: "#8b5cf6",
+      messages: [
+        { role: "user", text: "Use a warmer tone for replies" },
+        {
+          role: "bot",
+          text: "Tone presets live in settings — current is `neutral`.",
+          buttons: [{ label: "Open Settings", action: "settings" }],
+        },
+        { role: "user", text: "Switched to `friendly`" },
+        {
+          role: "bot",
+          text: "Using the friendly preset for new drafts. Existing replies in flight keep their tone.",
+        },
+      ],
+    },
+  },
+  legal: {
+    permission: {
+      id: "legal-permission",
+      tabLabel: "Permission",
+      title: "Fetch a counterparty's draft",
+      description: "Agent asks to reach the counterparty's contract portal.",
+      settingsLabel: "Domains and tool permissions",
+      chatLabel: "Allow contracts.redwood.com",
+      botName: "Legal",
+      botInitial: "L",
+      botColor: "#0ea5e9",
+      messages: [
+        { role: "user", text: "Review Redwood's latest NDA draft" },
+        {
+          role: "bot",
+          text: "Can't reach contracts.redwood.com — not in the agent's allowed domains.\n\nGrant access?",
+          buttons: [{ label: "Allow contracts.redwood.com", action: "link" }],
+        },
+        { role: "user", text: "Allow for this session" },
+        {
+          role: "bot",
+          text: "Pulled v4. Two clauses changed since v3:\n• §7 indemnity — narrowed cap, OK\n• §12 IP — new carve-out, needs counsel review",
+        },
+      ],
+    },
+    skill: {
+      id: "legal-skill",
+      tabLabel: "Skill",
+      title: "Install the legal skill",
+      description: "Redline tools, clause library, and counsel approvals in one bundle.",
+      settingsLabel: "Skills and integrations",
+      chatLabel: "Agent installs legal skill",
+      botName: "Legal",
+      botInitial: "L",
+      botColor: "#0ea5e9",
+      messages: [
+        { role: "user", text: "Redline this MSA against our standard" },
+        {
+          role: "bot",
+          text: "I need the `legal` skill — it bundles the redline engine, clause library, and counsel approval flow.",
+          buttons: [{ label: "Install legal", action: "link" }],
+        },
+        { role: "user", text: "Install" },
+        {
+          role: "bot",
+          text: "6 redlines drafted, 2 flagged for counsel (§12 IP, §18 liability). Nothing sent until you approve.",
+        },
+      ],
+    },
+    settings: {
+      id: "legal-settings",
+      tabLabel: "Settings",
+      title: "Pick a counsel-approved model",
+      description: "Legal review needs a model counsel has signed off on.",
+      settingsLabel: "Model and redaction policy",
+      chatLabel: "Agent opens settings page",
+      botName: "Legal",
+      botInitial: "L",
+      botColor: "#0ea5e9",
+      messages: [
+        { role: "user", text: "Use a model our counsel approved" },
+        {
+          role: "bot",
+          text: "Model picker is in settings — current list is scoped to counsel-approved options.",
+          buttons: [{ label: "Open Settings", action: "settings" }],
+        },
+        { role: "user", text: "Switched to claude-sonnet-4-6 via Bedrock" },
+        {
+          role: "bot",
+          text: "Running on claude-sonnet-4-6 (Bedrock, EU region). Redaction policy unchanged.",
+        },
+      ],
+    },
+  },
+  sales: {
+    permission: {
+      id: "sales-permission",
+      tabLabel: "Permission",
+      title: "Pull account context",
+      description: "Agent asks to reach Salesforce before prepping the call.",
+      settingsLabel: "Domains and tool permissions",
+      chatLabel: "Allow yourco.my.salesforce.com",
+      botName: "Sales",
+      botInitial: "S",
+      botColor: "#10b981",
+      messages: [
+        { role: "user", text: "Prep me for the Redwood renewal call" },
+        {
+          role: "bot",
+          text: "Can't reach yourco.my.salesforce.com — not in the agent's allowed domains.\n\nGrant access?",
+          buttons: [{ label: "Allow Salesforce", action: "link" }],
+        },
+        { role: "user", text: "Allow" },
+        {
+          role: "bot",
+          text: "Redwood, Enterprise, ARR $180k, renewal in 12 days.\n• 2 open tickets (both resolved this week)\n• Exec sponsor changed — new CFO: Priya R.\n• Last usage dip: -8% in March",
+        },
+      ],
+    },
+    skill: {
+      id: "sales-skill",
+      tabLabel: "Skill",
+      title: "Install the sales skill",
+      description: "CRM, usage telemetry, and proposal templates bundled together.",
+      settingsLabel: "Skills and integrations",
+      chatLabel: "Agent installs sales skill",
+      botName: "Sales",
+      botInitial: "S",
+      botColor: "#10b981",
+      messages: [
+        { role: "user", text: "Which pilots are at risk?" },
+        {
+          role: "bot",
+          text: "I need the `sales` skill — it bundles Salesforce, usage telemetry, and proposal tooling.",
+          buttons: [{ label: "Install sales", action: "link" }],
+        },
+        { role: "user", text: "Go" },
+        {
+          role: "bot",
+          text: "3 pilots at risk:\n• Acme — no exec sponsor named\n• Northwind — usage -40% MoM\n• Globex — procurement stalled 2wk",
+        },
+      ],
+    },
+    settings: {
+      id: "sales-settings",
+      tabLabel: "Settings",
+      title: "Sync reporting cadence",
+      description: "Weekly deal review digests and who receives them.",
+      settingsLabel: "Digests, schedules, and recipients",
+      chatLabel: "Agent opens settings page",
+      botName: "Sales",
+      botInitial: "S",
+      botColor: "#10b981",
+      messages: [
+        { role: "user", text: "Send me the weekly pipeline digest" },
+        {
+          role: "bot",
+          text: "Digest schedule is in settings — you can add recipients and pick the day.",
+          buttons: [{ label: "Open Settings", action: "settings" }],
+        },
+        { role: "user", text: "Friday 8am, add Priya" },
+        {
+          role: "bot",
+          text: "Digest scheduled Fridays 08:00 PT, sent to you + Priya. First run ships this week.",
+        },
+      ],
+    },
+  },
+  leadership: {
+    permission: {
+      id: "leadership-permission",
+      tabLabel: "Permission",
+      title: "Read this week's updates",
+      description: "Agent asks to reach Notion before summarizing team updates.",
+      settingsLabel: "Domains and tool permissions",
+      chatLabel: "Allow yourco.notion.site",
+      botName: "Chief of Staff",
+      botInitial: "C",
+      botColor: "#ec4899",
+      messages: [
+        { role: "user", text: "What shipped this week across the org?" },
+        {
+          role: "bot",
+          text: "Can't reach yourco.notion.site — not in the agent's allowed domains.\n\nGrant access?",
+          buttons: [{ label: "Allow Notion", action: "link" }],
+        },
+        { role: "user", text: "Allow" },
+        {
+          role: "bot",
+          text: "This week:\n• Platform — shipped multi-region failover\n• Growth — launched partner portal beta\n• Ops — closed 3 P1 incidents, MTTR down 22%",
+        },
+      ],
+    },
+    skill: {
+      id: "leadership-skill",
+      tabLabel: "Skill",
+      title: "Install the leadership skill",
+      description: "Docs, decisions, and team updates connected together.",
+      settingsLabel: "Skills and integrations",
+      chatLabel: "Agent installs leadership skill",
+      botName: "Chief of Staff",
+      botInitial: "C",
+      botColor: "#ec4899",
+      messages: [
+        { role: "user", text: "What decisions are still open from Q1 planning?" },
+        {
+          role: "bot",
+          text: "I need the `leadership` skill — it bundles Notion, Google Docs, and the decision log.",
+          buttons: [{ label: "Install leadership", action: "link" }],
+        },
+        { role: "user", text: "Install" },
+        {
+          role: "bot",
+          text: "4 open Q1 decisions:\n• Hiring plan for Growth (owner: Dara)\n• EU region GTM (owner: Priya)\n• Pricing revamp (blocked on finance)\n• Analytics rebuild (in discovery)",
+        },
+      ],
+    },
+    settings: {
+      id: "leadership-settings",
+      tabLabel: "Settings",
+      title: "Configure the weekly brief",
+      description: "Pick which signals flow into the Monday morning brief.",
+      settingsLabel: "Briefing topics and cadence",
+      chatLabel: "Agent opens settings page",
+      botName: "Chief of Staff",
+      botInitial: "C",
+      botColor: "#ec4899",
+      messages: [
+        { role: "user", text: "Add revenue to my Monday brief" },
+        {
+          role: "bot",
+          text: "Briefing topics live in settings — current topics: product, ops, hiring.",
+          buttons: [{ label: "Open Settings", action: "settings" }],
+        },
+        { role: "user", text: "Added revenue and churn" },
+        {
+          role: "bot",
+          text: "Monday brief now includes revenue and churn alongside the existing topics. First run Monday 07:00 PT.",
+        },
+      ],
+    },
+  },
+  finance: {
+    permission: {
+      id: "finance-permission",
+      tabLabel: "Permission",
+      title: "Read ledger data",
+      description: "Agent asks to reach NetSuite before running a reconciliation.",
+      settingsLabel: "Domains and tool permissions",
+      chatLabel: "Allow yourco.netsuite.com",
+      botName: "Finance",
+      botInitial: "F",
+      botColor: "#0ea5e9",
+      messages: [
+        { role: "user", text: "Reconcile March Stripe payouts to the GL" },
+        {
+          role: "bot",
+          text: "Can't reach yourco.netsuite.com — not in the agent's allowed domains.\n\nGrant access?",
+          buttons: [{ label: "Allow NetSuite", action: "link" }],
+        },
+        { role: "user", text: "Allow" },
+        {
+          role: "bot",
+          text: "$412,308 in Stripe payouts vs $411,922 in GL. 3 variances:\n• $180 refund booked next-month\n• $206 FX delta on EUR charges\n• Remaining balances tie.",
+        },
+      ],
+    },
+    skill: {
+      id: "finance-skill",
+      tabLabel: "Skill",
+      title: "Install the finance skill",
+      description: "ERP, payment systems, and close-process tooling bundled together.",
+      settingsLabel: "Skills and integrations",
+      chatLabel: "Agent installs finance skill",
+      botName: "Finance",
+      botInitial: "F",
+      botColor: "#0ea5e9",
+      messages: [
+        { role: "user", text: "Flag exceptions over $5k in this week's AP run" },
+        {
+          role: "bot",
+          text: "I need the `finance` skill — it bundles NetSuite, Stripe, and the close playbook.",
+          buttons: [{ label: "Install finance", action: "link" }],
+        },
+        { role: "user", text: "Install" },
+        {
+          role: "bot",
+          text: "7 AP exceptions over $5k flagged — 2 missing POs, 1 duplicate invoice, 4 awaiting approval. Summary queued for review.",
+        },
+      ],
+    },
+    settings: {
+      id: "finance-settings",
+      tabLabel: "Settings",
+      title: "Set approval thresholds",
+      description: "Which transaction sizes require human sign-off before posting.",
+      settingsLabel: "Approval thresholds and policy",
+      chatLabel: "Agent opens settings page",
+      botName: "Finance",
+      botInitial: "F",
+      botColor: "#0ea5e9",
+      messages: [
+        { role: "user", text: "Require approval for anything over $25k" },
+        {
+          role: "bot",
+          text: "Approval thresholds live in settings — current ceiling is $10k.",
+          buttons: [{ label: "Open Settings", action: "settings" }],
+        },
+        { role: "user", text: "Set to $25k" },
+        {
+          role: "bot",
+          text: "New ceiling: $25k. Transactions above that route to you before posting. Existing approvals unchanged.",
+        },
+      ],
+    },
+  },
+  delivery: {
+    permission: {
+      id: "delivery-permission",
+      tabLabel: "Permission",
+      title: "Pull project status",
+      description: "Agent asks to reach Jira before assembling a rollout report.",
+      settingsLabel: "Domains and tool permissions",
+      chatLabel: "Allow yourco.atlassian.net",
+      botName: "Delivery",
+      botInitial: "D",
+      botColor: "#14b8a6",
+      messages: [
+        { role: "user", text: "Status on the Q2 onboarding rollout?" },
+        {
+          role: "bot",
+          text: "Can't reach yourco.atlassian.net — not in the agent's allowed domains.\n\nGrant access?",
+          buttons: [{ label: "Allow Atlassian", action: "link" }],
+        },
+        { role: "user", text: "Allow" },
+        {
+          role: "bot",
+          text: "Q2 onboarding: 58% complete, 2d slip vs plan.\n• Blocked: ONB-318 (design review)\n• At risk: ONB-322 (dep on legal)\n• Next milestone: pilot kickoff May 6.",
+        },
+      ],
+    },
+    skill: {
+      id: "delivery-skill",
+      tabLabel: "Skill",
+      title: "Install the delivery skill",
+      description: "Jira, rollout checklists, and status reporting in one bundle.",
+      settingsLabel: "Skills and integrations",
+      chatLabel: "Agent installs delivery skill",
+      botName: "Delivery",
+      botInitial: "D",
+      botColor: "#14b8a6",
+      messages: [
+        { role: "user", text: "Who owns each open blocker this week?" },
+        {
+          role: "bot",
+          text: "I need the `delivery` skill — it bundles Jira, ownership data, and status templates.",
+          buttons: [{ label: "Install delivery", action: "link" }],
+        },
+        { role: "user", text: "Install" },
+        {
+          role: "bot",
+          text: "5 open blockers:\n• ONB-318 → Dara (design)\n• API-94 → Luis (backend)\n• SEC-22 → Priya (sec review)\n• ONB-322 → Legal\n• DATA-61 → Unassigned",
+        },
+      ],
+    },
+    settings: {
+      id: "delivery-settings",
+      tabLabel: "Settings",
+      title: "Configure status digests",
+      description: "Who gets the weekly rollout digest, and when.",
+      settingsLabel: "Digests, schedules, and recipients",
+      chatLabel: "Agent opens settings page",
+      botName: "Delivery",
+      botInitial: "D",
+      botColor: "#14b8a6",
+      messages: [
+        { role: "user", text: "Send stakeholders a rollout digest every Thursday" },
+        {
+          role: "bot",
+          text: "Digest cadence lives in settings — current: none.",
+          buttons: [{ label: "Open Settings", action: "settings" }],
+        },
+        { role: "user", text: "Added stakeholders, Thursdays 09:00" },
+        {
+          role: "bot",
+          text: "Scheduled Thursdays 09:00 PT to the stakeholder list. First run ships this week with current blockers and risks.",
+        },
+      ],
+    },
+  },
+  "agent-community": {
+    permission: {
+      id: "community-permission",
+      tabLabel: "Permission",
+      title: "Read member directory",
+      description: "Agent asks to reach the community platform before matching members.",
+      settingsLabel: "Domains and tool permissions",
+      chatLabel: "Allow yourco.circle.so",
+      botName: "Community",
+      botInitial: "C",
+      botColor: "#8b5cf6",
+      messages: [
+        { role: "user", text: "Find 5 members working on RAG eval tooling" },
+        {
+          role: "bot",
+          text: "Can't reach yourco.circle.so — not in the agent's allowed domains.\n\nGrant access?",
+          buttons: [{ label: "Allow Circle", action: "link" }],
+        },
+        { role: "user", text: "Allow" },
+        {
+          role: "bot",
+          text: "5 member matches:\n• Maya R. — shipped eval harness in #ml-infra\n• Dev K. — posted benchmark last week\n• Lin C. — asking for RAG ground truth\n• Priya N. — hiring for eval work\n• Sam T. — wrote the eval FAQ.",
+        },
+      ],
+    },
+    skill: {
+      id: "community-skill",
+      tabLabel: "Skill",
+      title: "Install the community skill",
+      description: "Member directory, interest graph, and intro workflows bundled together.",
+      settingsLabel: "Skills and integrations",
+      chatLabel: "Agent installs community skill",
+      botName: "Community",
+      botInitial: "C",
+      botColor: "#8b5cf6",
+      messages: [
+        { role: "user", text: "Who's active in #ai-safety this month?" },
+        {
+          role: "bot",
+          text: "I need the `community` skill — it bundles the member directory, interest graph, and intro playbooks.",
+          buttons: [{ label: "Install community", action: "link" }],
+        },
+        { role: "user", text: "Install" },
+        {
+          role: "bot",
+          text: "Top 8 active: Priya, Dev, Maya, Lin, Sam, Alex, Rui, Chen. 3 new members joined this week — suggest intros?",
+        },
+      ],
+    },
+    settings: {
+      id: "community-settings",
+      tabLabel: "Settings",
+      title: "Tune matching signals",
+      description: "Which activity signals weigh most when recommending member matches.",
+      settingsLabel: "Matching weights and recency",
+      chatLabel: "Agent opens settings page",
+      botName: "Community",
+      botInitial: "C",
+      botColor: "#8b5cf6",
+      messages: [
+        { role: "user", text: "Weight recent posts higher than bio tags" },
+        {
+          role: "bot",
+          text: "Matching weights live in settings — current: equal weight, 90-day window.",
+          buttons: [{ label: "Open Settings", action: "settings" }],
+        },
+        { role: "user", text: "Posts 2x bio, 30-day window" },
+        {
+          role: "bot",
+          text: "Updated. New matches favor active posters in the last 30 days. Next request will use the new weights.",
+        },
+      ],
+    },
+  },
+  "market-intelligence": {
+    permission: {
+      id: "market-permission",
+      tabLabel: "Permission",
+      title: "Fetch competitor signals",
+      description: "Agent asks to reach Crunchbase before pulling funding data.",
+      settingsLabel: "Domains and tool permissions",
+      chatLabel: "Allow crunchbase.com",
+      botName: "Market Intel",
+      botInitial: "M",
+      botColor: "#eab308",
+      messages: [
+        { role: "user", text: "Did Acme's competitor raise recently?" },
+        {
+          role: "bot",
+          text: "Can't reach crunchbase.com — not in the agent's allowed domains.\n\nGrant access?",
+          buttons: [{ label: "Allow Crunchbase", action: "link" }],
+        },
+        { role: "user", text: "Allow" },
+        {
+          role: "bot",
+          text: "Yes — Northwind raised $48M Series B two weeks ago (led by Sequoia).\nHead count jumped from 42 → 61 on LinkedIn.\nNew product page: launched April 8.",
+        },
+      ],
+    },
+    skill: {
+      id: "market-skill",
+      tabLabel: "Skill",
+      title: "Install the market intel skill",
+      description: "Crunchbase, Product Hunt, review sites, and news feeds in one bundle.",
+      settingsLabel: "Skills and integrations",
+      chatLabel: "Agent installs market intel skill",
+      botName: "Market Intel",
+      botInitial: "M",
+      botColor: "#eab308",
+      messages: [
+        { role: "user", text: "What launched in our category this week?" },
+        {
+          role: "bot",
+          text: "I need the `market-intel` skill — it bundles Product Hunt, Crunchbase, and review aggregators.",
+          buttons: [{ label: "Install market-intel", action: "link" }],
+        },
+        { role: "user", text: "Install" },
+        {
+          role: "bot",
+          text: "6 launches this week:\n• Northwind Cloud — #2 on PH\n• 2 niche OSS entrants\n• 3 feature expansions by incumbents.\nSummary and links queued.",
+        },
+      ],
+    },
+    settings: {
+      id: "market-settings",
+      tabLabel: "Settings",
+      title: "Pick tracked competitors",
+      description: "The watchlist that drives daily signals and digests.",
+      settingsLabel: "Competitor watchlist",
+      chatLabel: "Agent opens settings page",
+      botName: "Market Intel",
+      botInitial: "M",
+      botColor: "#eab308",
+      messages: [
+        { role: "user", text: "Add Northwind to the tracked list" },
+        {
+          role: "bot",
+          text: "Watchlist lives in settings — current: 6 companies.",
+          buttons: [{ label: "Open Settings", action: "settings" }],
+        },
+        { role: "user", text: "Added Northwind" },
+        {
+          role: "bot",
+          text: "Now tracking Northwind across funding, launches, and hiring. First daily signal email includes them tomorrow.",
+        },
+      ],
+    },
+  },
+  careops: {
+    permission: {
+      id: "careops-permission",
+      tabLabel: "Permission",
+      title: "Read the care platform",
+      description: "Agent asks to reach the care platform before reviewing a patient.",
+      settingsLabel: "Domains and tool permissions",
+      chatLabel: "Allow yourco.healthie.com",
+      botName: "CareOps",
+      botInitial: "C",
+      botColor: "#ec4899",
+      messages: [
+        { role: "user", text: "Prep a follow-up plan for Jordan Lee" },
+        {
+          role: "bot",
+          text: "Can't reach yourco.healthie.com — not in the agent's allowed domains.\n\nGrant access?",
+          buttons: [{ label: "Allow Healthie", action: "link" }],
+        },
+        { role: "user", text: "Allow" },
+        {
+          role: "bot",
+          text: "Jordan Lee — intake 3 weeks ago, last visit Tuesday.\n• Outstanding: lab results review\n• Next scheduled: May 2\n• Draft follow-up plan queued for your review.",
+        },
+      ],
+    },
+    skill: {
+      id: "careops-skill",
+      tabLabel: "Skill",
+      title: "Install the careops skill",
+      description: "Care platform, scheduling, and follow-up playbooks bundled together.",
+      settingsLabel: "Skills and integrations",
+      chatLabel: "Agent installs careops skill",
+      botName: "CareOps",
+      botInitial: "C",
+      botColor: "#ec4899",
+      messages: [
+        { role: "user", text: "Which patients are overdue for a check-in?" },
+        {
+          role: "bot",
+          text: "I need the `careops` skill — it bundles Healthie, scheduling, and the follow-up playbook.",
+          buttons: [{ label: "Install careops", action: "link" }],
+        },
+        { role: "user", text: "Install" },
+        {
+          role: "bot",
+          text: "12 overdue check-ins, 4 over 60 days. Top priorities: Jordan L., Sam C., Priya R., Devon K. Suggested outreach drafts ready for review.",
+        },
+      ],
+    },
+    settings: {
+      id: "careops-settings",
+      tabLabel: "Settings",
+      title: "Configure reminder cadence",
+      description: "When and how to remind patients about overdue follow-ups.",
+      settingsLabel: "Reminder cadence and channels",
+      chatLabel: "Agent opens settings page",
+      botName: "CareOps",
+      botInitial: "C",
+      botColor: "#ec4899",
+      messages: [
+        { role: "user", text: "Remind overdue patients weekly by SMS" },
+        {
+          role: "bot",
+          text: "Reminder cadence lives in settings — current: none automated.",
+          buttons: [{ label: "Open Settings", action: "settings" }],
+        },
+        { role: "user", text: "Weekly SMS after 7 days overdue" },
+        {
+          role: "bot",
+          text: "Set. SMS sends weekly for check-ins overdue by 7+ days. First batch queued for Monday AM; you'll get a pre-send summary.",
+        },
+      ],
+    },
+  },
+  ecommerce: {
+    permission: {
+      id: "ecommerce-permission",
+      tabLabel: "Permission",
+      title: "Pull order data",
+      description: "Agent asks to reach Shopify before investigating an order.",
+      settingsLabel: "Domains and tool permissions",
+      chatLabel: "Allow yourco.myshopify.com",
+      botName: "Store",
+      botInitial: "S",
+      botColor: "#22c55e",
+      messages: [
+        { role: "user", text: "Where's order #10482?" },
+        {
+          role: "bot",
+          text: "Can't reach yourco.myshopify.com — not in the agent's allowed domains.\n\nGrant access?",
+          buttons: [{ label: "Allow Shopify", action: "link" }],
+        },
+        { role: "user", text: "Allow" },
+        {
+          role: "bot",
+          text: "Order #10482 shipped Apr 12, delivered Apr 15. Customer opened a \"where is it\" ticket today — tracking shows delivered to mailroom. Drafted reply with photo proof.",
+        },
+      ],
+    },
+    skill: {
+      id: "ecommerce-skill",
+      tabLabel: "Skill",
+      title: "Install the store skill",
+      description: "Shopify, fulfillment, and CX playbooks in one bundle.",
+      settingsLabel: "Skills and integrations",
+      chatLabel: "Agent installs store skill",
+      botName: "Store",
+      botInitial: "S",
+      botColor: "#22c55e",
+      messages: [
+        { role: "user", text: "Which SKUs are low in stock?" },
+        {
+          role: "bot",
+          text: "I need the `ecommerce` skill — it bundles Shopify, inventory, and reorder logic.",
+          buttons: [{ label: "Install ecommerce", action: "link" }],
+        },
+        { role: "user", text: "Install" },
+        {
+          role: "bot",
+          text: "7 SKUs below reorder point:\n• SKU-1204 (2 left)\n• SKU-1187 (4 left)\n• 5 more flagged.\nDraft PO queued; awaiting your approval before sending to supplier.",
+        },
+      ],
+    },
+    settings: {
+      id: "ecommerce-settings",
+      tabLabel: "Settings",
+      title: "Set refund approval limits",
+      description: "Maximum auto-refund the agent can issue without human review.",
+      settingsLabel: "Refund limits and policy",
+      chatLabel: "Agent opens settings page",
+      botName: "Store",
+      botInitial: "S",
+      botColor: "#22c55e",
+      messages: [
+        { role: "user", text: "Let the agent auto-refund up to $50" },
+        {
+          role: "bot",
+          text: "Refund cap lives in settings — current: $0 (all refunds require approval).",
+          buttons: [{ label: "Open Settings", action: "settings" }],
+        },
+        { role: "user", text: "Set to $50" },
+        {
+          role: "bot",
+          text: "Auto-refund cap set to $50. Anything above still routes to you. Last 7 days: 12 refunds would have qualified for auto.",
+        },
+      ],
+    },
+  },
+  "venture-capital": {
+    permission: {
+      id: "vc-permission",
+      tabLabel: "Permission",
+      title: "Pull deal flow data",
+      description: "Agent asks to reach Affinity before summarizing the pipeline.",
+      settingsLabel: "Domains and tool permissions",
+      chatLabel: "Allow affinity.co",
+      botName: "Deal Flow",
+      botInitial: "D",
+      botColor: "#f43f5e",
+      messages: [
+        { role: "user", text: "What's in the pipeline this week?" },
+        {
+          role: "bot",
+          text: "Can't reach affinity.co — not in the agent's allowed domains.\n\nGrant access?",
+          buttons: [{ label: "Allow Affinity", action: "link" }],
+        },
+        { role: "user", text: "Allow" },
+        {
+          role: "bot",
+          text: "12 deals moved stages this week:\n• 4 new intros (2 warm, 2 cold)\n• 3 into diligence\n• 2 term sheet drafts\n• 3 passed with rationale logged.",
+        },
+      ],
+    },
+    skill: {
+      id: "vc-skill",
+      tabLabel: "Skill",
+      title: "Install the VC skill",
+      description: "Affinity, Crunchbase, and diligence checklists bundled together.",
+      settingsLabel: "Skills and integrations",
+      chatLabel: "Agent installs vc skill",
+      botName: "Deal Flow",
+      botInitial: "D",
+      botColor: "#f43f5e",
+      messages: [
+        { role: "user", text: "Find co-investors we've backed with in AI infra" },
+        {
+          role: "bot",
+          text: "I need the `vc` skill — it bundles Affinity, Crunchbase, and our portfolio graph.",
+          buttons: [{ label: "Install vc", action: "link" }],
+        },
+        { role: "user", text: "Install" },
+        {
+          role: "bot",
+          text: "6 repeat co-investors in AI infra since 2023: Accel, Benchmark, Sequoia, Index, Lux, USV. Strongest overlap with Accel (4 shared deals).",
+        },
+      ],
+    },
+    settings: {
+      id: "vc-settings",
+      tabLabel: "Settings",
+      title: "Choose an investment thesis",
+      description: "Pick which thesis the agent uses when scoring inbound deals.",
+      settingsLabel: "Thesis and scoring model",
+      chatLabel: "Agent opens settings page",
+      botName: "Deal Flow",
+      botInitial: "D",
+      botColor: "#f43f5e",
+      messages: [
+        { role: "user", text: "Score incoming deals against our 2026 thesis" },
+        {
+          role: "bot",
+          text: "Thesis selection lives in settings — current: 2025 thesis.",
+          buttons: [{ label: "Open Settings", action: "settings" }],
+        },
+        { role: "user", text: "Switched to 2026 AI infra thesis" },
+        {
+          role: "bot",
+          text: "Scoring now uses the 2026 AI infra thesis. Next 20 inbounds will be re-ranked; full list in the pipeline view.",
+        },
+      ],
+    },
+  },
+};
 
 export const landingUseCaseShowcases: LandingUseCaseShowcase[] = (
   Object.entries(landingUseCases) as Array<
@@ -1734,6 +2636,7 @@ export const landingUseCaseShowcases: LandingUseCaseShowcase[] = (
     runtime,
     skills: toSkillPreview(useCaseId, useCase),
     memory: toMemoryExample(useCaseId, useCase),
+    chatScenarios: chatScenarioContent[useCaseId],
   };
 });
 
@@ -1742,7 +2645,7 @@ export const DEFAULT_LANDING_USE_CASE_ID: LandingUseCaseId = "devops";
 const surfaceHeroCopy: Record<SurfaceId, SurfaceHeroCopyConfig> = {
   landing: {
     default: {
-      title: "Your AI team, running in your infrastructure",
+      title: "Your AI team, running on your infrastructure",
       highlight: "AI team",
       description:
         "Sandboxed persistent agents powered by the OpenClaw harness, long-term memory, and installable skills.",
@@ -1824,8 +2727,8 @@ const surfaceHeroCopy: Record<SurfaceId, SurfaceHeroCopyConfig> = {
   },
   skills: {
     default: {
-      title: "Build reliable agents with CLI-like skills",
-      highlight: "CLI-like skills",
+      title: "Build reliable agents with skills",
+      highlight: "skills",
       description:
         "A skill isn't a prompt template, it's a full sandboxed computer. All capabilities bundled into one installable unit.",
       startTitle: "Start a new agent in seconds",
@@ -1946,3 +2849,20 @@ export function getOwlettoScopedMcpUrl(useCaseId?: LandingUseCaseId) {
   const orgSlug = getOwlettoOrgSlug(useCaseId);
   return orgSlug ? `${OWLETTO_MCP_URL}/${orgSlug}` : OWLETTO_MCP_URL;
 }
+
+export function getOwlettoBaseUrl() {
+  return OWLETTO_URL;
+}
+
+export type LandingUseCaseWorkspaceOption = {
+  id: LandingUseCaseId;
+  label: string;
+  orgSlug?: string;
+};
+
+export const landingUseCaseWorkspaceOptions: LandingUseCaseWorkspaceOption[] =
+  landingUseCaseShowcases.map((useCase) => ({
+    id: useCase.id,
+    label: useCase.label,
+    orgSlug: getOwlettoOrgSlug(useCase.id),
+  }));

--- a/packages/landing/src/use-case-showcases.ts
+++ b/packages/landing/src/use-case-showcases.ts
@@ -1754,7 +1754,8 @@ const chatScenarioContent: Partial<
       id: "devops-skill",
       tabLabel: "Skill",
       title: "Install the devops skill",
-      description: "Bundles PagerDuty, GitHub, and k8s tools with safe rollback.",
+      description:
+        "Bundles PagerDuty, GitHub, and k8s tools with safe rollback.",
       settingsLabel: "Skills and integrations",
       chatLabel: "Agent installs devops skill",
       botName: "DevOps",
@@ -1805,7 +1806,8 @@ const chatScenarioContent: Partial<
       id: "support-permission",
       tabLabel: "Permission",
       title: "Read ticket history",
-      description: "Agent asks to reach Zendesk before pulling account context.",
+      description:
+        "Agent asks to reach Zendesk before pulling account context.",
       settingsLabel: "Domains and tool permissions",
       chatLabel: "Allow yourco.zendesk.com",
       botName: "Support",
@@ -1853,7 +1855,8 @@ const chatScenarioContent: Partial<
       id: "support-settings",
       tabLabel: "Settings",
       title: "Pick a canned-response voice",
-      description: "Switch tone presets without editing the system prompt in chat.",
+      description:
+        "Switch tone presets without editing the system prompt in chat.",
       settingsLabel: "Voice, tone, and templates",
       chatLabel: "Agent opens settings page",
       botName: "Support",
@@ -1903,7 +1906,8 @@ const chatScenarioContent: Partial<
       id: "legal-skill",
       tabLabel: "Skill",
       title: "Install the legal skill",
-      description: "Redline tools, clause library, and counsel approvals in one bundle.",
+      description:
+        "Redline tools, clause library, and counsel approvals in one bundle.",
       settingsLabel: "Skills and integrations",
       chatLabel: "Agent installs legal skill",
       botName: "Legal",
@@ -1977,7 +1981,8 @@ const chatScenarioContent: Partial<
       id: "sales-skill",
       tabLabel: "Skill",
       title: "Install the sales skill",
-      description: "CRM, usage telemetry, and proposal templates bundled together.",
+      description:
+        "CRM, usage telemetry, and proposal templates bundled together.",
       settingsLabel: "Skills and integrations",
       chatLabel: "Agent installs sales skill",
       botName: "Sales",
@@ -2027,7 +2032,8 @@ const chatScenarioContent: Partial<
       id: "leadership-permission",
       tabLabel: "Permission",
       title: "Read this week's updates",
-      description: "Agent asks to reach Notion before summarizing team updates.",
+      description:
+        "Agent asks to reach Notion before summarizing team updates.",
       settingsLabel: "Domains and tool permissions",
       chatLabel: "Allow yourco.notion.site",
       botName: "Chief of Staff",
@@ -2058,7 +2064,10 @@ const chatScenarioContent: Partial<
       botInitial: "C",
       botColor: "#ec4899",
       messages: [
-        { role: "user", text: "What decisions are still open from Q1 planning?" },
+        {
+          role: "user",
+          text: "What decisions are still open from Q1 planning?",
+        },
         {
           role: "bot",
           text: "I need the `leadership` skill — it bundles Notion, Google Docs, and the decision log.",
@@ -2101,7 +2110,8 @@ const chatScenarioContent: Partial<
       id: "finance-permission",
       tabLabel: "Permission",
       title: "Read ledger data",
-      description: "Agent asks to reach NetSuite before running a reconciliation.",
+      description:
+        "Agent asks to reach NetSuite before running a reconciliation.",
       settingsLabel: "Domains and tool permissions",
       chatLabel: "Allow yourco.netsuite.com",
       botName: "Finance",
@@ -2125,14 +2135,18 @@ const chatScenarioContent: Partial<
       id: "finance-skill",
       tabLabel: "Skill",
       title: "Install the finance skill",
-      description: "ERP, payment systems, and close-process tooling bundled together.",
+      description:
+        "ERP, payment systems, and close-process tooling bundled together.",
       settingsLabel: "Skills and integrations",
       chatLabel: "Agent installs finance skill",
       botName: "Finance",
       botInitial: "F",
       botColor: "#0ea5e9",
       messages: [
-        { role: "user", text: "Flag exceptions over $5k in this week's AP run" },
+        {
+          role: "user",
+          text: "Flag exceptions over $5k in this week's AP run",
+        },
         {
           role: "bot",
           text: "I need the `finance` skill — it bundles NetSuite, Stripe, and the close playbook.",
@@ -2149,7 +2163,8 @@ const chatScenarioContent: Partial<
       id: "finance-settings",
       tabLabel: "Settings",
       title: "Set approval thresholds",
-      description: "Which transaction sizes require human sign-off before posting.",
+      description:
+        "Which transaction sizes require human sign-off before posting.",
       settingsLabel: "Approval thresholds and policy",
       chatLabel: "Agent opens settings page",
       botName: "Finance",
@@ -2175,7 +2190,8 @@ const chatScenarioContent: Partial<
       id: "delivery-permission",
       tabLabel: "Permission",
       title: "Pull project status",
-      description: "Agent asks to reach Jira before assembling a rollout report.",
+      description:
+        "Agent asks to reach Jira before assembling a rollout report.",
       settingsLabel: "Domains and tool permissions",
       chatLabel: "Allow yourco.atlassian.net",
       botName: "Delivery",
@@ -2199,7 +2215,8 @@ const chatScenarioContent: Partial<
       id: "delivery-skill",
       tabLabel: "Skill",
       title: "Install the delivery skill",
-      description: "Jira, rollout checklists, and status reporting in one bundle.",
+      description:
+        "Jira, rollout checklists, and status reporting in one bundle.",
       settingsLabel: "Skills and integrations",
       chatLabel: "Agent installs delivery skill",
       botName: "Delivery",
@@ -2230,7 +2247,10 @@ const chatScenarioContent: Partial<
       botInitial: "D",
       botColor: "#14b8a6",
       messages: [
-        { role: "user", text: "Send stakeholders a rollout digest every Thursday" },
+        {
+          role: "user",
+          text: "Send stakeholders a rollout digest every Thursday",
+        },
         {
           role: "bot",
           text: "Digest cadence lives in settings — current: none.",
@@ -2249,7 +2269,8 @@ const chatScenarioContent: Partial<
       id: "community-permission",
       tabLabel: "Permission",
       title: "Read member directory",
-      description: "Agent asks to reach the community platform before matching members.",
+      description:
+        "Agent asks to reach the community platform before matching members.",
       settingsLabel: "Domains and tool permissions",
       chatLabel: "Allow yourco.circle.so",
       botName: "Community",
@@ -2273,7 +2294,8 @@ const chatScenarioContent: Partial<
       id: "community-skill",
       tabLabel: "Skill",
       title: "Install the community skill",
-      description: "Member directory, interest graph, and intro workflows bundled together.",
+      description:
+        "Member directory, interest graph, and intro workflows bundled together.",
       settingsLabel: "Skills and integrations",
       chatLabel: "Agent installs community skill",
       botName: "Community",
@@ -2297,7 +2319,8 @@ const chatScenarioContent: Partial<
       id: "community-settings",
       tabLabel: "Settings",
       title: "Tune matching signals",
-      description: "Which activity signals weigh most when recommending member matches.",
+      description:
+        "Which activity signals weigh most when recommending member matches.",
       settingsLabel: "Matching weights and recency",
       chatLabel: "Agent opens settings page",
       botName: "Community",
@@ -2323,7 +2346,8 @@ const chatScenarioContent: Partial<
       id: "market-permission",
       tabLabel: "Permission",
       title: "Fetch competitor signals",
-      description: "Agent asks to reach Crunchbase before pulling funding data.",
+      description:
+        "Agent asks to reach Crunchbase before pulling funding data.",
       settingsLabel: "Domains and tool permissions",
       chatLabel: "Allow crunchbase.com",
       botName: "Market Intel",
@@ -2347,7 +2371,8 @@ const chatScenarioContent: Partial<
       id: "market-skill",
       tabLabel: "Skill",
       title: "Install the market intel skill",
-      description: "Crunchbase, Product Hunt, review sites, and news feeds in one bundle.",
+      description:
+        "Crunchbase, Product Hunt, review sites, and news feeds in one bundle.",
       settingsLabel: "Skills and integrations",
       chatLabel: "Agent installs market intel skill",
       botName: "Market Intel",
@@ -2397,7 +2422,8 @@ const chatScenarioContent: Partial<
       id: "careops-permission",
       tabLabel: "Permission",
       title: "Read the care platform",
-      description: "Agent asks to reach the care platform before reviewing a patient.",
+      description:
+        "Agent asks to reach the care platform before reviewing a patient.",
       settingsLabel: "Domains and tool permissions",
       chatLabel: "Allow yourco.healthie.com",
       botName: "CareOps",
@@ -2421,7 +2447,8 @@ const chatScenarioContent: Partial<
       id: "careops-skill",
       tabLabel: "Skill",
       title: "Install the careops skill",
-      description: "Care platform, scheduling, and follow-up playbooks bundled together.",
+      description:
+        "Care platform, scheduling, and follow-up playbooks bundled together.",
       settingsLabel: "Skills and integrations",
       chatLabel: "Agent installs careops skill",
       botName: "CareOps",
@@ -2487,7 +2514,7 @@ const chatScenarioContent: Partial<
         { role: "user", text: "Allow" },
         {
           role: "bot",
-          text: "Order #10482 shipped Apr 12, delivered Apr 15. Customer opened a \"where is it\" ticket today — tracking shows delivered to mailroom. Drafted reply with photo proof.",
+          text: 'Order #10482 shipped Apr 12, delivered Apr 15. Customer opened a "where is it" ticket today — tracking shows delivered to mailroom. Drafted reply with photo proof.',
         },
       ],
     },
@@ -2519,7 +2546,8 @@ const chatScenarioContent: Partial<
       id: "ecommerce-settings",
       tabLabel: "Settings",
       title: "Set refund approval limits",
-      description: "Maximum auto-refund the agent can issue without human review.",
+      description:
+        "Maximum auto-refund the agent can issue without human review.",
       settingsLabel: "Refund limits and policy",
       chatLabel: "Agent opens settings page",
       botName: "Store",
@@ -2545,7 +2573,8 @@ const chatScenarioContent: Partial<
       id: "vc-permission",
       tabLabel: "Permission",
       title: "Pull deal flow data",
-      description: "Agent asks to reach Affinity before summarizing the pipeline.",
+      description:
+        "Agent asks to reach Affinity before summarizing the pipeline.",
       settingsLabel: "Domains and tool permissions",
       chatLabel: "Allow affinity.co",
       botName: "Deal Flow",
@@ -2569,14 +2598,18 @@ const chatScenarioContent: Partial<
       id: "vc-skill",
       tabLabel: "Skill",
       title: "Install the VC skill",
-      description: "Affinity, Crunchbase, and diligence checklists bundled together.",
+      description:
+        "Affinity, Crunchbase, and diligence checklists bundled together.",
       settingsLabel: "Skills and integrations",
       chatLabel: "Agent installs vc skill",
       botName: "Deal Flow",
       botInitial: "D",
       botColor: "#f43f5e",
       messages: [
-        { role: "user", text: "Find co-investors we've backed with in AI infra" },
+        {
+          role: "user",
+          text: "Find co-investors we've backed with in AI infra",
+        },
         {
           role: "bot",
           text: "I need the `vc` skill — it bundles Affinity, Crunchbase, and our portfolio graph.",
@@ -2593,7 +2626,8 @@ const chatScenarioContent: Partial<
       id: "vc-settings",
       tabLabel: "Settings",
       title: "Choose an investment thesis",
-      description: "Pick which thesis the agent uses when scoring inbound deals.",
+      description:
+        "Pick which thesis the agent uses when scoring inbound deals.",
       settingsLabel: "Thesis and scoring model",
       chatLabel: "Agent opens settings page",
       botName: "Deal Flow",


### PR DESCRIPTION
## Summary
- Platform docs pages (`/platforms/{telegram,slack,discord,whatsapp,teams,google-chat}`) get a use-case switcher above the 3-chat grid. Transcripts re-skin for all 12 use-cases (DevOps, Support, Legal, Sales, Leadership, Finance, Delivery, Agent Community, Market Intelligence, CareOps, Ecommerce, Venture Capital) while the platform theme stays fixed. Data lives in a new `chatScenarios` field on each `LandingUseCaseShowcase`.
- Extract `Chip` into its own component and reuse it inside `ExampleShowcase`. `TryItSection` (connect-from pages) switches to `UseCaseTabs`, surfaces the scoped MCP URL + `owletto.com/<slug>` sign-in label live when a workspace is selected, and drops the redundant bottom links.
- Getting Started page gets a concise project-structure tree with deep links to relevant docs, and trims redundant copy. Minor homepage copy fixes (hero, skills).

## Test plan
- [ ] `cd packages/landing && bun run build` passes (120 pages)
- [ ] Visit `/platforms/telegram/` — tab row: General + 12 use-cases. Default General, clicking DevOps re-renders the three chat windows with DevOps transcripts, Telegram theme preserved
- [ ] Repeat on `/platforms/slack/`, `/whatsapp/`, `/discord/` — each picks up its own theme
- [ ] Visit `/connect-from/openclaw/` — the use-case chips at the top change the MCP URL and the sign-in link text (`owletto.com/<slug>`) inline; no duplicate link row below
- [ ] `/getting-started/` shows the project tree with working links