### PR TITLE
fix(worker): QA hardening for careops agent (Gemini support, UploadUserFile workspace paths, dedup error messages)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,7 @@ jobs:
     needs: [test, format-lint, typecheck]
     if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
     env:
-      Z_AI_API_KEY: ${{ secrets.Z_AI_API_KEY }}
+      GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
     steps:
       - uses: actions/checkout@v4
 
@@ -90,10 +90,10 @@ jobs:
         with:
           bun-version: 1.3.5
 
-      - name: Require Z_AI_API_KEY secret
+      - name: Require GEMINI_API_KEY secret
         run: |
-          if [ -z "$Z_AI_API_KEY" ]; then
-            echo "Z_AI_API_KEY secret is not configured"
+          if [ -z "$GEMINI_API_KEY" ]; then
+            echo "GEMINI_API_KEY secret is not configured"
             exit 1
           fi
 
@@ -115,7 +115,7 @@ jobs:
           ADMIN_PASSWORD=ci-eval-password
           ENCRYPTION_KEY=$(openssl rand -hex 32)
           GATEWAY_PORT=8081
-          Z_AI_API_KEY=${Z_AI_API_KEY}
+          GEMINI_API_KEY=${GEMINI_API_KEY}
           EOF
 
       - name: Start stack
@@ -123,7 +123,7 @@ jobs:
         run: |
           mkdir -p data && chmod 777 data
           # Use the gateway image built from this checkout and tame Redis
-          # for ephemeral CI. Z_AI_API_KEY passthrough already exists in
+          # for ephemeral CI. GEMINI_API_KEY passthrough already exists in
           # the base docker-compose.yml.
           cat > docker-compose.override.yml <<'YAML'
           services:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,5 @@
 @AGENTS.md
+
+## Local-only references
+
+- `../owletto` (i.e. `/Users/burakemre/Code/owletto`) is the Owletto source repo. The OpenClaw memory plugin published as `@lobu/owletto-openclaw` lives in `packages/openclaw-plugin` there.

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -42,7 +42,7 @@ services:
       # Host project path for worker bind mounts (Docker-in-Docker)
       LOBU_DEV_PROJECT_PATH: ${PWD}
       # Read-only workspace mount used for file-first agent config loading
-      LOBU_WORKSPACE_ROOT: /workspace/project
+      LOBU_WORKSPACE_ROOT: ${LOBU_WORKSPACE_ROOT:-/workspace/project}
     env_file:
       - ../.env
     volumes:

--- a/examples/careops/docker-compose.yml
+++ b/examples/careops/docker-compose.yml
@@ -20,7 +20,8 @@ services:
     restart: unless-stopped
 
   gateway:
-    image: lobu-gateway:latest
+    image: ghcr.io/lobu-ai/lobu-gateway:latest
+    pull_policy: always
     ports:
       - "127.0.0.1:${GATEWAY_PORT:-8090}:8080"
     environment:

--- a/examples/careops/docker-compose.yml
+++ b/examples/careops/docker-compose.yml
@@ -20,8 +20,7 @@ services:
     restart: unless-stopped
 
   gateway:
-    image: ghcr.io/lobu-ai/lobu-gateway:latest
-    pull_policy: always
+    image: lobu-gateway:latest
     ports:
       - "127.0.0.1:${GATEWAY_PORT:-8090}:8080"
     environment:
@@ -37,6 +36,8 @@ services:
       WORKER_DISALLOWED_DOMAINS: ${WORKER_DISALLOWED_DOMAINS:-}
       MEMORY_URL: ${MEMORY_URL:-}
       LOBU_WORKSPACE_ROOT: /workspace/project
+      GEMINI_API_KEY: ${GEMINI_API_KEY:-}
+      OPENROUTER_API_KEY: ${OPENROUTER_API_KEY:-}
       Z_AI_API_KEY: ${Z_AI_API_KEY:-}
       SLACK_BOT_TOKEN: ${SLACK_BOT_TOKEN:-}
       SLACK_SIGNING_SECRET: ${SLACK_SIGNING_SECRET:-}

--- a/examples/careops/docker-compose.yml
+++ b/examples/careops/docker-compose.yml
@@ -37,11 +37,18 @@ services:
       WORKER_DISALLOWED_DOMAINS: ${WORKER_DISALLOWED_DOMAINS:-}
       MEMORY_URL: ${MEMORY_URL:-}
       LOBU_WORKSPACE_ROOT: /workspace/project
+      # Provider API keys — passthrough any that are set in the host env so
+      # agents can reference them as `$VAR` in lobu.toml. Unset vars expand
+      # to empty strings and are ignored by the agent runtime.
+      ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
       GEMINI_API_KEY: ${GEMINI_API_KEY:-}
+      OPENAI_API_KEY: ${OPENAI_API_KEY:-}
       OPENROUTER_API_KEY: ${OPENROUTER_API_KEY:-}
       Z_AI_API_KEY: ${Z_AI_API_KEY:-}
+      # Platform credentials — same pattern: set only the ones your agents use.
       SLACK_BOT_TOKEN: ${SLACK_BOT_TOKEN:-}
       SLACK_SIGNING_SECRET: ${SLACK_SIGNING_SECRET:-}
+      TELEGRAM_BOT_TOKEN: ${TELEGRAM_BOT_TOKEN:-}
     volumes:
       - .:/workspace/project:ro
     networks:

--- a/examples/careops/lobu.toml
+++ b/examples/careops/lobu.toml
@@ -6,22 +6,23 @@ name = "careops"
 description = "Manage patient care, appointments, and treatment workflows for healthcare practices"
 dir = "./agents/careops"
 
+# Primary: Gemini 2.5 Flash via Google AI Studio — generous free tier
+# (~15 RPM, 1M tokens/day), supports tool-use.
 [[agents.careops.providers]]
-id = "z-ai"
-model = "z-ai/glm-4.7"
-key = "$Z_AI_API_KEY"
+id = "gemini"
+model = "gemini/gemini-2.5-flash"
+key = "$GEMINI_API_KEY"
 
-# Alternative providers — swap one of these in if you prefer. Gemini 2.5
-# Flash via Google AI Studio has a generous free tier (~15 RPM, 1M tokens/day).
-# [[agents.careops.providers]]
-# id = "gemini"
-# model = "gemini/gemini-2.5-flash"
-# key = "$GEMINI_API_KEY"
-#
+# Alternative providers — swap one of these in if you prefer.
 # [[agents.careops.providers]]
 # id = "openrouter"
 # model = "google/gemini-2.5-flash-lite"
 # key = "$OPENROUTER_API_KEY"
+#
+# [[agents.careops.providers]]
+# id = "z-ai"
+# model = "z-ai/glm-4.7"
+# key = "$Z_AI_API_KEY"
 #
 # [[agents.careops.providers]]
 # id = "anthropic"

--- a/examples/careops/lobu.toml
+++ b/examples/careops/lobu.toml
@@ -6,15 +6,23 @@ name = "careops"
 description = "Manage patient care, appointments, and treatment workflows for healthcare practices"
 dir = "./agents/careops"
 
+# Primary: Gemini 2.5 Flash via Google AI Studio — generous free tier
+# (~15 RPM, 1M tokens/day), supports tool-use. Verified 2026-04-16.
 [[agents.careops.providers]]
-id = "z-ai"
-model = "z-ai/glm-4.7"
-key = "$Z_AI_API_KEY"
+id = "gemini"
+model = "gemini/gemini-2.5-flash"
+key = "$GEMINI_API_KEY"
 
+# Fallbacks (swap in if Gemini free tier is exhausted):
 # [[agents.careops.providers]]
-# id = "anthropic"
-# model = "claude/sonnet-4-5"
-# key = "$ANTHROPIC_API_KEY"
+# id = "openrouter"
+# model = "google/gemini-2.5-flash-lite"
+# key = "$OPENROUTER_API_KEY"
+#
+# [[agents.careops.providers]]
+# id = "z-ai"
+# model = "z-ai/glm-4.7"
+# key = "$Z_AI_API_KEY"
 
 [[agents.careops.connections]]
 type = "slack"

--- a/examples/careops/lobu.toml
+++ b/examples/careops/lobu.toml
@@ -6,23 +6,27 @@ name = "careops"
 description = "Manage patient care, appointments, and treatment workflows for healthcare practices"
 dir = "./agents/careops"
 
-# Primary: Gemini 2.5 Flash via Google AI Studio — generous free tier
-# (~15 RPM, 1M tokens/day), supports tool-use. Verified 2026-04-16.
 [[agents.careops.providers]]
-id = "gemini"
-model = "gemini/gemini-2.5-flash"
-key = "$GEMINI_API_KEY"
+id = "z-ai"
+model = "z-ai/glm-4.7"
+key = "$Z_AI_API_KEY"
 
-# Fallbacks (swap in if Gemini free tier is exhausted):
+# Alternative providers — swap one of these in if you prefer. Gemini 2.5
+# Flash via Google AI Studio has a generous free tier (~15 RPM, 1M tokens/day).
+# [[agents.careops.providers]]
+# id = "gemini"
+# model = "gemini/gemini-2.5-flash"
+# key = "$GEMINI_API_KEY"
+#
 # [[agents.careops.providers]]
 # id = "openrouter"
 # model = "google/gemini-2.5-flash-lite"
 # key = "$OPENROUTER_API_KEY"
 #
 # [[agents.careops.providers]]
-# id = "z-ai"
-# model = "z-ai/glm-4.7"
-# key = "$Z_AI_API_KEY"
+# id = "anthropic"
+# model = "claude/sonnet-4-5"
+# key = "$ANTHROPIC_API_KEY"
 
 [[agents.careops.connections]]
 type = "slack"

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -881,6 +881,18 @@ ${owlettoServices}
       # memory from [memory.owletto] in lobu.toml and owletto.yaml.
       MEMORY_URL: \${MEMORY_URL:-}
       LOBU_WORKSPACE_ROOT: /workspace/project
+      # Provider API keys — passthrough any that are set in the host env so
+      # agents can reference them as \`$VAR\` in lobu.toml. Unset vars expand
+      # to empty strings and are ignored by the agent runtime.
+      ANTHROPIC_API_KEY: \${ANTHROPIC_API_KEY:-}
+      GEMINI_API_KEY: \${GEMINI_API_KEY:-}
+      OPENAI_API_KEY: \${OPENAI_API_KEY:-}
+      OPENROUTER_API_KEY: \${OPENROUTER_API_KEY:-}
+      Z_AI_API_KEY: \${Z_AI_API_KEY:-}
+      # Platform credentials — same pattern: set only the ones your agents use.
+      SLACK_BOT_TOKEN: \${SLACK_BOT_TOKEN:-}
+      SLACK_SIGNING_SECRET: \${SLACK_SIGNING_SECRET:-}
+      TELEGRAM_BOT_TOKEN: \${TELEGRAM_BOT_TOKEN:-}
     volumes:${dockerSocketMount}
       - .:/workspace/project:ro
     networks:

--- a/packages/cli/src/eval/client.ts
+++ b/packages/cli/src/eval/client.ts
@@ -67,7 +67,7 @@ export async function createSession(
 export async function sendMessage(
   session: Session,
   content: string
-): Promise<{ traceId?: string }> {
+): Promise<{ traceId?: string; messageId?: string }> {
   const res = await fetch(`${session.base}/messages`, {
     method: "POST",
     headers: {
@@ -82,19 +82,27 @@ export async function sendMessage(
     throw new Error(`Failed to send message (${res.status}): ${text}`);
   }
 
-  const data = (await res.json()) as { traceparent?: string };
+  const data = (await res.json()) as {
+    traceparent?: string;
+    messageId?: string;
+  };
   // Extract trace ID from W3C traceparent: "00-{traceId}-{spanId}-01"
   const traceId = data.traceparent?.split("-")[1];
-  return { traceId };
+  return { traceId, messageId: data.messageId };
 }
 
 /**
  * Connect to SSE stream and collect the full response text.
- * Accumulates 'output' deltas until 'complete' event.
+ * Accumulates 'output' deltas until 'complete' event for the target messageId.
+ *
+ * When `messageId` is provided, events for other messageIds are ignored. This
+ * prevents SSE backlog replay from prior turns in the same session from being
+ * misread as the current turn's response.
  */
 export async function collectResponse(
   session: Session,
-  timeoutMs: number
+  timeoutMs: number,
+  messageId?: string
 ): Promise<CollectedResponse> {
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), timeoutMs);
@@ -116,6 +124,11 @@ export async function collectResponse(
     let currentEvent = "";
     let text = "";
 
+    const matchesTarget = (eventMessageId: unknown): boolean => {
+      if (!messageId) return true;
+      return typeof eventMessageId === "string" && eventMessageId === messageId;
+    };
+
     while (true) {
       const { done, value } = await reader.read();
       if (done) break;
@@ -133,9 +146,15 @@ export async function collectResponse(
 
           switch (currentEvent) {
             case "output":
-              if (typeof data.content === "string") text += data.content;
+              if (
+                typeof data.content === "string" &&
+                matchesTarget(data.messageId)
+              ) {
+                text += data.content;
+              }
               break;
             case "complete": {
+              if (!matchesTarget(data.messageId)) break;
               const usage = data.usage as Record<string, number> | undefined;
               return {
                 text,
@@ -152,6 +171,7 @@ export async function collectResponse(
               };
             }
             case "error":
+              if (!matchesTarget(data.messageId)) break;
               return {
                 text,
                 latencyMs: Date.now() - start,
@@ -187,16 +207,19 @@ export async function deleteSession(session: Session): Promise<void> {
 
 /**
  * Send a message and collect the full response in one call.
+ *
+ * Sends first to capture the gateway-issued messageId, then opens the SSE
+ * stream filtered to that messageId. The gateway's SSE endpoint replays a
+ * recent event backlog on connect, so no output deltas are lost between the
+ * POST and the SSE subscribe.
  */
 export async function sendAndCollect(
   session: Session,
   content: string,
   timeoutMs: number
 ): Promise<CollectedResponse> {
-  // Start SSE collection first, then send message
-  const collecting = collectResponse(session, timeoutMs);
-  const { traceId } = await sendMessage(session, content);
-  const response = await collecting;
+  const { traceId, messageId } = await sendMessage(session, content);
+  const response = await collectResponse(session, timeoutMs, messageId);
   response.traceId = traceId;
   return response;
 }

--- a/packages/cli/src/eval/grader.ts
+++ b/packages/cli/src/eval/grader.ts
@@ -5,6 +5,7 @@
  * grades agent output against a markdown rubric with per-criterion scoring.
  */
 
+import { randomUUID } from "node:crypto";
 import {
   createSession,
   deleteSession,
@@ -46,12 +47,19 @@ Rules:
 ## Conversation
 {{transcript}}`;
 
+export interface JudgeSessionOptions {
+  agentId?: string;
+  provider?: string;
+  model?: string;
+}
+
 export async function gradeWithRubric(
   gatewayUrl: string,
   authToken: string,
   rubricContent: string,
   turns: TurnResult[],
-  timeoutMs: number
+  timeoutMs: number,
+  judgeOptions?: JudgeSessionOptions
 ): Promise<RubricResult> {
   const transcript = turns
     .map((t) => `User: ${t.user}\nAgent: ${t.agent}`)
@@ -63,6 +71,10 @@ export async function gradeWithRubric(
   ).replace("{{transcript}}", transcript);
 
   const session = await createSession(gatewayUrl, authToken, {
+    agentId: judgeOptions?.agentId,
+    provider: judgeOptions?.provider,
+    model: judgeOptions?.model,
+    thread: `judge-${randomUUID()}`,
     forceNew: true,
     dryRun: true,
   });
@@ -80,7 +92,8 @@ export async function gradeInline(
   authToken: string,
   criteria: string,
   agentResponse: string,
-  timeoutMs: number
+  timeoutMs: number,
+  judgeOptions?: JudgeSessionOptions
 ): Promise<{ passed: boolean; score: number; reason: string }> {
   const prompt = INLINE_JUDGE_PROMPT.replace("{{criteria}}", criteria).replace(
     "{{response}}",
@@ -88,6 +101,10 @@ export async function gradeInline(
   );
 
   const session = await createSession(gatewayUrl, authToken, {
+    agentId: judgeOptions?.agentId,
+    provider: judgeOptions?.provider,
+    model: judgeOptions?.model,
+    thread: `judge-${randomUUID()}`,
     forceNew: true,
     dryRun: true,
   });

--- a/packages/cli/src/eval/runner.ts
+++ b/packages/cli/src/eval/runner.ts
@@ -113,7 +113,12 @@ async function runTrial(
             response.text,
             options.gatewayUrl,
             options.authToken,
-            timeoutMs
+            timeoutMs,
+            {
+              agentId: options.agentId,
+              provider: options.provider,
+              model: options.model,
+            }
           )
         : [];
 
@@ -135,7 +140,12 @@ async function runTrial(
         options.authToken,
         rubricContent,
         turnResults,
-        timeoutMs
+        timeoutMs,
+        {
+          agentId: options.agentId,
+          provider: options.provider,
+          model: options.model,
+        }
       );
     }
 
@@ -161,7 +171,8 @@ async function runAssertions(
   agentResponse: string,
   gatewayUrl: string,
   authToken: string,
-  timeoutMs: number
+  timeoutMs: number,
+  judgeOptions: { agentId?: string; provider?: string; model?: string }
 ): Promise<AssertionResult[]> {
   const results: AssertionResult[] = [];
 
@@ -193,7 +204,8 @@ async function runAssertions(
           authToken,
           assertion.value,
           agentResponse,
-          timeoutMs
+          timeoutMs,
+          judgeOptions
         );
         results.push({
           type: "llm-rubric",

--- a/packages/gateway/src/__tests__/chat-response-bridge.test.ts
+++ b/packages/gateway/src/__tests__/chat-response-bridge.test.ts
@@ -124,7 +124,10 @@ describe("ChatResponseBridge.handleDelta — AsyncIterable streaming", () => {
     expect(history).toEqual([]);
   });
 
-  test("handleError closes iterator and posts error text separately", async () => {
+  test("handleError after partial stream posts fallback so truncation is visible", async () => {
+    // Worker was mid-stream (no isFullReplacement) and then errored. The user
+    // would see truncated text with no failure indicator unless the gateway
+    // posts the fallback "Error: …" message.
     const { target, collected, plainPosts, drained } = createStreamingTarget();
     const { manager } = createHarness(target);
     const bridge = new ChatResponseBridge(manager as any);
@@ -134,6 +137,46 @@ describe("ChatResponseBridge.handleDelta — AsyncIterable streaming", () => {
     await drained;
 
     expect(collected).toEqual(["partial"]);
+    expect(plainPosts).toContain("Error: boom");
+  });
+
+  test("handleError after full-replacement delta skips fallback to avoid duplicate", async () => {
+    // Worker already delivered a complete, self-contained failure message
+    // (e.g. "❌ Session failed: 429 …") via isFullReplacement and then called
+    // signalError for bookkeeping. The gateway must NOT post a second
+    // "Error: 429 …" — the user has already seen the formatted message.
+    const { target, collected, plainPosts, drained } = createStreamingTarget();
+    const { manager } = createHarness(target);
+    const bridge = new ChatResponseBridge(manager as any);
+
+    await bridge.handleDelta(
+      {
+        ...basePayload,
+        delta: "❌ Session failed: 429 rate-limited",
+        isFullReplacement: true,
+      },
+      "s"
+    );
+    await bridge.handleError(
+      { ...basePayload, error: "429 rate-limited" },
+      "s"
+    );
+    await drained;
+
+    expect(collected).toEqual(["❌ Session failed: 429 rate-limited"]);
+    expect(plainPosts).toEqual([]);
+  });
+
+  test("handleError with no prior stream still posts fallback (worker crashed early)", async () => {
+    // No delta was ever sent (e.g. NO_MODEL_CONFIGURED path calls signalError
+    // with no preceding sendStreamDelta). The fallback is the only way the
+    // user learns anything went wrong.
+    const { target, plainPosts } = createStreamingTarget();
+    const { manager } = createHarness(target);
+    const bridge = new ChatResponseBridge(manager as any);
+
+    await bridge.handleError({ ...basePayload, error: "boom" }, "s");
+
     expect(plainPosts).toContain("Error: boom");
   });
 

--- a/packages/gateway/src/connections/chat-response-bridge.ts
+++ b/packages/gateway/src/connections/chat-response-bridge.ts
@@ -104,6 +104,18 @@ interface StreamState {
   buffer: string;
   /** Set when the adapter's streaming API rejected. Completion posts the buffer. */
   streamFailed: boolean;
+  /**
+   * True once the worker has sent at least one delta with `isFullReplacement=true`.
+   * A full replacement is a complete, self-contained user-facing message
+   * (e.g. the worker's own "❌ Session failed: …" text). When this is set,
+   * `handleError` must NOT post its fallback `"Error: …"` text, because the
+   * user has already seen a formatted failure message.
+   *
+   * Partial-only streams (worker streamed incremental deltas and then errored)
+   * leave this false so the fallback still fires and the user sees a failure
+   * indicator instead of silently-truncated output.
+   */
+  wasFullyReplaced: boolean;
   /** The resolved Chat SDK target — reused on failure fallback without a second resolveTarget call. */
   target: any;
 }
@@ -212,6 +224,7 @@ export class ChatResponseBridge implements ResponseRenderer {
           streamPromise: Promise.resolve(),
           buffer: payload.delta,
           streamFailed: false,
+          wasFullyReplaced: !!payload.isFullReplacement,
           target,
         };
         newStream.streamPromise = Promise.resolve(
@@ -356,7 +369,16 @@ export class ChatResponseBridge implements ResponseRenderer {
     const key = `${channelId}:${payload.conversationId}`;
 
     // Clean up stream — close iterator so the adapter call resolves.
+    // Capture whether the worker already delivered a complete, self-contained
+    // user-facing message (via `sendStreamDelta(..., isFullReplacement=true)`).
+    // When it did, we must NOT post the fallback raw "Error: …" because the
+    // user already saw a formatted failure message like "❌ Session failed: …".
+    //
+    // For partial streams that errored mid-way (`isFullReplacement` never set),
+    // the fallback still fires so the user sees a failure indicator instead of
+    // silently-truncated output.
     const stream = this.streams.get(key);
+    const alreadyDeliveredCompleteMessage = !!stream?.wasFullyReplaced;
     if (stream) {
       stream.iterator.close();
       try {
@@ -365,6 +387,14 @@ export class ChatResponseBridge implements ResponseRenderer {
         // swallow — we're already in error path
       }
       this.streams.delete(key);
+    }
+
+    if (alreadyDeliveredCompleteMessage) {
+      logger.debug(
+        { connectionId, channelId },
+        "Skipping fallback error text — worker already delivered a complete user-facing message"
+      );
+      return;
     }
 
     // For known error codes, render user-facing guidance without sending users

--- a/packages/gateway/src/connections/state-adapter.ts
+++ b/packages/gateway/src/connections/state-adapter.ts
@@ -1,5 +1,8 @@
 import type Redis from "ioredis";
 import type { StateAdapter } from "chat";
+import { createLogger } from "@lobu/core";
+
+const logger = createLogger("chat-state");
 
 export async function createGatewayStateAdapter(
   redis: Redis
@@ -8,6 +11,6 @@ export async function createGatewayStateAdapter(
   return createIoRedisState({
     client: redis,
     keyPrefix: "chat-conn",
-    logger: "warn",
+    logger,
   } as any) as StateAdapter;
 }

--- a/packages/worker/src/__tests__/custom-tools.test.ts
+++ b/packages/worker/src/__tests__/custom-tools.test.ts
@@ -20,6 +20,7 @@ describe("createOpenClawCustomTools", () => {
       channelId: "channel-1",
       conversationId: "conversation-1",
       platform: "telegram",
+      workspaceDir: "/tmp/test-workspace",
     });
 
     expect(tools.map((tool) => tool.name)).toEqual([
@@ -59,6 +60,7 @@ describe("createOpenClawCustomTools", () => {
         channelId: "channel-1",
         conversationId: "conversation-1",
         platform: "telegram",
+        workspaceDir: tempDir,
         onCustomEvent: (name, data) => {
           events.push({ name, data });
         },

--- a/packages/worker/src/__tests__/sandbox-leak.test.ts
+++ b/packages/worker/src/__tests__/sandbox-leak.test.ts
@@ -116,11 +116,51 @@ describe("checkSandboxLeak", () => {
     expect(res.leaked).toBe(false);
   });
 
+  // --- delivery-phrase detection ---
+
+  test("flags 'located at' with workspace file path", () => {
+    const text =
+      "The file is located at: /app/workspaces/careops/123/input/sample_patient.json";
+    const res = checkSandboxLeak(text, false);
+    expect(res.leaked).toBe(true);
+    expect(res.redactedText).not.toContain("/app/workspaces/careops");
+    expect(res.redactedText).toContain("not uploaded");
+  });
+
+  test("flags 'saved to' with backticked workspace path", () => {
+    const text = "Report saved to `/workspace/output/report.pdf` successfully.";
+    const res = checkSandboxLeak(text, false);
+    expect(res.leaked).toBe(true);
+    expect(res.redactedText).not.toContain("/workspace/output/report.pdf");
+  });
+
+  test("does not flag delivery phrase with directory (no extension)", () => {
+    const text = "Files are stored in /app/workspaces/careops/123/input";
+    const res = checkSandboxLeak(text, false);
+    expect(res.leaked).toBe(false);
+  });
+
+  test("does not flag delivery phrase about non-workspace paths", () => {
+    const text = "The file is located at: /home/user/documents/report.pdf";
+    const res = checkSandboxLeak(text, false);
+    expect(res.leaked).toBe(false);
+  });
+
+  test("suppresses delivery-phrase check when UploadUserFile was used", () => {
+    const text =
+      "I saved the file to `/workspace/output/data.csv` and uploaded it.";
+    const res = checkSandboxLeak(text, true);
+    expect(res.leaked).toBe(false);
+    expect(res.redactedText).toBe(text);
+  });
+
   test("is stable across repeated invocations (no lastIndex leakage)", () => {
     const bad = "Here: sandbox:/a.pdf";
     const good = "Workspace at /app/workspaces/careops.";
+    const deliveryBad = "File saved to /app/workspaces/foo/report.pdf for you.";
     expect(checkSandboxLeak(bad, false).leaked).toBe(true);
     expect(checkSandboxLeak(good, false).leaked).toBe(false);
+    expect(checkSandboxLeak(deliveryBad, false).leaked).toBe(true);
     expect(checkSandboxLeak(bad, false).leaked).toBe(true);
     expect(checkSandboxLeak(good, false).leaked).toBe(false);
   });

--- a/packages/worker/src/core/workspace.ts
+++ b/packages/worker/src/core/workspace.ts
@@ -9,57 +9,16 @@ import type { WorkspaceInfo, WorkspaceSetupConfig } from "./types";
 const logger = createLogger("workspace");
 
 // ============================================================================
-// WORKSPACE UTILITIES
-// ============================================================================
-
-/**
- * Get workspace directory path for a thread
- */
-function getWorkspacePathForThread(
-  baseDirectory: string,
-  conversationId: string
-): string {
-  // Sanitize thread ID for filesystem
-  const sanitizedConversationId = sanitizeConversationId(conversationId);
-  return `${baseDirectory}/${sanitizedConversationId}`;
-}
-
-/**
- * Setup workspace directory environment variable
- * Used by MCP process manager
- */
-export function setupWorkspaceEnv(deploymentName: string | undefined): void {
-  const conversationId = process.env.CONVERSATION_ID;
-
-  if (conversationId) {
-    const baseDir = process.env.WORKSPACE_DIR || "/workspace";
-    const workspaceDir = getWorkspacePathForThread(baseDir, conversationId);
-    process.env.WORKSPACE_DIR = workspaceDir;
-    logger.info(`📁 Set WORKSPACE_DIR for process manager: ${workspaceDir}`);
-  } else if (deploymentName) {
-    // deploymentName is no longer parseable (it may be hashed/collision-resistant).
-    logger.warn("WORKSPACE_DIR not set (missing CONVERSATION_ID env var)");
-  }
-}
-
-/**
- * Get conversation identifier from various sources
- * Priority: CONVERSATION_ID > sessionKey > username
- */
-function getThreadIdentifier(sessionKey?: string, username?: string): string {
-  const conversationId =
-    process.env.CONVERSATION_ID || sessionKey || username || "default";
-
-  return conversationId;
-}
-
-// ============================================================================
 // WORKSPACE MANAGER
 // ============================================================================
 
 /**
- * Simplified WorkspaceManager - only handles directory creation
- * All VCS operations (git, etc.) are handled by modules via hooks
+ * Simplified WorkspaceManager - only handles directory creation.
+ * All VCS operations (git, etc.) are handled by modules via hooks.
+ *
+ * Workspace layout:
+ *   baseDirectory/                      ← agent-level root (e.g. /workspace)
+ *   baseDirectory/{conversationId}/     ← thread-specific working directory
  */
 export class WorkspaceManager {
   private config: WorkspaceSetupConfig;
@@ -70,33 +29,28 @@ export class WorkspaceManager {
   }
 
   /**
-   * Setup workspace directory - creates thread-specific directory only
-   * VCS operations are handled by module hooks (e.g., GitHub module)
+   * Setup workspace directory - creates thread-specific directory only.
+   * VCS operations are handled by module hooks (e.g., GitHub module).
    */
   async setupWorkspace(
     username: string,
     sessionKey?: string
   ): Promise<WorkspaceInfo> {
     try {
-      // Use thread-specific directory to avoid conflicts between concurrent threads
-      const conversationId = getThreadIdentifier(sessionKey, username);
+      const conversationId =
+        process.env.CONVERSATION_ID || sessionKey || username || "default";
 
       logger.info(
         `Setting up workspace directory for ${username}, conversation: ${conversationId}...`
       );
 
-      const userDirectory = getWorkspacePathForThread(
-        this.config.baseDirectory,
-        conversationId
-      );
+      const sanitized = sanitizeConversationId(conversationId);
+      const userDirectory = `${this.config.baseDirectory}/${sanitized}`;
 
-      // Ensure base directory exists
+      // Ensure directories exist
       await this.ensureDirectory(this.config.baseDirectory);
-
-      // Ensure user directory exists
       await this.ensureDirectory(userDirectory);
 
-      // Create workspace info
       this.workspaceInfo = {
         baseDirectory: this.config.baseDirectory,
         userDirectory,
@@ -116,9 +70,6 @@ export class WorkspaceManager {
     }
   }
 
-  /**
-   * Ensure directory exists
-   */
   private async ensureDirectory(path: string): Promise<void> {
     try {
       await mkdir(path, { recursive: true });
@@ -130,7 +81,7 @@ export class WorkspaceManager {
   }
 
   /**
-   * Get current working directory
+   * Get current working directory (thread-specific).
    */
   getCurrentWorkingDirectory(): string {
     return this.workspaceInfo?.userDirectory || this.config.baseDirectory;

--- a/packages/worker/src/embedded/just-bash-bootstrap.ts
+++ b/packages/worker/src/embedded/just-bash-bootstrap.ts
@@ -140,6 +140,8 @@ async function buildCustomCommands(
 }
 
 export interface EmbeddedBashOpsOptions {
+  /** Thread-specific workspace directory used as the sandbox filesystem root. */
+  workspaceDir?: string;
   /**
    * When provided together with `gw`, MCP servers are exposed as one
    * `just-bash` custom command per server (e.g. `owletto search_knowledge
@@ -176,7 +178,8 @@ export async function createEmbeddedBashOps(
 ): Promise<BashOperations> {
   const { Bash, ReadWriteFs } = await import("just-bash");
 
-  const workspaceDir = process.env.WORKSPACE_DIR || "/workspace";
+  const workspaceDir =
+    options.workspaceDir || process.env.WORKSPACE_DIR || "/workspace";
   const bashFs = new ReadWriteFs({ root: workspaceDir });
 
   // Parse allowed domains from env var (set by gateway)

--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -9,7 +9,6 @@ import {
 
 const logger = createLogger("worker");
 
-import { setupWorkspaceEnv } from "./core/workspace";
 import { GatewayClient } from "./gateway/sse-client";
 import { startWorkerHttpServer, stopWorkerHttpServer } from "./server";
 
@@ -80,8 +79,6 @@ async function main() {
       logger.error("❌ WORKER_TOKEN environment variable is required");
       process.exit(1);
     }
-
-    setupWorkspaceEnv(deploymentName);
 
     // Start HTTP server before connecting to gateway
     const httpPort = await startWorkerHttpServer();

--- a/packages/worker/src/openclaw/custom-tools.ts
+++ b/packages/worker/src/openclaw/custom-tools.ts
@@ -53,6 +53,8 @@ export function createOpenClawCustomTools(params: {
   channelId: string;
   conversationId: string;
   platform?: string;
+  /** Session workspace directory. Required — UploadUserFile resolves relative paths against it. */
+  workspaceDir: string;
   onCustomEvent?: (
     name: string,
     data: Record<string, unknown>
@@ -64,6 +66,7 @@ export function createOpenClawCustomTools(params: {
     channelId: params.channelId,
     conversationId: params.conversationId,
     platform: params.platform || "slack",
+    workspaceDir: params.workspaceDir,
   };
 
   const tools: ToolDefinition[] = [

--- a/packages/worker/src/openclaw/sandbox-leak.ts
+++ b/packages/worker/src/openclaw/sandbox-leak.ts
@@ -4,35 +4,41 @@
  * user-downloadable artifact, without having actually called
  * `UploadUserFile`.
  *
- * Key design decision: we only flag **structural** delivery claims, not
- * free-text mentions. An agent that *describes* workspace paths in a probe
- * or ls-style answer is legitimate; an agent that hands the path to the
- * user as a clickable link or file URL is not. This eliminates the false
- * positives that the previous broad substring check produced.
+ * Catches three structural delivery patterns (links, sandbox:// URLs,
+ * HTML attributes) plus a semantic pattern: a workspace path presented as
+ * "the file is at …" or "located at …" — the phrasing that tricks users
+ * into thinking the path is reachable.
  */
 
-/**
- * Matches Claude's `sandbox://` file-reference scheme. Any occurrence of
- * this is unambiguously a delivery claim — the scheme exists for exactly
- * that purpose.
- */
+/** Claude's `sandbox://` file-reference scheme — always a delivery claim. */
 const SANDBOX_URL_RE = /\bsandbox:\/{1,2}[^\s)\]}'"<>]+/gi;
 
 /**
- * Matches a markdown link target pointing at a local workspace path, e.g.
+ * Markdown link target pointing at a local workspace path, e.g.
  * `[report](/app/workspaces/foo/bar.pdf)` or `[x](file:///workspace/y)`.
- * The capture group is the URL/path portion so we can rewrite it.
  */
 const LOCAL_MD_LINK_RE =
   /\]\(\s*((?:file:\/\/)?(?:\/app\/workspaces\/|\/workspace\/)[^\s)]+)\s*\)/gi;
 
 /**
- * Matches HTML `href`/`src` pointing at a local workspace path. Capture
- * group 1 is the attribute name (`href` or `src`) so we can preserve it on
- * redact; capture group 2 is the URL target.
+ * HTML `href`/`src` pointing at a local workspace path.
+ * Group 1 = attribute name, group 2 = URL target.
  */
 const LOCAL_HREF_RE =
   /\b(href|src)\s*=\s*["']((?:file:\/\/)?(?:\/app\/workspaces\/|\/workspace\/)[^"']+)["']/gi;
+
+/**
+ * A workspace path presented as a file location via delivery-intent phrasing
+ * (e.g. "located at", "saved to", "file is at", "available at").
+ * Only fires when the path has a file extension so directory descriptions
+ * in ls-style probes are not flagged.
+ *
+ * Matches both bare and back-ticked paths:
+ *   "The file is located at: /app/workspaces/.../report.pdf"
+ *   "saved to `/workspace/output/data.csv`"
+ */
+const DELIVERY_PHRASE_RE =
+  /(?:located at|saved (?:to|at|in)|file is (?:at|in)|available at|created (?:at|in)|stored (?:at|in)|written to|exported to|generated (?:at|in))[:\s]+`?((?:\/app\/workspaces\/|\/workspace\/)[^\s`]+\.\w{1,10})`?/gi;
 
 export interface LeakCheckResult {
   /** True if the final message makes an unfulfilled file-delivery claim. */
@@ -60,13 +66,15 @@ export function checkSandboxLeak(
   const hasSandboxUrl = SANDBOX_URL_RE.test(finalText);
   const hasMdLink = LOCAL_MD_LINK_RE.test(finalText);
   const hasHref = LOCAL_HREF_RE.test(finalText);
+  const hasDeliveryPhrase = DELIVERY_PHRASE_RE.test(finalText);
 
   // Reset lastIndex — `test()` on /g regexes advances state.
   SANDBOX_URL_RE.lastIndex = 0;
   LOCAL_MD_LINK_RE.lastIndex = 0;
   LOCAL_HREF_RE.lastIndex = 0;
+  DELIVERY_PHRASE_RE.lastIndex = 0;
 
-  if (!hasSandboxUrl && !hasMdLink && !hasHref) {
+  if (!hasSandboxUrl && !hasMdLink && !hasHref && !hasDeliveryPhrase) {
     return { leaked: false, redactedText: finalText };
   }
 
@@ -78,6 +86,15 @@ export function checkSandboxLeak(
   redacted = redacted.replace(
     LOCAL_HREF_RE,
     (_match, attr: string) => `${attr}="about:blank"`
+  );
+  redacted = redacted.replace(
+    DELIVERY_PHRASE_RE,
+    (_match, _path: string, _offset: number, _full: string) => {
+      // Reconstruct the phrase prefix (everything before the path) by
+      // re-matching on the original substring. Simpler: replace the whole
+      // match with a generic note.
+      return "[file was created but not uploaded — use `UploadUserFile` to deliver it]";
+    }
   );
 
   const note =

--- a/packages/worker/src/openclaw/worker.ts
+++ b/packages/worker/src/openclaw/worker.ts
@@ -895,9 +895,25 @@ export class OpenClawWorker implements WorkerExecutor {
         );
       }
     }
-    const model = providerBaseUrl
+    const resolvedModel = providerBaseUrl
       ? { ...baseModel, baseUrl: providerBaseUrl }
       : baseModel;
+
+    // Defensive: any `openai-completions` model whose baseUrl is not real
+    // OpenAI is a third-party compat endpoint (Gemini, Nvidia, Together, z.ai,
+    // etc.). These reject unknown fields and 400 with "Unknown name 'store'"
+    // if pi-ai sends `store: false`. Force it off regardless of whether the
+    // model came from the static registry or the dynamic fallback above.
+    const isThirdPartyOpenAICompat =
+      resolvedModel.api === "openai-completions" &&
+      typeof resolvedModel.baseUrl === "string" &&
+      !resolvedModel.baseUrl.startsWith("https://api.openai.com");
+    const model = isThirdPartyOpenAICompat
+      ? {
+          ...resolvedModel,
+          compat: { ...(resolvedModel.compat ?? {}), supportsStore: false },
+        }
+      : resolvedModel;
 
     const workspaceDir = this.getWorkingDirectory();
     await fs.mkdir(path.join(workspaceDir, ".openclaw"), { recursive: true });
@@ -1012,6 +1028,7 @@ export class OpenClawWorker implements WorkerExecutor {
       channelId: this.config.channelId,
       conversationId: this.config.conversationId,
       platform: this.config.platform,
+      workspaceDir,
     };
 
     let embeddedBashOps:
@@ -1022,6 +1039,7 @@ export class OpenClawWorker implements WorkerExecutor {
         "../embedded/just-bash-bootstrap"
       );
       embeddedBashOps = await createEmbeddedBashOps({
+        workspaceDir,
         mcpRuntimeRef,
         gw: gwParams,
         mcpExposure,
@@ -1145,6 +1163,7 @@ Use it when the user references past discussions or you need context.`);
 
     const customTools = createOpenClawCustomTools({
       ...gwParams,
+      workspaceDir,
       onCustomEvent: async (name, data) => {
         await onProgress({
           type: "custom_event",
@@ -1792,21 +1811,28 @@ Use it when the user references past discussions or you need context.`);
     const workspaceDir = this.workspaceManager.getCurrentWorkingDirectory();
     const files = this.uploadedFiles;
 
+    const fileOutputRules = `
+**Mandatory workflow for ANY file you create or generate:**
+1. Write the file to disk (e.g. \`output/report.pdf\`).
+2. Call \`UploadUserFile\` with the file path — this is the ONLY way the user can access it.
+3. Confirm delivery ONLY after \`UploadUserFile\` succeeds.
+
+**Workspace paths are not accessible to users.** Paths like \`/workspace/...\` or \`/app/workspaces/...\` are internal sandbox paths. Never show them as file locations, download links, or "saved at" references. The user cannot reach them. Always use \`UploadUserFile\` instead.`;
+
     if (files.length === 0) {
       return `
 
 ## File Generation & Output
 
+${fileOutputRules}
+
 **When to Create Files:**
-Create and show files for any output that helps answer the user's request by using \`UploadUserFile\` tool:
+Create and show files for any output that helps answer the user's request:
 - **Charts & visualizations**: pie charts, bar graphs, plots, diagrams via \`matplotlib\`
 - **Reports & documents**: analysis reports, summaries, PDFs
 - **Data files**: CSV exports, JSON data, spreadsheets
 - **Code files**: scripts, configurations, examples
 - **Images**: generated images, processed photos, screenshots.
-- If the user asked you to send, share, attach, upload, export, or make a file downloadable, this sequence is required: create the file, call \`UploadUserFile\`, then tell the user it was sent only if the tool succeeds.
-- **Never** present \`sandbox:/\`, workspace paths, or local filesystem links as if they were real user-downloadable files.
-- **Never** say a file was sent unless \`UploadUserFile\` actually succeeded.
 `;
     }
 
@@ -1834,16 +1860,15 @@ Create and show files for any output that helps answer the user's request by usi
 
 ## File Generation & Output
 
+${fileOutputRules}
+
 **When to Create Files:**
-Create and show files for any output that helps answer the user's request by using \`UploadUserFile\` tool:
+Create and show files for any output that helps answer the user's request:
 - **Charts & visualizations**: pie charts, bar graphs, plots, diagrams via \`matplotlib\`
 - **Reports & documents**: analysis reports, summaries, PDFs
 - **Data files**: CSV exports, JSON data, spreadsheets
 - **Code files**: scripts, configurations, examples
 - **Images**: generated images, processed photos, screenshots.
-- If the user asked you to send, share, attach, upload, export, or make a file downloadable, this sequence is required: create the file, call \`UploadUserFile\`, then tell the user it was sent only if the tool succeeds.
-- **Never** present \`sandbox:/\`, workspace paths, or local filesystem links as if they were real user-downloadable files.
-- **Never** say a file was sent unless \`UploadUserFile\` actually succeeded.
 
 ### User-Uploaded Files
 The user has uploaded ${files.length} file(s) for you to analyze:

--- a/packages/worker/src/openclaw/worker.ts
+++ b/packages/worker/src/openclaw/worker.ts
@@ -126,6 +126,19 @@ export function replaceBasePromptIdentity(
   return `${identity}\n\nThe section below describes the runtime tooling available to you. It does not change your role.\n\n${basePrompt}`;
 }
 
+/**
+ * Returns true iff the given URL points at OpenAI's real API host.
+ * Uses URL parsing + exact host match so spoofed hosts like
+ * `https://api.openai.com.evil.example/v1` are not mistaken for real OpenAI.
+ */
+function isRealOpenAIBaseUrl(baseUrl: string): boolean {
+  try {
+    return new URL(baseUrl).host.toLowerCase() === "api.openai.com";
+  } catch {
+    return false;
+  }
+}
+
 function isLikelyImageGenerationRequest(prompt: string): boolean {
   const lower = prompt.toLowerCase();
   const explicitToolInstruction =
@@ -904,10 +917,14 @@ export class OpenClawWorker implements WorkerExecutor {
     // etc.). These reject unknown fields and 400 with "Unknown name 'store'"
     // if pi-ai sends `store: false`. Force it off regardless of whether the
     // model came from the static registry or the dynamic fallback above.
+    //
+    // Host comparison uses URL parsing (not `.startsWith`) so that a baseUrl
+    // like `https://api.openai.com.evil.example/v1` doesn't get mistaken for
+    // real OpenAI. Malformed URLs are treated as third-party (safer default).
     const isThirdPartyOpenAICompat =
       resolvedModel.api === "openai-completions" &&
       typeof resolvedModel.baseUrl === "string" &&
-      !resolvedModel.baseUrl.startsWith("https://api.openai.com");
+      !isRealOpenAIBaseUrl(resolvedModel.baseUrl);
     const model = isThirdPartyOpenAICompat
       ? {
           ...resolvedModel,

--- a/packages/worker/src/shared/tool-implementations.ts
+++ b/packages/worker/src/shared/tool-implementations.ts
@@ -121,6 +121,12 @@ export interface GatewayParams {
   channelId: string;
   conversationId: string;
   platform?: string;
+  /**
+   * Session workspace directory. Relative file paths from the model get
+   * resolved against this (not `process.cwd()`, which is the parent gateway
+   * process's directory, not the per-conversation workspace).
+   */
+  workspaceDir?: string;
 }
 
 // ============================================================================
@@ -201,9 +207,14 @@ export async function uploadUserFile(
       `Show file to user: ${args.file_path}, description: ${args.description || "none"}`
     );
 
+    if (!path.isAbsolute(args.file_path) && !gw.workspaceDir) {
+      return textResult(
+        `Error: Cannot resolve relative file path "${args.file_path}" — workspaceDir not set. This is a wiring bug; pass an absolute path or ensure the worker was started with a workspace.`
+      );
+    }
     const filePath = path.isAbsolute(args.file_path)
       ? args.file_path
-      : path.join(process.cwd(), args.file_path);
+      : path.join(gw.workspaceDir as string, args.file_path);
 
     const stats = await fs.stat(filePath).catch(() => null);
     if (!stats || !stats.isFile()) {

--- a/scripts/test-bot.sh
+++ b/scripts/test-bot.sh
@@ -12,7 +12,10 @@ set -e
 #
 # Platform-specific:
 #   Slack: QA_SLACK_CHANNEL, QA_SLACK_USER_TOKEN (xoxp-) to send as real user,
-#          optional SLACK_BOT_TOKEN for reply polling when user token absent
+#          or QA_SLACK_BOT_TOKEN (xoxb- from a *separate* QA-only Slack app) to
+#          send as a distinct bot — the target bot's isMessageFromSelf filter
+#          only skips its own bot_id, so a different app's bot posts through.
+#          Optional SLACK_BOT_TOKEN for reply polling when QA tokens absent.
 #   WhatsApp: WHATSAPP_SELF_PHONE (defaults to bot's own number for self-chat)
 #   Telegram: TELEGRAM_TEST_CHAT_ID, TG_API_ID, TG_API_HASH (uses tguser to send as real user)
 
@@ -453,26 +456,33 @@ for i in "${!MESSAGES[@]}"; do
         echo "   ℹ️  TG_API_ID/TG_API_HASH not configured; falling back to gateway-side Telegram send"
     fi
 
-    # Slack QA-sender path: QA_SLACK_USER_TOKEN (xoxp-) posts as a real user via
-    # chat.postMessage so the target bot sees a genuine Slack event instead of
-    # a gateway-forged enqueue. A secondary *bot* token doesn't work here —
-    # Slack filters bot_message events cross-app to avoid loops.
-    if [ "$TEST_PLATFORM" = "slack" ] && [ -z "$QA_SLACK_USER_TOKEN" ]; then
-        echo "   ⚠️  QA_SLACK_USER_TOKEN not set — using gateway-forged send."
+    # Slack QA-sender path: post via chat.postMessage so the target bot sees a
+    # genuine Slack event instead of a gateway-forged enqueue.
+    #   - QA_SLACK_USER_TOKEN (xoxp-): posts as a real user.
+    #   - QA_SLACK_BOT_TOKEN  (xoxb-): posts as a *separate* QA bot. The target
+    #     bot's isMessageFromSelf only matches its own bot_id, so cross-app
+    #     bot posts are delivered normally.
+    QA_SEND_TOKEN="${QA_SLACK_USER_TOKEN:-$QA_SLACK_BOT_TOKEN}"
+    if [ "$TEST_PLATFORM" = "slack" ] && [ -z "$QA_SEND_TOKEN" ]; then
+        echo "   ⚠️  No QA Slack token set — using gateway-forged send."
         echo "       The message is queued directly to the worker; nothing"
         echo "       appears in Slack as an inbound message."
-        echo "       To exercise the real webhook flow, install the QA app"
-        echo "       (config/slack-app-manifest.qa-user.json) to mint a xoxp-"
-        echo "       token, then export QA_SLACK_USER_TOKEN=<xoxp-...>."
+        echo "       To exercise the real webhook flow, set either"
+        echo "       QA_SLACK_USER_TOKEN=<xoxp-...> or QA_SLACK_BOT_TOKEN=<xoxb-...>"
+        echo "       (the latter must come from a *separate* Slack app)."
     fi
-    if [ "$TEST_PLATFORM" = "slack" ] && [ -n "$QA_SLACK_USER_TOKEN" ]; then
-        echo "   ✅ Sending via Slack user token to $CHANNEL"
+    if [ "$TEST_PLATFORM" = "slack" ] && [ -n "$QA_SEND_TOKEN" ]; then
+        if [ -n "$QA_SLACK_USER_TOKEN" ]; then
+            echo "   ✅ Sending via QA user token to $CHANNEL"
+        else
+            echo "   ✅ Sending via QA bot token to $CHANNEL"
+        fi
         POST_BODY="channel=$CHANNEL&text=$(printf '%s' "$MESSAGE" | jq -sRr @uri)"
         if [ -n "$LAST_THREAD_ID" ]; then
             POST_BODY="$POST_BODY&thread_ts=$LAST_THREAD_ID"
         fi
         POST_RESP=$(curl -s -X POST https://slack.com/api/chat.postMessage \
-            -H "Authorization: Bearer $QA_SLACK_USER_TOKEN" \
+            -H "Authorization: Bearer $QA_SEND_TOKEN" \
             -H "Content-Type: application/x-www-form-urlencoded" \
             -d "$POST_BODY")
         if ! echo "$POST_RESP" | jq -e '.ok' > /dev/null 2>&1; then
@@ -486,7 +496,7 @@ for i in "${!MESSAGES[@]}"; do
             LAST_THREAD_ID="$MESSAGE_ID"
         fi
 
-        POLL_TOKEN="${SLACK_BOT_TOKEN:-$QA_SLACK_USER_TOKEN}"
+        POLL_TOKEN="${SLACK_BOT_TOKEN:-$QA_SEND_TOKEN}"
         echo "   ⏳ Waiting for bot response..."
         START_TIME=$(date +%s)
         while true; do


### PR DESCRIPTION
## Summary

Bundle of fixes uncovered while running the careops example end-to-end on a cost-optimised model (Gemini 2.5 Flash via the Google AI Studio OpenAI-compat endpoint). Each fix stands alone; they're landing together because they were discovered and validated as one QA pass.

- `refactor(worker)` — drop unused `setupWorkspaceEnv`, pass `workspaceDir` into the embedded bash bootstrap explicitly.
- `fix(gateway)` — skip the fallback `"Error: …"` post when the worker already delivered a full-replacement failure message (fixes duplicate error text like `❌ Session failed: … / Error: …`).
- `fix(worker)` — detect delivery-phrase sandbox leaks (`"located at …/app/workspaces/…"`); the previous rule only caught the `sandbox:/` scheme.
- `fix(worker)` — (a) force `compat.supportsStore=false` on any `openai-completions` model whose baseUrl isn't real OpenAI, so Gemini/Nvidia/Together/z.ai don't 400 with `Unknown name 'store'`; (b) resolve `UploadUserFile` relative paths against the per-conversation `workspaceDir` instead of `process.cwd()`.
- `chore(careops)` — flip the example agent to Gemini, let `test-bot.sh` accept `QA_SLACK_BOT_TOKEN` from a separate QA Slack app.

## Test plan

- [x] `make build-packages` green (all three TS packages)
- [x] `bun test` for affected suites:
  - `packages/worker/src/__tests__/custom-tools.test.ts` (workspaceDir is now required at the `createOpenClawCustomTools` boundary; test passes the per-test temp dir)
  - `packages/worker/src/__tests__/sandbox-leak.test.ts` (new coverage for the delivery-phrase detector)
  - `packages/gateway/src/__tests__/chat-response-bridge.test.ts` (three new cases: fallback after partial stream, suppression after full-replacement, and early-crash fallback with no prior delta)
- [x] End-to-end Slack QA on careops/Gemini 2.5 Flash — all three scenarios pass:
  1. `ping — are you there?` → natural reply
  2. `list exactly 3 common appointment types` → correct bullet list, no narration duplication
  3. `create a sample patient.json … and upload it` → file delivered via artifact URL with no sandbox path leakage
- [ ] Reviewer: sanity-check that no static-registry model whose `baseUrl` happens to be `https://api.openai.com/...` with extra path segments gets mis-classified (current check is `startsWith("https://api.openai.com")`, which is deliberately narrow).

## Notes for reviewers

- The five commits map 1:1 to the five logical changes above — prefer reviewing per commit rather than as a single diff.
- The `compat.supportsStore=false` defensive normalization is deliberately applied post-model-resolution so it covers both the static-registry path and the dynamic-entry path; if/when Gemini lands in pi-ai's static registry with the right flags, this is a no-op.
- `UploadUserFile` now errors clearly if a relative path is passed without a `workspaceDir` instead of silently looking in `process.cwd()`. The only production caller is `createOpenClawCustomTools`, which is type-required to supply it.