### PR TITLE
fix(landing): refine Owletto memory section copy

### DIFF
--- a/packages/landing/src/components/MemorySection.tsx
+++ b/packages/landing/src/components/MemorySection.tsx
@@ -70,7 +70,7 @@ export function MemorySection(props: {
           }
           description={
             props.heroCopy?.description ??
-            "Owletto gives every Lobu use case the same durable graph: connectors, recall, and managed auth without leaking credentials to the runtime."
+            "Owletto gives all your agents the same durable graph: connectors, recall, and managed auth without leaking credentials to the runtime."
           }
           prompt={getMemoryPrompt(activeUseCase)}
           startTitle={props.heroCopy?.startTitle ?? "Start Owletto in seconds"}

--- a/packages/landing/src/use-case-showcases.ts
+++ b/packages/landing/src/use-case-showcases.ts
@@ -2786,10 +2786,10 @@ const surfaceHeroCopy: Record<SurfaceId, SurfaceHeroCopyConfig> = {
   },
   memory: {
     default: {
-      title: "Turn data into shared, structured memory",
-      highlight: "structured memory",
+      title: "Build long-term collective memory",
+      highlight: "collective memory",
       description:
-        "Owletto gives every Lobu use case the same durable graph: connectors, recall, and managed auth without leaking credentials to the runtime.",
+        "Owletto gives all your agents the same durable graph: connectors, recall, and managed auth without leaking credentials to the runtime.",
       startTitle: "Start Owletto in seconds",
     },
     byUseCase: {


### PR DESCRIPTION
## Summary
- Update Owletto memory section hero copy from "every Lobu use case" to "all your agents"
- Rename default memory title to "Build long-term collective memory" with updated highlight

## Test plan
- [ ] `cd packages/landing && bun run build` succeeds
- [ ] Visually verify memory section on landing renders updated copy