### PR TITLE
chore(dev): simplify compose DEPLOYMENT_MODE and opt-in OpenAI for careops

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -35,9 +35,10 @@ services:
       dockerfile: docker/Dockerfile.gateway
     image: lobu-gateway:latest
     environment:
-      # Docker context overrides (gateway loads mounted .env file via dotenv)
+      # Docker context overrides (gateway loads mounted .env file via dotenv).
+      # DEPLOYMENT_MODE is read from the mounted .env so operators can pick
+      # embedded vs docker without exporting shell vars.
       NODE_ENV: development
-      DEPLOYMENT_MODE: ${DEPLOYMENT_MODE:-docker}
       QUEUE_URL: redis://redis:6379
       # Host project path for worker bind mounts (Docker-in-Docker)
       LOBU_DEV_PROJECT_PATH: ${PWD}

--- a/examples/careops/lobu.toml
+++ b/examples/careops/lobu.toml
@@ -13,6 +13,13 @@ id = "gemini"
 model = "gemini/gemini-2.5-flash"
 key = "$GEMINI_API_KEY"
 
+# Secondary: OpenAI — only used by the built-in GenerateImage tool
+# (gpt-image-1). Gemini handles all chat/tool-use; OpenAI is opt-in
+# for image generation. Leave $OPENAI_API_KEY unset to disable.
+[[agents.careops.providers]]
+id = "openai"
+key = "$OPENAI_API_KEY"
+
 # Alternative providers — swap one of these in if you prefer.
 # [[agents.careops.providers]]
 # id = "openrouter"


### PR DESCRIPTION
## Summary

Two small, independent dev-config tweaks that were sitting in my working tree — splitting them out from the auth refactor so each can land on its own.

- **`docker/docker-compose.yml`**: drop the inline \`DEPLOYMENT_MODE: \${DEPLOYMENT_MODE:-docker}\` shell-var override. The gateway already reads \`DEPLOYMENT_MODE\` from the mounted \`.env\` via \`dotenv\`, so the compose-level override was a redundant second source that silently masked the \`.env\` value unless you also exported it in your shell. Comment refreshed to explain the \`.env\`-only contract.
- **`examples/careops/lobu.toml`**: add an opt-in OpenAI provider entry. The built-in \`GenerateImage\` tool uses \`gpt-image-1\`, so exposing an OpenAI provider lets careops generate images when \`\$OPENAI_API_KEY\` is set, while Gemini remains primary for chat/tool-use. Leaving \`\$OPENAI_API_KEY\` unset keeps the previous behavior.

## Test plan

- [ ] \`make dev\` with \`DEPLOYMENT_MODE=embedded\` in \`.env\` → gateway picks up embedded mode (was previously forced to \`docker\` unless shell-exported).
- [ ] \`lobu chat\` against careops with \`\$OPENAI_API_KEY\` set → \`GenerateImage\` works.
- [ ] Same chat with \`\$OPENAI_API_KEY\` unset → \`GenerateImage\` fails gracefully, chat/tool-use still works via Gemini.