### PR TITLE
fix(docker): name owletto-cli stub package as 'owletto' (unscoped)

### DIFF
--- a/docker/app/Dockerfile
+++ b/docker/app/Dockerfile
@@ -37,9 +37,10 @@ COPY packages/owletto-web/package.jso[n] packages/owletto-web/
 # Stub out workspace packages we don't build in this image so bun install doesn't
 # error on missing manifests.
 RUN mkdir -p packages/cli packages/cli-core packages/landing packages/owletto-cli packages/owletto-extension packages/mcpsandbox \
-    && for p in cli cli-core landing owletto-cli owletto-extension mcpsandbox; do \
+    && for p in cli cli-core landing owletto-extension mcpsandbox; do \
         echo "{\"name\":\"@lobu/$p\",\"version\":\"0.0.0\",\"private\":true}" > "packages/$p/package.json"; \
-      done
+      done \
+    && echo '{"name":"owletto","version":"0.0.0","private":true}' > packages/owletto-cli/package.json
 
 RUN --mount=type=cache,target=/root/.bun/install/cache bun install
 

--- a/docker/embeddings-service/Dockerfile
+++ b/docker/embeddings-service/Dockerfile
@@ -23,10 +23,11 @@ RUN mkdir -p packages/cli packages/cli-core packages/core packages/gateway packa
                packages/owletto-backend packages/owletto-cli packages/owletto-connectors \
                packages/owletto-extension packages/owletto-openclaw packages/owletto-sdk \
                packages/owletto-web packages/owletto-worker packages/worker packages/mcpsandbox \
-    && for p in cli cli-core core gateway landing owletto-backend owletto-cli owletto-connectors \
+    && for p in cli cli-core core gateway landing owletto-backend owletto-connectors \
                 owletto-extension owletto-openclaw owletto-sdk owletto-web owletto-worker worker mcpsandbox; do \
         echo "{\"name\":\"@lobu/$p\",\"version\":\"0.0.0\",\"private\":true}" > "packages/$p/package.json"; \
-      done
+      done \
+    && echo '{"name":"owletto","version":"0.0.0","private":true}' > packages/owletto-cli/package.json
 
 RUN --mount=type=cache,target=/root/.bun/install/cache bun install
 

--- a/docker/worker/Dockerfile
+++ b/docker/worker/Dockerfile
@@ -29,10 +29,11 @@ COPY packages/owletto-embeddings/package.json packages/owletto-embeddings/
 RUN mkdir -p packages/cli packages/cli-core packages/core packages/gateway packages/landing \
                packages/owletto-backend packages/owletto-cli packages/owletto-extension \
                packages/owletto-openclaw packages/owletto-web packages/worker packages/mcpsandbox \
-    && for p in cli cli-core core gateway landing owletto-backend owletto-cli \
+    && for p in cli cli-core core gateway landing owletto-backend \
                 owletto-extension owletto-openclaw owletto-web worker mcpsandbox; do \
         echo "{\"name\":\"@lobu/$p\",\"version\":\"0.0.0\",\"private\":true}" > "packages/$p/package.json"; \
-      done
+      done \
+    && echo '{"name":"owletto","version":"0.0.0","private":true}' > packages/owletto-cli/package.json
 
 RUN --mount=type=cache,target=/root/.bun/install/cache bun install
 


### PR DESCRIPTION
packages/owletto-cli ships as the unscoped `owletto` npm package. The Docker stubs in build-images.yml previously named it `@lobu/owletto-cli`, so `owletto@workspace:*` (depended on by packages/worker) failed to resolve during `bun install`. All three jobs (build-app, build-worker, build-embeddings-service) failed on every push to main since PR #212 merged.

Stub it under the correct unscoped name.