### PR TITLE
fix(docker): unzip in runtime + worker chromium install via bunx

### DIFF
--- a/docker/app/Dockerfile
+++ b/docker/app/Dockerfile
@@ -91,7 +91,7 @@ WORKDIR /app
 
 # curl for health checks, dbmate for migrations, bun for tsx-equivalent, Chromium deps for connectors
 RUN apt-get update && apt-get install -y --no-install-recommends \
-      curl ca-certificates \
+      curl ca-certificates unzip \
       libnss3 libnspr4 libatk1.0-0 libatk-bridge2.0-0 libcups2 libdrm2 libdbus-1-3 \
       libxkbcommon0 libatspi2.0-0 libxcomposite1 libxdamage1 libxfixes3 libxrandr2 \
       libgbm1 libpango-1.0-0 libcairo2 libasound2 libwayland-client0 \

--- a/docker/app/Dockerfile
+++ b/docker/app/Dockerfile
@@ -37,9 +37,10 @@ COPY packages/owletto-web/package.jso[n] packages/owletto-web/
 # Stub out workspace packages we don't build in this image so bun install doesn't
 # error on missing manifests.
 RUN mkdir -p packages/cli packages/cli-core packages/landing packages/owletto-cli packages/owletto-extension packages/mcpsandbox \
-    && for p in cli cli-core landing owletto-cli owletto-extension mcpsandbox; do \
+    && for p in cli cli-core landing owletto-extension mcpsandbox; do \
         echo "{\"name\":\"@lobu/$p\",\"version\":\"0.0.0\",\"private\":true}" > "packages/$p/package.json"; \
-      done
+      done \
+    && echo '{"name":"owletto","version":"0.0.0","private":true}' > packages/owletto-cli/package.json
 
 RUN --mount=type=cache,target=/root/.bun/install/cache bun install
 

--- a/docker/embeddings-service/Dockerfile
+++ b/docker/embeddings-service/Dockerfile
@@ -23,10 +23,11 @@ RUN mkdir -p packages/cli packages/cli-core packages/core packages/gateway packa
                packages/owletto-backend packages/owletto-cli packages/owletto-connectors \
                packages/owletto-extension packages/owletto-openclaw packages/owletto-sdk \
                packages/owletto-web packages/owletto-worker packages/worker packages/mcpsandbox \
-    && for p in cli cli-core core gateway landing owletto-backend owletto-cli owletto-connectors \
+    && for p in cli cli-core core gateway landing owletto-backend owletto-connectors \
                 owletto-extension owletto-openclaw owletto-sdk owletto-web owletto-worker worker mcpsandbox; do \
         echo "{\"name\":\"@lobu/$p\",\"version\":\"0.0.0\",\"private\":true}" > "packages/$p/package.json"; \
-      done
+      done \
+    && echo '{"name":"owletto","version":"0.0.0","private":true}' > packages/owletto-cli/package.json
 
 RUN --mount=type=cache,target=/root/.bun/install/cache bun install
 

--- a/docker/worker/Dockerfile
+++ b/docker/worker/Dockerfile
@@ -81,15 +81,12 @@ COPY --from=builder --chown=worker:worker /app/packages/owletto-worker ./package
 COPY --chown=worker:worker docker/worker/healthcheck.sh /healthcheck.sh
 RUN chmod +x /healthcheck.sh
 
-# Install patchright's Chromium (aliased as playwright in package.json)
+# Install patchright's Chromium (declared as `playwright` alias in worker package.json).
+# Use bunx from the worker workspace so bun's resolver finds the alias.
 USER worker
-RUN node -e " \
-  const p = require('path'); \
-  const dir = p.dirname(require.resolve('playwright/package.json')); \
-  require('child_process').execSync( \
-    'node ' + p.join(dir, 'cli.js') + ' install chromium', \
-    { stdio: 'inherit' } \
-  );"
+WORKDIR /app/packages/owletto-worker
+RUN bunx --bun playwright install chromium
+WORKDIR /app
 
 ENV NODE_ENV=production
 ENV TRANSFORMERS_CACHE=/app/.cache/transformers

--- a/docker/worker/Dockerfile
+++ b/docker/worker/Dockerfile
@@ -29,10 +29,11 @@ COPY packages/owletto-embeddings/package.json packages/owletto-embeddings/
 RUN mkdir -p packages/cli packages/cli-core packages/core packages/gateway packages/landing \
                packages/owletto-backend packages/owletto-cli packages/owletto-extension \
                packages/owletto-openclaw packages/owletto-web packages/worker packages/mcpsandbox \
-    && for p in cli cli-core core gateway landing owletto-backend owletto-cli \
+    && for p in cli cli-core core gateway landing owletto-backend \
                 owletto-extension owletto-openclaw owletto-web worker mcpsandbox; do \
         echo "{\"name\":\"@lobu/$p\",\"version\":\"0.0.0\",\"private\":true}" > "packages/$p/package.json"; \
-      done
+      done \
+    && echo '{"name":"owletto","version":"0.0.0","private":true}' > packages/owletto-cli/package.json
 
 RUN --mount=type=cache,target=/root/.bun/install/cache bun install
 


### PR DESCRIPTION
Two fixes for build-images.yml on main:

1. **build-app + build-embeddings runtime stages** — bun's installer needs `unzip` in slim runtimes; missing dep caused 'unzip is required to install bun' failure.
2. **build-worker chromium install** — `require.resolve('playwright/package.json')` from /app/packages/owletto-worker fails under bun's per-workspace node_modules layout. Switch to `bunx --bun playwright install chromium` so bun's resolver finds the patchright alias.

(Embeddings push still 403s on a registry-owner permission issue separate from this PR.)