### PR TITLE
fix(owletto-backend): resolve typecheck errors blocking build-images

### DIFF
--- a/packages/core/src/agent-store.ts
+++ b/packages/core/src/agent-store.ts
@@ -8,6 +8,7 @@
 
 import type { PluginsConfig } from "./plugin-types";
 import type {
+  AuthProfile,
   InstalledProvider,
   McpServerConfig,
   ModelSelectionState,
@@ -52,6 +53,12 @@ export interface AgentSettings {
   toolsConfig?: ToolsConfig;
   /** OpenClaw plugin configuration */
   pluginsConfig?: PluginsConfig;
+  /**
+   * Reusable auth profiles persisted by host stores (e.g. Owletto's Postgres
+   * store). Lobu's gateway runtime uses UserAuthProfileStore instead, but the
+   * host's settings JSON column still round-trips this list.
+   */
+  authProfiles?: AuthProfile[];
   /** Installed providers for this agent (index 0 = primary). */
   installedProviders?: InstalledProvider[];
   /** Enable verbose logging (show tool calls, reasoning, etc.) */

--- a/packages/owletto-backend/src/__tests__/unit/connectors/linkedin.test.ts
+++ b/packages/owletto-backend/src/__tests__/unit/connectors/linkedin.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { filterPostsSinceCheckpoint } from '../../../../connectors/linkedin';
+import { filterPostsSinceCheckpoint } from '../../../../../owletto-connectors/src/linkedin';
 
 describe('LinkedIn checkpoint filtering', () => {
   it('drops posts at or before the saved timestamp', () => {

--- a/packages/owletto-backend/src/auth/index.ts
+++ b/packages/owletto-backend/src/auth/index.ts
@@ -138,7 +138,7 @@ export async function createAuth(env: Env, request?: Request) {
   }
 
   const auth = betterAuth({
-    secret: env.BETTER_AUTH_SECRET,
+    ...(env.BETTER_AUTH_SECRET ? { secret: env.BETTER_AUTH_SECRET } : {}),
     database: pool,
     baseURL: resolveBaseUrl({ request }),
     basePath: '/api/auth',
@@ -511,6 +511,9 @@ export async function createAuth(env: Env, request?: Request) {
 
     trustedOrigins: Array.from(trustedOriginSet),
   });
-  authCache.set(cacheKey, auth);
+  // betterAuth's inferred return narrows generics per call site (socialProviders
+  // shape, required-vs-optional database/secret); the cache stores the general
+  // Auth<BetterAuthOptions> shape, so widen via unknown.
+  authCache.set(cacheKey, auth as unknown as ReturnType<typeof betterAuth>);
   return auth;
 }

--- a/packages/owletto-backend/src/auth/routes.ts
+++ b/packages/owletto-backend/src/auth/routes.ts
@@ -87,7 +87,7 @@ credentialRoutes.post('/credentials', requireAuth, async (c) => {
  */
 credentialRoutes.patch('/credentials/:id', requireAuth, async (c) => {
   const user = getAuthenticatedUser(c);
-  const credentialId = parseInt(c.req.param('id'), 10);
+  const credentialId = parseInt(c.req.param('id') ?? '', 10);
   if (Number.isNaN(credentialId)) {
     return c.json({ error: 'Invalid credential ID' }, 400);
   }
@@ -124,7 +124,7 @@ credentialRoutes.patch('/credentials/:id', requireAuth, async (c) => {
  */
 credentialRoutes.delete('/credentials/:id', requireAuth, async (c) => {
   const user = getAuthenticatedUser(c);
-  const credentialId = parseInt(c.req.param('id'), 10);
+  const credentialId = parseInt(c.req.param('id') ?? '', 10);
   if (Number.isNaN(credentialId)) {
     return c.json({ error: 'Invalid credential ID' }, 400);
   }
@@ -259,7 +259,7 @@ credentialRoutes.post('/tokens', requireAuth, async (c) => {
  */
 credentialRoutes.get('/tokens/:id', requireAuth, async (c) => {
   const user = getAuthenticatedUser(c);
-  const tokenId = parseInt(c.req.param('id'), 10);
+  const tokenId = parseInt(c.req.param('id') ?? '', 10);
   if (Number.isNaN(tokenId)) {
     return c.json({ error: 'Invalid token ID' }, 400);
   }
@@ -280,7 +280,7 @@ credentialRoutes.get('/tokens/:id', requireAuth, async (c) => {
  */
 credentialRoutes.patch('/tokens/:id', requireAuth, async (c) => {
   const user = getAuthenticatedUser(c);
-  const tokenId = parseInt(c.req.param('id'), 10);
+  const tokenId = parseInt(c.req.param('id') ?? '', 10);
   if (Number.isNaN(tokenId)) {
     return c.json({ error: 'Invalid token ID' }, 400);
   }
@@ -310,7 +310,7 @@ credentialRoutes.patch('/tokens/:id', requireAuth, async (c) => {
  */
 credentialRoutes.delete('/tokens/:id', requireAuth, async (c) => {
   const user = getAuthenticatedUser(c);
-  const tokenId = parseInt(c.req.param('id'), 10);
+  const tokenId = parseInt(c.req.param('id') ?? '', 10);
   if (Number.isNaN(tokenId)) {
     return c.json({ error: 'Invalid token ID' }, 400);
   }

--- a/packages/owletto-backend/src/index.ts
+++ b/packages/owletto-backend/src/index.ts
@@ -212,7 +212,11 @@ async function serveStaticFile(c: Context<{ Bindings: Env }>, filePath: string) 
     'Cache-Control',
     isHtml ? 'no-cache, no-store, must-revalidate' : 'public, max-age=31536000, immutable'
   );
-  return c.body(body);
+  // Hono's Data type expects Uint8Array<ArrayBuffer>; copy into a fresh
+  // ArrayBuffer since fs.readFile returns Buffer<ArrayBufferLike>.
+  const ab = new ArrayBuffer(body.byteLength);
+  new Uint8Array(ab).set(body);
+  return c.body(new Uint8Array(ab));
 }
 
 const app = new Hono<{ Bindings: Env }>();

--- a/packages/owletto-backend/src/lib/feed-sync.ts
+++ b/packages/owletto-backend/src/lib/feed-sync.ts
@@ -4,7 +4,7 @@
  * Extracted from scripts/sync-local.ts for programmatic reuse.
  */
 
-import { executeCompiledConnector } from '../../packages/worker/src/executor/runtime';
+import { executeCompiledConnector } from '../../../owletto-worker/src/executor/runtime';
 import { getDb } from '../db/client';
 import { resolveConnectorCode } from '../utils/ensure-connector-installed';
 import { mergeExecutionConfig, resolveExecutionAuth } from '../utils/execution-context';

--- a/packages/owletto-backend/src/lobu/client-routes.ts
+++ b/packages/owletto-backend/src/lobu/client-routes.ts
@@ -552,6 +552,9 @@ routes.delete('/mcp/:clientId', mcpAuth, async (c) => {
   return withOrg(c, async () => {
     const organizationId = c.get('organizationId') as string;
     const clientId = c.req.param('clientId');
+    if (!clientId) {
+      return c.json({ error: 'Client ID is required' }, 400);
+    }
     const sql = getDb();
 
     const rows = await sql`

--- a/packages/owletto-backend/src/rest-api.ts
+++ b/packages/owletto-backend/src/rest-api.ts
@@ -83,6 +83,9 @@ async function withPublicOrg<T>(
 ): Promise<Response> {
   try {
     const orgSlug = c.req.param('orgSlug');
+    if (!orgSlug) {
+      return c.json({ error: 'Organization slug is required' }, 400);
+    }
     const organizationId = await resolvePublicOrganizationId(orgSlug);
     if (!organizationId) {
       return c.json({ error: 'Not found' }, 404);
@@ -214,6 +217,9 @@ export async function restToolProxy(
 ) {
   try {
     const toolName = explicitToolName ?? c.req.param('toolName');
+    if (!toolName) {
+      return c.json({ error: 'Tool name is required' }, 400);
+    }
     const args: Record<string, unknown> = explicitArgs ?? (await c.req.json());
     const authCtx = extractAuthContext(c);
     const result = await executeTool(toolName, args, c.env, authCtx);
@@ -405,6 +411,9 @@ export async function publicRestGetConnector(c: Context<{ Bindings: Env }>) {
   return withPublicOrg(c, async (organizationId) => {
     const sql = getDb();
     const connectorKey = c.req.param('connectorKey');
+    if (!connectorKey) {
+      throw new Error('Connector key is required');
+    }
 
     const connector = await getScopedConnectorDefinition({
       organizationId,
@@ -483,7 +492,7 @@ export async function publicRestGetConnector(c: Context<{ Bindings: Env }>) {
  */
 export async function restUpdateContentClassification(c: Context<{ Bindings: Env }>) {
   try {
-    const contentId = parseInt(c.req.param('id'), 10);
+    const contentId = parseInt(c.req.param('id') ?? '', 10);
     const classifierSlug = c.req.param('classifier_slug');
     const body = await c.req.json<{ value: string | null }>();
 

--- a/packages/owletto-backend/src/tools/admin/manage_operations.ts
+++ b/packages/owletto-backend/src/tools/admin/manage_operations.ts
@@ -198,7 +198,7 @@ async function executeLocalActionInline(
 
   try {
     const { executeCompiledConnector, getActionOutput } = await import(
-      '../../../packages/worker/src/executor/runtime'
+      '../../../../owletto-worker/src/executor/runtime'
     );
     const result = await executeCompiledConnector({
       mode: 'action',

--- a/packages/owletto-backend/src/utils/__tests__/mcp-install-targets.test.ts
+++ b/packages/owletto-backend/src/utils/__tests__/mcp-install-targets.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { getMcpInstallTargets } from '../../../packages/web/src/lib/mcp-install-targets';
+import { getMcpInstallTargets } from '../../../../owletto-web/src/lib/mcp-install-targets';
 
 describe('getMcpInstallTargets', () => {
   const mcpUrl = 'http://localhost:4821/mcp/public-owletto';


### PR DESCRIPTION
## Summary

After the owletto monorepo merge in #212/#214, the `build-app` step in `build-images.yml` fails on `bun run typecheck` because of three classes of drift between upstream owletto's lockfile and lobu's:

- **Hono 4.10 → 4.12.14** narrowed `c.req.param('id')` to `string | undefined`. Guard `parseInt` with `?? ''` so the existing NaN check still rejects, and add early-return guards where the param flows into a typed call (`orgSlug`, `toolName`, `connectorKey`, `clientId`).
- **better-auth 1.4 → 1.6.5** tightened `BetterAuthOptions.secret` (now `string | undefined` is no longer assignable to optional `string?`). Conditionally spread `secret` only when defined; widen the per-call inferred return through `unknown` when caching as the general `Auth<BetterAuthOptions>`.
- **Hono `c.body`** Data type now `Uint8Array<ArrayBuffer>`, but `fs.readFile` returns `Buffer<ArrayBufferLike>`. Copy into a fresh `ArrayBuffer`.

Also fixes 4 broken relative imports in owletto-backend that still pointed at the pre-merge `../../packages/{web,worker}` and `../../connectors` layout instead of the new `packages/owletto-{web,worker,connectors}` paths.

Re-adds `AgentSettings.authProfiles` in `@lobu/core` (removed in #207). Lobu's gateway runtime uses `UserAuthProfileStore`, but owletto-backend's Postgres agent-config store still round-trips this column — the field is persistence-layer only.

## Test plan

- [x] `bun run typecheck` clean across the repo
- [x] `make build-packages` green
- [x] `bunx vitest run` for the path-fix tests (`mcp-install-targets`, `linkedin`) — 5/5 passing
- [ ] `build-images.yml` succeeds for build-app (the original failure surface)