### PR TITLE
fix(docker): build gateway dist + exclude tests from backend typecheck

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -219,6 +219,7 @@
       "version": "1.6.0",
       "dependencies": {
         "@lobu/owletto-sdk": "workspace:*",
+        "playwright": "npm:patchright@^1.57.0",
       },
     },
     "packages/owletto-embeddings": {

--- a/docker/app/Dockerfile
+++ b/docker/app/Dockerfile
@@ -64,13 +64,15 @@ COPY packages/owletto-backend/ packages/owletto-backend/
 # Copy the private frontend submodule when present.
 COPY packages/owletto-web packages/owletto-web
 
-# Build core + SDK dist (runtime imports from dist)
+# Build dist for packages whose `exports` map points at dist subpaths.
+# owletto-backend imports `@lobu/gateway/dist/connections` and
+# `@lobu/gateway/dist/api`, so gateway must be built before typechecking.
 RUN cd packages/core && bunx tsc
 RUN cd packages/owletto-sdk && bunx tsc
+RUN cd packages/gateway && bunx tsc
 
 # Type check
-ARG SKIP_TSC=false
-RUN if [ "$SKIP_TSC" = "false" ]; then cd packages/owletto-backend && bunx tsc --noEmit; fi
+RUN cd packages/owletto-backend && bunx tsc --noEmit
 
 # Build frontend static assets (production only)
 ARG VITE_API_URL=

--- a/packages/owletto-backend/tsconfig.json
+++ b/packages/owletto-backend/tsconfig.json
@@ -40,8 +40,6 @@
   "exclude": [
     "node_modules",
     "dist",
-    "src/utils/__tests__/owletto-guidance-sync.test.ts",
-    "src/__tests__/integration/events/content-distribution.test.ts",
-    "src/__tests__/integration/cli"
+    "src/**/__tests__/**"
   ]
 }

--- a/packages/owletto-connectors/package.json
+++ b/packages/owletto-connectors/package.json
@@ -10,6 +10,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@lobu/owletto-sdk": "workspace:*"
+    "@lobu/owletto-sdk": "workspace:*",
+    "playwright": "npm:patchright@^1.57.0"
   }
 }


### PR DESCRIPTION
## Summary

Follow-up to #218. The build-images.yml `build-app` step still fails inside Docker even after the source-level typecheck fixes — three remaining root causes:

1. **`@lobu/gateway` dist wasn't built before typecheck.** owletto-backend imports `@lobu/gateway/dist/connections` and `@lobu/gateway/dist/api` (subpaths declared in gateway's `exports` map). Add a gateway tsc build alongside the existing core + sdk dist builds.

2. **Tests depend on the private `owletto-web` submodule.** `mcp-install-targets.test.ts` imports from `owletto-web`, which isn't available without `OWLETTO_WEB_DEPLOY_KEY` (not currently set on `lobu-ai/lobu` — forks and build-images runs always fail). Production typecheck shouldn't depend on test files — vitest runs them separately. Exclude `src/**/__tests__/**` from owletto-backend's tsconfig.

3. **`owletto-connectors` imports `playwright` types** without declaring the dep, relying on hoisting from `owletto-worker` / `owletto-sdk` / `owletto-cli`. Declare it directly so Docker installs (which stub `owletto-cli`) still resolve it.

Also dropped the `SKIP_TSC` build-arg — the typecheck step is a hard requirement again, no escape hatch.

## Test plan

- [x] `bun run typecheck` clean
- [x] `make build-packages` green
- [ ] `build-images.yml` `build-app` succeeds (the original failure surface)

## Out of scope

- `build-worker` and `build-embeddings` GHCR `403 Forbidden` push errors — the `ghcr.io/lobu-ai/owletto-{worker,embeddings}` packages were originally created from the old owletto repo and need write-access added for `lobu-ai/lobu` in the GitHub Packages UI. Manual ops fix.