### PR TITLE
fix(gateway): isolate tsconfig from root bun-types

### DIFF
--- a/docker/app/Dockerfile
+++ b/docker/app/Dockerfile
@@ -67,11 +67,12 @@ COPY packages/owletto-web packages/owletto-web
 # Build dist for packages whose `exports` map points at dist subpaths.
 # owletto-backend imports `@lobu/gateway/dist/connections` and
 # `@lobu/gateway/dist/api`, so gateway must be built before typechecking.
-# Use `tsc -b` (build mode) for gateway so it transitively builds its
-# `composite: true` reference (core) in dependency order with a coherent
-# tsbuildinfo. owletto-sdk has no references so a plain tsc is fine.
-RUN cd packages/owletto-sdk && bunx tsc \
-    && cd ../gateway && bunx tsc -b
+# Build everything in a single RUN for consistent file mtimes (composite
+# project references are mtime-sensitive). Use `tsc -b` from gateway so
+# it walks the reference graph (gateway → core) in dependency order.
+RUN cd packages/core && bunx tsc \
+    && cd ../owletto-sdk && bunx tsc \
+    && cd ../gateway && bunx tsc -b --force
 
 # Type check
 RUN cd packages/owletto-backend && bunx tsc --noEmit

--- a/docker/app/Dockerfile
+++ b/docker/app/Dockerfile
@@ -67,9 +67,11 @@ COPY packages/owletto-web packages/owletto-web
 # Build dist for packages whose `exports` map points at dist subpaths.
 # owletto-backend imports `@lobu/gateway/dist/connections` and
 # `@lobu/gateway/dist/api`, so gateway must be built before typechecking.
-RUN cd packages/core && bunx tsc
-RUN cd packages/owletto-sdk && bunx tsc
-RUN cd packages/gateway && bunx tsc
+# Use `tsc -b` (build mode) for gateway so it transitively builds its
+# `composite: true` reference (core) in dependency order with a coherent
+# tsbuildinfo. owletto-sdk has no references so a plain tsc is fine.
+RUN cd packages/owletto-sdk && bunx tsc \
+    && cd ../gateway && bunx tsc -b
 
 # Type check
 RUN cd packages/owletto-backend && bunx tsc --noEmit

--- a/packages/gateway/src/proxy/token-refresh-job.ts
+++ b/packages/gateway/src/proxy/token-refresh-job.ts
@@ -21,7 +21,7 @@ export interface RefreshableProvider {
  * 3. Writes the rotated credentials back through `AuthProfilesManager.upsertProfile`.
  */
 export class TokenRefreshJob {
-  private timer: Timer | null = null;
+  private timer: ReturnType<typeof setInterval> | null = null;
   private refreshLocks = new Map<string, Promise<void>>();
 
   constructor(

--- a/packages/gateway/tsconfig.json
+++ b/packages/gateway/tsconfig.json
@@ -17,7 +17,8 @@
     "skipLibCheck": true,
     "noUnusedLocals": false,
     "noUnusedParameters": false,
-    "composite": true
+    "composite": true,
+    "types": ["node"]
   },
   "include": ["src/**/*", "../core/src/deployment/base-deployment-manager.ts"],
   "exclude": [


### PR DESCRIPTION
## Summary

- Override `types` field in `packages/gateway/tsconfig.json` to `[\"node\"]` so gateway no longer depends on `bun-types` at compile time.
- Replace Bun-global `Timer` with `ReturnType<typeof setInterval>` in `token-refresh-job.ts` so the type resolves under Node type definitions.

## Why

The Docker build of gateway dist (added in #219) was failing with:
\`\`\`
error TS2688: Cannot find type definition file for 'bun-types'.
\`\`\`
Gateway extends the root tsconfig which sets `types: [\"bun-types\"]`. `bun-types` is a transitive dep of `@types/bun` and not reliably surfaced where `bunx tsc` looks during the per-package compile in the Docker builder. Gateway has zero `Bun.*` API usage (verified via grep), so it should not depend on Bun's types at all.

## Test plan

- [x] Local: `make build-packages` builds core/gateway/worker dist cleanly
- [x] Local: `cd packages/gateway && bunx tsc` exits 0 with the new types override
- [ ] CI: `build-images.yml` build-app step succeeds end-to-end