### PR TITLE
fix(docker): use bun run build for owletto-web

### DIFF
--- a/docker/app/Dockerfile
+++ b/docker/app/Dockerfile
@@ -82,7 +82,7 @@ ARG VITE_API_URL=
 ENV VITE_API_URL=$VITE_API_URL
 ARG SKIP_WEB_BUILD=false
 RUN if [ "$SKIP_WEB_BUILD" = "false" ] && [ -f packages/owletto-web/package.json ]; then \
-      cd packages/owletto-web && bunx vite build; \
+      cd packages/owletto-web && bun run build; \
     else \
       mkdir -p /app/packages/owletto-web/dist; \
     fi


### PR DESCRIPTION
build-images was failing at the vite build step with `Cannot resolve entry module index.html` because `bunx vite build` downloaded vite@latest from npm (rolldown-based v6) instead of using the project's local vite. `bun run build` invokes the package script which resolves vite from local node_modules and also runs `tsc -b` first.