### PR TITLE
fix(ci): skip web build when owletto-web is stubbed

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -40,7 +40,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - uses: ./.github/actions/setup-submodule
+      - id: submodule
+        uses: ./.github/actions/setup-submodule
         with:
           deploy-key: ${{ secrets.OWLETTO_WEB_DEPLOY_KEY }}
 
@@ -75,6 +76,7 @@ jobs:
             CACHEBUST=${{ github.sha }}
             APP_GIT_SHA=${{ github.sha }}
             APP_BUILD_TIME=${{ github.event.head_commit.timestamp || github.run_id }}
+            SKIP_WEB_BUILD=${{ steps.submodule.outputs.stubbed == 'true' }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 

--- a/docker/app/Dockerfile
+++ b/docker/app/Dockerfile
@@ -82,7 +82,7 @@ ARG VITE_API_URL=
 ENV VITE_API_URL=$VITE_API_URL
 ARG SKIP_WEB_BUILD=false
 RUN if [ "$SKIP_WEB_BUILD" = "false" ] && [ -f packages/owletto-web/package.json ]; then \
-      cd packages/owletto-web && bunx vite build; \
+      cd packages/owletto-web && bun run build; \
     else \
       mkdir -p /app/packages/owletto-web/dist; \
     fi


### PR DESCRIPTION
OWLETTO_WEB_DEPLOY_KEY isn't set on this repo, so setup-submodule writes a stub package.json without scripts. Wire its 'stubbed' output into the docker build-args as SKIP_WEB_BUILD=true so the build short-circuits to creating an empty dist/ instead of failing on 'Script not found build'.