### PR TITLE
fix(owletto-backend): resolve *.lobu.ai as org subdomain under AUTH_COOKIE_DOMAIN

### DIFF
--- a/packages/owletto-backend/src/index.ts
+++ b/packages/owletto-backend/src/index.ts
@@ -58,7 +58,12 @@ import { entityLinkMatchSql } from './utils/content-search';
 import { errorMessage } from './utils/errors';
 import logger from './utils/logger';
 import { generateOpenAPISpec } from './utils/openapi-generator';
-import { getCanonicalRedirectUrl, getConfiguredPublicOrigin } from './utils/public-origin';
+import {
+  extractSubdomainOrg,
+  getCanonicalRedirectUrl,
+  getConfiguredPublicOrigin,
+  getSubdomainZone,
+} from './utils/public-origin';
 import { getClientIP, getRateLimiter, RateLimitPresets } from './utils/rate-limiter';
 import { getRuntimeInfo } from './utils/runtime-info';
 import { getWorkspaceProvider } from './workspace';
@@ -86,8 +91,16 @@ function isAllowedCorsOrigin(origin: string, _env: Env, requestUrl: string): boo
   if (parsed.origin === canonicalOrigin) return true;
 
   // Allow wildcard subdomains of the canonical origin (e.g. acme.owletto.com)
-  const baseDomain = new URL(canonicalOrigin).hostname;
-  if (parsed.hostname.endsWith(`.${baseDomain}`)) return true;
+  // and — when AUTH_COOKIE_DOMAIN is configured — sibling subdomains under the
+  // cookie zone so browsers on `acme.lobu.ai` can call `app.lobu.ai`.
+  const parsedHost = parsed.hostname.toLowerCase();
+  const baseDomain = new URL(canonicalOrigin).hostname.toLowerCase();
+  if (parsedHost.endsWith(`.${baseDomain}`)) return true;
+
+  const subdomainZone = getSubdomainZone(canonicalOrigin);
+  if (subdomainZone && (parsedHost === subdomainZone || parsedHost.endsWith(`.${subdomainZone}`))) {
+    return true;
+  }
 
   return false;
 }
@@ -280,8 +293,11 @@ app.use('/*', async (c, next) => {
 
 /**
  * Subdomain org extraction middleware
- * Parses Host header for {org}.{baseDomain} pattern and sets subdomainOrg.
- * Reserved subdomains (www, api, app, admin, etc.) are not treated as orgs.
+ * Parses Host header for {org}.{zone} pattern and sets subdomainOrg.
+ * The zone is AUTH_COOKIE_DOMAIN when set (so per-org hosts like `acme.lobu.ai`
+ * resolve even though PUBLIC_WEB_URL is `app.lobu.ai`), otherwise the
+ * PUBLIC_WEB_URL hostname. Reserved subdomains (www, api, app, admin, etc.)
+ * are not treated as orgs.
  */
 const RESERVED_SUBDOMAINS = new Set([
   'www',
@@ -298,22 +314,9 @@ const RESERVED_SUBDOMAINS = new Set([
 ]);
 
 app.use('/*', async (c, next) => {
-  c.set('subdomainOrg', null);
-  const baseUrlValue = getConfiguredPublicOrigin();
-  if (baseUrlValue) {
-    try {
-      const baseDomain = new URL(baseUrlValue).hostname;
-      const host = c.req.header('host')?.split(':')[0];
-      if (host?.endsWith(`.${baseDomain}`)) {
-        const sub = host.slice(0, -(baseDomain.length + 1));
-        if (sub && !sub.includes('.') && !RESERVED_SUBDOMAINS.has(sub.toLowerCase())) {
-          c.set('subdomainOrg', sub);
-        }
-      }
-    } catch {
-      // ignore
-    }
-  }
+  const zone = getSubdomainZone();
+  const sub = extractSubdomainOrg(c.req.header('host'), zone, RESERVED_SUBDOMAINS);
+  c.set('subdomainOrg', sub);
   await next();
 });
 

--- a/packages/owletto-backend/src/utils/__tests__/public-origin.test.ts
+++ b/packages/owletto-backend/src/utils/__tests__/public-origin.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from 'vitest';
-import { getCanonicalRedirectUrl } from '../public-origin';
+import {
+  extractSubdomainOrg,
+  getCanonicalRedirectUrl,
+  getSubdomainZone,
+} from '../public-origin';
+
+const RESERVED = new Set(['www', 'api', 'app', 'admin', 'auth', 'mcp']);
 
 describe('getCanonicalRedirectUrl', () => {
   it('redirects non-canonical hosts to the configured origin', () => {
@@ -45,5 +51,59 @@ describe('getCanonicalRedirectUrl', () => {
     expect(
       getCanonicalRedirectUrl('https://owletto.com/foo', 'https://app.lobu.ai', '.lobu.ai')
     ).toBe('https://app.lobu.ai/foo');
+  });
+});
+
+describe('getSubdomainZone', () => {
+  it('prefers AUTH_COOKIE_DOMAIN over the configured origin host', () => {
+    expect(getSubdomainZone('https://app.lobu.ai', '.lobu.ai')).toBe('lobu.ai');
+  });
+
+  it('accepts cookie domains without a leading dot', () => {
+    expect(getSubdomainZone('https://app.lobu.ai', 'lobu.ai')).toBe('lobu.ai');
+  });
+
+  it('falls back to the configured origin host when no cookie domain is set', () => {
+    expect(getSubdomainZone('https://app.example.com', undefined)).toBe('app.example.com');
+  });
+
+  it('returns null when nothing is configured', () => {
+    expect(getSubdomainZone(undefined, undefined)).toBeNull();
+  });
+});
+
+describe('extractSubdomainOrg', () => {
+  it('extracts the org slug from a matching host', () => {
+    expect(extractSubdomainOrg('acme.lobu.ai', 'lobu.ai', RESERVED)).toBe('acme');
+  });
+
+  it('strips port numbers before matching', () => {
+    expect(extractSubdomainOrg('acme.lobu.ai:443', 'lobu.ai', RESERVED)).toBe('acme');
+  });
+
+  it('returns null for reserved subdomains', () => {
+    expect(extractSubdomainOrg('app.lobu.ai', 'lobu.ai', RESERVED)).toBeNull();
+    expect(extractSubdomainOrg('www.lobu.ai', 'lobu.ai', RESERVED)).toBeNull();
+  });
+
+  it('returns null for the bare zone', () => {
+    expect(extractSubdomainOrg('lobu.ai', 'lobu.ai', RESERVED)).toBeNull();
+  });
+
+  it('returns null for multi-label subdomains', () => {
+    expect(extractSubdomainOrg('foo.bar.lobu.ai', 'lobu.ai', RESERVED)).toBeNull();
+  });
+
+  it('returns null for unrelated hosts', () => {
+    expect(extractSubdomainOrg('acme.example.com', 'lobu.ai', RESERVED)).toBeNull();
+  });
+
+  it('returns null when host or zone is missing', () => {
+    expect(extractSubdomainOrg(undefined, 'lobu.ai', RESERVED)).toBeNull();
+    expect(extractSubdomainOrg('acme.lobu.ai', null, RESERVED)).toBeNull();
+  });
+
+  it('is case-insensitive', () => {
+    expect(extractSubdomainOrg('ACME.Lobu.AI', 'lobu.ai', RESERVED)).toBe('acme');
   });
 });

--- a/packages/owletto-backend/src/utils/public-origin.ts
+++ b/packages/owletto-backend/src/utils/public-origin.ts
@@ -114,3 +114,46 @@ export function getCanonicalRedirectUrl(
 
   return `${canonical.origin}${request.pathname}${request.search}`;
 }
+
+/**
+ * Returns the DNS zone used to map `{sub}.{zone}` hostnames to an organization
+ * slug. Prefers AUTH_COOKIE_DOMAIN (e.g. `.lobu.ai`) so per-org subdomains like
+ * `acme.lobu.ai` resolve even when PUBLIC_WEB_URL points at a non-apex canonical
+ * host like `app.lobu.ai`. Falls back to the configured origin's hostname so
+ * deployments without a cookie zone still get subdomain extraction for
+ * `{sub}.{canonicalHost}`.
+ */
+export function getSubdomainZone(
+  configuredOrigin = getConfiguredPublicOrigin(),
+  cookieDomain = process.env.AUTH_COOKIE_DOMAIN
+): string | null {
+  const cookieZone = cookieDomain?.trim().replace(/^\./, '').toLowerCase();
+  if (cookieZone) return cookieZone;
+
+  if (!configuredOrigin) return null;
+  try {
+    return new URL(configuredOrigin).hostname.toLowerCase();
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Extracts the org slug from a Host header for `{org}.{zone}` requests.
+ * Reserved subdomains (www, api, app, etc.) are skipped so infra hostnames are
+ * not mistaken for org slugs. Returns null when the host does not belong to the
+ * zone, is the bare zone, or is a reserved/multi-label subdomain.
+ */
+export function extractSubdomainOrg(
+  host: string | undefined | null,
+  zone: string | null | undefined,
+  reservedSubdomains: ReadonlySet<string>
+): string | null {
+  if (!host || !zone) return null;
+  const normalizedHost = host.split(':')[0]?.toLowerCase();
+  if (!normalizedHost || !normalizedHost.endsWith(`.${zone}`)) return null;
+
+  const sub = normalizedHost.slice(0, -(zone.length + 1));
+  if (!sub || sub.includes('.') || reservedSubdomains.has(sub)) return null;
+  return sub;
+}


### PR DESCRIPTION
## Summary

PR #214 set up the infra (wildcard cert/ingress, `AUTH_COOKIE_DOMAIN=.lobu.ai`, BetterAuth wildcard trust, canonical-redirect cookie-zone preservation) so `{org}.lobu.ai` could carry sessions — but the middleware that actually populates `subdomainOrg` still keyed off the `PUBLIC_WEB_URL` hostname (`app.lobu.ai`). `acme.lobu.ai` doesn't end with `.app.lobu.ai`, so the slug was never extracted and only `*.app.lobu.ai` worked.

- Add `getSubdomainZone()` + `extractSubdomainOrg()` helpers that prefer `AUTH_COOKIE_DOMAIN` as the zone and fall back to the `PUBLIC_WEB_URL` hostname for deployments without a cookie zone
- Update the subdomain middleware (`packages/owletto-backend/src/index.ts`) to use the zone helpers — port stripping, case-insensitive matching
- Extend `isAllowedCorsOrigin` so the cookie-zone apex (`lobu.ai`) and its wildcard subdomains are trusted CORS origins, enabling the bare landing site and org subdomains to call `app.lobu.ai`
- 13 new unit tests covering zone selection, reserved-subdomain skip, multi-label rejection, port handling, and case-insensitivity

## Test plan

- [x] `bun run --cwd packages/owletto-backend vitest run src/utils/__tests__/public-origin.test.ts` — 18/18 pass
- [x] `bun run typecheck` — clean
- [ ] After merge: curl `https://acme.lobu.ai/mcp/tools/list` and confirm it resolves to the `acme` org (no `:orgSlug` in URL needed)
- [ ] Confirm `https://lobu.ai` (apex) can still fetch from `https://app.lobu.ai` (CORS preflight passes)