### PR TITLE
fix(gateway,worker): deliver provider base URLs via session context only

### DIFF
--- a/packages/gateway/src/orchestration/base-deployment-manager.ts
+++ b/packages/gateway/src/orchestration/base-deployment-manager.ts
@@ -746,13 +746,6 @@ export abstract class BaseDeploymentManager {
     }
 
     if (hasSecrets) {
-      const proxyUrl = `${this.getDispatcherUrl()}/api/proxy`;
-      for (const provider of this.providerModules) {
-        Object.assign(
-          envVars,
-          provider.getProxyBaseUrlMappings(proxyUrl, agentId, context)
-        );
-      }
       logger.info(
         `🔐 Generated secret placeholders for ${deploymentName}, routing through proxy`
       );

--- a/packages/worker/src/openclaw/worker.ts
+++ b/packages/worker/src/openclaw/worker.ts
@@ -872,8 +872,7 @@ export class OpenClawWorker implements WorkerExecutor {
     if (!providerBaseUrl) {
       const baseUrlEnvVar = DEFAULT_PROVIDER_BASE_URL_ENV[rawProvider];
       if (baseUrlEnvVar) {
-        const baseUrlValue =
-          credentialStore.get(baseUrlEnvVar) || process.env[baseUrlEnvVar];
+        const baseUrlValue = credentialStore.get(baseUrlEnvVar);
         if (baseUrlValue) {
           providerBaseUrl = baseUrlValue;
         }
@@ -1117,8 +1116,7 @@ export class OpenClawWorker implements WorkerExecutor {
     if (!providerBaseUrl) {
       const baseUrlEnvVar = DEFAULT_PROVIDER_BASE_URL_ENV[rawProvider];
       if (baseUrlEnvVar) {
-        const baseUrlValue =
-          credentialStore.get(baseUrlEnvVar) || process.env[baseUrlEnvVar];
+        const baseUrlValue = credentialStore.get(baseUrlEnvVar);
         if (baseUrlValue) {
           providerBaseUrl = baseUrlValue;
         }


### PR DESCRIPTION
## Summary

- Workers with multiple openai-compatible providers configured (z-ai, groq, openai-codex, together-ai, deepseek) all wrote `OPENAI_BASE_URL` into the worker's environment. Last provider module to write wins, so an agent configured with `z-ai/glm-4.6` could silently be routed to the openai-codex upstream.
- Remove env-var delivery of provider base URLs entirely. Session context (`providerBaseUrlMappings`) is already agent-scoped and becomes the single source of truth.

## Changes

**`packages/gateway/src/orchestration/base-deployment-manager.ts`**
- Drop the loop over globally registered provider modules inside `injectSecretPlaceholders` that wrote `{PROVIDER}_BASE_URL` + (for `sdkCompat: "openai"` providers) `OPENAI_BASE_URL` into the deployment env.
- The agent-scoped mapping built from `effectiveProviders` higher up (written into `validated.agentOptions.providerBaseUrlMappings`) remains — that's the session-context delivery path.

**`packages/worker/src/openclaw/worker.ts`**
- Drop `process.env[baseUrlEnvVar]` fallbacks in both provider-resolution sites.
- `credentialStore` (populated from session-context `providerBaseUrlMappings`) is the only authoritative source.

## Why this is the right fix, not a patch

The env-var path was never agent-scoped — it iterated `this.providerModules` (all globally registered providers), not `effectiveProviders` for the deployment's agent. Any collision on the shared env var (`OPENAI_BASE_URL` across openai-compat providers) was unavoidable at that layer. Scoping the loop would have worked for single-provider agents but still collided for multi-openai-compat agents. Removing the layer is the structural fix.

## Test plan

- [x] \`bun run typecheck\` — clean
- [x] gateway unit tests — 488 pass / 0 fail
- [x] worker unit tests — 17 pass / 0 fail
- [x] End-to-end verification against an agent configured with \`z-ai/glm-4.6\`: worker env has no \`*_BASE_URL\` vars; \`[secret-proxy] Forwarding to upstream: POST https://api.z.ai/...\` confirmed (previously went to \`openai-codex\` upstream when multiple openai-compat providers were registered).