### PR TITLE
feat(landing): consolidate use-case demo into unified trace view

### DIFF
--- a/packages/landing/src/components/DemoSection.tsx
+++ b/packages/landing/src/components/DemoSection.tsx
@@ -1,14 +1,24 @@
 import type { ComponentChildren } from "preact";
 import { useEffect, useMemo, useState } from "preact/hooks";
-import type { LandingUseCaseId } from "../use-case-definitions";
+import type {
+  ExampleRelation,
+  LandingUseCaseId,
+  RecordNode,
+} from "../use-case-definitions";
 import {
   DEFAULT_LANDING_USE_CASE_ID,
   getLandingUseCaseShowcase,
-  landingUseCaseOptions,
+  landingUseCaseGroupedOptions,
+  type TraceRow,
 } from "../use-case-showcases";
 import { deliverySurfaces } from "./platforms";
-import { UseCaseTabs } from "./UseCaseTabs";
-import { accentCyan, accentPink, textColor } from "./memory/styles";
+import { ScopedUseCaseTabs } from "./ScopedUseCaseTabs";
+import {
+  accentAmber,
+  accentCyan,
+  accentPink,
+  textColor,
+} from "./memory/styles";
 
 function Card({
   title,
@@ -81,42 +91,375 @@ function PillList({ items }: { items: string[] }) {
   );
 }
 
-function StepsList({
-  steps,
-}: {
-  steps: Array<{ title: string; detail: string; chips?: string[] }>;
-}) {
+function ResponseBlock({ label, text }: { label: string; text: string }) {
   return (
-    <div class="grid gap-4">
-      {steps.map((step, index) => (
-        <div key={step.title} class="grid gap-2">
-          <div class="flex items-start gap-3">
-            <div
-              class="w-7 h-7 rounded-full flex items-center justify-center text-xs font-semibold shrink-0"
+    <div
+      class="rounded-xl p-4"
+      style={{
+        backgroundColor: "rgba(255,255,255,0.03)",
+        border: "1px solid var(--color-tg-accent)",
+      }}
+    >
+      <div
+        class="text-[10px] uppercase tracking-[0.18em] mb-2"
+        style={{ color: "var(--color-tg-accent)" }}
+      >
+        {label}
+      </div>
+      <div
+        class="text-sm leading-7"
+        style={{ color: "var(--color-page-text)" }}
+      >
+        {text}
+      </div>
+    </div>
+  );
+}
+
+const TRACE_KIND_META: Record<
+  TraceRow["kind"],
+  { label: string; color: string }
+> = {
+  skill: { label: "skill", color: "var(--color-tg-accent)" },
+  memory_recall: { label: "recall", color: accentCyan },
+  memory_upsert: { label: "upsert", color: accentPink },
+  memory_link: { label: "link", color: accentPink },
+};
+
+type TraceTile = { text: string; fg: string; bg: string; border: string };
+
+function getTraceTile(row: TraceRow): TraceTile {
+  const call = row.call.toLowerCase();
+  if (row.kind === "skill") {
+    if (call.startsWith("pagerduty")) {
+      return {
+        text: "PD",
+        fg: "#f59e0b",
+        bg: "rgba(245, 158, 11, 0.14)",
+        border: "rgba(245, 158, 11, 0.4)",
+      };
+    }
+    if (call.startsWith("k8s") || call.startsWith("helm")) {
+      return {
+        text: "K8",
+        fg: "#60a5fa",
+        bg: "rgba(96, 165, 250, 0.14)",
+        border: "rgba(96, 165, 250, 0.4)",
+      };
+    }
+    if (call.startsWith("approval")) {
+      return {
+        text: "OK",
+        fg: accentAmber,
+        bg: "rgba(248, 184, 78, 0.14)",
+        border: "rgba(248, 184, 78, 0.4)",
+      };
+    }
+    return {
+      text: row.source.slice(0, 2).toUpperCase(),
+      fg: "var(--color-tg-accent)",
+      bg: "rgba(255,255,255,0.06)",
+      border: "rgba(255,255,255,0.16)",
+    };
+  }
+  if (row.kind === "memory_recall") {
+    return {
+      text: "\u21BA",
+      fg: accentCyan,
+      bg: "rgba(103, 232, 249, 0.12)",
+      border: "rgba(103, 232, 249, 0.4)",
+    };
+  }
+  if (row.kind === "memory_upsert") {
+    return {
+      text: "+",
+      fg: accentPink,
+      bg: "rgba(251, 113, 133, 0.12)",
+      border: "rgba(251, 113, 133, 0.4)",
+    };
+  }
+  return {
+    text: "\u2192",
+    fg: accentPink,
+    bg: "rgba(251, 113, 133, 0.12)",
+    border: "rgba(251, 113, 133, 0.4)",
+  };
+}
+
+function EntityCard({ node }: { node: RecordNode }) {
+  return (
+    <div
+      class="rounded-lg p-3 grid gap-1.5"
+      style={{
+        backgroundColor: "rgba(255,255,255,0.03)",
+        border: "1px solid rgba(255,255,255,0.08)",
+      }}
+    >
+      <div class="flex items-center gap-2 flex-wrap">
+        <span
+          class="text-[10px] uppercase tracking-[0.16em] px-1.5 py-0.5 rounded"
+          style={{
+            color: accentCyan,
+            border: `1px solid rgba(103, 232, 249, 0.35)`,
+            backgroundColor: `rgba(103, 232, 249, 0.06)`,
+          }}
+        >
+          {node.kind}
+        </span>
+        <span class="text-sm" style={{ color: "var(--color-page-text)" }}>
+          {node.label}
+        </span>
+      </div>
+      {node.chips?.length ? (
+        <div class="flex flex-wrap gap-1">
+          {node.chips.map((chip) => (
+            <span
+              key={chip}
+              class="text-[10px] px-1.5 py-0.5 rounded-full"
               style={{
-                color: "var(--color-page-bg)",
-                backgroundColor: "var(--color-tg-accent)",
+                color: "var(--color-page-text-muted)",
+                backgroundColor: "rgba(255,255,255,0.04)",
+                border: "1px solid rgba(255,255,255,0.06)",
               }}
             >
-              {index + 1}
-            </div>
-            <div class="min-w-0">
-              <div
-                class="text-sm font-semibold mb-1"
-                style={{ color: "var(--color-page-text)" }}
-              >
-                {step.title}
+              {chip}
+            </span>
+          ))}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function RelationshipTriple({ relation }: { relation: ExampleRelation }) {
+  return (
+    <div class="flex flex-wrap items-center gap-1.5">
+      <span
+        class="px-2 py-0.5 rounded-full text-xs"
+        style={{
+          color: textColor,
+          backgroundColor: `rgba(103, 232, 249, 0.08)`,
+          border: "1px solid rgba(103, 232, 249, 0.22)",
+        }}
+      >
+        <span class="font-semibold">{relation.sourceType}</span>{" "}
+        {relation.source}
+      </span>
+      <span
+        class="px-1.5 py-0.5 rounded-full text-[10px] uppercase tracking-[0.16em]"
+        style={{
+          color: accentCyan,
+          backgroundColor: `rgba(103, 232, 249, 0.06)`,
+          border: "1px solid rgba(103, 232, 249, 0.18)",
+        }}
+      >
+        {relation.label}
+      </span>
+      <span
+        class="px-2 py-0.5 rounded-full text-xs"
+        style={{
+          color: textColor,
+          backgroundColor: `rgba(134, 239, 172, 0.08)`,
+          border: "1px solid rgba(134, 239, 172, 0.22)",
+        }}
+      >
+        <span class="font-semibold">{relation.targetType}</span>{" "}
+        {relation.target}
+      </span>
+    </div>
+  );
+}
+
+function TraceSection({
+  rows,
+  skillsHref,
+  memoryHref,
+  mcpServer,
+  allowedDomains,
+  entities,
+  relation,
+}: {
+  rows: TraceRow[];
+  skillsHref: string;
+  memoryHref: string;
+  mcpServer: string;
+  allowedDomains: string[];
+  entities: RecordNode[];
+  relation?: ExampleRelation;
+}) {
+  return (
+    <div class="mt-5">
+      <div
+        class="text-[10px] uppercase tracking-[0.18em] mb-3"
+        style={{ color: "var(--color-page-text-muted)" }}
+      >
+        Trace
+      </div>
+      <div class="flex flex-col">
+        {rows.map((row, i) => {
+          const meta = TRACE_KIND_META[row.kind];
+          const tile = getTraceTile(row);
+          const isLast = i === rows.length - 1;
+          return (
+            <div
+              key={`${row.call}-${i}`}
+              class="flex items-stretch gap-3"
+              style={{ paddingBottom: isLast ? 0 : "12px" }}
+            >
+              <div class="relative flex flex-col items-center shrink-0 w-8">
+                <div
+                  class="w-8 h-8 shrink-0 rounded-lg flex items-center justify-center text-[11px] font-semibold relative z-10"
+                  style={{
+                    color: tile.fg,
+                    backgroundColor: tile.bg,
+                    border: `1px solid ${tile.border}`,
+                  }}
+                >
+                  {tile.text}
+                </div>
+                {!isLast ? (
+                  <div
+                    class="absolute w-px"
+                    style={{
+                      left: "50%",
+                      top: "32px",
+                      bottom: "-12px",
+                      transform: "translateX(-50%)",
+                      background:
+                        "linear-gradient(180deg, rgba(255,255,255,0.18) 0%, rgba(255,255,255,0.08) 100%)",
+                    }}
+                  />
+                ) : null}
               </div>
               <div
-                class="text-sm leading-6"
-                style={{ color: "var(--color-page-text-muted)" }}
+                class="flex-1 min-w-0 rounded-xl px-3 py-3"
+                style={{
+                  backgroundColor: "rgba(255,255,255,0.035)",
+                  border: "1px solid rgba(255,255,255,0.07)",
+                }}
               >
-                {step.detail}
+                <div class="flex items-center gap-2 flex-wrap">
+                  <span
+                    class="text-sm font-semibold"
+                    style={{ color: "var(--color-page-text)" }}
+                  >
+                    {row.source}
+                  </span>
+                  <span
+                    class="text-[10px] uppercase tracking-[0.18em] px-1.5 py-0.5 rounded"
+                    style={{
+                      color: meta.color,
+                      border: `1px solid ${meta.color}`,
+                    }}
+                  >
+                    {meta.label}
+                  </span>
+                </div>
+                <div
+                  class="font-mono text-[11px] mt-1 break-all"
+                  style={{ color: "var(--color-page-text-muted)" }}
+                >
+                  {row.call}
+                </div>
+                <div
+                  class="text-sm mt-1.5"
+                  style={{ color: "var(--color-page-text)" }}
+                >
+                  <span style={{ color: meta.color }}>{"\u2192 "}</span>
+                  {row.result}
+                </div>
               </div>
             </div>
+          );
+        })}
+      </div>
+
+      <div class="mt-5 grid gap-3">
+        <div class="grid gap-2 sm:grid-cols-[8rem_1fr] items-start">
+          <div
+            class="text-[10px] uppercase tracking-[0.18em] sm:pt-1"
+            style={{ color: "var(--color-page-text-muted)" }}
+          >
+            MCP server
+          </div>
+          <div class="flex flex-wrap gap-1.5">
+            <span
+              class="text-[11px] font-mono px-2 py-1 rounded-full"
+              style={{
+                color: "var(--color-page-text)",
+                backgroundColor: "rgba(255,255,255,0.05)",
+                border: "1px solid rgba(255,255,255,0.09)",
+              }}
+            >
+              {mcpServer}
+            </span>
+          </div>
+          <div
+            class="text-[10px] uppercase tracking-[0.18em] sm:pt-1"
+            style={{ color: "var(--color-page-text-muted)" }}
+          >
+            Network allowlist
+          </div>
+          <div class="flex flex-wrap gap-1.5">
+            {allowedDomains.map((domain) => (
+              <span
+                key={domain}
+                class="text-[11px] font-mono px-2 py-1 rounded-full"
+                style={{
+                  color: "var(--color-page-text-muted)",
+                  backgroundColor: "rgba(255,255,255,0.03)",
+                  border: "1px solid rgba(255,255,255,0.08)",
+                }}
+              >
+                {domain}
+              </span>
+            ))}
           </div>
         </div>
-      ))}
+        {entities.length ? (
+          <div class="grid gap-2">
+            <div
+              class="text-[10px] uppercase tracking-[0.18em]"
+              style={{ color: "var(--color-page-text-muted)" }}
+            >
+              Entities touched
+            </div>
+            <div class="grid gap-2 sm:grid-cols-2">
+              {entities.map((node) => (
+                <EntityCard key={node.id} node={node} />
+              ))}
+            </div>
+          </div>
+        ) : null}
+        {relation ? (
+          <div class="grid gap-1">
+            <div
+              class="text-[10px] uppercase tracking-[0.18em]"
+              style={{ color: "var(--color-page-text-muted)" }}
+            >
+              Relationship
+            </div>
+            <RelationshipTriple relation={relation} />
+          </div>
+        ) : null}
+      </div>
+
+      <div class="mt-4 flex flex-wrap gap-4">
+        <a
+          href={skillsHref}
+          class="text-xs hover:underline"
+          style={{ color: "var(--color-tg-accent)" }}
+        >
+          Learn more about Skills →
+        </a>
+        <a
+          href={memoryHref}
+          class="text-xs hover:underline"
+          style={{ color: "var(--color-tg-accent)" }}
+        >
+          Learn more about Memory →
+        </a>
+      </div>
     </div>
   );
 }
@@ -175,30 +518,6 @@ function RequestBlock({
   );
 }
 
-function HighlightGrid({
-  items,
-}: {
-  items: Array<{ label: string; value: string }>;
-}) {
-  return (
-    <div class="grid gap-3 sm:grid-cols-2">
-      {items.map((item) => (
-        <div key={item.label} class="grid gap-0.5">
-          <div
-            class="text-[10px] uppercase tracking-[0.18em]"
-            style={{ color: "var(--color-page-text-muted)" }}
-          >
-            {item.label}
-          </div>
-          <div class="text-sm" style={{ color: "var(--color-page-text)" }}>
-            {item.value}
-          </div>
-        </div>
-      ))}
-    </div>
-  );
-}
-
 export function DemoSection(props: {
   defaultUseCaseId?: LandingUseCaseId;
   activeUseCaseId?: LandingUseCaseId;
@@ -232,8 +551,8 @@ export function DemoSection(props: {
     <section id="how-it-works" class="pt-4 pb-14 px-8">
       <div class="w-full max-w-[72rem] mx-auto px-2 sm:px-6 lg:px-6 box-border">
         {props.showTabs === false ? null : (
-          <UseCaseTabs
-            tabs={landingUseCaseOptions}
+          <ScopedUseCaseTabs
+            groups={landingUseCaseGroupedOptions}
             activeId={activeUseCase.id}
             onSelect={
               props.linkTabsToCampaigns
@@ -263,233 +582,21 @@ export function DemoSection(props: {
               text={activeUseCase.runtime.request}
               showPlatforms
             />
-            <StepsList steps={activeUseCase.runtime.steps} />
-          </Card>
-        </div>
-
-        <div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
-          <Card
-            title="Skills"
-            description={activeUseCase.skills.description}
-            href={skillsHref}
-            hrefLabel="Learn more about Skills"
-          >
-            <div class="grid gap-4 md:grid-cols-3">
-              <div>
-                <div
-                  class="text-[10px] uppercase tracking-[0.18em] mb-2"
-                  style={{ color: "var(--color-page-text-muted)" }}
-                >
-                  Skills
-                </div>
-                <PillList items={activeUseCase.skills.skills} />
-              </div>
-              <div>
-                <div
-                  class="text-[10px] uppercase tracking-[0.18em] mb-2"
-                  style={{ color: "var(--color-page-text-muted)" }}
-                >
-                  Nix packages
-                </div>
-                <PillList items={activeUseCase.skills.nixPackages} />
-              </div>
-              <div>
-                <div
-                  class="text-[10px] uppercase tracking-[0.18em] mb-2"
-                  style={{ color: "var(--color-page-text-muted)" }}
-                >
-                  Allowed domains
-                </div>
-                <PillList items={activeUseCase.skills.allowedDomains} />
-              </div>
-            </div>
-            <div class="grid gap-3 sm:grid-cols-2 mt-5">
-              <div class="grid gap-0.5">
-                <div
-                  class="text-[10px] uppercase tracking-[0.18em]"
-                  style={{ color: "var(--color-page-text-muted)" }}
-                >
-                  Agent
-                </div>
-                <div
-                  class="text-sm"
-                  style={{ color: "var(--color-page-text)" }}
-                >
-                  {activeUseCase.skills.agentId}
-                </div>
-              </div>
-              <div class="grid gap-0.5">
-                <div
-                  class="text-[10px] uppercase tracking-[0.18em]"
-                  style={{ color: "var(--color-page-text-muted)" }}
-                >
-                  MCP server
-                </div>
-                <div
-                  class="text-sm"
-                  style={{ color: "var(--color-page-text)" }}
-                >
-                  {activeUseCase.skills.mcpServer}
-                </div>
-              </div>
-              <div class="grid gap-0.5">
-                <div
-                  class="text-[10px] uppercase tracking-[0.18em]"
-                  style={{ color: "var(--color-page-text-muted)" }}
-                >
-                  Provider
-                </div>
-                <div
-                  class="text-sm"
-                  style={{ color: "var(--color-page-text)" }}
-                >
-                  {activeUseCase.skills.providerId}
-                </div>
-              </div>
-              <div class="grid gap-0.5">
-                <div
-                  class="text-[10px] uppercase tracking-[0.18em]"
-                  style={{ color: "var(--color-page-text-muted)" }}
-                >
-                  Model
-                </div>
-                <div
-                  class="text-sm"
-                  style={{ color: "var(--color-page-text)" }}
-                >
-                  {activeUseCase.skills.model}
-                </div>
-              </div>
-            </div>
-            <div class="mt-5 grid gap-2">
-              {activeUseCase.skills.skillInstructions.map((instruction) => (
-                <div
-                  key={instruction}
-                  class="rounded-lg px-3 py-2 text-sm leading-6"
-                  style={{
-                    color: "var(--color-page-text)",
-                    backgroundColor: "rgba(255,255,255,0.04)",
-                    border: "1px solid rgba(255,255,255,0.06)",
-                  }}
-                >
-                  {instruction}
-                </div>
-              ))}
-            </div>
-            <p
-              class="text-xs leading-6 mt-5"
-              style={{ color: "var(--color-page-text-muted)" }}
-            >
-              Need another service or workflow? Add your own MCP servers, Nix
-              packages, and custom skills. See the{" "}
-              <a
-                href={skillsHref}
-                class="hover:underline"
-                style={{ color: "var(--color-tg-accent)" }}
-              >
-                skills page
-              </a>
-              .
-            </p>
-          </Card>
-
-          <Card
-            title="Memory"
-            description={activeUseCase.memory.description}
-            href={memoryHref}
-            hrefLabel="Learn more about Memory"
-          >
-            <RequestBlock
-              label={activeUseCase.memory.sourceLabel}
-              text={activeUseCase.memory.sourceText}
+            <ResponseBlock
+              label={activeUseCase.runtime.responseLabel}
+              text={activeUseCase.runtime.response}
             />
-            <HighlightGrid items={activeUseCase.memory.highlights} />
-            <div class="mt-5">
-              <div
-                class="text-[10px] uppercase tracking-[0.18em] mb-2"
-                style={{ color: "var(--color-page-text-muted)" }}
-              >
-                Structured entities
-              </div>
-              <PillList items={activeUseCase.memory.entityTypes} />
-            </div>
-            <div class="mt-5">
-              <div
-                class="text-[10px] uppercase tracking-[0.18em] mb-2"
-                style={{ color: "var(--color-page-text-muted)" }}
-              >
-                Relationships
-              </div>
-              <div class="flex flex-wrap items-center gap-1.5">
-                <span
-                  class="px-2 py-0.5 rounded-full text-xs"
-                  style={{
-                    color: textColor,
-                    backgroundColor: `rgba(103, 232, 249, 0.08)`,
-                    border: "1px solid rgba(103, 232, 249, 0.22)",
-                  }}
-                >
-                  <span class="font-semibold">
-                    {activeUseCase.memory.relations[0]?.sourceType}
-                  </span>{" "}
-                  {activeUseCase.memory.relations[0]?.source}
-                </span>
-                <span
-                  class="px-1.5 py-0.5 rounded-full text-[10px] uppercase tracking-[0.16em]"
-                  style={{
-                    color: accentCyan,
-                    backgroundColor: `rgba(103, 232, 249, 0.06)`,
-                    border: "1px solid rgba(103, 232, 249, 0.18)",
-                  }}
-                >
-                  {activeUseCase.memory.relations[0]?.label}
-                </span>
-                <span
-                  class="px-2 py-0.5 rounded-full text-xs"
-                  style={{
-                    color: textColor,
-                    backgroundColor: `rgba(134, 239, 172, 0.08)`,
-                    border: "1px solid rgba(134, 239, 172, 0.22)",
-                  }}
-                >
-                  <span class="font-semibold">
-                    {activeUseCase.memory.relations[0]?.targetType}
-                  </span>{" "}
-                  {activeUseCase.memory.relations[0]?.target}
-                </span>
-              </div>
-            </div>
-
-            <div class="mt-5">
-              <div
-                class="text-[10px] uppercase tracking-[0.18em] mb-2"
-                style={{ color: "var(--color-page-text-muted)" }}
-              >
-                Watcher
-              </div>
-              <div class="flex flex-wrap items-center gap-2">
-                <span
-                  class="px-2 py-0.5 rounded-full text-xs"
-                  style={{
-                    color: textColor,
-                    backgroundColor: `rgba(251, 113, 133, 0.08)`,
-                    border: "1px solid rgba(251, 113, 133, 0.22)",
-                  }}
-                >
-                  {activeUseCase.memory.watcher.name}
-                </span>
-                <span
-                  class="px-1.5 py-0.5 rounded-full text-[10px] uppercase tracking-[0.14em]"
-                  style={{
-                    color: accentPink,
-                    backgroundColor: `rgba(251, 113, 133, 0.06)`,
-                    border: "1px solid rgba(251, 113, 133, 0.18)",
-                  }}
-                >
-                  {activeUseCase.memory.watcher.schedule}
-                </span>
-              </div>
-            </div>
+            {activeUseCase.runtime.trace?.length ? (
+              <TraceSection
+                rows={activeUseCase.runtime.trace}
+                skillsHref={skillsHref}
+                memoryHref={memoryHref}
+                mcpServer={activeUseCase.skills.mcpServer}
+                allowedDomains={activeUseCase.skills.allowedDomains}
+                entities={activeUseCase.memory.recordTree.children ?? []}
+                relation={activeUseCase.memory.relations[0]}
+              />
+            ) : null}
           </Card>
         </div>
       </div>

--- a/packages/landing/src/components/HeroSection.tsx
+++ b/packages/landing/src/components/HeroSection.tsx
@@ -2,11 +2,11 @@ import type { LandingUseCaseId } from "../use-case-definitions";
 import {
   getLandingUseCaseShowcase,
   getOwlettoUrl,
-  landingUseCaseOptions,
+  landingUseCaseGroupedOptions,
   type SurfaceHeroCopy,
 } from "../use-case-showcases";
 import { HighlightedText } from "./HighlightedText";
-import { UseCaseTabs } from "./UseCaseTabs";
+import { ScopedUseCaseTabs } from "./ScopedUseCaseTabs";
 
 const SecondaryCtaIcon = ({ external }: { external: boolean }) =>
   external ? (
@@ -158,10 +158,9 @@ export function HeroSection(props: {
         </div>
 
         <div class="mt-8 mb-6">
-          <UseCaseTabs
-            tabs={landingUseCaseOptions}
+          <ScopedUseCaseTabs
+            groups={landingUseCaseGroupedOptions}
             activeId={activeUseCase.id}
-            label="Pick a use case"
             onSelect={
               props.linkTabsToCampaigns
                 ? undefined

--- a/packages/landing/src/use-case-showcases.ts
+++ b/packages/landing/src/use-case-showcases.ts
@@ -16,18 +16,28 @@ type RuntimeStep = {
   chips?: string[];
 };
 
+export type TraceRow = {
+  kind: "skill" | "memory_recall" | "memory_upsert" | "memory_link";
+  source: string;
+  call: string;
+  result: string;
+};
+
 type RuntimeJourney = {
   requestLabel: string;
   request: string;
   summary: string;
   steps: RuntimeStep[];
+  trace?: TraceRow[];
+  responseLabel: string;
+  response: string;
   outcomeLabel: string;
   outcome: string[];
 };
 
 type RuntimeJourneyInput = Omit<
   RuntimeJourney,
-  "requestLabel" | "outcomeLabel"
+  "requestLabel" | "outcomeLabel" | "responseLabel"
 >;
 
 type CampaignMeta = {
@@ -1253,6 +1263,8 @@ const runtimeContent: Record<LandingUseCaseId, RuntimeJourneyInput> = {
         result: "flagged counsel-required",
       },
     ],
+    response:
+      "Clause §7 carries uncapped indemnity language — the same pattern that blocked the Acme NDA in September, so it needs counsel sign-off before you countersign. I've filed REV-88 with Priya and linked the clause to the Redwood counterparty record for future drafts.",
     outcome: [
       "Clause-level risk summary with citations",
       "Recommended edits and unresolved approval items",
@@ -1315,6 +1327,8 @@ const runtimeContent: Record<LandingUseCaseId, RuntimeJourneyInput> = {
         result: "awaiting oncall confirmation",
       },
     ],
+    response:
+      "Blocker is INC-4421: the checkout-v43 rollout has 3 of 5 pods unhealthy and ties to PR #882. checkout-v41 was the last safe version, so I've queued a rollback and it's waiting on oncall confirmation before it executes.",
     outcome: [
       "A current deploy-risk answer with blockers called out",
       "Incident and rollback context shared across the team",
@@ -1378,6 +1392,8 @@ const runtimeContent: Record<LandingUseCaseId, RuntimeJourneyInput> = {
         result: "set for Oct 24 10:00",
       },
     ],
+    response:
+      "Draft reply to Alex is ready in your outbox, matched to his usual tone. Owner set to Priya and a Thursday 10am follow-up is on the calendar.",
     outcome: [
       "Faster first replies with consistent context",
       "Less re-triage across shifts and escalations",
@@ -1441,6 +1457,8 @@ const runtimeContent: Record<LandingUseCaseId, RuntimeJourneyInput> = {
         result: "draft ready for sign-off",
       },
     ],
+    response:
+      "The 4100 variance traces to merchant STR-44 — same 3-day settlement lag we saw in September, $12,480 net. Month-end note is drafted and ready for your sign-off.",
     outcome: [
       "A structured explanation for the variance",
       "Operator-ready notes for the month-end deck",
@@ -1504,6 +1522,8 @@ const runtimeContent: Record<LandingUseCaseId, RuntimeJourneyInput> = {
         result: "usage down 38% since Aug",
       },
     ],
+    response:
+      "Northstar's renewal owner changed — Jake Chen is the new contact after Maria moved roles, and usage is down 38% since August. Recommend an exec sync with Jake and Jane before the Oct renewal to reset the relationship.",
     outcome: [
       "Renewal summaries grounded in account evidence",
       "Expansion and risk signals in one place",
@@ -1567,6 +1587,8 @@ const runtimeContent: Record<LandingUseCaseId, RuntimeJourneyInput> = {
         result: "escalation draft ready",
       },
     ],
+    response:
+      "Phoenix is blocked on shard-14 — same pattern we saw in the Apollo rollout — and Lena owns the fix on the backend side. Escalation draft to Rahul is ready if shard-14 isn't cleared by end of day Tuesday.",
     outcome: [
       "Consistent rollout updates with owners and blockers",
       "Project context that survives across standups and escalations",
@@ -1630,6 +1652,8 @@ const runtimeContent: Record<LandingUseCaseId, RuntimeJourneyInput> = {
         result: "due Fri Apr 25",
       },
     ],
+    response:
+      "Board approved the $4M Series A bridge and the Q1 hiring freeze. Blocked: the Frankfurt office lease pending legal diligence — Priya owns the counter with a decision due Fri Apr 25.",
     outcome: [
       "Action-oriented board summaries grounded in source material",
       "Durable decision history across review cycles",
@@ -1693,6 +1717,8 @@ const runtimeContent: Record<LandingUseCaseId, RuntimeJourneyInput> = {
         result: "draft ready · references Devon's repo",
       },
     ],
+    response:
+      "Top matches for Sarah this week are Devon Lin (shipped a similar embeddings eval harness) and Mira Sato (deep MCP work). Intro drafts for both are queued in your outbox referencing Devon's repo and Mira's recent post.",
     outcome: [
       "Higher-quality member discovery and introductions",
       "Fresh profile context without manual curation",
@@ -1756,6 +1782,8 @@ const runtimeContent: Record<LandingUseCaseId, RuntimeJourneyInput> = {
         result: "competitor pair updated",
       },
     ],
+    response:
+      "Airtable AI launched this week — automation-heavy but Reddit's flagging reliability issues (12 posts, 2 with concerns). Versus Notion: Airtable still leads on automation depth, Notion still leads on docs and collaboration — the Q3 gap hasn't closed.",
     outcome: [
       "Weekly competitive scans with feature and pricing changes",
       "Durable brand and product memory for pattern recognition",
@@ -1819,6 +1847,8 @@ const runtimeContent: Record<LandingUseCaseId, RuntimeJourneyInput> = {
         result: "plan=annual · cancel-risk=low",
       },
     ],
+    response:
+      "Emma's plan switched from monthly to annual ($199/yr, saves $48) and April's shipment is skipped — next delivery May 3. Confirmation email is queued with the updated billing date.",
     outcome: [
       "Faster subscription and order changes with approval flows",
       "Customer context that persists across interactions",
@@ -1882,6 +1912,8 @@ const runtimeContent: Record<LandingUseCaseId, RuntimeJourneyInput> = {
         result: "re-auth due May 1",
       },
     ],
+    response:
+      "James's next appointment is Apr 24 at 2:00pm with Dr. Patel. Treatment progress: 8 of 12 sessions complete, PHQ-9 down from 17 to 9 — on track. Insurance re-auth is due May 1.",
     outcome: [
       "Current patient status and appointment availability",
       "Treatment progress summaries across sessions",
@@ -1945,6 +1977,8 @@ const runtimeContent: Record<LandingUseCaseId, RuntimeJourneyInput> = {
         result: "linked Company Lovable · Lead Accel",
       },
     ],
+    response:
+      "Lovable just closed a $15M Series A led by Accel — already in portfolio. Also worth tracking: v0, Bolt, and Replit Agent in the same prompt-to-app space. Adam K. (ex-Replit) is a warm intro through your network.",
     outcome: [
       "Company summaries with funding and team history",
       "Portfolio health and competitive signals",
@@ -3058,6 +3092,7 @@ export const landingUseCaseShowcases: LandingUseCaseShowcase[] = (
   const runtime: RuntimeJourney = {
     ...input,
     requestLabel: "Incoming request",
+    responseLabel: "Agent response",
     outcomeLabel: "What the team gets",
   };
 

--- a/packages/landing/src/use-case-showcases.ts
+++ b/packages/landing/src/use-case-showcases.ts
@@ -1221,6 +1221,38 @@ const runtimeContent: Record<LandingUseCaseId, RuntimeJourneyInput> = {
           "Owletto stores the contract, clause, risk, and counterparty graph so future reviews begin with the same evidence.",
       },
     ],
+    trace: [
+      {
+        kind: "skill",
+        source: "Legal",
+        call: "docusign.contracts.get(redwood-nda)",
+        result: "37 pages · 9 clauses",
+      },
+      {
+        kind: "memory_recall",
+        source: "Owletto",
+        call: "recall(counterparty: Redwood, topic: risk)",
+        result: "Acme NDA blocked Sep — similar §7 language",
+      },
+      {
+        kind: "memory_upsert",
+        source: "Owletto",
+        call: "upsert(Contract Redwood-NDA-v2)",
+        result: 'linked Clause §7 "uncapped indemnity"',
+      },
+      {
+        kind: "skill",
+        source: "Legal",
+        call: "jira.create(legal-review)",
+        result: "REV-88 assigned to Priya",
+      },
+      {
+        kind: "memory_link",
+        source: "Owletto",
+        call: "link(Contract → Clause §7 → Risk)",
+        result: "flagged counsel-required",
+      },
+    ],
     outcome: [
       "Clause-level risk summary with citations",
       "Recommended edits and unresolved approval items",
@@ -1249,6 +1281,38 @@ const runtimeContent: Record<LandingUseCaseId, RuntimeJourneyInput> = {
         detail:
           "Owletto links the current outage to affected services, triggering deploys, and remediation work so context survives handoffs.",
         chips: ["incident memory", "service graph"],
+      },
+    ],
+    trace: [
+      {
+        kind: "skill",
+        source: "DevOps",
+        call: "pagerduty.incidents.list(active)",
+        result: "INC-4421 checkout p95 latency · sev-2",
+      },
+      {
+        kind: "memory_recall",
+        source: "Owletto",
+        call: "recall(service: checkout, topic: rollback)",
+        result: "checkout-v41 last safe · v42 tied to INC-4102",
+      },
+      {
+        kind: "skill",
+        source: "DevOps",
+        call: "k8s.deploy.status(checkout)",
+        result: "rollout 3/5 pods unhealthy · ReplicaSet checkout-v43",
+      },
+      {
+        kind: "memory_upsert",
+        source: "Owletto",
+        call: "upsert(Incident INC-4421 → checkout-v43)",
+        result: "linked to deploy, PR #882, oncall Priya",
+      },
+      {
+        kind: "skill",
+        source: "DevOps",
+        call: "approval.request(rollback checkout → v41)",
+        result: "awaiting oncall confirmation",
       },
     ],
     outcome: [
@@ -1282,6 +1346,38 @@ const runtimeContent: Record<LandingUseCaseId, RuntimeJourneyInput> = {
         chips: ["contact memory", "follow-ups", "preferences"],
       },
     ],
+    trace: [
+      {
+        kind: "skill",
+        source: "Support",
+        call: "zendesk.tickets.get(alex-kim)",
+        result: "Ticket #4912 · billing question",
+      },
+      {
+        kind: "memory_recall",
+        source: "Owletto",
+        call: "recall(customer: Alex Kim)",
+        result: "Feb billing escalation · tone: direct, concise",
+      },
+      {
+        kind: "skill",
+        source: "Support",
+        call: "zendesk.drafts.create(alex-kim-reply)",
+        result: "reply drafted in Alex's tone",
+      },
+      {
+        kind: "memory_upsert",
+        source: "Owletto",
+        call: "upsert(Account alex-kim)",
+        result: "owner=Priya · next-touch=Thu 10am",
+      },
+      {
+        kind: "skill",
+        source: "Support",
+        call: "reminder.schedule(alex-kim, thu-10am)",
+        result: "set for Oct 24 10:00",
+      },
+    ],
     outcome: [
       "Faster first replies with consistent context",
       "Less re-triage across shifts and escalations",
@@ -1311,6 +1407,38 @@ const runtimeContent: Record<LandingUseCaseId, RuntimeJourneyInput> = {
         detail:
           "Owletto saves the account, variance, source transactions, and reporting destination so the next close starts with history.",
         chips: ["variance memory", "reporting context"],
+      },
+    ],
+    trace: [
+      {
+        kind: "skill",
+        source: "Finance",
+        call: "netsuite.accounts.get(4100)",
+        result: "balance $187,420 · variance $12,480",
+      },
+      {
+        kind: "skill",
+        source: "Finance",
+        call: "stripe.refunds.list(since: Oct 20)",
+        result: "3 refunds · posted Oct 23",
+      },
+      {
+        kind: "memory_recall",
+        source: "Owletto",
+        call: "recall(account: 4100, topic: variance)",
+        result: "Sep same merchant · 3-day settlement lag",
+      },
+      {
+        kind: "memory_upsert",
+        source: "Owletto",
+        call: "upsert(Variance Oct-4100-12480)",
+        result: "linked merchant STR-44",
+      },
+      {
+        kind: "skill",
+        source: "Finance",
+        call: "notes.draft(month-end-4100)",
+        result: "draft ready for sign-off",
       },
     ],
     outcome: [
@@ -1344,6 +1472,38 @@ const runtimeContent: Record<LandingUseCaseId, RuntimeJourneyInput> = {
         chips: ["account memory", "renewal risk"],
       },
     ],
+    trace: [
+      {
+        kind: "skill",
+        source: "Sales",
+        call: "salesforce.accounts.get(northstar)",
+        result: "ARR $420K · renewal Oct 31",
+      },
+      {
+        kind: "skill",
+        source: "Sales",
+        call: "linkedin.company.changes(northstar)",
+        result: "Maria Rivera → Globex (Aug)",
+      },
+      {
+        kind: "memory_recall",
+        source: "Owletto",
+        call: "recall(account: northstar)",
+        result: "champion=Maria · exec-sponsor=Jane",
+      },
+      {
+        kind: "memory_upsert",
+        source: "Owletto",
+        call: "upsert(Contact Jake Chen)",
+        result: "new renewal owner at Northstar",
+      },
+      {
+        kind: "skill",
+        source: "Sales",
+        call: "gong.calls.usage(northstar, 60d)",
+        result: "usage down 38% since Aug",
+      },
+    ],
     outcome: [
       "Renewal summaries grounded in account evidence",
       "Expansion and risk signals in one place",
@@ -1373,6 +1533,38 @@ const runtimeContent: Record<LandingUseCaseId, RuntimeJourneyInput> = {
         detail:
           "Owletto stores milestones, blockers, stakeholders, and artifacts so every update starts from current project context.",
         chips: ["project memory", "blockers", "owners"],
+      },
+    ],
+    trace: [
+      {
+        kind: "skill",
+        source: "Delivery",
+        call: "linear.projects.get(phoenix)",
+        result: "72% complete · 28 shards pending",
+      },
+      {
+        kind: "skill",
+        source: "Delivery",
+        call: "datadog.errors(phoenix-shard-14)",
+        result: "DB timeout since Mon 03:14",
+      },
+      {
+        kind: "memory_recall",
+        source: "Owletto",
+        call: "recall(project: phoenix, topic: shards)",
+        result: "Apollo rollout had same shard-pattern",
+      },
+      {
+        kind: "memory_upsert",
+        source: "Owletto",
+        call: "upsert(Blocker phoenix-shard-14)",
+        result: "owner=Lena (backend)",
+      },
+      {
+        kind: "skill",
+        source: "Delivery",
+        call: "slack.message.draft(@rahul)",
+        result: "escalation draft ready",
       },
     ],
     outcome: [
@@ -1406,6 +1598,38 @@ const runtimeContent: Record<LandingUseCaseId, RuntimeJourneyInput> = {
         chips: ["decision memory", "assignments", "blockers"],
       },
     ],
+    trace: [
+      {
+        kind: "skill",
+        source: "Leadership",
+        call: "notion.pages.get(board-memo-q4)",
+        result: "8 decisions · 3 action items",
+      },
+      {
+        kind: "memory_recall",
+        source: "Owletto",
+        call: "recall(topic: Series A)",
+        result: "seed approval same pattern · closed in 2 wks",
+      },
+      {
+        kind: "memory_upsert",
+        source: "Owletto",
+        call: "upsert(Decision bridge-4M-approved)",
+        result: "linked to Board Q4",
+      },
+      {
+        kind: "memory_upsert",
+        source: "Owletto",
+        call: "upsert(Blocker q1-hiring-freeze)",
+        result: "condition: until close",
+      },
+      {
+        kind: "skill",
+        source: "Leadership",
+        call: "linear.tasks.create(priya-counter)",
+        result: "due Fri Apr 25",
+      },
+    ],
     outcome: [
       "Action-oriented board summaries grounded in source material",
       "Durable decision history across review cycles",
@@ -1435,6 +1659,38 @@ const runtimeContent: Record<LandingUseCaseId, RuntimeJourneyInput> = {
         detail:
           "Owletto stores members, companies, projects, topics, and match history so new launches, posts, and project updates can trigger relevant intros instead of manual research.",
         chips: ["member graph", "connected profiles", "intro history"],
+      },
+    ],
+    trace: [
+      {
+        kind: "skill",
+        source: "Community",
+        call: "github.search.users(topic: embeddings)",
+        result: "42 recent contributors",
+      },
+      {
+        kind: "memory_recall",
+        source: "Owletto",
+        call: "recall(member: Sarah, topic: needs)",
+        result: "needs infra feedback · embeddings, MCP",
+      },
+      {
+        kind: "memory_recall",
+        source: "Owletto",
+        call: "recall(members, overlap: embeddings)",
+        result: "Devon Lin · Mira Sato",
+      },
+      {
+        kind: "memory_link",
+        source: "Owletto",
+        call: "link(Sarah ↔ Devon)",
+        result: "match · shared topic: embeddings",
+      },
+      {
+        kind: "skill",
+        source: "Community",
+        call: "intros.draft(sarah-devon)",
+        result: "draft ready · references Devon's repo",
       },
     ],
     outcome: [
@@ -1468,6 +1724,38 @@ const runtimeContent: Record<LandingUseCaseId, RuntimeJourneyInput> = {
         chips: ["brand memory", "mentions", "positioning"],
       },
     ],
+    trace: [
+      {
+        kind: "skill",
+        source: "Market",
+        call: "producthunt.launches(since: Mar 11)",
+        result: "Airtable AI · 3 competitors",
+      },
+      {
+        kind: "skill",
+        source: "Market",
+        call: "reddit.reviews(airtable, 7d)",
+        result: "12 posts · 2 flag reliability",
+      },
+      {
+        kind: "memory_recall",
+        source: "Owletto",
+        call: "recall(product: Airtable)",
+        result: "Q3 scan: automation strong, docs weak",
+      },
+      {
+        kind: "memory_upsert",
+        source: "Owletto",
+        call: "upsert(Release airtable-ai-mar18)",
+        result: "linked Product Airtable",
+      },
+      {
+        kind: "memory_link",
+        source: "Owletto",
+        call: "link(Airtable ↔ Notion)",
+        result: "competitor pair updated",
+      },
+    ],
     outcome: [
       "Weekly competitive scans with feature and pricing changes",
       "Durable brand and product memory for pattern recognition",
@@ -1497,6 +1785,38 @@ const runtimeContent: Record<LandingUseCaseId, RuntimeJourneyInput> = {
         detail:
           "Owletto stores customers, subscriptions, orders, and preferences so every interaction starts with full purchase context.",
         chips: ["customer memory", "subscriptions", "preferences"],
+      },
+    ],
+    trace: [
+      {
+        kind: "skill",
+        source: "Store",
+        call: "shopify.subscriptions.get(emma-k)",
+        result: "monthly · $20/mo · next Apr 3",
+      },
+      {
+        kind: "memory_recall",
+        source: "Owletto",
+        call: "recall(customer: Emma K, topic: cancel)",
+        result: "Aug 2024 · 14-day retention window",
+      },
+      {
+        kind: "skill",
+        source: "Store",
+        call: "shopify.subscriptions.update(emma-k, annual)",
+        result: "$199/yr · saves $48",
+      },
+      {
+        kind: "skill",
+        source: "Store",
+        call: "shopify.orders.skip(emma-k, april)",
+        result: "next ship May 3",
+      },
+      {
+        kind: "memory_upsert",
+        source: "Owletto",
+        call: "upsert(Customer emma-k)",
+        result: "plan=annual · cancel-risk=low",
       },
     ],
     outcome: [
@@ -1530,6 +1850,38 @@ const runtimeContent: Record<LandingUseCaseId, RuntimeJourneyInput> = {
         chips: ["patient memory", "therapists", "treatments"],
       },
     ],
+    trace: [
+      {
+        kind: "skill",
+        source: "CareOps",
+        call: "athena.appointments.get(james-mcmanus)",
+        result: "Apr 24 · Dr. Patel · 2:00pm",
+      },
+      {
+        kind: "skill",
+        source: "CareOps",
+        call: "athena.sessions.list(james-mcmanus)",
+        result: "8 of 12 complete · PHQ-9 down 17→9",
+      },
+      {
+        kind: "memory_recall",
+        source: "Owletto",
+        call: "recall(patient: James M)",
+        result: "PHQ-9 baseline 17 · weekly exposure therapy",
+      },
+      {
+        kind: "memory_upsert",
+        source: "Owletto",
+        call: "upsert(Treatment james-12wk)",
+        result: "progress 67% · on-track",
+      },
+      {
+        kind: "skill",
+        source: "CareOps",
+        call: "insurance.reauth.check(james)",
+        result: "re-auth due May 1",
+      },
+    ],
     outcome: [
       "Current patient status and appointment availability",
       "Treatment progress summaries across sessions",
@@ -1559,6 +1911,38 @@ const runtimeContent: Record<LandingUseCaseId, RuntimeJourneyInput> = {
         detail:
           "Owletto stores companies, founders, investors, and sectors so deal context compounds over time.",
         chips: ["portfolio memory", "deal flow", "network"],
+      },
+    ],
+    trace: [
+      {
+        kind: "skill",
+        source: "VC",
+        call: "crunchbase.companies.get(lovable)",
+        result: "$15M Series A · Accel led",
+      },
+      {
+        kind: "skill",
+        source: "VC",
+        call: "market.launches(ai-dev-tools, 30d)",
+        result: "v0 · Bolt · Replit Agent",
+      },
+      {
+        kind: "memory_recall",
+        source: "Owletto",
+        call: "recall(sector: ai-dev-tools)",
+        result: "Q4 thesis · Lovable in portfolio",
+      },
+      {
+        kind: "memory_recall",
+        source: "Owletto",
+        call: "recall(network, topic: replit-alumni)",
+        result: "Adam K. · ex-Replit, warm intro",
+      },
+      {
+        kind: "memory_upsert",
+        source: "Owletto",
+        call: "upsert(Round lovable-series-a)",
+        result: "linked Company Lovable · Lead Accel",
       },
     ],
     outcome: [
@@ -2830,6 +3214,81 @@ export const landingUseCaseOptions = landingUseCaseShowcases.map((useCase) => ({
   id: useCase.id,
   label: useCase.label,
 }));
+
+export type LandingUseCaseScope = "personal" | "organizations" | "public";
+
+const useCaseScopeMap: Record<LandingUseCaseId, LandingUseCaseScope> = {
+  legal: "organizations",
+  devops: "organizations",
+  support: "organizations",
+  finance: "organizations",
+  sales: "organizations",
+  delivery: "organizations",
+  ecommerce: "organizations",
+  careops: "organizations",
+  leadership: "personal",
+  "venture-capital": "personal",
+  "agent-community": "public",
+  "market-intelligence": "public",
+};
+
+const useCaseEmojiMap: Record<LandingUseCaseId, string> = {
+  legal: "\u2696\uFE0F",
+  devops: "\uD83D\uDEA8",
+  support: "\uD83D\uDCAC",
+  finance: "\uD83D\uDCCA",
+  sales: "\uD83D\uDCC8",
+  delivery: "\uD83D\uDCE6",
+  leadership: "\uD83E\uDDED",
+  ecommerce: "\uD83D\uDED2",
+  "venture-capital": "\uD83D\uDCBC",
+  careops: "\uD83C\uDFE5",
+  "agent-community": "\uD83E\uDD1D",
+  "market-intelligence": "\uD83D\uDD2D",
+};
+
+const landingUseCaseScopeMeta: Array<{
+  id: LandingUseCaseScope;
+  label: string;
+  description: string;
+}> = [
+  {
+    id: "personal",
+    label: "Personal",
+    description:
+      "Solo-professional memory — your own decisions, deals, and context.",
+  },
+  {
+    id: "organizations",
+    label: "Organizations",
+    description: "Team agents with shared memory and shared skills.",
+  },
+  {
+    id: "public",
+    label: "Public",
+    description:
+      "Community-scale memory — members, markets, and open knowledge.",
+  },
+];
+
+export const landingUseCaseGroupedOptions = landingUseCaseScopeMeta
+  .map((scope) => ({
+    ...scope,
+    useCases: landingUseCaseShowcases
+      .filter((uc) => useCaseScopeMap[uc.id] === scope.id)
+      .map((uc) => ({
+        id: uc.id,
+        label: uc.label,
+        emoji: useCaseEmojiMap[uc.id],
+      })),
+  }))
+  .filter((group) => group.useCases.length > 0);
+
+export function getLandingUseCaseScope(
+  useCaseId: LandingUseCaseId
+): LandingUseCaseScope {
+  return useCaseScopeMap[useCaseId];
+}
 
 export function getLandingUseCaseShowcase(
   useCaseId?: string


### PR DESCRIPTION
## Summary
- Merge separate Skills + Memory cards into a single agent card with an inline trace showing skill calls and memory operations in order, per use case
- Replace the flat 12-tab row with a scope-grouped layout (Personal / Organizations / Public) so visitors can orient themselves without reading every label
- Replace the static "Skills used" pill list (which was always `["github"]` from the generated agent config) with the actual MCP server and network allowlist from the skill config

## Test plan
- [x] `cd packages/landing && bun run build` passes
- [x] All 12 `/for/<use-case>/` pages render the trace + MCP + allowlist block (verified via Playwright)
- [ ] Visual review of the scope-grouped tabs on the home hero + campaign pages