### PR TITLE
fix(deps): sync bun.lock with release-please 3.6.0 version bump

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -16,7 +16,7 @@
     },
     "packages/cli": {
       "name": "@lobu/cli",
-      "version": "3.5.0",
+      "version": "3.6.0",
       "bin": {
         "lobu": "bin/lobu.js",
       },
@@ -42,11 +42,11 @@
     },
     "packages/cli-core": {
       "name": "@lobu/cli-core",
-      "version": "3.5.0",
+      "version": "3.6.0",
     },
     "packages/core": {
       "name": "@lobu/core",
-      "version": "3.5.0",
+      "version": "3.6.0",
       "dependencies": {
         "@opentelemetry/api": "^1.9.0",
         "@opentelemetry/exporter-trace-otlp-grpc": "^0.57.0",
@@ -66,7 +66,7 @@
     },
     "packages/gateway": {
       "name": "@lobu/gateway",
-      "version": "3.5.0",
+      "version": "3.6.0",
       "dependencies": {
         "@aws-sdk/client-bedrock": "^3.1028.0",
         "@aws-sdk/client-secrets-manager": "^3.1028.0",
@@ -168,7 +168,7 @@
     },
     "packages/owletto-cli": {
       "name": "owletto",
-      "version": "1.6.0",
+      "version": "3.6.0",
       "bin": {
         "owletto": "./dist/bin.js",
       },
@@ -254,7 +254,7 @@
     },
     "packages/owletto-openclaw": {
       "name": "@lobu/owletto-openclaw",
-      "version": "1.6.0",
+      "version": "3.6.0",
       "devDependencies": {
         "@types/node": "^20.10.0",
         "postgres": "^3.4.7",
@@ -264,7 +264,7 @@
     },
     "packages/owletto-sdk": {
       "name": "@lobu/owletto-sdk",
-      "version": "1.6.0",
+      "version": "3.6.0",
       "dependencies": {
         "@sinclair/typebox": "^0.34.41",
         "ky": "^1.14.0",
@@ -366,7 +366,7 @@
     },
     "packages/worker": {
       "name": "@lobu/worker",
-      "version": "3.5.0",
+      "version": "3.6.0",
       "bin": {
         "lobu-worker": "./dist/index.js",
       },


### PR DESCRIPTION
## Summary
- Sync workspace package versions in `bun.lock` (3.5.0 → 3.6.0, 1.6.0 → 3.6.0) to match release-please's version bump in #204
- Unblocks Cloudflare Pages landing deploy, which fails `bun install --frozen-lockfile` on every push since the 3.6.0 release

## Context
release-please bumped `package.json` files but doesn't touch `bun.lock`, so CI sees stale workspace versions and fails fast. Every deploy after 1c0d926a has been red.

## Test plan
- [ ] Deploy Landing to Cloudflare Pages turns green
- [ ] lobu.ai reflects the consolidated trace view from #226