### PR TITLE
fix(ci): initialize owletto-web submodule in landing deploy

### DIFF
--- a/.github/workflows/deploy-landing-cloudflare.yml
+++ b/.github/workflows/deploy-landing-cloudflare.yml
@@ -20,13 +20,23 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - uses: ./.github/actions/setup-submodule
+        id: submodule
+        with:
+          deploy-key: ${{ secrets.OWLETTO_WEB_DEPLOY_KEY }}
+
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
           bun-version: 1.3.5
 
       - name: Install dependencies
-        run: bun install --frozen-lockfile
+        run: |
+          if [ "${{ steps.submodule.outputs.stubbed }}" = "true" ]; then
+            bun install
+          else
+            bun install --frozen-lockfile
+          fi
 
       - name: Build landing
         env:


### PR DESCRIPTION
## Summary
- Add `setup-submodule` action step to `deploy-landing-cloudflare.yml` (mirrors `ci.yml` pattern)
- Conditionally skip `--frozen-lockfile` when the submodule is stubbed (no deploy key), since a stub package.json diverges from bun.lock

## Context
The landing deploy workflow has been failing since the 3.6.0 release because `packages/owletto-web` (a git submodule) was never initialized. `bun install --frozen-lockfile` sees lockfile drift — the lockfile knows the submodule's real deps, but CI sees an empty directory, so dependency resolution computes a different hash.

Other workflows (ci.yml, pr-validation.yml) already use `./.github/actions/setup-submodule`; this PR brings the landing deploy in line.

## Test plan
- [ ] Deploy Landing to Cloudflare Pages goes green
- [ ] lobu.ai reflects the consolidated trace view from #226