### PR TITLE
fix: ship app.lobu.ai SPA + retire owletto.com defaults

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -343,6 +343,7 @@
         "tailwindcss": "^4.1.17",
         "typescript": "^5.7.2",
         "vite": "^6.0.0",
+        "vitest": "^2.1.8",
       },
     },
     "packages/owletto-worker": {

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -23,7 +23,7 @@ Scaffold a new Lobu project with interactive prompts:
 - **AI provider** selection from the bundled provider registry + API key
 - **Providers** to enable (from `config/providers.json`)
 - **Messaging platform** (Telegram, Slack, Discord, or none)
-- **Memory** selection (filesystem, Owletto Cloud, Owletto Local, or custom Owletto URL)
+- **Memory** selection (filesystem, Lobu Cloud, Owletto Local, or custom Owletto URL)
 
 **Generates:** `docker-compose.yml`, `.env`, `Dockerfile.worker`, `lobu.toml`, `IDENTITY.md`, `.gitignore`, `README.md`
 

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -14,7 +14,7 @@ import {
 } from "../commands/providers/registry.js";
 import { renderTemplate } from "../utils/template.js";
 
-const DEFAULT_OWLETTO_MCP_URL = "https://owletto.com/mcp";
+const DEFAULT_OWLETTO_MCP_URL = "https://app.lobu.ai/mcp";
 const LOCAL_OWLETTO_MCP_URL = "http://owletto:8787/mcp";
 
 export async function initCommand(
@@ -234,7 +234,7 @@ export async function initCommand(
       message: "Memory:",
       choices: [
         { name: "None (filesystem memory)", value: "none" },
-        { name: "Owletto Cloud (owletto.com)", value: "owletto-cloud" },
+        { name: "Lobu Cloud (app.lobu.ai)", value: "owletto-cloud" },
         {
           name: "Owletto Local (runs alongside gateway)",
           value: "owletto-local",

--- a/packages/gateway/src/__tests__/file-loader-memory.test.ts
+++ b/packages/gateway/src/__tests__/file-loader-memory.test.ts
@@ -62,8 +62,8 @@ org: careops
 
     const memoryUrl = await applyOwlettoMemoryEnvFromProject(projectDir);
 
-    expect(memoryUrl).toBe("https://owletto.com/mcp/careops");
-    expect(process.env.MEMORY_URL).toBe("https://owletto.com/mcp/careops");
+    expect(memoryUrl).toBe("https://app.lobu.ai/mcp/careops");
+    expect(process.env.MEMORY_URL).toBe("https://app.lobu.ai/mcp/careops");
   });
 
   test("uses MEMORY_URL as the base endpoint before scoping to the project org", async () => {

--- a/packages/gateway/src/config/file-loader.ts
+++ b/packages/gateway/src/config/file-loader.ts
@@ -18,7 +18,7 @@ import { parse as parseToml } from "smol-toml";
 import { parse as parseYaml } from "yaml";
 
 const logger = createLogger("file-loader");
-const DEFAULT_OWLETTO_MCP_URL = "https://owletto.com/mcp";
+const DEFAULT_OWLETTO_MCP_URL = "https://app.lobu.ai/mcp";
 
 // ── Public Types ──────────────────────────────────────────────────────────
 

--- a/packages/landing/src/content/docs/guides/agent-settings.md
+++ b/packages/landing/src/content/docs/guides/agent-settings.md
@@ -50,7 +50,7 @@ Memory is pluggable. In file-first projects, the gateway first checks `[memory.o
 - `data/`
 - `[memory.owletto]` in `lobu.toml`
 
-For **Owletto Cloud**, Lobu can use the hosted default automatically. For **Owletto Local** and **Custom URL**, `MEMORY_URL` remains the base-endpoint override.
+For **Lobu Cloud**, Lobu can use the hosted default automatically. For **Owletto Local** and **Custom URL**, `MEMORY_URL` remains the base-endpoint override.
 
 If the preferred plugin isn't installed, the gateway falls back to the other one (or to no memory if neither is installed).
 

--- a/packages/owletto-cli/src/commands/init.ts
+++ b/packages/owletto-cli/src/commands/init.ts
@@ -3,7 +3,7 @@ import { defineCommand } from 'citty';
 import { healthPing, runInitWizard } from '../lib/init-wizard.ts';
 import { normalizeMcpUrl } from '../lib/openclaw-auth.ts';
 
-const CLOUD_MCP_URL = 'https://owletto.com/mcp';
+const CLOUD_MCP_URL = 'https://app.lobu.ai/mcp';
 
 async function chooseMcpUrl(urlFlag?: string): Promise<string> {
   if (urlFlag) return normalizeMcpUrl(urlFlag);
@@ -11,7 +11,7 @@ async function chooseMcpUrl(urlFlag?: string): Promise<string> {
   const mode = await p.select({
     message: 'Which Owletto MCP endpoint should your agents use?',
     options: [
-      { value: 'cloud', label: 'Owletto Cloud', hint: 'https://owletto.com/mcp' },
+      { value: 'cloud', label: 'Lobu Cloud', hint: 'https://app.lobu.ai/mcp' },
       { value: 'local', label: 'Local runtime', hint: 'http://localhost:8787/mcp' },
       { value: 'custom', label: 'Custom MCP URL', hint: 'enter URL' },
     ],

--- a/packages/owletto-extension/manifest.json
+++ b/packages/owletto-extension/manifest.json
@@ -16,7 +16,7 @@
   ],
 
   "host_permissions": [
-    "https://owletto.com/*",
+    "https://app.lobu.ai/*",
     "https://localhost:5173/*",
     "http://localhost:5173/*"
   ],


### PR DESCRIPTION
## Summary
- **Restore the SPA at `https://app.lobu.ai/`.** The deployed image was returning the JSON status fallback from `packages/owletto-backend/src/index.ts:902-968` because `dist/index.html` was missing. The submodule build (`tsc -b && vite build`) had been failing for the past several `build-images` runs with `TS2307: Cannot find module 'vitest'` across 9 `*.test.ts` files. Fixed in lobu-ai/owletto-web#1; this PR bumps the submodule pointer and refreshes `bun.lock`.
- **Retire the legacy `owletto.com` defaults** the rebrand left behind so new installs and the extension stop relying on the Namecheap apex redirect. Replaces with `https://app.lobu.ai/mcp` (and `https://app.lobu.ai/*` for the extension manifest), and renames the user-facing `Owletto Cloud` label to `Lobu Cloud` in both CLI wizards.

### Files
**SPA fix**
- Submodule pointer `packages/owletto-web` → 057105c (lobu-ai/owletto-web#1)
- `bun.lock` — picks up the new vitest devDep on the submodule

**Default URL rebrand**
- `packages/gateway/src/config/file-loader.ts` — `DEFAULT_OWLETTO_MCP_URL`
- `packages/gateway/src/__tests__/file-loader-memory.test.ts` — updated expectations
- `packages/owletto-cli/src/commands/init.ts` — `CLOUD_MCP_URL` + label
- `packages/cli/src/commands/init.ts` — default + memory-choice label
- `packages/owletto-extension/manifest.json` — `host_permissions`
- `packages/cli/README.md`, `packages/landing/src/content/docs/guides/agent-settings.md` — `Owletto Cloud` → `Lobu Cloud`

## Test plan
- [x] `bun run typecheck` clean
- [x] `bun test packages/gateway/src/__tests__/file-loader-memory.test.ts` (4/4 pass)
- [x] `make build-packages` clean
- [x] `cd packages/owletto-web && bun run build` produces `dist/index.html` and chunks locally
- [ ] `build-images` workflow succeeds on this PR (depends on lobu-ai/owletto-web#1 being reachable via deploy key — it is, branch is pushed)
- [ ] After merge + Flux reconcile, `curl -H "Accept: text/html" https://app.lobu.ai/` returns `text/html` instead of the JSON status object

## Depends on
- lobu-ai/owletto-web#1