### PR TITLE
fix(owletto-backend): resolve default org when loading social credentials

### DIFF
--- a/packages/owletto-backend/src/auth/index.ts
+++ b/packages/owletto-backend/src/auth/index.ts
@@ -17,6 +17,7 @@ import { resolveBaseUrl, safeParseUrl } from './base-url';
 import {
   getAuthConfig as getAuthConfigFromEnv,
   getEnabledLoginProviderConfigs,
+  resolveDefaultOrganizationId,
   resolveLoginProviderCredentials,
   resolveRequestOrganizationId,
 } from './config';
@@ -63,7 +64,8 @@ export async function createAuth(env: Env, request?: Request) {
   const pool = getAuthPool(env.DATABASE_URL!);
   const runtimeNodeEnv = env.NODE_ENV || process.env.NODE_ENV || 'development';
 
-  const providerRows = await getEnabledLoginProviderConfigs(organizationId);
+  const effectiveOrgId = organizationId ?? (await resolveDefaultOrganizationId());
+  const providerRows = await getEnabledLoginProviderConfigs(effectiveOrgId);
 
   // Build dynamic social providers from enabled connectors
   const socialProviders: Record<
@@ -79,7 +81,7 @@ export async function createAuth(env: Env, request?: Request) {
       connectorKey: row.connectorKey,
       clientIdKey: row.clientIdKey,
       clientSecretKey: row.clientSecretKey,
-      organizationId,
+      organizationId: effectiveOrgId,
     });
     const clientId = credentials.clientId ?? '';
     const clientSecret = credentials.clientSecret ?? '';


### PR DESCRIPTION
## Summary
- `createAuth` was passing `organizationId=null` for `/api/...` requests (the resolver only inspects the URL path, which starts with a reserved segment), so `resolveLoginProviderCredentials` skipped the DB `auth_profiles` lookup entirely and fell back to env vars.
- LinkedIn/Twitter credentials that live only in the app org's DB were invisible, so Better Auth returned "Provider not found" on `/api/auth/sign-in/social`.
- Fix: resolve the default org via `AUTH_DEFAULT_ORGANIZATION_SLUG` (`resolveDefaultOrganizationId()`) when the request doesn't carry an org, and pass that id to both `getEnabledLoginProviderConfigs` and `resolveLoginProviderCredentials`.

## Test plan
- [x] `bun run typecheck`
- [x] Prod DB sanity: running `resolveLoginProviderCredentials` against the `app` org returns valid `clientId` for github/google/linkedin/twitter
- [ ] Post-deploy: `curl -s -X POST -H 'content-type: application/json' -d '{"provider":"linkedin","callbackURL":"/"}' https://app.lobu.ai/api/auth/sign-in/social` returns a redirect (not "Provider not found")
- [ ] End-to-end LinkedIn login on `https://app.lobu.ai`