### PR TITLE
fix(web): bump owletto-web for sidebar gating + reserved-subdomain parity test

### DIFF
--- a/packages/owletto-backend/src/__tests__/unit/subdomain-reserved-parity.test.ts
+++ b/packages/owletto-backend/src/__tests__/unit/subdomain-reserved-parity.test.ts
@@ -1,0 +1,45 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * Guard against drift between the SPA copy of RESERVED_SUBDOMAINS in
+ * `packages/owletto-web/src/lib/subdomain.ts` and the backend canonical
+ * list in `packages/owletto-backend/src/index.ts`. Divergence would
+ * silently break subdomain → org resolution on one side.
+ *
+ * The SPA is a git submodule, so we read the file via fs and parse the
+ * literal Set entries with a regex instead of importing the TS module
+ * (CI may build the parent before the submodule is checked out).
+ */
+
+const REPO_ROOT = join(__dirname, '..', '..', '..', '..', '..');
+const SPA_FILE = join(REPO_ROOT, 'packages/owletto-web/src/lib/subdomain.ts');
+const BACKEND_FILE = join(REPO_ROOT, 'packages/owletto-backend/src/index.ts');
+
+function extractReservedSubdomains(filePath: string): string[] {
+  const source = readFileSync(filePath, 'utf8');
+  const match = source.match(/RESERVED_SUBDOMAINS\s*=\s*new Set\(\[([^\]]+)\]\)/);
+  if (!match) {
+    throw new Error(`Could not find RESERVED_SUBDOMAINS literal in ${filePath}`);
+  }
+  return [...match[1]!.matchAll(/['"]([^'"]+)['"]/g)].map((m) => m[1]!).sort();
+}
+
+describe('RESERVED_SUBDOMAINS parity', () => {
+  it('SPA and backend reserved-subdomain lists are identical', () => {
+    // Skip when the submodule is a stub (no SPA file checked out).
+    let spaList: string[];
+    try {
+      spaList = extractReservedSubdomains(SPA_FILE);
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+        return;
+      }
+      throw err;
+    }
+    const backendList = extractReservedSubdomains(BACKEND_FILE);
+    expect(spaList).toEqual(backendList);
+    expect(spaList.length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary
- Bumps \`packages/owletto-web\` to pull in [lobu-ai/owletto-web#7](https://github.com/lobu-ai/owletto-web/pull/7): hides Knowledge / Watchers / Connectors nav items from anonymous visitors on public-org subdomains. (Members and Agents were already gated by PR #5.)
- Adds \`packages/owletto-backend/src/__tests__/unit/subdomain-reserved-parity.test.ts\` to guard against drift between the SPA copy of \`RESERVED_SUBDOMAINS\` (\`packages/owletto-web/src/lib/subdomain.ts\`) and the backend canonical list (\`packages/owletto-backend/src/index.ts\`). Test parses both files via \`fs\` rather than importing the SPA module so it works even when the submodule is a stub.

## Test plan
- [x] \`bunx vitest run src/__tests__/unit/subdomain-reserved-parity.test.ts\` passes locally.
- [ ] CI green.
- [ ] Post-deploy: signed-out visit to \`https://delivery.lobu.ai/\` shows entity-type sidebar but no admin tabs; signed-in visit shows all tabs.