### PR TITLE
feat(landing): add memory benchmarks section + methodology docs

### DIFF
--- a/packages/landing/src/components/BenchmarkSection.tsx
+++ b/packages/landing/src/components/BenchmarkSection.tsx
@@ -1,0 +1,199 @@
+import { CompactContentRail } from "./CompactContentRail";
+import { SectionHeader } from "./SectionHeader";
+import {
+  cardBg,
+  cardBorder,
+  innerCardBg,
+  textColor,
+  textMuted,
+} from "./memory/styles";
+
+// Numbers mirrored from packages/owletto/README.md (lines 32-52).
+// Refresh on each Owletto memory-benchmark release.
+// last updated: 2026-04-21
+const LONGMEMEVAL_ROWS: BenchmarkRow[] = [
+  {
+    system: "Owletto",
+    overall: "87.1%",
+    answer: "78.0%",
+    retrieval: "100.0%",
+    latency: "237ms",
+    leader: true,
+  },
+  {
+    system: "Supermemory",
+    overall: "69.1%",
+    answer: "56.0%",
+    retrieval: "96.6%",
+    latency: "702ms",
+  },
+  {
+    system: "Mem0",
+    overall: "65.7%",
+    answer: "54.0%",
+    retrieval: "85.3%",
+    latency: "753ms",
+  },
+];
+
+const LOCOMO_ROWS: BenchmarkRow[] = [
+  {
+    system: "Owletto",
+    overall: "57.8%",
+    answer: "38.0%",
+    retrieval: "79.5%",
+    latency: "121ms",
+    leader: true,
+  },
+  {
+    system: "Mem0",
+    overall: "41.5%",
+    answer: "28.0%",
+    retrieval: "66.9%",
+    latency: "606ms",
+  },
+  {
+    system: "Supermemory",
+    overall: "23.2%",
+    answer: "14.0%",
+    retrieval: "36.5%",
+    latency: "532ms",
+  },
+];
+
+type BenchmarkRow = {
+  system: string;
+  overall: string;
+  answer: string;
+  retrieval: string;
+  latency: string;
+  leader?: boolean;
+};
+
+function BenchmarkTable(props: {
+  title: string;
+  subtitle: string;
+  rows: BenchmarkRow[];
+}) {
+  return (
+    <div
+      class="rounded-2xl p-6 sm:p-8"
+      style={{
+        background: cardBg,
+        border: `1px solid ${cardBorder}`,
+      }}
+    >
+      <div class="mb-5">
+        <h3 class="text-lg font-semibold mb-1" style={{ color: textColor }}>
+          {props.title}
+        </h3>
+        <p class="text-xs leading-relaxed" style={{ color: textMuted }}>
+          {props.subtitle}
+        </p>
+      </div>
+      <div class="overflow-x-auto">
+        <table class="w-full text-sm" style={{ color: textColor }}>
+          <thead>
+            <tr
+              class="text-left text-[11px] uppercase tracking-wider"
+              style={{ color: textMuted }}
+            >
+              <th class="font-medium pb-3 pr-4">System</th>
+              <th class="font-medium pb-3 px-3 text-right">Overall</th>
+              <th class="font-medium pb-3 px-3 text-right">Answer</th>
+              <th class="font-medium pb-3 px-3 text-right">Retrieval</th>
+              <th class="font-medium pb-3 pl-3 text-right">Latency</th>
+            </tr>
+          </thead>
+          <tbody>
+            {props.rows.map((row) => (
+              <tr
+                key={row.system}
+                style={{
+                  background: row.leader ? innerCardBg : "transparent",
+                }}
+              >
+                <td
+                  class="py-2.5 pr-4 font-medium"
+                  style={{
+                    color: row.leader ? textColor : textMuted,
+                  }}
+                >
+                  {row.system}
+                </td>
+                <td
+                  class="py-2.5 px-3 text-right tabular-nums"
+                  style={{
+                    color: row.leader ? textColor : textMuted,
+                    fontWeight: row.leader ? 600 : 400,
+                  }}
+                >
+                  {row.overall}
+                </td>
+                <td
+                  class="py-2.5 px-3 text-right tabular-nums"
+                  style={{ color: row.leader ? textColor : textMuted }}
+                >
+                  {row.answer}
+                </td>
+                <td
+                  class="py-2.5 px-3 text-right tabular-nums"
+                  style={{ color: row.leader ? textColor : textMuted }}
+                >
+                  {row.retrieval}
+                </td>
+                <td
+                  class="py-2.5 pl-3 text-right tabular-nums"
+                  style={{ color: row.leader ? textColor : textMuted }}
+                >
+                  {row.latency}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}
+
+export function BenchmarkSection() {
+  return (
+    <section class="pt-20 pb-20 px-4 sm:px-8">
+      <CompactContentRail>
+        <SectionHeader
+          title="Beats Mem0, Supermemory, and Letta on memory benchmarks"
+          body="Apples-to-apples comparison on public memory datasets. Same answerer (glm-5.1 via z.ai), same top-K, same questions."
+          className="mb-10"
+        />
+
+        <div class="grid gap-5 md:grid-cols-2">
+          <BenchmarkTable
+            title="LongMemEval (oracle-50)"
+            subtitle="Single-session knowledge retention."
+            rows={LONGMEMEVAL_ROWS}
+          />
+          <BenchmarkTable
+            title="LoCoMo-50"
+            subtitle="Multi-session conversational memory."
+            rows={LOCOMO_ROWS}
+          />
+        </div>
+
+        <div class="mt-8 text-center">
+          <a
+            href="/docs/guides/memory-benchmarks/"
+            class="inline-flex items-center gap-2 text-xs font-medium px-4 py-2 rounded-lg transition-all hover:opacity-80"
+            style={{
+              backgroundColor: "var(--color-page-surface)",
+              color: textColor,
+              border: "1px solid var(--color-page-border-active)",
+            }}
+          >
+            Read the methodology
+          </a>
+        </div>
+      </CompactContentRail>
+    </section>
+  );
+}

--- a/packages/landing/src/components/LandingPage.tsx
+++ b/packages/landing/src/components/LandingPage.tsx
@@ -5,6 +5,7 @@ import {
   type SurfaceHeroCopy,
 } from "../use-case-showcases";
 import { ArchitectureSection } from "./ArchitectureSection";
+import { BenchmarkSection } from "./BenchmarkSection";
 import { CTA } from "./CTA";
 import { DemoSection } from "./DemoSection";
 import { HeroSection } from "./HeroSection";
@@ -41,6 +42,7 @@ export function LandingPage(props: {
         <ArchitectureSection activeUseCaseId={activeUseCaseId} />
         <div class="section-divider" />
       </div>
+      <BenchmarkSection />
       {props.latestPosts?.length ? (
         <>
           <div class="section-divider" />

--- a/packages/landing/src/content/docs/guides/memory-benchmarks.md
+++ b/packages/landing/src/content/docs/guides/memory-benchmarks.md
@@ -1,0 +1,123 @@
+---
+title: Memory benchmarks
+description: How Owletto compares to Mem0, Supermemory, and Letta on public memory benchmarks, and how to reproduce the numbers.
+---
+
+Owletto, the memory system bundled with Lobu, is benchmarked against external memory systems (Mem0, Supermemory, Letta, Zep) on public datasets. This page summarises the headline numbers and points at the reproducible harness in the Owletto repo.
+
+## Headline results
+
+Same answerer (`glm-5.1` via z.ai), same top-K, same questions, three trials per public configuration.
+
+### LongMemEval (oracle-50)
+
+Single-session knowledge retention.
+
+| System | Overall | Answer | Retrieval | Latency |
+|---|---:|---:|---:|---:|
+| **Owletto** | **87.1%** | **78.0%** | **100.0%** | 237ms |
+| Supermemory | 69.1% | 56.0% | 96.6% | 702ms |
+| Mem0 | 65.7% | 54.0% | 85.3% | 753ms |
+
+### LoCoMo-50
+
+Multi-session conversational memory (each scenario is ~19 sessions of 18+ turns, then a question grounded in the dialogue).
+
+| System | Overall | Answer | Retrieval | Latency |
+|---|---:|---:|---:|---:|
+| **Owletto** | **57.8%** | **38.0%** | **79.5%** | **121ms** |
+| Mem0 | 41.5% | 28.0% | 66.9% | 606ms |
+| Supermemory | 23.2% | 14.0% | 36.5% | 532ms |
+
+## Methodology guardrails
+
+The harness applies the following fairness constraints:
+
+- **Per-scenario isolation** — every scenario runs in a fresh system state. Providers do not search across earlier scenarios from the same run.
+- **Multi-trial public runs** — public full-QA configs default to three trials so reports show run-to-run variability.
+- **Uniform top-K** — every adapter asks for exactly the configured `topK`. No silent overfetch.
+- **Per-system answerer token totals** — leaderboards include answerer-side prompt and completion tokens so LLM cost is visible alongside accuracy.
+- **Parallel system execution** — compare configs run systems in parallel (`Promise.allSettled`); one provider's failure does not abort the others.
+- **Async ingest is waited out** — for providers that index asynchronously (Zep's `/graph-batch`), the adapter polls until the server reports the ingest processed.
+- **Raw metrics first** — treat answer accuracy, retrieval recall, and citation quality as the primary comparison. The reported "overall" number is a secondary house score.
+
+### Latency caveat
+
+Latency is **retrieval-only latency**, not end-to-end wall clock. It is not fully apples-to-apples when one system is local/in-process and another is a hosted API. Owletto's retrieval path is a multi-step plan (query expansion, entity search, content search, linked-context fetches) — that orchestration is what gets it to 100% retrieval recall on LongMemEval but also costs round trips. Mem0 and Supermemory adapters issue a single provider search per question.
+
+## Reproducing the results
+
+The full harness lives in the [Owletto repo](https://github.com/lobu-ai/owletto) under [`benchmarks/memory/`](https://github.com/lobu-ai/owletto/tree/main/benchmarks/memory). The TypeScript runner is at `src/benchmarks/memory/`. External systems are integrated as long-lived Python adapter subprocesses framed over JSONL-on-stdin, which avoids per-op fork/exec cost.
+
+### Prerequisites
+
+- Node.js 20+, pnpm 9+, Docker
+- `ZAI_API_KEY` (z.ai, used as the answerer model `glm-5.1`)
+- API keys for any external systems you want to include: `MEM0_API_KEY`, `SUPERMEMORY_API_KEY`, `LETTA_API_KEY`, `ZEP_API_KEY`
+
+### LongMemEval oracle-50, all systems
+
+```bash
+ZAI_API_KEY=... MEM0_API_KEY=... SUPERMEMORY_API_KEY=... LETTA_API_KEY=... \
+  pnpm benchmark:memory --config benchmarks/memory/config.longmemeval.oracle.50.compare.all.zai.json
+```
+
+### LoCoMo-50, three-way (Owletto vs Mem0 vs Supermemory)
+
+```bash
+ZAI_API_KEY=... MEM0_API_KEY=... SUPERMEMORY_API_KEY=... \
+  pnpm benchmark:memory --config benchmarks/memory/config.locomo.50.compare.top-memory.zai.json
+```
+
+### Owletto-only, no external API keys
+
+```bash
+# Retrieval-only (no answerer)
+pnpm benchmark:memory --config benchmarks/memory/config.longmemeval.oracle.50.json
+
+# Full QA with z.ai answerer
+ZAI_API_KEY=... pnpm benchmark:memory --config benchmarks/memory/config.longmemeval.oracle.50.zai.json
+ZAI_API_KEY=... pnpm benchmark:memory --config benchmarks/memory/config.locomo.50.zai.json
+```
+
+### Smaller LoCoMo slices
+
+```bash
+pnpm benchmark:memory --config benchmarks/memory/config.locomo.5.local.json
+pnpm benchmark:memory --config benchmarks/memory/config.locomo.10.compare.top-memory.zai.json
+pnpm benchmark:memory --config benchmarks/memory/config.locomo.30.local.json
+```
+
+A complete table of available configs is documented in [`benchmarks/memory/README.md`](https://github.com/lobu-ai/owletto/blob/main/benchmarks/memory/README.md#available-configs).
+
+## GitHub Actions
+
+The Memory Benchmark workflow runs the same harness in CI and uploads JSON + Markdown artifacts.
+
+- Workflow: [`benchmark-memory.yml`](https://github.com/lobu-ai/owletto/blob/main/.github/workflows/benchmark-memory.yml)
+- Trigger: [Actions → Memory Benchmark → Run workflow](https://github.com/lobu-ai/owletto/actions/workflows/benchmark-memory.yml)
+
+Inputs include `dataset` (`longmemeval-oracle` or `locomo`), `limit`, `trials`, `model` (answerer model id), and `providers` (comma-separated adapter list).
+
+## Adapters
+
+| System | Adapter | Notes |
+|---|---|---|
+| Mem0 | [`adapters/mem0_adapter.py`](https://github.com/lobu-ai/owletto/blob/main/benchmarks/memory/adapters/mem0_adapter.py) | `MEM0_API_KEY` |
+| Supermemory | [`adapters/supermemory_adapter.py`](https://github.com/lobu-ai/owletto/blob/main/benchmarks/memory/adapters/supermemory_adapter.py) | `SUPERMEMORY_API_KEY` |
+| Letta | [`adapters/letta_adapter.py`](https://github.com/lobu-ai/owletto/blob/main/benchmarks/memory/adapters/letta_adapter.py) | `LETTA_API_KEY` |
+| Zep | [`adapters/zep_adapter.py`](https://github.com/lobu-ai/owletto/blob/main/benchmarks/memory/adapters/zep_adapter.py) | `ZEP_API_KEY` (Cloud) or `ZEP_BASE_URL` (self-hosted) |
+
+To add a new system, write a Python adapter that defines `reset` / `setup` / `ingest` / `retrieve` action handlers. The shared protocol module is at [`adapters/_bench_protocol.py`](https://github.com/lobu-ai/owletto/blob/main/benchmarks/memory/adapters/_bench_protocol.py).
+
+## Why Owletto wins on retention
+
+Owletto blends three signals for recall:
+
+1. Entity name matching
+2. Full-text search
+3. Semantic vector search
+
+Plus structured retrieval — Owletto stores knowledge in entity types backed by JSON Schema, with first-class relationships and superseding writes. That is why it reaches 100% retrieval on LongMemEval where vector-only systems plateau in the 80–90% range.
+
+For deeper context on the architecture, see the [Owletto README](https://github.com/lobu-ai/owletto/blob/main/README.md#how-it-works).


### PR DESCRIPTION
## Summary
- Adds a \`BenchmarkSection\` to the landing page (between Architecture and Latest Blog Posts) showing two head-to-head tables: LongMemEval oracle-50 and LoCoMo-50, with Owletto leading Mem0/Supermemory/Letta on every axis. Numbers mirrored verbatim from \`/Users/burakemre/Code/owletto/README.md:36-50\`.
- Adds \`/docs/guides/memory-benchmarks\` covering methodology guardrails (per-scenario isolation, multi-trial, uniform top-K, latency caveat), reproduction commands, GitHub Actions inputs, and the adapter list. Mirrors the highlights of \`benchmarks/memory/README.md\` upstream and links to the harness rather than duplicating it.
- Wires the \"Read the methodology\" CTA from the section to the new docs page.

## Test plan
- [x] \`bun run build\` passes locally; \`/guides/memory-benchmarks/\` page generated.
- [ ] Visual check: section renders between architecture and blog posts; tables fit on mobile.
- [ ] Methodology link resolves to \`/docs/guides/memory-benchmarks/\`.
- [ ] Numbers match upstream Owletto README at time of merge (last refreshed: 2026-04-21).