### PR TITLE
feat(owletto-backend): allow lobu.ai iframe embedding via CSP frame-ancestors

### DIFF
--- a/packages/owletto-backend/src/index.ts
+++ b/packages/owletto-backend/src/index.ts
@@ -281,10 +281,27 @@ app.use('/*', async (c, next) => {
   c.header('X-XSS-Protection', '1; mode=block');
   c.header('Strict-Transport-Security', 'max-age=31536000; includeSubDomains');
 
-  // No CSP header for JSON APIs - CSP is designed to protect HTML events erom XSS
-  // MCP/API endpoints only return JSON, so CSP restrictions aren't necessary
-  // and can interfere with ChatGPT's connector validation
-  // Removed: Content-Security-Policy header
+  // For HTML responses (SPA entrypoints), add a CSP frame-ancestors directive
+  // that allows the lobu.ai landing page to embed the app. Modern browsers
+  // prefer frame-ancestors over X-Frame-Options when both are present, so this
+  // effectively loosens the SAMEORIGIN restriction for our own properties while
+  // still blocking third-party clickjacking. JSON/API responses keep the
+  // stricter header and no CSP, preserving ChatGPT connector validation.
+  const contentType = c.res.headers.get('content-type') ?? '';
+  if (contentType.startsWith('text/html')) {
+    const rawFrameAncestors = c.env.FRAME_ANCESTORS?.trim();
+    const frameAncestors = rawFrameAncestors
+      ? rawFrameAncestors
+          .split(/[\s,]+/)
+          .map((entry) => entry.trim())
+          .filter(Boolean)
+          .join(' ')
+      : 'https://lobu.ai https://*.lobu.ai';
+    c.header(
+      'Content-Security-Policy',
+      `frame-ancestors 'self' ${frameAncestors}`
+    );
+  }
 
   c.header('Referrer-Policy', 'strict-origin-when-cross-origin');
   // Minimal permissions policy to prevent FLoC without blocking ChatGPT validation

--- a/packages/owletto-sdk/src/types.ts
+++ b/packages/owletto-sdk/src/types.ts
@@ -109,6 +109,11 @@ export interface Env {
   PUBLIC_LOGO_URL?: string;
   PUBLIC_LEGAL_URL?: string;
 
+  // Space- or comma-separated list of origins allowed to iframe the SPA.
+  // Applied as `Content-Security-Policy: frame-ancestors 'self' <list>` on
+  // HTML responses. Defaults to `https://lobu.ai https://*.lobu.ai` when unset.
+  FRAME_ANCESTORS?: string;
+
   // Sync intervals
   DEFAULT_SYNC_INTERVAL_MS?: string;
   DEFAULT_SYNC_INTERVAL_HOURS?: string;


### PR DESCRIPTION
## Summary
- On HTML responses, emit `Content-Security-Policy: frame-ancestors 'self' <list>` so the landing page can embed the Owletto SPA in an iframe.
- Default allowlist: `https://lobu.ai https://*.lobu.ai`. Overridable with the new `FRAME_ANCESTORS` env var (space- or comma-separated).
- JSON/API responses keep the stricter existing headers and omit CSP to preserve ChatGPT connector validation.

## Why
The landing page's Live workspace iframe was being blocked by the default `X-Frame-Options: SAMEORIGIN`. `frame-ancestors` is the modern, browser-preferred replacement and lets us whitelist specific origins without loosening third-party clickjacking protection.

## Test plan
- [ ] `curl -I https://owletto.lobu.ai/` returns `Content-Security-Policy: frame-ancestors 'self' https://lobu.ai https://*.lobu.ai`
- [ ] API endpoints (`/mcp`, `/api/...`) still return no CSP header
- [ ] Landing `/memory` use-case iframe loads without X-Frame-Options blocking