### PR TITLE
fix(landing): restore campaign description from runtime.request

### DIFF
--- a/packages/landing/src/use-case-showcases.ts
+++ b/packages/landing/src/use-case-showcases.ts
@@ -2058,9 +2058,9 @@ function toCampaignMeta(
 ): CampaignMeta {
   return {
     title: `Deploy secure ${useCase.label.toLowerCase()} agents on your infrastructure`,
-    description: runtime.summary,
+    description: runtime.request,
     seoTitle: `${useCase.label} AI agents on your infrastructure - Lobu`,
-    seoDescription: runtime.summary,
+    seoDescription: runtime.request,
     ctaHref: `/for/${useCaseId}`,
     ctaLabel: `Open ${useCase.label} page`,
   };


### PR DESCRIPTION
## Summary
`toCampaignMeta` was still reading `runtime.summary`, but that field was removed during the runtime refactor in #247. Result: `undefined` for both `campaign.description` and `campaign.seoDescription`, which dropped the meta description and `og:description` on every `/for/[useCase]` page.

Uses `runtime.request` instead — a one-sentence description of what the agent does, which is the closest surviving equivalent of the old summary.

Caught by Codex review on #247 (P2).

## Test plan
- [x] `cd packages/landing && bun run build` passes
- [x] `dist/for/legal/index.html` has non-empty `<meta name="description">` and `og:description`