### PR TITLE
refactor(scripts): dedup env-sync secrets and makefile deployment-mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,15 @@
 # Development Makefile for Lobu
 
+# Resolve deployment mode once: honor explicit env var, else parse .env, else default to docker.
+DEPLOYMENT_MODE := $(shell \
+	if [ -n "$$DEPLOYMENT_MODE" ]; then \
+		echo "$$DEPLOYMENT_MODE"; \
+	elif [ -f .env ]; then \
+		grep "^DEPLOYMENT_MODE=" .env | cut -d'=' -f2 | tr -d ' '; \
+	else \
+		echo docker; \
+	fi)
+
 .PHONY: help setup build test eval clean logs deploy down build-packages dev
 
 # Default target
@@ -142,13 +152,7 @@ deploy:
 
 # View logs based on deployment mode
 logs:
-	@# Read DEPLOYMENT_MODE from .env file
-	@if [ -f .env ]; then \
-		DEPLOYMENT_MODE=$$(grep "^DEPLOYMENT_MODE=" .env | cut -d'=' -f2 | tr -d ' '); \
-	else \
-		DEPLOYMENT_MODE="docker"; \
-	fi; \
-	if [ "$$DEPLOYMENT_MODE" = "kubernetes" ] || [ "$$DEPLOYMENT_MODE" = "k8s" ]; then \
+	@if [ "$(DEPLOYMENT_MODE)" = "kubernetes" ] || [ "$(DEPLOYMENT_MODE)" = "k8s" ]; then \
 		echo "☸️  Viewing Kubernetes logs..."; \
 		echo "Select a pod to view logs:"; \
 		kubectl get pods -n lobu; \
@@ -169,14 +173,8 @@ down:
 
 # Clean up everything including volumes
 clean:
-	@# Load deployment mode from .env
-	@if [ -f .env ]; then \
-		DEPLOYMENT_MODE=$$(grep "^DEPLOYMENT_MODE=" .env | cut -d'=' -f2 | tr -d ' '); \
-	else \
-		DEPLOYMENT_MODE="docker"; \
-	fi; \
-	echo "🧹 Cleaning up lobu resources (mode: $$DEPLOYMENT_MODE)..."; \
-	if [ "$$DEPLOYMENT_MODE" = "kubernetes" ] || [ "$$DEPLOYMENT_MODE" = "k8s" ]; then \
+	@echo "🧹 Cleaning up lobu resources (mode: $(DEPLOYMENT_MODE))..."; \
+	if [ "$(DEPLOYMENT_MODE)" = "kubernetes" ] || [ "$(DEPLOYMENT_MODE)" = "k8s" ]; then \
 		echo "☸️  Cleaning Kubernetes resources..."; \
 		helm uninstall lobu -n lobu 2>/dev/null || true; \
 		kubectl delete namespace lobu --wait=false 2>/dev/null || true; \
@@ -191,14 +189,8 @@ clean:
 	fi
 
 clean-workers:
-	@# Load deployment mode from .env
-	@if [ -f .env ]; then \
-		DEPLOYMENT_MODE=$$(grep "^DEPLOYMENT_MODE=" .env | cut -d'=' -f2 | tr -d ' '); \
-	else \
-		DEPLOYMENT_MODE="docker"; \
-	fi; \
-	echo "🧹 Removing worker containers (mode: $$DEPLOYMENT_MODE)..."; \
-	if [ "$$DEPLOYMENT_MODE" = "kubernetes" ] || [ "$$DEPLOYMENT_MODE" = "k8s" ]; then \
+	@echo "🧹 Removing worker containers (mode: $(DEPLOYMENT_MODE))..."; \
+	if [ "$(DEPLOYMENT_MODE)" = "kubernetes" ] || [ "$(DEPLOYMENT_MODE)" = "k8s" ]; then \
 		echo "☸️  Removing Kubernetes worker pods..."; \
 		kubectl delete pods -n lobu -l app.kubernetes.io/component=worker --wait=false 2>/dev/null || true; \
 		echo "✅ Kubernetes worker pods removed"; \

--- a/scripts/lib/secret-args.sh
+++ b/scripts/lib/secret-args.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+# Shared secret-args builder for .env → Kubernetes secret tooling.
+#
+# Sourced by `scripts/seal-env.sh` and `scripts/sync-env-to-k8s.sh`. Reads
+# env vars from the current shell (callers `set -a; source .env; set +a`
+# beforehand) and populates a SECRET_ARGS bash array with
+# `--from-literal=<k8s-key>=<value>` entries for every non-empty secret.
+#
+# Usage:
+#   SECRET_ARGS=()
+#   source "$SCRIPT_DIR/lib/secret-args.sh"
+#   build_secret_args
+#   # SECRET_ARGS is now populated
+
+build_secret_args() {
+  # Slack credentials
+  [[ -n "$SLACK_BOT_TOKEN" ]] && SECRET_ARGS+=(--from-literal=slack-bot-token="$SLACK_BOT_TOKEN")
+  [[ -n "$SLACK_APP_TOKEN" ]] && SECRET_ARGS+=(--from-literal=slack-app-token="$SLACK_APP_TOKEN")
+  [[ -n "$SLACK_SIGNING_SECRET" ]] && SECRET_ARGS+=(--from-literal=slack-signing-secret="$SLACK_SIGNING_SECRET")
+  [[ -n "$SLACK_CLIENT_ID" ]] && SECRET_ARGS+=(--from-literal=slack-client-id="$SLACK_CLIENT_ID")
+  [[ -n "$SLACK_CLIENT_SECRET" ]] && SECRET_ARGS+=(--from-literal=slack-client-secret="$SLACK_CLIENT_SECRET")
+
+  # Claude/Anthropic credentials
+  [[ -n "$ANTHROPIC_API_KEY" ]] && SECRET_ARGS+=(--from-literal=anthropic-api-key="$ANTHROPIC_API_KEY")
+  [[ -n "$CLAUDE_CODE_OAUTH_TOKEN" ]] && SECRET_ARGS+=(--from-literal=claude-code-oauth-token="$CLAUDE_CODE_OAUTH_TOKEN")
+
+  # Encryption key
+  [[ -n "$ENCRYPTION_KEY" ]] && SECRET_ARGS+=(--from-literal=encryption-key="$ENCRYPTION_KEY")
+
+  # Sentry
+  [[ -n "$SENTRY_DSN" ]] && SECRET_ARGS+=(--from-literal=sentry-dsn="$SENTRY_DSN")
+
+  # GitHub
+  [[ -n "$GITHUB_CLIENT_SECRET" ]] && SECRET_ARGS+=(--from-literal=github-client-secret="$GITHUB_CLIENT_SECRET")
+
+  # Telegram
+  [[ -n "$TELEGRAM_BOT_TOKEN" ]] && SECRET_ARGS+=(--from-literal=telegram-bot-token="$TELEGRAM_BOT_TOKEN")
+}

--- a/scripts/seal-env.sh
+++ b/scripts/seal-env.sh
@@ -67,29 +67,9 @@ rm -f "$TEMP_ENV"
 
 # Build secret from env vars (only include non-empty values)
 SECRET_ARGS=()
-
-# Slack credentials
-[[ -n "$SLACK_BOT_TOKEN" ]] && SECRET_ARGS+=(--from-literal=slack-bot-token="$SLACK_BOT_TOKEN")
-[[ -n "$SLACK_APP_TOKEN" ]] && SECRET_ARGS+=(--from-literal=slack-app-token="$SLACK_APP_TOKEN")
-[[ -n "$SLACK_SIGNING_SECRET" ]] && SECRET_ARGS+=(--from-literal=slack-signing-secret="$SLACK_SIGNING_SECRET")
-[[ -n "$SLACK_CLIENT_ID" ]] && SECRET_ARGS+=(--from-literal=slack-client-id="$SLACK_CLIENT_ID")
-[[ -n "$SLACK_CLIENT_SECRET" ]] && SECRET_ARGS+=(--from-literal=slack-client-secret="$SLACK_CLIENT_SECRET")
-
-# Claude/Anthropic credentials
-[[ -n "$ANTHROPIC_API_KEY" ]] && SECRET_ARGS+=(--from-literal=anthropic-api-key="$ANTHROPIC_API_KEY")
-[[ -n "$CLAUDE_CODE_OAUTH_TOKEN" ]] && SECRET_ARGS+=(--from-literal=claude-code-oauth-token="$CLAUDE_CODE_OAUTH_TOKEN")
-
-# Encryption key
-[[ -n "$ENCRYPTION_KEY" ]] && SECRET_ARGS+=(--from-literal=encryption-key="$ENCRYPTION_KEY")
-
-# Sentry
-[[ -n "$SENTRY_DSN" ]] && SECRET_ARGS+=(--from-literal=sentry-dsn="$SENTRY_DSN")
-
-# GitHub
-[[ -n "$GITHUB_CLIENT_SECRET" ]] && SECRET_ARGS+=(--from-literal=github-client-secret="$GITHUB_CLIENT_SECRET")
-
-# Telegram
-[[ -n "$TELEGRAM_BOT_TOKEN" ]] && SECRET_ARGS+=(--from-literal=telegram-bot-token="$TELEGRAM_BOT_TOKEN")
+# shellcheck source=lib/secret-args.sh
+source "$SCRIPT_DIR/lib/secret-args.sh"
+build_secret_args
 
 if [[ ${#SECRET_ARGS[@]} -eq 0 ]]; then
   echo "Error: No secrets found in .env file" >&2

--- a/scripts/setup-dev.sh
+++ b/scripts/setup-dev.sh
@@ -4,6 +4,14 @@ set -e
 # Check dependencies
 command -v bun >/dev/null || { echo "Install bun: curl -fsSL https://bun.sh/install | bash"; exit 1; }
 command -v docker >/dev/null || { echo "Install Docker Desktop"; exit 1; }
+if ! command -v yq >/dev/null; then
+  case "$(uname -s)" in
+    Darwin) echo "Install yq: brew install yq" ;;
+    Linux)  echo "Install yq: sudo apt-get install -y yq  (or see https://github.com/mikefarah/yq#install)" ;;
+    *)      echo "Install yq: https://github.com/mikefarah/yq#install" ;;
+  esac
+  exit 1
+fi
 
 # Build worker + packages
 docker build -t lobu-worker:latest -f docker/Dockerfile.worker --build-arg NODE_ENV=development .

--- a/scripts/sync-env-to-k8s.sh
+++ b/scripts/sync-env-to-k8s.sh
@@ -52,26 +52,9 @@ rm "$TEMP_ENV"
 
 # Build secret args (only include non-empty values)
 SECRET_ARGS=()
-
-# Slack credentials (optional)
-[[ -n "$SLACK_BOT_TOKEN" ]] && SECRET_ARGS+=(--from-literal=slack-bot-token="$SLACK_BOT_TOKEN")
-[[ -n "$SLACK_APP_TOKEN" ]] && SECRET_ARGS+=(--from-literal=slack-app-token="$SLACK_APP_TOKEN")
-[[ -n "$SLACK_SIGNING_SECRET" ]] && SECRET_ARGS+=(--from-literal=slack-signing-secret="$SLACK_SIGNING_SECRET")
-[[ -n "$SLACK_CLIENT_ID" ]] && SECRET_ARGS+=(--from-literal=slack-client-id="$SLACK_CLIENT_ID")
-[[ -n "$SLACK_CLIENT_SECRET" ]] && SECRET_ARGS+=(--from-literal=slack-client-secret="$SLACK_CLIENT_SECRET")
-
-# Claude/Anthropic credentials
-[[ -n "$ANTHROPIC_API_KEY" ]] && SECRET_ARGS+=(--from-literal=anthropic-api-key="$ANTHROPIC_API_KEY")
-[[ -n "$CLAUDE_CODE_OAUTH_TOKEN" ]] && SECRET_ARGS+=(--from-literal=claude-code-oauth-token="$CLAUDE_CODE_OAUTH_TOKEN")
-
-# Encryption key
-[[ -n "$ENCRYPTION_KEY" ]] && SECRET_ARGS+=(--from-literal=encryption-key="$ENCRYPTION_KEY")
-
-# Sentry
-[[ -n "$SENTRY_DSN" ]] && SECRET_ARGS+=(--from-literal=sentry-dsn="$SENTRY_DSN")
-
-# GitHub
-[[ -n "$GITHUB_CLIENT_SECRET" ]] && SECRET_ARGS+=(--from-literal=github-client-secret="$GITHUB_CLIENT_SECRET")
+# shellcheck source=lib/secret-args.sh
+source "$SCRIPT_DIR/lib/secret-args.sh"
+build_secret_args
 
 if [[ ${#SECRET_ARGS[@]} -eq 0 ]]; then
   echo "Error: No secrets found in .env file" >&2

--- a/scripts/sync-env-to-values.sh
+++ b/scripts/sync-env-to-values.sh
@@ -5,6 +5,16 @@
 
 ENV_FILE=".env"
 
+if ! command -v yq >/dev/null 2>&1; then
+    echo "❌ yq is required. Install it and retry:" >&2
+    case "$(uname -s)" in
+        Darwin) echo "   brew install yq" >&2 ;;
+        Linux)  echo "   sudo apt-get install -y yq  (or see https://github.com/mikefarah/yq#install)" >&2 ;;
+        *)      echo "   https://github.com/mikefarah/yq#install" >&2 ;;
+    esac
+    exit 1
+fi
+
 # Determine values file based on environment or explicit path
 if [ -n "$2" ]; then
     # Environment specified (dev, production, local)
@@ -49,13 +59,7 @@ update_yaml_value() {
 
     if [ -n "$value" ]; then
         echo "  ✓ $key: $value"
-        # Use yq if available, otherwise sed
-        if command -v yq >/dev/null 2>&1; then
-            yq eval "$yaml_path = \"$value\"" -i "$TEMP_VALUES"
-        else
-            # Fallback to sed for simple cases
-            sed -i.bak "s|$yaml_path:.*|$yaml_path: $value|g" "$TEMP_VALUES" && rm "$TEMP_VALUES.bak"
-        fi
+        yq eval "$yaml_path = \"$value\"" -i "$TEMP_VALUES"
     fi
 }
 


### PR DESCRIPTION
## Summary
- Extract the shared `SECRET_ARGS` builder into `scripts/lib/secret-args.sh` and source it from both `scripts/seal-env.sh` and `scripts/sync-env-to-k8s.sh`. **Drift fix:** `sync-env-to-k8s.sh` was missing `TELEGRAM_BOT_TOKEN`, which `seal-env.sh` already had; both now produce identical secret args.
- Resolve `DEPLOYMENT_MODE` once at the top of the `Makefile` via `$(shell ...)` (honoring an explicit env var, else `.env`, else `docker`). Removes three copy-pasted sed/grep blocks from `logs`, `clean`, and `clean-workers`.
- Require `yq` upfront in `scripts/setup-dev.sh` (fails fast with a macOS/Linux install hint) and drop the silent `sed` fallback in `scripts/sync-env-to-values.sh`. **Behavior change:** `sync-env-to-values.sh` now errors out when `yq` is missing instead of silently degrading to a less-correct `sed` path.

## Test plan
- [x] `bash -n scripts/seal-env.sh`
- [x] `bash -n scripts/sync-env-to-k8s.sh`
- [x] `bash -n scripts/lib/secret-args.sh`
- [x] `bash -n scripts/sync-env-to-values.sh`
- [x] `bash -n scripts/setup-dev.sh`
- [x] `make -n deploy`, `make -n logs`, `make -n clean`, `make -n clean-workers` all expand with the resolved `DEPLOYMENT_MODE`
- [ ] On a host with `.env` configured, `./scripts/sync-env-to-k8s.sh` seals the same set of keys as `./scripts/seal-env.sh`
- [ ] Fresh machine: `./scripts/setup-dev.sh` exits non-zero with install hint when `yq` is absent