### PR TITLE
refactor(gateway): consolidate agent stores behind BaseAgentStore

### DIFF
--- a/packages/gateway/src/__tests__/core-services-store-selection.test.ts
+++ b/packages/gateway/src/__tests__/core-services-store-selection.test.ts
@@ -7,11 +7,7 @@ import {
   SecretStoreRegistry,
   type WritableSecretStore,
 } from "../secrets";
-import {
-  RedisAgentAccessStore,
-  RedisAgentConfigStore,
-  RedisAgentConnectionStore,
-} from "../stores/redis-agent-store";
+import { RedisAgentStore } from "../stores/redis-agent-store";
 import { MockMessageQueue } from "./setup";
 
 function createGatewayConfig(
@@ -144,11 +140,9 @@ describe("CoreServices store selection", () => {
 
     await (coreServices as any).initializeSessionServices();
 
-    expect(coreServices.getConfigStore()).toBeInstanceOf(RedisAgentConfigStore);
-    expect(coreServices.getConnectionStore()).toBeInstanceOf(
-      RedisAgentConnectionStore
-    );
-    expect(coreServices.getAccessStore()).toBeInstanceOf(RedisAgentAccessStore);
+    expect(coreServices.getConfigStore()).toBeInstanceOf(RedisAgentStore);
+    expect(coreServices.getConnectionStore()).toBeInstanceOf(RedisAgentStore);
+    expect(coreServices.getAccessStore()).toBeInstanceOf(RedisAgentStore);
   });
 
   test("uses the host-provided secret store for persisted auth profiles", async () => {

--- a/packages/gateway/src/services/core-services.ts
+++ b/packages/gateway/src/services/core-services.ts
@@ -63,11 +63,7 @@ import {
   SecretStoreRegistry,
 } from "../secrets";
 import { InMemoryAgentStore } from "../stores/in-memory-agent-store";
-import {
-  RedisAgentAccessStore,
-  RedisAgentConfigStore,
-  RedisAgentConnectionStore,
-} from "../stores/redis-agent-store";
+import { RedisAgentStore } from "../stores/redis-agent-store";
 import { BedrockModelCatalog } from "./bedrock-model-catalog";
 import { BedrockOpenAIService } from "./bedrock-openai-service";
 import {
@@ -436,24 +432,17 @@ export class CoreServices {
             `Agent sub-stores initialized (in-memory, ${this.fileLoadedAgents.length} agent(s) from files)`
           );
         } else {
-          if (!this.configStore) {
-            this.configStore = new RedisAgentConfigStore(
-              this.agentSettingsStore,
-              this.agentMetadataStore
-            );
-          }
-          if (!this.connectionStore) {
-            this.connectionStore = new RedisAgentConnectionStore(
-              redisClient,
-              this.channelBindingService
-            );
-          }
-          if (!this.accessStore) {
-            this.accessStore = new RedisAgentAccessStore(
-              this.grantStore,
-              this.userAgentsStore
-            );
-          }
+          const redisStore = new RedisAgentStore(
+            redisClient,
+            this.agentSettingsStore,
+            this.agentMetadataStore,
+            this.grantStore,
+            this.userAgentsStore,
+            this.channelBindingService
+          );
+          if (!this.configStore) this.configStore = redisStore;
+          if (!this.connectionStore) this.connectionStore = redisStore;
+          if (!this.accessStore) this.accessStore = redisStore;
           logger.debug("Agent sub-stores initialized (Redis-backed defaults)");
         }
       }

--- a/packages/gateway/src/stores/base-agent-store.ts
+++ b/packages/gateway/src/stores/base-agent-store.ts
@@ -90,7 +90,9 @@ export abstract class BaseAgentStore implements AgentStore {
   protected abstract readConnection(
     connectionId: string
   ): Promise<StoredConnection | null>;
-  protected abstract writeConnection(connection: StoredConnection): Promise<void>;
+  protected abstract writeConnection(
+    connection: StoredConnection
+  ): Promise<void>;
   protected abstract deleteConnectionRaw(connectionId: string): Promise<void>;
   protected abstract listConnectionsByTemplate(
     templateAgentId?: string

--- a/packages/gateway/src/stores/base-agent-store.ts
+++ b/packages/gateway/src/stores/base-agent-store.ts
@@ -1,0 +1,239 @@
+/**
+ * BaseAgentStore — shared scaffolding for AgentStore implementations.
+ *
+ * Concrete stores (InMemoryAgentStore, RedisAgentStore) provide raw CRUD
+ * primitives for each resource; the base class exposes the public AgentStore
+ * interface on top of those primitives, centralizing the get→merge→save
+ * update pattern and the listConnections platform filter.
+ *
+ * Grants, user-agent associations and channel bindings vary too much between
+ * in-memory (self-contained Maps) and Redis (delegating to GrantStore /
+ * UserAgentsStore / ChannelBindingService) to share concrete logic; subclasses
+ * implement those groups directly.
+ */
+
+import type {
+  AgentMetadata,
+  AgentSettings,
+  AgentStore,
+  ChannelBinding,
+  Grant,
+  StoredConnection,
+} from "@lobu/core";
+
+/**
+ * Join key parts with `:` — the canonical separator used by every
+ * composite key in the gateway stores.
+ */
+export function buildKey(parts: string[]): string {
+  return parts.join(":");
+}
+
+/**
+ * Return the Set stored at `key`, creating (and inserting) an empty one if
+ * it's missing. Saves the `if (!set) { set = new Set(); map.set(key, set); }`
+ * dance at every call site.
+ */
+export function getOrCreateSet<K, V>(map: Map<K, Set<V>>, key: K): Set<V> {
+  let set = map.get(key);
+  if (!set) {
+    set = new Set();
+    map.set(key, set);
+  }
+  return set;
+}
+
+export abstract class BaseAgentStore implements AgentStore {
+  // ── Settings primitives ────────────────────────────────────────────
+
+  protected abstract readSettings(
+    agentId: string
+  ): Promise<AgentSettings | null>;
+  protected abstract writeSettings(
+    agentId: string,
+    settings: AgentSettings
+  ): Promise<void>;
+  protected abstract deleteSettingsRaw(agentId: string): Promise<void>;
+  protected abstract hasSettingsRaw(agentId: string): Promise<boolean>;
+
+  // ── Metadata primitives ────────────────────────────────────────────
+  //
+  // `saveMetadata` / `updateMetadata` are abstract rather than expressed as a
+  // shared read→merge→write pattern because the Redis backend delegates to
+  // `AgentMetadataStore.createAgent` for saves (which stamps a fresh
+  // `createdAt`) and to `AgentMetadataStore.updateMetadata` for updates
+  // (which preserves `createdAt` and accepts only a narrow subset of
+  // fields). Routing updates through a shared `writeMetadata` primitive
+  // would corrupt `createdAt` on every update call.
+
+  protected abstract readMetadata(
+    agentId: string
+  ): Promise<AgentMetadata | null>;
+  protected abstract deleteMetadataRaw(agentId: string): Promise<void>;
+  protected abstract hasMetadataRaw(agentId: string): Promise<boolean>;
+  protected abstract listAllMetadata(): Promise<AgentMetadata[]>;
+  protected abstract listSandboxMetadata(
+    connectionId: string
+  ): Promise<AgentMetadata[]>;
+
+  abstract saveMetadata(
+    agentId: string,
+    metadata: AgentMetadata
+  ): Promise<void>;
+  abstract updateMetadata(
+    agentId: string,
+    updates: Partial<AgentMetadata>
+  ): Promise<void>;
+
+  // ── Connection primitives ────────────────────────────────────────
+
+  protected abstract readConnection(
+    connectionId: string
+  ): Promise<StoredConnection | null>;
+  protected abstract writeConnection(connection: StoredConnection): Promise<void>;
+  protected abstract deleteConnectionRaw(connectionId: string): Promise<void>;
+  protected abstract listConnectionsByTemplate(
+    templateAgentId?: string
+  ): Promise<StoredConnection[]>;
+
+  // ── Grants (implemented per-backend) ──────────────────────────────
+
+  abstract grant(
+    agentId: string,
+    pattern: string,
+    expiresAt: number | null,
+    denied?: boolean
+  ): Promise<void>;
+  abstract hasGrant(agentId: string, pattern: string): Promise<boolean>;
+  abstract isDenied(agentId: string, pattern: string): Promise<boolean>;
+  abstract listGrants(agentId: string): Promise<Grant[]>;
+  abstract revokeGrant(agentId: string, pattern: string): Promise<void>;
+
+  // ── User-Agent Associations (implemented per-backend) ─────────────
+
+  abstract addUserAgent(
+    platform: string,
+    userId: string,
+    agentId: string
+  ): Promise<void>;
+  abstract removeUserAgent(
+    platform: string,
+    userId: string,
+    agentId: string
+  ): Promise<void>;
+  abstract listUserAgents(platform: string, userId: string): Promise<string[]>;
+  abstract ownsAgent(
+    platform: string,
+    userId: string,
+    agentId: string
+  ): Promise<boolean>;
+
+  // ── Channel Bindings (implemented per-backend) ────────────────────
+
+  abstract getChannelBinding(
+    platform: string,
+    channelId: string,
+    teamId?: string
+  ): Promise<ChannelBinding | null>;
+  abstract createChannelBinding(binding: ChannelBinding): Promise<void>;
+  abstract deleteChannelBinding(
+    platform: string,
+    channelId: string,
+    teamId?: string
+  ): Promise<void>;
+  abstract listChannelBindings(agentId: string): Promise<ChannelBinding[]>;
+  abstract deleteAllChannelBindings(agentId: string): Promise<number>;
+
+  // ── Settings (AgentConfigStore) ────────────────────────────────────
+
+  async getSettings(agentId: string): Promise<AgentSettings | null> {
+    return this.readSettings(agentId);
+  }
+
+  async saveSettings(agentId: string, settings: AgentSettings): Promise<void> {
+    await this.writeSettings(agentId, { ...settings, updatedAt: Date.now() });
+  }
+
+  async updateSettings(
+    agentId: string,
+    updates: Partial<AgentSettings>
+  ): Promise<void> {
+    const existing = await this.readSettings(agentId);
+    await this.writeSettings(agentId, {
+      ...(existing || {}),
+      ...updates,
+      updatedAt: Date.now(),
+    } as AgentSettings);
+  }
+
+  async deleteSettings(agentId: string): Promise<void> {
+    await this.deleteSettingsRaw(agentId);
+  }
+
+  async hasSettings(agentId: string): Promise<boolean> {
+    return this.hasSettingsRaw(agentId);
+  }
+
+  // ── Metadata (AgentConfigStore) ────────────────────────────────────
+
+  async getMetadata(agentId: string): Promise<AgentMetadata | null> {
+    return this.readMetadata(agentId);
+  }
+
+  async deleteMetadata(agentId: string): Promise<void> {
+    await this.deleteMetadataRaw(agentId);
+  }
+
+  async hasAgent(agentId: string): Promise<boolean> {
+    return this.hasMetadataRaw(agentId);
+  }
+
+  async listAgents(): Promise<AgentMetadata[]> {
+    return this.listAllMetadata();
+  }
+
+  async listSandboxes(connectionId: string): Promise<AgentMetadata[]> {
+    return this.listSandboxMetadata(connectionId);
+  }
+
+  // ── Connections (AgentConnectionStore) ────────────────────────────
+
+  async getConnection(connectionId: string): Promise<StoredConnection | null> {
+    return this.readConnection(connectionId);
+  }
+
+  async saveConnection(connection: StoredConnection): Promise<void> {
+    await this.writeConnection(connection);
+  }
+
+  async updateConnection(
+    connectionId: string,
+    updates: Partial<StoredConnection>
+  ): Promise<void> {
+    const existing = await this.readConnection(connectionId);
+    if (!existing) return;
+    await this.saveConnection({
+      ...existing,
+      ...updates,
+      id: connectionId,
+      updatedAt: Date.now(),
+    });
+  }
+
+  async deleteConnection(connectionId: string): Promise<void> {
+    await this.deleteConnectionRaw(connectionId);
+  }
+
+  async listConnections(filter?: {
+    templateAgentId?: string;
+    platform?: string;
+  }): Promise<StoredConnection[]> {
+    const connections = await this.listConnectionsByTemplate(
+      filter?.templateAgentId
+    );
+    if (filter?.platform) {
+      return connections.filter((c) => c.platform === filter.platform);
+    }
+    return connections;
+  }
+}

--- a/packages/gateway/src/stores/in-memory-agent-store.ts
+++ b/packages/gateway/src/stores/in-memory-agent-store.ts
@@ -14,11 +14,7 @@ import {
   type Grant,
   type StoredConnection,
 } from "@lobu/core";
-import {
-  BaseAgentStore,
-  buildKey,
-  getOrCreateSet,
-} from "./base-agent-store";
+import { BaseAgentStore, buildKey, getOrCreateSet } from "./base-agent-store";
 
 export class InMemoryAgentStore extends BaseAgentStore {
   private settings = new Map<string, AgentSettings>();
@@ -37,9 +33,7 @@ export class InMemoryAgentStore extends BaseAgentStore {
 
   // ── Settings primitives ───────────────────────────────────────────
 
-  protected async readSettings(
-    agentId: string
-  ): Promise<AgentSettings | null> {
+  protected async readSettings(agentId: string): Promise<AgentSettings | null> {
     return this.settings.get(agentId) ?? null;
   }
 
@@ -60,16 +54,11 @@ export class InMemoryAgentStore extends BaseAgentStore {
 
   // ── Metadata primitives ───────────────────────────────────────────
 
-  protected async readMetadata(
-    agentId: string
-  ): Promise<AgentMetadata | null> {
+  protected async readMetadata(agentId: string): Promise<AgentMetadata | null> {
     return this.metadata.get(agentId) ?? null;
   }
 
-  async saveMetadata(
-    agentId: string,
-    metadata: AgentMetadata
-  ): Promise<void> {
+  async saveMetadata(agentId: string, metadata: AgentMetadata): Promise<void> {
     this.metadata.set(agentId, metadata);
     if (metadata.parentConnectionId) {
       getOrCreateSet(this.sandboxes, metadata.parentConnectionId).add(agentId);
@@ -126,9 +115,7 @@ export class InMemoryAgentStore extends BaseAgentStore {
     return this.connections.get(connectionId) ?? null;
   }
 
-  protected async writeConnection(
-    connection: StoredConnection
-  ): Promise<void> {
+  protected async writeConnection(connection: StoredConnection): Promise<void> {
     this.connections.set(connection.id, connection);
     this.connectionsAll.add(connection.id);
     if (connection.templateAgentId) {

--- a/packages/gateway/src/stores/in-memory-agent-store.ts
+++ b/packages/gateway/src/stores/in-memory-agent-store.ts
@@ -1,20 +1,26 @@
 /**
  * InMemoryAgentStore — default AgentStore backed by in-memory Maps.
  *
- * Populated from files (dev mode) or via API (embedded mode).
+ * Populated from files (dev mode) or via API (embedded mode). Raw CRUD
+ * primitives operate on Maps; the public AgentStore surface is inherited
+ * from BaseAgentStore.
  */
 
 import {
   normalizeDomainPattern,
   type AgentMetadata,
   type AgentSettings,
-  type AgentStore,
   type ChannelBinding,
   type Grant,
   type StoredConnection,
 } from "@lobu/core";
+import {
+  BaseAgentStore,
+  buildKey,
+  getOrCreateSet,
+} from "./base-agent-store";
 
-export class InMemoryAgentStore implements AgentStore {
+export class InMemoryAgentStore extends BaseAgentStore {
   private settings = new Map<string, AgentSettings>();
   private metadata = new Map<string, AgentMetadata>();
   private connections = new Map<string, StoredConnection>();
@@ -29,51 +35,44 @@ export class InMemoryAgentStore implements AgentStore {
   private userAgents = new Map<string, Set<string>>();
   private sandboxes = new Map<string, Set<string>>();
 
-  // ── Agent Settings ──────────────────────────────────────────────────
+  // ── Settings primitives ───────────────────────────────────────────
 
-  async getSettings(agentId: string): Promise<AgentSettings | null> {
+  protected async readSettings(
+    agentId: string
+  ): Promise<AgentSettings | null> {
     return this.settings.get(agentId) ?? null;
   }
 
-  async saveSettings(agentId: string, settings: AgentSettings): Promise<void> {
-    this.settings.set(agentId, { ...settings, updatedAt: Date.now() });
-  }
-
-  async updateSettings(
+  protected async writeSettings(
     agentId: string,
-    updates: Partial<AgentSettings>
+    settings: AgentSettings
   ): Promise<void> {
-    const existing = this.settings.get(agentId);
-    this.settings.set(agentId, {
-      ...(existing || {}),
-      ...updates,
-      updatedAt: Date.now(),
-    } as AgentSettings);
+    this.settings.set(agentId, settings);
   }
 
-  async deleteSettings(agentId: string): Promise<void> {
+  protected async deleteSettingsRaw(agentId: string): Promise<void> {
     this.settings.delete(agentId);
   }
 
-  async hasSettings(agentId: string): Promise<boolean> {
+  protected async hasSettingsRaw(agentId: string): Promise<boolean> {
     return this.settings.has(agentId);
   }
 
-  // ── Agent Metadata ────────────────────────────────────────────────
+  // ── Metadata primitives ───────────────────────────────────────────
 
-  async getMetadata(agentId: string): Promise<AgentMetadata | null> {
+  protected async readMetadata(
+    agentId: string
+  ): Promise<AgentMetadata | null> {
     return this.metadata.get(agentId) ?? null;
   }
 
-  async saveMetadata(agentId: string, metadata: AgentMetadata): Promise<void> {
+  async saveMetadata(
+    agentId: string,
+    metadata: AgentMetadata
+  ): Promise<void> {
     this.metadata.set(agentId, metadata);
     if (metadata.parentConnectionId) {
-      let set = this.sandboxes.get(metadata.parentConnectionId);
-      if (!set) {
-        set = new Set();
-        this.sandboxes.set(metadata.parentConnectionId, set);
-      }
-      set.add(agentId);
+      getOrCreateSet(this.sandboxes, metadata.parentConnectionId).add(agentId);
     }
   }
 
@@ -86,7 +85,7 @@ export class InMemoryAgentStore implements AgentStore {
     await this.saveMetadata(agentId, { ...existing, ...updates });
   }
 
-  async deleteMetadata(agentId: string): Promise<void> {
+  protected async deleteMetadataRaw(agentId: string): Promise<void> {
     const existing = this.metadata.get(agentId);
     this.metadata.delete(agentId);
     if (existing?.parentConnectionId) {
@@ -98,15 +97,17 @@ export class InMemoryAgentStore implements AgentStore {
     }
   }
 
-  async hasAgent(agentId: string): Promise<boolean> {
+  protected async hasMetadataRaw(agentId: string): Promise<boolean> {
     return this.metadata.has(agentId);
   }
 
-  async listAgents(): Promise<AgentMetadata[]> {
+  protected async listAllMetadata(): Promise<AgentMetadata[]> {
     return Array.from(this.metadata.values());
   }
 
-  async listSandboxes(connectionId: string): Promise<AgentMetadata[]> {
+  protected async listSandboxMetadata(
+    connectionId: string
+  ): Promise<AgentMetadata[]> {
     const ids = this.sandboxes.get(connectionId);
     if (!ids) return [];
     const results: AgentMetadata[] = [];
@@ -117,63 +118,27 @@ export class InMemoryAgentStore implements AgentStore {
     return results;
   }
 
-  // ── Connections ──────────────────────────────────────────────────
+  // ── Connection primitives ─────────────────────────────────────────
 
-  async getConnection(connectionId: string): Promise<StoredConnection | null> {
+  protected async readConnection(
+    connectionId: string
+  ): Promise<StoredConnection | null> {
     return this.connections.get(connectionId) ?? null;
   }
 
-  async listConnections(filter?: {
-    templateAgentId?: string;
-    platform?: string;
-  }): Promise<StoredConnection[]> {
-    let ids: Iterable<string>;
-    if (filter?.templateAgentId) {
-      ids = this.connectionsByAgent.get(filter.templateAgentId) ?? [];
-    } else {
-      ids = this.connectionsAll;
-    }
-
-    let connections: StoredConnection[] = [];
-    for (const id of ids) {
-      const conn = this.connections.get(id);
-      if (conn) connections.push(conn);
-    }
-
-    if (filter?.platform) {
-      connections = connections.filter((c) => c.platform === filter.platform);
-    }
-    return connections;
-  }
-
-  async saveConnection(connection: StoredConnection): Promise<void> {
+  protected async writeConnection(
+    connection: StoredConnection
+  ): Promise<void> {
     this.connections.set(connection.id, connection);
     this.connectionsAll.add(connection.id);
     if (connection.templateAgentId) {
-      let set = this.connectionsByAgent.get(connection.templateAgentId);
-      if (!set) {
-        set = new Set();
-        this.connectionsByAgent.set(connection.templateAgentId, set);
-      }
-      set.add(connection.id);
+      getOrCreateSet(this.connectionsByAgent, connection.templateAgentId).add(
+        connection.id
+      );
     }
   }
 
-  async updateConnection(
-    connectionId: string,
-    updates: Partial<StoredConnection>
-  ): Promise<void> {
-    const existing = this.connections.get(connectionId);
-    if (!existing) return;
-    await this.saveConnection({
-      ...existing,
-      ...updates,
-      id: connectionId,
-      updatedAt: Date.now(),
-    });
-  }
-
-  async deleteConnection(connectionId: string): Promise<void> {
+  protected async deleteConnectionRaw(connectionId: string): Promise<void> {
     const conn = this.connections.get(connectionId);
     this.connections.delete(connectionId);
     this.connectionsAll.delete(connectionId);
@@ -187,6 +152,21 @@ export class InMemoryAgentStore implements AgentStore {
     }
   }
 
+  protected async listConnectionsByTemplate(
+    templateAgentId?: string
+  ): Promise<StoredConnection[]> {
+    const ids: Iterable<string> = templateAgentId
+      ? (this.connectionsByAgent.get(templateAgentId) ?? [])
+      : this.connectionsAll;
+
+    const connections: StoredConnection[] = [];
+    for (const id of ids) {
+      const conn = this.connections.get(id);
+      if (conn) connections.push(conn);
+    }
+    return connections;
+  }
+
   // ── Grants ──────────────────────────────────────────────────────
 
   private grantKey(agentId: string, pattern: string): string {
@@ -194,7 +174,7 @@ export class InMemoryAgentStore implements AgentStore {
       ? pattern
       : normalizeDomainPattern(pattern);
 
-    return `${agentId}:${normalizedPattern}`;
+    return buildKey([agentId, normalizedPattern]);
   }
 
   private getValidGrant(
@@ -284,7 +264,7 @@ export class InMemoryAgentStore implements AgentStore {
   // ── User-Agent Associations ─────────────────────────────────────
 
   private userKey(platform: string, userId: string): string {
-    return `${platform}:${userId}`;
+    return buildKey([platform, userId]);
   }
 
   async addUserAgent(
@@ -292,13 +272,9 @@ export class InMemoryAgentStore implements AgentStore {
     userId: string,
     agentId: string
   ): Promise<void> {
-    const key = this.userKey(platform, userId);
-    let set = this.userAgents.get(key);
-    if (!set) {
-      set = new Set();
-      this.userAgents.set(key, set);
-    }
-    set.add(agentId);
+    getOrCreateSet(this.userAgents, this.userKey(platform, userId)).add(
+      agentId
+    );
   }
 
   async removeUserAgent(
@@ -336,8 +312,8 @@ export class InMemoryAgentStore implements AgentStore {
     teamId?: string
   ): string {
     return teamId
-      ? `${platform}:${channelId}:${teamId}`
-      : `${platform}:${channelId}`;
+      ? buildKey([platform, channelId, teamId])
+      : buildKey([platform, channelId]);
   }
 
   async getChannelBinding(
@@ -359,12 +335,7 @@ export class InMemoryAgentStore implements AgentStore {
       binding.teamId
     );
     this.channelBindings.set(key, binding);
-    let set = this.channelBindingIndex.get(binding.agentId);
-    if (!set) {
-      set = new Set();
-      this.channelBindingIndex.set(binding.agentId, set);
-    }
-    set.add(key);
+    getOrCreateSet(this.channelBindingIndex, binding.agentId).add(key);
   }
 
   async deleteChannelBinding(

--- a/packages/gateway/src/stores/redis-agent-store.ts
+++ b/packages/gateway/src/stores/redis-agent-store.ts
@@ -1,7 +1,13 @@
+/**
+ * RedisAgentStore — Redis-backed AgentStore that extends BaseAgentStore.
+ *
+ * Primitives delegate to the purpose-built Redis services
+ * (AgentSettingsStore, AgentMetadataStore, GrantStore, UserAgentsStore,
+ * ChannelBindingService). Connections are stored directly against Redis
+ * because they have no standalone service.
+ */
+
 import type {
-  AgentAccessStore,
-  AgentConfigStore,
-  AgentConnectionStore,
   AgentMetadata,
   AgentSettings,
   ChannelBinding,
@@ -11,44 +17,77 @@ import type {
 import type Redis from "ioredis";
 import type { AgentMetadataStore } from "../auth/agent-metadata-store";
 import type { AgentSettingsStore } from "../auth/settings";
+import type { UserAgentsStore } from "../auth/user-agents-store";
 import type { ChannelBindingService } from "../channels";
 import type { GrantStore } from "../permissions/grant-store";
-import type { UserAgentsStore } from "../auth/user-agents-store";
+import { BaseAgentStore } from "./base-agent-store";
 
-export class RedisAgentConfigStore implements AgentConfigStore {
+export class RedisAgentStore extends BaseAgentStore {
   constructor(
+    private readonly redis: Redis,
     private readonly settingsStore: AgentSettingsStore,
-    private readonly metadataStore: AgentMetadataStore
-  ) {}
+    private readonly metadataStore: AgentMetadataStore,
+    private readonly grantStore: GrantStore,
+    private readonly userAgentsStore: UserAgentsStore,
+    private readonly channelBindingService: ChannelBindingService
+  ) {
+    super();
+  }
 
-  async getSettings(agentId: string): Promise<AgentSettings | null> {
+  // ── Settings primitives ───────────────────────────────────────────
+
+  protected async readSettings(
+    agentId: string
+  ): Promise<AgentSettings | null> {
     return this.settingsStore.getSettings(agentId);
   }
 
-  async saveSettings(agentId: string, settings: AgentSettings): Promise<void> {
+  protected async writeSettings(
+    agentId: string,
+    settings: AgentSettings
+  ): Promise<void> {
+    // `AgentSettingsStore.saveSettings` re-stamps `updatedAt`; the base class
+    // already stamped it, so this is effectively a no-op overwrite.
     await this.settingsStore.saveSettings(agentId, settings);
   }
 
-  async updateSettings(
-    agentId: string,
-    updates: Partial<AgentSettings>
-  ): Promise<void> {
-    await this.settingsStore.updateSettings(agentId, updates);
-  }
-
-  async deleteSettings(agentId: string): Promise<void> {
+  protected async deleteSettingsRaw(agentId: string): Promise<void> {
     await this.settingsStore.deleteSettings(agentId);
   }
 
-  async hasSettings(agentId: string): Promise<boolean> {
+  protected async hasSettingsRaw(agentId: string): Promise<boolean> {
     return this.settingsStore.hasSettings(agentId);
   }
 
-  async getMetadata(agentId: string): Promise<AgentMetadata | null> {
+  // ── Metadata primitives ───────────────────────────────────────────
+
+  protected async readMetadata(
+    agentId: string
+  ): Promise<AgentMetadata | null> {
     return this.metadataStore.getMetadata(agentId);
   }
 
+  protected async deleteMetadataRaw(agentId: string): Promise<void> {
+    await this.metadataStore.deleteAgent(agentId);
+  }
+
+  protected async hasMetadataRaw(agentId: string): Promise<boolean> {
+    return this.metadataStore.hasAgent(agentId);
+  }
+
+  protected async listAllMetadata(): Promise<AgentMetadata[]> {
+    return this.metadataStore.listAllAgents();
+  }
+
+  protected async listSandboxMetadata(
+    connectionId: string
+  ): Promise<AgentMetadata[]> {
+    return this.metadataStore.listSandboxes(connectionId);
+  }
+
   async saveMetadata(agentId: string, metadata: AgentMetadata): Promise<void> {
+    // `createAgent` overwrites unconditionally and stamps `createdAt` with
+    // Date.now(); it accepts no `lastUsedAt` param, so we patch that in after.
     await this.metadataStore.createAgent(
       agentId,
       metadata.name,
@@ -72,60 +111,25 @@ export class RedisAgentConfigStore implements AgentConfigStore {
     agentId: string,
     updates: Partial<AgentMetadata>
   ): Promise<void> {
+    // AgentMetadataStore.updateMetadata only supports a narrow subset of
+    // fields (name/description/lastUsedAt). Other fields are silently
+    // dropped — same behavior as before the refactor.
     await this.metadataStore.updateMetadata(agentId, updates);
   }
 
-  async deleteMetadata(agentId: string): Promise<void> {
-    await this.metadataStore.deleteAgent(agentId);
-  }
+  // ── Connection primitives ─────────────────────────────────────────
 
-  async hasAgent(agentId: string): Promise<boolean> {
-    return this.metadataStore.hasAgent(agentId);
-  }
-
-  async listAgents(): Promise<AgentMetadata[]> {
-    return this.metadataStore.listAllAgents();
-  }
-
-  async listSandboxes(connectionId: string): Promise<AgentMetadata[]> {
-    return this.metadataStore.listSandboxes(connectionId);
-  }
-}
-
-export class RedisAgentConnectionStore implements AgentConnectionStore {
-  constructor(
-    private readonly redis: Redis,
-    private readonly channelBindingService: ChannelBindingService
-  ) {}
-
-  async getConnection(connectionId: string): Promise<StoredConnection | null> {
+  protected async readConnection(
+    connectionId: string
+  ): Promise<StoredConnection | null> {
     const raw = await this.redis.get(`connection:${connectionId}`);
     return raw ? (JSON.parse(raw) as StoredConnection) : null;
   }
 
-  async listConnections(filter?: {
-    templateAgentId?: string;
-    platform?: string;
-  }): Promise<StoredConnection[]> {
-    const ids = filter?.templateAgentId
-      ? await this.redis.smembers(`connections:agent:${filter.templateAgentId}`)
-      : await this.redis.smembers("connections:all");
-
-    const connections: StoredConnection[] = [];
-    for (const id of ids) {
-      const raw = await this.redis.get(`connection:${id}`);
-      if (!raw) continue;
-      const connection = JSON.parse(raw) as StoredConnection;
-      if (filter?.platform && connection.platform !== filter.platform) {
-        continue;
-      }
-      connections.push(connection);
-    }
-    return connections;
-  }
-
-  async saveConnection(connection: StoredConnection): Promise<void> {
-    const existing = await this.getConnection(connection.id);
+  protected async writeConnection(
+    connection: StoredConnection
+  ): Promise<void> {
+    const existing = await this.readConnection(connection.id);
     await this.redis.set(
       `connection:${connection.id}`,
       JSON.stringify(connection)
@@ -147,22 +151,8 @@ export class RedisAgentConnectionStore implements AgentConnectionStore {
     }
   }
 
-  async updateConnection(
-    connectionId: string,
-    updates: Partial<StoredConnection>
-  ): Promise<void> {
-    const existing = await this.getConnection(connectionId);
-    if (!existing) return;
-    await this.saveConnection({
-      ...existing,
-      ...updates,
-      id: connectionId,
-      updatedAt: Date.now(),
-    });
-  }
-
-  async deleteConnection(connectionId: string): Promise<void> {
-    const existing = await this.getConnection(connectionId);
+  protected async deleteConnectionRaw(connectionId: string): Promise<void> {
+    const existing = await this.readConnection(connectionId);
     await this.redis.del(`connection:${connectionId}`);
     await this.redis.srem("connections:all", connectionId);
     if (existing?.templateAgentId) {
@@ -172,6 +162,81 @@ export class RedisAgentConnectionStore implements AgentConnectionStore {
       );
     }
   }
+
+  protected async listConnectionsByTemplate(
+    templateAgentId?: string
+  ): Promise<StoredConnection[]> {
+    const ids = templateAgentId
+      ? await this.redis.smembers(`connections:agent:${templateAgentId}`)
+      : await this.redis.smembers("connections:all");
+
+    const connections: StoredConnection[] = [];
+    for (const id of ids) {
+      const raw = await this.redis.get(`connection:${id}`);
+      if (!raw) continue;
+      connections.push(JSON.parse(raw) as StoredConnection);
+    }
+    return connections;
+  }
+
+  // ── Grants ──────────────────────────────────────────────────────
+
+  async grant(
+    agentId: string,
+    pattern: string,
+    expiresAt: number | null,
+    denied?: boolean
+  ): Promise<void> {
+    await this.grantStore.grant(agentId, pattern, expiresAt, denied);
+  }
+
+  async hasGrant(agentId: string, pattern: string): Promise<boolean> {
+    return this.grantStore.hasGrant(agentId, pattern);
+  }
+
+  async isDenied(agentId: string, pattern: string): Promise<boolean> {
+    return this.grantStore.isDenied(agentId, pattern);
+  }
+
+  async listGrants(agentId: string): Promise<Grant[]> {
+    return this.grantStore.listGrants(agentId);
+  }
+
+  async revokeGrant(agentId: string, pattern: string): Promise<void> {
+    await this.grantStore.revoke(agentId, pattern);
+  }
+
+  // ── User-Agent Associations ─────────────────────────────────────
+
+  async addUserAgent(
+    platform: string,
+    userId: string,
+    agentId: string
+  ): Promise<void> {
+    await this.userAgentsStore.addAgent(platform, userId, agentId);
+  }
+
+  async removeUserAgent(
+    platform: string,
+    userId: string,
+    agentId: string
+  ): Promise<void> {
+    await this.userAgentsStore.removeAgent(platform, userId, agentId);
+  }
+
+  async listUserAgents(platform: string, userId: string): Promise<string[]> {
+    return this.userAgentsStore.listAgents(platform, userId);
+  }
+
+  async ownsAgent(
+    platform: string,
+    userId: string,
+    agentId: string
+  ): Promise<boolean> {
+    return this.userAgentsStore.ownsAgent(platform, userId, agentId);
+  }
+
+  // ── Channel Bindings ────────────────────────────────────────────
 
   async getChannelBinding(
     platform: string,
@@ -215,65 +280,5 @@ export class RedisAgentConnectionStore implements AgentConnectionStore {
 
   async deleteAllChannelBindings(agentId: string): Promise<number> {
     return this.channelBindingService.deleteAllBindings(agentId);
-  }
-}
-
-export class RedisAgentAccessStore implements AgentAccessStore {
-  constructor(
-    private readonly grantStore: GrantStore,
-    private readonly userAgentsStore: UserAgentsStore
-  ) {}
-
-  async grant(
-    agentId: string,
-    pattern: string,
-    expiresAt: number | null,
-    denied?: boolean
-  ): Promise<void> {
-    await this.grantStore.grant(agentId, pattern, expiresAt, denied);
-  }
-
-  async hasGrant(agentId: string, pattern: string): Promise<boolean> {
-    return this.grantStore.hasGrant(agentId, pattern);
-  }
-
-  async isDenied(agentId: string, pattern: string): Promise<boolean> {
-    return this.grantStore.isDenied(agentId, pattern);
-  }
-
-  async listGrants(agentId: string): Promise<Grant[]> {
-    return this.grantStore.listGrants(agentId);
-  }
-
-  async revokeGrant(agentId: string, pattern: string): Promise<void> {
-    await this.grantStore.revoke(agentId, pattern);
-  }
-
-  async addUserAgent(
-    platform: string,
-    userId: string,
-    agentId: string
-  ): Promise<void> {
-    await this.userAgentsStore.addAgent(platform, userId, agentId);
-  }
-
-  async removeUserAgent(
-    platform: string,
-    userId: string,
-    agentId: string
-  ): Promise<void> {
-    await this.userAgentsStore.removeAgent(platform, userId, agentId);
-  }
-
-  async listUserAgents(platform: string, userId: string): Promise<string[]> {
-    return this.userAgentsStore.listAgents(platform, userId);
-  }
-
-  async ownsAgent(
-    platform: string,
-    userId: string,
-    agentId: string
-  ): Promise<boolean> {
-    return this.userAgentsStore.ownsAgent(platform, userId, agentId);
   }
 }

--- a/packages/gateway/src/stores/redis-agent-store.ts
+++ b/packages/gateway/src/stores/redis-agent-store.ts
@@ -36,9 +36,7 @@ export class RedisAgentStore extends BaseAgentStore {
 
   // ── Settings primitives ───────────────────────────────────────────
 
-  protected async readSettings(
-    agentId: string
-  ): Promise<AgentSettings | null> {
+  protected async readSettings(agentId: string): Promise<AgentSettings | null> {
     return this.settingsStore.getSettings(agentId);
   }
 
@@ -61,9 +59,7 @@ export class RedisAgentStore extends BaseAgentStore {
 
   // ── Metadata primitives ───────────────────────────────────────────
 
-  protected async readMetadata(
-    agentId: string
-  ): Promise<AgentMetadata | null> {
+  protected async readMetadata(agentId: string): Promise<AgentMetadata | null> {
     return this.metadataStore.getMetadata(agentId);
   }
 
@@ -126,9 +122,7 @@ export class RedisAgentStore extends BaseAgentStore {
     return raw ? (JSON.parse(raw) as StoredConnection) : null;
   }
 
-  protected async writeConnection(
-    connection: StoredConnection
-  ): Promise<void> {
+  protected async writeConnection(connection: StoredConnection): Promise<void> {
     const existing = await this.readConnection(connection.id);
     await this.redis.set(
       `connection:${connection.id}`,


### PR DESCRIPTION
## Summary
- Introduce a shared `BaseAgentStore` abstract class that exposes the public `AgentStore` surface on top of backend-specific CRUD primitives, plus `buildKey` / `getOrCreateSet` helpers. Lifts the get-merge-save update pattern and the listConnections platform filter that previously lived in both stores.
- Reduce `InMemoryAgentStore` to Map-backed primitives and the grant / user-agent / channel-binding groups that legitimately differ between backends.
- Collapse the three Redis delegation wrappers (`RedisAgentConfigStore`, `RedisAgentConnectionStore`, `RedisAgentAccessStore`) into a single `RedisAgentStore` that satisfies the full `AgentStore` interface; `CoreServices` now constructs it once and assigns it to all three sub-store slots.

## Test plan
- [x] `bun run typecheck` (repo root)
- [x] `make build-packages`
- [x] `bun test packages/gateway` (488 pass / 0 fail, including `core-services-store-selection.test.ts`, `grant-store.test.ts`, `agent-settings-store.test.ts`, `connection-routes.test.ts`)

## Notes
- `saveMetadata` / `updateMetadata` are kept abstract on the base class because the Redis backend delegates to `AgentMetadataStore.createAgent` for saves (stamps a fresh `createdAt`) and to `AgentMetadataStore.updateMetadata` for updates (preserves `createdAt`, narrow field set). Routing updates through a shared `writeMetadata` would have corrupted `createdAt` on every update call, so that quirk is preserved by keeping the two methods implemented per backend.