### PR TITLE
refactor(core): unify message types and extract BaseMessage

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -142,6 +142,8 @@ export type {
   UserSuggestion,
 } from "./types";
 export { hasCredentialSource } from "./types";
+// Shared message/interaction base shape
+export type { BaseMessage } from "./types/message";
 
 // Utilities
 export * from "./utils/encryption";

--- a/packages/core/src/types/message.ts
+++ b/packages/core/src/types/message.ts
@@ -1,0 +1,25 @@
+/**
+ * Canonical base shape for messages and interaction events that flow between
+ * the gateway and platform renderers.
+ *
+ * Concrete payload types (posted interactions, thread responses) extend this
+ * interface and add their own specialised fields. Keeping the shared primitive
+ * identifiers in one place eliminates the drift that happens when each call
+ * site re-declares `conversationId`, `channelId`, etc. independently.
+ *
+ * Note: `userId` is intentionally NOT part of the base because some events
+ * (e.g. status messages) are channel-scoped and have no originating user.
+ * Types that do carry a user simply add `userId: string` themselves.
+ */
+export interface BaseMessage {
+  /** Stable identifier for this message/event. */
+  id: string;
+  /** Logical conversation the message belongs to. */
+  conversationId: string;
+  /** Platform channel the message was delivered to. */
+  channelId: string;
+  /** Platform team/workspace identifier when the platform exposes one. */
+  teamId?: string;
+  /** Originating PlatformConnection id, when applicable. */
+  connectionId?: string;
+}

--- a/packages/gateway/src/infrastructure/queue/types.ts
+++ b/packages/gateway/src/infrastructure/queue/types.ts
@@ -98,40 +98,7 @@ export interface IMessageQueue {
 // Payload Types
 // ============================================================================
 
-/**
- * Shared payload contract for worker → platform thread responses.
- * Ensures gateway consumers and workers stay type-aligned.
- */
-export interface ThreadResponsePayload {
-  messageId: string;
-  channelId: string;
-  conversationId: string;
-  userId: string;
-  teamId: string;
-  platform?: string; // Platform identifier (slack, whatsapp, api, etc.) for multi-platform routing
-  content?: string; // Used only for ephemeral messages (OAuth/auth flows)
-  delta?: string;
-  isFullReplacement?: boolean;
-  processedMessageIds?: string[];
-  error?: string;
-  errorCode?: string;
-  timestamp: number;
-  originalMessageId?: string;
-  moduleData?: Record<string, unknown>;
-  botResponseId?: string;
-  ephemeral?: boolean;
-  statusUpdate?: {
-    elapsedSeconds: number;
-    state: string;
-  };
-  platformMetadata?: Record<string, unknown>; // Platform-specific metadata (e.g., sessionId for API)
-  customEvent?: {
-    name: string;
-    data: Record<string, unknown>;
-  };
-
-  // Exec-specific response fields (for jobType === "exec")
-  execId?: string; // Exec job ID for response routing
-  execStream?: "stdout" | "stderr"; // Which stream this delta is from
-  execExitCode?: number; // Process exit code (sent on completion)
-}
+// `ThreadResponsePayload` is defined once in `@lobu/core` and re-exported
+// from this package's queue index for convenience. It is shared by workers
+// and platform renderers, so keeping a single source of truth is essential.
+export type { ThreadResponsePayload } from "@lobu/core";

--- a/packages/gateway/src/interactions.ts
+++ b/packages/gateway/src/interactions.ts
@@ -2,20 +2,19 @@
 
 import { randomUUID } from "node:crypto";
 import { EventEmitter } from "node:events";
-import { createLogger, type UserSuggestion } from "@lobu/core";
+import {
+  type BaseMessage,
+  createLogger,
+  type UserSuggestion,
+} from "@lobu/core";
 
 const logger = createLogger("interactions");
 
 /**
  * Payload emitted on "question:created" — platform renderers listen for this.
  */
-export interface PostedQuestion {
-  id: string;
+export interface PostedQuestion extends BaseMessage {
   userId: string;
-  conversationId: string;
-  channelId: string;
-  teamId?: string;
-  connectionId?: string;
   question: string;
   options: string[];
 }
@@ -28,13 +27,8 @@ export interface PostedQuestion {
  * renderer will skip the card-body text entirely rather than duplicate the
  * button's own label.
  */
-export interface PostedLinkButton {
-  id: string;
+export interface PostedLinkButton extends BaseMessage {
   userId: string;
-  conversationId: string;
-  channelId: string;
-  teamId?: string;
-  connectionId?: string;
   platform: string;
   url: string;
   label: string;
@@ -45,14 +39,9 @@ export interface PostedLinkButton {
 /**
  * Payload emitted on "tool:approval-needed" — platform renderers listen for this.
  */
-export interface PostedToolApproval {
-  id: string;
+export interface PostedToolApproval extends BaseMessage {
   agentId: string;
   userId: string;
-  conversationId: string;
-  channelId: string;
-  teamId?: string;
-  connectionId?: string;
   mcpId: string;
   toolName: string;
   args: Record<string, unknown>;
@@ -62,12 +51,7 @@ export interface PostedToolApproval {
 /**
  * Payload emitted on "status-message:created" — platform renderers listen for this.
  */
-export interface PostedStatusMessage {
-  id: string;
-  conversationId: string;
-  channelId: string;
-  teamId?: string;
-  connectionId?: string;
+export interface PostedStatusMessage extends BaseMessage {
   platform: string;
   text: string;
 }


### PR DESCRIPTION
## Summary
- Extracted a canonical `BaseMessage` interface in `@lobu/core` (`packages/core/src/types/message.ts`) carrying the shared identifier primitives (`id`, `conversationId`, `channelId`, optional `teamId`/`connectionId`) used across posted-interaction events.
- Removed the verbatim duplicate of `ThreadResponsePayload` that lived in `packages/gateway/src/infrastructure/queue/types.ts` and re-exported the canonical one from `@lobu/core` instead, preserving existing gateway import paths.
- Refactored `PostedQuestion`, `PostedLinkButton`, `PostedToolApproval`, and `PostedStatusMessage` in `packages/gateway/src/interactions.ts` to extend `BaseMessage` instead of re-declaring the shared primitives inline.

### Scope note
`PlatformConnection` was intentionally left untouched. It is a connection record (id/platform/config/settings/status/createdAt/etc.), not a message, and shares no primitive message fields with the other two call sites, so folding it under `BaseMessage` would be a wrong abstraction. `ThreadResponsePayload` also does not extend `BaseMessage` because it uses `messageId` rather than `id`; renaming that field would be a breaking change well outside this refactor's surface.

## Test plan
- [x] `make build-packages` — core + gateway + worker all compile
- [x] `bun run typecheck` — repo-wide tsc --noEmit passes
- [x] `bun test packages/gateway` — 488 / 488 pass
- [x] `bun test packages/core` — 102 / 102 pass