### PR TITLE
refactor(landing): tighten homepage voice

### DIFF
--- a/packages/landing/src/components/ArchitectureSection.tsx
+++ b/packages/landing/src/components/ArchitectureSection.tsx
@@ -17,8 +17,8 @@ export function ArchitectureSection(props: {
           class="text-center text-sm mb-12 max-w-xl mx-auto"
           style={{ color: "var(--color-page-text-muted)" }}
         >
-          Every agent runs in a sandboxed container with no outbound network
-          by default — on your infrastructure, not ours.
+          Every agent runs in a sandboxed container with no outbound network by
+          default — on your infrastructure, not ours.
         </p>
 
         <div class="max-w-3xl mx-auto xl:max-w-none">

--- a/packages/landing/src/components/ArchitectureSection.tsx
+++ b/packages/landing/src/components/ArchitectureSection.tsx
@@ -17,8 +17,8 @@ export function ArchitectureSection(props: {
           class="text-center text-sm mb-12 max-w-xl mx-auto"
           style={{ color: "var(--color-page-text-muted)" }}
         >
-          Agents runs in an isolated sandbox with no direct network access, in
-          your infrastructure.
+          Every agent runs in a sandboxed container with no outbound network
+          by default — on your infrastructure, not ours.
         </p>
 
         <div class="max-w-3xl mx-auto xl:max-w-none">

--- a/packages/landing/src/components/BenchmarkSection.tsx
+++ b/packages/landing/src/components/BenchmarkSection.tsx
@@ -162,7 +162,7 @@ export function BenchmarkSection() {
     <section class="pt-20 pb-20 px-4 sm:px-8">
       <CompactContentRail>
         <SectionHeader
-          title="Beats most common memory benchmarks"
+          title="Beats Mem0 and Supermemory on public benchmarks"
           body="Apples-to-apples comparison on public memory datasets. Same answerer (glm-5.1 via z.ai), same top-K, same questions."
           className="mb-10"
         />

--- a/packages/landing/src/components/CTA.tsx
+++ b/packages/landing/src/components/CTA.tsx
@@ -20,13 +20,13 @@ export function CTA(props: {
           class="text-2xl sm:text-3xl font-bold mb-3 tracking-tight"
           style={{ color: "var(--color-page-text)" }}
         >
-          Ready to try it?
+          Two ways to see it run.
         </h2>
         <p
           class="text-sm mb-8"
           style={{ color: "var(--color-page-text-muted)" }}
         >
-          Get started locally, then self-host or embed with TypeScript.
+          Click through a live workspace, or book 20 minutes with the founder.
         </p>
         <div class="flex flex-wrap justify-center gap-3 mb-8">
           <a
@@ -37,7 +37,7 @@ export function CTA(props: {
               color: "var(--color-page-bg)",
             }}
           >
-            See demo now
+            Open live workspace
           </a>
           <ScheduleCallButton
             class="inline-flex items-center gap-2 text-sm font-medium px-6 py-3 rounded-lg transition-all hover:opacity-90"

--- a/packages/landing/src/components/HeroSection.tsx
+++ b/packages/landing/src/components/HeroSection.tsx
@@ -54,8 +54,8 @@ export function HeroSection(props: {
     props.useScopedOwlettoUrl ? activeUseCase.id : undefined
   );
   const primaryCtaLabel = props.heroCopy
-    ? `See ${activeUseCase.label} demo`
-    : "See demo";
+    ? `Try the ${activeUseCase.label} demo`
+    : "Try it live";
 
   return (
     <section class="pt-24 pb-4 px-8 relative">
@@ -93,8 +93,8 @@ export function HeroSection(props: {
             class="text-lg mx-auto mb-4 leading-relaxed max-w-3xl"
             style={{ color: "var(--color-page-text-muted)" }}
           >
-            Pre-built templates for research, internal ops, and personal memory.
-            Fork one to build your own.
+            Pre-built agents for team ops, personal memory, and community
+            workflows — fork one, wire it to your tools, let it run.
           </p>
         )}
         {/* CTA buttons */}


### PR DESCRIPTION
## Summary

Copy-only pass on the landing homepage to make it feel written by an engineer who uses it, not a marketing template. Net-neutral LOC (10/10), no new components or sections.

### Before / After

**Hero subhead**

Before: `Pre-built templates for research, internal ops, and personal memory. Fork one to build your own.`

After: `Pre-built agents for team ops, personal memory, and community workflows — fork one, wire it to your tools, let it run.`

Fixes the fact that the old copy named buckets ("research") that don't match the tab labels (Company / Personal / Public), and trades "templates" for the concrete thing you actually get.

**Hero CTA**

Before: `See demo` / `See {label} demo`

After: `Try it live` / `Try the {label} demo`

"Live" is the differentiator — the button opens a running workspace, not a video.

**Closing CTA section**

Before heading: `Ready to try it?` / subhead: `Get started locally, then self-host or embed with TypeScript.` / button: `See demo now`

After heading: `Two ways to see it run.` / subhead: `Click through a live workspace, or book 20 minutes with the founder.` / button: `Open live workspace`

The old subhead described a third path (local install) that the buttons beneath it don't lead to. New copy actually maps to the two buttons.

**Architecture subhead**

Before: `Agents runs in an isolated sandbox with no direct network access, in your infrastructure.` (also fixes `Agents runs` subject-verb typo)

After: `Every agent runs in a sandboxed container with no outbound network by default — on your infrastructure, not ours.`

**Benchmark heading**

Before: `Beats most common memory benchmarks`

After: `Beats Mem0 and Supermemory on public benchmarks`

Tables below already name these two; the heading was softer than the data.

## Test plan

- [x] `cd packages/landing && bun run build` — homepage routes compile; pre-existing unrelated zod error on `/connect-from/.../for/...` reproduces on `main` and is outside the scope of this PR.
- [ ] Visual skim of `/` in dev — verify hero, demo-section, architecture, benchmark, closing CTA all render cleanly on desktop + mobile widths.
- [ ] Verify scoped `/for/{useCase}` pages still show `Try the {label} demo` and the correct Owletto deep link.