### PR TITLE
feat(landing): subtle hero and scroll-reveal animations

### DIFF
--- a/packages/landing/src/components/HeroSection.tsx
+++ b/packages/landing/src/components/HeroSection.tsx
@@ -64,7 +64,7 @@ export function HeroSection(props: {
           href={GITHUB_URL}
           target="_blank"
           rel="noopener noreferrer"
-          class="inline-flex items-center gap-2 text-xs font-semibold tracking-wider uppercase px-3 py-1 mb-5 rounded-full transition-all hover:opacity-80"
+          class="hero-rise hero-rise-1 inline-flex items-center gap-2 text-xs font-semibold tracking-wider uppercase px-3 py-1 mb-5 rounded-full transition-all hover:opacity-80"
           style={{
             color: "var(--color-page-text-muted)",
             border: "1px solid var(--color-page-border)",
@@ -73,7 +73,7 @@ export function HeroSection(props: {
           Open source · Self-hosted
         </a>
         <h1
-          class="text-4xl sm:text-5xl font-bold tracking-tight leading-[1.1] mb-5"
+          class="hero-rise hero-rise-2 text-4xl sm:text-5xl font-bold tracking-tight leading-[1.1] mb-5"
           style={{ color: "var(--color-page-text)" }}
         >
           <HighlightedText
@@ -83,14 +83,14 @@ export function HeroSection(props: {
         </h1>
         {props.heroCopy ? (
           <p
-            class="text-lg mx-auto mb-4 leading-relaxed max-w-3xl"
+            class="hero-rise hero-rise-3 text-lg mx-auto mb-4 leading-relaxed max-w-3xl"
             style={{ color: "var(--color-page-text-muted)" }}
           >
             {props.heroCopy.description}
           </p>
         ) : (
           <p
-            class="text-lg mx-auto mb-4 leading-relaxed max-w-3xl"
+            class="hero-rise hero-rise-3 text-lg mx-auto mb-4 leading-relaxed max-w-3xl"
             style={{ color: "var(--color-page-text-muted)" }}
           >
             Pre-built templates for research, internal ops, and personal memory.
@@ -98,7 +98,7 @@ export function HeroSection(props: {
           </p>
         )}
         {/* CTA buttons */}
-        <div class="flex flex-wrap gap-3 mb-6 justify-center items-center">
+        <div class="hero-rise hero-rise-4 flex flex-wrap gap-3 mb-6 justify-center items-center">
           <a
             href={owlettoUrl}
             target="_blank"
@@ -135,7 +135,7 @@ export function HeroSection(props: {
           )}
         </div>
 
-        <div class="mt-8 mb-6">
+        <div class="hero-rise hero-rise-5 mt-8 mb-6">
           <ScopedUseCaseTabs
             groups={landingUseCaseGroupedOptions}
             activeId={activeUseCase.id}

--- a/packages/landing/src/components/SectionHeader.tsx
+++ b/packages/landing/src/components/SectionHeader.tsx
@@ -12,11 +12,7 @@ export function SectionHeader({
   className = "",
 }: SectionHeaderProps) {
   const { ref, className: revealClassName } = useReveal<HTMLDivElement>();
-  const composed = [
-    "max-w-3xl mx-auto text-center",
-    className,
-    revealClassName,
-  ]
+  const composed = ["max-w-3xl mx-auto text-center", className, revealClassName]
     .filter(Boolean)
     .join(" ");
 

--- a/packages/landing/src/components/SectionHeader.tsx
+++ b/packages/landing/src/components/SectionHeader.tsx
@@ -1,3 +1,5 @@
+import { useReveal } from "./use-reveal";
+
 type SectionHeaderProps = {
   title: string;
   body?: string;
@@ -9,8 +11,17 @@ export function SectionHeader({
   body,
   className = "",
 }: SectionHeaderProps) {
+  const { ref, className: revealClassName } = useReveal<HTMLDivElement>();
+  const composed = [
+    "max-w-3xl mx-auto text-center",
+    className,
+    revealClassName,
+  ]
+    .filter(Boolean)
+    .join(" ");
+
   return (
-    <div class={`max-w-3xl mx-auto text-center ${className}`.trim()}>
+    <div ref={ref} class={composed}>
       <h2
         class="text-2xl sm:text-3xl font-bold tracking-tight mb-3"
         style={{ color: "var(--color-page-text)" }}

--- a/packages/landing/src/components/use-reveal.ts
+++ b/packages/landing/src/components/use-reveal.ts
@@ -1,0 +1,69 @@
+import { useEffect, useRef, useState } from "preact/hooks";
+
+type RevealPhase = "idle" | "armed" | "visible";
+
+/**
+ * Returns a ref and a className that drives a subtle fade-rise animation the
+ * first time the element enters the viewport.
+ *
+ * SSR-safe: the element ships with no animation class, so it's visible to
+ * users without JavaScript (and during hydration). Post-hydration, if the
+ * element is still below the fold we arm it (fade out), then reveal it with
+ * a transition when it intersects. If it's already on-screen at mount, we
+ * skip the animation entirely to avoid a flash.
+ *
+ * Honors `prefers-reduced-motion: reduce` by skipping animations outright.
+ */
+export function useReveal<T extends Element = HTMLDivElement>(
+  rootMargin = "0px 0px -10% 0px",
+) {
+  const ref = useRef<T | null>(null);
+  const [phase, setPhase] = useState<RevealPhase>("idle");
+
+  useEffect(() => {
+    const node = ref.current;
+    if (!node) return;
+
+    if (typeof window === "undefined") return;
+
+    const prefersReducedMotion =
+      typeof window.matchMedia === "function" &&
+      window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+
+    if (prefersReducedMotion || typeof IntersectionObserver === "undefined") {
+      return;
+    }
+
+    const rect = node.getBoundingClientRect();
+    const viewportHeight =
+      window.innerHeight || document.documentElement.clientHeight;
+
+    // Already on screen at mount → don't animate; just leave it as-is.
+    if (rect.top < viewportHeight && rect.bottom > 0) {
+      return;
+    }
+
+    setPhase("armed");
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        for (const entry of entries) {
+          if (entry.isIntersecting) {
+            setPhase("visible");
+            observer.disconnect();
+            break;
+          }
+        }
+      },
+      { rootMargin, threshold: 0.1 },
+    );
+
+    observer.observe(node);
+    return () => observer.disconnect();
+  }, [rootMargin]);
+
+  const className =
+    phase === "armed" ? "reveal" : phase === "visible" ? "reveal is-visible" : "";
+
+  return { ref, className };
+}

--- a/packages/landing/src/components/use-reveal.ts
+++ b/packages/landing/src/components/use-reveal.ts
@@ -15,7 +15,7 @@ type RevealPhase = "idle" | "armed" | "visible";
  * Honors `prefers-reduced-motion: reduce` by skipping animations outright.
  */
 export function useReveal<T extends Element = HTMLDivElement>(
-  rootMargin = "0px 0px -10% 0px",
+  rootMargin = "0px 0px -10% 0px"
 ) {
   const ref = useRef<T | null>(null);
   const [phase, setPhase] = useState<RevealPhase>("idle");
@@ -55,7 +55,7 @@ export function useReveal<T extends Element = HTMLDivElement>(
           }
         }
       },
-      { rootMargin, threshold: 0.1 },
+      { rootMargin, threshold: 0.1 }
     );
 
     observer.observe(node);
@@ -63,7 +63,11 @@ export function useReveal<T extends Element = HTMLDivElement>(
   }, [rootMargin]);
 
   const className =
-    phase === "armed" ? "reveal" : phase === "visible" ? "reveal is-visible" : "";
+    phase === "armed"
+      ? "reveal"
+      : phase === "visible"
+        ? "reveal is-visible"
+        : "";
 
   return { ref, className };
 }

--- a/packages/landing/src/globals.css
+++ b/packages/landing/src/globals.css
@@ -316,3 +316,65 @@ button.chat-action-btn:hover {
   overflow-x: auto;
   border-radius: 0.9rem;
 }
+
+/* ---------- Subtle landing animations ---------- */
+
+/* Hero entrance: fade + rise on first paint, staggered by child. */
+@keyframes hero-rise {
+  from {
+    opacity: 0;
+    transform: translate3d(0, 8px, 0);
+  }
+  to {
+    opacity: 1;
+    transform: translate3d(0, 0, 0);
+  }
+}
+
+.hero-rise {
+  opacity: 0;
+  animation: hero-rise 380ms cubic-bezier(0.22, 1, 0.36, 1) both;
+}
+
+.hero-rise-1 { animation-delay: 0ms; }
+.hero-rise-2 { animation-delay: 80ms; }
+.hero-rise-3 { animation-delay: 160ms; }
+.hero-rise-4 { animation-delay: 240ms; }
+.hero-rise-5 { animation-delay: 320ms; }
+
+/* Scroll-reveal: applied to elements observed by useReveal().
+   Only transform/opacity — no layout shift. */
+.reveal {
+  opacity: 0;
+  transform: translate3d(0, 12px, 0);
+  transition:
+    opacity 420ms cubic-bezier(0.22, 1, 0.36, 1),
+    transform 420ms cubic-bezier(0.22, 1, 0.36, 1);
+  will-change: opacity, transform;
+}
+
+.reveal.is-visible {
+  opacity: 1;
+  transform: translate3d(0, 0, 0);
+}
+
+/* Respect user motion preference — disable all landing animations. */
+@media (prefers-reduced-motion: reduce) {
+  .hero-rise,
+  .hero-rise-1,
+  .hero-rise-2,
+  .hero-rise-3,
+  .hero-rise-4,
+  .hero-rise-5 {
+    animation: none;
+    opacity: 1;
+    transform: none;
+  }
+
+  .reveal,
+  .reveal.is-visible {
+    opacity: 1;
+    transform: none;
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Summary
Two restrained motion effects on the Lobu landing page. Nothing flashy, zero CLS, `prefers-reduced-motion` honored, no new dependencies.

**Effects added**
- **Hero entrance stagger** (`HeroSection`). The GitHub pill, headline, subhead, CTA row, and use-case tabs fade-rise on first paint with ~80ms stagger (380ms duration, cubic ease). Pure CSS keyframe — no JS trigger, no hydration dependency, no flash before Preact boots.
- **Section reveal on scroll** (`SectionHeader`). Section headers (used by `BenchmarkSection`, `MemorySection`, `SkillsWorkflowSection`, `SettingsPanels`, `ExampleShowcase`) fade-rise on entering the viewport via IntersectionObserver. Small helper hook `useReveal` ships alongside. If the header is already on-screen at mount (hero area), animation is skipped entirely to avoid a flash during hydration.

**Deliberately skipped**
- Card hover lift — the feature-equivalent areas (benchmark tables, architecture diagram) aren't quite "cards" in the classic marketing sense; adding lift would feel out of place.
- CTA arrow-slide — hero primary CTA has no arrow to slide; didn't want to add one just to justify the motion.
- Code-block typing effect — `InstallSection.tsx` is explicitly off-limits, and the hero has no other prominent install snippet.

**Implementation notes**
- Only `transform` and `opacity` are animated — no layout shift.
- `prefers-reduced-motion: reduce` disables everything (both the hero keyframes and the scroll-reveal transition).
- No IntersectionObserver fallback path is needed for SSR — `SectionHeader` renders without the `reveal` class by default, so non-JS / no-IO browsers see content as-is.
- No new deps. Bundle impact is a few lines of CSS and a ~50-line Preact hook.

## Test plan
- [x] `cd packages/landing && bun run build` — vite transform + client build pass. The SSG stage hits a pre-existing `_zod` error in Starlight's `connect-from/[client]/for/[useCase]` route that also reproduces on a clean `main`; unrelated to this change.
- [x] `bunx tsc --noEmit` clean for the three files I touched (only pre-existing errors elsewhere).
- [x] Pre-commit biome + tsc hooks pass.
- [ ] Manual browser verification skipped — no Chrome MCP / Playwright available in the session. Reduced-motion behavior verified by CSS review only: `@media (prefers-reduced-motion: reduce)` block zeroes out both `hero-rise*` keyframes and the `.reveal` transition.