### PR TITLE
docs(landing): tighten clarity across docs

### DIFF
--- a/packages/landing/src/content/docs/deployment/embedding.md
+++ b/packages/landing/src/content/docs/deployment/embedding.md
@@ -5,7 +5,7 @@ sidebar:
   order: 0
 ---
 
-Lobu can run inside your existing application as a library instead of a standalone server. Import `@lobu/gateway`, define your agents in code, and mount the HTTP handler into whatever framework you already use.
+Run Lobu inside your application as a library instead of a standalone server. Import `@lobu/gateway`, define your agents in code, and mount the HTTP handler into whatever framework you already use.
 
 ## Install
 
@@ -42,9 +42,7 @@ await lobu.initialize();
 const app = lobu.getApp(); // Hono app with .fetch(Request) → Response
 ```
 
-`getApp()` returns a [Hono](https://hono.dev) application. Hono implements the Web Standard `fetch(Request) → Response` interface, which means it can be mounted in any framework that speaks Web Standard Request/Response — or adapted to Node.js `IncomingMessage`/`ServerResponse` via `@hono/node-server`'s `getRequestListener`.
-
-All examples below reuse the `new Lobu({ ... })` config shown above.
+`getApp()` returns a [Hono](https://hono.dev) application. Hono implements the Web Standard `fetch(Request) → Response` interface, so it mounts in any framework that speaks Web Standard Request/Response — or adapts to Node.js `IncomingMessage`/`ServerResponse` via `@hono/node-server`'s `getRequestListener`.
 
 ---
 
@@ -71,7 +69,7 @@ export const DELETE = handler;
 ```
 
 :::note
-Call `lobu.initialize()` once and await the returned promise in each request. This ensures services start exactly once regardless of how many requests arrive concurrently.
+Call `lobu.initialize()` once and await the returned promise in each request. Services start exactly once regardless of how many requests arrive concurrently.
 :::
 
 ## Next.js (Pages Router)
@@ -191,7 +189,7 @@ Each agent in the `agents` array:
 
 ## What's included
 
-When you embed Lobu, you get the full gateway feature set:
+Embedding gives you the full gateway feature set:
 
 - Agent orchestration and worker lifecycle
 - MCP tool proxy
@@ -200,4 +198,4 @@ When you embed Lobu, you get the full gateway feature set:
 - OpenAPI-documented REST API at `/api/docs`
 - Skills and memory support
 
-The only difference from a standalone deployment is that your application controls the HTTP server.
+The only difference from a standalone deployment: your application controls the HTTP server.

--- a/packages/landing/src/content/docs/getting-started/comparison.md
+++ b/packages/landing/src/content/docs/getting-started/comparison.md
@@ -5,7 +5,7 @@ description: How Lobu compares to other agent deployment options.
 
 Lobu is multi-tenant agent infrastructure. It handles sandboxing, persistence, platform delivery, and network isolation so you can ship agents to your users without building that plumbing yourself.
 
-This page compares Lobu against the alternatives you'd evaluate when deploying agents to production.
+This page compares Lobu against alternatives for deploying agents to production.
 
 ## At a glance
 
@@ -30,7 +30,7 @@ This page compares Lobu against the alternatives you'd evaluate when deploying a
 
 ## Sandboxing and deployment modes
 
-Lobu offers three deployment modes, each with different isolation guarantees. No other platform in this space provides all three.
+Lobu offers three deployment modes, each with different isolation guarantees.
 
 ### Kubernetes (production, on-premise)
 
@@ -41,7 +41,7 @@ Each user session gets its own **pod** with:
 - **PVC per session** — workspace files persist across restarts while remaining isolated per user
 - **Runtime hardening** — designed to run with **gVisor** (GCP), **Kata Containers**, or **Firecracker microVMs** where available
 
-This is the strongest isolation model and the one suited for on-premise enterprise deployments where compliance requires that agent-generated code cannot escape its sandbox.
+The strongest isolation model, suited for on-premise deployments where compliance requires agent-generated code cannot escape its sandbox.
 
 ### Docker Compose (single-machine production)
 
@@ -71,9 +71,7 @@ Mount Lobu inside Next.js, Express, Hono, Fastify, or Bun — no Docker or Kuber
 
 ## MCP proxy and credential isolation
 
-Lobu's MCP proxy is a key differentiator for on-premise and security-conscious deployments.
-
-**How it works**: workers call MCP tools through the gateway. The gateway resolves `${env:VAR}` secrets and injects OAuth tokens before forwarding to the upstream MCP server. Workers never see credentials — they receive opaque proxy URLs.
+Workers call MCP tools through the gateway. The gateway resolves `${env:VAR}` secrets and injects OAuth tokens before forwarding to the upstream MCP server. Workers never see credentials — they receive opaque proxy URLs.
 
 | | Lobu | DeepAgents Deploy | Claude Managed Agents | Direct MCP |
 |---|---|---|---|---|
@@ -83,7 +81,7 @@ Lobu's MCP proxy is a key differentiator for on-premise and security-conscious d
 | Worker sees credentials | Never | Yes (env vars) | N/A | Yes |
 | Audit trail | Gateway logs all MCP calls | No | No | No |
 
-For enterprises with compliance requirements, the fact that agent code never touches API keys or OAuth tokens — even if the agent is compromised — is the deciding factor.
+For compliance-bound deployments, agent code never touches API keys or OAuth tokens — even if the agent is compromised.
 
 ## Why Lobu for on-premise
 
@@ -112,7 +110,7 @@ If you need a single personal agent for yourself, use OpenClaw directly.
 
 Lobu and OpenClaw are complementary. OpenClaw is the agent runtime — the execution engine that runs tools, manages sessions, and talks to LLM providers. Lobu is the infrastructure layer that deploys, isolates, and delivers that runtime to multiple users.
 
-OpenClaw is a powerful runtime (~800k lines of code), but it was designed as a **single-tenant, single-user system**. Production deployments need multi-tenant isolation, platform routing, credential separation, network control, and scale-to-zero — concerns OpenClaw doesn't have opinions about.
+OpenClaw (~800k LOC) was designed as a **single-tenant, single-user system**. Production deployments need multi-tenant isolation, platform routing, credential separation, network control, and scale-to-zero — concerns OpenClaw doesn't have opinions about.
 
 | Capability | Lobu | OpenClaw |
 |---|---|---|
@@ -170,7 +168,7 @@ Claude Managed Agents is Anthropic's hosted agent platform.
 
 ## Lobu vs building it yourself
 
-The alternative to Lobu is often "we'll build it ourselves." Here's what that entails:
+What "we'll build it ourselves" entails:
 
 - **Sandboxing**: per-user container orchestration with workspace persistence
 - **Platform adapters**: Slack Events API, Telegram long-polling, WhatsApp webhooks, each with their own auth flows

--- a/packages/landing/src/content/docs/getting-started/memory.mdx
+++ b/packages/landing/src/content/docs/getting-started/memory.mdx
@@ -3,12 +3,12 @@ title: Memory
 description: How Lobu uses Owletto for shared, structured memory across agents, threads, and teams.
 ---
 
-Lobu has two different memory layers:
+Lobu has two memory layers:
 
 - **Filesystem** for short-term working memory inside a specific channel or user space
 - **Owletto** for long-term organizational memory shared across the workspace
 
-They solve different problems. The filesystem is where an agent does work. Owletto is where the organization remembers what matters.
+The filesystem is where an agent does work. Owletto is where the organization remembers what matters.
 
 - Owletto site: [app.lobu.ai](https://app.lobu.ai)
 - GitHub: [lobu-ai/owletto](https://github.com/lobu-ai/owletto)
@@ -16,23 +16,21 @@ They solve different problems. The filesystem is where an agent does work. Owlet
 
 ## Short-Term Vs Long-Term Memory
 
-Each Lobu channel or user space gets its own filesystem. That filesystem is the agent's working area for the current job:
+Each Lobu channel or user space gets its own filesystem — the agent's working area for the current job:
 
 - downloaded PDFs, screenshots, and other raw inputs
 - temporary Python scripts, notebooks, and scratch files
 - generated CSVs, images, reports, and intermediate outputs
-- duplicate files, renamed files, and ad hoc folder structures that make sense to the agent while it works
+- duplicate files, renamed files, and ad hoc folder structures
 
-That is useful, but it is not a good long-term system of record. The agent may know where files are in its local workspace, but other agents and future sessions usually do not.
+Useful, but not a good long-term system of record. The agent may know where files are in its local workspace, but other agents and future sessions usually do not.
 
-Owletto plays the role of the shared data warehouse or knowledge system for the organization:
+Owletto is the shared knowledge system for the organization:
 
-- it stores durable knowledge in entities
-- it makes that knowledge queryable and analyzable
-- it structures what should be remembered after the local working session is over
-- it lets multiple agents access the same long-term context
-
-The right mental model is:
+- stores durable knowledge in entities
+- makes that knowledge queryable and analyzable
+- structures what should be remembered after the local session ends
+- lets multiple agents access the same long-term context
 
 ```text
 filesystem = short-term working memory + artifacts
@@ -41,29 +39,22 @@ owletto = long-term organizational memory
 
 ## Why Both Exist
 
-An analyst might:
+An analyst might download PDFs into a local folder, write Python to parse them, generate CSVs and charts, then load the final result into a warehouse so the rest of the org can query it later.
 
-1. download PDFs into a local folder
-2. write Python to parse them
-3. generate CSVs and charts
-4. load the final result into a warehouse so the rest of the org can query it later
-
-Lobu agents work the same way.
-
-The filesystem is where the messy work happens. Owletto is where the agent stores the durable, structured result so it can be recalled later across users, channels, and agents.
+Lobu agents work the same way. The filesystem is where the messy work happens. Owletto is where the agent stores the durable, structured result so it can be recalled later across users, channels, and agents.
 
 ## What Owletto Adds
 
 Compared with local filesystem memory, Owletto gives Lobu:
 
 - Workspace-scoped memory shared across agents, users, and threads
-- Typed entities and relationships instead of loose notes only
+- Typed entities and relationships instead of loose notes
 - Hybrid recall using entity matching, full-text search, and semantic search
 - External data ingestion through connectors
 - Scheduled watchers that turn raw events into structured analysis
 - A web UI where operators can review, edit, and correct memory
 
-This matters when memory needs to outlive one sandbox, one machine, one channel, or one user session.
+Useful when memory needs to outlive one sandbox, machine, channel, or user session.
 
 ## How Memory Recall Works
 
@@ -103,7 +94,7 @@ A few details matter in practice:
 - **Relationships** are first-class, so context such as `owned-by`, `depends-on`, or `integrates-with` can influence recall.
 - **Watchers** analyze incoming event streams on a schedule and write structured results back into the graph.
 
-That append-only event history matters because it lets agents and operators inspect what changed over time:
+The append-only event history lets agents and operators inspect what changed over time:
 
 - what arrived from a connector
 - what an agent saved
@@ -112,9 +103,7 @@ That append-only event history matters because it lets agents and operators insp
 
 That makes it easier to recover from mistakes, understand why an agent believed something, and improve future recall.
 
-The important boundary is that **artifacts stay in the filesystem**, while **durable organizational knowledge gets written into Owletto**.
-
-For example:
+The boundary: **artifacts stay in the filesystem**, **durable organizational knowledge gets written into Owletto**. For example:
 
 - keep a downloaded PDF, generated chart, or temporary CSV in the filesystem
 - save "customer prefers weekly summaries" or "vendor X owns system Y" into Owletto
@@ -149,14 +138,9 @@ At runtime, Lobu resolves the memory backend like this:
 - If no Owletto endpoint is resolved, Lobu falls back to `@openclaw/native-memory`.
 - Agents can also override plugin configuration through `pluginsConfig` in agent settings.
 
-The `@lobu/owletto-openclaw` plugin is the adapter between OpenClaw and Owletto. OpenClaw still calls normal memory operations through its plugin interface; the plugin translates those reads and writes into Owletto MCP calls through the gateway proxy, so the worker never needs raw OAuth tokens or direct Owletto credentials.
+The `@lobu/owletto-openclaw` plugin adapts OpenClaw to Owletto. OpenClaw calls normal memory operations through its plugin interface; the plugin translates those reads and writes into Owletto MCP calls through the gateway proxy, so the worker never needs raw OAuth tokens or direct Owletto credentials.
 
-In practice:
-
-- native filesystem memory is the local scratchpad
-- Owletto is the long-term organizational memory layer
-
-That split lets agents keep using local files for active work while persisting the durable parts of that work into shared structured memory.
+The split lets agents keep using local files for active work while persisting the durable parts into shared structured memory.
 
 See also: [Architecture](/guides/architecture/) and [Agent Settings](/guides/agent-settings/).
 
@@ -200,7 +184,7 @@ Typical flow:
 search_knowledge -> read_knowledge -> save_knowledge
 ```
 
-That is the same pattern used by coding agents like Codex, Claude Code, and Cursor when they do not have automatic memory hooks built into the runtime.
+Coding agents like Codex, Claude Code, and Cursor use the same pattern when they lack automatic memory hooks in the runtime.
 
 ## When To Use Owletto
 

--- a/packages/landing/src/content/docs/guides/architecture.mdx
+++ b/packages/landing/src/content/docs/guides/architecture.mdx
@@ -31,11 +31,9 @@ In file-first projects, Lobu resolves persistent memory from `[memory.owletto]` 
 - **`MEMORY_URL`**: still supported as an optional base-endpoint override for local or custom Owletto deployments.
 - **No Owletto config resolved**: uses `@openclaw/native-memory`, which is effectively filesystem-backed short-term memory inside the agent's local workspace.
 
-Memory plugins are configurable per agent through `pluginsConfig` in agent settings.
+Memory plugins are configurable per agent through `pluginsConfig` in agent settings. The split is intentional:
 
-This is an intentional split:
-
-- **Filesystem** is per channel or user space. It is the agent's working area for artifacts such as PDFs, images, scripts, CSVs, and temporary outputs.
+- **Filesystem** is per channel or user space — the agent's working area for artifacts such as PDFs, images, scripts, CSVs, and temporary outputs.
 - **Owletto** is long-term organizational memory. Agents write durable facts into entities so other sessions, users, and agents can query and reuse that knowledge later.
 
 ### How It Works
@@ -46,10 +44,7 @@ This is an intentional split:
 4. If memory is set to `@lobu/owletto-openclaw`, that plugin converts OpenClaw memory reads/writes into Owletto MCP calls through the gateway proxy.
 5. The memory plugin handles persistent memory operations so context can be reused across future runs.
 
-The practical model is:
-
-- local filesystem for short-term working state
-- Owletto for long-term shared knowledge
+In short: local filesystem for short-term working state; Owletto for long-term shared knowledge.
 
 ## Security-Critical Path
 

--- a/packages/landing/src/content/docs/guides/testing.md
+++ b/packages/landing/src/content/docs/guides/testing.md
@@ -7,7 +7,7 @@ Lobu provides multiple ways to test your agent during development.
 
 ## CLI chat
 
-The fastest way to test. Sends a prompt and streams the response in your terminal.
+Send a prompt and stream the response in your terminal.
 
 ```bash
 # Basic test
@@ -31,7 +31,7 @@ This uses **API mode** — the agent runs and responds directly to your terminal
 
 ## Testing through a platform
 
-To test the full end-to-end flow as a real user would experience it, route messages through a connected platform.
+Route messages through a connected platform to test the full end-to-end flow.
 
 ### Using the CLI
 


### PR DESCRIPTION
## Summary

Surgical prose tightening across 5 docs files — net -25 lines. No new sections, diagrams, or examples; only redundant phrasing, marketing-speak, and filler removed.

- `getting-started/comparison.md` — drop "powerful runtime" / "No other platform in this space" / "This page compares..." filler; tighten enterprise framing.
- `getting-started/memory.mdx` — collapse parallel "mental model" prose, merge the analyst walkthrough into one sentence, trim "Why Both Exist" and "How Lobu Connects" repetition.
- `deployment/embedding.md` — remove the "All examples below reuse" scaffolding line and a few "which means" / "When you embed Lobu, you get" filler phrases.
- `guides/architecture.mdx` — merge a dangling one-line paragraph into the split callout; compress "The practical model is:" list into a single sentence.
- `guides/testing.md` — trim the two "The fastest way to test" / "as a real user would experience it" lead-ins to imperative present tense.

## Test plan

- [x] `cd packages/landing && bun run build` — 103 pages built, no errors
- [ ] Visual skim of rendered pages on preview deploy