### PR TITLE
docs(packages): unify and tighten per-package READMEs

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -35,40 +35,9 @@ When Owletto memory is enabled, `lobu init` also scaffolds the file-first memory
 
 For Owletto Local or a custom Owletto deployment, `.env` keeps `MEMORY_URL` as the optional base MCP URL override.
 
-## Usage
-
-```bash
-# Start services
-docker compose up -d
-
-# View logs
-docker compose logs -f
-
-# Stop services
-docker compose down
-
-# Rebuild worker after changes
-docker compose build worker
-```
-
 ## Worker Customization
 
-Extend the generated `Dockerfile.worker` to add tools:
-
-```dockerfile
-FROM ghcr.io/lobu-ai/lobu-worker-base:0.1.0
-
-# Add system packages
-RUN apt-get update && apt-get install -y postgresql-client
-
-# Add Python packages
-RUN pip install pandas matplotlib
-
-# Copy custom scripts
-COPY ./scripts /workspace/scripts
-```
-
-See [custom base image docs](../worker/docs/custom-base-image.md) for using your own base image.
+Extend the generated `Dockerfile.worker` to add system packages, Python packages, or custom scripts on top of `ghcr.io/lobu-ai/lobu-worker-base`. See [custom base image docs](../worker/docs/custom-base-image.md).
 
 ## License
 

--- a/packages/owletto-worker/README.md
+++ b/packages/owletto-worker/README.md
@@ -1,12 +1,6 @@
-# @owletto/worker
+# @lobu/owletto-worker
 
-Self-hosted worker for Owletto. Includes connectors, feeds, and local embedding generation.
-
-## Installation
-
-```bash
-npm install -g @owletto/worker
-```
+Self-hosted Owletto worker. Polls the backend for sync jobs, executes connectors locally, generates embeddings, and streams results back. Private workspace package — not published to npm.
 
 ## Usage
 
@@ -14,16 +8,11 @@ npm install -g @owletto/worker
 owletto-worker daemon --api-url https://api.example.com
 ```
 
-The daemon polls for sync jobs, executes them locally, generates embeddings, and streams results back.
-
 ## Development
 
 ```bash
-cd packages/worker
-API_URL=http://localhost:8787 pnpm daemon
-
-# Or directly:
-npx tsx src/bin.ts daemon --api-url http://localhost:8787
+cd packages/owletto-worker
+API_URL=http://localhost:8787 bun run daemon
 ```
 
 ## Environment Variables
@@ -32,47 +21,19 @@ npx tsx src/bin.ts daemon --api-url http://localhost:8787
 |----------|-------------|----------|
 | `API_URL` | Backend API URL | Yes |
 | `WORKER_ID` | Worker identifier (auto-generated if unset) | No |
+| `WORKER_API_TOKEN` | Bearer token for backend auth | No |
+| `WORKER_MAX_CONCURRENT_JOBS` | Max concurrent sync jobs | No |
+| `EMBEDDINGS_MODEL` | Override local embedding model | No |
+| `EMBEDDINGS_SERVICE_URL` | Use a remote embedding service instead of local | No |
 | `GITHUB_TOKEN` | GitHub API token | No |
-| `REDDIT_CLIENT_ID` | Reddit API client ID | No |
-| `REDDIT_CLIENT_SECRET` | Reddit API client secret | No |
-| `REDDIT_USER_AGENT` | Reddit API user agent | No |
-| `X_USERNAME` | X/Twitter username | No |
-| `X_PASSWORD` | X/Twitter password | No |
-| `X_EMAIL` | X/Twitter email | No |
+| `REDDIT_CLIENT_ID` / `REDDIT_CLIENT_SECRET` / `REDDIT_USER_AGENT` | Reddit API credentials | No |
+| `X_USERNAME` / `X_PASSWORD` / `X_EMAIL` / `X_2FA_SECRET` / `X_COOKIES` | X/Twitter credentials | No |
 | `GOOGLE_MAPS_API_KEY` | Google Maps API key | No |
-
-## Architecture
-
-```
-┌─────────────────────────────────────────────────────────────┐
-│            @owletto/worker                                   │
-│  ┌──────────────┐  ┌──────────────┐                         │
-│  │ Worker Daemon│  │ Feeds        │                         │
-│  │ (poll loop)  │  │ + Embeddings │                         │
-│  └──────┬───────┘  └──────────────┘                         │
-└─────────┼───────────────────────────────────────────────────┘
-          │  HTTP/REST
-          ▼
-┌─────────────────────────────────────────────────────────────┐
-│              Backend                                         │
-│  ┌──────────────┐  ┌──────────────┐  ┌──────────────┐      │
-│  │ MCP + REST   │  │ Tools        │  │ Database     │      │
-│  │ Endpoints    │  │              │  │ (Postgres)   │      │
-│  └──────────────┘  └──────────────┘  └──────────────┘      │
-└─────────────────────────────────────────────────────────────┘
-```
-
-## API Endpoints
-
-- `POST /api/workers/poll` — Poll for available jobs
-- `POST /api/workers/heartbeat` — Heartbeat during execution
-- `POST /api/workers/stream` — Stream synced content
-- `POST /api/workers/complete` — Report job completion
 
 ## Embeddings
 
-Generated locally via `@xenova/transformers` with `bge-base-en-v1.5` (768 dimensions). Runs on CPU, no external API calls.
+Generated locally via `@xenova/transformers` with `bge-base-en-v1.5` (768 dimensions). Runs on CPU, no external API calls. Set `EMBEDDINGS_SERVICE_URL` to offload to a remote service.
 
 ## License
 
-BSL 1.1. See the repository [LICENSE](../../LICENSE).
+BUSL-1.1. See the repository [LICENSE](../../LICENSE).


### PR DESCRIPTION
## Summary

Fixes the only 3 per-package READMEs that exist (`cli`, `owletto-openclaw`, `owletto-worker`) so they're accurate and brief. Net -70 LOC.

- **packages/owletto-worker/README.md**: Fixed wrong publish name (`@owletto/worker` → `@lobu/owletto-worker`) and the bogus `npm install -g` instruction — the package is `"private": true`, so global install from npm never worked. Switched `pnpm daemon` → `bun run daemon` to match the monorepo. Dropped the stale ASCII architecture diagram and internal `/api/workers/*` endpoint list (implementation detail that doesn't belong in a README). Added the env vars the bin script actually reads (`WORKER_API_TOKEN`, `WORKER_MAX_CONCURRENT_JOBS`, `EMBEDDINGS_MODEL`, `EMBEDDINGS_SERVICE_URL`, `X_2FA_SECRET`, `X_COOKIES`).
- **packages/cli/README.md**: Removed the generic `docker compose up/logs/down/build` block (duplicates what `lobu init` prints in the scaffolded project's own README) and the inlined Dockerfile example (same info is already in the linked `../worker/docs/custom-base-image.md`).
- **packages/owletto-openclaw/README.md**: Left as-is. Already tight, accurate, and follows the same skeleton.

Did not create READMEs for the 11 packages that don't have one — task brief said not to expand unless matched by equivalent deletions.

## Test plan

- [x] Visual read of both edited files
- [x] Verified `bun run daemon` exists in `packages/owletto-worker/package.json`
- [x] Verified `../worker/docs/custom-base-image.md` link target exists
- [x] Verified new env vars are referenced in `packages/owletto-worker/src/bin.ts` and `src/embeddings.ts`
- [x] Pre-commit hooks passed (biome + tsc)