### PR TITLE
docs: tighten root + docs/ consistency

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,47 +12,42 @@
 - **Platform isolation**: InteractionService events (e.g. `link-button:created`) carry an explicit `platform` field. Each platform renderer MUST filter on its own platform identity (`platform === "telegram"`, `platform === "slack"`). Never reference another platform's identifier.
 
 ### Repository Layout
-- Monorepo managed by Bun workspaces: `packages/gateway`, `packages/worker`, `packages/core`.
-- Top-level: `Makefile`, `scripts/` (CLI/setup), `charts/lobu` (Helm), `config/` (biome, knip, etc.), `docker/` (Dockerfiles, compose), `docs/` (CONTRIBUTING, SECURITY), `.env*`.
-- TypeScript sources under `packages/*/src`. Tests in `packages/*/src/__tests__` and `packages/core/tests`.
-- **ALWAYS prefer `bun` commands over `npm`**
-- When fixing unused parameter errors, remove the parameter entirely if possible rather than prefixing with underscore
-- Worker prompt delivery: prompts are passed to the agent runtime directly (no named pipes used)
+- Monorepo managed by Bun workspaces under `packages/*`.
+- Top-level: `Makefile`, `scripts/`, `charts/lobu` (Helm), `config/`, `docker/`, `docs/` (RELEASING, SECURITY), `.env*`.
+- TypeScript sources in `packages/*/src`, tests in `packages/*/src/__tests__`.
+- Always prefer `bun` over `npm`.
+- When fixing unused-parameter errors, delete the parameter rather than prefixing with `_`.
 
 ### Submodules
-- `packages/owletto-web` is a git submodule pointing at `lobu-ai/owletto-web`. ANY code change inside it must ship as TWO PRs in this order: (1) submodule PR in `lobu-ai/owletto-web`, merge it; (2) parent PR in `lobu-ai/lobu` that bumps the submodule pointer. Never push parent commits that reference an unmerged submodule SHA — the production build resolves submodule SHAs from the parent and the deploy will break.
-- After the submodule PR merges, run `git -C packages/owletto-web pull --ff-only origin main`, stage `packages/owletto-web` in the parent, and open the parent bump PR.
+`packages/owletto-web` is a submodule of `lobu-ai/owletto-web`. Every change there ships as **two PRs**: (1) land the submodule PR; (2) open a parent PR that bumps the pointer. Never push a parent commit that references an unmerged submodule SHA — production resolves SHAs from the parent and will break. After the submodule PR merges: `git -C packages/owletto-web pull --ff-only origin main`, stage the submodule in the parent, open the bump PR.
 
 ### Architecture
 
 #### Platform
-All messaging platforms (Telegram, Slack, Discord, WhatsApp, Teams) are managed via Chat SDK adapters in `packages/gateway/src/connections/`. Connections are created via the admin page UI (`/agents`) or the connections CRUD API — no platform-specific env vars required. Each connection has a typed config schema (e.g. bot token for Telegram, signing secret + bot token for Slack). There is also a public endpoint in gateway to trigger running the agent.
-Settings page provider order is drag-sortable via handle, with per-provider model selection inline in each provider row.
+All chat platforms (Telegram, Slack, Discord, WhatsApp, Teams) run through Chat SDK adapters in `packages/gateway/src/connections/`. Connections are created via the `/agents` admin UI or the connections CRUD API — no per-platform env vars. Each connection has a typed config schema (bot token for Telegram, signing secret + bot token for Slack, etc.). Gateway also exposes a public endpoint that triggers an agent run. Settings-page provider order is drag-sortable, with per-provider model selection inline.
 
 #### Orchestration
-- **Deployment modes**: Kubernetes (production), Docker (development)
-- All workers are sandboxed with your settings.
-- **Workers must NEVER see real credentials.** Provider credentials are resolved by the gateway proxy using agentId from the URL path (`/api/proxy/{slug}/a/{agentId}/...`). Workers only receive opaque placeholders in env vars.
+- Deployment modes: Kubernetes (production), Docker Compose (development).
+- Workers are sandboxed and **never see real credentials**. The gateway proxy resolves provider credentials from the agentId in the URL path (`/api/proxy/{slug}/a/{agentId}/...`); workers get opaque placeholders in env.
 
 #### MCP
-- Bundled LLM providers are registered via `config/providers.json`; MCP servers come from per-agent settings or local SKILL.md files.
+- Bundled LLM providers come from `config/providers.json`; MCP servers come from per-agent settings or local `SKILL.md` files.
 - Workers discover MCP tools at startup and register them as first-class agent tools (direct function calls, not curl instructions).
-- Workers call MCP tools through the gateway proxy using their JWT token.
-- Built-in MCPs available to workers: AskUser (request user input), UploadFile (share files with user).
-- **Integration auth is handled by Owletto** — OAuth credentials, token refresh, and API proxying for third-party services (GitHub, Google, etc.) are managed by Owletto MCP servers. Workers call integration APIs through Owletto MCP tools; they never see OAuth tokens directly.
+- Workers call MCP tools via the gateway proxy using their JWT.
+- Built-in MCPs: `AskUser` (request user input), `UploadFile` (share files with user).
+- **Integration auth lives in Owletto** — OAuth, token refresh, and API proxying for third-party services (GitHub, Google, etc.) are handled by Owletto MCP servers. Workers never see OAuth tokens.
 
 #### Network
-
-- Workers run on isolated internal network (`lobu-internal`) with no direct internet access. Gateway sits on both `lobu-public` and `lobu-internal` networks, acting as single egress point.
-- **Proxy filtering**: Gateway runs custom Node.js HTTP proxy on port 8118. Workers configured with `HTTP_PROXY=http://gateway:8118` for all outbound requests (curl/wget/npm/git).
-- **Network access control** (via `WORKER_ALLOWED_DOMAINS` environment variable):
-  - **Complete isolation** (default): Leave empty or unset → workers have NO internet access
-  - **Allowlist mode**: `WORKER_ALLOWED_DOMAINS="github.com"` → deny by default, allow only these domains
-  - **Unrestricted access**: `WORKER_ALLOWED_DOMAINS="*"` → allow all domains (not recommended for production)
-  - **Blocklist mode**: `WORKER_ALLOWED_DOMAINS="*"` + `WORKER_DISALLOWED_DOMAINS="malicious.com,spam.org"` → allow all except blocked
-- **Domain format**: Exact domain (`api.example.com`) or wildcard (`.example.com` matches `*.example.com`)
-- **Enforcement**: Docker's `internal: true` network flag prevents routing to external networks at infrastructure layer. Even if worker code is compromised, no network route exists. HTTP proxy provides selective access to approved domains only.
-- **Worker env passthrough**: Gateway env vars prefixed with `WORKER_ENV_` are forwarded to workers with the prefix stripped. Example: `WORKER_ENV_FOO=bar` → worker sees `FOO=bar`. Use this only for worker-specific runtime env, not for the default Owletto memory plugin config.
+- Workers run on the internal-only `lobu-internal` network; the gateway sits on both `lobu-public` and `lobu-internal` and is the single egress.
+- Gateway runs a Node HTTP proxy on :8118; workers get `HTTP_PROXY=http://gateway:8118` for all outbound (curl/wget/npm/git).
+- Access is controlled by `WORKER_ALLOWED_DOMAINS`:
+  - Empty/unset → no internet (default).
+  - `"github.com"` → allowlist only.
+  - `"*"` → allow all (not for production).
+  - `"*"` + `WORKER_DISALLOWED_DOMAINS="malicious.com,spam.org"` → blocklist mode.
+- Domain format: exact (`api.example.com`) or wildcard (`.example.com`).
+- Docker's `internal: true` enforces isolation at the infra layer; the proxy adds selective egress on top.
+- `WORKER_ENV_*` gateway vars are forwarded to workers with the prefix stripped (`WORKER_ENV_FOO=bar` → `FOO=bar`). Use only for worker runtime env, not the default Owletto memory plugin config.
 
 ## TypeScript Build System
 
@@ -60,113 +55,83 @@ TypeScript packages must be compiled from `src/` → `dist/`. If you modify any 
 
 ## Versioning and releasing
 
-Releases are driven by [release-please](https://github.com/googleapis/release-please). You never bump versions by hand — just land feature work on `main` via PRs with conventional commit messages (`feat:`, `fix:`, `docs:`, `chore:`, etc.) and release-please opens a release PR. Merging the release PR triggers the automated publish to npm via OIDC trusted publishing and dispatches the Docker image build. See [`docs/RELEASING.md`](docs/RELEASING.md) for the full flow, commit conventions, recovery playbook, and local-publish fallback.
+Releases are driven by [release-please](https://github.com/googleapis/release-please): land conventional commits on `main`, merge the generated release PR, and CI publishes to npm (OIDC) and builds Docker images. See [`docs/RELEASING.md`](docs/RELEASING.md) for the full flow, recovery playbook, and local-publish fallback.
 
-Implementation details for when you need to change the release system itself:
+Rules for agents:
+- Inter-package deps MUST be `"@lobu/<name>": "workspace:*"` — never a hardcoded version. `scripts/publish-packages.mjs` rewrites them at publish time.
+- Don't hand-edit `packages/*/package.json` versions and don't push `chore(release)` commits directly; release-please owns those.
+- Source of truth for the current version: `.release-please-manifest.json` plus the `v<version>` tags.
 
-- **Inter-package deps MUST use `"@lobu/<name>": "workspace:*"`**, never a hardcoded version string. `scripts/publish-packages.mjs` rewrites `workspace:*` to the current root version right before `npm publish` and restores the file afterwards.
-- Don't hand-edit versions in individual `packages/*/package.json` files and don't push `chore(release)` bumps directly. release-please writes those commits via its release PR.
-- `scripts/bump-version.mjs` still exists for manual fallback, but the normal path is release-please. If you have to run it, land the version bump via a PR, not a direct push.
-- The single source of truth for the "current version" is `.release-please-manifest.json` plus the `v<version>` git tags. Keep them in sync if you ever edit either.
-- Adding a new published workspace means updating two files: `release-please-config.json` (to add `extra-files` for the new `package.json`) and `scripts/publish-packages.mjs` (`PACKAGES` array).
+## Agent Rules
+- Do only what's asked — nothing more, nothing less.
+- Don't create `*.md` files unless explicitly asked. Add memory to `CLAUDE.md` as a single sentence.
+- Delete any ephemeral files you create.
+- Ignore `/dist/` — compiled artifacts, not source.
+- After editing `packages/worker/*`, run `make clean-workers` so new workers pick up the change.
+- When the user pastes a Slack link (`slack.com/archives/…?thread_ts=`), call `./scripts/slack-thread-viewer.js "<link>"` first.
+- In planning mode, when unsure, ask: `codex exec "QUESTION" --config model_reasoning_effort="high"`.
 
-## Instructions
-- You MUST only do what has been asked; nothing more, nothing less.
-- When the user types a Slack message link (slack.com/archives/x/x/?thread_ts=) you MUST call ./scripts/slack-thread-viewer.js "link" to gather context
-- When you are in planning mode and you're not fully sure, you need to ask 'codex exec "YOUR_QUESTION" --config model_reasoning_effort="high"'
-- When you make changes to worker code (`packages/worker/*`), run `make clean-workers` to ensure new workers use the updated code.
-- The "is running" thread status indicator (with rotating messages) provides user feedback during processing; visible "Still processing" heartbeat messages are not sent to avoid clutter.
-- Anytime you make changes in the code, you MUST:
+## Development
 
-1. Have the stack running (`make dev`).
-2. Run validations that match the surface you changed — do not skip the relevant app:
-   - `packages/landing/*`: run `cd packages/landing && bun run build`
-   - `packages/core/*`, `packages/gateway/*`, `packages/worker/*`, `packages/cli/*`: run `make build-packages`
-   - For broad TS safety across the repo, prefer `bun run typecheck` when practical
-3. When possible, first verify MCP tool calls work by calling the gateway proxy or Owletto directly (e.g., via a temporary script or `bun -e`). This catches issues before involving the full agent loop.
-4. If your change affects bot behavior, worker execution, gateway orchestration, platform integrations, MCP tools, or agent responses, test the bot using the test script:
+Prerequisites: Bun, Docker Desktop.
+
 ```bash
-./scripts/test-bot.sh "@me test prompt"
-```
-The script automatically handles sending the message, waiting for response, and checking logs. You can send multiple messages in sequence:
-```bash
-./scripts/test-bot.sh "@me first message" "follow up question" "another question"
-```
-5. If the bot gives stale/wrong responses, clear Redis chat history for the test user before retesting:
-```bash
-docker compose -f docker/docker-compose.yml exec redis redis-cli KEYS 'chat:history:*' # find the key
-docker compose -f docker/docker-compose.yml exec redis redis-cli DEL 'chat:history:<key>'
-```
-
-6. For automated quality checks, use the eval system when the change affects agent behavior or prompt quality:
-```bash
-lobu eval                    # run all evals for default agent
-lobu eval ping               # run a specific eval
-lobu eval -m claude/sonnet   # eval with a specific model
-lobu eval --list             # list available evals
-```
-Eval definitions live in `agents/{name}/evals/*.yaml`. See [lobu.ai/guides/evals](https://lobu.ai/guides/evals/) for format details.
-
-- If you create ephemeral files, you MUST delete them when you're done with them.
-- Use Docker to build and run the bot in development mode, K8S for production.
-- NEVER proactively create documentation files (\*.md) or README files. Only create documentation files if explicitly requested by the User. If you need to remember something, add it to CLAUDE.md as a single sentence.
-- ALWAYS ignore `/dist/` directories when analyzing code - these contain compiled artifacts, not source
-
-## Development Mode
-
-### Prerequisites
-- Bun: installed
-- Docker Desktop: running
-
-### First-time Setup
-```bash
-./scripts/setup-dev.sh
-```
-
-### Starting Development
-```bash
-make dev
-```
-
-This runs `docker compose watch` which starts the full stack (gateway, Redis, etc.) and auto-syncs source changes into containers. No manual rebuilds needed.
-
-### Hot Reload
-- **Gateway + Packages**: `docker compose watch` (`make dev`) auto-syncs source changes
-- **Worker**: Run `make clean-workers` after worker code changes
-
-### Check Logs
-```bash
+./scripts/setup-dev.sh   # first-time setup
+make dev                  # docker compose watch (auto-syncs source)
+make clean-workers        # after worker/* changes
+make deploy               # Kubernetes (production)
 docker compose -f docker/docker-compose.yml logs -f gateway
 ```
 
-### Deployment
-1. **Development**: `make dev` (docker compose watch)
-2. **Kubernetes deployment**: Use `make deploy` for production deployment
+### Validation after code changes
 
-## Environment Configuration
+Run the validation that matches what you touched:
 
-The `.env` file is the single source of truth for all secrets and configuration.
+| Change | Command |
+| --- | --- |
+| `packages/landing/*` | `cd packages/landing && bun run build` |
+| `packages/{core,gateway,worker,cli}/*` | `make build-packages` |
+| Broad TS check | `bun run typecheck` |
 
-### Local Development
-- Gateway reads `.env` on startup via Docker Compose
-- Restart after `.env` changes: `make dev` (or `docker compose -f docker/docker-compose.yml up`)
+For MCP work, verify tool calls against the gateway proxy or Owletto directly (e.g. via `bun -e`) before exercising the full agent loop.
 
-The gateway deployment has a checksum annotation that triggers automatic pod restart when secrets change via `helm upgrade`.
+If the change affects bot behavior, run the test bot:
 
-Worker deployments use persistent volumes for session continuity across scale-to-zero:
+```bash
+./scripts/test-bot.sh "@me test prompt"              # single
+./scripts/test-bot.sh "@me first" "follow up"        # multi-turn
+# Telegram: TEST_PLATFORM=telegram TEST_CHANNEL=@clawdotfreebot ./scripts/test-bot.sh "…"
+```
 
-1. **Per-Deployment PVC**: Each worker deployment gets its own PersistentVolumeClaim (1 thread = 1 PVC) mounted at `/workspace`
-2. **Session Storage**: Agent sessions are stored in `/workspace/` (via `HOME=/workspace` environment variable)
-3. **Auto-Resume**: When a worker scales back up, it automatically detects existing sessions and resumes
-4. **Cleanup**: PVCs are automatically deleted when deployments are cleaned up after thread inactivity
-5. **Docker Mode**: Uses host directory mounts at `./workspaces/{threadId}/` for equivalent persistence
+If replies look stale, clear Redis chat history:
 
-### Integration Authentication
+```bash
+docker compose -f docker/docker-compose.yml exec redis redis-cli KEYS 'chat:history:*'
+docker compose -f docker/docker-compose.yml exec redis redis-cli DEL 'chat:history:<key>'
+```
 
-OAuth authentication for third-party APIs (GitHub, Google, Linear, etc.) is handled by **Owletto**, not by the Lobu gateway. Workers access these APIs through Owletto MCP tools, which handle credential management, token refresh, and API proxying. Workers never see OAuth tokens directly.
+For prompt / behavior changes, run evals (definitions in `<example>/agents/<name>/evals/*.yaml`):
 
-Skills that need direct network access (e.g., `git clone`) declare `networkConfig.allowedDomains`, which is merged into the agent's network allowlist when the skill is enabled. Skills that need system tools declare `nixPackages` which are merged into the worker's Nix environment. Review skills before installing — declared domains and packages are applied without a separate per-skill approval step. Destructive MCP tool calls still require in-thread approval unless the operator pre-approves them in `[agents.<id>.tools]` in `lobu.toml`.
+```bash
+lobu eval                    # all evals for default agent
+lobu eval ping               # single eval
+lobu eval -m claude/sonnet   # with model override
+lobu eval --list
+```
 
-Local dev Telegram bot is `@clawdotfreebot`, production is `@lobuaibot`.
-To test Telegram bot, use `TEST_PLATFORM=telegram TEST_CHANNEL=@clawdotfreebot ./scripts/test-bot.sh "message"` (or set `TELEGRAM_TEST_CHAT_ID`); this path uses `tguser` and sends as your real user account.
-When testing locally, always start the stack with `make dev` (docker compose watch) so changes auto-sync.
+Local dev Telegram bot: `@clawdotfreebot`. Production: `@lobuaibot`.
+
+## Environment & Runtime
+
+`.env` is the single source of truth for secrets. Gateway reads it on startup; restart with `make dev` after changes. In Kubernetes, a checksum annotation triggers pod restart when secrets change via `helm upgrade`.
+
+Workers get persistent storage for session continuity across scale-to-zero:
+
+- **K8s**: each worker deployment has its own PVC mounted at `/workspace` (1 thread = 1 PVC). Sessions live in `/workspace/` (`HOME=/workspace`). PVCs are deleted when the deployment is cleaned up after thread inactivity; on scale-up, existing sessions auto-resume.
+- **Docker**: equivalent host mount at `./workspaces/{threadId}/`.
+
+### Integration authentication
+
+OAuth for third-party APIs (GitHub, Google, Linear, etc.) is handled by **Owletto**, not the gateway. Workers hit those APIs through Owletto MCP tools and never see tokens directly.
+
+Skills that need network declare `networkConfig.allowedDomains`; skills that need system tools declare `nixPackages`. Both are merged into the agent's allowlist / Nix env when the skill is enabled, with no per-skill approval prompt — review skills before installing. Destructive MCP tool calls still require in-thread approval unless pre-approved in `[agents.<id>.tools]` in `lobu.toml`.

--- a/README.md
+++ b/README.md
@@ -1,36 +1,27 @@
-# Lobu - Multi-tenant OpenClaw for Organizations
+# Lobu — Multi-tenant OpenClaw for Organizations
 
 **Lobu** is an open-source multi-tenant gateway for [OpenClaw](https://github.com/openclaw/openclaw). One sandbox and filesystem per user/channel. Shared memory across contexts. Agents never see secrets.
 
-OpenClaw is an incredible agent runtime (800k LOC) but it's [single-tenant by design](https://x.com/steipete/status/2026092642623201379). Every user shares the same filesystem and bash session. Lobu rewrites only the gateway layer (~40k LOC) to be multi-tenant and keeps OpenClaw's Pi agent harness untouched inside each worker.
+OpenClaw is a full agent runtime (~800k LOC) but it's [single-tenant by design](https://x.com/steipete/status/2026092642623201379) — every user shares the same filesystem and bash session. Lobu rewrites only the gateway layer (~40k LOC) to be multi-tenant and keeps OpenClaw's Pi harness untouched inside each worker.
 
-**Embedded mode** uses [just-bash](https://github.com/nicholasgasior/just-bash) (virtual bash) + Nix for reproducible packages. Each user gets an isolated virtual filesystem and bash session at ~50MB memory footprint. We've tested 300 concurrent instances on a single machine. No Docker needed.
+**Embedded mode** uses [just-bash](https://github.com/nicholasgasior/just-bash) + Nix for reproducible packages. Each user gets an isolated virtual filesystem and bash session at ~50MB per instance — tested at 300 concurrent instances on a single machine, no Docker needed.
 
-Embed OpenClaw-powered agents into your product, or give your team powerful agents without managing separate instances for everyone.
+Embed OpenClaw-powered agents into your product, or give your team agents without managing a separate instance per person.
 
 https://github.com/user-attachments/assets/d72a9286-0325-4b8b-afc0-c1efe9c96f4e
 
 ## Channels & API
 
-**REST API** — Programmatic agent creation, control, and state management.
-
-[![API Docs](https://img.shields.io/badge/API_Docs-0096FF?style=for-the-badge&logo=readme&logoColor=white)](https://lobu.ai/reference/api-reference/)
-
-**Slack** — Multi-channel/DM agents with rich interactivity.
-
-**Telegram** — Long-polling bot integration with interactive agent workflows.
-
-**WhatsApp** — WhatsApp Business Cloud API integration.
-
-**Discord** — Bot integration with channel and DM support.
-
-**Teams** — Microsoft Teams bot integration.
+- **REST API** — programmatic agent creation, control, and state. [![API Docs](https://img.shields.io/badge/API_Docs-0096FF?style=for-the-badge&logo=readme&logoColor=white)](https://lobu.ai/reference/api-reference/)
+- **Slack** — multi-channel/DM agents with rich interactivity.
+- **Telegram** — long-polling bot with interactive workflows.
+- **WhatsApp** — WhatsApp Business Cloud API.
+- **Discord** — channel + DM bot support.
+- **Teams** — Microsoft Teams bot.
 
 ## Quick Start
 
-### Self-host in under a minute
-
-The quickest way to start is the CLI scaffold:
+Scaffold and run via the CLI:
 
 ```bash
 npx @lobu/cli@latest init my-bot
@@ -39,19 +30,13 @@ cd my-bot && npx @lobu/cli@latest run -d
 
 ### Deployment modes
 
-- **Docker Compose** — `docker compose up` (One-click, production single-machine)
-- **Kubernetes** — Install via OCI Helm chart (no clone needed):
-
-```bash
-helm install lobu oci://ghcr.io/lobu-ai/charts/lobu \
-  --namespace lobu \
-  --create-namespace
-```
-
-- **Local Development** — For contributing to Lobu itself:
-  1. Clone this repo
-  2. `make setup`
-  3. `make dev` (Uses Docker Compose Watch for hot-reloading)
+- **Docker Compose** — `docker compose up` (single-machine production).
+- **Kubernetes** — OCI Helm chart, no clone needed:
+  ```bash
+  helm install lobu oci://ghcr.io/lobu-ai/charts/lobu \
+    --namespace lobu --create-namespace
+  ```
+- **Local dev** (contributing to Lobu itself): clone, `make setup`, `make dev` (Docker Compose Watch + hot reload).
 
 ## Architecture
 
@@ -78,73 +63,67 @@ flowchart LR
 
 ## Capabilities
 
-Every Lobu agent comes equipped with a suite of tools for autonomous execution and persistence:
+Every Lobu agent ships with tools for autonomous execution and persistence:
 
-| Feature | Description | Built-in Tools |
-| :--- | :--- | :--- |
-| **Autonomous Scheduling** | Schedule one-time or recurring execution via cron. | `ScheduleReminder`, `ListReminders`, `CancelReminder` |
-| **Human-in-the-Loop** | Pause for user input via buttons and resume when answered. | `AskUserQuestion` |
-| **Full Linux Toolbox** | Sandboxed shell access, file editing, and advanced search. | `bash`, `read`, `write`, `edit`, `grep`, `find`, `ls` |
-| **Conversation Context** | Pull earlier thread messages when the user references prior work. | `GetChannelHistory` |
-| **File & Media Delivery** | Share reports, charts, or generated voice messages. | `UploadUserFile`, `GenerateAudio` |
-| **Skills** | Extend agent capabilities via skills configured in lobu.toml or the admin settings page. | `lobu.toml`, Settings UI |
-| **Connected APIs** | Access third-party APIs (GitHub, Google, etc.) through Owletto MCP tools with managed OAuth. | MCP tools via Owletto |
-| **Managed MCP Proxy** | Securely connect to any MCP server with secret injection. | [MCP Proxy](docs/SECURITY.md#credentials) |
-| **Advanced Capabilities** | Extend agent abilities with web browsing, headless UI interaction, and specialized utilities via Nix packages or external MCP servers. | `bash` (Nix), MCP servers |
+| Feature | Built-in Tools |
+| --- | --- |
+| **Autonomous scheduling** — one-time or cron | `ScheduleReminder`, `ListReminders`, `CancelReminder` |
+| **Human-in-the-loop** — pause on button input, resume on answer | `AskUserQuestion` |
+| **Full Linux toolbox** — sandboxed shell, file edit, search | `bash`, `read`, `write`, `edit`, `grep`, `find`, `ls` |
+| **Conversation context** — pull earlier thread messages | `GetChannelHistory` |
+| **File & media delivery** — share reports, charts, audio | `UploadUserFile`, `GenerateAudio` |
+| **Skills** — extend via `lobu.toml` or admin settings | `lobu.toml`, Settings UI |
+| **Connected APIs** — GitHub, Google, etc. with Owletto-managed OAuth | MCP tools via Owletto |
+| **Managed MCP proxy** — any MCP server with secret injection | [MCP Proxy](docs/SECURITY.md#credentials) |
+| **Nix + external MCP** — browsing, headless UI, custom tools | `bash` (Nix), MCP servers |
 
-### Popular MCP Integrations
-Workers access third-party APIs through MCP servers. OAuth and credential management is handled by Owletto:
+### Popular MCP integrations
+
 - **Productivity:** Google Calendar, Slack, Jira, Notion
 - **Development:** GitHub, GitLab, Postgres, Docker
 - **Knowledge:** Wikipedia, Brave Search, YouTube, PDF Search
 
-**Gateway as single egress.** All worker traffic — internet and MCP — routes through the gateway. Workers have no direct network access. Domain filtering controls which external services workers can reach.
+### Design
 
-**MCP Proxy.** Workers call MCP tools via the gateway. The gateway resolves `${env:VAR}` secrets and routes to upstream MCP servers. OAuth credentials for third-party APIs are managed by Owletto — workers never see tokens directly.
-
-**Multi-platform, multi-tenant.** One bot instance serves Slack, Telegram, WhatsApp, Discord, Teams, and REST API. Each channel/DM gets its own isolated runtime, model, tools, credentials, and Nix packages.
-
-**OpenClaw runtime.** Workers run [OpenClaw Pi Agent](https://openclaw.ai/), with per-agent model selection via the settings page. Supports OpenClaw skills, `IDENTITY.md`, `SOUL.md`, and `USER.md` workspace files.
-
-**Multi-provider auth.** 16 LLM providers (OpenAI, Gemini, Groq, DeepSeek, Mistral, etc.) via config-driven provider registry. API keys resolved at the gateway — workers never see credentials.
+- **Gateway as single egress.** All worker traffic — internet and MCP — routes through the gateway. Workers have no direct network access; domain filtering controls which services they reach.
+- **MCP proxy.** Gateway resolves `${env:VAR}` secrets and routes to upstream MCP servers. OAuth for third-party APIs stays in Owletto — workers never see tokens.
+- **Multi-platform, multi-tenant.** One instance serves Slack, Telegram, WhatsApp, Discord, Teams, and the REST API. Each channel/DM gets its own runtime, model, tools, credentials, and Nix packages.
+- **OpenClaw runtime.** Workers run [OpenClaw Pi Agent](https://openclaw.ai/) with per-agent model selection. Supports OpenClaw skills and `IDENTITY.md` / `SOUL.md` / `USER.md` workspace files.
+- **Multi-provider auth.** 16 LLM providers (OpenAI, Gemini, Groq, DeepSeek, Mistral, …) via a config-driven registry. API keys stay on the gateway.
 
 ## How Lobu Differs
 
-Lobu is the **infrastructure layer** for autonomous agents. Unlike frameworks (LangChain, CrewAI) that help you *write* agent logic, Lobu is the **delivery mechanism** that runs those agents at scale — handling the sandboxing, persistence, and messaging connectivity.
+Lobu is the **infrastructure layer** for autonomous agents. Frameworks like LangChain or CrewAI help you *write* agent logic; Lobu is the delivery layer that runs those agents at scale — sandboxing, persistence, and messaging connectivity.
 
 | | Lobu | OpenClaw |
-|---|---|---|
-| **Scale to zero** | Workers scale down when idle | Requires always-on computer |
-| **Multi-tenant** | Single bot, per-channel/DM isolation | One instance per setup |
-| **Multi-platform** | Slack, Telegram, WhatsApp, Discord, Teams, REST API | [15+ chat platforms](https://openclaw.ai/integrations) |
-| **Runtime** | OpenClaw engine (sandboxed/proxied) | Native OpenClaw runtime |
-| **User onboarding** | Configure page with OAuth login per provider | CLI setup required |
-| **MCP access** | Proxied through gateway, secrets isolated | Direct from agent |
-| **Network isolation** | Workers sandboxed, domain-filtered egress | No built-in isolation |
-| **Deployment** | K8s, Docker | Single node |
+| --- | --- | --- |
+| Scale to zero | Workers scale down when idle | Requires always-on machine |
+| Multi-tenant | Single bot, per-channel/DM isolation | One instance per setup |
+| Multi-platform | Slack, Telegram, WhatsApp, Discord, Teams, REST API | [15+ chat platforms](https://openclaw.ai/integrations) |
+| Runtime | OpenClaw engine (sandboxed/proxied) | Native OpenClaw |
+| Onboarding | Config page with per-provider OAuth | CLI setup |
+| MCP access | Proxied through gateway, secrets isolated | Direct from agent |
+| Network | Sandboxed, domain-filtered egress | No built-in isolation |
+| Deployment | K8s, Docker | Single node |
 
 ## Security and Privacy
 
 - [**No direct worker egress**](docs/SECURITY.md#network-egress) — all traffic routes through the gateway proxy.
-- [**Secrets stay in gateway**](docs/SECURITY.md#credentials) — Provider credentials and `${env:}` substitution. OAuth for third-party APIs managed by Owletto.
-- [**Defense-in-depth on K8s**](docs/SECURITY.md#kubernetes) — NetworkPolicies, RBAC, and optional gVisor/Kata runtimes.
-- [**Nix system packages**](docs/SECURITY.md#skills-and-policy) — per-agent reproducible tooling and skills policy enforcement.
+- [**Secrets stay in gateway**](docs/SECURITY.md#credentials) — provider credentials and `${env:}` substitution; OAuth lives in Owletto.
+- [**Defense in depth on K8s**](docs/SECURITY.md#kubernetes) — NetworkPolicies, RBAC, optional gVisor / Kata.
+- [**Nix system packages**](docs/SECURITY.md#skills-and-policy) — per-agent reproducible tooling and skill policy.
 
 ## Support & Consultancy
 
-Lobu is designed for high-stakes, persistent agents. While the platform is open-source, the true value of an agent lies in its **soul, identity, and integration**.
+Lobu is open source, but deploying production-grade agents usually means tuning soul, identity, and integrations. I offer hands-on implementation for:
 
-If you want to deploy agents for your organization but need expert implementation and infrastructure maintenance, I provide end-to-end support for:
+- **Employee AI assistants** — persistent sandboxed agents on Slack wired into internal tools and docs.
+- **Automated customer support** — multi-step ticket handling with human-in-the-loop.
+- **Autonomous workflows** — long-running, scheduled background jobs with persistent state.
+- **Managed infrastructure** — private Lobu deployments on your Kubernetes cluster with updates and scaling.
+- **Custom tooling & skills** — bespoke MCP servers, Nix runtimes, and OpenClaw skills.
 
-*   **Employee AI Assistants** — Deploy persistent, sandboxed agents across Slack that have access to your internal tools and documentation.
-*   **Automated Customer Support** — Build agents that handle complex, multi-step support tickets autonomously while keeping a human in the loop.
-*   **Autonomous Workflows** — Use Lobu to automate background tasks that require persistent state, long-running execution, and scheduled cron jobs.
-*   **Infrastructure Maintenance** — Let me manage your private Lobu deployment on your own Kubernetes cluster, ensuring 99.9% uptime, security updates, and automated scaling.
-*   **Custom Tooling & Skills** — I build specialized MCP servers, Nix-powered runtimes, and OpenClaw skills tailored to your business needs.
-
----
-
-**Expert Implementation.** I'm a second-time technical founder. Previously, I founded [rakam.io](https://rakam.io), an enterprise analytics PaaS acquired by [LiveRamp](https://liveramp.com) (NYSE: RAMP). I help organizations move beyond chatbots by building the secure, scalable infrastructure required for production-grade autonomous agents.
+I'm a second-time technical founder. Previously founded [rakam.io](https://rakam.io) (enterprise analytics PaaS), acquired by [LiveRamp](https://liveramp.com) (NYSE: RAMP).
 
 > [!TIP]
-> **Interested in launching persistent agents for your team or customers?** I'm happy to help you architect a reliable deployment for your specific use case. [🗓️ **Talk to Founder**](https://calendar.app.google/LwAk3ecptkJQaYr87) or [reach out on **X/Twitter**](https://x.com/bu7emba).
+> Want persistent agents for your team or customers? [Talk to Founder](https://calendar.app.google/LwAk3ecptkJQaYr87) or reach out on [X/Twitter](https://x.com/bu7emba).

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,6 +1,6 @@
 # Releasing
 
-Eight packages ship to npm as a synchronized release: `@lobu/core`, `@lobu/cli-core`, `@lobu/gateway`, `@lobu/worker`, `@lobu/cli`, `@lobu/owletto-sdk`, `@lobu/owletto-openclaw`, `@lobu/owletto-cli`. `charts/lobu/Chart.yaml` bumps in lockstep. [release-please](https://github.com/googleapis/release-please) reads conventional commits on `main` and drives versioning; publishing uses npm OIDC trusted publishing (no `NPM_TOKEN`, no OTP).
+Eight packages ship to npm as a synchronized release: `@lobu/core`, `@lobu/cli-core`, `@lobu/gateway`, `@lobu/worker`, `@lobu/cli`, `@lobu/owletto-sdk`, `@lobu/owletto-openclaw`, `owletto` (unscoped; source at `packages/owletto-cli`). `charts/lobu/Chart.yaml` bumps in lockstep. [release-please](https://github.com/googleapis/release-please) reads conventional commits on `main` and drives versioning; publishing uses npm OIDC trusted publishing (no `NPM_TOKEN`, no OTP).
 
 ## Flow
 
@@ -73,8 +73,8 @@ After a local publish, land a `chore(release)` commit on `main` so `.release-ple
 ## Verify
 
 ```bash
-for pkg in core cli-core gateway worker cli owletto-sdk owletto-openclaw owletto-cli; do
-  npm view "@lobu/$pkg" version
+for pkg in @lobu/core @lobu/cli-core @lobu/gateway @lobu/worker @lobu/cli @lobu/owletto-sdk @lobu/owletto-openclaw owletto; do
+  npm view "$pkg" version
 done
 ```
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,6 +1,6 @@
 # Releasing
 
-Four packages ship to npm as a synchronized release: `@lobu/core`, `@lobu/gateway`, `@lobu/worker`, `@lobu/cli`. `charts/lobu/Chart.yaml` bumps in lockstep. [release-please](https://github.com/googleapis/release-please) reads conventional commits from `main` and drives versioning; publishing uses npm OIDC trusted publishing (no `NPM_TOKEN`, no OTP).
+Eight packages ship to npm as a synchronized release: `@lobu/core`, `@lobu/cli-core`, `@lobu/gateway`, `@lobu/worker`, `@lobu/cli`, `@lobu/owletto-sdk`, `@lobu/owletto-openclaw`, `@lobu/owletto-cli`. `charts/lobu/Chart.yaml` bumps in lockstep. [release-please](https://github.com/googleapis/release-please) reads conventional commits on `main` and drives versioning; publishing uses npm OIDC trusted publishing (no `NPM_TOKEN`, no OTP).
 
 ## Flow
 
@@ -73,10 +73,9 @@ After a local publish, land a `chore(release)` commit on `main` so `.release-ple
 ## Verify
 
 ```bash
-npm view @lobu/core version
-npm view @lobu/gateway version
-npm view @lobu/worker version
-npm view @lobu/cli version
+for pkg in core cli-core gateway worker cli owletto-sdk owletto-openclaw owletto-cli; do
+  npm view "@lobu/$pkg" version
+done
 ```
 
-All four should match the release PR.
+All versions should match the release PR.

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -1,17 +1,17 @@
 # Security
 
-Lobu's security model: what's isolated, what's trusted, how deployment mode changes the controls.
+Lobu's security model: what's isolated, what's trusted, and how deployment mode changes the controls.
 
 ## Threat Model
 
-Assume:
+Assumptions:
 - The agent executes untrusted LLM-generated code and fetches untrusted dependencies.
 - Skills and MCP servers can be third-party.
-- Users in different channels/DMs must not read or write each other's workspaces or secrets.
+- Users in different channels/DMs must never read or write each other's workspaces or secrets.
 
-Goal:
+Goals:
 - Contain compromise to a single worker/session.
-- Centralize secrets and outbound access decisions in the gateway.
+- Centralize secrets and outbound-access decisions in the gateway.
 
 ## Kubernetes
 


### PR DESCRIPTION
## Summary
- Trim and consolidate root-level + `docs/` markdown. Net -57 LOC.
- `AGENTS.md` (-50 lines): merge the Instructions / Development / Environment sections into three leaner ones (`Agent Rules`, `Development`, `Environment & Runtime`), replace verbose bullet lists with a validation table and single command block, drop the stale `docs/CONTRIBUTING` reference, trim release-section overlap with `docs/RELEASING.md`, reflow the Network bullets.
- `README.md` (-21 lines): tighten prose throughout, collapse the repeated "how it works" paragraphs into a single **Design** bullet list, compress the Capabilities and How-Lobu-Differs tables, shorten the consultancy copy.
- `docs/RELEASING.md`: fix stale "Four packages" (actual count is 8 — `core`, `cli-core`, `gateway`, `worker`, `cli`, `owletto-sdk`, `owletto-openclaw`, `owletto-cli`) and replace the hardcoded verify block with a loop.
- `docs/SECURITY.md`: minor wording/parallelism tweaks.

## Test plan
- [x] Visual read of all four files.
- [x] All `docs/SECURITY.md#...` anchors referenced from `README.md` still resolve.
- [x] All paths referenced in `AGENTS.md` exist (`packages/gateway/src/connections/`, `packages/worker/src/openclaw/`, `config/providers.json`, `scripts/test-bot.sh`, `charts/lobu`, etc.).
- [x] `git diff --stat` shows net-negative LOC (150 insertions, 207 deletions).

Out of scope per task brief: `CHANGELOG.md`, `packages/**`, `.github/**`, submodule contents.