### PR TITLE
refactor: second dead-code sweep post-refactor

### DIFF
--- a/packages/cli/src/commands/connections/platforms.ts
+++ b/packages/cli/src/commands/connections/platforms.ts
@@ -10,15 +10,6 @@ export interface PlatformPromptResult {
   connectionSecrets: Array<{ envVar: string; value: string }>;
 }
 
-export const PLATFORM_CHOICES: Array<{ name: string; value: string }> = [
-  { name: "Telegram", value: "telegram" },
-  { name: "Slack", value: "slack" },
-  { name: "Discord", value: "discord" },
-  { name: "WhatsApp", value: "whatsapp" },
-  { name: "Microsoft Teams", value: "teams" },
-  { name: "Google Chat", value: "gchat" },
-];
-
 export const PLATFORM_LABELS: Record<string, string> = {
   telegram: "Telegram",
   slack: "Slack",

--- a/packages/gateway/src/auth/mcp/oauth-discovery.ts
+++ b/packages/gateway/src/auth/mcp/oauth-discovery.ts
@@ -497,33 +497,3 @@ export async function discoverOAuth(
 
   return result;
 }
-
-/**
- * Invalidate cached discovery for a single `(mcpId, agentId, upstreamUrl)`.
- * Called on logout or when a refresh indicates the server has rotated endpoints.
- */
-export async function invalidateDiscovery(
-  redis: Redis,
-  secretStore: WritableSecretStore,
-  mcpId: string,
-  agentId: string,
-  upstreamUrl: string
-): Promise<void> {
-  const keys = [
-    discoveryCacheKey(mcpId, agentId, upstreamUrl),
-    clientCacheKey(mcpId, agentId, upstreamUrl),
-  ];
-  for (const key of keys) {
-    const raw = await redis.get(key).catch(() => null);
-    if (!raw) continue;
-    try {
-      const pointer = JSON.parse(raw) as SecretPointer;
-      if (typeof pointer.secretRef === "string") {
-        await secretStore.delete(pointer.secretRef).catch(() => undefined);
-      }
-    } catch {
-      /* ignore corrupt pointer */
-    }
-    await redis.del(key).catch(() => undefined);
-  }
-}

--- a/packages/gateway/src/routes/public/settings-auth.ts
+++ b/packages/gateway/src/routes/public/settings-auth.ts
@@ -1,6 +1,6 @@
 import { decrypt, encrypt } from "@lobu/core";
 import type { Context } from "hono";
-import { deleteCookie, getCookie, setCookie } from "hono/cookie";
+import { getCookie, setCookie } from "hono/cookie";
 import type { SettingsTokenPayload } from "../../auth/settings/token-service";
 
 export type AuthProvider = (c: Context) => SettingsTokenPayload | null;
@@ -97,8 +97,4 @@ export function setSettingsSessionCookie(
     secure: isSecureRequest(c),
     maxAge: maxAgeSeconds,
   });
-}
-
-export function clearSettingsSessionCookie(c: Context): void {
-  deleteCookie(c, SETTINGS_SESSION_COOKIE_NAME, { path: "/" });
 }


### PR DESCRIPTION
## Summary

Second pass after the refactor wave. Small, surgical deletions of exports that `bunx knip` flagged as unreferenced and that I verified have zero callers anywhere in the monorepo (including dynamic `require` / `await import` sites).

- `packages/gateway/src/auth/mcp/oauth-discovery.ts`: remove `invalidateDiscovery()` (no callers)
- `packages/gateway/src/routes/public/settings-auth.ts`: remove `clearSettingsSessionCookie()` and its now-orphan `deleteCookie` import
- `packages/cli/src/commands/connections/platforms.ts`: remove `PLATFORM_CHOICES` (live usage goes through `PLATFORM_LABELS`)

Knip also flagged many gateway route files (`channels.ts`, `mcp-oauth.ts`, `oauth.ts`, `landing.ts`, `history.ts`, `system-env-store.ts`) but those are pulled in via dynamic `require()` in `gateway/src/cli/gateway.ts`, so they are live. Left alone.

`ErrorCode` enum members (`USER_CREDENTIALS_CREATE_FAILED`, `INVALID_CONFIGURATION`, `THREAD_DEPLOYMENT_NOT_FOUND`, `USER_QUEUE_NOT_FOUND`) are genuinely unused internally but the enum ships from `@lobu/core`, so external consumers may switch on them. Left alone.

Diff stat:

```
 packages/cli/src/commands/connections/platforms.ts |  9 -------
 packages/gateway/src/auth/mcp/oauth-discovery.ts   | 30 ----------------------
 .../gateway/src/routes/public/settings-auth.ts     |  6 +----
 3 files changed, 1 insertion(+), 44 deletions(-)
```

Pure deletion, net -43 LOC.

## Test plan

- [x] `bun run typecheck` passes
- [x] `make build-packages` passes (core / gateway / worker)
- [x] `bun run format:check` passes
- [x] `grep` across repo confirms deleted symbols have no remaining references