### PR TITLE
fix(landing): resolve zod parse error on connect-from route

### DIFF
--- a/packages/landing/astro.config.mjs
+++ b/packages/landing/astro.config.mjs
@@ -10,7 +10,11 @@ import { defineConfig } from "astro/config";
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const require = createRequire(import.meta.url);
 // Force Zod v3 for Astro action runtime compatibility.
-const zodPath = dirname(require.resolve("zod/package.json"));
+// Resolve zod from Astro's own dependency tree so we always pick up the
+// v3 copy that Astro/Starlight were built against, even when a newer zod
+// (e.g. v4) is hoisted higher in the workspace.
+const astroRequire = createRequire(require.resolve("astro/package.json"));
+const zodPath = dirname(astroRequire.resolve("zod/package.json"));
 
 const settingsDir = resolve(
   __dirname,


### PR DESCRIPTION
## Summary

- The Vite `zod` alias in `packages/landing/astro.config.mjs` was resolving `require.resolve("zod/package.json")` from the landing package directory. When `packages/landing/node_modules/zod` is not present, Node's resolution walks up to the workspace-root `node_modules/zod`, which currently holds zod v4. The alias then redirected every `zod` import (including Astro's re-export via `astro/zod`) to v4. Starlight's `HeadConfigSchema` — built with `z` from `astro/zod` — became a v4 schema, and the first `StarlightPage` rendered during the build (`/connect-from/chatgpt/for/legal/`) crashed inside `createHead` with `Cannot read properties of undefined (reading '_zod')`.
- Fix: resolve `zod/package.json` against Astro's own dependency tree (`node_modules/astro/node_modules/zod`), which is always the v3 copy Astro/Starlight were compiled against, regardless of what else the workspace hoists.

## Test plan

- [x] `cd packages/landing && bun run build` — passes (103 pages built, including all `/connect-from/<client>/for/<useCase>/` variants).
- [x] Reproduced the original failure by removing `packages/landing/node_modules/zod` pre-fix, then confirmed the same scenario builds cleanly with the fix.
- [x] `bun run typecheck` at repo root — passes.