### PR TITLE
refactor: strip obvious comments and JSDoc

### DIFF
--- a/packages/core/src/otel.ts
+++ b/packages/core/src/otel.ts
@@ -1,8 +1,3 @@
-/**
- * OpenTelemetry tracing setup for distributed tracing.
- * Ships traces via OTLP gRPC to any compatible collector (Tempo, Jaeger, Datadog, etc.).
- */
-
 import type { Span, Tracer } from "@opentelemetry/api";
 import { context, SpanKind, SpanStatusCode, trace } from "@opentelemetry/api";
 import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-grpc";
@@ -25,23 +20,13 @@ let tracer: Tracer | null = null;
 export interface OtelConfig {
   serviceName: string;
   serviceVersion?: string;
-  otlpEndpoint?: string; // e.g., "http://collector:4317"
+  otlpEndpoint?: string;
   enabled?: boolean;
 }
 
-/**
- * Initialize OpenTelemetry tracing.
- * Call this once at application startup.
- *
- * @example
- * initTracing({
- *   serviceName: "lobu-gateway",
- *   otlpEndpoint: "http://collector:4317",
- * });
- */
 export function initTracing(config: OtelConfig): void {
   if (provider) {
-    return; // Already initialized
+    return;
   }
 
   const enabled = config.enabled ?? !!config.otlpEndpoint;
@@ -61,10 +46,10 @@ export function initTracing(config: OtelConfig): void {
 
   const exporter = new OTLPTraceExporter({
     url: config.otlpEndpoint,
-    timeoutMillis: 30000, // 30 second timeout for reliability
+    timeoutMillis: 30000,
   });
 
-  // Use SimpleSpanProcessor for immediate export (better for short-lived workers)
+  // SimpleSpanProcessor exports immediately — workers are short-lived
   provider.addSpanProcessor(new SimpleSpanProcessor(exporter));
   provider.register();
 
@@ -75,16 +60,10 @@ export function initTracing(config: OtelConfig): void {
   );
 }
 
-/**
- * Get the configured tracer. Returns null if not initialized.
- */
 export function getTracer(): Tracer | null {
   return tracer;
 }
 
-/**
- * Shutdown tracing gracefully.
- */
 export async function shutdownTracing(): Promise<void> {
   if (provider) {
     await provider.shutdown();
@@ -93,24 +72,12 @@ export async function shutdownTracing(): Promise<void> {
   }
 }
 
-/**
- * Force flush all pending spans to the exporter.
- * Call this after processing a message to ensure spans are exported promptly.
- */
 export async function flushTracing(): Promise<void> {
   if (provider) {
     await provider.forceFlush();
   }
 }
 
-/**
- * Create a new span for tracing.
- * If tracing is not initialized, returns a no-op span.
- *
- * @param name Span name (e.g., "queue_processing", "agent_execution")
- * @param attributes Optional attributes to add to the span
- * @param parentContext Optional parent context for trace correlation
- */
 export function createSpan(
   name: string,
   attributes?: Record<string, string | number | boolean>,
@@ -128,16 +95,6 @@ export function createSpan(
   return span;
 }
 
-/**
- * Execute a function within a span context.
- * Automatically handles span lifecycle (start, end, error recording).
- *
- * @example
- * const result = await withSpan("process_message", async (span) => {
- *   span?.setAttribute("messageId", messageId);
- *   return await processMessage();
- * });
- */
 export async function withSpan<T>(
   name: string,
   fn: (span: Span | null) => Promise<T>,
@@ -163,31 +120,15 @@ export async function withSpan<T>(
   }
 }
 
-/**
- * Get current active span from context.
- */
 export function getCurrentSpan(): Span | undefined {
   return trace.getActiveSpan();
 }
 
-/**
- * Run a function within a span context, propagating the span.
- */
 export function runInSpanContext<T>(span: Span, fn: () => T): T {
   const ctx = trace.setSpan(context.active(), span);
   return context.with(ctx, fn);
 }
 
-/**
- * Create a root span and return traceparent header for propagation.
- * Use this at the entry point (message ingestion) to start a trace.
- *
- * @example
- * const { span, traceparent } = createRootSpan("message_received", { messageId });
- * // Store traceparent in message metadata for downstream propagation
- * await queueProducer.enqueueMessage({ ...data, platformMetadata: { traceparent } });
- * span.end();
- */
 export function createRootSpan(
   name: string,
   attributes?: Record<string, string | number | boolean>
@@ -201,23 +142,12 @@ export function createRootSpan(
     attributes,
   });
 
-  // Extract W3C traceparent header from span context
   const spanContext = span.spanContext();
   const traceparent = `00-${spanContext.traceId}-${spanContext.spanId}-01`;
 
   return { span, traceparent };
 }
 
-/**
- * Create a child span from a traceparent header.
- * Use this to continue a trace in downstream services (queue consumer, worker).
- *
- * @example
- * const traceparent = data.platformMetadata?.traceparent;
- * const span = createChildSpan("queue_processing", traceparent, { jobId });
- * // ... do work ...
- * span?.end();
- */
 export function createChildSpan(
   name: string,
   traceparent: string | null | undefined,
@@ -228,11 +158,10 @@ export function createChildSpan(
   }
 
   if (!traceparent) {
-    // No parent context - create independent span
     return createSpan(name, attributes);
   }
 
-  // Parse W3C traceparent: 00-traceId-parentSpanId-flags
+  // W3C traceparent: 00-traceId-parentSpanId-flags
   const parts = traceparent.split("-");
   if (parts.length !== 4) {
     return createSpan(name, attributes);
@@ -241,15 +170,13 @@ export function createChildSpan(
   const traceId = parts[1]!;
   const parentSpanId = parts[2]!;
 
-  // Create span context from traceparent
   const parentContext = trace.setSpanContext(context.active(), {
     traceId,
     spanId: parentSpanId,
-    traceFlags: 1, // sampled
+    traceFlags: 1,
     isRemote: true,
   });
 
-  // Start span as child of the propagated context
   return tracer.startSpan(
     name,
     { kind: SpanKind.INTERNAL, attributes },
@@ -257,16 +184,6 @@ export function createChildSpan(
   );
 }
 
-/**
- * Run a function within a child span context.
- * Automatically handles span lifecycle and error recording.
- *
- * @example
- * const result = await withChildSpan("process_job", traceparent, async (span) => {
- *   span?.setAttribute("jobId", jobId);
- *   return await processJob();
- * });
- */
 export async function withChildSpan<T>(
   name: string,
   traceparent: string | null | undefined,
@@ -293,9 +210,6 @@ export async function withChildSpan<T>(
   }
 }
 
-/**
- * Extract traceparent from span for propagation to downstream services.
- */
 export function getTraceparent(span: Span | null): string | null {
   if (!span) return null;
   const ctx = span.spanContext();
@@ -303,5 +217,4 @@ export function getTraceparent(span: Span | null): string | null {
 }
 
 export type { Span, Tracer };
-// Re-export OpenTelemetry types for convenience
 export { SpanKind, SpanStatusCode };

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1,9 +1,5 @@
 import type { SecretRef } from "./secret-refs";
 
-// ============================================================================
-// Model Selection
-// ============================================================================
-
 export type ModelSelectionMode = "auto" | "pinned";
 
 /**
@@ -18,10 +14,6 @@ export interface ModelSelectionState {
 
 /** Per-provider preferred model for auto mode, keyed by provider id. */
 export type ProviderModelPreferences = Record<string, string>;
-
-// ============================================================================
-// Provider Catalog Types
-// ============================================================================
 
 /**
  * Represents a provider installed for a specific agent.
@@ -48,10 +40,6 @@ export interface CliBackendConfig {
   modelArg?: string; // "--model"
   sessionArg?: string; // "--session"
 }
-
-// ============================================================================
-// Auth Profile Types
-// ============================================================================
 
 /**
  * Unified authentication profile for any model provider.
@@ -131,10 +119,6 @@ export interface ConversationMessage {
   timestamp: number;
 }
 
-// ============================================================================
-// Schedule Types
-// ============================================================================
-
 /**
  * Concurrency policy applied when a schedule fires while the previous
  * run for the same id is still executing.
@@ -192,14 +176,6 @@ export interface DeclaredSchedule {
   /** Default "queue". */
   concurrency?: ScheduleConcurrency;
 }
-
-// ============================================================================
-// Conversation History Types
-// ============================================================================
-
-// ============================================================================
-// Skills Configuration Types
-// ============================================================================
 
 /**
  * Per-skill thinking budget level.
@@ -338,10 +314,6 @@ export interface NixConfig {
   packages?: string[];
 }
 
-// ============================================================================
-// Tools Configuration Types
-// ============================================================================
-
 /**
  * Tool permission configuration for agent settings.
  * Follows Claude Code's permission patterns for consistency.
@@ -457,10 +429,6 @@ export interface AgentOptions {
  */
 export type LogLevel = "debug" | "info" | "warn" | "error";
 
-// ============================================================================
-// Instruction Provider Types
-// ============================================================================
-
 /**
  * Context information passed to instruction providers
  */
@@ -490,10 +458,6 @@ export interface InstructionProvider {
    */
   getInstructions(context: InstructionContext): Promise<string> | string;
 }
-
-// ============================================================================
-// Thread Response Types
-// ============================================================================
 
 /**
  * Shared payload contract for worker → platform thread responses.
@@ -532,10 +496,6 @@ export interface ThreadResponsePayload {
   execStream?: "stdout" | "stderr"; // Which stream this delta is from
   execExitCode?: number; // Process exit code (sent on completion)
 }
-
-// ============================================================================
-// User Interaction Types
-// ============================================================================
 
 /**
  * Suggested prompt for user

--- a/packages/gateway/src/cli/gateway.ts
+++ b/packages/gateway/src/cli/gateway.ts
@@ -48,7 +48,6 @@ export function createGatewayApp(
     authProvider,
   } = options;
 
-  // Wire injectable auth provider (for embedded mode)
   if (authProvider) {
     const { setAuthProvider } = require("../routes/public/settings-auth");
     setAuthProvider(authProvider);
@@ -56,7 +55,6 @@ export function createGatewayApp(
 
   const app = new OpenAPIHono();
 
-  // Global middleware
   app.use(
     "*",
     secureHeaders({
@@ -85,7 +83,6 @@ export function createGatewayApp(
     })
   );
 
-  // Health endpoints
   app.get("/health", (c) => {
     const mode =
       process.env.LOBU_MODE ||
@@ -110,13 +107,11 @@ export function createGatewayApp(
 
   app.get("/ready", (c) => c.json({ ready: true }));
 
-  // Compute adminPassword once — used by Agent API, CLI auth, metrics, and messaging
   const crypto = require("node:crypto");
   const adminPassword: string =
     process.env.ADMIN_PASSWORD || crypto.randomBytes(16).toString("base64url");
 
-  // Prometheus metrics endpoint.
-  // Keep auth optional so existing ServiceMonitor configs continue to scrape.
+  // Metrics auth is optional so existing ServiceMonitor configs continue to scrape.
   app.get("/metrics", async (c) => {
     const metricsAuthToken = process.env.METRICS_AUTH_TOKEN;
     if (metricsAuthToken) {
@@ -130,7 +125,6 @@ export function createGatewayApp(
     return c.text(getMetricsText());
   });
 
-  // Secret injection proxy (Hono)
   if (secretProxy) {
     app.route("/api/proxy", secretProxy.getApp());
     logger.debug("Secret proxy enabled at :8080/api/proxy");
@@ -144,26 +138,22 @@ export function createGatewayApp(
     }
   }
 
-  // Worker Gateway routes (Hono)
   if (workerGateway) {
     app.route("/worker", workerGateway.getApp());
     logger.debug("Worker gateway routes enabled at :8080/worker/*");
   }
 
-  // Register module endpoints
   const { moduleRegistry: coreModuleRegistry } = require("@lobu/core");
   if (coreModuleRegistry.registerHonoEndpoints) {
     coreModuleRegistry.registerHonoEndpoints(app);
   } else {
-    // Create express-like adapter for module registry
     const expressApp = createExpressAdapter(app);
     coreModuleRegistry.registerEndpoints(expressApp);
   }
   logger.debug("Module endpoints registered");
 
-  // MCP OAuth auth-code callback (public — browser-facing).
-  // MUST register BEFORE the MCP proxy mount at /mcp, otherwise the proxy's
-  // catch-all `/:mcpId/*` route swallows /mcp/oauth/callback.
+  // MCP OAuth callback MUST register before the MCP proxy mount at /mcp,
+  // otherwise the proxy's `/:mcpId/*` route swallows /mcp/oauth/callback.
   if (coreServices) {
     const { createMcpOAuthRoutes } = require("../routes/public/mcp-oauth");
     const mcpOAuthRouter = createMcpOAuthRoutes({
@@ -179,22 +169,17 @@ export function createGatewayApp(
     );
   }
 
-  // MCP proxy routes (Hono)
   if (mcpProxy) {
-    // Handle root path requests with X-Mcp-Id header
     app.all("/", async (c, next) => {
       if (mcpProxy.isMcpRequest(c)) {
-        // Forward to MCP proxy - need to handle directly since it's at root
         return mcpProxy.getApp().fetch(c.req.raw);
       }
       return next();
     });
-    // Mount MCP proxy at /mcp/*
     app.route("/mcp", mcpProxy.getApp());
     logger.debug("MCP proxy routes enabled at :8080/mcp/*");
   }
 
-  // File routes (already Hono) - uses platform registry for per-platform file handling
   if (platformRegistry && coreServices) {
     const artifactStore = coreServices.getArtifactStore();
     const { createFileRoutes } = require("../routes/internal/files");
@@ -212,7 +197,6 @@ export function createGatewayApp(
     );
   }
 
-  // History routes (already Hono)
   {
     const { createHistoryRoutes } = require("../routes/internal/history");
     const historyRouter = createHistoryRoutes();
@@ -220,7 +204,6 @@ export function createGatewayApp(
     logger.debug("History routes enabled at :8080/internal/history");
   }
 
-  // Device auth routes (gateway-mediated OAuth for workers)
   if (coreServices) {
     const {
       createDeviceAuthRoutes,
@@ -240,7 +223,6 @@ export function createGatewayApp(
     }
   }
 
-  // Audio routes (TTS synthesis for workers)
   if (coreServices) {
     const transcriptionService = coreServices.getTranscriptionService();
     if (transcriptionService) {
@@ -251,7 +233,6 @@ export function createGatewayApp(
     }
   }
 
-  // Image routes (image generation for workers)
   if (coreServices) {
     const imageGenerationService = coreServices.getImageGenerationService();
     if (imageGenerationService) {
@@ -262,7 +243,6 @@ export function createGatewayApp(
     }
   }
 
-  // Interaction routes (already Hono)
   if (interactionService) {
     const {
       createInteractionRoutes,
@@ -272,7 +252,6 @@ export function createGatewayApp(
     logger.debug("Internal interaction routes enabled");
   }
 
-  // Create CLI token service early so it can be shared by messaging + agent API
   let cliTokenService: any;
   if (coreServices) {
     const { CliTokenService } = require("../auth/cli/token-service");
@@ -280,7 +259,6 @@ export function createGatewayApp(
     cliTokenService = new CliTokenService(redisClient);
   }
 
-  // Agent API routes (direct API access + platform-routed messaging)
   if (coreServices) {
     const queueProducer = coreServices.getQueueProducer();
     const sessionMgr = coreServices.getSessionManager();

--- a/packages/gateway/src/cli/gateway.ts
+++ b/packages/gateway/src/cli/gateway.ts
@@ -332,7 +332,6 @@ export function createGatewayApp(
   }
 
   if (coreServices) {
-    // Mount OAuth modules under unified auth router
     const authRouter = new OpenAPIHono();
     const registeredProviders: string[] = [];
 
@@ -578,12 +577,10 @@ export function createGatewayApp(
       });
     }
 
-    // Get shared dependencies (needed before mounting auth router)
     const agentSettingsStore = coreServices.getAgentSettingsStore();
     const claudeOAuthStateStore = coreServices.getOAuthStateStore();
     const scheduleService = coreServices.getScheduleService();
 
-    // Build provider stores and overrides dynamically from registered modules
     const providerStores: Record<
       string,
       { hasCredentials(agentId: string): Promise<boolean> }
@@ -616,7 +613,6 @@ export function createGatewayApp(
       );
     }
 
-    // Landing page (docs + integrations)
     {
       const { createLandingRoutes } = require("../routes/public/landing");
       const landingRouter = createLandingRoutes();
@@ -624,7 +620,6 @@ export function createGatewayApp(
       logger.debug("Landing page enabled at :8080/");
     }
 
-    // Agent history routes (proxy to worker HTTP server)
     {
       const connectionManager = coreServices
         .getWorkerGateway()
@@ -646,7 +641,6 @@ export function createGatewayApp(
       }
     }
 
-    // Agent config routes (/api/v1/agents/{id}/config)
     if (agentSettingsStore) {
       const {
         createAgentConfigRoutes,
@@ -674,7 +668,6 @@ export function createGatewayApp(
       );
     }
 
-    // OAuth routes (mounted under unified auth router)
     if (agentSettingsStore) {
       const { createOAuthRoutes } = require("../routes/public/oauth");
       const { OAuthClient } = require("../auth/oauth/client");
@@ -690,7 +683,6 @@ export function createGatewayApp(
       registeredProviders.push("oauth");
     }
 
-    // Mount unified auth router (includes provider modules + OAuth)
     if (registeredProviders.length > 0) {
       app.route("/api/v1/auth", authRouter);
       logger.debug(

--- a/packages/gateway/src/cli/gateway.ts
+++ b/packages/gateway/src/cli/gateway.ts
@@ -690,7 +690,6 @@ export function createGatewayApp(
       );
     }
 
-    // Channel binding routes (mount under agent API)
     const channelBindingService = coreServices.getChannelBindingService();
     if (channelBindingService) {
       const {
@@ -701,14 +700,12 @@ export function createGatewayApp(
         userAgentsStore: coreServices.getUserAgentsStore(),
         agentMetadataStore: coreServices.getAgentMetadataStore(),
       });
-      // Mount as a sub-router under /api/v1/agents/:agentId/channels
       app.route("/api/v1/agents/:agentId/channels", channelBindingRouter);
       logger.debug(
         "Channel binding routes enabled at :8080/api/v1/agents/{agentId}/channels/*"
       );
     }
 
-    // Agent management routes (separate from Agent API's /api/v1/agents)
     {
       const userAgentsStore = coreServices.getUserAgentsStore();
       const agentMetadataStore = coreServices.getAgentMetadataStore();
@@ -724,7 +721,6 @@ export function createGatewayApp(
     }
   }
 
-  // Chat SDK connection routes (webhook + CRUD)
   if (chatInstanceManager) {
     const {
       createSlackRoutes,
@@ -748,9 +744,6 @@ export function createGatewayApp(
     );
   }
 
-  // ─── Reload endpoint (file-first dev mode) ──────────────────────────────────
-  // Re-reads lobu.toml + markdown and re-populates InMemoryAgentStore.
-  // Only works in dev mode (files exist), authenticated with ADMIN_PASSWORD.
   app.post("/api/v1/reload", async (c) => {
     if (process.env.NODE_ENV === "production") {
       return c.json({ error: "Not found" }, 404);
@@ -778,9 +771,6 @@ export function createGatewayApp(
     }
   });
 
-  // ─── Internal CLI status endpoint ──────────────────────────────────────────
-  // Returns agents, connections, and sandboxes for `lobu status`.
-  // Only available in non-production, authenticated with ADMIN_PASSWORD.
   app.get("/internal/status", async (c) => {
     if (process.env.NODE_ENV === "production") {
       return c.json({ error: "Not found" }, 404);
@@ -853,10 +843,8 @@ export function createGatewayApp(
     });
   });
 
-  // Auto-register any non-openapi routes so everything shows up in the schema
   registerAutoOpenApiRoutes(app);
 
-  // OpenAPI Documentation
   app.doc("/api/docs/openapi.json", {
     openapi: "3.0.0",
     info: {
@@ -1001,7 +989,6 @@ function createExpressCompatObjects(c: any, overridePath?: string) {
     headers[key] = value;
   });
 
-  // Express-compatible request object
   const req: any = {
     method: c.req.method,
     url: c.req.url,
@@ -1012,18 +999,16 @@ function createExpressCompatObjects(c: any, overridePath?: string) {
     body: null,
     get: (name: string) => headers[name.toLowerCase()],
     on: () => {
-      // Express event listener stub - not used in Hono compat layer
+      /* no-op */
     },
   };
 
-  // Response state
   let statusCode = 200;
   const responseHeaders = new Headers();
   let isStreaming = false;
   let streamController: ReadableStreamDefaultController<Uint8Array> | null =
     null;
 
-  // Express-compatible response object
   const res: any = {
     statusCode: 200,
     destroyed: false,
@@ -1122,11 +1107,10 @@ function createExpressCompatObjects(c: any, overridePath?: string) {
     },
 
     flushHeaders() {
-      // No-op for compatibility
+      /* no-op */
     },
   };
 
-  // Parse body for POST/PUT/PATCH
   if (["POST", "PUT", "PATCH"].includes(c.req.method)) {
     const contentType = c.req.header("content-type") || "";
     c.req.raw
@@ -1171,7 +1155,7 @@ function createExpressAdapter(honoApp: any) {
     },
     use: (pathOrHandler: any, handler?: any) => {
       if (typeof pathOrHandler === "function") {
-        // Global middleware - skip for now
+        // no-op
       } else if (handler) {
         honoApp.all(`${pathOrHandler}/*`, (c: any) =>
           handleExpressHandler(c, handler)
@@ -1187,30 +1171,24 @@ function createExpressAdapter(honoApp: any) {
 export async function startGateway(config: GatewayConfig): Promise<void> {
   logger.info("Starting Lobu Gateway");
 
-  // Start filtering proxy for worker network isolation (if enabled)
   const { startFilteringProxy } = await import("../proxy/proxy-manager");
   await startFilteringProxy();
 
-  // Import dependencies
   const { Orchestrator } = await import("../orchestration");
   const { Gateway } = await import("../gateway-main");
 
-  // Create and start orchestrator
   logger.debug("Creating orchestrator", { mode: process.env.DEPLOYMENT_MODE });
   const orchestrator = new Orchestrator(config.orchestration);
   await orchestrator.start();
   logger.debug("Orchestrator started");
 
-  // Create Gateway
   const gateway = new Gateway(config);
 
-  // Register API platform (always enabled)
   const { ApiPlatform } = await import("../api");
   const apiPlatform = new ApiPlatform();
   gateway.registerPlatform(apiPlatform);
   logger.debug("API platform registered");
 
-  // Start gateway
   await gateway.start();
   logger.debug("Gateway started");
 
@@ -1225,7 +1203,6 @@ export async function startGateway(config: GatewayConfig): Promise<void> {
     logger.debug("Grant store connected to HTTP proxy");
   }
 
-  // Inject core services into orchestrator (provider modules carry their own credential stores)
   await orchestrator.injectCoreServices(
     coreServices.getQueue().getRedisClient(),
     coreServices.getSecretStore(),
@@ -1248,7 +1225,6 @@ export async function startGateway(config: GatewayConfig): Promise<void> {
     );
   });
 
-  // Initialize Chat SDK connection manager (API-driven platform connections)
   const { ChatInstanceManager, ChatResponseBridge } = await import(
     "../connections"
   );
@@ -1256,13 +1232,11 @@ export async function startGateway(config: GatewayConfig): Promise<void> {
   try {
     await chatInstanceManager.initialize(coreServices);
 
-    // Register chat platform adapters (delegates to ChatInstanceManager)
     for (const adapter of chatInstanceManager.createPlatformAdapters()) {
       gateway.registerPlatform(adapter);
     }
     logger.debug("ChatInstanceManager initialized");
 
-    // Seed connections from file-loaded agents (file-first architecture)
     const fileLoadedAgents = coreServices.getFileLoadedAgents();
     if (fileLoadedAgents.length > 0) {
       for (const agent of fileLoadedAgents) {
@@ -1298,7 +1272,6 @@ export async function startGateway(config: GatewayConfig): Promise<void> {
       }
     }
 
-    // Wire ChatResponseBridge into unified thread consumer
     const unifiedConsumer = gateway.getUnifiedConsumer();
     if (unifiedConsumer) {
       const chatResponseBridge = new ChatResponseBridge(chatInstanceManager);
@@ -1312,7 +1285,6 @@ export async function startGateway(config: GatewayConfig): Promise<void> {
     );
   }
 
-  // Setup server on port 8080 (single port for all HTTP traffic)
   if (!httpServer) {
     const app = createGatewayApp({
       secretProxy: coreServices.getSecretProxy(),
@@ -1328,7 +1300,6 @@ export async function startGateway(config: GatewayConfig): Promise<void> {
 
   logger.info("Lobu Gateway is running!");
 
-  // Setup graceful shutdown
   const cleanup = async () => {
     logger.info("Shutting down gateway...");
 

--- a/packages/gateway/src/config/index.ts
+++ b/packages/gateway/src/config/index.ts
@@ -24,26 +24,12 @@ const WORKER_PACKAGE_JSON_CANDIDATES = [
   "/app/packages/worker/package.json",
 ] as const;
 
-// ============================================================================
-// CONSTANTS
-// ============================================================================
-
-/**
- * Gateway-specific constants
- * Core constants (TIME, REDIS_KEYS, core DEFAULTS) are imported from @lobu/core
- * This file contains gateway-specific configuration values
- */
-
-// Gateway-specific default configuration values
+// Gateway-specific constants; core ones (TIME, REDIS_KEYS, DEFAULTS) come from @lobu/core.
 const GATEWAY_DEFAULTS = {
-  /** Default HTTP server port */
   HTTP_PORT: 3000,
-  /** Default public gateway URL */
   PUBLIC_GATEWAY_URL: "",
-  /** Default queue names */
   QUEUE_DIRECT_MESSAGE: "direct_message",
   QUEUE_MESSAGE_QUEUE: "message_queue",
-  /** Default worker settings */
   WORKER_IMAGE_REPOSITORY: "lobu-worker",
   WORKER_IMAGE_TAG: "latest",
   WORKER_IMAGE_DIGEST: "",
@@ -59,25 +45,18 @@ const GATEWAY_DEFAULTS = {
   WORKER_IDLE_CLEANUP_MINUTES: 60,
   MAX_WORKER_DEPLOYMENTS: 100,
   WORKER_STALE_TIMEOUT_MINUTES: 10,
-  /** Default Kubernetes namespace */
   KUBERNETES_NAMESPACE: "lobu",
-  /** Default cleanup settings */
   CLEANUP_INITIAL_DELAY_MS: TIME.FIVE_SECONDS_MS,
-  CLEANUP_INTERVAL_MS: 60000, // 1 minute
+  CLEANUP_INTERVAL_MS: 60000,
   CLEANUP_VERY_OLD_DAYS: 7,
-  /** Default socket health settings */
-  SOCKET_HEALTH_CHECK_INTERVAL_MS: 5 * TIME.MINUTE_MS, // 5 minutes
-  SOCKET_STALE_THRESHOLD_MS: 15 * TIME.MINUTE_MS, // 15 minutes
+  SOCKET_HEALTH_CHECK_INTERVAL_MS: 5 * TIME.MINUTE_MS,
+  SOCKET_STALE_THRESHOLD_MS: 15 * TIME.MINUTE_MS,
   SOCKET_PROTECT_ACTIVE_WORKERS: true,
-  /** Default deployment settings */
   LOBU_DEV_PROJECT_PATH: "/app",
   COMPOSE_PROJECT_NAME: "lobu",
   DISPATCHER_SERVICE_NAME: "lobu-dispatcher",
-  /** Default log level */
   LOG_LEVEL: "INFO" as const,
-  /** Default kubeconfig path */
   KUBECONFIG: "~/.kube/config",
-  /** Embedded mode defaults */
   EMBEDDED_MAX_CONCURRENT_SESSIONS: 100,
   EMBEDDED_MAX_MEMORY_PER_SESSION_MB: 256,
   EMBEDDED_BASH_MAX_COMMAND_COUNT: 50_000,
@@ -85,23 +64,15 @@ const GATEWAY_DEFAULTS = {
   EMBEDDED_BASH_MAX_CALL_DEPTH: 50,
 } as const;
 
-// Merged DEFAULTS with core and gateway-specific values (internal use only)
 const DEFAULTS = {
   ...CORE_DEFAULTS,
   ...GATEWAY_DEFAULTS,
 } as const;
 
-// Display formatting (internal use only)
 const DISPLAY = {
-  /** Horizontal separator length */
   SEPARATOR_LENGTH: 50,
-  /** Token preview length for logging */
   TOKEN_PREVIEW_LENGTH: 10,
 } as const;
-
-// ============================================================================
-// TYPES
-// ============================================================================
 
 /** Recursively makes all properties optional */
 export type DeepPartial<T> = {
@@ -178,13 +149,6 @@ export interface GatewayConfig {
   };
 }
 
-// ============================================================================
-// CONFIGURATION BUILDERS
-// ============================================================================
-
-/**
- * Load environment variables from .env file if in non-production
- */
 export function loadEnvFile(envPath?: string): void {
   if (process.env.NODE_ENV === "production") {
     logger.debug("Production mode - skipping .env file");
@@ -362,7 +326,6 @@ export function buildGatewayConfig(
 ): GatewayConfig {
   logger.debug("Building gateway configuration from environment variables");
 
-  // Required variables (allow override to satisfy the requirement)
   const connectionString =
     overrides?.queues?.connectionString || getRequiredEnv("QUEUE_URL");
 
@@ -386,7 +349,6 @@ export function buildGatewayConfig(
     "PUBLIC_GATEWAY_URL",
     DEFAULTS.PUBLIC_GATEWAY_URL
   );
-  // Build configuration
   const config: GatewayConfig = {
     agentDefaults: {
       allowedTools: process.env.ALLOWED_TOOLS?.split(","),

--- a/packages/gateway/src/orchestration/impl/docker-deployment.ts
+++ b/packages/gateway/src/orchestration/impl/docker-deployment.ts
@@ -17,9 +17,6 @@ import {
   resolvePlatformDeploymentMetadata,
 } from "../deployment-utils";
 
-/**
- * Resource parsing utilities for memory and CPU limits
- */
 class ResourceParser {
   static parseMemory(memoryStr: string): number {
     const units: Record<string, number> = {
@@ -63,13 +60,9 @@ export class DockerDeploymentManager extends BaseDeploymentManager {
   ) {
     super(config, moduleEnvVarsBuilder, providerModules);
 
-    // Explicitly use the Unix socket for Docker connection
     this.docker = new Docker({ socketPath: "/var/run/docker.sock" });
 
-    // Check for gvisor availability on initialization
     this.checkGvisorAvailability();
-
-    // Ensure the internal network exists for worker isolation
     this.ensureInternalNetwork();
   }
 
@@ -95,13 +88,9 @@ export class DockerDeploymentManager extends BaseDeploymentManager {
     }
   }
 
-  /**
-   * Ensure the internal Docker network exists with `internal: true` for worker isolation.
-   * Skipped when WORKER_NETWORK is explicitly set (e.g. local dev using bridge).
-   * Creates the network if it doesn't exist (e.g. production without docker-compose).
-   */
+  // Creates the internal Docker network with `internal: true` when missing.
+  // Skipped when WORKER_NETWORK is explicitly set (e.g. local dev using bridge).
   private async ensureInternalNetwork(): Promise<void> {
-    // If explicitly overridden (e.g. WORKER_NETWORK=bridge for local dev), skip
     if (process.env.WORKER_NETWORK) {
       return;
     }
@@ -140,30 +129,17 @@ export class DockerDeploymentManager extends BaseDeploymentManager {
     }
   }
 
-  /**
-   * Check if gateway is running inside a Docker container
-   */
   private isRunningInContainer(): boolean {
     return fs.existsSync("/.dockerenv") || process.env.CONTAINER === "true";
   }
 
-  /**
-   * Get the host address that workers should use to reach the gateway
-   * When gateway runs on host, workers use host.docker.internal
-   * When gateway runs in container (docker-compose mode), workers use service name
-   */
   private getHostAddress(): string {
     if (this.isRunningInContainer()) {
       return "gateway";
     }
-    // For host-mode development, workers reach gateway via host.docker.internal
     return "host.docker.internal";
   }
 
-  /**
-   * Validate that the worker image exists locally, or pull it if missing.
-   * Called on gateway startup to ensure workers can be created.
-   */
   async validateWorkerImage(): Promise<void> {
     const imageName = this.getWorkerImageReference();
 
@@ -174,7 +150,6 @@ export class DockerDeploymentManager extends BaseDeploymentManager {
       const errorMessage =
         error instanceof Error ? error.message : String(error);
 
-      // If image not found, try to pull it
       if (
         errorMessage.includes("No such image") ||
         errorMessage.includes("404")
@@ -204,7 +179,6 @@ export class DockerDeploymentManager extends BaseDeploymentManager {
           );
         }
       } else {
-        // Other error - re-throw
         throw new OrchestratorError(
           ErrorCode.DEPLOYMENT_CREATE_FAILED,
           `Failed to validate worker image ${imageName}: ${errorMessage}`
@@ -227,9 +201,8 @@ export class DockerDeploymentManager extends BaseDeploymentManager {
       const veryOldDays = getVeryOldThresholdDays(this.config);
 
       return containers.map((containerInfo: Docker.ContainerInfo) => {
-        const deploymentName = containerInfo.Names[0]?.substring(1) || ""; // Remove leading '/'
+        const deploymentName = containerInfo.Names[0]?.substring(1) || "";
 
-        // Get last activity from in-memory tracking, labels, or creation time
         const trackedActivity = this.activityTimestamps.get(deploymentName);
         const lastActivityStr =
           containerInfo.Labels?.["lobu.io/last-activity"] ||
@@ -239,7 +212,6 @@ export class DockerDeploymentManager extends BaseDeploymentManager {
           ? new Date(lastActivityStr)
           : new Date(containerInfo.Created * 1000);
 
-        // Use the most recent timestamp from any source
         const lastActivity =
           trackedActivity && trackedActivity > labelActivity
             ? trackedActivity
@@ -264,21 +236,14 @@ export class DockerDeploymentManager extends BaseDeploymentManager {
     }
   }
 
-  /**
-   * Ensures a Docker volume exists for the given space ID.
-   * Uses named volumes for better isolation and security.
-   * Multiple threads in the same space share the same volume.
-   */
   private async ensureVolume(agentId: string): Promise<string> {
     const volumeName = `lobu-workspace-${agentId}`;
     let volumeCreated = false;
 
     try {
-      // Check if volume already exists (idempotent for concurrent creation)
       await this.docker.getVolume(volumeName).inspect();
       logger.info(`✅ Volume ${volumeName} already exists`);
     } catch (_error) {
-      // Volume doesn't exist, create it
       try {
         await this.docker.createVolume({
           Name: volumeName,
@@ -290,7 +255,7 @@ export class DockerDeploymentManager extends BaseDeploymentManager {
         logger.info(`✅ Created volume: ${volumeName}`);
         volumeCreated = true;
       } catch (createError: any) {
-        // Handle race condition: volume created by another thread
+        // Race: another thread created the volume concurrently.
         if (
           createError.statusCode === 409 ||
           createError.message?.includes("already exists")
@@ -302,8 +267,7 @@ export class DockerDeploymentManager extends BaseDeploymentManager {
       }
     }
 
-    // Fix volume permissions for new volumes
-    // The claude user in the worker container has UID 1001
+    // Worker container's claude user is UID 1001.
     if (volumeCreated) {
       try {
         const initContainer = await this.docker.createContainer({
@@ -340,7 +304,6 @@ export class DockerDeploymentManager extends BaseDeploymentManager {
     messageData?: MessagePayload
   ): Promise<void> {
     try {
-      // Use agentId for volume naming (shared across threads in same space)
       const agentId = messageData?.agentId;
       if (!agentId) {
         throw new OrchestratorError(
@@ -349,7 +312,6 @@ export class DockerDeploymentManager extends BaseDeploymentManager {
         );
       }
 
-      // Determine if running in Docker and resolve project paths
       const isRunningInDocker = process.env.DEPLOYMENT_MODE === "docker";
       const projectRoot = isRunningInDocker
         ? process.env.LOBU_DEV_PROJECT_PATH || "/app"
@@ -357,10 +319,8 @@ export class DockerDeploymentManager extends BaseDeploymentManager {
 
       const workspaceDir = `${projectRoot}/workspaces/${agentId}`;
 
-      // Ensure volume exists for production mode (space-scoped)
       const volumeName = await this.ensureVolume(agentId);
 
-      // Get common environment variables from base class
       const commonEnvVars = await this.generateEnvironmentVariables(
         username,
         userId,
@@ -369,7 +329,7 @@ export class DockerDeploymentManager extends BaseDeploymentManager {
         true
       );
 
-      // On macOS/Windows, Docker containers need to use host.docker.internal instead of localhost
+      // macOS/Windows: Docker containers cannot reach localhost on the host
       if (process.platform === "darwin" || process.platform === "win32") {
         if (
           commonEnvVars.LOBU_DATABASE_HOST === "localhost" ||
@@ -379,19 +339,15 @@ export class DockerDeploymentManager extends BaseDeploymentManager {
         }
       }
 
-      // Environment variables from base class already include:
-      // HTTP_PROXY, HTTPS_PROXY, NO_PROXY, NODE_ENV, DEBUG
-      // Provider credentials are injected via provider modules in generateEnvironmentVariables()
       const envVars = Object.entries(commonEnvVars).map(
         ([key, value]) => `${key}=${value}`
       );
 
-      // Check if Nix packages are configured (need writable rootfs for symlinks)
+      // Nix packages require writable rootfs for symlinks
       const hasNixConfig =
         (messageData?.nixConfig?.packages?.length ?? 0) > 0 ||
         !!messageData?.nixConfig?.flakeUrl;
 
-      // Get the Docker Compose project name from environment or use default
       const composeProjectName = process.env.COMPOSE_PROJECT_NAME || "lobu";
 
       const createOptions: Docker.ContainerCreateOptions = {
@@ -402,24 +358,19 @@ export class DockerDeploymentManager extends BaseDeploymentManager {
           ...BASE_WORKER_LABELS,
           "lobu.io/created": new Date().toISOString(),
           "lobu.io/agent-id": agentId,
-          // Docker Compose labels to associate with the project
           "com.docker.compose.project": composeProjectName,
-          "com.docker.compose.service": deploymentName, // Use unique service name
+          "com.docker.compose.service": deploymentName,
           "com.docker.compose.oneoff": "False",
-          // Add platform-specific metadata
           ...resolvePlatformDeploymentMetadata(messageData),
         },
         HostConfig: {
-          // Use named volumes in production for better isolation
-          // Use bind mounts in development for hot reload
+          // Dev uses bind mounts for hot reload; production uses named volumes for isolation
           ...(process.env.NODE_ENV === "development" && isRunningInDocker
             ? {
                 Binds: [
                   `${workspaceDir}:/workspace`,
-                  // Mount packages and scripts for hot reload
                   `${projectRoot}/packages:/app/packages`,
                   `${projectRoot}/scripts:/app/scripts`,
-                  // Additional custom mounts (optional)
                   ...(process.env.WORKER_VOLUME_MOUNTS
                     ? process.env.WORKER_VOLUME_MOUNTS.split(";")
                         .filter((mount) => mount.trim())
@@ -432,7 +383,6 @@ export class DockerDeploymentManager extends BaseDeploymentManager {
                 ],
               }
             : {
-                // Production: use named volumes for better isolation
                 Mounts: [
                   {
                     Type: "volume",
@@ -445,58 +395,42 @@ export class DockerDeploymentManager extends BaseDeploymentManager {
           RestartPolicy: {
             Name: "unless-stopped",
           },
-          // Resource limits similar to K8s
           Memory: ResourceParser.parseMemory(
             this.config.worker.resources.limits.memory
           ),
           NanoCpus: ResourceParser.parseCpu(
             this.config.worker.resources.limits.cpu
           ),
-          // Always connect to internal network (network isolation always enabled)
-          // In docker-compose mode: uses compose project prefix
-          // In host mode: uses plain network name (WORKER_NETWORK env var)
           NetworkMode:
             process.env.WORKER_NETWORK || `${composeProjectName}_lobu-internal`,
-          // Add host.docker.internal mapping when gateway runs on host
-          // Required on Linux, and needed on macOS/Windows when using internal networks
+          // Required on Linux + macOS/Windows when using internal networks
           ...(!this.isRunningInContainer() && {
             ExtraHosts: ["host.docker.internal:host-gateway"],
           }),
-          // Security: Drop all capabilities and only add what's needed
           CapDrop: ["ALL"],
           CapAdd: process.env.WORKER_CAPABILITIES
             ? process.env.WORKER_CAPABILITIES.split(",")
             : [],
-          // Security: Prevent privilege escalation
           SecurityOpt: [
             "no-new-privileges:true",
-            // Custom seccomp profile (default Docker seccomp is applied automatically)
             ...(process.env.WORKER_SECCOMP_PROFILE
               ? [`seccomp=${process.env.WORKER_SECCOMP_PROFILE}`]
               : []),
-            // AppArmor profile if specified
             ...(process.env.WORKER_APPARMOR_PROFILE
               ? [`apparmor=${process.env.WORKER_APPARMOR_PROFILE}`]
               : []),
           ],
-          // User namespace remapping (if Docker daemon is configured for it)
-          // This makes the root user inside container map to non-root on host
           UsernsMode: process.env.WORKER_USERNS_MODE || "",
-          // Read-only root filesystem (worker can write to /workspace and /tmp)
-          // Disabled when Nix packages configured (entrypoint needs to symlink /nix/store)
-          // Enabled by default for security, set WORKER_READONLY_ROOTFS=false to disable
+          // Nix entrypoint needs writable / to symlink /nix/store
           ReadonlyRootfs:
             !hasNixConfig && process.env.WORKER_READONLY_ROOTFS !== "false",
-          // Temporary filesystem for /tmp (writable, in-memory)
           ...(!hasNixConfig &&
             process.env.WORKER_READONLY_ROOTFS !== "false" && {
               Tmpfs: {
                 "/tmp": "rw,noexec,nosuid,size=100m",
               },
             }),
-          // Shared memory for Chromium and other apps requiring /dev/shm
-          ShmSize: 268435456, // 256MB
-          // Use gVisor runtime if available for enhanced isolation
+          ShmSize: 268435456,
           ...(this.gvisorAvailable && {
             Runtime: "runsc",
           }),
@@ -531,7 +465,6 @@ export class DockerDeploymentManager extends BaseDeploymentManager {
       try {
         await container.start();
       } catch (startError) {
-        // Clean up orphaned container if start fails
         logger.error(
           `Failed to start container ${deploymentName}, removing orphaned container`,
           startError
@@ -547,8 +480,8 @@ export class DockerDeploymentManager extends BaseDeploymentManager {
         throw startError;
       }
 
-      // In host mode, also connect the worker to the public network so it can
-      // reach the host gateway via host.docker.internal (internal network blocks host access)
+      // Host-mode workers need the public network to reach host.docker.internal
+      // (the internal network blocks host access by design)
       if (!this.isRunningInContainer()) {
         try {
           const publicNetwork = this.docker.getNetwork(
@@ -602,16 +535,13 @@ export class DockerDeploymentManager extends BaseDeploymentManager {
     try {
       const container = this.docker.getContainer(deploymentName);
 
-      // Stop container if running
       try {
         await container.stop();
         logger.info(`✅ Stopped container: ${deploymentName}`);
       } catch (_error) {
-        // Container might already be stopped
         logger.warn(`⚠️  Container ${deploymentName} was not running`);
       }
 
-      // Remove container
       await container.remove();
       this.activityTimestamps.delete(deploymentName);
       logger.info(`✅ Removed container: ${deploymentName}`);
@@ -626,14 +556,11 @@ export class DockerDeploymentManager extends BaseDeploymentManager {
       }
     }
 
-    // NOTE: Space volumes are NOT deleted on deployment deletion
-    // They are shared across threads in the same space and persist
-    // for future conversations. Cleanup is done manually or via separate process.
+    // Space volumes are shared across threads and intentionally persist; cleanup is manual.
   }
 
   async updateDeploymentActivity(deploymentName: string): Promise<void> {
-    // Docker doesn't support runtime label updates like K8s annotations
-    // Track activity in-memory for idle cleanup calculations
+    // Docker has no runtime label updates; track in-memory instead
     this.activityTimestamps.set(deploymentName, new Date());
   }
 

--- a/packages/gateway/src/orchestration/impl/k8s/deployment.ts
+++ b/packages/gateway/src/orchestration/impl/k8s/deployment.ts
@@ -209,7 +209,6 @@ export class K8sDeploymentManager extends BaseDeploymentManager {
 
     const kc = new k8s.KubeConfig();
     try {
-      // Try in-cluster config first, then fall back to default
       if (process.env.KUBERNETES_SERVICE_HOST) {
         try {
           kc.loadFromCluster();
@@ -220,7 +219,7 @@ export class K8sDeploymentManager extends BaseDeploymentManager {
         kc.loadFromDefault();
       }
 
-      // For development environments, disable TLS verification to avoid certificate issues
+      // Dev clusters often have self-signed certs
       if (
         process.env.NODE_ENV === "development" ||
         process.env.KUBERNETES_SERVICE_HOST?.includes("127.0.0.1") ||
@@ -233,7 +232,6 @@ export class K8sDeploymentManager extends BaseDeploymentManager {
           typeof cluster === "object" &&
           cluster.skipTLSVerify !== true
         ) {
-          // Safely set skipTLSVerify property with type checking
           Object.defineProperty(cluster, "skipTLSVerify", {
             value: true,
             writable: true,
@@ -252,30 +250,20 @@ export class K8sDeploymentManager extends BaseDeploymentManager {
       );
     }
 
-    // Store KubeConfig for informer creation
     this.kc = kc;
 
-    // Configure K8s API clients
     this.appsV1Api = kc.makeApiClient(k8s.AppsV1Api);
     this.coreV1Api = kc.makeApiClient(k8s.CoreV1Api);
     this.nodeV1Api = kc.makeApiClient(k8s.NodeV1Api);
-
-    // API clients are already configured with authentication through makeApiClient
 
     logger.info(
       `🔧 K8s client initialized for namespace: ${this.config.kubernetes.namespace}`
     );
 
-    // Validate namespace exists and we have access
     this.validateNamespace();
-
-    // Check runtime class availability on initialization (like Docker's gVisor check)
     this.checkRuntimeClassAvailability();
   }
 
-  /**
-   * Validate that the target namespace exists and we have access to it
-   */
   private async validateNamespace(): Promise<void> {
     const namespace = this.config.kubernetes.namespace;
 
@@ -297,26 +285,18 @@ export class K8sDeploymentManager extends BaseDeploymentManager {
           true
         );
       } else if (k8sError.statusCode === 403) {
-        // 403 Forbidden for namespace read is expected with namespace-scoped Roles
-        // The gateway can still create resources in the namespace without cluster-level namespace read permission
         logger.info(
           `ℹ️  Namespace '${namespace}' access check skipped (namespace-scoped RBAC). ` +
             `Will validate via resource operations.`
         );
-        // Don't throw - we're running in this namespace so it exists
       } else {
         logger.warn(
           `⚠️  Could not validate namespace '${namespace}': ${error instanceof Error ? error.message : String(error)}`
         );
-        // Don't throw - let operations fail with more specific errors
       }
     }
   }
 
-  /**
-   * Check if the configured RuntimeClass exists in the cluster
-   * Similar to Docker's checkGvisorAvailability()
-   */
   private async checkRuntimeClassAvailability(): Promise<void> {
     const runtimeClassName = this.config.worker.runtimeClassName || "kata";
 
@@ -337,7 +317,6 @@ export class K8sDeploymentManager extends BaseDeploymentManager {
           `⚠️  Failed to verify RuntimeClass '${runtimeClassName}': ${error instanceof Error ? error.message : String(error)}`
         );
       }
-      // Clear runtime class if not available or verification failed (workers will use default)
       this.config.worker.runtimeClassName = undefined;
     }
   }
@@ -361,11 +340,11 @@ export class K8sDeploymentManager extends BaseDeploymentManager {
   private async listRawWorkerDeployments(): Promise<k8s.V1Deployment[]> {
     const k8sDeployments = await this.appsV1Api.listNamespacedDeployment(
       this.config.kubernetes.namespace,
-      undefined, // pretty
-      undefined, // allowWatchBookmarks
-      undefined, // _continue
-      undefined, // fieldSelector
-      "app.kubernetes.io/component=worker" // labelSelector - only worker deployments
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      "app.kubernetes.io/component=worker"
     );
 
     const response = k8sDeployments as {
@@ -375,10 +354,6 @@ export class K8sDeploymentManager extends BaseDeploymentManager {
     return response.body?.items || [];
   }
 
-  /**
-   * Validate that the worker image exists and is pullable
-   * Called on gateway startup to ensure workers can be created
-   */
   async validateWorkerImage(): Promise<void> {
     const imageName = this.getWorkerImageReference();
     logger.info(
@@ -424,7 +399,6 @@ export class K8sDeploymentManager extends BaseDeploymentManager {
       for (const deployment of await this.listRawWorkerDeployments()) {
         const deploymentName = deployment.metadata?.name || "";
 
-        // Clean up orphaned finalizers on Terminating deployments (avoids extra API call)
         if (
           deployment.metadata?.deletionTimestamp &&
           deployment.metadata?.finalizers?.includes(LOBU_FINALIZER)
@@ -444,10 +418,9 @@ export class K8sDeploymentManager extends BaseDeploymentManager {
               err instanceof Error ? err.message : String(err)
             )
           );
-          continue; // Skip Terminating deployments from the active list
+          continue;
         }
 
-        // Get last activity from annotations or fallback to creation time
         const lastActivityStr =
           deployment.metadata?.annotations?.["lobu.io/last-activity"] ||
           deployment.metadata?.annotations?.["lobu.io/created"] ||
@@ -486,7 +459,6 @@ export class K8sDeploymentManager extends BaseDeploymentManager {
     userId: string,
     messageData?: MessagePayload
   ): Promise<void> {
-    // Extract traceparent for distributed tracing
     const traceparent = messageData?.platformMetadata?.traceparent as
       | string
       | undefined;
@@ -496,7 +468,6 @@ export class K8sDeploymentManager extends BaseDeploymentManager {
       "Creating K8s deployment"
     );
 
-    // Use agentId for PVC naming (shared across threads in same space)
     const agentId = messageData?.agentId;
     if (!agentId) {
       throw new OrchestratorError(
@@ -506,12 +477,11 @@ export class K8sDeploymentManager extends BaseDeploymentManager {
     }
     const pvcName = `lobu-workspace-${agentId}`;
 
-    // Check if Nix packages are configured (need init container + subPath mounts)
     const hasNixConfig =
       (messageData?.nixConfig?.packages?.length ?? 0) > 0 ||
       !!messageData?.nixConfig?.flakeUrl;
 
-    // Use larger PVC when Nix packages are configured (Chromium etc. need space)
+    // Nix PVC holds Chromium etc.
     const pvcSize = hasNixConfig ? "5Gi" : undefined;
     await createPVC(
       this.coreV1Api,
@@ -524,14 +494,12 @@ export class K8sDeploymentManager extends BaseDeploymentManager {
       this.config.worker.persistence?.size
     );
 
-    // Get environment variables before creating the deployment spec
-    // Include secrets (same as Docker behavior) - secrets are passed via env vars
     const envVars = await this.generateEnvironmentVariables(
       username,
       userId,
       deploymentName,
       messageData,
-      true // Include secrets to match Docker behavior
+      true
     );
 
     const platform = messageData?.platform || "unknown";
@@ -562,7 +530,6 @@ export class K8sDeploymentManager extends BaseDeploymentManager {
         template: {
           metadata: {
             annotations: {
-              // Add platform-specific metadata
               ...resolvePlatformDeploymentMetadata(messageData),
               "lobu.io/created": new Date().toISOString(),
               "lobu.io/agent-id": agentId,
@@ -576,7 +543,6 @@ export class K8sDeploymentManager extends BaseDeploymentManager {
           spec: {
             serviceAccountName: this.getWorkerServiceAccountName(),
             imagePullSecrets: this.getWorkerImagePullSecrets(),
-            // Only set runtimeClassName if configured and available (validated on startup)
             ...(this.config.worker.runtimeClassName
               ? { runtimeClassName: this.config.worker.runtimeClassName }
               : {}),
@@ -584,7 +550,6 @@ export class K8sDeploymentManager extends BaseDeploymentManager {
               fsGroup: WORKER_SECURITY.GROUP_ID,
               fsGroupChangePolicy: "OnRootMismatch",
             },
-            // Init container to bootstrap Nix store from image to PVC (first time only)
             ...(hasNixConfig
               ? {
                   initContainers: [
@@ -629,23 +594,17 @@ export class K8sDeploymentManager extends BaseDeploymentManager {
                   runAsUser: WORKER_SECURITY.USER_ID,
                   runAsGroup: WORKER_SECURITY.GROUP_ID,
                   runAsNonRoot: true,
-                  // Enable read-only root filesystem for security (matches Docker behavior)
                   readOnlyRootFilesystem: true,
-                  // Prevent privilege escalation
                   allowPrivilegeEscalation: false,
-                  // Drop all capabilities (matches Docker CAP_DROP: ALL)
                   capabilities: {
                     drop: ["ALL"],
                   },
                 },
                 env: [
-                  // Common environment variables from base class
-                  // (includes HTTP_PROXY, HTTPS_PROXY, NO_PROXY, NODE_ENV, DEBUG)
                   ...Object.entries(envVars).map(([key, value]) => ({
                     name: key,
                     value: value,
                   })),
-                  // Add traceparent for distributed tracing (passed to worker)
                   ...(traceparent
                     ? [{ name: "TRACEPARENT", value: traceparent }]
                     : []),
@@ -659,17 +618,14 @@ export class K8sDeploymentManager extends BaseDeploymentManager {
                     name: "workspace",
                     mountPath: "/workspace",
                   },
-                  // Tmpfs mounts for writable directories (matches Docker behavior)
                   {
                     name: "tmp",
                     mountPath: "/tmp",
                   },
-                  // /dev/shm for shared memory (needed by Chromium and other apps)
                   {
                     name: "dshm",
                     mountPath: "/dev/shm",
                   },
-                  // When Nix packages configured, mount PVC subpaths at /nix/store and /nix/var
                   ...(hasNixConfig
                     ? [
                         {
@@ -690,12 +646,10 @@ export class K8sDeploymentManager extends BaseDeploymentManager {
             volumes: [
               {
                 name: "workspace",
-                // Use per-deployment PVC for session persistence across scale-to-zero
                 persistentVolumeClaim: {
                   claimName: pvcName,
                 },
               },
-              // Tmpfs volumes for temporary files (in-memory, matches Docker Tmpfs)
               {
                 name: "tmp",
                 emptyDir: {
@@ -703,7 +657,6 @@ export class K8sDeploymentManager extends BaseDeploymentManager {
                   sizeLimit: WORKER_SECURITY.TMP_SIZE_LIMIT,
                 },
               },
-              // Shared memory for Chromium and other apps requiring /dev/shm
               {
                 name: "dshm",
                 emptyDir: {
@@ -717,7 +670,6 @@ export class K8sDeploymentManager extends BaseDeploymentManager {
       },
     };
 
-    // Create child span for worker creation (linked to parent via traceparent)
     const workerSpan = createChildSpan("worker_creation", traceparent, {
       "lobu.deployment_name": deploymentName,
       "lobu.user_id": userId,
@@ -776,7 +728,6 @@ export class K8sDeploymentManager extends BaseDeploymentManager {
         return;
       }
 
-      // Log detailed error information
       logger.error(`❌ Failed to create deployment ${deploymentName}:`, {
         statusCode: k8sError.statusCode,
         message: k8sError.message,
@@ -784,7 +735,6 @@ export class K8sDeploymentManager extends BaseDeploymentManager {
         response: k8sError.response?.statusMessage,
       });
 
-      // Clean up the PVC that was created before the deployment failed
       try {
         await this.coreV1Api.deleteNamespacedPersistentVolumeClaim(
           pvcName,
@@ -807,7 +757,6 @@ export class K8sDeploymentManager extends BaseDeploymentManager {
         }
       }
 
-      // End span with error
       workerSpan?.setStatus({
         code: SpanStatusCode.ERROR,
         message: k8sError.message || "Deployment failed",
@@ -908,7 +857,6 @@ export class K8sDeploymentManager extends BaseDeploymentManager {
   }
 
   async deleteDeployment(deploymentName: string): Promise<void> {
-    // Remove our finalizer before deleting so the resource can be garbage-collected
     await removeFinalizerFromResource(
       this.appsV1Api,
       this.coreV1Api,
@@ -917,7 +865,6 @@ export class K8sDeploymentManager extends BaseDeploymentManager {
       deploymentName
     );
 
-    // Delete the deployment with propagation policy
     try {
       await this.appsV1Api.deleteNamespacedDeployment(
         deploymentName,
@@ -926,7 +873,7 @@ export class K8sDeploymentManager extends BaseDeploymentManager {
         undefined,
         undefined,
         undefined,
-        "Foreground" // Wait for pods to terminate before returning
+        "Foreground"
       );
       logger.info(`✅ Deleted deployment: ${deploymentName}`);
     } catch (error) {
@@ -940,16 +887,9 @@ export class K8sDeploymentManager extends BaseDeploymentManager {
       }
     }
 
-    // NOTE: Space PVCs are NOT deleted on deployment deletion
-    // They are shared across threads in the same space and persist
-    // for future conversations. Cleanup is done manually or via separate process.
+    // Space PVCs are shared across threads in the same space; cleanup runs separately.
   }
 
-  /**
-   * Override reconcileDeployments to also clean up orphaned PVC finalizers.
-   * Deployment orphan cleanup is handled inside listDeployments() to avoid
-   * duplicate API calls (listDeployments already iterates raw K8s objects).
-   */
   async reconcileDeployments(): Promise<void> {
     await this.reconcileWorkerDeploymentImages();
     await cleanupOrphanedPvcFinalizers(
@@ -989,7 +929,6 @@ export class K8sDeploymentManager extends BaseDeploymentManager {
         `❌ Failed to update activity for deployment ${deploymentName}:`,
         error instanceof Error ? error.message : String(error)
       );
-      // Don't throw - activity tracking should not block message processing
     }
   }
 
@@ -999,11 +938,6 @@ export class K8sDeploymentManager extends BaseDeploymentManager {
     return `${dispatcherService}.${this.config.kubernetes.namespace}.svc.cluster.local`;
   }
 
-  /**
-   * Start a watch-based informer for worker deployments.
-   * The informer maintains a local cache that is updated via K8s watch events,
-   * reducing the need for frequent list API calls.
-   */
   async startInformer(): Promise<void> {
     if (this.informer || this.informerInitializing) return;
 
@@ -1048,9 +982,6 @@ export class K8sDeploymentManager extends BaseDeploymentManager {
     }
   }
 
-  /**
-   * Stop the informer and clear the cache.
-   */
   async stopInformer(): Promise<void> {
     if (this.informer) {
       this.informer.stop();
@@ -1059,9 +990,6 @@ export class K8sDeploymentManager extends BaseDeploymentManager {
     }
   }
 
-  /**
-   * Whether the informer is active and has a populated cache.
-   */
   isInformerActive(): boolean {
     return this.informer !== null;
   }


### PR DESCRIPTION
## Summary
- Removes file-level JSDoc blocks, section banners (`// === FOO ===`), and single-line comments that just restate well-named identifiers across 6 gateway/core files
- Aligns with the \"default to writing no comments\" rule in CLAUDE.md
- Keeps the comments that explain non-obvious WHY (dev-cluster self-signed certs, host-mode workers needing public network, SimpleSpanProcessor for short-lived workers, metrics-auth optional for existing ServiceMonitors)

## Scope
- `packages/core/src/otel.ts`, `packages/core/src/types.ts`
- `packages/gateway/src/cli/gateway.ts`, `packages/gateway/src/config/index.ts`
- `packages/gateway/src/orchestration/impl/docker-deployment.ts`
- `packages/gateway/src/orchestration/impl/k8s/deployment.ts`

No logic changes: `+40 / -372`, purely comment/JSDoc cleanup.

## Test plan
- [x] `bun run typecheck` passes
- [x] Biome pre-commit hook passes