### PR TITLE
refactor(gateway): extract SseManager from agent route

### DIFF
--- a/packages/gateway/src/__tests__/sse-manager.test.ts
+++ b/packages/gateway/src/__tests__/sse-manager.test.ts
@@ -1,0 +1,155 @@
+/**
+ * Tests for SseManager — backlog pruning, dead-connection sweep, and
+ * broadcast semantics. Covers behavior previously inlined in
+ * `routes/public/agent.ts` so we don't regress on extraction.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { SseManager, type SseConnection } from "../services/sse-manager";
+
+function fakeStream(): SseConnection & {
+  events: Array<{ event: string; data: string }>;
+  failOnNextWrite: boolean;
+} {
+  const events: Array<{ event: string; data: string }> = [];
+  return {
+    events,
+    failOnNextWrite: false,
+    writeSSE(payload) {
+      if ((this as any).failOnNextWrite) {
+        (this as any).failOnNextWrite = false;
+        throw new Error("boom");
+      }
+      events.push(payload);
+    },
+  } as any;
+}
+
+describe("SseManager", () => {
+  test("broadcast delivers events to all live connections for the agent", () => {
+    const mgr = new SseManager();
+    const a = fakeStream();
+    const b = fakeStream();
+    mgr.addConnection("agent-1", a);
+    mgr.addConnection("agent-1", b);
+
+    mgr.broadcast("agent-1", "output", { hello: "world" });
+
+    expect(a.events).toHaveLength(1);
+    expect(a.events[0]?.event).toBe("output");
+    expect(a.events[0]?.data).toBe(JSON.stringify({ hello: "world" }));
+    expect(b.events).toHaveLength(1);
+  });
+
+  test("broadcast to an agent with no connections still records backlog", () => {
+    const mgr = new SseManager();
+    mgr.broadcast("agent-2", "output", { n: 1 });
+
+    const stream = fakeStream();
+    mgr.addConnection("agent-2", stream);
+
+    const backlog = mgr.getRecentEvents("agent-2");
+    expect(backlog).toHaveLength(1);
+    expect(backlog[0]?.event).toBe("output");
+  });
+
+  test("backlog is capped at the configured limit (most-recent wins)", () => {
+    const mgr = new SseManager(3);
+    for (let i = 0; i < 10; i++) {
+      mgr.broadcast("agent", "output", { n: i });
+    }
+
+    const backlog = mgr.getRecentEvents("agent");
+    expect(backlog).toHaveLength(3);
+    const values = backlog.map((e) => (e.data as { n: number }).n);
+    expect(values).toEqual([7, 8, 9]);
+  });
+
+  test("dead connections are swept on broadcast write failure", () => {
+    const mgr = new SseManager();
+    const healthy = fakeStream();
+    const dying = fakeStream();
+    dying.failOnNextWrite = true;
+    mgr.addConnection("agent", healthy);
+    mgr.addConnection("agent", dying);
+
+    mgr.broadcast("agent", "output", { n: 1 });
+
+    expect(mgr.connectionCount("agent")).toBe(1);
+    expect(mgr.hasActiveConnection("agent")).toBe(true);
+    // Subsequent broadcast should only reach the healthy stream.
+    mgr.broadcast("agent", "output", { n: 2 });
+    expect(healthy.events).toHaveLength(2);
+    expect(dying.events).toHaveLength(0);
+  });
+
+  test("connections reporting closed/destroyed/writableEnded are treated as dead", () => {
+    const mgr = new SseManager();
+    const closed = fakeStream();
+    (closed as any).closed = true;
+    mgr.addConnection("agent", closed);
+
+    mgr.broadcast("agent", "output", { n: 1 });
+
+    expect(closed.events).toHaveLength(0);
+    expect(mgr.connectionCount("agent")).toBe(0);
+    expect(mgr.hasActiveConnection("agent")).toBe(false);
+  });
+
+  test("removeConnection cleans up the per-agent set", () => {
+    const mgr = new SseManager();
+    const stream = fakeStream();
+    mgr.addConnection("agent", stream);
+    expect(mgr.hasActiveConnection("agent")).toBe(true);
+    mgr.removeConnection("agent", stream);
+    expect(mgr.hasActiveConnection("agent")).toBe(false);
+    expect(mgr.connectionCount("agent")).toBe(0);
+  });
+
+  test("totalConnections sums across all agents", () => {
+    const mgr = new SseManager();
+    mgr.addConnection("a", fakeStream());
+    mgr.addConnection("a", fakeStream());
+    mgr.addConnection("b", fakeStream());
+    expect(mgr.totalConnections()).toBe(3);
+  });
+
+  test("closeAgent writes a closed event, clears connections, and drops backlog", () => {
+    const mgr = new SseManager();
+    const stream = fakeStream();
+    mgr.addConnection("agent", stream);
+    mgr.broadcast("agent", "output", { n: 1 });
+
+    mgr.closeAgent("agent", "agent_deleted");
+
+    expect(stream.events.at(-1)?.event).toBe("closed");
+    expect(stream.events.at(-1)?.data).toBe(
+      JSON.stringify({ reason: "agent_deleted" })
+    );
+    expect(mgr.hasActiveConnection("agent")).toBe(false);
+    expect(mgr.getRecentEvents("agent")).toEqual([]);
+  });
+
+  test("rememberEvent + getRecentEvents with since filter", () => {
+    const mgr = new SseManager();
+    const base = Date.now();
+    mgr.rememberEvent("agent", { event: "a", data: 1, timestamp: base - 30 });
+    mgr.rememberEvent("agent", { event: "b", data: 2, timestamp: base - 20 });
+    mgr.rememberEvent("agent", { event: "c", data: 3, timestamp: base - 10 });
+
+    const since = mgr.getRecentEvents("agent", base - 25);
+    expect(since.map((e) => e.event)).toEqual(["b", "c"]);
+  });
+
+  test("expired backlog entries are pruned on read", () => {
+    // 10ms TTL so we can advance past it with a real timestamp.
+    const mgr = new SseManager(100, 10);
+    mgr.rememberEvent("agent", {
+      event: "stale",
+      data: null,
+      timestamp: Date.now() - 1000,
+    });
+    // A second read-after-TTL should return nothing.
+    expect(mgr.getRecentEvents("agent")).toEqual([]);
+  });
+});

--- a/packages/gateway/src/api/platform.ts
+++ b/packages/gateway/src/api/platform.ts
@@ -10,7 +10,6 @@ import { randomUUID } from "node:crypto";
 import { createLogger, type InstructionProvider } from "@lobu/core";
 import type { CoreServices, PlatformAdapter } from "../platform";
 import type { ResponseRenderer } from "../platform/response-renderer";
-import { broadcastToAgent } from "../routes/public/agent";
 import { ApiResponseRenderer } from "./response-renderer";
 
 const logger = createLogger("api-platform");
@@ -46,16 +45,17 @@ export class ApiPlatform implements PlatformAdapter {
     logger.debug("Initializing API platform...");
 
     this.services = services;
+    const sseManager = services.getSseManager();
 
     // Create response renderer for routing worker responses to SSE clients
-    this.responseRenderer = new ApiResponseRenderer();
+    this.responseRenderer = new ApiResponseRenderer(sseManager);
 
     // Subscribe to interaction events to broadcast to SSE clients
     const interactionService = services.getInteractionService();
 
     interactionService.on("question:created", (event: any) => {
       if (event.teamId !== "api") return;
-      broadcastToAgent(event.conversationId, "question", {
+      sseManager.broadcast(event.conversationId, "question", {
         type: "question",
         questionId: event.id,
         question: event.question,
@@ -66,7 +66,7 @@ export class ApiPlatform implements PlatformAdapter {
 
     interactionService.on("link-button:created", (event: any) => {
       if (event.platform !== "api") return;
-      broadcastToAgent(event.conversationId, "link-button", {
+      sseManager.broadcast(event.conversationId, "link-button", {
         type: "link-button",
         url: event.url,
         label: event.label,
@@ -77,7 +77,7 @@ export class ApiPlatform implements PlatformAdapter {
 
     interactionService.on("tool:approval-needed", (event: any) => {
       if (event.teamId !== "api") return;
-      broadcastToAgent(event.conversationId, "tool-approval", {
+      sseManager.broadcast(event.conversationId, "tool-approval", {
         type: "tool-approval",
         requestId: event.id,
         mcpId: event.mcpId,
@@ -91,7 +91,7 @@ export class ApiPlatform implements PlatformAdapter {
 
     interactionService.on("suggestion:created", (event: any) => {
       if (event.teamId !== "api") return;
-      broadcastToAgent(event.conversationId, "suggestion", {
+      sseManager.broadcast(event.conversationId, "suggestion", {
         type: "suggestion",
         prompts: event.prompts,
         timestamp: Date.now(),

--- a/packages/gateway/src/api/response-renderer.ts
+++ b/packages/gateway/src/api/response-renderer.ts
@@ -8,7 +8,7 @@
 import { createLogger } from "@lobu/core";
 import type { ThreadResponsePayload } from "../infrastructure/queue/types";
 import type { ResponseRenderer } from "../platform/response-renderer";
-import { broadcastToAgent } from "../routes/public/agent";
+import type { SseManager } from "../services/sse-manager";
 
 const logger = createLogger("api-response-renderer");
 
@@ -17,6 +17,8 @@ const logger = createLogger("api-response-renderer");
  * Broadcasts responses to SSE clients instead of external platforms
  */
 export class ApiResponseRenderer implements ResponseRenderer {
+  constructor(private readonly sseManager: SseManager) {}
+
   /**
    * Handle streaming delta content
    * Broadcasts delta to SSE connections
@@ -34,7 +36,7 @@ export class ApiResponseRenderer implements ResponseRenderer {
     }
 
     // Broadcast delta to SSE clients
-    broadcastToAgent(sessionId, "output", {
+    this.sseManager.broadcast(sessionId, "output", {
       type: "delta",
       content: payload.delta,
       timestamp: payload.timestamp || Date.now(),
@@ -65,7 +67,7 @@ export class ApiResponseRenderer implements ResponseRenderer {
     }
 
     // Broadcast completion to SSE clients
-    broadcastToAgent(sessionId, "complete", {
+    this.sseManager.broadcast(sessionId, "complete", {
       type: "complete",
       messageId: payload.messageId,
       processedMessageIds: payload.processedMessageIds,
@@ -92,7 +94,7 @@ export class ApiResponseRenderer implements ResponseRenderer {
     }
 
     // Broadcast error to SSE clients
-    broadcastToAgent(sessionId, "error", {
+    this.sseManager.broadcast(sessionId, "error", {
       type: "error",
       error: payload.error,
       messageId: payload.messageId,
@@ -115,7 +117,7 @@ export class ApiResponseRenderer implements ResponseRenderer {
     }
 
     // Broadcast status to SSE clients
-    broadcastToAgent(sessionId, "status", {
+    this.sseManager.broadcast(sessionId, "status", {
       type: "status",
       status: payload.statusUpdate,
       messageId: payload.messageId,
@@ -136,7 +138,7 @@ export class ApiResponseRenderer implements ResponseRenderer {
     }
 
     // Broadcast ephemeral content to SSE clients
-    broadcastToAgent(sessionId, "ephemeral", {
+    this.sseManager.broadcast(sessionId, "ephemeral", {
       type: "ephemeral",
       content: payload.content,
       messageId: payload.messageId,

--- a/packages/gateway/src/cli/gateway.ts
+++ b/packages/gateway/src/cli/gateway.ts
@@ -296,6 +296,7 @@ export function createGatewayApp(
       const agentApi = createAgentApi({
         queueProducer,
         sessionManager: sessionMgr,
+        sseManager: coreServices.getSseManager(),
         publicGatewayUrl: publicUrl,
         adminPassword,
         cliTokenService,

--- a/packages/gateway/src/gateway-main.ts
+++ b/packages/gateway/src/gateway-main.ts
@@ -138,7 +138,8 @@ export class Gateway {
     // Single consumer routes responses to platforms via registry
     this.unifiedConsumer = new UnifiedThreadResponseConsumer(
       this.coreServices.getQueue(),
-      platformRegistry
+      platformRegistry,
+      this.coreServices.getSseManager()
     );
     await this.unifiedConsumer.start();
 

--- a/packages/gateway/src/platform.ts
+++ b/packages/gateway/src/platform.ts
@@ -23,6 +23,7 @@ import type { SecretProxy } from "./proxy/secret-proxy";
 import type { WritableSecretStore } from "./secrets";
 import type { DeclaredAgentRegistry } from "./services/declared-agent-registry";
 import type { InstructionService } from "./services/instruction-service";
+import type { SseManager } from "./services/sse-manager";
 import type { TranscriptionService } from "./services/transcription-service";
 import type { ISessionManager } from "./session";
 
@@ -48,6 +49,7 @@ export interface CoreServices {
   getSessionManager(): ISessionManager;
   getInstructionService(): InstructionService | undefined;
   getInteractionService(): InteractionService;
+  getSseManager(): SseManager;
   getAgentSettingsStore(): AgentSettingsStore;
   getChannelBindingService(): ChannelBindingService;
   getTranscriptionService(): TranscriptionService | undefined;

--- a/packages/gateway/src/platform/unified-thread-consumer.ts
+++ b/packages/gateway/src/platform/unified-thread-consumer.ts
@@ -13,7 +13,7 @@ import type {
 } from "../infrastructure/queue";
 import { getScheduleServiceInstance } from "../orchestration/scheduled-wakeup";
 import type { PlatformRegistry } from "../platform";
-import { broadcastToAgent } from "../routes/public/agent";
+import type { SseManager } from "../services/sse-manager";
 import type { ResponseRenderer } from "./response-renderer";
 
 const logger = createLogger("unified-thread-consumer");
@@ -29,7 +29,8 @@ export class UnifiedThreadResponseConsumer {
 
   constructor(
     private queue: IMessageQueue,
-    private platformRegistry: PlatformRegistry
+    private platformRegistry: PlatformRegistry,
+    private sseManager: SseManager
   ) {}
 
   setChatResponseBridge(bridge: ChatResponseBridge): void {
@@ -182,13 +183,17 @@ export class UnifiedThreadResponseConsumer {
         timestamp: data.timestamp,
         messageId: data.messageId,
       };
-      broadcastToAgent(
+      this.sseManager.broadcast(
         data.conversationId,
         data.customEvent.name,
         eventPayload
       );
       if (cliSessionId) {
-        broadcastToAgent(cliSessionId, data.customEvent.name, eventPayload);
+        this.sseManager.broadcast(
+          cliSessionId,
+          data.customEvent.name,
+          eventPayload
+        );
       }
 
       if (
@@ -205,7 +210,7 @@ export class UnifiedThreadResponseConsumer {
     // Handle ephemeral messages (OAuth/auth flows)
     if (data.ephemeral && data.content && renderer.handleEphemeral) {
       if (cliSessionId) {
-        broadcastToAgent(cliSessionId, "ephemeral", {
+        this.sseManager.broadcast(cliSessionId, "ephemeral", {
           type: "ephemeral",
           content: data.content,
           messageId: data.messageId,
@@ -219,7 +224,7 @@ export class UnifiedThreadResponseConsumer {
     // Handle status updates (heartbeat with elapsed time)
     if (data.statusUpdate && renderer.handleStatusUpdate) {
       if (cliSessionId) {
-        broadcastToAgent(cliSessionId, "status", {
+        this.sseManager.broadcast(cliSessionId, "status", {
           type: "status",
           status: data.statusUpdate,
           messageId: data.messageId,
@@ -233,7 +238,7 @@ export class UnifiedThreadResponseConsumer {
     // Handle streaming delta
     if (data.delta && renderer.handleDelta) {
       if (cliSessionId) {
-        broadcastToAgent(cliSessionId, "output", {
+        this.sseManager.broadcast(cliSessionId, "output", {
           type: "delta",
           content: data.delta,
           timestamp: data.timestamp,
@@ -250,7 +255,7 @@ export class UnifiedThreadResponseConsumer {
     // Handle error
     if (data.error) {
       if (cliSessionId) {
-        broadcastToAgent(cliSessionId, "error", {
+        this.sseManager.broadcast(cliSessionId, "error", {
           type: "error",
           error: data.error,
           messageId: data.messageId,
@@ -260,7 +265,7 @@ export class UnifiedThreadResponseConsumer {
       await renderer.handleError(data, sessionKey);
       // Also complete session on error
       if (cliSessionId) {
-        broadcastToAgent(cliSessionId, "complete", {
+        this.sseManager.broadcast(cliSessionId, "complete", {
           type: "complete",
           messageId: data.messageId,
           processedMessageIds: data.processedMessageIds,
@@ -274,7 +279,7 @@ export class UnifiedThreadResponseConsumer {
     // Handle completion
     if (data.processedMessageIds?.length) {
       if (cliSessionId) {
-        broadcastToAgent(cliSessionId, "complete", {
+        this.sseManager.broadcast(cliSessionId, "complete", {
           type: "complete",
           messageId: data.messageId,
           processedMessageIds: data.processedMessageIds,

--- a/packages/gateway/src/routes/public/agent.ts
+++ b/packages/gateway/src/routes/public/agent.ts
@@ -25,6 +25,7 @@ import type { QueueProducer } from "../../infrastructure/queue/queue-producer";
 import { getModelProviderModules } from "../../modules/module-system";
 import type { PlatformRegistry } from "../../platform";
 import { resolveAgentOptions } from "../../services/platform-helpers";
+import type { SseManager } from "../../services/sse-manager";
 import type { ISessionManager, ThreadSession } from "../../session";
 import { errorResponse } from "../shared/helpers";
 
@@ -36,28 +37,6 @@ const logger = createLogger("agent-api");
 
 const MAX_CONNECTIONS_PER_AGENT = 5;
 const MAX_TOTAL_CONNECTIONS = 1000;
-
-// SSE connection tracking
-const sseConnections = new Map<string, Set<any>>();
-const sseEventBacklog = new Map<
-  string,
-  Array<{ event: string; data: unknown; timestamp: number }>
->();
-const SSE_EVENT_BACKLOG_LIMIT = 100;
-const SSE_EVENT_BACKLOG_TTL_MS = 2 * 60 * 1000;
-
-function pruneExpiredSseEventBacklog(now = Date.now()): void {
-  for (const [agentId, entries] of sseEventBacklog.entries()) {
-    const freshEntries = entries.filter(
-      (entry) => now - entry.timestamp <= SSE_EVENT_BACKLOG_TTL_MS
-    );
-    if (freshEntries.length === 0) {
-      sseEventBacklog.delete(agentId);
-      continue;
-    }
-    sseEventBacklog.set(agentId, freshEntries);
-  }
-}
 
 // =============================================================================
 // Zod Schemas
@@ -264,65 +243,6 @@ function validateMcpConfig(
 }
 
 // =============================================================================
-// Broadcast Functions (exported for use by other modules)
-// =============================================================================
-
-function rememberSseEvent(agentId: string, event: string, data: unknown): void {
-  const now = Date.now();
-  pruneExpiredSseEventBacklog(now);
-  const existing = sseEventBacklog.get(agentId) || [];
-  const next = existing
-    .concat({ event, data, timestamp: now })
-    .slice(-SSE_EVENT_BACKLOG_LIMIT);
-  sseEventBacklog.set(agentId, next);
-}
-
-function getRecentSseEvents(
-  agentId: string
-): Array<{ event: string; data: unknown; timestamp: number }> {
-  const now = Date.now();
-  pruneExpiredSseEventBacklog(now);
-  return sseEventBacklog.get(agentId) || [];
-}
-
-export function broadcastToAgent(
-  agentId: string,
-  event: string,
-  data: unknown
-): void {
-  rememberSseEvent(agentId, event, data);
-
-  const connections = sseConnections.get(agentId);
-  if (!connections || connections.size === 0) return;
-
-  const deadConnections = new Set<any>();
-
-  for (const res of connections) {
-    try {
-      if (res.closed || res.destroyed || res.writableEnded) {
-        deadConnections.add(res);
-        continue;
-      }
-      if (typeof res.writeSSE === "function") {
-        res.writeSSE({ event, data: JSON.stringify(data) });
-      } else if (typeof res.write === "function") {
-        const message = `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`;
-        res.write(message);
-      }
-    } catch {
-      deadConnections.add(res);
-    }
-  }
-
-  for (const deadRes of deadConnections) {
-    connections.delete(deadRes);
-  }
-  if (connections.size === 0) {
-    sseConnections.delete(agentId);
-  }
-}
-
-// =============================================================================
 // OpenAPI Route Definitions
 // =============================================================================
 
@@ -473,6 +393,7 @@ const sendMessageRoute = createRoute({
 export interface AgentApiConfig {
   queueProducer: QueueProducer;
   sessionManager: ISessionManager;
+  sseManager: SseManager;
   publicGatewayUrl: string;
   adminPassword?: string;
   cliTokenService?: CliTokenService;
@@ -486,26 +407,7 @@ export interface AgentApiConfig {
   ) => Promise<{ success: boolean; error?: string }>;
 }
 
-export function createAgentApi(config: AgentApiConfig): OpenAPIHono;
-export function createAgentApi(
-  queueProducer: QueueProducer,
-  sessionManager: ISessionManager,
-  publicGatewayUrl: string
-): OpenAPIHono;
-export function createAgentApi(
-  configOrQueue: AgentApiConfig | QueueProducer,
-  sessionManager?: ISessionManager,
-  publicGatewayUrl?: string
-): OpenAPIHono {
-  const config: AgentApiConfig =
-    configOrQueue instanceof Object && "queueProducer" in configOrQueue
-      ? configOrQueue
-      : {
-          queueProducer: configOrQueue as QueueProducer,
-          sessionManager: sessionManager!,
-          publicGatewayUrl: publicGatewayUrl!,
-        };
-
+export function createAgentApi(config: AgentApiConfig): OpenAPIHono {
   const {
     queueProducer,
     adminPassword,
@@ -515,6 +417,7 @@ export function createAgentApi(
     platformRegistry,
   } = config;
   const sessMgr = config.sessionManager;
+  const sseManager = config.sseManager;
   const pubUrl = config.publicGatewayUrl;
   const app = new OpenAPIHono();
 
@@ -730,9 +633,7 @@ export function createAgentApi(
       return c.json({ success: false, error: "Agent not found" }, 404);
     }
 
-    const hasActiveConnection =
-      sseConnections.has(sessionKey) &&
-      (sseConnections.get(sessionKey)?.size ?? 0) > 0;
+    const hasActiveConnection = sseManager.hasActiveConnection(sessionKey);
 
     return c.json({
       success: true,
@@ -751,33 +652,10 @@ export function createAgentApi(
   app.openapi(deleteAgentRoute, async (c): Promise<any> => {
     const { agentId: sessionKey } = c.req.valid("param");
 
-    const connections = sseConnections.get(sessionKey);
-    if (connections) {
-      for (const connection of connections) {
-        try {
-          if (typeof connection.writeSSE === "function") {
-            connection.writeSSE({
-              event: "closed",
-              data: JSON.stringify({ reason: "agent_deleted" }),
-            });
-          } else if (typeof connection.write === "function") {
-            connection.write(
-              `event: closed\ndata: ${JSON.stringify({ reason: "agent_deleted" })}\n\n`
-            );
-          }
-          connection.close?.();
-          connection.end?.();
-        } catch {
-          // Ignore
-        }
-      }
-      sseConnections.delete(sessionKey);
-    }
-
-    // Drop any remembered SSE events so a later connection with the same key
-    // (rare, but possible with deterministic conversationIds) can't replay
-    // stale completion events from this deleted session.
-    sseEventBacklog.delete(sessionKey);
+    // Close connections + drop backlog so a later connection with the same
+    // key (rare, but possible with deterministic conversationIds) can't
+    // replay stale completion events from this deleted session.
+    sseManager.closeAgent(sessionKey, "agent_deleted");
 
     // Get real agentId from session before deleting
     const session = await sessMgr.getSession(sessionKey);
@@ -812,24 +690,16 @@ export function createAgentApi(
     }
 
     // Check connection limits
-    const totalConnections = Array.from(sseConnections.values()).reduce(
-      (acc, set) => acc + set.size,
-      0
-    );
-    if (totalConnections >= MAX_TOTAL_CONNECTIONS) {
+    if (sseManager.totalConnections() >= MAX_TOTAL_CONNECTIONS) {
       return c.json(
         { success: false, error: "Server connection limit reached" },
         429
       );
     }
 
-    // Use conversationId as the SSE connection key (matches broadcastToAgent calls)
+    // Use conversationId as the SSE connection key (matches broadcast calls)
     const sseKey = session.conversationId;
-    if (!sseConnections.has(sseKey)) {
-      sseConnections.set(sseKey, new Set());
-    }
-    const agentConnections = sseConnections.get(sseKey)!;
-    if (agentConnections.size >= MAX_CONNECTIONS_PER_AGENT) {
+    if (sseManager.connectionCount(sseKey) >= MAX_CONNECTIONS_PER_AGENT) {
       return c.json(
         {
           success: false,
@@ -841,7 +711,7 @@ export function createAgentApi(
 
     // Return SSE stream
     return streamSSE(c, async (stream) => {
-      agentConnections.add(stream);
+      sseManager.addConnection(sseKey, stream);
 
       await stream.writeSSE({
         event: "connected",
@@ -851,7 +721,7 @@ export function createAgentApi(
         }),
       });
 
-      for (const entry of getRecentSseEvents(sseKey)) {
+      for (const entry of sseManager.getRecentEvents(sseKey)) {
         await stream.writeSSE({
           event: entry.event,
           data: JSON.stringify(entry.data),
@@ -871,10 +741,7 @@ export function createAgentApi(
 
       stream.onAbort(() => {
         clearInterval(heartbeatInterval);
-        agentConnections.delete(stream);
-        if (agentConnections.size === 0) {
-          sseConnections.delete(sseKey);
-        }
+        sseManager.removeConnection(sseKey, stream);
         logger.info(`SSE connection closed for session ${sseKey}`);
       });
 

--- a/packages/gateway/src/services/core-services.ts
+++ b/packages/gateway/src/services/core-services.ts
@@ -75,6 +75,7 @@ import { ImageGenerationService } from "./image-generation-service";
 import { InstructionService } from "./instruction-service";
 import { SessionManager, StateAdapterSessionStore } from "./session-manager";
 import { SettingsResolver } from "./settings-resolver";
+import { SseManager } from "./sse-manager";
 import { ProviderConfigResolver } from "./provider-config-resolver";
 import { ProviderRegistryService } from "./provider-registry-service";
 import { TranscriptionService } from "./transcription-service";
@@ -97,6 +98,7 @@ export class CoreServices {
   private sessionManager?: SessionManager;
   private instructionService?: InstructionService;
   private interactionService?: InteractionService;
+  private sseManager?: SseManager;
 
   // ============================================================================
   // Auth & Provider Services
@@ -350,6 +352,9 @@ export class CoreServices {
 
     this.interactionService = new InteractionService();
     logger.debug("Interaction service initialized");
+
+    this.sseManager = new SseManager();
+    logger.debug("SSE manager initialized");
 
     // Initialize grant store for unified permissions
     this.grantStore = new GrantStore(redisClient);
@@ -1143,6 +1148,11 @@ export class CoreServices {
     if (!this.interactionService)
       throw new Error("Interaction service not initialized");
     return this.interactionService;
+  }
+
+  getSseManager(): SseManager {
+    if (!this.sseManager) throw new Error("SSE manager not initialized");
+    return this.sseManager;
   }
 
   getAgentSettingsStore(): AgentSettingsStore {

--- a/packages/gateway/src/services/sse-manager.ts
+++ b/packages/gateway/src/services/sse-manager.ts
@@ -1,0 +1,211 @@
+/**
+ * SseManager — owns per-agent Server-Sent Events fan-out.
+ *
+ * Extracted from `routes/public/agent.ts` so the route handler doesn't have
+ * to track in-memory connection maps, TTL-pruned backlogs, and dead-connection
+ * sweeps inline. A single instance is created in `core-services.ts` and
+ * injected into the agent route and into any component that broadcasts
+ * into SSE streams (API platform, response renderer, unified thread
+ * consumer).
+ *
+ * Behavior notes (preserved exactly from the previous inline implementation):
+ *  - Backlog is per-agentId, capped at `BACKLOG_LIMIT` most-recent entries.
+ *  - Backlog entries older than `BACKLOG_TTL_MS` are pruned lazily on every
+ *    read AND every write.
+ *  - `broadcast` writes to every live connection; a connection is treated as
+ *    dead when it reports `closed`/`destroyed`/`writableEnded` OR when a
+ *    write throws — dead connections are removed silently (no throw, no log).
+ *  - Backlog is ALWAYS remembered (even when no connections are attached) so
+ *    a late subscriber can replay recent events.
+ */
+
+export interface SseEvent {
+  event: string;
+  data: unknown;
+  timestamp: number;
+}
+
+/**
+ * Minimal shape of an SSE stream we can write to. Matches Hono's
+ * `streamSSE` controller (the `writeSSE` path) and also falls back to a
+ * raw Node-style writable for consumers that attach plain response
+ * objects. Kept loose on purpose — SseManager doesn't own the connection
+ * lifecycle, it just fans events out.
+ */
+export interface SseConnection {
+  closed?: boolean;
+  destroyed?: boolean;
+  writableEnded?: boolean;
+  writeSSE?(payload: { event: string; data: string }): unknown;
+  write?(chunk: string): unknown;
+}
+
+export class SseManager {
+  private readonly connections = new Map<string, Set<SseConnection>>();
+  private readonly backlog = new Map<string, SseEvent[]>();
+
+  constructor(
+    private readonly backlogLimit = 100,
+    private readonly backlogTtlMs = 2 * 60 * 1000
+  ) {}
+
+  /**
+   * Append an event to the per-agent backlog and prune expired entries.
+   *
+   * Called from `broadcast` and is safe to call on its own for callers that
+   * want to seed the backlog without an active connection.
+   */
+  rememberEvent(agentId: string, event: SseEvent): void {
+    this.pruneExpired(event.timestamp);
+    const existing = this.backlog.get(agentId) || [];
+    const next = existing.concat(event).slice(-this.backlogLimit);
+    this.backlog.set(agentId, next);
+  }
+
+  /**
+   * Return the current fresh backlog for an agent. Always prunes expired
+   * entries first so callers never observe stale events.
+   *
+   * The optional `since` timestamp filters entries with `timestamp > since`.
+   * Without it, the full retained backlog is returned.
+   */
+  getRecentEvents(agentId: string, since?: number): SseEvent[] {
+    this.pruneExpired();
+    const entries = this.backlog.get(agentId) || [];
+    if (typeof since === "number") {
+      return entries.filter((entry) => entry.timestamp > since);
+    }
+    return entries;
+  }
+
+  /**
+   * Remember the event, then write it to every live connection for `agentId`.
+   * Dead connections (closed / ended / threw on write) are removed silently.
+   * If the agent has no connections, only the backlog is updated.
+   */
+  broadcast(agentId: string, event: string, data: unknown): void {
+    const entry: SseEvent = { event, data, timestamp: Date.now() };
+    this.rememberEvent(agentId, entry);
+
+    const connections = this.connections.get(agentId);
+    if (!connections || connections.size === 0) return;
+
+    const dead = new Set<SseConnection>();
+    for (const res of connections) {
+      try {
+        if (res.closed || res.destroyed || res.writableEnded) {
+          dead.add(res);
+          continue;
+        }
+        if (typeof res.writeSSE === "function") {
+          res.writeSSE({ event, data: JSON.stringify(data) });
+        } else if (typeof res.write === "function") {
+          const message = `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`;
+          res.write(message);
+        }
+      } catch {
+        dead.add(res);
+      }
+    }
+
+    for (const deadRes of dead) {
+      connections.delete(deadRes);
+    }
+    if (connections.size === 0) {
+      this.connections.delete(agentId);
+    }
+  }
+
+  /**
+   * Register a live connection for fan-out. Caller is responsible for calling
+   * `removeConnection` on disconnect — `broadcast` will also evict connections
+   * it detects as dead during a write.
+   */
+  addConnection(agentId: string, connection: SseConnection): void {
+    let set = this.connections.get(agentId);
+    if (!set) {
+      set = new Set();
+      this.connections.set(agentId, set);
+    }
+    set.add(connection);
+  }
+
+  removeConnection(agentId: string, connection: SseConnection): void {
+    const set = this.connections.get(agentId);
+    if (!set) return;
+    set.delete(connection);
+    if (set.size === 0) {
+      this.connections.delete(agentId);
+    }
+  }
+
+  /**
+   * True if `agentId` has at least one live connection registered.
+   * Used by status endpoints that expose `hasActiveConnection`.
+   */
+  hasActiveConnection(agentId: string): boolean {
+    const set = this.connections.get(agentId);
+    return !!set && set.size > 0;
+  }
+
+  /**
+   * Snapshot the number of live connections for an agent. Used for
+   * per-agent connection-limit checks.
+   */
+  connectionCount(agentId: string): number {
+    return this.connections.get(agentId)?.size ?? 0;
+  }
+
+  /** Total number of live connections across all agents. */
+  totalConnections(): number {
+    let total = 0;
+    for (const set of this.connections.values()) total += set.size;
+    return total;
+  }
+
+  /**
+   * Close every connection for `agentId`, emitting a `closed` event with
+   * `reason` first (best-effort — write errors are swallowed, matching the
+   * previous inline DELETE /agents behavior). Also drops the backlog so a
+   * later connection with the same key cannot replay stale completion
+   * events from the deleted session.
+   */
+  closeAgent(agentId: string, reason: string): void {
+    const connections = this.connections.get(agentId);
+    if (connections) {
+      for (const connection of connections) {
+        try {
+          if (typeof connection.writeSSE === "function") {
+            connection.writeSSE({
+              event: "closed",
+              data: JSON.stringify({ reason }),
+            });
+          } else if (typeof connection.write === "function") {
+            connection.write(
+              `event: closed\ndata: ${JSON.stringify({ reason })}\n\n`
+            );
+          }
+          (connection as { close?: () => void }).close?.();
+          (connection as { end?: () => void }).end?.();
+        } catch {
+          // Ignore — connection is already dead.
+        }
+      }
+      this.connections.delete(agentId);
+    }
+    this.backlog.delete(agentId);
+  }
+
+  private pruneExpired(now = Date.now()): void {
+    for (const [agentId, entries] of this.backlog.entries()) {
+      const fresh = entries.filter(
+        (entry) => now - entry.timestamp <= this.backlogTtlMs
+      );
+      if (fresh.length === 0) {
+        this.backlog.delete(agentId);
+        continue;
+      }
+      this.backlog.set(agentId, fresh);
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Extracts ~130 LOC of inline SSE plumbing (per-agent connection maps, backlog with TTL, dead-connection sweep, `closed`-on-delete) out of `packages/gateway/src/routes/public/agent.ts` into a new `SseManager` service at `packages/gateway/src/services/sse-manager.ts`.
- `SseManager` owns: per-agent connection set, backlog (capped + TTL-pruned, pruned on read and on write), `broadcast` fan-out with try/catch sweep, `closed`/`destroyed`/`writableEnded` detection, and `closeAgent(reason)` (emits `closed` SSE event, closes streams, clears connections, drops backlog).
- Single instance lives on `CoreServices` and is injected into the route, `ApiPlatform` / `ApiResponseRenderer`, and `UnifiedThreadResponseConsumer` — all previous `broadcastToAgent` call sites now go through the manager.

## Behavior preserved

- Backlog limit (100), TTL (2 min), prune-on-read-and-write.
- Write path prefers `writeSSE` then falls back to Node `write`; errors swallow and mark the connection dead.
- Per-agent (5) and total (1000) connection limits remain enforced in the route.
- `DELETE /agents/:id` emits a `closed` event to every live connection, then clears both the connection set and backlog — identical to the pre-refactor path.

## Test plan

- [x] `make build-packages` — all packages build clean
- [x] `bun run typecheck` — no errors
- [x] `bun test packages/gateway` — 498 pass, 0 fail (includes 10 new `SseManager` tests covering broadcast fan-out, backlog cap, TTL prune, dead-connection sweep, `closeAgent`, and `rememberEvent` + `since` filter)
- [x] Mental trace of golden path: `POST /agents` → `GET /events` (addConnection → backlog replay → heartbeat → onAbort → removeConnection) → worker response `broadcast` → `DELETE /agents` (emits `closed` + clears)