### PR TITLE
fix(docker): include owletto workspaces in Dockerfile.worker

### DIFF
--- a/docker/Dockerfile.worker
+++ b/docker/Dockerfile.worker
@@ -67,14 +67,19 @@ RUN echo 'export PATH="/home/bun/.bun/bin:$PATH"' >> /home/worker/.bashrc && \
     echo 'export BUN_INSTALL="/home/bun/.bun"' >> /home/worker/.bashrc && \
     echo 'export PATH="/root/.cargo/bin:$PATH"' >> /home/worker/.bashrc
 
-# Create minimal package.json for worker-only workspace
-RUN echo '{ "name": "@lobu/worker-build", "private": true, "workspaces": [ "packages/core", "packages/worker" ] }' > package.json
+# Create minimal package.json for worker-only workspace.
+# Must include every workspace the worker depends on (directly or transitively)
+# so `bun install` can resolve workspace:* specifiers.
+RUN echo '{ "name": "@lobu/worker-build", "private": true, "workspaces": [ "packages/core", "packages/worker", "packages/owletto-openclaw", "packages/owletto-cli", "packages/owletto-sdk" ] }' > package.json
 
 # Copy dependency manifests
 COPY bun.lock ./bun.lock
 COPY tsconfig.json ./
 COPY packages/worker/package.json ./packages/worker/
 COPY packages/core/package.json ./packages/core/
+COPY packages/owletto-openclaw/package.json ./packages/owletto-openclaw/
+COPY packages/owletto-cli/package.json ./packages/owletto-cli/
+COPY packages/owletto-sdk/package.json ./packages/owletto-sdk/
 
 # Install all dependencies including devDependencies for building
 RUN --mount=type=cache,target=/root/.bun/install/cache bun install


### PR DESCRIPTION
## Summary
- Worker Base image build has been failing since the owletto monorepo consolidation (commit `a6d0d3f9`, PR #212)
- That commit added `@lobu/owletto-openclaw` and `owletto` (owletto-cli) as worker dependencies but did not update `docker/Dockerfile.worker`, which still declared a minimal workspace list of just `packages/core` + `packages/worker`
- `bun install` was failing on every push with:
  ```
  error: Workspace dependency "@lobu/owletto-openclaw" not found
  error: Workspace dependency "owletto" not found
  ```
- Adds `owletto-openclaw`, `owletto-cli`, and their transitive `owletto-sdk` dep to the workspace list and copies their `package.json` manifests before `bun install`

## Why the landing page / gateway images aren't affected
They use their own Dockerfiles (`docker/Dockerfile.gateway`, `packages/landing/**`, `docker/worker/Dockerfile`) which already stub out or include the relevant workspaces.

## Verification
Reproduced the fix locally by running `bun install` in a scratch dir with exactly the files the Dockerfile COPYs:
- Root `package.json` with the new workspace list
- `bun.lock`
- `packages/{core,worker,owletto-openclaw,owletto-cli,owletto-sdk}/package.json`

Install succeeded — 1571 packages resolved, zero workspace errors (vs the `Workspace dependency ... not found` failure without the fix).

## Test plan
- [ ] CI Docker publish workflow turns green on this PR
- [ ] After merge, confirm `lobu-worker-base:latest` image gets pushed to ghcr.io