### PR TITLE
fix(landing): repair broken links surfaced by audit

### DIFF
--- a/packages/landing/src/components/BenchmarkSection.tsx
+++ b/packages/landing/src/components/BenchmarkSection.tsx
@@ -182,7 +182,7 @@ export function BenchmarkSection() {
 
         <div class="mt-8 text-center">
           <a
-            href="/docs/guides/memory-benchmarks/"
+            href="/guides/memory-benchmarks/"
             class="inline-flex items-center gap-2 text-xs font-medium px-4 py-2 rounded-lg transition-all hover:opacity-80"
             style={{
               backgroundColor: "var(--color-page-surface)",

--- a/packages/landing/src/components/ServerlessSection.tsx
+++ b/packages/landing/src/components/ServerlessSection.tsx
@@ -63,7 +63,7 @@ const docsLinks = [
   { label: "Security", href: "/guides/security" },
   { label: "Kubernetes Deploy", href: "/deployment/kubernetes" },
   { label: "Docker Deploy", href: "/deployment/docker" },
-  { label: "MCP & Integrations", href: "/guides/integrations-mcp" },
+  { label: "MCP Proxy", href: "/guides/mcp-proxy/" },
 ];
 
 export function ServerlessSection() {

--- a/packages/landing/src/content/docs/reference/providers.mdx
+++ b/packages/landing/src/content/docs/reference/providers.mdx
@@ -12,7 +12,7 @@ export const providerConfigEntries = (providersConfig.providers || []).map(
 
 Lobu model providers are config-driven and loaded from a single source of truth.
 
-See also: [Skills](/getting-started/skills/) and [Capabilities](/getting-started/capabilities/).
+See also: [Skills](/getting-started/skills/).
 
 ## Source of truth
 


### PR DESCRIPTION
## Summary

Audited every internal href in the landing frontend (`packages/landing/src/**/*.{tsx,astro,md,mdx}`) against the real routes generated into `dist/`. Fixed three broken internal links.

## Audit results

- **Total internal links scanned:** 147 (plus 63 external, 2 ignored mailto/anchors)
- **Fixed:** 3
- **Unresolved:** 0

## Fixes

| File | Before | After | Reason |
| --- | --- | --- | --- |
| `packages/landing/src/components/BenchmarkSection.tsx` | `/docs/guides/memory-benchmarks/` | `/guides/memory-benchmarks/` | Site has no `/docs` prefix; this is the original broken link reported by the user. |
| `packages/landing/src/components/ServerlessSection.tsx` | `/guides/integrations-mcp` | `/guides/mcp-proxy/` | No `integrations-mcp` page exists; `/guides/mcp-proxy/` is the real doc for MCP. Label changed to "MCP Proxy" to match. |
| `packages/landing/src/content/docs/reference/providers.mdx` | `[Capabilities](/getting-started/capabilities/)` | (removed) | `/getting-started/capabilities/` has never existed. The neighboring `[Skills](/getting-started/skills/)` link is kept. |

## Method

Rebuilt the site, enumerated every route under `dist/` (102 pages), then regex-extracted hrefs and markdown links from all sources, normalized trailing slashes, and checked each against the real page set. Script was ephemeral and has been removed.

External `lobu.ai` / `github.com/lobu-ai` links were spot-checked but not mechanically validated (per scope).

## Note on `bun run build`

`bun run build` on `main` is currently broken by an unrelated Zod resolution issue on `src/pages/connect-from/[client]/for/[useCase].astro` (`Cannot read properties of undefined (reading '_zod')`). That is already fixed in PR #271 (`fix(landing): resolve zod parse error on connect-from route`). With #271's one-line `astro.config.mjs` change applied locally, the build completes and emits all 102 pages including the three destinations fixed here. This PR intentionally does not touch `astro.config.mjs` to avoid overlapping with #271.

## Test plan

- [ ] Merge #271 first, then confirm `cd packages/landing && bun run build` succeeds
- [ ] Visit `/` and click the "Read the methodology" button under the benchmark chart -> lands on `/guides/memory-benchmarks/`
- [ ] Visit the Serverless section footer link "MCP Proxy" -> lands on `/guides/mcp-proxy/`
- [ ] Visit `/reference/providers/` -> single "See also: Skills" link, no broken capabilities link