### PR TITLE
fix(landing): wire benchmark methodology link and add tables to memory + comparison

### DIFF
--- a/packages/landing/src/components/BenchmarkSection.tsx
+++ b/packages/landing/src/components/BenchmarkSection.tsx
@@ -1,161 +1,7 @@
 import { ContentRail } from "./ContentRail";
 import { SectionHeader } from "./SectionHeader";
-import {
-  cardBg,
-  cardBorder,
-  innerCardBg,
-  textColor,
-  textMuted,
-} from "./memory/styles";
-
-// Numbers mirrored from packages/owletto/README.md (lines 32-52).
-// Refresh on each Owletto memory-benchmark release.
-// last updated: 2026-04-21
-const LONGMEMEVAL_ROWS: BenchmarkRow[] = [
-  {
-    system: "Owletto",
-    overall: "87.1%",
-    answer: "78.0%",
-    retrieval: "100.0%",
-    latency: "237ms",
-    leader: true,
-  },
-  {
-    system: "Supermemory",
-    overall: "69.1%",
-    answer: "56.0%",
-    retrieval: "96.6%",
-    latency: "702ms",
-  },
-  {
-    system: "Mem0",
-    overall: "65.7%",
-    answer: "54.0%",
-    retrieval: "85.3%",
-    latency: "753ms",
-  },
-];
-
-const LOCOMO_ROWS: BenchmarkRow[] = [
-  {
-    system: "Owletto",
-    overall: "57.8%",
-    answer: "38.0%",
-    retrieval: "79.5%",
-    latency: "121ms",
-    leader: true,
-  },
-  {
-    system: "Mem0",
-    overall: "41.5%",
-    answer: "28.0%",
-    retrieval: "66.9%",
-    latency: "606ms",
-  },
-  {
-    system: "Supermemory",
-    overall: "23.2%",
-    answer: "14.0%",
-    retrieval: "36.5%",
-    latency: "532ms",
-  },
-];
-
-type BenchmarkRow = {
-  system: string;
-  overall: string;
-  answer: string;
-  retrieval: string;
-  latency: string;
-  leader?: boolean;
-};
-
-function BenchmarkTable(props: {
-  title: string;
-  subtitle: string;
-  rows: BenchmarkRow[];
-}) {
-  return (
-    <div
-      class="rounded-2xl p-6 sm:p-8"
-      style={{
-        background: cardBg,
-        border: `1px solid ${cardBorder}`,
-      }}
-    >
-      <div class="mb-5">
-        <h3 class="text-lg font-semibold mb-1" style={{ color: textColor }}>
-          {props.title}
-        </h3>
-        <p class="text-xs leading-relaxed" style={{ color: textMuted }}>
-          {props.subtitle}
-        </p>
-      </div>
-      <div class="overflow-x-auto">
-        <table class="w-full text-sm" style={{ color: textColor }}>
-          <thead>
-            <tr
-              class="text-left text-[11px] uppercase tracking-wider"
-              style={{ color: textMuted }}
-            >
-              <th class="font-medium pb-3 pr-4">System</th>
-              <th class="font-medium pb-3 px-3 text-right">Overall</th>
-              <th class="font-medium pb-3 px-3 text-right">Answer</th>
-              <th class="font-medium pb-3 px-3 text-right">Retrieval</th>
-              <th class="font-medium pb-3 pl-3 text-right">Latency</th>
-            </tr>
-          </thead>
-          <tbody>
-            {props.rows.map((row) => (
-              <tr
-                key={row.system}
-                style={{
-                  background: row.leader ? innerCardBg : "transparent",
-                }}
-              >
-                <td
-                  class="py-2.5 pr-4 font-medium"
-                  style={{
-                    color: row.leader ? textColor : textMuted,
-                  }}
-                >
-                  {row.system}
-                </td>
-                <td
-                  class="py-2.5 px-3 text-right tabular-nums"
-                  style={{
-                    color: row.leader ? textColor : textMuted,
-                    fontWeight: row.leader ? 600 : 400,
-                  }}
-                >
-                  {row.overall}
-                </td>
-                <td
-                  class="py-2.5 px-3 text-right tabular-nums"
-                  style={{ color: row.leader ? textColor : textMuted }}
-                >
-                  {row.answer}
-                </td>
-                <td
-                  class="py-2.5 px-3 text-right tabular-nums"
-                  style={{ color: row.leader ? textColor : textMuted }}
-                >
-                  {row.retrieval}
-                </td>
-                <td
-                  class="py-2.5 pl-3 text-right tabular-nums"
-                  style={{ color: row.leader ? textColor : textMuted }}
-                >
-                  {row.latency}
-                </td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
-      </div>
-    </div>
-  );
-}
+import { BenchmarkTablesGrid } from "./memory/BenchmarkTables";
+import { textColor } from "./memory/styles";
 
 export function BenchmarkSection() {
   return (
@@ -167,22 +13,11 @@ export function BenchmarkSection() {
           className="mb-10"
         />
 
-        <div class="grid gap-5 md:grid-cols-2">
-          <BenchmarkTable
-            title="LongMemEval (oracle-50)"
-            subtitle="Single-session knowledge retention."
-            rows={LONGMEMEVAL_ROWS}
-          />
-          <BenchmarkTable
-            title="LoCoMo-50"
-            subtitle="Multi-session conversational memory."
-            rows={LOCOMO_ROWS}
-          />
-        </div>
+        <BenchmarkTablesGrid />
 
         <div class="mt-8 text-center">
           <a
-            href="/docs/guides/memory-benchmarks/"
+            href="/guides/memory-benchmarks/"
             class="inline-flex items-center gap-2 text-xs font-medium px-4 py-2 rounded-lg transition-all hover:opacity-80"
             style={{
               backgroundColor: "var(--color-page-surface)",

--- a/packages/landing/src/components/MemorySection.tsx
+++ b/packages/landing/src/components/MemorySection.tsx
@@ -15,6 +15,8 @@ import { ExampleShowcase } from "./memory/ExampleShowcase";
 import { LatestBlogPosts, type LatestBlogPost } from "./LatestBlogPosts";
 import { ScheduleCallButton, ScheduleCallIcon } from "./ScheduleDialog";
 import { ScopedUseCaseTabs } from "./ScopedUseCaseTabs";
+import { SectionHeader } from "./SectionHeader";
+import { BenchmarkTablesGrid } from "./memory/BenchmarkTables";
 import { textColor, textMuted } from "./memory/styles";
 
 function SectionDivider() {
@@ -106,6 +108,32 @@ export function MemorySection(props: {
         <SectionDivider />
 
         <LatestBlogPosts posts={props.latestPosts} />
+
+        <SectionDivider />
+
+        <ContentRail variant="compact">
+          <SectionHeader
+            title="Beats Mem0 and Supermemory on public benchmarks"
+            body="Apples-to-apples comparison on public memory datasets. Same answerer (glm-5.1 via z.ai), same top-K, same questions."
+            className="mb-10"
+          />
+
+          <BenchmarkTablesGrid />
+
+          <div class="mt-8 text-center">
+            <a
+              href="/guides/memory-benchmarks/"
+              class="inline-flex items-center gap-2 text-xs font-medium px-4 py-2 rounded-lg transition-all hover:opacity-80"
+              style={{
+                backgroundColor: "var(--color-page-surface)",
+                color: textColor,
+                border: "1px solid var(--color-page-border-active)",
+              }}
+            >
+              Read the methodology
+            </a>
+          </div>
+        </ContentRail>
 
         <SectionDivider />
 

--- a/packages/landing/src/components/memory/BenchmarkTables.tsx
+++ b/packages/landing/src/components/memory/BenchmarkTables.tsx
@@ -1,0 +1,171 @@
+import { cardBg, cardBorder, innerCardBg, textColor, textMuted } from "./styles";
+
+// Benchmark numbers mirrored across:
+//   - this component
+//   - packages/landing/src/content/docs/guides/memory-benchmarks.md
+//   - packages/landing/src/content/docs/getting-started/comparison.md
+//   - packages/owletto/README.md (source of truth)
+// Refresh all four on each Owletto memory-benchmark release.
+// last updated: 2026-04-21
+export const LONGMEMEVAL_ROWS: BenchmarkRow[] = [
+  {
+    system: "Owletto",
+    overall: "87.1%",
+    answer: "78.0%",
+    retrieval: "100.0%",
+    latency: "237ms",
+    leader: true,
+  },
+  {
+    system: "Supermemory",
+    overall: "69.1%",
+    answer: "56.0%",
+    retrieval: "96.6%",
+    latency: "702ms",
+  },
+  {
+    system: "Mem0",
+    overall: "65.7%",
+    answer: "54.0%",
+    retrieval: "85.3%",
+    latency: "753ms",
+  },
+];
+
+export const LOCOMO_ROWS: BenchmarkRow[] = [
+  {
+    system: "Owletto",
+    overall: "57.8%",
+    answer: "38.0%",
+    retrieval: "79.5%",
+    latency: "121ms",
+    leader: true,
+  },
+  {
+    system: "Mem0",
+    overall: "41.5%",
+    answer: "28.0%",
+    retrieval: "66.9%",
+    latency: "606ms",
+  },
+  {
+    system: "Supermemory",
+    overall: "23.2%",
+    answer: "14.0%",
+    retrieval: "36.5%",
+    latency: "532ms",
+  },
+];
+
+export type BenchmarkRow = {
+  system: string;
+  overall: string;
+  answer: string;
+  retrieval: string;
+  latency: string;
+  leader?: boolean;
+};
+
+export function BenchmarkTable(props: {
+  title: string;
+  subtitle: string;
+  rows: BenchmarkRow[];
+}) {
+  return (
+    <div
+      class="rounded-2xl p-6 sm:p-8"
+      style={{
+        background: cardBg,
+        border: `1px solid ${cardBorder}`,
+      }}
+    >
+      <div class="mb-5">
+        <h3 class="text-lg font-semibold mb-1" style={{ color: textColor }}>
+          {props.title}
+        </h3>
+        <p class="text-xs leading-relaxed" style={{ color: textMuted }}>
+          {props.subtitle}
+        </p>
+      </div>
+      <div class="overflow-x-auto">
+        <table class="w-full text-sm" style={{ color: textColor }}>
+          <thead>
+            <tr
+              class="text-left text-[11px] uppercase tracking-wider"
+              style={{ color: textMuted }}
+            >
+              <th class="font-medium pb-3 pr-4">System</th>
+              <th class="font-medium pb-3 px-3 text-right">Overall</th>
+              <th class="font-medium pb-3 px-3 text-right">Answer</th>
+              <th class="font-medium pb-3 px-3 text-right">Retrieval</th>
+              <th class="font-medium pb-3 pl-3 text-right">Latency</th>
+            </tr>
+          </thead>
+          <tbody>
+            {props.rows.map((row) => (
+              <tr
+                key={row.system}
+                style={{
+                  background: row.leader ? innerCardBg : "transparent",
+                }}
+              >
+                <td
+                  class="py-2.5 pr-4 font-medium"
+                  style={{
+                    color: row.leader ? textColor : textMuted,
+                  }}
+                >
+                  {row.system}
+                </td>
+                <td
+                  class="py-2.5 px-3 text-right tabular-nums"
+                  style={{
+                    color: row.leader ? textColor : textMuted,
+                    fontWeight: row.leader ? 600 : 400,
+                  }}
+                >
+                  {row.overall}
+                </td>
+                <td
+                  class="py-2.5 px-3 text-right tabular-nums"
+                  style={{ color: row.leader ? textColor : textMuted }}
+                >
+                  {row.answer}
+                </td>
+                <td
+                  class="py-2.5 px-3 text-right tabular-nums"
+                  style={{ color: row.leader ? textColor : textMuted }}
+                >
+                  {row.retrieval}
+                </td>
+                <td
+                  class="py-2.5 pl-3 text-right tabular-nums"
+                  style={{ color: row.leader ? textColor : textMuted }}
+                >
+                  {row.latency}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}
+
+export function BenchmarkTablesGrid() {
+  return (
+    <div class="grid gap-5 md:grid-cols-2">
+      <BenchmarkTable
+        title="LongMemEval (oracle-50)"
+        subtitle="Single-session knowledge retention."
+        rows={LONGMEMEVAL_ROWS}
+      />
+      <BenchmarkTable
+        title="LoCoMo-50"
+        subtitle="Multi-session conversational memory."
+        rows={LOCOMO_ROWS}
+      />
+    </div>
+  );
+}

--- a/packages/landing/src/components/memory/BenchmarkTables.tsx
+++ b/packages/landing/src/components/memory/BenchmarkTables.tsx
@@ -1,4 +1,10 @@
-import { cardBg, cardBorder, innerCardBg, textColor, textMuted } from "./styles";
+import {
+  cardBg,
+  cardBorder,
+  innerCardBg,
+  textColor,
+  textMuted,
+} from "./styles";
 
 // Benchmark numbers mirrored across:
 //   - this component

--- a/packages/landing/src/content/docs/getting-started/comparison.md
+++ b/packages/landing/src/content/docs/getting-started/comparison.md
@@ -28,6 +28,32 @@ This page compares Lobu against the alternatives you'd evaluate when deploying a
 | **Config format** | `lobu.toml` + IDENTITY/SOUL/USER.md | CLI flags | `deepagents.toml` + AGENTS.md | Dashboard |
 | **License** | Open source | Open source | MIT (harness), proprietary (hosting) | Proprietary |
 
+## Memory benchmarks
+
+Lobu's bundled memory system (Owletto) is benchmarked against Mem0 and Supermemory on public datasets. Same answerer (`glm-5.1` via z.ai), same top-K, same questions.
+
+### LongMemEval (oracle-50)
+
+Single-session knowledge retention.
+
+| System | Overall | Answer | Retrieval | Latency |
+|---|---:|---:|---:|---:|
+| **Owletto** | **87.1%** | **78.0%** | **100.0%** | 237ms |
+| Supermemory | 69.1% | 56.0% | 96.6% | 702ms |
+| Mem0 | 65.7% | 54.0% | 85.3% | 753ms |
+
+### LoCoMo-50
+
+Multi-session conversational memory.
+
+| System | Overall | Answer | Retrieval | Latency |
+|---|---:|---:|---:|---:|
+| **Owletto** | **57.8%** | **38.0%** | **79.5%** | **121ms** |
+| Mem0 | 41.5% | 28.0% | 66.9% | 606ms |
+| Supermemory | 23.2% | 14.0% | 36.5% | 532ms |
+
+See the [memory benchmarks methodology](/guides/memory-benchmarks/) for fairness guardrails and reproduction steps, or the [harness README](https://github.com/lobu-ai/owletto/blob/main/benchmarks/memory/README.md) in the Owletto repo.
+
 ## Sandboxing and deployment modes
 
 Lobu offers three deployment modes, each with different isolation guarantees. No other platform in this space provides all three.


### PR DESCRIPTION
## Summary

- **Fix broken methodology link.** `BenchmarkSection` linked to `/docs/guides/memory-benchmarks/`, but Starlight routes docs at `/guides/...` (no `/docs/` prefix). The link now points to `/guides/memory-benchmarks/`, which is the page Astro actually emits (`dist/guides/memory-benchmarks/index.html`).
- **Extract shared BenchmarkTable component** into `packages/landing/src/components/memory/BenchmarkTables.tsx` so the homepage, `/memory`, and any future surface render the same numbers from one place.
- **Propagate the benchmarks to `/memory`** (`MemorySection`) — new section with the two tables and the fixed "Read the methodology" link, placed before the existing "Start building shared memory" CTA.
- **Propagate the benchmarks to the comparison doc** — new "Memory benchmarks" section in `docs/getting-started/comparison.md` with the same two tables plus links to the methodology page and the Owletto `benchmarks/memory/README.md`.

Numbers are identical to the existing `BenchmarkSection.tsx` / `guides/memory-benchmarks.md`. The shared component carries a single comment pointing at the four mirrored locations so they stay in sync.

## Test plan

- [x] `cd packages/landing && bun run build` — builds clean, emits `/guides/memory-benchmarks/index.html` and includes the new section in `/getting-started/comparison/index.html`
- [x] `bun run typecheck` — passes at repo root
- [ ] Manual: on a preview, click "Read the methodology" on the landing benchmark card and on the new `/memory` section — both should load the methodology page instead of 404
- [ ] Manual: verify comparison doc renders the two tables and both external links resolve