### PR TITLE
refactor(infra): bug fixes and long-term maintainability

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -54,9 +54,10 @@ jobs:
           # Trusted publishing via OIDC: npm CLI automatically exchanges the
           # GitHub Actions OIDC token for a short-lived publish token when
           # id-token: write is granted and a trusted publisher is registered
-          # on npmjs.com. No NPM_TOKEN secret is used. `--provenance`
-          # enables provenance attestations tied to this workflow run.
-          NPM_CONFIG_PROVENANCE: "true"
+          # on npmjs.com. No NPM_TOKEN secret is used.
+          # NPM_CONFIG_PROVENANCE enables provenance attestations when the
+          # provenance input is true (requires trusted publisher on npmjs.com).
+          NPM_CONFIG_PROVENANCE: "${{ inputs.provenance }}"
         run: |
           if [ "${{ inputs.bump }}" = "skip" ]; then
             node scripts/publish-packages.mjs --skip-bump

--- a/charts/lobu/templates/gateway-deployment.yaml
+++ b/charts/lobu/templates/gateway-deployment.yaml
@@ -228,7 +228,7 @@ spec:
             # Admin password (direct value override, not in sealed secrets)
             {{- if .Values.secrets.adminPassword }}
             - name: ADMIN_PASSWORD
-              value: "{{ .Values.secrets.adminPassword }}"
+              value: {{ .Values.secrets.adminPassword | quote }}
             {{- end }}
           volumeMounts:
             # Tmpfs for tsx and other temp files (required for readOnlyRootFilesystem)

--- a/charts/lobu/templates/limit-range.yaml
+++ b/charts/lobu/templates/limit-range.yaml
@@ -68,10 +68,6 @@ spec:
   limits:
   # More restrictive limits for worker containers
   - type: Container
-    # Apply to containers with worker label
-    selector:
-      matchLabels:
-        component: worker
     default:
       cpu: {{ .Values.limitRange.worker.default.cpu | default "1" }}
       memory: {{ .Values.limitRange.worker.default.memory | default "2Gi" }}

--- a/charts/lobu/templates/network-policy.yaml
+++ b/charts/lobu/templates/network-policy.yaml
@@ -9,11 +9,12 @@ metadata:
 spec:
   podSelector:
     matchLabels:
-      app: {{ include "lobu.name" . }}
+      {{- include "lobu.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: gateway
   policyTypes:
   - Ingress
   - Egress
-  
+
   # Ingress rules - only allow traffic from within namespace and to gateway
   ingress:
   - from:
@@ -22,7 +23,7 @@ spec:
           name: {{ .Values.kubernetes.namespace }}
     - podSelector:
         matchLabels:
-          app: {{ include "lobu.name" . }}
+          {{- include "lobu.selectorLabels" . | nindent 10 }}
     ports:
     - protocol: TCP
       port: 8080

--- a/charts/lobu/templates/pod-disruption-budget.yaml
+++ b/charts/lobu/templates/pod-disruption-budget.yaml
@@ -16,8 +16,8 @@ spec:
   {{- end }}
   selector:
     matchLabels:
-      app: {{ include "lobu.name" . }}
-      component: gateway
+      {{- include "lobu.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: gateway
 
 ---
 # PDB for worker jobs - allow more disruption since they are transient
@@ -29,7 +29,7 @@ metadata:
   namespace: {{ .Values.kubernetes.namespace }}
   labels:
     {{- include "lobu.labels" . | nindent 4 }}
-    component: worker
+    app.kubernetes.io/component: worker
 spec:
   # Allow more aggressive disruption for worker pods
   {{- if .Values.podDisruptionBudget.worker.minAvailable }}
@@ -39,8 +39,7 @@ spec:
   {{- end }}
   selector:
     matchLabels:
-      app: {{ include "lobu.name" . }}
-      component: worker
+      app.kubernetes.io/component: worker
 {{- end }}
 
 {{- end }}

--- a/charts/lobu/templates/sealed-secrets.yaml
+++ b/charts/lobu/templates/sealed-secrets.yaml
@@ -35,7 +35,7 @@ metadata:
 spec:
   encryptedData:
     {{- range $key, $value := .Values.sealedSecrets.encryptedData }}
-    {{ $key }}: {{ $value }}
+    {{ $key }}: {{ $value | quote }}
     {{- end }}
   template:
     metadata:

--- a/charts/lobu/templates/servicemonitor.yaml
+++ b/charts/lobu/templates/servicemonitor.yaml
@@ -21,7 +21,7 @@ spec:
     matchNames:
       - {{ .Values.kubernetes.namespace }}
   endpoints:
-    - port: health-proxy
+    - port: http
       path: /metrics
       interval: {{ .Values.metrics.serviceMonitor.interval | default "30s" }}
       scrapeTimeout: {{ .Values.metrics.serviceMonitor.scrapeTimeout | default "10s" }}

--- a/scripts/lib/secret-args.sh
+++ b/scripts/lib/secret-args.sh
@@ -14,25 +14,25 @@
 
 build_secret_args() {
   # Slack credentials
-  [[ -n "$SLACK_BOT_TOKEN" ]] && SECRET_ARGS+=(--from-literal=slack-bot-token="$SLACK_BOT_TOKEN")
-  [[ -n "$SLACK_APP_TOKEN" ]] && SECRET_ARGS+=(--from-literal=slack-app-token="$SLACK_APP_TOKEN")
-  [[ -n "$SLACK_SIGNING_SECRET" ]] && SECRET_ARGS+=(--from-literal=slack-signing-secret="$SLACK_SIGNING_SECRET")
-  [[ -n "$SLACK_CLIENT_ID" ]] && SECRET_ARGS+=(--from-literal=slack-client-id="$SLACK_CLIENT_ID")
-  [[ -n "$SLACK_CLIENT_SECRET" ]] && SECRET_ARGS+=(--from-literal=slack-client-secret="$SLACK_CLIENT_SECRET")
+  [[ -n "${SLACK_BOT_TOKEN:-}" ]] && SECRET_ARGS+=(--from-literal=slack-bot-token="$SLACK_BOT_TOKEN")
+  [[ -n "${SLACK_APP_TOKEN:-}" ]] && SECRET_ARGS+=(--from-literal=slack-app-token="$SLACK_APP_TOKEN")
+  [[ -n "${SLACK_SIGNING_SECRET:-}" ]] && SECRET_ARGS+=(--from-literal=slack-signing-secret="$SLACK_SIGNING_SECRET")
+  [[ -n "${SLACK_CLIENT_ID:-}" ]] && SECRET_ARGS+=(--from-literal=slack-client-id="$SLACK_CLIENT_ID")
+  [[ -n "${SLACK_CLIENT_SECRET:-}" ]] && SECRET_ARGS+=(--from-literal=slack-client-secret="$SLACK_CLIENT_SECRET")
 
   # Claude/Anthropic credentials
-  [[ -n "$ANTHROPIC_API_KEY" ]] && SECRET_ARGS+=(--from-literal=anthropic-api-key="$ANTHROPIC_API_KEY")
-  [[ -n "$CLAUDE_CODE_OAUTH_TOKEN" ]] && SECRET_ARGS+=(--from-literal=claude-code-oauth-token="$CLAUDE_CODE_OAUTH_TOKEN")
+  [[ -n "${ANTHROPIC_API_KEY:-}" ]] && SECRET_ARGS+=(--from-literal=anthropic-api-key="$ANTHROPIC_API_KEY")
+  [[ -n "${CLAUDE_CODE_OAUTH_TOKEN:-}" ]] && SECRET_ARGS+=(--from-literal=claude-code-oauth-token="$CLAUDE_CODE_OAUTH_TOKEN")
 
   # Encryption key
-  [[ -n "$ENCRYPTION_KEY" ]] && SECRET_ARGS+=(--from-literal=encryption-key="$ENCRYPTION_KEY")
+  [[ -n "${ENCRYPTION_KEY:-}" ]] && SECRET_ARGS+=(--from-literal=encryption-key="$ENCRYPTION_KEY")
 
   # Sentry
-  [[ -n "$SENTRY_DSN" ]] && SECRET_ARGS+=(--from-literal=sentry-dsn="$SENTRY_DSN")
+  [[ -n "${SENTRY_DSN:-}" ]] && SECRET_ARGS+=(--from-literal=sentry-dsn="$SENTRY_DSN")
 
   # GitHub
-  [[ -n "$GITHUB_CLIENT_SECRET" ]] && SECRET_ARGS+=(--from-literal=github-client-secret="$GITHUB_CLIENT_SECRET")
+  [[ -n "${GITHUB_CLIENT_SECRET:-}" ]] && SECRET_ARGS+=(--from-literal=github-client-secret="$GITHUB_CLIENT_SECRET")
 
   # Telegram
-  [[ -n "$TELEGRAM_BOT_TOKEN" ]] && SECRET_ARGS+=(--from-literal=telegram-bot-token="$TELEGRAM_BOT_TOKEN")
+  [[ -n "${TELEGRAM_BOT_TOKEN:-}" ]] && SECRET_ARGS+=(--from-literal=telegram-bot-token="$TELEGRAM_BOT_TOKEN")
 }

--- a/scripts/publish-packages.mjs
+++ b/scripts/publish-packages.mjs
@@ -181,6 +181,7 @@ async function main() {
   } else {
     console.log("\n[2/3] Building packages");
     run("bun", ["run", "build:packages"]);
+    run("bun", ["run", "build:owletto"]);
   }
 
   console.log("\n[3/3] Publishing to npm");

--- a/scripts/seal-env.sh
+++ b/scripts/seal-env.sh
@@ -10,7 +10,7 @@
 #   ./scripts/seal-env.sh -o values.yaml     # Output to file
 #   ./scripts/seal-env.sh --apply            # Apply directly to cluster
 
-set -e
+set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
@@ -83,12 +83,7 @@ SEALED_SECRET=$(kubectl create secret generic lobu-secrets \
   "${SECRET_ARGS[@]}" \
   --dry-run=client -o yaml | \
 kubeseal --controller-name=sealed-secrets-controller --controller-namespace=kube-system \
-  --scope namespace-wide --format yaml 2>/dev/null)
-
-if [[ $? -ne 0 ]]; then
-  echo "Error: Failed to seal secrets. Is the Sealed Secrets controller running?" >&2
-  exit 1
-fi
+  --scope namespace-wide --format yaml)
 
 if [[ "$APPLY_DIRECT" == "true" ]]; then
   echo "$SEALED_SECRET" | kubectl apply -f -

--- a/scripts/setup-dev.sh
+++ b/scripts/setup-dev.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -e
+set -euo pipefail
 
 # Check dependencies
 command -v bun >/dev/null || { echo "Install bun: curl -fsSL https://bun.sh/install | bash"; exit 1; }

--- a/scripts/sync-env-to-k8s.sh
+++ b/scripts/sync-env-to-k8s.sh
@@ -5,7 +5,7 @@
 #   ./scripts/sync-env-to-k8s.sh                # Sync to lobu namespace
 #   ./scripts/sync-env-to-k8s.sh -n my-ns       # Sync to custom namespace
 
-set -e
+set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"

--- a/scripts/sync-env-to-values.sh
+++ b/scripts/sync-env-to-values.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euo pipefail
 
 # Sync .env values to Helm values.yaml
 # Usage: ./scripts/sync-env-to-values.sh [values-file] [environment]

--- a/scripts/sync-env-to-values.sh
+++ b/scripts/sync-env-to-values.sh
@@ -17,15 +17,17 @@ if ! command -v yq >/dev/null 2>&1; then
 fi
 
 # Determine values file based on environment or explicit path
-if [ -n "$2" ]; then
+ARG1="${1:-}"
+ARG2="${2:-}"
+if [ -n "$ARG2" ]; then
     # Environment specified (dev, production, local)
-    VALUES_FILE="charts/lobu/values-$2.yaml"
-elif [ -n "$1" ] && [[ "$1" == *.yaml ]]; then
+    VALUES_FILE="charts/lobu/values-$ARG2.yaml"
+elif [ -n "$ARG1" ] && [[ "$ARG1" == *.yaml ]]; then
     # Explicit values file path provided
-    VALUES_FILE="$1"
-elif [ -n "$1" ]; then
+    VALUES_FILE="$ARG1"
+elif [ -n "$ARG1" ]; then
     # Environment name provided as first argument
-    VALUES_FILE="charts/lobu/values-$1.yaml"
+    VALUES_FILE="charts/lobu/values-$ARG1.yaml"
 else
     # Default to base values.yaml
     VALUES_FILE="charts/lobu/values.yaml"
@@ -65,37 +67,37 @@ update_yaml_value() {
 }
 
 # Sync orchestrator configuration
-if [ -n "$MAX_WORKER_DEPLOYMENTS" ]; then
+if [ -n "${MAX_WORKER_DEPLOYMENTS:-}" ]; then
     update_yaml_value "MAX_WORKER_DEPLOYMENTS" "$MAX_WORKER_DEPLOYMENTS" ".orchestrator.maxWorkerDeployments"
 fi
 
-if [ -n "$WORKER_IDLE_CLEANUP_MINUTES" ]; then
+if [ -n "${WORKER_IDLE_CLEANUP_MINUTES:-}" ]; then
     update_yaml_value "WORKER_IDLE_CLEANUP_MINUTES" "$WORKER_IDLE_CLEANUP_MINUTES" ".orchestrator.idleCleanupMinutes"
 fi
 
 # Sync worker configuration
-if [ -n "$WORKER_CPU_LIMIT" ]; then
+if [ -n "${WORKER_CPU_LIMIT:-}" ]; then
     update_yaml_value "WORKER_CPU_LIMIT" "$WORKER_CPU_LIMIT" ".worker.resources.limits.cpu"
 fi
 
-if [ -n "$WORKER_MEMORY_LIMIT" ]; then
+if [ -n "${WORKER_MEMORY_LIMIT:-}" ]; then
     update_yaml_value "WORKER_MEMORY_LIMIT" "$WORKER_MEMORY_LIMIT" ".worker.resources.limits.memory"
 fi
 
-if [ -n "$WORKER_CPU_REQUEST" ]; then
+if [ -n "${WORKER_CPU_REQUEST:-}" ]; then
     update_yaml_value "WORKER_CPU_REQUEST" "$WORKER_CPU_REQUEST" ".worker.resources.requests.cpu"
 fi
 
-if [ -n "$WORKER_MEMORY_REQUEST" ]; then
+if [ -n "${WORKER_MEMORY_REQUEST:-}" ]; then
     update_yaml_value "WORKER_MEMORY_REQUEST" "$WORKER_MEMORY_REQUEST" ".worker.resources.requests.memory"
 fi
 
 # Sync agent model configuration
-if [ -n "$AGENT_DEFAULT_MODEL" ]; then
+if [ -n "${AGENT_DEFAULT_MODEL:-}" ]; then
     update_yaml_value "AGENT_DEFAULT_MODEL" "$AGENT_DEFAULT_MODEL" ".claude.model"
 fi
 
-if [ -n "$CLAUDE_TIMEOUT_MINUTES" ]; then
+if [ -n "${CLAUDE_TIMEOUT_MINUTES:-}" ]; then
     update_yaml_value "CLAUDE_TIMEOUT_MINUTES" "$CLAUDE_TIMEOUT_MINUTES" ".claude.timeoutMinutes"
 fi
 

--- a/scripts/test-bot.sh
+++ b/scripts/test-bot.sh
@@ -47,7 +47,7 @@ fetch_telegram_bot_peer() {
 resolve_tguser_python() {
     local tguser_bin shebang interpreter exec_python
 
-    if [ -n "$TGUSER_PYTHON" ] && [ -x "$TGUSER_PYTHON" ]; then
+    if [ -n "${TGUSER_PYTHON:-}" ] && [ -x "$TGUSER_PYTHON" ]; then
         printf '%s\n' "$TGUSER_PYTHON"
         return
     fi

--- a/scripts/test-bot.sh
+++ b/scripts/test-bot.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -e
+set -euo pipefail
 
 # Bot testing script with multi-message and multi-platform support
 # Usage: ./scripts/test-bot.sh "message 1" ["message 2"] ["message 3"] ...


### PR DESCRIPTION
## Summary

- **Shell strictness**: Added `set -euo pipefail` to `seal-env.sh`, `sync-env-to-k8s.sh`, `sync-env-to-values.sh`, `setup-dev.sh`, and `test-bot.sh`. Removed a dead `$?` check in `seal-env.sh` (unreachable with `set -e`, stale after pipe assignment).
- **Helm: ServiceMonitor wrong port** (`servicemonitor.yaml`): scrape port was `health-proxy` — that name does not exist in `service.yaml` (ports are `http`/`http-proxy`). Fixes: metrics were never scraped.
- **Helm: PDB selector mismatch** (`pod-disruption-budget.yaml`): used bare `app:` + `component:` labels; pods use `app.kubernetes.io/name` + `app.kubernetes.io/component`. PDB was selecting zero pods and providing no protection.
- **Helm: NetworkPolicy selector mismatch** (`network-policy.yaml`): gateway `podSelector` used `app:` label. Same mismatch — the policy was applied to no pods.
- **Helm: Invalid LimitRange field** (`limit-range.yaml`): worker LimitRange item had `selector.matchLabels` which does not exist in the K8s `LimitRange` API; apiserver would reject the manifest at apply time.
- **Helm: Unquoted secret value** (`gateway-deployment.yaml`): `ADMIN_PASSWORD` used bare string interpolation; special characters break YAML. Added `| quote`.
- **Helm: Unquoted sealed values** (`sealed-secrets.yaml`): encrypted data values not quoted; certain base64 characters can break YAML parsing. Added `| quote`.
- **Publish flow — missing owletto build** (`publish-packages.mjs`): `owletto-sdk`, `owletto-openclaw`, `owletto-cli` are in `PACKAGES` but the `build:packages` script does not build them. Added `build:owletto` step before publish so those packages are not published from stale or empty `dist/`.
- **Publish flow — hardcoded provenance** (`publish-packages.yml`): `NPM_CONFIG_PROVENANCE` was hardcoded `true` regardless of the `provenance` workflow input. Now reads `${{ inputs.provenance }}`.

## ENEEDAUTH root cause (publish)

The script-side issues above (missing owletto build, provenance always-true) are fixed. The **primary cause of `ENEEDAUTH`** is external: each package must be individually registered on npmjs.com under Settings → Publishing → Add Trusted Publisher → Workflow: `publish-packages.yml`, Environment: `production`. Without that per-package registration, npm rejects OIDC token exchange with ENEEDAUTH even when `id-token: write` is correctly granted. No code change can fix this — it requires action on npmjs.com for each package.

## Test plan

- [ ] `bash -n scripts/*.sh` — all pass (run locally, confirmed clean)
- [ ] `helm lint charts/lobu` — 0 failures
- [ ] `bun run build:packages` — succeeds
- [ ] TypeScript typecheck — passes (pre-commit hook confirmed)