### PR TITLE
refactor(owletto): bug fixes and long-term maintainability

### DIFF
--- a/packages/owletto-openclaw/src/index.ts
+++ b/packages/owletto-openclaw/src/index.ts
@@ -350,12 +350,6 @@ function hasAuthConfigured(config: ResolvedPluginConfig): boolean {
   return !!(sessionToken || config.token || config.tokenCommand);
 }
 
-// Cached result of gateway auth status check
-// In standalone mode, tracks whether gateway device-auth has completed.
-// In gateway mode this is unused — hasAuthConfigured always returns true
-// and the proxy handles credential management automatically.
-let _gatewayAuthStatus = false;
-
 function getWorkerToken(): string | null {
   return asString(process.env.WORKER_TOKEN);
 }
@@ -1077,7 +1071,6 @@ const plugin = {
               // Check if already authenticated via gateway
               const alreadyAuth = await gatewayDeviceAuthCheck(config.gatewayAuthUrl);
               if (alreadyAuth) {
-                _gatewayAuthStatus = true;
                 return {
                   content: [
                     {
@@ -1184,7 +1177,6 @@ const plugin = {
               const result = await gatewayDeviceAuthPoll(config.gatewayAuthUrl);
 
               if (result.status === 'complete') {
-                _gatewayAuthStatus = true;
                 log.info('owletto: gateway device auth completed');
 
                 // Fetch workspace instructions now that we're authenticated

--- a/packages/owletto-worker/src/daemon/client.ts
+++ b/packages/owletto-worker/src/daemon/client.ts
@@ -33,6 +33,7 @@ export interface ExecutorClient {
   ): Promise<void>;
   stream(batch: StreamBatch): Promise<void>;
   complete(req: CompleteRequest): Promise<void>;
+  completeAction(req: CompleteActionRequest): Promise<void>;
   fetchEventsForEmbedding(eventIds: number[]): Promise<EmbedEvent[]>;
   completeEmbeddings(req: CompleteEmbeddingsRequest): Promise<void>;
   emitAuthArtifact(req: EmitAuthArtifactRequest): Promise<void>;

--- a/packages/owletto-worker/src/daemon/executor.ts
+++ b/packages/owletto-worker/src/daemon/executor.ts
@@ -282,22 +282,12 @@ async function executeActionRun(
     // For actions, the "contents" array may contain a single result envelope
     const actionOutput = getActionOutput(result);
 
-    // Use completeAction if available, otherwise fall back to complete
-    if ('completeAction' in client && typeof (client as any).completeAction === 'function') {
-      await (client as any).completeAction({
-        run_id,
-        worker_id: client.id,
-        status: 'success',
-        action_output: actionOutput,
-      });
-    } else {
-      await client.complete({
-        run_id,
-        worker_id: client.id,
-        status: 'success',
-        items_collected: 0,
-      });
-    }
+    await client.completeAction({
+      run_id,
+      worker_id: client.id,
+      status: 'success',
+      action_output: actionOutput,
+    });
 
     console.error(`[executor] Action run ${run_id} completed`);
     return { itemsCollected: 0 };
@@ -305,21 +295,12 @@ async function executeActionRun(
     const errorMessage = error instanceof Error ? error.message : String(error);
     console.error(`[executor] Action run ${run_id} failed:`, errorMessage);
 
-    if ('completeAction' in client && typeof (client as any).completeAction === 'function') {
-      await (client as any).completeAction({
-        run_id,
-        worker_id: client.id,
-        status: 'failed',
-        error_message: errorMessage,
-      });
-    } else {
-      await client.complete({
-        run_id,
-        worker_id: client.id,
-        status: 'failed',
-        error_message: errorMessage,
-      });
-    }
+    await client.completeAction({
+      run_id,
+      worker_id: client.id,
+      status: 'failed',
+      error_message: errorMessage,
+    });
 
     return { itemsCollected: 0, error: errorMessage };
   }
@@ -460,8 +441,25 @@ async function executeEmbedBackfillRun(
   }
 
   // Parse event_ids from action_input
-  const input = typeof action_input === 'string' ? JSON.parse(action_input) : action_input;
-  const eventIds: number[] = input?.event_ids ?? [];
+  let input: Record<string, unknown> | null | undefined;
+  if (typeof action_input === 'string') {
+    try {
+      input = JSON.parse(action_input);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      console.error(`[executor] Embed backfill run ${run_id}: invalid action_input JSON:`, msg);
+      await client.complete({
+        run_id,
+        worker_id: client.id,
+        status: 'failed',
+        error_message: `Invalid action_input JSON: ${msg}`,
+      });
+      return { itemsCollected: 0, error: `Invalid action_input JSON: ${msg}` };
+    }
+  } else {
+    input = action_input;
+  }
+  const eventIds: number[] = (input?.event_ids as number[]) ?? [];
 
   if (eventIds.length === 0) {
     console.error(`[executor] Embed backfill run ${run_id}: no event_ids`);


### PR DESCRIPTION
## Summary

Narrow pass through the Owletto packages (owletto-backend, owletto-sdk, owletto-connectors, owletto-embeddings, owletto-openclaw, owletto-worker) for real bugs, dead code, and defensive checks at internal boundaries. Touched only 3 files; most of the surface area looked clean.

## Changes

- **packages/owletto-worker/src/daemon/executor.ts:463** — Wrap \`JSON.parse(action_input)\` for embed_backfill runs in try/catch. A malformed payload would previously throw out of \`executeRun\`, which the daemon's \`pollAndExecute\` catch does not propagate to the API, so the run would stay stuck and the daemon would log \`crashed\` instead of reporting a failed run. Now it reports the run as \`failed\` with a clear error.
- **packages/owletto-worker/src/daemon/executor.ts:286-322** — Remove the \`'completeAction' in client\` runtime type guards in \`executeActionRun\`. \`WorkerClient\` is the sole implementation of \`ExecutorClient\` and always has \`completeAction\`; the fallback to \`complete\` was dead defensive code that silently swallowed the action result on the failure path.
- **packages/owletto-worker/src/daemon/client.ts:36** — Add \`completeAction(req: CompleteActionRequest)\` to \`ExecutorClient\` so callers do not need to cast through \`as any\`.
- **packages/owletto-openclaw/src/index.ts** — Remove the write-only \`_gatewayAuthStatus\` module variable (set in two branches, never read). Auth status is always re-checked via \`gatewayDeviceAuthCheck\` on every call.

## Unresolved findings (not fixed — out of scope or too risky)

- \`packages/owletto-backend/src/db/client.ts:150\` — \`createDbClientFromEnv(env)\` ignores \`env\` and just returns \`getDb()\`. Used across 30+ call sites in auth/routes, mcp-handler, tools — cleanup is a larger PR.
- \`packages/owletto-sdk/src/retry.ts\` — \`isDatabaseError\` triggers retry on things like \`'syntax error'\` and \`'relation does not exist'\` from an SDK used by connectors (external API callers). Retrying a SQL syntax error is pointless but harmless. SDK is published, skipping.
- \`packages/owletto-backend/src/connect/oauth-providers.ts:215-218\` — On failed OAuth token exchange, the raw provider response body is logged at \`error\` level. Providers shouldn't return tokens in error bodies, but some echo back submitted fields. Worth a follow-up to redact.

## Test plan

- [x] \`make build-packages\` passes (core/gateway/worker build clean)
- [x] \`bun run typecheck\` passes at repo root
- [x] Pre-existing owletto-worker \`tsc\` errors (\`workerApiToken\` required, missing \`embeddings-service/src/embedding-utils\` path) are unchanged by this PR