### PR TITLE
refactor(gateway): bug fixes and long-term maintainability

### DIFF
--- a/packages/gateway/src/__tests__/worker-gateway-session-context.test.ts
+++ b/packages/gateway/src/__tests__/worker-gateway-session-context.test.ts
@@ -25,7 +25,6 @@ describe("WorkerGateway session context", () => {
     const gateway = new WorkerGateway(
       { send: async () => undefined } as any,
       "https://gateway.example.com",
-      {} as any,
       {
         getWorkerConfig: async () => ({ mcpServers: {} }),
       } as any,

--- a/packages/gateway/src/__tests__/worker-job-router.test.ts
+++ b/packages/gateway/src/__tests__/worker-job-router.test.ts
@@ -6,7 +6,6 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { WorkerConnectionManager } from "../gateway/connection-manager";
 import { WorkerJobRouter } from "../gateway/job-router";
-import type { ISessionManager } from "../session";
 import {
   cleanupTestEnv,
   MockMessageQueue,
@@ -19,36 +18,13 @@ describe("WorkerJobRouter", () => {
   let queue: MockMessageQueue;
   let connectionManager: WorkerConnectionManager;
   let router: WorkerJobRouter;
-  let mockSessionManager: ISessionManager;
 
   beforeEach(() => {
     setupTestEnv();
     queue = new MockMessageQueue();
     connectionManager = new WorkerConnectionManager();
 
-    // Create mock session manager
-    mockSessionManager = {
-      findSessionByThread: async () => null,
-      updateSession: async () => {
-        /* noop */
-      },
-      createSession: async () => ({}) as any,
-      getSession: async () => null,
-      setSession: async () => {
-        /* noop */
-      },
-      deleteSession: async () => {
-        /* noop */
-      },
-      validateThreadOwnership: async () => ({ allowed: true }),
-      cleanupExpired: async () => 0,
-    };
-
-    router = new WorkerJobRouter(
-      queue as any,
-      connectionManager,
-      mockSessionManager
-    );
+    router = new WorkerJobRouter(queue as any, connectionManager);
   });
 
   afterEach(() => {

--- a/packages/gateway/src/auth/mcp/oauth-discovery.ts
+++ b/packages/gateway/src/auth/mcp/oauth-discovery.ts
@@ -497,4 +497,3 @@ export async function discoverOAuth(
 
   return result;
 }
-

--- a/packages/gateway/src/auth/mcp/oauth-discovery.ts
+++ b/packages/gateway/src/auth/mcp/oauth-discovery.ts
@@ -498,32 +498,3 @@ export async function discoverOAuth(
   return result;
 }
 
-/**
- * Invalidate cached discovery for a single `(mcpId, agentId, upstreamUrl)`.
- * Called on logout or when a refresh indicates the server has rotated endpoints.
- */
-export async function invalidateDiscovery(
-  redis: Redis,
-  secretStore: WritableSecretStore,
-  mcpId: string,
-  agentId: string,
-  upstreamUrl: string
-): Promise<void> {
-  const keys = [
-    discoveryCacheKey(mcpId, agentId, upstreamUrl),
-    clientCacheKey(mcpId, agentId, upstreamUrl),
-  ];
-  for (const key of keys) {
-    const raw = await redis.get(key).catch(() => null);
-    if (!raw) continue;
-    try {
-      const pointer = JSON.parse(raw) as SecretPointer;
-      if (typeof pointer.secretRef === "string") {
-        await secretStore.delete(pointer.secretRef).catch(() => undefined);
-      }
-    } catch {
-      /* ignore corrupt pointer */
-    }
-    await redis.del(key).catch(() => undefined);
-  }
-}

--- a/packages/gateway/src/cli/gateway.ts
+++ b/packages/gateway/src/cli/gateway.ts
@@ -969,7 +969,7 @@ export function startGatewayServer(app: OpenAPIHono, port = 8080): Server {
  * Handle Express-style handler with Hono context
  */
 async function handleExpressHandler(c: any, handler: any): Promise<Response> {
-  const { req, res, responsePromise } = createExpressCompatObjects(c);
+  const { req, res, responsePromise } = await createExpressCompatObjects(c);
   await handler(req, res);
   return responsePromise;
 }
@@ -977,7 +977,7 @@ async function handleExpressHandler(c: any, handler: any): Promise<Response> {
 /**
  * Create Express-compatible request/response objects from Hono context
  */
-function createExpressCompatObjects(c: any, overridePath?: string) {
+async function createExpressCompatObjects(c: any, overridePath?: string) {
   let resolveResponse: (response: Response) => void;
   const responsePromise = new Promise<Response>((resolve) => {
     resolveResponse = resolve;
@@ -1113,20 +1113,16 @@ function createExpressCompatObjects(c: any, overridePath?: string) {
 
   if (["POST", "PUT", "PATCH"].includes(c.req.method)) {
     const contentType = c.req.header("content-type") || "";
-    c.req.raw
-      .clone()
-      .arrayBuffer()
-      .then((buffer: ArrayBuffer) => {
-        if (contentType.includes("application/json")) {
-          try {
-            req.body = JSON.parse(new TextDecoder().decode(buffer));
-          } catch {
-            req.body = buffer;
-          }
-        } else {
-          req.body = buffer;
-        }
-      });
+    const buffer = await c.req.raw.clone().arrayBuffer();
+    if (contentType.includes("application/json")) {
+      try {
+        req.body = JSON.parse(new TextDecoder().decode(buffer));
+      } catch {
+        req.body = buffer;
+      }
+    } else {
+      req.body = buffer;
+    }
   }
 
   return { req, res, responsePromise };

--- a/packages/gateway/src/connections/chat-instance-manager.ts
+++ b/packages/gateway/src/connections/chat-instance-manager.ts
@@ -49,7 +49,7 @@ function configsEqual(
 }
 
 const logger = createLogger("chat-instance-manager");
-export const ADAPTER_FACTORIES: Record<string, (config: any) => Promise<any>> =
+const ADAPTER_FACTORIES: Record<string, (config: any) => Promise<any>> =
   {
     telegram: async (c) =>
       (await import("@chat-adapter/telegram")).createTelegramAdapter(c),

--- a/packages/gateway/src/connections/chat-instance-manager.ts
+++ b/packages/gateway/src/connections/chat-instance-manager.ts
@@ -49,21 +49,20 @@ function configsEqual(
 }
 
 const logger = createLogger("chat-instance-manager");
-const ADAPTER_FACTORIES: Record<string, (config: any) => Promise<any>> =
-  {
-    telegram: async (c) =>
-      (await import("@chat-adapter/telegram")).createTelegramAdapter(c),
-    slack: async (c) =>
-      (await import("@chat-adapter/slack")).createSlackAdapter(c),
-    discord: async (c) =>
-      (await import("@chat-adapter/discord")).createDiscordAdapter(c),
-    whatsapp: async (c) =>
-      (await import("@chat-adapter/whatsapp")).createWhatsAppAdapter(c),
-    teams: async (c) =>
-      (await import("@chat-adapter/teams")).createTeamsAdapter(c),
-    gchat: async (c) =>
-      (await import("@chat-adapter/gchat")).createGoogleChatAdapter(c),
-  };
+const ADAPTER_FACTORIES: Record<string, (config: any) => Promise<any>> = {
+  telegram: async (c) =>
+    (await import("@chat-adapter/telegram")).createTelegramAdapter(c),
+  slack: async (c) =>
+    (await import("@chat-adapter/slack")).createSlackAdapter(c),
+  discord: async (c) =>
+    (await import("@chat-adapter/discord")).createDiscordAdapter(c),
+  whatsapp: async (c) =>
+    (await import("@chat-adapter/whatsapp")).createWhatsAppAdapter(c),
+  teams: async (c) =>
+    (await import("@chat-adapter/teams")).createTeamsAdapter(c),
+  gchat: async (c) =>
+    (await import("@chat-adapter/gchat")).createGoogleChatAdapter(c),
+};
 
 interface ManagedInstance {
   connection: PlatformConnection;

--- a/packages/gateway/src/connections/conversation-state-store.ts
+++ b/packages/gateway/src/connections/conversation-state-store.ts
@@ -23,10 +23,10 @@ type HistoryChannelIndex = Record<string, number>;
 
 export const MAX_HISTORY_MESSAGES = 10;
 export const HISTORY_TTL_MS = 86_400_000; // 24 hours
-export const SESSION_TTL_MS = DEFAULTS.SESSION_TTL_MS;
+const SESSION_TTL_MS = DEFAULTS.SESSION_TTL_MS;
 const HISTORY_INDEX_LOCK_TTL_MS = 5_000;
 
-export function historyKey(connectionId: string, channelId: string): string {
+function historyKey(connectionId: string, channelId: string): string {
   return `history:${connectionId}:${channelId}`;
 }
 

--- a/packages/gateway/src/connections/platform-strategies/index.ts
+++ b/packages/gateway/src/connections/platform-strategies/index.ts
@@ -99,7 +99,7 @@ export interface PlatformResponseStrategy {
  * `target.post(AsyncIterable)` path. Used for Telegram and anything without
  * platform-specific buffering requirements.
  */
-export class DefaultResponseStrategy implements PlatformResponseStrategy {
+class DefaultResponseStrategy implements PlatformResponseStrategy {
   async disposeOnFullReplacement(existing: StreamState): Promise<void> {
     // Close current stream and await delivery so a new one can open cleanly.
     existing.iterator.close();
@@ -360,7 +360,7 @@ async function postSlackMarkdown(
  * Buffer-and-post on completion gives us paragraph-aligned chunks AND
  * markdown-native rendering.
  */
-export class SlackResponseStrategy implements PlatformResponseStrategy {
+class SlackResponseStrategy implements PlatformResponseStrategy {
   async disposeOnFullReplacement(_existing: StreamState): Promise<void> {
     // Slack never opens a real streaming target — no async teardown needed.
     // The bridge simply drops the prior state so the next delta opens a
@@ -455,7 +455,7 @@ export class SlackResponseStrategy implements PlatformResponseStrategy {
  * Kept as a named subclass so future Telegram-specific tweaks have an obvious
  * home and the bridge's strategy map reads explicitly.
  */
-export class TelegramResponseStrategy extends DefaultResponseStrategy {}
+class TelegramResponseStrategy extends DefaultResponseStrategy {}
 
 const slackStrategy = new SlackResponseStrategy();
 const telegramStrategy = new TelegramResponseStrategy();

--- a/packages/gateway/src/gateway/index.ts
+++ b/packages/gateway/src/gateway/index.ts
@@ -20,7 +20,6 @@ import { resolveEffectiveModelRef } from "../auth/settings/model-selection";
 import type { IMessageQueue } from "../infrastructure/queue";
 import type { InstructionService } from "../services/instruction-service";
 import type { SettingsResolver } from "../services/settings-resolver";
-import type { ISessionManager } from "../session";
 import { type SSEWriter, WorkerConnectionManager } from "./connection-manager";
 import { WorkerJobRouter } from "./job-router";
 
@@ -47,7 +46,6 @@ export class WorkerGateway {
   constructor(
     queue: IMessageQueue,
     publicGatewayUrl: string,
-    sessionManager: ISessionManager,
     mcpConfigService: McpConfigService,
     instructionService: InstructionService,
     mcpProxy?: McpProxy,
@@ -58,11 +56,7 @@ export class WorkerGateway {
     this.queue = queue;
     this.publicGatewayUrl = publicGatewayUrl;
     this.connectionManager = new WorkerConnectionManager();
-    this.jobRouter = new WorkerJobRouter(
-      queue,
-      this.connectionManager,
-      sessionManager
-    );
+    this.jobRouter = new WorkerJobRouter(queue, this.connectionManager);
     this.mcpConfigService = mcpConfigService;
     this.instructionService = instructionService;
     this.mcpProxy = mcpProxy;

--- a/packages/gateway/src/gateway/job-router.ts
+++ b/packages/gateway/src/gateway/job-router.ts
@@ -2,7 +2,6 @@
 
 import { createLogger } from "@lobu/core";
 import type { IMessageQueue } from "../infrastructure/queue";
-import type { ISessionManager } from "../session";
 import type { WorkerConnectionManager } from "./connection-manager";
 
 const logger = createLogger("worker-job-router");
@@ -23,8 +22,7 @@ export class WorkerJobRouter {
 
   constructor(
     private queue: IMessageQueue,
-    private connectionManager: WorkerConnectionManager,
-    _sessionManager: ISessionManager
+    private connectionManager: WorkerConnectionManager
   ) {}
 
   /**

--- a/packages/gateway/src/orchestration/index.ts
+++ b/packages/gateway/src/orchestration/index.ts
@@ -32,6 +32,7 @@ export class Orchestrator {
   private isRunning = false;
   private shuttingDown = false;
   private cleanupInterval?: NodeJS.Timeout;
+  private initialReconcileTimer?: NodeJS.Timeout;
   private activeReconciliation: Promise<void> | null = null;
   private isReconciling = false;
 
@@ -231,6 +232,10 @@ export class Orchestrator {
         clearInterval(this.cleanupInterval);
         this.cleanupInterval = undefined;
       }
+      if (this.initialReconcileTimer) {
+        clearTimeout(this.initialReconcileTimer);
+        this.initialReconcileTimer = undefined;
+      }
 
       // Wait for in-flight reconciliation to finish (with 10s timeout)
       if (this.activeReconciliation) {
@@ -262,7 +267,8 @@ export class Orchestrator {
   }
 
   private setupIdleCleanup(): void {
-    setTimeout(() => {
+    this.initialReconcileTimer = setTimeout(() => {
+      this.initialReconcileTimer = undefined;
       if (this.shuttingDown) return;
       const p = this.deploymentManager.reconcileDeployments().catch((error) => {
         logger.error("❌ Initial deployment reconciliation failed:", error);

--- a/packages/gateway/src/orchestration/scheduled-wakeup.ts
+++ b/packages/gateway/src/orchestration/scheduled-wakeup.ts
@@ -422,7 +422,7 @@ export class ScheduleService {
  * Returns null when the string is missing or malformed (caller falls back to
  * headless mode).
  */
-export function parseDeliveryTarget(deliverTo: string | undefined): {
+function parseDeliveryTarget(deliverTo: string | undefined): {
   platform: string;
   connectionSlug: string;
   channelId: string;

--- a/packages/gateway/src/services/bedrock-openai-service.ts
+++ b/packages/gateway/src/services/bedrock-openai-service.ts
@@ -163,7 +163,7 @@ function parseToolArguments(raw?: string): Record<string, unknown> {
   }
 }
 
-export function buildBedrockContext(
+function buildBedrockContext(
   request: OpenAIChatCompletionRequest
 ): BedrockContextPayload {
   const messages: PiMessage[] = [];

--- a/packages/gateway/src/services/core-services.ts
+++ b/packages/gateway/src/services/core-services.ts
@@ -849,15 +849,9 @@ export class CoreServices {
     logger.debug("MCP proxy initialized");
 
     // Initialize worker gateway
-    if (!this.sessionManager) {
-      throw new Error(
-        "Session manager must be initialized before worker gateway"
-      );
-    }
     this.workerGateway = new WorkerGateway(
       this.queue,
       this.config.mcp.publicGatewayUrl,
-      this.sessionManager,
       this.mcpConfigService,
       this.instructionService,
       this.mcpProxy,


### PR DESCRIPTION
Gateway-only bug hunt. Each change isolated to its own commit so any one can be reverted cleanly.

## Bugs fixed

1. **Race: Express adapter `req.body` could be `null` when the handler ran**
   - `packages/gateway/src/cli/gateway.ts:1114-1130` (old line numbers)
   - `handleExpressHandler` awaited `handler(req, res)` but the arrayBuffer parse was chained with `.then()` and never awaited, so downstream Express-style handlers that read `req.body` saw it still `null` on the first tick. Made `createExpressCompatObjects` async and awaited the parse.

2. **Leaked initial reconcile timer in `Orchestrator`**
   - `packages/gateway/src/orchestration/index.ts:265` (old) — `setupIdleCleanup` scheduled the first reconciliation with an untracked `setTimeout`. `stop()` cleared the interval but could not cancel the pending one-shot. Now tracked via `initialReconcileTimer` and cleared in `stop()`.

## Maintainability / dead code

3. **Drop unused `sessionManager` from `WorkerGateway` / `WorkerJobRouter`**
   - `packages/gateway/src/gateway/job-router.ts` accepted `_sessionManager` and never used it. Removed from both the router and `WorkerGateway`'s constructor signature (plus callers in `services/core-services.ts` and two tests). Per repo rule, unused parameters are dropped entirely rather than `_`-prefixed.

4. **Drop unnecessary `export` on internal helpers and delete dead function**
   - `ADAPTER_FACTORIES`, `SESSION_TTL_MS`, `historyKey`, `parseDeliveryTarget`, `buildBedrockContext`, `DefaultResponseStrategy`, `SlackResponseStrategy`, `TelegramResponseStrategy` — all used only inside their own file. `export` removed.
   - `invalidateDiscovery` in `packages/gateway/src/auth/mcp/oauth-discovery.ts` had no callers anywhere in the monorepo; deleted.

## Out of scope (noted, not fixed)

- None cross-package this round. Knip reports a number of unused exports and 7 "unused files" in gateway, but most are used via dynamic `require()` in `cli/gateway.ts` (e.g. `createLandingRoutes`, `SystemEnvStore`, `createMcpOAuthRoutes`, `createHistoryRoutes`, `createOAuthRoutes`, `createConnectionWebhookRoutes`, `postOAuthCompletionPrompt`) — leaving those alone.
- The remaining unused exported types (~100 interfaces) are mostly DX/type-only surface; not removed here to keep this PR focused on bugs + clearly dead code.

## Validation

- `make build-packages` passes (core + gateway + worker).
- `cd packages/gateway && bun test` → **488 pass, 0 fail, 1145 expects**.

## Test plan

- [x] `make build-packages`
- [x] `bun test` in `packages/gateway`
- [ ] Smoke: exercise the CLI gateway path that hits `handleExpressHandler` with a POST body (e.g. module-registry route) and confirm `req.body` is parsed JSON before the handler runs.