### PR TITLE
refactor(core, worker)!: drop unused public exports from @lobu/core

### DIFF
--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -119,39 +119,6 @@ export class SessionError extends BaseError {
   }
 }
 
-/**
- * Worker error variant with workerId for core operations
- */
-export class CoreWorkerError extends WorkerError {
-  constructor(
-    public workerId: string,
-    operation: string,
-    message: string,
-    cause?: Error
-  ) {
-    super(operation, message, cause);
-  }
-
-  override toJSON(): Record<string, any> {
-    return {
-      ...super.toJSON(),
-      workerId: this.workerId,
-    };
-  }
-}
-
-/**
- * Error class for dispatcher-related operations
- */
-export class DispatcherError extends BaseError {
-  override readonly name = "DispatcherError";
-
-  constructor(operation: string, message: string, cause?: Error) {
-    super(message, cause);
-    this.operation = operation;
-  }
-}
-
 // ErrorCode enum for orchestration operations
 export enum ErrorCode {
   DATABASE_CONNECTION_FAILED = "DATABASE_CONNECTION_FAILED",

--- a/packages/core/src/redis/base-store.ts
+++ b/packages/core/src/redis/base-store.ts
@@ -178,4 +178,3 @@ export abstract class BaseRedisStore<T> {
     return true;
   }
 }
-

--- a/packages/core/src/redis/base-store.ts
+++ b/packages/core/src/redis/base-store.ts
@@ -15,10 +15,6 @@ export interface RedisStoreConfig {
 /**
  * Base class for all Redis-backed stores
  * Provides common CRUD operations with JSON serialization
- *
- * Consolidates:
- * - packages/gateway/src/auth/credential-store.ts (BaseCredentialStore)
- * - packages/gateway/src/infrastructure/redis/store.ts (BaseRedisStore)
  */
 export abstract class BaseRedisStore<T> {
   protected logger: Logger;
@@ -183,18 +179,3 @@ export abstract class BaseRedisStore<T> {
   }
 }
 
-/**
- * Specialized base for credential stores
- * Validates that accessToken field exists
- */
-export abstract class BaseCredentialStore<
-  T extends { accessToken: string },
-> extends BaseRedisStore<T> {
-  protected override validate(value: T): boolean {
-    if (!value.accessToken) {
-      this.logger.warn("Invalid credentials: missing accessToken");
-      return false;
-    }
-    return true;
-  }
-}

--- a/packages/core/src/utils/encryption.ts
+++ b/packages/core/src/utils/encryption.ts
@@ -1,8 +1,6 @@
 import * as crypto from "node:crypto";
-import { createLogger } from "../logger";
 
 const IV_LENGTH = 12; // 96-bit nonce for AES-GCM
-const logger = createLogger("encryption");
 
 /**
  * Get encryption key from environment with validation
@@ -18,22 +16,19 @@ function getEncryptionKey(): Buffer {
     );
   }
 
-  // Try to decode as base64 first (most common format)
-  let keyBuffer: Buffer;
-  try {
-    keyBuffer = Buffer.from(key, "base64");
-    if (keyBuffer.length === 32) {
-      return keyBuffer;
-    }
-  } catch (err) {
-    logger.debug("ENCRYPTION_KEY is not valid base64, trying hex format", err);
+  // Try to decode as base64 first (most common format).
+  // Buffer.from with "base64" does not throw on invalid input — it silently
+  // discards non-base64 chars — so we only need a length check here.
+  const base64Buffer = Buffer.from(key, "base64");
+  if (base64Buffer.length === 32) {
+    return base64Buffer;
   }
 
   // Try as hex (must be exactly 64 hex characters for 32 bytes)
   if (/^[0-9a-fA-F]{64}$/.test(key)) {
-    keyBuffer = Buffer.from(key, "hex");
-    if (keyBuffer.length === 32) {
-      return keyBuffer;
+    const hexBuffer = Buffer.from(key, "hex");
+    if (hexBuffer.length === 32) {
+      return hexBuffer;
     }
   }
 


### PR DESCRIPTION
## Summary

Conservative cleanup inside `packages/core` and `packages/worker` only. No behavior changes, net −57 lines.

### Dead export removal (`@lobu/core`)
- `CoreWorkerError` — `packages/core/src/errors.ts:125`
- `DispatcherError` — `packages/core/src/errors.ts:146`
- `BaseCredentialStore` — `packages/core/src/redis/base-store.ts:190`

All three were defined but never imported anywhere in the monorepo or in the Owletto source tree (`/Users/burakemre/Code/owletto`, excluding `node_modules`). The `BaseCredentialStore` doc-comment referenced `packages/gateway/src/auth/credential-store.ts`, which does not exist.

`ErrorCode` (the sibling enum to `DispatcherError`) stays — it is consumed by `OrchestratorError`. `BaseRedisStore` and `WorkerError` stay — they have active consumers.

### Dead defensive code
- `packages/core/src/utils/encryption.ts:23-30`: removed `try/catch` around `Buffer.from(key, "base64")`. Node's base64 decoder never throws — invalid chars are silently discarded — so the catch branch was unreachable. The `byteLength === 32` check already guards invalid input, and fall-through to the hex path is preserved.
- Dropped the now-unused `createLogger` import this produced.

### Validation
- `make build-packages` — OK (core + gateway + worker).
- `bun run typecheck` — OK (repo-wide `tsc --noEmit`).
- `bun test packages/core/src packages/worker/src` — 241 pass, 0 fail, 480 `expect()` calls, 23 files.

### Unresolved / intentionally deferred findings
- `packages/worker/src/openclaw/processor.ts` defines `setFinalResult` / `getFinalResult`. `getFinalResult()` is consumed at `packages/worker/src/openclaw/worker.ts:547`, but `setFinalResult` is **only** called from tests (`packages/worker/src/__tests__/processor.test.ts`). In production the branch at `worker.ts:548 (if (finalResult))` never fires. Flagging rather than deleting: the tests document the intended lifecycle, and removing the API would erase a deliberately kept extension point. Worth revisiting if nobody wires a production caller.
- `packages/worker/src/openclaw/session-context.ts`: `{ ...DEFAULT_SESSION_CONTEXT }` is a shallow spread. All current callers treat the result as read-only, so no live bug — but a future caller that mutates a nested field would corrupt the default. Left as-is to avoid churn.

## Test plan

- [x] `make build-packages` passes
- [x] `bun run typecheck` passes
- [x] `bun test packages/core/src packages/worker/src` passes (241/241)
- [ ] No consumer breakage (verified via monorepo grep + Owletto source grep; published package has no other known consumers)

---

**BREAKING CHANGE**: Removes `CoreWorkerError`, `DispatcherError`, and `BaseCredentialStore` from the public `@lobu/core` API. These had zero consumers in this monorepo and in the Owletto source, but external downstream consumers of `@lobu/core` (if any) will see TypeScript compile errors on upgrade. Per project policy ([`CLAUDE.md`](../blob/main/CLAUDE.md): "do not add backwards-compatibility shims … no `@deprecated` tags — just delete the old thing"), this is a clean removal; release-please will bump `@lobu/core` to the next major.
