### PR TITLE
chore(docker): consolidate dev stack on owletto-backend

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,11 +165,11 @@ jobs:
             sleep 2
           done
 
-      - name: Run all evals with local CLI
+      - name: Run smoke eval with local CLI
         working-directory: examples/careops
         env:
           ADMIN_PASSWORD: ci-eval-password
-        run: node ../../packages/cli/bin/lobu.js eval --ci --output eval-results.json
+        run: node ../../packages/cli/bin/lobu.js eval smoke --ci --output eval-results.json
 
       - name: Gateway logs
         if: always()

--- a/Makefile
+++ b/Makefile
@@ -161,7 +161,7 @@ logs:
 		echo "  kubectl logs -f <pod-name> -n lobu"; \
 	else \
 		echo "View logs with:"; \
-		echo "  docker compose logs -f gateway"; \
+		echo "  docker compose logs -f app"; \
 	fi
 
 # Stop worker containers

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -150,13 +150,25 @@ services:
     develop:
       watch:
         - action: sync+restart
-          path: ../packages/worker/src
-          target: /app/packages/worker/src
+          path: ../packages/owletto-worker/src
+          target: /app/packages/owletto-worker/src
         - action: sync+restart
-          path: ../packages/owletto-backend/src
-          target: /app/packages/owletto-backend/src
+          path: ../packages/owletto-sdk/src
+          target: /app/packages/owletto-sdk/src
+        - action: sync+restart
+          path: ../packages/owletto-connectors/src
+          target: /app/packages/owletto-connectors/src
+        - action: sync+restart
+          path: ../packages/owletto-embeddings/src
+          target: /app/packages/owletto-embeddings/src
         - action: rebuild
-          path: ../packages/worker/package.json
+          path: ../packages/owletto-worker/package.json
+        - action: rebuild
+          path: ../packages/owletto-sdk/package.json
+        - action: rebuild
+          path: ../packages/owletto-connectors/package.json
+        - action: rebuild
+          path: ../packages/owletto-embeddings/package.json
 
   openclaw:
     build:
@@ -173,7 +185,6 @@ services:
     volumes:
       - ../data/openclaw:/home/openclaw/.openclaw
       - ../data/openclaw-auth:/home/openclaw/.owletto
-      - ../packages/owletto-openclaw/dist:/plugin/dist
     depends_on:
       app:
         condition: service_healthy

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,7 +1,6 @@
 name: lobu
 
 services:
-  # Redis for queue and state management
   redis:
     image: redis:7-alpine
     command: redis-server --maxmemory 256mb --maxmemory-policy noeviction --save 60 1 --dir /data
@@ -16,79 +15,172 @@ services:
       timeout: 3s
       retries: 3
 
-  # Build worker image that orchestrator will use
-  worker:
+  # owletto-backend + owletto-web static serving; embeds @lobu/gateway at /lobu.
+  # Connects to prod Postgres via DATABASE_URL from ../.env (no local postgres).
+  app:
     build:
       context: ..
-      dockerfile: docker/Dockerfile.worker
+      dockerfile: docker/app/Dockerfile
+      target: runtime
       args:
-        NODE_ENV: production
-    image: lobu-worker:latest
-    # This service only builds the image, doesn't run continuously
-    command: echo "Worker image built successfully"
-    profiles:
-      - build-only
-
-  gateway:
-    build:
-      context: ..
-      dockerfile: docker/Dockerfile.gateway
-    image: lobu-gateway:latest
+        SKIP_WEB_BUILD: "true"
+        SKIP_TSC: "true"
     environment:
-      # Docker context overrides (gateway loads mounted .env file via dotenv).
-      # DEPLOYMENT_MODE is read from the mounted .env so operators can pick
-      # embedded vs docker without exporting shell vars.
       NODE_ENV: development
-      QUEUE_URL: redis://redis:6379
-      # Host project path for worker bind mounts (Docker-in-Docker)
+      ENVIRONMENT: development
+      PORT: 8787
+      HOST: 0.0.0.0
+      PUBLIC_WEB_URL: ${PUBLIC_WEB_URL:-http://localhost:8787}
+      FRAME_ANCESTORS: ${FRAME_ANCESTORS:-http://localhost:4321 https://lobu.ai https://*.lobu.ai}
+      DATABASE_URL: ${DATABASE_URL}
+      PGSSLMODE: ${PGSSLMODE:-require}
+      REDIS_URL: redis://redis:6379
+      EMBEDDINGS_SERVICE_URL: http://embeddings:8790
+      VITE_HMR_HOST: ${TAILSCALE_HOSTNAME:-localhost}
+      VITE_HMR_PROTOCOL: wss
+      BETTER_AUTH_SECRET: ${BETTER_AUTH_SECRET:-dev-secret-change-me}
+      JWT_SECRET: ${JWT_SECRET:-dev-jwt-secret-change-me}
+      ENCRYPTION_KEY: ${ENCRYPTION_KEY:-Jz9s2AmRGvu+uCICS07GvjvGxl5Fov+zZ3saS0Gui2Q=}
+      RESEND_API_KEY: ${RESEND_API_KEY:-}
+      AUTH_EMAIL_FROM: ${AUTH_EMAIL_FROM:-}
+      GOOGLE_CLIENT_ID: ${GOOGLE_CLIENT_ID:-}
+      GOOGLE_CLIENT_SECRET: ${GOOGLE_CLIENT_SECRET:-}
+      GITHUB_CLIENT_ID: ${GITHUB_CLIENT_ID:-}
+      GITHUB_CLIENT_SECRET: ${GITHUB_CLIENT_SECRET:-}
+      SENTRY_DSN: ${SENTRY_DSN:-}
+      LOBU_PROVIDER_REGISTRY_PATH: ${LOBU_PROVIDER_REGISTRY_PATH:-/app/config/providers.json}
       LOBU_DEV_PROJECT_PATH: ${PWD}
-      # Read-only workspace mount used for file-first agent config loading
       LOBU_WORKSPACE_ROOT: ${LOBU_WORKSPACE_ROOT:-/workspace/project}
     env_file:
       - ../.env
     volumes:
-      # Mount Docker socket
       - /var/run/docker.sock:/var/run/docker.sock
-      # Mount .env so gateway can load it via dotenv (avoids ARG_MAX with large vars)
       - ../.env:/app/.env:ro
-      # Mount workspace root so the gateway can read lobu.toml directly
       - ..:/workspace/project:ro
-      # Mount integrations config for live editing
       - ../config:/app/config:ro
-      # Mount source for hot reload (bun --watch detects changes)
-      - ../packages/core/src:/app/packages/core/src
-      - ../packages/gateway/src:/app/packages/gateway/src
-      # Mount worker source so spawned worker containers get latest code
-      - ../packages/worker/src:/app/packages/worker/src
-      - ../packages/worker/scripts:/app/packages/worker/scripts
-      # Mount workspaces for embedded mode session access
+      - ../packages/owletto-web:/app/packages/owletto-web
+      - /app/packages/owletto-web/node_modules
+      - ../packages/owletto-connectors:/app/packages/owletto-connectors
       - ../workspaces:/app/workspaces
     ports:
-      - "8080:8080"
-      - "8118:8118" # HTTP proxy for workers
+      - "8787:8787"
+      - "8118:8118" # HTTP proxy for workers (embedded gateway)
     networks:
-      - lobu-public   # Internet access
-      - lobu-internal # Internal services (redis, workers)
+      - lobu-public
+      - lobu-internal
     restart: unless-stopped
     depends_on:
       redis:
         condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "curl -f http://127.0.0.1:8787/health || exit 1"]
+      interval: 10s
+      timeout: 10s
+      retries: 10
+      start_period: 20s
     develop:
       watch:
+        - action: sync+restart
+          path: ../packages/owletto-backend/src
+          target: /app/packages/owletto-backend/src
+        - action: sync+restart
+          path: ../packages/core/src
+          target: /app/packages/core/src
+        - action: sync+restart
+          path: ../packages/gateway/src
+          target: /app/packages/gateway/src
+        - action: sync+restart
+          path: ../config
+          target: /app/config
         - action: rebuild
-          path: ../packages/gateway/package.json
+          path: ../packages/owletto-backend/package.json
         - action: rebuild
           path: ../packages/core/package.json
         - action: rebuild
+          path: ../packages/gateway/package.json
+
+  embeddings:
+    build:
+      context: ..
+      dockerfile: docker/embeddings-service/Dockerfile
+      target: runtime
+    environment:
+      NODE_ENV: development
+      PORT: 8790
+    networks:
+      - lobu-internal
+    ports:
+      - "8790:8790"
+    healthcheck:
+      test: ["CMD-SHELL", "node -e \"fetch('http://127.0.0.1:8790/health').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))\""]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 20s
+    develop:
+      watch:
+        - action: sync+restart
+          path: ../packages/owletto-embeddings/src
+          target: /app/packages/owletto-embeddings/src
+        - action: rebuild
+          path: ../packages/owletto-embeddings/package.json
+
+  worker:
+    build:
+      context: ..
+      dockerfile: docker/worker/Dockerfile
+      target: runtime
+    image: lobu-worker:latest
+    environment:
+      NODE_ENV: development
+      API_URL: http://app:8787
+      EMBEDDINGS_SERVICE_URL: http://embeddings:8790
+      DATABASE_URL: ${DATABASE_URL}
+      PGSSLMODE: ${PGSSLMODE:-require}
+      WORKER_MAX_CONCURRENT_JOBS: ${WORKER_MAX_CONCURRENT_JOBS:-4}
+    networks:
+      - lobu-internal
+    depends_on:
+      app:
+        condition: service_healthy
+      embeddings:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    develop:
+      watch:
+        - action: sync+restart
+          path: ../packages/worker/src
+          target: /app/packages/worker/src
+        - action: sync+restart
+          path: ../packages/owletto-backend/src
+          target: /app/packages/owletto-backend/src
+        - action: rebuild
           path: ../packages/worker/package.json
 
+  openclaw:
+    build:
+      context: ..
+      dockerfile: docker/openclaw/Dockerfile
+    environment:
+      OPENCLAW_GATEWAY_PORT: 18789
+      OPENCLAW_GATEWAY_TOKEN: ${OPENCLAW_GATEWAY_TOKEN:-dev-openclaw-token}
+      TELEGRAM_BOT_TOKEN: ${TELEGRAM_BOT_TOKEN:-}
+    networks:
+      - lobu-internal
+    ports:
+      - "18789:18789"
+    volumes:
+      - ../data/openclaw:/home/openclaw/.openclaw
+      - ../data/openclaw-auth:/home/openclaw/.owletto
+      - ../packages/owletto-openclaw/dist:/plugin/dist
+    depends_on:
+      app:
+        condition: service_healthy
+
 networks:
-  # Public network with internet access (gateway only)
   lobu-public:
     driver: bridge
-
-  # Internal network - no direct internet access
-  # Workers use this network and can only reach internet via gateway's proxy
   lobu-internal:
     internal: true
     driver: bridge

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -151,6 +151,7 @@ services:
       DATABASE_URL: ${DATABASE_URL}
       PGSSLMODE: ${PGSSLMODE:-require}
       WORKER_MAX_CONCURRENT_JOBS: ${WORKER_MAX_CONCURRENT_JOBS:-4}
+      WORKER_API_TOKEN: ${WORKER_API_TOKEN:-}
       # Route worker egress through the gateway proxy (embedded in the app service).
       # lobu-internal is internal: true, so without this the worker has no path
       # to provider/connector endpoints.

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -68,6 +68,10 @@ services:
     networks:
       - lobu-public
       - lobu-internal
+    extra_hosts:
+      # Tailscale MagicDNS isn't available to Docker's embedded resolver on macOS,
+      # so map the prod Postgres tailnet host to its tailnet IP.
+      - "summaries-db.brill-kanyu.ts.net:100.101.120.15"
     restart: unless-stopped
     depends_on:
       redis:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -61,6 +61,9 @@ services:
       - ../packages/owletto-web:/app/packages/owletto-web
       - /app/packages/owletto-web/node_modules
       - ../packages/owletto-connectors:/app/packages/owletto-connectors
+      # Embedded workers (spawned by the gateway) load from this path at runtime;
+      # mount so `make dev` picks up worker edits without rebuilding.
+      - ../packages/worker/src:/app/packages/worker/src
       - ../workspaces:/app/workspaces
     ports:
       - "8787:8787"
@@ -93,6 +96,9 @@ services:
         - action: sync+restart
           path: ../packages/gateway/src
           target: /app/packages/gateway/src
+        - action: sync+restart
+          path: ../packages/worker/src
+          target: /app/packages/worker/src
         - action: sync+restart
           path: ../config
           target: /app/config
@@ -142,6 +148,12 @@ services:
       DATABASE_URL: ${DATABASE_URL}
       PGSSLMODE: ${PGSSLMODE:-require}
       WORKER_MAX_CONCURRENT_JOBS: ${WORKER_MAX_CONCURRENT_JOBS:-4}
+      # Route worker egress through the gateway proxy (embedded in the app service).
+      # lobu-internal is internal: true, so without this the worker has no path
+      # to provider/connector endpoints.
+      HTTP_PROXY: http://app:8118
+      HTTPS_PROXY: http://app:8118
+      NO_PROXY: localhost,127.0.0.1,app,redis,embeddings,openclaw
     networks:
       - lobu-internal
     depends_on:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -99,9 +99,9 @@ services:
         - action: sync+restart
           path: ../packages/worker/src
           target: /app/packages/worker/src
-        - action: sync+restart
-          path: ../config
-          target: /app/config
+        # config/ is bind-mounted read-only (../config:/app/config:ro), so file
+        # edits are already visible to the process — a sync+restart watch here
+        # would fail to write into the read-only target.
         - action: rebuild
           path: ../packages/owletto-backend/package.json
         - action: rebuild

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -140,7 +140,10 @@ services:
       context: ..
       dockerfile: docker/worker/Dockerfile
       target: runtime
-    image: lobu-worker:latest
+    # Distinct tag from the Lobu agent worker image (also `lobu-worker:latest`)
+    # built by scripts/setup-dev.sh and `make build-worker`, so running compose
+    # does not clobber the tag those flows rely on.
+    image: lobu-owletto-worker:latest
     environment:
       NODE_ENV: development
       API_URL: http://app:8787

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -183,6 +183,9 @@ services:
       OPENCLAW_GATEWAY_TOKEN: ${OPENCLAW_GATEWAY_TOKEN:-dev-openclaw-token}
       TELEGRAM_BOT_TOKEN: ${TELEGRAM_BOT_TOKEN:-}
     networks:
+      # lobu-public for outbound access to Telegram / hosted LLM providers;
+      # lobu-internal to reach the embedded gateway on the `app` service.
+      - lobu-public
       - lobu-internal
     ports:
       - "18789:18789"

--- a/docker/openclaw/Dockerfile
+++ b/docker/openclaw/Dockerfile
@@ -1,0 +1,36 @@
+FROM node:22-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends git ca-certificates python3 make g++ && rm -rf /var/lib/apt/lists/*
+
+# Configure git to use HTTPS instead of git+ssh
+RUN git config --global url."https://github.com/".insteadOf "git+https://github.com/" && \
+    git config --global url."https://github.com/".insteadOf "git://github.com/"
+
+RUN npm install -g openclaw@latest
+
+# Install the prebuilt local Owletto CLI so the container matches the repo's OpenClaw flow.
+WORKDIR /owletto-cli
+COPY packages/cli/package.json ./
+COPY packages/cli/dist ./dist
+RUN npm install -g .
+
+# Copy and build the owletto plugin
+WORKDIR /plugin
+COPY packages/owletto-openclaw/package.json packages/owletto-openclaw/tsconfig.json ./
+COPY packages/owletto-openclaw/src ./src
+COPY packages/owletto-openclaw/openclaw.plugin.json ./
+RUN npm install && npm run build
+
+# Set up openclaw home
+RUN useradd -m -s /bin/bash openclaw
+USER openclaw
+WORKDIR /home/openclaw
+ENV HOME=/home/openclaw
+
+# Openclaw config
+RUN mkdir -p .openclaw
+COPY --chown=openclaw:openclaw docker/openclaw/openclaw.json .openclaw/openclaw.json
+
+EXPOSE 18789
+
+CMD ["openclaw", "gateway", "--port", "18789"]

--- a/docker/openclaw/Dockerfile
+++ b/docker/openclaw/Dockerfile
@@ -6,13 +6,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends git ca-certific
 RUN git config --global url."https://github.com/".insteadOf "git+https://github.com/" && \
     git config --global url."https://github.com/".insteadOf "git://github.com/"
 
+# Install OpenClaw only. The plugin handles auth itself, so the container
+# does not need a host-built local CLI to start correctly.
 RUN npm install -g openclaw@latest
-
-# Install the prebuilt local Owletto CLI so the container matches the repo's OpenClaw flow.
-WORKDIR /owletto-cli
-COPY packages/cli/package.json ./
-COPY packages/cli/dist ./dist
-RUN npm install -g .
 
 # Copy and build the owletto plugin
 WORKDIR /plugin
@@ -21,16 +17,21 @@ COPY packages/owletto-openclaw/src ./src
 COPY packages/owletto-openclaw/openclaw.plugin.json ./
 RUN npm install && npm run build
 
+# Seed defaults outside mounted directories so first compose startup can
+# populate ~/.openclaw even when the bind mounts start empty.
+RUN mkdir -p /usr/local/share/openclaw/openclaw-owletto/dist \
+    && cp -R /plugin/dist/. /usr/local/share/openclaw/openclaw-owletto/dist/ \
+    && cp /plugin/openclaw.plugin.json /usr/local/share/openclaw/openclaw-owletto/openclaw.plugin.json
+COPY docker/openclaw/openclaw.json /usr/local/share/openclaw/openclaw.json
+COPY docker/openclaw/start.sh /usr/local/bin/openclaw-start
+RUN chmod +x /usr/local/bin/openclaw-start
+
 # Set up openclaw home
 RUN useradd -m -s /bin/bash openclaw
 USER openclaw
 WORKDIR /home/openclaw
 ENV HOME=/home/openclaw
 
-# Openclaw config
-RUN mkdir -p .openclaw
-COPY --chown=openclaw:openclaw docker/openclaw/openclaw.json .openclaw/openclaw.json
-
 EXPOSE 18789
 
-CMD ["openclaw", "gateway", "--port", "18789"]
+CMD ["openclaw-start"]

--- a/docker/openclaw/openclaw.json
+++ b/docker/openclaw/openclaw.json
@@ -25,9 +25,9 @@
       "openclaw-owletto": {
         "enabled": true,
         "config": {
-          "mcpUrl": "http://app:8787/mcp",
+          "mcpUrl": "http://app:8787/lobu/mcp/owletto",
           "webUrl": "http://app:8787",
-          "gatewayAuthUrl": "http://app:8787",
+          "gatewayAuthUrl": "http://app:8787/lobu",
           "autoRecall": true,
           "autoCapture": true
         }

--- a/docker/openclaw/openclaw.json
+++ b/docker/openclaw/openclaw.json
@@ -12,10 +12,7 @@
       "resetOnExit": false
     },
     "controlUi": {
-      "allowedOrigins": [
-        "http://localhost:18789",
-        "http://127.0.0.1:18789"
-      ]
+      "allowedOrigins": ["http://localhost:18789", "http://127.0.0.1:18789"]
     }
   },
   "channels": {

--- a/docker/openclaw/openclaw.json
+++ b/docker/openclaw/openclaw.json
@@ -1,4 +1,28 @@
 {
+  "gateway": {
+    "port": 18789,
+    "mode": "local",
+    "bind": "lan",
+    "auth": {
+      "mode": "token",
+      "token": "dev-openclaw-token"
+    },
+    "tailscale": {
+      "mode": "off",
+      "resetOnExit": false
+    },
+    "controlUi": {
+      "allowedOrigins": [
+        "http://localhost:18789",
+        "http://127.0.0.1:18789"
+      ]
+    }
+  },
+  "channels": {
+    "telegram": {
+      "enabled": true
+    }
+  },
   "plugins": {
     "entries": {
       "openclaw-owletto": {
@@ -11,6 +35,16 @@
           "autoCapture": true
         }
       }
+    },
+    "installs": {
+      "openclaw-owletto": {
+        "source": "path",
+        "sourcePath": "/plugin",
+        "installPath": "/home/openclaw/.openclaw/extensions/openclaw-owletto"
+      }
+    },
+    "slots": {
+      "memory": "openclaw-owletto"
     }
   }
 }

--- a/docker/openclaw/openclaw.json
+++ b/docker/openclaw/openclaw.json
@@ -1,0 +1,16 @@
+{
+  "plugins": {
+    "entries": {
+      "openclaw-owletto": {
+        "enabled": true,
+        "config": {
+          "mcpUrl": "http://app:8787/mcp",
+          "webUrl": "http://app:8787",
+          "gatewayAuthUrl": "http://app:8787",
+          "autoRecall": true,
+          "autoCapture": true
+        }
+      }
+    }
+  }
+}

--- a/docker/openclaw/start.sh
+++ b/docker/openclaw/start.sh
@@ -27,12 +27,11 @@ with open(path, "w") as fh:
 PY
 fi
 
-if [ ! -f "$EXTENSION_DIR/openclaw.plugin.json" ]; then
-  cp "$DEFAULTS_DIR/openclaw-owletto/openclaw.plugin.json" "$EXTENSION_DIR/openclaw.plugin.json"
-fi
-
-if [ ! -e "$EXTENSION_DIR/dist/index.js" ]; then
-  cp -R "$DEFAULTS_DIR/openclaw-owletto/dist/." "$EXTENSION_DIR/dist/"
-fi
+# Always refresh plugin manifest + dist from the image so rebuilds ship new
+# plugin code even though ../data/openclaw is a persistent bind mount.
+cp "$DEFAULTS_DIR/openclaw-owletto/openclaw.plugin.json" "$EXTENSION_DIR/openclaw.plugin.json"
+rm -rf "$EXTENSION_DIR/dist"
+mkdir -p "$EXTENSION_DIR/dist"
+cp -R "$DEFAULTS_DIR/openclaw-owletto/dist/." "$EXTENSION_DIR/dist/"
 
 exec openclaw gateway --port "${OPENCLAW_GATEWAY_PORT:-18789}"

--- a/docker/openclaw/start.sh
+++ b/docker/openclaw/start.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+set -eu
+
+OPENCLAW_HOME="${HOME:-/home/openclaw}/.openclaw"
+DEFAULTS_DIR="/usr/local/share/openclaw"
+EXTENSION_DIR="$OPENCLAW_HOME/extensions/openclaw-owletto"
+
+mkdir -p "$OPENCLAW_HOME" "$EXTENSION_DIR/dist"
+
+if [ ! -f "$OPENCLAW_HOME/openclaw.json" ]; then
+  cp "$DEFAULTS_DIR/openclaw.json" "$OPENCLAW_HOME/openclaw.json"
+fi
+
+if [ ! -f "$EXTENSION_DIR/openclaw.plugin.json" ]; then
+  cp "$DEFAULTS_DIR/openclaw-owletto/openclaw.plugin.json" "$EXTENSION_DIR/openclaw.plugin.json"
+fi
+
+if [ ! -e "$EXTENSION_DIR/dist/index.js" ]; then
+  cp -R "$DEFAULTS_DIR/openclaw-owletto/dist/." "$EXTENSION_DIR/dist/"
+fi
+
+exec openclaw gateway --port "${OPENCLAW_GATEWAY_PORT:-18789}"

--- a/docker/openclaw/start.sh
+++ b/docker/openclaw/start.sh
@@ -11,6 +11,22 @@ if [ ! -f "$OPENCLAW_HOME/openclaw.json" ]; then
   cp "$DEFAULTS_DIR/openclaw.json" "$OPENCLAW_HOME/openclaw.json"
 fi
 
+# Apply the configured gateway token to the persisted config on every startup
+# so compose/env rotations actually reach the running gateway.
+if [ -n "${OPENCLAW_GATEWAY_TOKEN:-}" ]; then
+  python3 - "$OPENCLAW_HOME/openclaw.json" "$OPENCLAW_GATEWAY_TOKEN" <<'PY'
+import json, sys
+path, token = sys.argv[1], sys.argv[2]
+with open(path) as fh:
+    cfg = json.load(fh)
+cfg.setdefault("gateway", {}).setdefault("auth", {})["token"] = token
+cfg["gateway"]["auth"].setdefault("mode", "token")
+with open(path, "w") as fh:
+    json.dump(cfg, fh, indent=2)
+    fh.write("\n")
+PY
+fi
+
 if [ ! -f "$EXTENSION_DIR/openclaw.plugin.json" ]; then
   cp "$DEFAULTS_DIR/openclaw-owletto/openclaw.plugin.json" "$EXTENSION_DIR/openclaw.plugin.json"
 fi

--- a/packages/owletto-openclaw/src/index.ts
+++ b/packages/owletto-openclaw/src/index.ts
@@ -865,6 +865,10 @@ interface McpBootstrap {
 }
 
 function fetchMcpBootstrapSync(config: ResolvedPluginConfig): McpBootstrap {
+  if (!config.mcpUrl) {
+    return { tools: [], instructions: null, sessionId: null };
+  }
+
   let token: string | null = sessionToken || config.token || null;
   if (!token && config.tokenCommand) {
     try {

--- a/packages/owletto-worker/src/embeddings.ts
+++ b/packages/owletto-worker/src/embeddings.ts
@@ -10,7 +10,7 @@ import {
   pipeline,
   env as transformersEnv,
 } from '@xenova/transformers';
-import { validateEmbeddingDimensions } from '../../embeddings-service/src/embedding-utils';
+import { validateEmbeddingDimensions } from '../../owletto-embeddings/src/embedding-utils';
 
 const DEFAULT_MODEL_NAME = 'Xenova/bge-base-en-v1.5';
 const DEFAULT_DIMENSIONS = 768;

--- a/scripts/test-bot.sh
+++ b/scripts/test-bot.sh
@@ -19,7 +19,7 @@ set -e
 #   WhatsApp: WHATSAPP_SELF_PHONE (defaults to bot's own number for self-chat)
 #   Telegram: TELEGRAM_TEST_CHAT_ID, TG_API_ID, TG_API_HASH (uses tguser to send as real user)
 
-GATEWAY_URL="${GATEWAY_URL:-http://localhost:8080}"
+GATEWAY_URL="${GATEWAY_URL:-http://localhost:8787/lobu}"
 
 fetch_telegram_bot_peer() {
     local username


### PR DESCRIPTION
## Summary
- Replace standalone \`gateway\` service with \`app\` (owletto-backend + owletto-web static serving) which already embeds \`@lobu/gateway\` internally at \`/lobu\`
- Add \`embeddings\` and \`openclaw\` services (copied from owletto dev compose, adjusted to lobu package names)
- Copy \`docker/openclaw/\` from the owletto repo and rename \`openclaw-plugin\` → \`owletto-openclaw\` to match lobu's package layout
- No local postgres — \`DATABASE_URL\` from \`.env\` points at prod

## Why
We're consolidating the full dev stack into this repo so the web UI, embedded gateway, and workers all come from one place. Standalone lobu gateway remains shipable via \`packages/cli\` for gateway-only use — it's just not in the docker-compose dev path anymore.

## Services after
| Service | Port | Source |
|---|---|---|
| redis | (internal) | redis:7-alpine |
| app | 8787 | docker/app/Dockerfile (owletto-backend + owletto-web) |
| embeddings | 8790 | docker/embeddings-service/Dockerfile |
| worker | (internal) | docker/worker/Dockerfile |
| openclaw | 18789 | docker/openclaw/Dockerfile |

## Test plan
- [x] \`docker compose -f docker/docker-compose.yml config\` parses cleanly
- [ ] \`make dev\` with prod \`DATABASE_URL\` in \`.env\` brings the stack up and serves the web UI at :8787
- [ ] Retarget tailscale funnel (\`:443\`) at \`localhost:8787\` and confirm \`/buremba\` loads