### PR TITLE
fix(gateway): escape user input in MCP OAuth callback to prevent XSS

### DIFF
--- a/packages/gateway/src/__tests__/routes/mcp-oauth.test.ts
+++ b/packages/gateway/src/__tests__/routes/mcp-oauth.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from "bun:test";
+import { createMcpOAuthRoutes } from "../../routes/public/mcp-oauth";
+
+describe("mcp oauth callback route", () => {
+  test("escapes reflected error and error_description to prevent XSS", async () => {
+    const router = createMcpOAuthRoutes({
+      redis: {} as any,
+      secretStore: {} as any,
+      publicGatewayUrl: "https://gateway.example.com",
+    });
+
+    const maliciousError = '"><script>alert(1)</script>';
+    const maliciousDescription = '<script>alert("xss")</script>';
+    const url =
+      "https://gateway.example.com/mcp/oauth/callback" +
+      `?error=${encodeURIComponent(maliciousError)}` +
+      `&error_description=${encodeURIComponent(maliciousDescription)}`;
+
+    const res = await router.request(url);
+
+    expect(res.status).toBe(400);
+    const html = await res.text();
+
+    expect(html).not.toContain(maliciousError);
+    expect(html).not.toContain(maliciousDescription);
+    expect(html).toContain("&quot;&gt;&lt;script&gt;alert(1)&lt;/script&gt;");
+    expect(html).toContain(
+      "&lt;script&gt;alert(&quot;xss&quot;)&lt;/script&gt;"
+    );
+  });
+});

--- a/packages/gateway/src/auth/oauth-templates.ts
+++ b/packages/gateway/src/auth/oauth-templates.ts
@@ -2,7 +2,7 @@
  * HTML templates for OAuth flow
  */
 
-function escapeHtml(value: string): string {
+export function escapeHtml(value: string): string {
   return value.replace(/[&<>"'`]/g, (char) => {
     switch (char) {
       case "&":

--- a/packages/gateway/src/routes/public/mcp-oauth.ts
+++ b/packages/gateway/src/routes/public/mcp-oauth.ts
@@ -12,6 +12,7 @@ import { Hono } from "hono";
 import type Redis from "ioredis";
 import { completeAuthCodeFlow } from "../../auth/mcp/oauth-flow";
 import { postOAuthCompletionPrompt } from "../../auth/mcp/resume-after-oauth";
+import { escapeHtml } from "../../auth/oauth-templates";
 import type { ChatInstanceManager } from "../../connections/chat-instance-manager";
 import type { CoreServices } from "../../platform";
 import type { WritableSecretStore } from "../../secrets";
@@ -38,12 +39,13 @@ function renderResultPage(opts: {
   body: string;
 }): string {
   const color = opts.success ? "#16a34a" : "#dc2626";
+  const safeTitle = escapeHtml(opts.title);
   return `<!doctype html>
 <html lang="en">
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
-  <title>${opts.title}</title>
+  <title>${safeTitle}</title>
   <style>
     body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
            display: flex; align-items: center; justify-content: center;
@@ -59,7 +61,7 @@ function renderResultPage(opts: {
 </head>
 <body>
   <div class="card">
-    <h1>${opts.title}</h1>
+    <h1>${safeTitle}</h1>
     ${opts.body}
   </div>
 </body>
@@ -89,12 +91,16 @@ export function createMcpOAuthRoutes(config: McpOAuthRoutesConfig): Hono {
         error,
         errorDescription,
       });
+      const safeError = escapeHtml(error);
+      const safeErrorDescription = errorDescription
+        ? escapeHtml(errorDescription)
+        : "Please try again from the chat.";
       return c.html(
         renderResultPage({
           success: false,
           title: "Authorization failed",
-          body: `<p>The provider returned <span class="mono">${error}</span>.</p>
-                 <p>${errorDescription ?? "Please try again from the chat."}</p>`,
+          body: `<p>The provider returned <span class="mono">${safeError}</span>.</p>
+                 <p>${safeErrorDescription}</p>`,
         }),
         400
       );
@@ -155,23 +161,30 @@ export function createMcpOAuthRoutes(config: McpOAuthRoutesConfig): Hono {
         }
       }
 
+      const safeMcpId = escapeHtml(result.mcpId);
+      const scopeLabel = result.scopeKey.startsWith("channel-")
+        ? "channel"
+        : "user";
       return c.html(
         renderResultPage({
           success: true,
           title: `Connected ${result.mcpId}`,
           body: `<p>You can close this tab and return to the chat.</p>
-                 <p>Signed in as <span class="mono">${result.mcpId}</span> for this ${result.scopeKey.startsWith("channel-") ? "channel" : "user"}.</p>`,
+                 <p>Signed in as <span class="mono">${safeMcpId}</span> for this ${scopeLabel}.</p>`,
         })
       );
     } catch (err) {
       logger.error("Failed to complete MCP OAuth flow", {
         error: err instanceof Error ? err.message : String(err),
       });
+      const safeMessage = escapeHtml(
+        err instanceof Error ? err.message : "Unknown error"
+      );
       return c.html(
         renderResultPage({
           success: false,
           title: "Authorization failed",
-          body: `<p>${err instanceof Error ? err.message : "Unknown error"}</p>
+          body: `<p>${safeMessage}</p>
                  <p>Please try again from the chat.</p>`,
         }),
         500


### PR DESCRIPTION
## Summary

The MCP OAuth callback handler at `packages/gateway/src/routes/public/mcp-oauth.ts` was interpolating user-controlled values into HTML responses without escaping, allowing reflected XSS. The handler now routes every user-controlled value through the existing `escapeHtml` helper from `auth/oauth-templates` (which is now exported instead of file-private).

Values now escaped:
- `error` and `error_description` query params (provider error path)
- `result.mcpId` (success page title + body)
- Caught exception `err.message` (try/catch error path)
- The `title` passed into `renderResultPage` (so any user-derived title is safe by construction)

## Before / after

### error / error_description (lines 92-97 before)

Before:
```ts
body: `<p>The provider returned <span class="mono">${error}</span>.</p>
       <p>${errorDescription ?? "Please try again from the chat."}</p>`,
```

After:
```ts
const safeError = escapeHtml(error);
const safeErrorDescription = errorDescription
  ? escapeHtml(errorDescription)
  : "Please try again from the chat.";
body: `<p>The provider returned <span class="mono">${safeError}</span>.</p>
       <p>${safeErrorDescription}</p>`,
```

### mcpId success page (line 163 before)

Before:
```ts
body: `<p>You can close this tab and return to the chat.</p>
       <p>Signed in as <span class="mono">${result.mcpId}</span> for this ${result.scopeKey.startsWith("channel-") ? "channel" : "user"}.</p>`,
```

After:
```ts
const safeMcpId = escapeHtml(result.mcpId);
const scopeLabel = result.scopeKey.startsWith("channel-") ? "channel" : "user";
body: `<p>You can close this tab and return to the chat.</p>
       <p>Signed in as <span class="mono">${safeMcpId}</span> for this ${scopeLabel}.</p>`,
```

### exception message (line 174 before)

Before:
```ts
body: `<p>${err instanceof Error ? err.message : "Unknown error"}</p>
       <p>Please try again from the chat.</p>`,
```

After:
```ts
const safeMessage = escapeHtml(
  err instanceof Error ? err.message : "Unknown error"
);
body: `<p>${safeMessage}</p>
       <p>Please try again from the chat.</p>`,
```

### renderResultPage title

Before the title was interpolated raw into `<title>` and `<h1>`. Now it is escaped once at the top of the helper:
```ts
const safeTitle = escapeHtml(opts.title);
// ...
<title>${safeTitle}</title>
// ...
<h1>${safeTitle}</h1>
```

## Helper reuse

Rather than reinventing escaping, `escapeHtml` (already used by `renderOAuthSuccessPage` / `renderOAuthErrorPage`) is now `export`ed from `packages/gateway/src/auth/oauth-templates.ts` and imported by the MCP OAuth route.

## Test plan

- [x] New unit test `packages/gateway/src/__tests__/routes/mcp-oauth.test.ts` sends a malicious `error` (`"><script>alert(1)</script>`) and `error_description` (`<script>alert("xss")</script>`) through the callback and asserts the raw payloads are absent and the HTML-escaped forms are present.
- [x] Existing `oauth-templates.test.ts` still passes (3/3).
- [x] All route tests pass (20/20).
- [x] `make build-packages` succeeds.
- [x] `bun run typecheck` succeeds.