### PR TITLE
fix(owletto-backend): use parameter binding in content-search to prevent SQL injection

### DIFF
--- a/packages/owletto-backend/src/utils/__tests__/sql-validation.test.ts
+++ b/packages/owletto-backend/src/utils/__tests__/sql-validation.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+import { validateAndFormatIds, validateNumericId } from '../sql-validation';
+
+describe('validateNumericId', () => {
+  it('accepts non-negative integers', () => {
+    expect(validateNumericId(0, 'id')).toBe(0);
+    expect(validateNumericId(42, 'id')).toBe(42);
+    expect(validateNumericId(2 ** 31 - 1, 'id')).toBe(2 ** 31 - 1);
+  });
+
+  it('rejects negative integers', () => {
+    expect(() => validateNumericId(-1, 'id')).toThrow(/Invalid id/);
+  });
+
+  it('rejects non-integer numbers', () => {
+    expect(() => validateNumericId(1.5, 'id')).toThrow(/Invalid id/);
+    expect(() => validateNumericId(Number.NaN, 'id')).toThrow(/Invalid id/);
+    expect(() => validateNumericId(Number.POSITIVE_INFINITY, 'id')).toThrow(/Invalid id/);
+  });
+
+  it('rejects SQL injection payloads masquerading as numbers', () => {
+    // This is the shape a TypeScript type coercion bypass would look like at
+    // runtime: an untyped JSON body smuggling a string through a number-typed
+    // field. The validator must refuse it so the value never reaches an SQL
+    // string builder.
+    const malicious = "1) OR 1=1; DROP TABLE watchers; --" as unknown as number;
+    expect(() => validateNumericId(malicious, 'exclude_watcher_id')).toThrow(
+      /Invalid exclude_watcher_id/
+    );
+  });
+});
+
+describe('validateAndFormatIds', () => {
+  it('joins valid integer ids as a comma-separated string', () => {
+    expect(validateAndFormatIds([1, 2, 3], 'connection_ids')).toBe('1,2,3');
+  });
+
+  it('rejects empty or nullish arrays', () => {
+    expect(() => validateAndFormatIds([], 'connection_ids')).toThrow(/non-empty array/);
+    expect(() => validateAndFormatIds(null as unknown as number[], 'connection_ids')).toThrow(
+      /non-empty array/
+    );
+  });
+
+  it('rejects arrays containing non-integers or negatives', () => {
+    expect(() => validateAndFormatIds([1, -2, 3], 'connection_ids')).toThrow(
+      /Invalid connection_ids/
+    );
+    expect(() => validateAndFormatIds([1, 1.5, 3], 'connection_ids')).toThrow(
+      /Invalid connection_ids/
+    );
+  });
+
+  it('rejects arrays with injected strings', () => {
+    const malicious = [1, "2); DROP TABLE connections; --" as unknown as number];
+    expect(() => validateAndFormatIds(malicious, 'connection_ids')).toThrow(
+      /Invalid connection_ids/
+    );
+  });
+});

--- a/packages/owletto-backend/src/utils/content-scoring.ts
+++ b/packages/owletto-backend/src/utils/content-scoring.ts
@@ -3,34 +3,7 @@ import { buildClassificationFilterSQL } from './content-query-filters';
 import { entityLinkMatchSql } from './content-search';
 import logger from './logger';
 import { getScoringFormulaSql, resolveStoredScoringProfile } from './scoring-profiles';
-
-/**
- * Validate and format an array of IDs for safe SQL usage.
- * Ensures all values are valid integers to prevent SQL injection.
- * @throws Error if any value is not a valid integer
- */
-function validateAndFormatIds(ids: number[], fieldName: string): string {
-  if (!ids || ids.length === 0) {
-    throw new Error(`${fieldName} must be a non-empty array`);
-  }
-  for (const id of ids) {
-    if (!Number.isInteger(id) || id < 0) {
-      throw new Error(`Invalid ${fieldName}: ${id} is not a valid positive integer`);
-    }
-  }
-  return ids.join(',');
-}
-
-/**
- * Validate a single numeric ID for safe SQL usage.
- * @throws Error if value is not a valid integer
- */
-function validateNumericId(value: number, fieldName: string): number {
-  if (!Number.isInteger(value) || value < 0) {
-    throw new Error(`Invalid ${fieldName}: ${value} is not a valid positive integer`);
-  }
-  return value;
-}
+import { validateAndFormatIds, validateNumericId } from './sql-validation';
 
 export interface NormalizedScoreFilters {
   connection_ids?: number[];

--- a/packages/owletto-backend/src/utils/content-search.ts
+++ b/packages/owletto-backend/src/utils/content-search.ts
@@ -19,6 +19,7 @@ import { generateEmbeddings } from './embeddings';
 import { toVectorLiteral } from './entity-management';
 import logger from './logger';
 import { expandSearchQueries } from './query-expansion';
+import { validateNumericId } from './sql-validation';
 
 const CONTEXT_CASE_SQL = `
         CASE
@@ -219,18 +220,31 @@ const WINDOW_JOIN_SQL = `LEFT JOIN watcher_window_events iwf
           AND iwf.window_id = $5::int`;
 
 /**
- * Build NOT EXISTS clause to exclude content already in any window for a given watcher
+ * Build NOT EXISTS clause to exclude content already in any window for a given
+ * watcher. The watcher id is both validated (integer check) and bound as a query
+ * parameter — validation guards against obvious injection attempts and the
+ * parameter binding is the real defense.
+ *
  * @param excludeWatcherId - Watcher ID to exclude content for
+ * @param baseParamIndex - Next 1-based `$N` index to allocate for bound params
  * @param tableAlias - Alias for the content table (default: 'f')
- * @returns SQL clause string or empty string if not filtering
+ * @returns `{ sql, params }` — empty strings/arrays when no filter is applied
  */
-function buildExcludeWatcherClause(excludeWatcherId: number | undefined, tableAlias = 'f'): string {
-  if (excludeWatcherId === undefined) return '';
-  return ` AND NOT EXISTS (
+function buildExcludeWatcherClause(
+  excludeWatcherId: number | undefined,
+  baseParamIndex: number,
+  tableAlias = 'f'
+): { sql: string; params: unknown[] } {
+  if (excludeWatcherId === undefined) return { sql: '', params: [] };
+  const validated = validateNumericId(excludeWatcherId, 'exclude_watcher_id');
+  return {
+    sql: ` AND NOT EXISTS (
     SELECT 1 FROM watcher_window_events exc_iwe
     JOIN watcher_windows exc_iw ON exc_iw.id = exc_iwe.window_id
-    WHERE exc_iwe.event_id = ${tableAlias}.id AND exc_iw.watcher_id = ${excludeWatcherId}
-  )`;
+    WHERE exc_iwe.event_id = ${tableAlias}.id AND exc_iw.watcher_id = $${baseParamIndex}::bigint
+  )`,
+    params: [validated],
+  };
 }
 
 /**
@@ -767,7 +781,6 @@ async function listContentInternal(
   if (hasClassificationFilters && filtersBySlug) {
     const classifierVersionIds = await resolveClassifierVersionIds(sql, filtersBySlug, entityId);
     const connectionFilterClause = buildConnectionFilter(connectionIdsArray);
-    const excludeClause = buildExcludeWatcherClause(options.exclude_watcher_id);
 
     const baseConditions: string[] = [];
     const baseParams: any[] = [];
@@ -842,10 +855,15 @@ async function listContentInternal(
 
     baseConditions.push(...classificationExists.clauses);
     const whereSql = baseConditions.length > 0 ? baseConditions.join(' AND ') : '1=1';
-    const allFilterParams = [...baseParams, ...classificationExists.params];
+    const filterParamsBeforeExclude = [...baseParams, ...classificationExists.params];
+    const excludeClause = buildExcludeWatcherClause(
+      options.exclude_watcher_id,
+      filterParamsBeforeExclude.length + 1
+    );
+    const allFilterParams = [...filterParamsBeforeExclude, ...excludeClause.params];
 
     const countResult = await sql.unsafe<{ total: number | string }>(
-      `SELECT COUNT(*) as total FROM current_event_records f LEFT JOIN connections c ON c.id = f.connection_id WHERE ${whereSql} ${excludeClause}`,
+      `SELECT COUNT(*) as total FROM current_event_records f LEFT JOIN connections c ON c.id = f.connection_id WHERE ${whereSql} ${excludeClause.sql}`,
       allFilterParams
     );
     const total = parseInt(String(countResult[0]?.total ?? '0'), 10);
@@ -859,6 +877,7 @@ async function listContentInternal(
     const queryBaseParams = [...allFilterParams, ...cursorClause.params];
     const limitIndex = queryBaseParams.length + 1;
     const offsetIndex = queryBaseParams.length + 2;
+    const validatedLimit = validateNumericId(limit, 'limit');
     const ctes = needClassifications
       ? `${threadMetaCteSql},\n        ${latestClassificationsCteSql}`
       : threadMetaCteSql;
@@ -872,7 +891,7 @@ async function listContentInternal(
           FROM current_event_records f
           LEFT JOIN connections c ON c.id = f.connection_id
           WHERE ${whereSql}
-            ${excludeClause}
+            ${excludeClause.sql}
             ${cursorClause.sql}
           ORDER BY ${buildDateCandidateOrderBy(cursor, 'f')}
           LIMIT $${limitIndex}
@@ -883,7 +902,7 @@ async function listContentInternal(
             (SELECT COUNT(*) FROM candidate_set) as cursor_fetched_count
           FROM candidate_set cs
           ORDER BY ${buildDateCandidateOrderBy(cursor, 'cs')}
-          LIMIT ${limit}
+          LIMIT ${validatedLimit}
         ),
         ${ctes}
         ${mkFinalSelect(!!needClassifications)}`
@@ -894,7 +913,7 @@ async function listContentInternal(
             NULL::bigint as cursor_fetched_count
           FROM current_event_records f
           LEFT JOIN connections c ON c.id = f.connection_id
-          WHERE ${whereSql} ${excludeClause}
+          WHERE ${whereSql} ${excludeClause.sql}
           ORDER BY ${orderByForResultSet}
           LIMIT $${limitIndex} OFFSET $${offsetIndex}
         ),
@@ -926,14 +945,18 @@ async function listContentInternal(
   }
 
   const connectionCondition = buildConnectionFilter(connectionIdsArray);
-  const excludeClause = buildExcludeWatcherClause(options.exclude_watcher_id);
   const standardParams = buildStandardParams(options, { sinceDate, untilDate });
   const orgScope = buildOrgScopeWhere({
     entity_id: entityId,
     organization_id: organizationId,
     baseParamIndex: standardParams.length + 1,
   });
-  const countParams = [...standardParams, ...orgScope.params];
+  const paramsBeforeExclude = [...standardParams, ...orgScope.params];
+  const excludeClause = buildExcludeWatcherClause(
+    options.exclude_watcher_id,
+    paramsBeforeExclude.length + 1
+  );
+  const countParams = [...paramsBeforeExclude, ...excludeClause.params];
 
   const countResult = await sql.unsafe(
     `SELECT COUNT(*) as total FROM current_event_records f
@@ -941,7 +964,7 @@ async function listContentInternal(
       ${WINDOW_JOIN_SQL}
       WHERE ${STANDARD_WHERE_SQL}
         AND ${connectionCondition}
-        ${excludeClause}
+        ${excludeClause.sql}
         ${orgScope.sql}`,
     countParams
   );
@@ -960,6 +983,7 @@ async function listContentInternal(
   const queryBaseParams = [...countParams, ...cursorClause.params];
   const limitIdx = queryBaseParams.length + 1;
   const offsetIdx = queryBaseParams.length + 2;
+  const validatedLimit = validateNumericId(limit, 'limit');
   const querySQL = useDateFeed
     ? `
       WITH RECURSIVE candidate_set AS (
@@ -971,7 +995,7 @@ async function listContentInternal(
         ${WINDOW_JOIN_SQL}
         WHERE ${STANDARD_WHERE_SQL}
           AND ${connectionCondition}
-          ${excludeClause}
+          ${excludeClause.sql}
           ${orgScope.sql}
           ${cursorClause.sql}
         ORDER BY ${buildDateCandidateOrderBy(cursor, 'f')}
@@ -983,7 +1007,7 @@ async function listContentInternal(
           (SELECT COUNT(*) FROM candidate_set) as cursor_fetched_count
         FROM candidate_set cs
         ORDER BY ${buildDateCandidateOrderBy(cursor, 'cs')}
-        LIMIT ${limit}
+        LIMIT ${validatedLimit}
       ),
       ${ctes}
       ${mkFinalSelect(!!needClassifications)}`
@@ -997,7 +1021,7 @@ async function listContentInternal(
         ${WINDOW_JOIN_SQL}
         WHERE ${STANDARD_WHERE_SQL}
           AND ${connectionCondition}
-          ${excludeClause}
+          ${excludeClause.sql}
           ${orgScope.sql}
         ORDER BY ${orderByForResultSet}
         LIMIT $${limitIdx} OFFSET $${offsetIdx}
@@ -1116,7 +1140,14 @@ async function searchContentBySingleQuery(
     }
   }
   const hasEmbedding = queryEmbedding !== null;
-  const minSimilarity = options.min_similarity ?? 0.3;
+  // Clamp to [0, 1] so a caller can't produce an always-true / always-false
+  // predicate with an out-of-range value. Non-numeric input falls back to the
+  // default. The parameter is still bound (not interpolated) below for defense
+  // in depth.
+  const rawMinSimilarity = Number(options.min_similarity ?? 0.3);
+  const minSimilarity = Number.isFinite(rawMinSimilarity)
+    ? Math.max(0, Math.min(1, rawMinSimilarity))
+    : 0.3;
 
   const sinceDate = options.since ? parseDateAlias(options.since).date : null;
   const untilDate = options.until ? toEndOfDay(parseDateAlias(options.until).date) : null;
@@ -1128,15 +1159,24 @@ async function searchContentBySingleQuery(
     (options.classification_filters && options.classification_filters.length > 0);
 
   const connectionCondition = buildConnectionFilter(connectionIdsArray);
-  const excludeClause = buildExcludeWatcherClause(options.exclude_watcher_id);
 
   const orgScope = buildOrgScopeWhere({
     entity_id: entityId,
     organization_id: options.organization_id,
     baseParamIndex: 11,
   });
-  const baseParamIdx = 11 + orgScope.params.length;
+  // Exclude-watcher param slot sits immediately after orgScope so its $N index
+  // is stable regardless of whether an embedding param follows.
+  const excludeParamIdx = 11 + orgScope.params.length;
+  const excludeClause = buildExcludeWatcherClause(
+    options.exclude_watcher_id,
+    excludeParamIdx
+  );
+  const baseParamIdx = excludeParamIdx + excludeClause.params.length;
   const vectorParamIdx = hasEmbedding ? baseParamIdx : null;
+  // Bind min_similarity as a numeric parameter after the vector slot (when
+  // present) so a hostile float can't break out of the comparison expression.
+  const minSimilarityParamIdx = baseParamIdx + (hasEmbedding ? 1 : 0);
 
   const standardFiltersSQL = `($2::bigint IS NULL OR ${entityLinkMatchSql('$2::bigint')})
           AND ${connectionCondition}
@@ -1148,7 +1188,7 @@ async function searchContentBySingleQuery(
           AND ($8::numeric IS NULL OR f.score <= $8::numeric)
           AND ($9::text IS NULL OR f.semantic_type = $9::text)
           AND ($10::text IS NULL OR f.interaction_status = $10::text)
-          ${excludeClause}
+          ${excludeClause.sql}
           ${orgScope.sql}`;
 
   const textDocumentExpr = buildSearchDocumentExpr('f');
@@ -1158,8 +1198,9 @@ async function searchContentBySingleQuery(
   // branch to be the sole filter in that case.
   const textMatchExpr = `(LENGTH($1) > 0 AND (f.payload_text ILIKE '%' || $1 || '%' OR COALESCE(${textDocumentExpr} @@ ${TSQUERY_SQL}, false)))`;
   const vecParam = vectorParamIdx ? `$${vectorParamIdx}::vector` : 'NULL::vector';
+  const minSimilarityParam = `$${minSimilarityParamIdx}::numeric`;
   const matchCondition = hasEmbedding
-    ? `(${textMatchExpr} OR (f.embedding IS NOT NULL AND 1 - (f.embedding <=> ${vecParam}) >= ${minSimilarity}))`
+    ? `(${textMatchExpr} OR (f.embedding IS NOT NULL AND 1 - (f.embedding <=> ${vecParam}) >= ${minSimilarityParam}))`
     : textMatchExpr;
 
   const searchWhereSQL = `${matchCondition}
@@ -1228,10 +1269,13 @@ async function searchContentBySingleQuery(
     ? `${searchThreadCteSql},\n      ${latestClassificationsCteSql}`
     : searchThreadCteSql;
 
-  const cursorBaseParamIdx = baseParamIdx + (hasEmbedding ? 1 : 0);
+  // When hasEmbedding, two params (vector + min_similarity) follow baseParamIdx;
+  // otherwise neither is bound, so the cursor params resume at baseParamIdx.
+  const cursorBaseParamIdx = baseParamIdx + (hasEmbedding ? 2 : 0);
   const cursorClause = buildDateCursorClause(cursor, 'fi.occurred_at', 'fi.id', cursorBaseParamIdx);
   const limitParamIdx = cursorBaseParamIdx + cursorClause.params.length;
   const offsetParamIdx = limitParamIdx + 1;
+  const validatedLimit = validateNumericId(limit, 'limit');
   const querySQL = useDateFeed
     ? `
       WITH RECURSIVE filtered_ids AS (
@@ -1269,7 +1313,7 @@ async function searchContentBySingleQuery(
           (SELECT COUNT(*) FROM candidate_set) as cursor_fetched_count
         FROM candidate_set cs
         ORDER BY ${buildDateCandidateOrderBy(cursor, 'cs')}
-        LIMIT ${limit}
+        LIMIT ${validatedLimit}
       ),
       ${ctes}
       ${searchFinalSelect}`
@@ -1312,7 +1356,8 @@ async function searchContentBySingleQuery(
     options.semantic_type ?? null,
     options.interaction_status ?? null,
     ...orgScope.params,
-    ...(hasEmbedding ? [toVectorLiteral(queryEmbedding!)] : []),
+    ...excludeClause.params,
+    ...(hasEmbedding ? [toVectorLiteral(queryEmbedding!), minSimilarity] : []),
     ...cursorClause.params,
     ...(useDateFeed ? [fetchLimit] : [limit, effectiveOffset]),
   ];

--- a/packages/owletto-backend/src/utils/sql-validation.ts
+++ b/packages/owletto-backend/src/utils/sql-validation.ts
@@ -1,0 +1,34 @@
+/**
+ * SQL validation helpers for values that must be safely interpolated into SQL
+ * (e.g. inside CTE LIMIT clauses, IN (...) lists, or other positions where
+ * `pg`/`postgres` bind parameters are awkward). Prefer parameter binding when
+ * possible; these validators are a defense-in-depth layer for the rest.
+ */
+
+/**
+ * Validate and format an array of IDs for safe SQL usage.
+ * Ensures all values are valid non-negative integers to prevent SQL injection.
+ * @throws Error if any value is not a valid non-negative integer
+ */
+export function validateAndFormatIds(ids: number[], fieldName: string): string {
+  if (!ids || ids.length === 0) {
+    throw new Error(`${fieldName} must be a non-empty array`);
+  }
+  for (const id of ids) {
+    if (!Number.isInteger(id) || id < 0) {
+      throw new Error(`Invalid ${fieldName}: ${id} is not a valid positive integer`);
+    }
+  }
+  return ids.join(',');
+}
+
+/**
+ * Validate a single numeric ID for safe SQL usage.
+ * @throws Error if value is not a valid non-negative integer
+ */
+export function validateNumericId(value: number, fieldName: string): number {
+  if (!Number.isInteger(value) || value < 0) {
+    throw new Error(`Invalid ${fieldName}: ${value} is not a valid positive integer`);
+  }
+  return value;
+}


### PR DESCRIPTION
## Summary

HIGH-severity SQL injection fix in `packages/owletto-backend/src/utils/content-search.ts`.

### Vulnerability

`buildExcludeWatcherClause` string-interpolated `exclude_watcher_id` directly into the query it returned:

```ts
WHERE exc_iwe.event_id = ${tableAlias}.id AND exc_iw.watcher_id = ${excludeWatcherId}
```

`ContentSearchOptions.exclude_watcher_id` is typed `number` in TypeScript, but any runtime path that skips runtime validation of the shape (untyped JSON body, REST query string parsing, MCP tool arg, etc.) could smuggle arbitrary SQL through this field. The sibling `content-scoring.ts` already had a `validateNumericId` helper for exactly this reason.

### Fix

- Extract the existing `validateNumericId` / `validateAndFormatIds` helpers from `content-scoring.ts` into a shared `utils/sql-validation.ts` so both sibling query builders share the same guard (no duplicate local copies).
- Refactor `buildExcludeWatcherClause` to validate `exclude_watcher_id` (integer check) **and** bind it as a `$N::bigint` parameter. Thread the param index + value through all three call sites in `listContentInternal` and `searchContentBySingleQuery`. Both layers matter: the validator prevents obvious injection attempts, the parameter binding is the real defense.
- Apply the same defense-in-depth pass to the other user-influenced values still interpolated into SQL strings in `content-search.ts`:
  - `LIMIT ${limit}` in the three CTE slices (lines 905, 1010, 1314 in the new file) now goes through `validateNumericId`.
  - `min_similarity` is clamped to `[0, 1]` (with a finite-number guard for non-numeric input) and bound as a `$N::numeric` parameter instead of being interpolated into the cosine-distance comparison expression.

### Test plan

- [x] New unit test `src/utils/__tests__/sql-validation.test.ts` exercises the validator against representative SQL-injection payloads masquerading as a number (e.g. `"1) OR 1=1; DROP TABLE watchers; --"`).
- [x] Existing `content-query-filters` unit tests pass.
- [x] `bun run typecheck` (repo-wide) passes.
- [x] `make build-packages` passes.
- [ ] Integration suites exercising `listContent` / `searchContentByText` in CI (no DB available locally in this worktree).