### PR TITLE
fix(gateway): require worker auth on /api/bedrock/* to prevent unauthenticated AWS spend

### DIFF
--- a/packages/gateway/src/__tests__/bedrock-openai-service.test.ts
+++ b/packages/gateway/src/__tests__/bedrock-openai-service.test.ts
@@ -1,7 +1,18 @@
 import { describe, expect, test } from "bun:test";
+import { generateWorkerToken } from "@lobu/core";
 import type { Model } from "@mariozechner/pi-ai/dist/types.js";
 import { BedrockModelCatalog } from "../services/bedrock-model-catalog";
 import { BedrockOpenAIService } from "../services/bedrock-openai-service";
+
+process.env.ENCRYPTION_KEY ??=
+  "0000000000000000000000000000000000000000000000000000000000000000";
+
+function workerAuthHeader(): Record<string, string> {
+  const token = generateWorkerToken("user-test", "conv-test", "deploy-test", {
+    channelId: "channel-test",
+  });
+  return { Authorization: `Bearer ${token}` };
+}
 
 function createCatalog() {
   return new BedrockModelCatalog({
@@ -27,7 +38,9 @@ describe("BedrockOpenAIService", () => {
 
     const response = await service
       .getApp()
-      .request("http://localhost/openai/a/test-agent/v1/models");
+      .request("http://localhost/openai/a/test-agent/v1/models", {
+        headers: workerAuthHeader(),
+      });
 
     expect(response.status).toBe(200);
     expect(await response.json()).toEqual({
@@ -81,7 +94,7 @@ describe("BedrockOpenAIService", () => {
       .getApp()
       .request("http://localhost/openai/a/test-agent/v1/chat/completions", {
         method: "POST",
-        headers: { "Content-Type": "application/json" },
+        headers: { "Content-Type": "application/json", ...workerAuthHeader() },
         body: JSON.stringify({
           model: "amazon.nova-lite-v1:0",
           stream: true,
@@ -140,7 +153,7 @@ describe("BedrockOpenAIService", () => {
       .getApp()
       .request("http://localhost/openai/a/test-agent/v1/chat/completions", {
         method: "POST",
-        headers: { "Content-Type": "application/json" },
+        headers: { "Content-Type": "application/json", ...workerAuthHeader() },
         body: JSON.stringify({
           model: "custom.model-v1:0",
           stream: true,
@@ -153,5 +166,44 @@ describe("BedrockOpenAIService", () => {
     expect(resolvedModel?.id).toBe("custom.model-v1:0");
     expect(resolvedModel?.provider).toBe("amazon-bedrock");
     expect(resolvedModel?.api).toBe("bedrock-converse-stream");
+  });
+
+  test("rejects unauthenticated /openai requests with 401", async () => {
+    const service = new BedrockOpenAIService({
+      modelCatalog: createCatalog(),
+    });
+
+    const models = await service
+      .getApp()
+      .request("http://localhost/openai/a/test-agent/v1/models");
+    expect(models.status).toBe(401);
+
+    const completion = await service
+      .getApp()
+      .request("http://localhost/openai/a/test-agent/v1/chat/completions", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          model: "amazon.nova-lite-v1:0",
+          messages: [{ role: "user", content: "hi" }],
+        }),
+      });
+    expect(completion.status).toBe(401);
+
+    const badToken = await service
+      .getApp()
+      .request("http://localhost/openai/a/test-agent/v1/models", {
+        headers: { Authorization: "Bearer not-a-real-token" },
+      });
+    expect(badToken.status).toBe(401);
+  });
+
+  test("leaves /health unauthenticated for probes", async () => {
+    const service = new BedrockOpenAIService({
+      modelCatalog: createCatalog(),
+    });
+
+    const response = await service.getApp().request("http://localhost/health");
+    expect(response.status).toBe(200);
   });
 });

--- a/packages/gateway/src/auth/bedrock/provider-module.ts
+++ b/packages/gateway/src/auth/bedrock/provider-module.ts
@@ -4,10 +4,10 @@ import type { BedrockModelCatalog } from "../../services/bedrock-model-catalog";
 import { BaseProviderModule } from "../base-provider-module";
 import type { AuthProfilesManager } from "../settings/auth-profiles-manager";
 
-const BEDROCK_PROXY_CREDENTIAL = "bedrock-proxy";
 const BEDROCK_ROUTE_PREFIX = "/api/bedrock/openai";
 const BEDROCK_BASE_URL_ENV = "AMAZON_BEDROCK_BASE_URL";
 const BEDROCK_CREDENTIAL_ENV = "AMAZON_BEDROCK_API_KEY";
+const WORKER_TOKEN_ENV = "WORKER_TOKEN";
 const DEFAULT_BEDROCK_MODEL = "amazon.nova-lite-v1:0";
 
 function hasAwsCredentialHint(): boolean {
@@ -58,8 +58,13 @@ export class BedrockProviderModule extends BaseProviderModule {
   override injectSystemKeyFallback(
     envVars: Record<string, string>
   ): Record<string, string> {
-    if (!envVars[BEDROCK_CREDENTIAL_ENV]) {
-      envVars[BEDROCK_CREDENTIAL_ENV] = BEDROCK_PROXY_CREDENTIAL;
+    // The Bedrock service authenticates callers with a worker JWT, so the
+    // SDK-facing "API key" is populated with the worker's own token. That
+    // way the OpenAI SDK's `Authorization: Bearer <key>` header carries a
+    // verifiable worker credential to /api/bedrock/*.
+    const workerToken = envVars[WORKER_TOKEN_ENV];
+    if (workerToken) {
+      envVars[BEDROCK_CREDENTIAL_ENV] = workerToken;
     }
     return envVars;
   }
@@ -68,8 +73,9 @@ export class BedrockProviderModule extends BaseProviderModule {
     _agentId: string,
     envVars: Record<string, string>
   ): Promise<Record<string, string>> {
-    if (!envVars[BEDROCK_CREDENTIAL_ENV]) {
-      envVars[BEDROCK_CREDENTIAL_ENV] = BEDROCK_PROXY_CREDENTIAL;
+    const workerToken = envVars[WORKER_TOKEN_ENV];
+    if (workerToken) {
+      envVars[BEDROCK_CREDENTIAL_ENV] = workerToken;
     }
     return envVars;
   }
@@ -89,8 +95,17 @@ export class BedrockProviderModule extends BaseProviderModule {
     };
   }
 
-  buildCredentialPlaceholder(): string {
-    return BEDROCK_PROXY_CREDENTIAL;
+  buildCredentialPlaceholder(
+    _agentId: string,
+    context?: import("../../embedded").ProviderCredentialContext
+  ): string {
+    // The /api/bedrock/* route authenticates callers with a worker JWT.
+    // Workers forward their WORKER_TOKEN as the Bearer credential via the
+    // OpenAI SDK's `Authorization` header, so the "placeholder" handed to
+    // the runtime is the worker's own token. Orchestrated deploys inject
+    // the same value through `buildEnvVars` / `injectSystemKeyFallback`;
+    // embedded workers receive it through the session-context endpoint.
+    return context?.workerToken ?? "";
   }
 
   getProviderMetadata(): ConfigProviderMeta {

--- a/packages/gateway/src/embedded.ts
+++ b/packages/gateway/src/embedded.ts
@@ -10,6 +10,13 @@ export interface ProviderCredentialContext {
   deploymentName?: string;
   platform?: string;
   connectionId?: string;
+  /**
+   * The worker's JWT, when the caller is a worker. Providers whose gateway
+   * routes authenticate via worker auth (e.g. Bedrock) use this as the
+   * credential/placeholder handed back to the runtime so the OpenAI SDK
+   * sends `Authorization: Bearer <workerToken>` on upstream calls.
+   */
+  workerToken?: string;
 }
 
 export interface RuntimeProviderCredentialLookup

--- a/packages/gateway/src/gateway/index.ts
+++ b/packages/gateway/src/gateway/index.ts
@@ -462,7 +462,8 @@ export class WorkerGateway {
       const providerConfig = await this.resolveProviderConfig(
         agentSettings?.templateAgentId || agentId || "",
         resolveEffectiveModelRef(agentSettings),
-        baseUrl
+        baseUrl,
+        auth.token
       );
 
       // Fetch enabled skills with content for worker filesystem sync
@@ -576,7 +577,8 @@ export class WorkerGateway {
   private async resolveProviderConfig(
     agentId: string,
     agentModel?: string,
-    requestBaseUrl?: string
+    requestBaseUrl?: string,
+    workerToken?: string
   ): Promise<{
     credentialEnvVarName?: string;
     defaultProvider?: string;
@@ -662,12 +664,14 @@ export class WorkerGateway {
 
     // Build credential placeholders for proxy mode — in-process workers need
     // these so the runtime doesn't reject requests before they reach the proxy.
+    // Providers that authenticate via the worker JWT (e.g. Bedrock) receive
+    // the worker token so their placeholder *is* a verifiable credential.
     const credentialPlaceholders: Record<string, string> = {};
     for (const provider of effectiveProviders) {
       if (provider.hasSystemKey() || (await provider.hasCredentials(agentId))) {
         const credVar = provider.getCredentialEnvVarName();
         const placeholder = provider.buildCredentialPlaceholder
-          ? await provider.buildCredentialPlaceholder(agentId)
+          ? await provider.buildCredentialPlaceholder(agentId, { workerToken })
           : "lobu-proxy";
         credentialPlaceholders[credVar] = placeholder;
       }

--- a/packages/gateway/src/orchestration/base-deployment-manager.ts
+++ b/packages/gateway/src/orchestration/base-deployment-manager.ts
@@ -698,9 +698,16 @@ export abstract class BaseDeploymentManager {
     }
 
     let hasSecrets = false;
+    const workerToken = envVars.WORKER_TOKEN;
     for (const [key, value] of Object.entries(envVars)) {
       if (!value || !isSecretEnvVar(key, this.providerModules)) continue;
       if (key === "WORKER_TOKEN") continue;
+      // Some providers (e.g. Bedrock) authenticate workers by JWT and
+      // legitimately put the worker's own WORKER_TOKEN into the credential
+      // env var — the gateway verifies it on the incoming request. In that
+      // case we must not swap the value for a placeholder; the worker needs
+      // the real JWT to call the gateway route.
+      if (workerToken && value === workerToken) continue;
 
       if (providerCredentialVars.has(key)) {
         // Provider credentials use a proxy placeholder. The worker never

--- a/packages/gateway/src/services/bedrock-openai-service.ts
+++ b/packages/gateway/src/services/bedrock-openai-service.ts
@@ -4,6 +4,7 @@ import type { Model } from "@mariozechner/pi-ai/dist/types.js";
 import type { Context } from "hono";
 import { Hono } from "hono";
 import { createLogger } from "@lobu/core";
+import { authenticateWorker } from "../routes/internal/middleware";
 import {
   BedrockModelCatalog,
   buildDynamicBedrockModel,
@@ -533,6 +534,11 @@ export class BedrockOpenAIService {
         region: resolveAwsRegion() || null,
       })
     );
+
+    // All routes below this line require a valid worker JWT. Without auth
+    // anyone on the network could burn AWS Bedrock spend through this
+    // gateway-owned IAM bridge and exfiltrate model outputs.
+    this.app.use("/openai/*", authenticateWorker);
 
     this.app.get("/openai/a/:agentId/v1/models", async (c) => {
       const models = await this.modelCatalog.listModelOptions();


### PR DESCRIPTION
## Threat

`/api/bedrock/openai/*` was mounted without any authentication in `packages/gateway/src/services/bedrock-openai-service.ts` (setupRoutes) and wired into the app at `packages/gateway/src/cli/gateway.ts`. Anyone with network reachability to the gateway could hit:

- `POST /api/bedrock/openai/a/<agentId>/v1/chat/completions` to invoke AWS Bedrock models through the gateway's own IAM credentials, directly burning AWS spend
- `GET  /api/bedrock/openai/a/<agentId>/v1/models` to enumerate the available model catalogue
- Exfiltrate any prompt/output routed through this proxy

This is an unauthenticated bridge to a paid, IAM-holding service. It had to be closed.

## Mitigation

Apply the existing `authenticateWorker` middleware (the same one used for `/api/internal/*` routes) to all `/openai/*` paths on the Bedrock service. `/health` stays public so Kubernetes probes continue to work.

Workers hand their `WORKER_TOKEN` to the OpenAI SDK as `AMAZON_BEDROCK_API_KEY`, so the SDK's `Authorization: Bearer <jwt>` header carries a verifiable worker credential. The credential plumbing:

- `BedrockProviderModule.{buildEnvVars,injectSystemKeyFallback,buildCredentialPlaceholder}`: pull `WORKER_TOKEN` from `envVars` / `ProviderCredentialContext.workerToken` instead of a static `"bedrock-proxy"` string
- `BaseDeploymentManager.injectSecretPlaceholders`: skip values that match the worker token so the secret-proxy swap does not clobber the JWT
- `WorkerGateway.handleSessionContextRequest`: plumb `auth.token` into `resolveProviderConfig` so embedded / in-process workers receive a verifiable placeholder via the session-context endpoint

No fallback auth, no optional middleware — if you do not have a valid worker JWT you cannot reach `/api/bedrock/openai/*`.

## Callers audit

Grepped `packages/worker/`, `packages/core/`, `packages/cli/` for `/api/bedrock`, `AMAZON_BEDROCK_BASE_URL`, `AMAZON_BEDROCK_API_KEY`, and `bedrock-proxy`. The only references outside the gateway package are in `.claude/worktrees/*` scratch directories. No admin-facing UI calls these routes.

## Test plan

- [x] `make build-packages` (all three packages build cleanly)
- [x] `bun run typecheck` (0 errors)
- [x] `bun test packages/gateway/src/__tests__/bedrock-openai-service.test.ts packages/gateway/src/__tests__/bedrock-provider-module.test.ts` (8 pass)
- [x] Full gateway test suite: `bun test packages/gateway/src/__tests__/` (490 pass)
- [x] New regression tests assert `/openai/*` returns 401 without a token, 401 with a bogus Bearer, and 200 with a real worker JWT; `/health` stays 200 unauthenticated