### PR TITLE
feat(landing): restore Integrate dropdown on copy-prompt CTAs

### DIFF
--- a/packages/landing/src/components/BenchmarkSection.tsx
+++ b/packages/landing/src/components/BenchmarkSection.tsx
@@ -8,8 +8,8 @@ export function BenchmarkSection() {
     <section class="pt-20 pb-20 px-4 sm:px-8">
       <ContentRail variant="compact">
         <SectionHeader
-          title="Beats Mem0 and Supermemory on public benchmarks"
-          body="Apples-to-apples comparison on public memory datasets. Same answerer (glm-5.1 via z.ai), same top-K, same questions."
+          title="Lobu in memory benchmarks"
+          body="Apples-to-apples comparison on public memory datasets. The model is GLM 5.1 via z.ai."
           className="mb-10"
         />
 

--- a/packages/landing/src/components/CommandHero.tsx
+++ b/packages/landing/src/components/CommandHero.tsx
@@ -1,11 +1,19 @@
 import type { ComponentChildren } from "preact";
-import { CopyPromptButton } from "./CopyPromptButton";
+import {
+  CopyPromptButton,
+  type SupportedPromptClientId,
+} from "./CopyPromptButton";
 
 type CommandHeroProps = {
   title: ComponentChildren;
   description: string;
   prompt?: string;
   promptLabel?: string;
+  promptTriggerLabel?: string;
+  supportedClients?: SupportedPromptClientId[];
+  supportedClientHrefForId?: (
+    clientId: SupportedPromptClientId
+  ) => string | undefined;
   actions?: ComponentChildren;
   footer?: ComponentChildren;
 };
@@ -15,6 +23,9 @@ export function CommandHero({
   description,
   prompt,
   promptLabel = "Copy prompt to your agent",
+  promptTriggerLabel,
+  supportedClients,
+  supportedClientHrefForId,
   actions,
   footer,
 }: CommandHeroProps) {
@@ -35,7 +46,14 @@ export function CommandHero({
 
       <div class="mt-10 flex flex-wrap items-center justify-center gap-3 mb-4">
         {actions}
-        <CopyPromptButton prompt={prompt} label={promptLabel} />
+        <CopyPromptButton
+          prompt={prompt}
+          label={promptLabel}
+          triggerLabel={promptTriggerLabel}
+          variant="outline-muted"
+          supportedClients={supportedClients}
+          supportedClientHrefForId={supportedClientHrefForId}
+        />
       </div>
 
       {footer ? <div class="mt-6">{footer}</div> : null}

--- a/packages/landing/src/components/CopyPromptButton.tsx
+++ b/packages/landing/src/components/CopyPromptButton.tsx
@@ -1,5 +1,5 @@
 import type { JSX } from "preact";
-import { useState } from "preact/hooks";
+import { useEffect, useRef, useState } from "preact/hooks";
 
 export type SupportedPromptClientId =
   | "chatgpt"
@@ -10,8 +10,12 @@ export type SupportedPromptClientId =
 type CopyPromptButtonProps = {
   prompt?: string;
   label: string;
+  triggerLabel?: string;
   variant?: "surface" | "outline-muted";
   supportedClients?: SupportedPromptClientId[];
+  supportedClientHrefForId?: (
+    clientId: SupportedPromptClientId
+  ) => string | undefined;
 };
 
 function useCopy(value?: string) {
@@ -99,6 +103,24 @@ function McpClientIcon({ size = 12 }: { size?: number }) {
   );
 }
 
+function ChevronDownIcon({ size = 12 }: { size?: number }) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="2"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      aria-hidden="true"
+    >
+      <path d="m6 9 6 6 6-6" />
+    </svg>
+  );
+}
+
 const supportedClientMeta: Record<
   SupportedPromptClientId,
   {
@@ -127,113 +149,202 @@ const supportedClientMeta: Record<
 export function CopyPromptButton({
   prompt,
   label,
+  triggerLabel,
   variant = "surface",
   supportedClients = [],
+  supportedClientHrefForId,
 }: CopyPromptButtonProps) {
   const { copied, handleCopy } = useCopy(prompt);
-  const [previewOpen, setPreviewOpen] = useState(false);
+  const [menuOpen, setMenuOpen] = useState(false);
+  const menuRef = useRef<HTMLDivElement>(null);
   const isOutline = variant === "outline-muted";
-  const supportedClientLabel = supportedClients.length
+  const hasSupportedClients = supportedClients.length > 0;
+  const supportedClientLabel = hasSupportedClients
     ? `Works with ${supportedClients
         .map((clientId) => supportedClientMeta[clientId].label)
         .join(", ")}`
     : undefined;
 
+  useEffect(() => {
+    if (!menuOpen) {
+      return;
+    }
+
+    const handlePointerDown = (event: MouseEvent) => {
+      if (!menuRef.current?.contains(event.target as Node)) {
+        setMenuOpen(false);
+      }
+    };
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        setMenuOpen(false);
+      }
+    };
+
+    document.addEventListener("mousedown", handlePointerDown);
+    document.addEventListener("keydown", handleKeyDown);
+
+    return () => {
+      document.removeEventListener("mousedown", handlePointerDown);
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [menuOpen]);
+
   if (!prompt) return null;
 
+  const buttonBackground = copied
+    ? "rgba(122,162,247,0.18)"
+    : isOutline
+      ? "transparent"
+      : "var(--color-page-surface)";
+  const buttonColor = copied
+    ? "var(--color-page-text)"
+    : isOutline
+      ? "var(--color-page-text-muted)"
+      : "var(--color-page-text)";
+  const buttonBorder = isOutline
+    ? "var(--color-page-border)"
+    : "var(--color-page-border-active)";
+  const buttonText = hasSupportedClients
+    ? (triggerLabel ?? label)
+    : copied
+      ? "Copied"
+      : label;
+
   return (
-    // biome-ignore lint/a11y/noStaticElementInteractions: hover is a progressive enhancement; button itself exposes focus/blur handlers for keyboard users
-    <div
-      class="relative inline-flex flex-col items-center"
-      onMouseEnter={() => setPreviewOpen(true)}
-      onMouseLeave={() => setPreviewOpen(false)}
-    >
+    <div ref={menuRef} class="relative inline-flex flex-col items-center">
       <button
         type="button"
-        onClick={handleCopy}
-        onFocus={() => setPreviewOpen(true)}
-        onBlur={() => setPreviewOpen(false)}
+        onClick={() => {
+          if (hasSupportedClients) {
+            setMenuOpen((open) => !open);
+            return;
+          }
+
+          handleCopy();
+        }}
         class={
           isOutline
             ? "inline-flex items-center gap-2 text-sm font-medium px-5 py-2.5 rounded-lg cursor-pointer transition-all hover:opacity-90"
             : "inline-flex items-center gap-2 rounded-xl px-4 py-2.5 text-[13px] font-medium cursor-pointer transition-colors hover:opacity-90"
         }
         aria-label={
-          supportedClientLabel ? `${label}. ${supportedClientLabel}` : label
+          supportedClientLabel
+            ? `${triggerLabel ?? label}. ${supportedClientLabel}`
+            : buttonText
         }
+        aria-expanded={hasSupportedClients ? menuOpen : undefined}
+        aria-haspopup={hasSupportedClients ? "dialog" : undefined}
         style={{
-          backgroundColor: copied
+          backgroundColor: menuOpen
             ? "rgba(122,162,247,0.18)"
-            : isOutline
-              ? "transparent"
-              : "var(--color-page-surface)",
-          color: copied
-            ? "var(--color-page-text)"
-            : isOutline
-              ? "var(--color-page-text-muted)"
-              : "var(--color-page-text)",
-          border: isOutline
-            ? "1px solid var(--color-page-border)"
-            : "1px solid var(--color-page-border-active)",
+            : buttonBackground,
+          color: menuOpen ? "var(--color-page-text)" : buttonColor,
+          border: `1px solid ${buttonBorder}`,
         }}
       >
-        <span>{copied ? "Copied" : label}</span>
+        <span>{buttonText}</span>
 
-        {supportedClients.length ? (
+        {hasSupportedClients ? (
           <span
-            class="inline-flex items-center gap-1.5 pl-2 ml-1"
             aria-hidden="true"
-            title={supportedClientLabel}
             style={{
-              borderLeft: "1px solid var(--color-page-border)",
+              transform: menuOpen ? "rotate(180deg)" : "rotate(0deg)",
+              transition: "transform 150ms ease",
             }}
           >
-            {supportedClients.map((clientId) => {
-              const client = supportedClientMeta[clientId];
-
-              return (
-                <span
-                  key={clientId}
-                  class="inline-flex h-4 w-4 items-center justify-center"
-                  title={client.label}
-                  style={{ color: "currentColor" }}
-                >
-                  {client.renderIcon(12)}
-                </span>
-              );
-            })}
+            <ChevronDownIcon size={12} />
           </span>
         ) : null}
       </button>
 
-      <div
-        role="tooltip"
-        class="absolute left-1/2 top-full z-20 mt-3 w-[32rem] max-w-[calc(100vw-2rem)] rounded-xl p-3"
-        style={{
-          opacity: previewOpen ? 1 : 0,
-          pointerEvents: previewOpen ? "auto" : "none",
-          transform: previewOpen
-            ? "translateX(-50%) translateY(0)"
-            : "translateX(-50%) translateY(-4px)",
-          transition: "opacity 150ms ease, transform 150ms ease",
-          backgroundColor: "var(--color-page-bg-elevated)",
-          border: "1px solid var(--color-page-border)",
-          boxShadow: "0 18px 50px rgba(0,0,0,0.35)",
-        }}
-      >
+      {hasSupportedClients ? (
         <div
-          class="mb-2 text-[10px] uppercase tracking-[0.18em]"
-          style={{ color: "var(--color-page-text-muted)" }}
+          role="dialog"
+          aria-label="Copy prompt and integration docs"
+          class="absolute left-1/2 top-full z-20 mt-3 min-w-[18rem] max-w-[calc(100vw-2rem)] rounded-xl p-2"
+          style={{
+            opacity: menuOpen ? 1 : 0,
+            pointerEvents: menuOpen ? "auto" : "none",
+            transform: menuOpen
+              ? "translateX(-50%) translateY(0)"
+              : "translateX(-50%) translateY(-4px)",
+            transition: "opacity 150ms ease, transform 150ms ease",
+            backgroundColor: "var(--color-page-bg-elevated)",
+            border: "1px solid var(--color-page-border)",
+            boxShadow: "0 18px 50px rgba(0,0,0,0.35)",
+          }}
         >
-          Prompt preview
+          <div class="grid gap-1">
+            <button
+              type="button"
+              onClick={() => {
+                handleCopy();
+                setMenuOpen(false);
+              }}
+              class="w-full rounded-lg px-3 py-2 text-left text-sm font-medium transition-all hover:opacity-90"
+              style={{
+                backgroundColor: "var(--color-page-surface)",
+                color: "var(--color-page-text)",
+                border: "1px solid var(--color-page-border)",
+              }}
+            >
+              {copied ? "Copied" : label}
+            </button>
+
+            {supportedClients.map((clientId) => {
+              const client = supportedClientMeta[clientId];
+              const href = supportedClientHrefForId?.(clientId);
+              const rowLabel = client.label;
+
+              const rowContent = (
+                <>
+                  <span
+                    class="inline-flex h-4 w-4 items-center justify-center"
+                    aria-hidden="true"
+                  >
+                    {client.renderIcon(12)}
+                  </span>
+                  <span>{rowLabel}</span>
+                </>
+              );
+
+              if (href) {
+                return (
+                  <a
+                    key={clientId}
+                    href={href}
+                    onClick={() => setMenuOpen(false)}
+                    class="inline-flex w-full items-center gap-2 rounded-lg px-3 py-2 text-left text-sm font-medium transition-all hover:opacity-90"
+                    style={{
+                      backgroundColor: "var(--color-page-surface)",
+                      color: "var(--color-page-text)",
+                      border: "1px solid var(--color-page-border)",
+                    }}
+                  >
+                    {rowContent}
+                  </a>
+                );
+              }
+
+              return (
+                <span
+                  key={clientId}
+                  class="inline-flex w-full items-center gap-2 rounded-lg px-3 py-2 text-left text-sm font-medium"
+                  style={{
+                    backgroundColor: "var(--color-page-surface)",
+                    color: "var(--color-page-text)",
+                    border: "1px solid var(--color-page-border)",
+                  }}
+                >
+                  {rowContent}
+                </span>
+              );
+            })}
+          </div>
         </div>
-        <code
-          class="block text-left text-[11px] leading-6 font-mono whitespace-pre-wrap break-words"
-          style={{ color: "var(--color-page-text)" }}
-        >
-          {prompt}
-        </code>
-      </div>
+      ) : null}
     </div>
   );
 }

--- a/packages/landing/src/components/DemoSection.tsx
+++ b/packages/landing/src/components/DemoSection.tsx
@@ -28,39 +28,49 @@ function Card({
   description,
   href,
   hrefLabel,
+  surface = true,
   children,
 }: {
-  title: string;
+  title?: string;
   description?: string;
   href?: string;
   hrefLabel?: string;
+  surface?: boolean;
   children: ComponentChildren;
 }) {
   return (
     <div
-      class="rounded-2xl p-6 h-full"
-      style={{
-        backgroundColor: "var(--color-page-bg-elevated)",
-        border: "1px solid var(--color-page-border)",
-      }}
+      class={surface ? "rounded-2xl p-6 h-full" : "h-full"}
+      style={
+        surface
+          ? {
+              backgroundColor: "var(--color-page-bg-elevated)",
+              border: "1px solid var(--color-page-border)",
+            }
+          : undefined
+      }
     >
-      <div class="flex items-center justify-between gap-3 mb-2">
-        <h3
-          class="text-lg font-semibold"
-          style={{ color: "var(--color-page-text)" }}
-        >
-          {title}
-        </h3>
-        {href ? (
-          <a
-            href={href}
-            class="text-sm font-medium transition-opacity hover:opacity-80 shrink-0"
-            style={{ color: "var(--color-tg-accent)" }}
-          >
-            {hrefLabel ?? `${title} page`} →
-          </a>
-        ) : null}
-      </div>
+      {title || href ? (
+        <div class="flex items-center justify-between gap-3 mb-2">
+          {title ? (
+            <h3
+              class="text-lg font-semibold"
+              style={{ color: "var(--color-page-text)" }}
+            >
+              {title}
+            </h3>
+          ) : <div />}
+          {href ? (
+            <a
+              href={href}
+              class="text-sm font-medium transition-opacity hover:opacity-80 shrink-0"
+              style={{ color: "var(--color-tg-accent)" }}
+            >
+              {hrefLabel ?? `${title ?? "Details"} page`} →
+            </a>
+          ) : null}
+        </div>
+      ) : null}
       {description ? (
         <p
           class="text-sm leading-relaxed mb-4"
@@ -85,8 +95,9 @@ function Panel({
     <div
       class={`rounded-xl p-4${extraClass ? ` ${extraClass}` : ""}`}
       style={{
-        backgroundColor: "rgba(0,0,0,0.28)",
-        border: "1px solid rgba(255,255,255,0.06)",
+        background:
+          "linear-gradient(180deg, rgba(20, 20, 24, 0.98), rgba(12, 12, 16, 0.98))",
+        border: "1px solid rgba(255, 255, 255, 0.09)",
       }}
     >
       {children}
@@ -666,7 +677,7 @@ export function DemoSection(props: {
         )}
 
         <div class="mb-6">
-          <Card title={activeUseCase.label || " Agent"}>
+          <Card surface={false}>
             <RequestBlock
               text={activeUseCase.runtime.request}
               schedule={activeUseCase.runtime.schedule}

--- a/packages/landing/src/components/DemoSection.tsx
+++ b/packages/landing/src/components/DemoSection.tsx
@@ -59,7 +59,9 @@ function Card({
             >
               {title}
             </h3>
-          ) : <div />}
+          ) : (
+            <div />
+          )}
           {href ? (
             <a
               href={href}

--- a/packages/landing/src/components/HeroSection.tsx
+++ b/packages/landing/src/components/HeroSection.tsx
@@ -93,12 +93,12 @@ export function HeroSection(props: {
             class="hero-rise hero-rise-3 text-lg mx-auto mb-4 leading-relaxed max-w-3xl"
             style={{ color: "var(--color-page-text-muted)" }}
           >
-            Pre-built agents for team ops, personal memory, and community
-            workflows — fork one, wire it to your tools, let it run.
+            Deploy AI agents with long-term memory, secure access to your
+            tools, and the same context everywhere they run.
           </p>
         )}
         {/* CTA buttons */}
-        <div class="hero-rise hero-rise-4 flex flex-wrap gap-3 mb-6 justify-center items-center">
+        <div class="hero-rise hero-rise-4 relative z-20 flex flex-wrap gap-3 mb-6 justify-center items-center">
           <a
             href={owlettoUrl}
             target="_blank"
@@ -129,8 +129,16 @@ export function HeroSection(props: {
             <CopyPromptButton
               prompt={getLandingPrompt(activeUseCase)}
               label="Copy prompt to your agent"
+              triggerLabel="Integrate"
               variant="outline-muted"
               supportedClients={["chatgpt", "openclaw", "claude", "mcp-client"]}
+              supportedClientHrefForId={(clientId) => {
+                if (clientId === "mcp-client") {
+                  return "/getting-started/memory/";
+                }
+
+                return `/connect-from/${clientId}/for/${activeUseCase.id}/`;
+              }}
             />
           )}
         </div>

--- a/packages/landing/src/components/HeroSection.tsx
+++ b/packages/landing/src/components/HeroSection.tsx
@@ -93,8 +93,8 @@ export function HeroSection(props: {
             class="hero-rise hero-rise-3 text-lg mx-auto mb-4 leading-relaxed max-w-3xl"
             style={{ color: "var(--color-page-text-muted)" }}
           >
-            Deploy AI agents with long-term memory, secure access to your
-            tools, and the same context everywhere they run.
+            Deploy AI agents with long-term memory, secure access to your tools,
+            and the same context everywhere they run.
           </p>
         )}
         {/* CTA buttons */}

--- a/packages/landing/src/components/MemorySection.tsx
+++ b/packages/landing/src/components/MemorySection.tsx
@@ -68,6 +68,15 @@ export function MemorySection(props: {
             "Owletto gives all your agents the same durable graph: connectors, recall, and managed auth without leaking credentials to the runtime."
           }
           prompt={getMemoryPrompt(activeUseCase)}
+          promptTriggerLabel="Integrate"
+          supportedClients={["chatgpt", "openclaw", "claude", "mcp-client"]}
+          supportedClientHrefForId={(clientId) => {
+            if (clientId === "mcp-client") {
+              return "/getting-started/memory/";
+            }
+
+            return `/connect-from/${clientId}/for/${activeUseCase.id}/`;
+          }}
           actions={
             <a
               href={getOwlettoLoginUrl()}

--- a/packages/landing/src/components/SkillsSection.tsx
+++ b/packages/landing/src/components/SkillsSection.tsx
@@ -706,6 +706,15 @@ export function SkillsSection(props: {
             "A skill isn't a prompt template, it's a full sandboxed computer. All capabilities bundled into one installable unit."
           }
           prompt={getSkillsPrompt(activeUseCase)}
+          promptTriggerLabel="Integrate"
+          supportedClients={["chatgpt", "openclaw", "claude", "mcp-client"]}
+          supportedClientHrefForId={(clientId) => {
+            if (clientId === "mcp-client") {
+              return "/getting-started/skills/";
+            }
+
+            return `/connect-from/${clientId}/for/${activeUseCase.id}/`;
+          }}
           actions={
             <a
               href={getOwlettoLoginUrl()}


### PR DESCRIPTION
## Summary
- Replace the hover-only prompt preview with a proper click-open dropdown on the **Integrate** button. Clicking the trigger now surfaces "Copy prompt" plus one row per supported client (ChatGPT, Claude, OpenClaw, any MCP client), with Escape / click-outside to close.
- Each client row becomes an `<a>` link into the existing `connect-from/{client}/for/{useCase}/` docs (or `/getting-started/memory/` for generic MCP), so visitors land on real setup instructions instead of a naked prompt copy.
- Wires the dropdown into `HeroSection`, `MemorySection`, `SkillsSection` via new `promptTriggerLabel` / `supportedClientHrefForId` props on `CommandHero` + `CopyPromptButton`. Restores from a local stash that predated the recent landing polish.
- Bundles two small copy adjustments that were part of the same stash: benchmark section title, hero subheading.

## Test plan
- [x] `bun run build` in `packages/landing` — 103 pages built clean
- [x] Pre-commit biome + `tsc --noEmit` both pass
- [ ] Post-deploy: open lobu.ai, click **Integrate** on Hero / Memory / Skills sections → dropdown opens, Copy prompt copies, client rows link to `connect-from/*/for/*/` pages