### PR TITLE
docs: rename Owletto to Lobu memory in user-facing copy

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -23,17 +23,17 @@ Scaffold a new Lobu project with interactive prompts:
 - **AI provider** selection from the bundled provider registry + API key
 - **Providers** to enable (from `config/providers.json`)
 - **Messaging platform** (Telegram, Slack, Discord, or none)
-- **Memory** selection (filesystem, Lobu Cloud, Owletto Local, or custom Owletto URL)
+- **Memory** selection (filesystem, Lobu Cloud, Lobu memory Local, or custom Lobu memory URL)
 
 **Generates:** `docker-compose.yml`, `.env`, `Dockerfile.worker`, `lobu.toml`, `IDENTITY.md`, `.gitignore`, `README.md`
 
-When Owletto memory is enabled, `lobu init` also scaffolds the file-first memory layout:
+When Lobu memory is enabled, `lobu init` also scaffolds the file-first memory layout:
 
 - `[memory.owletto]` in `lobu.toml` (org, name, description, models, data)
 - `models/`
 - `data/`
 
-For Owletto Local or a custom Owletto deployment, `.env` keeps `MEMORY_URL` as the optional base MCP URL override.
+For Lobu memory Local or a custom Lobu memory deployment, `.env` keeps `MEMORY_URL` as the optional base MCP URL override.
 
 ## Worker Customization
 

--- a/packages/cli/src/__tests__/init-memory.test.ts
+++ b/packages/cli/src/__tests__/init-memory.test.ts
@@ -66,7 +66,7 @@ describe("init memory scaffolding", () => {
       includeOwlettoLocal: true,
     });
 
-    expect(content).toContain("Optional Owletto base MCP URL override");
+    expect(content).toContain("Optional Lobu memory base MCP URL override");
     expect(content).toContain("MEMORY_URL: ${MEMORY_URL:-}");
     expect(content).toContain("owletto:");
     expect(content).toContain("owletto-postgres:");

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -236,10 +236,10 @@ export async function initCommand(
         { name: "None (filesystem memory)", value: "none" },
         { name: "Lobu Cloud (app.lobu.ai)", value: "owletto-cloud" },
         {
-          name: "Owletto Local (runs alongside gateway)",
+          name: "Lobu memory Local (runs alongside gateway)",
           value: "owletto-local",
         },
-        { name: "Custom Owletto URL", value: "owletto-custom" },
+        { name: "Custom Lobu memory URL", value: "owletto-custom" },
       ],
       default: "none",
     },
@@ -269,7 +269,7 @@ export async function initCommand(
       {
         type: "input",
         name: "customOwlettoUrl",
-        message: "Owletto MCP URL:",
+        message: "Lobu memory MCP URL:",
         validate: (v: string) => (v ? true : "URL is required"),
       },
     ]);
@@ -563,13 +563,13 @@ turns:
       const displayUrl = includeOwlettoLocal
         ? "http://localhost:8787"
         : owlettoUrl;
-      console.log(chalk.cyan("  Owletto:"));
+      console.log(chalk.cyan("  Lobu memory:"));
       console.log(chalk.dim(`     ${displayUrl}\n`));
     }
     console.log(chalk.cyan("  3. Start the services:"));
     console.log(chalk.dim("     npx @lobu/cli@latest run -d\n"));
     if (includeOwlettoLocal) {
-      console.log(chalk.cyan("  4. Set up Owletto (first run):"));
+      console.log(chalk.cyan("  4. Set up Lobu memory (first run):"));
       console.log(
         chalk.dim("     Visit http://localhost:8787 to create your account\n")
       );
@@ -710,7 +710,7 @@ export async function generateLobuToml(
     const name = options.owlettoName ?? humanizeSlug(options.agentName);
     lines.push(
       "",
-      "# Project-scoped Owletto memory",
+      "# Project-scoped Lobu memory",
       `[memory.owletto]`,
       "enabled = true",
       `org = ${JSON.stringify(org)}`,
@@ -858,7 +858,7 @@ ${owlettoServices}
       ENCRYPTION_KEY: \${ENCRYPTION_KEY}
       WORKER_ALLOWED_DOMAINS: \${WORKER_ALLOWED_DOMAINS:-}
       WORKER_DISALLOWED_DOMAINS: \${WORKER_DISALLOWED_DOMAINS:-}
-      # Optional Owletto base MCP URL override. File-first projects derive scoped
+      # Optional Lobu memory base MCP URL override. File-first projects derive scoped
       # memory from [memory.owletto] in lobu.toml.
       MEMORY_URL: \${MEMORY_URL:-}
       LOBU_WORKSPACE_ROOT: /workspace/project

--- a/packages/landing/astro.config.mjs
+++ b/packages/landing/astro.config.mjs
@@ -91,7 +91,7 @@ export default defineConfig({
             { label: "SKILL.md", link: "/reference/skill-md/" },
             { label: "Providers", link: "/reference/providers/" },
             { label: "CLI", link: "/reference/cli/" },
-            { label: "Owletto CLI", link: "/reference/owletto-cli/" },
+            { label: "Lobu memory CLI", link: "/reference/owletto-cli/" },
             { label: "API Reference", link: "/reference/api-reference/" },
           ],
         },

--- a/packages/landing/public/.well-known/agent-skills/index.json
+++ b/packages/landing/public/.well-known/agent-skills/index.json
@@ -20,7 +20,7 @@
     {
       "name": "memory",
       "type": "documentation",
-      "description": "Persistent agent memory via the Owletto integration.",
+      "description": "Persistent agent memory via Lobu memory.",
       "url": "https://lobu.ai/getting-started/memory/"
     },
     {

--- a/packages/landing/public/llms.txt
+++ b/packages/landing/public/llms.txt
@@ -12,7 +12,7 @@
 ## Core concepts
 
 - [Skills](https://lobu.ai/getting-started/skills/): Reusable agent capabilities via SKILL.md
-- [Memory](https://lobu.ai/getting-started/memory/): Persistent agent memory powered by Owletto
+- [Memory](https://lobu.ai/getting-started/memory/): Persistent agent memory powered by Lobu
 - [Architecture](https://lobu.ai/guides/architecture/): Gateway + worker + orchestration overview
 - [Security](https://lobu.ai/guides/security/): Sandboxing, network policy, credential isolation
 - [Tool policy](https://lobu.ai/guides/tool-policy/): Approval model for destructive MCP tools
@@ -47,7 +47,7 @@
 - [SKILL.md](https://lobu.ai/reference/skill-md/)
 - [Providers](https://lobu.ai/reference/providers/)
 - [REST API reference](https://lobu.ai/reference/api-reference/)
-- [Owletto CLI](https://lobu.ai/reference/owletto-cli/)
+- [Lobu memory CLI](https://lobu.ai/reference/owletto-cli/)
 
 ## Guides
 

--- a/packages/landing/src/chat-scenarios.ts
+++ b/packages/landing/src/chat-scenarios.ts
@@ -49,14 +49,14 @@ export const PERMISSION_SCENARIO: UseCase = {
 /**
  * Skill install flow — user asks for a capability, agent proposes installing
  * a Lobu provider (real ID from providers.json), OAuth flows handled by
- * Owletto, user approves via in-chat button.
+ * Lobu, user approves via in-chat button.
  */
 export const SKILL_INSTALL_SCENARIO: UseCase = {
   id: "skill-install",
   tabLabel: "Skill",
   title: "Install a skill",
   description:
-    "Agents propose Lobu skills when they need a capability. Owletto manages OAuth and API keys.",
+    "Agents propose Lobu skills when they need a capability. Lobu manages OAuth and API keys.",
   settingsLabel: "Skills and integrations",
   chatLabel: "Agent installs linear skill",
   botName: "Ops Assistant",
@@ -69,7 +69,7 @@ export const SKILL_INSTALL_SCENARIO: UseCase = {
     },
     {
       role: "bot",
-      text: "I need the `linear` skill to query Linear.\n\nIt bundles the Linear MCP and handles OAuth via Owletto.",
+      text: "I need the `linear` skill to query Linear.\n\nIt bundles the Linear MCP and handles OAuth via Lobu.",
       buttons: [{ label: "Install linear", action: "link" }],
     },
     {

--- a/packages/landing/src/components/ArchitectureDiagram.tsx
+++ b/packages/landing/src/components/ArchitectureDiagram.tsx
@@ -249,7 +249,7 @@ function GatewayColumn({ useCaseId }: { useCaseId?: LandingUseCaseId }) {
       </div>
       <AgentStack useCaseId={useCaseId} />
       <AttachmentPill
-        label="Owletto Memory"
+        label="Lobu Memory"
         href={`/memory${suffix}`}
         icon={<MemoryIcon size={11} />}
       />

--- a/packages/landing/src/components/MemorySection.tsx
+++ b/packages/landing/src/components/MemorySection.tsx
@@ -65,7 +65,7 @@ export function MemorySection(props: {
           }
           description={
             props.heroCopy?.description ??
-            "Owletto gives all your agents the same durable graph: connectors, recall, and managed auth without leaking credentials to the runtime."
+            "Lobu memory gives all your agents the same durable graph: connectors, recall, and managed auth without leaking credentials to the runtime."
           }
           prompt={getMemoryPrompt(activeUseCase)}
           promptTriggerLabel="Integrate"
@@ -122,8 +122,8 @@ export function MemorySection(props: {
 
         <ContentRail variant="compact">
           <SectionHeader
-            title="Beats Mem0 and Supermemory on public benchmarks"
-            body="Apples-to-apples comparison on public memory datasets. Same answerer (glm-5.1 via z.ai), same top-K, same questions."
+            title="Beats other memory systems on public benchmarks"
+            body="Apples-to-apples comparison on public memory datasets. Same answerer (glm-5.1) and same questions."
             className="mb-10"
           />
 
@@ -173,7 +173,7 @@ export function MemorySection(props: {
               }}
             >
               <GitHubIcon />
-              Owletto on GitHub
+              Lobu on GitHub
             </a>
             <ScheduleCallButton
               class="inline-flex items-center gap-2 text-xs font-medium px-4 py-2 rounded-lg transition-all hover:opacity-80"

--- a/packages/landing/src/components/PricingSection.tsx
+++ b/packages/landing/src/components/PricingSection.tsx
@@ -58,7 +58,7 @@ const plans: PricingPlan[] = [
     features: [
       "Deploy in minutes",
       "Managed gateway and scaling",
-      "Built-in integrations via Owletto",
+      "Built-in integrations via Lobu memory",
       "Credential isolation included",
       "No infrastructure to operate",
     ],

--- a/packages/landing/src/components/SkillsWorkflowSection.tsx
+++ b/packages/landing/src/components/SkillsWorkflowSection.tsx
@@ -119,7 +119,7 @@ function getInitLinesForUseCase(useCase: LandingUseCaseShowcase): TermLine[] {
           selected: config.memory === "filesystem",
         },
         {
-          label: "Owletto",
+          label: "Lobu memory",
           href: `/memory/for/${useCase.id}`,
           selected: config.memory === "owletto",
         },

--- a/packages/landing/src/components/connect-from/ConnectFromDocContent.astro
+++ b/packages/landing/src/components/connect-from/ConnectFromDocContent.astro
@@ -84,7 +84,7 @@ const relatedLinks = client.docsRelated.map((link) => {
 ) : null}
 
 <p>
-  Paste this into {client.label} and it will install Owletto memory for you.
+  Paste this into {client.label} and it will install Lobu memory for you.
 </p>
 <CopyableSnippet
   client:load

--- a/packages/landing/src/components/memory/BenchmarkTables.tsx
+++ b/packages/landing/src/components/memory/BenchmarkTables.tsx
@@ -93,10 +93,7 @@ export function BenchmarkTable(props: {
           {props.subtitle}
         </p>
       </div>
-      <table
-        class="w-full table-fixed text-sm"
-        style={{ color: textColor }}
-      >
+      <table class="w-full table-fixed text-sm" style={{ color: textColor }}>
         <colgroup>
           <col style={{ width: "34%" }} />
           <col style={{ width: "17%" }} />

--- a/packages/landing/src/components/memory/BenchmarkTables.tsx
+++ b/packages/landing/src/components/memory/BenchmarkTables.tsx
@@ -10,12 +10,12 @@ import {
 //   - this component
 //   - packages/landing/src/content/docs/guides/memory-benchmarks.md
 //   - packages/landing/src/content/docs/getting-started/comparison.md
-//   - packages/owletto/README.md (source of truth)
-// Refresh all four on each Owletto memory-benchmark release.
+//   - Lobu memory (Owletto) benchmarks README (source of truth)
+// Refresh all four on each Lobu memory-benchmark release.
 // last updated: 2026-04-21
 export const LONGMEMEVAL_ROWS: BenchmarkRow[] = [
   {
-    system: "Owletto",
+    system: "Lobu",
     overall: "87.1%",
     answer: "78.0%",
     retrieval: "100.0%",
@@ -40,7 +40,7 @@ export const LONGMEMEVAL_ROWS: BenchmarkRow[] = [
 
 export const LOCOMO_ROWS: BenchmarkRow[] = [
   {
-    system: "Owletto",
+    system: "Lobu",
     overall: "57.8%",
     answer: "38.0%",
     retrieval: "79.5%",
@@ -79,7 +79,7 @@ export function BenchmarkTable(props: {
 }) {
   return (
     <div
-      class="rounded-2xl p-6 sm:p-8"
+      class="rounded-2xl p-5 sm:p-6"
       style={{
         background: cardBg,
         border: `1px solid ${cardBorder}`,
@@ -93,68 +93,76 @@ export function BenchmarkTable(props: {
           {props.subtitle}
         </p>
       </div>
-      <div class="overflow-x-auto">
-        <table class="w-full text-sm" style={{ color: textColor }}>
-          <thead>
+      <table
+        class="w-full table-fixed text-sm"
+        style={{ color: textColor }}
+      >
+        <colgroup>
+          <col style={{ width: "34%" }} />
+          <col style={{ width: "17%" }} />
+          <col style={{ width: "15%" }} />
+          <col style={{ width: "17%" }} />
+          <col style={{ width: "17%" }} />
+        </colgroup>
+        <thead>
+          <tr
+            class="text-left text-[10px] uppercase tracking-wide"
+            style={{ color: textMuted }}
+          >
+            <th class="font-medium pb-3 pr-2">System</th>
+            <th class="font-medium pb-3 px-1.5 text-right">Overall</th>
+            <th class="font-medium pb-3 px-1.5 text-right">Answer</th>
+            <th class="font-medium pb-3 px-1.5 text-right">Retrieval</th>
+            <th class="font-medium pb-3 pl-1.5 text-right">Latency</th>
+          </tr>
+        </thead>
+        <tbody>
+          {props.rows.map((row) => (
             <tr
-              class="text-left text-[11px] uppercase tracking-wider"
-              style={{ color: textMuted }}
+              key={row.system}
+              style={{
+                background: row.leader ? innerCardBg : "transparent",
+              }}
             >
-              <th class="font-medium pb-3 pr-4">System</th>
-              <th class="font-medium pb-3 px-3 text-right">Overall</th>
-              <th class="font-medium pb-3 px-3 text-right">Answer</th>
-              <th class="font-medium pb-3 px-3 text-right">Retrieval</th>
-              <th class="font-medium pb-3 pl-3 text-right">Latency</th>
-            </tr>
-          </thead>
-          <tbody>
-            {props.rows.map((row) => (
-              <tr
-                key={row.system}
+              <td
+                class="py-2.5 pr-2 font-medium truncate"
                 style={{
-                  background: row.leader ? innerCardBg : "transparent",
+                  color: row.leader ? textColor : textMuted,
                 }}
               >
-                <td
-                  class="py-2.5 pr-4 font-medium"
-                  style={{
-                    color: row.leader ? textColor : textMuted,
-                  }}
-                >
-                  {row.system}
-                </td>
-                <td
-                  class="py-2.5 px-3 text-right tabular-nums"
-                  style={{
-                    color: row.leader ? textColor : textMuted,
-                    fontWeight: row.leader ? 600 : 400,
-                  }}
-                >
-                  {row.overall}
-                </td>
-                <td
-                  class="py-2.5 px-3 text-right tabular-nums"
-                  style={{ color: row.leader ? textColor : textMuted }}
-                >
-                  {row.answer}
-                </td>
-                <td
-                  class="py-2.5 px-3 text-right tabular-nums"
-                  style={{ color: row.leader ? textColor : textMuted }}
-                >
-                  {row.retrieval}
-                </td>
-                <td
-                  class="py-2.5 pl-3 text-right tabular-nums"
-                  style={{ color: row.leader ? textColor : textMuted }}
-                >
-                  {row.latency}
-                </td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
-      </div>
+                {row.system}
+              </td>
+              <td
+                class="py-2.5 px-1.5 text-right tabular-nums"
+                style={{
+                  color: row.leader ? textColor : textMuted,
+                  fontWeight: row.leader ? 600 : 400,
+                }}
+              >
+                {row.overall}
+              </td>
+              <td
+                class="py-2.5 px-1.5 text-right tabular-nums"
+                style={{ color: row.leader ? textColor : textMuted }}
+              >
+                {row.answer}
+              </td>
+              <td
+                class="py-2.5 px-1.5 text-right tabular-nums"
+                style={{ color: row.leader ? textColor : textMuted }}
+              >
+                {row.retrieval}
+              </td>
+              <td
+                class="py-2.5 pl-1.5 text-right tabular-nums"
+                style={{ color: row.leader ? textColor : textMuted }}
+              >
+                {row.latency}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
     </div>
   );
 }

--- a/packages/landing/src/connect-from-config.ts
+++ b/packages/landing/src/connect-from-config.ts
@@ -25,13 +25,13 @@ type ConnectFromClientConfig = {
   docsHref: string;
   docsLabel: string;
   /**
-   * One-liner shown directly under the page title that explains what Owletto
+   * One-liner shown directly under the page title that explains what Lobu memory
    * adds to this agent.
    */
   valueProp: string;
   /**
    * The text the user copies into their agent (or assistant) so it can install
-   * Owletto memory for them.
+   * Lobu memory for them.
    */
   installPrompt: string;
   /**
@@ -62,20 +62,20 @@ export const connectFromClientConfigs: Record<
     valueProp:
       "Add structured, queryable long-term memory to ChatGPT — the same graph other agents share, recalled and updated through one MCP endpoint.",
     installPrompt:
-      "Connect ChatGPT to Owletto: open Settings → Integrations → Model Context Protocol → Add Server, name it `Owletto`, and paste the MCP URL https://app.lobu.ai/mcp. Sign in with your Owletto account when prompted, then point ChatGPT at the workspace I want it to use.",
+      "Connect ChatGPT to Lobu memory: open Settings → Integrations → Model Context Protocol → Add Server, name it `Lobu memory`, and paste the MCP URL https://app.lobu.ai/mcp. Sign in with your Lobu account when prompted, then point ChatGPT at the workspace I want it to use.",
     describe: mcpClientDescribe("ChatGPT"),
     docsSetupTitle: "Connect ChatGPT",
     docsSetupSteps: [
       "Open Settings → Integrations → Model Context Protocol → Add Server in ChatGPT.",
-      "Name the server `Owletto` and paste https://app.lobu.ai/mcp as the URL.",
-      "Complete the Owletto sign-in flow in the popup.",
+      "Name the server `Lobu memory` and paste https://app.lobu.ai/mcp as the URL.",
+      "Complete the Lobu sign-in flow in the popup.",
       "Pick the workspace ChatGPT should read and write.",
     ],
     docsSetupNote:
       "ChatGPT discovers the available memory tools automatically once the MCP connection is approved.",
     docsRelated: [
       { label: "Memory", href: "/getting-started/memory/" },
-      { label: "Owletto CLI Reference", href: "/reference/owletto-cli/" },
+      { label: "Lobu memory CLI Reference", href: "/reference/owletto-cli/" },
     ],
   },
   claude: {
@@ -86,13 +86,13 @@ export const connectFromClientConfigs: Record<
     valueProp:
       "Give Claude durable, structured memory it can search and append to — so the same recall is available across Claude, ChatGPT, and your own agents.",
     installPrompt:
-      "Connect Claude to Owletto: open Settings → Connectors → Add Custom Connector, paste the MCP URL https://app.lobu.ai/mcp, complete the Owletto sign-in, then enable the connector. Pick the workspace I want Claude to read and write.",
+      "Connect Claude to Lobu memory: open Settings → Connectors → Add Custom Connector, paste the MCP URL https://app.lobu.ai/mcp, complete the Lobu sign-in, then enable the connector. Pick the workspace I want Claude to read and write.",
     describe: mcpClientDescribe("Claude"),
     docsSetupTitle: "Connect Claude",
     docsSetupSteps: [
       "Open Settings → Connectors → Add Custom Connector in Claude Desktop or claude.ai.",
       "Paste https://app.lobu.ai/mcp as the MCP URL.",
-      "Complete the Owletto sign-in flow.",
+      "Complete the Lobu sign-in flow.",
       "Enable the connector and choose the workspace Claude should use.",
     ],
     docsSetupNote:
@@ -107,7 +107,7 @@ export const connectFromClientConfigs: Record<
     docsRelated: [
       { label: "Memory", href: "/getting-started/memory/" },
       { label: "Skills", href: "/getting-started/skills/" },
-      { label: "Owletto CLI Reference", href: "/reference/owletto-cli/" },
+      { label: "Lobu memory CLI Reference", href: "/reference/owletto-cli/" },
     ],
   },
   openclaw: {
@@ -116,9 +116,9 @@ export const connectFromClientConfigs: Record<
     docsHref: "/connect-from/openclaw/",
     docsLabel: "OpenClaw setup docs",
     valueProp:
-      "Layer structured, shareable memory on top of OpenClaw's built-in filesystem memory — the plugin extends OpenClaw's filesystem plugin and can optionally take over its memory slot, so different OpenClaw agents can talk to each other through the same Owletto graph.",
+      "Layer structured, shareable memory on top of OpenClaw's built-in filesystem memory — the plugin extends OpenClaw's filesystem plugin and can optionally take over its memory slot, so different OpenClaw agents can talk to each other through the same Lobu memory graph.",
     installPrompt:
-      "Install Owletto memory in OpenClaw. Run:\n\n  openclaw plugins install owletto-openclaw-plugin\n  owletto login https://app.lobu.ai/mcp\n  owletto configure\n  owletto health\n\nThe plugin extends OpenClaw's filesystem plugin and can replace its memory slot. After install, point me at the Owletto workspace I should use as shared memory across my OpenClaw agents.",
+      "Install Lobu memory in OpenClaw. Run:\n\n  openclaw plugins install owletto-openclaw-plugin\n  owletto login https://app.lobu.ai/mcp\n  owletto configure\n  owletto health\n\nThe plugin extends OpenClaw's filesystem plugin and can replace its memory slot. After install, point me at the Lobu memory workspace I should use as shared memory across my OpenClaw agents.",
     npmPackage: {
       name: "@lobu/owletto-openclaw",
       registryUrl: "https://www.npmjs.com/package/@lobu/owletto-openclaw",
@@ -127,25 +127,25 @@ export const connectFromClientConfigs: Record<
       installCommand: "openclaw plugins install owletto-openclaw-plugin",
     },
     describe: (showcase) =>
-      `Install Owletto into OpenClaw and point it at the ${showcase.label.toLowerCase()} workspace so multiple OpenClaw agents share the same memory shown in this example.`,
+      `Install Lobu memory into OpenClaw and point it at the ${showcase.label.toLowerCase()} workspace so multiple OpenClaw agents share the same memory shown in this example.`,
     docsSetupTitle: "Install in OpenClaw",
     docsSetupSteps: [
       "Install the plugin: `openclaw plugins install owletto-openclaw-plugin`.",
-      "Log in to Owletto: `owletto login https://app.lobu.ai/mcp`.",
+      "Log in to Lobu: `owletto login https://app.lobu.ai/mcp`.",
       "Wire it into OpenClaw: `owletto configure` (writes the plugin config and, if you opt in, takes over the filesystem memory slot).",
       "Verify: `owletto health`.",
     ],
     docsSetupNote:
-      "The plugin extends OpenClaw's filesystem plugin. Leave that plugin enabled if you want both, or let `owletto configure` swap Owletto in as the memory slot.",
+      "The plugin extends OpenClaw's filesystem plugin. Leave that plugin enabled if you want both, or let `owletto configure` swap Lobu memory in as the memory slot.",
     docsExtraSection: {
       title: "Cross-agent memory",
       paragraphs: [
-        "Once two OpenClaw agents point at the same Owletto workspace, they read and write the same entities, observations, and decisions — that is how a team of OpenClaw agents stays coherent without copy-pasting context.",
+        "Once two OpenClaw agents point at the same Lobu memory workspace, they read and write the same entities, observations, and decisions — that is how a team of OpenClaw agents stays coherent without copy-pasting context.",
       ],
     },
     docsRelated: [
       { label: "Memory", href: "/getting-started/memory/" },
-      { label: "Owletto CLI Reference", href: "/reference/owletto-cli/" },
+      { label: "Lobu memory CLI Reference", href: "/reference/owletto-cli/" },
     ],
   },
 };

--- a/packages/landing/src/content/blog/filesystem-vs-database-agent-memory.mdx
+++ b/packages/landing/src/content/blog/filesystem-vs-database-agent-memory.mdx
@@ -109,12 +109,12 @@ Good agents should be able to **think messily and remember cleanly**.
 Lobu makes this split explicit.
 
 - Every agent has a local workspace.
-- In file-first projects, Lobu enables Owletto from `[memory.owletto]` in `lobu.toml`.
-- `MEMORY_URL` is still supported as an optional base-endpoint override for local or custom Owletto deployments.
-- If no Owletto config is resolved, Lobu uses `@openclaw/native-memory`, so memory stays local to that workspace.
-- If Owletto is configured, Lobu uses `@lobu/owletto-openclaw` when that plugin is installed, otherwise it falls back to native memory.
+- In file-first projects, Lobu enables Lobu memory from `[memory.owletto]` in `lobu.toml`.
+- `MEMORY_URL` is still supported as an optional base-endpoint override for local or custom Lobu memory deployments.
+- If no Lobu memory config is resolved, Lobu uses `@openclaw/native-memory`, so memory stays local to that workspace.
+- If Lobu memory is configured, Lobu uses `@lobu/owletto-openclaw` when that plugin is installed, otherwise it falls back to native memory.
 
-Owletto is the shared organizational memory layer:
+Lobu memory is the shared organizational memory layer:
 
 - shared across agents and sessions
 - structured as entities, relationships, and events
@@ -124,7 +124,7 @@ Owletto is the shared organizational memory layer:
 So the practical model is:
 
 - **filesystem** = ephemeral working state
-- **Owletto** = durable organizational knowledge
+- **Lobu memory** = durable organizational knowledge
 
 ## The short version
 
@@ -137,5 +137,5 @@ That is why serious agent systems usually need both.
 ## Read next
 
 - [Memory](/getting-started/memory/)
-- [Owletto memory overview](/memory)
+- [Lobu memory overview](/memory)
 - [Agent Settings](/guides/agent-settings/)

--- a/packages/landing/src/content/docs/connect-from/chatgpt.mdx
+++ b/packages/landing/src/content/docs/connect-from/chatgpt.mdx
@@ -1,6 +1,6 @@
 ---
 title: Connect from ChatGPT
-description: Connect ChatGPT to Owletto memory so it can read and write shared organizational context.
+description: Connect ChatGPT to Lobu memory so it can read and write shared organizational context.
 ---
 
 import ConnectFromDocContent from "../../../components/connect-from/ConnectFromDocContent.astro";

--- a/packages/landing/src/content/docs/connect-from/claude.mdx
+++ b/packages/landing/src/content/docs/connect-from/claude.mdx
@@ -1,6 +1,6 @@
 ---
 title: Connect from Claude
-description: Connect Claude to Owletto memory so Claude-based workflows can reuse shared context.
+description: Connect Claude to Lobu memory so Claude-based workflows can reuse shared context.
 ---
 
 import ConnectFromDocContent from "../../../components/connect-from/ConnectFromDocContent.astro";

--- a/packages/landing/src/content/docs/connect-from/openclaw.mdx
+++ b/packages/landing/src/content/docs/connect-from/openclaw.mdx
@@ -1,6 +1,6 @@
 ---
 title: Install to OpenClaw
-description: Install and configure Owletto memory in OpenClaw with the Owletto memory plugin.
+description: Install and configure Lobu memory in OpenClaw with the Lobu memory plugin.
 ---
 
 import ConnectFromDocContent from "../../../components/connect-from/ConnectFromDocContent.astro";

--- a/packages/landing/src/content/docs/getting-started/comparison.md
+++ b/packages/landing/src/content/docs/getting-started/comparison.md
@@ -23,14 +23,14 @@ This page compares Lobu against alternatives for deploying agents to production.
 | **MCP support** | Proxied through gateway with secret injection | Direct | HTTP/SSE only | Yes |
 | **Agent Protocol / A2A** | Not yet | No | Yes | No |
 | **Built-in evals** | YAML eval framework with model comparison | No | No | No |
-| **Memory** | Owletto plugin (self-hosted) | Local | LangSmith APIs | Platform-managed |
+| **Memory** | Self-hosted Lobu memory plugin | Local | LangSmith APIs | Platform-managed |
 | **Scale-to-zero** | Built-in idle timeout | Always running | Managed by LangSmith | Managed |
 | **Config format** | `lobu.toml` + IDENTITY/SOUL/USER.md | CLI flags | `deepagents.toml` + AGENTS.md | Dashboard |
 | **License** | Open source | Open source | MIT (harness), proprietary (hosting) | Proprietary |
 
 ## Memory benchmarks
 
-Lobu's bundled memory system (Owletto) is benchmarked against Mem0 and Supermemory on public datasets. Same answerer (`glm-5.1` via z.ai), same top-K, same questions.
+Lobu's bundled memory system is benchmarked against Mem0 and Supermemory on public datasets. Same answerer (`glm-5.1` via z.ai), same top-K, same questions.
 
 ### LongMemEval (oracle-50)
 
@@ -38,7 +38,7 @@ Single-session knowledge retention.
 
 | System | Overall | Answer | Retrieval | Latency |
 |---|---:|---:|---:|---:|
-| **Owletto** | **87.1%** | **78.0%** | **100.0%** | 237ms |
+| **Lobu** | **87.1%** | **78.0%** | **100.0%** | 237ms |
 | Supermemory | 69.1% | 56.0% | 96.6% | 702ms |
 | Mem0 | 65.7% | 54.0% | 85.3% | 753ms |
 
@@ -48,11 +48,11 @@ Multi-session conversational memory.
 
 | System | Overall | Answer | Retrieval | Latency |
 |---|---:|---:|---:|---:|
-| **Owletto** | **57.8%** | **38.0%** | **79.5%** | **121ms** |
+| **Lobu** | **57.8%** | **38.0%** | **79.5%** | **121ms** |
 | Mem0 | 41.5% | 28.0% | 66.9% | 606ms |
 | Supermemory | 23.2% | 14.0% | 36.5% | 532ms |
 
-See the [memory benchmarks methodology](/guides/memory-benchmarks/) for fairness guardrails and reproduction steps, or the [harness README](https://github.com/lobu-ai/owletto/blob/main/benchmarks/memory/README.md) in the Owletto repo.
+See the [memory benchmarks methodology](/guides/memory-benchmarks/) for fairness guardrails and reproduction steps.
 
 ## Sandboxing and deployment modes
 
@@ -102,7 +102,7 @@ Workers call MCP tools through the gateway. The gateway resolves `${env:VAR}` se
 | | Lobu | DeepAgents Deploy | Claude Managed Agents | Direct MCP |
 |---|---|---|---|---|
 | Secret injection | Gateway proxy resolves at request time | Environment variables | Platform-managed | Direct env vars |
-| OAuth management | Owletto handles token refresh | Manual | Platform-managed | Manual |
+| OAuth management | Lobu handles token refresh | Manual | Platform-managed | Manual |
 | Transport support | HTTP, SSE, stdio (proxied) | HTTP/SSE only (no stdio) | Yes | All |
 | Worker sees credentials | Never | Yes (env vars) | N/A | Yes |
 | Audit trail | Gateway logs all MCP calls | No | No | No |
@@ -167,7 +167,7 @@ Inside each Lobu worker, the full OpenClaw runtime runs untouched. Lobu rewrites
 | Network isolation | Gateway-mediated domain filtering | Sandbox-level |
 | Protocols | MCP | MCP, A2A, Agent Protocol |
 | Evals | Built-in YAML framework | Not included |
-| Memory ownership | Fully self-hosted (Owletto) | LangSmith APIs (self-host option) |
+| Memory ownership | Fully self-hosted (Lobu memory) | LangSmith APIs (self-host option) |
 | Runtime | OpenClaw | LangGraph |
 
 **Choose DeepAgents Deploy** if you want zero-ops hosted deployment and need A2A multi-agent orchestration.

--- a/packages/landing/src/content/docs/getting-started/index.mdx
+++ b/packages/landing/src/content/docs/getting-started/index.mdx
@@ -25,7 +25,7 @@ npx @lobu/cli@latest eval
 my-agent/
 ├── lobu.toml                  # agents, providers, skills, network
 ├── .env                       # secrets (API keys, OAuth tokens)
-├── docker-compose.yml         # Redis + gateway + optional Owletto
+├── docker-compose.yml         # Redis + gateway + optional Lobu memory
 ├── AGENTS.md                  # briefing for coding agents
 ├── README.md
 ├── TESTING.md
@@ -37,8 +37,8 @@ my-agent/
 │   └── evals/
 │       └── ping.yaml          # test cases for agent quality
 ├── skills/                    # skills shared across all agents
-├── models/                    # Owletto entity schemas (if memory enabled)
-└── data/                      # Owletto seed entities and relationships
+├── models/                    # Lobu memory entity schemas (if memory enabled)
+└── data/                      # Lobu memory seed entities and relationships
 ```
 
 | Path | Docs |

--- a/packages/landing/src/content/docs/getting-started/memory.mdx
+++ b/packages/landing/src/content/docs/getting-started/memory.mdx
@@ -1,17 +1,16 @@
 ---
 title: Memory
-description: How Lobu uses Owletto for shared, structured memory across agents, threads, and teams.
+description: How Lobu memory provides shared, structured memory across agents, threads, and teams.
 ---
 
 Lobu has two memory layers:
 
 - **Filesystem** for short-term working memory inside a specific channel or user space
-- **Owletto** for long-term organizational memory shared across the workspace
+- **Lobu memory** for long-term organizational memory shared across the workspace
 
-The filesystem is where an agent does work. Owletto is where the organization remembers what matters.
+The filesystem is where an agent does work. Lobu memory is where the organization remembers what matters.
 
-- Owletto site: [app.lobu.ai](https://app.lobu.ai)
-- GitHub: [lobu-ai/owletto](https://github.com/lobu-ai/owletto)
+- Lobu memory site: [app.lobu.ai](https://app.lobu.ai)
 - Lobu memory overview: [/memory](/memory)
 
 ## Short-Term Vs Long-Term Memory
@@ -25,7 +24,7 @@ Each Lobu channel or user space gets its own filesystem — the agent's working 
 
 Useful, but not a good long-term system of record. The agent may know where files are in its local workspace, but other agents and future sessions usually do not.
 
-Owletto is the shared knowledge system for the organization:
+Lobu memory is the shared knowledge system for the organization:
 
 - stores durable knowledge in entities
 - makes that knowledge queryable and analyzable
@@ -34,18 +33,18 @@ Owletto is the shared knowledge system for the organization:
 
 ```text
 filesystem = short-term working memory + artifacts
-owletto = long-term organizational memory
+lobu memory = long-term organizational memory
 ```
 
 ## Why Both Exist
 
 An analyst might download PDFs into a local folder, write Python to parse them, generate CSVs and charts, then load the final result into a warehouse so the rest of the org can query it later.
 
-Lobu agents work the same way. The filesystem is where the messy work happens. Owletto is where the agent stores the durable, structured result so it can be recalled later across users, channels, and agents.
+Lobu agents work the same way. The filesystem is where the messy work happens. Lobu memory is where the agent stores the durable, structured result so it can be recalled later across users, channels, and agents.
 
-## What Owletto Adds
+## What Lobu Memory Adds
 
-Compared with local filesystem memory, Owletto gives Lobu:
+Compared with local filesystem memory, Lobu memory gives agents:
 
 - Workspace-scoped memory shared across agents, users, and threads
 - Typed entities and relationships instead of loose notes
@@ -58,23 +57,23 @@ Useful when memory needs to outlive one sandbox, machine, channel, or user sessi
 
 ## How Memory Recall Works
 
-Owletto is not just a vector store. It keeps a structured graph of organizations, entity types, entities, events, relationships, connectors, and watcher output.
+Lobu memory is not just a vector store. It keeps a structured graph of organizations, entity types, entities, events, relationships, connectors, and watcher output.
 
 At a high level, the recall loop is:
 
 1. A user sends a message to a Lobu agent.
 2. Lobu routes the request into the worker and loads the active memory plugin.
-3. Owletto identifies likely entities from the prompt and retrieves related knowledge.
+3. Lobu memory identifies likely entities from the prompt and retrieves related knowledge.
 4. Recall combines entity-name matching, full-text search, and semantic vector search.
 5. The recalled memory is injected before prompt construction, so the model reasons with that context from the start.
-6. During the turn, the agent can search, read, and save new knowledge back into Owletto entities.
-7. Users can review or correct the resulting memory in the Owletto UI, which immediately affects future recall.
+6. During the turn, the agent can search, read, and save new knowledge back into Lobu memory entities.
+7. Users can review or correct the resulting memory in the Lobu memory UI, which immediately affects future recall.
 
 That gives you both automatic recall and explicit long-term memory writes.
 
 ## Memory Model
 
-Owletto stores memory under an organization:
+Lobu memory stores data under an organization:
 
 ```text
 Organization
@@ -103,13 +102,13 @@ The append-only event history lets agents and operators inspect what changed ove
 
 That makes it easier to recover from mistakes, understand why an agent believed something, and improve future recall.
 
-The boundary: **artifacts stay in the filesystem**, **durable organizational knowledge gets written into Owletto**. For example:
+The boundary: **artifacts stay in the filesystem**, **durable organizational knowledge gets written into Lobu memory**. For example:
 
 - keep a downloaded PDF, generated chart, or temporary CSV in the filesystem
-- save "customer prefers weekly summaries" or "vendor X owns system Y" into Owletto
-- move final structured outputs into your org systems, and store the durable facts or references in Owletto so agents can find them later
+- save "customer prefers weekly summaries" or "vendor X owns system Y" into Lobu memory
+- move final structured outputs into your org systems, and store the durable facts or references in Lobu memory so agents can find them later
 
-## How Lobu Connects To Owletto
+## How Lobu Wires Memory In
 
 In Lobu, memory is pluggable per agent.
 
@@ -133,12 +132,12 @@ data = "./data"
 
 At runtime, Lobu resolves the memory backend like this:
 
-- If `[memory.owletto]` is enabled, Lobu derives the effective Owletto MCP endpoint from `org` in `[memory.owletto]`.
-- `MEMORY_URL` is still supported as an optional base-endpoint override, mainly for local or custom Owletto deployments.
-- If no Owletto endpoint is resolved, Lobu falls back to `@openclaw/native-memory`.
+- If `[memory.owletto]` is enabled, Lobu derives the effective Lobu memory MCP endpoint from `org` in `[memory.owletto]`.
+- `MEMORY_URL` is still supported as an optional base-endpoint override, mainly for local or custom Lobu memory deployments.
+- If no Lobu memory endpoint is resolved, Lobu falls back to `@openclaw/native-memory`.
 - Agents can also override plugin configuration through `pluginsConfig` in agent settings.
 
-The `@lobu/owletto-openclaw` plugin adapts OpenClaw to Owletto. OpenClaw calls normal memory operations through its plugin interface; the plugin translates those reads and writes into Owletto MCP calls through the gateway proxy, so the worker never needs raw OAuth tokens or direct Owletto credentials.
+The `@lobu/owletto-openclaw` plugin adapts OpenClaw to Lobu memory. OpenClaw calls normal memory operations through its plugin interface; the plugin translates those reads and writes into Lobu memory MCP calls through the gateway proxy, so the worker never needs raw OAuth tokens or direct Lobu memory credentials.
 
 The split lets agents keep using local files for active work while persisting the durable parts into shared structured memory.
 
@@ -146,7 +145,7 @@ See also: [Architecture](/guides/architecture/) and [Agent Settings](/guides/age
 
 ## Compatible Agent Clients
 
-Owletto memory can be used from MCP-compatible clients and agent runtimes, not just Lobu.
+Lobu memory can be used from MCP-compatible clients and agent runtimes, not just Lobu.
 
 Common examples include:
 
@@ -156,7 +155,7 @@ Common examples include:
 - Codex
 - Cursor
 
-For the most up-to-date list of compatible clients and integration patterns, see the [Owletto CLI Reference](/reference/owletto-cli/#which-mcp-tools-are-available).
+For the most up-to-date list of compatible clients and integration patterns, see the [Lobu memory CLI Reference](/reference/owletto-cli/#which-mcp-tools-are-available).
 
 For setup instructions by client, see:
 
@@ -168,11 +167,11 @@ For setup instructions by client, see:
 
 Watchers analyze incoming event streams on a schedule and write structured results back into the memory graph.
 
-To inspect available watcher tooling and related MCP operations, see the [Owletto CLI Reference](/reference/owletto-cli/#which-mcp-tools-are-available).
+To inspect available watcher tooling and related MCP operations, see the [Lobu memory CLI Reference](/reference/owletto-cli/#which-mcp-tools-are-available).
 
 ## Tool-Level Workflow
 
-Agents that talk to Owletto directly usually use three core MCP tools:
+Agents that talk to Lobu memory directly usually use three core MCP tools:
 
 - `search_knowledge` to find entities and graph context first
 - `read_knowledge` to retrieve saved events or semantic matches
@@ -186,9 +185,9 @@ search_knowledge -> read_knowledge -> save_knowledge
 
 Coding agents like Codex, Claude Code, and Cursor use the same pattern when they lack automatic memory hooks in the runtime.
 
-## When To Use Owletto
+## When To Use Lobu Memory
 
-Owletto is the right fit when you want:
+Lobu memory is the right fit when you want:
 
 - Multiple Lobu agents to share one memory space
 - Memory that survives local sandboxes and channel-specific filesystems
@@ -196,11 +195,10 @@ Owletto is the right fit when you want:
 - Scheduled ingestion and analysis of external sources
 - Operator-visible memory that can be audited and corrected
 
-If you only need a local working directory for one session, the filesystem is enough. If you want the organization to remember something in a structured, queryable way, use Owletto.
+If you only need a local working directory for one session, the filesystem is enough. If you want the organization to remember something in a structured, queryable way, use Lobu memory.
 
 ## Read Next
 
 - [Skills](/getting-started/skills/)
-- [Owletto CLI Reference](/reference/owletto-cli/)
+- [Lobu memory CLI Reference](/reference/owletto-cli/)
 - [Lobu CLI Reference](/reference/cli/)
-- [Owletto GitHub Repository](https://github.com/lobu-ai/owletto)

--- a/packages/landing/src/content/docs/getting-started/skills.mdx
+++ b/packages/landing/src/content/docs/getting-started/skills.mdx
@@ -59,9 +59,9 @@ See [Tool Policy](/guides/tool-policy/) for that split.
 
 ## Integrations
 
-Integration auth for third-party APIs (GitHub, Google, Linear, etc.) is handled by **Owletto**. Workers access these APIs through Owletto MCP tools, which manage OAuth credentials, token refresh, and API proxying. Workers never see OAuth tokens directly.
+Integration auth for third-party APIs (GitHub, Google, Linear, etc.) is handled by **Lobu**. Workers access these APIs through Lobu MCP tools, which manage OAuth credentials, token refresh, and API proxying. Workers never see OAuth tokens directly.
 
-Owletto also powers Lobu's richer shared-memory model: workspace-scoped knowledge, typed entities, hybrid recall, connectors, and watchers. See [Memory](/getting-started/memory/) for how that layer works and when to use it instead of local-only memory.
+Lobu memory also powers Lobu's richer shared-memory model: workspace-scoped knowledge, typed entities, hybrid recall, connectors, and watchers. See [Memory](/getting-started/memory/) for how that layer works and when to use it instead of local-only memory.
 
 <SkillsRegistryTable client:load />
 
@@ -70,6 +70,6 @@ Owletto also powers Lobu's richer shared-memory model: workspace-scoped knowledg
 ## Read Next
 
 - [SKILL.md Reference](/reference/skill-md/) for the file format and supported frontmatter
-- [Memory](/getting-started/memory/) for how Owletto powers Lobu's shared memory layer
+- [Memory](/getting-started/memory/) for how Lobu memory powers Lobu's shared memory layer
 - [`lobu.toml` Reference](/reference/lobu-toml/) for agent-level configuration
 - [Tool Policy](/guides/tool-policy/) for tool visibility and MCP approval overrides

--- a/packages/landing/src/content/docs/guides/agent-prompts.md
+++ b/packages/landing/src/content/docs/guides/agent-prompts.md
@@ -140,7 +140,7 @@ Use the [`lobu.toml` Reference](/reference/lobu-toml/) for the exact schema. Kee
 
 The sandbox filesystem is short-term working memory: drafts, scripts, downloaded files, generated artifacts, and intermediate results for one user or channel workspace.
 
-When you use Owletto, it adds long-term memory across workspaces. The filesystem stays local to one sandbox, while Owletto stores durable knowledge that other sessions, users, or agents can recall later.
+When you use Lobu memory, it adds long-term memory across workspaces. The filesystem stays local to one sandbox, while Lobu memory stores durable knowledge that other sessions, users, or agents can recall later.
 
 See [Memory](/getting-started/memory/) for the full model.
 

--- a/packages/landing/src/content/docs/guides/agent-settings.md
+++ b/packages/landing/src/content/docs/guides/agent-settings.md
@@ -40,16 +40,16 @@ Memory is pluggable. In file-first projects, the gateway first checks `[memory.o
 | Effective config | Plugin used |
 |---|---|
 | `[memory.owletto]` disabled or unresolved, and no `MEMORY_URL` override | `@openclaw/native-memory` — files under `/workspace` (per-thread PVC in K8s, `./workspaces/{threadId}/` in Docker). Not shared across threads. |
-| `[memory.owletto]` enabled | `@lobu/owletto-openclaw` — the OpenClaw memory plugin for Owletto. It translates OpenClaw memory calls into Owletto MCP requests via the gateway's `/mcp/owletto` proxy. Cross-session, shareable across agents. |
-| `MEMORY_URL` set | Used as the base Owletto MCP endpoint before Lobu scopes it to the org from `[memory.owletto]` in `lobu.toml`. Useful for local or custom Owletto deployments. |
+| `[memory.owletto]` enabled | `@lobu/owletto-openclaw` — the OpenClaw memory plugin for Lobu memory. It translates OpenClaw memory calls into Lobu memory MCP requests via the gateway's `/mcp/owletto` proxy. Cross-session, shareable across agents. |
+| `MEMORY_URL` set | Used as the base Lobu memory MCP endpoint before Lobu scopes it to the org from `[memory.owletto]` in `lobu.toml`. Useful for local or custom Lobu memory deployments. |
 
-`lobu init` now scaffolds the file-first Owletto layout for memory-enabled projects:
+`lobu init` now scaffolds the file-first Lobu memory layout for memory-enabled projects:
 
 - `[memory.owletto]` in `lobu.toml` (org, name, description, models, data)
 - `models/`
 - `data/`
 
-For **Lobu Cloud**, Lobu can use the hosted default automatically. For **Owletto Local** and **Custom URL**, `MEMORY_URL` remains the base-endpoint override.
+For **Lobu Cloud**, Lobu can use the hosted default automatically. For **Lobu memory Local** and **Custom URL**, `MEMORY_URL` remains the base-endpoint override.
 
 If the preferred plugin isn't installed, the gateway falls back to the other one (or to no memory if neither is installed).
 
@@ -57,7 +57,7 @@ If the preferred plugin isn't installed, the gateway falls back to the other one
 
 A per-agent `pluginsConfig` **replaces** the default plugin list entirely — it does not merge. Include every plugin the agent should run.
 
-Switch one agent to Owletto:
+Switch one agent to Lobu memory:
 
 ```json
 {
@@ -71,7 +71,7 @@ Switch one agent to Owletto:
 
 The gateway injects the internal `mcpUrl` and `gatewayAuthUrl` automatically — you don't need to hand-write them.
 
-That means the plugin source is the only part you normally set yourself. OpenClaw loads `@lobu/owletto-openclaw` as the agent's `slot: "memory"` plugin, and Lobu fills in the proxy/auth details needed to reach Owletto safely.
+That means the plugin source is the only part you normally set yourself. OpenClaw loads `@lobu/owletto-openclaw` as the agent's `slot: "memory"` plugin, and Lobu fills in the proxy/auth details needed to reach Lobu memory safely.
 
 Switch to native memory:
 

--- a/packages/landing/src/content/docs/guides/architecture.mdx
+++ b/packages/landing/src/content/docs/guides/architecture.mdx
@@ -27,27 +27,27 @@ Lobu runs as a gateway + worker architecture.
 
 In file-first projects, Lobu resolves persistent memory from `[memory.owletto]` in `lobu.toml`.
 
-- **`[memory.owletto]` enabled**: Lobu derives an Owletto MCP endpoint and uses `@lobu/owletto-openclaw`, falling back to native memory if the plugin is unavailable.
-- **`MEMORY_URL`**: still supported as an optional base-endpoint override for local or custom Owletto deployments.
-- **No Owletto config resolved**: uses `@openclaw/native-memory`, which is effectively filesystem-backed short-term memory inside the agent's local workspace.
+- **`[memory.owletto]` enabled**: Lobu derives a Lobu memory MCP endpoint and uses `@lobu/owletto-openclaw`, falling back to native memory if the plugin is unavailable.
+- **`MEMORY_URL`**: still supported as an optional base-endpoint override for local or custom Lobu memory deployments.
+- **No Lobu memory config resolved**: uses `@openclaw/native-memory`, which is effectively filesystem-backed short-term memory inside the agent's local workspace.
 
 Memory plugins are configurable per agent through `pluginsConfig` in agent settings. The split is intentional:
 
 - **Filesystem** is per channel or user space — the agent's working area for artifacts such as PDFs, images, scripts, CSVs, and temporary outputs.
-- **Owletto** is long-term organizational memory. Agents write durable facts into entities so other sessions, users, and agents can query and reuse that knowledge later.
+- **Lobu memory** is long-term organizational memory. Agents write durable facts into entities so other sessions, users, and agents can query and reuse that knowledge later.
 
 ### How It Works
 
-1. Gateway resolves an effective Owletto endpoint from `[memory.owletto]` (and optional `MEMORY_URL` override), then selects the default memory plugin and sets it in `agentDefaults.pluginsConfig`.
+1. Gateway resolves an effective Lobu memory endpoint from `[memory.owletto]` (and optional `MEMORY_URL` override), then selects the default memory plugin and sets it in `agentDefaults.pluginsConfig`.
 2. Worker fetches session context from gateway and passes `pluginsConfig` into OpenClaw runtime startup.
 3. OpenClaw loads enabled plugins for that agent session.
-4. If memory is set to `@lobu/owletto-openclaw`, that plugin converts OpenClaw memory reads/writes into Owletto MCP calls through the gateway proxy.
+4. If memory is set to `@lobu/owletto-openclaw`, that plugin converts OpenClaw memory reads/writes into Lobu memory MCP calls through the gateway proxy.
 5. The memory plugin handles persistent memory operations so context can be reused across future runs.
 
-In short: local filesystem for short-term working state; Owletto for long-term shared knowledge.
+In short: local filesystem for short-term working state; Lobu memory for long-term shared knowledge.
 
 ## Security-Critical Path
 
 - Workers do not directly own global provider secrets.
 - Outbound access is controlled via gateway proxy and domain policy.
-- MCP credentials are resolved by the gateway proxy. Integration auth is handled by Owletto.
+- MCP credentials are resolved by the gateway proxy. Integration auth is handled by Lobu memory.

--- a/packages/landing/src/content/docs/guides/mcp-proxy.md
+++ b/packages/landing/src/content/docs/guides/mcp-proxy.md
@@ -34,7 +34,7 @@ There are three ways an MCP server can authenticate:
 |--------|-------------|----------|
 | **Static headers** | `headers` | API keys, service tokens — no per-user auth needed |
 | **Device-code OAuth** | `oauth` on the MCP server | Per-user OAuth — each user authenticates in their browser |
-| **Owletto-managed** | N/A (Owletto handles internally) | Third-party APIs (GitHub, Google, Linear, etc.) |
+| **Lobu-memory-managed** | N/A (Lobu memory handles internally) | Third-party APIs (GitHub, Google, Linear, etc.) |
 
 ### Static headers
 
@@ -174,11 +174,11 @@ If the MCP server's OAuth endpoints live at non-standard paths, or if you have a
 
 When `clientId` is provided, dynamic client registration is skipped entirely — useful when you've pre-registered an OAuth application with the MCP server.
 
-### Owletto-managed auth
+### Lobu-memory-managed auth
 
-Third-party API integrations (GitHub, Google, Linear, Notion, etc.) are handled by Owletto MCP servers. Owletto manages OAuth flows, token storage, and API proxying internally. The gateway acts as a thin proxy — it doesn't know or care about the integration's auth.
+Third-party API integrations (GitHub, Google, Linear, Notion, etc.) are handled by Lobu memory MCP servers. Lobu memory manages OAuth flows, token storage, and API proxying internally. The gateway acts as a thin proxy — it doesn't know or care about the integration's auth.
 
-Workers access these APIs through Owletto tools (e.g., `owletto_github_read_repo`). If Owletto needs the user to authenticate, it returns instructions for the user to call `owletto_login`.
+Workers access these APIs through Lobu memory tools (e.g., `owletto_github_read_repo`). If Lobu memory needs the user to authenticate, it returns instructions for the user to call `owletto_login`.
 
 ## Worker auth awareness
 

--- a/packages/landing/src/content/docs/guides/memory-benchmarks.md
+++ b/packages/landing/src/content/docs/guides/memory-benchmarks.md
@@ -1,9 +1,9 @@
 ---
 title: Memory benchmarks
-description: How Owletto compares to Mem0, Supermemory, and Letta on public memory benchmarks, and how to reproduce the numbers.
+description: How Lobu compares to Mem0, Supermemory, and Letta on public memory benchmarks, and how to reproduce the numbers.
 ---
 
-Owletto, the memory system bundled with Lobu, is benchmarked against external memory systems (Mem0, Supermemory, Letta, Zep) on public datasets. This page summarises the headline numbers and points at the reproducible harness in the Owletto repo.
+Lobu's memory system is benchmarked against external memory systems (Mem0, Supermemory, Letta, Zep) on public datasets. This page summarises the headline numbers and points at the reproducible harness.
 
 ## Headline results
 
@@ -15,7 +15,7 @@ Single-session knowledge retention.
 
 | System | Overall | Answer | Retrieval | Latency |
 |---|---:|---:|---:|---:|
-| **Owletto** | **87.1%** | **78.0%** | **100.0%** | 237ms |
+| **Lobu** | **87.1%** | **78.0%** | **100.0%** | 237ms |
 | Supermemory | 69.1% | 56.0% | 96.6% | 702ms |
 | Mem0 | 65.7% | 54.0% | 85.3% | 753ms |
 
@@ -25,7 +25,7 @@ Multi-session conversational memory (each scenario is ~19 sessions of 18+ turns,
 
 | System | Overall | Answer | Retrieval | Latency |
 |---|---:|---:|---:|---:|
-| **Owletto** | **57.8%** | **38.0%** | **79.5%** | **121ms** |
+| **Lobu** | **57.8%** | **38.0%** | **79.5%** | **121ms** |
 | Mem0 | 41.5% | 28.0% | 66.9% | 606ms |
 | Supermemory | 23.2% | 14.0% | 36.5% | 532ms |
 
@@ -43,11 +43,11 @@ The harness applies the following fairness constraints:
 
 ### Latency caveat
 
-Latency is **retrieval-only latency**, not end-to-end wall clock. It is not fully apples-to-apples when one system is local/in-process and another is a hosted API. Owletto's retrieval path is a multi-step plan (query expansion, entity search, content search, linked-context fetches) — that orchestration is what gets it to 100% retrieval recall on LongMemEval but also costs round trips. Mem0 and Supermemory adapters issue a single provider search per question.
+Latency is **retrieval-only latency**, not end-to-end wall clock. It is not fully apples-to-apples when one system is local/in-process and another is a hosted API. Lobu's retrieval path is a multi-step plan (query expansion, entity search, content search, linked-context fetches) — that orchestration is what gets it to 100% retrieval recall on LongMemEval but also costs round trips. Mem0 and Supermemory adapters issue a single provider search per question.
 
 ## Reproducing the results
 
-The full harness lives in the [Owletto repo](https://github.com/lobu-ai/owletto) under [`benchmarks/memory/`](https://github.com/lobu-ai/owletto/tree/main/benchmarks/memory). The TypeScript runner is at `src/benchmarks/memory/`. External systems are integrated as long-lived Python adapter subprocesses framed over JSONL-on-stdin, which avoids per-op fork/exec cost.
+The full harness lives in the [`owletto` repo](https://github.com/lobu-ai/owletto) under [`benchmarks/memory/`](https://github.com/lobu-ai/owletto/tree/main/benchmarks/memory). The TypeScript runner is at `src/benchmarks/memory/`. External systems are integrated as long-lived Python adapter subprocesses framed over JSONL-on-stdin, which avoids per-op fork/exec cost.
 
 ### Prerequisites
 
@@ -62,14 +62,14 @@ ZAI_API_KEY=... MEM0_API_KEY=... SUPERMEMORY_API_KEY=... LETTA_API_KEY=... \
   pnpm benchmark:memory --config benchmarks/memory/config.longmemeval.oracle.50.compare.all.zai.json
 ```
 
-### LoCoMo-50, three-way (Owletto vs Mem0 vs Supermemory)
+### LoCoMo-50, three-way (Lobu vs Mem0 vs Supermemory)
 
 ```bash
 ZAI_API_KEY=... MEM0_API_KEY=... SUPERMEMORY_API_KEY=... \
   pnpm benchmark:memory --config benchmarks/memory/config.locomo.50.compare.top-memory.zai.json
 ```
 
-### Owletto-only, no external API keys
+### Lobu-only, no external API keys
 
 ```bash
 # Retrieval-only (no answerer)
@@ -110,14 +110,12 @@ Inputs include `dataset` (`longmemeval-oracle` or `locomo`), `limit`, `trials`, 
 
 To add a new system, write a Python adapter that defines `reset` / `setup` / `ingest` / `retrieve` action handlers. The shared protocol module is at [`adapters/_bench_protocol.py`](https://github.com/lobu-ai/owletto/blob/main/benchmarks/memory/adapters/_bench_protocol.py).
 
-## Why Owletto wins on retention
+## Why Lobu wins on retention
 
-Owletto blends three signals for recall:
+Lobu blends three signals for recall:
 
 1. Entity name matching
 2. Full-text search
 3. Semantic vector search
 
-Plus structured retrieval — Owletto stores knowledge in entity types backed by JSON Schema, with first-class relationships and superseding writes. That is why it reaches 100% retrieval on LongMemEval where vector-only systems plateau in the 80–90% range.
-
-For deeper context on the architecture, see the [Owletto README](https://github.com/lobu-ai/owletto/blob/main/README.md#how-it-works).
+Plus structured retrieval — Lobu stores knowledge in entity types backed by JSON Schema, with first-class relationships and superseding writes. That is why it reaches 100% retrieval on LongMemEval where vector-only systems plateau in the 80–90% range.

--- a/packages/landing/src/content/docs/guides/security.md
+++ b/packages/landing/src/content/docs/guides/security.md
@@ -34,12 +34,12 @@ Workers never receive raw provider credentials or OAuth tokens. The gateway reso
 | Category | How it works | Where secret material can live |
 |---|---|---|
 | Provider secrets | Standalone `lobu run` can read from `.env` / `$ENV_VAR` or `secret_ref`. Embedded mode can pass `key` / `secretRef` at startup or resolve credentials dynamically per request. | Built-in encrypted Redis-backed secret store, external refs such as `secret://...` or `aws-sm://...`, or a host-provided embedded secret store |
-| Per-user MCP / OAuth tokens | Collected through device-auth and injected by the gateway MCP proxy per call. Integration auth for GitHub, Google, Linear, and similar services is handled through [Owletto](https://github.com/lobu-ai/owletto). | Writable gateway secret store or host-provided embedded secret store |
+| Per-user MCP / OAuth tokens | Collected through device-auth and injected by the gateway MCP proxy per call. Integration auth for GitHub, Google, Linear, and similar services is handled through [Lobu memory](/getting-started/memory/). | Writable gateway secret store or host-provided embedded secret store |
 | Redis role | Redis may be the built-in encrypted secret store, or it may hold only metadata and `secretRef` pointers when secrets live elsewhere. | Redis-backed secret store or metadata only |
 
 - **AWS Secrets Manager refs are read-only**. `aws-sm://...` works well for durable provider secret references, but refreshed user tokens still need a writable secret store.
 - **User-scoped provider credentials are supported in embedded mode**. A host app can resolve credentials at runtime from request context such as `userId` without persisting plaintext keys in Lobu state.
-- **Workers never touch third-party OAuth tokens directly**. They call integrations through Owletto MCP tools and the gateway proxy.
+- **Workers never touch third-party OAuth tokens directly**. They call integrations through Lobu memory MCP tools and the gateway proxy.
 
 For concrete config examples, see [Embedding](/deployment/embedding/), [AWS](/deployment/aws/), the [`lobu.toml` reference](/reference/lobu-toml/), and the [CLI reference](/reference/cli/).
 

--- a/packages/landing/src/content/docs/guides/troubleshooting.md
+++ b/packages/landing/src/content/docs/guides/troubleshooting.md
@@ -102,15 +102,15 @@ kubectl get pvc -n lobu
 kubectl describe pvc <pvc-name> -n lobu
 ```
 
-## Owletto connection issues
+## Lobu memory connection issues
 
 ```bash
-# Verify local Owletto is running (if you're using owletto-local)
+# Verify local Lobu memory is running (if you're using owletto-local)
 curl http://localhost:8787/health
 
 # Check file-first memory config
 # - lobu.toml should contain [memory.owletto] with enabled = true and an org
-# - MEMORY_URL is optional; use it mainly for local/custom Owletto base URLs
+# - MEMORY_URL is optional; use it mainly for local/custom Lobu memory base URLs
 
 # Test connection
 npx owletto@latest health

--- a/packages/landing/src/content/docs/reference/cli.md
+++ b/packages/landing/src/content/docs/reference/cli.md
@@ -31,7 +31,7 @@ npx @lobu/cli@latest init my-agent
 Generates:
 
 - `lobu.toml` — agent configuration (skills, providers, connections, network)
-- `docker-compose.yml` — service definitions (gateway, Redis, optional Owletto)
+- `docker-compose.yml` — service definitions (gateway, Redis, optional Lobu memory)
 - `.env` — credentials and environment variables
 - `agents/{name}/` — agent directory with `IDENTITY.md`, `SOUL.md`, `USER.md`, and `skills/`
 - `skills/` — shared skills directory (available to all agents)

--- a/packages/landing/src/content/docs/reference/lobu-toml.md
+++ b/packages/landing/src/content/docs/reference/lobu-toml.md
@@ -5,7 +5,7 @@ sidebar:
   order: 1
 ---
 
-`lobu.toml` is the project configuration file created by `lobu init`. It defines agents, providers, connections, skills, network access, worker settings, and optional file-first Owletto memory configuration.
+`lobu.toml` is the project configuration file created by `lobu init`. It defines agents, providers, connections, skills, network access, worker settings, and optional file-first Lobu memory configuration.
 
 ## Minimal example
 
@@ -93,7 +93,7 @@ strict = false
 [agents.support.worker]
 nix_packages = ["imagemagick", "ffmpeg"]
 
-# File-first Owletto memory
+# File-first Lobu memory
 [memory.owletto]
 enabled = true
 org = "support"
@@ -107,7 +107,7 @@ data = "./data"
 
 ### `[memory.owletto]`
 
-Optional project-level Owletto memory configuration for file-first projects.
+Optional project-level Lobu memory configuration for file-first projects.
 
 Typical companion layout:
 
@@ -120,15 +120,15 @@ project/
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `enabled` | boolean | no | Enables file-first Owletto memory resolution for the project |
-| `org` | string | yes (when enabled) | Owletto organization slug — scopes the MCP endpoint |
+| `enabled` | boolean | no | Enables file-first Lobu memory resolution for the project |
+| `org` | string | yes (when enabled) | Lobu memory organization slug — scopes the MCP endpoint |
 | `name` | string | yes (when enabled) | Human-readable project name |
 | `description` | string | no | Short project description |
-| `visibility` | string | no | `public` or `private`; defaults to Owletto's account setting |
-| `models` | string | no | Path to Owletto model files, usually `./models` |
-| `data` | string | no | Path to Owletto seed data, usually `./data` |
+| `visibility` | string | no | `public` or `private`; defaults to Lobu's account setting |
+| `models` | string | no | Path to Lobu memory model files, usually `./models` |
+| `data` | string | no | Path to Lobu memory seed data, usually `./data` |
 
-When `[memory.owletto]` is enabled, Lobu reads `org` directly from `lobu.toml` and derives the effective Owletto MCP endpoint. `MEMORY_URL` remains available as an optional base-endpoint override for local or custom Owletto deployments.
+When `[memory.owletto]` is enabled, Lobu reads `org` directly from `lobu.toml` and derives the effective Lobu memory MCP endpoint. `MEMORY_URL` remains available as an optional base-endpoint override for local or custom Lobu memory deployments.
 
 
 ### `[agents.<id>]`

--- a/packages/landing/src/content/docs/reference/owletto-cli.md
+++ b/packages/landing/src/content/docs/reference/owletto-cli.md
@@ -1,11 +1,10 @@
 ---
-title: Owletto CLI Reference
-description: What the owletto CLI does, how it authenticates, and how to use it to run Owletto memory tools directly.
+title: Lobu memory CLI Reference
+description: What the owletto CLI does, how it authenticates, and how to use it to run Lobu memory tools directly.
 ---
 
-The `owletto` CLI starts local Owletto servers, connects agent clients, and runs memory tools directly.
+The `owletto` CLI starts local Lobu memory servers, connects agent clients, and runs memory tools directly.
 
-- GitHub: [lobu-ai/owletto](https://github.com/lobu-ai/owletto)
 - Hosted: [app.lobu.ai](https://app.lobu.ai)
 
 ## Install And Run
@@ -23,7 +22,7 @@ The published package name is `owletto`.
 
 ## Architecture Overview
 
-Owletto is a layered memory system that separates raw capture from structured knowledge:
+Lobu memory is a layered system that separates raw capture from structured knowledge:
 
 ```
 external source
@@ -43,7 +42,7 @@ external source
 
 ## Connector SDK
 
-Owletto's data integration layer. Each connector declares:
+Lobu memory's data integration layer. Each connector declares:
 
 - `ConnectorDefinition` — auth, feeds, actions, schemas
 - `ConnectorRuntime` — implements `sync()` and optional `execute()`
@@ -54,7 +53,7 @@ Docs: [Connector SDK](https://github.com/lobu-ai/owletto/blob/main/connectors/RE
 
 ### `owletto start`
 
-Starts a local Owletto runtime.
+Starts a local Lobu memory runtime.
 
 ```bash
 npx owletto@latest start
@@ -66,13 +65,13 @@ Default behavior:
 - listens on `http://localhost:8787`
 - uses embedded Postgres (`PGlite`) by default
 - stores local data in `~/.owletto/data/` for packaged installs
-- uses `./data/` when running from a real Owletto repo checkout
+- uses `./data/` when running from an `owletto` repo checkout
 
 If `DATABASE_URL` is set, the CLI starts the server against external Postgres instead.
 
 ### `owletto init`
 
-Configures local agent clients to use an Owletto MCP endpoint.
+Configures local agent clients to use a Lobu memory MCP endpoint.
 
 ```bash
 npx owletto@latest init
@@ -85,7 +84,7 @@ Detects supported clients and auto-configures them. Falls back to manual steps w
 
 ### `owletto login`
 
-Authenticates the CLI against an Owletto MCP server using OAuth.
+Authenticates the CLI against a Lobu memory MCP server using OAuth.
 
 ```bash
 npx owletto@latest login https://app.lobu.ai/mcp
@@ -126,7 +125,7 @@ npx owletto@latest health
 
 ## Organization Selection
 
-Owletto sessions are organization-aware. After login, set the default org if needed:
+Lobu memory sessions are organization-aware. After login, set the default org if needed:
 
 ```bash
 npx owletto@latest org current
@@ -160,7 +159,7 @@ npx owletto@latest run read_knowledge '{"query":"customer preferences"}'
 npx owletto@latest run save_knowledge '{"content":"Prefers weekly summaries","semantic_type":"preference","metadata":{}}'
 ```
 
-This is the most direct way to inspect or test Owletto memory behavior outside an agent runtime.
+This is the most direct way to inspect or test Lobu memory behavior outside an agent runtime.
 
 ### Which MCP tools are available?
 
@@ -196,7 +195,7 @@ Writes OpenClaw plugin config for `@lobu/owletto-openclaw` using an `owletto tok
 
 ## Repo-Local Development
 
-When working inside the Owletto repository itself, you can run the TypeScript entrypoint directly:
+When working inside the `owletto` repository itself, you can run the TypeScript entrypoint directly:
 
 ```bash
 pnpm -C packages/cli exec tsx src/bin.ts start
@@ -206,7 +205,7 @@ pnpm -C packages/cli exec tsx src/bin.ts run search_knowledge '{"query":"spotify
 
 ## How This Fits With Lobu
 
-Use the Lobu CLI to scaffold and run Lobu projects. Use the Owletto CLI when you need to stand up or inspect the memory system behind Lobu.
+Use the Lobu CLI to scaffold and run Lobu projects. Use the `owletto` CLI when you need to stand up or inspect the Lobu memory system behind them.
 
 - Lobu CLI: [CLI Reference](/reference/cli/)
 - Lobu memory docs: [Memory](/getting-started/memory/)

--- a/packages/landing/src/pages/memory.astro
+++ b/packages/landing/src/pages/memory.astro
@@ -11,8 +11,8 @@ const latestPosts = await getLatestPosts();
 ---
 
 <BaseLayout
-  title="Memory - Owletto organizational memory for agents"
-  description="Owletto gives Lobu multi-tenant organizational memory with typed entities, connectors, watchers, and managed OAuth."
+  title="Memory - Lobu organizational memory for agents"
+  description="Lobu memory provides multi-tenant organizational memory with typed entities, connectors, watchers, and managed OAuth."
 >
   <div
     class="min-h-screen grid-lines"

--- a/packages/landing/src/use-case-showcases.ts
+++ b/packages/landing/src/use-case-showcases.ts
@@ -1234,13 +1234,13 @@ const runtimeContent: Record<LandingUseCaseId, RuntimeJourney> = {
       },
       {
         kind: "memory_recall",
-        source: "Owletto",
+        source: "Lobu memory",
         call: "recall(counterparty: Redwood, topic: risk)",
         result: "Acme NDA blocked Sep — similar §7 language",
       },
       {
         kind: "memory_upsert",
-        source: "Owletto",
+        source: "Lobu memory",
         call: "upsert(Contract Redwood-NDA-v2)",
         result: 'linked Clause §7 "uncapped indemnity"',
       },
@@ -1252,7 +1252,7 @@ const runtimeContent: Record<LandingUseCaseId, RuntimeJourney> = {
       },
       {
         kind: "memory_link",
-        source: "Owletto",
+        source: "Lobu memory",
         call: "link(Contract → Clause §7 → Risk)",
         result: "flagged counsel-required",
       },
@@ -1298,14 +1298,8 @@ const runtimeContent: Record<LandingUseCaseId, RuntimeJourney> = {
     ],
     trace: [
       {
-        kind: "skill",
-        source: "Slack",
-        call: "slack.dms.collect(since: 9:00, until: 9:30)",
-        result: "5 updates from Dan, Priya, Jay, Sam, Nina",
-      },
-      {
         kind: "memory_recall",
-        source: "Owletto",
+        source: "Lobu memory",
         call: "recall(incident: INC-4421, owner: Dan)",
         result: "checkout rollback in progress · needs cluster access",
       },
@@ -1317,7 +1311,7 @@ const runtimeContent: Record<LandingUseCaseId, RuntimeJourney> = {
       },
       {
         kind: "memory_upsert",
-        source: "Owletto",
+        source: "Lobu memory",
         call: "upsert(Engineer Sam → OOO today)",
         result: "linked to on-call schedule",
       },
@@ -1368,7 +1362,7 @@ const runtimeContent: Record<LandingUseCaseId, RuntimeJourney> = {
       },
       {
         kind: "memory_recall",
-        source: "Owletto",
+        source: "Lobu memory",
         call: "recall(customer: Alex Kim)",
         result: "Feb billing escalation · tone: direct, concise",
       },
@@ -1380,7 +1374,7 @@ const runtimeContent: Record<LandingUseCaseId, RuntimeJourney> = {
       },
       {
         kind: "memory_upsert",
-        source: "Owletto",
+        source: "Lobu memory",
         call: "upsert(Account alex-kim)",
         result: "owner=Priya · next-touch=Thu 10am",
       },
@@ -1436,13 +1430,13 @@ const runtimeContent: Record<LandingUseCaseId, RuntimeJourney> = {
       },
       {
         kind: "memory_recall",
-        source: "Owletto",
+        source: "Lobu memory",
         call: "recall(account: 4100, topic: variance)",
         result: "Sep same merchant · 3-day settlement lag",
       },
       {
         kind: "memory_upsert",
-        source: "Owletto",
+        source: "Lobu memory",
         call: "upsert(Variance Oct-4100-12480)",
         result: "linked merchant STR-44",
       },
@@ -1498,13 +1492,13 @@ const runtimeContent: Record<LandingUseCaseId, RuntimeJourney> = {
       },
       {
         kind: "memory_recall",
-        source: "Owletto",
+        source: "Lobu memory",
         call: "recall(account: northstar)",
         result: "champion=Maria · exec-sponsor=Jane",
       },
       {
         kind: "memory_upsert",
-        source: "Owletto",
+        source: "Lobu memory",
         call: "upsert(Contact Jake Chen)",
         result: "new renewal owner at Northstar",
       },
@@ -1560,13 +1554,13 @@ const runtimeContent: Record<LandingUseCaseId, RuntimeJourney> = {
       },
       {
         kind: "memory_recall",
-        source: "Owletto",
+        source: "Lobu memory",
         call: "recall(project: phoenix, topic: shards)",
         result: "Apollo rollout had same shard-pattern",
       },
       {
         kind: "memory_upsert",
-        source: "Owletto",
+        source: "Lobu memory",
         call: "upsert(Blocker phoenix-shard-14)",
         result: "owner=Lena (backend)",
       },
@@ -1616,19 +1610,19 @@ const runtimeContent: Record<LandingUseCaseId, RuntimeJourney> = {
       },
       {
         kind: "memory_recall",
-        source: "Owletto",
+        source: "Lobu memory",
         call: "recall(topic: Series A)",
         result: "seed approval same pattern · closed in 2 wks",
       },
       {
         kind: "memory_upsert",
-        source: "Owletto",
+        source: "Lobu memory",
         call: "upsert(Decision bridge-4M-approved)",
         result: "linked to Board Q4",
       },
       {
         kind: "memory_upsert",
-        source: "Owletto",
+        source: "Lobu memory",
         call: "upsert(Blocker q1-hiring-freeze)",
         result: "condition: until close",
       },
@@ -1678,19 +1672,19 @@ const runtimeContent: Record<LandingUseCaseId, RuntimeJourney> = {
       },
       {
         kind: "memory_recall",
-        source: "Owletto",
+        source: "Lobu memory",
         call: "recall(member: Sarah, topic: needs)",
         result: "needs infra feedback · embeddings, MCP",
       },
       {
         kind: "memory_recall",
-        source: "Owletto",
+        source: "Lobu memory",
         call: "recall(members, overlap: embeddings)",
         result: "Devon Lin · Mira Sato",
       },
       {
         kind: "memory_link",
-        source: "Owletto",
+        source: "Lobu memory",
         call: "link(Sarah ↔ Devon)",
         result: "match · shared topic: embeddings",
       },
@@ -1746,19 +1740,19 @@ const runtimeContent: Record<LandingUseCaseId, RuntimeJourney> = {
       },
       {
         kind: "memory_recall",
-        source: "Owletto",
+        source: "Lobu memory",
         call: "recall(product: Airtable)",
         result: "Q3 scan: automation strong, docs weak",
       },
       {
         kind: "memory_upsert",
-        source: "Owletto",
+        source: "Lobu memory",
         call: "upsert(Release airtable-ai-mar18)",
         result: "linked Product Airtable",
       },
       {
         kind: "memory_link",
-        source: "Owletto",
+        source: "Lobu memory",
         call: "link(Airtable ↔ Notion)",
         result: "competitor pair updated",
       },
@@ -1802,7 +1796,7 @@ const runtimeContent: Record<LandingUseCaseId, RuntimeJourney> = {
       },
       {
         kind: "memory_recall",
-        source: "Owletto",
+        source: "Lobu memory",
         call: "recall(customer: Emma K, topic: cancel)",
         result: "Aug 2024 · 14-day retention window",
       },
@@ -1820,7 +1814,7 @@ const runtimeContent: Record<LandingUseCaseId, RuntimeJourney> = {
       },
       {
         kind: "memory_upsert",
-        source: "Owletto",
+        source: "Lobu memory",
         call: "upsert(Customer emma-k)",
         result: "plan=annual · cancel-risk=low",
       },
@@ -1870,13 +1864,13 @@ const runtimeContent: Record<LandingUseCaseId, RuntimeJourney> = {
       },
       {
         kind: "memory_recall",
-        source: "Owletto",
+        source: "Lobu memory",
         call: "recall(patient: James M)",
         result: "PHQ-9 baseline 17 · weekly exposure therapy",
       },
       {
         kind: "memory_upsert",
-        source: "Owletto",
+        source: "Lobu memory",
         call: "upsert(Treatment james-12wk)",
         result: "progress 67% · on-track",
       },
@@ -1933,19 +1927,19 @@ const runtimeContent: Record<LandingUseCaseId, RuntimeJourney> = {
       },
       {
         kind: "memory_recall",
-        source: "Owletto",
+        source: "Lobu memory",
         call: "recall(sector: ai-dev-tools)",
         result: "Q4 thesis · Lovable in portfolio",
       },
       {
         kind: "memory_recall",
-        source: "Owletto",
+        source: "Lobu memory",
         call: "recall(network, topic: replit-alumni)",
         result: "Adam K. · ex-Replit, warm intro",
       },
       {
         kind: "memory_upsert",
-        source: "Owletto",
+        source: "Lobu memory",
         call: "upsert(Round lovable-series-a)",
         result: "linked Company Lovable · Lead Accel",
       },
@@ -3150,7 +3144,7 @@ const surfaceHeroCopy: Record<SurfaceId, SurfaceHeroCopyConfig> = {
       title: "Build long-term collective memory",
       highlight: "collective memory",
       description:
-        "Owletto gives all your agents the same durable graph: connectors, recall, and managed auth without leaking credentials to the runtime.",
+        "Lobu memory gives all your agents the same durable graph: connectors, recall, and managed auth without leaking credentials to the runtime.",
     },
     byUseCase: {
       legal: { title: "Contract memory for legal agents" },
@@ -3268,7 +3262,7 @@ export const showcaseMemoryExamples = landingUseCaseShowcases.map(
 );
 
 export function getLandingPrompt(showcase: LandingUseCaseShowcase) {
-  return `I want to build a Lobu agent for ${showcase.label}.\n\nPlease:\n1. Start with \`npx @lobu/cli@latest init\`.\n2. Shape the project around this workflow: ${showcase.runtime.request}\n3. After scaffolding, read AGENTS.md, lobu.toml, and the agent prompt files first.\n4. Add the right skills, connections, and Owletto memory model.\n5. Keep the project runnable with \`npx @lobu/cli@latest run -d\`.\n\nExplain what you change and why.`;
+  return `I want to build a Lobu agent for ${showcase.label}.\n\nPlease:\n1. Start with \`npx @lobu/cli@latest init\`.\n2. Shape the project around this workflow: ${showcase.runtime.request}\n3. After scaffolding, read AGENTS.md, lobu.toml, and the agent prompt files first.\n4. Add the right skills, connections, and Lobu memory model.\n5. Keep the project runnable with \`npx @lobu/cli@latest run -d\`.\n\nExplain what you change and why.`;
 }
 
 export function getSkillsPrompt(showcase: LandingUseCaseShowcase) {
@@ -3280,7 +3274,7 @@ export function getSkillsPrompt(showcase: LandingUseCaseShowcase) {
 export function getMemoryPrompt(showcase: LandingUseCaseShowcase) {
   const memory = showcase.memory;
 
-  return `Run \`npx owletto@latest init\` to initialize Owletto memory for ${showcase.label}. Model these entities: ${memory.entityTypes.join(", ")}. Keep the extracted memory durable, typed, and linked so the runtime can reuse it across future tasks.`;
+  return `Run \`npx owletto@latest init\` to initialize Lobu memory for ${showcase.label}. Model these entities: ${memory.entityTypes.join(", ")}. Keep the extracted memory durable, typed, and linked so the runtime can reuse it across future tasks.`;
 }
 
 const LOBU_ZONE =

--- a/packages/owletto-backend/package.json
+++ b/packages/owletto-backend/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "license": "BUSL-1.1",
   "type": "module",
-  "description": "Owletto backend — Hono HTTP server, MCP handler, REST API, embedded @lobu/gateway",
+  "description": "Lobu memory backend — Hono HTTP server, MCP handler, REST API, embedded @lobu/gateway",
   "scripts": {
     "dev": "tsx watch src/server.ts",
     "start": "tsx src/server.ts",

--- a/packages/owletto-cli/package.json
+++ b/packages/owletto-cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "owletto",
   "version": "3.7.0",
-  "description": "Unified CLI for Owletto — dev, deploy, and manage from one command",
+  "description": "Unified CLI for Lobu memory — dev, deploy, and manage from one command",
   "type": "module",
   "bin": {
     "owletto": "./dist/bin.js"

--- a/packages/owletto-connectors/package.json
+++ b/packages/owletto-connectors/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "license": "BUSL-1.1",
   "type": "module",
-  "description": "Owletto connectors — third-party integration implementations built on @lobu/owletto-sdk",
+  "description": "Lobu memory connectors — third-party integration implementations built on @lobu/owletto-sdk",
   "main": "src/index.ts",
   "scripts": {
     "typecheck": "tsc --noEmit"

--- a/packages/owletto-embeddings/package.json
+++ b/packages/owletto-embeddings/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "license": "BUSL-1.1",
   "type": "module",
-  "description": "Embeddings HTTP service for the Owletto platform",
+  "description": "Embeddings HTTP service for Lobu memory",
   "main": "dist/index.js",
   "scripts": {
     "dev": "tsx watch --tsconfig tsconfig.json src/server.ts",

--- a/packages/owletto-extension/package.json
+++ b/packages/owletto-extension/package.json
@@ -3,7 +3,7 @@
   "version": "1.6.0",
   "private": true,
   "license": "BUSL-1.1",
-  "description": "Owletto Chrome Extension - Your companion to connect and manage data sources from your browser.",
+  "description": "Lobu memory Chrome Extension — connect and manage data sources from your browser.",
   "type": "module",
   "scripts": {
     "dev": "vite build --watch --mode development",

--- a/packages/owletto-openclaw/README.md
+++ b/packages/owletto-openclaw/README.md
@@ -1,6 +1,6 @@
 # @lobu/owletto-openclaw
 
-Owletto long-term memory plugin for [OpenClaw](https://openclaw.ai). Gives OpenClaw agents persistent, structured memory over MCP — recall relevant facts before each prompt and capture new observations after each session.
+Lobu memory plugin for [OpenClaw](https://openclaw.ai). Gives OpenClaw agents persistent, structured memory over MCP — recall relevant facts before each prompt and capture new observations after each session.
 
 Full install guide: **[lobu.ai/connect-from/openclaw](https://lobu.ai/connect-from/openclaw/)**
 
@@ -10,7 +10,7 @@ Full install guide: **[lobu.ai/connect-from/openclaw](https://lobu.ai/connect-fr
 openclaw plugins install owletto-openclaw-plugin
 ```
 
-Then log in and configure against your Owletto MCP endpoint:
+Then log in and configure against your Lobu memory MCP endpoint:
 
 ```bash
 owletto login <mcp-url>
@@ -31,11 +31,11 @@ owletto login --device <mcp-url>
 | Field | Description |
 |-------|-------------|
 | `mcpUrl` | Full MCP endpoint URL. Required. |
-| `webUrl` | Public web URL for the Owletto instance. Used to generate links shown to the agent. |
+| `webUrl` | Public web URL for the Lobu memory instance. Used to generate links shown to the agent. |
 | `token` | Bearer token for MCP requests. Optional — if unset, the plugin runs interactive device login. |
 | `tokenCommand` | Shell command that prints a bearer token to stdout. Alternative to `token`. |
 | `headers` | Extra HTTP headers for MCP requests. |
-| `autoRecall` | Search Owletto for relevant memories before each prompt. Default `true`. |
+| `autoRecall` | Search Lobu memory for relevant memories before each prompt. Default `true`. |
 | `recallLimit` | Maximum recalled memory records per request. Default `6`. |
 | `autoCapture` | Capture conversation observations as long-term memories after each session. Default `true`. |
 

--- a/packages/owletto-openclaw/openclaw.plugin.json
+++ b/packages/owletto-openclaw/openclaw.plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "openclaw-owletto",
   "kind": "memory",
-  "description": "Owletto long-term memory over MCP. Set mcpUrl to enable. Authentication via token, tokenCommand, or interactive device login.",
+  "description": "Lobu memory over MCP. Set mcpUrl to enable. Authentication via token, tokenCommand, or interactive device login.",
   "entry": "./dist/index.js",
   "configSchema": {
     "type": "object",
@@ -9,11 +9,11 @@
     "properties": {
       "mcpUrl": {
         "type": "string",
-        "description": "Full MCP endpoint URL (for example, https://owletto.com/mcp/acme). Required."
+        "description": "Full MCP endpoint URL (for example, https://app.lobu.ai/mcp/acme). Required."
       },
       "webUrl": {
         "type": "string",
-        "description": "Public web URL for the Owletto instance (for example, https://owletto.com). Used to generate links for the agent."
+        "description": "Public web URL for the Lobu memory instance (for example, https://app.lobu.ai). Used to generate links for the agent."
       },
       "token": {
         "type": "string",
@@ -33,7 +33,7 @@
       "autoRecall": {
         "type": "boolean",
         "default": true,
-        "description": "When true, searches Owletto for relevant memories before each prompt."
+        "description": "When true, searches Lobu memory for relevant memories before each prompt."
       },
       "recallLimit": {
         "type": "integer",

--- a/packages/owletto-openclaw/package.json
+++ b/packages/owletto-openclaw/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@lobu/owletto-openclaw",
   "version": "3.7.0",
-  "description": "Owletto long-term memory plugin for OpenClaw",
+  "description": "Lobu memory plugin for OpenClaw",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/owletto-openclaw/src/index.ts
+++ b/packages/owletto-openclaw/src/index.ts
@@ -26,7 +26,7 @@ type PluginLogger = {
 };
 
 const AUTH_REQUIRED_MSG =
-  'Owletto memory is not connected. Call the owletto_login tool to authenticate, then show the user the login URL and code. After the user completes login in their browser, call owletto_login_check to finish authentication.';
+  'Lobu memory is not connected. Call the owletto_login tool to authenticate, then show the user the login URL and code. After the user completes login in their browser, call owletto_login_check to finish authentication.';
 const DEFAULT_RECALL_LIMIT = 6;
 
 // Minimal fallback context used before the workspace instructions are fetched.
@@ -957,8 +957,8 @@ function registerMcpTools(
 
 const plugin = {
   id: 'openclaw-owletto',
-  name: 'Owletto Memory',
-  description: 'Owletto long-term memory plugin via MCP.',
+  name: 'Lobu Memory',
+  description: 'Lobu long-term memory plugin via MCP.',
   kind: 'memory' as const,
   register(api: Record<string, unknown>) {
     const log = getLogger(api);
@@ -1063,7 +1063,7 @@ const plugin = {
         name: 'owletto_login',
         label: 'Owletto Login',
         description:
-          'Start Owletto authentication. Only call this if other Owletto tools return authentication errors. If Owletto memory is already connected, skip this step. Returns a URL and code for the user to complete login in their browser. After the user completes login, call owletto_login_check to finish.',
+          'Start Lobu memory authentication. Only call this if other Lobu memory tools return authentication errors. If Lobu memory is already connected, skip this step. Returns a URL and code for the user to complete login in their browser. After the user completes login, call owletto_login_check to finish.',
         parameters: {
           type: 'object',
           properties: {},

--- a/packages/owletto-sdk/package.json
+++ b/packages/owletto-sdk/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@lobu/owletto-sdk",
   "version": "3.7.0",
-  "description": "Owletto SDK - build pluggable connectors for the Owletto integration platform",
+  "description": "Lobu memory SDK — build pluggable connectors for Lobu memory",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/owletto-worker/README.md
+++ b/packages/owletto-worker/README.md
@@ -1,6 +1,6 @@
 # @lobu/owletto-worker
 
-Self-hosted Owletto worker. Polls the backend for sync jobs, executes connectors locally, generates embeddings, and streams results back. Private workspace package — not published to npm.
+Self-hosted Lobu memory worker. Polls the backend for sync jobs, executes connectors locally, generates embeddings, and streams results back. Private workspace package — not published to npm.
 
 ## Usage
 

--- a/packages/owletto-worker/package.json
+++ b/packages/owletto-worker/package.json
@@ -2,7 +2,7 @@
   "name": "@lobu/owletto-worker",
   "version": "1.6.0",
   "private": true,
-  "description": "Self-hosted worker for Owletto - connectors and embedding generation",
+  "description": "Self-hosted worker for Lobu memory — connectors and embedding generation",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary
Rebrand the memory product from **Owletto** to **Lobu memory** across user-facing surfaces (landing site, docs, CLI prompts, and the \`@lobu/owletto-openclaw\` plugin self-name).

**Preserved intact** (technical identifiers, not renamed):
- Package name: \`@lobu/owletto-openclaw\`
- TOML key: \`[memory.owletto]\`
- CLI commands: \`owletto login\`, \`npx owletto@latest …\`
- Env vars: \`OWLETTO_*\`, \`MEMORY_URL\`
- URL slugs: \`/reference/owletto-cli/\`, \`/mcp/owletto\`
- Code identifiers: \`getOwlettoUrl\`, \`getOwlettoMcpUrl\`, etc.

## Scope
- \`packages/landing\`: 32 files — guides, reference, getting-started, connect-from, blog post, components (MemorySection, ArchitectureDiagram, PricingSection, SkillsWorkflowSection, ConnectFromDocContent), \`llms.txt\`, agent-skills manifest, memory.astro, astro config sidebar.
- \`packages/cli\`: \`README.md\`, \`init.ts\` prompts (\"Memory:\" choices, post-init success message, scaffolded docker-compose and \`lobu.toml\` comments), matching test assertion.
- \`packages/owletto-openclaw\`: plugin \`name\` metadata + LLM-facing tool descriptions (so agents say \"Lobu memory\").

## Test plan
- [x] \`cd packages/landing && bun run build\` — 103 pages built cleanly
- [x] \`make build-packages\` — core/gateway/worker all pass
- [x] \`bun test packages/cli/src/__tests__/init-memory.test.ts\` — 3/3 pass
- [x] Grep sweep: zero user-facing \"Owletto\" strings remain in built landing HTML; only code identifiers (\`useScopedOwlettoUrl\`, etc.) left