### PR TITLE
chore(ci): add codex auto-approve workflow

### DIFF
--- a/.github/workflows/codex-auto-approve.yml
+++ b/.github/workflows/codex-auto-approve.yml
@@ -1,0 +1,78 @@
+name: Codex Auto-Approve
+
+on:
+  pull_request_review:
+    types: [submitted]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "PR number to check for Codex approval"
+        required: true
+        type: number
+
+permissions:
+  contents: read
+
+concurrency:
+  group: codex-auto-approve-${{ github.event.pull_request.number || inputs.pr_number }}
+  cancel-in-progress: false
+
+jobs:
+  approve:
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    if: >
+      github.event_name == 'workflow_dispatch' ||
+      github.event.review.user.login == 'chatgpt-codex-connector' ||
+      github.event.review.user.login == 'chatgpt-codex-connector[bot]'
+    steps:
+      - name: Generate App token
+        id: app
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.CODEX_APPROVER_APP_ID }}
+          private-key: ${{ secrets.CODEX_APPROVER_PRIVATE_KEY }}
+
+      - name: Resolve PR number
+        id: pr
+        env:
+          EVENT_PR: ${{ github.event.pull_request.number }}
+          INPUT_PR: ${{ inputs.pr_number }}
+        run: |
+          pr="${INPUT_PR:-$EVENT_PR}"
+          if [ -z "$pr" ]; then
+            echo "No PR number available"
+            exit 1
+          fi
+          echo "number=$pr" >> "$GITHUB_OUTPUT"
+
+      - name: Wait for Codex 👍 and approve
+        env:
+          GH_TOKEN: ${{ steps.app.outputs.token }}
+          PR: ${{ steps.pr.outputs.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          echo "Checking PR #$PR for Codex 👍 on $REPO"
+
+          existing=$(gh api "repos/$REPO/pulls/$PR/reviews" \
+            --jq '[.[] | select(.user.type == "Bot" and .user.login | startswith("codex-approver")) | select(.state == "APPROVED")] | length')
+          if [ "$existing" -gt 0 ]; then
+            echo "Already approved by this app; nothing to do."
+            exit 0
+          fi
+
+          for i in $(seq 1 10); do
+            reacts=$(gh api "repos/$REPO/issues/$PR/reactions" \
+              --jq '[.[] | select(.user.login == "chatgpt-codex-connector[bot]" and .content == "+1")] | length')
+            echo "attempt $i: codex 👍 reactions=$reacts"
+            if [ "$reacts" -gt 0 ]; then
+              gh api -X POST "repos/$REPO/pulls/$PR/reviews" \
+                -F event=APPROVE \
+                -F body="Auto-approved: Codex review left a 👍 reaction (no suggestions remaining)."
+              echo "Approved PR #$PR"
+              exit 0
+            fi
+            sleep 6
+          done
+          echo "No 👍 after 60s; nothing to do."


### PR DESCRIPTION
## Summary

- Bridges Codex's 👍 reaction into a formal `APPROVE` review.
- Uses the `codex-approver` GitHub App (App ID 3457334) via `actions/create-github-app-token@v1`.
- Triggers on `pull_request_review` (submitted) and `workflow_dispatch` for manual retries.
- Polls reactions up to 60s to handle Codex's eventual-consistency gap between posting its review and leaving the 👍 reaction.
- Skips if already approved by this app.

## Test plan

- [ ] Merge this PR and verify a future Codex 👍 triggers an `APPROVE` review on the target PR.
- [ ] Try `workflow_dispatch` with an existing approved-but-open PR if one exists, to validate end-to-end without waiting for a fresh Codex pass.