### PR TITLE
chore: gitignore .claude/worktrees/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 node_modules
 
 **/.claude/settings.local.json
+.claude/worktrees/
 
 # Environment files
 .env

--- a/config/biome.config.json
+++ b/config/biome.config.json
@@ -14,6 +14,7 @@
       "!**/packages/**/*/workspaces/**",
       "!**/workspaces/**",
       "!**/.claude/debug/**",
+      "!**/.claude/worktrees/**",
       "!**/dist/**",
       "!**/src/errors.js",
       "!**/*.raw.js",


### PR DESCRIPTION
## Summary
- Add `.claude/worktrees/` to `.gitignore` so per-agent worktree checkouts never get staged (they were accidentally `git add`'d in past sessions).
- Add the same path to `config/biome.config.json` `files.includes` exclusions so lint doesn't recurse into those nested worktrees.

## Test plan
- [x] `bun run check:fix` clean
- [x] `tsc --noEmit` clean (pre-commit)
- [x] `git status` on a parent checkout with live worktrees shows nothing under `.claude/worktrees/`