### PR TITLE
ci: tighten PR pipeline — smoke gate, claude re-review, size limit

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,28 +1,12 @@
-## Description
-Brief description of the changes in this PR.
+## Summary
+<!-- Why this change? 1–3 bullets. Skip if the PR title is self-explanatory. -->
 
-## Type of Change
-- [ ] Bug fix (non-breaking change which fixes an issue)
-- [ ] New feature (non-breaking change which adds functionality)
-- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-- [ ] Documentation update
-- [ ] Performance improvement
-- [ ] Refactoring
+## Test plan
+<!-- Check only what you actually ran. See AGENTS.md → "Validation after code changes". -->
+- [ ] `bun run check:fix` clean
+- [ ] `bun run typecheck` passes (or `make build-packages` if TS packages changed)
+- [ ] Package-specific validation (landing: `cd packages/landing && bun run build`)
+- [ ] If bot behavior: ran `./scripts/test-bot.sh` or relevant eval
 
-## Testing
-- [ ] Ran `bun test` and all tests pass
-- [ ] Ran `bun run format` and `bun run lint` 
-- [ ] Verified changes work in Docker Compose (`make dev`)
-
-## Checklist
-- [ ] My code follows the project's style guidelines
-- [ ] I have performed a self-review of my code
-- [ ] I have commented my code, particularly in hard-to-understand areas
-- [ ] My changes generate no new warnings
-- [ ] Any dependent changes have been merged and published
-
-## Related Issues
-Closes #(issue number)
-
-## Additional Notes
-Any additional information or context about the PR.
+## Notes
+<!-- Screenshots, follow-ups, linked issues (`Closes #123`), breaking-change callouts. Delete if none. -->

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,11 +88,43 @@ jobs:
       - name: Run TypeScript type check
         run: bun run typecheck
 
+  detect-smoke:
+    runs-on: ubuntu-latest
+    outputs:
+      run: ${{ steps.check.outputs.run }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - id: check
+        env:
+          EVENT: ${{ github.event_name }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          if [ "$EVENT" != "pull_request" ]; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          non_trivial=$(git diff --name-only "$BASE_SHA" "$HEAD_SHA" \
+            | grep -Ev '^(\.gitignore|LICENSE|CODEOWNERS|.*\.md|\.github/.*|docs/.*|config/.*)$' \
+            || true)
+          if [ -n "$non_trivial" ]; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "run=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::Docs/config-only diff; skipping smoke eval."
+          fi
+
   smoke-example:
     runs-on: ubuntu-latest
     timeout-minutes: 45
-    needs: [test, format-lint, typecheck]
-    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
+    needs: [test, format-lint, typecheck, detect-smoke]
+    if: >
+      needs.detect-smoke.outputs.run == 'true' &&
+      (github.event_name != 'pull_request' ||
+       github.event.pull_request.head.repo.full_name == github.repository)
     env:
       GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
     steps:

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -2,10 +2,15 @@ name: Auto review PRs
 
 on:
   pull_request:
-    types: [opened]
+    types: [opened, synchronize, ready_for_review]
+
+concurrency:
+  group: claude-auto-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
 
 jobs:
   auto-review:
+    if: github.event.pull_request.draft == false
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -29,22 +29,33 @@ jobs:
   pr-size:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      
       - name: Check PR size
         uses: actions/github-script@v7
         with:
           script: |
             const pr = context.payload.pull_request;
-            const additions = pr.additions;
-            const deletions = pr.deletions;
-            const total = additions + deletions;
-            
-            if (total > 1000) {
-              core.warning(`Large PR detected: ${total} lines changed. Consider breaking into smaller PRs.`);
+            const labels = (pr.labels || []).map(l => l.name);
+            const total = pr.additions + pr.deletions;
+
+            console.log(`PR size: +${pr.additions} -${pr.deletions} (total ${total})`);
+
+            const HARD_LIMIT = 1000;
+            const SOFT_LIMIT = 500;
+
+            if (labels.includes('skip-size-check')) {
+              core.notice(`Size gate skipped via 'skip-size-check' label (${total} lines).`);
+              return;
             }
-            
-            console.log(`PR size: +${additions} -${deletions}`);
+
+            if (total > HARD_LIMIT) {
+              core.setFailed(
+                `PR exceeds ${HARD_LIMIT} lines (has ${total}). ` +
+                `AGENTS.md: "one branch = one concern" — split the PR, or add the ` +
+                `'skip-size-check' label if this is genuinely one concern (e.g. generated code).`,
+              );
+            } else if (total > SOFT_LIMIT) {
+              core.warning(`PR has ${total} lines; consider splitting if it covers multiple concerns.`);
+            }
   
   build-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -2,7 +2,7 @@ name: PR Validation
 
 on:
   pull_request:
-    types: [opened, edited, synchronize, reopened]
+    types: [opened, edited, synchronize, reopened, labeled, unlabeled]
 
 jobs:
   pr-title:


### PR DESCRIPTION
## Summary
Closes four PR-workflow gaps surfaced in the recent pipeline audit.

- **Gap 6 — `smoke-example` now skips trivial diffs.** New `detect-smoke` job diffs base↔head; if all changed files match `.gitignore|LICENSE|CODEOWNERS|*.md|.github/*|docs/*|config/*`, the Gemini eval is skipped. Docs-only PRs like #303 no longer spend ~3 min and Gemini quota on an always-failing eval.
- **Gap 7 — PR template rewritten.** Old template referenced `bun run format` / `bun run lint` (neither exist). New template cites the real commands from AGENTS.md → "Validation after code changes" (`bun run check:fix`, `bun run typecheck`, package-specific build).
- **Gap 8 — Claude auto-review now re-runs on push.** `claude-review.yml` was `types: [opened]`, so Claude reviewed the initial commit and never the fixes. Added `synchronize` + `ready_for_review`, with a `concurrency` group so only the latest push is reviewed. Drafts are skipped.
- **Gap 9 — `pr-size` now enforces.** Was advisory-only (`core.warning`). Now fails at >1000 lines (matching AGENTS.md "one branch = one concern"), warns at >500, and has a `skip-size-check` label escape hatch for legitimate single-concern large PRs (generated code, big formatter runs, etc.).

## Follow-ups (not in this PR)
- Gap 5 (stale branches + auto-delete-branch setting) — repo-settings change, handled out-of-band.
- Add `pr-size` to the required-checks list in branch protection once we confirm the threshold isn't too aggressive.
- Make `smoke-example` required once the upstream Gemini eval flakiness is fixed.

## Test plan
- [x] `bun run check:fix` clean (ran by pre-commit)
- [x] `bun run typecheck` passes (ran by pre-commit)
- [ ] After merge, verify `smoke-example` is SKIPPED on a docs-only follow-up PR
- [ ] After merge, push a fixup commit to any open PR and confirm `auto-review` re-runs
- [ ] Open a >1000-line test PR and confirm `pr-size` fails; add `skip-size-check` label and confirm it passes