### PR TITLE
fix(owletto-backend): add missing memberRole to internal ToolContext literals

### DIFF
--- a/packages/owletto-backend/src/rest-api.ts
+++ b/packages/owletto-backend/src/rest-api.ts
@@ -71,6 +71,7 @@ function publicToolContext(requestUrl: string, organizationId: string) {
   return {
     organizationId,
     userId: null,
+    memberRole: null,
     isAuthenticated: false,
     clientId: null,
     requestUrl,

--- a/packages/owletto-backend/src/utils/provisioned-connection.ts
+++ b/packages/owletto-backend/src/utils/provisioned-connection.ts
@@ -43,6 +43,7 @@ export async function createProvisionedConnection(
       {
         organizationId: params.organizationId,
         userId: params.userId,
+        memberRole: null,
         isAuthenticated: true,
         requestUrl: params.requestUrl,
         baseUrl: getConfiguredPublicOrigin() ?? undefined,

--- a/packages/owletto-backend/src/watchers/reaction-executor.ts
+++ b/packages/owletto-backend/src/watchers/reaction-executor.ts
@@ -35,7 +35,12 @@ function buildReactionSDK(
   const windowId = window.id;
   // userId=null + isAuthenticated=true signals a system/internal call (e.g. reaction scripts).
   // canWriteEntity() in organization-access.ts grants write access on org match alone for this case.
-  const toolCtx = { organizationId: organization_id, userId: null, isAuthenticated: true };
+  const toolCtx = {
+    organizationId: organization_id,
+    userId: null,
+    memberRole: null,
+    isAuthenticated: true,
+  };
   const entityIds = context.entities.map((e) => e.id);
 
   function track(


### PR DESCRIPTION
## Summary
- #309 added \`memberRole: string | null\` as a required field on \`ToolContext\` but missed three non-MCP callers that construct the context by hand:
  - \`publicToolContext\` in \`rest-api.ts\` (anonymous public REST reads)
  - \`createProvisionedConnection\` in \`utils/provisioned-connection.ts\`
  - the watcher reaction executor in \`watchers/reaction-executor.ts\`
- Main has been red (\`build-app\` image build) since #309 landed — the Dockerfile runs a package-local \`tsc\` which catches these, while the root-level CI \`typecheck\` apparently doesn't. That's a separate gap worth fixing.

## Test plan
- [ ] \`cd packages/owletto-backend && bunx tsc --noEmit\` clean
- [ ] \`build-app\` image build green on this PR