### PR TITLE
fix(owletto-backend): exclude watcher runs from worker poll

### DIFF
--- a/packages/owletto-backend/src/worker-api.ts
+++ b/packages/owletto-backend/src/worker-api.ts
@@ -61,6 +61,7 @@ export async function pollWorkerJob(c: Context<{ Bindings: Env }>) {
         SELECT r.id
         FROM runs r
         WHERE r.status = 'pending'
+          AND r.run_type <> 'watcher'
           AND (r.approval_status = 'auto' OR r.approval_status = 'approved')
           AND (${hasBrowser} OR COALESCE((SELECT cd.api_type FROM connector_definitions cd WHERE cd.key = r.connector_key LIMIT 1), 'api') = 'api')
         ORDER BY


### PR DESCRIPTION
## Summary
- `pollWorkerJob` was claiming `runs` rows with `run_type='watcher'` and immediately marking them `completed` in ~15 ms, silently dropping the actual work. Watcher runs must be dispatched by the in-process gateway scheduler that invokes the lobu agent API.
- Adds `AND r.run_type <> 'watcher'` to the poll query so the worker daemon only claims non-watcher work.

## Why now
In local multi-environment testing, the `summaries-prod` K8s worker daemon was racing the local gateway, claiming watcher runs from the shared DB and starving local validation.

## Test plan
- [ ] Unit: worker pollWorkerJob no longer returns a watcher run
- [ ] Integration: with this deployed, `summaries-app-owletto-worker` stops taking watcher 176 runs; the in-process scheduler dispatches them as expected