### PR TITLE
test(gateway): lock in DNS pinning in worker HTTP proxy

### DIFF
--- a/packages/gateway/src/__tests__/http-proxy.test.ts
+++ b/packages/gateway/src/__tests__/http-proxy.test.ts
@@ -301,11 +301,21 @@ describe("HTTP Proxy DNS pinning", () => {
     __testOnly.setDnsLookup(null);
   });
 
-  function mockLookup(addresses: LookupAddress[][]): { calls: number } {
-    const state = { calls: 0 };
+  interface MockLookupState {
+    calls: number;
+    firstCall: Promise<void>;
+  }
+
+  function mockLookup(addresses: LookupAddress[][]): MockLookupState {
+    let resolveFirst!: () => void;
+    const firstCall = new Promise<void>((resolve) => {
+      resolveFirst = resolve;
+    });
+    const state: MockLookupState = { calls: 0, firstCall };
     __testOnly.setDnsLookup(async () => {
       const i = Math.min(state.calls, addresses.length - 1);
       state.calls += 1;
+      if (state.calls === 1) resolveFirst();
       return addresses[i]!;
     });
     return state;
@@ -340,23 +350,49 @@ describe("HTTP Proxy DNS pinning", () => {
     expect(res.statusLine).toContain("403");
   });
 
+  async function issueRawRequest(request: string): Promise<net.Socket> {
+    const client = new net.Socket();
+    await new Promise<void>((resolve, reject) => {
+      client.on("error", reject);
+      client.connect(proxyPort, "127.0.0.1", () => {
+        client.write(request);
+        resolve();
+      });
+    });
+    return client;
+  }
+
   test("performs exactly one DNS lookup per HTTP proxy request", async () => {
     const state = mockLookup([[{ address: "203.0.113.1", family: 4 }]]);
     const token = createValidToken(deploymentName);
-    // Upstream connection to TEST-NET-3 will fail/time out — irrelevant.
-    // What matters is that the proxy only resolves once.
-    await rawProxyRequest("http://rebind.test/", {
-      proxyAuth: makeBasicAuth(deploymentName, token),
-    }).catch(() => undefined);
+    const auth = makeBasicAuth(deploymentName, token);
+    const client = await issueRawRequest(
+      `GET http://rebind.test/ HTTP/1.1\r\nHost: rebind.test\r\n` +
+        `Proxy-Authorization: ${auth}\r\nConnection: close\r\n\r\n`
+    );
+    try {
+      await state.firstCall;
+      await new Promise((r) => setTimeout(r, 100));
+    } finally {
+      client.destroy();
+    }
     expect(state.calls).toBe(1);
   });
 
   test("performs exactly one DNS lookup per CONNECT request", async () => {
     const state = mockLookup([[{ address: "203.0.113.1", family: 4 }]]);
     const token = createValidToken(deploymentName);
-    await connectRequest("rebind.test", 443, {
-      proxyAuth: makeBasicAuth(deploymentName, token),
-    }).catch(() => undefined);
+    const auth = makeBasicAuth(deploymentName, token);
+    const client = await issueRawRequest(
+      `CONNECT rebind.test:443 HTTP/1.1\r\nHost: rebind.test:443\r\n` +
+        `Proxy-Authorization: ${auth}\r\n\r\n`
+    );
+    try {
+      await state.firstCall;
+      await new Promise((r) => setTimeout(r, 100));
+    } finally {
+      client.destroy();
+    }
     expect(state.calls).toBe(1);
   });
 
@@ -378,12 +414,14 @@ describe("HTTP Proxy DNS pinning", () => {
     await new Promise<void>((resolve) => trap.listen(0, "127.0.0.1", resolve));
     const trapAddr = trap.address() as net.AddressInfo;
 
+    const client = new net.Socket();
     try {
-      // Fire the proxy request via a raw socket and give the proxy time to
-      // do DNS + attempt an upstream connect, then bail. We don't wait for
-      // the upstream connect to 203.0.113.1 to fail — that can take seconds.
+      // Fire the proxy request via a raw socket. Wait for the mocked DNS
+      // lookup to be called once (signal), then give the event loop a small
+      // settle window for any follow-up connect attempt to land on the trap
+      // before asserting. We don't wait for the upstream connect to
+      // 203.0.113.1 to fail — that can take seconds on CI.
       const token = createValidToken(deploymentName);
-      const client = new net.Socket();
       await new Promise<void>((resolve) => {
         client.on("error", () => resolve());
         client.connect(proxyPort, "127.0.0.1", () => {
@@ -393,13 +431,13 @@ describe("HTTP Proxy DNS pinning", () => {
               `Proxy-Authorization: ${makeBasicAuth(deploymentName, token)}\r\n` +
               "Connection: close\r\n\r\n"
           );
-          setTimeout(() => {
-            client.destroy();
-            resolve();
-          }, 500);
+          resolve();
         });
       });
+      await state.firstCall;
+      await new Promise((r) => setTimeout(r, 250));
     } finally {
+      client.destroy();
       await new Promise<void>((resolve, reject) =>
         trap.close((err) => (err ? reject(err) : resolve()))
       );

--- a/packages/gateway/src/__tests__/http-proxy.test.ts
+++ b/packages/gateway/src/__tests__/http-proxy.test.ts
@@ -1,5 +1,6 @@
-import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { afterAll, afterEach, beforeAll, describe, expect, test } from "bun:test";
 import * as crypto from "node:crypto";
+import type { LookupAddress } from "node:dns";
 import * as http from "node:http";
 import * as net from "node:net";
 import { generateWorkerToken } from "@lobu/core";
@@ -277,5 +278,129 @@ describe("HTTP Proxy Domain Filtering (unrestricted mode)", () => {
       proxyAuth: makeBasicAuth(deploymentName, token),
     });
     expect(res.statusLine).toContain("200");
+  });
+});
+
+// ─── DNS pinning / rebinding tests ───────────────────────────────────────────
+// Regression coverage for https://github.com/lobu-ai/lobu/issues/252.
+// The proxy must do exactly one DNS lookup per request, validate that result,
+// and connect to the validated IP — so a resolver that flips between a public
+// and an internal IP cannot bypass the internal-IP block.
+
+describe("HTTP Proxy DNS pinning", () => {
+  const deploymentName = "dns-pin-worker";
+
+  afterEach(() => {
+    __testOnly.setDnsLookup(null);
+  });
+
+  function mockLookup(addresses: LookupAddress[][]): { calls: number } {
+    const state = { calls: 0 };
+    __testOnly.setDnsLookup(async () => {
+      const i = Math.min(state.calls, addresses.length - 1);
+      state.calls += 1;
+      return addresses[i]!;
+    });
+    return state;
+  }
+
+  test("blocks when DNS returns a mix of public and loopback IPs", async () => {
+    mockLookup([
+      [
+        { address: "203.0.113.1", family: 4 },
+        { address: "127.0.0.1", family: 4 },
+      ],
+    ]);
+    const token = createValidToken(deploymentName);
+    const res = await rawProxyRequest("http://rebind.test/", {
+      proxyAuth: makeBasicAuth(deploymentName, token),
+    });
+    expect(res.statusCode).toBe(403);
+    expect(res.body).toContain("local/private IP");
+  });
+
+  test("blocks CONNECT when DNS returns a mix of public and loopback IPs", async () => {
+    mockLookup([
+      [
+        { address: "203.0.113.1", family: 4 },
+        { address: "127.0.0.1", family: 4 },
+      ],
+    ]);
+    const token = createValidToken(deploymentName);
+    const res = await connectRequest("rebind.test", 443, {
+      proxyAuth: makeBasicAuth(deploymentName, token),
+    });
+    expect(res.statusLine).toContain("403");
+  });
+
+  test("performs exactly one DNS lookup per HTTP proxy request", async () => {
+    const state = mockLookup([[{ address: "203.0.113.1", family: 4 }]]);
+    const token = createValidToken(deploymentName);
+    // Upstream connection to TEST-NET-3 will fail/time out — irrelevant.
+    // What matters is that the proxy only resolves once.
+    await rawProxyRequest("http://rebind.test/", {
+      proxyAuth: makeBasicAuth(deploymentName, token),
+    }).catch(() => undefined);
+    expect(state.calls).toBe(1);
+  });
+
+  test("performs exactly one DNS lookup per CONNECT request", async () => {
+    const state = mockLookup([[{ address: "203.0.113.1", family: 4 }]]);
+    const token = createValidToken(deploymentName);
+    await connectRequest("rebind.test", 443, {
+      proxyAuth: makeBasicAuth(deploymentName, token),
+    }).catch(() => undefined);
+    expect(state.calls).toBe(1);
+  });
+
+  test("is flip-resistant: connects to first IP even if resolver later returns loopback", async () => {
+    // First lookup returns a public IP; any subsequent lookup would return
+    // loopback. The proxy must never issue that second lookup, and must not
+    // land a connection on the loopback trap even if it did.
+    const state = mockLookup([
+      [{ address: "203.0.113.1", family: 4 }],
+      [{ address: "127.0.0.1", family: 4 }],
+    ]);
+
+    let loopbackHit = false;
+    const trap = http.createServer((_req, res) => {
+      loopbackHit = true;
+      res.writeHead(200);
+      res.end("trapped");
+    });
+    await new Promise<void>((resolve) =>
+      trap.listen(0, "127.0.0.1", resolve)
+    );
+    const trapAddr = trap.address() as net.AddressInfo;
+
+    try {
+      // Fire the proxy request via a raw socket and give the proxy time to
+      // do DNS + attempt an upstream connect, then bail. We don't wait for
+      // the upstream connect to 203.0.113.1 to fail — that can take seconds.
+      const token = createValidToken(deploymentName);
+      const client = new net.Socket();
+      await new Promise<void>((resolve) => {
+        client.on("error", () => resolve());
+        client.connect(proxyPort, "127.0.0.1", () => {
+          client.write(
+            `GET http://rebind.test:${trapAddr.port}/ HTTP/1.1\r\n` +
+              `Host: rebind.test:${trapAddr.port}\r\n` +
+              `Proxy-Authorization: ${makeBasicAuth(deploymentName, token)}\r\n` +
+              "Connection: close\r\n\r\n"
+          );
+          setTimeout(() => {
+            client.destroy();
+            resolve();
+          }, 500);
+        });
+      });
+    } finally {
+      await new Promise<void>((resolve, reject) =>
+        trap.close((err) => (err ? reject(err) : resolve()))
+      );
+    }
+
+    expect(state.calls).toBe(1);
+    expect(loopbackHit).toBe(false);
   });
 });

--- a/packages/gateway/src/__tests__/http-proxy.test.ts
+++ b/packages/gateway/src/__tests__/http-proxy.test.ts
@@ -1,4 +1,11 @@
-import { afterAll, afterEach, beforeAll, describe, expect, test } from "bun:test";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  describe,
+  expect,
+  test,
+} from "bun:test";
 import * as crypto from "node:crypto";
 import type { LookupAddress } from "node:dns";
 import * as http from "node:http";
@@ -368,9 +375,7 @@ describe("HTTP Proxy DNS pinning", () => {
       res.writeHead(200);
       res.end("trapped");
     });
-    await new Promise<void>((resolve) =>
-      trap.listen(0, "127.0.0.1", resolve)
-    );
+    await new Promise<void>((resolve) => trap.listen(0, "127.0.0.1", resolve));
     const trapAddr = trap.address() as net.AddressInfo;
 
     try {

--- a/packages/gateway/src/proxy/http-proxy.ts
+++ b/packages/gateway/src/proxy/http-proxy.ts
@@ -204,8 +204,18 @@ function isBlockedIpAddress(ip: string): boolean {
   return false;
 }
 
+type DnsLookupAllFn = (
+  hostname: string,
+  options: { all: true; verbatim: true }
+) => Promise<LookupAddress[]>;
+
+let dnsLookupOverride: DnsLookupAllFn | null = null;
+
 export const __testOnly = {
   isBlockedIpAddress,
+  setDnsLookup(fn: DnsLookupAllFn | null): void {
+    dnsLookupOverride = fn;
+  },
 };
 
 async function resolveAndValidateTarget(
@@ -226,7 +236,9 @@ async function resolveAndValidateTarget(
 
   let addresses: LookupAddress[];
   try {
-    addresses = await dns.lookup(hostname, { all: true, verbatim: true });
+    addresses = dnsLookupOverride
+      ? await dnsLookupOverride(hostname, { all: true, verbatim: true })
+      : await dns.lookup(hostname, { all: true, verbatim: true });
   } catch (error) {
     const message = error instanceof Error ? error.message : "unknown error";
     return {


### PR DESCRIPTION
## Summary

Adds regression coverage for the DNS-rebinding/TOCTOU concern in #252. The worker HTTP proxy already resolves each hostname once via `resolveAndValidateTarget()` at `packages/gateway/src/proxy/http-proxy.ts` and then connects to the validated IP (both CONNECT and plain-HTTP paths), so the core fix the issue asks for is already in place. What was missing is the test coverage to lock that invariant in.

Changes:
- Add a test-only `setDnsLookup` hook in `__testOnly` so tests can inject a mock resolver without racing Node's internal `dns.lookup`.
- Add a new `HTTP Proxy DNS pinning` describe block covering:
  - Mixed result sets (`[public, loopback]`) are rejected on both HTTP and CONNECT.
  - Exactly one DNS lookup per proxied request (HTTP + CONNECT).
  - Flip-resistance: if a resolver would return loopback on a second call, the proxy never issues that call and never lands a connection on a loopback trap.

Not in scope here: tightening the production code further (e.g. passing an explicit pinned `lookup` to `net.connect` / `http.request` as belt-and-suspenders). The current IP-only handoff is already sufficient — the tests assert the invariant directly, and any future regression will fail them.

## Test plan

- [x] `bun test src/__tests__/http-proxy.test.ts` — 20 pass, 1 pre-existing failure unrelated to this change (`allows request to any domain in unrestricted mode` — environmental DNS for example.com).
- [x] `bun run typecheck` — clean.
- [x] Biome pre-commit hook — clean.

Closes #252.

https://claude.ai/code/session_01EwwkpxHTTbadguFseqgn9x

---
_Generated by [Claude Code](https://claude.ai/code/session_01EwwkpxHTTbadguFseqgn9x)_