### PR TITLE
feat(core): add guardrail primitive (#254)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,6 +37,12 @@ All chat platforms (Telegram, Slack, Discord, WhatsApp, Teams) run through Chat 
 - Built-in MCPs: `AskUser` (request user input), `UploadFile` (share files with user).
 - **Integration auth lives in Owletto** — OAuth, token refresh, and API proxying for third-party services (GitHub, Google, etc.) are handled by Owletto MCP servers. Workers never see OAuth tokens.
 
+#### Guardrails
+- Primitive lives in `packages/core/src/guardrails/`: `Guardrail<stage>`, `GuardrailRegistry`, `runGuardrails()`. Stages: `input` (user message → worker), `output` (worker text → user), `pre-tool` (tool call authorization).
+- Each guardrail's `run(ctx)` returns `{ tripped, reason?, metadata? }`. The runner races all enabled guardrails at a stage; the first trip short-circuits (later results are discarded) and a thrown guardrail is logged and treated as a pass.
+- Enable per-agent in `lobu.toml`: `[agents.<id>] guardrails = ["secret-scan", "prompt-injection"]`. Names must match a guardrail registered in the gateway's `GuardrailRegistry` at startup.
+- Built-in: `createNoopGuardrail(stage, name?)` for tests and as a template. Real guardrails (prompt-injection classifier, secret/PII scanner) live in downstream packages that call `registry.register(...)` during gateway boot.
+
 #### Network
 - Workers run on the internal-only `lobu-internal` network; the gateway sits on both `lobu-public` and `lobu-internal` and is the single egress.
 - Gateway runs a Node HTTP proxy on :8118; workers get `HTTP_PROXY=http://gateway:8118` for all outbound (curl/wget/npm/git).

--- a/packages/core/src/__tests__/guardrails.test.ts
+++ b/packages/core/src/__tests__/guardrails.test.ts
@@ -155,12 +155,7 @@ describe("runGuardrails", () => {
     registry.register(first);
     registry.register(second);
 
-    const outcomeP = runGuardrails(
-      registry,
-      "input",
-      ["first", "second"],
-      ctx
-    );
+    const outcomeP = runGuardrails(registry, "input", ["first", "second"], ctx);
     firstGate.resolve();
     const outcome = await outcomeP;
     expect(outcome.tripped?.guardrail).toBe("first");

--- a/packages/core/src/__tests__/guardrails.test.ts
+++ b/packages/core/src/__tests__/guardrails.test.ts
@@ -1,0 +1,240 @@
+import { describe, expect, test } from "bun:test";
+import {
+  createNoopGuardrail,
+  type Guardrail,
+  GuardrailRegistry,
+  type InputGuardrailContext,
+  runGuardrails,
+} from "../guardrails";
+
+const ctx: InputGuardrailContext = {
+  agentId: "agent-1",
+  userId: "user-1",
+  message: "hello",
+  platform: "telegram",
+};
+
+function deferred<T>(): {
+  promise: Promise<T>;
+  resolve: (v: T) => void;
+  reject: (e: unknown) => void;
+} {
+  let resolve!: (v: T) => void;
+  let reject!: (e: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+describe("GuardrailRegistry", () => {
+  test("register + resolve by enable list", () => {
+    const registry = new GuardrailRegistry();
+    const a = createNoopGuardrail("input", "a");
+    const b = createNoopGuardrail("input", "b");
+    registry.register(a);
+    registry.register(b);
+
+    const resolved = registry.resolve("input", ["a"]);
+    expect(resolved).toHaveLength(1);
+    expect(resolved[0]?.name).toBe("a");
+  });
+
+  test("list returns all guardrails for a stage", () => {
+    const registry = new GuardrailRegistry();
+    registry.register(createNoopGuardrail("input", "a"));
+    registry.register(createNoopGuardrail("output", "b"));
+
+    expect(registry.list("input").map((g) => g.name)).toEqual(["a"]);
+    expect(registry.list("output").map((g) => g.name)).toEqual(["b"]);
+    expect(registry.list("pre-tool")).toEqual([]);
+  });
+
+  test("duplicate registration at same stage throws", () => {
+    const registry = new GuardrailRegistry();
+    registry.register(createNoopGuardrail("input", "dup"));
+    expect(() =>
+      registry.register(createNoopGuardrail("input", "dup"))
+    ).toThrow(/already registered/);
+  });
+
+  test("same name at different stages is allowed", () => {
+    const registry = new GuardrailRegistry();
+    registry.register(createNoopGuardrail("input", "shared"));
+    registry.register(createNoopGuardrail("output", "shared"));
+    expect(registry.get("input", "shared")).toBeDefined();
+    expect(registry.get("output", "shared")).toBeDefined();
+  });
+
+  test("resolve silently skips unknown names", () => {
+    const registry = new GuardrailRegistry();
+    registry.register(createNoopGuardrail("input", "known"));
+    const resolved = registry.resolve("input", ["known", "missing"]);
+    expect(resolved.map((g) => g.name)).toEqual(["known"]);
+  });
+});
+
+describe("runGuardrails", () => {
+  test("empty enabled list returns no-trip outcome without touching registry", async () => {
+    const registry = new GuardrailRegistry();
+    const outcome = await runGuardrails(registry, "input", [], ctx);
+    expect(outcome.tripped).toBeNull();
+    expect(outcome.ran).toEqual([]);
+  });
+
+  test("all pass → tripped is null, ran lists every guardrail", async () => {
+    const registry = new GuardrailRegistry();
+    registry.register(createNoopGuardrail("input", "a"));
+    registry.register(createNoopGuardrail("input", "b"));
+
+    const outcome = await runGuardrails(registry, "input", ["a", "b"], ctx);
+    expect(outcome.tripped).toBeNull();
+    expect(outcome.ran.sort()).toEqual(["a", "b"]);
+  });
+
+  test("first trip short-circuits; other guardrails are cancelled", async () => {
+    const slow = deferred<never>();
+    const registry = new GuardrailRegistry();
+    const tripper: Guardrail<"input"> = {
+      name: "tripper",
+      stage: "input",
+      async run() {
+        return { tripped: true, reason: "caught" };
+      },
+    };
+    const slowGuard: Guardrail<"input"> = {
+      name: "slow",
+      stage: "input",
+      async run() {
+        await slow.promise;
+        return { tripped: false };
+      },
+    };
+    registry.register(tripper);
+    registry.register(slowGuard);
+
+    const outcome = await runGuardrails(
+      registry,
+      "input",
+      ["tripper", "slow"],
+      ctx
+    );
+    expect(outcome.tripped).toEqual({
+      guardrail: "tripper",
+      reason: "caught",
+      metadata: undefined,
+    });
+    // `ran` should only contain tripper — slow is still blocked on `slow.promise`
+    expect(outcome.ran).toEqual(["tripper"]);
+
+    // clean up the hanging promise so the test process doesn't keep a handle
+    slow.resolve(undefined as never);
+  });
+
+  test("only the first trip is surfaced even when multiple trip", async () => {
+    const registry = new GuardrailRegistry();
+    const firstGate = deferred<void>();
+    const secondGate = deferred<void>();
+    const first: Guardrail<"input"> = {
+      name: "first",
+      stage: "input",
+      async run() {
+        await firstGate.promise;
+        return { tripped: true, reason: "first" };
+      },
+    };
+    const second: Guardrail<"input"> = {
+      name: "second",
+      stage: "input",
+      async run() {
+        await secondGate.promise;
+        return { tripped: true, reason: "second" };
+      },
+    };
+    registry.register(first);
+    registry.register(second);
+
+    const outcomeP = runGuardrails(
+      registry,
+      "input",
+      ["first", "second"],
+      ctx
+    );
+    firstGate.resolve();
+    const outcome = await outcomeP;
+    expect(outcome.tripped?.guardrail).toBe("first");
+    secondGate.resolve();
+  });
+
+  test("thrown guardrail is treated as a pass and logged", async () => {
+    const registry = new GuardrailRegistry();
+    const thrower: Guardrail<"input"> = {
+      name: "thrower",
+      stage: "input",
+      async run() {
+        throw new Error("boom");
+      },
+    };
+    registry.register(thrower);
+    registry.register(createNoopGuardrail("input", "ok"));
+
+    const outcome = await runGuardrails(
+      registry,
+      "input",
+      ["thrower", "ok"],
+      ctx
+    );
+    expect(outcome.tripped).toBeNull();
+    // thrower never contributed to `ran`; only ok did
+    expect(outcome.ran).toEqual(["ok"]);
+  });
+
+  test("metadata is surfaced from the tripping guardrail", async () => {
+    const registry = new GuardrailRegistry();
+    const detector: Guardrail<"input"> = {
+      name: "detector",
+      stage: "input",
+      async run() {
+        return {
+          tripped: true,
+          reason: "matched",
+          metadata: { pattern: "secret-xyz" },
+        };
+      },
+    };
+    registry.register(detector);
+
+    const outcome = await runGuardrails(registry, "input", ["detector"], ctx);
+    expect(outcome.tripped?.metadata).toEqual({ pattern: "secret-xyz" });
+  });
+
+  test("unknown names in enabled list are skipped, known ones still run", async () => {
+    const registry = new GuardrailRegistry();
+    registry.register(createNoopGuardrail("input", "exists"));
+
+    const outcome = await runGuardrails(
+      registry,
+      "input",
+      ["exists", "missing"],
+      ctx
+    );
+    expect(outcome.tripped).toBeNull();
+    expect(outcome.ran).toEqual(["exists"]);
+  });
+});
+
+describe("createNoopGuardrail", () => {
+  test("returns pass regardless of stage and name", async () => {
+    const g = createNoopGuardrail("pre-tool", "my-noop");
+    expect(g.name).toBe("my-noop");
+    expect(g.stage).toBe("pre-tool");
+    const result = await g.run({
+      agentId: "a",
+      userId: "u",
+      toolName: "t",
+      arguments: {},
+    });
+    expect(result).toEqual({ tripped: false });
+  });
+});

--- a/packages/core/src/agent-store.ts
+++ b/packages/core/src/agent-store.ts
@@ -51,6 +51,12 @@ export interface AgentSettings {
   skillsConfig?: SkillsConfig;
   /** Tool permission configuration — allowed/denied tools (worker-side visibility). */
   toolsConfig?: ToolsConfig;
+  /**
+   * Guardrails enabled for this agent, by registered name. The gateway
+   * resolves these against its GuardrailRegistry at each stage (input,
+   * output, pre-tool) and halts the run on the first trip.
+   */
+  guardrails?: string[];
   /** OpenClaw plugin configuration */
   pluginsConfig?: PluginsConfig;
   /**

--- a/packages/core/src/guardrails/builtins/noop.ts
+++ b/packages/core/src/guardrails/builtins/noop.ts
@@ -1,0 +1,18 @@
+import type { Guardrail, GuardrailStage } from "../types";
+
+/**
+ * No-op guardrail — always passes. Used as a default in tests and as a
+ * template for new guardrail implementations.
+ */
+export function createNoopGuardrail<S extends GuardrailStage>(
+  stage: S,
+  name = `noop-${stage}`
+): Guardrail<S> {
+  return {
+    name,
+    stage,
+    async run() {
+      return { tripped: false };
+    },
+  };
+}

--- a/packages/core/src/guardrails/index.ts
+++ b/packages/core/src/guardrails/index.ts
@@ -1,0 +1,13 @@
+export { createNoopGuardrail } from "./builtins/noop";
+export { GuardrailRegistry } from "./registry";
+export { runGuardrails } from "./runner";
+export type {
+  Guardrail,
+  GuardrailContext,
+  GuardrailResult,
+  GuardrailRunOutcome,
+  GuardrailStage,
+  InputGuardrailContext,
+  OutputGuardrailContext,
+  PreToolGuardrailContext,
+} from "./types";

--- a/packages/core/src/guardrails/registry.ts
+++ b/packages/core/src/guardrails/registry.ts
@@ -1,0 +1,63 @@
+import { createLogger } from "../logger";
+import type { Guardrail, GuardrailStage } from "./types";
+
+const logger = createLogger("guardrail-registry");
+
+/**
+ * Registry of guardrails keyed by `stage + name`. Callers register guardrails
+ * at startup (builtins + plugin-provided); the runner filters by stage and
+ * by a per-agent enable list.
+ */
+export class GuardrailRegistry {
+  private byStage = new Map<GuardrailStage, Map<string, Guardrail>>();
+
+  register<S extends GuardrailStage>(guardrail: Guardrail<S>): void {
+    let stageMap = this.byStage.get(guardrail.stage);
+    if (!stageMap) {
+      stageMap = new Map();
+      this.byStage.set(guardrail.stage, stageMap);
+    }
+    if (stageMap.has(guardrail.name)) {
+      throw new Error(
+        `Guardrail "${guardrail.name}" already registered for stage "${guardrail.stage}"`
+      );
+    }
+    stageMap.set(guardrail.name, guardrail as Guardrail);
+    logger.debug(
+      { name: guardrail.name, stage: guardrail.stage },
+      "Guardrail registered"
+    );
+  }
+
+  get(stage: GuardrailStage, name: string): Guardrail | undefined {
+    return this.byStage.get(stage)?.get(name);
+  }
+
+  list(stage: GuardrailStage): Guardrail[] {
+    const stageMap = this.byStage.get(stage);
+    return stageMap ? Array.from(stageMap.values()) : [];
+  }
+
+  /**
+   * Resolve the guardrails to run for a given stage and an agent's enable
+   * list. Unknown names are logged and skipped — a missing guardrail should
+   * never silently block a message, but operators need to see the drift.
+   */
+  resolve(stage: GuardrailStage, enabled: readonly string[]): Guardrail[] {
+    const stageMap = this.byStage.get(stage);
+    if (!stageMap) return [];
+    const out: Guardrail[] = [];
+    for (const name of enabled) {
+      const g = stageMap.get(name);
+      if (g) {
+        out.push(g);
+      } else {
+        logger.warn(
+          { name, stage },
+          "Enabled guardrail not found in registry; skipping"
+        );
+      }
+    }
+    return out;
+  }
+}

--- a/packages/core/src/guardrails/runner.ts
+++ b/packages/core/src/guardrails/runner.ts
@@ -16,8 +16,11 @@ const logger = createLogger("guardrail-runner");
  * pass — guardrails must fail closed on their own if they want halt-on-error
  * semantics.
  *
- * The returned outcome includes `ran`, the list of guardrails whose run
- * actually resolved before the race ended; useful for audit logs.
+ * The returned outcome includes `ran`, a snapshot of which guardrails had
+ * produced a result at the moment the race ended (on first trip, or when all
+ * settled). Guardrails still running after short-circuit are intentionally
+ * not reflected — they complete in the background and their output is
+ * discarded.
  */
 export async function runGuardrails<S extends GuardrailStage>(
   registry: GuardrailRegistry,
@@ -44,7 +47,9 @@ export async function runGuardrails<S extends GuardrailStage>(
     const finish = () => {
       if (settled) return;
       settled = true;
-      resolve({ tripped, ran });
+      // Snapshot `ran` — background guardrails keep pushing to the live array
+      // after short-circuit, and consumers shouldn't see those late appends.
+      resolve({ tripped, ran: [...ran] });
     };
 
     for (const g of guardrails) {

--- a/packages/core/src/guardrails/runner.ts
+++ b/packages/core/src/guardrails/runner.ts
@@ -1,0 +1,86 @@
+import { createLogger } from "../logger";
+import type { GuardrailRegistry } from "./registry";
+import type {
+  Guardrail,
+  GuardrailContext,
+  GuardrailRunOutcome,
+  GuardrailStage,
+} from "./types";
+
+const logger = createLogger("guardrail-runner");
+
+/**
+ * Run all enabled guardrails for `stage` in parallel. Resolves with the first
+ * trip (others keep running but their results are discarded), or `{tripped: null}`
+ * if every guardrail passes. A thrown guardrail is logged and treated as a
+ * pass — guardrails must fail closed on their own if they want halt-on-error
+ * semantics.
+ *
+ * The returned outcome includes `ran`, the list of guardrails whose run
+ * actually resolved before the race ended; useful for audit logs.
+ */
+export async function runGuardrails<S extends GuardrailStage>(
+  registry: GuardrailRegistry,
+  stage: S,
+  enabled: readonly string[],
+  ctx: GuardrailContext[S]
+): Promise<GuardrailRunOutcome> {
+  if (enabled.length === 0) {
+    return { tripped: null, ran: [] };
+  }
+
+  const guardrails = registry.resolve(stage, enabled) as Guardrail<S>[];
+  if (guardrails.length === 0) {
+    return { tripped: null, ran: [] };
+  }
+
+  const ran: string[] = [];
+  let tripped: GuardrailRunOutcome["tripped"] = null;
+
+  return await new Promise<GuardrailRunOutcome>((resolve) => {
+    let settled = false;
+    let remaining = guardrails.length;
+
+    const finish = () => {
+      if (settled) return;
+      settled = true;
+      resolve({ tripped, ran });
+    };
+
+    for (const g of guardrails) {
+      Promise.resolve()
+        .then(() => g.run(ctx))
+        .then((result) => {
+          ran.push(g.name);
+          if (!tripped && result.tripped) {
+            tripped = {
+              guardrail: g.name,
+              reason: result.reason,
+              metadata: result.metadata,
+            };
+            logger.info(
+              { guardrail: g.name, stage, reason: result.reason },
+              "Guardrail tripped"
+            );
+            // Short-circuit: resolve immediately on first trip. Other
+            // guardrails continue running but their outcome is discarded.
+            finish();
+          }
+        })
+        .catch((err) => {
+          logger.error(
+            {
+              guardrail: g.name,
+              stage,
+              error: err instanceof Error ? err.message : String(err),
+            },
+            "Guardrail threw; treating as pass"
+          );
+        })
+        .finally(() => {
+          remaining -= 1;
+          if (remaining === 0) finish();
+        });
+    }
+  });
+}

--- a/packages/core/src/guardrails/types.ts
+++ b/packages/core/src/guardrails/types.ts
@@ -1,0 +1,90 @@
+/**
+ * Guardrail primitive — composable input/output/pre-tool checks that can halt
+ * a run before it produces user-visible output or side effects. Modeled on
+ * OpenAI Agents SDK's input_guardrails / output_guardrails pattern.
+ *
+ * A guardrail returns `{ tripped: true, reason, metadata }` to halt; the
+ * runner cancels the remaining guardrails at the same stage on first trip.
+ *
+ * Guardrails are stage-scoped:
+ *   - `input`    — user message before dispatch to worker
+ *   - `output`   — worker-produced text/attachments before user rendering
+ *   - `pre-tool` — tool call authorization (agent → gateway MCP proxy)
+ *
+ * Register guardrails in a {@link GuardrailRegistry} and enable them per-agent
+ * via `[agents.<id>] guardrails = ["name-a", "name-b"]` in `lobu.toml`.
+ */
+
+export type GuardrailStage = "input" | "output" | "pre-tool";
+
+/**
+ * Context shape passed to each stage. Each stage has a distinct payload so
+ * guardrails can be typed against what they'll actually inspect. Additional
+ * fields can be added over time — guardrails should read only what they need.
+ */
+export interface InputGuardrailContext {
+  agentId: string;
+  userId: string;
+  message: string;
+  platform: string;
+  conversationId?: string;
+}
+
+export interface OutputGuardrailContext {
+  agentId: string;
+  userId: string;
+  /** Full response text or streamed delta being inspected. */
+  text: string;
+  platform: string;
+  conversationId?: string;
+}
+
+export interface PreToolGuardrailContext {
+  agentId: string;
+  userId: string;
+  toolName: string;
+  /** Raw JSON-RPC params the worker is about to invoke the tool with. */
+  arguments: unknown;
+  conversationId?: string;
+}
+
+export type GuardrailContext = {
+  input: InputGuardrailContext;
+  output: OutputGuardrailContext;
+  "pre-tool": PreToolGuardrailContext;
+};
+
+/**
+ * Result of a single guardrail invocation. `tripped: true` halts the run at
+ * this stage; `reason` surfaces in logs/user messages, `metadata` is
+ * opaque structured data for downstream handlers (e.g. which pattern matched).
+ */
+export interface GuardrailResult {
+  tripped: boolean;
+  reason?: string;
+  metadata?: unknown;
+}
+
+/**
+ * A single guardrail. The `name` must be unique within a stage — the registry
+ * uses it as the lookup key when agents enable guardrails by name in config.
+ */
+export interface Guardrail<S extends GuardrailStage = GuardrailStage> {
+  name: string;
+  stage: S;
+  run(ctx: GuardrailContext[S]): Promise<GuardrailResult>;
+}
+
+/**
+ * Outcome of running all enabled guardrails at a stage. `tripped` is the
+ * first guardrail that halted (others were cancelled); `ran` lists every
+ * guardrail that actually produced a result (useful for audit logs).
+ */
+export interface GuardrailRunOutcome {
+  tripped: {
+    guardrail: string;
+    reason?: string;
+    metadata?: unknown;
+  } | null;
+  ran: string[];
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -40,6 +40,8 @@ export type { CommandContext, CommandDefinition } from "./command-registry";
 // Command registry
 export { CommandRegistry } from "./command-registry";
 export * from "./constants";
+// Guardrail primitive (type + registry + parallel runner + no-op builtin)
+export * from "./guardrails";
 // Errors & logging
 export * from "./errors";
 // Integration types

--- a/packages/core/src/lobu-toml-schema.ts
+++ b/packages/core/src/lobu-toml-schema.ts
@@ -183,6 +183,11 @@ const agentEntrySchema = z.object({
   skills: skillsSchema.default({}),
   network: networkSchema.optional(),
   tools: toolsSchema.optional(),
+  /**
+   * Guardrails enabled for this agent. Each name must match a guardrail
+   * registered in the gateway's GuardrailRegistry. See packages/core/src/guardrails.
+   */
+  guardrails: z.array(z.string()).optional(),
   worker: workerSchema.optional(),
   /**
    * Default delivery target for scheduled fires that omit `deliver_to`.

--- a/packages/gateway/src/auth/mcp/proxy.ts
+++ b/packages/gateway/src/auth/mcp/proxy.ts
@@ -1065,6 +1065,12 @@ export class McpProxy {
           if (jsonRpc.method === "tools/call" && jsonRpc.params?.name) {
             const toolName = jsonRpc.params.name;
             const toolArgs = jsonRpc.params.arguments || {};
+            // TODO(#254): pre-tool-stage guardrail hook. Before the existing
+            // approval check below, call runGuardrails("pre-tool", registry,
+            // settings.guardrails, { toolName, arguments: toolArgs, agentId, ...}).
+            // On trip: reuse the onToolBlocked path to return a JSON-RPC error
+            // with trip.reason. Wiring deferred to the PR that registers the
+            // first real pre-tool guardrail.
             const { found, annotations } = await this.getToolAnnotations(
               mcpId!,
               toolName,

--- a/packages/gateway/src/config/file-loader.ts
+++ b/packages/gateway/src/config/file-loader.ts
@@ -354,6 +354,12 @@ async function buildAgentConfig(
   // pre-approvals that bypass the in-thread approval gate).
   applyAgentToolsConfig(settings, agentConfig.tools);
 
+  // Agent-level guardrail enable list. Names resolve against the gateway's
+  // GuardrailRegistry at runtime — see packages/core/src/guardrails.
+  if (agentConfig.guardrails?.length) {
+    settings.guardrails = [...new Set(agentConfig.guardrails)];
+  }
+
   // Apply merged MCP servers
   if (Object.keys(mcpServers).length > 0) {
     settings.mcpServers = mcpServers;

--- a/packages/gateway/src/connections/chat-response-bridge.ts
+++ b/packages/gateway/src/connections/chat-response-bridge.ts
@@ -74,6 +74,11 @@ export class ChatResponseBridge implements ResponseRenderer {
 
   constructor(private manager: ChatInstanceManager) {}
 
+  // TODO(#254): output-stage guardrail hook. Before emitting a delta to the
+  // platform strategy, call runGuardrails("output", registry, settings.guardrails,
+  // { text: payload.delta, ... }). On trip: redact or replace the delta per
+  // guardrail policy. Wiring deferred to the PR that registers the first
+  // real output guardrail (#253 secret/PII scan).
   private extractResponseContext(
     payload: ThreadResponsePayload
   ): ResponseContext | null {

--- a/packages/gateway/src/orchestration/message-consumer.ts
+++ b/packages/gateway/src/orchestration/message-consumer.ts
@@ -171,6 +171,12 @@ export class MessageConsumer {
         `Conversation routing - effectiveConversationId: ${effectiveConversationId}, canonicalKey: ${canonicalConversationKey}, deploymentName: ${deploymentName}`
       );
 
+      // TODO(#254): input-stage guardrail hook. When a GuardrailRegistry is
+      // injected here, call runGuardrails("input", registry, settings.guardrails, ctx)
+      // before sendToWorkerQueue. On trip: skip dispatch, surface trip.reason
+      // to the user via the response bridge. Lookup of settings.guardrails
+      // requires threading an AgentConfigStore into MessageConsumer; deferred
+      // to the PR that registers the first real input guardrail (#251).
       // 1) Send to thread queue immediately (Redis persists; worker will drain on attach)
       await Sentry.startSpan(
         {


### PR DESCRIPTION
Closes #254 (primitive-only scope).

## Summary

Introduces the composable guardrail primitive so future guardrails (prompt-injection classifier #251, output secret/PII scanner #253) share plumbing instead of bolting on ad-hoc.

- `Guardrail<stage>` type with stages `input` / `output` / `pre-tool`, each with its own typed context payload.
- `GuardrailRegistry` in `packages/core/src/guardrails/` — register by `(stage, name)`, resolve against a per-agent enable list, warn-and-skip on unknown names.
- `runGuardrails()` races all enabled guardrails at a stage in parallel; first trip short-circuits (others keep running but their results are discarded). A thrown guardrail is logged and treated as a pass — guardrails fail closed on their own if they want halt-on-error semantics.
- `createNoopGuardrail()` built-in for tests and as a template.
- `[agents.<id>] guardrails = [...]` field added to `lobu.toml` schema and `AgentSettings.guardrails`; the file-loader copies it through.
- `TODO(#254)` markers at the three gateway call sites (`message-consumer.ts` input, `chat-response-bridge.ts` output, `auth/mcp/proxy.ts` pre-tool) so wire-up for #251/#253 is a one-line call to `runGuardrails(...)` without orchestration archaeology.
- AGENTS.md section under `#### Guardrails` documenting the shape and config.

## Test plan

- [x] `bun run typecheck` — clean
- [x] `make build-packages` — clean
- [x] `bun run --cwd packages/core test` — 134 pass (13 new covering register/resolve/parallel/first-trip/throws-as-pass/metadata/unknown-name)
- [ ] Live wiring at the three stages — intentionally deferred to the PRs that register the first real guardrails (#251, #253). Primitive is validated via unit tests only.

https://claude.ai/code/session_01EtpFmmGNckbuxpNeWKywaq

---
_Generated by [Claude Code](https://claude.ai/code/session_01EtpFmmGNckbuxpNeWKywaq)_