### PR TITLE
feat(owletto-backend): accept entity_link_overrides at install/create/connect

### DIFF
--- a/packages/owletto-backend/src/__tests__/integration/entities/manage-connections-entity-link-overrides.test.ts
+++ b/packages/owletto-backend/src/__tests__/integration/entities/manage-connections-entity-link-overrides.test.ts
@@ -134,4 +134,49 @@ describe('manage_connections > set_connector_entity_link_overrides', () => {
 
     expect(result.error).toMatch(/not found/);
   });
+
+  it('accepts retargetEntityType pointing at an existing user-defined entity type', async () => {
+    const sql = getTestDb();
+    await sql`
+      INSERT INTO entity_types (organization_id, slug, name, metadata_schema, created_at, updated_at)
+      VALUES (${org.id}, 'contact', 'Contact', ${sql.json({})}, NOW(), NOW())
+      ON CONFLICT DO NOTHING
+    `;
+
+    const result = (await manageConnections(
+      {
+        action: 'set_connector_entity_link_overrides',
+        connector_key: 'whatsapp',
+        overrides: { $member: { retargetEntityType: 'contact' } },
+      },
+      env,
+      ctx
+    )) as { success?: boolean; overrides?: unknown; error?: string };
+
+    expect(result.error).toBeUndefined();
+    expect(result.success).toBe(true);
+
+    const rows = await sql<{ entity_link_overrides: Record<string, unknown> | null }[]>`
+      SELECT entity_link_overrides FROM connector_definitions
+      WHERE key = 'whatsapp' AND organization_id = ${org.id}
+    `;
+    expect(rows[0].entity_link_overrides).toEqual({
+      $member: { retargetEntityType: 'contact' },
+    });
+  });
+
+  it('rejects retargetEntityType pointing at an entity type that does not exist in the org', async () => {
+    const result = (await manageConnections(
+      {
+        action: 'set_connector_entity_link_overrides',
+        connector_key: 'whatsapp',
+        overrides: { $member: { retargetEntityType: 'nonexistent_type' } },
+      },
+      env,
+      ctx
+    )) as { error?: string };
+
+    expect(result.error).toMatch(/nonexistent_type/);
+    expect(result.error).toMatch(/does not exist/);
+  });
 });

--- a/packages/owletto-backend/src/tools/admin/manage_connections.ts
+++ b/packages/owletto-backend/src/tools/admin/manage_connections.ts
@@ -39,8 +39,7 @@ import {
 } from '../../utils/auth-profiles';
 import { createConnectToken } from '../../utils/connect-tokens';
 import { ensureConnectorInstalled } from '../../utils/ensure-connector-installed';
-import { clearEntityLinkRulesCache } from '../../utils/entity-link-upsert';
-import { validateEntityLinkOverrides } from '../../utils/entity-link-validation';
+import { applyEntityLinkOverrides } from '../../utils/entity-link-overrides';
 import { recordChangeEvent } from '../../utils/insert-event';
 import logger from '../../utils/logger';
 import { syncOAuthConnectionsForAuthProfile } from '../../utils/oauth-connection-state';
@@ -109,6 +108,25 @@ const ListConnectorDefinitionsAction = Type.Object({
   ),
 });
 
+const EntityLinkOverridesSchema = Type.Union(
+  [
+    Type.Null(),
+    Type.Record(
+      Type.String(),
+      Type.Object({
+        disable: Type.Optional(Type.Boolean()),
+        retargetEntityType: Type.Optional(Type.String()),
+        autoCreate: Type.Optional(Type.Boolean()),
+        maskIdentities: Type.Optional(Type.Array(Type.String())),
+      })
+    ),
+  ],
+  {
+    description:
+      "Per-entityType override of the connector's declared entityLinks rules (keyed by the rule's entityType). Applies at the connector-definition level for this org.",
+  }
+);
+
 const CreateAction = Type.Object({
   action: Type.Literal('create'),
   connector_key: Type.String({ description: 'Connector key (e.g. google.gmail)' }),
@@ -127,6 +145,7 @@ const CreateAction = Type.Object({
       description: 'Override the connection owner (admin/owner only). Defaults to current user.',
     })
   ),
+  entity_link_overrides: Type.Optional(EntityLinkOverridesSchema),
 });
 
 const UpdateAction = Type.Object({
@@ -183,6 +202,7 @@ const InstallConnectorAction = Type.Object({
         'Reusable auth values for env_keys and OAuth client keys. Stored as auth profiles.',
     })
   ),
+  entity_link_overrides: Type.Optional(EntityLinkOverridesSchema),
 });
 
 const UninstallConnectorAction = Type.Object({
@@ -205,6 +225,7 @@ const ConnectAction = Type.Object({
   config: Type.Optional(
     Type.Record(Type.String(), Type.Any(), { description: 'Connection config' })
   ),
+  entity_link_overrides: Type.Optional(EntityLinkOverridesSchema),
 });
 
 const ToggleConnectorLoginAction = Type.Object({
@@ -232,24 +253,7 @@ const UpdateConnectorDefaultConfigAction = Type.Object({
 const SetConnectorEntityLinkOverridesAction = Type.Object({
   action: Type.Literal('set_connector_entity_link_overrides'),
   connector_key: Type.String({ description: 'Connector key' }),
-  overrides: Type.Union(
-    [
-      Type.Null(),
-      Type.Record(
-        Type.String(),
-        Type.Object({
-          disable: Type.Optional(Type.Boolean()),
-          retargetEntityType: Type.Optional(Type.String()),
-          autoCreate: Type.Optional(Type.Boolean()),
-          maskIdentities: Type.Optional(Type.Array(Type.String())),
-        })
-      ),
-    ],
-    {
-      description:
-        "Per-entityType override of this connector's declared entityLinks. Use null to clear overrides and use connector defaults.",
-    }
-  ),
+  overrides: EntityLinkOverridesSchema,
 });
 
 export const ManageConnectionsSchema = Type.Union([
@@ -656,6 +660,15 @@ async function handleCreate(
     return { error: `Connector '${args.connector_key}' not found or not active` };
   }
 
+  if (args.entity_link_overrides !== undefined) {
+    const err = await applyEntityLinkOverrides(
+      organizationId,
+      args.connector_key,
+      args.entity_link_overrides
+    );
+    if (err) return { error: err };
+  }
+
   // No-auth connectors: one connection per user
   const authMethods =
     (connector.auth_schema as { methods?: Array<{ type: string }> })?.methods ?? [];
@@ -869,6 +882,15 @@ async function handleConnect(
       error: `Connector '${args.connector_key}' not found. Install it first from the connections page.`,
       setup_url: buildSetupUrl({ install: args.connector_key }),
     };
+  }
+
+  if (args.entity_link_overrides !== undefined) {
+    const err = await applyEntityLinkOverrides(
+      organizationId,
+      args.connector_key,
+      args.entity_link_overrides
+    );
+    if (err) return { error: err };
   }
 
   const setupUrl = buildSetupUrl({ connectorKey: args.connector_key });
@@ -1598,6 +1620,15 @@ async function handleInstallConnector(
 
     await maybeUpsertAuthAfterInstall(installed, args.auth_values, ctx);
 
+    if (args.entity_link_overrides !== undefined) {
+      const err = await applyEntityLinkOverrides(
+        ctx.organizationId,
+        installed.connectorKey,
+        args.entity_link_overrides
+      );
+      if (err) return { error: err };
+    }
+
     return {
       action: 'install_connector',
       installed: true,
@@ -1754,30 +1785,12 @@ async function handleSetConnectorEntityLinkOverrides(
   args: Extract<ConnectionsArgs, { action: 'set_connector_entity_link_overrides' }>,
   ctx: ToolContext
 ): Promise<ManageConnectionsResult> {
-  const sql = getDb();
-  const { organizationId } = ctx;
-
-  const errors = validateEntityLinkOverrides(args.overrides);
-  if (errors.length > 0) {
-    return { error: `Invalid overrides:\n  - ${errors.join('\n  - ')}` };
-  }
-
-  const updated = await sql`
-    UPDATE connector_definitions
-    SET entity_link_overrides = ${args.overrides ? sql.json(args.overrides) : null},
-        updated_at = NOW()
-    WHERE key = ${args.connector_key}
-      AND organization_id = ${organizationId}
-      AND status = 'active'
-    RETURNING key
-  `;
-
-  if (updated.length === 0) {
-    return { error: `Connector '${args.connector_key}' not found` };
-  }
-
-  // Invalidate cached resolved rules so the next ingestion batch sees the change.
-  clearEntityLinkRulesCache();
+  const err = await applyEntityLinkOverrides(
+    ctx.organizationId,
+    args.connector_key,
+    args.overrides
+  );
+  if (err) return { error: err };
 
   return {
     action: 'set_connector_entity_link_overrides',

--- a/packages/owletto-backend/src/utils/entity-link-overrides.ts
+++ b/packages/owletto-backend/src/utils/entity-link-overrides.ts
@@ -1,0 +1,50 @@
+import type { EntityLinkOverrides } from '@lobu/owletto-sdk';
+import { getDb } from '../db/client';
+import { clearEntityLinkRulesCache } from './entity-link-upsert';
+import {
+  validateEntityLinkOverrides,
+  verifyEntityLinkOverrideTargets,
+} from './entity-link-validation';
+
+/**
+ * Validate + verify + persist connector entity-link overrides for an org.
+ * Returns an error message on failure, null on success. Callers should short-
+ * circuit and return `{ error }` when this returns a string.
+ *
+ * The caller is responsible for ensuring the connector definition row exists
+ * before invoking this — used by install/create/connect (after install or
+ * ensure-install), by the standalone set_connector_entity_link_overrides
+ * admin action, and by the CLI install script.
+ */
+export async function applyEntityLinkOverrides(
+  organizationId: string,
+  connectorKey: string,
+  overrides: unknown
+): Promise<string | null> {
+  const structural = validateEntityLinkOverrides(overrides);
+  if (structural.length > 0) {
+    return `Invalid overrides:\n  - ${structural.join('\n  - ')}`;
+  }
+  const typed = (overrides ?? null) as EntityLinkOverrides | null;
+  const missing = await verifyEntityLinkOverrideTargets(typed, organizationId);
+  if (missing.length > 0) {
+    return missing.join('\n');
+  }
+
+  const sql = getDb();
+  const updated = await sql`
+    UPDATE connector_definitions
+    SET entity_link_overrides = ${typed ? sql.json(typed) : null},
+        updated_at = NOW()
+    WHERE key = ${connectorKey}
+      AND organization_id = ${organizationId}
+      AND status = 'active'
+    RETURNING key
+  `;
+  if (updated.length === 0) {
+    return `Connector '${connectorKey}' not found`;
+  }
+
+  clearEntityLinkRulesCache();
+  return null;
+}

--- a/packages/owletto-backend/src/utils/entity-link-validation.ts
+++ b/packages/owletto-backend/src/utils/entity-link-validation.ts
@@ -5,6 +5,7 @@
  * overrides (which arrive via MCP as untrusted JSON).
  */
 import type { EntityLinkOverrides, EntityLinkRule } from '@lobu/owletto-sdk';
+import { getDb } from '../db/client';
 
 export function validateEntityLinkOverrides(overrides: unknown): string[] {
   if (overrides === null || overrides === undefined) return [];
@@ -36,6 +37,39 @@ export function validateEntityLinkOverrides(overrides: unknown): string[] {
     }
   }
   return errors;
+}
+
+/**
+ * Verify that every `retargetEntityType` in the overrides points to an
+ * existing entity type in the given org. Returns an array of error messages
+ * (empty if all targets resolve). The caller is expected to have already
+ * passed the overrides through `validateEntityLinkOverrides` for structural
+ * checks.
+ */
+export async function verifyEntityLinkOverrideTargets(
+  overrides: EntityLinkOverrides | null | undefined,
+  organizationId: string
+): Promise<string[]> {
+  if (!overrides) return [];
+  const targets = new Set<string>();
+  for (const override of Object.values(overrides)) {
+    if (override?.retargetEntityType) targets.add(override.retargetEntityType);
+  }
+  if (targets.size === 0) return [];
+
+  const sql = getDb();
+  const rows = await sql`
+    SELECT slug FROM entity_types
+    WHERE organization_id = ${organizationId}
+      AND deleted_at IS NULL
+      AND slug = ANY(${Array.from(targets)})
+  `;
+  const found = new Set(rows.map((r) => r.slug as string));
+  const missing = Array.from(targets).filter((slug) => !found.has(slug));
+  return missing.map(
+    (slug) =>
+      `entity_link_overrides retargetEntityType '${slug}' does not exist in this organization. Create the entity type first.`
+  );
 }
 
 /**

--- a/scripts/owletto/install-connectors.ts
+++ b/scripts/owletto/install-connectors.ts
@@ -8,6 +8,7 @@
  *
  * Usage:
  *   pnpm tsx --env-file=.env scripts/install-connectors.ts --org buremba --file connectors/whatsapp.ts
+ *   pnpm tsx --env-file=.env scripts/install-connectors.ts --org buremba --file connectors/whatsapp.ts --target-entity-type contact
  */
 
 import { basename, resolve } from 'node:path';
@@ -16,11 +17,14 @@ import { getDb } from '../../packages/owletto-backend/src/db/client';
 import { compileConnectorFromFile } from '../../packages/owletto-backend/src/utils/connector-catalog';
 import { extractConnectorMetadata } from '../../packages/owletto-backend/src/utils/connector-compiler';
 import { upsertConnectorDefinitionRecords } from '../../packages/owletto-backend/src/utils/connector-definition-install';
+import { applyEntityLinkOverrides } from '../../packages/owletto-backend/src/utils/entity-link-overrides';
 
 const { values } = parseArgs({
   options: {
     org: { type: 'string' },
     file: { type: 'string', multiple: true },
+    'target-entity-type': { type: 'string' },
+    'entity-link-overrides': { type: 'string' },
     help: { type: 'boolean' },
   },
 });
@@ -33,10 +37,31 @@ Usage:
   pnpm tsx --env-file=.env scripts/install-connectors.ts --org <slug> --file <path>...
 
 Options:
-  --org     Organization slug (required)
-  --file    Path to connector .ts file (repeatable)
+  --org                      Organization slug (required)
+  --file                     Path to connector .ts file (repeatable)
+  --target-entity-type       Entity type slug to retarget the connector's $member
+                             entityLink rule to (e.g. "contact"). The type must
+                             already exist in the org.
+  --entity-link-overrides    Full JSON entity_link_overrides payload (advanced;
+                             overrides --target-entity-type when both are set).
 `);
   process.exit(values.help ? 0 : 1);
+}
+
+let parsedOverrides: Record<string, unknown> | null = null;
+if (values['entity-link-overrides']) {
+  try {
+    parsedOverrides = JSON.parse(values['entity-link-overrides']) as Record<string, unknown>;
+  } catch (err) {
+    console.error(
+      `Invalid --entity-link-overrides JSON: ${err instanceof Error ? err.message : String(err)}`
+    );
+    process.exit(1);
+  }
+} else if (values['target-entity-type']) {
+  parsedOverrides = {
+    $member: { retargetEntityType: values['target-entity-type'] },
+  };
 }
 
 const sql = getDb();
@@ -72,6 +97,12 @@ for (const file of values.file ?? []) {
         sourcePath: basename(absolutePath),
       },
     });
+
+    if (parsedOverrides !== null) {
+      const err = await applyEntityLinkOverrides(organizationId, metadata.key, parsedOverrides);
+      if (err) throw new Error(err);
+    }
+
     console.log(`✓ ${metadata.key} v${metadata.version} (${updated ? 'updated' : 'created'})`);
   } catch (err) {
     hadFailure = true;


### PR DESCRIPTION
## Summary

- Gmail and WhatsApp connectors hardcode `$member` as their entityLink auto-create target. Today the only way to retarget (e.g. to a user-defined `contact` type) is a second `set_connector_entity_link_overrides` admin call after install. This PR lets install/create/connect accept `entity_link_overrides` inline so the target can be picked in one step.
- Adds an existence check on `retargetEntityType` — retargets pointing at a slug the org hasn't created are rejected before any DB writes, with a clear message telling the caller to create the entity type first.
- CLI (`scripts/owletto/install-connectors.ts`) gains `--target-entity-type <slug>` for the common case (`$member → <slug>`) and `--entity-link-overrides <json>` for the full structure.
- Validate/verify/persist logic is extracted into `utils/entity-link-overrides.ts` so the MCP handler, the existing `set_connector_entity_link_overrides` action, and the CLI share a single code path.
- Web UI picker is **deferred** to a follow-up submodule PR (per the `packages/owletto-web` two-PR rule).

## Design notes

- No seeded `$contact` or new system entity types. Orgs create their own non-`$` target type through the normal entity-type admin flow; the override just points at it by slug. Keeps `$member` as the connector default, so personal-org behavior is unchanged — a team org just points the connectors at whatever bucket they've named.
- Override scope stays per-connector-definition (as today). One Gmail install per org = one target choice. If per-connection overrides are needed later, that's a separate schema change.
- `#309`'s email-redaction gate on `$member` is untouched — still acts as defense-in-depth for whatever ends up in `$member`.

## Test plan

- [x] `bun run typecheck` (repo-wide + `packages/owletto-backend` explicit)
- [x] `make build-packages`
- [x] Extended `manage-connections-entity-link-overrides.test.ts` with:
  - retarget to an existing user-defined entity type → persists, reads back
  - retarget to a nonexistent slug → clean error, no partial write
- [ ] Manual end-to-end once merged: create a `contact` entity type in an org, install Gmail/WhatsApp with `--target-entity-type contact`, run a sync, confirm senders land on `contact` rows (not `$member`).
- [ ] Follow-up submodule PR: `DynamicConnectorForm` picker populated from the org's entity types.