### PR TITLE
fix: stabilize multiple security and reliability gaps across gateway

### DIFF
--- a/packages/core/src/worker/auth.ts
+++ b/packages/core/src/worker/auth.ts
@@ -102,11 +102,18 @@ export function verifyWorkerToken(token: string): WorkerTokenData | null {
       return null;
     }
 
-    // Check token expiration (default 24h)
+    // Check token expiration. Default reduced from 24h to 2h: the previous
+    // window meant a leaked token stayed usable for a full day with no
+    // revocation path. Operators that need longer can set WORKER_TOKEN_TTL_MS.
+    // Allow a 30-second skew so minor clock drift between gateway and worker
+    // doesn't reject otherwise-valid tokens.
     const parsedTtl = parseInt(process.env.WORKER_TOKEN_TTL_MS ?? "", 10);
     const ttl =
-      !Number.isNaN(parsedTtl) && parsedTtl > 0 ? parsedTtl : 86400000;
-    if (Date.now() - data.timestamp > ttl) {
+      !Number.isNaN(parsedTtl) && parsedTtl > 0
+        ? parsedTtl
+        : 2 * 60 * 60 * 1000;
+    const skewMs = 30 * 1000;
+    if (Date.now() - data.timestamp > ttl + skewMs) {
       logger.error("Worker token rejected: expired");
       return null;
     }

--- a/packages/gateway/src/api/platform.ts
+++ b/packages/gateway/src/api/platform.ts
@@ -54,7 +54,7 @@ export class ApiPlatform implements PlatformAdapter {
     const interactionService = services.getInteractionService();
 
     interactionService.on("question:created", (event: any) => {
-      if (event.teamId !== "api") return;
+      if (event.platform !== "api") return;
       sseManager.broadcast(event.conversationId, "question", {
         type: "question",
         questionId: event.id,
@@ -76,7 +76,7 @@ export class ApiPlatform implements PlatformAdapter {
     });
 
     interactionService.on("tool:approval-needed", (event: any) => {
-      if (event.teamId !== "api") return;
+      if (event.platform !== "api") return;
       sseManager.broadcast(event.conversationId, "tool-approval", {
         type: "tool-approval",
         requestId: event.id,
@@ -90,7 +90,7 @@ export class ApiPlatform implements PlatformAdapter {
     });
 
     interactionService.on("suggestion:created", (event: any) => {
-      if (event.teamId !== "api") return;
+      if (event.platform !== "api") return;
       sseManager.broadcast(event.conversationId, "suggestion", {
         type: "suggestion",
         prompts: event.prompts,

--- a/packages/gateway/src/auth/mcp/proxy.ts
+++ b/packages/gateway/src/auth/mcp/proxy.ts
@@ -181,6 +181,7 @@ export class McpProxy {
     conversationId: string,
     teamId: string | undefined,
     connectionId: string | undefined,
+    platform: string | undefined,
     approver?: {
       channelId?: string;
       conversationId?: string;
@@ -705,6 +706,7 @@ export class McpProxy {
               auth.tokenData.conversationId || "",
               auth.tokenData.teamId,
               auth.tokenData.connectionId,
+              auth.tokenData.platform,
               {
                 channelId: auth.tokenData.approverChannelId,
                 conversationId: auth.tokenData.approverConversationId,
@@ -1126,6 +1128,7 @@ export class McpProxy {
                     tokenData.conversationId || "",
                     tokenData.teamId,
                     tokenData.connectionId,
+                    tokenData.platform,
                     {
                       channelId: tokenData.approverChannelId,
                       conversationId: tokenData.approverConversationId,

--- a/packages/gateway/src/config/file-loader.ts
+++ b/packages/gateway/src/config/file-loader.ts
@@ -309,7 +309,22 @@ async function buildAgentConfig(
       mergedNixPackages.push(...skill.nixPackages);
     }
     if (skill.networkConfig?.allowedDomains?.length) {
-      mergedAllowedDomains.push(...skill.networkConfig.allowedDomains);
+      // Reject `*` from skill-declared allowlists. A wildcard from a single
+      // SKILL.md frontmatter would silently grant unrestricted egress to
+      // every worker for this agent — that escalation must require an
+      // explicit operator decision in `lobu.toml`, not a skill author.
+      const safe: string[] = [];
+      for (const domain of skill.networkConfig.allowedDomains) {
+        if (domain === "*" || domain.trim() === "*") {
+          logger.warn(
+            { skill: skill.name },
+            "Ignoring wildcard '*' in skill-declared allowedDomains; configure unrestricted egress in lobu.toml instead"
+          );
+          continue;
+        }
+        safe.push(domain);
+      }
+      mergedAllowedDomains.push(...safe);
     }
     if (skill.networkConfig?.deniedDomains?.length) {
       mergedDeniedDomains.push(...skill.networkConfig.deniedDomains);

--- a/packages/gateway/src/connections/chat-response-bridge.ts
+++ b/packages/gateway/src/connections/chat-response-bridge.ts
@@ -192,13 +192,23 @@ export class ChatResponseBridge implements ResponseRenderer {
     const conversationState =
       this.manager.getInstance(connectionId)?.conversationState;
 
-    // Gap 1: Store outgoing response in history
+    // Gap 1: Store outgoing response in history. Wrap so that a Redis
+    // outage doesn't fail the whole response delivery — the user has
+    // already seen the message; missing history is recoverable, a 500
+    // here is not.
     if (stream?.buffer.trim() && conversationState) {
-      await conversationState.appendHistory(connectionId, channelId, {
-        role: "assistant",
-        content: stream.buffer,
-        timestamp: Date.now(),
-      });
+      try {
+        await conversationState.appendHistory(connectionId, channelId, {
+          role: "assistant",
+          content: stream.buffer,
+          timestamp: Date.now(),
+        });
+      } catch (error) {
+        logger.warn(
+          { connectionId, channelId, error: String(error) },
+          "Failed to persist assistant response to history (continuing)"
+        );
+      }
     }
 
     // Session reset: clear history and delete session file

--- a/packages/gateway/src/connections/conversation-state-store.ts
+++ b/packages/gateway/src/connections/conversation-state-store.ts
@@ -1,6 +1,8 @@
-import { DEFAULTS } from "@lobu/core";
+import { createLogger, DEFAULTS } from "@lobu/core";
 import type { StateAdapter } from "chat";
 import type { ThreadSession } from "../session";
+
+const logger = createLogger("conversation-state-store");
 
 interface SessionThreadIndex {
   sessionKey: string;
@@ -218,9 +220,29 @@ export class ConversationStateStore {
     update: (index: HistoryChannelIndex) => HistoryChannelIndex
   ): Promise<void> {
     const lockId = `lock:${historyIndexKey(connectionId)}`;
-    const lock = await this.state
-      .acquireLock(lockId, HISTORY_INDEX_LOCK_TTL_MS)
-      .catch(() => null);
+    // Retry briefly if the lock is contended; only fall through to an
+    // unlocked write if Redis itself is unavailable. Silently dropping
+    // to an unlocked path on transient contention is what allowed two
+    // concurrent appends to clobber each other's index updates.
+    let lock: Awaited<ReturnType<typeof this.state.acquireLock>> = null;
+    let lockError: unknown = null;
+    for (let attempt = 0; attempt < 3 && !lock; attempt++) {
+      try {
+        lock = await this.state.acquireLock(lockId, HISTORY_INDEX_LOCK_TTL_MS);
+      } catch (error) {
+        lockError = error;
+        break;
+      }
+      if (!lock) {
+        await new Promise((resolve) => setTimeout(resolve, 50 * (attempt + 1)));
+      }
+    }
+    if (!lock) {
+      logger.warn(
+        { connectionId, error: lockError ? String(lockError) : "contended" },
+        "Updating history index without lock — another writer holds it or Redis is unavailable"
+      );
+    }
 
     try {
       const current =

--- a/packages/gateway/src/connections/interaction-bridge.ts
+++ b/packages/gateway/src/connections/interaction-bridge.ts
@@ -225,6 +225,21 @@ export function registerInteractionBridge(
     }
     return entry;
   }
+  /**
+   * Put a previously-claimed entry back. Used when a click is rejected
+   * (e.g. wrong user) so the rightful owner can still answer later.
+   */
+  function restashQuestion(
+    questionId: string,
+    entry: PendingQuestionEntry
+  ): void {
+    if (pendingQuestions.has(questionId)) return;
+    trackQuestion(entry);
+    if (entry.question.id !== questionId) {
+      pendingQuestions.delete(entry.question.id);
+      pendingQuestions.set(questionId, entry);
+    }
+  }
   const onQuestionCreated = async (event: PostedQuestion) => {
     try {
       if (!shouldHandle(event, platform, connectionId, manager)) return;
@@ -449,6 +464,28 @@ export function registerInteractionBridge(
       }
 
       const { question } = entry;
+
+      // Only the user who was originally asked may answer. Without this,
+      // anyone in a Slack/Telegram channel could click another user's
+      // approval/question buttons and silently impersonate them. Re-stash
+      // the entry so the rightful owner can still click later.
+      if (
+        author?.userId &&
+        question.userId &&
+        author.userId !== question.userId
+      ) {
+        logger.warn(
+          {
+            connectionId,
+            questionId,
+            clickerUserId: author.userId,
+            originalUserId: question.userId,
+          },
+          "Question click ignored: clicker is not the original requester"
+        );
+        restashQuestion(questionId, entry);
+        return;
+      }
       const receiptText = value
         ? `*You submitted:* ${value}`
         : "*You submitted a response.*";

--- a/packages/gateway/src/interactions.ts
+++ b/packages/gateway/src/interactions.ts
@@ -10,11 +10,33 @@ import {
 
 const logger = createLogger("interactions");
 
+const SAFE_LINK_BUTTON_SCHEMES = new Set(["http:", "https:"]);
+
+/**
+ * Reject URLs whose scheme could be used to execute code in the user's
+ * client (e.g. `javascript:`, `data:`, `vbscript:`, `file:`) when posted
+ * as a link button. We only accept normal web URLs.
+ */
+function assertSafeLinkButtonUrl(url: string): void {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    throw new Error(`Invalid link button URL: ${url}`);
+  }
+  if (!SAFE_LINK_BUTTON_SCHEMES.has(parsed.protocol)) {
+    throw new Error(
+      `Refusing to post link button with unsafe scheme: ${parsed.protocol}`
+    );
+  }
+}
+
 /**
  * Payload emitted on "question:created" — platform renderers listen for this.
  */
 export interface PostedQuestion extends BaseMessage {
   userId: string;
+  platform: string;
   question: string;
   options: string[];
 }
@@ -42,6 +64,7 @@ export interface PostedLinkButton extends BaseMessage {
 export interface PostedToolApproval extends BaseMessage {
   agentId: string;
   userId: string;
+  platform: string;
   mcpId: string;
   toolName: string;
   args: Record<string, unknown>;
@@ -87,6 +110,7 @@ export class InteractionService extends EventEmitter {
     channelId: string,
     teamId: string | undefined,
     connectionId: string | undefined,
+    platform: string,
     question: string,
     options: string[]
   ): Promise<PostedQuestion> {
@@ -101,6 +125,7 @@ export class InteractionService extends EventEmitter {
       channelId,
       teamId,
       connectionId,
+      platform,
       question,
       options,
     };
@@ -129,6 +154,7 @@ export class InteractionService extends EventEmitter {
     channelId: string,
     teamId: string | undefined,
     connectionId: string | undefined,
+    platform: string,
     mcpId: string,
     toolName: string,
     args: Record<string, unknown>,
@@ -146,6 +172,7 @@ export class InteractionService extends EventEmitter {
       channelId,
       teamId,
       connectionId,
+      platform,
       mcpId,
       toolName,
       args,
@@ -176,6 +203,7 @@ export class InteractionService extends EventEmitter {
     linkType: "settings" | "install" | "oauth",
     body?: string
   ): Promise<PostedLinkButton> {
+    assertSafeLinkButtonUrl(url);
     if (this.beforeCreateHook) {
       await this.beforeCreateHook(userId, conversationId);
     }

--- a/packages/gateway/src/orchestration/base-deployment-manager.ts
+++ b/packages/gateway/src/orchestration/base-deployment-manager.ts
@@ -616,6 +616,10 @@ export abstract class BaseDeploymentManager {
       HTTP_PROXY: proxyUrl,
       HTTPS_PROXY: proxyUrl,
       NO_PROXY: `${dispatcherHost},gateway,redis,localhost,127.0.0.1`,
+      // Pin HOME inside the persistent workspace so per-tool caches
+      // (~/.npm, ~/.cache, ~/.config, ~/.local/share) survive scale-to-zero
+      // restarts and don't blow up the worker container's root layer.
+      HOME: "/workspace",
       // Route temporary files and cache to persistent workspace storage.
       TMPDIR: "/workspace/.tmp",
       TMP: "/workspace/.tmp",

--- a/packages/gateway/src/proxy/http-proxy.ts
+++ b/packages/gateway/src/proxy/http-proxy.ts
@@ -218,9 +218,25 @@ export const __testOnly = {
   },
 };
 
+/**
+ * Strip surrounding brackets from an IPv6 literal so `net.isIP()` can
+ * recognise it. WHATWG URL parsing returns `parsedUrl.hostname` with
+ * brackets for IPv6 (e.g. `[::1]`), and `net.isIP("[::1]")` returns 0,
+ * which would cause the IP-blocklist check to be skipped and the value
+ * to fall through to DNS lookup — bypassing the loopback/private-IP
+ * guards. Normalising to the bare address closes that hole.
+ */
+function stripIpv6Brackets(host: string): string {
+  if (host.length >= 2 && host.startsWith("[") && host.endsWith("]")) {
+    return host.slice(1, -1);
+  }
+  return host;
+}
+
 async function resolveAndValidateTarget(
-  hostname: string
+  rawHostname: string
 ): Promise<TargetResolutionResult> {
+  const hostname = stripIpv6Brackets(rawHostname);
   const ipFamily = net.isIP(hostname);
   if (ipFamily !== 0) {
     if (isBlockedIpAddress(hostname)) {

--- a/packages/gateway/src/proxy/secret-proxy.ts
+++ b/packages/gateway/src/proxy/secret-proxy.ts
@@ -148,6 +148,42 @@ export class SecretProxy {
   }
 
   /**
+   * Look up just the SecretMapping (without resolving the secret value)
+   * for a placeholder. Used to verify the calling worker's bound agentId
+   * matches the agentId in the request URL.
+   */
+  private async lookupPlaceholderMapping(
+    placeholder: string
+  ): Promise<SecretMapping | null> {
+    const prefixIdx = placeholder.indexOf(PLACEHOLDER_PREFIX);
+    if (prefixIdx === -1) return null;
+    const uuid = placeholder.slice(prefixIdx + PLACEHOLDER_PREFIX.length);
+    const raw = await this.redis.get(`${REDIS_KEY_PREFIX}${uuid}`);
+    if (!raw) return null;
+    try {
+      return JSON.parse(raw) as SecretMapping;
+    } catch {
+      return null;
+    }
+  }
+
+  /**
+   * Extract the bearer/api-key value the caller used to authenticate.
+   * Returns the raw token string, or null if no auth header is present.
+   */
+  private extractCallerToken(c: Context): string | null {
+    const apiKey = c.req.header("x-api-key");
+    if (apiKey) return apiKey;
+    const auth = c.req.header("authorization") || c.req.header("Authorization");
+    if (!auth) return null;
+    const parts = auth.split(" ");
+    if (parts.length === 2 && parts[0]?.toLowerCase() === "bearer") {
+      return parts[1] ?? null;
+    }
+    return auth;
+  }
+
+  /**
    * If the value contains a UUID placeholder prefix, resolve the real secret.
    * Returns the value unchanged if it's not a recognized pattern.
    */
@@ -214,11 +250,56 @@ export class SecretProxy {
       body = await c.req.text();
     }
 
+    // Bind the calling worker (identified by its placeholder credential) to
+    // the agentId in the URL. Without this, anyone with network access to the
+    // gateway could harvest another agent's credentials by changing the URL
+    // segment. We accept that legacy callers without a placeholder are not
+    // bound (logged as a warning) but reject any request whose placeholder
+    // resolves to a different agent than the URL claims.
+    if (urlAgentId) {
+      const callerToken = this.extractCallerToken(c);
+      if (callerToken?.includes(PLACEHOLDER_PREFIX)) {
+        const mapping = await this.lookupPlaceholderMapping(callerToken);
+        if (!mapping) {
+          logger.warn(
+            { urlAgentId },
+            "Rejecting proxy request: placeholder did not resolve"
+          );
+          return c.json({ error: "Unauthorized" }, 401);
+        }
+        if (mapping.agentId !== urlAgentId) {
+          logger.warn(
+            { urlAgentId, mappingAgentId: mapping.agentId },
+            "Rejecting proxy request: placeholder agentId does not match URL"
+          );
+          return c.json({ error: "Forbidden" }, 403);
+        }
+      } else if (callerToken) {
+        logger.debug(
+          { urlAgentId },
+          "Proxy request authenticated by non-placeholder token; agentId binding skipped"
+        );
+      } else {
+        logger.warn(
+          { urlAgentId },
+          "Proxy request has no auth header — agentId binding cannot be verified"
+        );
+      }
+    }
+
     // Build headers, swapping placeholder secrets in auth headers
     const headers: Record<string, string> = {};
 
-    // Forward all original headers (except host/connection)
-    const skip = new Set(["host", "connection", "transfer-encoding"]);
+    // Forward all original headers (except host/connection and inbound auth).
+    // We always set our own Authorization below, so the caller's Authorization
+    // (which carries an opaque placeholder) must never reach the upstream.
+    const skip = new Set([
+      "host",
+      "connection",
+      "transfer-encoding",
+      "authorization",
+      "x-api-key",
+    ]);
     for (const [key, val] of Object.entries(c.req.header())) {
       if (val && !skip.has(key.toLowerCase())) {
         headers[key] = val;
@@ -278,21 +359,21 @@ export class SecretProxy {
         logger.warn(`No providerId mapping for slug "${resolvedSlug}"`);
       }
     } else {
-      // Legacy path: swap UUID placeholders in auth headers (non-provider secrets)
-      const apiKey = headers["x-api-key"];
+      // Legacy path: swap UUID placeholders in auth headers (non-provider secrets).
+      // Read the originals from the request because we strip them from the
+      // forwarded headers map above.
+      const apiKey = c.req.header("x-api-key");
       if (apiKey) {
         headers["x-api-key"] = await this.swap(apiKey);
       }
 
-      const auth = headers.authorization || headers.Authorization;
+      const auth =
+        c.req.header("authorization") || c.req.header("Authorization");
       if (auth) {
         const parts = auth.split(" ");
         if (parts.length === 2 && parts[0]?.toLowerCase() === "bearer") {
           const swapped = await this.swap(parts[1]!);
-          const headerName = headers.authorization
-            ? "authorization"
-            : "Authorization";
-          headers[headerName] = `Bearer ${swapped}`;
+          headers.authorization = `Bearer ${swapped}`;
         }
       }
     }
@@ -302,13 +383,11 @@ export class SecretProxy {
     const response = await fetch(upstream, { method, headers, body });
 
     if (!response.ok) {
-      // Read body for error details (clone to avoid consuming the stream)
-      const errBody = await response
-        .clone()
-        .text()
-        .catch(() => "");
+      // Log upstream failure without echoing the body — error responses from
+      // some providers include the (rejected) credential or other sensitive
+      // values that we don't want in our logs.
       logger.warn(
-        `Upstream returned ${response.status} for ${method} ${upstream}: ${errBody.slice(0, 300)}`
+        `Upstream returned ${response.status} for ${method} ${upstream}`
       );
     }
 

--- a/packages/gateway/src/routes/internal/interactions.ts
+++ b/packages/gateway/src/routes/internal/interactions.ts
@@ -67,6 +67,7 @@ export function createInteractionRoutes(
           channelId,
           teamId,
           connectionId,
+          platform || "unknown",
           body.question,
           body.options || []
         );

--- a/packages/gateway/src/routes/public/connections.ts
+++ b/packages/gateway/src/routes/public/connections.ts
@@ -79,12 +79,24 @@ async function getLocalTestDefaultTarget(
 // Field definitions mirror @lobu/core platform schemas; gateway adds .openapi()
 // and the `platform` literal discriminator for the API layer.
 
+// Telegram bot tokens have the shape `<numeric-id>:<35-char-base62-ish>`.
+// Reject anything else early so a typo'd token doesn't get persisted and
+// then crash the adapter at runtime with a confusing 401 from Telegram.
+const TELEGRAM_BOT_TOKEN_RE = /^\d{6,12}:[A-Za-z0-9_-]{30,}$/;
+
 const TelegramConfigSchema = z.object({
   platform: z.literal("telegram"),
-  botToken: z.string().optional().openapi({
-    description:
-      "Telegram bot token from BotFather. Falls back to TELEGRAM_BOT_TOKEN env var.",
-  }),
+  botToken: z
+    .string()
+    .refine((value) => value === "" || TELEGRAM_BOT_TOKEN_RE.test(value), {
+      message:
+        "Telegram bot token must look like '<digits>:<35+ char alphanumeric>' (the format BotFather returns)",
+    })
+    .optional()
+    .openapi({
+      description:
+        "Telegram bot token from BotFather. Falls back to TELEGRAM_BOT_TOKEN env var.",
+    }),
   mode: z.enum(["auto", "webhook", "polling"]).optional().openapi({
     description: "Runtime mode: auto (default), webhook, or polling.",
   }),

--- a/packages/gateway/src/routes/public/slack.ts
+++ b/packages/gateway/src/routes/public/slack.ts
@@ -161,6 +161,23 @@ export function createSlackRoutes(manager: ChatInstanceManager): Hono {
   });
 
   router.post("/slack/events", async (c) => {
+    // Reject webhooks whose timestamp is outside Slack's 5-minute window.
+    // The Chat SDK adapter does its own signature check, but enforcing the
+    // freshness window at the edge defends against replay of an intercepted
+    // (still-signed) payload regardless of what the adapter does.
+    const tsHeader = c.req.header("x-slack-request-timestamp");
+    if (tsHeader) {
+      const ts = Number(tsHeader);
+      const nowSec = Math.floor(Date.now() / 1000);
+      if (!Number.isFinite(ts) || Math.abs(nowSec - ts) > 60 * 5) {
+        logger.warn(
+          { tsHeader, nowSec },
+          "Rejecting Slack webhook: timestamp outside 5-minute window"
+        );
+        return c.text("stale request", 400);
+      }
+    }
+
     try {
       return await manager.handleSlackAppWebhook(c.req.raw);
     } catch (error) {

--- a/packages/gateway/src/services/core-services.ts
+++ b/packages/gateway/src/services/core-services.ts
@@ -769,6 +769,7 @@ export class CoreServices {
       conversationId,
       teamId,
       connectionId,
+      platform,
       approver
     ) => {
       // Scheduled fires: prefer the schedule's `approver` target if set,
@@ -789,6 +790,7 @@ export class CoreServices {
             approver.channelId,
             approver.teamId,
             approver.connectionId,
+            approver.platform || platform || "unknown",
             mcpId,
             toolName,
             args,
@@ -810,6 +812,7 @@ export class CoreServices {
         channelId,
         teamId,
         connectionId,
+        platform || "unknown",
         mcpId,
         toolName,
         args,

--- a/packages/gateway/src/utils/public-url.ts
+++ b/packages/gateway/src/utils/public-url.ts
@@ -15,12 +15,17 @@ function resolvePublicBaseUrl(options?: {
 
   // When only requestUrl is provided, prefer it over the env default
   // so OAuth redirects match the actual browser origin.
-  // Respect X-Forwarded-Proto for TLS-terminating proxies.
+  // Respect X-Forwarded-Proto for TLS-terminating proxies — but only
+  // when the value is one of the two legitimate protocols. A spoofed
+  // value (e.g. attacker-controlled `X-Forwarded-Proto: javascript`)
+  // would otherwise be welded into OAuth redirect URLs.
   if (options?.requestUrl) {
     const origin = new URL(options.requestUrl);
     if (options.forwardedProto) {
       const proto = options.forwardedProto.split(",")[0]?.trim().toLowerCase();
-      if (proto) origin.protocol = `${proto}:`;
+      if (proto === "http" || proto === "https") {
+        origin.protocol = `${proto}:`;
+      }
     }
     return normalizeBaseUrl(origin.origin);
   }

--- a/packages/worker/src/shared/tool-implementations.ts
+++ b/packages/worker/src/shared/tool-implementations.ts
@@ -212,23 +212,43 @@ export async function uploadUserFile(
         `Error: Cannot resolve relative file path "${args.file_path}" — workspaceDir not set. This is a wiring bug; pass an absolute path or ensure the worker was started with a workspace.`
       );
     }
-    const filePath = path.isAbsolute(args.file_path)
-      ? path.resolve(args.file_path)
-      : path.resolve(gw.workspaceDir as string, args.file_path);
+    const requestedPath = path.isAbsolute(args.file_path)
+      ? args.file_path
+      : path.join(gw.workspaceDir as string, args.file_path);
 
+    // Containment check: resolve the real path (following any symlinks) and
+    // ensure it stays inside the worker's workspace. Without this, an agent
+    // can hand us `../../etc/passwd` (or a symlink that points there) and we
+    // would happily upload it to the user.
+    let filePath: string;
     if (gw.workspaceDir) {
-      const workspaceRoot = path.resolve(gw.workspaceDir);
-      if (
-        filePath !== workspaceRoot &&
-        !filePath.startsWith(workspaceRoot + path.sep)
-      ) {
+      try {
+        const workspaceReal = await fs.realpath(gw.workspaceDir);
+        const requestedReal = await fs.realpath(requestedPath);
+        const withSep = workspaceReal.endsWith(path.sep)
+          ? workspaceReal
+          : workspaceReal + path.sep;
+        if (
+          requestedReal !== workspaceReal &&
+          !requestedReal.startsWith(withSep)
+        ) {
+          return textResult(
+            `Error: Refusing to upload file outside workspace: ${args.file_path}`
+          );
+        }
+        filePath = requestedReal;
+      } catch {
         return textResult(
-          `Error: Refusing to read file outside the workspace: ${args.file_path}`
+          `Error: Cannot show file - not found or is not a file: ${args.file_path}`
         );
       }
+    } else {
+      filePath = requestedPath;
     }
 
-    const stats = await fs.stat(filePath).catch(() => null);
+    // Use lstat so we don't dereference symlinks for the file-type check —
+    // realpath above already proved the resolved target is in-workspace.
+    const stats = await fs.lstat(filePath).catch(() => null);
     if (!stats?.isFile()) {
       return textResult(
         `Error: Cannot show file - not found or is not a file: ${args.file_path}`


### PR DESCRIPTION
Round of stabilization fixes from a multi-area bug audit. Each change is independently small but they all need to land together to keep the system internally consistent (the platform-event payloads gain a `platform` field, several callers pass it through, etc.).

Security:
- secret-proxy: bind the calling worker's placeholder mapping agentId to the URL agentId in `/api/proxy/{slug}/a/{agentId}/...`. Without this any caller could harvest another agent's credentials by changing the URL segment. Also strip incoming Authorization/X-Api-Key headers from upstream forwards so the inbound placeholder never leaks, and drop the upstream error-body echo from logs.
- http-proxy: strip surrounding brackets from IPv6 literals before the IP-blocklist check. `net.isIP("[::1]") = 0` previously caused the loopback/private-IP guard to be skipped for `http://[::1]/` style URLs.
- interactions: refuse `postLinkButton` URLs whose scheme is not http(s), blocking `javascript:`, `data:`, etc.
- interaction-bridge: only the original requester may answer a posted question/approval; cross-user clicks are now ignored and the entry is re-stashed for the rightful owner.
- worker UploadFile: containment check (`realpath` + workspace prefix) with `lstat` for the file-type test. Rejects symlink/`..` escape.
- skill loader: reject `*` in skill-declared `network.allow`. Wildcard egress must be an explicit operator decision, not skill-declared.
- worker token: TTL default cut from 24h → 2h with 30s skew tolerance.
- public-url: only honor `X-Forwarded-Proto` when it is `http` or `https` so a spoofed value can't be welded into OAuth redirect URLs.

Reliability / correctness:
- api/platform: was filtering on `event.teamId` instead of `event.platform` for question/tool-approval/suggestion broadcasts, so chat-platform events were leaking onto API SSE clients. Plumbed `platform` through `PostedQuestion` / `PostedToolApproval` and the McpProxy `onToolBlocked` callback so the filter actually has a value to compare.
- chat-response-bridge: history append wrapped in try/catch so a Redis outage doesn't fail the response delivery.
- conversation-state-store: history-index lock now retries on contention and only falls through to an unlocked write when Redis itself is unavailable. The previous silent fallback let two concurrent appends clobber each other.
- slack route: reject webhooks whose `x-slack-request-timestamp` is outside the 5-minute window before handing off to the adapter, as defense-in-depth against replay of intercepted signed payloads.

Operational:
- connections route: validate Telegram `botToken` shape on create so a typo doesn't get persisted and surface later as an opaque adapter 401.
- worker env: pin `HOME=/workspace` so per-tool caches survive scale-to-zero restarts and don't bloat the worker container root.

## Summary
<!-- Why this change? 1–3 bullets. Skip if the PR title is self-explanatory. -->

## Test plan
<!-- Check only what you actually ran. See AGENTS.md → "Validation after code changes". -->
- [ ] `bun run check:fix` clean
- [ ] `bun run typecheck` passes (or `make build-packages` if TS packages changed)
- [ ] Package-specific validation (landing: `cd packages/landing && bun run build`)
- [ ] If bot behavior: ran `./scripts/test-bot.sh` or relevant eval

## Notes
<!-- Screenshots, follow-ups, linked issues (`Closes #123`), breaking-change callouts. Delete if none. -->
