### PR TITLE
chore(charts): default email from addresses to emre@lobu.ai

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -84,14 +84,14 @@ MEMORY_URL=https://owletto.com/mcp
 RESEND_API_KEY=
 
 # From addresses. Must use a domain verified in Resend with SPF/DKIM/DMARC set up.
-EMAIL_FROM_AUTH="Lobu <auth@lobu.ai>"
-EMAIL_FROM_INVITES="Lobu <invites@lobu.ai>"
+EMAIL_FROM_AUTH="Lobu <emre@lobu.ai>"
+EMAIL_FROM_INVITES="Lobu <emre@lobu.ai>"
 
 # Reply-To for transactional mail. Should be a monitored inbox.
-EMAIL_REPLY_TO=support@lobu.ai
+EMAIL_REPLY_TO=emre@lobu.ai
 
 # List-Unsubscribe value. Adds one-click unsubscribe headers (helps keep mail out of Promotions).
-EMAIL_UNSUBSCRIBE=mailto:unsubscribe@lobu.ai
+EMAIL_UNSUBSCRIBE=mailto:emre@lobu.ai
 
 # Socket Mode Health Monitoring
 SOCKET_HEALTH_CHECK_INTERVAL_MS=300000

--- a/charts/lobu/values.yaml
+++ b/charts/lobu/values.yaml
@@ -41,11 +41,12 @@ config:
 
 # Transactional email (Resend) - non-secret settings.
 # Set secrets.resendApiKey for delivery to actually work.
+# All addresses default to emre@lobu.ai while dedicated mailboxes are set up.
 email:
-  fromAuth: "Lobu <auth@lobu.ai>"       # From address for magic link / password reset
-  fromInvites: "Lobu <invites@lobu.ai>" # From address for org invitations
-  replyTo: "support@lobu.ai"            # Reply-To for all transactional mail
-  unsubscribe: "mailto:unsubscribe@lobu.ai" # List-Unsubscribe header value
+  fromAuth: "Lobu <emre@lobu.ai>"
+  fromInvites: "Lobu <emre@lobu.ai>"
+  replyTo: "emre@lobu.ai"
+  unsubscribe: "mailto:emre@lobu.ai"
 
 kubernetes:
   namespace: lobu


### PR DESCRIPTION
## Summary
- Points the chart's \`email.fromAuth\` / \`email.fromInvites\` / \`email.replyTo\` / \`email.unsubscribe\` defaults at \`emre@lobu.ai\` — a real mailbox on the Lobu Google Workspace — until dedicated \`auth@\` / \`invites@\` / \`support@\` / \`unsubscribe@\` aliases are provisioned.
- Syncs \`.env.example\` to match, so \`make setup\` produces a working \`.env\` out of the box.

Unblocks prod email delivery once v4.1.0+ is deployed: bounces, replies, and one-click unsubscribe signals all go to a monitored inbox instead of a non-existent alias.

## Test plan
- [ ] Chart template renders the new values (no runtime logic change).
- [ ] After v4.2.0 release + helm upgrade, confirm gateway pod env has \`EMAIL_FROM_AUTH=Lobu <emre@lobu.ai>\` etc.
- [ ] Trigger a magic-link sign-in, verify the \`From\` and \`Reply-To\` headers in the raw email source.