### PR TITLE
fix(owletto-backend): unblock image builds after dead-code refactor

### DIFF
--- a/packages/owletto-backend/src/email/templates/BrandedEmail.tsx
+++ b/packages/owletto-backend/src/email/templates/BrandedEmail.tsx
@@ -10,7 +10,7 @@ import {
   Section,
   Text,
 } from '@react-email/components';
-import type { ReactNode } from 'react';
+import type { CSSProperties, ReactNode } from 'react';
 
 export interface BrandedEmailProps {
   preview: string;
@@ -77,7 +77,7 @@ export function BrandedEmail({
   );
 }
 
-const body: React.CSSProperties = {
+const body: CSSProperties = {
   backgroundColor: '#f5f5f7',
   fontFamily:
     '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif',
@@ -85,17 +85,17 @@ const body: React.CSSProperties = {
   padding: '32px 0',
 };
 
-const container: React.CSSProperties = {
+const container: CSSProperties = {
   margin: '0 auto',
   maxWidth: 560,
   padding: '0 16px',
 };
 
-const header: React.CSSProperties = {
+const header: CSSProperties = {
   padding: '0 8px 16px',
 };
 
-const wordmark: React.CSSProperties = {
+const wordmark: CSSProperties = {
   color: '#0a0a0a',
   fontSize: 20,
   fontWeight: 700,
@@ -103,14 +103,14 @@ const wordmark: React.CSSProperties = {
   margin: 0,
 };
 
-const card: React.CSSProperties = {
+const card: CSSProperties = {
   backgroundColor: '#ffffff',
   border: '1px solid #e5e5e5',
   borderRadius: 12,
   padding: '32px 28px',
 };
 
-const h1: React.CSSProperties = {
+const h1: CSSProperties = {
   color: '#0a0a0a',
   fontSize: 22,
   fontWeight: 600,
@@ -119,25 +119,25 @@ const h1: React.CSSProperties = {
   margin: '0 0 16px',
 };
 
-const paragraph: React.CSSProperties = {
+const paragraph: CSSProperties = {
   color: '#333333',
   fontSize: 15,
   lineHeight: '1.6',
   margin: '0 0 20px',
 };
 
-const muted: React.CSSProperties = {
+const muted: CSSProperties = {
   color: '#6b7280',
   fontSize: 13,
   lineHeight: '1.5',
   margin: '16px 0 0',
 };
 
-const buttonWrapper: React.CSSProperties = {
+const buttonWrapper: CSSProperties = {
   margin: '24px 0',
 };
 
-const button: React.CSSProperties = {
+const button: CSSProperties = {
   backgroundColor: '#0a0a0a',
   borderRadius: 8,
   color: '#ffffff',
@@ -148,24 +148,24 @@ const button: React.CSSProperties = {
   textDecoration: 'none',
 };
 
-const hr: React.CSSProperties = {
+const hr: CSSProperties = {
   borderColor: '#e5e5e5',
   margin: '32px 0 16px',
 };
 
-const footer: React.CSSProperties = {
+const footer: CSSProperties = {
   color: '#6b7280',
   fontSize: 13,
   margin: '0 0 4px',
   padding: '0 8px',
 };
 
-const footerLink: React.CSSProperties = {
+const footerLink: CSSProperties = {
   color: '#6b7280',
   textDecoration: 'underline',
 };
 
-const footerSmall: React.CSSProperties = {
+const footerSmall: CSSProperties = {
   color: '#9ca3af',
   fontSize: 12,
   lineHeight: '1.5',

--- a/packages/owletto-backend/src/mcp-proxy/client.ts
+++ b/packages/owletto-backend/src/mcp-proxy/client.ts
@@ -6,7 +6,6 @@
  * Tool discovery cache is stored in-process with a short TTL.
  */
 
-import { getDb } from '../db/client';
 import { errorMessage } from '../utils/errors';
 import logger from '../utils/logger';
 import { TtlCache } from '../utils/ttl-cache';

--- a/packages/owletto-backend/src/scheduled/check-stalled-executions.ts
+++ b/packages/owletto-backend/src/scheduled/check-stalled-executions.ts
@@ -198,11 +198,7 @@ export async function checkStalledExecutions(_env: Env) {
         LIMIT 1000
       )
     `;
-    if (deleted.count > 0) {
-      logger.info(`[StalledRuns] Cleaned up ${deleted.count} old runs (> 30 days)`);
-    }
-  } catch (error) {
-    logger.error({ error }, '[StalledRuns] Error checking stalled runs');
-    throw error;
+  if (deleted.count > 0) {
+    logger.info(`[StalledRuns] Cleaned up ${deleted.count} old runs (> 30 days)`);
   }
 }

--- a/packages/owletto-backend/src/tools/admin/helpers/connection-helpers.ts
+++ b/packages/owletto-backend/src/tools/admin/helpers/connection-helpers.ts
@@ -308,24 +308,6 @@ export function getDefaultSchedule(env: Env): string {
   return env.DEFAULT_SYNC_SCHEDULE ?? DEFAULT_SCHEDULE;
 }
 
-function getDefaultFeedKey(feedsSchema: unknown): string {
-  if (typeof feedsSchema === 'string') {
-    try {
-      const parsed = JSON.parse(feedsSchema) as unknown;
-      return getDefaultFeedKey(parsed);
-    } catch {
-      return 'default';
-    }
-  }
-
-  if (!feedsSchema || typeof feedsSchema !== 'object' || Array.isArray(feedsSchema)) {
-    return 'default';
-  }
-
-  const keys = Object.keys(feedsSchema as Record<string, unknown>);
-  return keys.length > 0 ? keys[0] : 'default';
-}
-
 export function mapConnectionStatusToFeedStatus(status: string): 'active' | 'paused' {
   return status === 'active' ? 'active' : 'paused';
 }

--- a/packages/owletto-backend/src/types/watchers.ts
+++ b/packages/owletto-backend/src/types/watchers.ts
@@ -23,30 +23,6 @@ export interface WatcherSource {
 // Watcher Version
 // ============================================
 
-/**
- * A versioned snapshot of a watcher's analysis configuration.
- * Like connector_versions for connector_definitions.
- */
-interface WatcherVersion {
-  id: number;
-  watcher_id: number;
-  version: number;
-  name: string;
-  description?: string | null;
-  prompt: string;
-  extraction_schema: Record<string, unknown>;
-  sources: WatcherSource[];
-  json_template?: unknown;
-  keying_config?: KeyingConfig | null;
-  classifiers?: unknown[];
-  condensation_prompt?: string | null;
-  condensation_window_count?: number;
-  reactions_guidance?: string | null;
-  change_notes?: string | null;
-  created_by: string;
-  created_at: string;
-}
-
 // ============================================
 // Watcher Window
 // ============================================
@@ -120,7 +96,7 @@ export interface KeyingConfig {
 // Version Info (for listing available versions)
 // ============================================
 
-interface WatcherVersionInfo {
+export interface WatcherVersionInfo {
   version: number;
   name: string;
   created_at: string;

--- a/packages/owletto-backend/src/utils/reserved.ts
+++ b/packages/owletto-backend/src/utils/reserved.ts
@@ -47,12 +47,3 @@ export const RESERVED_ENTITY_TYPES = [
   'connector',
 ];
 
-const RESERVED_SEGMENTS = new Set<string>([...RESERVED_ENTITY_TYPES, ...RESERVED_PATHS]);
-
-/**
- * Check if a URL segment is reserved (i.e. it's a known route name or system path).
- * Used by resolve_path to distinguish reserved routes from entity types.
- */
-function isReservedSegment(segment: string): boolean {
-  return RESERVED_SEGMENTS.has(segment);
-}

--- a/packages/owletto-backend/tsconfig.json
+++ b/packages/owletto-backend/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "target": "ES2022",
     "lib": ["ES2022"],
-    "jsx": "react",
+    "jsx": "react-jsx",
 
     "module": "ESNext",
     "moduleResolution": "bundler",


### PR DESCRIPTION
## Summary
Docker image publishing has been failing since #314 (email rebrand) and #320 (dead-code removal). That means \`lobu-ai/owletto-app\` is still on \`20260423-121201\` — app.lobu.ai hasn't picked up any commit from today.

### What broke
- #320's refactor removed the outer \`try { ... }\` in \`check-stalled-executions.ts\` but left the \`} catch (error) { ... }\` closing block behind → \`TS1005: 'try' expected\`.
- Same refactor left five exports / locals unreferenced (\`getDb\`, \`getDefaultFeedKey\`, \`isReservedSegment\`, \`RESERVED_SEGMENTS\`, \`WatcherVersion\`) → \`TS6133\` / \`TS6196\`. Package-level \`bunx tsc --noEmit\` has \`noUnusedLocals: true\`, workspace-level doesn't, which is why \`bun run typecheck\` at the root was passing while the Dockerfile's per-package tsc was not.
- \`WatcherVersionInfo\` in \`types/watchers.ts\` was \`interface\` without \`export\`, but \`get_watchers.ts\` imports it.
- #314's email templates used \`React.CSSProperties\` as a UMD global and \`@types/react\` isn't in the package tsconfig's \`types\` array — Docker had no way to resolve it.

### Fix
- Drop the dangling \`catch\` block — matches the "let it throw" intent.
- Delete the five unreferenced declarations.
- Export \`WatcherVersionInfo\`.
- Switch \`packages/owletto-backend/tsconfig.json\` \`jsx\` to \`react-jsx\` (same as the root) and replace \`React.CSSProperties\` with an explicit \`import type { CSSProperties } from 'react'\` in \`BrandedEmail.tsx\`.

## Test plan
- [x] \`bun run typecheck\` (root) clean.
- [x] \`bunx tsc --noEmit\` inside \`packages/owletto-backend\` clean — replicates the Dockerfile step that was failing.
- [ ] \`build-images.yml\` turns green on this commit.
- [ ] Once merged, \`ghcr.io/lobu-ai/owletto-app\` picks up a fresh tag and Flux image-automation rolls app.lobu.ai forward.