### PR TITLE
refactor(gateway): introduce CliBackendOnlyModule base for shell-out providers

### DIFF
--- a/packages/gateway/src/auth/cli-backend-only-module.ts
+++ b/packages/gateway/src/auth/cli-backend-only-module.ts
@@ -1,0 +1,72 @@
+import type { ProviderCredentialContext } from "../embedded.js";
+import { BaseProviderModule } from "./base-provider-module.js";
+import type { AuthProfilesManager } from "./settings/auth-profiles-manager.js";
+
+interface CliBackendOnlyConfig {
+  providerId: string;
+  providerDisplayName: string;
+  providerIconUrl: string;
+  catalogDescription?: string;
+  catalogVisible?: boolean;
+}
+
+/**
+ * Base class for providers that exist solely to register a CLI backend
+ * (acpx-style sub-agent shell-out). They do not own any lobu-managed
+ * credential or env var — the underlying CLI reads its own auth from the
+ * host filesystem (e.g. `~/.gemini/oauth_creds.json`,
+ * `~/.codex/auth.json`).
+ *
+ * Subclasses only need to implement `getCliBackendConfig()` and
+ * `getModelOptions()`. Everything credential-related is intentionally
+ * inert.
+ */
+export abstract class CliBackendOnlyModule extends BaseProviderModule {
+  constructor(
+    config: CliBackendOnlyConfig,
+    authProfilesManager: AuthProfilesManager
+  ) {
+    super(
+      {
+        ...config,
+        credentialEnvVarName: "",
+        secretEnvVarNames: [],
+        authType: "oauth",
+      },
+      authProfilesManager
+    );
+  }
+
+  override hasSystemKey(): boolean {
+    return false;
+  }
+
+  override async hasCredentials(
+    _agentId: string,
+    _context?: ProviderCredentialContext
+  ): Promise<boolean> {
+    return false;
+  }
+
+  override injectSystemKeyFallback(
+    envVars: Record<string, string>
+  ): Record<string, string> {
+    return envVars;
+  }
+
+  override async buildEnvVars(
+    _agentId: string,
+    envVars: Record<string, string>,
+    _context?: ProviderCredentialContext
+  ): Promise<Record<string, string>> {
+    return envVars;
+  }
+
+  override getProxyBaseUrlMappings(
+    _proxyUrl: string,
+    _agentId?: string,
+    _context?: ProviderCredentialContext
+  ): Record<string, string> {
+    return {};
+  }
+}

--- a/packages/gateway/src/auth/gemini/cli-module.ts
+++ b/packages/gateway/src/auth/gemini/cli-module.ts
@@ -1,5 +1,5 @@
 import type { ModelOption } from "../../modules/module-system.js";
-import { BaseProviderModule } from "../base-provider-module.js";
+import { CliBackendOnlyModule } from "../cli-backend-only-module.js";
 import type { AuthProfilesManager } from "../settings/auth-profiles-manager.js";
 
 /**
@@ -17,7 +17,7 @@ import type { AuthProfilesManager } from "../settings/auth-profiles-manager.js";
  * provider in `config/providers.json`) or OpenRouter — both stable HTTP
  * paths that don't depend on the reverse-engineered Code Assist API.
  */
-export class GeminiCliModule extends BaseProviderModule {
+export class GeminiCliModule extends CliBackendOnlyModule {
   constructor(authProfilesManager: AuthProfilesManager) {
     super(
       {
@@ -25,43 +25,12 @@ export class GeminiCliModule extends BaseProviderModule {
         providerDisplayName: "Gemini CLI",
         providerIconUrl:
           "https://www.google.com/s2/favicons?domain=gemini.google.com&sz=128",
-        // No lobu-managed credential — gemini CLI reads its own OAuth file.
-        // Empty placeholder names keep BaseProviderModule's interface happy
-        // without claiming an env var slot.
-        credentialEnvVarName: "",
-        secretEnvVarNames: [],
-        authType: "oauth",
         catalogDescription:
           "Google's gemini CLI as a sub-agent shell-out (uses your local ~/.gemini OAuth)",
       },
       authProfilesManager
     );
     this.name = "gemini-cli";
-  }
-
-  override hasSystemKey(): boolean {
-    return false;
-  }
-
-  override async hasCredentials(): Promise<boolean> {
-    return false;
-  }
-
-  override injectSystemKeyFallback(
-    envVars: Record<string, string>
-  ): Record<string, string> {
-    return envVars;
-  }
-
-  override async buildEnvVars(
-    _agentId: string,
-    envVars: Record<string, string>
-  ): Promise<Record<string, string>> {
-    return envVars;
-  }
-
-  override getProxyBaseUrlMappings(): Record<string, string> {
-    return {};
   }
 
   getCliBackendConfig() {


### PR DESCRIPTION
## Summary
- Extracts the \"no credentials, CLI handles its own auth\" intent from \`GeminiCliModule\` (which was overriding 5 methods of \`BaseProviderModule\` to no-ops) into a new \`CliBackendOnlyModule\` base.
- Subclasses now declare identity (id, name, icon, description) and only implement \`getCliBackendConfig()\` + \`getModelOptions()\`. Everything credential-related is inherited as inert.
- \`GeminiCliModule\` drops from 84 lines to 53 and reads as the thin shell-out shim it was always supposed to be.
- Lays the path for adding more acpx-style providers (e.g. a future \`codex-cli\`) without re-stubbing the same five methods every time.

## Test plan
- [x] \`bun run build\` — clean across workspace
- [x] \`bun test packages/gateway\` — 576 pass, 0 fail
- [x] No behavior change: the new base just consolidates the existing overrides