### PR TITLE
feat(watchers): in-process lifecycle tracker, durable correlation, drop heartbeat

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ help:
 	@echo "Available commands:"
 	@echo "  make setup                                 - Setup development environment (run once)"
 	@echo "  make dev                                   - Start dev environment (Docker Compose Watch)"
+	@echo "  make dev-native                            - Native foreground dev (host redis, remote Postgres, Vite HMR)"
 	@echo "  make build-packages                        - Build all TypeScript packages"
 	@echo "  make build-worker                          - Build worker Docker image"
 	@echo "  make deploy                                - Deploy to K8s using values-local.yaml"
@@ -40,6 +41,10 @@ build-packages:
 # Start dev environment with Docker Compose Watch
 dev:
 	docker compose --env-file .env -f docker/docker-compose.yml watch
+
+# Native foreground dev: embedded gateway + workers + Vite HMR, against host redis + remote Postgres.
+dev-native:
+	@./scripts/dev-native.sh
 
 # Setup development environment (run once)
 setup:

--- a/db/migrations/20260424030000_add_watcher_run_correlation.sql
+++ b/db/migrations/20260424030000_add_watcher_run_correlation.sql
@@ -1,0 +1,28 @@
+-- migrate:up
+
+-- Durable correlation between a dispatched watcher run and the agent message
+-- that executes it, and between a completed watcher window and the run that
+-- produced it. Replaces payload-based matching in reconcileWatcherRuns.
+
+ALTER TABLE public.runs
+    ADD COLUMN IF NOT EXISTS dispatched_message_id text;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_runs_dispatched_message_id
+    ON public.runs (dispatched_message_id)
+    WHERE dispatched_message_id IS NOT NULL;
+
+ALTER TABLE public.watcher_windows
+    ADD COLUMN IF NOT EXISTS run_id bigint
+    REFERENCES public.runs(id) ON DELETE SET NULL;
+
+CREATE INDEX IF NOT EXISTS idx_watcher_windows_run_id
+    ON public.watcher_windows (run_id)
+    WHERE run_id IS NOT NULL;
+
+
+-- migrate:down
+
+DROP INDEX IF EXISTS public.idx_watcher_windows_run_id;
+ALTER TABLE public.watcher_windows DROP COLUMN IF EXISTS run_id;
+DROP INDEX IF EXISTS public.idx_runs_dispatched_message_id;
+ALTER TABLE public.runs DROP COLUMN IF EXISTS dispatched_message_id;

--- a/db/migrations/20260424030000_add_watcher_run_correlation.sql
+++ b/db/migrations/20260424030000_add_watcher_run_correlation.sql
@@ -15,6 +15,30 @@ ALTER TABLE public.watcher_windows
     ADD COLUMN IF NOT EXISTS run_id bigint
     REFERENCES public.runs(id) ON DELETE SET NULL;
 
+-- Rollout backfill: older windows already stored watcher_run_id in run_metadata,
+-- but pre-migration rows have NULL run_id. Populate the durable FK before the
+-- new reconciler/reset path runs so successful pre-deploy executions are not
+-- re-dispatched on first tick.
+WITH correlated_windows AS (
+    SELECT ww.id,
+           (btrim(ww.run_metadata->>'watcher_run_id'))::bigint AS correlated_run_id
+    FROM public.watcher_windows ww
+    WHERE ww.run_id IS NULL
+      AND ww.run_metadata ? 'watcher_run_id'
+      AND jsonb_typeof(ww.run_metadata->'watcher_run_id') IN ('number', 'string')
+      AND btrim(ww.run_metadata->>'watcher_run_id') ~ '^[0-9]+$'
+)
+UPDATE public.watcher_windows ww
+SET run_id = cw.correlated_run_id
+FROM correlated_windows cw
+WHERE ww.id = cw.id
+  AND EXISTS (
+      SELECT 1
+      FROM public.runs r
+      WHERE r.id = cw.correlated_run_id
+        AND r.run_type = 'watcher'
+  );
+
 CREATE INDEX IF NOT EXISTS idx_watcher_windows_run_id
     ON public.watcher_windows (run_id)
     WHERE run_id IS NOT NULL;

--- a/packages/gateway/src/api/platform.ts
+++ b/packages/gateway/src/api/platform.ts
@@ -46,9 +46,13 @@ export class ApiPlatform implements PlatformAdapter {
 
     this.services = services;
     const sseManager = services.getSseManager();
+    const watcherRunTracker = services.getWatcherRunTracker();
 
     // Create response renderer for routing worker responses to SSE clients
-    this.responseRenderer = new ApiResponseRenderer(sseManager);
+    this.responseRenderer = new ApiResponseRenderer(
+      sseManager,
+      watcherRunTracker
+    );
 
     // Subscribe to interaction events to broadcast to SSE clients
     const interactionService = services.getInteractionService();

--- a/packages/gateway/src/api/response-renderer.ts
+++ b/packages/gateway/src/api/response-renderer.ts
@@ -9,6 +9,7 @@ import { createLogger } from "@lobu/core";
 import type { ThreadResponsePayload } from "../infrastructure/queue/types.js";
 import type { ResponseRenderer } from "../platform/response-renderer.js";
 import type { SseManager } from "../services/sse-manager.js";
+import type { WatcherRunTracker } from "../watchers/run-tracker.js";
 
 const logger = createLogger("api-response-renderer");
 
@@ -17,7 +18,10 @@ const logger = createLogger("api-response-renderer");
  * Broadcasts responses to SSE clients instead of external platforms
  */
 export class ApiResponseRenderer implements ResponseRenderer {
-  constructor(private readonly sseManager: SseManager) {}
+  constructor(
+    private readonly sseManager: SseManager,
+    private readonly watcherRunTracker?: WatcherRunTracker
+  ) {}
 
   /**
    * Handle streaming delta content
@@ -75,6 +79,8 @@ export class ApiResponseRenderer implements ResponseRenderer {
     });
 
     logger.info(`Broadcast completion to session ${sessionId}`);
+
+    await this.resolveWatcherRunsFromPayload(payload, { ok: true });
   }
 
   /**
@@ -102,6 +108,31 @@ export class ApiResponseRenderer implements ResponseRenderer {
     });
 
     logger.error(`Broadcast error to session ${sessionId}: ${payload.error}`);
+
+    await this.resolveWatcherRunsFromPayload(payload, {
+      ok: false,
+      error: typeof payload.error === "string" ? payload.error : "agent error",
+    });
+  }
+
+  /**
+   * Resolve any watcher-run handles whose dispatched messageId matches the
+   * terminal event. Checks both the immediate messageId and processedMessageIds
+   * since a single turn can batch-process multiple messages.
+   */
+  private async resolveWatcherRunsFromPayload(
+    payload: ThreadResponsePayload,
+    result: { ok: true } | { ok: false; error: string }
+  ): Promise<void> {
+    if (!this.watcherRunTracker) return;
+    const ids = new Set<string>();
+    if (payload.messageId) ids.add(payload.messageId);
+    for (const id of payload.processedMessageIds ?? []) {
+      if (id) ids.add(id);
+    }
+    for (const id of ids) {
+      await this.watcherRunTracker.resolve(id, result);
+    }
   }
 
   /**

--- a/packages/gateway/src/index.ts
+++ b/packages/gateway/src/index.ts
@@ -28,6 +28,11 @@ export type {
 } from "./embedded.js";
 export { Gateway, type GatewayOptions } from "./gateway-main.js";
 export { CoreServices } from "./services/core-services.js";
+export {
+  WatcherRunTracker,
+  type WatcherRunHandle,
+  type WatcherRunResult,
+} from "./watchers/run-tracker.js";
 export { InMemoryAgentStore } from "./stores/in-memory-agent-store.js";
 export {
   AwsSecretsManagerSecretStore,

--- a/packages/gateway/src/platform.ts
+++ b/packages/gateway/src/platform.ts
@@ -29,6 +29,7 @@ import type { InstructionService } from "./services/instruction-service.js";
 import type { SseManager } from "./services/sse-manager.js";
 import type { TranscriptionService } from "./services/transcription-service.js";
 import type { ISessionManager } from "./session.js";
+import type { WatcherRunTracker } from "./watchers/run-tracker.js";
 
 // ============================================================================
 // Core Services Interface
@@ -53,6 +54,7 @@ export interface CoreServices {
   getInstructionService(): InstructionService | undefined;
   getInteractionService(): InteractionService;
   getSseManager(): SseManager;
+  getWatcherRunTracker(): WatcherRunTracker;
   getAgentSettingsStore(): AgentSettingsStore;
   getChannelBindingService(): ChannelBindingService;
   getTranscriptionService(): TranscriptionService | undefined;

--- a/packages/gateway/src/routes/public/agent.ts
+++ b/packages/gateway/src/routes/public/agent.ts
@@ -503,10 +503,22 @@ export function createAgentApi(config: AgentApiConfig): OpenAPIHono {
   // =============================================================================
 
   // Accept either an AgentMetadataStore or an AgentConfigStore exposing
-  // getMetadata for ownership resolution.
+  // getMetadata for ownership resolution. When both are provided, try the
+  // metadata store first (Redis cache) and fall through to the config store
+  // (Postgres, authoritative) — needed in embedded mode where agent rows live
+  // in Postgres but the Redis cache is never hydrated.
   const ownershipMetadataStore:
     | { getMetadata: AgentMetadataStore["getMetadata"] }
-    | undefined = agentMetadataStore ?? agentConfigStore;
+    | undefined =
+    agentMetadataStore && agentConfigStore
+      ? {
+          async getMetadata(agentId) {
+            const fromCache = await agentMetadataStore.getMetadata(agentId);
+            if (fromCache) return fromCache;
+            return agentConfigStore.getMetadata(agentId);
+          },
+        }
+      : (agentMetadataStore ?? agentConfigStore);
 
   const ownershipAccessConfig = {
     userAgentsStore,

--- a/packages/gateway/src/services/core-services.ts
+++ b/packages/gateway/src/services/core-services.ts
@@ -81,6 +81,7 @@ import { InstructionService } from "./instruction-service.js";
 import { SessionManager, StateAdapterSessionStore } from "./session-manager.js";
 import { SettingsResolver } from "./settings-resolver.js";
 import { SseManager } from "./sse-manager.js";
+import { WatcherRunTracker } from "../watchers/run-tracker.js";
 import { ProviderConfigResolver } from "./provider-config-resolver.js";
 import { ProviderRegistryService } from "./provider-registry-service.js";
 import { TranscriptionService } from "./transcription-service.js";
@@ -104,6 +105,7 @@ export class CoreServices {
   private instructionService?: InstructionService;
   private interactionService?: InteractionService;
   private sseManager?: SseManager;
+  private watcherRunTracker?: WatcherRunTracker;
 
   // ============================================================================
   // Auth & Provider Services
@@ -361,6 +363,9 @@ export class CoreServices {
 
     this.sseManager = new SseManager();
     logger.debug("SSE manager initialized");
+
+    this.watcherRunTracker = new WatcherRunTracker();
+    logger.debug("Watcher run tracker initialized");
 
     // Initialize grant store for unified permissions
     this.grantStore = new GrantStore(redisClient);
@@ -1168,6 +1173,12 @@ export class CoreServices {
   getSseManager(): SseManager {
     if (!this.sseManager) throw new Error("SSE manager not initialized");
     return this.sseManager;
+  }
+
+  getWatcherRunTracker(): WatcherRunTracker {
+    if (!this.watcherRunTracker)
+      throw new Error("Watcher run tracker not initialized");
+    return this.watcherRunTracker;
   }
 
   getAgentSettingsStore(): AgentSettingsStore {

--- a/packages/gateway/src/watchers/run-tracker.ts
+++ b/packages/gateway/src/watchers/run-tracker.ts
@@ -1,0 +1,60 @@
+import { createLogger } from "@lobu/core";
+
+const logger = createLogger("watcher-run-tracker");
+
+export type WatcherRunResult = { ok: true } | { ok: false; error: string };
+
+export interface WatcherRunHandle {
+  messageId: string;
+  runId: number;
+  watcherId: number;
+  organizationId: string;
+  onResolve: (result: WatcherRunResult) => Promise<void>;
+}
+
+/**
+ * In-process registry of watcher runs awaiting completion.
+ *
+ * Dispatch registers a handle keyed by the agent messageId; the API response
+ * renderer calls resolve() when the agent turn finishes (success or error).
+ * Resolve is idempotent — duplicate events are dropped.
+ *
+ * This is the fast path. Durable correlation lives in runs.dispatched_message_id
+ * and watcher_windows.run_id so a gateway restart can reconcile without it.
+ */
+export class WatcherRunTracker {
+  private readonly pending = new Map<string, WatcherRunHandle>();
+
+  register(handle: WatcherRunHandle): void {
+    if (this.pending.has(handle.messageId)) {
+      logger.warn(
+        { messageId: handle.messageId, runId: handle.runId },
+        "duplicate watcher run registration ignored"
+      );
+      return;
+    }
+    this.pending.set(handle.messageId, handle);
+  }
+
+  async resolve(messageId: string, result: WatcherRunResult): Promise<void> {
+    const handle = this.pending.get(messageId);
+    if (!handle) return;
+    this.pending.delete(messageId);
+    try {
+      await handle.onResolve(result);
+    } catch (err) {
+      logger.error(
+        { err, messageId, runId: handle.runId },
+        "watcher run onResolve callback failed"
+      );
+    }
+  }
+
+  unregister(messageId: string): void {
+    this.pending.delete(messageId);
+  }
+
+  size(): number {
+    return this.pending.size;
+  }
+}

--- a/packages/owletto-backend/src/__tests__/integration/watchers/watcher-automation.test.ts
+++ b/packages/owletto-backend/src/__tests__/integration/watchers/watcher-automation.test.ts
@@ -221,7 +221,7 @@ describe('watcher automation', () => {
     expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 
-  it('marks watcher runs completed when an external completion already created the queued window', async () => {
+  it('marks watcher runs completed when a correlated window already exists', async () => {
     const { sql, dbClient, org, watcher, agent } = await createAutomatedWatcher();
     const granularity = inferWatcherGranularityFromSchedule('0 9 * * *');
     const { windowStart, windowEnd } = await computePendingWindow(
@@ -249,6 +249,7 @@ describe('watcher automation', () => {
         content_analyzed,
         model_used,
         run_metadata,
+        run_id,
         created_at
       ) VALUES (
         ${watcher.id},
@@ -258,7 +259,8 @@ describe('watcher automation', () => {
         ${sql.json({ summary: 'External completion' })},
         1,
         'external-client',
-        ${sql.json({ source: 'external' })},
+        ${sql.json({ source: 'external', watcher_run_id: queued.runId })},
+        ${queued.runId},
         NOW()
       )
       RETURNING id
@@ -276,7 +278,7 @@ describe('watcher automation', () => {
     expect(Number(run.window_id)).toBe(Number(window.id));
   });
 
-  it('times out stalled watcher runs and retries the same queued window', async () => {
+  it('times out stale watcher runs after the coarse ttl without creating a retry', async () => {
     const { sql, dbClient, org, watcher, agent } = await createAutomatedWatcher();
     const granularity = inferWatcherGranularityFromSchedule('0 9 * * *');
     const { windowStart, windowEnd } = await computePendingWindow(
@@ -297,27 +299,24 @@ describe('watcher automation', () => {
     await sql`
       UPDATE runs
       SET status = 'running',
-          claimed_at = NOW() - INTERVAL '10 minutes',
-          last_heartbeat_at = NOW() - INTERVAL '10 minutes'
+          claimed_at = NOW() - INTERVAL '3 hours',
+          last_heartbeat_at = NOW() - INTERVAL '3 hours'
       WHERE id = ${queued.runId}
     `;
 
     await checkStalledExecutions({} as Env);
 
     const runs = await sql`
-      SELECT id, status, approved_input
+      SELECT id, status, error_message
       FROM runs
       WHERE watcher_id = ${watcher.id}
         AND run_type = 'watcher'
       ORDER BY id ASC
     `;
 
-    expect(runs).toHaveLength(2);
+    expect(runs).toHaveLength(1);
     expect(String(runs[0].status)).toBe('timeout');
-    expect(String(runs[1].status)).toBe('pending');
-    expect((runs[0] as { approved_input: unknown }).approved_input).toEqual(
-      (runs[1] as { approved_input: unknown }).approved_input
-    );
+    expect(String((runs[0] as { error_message: unknown }).error_message)).toContain('2 hours');
   });
 
   it('completes the queued watcher run from complete_window provenance and advances next_run_at', async () => {
@@ -390,6 +389,81 @@ describe('watcher automation', () => {
     expect(String(run.status)).toBe('completed');
     expect(Number(run.window_id)).toBe(completion.window_id);
     expect(watcherRow.next_run_at).not.toBeNull();
+  });
+
+  it('does not reopen a timed out watcher run when complete_window arrives late', async () => {
+    const { sql, dbClient, org, entity, watcher, agent, token } = await createAutomatedWatcher();
+
+    await createTestEvent({
+      entity_id: entity.id,
+      organization_id: org.id,
+      content: 'Late watcher completion content.',
+      occurred_at: new Date(Date.now() - 60 * 60 * 1000),
+    });
+
+    const granularity = inferWatcherGranularityFromSchedule('0 9 * * *');
+    const { windowStart, windowEnd } = await computePendingWindow(
+      dbClient,
+      watcher.id,
+      granularity
+    );
+
+    const queued = await createWatcherRun({
+      organizationId: org.id,
+      watcherId: watcher.id,
+      agentId: agent.agentId,
+      windowStart: windowStart.toISOString(),
+      windowEnd: windowEnd.toISOString(),
+      dispatchSource: 'scheduled',
+    });
+
+    await sql`
+      UPDATE runs
+      SET status = 'timeout',
+          completed_at = NOW(),
+          error_message = 'Watcher run exceeded 2 hours without reaching terminal state'
+      WHERE id = ${queued.runId}
+    `;
+
+    const content = await mcpToolsCall<{
+      window_token: string;
+    }>('read_knowledge', { watcher_id: watcher.id }, { token });
+
+    const completion = await mcpToolsCall<{
+      action: 'complete_window';
+      watcher_id: string;
+      window_id: number;
+    }>(
+      'manage_watchers',
+      {
+        action: 'complete_window',
+        window_token: content.window_token,
+        extracted_data: { summary: 'Late watcher completion summary' },
+        run_metadata: {
+          executor: 'lobu-agent',
+          agent_id: agent.agentId,
+          watcher_run_id: queued.runId,
+          dispatch_source: 'scheduled',
+        },
+      },
+      { token }
+    );
+
+    const [run] = await sql`
+      SELECT status, window_id
+      FROM runs
+      WHERE id = ${queued.runId}
+    `;
+    const [window] = await sql`
+      SELECT run_id
+      FROM watcher_windows
+      WHERE id = ${completion.window_id}
+    `;
+
+    expect(completion.action).toBe('complete_window');
+    expect(String(run.status)).toBe('timeout');
+    expect(run.window_id).toBeNull();
+    expect(Number(window.run_id)).toBe(queued.runId);
   });
 
   it('triggers an assigned watcher through manage_watchers(trigger)', async () => {

--- a/packages/owletto-backend/src/scheduled/check-stalled-executions.ts
+++ b/packages/owletto-backend/src/scheduled/check-stalled-executions.ts
@@ -1,11 +1,11 @@
 /**
  * Scheduled Job: Check Stalled Runs
  *
- * Runs every 5 minutes to detect runs that:
- * 1. Were started by a worker but never sent a heartbeat (5+ minutes)
- * 2. Stopped sending heartbeats (5+ minutes since last heartbeat)
- *
- * Marks them as 'timeout' and creates new pending run for retry (sync only).
+ * Runs every 5 minutes to detect stalled sync/embed-backfill runs driven by the
+ * out-of-process owletto-worker daemon. Watcher runs are driven in-process by
+ * the embedded Lobu gateway; their lifecycle is handled by WatcherRunTracker
+ * and startup reconciliation (see automation.ts and lobu/gateway.ts), with a
+ * coarse backstop in sweepStaleWatcherRuns below.
  */
 
 import { getDb } from '../db/client';
@@ -13,29 +13,27 @@ import type { Env } from '../index';
 import { expireStaleConnectTokens } from '../utils/connect-tokens';
 import logger from '../utils/logger';
 import { isUniqueViolation } from '../utils/pg-errors';
-import { createWatcherRun } from '../utils/queue-helpers';
 import {
   EXECUTING_RUN_STATUSES,
   isExecutingRunStatus,
   runStatusLiteral,
 } from '../utils/run-statuses';
-import {
-  findWatcherWindowIdForPayload,
-  parseWatcherRunPayload,
-  reconcileWatcherRuns,
-} from '../watchers/automation';
+import { reconcileWatcherRuns, sweepStaleWatcherRuns } from '../watchers/automation';
 
 export async function checkStalledExecutions(_env: Env) {
   const sql = getDb();
 
   await reconcileWatcherRuns(sql);
+  await sweepStaleWatcherRuns(sql);
 
-    // Find stalled runs that are still considered executing, including legacy claimed rows.
+    // Find stalled sync/embed_backfill runs (driven by out-of-process workers).
+    // Watcher runs are excluded — they run in-process and use tracker-based lifecycle.
     const timedOut = await sql`
       SELECT id, feed_id, connection_id, run_type, claimed_by, last_heartbeat_at, claimed_at,
              organization_id, connector_key, connector_version, watcher_id, approved_input
       FROM runs
-      WHERE status = ANY(${runStatusLiteral(EXECUTING_RUN_STATUSES)}::text[])
+      WHERE run_type IN ('sync', 'embed_backfill')
+        AND status = ANY(${runStatusLiteral(EXECUTING_RUN_STATUSES)}::text[])
         AND (
           (last_heartbeat_at IS NULL AND COALESCE(claimed_at, created_at) < current_timestamp - INTERVAL '5 minutes')
           OR
@@ -68,33 +66,6 @@ export async function checkStalledExecutions(_env: Env) {
               return; // Already handled by another process
             }
 
-            if (run.run_type === 'watcher') {
-              const payload = parseWatcherRunPayload(run.approved_input);
-              if (!payload) {
-                await tx`
-                  UPDATE runs
-                  SET status = 'failed',
-                      completed_at = current_timestamp,
-                      error_message = 'Watcher run timed out with an invalid dispatch payload.'
-                  WHERE id = ${run.id}
-                `;
-                return;
-              }
-
-              const existingWindowId = await findWatcherWindowIdForPayload(tx, payload);
-              if (existingWindowId) {
-                await tx`
-                  UPDATE runs
-                  SET status = 'completed',
-                      window_id = ${existingWindowId},
-                      completed_at = current_timestamp,
-                      error_message = NULL
-                  WHERE id = ${run.id}
-                `;
-                return;
-              }
-            }
-
             await tx`
               UPDATE runs
               SET status = 'timeout',
@@ -120,45 +91,6 @@ export async function checkStalledExecutions(_env: Env) {
                 if (isUniqueViolation(retryError, 'idx_runs_active_sync_per_feed')) {
                   logger.info(
                     `[StalledRuns] Skipped retry for feed ${run.feed_id} - another active sync run exists`
-                  );
-                } else {
-                  throw retryError;
-                }
-              }
-            }
-
-            if (run.run_type === 'watcher' && run.watcher_id) {
-              const payload = parseWatcherRunPayload(run.approved_input);
-              if (!payload) {
-                return;
-              }
-
-              try {
-                const retryResult = await createWatcherRun(
-                  {
-                    organizationId: run.organization_id,
-                    watcherId: run.watcher_id,
-                    agentId: payload.agent_id,
-                    windowStart: payload.window_start,
-                    windowEnd: payload.window_end,
-                    dispatchSource: payload.dispatch_source,
-                  },
-                  tx
-                );
-
-                if (retryResult.created) {
-                  logger.info(
-                    `[StalledRuns] Created retry watcher run ${retryResult.runId} for watcher ${run.watcher_id}`
-                  );
-                } else {
-                  logger.info(
-                    `[StalledRuns] Reused watcher run ${retryResult.runId} for watcher ${run.watcher_id}`
-                  );
-                }
-              } catch (retryError) {
-                if (isUniqueViolation(retryError, 'idx_runs_active_watcher_per_watcher')) {
-                  logger.info(
-                    `[StalledRuns] Skipped watcher retry for watcher ${run.watcher_id} - another active watcher run exists`
                   );
                 } else {
                   throw retryError;

--- a/packages/owletto-backend/src/scheduled/jobs.ts
+++ b/packages/owletto-backend/src/scheduled/jobs.ts
@@ -5,6 +5,10 @@ import { withAdvisoryLock } from './advisory-lock';
 const MAINTENANCE_LOCK_KEY = 71002;
 const MAINTENANCE_INTERVAL_MS = 5 * 60_000;
 
+// Reset orphaned watcher runs once per process on the first maintenance tick
+// where we acquire the lock — ensures we are the singleton dispatcher/reconciler.
+let orphanedWatcherRunsReset = false;
+
 async function runMaintenanceTasks(env: Env): Promise<void> {
   logger.info('Running scheduled maintenance tasks');
   let failures = 0;
@@ -39,8 +43,20 @@ async function runMaintenanceTasks(env: Env): Promise<void> {
   }
 
   try {
-    const { dispatchPendingWatcherRuns, materializeDueWatcherRuns, reconcileWatcherRuns } =
-      await import('../watchers/automation');
+    const {
+      dispatchPendingWatcherRuns,
+      materializeDueWatcherRuns,
+      reconcileWatcherRuns,
+      resetOrphanedWatcherRuns,
+    } = await import('../watchers/automation');
+
+    if (!orphanedWatcherRunsReset) {
+      const { reset } = await resetOrphanedWatcherRuns();
+      orphanedWatcherRunsReset = true;
+      if (reset > 0) {
+        logger.info({ reset }, 'Scheduled: Reset orphaned watcher runs on first tick');
+      }
+    }
 
     const reconciliationResult = await reconcileWatcherRuns();
     const materializeResult = await materializeDueWatcherRuns(env);

--- a/packages/owletto-backend/src/start-local.ts
+++ b/packages/owletto-backend/src/start-local.ts
@@ -245,6 +245,27 @@ const EMBEDDED_SCHEMA_PATCHES: EmbeddedSchemaPatch[] = [
         REFERENCES public.runs(id) ON DELETE SET NULL
       `);
       await sql.unsafe(`
+        WITH correlated_windows AS (
+          SELECT ww.id,
+                 (btrim(ww.run_metadata->>'watcher_run_id'))::bigint AS correlated_run_id
+          FROM public.watcher_windows ww
+          WHERE ww.run_id IS NULL
+            AND ww.run_metadata ? 'watcher_run_id'
+            AND jsonb_typeof(ww.run_metadata->'watcher_run_id') IN ('number', 'string')
+            AND btrim(ww.run_metadata->>'watcher_run_id') ~ '^[0-9]+$'
+        )
+        UPDATE public.watcher_windows ww
+        SET run_id = cw.correlated_run_id
+        FROM correlated_windows cw
+        WHERE ww.id = cw.id
+          AND EXISTS (
+            SELECT 1
+            FROM public.runs r
+            WHERE r.id = cw.correlated_run_id
+              AND r.run_type = 'watcher'
+          )
+      `);
+      await sql.unsafe(`
         CREATE INDEX IF NOT EXISTS idx_watcher_windows_run_id
         ON public.watcher_windows (run_id)
         WHERE run_id IS NOT NULL

--- a/packages/owletto-backend/src/start-local.ts
+++ b/packages/owletto-backend/src/start-local.ts
@@ -228,6 +228,30 @@ const EMBEDDED_SCHEMA_PATCHES: EmbeddedSchemaPatch[] = [
     },
   },
   {
+    id: 'watcher-run-correlation',
+    apply: async (sql) => {
+      await sql.unsafe(`
+        ALTER TABLE public.runs
+        ADD COLUMN IF NOT EXISTS dispatched_message_id text
+      `);
+      await sql.unsafe(`
+        CREATE UNIQUE INDEX IF NOT EXISTS idx_runs_dispatched_message_id
+        ON public.runs (dispatched_message_id)
+        WHERE dispatched_message_id IS NOT NULL
+      `);
+      await sql.unsafe(`
+        ALTER TABLE public.watcher_windows
+        ADD COLUMN IF NOT EXISTS run_id bigint
+        REFERENCES public.runs(id) ON DELETE SET NULL
+      `);
+      await sql.unsafe(`
+        CREATE INDEX IF NOT EXISTS idx_watcher_windows_run_id
+        ON public.watcher_windows (run_id)
+        WHERE run_id IS NOT NULL
+      `);
+    },
+  },
+  {
     id: 'mcp-sessions-table',
     apply: async (sql) => {
       await sql.unsafe(`

--- a/packages/owletto-backend/src/tools/admin/manage_watchers.ts
+++ b/packages/owletto-backend/src/tools/admin/manage_watchers.ts
@@ -1433,11 +1433,11 @@ async function handleCompleteWindow(
       INSERT INTO watcher_windows (
         id, watcher_id, window_start, window_end, granularity,
         extracted_data, content_analyzed, model_used, client_id, run_metadata,
-        is_rollup, depth, source_window_ids, created_at
+        is_rollup, depth, source_window_ids, run_id, created_at
       ) VALUES (
         ${newWindowId}, ${watcherId}, ${window_start}, ${window_end}, ${granularity || timeGranularity},
         ${sql.json(extractedData)}, 0, ${provenanceModel}, ${provenanceClientId}, ${sql.json(provenanceMetadata)},
-        true, ${depth}, ${sourceIds}, NOW()
+        true, ${depth}, ${sourceIds}, ${watcherRunId}, NOW()
       )
     `;
 
@@ -1551,6 +1551,7 @@ async function handleCompleteWindow(
           model_used = ${provenanceModel},
           client_id = ${provenanceClientId},
           run_metadata = ${sql.json(provenanceMetadata)},
+          run_id = COALESCE(run_id, ${watcherRunId}),
           created_at = COALESCE(created_at, NOW())
         WHERE id = ${tokenWindowId} AND watcher_id = ${watcherId}
         RETURNING id
@@ -1599,11 +1600,11 @@ async function handleCompleteWindow(
           INSERT INTO watcher_windows (
             id,
             watcher_id, window_start, window_end, granularity,
-            extracted_data, content_analyzed, model_used, client_id, run_metadata, created_at
+            extracted_data, content_analyzed, model_used, client_id, run_metadata, run_id, created_at
           ) VALUES (
             ${newWindowId},
             ${watcherId}, ${window_start}, ${window_end}, ${timeGranularity},
-            ${sql.json(cleanedExtractedData)}, ${uniqueContentIds.length}, ${provenanceModel}, ${provenanceClientId}, ${sql.json(provenanceMetadata)}, NOW()
+            ${sql.json(cleanedExtractedData)}, ${uniqueContentIds.length}, ${provenanceModel}, ${provenanceClientId}, ${sql.json(provenanceMetadata)}, ${watcherRunId}, NOW()
           )
         `;
       } catch (err: any) {

--- a/packages/owletto-backend/src/tools/admin/manage_watchers.ts
+++ b/packages/owletto-backend/src/tools/admin/manage_watchers.ts
@@ -1690,6 +1690,7 @@ async function handleCompleteWindow(
             error_message = NULL
         WHERE id = ${watcherRunId}
           AND run_type = 'watcher'
+          AND status IN ('running', 'claimed')
       `;
     }
 

--- a/packages/owletto-backend/src/watchers/automation.ts
+++ b/packages/owletto-backend/src/watchers/automation.ts
@@ -1,8 +1,12 @@
+import { randomUUID } from 'node:crypto';
 import { inferWatcherGranularityFromSchedule } from '@lobu/owletto-sdk';
 import type { DbClient } from '../db/client';
 import { getDb } from '../db/client';
 import type { Env } from '../index';
-import { isLobuGatewayRunning } from '../lobu/gateway';
+import {
+  getLobuCoreServices,
+  isLobuGatewayRunning,
+} from '../lobu/gateway';
 import { getLobuServiceToken } from '../lobu/service-token';
 import logger from '../utils/logger';
 import { createWatcherRun, type WatcherRunPayload } from '../utils/queue-helpers';
@@ -107,16 +111,11 @@ export function parseWatcherRunPayload(value: unknown): WatcherRunPayload | null
   };
 }
 
-export async function findWatcherWindowIdForPayload(
-  sql: DbClient,
-  payload: WatcherRunPayload
-): Promise<number | null> {
+async function findWindowIdForRun(sql: DbClient, runId: number): Promise<number | null> {
   const rows = await sql`
     SELECT id
     FROM watcher_windows
-    WHERE watcher_id = ${payload.watcher_id}
-      AND window_start = ${payload.window_start}::timestamptz
-      AND window_end = ${payload.window_end}::timestamptz
+    WHERE run_id = ${runId}
     ORDER BY id DESC
     LIMIT 1
   `;
@@ -187,7 +186,7 @@ async function enqueueWatcherRunForWatcher(
 async function markWatcherRunCompleted(
   sql: DbClient,
   runId: number,
-  windowId: number
+  windowId: number | null
 ): Promise<void> {
   await sql`
     UPDATE runs
@@ -196,6 +195,22 @@ async function markWatcherRunCompleted(
         completed_at = current_timestamp,
         error_message = NULL
     WHERE id = ${runId}
+      AND status IN ('running', 'claimed')
+  `;
+}
+
+async function markWatcherRunFailedIdempotent(
+  sql: DbClient,
+  runId: number,
+  message: string
+): Promise<void> {
+  await sql`
+    UPDATE runs
+    SET status = 'failed',
+        completed_at = current_timestamp,
+        error_message = ${message}
+    WHERE id = ${runId}
+      AND status IN ('running', 'claimed')
   `;
 }
 
@@ -228,12 +243,12 @@ export async function getWatcherRunInfo(
 export async function reconcileWatcherRuns(db?: DbClient): Promise<ReconcileWatcherRunsResult> {
   const sql = db ?? getDb();
   const rows = await sql`
-    SELECT id, approved_input
-    FROM runs
-    WHERE run_type = 'watcher'
-      AND status = ANY(${runStatusLiteral(ACTIVE_RUN_STATUSES)}::text[])
-      AND approved_input IS NOT NULL
-    ORDER BY created_at ASC
+    SELECT r.id, ww.id AS window_id
+    FROM runs r
+    JOIN watcher_windows ww ON ww.run_id = r.id
+    WHERE r.run_type = 'watcher'
+      AND r.status = ANY(${runStatusLiteral(ACTIVE_RUN_STATUSES)}::text[])
+    ORDER BY r.created_at ASC
     LIMIT 100
   `;
 
@@ -241,17 +256,73 @@ export async function reconcileWatcherRuns(db?: DbClient): Promise<ReconcileWatc
 
   for (const row of rows) {
     const runId = Number((row as { id: unknown }).id);
-    const payload = parseWatcherRunPayload((row as { approved_input: unknown }).approved_input);
-    if (!payload) continue;
-
-    const windowId = await findWatcherWindowIdForPayload(sql, payload);
-    if (!windowId) continue;
+    const windowId = Number((row as { window_id: unknown }).window_id);
 
     await markWatcherRunCompleted(sql, runId, windowId);
     reconciled++;
   }
 
   return { reconciled };
+}
+
+/**
+ * Coarse backstop for watcher runs that never reached terminal state.
+ *
+ * The primary lifecycle is driven by WatcherRunTracker (in-process completion
+ * events) plus startup reconciliation on gateway boot. This sweeper only
+ * catches truly stuck runs — the tracker entry was lost without a crash
+ * (graceful shutdown mid-turn, redis message silently dropped, etc). TTL is
+ * intentionally generous so long LLM turns are not killed.
+ */
+const WATCHER_RUN_STALE_INTERVAL = '2 hours';
+
+export async function sweepStaleWatcherRuns(
+  db?: DbClient
+): Promise<{ timedOut: number }> {
+  const sql = db ?? getDb();
+  const errorMessage = `Watcher run exceeded ${WATCHER_RUN_STALE_INTERVAL} without reaching terminal state`;
+  const result = await sql`
+    UPDATE runs
+    SET status = 'timeout',
+        completed_at = current_timestamp,
+        error_message = ${errorMessage}
+    WHERE run_type = 'watcher'
+      AND status IN ('running', 'claimed')
+      AND COALESCE(claimed_at, created_at)
+          < current_timestamp - ${WATCHER_RUN_STALE_INTERVAL}::interval
+  `;
+  const timedOut = Number(result.count ?? 0);
+  if (timedOut > 0) {
+    logger.warn({ timedOut }, '[watchers] Swept stale watcher runs past coarse TTL');
+  }
+  return { timedOut };
+}
+
+/**
+ * Startup reconciliation: reset any watcher run claimed by this gateway that
+ * was never resolved (crash recovery). Safe to call only when this process
+ * holds the watcher-dispatcher advisory lock — otherwise another gateway may
+ * be legitimately executing those runs.
+ */
+export async function resetOrphanedWatcherRuns(
+  db?: DbClient
+): Promise<{ reset: number }> {
+  const sql = db ?? getDb();
+  const result = await sql`
+    UPDATE runs
+    SET status = 'pending',
+        claimed_by = NULL,
+        claimed_at = NULL,
+        dispatched_message_id = NULL,
+        error_message = NULL
+    WHERE run_type = 'watcher'
+      AND status IN ('running', 'claimed')
+  `;
+  const reset = Number(result.count ?? 0);
+  if (reset > 0) {
+    logger.info({ reset }, '[watchers] Reset orphaned watcher runs on startup');
+  }
+  return { reset };
 }
 
 export async function materializeDueWatcherRuns(
@@ -423,7 +494,8 @@ async function dispatchWatcherRun(
     return 'failed';
   }
 
-  const existingWindowId = await findWatcherWindowIdForPayload(sql, payload);
+  // Already-produced window for this exact run (e.g. retry after crash).
+  const existingWindowId = await findWindowIdForRun(sql, run.id);
   if (existingWindowId) {
     await markWatcherRunCompleted(sql, run.id, existingWindowId);
     return 'reconciled';
@@ -455,6 +527,7 @@ async function dispatchWatcherRun(
     Authorization: `Bearer ${serviceToken}`,
     'Content-Type': 'application/json',
   };
+  const messageId = randomUUID();
 
   try {
     const sessionResponse = await fetch(baseUrl, {
@@ -485,10 +558,29 @@ async function dispatchWatcherRun(
       return 'failed';
     }
 
+    // Mark the run 'running' with a durable message correlation BEFORE posting,
+    // so a late completion event arriving mid-POST has somewhere to land.
+    await sql`
+      UPDATE runs
+      SET status = 'running',
+          claimed_by = ${`lobu:${payload.agent_id}`},
+          dispatched_message_id = ${messageId},
+          error_message = NULL
+      WHERE id = ${run.id}
+    `;
+
+    registerWatcherRunHandle({
+      runId: run.id,
+      watcherId: run.watcher_id,
+      organizationId: run.organization_id,
+      messageId,
+    });
+
     const messageResponse = await fetch(messagesUrl, {
       method: 'POST',
       headers,
       body: JSON.stringify({
+        messageId,
         content: buildDispatchMessage({
           watcherId: run.watcher_id,
           runId: run.id,
@@ -501,6 +593,7 @@ async function dispatchWatcherRun(
 
     if (!messageResponse.ok) {
       const body = await messageResponse.text();
+      unregisterWatcherRunHandle(messageId);
       await failWatcherRun(
         sql,
         run.id,
@@ -509,16 +602,9 @@ async function dispatchWatcherRun(
       return 'failed';
     }
 
-    await sql`
-      UPDATE runs
-      SET status = 'running',
-          claimed_by = ${`lobu:${payload.agent_id}`},
-          error_message = NULL
-      WHERE id = ${run.id}
-    `;
-
     return 'dispatched';
   } catch (error) {
+    unregisterWatcherRunHandle(messageId);
     await failWatcherRun(
       sql,
       run.id,
@@ -526,6 +612,45 @@ async function dispatchWatcherRun(
     );
     return 'failed';
   }
+}
+
+function registerWatcherRunHandle(params: {
+  runId: number;
+  watcherId: number;
+  organizationId: string;
+  messageId: string;
+}): void {
+  const coreServices = getLobuCoreServices();
+  const tracker = coreServices?.getWatcherRunTracker?.();
+  if (!tracker) {
+    logger.warn(
+      { runId: params.runId },
+      '[watcher-dispatch] No WatcherRunTracker available — completion will rely on reconciler'
+    );
+    return;
+  }
+
+  tracker.register({
+    messageId: params.messageId,
+    runId: params.runId,
+    watcherId: params.watcherId,
+    organizationId: params.organizationId,
+    onResolve: async (result: { ok: true } | { ok: false; error: string }) => {
+      const db = getDb();
+      if (result.ok) {
+        const windowId = await findWindowIdForRun(db, params.runId);
+        await markWatcherRunCompleted(db, params.runId, windowId);
+      } else {
+        await markWatcherRunFailedIdempotent(db, params.runId, result.error);
+      }
+    },
+  });
+}
+
+function unregisterWatcherRunHandle(messageId: string): void {
+  const coreServices = getLobuCoreServices();
+  const tracker = coreServices?.getWatcherRunTracker?.();
+  tracker?.unregister(messageId);
 }
 
 export async function dispatchPendingWatcherRuns(

--- a/packages/owletto-backend/src/watchers/automation.ts
+++ b/packages/owletto-backend/src/watchers/automation.ts
@@ -316,7 +316,9 @@ export async function resetOrphanedWatcherRuns(
         dispatched_message_id = NULL,
         error_message = NULL
     WHERE run_type = 'watcher'
-      AND status IN ('running', 'claimed')
+      AND status = 'claimed'
+      AND claimed_by = 'lobu-dispatcher'
+      AND COALESCE(approved_input->>'dispatch_source', 'scheduled') = 'scheduled'
   `;
   const reset = Number(result.count ?? 0);
   if (reset > 0) {
@@ -422,13 +424,7 @@ function buildDispatchMessage(params: {
 }
 
 async function failWatcherRun(sql: DbClient, runId: number, message: string): Promise<void> {
-  await sql`
-    UPDATE runs
-    SET status = 'failed',
-        completed_at = current_timestamp,
-        error_message = ${message}
-    WHERE id = ${runId}
-  `;
+  await markWatcherRunFailedIdempotent(sql, runId, message);
 }
 
 async function claimWatcherRun(

--- a/scripts/dev-native.sh
+++ b/scripts/dev-native.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# Run the embedded Lobu stack natively (no Docker Compose).
+#
+# What runs:
+#   - owletto-backend (Hono + tsx watch) on :8787
+#   - embedded @lobu/gateway (in-process) with HTTP egress proxy on :8118
+#   - embedded workers (spawned as Bun subprocesses on demand)
+#   - Vite dev middleware for owletto-web on the same :8787 (HMR via WS)
+#
+# Requires, managed outside this script:
+#   - redis-server on localhost:6379 (e.g. `brew services start redis`)
+#   - remote Postgres reachable via DATABASE_URL in .env
+#
+# Skipped vs `make dev`: embeddings service (cloud backfill), openclaw, docker worker image.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+# --- Preflight -------------------------------------------------------------
+
+command -v bun >/dev/null || { echo "bun is required: curl -fsSL https://bun.sh/install | bash"; exit 1; }
+
+if [ ! -f .env ]; then
+  echo "❌ .env not found at $REPO_ROOT/.env"
+  echo "   Copy from .env.example or run: npx @lobu/cli@latest"
+  exit 1
+fi
+
+if [ ! -d packages/gateway/dist ] || [ ! -d packages/core/dist ]; then
+  echo "📦 Building workspace packages (one-time)…"
+  make build-packages
+fi
+
+if ! (exec 3<>/dev/tcp/127.0.0.1/6379) 2>/dev/null; then
+  echo "❌ redis not reachable on localhost:6379"
+  echo "   Start it with: brew services start redis"
+  exit 1
+fi
+exec 3<&- 2>/dev/null || true
+exec 3>&- 2>/dev/null || true
+
+# --- Env -------------------------------------------------------------------
+
+set -a
+# shellcheck disable=SC1091
+source .env
+set +a
+
+export NODE_ENV="${NODE_ENV:-development}"
+export ENVIRONMENT="${ENVIRONMENT:-development}"
+export HOST="${HOST:-127.0.0.1}"
+export PORT="${PORT:-8787}"
+export PUBLIC_WEB_URL="${PUBLIC_WEB_URL:-http://localhost:${PORT}}"
+export REDIS_URL="${REDIS_URL:-redis://localhost:6379}"
+export PGSSLMODE="${PGSSLMODE:-require}"
+export LOBU_PROVIDER_REGISTRY_PATH="${LOBU_PROVIDER_REGISTRY_PATH:-$REPO_ROOT/config/providers.json}"
+export LOBU_DEV_PROJECT_PATH="${LOBU_DEV_PROJECT_PATH:-$REPO_ROOT}"
+export LOBU_WORKSPACE_ROOT="${LOBU_WORKSPACE_ROOT:-$REPO_ROOT/workspaces}"
+
+mkdir -p "$LOBU_WORKSPACE_ROOT"
+
+if [ -z "${DATABASE_URL:-}" ]; then
+  echo "❌ DATABASE_URL not set in .env"
+  exit 1
+fi
+
+# --- Run -------------------------------------------------------------------
+
+echo "→ owletto-backend on http://${HOST}:${PORT}"
+echo "→ embedded gateway proxy on :8118"
+echo "→ Vite HMR in-process (same port)"
+echo ""
+
+exec bun --cwd packages/owletto-backend run dev


### PR DESCRIPTION
## Summary

Watcher runs dispatched to the embedded Lobu gateway never reached terminal state because nothing bridged the agent turn's completion back to Owletto's `runs` table. The 5-min heartbeat sweeper then marked them `timeout` and created retries — looping forever, even when the agent had actually completed the window successfully.

This PR replaces heartbeat-based liveness for watcher runs with **in-process completion tracking + durable DB correlation + a coarse backstop**. Heartbeats stay where they're genuinely needed (cross-network connector-sync / embed-backfill runs).

A second commit fixes a related embedded-mode ownership bug that surfaced during verification — the Redis-backed `AgentMetadataStore` is never hydrated from Postgres, so service-token-driven dispatch was rejected with 403 even though the caller DID own the agent.

## Design

**In-process completion, not heartbeats.** Embedded mode means the Owletto dispatcher and the Lobu gateway run in the same node process — there is no network partition to detect. A new `WatcherRunTracker` holds a `Map<messageId, handle>` keyed by the dispatched agent messageId. `dispatchWatcherRun` registers a handle before posting; `ApiResponseRenderer.handleCompletion` / `handleError` (the existing chokepoint for `platform: "api"` turns) call `tracker.resolve()` idempotently. The resolve callback writes the terminal state to `runs` in a single postgres transaction.

**Durable correlation survives tracker loss.** Two new columns:
- `runs.dispatched_message_id text UNIQUE` — persisted atomically with `status='running'`.
- `watcher_windows.run_id bigint REFERENCES runs(id)` — populated by `manage_watchers(complete_window)` from the existing `run_metadata.watcher_run_id` field.

This deletes the payload-based matching in `findWatcherWindowIdForPayload`, which could complete the *wrong* run on a retry (two attempts with identical payload shapes would race). Reconciler now joins `runs ← watcher_windows.run_id` — explicit, safe.

**Startup reconciliation, not unbounded sweeps.** On the first maintenance tick where this process acquires the existing `MAINTENANCE_LOCK_KEY` advisory lock, `resetOrphanedWatcherRuns` resets any `running`/`claimed` watcher rows to `pending` (crashed peer) — then the dispatcher picks them up again. Idempotent; the lock ensures singleton leadership so two replicas can't step on each other.

**Coarse backstop (2h).** `sweepStaleWatcherRuns` catches runs that somehow escaped both the tracker and startup reset (graceful shutdown mid-turn, redis message silently dropped, etc). TTL is intentionally generous so long LLM turns aren't killed; a genuinely stuck run eventually times out without blocking the schedule forever.

**Idempotent terminal transitions.** All completion/failure writes use `UPDATE … WHERE status IN ('running', 'claimed')` so duplicate events (e.g. both `handleCompletion` and a late reconcile) can't reopen a terminal state.

**Ownership lookup fallback.** The gateway's `requireAgentOwnership` previously asked the Redis `AgentMetadataStore` (empty in embedded mode) and denied on cache miss. Wrap it to fall through to the Postgres config store, preserving Redis-first behavior for standalone gateway.

**What stays.** `checkStalledExecutions` still runs for `run_type IN ('sync', 'embed_backfill')` — the owletto-worker daemon is out-of-process and genuinely needs heartbeat-based liveness. The watcher branch is removed.

## Files

- `db/migrations/20260424030000_add_watcher_run_correlation.sql` + embedded patch in `start-local.ts`
- `packages/gateway/src/watchers/run-tracker.ts` (new), `packages/gateway/src/api/response-renderer.ts`, `platform.ts`, `api/platform.ts`, `services/core-services.ts`, `index.ts`, `routes/public/agent.ts` (ownership fallback)
- `packages/owletto-backend/src/watchers/automation.ts` (dispatcher + reconciler rework, new `sweepStaleWatcherRuns` + `resetOrphanedWatcherRuns`)
- `packages/owletto-backend/src/scheduled/jobs.ts` (first-tick orphan reset)
- `packages/owletto-backend/src/scheduled/check-stalled-executions.ts` (watcher branch removed)
- `packages/owletto-backend/src/tools/admin/manage_watchers.ts` (persist `watcher_windows.run_id`)

## Test plan

- [x] `make build-packages` green
- [x] `bun run typecheck` green (root + all packages)
- [x] Local smoke: rebuilt image, restarted stack. Watcher 176 run 38247 dispatched and reached `status='completed'` in <60s with `dispatched_message_id` populated. Previously every run stalled at 5-min sweeper and retried forever.
- [x] Migration applies cleanly on existing DB (both fresh `db/migrations/*.sql` path and embedded `EMBEDDED_SCHEMA_PATCHES` path).
- [ ] Verify reconciler path (`watcher_windows.run_id` join) on a late-arriving window — not hit in smoke (agent did not produce a window for this cycle; lifecycle path closed via `handleCompletion` resolve, which is the intended fast path).
- [ ] Verify `resetOrphanedWatcherRuns` crash-recovery behavior — not hit in smoke (no process crash mid-turn).

## Risks / notes

- Multi-pod: `resetOrphanedWatcherRuns` resets *any* orphaned watcher row it finds, guarded by the existing `MAINTENANCE_LOCK_KEY` advisory lock (singleton across replicas). For a stricter multi-pod fencing model we'd want a `worker_instance_id` column — out of scope here.
- `manage_watchers(complete_window)` now persists `watcher_windows.run_id`. Existing rows stay NULL; the reconciler only matches rows with a non-null `run_id`, so historical windows are unaffected.
- The ownership fallback is scoped to the `requireAgentOwnership` resolver; standalone deploys still check Redis first.