### PR TITLE
fix(watchers): no-op complete_window when all events already analyzed

### DIFF
--- a/packages/owletto-backend/src/tools/admin/manage_watchers.ts
+++ b/packages/owletto-backend/src/tools/admin/manage_watchers.ts
@@ -1513,13 +1513,61 @@ async function handleCompleteWindow(
   }
 
   // ============================================
-  // STEP 5: Fail fast if no content (NO DB WRITES YET!)
+  // STEP 5: No-op if there's nothing to analyze
+  //
+  // Watchers can be triggered for periods where every candidate event was
+  // already consumed by an earlier window. Throwing here causes the agent
+  // loop to retry the same period indefinitely (Sentry: OWLETTO-Q). Treat
+  // it as a successful no-op completion: bump the schedule, mark the run
+  // completed, and return a zero-content result.
   // ============================================
   if (uniqueContentIds.length === 0) {
-    throw new Error(
-      'Cannot complete window: no NEW events found for the specified date range ' +
-        `(${window_start} to ${window_end}). ${skippedCount > 0 ? `All ${skippedCount} content items were already analyzed by other windows.` : ''}`
+    await sql.begin(async (tx) => {
+      const watcherScheduleRows = await tx`
+        SELECT schedule, next_run_at
+        FROM watchers
+        WHERE id = ${watcherId}
+        LIMIT 1
+      `;
+      const watcherSchedule = (watcherScheduleRows[0]?.schedule as string | null) ?? null;
+      const currentNextRunAt = (watcherScheduleRows[0]?.next_run_at as string | null) ?? null;
+      if (watcherSchedule) {
+        const nextRunBase = currentNextRunAt
+          ? new Date(Math.max(Date.now(), new Date(currentNextRunAt).getTime()))
+          : new Date();
+        await tx`
+          UPDATE watchers
+          SET next_run_at = ${nextRunAt(watcherSchedule, nextRunBase)}::timestamptz,
+              updated_at = NOW()
+          WHERE id = ${watcherId}
+        `;
+      }
+      if (watcherRunId && Number.isFinite(watcherRunId)) {
+        await tx`
+          UPDATE runs
+          SET status = 'completed',
+              completed_at = current_timestamp,
+              error_message = NULL
+          WHERE id = ${watcherRunId}
+            AND run_type = 'watcher'
+        `;
+      }
+    });
+
+    logger.info(
+      `[complete_window] No new content for watcher ${watcherId} (${window_start} - ${window_end}); ` +
+        `${skippedCount} item(s) already analyzed by prior windows. Marked as no-op completion.`
     );
+
+    return {
+      action: 'complete_window' as const,
+      watcher_id: String(watcherId),
+      window_id: 0,
+      window_start,
+      window_end,
+      content_linked: 0,
+      reaction_status: 'skipped' as const,
+    };
   }
 
   // ============================================

--- a/packages/owletto-backend/src/tools/admin/manage_watchers.ts
+++ b/packages/owletto-backend/src/tools/admin/manage_watchers.ts
@@ -1534,16 +1534,10 @@ async function handleCompleteWindow(
 
       if (tokenWindowId) {
         const windowResult = await tx`
-          UPDATE watcher_windows
-          SET
-            extracted_data = ${sql.json(cleanedExtractedData)},
-            content_analyzed = 0,
-            model_used = ${provenanceModel},
-            client_id = ${provenanceClientId},
-            run_metadata = ${sql.json(provenanceMetadata)},
-            created_at = COALESCE(created_at, NOW())
+          SELECT id, content_analyzed
+          FROM watcher_windows
           WHERE id = ${tokenWindowId} AND watcher_id = ${watcherId}
-          RETURNING id
+          LIMIT 1
         `;
         if (windowResult.length === 0) {
           throw new Error(
@@ -1552,18 +1546,7 @@ async function handleCompleteWindow(
           );
         }
         windowId = tokenWindowId;
-      } else {
-        const existingWindow = await tx`
-          SELECT id FROM watcher_windows
-          WHERE watcher_id = ${watcherId}
-            AND window_start = ${window_start}
-            AND window_end = ${window_end}
-            AND granularity = ${timeGranularity}
-          LIMIT 1
-        `;
-
-        if (existingWindow.length > 0) {
-          windowId = existingWindow[0].id as number;
+        if (Number(windowResult[0].content_analyzed ?? 0) === 0) {
           await tx`
             UPDATE watcher_windows
             SET extracted_data = ${sql.json(cleanedExtractedData)},
@@ -1574,6 +1557,31 @@ async function handleCompleteWindow(
                 created_at = COALESCE(created_at, NOW())
             WHERE id = ${windowId} AND watcher_id = ${watcherId}
           `;
+        }
+      } else {
+        const existingWindow = await tx`
+          SELECT id, content_analyzed FROM watcher_windows
+          WHERE watcher_id = ${watcherId}
+            AND window_start = ${window_start}
+            AND window_end = ${window_end}
+            AND granularity = ${timeGranularity}
+          LIMIT 1
+        `;
+
+        if (existingWindow.length > 0) {
+          windowId = existingWindow[0].id as number;
+          if (Number(existingWindow[0].content_analyzed ?? 0) === 0) {
+            await tx`
+              UPDATE watcher_windows
+              SET extracted_data = ${sql.json(cleanedExtractedData)},
+                  content_analyzed = 0,
+                  model_used = ${provenanceModel},
+                  client_id = ${provenanceClientId},
+                  run_metadata = ${sql.json(provenanceMetadata)},
+                  created_at = COALESCE(created_at, NOW())
+              WHERE id = ${windowId} AND watcher_id = ${watcherId}
+            `;
+          }
         } else {
           const newWindowId = await getNextNumericId(tx, 'watcher_windows');
           try {

--- a/packages/owletto-backend/src/tools/admin/manage_watchers.ts
+++ b/packages/owletto-backend/src/tools/admin/manage_watchers.ts
@@ -1513,45 +1513,138 @@ async function handleCompleteWindow(
   }
 
   // ============================================
-  // STEP 5: No-op if there's nothing to analyze
+  // STEP 5: Process extracted_data BEFORE any writes (in-memory)
+  // ============================================
+  const fieldsToStrip = getFieldsToStrip(classifiers);
+  const cleanedExtractedData = stripFields(extractedData, Array.from(fieldsToStrip));
+
+  // ============================================
+  // STEP 6: No-op if there's nothing to analyze
   //
   // Watchers can be triggered for periods where every candidate event was
   // already consumed by an earlier window. Throwing here causes the agent
   // loop to retry the same period indefinitely (Sentry: OWLETTO-Q). Treat
-  // it as a successful no-op completion: bump the schedule, mark the run
-  // completed, and return a zero-content result.
+  // it as a successful no-op completion, but persist a zero-content window
+  // so the scheduler has durable cursor progress and retries are idempotent.
   // ============================================
   if (uniqueContentIds.length === 0) {
-    await sql.begin(async (tx) => {
-      const watcherScheduleRows = await tx`
-        SELECT schedule, next_run_at
-        FROM watchers
-        WHERE id = ${watcherId}
-        LIMIT 1
-      `;
-      const watcherSchedule = (watcherScheduleRows[0]?.schedule as string | null) ?? null;
-      const currentNextRunAt = (watcherScheduleRows[0]?.next_run_at as string | null) ?? null;
-      if (watcherSchedule) {
-        const nextRunBase = currentNextRunAt
-          ? new Date(Math.max(Date.now(), new Date(currentNextRunAt).getTime()))
-          : new Date();
-        await tx`
-          UPDATE watchers
-          SET next_run_at = ${nextRunAt(watcherSchedule, nextRunBase)}::timestamptz,
-              updated_at = NOW()
-          WHERE id = ${watcherId}
+    const noOpResult = await sql.begin(async (tx) => {
+      let windowId: number;
+      let createdWindow = false;
+
+      if (tokenWindowId) {
+        const windowResult = await tx`
+          UPDATE watcher_windows
+          SET
+            extracted_data = ${sql.json(cleanedExtractedData)},
+            content_analyzed = 0,
+            model_used = ${provenanceModel},
+            client_id = ${provenanceClientId},
+            run_metadata = ${sql.json(provenanceMetadata)},
+            created_at = COALESCE(created_at, NOW())
+          WHERE id = ${tokenWindowId} AND watcher_id = ${watcherId}
+          RETURNING id
         `;
+        if (windowResult.length === 0) {
+          throw new Error(
+            `Window ${tokenWindowId} not found for watcher ${watcherId}. ` +
+              'The window may have been deleted. Get a fresh token from read_knowledge({ watcher_id: ... }).'
+          );
+        }
+        windowId = tokenWindowId;
+      } else {
+        const existingWindow = await tx`
+          SELECT id FROM watcher_windows
+          WHERE watcher_id = ${watcherId}
+            AND window_start = ${window_start}
+            AND window_end = ${window_end}
+            AND granularity = ${timeGranularity}
+          LIMIT 1
+        `;
+
+        if (existingWindow.length > 0) {
+          windowId = existingWindow[0].id as number;
+          await tx`
+            UPDATE watcher_windows
+            SET extracted_data = ${sql.json(cleanedExtractedData)},
+                content_analyzed = 0,
+                model_used = ${provenanceModel},
+                client_id = ${provenanceClientId},
+                run_metadata = ${sql.json(provenanceMetadata)},
+                created_at = COALESCE(created_at, NOW())
+            WHERE id = ${windowId} AND watcher_id = ${watcherId}
+          `;
+        } else {
+          const newWindowId = await getNextNumericId(tx, 'watcher_windows');
+          try {
+            await tx`
+              INSERT INTO watcher_windows (
+                id,
+                watcher_id, window_start, window_end, granularity,
+                extracted_data, content_analyzed, model_used, client_id, run_metadata, created_at
+              ) VALUES (
+                ${newWindowId},
+                ${watcherId}, ${window_start}, ${window_end}, ${timeGranularity},
+                ${sql.json(cleanedExtractedData)}, 0, ${provenanceModel}, ${provenanceClientId}, ${sql.json(provenanceMetadata)}, NOW()
+              )
+            `;
+            windowId = newWindowId;
+            createdWindow = true;
+          } catch (err: any) {
+            if (err?.code !== '23505') throw err;
+            const racedWindow = await tx`
+              SELECT id FROM watcher_windows
+              WHERE watcher_id = ${watcherId}
+                AND window_start = ${window_start}
+                AND window_end = ${window_end}
+                AND granularity = ${timeGranularity}
+              LIMIT 1
+            `;
+            if (racedWindow.length === 0) throw err;
+            windowId = racedWindow[0].id as number;
+          }
+        }
       }
+
+      let completedRun = false;
       if (watcherRunId && Number.isFinite(watcherRunId)) {
-        await tx`
+        const completedRows = await tx`
           UPDATE runs
           SET status = 'completed',
+              window_id = ${windowId},
               completed_at = current_timestamp,
               error_message = NULL
           WHERE id = ${watcherRunId}
             AND run_type = 'watcher'
+            AND status IN ('running', 'claimed')
+          RETURNING id
         `;
+        completedRun = completedRows.length > 0;
       }
+
+      if (createdWindow || completedRun) {
+        const watcherScheduleRows = await tx`
+          SELECT schedule, next_run_at
+          FROM watchers
+          WHERE id = ${watcherId}
+          LIMIT 1
+        `;
+        const watcherSchedule = (watcherScheduleRows[0]?.schedule as string | null) ?? null;
+        const currentNextRunAt = (watcherScheduleRows[0]?.next_run_at as string | null) ?? null;
+        if (watcherSchedule) {
+          const nextRunBase = currentNextRunAt
+            ? new Date(Math.max(Date.now(), new Date(currentNextRunAt).getTime()))
+            : new Date();
+          await tx`
+            UPDATE watchers
+            SET next_run_at = ${nextRunAt(watcherSchedule, nextRunBase)}::timestamptz,
+                updated_at = NOW()
+            WHERE id = ${watcherId}
+          `;
+        }
+      }
+
+      return { windowId };
     });
 
     logger.info(
@@ -1562,19 +1655,13 @@ async function handleCompleteWindow(
     return {
       action: 'complete_window' as const,
       watcher_id: String(watcherId),
-      window_id: 0,
+      window_id: noOpResult.windowId,
       window_start,
       window_end,
       content_linked: 0,
       reaction_status: 'skipped' as const,
     };
   }
-
-  // ============================================
-  // STEP 6: Process extracted_data BEFORE any writes (in-memory)
-  // ============================================
-  const fieldsToStrip = getFieldsToStrip(classifiers);
-  const cleanedExtractedData = stripFields(extractedData, Array.from(fieldsToStrip));
 
   // ============================================
   // STEP 7-9: Wrap all DB operations in a transaction

--- a/packages/owletto-backend/src/utils/window-utils.ts
+++ b/packages/owletto-backend/src/utils/window-utils.ts
@@ -30,12 +30,14 @@ export async function computePendingWindow(
   watcherId: number,
   granularity: WatcherTimeGranularity
 ): Promise<WindowDates> {
-  // Find the last completed window for this watcher
+  // Find the last completed leaf window for this watcher. Zero-content
+  // windows are durable cursor progress too; otherwise empty periods can be
+  // reprocessed forever.
   const lastWindow = await sql`
     SELECT window_end
     FROM watcher_windows
     WHERE watcher_id = ${watcherId}
-      AND content_analyzed > 0
+      AND COALESCE(is_rollup, false) = false
     ORDER BY window_end DESC
     LIMIT 1
   `;


### PR DESCRIPTION
## Summary
- When `complete_window` was called with `extracted_data` but every candidate event had already been consumed by a prior window, the backend threw a 500. The agent loop retried the same period indefinitely (10+ consecutive failures observed in the wild — see Sentry).
- Convert that case to a successful no-op: bump `next_run_at`, mark the run completed, and return a zero-content result. No window row is written.

Fixes OWLETTO-Q

## Test plan
- [x] `bunx tsc --noEmit -p packages/owletto-backend/tsconfig.json`
- [ ] Trigger a watcher whose period contains no new content (e.g. re-run an already-completed window) and confirm the run lands as `completed` with `content_linked: 0` instead of 500