### PR TITLE
fix(resolve_path): return 4xx instead of throwing on client-input errors

### DIFF
--- a/packages/owletto-backend/src/rest-api.ts
+++ b/packages/owletto-backend/src/rest-api.ts
@@ -24,7 +24,7 @@ import { executeTool, extractAuthContext, toToolContext } from './tools/execute'
 import { getContent } from './tools/get_content';
 import { getWatcher } from './tools/get_watchers';
 import { getTool } from './tools/registry';
-import { errorMessage } from './utils/errors';
+import { ToolUserError, errorMessage } from './utils/errors';
 import { toJsonSafe } from './utils/json';
 import logger from './utils/logger';
 import { ACTIVE_RUN_STATUSES, runStatusLiteral } from './utils/run-statuses';
@@ -227,6 +227,9 @@ export async function restToolProxy(
     const result = await executeTool(toolName, args, c.env, authCtx);
     return c.json(toJsonSafe(result));
   } catch (error) {
+    if (error instanceof ToolUserError) {
+      return c.json({ error: error.message }, error.httpStatus as 400 | 404);
+    }
     return c.json({ error: errorMessage(error) }, 400);
   }
 }

--- a/packages/owletto-backend/src/sentry.ts
+++ b/packages/owletto-backend/src/sentry.ts
@@ -6,6 +6,7 @@
  */
 
 import * as Sentry from '@sentry/node';
+import { ToolUserError } from './utils/errors';
 
 /**
  * Track an MCP tool call with Sentry
@@ -39,25 +40,29 @@ export async function trackMCPToolCall<T>(
       } catch (error: unknown) {
         const errorMessage = error instanceof Error ? error.message : String(error);
 
-        // Capture error with full context
-        Sentry.captureException(error, {
-          tags: {
-            tool_name: toolName,
-            status: 'error',
-          },
-          extra: {
-            arguments: sanitizeArguments(args),
-            error_message: errorMessage,
-          },
-        });
+        // 4xx-class outcomes raised by the tool itself (bad path, not found,
+        // schema validation) aren't operational errors — annotate the span
+        // but skip Sentry capture to keep the alert feed clean.
+        const isUserError = error instanceof ToolUserError;
 
-        // Set error attributes on span
+        if (!isUserError) {
+          Sentry.captureException(error, {
+            tags: {
+              tool_name: toolName,
+              status: 'error',
+            },
+            extra: {
+              arguments: sanitizeArguments(args),
+              error_message: errorMessage,
+            },
+          });
+        }
+
         span?.setAttributes({
-          'mcp.tool.status': 'error',
+          'mcp.tool.status': isUserError ? 'user_error' : 'error',
           'mcp.tool.error': errorMessage,
         });
 
-        // Re-throw the error
         throw error;
       }
     }

--- a/packages/owletto-backend/src/tools/resolve_path.ts
+++ b/packages/owletto-backend/src/tools/resolve_path.ts
@@ -17,6 +17,7 @@ import {
   type DataSourceInput,
   executeDataSources,
 } from '../utils/execute-data-sources';
+import { ToolUserError } from '../utils/errors';
 import { resolveMemberSchemaFieldsFromSchema } from '../utils/member-entity-type';
 import { stripMemberEmailsFromRows } from '../utils/member-redaction';
 import { RESERVED_PATHS } from '../utils/reserved';
@@ -277,7 +278,7 @@ async function _resolvePath(
     .filter(Boolean);
 
   if (segments.length === 0) {
-    throw new Error('Path must include an owner');
+    throw new ToolUserError('Path must include an owner', 400);
   }
 
   const ownerRaw = segments[0];
@@ -285,7 +286,7 @@ async function _resolvePath(
   const ownerSlug = isUserSpace ? ownerRaw.slice(1) : ownerRaw;
 
   if (RESERVED_PATHS.includes(ownerSlug)) {
-    throw new Error(`Owner '${ownerSlug}' is reserved`);
+    throw new ToolUserError(`Owner '${ownerSlug}' is reserved`, 400);
   }
 
   const pgSql = createDbClientFromEnv(env);
@@ -296,7 +297,10 @@ async function _resolvePath(
   );
 
   if (!resolved) {
-    throw new Error(`${isUserSpace ? 'User' : 'Organization'} '${ownerSlug}' not found`);
+    throw new ToolUserError(
+      `${isUserSpace ? 'User' : 'Organization'} '${ownerSlug}' not found`,
+      404
+    );
   }
 
   const workspace: ResolvedWorkspace = {
@@ -319,7 +323,13 @@ async function _resolvePath(
   entitySegments = remaining;
 
   if (entitySegments.length % 2 !== 0) {
-    throw new Error('Entity path must be in [type]/[slug] pairs');
+    // Frontend routes like /:owner/agents/:slug/settings have a UI subroute
+    // appended after the entity tail. Treat the malformed-pair case as a
+    // not-found so the client can fall back without surfacing a 500.
+    throw new ToolUserError(
+      `Entity path '${normalized}' is not resolvable: expected [type]/[slug] pairs after the owner`,
+      404
+    );
   }
 
   const parsedSegments: Array<{ entity_type: string; slug: string }> = [];
@@ -331,7 +341,7 @@ async function _resolvePath(
   }
 
   if (workspace.type !== 'organization') {
-    throw new Error('Entity paths require an organization namespace');
+    throw new ToolUserError('Entity paths require an organization namespace', 400);
   }
 
   let parentId: number | null = null;
@@ -358,7 +368,10 @@ async function _resolvePath(
       `);
 
       if (row.length === 0) {
-        throw new Error(`Entity not found for ${segment.entity_type}/${segment.slug}`);
+        throw new ToolUserError(
+          `Entity not found for ${segment.entity_type}/${segment.slug}`,
+          404
+        );
       }
 
       const entityRow = row[0] as unknown as ResolvedEntityRow;
@@ -460,8 +473,9 @@ async function _resolvePath(
     let processedEntityTabs = await processTabsDataSources(mergedTabs, entityDataCtx, sql);
     let redactedTemplateData = entityTemplateData;
     if (entityRow.entity_type === '$member' && !ctx.memberRole) {
-      throw new Error(
-        'Member details are only visible to members of this workspace. Join the workspace to see members.'
+      throw new ToolUserError(
+        'Member details are only visible to members of this workspace. Join the workspace to see members.',
+        403
       );
     }
     const rawEntityMetadata = entityRow.metadata ?? {};

--- a/packages/owletto-backend/src/tools/resolve_path.ts
+++ b/packages/owletto-backend/src/tools/resolve_path.ts
@@ -416,7 +416,10 @@ async function _resolvePath(
       `);
 
     if (row.length === 0) {
-      throw new Error(`Entity not found for ${segment.entity_type}/${segment.slug}`);
+      throw new ToolUserError(
+        `Entity not found for ${segment.entity_type}/${segment.slug}`,
+        404
+      );
     }
 
     const entityRow = row[0] as unknown as ResolvedEntityRow & {

--- a/packages/owletto-backend/src/utils/errors.ts
+++ b/packages/owletto-backend/src/utils/errors.ts
@@ -1,3 +1,19 @@
 export function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
+
+/**
+ * Error class for client-input failures inside MCP/REST tools (bad path,
+ * not-found, validation errors). Carries an HTTP status so the REST proxy
+ * can return the right code, and is recognised by `trackMCPToolCall` to
+ * avoid noisy Sentry alerts on 4xx-class outcomes.
+ */
+export class ToolUserError extends Error {
+  readonly httpStatus: number;
+
+  constructor(message: string, httpStatus = 400) {
+    super(message);
+    this.name = 'ToolUserError';
+    this.httpStatus = httpStatus;
+  }
+}


### PR DESCRIPTION
## Summary
- Add `ToolUserError` for client-input failures (bad path, not found, validation). Carries an HTTP status; the REST proxy honors it; `trackMCPToolCall` skips Sentry capture for these so 4xx outcomes don't pollute the alert feed.
- Convert all client-input throws in `resolve_path` to `ToolUserError`. The frequent 500 from frontend UI sub-routes (`/:owner/agents/:slug/settings`) now returns 404.

Fixes OWLETTO-S

## Test plan
- [x] `bunx tsc --noEmit -p packages/owletto-backend/tsconfig.json`
- [ ] Hit `POST /api/<org>/resolve_path` with `path: "/<org>/agents/<slug>/settings"` and confirm a 404 instead of 500
- [ ] Confirm a happy-path resolve still returns 200