### PR TITLE
fix(events): tolerate stale client_id refs on insert + relax FK

### DIFF
--- a/db/migrations/20260424130000_relax_events_client_id_fk.sql
+++ b/db/migrations/20260424130000_relax_events_client_id_fk.sql
@@ -9,22 +9,39 @@
 -- Match the relaxation already applied to other event-side FKs
 -- (connection_id, feed_id, run_id) and let stale client references reset
 -- to NULL instead of breaking inserts.
+--
+-- Add and validate the replacement constraint before the quick final swap so
+-- existing traffic stays protected and the ACCESS EXCLUSIVE window is short.
+
+ALTER TABLE public.events
+    ADD CONSTRAINT events_client_id_fkey_v2
+    FOREIGN KEY (client_id)
+    REFERENCES public.oauth_clients(id)
+    ON DELETE SET NULL
+    NOT VALID;
+
+ALTER TABLE public.events
+    VALIDATE CONSTRAINT events_client_id_fkey_v2;
 
 ALTER TABLE public.events
     DROP CONSTRAINT IF EXISTS events_client_id_fkey;
 
 ALTER TABLE public.events
-    ADD CONSTRAINT events_client_id_fkey
-    FOREIGN KEY (client_id)
-    REFERENCES public.oauth_clients(id)
-    ON DELETE SET NULL;
+    RENAME CONSTRAINT events_client_id_fkey_v2 TO events_client_id_fkey;
 
 -- migrate:down
 
 ALTER TABLE public.events
+    ADD CONSTRAINT events_client_id_fkey_v2
+    FOREIGN KEY (client_id)
+    REFERENCES public.oauth_clients(id)
+    NOT VALID;
+
+ALTER TABLE public.events
+    VALIDATE CONSTRAINT events_client_id_fkey_v2;
+
+ALTER TABLE public.events
     DROP CONSTRAINT IF EXISTS events_client_id_fkey;
 
 ALTER TABLE public.events
-    ADD CONSTRAINT events_client_id_fkey
-    FOREIGN KEY (client_id)
-    REFERENCES public.oauth_clients(id);
+    RENAME CONSTRAINT events_client_id_fkey_v2 TO events_client_id_fkey;

--- a/db/migrations/20260424130000_relax_events_client_id_fk.sql
+++ b/db/migrations/20260424130000_relax_events_client_id_fk.sql
@@ -1,0 +1,30 @@
+-- migrate:up
+
+-- The events table tags each row with the OAuth client that produced it via
+-- `events.client_id -> oauth_clients.id`. The original FK had no ON DELETE
+-- behaviour, so when an oauth_client row was removed (manual cleanup, e2e
+-- teardown, expired registration) any in-flight token still issuing inserts
+-- failed with `events_client_id_fkey` violations (Sentry: OWLETTO-34).
+--
+-- Match the relaxation already applied to other event-side FKs
+-- (connection_id, feed_id, run_id) and let stale client references reset
+-- to NULL instead of breaking inserts.
+
+ALTER TABLE public.events
+    DROP CONSTRAINT IF EXISTS events_client_id_fkey;
+
+ALTER TABLE public.events
+    ADD CONSTRAINT events_client_id_fkey
+    FOREIGN KEY (client_id)
+    REFERENCES public.oauth_clients(id)
+    ON DELETE SET NULL;
+
+-- migrate:down
+
+ALTER TABLE public.events
+    DROP CONSTRAINT IF EXISTS events_client_id_fkey;
+
+ALTER TABLE public.events
+    ADD CONSTRAINT events_client_id_fkey
+    FOREIGN KEY (client_id)
+    REFERENCES public.oauth_clients(id);

--- a/packages/owletto-backend/src/utils/insert-event.ts
+++ b/packages/owletto-backend/src/utils/insert-event.ts
@@ -169,6 +169,21 @@ async function upsertEmbedding(eventId: number, embedding?: number[] | null): Pr
   `;
 }
 
+function isEventsClientIdForeignKeyViolation(error: unknown): boolean {
+  const err = error as {
+    code?: unknown;
+    constraint?: unknown;
+    constraint_name?: unknown;
+    message?: unknown;
+  };
+  if (err?.code !== '23503') return false;
+  return (
+    err.constraint === 'events_client_id_fkey' ||
+    err.constraint_name === 'events_client_id_fkey' ||
+    (typeof err.message === 'string' && err.message.includes('events_client_id_fkey'))
+  );
+}
+
 /**
  * Insert a single event into the events table.
  *
@@ -184,22 +199,7 @@ export async function insertEvent(
   const entityIdsValue = params.entityIds.length > 0 ? `{${params.entityIds.join(',')}}` : null;
   let supersedesEventId = params.supersedesEventId ?? null;
 
-  // `events.client_id` is a soft tag, but the FK to `oauth_clients` rejects
-  // inserts when the referenced row has been removed (manual cleanup, e2e
-  // teardown, expired registration) while a token is still in flight. Drop
-  // the value to NULL when the referenced client no longer exists so the
-  // event still lands. (Sentry: OWLETTO-34.)
-  let clientId = params.clientId ?? null;
-  if (clientId) {
-    const exists = await sql`SELECT 1 FROM oauth_clients WHERE id = ${clientId} LIMIT 1`;
-    if (exists.length === 0) {
-      logger.warn(
-        { clientId },
-        '[insert-event] dropping client_id — referenced oauth_clients row no longer exists'
-      );
-      clientId = null;
-    }
-  }
+  const requestedClientId = params.clientId ?? null;
 
   if (options?.onConflictUpdate) {
     const existing = await findCurrentEventByOrigin(sql, params);
@@ -218,7 +218,7 @@ export async function insertEvent(
     }
   }
 
-  const result = await sql`
+  const insertWithClientId = (clientId: string | null) => sql`
     INSERT INTO events (
       entity_ids, organization_id, source_id, origin_id, title,
       payload_type, payload_text, payload_data, payload_template, attachments, metadata,
@@ -263,6 +263,20 @@ export async function insertEvent(
     )
     RETURNING id, entity_ids, origin_id, title, semantic_type, created_at
   `;
+
+  let result: Awaited<ReturnType<typeof insertWithClientId>>;
+  try {
+    result = await insertWithClientId(requestedClientId);
+  } catch (error) {
+    if (!requestedClientId || !isEventsClientIdForeignKeyViolation(error)) {
+      throw error;
+    }
+    logger.warn(
+      { clientId: requestedClientId },
+      '[insert-event] retrying insert with client_id NULL — referenced oauth_clients row no longer exists'
+    );
+    result = await insertWithClientId(null);
+  }
 
   const inserted = result[0] as InsertedEvent;
   await upsertEmbedding(inserted.id, params.embedding);

--- a/packages/owletto-backend/src/utils/insert-event.ts
+++ b/packages/owletto-backend/src/utils/insert-event.ts
@@ -184,6 +184,23 @@ export async function insertEvent(
   const entityIdsValue = params.entityIds.length > 0 ? `{${params.entityIds.join(',')}}` : null;
   let supersedesEventId = params.supersedesEventId ?? null;
 
+  // `events.client_id` is a soft tag, but the FK to `oauth_clients` rejects
+  // inserts when the referenced row has been removed (manual cleanup, e2e
+  // teardown, expired registration) while a token is still in flight. Drop
+  // the value to NULL when the referenced client no longer exists so the
+  // event still lands. (Sentry: OWLETTO-34.)
+  let clientId = params.clientId ?? null;
+  if (clientId) {
+    const exists = await sql`SELECT 1 FROM oauth_clients WHERE id = ${clientId} LIMIT 1`;
+    if (exists.length === 0) {
+      logger.warn(
+        { clientId },
+        '[insert-event] dropping client_id — referenced oauth_clients row no longer exists'
+      );
+      clientId = null;
+    }
+  }
+
   if (options?.onConflictUpdate) {
     const existing = await findCurrentEventByOrigin(sql, params);
     if (existing) {
@@ -234,7 +251,7 @@ export async function insertEvent(
       ${params.feedId ?? null},
       ${params.runId ?? null},
       ${params.semanticType},
-      ${params.clientId ?? null},
+      ${clientId},
       ${params.createdBy ?? null},
       ${params.interactionType ?? 'none'},
       ${params.interactionStatus ?? null},


### PR DESCRIPTION
## Summary
- `events.client_id -> oauth_clients(id)` had no `ON DELETE` behaviour, so any insert whose `client_id` no longer existed (cleanup, e2e teardown, registration expiry) failed with `events_client_id_fkey` violations and the tool call 500'd.
- App: `insertEvent` now retries with `client_id = NULL` (and logs a warning) when the insert raises `23503 events_client_id_fkey`. Atomic — no TOCTOU window.
- DB: convert the FK to `ON DELETE SET NULL`, matching the other event-side FKs (`connection_id`, `feed_id`, `run_id`). Uses `ADD NOT VALID` + `VALIDATE` + swap to keep the ACCESS EXCLUSIVE window short.

Fixes OWLETTO-34

## Test plan
- [x] `bunx tsc --noEmit -p packages/owletto-backend/tsconfig.json`
- [ ] Apply migration to staging DB, then call `save_knowledge` with a `client_id` that's been deleted from `oauth_clients` and confirm the event lands with `client_id = NULL` (warning log present)