### PR TITLE
fix(sentry): disable NodeSystemError integration to unblock node v24 builds

### DIFF
--- a/packages/owletto-backend/src/instrument.ts
+++ b/packages/owletto-backend/src/instrument.ts
@@ -20,5 +20,11 @@ if (dsn) {
     dsn,
     environment: process.env.ENVIRONMENT || 'production',
     tracesSampleRate: isDev ? 1.0 : 0.1,
+    // The NodeSystemError integration calls util.getSystemErrorMap(), which
+    // some Node builds we run under (notably v24.x in our app image) don't
+    // expose. The integration itself then throws inside the event processor
+    // and the underlying exception never reaches Sentry. Drop it. (Sentry:
+    // OWLETTO-36.)
+    integrations: (defaults) => defaults.filter((i) => i.name !== 'NodeSystemError'),
   });
 }


### PR DESCRIPTION
## Summary
The default `NodeSystemError` Sentry integration calls `util.getSystemErrorMap()`. The Node build in our app image (v24.x) doesn't expose that function, so the integration's processor throws inside the event-processing pipeline and the underlying exception never makes it to Sentry. Filter it out at init time.

Fixes OWLETTO-36

## Test plan
- [x] `bunx tsc --noEmit -p packages/owletto-backend/tsconfig.json`
- [ ] Deploy to dev and trigger an unhandled exception; confirm it lands in Sentry without the `getSystemErrorMap is not a function` follow-up