### PR TITLE
perf(auth): consolidate better-auth onto shared postgres.js pool

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -140,6 +140,8 @@
         "handlebars": "^4.7.9",
         "hono": "^4.10.4",
         "hono-pino": "^0.10.3",
+        "kysely": "^0.28.0",
+        "kysely-postgres-js": "^2.0.0",
         "node-sql-parser": "^5.4.0",
         "pg": "^8.16.3",
         "pino": "^10.1.0",
@@ -2621,6 +2623,8 @@
     "ky": ["ky@1.14.3", "", {}, "sha512-9zy9lkjac+TR1c2tG+mkNSVlyOpInnWdSMiue4F+kq8TwJSgv6o8jhLRg8Ho6SnZ9wOYUq/yozts9qQCfk7bIw=="],
 
     "kysely": ["kysely@0.28.16", "", {}, "sha512-3i5pmOiZvMDj00qhrIVbH0AnioVTx22DMP7Vn5At4yJO46iy+FM8Y/g61ltenLVSo3fiO8h8Q3QOFgf/gQ72ww=="],
+
+    "kysely-postgres-js": ["kysely-postgres-js@2.0.0", "", { "peerDependencies": { "kysely": ">= 0.24.0 < 1", "postgres": ">= 3.4.0 < 4" } }, "sha512-R1tWx6/x3tSatWvsmbHJxpBZYhNNxcnMw52QzZaHKg7ZOWtHib4iZyEaw4gb2hNKVctWQ3jfMxZT/ZaEMK6kBQ=="],
 
     "leac": ["leac@0.6.0", "", {}, "sha512-y+SqErxb8h7nE/fiEX07jsbuhrpO9lL8eca7/Y1nuWV2moNlXhyd59iDGcRf6moVyDMbmTNzL40SUyrFU/yDpg=="],
 

--- a/packages/owletto-backend/package.json
+++ b/packages/owletto-backend/package.json
@@ -38,6 +38,8 @@
     "handlebars": "^4.7.9",
     "hono": "^4.10.4",
     "hono-pino": "^0.10.3",
+    "kysely": "^0.28.0",
+    "kysely-postgres-js": "^2.0.0",
     "node-sql-parser": "^5.4.0",
     "pg": "^8.16.3",
     "pino": "^10.1.0",

--- a/packages/owletto-backend/src/auth/index.tsx
+++ b/packages/owletto-backend/src/auth/index.tsx
@@ -1,8 +1,8 @@
 import { createHash } from 'node:crypto';
 import { betterAuth } from 'better-auth';
 import { magicLink, organization, phoneNumber } from 'better-auth/plugins';
-import { Pool } from 'pg';
 import type { Env } from '../index';
+import { getAuthDialect, getDb } from '../db/client';
 import { sendTransactionalEmail } from '../email/send';
 import { InvitationEmail, invitationSubject } from '../email/templates/invitation';
 import { MagicLinkEmail, magicLinkSubject } from '../email/templates/magic-link';
@@ -24,22 +24,6 @@ import {
   resolveLoginProviderCredentials,
   resolveRequestOrganizationId,
 } from './config';
-
-let authPool: Pool | null = null;
-function getAuthPool(connectionString: string): Pool {
-  if (!authPool) {
-    const ssl =
-      process.env.PGSSLMODE === 'require' || process.env.PGSSLMODE === 'prefer'
-        ? { rejectUnauthorized: false }
-        : undefined;
-    authPool = new Pool({
-      connectionString,
-      max: parseInt(process.env.AUTH_DB_POOL_MAX || '8', 10),
-      ssl,
-    });
-  }
-  return authPool;
-}
 
 function gravatarUrl(email: string): string {
   const hash = createHash('md5').update(email.trim().toLowerCase()).digest('hex');
@@ -64,7 +48,6 @@ export async function createAuth(env: Env, request?: Request) {
     return cached;
   }
   const authConfig = await getAuthConfigFromEnv(env, { organizationId, request });
-  const pool = getAuthPool(env.DATABASE_URL!);
   const runtimeNodeEnv = env.NODE_ENV || process.env.NODE_ENV || 'development';
 
   const effectiveOrgId = organizationId ?? (await resolveDefaultOrganizationId());
@@ -144,7 +127,7 @@ export async function createAuth(env: Env, request?: Request) {
 
   const auth = betterAuth({
     ...(env.BETTER_AUTH_SECRET ? { secret: env.BETTER_AUTH_SECRET } : {}),
-    database: pool,
+    database: { dialect: getAuthDialect(), type: 'postgres' },
     baseURL: resolveBaseUrl({ request }),
     basePath: '/api/auth',
 
@@ -303,10 +286,11 @@ export async function createAuth(env: Env, request?: Request) {
 
           // Also send in-app notification if user already exists
           try {
-            const userRows = await pool.query('SELECT id FROM "user" WHERE email = $1 LIMIT 1', [
-              email,
-            ]);
-            const userId = userRows.rows[0]?.id;
+            const sql = getDb();
+            const userRows = await sql<{ id: string }>`
+              SELECT id FROM "user" WHERE email = ${email} LIMIT 1
+            `;
+            const userId = userRows[0]?.id;
             if (userId) {
               await notifyInvitationReceived({ orgId, userId, orgName, inviterName });
             }

--- a/packages/owletto-backend/src/db/client.ts
+++ b/packages/owletto-backend/src/db/client.ts
@@ -5,6 +5,7 @@
  * for creating additional connections when needed.
  */
 
+import { PostgresJSDialect } from 'kysely-postgres-js';
 import postgres from 'postgres';
 import type { Env } from '../index';
 import logger from '../utils/logger';
@@ -66,8 +67,17 @@ function createDbClient(connectionString: string, maxConnections?: number): DbCl
     : {};
 
   const rawClient = postgres(connectionString, {
-    max: maxConnections ?? parseInt(process.env.DB_POOL_MAX || '10', 10),
-    idle_timeout: 20,
+    max: maxConnections ?? parseInt(process.env.DB_POOL_MAX || '20', 10),
+    // Keep connections forever client-side. Postgres handles eviction via its
+    // own idle/lifetime settings; recycling every 20s on the client side
+    // forces every spotty-traffic burst to pay a ~1s TCP+TLS handshake.
+    idle_timeout: 0,
+    // Cap connection lifetime so long-lived sockets survive a finite duration
+    // (defends against PG-side state drift, certificate rotations, etc.).
+    max_lifetime: 60 * 30,
+    connection: {
+      application_name: 'owletto-backend',
+    },
     fetch_types: false,
     ...embeddedProtocolOptions,
     transform: {
@@ -182,4 +192,16 @@ export async function closeDbSingleton(): Promise<void> {
     await dbSingleton.end();
   }
   dbSingleton = null;
+}
+
+/**
+ * Kysely dialect bound to the singleton postgres.js client. Used by better-auth
+ * so that auth queries share the same connection pool as the rest of the app
+ * instead of opening a second pg.Pool with its own (cold-prone) connections.
+ */
+export function getAuthDialect(): PostgresJSDialect {
+  // postgres.js's Sql client is a callable; our DbClient interface narrows it,
+  // but the runtime object exposes everything PostgresJSDialect needs.
+  const sql = getDb() as unknown as ConstructorParameters<typeof PostgresJSDialect>[0]['postgres'];
+  return new PostgresJSDialect({ postgres: sql });
 }

--- a/packages/owletto-backend/src/db/client.ts
+++ b/packages/owletto-backend/src/db/client.ts
@@ -6,7 +6,7 @@
  */
 
 import { PostgresJSDialect } from 'kysely-postgres-js';
-import postgres from 'postgres';
+import postgres, { type Sql } from 'postgres';
 import type { Env } from '../index';
 import logger from '../utils/logger';
 
@@ -60,7 +60,15 @@ const PG_OID_JSONB = 3802;
 // PostgreSQL client factory
 // =========================================================
 
-function createDbClient(connectionString: string, maxConnections?: number): DbClient {
+interface CreatedDbClient {
+  /** Client used by application code; in pglite mode this is queue-serialized. */
+  wrapped: DbClient;
+  /** Raw postgres.js Sql client. Bypasses the serialization queue — only safe
+   *  for callers that own their own connection (e.g. Kysely via reserve()). */
+  raw: Sql;
+}
+
+function createDbClient(connectionString: string, maxConnections?: number): CreatedDbClient {
   const embeddedCompatMode = process.env.OWLETTO_DISABLE_PREPARE === '1';
   const embeddedProtocolOptions = embeddedCompatMode
     ? ({ max_pipeline: 1, prepare: false } as Record<string, unknown>)
@@ -116,13 +124,15 @@ function createDbClient(connectionString: string, maxConnections?: number): DbCl
         serialize: (value: number) => String(value),
       },
     },
-  }) as unknown as DbClient;
+  });
+
+  const dbClient = rawClient as unknown as DbClient;
 
   if (!embeddedCompatMode) {
-    return rawClient;
+    return { wrapped: dbClient, raw: rawClient };
   }
 
-  return createSerializedClient(rawClient);
+  return { wrapped: createSerializedClient(dbClient), raw: rawClient };
 }
 
 function createSerializedClient(client: DbClient): DbClient {
@@ -166,21 +176,27 @@ export function createDbClientFromEnv(_env: Env): DbClient {
 // =========================================================
 
 let dbSingleton: DbClient | null = null;
+let rawDbSingleton: Sql | null = null;
+
+function ensureSingleton(): void {
+  if (dbSingleton) return;
+  const url = process.env.DATABASE_URL;
+  if (!url) {
+    throw new Error('DATABASE_URL is required');
+  }
+  const created = createDbClient(url);
+  dbSingleton = created.wrapped;
+  rawDbSingleton = created.raw;
+  logger.info('[DB] PostgreSQL singleton pool created');
+}
 
 /**
  * Get the singleton PostgreSQL client.
  * Lazily created from DATABASE_URL on first call.
  */
 export function getDb(): DbClient {
-  if (!dbSingleton) {
-    const url = process.env.DATABASE_URL;
-    if (!url) {
-      throw new Error('DATABASE_URL is required');
-    }
-    dbSingleton = createDbClient(url);
-    logger.info('[DB] PostgreSQL singleton pool created');
-  }
-  return dbSingleton;
+  ensureSingleton();
+  return dbSingleton as DbClient;
 }
 
 /**
@@ -188,20 +204,30 @@ export function getDb(): DbClient {
  * Primarily used by tests that need strict connection handoff between setup and workers.
  */
 export async function closeDbSingleton(): Promise<void> {
-  if (dbSingleton?.end) {
+  if (rawDbSingleton?.end) {
+    await rawDbSingleton.end();
+  } else if (dbSingleton?.end) {
     await dbSingleton.end();
   }
   dbSingleton = null;
+  rawDbSingleton = null;
 }
 
 /**
  * Kysely dialect bound to the singleton postgres.js client. Used by better-auth
  * so that auth queries share the same connection pool as the rest of the app
  * instead of opening a second pg.Pool with its own (cold-prone) connections.
+ *
+ * Uses the raw (un-wrapped) postgres.js client because PostgresJSDialect calls
+ * sql.reserve() to acquire a dedicated connection — a code path the in-process
+ * pglite serialization wrapper doesn't proxy. This matches the pre-refactor
+ * behavior where better-auth ran on its own pg.Pool entirely outside the
+ * wrapper, so pglite tests that exercise auth retain their existing semantics.
  */
 export function getAuthDialect(): PostgresJSDialect {
-  // postgres.js's Sql client is a callable; our DbClient interface narrows it,
-  // but the runtime object exposes everything PostgresJSDialect needs.
-  const sql = getDb() as unknown as ConstructorParameters<typeof PostgresJSDialect>[0]['postgres'];
-  return new PostgresJSDialect({ postgres: sql });
+  ensureSingleton();
+  if (!rawDbSingleton) {
+    throw new Error('rawDbSingleton was not initialized');
+  }
+  return new PostgresJSDialect({ postgres: rawDbSingleton });
 }


### PR DESCRIPTION
## Summary

Better-auth was opening its own `pg.Pool` (max 8, default pg-pool 10s idle timeout, no TCP keepalive). With the loading page's spotty traffic that pool kept going cold — Sentry showed `pg.connect` at p50 ~943ms inside `GET /api/auth/organization/list`, dragging the endpoint to a p50 of 1.6s and the loading spinner with it.

This PR replaces the second pool with a `kysely-postgres-js` dialect bound to the existing `postgres.js` singleton. Better-auth now shares the same connection budget as the rest of the app.

## Changes

- **`packages/owletto-backend/src/auth/index.tsx`**: deleted the `pg.Pool` factory and `database: pool` wiring. Better-auth now gets `{ dialect: getAuthDialect(), type: 'postgres' }`. The lone `pool.query(...)` for invitation notifications moved to postgres.js template-literal style.
- **`packages/owletto-backend/src/db/client.ts`**:
  - New `getAuthDialect()` returns a `PostgresJSDialect` bound to the singleton.
  - Tracks both wrapped (queue-serialized for pglite) and raw clients; the dialect uses raw because `PostgresJSDialect` calls `sql.reserve()` which the wrapper doesn't proxy. Matches the pre-refactor behavior (better-auth previously ran on its own pool entirely outside the wrapper).
  - Pool config: `idle_timeout: 0` (no client-side recycling — the load-bearing change), `max_lifetime: 1800s`, `max` default 10 → 20, `application_name: 'owletto-backend'`.
- **deps**: `kysely@^0.28.0` (was already transitive via better-auth, now explicit) and `kysely-postgres-js@^2.0.0`.

## Expected impact

- `pg.connect` cold-rate inside `/api/auth/*` should drop from ~20% to near-zero.
- p50 of `GET /api/auth/organization/list` should drop from 1.6s to ~400ms.
- Loading spinner unblocks roughly 1s earlier on cold loads, more on slow ones.

## Test plan

- [x] `bun run typecheck` (owletto-backend)
- [x] `make build-packages` (core, gateway, worker — all clean)
- [x] `bun test src/db/__tests__/client.test.ts` — passes
- [x] Verified against ephemeral pglite: wrapped `getDb()` queries, Kysely via `getAuthDialect()` (exercises `sql.reserve()`), concurrent app+auth interleaving, and cross-path write-via-postgres.js / read-via-Kysely all succeed
- [ ] Watch Sentry `pg.connect` p50 + `/api/auth/organization/list` p50 after deploy
- [ ] Confirm `pg_stat_activity` count per pod stays under PG `max_connections` budget (was 8 auth + 10 app = 18 per pod, now up to 20 shared)

## Notes

- `pg` dep stays — `scheduled/advisory-lock.ts` uses `pg.Client` for cron locking, which is a deliberate one-shot connection.
- `AUTH_DB_POOL_MAX` env var is now a no-op; the single pool is governed by `DB_POOL_MAX`.