### PR TITLE
fix(ci): bump landing deploy to Node 22 for Astro 6

### DIFF
--- a/.github/workflows/deploy-landing-cloudflare.yml
+++ b/.github/workflows/deploy-landing-cloudflare.yml
@@ -25,6 +25,11 @@ jobs:
         with:
           deploy-key: ${{ secrets.OWLETTO_WEB_DEPLOY_KEY }}
 
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:


### PR DESCRIPTION
## Summary

Astro 6 (bumped in #308) requires Node ≥22.12.0. The deploy-landing workflow relied on the runner's default Node 20, so every push to \`main\` since that bump has failed with \`Node.js v20.20.2 is not supported by Astro!\`. Cloudflare silently kept serving the last successful build in the meantime — the site was live but stale.

Pin Node 22 before the build step.

## Test plan

- [x] Workflow syntax valid (only adds a \`setup-node\` step).
- [ ] On merge, a \`Deploy Landing to Cloudflare Pages\` run succeeds and a fresh \`main\` build ships to \`lobu.ai\`.