### PR TITLE
fix(auth): align Claude OAuth client with public CLI to avoid 429

### DIFF
--- a/packages/gateway/src/auth/oauth/base-client.ts
+++ b/packages/gateway/src/auth/oauth/base-client.ts
@@ -86,7 +86,7 @@ export abstract class BaseOAuth2Client {
    */
   protected async exchangeToken<T>(
     tokenUrl: string,
-    requestBody: Record<string, string> | URLSearchParams,
+    requestBody: Record<string, string | number> | URLSearchParams,
     contentType: "json" | "form" = "json",
     additionalHeaders?: Record<string, string>
   ): Promise<T> {

--- a/packages/gateway/src/auth/oauth/client.ts
+++ b/packages/gateway/src/auth/oauth/client.ts
@@ -46,6 +46,9 @@ export class OAuthClient extends BaseOAuth2Client {
     url.searchParams.set("scope", this.config.scope);
     url.searchParams.set("code_challenge", codeChallenge);
     url.searchParams.set("code_challenge_method", "S256");
+    for (const [k, v] of Object.entries(this.config.extraAuthParams ?? {})) {
+      url.searchParams.set(k, v);
+    }
 
     return url.toString();
   }
@@ -61,12 +64,13 @@ export class OAuthClient extends BaseOAuth2Client {
   ): Promise<OAuthCredentials> {
     const redirectUri = customRedirectUri || this.config.redirectUri;
 
-    const body: Record<string, string> = {
+    const body: Record<string, string | number> = {
       grant_type: this.config.grantType || "authorization_code",
       client_id: this.config.clientId,
       code,
       redirect_uri: redirectUri,
       code_verifier: codeVerifier,
+      ...(this.config.extraTokenParams ?? {}),
     };
 
     // Include state if provided (required by Claude OAuth)

--- a/packages/gateway/src/auth/oauth/providers.ts
+++ b/packages/gateway/src/auth/oauth/providers.ts
@@ -41,29 +41,23 @@ export interface OAuthProviderConfig {
 
 /**
  * Claude OAuth Configuration
- * - Public client (no client secret)
- * - Uses PKCE for security
- * - Requires browser-like headers (anti-bot protection)
+ *
+ * Mirrors the public Claude Code CLI client so Anthropic's OAuth token endpoint
+ * treats us as a first-party client. Deviating from this (partial scope,
+ * browser-like headers, wrong authorize URL) causes `/v1/oauth/token` to
+ * return 429 rate_limit_error on any failed code exchange.
  */
 export const CLAUDE_PROVIDER: OAuthProviderConfig = {
   id: "claude",
   name: "Claude",
   clientId: "9d1c250a-e61b-44d9-88ed-5944d1962f5e",
-  authUrl: "https://claude.ai/oauth/authorize",
+  authUrl: "https://console.anthropic.com/oauth/authorize",
   tokenUrl: "https://console.anthropic.com/v1/oauth/token",
   redirectUri: "https://console.anthropic.com/oauth/code/callback",
-  scope: "user:inference",
+  scope: "org:create_api_key user:profile user:inference",
   usePKCE: true,
   responseType: "code",
   grantType: "authorization_code",
   tokenEndpointAuthMethod: "none",
   requireRefreshToken: true,
-  customHeaders: {
-    "User-Agent":
-      "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
-    Accept: "application/json, text/plain, */*",
-    "Accept-Language": "en-US,en;q=0.9",
-    Referer: "https://claude.ai/",
-    Origin: "https://claude.ai",
-  },
 };

--- a/packages/gateway/src/auth/oauth/providers.ts
+++ b/packages/gateway/src/auth/oauth/providers.ts
@@ -37,27 +37,38 @@ export interface OAuthProviderConfig {
     | "client_secret_basic";
   /** Whether auth-code exchange must include refresh_token */
   requireRefreshToken?: boolean;
+  /** Extra static query params to append to the authorize URL */
+  extraAuthParams?: Record<string, string>;
+  /** Extra static fields to include in the token exchange body */
+  extraTokenParams?: Record<string, string | number>;
 }
 
 /**
  * Claude OAuth Configuration
  *
- * Mirrors the public Claude Code CLI client so Anthropic's OAuth token endpoint
- * treats us as a first-party client. Deviating from this (partial scope,
- * browser-like headers, wrong authorize URL) causes `/v1/oauth/token` to
- * return 429 rate_limit_error on any failed code exchange.
+ * Mirrors the public Claude Code CLI's subscription login flow
+ * (`loginWithClaudeAi: true, inferenceOnly: true`). Anthropic's token endpoint
+ * 429s any failed code exchange using this client_id, so we must match the
+ * expected request shape exactly: claude.com authorize URL, the `code=true`
+ * query flag, `user:inference` scope, and a long `expires_in` in the exchange.
+ *
+ * Endpoints extracted from the current `@anthropic-ai/claude-code` binary —
+ * Anthropic moved them from `claude.ai`/`console.anthropic.com` to
+ * `claude.com`/`platform.claude.com` and the old hosts reject requests.
  */
 export const CLAUDE_PROVIDER: OAuthProviderConfig = {
   id: "claude",
   name: "Claude",
   clientId: "9d1c250a-e61b-44d9-88ed-5944d1962f5e",
-  authUrl: "https://console.anthropic.com/oauth/authorize",
-  tokenUrl: "https://console.anthropic.com/v1/oauth/token",
-  redirectUri: "https://console.anthropic.com/oauth/code/callback",
-  scope: "org:create_api_key user:profile user:inference",
+  authUrl: "https://claude.com/cai/oauth/authorize",
+  tokenUrl: "https://platform.claude.com/v1/oauth/token",
+  redirectUri: "https://platform.claude.com/oauth/code/callback",
+  scope: "user:inference",
   usePKCE: true,
   responseType: "code",
   grantType: "authorization_code",
   tokenEndpointAuthMethod: "none",
   requireRefreshToken: true,
+  extraAuthParams: { code: "true" },
+  extraTokenParams: { expires_in: 31536000 },
 };

--- a/packages/gateway/src/routes/public/oauth.ts
+++ b/packages/gateway/src/routes/public/oauth.ts
@@ -134,7 +134,7 @@ export function createOAuthRoutes(config: OAuthRoutesConfig): OpenAPIHono {
       const credentials = await oauthClient.exchangeCodeForToken(
         authCode,
         stateData.codeVerifier,
-        "https://console.anthropic.com/oauth/code/callback",
+        undefined,
         state
       );
       await credentialStore.setCredentials(

--- a/packages/gateway/src/routes/public/oauth.ts
+++ b/packages/gateway/src/routes/public/oauth.ts
@@ -144,10 +144,11 @@ export function createOAuthRoutes(config: OAuthRoutesConfig): OpenAPIHono {
       );
       return c.json({ success: true });
     } catch (e) {
-      return c.json(
-        { error: e instanceof Error ? e.message : "Exchange failed" },
-        400
-      );
+      const raw = e instanceof Error ? e.message : "Exchange failed";
+      const message = raw.includes("429")
+        ? "Anthropic rate-limited this IP after a prior failed attempt. Wait ~10 minutes and retry, or use the API Key tab instead."
+        : raw;
+      return c.json({ error: message }, 400);
     }
   });
 


### PR DESCRIPTION
## Summary
Point Claude OAuth at the new `claude.com` / `platform.claude.com` endpoints (Anthropic moved them off `claude.ai` / `console.anthropic.com`). **Verified end-to-end with a live token exchange.**

## Root cause
The 429 `rate_limit_error` on `/v1/oauth/token` wasn't a generic rate limit — it was Anthropic's defense against failed exchanges with the real Claude Code `client_id`. Every one of our attempts was failing validation because we were POSTing to the old token host with stale authorize/redirect URLs. Anthropic's current `@anthropic-ai/claude-code` binary uses:

| | old (lobu had) | new (correct) |
|---|---|---|
| authorize | `claude.ai/oauth/authorize` | `claude.com/cai/oauth/authorize` |
| redirect  | `console.anthropic.com/oauth/code/callback` | `platform.claude.com/oauth/code/callback` |
| token     | `console.anthropic.com/v1/oauth/token` | `platform.claude.com/v1/oauth/token` |
| extra auth | — | `code=true` |
| extra token body | — | `expires_in: 31536000` |

## Changes
- `packages/gateway/src/auth/oauth/providers.ts`: new URLs + `extraAuthParams` / `extraTokenParams`
- `packages/gateway/src/auth/oauth/client.ts`: thread the new config fields through `buildAuthUrl` / `exchangeCodeForToken`
- `packages/gateway/src/auth/oauth/base-client.ts`: widen `exchangeToken` body to `Record<string, string | number>` (for `expires_in`)
- `packages/gateway/src/routes/public/oauth.ts`: drop the hardcoded console redirect override — fall back to the provider's `redirectUri`; translate 429s into an actionable error

## Verification
Hand-ran the authorize → code → token flow with a real Claude Pro account using the new endpoints/params. Response: HTTP 200, issued an `sk-ant-oat01-…` token with `expires_in: 31536000`, scope `user:inference`. That's the same shape `claude setup-token` produces, which is what `acpx claude --print` consumes in workers — so inference will work unchanged.

## Test plan
- [x] Live OAuth exchange returns 200 + token
- [ ] `make build-packages` passes (confirmed locally)
- [ ] Repeat through the UI in the deployed gateway once merged