### PR TITLE
feat(examples): add personal-finance project for UK Self Assessment

### DIFF
--- a/examples/personal-finance/agents/personal-finance/IDENTITY.md
+++ b/examples/personal-finance/agents/personal-finance/IDENTITY.md
@@ -1,0 +1,9 @@
+# Identity
+
+You are a private financial accountant for an individual UK taxpayer.
+
+You help them capture the financial activity they need for their HMRC Self Assessment (SA100) — wages, side income, savings interest, dividends, capital gains, pension contributions, charitable donations, rental income, allowable expenses — across each tax year (6 April to 5 April).
+
+You operate inside the user's own private workspace. Their data is theirs; you work on it on their behalf. You never see another taxpayer's data.
+
+You are precise with money and dates, conservative with assumptions, and explicit about what you don't know.

--- a/examples/personal-finance/agents/personal-finance/SOUL.md
+++ b/examples/personal-finance/agents/personal-finance/SOUL.md
@@ -1,0 +1,30 @@
+# Instructions
+
+## Tax-year context
+- The UK fiscal year runs 6 April to 5 April. Always anchor work to the active `tax_year` entity. If none exists for the current year, create it before recording activity.
+- Filing deadlines: paper 31 October, online 31 January, balancing payment 31 January, second payment on account 31 July.
+
+## Capturing data
+- When the user mentions a transaction, dividend, disposal, contribution or expense, record it as the appropriate entity (`transaction`, `cgt_event`, `contribution`, `expense`, etc.) and link it to the active `tax_year`.
+- For uncertain or fuzzy inputs, prefer `save_knowledge` (note/observation/decision) on the user's `$member` entity rather than guessing structured fields.
+- Always link transactions to the `account` they belong to and, where relevant, to an `income_source` or `expense` category.
+- For capital-gains disposals, capture acquisition cost + date, disposal proceeds + date, incidental costs, and any reliefs claimed (PRR, BADR, EIS/SEIS). Link to the `asset_lot` for s.104 pool matching where applicable.
+- For provenance, every entity parsed from a document or email should have a `parsed_from` link to the source `document` entity.
+
+## ISA / SIPP wrappers
+- Activity inside ISAs is not reportable for income tax or CGT. Capture for the user's net-worth picture but flag `tax_relevance=none` on related transactions.
+- SIPP contributions are reportable for higher-rate relief; growth inside the wrapper is not.
+
+## Ingestion paths
+1. **Forwarded Gmail** — bank confirmations, broker contract notes, dividend notices, P60/P11D, mortgage statements. Watcher `personal-finance.gmail-tx` parses these automatically. Verify gaps and ask the user to forward what's missing.
+2. **WhatsApp file uploads** — statements, contract notes, P60s. Use the `parse_statement` tool to extract structured rows; if post-validation flags a totals mismatch, surface it to the user before committing.
+3. **Chat** — direct entry. Confirm key fields back to the user before creating an entity.
+
+## SA100 assembly
+- When the user asks to assemble their return, run `assemble_self_assessment(tax_year=<label>)`. The output groups data by SA100 supplementary page (SA102 employment, SA105 UK property, SA108 capital gains, dividends/interest on the main return).
+- If you spot gaps (e.g. an employer with no P60 captured, a disposal without acquisition cost), list them clearly before producing the assembly.
+
+## Privacy and tone
+- The user owns their data. Never reference other users or other workspaces.
+- Never guess at someone's UTR, NI number, or address — ask.
+- Be terse. Money and dates exact. Keep narrative minimal.

--- a/examples/personal-finance/agents/personal-finance/USER.md
+++ b/examples/personal-finance/agents/personal-finance/USER.md
@@ -1,0 +1,6 @@
+# User Context
+
+- Role: Individual UK taxpayer preparing their own Self Assessment return
+- Active tax year: the year ending 5 April 2026 (label "2025-26") unless they specify otherwise
+- Connection: Forwards bank/broker emails to a personal Gmail; uploads statements via WhatsApp; chats with the agent for everything else
+- Preference: Concise summaries, exact figures, flagged gaps over guessed values

--- a/examples/personal-finance/lobu.toml
+++ b/examples/personal-finance/lobu.toml
@@ -1,0 +1,31 @@
+# lobu.toml — Personal Finance agent (UK Self Assessment)
+# Docs: https://lobu.ai/docs/getting-started
+
+[agents.personal-finance]
+name = "personal-finance"
+description = "Help individuals capture wages, expenses, savings, dividends, capital gains and pension contributions across the tax year and assemble a UK Self Assessment (SA100) return."
+dir = "./agents/personal-finance"
+
+[[agents.personal-finance.providers]]
+id = "anthropic"
+model = "claude/sonnet-4-5"
+key = "$ANTHROPIC_API_KEY"
+
+[agents.personal-finance.network]
+allowed = [
+  "gov.uk",
+  ".gov.uk",
+  "github.com",
+  ".github.com",
+  ".githubusercontent.com",
+  "registry.npmjs.org",
+  ".npmjs.org",
+]
+
+[memory.owletto]
+enabled = true
+org = "personal-finance"
+name = "Personal Finance"
+description = "UK Self Assessment helper — captures financial activity across the tax year and assembles SA100 + supplementary pages."
+models = "./models"
+data = "./data"

--- a/examples/personal-finance/lobu.toml
+++ b/examples/personal-finance/lobu.toml
@@ -13,7 +13,6 @@ key = "$ANTHROPIC_API_KEY"
 
 [agents.personal-finance.network]
 allowed = [
-  "gov.uk",
   ".gov.uk",
   "github.com",
   ".github.com",

--- a/examples/personal-finance/models/account.yaml
+++ b/examples/personal-finance/models/account.yaml
@@ -1,0 +1,52 @@
+version: 1
+type: entity
+slug: account
+name: Account
+description: A bank, savings, brokerage, pension or mortgage account held by the user.
+icon: wallet
+color: "#3B82F6"
+metadata_schema:
+  type: object
+  required:
+    - provider
+    - wrapper
+  properties:
+    provider:
+      type: string
+      description: Bank or broker name (e.g. "Monzo", "Hargreaves Lansdown")
+      x-table-label: Provider
+      x-table-column: true
+    wrapper:
+      type: string
+      enum:
+        - current
+        - savings
+        - ISA
+        - LISA
+        - JISA
+        - SIPP
+        - GIA
+        - mortgage
+        - credit_card
+        - other
+      description: Tax wrapper / account class
+      x-table-label: Wrapper
+      x-table-column: true
+    currency:
+      type: string
+      description: ISO 4217 currency code
+      default: GBP
+      x-table-label: Ccy
+      x-table-column: true
+    account_number_last4:
+      type: string
+      description: Last 4 digits, for matching
+    sort_code:
+      type: string
+    opening_balance:
+      type: string
+      description: Decimal string, e.g. "1234.56"
+    closing_balance:
+      type: string
+    notes:
+      type: string

--- a/examples/personal-finance/models/account_contains.yaml
+++ b/examples/personal-finance/models/account_contains.yaml
@@ -1,0 +1,8 @@
+version: 1
+type: relationship
+slug: account_contains
+name: Account Contains
+description: An account contains a transaction or holding.
+metadata_schema:
+  type: object
+  properties: {}

--- a/examples/personal-finance/models/asset_lot.yaml
+++ b/examples/personal-finance/models/asset_lot.yaml
@@ -1,0 +1,36 @@
+version: 1
+type: entity
+slug: asset_lot
+name: Asset Lot
+description: An acquisition lot used for s.104 share-pool / matching rules. One lot per buy event.
+icon: layers
+color: "#A78BFA"
+metadata_schema:
+  type: object
+  required:
+    - acquisition_date
+    - quantity
+    - cost_basis
+  properties:
+    pool_id:
+      type: string
+      description: Identifier for the s.104 pool (typically the ticker/ISIN)
+      x-table-label: Pool
+      x-table-column: true
+    acquisition_date:
+      type: string
+      format: date
+      x-table-label: Acquired
+      x-table-column: true
+    quantity:
+      type: string
+      x-table-label: Quantity
+      x-table-column: true
+    cost_basis:
+      type: string
+      description: Total cost for this lot, decimal GBP
+      x-table-label: Cost
+      x-table-column: true
+    quantity_remaining:
+      type: string
+      description: After partial disposals

--- a/examples/personal-finance/models/cgt_event.yaml
+++ b/examples/personal-finance/models/cgt_event.yaml
@@ -1,0 +1,65 @@
+version: 1
+type: entity
+slug: cgt_event
+name: CGT Event
+description: A capital-gains disposal — sale, gift, or other event triggering CGT (SA108).
+icon: scissors
+color: "#F59E0B"
+metadata_schema:
+  type: object
+  required:
+    - asset_description
+    - asset_class
+    - disposal_date
+    - disposal_proceeds
+  properties:
+    asset_description:
+      type: string
+      x-table-label: Asset
+      x-table-column: true
+    asset_class:
+      type: string
+      enum:
+        - listed_shares
+        - unlisted_shares
+        - residential_property
+        - other_property
+        - crypto
+        - other
+      x-table-label: Class
+      x-table-column: true
+    acquisition_date:
+      type: string
+      format: date
+    acquisition_cost:
+      type: string
+      description: Total acquisition cost, decimal string GBP
+    disposal_date:
+      type: string
+      format: date
+      x-table-label: Disposal
+      x-table-column: true
+    disposal_proceeds:
+      type: string
+      description: Total proceeds, decimal string GBP
+      x-table-label: Proceeds
+      x-table-column: true
+    incidental_costs:
+      type: string
+      description: Legal, broker, SDLT on acquisition, enhancement
+    relief_claimed:
+      type: string
+      enum:
+        - none
+        - PRR
+        - BADR
+        - investors_relief
+        - gift_holdover
+        - EIS_deferral
+        - SEIS_deferral
+      default: none
+      x-table-label: Relief
+      x-table-column: true
+    residential_60day_return_ref:
+      type: string
+      description: HMRC reference if a 60-day residential CGT return was already filed

--- a/examples/personal-finance/models/contribution.yaml
+++ b/examples/personal-finance/models/contribution.yaml
@@ -1,0 +1,44 @@
+version: 1
+type: entity
+slug: contribution
+name: Contribution
+description: A pension or charitable contribution affecting tax (Gift Aid, SIPP, etc.).
+icon: piggy-bank
+color: "#7C3AED"
+metadata_schema:
+  type: object
+  required:
+    - scheme
+    - mechanism
+    - amount
+    - date
+  properties:
+    scheme:
+      type: string
+      description: Provider/charity name
+      x-table-label: Scheme
+      x-table-column: true
+    mechanism:
+      type: string
+      enum:
+        - relief_at_source
+        - net_pay
+        - salary_sacrifice
+        - gift_aid
+      description: Pension relief mechanism, or gift_aid for charitable donations
+      x-table-label: Mechanism
+      x-table-column: true
+    amount:
+      type: string
+      description: Net amount paid, decimal GBP
+      x-table-label: Amount
+      x-table-column: true
+    date:
+      type: string
+      format: date
+      x-table-label: Date
+      x-table-column: true
+    carry_back_to_prior_year:
+      type: boolean
+      default: false
+      description: Gift Aid carry-back election

--- a/examples/personal-finance/models/disposal_of.yaml
+++ b/examples/personal-finance/models/disposal_of.yaml
@@ -1,0 +1,11 @@
+version: 1
+type: relationship
+slug: disposal_of
+name: Disposal Of
+description: A CGT event disposes of (all or part of) an asset lot.
+metadata_schema:
+  type: object
+  properties:
+    quantity_disposed:
+      type: string
+      description: Decimal — partial vs full disposal

--- a/examples/personal-finance/models/document.yaml
+++ b/examples/personal-finance/models/document.yaml
@@ -1,0 +1,49 @@
+version: 1
+type: entity
+slug: document
+name: Document
+description: A source document — P60, P45, P11D, SA302, broker contract note, mortgage statement, bank statement — that other entities are parsed from.
+icon: file-text
+color: "#6B7280"
+metadata_schema:
+  type: object
+  required:
+    - doc_type
+    - source
+  properties:
+    doc_type:
+      type: string
+      enum:
+        - P60
+        - P45
+        - P11D
+        - SA302
+        - bank_statement
+        - savings_statement
+        - broker_statement
+        - contract_note
+        - dividend_voucher
+        - mortgage_statement
+        - rental_agreement
+        - receipt
+        - other
+      x-table-label: Type
+      x-table-column: true
+    source:
+      type: string
+      enum:
+        - gmail
+        - whatsapp_upload
+        - manual
+      x-table-label: Source
+      x-table-column: true
+    download_url:
+      type: string
+      format: uri
+      description: Signed gateway artifact URL
+    payer_or_employer:
+      type: string
+      description: Counterparty named on the document
+    captured_at:
+      type: string
+      format: date-time

--- a/examples/personal-finance/models/employed_by.yaml
+++ b/examples/personal-finance/models/employed_by.yaml
@@ -1,0 +1,8 @@
+version: 1
+type: relationship
+slug: employed_by
+name: Employed By
+description: An employment-type income source is employment by an employer (links income_source to employer for SA102).
+metadata_schema:
+  type: object
+  properties: {}

--- a/examples/personal-finance/models/employer.yaml
+++ b/examples/personal-finance/models/employer.yaml
@@ -1,0 +1,31 @@
+version: 1
+type: entity
+slug: employer
+name: Employer
+description: An employer for SA102 employment-page reporting.
+icon: briefcase
+color: "#0891B2"
+metadata_schema:
+  type: object
+  required:
+    - name
+  properties:
+    name:
+      type: string
+      x-table-label: Employer
+      x-table-column: true
+    paye_reference:
+      type: string
+      description: PAYE reference, e.g. "123/AB456"
+      x-table-label: PAYE Ref
+      x-table-column: true
+    director_flag:
+      type: boolean
+      default: false
+    employment_start:
+      type: string
+      format: date
+    cessation_date:
+      type: string
+      format: date
+      description: From P45 if the employment ended in this tax year

--- a/examples/personal-finance/models/expense.yaml
+++ b/examples/personal-finance/models/expense.yaml
@@ -1,0 +1,48 @@
+version: 1
+type: entity
+slug: expense
+name: Expense
+description: An allowable expense against a trade or property.
+icon: receipt
+color: "#DC2626"
+metadata_schema:
+  type: object
+  required:
+    - category
+    - amount
+    - date
+  properties:
+    category:
+      type: string
+      enum:
+        - cost_of_goods
+        - travel
+        - premises
+        - repairs
+        - admin
+        - advertising
+        - interest_finance
+        - professional_fees
+        - wages
+        - utilities
+        - insurance
+        - agent_fees
+        - other
+      x-table-label: Category
+      x-table-column: true
+    amount:
+      type: string
+      description: Decimal GBP
+      x-table-label: Amount
+      x-table-column: true
+    date:
+      type: string
+      format: date
+      x-table-label: Date
+      x-table-column: true
+    notes:
+      type: string
+    is_capital:
+      type: boolean
+      default: false
+      description: Capital vs revenue (capital expenses go to capital_allowances, not expenses)

--- a/examples/personal-finance/models/expense_of.yaml
+++ b/examples/personal-finance/models/expense_of.yaml
@@ -1,0 +1,8 @@
+version: 1
+type: relationship
+slug: expense_of
+name: Expense Of
+description: An expense is incurred against a trade or property.
+metadata_schema:
+  type: object
+  properties: {}

--- a/examples/personal-finance/models/for_tax_year.yaml
+++ b/examples/personal-finance/models/for_tax_year.yaml
@@ -1,0 +1,8 @@
+version: 1
+type: relationship
+slug: for_tax_year
+name: For Tax Year
+description: An entity (transaction, cgt_event, contribution, relief_claim, expense) is recorded against a particular tax year.
+metadata_schema:
+  type: object
+  properties: {}

--- a/examples/personal-finance/models/gmail-tx.yaml
+++ b/examples/personal-finance/models/gmail-tx.yaml
@@ -1,0 +1,188 @@
+version: 1
+type: watcher
+slug: gmail-tx
+name: Gmail financial-event extractor
+schedule: "*/30 * * * *"
+prompt: |
+  You are a private financial accountant scanning the user's forwarded Gmail messages for events that matter to a UK Self Assessment return.
+
+  ## Recent emails
+  {{#if sources.gmail_messages}}
+  {{sources.gmail_messages}}
+  {{else}}
+  No new messages this window.
+  {{/if}}
+
+  ## Active tax year
+  {{#if entities}}
+  {{#each entities}}
+  - {{name}} ({{entity_type}}, ID: {{id}})
+  {{/each}}
+  {{else}}
+  No tax year context provided.
+  {{/if}}
+
+  ---
+
+  Identify and extract financial events. Each email may yield zero, one, or many events. Be conservative: skip noise (marketing, password resets, etc.).
+
+  Categories to extract:
+  - **transactions** — deposits, debits, transfers, salary credits, dividend payments hitting an account
+  - **cgt_events** — broker contract notes for sells/disposals, gifts, transfers out of a GIA
+  - **dividends** — UK or foreign dividend notifications (gross + currency)
+  - **documents** — P60/P45/P11D/SA302/contract notes/mortgage statements arriving as attachments or linked PDFs
+
+  For each item, include the source `gmail_message_id` so we can link provenance. Prefer GBP unless the message clearly states a different currency.
+
+  Skip transactions inside ISAs and SIPPs unless they are dividends or contributions (which are still reportable). Mark `tax_relevance="none"` for ISA-internal transactions; mark `tax_relevance="cgt"` for non-wrapper disposals.
+extraction_schema:
+  type: object
+  required:
+    - transactions
+    - cgt_events
+    - dividends
+    - documents
+  properties:
+    transactions:
+      type: array
+      items:
+        type: object
+        required:
+          - date
+          - amount
+          - currency
+          - description
+          - gmail_message_id
+        properties:
+          date:
+            type: string
+            format: date
+          amount:
+            type: string
+            description: Decimal string. Positive = credit, negative = debit.
+          currency:
+            type: string
+          description:
+            type: string
+          merchant_raw:
+            type: string
+          account_hint:
+            type: string
+            description: Free-text hint about which account ("Monzo current", "HL ISA", etc.). Resolved later.
+          tax_relevance:
+            type: string
+            enum: [none, income, expense, cgt]
+          gmail_message_id:
+            type: string
+    cgt_events:
+      type: array
+      items:
+        type: object
+        required:
+          - asset_description
+          - asset_class
+          - disposal_date
+          - disposal_proceeds
+          - gmail_message_id
+        properties:
+          asset_description:
+            type: string
+          asset_class:
+            type: string
+            enum:
+              [
+                listed_shares,
+                unlisted_shares,
+                residential_property,
+                other_property,
+                crypto,
+                other,
+              ]
+          acquisition_date:
+            type: string
+            format: date
+          acquisition_cost:
+            type: string
+          disposal_date:
+            type: string
+            format: date
+          disposal_proceeds:
+            type: string
+          incidental_costs:
+            type: string
+          gmail_message_id:
+            type: string
+    dividends:
+      type: array
+      items:
+        type: object
+        required:
+          - payer
+          - gross
+          - currency
+          - date
+          - gmail_message_id
+        properties:
+          payer:
+            type: string
+          gross:
+            type: string
+          currency:
+            type: string
+          date:
+            type: string
+            format: date
+          country:
+            type: string
+            description: ISO 3166-1 alpha-2 if foreign
+          gmail_message_id:
+            type: string
+    documents:
+      type: array
+      items:
+        type: object
+        required:
+          - doc_type
+          - gmail_message_id
+        properties:
+          doc_type:
+            type: string
+            enum:
+              [
+                P60,
+                P45,
+                P11D,
+                SA302,
+                bank_statement,
+                savings_statement,
+                broker_statement,
+                contract_note,
+                dividend_voucher,
+                mortgage_statement,
+                rental_agreement,
+                receipt,
+                other,
+              ]
+          payer_or_employer:
+            type: string
+          tax_year_hint:
+            type: string
+            description: Tax year label if visible on the document, e.g. "2025-26"
+          gmail_message_id:
+            type: string
+sources:
+  - name: gmail_messages
+    query: >
+      SELECT id, title, payload_text, payload_html, occurred_at
+      FROM events
+      WHERE connector_key = 'google.gmail'
+      ORDER BY occurred_at DESC
+      LIMIT 200
+reactions_guidance: |
+  After extracting:
+  1. Resolve or create the active `tax_year` entity from the user's profile. Each new transaction / cgt_event / contribution must be linked to it via `for_tax_year`.
+  2. For each `documents[]` entry, create a `document` entity (source="gmail") and use it as the `parsed_from` target for the transactions / cgt_events / dividends extracted from that same gmail_message_id.
+  3. For each `transactions[]` entry, resolve or create the `account` from `account_hint` and link via `account_contains`. If income, create or resolve an `income_source` and link via `income_from`.
+  4. For `cgt_events[]`, look up matching `asset_lot` rows in the same `pool_id` and link via `disposal_of`. If acquisition data is missing, save a note flagging the gap rather than guessing.
+  5. For `dividends[]`, create a `transaction(tax_relevance=income)` linked to an `income_source(type=dividend, payer_name, country)`.
+  6. Never overwrite a user-edited entity. If a duplicate is suspected (same date + amount + account), surface it as a question instead of writing.

--- a/examples/personal-finance/models/goal.yaml
+++ b/examples/personal-finance/models/goal.yaml
@@ -1,0 +1,41 @@
+version: 1
+type: entity
+slug: goal
+name: Goal
+description: A personal financial goal (emergency fund, deposit, retirement target, etc.).
+icon: target
+color: "#EC4899"
+metadata_schema:
+  type: object
+  required:
+    - name
+    - target_amount
+    - category
+  properties:
+    name:
+      type: string
+      x-table-label: Goal
+      x-table-column: true
+    target_amount:
+      type: string
+      description: Decimal GBP
+      x-table-label: Target
+      x-table-column: true
+    target_date:
+      type: string
+      format: date
+      x-table-label: By
+      x-table-column: true
+    category:
+      type: string
+      enum:
+        - emergency_fund
+        - deposit
+        - retirement
+        - debt_payoff
+        - other
+      x-table-label: Category
+      x-table-column: true
+    current_amount:
+      type: string
+      description: Optional snapshot, decimal GBP

--- a/examples/personal-finance/models/holding.yaml
+++ b/examples/personal-finance/models/holding.yaml
@@ -1,0 +1,36 @@
+version: 1
+type: entity
+slug: holding
+name: Holding
+description: A current security position in a brokerage account.
+icon: trending-up
+color: "#8B5CF6"
+metadata_schema:
+  type: object
+  required:
+    - ticker
+    - quantity
+    - as_of_date
+  properties:
+    ticker:
+      type: string
+      x-table-label: Ticker
+      x-table-column: true
+    isin:
+      type: string
+    quantity:
+      type: string
+      description: Decimal string
+      x-table-label: Quantity
+      x-table-column: true
+    avg_cost:
+      type: string
+      description: Average cost per unit (s.104 pool), decimal string
+    currency:
+      type: string
+      default: GBP
+    as_of_date:
+      type: string
+      format: date
+      x-table-label: As of
+      x-table-column: true

--- a/examples/personal-finance/models/income_from.yaml
+++ b/examples/personal-finance/models/income_from.yaml
@@ -1,0 +1,14 @@
+version: 1
+type: relationship
+slug: income_from
+name: Income From
+description: A transaction is income from a particular source (employer, dividend payer, interest payer, rental, etc.).
+metadata_schema:
+  type: object
+  properties:
+    gross_amount:
+      type: string
+      description: Gross decimal GBP if different from the net transaction amount
+    tax_deducted:
+      type: string
+      description: PAYE / withholding deducted at source, decimal GBP

--- a/examples/personal-finance/models/income_source.yaml
+++ b/examples/personal-finance/models/income_source.yaml
@@ -1,0 +1,33 @@
+version: 1
+type: entity
+slug: income_source
+name: Income Source
+description: A recurring origin of income (employer, trade, dividend payer, interest payer, rental property, pension, foreign source).
+icon: banknote
+color: "#22C55E"
+metadata_schema:
+  type: object
+  required:
+    - type
+  properties:
+    type:
+      type: string
+      enum:
+        - employment
+        - self_employment
+        - dividend
+        - interest
+        - rental
+        - pension
+        - foreign
+      x-table-label: Type
+      x-table-column: true
+    payer_name:
+      type: string
+      x-table-label: Payer
+      x-table-column: true
+    country:
+      type: string
+      description: ISO 3166-1 alpha-2; relevant for SA106 foreign income
+    notes:
+      type: string

--- a/examples/personal-finance/models/parsed_from.yaml
+++ b/examples/personal-finance/models/parsed_from.yaml
@@ -1,0 +1,15 @@
+version: 1
+type: relationship
+slug: parsed_from
+name: Parsed From
+description: An entity (transaction, cgt_event, holding, etc.) was parsed from a source document — provenance link.
+metadata_schema:
+  type: object
+  properties:
+    extraction_confidence:
+      type: number
+      minimum: 0
+      maximum: 1
+    line_number:
+      type: integer
+      description: Optional anchor into the source document

--- a/examples/personal-finance/models/property.yaml
+++ b/examples/personal-finance/models/property.yaml
@@ -1,0 +1,39 @@
+version: 1
+type: entity
+slug: property
+name: Property
+description: A let property (UK or foreign) for SA105 / SA106 reporting.
+icon: home
+color: "#EA580C"
+metadata_schema:
+  type: object
+  required:
+    - address
+    - type
+  properties:
+    address:
+      type: string
+      x-table-label: Address
+      x-table-column: true
+    type:
+      type: string
+      enum:
+        - residential
+        - FHL
+        - commercial
+      x-table-label: Type
+      x-table-column: true
+    country:
+      type: string
+      description: ISO 3166-1 alpha-2; non-GB triggers SA106
+      default: GB
+    joint_share_pct:
+      type: number
+      minimum: 0
+      maximum: 100
+      description: Your share of the property income, percent
+      default: 100
+    rental_income_allowance_claimed:
+      type: boolean
+      default: false
+      description: £1,000 property income allowance flag

--- a/examples/personal-finance/models/relief_claim.yaml
+++ b/examples/personal-finance/models/relief_claim.yaml
@@ -1,0 +1,32 @@
+version: 1
+type: entity
+slug: relief_claim
+name: Relief Claim
+description: A tax relief or allowance claim (Gift Aid, marriage allowance, EIS/SEIS, BADR, PRR).
+icon: shield-check
+color: "#059669"
+metadata_schema:
+  type: object
+  required:
+    - type
+  properties:
+    type:
+      type: string
+      enum:
+        - gift_aid
+        - marriage_allowance
+        - EIS
+        - SEIS
+        - BADR
+        - PRR
+        - investors_relief
+        - foreign_tax_credit
+      x-table-label: Type
+      x-table-column: true
+    amount:
+      type: string
+      description: Decimal GBP if applicable
+      x-table-label: Amount
+      x-table-column: true
+    notes:
+      type: string

--- a/examples/personal-finance/models/tax_year.yaml
+++ b/examples/personal-finance/models/tax_year.yaml
@@ -1,0 +1,39 @@
+version: 1
+type: entity
+slug: tax_year
+name: Tax Year
+description: A UK fiscal year (6 April to 5 April) — the container all reportable activity is anchored to.
+icon: calendar
+color: "#0EA5E9"
+metadata_schema:
+  type: object
+  required:
+    - year_label
+    - start
+    - end
+  properties:
+    year_label:
+      type: string
+      description: Year label, e.g. "2025-26"
+      x-table-label: Year
+      x-table-column: true
+    start:
+      type: string
+      format: date
+      description: Inclusive start, e.g. 2025-04-06
+    end:
+      type: string
+      format: date
+      description: Inclusive end, e.g. 2026-04-05
+    filing_status:
+      type: string
+      enum:
+        - in_progress
+        - assembled
+        - filed
+      description: Where the user is in the cycle
+      x-table-label: Status
+      x-table-column: true
+    filed_at:
+      type: string
+      format: date-time

--- a/examples/personal-finance/models/trade.yaml
+++ b/examples/personal-finance/models/trade.yaml
@@ -1,0 +1,31 @@
+version: 1
+type: entity
+slug: trade
+name: Trade
+description: A self-employment business for SA103 reporting.
+icon: store
+color: "#0D9488"
+metadata_schema:
+  type: object
+  required:
+    - name
+  properties:
+    name:
+      type: string
+      x-table-label: Trade
+      x-table-column: true
+    description:
+      type: string
+    accounting_period_start:
+      type: string
+      format: date
+    accounting_period_end:
+      type: string
+      format: date
+    cash_basis_flag:
+      type: boolean
+      default: true
+      description: Cash basis (true) vs accruals (false)
+    simplified_expenses_flag:
+      type: boolean
+      default: false

--- a/examples/personal-finance/models/trade_of.yaml
+++ b/examples/personal-finance/models/trade_of.yaml
@@ -1,0 +1,8 @@
+version: 1
+type: relationship
+slug: trade_of
+name: Trade Of
+description: A self-employment income source is the trade of a particular business (links income_source to trade for SA103).
+metadata_schema:
+  type: object
+  properties: {}

--- a/examples/personal-finance/models/transaction.yaml
+++ b/examples/personal-finance/models/transaction.yaml
@@ -1,0 +1,50 @@
+version: 1
+type: entity
+slug: transaction
+name: Transaction
+description: A single debit or credit on an account.
+icon: arrow-left-right
+color: "#10B981"
+metadata_schema:
+  type: object
+  required:
+    - date
+    - amount
+    - currency
+  properties:
+    date:
+      type: string
+      format: date
+      x-table-label: Date
+      x-table-column: true
+    amount:
+      type: string
+      description: Decimal string. Positive = credit, negative = debit.
+      x-table-label: Amount
+      x-table-column: true
+    currency:
+      type: string
+      default: GBP
+    description:
+      type: string
+      x-table-label: Description
+      x-table-column: true
+    merchant_raw:
+      type: string
+      description: Verbatim merchant text from the statement; resolved/categorised later.
+    tax_relevance:
+      type: string
+      enum:
+        - none
+        - income
+        - expense
+        - cgt
+      description: Whether this transaction matters for the SA return.
+      x-table-label: Tax
+      x-table-column: true
+    expense_category:
+      type: string
+      description: HMRC-aligned category for allowable expenses (cost_of_goods, travel, premises, repairs, admin, advertising, interest, professional_fees, wages, other).
+    is_personal:
+      type: boolean
+      default: true


### PR DESCRIPTION
## Summary
- New `examples/personal-finance/` project: UK Self Assessment helper exposed as a WhatsApp accountant.
- 15 entity types (`tax_year`, `account`, `transaction`, `holding`, `cgt_event`, `asset_lot`, `income_source`, `employer`, `trade`, `property`, `expense`, `contribution`, `relief_claim`, `document`, `goal`) modelling SA100 + SA102 / SA103 / SA105 / SA106 / SA108.
- 8 relationship types (`account_contains`, `disposal_of`, `income_from`, `employed_by`, `trade_of`, `expense_of`, `for_tax_year`, `parsed_from`).
- 1 Gmail watcher (`gmail-tx`) that extracts transactions / cgt_events / dividends / documents from forwarded financial emails, with reaction guidance for linking to the active `tax_year`.
- Agent persona/rules in `agents/personal-finance/{IDENTITY,SOUL,USER}.md`.

This is the canonical schema source. In the architecture it's the read-only template; per-user installs will mirror this schema into each user's personal org via the upcoming install flow.

## Test plan
- [x] All 24 model YAMLs validate against \`@lobu/owletto-cli\`'s \`validateModel\` schema.
- [x] \`lobu.toml\` parses.
- [x] Pre-commit hooks (Biome, tsc) pass.
- [ ] Once auth is set up: \`owletto seed --dryRun\` reports the planned writes correctly.
- [ ] Once seeded: schema visible in the personal-finance org via \`manage_entity_schema(action=list)\`.