### PR TITLE
feat(auth): auto-provision personal org on user signup

### DIFF
--- a/packages/owletto-backend/src/auth/__tests__/personal-org-provisioning.test.ts
+++ b/packages/owletto-backend/src/auth/__tests__/personal-org-provisioning.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from 'vitest';
+import {
+  RESERVED_SLUGS,
+  deriveSlugCandidate,
+  slugify,
+} from '../personal-org-provisioning';
+
+describe('slugify', () => {
+  it('lowercases and dash-separates words', () => {
+    expect(slugify('Burak Emre')).toBe('burak-emre');
+  });
+
+  it('strips diacritics', () => {
+    expect(slugify('João Martins')).toBe('joao-martins');
+    expect(slugify('Zoë')).toBe('zoe');
+  });
+
+  it('collapses non-alphanumeric runs and trims edges', () => {
+    expect(slugify('  --Finance & Ops!!  ')).toBe('finance-ops');
+  });
+
+  it('returns empty string for empty-after-sanitize input', () => {
+    expect(slugify('🚀💸')).toBe('');
+    expect(slugify('---')).toBe('');
+  });
+
+  it('truncates to 48 characters', () => {
+    const long = 'a'.repeat(100);
+    expect(slugify(long)).toHaveLength(48);
+  });
+});
+
+describe('deriveSlugCandidate', () => {
+  it('prefers username when available', () => {
+    expect(
+      deriveSlugCandidate({
+        id: 'user_abc',
+        username: 'buremba',
+        name: 'Burak Emre',
+        email: 'emr.e@rakam.io',
+      })
+    ).toBe('buremba');
+  });
+
+  it('falls back to name when username is missing', () => {
+    expect(
+      deriveSlugCandidate({
+        id: 'user_abc',
+        username: null,
+        name: 'Burak Emre',
+        email: 'emr.e@rakam.io',
+      })
+    ).toBe('burak-emre');
+  });
+
+  it('falls back to email local part when name is missing', () => {
+    expect(
+      deriveSlugCandidate({
+        id: 'user_abc',
+        username: null,
+        name: null,
+        email: 'emr.e@rakam.io',
+      })
+    ).toBe('emr-e');
+  });
+
+  it('uses a user-id stub when everything is empty', () => {
+    expect(
+      deriveSlugCandidate({
+        id: 'userABCDEF1234',
+        username: null,
+        name: null,
+        email: null,
+      })
+    ).toBe('user-userabcd');
+  });
+
+  it('skips non-slugifiable fields and moves to the next candidate', () => {
+    expect(
+      deriveSlugCandidate({
+        id: 'user_abc',
+        username: '🚀',
+        name: 'Burak',
+        email: null,
+      })
+    ).toBe('burak');
+  });
+});
+
+describe('RESERVED_SLUGS', () => {
+  it('mirrors the DB org_slug_not_reserved CHECK set', () => {
+    // If this diverges from the DB constraint the hook will hit a
+    // constraint violation at runtime rather than producing a clean suffix.
+    const expected = [
+      'settings',
+      'auth',
+      'api',
+      'templates',
+      'help',
+      'account',
+      'admin',
+      'health',
+      'login',
+      'logout',
+      'signup',
+      'register',
+      'www',
+      'mcp',
+      'static',
+      'assets',
+      'cdn',
+      'docs',
+      'mail',
+    ];
+    for (const slug of expected) {
+      expect(RESERVED_SLUGS.has(slug)).toBe(true);
+    }
+    expect(RESERVED_SLUGS.size).toBe(expected.length);
+  });
+});

--- a/packages/owletto-backend/src/auth/__tests__/personal-org-provisioning.test.ts
+++ b/packages/owletto-backend/src/auth/__tests__/personal-org-provisioning.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
   RESERVED_SLUGS,
   deriveSlugCandidate,
+  personalOrgLockKey,
   slugify,
 } from '../personal-org-provisioning';
 
@@ -84,6 +85,20 @@ describe('deriveSlugCandidate', () => {
         email: null,
       })
     ).toBe('burak');
+  });
+});
+
+describe('personalOrgLockKey', () => {
+  it('returns a stable signed int32 advisory-lock key', () => {
+    const key = personalOrgLockKey('user_abc123');
+    expect(personalOrgLockKey('user_abc123')).toBe(key);
+    expect(Number.isInteger(key)).toBe(true);
+    expect(key).toBeGreaterThanOrEqual(-2147483648);
+    expect(key).toBeLessThanOrEqual(2147483647);
+  });
+
+  it('varies by user id', () => {
+    expect(personalOrgLockKey('user_a')).not.toBe(personalOrgLockKey('user_b'));
   });
 });
 

--- a/packages/owletto-backend/src/auth/index.tsx
+++ b/packages/owletto-backend/src/auth/index.tsx
@@ -367,6 +367,26 @@ export async function createAuth(env: Env, request?: Request) {
             }
             return { data: user };
           },
+          after: async (user) => {
+            try {
+              const { ensurePersonalOrganization } = await import(
+                './personal-org-provisioning'
+              );
+              const result = await ensurePersonalOrganization({
+                id: user.id,
+                email: user.email,
+                name: user.name,
+                username: (user as { username?: string | null }).username ?? null,
+              });
+              if (result.created) {
+                console.log(
+                  `[Auth] Provisioned personal org ${result.slug} for user ${user.id}`
+                );
+              }
+            } catch (error) {
+              console.error('[Auth] Failed to provision personal org:', error);
+            }
+          },
         },
       },
       account: {

--- a/packages/owletto-backend/src/auth/personal-org-provisioning.ts
+++ b/packages/owletto-backend/src/auth/personal-org-provisioning.ts
@@ -1,0 +1,127 @@
+/**
+ * Auto-provision a private personal organization for every newly created user.
+ *
+ * Mirrors the "filing cabinet" model: each user gets their own private org
+ * (their data) which template agents (e.g. examples/personal-finance) can be
+ * installed into. Without this, a user landing on the app has no workspace
+ * to receive auto-installed agents or per-user mirrored schemas.
+ */
+
+import { getDb } from '../db/client';
+import { generateSecureToken } from './oauth/utils';
+
+interface UserLike {
+  id: string;
+  email?: string | null;
+  name?: string | null;
+  username?: string | null;
+}
+
+// Mirrors the org_slug_not_reserved CHECK constraint added in
+// 20260420120000_extend_reserved_org_slugs.sql. Inserts that hit a reserved
+// slug raise a constraint violation, so the candidate-derivation layer must
+// avoid them up front.
+export const RESERVED_SLUGS = new Set([
+  'settings',
+  'auth',
+  'api',
+  'templates',
+  'help',
+  'account',
+  'admin',
+  'health',
+  'login',
+  'logout',
+  'signup',
+  'register',
+  'www',
+  'mcp',
+  'static',
+  'assets',
+  'cdn',
+  'docs',
+  'mail',
+]);
+
+const MAX_SLUG_LENGTH = 48;
+const MAX_COLLISION_ATTEMPTS = 100;
+
+export function slugify(input: string): string {
+  return input
+    .toLowerCase()
+    .normalize('NFKD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, MAX_SLUG_LENGTH);
+}
+
+export function deriveSlugCandidate(user: UserLike): string {
+  const candidates = [user.username, user.name, user.email?.split('@')[0]];
+  for (const raw of candidates) {
+    if (!raw) continue;
+    const s = slugify(raw);
+    if (s) return s;
+  }
+  return `user-${user.id.slice(0, 8).toLowerCase()}`;
+}
+
+async function findAvailableSlug(base: string, sql: ReturnType<typeof getDb>): Promise<string> {
+  const safeBase = RESERVED_SLUGS.has(base) ? `${base}-1` : base;
+  let candidate = safeBase;
+  for (let attempt = 0; attempt < MAX_COLLISION_ATTEMPTS; attempt++) {
+    if (!RESERVED_SLUGS.has(candidate)) {
+      const rows = await sql`
+        SELECT 1 FROM "organization" WHERE slug = ${candidate} LIMIT 1
+      `;
+      if (rows.length === 0) return candidate;
+    }
+    candidate = `${safeBase}-${attempt + 2}`;
+  }
+  // Last-resort suffix — astronomically unlikely to reach this branch.
+  return `${safeBase}-${generateSecureToken(4).toLowerCase().replace(/[^a-z0-9]/g, '')}`;
+}
+
+interface EnsureResult {
+  organizationId: string;
+  slug: string;
+  created: boolean;
+}
+
+export async function ensurePersonalOrganization(user: UserLike): Promise<EnsureResult> {
+  const sql = getDb();
+
+  // Idempotency: an org tagged with this user.id in metadata is already this
+  // user's personal one. Re-running the hook (e.g. after a transient failure)
+  // is a no-op.
+  const tagFragment = `"personal_org_for_user_id":"${user.id}"`;
+  const existing = await sql`
+    SELECT id, slug FROM "organization"
+    WHERE metadata IS NOT NULL AND metadata LIKE ${`%${tagFragment}%`}
+    LIMIT 1
+  `;
+  if (existing.length > 0) {
+    const row = existing[0] as { id: string; slug: string };
+    return { organizationId: row.id, slug: row.slug, created: false };
+  }
+
+  const baseSlug = deriveSlugCandidate(user);
+  const slug = await findAvailableSlug(baseSlug, sql);
+  const orgId = `org_${generateSecureToken(8)}`;
+  const memberId = `member_${generateSecureToken(8)}`;
+  const orgName = user.name?.trim() || user.email?.split('@')[0] || slug;
+  const metadata = JSON.stringify({ personal_org_for_user_id: user.id });
+
+  await sql.begin(async (tx) => {
+    await tx`
+      INSERT INTO "organization" (id, name, slug, visibility, metadata, "createdAt")
+      VALUES (${orgId}, ${orgName}, ${slug}, 'private', ${metadata}, NOW())
+    `;
+    await tx`
+      INSERT INTO "member" (id, "userId", "organizationId", role, "createdAt")
+      VALUES (${memberId}, ${user.id}, ${orgId}, 'owner', NOW())
+    `;
+  });
+
+  return { organizationId: orgId, slug, created: true };
+}

--- a/packages/owletto-backend/src/auth/personal-org-provisioning.ts
+++ b/packages/owletto-backend/src/auth/personal-org-provisioning.ts
@@ -45,6 +45,11 @@ export const RESERVED_SLUGS = new Set([
 
 const MAX_SLUG_LENGTH = 48;
 const MAX_COLLISION_ATTEMPTS = 100;
+// Namespace for pg_advisory_xact_lock(key1, key2). Kept in the signed int32
+// range required by PostgreSQL's two-key advisory lock overload.
+const PERSONAL_ORG_LOCK_NAMESPACE = 0x706f7267; // "porg"
+
+type Sql = ReturnType<typeof getDb>;
 
 export function slugify(input: string): string {
   return input
@@ -66,7 +71,7 @@ export function deriveSlugCandidate(user: UserLike): string {
   return `user-${user.id.slice(0, 8).toLowerCase()}`;
 }
 
-async function findAvailableSlug(base: string, sql: ReturnType<typeof getDb>): Promise<string> {
+async function findAvailableSlug(base: string, sql: Sql): Promise<string> {
   const safeBase = RESERVED_SLUGS.has(base) ? `${base}-1` : base;
   let candidate = safeBase;
   for (let attempt = 0; attempt < MAX_COLLISION_ATTEMPTS; attempt++) {
@@ -88,31 +93,63 @@ interface EnsureResult {
   created: boolean;
 }
 
-export async function ensurePersonalOrganization(user: UserLike): Promise<EnsureResult> {
-  const sql = getDb();
+export function personalOrgLockKey(userId: string): number {
+  let hash = 0x811c9dc5;
+  for (let i = 0; i < userId.length; i++) {
+    hash ^= userId.charCodeAt(i);
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return hash | 0;
+}
 
+async function lockPersonalOrgForUser(userId: string, sql: Sql): Promise<void> {
+  await sql`
+    SELECT pg_advisory_xact_lock(
+      ${PERSONAL_ORG_LOCK_NAMESPACE},
+      ${personalOrgLockKey(userId)}
+    )
+  `;
+}
+
+async function findExistingPersonalOrg(
+  userId: string,
+  sql: Sql
+): Promise<{ id: string; slug: string } | null> {
   // Idempotency: an org tagged with this user.id in metadata is already this
   // user's personal one. Re-running the hook (e.g. after a transient failure)
-  // is a no-op.
-  const tagFragment = `"personal_org_for_user_id":"${user.id}"`;
+  // is a no-op. The ORDER BY keeps resolution deterministic if legacy data ever
+  // contains duplicates.
+  const tagFragment = `"personal_org_for_user_id":"${userId}"`;
   const existing = await sql`
     SELECT id, slug FROM "organization"
     WHERE metadata IS NOT NULL AND metadata LIKE ${`%${tagFragment}%`}
+    ORDER BY "createdAt" ASC, id ASC
     LIMIT 1
   `;
-  if (existing.length > 0) {
-    const row = existing[0] as { id: string; slug: string };
-    return { organizationId: row.id, slug: row.slug, created: false };
-  }
+  if (existing.length === 0) return null;
+  return existing[0] as { id: string; slug: string };
+}
 
-  const baseSlug = deriveSlugCandidate(user);
-  const slug = await findAvailableSlug(baseSlug, sql);
-  const orgId = `org_${generateSecureToken(8)}`;
-  const memberId = `member_${generateSecureToken(8)}`;
-  const orgName = user.name?.trim() || user.email?.split('@')[0] || slug;
-  const metadata = JSON.stringify({ personal_org_for_user_id: user.id });
+export async function ensurePersonalOrganization(user: UserLike): Promise<EnsureResult> {
+  const sql = getDb();
+  let result: EnsureResult | null = null;
 
   await sql.begin(async (tx) => {
+    await lockPersonalOrgForUser(user.id, tx);
+
+    const existing = await findExistingPersonalOrg(user.id, tx);
+    if (existing) {
+      result = { organizationId: existing.id, slug: existing.slug, created: false };
+      return;
+    }
+
+    const baseSlug = deriveSlugCandidate(user);
+    const slug = await findAvailableSlug(baseSlug, tx);
+    const orgId = `org_${generateSecureToken(8)}`;
+    const memberId = `member_${generateSecureToken(8)}`;
+    const orgName = user.name?.trim() || user.email?.split('@')[0] || slug;
+    const metadata = JSON.stringify({ personal_org_for_user_id: user.id });
+
     await tx`
       INSERT INTO "organization" (id, name, slug, visibility, metadata, "createdAt")
       VALUES (${orgId}, ${orgName}, ${slug}, 'private', ${metadata}, NOW())
@@ -121,7 +158,12 @@ export async function ensurePersonalOrganization(user: UserLike): Promise<Ensure
       INSERT INTO "member" (id, "userId", "organizationId", role, "createdAt")
       VALUES (${memberId}, ${user.id}, ${orgId}, 'owner', NOW())
     `;
+
+    result = { organizationId: orgId, slug, created: true };
   });
 
-  return { organizationId: orgId, slug, created: true };
+  if (!result) {
+    throw new Error('Personal organization transaction did not produce a result');
+  }
+  return result;
 }

--- a/packages/owletto-backend/src/auth/personal-org-provisioning.ts
+++ b/packages/owletto-backend/src/auth/personal-org-provisioning.ts
@@ -119,10 +119,12 @@ async function findExistingPersonalOrg(
   // user's personal one. Re-running the hook (e.g. after a transient failure)
   // is a no-op. The ORDER BY keeps resolution deterministic if legacy data ever
   // contains duplicates.
-  const tagFragment = `"personal_org_for_user_id":"${userId}"`;
+  // organization.metadata is `text` storing JSON; cast to jsonb and use ->>
+  // instead of LIKE so a userId containing % or _ can't match unintended rows.
   const existing = await sql`
     SELECT id, slug FROM "organization"
-    WHERE metadata IS NOT NULL AND metadata LIKE ${`%${tagFragment}%`}
+    WHERE metadata IS NOT NULL
+      AND (metadata::jsonb)->>'personal_org_for_user_id' = ${userId}
     ORDER BY "createdAt" ASC, id ASC
     LIMIT 1
   `;


### PR DESCRIPTION
## Summary
- New \`user.create.after\` hook in \`packages/owletto-backend/src/auth/index.tsx\` provisions a private organization for every newly created user, makes them owner.
- Idempotent via \`organization.metadata.personal_org_for_user_id\` tag (safe against Better Auth retry/replay).
- Slug derivation: \`username\` → \`name\` → \`email\` local part → \`user-<id-stub>\`; collisions suffix \`-2\`, \`-3\`, …
- \`RESERVED_SLUGS\` constant mirrors the DB \`org_slug_not_reserved\` CHECK constraint.

Foundation for product agents like examples/personal-finance: each user lands in the app with their own workspace into which template agents can be installed and schema mirrored.

## Test plan
- [x] 11 unit tests for \`slugify\` / \`deriveSlugCandidate\` / reserved-slug parity.
- [x] Pre-commit Biome + tsc pass.
- [ ] Manual: sign up a fresh user via the web app, confirm a new private \`organization\` row + \`member\` row exist with role=owner and slug derived from the user's profile.
- [ ] Manual: re-trigger the hook for the same user (simulating retry), confirm no duplicate org created.

## Stacked on
- Independent of #351 (DB migration for template-mirror columns) but both land in the personal-finance foundation series.