### PR TITLE
feat(agents): install-token + chat-claim primitives for WhatsApp deep-link install

### DIFF
--- a/packages/owletto-backend/src/agents/__tests__/install-token.test.ts
+++ b/packages/owletto-backend/src/agents/__tests__/install-token.test.ts
@@ -1,0 +1,98 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import {
+  isInstallTokenMessage,
+  mintInstallToken,
+  verifyInstallToken,
+} from '../install-token';
+
+const ORIGINAL_KEY = process.env.ENCRYPTION_KEY;
+
+describe('install-token', () => {
+  beforeAll(() => {
+    process.env.ENCRYPTION_KEY =
+      '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
+  });
+  afterAll(() => {
+    if (ORIGINAL_KEY === undefined) delete process.env.ENCRYPTION_KEY;
+    else process.env.ENCRYPTION_KEY = ORIGINAL_KEY;
+  });
+
+  describe('mint + verify round-trip', () => {
+    it('verifies a freshly minted token', () => {
+      const token = mintInstallToken({
+        userId: 'user_abc',
+        templateAgentId: 'agent_xyz',
+      });
+      expect(token.startsWith('install:')).toBe(true);
+
+      const result = verifyInstallToken(token);
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.userId).toBe('user_abc');
+        expect(result.templateAgentId).toBe('agent_xyz');
+        expect(result.expiresAt).toBeGreaterThan(Math.floor(Date.now() / 1000));
+      }
+    });
+
+    it('detects tampered payload via HMAC mismatch', () => {
+      const token = mintInstallToken({
+        userId: 'user_abc',
+        templateAgentId: 'agent_xyz',
+      });
+      const [head, sig] = token.slice('install:'.length).split('.');
+      const tamperedPayload = Buffer.from(
+        JSON.stringify({ u: 'attacker', t: 'agent_xyz', e: Math.floor(Date.now() / 1000) + 600 })
+      ).toString('base64url');
+      const tampered = `install:${tamperedPayload}.${sig}`;
+      const result = verifyInstallToken(tampered);
+      expect(result.ok).toBe(false);
+      if (!result.ok) expect(result.error).toBe('bad_signature');
+      expect(head).toBeTruthy();
+    });
+
+    it('rejects expired tokens', () => {
+      const token = mintInstallToken({
+        userId: 'user_abc',
+        templateAgentId: 'agent_xyz',
+        ttlSeconds: -1,
+      });
+      const result = verifyInstallToken(token);
+      expect(result.ok).toBe(false);
+      if (!result.ok) expect(result.error).toBe('expired');
+    });
+
+    it('rejects malformed tokens', () => {
+      expect(verifyInstallToken('not a token').ok).toBe(false);
+      expect(verifyInstallToken('install:').ok).toBe(false);
+      expect(verifyInstallToken('install:abc').ok).toBe(false);
+      expect(verifyInstallToken('install:abc.def').ok).toBe(false);
+    });
+
+    it('rejects tokens minted with a different secret', () => {
+      const token = mintInstallToken({
+        userId: 'user_abc',
+        templateAgentId: 'agent_xyz',
+      });
+      const oldKey = process.env.ENCRYPTION_KEY;
+      process.env.ENCRYPTION_KEY =
+        'fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210';
+      const result = verifyInstallToken(token);
+      expect(result.ok).toBe(false);
+      if (!result.ok) expect(result.error).toBe('bad_signature');
+      process.env.ENCRYPTION_KEY = oldKey;
+    });
+  });
+
+  describe('isInstallTokenMessage', () => {
+    it('accepts the canonical prefix', () => {
+      expect(isInstallTokenMessage('install:abc.def')).toBe(true);
+      expect(isInstallTokenMessage('   install:abc.def')).toBe(true);
+    });
+
+    it('rejects normal chat messages', () => {
+      expect(isInstallTokenMessage('hello')).toBe(false);
+      expect(isInstallTokenMessage('install me please')).toBe(false);
+      expect(isInstallTokenMessage('install: foo')).toBe(true); // a malformed token still claims to be one
+    });
+  });
+});

--- a/packages/owletto-backend/src/agents/install-token-routes.ts
+++ b/packages/owletto-backend/src/agents/install-token-routes.ts
@@ -1,0 +1,54 @@
+/**
+ * POST /api/install/token
+ * Mints a short-lived install token for a signed-in user. The landing page
+ * embeds it in a `https://wa.me/<bot-phone>?text=install:<token>` link so the
+ * user can claim the install via WhatsApp without re-typing their phone
+ * number.
+ */
+
+import { type Context, Hono } from 'hono';
+import { requireAuth } from '../auth/middleware';
+import type { Env } from '../index';
+import { errorMessage } from '../utils/errors';
+import { mintInstallToken } from './install-token';
+
+const installTokenRoutes = new Hono<{ Bindings: Env }>();
+
+function getAuthenticatedUser(c: Context<{ Bindings: Env }>) {
+  const user = c.get('user');
+  if (!user) throw new Error('Authenticated user missing from context');
+  return user;
+}
+
+installTokenRoutes.post('/install/token', requireAuth, async (c) => {
+  const user = getAuthenticatedUser(c);
+
+  let body: { templateAgentId?: string };
+  try {
+    body = await c.req.json();
+  } catch {
+    return c.json({ error: 'Invalid JSON body' }, 400);
+  }
+
+  if (!body.templateAgentId || typeof body.templateAgentId !== 'string') {
+    return c.json({ error: 'templateAgentId is required' }, 400);
+  }
+
+  try {
+    const token = mintInstallToken({
+      userId: user.id,
+      templateAgentId: body.templateAgentId,
+    });
+    return c.json({
+      token,
+      expiresInSeconds: 15 * 60,
+      // wa.me link is constructed by the caller — they know the bot's phone
+      // number from the connection config (or hard-coded in the landing
+      // page). We don't ship phone numbers from this endpoint.
+    });
+  } catch (error) {
+    return c.json({ error: errorMessage(error) }, 500);
+  }
+});
+
+export { installTokenRoutes };

--- a/packages/owletto-backend/src/agents/install-token.ts
+++ b/packages/owletto-backend/src/agents/install-token.ts
@@ -1,0 +1,115 @@
+/**
+ * Install tokens — short-lived HMAC-signed claims that authorize installing
+ * a specific template agent into a specific user's personal org via a
+ * non-web channel (e.g. inbound WhatsApp message containing the token).
+ *
+ * Format:
+ *   install:<base64url(payload)>.<base64url(hmac-sha256)>
+ * Payload (JSON): { u: userId, t: templateAgentId, e: expiryEpochSeconds }
+ *
+ * Stateless — no DB row. Re-using a token within the expiry window is fine
+ * (idempotent install). Once the token expires the user gets a fresh one
+ * from the landing page.
+ */
+
+import { createHmac, timingSafeEqual } from 'node:crypto';
+
+const TOKEN_PREFIX = 'install:';
+const TOKEN_TTL_SECONDS = 15 * 60;
+
+interface TokenPayload {
+  u: string; // userId
+  t: string; // templateAgentId
+  e: number; // expiry, epoch seconds
+}
+
+function getSecret(): Buffer {
+  const raw = process.env.ENCRYPTION_KEY;
+  if (!raw) {
+    throw new Error('ENCRYPTION_KEY is required to mint install tokens');
+  }
+  // Domain-separate from the encryption key by hashing once with a label.
+  return createHmac('sha256', raw).update('install-token:v1').digest();
+}
+
+function base64UrlEncode(buf: Buffer | string): string {
+  const b = typeof buf === 'string' ? Buffer.from(buf, 'utf8') : buf;
+  return b.toString('base64url');
+}
+
+function base64UrlDecode(s: string): Buffer {
+  return Buffer.from(s, 'base64url');
+}
+
+export function mintInstallToken(params: {
+  userId: string;
+  templateAgentId: string;
+  ttlSeconds?: number;
+}): string {
+  const ttl = params.ttlSeconds ?? TOKEN_TTL_SECONDS;
+  const payload: TokenPayload = {
+    u: params.userId,
+    t: params.templateAgentId,
+    e: Math.floor(Date.now() / 1000) + ttl,
+  };
+  const payloadEncoded = base64UrlEncode(JSON.stringify(payload));
+  const sig = createHmac('sha256', getSecret()).update(payloadEncoded).digest();
+  return `${TOKEN_PREFIX}${payloadEncoded}.${base64UrlEncode(sig)}`;
+}
+
+interface VerifyOk {
+  ok: true;
+  userId: string;
+  templateAgentId: string;
+  expiresAt: number;
+}
+interface VerifyErr {
+  ok: false;
+  error: 'malformed' | 'bad_signature' | 'expired';
+}
+
+export function verifyInstallToken(input: string): VerifyOk | VerifyErr {
+  if (!input.startsWith(TOKEN_PREFIX)) return { ok: false, error: 'malformed' };
+  const body = input.slice(TOKEN_PREFIX.length).trim();
+  const [payloadEncoded, sigEncoded] = body.split('.');
+  if (!payloadEncoded || !sigEncoded) return { ok: false, error: 'malformed' };
+
+  const expected = createHmac('sha256', getSecret()).update(payloadEncoded).digest();
+  let provided: Buffer;
+  try {
+    provided = base64UrlDecode(sigEncoded);
+  } catch {
+    return { ok: false, error: 'malformed' };
+  }
+  if (provided.length !== expected.length) return { ok: false, error: 'bad_signature' };
+  if (!timingSafeEqual(provided, expected)) return { ok: false, error: 'bad_signature' };
+
+  let payload: TokenPayload;
+  try {
+    payload = JSON.parse(base64UrlDecode(payloadEncoded).toString('utf8')) as TokenPayload;
+  } catch {
+    return { ok: false, error: 'malformed' };
+  }
+  if (
+    typeof payload.u !== 'string' ||
+    typeof payload.t !== 'string' ||
+    typeof payload.e !== 'number'
+  ) {
+    return { ok: false, error: 'malformed' };
+  }
+
+  if (Math.floor(Date.now() / 1000) >= payload.e) {
+    return { ok: false, error: 'expired' };
+  }
+  return {
+    ok: true,
+    userId: payload.u,
+    templateAgentId: payload.t,
+    expiresAt: payload.e,
+  };
+}
+
+/** True when an inbound chat message looks like an install token claim. */
+export function isInstallTokenMessage(text: string): boolean {
+  return text.trim().startsWith(TOKEN_PREFIX);
+}

--- a/packages/owletto-backend/src/agents/installed-agent-lookup.ts
+++ b/packages/owletto-backend/src/agents/installed-agent-lookup.ts
@@ -1,0 +1,159 @@
+/**
+ * Cross-package lookup that resolves an inbound platform identity (e.g.
+ * a WhatsApp JID) to the installed-agent instance the gateway should route
+ * messages to. Backed by the same Postgres the rest of owletto-backend uses;
+ * the gateway gets it via CoreServices.
+ *
+ * The data path:
+ *   wa_jid → entity_identities → $member entity → its organization →
+ *   the agent in that org with template_agent_id matching
+ */
+
+import { getDb } from '../db/client';
+import { installAgentFromTemplate } from './install';
+import { linkWhatsAppToMember } from '../auth/subject-identities';
+import { isInstallTokenMessage, verifyInstallToken } from './install-token';
+
+export interface InstalledAgentLocation {
+  agentId: string;
+  organizationId: string;
+}
+
+/**
+ * Find the agent instance that should handle messages from `(platform, userId)`
+ * for the given template. Returns null when the platform user hasn't yet
+ * installed the template agent in their personal org.
+ */
+export async function findInstalledAgentByIdentity(params: {
+  platform: string;
+  platformUserId: string;
+  templateAgentId: string;
+}): Promise<InstalledAgentLocation | null> {
+  const sql = getDb();
+  const namespace = identityNamespaceForPlatform(params.platform);
+  if (!namespace) return null;
+
+  // Single query: from the inbound identifier, walk to the $member entity,
+  // then to its organization, then to the agent installed in that org with
+  // matching template_agent_id.
+  const rows = await sql`
+    SELECT a.id AS agent_id, a.organization_id
+    FROM entity_identities ei
+    JOIN entities m ON m.id = ei.entity_id
+      AND m.entity_type = '$member'
+      AND m.deleted_at IS NULL
+    JOIN agents a ON a.organization_id = ei.organization_id
+      AND a.template_agent_id = ${params.templateAgentId}
+    WHERE ei.namespace = ${namespace}
+      AND ei.identifier = ${params.platformUserId}
+      AND ei.deleted_at IS NULL
+    LIMIT 1
+  `;
+  if (rows.length === 0) return null;
+  return {
+    agentId: rows[0].agent_id as string,
+    organizationId: rows[0].organization_id as string,
+  };
+}
+
+function identityNamespaceForPlatform(platform: string): string | null {
+  switch (platform.toLowerCase()) {
+    case 'whatsapp':
+      return 'wa_jid';
+    case 'slack':
+      return 'slack_user_id';
+    case 'telegram':
+      return 'telegram_user_id';
+    default:
+      return null;
+  }
+}
+
+/**
+ * Look up the email of the user who owns this Lobu user_id, used to bridge
+ * back into linkWhatsAppToMember (which keys on email — same as ensureMemberEntity).
+ */
+async function getUserEmail(userId: string): Promise<string | null> {
+  const sql = getDb();
+  const rows = await sql`SELECT email FROM "user" WHERE id = ${userId} LIMIT 1`;
+  if (rows.length === 0) return null;
+  return rows[0].email as string;
+}
+
+interface ClaimResult {
+  status: 'installed' | 'token_invalid' | 'token_expired' | 'no_personal_org' | 'no_member';
+  agentId?: string;
+  organizationId?: string;
+  reason?: string;
+}
+
+/**
+ * Process an inbound `install:<token>` message from a chat platform.
+ * Validates the token, completes the install in the user's personal org,
+ * and links the platform identity (e.g. wa_jid) to their $member.
+ *
+ * Returns a structured result the gateway can render back as a chat reply.
+ */
+export async function claimInstallFromChat(params: {
+  message: string;
+  platform: string;
+  platformUserId: string;
+}): Promise<ClaimResult> {
+  if (!isInstallTokenMessage(params.message)) {
+    return { status: 'token_invalid', reason: 'Message is not an install token' };
+  }
+  const verified = verifyInstallToken(params.message.trim());
+  if (!verified.ok) {
+    return verified.error === 'expired'
+      ? { status: 'token_expired' }
+      : { status: 'token_invalid', reason: verified.error };
+  }
+
+  const sql = getDb();
+  const orgRows = await sql`
+    SELECT id, slug FROM "organization"
+    WHERE metadata IS NOT NULL
+      AND metadata LIKE ${`%"personal_org_for_user_id":"${verified.userId}"%`}
+    ORDER BY "createdAt" ASC, id ASC
+    LIMIT 1
+  `;
+  if (orgRows.length === 0) {
+    return { status: 'no_personal_org' };
+  }
+  const personalOrgId = orgRows[0].id as string;
+
+  const installResult = await installAgentFromTemplate({
+    templateAgentId: verified.templateAgentId,
+    targetOrganizationId: personalOrgId,
+    userId: verified.userId,
+  });
+
+  // Link the platform identity. linkWhatsAppToMember keys on email, so we
+  // need it from the user row.
+  if (params.platform.toLowerCase() === 'whatsapp') {
+    const email = await getUserEmail(verified.userId);
+    if (!email) return { status: 'no_member' };
+    const linked = await linkWhatsAppToMember({
+      organizationId: personalOrgId,
+      email,
+      // The platformUserId here is already a JID like "447...@s.whatsapp.net".
+      // linkWhatsAppToMember normalizes from a phone string, so reverse-derive.
+      rawPhone: jidToPhone(params.platformUserId),
+    });
+    if ('error' in linked) {
+      return { status: 'no_member', reason: linked.error };
+    }
+  }
+
+  return {
+    status: 'installed',
+    agentId: installResult.agentId,
+    organizationId: installResult.organizationId,
+  };
+}
+
+function jidToPhone(jid: string): string {
+  const at = jid.indexOf('@');
+  const digits = at >= 0 ? jid.slice(0, at) : jid;
+  return `+${digits}`;
+}

--- a/packages/owletto-backend/src/index.ts
+++ b/packages/owletto-backend/src/index.ts
@@ -24,6 +24,7 @@ import { getDb } from './db/client';
 import * as invalidationEmitter from './events/emitter';
 import { isExcludedSpaPath } from './http/spa-route-filter';
 import { installRoutes } from './agents/install-routes';
+import { installTokenRoutes } from './agents/install-token-routes';
 import { agentRoutes } from './lobu/agent-routes';
 import { clientRoutes, platformSchemaRoutes } from './lobu/client-routes';
 import { isLobuGatewayRunning } from './lobu/gateway';
@@ -441,8 +442,10 @@ app.route('/api', credentialRoutes);
 /**
  * Template agent installation routes
  * POST /api/install — install a template agent into the caller's personal org
+ * POST /api/install/token — mint an install token for chat-side claim
  */
 app.route('/api', installRoutes);
+app.route('/api', installTokenRoutes);
 
 /**
  * OAuth 2.1 Authorization Server routes


### PR DESCRIPTION
## Summary
The backend half of the WhatsApp deep-link install flow. The landing page (next PR) will use the token endpoint to render a \`https://wa.me/<bot-phone>?text=install:<token>\` button; the gateway hot-path PR (follow-up) will use the lookup + claim helpers to actually receive and route the install message.

**New: \`install-token.ts\`**
- \`mintInstallToken(userId, templateAgentId, ttl=15min)\` and \`verifyInstallToken(message)\`.
- Format: \`install:<base64url(payload)>.<base64url(hmac)>\`. HMAC-SHA256 over a domain-separated key derived from \`ENCRYPTION_KEY\`.
- Stateless — no DB row, single-instance compatible with K8s replicas.

**New: \`install-token-routes.ts\`**
- \`POST /api/install/token\` (auth required) — signed-in user supplies \`{templateAgentId}\`, gets back \`{token, expiresInSeconds}\`. Landing page builds the wa.me link client-side.

**New: \`installed-agent-lookup.ts\`**
- \`findInstalledAgentByIdentity(platform, platformUserId, templateAgentId)\` — single SQL hop from inbound JID to the user's installed agent instance, via \`entity_identities\` → \`$member\` → \`organization\` → \`agents.template_agent_id\`.
- \`claimInstallFromChat(message, platform, platformUserId)\` — verifies the token, resolves the user's personal org, calls \`installAgentFromTemplate\`, and links the platform identity onto the \`\$member\`.

**Tests**
7 unit tests for the token: mint/verify round-trip, HMAC tamper detection, expiry, malformed input, secret rotation.

## Stacked on
\`feat/install-identity-provisioning\` (#359) — uses the \`linkWhatsAppToMember\` helper added there.

## Out of scope (follow-up PR)
The gateway-side wiring in \`message-handler-bridge.ts\` that:
1. Detects \`install:<token>\` and calls \`claimInstallFromChat\`.
2. For any other inbound message on a connection with \`templateAgentId\`, calls \`findInstalledAgentByIdentity\` and routes to the resolved agent. On miss, replies with the install URL.

That PR also adds a new optional \`getInstalledAgentLookup()\` method on \`CoreServices\` so owletto-backend can inject the implementation. Touches the hot path — deserves its own focused review.

## Test plan
- [x] 7 unit tests pass.
- [x] Typecheck clean.
- [ ] Manual: \`POST /api/install/token -d '{"templateAgentId":"..."}'\` while signed in returns a token; calling \`verifyInstallToken\` on it round-trips correctly.
- [ ] Manual: feed the token to \`claimInstallFromChat\` with platform=whatsapp + a JID — confirm install runs and \`entity_identities\` rows for \`wa_jid\`/\`phone\` are written.