### PR TITLE
feat(agents): install manifest endpoint + slug-based install

### DIFF
--- a/packages/owletto-backend/src/__tests__/integration/agents/install-manifest-routes.test.ts
+++ b/packages/owletto-backend/src/__tests__/integration/agents/install-manifest-routes.test.ts
@@ -1,0 +1,86 @@
+import { Hono } from 'hono';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { installManifestRoutes } from '../../../agents/install-manifest-routes';
+import type { Env } from '../../../index';
+import { cleanupTestDatabase, getTestDb } from '../../setup/test-db';
+import { createTestAgent, createTestOrganization } from '../../setup/test-fixtures';
+
+const ORIGINAL_PHONE = process.env.PERSONAL_FINANCE_BOT_PHONE;
+
+describe('GET /api/install/manifest/:slug', () => {
+  let templateOrg: Awaited<ReturnType<typeof createTestOrganization>>;
+  let templateAgent: Awaited<ReturnType<typeof createTestAgent>>;
+  let app: Hono<{ Bindings: Env }>;
+
+  beforeAll(async () => {
+    await cleanupTestDatabase();
+
+    templateOrg = await createTestOrganization({
+      name: 'Personal Finance',
+      slug: 'personal-finance',
+    });
+    templateAgent = await createTestAgent({
+      organizationId: templateOrg.id,
+      name: 'Personal Finance',
+    });
+
+    app = new Hono<{ Bindings: Env }>();
+    app.route('/api', installManifestRoutes);
+  });
+
+  afterAll(() => {
+    if (ORIGINAL_PHONE === undefined) delete process.env.PERSONAL_FINANCE_BOT_PHONE;
+    else process.env.PERSONAL_FINANCE_BOT_PHONE = ORIGINAL_PHONE;
+  });
+
+  it('resolves slug → template agent, returns name + description + templateAgentId', async () => {
+    const res = await app.request('/api/install/manifest/personal-finance');
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      slug: string;
+      name: string;
+      templateAgentId: string;
+      botPhone: string | null;
+    };
+    expect(body.slug).toBe('personal-finance');
+    expect(body.name).toBe('Personal Finance');
+    expect(body.templateAgentId).toBe(templateAgent.agentId);
+  });
+
+  it('returns botPhone as bare digits when env var is set', async () => {
+    process.env.PERSONAL_FINANCE_BOT_PHONE = '+447123456789';
+    const res = await app.request('/api/install/manifest/personal-finance');
+    const body = (await res.json()) as { botPhone: string | null };
+    expect(body.botPhone).toBe('447123456789');
+  });
+
+  it('returns botPhone: null when env var is unset', async () => {
+    delete process.env.PERSONAL_FINANCE_BOT_PHONE;
+    const res = await app.request('/api/install/manifest/personal-finance');
+    const body = (await res.json()) as { botPhone: string | null };
+    expect(body.botPhone).toBeNull();
+  });
+
+  it('returns 404 for an unknown slug', async () => {
+    const res = await app.request('/api/install/manifest/no-such-template');
+    expect(res.status).toBe(404);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe('not_found');
+  });
+
+  it('does not return a template-agent when only instance agents exist', async () => {
+    const sql = getTestDb();
+    const orphanOrg = await createTestOrganization({
+      name: 'Orphan',
+      slug: 'orphan-org',
+    });
+    // An agent that points at another template — i.e. it's an INSTANCE, not a template.
+    const instanceId = `agent_${Math.random().toString(36).slice(2, 10).toLowerCase()}`;
+    await sql`
+      INSERT INTO agents (id, organization_id, name, owner_platform, template_agent_id, is_workspace_agent, created_at, updated_at)
+      VALUES (${instanceId}, ${orphanOrg.id}, 'Instance', 'owletto', ${templateAgent.agentId}, false, NOW(), NOW())
+    `;
+    const res = await app.request('/api/install/manifest/orphan-org');
+    expect(res.status).toBe(404);
+  });
+});

--- a/packages/owletto-backend/src/agents/install-manifest-routes.ts
+++ b/packages/owletto-backend/src/agents/install-manifest-routes.ts
@@ -1,0 +1,82 @@
+/**
+ * Public install-discovery endpoint.
+ *
+ *   GET /api/install/manifest/:slug
+ *     → { slug, name, description, botPhone, templateAgentId }
+ *
+ * Lets a public landing page render itself + build a `wa.me/<botPhone>`
+ * link without baking the agent ID or bot phone into a Vite build. The
+ * frontend only ever knows the URL slug; everything else is server-resolved.
+ *
+ * Resolution rules:
+ *   - The URL slug equals the template org's slug. We currently maintain
+ *     one canonical template agent per template org (`agents.template_agent_id
+ *     IS NULL` row in that org).
+ *   - The bot's E.164 phone number (without `+`) is operator config. v1
+ *     reads it from a per-slug env var (e.g.
+ *     PERSONAL_FINANCE_BOT_PHONE=447123456789). When unset the manifest
+ *     reports `botPhone: null` and the landing page falls back to a
+ *     "message the bot to start" instruction.
+ *
+ * No auth — manifests are public marketing data.
+ */
+
+import { Hono } from 'hono';
+import { getDb } from '../db/client';
+import type { Env } from '../index';
+
+const installManifestRoutes = new Hono<{ Bindings: Env }>();
+
+interface ManifestRow {
+  id: string;
+  name: string;
+  description: string | null;
+}
+
+async function loadCanonicalTemplate(slug: string): Promise<ManifestRow | null> {
+  const sql = getDb();
+  const rows = await sql`
+    SELECT a.id, a.name, a.description
+    FROM agents a
+    JOIN "organization" o ON o.id = a.organization_id
+    WHERE o.slug = ${slug}
+      AND a.template_agent_id IS NULL
+    ORDER BY a.created_at ASC
+    LIMIT 1
+  `;
+  if (rows.length === 0) return null;
+  return rows[0] as ManifestRow;
+}
+
+function botPhoneForSlug(slug: string): string | null {
+  // Map URL slug → server env var. Adding a new productized template means
+  // adding one row here + setting the env. Avoids any frontend rebuild.
+  const envByName: Record<string, string | undefined> = {
+    'personal-finance': process.env.PERSONAL_FINANCE_BOT_PHONE,
+  };
+  const raw = envByName[slug];
+  if (!raw) return null;
+  // Accept "+447..." or "447..." in the env; surface to the wire as bare digits
+  // so the landing page can plug it straight into wa.me/<phone>.
+  return raw.replace(/^\+/, '').replace(/[^0-9]/g, '') || null;
+}
+
+installManifestRoutes.get('/install/manifest/:slug', async (c) => {
+  const slug = c.req.param('slug');
+  if (!slug) return c.json({ error: 'slug required' }, 400);
+
+  const template = await loadCanonicalTemplate(slug);
+  if (!template) {
+    return c.json({ error: 'not_found', message: `No installable template at /${slug}` }, 404);
+  }
+
+  return c.json({
+    slug,
+    name: template.name,
+    description: template.description,
+    botPhone: botPhoneForSlug(slug),
+    templateAgentId: template.id,
+  });
+});
+
+export { installManifestRoutes };

--- a/packages/owletto-backend/src/agents/install-routes.ts
+++ b/packages/owletto-backend/src/agents/install-routes.ts
@@ -1,10 +1,13 @@
 /**
  * Public install endpoints backing the /install/:slug landing pages.
  *
- * A signed-in user POSTs { templateAgentId, whatsapp_phone? } and we:
+ * A signed-in user POSTs { slug, whatsapp_phone? } (or the equivalent
+ * { templateAgentId } form) and we:
  *   1. Look up their personal org (created by the user.create.after hook).
- *   2. Mirror the template's schema into that org via installAgentFromTemplate.
- *   3. Optionally write a WhatsApp identity (`wa_jid` + `phone`) on their
+ *   2. Resolve the slug to its canonical template agent (or accept an
+ *      explicit templateAgentId from internal callers).
+ *   3. Mirror the template's schema into that org via installAgentFromTemplate.
+ *   4. Optionally write a WhatsApp identity (`wa_jid` + `phone`) on their
  *      $member entity so the gateway can later route inbound WhatsApp
  *      messages from that number back to this user's org.
  *
@@ -46,6 +49,21 @@ async function resolvePersonalOrg(
   return { id: rows[0].id as string, slug: rows[0].slug as string };
 }
 
+async function resolveTemplateAgentBySlug(slug: string): Promise<string | null> {
+  const sql = getDb();
+  const rows = await sql`
+    SELECT a.id
+    FROM agents a
+    JOIN "organization" o ON o.id = a.organization_id
+    WHERE o.slug = ${slug}
+      AND a.template_agent_id IS NULL
+    ORDER BY a.created_at ASC
+    LIMIT 1
+  `;
+  if (rows.length === 0) return null;
+  return rows[0].id as string;
+}
+
 installRoutes.post('/install', requireAuth, async (c) => {
   const user = getAuthenticatedUser(c);
 
@@ -58,15 +76,32 @@ installRoutes.post('/install', requireAuth, async (c) => {
     return c.json({ error: rateLimit.errorMessage }, 429);
   }
 
-  let body: { templateAgentId?: string; name?: string; whatsapp_phone?: string };
+  let body: {
+    slug?: string;
+    templateAgentId?: string;
+    name?: string;
+    whatsapp_phone?: string;
+  };
   try {
     body = await c.req.json();
   } catch {
     return c.json({ error: 'Invalid JSON body' }, 400);
   }
 
-  if (!body.templateAgentId || typeof body.templateAgentId !== 'string') {
-    return c.json({ error: 'templateAgentId is required' }, 400);
+  let templateAgentId: string;
+  if (typeof body.slug === 'string' && body.slug.trim()) {
+    const resolved = await resolveTemplateAgentBySlug(body.slug.trim());
+    if (!resolved) {
+      return c.json(
+        { error: 'unknown_slug', message: `No installable template at /${body.slug}` },
+        404
+      );
+    }
+    templateAgentId = resolved;
+  } else if (typeof body.templateAgentId === 'string' && body.templateAgentId.trim()) {
+    templateAgentId = body.templateAgentId.trim();
+  } else {
+    return c.json({ error: '`slug` or `templateAgentId` is required' }, 400);
   }
 
   const personalOrg = await resolvePersonalOrg(user.id);
@@ -84,7 +119,7 @@ installRoutes.post('/install', requireAuth, async (c) => {
   let installResult: Awaited<ReturnType<typeof installAgentFromTemplate>>;
   try {
     installResult = await installAgentFromTemplate({
-      templateAgentId: body.templateAgentId,
+      templateAgentId,
       targetOrganizationId: personalOrg.id,
       userId: user.id,
       name: body.name,

--- a/packages/owletto-backend/src/index.ts
+++ b/packages/owletto-backend/src/index.ts
@@ -23,6 +23,7 @@ import { connectRoutes } from './connect/routes';
 import { getDb } from './db/client';
 import * as invalidationEmitter from './events/emitter';
 import { isExcludedSpaPath } from './http/spa-route-filter';
+import { installManifestRoutes } from './agents/install-manifest-routes';
 import { installRoutes } from './agents/install-routes';
 import { agentRoutes } from './lobu/agent-routes';
 import { clientRoutes, platformSchemaRoutes } from './lobu/client-routes';
@@ -440,8 +441,10 @@ app.route('/api', credentialRoutes);
 
 /**
  * Template agent installation routes
+ * GET  /api/install/manifest/:slug — public discovery for a landing page
  * POST /api/install — install a template agent into the caller's personal org
  */
+app.route('/api', installManifestRoutes);
 app.route('/api', installRoutes);
 
 /**


### PR DESCRIPTION
## Summary
Replaces the env-var leak in the closed PRs (#361 + lobu-ai/owletto-web#19). Frontend now talks slugs only; the backend resolves internal IDs.

\`\`\`
GET  /api/install/manifest/:slug
  → { slug, name, description, botPhone, templateAgentId }

POST /api/install
  body now accepts { slug } in addition to { templateAgentId }
\`\`\`

**Resolution**
- \`slug\` equals the template org's slug. We pick the canonical template agent in that org (\`agents.template_agent_id IS NULL\`).
- \`botPhone\` comes from a per-slug server env var (e.g. \`PERSONAL_FINANCE_BOT_PHONE\`). Stripped to bare digits so the landing page plugs straight into \`wa.me/<digits>\`. Null when unset.

Public, no auth — manifests are marketing data. The install POST still requires a session.

**What this kills**
- Build-time \`VITE_PERSONAL_FINANCE_TEMPLATE_AGENT_ID\` (frontend no longer needs an agent ID).
- Build-time \`VITE_PERSONAL_FINANCE_BOT_PHONE\` (frontend no longer needs the bot phone).
- The HMAC install-token + chat-claim flow from the closed #361.

Net change against the closed work: drop ~430 LOC, replace 1 page, same product.

**Adding a new productized template** is now:
1. Seed the org + canonical template agent (existing tooling).
2. Set a per-slug bot phone env var if you want a wa.me link.
3. Link to \`/install/<new-slug>\`.

## Stacked on
\`feat/install-identity-provisioning\` (#359).

## Test plan
- [x] Manifest 200 returns expected shape.
- [x] Manifest 404 for unknown slug.
- [x] Manifest skips orgs that only contain instance agents (template_agent_id IS NOT NULL).
- [x] Manifest returns \`botPhone\` as bare digits when env var is set; null when unset.
- [x] Pre-commit Biome + tsc pass.
- [ ] Manual: \`POST /api/install -d '{"slug":"personal-finance","whatsapp_phone":"+447123456789"}'\` works without templateAgentId.