### PR TITLE
feat(watchers): per-field feedback storage with mutation kinds

### DIFF
--- a/db/migrations/20260425100000_normalize_watcher_feedback.sql
+++ b/db/migrations/20260425100000_normalize_watcher_feedback.sql
@@ -1,0 +1,87 @@
+-- migrate:up
+
+-- Normalize watcher feedback to one row per corrected field.
+--
+-- The original `watcher_window_feedback` stored every correction batch as a
+-- single JSONB blob (`corrections`) with one shared `notes` column. That
+-- shape blocks per-field notes, makes "latest correction per field" a JSONB
+-- aggregation, and lets duplicate submissions for the same field accumulate
+-- forever (the prompt summary then injects every historical version).
+--
+-- New table is per-field with explicit mutation kind so structural edits
+-- (remove an array item, append a new one) live alongside value corrections
+-- without overloading the value column. Existing rows are migrated by
+-- expanding the JSONB map into one row per key.
+
+CREATE TABLE IF NOT EXISTS public.watcher_window_field_feedback (
+    id bigserial PRIMARY KEY,
+    window_id integer NOT NULL REFERENCES public.watcher_windows(id) ON DELETE CASCADE,
+    watcher_id integer NOT NULL REFERENCES public.watchers(id) ON DELETE CASCADE,
+    organization_id text NOT NULL,
+    field_path text NOT NULL,
+    mutation text NOT NULL DEFAULT 'set'
+        CHECK (mutation IN ('set', 'remove', 'add')),
+    corrected_value jsonb,
+    note text,
+    created_by text NOT NULL,
+    created_at timestamp with time zone NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_wwff_watcher_field_recent
+    ON public.watcher_window_field_feedback (watcher_id, field_path, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_wwff_window
+    ON public.watcher_window_field_feedback (window_id);
+
+INSERT INTO public.watcher_window_field_feedback (
+    window_id, watcher_id, organization_id,
+    field_path, mutation, corrected_value, note,
+    created_by, created_at
+)
+SELECT
+    f.window_id,
+    f.watcher_id,
+    f.organization_id,
+    kv.key AS field_path,
+    'set' AS mutation,
+    kv.value AS corrected_value,
+    f.notes AS note,
+    f.created_by,
+    f.created_at
+FROM public.watcher_window_feedback f,
+     LATERAL jsonb_each(f.corrections) AS kv;
+
+DROP TABLE IF EXISTS public.watcher_window_feedback;
+
+-- migrate:down
+
+CREATE TABLE IF NOT EXISTS public.watcher_window_feedback (
+    id bigserial PRIMARY KEY,
+    window_id integer NOT NULL REFERENCES public.watcher_windows(id) ON DELETE CASCADE,
+    watcher_id integer NOT NULL REFERENCES public.watchers(id) ON DELETE CASCADE,
+    organization_id text NOT NULL,
+    corrections jsonb NOT NULL,
+    notes text,
+    created_by text NOT NULL,
+    created_at timestamp with time zone NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_wwf_window ON public.watcher_window_feedback(window_id);
+CREATE INDEX IF NOT EXISTS idx_wwf_watcher ON public.watcher_window_feedback(watcher_id);
+
+INSERT INTO public.watcher_window_feedback (
+    window_id, watcher_id, organization_id,
+    corrections, notes, created_by, created_at
+)
+SELECT
+    window_id,
+    watcher_id,
+    organization_id,
+    jsonb_object_agg(field_path, COALESCE(corrected_value, 'null'::jsonb)) AS corrections,
+    MAX(note) AS notes,
+    MAX(created_by) AS created_by,
+    MAX(created_at) AS created_at
+FROM public.watcher_window_field_feedback
+WHERE mutation = 'set'
+GROUP BY window_id, watcher_id, organization_id;
+
+DROP TABLE IF EXISTS public.watcher_window_field_feedback;

--- a/db/migrations/20260425100000_normalize_watcher_feedback.sql
+++ b/db/migrations/20260425100000_normalize_watcher_feedback.sql
@@ -68,6 +68,10 @@ CREATE TABLE IF NOT EXISTS public.watcher_window_feedback (
 CREATE INDEX IF NOT EXISTS idx_wwf_window ON public.watcher_window_feedback(window_id);
 CREATE INDEX IF NOT EXISTS idx_wwf_watcher ON public.watcher_window_feedback(watcher_id);
 
+-- Best-effort rollback: structural mutations ('add' / 'remove') don't fit
+-- the old shape and are dropped (WHERE mutation = 'set'). When multiple
+-- contributors edited the same window, MAX(note) and MAX(created_by) pick
+-- one arbitrarily — this is an emergency recovery path, not a clean inverse.
 INSERT INTO public.watcher_window_feedback (
     window_id, watcher_id, organization_id,
     corrections, notes, created_by, created_at

--- a/packages/owletto-backend/src/__tests__/integration/watchers/feedback.test.ts
+++ b/packages/owletto-backend/src/__tests__/integration/watchers/feedback.test.ts
@@ -324,6 +324,30 @@ describe('Watcher feedback', () => {
         )
       ).rejects.toThrow(/requires a value/);
     });
+
+    it('refuses to submit feedback against a watcher in a different org', async () => {
+      // Build a watcher in a second org. The first user (Alice) has no
+      // membership there, so her token's org context is still the first org;
+      // passing the foreign watcher_id must fail the org-scoped windowCheck.
+      const otherOrg = await createTestOrganization({ name: 'Stranger Org' });
+      const otherUser = await createTestUser({ email: 'stranger@test.com' });
+      await addUserToOrganization(otherUser.id, otherOrg.id, 'owner');
+      const foreign = await seedWatcher(otherOrg.id, otherUser.id);
+      const foreignWindow = await seedWindow(foreign.id, { problems: [] });
+
+      await expect(
+        mcpToolsCall(
+          'manage_watchers',
+          {
+            action: 'submit_feedback',
+            watcher_id: String(foreign.id),
+            window_id: foreignWindow,
+            corrections: [{ field_path: 'problems[0]', value: 'x' }],
+          },
+          { token }
+        )
+      ).rejects.toThrow(/not found/);
+    });
   });
 
   describe('get_feedback', () => {

--- a/packages/owletto-backend/src/__tests__/integration/watchers/feedback.test.ts
+++ b/packages/owletto-backend/src/__tests__/integration/watchers/feedback.test.ts
@@ -1,0 +1,401 @@
+/**
+ * Integration tests for the per-field watcher feedback API.
+ *
+ * Covers the schema introduced by the
+ * `20260425100000_normalize_watcher_feedback` migration:
+ * - `submit_feedback` accepts an array of {field_path, mutation, value, note}
+ * - mutation kinds: `set` (default), `remove`, `add`
+ * - `get_feedback` returns one row per submission, newest first; the prompt
+ *   summary is responsible for collapsing per-field at read time
+ * - validation: empty array, bad mutation, missing value for set/add
+ *
+ * The watcher row is built directly via SQL because the existing
+ * `createTestWatcherTemplate` fixture predates the `watcher_group_id NOT NULL`
+ * migration and would fail unrelated to anything tested here.
+ */
+
+import { beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { cleanupTestDatabase, getTestDb } from '../../setup/test-db';
+import {
+  addUserToOrganization,
+  createTestAccessToken,
+  createTestEntity,
+  createTestOAuthClient,
+  createTestOrganization,
+  createTestUser,
+  seedSystemEntityTypes,
+} from '../../setup/test-fixtures';
+import { mcpToolsCall } from '../../setup/test-helpers';
+
+interface SeededWatcher {
+  id: number;
+  versionId: number;
+}
+
+async function seedWatcher(organizationId: string, userId: string): Promise<SeededWatcher> {
+  const sql = getTestDb();
+  const [version] = await sql<{ id: number }[]>`
+    INSERT INTO watcher_versions (
+      version, name, description, prompt, extraction_schema, created_by
+    ) VALUES (
+      1,
+      'Feedback Test',
+      'Watcher used to exercise the feedback APIs',
+      'Analyze inputs',
+      ${sql.json({
+        type: 'object',
+        properties: {
+          problems: {
+            type: 'array',
+            items: {
+              type: 'object',
+              properties: {
+                name: { type: 'string' },
+                severity: { type: 'string', enum: ['low', 'medium', 'high'] },
+              },
+            },
+          },
+        },
+      })},
+      ${userId}
+    )
+    RETURNING id
+  `;
+
+  const [watcher] = await sql<{ id: number }[]>`
+    INSERT INTO watchers (
+      slug, name, description, status, created_by, organization_id,
+      current_version_id, watcher_group_id
+    ) VALUES (
+      'feedback-test',
+      'Feedback Test',
+      'Feedback API integration watcher',
+      'active',
+      ${userId},
+      ${organizationId},
+      ${version.id},
+      0
+    )
+    RETURNING id
+  `;
+  await sql`UPDATE watchers SET watcher_group_id = ${watcher.id} WHERE id = ${watcher.id}`;
+  await sql`UPDATE watcher_versions SET watcher_id = ${watcher.id} WHERE id = ${version.id}`;
+
+  return { id: watcher.id, versionId: version.id };
+}
+
+async function seedWindow(
+  watcherId: number,
+  extractedData: Record<string, unknown>
+): Promise<number> {
+  const sql = getTestDb();
+  const [row] = await sql<{ id: number }[]>`
+    INSERT INTO watcher_windows (
+      watcher_id, granularity, window_start, window_end,
+      extracted_data, content_analyzed, model_used, created_at
+    ) VALUES (
+      ${watcherId}, 'weekly',
+      ${new Date(Date.now() - 7 * 24 * 60 * 60 * 1000)},
+      ${new Date()},
+      ${sql.json(extractedData)},
+      0, 'test-model', NOW()
+    )
+    RETURNING id
+  `;
+  return row.id;
+}
+
+describe('Watcher feedback', () => {
+  let org: Awaited<ReturnType<typeof createTestOrganization>>;
+  let user: Awaited<ReturnType<typeof createTestUser>>;
+  let token: string;
+  let watcher: SeededWatcher;
+  let windowId: number;
+
+  beforeAll(async () => {
+    await cleanupTestDatabase();
+    await seedSystemEntityTypes();
+
+    org = await createTestOrganization({ name: 'Feedback Test Org' });
+    user = await createTestUser({ email: 'feedback@test.com' });
+    await addUserToOrganization(user.id, org.id, 'owner');
+
+    const client = await createTestOAuthClient();
+    token = (await createTestAccessToken(user.id, org.id, client.client_id)).token;
+
+    // createTestEntity ensures the org-bound entity types are seeded; the
+    // entity itself isn't referenced by the feedback flow.
+    await createTestEntity({ name: 'Feedback Entity', organization_id: org.id });
+
+    watcher = await seedWatcher(org.id, user.id);
+    windowId = await seedWindow(watcher.id, {
+      problems: [
+        { name: 'A', severity: 'low' },
+        { name: 'B', severity: 'medium' },
+      ],
+    });
+  });
+
+  beforeEach(async () => {
+    const sql = getTestDb();
+    await sql`DELETE FROM watcher_window_field_feedback WHERE watcher_id = ${watcher.id}`;
+  });
+
+  describe('submit_feedback', () => {
+    it('accepts a single set correction (default mutation)', async () => {
+      const result = await mcpToolsCall(
+        'manage_watchers',
+        {
+          action: 'submit_feedback',
+          watcher_id: String(watcher.id),
+          window_id: windowId,
+          corrections: [
+            { field_path: 'problems[0].severity', value: 'high', note: 'misclassified' },
+          ],
+        },
+        { token }
+      );
+      expect(result.feedback_ids).toHaveLength(1);
+
+      const sql = getTestDb();
+      const rows = await sql<
+        {
+          field_path: string;
+          mutation: string;
+          corrected_value: unknown;
+          note: string | null;
+        }[]
+      >`SELECT field_path, mutation, corrected_value, note FROM watcher_window_field_feedback WHERE watcher_id = ${watcher.id}`;
+      expect(rows).toHaveLength(1);
+      expect(rows[0].field_path).toBe('problems[0].severity');
+      expect(rows[0].mutation).toBe('set');
+      expect(rows[0].corrected_value).toBe('high');
+      expect(rows[0].note).toBe('misclassified');
+    });
+
+    it('accepts a remove correction without a value', async () => {
+      const result = await mcpToolsCall(
+        'manage_watchers',
+        {
+          action: 'submit_feedback',
+          watcher_id: String(watcher.id),
+          window_id: windowId,
+          corrections: [{ field_path: 'problems[1]', mutation: 'remove' }],
+        },
+        { token }
+      );
+      expect(result.feedback_ids).toHaveLength(1);
+
+      const sql = getTestDb();
+      const rows = await sql<
+        { mutation: string; corrected_value: unknown }[]
+      >`SELECT mutation, corrected_value FROM watcher_window_field_feedback WHERE watcher_id = ${watcher.id}`;
+      expect(rows[0].mutation).toBe('remove');
+      expect(rows[0].corrected_value).toBeNull();
+    });
+
+    it('accepts an add correction that appends to an array', async () => {
+      const result = await mcpToolsCall(
+        'manage_watchers',
+        {
+          action: 'submit_feedback',
+          watcher_id: String(watcher.id),
+          window_id: windowId,
+          corrections: [
+            {
+              field_path: 'problems',
+              mutation: 'add',
+              value: { name: 'C', severity: 'high' },
+            },
+          ],
+        },
+        { token }
+      );
+      expect(result.feedback_ids).toHaveLength(1);
+
+      const sql = getTestDb();
+      const rows = await sql<
+        { mutation: string; corrected_value: { name: string; severity: string } }[]
+      >`SELECT mutation, corrected_value FROM watcher_window_field_feedback WHERE watcher_id = ${watcher.id}`;
+      expect(rows[0].mutation).toBe('add');
+      expect(rows[0].corrected_value).toEqual({ name: 'C', severity: 'high' });
+    });
+
+    it('stores multiple corrections from one batch as separate rows', async () => {
+      await mcpToolsCall(
+        'manage_watchers',
+        {
+          action: 'submit_feedback',
+          watcher_id: String(watcher.id),
+          window_id: windowId,
+          corrections: [
+            { field_path: 'problems[0].severity', value: 'high' },
+            { field_path: 'problems[0].name', value: 'Renamed A' },
+            { field_path: 'problems[1]', mutation: 'remove' },
+          ],
+        },
+        { token }
+      );
+
+      const sql = getTestDb();
+      const rows = await sql`SELECT field_path, mutation FROM watcher_window_field_feedback WHERE watcher_id = ${watcher.id} ORDER BY field_path`;
+      expect(rows).toHaveLength(3);
+      expect(rows.map((r) => r.field_path)).toEqual([
+        'problems[0].name',
+        'problems[0].severity',
+        'problems[1]',
+      ]);
+    });
+
+    it('lets a later submission supersede an earlier one without overwriting', async () => {
+      const path = 'problems[0].severity';
+      await mcpToolsCall(
+        'manage_watchers',
+        {
+          action: 'submit_feedback',
+          watcher_id: String(watcher.id),
+          window_id: windowId,
+          corrections: [{ field_path: path, value: 'medium' }],
+        },
+        { token }
+      );
+      await mcpToolsCall(
+        'manage_watchers',
+        {
+          action: 'submit_feedback',
+          watcher_id: String(watcher.id),
+          window_id: windowId,
+          corrections: [{ field_path: path, value: 'high', note: 'on second look' }],
+        },
+        { token }
+      );
+
+      const sql = getTestDb();
+      const rows = await sql<
+        { corrected_value: unknown; note: string | null }[]
+      >`SELECT corrected_value, note FROM watcher_window_field_feedback WHERE watcher_id = ${watcher.id} AND field_path = ${path} ORDER BY created_at ASC, id ASC`;
+      expect(rows).toHaveLength(2);
+      expect(rows[0].corrected_value).toBe('medium');
+      expect(rows[1].corrected_value).toBe('high');
+      expect(rows[1].note).toBe('on second look');
+    });
+
+    it('rejects an empty corrections array', async () => {
+      await expect(
+        mcpToolsCall(
+          'manage_watchers',
+          {
+            action: 'submit_feedback',
+            watcher_id: String(watcher.id),
+            window_id: windowId,
+            corrections: [],
+          },
+          { token }
+        )
+      ).rejects.toThrow(/non-empty array/);
+    });
+
+    it('rejects an unsupported mutation kind', async () => {
+      await expect(
+        mcpToolsCall(
+          'manage_watchers',
+          {
+            action: 'submit_feedback',
+            watcher_id: String(watcher.id),
+            window_id: windowId,
+            corrections: [{ field_path: 'problems[0]', mutation: 'patch', value: 'x' }],
+          },
+          { token }
+        )
+      ).rejects.toThrow();
+    });
+
+    it('rejects a set mutation with no value', async () => {
+      await expect(
+        mcpToolsCall(
+          'manage_watchers',
+          {
+            action: 'submit_feedback',
+            watcher_id: String(watcher.id),
+            window_id: windowId,
+            corrections: [{ field_path: 'problems[0].severity' }],
+          },
+          { token }
+        )
+      ).rejects.toThrow(/requires a value/);
+    });
+  });
+
+  describe('get_feedback', () => {
+    it('returns rows newest-first for a watcher', async () => {
+      await mcpToolsCall(
+        'manage_watchers',
+        {
+          action: 'submit_feedback',
+          watcher_id: String(watcher.id),
+          window_id: windowId,
+          corrections: [{ field_path: 'problems[0].severity', value: 'medium' }],
+        },
+        { token }
+      );
+      await mcpToolsCall(
+        'manage_watchers',
+        {
+          action: 'submit_feedback',
+          watcher_id: String(watcher.id),
+          window_id: windowId,
+          corrections: [{ field_path: 'problems[0].severity', value: 'high' }],
+        },
+        { token }
+      );
+
+      const result = await mcpToolsCall(
+        'manage_watchers',
+        {
+          action: 'get_feedback',
+          watcher_id: String(watcher.id),
+        },
+        { token }
+      );
+      expect(result.feedback).toHaveLength(2);
+      expect(result.feedback[0].corrected_value).toBe('high');
+      expect(result.feedback[1].corrected_value).toBe('medium');
+    });
+
+    it('filters by window_id when provided', async () => {
+      const otherWindow = await seedWindow(watcher.id, { problems: [] });
+      await mcpToolsCall(
+        'manage_watchers',
+        {
+          action: 'submit_feedback',
+          watcher_id: String(watcher.id),
+          window_id: windowId,
+          corrections: [{ field_path: 'a', value: 1 }],
+        },
+        { token }
+      );
+      await mcpToolsCall(
+        'manage_watchers',
+        {
+          action: 'submit_feedback',
+          watcher_id: String(watcher.id),
+          window_id: otherWindow,
+          corrections: [{ field_path: 'b', value: 2 }],
+        },
+        { token }
+      );
+
+      const filtered = await mcpToolsCall(
+        'manage_watchers',
+        {
+          action: 'get_feedback',
+          watcher_id: String(watcher.id),
+          window_id: otherWindow,
+        },
+        { token }
+      );
+      expect(filtered.feedback).toHaveLength(1);
+      expect(filtered.feedback[0].field_path).toBe('b');
+    });
+  });
+});

--- a/packages/owletto-backend/src/start-local.ts
+++ b/packages/owletto-backend/src/start-local.ts
@@ -395,6 +395,6 @@ async function startEmbeddings(): Promise<ReturnType<typeof fork> | null> {
 }
 
 main().catch((error) => {
-  logger.error({ error }, 'Failed to start');
+  logger.error({ err: error }, 'Failed to start');
   process.exit(1);
 });

--- a/packages/owletto-backend/src/tools/admin/index.ts
+++ b/packages/owletto-backend/src/tools/admin/index.ts
@@ -107,7 +107,7 @@ EXECUTION WORKFLOW: Use read_knowledge(watcher_id, since/until) to fetch prompt_
 
 REACTION SCRIPTS: Use set_reaction_script to attach TypeScript that auto-executes after complete_window. Script receives ReactionContext + ReactionSDK for entities, actions, content, and notifications.
 
-FEEDBACK: Use submit_feedback(watcher_id, window_id, corrections, notes) to correct extraction fields. Use get_feedback(watcher_id) to retrieve corrections. Corrections are automatically injected into future prompts.`,
+FEEDBACK: Use submit_feedback(watcher_id, window_id, corrections=[{field_path, mutation?, value?, note?}]) to correct extraction. Mutation defaults to 'set'; use 'remove' to drop an array item, 'add' to append one. Each entry is stored as its own row so later submissions supersede earlier ones per field. Use get_feedback(watcher_id) to retrieve corrections. Most-recent-per-field corrections are injected into future prompts.`,
     inputSchema: ManageWatchersSchema,
     annotations: { destructiveHint: false },
     handler: async (args: Static<typeof ManageWatchersSchema>, env: Env, ctx: ToolContext) => {

--- a/packages/owletto-backend/src/tools/admin/manage_watchers.ts
+++ b/packages/owletto-backend/src/tools/admin/manage_watchers.ts
@@ -668,7 +668,7 @@ export async function manageWatchers(
     get_version_details: () => handleGetVersionDetails(args),
     get_component_reference: () => Promise.resolve(handleGetComponentReference()),
     submit_feedback: () => handleSubmitFeedback(args, ctx),
-    get_feedback: () => handleGetFeedback(args),
+    get_feedback: () => handleGetFeedback(args, ctx),
     create_from_version: () => handleCreateFromVersion(args, env, ctx),
   });
 }
@@ -2507,11 +2507,15 @@ async function handleSubmitFeedback(
   const sql = getDb();
   const watcherId = Number(args.watcher_id);
 
+  // Scope to the caller's current org so a member of org A can't write
+  // feedback against a watcher in org B by passing its watcher_id.
   const windowCheck = await sql`
     SELECT ww.id, w.organization_id
     FROM watcher_windows ww
     JOIN watchers w ON ww.watcher_id = w.id
-    WHERE ww.id = ${args.window_id} AND ww.watcher_id = ${watcherId}
+    WHERE ww.id = ${args.window_id}
+      AND ww.watcher_id = ${watcherId}
+      AND w.organization_id = ${ctx.organizationId}
   `;
   if (windowCheck.length === 0) {
     throw new Error(`Window ${args.window_id} not found for watcher ${watcherId}`);
@@ -2551,13 +2555,18 @@ async function handleSubmitFeedback(
   };
 }
 
-async function handleGetFeedback(args: ManageWatchersArgs): Promise<ManageWatchersResult> {
+async function handleGetFeedback(
+  args: ManageWatchersArgs,
+  ctx: ToolContext
+): Promise<ManageWatchersResult> {
   if (!args.watcher_id) throw new Error('watcher_id is required');
 
   const sql = getDb();
   const watcherId = Number(args.watcher_id);
   const limit = args.limit ?? 50;
 
+  // Scope to the caller's current org so a member of org A can't enumerate
+  // feedback for a watcher in org B by passing its watcher_id.
   const feedback = args.window_id
     ? await sql`
         SELECT f.id, f.window_id, f.field_path, f.mutation, f.corrected_value,
@@ -2565,7 +2574,9 @@ async function handleGetFeedback(args: ManageWatchersArgs): Promise<ManageWatche
                w.window_start, w.window_end
         FROM watcher_window_field_feedback f
         JOIN watcher_windows w ON f.window_id = w.id
-        WHERE f.watcher_id = ${watcherId} AND f.window_id = ${args.window_id}
+        WHERE f.watcher_id = ${watcherId}
+          AND f.window_id = ${args.window_id}
+          AND f.organization_id = ${ctx.organizationId}
         ORDER BY f.created_at DESC
         LIMIT ${limit}
       `
@@ -2576,6 +2587,7 @@ async function handleGetFeedback(args: ManageWatchersArgs): Promise<ManageWatche
         FROM watcher_window_field_feedback f
         JOIN watcher_windows w ON f.window_id = w.id
         WHERE f.watcher_id = ${watcherId}
+          AND f.organization_id = ${ctx.organizationId}
         ORDER BY f.created_at DESC
         LIMIT ${limit}
       `;

--- a/packages/owletto-backend/src/tools/admin/manage_watchers.ts
+++ b/packages/owletto-backend/src/tools/admin/manage_watchers.ts
@@ -462,19 +462,40 @@ export const ManageWatchersSchema = Type.Object({
     })
   ),
   corrections: Type.Optional(
-    Type.Any({
-      description:
-        '[submit_feedback] JSONB object with field path corrections, e.g. { "problems[1].severity": "high" }',
-    })
-  ),
-  notes: Type.Optional(
-    Type.String({
-      description: '[submit_feedback] Optional explanation for the corrections.',
-    })
+    Type.Array(
+      Type.Object({
+        field_path: Type.String({
+          description:
+            'Dot/bracket path into extracted_data, e.g. "problems[1].severity" or "problems[2]" for an array item.',
+        }),
+        mutation: Type.Optional(
+          Type.Union(
+            [Type.Literal('set'), Type.Literal('remove'), Type.Literal('add')],
+            {
+              description:
+                'Default "set". Use "remove" to drop an array item; "add" to append one.',
+            }
+          )
+        ),
+        value: Type.Optional(
+          Type.Any({
+            description:
+              'New value for set/add. Omitted for remove. Any JSON type (string/number/object/array).',
+          })
+        ),
+        note: Type.Optional(
+          Type.String({ description: 'Optional per-field explanation.' })
+        ),
+      }),
+      {
+        description:
+          '[submit_feedback] One entry per corrected field. Each row is stored independently so future corrections can supersede earlier ones per field.',
+      }
+    )
   ),
   limit: Type.Optional(
     Type.Number({
-      description: '[get_feedback] Max feedback records to return (default: 20).',
+      description: '[get_feedback] Max feedback records to return (default: 50).',
     })
   ),
 });
@@ -535,9 +556,9 @@ type ManageWatchersResult =
   | { action: 'get_component_reference'; documentation: ComponentReferenceDocumentation }
   | {
       action: 'submit_feedback';
-      feedback_id: number;
       watcher_id: string;
       window_id: number;
+      feedback_ids: number[];
     }
   | {
       action: 'get_feedback';
@@ -545,8 +566,10 @@ type ManageWatchersResult =
       feedback: Array<{
         id: number;
         window_id: number;
-        corrections: Record<string, unknown>;
-        notes: string | null;
+        field_path: string;
+        mutation: 'set' | 'remove' | 'add';
+        corrected_value: unknown;
+        note: string | null;
         created_by: string;
         created_at: string;
         window_start?: string;
@@ -2447,28 +2470,43 @@ async function handleGetVersionDetails(args: ManageWatchersArgs): Promise<Manage
 // Feedback Handlers
 // ============================================
 
+type CorrectionInput = {
+  field_path: string;
+  mutation?: 'set' | 'remove' | 'add';
+  value?: unknown;
+  note?: string;
+};
+
 async function handleSubmitFeedback(
   args: ManageWatchersArgs,
   ctx: ToolContext
 ): Promise<ManageWatchersResult> {
   if (!args.watcher_id) throw new Error('watcher_id is required');
   if (!args.window_id) throw new Error('window_id is required');
-  if (!args.corrections || typeof args.corrections !== 'object') {
-    throw new Error('corrections is required and must be a JSON object');
-  }
   if (!ctx.userId) {
     throw new Error('Authentication required to submit feedback');
   }
+  const corrections = args.corrections as CorrectionInput[] | undefined;
+  if (!Array.isArray(corrections) || corrections.length === 0) {
+    throw new Error('corrections must be a non-empty array of {field_path, ...} entries');
+  }
 
-  const correctionKeys = Object.keys(args.corrections as Record<string, unknown>);
-  if (correctionKeys.length === 0) {
-    throw new Error('corrections must contain at least one field');
+  for (const c of corrections) {
+    if (!c.field_path || typeof c.field_path !== 'string') {
+      throw new Error('each correction requires a string field_path');
+    }
+    const m = c.mutation ?? 'set';
+    if (m !== 'set' && m !== 'remove' && m !== 'add') {
+      throw new Error(`unsupported mutation "${m}" for ${c.field_path}`);
+    }
+    if ((m === 'set' || m === 'add') && c.value === undefined) {
+      throw new Error(`${m} correction for ${c.field_path} requires a value`);
+    }
   }
 
   const sql = getDb();
   const watcherId = Number(args.watcher_id);
 
-  // Verify window exists and belongs to this watcher, get org_id from watchers table
   const windowCheck = await sql`
     SELECT ww.id, w.organization_id
     FROM watcher_windows ww
@@ -2478,25 +2516,38 @@ async function handleSubmitFeedback(
   if (windowCheck.length === 0) {
     throw new Error(`Window ${args.window_id} not found for watcher ${watcherId}`);
   }
+  const organizationId = windowCheck[0].organization_id as string;
 
-  const result = await sql`
-    INSERT INTO watcher_window_feedback (
-      window_id, watcher_id, organization_id,
-      corrections, notes, created_by
-    )
-    VALUES (
-      ${args.window_id}, ${watcherId}, ${windowCheck[0].organization_id},
-      ${sql.json(args.corrections)}, ${args.notes || null},
-      ${ctx.userId}
-    )
-    RETURNING id
-  `;
+  // Insert in one transaction so a partial failure never leaks half-applied
+  // corrections — submit_feedback is naturally a batch operation from the UI.
+  const feedbackIds = await sql.begin(async (tx) => {
+    const ids: number[] = [];
+    for (const c of corrections) {
+      const mutation = c.mutation ?? 'set';
+      const correctedValueJson =
+        mutation === 'remove' || c.value === undefined ? null : tx.json(c.value);
+      const result = await tx`
+        INSERT INTO watcher_window_field_feedback (
+          window_id, watcher_id, organization_id,
+          field_path, mutation, corrected_value, note, created_by
+        )
+        VALUES (
+          ${args.window_id}, ${watcherId}, ${organizationId},
+          ${c.field_path}, ${mutation}, ${correctedValueJson},
+          ${c.note ?? null}, ${ctx.userId}
+        )
+        RETURNING id
+      `;
+      ids.push(Number(result[0].id));
+    }
+    return ids;
+  });
 
   return {
     action: 'submit_feedback',
-    feedback_id: Number(result[0].id),
     watcher_id: args.watcher_id,
     window_id: args.window_id,
+    feedback_ids: feedbackIds,
   };
 }
 
@@ -2505,30 +2556,29 @@ async function handleGetFeedback(args: ManageWatchersArgs): Promise<ManageWatche
 
   const sql = getDb();
   const watcherId = Number(args.watcher_id);
-  const limit = args.limit ?? 20;
+  const limit = args.limit ?? 50;
 
-  let feedback;
-  if (args.window_id) {
-    feedback = await sql`
-      SELECT f.id, f.window_id, f.corrections, f.notes, f.created_by, f.created_at,
-             w.window_start, w.window_end
-      FROM watcher_window_feedback f
-      JOIN watcher_windows w ON f.window_id = w.id
-      WHERE f.watcher_id = ${watcherId} AND f.window_id = ${args.window_id}
-      ORDER BY f.created_at DESC
-      LIMIT ${limit}
-    `;
-  } else {
-    feedback = await sql`
-      SELECT f.id, f.window_id, f.corrections, f.notes, f.created_by, f.created_at,
-             w.window_start, w.window_end
-      FROM watcher_window_feedback f
-      JOIN watcher_windows w ON f.window_id = w.id
-      WHERE f.watcher_id = ${watcherId}
-      ORDER BY f.created_at DESC
-      LIMIT ${limit}
-    `;
-  }
+  const feedback = args.window_id
+    ? await sql`
+        SELECT f.id, f.window_id, f.field_path, f.mutation, f.corrected_value,
+               f.note, f.created_by, f.created_at,
+               w.window_start, w.window_end
+        FROM watcher_window_field_feedback f
+        JOIN watcher_windows w ON f.window_id = w.id
+        WHERE f.watcher_id = ${watcherId} AND f.window_id = ${args.window_id}
+        ORDER BY f.created_at DESC
+        LIMIT ${limit}
+      `
+    : await sql`
+        SELECT f.id, f.window_id, f.field_path, f.mutation, f.corrected_value,
+               f.note, f.created_by, f.created_at,
+               w.window_start, w.window_end
+        FROM watcher_window_field_feedback f
+        JOIN watcher_windows w ON f.window_id = w.id
+        WHERE f.watcher_id = ${watcherId}
+        ORDER BY f.created_at DESC
+        LIMIT ${limit}
+      `;
 
   return {
     action: 'get_feedback',
@@ -2536,8 +2586,10 @@ async function handleGetFeedback(args: ManageWatchersArgs): Promise<ManageWatche
     feedback: feedback.map((row) => ({
       id: Number(row.id),
       window_id: Number(row.window_id),
-      corrections: row.corrections as Record<string, unknown>,
-      notes: row.notes as string | null,
+      field_path: row.field_path as string,
+      mutation: row.mutation as 'set' | 'remove' | 'add',
+      corrected_value: row.corrected_value as unknown,
+      note: row.note as string | null,
       created_by: row.created_by as string,
       created_at: (row.created_at as Date).toISOString(),
       window_start: row.window_start ? (row.window_start as Date).toISOString() : undefined,

--- a/packages/owletto-backend/src/tools/get_content.ts
+++ b/packages/owletto-backend/src/tools/get_content.ts
@@ -104,7 +104,7 @@ import {
   getOrganizationSlug,
   getPublicWebUrl,
 } from '../utils/url-builder';
-import { getRecentFeedbackSummary, hasFeedback } from '../utils/watcher-feedback';
+import { getRecentFeedbackSummary } from '../utils/watcher-feedback';
 import { getAvailableOperations, getPastReactionsSummary } from '../utils/watcher-reactions';
 import { computePendingWindow, queryUncondensedWindows } from '../utils/window-utils';
 import type { ToolContext } from './registry';
@@ -1669,16 +1669,14 @@ async function handleWatcherMode(
 
   let pastFeedback: string | undefined;
   try {
-    const [pastReactionsResult, operations, feedbackExists] = await Promise.all([
+    const [pastReactionsResult, operations, feedbackSummary] = await Promise.all([
       getPastReactionsSummary(watcherId, 30),
       getAvailableOperations(watcherEntityIds),
-      hasFeedback(watcherId),
+      getRecentFeedbackSummary(watcherId, 10),
     ]);
     pastReactions = pastReactionsResult;
     availableOperations = operations.length > 0 ? operations : undefined;
-    if (feedbackExists) {
-      pastFeedback = await getRecentFeedbackSummary(watcherId, 10);
-    }
+    pastFeedback = feedbackSummary;
   } catch (err) {
     logger.warn({ err }, '[get_content] Failed to fetch reaction data for watcher mode');
   }

--- a/packages/owletto-backend/src/tools/get_watchers.ts
+++ b/packages/owletto-backend/src/tools/get_watchers.ts
@@ -477,9 +477,14 @@ export async function getWatcher(
   const classificationStatsMap: Map<number, Record<string, Record<string, number>>> = new Map();
   let classificationTimeline: ClassificationTimeline | undefined;
 
-  // Fire watcher details query early (awaited after classification stats)
+  // Fire watcher details query early (awaited after classification stats).
+  // Use sql.unsafe() with a $N parameter so the latest-run LATERAL JOIN can
+  // be string-interpolated safely. Tagged-template + sql.unsafe() inside the
+  // template breaks PGlite's simple-query mode (prepare=false), so we keep
+  // this path as a single unsafe call instead.
   const watcherQueryPromise = args.watcher_id
-    ? sql`
+    ? sql.unsafe(
+        `
       SELECT
         i.id as watcher_id,
         i.name,
@@ -504,9 +509,11 @@ export async function getWatcher(
         wr.completed_at as watcher_run_completed_at
       FROM watchers i
       LEFT JOIN watcher_versions cv ON i.current_version_id = cv.id
-      ${sql.unsafe(buildLatestWatcherRunJoinSql('i', 'wr'))}
-      WHERE i.id = ${args.watcher_id}
-    `
+      ${buildLatestWatcherRunJoinSql('i', 'wr')}
+      WHERE i.id = $1
+    `,
+        [args.watcher_id]
+      )
     : null;
 
   logger.info(

--- a/packages/owletto-backend/src/tools/resolve_path.ts
+++ b/packages/owletto-backend/src/tools/resolve_path.ts
@@ -453,7 +453,9 @@ async function _resolvePath(
     ] = await Sentry.startSpan({ name: 'entity:counts+tabs', op: 'db' }, () =>
       Promise.all([
         simpleQuery(
-          sql`SELECT COUNT(*) as cnt FROM current_event_records ev WHERE ${sql.unsafe(entityLinkMatchSql(`${Number(entityRow.id)}::bigint`, 'ev'))}`
+          sql.unsafe<{ cnt: number }>(
+            `SELECT COUNT(*) as cnt FROM current_event_records ev WHERE ${entityLinkMatchSql(`${Number(entityRow.id)}::bigint`, 'ev')}`
+          )
         ),
         simpleQuery(sql`
           SELECT COUNT(DISTINCT cn.connector_key) as cnt
@@ -731,7 +733,16 @@ async function fetchRecentContent(
   organizationId: string,
   entityId: number | null
 ): Promise<BootstrapContentItem[]> {
-  const rows = await simpleQuery(sql`
+  // Inline the entity-link match as raw SQL — postgres.js can't combine
+  // sql.unsafe() inside a tagged template that also has $N values when
+  // running against PGlite (prepare:false simple-query mode).
+  const entityFilter =
+    entityId !== null
+      ? `AND ${entityLinkMatchSql(`${Number(entityId)}::bigint`, 'ev')}`
+      : '';
+  const rows = await simpleQuery(
+    sql.unsafe<Record<string, unknown>>(
+      `
     SELECT
       ev.id,
       ev.entity_ids,
@@ -754,11 +765,14 @@ async function fetchRecentContent(
       ev.occurred_at
     FROM current_event_records ev
     LEFT JOIN connections cn ON cn.id = ev.connection_id
-    WHERE ev.organization_id = ${organizationId}
-      ${entityId !== null ? sql`AND ${sql.unsafe(entityLinkMatchSql(`${Number(entityId)}::bigint`, 'ev'))}` : sql``}
+    WHERE ev.organization_id = $1
+      ${entityFilter}
     ORDER BY COALESCE(ev.occurred_at, ev.created_at) DESC
-    LIMIT ${BOOTSTRAP_RECENT_LIMIT}
-  `);
+    LIMIT $2
+  `,
+      [organizationId, BOOTSTRAP_RECENT_LIMIT]
+    )
+  );
 
   return (rows as Array<Record<string, unknown>>).map((row) => ({
     id: Number(row.id),

--- a/packages/owletto-backend/src/utils/watcher-feedback.ts
+++ b/packages/owletto-backend/src/utils/watcher-feedback.ts
@@ -8,17 +8,6 @@
 import { getDb } from '../db/client';
 
 /**
- * Check whether any feedback exists for a watcher (cheap EXISTS query).
- */
-export async function hasFeedback(watcherId: number | string): Promise<boolean> {
-  const sql = getDb();
-  const result = await sql`
-    SELECT 1 FROM watcher_window_field_feedback WHERE watcher_id = ${watcherId} LIMIT 1
-  `;
-  return result.length > 0;
-}
-
-/**
  * Build a human-readable summary of past user corrections for a watcher.
  *
  * Returns only the most-recent correction per (field_path) — earlier

--- a/packages/owletto-backend/src/utils/watcher-feedback.ts
+++ b/packages/owletto-backend/src/utils/watcher-feedback.ts
@@ -13,27 +13,31 @@ import { getDb } from '../db/client';
 export async function hasFeedback(watcherId: number | string): Promise<boolean> {
   const sql = getDb();
   const result = await sql`
-    SELECT 1 FROM watcher_window_feedback WHERE watcher_id = ${watcherId} LIMIT 1
+    SELECT 1 FROM watcher_window_field_feedback WHERE watcher_id = ${watcherId} LIMIT 1
   `;
   return result.length > 0;
 }
 
 /**
  * Build a human-readable summary of past user corrections for a watcher.
- * Returns undefined if no feedback exists.
+ *
+ * Returns only the most-recent correction per (field_path) — earlier
+ * superseded corrections are dropped so the prompt does not accumulate
+ * historical noise. Returns undefined if no feedback exists.
  */
 export async function getRecentFeedbackSummary(
   watcherId: number | string,
-  limit = 10
+  limit = 20
 ): Promise<string | undefined> {
   const sql = getDb();
   const feedback = await sql`
-    SELECT f.corrections, f.notes, f.created_at,
+    SELECT DISTINCT ON (f.field_path)
+           f.field_path, f.mutation, f.corrected_value, f.note, f.created_at,
            w.window_start, w.window_end
-    FROM watcher_window_feedback f
+    FROM watcher_window_field_feedback f
     JOIN watcher_windows w ON f.window_id = w.id
     WHERE f.watcher_id = ${watcherId}
-    ORDER BY f.created_at DESC
+    ORDER BY f.field_path, f.created_at DESC
     LIMIT ${limit}
   `;
 
@@ -43,15 +47,23 @@ export async function getRecentFeedbackSummary(
   for (const row of feedback) {
     const start = new Date(row.window_start as string).toISOString().split('T')[0];
     const end = new Date(row.window_end as string).toISOString().split('T')[0];
-    const corrections = row.corrections as Record<string, unknown>;
+    const path = row.field_path as string;
+    const mutation = row.mutation as 'set' | 'remove' | 'add';
+    const value = row.corrected_value;
 
-    for (const [field, correctedValue] of Object.entries(corrections)) {
-      let line = `- Window ${start} to ${end}: "${field}" corrected to "${correctedValue}"`;
-      if (row.notes) {
-        line += ` (note: "${row.notes}")`;
-      }
-      lines.push(line);
+    let line: string;
+    if (mutation === 'remove') {
+      line = `- Window ${start}–${end}: drop "${path}"`;
+    } else if (mutation === 'add') {
+      line = `- Window ${start}–${end}: append to "${path}" — ${JSON.stringify(value)}`;
+    } else {
+      const rendered = typeof value === 'string' ? value : JSON.stringify(value);
+      line = `- Window ${start}–${end}: "${path}" → ${rendered}`;
     }
+    if (row.note) {
+      line += ` (note: "${row.note}")`;
+    }
+    lines.push(line);
   }
 
   return lines.join('\n');


### PR DESCRIPTION
## Summary
- Replace JSONB-blob `watcher_window_feedback.corrections` with per-field `watcher_window_field_feedback` rows so each correction stands alone with its own note + mutation kind (set/remove/add).
- `submit_feedback` now takes an array of `{field_path, mutation?, value?, note?}`; `get_feedback` returns one row per field (most recent wins) so the prompt summary stops accumulating every historical revision.
- Migration backfills existing JSONB blobs into per-field rows; down-migration aggregates them back.

## Drift fixes (bundled because they were already in the branch)
- `start-local.ts`: pino's err-serializer key is `err`, not `error`.
- `resolve_path.ts`: fold `sql.unsafe()` back into the outer template so PGlite simple-query mode (prepare:false) can parse the statement.

## Follow-up
- Frontend (`packages/owletto-web`): inline-correction UI (`editable-field/`, `json-renderer.tsx`, `watcher-detail.tsx`, `use-watchers.ts`) ships as a separate submodule PR per AGENTS.md two-PR rule, then a parent bump PR.

## Test plan
- [ ] `make build-packages` clean
- [ ] Migration up + down round-trips against summaries-db copy
- [ ] `submit_feedback` with `mutation: 'remove'` drops an array item; `'add'` appends
- [ ] `get_feedback` returns latest-per-field, not historical accumulation
- [ ] Existing watcher prompt summary still injects corrections (now from new table)