### PR TITLE
docs(landing): rewrite memory page with entity tree + watcher trace card

### DIFF
--- a/packages/landing/src/components/blog/EntityMemoryDiagram.tsx
+++ b/packages/landing/src/components/blog/EntityMemoryDiagram.tsx
@@ -1,0 +1,158 @@
+import type { ComponentChildren } from "preact";
+
+type EntityMemoryItem = {
+  emoji?: string;
+  text: string;
+};
+
+type EntityMemoryNode = {
+  label: string;
+  emoji?: string;
+  target?: boolean;
+  items?: EntityMemoryItem[];
+};
+
+type EntityMemoryDiagramProps = {
+  prompt: string;
+  promptLabel?: string;
+  rootLabel: string;
+  rootEmoji?: string;
+  entities: EntityMemoryNode[];
+};
+
+const guideColor = "rgba(255,255,255,0.16)";
+
+function TreeBranch({ children }: { children: ComponentChildren }) {
+  return (
+    <div
+      class="relative ml-3 pl-5"
+      style={{ borderLeft: `1px solid ${guideColor}` }}
+    >
+      {children}
+    </div>
+  );
+}
+
+function TreeRow({
+  children,
+  last,
+}: {
+  children: ComponentChildren;
+  last?: boolean;
+}) {
+  return (
+    <div class="relative">
+      <span
+        aria-hidden="true"
+        class="absolute left-[-20px] top-[14px] block h-px w-4"
+        style={{ background: guideColor }}
+      />
+      {last && (
+        <span
+          aria-hidden="true"
+          class="absolute left-[-21px] top-[14px] block h-[calc(100%_-_14px)] w-px"
+          style={{ background: "var(--color-page-bg, #0b0b10)" }}
+        />
+      )}
+      {children}
+    </div>
+  );
+}
+
+export function EntityMemoryDiagram({
+  prompt,
+  promptLabel = "Inbound fact",
+  rootLabel,
+  rootEmoji,
+  entities,
+}: EntityMemoryDiagramProps) {
+  return (
+    <div class="my-8 rounded-2xl border border-[rgba(255,255,255,0.08)] bg-[linear-gradient(180deg,rgba(18,18,24,0.96),rgba(11,11,16,0.96))] p-4 sm:p-5">
+      <div class="rounded-lg border border-[rgba(255,255,255,0.08)] bg-[rgba(255,255,255,0.03)] px-3 py-2.5 sm:px-4 sm:py-3">
+        <div class="grid gap-1.5 sm:grid-cols-[minmax(0,12rem)_1fr] sm:gap-3">
+          <div>
+            <div class="text-[10px] font-semibold uppercase tracking-[0.18em] text-[var(--color-page-text-muted)]">
+              {promptLabel}
+            </div>
+            <div class="mt-0.5 flex items-start gap-2 text-[0.98rem] font-semibold leading-tight text-[var(--color-page-text)] sm:text-[1rem]">
+              <span aria-hidden="true">📥</span>
+              <span>Prompt</span>
+            </div>
+          </div>
+          <div class="text-[0.92rem] leading-6 text-[var(--color-page-text-muted)] sm:self-center">
+            “{prompt}”
+          </div>
+        </div>
+      </div>
+
+      <div
+        aria-hidden="true"
+        class="flex items-center justify-center py-1.5 text-base text-[var(--color-tg-accent)]"
+      >
+        ↓
+      </div>
+
+      <div class="rounded-lg border border-[rgba(255,255,255,0.08)] bg-[rgba(255,255,255,0.03)] px-3 py-3 sm:px-5 sm:py-4">
+        <div class="flex items-center gap-2 text-[0.95rem] font-semibold text-[var(--color-page-text)]">
+          {rootEmoji && <span aria-hidden="true">{rootEmoji}</span>}
+          <span>{rootLabel}</span>
+          <span class="ml-1 rounded-full border border-[rgba(255,255,255,0.1)] px-2 py-[1px] text-[10px] font-medium uppercase tracking-[0.16em] text-[var(--color-page-text-muted)]">
+            entity type
+          </span>
+        </div>
+
+        <div class="mt-3">
+          {entities.map((entity, idx) => {
+            const isLast = idx === entities.length - 1;
+            const items = entity.items ?? [];
+            const targetClass = entity.target
+              ? "font-semibold text-[var(--color-page-text)]"
+              : "text-[var(--color-page-text-muted)]";
+            return (
+              <TreeBranch key={entity.label}>
+                <TreeRow last={isLast}>
+                  <div
+                    class={`flex items-center gap-2 py-0.5 text-[0.95rem] ${targetClass}`}
+                  >
+                    {entity.emoji && (
+                      <span aria-hidden="true">{entity.emoji}</span>
+                    )}
+                    <span>{entity.label}</span>
+                    {entity.target && (
+                      <span
+                        class="ml-1 rounded-md border px-1.5 py-[1px] text-[10px] font-medium uppercase tracking-[0.14em]"
+                        style={{
+                          borderColor: "var(--color-tg-accent)",
+                          color: "var(--color-tg-accent)",
+                        }}
+                      >
+                        target
+                      </span>
+                    )}
+                  </div>
+                </TreeRow>
+
+                {items.length > 0 && (
+                  <div class="pb-1">
+                    {items.map((item, itemIdx) => (
+                      <TreeBranch key={item.text}>
+                        <TreeRow last={itemIdx === items.length - 1}>
+                          <div class="flex items-start gap-2 py-0.5 text-[0.9rem] leading-6 text-[var(--color-page-text-muted)]">
+                            <span aria-hidden="true">
+                              {item.emoji ?? "•"}
+                            </span>
+                            <span>{item.text}</span>
+                          </div>
+                        </TreeRow>
+                      </TreeBranch>
+                    ))}
+                  </div>
+                )}
+              </TreeBranch>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/landing/src/components/blog/EntityMemoryDiagram.tsx
+++ b/packages/landing/src/components/blog/EntityMemoryDiagram.tsx
@@ -138,9 +138,7 @@ export function EntityMemoryDiagram({
                       <TreeBranch key={item.text}>
                         <TreeRow last={itemIdx === items.length - 1}>
                           <div class="flex items-start gap-2 py-0.5 text-[0.9rem] leading-6 text-[var(--color-page-text-muted)]">
-                            <span aria-hidden="true">
-                              {item.emoji ?? "•"}
-                            </span>
+                            <span aria-hidden="true">{item.emoji ?? "•"}</span>
                             <span>{item.text}</span>
                           </div>
                         </TreeRow>

--- a/packages/landing/src/components/memory/ExampleShowcase.tsx
+++ b/packages/landing/src/components/memory/ExampleShowcase.tsx
@@ -726,9 +726,7 @@ export function ExampleShowcase(props: {
 
                         {(() => {
                           if (step.panel.trace) {
-                            return (
-                              <WatcherTraceCard {...step.panel.trace} />
-                            );
+                            return <WatcherTraceCard {...step.panel.trace} />;
                           }
                           if (panelTable) {
                             return (

--- a/packages/landing/src/components/memory/ExampleShowcase.tsx
+++ b/packages/landing/src/components/memory/ExampleShowcase.tsx
@@ -6,6 +6,7 @@ import { Chip } from "../Chip";
 import { ContentRail } from "../ContentRail";
 import { SectionHeader } from "../SectionHeader";
 import { ScopedUseCaseTabs } from "../ScopedUseCaseTabs";
+import { WatcherTraceCard } from "./WatcherTraceCard";
 import {
   accentCyan,
   cardBorderFaint,
@@ -723,114 +724,128 @@ export function ExampleShowcase(props: {
                           ) : null}
                         </div>
 
-                        {panelTable ? (
-                          <div
-                            class="mb-4 overflow-hidden rounded-xl border"
-                            style={{
-                              borderColor: cardBorderSubtle,
-                              backgroundColor: deepBg,
-                            }}
-                          >
-                            <div class="overflow-x-auto">
-                              <table class="min-w-full border-collapse text-left">
-                                <thead>
-                                  <tr>
-                                    {panelTable.columns.map((column) => (
-                                      <th
-                                        key={column}
-                                        class="px-3 py-2 text-[10px] font-semibold uppercase tracking-[0.18em]"
-                                        style={{
-                                          color,
-                                          borderBottom: `1px solid ${cardBorderSubtle}`,
-                                          backgroundColor:
-                                            "rgba(255,255,255,0.02)",
-                                        }}
-                                      >
-                                        {column}
-                                      </th>
-                                    ))}
-                                  </tr>
-                                </thead>
-                                <tbody>
-                                  {panelTable.rows.map((row) => (
-                                    <tr key={row.join("-")}>
-                                      {row.map((cell, index) => (
-                                        <td
-                                          key={`${row[0] ?? "row"}-${index}`}
-                                          class="px-3 py-2 text-xs leading-5 align-top"
-                                          style={{
-                                            color:
-                                              index === 0
-                                                ? textColor
-                                                : textMuted,
-                                            borderBottom: `1px solid ${cardBorderFaint}`,
-                                          }}
-                                        >
-                                          {cell}
-                                        </td>
-                                      ))}
-                                    </tr>
-                                  ))}
-                                </tbody>
-                              </table>
-                            </div>
-                          </div>
-                        ) : step.panel.items?.length ? (
-                          <div class="grid gap-3 sm:grid-cols-2 mb-4">
-                            {step.panel.items.map((item) => (
+                        {(() => {
+                          if (step.panel.trace) {
+                            return (
+                              <WatcherTraceCard {...step.panel.trace} />
+                            );
+                          }
+                          if (panelTable) {
+                            return (
                               <div
-                                key={`${item.meta ?? ""}-${item.label}`}
-                                class="rounded-xl p-3 border"
+                                class="mb-4 overflow-hidden rounded-xl border"
                                 style={{
-                                  backgroundColor: deepBg,
                                   borderColor: cardBorderSubtle,
+                                  backgroundColor: deepBg,
                                 }}
                               >
-                                {item.meta ? (
+                                <div class="overflow-x-auto">
+                                  <table class="min-w-full border-collapse text-left">
+                                    <thead>
+                                      <tr>
+                                        {panelTable.columns.map((column) => (
+                                          <th
+                                            key={column}
+                                            class="px-3 py-2 text-[10px] font-semibold uppercase tracking-[0.18em]"
+                                            style={{
+                                              color,
+                                              borderBottom: `1px solid ${cardBorderSubtle}`,
+                                              backgroundColor:
+                                                "rgba(255,255,255,0.02)",
+                                            }}
+                                          >
+                                            {column}
+                                          </th>
+                                        ))}
+                                      </tr>
+                                    </thead>
+                                    <tbody>
+                                      {panelTable.rows.map((row) => (
+                                        <tr key={row.join("-")}>
+                                          {row.map((cell, index) => (
+                                            <td
+                                              key={`${row[0] ?? "row"}-${index}`}
+                                              class="px-3 py-2 text-xs leading-5 align-top"
+                                              style={{
+                                                color:
+                                                  index === 0
+                                                    ? textColor
+                                                    : textMuted,
+                                                borderBottom: `1px solid ${cardBorderFaint}`,
+                                              }}
+                                            >
+                                              {cell}
+                                            </td>
+                                          ))}
+                                        </tr>
+                                      ))}
+                                    </tbody>
+                                  </table>
+                                </div>
+                              </div>
+                            );
+                          }
+                          if (step.panel.items?.length) {
+                            return (
+                              <div class="grid gap-3 sm:grid-cols-2 mb-4">
+                                {step.panel.items.map((item) => (
                                   <div
-                                    class="text-[10px] uppercase tracking-[0.18em] mb-1"
-                                    style={{ color }}
-                                  >
-                                    {item.meta}
-                                  </div>
-                                ) : null}
-                                <div
-                                  class="text-sm font-semibold mb-1"
-                                  style={{ color: textColor }}
-                                >
-                                  {item.label}
-                                </div>
-                                <div
-                                  class="text-xs leading-5"
-                                  style={{ color: textMuted }}
-                                >
-                                  {item.detail}
-                                </div>
-                                {item.platform ? (
-                                  <a
-                                    href={getConnectionHref(
-                                      item.platform.id,
-                                      activeExample.useCaseId
-                                    )}
-                                    class="mt-3 inline-flex items-center gap-1.5 rounded-full px-2 py-1 text-[10px] font-medium transition-colors hover:opacity-80"
+                                    key={`${item.meta ?? ""}-${item.label}`}
+                                    class="rounded-xl p-3 border"
                                     style={{
-                                      color: labelGray,
-                                      backgroundColor: "rgba(255,255,255,0.03)",
-                                      border: `1px solid ${cardBorderSubtle}`,
+                                      backgroundColor: deepBg,
+                                      borderColor: cardBorderSubtle,
                                     }}
                                   >
-                                    <PlatformLogo
-                                      platformId={item.platform.id}
-                                    />
-                                    <span>
-                                      {getConnectionLabel(item.platform.id)}
-                                    </span>
-                                  </a>
-                                ) : null}
+                                    {item.meta ? (
+                                      <div
+                                        class="text-[10px] uppercase tracking-[0.18em] mb-1"
+                                        style={{ color }}
+                                      >
+                                        {item.meta}
+                                      </div>
+                                    ) : null}
+                                    <div
+                                      class="text-sm font-semibold mb-1"
+                                      style={{ color: textColor }}
+                                    >
+                                      {item.label}
+                                    </div>
+                                    <div
+                                      class="text-xs leading-5"
+                                      style={{ color: textMuted }}
+                                    >
+                                      {item.detail}
+                                    </div>
+                                    {item.platform ? (
+                                      <a
+                                        href={getConnectionHref(
+                                          item.platform.id,
+                                          activeExample.useCaseId
+                                        )}
+                                        class="mt-3 inline-flex items-center gap-1.5 rounded-full px-2 py-1 text-[10px] font-medium transition-colors hover:opacity-80"
+                                        style={{
+                                          color: labelGray,
+                                          backgroundColor:
+                                            "rgba(255,255,255,0.03)",
+                                          border: `1px solid ${cardBorderSubtle}`,
+                                        }}
+                                      >
+                                        <PlatformLogo
+                                          platformId={item.platform.id}
+                                        />
+                                        <span>
+                                          {getConnectionLabel(item.platform.id)}
+                                        </span>
+                                      </a>
+                                    ) : null}
+                                  </div>
+                                ))}
                               </div>
-                            ))}
-                          </div>
-                        ) : null}
+                            );
+                          }
+                          return null;
+                        })()}
                       </>
                     ) : step.chips?.length ? (
                       <div class="flex flex-wrap gap-1.5 mb-4">

--- a/packages/landing/src/components/memory/WatcherTraceCard.tsx
+++ b/packages/landing/src/components/memory/WatcherTraceCard.tsx
@@ -1,0 +1,115 @@
+import type { HowItWorksPanelTrace } from "../../use-case-definitions";
+import { accentCyan } from "./styles";
+
+export function WatcherTraceCard({
+  schedule,
+  prompt,
+  events,
+  entityLabel,
+  entityEmoji,
+  consolidated,
+}: HowItWorksPanelTrace) {
+  return (
+    <div class="my-8 rounded-2xl border border-[rgba(255,255,255,0.08)] bg-[linear-gradient(180deg,rgba(18,18,24,0.96),rgba(11,11,16,0.96))] p-4 sm:p-5">
+      <div class="mb-3 text-[10px] font-semibold uppercase tracking-[0.22em] text-[var(--color-page-text-muted)]">
+        Trace
+      </div>
+
+      <div class="rounded-lg border border-[rgba(255,255,255,0.08)] bg-[rgba(255,255,255,0.03)] px-3 py-3 sm:px-4 sm:py-3.5">
+        <div class="mb-3 rounded-md border border-[rgba(255,255,255,0.06)] bg-[rgba(255,255,255,0.02)] px-3 py-2">
+          <div class="text-[10px] font-semibold uppercase tracking-[0.18em] text-[var(--color-page-text-muted)]">
+            Watcher prompt
+          </div>
+          <div class="mt-1 text-[0.88rem] leading-6 text-[var(--color-page-text)]">
+            “{prompt}”
+          </div>
+        </div>
+
+        <div class="flex items-center gap-2">
+          <span
+            aria-hidden="true"
+            class="inline-flex h-5 w-5 items-center justify-center rounded-full border text-[12px]"
+            style={{
+              color: accentCyan,
+              backgroundColor: "rgba(103, 232, 249, 0.12)",
+              borderColor: "rgba(103, 232, 249, 0.4)",
+            }}
+          >
+            ◉
+          </span>
+          <code
+            class="font-mono text-[0.85rem]"
+            style={{ color: "var(--color-page-text)" }}
+          >
+            watcher.poll(every: {schedule})
+          </code>
+        </div>
+        <div
+          class="ml-7 mt-1 font-mono text-[0.8rem]"
+          style={{ color: accentCyan }}
+        >
+          → {events.length} event{events.length === 1 ? "" : "s"} collected
+        </div>
+
+        <div class="ml-7 mt-2 flex flex-col gap-1">
+          {events.map((event, i) => (
+            <div
+              key={`${event.source}-${i}`}
+              class="flex items-start gap-2 text-[0.82rem] leading-snug"
+            >
+              <span
+                class="shrink-0 pt-0.5 font-mono text-[0.72rem]"
+                style={{ color: "var(--color-page-text-muted)" }}
+              >
+                {event.time}
+              </span>
+              <span
+                class="shrink-0 font-semibold"
+                style={{ color: "var(--color-page-text)" }}
+              >
+                {event.source}
+              </span>
+              <span style={{ color: "var(--color-page-text-muted)" }}>
+                {event.text}
+              </span>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      <div
+        aria-hidden="true"
+        class="flex items-center justify-center gap-2 py-2 text-[0.78rem] font-mono uppercase tracking-[0.18em] text-[var(--color-page-text-muted)]"
+      >
+        <span class="text-base text-[var(--color-tg-accent)]">↓</span>
+        consolidate
+        <span class="text-base text-[var(--color-tg-accent)]">↓</span>
+      </div>
+
+      <div class="rounded-lg border border-[rgba(255,255,255,0.08)] bg-[rgba(255,255,255,0.03)] px-3 py-3 sm:px-4 sm:py-3.5">
+        <div class="flex items-center gap-2 text-[0.92rem] font-semibold text-[var(--color-page-text)]">
+          <span aria-hidden="true">🧠</span>
+          <span>New memory written to</span>
+          {entityEmoji && (
+            <span aria-hidden="true" class="ml-1">
+              {entityEmoji}
+            </span>
+          )}
+          <span style={{ color: "var(--color-tg-accent)" }}>
+            {entityLabel}
+          </span>
+        </div>
+        <ul class="m-0 mt-2 flex list-none flex-col gap-1 p-0 text-[0.9rem] leading-6 text-[var(--color-page-text-muted)]">
+          {consolidated.map((item) => (
+            <li key={item.text} class="flex items-start gap-2">
+              <span aria-hidden="true" class="mt-[2px]">
+                {item.emoji ?? "•"}
+              </span>
+              <span>{item.text}</span>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+}

--- a/packages/landing/src/components/memory/WatcherTraceCard.tsx
+++ b/packages/landing/src/components/memory/WatcherTraceCard.tsx
@@ -95,9 +95,7 @@ export function WatcherTraceCard({
               {entityEmoji}
             </span>
           )}
-          <span style={{ color: "var(--color-tg-accent)" }}>
-            {entityLabel}
-          </span>
+          <span style={{ color: "var(--color-tg-accent)" }}>{entityLabel}</span>
         </div>
         <ul class="m-0 mt-2 flex list-none flex-col gap-1 p-0 text-[0.9rem] leading-6 text-[var(--color-page-text-muted)]">
           {consolidated.map((item) => (

--- a/packages/landing/src/content/docs/getting-started/memory.mdx
+++ b/packages/landing/src/content/docs/getting-started/memory.mdx
@@ -1,127 +1,102 @@
 ---
 title: Memory
-description: How Lobu uses Owletto for shared, structured memory across agents, threads, and teams.
+description: Why Lobu uses entity-based memory instead of flat per-user files, and how a single fact becomes shared organizational context.
 ---
 
-Lobu has two memory layers:
+import { EntityMemoryDiagram } from "../../../components/blog/EntityMemoryDiagram";
+import { WatcherTraceCard } from "../../../components/memory/WatcherTraceCard";
 
-- **Filesystem** for short-term working memory inside one sandbox
-- **Owletto** for long-term organizational memory shared across agents, users, and threads
+Most agent memory systems are flat files scoped to one user. The agent appends notes, then re-scans them every turn to recall context. That works for a personal assistant. It breaks the moment two agents — or a watcher, or another teammate — need to converge on the same fact.
 
-The filesystem is where an agent does work. Owletto is where the organization remembers what matters.
+Lobu uses **entity-based memory** through [Owletto](https://app.lobu.ai). Facts attach to typed entities (Company, Project, Member), so any agent in your org reads the same record.
 
-- Owletto site: [app.lobu.ai](https://app.lobu.ai)
-- Owletto CLI reference: [/reference/owletto-cli/](/reference/owletto-cli/)
+## Filesystem vs entity memory
 
-## Filesystem Vs Owletto
+This is the same split data teams already use. Analysts pull data into a notebook, run scripts, produce charts — then write the durable result back to the warehouse so the rest of the business can use it. Nobody asks an analyst to do every query in production tables, and nobody runs the company off one analyst's notebook.
 
-Each Lobu user, channel, or DM gets its own filesystem workspace. That is the agent's short-term working area for the current job:
+Agents need both layers too:
 
-- downloaded files and raw inputs
-- scratch scripts and notebooks
-- generated reports, CSVs, and images
-- temporary intermediate outputs
+- **Filesystem** is the agent's notebook — ephemeral. Downloaded PDFs, scratch scripts, intermediate CSVs, generated reports. One agent, one channel, one task.
+- **Entity memory** is the warehouse — durable. Customer facts, decisions, project state, recurring operational knowledge. Shared across agents, sessions, and operators.
 
-Owletto is the separate memory product behind Lobu's shared-memory layer. It stores durable knowledge so other sessions and agents can recall it later.
+A note on a Slack DM filesystem dies with the sandbox. A fact written to `Company:Acme` survives and shows up the next time *any* agent — billing, support, CSM — touches Acme.
 
-```text
-filesystem = short-term working memory + artifacts
-owletto = long-term organizational memory
-```
+For the longer argument and where to draw the line between the two, see [Filesystem vs Database for Agent Memory](/blog/filesystem-vs-database-agent-memory/).
 
-## What Owletto Adds
+## Entity memory in practice
 
-Compared with local filesystem memory, Owletto gives Lobu:
+A single inbound fact lands on the right entity and accumulates alongside everything else known about that customer:
 
-- memory shared across agents, users, and threads
-- typed entities and relationships instead of loose notes
-- hybrid recall across entity lookup, text search, and semantic search
-- connectors and watchers for external data ingestion
-- an operator UI to inspect, edit, and correct memory
+<EntityMemoryDiagram
+  prompt="Acme's CTO left in March, no exec champion since"
+  rootLabel="Company"
+  rootEmoji="🏢"
+  entities={[
+    { label: "Globex", emoji: "🏢" },
+    {
+      label: "Acme",
+      emoji: "🏢",
+      target: true,
+      items: [
+        { emoji: "🧑‍💼", text: "CTO departed 2026-03 — no exec champion" },
+        { emoji: "🐞", text: "Watcher: 3 open Linear bugs this week" },
+        { emoji: "📉", text: "DSCR 1.1× (Q1 review)" },
+        { emoji: "🗓️", text: "Renewal due May 2026" },
+        { emoji: "✅", text: "Decision: declined $2M extension — DSCR below 1.2×" },
+      ],
+    },
+    { label: "Initech", emoji: "🏢" },
+  ]}
+/>
 
-Use the filesystem for active work. Use Owletto for durable facts and shared organizational context.
+Different sources, same destination. A CSM's note in Slack, a watcher ingesting Linear bugs, and a credit decision from a separate agent all converge on `Company:Acme`. The next agent that reads Acme — through search, recall, or an explicit lookup — sees the full picture without re-deriving it from scratch.
 
-## Install Owletto In Other Agents
+This is the moat: shared, queryable, operator-visible memory that survives the sandbox.
 
-If you want a non-Lobu agent to understand and use Owletto well, install the Owletto skill separately:
+## Watchers: forcing your agent to dream
 
-```bash
-npx owletto@latest skills add owletto
-npx owletto@latest init
-```
+You don't sit at your desk thinking about every Slack message — but at night your brain replays the day, drops the noise, and consolidates what mattered into long-term memory. That's what watchers do for your agent.
 
-- `owletto skills add owletto` installs the starter skill into a local `skills/` directory.
-- `owletto init` configures MCP/auth for supported clients.
+A watcher has three pieces: a **schedule** (how often it wakes), a **prompt** (what to remember and what to ignore), and an **entity** to attach memory to. The prompt is the filter — it tells the agent which signals from a noisy event stream actually matter, so it doesn't write down every OOO message and lunch plan.
 
-For OpenClaw-specific setup, use:
+<WatcherTraceCard
+  schedule="1h"
+  prompt="Track changes to active incidents, blockers, and pending PRs for Acme. Skip OOO and personal chatter."
+  events={[
+    { time: "9:02", source: "Dan", text: "picking up INC-4421, rolling back checkout-v43" },
+    { time: "9:05", source: "Priya", text: "still blocked on k8s cluster admin creds — can someone grant?" },
+    { time: "9:11", source: "Jay", text: "caching layer PR is ready for review, needs to land by EOD" },
+    { time: "9:18", source: "Sam", text: "OOO today — family thing" },
+    { time: "9:27", source: "Nina", text: "writing INC-4378 postmortem, sharing draft at lunch" },
+  ]}
+  entityLabel="Company:Acme"
+  entityEmoji="🏢"
+  consolidated={[
+    { emoji: "🚨", text: "Incident INC-4421 — checkout-v43 rollback in progress (Dan)" },
+    { emoji: "⏳", text: "Caching layer PR pending merge by EOD (Jay)" },
+    { emoji: "📝", text: "INC-4378 postmortem drafting (Nina)" },
+  ]}
+/>
 
-```bash
-npx owletto@latest skills add owletto-openclaw
-npx owletto@latest init
-```
+Five events came in; three made it into memory. Sam's OOO and Nina's lunch draft drop off the floor — they don't match the prompt. The agent isn't online, but the memory is moving. By the time someone asks "what's going on with Acme?", the answer is already in the entity.
 
-## How Lobu Wires Owletto In
+## When to use entity memory
 
-In Lobu, memory is pluggable per agent. To use Owletto as the shared memory backend, configure `[memory.owletto]` in `lobu.toml`:
+Reach for entity memory when you need:
 
-```toml
-[memory.owletto]
-enabled = true
-org = "my-org"
-name = "My Project"
-models = "./models"
-data = "./data"
-```
+- multiple agents (or watchers) to write into and read from the same record
+- decisions and context that survive sandboxes and channel resets
+- ingested external signal (Linear, HubSpot, Stripe, email) attached to the right customer or project
+- operator-visible memory that can be audited and corrected in the UI
 
-At runtime, Lobu resolves memory like this:
+If you only need a working directory for one session, the filesystem is enough.
 
-- If `[memory.owletto]` is enabled, Lobu derives the effective Owletto MCP endpoint from `org`
-- `MEMORY_URL` remains an optional base-endpoint override for local or custom Owletto deployments
-- If no Owletto endpoint is resolved, Lobu falls back to `@openclaw/native-memory`
-- Agents can still override plugin configuration through `pluginsConfig`
+## Set it up
 
-The `@lobu/owletto-openclaw` plugin adapts OpenClaw memory calls to Owletto MCP calls through the gateway proxy, so workers never need raw Owletto credentials or third-party OAuth tokens.
+Owletto wiring (TOML config, plugin install, CLI) is covered in the [Getting Started guide](/getting-started/) and the [Owletto CLI reference](/reference/owletto-cli/).
 
-## Recall Loop
+## Read next
 
-At a high level, Lobu + Owletto memory recall works like this:
-
-1. A user sends a message to a Lobu agent.
-2. Lobu routes the request into the worker and loads the active memory plugin.
-3. Owletto identifies likely entities and retrieves related knowledge.
-4. Recall combines entity-name matching, text search, and semantic search.
-5. That recalled context is injected before prompt construction.
-6. During the turn, the agent can search, read, and save new knowledge back into Owletto.
-7. Operators can review or correct memory in the Owletto UI.
-
-## Tool Workflow
-
-Agents that talk to Owletto directly usually follow this pattern:
-
-```text
-search_knowledge -> read_knowledge -> save_knowledge
-```
-
-Use:
-
-- `search_knowledge` to find relevant entities and context first
-- `read_knowledge` to inspect saved facts or semantic matches
-- `save_knowledge` to persist durable facts and supersede stale ones
-
-## When To Use Owletto
-
-Owletto is the right fit when you want:
-
-- multiple agents to share one memory space
-- memory that survives local sandboxes and channel filesystems
-- OAuth-managed integrations without handing tokens to workers
-- scheduled ingestion and analysis of external sources
-- operator-visible memory that can be audited and corrected
-
-If you only need a local working directory for one session, the filesystem is enough. If you want durable, queryable organizational memory, use Owletto.
-
-## Read Next
-
+- [Filesystem vs Database for Agent Memory](/blog/filesystem-vs-database-agent-memory/)
 - [Skills](/getting-started/skills/)
-- [Owletto CLI Reference](/reference/owletto-cli/)
 - [Lobu CLI Reference](/reference/cli/)

--- a/packages/landing/src/use-case-definitions.ts
+++ b/packages/landing/src/use-case-definitions.ts
@@ -43,11 +43,32 @@ export type HowItWorksPanelTable = {
   rows: string[][];
 };
 
+export type HowItWorksPanelTraceEvent = {
+  time: string;
+  source: string;
+  text: string;
+};
+
+export type HowItWorksPanelTraceMemory = {
+  emoji?: string;
+  text: string;
+};
+
+export type HowItWorksPanelTrace = {
+  schedule: string;
+  prompt: string;
+  events: HowItWorksPanelTraceEvent[];
+  entityLabel: string;
+  entityEmoji?: string;
+  consolidated: HowItWorksPanelTraceMemory[];
+};
+
 export type HowItWorksPanel = {
   title: string;
   description?: string;
   items?: HowItWorksPanelItem[];
   table?: HowItWorksPanelTable;
+  trace?: HowItWorksPanelTrace;
 };
 
 export type HowItWorksStep = {

--- a/packages/landing/src/use-case-showcases.ts
+++ b/packages/landing/src/use-case-showcases.ts
@@ -634,34 +634,57 @@ const memoryStepPanels: Record<
     connect: {
       title: "Operational events",
       description:
-        "Turn live operational signals into structured incident memory.",
-      table: {
-        columns: ["Entity", "Events", "Sources", "Added context"],
-        rows: [
-          [
-            "Alerts",
-            "Triggered, resolved, severity changed",
-            "PagerDuty, Datadog",
-            "State, urgency, impact",
-          ],
-          [
-            "Code",
-            "PRs, fixes, rollbacks",
-            "GitHub, GitLab",
-            "Change timeline",
-          ],
-          [
-            "Deploys",
-            "Started, failed, rolled back",
-            "CI/CD, Argo, Kubernetes",
-            "Rollout history",
-          ],
-          [
-            "Notes",
-            "Updates, handoffs, comments",
-            "Slack, incident tools",
-            "Decisions and context",
-          ],
+        "A scheduled watcher polls the channels and tools your team already uses, then writes the relevant signals back to the right entity. The prompt is the filter — chatter that doesn't match never becomes memory.",
+      trace: {
+        schedule: "30m",
+        prompt:
+          "Track changes to active incidents, blockers, and pending PRs for Acme. Skip OOO and personal chatter.",
+        events: [
+          {
+            time: "9:02",
+            source: "Dan",
+            text: "picking up INC-4421, rolling back checkout-v43",
+          },
+          {
+            time: "9:05",
+            source: "Priya",
+            text: "still blocked on k8s cluster admin creds — can someone grant?",
+          },
+          {
+            time: "9:11",
+            source: "Jay",
+            text: "caching layer PR is ready for review, needs to land by EOD",
+          },
+          {
+            time: "9:18",
+            source: "Sam",
+            text: "OOO today — family thing",
+          },
+          {
+            time: "9:27",
+            source: "Nina",
+            text: "writing INC-4378 postmortem, sharing draft at lunch",
+          },
+        ],
+        entityLabel: "Company:Acme",
+        entityEmoji: "🏢",
+        consolidated: [
+          {
+            emoji: "🚨",
+            text: "Incident INC-4421 — checkout-v43 rollback in progress (Dan)",
+          },
+          {
+            emoji: "🚧",
+            text: "Priya blocked on k8s cluster admin creds",
+          },
+          {
+            emoji: "⏳",
+            text: "Caching layer PR pending merge by EOD (Jay)",
+          },
+          {
+            emoji: "📝",
+            text: "INC-4378 postmortem drafting (Nina)",
+          },
         ],
       },
     },


### PR DESCRIPTION
## Summary

- Rewrites `/getting-started/memory/` from prose-heavy to use-case-driven, with the warehouse/analyst framing from the [filesystem-vs-database blog post](/blog/filesystem-vs-database-agent-memory/).
- Adds a branching **EntityMemoryDiagram** (entity type → sibling entities → memory items) so readers see why entity-based memory beats flat per-user files for shared org context.
- Adds a **WatcherTraceCard** that visualizes the watcher prompt → events feed → consolidated memory cycle, with the *"forcing your agent to dream"* metaphor.
- Replaces the engineering "Operational events" catalog table on `/memory/for/engineering/` with the same `WatcherTraceCard`, so docs and landing share one component (panel gains a `trace` field via new `HowItWorksPanelTrace` type).
- Drops the install/wiring/recall-loop/tool-workflow sections from the docs page; setup links out to `/getting-started/`.

## Test plan

- [ ] `cd packages/landing && bun run build` passes
- [ ] Visit `/getting-started/memory/` — entity tree + watcher trace render, blog cross-link works
- [ ] Visit `/memory/for/engineering/` — Operational events block now shows the trace card instead of the table
- [ ] Switch to a non-engineering use case (legal, sales) — those still render the items grid as before