### PR TITLE
feat(examples): add LLM-judged ping eval to each surfaced example

### DIFF
--- a/examples/agent-community/agents/agent-community/evals/ping.yaml
+++ b/examples/agent-community/agents/agent-community/evals/ping.yaml
@@ -1,0 +1,16 @@
+version: 1
+name: ping
+description: Agent suggests an aligned community match in concierge style
+trials: 3
+timeout: 30
+tags: [smoke, fast]
+
+turns:
+  - content: "A new member just joined and described themselves as 'building developer tooling for AI agents'. In one sentence, who in our community should they meet first and why?"
+    assert:
+      - type: regex
+        value: ".{40,}"
+        weight: 0.3
+      - type: llm-rubric
+        value: "Names a plausible community match (someone in AI tooling, dev infra, or adjacent space) and gives a clear, warm reason to connect. Avoids generic 'reach out to other members' answers."
+        weight: 0.7

--- a/examples/engineering/agents/engineering/evals/ping.yaml
+++ b/examples/engineering/agents/engineering/evals/ping.yaml
@@ -1,0 +1,16 @@
+version: 1
+name: ping
+description: Agent triages a vague engineering status request
+trials: 3
+timeout: 30
+tags: [smoke, fast]
+
+turns:
+  - content: "Tell me what's broken and what's blocked. Use one short bullet for each."
+    assert:
+      - type: regex
+        value: ".{40,}"
+        weight: 0.3
+      - type: llm-rubric
+        value: "Either responds with a triage-style summary using bullets covering broken vs blocked, or asks a focused clarifying question (system name, time range, scope). Avoids generic boilerplate or unrelated content."
+        weight: 0.7

--- a/examples/finance/agents/finance/evals/ping.yaml
+++ b/examples/finance/agents/finance/evals/ping.yaml
@@ -1,0 +1,16 @@
+version: 1
+name: ping
+description: Agent proposes a concrete reconciliation step
+trials: 3
+timeout: 30
+tags: [smoke, fast]
+
+turns:
+  - content: "Stripe shows $4,200 settled today; NetSuite account 4100 is $4,000. What do you check first?"
+    assert:
+      - type: regex
+        value: ".{40,}"
+        weight: 0.3
+      - type: llm-rubric
+        value: "Names a concrete reconciliation step — for example settlement timing/cutoff, processor fees or refunds, currency conversion, or account mapping. Avoids generic advice like 'review the data' or 'check both sources'."
+        weight: 0.7

--- a/examples/leadership/agents/leadership/evals/ping.yaml
+++ b/examples/leadership/agents/leadership/evals/ping.yaml
@@ -1,0 +1,16 @@
+version: 1
+name: ping
+description: Agent captures a leadership decision as structured operating context
+trials: 3
+timeout: 30
+tags: [smoke, fast]
+
+turns:
+  - content: "Capture a leadership decision: 'we're freezing hiring in EMEA through Q3'. Reply with a structured summary I can drop in a memo."
+    assert:
+      - type: regex
+        value: ".{40,}"
+        weight: 0.3
+      - type: llm-rubric
+        value: "Returns a structured note covering at minimum the decision, the scope (EMEA), and the timeframe (through Q3), plus either a stated owner or an explicit open question about owner. Stays concise and memo-ready."
+        weight: 0.7

--- a/examples/legal/agents/legal/evals/ping.yaml
+++ b/examples/legal/agents/legal/evals/ping.yaml
@@ -1,0 +1,16 @@
+version: 1
+name: ping
+description: Agent surfaces a specific missing legal protection
+trials: 3
+timeout: 30
+tags: [smoke, fast]
+
+turns:
+  - content: "Give me one missing protection commonly absent from a startup's first SaaS subscription agreement."
+    assert:
+      - type: regex
+        value: ".{40,}"
+        weight: 0.3
+      - type: llm-rubric
+        value: "Names a specific, real missing protection — for example a limitation of liability cap, mutual indemnification carve-outs, a data processing addendum, or termination-for-cause language. Avoids vague 'add legal review' or 'consult a lawyer' non-answers."
+        weight: 0.7

--- a/examples/market-intelligence/agents/market-intel/evals/ping.yaml
+++ b/examples/market-intelligence/agents/market-intel/evals/ping.yaml
@@ -1,0 +1,16 @@
+version: 1
+name: ping
+description: Agent names a concrete market signal to monitor
+trials: 3
+timeout: 30
+tags: [smoke, fast]
+
+turns:
+  - content: "Acme just announced an AI feature. What signal should I watch over the next 30 days?"
+    assert:
+      - type: regex
+        value: ".{40,}"
+        weight: 0.3
+      - type: llm-rubric
+        value: "Names at least one concrete signal to monitor — for example pricing changes, public user reviews, hiring patterns for relevant roles, partnership or integration announcements, or pickup in case studies. Avoids generic 'watch their website' advice."
+        weight: 0.7

--- a/examples/sales/agents/sales/evals/ping.yaml
+++ b/examples/sales/agents/sales/evals/ping.yaml
@@ -1,0 +1,16 @@
+version: 1
+name: ping
+description: Agent proposes a concrete next step on a renewal at risk
+trials: 3
+timeout: 30
+tags: [smoke, fast]
+
+turns:
+  - content: "Northstar's renewal is in 60 days and their usage dropped 30% last month. Give me one next step."
+    assert:
+      - type: regex
+        value: ".{40,}"
+        weight: 0.3
+      - type: llm-rubric
+        value: "Recommends a concrete, time-appropriate next step — for example an exec touch, a value review, a churn-risk flag, a usage drop investigation, or a success plan. Avoids generic 'reach out to the customer' answers."
+        weight: 0.7

--- a/examples/support/agents/support/evals/ping.yaml
+++ b/examples/support/agents/support/evals/ping.yaml
@@ -1,0 +1,16 @@
+version: 1
+name: ping
+description: Agent asks a focused first clarifying question on a vague support report
+trials: 3
+timeout: 30
+tags: [smoke, fast]
+
+turns:
+  - content: "A customer says 'login is broken'. What's your first clarifying question?"
+    assert:
+      - type: regex
+        value: ".{20,}"
+        weight: 0.3
+      - type: llm-rubric
+        value: "Asks one focused, useful clarifying question — for example the exact error message, the auth method (SSO vs password), the browser/device, or when it last worked. Avoids open-ended 'tell me more' or empathy-only replies."
+        weight: 0.7


### PR DESCRIPTION
## Summary

The skills page advertises evals (\`SkillsWorkflowSection.tsx\` shows a fake terminal running \`npx @lobu/cli@latest eval\` and links to the Evaluations guide), but the 9 surfaced \`examples/*\` directories had no \`evals/\` folder at all — only the **hidden** \`careops\` example backed up the claim.

This PR adds one domain-tinted, LLM-judged \`ping.yaml\` to each surfaced example, modeled on \`examples/careops/agents/careops/evals/ping.yaml\`:

- \`agent-community\` — community-match suggestion
- \`engineering\` — vague triage prompt → bullet summary or focused clarifier
- \`finance\` — concrete reconciliation step (Stripe vs NetSuite variance)
- \`leadership\` — capture a hiring-freeze decision as memo-ready context
- \`legal\` — name a specific missing protection in a startup SaaS contract
- \`market-intelligence\` — concrete competitive signal to monitor
- \`sales\` — next step on an at-risk renewal
- \`support\` — focused first clarifying question on \"login is broken\"

Each eval combines a \`regex\` sanity assertion (weight 0.3) with an \`llm-rubric\` judge (weight 0.7) — the same shape careops uses.

\`venture-capital\` still has no \`agents/\` directory, so no eval was added there. Worth a follow-up to either build the agent or hide the use case until it exists.

## Test plan

- [ ] \`python3 -c \"import yaml; yaml.safe_load(open(p))\"\` over each new file (already validated locally)
- [ ] \`npx @lobu/cli@latest eval ping\` from any example directory once a provider is configured
- [ ] Skim each rubric — they should be specific enough to fail a generic chatbot but pass a role-aware agent