### PR TITLE
docs: ref owletto-web DESIGN_GUIDELINES.md from AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,9 @@
 ### Submodules
 `packages/owletto-web` is a submodule of `lobu-ai/owletto-web`. Every change there ships as **two PRs**: (1) land the submodule PR; (2) open a parent PR that bumps the pointer. Never push a parent commit that references an unmerged submodule SHA — production resolves SHAs from the parent and will break. After the submodule PR merges: `git -C packages/owletto-web pull --ff-only origin main`, stage the submodule in the parent, open the bump PR.
 
+### Frontend (owletto-web)
+When editing UI under `packages/owletto-web`, follow the design rules in @packages/owletto-web/DESIGN_GUIDELINES.md — confirmations, surfaces, empty states, selection, forms, page copy, radius, Sheet vs Dialog. Match the existing components and exemplar files referenced there; do not introduce new primitives without updating the guideline in the same PR.
+
 ### Architecture
 
 #### Platform


### PR DESCRIPTION
## Summary
- Bumps `packages/owletto-web` to lobu-ai/owletto-web#21 — that PR adds `DESIGN_GUIDELINES.md` to the submodule.
- Adds a one-line `@packages/owletto-web/DESIGN_GUIDELINES.md` reference under a new "Frontend (owletto-web)" section in `AGENTS.md`, so the rules auto-load into every agent's context whenever they touch the frontend.

## Why
Frontend pages have drifted on a few patterns (dashed empty-state boxes, hard-bordered cards on dark theme, layout-describing ledes, `border-foreground` selection). With the guideline ref'd from `AGENTS.md`, every agent or contributor working in this repo reads the rules before they start — the same mistakes stop recurring without anyone needing to remember to point at the doc.

## Test plan
- [x] `bun run typecheck` (parent pre-commit ran tsc + biome — clean).
- [x] AGENTS.md `@-ref` resolves: `packages/owletto-web/DESIGN_GUIDELINES.md` exists at the bumped submodule SHA.