### PR TITLE
feat(landing): add siloed-vs-shared memory topology section

### DIFF
--- a/packages/landing/src/components/MemorySection.tsx
+++ b/packages/landing/src/components/MemorySection.tsx
@@ -12,6 +12,7 @@ import { CommandHero } from "./CommandHero";
 import { HighlightedText } from "./HighlightedText";
 import { ContentRail } from "./ContentRail";
 import { ExampleShowcase } from "./memory/ExampleShowcase";
+import { MemoryTopologyCompare } from "./memory/MemoryTopologyCompare";
 import { LatestBlogPosts, type LatestBlogPost } from "./LatestBlogPosts";
 import { ScheduleCallButton, ScheduleCallIcon } from "./ScheduleDialog";
 import { ScopedUseCaseTabs } from "./ScopedUseCaseTabs";
@@ -92,6 +93,15 @@ export function MemorySection(props: {
             </a>
           }
         />
+
+        <ContentRail variant="compact" className="mb-16 mt-10">
+          <SectionHeader
+            title="Two ways to give agents memory"
+            body="One sandbox, one filesystem — or one shared layer your whole org reads and writes."
+            className="mb-8"
+          />
+          <MemoryTopologyCompare />
+        </ContentRail>
 
         <div class="mb-10 text-center">
           <ScopedUseCaseTabs

--- a/packages/landing/src/components/MemorySection.tsx
+++ b/packages/landing/src/components/MemorySection.tsx
@@ -97,7 +97,7 @@ export function MemorySection(props: {
         <ContentRail variant="compact" className="mb-16 mt-10">
           <SectionHeader
             title="Two ways to give agents memory"
-            body="One sandbox, one filesystem — or one shared layer your whole org reads and writes."
+            body="Per-agent files keep memory local to one sandbox. Lobu Memory gives every agent a shared, auditable graph through MCP."
             className="mb-8"
           />
           <MemoryTopologyCompare />

--- a/packages/landing/src/components/memory/MemoryTopologyCompare.tsx
+++ b/packages/landing/src/components/memory/MemoryTopologyCompare.tsx
@@ -1,4 +1,5 @@
 import type { ComponentChildren } from "preact";
+import { useId } from "preact/hooks";
 import {
   accentCyan,
   cardBg,
@@ -71,16 +72,18 @@ function DownArrow() {
 }
 
 function ConvergingArrows() {
+  const reactId = useId();
+  const markerId = `memory-arrow-head-${reactId.replace(/[:]/g, "")}`;
   return (
     <svg
-      viewBox="0 0 240 60"
-      class="h-14 w-full"
+      viewBox="0 0 240 70"
+      class="h-16 w-full"
       aria-hidden="true"
       style={{ color: accentCyan }}
     >
       <defs>
         <marker
-          id="memory-arrow-head"
+          id={markerId}
           viewBox="0 0 10 10"
           refX="8"
           refY="5"
@@ -95,52 +98,78 @@ function ConvergingArrows() {
         x1="32"
         y1="2"
         x2="120"
-        y2="56"
+        y2="62"
         stroke="currentColor"
         stroke-width="1.1"
         stroke-dasharray="3 3"
-        marker-end="url(#memory-arrow-head)"
+        marker-end={`url(#${markerId})`}
       />
       <line
         x1="120"
         y1="2"
         x2="120"
-        y2="56"
+        y2="62"
         stroke="currentColor"
         stroke-width="1.1"
         stroke-dasharray="3 3"
-        marker-end="url(#memory-arrow-head)"
+        marker-end={`url(#${markerId})`}
       />
       <line
         x1="208"
         y1="2"
         x2="120"
-        y2="56"
+        y2="62"
         stroke="currentColor"
         stroke-width="1.1"
         stroke-dasharray="3 3"
-        marker-end="url(#memory-arrow-head)"
+        marker-end={`url(#${markerId})`}
       />
-      <text
-        x="68"
-        y="34"
-        font-size="9"
-        font-family="ui-monospace, SFMono-Regular, monospace"
-        fill="currentColor"
-        opacity="0.85"
-      >
-        mcp
-      </text>
-      <text
-        x="148"
-        y="34"
-        font-size="9"
-        font-family="ui-monospace, SFMono-Regular, monospace"
-        fill="currentColor"
-        opacity="0.85"
-      >
-        mcp
-      </text>
+      <g>
+        <rect
+          x="58"
+          y="30"
+          width="22"
+          height="13"
+          rx="3"
+          fill="rgba(5,7,10,0.92)"
+          stroke="currentColor"
+          stroke-width="0.6"
+          opacity="0.95"
+        />
+        <text
+          x="69"
+          y="39"
+          font-size="9"
+          font-family="ui-monospace, SFMono-Regular, monospace"
+          fill="currentColor"
+          text-anchor="middle"
+        >
+          mcp
+        </text>
+      </g>
+      <g>
+        <rect
+          x="160"
+          y="30"
+          width="22"
+          height="13"
+          rx="3"
+          fill="rgba(5,7,10,0.92)"
+          stroke="currentColor"
+          stroke-width="0.6"
+          opacity="0.95"
+        />
+        <text
+          x="171"
+          y="39"
+          font-size="9"
+          font-family="ui-monospace, SFMono-Regular, monospace"
+          fill="currentColor"
+          text-anchor="middle"
+        >
+          mcp
+        </text>
+      </g>
     </svg>
   );
 }
@@ -205,8 +234,15 @@ function CardShell({
 
 function SiloedDiagram() {
   return (
-    <div class="flex flex-col items-center">
-      <div class="flex items-end justify-around gap-6 sm:gap-10">
+    <div
+      class="flex flex-col items-center"
+      role="img"
+      aria-label="Three agents, each pointing down to its own private filesystem. No shared layer between them."
+    >
+      <div
+        class="flex items-end justify-around gap-6 sm:gap-10"
+        aria-hidden="true"
+      >
         {AGENT_LABELS.map((label) => (
           <div key={label} class="flex flex-col items-center gap-1">
             <AgentTile label={label} />
@@ -216,6 +252,7 @@ function SiloedDiagram() {
         ))}
       </div>
       <div
+        aria-hidden="true"
         class="mt-4 text-[10px] uppercase tracking-[0.18em]"
         style={{ color: labelGray }}
       >
@@ -227,8 +264,15 @@ function SiloedDiagram() {
 
 function SharedDiagram() {
   return (
-    <div class="flex flex-col items-center">
-      <div class="grid w-full max-w-[18rem] grid-cols-3 items-center gap-4">
+    <div
+      class="flex flex-col items-center"
+      role="img"
+      aria-label="Three agents converging through MCP onto a single shared Lobu Memory layer of entities and events."
+    >
+      <div
+        class="grid w-full max-w-[18rem] grid-cols-3 items-center gap-4"
+        aria-hidden="true"
+      >
         {AGENT_LABELS.map((label) => (
           <div key={label} class="flex justify-center">
             <AgentTile label={label} />
@@ -237,6 +281,7 @@ function SharedDiagram() {
       </div>
       <ConvergingArrows />
       <div
+        aria-hidden="true"
         class="mt-1 flex w-full max-w-[18rem] flex-col items-center rounded-lg px-3 py-2"
         style={{
           backgroundColor: "rgba(103, 232, 249, 0.08)",
@@ -265,8 +310,8 @@ export function MemoryTopologyCompare() {
         title="Each agent has its own filesystem"
         bullets={[
           "no cross-agent recall",
-          "no audit trail",
-          "dies with the sandbox",
+          "audit is per-agent and manual",
+          "tied to one sandbox / session",
         ]}
       >
         <SiloedDiagram />

--- a/packages/landing/src/components/memory/MemoryTopologyCompare.tsx
+++ b/packages/landing/src/components/memory/MemoryTopologyCompare.tsx
@@ -1,0 +1,292 @@
+import type { ComponentChildren } from "preact";
+import {
+  accentCyan,
+  cardBg,
+  cardBorder,
+  innerCardBg,
+  labelGray,
+  textColor,
+  textMuted,
+} from "./styles";
+
+const AGENT_LABELS = ["A1", "A2", "A3"] as const;
+
+function AgentTile({ label }: { label: string }) {
+  return (
+    <div
+      class="flex h-12 w-12 items-center justify-center rounded-lg font-mono text-[0.8rem] font-semibold"
+      style={{
+        backgroundColor: innerCardBg,
+        border: `1px solid ${cardBorder}`,
+        color: textColor,
+      }}
+    >
+      {label}
+    </div>
+  );
+}
+
+function FsTile() {
+  return (
+    <div
+      class="flex h-10 w-12 items-center justify-center rounded-md font-mono text-[0.7rem]"
+      style={{
+        backgroundColor: "rgba(255,255,255,0.02)",
+        border: `1px dashed ${cardBorder}`,
+        color: labelGray,
+      }}
+    >
+      fs
+    </div>
+  );
+}
+
+function DownArrow() {
+  return (
+    <svg
+      width="14"
+      height="22"
+      viewBox="0 0 14 22"
+      aria-hidden="true"
+      style={{ color: labelGray }}
+    >
+      <line
+        x1="7"
+        y1="0"
+        x2="7"
+        y2="16"
+        stroke="currentColor"
+        stroke-width="1.2"
+      />
+      <polyline
+        points="3,14 7,20 11,14"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="1.2"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+      />
+    </svg>
+  );
+}
+
+function ConvergingArrows() {
+  return (
+    <svg
+      viewBox="0 0 240 60"
+      class="h-14 w-full"
+      aria-hidden="true"
+      style={{ color: accentCyan }}
+    >
+      <defs>
+        <marker
+          id="memory-arrow-head"
+          viewBox="0 0 10 10"
+          refX="8"
+          refY="5"
+          markerWidth="6"
+          markerHeight="6"
+          orient="auto-start-reverse"
+        >
+          <path d="M0,0 L10,5 L0,10 z" fill="currentColor" />
+        </marker>
+      </defs>
+      <line
+        x1="32"
+        y1="2"
+        x2="120"
+        y2="56"
+        stroke="currentColor"
+        stroke-width="1.1"
+        stroke-dasharray="3 3"
+        marker-end="url(#memory-arrow-head)"
+      />
+      <line
+        x1="120"
+        y1="2"
+        x2="120"
+        y2="56"
+        stroke="currentColor"
+        stroke-width="1.1"
+        stroke-dasharray="3 3"
+        marker-end="url(#memory-arrow-head)"
+      />
+      <line
+        x1="208"
+        y1="2"
+        x2="120"
+        y2="56"
+        stroke="currentColor"
+        stroke-width="1.1"
+        stroke-dasharray="3 3"
+        marker-end="url(#memory-arrow-head)"
+      />
+      <text
+        x="68"
+        y="34"
+        font-size="9"
+        font-family="ui-monospace, SFMono-Regular, monospace"
+        fill="currentColor"
+        opacity="0.85"
+      >
+        mcp
+      </text>
+      <text
+        x="148"
+        y="34"
+        font-size="9"
+        font-family="ui-monospace, SFMono-Regular, monospace"
+        fill="currentColor"
+        opacity="0.85"
+      >
+        mcp
+      </text>
+    </svg>
+  );
+}
+
+function CardShell({
+  eyebrow,
+  eyebrowColor,
+  title,
+  children,
+  bullets,
+}: {
+  eyebrow: string;
+  eyebrowColor: string;
+  title: string;
+  children: ComponentChildren;
+  bullets: string[];
+}) {
+  return (
+    <div
+      class="flex flex-col rounded-2xl p-5 sm:p-6"
+      style={{
+        background: cardBg,
+        border: `1px solid ${cardBorder}`,
+      }}
+    >
+      <div
+        class="mb-2 text-[10px] font-semibold uppercase tracking-[0.22em]"
+        style={{ color: eyebrowColor }}
+      >
+        {eyebrow}
+      </div>
+      <h3
+        class="mb-5 text-lg font-semibold"
+        style={{ color: textColor }}
+      >
+        {title}
+      </h3>
+
+      <div
+        class="rounded-xl px-4 py-5"
+        style={{
+          backgroundColor: innerCardBg,
+          border: `1px solid ${cardBorder}`,
+        }}
+      >
+        {children}
+      </div>
+
+      <ul
+        class="m-0 mt-5 flex list-none flex-col gap-2 p-0 text-[0.88rem] leading-6"
+        style={{ color: textMuted }}
+      >
+        {bullets.map((bullet) => (
+          <li key={bullet} class="flex items-start gap-2">
+            <span aria-hidden="true" class="mt-[2px]">
+              ·
+            </span>
+            <span>{bullet}</span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+function SiloedDiagram() {
+  return (
+    <div class="flex flex-col items-center">
+      <div class="flex items-end justify-around gap-6 sm:gap-10">
+        {AGENT_LABELS.map((label) => (
+          <div key={label} class="flex flex-col items-center gap-1">
+            <AgentTile label={label} />
+            <DownArrow />
+            <FsTile />
+          </div>
+        ))}
+      </div>
+      <div
+        class="mt-4 text-[10px] uppercase tracking-[0.18em]"
+        style={{ color: labelGray }}
+      >
+        no shared layer
+      </div>
+    </div>
+  );
+}
+
+function SharedDiagram() {
+  return (
+    <div class="flex flex-col items-center">
+      <div class="grid w-full max-w-[18rem] grid-cols-3 items-center gap-4">
+        {AGENT_LABELS.map((label) => (
+          <div key={label} class="flex justify-center">
+            <AgentTile label={label} />
+          </div>
+        ))}
+      </div>
+      <ConvergingArrows />
+      <div
+        class="mt-1 flex w-full max-w-[18rem] flex-col items-center rounded-lg px-3 py-2"
+        style={{
+          backgroundColor: "rgba(103, 232, 249, 0.08)",
+          border: `1px solid rgba(103, 232, 249, 0.4)`,
+          color: textColor,
+        }}
+      >
+        <div class="text-[0.92rem] font-semibold">Lobu Memory</div>
+        <div
+          class="mt-0.5 font-mono text-[0.72rem]"
+          style={{ color: labelGray }}
+        >
+          entities · events
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function MemoryTopologyCompare() {
+  return (
+    <div class="grid grid-cols-1 gap-6 lg:grid-cols-2">
+      <CardShell
+        eyebrow="Siloed"
+        eyebrowColor={labelGray}
+        title="Each agent has its own filesystem"
+        bullets={[
+          "no cross-agent recall",
+          "no audit trail",
+          "dies with the sandbox",
+        ]}
+      >
+        <SiloedDiagram />
+      </CardShell>
+
+      <CardShell
+        eyebrow="Shared via MCP"
+        eyebrowColor={accentCyan}
+        title="Agents share Lobu Memory through MCP"
+        bullets={[
+          "one truth across agents",
+          "dedup via entity model",
+          "inspectable + correctable",
+        ]}
+      >
+        <SharedDiagram />
+      </CardShell>
+    </div>
+  );
+}

--- a/packages/landing/src/components/memory/MemoryTopologyCompare.tsx
+++ b/packages/landing/src/components/memory/MemoryTopologyCompare.tsx
@@ -172,10 +172,7 @@ function CardShell({
       >
         {eyebrow}
       </div>
-      <h3
-        class="mb-5 text-lg font-semibold"
-        style={{ color: textColor }}
-      >
+      <h3 class="mb-5 text-lg font-semibold" style={{ color: textColor }}>
         {title}
       </h3>
 


### PR DESCRIPTION
## Summary

- New section on `/memory` between the hero and the use-case tabs that contrasts two memory architectures: each agent with its own filesystem vs agents sharing Lobu Memory through MCP.
- Side-by-side cards with inline SVG topology diagrams (`A1/A2/A3 → fs` on the left, three agents converging into a shared `Lobu Memory` block on the right).
- Reuses the existing `memory/styles.ts` tokens — no new design primitives.

## Test plan

- [ ] `cd packages/landing && bun run build` passes
- [ ] `cd packages/landing && bun run dev`, open `/memory`, confirm the new section renders between the hero and the use-case tabs
- [ ] Cards stack at `sm`, sit side-by-side at `lg`
- [ ] SVG arrows render in the dark theme; `mcp` labels are legible
- [ ] `/memory/for/{usecase}` routes still load correctly