### PR TITLE
feat(worker,backend): capture subprocess output and exit metadata on run records

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,3 +76,8 @@ packages/.pi/
 pbcopy
 .pi/
 packages/*/~/
+
+# Subprocess executor temp files (.connector-child-<pid>-<ts>.mjs).
+# Cleaned up on success; can leak when a run or test is killed.
+.connector-child-*.mjs
+**/.connector-child-*.mjs

--- a/db/migrations/20260425120000_add_run_diagnostics.sql
+++ b/db/migrations/20260425120000_add_run_diagnostics.sql
@@ -1,0 +1,11 @@
+-- Add diagnostic columns to runs so subprocess failures carry enough context
+-- to diagnose without reading gateway pod logs.
+--
+-- output_tail: redacted tail (~16 KiB) of child stdout+stderr at exit.
+-- exit_code:   subprocess exit code, NULL when terminated by IPC error path.
+-- exit_signal: signal name (e.g. SIGKILL) when killed.
+-- exit_reason: categorized — ok | error_message | timeout | oom | crash.
+ALTER TABLE public.runs ADD COLUMN output_tail TEXT NULL;
+ALTER TABLE public.runs ADD COLUMN exit_code INTEGER NULL;
+ALTER TABLE public.runs ADD COLUMN exit_signal TEXT NULL;
+ALTER TABLE public.runs ADD COLUMN exit_reason TEXT NULL;

--- a/db/migrations/20260425130000_add_repair_agent_plumbing.sql
+++ b/db/migrations/20260425130000_add_repair_agent_plumbing.sql
@@ -1,0 +1,31 @@
+-- Repair-agent plumbing for connector reliability.
+--
+-- When a feed accumulates persistent failures, the worker-completion path
+-- can open a Lobu agent thread for triage. These columns track the
+-- per-feed override, the open thread (if any), the lifetime budget of
+-- repair attempts, the start of the current failure streak, and the
+-- last-posted content hash for append throttling.
+ALTER TABLE public.feeds
+  ADD COLUMN repair_agent_id text NULL,
+  ADD COLUMN repair_thread_id text NULL,
+  ADD COLUMN repair_attempt_count integer NOT NULL DEFAULT 0,
+  ADD COLUMN last_repair_at timestamp with time zone NULL,
+  ADD COLUMN first_failure_at timestamp with time zone NULL,
+  ADD COLUMN last_repair_post_hash text NULL;
+
+-- The unique partial index documents intent: a feed has at most one open
+-- repair thread at a time. (`feeds.id` is already PK so the constraint is
+-- redundant for uniqueness; the actual race guard is the conditional
+-- UPDATE on repair_thread_id IS NULL in the worker-completion path.)
+CREATE UNIQUE INDEX feeds_open_repair_thread_uniq
+  ON public.feeds (id) WHERE repair_thread_id IS NOT NULL;
+
+-- Per-connector default repair agent. When a feed has no explicit
+-- repair_agent_id, the trigger logic falls back to this value.
+ALTER TABLE public.connector_definitions
+  ADD COLUMN default_repair_agent_id text NULL;
+
+-- Per-org kill switch. When FALSE, no repair threads are opened for any
+-- feed in the org regardless of per-feed configuration.
+ALTER TABLE public.organization
+  ADD COLUMN repair_agents_enabled boolean NOT NULL DEFAULT TRUE;

--- a/packages/gateway/src/index.ts
+++ b/packages/gateway/src/index.ts
@@ -27,6 +27,14 @@ export type {
   RuntimeProviderCredentialResult,
 } from "./embedded.js";
 export { Gateway, type GatewayOptions } from "./gateway-main.js";
+export {
+  type CreateThreadForAgentArgs,
+  type CreateThreadForAgentResult,
+  createThreadForAgent,
+  type EnqueueAgentMessageArgs,
+  type EnqueueAgentMessageResult,
+  enqueueAgentMessage,
+} from "./services/agent-threads.js";
 export { CoreServices } from "./services/core-services.js";
 export {
   WatcherRunTracker,

--- a/packages/gateway/src/services/agent-threads.ts
+++ b/packages/gateway/src/services/agent-threads.ts
@@ -1,0 +1,175 @@
+/**
+ * Agent thread service — programmatic counterparts to the public HTTP routes
+ * `POST /api/v1/agents` (create thread/session) and `POST
+ * /api/v1/agents/:agentId/messages` (enqueue message).
+ *
+ * The HTTP routes in `routes/public/agent.ts` delegate the underlying work
+ * (session minting, queue enqueue) to these functions so that internal
+ * callers — for example the worker-completion path in `owletto-backend` —
+ * can open threads and post messages without going through HTTP.
+ *
+ * The functions here intentionally do NOT perform any HTTP-shaped auth
+ * (admin password, settings session, worker-token, OAuth, …). Callers are
+ * presumed to be inside the gateway's trust boundary; the public routes
+ * remain the single auth-gated entry point for external clients.
+ */
+import { randomUUID } from "node:crypto";
+import { createLogger, generateWorkerToken } from "@lobu/core";
+import type { QueueProducer } from "../infrastructure/queue/queue-producer.js";
+import type { ISessionManager, ThreadSession } from "../session.js";
+
+const logger = createLogger("agent-threads");
+
+/**
+ * Arguments for `createThreadForAgent`.
+ *
+ * Mirrors the shape of `POST /api/v1/agents` for the fields it needs to mint
+ * a session, but with no notion of provider/model/network/MCP overrides:
+ * internal callers always inherit the agent's stored settings.
+ */
+export interface CreateThreadForAgentArgs {
+  /** Target agent id. The session and resulting thread will be scoped to this agent. */
+  agentId: string;
+  /** Owning organization id (informational; persisted onto the session). */
+  organizationId: string;
+  /** Optional human-recorded principal that triggered the open. */
+  createdByUserId?: string;
+  /** Free-form reason tag for log lines (e.g. "connector-repair"). */
+  reason?: string;
+  /**
+   * Optional caller-supplied id for the new thread. Lets callers mint the id
+   * BEFORE writing it to their own state (e.g. an atomic UPDATE that wins
+   * against racing workers) and only then commit the session.
+   */
+  externalThreadId?: string;
+  /** User id to attribute the thread to. Defaults to `agentId`. */
+  userId?: string;
+}
+
+export interface CreateThreadForAgentResult {
+  /** Thread / session identifier (also referred to as `conversationId`). */
+  threadId: string;
+  /** Worker token usable by the caller's HTTP client (rarely needed internally). */
+  token: string;
+  /** Token expiration timestamp (ms since epoch). */
+  expiresAt: number;
+}
+
+const TOKEN_EXPIRATION_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * Mint a new thread session for an agent.
+ *
+ * Returns the threadId (== conversationId) without enqueueing any message.
+ * Callers wire follow-up state (e.g. `feeds.repair_thread_id = $threadId`)
+ * and then call {@link enqueueAgentMessage} to post the first message.
+ */
+export async function createThreadForAgent(
+  deps: { sessionManager: ISessionManager },
+  args: CreateThreadForAgentArgs
+): Promise<CreateThreadForAgentResult> {
+  const { sessionManager } = deps;
+  const { agentId, reason, externalThreadId } = args;
+  const userId = args.userId || args.createdByUserId || agentId;
+
+  const threadId = externalThreadId || randomUUID();
+  const conversationId = `${agentId}_${userId}_${threadId}`;
+  const channelId = `api_${userId}`;
+  const deploymentName = `api-${agentId.slice(0, 8)}`;
+
+  const token = generateWorkerToken(agentId, conversationId, deploymentName, {
+    channelId,
+    agentId,
+    platform: "api",
+    sessionKey: userId,
+  });
+  const expiresAt = Date.now() + TOKEN_EXPIRATION_MS;
+
+  const session: ThreadSession = {
+    conversationId,
+    channelId,
+    userId,
+    threadCreator: userId,
+    lastActivity: Date.now(),
+    createdAt: Date.now(),
+    status: "created",
+    provider: "claude",
+    agentId,
+    dryRun: false,
+    isEphemeral: false,
+  };
+  await sessionManager.setSession(session);
+
+  logger.info(
+    `Created thread ${conversationId} for agent ${agentId}${reason ? ` (reason=${reason})` : ""}`
+  );
+
+  return { threadId: conversationId, token, expiresAt };
+}
+
+export interface EnqueueAgentMessageArgs {
+  /** Thread id (conversationId) returned by `createThreadForAgent`. */
+  threadId: string;
+  /** Plain-text user message body. */
+  messageText: string;
+  /** Optional caller-supplied messageId (defaults to a fresh UUID). */
+  messageId?: string;
+  /** Free-form source tag for log lines / platformMetadata. */
+  source?: string;
+}
+
+export interface EnqueueAgentMessageResult {
+  messageId: string;
+  jobId: string;
+}
+
+/**
+ * Enqueue a message into an existing agent thread.
+ *
+ * Mirrors the direct-API path of `POST /api/v1/agents/:agentId/messages`:
+ * resolves the session, touches it, and dispatches a `MessagePayload` to
+ * the unified message queue. Throws if the thread does not exist.
+ */
+export async function enqueueAgentMessage(
+  deps: { sessionManager: ISessionManager; queueProducer: QueueProducer },
+  args: EnqueueAgentMessageArgs
+): Promise<EnqueueAgentMessageResult> {
+  const { sessionManager, queueProducer } = deps;
+  const { threadId, messageText } = args;
+  const messageId = args.messageId || randomUUID();
+
+  const session = await sessionManager.getSession(threadId);
+  if (!session) {
+    throw new Error(`Thread ${threadId} not found`);
+  }
+
+  await sessionManager.touchSession(threadId);
+
+  const realAgentId = session.agentId || threadId;
+  const channelId = session.channelId || `api_${session.userId}`;
+
+  const jobId = await queueProducer.enqueueMessage({
+    userId: session.userId,
+    conversationId: session.conversationId || threadId,
+    messageId,
+    channelId,
+    teamId: "api",
+    agentId: realAgentId,
+    botId: "lobu-api",
+    platform: "api",
+    messageText,
+    platformMetadata: {
+      agentId: realAgentId,
+      source: args.source || "internal",
+      dryRun: session.dryRun || false,
+    },
+    agentOptions: {
+      provider: session.provider || "claude",
+      model: session.model,
+    },
+    networkConfig: session.networkConfig,
+    mcpConfig: session.mcpConfig,
+  });
+
+  return { messageId, jobId };
+}

--- a/packages/owletto-backend/src/__tests__/unit/connectors/repair-agent.test.ts
+++ b/packages/owletto-backend/src/__tests__/unit/connectors/repair-agent.test.ts
@@ -1,0 +1,382 @@
+import { beforeEach, describe, expect, it, mock } from 'bun:test';
+import type { DbClient } from '../../../db/client';
+import {
+  hashFailureSignature,
+  maybeOpenOrAppendRepairThread,
+  type RepairAgentConfig,
+} from '../../../connectors/repair-agent';
+import {
+  buildOpenPacket,
+  type DiagnosticRunRow,
+} from '../../../connectors/repair-agent-packet';
+
+/**
+ * Build a tagged-template mock that matches each invocation against an
+ * ordered queue of `(matcher, response)` pairs. Each matcher is a substring
+ * of the SQL it should fire on — the first whose pattern is contained in
+ * the joined template strings is consumed and returns its rows.
+ *
+ * If no pattern matches, throws — surfaces unexpected queries instead of
+ * silently returning empty.
+ */
+function makeMockSql(plan: Array<{ match: string | RegExp; rows: any[] }>): {
+  sql: DbClient;
+  remaining: () => number;
+  log: string[];
+} {
+  const queue = [...plan];
+  const log: string[] = [];
+  const fn = ((strings: TemplateStringsArray, ..._values: unknown[]) => {
+    const joined = strings.join('?');
+    log.push(joined.trim().split(/\s+/).slice(0, 8).join(' '));
+    const idx = queue.findIndex((item) =>
+      typeof item.match === 'string'
+        ? joined.includes(item.match)
+        : item.match.test(joined)
+    );
+    if (idx === -1) {
+      throw new Error(`unexpected query: ${joined.slice(0, 120)}`);
+    }
+    const [{ rows }] = queue.splice(idx, 1);
+    const result = Object.assign(Promise.resolve(rows), {
+      count: rows.length,
+    }) as any;
+    return result;
+  }) as DbClient;
+  fn.unsafe = (() => {
+    throw new Error('unsafe() not supported by mock');
+  }) as any;
+  fn.array = ((values: any) => values) as any;
+  fn.json = ((value: any) => value) as any;
+  fn.begin = (async (cb: any) => cb(fn)) as any;
+  return { sql: fn, remaining: () => queue.length, log };
+}
+
+const TEST_CONFIG: RepairAgentConfig = {
+  threshold: 3,
+  minFailingDurationMs: 30 * 60 * 1000,
+  maxAttempts: 5,
+  cooldownMs: 6 * 60 * 60 * 1000,
+};
+
+const NOW = Date.UTC(2026, 3, 25, 12, 0, 0); // 2026-04-25 12:00:00 UTC
+const FRESH_FIRST_FAILURE = new Date(NOW - TEST_CONFIG.minFailingDurationMs - 60 * 1000); // 31 min ago
+
+function feedRow(overrides: Partial<Record<string, any>> = {}): any {
+  return {
+    id: 42,
+    organization_id: 'org-1',
+    consecutive_failures: 3,
+    first_failure_at: FRESH_FIRST_FAILURE,
+    repair_thread_id: null,
+    repair_attempt_count: 0,
+    last_repair_at: null,
+    repair_agent_id: 'repair-agent',
+    display_name: 'My Feed',
+    config: { foo: 'bar' },
+    schedule: '0 */6 * * *',
+    connection_id: 7,
+    connector_key: 'gmail',
+    connection_display_name: 'Gmail',
+    auth_profile_status: 'active',
+    connector_name: 'Gmail',
+    connector_version: '1.2.3',
+    default_repair_agent_id: null,
+    org_repair_enabled: true,
+    ...overrides,
+  };
+}
+
+const RUN_ROW = {
+  id: 99,
+  status: 'failed',
+  started_at: new Date(NOW - 5 * 60 * 1000),
+  completed_at: new Date(NOW),
+  error_message: 'token expired',
+  exit_reason: 'error_message',
+  exit_code: 1,
+  exit_signal: null,
+  output_tail: 'gmail: 401 Unauthorized\n  at refreshToken (auth.ts:42)',
+};
+
+function fakeServices() {
+  const createThreadForAgent = mock(async () => ({ threadId: 'mock-thread' }));
+  const enqueueAgentMessage = mock(async () => ({ jobId: 'job-1', messageId: 'msg-1' }));
+  return {
+    createThreadForAgent,
+    enqueueAgentMessage,
+    sessionManager: {} as any,
+    queueProducer: {} as any,
+  };
+}
+
+describe('maybeOpenOrAppendRepairThread', () => {
+  let services: ReturnType<typeof fakeServices>;
+
+  beforeEach(() => {
+    services = fakeServices();
+  });
+
+  it('opens a thread when threshold met and cooldown clear (UPDATE wins)', async () => {
+    const { sql } = makeMockSql([
+      { match: 'FROM feeds f', rows: [feedRow()] },
+      { match: 'FROM runs', rows: [RUN_ROW] },
+      { match: 'UPDATE feeds', rows: [{ repair_thread_id: 'mock-conv' }] },
+    ]);
+
+    await maybeOpenOrAppendRepairThread(42, 99, {
+      sql,
+      services,
+      config: TEST_CONFIG,
+      now: () => NOW,
+      mintThreadId: () => 'fixed-thread-id',
+    });
+
+    expect(services.createThreadForAgent).toHaveBeenCalledTimes(1);
+    expect(services.enqueueAgentMessage).toHaveBeenCalledTimes(1);
+    const enqueueArg = services.enqueueAgentMessage.mock.calls[0][1] as any;
+    expect(enqueueArg.threadId).toBe('repair-agent_repair-agent_fixed-thread-id');
+    expect(enqueueArg.messageText).toContain('A connector feed sync has been failing');
+    expect(enqueueArg.messageText).toContain('consecutive_failures: 3');
+  });
+
+  it('skips when cooldown is active', async () => {
+    const recentRepair = new Date(NOW - TEST_CONFIG.cooldownMs / 2);
+    const { sql, remaining } = makeMockSql([
+      {
+        match: 'FROM feeds f',
+        rows: [
+          feedRow({
+            repair_attempt_count: 1,
+            last_repair_at: recentRepair,
+          }),
+        ],
+      },
+      { match: 'FROM runs', rows: [RUN_ROW] },
+    ]);
+
+    await maybeOpenOrAppendRepairThread(42, 99, {
+      sql,
+      services,
+      config: TEST_CONFIG,
+      now: () => NOW,
+    });
+
+    expect(services.createThreadForAgent).not.toHaveBeenCalled();
+    expect(services.enqueueAgentMessage).not.toHaveBeenCalled();
+    // Both queued queries should have been consumed: state load + recent runs.
+    expect(remaining()).toBe(0);
+  });
+
+  it('skips when threshold not yet met', async () => {
+    const { sql } = makeMockSql([
+      { match: 'FROM feeds f', rows: [feedRow({ consecutive_failures: 2 })] },
+      { match: 'FROM runs', rows: [RUN_ROW] },
+    ]);
+    await maybeOpenOrAppendRepairThread(42, 99, {
+      sql,
+      services,
+      config: TEST_CONFIG,
+      now: () => NOW,
+    });
+    expect(services.createThreadForAgent).not.toHaveBeenCalled();
+  });
+
+  it('skips when first_failure_at is too recent', async () => {
+    const { sql } = makeMockSql([
+      {
+        match: 'FROM feeds f',
+        rows: [
+          feedRow({
+            first_failure_at: new Date(NOW - 60 * 1000), // 1 min ago
+          }),
+        ],
+      },
+      { match: 'FROM runs', rows: [RUN_ROW] },
+    ]);
+    await maybeOpenOrAppendRepairThread(42, 99, {
+      sql,
+      services,
+      config: TEST_CONFIG,
+      now: () => NOW,
+    });
+    expect(services.createThreadForAgent).not.toHaveBeenCalled();
+  });
+
+  it('pauses feed (no thread) when repair_attempt_count is at the cap', async () => {
+    const { sql } = makeMockSql([
+      {
+        match: 'FROM feeds f',
+        rows: [feedRow({ repair_attempt_count: TEST_CONFIG.maxAttempts })],
+      },
+      { match: 'FROM runs', rows: [RUN_ROW] },
+      { match: "status = 'paused'", rows: [{ id: 42 }] },
+    ]);
+    await maybeOpenOrAppendRepairThread(42, 99, {
+      sql,
+      services,
+      config: TEST_CONFIG,
+      now: () => NOW,
+    });
+    expect(services.createThreadForAgent).not.toHaveBeenCalled();
+  });
+
+  it('skips when org has repair agents disabled', async () => {
+    const { sql, remaining } = makeMockSql([
+      { match: 'FROM feeds f', rows: [feedRow({ org_repair_enabled: false })] },
+    ]);
+    await maybeOpenOrAppendRepairThread(42, 99, {
+      sql,
+      services,
+      config: TEST_CONFIG,
+      now: () => NOW,
+    });
+    expect(services.createThreadForAgent).not.toHaveBeenCalled();
+    // We never even loaded recent runs.
+    expect(remaining()).toBe(0);
+  });
+
+  it('only one of two racing callers wins the atomic UPDATE', async () => {
+    // Caller A: load_state + recent_runs + UPDATE returns 1 row (won)
+    const callA = makeMockSql([
+      { match: 'FROM feeds f', rows: [feedRow()] },
+      { match: 'FROM runs', rows: [RUN_ROW] },
+      { match: 'UPDATE feeds', rows: [{ repair_thread_id: 'won' }] },
+    ]);
+    // Caller B: same gating passes, but the UPDATE returns 0 rows because
+    // caller A already filled in repair_thread_id.
+    const callB = makeMockSql([
+      { match: 'FROM feeds f', rows: [feedRow()] },
+      { match: 'FROM runs', rows: [RUN_ROW] },
+      { match: 'UPDATE feeds', rows: [] },
+    ]);
+
+    const servicesA = fakeServices();
+    const servicesB = fakeServices();
+
+    await Promise.all([
+      maybeOpenOrAppendRepairThread(42, 99, {
+        sql: callA.sql,
+        services: servicesA,
+        config: TEST_CONFIG,
+        now: () => NOW,
+      }),
+      maybeOpenOrAppendRepairThread(42, 99, {
+        sql: callB.sql,
+        services: servicesB,
+        config: TEST_CONFIG,
+        now: () => NOW,
+      }),
+    ]);
+
+    expect(servicesA.createThreadForAgent).toHaveBeenCalledTimes(1);
+    expect(servicesA.enqueueAgentMessage).toHaveBeenCalledTimes(1);
+    expect(servicesB.createThreadForAgent).not.toHaveBeenCalled();
+    expect(servicesB.enqueueAgentMessage).not.toHaveBeenCalled();
+  });
+});
+
+describe('hashFailureSignature', () => {
+  it('returns the same hash for identical signatures', () => {
+    const a: DiagnosticRunRow = {
+      id: 1,
+      status: 'failed',
+      startedAt: null,
+      completedAt: null,
+      durationMs: null,
+      errorMessage: 'boom',
+      exitReason: 'error_message',
+      exitCode: 1,
+      exitSignal: null,
+      outputTail: 'tail',
+    };
+    const b = { ...a, id: 2 };
+    expect(hashFailureSignature(a)).toEqual(hashFailureSignature(b));
+  });
+
+  it('differs when output_tail differs', () => {
+    const a: DiagnosticRunRow = {
+      id: 1,
+      status: 'failed',
+      startedAt: null,
+      completedAt: null,
+      durationMs: null,
+      errorMessage: 'boom',
+      exitReason: 'error_message',
+      exitCode: 1,
+      exitSignal: null,
+      outputTail: 'tail-a',
+    };
+    const b = { ...a, outputTail: 'tail-b' };
+    expect(hashFailureSignature(a)).not.toEqual(hashFailureSignature(b));
+  });
+});
+
+describe('buildOpenPacket', () => {
+  it('preserves the worker-redacted output_tail verbatim and does not introduce raw values from elsewhere', () => {
+    // Worker-side redaction replaces secrets with a sentinel like
+    // `[REDACTED:bearer]`. The packet builder must NOT mention any raw
+    // value — it has access only to the row fields it's handed, all of
+    // which are already redacted by the worker.
+    const REDACTED_TAIL = [
+      'gmail: response { Authorization: [REDACTED:bearer] }',
+      'token=[REDACTED:apiKey]',
+      'cookie=[REDACTED:cookie]',
+    ].join('\n');
+
+    const packet = buildOpenPacket({
+      feedId: 42,
+      feedDisplayName: 'My Feed',
+      connectorKey: 'gmail',
+      connectorName: 'Gmail',
+      connectorVersion: '1.2.3',
+      feedConfig: { folder: 'INBOX' },
+      feedSchedule: '0 */6 * * *',
+      consecutiveFailures: 4,
+      firstFailureAt: '2026-04-25T11:00:00.000Z',
+      connectionId: 7,
+      connectionDisplayName: 'Gmail (work)',
+      authProfileStatus: 'active',
+      recentRuns: [
+        {
+          id: 99,
+          status: 'failed',
+          startedAt: '2026-04-25T11:55:00.000Z',
+          completedAt: '2026-04-25T12:00:00.000Z',
+          durationMs: 300000,
+          errorMessage: 'token expired',
+          exitReason: 'error_message',
+          exitCode: 1,
+          exitSignal: null,
+          outputTail: REDACTED_TAIL,
+        },
+      ],
+    });
+
+    // The redacted sentinels MUST appear verbatim — if they didn't, the
+    // builder lost the worker's redaction.
+    expect(packet).toContain('[REDACTED:bearer]');
+    expect(packet).toContain('[REDACTED:apiKey]');
+    expect(packet).toContain('[REDACTED:cookie]');
+
+    // Things the builder MUST NOT invent / inject from elsewhere:
+    //   - actual bearer / api key / cookie values
+    //   - any hard-coded credential string
+    // These would mean the builder pulled raw data from outside the row.
+    const forbiddenSubstrings = [
+      'Authorization: Bearer ', // unredacted bearer header
+      'sk-ant-', // anthropic key prefix
+      'AKIA', // AWS access key prefix
+      'eyJhbGc', // JWT prefix
+    ];
+    for (const needle of forbiddenSubstrings) {
+      expect(packet).not.toContain(needle);
+    }
+
+    // Structural smoke checks.
+    expect(packet).toContain('Connector feed repair — Gmail / My Feed');
+    expect(packet).toContain('consecutive_failures: 4');
+    expect(packet).toContain('first_failure_at: 2026-04-25T11:00:00.000Z');
+    expect(packet).toContain('connector-source MCP tool');
+  });
+});

--- a/packages/owletto-backend/src/auth/tool-access.ts
+++ b/packages/owletto-backend/src/auth/tool-access.ts
@@ -38,6 +38,7 @@ const OWNER_ADMIN_ACTIONS: Record<string, Set<string>> = {
     'toggle_connector_login',
     'update_connector_auth',
     'update_connector_default_config',
+    'update_connector_default_repair_agent',
     'set_connector_entity_link_overrides',
   ]),
   manage_feeds: new Set(['create_feed', 'update_feed', 'delete_feed', 'trigger_feed']),
@@ -70,6 +71,7 @@ const OWNER_ADMIN_ACTIONS: Record<string, Set<string>> = {
     'classify',
   ]),
   manage_view_templates: new Set(['set', 'rollback', 'remove_tab']),
+  manage_organization: new Set(['get_settings', 'update_settings']),
 };
 
 const PUBLIC_READ_ACTIONS: Record<string, Set<string> | null> = {

--- a/packages/owletto-backend/src/connectors/repair-agent-packet.ts
+++ b/packages/owletto-backend/src/connectors/repair-agent-packet.ts
@@ -1,0 +1,126 @@
+/**
+ * Diagnostic packet builders for connector repair threads.
+ *
+ * The packet is plain text; the agent reads it as a regular user message.
+ * No new schema is invented here — all fields come from existing run/feed
+ * rows. `output_tail` is already redacted by the worker before it reaches
+ * the backend (see PR 1's diagnostic substrate); the builder MUST NOT
+ * source raw values from anywhere else.
+ */
+
+export interface DiagnosticRunRow {
+  id: number;
+  status: string;
+  startedAt: string | null;
+  completedAt: string | null;
+  durationMs: number | null;
+  errorMessage: string | null;
+  exitReason: string | null;
+  exitCode: number | null;
+  exitSignal: string | null;
+  outputTail: string | null;
+}
+
+export interface OpenPacketInput {
+  feedId: number;
+  feedDisplayName: string | null;
+  connectorKey: string | null;
+  connectorName: string | null;
+  connectorVersion: string | null;
+  feedConfig: Record<string, unknown> | null;
+  feedSchedule: string | null;
+  consecutiveFailures: number;
+  firstFailureAt: string | null;
+  connectionId: number | null;
+  connectionDisplayName: string | null;
+  authProfileStatus: string | null;
+  recentRuns: DiagnosticRunRow[];
+}
+
+function fmtRun(run: DiagnosticRunRow): string {
+  const lines: string[] = [];
+  lines.push(`- id: ${run.id}`);
+  lines.push(`  status: ${run.status}`);
+  if (run.startedAt) lines.push(`  started_at: ${run.startedAt}`);
+  if (run.completedAt) lines.push(`  completed_at: ${run.completedAt}`);
+  if (run.durationMs != null) lines.push(`  duration_ms: ${run.durationMs}`);
+  if (run.errorMessage) lines.push(`  error_message: ${run.errorMessage}`);
+  if (run.exitReason) lines.push(`  exit_reason: ${run.exitReason}`);
+  if (run.exitCode != null) lines.push(`  exit_code: ${run.exitCode}`);
+  if (run.exitSignal) lines.push(`  exit_signal: ${run.exitSignal}`);
+  if (run.outputTail) {
+    lines.push('  output_tail: |');
+    for (const tailLine of run.outputTail.split('\n')) {
+      lines.push(`    ${tailLine}`);
+    }
+  }
+  return lines.join('\n');
+}
+
+export function buildOpenPacket(input: OpenPacketInput): string {
+  const connectorLabel = input.connectorName || input.connectorKey || 'unknown';
+  const feedLabel = input.feedDisplayName || `feed#${input.feedId}`;
+
+  const sections: string[] = [];
+  sections.push(`Title: Connector feed repair — ${connectorLabel} / ${feedLabel}`);
+  sections.push('');
+  sections.push(
+    'A connector feed sync has been failing repeatedly. Diagnose the cause and, if you can, fix it.'
+  );
+  sections.push('');
+
+  const feedLines: string[] = [];
+  feedLines.push('Feed');
+  feedLines.push(`- id: ${input.feedId}`);
+  if (input.connectorKey) feedLines.push(`- connector_key: ${input.connectorKey}`);
+  if (input.connectorVersion) feedLines.push(`- connector_version: ${input.connectorVersion}`);
+  feedLines.push(`- config: ${input.feedConfig ? JSON.stringify(input.feedConfig) : 'null'}`);
+  feedLines.push(`- schedule: ${input.feedSchedule ?? 'null'}`);
+  feedLines.push(`- consecutive_failures: ${input.consecutiveFailures}`);
+  feedLines.push(`- first_failure_at: ${input.firstFailureAt ?? 'null'}`);
+  sections.push(feedLines.join('\n'));
+  sections.push('');
+
+  if (input.connectionId != null) {
+    const connLines: string[] = [];
+    connLines.push('Connection');
+    connLines.push(`- id: ${input.connectionId}`);
+    if (input.connectionDisplayName)
+      connLines.push(`- display_name: ${input.connectionDisplayName}`);
+    if (input.authProfileStatus)
+      connLines.push(`- auth_profile_status: ${input.authProfileStatus}`);
+    sections.push(connLines.join('\n'));
+    sections.push('');
+  }
+
+  sections.push(`Recent runs (most recent first, up to ${input.recentRuns.length}):`);
+  for (const run of input.recentRuns) sections.push(fmtRun(run));
+  sections.push('');
+
+  const cdLines: string[] = [];
+  cdLines.push('Connector definition');
+  cdLines.push(`- name: ${input.connectorName ?? 'unknown'}`);
+  cdLines.push(`- version: ${input.connectorVersion ?? 'unknown'}`);
+  cdLines.push(
+    '- source: fetch via the connector-source MCP tool when needed (not inlined here)'
+  );
+  sections.push(cdLines.join('\n'));
+  sections.push('');
+
+  sections.push(
+    'You have access to the manage_feeds, manage_connections, manage_operations, query_sql, and connector-source CRUD tools. Investigate the cause; if it is in the connector code, propose or apply a fix per the org\'s policy. If you make any change, run a single test sync after to verify.'
+  );
+
+  return sections.join('\n');
+}
+
+export function buildAppendPacket(input: {
+  consecutiveFailures: number;
+  run: DiagnosticRunRow;
+}): string {
+  return [
+    `Still failing — ${input.consecutiveFailures} consecutive failures, latest run below.`,
+    '',
+    fmtRun(input.run),
+  ].join('\n');
+}

--- a/packages/owletto-backend/src/connectors/repair-agent.ts
+++ b/packages/owletto-backend/src/connectors/repair-agent.ts
@@ -1,0 +1,561 @@
+/**
+ * Connector repair-agent triggers.
+ *
+ * When a feed accumulates persistent failures, the worker-completion path
+ * calls `maybeOpenOrAppendRepairThread` to (a) decide whether to open a
+ * Lobu agent thread for triage, (b) win an atomic UPDATE so racing workers
+ * don't double-open, and (c) post the diagnostic packet to the resulting
+ * thread. On success after a streak, `maybeCloseRepairThread` posts a
+ * one-line "resolved" message and clears the open-thread pointer.
+ *
+ * The trigger logic is deliberately conservative: bounded retries, a
+ * cooldown window, a per-feed first-failure-duration gate, and a per-org
+ * kill switch all prevent runaway behavior.
+ */
+import { createHash, randomUUID } from 'node:crypto';
+import { type DbClient, getDb } from '../db/client';
+import { getLobuCoreServices } from '../lobu/gateway';
+import logger from '../utils/logger';
+import {
+  type DiagnosticRunRow,
+  buildAppendPacket,
+  buildOpenPacket,
+} from './repair-agent-packet';
+
+const DEFAULT_THRESHOLD = 3;
+const DEFAULT_MIN_FAILING_MS = 30 * 60 * 1000; // 30 min
+const DEFAULT_MAX_ATTEMPTS = 5;
+const DEFAULT_COOLDOWN_MS = 6 * 60 * 60 * 1000; // 6 hours
+
+function envInt(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (!raw) return fallback;
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+export interface RepairAgentConfig {
+  threshold: number;
+  minFailingDurationMs: number;
+  maxAttempts: number;
+  cooldownMs: number;
+}
+
+export function loadRepairConfigFromEnv(): RepairAgentConfig {
+  return {
+    threshold: envInt('CONNECTOR_REPAIR_THRESHOLD', DEFAULT_THRESHOLD),
+    minFailingDurationMs: envInt('CONNECTOR_REPAIR_MIN_FAILING_MS', DEFAULT_MIN_FAILING_MS),
+    maxAttempts: envInt('CONNECTOR_REPAIR_MAX_ATTEMPTS', DEFAULT_MAX_ATTEMPTS),
+    cooldownMs: envInt('CONNECTOR_REPAIR_COOLDOWN_MS', DEFAULT_COOLDOWN_MS),
+  };
+}
+
+interface FeedState {
+  id: number;
+  organization_id: string;
+  consecutive_failures: number;
+  first_failure_at: Date | null;
+  repair_thread_id: string | null;
+  repair_attempt_count: number;
+  last_repair_at: Date | null;
+  repair_agent_id: string | null;
+  connector_key: string | null;
+  display_name: string | null;
+  config: Record<string, unknown> | null;
+  schedule: string | null;
+  default_repair_agent_id: string | null;
+  org_repair_enabled: boolean;
+  connection_id: number | null;
+  connection_display_name: string | null;
+  auth_profile_status: string | null;
+  connector_name: string | null;
+  connector_version: string | null;
+}
+
+async function loadFeedState(
+  sql: DbClient,
+  feedId: number
+): Promise<FeedState | null> {
+  // Pick the most-specific connector definition for the feed:
+  //   1. org-scoped + active row (idx_connector_defs_org_key)
+  //   2. system-level + active row (idx_connector_defs_system_key)
+  // The DISTINCT ON + ORDER BY ensures exactly one cd row per feed and gives
+  // org-specific definitions priority.
+  const rows = (await sql`
+    SELECT * FROM (
+      SELECT DISTINCT ON (f.id)
+        f.id,
+        f.organization_id,
+        f.consecutive_failures,
+        f.first_failure_at,
+        f.repair_thread_id,
+        f.repair_attempt_count,
+        f.last_repair_at,
+        f.repair_agent_id,
+        f.display_name,
+        f.config,
+        f.schedule,
+        c.id AS connection_id,
+        c.connector_key,
+        c.display_name AS connection_display_name,
+        ap.status AS auth_profile_status,
+        cd.name AS connector_name,
+        cd.version AS connector_version,
+        cd.default_repair_agent_id,
+        org.repair_agents_enabled AS org_repair_enabled
+      FROM feeds f
+      LEFT JOIN connections c ON c.id = f.connection_id
+      LEFT JOIN auth_profiles ap ON ap.id = c.auth_profile_id
+      LEFT JOIN connector_definitions cd ON cd.key = c.connector_key
+        AND cd.status = 'active'
+        AND (cd.organization_id = f.organization_id OR cd.organization_id IS NULL)
+      LEFT JOIN organization org ON org.id = f.organization_id
+      WHERE f.id = ${feedId}
+      ORDER BY f.id,
+               (cd.organization_id IS NULL) ASC -- org-specific first
+    ) sub
+    LIMIT 1
+  `) as unknown as Array<FeedState>;
+  return rows[0] ?? null;
+}
+
+async function loadRecentRuns(
+  sql: DbClient,
+  feedId: number,
+  limit = 10
+): Promise<DiagnosticRunRow[]> {
+  const rows = (await sql`
+    SELECT id, status, started_at, completed_at, error_message,
+           exit_reason, exit_code, exit_signal, output_tail
+    FROM runs
+    WHERE feed_id = ${feedId}
+    ORDER BY id DESC
+    LIMIT ${limit}
+  `) as unknown as Array<{
+    id: number;
+    status: string;
+    started_at: Date | null;
+    completed_at: Date | null;
+    error_message: string | null;
+    exit_reason: string | null;
+    exit_code: number | null;
+    exit_signal: string | null;
+    output_tail: string | null;
+  }>;
+  return rows.map((r) => ({
+    id: Number(r.id),
+    status: r.status,
+    startedAt: r.started_at ? new Date(r.started_at).toISOString() : null,
+    completedAt: r.completed_at ? new Date(r.completed_at).toISOString() : null,
+    durationMs:
+      r.started_at && r.completed_at
+        ? new Date(r.completed_at).getTime() - new Date(r.started_at).getTime()
+        : null,
+    errorMessage: r.error_message,
+    exitReason: r.exit_reason,
+    exitCode: r.exit_code,
+    exitSignal: r.exit_signal,
+    outputTail: r.output_tail,
+  }));
+}
+
+function resolveRepairAgentId(state: FeedState): string | null {
+  if (state.repair_agent_id) return state.repair_agent_id;
+  if (state.default_repair_agent_id) return state.default_repair_agent_id;
+  return null;
+}
+
+/**
+ * Hash the run's failure signature so repeated identical failures don't spam
+ * the thread. Combines `error_message`, `exit_reason`, and a hash of
+ * `output_tail` (which itself is already redacted by the worker).
+ */
+export function hashFailureSignature(run: DiagnosticRunRow): string {
+  const tailHash = run.outputTail
+    ? createHash('sha256').update(run.outputTail).digest('hex')
+    : '';
+  return createHash('sha256')
+    .update([run.errorMessage ?? '', run.exitReason ?? '', tailHash].join('\x1f'))
+    .digest('hex');
+}
+
+interface CallableServices {
+  sessionManager: any;
+  queueProducer: any;
+  createThreadForAgent: (deps: any, args: any) => Promise<{ threadId: string }>;
+  enqueueAgentMessage: (deps: any, args: any) => Promise<unknown>;
+}
+
+async function loadCallableServices(): Promise<CallableServices | null> {
+  const core = getLobuCoreServices();
+  if (!core) return null;
+  try {
+    const mod = await import('@lobu/gateway');
+    return {
+      sessionManager: core.getSessionManager(),
+      queueProducer: core.getQueueProducer(),
+      createThreadForAgent: mod.createThreadForAgent,
+      enqueueAgentMessage: mod.enqueueAgentMessage,
+    };
+  } catch (error) {
+    logger.warn(
+      { error: String(error) },
+      '[repair-agent] embedded gateway not available — skipping repair trigger'
+    );
+    return null;
+  }
+}
+
+export interface RepairTriggerDeps {
+  /** Override the gateway services (used in tests). */
+  services?: CallableServices;
+  /** Override the env-loaded config (used in tests). */
+  config?: RepairAgentConfig;
+  /** Override the wall clock (used in tests). */
+  now?: () => number;
+  /** Override the DB client (used in tests). */
+  sql?: DbClient;
+  /** Override thread id minting (used in tests for deterministic ids). */
+  mintThreadId?: () => string;
+}
+
+/**
+ * Decide and execute the repair-thread side effects for a feed that just
+ * had its `consecutive_failures` incremented.
+ *
+ * Called from `worker-api.ts:completeWorkerJob` after the feed UPDATE.
+ *
+ * - If no thread is open and the gating conditions hold, opens a new thread
+ *   via an atomic UPDATE on `feeds(repair_thread_id IS NULL)` to win against
+ *   racing workers, then enqueues the diagnostic packet.
+ * - If a thread is already open, optionally appends the new failure
+ *   subject to a content-hash + every-Nth-failure throttle.
+ * - On the cap, pauses the feed and stops.
+ *
+ * All errors are logged and swallowed — the repair trigger must never
+ * block the worker-completion path.
+ */
+export async function maybeOpenOrAppendRepairThread(
+  feedId: number,
+  runId: number,
+  deps: RepairTriggerDeps = {}
+): Promise<void> {
+  const cfg = deps.config ?? loadRepairConfigFromEnv();
+  const now = deps.now ?? (() => Date.now());
+  const sql = deps.sql ?? getDb();
+
+  let state: FeedState | null;
+  try {
+    state = await loadFeedState(sql, feedId);
+  } catch (error) {
+    logger.error({ feed_id: feedId, error: String(error) }, '[repair-agent] failed to load feed state');
+    return;
+  }
+  if (!state) return;
+
+  // Defensive: this function is only meant to fire after the worker-api
+  // failure path has incremented consecutive_failures, but a future caller
+  // path could violate that. Bail at <= 0 so the bucket=0 claim slot
+  // doesn't get consumed before the first real failure.
+  if (state.consecutive_failures <= 0) return;
+
+  if (!state.org_repair_enabled) {
+    logger.debug(
+      { feed_id: feedId, org: state.organization_id },
+      '[repair-agent] org has repair agents disabled — skipping'
+    );
+    return;
+  }
+
+  const recentRuns = await loadRecentRuns(sql, feedId, 10);
+  // The completed run we were called for is the canonical signature source —
+  // not whichever run happens to be at the top of recentRuns. Out-of-order
+  // worker completions (later run finishes before an earlier one) would
+  // otherwise attach the wrong run's diagnostics. If the runId we were
+  // called for isn't yet visible in the recent runs (DB read raced the
+  // INSERT), skip silently — the next failure cron will pick it up.
+  const completedRun = recentRuns.find((r) => r.id === runId) ?? null;
+
+  // Branch 1: Thread already open — consider appending.
+  if (state.repair_thread_id) {
+    if (!completedRun) {
+      logger.debug(
+        { feed_id: feedId, run_id: runId },
+        '[repair-agent] completed run not yet visible in recent_runs — skipping append'
+      );
+      return;
+    }
+    // Encode (signature, ceil-floor-of-5 bucket) into the claim key so the
+    // dedupe is purely IS-DISTINCT-FROM and doesn't need an OR-clause that
+    // would let concurrent workers both win on multiples of 5. Same hash
+    // within the same 5-failure bucket → same key → only one UPDATE wins;
+    // signature changes OR crossing a 5-boundary → key changes → next post
+    // fires once.
+    //   consec 1..4  → `${hash}@0`   (initial post)
+    //   consec 5..9  → `${hash}@5`   (every-5th override fires once at 5)
+    //   consec 10..14→ `${hash}@10`  (every-5th override fires once at 10)
+    const baseHash = hashFailureSignature(completedRun);
+    const bucket = Math.floor(state.consecutive_failures / 5) * 5;
+    const claimKey = `${baseHash}@${bucket}`;
+
+    // Atomic dedupe: claim the new key in one UPDATE that's a no-op when
+    // another concurrent worker just wrote the same key. Prevents two
+    // workers from observing the same `last_repair_post_hash` and both
+    // posting duplicate appends.
+    const claimRows = (await sql`
+      UPDATE feeds
+      SET last_repair_post_hash = ${claimKey}
+      WHERE id = ${feedId}
+        AND last_repair_post_hash IS DISTINCT FROM ${claimKey}
+      RETURNING last_repair_post_hash
+    `) as unknown as Array<{ last_repair_post_hash: string | null }>;
+    if (claimRows.length === 0) {
+      logger.debug(
+        { feed_id: feedId, claim_key: claimKey },
+        '[repair-agent] suppressing append — same claim key already recorded'
+      );
+      return;
+    }
+
+    const services = deps.services ?? (await loadCallableServices());
+    if (!services) return;
+
+    try {
+      const packet = buildAppendPacket({
+        consecutiveFailures: state.consecutive_failures,
+        run: completedRun,
+      });
+      await services.enqueueAgentMessage(
+        { sessionManager: services.sessionManager, queueProducer: services.queueProducer },
+        { threadId: state.repair_thread_id, messageText: packet, source: 'connector-repair' }
+      );
+      logger.info(
+        { feed_id: feedId, thread_id: state.repair_thread_id, run_id: runId },
+        '[repair-agent] appended failure to existing repair thread'
+      );
+    } catch (error) {
+      logger.error(
+        { feed_id: feedId, error: String(error) },
+        '[repair-agent] failed to append to existing thread'
+      );
+    }
+    return;
+  }
+
+  // Branch 2: No thread — check gating conditions.
+  if (state.consecutive_failures < cfg.threshold) return;
+  if (
+    !state.first_failure_at ||
+    now() - new Date(state.first_failure_at).getTime() < cfg.minFailingDurationMs
+  ) {
+    return;
+  }
+  if (
+    state.last_repair_at &&
+    now() - new Date(state.last_repair_at).getTime() < cfg.cooldownMs
+  ) {
+    return;
+  }
+
+  if (state.repair_attempt_count >= cfg.maxAttempts) {
+    // Lifetime budget exhausted — pause the feed and stop.
+    try {
+      await sql`
+        UPDATE feeds
+        SET status = 'paused', next_run_at = NULL, updated_at = current_timestamp
+        WHERE id = ${feedId} AND status <> 'paused'
+      `;
+      logger.warn(
+        { feed_id: feedId, attempt_count: state.repair_attempt_count },
+        '[repair-agent] repair budget exhausted — paused feed'
+      );
+    } catch (error) {
+      logger.error(
+        { feed_id: feedId, error: String(error) },
+        '[repair-agent] failed to pause feed at budget cap'
+      );
+    }
+    return;
+  }
+
+  const repairAgentId = resolveRepairAgentId(state);
+  if (!repairAgentId) {
+    logger.debug({ feed_id: feedId }, '[repair-agent] no repair agent resolves — skipping');
+    return;
+  }
+
+  const services = deps.services ?? (await loadCallableServices());
+  if (!services) return;
+
+  // Mint the thread id BEFORE the atomic UPDATE so we can race-guard on
+  // `feeds.repair_thread_id IS NULL`. Only after winning do we materialize
+  // the session and enqueue. Losing workers exit silently — no orphan
+  // session is created.
+  const userId = repairAgentId;
+  const mint = deps.mintThreadId ?? (() => randomUUID());
+  const externalThreadId = mint();
+  const conversationId = `${repairAgentId}_${userId}_${externalThreadId}`;
+
+  // All gates re-checked atomically inside the UPDATE, not just the
+  // already-read JS values. Stale readers (e.g. another worker that loaded
+  // state before a manual pause / budget reset) cannot win the claim if any
+  // gate has flipped between the read and the UPDATE.
+  const minFailingDurationSeconds = Math.floor(cfg.minFailingDurationMs / 1000);
+  const cooldownSeconds = Math.floor(cfg.cooldownMs / 1000);
+  let won = false;
+  try {
+    const claim = (await sql`
+      UPDATE feeds
+      SET repair_thread_id = ${conversationId},
+          repair_attempt_count = repair_attempt_count + 1,
+          last_repair_at = current_timestamp,
+          updated_at = current_timestamp
+      WHERE id = ${feedId}
+        AND repair_thread_id IS NULL
+        AND status <> 'paused'
+        AND consecutive_failures >= ${cfg.threshold}
+        AND first_failure_at IS NOT NULL
+        AND first_failure_at <= current_timestamp - make_interval(secs => ${minFailingDurationSeconds})
+        AND (last_repair_at IS NULL
+             OR last_repair_at <= current_timestamp - make_interval(secs => ${cooldownSeconds}))
+        AND repair_attempt_count < ${cfg.maxAttempts}
+        AND organization_id IN (
+          SELECT id FROM organization WHERE id = ${state.organization_id} AND repair_agents_enabled = TRUE
+        )
+      RETURNING repair_thread_id
+    `) as unknown as Array<{ repair_thread_id: string | null }>;
+    won = claim.length > 0;
+  } catch (error) {
+    logger.error(
+      { feed_id: feedId, error: String(error) },
+      '[repair-agent] atomic UPDATE failed'
+    );
+    return;
+  }
+
+  if (!won) {
+    logger.debug({ feed_id: feedId }, '[repair-agent] another worker won the open — skipping');
+    return;
+  }
+
+  try {
+    await services.createThreadForAgent(
+      { sessionManager: services.sessionManager },
+      {
+        agentId: repairAgentId,
+        organizationId: state.organization_id,
+        userId,
+        externalThreadId,
+        reason: 'connector-repair',
+      }
+    );
+    const packet = buildOpenPacket({
+      feedId: state.id,
+      feedDisplayName: state.display_name,
+      connectorKey: state.connector_key,
+      connectorName: state.connector_name,
+      connectorVersion: state.connector_version,
+      feedConfig: state.config,
+      feedSchedule: state.schedule,
+      consecutiveFailures: state.consecutive_failures,
+      firstFailureAt: state.first_failure_at
+        ? new Date(state.first_failure_at).toISOString()
+        : null,
+      connectionId: state.connection_id,
+      connectionDisplayName: state.connection_display_name,
+      authProfileStatus: state.auth_profile_status,
+      recentRuns,
+    });
+    await services.enqueueAgentMessage(
+      { sessionManager: services.sessionManager, queueProducer: services.queueProducer },
+      { threadId: conversationId, messageText: packet, source: 'connector-repair' }
+    );
+    logger.info(
+      {
+        feed_id: feedId,
+        thread_id: conversationId,
+        run_id: runId,
+        repair_agent_id: repairAgentId,
+      },
+      '[repair-agent] opened repair thread'
+    );
+  } catch (error) {
+    logger.error(
+      { feed_id: feedId, thread_id: conversationId, error: String(error) },
+      '[repair-agent] thread create/enqueue failed after winning UPDATE — thread row left in feeds.repair_thread_id; will be retried on next failure if cleared'
+    );
+  }
+}
+
+/**
+ * Called from `completeWorkerJob` on a successful run that resets
+ * `consecutive_failures` to zero. Posts a one-line "resolved" message to
+ * the open repair thread (if any) and clears the open-thread pointer.
+ *
+ * Note: `repair_attempt_count` is intentionally NOT reset — that field is
+ * the lifetime budget. Operators can reset it manually if they want.
+ */
+export async function maybeCloseRepairThread(
+  feedId: number,
+  runId: number,
+  deps: RepairTriggerDeps = {}
+): Promise<void> {
+  const sql = deps.sql ?? getDb();
+
+  // Atomic claim: only the caller whose UPDATE actually clears the row sees
+  // the previously-open thread id. The `consecutive_failures = 0` guard
+  // ensures a stale success completion arriving AFTER a new failure has
+  // restarted the streak does not erase the new failure state.
+  let claimedThreadId: string | null = null;
+  try {
+    const rows = (await sql`
+      WITH old AS (
+        SELECT id, repair_thread_id
+        FROM feeds
+        WHERE id = ${feedId}
+          AND consecutive_failures = 0
+        FOR UPDATE
+      )
+      UPDATE feeds f
+      SET first_failure_at = NULL,
+          last_repair_post_hash = NULL,
+          repair_thread_id = NULL,
+          updated_at = current_timestamp
+      FROM old
+      WHERE f.id = old.id
+      RETURNING old.repair_thread_id
+    `) as unknown as Array<{ repair_thread_id: string | null }>;
+    claimedThreadId = rows[0]?.repair_thread_id ?? null;
+  } catch (error) {
+    logger.error(
+      { feed_id: feedId, error: String(error) },
+      '[repair-agent] failed to atomically clear streak state on success'
+    );
+    return;
+  }
+
+  if (!claimedThreadId) return;
+
+  const services = deps.services ?? (await loadCallableServices());
+  if (!services) return;
+
+  try {
+    await services.enqueueAgentMessage(
+      { sessionManager: services.sessionManager, queueProducer: services.queueProducer },
+      {
+        threadId: claimedThreadId,
+        messageText: `Resolved: feed has resumed successfully (run id ${runId})`,
+        source: 'connector-repair',
+      }
+    );
+    logger.info(
+      { feed_id: feedId, thread_id: claimedThreadId, run_id: runId },
+      '[repair-agent] posted resolved message and cleared open thread'
+    );
+  } catch (error) {
+    logger.error(
+      { feed_id: feedId, thread_id: claimedThreadId, error: String(error) },
+      '[repair-agent] failed to post resolved message'
+    );
+  }
+}

--- a/packages/owletto-backend/src/tools/admin/connector-definition-helpers.ts
+++ b/packages/owletto-backend/src/tools/admin/connector-definition-helpers.ts
@@ -36,6 +36,7 @@ export type ScopedConnectorDefinitionRow = {
   favicon_domain?: string | null;
   source_path?: string | null;
   default_connection_config?: Record<string, unknown> | null;
+  default_repair_agent_id?: string | null;
   status: string;
   login_enabled?: boolean | null;
   created_at?: string;
@@ -85,6 +86,7 @@ export async function listScopedConnectorDefinitions(params: {
       d.openapi_config,
       d.favicon_domain,
       d.default_connection_config,
+      d.default_repair_agent_id,
       d.status,
       d.login_enabled,
       d.created_at,

--- a/packages/owletto-backend/src/tools/admin/index.ts
+++ b/packages/owletto-backend/src/tools/admin/index.ts
@@ -13,6 +13,7 @@ import { ManageEntitySchema, manageEntity } from './manage_entity';
 import { ManageEntitySchemaSchema, manageEntitySchema } from './manage_entity_schema';
 import { ManageFeedsSchema, manageFeeds } from './manage_feeds';
 import { ManageOperationsSchema, manageOperations } from './manage_operations';
+import { ManageOrganizationSchema, manageOrganization } from './manage_organization';
 import { ManageViewTemplatesSchema, manageViewTemplates } from './manage_view_templates';
 import { ManageWatchersSchema, manageWatchers } from './manage_watchers';
 
@@ -120,6 +121,17 @@ export const LEGACY_ADMIN_TOOLS: ToolDefinition[] = [
     internal: true,
     handler: async (args: Static<typeof ManageViewTemplatesSchema>, env: Env, ctx: ToolContext) => {
       return await manageViewTemplates(args, env, ctx);
+    },
+  },
+  {
+    name: 'manage_organization',
+    description:
+      'Org-scoped settings (e.g. connector repair-agent kill switch). Frontend-only tool today; external MCP clients should not depend on this surface.',
+    inputSchema: ManageOrganizationSchema,
+    annotations: { destructiveHint: false },
+    internal: true,
+    handler: async (args: Static<typeof ManageOrganizationSchema>, _env: Env, ctx: ToolContext) => {
+      return await manageOrganization(args, ctx);
     },
   },
 ];

--- a/packages/owletto-backend/src/tools/admin/manage_connections.ts
+++ b/packages/owletto-backend/src/tools/admin/manage_connections.ts
@@ -256,6 +256,15 @@ const SetConnectorEntityLinkOverridesAction = Type.Object({
   overrides: EntityLinkOverridesSchema,
 });
 
+const UpdateConnectorDefaultRepairAgentAction = Type.Object({
+  action: Type.Literal('update_connector_default_repair_agent'),
+  connector_key: Type.String({ description: 'Connector key' }),
+  default_repair_agent_id: Type.Union([Type.String(), Type.Null()], {
+    description:
+      'Default repair agent ID for feeds of this connector. Null clears the default.',
+  }),
+});
+
 export const ManageConnectionsSchema = Type.Union([
   ListAction,
   ListConnectorDefinitionsAction,
@@ -271,6 +280,7 @@ export const ManageConnectionsSchema = Type.Union([
   ToggleConnectorLoginAction,
   UpdateConnectorAuthAction,
   UpdateConnectorDefaultConfigAction,
+  UpdateConnectorDefaultRepairAgentAction,
   SetConnectorEntityLinkOverridesAction,
 ]);
 
@@ -354,6 +364,12 @@ type ManageConnectionsResult =
       connector_key: string;
     }
   | {
+      action: 'update_connector_default_repair_agent';
+      success: true;
+      connector_key: string;
+      default_repair_agent_id: string | null;
+    }
+  | {
       action: 'set_connector_entity_link_overrides';
       success: true;
       connector_key: string;
@@ -410,6 +426,14 @@ export async function manageConnections(
     update_connector_default_config: () =>
       handleUpdateConnectorDefaultConfig(
         args as Extract<ConnectionsArgs, { action: 'update_connector_default_config' }>,
+        ctx
+      ),
+    update_connector_default_repair_agent: () =>
+      handleUpdateConnectorDefaultRepairAgent(
+        args as Extract<
+          ConnectionsArgs,
+          { action: 'update_connector_default_repair_agent' }
+        >,
         ctx
       ),
     set_connector_entity_link_overrides: () =>
@@ -1778,6 +1802,35 @@ async function handleUpdateConnectorDefaultConfig(
     action: 'update_connector_default_config',
     success: true,
     connector_key: args.connector_key,
+  };
+}
+
+async function handleUpdateConnectorDefaultRepairAgent(
+  args: Extract<ConnectionsArgs, { action: 'update_connector_default_repair_agent' }>,
+  ctx: ToolContext
+): Promise<ManageConnectionsResult> {
+  const sql = getDb();
+  const { organizationId } = ctx;
+
+  const updated = await sql`
+    UPDATE connector_definitions
+    SET default_repair_agent_id = ${args.default_repair_agent_id}::text,
+        updated_at = NOW()
+    WHERE key = ${args.connector_key}
+      AND organization_id = ${organizationId}
+      AND status = 'active'
+    RETURNING key
+  `;
+
+  if (updated.length === 0) {
+    return { error: `Connector '${args.connector_key}' not found` };
+  }
+
+  return {
+    action: 'update_connector_default_repair_agent',
+    success: true,
+    connector_key: args.connector_key,
+    default_repair_agent_id: args.default_repair_agent_id,
   };
 }
 

--- a/packages/owletto-backend/src/tools/admin/manage_feeds.ts
+++ b/packages/owletto-backend/src/tools/admin/manage_feeds.ts
@@ -69,6 +69,12 @@ const UpdateFeedAction = Type.Object({
   entity_ids: Type.Optional(Type.Array(Type.Number())),
   config: Type.Optional(Type.Record(Type.String(), Type.Any())),
   schedule: Type.Optional(Type.String({ description: 'Cron expression for sync schedule' })),
+  repair_agent_id: Type.Optional(
+    Type.Union([Type.String(), Type.Null()], {
+      description:
+        'Per-feed repair agent override. Null clears the override and falls back to the connector default.',
+    })
+  ),
 });
 
 const DeleteFeedAction = Type.Object({
@@ -335,6 +341,11 @@ async function handleUpdateFeed(
     }
   }
 
+  // `repair_agent_id` is tri-state: undefined = leave alone, null = clear, string = set.
+  // Use Object.hasOwn so an explicit null overwrites instead of being skipped.
+  const hasRepairAgentArg = Object.hasOwn(args, 'repair_agent_id');
+  const repairAgentValue = hasRepairAgentArg ? (args.repair_agent_id ?? null) : null;
+
   const updated = await sql`
     UPDATE feeds
     SET display_name = COALESCE(${args.display_name ?? null}::text, display_name),
@@ -343,6 +354,7 @@ async function handleUpdateFeed(
         config = CASE WHEN ${args.config ? sql.json(args.config) : null}::jsonb IS NOT NULL THEN COALESCE(config, '{}'::jsonb) || ${args.config ? sql.json(args.config) : null}::jsonb ELSE config END,
         schedule = COALESCE(${args.schedule ?? null}::text, schedule),
         next_run_at = CASE WHEN ${args.schedule ?? null}::text IS NOT NULL THEN ${args.schedule ? nextRunAt(args.schedule) : null}::timestamptz ELSE next_run_at END,
+        repair_agent_id = CASE WHEN ${hasRepairAgentArg} THEN ${repairAgentValue}::text ELSE repair_agent_id END,
         updated_at = NOW()
     WHERE id = ${args.feed_id} AND organization_id = ${organizationId}
     RETURNING *

--- a/packages/owletto-backend/src/tools/admin/manage_organization.ts
+++ b/packages/owletto-backend/src/tools/admin/manage_organization.ts
@@ -1,0 +1,128 @@
+/**
+ * Tool: manage_organization
+ *
+ * Org-scoped settings (toggles + small flags). Today this surfaces the
+ * connector repair-agent kill switch; new org-level toggles should land
+ * here rather than scattered into bespoke routes.
+ *
+ * Actions:
+ * - get_settings: Read the org settings record.
+ * - update_settings: Patch the editable fields (caller-provided fields only).
+ */
+
+import { type Static, Type } from '@sinclair/typebox';
+import { getDb } from '../../db/client';
+import type { ToolContext } from '../registry';
+import { routeAction } from './action-router';
+
+// ============================================
+// Schema
+// ============================================
+
+const GetSettingsAction = Type.Object({
+  action: Type.Literal('get_settings'),
+});
+
+const UpdateSettingsAction = Type.Object({
+  action: Type.Literal('update_settings'),
+  repair_agents_enabled: Type.Optional(
+    Type.Boolean({
+      description:
+        'Per-org kill switch for connector repair agents. When false, no repair threads are opened for any feed in the org regardless of per-feed configuration.',
+    })
+  ),
+});
+
+export const ManageOrganizationSchema = Type.Union([GetSettingsAction, UpdateSettingsAction]);
+
+// ============================================
+// Result Types
+// ============================================
+
+export interface OrganizationSettings {
+  organization_id: string;
+  repair_agents_enabled: boolean;
+}
+
+type ManageOrganizationResult =
+  | { error: string }
+  | { action: 'get_settings'; settings: OrganizationSettings }
+  | { action: 'update_settings'; settings: OrganizationSettings };
+
+type OrganizationArgs = Static<typeof ManageOrganizationSchema>;
+
+// ============================================
+// Main Function (Action Router)
+// ============================================
+
+export async function manageOrganization(
+  args: OrganizationArgs,
+  ctx: ToolContext
+): Promise<ManageOrganizationResult> {
+  return routeAction<ManageOrganizationResult>('manage_organization', args.action, ctx, {
+    get_settings: () => handleGetSettings(ctx),
+    update_settings: () =>
+      handleUpdateSettings(args as Extract<OrganizationArgs, { action: 'update_settings' }>, ctx),
+  });
+}
+
+// ============================================
+// Action Handlers
+// ============================================
+
+async function handleGetSettings(ctx: ToolContext): Promise<ManageOrganizationResult> {
+  const sql = getDb();
+  const { organizationId } = ctx;
+
+  const rows = (await sql`
+    SELECT id, repair_agents_enabled
+    FROM "organization"
+    WHERE id = ${organizationId}
+    LIMIT 1
+  `) as unknown as Array<{ id: string; repair_agents_enabled: boolean }>;
+
+  if (rows.length === 0) {
+    return { error: 'Organization not found' };
+  }
+
+  return {
+    action: 'get_settings',
+    settings: {
+      organization_id: rows[0].id,
+      repair_agents_enabled: Boolean(rows[0].repair_agents_enabled),
+    },
+  };
+}
+
+async function handleUpdateSettings(
+  args: Extract<OrganizationArgs, { action: 'update_settings' }>,
+  ctx: ToolContext
+): Promise<ManageOrganizationResult> {
+  const sql = getDb();
+  const { organizationId } = ctx;
+
+  // Only patch fields the caller provided.
+  const hasRepairToggle = Object.hasOwn(args, 'repair_agents_enabled');
+  if (!hasRepairToggle) {
+    return handleGetSettings(ctx);
+  }
+
+  const updated = (await sql`
+    UPDATE "organization"
+    SET repair_agents_enabled = COALESCE(${args.repair_agents_enabled ?? null}::boolean, repair_agents_enabled)
+    WHERE id = ${organizationId}
+    RETURNING id, repair_agents_enabled
+  `) as unknown as Array<{ id: string; repair_agents_enabled: boolean }>;
+
+  if (updated.length === 0) {
+    return { error: 'Organization not found' };
+  }
+
+  return {
+    action: 'update_settings',
+    settings: {
+      organization_id: updated[0].id,
+      repair_agents_enabled: Boolean(updated[0].repair_agents_enabled),
+    },
+  };
+}

--- a/packages/owletto-backend/src/worker-api.ts
+++ b/packages/owletto-backend/src/worker-api.ts
@@ -847,19 +847,40 @@ export async function completeAuthRun(c: Context<{ Bindings: Env }>) {
       credentials?: Record<string, unknown>;
       metadata?: Record<string, unknown>;
       error_message?: string;
+      // Diagnostic fields from the subprocess executor (failed-run path only).
+      // The worker redacts output_tail before sending; backend stores as-is.
+      output_tail?: string;
+      exit_code?: number | null;
+      exit_signal?: string | null;
+      exit_reason?: 'ok' | 'error_message' | 'timeout' | 'oom' | 'crash';
     }>();
 
     const sql = getDb();
 
-    const runRows = (await sql`
+    const runRows =
+      req.status === 'failed'
+        ? ((await sql`
       UPDATE runs
-      SET status = ${req.status === 'success' ? 'completed' : 'failed'},
+      SET status = 'failed',
+          completed_at = current_timestamp,
+          error_message = ${req.error_message ?? null},
+          auth_signal = NULL,
+          output_tail = ${req.output_tail ?? null},
+          exit_code = ${req.exit_code ?? null},
+          exit_signal = ${req.exit_signal ?? null},
+          exit_reason = ${req.exit_reason ?? null}
+      WHERE id = ${req.run_id}
+      RETURNING auth_profile_id, organization_id
+    `) as Array<{ auth_profile_id: number | null; organization_id: string }>)
+        : ((await sql`
+      UPDATE runs
+      SET status = 'completed',
           completed_at = current_timestamp,
           error_message = ${req.error_message ?? null},
           auth_signal = NULL
       WHERE id = ${req.run_id}
       RETURNING auth_profile_id, organization_id
-    `) as Array<{ auth_profile_id: number | null; organization_id: string }>;
+    `) as Array<{ auth_profile_id: number | null; organization_id: string }>);
 
     const authProfileId = runRows[0]?.auth_profile_id ?? null;
     const organizationId = runRows[0]?.organization_id;

--- a/packages/owletto-backend/src/worker-api.ts
+++ b/packages/owletto-backend/src/worker-api.ts
@@ -14,6 +14,10 @@ import { notifyBrowserAuthExpired } from './notifications/triggers';
 import { materializeDueFeeds } from './scheduled/check-due-feeds';
 import { supersedeActionEvent } from './tools/admin/manage_operations';
 import { getAuthProfileById, getBrowserSessionReadiness } from './utils/auth-profiles';
+import {
+  maybeCloseRepairThread,
+  maybeOpenOrAppendRepairThread,
+} from './connectors/repair-agent';
 import { autoLinkEvent } from './utils/auto-linker';
 import { nextRunAt as nextRunAtFromCron } from './utils/cron';
 import { resolveConnectorCode } from './utils/ensure-connector-installed';
@@ -504,12 +508,32 @@ export async function completeWorkerJob(c: Context<{ Bindings: Env }>) {
             last_sync_status = ${req.status},
             last_error = ${isSuccess ? null : (req.error_message ?? null)},
             consecutive_failures = ${isSuccess ? sql`0` : sql`consecutive_failures + 1`},
+            first_failure_at = ${isSuccess ? sql`NULL` : sql`COALESCE(first_failure_at, current_timestamp)`},
             items_collected = ${isSuccess ? sql`items_collected + ${req.items_collected ?? 0}` : sql`items_collected`},
             checkpoint = ${isSuccess ? sql`COALESCE(${req.checkpoint ? sql.json(req.checkpoint) : null}, checkpoint)` : sql`checkpoint`},
             next_run_at = ${nextRun},
             updated_at = current_timestamp
         WHERE id = ${feedId}
       `;
+
+      // Repair-agent trigger: open / append / close threads based on the
+      // updated streak state. All errors swallowed inside the helper — must
+      // never block the worker-completion path.
+      if (isSuccess) {
+        await maybeCloseRepairThread(feedId, req.run_id).catch((err) => {
+          logger.warn(
+            { feed_id: feedId, error: errorMessage(err) },
+            '[completeWorkerJob] maybeCloseRepairThread threw'
+          );
+        });
+      } else {
+        await maybeOpenOrAppendRepairThread(feedId, req.run_id).catch((err) => {
+          logger.warn(
+            { feed_id: feedId, error: errorMessage(err) },
+            '[completeWorkerJob] maybeOpenOrAppendRepairThread threw'
+          );
+        });
+      }
     }
 
     // Persist refreshed browser auth data on the auth profile

--- a/packages/owletto-backend/src/worker-api.ts
+++ b/packages/owletto-backend/src/worker-api.ts
@@ -447,19 +447,41 @@ export async function completeWorkerJob(c: Context<{ Bindings: Env }>) {
       error_message?: string;
       checkpoint?: Record<string, unknown>;
       auth_update?: Record<string, unknown>;
+      // Diagnostic fields from the subprocess executor (failed-run path only).
+      // The worker redacts output_tail before sending; backend stores as-is.
+      output_tail?: string;
+      exit_code?: number | null;
+      exit_signal?: string | null;
+      exit_reason?: 'ok' | 'error_message' | 'timeout' | 'oom' | 'crash';
     }>();
 
     const sql = getDb();
 
-    await sql`
-    UPDATE runs
-    SET status = ${req.status === 'success' ? 'completed' : 'failed'},
-        completed_at = current_timestamp,
-        items_collected = ${req.items_collected ?? 0},
-        error_message = ${req.error_message ?? null},
-        checkpoint = COALESCE(${req.checkpoint ? sql.json(req.checkpoint) : null}, checkpoint)
-    WHERE id = ${req.run_id}
-  `;
+    if (req.status === 'failed') {
+      await sql`
+      UPDATE runs
+      SET status = 'failed',
+          completed_at = current_timestamp,
+          items_collected = ${req.items_collected ?? 0},
+          error_message = ${req.error_message ?? null},
+          checkpoint = COALESCE(${req.checkpoint ? sql.json(req.checkpoint) : null}, checkpoint),
+          output_tail = ${req.output_tail ?? null},
+          exit_code = ${req.exit_code ?? null},
+          exit_signal = ${req.exit_signal ?? null},
+          exit_reason = ${req.exit_reason ?? null}
+      WHERE id = ${req.run_id}
+    `;
+    } else {
+      await sql`
+      UPDATE runs
+      SET status = 'completed',
+          completed_at = current_timestamp,
+          items_collected = ${req.items_collected ?? 0},
+          error_message = ${req.error_message ?? null},
+          checkpoint = COALESCE(${req.checkpoint ? sql.json(req.checkpoint) : null}, checkpoint)
+      WHERE id = ${req.run_id}
+    `;
+    }
 
     // Update the feed's sync state
     const runRows = (await sql`

--- a/packages/owletto-worker/integration-tests/subprocess.test.ts
+++ b/packages/owletto-worker/integration-tests/subprocess.test.ts
@@ -134,6 +134,27 @@ describe('SubprocessExecutor diagnostic capture', () => {
     expect(err!.outputTail).toContain('[REDACTED]');
   });
 
+  test('redacts secrets embedded in a thrown Error message and stack', async () => {
+    const executor = new SubprocessExecutor({ timeoutMs: 30_000, maxOldSpaceSize: 256 });
+    let err: SubprocessError | null = null;
+    try {
+      await executor.execute(
+        compiled(`
+          throw new Error('upstream failed: api_key=sk_live_abcdefghijklmn123');
+        `),
+        BASE_CONTEXT
+      );
+    } catch (e) {
+      err = e as SubprocessError;
+    }
+    expect(err).toBeInstanceOf(SubprocessError);
+    expect(err!.message).not.toContain('sk_live_abcdefghijklmn123');
+    expect(err!.message).toContain('[REDACTED]');
+    if (err!.stack) {
+      expect(err!.stack).not.toContain('sk_live_abcdefghijklmn123');
+    }
+  });
+
   test('classifies parent-driven SIGKILL as timeout', async () => {
     const executor = new SubprocessExecutor({ timeoutMs: 1_000, maxOldSpaceSize: 256 });
     let err: SubprocessError | null = null;

--- a/packages/owletto-worker/integration-tests/subprocess.test.ts
+++ b/packages/owletto-worker/integration-tests/subprocess.test.ts
@@ -1,0 +1,134 @@
+/**
+ * Integration tests for the subprocess diagnostic substrate.
+ *
+ * These spawn real child processes via SubprocessExecutor and require the
+ * package (and its workspace deps) to be built. Run with:
+ *
+ *   make build-packages
+ *   bun test packages/owletto-worker/integration-tests
+ *
+ * They live outside `src/` so tsc doesn't compile them and so `bun test`
+ * picked up by default test discovery doesn't pull them into unit-test
+ * runs that haven't built the workspace.
+ */
+import { describe, expect, test } from 'bun:test';
+import type { SyncContext } from '../dist/executor/interface.js';
+import { SubprocessError, SubprocessExecutor } from '../dist/executor/subprocess.js';
+
+const BASE_CONTEXT: SyncContext = {
+  options: {} as any,
+  checkpoint: null,
+  env: {},
+  apiType: 'api',
+};
+
+function compiled(body: string): string {
+  return `
+    class ConnectorRuntime {
+      async sync(_ctx, _hooks) {
+        ${body}
+      }
+      async execute() { return { contents: [], checkpoint: null }; }
+    }
+    module.exports = { ConnectorRuntime };
+  `;
+}
+
+describe('SubprocessExecutor diagnostic capture', () => {
+  test('captures stdout tail and classifies as crash on process.exit(1)', async () => {
+    const executor = new SubprocessExecutor({ timeoutMs: 30_000, maxOldSpaceSize: 256 });
+    let err: SubprocessError | null = null;
+    try {
+      await executor.execute(
+        compiled(`
+          console.log('starting connector run');
+          console.log('about to die hard');
+          process.exit(1);
+        `),
+        BASE_CONTEXT
+      );
+    } catch (e) {
+      err = e as SubprocessError;
+    }
+    expect(err).toBeInstanceOf(SubprocessError);
+    expect(err!.exitCode).toBe(1);
+    expect(err!.exitSignal).toBeNull();
+    expect(err!.exitReason).toBe('crash');
+    expect(err!.outputTail).toContain('about to die hard');
+  });
+
+  test('classifies thrown error as error_message via uncaught handler', async () => {
+    const executor = new SubprocessExecutor({ timeoutMs: 30_000, maxOldSpaceSize: 256 });
+    let err: SubprocessError | null = null;
+    try {
+      await executor.execute(
+        compiled(`
+          throw new Error('connector blew up');
+        `),
+        BASE_CONTEXT
+      );
+    } catch (e) {
+      err = e as SubprocessError;
+    }
+    expect(err).toBeInstanceOf(SubprocessError);
+    expect(err!.exitReason).toBe('error_message');
+    expect(err!.message).toContain('connector blew up');
+  });
+
+  test('uncaught handler catches unhandled rejection', async () => {
+    const executor = new SubprocessExecutor({ timeoutMs: 30_000, maxOldSpaceSize: 256 });
+    let err: SubprocessError | null = null;
+    try {
+      await executor.execute(
+        compiled(`
+          Promise.reject(new Error('dangling rejection'));
+          await new Promise(() => {});
+        `),
+        BASE_CONTEXT
+      );
+    } catch (e) {
+      err = e as SubprocessError;
+    }
+    expect(err).toBeInstanceOf(SubprocessError);
+    expect(err!.exitReason).toBe('error_message');
+    expect(err!.message).toContain('dangling rejection');
+  });
+
+  test('output tail is redacted before reaching the parent', async () => {
+    const executor = new SubprocessExecutor({ timeoutMs: 30_000, maxOldSpaceSize: 256 });
+    let err: SubprocessError | null = null;
+    try {
+      await executor.execute(
+        compiled(`
+          console.error('Authorization: Bearer abc123secret456789');
+          console.error('CH_API_KEY=longvaluesecret789');
+          process.exit(1);
+        `),
+        BASE_CONTEXT
+      );
+    } catch (e) {
+      err = e as SubprocessError;
+    }
+    expect(err).toBeInstanceOf(SubprocessError);
+    expect(err!.outputTail).not.toContain('abc123secret456789');
+    expect(err!.outputTail).not.toContain('longvaluesecret789');
+    expect(err!.outputTail).toContain('[REDACTED]');
+  });
+
+  test('classifies parent-driven SIGKILL as timeout', async () => {
+    const executor = new SubprocessExecutor({ timeoutMs: 1_000, maxOldSpaceSize: 256 });
+    let err: SubprocessError | null = null;
+    try {
+      await executor.execute(
+        compiled(`
+          await new Promise(() => {});
+        `),
+        BASE_CONTEXT
+      );
+    } catch (e) {
+      err = e as SubprocessError;
+    }
+    expect(err).toBeInstanceOf(SubprocessError);
+    expect(err!.exitReason).toBe('timeout');
+  });
+});

--- a/packages/owletto-worker/integration-tests/subprocess.test.ts
+++ b/packages/owletto-worker/integration-tests/subprocess.test.ts
@@ -57,7 +57,7 @@ describe('SubprocessExecutor diagnostic capture', () => {
     expect(err!.outputTail).toContain('about to die hard');
   });
 
-  test('classifies thrown error as error_message via uncaught handler', async () => {
+  test('thrown sync() error is caught by the runner try/catch and reported as error_message', async () => {
     const executor = new SubprocessExecutor({ timeoutMs: 30_000, maxOldSpaceSize: 256 });
     let err: SubprocessError | null = null;
     try {
@@ -75,7 +75,26 @@ describe('SubprocessExecutor diagnostic capture', () => {
     expect(err!.message).toContain('connector blew up');
   });
 
-  test('uncaught handler catches unhandled rejection', async () => {
+  test('uncaughtException handler catches asynchronous setTimeout throw', async () => {
+    const executor = new SubprocessExecutor({ timeoutMs: 30_000, maxOldSpaceSize: 256 });
+    let err: SubprocessError | null = null;
+    try {
+      await executor.execute(
+        compiled(`
+          setTimeout(() => { throw new Error('async tick throw'); }, 0);
+          await new Promise(() => {});
+        `),
+        BASE_CONTEXT
+      );
+    } catch (e) {
+      err = e as SubprocessError;
+    }
+    expect(err).toBeInstanceOf(SubprocessError);
+    expect(err!.exitReason).toBe('error_message');
+    expect(err!.message).toContain('async tick throw');
+  });
+
+  test('unhandledRejection handler catches dangling Promise.reject', async () => {
     const executor = new SubprocessExecutor({ timeoutMs: 30_000, maxOldSpaceSize: 256 });
     let err: SubprocessError | null = null;
     try {

--- a/packages/owletto-worker/src/__tests__/redact.test.ts
+++ b/packages/owletto-worker/src/__tests__/redact.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test';
-import { redactOutput } from '../executor/redact.js';
+import { StreamRedactor, redactOutput } from '../executor/redact.js';
 
 describe('redactOutput', () => {
   test('redacts HTTP Authorization header', () => {
@@ -60,5 +60,47 @@ describe('redactOutput', () => {
     // "no apikey set" or "key: id".
     const input = 'api_key: short';
     expect(redactOutput(input)).toBe(input);
+  });
+});
+
+describe('StreamRedactor', () => {
+  function collect(): { emit: (s: string) => void; out: () => string } {
+    let buf = '';
+    return { emit: (s) => (buf += s), out: () => buf };
+  }
+
+  test('redacts secret split across two chunks', () => {
+    const r = new StreamRedactor();
+    const c = collect();
+    r.process('GET /api\nAuthorization: Bear', c.emit);
+    r.process('er abc123secret456\nfoo\n', c.emit);
+    r.flush(c.emit);
+    expect(c.out()).not.toContain('abc123secret456');
+    expect(c.out()).toContain('Authorization: [REDACTED]');
+  });
+
+  test('emits complete lines as soon as a newline arrives', () => {
+    const r = new StreamRedactor();
+    const c = collect();
+    r.process('hello world\n', c.emit);
+    expect(c.out()).toBe('hello world\n');
+  });
+
+  test('flush releases trailing partial line through redactor', () => {
+    const r = new StreamRedactor();
+    const c = collect();
+    r.process('line1\nAuthorization: Bearer secret_long_token', c.emit);
+    expect(c.out()).toBe('line1\n');
+    r.flush(c.emit);
+    expect(c.out()).not.toContain('secret_long_token');
+    expect(c.out()).toContain('Authorization: [REDACTED]');
+  });
+
+  test('emits prefix when buffer would exceed cap with no newline', () => {
+    const r = new StreamRedactor();
+    const c = collect();
+    // 8200 chars, no newline — exceeds 8192 cap.
+    r.process('x'.repeat(8200), c.emit);
+    expect(c.out().length).toBeGreaterThan(0);
   });
 });

--- a/packages/owletto-worker/src/__tests__/redact.test.ts
+++ b/packages/owletto-worker/src/__tests__/redact.test.ts
@@ -103,4 +103,16 @@ describe('StreamRedactor', () => {
     r.process('x'.repeat(8200), c.emit);
     expect(c.out().length).toBeGreaterThan(0);
   });
+
+  test('redacts a secret embedded near the cap-boundary even with no newline', () => {
+    const r = new StreamRedactor();
+    const c = collect();
+    // A long no-newline payload with a secret somewhere inside. Cap is
+    // 8192; the redactor must redact the entire combined buffer before
+    // emitting, otherwise a slice near the cap could split the match.
+    const payload = 'x'.repeat(8000) + 'Authorization: Bearer abc123secret456 ' + 'y'.repeat(500);
+    r.process(payload, c.emit);
+    expect(c.out()).not.toContain('abc123secret456');
+    expect(c.out()).toContain('Authorization: [REDACTED]');
+  });
 });

--- a/packages/owletto-worker/src/__tests__/redact.test.ts
+++ b/packages/owletto-worker/src/__tests__/redact.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, test } from 'bun:test';
+import { redactOutput } from '../executor/redact.js';
+
+describe('redactOutput', () => {
+  test('redacts HTTP Authorization header', () => {
+    const input = 'GET /api\nAuthorization: Bearer abc123def456\nContent-Type: application/json';
+    const out = redactOutput(input);
+    expect(out).not.toContain('abc123def456');
+    expect(out).toContain('[REDACTED]');
+  });
+
+  test('redacts standalone Bearer tokens', () => {
+    const input = 'curl -H "x: Bearer eyJhbGc.payload-here.sig9_=="';
+    const out = redactOutput(input);
+    expect(out).toContain('Bearer [REDACTED]');
+    expect(out).not.toContain('payload-here.sig9_');
+  });
+
+  test('redacts JWTs anywhere they appear', () => {
+    const input =
+      'token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c more';
+    const out = redactOutput(input);
+    expect(out).not.toContain('eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9');
+    expect(out).toContain('[REDACTED]');
+  });
+
+  test('redacts CH_API_KEY env-style assignments', () => {
+    const input = 'env: CH_API_KEY=abcdef-12345 done';
+    const out = redactOutput(input);
+    expect(out).not.toContain('abcdef-12345');
+    expect(out).toContain('CH_API_KEY=[REDACTED]');
+  });
+
+  test('redacts api_key / access_token / secret JSON-style assignments', () => {
+    const variants = [
+      '"api_key": "longsecretvalue1234"',
+      '"apiKey":"longsecretvalue1234"',
+      "access_token = 'longsecretvalue1234'",
+      'access-token: longsecretvalue1234',
+      'secret="longsecretvalue1234"',
+    ];
+    for (const v of variants) {
+      const out = redactOutput(v);
+      expect(out).not.toContain('longsecretvalue1234');
+      expect(out).toContain('[REDACTED]');
+    }
+  });
+
+  test('preserves non-secret content', () => {
+    const input = 'Connector started, fetched 12 events, no errors.';
+    expect(redactOutput(input)).toBe(input);
+  });
+
+  test('handles empty input', () => {
+    expect(redactOutput('')).toBe('');
+  });
+
+  test('does not redact short api_key-like values (avoid false positives on word "key")', () => {
+    // The api_key pattern requires a 12+ char value to avoid eating things like
+    // "no apikey set" or "key: id".
+    const input = 'api_key: short';
+    expect(redactOutput(input)).toBe(input);
+  });
+});

--- a/packages/owletto-worker/src/__tests__/redact.test.ts
+++ b/packages/owletto-worker/src/__tests__/redact.test.ts
@@ -55,6 +55,42 @@ describe('redactOutput', () => {
     expect(redactOutput('')).toBe('');
   });
 
+  test('redacts Cookie / Set-Cookie headers as a whole', () => {
+    expect(redactOutput('Cookie: session=abc.def; user=alice')).toContain('Cookie: [REDACTED]');
+    expect(redactOutput('Set-Cookie: jwt=eyJxxx; HttpOnly')).toContain('Set-Cookie: [REDACTED]');
+  });
+
+  test('redacts Google OAuth ya29.* access tokens', () => {
+    const out = redactOutput('access_token=ya29.a0AfH6SMblahblahblah_more.morestuff');
+    expect(out).not.toContain('ya29.a0AfH6SMblahblahblah');
+    expect(out).toContain('[REDACTED]');
+  });
+
+  test('redacts password in URI userinfo while preserving scheme/host', () => {
+    const out = redactOutput('postgres://app_user:s3cretP@db.internal/mydb');
+    expect(out).toContain('postgres://app_user:[REDACTED]@db.internal/mydb');
+    expect(out).not.toContain('s3cretP');
+  });
+
+  test('redacts AWS_*_KEY/TOKEN/SECRET env-style assignments', () => {
+    expect(redactOutput('AWS_SECRET_ACCESS_KEY=AKIAlongvaluehere1234')).toContain('[REDACTED]');
+    expect(redactOutput('AWS_SESSION_TOKEN: longsessiontokenvalue')).toContain('[REDACTED]');
+  });
+
+  test('redacts refresh_token / id_token / password / client_secret', () => {
+    const variants = [
+      'refresh_token=longvaluehere1234',
+      'id_token: "longvaluehere1234"',
+      "password = 'longvaluehere1234'",
+      'client_secret="longvaluehere1234"',
+    ];
+    for (const v of variants) {
+      const out = redactOutput(v);
+      expect(out).not.toContain('longvaluehere1234');
+      expect(out).toContain('[REDACTED]');
+    }
+  });
+
   test('does not redact short api_key-like values (avoid false positives on word "key")', () => {
     // The api_key pattern requires a 12+ char value to avoid eating things like
     // "no apikey set" or "key: id".

--- a/packages/owletto-worker/src/daemon/client.ts
+++ b/packages/owletto-worker/src/daemon/client.ts
@@ -144,6 +144,14 @@ export interface CompleteRequest {
   error_message?: string;
   checkpoint?: Record<string, unknown>;
   auth_update?: Record<string, unknown>;
+  /** Tail of subprocess stdout+stderr (already redacted in the worker). */
+  output_tail?: string;
+  /** Subprocess exit code, if the child terminated without an IPC result. */
+  exit_code?: number | null;
+  /** Subprocess exit signal, if any. */
+  exit_signal?: string | null;
+  /** Categorized exit reason: ok | error_message | timeout | oom | crash. */
+  exit_reason?: 'ok' | 'error_message' | 'timeout' | 'oom' | 'crash';
 }
 
 export interface CompleteActionRequest {

--- a/packages/owletto-worker/src/daemon/client.ts
+++ b/packages/owletto-worker/src/daemon/client.ts
@@ -198,6 +198,14 @@ export interface CompleteAuthRequest {
   credentials?: Record<string, unknown>;
   metadata?: Record<string, unknown>;
   error_message?: string;
+  /** Tail of subprocess stdout+stderr (already redacted in the worker). */
+  output_tail?: string;
+  /** Subprocess exit code, if the child terminated without an IPC result. */
+  exit_code?: number | null;
+  /** Subprocess exit signal, if any. */
+  exit_signal?: string | null;
+  /** Categorized exit reason: ok | error_message | timeout | oom | crash. */
+  exit_reason?: 'ok' | 'error_message' | 'timeout' | 'oom' | 'crash';
 }
 
 /**

--- a/packages/owletto-worker/src/daemon/executor.ts
+++ b/packages/owletto-worker/src/daemon/executor.ts
@@ -440,12 +440,16 @@ async function executeAuthRun(
     clearInterval(heartbeatInterval);
     const errorMessage = error instanceof Error ? error.message : String(error);
     console.error(`[executor] Auth run ${run_id} failed:`, errorMessage);
+
+    const diag = extractSubprocessDiagnostics(error);
+
     try {
       await client.completeAuth({
         run_id,
         worker_id: client.id,
         status: 'failed',
         error_message: errorMessage,
+        ...(diag ?? {}),
       });
     } catch (completeErr) {
       console.error('[executor] completeAuth after failure errored:', completeErr);

--- a/packages/owletto-worker/src/daemon/executor.ts
+++ b/packages/owletto-worker/src/daemon/executor.ts
@@ -228,16 +228,48 @@ async function executeSyncRun(
     const errorMessage = error instanceof Error ? error.message : String(error);
     console.error(`[executor] Sync run ${run_id} failed:`, errorMessage);
 
+    const diag = extractSubprocessDiagnostics(error);
+
     await client.complete({
       run_id,
       worker_id: client.id,
       status: 'failed',
       items_collected: itemsCollectedSoFar,
       error_message: errorMessage,
+      ...(diag ?? {}),
     });
 
     return { itemsCollected: itemsCollectedSoFar, error: errorMessage };
   }
+}
+
+/**
+ * Pull diagnostic fields off a SubprocessError-shaped error so the worker
+ * can persist them on the failed run row. Returns `undefined` when the
+ * thrown value isn't a subprocess failure (e.g. a stream/HTTP error).
+ */
+function extractSubprocessDiagnostics(error: unknown):
+  | {
+      output_tail?: string;
+      exit_code?: number | null;
+      exit_signal?: string | null;
+      exit_reason?: 'ok' | 'error_message' | 'timeout' | 'oom' | 'crash';
+    }
+  | undefined {
+  if (!error || typeof error !== 'object') return undefined;
+  const e = error as {
+    exitReason?: 'ok' | 'error_message' | 'timeout' | 'oom' | 'crash';
+    exitCode?: number | null;
+    exitSignal?: string | null;
+    outputTail?: string;
+  };
+  if (!e.exitReason && e.exitCode === undefined && !e.outputTail) return undefined;
+  return {
+    output_tail: e.outputTail || undefined,
+    exit_code: e.exitCode ?? null,
+    exit_signal: e.exitSignal ?? null,
+    exit_reason: e.exitReason,
+  };
 }
 
 /**

--- a/packages/owletto-worker/src/executor/child-runner.ts
+++ b/packages/owletto-worker/src/executor/child-runner.ts
@@ -242,11 +242,18 @@ function sendIPC(msg: unknown): Promise<void> {
  */
 function installUncaughtHandlers(): void {
   let handled = false;
+  const safeStringify = (v: unknown): string => {
+    try {
+      return JSON.stringify(v) ?? String(v);
+    } catch {
+      return String(v);
+    }
+  };
   const handle = async (err: unknown) => {
     if (handled) return;
     handled = true;
     const e =
-      err instanceof Error ? err : new Error(typeof err === 'string' ? err : JSON.stringify(err));
+      err instanceof Error ? err : new Error(typeof err === 'string' ? err : safeStringify(err));
     try {
       await sendIPC({
         type: 'error',

--- a/packages/owletto-worker/src/executor/child-runner.ts
+++ b/packages/owletto-worker/src/executor/child-runner.ts
@@ -234,7 +234,46 @@ function sendIPC(msg: unknown): Promise<void> {
   });
 }
 
+/**
+ * Best-effort handlers for top-level errors that previously escaped the
+ * runner's try/catch and surfaced as the bare wrapper string in the parent.
+ * These do NOT catch SIGKILL, native crashes, OOM, or sync `process.exit()`;
+ * those are surfaced via `exit_reason` in the parent SubprocessExecutor.
+ */
+function installUncaughtHandlers(): void {
+  let handled = false;
+  const handle = async (err: unknown) => {
+    if (handled) return;
+    handled = true;
+    const e =
+      err instanceof Error ? err : new Error(typeof err === 'string' ? err : JSON.stringify(err));
+    try {
+      await sendIPC({
+        type: 'error',
+        error: {
+          message: e.message,
+          stack: e.stack,
+          name: e.name,
+        },
+      });
+    } catch {
+      // If IPC is dead, the parent's exit-handler path will still produce
+      // diagnostics from the output tail.
+    } finally {
+      process.exit(1);
+    }
+  };
+
+  process.on('uncaughtException', (err) => {
+    void handle(err);
+  });
+  process.on('unhandledRejection', (reason) => {
+    void handle(reason);
+  });
+}
+
 async function main() {
+  installUncaughtHandlers();
   let started = false;
   // Wait for message from parent
   process.on('message', async (msg: any) => {

--- a/packages/owletto-worker/src/executor/redact.ts
+++ b/packages/owletto-worker/src/executor/redact.ts
@@ -1,0 +1,44 @@
+/**
+ * Redact secrets from connector subprocess output before it leaves the worker.
+ *
+ * Patterns are deliberately broad — false positives are preferred to leaking a
+ * real credential into the runs table. Add new patterns here when a connector
+ * surfaces a new sensitive shape.
+ */
+
+const REDACTED = '[REDACTED]';
+
+const PATTERNS: Array<{ regex: RegExp; replacement: string }> = [
+  // HTTP Authorization header (e.g. "Authorization: Bearer abc...") — match
+  // the rest of the line so multi-token schemes like "Bearer xxx" get caught.
+  { regex: /Authorization:[^\r\n]+/gi, replacement: `Authorization: ${REDACTED}` },
+
+  // Bearer tokens anywhere
+  { regex: /Bearer\s+[\w\-.~+/=]+/gi, replacement: `Bearer ${REDACTED}` },
+
+  // JWT shape (eyJ...header.payload.sig)
+  { regex: /eyJ[\w\-]+\.[\w\-]+\.[\w\-]+/g, replacement: REDACTED },
+
+  // CH_API_KEY=value (literal env-var key from the connector ecosystem)
+  {
+    regex: /(CH_API_KEY)(["'\s:=]+["']?)([\w\-]+)(["']?)/gi,
+    replacement: `$1$2${REDACTED}$4`,
+  },
+
+  // JSON/YAML/env-var style "api_key": "..." / apikey=... / access_token: ...
+  // / secret = "..."
+  {
+    regex:
+      /((?:api[_-]?key|apikey|access[_-]?token|secret))(["'\s:=]+["']?)([\w\-]{12,})(["']?)/gi,
+    replacement: `$1$2${REDACTED}$4`,
+  },
+];
+
+export function redactOutput(text: string): string {
+  if (!text) return text;
+  let result = text;
+  for (const { regex, replacement } of PATTERNS) {
+    result = result.replace(regex, replacement);
+  }
+  return result;
+}

--- a/packages/owletto-worker/src/executor/redact.ts
+++ b/packages/owletto-worker/src/executor/redact.ts
@@ -8,16 +8,35 @@
 
 const REDACTED = '[REDACTED]';
 
+// Value charset for assignment-style secrets: word + URL-safe base64 + the
+// dot/dollar/percent that show up in OAuth tokens (e.g. ya29.a0AfH6SM…) and
+// signed cookies. Excludes whitespace, quote, brace, and bracket so the
+// pattern stops at the boundary of the value.
+const SECRET_VALUE = `[\\w\\-.~+/=:%$]{12,}`;
+
 const PATTERNS: Array<{ regex: RegExp; replacement: string }> = [
   // HTTP Authorization header (e.g. "Authorization: Bearer abc...") — match
   // the rest of the line so multi-token schemes like "Bearer xxx" get caught.
   { regex: /Authorization:[^\r\n]+/gi, replacement: `Authorization: ${REDACTED}` },
 
-  // Bearer tokens anywhere
+  // Cookie / Set-Cookie header — same line-eating shape.
+  { regex: /(Set-)?Cookie:[^\r\n]+/gi, replacement: `$1Cookie: ${REDACTED}` },
+
+  // Bearer tokens anywhere (URL-safe-base64 style values)
   { regex: /Bearer\s+[\w\-.~+/=]+/gi, replacement: `Bearer ${REDACTED}` },
 
   // JWT shape (eyJ...header.payload.sig)
   { regex: /eyJ[\w\-]+\.[\w\-]+\.[\w\-]+/g, replacement: REDACTED },
+
+  // Google OAuth access token shape (ya29.<varies>) — high-confidence.
+  { regex: /ya29\.[\w\-.]{20,}/g, replacement: REDACTED },
+
+  // URI userinfo: `scheme://user:pass@host` — redact the password segment.
+  // Captures any scheme; replaces password while preserving structure.
+  {
+    regex: /([a-z][a-z0-9+\-.]*:\/\/[^:/\s]+):([^@/\s]+)@/gi,
+    replacement: `$1:${REDACTED}@`,
+  },
 
   // CH_API_KEY=value (literal env-var key from the connector ecosystem)
   {
@@ -25,11 +44,23 @@ const PATTERNS: Array<{ regex: RegExp; replacement: string }> = [
     replacement: `$1$2${REDACTED}$4`,
   },
 
-  // JSON/YAML/env-var style "api_key": "..." / apikey=... / access_token: ...
-  // / secret = "..."
+  // AWS_<SOMETHING>_KEY / AWS_<SOMETHING>_TOKEN env-style.
   {
-    regex:
-      /((?:api[_-]?key|apikey|access[_-]?token|secret))(["'\s:=]+["']?)([\w\-]{12,})(["']?)/gi,
+    regex: new RegExp(
+      `(AWS_[A-Z0-9_]*(?:KEY|TOKEN|SECRET))(["'\\s:=]+["']?)(${SECRET_VALUE})(["']?)`,
+      'g'
+    ),
+    replacement: `$1$2${REDACTED}$4`,
+  },
+
+  // JSON/YAML/env-var style `api_key=...`, `apikey: "..."`, `access_token: ...`,
+  // `secret = "..."`, `refresh_token: ...`, `id_token=...`, `_authToken: ...`,
+  // `password: "..."`, `client_secret=...`.
+  {
+    regex: new RegExp(
+      `((?:api[_-]?key|apikey|access[_-]?token|refresh[_-]?token|id[_-]?token|_?auth[_-]?token|client[_-]?secret|secret|password))(["'\\s:=]+["']?)(${SECRET_VALUE})(["']?)`,
+      'gi'
+    ),
     replacement: `$1$2${REDACTED}$4`,
   },
 ];

--- a/packages/owletto-worker/src/executor/redact.ts
+++ b/packages/owletto-worker/src/executor/redact.ts
@@ -74,10 +74,13 @@ export class StreamRedactor {
       return;
     }
     if (combined.length > StreamRedactor.MAX_BUFFER) {
-      const overflow = combined.length - StreamRedactor.MAX_BUFFER;
-      const headPrefix = combined.slice(0, overflow);
-      this.carryover = combined.slice(overflow);
-      emit(redactOutput(headPrefix));
+      // No newline but we have to bound memory. Redact the whole buffer
+      // before emitting — slicing would re-introduce a boundary mid-secret.
+      // Carryover resets; the next chunk starts fresh, accepting that a
+      // secret split across the cap boundary may be redacted twice (safe)
+      // but never split within a regex match.
+      emit(redactOutput(combined));
+      this.carryover = '';
       return;
     }
     this.carryover = combined;

--- a/packages/owletto-worker/src/executor/redact.ts
+++ b/packages/owletto-worker/src/executor/redact.ts
@@ -42,3 +42,51 @@ export function redactOutput(text: string): string {
   }
   return result;
 }
+
+/**
+ * Streaming redactor for live tee to parent stdout/stderr. Buffers up to the
+ * last newline so that secrets split across stream chunk boundaries — for
+ * example "Authorization: Bear" + "er abc..." in two `data` events — still
+ * get matched by `redactOutput()`. The persisted `output_tail` already runs
+ * `redactOutput()` over the full ring-buffer string and is unaffected; this
+ * class exists solely to make the live-forwarded stream as safe as the
+ * persisted tail.
+ *
+ * `flush()` MUST be called on stream end to release any trailing partial
+ * line; otherwise its (redacted) content is dropped from the live tee but
+ * still appears in the persisted tail.
+ */
+export class StreamRedactor {
+  private carryover = '';
+  // Safety cap for input with no newlines at all; emit the prefix and keep
+  // a sliding window of the last MAX_BUFFER chars to catch boundary splits
+  // up to that length.
+  private static readonly MAX_BUFFER = 8192;
+
+  process(chunk: string, emit: (redacted: string) => void): void {
+    if (!chunk) return;
+    const combined = this.carryover + chunk;
+    const lastNewline = combined.lastIndexOf('\n');
+    if (lastNewline >= 0) {
+      const complete = combined.slice(0, lastNewline + 1);
+      this.carryover = combined.slice(lastNewline + 1);
+      emit(redactOutput(complete));
+      return;
+    }
+    if (combined.length > StreamRedactor.MAX_BUFFER) {
+      const overflow = combined.length - StreamRedactor.MAX_BUFFER;
+      const headPrefix = combined.slice(0, overflow);
+      this.carryover = combined.slice(overflow);
+      emit(redactOutput(headPrefix));
+      return;
+    }
+    this.carryover = combined;
+  }
+
+  flush(emit: (redacted: string) => void): void {
+    if (this.carryover) {
+      emit(redactOutput(this.carryover));
+      this.carryover = '';
+    }
+  }
+}

--- a/packages/owletto-worker/src/executor/subprocess.ts
+++ b/packages/owletto-worker/src/executor/subprocess.ts
@@ -339,9 +339,15 @@ export class SubprocessExecutor implements SyncExecutor {
             outputTail: tail,
             exitReason: 'error_message',
           };
-          const error = new SubprocessError(msg.error?.message ?? 'Subprocess reported error', diagnostics);
+          // Connector code is allowed to throw with the offending value
+          // embedded — `throw new Error('failed with api_key=sk_live_…')`.
+          // Redact the message and stack the same way the persisted tail
+          // is redacted so secrets don't leak through the error path
+          // (which is also written to gateway logs by upstream callers).
+          const rawMessage = msg.error?.message ?? 'Subprocess reported error';
+          const error = new SubprocessError(redactOutput(rawMessage), diagnostics);
           error.name = msg.error?.name ?? 'SubprocessError';
-          if (msg.error?.stack) error.stack = msg.error.stack;
+          if (msg.error?.stack) error.stack = redactOutput(msg.error.stack);
           settle(() => reject(error));
           return;
         }

--- a/packages/owletto-worker/src/executor/subprocess.ts
+++ b/packages/owletto-worker/src/executor/subprocess.ts
@@ -11,7 +11,7 @@ import { existsSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import type { ExecutionHooks, FeedSyncResult, SyncContext, SyncExecutor } from './interface.js';
-import { redactOutput } from './redact.js';
+import { StreamRedactor, redactOutput } from './redact.js';
 
 /**
  * exit_reason values surfaced to the runs table:
@@ -195,6 +195,10 @@ export class SubprocessExecutor implements SyncExecutor {
         child.removeListener('exit', onExit);
         child.stdout?.removeListener('data', onStdout);
         child.stderr?.removeListener('data', onStderr);
+        // Flush any trailing partial line from each stream so the live tee
+        // matches what the persisted tail saw.
+        stdoutRedactor.flush((clean) => process.stdout.write(`[subprocess] ${clean}`));
+        stderrRedactor.flush((clean) => process.stderr.write(`[subprocess] ${clean}`));
       };
 
       const settle = (fn: () => void) => {
@@ -387,17 +391,23 @@ export class SubprocessExecutor implements SyncExecutor {
       // the ring buffer so we can surface the tail on failure. Without this
       // listener, stdio: 'pipe' fills the OS pipe buffer (~16-64 KB) and the
       // child blocks on its next console.log until SIGKILL.
+      // Stream redactors buffer up to the last newline so secrets split
+      // across chunk boundaries still match. Persisted tails already
+      // redact the full ring-buffer string and are unaffected.
+      const stdoutRedactor = new StreamRedactor();
+      const stderrRedactor = new StreamRedactor();
+
       const onStdout = (data: Buffer) => {
         const text = data.toString();
         stdoutTail.append(text);
-        process.stdout.write(`[subprocess] ${redactOutput(text)}`);
+        stdoutRedactor.process(text, (clean) => process.stdout.write(`[subprocess] ${clean}`));
       };
 
       // Forward child stderr to parent stderr for logging + ring buffer.
       const onStderr = (data: Buffer) => {
         const text = data.toString();
         stderrTail.append(text);
-        process.stderr.write(`[subprocess] ${redactOutput(text)}`);
+        stderrRedactor.process(text, (clean) => process.stderr.write(`[subprocess] ${clean}`));
       };
 
       child.on('message', onMessage);

--- a/packages/owletto-worker/src/executor/subprocess.ts
+++ b/packages/owletto-worker/src/executor/subprocess.ts
@@ -11,6 +11,75 @@ import { existsSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import type { ExecutionHooks, FeedSyncResult, SyncContext, SyncExecutor } from './interface.js';
+import { redactOutput } from './redact.js';
+
+/**
+ * exit_reason values surfaced to the runs table:
+ *  - ok: successful 'result' IPC.
+ *  - error_message: child sent {type:'error',...} via IPC.
+ *  - timeout: parent killed the child with SIGKILL after timeoutMs.
+ *  - oom: code !== 0 and output tail mentions a JS heap OOM.
+ *  - crash: any other non-zero exit / unexpected signal.
+ */
+export type SubprocessExitReason = 'ok' | 'error_message' | 'timeout' | 'oom' | 'crash';
+
+/** Diagnostic fields attached to errors thrown by the executor. */
+export interface SubprocessDiagnostics {
+  exitCode: number | null;
+  exitSignal: string | null;
+  outputTail: string;
+  exitReason: SubprocessExitReason;
+}
+
+export class SubprocessError extends Error implements SubprocessDiagnostics {
+  exitCode: number | null;
+  exitSignal: string | null;
+  outputTail: string;
+  exitReason: SubprocessExitReason;
+
+  constructor(
+    message: string,
+    diagnostics: SubprocessDiagnostics,
+    options?: { cause?: unknown }
+  ) {
+    super(message, options);
+    this.name = 'SubprocessError';
+    this.exitCode = diagnostics.exitCode;
+    this.exitSignal = diagnostics.exitSignal;
+    this.outputTail = diagnostics.outputTail;
+    this.exitReason = diagnostics.exitReason;
+  }
+}
+
+/** Per-stream ring buffer that preserves the most recent bytes. */
+class RingBuffer {
+  private chunks: string[] = [];
+  private size = 0;
+  constructor(private readonly cap: number) {}
+
+  append(chunk: string): void {
+    if (!chunk) return;
+    this.chunks.push(chunk);
+    this.size += chunk.length;
+    while (this.size > this.cap && this.chunks.length > 0) {
+      const front = this.chunks[0];
+      const overflow = this.size - this.cap;
+      if (front.length <= overflow) {
+        this.size -= front.length;
+        this.chunks.shift();
+      } else {
+        this.chunks[0] = front.slice(overflow);
+        this.size -= overflow;
+      }
+    }
+  }
+
+  toString(): string {
+    return this.chunks.join('');
+  }
+}
+
+const STREAM_TAIL_CAP_BYTES = 16 * 1024;
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -89,6 +158,7 @@ export class SubprocessExecutor implements SyncExecutor {
 
       let resolved = false;
       let terminalMessageReceived = false;
+      let timedOut = false;
       let latestCheckpoint = context.checkpoint;
       let finalMetadata: Record<string, any> | undefined;
       let finalAuthUpdate: Record<string, any> | undefined;
@@ -96,6 +166,12 @@ export class SubprocessExecutor implements SyncExecutor {
       const collectedContents: FeedSyncResult['contents'] = [];
       const collectContents = hooks?.collectContents !== false;
       let processingChain = Promise.resolve();
+
+      // Per-stream ring buffers — preserve the *tail* (most recent bytes),
+      // which is where the failure cause lands. Cap each at 16 KiB so a
+      // chatty connector can't grow the worker's memory.
+      const stdoutTail = new RingBuffer(STREAM_TAIL_CAP_BYTES);
+      const stderrTail = new RingBuffer(STREAM_TAIL_CAP_BYTES);
 
       // Set timeout - kill child if it takes too long. timeoutMs <= 0 disables
       // the timer (used for interactive auth runs that wait on human input).
@@ -106,6 +182,7 @@ export class SubprocessExecutor implements SyncExecutor {
                 console.error(
                   `[SubprocessExecutor] Killing child process after ${this.options.timeoutMs}ms timeout`
                 );
+                timedOut = true;
                 child.kill('SIGKILL');
               }
             }, this.options.timeoutMs)
@@ -116,6 +193,7 @@ export class SubprocessExecutor implements SyncExecutor {
         child.removeListener('message', onMessage);
         child.removeListener('error', onError);
         child.removeListener('exit', onExit);
+        child.stdout?.removeListener('data', onStdout);
         child.stderr?.removeListener('data', onStderr);
       };
 
@@ -137,6 +215,29 @@ export class SubprocessExecutor implements SyncExecutor {
             reject(err instanceof Error ? err : new Error(String(err)));
           });
         });
+      };
+
+      const combinedTail = (): string => {
+        const out = stdoutTail.toString();
+        const err = stderrTail.toString();
+        if (!out && !err) return '';
+        if (!out) return `[stderr]\n${err}`;
+        if (!err) return `[stdout]\n${out}`;
+        return `[stdout]\n${out}\n[stderr]\n${err}`;
+      };
+
+      const computeExitReason = (
+        code: number | null,
+        signal: string | null,
+        tail: string
+      ): SubprocessExitReason => {
+        if (timedOut || signal === 'SIGKILL') return 'timeout';
+        if (code !== null && code !== 0) {
+          if (/javascript heap out of memory/i.test(tail)) return 'oom';
+          return 'crash';
+        }
+        if (signal) return 'crash';
+        return 'crash';
       };
 
       // Handle messages from child
@@ -231,9 +332,16 @@ export class SubprocessExecutor implements SyncExecutor {
 
         if (msg.type === 'error') {
           terminalMessageReceived = true;
-          const error = new Error(msg.error.message);
-          error.name = msg.error.name;
-          error.stack = msg.error.stack;
+          const tail = redactOutput(combinedTail());
+          const diagnostics: SubprocessDiagnostics = {
+            exitCode: null,
+            exitSignal: null,
+            outputTail: tail,
+            exitReason: 'error_message',
+          };
+          const error = new SubprocessError(msg.error?.message ?? 'Subprocess reported error', diagnostics);
+          error.name = msg.error?.name ?? 'SubprocessError';
+          if (msg.error?.stack) error.stack = msg.error.stack;
           settle(() => reject(error));
           return;
         }
@@ -241,7 +349,17 @@ export class SubprocessExecutor implements SyncExecutor {
 
       // Handle child errors
       const onError = (err: Error) => {
-        settle(() => reject(new Error(`Subprocess error: ${err.message}`)));
+        const tail = redactOutput(combinedTail());
+        const diagnostics: SubprocessDiagnostics = {
+          exitCode: null,
+          exitSignal: null,
+          outputTail: tail,
+          exitReason: 'crash',
+        };
+        const wrapped = new SubprocessError(`Subprocess error: ${err.message}`, diagnostics, {
+          cause: err,
+        });
+        settle(() => reject(wrapped));
       };
 
       // Handle child exit (single handler for both timeout cleanup and unexpected exits)
@@ -250,22 +368,46 @@ export class SubprocessExecutor implements SyncExecutor {
           return;
         }
         settle(() => {
-          if (signal === 'SIGKILL') {
-            reject(new Error(`Feed execution timed out after ${this.options.timeoutMs}ms`));
-          } else {
-            reject(new Error(`Subprocess exited with code ${code}, signal ${signal}`));
-          }
+          const tail = redactOutput(combinedTail());
+          const reason = computeExitReason(code, signal, tail);
+          const prefix =
+            reason === 'timeout'
+              ? `Feed execution timed out after ${this.options.timeoutMs}ms`
+              : reason === 'oom'
+                ? `Subprocess out of memory (code ${code}, signal ${signal})`
+                : `Subprocess exited with code ${code}, signal ${signal}`;
+          const message = tail ? `${prefix}\n${tail}` : prefix;
+          const diagnostics: SubprocessDiagnostics = {
+            exitCode: code,
+            exitSignal: signal,
+            outputTail: tail,
+            exitReason: reason,
+          };
+          reject(new SubprocessError(message, diagnostics));
         });
       };
 
-      // Forward child stderr to parent stderr for logging
+      // Forward child stdout to parent stdout for live tailing AND tap into
+      // the ring buffer so we can surface the tail on failure. Without this
+      // listener, stdio: 'pipe' fills the OS pipe buffer (~16-64 KB) and the
+      // child blocks on its next console.log until SIGKILL.
+      const onStdout = (data: Buffer) => {
+        const text = data.toString();
+        stdoutTail.append(text);
+        process.stdout.write(`[subprocess] ${text}`);
+      };
+
+      // Forward child stderr to parent stderr for logging + ring buffer.
       const onStderr = (data: Buffer) => {
-        process.stderr.write(`[subprocess] ${data.toString()}`);
+        const text = data.toString();
+        stderrTail.append(text);
+        process.stderr.write(`[subprocess] ${text}`);
       };
 
       child.on('message', onMessage);
       child.on('error', onError);
       child.on('exit', onExit);
+      child.stdout?.on('data', onStdout);
       child.stderr?.on('data', onStderr);
 
       // Send the compiled code and context to the child

--- a/packages/owletto-worker/src/executor/subprocess.ts
+++ b/packages/owletto-worker/src/executor/subprocess.ts
@@ -231,12 +231,8 @@ export class SubprocessExecutor implements SyncExecutor {
         signal: string | null,
         tail: string
       ): SubprocessExitReason => {
-        if (timedOut || signal === 'SIGKILL') return 'timeout';
-        if (code !== null && code !== 0) {
-          if (/javascript heap out of memory/i.test(tail)) return 'oom';
-          return 'crash';
-        }
-        if (signal) return 'crash';
+        if (timedOut) return 'timeout';
+        if (/javascript heap out of memory/i.test(tail)) return 'oom';
         return 'crash';
       };
 
@@ -394,14 +390,14 @@ export class SubprocessExecutor implements SyncExecutor {
       const onStdout = (data: Buffer) => {
         const text = data.toString();
         stdoutTail.append(text);
-        process.stdout.write(`[subprocess] ${text}`);
+        process.stdout.write(`[subprocess] ${redactOutput(text)}`);
       };
 
       // Forward child stderr to parent stderr for logging + ring buffer.
       const onStderr = (data: Buffer) => {
         const text = data.toString();
         stderrTail.append(text);
-        process.stderr.write(`[subprocess] ${text}`);
+        process.stderr.write(`[subprocess] ${redactOutput(text)}`);
       };
 
       child.on('message', onMessage);


### PR DESCRIPTION
## Summary

When a connector subprocess fails before sending a typed terminal IPC, the run record now carries enough context to diagnose the cause without reading gateway pod logs. Today every such failure surfaces as the bare wrapper string `Subprocess exited with code 1, signal null` and the real cause goes to gateway stderr only — see `lenkie.companies_house` feeds 273 and 274 in production, both at 8 consecutive failures with zero diagnostic info on the run records.

This is PR 1 of a connector reliability initiative. Diagnostic substrate only — no scheduler changes, no agent invocation, no `feeds` schema changes. Those land in PR 2.

## Changes

- **Drain stdout** in the subprocess executor. Previously stdio was piped on all three streams but only stderr had a listener — chatty connectors filled the OS pipe buffer and blocked on the next `console.log` until the 10-min SIGKILL. Latent hang fixed.
- **Ring-buffer both streams** at 16 KiB each, tail-preserving (drop from the front so the most recent bytes — where the failure cause lives — are kept).
- **Compute `exit_reason`** as one of `ok | error_message | timeout | oom | crash`. OOM detected by sniffing the tail for `JavaScript heap out of memory`.
- **Top-level handlers in `child-runner.ts`**: `uncaughtException` and `unhandledRejection` send `{type:'error',...}` IPC before exiting. Best-effort — does not catch SIGKILL / native crashes / sync `process.exit()`, but those cases are now classified by `exit_reason`.
- **Secrets redactor** (`packages/owletto-worker/src/executor/redact.ts`) covers Authorization headers, Bearer tokens, JWTs, common api_key/access_token/secret assignment forms, and the known `CH_API_KEY`. Runs **inside the worker before the IPC payload leaves**, so the gateway DB never sees unredacted bytes. 8/8 unit tests passing.
- **Schema** (`db/migrations/20260425120000_add_run_diagnostics.sql`): adds `output_tail`, `exit_code`, `exit_signal`, `exit_reason` to `runs`. No backfill, no index.
- **Backend persistence** (`packages/owletto-backend/src/worker-api.ts`): the failed-run UPDATE now writes the four new columns. Success path unchanged.

## Test plan

- [x] `bun run typecheck` — pass
- [x] `make build-packages` — pass
- [x] `bun test packages/owletto-worker/src/__tests__/redact.test.ts` — 8/8 pass
- [ ] Live validation: after deploy, watch `lenkie.companies_house` feeds 273 / 274 on the next 6h cron tick. The next failed run should populate `output_tail` and `exit_reason` instead of just the wrapper string. If stdout-buffer hang was the root cause, `exit_reason='timeout'` with stdout content visible.
- [ ] Confirm no production connector starts emitting redacted-looking output for legitimate reasons (false positives in the redactor).

## Follow-ups (not in this PR)

- Auth-run completion endpoint (`/api/workers/complete-auth`) does not yet forward subprocess diagnostics. Mirror `extractSubprocessDiagnostics()` there in a follow-up.
- PR 2 will add the repair-agent plumbing (per-feed `repair_agent_id`, threshold-triggered thread creation, cooldown / attempt ceiling, kill switch).