### PR TITLE
docs(agents): clarify PR bundling + mandate subagent worktree isolation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -109,7 +109,7 @@ Rules for agents:
 
 When the user pivots mid-session, the default failure mode is piling unrelated work onto one branch and producing a tangled PR. Prevent that:
 
-- **One branch = one concern.** Never mix unrelated features on a single branch.
+- **One branch = one concern, but bundle related work.** Never mix unrelated features on a single branch — but don't fragment one concern into a stack of tiny PRs either. Default to fewer, larger PRs as long as they stay reviewable. Split only when (a) the changes are genuinely independent, (b) the diff would be unreviewable as one piece, or (c) one piece is independently shippable and blocking it on the rest costs real time.
 - **When the user asks for something tangential to the current branch**, stop and say out loud: *"that's a separate concern — I'll finish/push the current work and start a fresh branch."* Then:
   1. Commit and push what you have.
   2. Open the PR for the current branch (or leave it draft if not ready).
@@ -117,6 +117,7 @@ When the user pivots mid-session, the default failure mode is piling unrelated w
 - **When the new ask genuinely builds on unmerged code**, stack it: `git switch -c feat/b feat/a` off the existing feature branch and open PR #2 targeting `feat/a` (not `main`). Rebase PR #2 onto `main` once PR #1 merges.
 - **Never `git stash`.** Stashes are invisible, easy to lose, and collide across agents. If you need to pivot without finishing, commit WIP to the current branch (`git add -A && git commit -m "wip"`) and squash later. WIP commits are visible, pushable, recoverable.
 - **Per-agent isolation:** when launching a parallel Claude Code session, use `claude --worktree <name>` so each agent gets its own checkout + branch. No shared working dir = no cross-agent collisions.
+- **Subagent isolation (mandatory):** any spawned subagent that may `git switch`, commit, push, or run a destructive command MUST run with `isolation: "worktree"`. Read-only research/exploration agents may share the parent checkout. If unsure, use a worktree — the cost is a temp checkout, the cost of skipping is overwriting the user's working tree.
 - **If a branch has already gotten mixed**, recover with `git rebase -i` + `git reset HEAD~N` and re-commit in clean groups before opening PRs.
 
 ## Development


### PR DESCRIPTION
## Summary
- **PR bundling rule.** Today's "One branch = one concern" gets read by agents as "split everything," producing PR sprawl. Softened to: default to fewer, larger, reviewable PRs; split only when genuinely independent or unreviewable as one piece.
- **Subagent worktree isolation.** Mandates \`isolation: "worktree"\` for any spawned subagent that may \`git switch\`, commit, push, or run destructive commands. Read-only research agents may share the parent checkout. Prevents subagents from clobbering the user's working tree.

## Test plan
- [ ] Read the diff at \`AGENTS.md:112\` and \`AGENTS.md:120\` and confirm the wording matches the intent.