### PR TITLE
chore: prune dead code and wire knip config

### DIFF
--- a/config/knip.ts
+++ b/config/knip.ts
@@ -31,14 +31,15 @@ const config: KnipConfig = {
       ],
     },
     "packages/owletto-embeddings": {
-      // package.json "main" points to dist/; the real source entries are these.
-      // embedding-utils.ts is imported by both — listing explicitly because
-      // src/ contains stale compiled .js siblings that confuse knip's resolver.
-      entry: ["src/server.ts", "src/openai.ts", "src/embedding-utils.ts"],
+      // src/openai.ts and src/embedding-utils.ts are reached transitively from
+      // server.ts (the package "main"); listing embedding-utils explicitly
+      // because src/ contains stale compiled .js siblings that confuse knip's
+      // resolver.
+      entry: ["src/openai.ts", "src/embedding-utils.ts"],
     },
     "packages/owletto-worker": {
       // child-runner is fork()ed by absolute path, not imported.
-      entry: ["src/index.ts", "src/executor/child-runner.ts"],
+      entry: ["src/executor/child-runner.ts"],
       ignoreDependencies: [
         // Loaded via dynamic specifier in src/index.ts.
         "@lobu/worker",

--- a/config/knip.ts
+++ b/config/knip.ts
@@ -1,0 +1,107 @@
+import type { KnipConfig } from "knip";
+
+const config: KnipConfig = {
+  ignore: [
+    // Submodule — cleaned up via its own repo / PR.
+    "packages/owletto-web/**",
+    // Bundled into owletto-cli at build time; not a separate workspace.
+    "packages/owletto-cli/runtime/**",
+  ],
+  ignoreBinaries: [
+    // Used in Makefile / k8s scripts but not declared as a workspace dep.
+    "helm",
+  ],
+  // Bun-style "npm:foo@x" import specifiers used by connectors.
+  ignoreUnresolved: ["^npm:"],
+  workspaces: {
+    // Connector source files are loaded by file path
+    // (scripts/owletto/install-connectors.ts), not imported as modules.
+    "packages/owletto-connectors": {
+      entry: ["src/*.ts"],
+    },
+    // Chrome MV3 extension — entries come from manifest.json + vite.config.ts.
+    "packages/owletto-extension": {
+      entry: [
+        "src/background/service-worker.ts",
+        "src/content/index.ts",
+        "src/sidebar/main.tsx",
+        "src/popup/main.tsx",
+        "src/offscreen/worker.ts",
+        "src/callback/callback.ts",
+      ],
+    },
+    "packages/owletto-embeddings": {
+      // package.json "main" points to dist/; the real source entries are these.
+      // embedding-utils.ts is imported by both — listing explicitly because
+      // src/ contains stale compiled .js siblings that confuse knip's resolver.
+      entry: ["src/server.ts", "src/openai.ts", "src/embedding-utils.ts"],
+    },
+    "packages/owletto-worker": {
+      // child-runner is fork()ed by absolute path, not imported.
+      entry: ["src/index.ts", "src/executor/child-runner.ts"],
+      ignoreDependencies: [
+        // Loaded via dynamic specifier in src/index.ts.
+        "@lobu/worker",
+      ],
+    },
+    "packages/owletto-backend": {
+      entry: [
+        // Embedded server boot path used by owletto-cli `start`.
+        "src/start-local.ts",
+        // Reached via cross-workspace import from scripts/owletto/sync-local.ts.
+        "src/lib/feed-sync.ts",
+        // Dynamically imported at runtime by reaction-executor.
+        "src/tools/admin/notify.ts",
+        // Benchmark suite — entries are scripts in scripts/owletto/.
+        "src/benchmarks/memory/runner.ts",
+        "src/benchmarks/memory/adapters/*.ts",
+        "src/benchmarks/memory/public-datasets/*.ts",
+      ],
+      ignoreDependencies: [
+        // Loaded via dynamic _require() in execute-data-sources.ts.
+        "node-sql-parser",
+        // Activated by `vitest --coverage`.
+        "@vitest/coverage-v8",
+      ],
+    },
+    "packages/landing": {
+      entry: [
+        // Cloudflare Pages middleware — file-based routing.
+        "functions/_middleware.ts",
+        // Wired through a custom Astro plugin in astro.config.mjs.
+        "src/settings-mock/mock-api.ts",
+        "src/settings-mock/mock-context.tsx",
+        // Starlight customCss — referenced from astro.config.mjs.
+        "src/styles/starlight-shared.css",
+        "src/styles/starlight-theme.css",
+      ],
+      ignoreDependencies: [
+        "@preact/signals",
+        // Resolved via Astro alias (`@providers-config`).
+        "@providers-config",
+      ],
+    },
+    "packages/owletto-cli": {
+      entry: [
+        // Ambient module declaration; not imported.
+        "src/node-sqlite.ts",
+        // bun:test files in src/lib/.
+        "src/**/*.test.ts",
+      ],
+    },
+    "packages/cli": {
+      entry: [
+        // Tests in __tests__/ run via `bun test packages/cli` in CI.
+        "src/__tests__/**/*.test.ts",
+      ],
+    },
+    ".": {
+      entry: [
+        // CLI/utility scripts.
+        "scripts/**/*.{ts,mjs,js}",
+      ],
+    },
+  },
+};
+
+export default config;

--- a/packages/gateway/src/proxy/egress-judge/index.ts
+++ b/packages/gateway/src/proxy/egress-judge/index.ts
@@ -1,12 +1,6 @@
-export { AnthropicJudgeClient, parseVerdict } from "./anthropic-client.js";
-export { VerdictCache } from "./cache.js";
-export { CircuitBreaker } from "./circuit-breaker.js";
-export { DEFAULT_JUDGE_MODEL, EgressJudge } from "./judge.js";
-export type { EgressJudgeOptions } from "./judge.js";
-export { buildSystemPrompt, buildUserPrompt } from "./policy-composer.js";
+export { EgressJudge } from "./judge.js";
 export type {
   JudgeClient,
   JudgeDecision,
-  JudgeRequest,
   JudgeVerdict,
 } from "./types.js";

--- a/packages/owletto-backend/src/benchmarks/memory/query-expansion.ts
+++ b/packages/owletto-backend/src/benchmarks/memory/query-expansion.ts
@@ -1,1 +1,0 @@
-export { expandSearchQueries as expandBenchmarkQueries } from '../../utils/query-expansion';

--- a/packages/owletto-cli/src/lib/openclaw-auth.ts
+++ b/packages/owletto-cli/src/lib/openclaw-auth.ts
@@ -72,12 +72,12 @@ export function orgFromMcpUrl(mcpUrl: string): string | null {
   }
 }
 
-export function getOpenClawAuthStorePath(customPath?: string): string {
+function getOpenClawAuthStorePath(customPath?: string): string {
   return customPath ? resolve(customPath) : DEFAULT_STORE_PATH;
 }
 
 /** Load and migrate the auth store (handles old field names). */
-export function loadOpenClawAuthStore(storePath?: string): OpenClawAuthStore {
+function loadOpenClawAuthStore(storePath?: string): OpenClawAuthStore {
   const path = getOpenClawAuthStorePath(storePath);
   try {
     const raw = readFileSync(path, 'utf-8');
@@ -110,13 +110,13 @@ export function loadOpenClawAuthStore(storePath?: string): OpenClawAuthStore {
   }
 }
 
-export function saveOpenClawAuthStore(store: OpenClawAuthStore, storePath?: string) {
+function saveOpenClawAuthStore(store: OpenClawAuthStore, storePath?: string) {
   const path = getOpenClawAuthStorePath(storePath);
   mkdirSync(dirname(path), { recursive: true });
   writeFileSync(path, JSON.stringify(store, null, 2) + '\n', { mode: 0o600 });
 }
 
-export function getStoredSession(
+function getStoredSession(
   mcpUrl: string,
   storePath?: string
 ): { session: OpenClawOAuthSession | null; path: string } {

--- a/packages/owletto-connectors/package.json
+++ b/packages/owletto-connectors/package.json
@@ -5,7 +5,6 @@
   "license": "BUSL-1.1",
   "type": "module",
   "description": "Lobu memory connectors — third-party integration implementations built on @lobu/owletto-sdk",
-  "main": "src/index.ts",
   "scripts": {
     "typecheck": "tsc --noEmit"
   },


### PR DESCRIPTION
## Summary
- Knip ran without a config (`config/knip.ts` referenced in `package.json` didn't exist). Added one tuned for this monorepo's quirks (Chrome MV3 manifest, file-path-loaded connectors, dynamic imports, the owletto-web submodule, scripts/). Result: **0 unused files** vs. 33 before — false positives are now silenced so the remaining signal is real.
- Small cleanups for items that knip surfaced as genuine:
  - Trim `egress-judge/index.ts` barrel from 13 re-exports → 4 (rest had no consumers)
  - Drop `export` on 4 functions in `openclaw-auth.ts` only used inside the file
  - Remove broken `"main": "src/index.ts"` from `owletto-connectors/package.json`
  - Delete `benchmarks/memory/query-expansion.ts` (single-line re-export with no callers)

## Knip status after this PR
`bun run knip` still **exits 1** because of residue we are deliberately leaving for follow-up:
- ~6 unused exports + ~31 unused types (mostly in `owletto-backend` benchmarks/email and gateway routes)
- 7 unlisted dependencies (Bun-style `npm:` specifiers, hoisted `smol-toml`/`yaml`/`dotenv` in `scripts/`, `@settings/types` Astro alias)
- 2 unresolved imports (a stale cross-workspace test import, and `bun-types`)

These are real findings worth a separate triage pass — out of scope here.

Out of scope (separate repos/PRs):
- `packages/owletto-web` is a submodule; its knip findings ship via the submodule.

## Test plan
- [x] `bun run typecheck` — passes
- [x] `bun run check:fix` — clean
- [x] `bun run knip` — script is wired up and runs (was broken before this PR); 0 unused files reported