### PR TITLE
feat(backend,gateway): trigger repair agent thread on persistent feed failures

### DIFF
--- a/db/migrations/20260425130000_add_repair_agent_plumbing.sql
+++ b/db/migrations/20260425130000_add_repair_agent_plumbing.sql
@@ -1,0 +1,31 @@
+-- Repair-agent plumbing for connector reliability.
+--
+-- When a feed accumulates persistent failures, the worker-completion path
+-- can open a Lobu agent thread for triage. These columns track the
+-- per-feed override, the open thread (if any), the lifetime budget of
+-- repair attempts, the start of the current failure streak, and the
+-- last-posted content hash for append throttling.
+ALTER TABLE public.feeds
+  ADD COLUMN repair_agent_id text NULL,
+  ADD COLUMN repair_thread_id text NULL,
+  ADD COLUMN repair_attempt_count integer NOT NULL DEFAULT 0,
+  ADD COLUMN last_repair_at timestamp with time zone NULL,
+  ADD COLUMN first_failure_at timestamp with time zone NULL,
+  ADD COLUMN last_repair_post_hash text NULL;
+
+-- The unique partial index documents intent: a feed has at most one open
+-- repair thread at a time. (`feeds.id` is already PK so the constraint is
+-- redundant for uniqueness; the actual race guard is the conditional
+-- UPDATE on repair_thread_id IS NULL in the worker-completion path.)
+CREATE UNIQUE INDEX feeds_open_repair_thread_uniq
+  ON public.feeds (id) WHERE repair_thread_id IS NOT NULL;
+
+-- Per-connector default repair agent. When a feed has no explicit
+-- repair_agent_id, the trigger logic falls back to this value.
+ALTER TABLE public.connector_definitions
+  ADD COLUMN default_repair_agent_id text NULL;
+
+-- Per-org kill switch. When FALSE, no repair threads are opened for any
+-- feed in the org regardless of per-feed configuration.
+ALTER TABLE public.organization
+  ADD COLUMN repair_agents_enabled boolean NOT NULL DEFAULT TRUE;

--- a/packages/gateway/src/index.ts
+++ b/packages/gateway/src/index.ts
@@ -27,6 +27,14 @@ export type {
   RuntimeProviderCredentialResult,
 } from "./embedded.js";
 export { Gateway, type GatewayOptions } from "./gateway-main.js";
+export {
+  type CreateThreadForAgentArgs,
+  type CreateThreadForAgentResult,
+  createThreadForAgent,
+  type EnqueueAgentMessageArgs,
+  type EnqueueAgentMessageResult,
+  enqueueAgentMessage,
+} from "./services/agent-threads.js";
 export { CoreServices } from "./services/core-services.js";
 export {
   WatcherRunTracker,

--- a/packages/gateway/src/services/agent-threads.ts
+++ b/packages/gateway/src/services/agent-threads.ts
@@ -1,0 +1,175 @@
+/**
+ * Agent thread service — programmatic counterparts to the public HTTP routes
+ * `POST /api/v1/agents` (create thread/session) and `POST
+ * /api/v1/agents/:agentId/messages` (enqueue message).
+ *
+ * The HTTP routes in `routes/public/agent.ts` delegate the underlying work
+ * (session minting, queue enqueue) to these functions so that internal
+ * callers — for example the worker-completion path in `owletto-backend` —
+ * can open threads and post messages without going through HTTP.
+ *
+ * The functions here intentionally do NOT perform any HTTP-shaped auth
+ * (admin password, settings session, worker-token, OAuth, …). Callers are
+ * presumed to be inside the gateway's trust boundary; the public routes
+ * remain the single auth-gated entry point for external clients.
+ */
+import { randomUUID } from "node:crypto";
+import { createLogger, generateWorkerToken } from "@lobu/core";
+import type { QueueProducer } from "../infrastructure/queue/queue-producer.js";
+import type { ISessionManager, ThreadSession } from "../session.js";
+
+const logger = createLogger("agent-threads");
+
+/**
+ * Arguments for `createThreadForAgent`.
+ *
+ * Mirrors the shape of `POST /api/v1/agents` for the fields it needs to mint
+ * a session, but with no notion of provider/model/network/MCP overrides:
+ * internal callers always inherit the agent's stored settings.
+ */
+export interface CreateThreadForAgentArgs {
+  /** Target agent id. The session and resulting thread will be scoped to this agent. */
+  agentId: string;
+  /** Owning organization id (informational; persisted onto the session). */
+  organizationId: string;
+  /** Optional human-recorded principal that triggered the open. */
+  createdByUserId?: string;
+  /** Free-form reason tag for log lines (e.g. "connector-repair"). */
+  reason?: string;
+  /**
+   * Optional caller-supplied id for the new thread. Lets callers mint the id
+   * BEFORE writing it to their own state (e.g. an atomic UPDATE that wins
+   * against racing workers) and only then commit the session.
+   */
+  externalThreadId?: string;
+  /** User id to attribute the thread to. Defaults to `agentId`. */
+  userId?: string;
+}
+
+export interface CreateThreadForAgentResult {
+  /** Thread / session identifier (also referred to as `conversationId`). */
+  threadId: string;
+  /** Worker token usable by the caller's HTTP client (rarely needed internally). */
+  token: string;
+  /** Token expiration timestamp (ms since epoch). */
+  expiresAt: number;
+}
+
+const TOKEN_EXPIRATION_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * Mint a new thread session for an agent.
+ *
+ * Returns the threadId (== conversationId) without enqueueing any message.
+ * Callers wire follow-up state (e.g. `feeds.repair_thread_id = $threadId`)
+ * and then call {@link enqueueAgentMessage} to post the first message.
+ */
+export async function createThreadForAgent(
+  deps: { sessionManager: ISessionManager },
+  args: CreateThreadForAgentArgs
+): Promise<CreateThreadForAgentResult> {
+  const { sessionManager } = deps;
+  const { agentId, reason, externalThreadId } = args;
+  const userId = args.userId || args.createdByUserId || agentId;
+
+  const threadId = externalThreadId || randomUUID();
+  const conversationId = `${agentId}_${userId}_${threadId}`;
+  const channelId = `api_${userId}`;
+  const deploymentName = `api-${agentId.slice(0, 8)}`;
+
+  const token = generateWorkerToken(agentId, conversationId, deploymentName, {
+    channelId,
+    agentId,
+    platform: "api",
+    sessionKey: userId,
+  });
+  const expiresAt = Date.now() + TOKEN_EXPIRATION_MS;
+
+  const session: ThreadSession = {
+    conversationId,
+    channelId,
+    userId,
+    threadCreator: userId,
+    lastActivity: Date.now(),
+    createdAt: Date.now(),
+    status: "created",
+    provider: "claude",
+    agentId,
+    dryRun: false,
+    isEphemeral: false,
+  };
+  await sessionManager.setSession(session);
+
+  logger.info(
+    `Created thread ${conversationId} for agent ${agentId}${reason ? ` (reason=${reason})` : ""}`
+  );
+
+  return { threadId: conversationId, token, expiresAt };
+}
+
+export interface EnqueueAgentMessageArgs {
+  /** Thread id (conversationId) returned by `createThreadForAgent`. */
+  threadId: string;
+  /** Plain-text user message body. */
+  messageText: string;
+  /** Optional caller-supplied messageId (defaults to a fresh UUID). */
+  messageId?: string;
+  /** Free-form source tag for log lines / platformMetadata. */
+  source?: string;
+}
+
+export interface EnqueueAgentMessageResult {
+  messageId: string;
+  jobId: string;
+}
+
+/**
+ * Enqueue a message into an existing agent thread.
+ *
+ * Mirrors the direct-API path of `POST /api/v1/agents/:agentId/messages`:
+ * resolves the session, touches it, and dispatches a `MessagePayload` to
+ * the unified message queue. Throws if the thread does not exist.
+ */
+export async function enqueueAgentMessage(
+  deps: { sessionManager: ISessionManager; queueProducer: QueueProducer },
+  args: EnqueueAgentMessageArgs
+): Promise<EnqueueAgentMessageResult> {
+  const { sessionManager, queueProducer } = deps;
+  const { threadId, messageText } = args;
+  const messageId = args.messageId || randomUUID();
+
+  const session = await sessionManager.getSession(threadId);
+  if (!session) {
+    throw new Error(`Thread ${threadId} not found`);
+  }
+
+  await sessionManager.touchSession(threadId);
+
+  const realAgentId = session.agentId || threadId;
+  const channelId = session.channelId || `api_${session.userId}`;
+
+  const jobId = await queueProducer.enqueueMessage({
+    userId: session.userId,
+    conversationId: session.conversationId || threadId,
+    messageId,
+    channelId,
+    teamId: "api",
+    agentId: realAgentId,
+    botId: "lobu-api",
+    platform: "api",
+    messageText,
+    platformMetadata: {
+      agentId: realAgentId,
+      source: args.source || "internal",
+      dryRun: session.dryRun || false,
+    },
+    agentOptions: {
+      provider: session.provider || "claude",
+      model: session.model,
+    },
+    networkConfig: session.networkConfig,
+    mcpConfig: session.mcpConfig,
+  });
+
+  return { messageId, jobId };
+}

--- a/packages/owletto-backend/src/__tests__/unit/connectors/repair-agent.test.ts
+++ b/packages/owletto-backend/src/__tests__/unit/connectors/repair-agent.test.ts
@@ -1,0 +1,382 @@
+import { beforeEach, describe, expect, it, mock } from 'bun:test';
+import type { DbClient } from '../../../db/client';
+import {
+  hashFailureSignature,
+  maybeOpenOrAppendRepairThread,
+  type RepairAgentConfig,
+} from '../../../connectors/repair-agent';
+import {
+  buildOpenPacket,
+  type DiagnosticRunRow,
+} from '../../../connectors/repair-agent-packet';
+
+/**
+ * Build a tagged-template mock that matches each invocation against an
+ * ordered queue of `(matcher, response)` pairs. Each matcher is a substring
+ * of the SQL it should fire on — the first whose pattern is contained in
+ * the joined template strings is consumed and returns its rows.
+ *
+ * If no pattern matches, throws — surfaces unexpected queries instead of
+ * silently returning empty.
+ */
+function makeMockSql(plan: Array<{ match: string | RegExp; rows: any[] }>): {
+  sql: DbClient;
+  remaining: () => number;
+  log: string[];
+} {
+  const queue = [...plan];
+  const log: string[] = [];
+  const fn = ((strings: TemplateStringsArray, ..._values: unknown[]) => {
+    const joined = strings.join('?');
+    log.push(joined.trim().split(/\s+/).slice(0, 8).join(' '));
+    const idx = queue.findIndex((item) =>
+      typeof item.match === 'string'
+        ? joined.includes(item.match)
+        : item.match.test(joined)
+    );
+    if (idx === -1) {
+      throw new Error(`unexpected query: ${joined.slice(0, 120)}`);
+    }
+    const [{ rows }] = queue.splice(idx, 1);
+    const result = Object.assign(Promise.resolve(rows), {
+      count: rows.length,
+    }) as any;
+    return result;
+  }) as DbClient;
+  fn.unsafe = (() => {
+    throw new Error('unsafe() not supported by mock');
+  }) as any;
+  fn.array = ((values: any) => values) as any;
+  fn.json = ((value: any) => value) as any;
+  fn.begin = (async (cb: any) => cb(fn)) as any;
+  return { sql: fn, remaining: () => queue.length, log };
+}
+
+const TEST_CONFIG: RepairAgentConfig = {
+  threshold: 3,
+  minFailingDurationMs: 30 * 60 * 1000,
+  maxAttempts: 5,
+  cooldownMs: 6 * 60 * 60 * 1000,
+};
+
+const NOW = Date.UTC(2026, 3, 25, 12, 0, 0); // 2026-04-25 12:00:00 UTC
+const FRESH_FIRST_FAILURE = new Date(NOW - TEST_CONFIG.minFailingDurationMs - 60 * 1000); // 31 min ago
+
+function feedRow(overrides: Partial<Record<string, any>> = {}): any {
+  return {
+    id: 42,
+    organization_id: 'org-1',
+    consecutive_failures: 3,
+    first_failure_at: FRESH_FIRST_FAILURE,
+    repair_thread_id: null,
+    repair_attempt_count: 0,
+    last_repair_at: null,
+    repair_agent_id: 'repair-agent',
+    display_name: 'My Feed',
+    config: { foo: 'bar' },
+    schedule: '0 */6 * * *',
+    connection_id: 7,
+    connector_key: 'gmail',
+    connection_display_name: 'Gmail',
+    auth_profile_status: 'active',
+    connector_name: 'Gmail',
+    connector_version: '1.2.3',
+    default_repair_agent_id: null,
+    org_repair_enabled: true,
+    ...overrides,
+  };
+}
+
+const RUN_ROW = {
+  id: 99,
+  status: 'failed',
+  started_at: new Date(NOW - 5 * 60 * 1000),
+  completed_at: new Date(NOW),
+  error_message: 'token expired',
+  exit_reason: 'error_message',
+  exit_code: 1,
+  exit_signal: null,
+  output_tail: 'gmail: 401 Unauthorized\n  at refreshToken (auth.ts:42)',
+};
+
+function fakeServices() {
+  const createThreadForAgent = mock(async () => ({ threadId: 'mock-thread' }));
+  const enqueueAgentMessage = mock(async () => ({ jobId: 'job-1', messageId: 'msg-1' }));
+  return {
+    createThreadForAgent,
+    enqueueAgentMessage,
+    sessionManager: {} as any,
+    queueProducer: {} as any,
+  };
+}
+
+describe('maybeOpenOrAppendRepairThread', () => {
+  let services: ReturnType<typeof fakeServices>;
+
+  beforeEach(() => {
+    services = fakeServices();
+  });
+
+  it('opens a thread when threshold met and cooldown clear (UPDATE wins)', async () => {
+    const { sql } = makeMockSql([
+      { match: 'FROM feeds f', rows: [feedRow()] },
+      { match: 'FROM runs', rows: [RUN_ROW] },
+      { match: 'UPDATE feeds', rows: [{ repair_thread_id: 'mock-conv' }] },
+    ]);
+
+    await maybeOpenOrAppendRepairThread(42, 99, {
+      sql,
+      services,
+      config: TEST_CONFIG,
+      now: () => NOW,
+      mintThreadId: () => 'fixed-thread-id',
+    });
+
+    expect(services.createThreadForAgent).toHaveBeenCalledTimes(1);
+    expect(services.enqueueAgentMessage).toHaveBeenCalledTimes(1);
+    const enqueueArg = services.enqueueAgentMessage.mock.calls[0][1] as any;
+    expect(enqueueArg.threadId).toBe('repair-agent_repair-agent_fixed-thread-id');
+    expect(enqueueArg.messageText).toContain('A connector feed sync has been failing');
+    expect(enqueueArg.messageText).toContain('consecutive_failures: 3');
+  });
+
+  it('skips when cooldown is active', async () => {
+    const recentRepair = new Date(NOW - TEST_CONFIG.cooldownMs / 2);
+    const { sql, remaining } = makeMockSql([
+      {
+        match: 'FROM feeds f',
+        rows: [
+          feedRow({
+            repair_attempt_count: 1,
+            last_repair_at: recentRepair,
+          }),
+        ],
+      },
+      { match: 'FROM runs', rows: [RUN_ROW] },
+    ]);
+
+    await maybeOpenOrAppendRepairThread(42, 99, {
+      sql,
+      services,
+      config: TEST_CONFIG,
+      now: () => NOW,
+    });
+
+    expect(services.createThreadForAgent).not.toHaveBeenCalled();
+    expect(services.enqueueAgentMessage).not.toHaveBeenCalled();
+    // Both queued queries should have been consumed: state load + recent runs.
+    expect(remaining()).toBe(0);
+  });
+
+  it('skips when threshold not yet met', async () => {
+    const { sql } = makeMockSql([
+      { match: 'FROM feeds f', rows: [feedRow({ consecutive_failures: 2 })] },
+      { match: 'FROM runs', rows: [RUN_ROW] },
+    ]);
+    await maybeOpenOrAppendRepairThread(42, 99, {
+      sql,
+      services,
+      config: TEST_CONFIG,
+      now: () => NOW,
+    });
+    expect(services.createThreadForAgent).not.toHaveBeenCalled();
+  });
+
+  it('skips when first_failure_at is too recent', async () => {
+    const { sql } = makeMockSql([
+      {
+        match: 'FROM feeds f',
+        rows: [
+          feedRow({
+            first_failure_at: new Date(NOW - 60 * 1000), // 1 min ago
+          }),
+        ],
+      },
+      { match: 'FROM runs', rows: [RUN_ROW] },
+    ]);
+    await maybeOpenOrAppendRepairThread(42, 99, {
+      sql,
+      services,
+      config: TEST_CONFIG,
+      now: () => NOW,
+    });
+    expect(services.createThreadForAgent).not.toHaveBeenCalled();
+  });
+
+  it('pauses feed (no thread) when repair_attempt_count is at the cap', async () => {
+    const { sql } = makeMockSql([
+      {
+        match: 'FROM feeds f',
+        rows: [feedRow({ repair_attempt_count: TEST_CONFIG.maxAttempts })],
+      },
+      { match: 'FROM runs', rows: [RUN_ROW] },
+      { match: "status = 'paused'", rows: [{ id: 42 }] },
+    ]);
+    await maybeOpenOrAppendRepairThread(42, 99, {
+      sql,
+      services,
+      config: TEST_CONFIG,
+      now: () => NOW,
+    });
+    expect(services.createThreadForAgent).not.toHaveBeenCalled();
+  });
+
+  it('skips when org has repair agents disabled', async () => {
+    const { sql, remaining } = makeMockSql([
+      { match: 'FROM feeds f', rows: [feedRow({ org_repair_enabled: false })] },
+    ]);
+    await maybeOpenOrAppendRepairThread(42, 99, {
+      sql,
+      services,
+      config: TEST_CONFIG,
+      now: () => NOW,
+    });
+    expect(services.createThreadForAgent).not.toHaveBeenCalled();
+    // We never even loaded recent runs.
+    expect(remaining()).toBe(0);
+  });
+
+  it('only one of two racing callers wins the atomic UPDATE', async () => {
+    // Caller A: load_state + recent_runs + UPDATE returns 1 row (won)
+    const callA = makeMockSql([
+      { match: 'FROM feeds f', rows: [feedRow()] },
+      { match: 'FROM runs', rows: [RUN_ROW] },
+      { match: 'UPDATE feeds', rows: [{ repair_thread_id: 'won' }] },
+    ]);
+    // Caller B: same gating passes, but the UPDATE returns 0 rows because
+    // caller A already filled in repair_thread_id.
+    const callB = makeMockSql([
+      { match: 'FROM feeds f', rows: [feedRow()] },
+      { match: 'FROM runs', rows: [RUN_ROW] },
+      { match: 'UPDATE feeds', rows: [] },
+    ]);
+
+    const servicesA = fakeServices();
+    const servicesB = fakeServices();
+
+    await Promise.all([
+      maybeOpenOrAppendRepairThread(42, 99, {
+        sql: callA.sql,
+        services: servicesA,
+        config: TEST_CONFIG,
+        now: () => NOW,
+      }),
+      maybeOpenOrAppendRepairThread(42, 99, {
+        sql: callB.sql,
+        services: servicesB,
+        config: TEST_CONFIG,
+        now: () => NOW,
+      }),
+    ]);
+
+    expect(servicesA.createThreadForAgent).toHaveBeenCalledTimes(1);
+    expect(servicesA.enqueueAgentMessage).toHaveBeenCalledTimes(1);
+    expect(servicesB.createThreadForAgent).not.toHaveBeenCalled();
+    expect(servicesB.enqueueAgentMessage).not.toHaveBeenCalled();
+  });
+});
+
+describe('hashFailureSignature', () => {
+  it('returns the same hash for identical signatures', () => {
+    const a: DiagnosticRunRow = {
+      id: 1,
+      status: 'failed',
+      startedAt: null,
+      completedAt: null,
+      durationMs: null,
+      errorMessage: 'boom',
+      exitReason: 'error_message',
+      exitCode: 1,
+      exitSignal: null,
+      outputTail: 'tail',
+    };
+    const b = { ...a, id: 2 };
+    expect(hashFailureSignature(a)).toEqual(hashFailureSignature(b));
+  });
+
+  it('differs when output_tail differs', () => {
+    const a: DiagnosticRunRow = {
+      id: 1,
+      status: 'failed',
+      startedAt: null,
+      completedAt: null,
+      durationMs: null,
+      errorMessage: 'boom',
+      exitReason: 'error_message',
+      exitCode: 1,
+      exitSignal: null,
+      outputTail: 'tail-a',
+    };
+    const b = { ...a, outputTail: 'tail-b' };
+    expect(hashFailureSignature(a)).not.toEqual(hashFailureSignature(b));
+  });
+});
+
+describe('buildOpenPacket', () => {
+  it('preserves the worker-redacted output_tail verbatim and does not introduce raw values from elsewhere', () => {
+    // Worker-side redaction replaces secrets with a sentinel like
+    // `[REDACTED:bearer]`. The packet builder must NOT mention any raw
+    // value — it has access only to the row fields it's handed, all of
+    // which are already redacted by the worker.
+    const REDACTED_TAIL = [
+      'gmail: response { Authorization: [REDACTED:bearer] }',
+      'token=[REDACTED:apiKey]',
+      'cookie=[REDACTED:cookie]',
+    ].join('\n');
+
+    const packet = buildOpenPacket({
+      feedId: 42,
+      feedDisplayName: 'My Feed',
+      connectorKey: 'gmail',
+      connectorName: 'Gmail',
+      connectorVersion: '1.2.3',
+      feedConfig: { folder: 'INBOX' },
+      feedSchedule: '0 */6 * * *',
+      consecutiveFailures: 4,
+      firstFailureAt: '2026-04-25T11:00:00.000Z',
+      connectionId: 7,
+      connectionDisplayName: 'Gmail (work)',
+      authProfileStatus: 'active',
+      recentRuns: [
+        {
+          id: 99,
+          status: 'failed',
+          startedAt: '2026-04-25T11:55:00.000Z',
+          completedAt: '2026-04-25T12:00:00.000Z',
+          durationMs: 300000,
+          errorMessage: 'token expired',
+          exitReason: 'error_message',
+          exitCode: 1,
+          exitSignal: null,
+          outputTail: REDACTED_TAIL,
+        },
+      ],
+    });
+
+    // The redacted sentinels MUST appear verbatim — if they didn't, the
+    // builder lost the worker's redaction.
+    expect(packet).toContain('[REDACTED:bearer]');
+    expect(packet).toContain('[REDACTED:apiKey]');
+    expect(packet).toContain('[REDACTED:cookie]');
+
+    // Things the builder MUST NOT invent / inject from elsewhere:
+    //   - actual bearer / api key / cookie values
+    //   - any hard-coded credential string
+    // These would mean the builder pulled raw data from outside the row.
+    const forbiddenSubstrings = [
+      'Authorization: Bearer ', // unredacted bearer header
+      'sk-ant-', // anthropic key prefix
+      'AKIA', // AWS access key prefix
+      'eyJhbGc', // JWT prefix
+    ];
+    for (const needle of forbiddenSubstrings) {
+      expect(packet).not.toContain(needle);
+    }
+
+    // Structural smoke checks.
+    expect(packet).toContain('Connector feed repair — Gmail / My Feed');
+    expect(packet).toContain('consecutive_failures: 4');
+    expect(packet).toContain('first_failure_at: 2026-04-25T11:00:00.000Z');
+    expect(packet).toContain('connector-source MCP tool');
+  });
+});

--- a/packages/owletto-backend/src/connectors/repair-agent-packet.ts
+++ b/packages/owletto-backend/src/connectors/repair-agent-packet.ts
@@ -1,0 +1,126 @@
+/**
+ * Diagnostic packet builders for connector repair threads.
+ *
+ * The packet is plain text; the agent reads it as a regular user message.
+ * No new schema is invented here — all fields come from existing run/feed
+ * rows. `output_tail` is already redacted by the worker before it reaches
+ * the backend (see PR 1's diagnostic substrate); the builder MUST NOT
+ * source raw values from anywhere else.
+ */
+
+export interface DiagnosticRunRow {
+  id: number;
+  status: string;
+  startedAt: string | null;
+  completedAt: string | null;
+  durationMs: number | null;
+  errorMessage: string | null;
+  exitReason: string | null;
+  exitCode: number | null;
+  exitSignal: string | null;
+  outputTail: string | null;
+}
+
+export interface OpenPacketInput {
+  feedId: number;
+  feedDisplayName: string | null;
+  connectorKey: string | null;
+  connectorName: string | null;
+  connectorVersion: string | null;
+  feedConfig: Record<string, unknown> | null;
+  feedSchedule: string | null;
+  consecutiveFailures: number;
+  firstFailureAt: string | null;
+  connectionId: number | null;
+  connectionDisplayName: string | null;
+  authProfileStatus: string | null;
+  recentRuns: DiagnosticRunRow[];
+}
+
+function fmtRun(run: DiagnosticRunRow): string {
+  const lines: string[] = [];
+  lines.push(`- id: ${run.id}`);
+  lines.push(`  status: ${run.status}`);
+  if (run.startedAt) lines.push(`  started_at: ${run.startedAt}`);
+  if (run.completedAt) lines.push(`  completed_at: ${run.completedAt}`);
+  if (run.durationMs != null) lines.push(`  duration_ms: ${run.durationMs}`);
+  if (run.errorMessage) lines.push(`  error_message: ${run.errorMessage}`);
+  if (run.exitReason) lines.push(`  exit_reason: ${run.exitReason}`);
+  if (run.exitCode != null) lines.push(`  exit_code: ${run.exitCode}`);
+  if (run.exitSignal) lines.push(`  exit_signal: ${run.exitSignal}`);
+  if (run.outputTail) {
+    lines.push('  output_tail: |');
+    for (const tailLine of run.outputTail.split('\n')) {
+      lines.push(`    ${tailLine}`);
+    }
+  }
+  return lines.join('\n');
+}
+
+export function buildOpenPacket(input: OpenPacketInput): string {
+  const connectorLabel = input.connectorName || input.connectorKey || 'unknown';
+  const feedLabel = input.feedDisplayName || `feed#${input.feedId}`;
+
+  const sections: string[] = [];
+  sections.push(`Title: Connector feed repair — ${connectorLabel} / ${feedLabel}`);
+  sections.push('');
+  sections.push(
+    'A connector feed sync has been failing repeatedly. Diagnose the cause and, if you can, fix it.'
+  );
+  sections.push('');
+
+  const feedLines: string[] = [];
+  feedLines.push('Feed');
+  feedLines.push(`- id: ${input.feedId}`);
+  if (input.connectorKey) feedLines.push(`- connector_key: ${input.connectorKey}`);
+  if (input.connectorVersion) feedLines.push(`- connector_version: ${input.connectorVersion}`);
+  feedLines.push(`- config: ${input.feedConfig ? JSON.stringify(input.feedConfig) : 'null'}`);
+  feedLines.push(`- schedule: ${input.feedSchedule ?? 'null'}`);
+  feedLines.push(`- consecutive_failures: ${input.consecutiveFailures}`);
+  feedLines.push(`- first_failure_at: ${input.firstFailureAt ?? 'null'}`);
+  sections.push(feedLines.join('\n'));
+  sections.push('');
+
+  if (input.connectionId != null) {
+    const connLines: string[] = [];
+    connLines.push('Connection');
+    connLines.push(`- id: ${input.connectionId}`);
+    if (input.connectionDisplayName)
+      connLines.push(`- display_name: ${input.connectionDisplayName}`);
+    if (input.authProfileStatus)
+      connLines.push(`- auth_profile_status: ${input.authProfileStatus}`);
+    sections.push(connLines.join('\n'));
+    sections.push('');
+  }
+
+  sections.push(`Recent runs (most recent first, up to ${input.recentRuns.length}):`);
+  for (const run of input.recentRuns) sections.push(fmtRun(run));
+  sections.push('');
+
+  const cdLines: string[] = [];
+  cdLines.push('Connector definition');
+  cdLines.push(`- name: ${input.connectorName ?? 'unknown'}`);
+  cdLines.push(`- version: ${input.connectorVersion ?? 'unknown'}`);
+  cdLines.push(
+    '- source: fetch via the connector-source MCP tool when needed (not inlined here)'
+  );
+  sections.push(cdLines.join('\n'));
+  sections.push('');
+
+  sections.push(
+    'You have access to the manage_feeds, manage_connections, manage_operations, query_sql, and connector-source CRUD tools. Investigate the cause; if it is in the connector code, propose or apply a fix per the org\'s policy. If you make any change, run a single test sync after to verify.'
+  );
+
+  return sections.join('\n');
+}
+
+export function buildAppendPacket(input: {
+  consecutiveFailures: number;
+  run: DiagnosticRunRow;
+}): string {
+  return [
+    `Still failing — ${input.consecutiveFailures} consecutive failures, latest run below.`,
+    '',
+    fmtRun(input.run),
+  ].join('\n');
+}

--- a/packages/owletto-backend/src/connectors/repair-agent.ts
+++ b/packages/owletto-backend/src/connectors/repair-agent.ts
@@ -253,6 +253,12 @@ export async function maybeOpenOrAppendRepairThread(
   }
   if (!state) return;
 
+  // Defensive: this function is only meant to fire after the worker-api
+  // failure path has incremented consecutive_failures, but a future caller
+  // path could violate that. Bail at <= 0 so the bucket=0 claim slot
+  // doesn't get consumed before the first real failure.
+  if (state.consecutive_failures <= 0) return;
+
   if (!state.org_repair_enabled) {
     logger.debug(
       { feed_id: feedId, org: state.organization_id },
@@ -265,30 +271,48 @@ export async function maybeOpenOrAppendRepairThread(
   // The completed run we were called for is the canonical signature source —
   // not whichever run happens to be at the top of recentRuns. Out-of-order
   // worker completions (later run finishes before an earlier one) would
-  // otherwise attach the wrong run's diagnostics.
-  const completedRun = recentRuns.find((r) => r.id === runId) ?? recentRuns[0] ?? null;
+  // otherwise attach the wrong run's diagnostics. If the runId we were
+  // called for isn't yet visible in the recent runs (DB read raced the
+  // INSERT), skip silently — the next failure cron will pick it up.
+  const completedRun = recentRuns.find((r) => r.id === runId) ?? null;
 
   // Branch 1: Thread already open — consider appending.
   if (state.repair_thread_id) {
-    if (!completedRun) return;
-    const hash = hashFailureSignature(completedRun);
-    const isMultipleOf5 = state.consecutive_failures > 0 && state.consecutive_failures % 5 === 0;
+    if (!completedRun) {
+      logger.debug(
+        { feed_id: feedId, run_id: runId },
+        '[repair-agent] completed run not yet visible in recent_runs — skipping append'
+      );
+      return;
+    }
+    // Encode (signature, ceil-floor-of-5 bucket) into the claim key so the
+    // dedupe is purely IS-DISTINCT-FROM and doesn't need an OR-clause that
+    // would let concurrent workers both win on multiples of 5. Same hash
+    // within the same 5-failure bucket → same key → only one UPDATE wins;
+    // signature changes OR crossing a 5-boundary → key changes → next post
+    // fires once.
+    //   consec 1..4  → `${hash}@0`   (initial post)
+    //   consec 5..9  → `${hash}@5`   (every-5th override fires once at 5)
+    //   consec 10..14→ `${hash}@10`  (every-5th override fires once at 10)
+    const baseHash = hashFailureSignature(completedRun);
+    const bucket = Math.floor(state.consecutive_failures / 5) * 5;
+    const claimKey = `${baseHash}@${bucket}`;
 
-    // Atomic dedupe: claim the new hash in one UPDATE that's a no-op when
-    // another concurrent worker just wrote the same hash. Prevents two
+    // Atomic dedupe: claim the new key in one UPDATE that's a no-op when
+    // another concurrent worker just wrote the same key. Prevents two
     // workers from observing the same `last_repair_post_hash` and both
     // posting duplicate appends.
     const claimRows = (await sql`
       UPDATE feeds
-      SET last_repair_post_hash = ${hash}
+      SET last_repair_post_hash = ${claimKey}
       WHERE id = ${feedId}
-        AND (last_repair_post_hash IS DISTINCT FROM ${hash} OR ${isMultipleOf5})
+        AND last_repair_post_hash IS DISTINCT FROM ${claimKey}
       RETURNING last_repair_post_hash
     `) as unknown as Array<{ last_repair_post_hash: string | null }>;
     if (claimRows.length === 0) {
       logger.debug(
-        { feed_id: feedId, hash },
-        '[repair-agent] suppressing append — same failure signature claimed by another worker'
+        { feed_id: feedId, claim_key: claimKey },
+        '[repair-agent] suppressing append — same claim key already recorded'
       );
       return;
     }

--- a/packages/owletto-backend/src/connectors/repair-agent.ts
+++ b/packages/owletto-backend/src/connectors/repair-agent.ts
@@ -363,6 +363,12 @@ export async function maybeOpenOrAppendRepairThread(
   const externalThreadId = mint();
   const conversationId = `${repairAgentId}_${userId}_${externalThreadId}`;
 
+  // All gates re-checked atomically inside the UPDATE, not just the
+  // already-read JS values. Stale readers (e.g. another worker that loaded
+  // state before a manual pause / budget reset) cannot win the claim if any
+  // gate has flipped between the read and the UPDATE.
+  const minFailingDurationSeconds = Math.floor(cfg.minFailingDurationMs / 1000);
+  const cooldownSeconds = Math.floor(cfg.cooldownMs / 1000);
   let won = false;
   try {
     const claim = (await sql`
@@ -373,6 +379,16 @@ export async function maybeOpenOrAppendRepairThread(
           updated_at = current_timestamp
       WHERE id = ${feedId}
         AND repair_thread_id IS NULL
+        AND status <> 'paused'
+        AND consecutive_failures >= ${cfg.threshold}
+        AND first_failure_at IS NOT NULL
+        AND first_failure_at <= current_timestamp - make_interval(secs => ${minFailingDurationSeconds})
+        AND (last_repair_at IS NULL
+             OR last_repair_at <= current_timestamp - make_interval(secs => ${cooldownSeconds}))
+        AND repair_attempt_count < ${cfg.maxAttempts}
+        AND organization_id IN (
+          SELECT id FROM organization WHERE id = ${state.organization_id} AND repair_agents_enabled = TRUE
+        )
       RETURNING repair_thread_id
     `) as unknown as Array<{ repair_thread_id: string | null }>;
     won = claim.length > 0;
@@ -453,40 +469,39 @@ export async function maybeCloseRepairThread(
 ): Promise<void> {
   const sql = deps.sql ?? getDb();
 
-  let openThreadId: string | null = null;
+  // Atomic claim: only the caller whose UPDATE actually clears the row sees
+  // the previously-open thread id. The `consecutive_failures = 0` guard
+  // ensures a stale success completion arriving AFTER a new failure has
+  // restarted the streak does not erase the new failure state.
+  let claimedThreadId: string | null = null;
   try {
     const rows = (await sql`
-      SELECT repair_thread_id FROM feeds WHERE id = ${feedId} LIMIT 1
-    `) as unknown as Array<{ repair_thread_id: string | null }>;
-    openThreadId = rows[0]?.repair_thread_id ?? null;
-  } catch (error) {
-    logger.error(
-      { feed_id: feedId, error: String(error) },
-      '[repair-agent] failed to read repair_thread_id on success'
-    );
-    return;
-  }
-
-  // Always clear first_failure_at and last_repair_post_hash on success — the
-  // streak is over regardless of whether a thread was open.
-  try {
-    await sql`
-      UPDATE feeds
+      WITH old AS (
+        SELECT id, repair_thread_id
+        FROM feeds
+        WHERE id = ${feedId}
+          AND consecutive_failures = 0
+        FOR UPDATE
+      )
+      UPDATE feeds f
       SET first_failure_at = NULL,
           last_repair_post_hash = NULL,
           repair_thread_id = NULL,
           updated_at = current_timestamp
-      WHERE id = ${feedId}
-    `;
+      FROM old
+      WHERE f.id = old.id
+      RETURNING old.repair_thread_id
+    `) as unknown as Array<{ repair_thread_id: string | null }>;
+    claimedThreadId = rows[0]?.repair_thread_id ?? null;
   } catch (error) {
     logger.error(
       { feed_id: feedId, error: String(error) },
-      '[repair-agent] failed to clear streak state on success'
+      '[repair-agent] failed to atomically clear streak state on success'
     );
     return;
   }
 
-  if (!openThreadId) return;
+  if (!claimedThreadId) return;
 
   const services = deps.services ?? (await loadCallableServices());
   if (!services) return;
@@ -495,18 +510,18 @@ export async function maybeCloseRepairThread(
     await services.enqueueAgentMessage(
       { sessionManager: services.sessionManager, queueProducer: services.queueProducer },
       {
-        threadId: openThreadId,
+        threadId: claimedThreadId,
         messageText: `Resolved: feed has resumed successfully (run id ${runId})`,
         source: 'connector-repair',
       }
     );
     logger.info(
-      { feed_id: feedId, thread_id: openThreadId, run_id: runId },
+      { feed_id: feedId, thread_id: claimedThreadId, run_id: runId },
       '[repair-agent] posted resolved message and cleared open thread'
     );
   } catch (error) {
     logger.error(
-      { feed_id: feedId, thread_id: openThreadId, error: String(error) },
+      { feed_id: feedId, thread_id: claimedThreadId, error: String(error) },
       '[repair-agent] failed to post resolved message'
     );
   }

--- a/packages/owletto-backend/src/connectors/repair-agent.ts
+++ b/packages/owletto-backend/src/connectors/repair-agent.ts
@@ -262,21 +262,33 @@ export async function maybeOpenOrAppendRepairThread(
   }
 
   const recentRuns = await loadRecentRuns(sql, feedId, 10);
-  const latestRun = recentRuns[0] ?? null;
+  // The completed run we were called for is the canonical signature source —
+  // not whichever run happens to be at the top of recentRuns. Out-of-order
+  // worker completions (later run finishes before an earlier one) would
+  // otherwise attach the wrong run's diagnostics.
+  const completedRun = recentRuns.find((r) => r.id === runId) ?? recentRuns[0] ?? null;
 
   // Branch 1: Thread already open — consider appending.
   if (state.repair_thread_id) {
-    if (!latestRun) return;
-    const hash = hashFailureSignature(latestRun);
+    if (!completedRun) return;
+    const hash = hashFailureSignature(completedRun);
     const isMultipleOf5 = state.consecutive_failures > 0 && state.consecutive_failures % 5 === 0;
-    const lastHashRows = (await sql`
-      SELECT last_repair_post_hash FROM feeds WHERE id = ${feedId} LIMIT 1
+
+    // Atomic dedupe: claim the new hash in one UPDATE that's a no-op when
+    // another concurrent worker just wrote the same hash. Prevents two
+    // workers from observing the same `last_repair_post_hash` and both
+    // posting duplicate appends.
+    const claimRows = (await sql`
+      UPDATE feeds
+      SET last_repair_post_hash = ${hash}
+      WHERE id = ${feedId}
+        AND (last_repair_post_hash IS DISTINCT FROM ${hash} OR ${isMultipleOf5})
+      RETURNING last_repair_post_hash
     `) as unknown as Array<{ last_repair_post_hash: string | null }>;
-    const lastHash = lastHashRows[0]?.last_repair_post_hash ?? null;
-    if (hash === lastHash && !isMultipleOf5) {
+    if (claimRows.length === 0) {
       logger.debug(
         { feed_id: feedId, hash },
-        '[repair-agent] suppressing append — same failure signature, no every-5th override'
+        '[repair-agent] suppressing append — same failure signature claimed by another worker'
       );
       return;
     }
@@ -287,15 +299,12 @@ export async function maybeOpenOrAppendRepairThread(
     try {
       const packet = buildAppendPacket({
         consecutiveFailures: state.consecutive_failures,
-        run: latestRun,
+        run: completedRun,
       });
       await services.enqueueAgentMessage(
         { sessionManager: services.sessionManager, queueProducer: services.queueProducer },
         { threadId: state.repair_thread_id, messageText: packet, source: 'connector-repair' }
       );
-      await sql`
-        UPDATE feeds SET last_repair_post_hash = ${hash} WHERE id = ${feedId}
-      `;
       logger.info(
         { feed_id: feedId, thread_id: state.repair_thread_id, run_id: runId },
         '[repair-agent] appended failure to existing repair thread'

--- a/packages/owletto-backend/src/connectors/repair-agent.ts
+++ b/packages/owletto-backend/src/connectors/repair-agent.ts
@@ -1,0 +1,513 @@
+/**
+ * Connector repair-agent triggers.
+ *
+ * When a feed accumulates persistent failures, the worker-completion path
+ * calls `maybeOpenOrAppendRepairThread` to (a) decide whether to open a
+ * Lobu agent thread for triage, (b) win an atomic UPDATE so racing workers
+ * don't double-open, and (c) post the diagnostic packet to the resulting
+ * thread. On success after a streak, `maybeCloseRepairThread` posts a
+ * one-line "resolved" message and clears the open-thread pointer.
+ *
+ * The trigger logic is deliberately conservative: bounded retries, a
+ * cooldown window, a per-feed first-failure-duration gate, and a per-org
+ * kill switch all prevent runaway behavior.
+ */
+import { createHash, randomUUID } from 'node:crypto';
+import { type DbClient, getDb } from '../db/client';
+import { getLobuCoreServices } from '../lobu/gateway';
+import logger from '../utils/logger';
+import {
+  type DiagnosticRunRow,
+  buildAppendPacket,
+  buildOpenPacket,
+} from './repair-agent-packet';
+
+const DEFAULT_THRESHOLD = 3;
+const DEFAULT_MIN_FAILING_MS = 30 * 60 * 1000; // 30 min
+const DEFAULT_MAX_ATTEMPTS = 5;
+const DEFAULT_COOLDOWN_MS = 6 * 60 * 60 * 1000; // 6 hours
+
+function envInt(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (!raw) return fallback;
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+export interface RepairAgentConfig {
+  threshold: number;
+  minFailingDurationMs: number;
+  maxAttempts: number;
+  cooldownMs: number;
+}
+
+export function loadRepairConfigFromEnv(): RepairAgentConfig {
+  return {
+    threshold: envInt('CONNECTOR_REPAIR_THRESHOLD', DEFAULT_THRESHOLD),
+    minFailingDurationMs: envInt('CONNECTOR_REPAIR_MIN_FAILING_MS', DEFAULT_MIN_FAILING_MS),
+    maxAttempts: envInt('CONNECTOR_REPAIR_MAX_ATTEMPTS', DEFAULT_MAX_ATTEMPTS),
+    cooldownMs: envInt('CONNECTOR_REPAIR_COOLDOWN_MS', DEFAULT_COOLDOWN_MS),
+  };
+}
+
+interface FeedState {
+  id: number;
+  organization_id: string;
+  consecutive_failures: number;
+  first_failure_at: Date | null;
+  repair_thread_id: string | null;
+  repair_attempt_count: number;
+  last_repair_at: Date | null;
+  repair_agent_id: string | null;
+  connector_key: string | null;
+  display_name: string | null;
+  config: Record<string, unknown> | null;
+  schedule: string | null;
+  default_repair_agent_id: string | null;
+  org_repair_enabled: boolean;
+  connection_id: number | null;
+  connection_display_name: string | null;
+  auth_profile_status: string | null;
+  connector_name: string | null;
+  connector_version: string | null;
+}
+
+async function loadFeedState(
+  sql: DbClient,
+  feedId: number
+): Promise<FeedState | null> {
+  // Pick the most-specific connector definition for the feed:
+  //   1. org-scoped + active row (idx_connector_defs_org_key)
+  //   2. system-level + active row (idx_connector_defs_system_key)
+  // The DISTINCT ON + ORDER BY ensures exactly one cd row per feed and gives
+  // org-specific definitions priority.
+  const rows = (await sql`
+    SELECT * FROM (
+      SELECT DISTINCT ON (f.id)
+        f.id,
+        f.organization_id,
+        f.consecutive_failures,
+        f.first_failure_at,
+        f.repair_thread_id,
+        f.repair_attempt_count,
+        f.last_repair_at,
+        f.repair_agent_id,
+        f.display_name,
+        f.config,
+        f.schedule,
+        c.id AS connection_id,
+        c.connector_key,
+        c.display_name AS connection_display_name,
+        ap.status AS auth_profile_status,
+        cd.name AS connector_name,
+        cd.version AS connector_version,
+        cd.default_repair_agent_id,
+        org.repair_agents_enabled AS org_repair_enabled
+      FROM feeds f
+      LEFT JOIN connections c ON c.id = f.connection_id
+      LEFT JOIN auth_profiles ap ON ap.id = c.auth_profile_id
+      LEFT JOIN connector_definitions cd ON cd.key = c.connector_key
+        AND cd.status = 'active'
+        AND (cd.organization_id = f.organization_id OR cd.organization_id IS NULL)
+      LEFT JOIN organization org ON org.id = f.organization_id
+      WHERE f.id = ${feedId}
+      ORDER BY f.id,
+               (cd.organization_id IS NULL) ASC -- org-specific first
+    ) sub
+    LIMIT 1
+  `) as unknown as Array<FeedState>;
+  return rows[0] ?? null;
+}
+
+async function loadRecentRuns(
+  sql: DbClient,
+  feedId: number,
+  limit = 10
+): Promise<DiagnosticRunRow[]> {
+  const rows = (await sql`
+    SELECT id, status, started_at, completed_at, error_message,
+           exit_reason, exit_code, exit_signal, output_tail
+    FROM runs
+    WHERE feed_id = ${feedId}
+    ORDER BY id DESC
+    LIMIT ${limit}
+  `) as unknown as Array<{
+    id: number;
+    status: string;
+    started_at: Date | null;
+    completed_at: Date | null;
+    error_message: string | null;
+    exit_reason: string | null;
+    exit_code: number | null;
+    exit_signal: string | null;
+    output_tail: string | null;
+  }>;
+  return rows.map((r) => ({
+    id: Number(r.id),
+    status: r.status,
+    startedAt: r.started_at ? new Date(r.started_at).toISOString() : null,
+    completedAt: r.completed_at ? new Date(r.completed_at).toISOString() : null,
+    durationMs:
+      r.started_at && r.completed_at
+        ? new Date(r.completed_at).getTime() - new Date(r.started_at).getTime()
+        : null,
+    errorMessage: r.error_message,
+    exitReason: r.exit_reason,
+    exitCode: r.exit_code,
+    exitSignal: r.exit_signal,
+    outputTail: r.output_tail,
+  }));
+}
+
+function resolveRepairAgentId(state: FeedState): string | null {
+  if (state.repair_agent_id) return state.repair_agent_id;
+  if (state.default_repair_agent_id) return state.default_repair_agent_id;
+  return null;
+}
+
+/**
+ * Hash the run's failure signature so repeated identical failures don't spam
+ * the thread. Combines `error_message`, `exit_reason`, and a hash of
+ * `output_tail` (which itself is already redacted by the worker).
+ */
+export function hashFailureSignature(run: DiagnosticRunRow): string {
+  const tailHash = run.outputTail
+    ? createHash('sha256').update(run.outputTail).digest('hex')
+    : '';
+  return createHash('sha256')
+    .update([run.errorMessage ?? '', run.exitReason ?? '', tailHash].join('\x1f'))
+    .digest('hex');
+}
+
+interface CallableServices {
+  sessionManager: any;
+  queueProducer: any;
+  createThreadForAgent: (deps: any, args: any) => Promise<{ threadId: string }>;
+  enqueueAgentMessage: (deps: any, args: any) => Promise<unknown>;
+}
+
+async function loadCallableServices(): Promise<CallableServices | null> {
+  const core = getLobuCoreServices();
+  if (!core) return null;
+  try {
+    const mod = await import('@lobu/gateway');
+    return {
+      sessionManager: core.getSessionManager(),
+      queueProducer: core.getQueueProducer(),
+      createThreadForAgent: mod.createThreadForAgent,
+      enqueueAgentMessage: mod.enqueueAgentMessage,
+    };
+  } catch (error) {
+    logger.warn(
+      { error: String(error) },
+      '[repair-agent] embedded gateway not available — skipping repair trigger'
+    );
+    return null;
+  }
+}
+
+export interface RepairTriggerDeps {
+  /** Override the gateway services (used in tests). */
+  services?: CallableServices;
+  /** Override the env-loaded config (used in tests). */
+  config?: RepairAgentConfig;
+  /** Override the wall clock (used in tests). */
+  now?: () => number;
+  /** Override the DB client (used in tests). */
+  sql?: DbClient;
+  /** Override thread id minting (used in tests for deterministic ids). */
+  mintThreadId?: () => string;
+}
+
+/**
+ * Decide and execute the repair-thread side effects for a feed that just
+ * had its `consecutive_failures` incremented.
+ *
+ * Called from `worker-api.ts:completeWorkerJob` after the feed UPDATE.
+ *
+ * - If no thread is open and the gating conditions hold, opens a new thread
+ *   via an atomic UPDATE on `feeds(repair_thread_id IS NULL)` to win against
+ *   racing workers, then enqueues the diagnostic packet.
+ * - If a thread is already open, optionally appends the new failure
+ *   subject to a content-hash + every-Nth-failure throttle.
+ * - On the cap, pauses the feed and stops.
+ *
+ * All errors are logged and swallowed — the repair trigger must never
+ * block the worker-completion path.
+ */
+export async function maybeOpenOrAppendRepairThread(
+  feedId: number,
+  runId: number,
+  deps: RepairTriggerDeps = {}
+): Promise<void> {
+  const cfg = deps.config ?? loadRepairConfigFromEnv();
+  const now = deps.now ?? (() => Date.now());
+  const sql = deps.sql ?? getDb();
+
+  let state: FeedState | null;
+  try {
+    state = await loadFeedState(sql, feedId);
+  } catch (error) {
+    logger.error({ feed_id: feedId, error: String(error) }, '[repair-agent] failed to load feed state');
+    return;
+  }
+  if (!state) return;
+
+  if (!state.org_repair_enabled) {
+    logger.debug(
+      { feed_id: feedId, org: state.organization_id },
+      '[repair-agent] org has repair agents disabled — skipping'
+    );
+    return;
+  }
+
+  const recentRuns = await loadRecentRuns(sql, feedId, 10);
+  const latestRun = recentRuns[0] ?? null;
+
+  // Branch 1: Thread already open — consider appending.
+  if (state.repair_thread_id) {
+    if (!latestRun) return;
+    const hash = hashFailureSignature(latestRun);
+    const isMultipleOf5 = state.consecutive_failures > 0 && state.consecutive_failures % 5 === 0;
+    const lastHashRows = (await sql`
+      SELECT last_repair_post_hash FROM feeds WHERE id = ${feedId} LIMIT 1
+    `) as unknown as Array<{ last_repair_post_hash: string | null }>;
+    const lastHash = lastHashRows[0]?.last_repair_post_hash ?? null;
+    if (hash === lastHash && !isMultipleOf5) {
+      logger.debug(
+        { feed_id: feedId, hash },
+        '[repair-agent] suppressing append — same failure signature, no every-5th override'
+      );
+      return;
+    }
+
+    const services = deps.services ?? (await loadCallableServices());
+    if (!services) return;
+
+    try {
+      const packet = buildAppendPacket({
+        consecutiveFailures: state.consecutive_failures,
+        run: latestRun,
+      });
+      await services.enqueueAgentMessage(
+        { sessionManager: services.sessionManager, queueProducer: services.queueProducer },
+        { threadId: state.repair_thread_id, messageText: packet, source: 'connector-repair' }
+      );
+      await sql`
+        UPDATE feeds SET last_repair_post_hash = ${hash} WHERE id = ${feedId}
+      `;
+      logger.info(
+        { feed_id: feedId, thread_id: state.repair_thread_id, run_id: runId },
+        '[repair-agent] appended failure to existing repair thread'
+      );
+    } catch (error) {
+      logger.error(
+        { feed_id: feedId, error: String(error) },
+        '[repair-agent] failed to append to existing thread'
+      );
+    }
+    return;
+  }
+
+  // Branch 2: No thread — check gating conditions.
+  if (state.consecutive_failures < cfg.threshold) return;
+  if (
+    !state.first_failure_at ||
+    now() - new Date(state.first_failure_at).getTime() < cfg.minFailingDurationMs
+  ) {
+    return;
+  }
+  if (
+    state.last_repair_at &&
+    now() - new Date(state.last_repair_at).getTime() < cfg.cooldownMs
+  ) {
+    return;
+  }
+
+  if (state.repair_attempt_count >= cfg.maxAttempts) {
+    // Lifetime budget exhausted — pause the feed and stop.
+    try {
+      await sql`
+        UPDATE feeds
+        SET status = 'paused', next_run_at = NULL, updated_at = current_timestamp
+        WHERE id = ${feedId} AND status <> 'paused'
+      `;
+      logger.warn(
+        { feed_id: feedId, attempt_count: state.repair_attempt_count },
+        '[repair-agent] repair budget exhausted — paused feed'
+      );
+    } catch (error) {
+      logger.error(
+        { feed_id: feedId, error: String(error) },
+        '[repair-agent] failed to pause feed at budget cap'
+      );
+    }
+    return;
+  }
+
+  const repairAgentId = resolveRepairAgentId(state);
+  if (!repairAgentId) {
+    logger.debug({ feed_id: feedId }, '[repair-agent] no repair agent resolves — skipping');
+    return;
+  }
+
+  const services = deps.services ?? (await loadCallableServices());
+  if (!services) return;
+
+  // Mint the thread id BEFORE the atomic UPDATE so we can race-guard on
+  // `feeds.repair_thread_id IS NULL`. Only after winning do we materialize
+  // the session and enqueue. Losing workers exit silently — no orphan
+  // session is created.
+  const userId = repairAgentId;
+  const mint = deps.mintThreadId ?? (() => randomUUID());
+  const externalThreadId = mint();
+  const conversationId = `${repairAgentId}_${userId}_${externalThreadId}`;
+
+  let won = false;
+  try {
+    const claim = (await sql`
+      UPDATE feeds
+      SET repair_thread_id = ${conversationId},
+          repair_attempt_count = repair_attempt_count + 1,
+          last_repair_at = current_timestamp,
+          updated_at = current_timestamp
+      WHERE id = ${feedId}
+        AND repair_thread_id IS NULL
+      RETURNING repair_thread_id
+    `) as unknown as Array<{ repair_thread_id: string | null }>;
+    won = claim.length > 0;
+  } catch (error) {
+    logger.error(
+      { feed_id: feedId, error: String(error) },
+      '[repair-agent] atomic UPDATE failed'
+    );
+    return;
+  }
+
+  if (!won) {
+    logger.debug({ feed_id: feedId }, '[repair-agent] another worker won the open — skipping');
+    return;
+  }
+
+  try {
+    await services.createThreadForAgent(
+      { sessionManager: services.sessionManager },
+      {
+        agentId: repairAgentId,
+        organizationId: state.organization_id,
+        userId,
+        externalThreadId,
+        reason: 'connector-repair',
+      }
+    );
+    const packet = buildOpenPacket({
+      feedId: state.id,
+      feedDisplayName: state.display_name,
+      connectorKey: state.connector_key,
+      connectorName: state.connector_name,
+      connectorVersion: state.connector_version,
+      feedConfig: state.config,
+      feedSchedule: state.schedule,
+      consecutiveFailures: state.consecutive_failures,
+      firstFailureAt: state.first_failure_at
+        ? new Date(state.first_failure_at).toISOString()
+        : null,
+      connectionId: state.connection_id,
+      connectionDisplayName: state.connection_display_name,
+      authProfileStatus: state.auth_profile_status,
+      recentRuns,
+    });
+    await services.enqueueAgentMessage(
+      { sessionManager: services.sessionManager, queueProducer: services.queueProducer },
+      { threadId: conversationId, messageText: packet, source: 'connector-repair' }
+    );
+    logger.info(
+      {
+        feed_id: feedId,
+        thread_id: conversationId,
+        run_id: runId,
+        repair_agent_id: repairAgentId,
+      },
+      '[repair-agent] opened repair thread'
+    );
+  } catch (error) {
+    logger.error(
+      { feed_id: feedId, thread_id: conversationId, error: String(error) },
+      '[repair-agent] thread create/enqueue failed after winning UPDATE — thread row left in feeds.repair_thread_id; will be retried on next failure if cleared'
+    );
+  }
+}
+
+/**
+ * Called from `completeWorkerJob` on a successful run that resets
+ * `consecutive_failures` to zero. Posts a one-line "resolved" message to
+ * the open repair thread (if any) and clears the open-thread pointer.
+ *
+ * Note: `repair_attempt_count` is intentionally NOT reset — that field is
+ * the lifetime budget. Operators can reset it manually if they want.
+ */
+export async function maybeCloseRepairThread(
+  feedId: number,
+  runId: number,
+  deps: RepairTriggerDeps = {}
+): Promise<void> {
+  const sql = deps.sql ?? getDb();
+
+  let openThreadId: string | null = null;
+  try {
+    const rows = (await sql`
+      SELECT repair_thread_id FROM feeds WHERE id = ${feedId} LIMIT 1
+    `) as unknown as Array<{ repair_thread_id: string | null }>;
+    openThreadId = rows[0]?.repair_thread_id ?? null;
+  } catch (error) {
+    logger.error(
+      { feed_id: feedId, error: String(error) },
+      '[repair-agent] failed to read repair_thread_id on success'
+    );
+    return;
+  }
+
+  // Always clear first_failure_at and last_repair_post_hash on success — the
+  // streak is over regardless of whether a thread was open.
+  try {
+    await sql`
+      UPDATE feeds
+      SET first_failure_at = NULL,
+          last_repair_post_hash = NULL,
+          repair_thread_id = NULL,
+          updated_at = current_timestamp
+      WHERE id = ${feedId}
+    `;
+  } catch (error) {
+    logger.error(
+      { feed_id: feedId, error: String(error) },
+      '[repair-agent] failed to clear streak state on success'
+    );
+    return;
+  }
+
+  if (!openThreadId) return;
+
+  const services = deps.services ?? (await loadCallableServices());
+  if (!services) return;
+
+  try {
+    await services.enqueueAgentMessage(
+      { sessionManager: services.sessionManager, queueProducer: services.queueProducer },
+      {
+        threadId: openThreadId,
+        messageText: `Resolved: feed has resumed successfully (run id ${runId})`,
+        source: 'connector-repair',
+      }
+    );
+    logger.info(
+      { feed_id: feedId, thread_id: openThreadId, run_id: runId },
+      '[repair-agent] posted resolved message and cleared open thread'
+    );
+  } catch (error) {
+    logger.error(
+      { feed_id: feedId, thread_id: openThreadId, error: String(error) },
+      '[repair-agent] failed to post resolved message'
+    );
+  }
+}

--- a/packages/owletto-backend/src/worker-api.ts
+++ b/packages/owletto-backend/src/worker-api.ts
@@ -14,6 +14,10 @@ import { notifyBrowserAuthExpired } from './notifications/triggers';
 import { materializeDueFeeds } from './scheduled/check-due-feeds';
 import { supersedeActionEvent } from './tools/admin/manage_operations';
 import { getAuthProfileById, getBrowserSessionReadiness } from './utils/auth-profiles';
+import {
+  maybeCloseRepairThread,
+  maybeOpenOrAppendRepairThread,
+} from './connectors/repair-agent';
 import { autoLinkEvent } from './utils/auto-linker';
 import { nextRunAt as nextRunAtFromCron } from './utils/cron';
 import { resolveConnectorCode } from './utils/ensure-connector-installed';
@@ -504,12 +508,32 @@ export async function completeWorkerJob(c: Context<{ Bindings: Env }>) {
             last_sync_status = ${req.status},
             last_error = ${isSuccess ? null : (req.error_message ?? null)},
             consecutive_failures = ${isSuccess ? sql`0` : sql`consecutive_failures + 1`},
+            first_failure_at = ${isSuccess ? sql`NULL` : sql`COALESCE(first_failure_at, current_timestamp)`},
             items_collected = ${isSuccess ? sql`items_collected + ${req.items_collected ?? 0}` : sql`items_collected`},
             checkpoint = ${isSuccess ? sql`COALESCE(${req.checkpoint ? sql.json(req.checkpoint) : null}, checkpoint)` : sql`checkpoint`},
             next_run_at = ${nextRun},
             updated_at = current_timestamp
         WHERE id = ${feedId}
       `;
+
+      // Repair-agent trigger: open / append / close threads based on the
+      // updated streak state. All errors swallowed inside the helper — must
+      // never block the worker-completion path.
+      if (isSuccess) {
+        await maybeCloseRepairThread(feedId, req.run_id).catch((err) => {
+          logger.warn(
+            { feed_id: feedId, error: errorMessage(err) },
+            '[completeWorkerJob] maybeCloseRepairThread threw'
+          );
+        });
+      } else {
+        await maybeOpenOrAppendRepairThread(feedId, req.run_id).catch((err) => {
+          logger.warn(
+            { feed_id: feedId, error: errorMessage(err) },
+            '[completeWorkerJob] maybeOpenOrAppendRepairThread threw'
+          );
+        });
+      }
     }
 
     // Persist refreshed browser auth data on the auth profile


### PR DESCRIPTION
## Summary

PR 2 of the connector reliability initiative. When a feed accumulates
persistent failures, the worker-completion path now opens (or appends to)
a Lobu agent thread that has the diagnostic context needed to triage the
failure. On a success that resets the streak, posts a "resolved" message
and clears the open thread.

Stacked on #376; rebase to main once #376 merges.

- Schema migration: `feeds.repair_*` (agent_id, thread_id, attempt_count,
  last_repair_at, first_failure_at, last_repair_post_hash);
  `connector_definitions.default_repair_agent_id`;
  `organization.repair_agents_enabled` (per-org kill switch).
- Gateway: extract `createThreadForAgent` and `enqueueAgentMessage` as
  callable primitives in `services/agent-threads.ts` so internal callers
  can mint sessions without HTTP. Existing public routes unchanged.
- Backend: `maybeOpenOrAppendRepairThread` + `maybeCloseRepairThread` fire
  from `completeWorkerJob` after the `consecutive_failures` UPDATE.
  - Open path uses an atomic conditional UPDATE on
    `feeds(id WHERE repair_thread_id IS NULL)` to win against racing workers.
  - Append path throttles by content hash of `(error_message, exit_reason,
    sha256(output_tail))` plus an every-5th-failure override.
  - At the lifetime cap (`CONNECTOR_REPAIR_MAX_ATTEMPTS=5`), pauses the
    feed instead of opening another thread.
- Resolution order for repair agent id: `feeds.repair_agent_id` →
  `connector_definitions.default_repair_agent_id` → none.
- Tunable env vars (defaults shown):
  `CONNECTOR_REPAIR_THRESHOLD=3`,
  `CONNECTOR_REPAIR_MIN_FAILING_MS=1800000` (30 min),
  `CONNECTOR_REPAIR_MAX_ATTEMPTS=5`,
  `CONNECTOR_REPAIR_COOLDOWN_MS=21600000` (6 hours).

## Out of scope

- No UI changes. Agent picker on feed/connector pages is a separate PR
  (lives in `packages/owletto-web`, two-PR submodule ship).
- No new MCP tools — agent uses existing `manage_feeds`,
  `manage_connections`, `manage_operations`, `query_sql`, `connector-source`.
- No changes to the auth-run path or PR 1's diagnostic substrate.

## Test plan

- [x] `bun run typecheck` passes
- [x] `make build-packages` passes
- [x] Unit tests cover: threshold met but cooldown active → no thread;
      threshold met and cooldown clear → thread opened (atomic UPDATE wins);
      racing call → only one wins (mocked thread-creation);
      threshold not met; first-failure too recent; budget cap pauses feed;
      org kill switch.
- [x] Packet builder test verifies worker-redacted output_tail is
      preserved verbatim and no raw secrets are sourced from elsewhere.
- [ ] Manual smoke test against a live feed in a dev cluster.