### PR TITLE
feat(worker,backend): forward subprocess diagnostics on auth-run failures

### DIFF
--- a/packages/owletto-backend/src/worker-api.ts
+++ b/packages/owletto-backend/src/worker-api.ts
@@ -823,19 +823,40 @@ export async function completeAuthRun(c: Context<{ Bindings: Env }>) {
       credentials?: Record<string, unknown>;
       metadata?: Record<string, unknown>;
       error_message?: string;
+      // Diagnostic fields from the subprocess executor (failed-run path only).
+      // The worker redacts output_tail before sending; backend stores as-is.
+      output_tail?: string;
+      exit_code?: number | null;
+      exit_signal?: string | null;
+      exit_reason?: 'ok' | 'error_message' | 'timeout' | 'oom' | 'crash';
     }>();
 
     const sql = getDb();
 
-    const runRows = (await sql`
+    const runRows =
+      req.status === 'failed'
+        ? ((await sql`
       UPDATE runs
-      SET status = ${req.status === 'success' ? 'completed' : 'failed'},
+      SET status = 'failed',
+          completed_at = current_timestamp,
+          error_message = ${req.error_message ?? null},
+          auth_signal = NULL,
+          output_tail = ${req.output_tail ?? null},
+          exit_code = ${req.exit_code ?? null},
+          exit_signal = ${req.exit_signal ?? null},
+          exit_reason = ${req.exit_reason ?? null}
+      WHERE id = ${req.run_id}
+      RETURNING auth_profile_id, organization_id
+    `) as Array<{ auth_profile_id: number | null; organization_id: string }>)
+        : ((await sql`
+      UPDATE runs
+      SET status = 'completed',
           completed_at = current_timestamp,
           error_message = ${req.error_message ?? null},
           auth_signal = NULL
       WHERE id = ${req.run_id}
       RETURNING auth_profile_id, organization_id
-    `) as Array<{ auth_profile_id: number | null; organization_id: string }>;
+    `) as Array<{ auth_profile_id: number | null; organization_id: string }>);
 
     const authProfileId = runRows[0]?.auth_profile_id ?? null;
     const organizationId = runRows[0]?.organization_id;

--- a/packages/owletto-worker/src/daemon/client.ts
+++ b/packages/owletto-worker/src/daemon/client.ts
@@ -198,6 +198,14 @@ export interface CompleteAuthRequest {
   credentials?: Record<string, unknown>;
   metadata?: Record<string, unknown>;
   error_message?: string;
+  /** Tail of subprocess stdout+stderr (already redacted in the worker). */
+  output_tail?: string;
+  /** Subprocess exit code, if the child terminated without an IPC result. */
+  exit_code?: number | null;
+  /** Subprocess exit signal, if any. */
+  exit_signal?: string | null;
+  /** Categorized exit reason: ok | error_message | timeout | oom | crash. */
+  exit_reason?: 'ok' | 'error_message' | 'timeout' | 'oom' | 'crash';
 }
 
 /**

--- a/packages/owletto-worker/src/daemon/executor.ts
+++ b/packages/owletto-worker/src/daemon/executor.ts
@@ -440,12 +440,16 @@ async function executeAuthRun(
     clearInterval(heartbeatInterval);
     const errorMessage = error instanceof Error ? error.message : String(error);
     console.error(`[executor] Auth run ${run_id} failed:`, errorMessage);
+
+    const diag = extractSubprocessDiagnostics(error);
+
     try {
       await client.completeAuth({
         run_id,
         worker_id: client.id,
         status: 'failed',
         error_message: errorMessage,
+        ...(diag ?? {}),
       });
     } catch (completeErr) {
       console.error('[executor] completeAuth after failure errored:', completeErr);


### PR DESCRIPTION
## Summary

Stacked on #376; rebase to main once #376 merges.

PR 1 (#376) added subprocess diagnostic capture (`output_tail`, `exit_code`, `exit_signal`, `exit_reason`) for normal connector feed runs by instrumenting `client.complete()` → `/api/workers/complete` → `UPDATE runs ... WHERE id = run_id`. It explicitly scoped out the **auth-run** path (interactive `connector.authenticate()` flows like WhatsApp QR / OAuth dance).

This PR closes that gap. The auth-run completion path (`client.completeAuth()` → `/api/workers/complete-auth` → `UPDATE runs WHERE id = run_id AND run_type='auth'`) now persists the same four diagnostic fields when the worker subprocess crashes before producing a typed terminal IPC message.

- **Worker (`executor.ts`)**: catch block of `executeAuthRun()` invokes the existing `extractSubprocessDiagnostics()` helper added in PR 1 and forwards the four fields on the failed `client.completeAuth(...)` call.
- **Worker (`client.ts`)**: `CompleteAuthRequest` DTO gains `output_tail`, `exit_code`, `exit_signal`, `exit_reason` (all nullable), mirroring the `CompleteRequest` extension from PR 1.
- **Backend (`worker-api.ts`)**: `completeAuthRun()` parses the four fields and writes them on the failed-status `UPDATE runs`. Success path untouched.

**No new migration.** Auth runs live in the same `runs` table as sync runs (`run_type='auth'`), so PR 1's `db/migrations/20260425120000_add_run_diagnostics.sql` already provides the columns.

## Test plan

- [x] `bun run typecheck` — passes
- [x] `make build-packages` — passes
- [x] Pre-commit hooks (Biome + tsc) — pass
- [ ] Manual: trigger an auth run that crashes the subprocess (e.g. throw inside `authenticate()`); verify the `runs` row has populated `output_tail` / `exit_code` / `exit_signal` / `exit_reason` instead of just the bare wrapper string.
- [ ] Manual: confirm successful auth runs still complete cleanly with no diagnostic columns set.