### PR TITLE
feat(backend): expose repair-agent fields on feed/connector/org APIs

### DIFF
--- a/packages/owletto-backend/src/auth/tool-access.ts
+++ b/packages/owletto-backend/src/auth/tool-access.ts
@@ -38,6 +38,7 @@ const OWNER_ADMIN_ACTIONS: Record<string, Set<string>> = {
     'toggle_connector_login',
     'update_connector_auth',
     'update_connector_default_config',
+    'update_connector_default_repair_agent',
     'set_connector_entity_link_overrides',
   ]),
   manage_feeds: new Set(['create_feed', 'update_feed', 'delete_feed', 'trigger_feed']),
@@ -70,6 +71,7 @@ const OWNER_ADMIN_ACTIONS: Record<string, Set<string>> = {
     'classify',
   ]),
   manage_view_templates: new Set(['set', 'rollback', 'remove_tab']),
+  manage_organization: new Set(['get_settings', 'update_settings']),
 };
 
 const PUBLIC_READ_ACTIONS: Record<string, Set<string> | null> = {

--- a/packages/owletto-backend/src/tools/admin/connector-definition-helpers.ts
+++ b/packages/owletto-backend/src/tools/admin/connector-definition-helpers.ts
@@ -36,6 +36,7 @@ export type ScopedConnectorDefinitionRow = {
   favicon_domain?: string | null;
   source_path?: string | null;
   default_connection_config?: Record<string, unknown> | null;
+  default_repair_agent_id?: string | null;
   status: string;
   login_enabled?: boolean | null;
   created_at?: string;
@@ -85,6 +86,7 @@ export async function listScopedConnectorDefinitions(params: {
       d.openapi_config,
       d.favicon_domain,
       d.default_connection_config,
+      d.default_repair_agent_id,
       d.status,
       d.login_enabled,
       d.created_at,

--- a/packages/owletto-backend/src/tools/admin/index.ts
+++ b/packages/owletto-backend/src/tools/admin/index.ts
@@ -13,6 +13,7 @@ import { ManageEntitySchema, manageEntity } from './manage_entity';
 import { ManageEntitySchemaSchema, manageEntitySchema } from './manage_entity_schema';
 import { ManageFeedsSchema, manageFeeds } from './manage_feeds';
 import { ManageOperationsSchema, manageOperations } from './manage_operations';
+import { ManageOrganizationSchema, manageOrganization } from './manage_organization';
 import { ManageViewTemplatesSchema, manageViewTemplates } from './manage_view_templates';
 import { ManageWatchersSchema, manageWatchers } from './manage_watchers';
 
@@ -120,6 +121,17 @@ export const LEGACY_ADMIN_TOOLS: ToolDefinition[] = [
     internal: true,
     handler: async (args: Static<typeof ManageViewTemplatesSchema>, env: Env, ctx: ToolContext) => {
       return await manageViewTemplates(args, env, ctx);
+    },
+  },
+  {
+    name: 'manage_organization',
+    description:
+      'Org-scoped settings (e.g. connector repair-agent kill switch). Frontend-only tool today; external MCP clients should not depend on this surface.',
+    inputSchema: ManageOrganizationSchema,
+    annotations: { destructiveHint: false },
+    internal: true,
+    handler: async (args: Static<typeof ManageOrganizationSchema>, _env: Env, ctx: ToolContext) => {
+      return await manageOrganization(args, ctx);
     },
   },
 ];

--- a/packages/owletto-backend/src/tools/admin/manage_connections.ts
+++ b/packages/owletto-backend/src/tools/admin/manage_connections.ts
@@ -256,6 +256,15 @@ const SetConnectorEntityLinkOverridesAction = Type.Object({
   overrides: EntityLinkOverridesSchema,
 });
 
+const UpdateConnectorDefaultRepairAgentAction = Type.Object({
+  action: Type.Literal('update_connector_default_repair_agent'),
+  connector_key: Type.String({ description: 'Connector key' }),
+  default_repair_agent_id: Type.Union([Type.String(), Type.Null()], {
+    description:
+      'Default repair agent ID for feeds of this connector. Null clears the default.',
+  }),
+});
+
 export const ManageConnectionsSchema = Type.Union([
   ListAction,
   ListConnectorDefinitionsAction,
@@ -271,6 +280,7 @@ export const ManageConnectionsSchema = Type.Union([
   ToggleConnectorLoginAction,
   UpdateConnectorAuthAction,
   UpdateConnectorDefaultConfigAction,
+  UpdateConnectorDefaultRepairAgentAction,
   SetConnectorEntityLinkOverridesAction,
 ]);
 
@@ -354,6 +364,12 @@ type ManageConnectionsResult =
       connector_key: string;
     }
   | {
+      action: 'update_connector_default_repair_agent';
+      success: true;
+      connector_key: string;
+      default_repair_agent_id: string | null;
+    }
+  | {
       action: 'set_connector_entity_link_overrides';
       success: true;
       connector_key: string;
@@ -410,6 +426,14 @@ export async function manageConnections(
     update_connector_default_config: () =>
       handleUpdateConnectorDefaultConfig(
         args as Extract<ConnectionsArgs, { action: 'update_connector_default_config' }>,
+        ctx
+      ),
+    update_connector_default_repair_agent: () =>
+      handleUpdateConnectorDefaultRepairAgent(
+        args as Extract<
+          ConnectionsArgs,
+          { action: 'update_connector_default_repair_agent' }
+        >,
         ctx
       ),
     set_connector_entity_link_overrides: () =>
@@ -1778,6 +1802,35 @@ async function handleUpdateConnectorDefaultConfig(
     action: 'update_connector_default_config',
     success: true,
     connector_key: args.connector_key,
+  };
+}
+
+async function handleUpdateConnectorDefaultRepairAgent(
+  args: Extract<ConnectionsArgs, { action: 'update_connector_default_repair_agent' }>,
+  ctx: ToolContext
+): Promise<ManageConnectionsResult> {
+  const sql = getDb();
+  const { organizationId } = ctx;
+
+  const updated = await sql`
+    UPDATE connector_definitions
+    SET default_repair_agent_id = ${args.default_repair_agent_id}::text,
+        updated_at = NOW()
+    WHERE key = ${args.connector_key}
+      AND organization_id = ${organizationId}
+      AND status = 'active'
+    RETURNING key
+  `;
+
+  if (updated.length === 0) {
+    return { error: `Connector '${args.connector_key}' not found` };
+  }
+
+  return {
+    action: 'update_connector_default_repair_agent',
+    success: true,
+    connector_key: args.connector_key,
+    default_repair_agent_id: args.default_repair_agent_id,
   };
 }
 

--- a/packages/owletto-backend/src/tools/admin/manage_feeds.ts
+++ b/packages/owletto-backend/src/tools/admin/manage_feeds.ts
@@ -69,6 +69,12 @@ const UpdateFeedAction = Type.Object({
   entity_ids: Type.Optional(Type.Array(Type.Number())),
   config: Type.Optional(Type.Record(Type.String(), Type.Any())),
   schedule: Type.Optional(Type.String({ description: 'Cron expression for sync schedule' })),
+  repair_agent_id: Type.Optional(
+    Type.Union([Type.String(), Type.Null()], {
+      description:
+        'Per-feed repair agent override. Null clears the override and falls back to the connector default.',
+    })
+  ),
 });
 
 const DeleteFeedAction = Type.Object({
@@ -335,6 +341,11 @@ async function handleUpdateFeed(
     }
   }
 
+  // `repair_agent_id` is tri-state: undefined = leave alone, null = clear, string = set.
+  // Use Object.hasOwn so an explicit null overwrites instead of being skipped.
+  const hasRepairAgentArg = Object.hasOwn(args, 'repair_agent_id');
+  const repairAgentValue = hasRepairAgentArg ? (args.repair_agent_id ?? null) : null;
+
   const updated = await sql`
     UPDATE feeds
     SET display_name = COALESCE(${args.display_name ?? null}::text, display_name),
@@ -343,6 +354,7 @@ async function handleUpdateFeed(
         config = CASE WHEN ${args.config ? sql.json(args.config) : null}::jsonb IS NOT NULL THEN COALESCE(config, '{}'::jsonb) || ${args.config ? sql.json(args.config) : null}::jsonb ELSE config END,
         schedule = COALESCE(${args.schedule ?? null}::text, schedule),
         next_run_at = CASE WHEN ${args.schedule ?? null}::text IS NOT NULL THEN ${args.schedule ? nextRunAt(args.schedule) : null}::timestamptz ELSE next_run_at END,
+        repair_agent_id = CASE WHEN ${hasRepairAgentArg} THEN ${repairAgentValue}::text ELSE repair_agent_id END,
         updated_at = NOW()
     WHERE id = ${args.feed_id} AND organization_id = ${organizationId}
     RETURNING *

--- a/packages/owletto-backend/src/tools/admin/manage_organization.ts
+++ b/packages/owletto-backend/src/tools/admin/manage_organization.ts
@@ -1,0 +1,128 @@
+/**
+ * Tool: manage_organization
+ *
+ * Org-scoped settings (toggles + small flags). Today this surfaces the
+ * connector repair-agent kill switch; new org-level toggles should land
+ * here rather than scattered into bespoke routes.
+ *
+ * Actions:
+ * - get_settings: Read the org settings record.
+ * - update_settings: Patch the editable fields (caller-provided fields only).
+ */
+
+import { type Static, Type } from '@sinclair/typebox';
+import { getDb } from '../../db/client';
+import type { ToolContext } from '../registry';
+import { routeAction } from './action-router';
+
+// ============================================
+// Schema
+// ============================================
+
+const GetSettingsAction = Type.Object({
+  action: Type.Literal('get_settings'),
+});
+
+const UpdateSettingsAction = Type.Object({
+  action: Type.Literal('update_settings'),
+  repair_agents_enabled: Type.Optional(
+    Type.Boolean({
+      description:
+        'Per-org kill switch for connector repair agents. When false, no repair threads are opened for any feed in the org regardless of per-feed configuration.',
+    })
+  ),
+});
+
+export const ManageOrganizationSchema = Type.Union([GetSettingsAction, UpdateSettingsAction]);
+
+// ============================================
+// Result Types
+// ============================================
+
+export interface OrganizationSettings {
+  organization_id: string;
+  repair_agents_enabled: boolean;
+}
+
+type ManageOrganizationResult =
+  | { error: string }
+  | { action: 'get_settings'; settings: OrganizationSettings }
+  | { action: 'update_settings'; settings: OrganizationSettings };
+
+type OrganizationArgs = Static<typeof ManageOrganizationSchema>;
+
+// ============================================
+// Main Function (Action Router)
+// ============================================
+
+export async function manageOrganization(
+  args: OrganizationArgs,
+  ctx: ToolContext
+): Promise<ManageOrganizationResult> {
+  return routeAction<ManageOrganizationResult>('manage_organization', args.action, ctx, {
+    get_settings: () => handleGetSettings(ctx),
+    update_settings: () =>
+      handleUpdateSettings(args as Extract<OrganizationArgs, { action: 'update_settings' }>, ctx),
+  });
+}
+
+// ============================================
+// Action Handlers
+// ============================================
+
+async function handleGetSettings(ctx: ToolContext): Promise<ManageOrganizationResult> {
+  const sql = getDb();
+  const { organizationId } = ctx;
+
+  const rows = (await sql`
+    SELECT id, repair_agents_enabled
+    FROM "organization"
+    WHERE id = ${organizationId}
+    LIMIT 1
+  `) as unknown as Array<{ id: string; repair_agents_enabled: boolean }>;
+
+  if (rows.length === 0) {
+    return { error: 'Organization not found' };
+  }
+
+  return {
+    action: 'get_settings',
+    settings: {
+      organization_id: rows[0].id,
+      repair_agents_enabled: Boolean(rows[0].repair_agents_enabled),
+    },
+  };
+}
+
+async function handleUpdateSettings(
+  args: Extract<OrganizationArgs, { action: 'update_settings' }>,
+  ctx: ToolContext
+): Promise<ManageOrganizationResult> {
+  const sql = getDb();
+  const { organizationId } = ctx;
+
+  // Only patch fields the caller provided.
+  const hasRepairToggle = Object.hasOwn(args, 'repair_agents_enabled');
+  if (!hasRepairToggle) {
+    return handleGetSettings(ctx);
+  }
+
+  const updated = (await sql`
+    UPDATE "organization"
+    SET repair_agents_enabled = COALESCE(${args.repair_agents_enabled ?? null}::boolean, repair_agents_enabled)
+    WHERE id = ${organizationId}
+    RETURNING id, repair_agents_enabled
+  `) as unknown as Array<{ id: string; repair_agents_enabled: boolean }>;
+
+  if (updated.length === 0) {
+    return { error: 'Organization not found' };
+  }
+
+  return {
+    action: 'update_settings',
+    settings: {
+      organization_id: updated[0].id,
+      repair_agents_enabled: Boolean(updated[0].repair_agents_enabled),
+    },
+  };
+}


### PR DESCRIPTION
## Summary

Wires the `manage_*` tool surface to the repair-agent plumbing in PR 2 (#381) so the owletto-web UI can pick repair agents and toggle the per-org kill switch.

- `manage_feeds.update_feed` accepts `repair_agent_id` (tri-state: undefined leaves the column alone, null clears the override, string sets it). `list_feeds` and `get_feed` already select `f.*`, so the new `repair_*` observability columns (`repair_thread_id`, `repair_attempt_count`, `last_repair_at`, `first_failure_at`) flow through unchanged.
- `manage_connections` gains a new `update_connector_default_repair_agent` action; `list_connector_definitions` now returns `default_repair_agent_id` (extends the SELECT in `connector-definition-helpers.ts`).
- New `manage_organization` tool (internal-only) with `get_settings` / `update_settings`, currently surfacing `repair_agents_enabled`.

All new actions are admin-tier per `OWNER_ADMIN_ACTIONS`.

## Stacking

- Stacked on **#381** (`feat/connector-repair-plumbing`), base = that branch. Will retarget `main` once #381 merges.
- UI submodule PR: **lobu-ai/owletto-web#24**.
- Submodule pointer bump for this repo lands as a follow-up parent PR after #24 merges, per AGENTS.md "two-PR ship" rule for `packages/owletto-web` — this PR contains backend wiring only.

## Non-goals

- No changes to `connectors/repair-agent.ts` (PR 2's territory).
- No changes to the diagnostic substrate (PR 1's territory).

## Test plan

- [x] `bun run typecheck` (root) passes.
- [x] `make build-packages` passes.
- [x] `packages/owletto-backend` unit tests still pass; the pre-existing `whatsapp.test.ts` failure is unrelated and present on `main`.
- [ ] Smoke against `manage_feeds.update_feed` — explicit `null` for `repair_agent_id` clears the override; `undefined` leaves it alone.
- [ ] Smoke against `manage_organization.update_settings` — `repair_agents_enabled=false` blocks repair-agent triggers (the existing trigger code already gates on `org.repair_agents_enabled`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)