### PR TITLE
chore(ci): add submodule drift check + auto-init dev targets

### DIFF
--- a/.github/workflows/submodule-drift.yml
+++ b/.github/workflows/submodule-drift.yml
@@ -33,12 +33,24 @@ jobs:
         with:
           deploy-key: ${{ secrets.OWLETTO_WEB_DEPLOY_KEY }}
 
-      - name: Skip on fork PR (no deploy key by design)
+      - name: Fork PR — fail if it modifies the submodule pointer, otherwise skip
         if: |
           steps.submodule.outputs.stubbed == 'true'
           && github.event_name == 'pull_request'
           && github.event.pull_request.head.repo.full_name != github.repository
-        run: echo "::notice::Fork PR — submodule drift check skipped."
+        shell: bash
+        run: |
+          set -euo pipefail
+          base_sha=$(git ls-tree "origin/${{ github.base_ref }}" packages/owletto-web | awk '{print $3}')
+          head_sha=$(git ls-tree HEAD packages/owletto-web | awk '{print $3}')
+          if [ "$base_sha" != "$head_sha" ]; then
+            echo "::error::Fork PRs cannot change the packages/owletto-web pointer."
+            echo "  base: $base_sha"
+            echo "  head: $head_sha"
+            echo "Submodule bumps must come from a same-repo PR (deploy-key-authorized)."
+            exit 1
+          fi
+          echo "::notice::Fork PR with unchanged submodule pointer — drift check skipped."
 
       - name: Fail when deploy key is missing on a same-repo run
         if: |
@@ -81,12 +93,21 @@ jobs:
             --pretty='tformat:%h|%ae|%s' "$PINNED..origin/main")
 
           # Walk each commit; exempt only those whose author email AND exact
-          # subject match the FluxCD image-tag bot.
+          # subject match the FluxCD image-tag bot AND that touch only deploy
+          # paths — a forged "chore: update images" with random contents
+          # outside deploy/ is treated as drift.
           DRIFT=""
           while IFS='|' read -r sha email subject; do
             [ -z "$sha" ] && continue
             if [ "$email" = "$BOT_AUTHOR_EMAIL" ] && [ "$subject" = "$BOT_SUBJECT" ]; then
-              continue
+              outside=$(git -C packages/owletto-web show --name-only \
+                --pretty='format:' "$sha" \
+                | sed '/^$/d' \
+                | grep -v '^deploy/' || true)
+              if [ -z "$outside" ]; then
+                continue
+              fi
+              echo "::warning::Commit $sha matches bot author/subject but touches non-deploy paths; treating as drift."
             fi
             DRIFT+="$sha $subject"$'\n'
           done <<< "$LOG"

--- a/.github/workflows/submodule-drift.yml
+++ b/.github/workflows/submodule-drift.yml
@@ -38,15 +38,21 @@ jobs:
           steps.submodule.outputs.stubbed == 'true'
           && github.event_name == 'pull_request'
           && github.event.pull_request.head.repo.full_name != github.repository
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         shell: bash
         run: |
           set -euo pipefail
-          base_sha=$(git ls-tree "origin/${{ github.base_ref }}" packages/owletto-web | awk '{print $3}')
-          head_sha=$(git ls-tree HEAD packages/owletto-web | awk '{print $3}')
-          if [ "$base_sha" != "$head_sha" ]; then
+          # actions/checkout@v4 with default fetch-depth=1 only has the merge
+          # commit; pull the two endpoints by SHA so ls-tree can resolve them.
+          git fetch --depth=1 origin "$BASE_SHA" "$HEAD_SHA"
+          base_pointer=$(git ls-tree "$BASE_SHA" packages/owletto-web | awk '{print $3}')
+          head_pointer=$(git ls-tree "$HEAD_SHA" packages/owletto-web | awk '{print $3}')
+          if [ "$base_pointer" != "$head_pointer" ]; then
             echo "::error::Fork PRs cannot change the packages/owletto-web pointer."
-            echo "  base: $base_sha"
-            echo "  head: $head_sha"
+            echo "  base: $base_pointer"
+            echo "  head: $head_pointer"
             echo "Submodule bumps must come from a same-repo PR (deploy-key-authorized)."
             exit 1
           fi

--- a/.github/workflows/submodule-drift.yml
+++ b/.github/workflows/submodule-drift.yml
@@ -2,7 +2,8 @@ name: Submodule Drift
 
 # Surfaces when packages/owletto-web (private) has merged commits past the
 # parent's pinned SHA — i.e. the two-PR rule's parent bump is missing.
-# Skips bot tag-update commits so FluxCD's image automation doesn't trip it.
+# Bot tag-update commits (FluxCD image automation) are exempted only when both
+# the author and exact subject match — a sloppy human commit cannot slip past.
 
 on:
   push:
@@ -16,6 +17,10 @@ on:
 permissions:
   contents: read
 
+env:
+  BOT_AUTHOR_EMAIL: fluxcd@lobu.ai
+  BOT_SUBJECT: "chore: update images"
+
 jobs:
   check-drift:
     runs-on: ubuntu-latest
@@ -28,9 +33,21 @@ jobs:
         with:
           deploy-key: ${{ secrets.OWLETTO_WEB_DEPLOY_KEY }}
 
-      - name: Skip when deploy key is unavailable (fork PRs)
-        if: steps.submodule.outputs.stubbed == 'true'
-        run: echo "::notice::No deploy key available — skipping submodule drift check."
+      - name: Skip on fork PR (no deploy key by design)
+        if: |
+          steps.submodule.outputs.stubbed == 'true'
+          && github.event_name == 'pull_request'
+          && github.event.pull_request.head.repo.full_name != github.repository
+        run: echo "::notice::Fork PR — submodule drift check skipped."
+
+      - name: Fail when deploy key is missing on a same-repo run
+        if: |
+          steps.submodule.outputs.stubbed == 'true'
+          && !(github.event_name == 'pull_request'
+            && github.event.pull_request.head.repo.full_name != github.repository)
+        run: |
+          echo "::error::OWLETTO_WEB_DEPLOY_KEY is missing for a same-repo run; drift check cannot run."
+          exit 1
 
       - name: Check for unmerged non-bot commits on owletto-web/main
         if: steps.submodule.outputs.stubbed != 'true'
@@ -44,16 +61,30 @@ jobs:
           echo "Pinned (parent):   $PINNED"
           echo "owletto-web/main:  $REMOTE"
 
+          # Hard rule: parent must never pin a SHA that isn't on owletto-web/main.
+          # FluxCD reads charts from owletto-web/main; an off-main pin breaks deploy.
+          if ! git -C packages/owletto-web merge-base --is-ancestor "$PINNED" origin/main; then
+            echo "::error::Pinned SHA $PINNED is not reachable from owletto-web/main."
+            echo "This violates the rule against pinning unmerged submodule SHAs (see AGENTS.md)."
+            exit 1
+          fi
+
           if [ "$PINNED" = "$REMOTE" ]; then
             echo "Submodule pin matches owletto-web/main — no drift."
             exit 0
           fi
 
-          NON_BOT=$(git -C packages/owletto-web log \
-            --invert-grep --grep '^chore: update images' \
-            --pretty='format:%h %s' "$PINNED..origin/main" || true)
+          # Walk each commit between PINNED..origin/main; exempt only those whose
+          # author email AND exact subject match the FluxCD image-tag bot.
+          DRIFT=""
+          while IFS='|' read -r sha email subject; do
+            if [ "$email" = "$BOT_AUTHOR_EMAIL" ] && [ "$subject" = "$BOT_SUBJECT" ]; then
+              continue
+            fi
+            DRIFT+="$sha $subject"$'\n'
+          done < <(git -C packages/owletto-web log --pretty='format:%h|%ae|%s' "$PINNED..origin/main")
 
-          if [ -z "$NON_BOT" ]; then
+          if [ -z "$DRIFT" ]; then
             echo "owletto-web/main is ahead, but only by FluxCD image-tag commits — no parent bump needed."
             exit 0
           fi
@@ -64,7 +95,7 @@ jobs:
           echo "owletto-web/main: $REMOTE"
           echo ""
           echo "Commits needing a parent bump:"
-          echo "$NON_BOT"
+          printf '%s' "$DRIFT"
           echo ""
           echo "Fix (open as a separate PR):"
           echo "  git -C packages/owletto-web fetch origin"

--- a/.github/workflows/submodule-drift.yml
+++ b/.github/workflows/submodule-drift.yml
@@ -74,15 +74,22 @@ jobs:
             exit 0
           fi
 
-          # Walk each commit between PINNED..origin/main; exempt only those whose
-          # author email AND exact subject match the FluxCD image-tag bot.
+          # Capture the log first so set -e propagates a git failure (process
+          # substitution would swallow it). tformat: guarantees a trailing
+          # newline so `read` doesn't drop the last commit.
+          LOG=$(git -C packages/owletto-web log \
+            --pretty='tformat:%h|%ae|%s' "$PINNED..origin/main")
+
+          # Walk each commit; exempt only those whose author email AND exact
+          # subject match the FluxCD image-tag bot.
           DRIFT=""
           while IFS='|' read -r sha email subject; do
+            [ -z "$sha" ] && continue
             if [ "$email" = "$BOT_AUTHOR_EMAIL" ] && [ "$subject" = "$BOT_SUBJECT" ]; then
               continue
             fi
             DRIFT+="$sha $subject"$'\n'
-          done < <(git -C packages/owletto-web log --pretty='format:%h|%ae|%s' "$PINNED..origin/main")
+          done <<< "$LOG"
 
           if [ -z "$DRIFT" ]; then
             echo "owletto-web/main is ahead, but only by FluxCD image-tag commits — no parent bump needed."

--- a/.github/workflows/submodule-drift.yml
+++ b/.github/workflows/submodule-drift.yml
@@ -1,0 +1,74 @@
+name: Submodule Drift
+
+# Surfaces when packages/owletto-web (private) has merged commits past the
+# parent's pinned SHA — i.e. the two-PR rule's parent bump is missing.
+# Skips bot tag-update commits so FluxCD's image automation doesn't trip it.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: "0 14 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  check-drift:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - id: submodule
+        uses: ./.github/actions/setup-submodule
+        with:
+          deploy-key: ${{ secrets.OWLETTO_WEB_DEPLOY_KEY }}
+
+      - name: Skip when deploy key is unavailable (fork PRs)
+        if: steps.submodule.outputs.stubbed == 'true'
+        run: echo "::notice::No deploy key available — skipping submodule drift check."
+
+      - name: Check for unmerged non-bot commits on owletto-web/main
+        if: steps.submodule.outputs.stubbed != 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          PINNED=$(git -C packages/owletto-web rev-parse HEAD)
+          git -C packages/owletto-web fetch --quiet origin main
+          REMOTE=$(git -C packages/owletto-web rev-parse origin/main)
+
+          echo "Pinned (parent):   $PINNED"
+          echo "owletto-web/main:  $REMOTE"
+
+          if [ "$PINNED" = "$REMOTE" ]; then
+            echo "Submodule pin matches owletto-web/main — no drift."
+            exit 0
+          fi
+
+          NON_BOT=$(git -C packages/owletto-web log \
+            --invert-grep --grep '^chore: update images' \
+            --pretty='format:%h %s' "$PINNED..origin/main" || true)
+
+          if [ -z "$NON_BOT" ]; then
+            echo "owletto-web/main is ahead, but only by FluxCD image-tag commits — no parent bump needed."
+            exit 0
+          fi
+
+          echo "::error::owletto-web/main has merged commits past the pinned SHA. The parent bump PR is missing."
+          echo ""
+          echo "Pinned:           $PINNED"
+          echo "owletto-web/main: $REMOTE"
+          echo ""
+          echo "Commits needing a parent bump:"
+          echo "$NON_BOT"
+          echo ""
+          echo "Fix (open as a separate PR):"
+          echo "  git -C packages/owletto-web fetch origin"
+          echo "  git -C packages/owletto-web checkout origin/main"
+          echo "  git add packages/owletto-web"
+          echo "  git commit -m 'chore(submodule): bump owletto-web to current main'"
+          exit 1

--- a/Makefile
+++ b/Makefile
@@ -41,8 +41,8 @@ build-packages:
 ensure-submodule:
 	@status=$$(git submodule status packages/owletto-web 2>/dev/null || true); \
 	case "$$status" in \
-		'-'*) echo ">> owletto-web submodule not initialized — running git submodule update --init"; \
-		      git submodule update --init packages/owletto-web ;; \
+		'-'*) echo ">> owletto-web submodule not initialized — running git submodule update --init --recursive"; \
+		      git submodule update --init --recursive packages/owletto-web ;; \
 		'+'*) echo ">> WARNING: packages/owletto-web is at a different SHA than the parent pin:"; \
 		      echo "   $$status"; \
 		      echo "   If this is unintentional, run: git submodule update packages/owletto-web" ;; \

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ DEPLOYMENT_MODE := $(shell \
 		echo docker; \
 	fi)
 
-.PHONY: help setup build test eval clean logs deploy down build-packages dev
+.PHONY: help setup build test eval clean logs deploy down build-packages dev dev-native ensure-submodule
 
 # Default target
 help:
@@ -36,12 +36,25 @@ build-packages:
 	done
 	@echo "✅ All packages built successfully!"
 
+# Ensure packages/owletto-web is initialized; warn on drift but don't auto-fix
+# (drift may be active feature-branch work — clobbering it silently is worse than the warning).
+ensure-submodule:
+	@status=$$(git submodule status packages/owletto-web 2>/dev/null || true); \
+	case "$$status" in \
+		'-'*) echo ">> owletto-web submodule not initialized — running git submodule update --init"; \
+		      git submodule update --init packages/owletto-web ;; \
+		'+'*) echo ">> WARNING: packages/owletto-web is at a different SHA than the parent pin:"; \
+		      echo "   $$status"; \
+		      echo "   If this is unintentional, run: git submodule update packages/owletto-web" ;; \
+		*) ;; \
+	esac
+
 # Start dev environment with Docker Compose Watch
-dev:
+dev: ensure-submodule
 	docker compose --env-file .env -f docker/docker-compose.yml watch
 
 # Native foreground dev: embedded gateway + workers + Vite HMR, against host redis + remote Postgres.
-dev-native:
+dev-native: ensure-submodule
 	@./scripts/dev-native.sh
 
 # Setup development environment (run once)


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/submodule-drift.yml` — fails when `lobu-ai/owletto-web:main` has merged commits past the parent's pinned SHA (skipping FluxCD bot `chore: update images` commits). Runs on PRs, pushes to main, daily cron, and manual dispatch.
- Wires `make dev` / `make dev-native` to a new `ensure-submodule` target that auto-inits the submodule on first use and warns (without auto-fixing) when local pointer drifts from the parent pin — protects active submodule branch work.

## Why
The two-PR submodule rule (per `AGENTS.md`) currently has no automated guard. If a PR merges on `owletto-web/main` and someone forgets the parent bump, the new code never deploys. This adds a CI signal so we can't silently miss bumps anymore.

This PR's own CI is expected to **fail** initially because `owletto-web/main` is currently ahead of parent's pin by one human PR (#24, the connector-repair feature). The signal will go green after a separate bump PR lands.

## Test plan
- [ ] Drift check runs on this PR and **fails** with the connector-repair commit listed (validates the workflow works).
- [ ] After merging the bump PR, rebase this and the check goes green.
- [ ] `make ensure-submodule` is silent when in sync, warns on `+` drift, and inits on `-` (verified locally).