### PR TITLE
fix(worker): drop unused code/signal params from computeExitReason

### DIFF
--- a/packages/owletto-worker/src/executor/subprocess.ts
+++ b/packages/owletto-worker/src/executor/subprocess.ts
@@ -230,11 +230,7 @@ export class SubprocessExecutor implements SyncExecutor {
         return `[stdout]\n${out}\n[stderr]\n${err}`;
       };
 
-      const computeExitReason = (
-        code: number | null,
-        signal: string | null,
-        tail: string
-      ): SubprocessExitReason => {
+      const computeExitReason = (tail: string): SubprocessExitReason => {
         if (timedOut) return 'timeout';
         if (/javascript heap out of memory/i.test(tail)) return 'oom';
         return 'crash';
@@ -375,7 +371,7 @@ export class SubprocessExecutor implements SyncExecutor {
         }
         settle(() => {
           const tail = redactOutput(combinedTail());
-          const reason = computeExitReason(code, signal, tail);
+          const reason = computeExitReason(tail);
           const prefix =
             reason === 'timeout'
               ? `Feed execution timed out after ${this.options.timeoutMs}ms`


### PR DESCRIPTION
## Summary

Fixes the `build-images` CI failure on `main` after #376 merged.

`packages/owletto-backend` has stricter unused-parameter typecheck than `packages/owletto-worker`, so the `code` and `signal` params on `computeExitReason` — both unused after the codex P2 review simplified the classifier to read only `timedOut` and the OOM substring of `tail` — passed local typecheck but broke the prod Docker image build.

Removed the dead params and updated the single call site.

## Test plan

- [x] `bun run typecheck` passes
- [x] `cd packages/owletto-backend && bunx tsc --noEmit` passes (the strict path)
- [x] 19 redact + integration tests still pass