### PR TITLE
fix(db): add dbmate up/down directives to repair-agent migrations

### DIFF
--- a/db/migrations/20260425120000_add_run_diagnostics.sql
+++ b/db/migrations/20260425120000_add_run_diagnostics.sql
@@ -1,3 +1,5 @@
+-- migrate:up
+
 -- Add diagnostic columns to runs so subprocess failures carry enough context
 -- to diagnose without reading gateway pod logs.
 --
@@ -9,3 +11,10 @@ ALTER TABLE public.runs ADD COLUMN output_tail TEXT NULL;
 ALTER TABLE public.runs ADD COLUMN exit_code INTEGER NULL;
 ALTER TABLE public.runs ADD COLUMN exit_signal TEXT NULL;
 ALTER TABLE public.runs ADD COLUMN exit_reason TEXT NULL;
+
+-- migrate:down
+
+ALTER TABLE public.runs DROP COLUMN IF EXISTS exit_reason;
+ALTER TABLE public.runs DROP COLUMN IF EXISTS exit_signal;
+ALTER TABLE public.runs DROP COLUMN IF EXISTS exit_code;
+ALTER TABLE public.runs DROP COLUMN IF EXISTS output_tail;

--- a/db/migrations/20260425130000_add_repair_agent_plumbing.sql
+++ b/db/migrations/20260425130000_add_repair_agent_plumbing.sql
@@ -1,3 +1,5 @@
+-- migrate:up
+
 -- Repair-agent plumbing for connector reliability.
 --
 -- When a feed accumulates persistent failures, the worker-completion path
@@ -29,3 +31,16 @@ ALTER TABLE public.connector_definitions
 -- feed in the org regardless of per-feed configuration.
 ALTER TABLE public.organization
   ADD COLUMN repair_agents_enabled boolean NOT NULL DEFAULT TRUE;
+
+-- migrate:down
+
+ALTER TABLE public.organization DROP COLUMN IF EXISTS repair_agents_enabled;
+ALTER TABLE public.connector_definitions DROP COLUMN IF EXISTS default_repair_agent_id;
+DROP INDEX IF EXISTS feeds_open_repair_thread_uniq;
+ALTER TABLE public.feeds
+  DROP COLUMN IF EXISTS last_repair_post_hash,
+  DROP COLUMN IF EXISTS first_failure_at,
+  DROP COLUMN IF EXISTS last_repair_at,
+  DROP COLUMN IF EXISTS repair_attempt_count,
+  DROP COLUMN IF EXISTS repair_thread_id,
+  DROP COLUMN IF EXISTS repair_agent_id;


### PR DESCRIPTION
## Summary

Production deploy at 00:25 UTC crash-looped on `dbmate requires each migration to define an up block with -- migrate:up`. Both migrations from #376 omitted the directives.

Adds the standard `-- migrate:up` / `-- migrate:down` markers and reversible drops.

## Test plan
- [x] Local typecheck passes (no code changed)
- [ ] Production pod `summaries-app-owletto-app` starts cleanly after merge + Flux reconcile
- [ ] New diagnostic columns visible on `runs`, `feeds`, `connector_definitions`, `organization`