### PR TITLE
fix(ci): deploy landing Pages Functions

### DIFF
--- a/.github/workflows/deploy-landing-cloudflare.yml
+++ b/.github/workflows/deploy-landing-cloudflare.yml
@@ -51,6 +51,11 @@ jobs:
         run: bun run --filter @lobu/landing build
 
       - name: Deploy to Cloudflare Pages
+        # Run from packages/landing so wrangler discovers the sibling
+        # `functions/` directory (Pages Functions live there). Running from
+        # the repo root with `wrangler pages deploy packages/landing/dist`
+        # only ships static assets and silently drops every function.
+        working-directory: packages/landing
         env:
           CLOUDFLARE_EMAIL: ${{ secrets.CLOUDFLARE_EMAIL }}
           CLOUDFLARE_API_KEY: ${{ secrets.CLOUDFLARE_API_KEY }}
@@ -60,7 +65,7 @@ jobs:
           # being evaluated as subshells / variable expansions.
           COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
         run: |
-          bunx wrangler pages deploy packages/landing/dist \
+          bunx wrangler pages deploy dist \
             --project-name lobu-ai \
             --branch main \
             --commit-hash "$COMMIT_SHA" \


### PR DESCRIPTION
## Summary

The landing deploy workflow ran `wrangler pages deploy packages/landing/dist` from the repo root. Wrangler auto-discovers `functions/` as a sibling of the deploy directory **relative to the current working directory** — so it looked for `<repo-root>/functions/` and silently shipped zero functions.

This blocked every Pages Function: the existing `_middleware.ts` (markdown content negotiation never ran in prod) and the new `/mcp` + `/.well-known/oauth-*` proxies from #389.

Fix: set `working-directory: packages/landing` and deploy `./dist`.

## Test plan

- [ ] After merge, Deploy Landing workflow runs and uploads functions
- [ ] `curl -I -H 'Accept: text/markdown' https://lobu.ai/getting-started/` returns `x-markdown-negotiated: true` (proves `_middleware.ts` ran)
- [ ] `curl -X POST https://lobu.ai/mcp` proxies to upstream and returns an MCP session