### PR TITLE
fix(db): backfill events.created_by NULLs before NOT NULL validate

### DIFF
--- a/.github/workflows/deploy-landing-cloudflare.yml
+++ b/.github/workflows/deploy-landing-cloudflare.yml
@@ -51,6 +51,11 @@ jobs:
         run: bun run --filter @lobu/landing build
 
       - name: Deploy to Cloudflare Pages
+        # Run from packages/landing so wrangler discovers the sibling
+        # `functions/` directory (Pages Functions live there). Running from
+        # the repo root with `wrangler pages deploy packages/landing/dist`
+        # only ships static assets and silently drops every function.
+        working-directory: packages/landing
         env:
           CLOUDFLARE_EMAIL: ${{ secrets.CLOUDFLARE_EMAIL }}
           CLOUDFLARE_API_KEY: ${{ secrets.CLOUDFLARE_API_KEY }}
@@ -60,7 +65,7 @@ jobs:
           # being evaluated as subshells / variable expansions.
           COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
         run: |
-          bunx wrangler pages deploy packages/landing/dist \
+          bunx wrangler pages deploy dist \
             --project-name lobu-ai \
             --branch main \
             --commit-hash "$COMMIT_SHA" \

--- a/db/migrations/20260426130001_db_integrity_cleanup_concurrent.sql
+++ b/db/migrations/20260426130001_db_integrity_cleanup_concurrent.sql
@@ -38,6 +38,30 @@ BEGIN
     END IF;
 END$$;
 
+-- Backfill historical NULLs with the existing 'system' sentinel before
+-- VALIDATE. Pre-`created_by` events (and any system-generated events
+-- written before the column was tracked) end up here. The chunked loop
+-- avoids a single 100k+ row UPDATE holding row locks for too long.
+DO $$
+DECLARE
+    rows_left bigint;
+BEGIN
+    LOOP
+        WITH chunk AS (
+            SELECT id FROM public.events
+             WHERE created_by IS NULL
+             LIMIT 50000
+             FOR UPDATE SKIP LOCKED
+        )
+        UPDATE public.events
+           SET created_by = 'system'
+          FROM chunk
+         WHERE events.id = chunk.id;
+        GET DIAGNOSTICS rows_left = ROW_COUNT;
+        EXIT WHEN rows_left = 0;
+    END LOOP;
+END$$;
+
 ALTER TABLE public.events
     VALIDATE CONSTRAINT events_created_by_not_null;
 


### PR DESCRIPTION
## Summary

PR #371's integrity migration crashes prod pods because 392k events have NULL `created_by`. Adds a chunked backfill to the existing `'system'` sentinel before `VALIDATE CONSTRAINT`.

This is the second migration crash exposed by tonight's deploy (after #390). Once this lands, the new image rolls out and #376 lands in prod for real.

## Test plan
- [ ] Build → Flux reconcile → new pod `summaries-app-owletto-app-*` reaches `1/1 Running`
- [ ] `SELECT COUNT(*) FROM events WHERE created_by IS NULL` returns 0 after migration runs
- [ ] No regressions on the existing `'system'` events (4 rows pre-existed)