### PR TITLE
fix(landing): point Scalar API reference at the real /openapi.json

### DIFF
--- a/packages/landing/src/pages/reference/api-reference.astro
+++ b/packages/landing/src/pages/reference/api-reference.astro
@@ -8,7 +8,7 @@ const specOrigin = import.meta.env.DEV
 
 let spec: string | null = null;
 try {
-  const res = await fetch(`${specOrigin}/api/docs/openapi.json`);
+  const res = await fetch(`${specOrigin}/openapi.json`);
   if (res.ok) {
     const text = await res.text();
     if (text.length > 0) spec = text;
@@ -20,7 +20,7 @@ try {
 const config = JSON.stringify({
   ...(spec
     ? { content: spec }
-    : { url: `${specOrigin}/api/docs/openapi.json` }),
+    : { url: `${specOrigin}/openapi.json` }),
   theme: "kepler",
   layout: "modern",
   defaultHttpClient: { targetKey: "js", clientKey: "fetch" },


### PR DESCRIPTION
## Summary

The api-reference page (`packages/landing/src/pages/reference/api-reference.astro`) fetched `/api/docs/openapi.json` on `app.lobu.ai`, which **doesn't exist as an OpenAPI route**. The backend's catch-all returns the apex status JSON (`{status, mcp_endpoint, health, openapi}`) with HTTP 200, and Scalar embedded that as the "spec." Result:

- The page rendered the status JSON instead of the API reference.
- The literal string `"mcp_endpoint":"http://app.lobu.ai/mcp"` leaked into the build output.

The real OpenAPI spec lives at `/openapi.json` (backend `index.ts:938`). Switching the fetch path makes Scalar render the actual API reference and removes the stale `mcp_endpoint` string from the dist.

## Test plan

- [ ] After deploy: `curl -s https://lobu.ai/reference/api-reference/ | grep mcp_endpoint` returns nothing
- [ ] Visit https://lobu.ai/reference/api-reference/ — Scalar renders the Owletto OpenAPI doc