### PR TITLE
fix(landing): satisfy isitagentready.com checks for markdown + OAuth metadata

### DIFF
--- a/packages/landing/.gitignore
+++ b/packages/landing/.gitignore
@@ -8,3 +8,5 @@
 /public/guides/**/*.md
 /public/platforms/**/*.md
 /public/reference/**/*.md
+# Apex homepage has no Starlight source — committed as the curated twin.
+!/public/index.md

--- a/packages/landing/functions/.well-known/oauth-protected-resource.ts
+++ b/packages/landing/functions/.well-known/oauth-protected-resource.ts
@@ -1,4 +1,12 @@
-import { proxyWellKnown } from "../_well-known-proxy";
+/**
+ * RFC 9728 Protected Resource Metadata for `https://lobu.ai/mcp`.
+ *
+ * Served as static JSON rather than proxied upstream because the `resource`
+ * field MUST match the scanned host. Proxying `app.lobu.ai/.well-known/...`
+ * would return `resource: https://app.lobu.ai/mcp`, which validators flag as
+ * a mismatch when fetched from `lobu.ai`. The authorization server lives on
+ * `app.lobu.ai`, so clients still complete OAuth there.
+ */
 
 type PagesFunction = (context: {
   request: Request;
@@ -7,4 +15,36 @@ type PagesFunction = (context: {
   params: Record<string, string | string[]>;
 }) => Promise<Response> | Response;
 
-export const onRequest: PagesFunction = (context) => proxyWellKnown(context);
+const METADATA = {
+  resource: "https://lobu.ai/mcp",
+  authorization_servers: ["https://app.lobu.ai"],
+  scopes_supported: ["mcp:read", "mcp:write", "mcp:admin", "profile:read"],
+  bearer_methods_supported: ["header"],
+  resource_name: "Lobu",
+  resource_documentation: "https://lobu.ai/mcp",
+};
+
+export const onRequest: PagesFunction = (context) => {
+  const method = context.request.method;
+  if (method !== "GET" && method !== "HEAD") {
+    return new Response(null, {
+      status: 405,
+      headers: {
+        allow: "GET, HEAD",
+        "access-control-allow-origin": "*",
+      },
+    });
+  }
+
+  const body = method === "HEAD" ? null : JSON.stringify(METADATA);
+  return new Response(body, {
+    status: 200,
+    headers: {
+      "content-type": "application/json; charset=utf-8",
+      "cache-control": "public, max-age=3600",
+      "access-control-allow-origin": "*",
+      "access-control-allow-methods": "GET, HEAD",
+      vary: "Accept",
+    },
+  });
+};

--- a/packages/landing/functions/_well-known-proxy.ts
+++ b/packages/landing/functions/_well-known-proxy.ts
@@ -88,6 +88,17 @@ export async function proxyWellKnown(context: PagesContext): Promise<Response> {
     "server-timing",
     `wellknown_upstream;dur=${Date.now() - startedAt}`
   );
+  // Public discovery: agent scanners and browser-based clients fetch these
+  // cross-origin. Upstream advertises CORS for app.lobu.ai only, which blocks
+  // anyone else. Override to a public allowlist.
+  headers.set("access-control-allow-origin", "*");
+  headers.set("access-control-allow-methods", "GET, HEAD, OPTIONS");
+  headers.delete("access-control-allow-credentials");
+  const existingVary = headers.get("vary");
+  headers.set(
+    "vary",
+    existingVary ? `${existingVary}, Accept` : "Accept"
+  );
 
   return new Response(upstream.body, {
     status: upstream.status,

--- a/packages/landing/public/index.md
+++ b/packages/landing/public/index.md
@@ -1,0 +1,65 @@
+# Lobu
+
+> Open-source platform for deploying persistent, sandboxed AI agents on Slack, Telegram, WhatsApp, Discord, Microsoft Teams, Google Chat, and REST API. Self-hosted on Docker or Kubernetes with per-agent MCP tools, skills, and memory.
+
+## What Lobu does
+
+Lobu runs autonomous agents on the messaging platforms your team already uses. Each agent runs in its own sandbox with isolated credentials, scoped network egress, and an approval model for destructive tool calls. Agents share organizational memory through Owletto so context, decisions, and observations persist across conversations and across the agents on your team.
+
+## Connect any agent to Lobu
+
+The orgless MCP endpoint at [https://lobu.ai/mcp](https://lobu.ai/mcp) exposes `list_organizations` and `switch_organization` so MCP-capable clients (Claude, ChatGPT, Claude Code, OpenClaw, Gemini CLI) can sign in once and pick a workspace per conversation. See [/mcp](https://lobu.ai/mcp/) for per-client setup.
+
+## Start here
+
+- [Home](https://lobu.ai/): Product overview and architecture
+- [Getting started](https://lobu.ai/getting-started/): Install and run your first agent
+- [Comparison](https://lobu.ai/getting-started/comparison/): How Lobu compares to other agent platforms
+- [Pricing](https://lobu.ai/pricing/): Free open source; paid support available
+
+## Core concepts
+
+- [Skills](https://lobu.ai/skills/): Reusable agent capabilities via SKILL.md
+- [Memory](https://lobu.ai/memory/): Persistent agent memory powered by Owletto
+- [Architecture](https://lobu.ai/guides/architecture/): Gateway + worker + orchestration overview
+- [Security](https://lobu.ai/guides/security/): Sandboxing, network policy, credential isolation
+- [Tool policy](https://lobu.ai/guides/tool-policy/): Approval model for destructive MCP tools
+
+## Deployment
+
+- [Docker](https://lobu.ai/deployment/docker/)
+- [Kubernetes](https://lobu.ai/deployment/kubernetes/)
+- [AWS](https://lobu.ai/deployment/aws/)
+- [Embedding](https://lobu.ai/deployment/embedding/): Embed Lobu in your own Node process
+
+## Messaging platforms
+
+- [Slack](https://lobu.ai/platforms/slack/)
+- [Telegram](https://lobu.ai/platforms/telegram/)
+- [WhatsApp](https://lobu.ai/platforms/whatsapp/)
+- [Discord](https://lobu.ai/platforms/discord/)
+- [Microsoft Teams](https://lobu.ai/platforms/teams/)
+- [Google Chat](https://lobu.ai/platforms/google-chat/)
+- [REST API](https://lobu.ai/platforms/rest-api/)
+
+## Connect external agents
+
+- [ChatGPT](https://lobu.ai/connect-from/chatgpt/)
+- [Claude](https://lobu.ai/connect-from/claude/)
+- [OpenClaw](https://lobu.ai/connect-from/openclaw/)
+
+## Reference
+
+- [API reference](https://lobu.ai/reference/api-reference/)
+- [lobu.toml](https://lobu.ai/reference/lobu-toml/)
+- [SKILL.md](https://lobu.ai/reference/skill-md/)
+- [Providers](https://lobu.ai/reference/providers/)
+- [CLI](https://lobu.ai/reference/cli/)
+- [Owletto CLI](https://lobu.ai/reference/owletto-cli/)
+
+## Project
+
+- [GitHub](https://github.com/lobu-ai/lobu)
+- [Blog](https://lobu.ai/blog/)
+- [Privacy](https://lobu.ai/privacy/)
+- [Terms](https://lobu.ai/terms/)


### PR DESCRIPTION
## Summary

Fixes three findings from https://isitagentready.com/?url=lobu.ai:

1. **Markdown for Agents on `/`** — middleware fetches `<route>.md` for negotiation; the apex resolves to `/index.md` which the generator never wrote (it only walks `src/content/`). Add a curated `public/index.md` mirroring `llms.txt` and gitignore-exempt it.

2. **OAuth Protected Resource Metadata** — RFC 9728 requires `resource` to match the scanned host. Proxying upstream returned `resource: https://app.lobu.ai/mcp` from a request to `https://lobu.ai/.well-known/oauth-protected-resource`, which scanners flag as a mismatch. Replace the proxy with a function that emits authoritative metadata declaring `resource: https://lobu.ai/mcp` and `authorization_servers: ["https://app.lobu.ai"]`. ACAO=* so cross-origin scanners can read it.

3. **CORS on `oauth-authorization-server`** — still proxied to upstream (live AS metadata). Upstream's ACAO is locked to `app.lobu.ai`; override to `*` and drop allow-credentials so public discovery works for any client.

WebMCP is a separate browser-API feature, deferred.

## Test plan

- [x] Local: GET `/` with `Accept: text/markdown` → 200 `text/markdown` + `x-markdown-negotiated: true`
- [x] Local: GET `/.well-known/oauth-protected-resource` → 200 with `resource: https://lobu.ai/mcp`, ACAO=*
- [x] Local: GET `/.well-known/oauth-authorization-server` → 200 with ACAO=*
- [x] Local: HEAD on protected-resource → 200 empty body, GET-supported
- [x] Local: POST on protected-resource → 405 with `allow: GET, HEAD`
- [ ] Production: re-run isitagentready.com against lobu.ai post-deploy