### PR TITLE
feat(world-model): cross-org list_rules read mode

### DIFF
--- a/packages/owletto-backend/src/tools/admin/manage_entity_schema.ts
+++ b/packages/owletto-backend/src/tools/admin/manage_entity_schema.ts
@@ -677,17 +677,42 @@ async function etHandleAudit(
 // ============================================
 
 /**
- * Look up a relationship type by slug and verify the caller's org owns it.
- * Returns the numeric type ID. Throws on not-found or access-denied.
+ * Look up a relationship type by slug.
+ *
+ * - `mode: 'write'` (default): require the caller's org to own the type. Used
+ *   by add_rule / remove_rule / update / delete.
+ * - `mode: 'read'`: also resolve types from any visibility=public catalog the
+ *   caller can see. Used by list_rules so cross-org public RTs surfaced via
+ *   list/get can have their rules read without 403.
+ *
+ * Tenant-first ordering means a tenant slug shadowing a public slug always
+ * wins.
  */
 async function requireRelationshipType(
   slug: string | undefined,
   action: string,
-  ctx: ToolContext
+  ctx: ToolContext,
+  mode: 'read' | 'write' = 'write'
 ): Promise<{ typeId: number; sql: ReturnType<typeof getDb> }> {
   if (!slug) throw new Error(`slug is required for ${action} action`);
 
   const sql = getDb();
+
+  if (mode === 'read') {
+    const rows = await sql`
+      SELECT rt.id
+      FROM entity_relationship_types rt
+      LEFT JOIN organization o ON o.id = rt.organization_id
+      WHERE rt.slug = ${slug}
+        AND rt.deleted_at IS NULL
+        AND (rt.organization_id = ${ctx.organizationId} OR o.visibility = 'public')
+      ORDER BY (rt.organization_id = ${ctx.organizationId}) DESC, rt.id ASC
+      LIMIT 1
+    `;
+    if (rows.length === 0) throw new Error(`Relationship type "${slug}" not found`);
+    return { typeId: Number(rows[0].id), sql };
+  }
+
   const existing = await sql`
     SELECT id, organization_id FROM entity_relationship_types
     WHERE slug = ${slug} AND deleted_at IS NULL
@@ -1057,7 +1082,7 @@ async function rtHandleListRules(
   args: ManageEntitySchemaArgs,
   ctx: ToolContext
 ): Promise<ManageEntitySchemaResult> {
-  const { typeId, sql } = await requireRelationshipType(args.slug, 'list_rules', ctx);
+  const { typeId, sql } = await requireRelationshipType(args.slug, 'list_rules', ctx, 'read');
 
   const rules = await sql`
     SELECT id, relationship_type_id, source_entity_type_slug, target_entity_type_slug, created_at


### PR DESCRIPTION
## Summary

Follow-up to #386 surfaced by Pi's review of [lobu-ai/owletto-web#26](https://github.com/lobu-ai/owletto-web/pull/26).

`rtHandleListRules` calls `requireRelationshipType`, which throws **\"Access denied: relationship type belongs to another organization\"** for any RT outside the caller's org. After #386, the frontend now lists public-catalog relationship types — but their rules can't be read, so the read-only sections come up empty.

This PR adds a `mode: 'read' | 'write'` parameter (default `'write'` to preserve existing callers) to `requireRelationshipType`. In `'read'` mode it widens the slug lookup to `(caller_org OR visibility = 'public')` with tenant-first `ORDER BY` — same shape as the resolver in `entity-management.ts:249–260`.

Only `rtHandleListRules` opts into `'read'`. Mutating handlers (`add_rule`, `remove_rule`, `update`, `delete`) keep the strict `'write'` mode and continue to deny cross-org writes — that's the correct behavior because cross-org RTs belong to the catalog and aren't editable from the tenant side.

## Test plan

- [x] `bun run typecheck` (owletto-backend) clean
- [ ] After merge + the dependent owletto-web PR, hit the entity-types relationship rules tab as a tenant org joined to a public catalog; confirm the cross-org section populates with the catalog's rules.