### PR TITLE
chore(landing): apply biome format

### DIFF
--- a/packages/landing/functions/_well-known-proxy.ts
+++ b/packages/landing/functions/_well-known-proxy.ts
@@ -95,10 +95,7 @@ export async function proxyWellKnown(context: PagesContext): Promise<Response> {
   headers.set("access-control-allow-methods", "GET, HEAD, OPTIONS");
   headers.delete("access-control-allow-credentials");
   const existingVary = headers.get("vary");
-  headers.set(
-    "vary",
-    existingVary ? `${existingVary}, Accept` : "Accept"
-  );
+  headers.set("vary", existingVary ? `${existingVary}, Accept` : "Accept");
 
   return new Response(upstream.body, {
     status: upstream.status,

--- a/packages/landing/src/pages/reference/api-reference.astro
+++ b/packages/landing/src/pages/reference/api-reference.astro
@@ -18,9 +18,7 @@ try {
 }
 
 const config = JSON.stringify({
-  ...(spec
-    ? { content: spec }
-    : { url: `${specOrigin}/openapi.json` }),
+  ...(spec ? { content: spec } : { url: `${specOrigin}/openapi.json` }),
   theme: "kepler",
   layout: "modern",
   defaultHttpClient: { targetKey: "js", clientKey: "fetch" },


### PR DESCRIPTION
Two files merged in #397 / #394 landed unformatted; required-check `format-lint` is failing on main and blocking every new PR. Applying `biome format --write`.

Unblocks #399 and any subsequent PRs.

## Test plan
- [x] `bun run format:check` clean (modulo `.pi/background-processes.json` which is local-only)