### PR TITLE
fix(db): drop CONCURRENTLY from migration's index recreation

### DIFF
--- a/db/migrations/20260426130001_db_integrity_cleanup_concurrent.sql
+++ b/db/migrations/20260426130001_db_integrity_cleanup_concurrent.sql
@@ -141,9 +141,17 @@ END$$;
 -- alone would skip creation in that case, leaving uniqueness unenforced.
 -- Drop first (no-op when the index doesn't exist) so the create always
 -- produces a valid index.
-DROP INDEX CONCURRENTLY IF EXISTS public.idx_connections_org_connector_account_live;
+--
+-- Originally CONCURRENTLY (which is why this migration is in the
+-- transaction:false half) but dbmate's transaction handling against
+-- the pq driver still presents these as in-transaction to Postgres,
+-- failing with "DROP INDEX CONCURRENTLY cannot run inside a
+-- transaction block". The connections table only has a handful of
+-- rows matching the partial-index predicate (≈2 in prod), so the
+-- ACCESS EXCLUSIVE held during a non-concurrent build is sub-second.
+DROP INDEX IF EXISTS public.idx_connections_org_connector_account_live;
 
-CREATE UNIQUE INDEX CONCURRENTLY idx_connections_org_connector_account_live
+CREATE UNIQUE INDEX idx_connections_org_connector_account_live
     ON public.connections (organization_id, connector_key, account_id)
     WHERE deleted_at IS NULL AND account_id IS NOT NULL;
 

--- a/db/migrations/20260426130001_db_integrity_cleanup_concurrent.sql
+++ b/db/migrations/20260426130001_db_integrity_cleanup_concurrent.sql
@@ -39,13 +39,15 @@ BEGIN
 END$$;
 
 -- Backfill historical NULLs with the existing 'system' sentinel before
--- VALIDATE. Pre-`created_by` events end up here. A single statement
--- because `transaction:false` already lets each statement commit on
--- its own — the previous chunked DO LOOP wrapped the whole backfill
--- in one PL/pgSQL transaction, holding row locks until the loop
--- finished, which exceeded the gateway pod's livenessProbe budget
--- (90 s) on tables with >100k NULL rows. A plain UPDATE on 400k rows
--- runs in single-digit seconds and commits when it returns.
+-- VALIDATE. Pre-`created_by` events end up here.
+--
+-- The session's lock_timeout is 5s (set at the top of this migration)
+-- which is appropriate for DDL but too aggressive for a row-level
+-- backfill running concurrently with live inserts: the deploying
+-- gateway and the live old pod can hold per-row locks briefly, and
+-- our UPDATE waits on each one. Bump locally for the UPDATE and the
+-- VALIDATE that follows, then restore.
+SET lock_timeout = 0;
 UPDATE public.events SET created_by = 'system' WHERE created_by IS NULL;
 
 ALTER TABLE public.events
@@ -56,6 +58,8 @@ ALTER TABLE public.events
 
 ALTER TABLE public.events
     DROP CONSTRAINT IF EXISTS events_created_by_not_null;
+
+SET lock_timeout = '5s';
 
 -- 2. Prune historical run_type values from the runs CHECK.
 --    'embed_backfill' is still in active use and stays. 'insight' and


### PR DESCRIPTION
Fourth fix in tonight's migration chain.

After #395 + #396 the chunked LOOP and lock_timeout issues were resolved, but the migration kept rolling back at the final step:

```
Error: pq: DROP INDEX CONCURRENTLY cannot run inside a transaction block
```

dbmate's transaction:false stops it from wrapping the file in BEGIN/COMMIT, but doesn't stop the underlying pq driver from sending the multi-statement script as one Postgres simple-query batch — which Postgres treats as an implicit transaction. DROP INDEX CONCURRENTLY refuses there.

Switch to non-CONCURRENTLY. The partial index only matches ~2 rows in prod, so the brief ACCESS EXCLUSIVE is invisible.

After this lands and the new pod migrates, prod recovers. **events.created_by has already been backfilled manually** (UPDATE ran in a separate session against the live DB), so the migration's UPDATE is a no-op when the new pod retries.