### PR TITLE
fix: connector-catalog externalises missing deps; worker-auth pino err format

### DIFF
--- a/packages/core/src/worker/auth.ts
+++ b/packages/core/src/worker/auth.ts
@@ -120,7 +120,15 @@ export function verifyWorkerToken(token: string): WorkerTokenData | null {
 
     return data;
   } catch (error) {
-    logger.error("Error verifying token:", error);
+    // Pino expects `(obj, msg)` for Error serialization. The previous
+    // `(msg, error)` form fell through to message-only logging and rendered
+    // the actual decryption / parse error as `{}`, hiding the real cause.
+    logger.error(
+      {
+        err: error instanceof Error ? { name: error.name, message: error.message } : error,
+      },
+      "Error verifying token"
+    );
     return null;
   }
 }

--- a/packages/owletto-backend/src/utils/connector-catalog.ts
+++ b/packages/owletto-backend/src/utils/connector-catalog.ts
@@ -20,15 +20,39 @@ const DEFAULT_CONNECTOR_DIR_CANDIDATES = [
   resolve(process.cwd(), 'connectors'),
 ];
 
+// Connectors declare their npm deps via `import x from 'npm:foo@1.2.3'`. This
+// plugin strips the prefix so esbuild can resolve the bare package against
+// node_modules. When the package isn't installed in the gateway image (e.g.
+// heavyweight deps like `baileys` that only the worker pod needs), we mark
+// the import as external rather than failing the whole bundle. The bundle
+// still emits `import 'baileys'` and the worker — which has those packages
+// installed — can run it. Without this, one un-installable npm dep takes
+// down the entire connector-catalog path, breaking /api/workers/poll for
+// every worker.
 const npmSpecifierPlugin: Plugin = {
   name: 'npm-specifier',
   setup(b) {
-    b.onResolve({ filter: /^npm:/ }, (args) => {
+    b.onResolve({ filter: /^npm:/ }, async (args) => {
       const bare = args.path
         .slice(4)
         .replace(/^(@[^/]+\/[^/@]+)@[^/]*/, '$1')
         .replace(/^([^/@]+)@[^/]*/, '$1');
-      return b.resolve(bare, { resolveDir: args.resolveDir, kind: args.kind });
+      const resolved = await b.resolve(bare, {
+        resolveDir: args.resolveDir,
+        kind: args.kind,
+      });
+      if (resolved.errors.length > 0) {
+        // Package isn't installed in this image — externalize so the bundle
+        // still produces. Worker runtime supplies the implementation.
+        // Log so an actual typo or missing-dep regression is diagnosable
+        // rather than silently producing a bundle that crashes at runtime.
+        logger.warn(
+          { package: bare, importer: args.importer },
+          'externalising npm:* import — package not resolvable in gateway image (worker runtime must provide it)'
+        );
+        return { path: bare, external: true, errors: [], warnings: [] };
+      }
+      return resolved;
     });
   },
 };


### PR DESCRIPTION
Two fixes for issues that surfaced after tonight's deploy chain settled:

## 1. `/api/workers/poll` 500 on `Could not resolve "baileys"`

`packages/owletto-backend/src/utils/connector-catalog.ts` — npmSpecifierPlugin previously failed the whole bundle when an `npm:foo@v` import couldn't resolve. The gateway image deliberately omits heavyweight worker-only deps (baileys for the WhatsApp connector); that took down `/api/workers/poll` for every worker because one un-installable import poisoned the catalog enumeration.

Fix: catch resolve failure, externalise the import, log a warning. The bundle still produces with `import 'baileys'` left intact; the worker pod (which has the package) executes it.

## 2. `worker-auth` log rendering errors as `{}`

`packages/core/src/worker/auth.ts` — pino called as `logger.error("msg", err)` was rendering errors as `{}` because pino expects `(obj, msg)`. Fix: pass `{ err: { name, message } }` first. Stack omitted on purpose to avoid leaking filesystem paths.

Pi-verified.