### PR TITLE
fix(db): scope baseline's search_path reset to migration transaction

### DIFF
--- a/db/migrations/00000000000000_baseline.sql
+++ b/db/migrations/00000000000000_baseline.sql
@@ -7,7 +7,15 @@ SET lock_timeout = 0;
 SET idle_in_transaction_session_timeout = 0;
 SET client_encoding = 'UTF8';
 SET standard_conforming_strings = on;
-SELECT pg_catalog.set_config('search_path', '', false);
+-- pg_dump emits this with `false` (session-wide) to make every CREATE
+-- statement below schema-unambiguous via fully-qualified names. dbmate
+-- reuses one connection across migrations, so a session-wide blank
+-- `search_path` persists into the NEXT migration — which uses bare
+-- table names (e.g. `INSERT INTO connector_definitions ...`) and fails
+-- with `relation does not exist` on a fresh DB. Setting `true` scopes
+-- the change to this migration's transaction; subsequent migrations get
+-- the default `"$user", public` again.
+SELECT pg_catalog.set_config('search_path', '', true);
 SET check_function_bodies = false;
 SET xmloption = content;
 SET client_min_messages = warning;


### PR DESCRIPTION
## Summary

Closes the gap that's been keeping PR #393 (CI migration gate) from going green. Baseline's pg_dump-style preamble has `SELECT set_config('search_path', '', false)` — `false` is session-wide, so dbmate's reused connection carries the empty search_path into the next migration, which uses bare table names and fails with "relation does not exist".

Switching to `true` (transaction-local) restores the default search_path after baseline commits.

## Test plan

- [x] `dbmate up` against empty local Postgres applies all 22 migrations cleanly (was failing on migration 3 before)
- [ ] PR #393's `migrations` job passes after rebase
- [ ] No prod impact: prod's schema_migrations already includes baseline, so dbmate skips it