### PR TITLE
refactor(owletto-backend): drop switch_organization MCP tool

### DIFF
--- a/packages/owletto-backend/src/__tests__/integration/mcp/auth.test.ts
+++ b/packages/owletto-backend/src/__tests__/integration/mcp/auth.test.ts
@@ -61,7 +61,7 @@ describe('MCP Authentication', () => {
   });
 
   describe('Unauthenticated Requests', () => {
-    it('allows unauthenticated tools/list discovery requests including org switching', async () => {
+    it('allows unauthenticated tools/list discovery requests including list_organizations', async () => {
       const response = await post('/mcp', {
         body: {
           jsonrpc: '2.0',
@@ -78,7 +78,7 @@ describe('MCP Authentication', () => {
       expect(body.result.tools.length).toBeGreaterThan(0);
       const toolNames = body.result.tools.map((t: any) => t.name);
       expect(toolNames).toContain('list_organizations');
-      expect(toolNames).toContain('switch_organization');
+      expect(toolNames).not.toContain('switch_organization');
     });
 
     it('returns an OAuth challenge for anonymous root session stream requests', async () => {
@@ -437,38 +437,20 @@ describe('MCP Authentication', () => {
       expect(response.error).toBeUndefined();
     });
 
-    it('exposes org switching tools on unscoped /mcp for authenticated tokens', async () => {
+    it('exposes list_organizations on unscoped /mcp for authenticated tokens', async () => {
       const { token } = await createTestAccessToken(user.id, org.id, client.client_id);
 
       const result = await mcpListTools({ token });
       const toolNames = result.tools.map((tool: any) => tool.name);
 
       expect(toolNames).toContain('list_organizations');
-      expect(toolNames).toContain('switch_organization');
-    });
-
-    it('allows switching organizations within an unscoped MCP session', async () => {
-      const { token } = await createTestAccessToken(user.id, org.id, client.client_id);
-
-      const result = await mcpRequest(
-        'tools/call',
-        {
-          name: 'switch_organization',
-          arguments: { org: org2.slug },
-        },
-        { token }
-      );
-
-      expect(result.error).toBeUndefined();
-      const payload = JSON.parse(result.result?.content?.[0]?.text ?? '{}');
-      expect(payload.switched).toBe(true);
-      expect(payload.org.slug).toBe(org2.slug);
+      expect(toolNames).not.toContain('switch_organization');
     });
 
     it('recovers a stale authenticated MCP session from the persisted session store', async () => {
       const { token } = await createTestAccessToken(user.id, org.id, client.client_id);
 
-      const initResponse = await post('/mcp', {
+      const initResponse = await post(`/mcp/${org.slug}`, {
         body: {
           jsonrpc: '2.0',
           id: '__test_init__',
@@ -485,24 +467,10 @@ describe('MCP Authentication', () => {
       const sessionId = initResponse.headers.get('mcp-session-id');
       expect(sessionId).toBeTruthy();
 
-      await post('/mcp', {
+      await post(`/mcp/${org.slug}`, {
         body: {
           jsonrpc: '2.0',
           method: 'notifications/initialized',
-        },
-        headers: { 'mcp-session-id': sessionId! },
-        token,
-      });
-
-      await post('/mcp', {
-        body: {
-          jsonrpc: '2.0',
-          id: 1,
-          method: 'tools/call',
-          params: {
-            name: 'switch_organization',
-            arguments: { org: org2.slug },
-          },
         },
         headers: { 'mcp-session-id': sessionId! },
         token,
@@ -514,18 +482,18 @@ describe('MCP Authentication', () => {
         WHERE session_id = ${sessionId}
       `;
       expect(persistedRows).toHaveLength(1);
-      expect(persistedRows[0].organization_id).toBe(org2.id);
+      expect(persistedRows[0].organization_id).toBe(org.id);
 
       clearInMemoryMcpSessionsForTests();
 
-      const recoveredResponse = await post('/mcp', {
+      const recoveredResponse = await post(`/mcp/${org.slug}`, {
         body: {
           jsonrpc: '2.0',
           id: 2,
           method: 'tools/call',
           params: {
-            name: 'resolve_path',
-            arguments: { path: `/${org2.slug}`, include_bootstrap: false },
+            name: 'search_knowledge',
+            arguments: { query: 'recovery-probe-nonexistent-12345' },
           },
         },
         headers: { 'X-MCP-Format': 'json', 'mcp-session-id': sessionId! },
@@ -536,9 +504,6 @@ describe('MCP Authentication', () => {
       const recoveredBody = await recoveredResponse.json();
       expect(recoveredBody.error).toBeUndefined();
       expect(recoveredBody.result?.isError).not.toBe(true);
-
-      const payload = JSON.parse(recoveredBody.result.content[0].text);
-      expect(payload.workspace.slug).toBe(org2.slug);
     });
 
     it('binds an MCP session to a durable agent and updates last_used_at', async () => {
@@ -723,10 +688,7 @@ describe('MCP Authentication', () => {
       expect(body.error?.message).toContain("Agent 'missing-agent' was not found");
     });
 
-    it('exposes org switching tools on scoped /mcp/:org routes too', async () => {
-      // PR-2: list_organizations + switch_organization are no longer
-      // gated behind the unscoped /mcp endpoint. Scoped sessions can still
-      // call switch_organization to move off the URL pin.
+    it('exposes list_organizations on scoped /mcp/:org routes too', async () => {
       const { token } = await createTestAccessToken(user.id, org.id, client.client_id);
 
       const response = await post(`/mcp/${org.slug}`, {
@@ -744,12 +706,12 @@ describe('MCP Authentication', () => {
       const toolNames = body.result.tools.map((tool: any) => tool.name);
 
       expect(toolNames).toContain('list_organizations');
-      expect(toolNames).toContain('switch_organization');
+      expect(toolNames).not.toContain('switch_organization');
     });
   });
 
   describe('Session Cookie Authentication', () => {
-    it('exposes org switching tools on unscoped /mcp for authenticated browser sessions', async () => {
+    it('exposes list_organizations on unscoped /mcp for authenticated browser sessions', async () => {
       const response = await post('/mcp', {
         body: {
           jsonrpc: '2.0',
@@ -765,7 +727,7 @@ describe('MCP Authentication', () => {
       const toolNames = body.result.tools.map((tool: any) => tool.name);
 
       expect(toolNames).toContain('list_organizations');
-      expect(toolNames).toContain('switch_organization');
+      expect(toolNames).not.toContain('switch_organization');
     });
 
     it('allows a signed-in non-member to call public-readable REST tools on a public org', async () => {

--- a/packages/owletto-backend/src/auth/tool-access.ts
+++ b/packages/owletto-backend/src/auth/tool-access.ts
@@ -149,7 +149,6 @@ export function getRequiredAccessLevel(
   args: unknown,
   readOnlyHint: boolean
 ): ToolAccessLevel {
-  if (toolName === 'switch_organization') return 'read';
   if (toolName === 'list_organizations') return 'read';
   if (requiresOwnerAdmin(toolName, args, readOnlyHint)) return 'admin';
   if (requiresMemberWrite(toolName, args, readOnlyHint)) return 'write';

--- a/packages/owletto-backend/src/mcp-handler.ts
+++ b/packages/owletto-backend/src/mcp-handler.ts
@@ -93,11 +93,7 @@ export async function revokeInMemoryMcpSessionsForClient(
 /** Shared mutable ref so handleMcp can signal the format to tool handlers. */
 const formatRef = { rawJson: false };
 
-function createServerForContext(
-  env: Env,
-  authCtx: SessionAuthContext,
-  onAuthContextChanged?: () => Promise<void>
-): Server {
+function createServerForContext(env: Env, authCtx: SessionAuthContext): Server {
   const server = new Server(
     { name: 'owletto-mcp', version: '0.2.0' },
     {
@@ -107,10 +103,9 @@ function createServerForContext(
   );
 
   // tools/list — return our TypeBox JSON Schemas
-  // Read auth state dynamically so the list updates after auth upgrades or org switches.
+  // Read auth state dynamically so the list updates after auth upgrades.
   server.setRequestHandler(ListToolsRequestSchema, async () => {
     const includeInternalTools = authCtx.allowInternalTools === true && !authCtx.clientId;
-    const includeOrgSwitching = !authCtx.scopedToOrg;
     const publicOnly = !!authCtx.organizationId && !authCtx.memberRole;
     const roleAccessLevel = !authCtx.memberRole
       ? 'read'
@@ -132,7 +127,6 @@ function createServerForContext(
           : 'admin';
     const staticTools = getAllTools({
       includeInternalTools,
-      includeOrgSwitching,
       publicOnly,
       maxAccessLevel,
     });
@@ -153,23 +147,6 @@ function createServerForContext(
     // Regular tool execution
     try {
       const result = await executeTool(name, args ?? {}, env, authCtx);
-
-      // After a successful org switch, mutate the session's auth context
-      if (
-        name === 'switch_organization' &&
-        result &&
-        typeof result === 'object' &&
-        'switched' in (result as any)
-      ) {
-        const switchResult = result as { switched: true; org: { id: string; role: string } };
-        authCtx.organizationId = switchResult.org.id;
-        authCtx.memberRole = switchResult.org.role;
-        authCtx.agentId = null;
-        authCtx.instructions =
-          (await buildWorkspaceInstructions(authCtx.organizationId)) ?? undefined;
-        await syncAgentBinding(authCtx);
-        await onAuthContextChanged?.();
-      }
 
       if (authCtx.agentId && authCtx.organizationId) {
         await touchAgentLastUsed(authCtx.organizationId, authCtx.agentId);
@@ -595,11 +572,9 @@ function createSessionTransport(
   authCtx: SessionAuthContext,
   sessionIdGenerator: () => string
 ): { transport: WebStandardStreamableHTTPServerTransport; server: Server } {
-  const sessionIdRef: { id: string | null } = { id: null };
   const transport = new WebStandardStreamableHTTPServerTransport({
     sessionIdGenerator,
     onsessioninitialized: (id) => {
-      sessionIdRef.id = id;
       sessions.set(id, { transport, server, authCtx, lastAccessedAt: Date.now() });
     },
   });
@@ -609,9 +584,7 @@ function createSessionTransport(
       void deletePersistedSession(transport.sessionId);
     }
   };
-  const server = createServerForContext(env, authCtx, async () => {
-    await persistSessionState(sessionIdRef.id, authCtx);
-  });
+  const server = createServerForContext(env, authCtx);
   return { transport, server };
 }
 

--- a/packages/owletto-backend/src/sandbox/namespaces/organizations.ts
+++ b/packages/owletto-backend/src/sandbox/namespaces/organizations.ts
@@ -26,7 +26,7 @@ export interface OrganizationsNamespace {
   list(options?: { search?: string }): Promise<OrgSummary[]>;
   /**
    * Return the session's current organization context. Reflects the URL pin
-   * (`/mcp/{slug}`) or the last successful `switch_organization`.
+   * (`/mcp/{slug}`) or the user's default org for an unscoped /mcp session.
    */
   current(): Promise<OrgSummary>;
 }

--- a/packages/owletto-backend/src/tools/execute.ts
+++ b/packages/owletto-backend/src/tools/execute.ts
@@ -9,7 +9,7 @@ import { getRequiredAccessLevel, hasRequiredMcpScope, isPublicReadable } from '.
 import type { Env } from '../index';
 import { trackMCPToolCall } from '../sentry';
 import { getConfiguredPublicOrigin } from '../utils/public-origin';
-import { listOrganizations, switchOrganization } from './organizations';
+import { listOrganizations } from './organizations';
 import { getTool, type ToolContext } from './registry';
 
 /**
@@ -58,22 +58,20 @@ export function extractAuthContext(c: Context<{ Bindings: Env }>): AuthContext {
 /**
  * Check access control for a tool call. Throws on denial.
  */
-const ORG_AGNOSTIC_TOOLS = new Set(['list_organizations', 'switch_organization']);
+const ORG_AGNOSTIC_TOOLS = new Set(['list_organizations']);
 
 export function checkToolAccess(toolName: string, args: unknown, authCtx: AuthContext): void {
   if (ORG_AGNOSTIC_TOOLS.has(toolName)) {
     if (!authCtx.isAuthenticated) {
       throw new Error('Authentication required.');
     }
-    // list_organizations + switch_organization are read-tier; OAuth tokens
-    // without `mcp:read` (e.g. profile-only) must not call them.
+    // list_organizations is read-tier; OAuth tokens without `mcp:read`
+    // (e.g. profile-only) must not call it.
     if (!hasRequiredMcpScope('read', authCtx.scopes)) {
       throw new Error(
-        'This MCP session does not include read access. Reconnect with read access to list or switch organizations.'
+        'This MCP session does not include read access. Reconnect with read access to list organizations.'
       );
     }
-    // Exposed on both unscoped /mcp and scoped /mcp/{slug} endpoints. The URL
-    // pin defines the default org; switching moves the session.
     return;
   }
 
@@ -146,14 +144,6 @@ export async function executeTool(
     if (toolName === 'list_organizations') {
       return trackMCPToolCall(toolName, args, () =>
         listOrganizations(args as any, env, { userId: authCtx.userId! })
-      );
-    }
-    if (toolName === 'switch_organization') {
-      return trackMCPToolCall(toolName, args, () =>
-        switchOrganization(args as any, env, {
-          userId: authCtx.userId!,
-          currentOrgId: authCtx.organizationId,
-        })
       );
     }
   }

--- a/packages/owletto-backend/src/tools/organizations.ts
+++ b/packages/owletto-backend/src/tools/organizations.ts
@@ -1,39 +1,23 @@
 /**
- * Tools: list_organizations, switch_organization
+ * Tool: list_organizations
  *
- * Exposed on both unscoped /mcp and scoped /mcp/{slug} endpoints. The URL
- * pin defines the default org; switch_organization moves the session
- * regardless of how it was initiated.
+ * Discovery for the orgs the authenticated user belongs to (and any public
+ * workspaces the session can read). Exposed on both unscoped /mcp and
+ * scoped /mcp/{slug} endpoints. Cross-org reads from inside `execute` go
+ * through `client.org(slug)`; scripts that need a different default org
+ * should use a different /mcp/{slug} URL or PAT.
  */
 
 import { type Static, Type } from '@sinclair/typebox';
-import { getDb } from '../db/client';
 import type { Env } from '../index';
-import { buildWorkspaceInstructions } from '../utils/workspace-instructions';
 import { getWorkspaceProvider } from '../workspace';
 import type { OrgInfo } from '../workspace/types';
-
-// ---------------------------------------------------------------------------
-// Schemas
-// ---------------------------------------------------------------------------
 
 export const ListOrganizationsSchema = Type.Object({
   search: Type.Optional(
     Type.String({ description: 'Filter organizations by name (case-insensitive substring match)' })
   ),
 });
-
-export const SwitchOrganizationSchema = Type.Object({
-  org: Type.String({
-    description:
-      'Organization slug to switch to (must appear in a prior list_organizations result)',
-    minLength: 1,
-  }),
-});
-
-// ---------------------------------------------------------------------------
-// Handlers
-// ---------------------------------------------------------------------------
 
 export async function listOrganizations(
   args: Static<typeof ListOrganizationsSchema>,
@@ -48,54 +32,5 @@ export async function listOrganizations(
     is_member: o.is_member,
     visibility: o.visibility,
   }));
-}
-
-export async function switchOrganization(
-  args: Static<typeof SwitchOrganizationSchema>,
-  _env: Env,
-  ctx: { userId: string; currentOrgId: string | null }
-): Promise<{
-  switched: true;
-  org: { slug: string; name: string; id: string; role: string };
-  previous_org_slug: string | null;
-  instructions: string | null;
-}> {
-  const sql = getDb();
-
-  // Resolve slug → org
-  const orgRows = await sql`
-    SELECT id, name, slug FROM "organization" WHERE slug = ${args.org} LIMIT 1
-  `;
-  if (orgRows.length === 0) {
-    throw new Error(`Organization '${args.org}' not found`);
-  }
-  const org = orgRows[0] as { id: string; name: string; slug: string };
-
-  // Verify membership
-  const memberRows = await sql`
-    SELECT role FROM "member"
-    WHERE "organizationId" = ${org.id} AND "userId" = ${ctx.userId}
-    LIMIT 1
-  `;
-  if (memberRows.length === 0) {
-    throw new Error(`You are not a member of organization '${args.org}'`);
-  }
-  const role = memberRows[0].role as string;
-
-  // Resolve previous org slug
-  let previousOrgSlug: string | null = null;
-  if (ctx.currentOrgId) {
-    previousOrgSlug = await getWorkspaceProvider().getOrgSlug(ctx.currentOrgId);
-  }
-
-  // Build workspace instructions for the new org
-  const instructions = await buildWorkspaceInstructions(org.id);
-
-  return {
-    switched: true,
-    org: { slug: org.slug, name: org.name, id: org.id, role },
-    previous_org_slug: previousOrgSlug,
-    instructions,
-  };
 }
 

--- a/packages/owletto-backend/src/tools/registry.ts
+++ b/packages/owletto-backend/src/tools/registry.ts
@@ -10,10 +10,7 @@ import { getPublicReadableActions, getRequiredAccessLevel } from '../auth/tool-a
 import type { Env } from '../index';
 import { LEGACY_ADMIN_TOOLS } from './admin';
 import { QuerySqlSchema, querySql } from './admin/query_sql';
-import {
-  ListOrganizationsSchema,
-  SwitchOrganizationSchema,
-} from './organizations';
+import { ListOrganizationsSchema } from './organizations';
 import { ResolvePathSchema, resolvePath } from './resolve_path';
 import { SaveContentSchema, saveContent } from './save_content';
 import { SearchSchema, search } from './search';
@@ -71,8 +68,6 @@ export interface ToolDefinition<T = any> {
   annotations?: ToolAnnotations;
   /** Internal tools are excluded from external MCP clients (only available to the frontend) */
   internal?: boolean;
-  /** Org-switching tools are only exposed when the session uses the unscoped /mcp endpoint */
-  orgSwitching?: boolean;
   handler: (args: T, env: Env, ctx: ToolContext) => Promise<any>;
 }
 
@@ -145,23 +140,13 @@ const TOOLS: ToolDefinition[] = [
       return await resolvePath(args, env, ctx);
     },
   },
-  // ─── Org tools (now exposed on both unscoped and scoped /mcp endpoints) ───
+  // ─── Org discovery (exposed on both unscoped and scoped /mcp endpoints) ───
   {
     name: 'list_organizations',
     description:
-      'List organizations the authenticated user belongs to, plus any public workspaces the session can read.',
+      'List organizations the authenticated user belongs to, plus any public workspaces the session can read. Use the slug with `client.org(slug)` inside an `execute` script for cross-org reads, or reconnect the MCP client to /mcp/{slug} to pin a different default.',
     inputSchema: ListOrganizationsSchema,
     annotations: { readOnlyHint: true, idempotentHint: true },
-    handler: async () => {
-      throw new Error('Handled directly in executeTool');
-    },
-  },
-  {
-    name: 'switch_organization',
-    description:
-      'Switch the current session to a different organization the user is a member of. After switching, all subsequent tool calls operate in the new org context. Available on both /mcp and /mcp/{slug} endpoints — on a scoped endpoint the URL pin defines the default, but a switch can move the session.',
-    inputSchema: SwitchOrganizationSchema,
-    annotations: { readOnlyHint: false },
     handler: async () => {
       throw new Error('Handled directly in executeTool');
     },
@@ -277,17 +262,14 @@ function filterSchemaForAccessLevel(
  */
 export function getAllTools(options?: {
   includeInternalTools?: boolean;
-  includeOrgSwitching?: boolean;
   publicOnly?: boolean;
   maxAccessLevel?: 'read' | 'write' | 'admin';
 }) {
   const includeInternalTools = options?.includeInternalTools ?? true;
-  const includeOrgSwitching = options?.includeOrgSwitching ?? false;
   const publicOnly = options?.publicOnly ?? false;
   const maxAccessLevel = options?.maxAccessLevel ?? 'admin';
 
   return TOOLS.filter((tool) => includeInternalTools || !tool.internal)
-    .filter((tool) => includeOrgSwitching || !tool.orgSwitching)
     .filter((tool) => !publicOnly || getPublicReadableActions(tool.name) !== undefined)
     .map((tool) => {
       let inputSchema = tool.inputSchema;

--- a/packages/owletto-backend/src/utils/workspace-instructions.ts
+++ b/packages/owletto-backend/src/utils/workspace-instructions.ts
@@ -154,7 +154,7 @@ export async function buildWorkspaceInstructions(organizationId: string): Promis
     sections.push(
       '',
       '### Tool surface',
-      'External MCP tools: `search_knowledge`, `save_knowledge`, `query_sql`, `search` (SDK method discovery), `execute` (run TS over the typed client SDK), `list_organizations`, `switch_organization`, `resolve_path`.',
+      'External MCP tools: `search_knowledge`, `save_knowledge`, `query_sql`, `search` (SDK method discovery), `execute` (run TS over the typed client SDK), `list_organizations`, `resolve_path`.',
       'For everything else (entity CRUD, watchers, classifiers, connections, feeds, view templates, operations) write a TS script and call via `execute`. Use `search` to discover method names.',
       '',
       '### Saving (do this automatically)',


### PR DESCRIPTION
## Summary

- Removes `switch_organization` from the MCP surface. Cross-org reads now go through `client.org(slug)` inside `execute`, or by reconnecting to `/mcp/{slug}`.
- Removes the auth-context mutation block in `mcp-handler.ts` plus the `onAuthContextChanged` callback / `sessionIdRef` plumbing that only existed to persist a successful org switch.
- Cleans up the now-dead `orgSwitching` flag on `ToolDefinition` and `includeOrgSwitching` filter in `getAllTools`.
- Updates the published "Tool surface" line in workspace instructions and the `list_organizations` description to point users at `client.org(slug)` and the URL-pin pattern.

`list_organizations` stays for discovery.

## Why

Three paths overlapped: URL pin (`/mcp/{slug}`), session-state mutation (`switch_organization`), and per-call cross-org via `client.org(slug)` inside `execute`. The middle path is the problem child — it rewrote `authCtx.organizationId`/`memberRole`/`agentId` mid-session, required a follow-on persistence callback, and was exposed on scoped URL-pinned endpoints too, which made the pin semantics ambiguous. Dropping it leaves two clean primitives (URL pin for the default org, `client.org(slug)` for explicit per-call cross-org).

## Test plan

- [x] `bun run typecheck` clean
- [x] Renamed three "exposes org switching tools" assertions to verify `list_organizations` is present and `switch_organization` is absent
- [x] Dropped the explicit "allows switching organizations" integration test
- [x] Rewrote stale-session-recovery test against a scoped `/mcp/{slug}` session with `search_knowledge` (was previously switching off the URL pin and asserting against the internal-only `resolve_path`); the rewritten test passes
- [x] No new failures vs `main` in `src/__tests__/integration/mcp/auth.test.ts` — the residual failures there are pre-existing
- [x] `pi` review (second pass) confirmed no leftover references, OAuth-client guard on `includeInternalTools` retained, no new security issue

## Out of scope

The original ask included also exposing the legacy `manage_*` admin tools to `owletto-cli` instead of routing it through `execute`. That was prototyped here and reverted — the obvious "trust by `client_name === 'Owletto CLI'`" allowlist is forgeable through dynamic OAuth client registration. The CLI already has the only two admin tools its `browser-auth` flow needs (`manage_connections`, `manage_auth_profiles`) on the public surface; the rest will need a separate, non-DCR-controllable trust signal (server-seeded client record or admin-flagged metadata) — out of scope for this cleanup.