### PR TITLE
chore(format): unbreak format-lint on main

### DIFF
--- a/packages/core/src/worker/auth.ts
+++ b/packages/core/src/worker/auth.ts
@@ -125,7 +125,10 @@ export function verifyWorkerToken(token: string): WorkerTokenData | null {
     // the actual decryption / parse error as `{}`, hiding the real cause.
     logger.error(
       {
-        err: error instanceof Error ? { name: error.name, message: error.message } : error,
+        err:
+          error instanceof Error
+            ? { name: error.name, message: error.message }
+            : error,
       },
       "Error verifying token"
     );


### PR DESCRIPTION
## Summary
- One-line biome format fix for `verifyWorkerToken` err-logger block.
- The unformatted code landed via #405 (`fix(connector-catalog,worker-auth)`); biome's PR-gate caught it but the merged commit's format-lint went red and is now blocking every open PR.

## Test plan
- [x] `bun run format:check` passes locally.
- [ ] CI green on `format-lint`.