### PR TITLE
docs(claude.md): point agents at in-tree packages/owletto-backend

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,3 +3,7 @@
 ## Local-only references
 
 - `../owletto` (i.e. `/Users/burakemre/Code/owletto`) is the Owletto source repo. The OpenClaw memory plugin published as `@lobu/owletto-openclaw` lives in `packages/openclaw-plugin` there.
+
+## Owletto
+
+The live Owletto MCP server, ClientSDK, sandbox, and tool registry are in `packages/owletto-backend/` of this repo. The prod `summaries-app-owletto-app` image is built from there (`docker/app/Dockerfile`). Any question about Owletto behavior — MCP tools, instructions, sandbox, SDK, auth — is answered from that path.


### PR DESCRIPTION
## Summary
- Adds an "Owletto" section to `CLAUDE.md` so agents know the live MCP server, ClientSDK, sandbox, and tool registry live in `packages/owletto-backend/` (not in the `../owletto` source repo).
- Keeps the existing `Local-only references` pointer for the OpenClaw memory plugin.

## Test plan
- [x] Docs only — no code paths touched.