### PR TITLE
fix(public-pages): serve scrapeable HTML for generic clients

### DIFF
--- a/packages/owletto-backend/src/__tests__/integration/pages/public-pages.test.ts
+++ b/packages/owletto-backend/src/__tests__/integration/pages/public-pages.test.ts
@@ -79,11 +79,25 @@ describe('Public pages', () => {
 
     const body = await response.text();
     expect(response.status).toBe(200);
+    expect(response.headers.get('cache-control')).toContain('public, max-age=300');
     expect(body).toContain('<meta name="description"');
     expect(body).toContain('Public SEO Org | Owletto');
     expect(body).toContain('window.__OWLETTO_PUBLIC_BOOTSTRAP__');
     expect(body).toContain('Tracked public brands');
     expect(body).toContain('Brand launch feedback');
+  });
+
+  it('serves scrapeable public HTML for generic GET clients', async () => {
+    const response = await get('/public-seo-org', {
+      env: { PUBLIC_WEB_URL: 'https://www.owletto.test' },
+    });
+
+    const body = await response.text();
+    expect(response.status).toBe(200);
+    expect(response.headers.get('content-type')).toContain('text/html');
+    expect(body).toContain('Public SEO Org | Owletto');
+    expect(body).toContain('Brand launch feedback');
+    expect(body).not.toContain('"mcp_endpoint"');
   });
 
   it('renders public entity type pages with crawlable listing content', async () => {

--- a/packages/owletto-backend/src/index.ts
+++ b/packages/owletto-backend/src/index.ts
@@ -991,12 +991,18 @@ app.all('/mcp/:orgSlug/', handleMcp);
  */
 app.get('*', async (c) => {
   const requestPath = c.req.path;
-  const acceptsHtml = c.req.header('accept')?.includes('text/html') ?? false;
+  const acceptHeader = c.req.header('accept') ?? '';
+  const acceptsHtml = acceptHeader.includes('text/html');
+  const acceptsGenericResponse = !acceptHeader || acceptHeader.includes('*/*');
   const hasFileExtension =
     /\.(?:js|css|html|json|map|png|jpe?g|gif|svg|ico|webp|avif|woff2?|ttf|eot|txt|xml)$/i.test(
       requestPath
     );
-  if (acceptsHtml && !hasFileExtension && !isExcludedSpaPath(requestPath)) {
+  if (
+    (acceptsHtml || acceptsGenericResponse) &&
+    !hasFileExtension &&
+    !isExcludedSpaPath(requestPath)
+  ) {
     const publicPageModel = await buildPublicPageModel(
       requestPath,
       c.env,


### PR DESCRIPTION
## Summary
- serve public-page HTML for generic GET clients (empty or */* Accept) so curl/simple scrapers get crawlable content instead of the JSON health fallback
- assert public HTML cache headers and generic-client scrapeability in public page integration coverage

## Related
- Frontend progressive enhancement fix: https://github.com/lobu-ai/owletto-web/pull/37
- Submodule drift unblocker: https://github.com/lobu-ai/lobu/pull/416
- After the owletto-web PR merges, the parent submodule pointer still needs a separate bump PR for that new SHA.

## Cloudflare
I applied the Cloudflare cache rule directly via the Cloudflare Rulesets API and removed the repo helper script from this PR to keep the diff focused.

Verified:
- public HTML: `curl -H 'Accept: text/html' https://app.lobu.ai/market-intelligence` returns cached public HTML from Cloudflare
- MCP excluded: `curl https://app.lobu.ai/mcp` returns `cf-cache-status: DYNAMIC`

## Validation
- bunx biome check --config-path config/biome.config.json --write package.json packages/owletto-backend/src/index.ts packages/owletto-backend/src/__tests__/integration/pages/public-pages.test.ts
- bun test packages/owletto-backend/src/__tests__/integration/pages/public-pages.test.ts *(blocked locally: DATABASE_URL is not set in the isolated worktree)*
