### PR TITLE
fix(events): make creator attribution nullable

### DIFF
--- a/db/migrations/20260427133000_events_created_by_nullable.sql
+++ b/db/migrations/20260427133000_events_created_by_nullable.sql
@@ -1,0 +1,74 @@
+-- migrate:up transaction:false
+
+-- `events.created_by` represents the Owletto user that explicitly saved or
+-- authored an event. Connector/scheduled/system-produced events have no human
+-- saver; their provenance is represented by connector_key, connection_id,
+-- feed_id, run_id, and client_id. Keep user attribution nullable and enforce
+-- that any non-null value is a real user id instead of a sentinel string.
+SET lock_timeout = '5s';
+
+ALTER TABLE public.events
+    ALTER COLUMN created_by DROP NOT NULL;
+
+-- During a rolling deploy, old application pods may still write the historical
+-- 'system'/'api' sentinel actors. Normalize only those known sentinels to NULL
+-- before the FK sees them. Unknown non-user values should still be rejected.
+CREATE OR REPLACE FUNCTION public.normalize_event_created_by()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    IF NEW.created_by IN ('system', 'api') AND NOT EXISTS (
+        SELECT 1 FROM public."user" u WHERE u.id = NEW.created_by
+    ) THEN
+        NEW.created_by := NULL;
+    END IF;
+    RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS normalize_event_created_by ON public.events;
+CREATE TRIGGER normalize_event_created_by
+    BEFORE INSERT OR UPDATE OF created_by ON public.events
+    FOR EACH ROW
+    EXECUTE FUNCTION public.normalize_event_created_by();
+
+-- The previous integrity migration backfilled NULL event actors to 'system'.
+-- Convert those sentinel values back to NULL. This uses idx_events_created_by.
+SET lock_timeout = 0;
+UPDATE public.events e
+   SET created_by = NULL
+ WHERE e.created_by IN ('system', 'api')
+   AND NOT EXISTS (
+       SELECT 1 FROM public."user" u WHERE u.id = e.created_by
+   );
+SET lock_timeout = '5s';
+
+ALTER TABLE public.events
+    ADD CONSTRAINT events_created_by_fkey
+    FOREIGN KEY (created_by)
+    REFERENCES public."user"(id)
+    ON DELETE SET NULL
+    NOT VALID;
+
+SET lock_timeout = 0;
+ALTER TABLE public.events
+    VALIDATE CONSTRAINT events_created_by_fkey;
+SET lock_timeout = '5s';
+
+-- migrate:down transaction:false
+
+ALTER TABLE public.events
+    DROP CONSTRAINT IF EXISTS events_created_by_fkey;
+
+DROP TRIGGER IF EXISTS normalize_event_created_by ON public.events;
+DROP FUNCTION IF EXISTS public.normalize_event_created_by();
+
+SET lock_timeout = 0;
+UPDATE public.events
+   SET created_by = 'system'
+ WHERE created_by IS NULL;
+SET lock_timeout = '5s';
+
+ALTER TABLE public.events
+    ALTER COLUMN created_by SET NOT NULL;

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -948,7 +948,7 @@ CREATE TABLE public.events (
     run_id bigint,
     semantic_type text DEFAULT 'content'::text NOT NULL,
     client_id text,
-    created_by text NOT NULL,
+    created_by text,
     interaction_type text DEFAULT 'none'::text NOT NULL,
     interaction_status text,
     interaction_input_schema jsonb,
@@ -5348,6 +5348,14 @@ ALTER TABLE ONLY public.event_embeddings
 
 ALTER TABLE ONLY public.events
     ADD CONSTRAINT events_client_id_fkey FOREIGN KEY (client_id) REFERENCES public.oauth_clients(id) ON DELETE SET NULL;
+
+
+--
+-- Name: events events_created_by_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.events
+    ADD CONSTRAINT events_created_by_fkey FOREIGN KEY (created_by) REFERENCES public."user"(id) ON DELETE SET NULL;
 
 
 --

--- a/packages/owletto-backend/src/__tests__/integration/events/worker-poll-scheduling.test.ts
+++ b/packages/owletto-backend/src/__tests__/integration/events/worker-poll-scheduling.test.ts
@@ -12,6 +12,107 @@ describe('Worker Poll Scheduling', () => {
     await cleanupTestDatabase();
   });
 
+  it('streams connector events without a human creator', async () => {
+    const sql = getTestDb();
+
+    const org = await createTestOrganization({ name: 'Worker Stream Org' });
+
+    await createTestConnectorDefinition({
+      key: 'test.worker.stream',
+      name: 'Worker Stream Connector',
+      version: '1.0.0',
+      feeds_schema: {
+        mentions: { description: 'Mentions feed' },
+      },
+      organization_id: org.id,
+    });
+
+    const connection = await createTestConnection({
+      organization_id: org.id,
+      connector_key: 'test.worker.stream',
+      status: 'active',
+    });
+
+    const [feed] = await sql`
+      INSERT INTO feeds (
+        organization_id,
+        connection_id,
+        feed_key,
+        status,
+        created_at,
+        updated_at
+      ) VALUES (
+        ${org.id},
+        ${connection.id},
+        'mentions',
+        'active',
+        current_timestamp,
+        current_timestamp
+      )
+      RETURNING id
+    `;
+
+    const [run] = await sql`
+      INSERT INTO runs (
+        organization_id,
+        run_type,
+        feed_id,
+        connection_id,
+        connector_key,
+        connector_version,
+        status,
+        approval_status,
+        created_at
+      ) VALUES (
+        ${org.id},
+        'sync',
+        ${feed.id},
+        ${connection.id},
+        'test.worker.stream',
+        '1.0.0',
+        'running',
+        'auto',
+        current_timestamp
+      )
+      RETURNING id
+    `;
+
+    const response = await post('/api/workers/stream', {
+      body: {
+        type: 'batch',
+        run_id: Number(run.id),
+        items: [
+          {
+            id: 'source-item-1',
+            title: 'Source item',
+            payload_text: 'Connector-sourced content',
+            source_url: 'https://example.com/source-item-1',
+            occurred_at: new Date().toISOString(),
+            score: 10,
+          },
+        ],
+      },
+    });
+
+    expect(response.status).toBe(200);
+
+    const events = await sql`
+      SELECT created_by, connector_key, connection_id, feed_id, run_id, author_name
+      FROM events
+      WHERE origin_id = 'source-item-1'
+        AND organization_id = ${org.id}
+      LIMIT 1
+    `;
+
+    expect(events).toHaveLength(1);
+    expect(events[0].created_by).toBeNull();
+    expect(events[0].author_name).toBeNull();
+    expect(events[0].connector_key).toBe('test.worker.stream');
+    expect(Number(events[0].connection_id)).toBe(Number(connection.id));
+    expect(Number(events[0].feed_id)).toBe(Number(feed.id));
+    expect(Number(events[0].run_id)).toBe(Number(run.id));
+  });
+
   it('materializes and claims at most one due sync run under concurrent polls', async () => {
     const sql = getTestDb();
 

--- a/packages/owletto-backend/src/tools/admin/manage_entity.ts
+++ b/packages/owletto-backend/src/tools/admin/manage_entity.ts
@@ -642,7 +642,7 @@ async function handleUpdate(
       title: `Entity updated: ${changes.map((c) => c.field).join(', ')}`,
       content: `Entity "${entityDetails.name}" (id: ${entityId}) updated:\n${contentLines.join('\n')}`,
       metadata: { changes },
-      createdBy: ctx.userId ?? 'system',
+      createdBy: ctx.userId ?? null,
       clientId: ctx.clientId ?? null,
     });
   }

--- a/packages/owletto-backend/src/utils/insert-event.ts
+++ b/packages/owletto-backend/src/utils/insert-event.ts
@@ -220,7 +220,7 @@ export async function insertEvent(
 
   const insertWithClientId = (clientId: string | null) => sql`
     INSERT INTO events (
-      entity_ids, organization_id, source_id, origin_id, title,
+      entity_ids, organization_id, origin_id, title,
       payload_type, payload_text, payload_data, payload_template, attachments, metadata,
       score, author_name, source_url, occurred_at, origin_parent_id, origin_type,
       connector_key, connection_id, feed_key, feed_id, run_id,
@@ -230,7 +230,6 @@ export async function insertEvent(
     ) VALUES (
       ${entityIdsValue}::bigint[],
       ${params.organizationId},
-      ${params.connectionId ?? null},
       ${params.originId},
       ${params.title ?? null},
       ${params.payloadType ?? 'text'},
@@ -293,7 +292,7 @@ interface ChangeEventParams {
   title: string;
   content: string;
   metadata: Record<string, unknown>;
-  createdBy?: string;
+  createdBy?: string | null;
   clientId?: string | null;
 }
 
@@ -316,7 +315,7 @@ export function recordChangeEvent(params: ChangeEventParams): void {
     content: params.content,
     semanticType: 'change',
     metadata: params.metadata,
-    createdBy: params.createdBy ?? 'system',
+    createdBy: params.createdBy ?? null,
     clientId: params.clientId ?? null,
   }).catch((err) => {
     logger.warn({ err, title: params.title }, 'Failed to record change event');

--- a/packages/owletto-backend/src/utils/scoring-profiles.ts
+++ b/packages/owletto-backend/src/utils/scoring-profiles.ts
@@ -14,11 +14,11 @@ const SCORING_PROFILE_SET = new Set<string>(SCORING_PROFILE_VALUES);
 
 const SCORING_PROFILE_SQL_MAP: Record<ScoringProfile, string> = {
   engagement_percentile_content_60_40: `
-    PERCENT_RANK() OVER (PARTITION BY f.source_id ORDER BY f.score) * 100 * 0.6 +
+    PERCENT_RANK() OVER (PARTITION BY f.connection_id ORDER BY f.score) * 100 * 0.6 +
     LEAST(f.content_length / 20.0, 100) * 0.4
   `,
   engagement_percentile_content_70_30_shortform: `
-    PERCENT_RANK() OVER (PARTITION BY f.source_id ORDER BY f.score) * 100 * 0.7 +
+    PERCENT_RANK() OVER (PARTITION BY f.connection_id ORDER BY f.score) * 100 * 0.7 +
     LEAST(f.content_length / 2.8, 100) * 0.3
   `,
   inverse_rating_content_50_50: `
@@ -27,22 +27,22 @@ const SCORING_PROFILE_SQL_MAP: Record<ScoringProfile, string> = {
   `,
   inverse_rating_engagement_content_30_40_30: `
     (5.0 - COALESCE((f.metadata->>'rating')::numeric, 3)) / 4.0 * 100 * 0.3 +
-    PERCENT_RANK() OVER (PARTITION BY f.source_id ORDER BY f.score) * 100 * 0.4 +
+    PERCENT_RANK() OVER (PARTITION BY f.connection_id ORDER BY f.score) * 100 * 0.4 +
     LEAST(f.content_length / 20.0, 100) * 0.3
   `,
   inverse_rating_helpful_content_30_40_30: `
     (5.0 - COALESCE((f.metadata->>'rating')::numeric, 3)) / 4.0 * 100 * 0.3 +
-    PERCENT_RANK() OVER (PARTITION BY f.source_id ORDER BY COALESCE((f.metadata->>'helpful_count')::numeric, 0)) * 100 * 0.4 +
+    PERCENT_RANK() OVER (PARTITION BY f.connection_id ORDER BY COALESCE((f.metadata->>'helpful_count')::numeric, 0)) * 100 * 0.4 +
     LEAST(f.content_length / 20.0, 100) * 0.3
   `,
   inverse_rating_thumbs_content_30_40_30: `
     (5.0 - COALESCE((f.metadata->>'rating')::numeric, 3)) / 4.0 * 100 * 0.3 +
-    PERCENT_RANK() OVER (PARTITION BY f.source_id ORDER BY COALESCE((f.metadata->>'thumbs_up')::numeric, 0)) * 100 * 0.4 +
+    PERCENT_RANK() OVER (PARTITION BY f.connection_id ORDER BY COALESCE((f.metadata->>'thumbs_up')::numeric, 0)) * 100 * 0.4 +
     LEAST(f.content_length / 20.0, 100) * 0.3
   `,
   inverse_rating_votesum_content_30_40_30: `
     (5.0 - COALESCE((f.metadata->>'rating')::numeric, 3)) / 4.0 * 100 * 0.3 +
-    PERCENT_RANK() OVER (PARTITION BY f.source_id ORDER BY COALESCE((f.metadata->>'vote_sum')::numeric, 0)) * 100 * 0.4 +
+    PERCENT_RANK() OVER (PARTITION BY f.connection_id ORDER BY COALESCE((f.metadata->>'vote_sum')::numeric, 0)) * 100 * 0.4 +
     LEAST(f.content_length / 20.0, 100) * 0.3
   `,
 };

--- a/packages/owletto-backend/src/utils/table-schema.ts
+++ b/packages/owletto-backend/src/utils/table-schema.ts
@@ -54,7 +54,6 @@ export const QUERYABLE_SCHEMA = {
         'id',
         'organization_id',
         'entity_ids',
-        'source_id',
         'origin_id',
         'title',
         'payload_type',


### PR DESCRIPTION
## Summary
- make events.created_by nullable user attribution and normalize legacy system/api sentinels
- add FK for non-null event creators and a rolling-deploy trigger for legacy sentinel writes
- stop writing/using legacy events.source_id from backend code while leaving the physical column for deploy compatibility
- add worker stream regression coverage for connector events without a human creator

## Validation
- OWLETTO_TEST_BACKEND=pglite bunx vitest run src/__tests__/integration/events/worker-poll-scheduling.test.ts -t "streams connector events without a human creator"
- cd packages/owletto-backend && bun run typecheck
- clauded2/claude review: NO BLOCKING FINDINGS