### PR TITLE
fix(public-pages): skip SSR shell for signed-in users

### DIFF
--- a/packages/owletto-backend/src/__tests__/integration/pages/public-pages.test.ts
+++ b/packages/owletto-backend/src/__tests__/integration/pages/public-pages.test.ts
@@ -80,6 +80,7 @@ describe('Public pages', () => {
     const body = await response.text();
     expect(response.status).toBe(200);
     expect(response.headers.get('cache-control')).toContain('public, max-age=300');
+    expect(response.headers.get('vary')).toContain('Cookie');
     expect(body).toContain('<meta name="description"');
     expect(body).toContain('Public SEO Org | Owletto');
     expect(body).toContain('window.__OWLETTO_PUBLIC_BOOTSTRAP__');
@@ -97,6 +98,40 @@ describe('Public pages', () => {
     expect(response.headers.get('content-type')).toContain('text/html');
     expect(body).toContain('Public SEO Org | Owletto');
     expect(body).toContain('Brand launch feedback');
+    expect(body).not.toContain('"mcp_endpoint"');
+  });
+
+  it('serves the SPA shell for signed-in public workspace requests', async () => {
+    const response = await get('/public-seo-org', {
+      headers: { Accept: 'text/html' },
+      cookie: '__Host-better-auth.session_token=test-session-token',
+      env: { PUBLIC_WEB_URL: 'https://www.owletto.test' },
+    });
+
+    const body = await response.text();
+    expect(response.status).toBe(200);
+    expect(response.headers.get('cache-control')).toContain('no-cache, no-store');
+    expect(response.headers.get('cache-control')).not.toContain('public, max-age=300');
+    expect(body).toContain('<title>Owletto</title>');
+    expect(body).toContain('<div id="root"></div>');
+    expect(body).not.toContain('window.__OWLETTO_PUBLIC_BOOTSTRAP__');
+    expect(body).not.toContain('Public SEO Org | Owletto');
+  });
+
+  it('serves the SPA shell for signed-in generic public workspace requests', async () => {
+    const response = await get('/public-seo-org', {
+      cookie: 'better-auth.session_token=test-session-token',
+      env: { PUBLIC_WEB_URL: 'https://www.owletto.test' },
+    });
+
+    const body = await response.text();
+    expect(response.status).toBe(200);
+    expect(response.headers.get('cache-control')).toContain('no-cache, no-store');
+    expect(response.headers.get('cache-control')).not.toContain('public, max-age=300');
+    expect(body).toContain('<title>Owletto</title>');
+    expect(body).toContain('<div id="root"></div>');
+    expect(body).not.toContain('window.__OWLETTO_PUBLIC_BOOTSTRAP__');
+    expect(body).not.toContain('Public SEO Org | Owletto');
     expect(body).not.toContain('"mcp_endpoint"');
   });
 

--- a/packages/owletto-backend/src/index.ts
+++ b/packages/owletto-backend/src/index.ts
@@ -212,6 +212,10 @@ function getContentTypeForStaticFile(filePath: string): string {
   );
 }
 
+function hasBetterAuthSessionCookie(cookieHeader: string | null | undefined): boolean {
+  return (cookieHeader ?? '').includes('better-auth.session_token=');
+}
+
 function resolveStaticFilePath(distDir: string, requestPath: string): string | null {
   const normalizedPath = path.posix.normalize(requestPath || '/');
   if (normalizedPath.includes('..')) {
@@ -994,15 +998,17 @@ app.get('*', async (c) => {
   const acceptHeader = c.req.header('accept') ?? '';
   const acceptsHtml = acceptHeader.includes('text/html');
   const acceptsGenericResponse = !acceptHeader || acceptHeader.includes('*/*');
+  const hasSessionCookie = hasBetterAuthSessionCookie(c.req.header('cookie'));
   const hasFileExtension =
     /\.(?:js|css|html|json|map|png|jpe?g|gif|svg|ico|webp|avif|woff2?|ttf|eot|txt|xml)$/i.test(
       requestPath
     );
-  if (
-    (acceptsHtml || acceptsGenericResponse) &&
-    !hasFileExtension &&
-    !isExcludedSpaPath(requestPath)
-  ) {
+  const isSpaRoute = !hasFileExtension && !isExcludedSpaPath(requestPath);
+  // Generic signed-in requests still need the SPA shell; otherwise they would fall through to the
+  // JSON status response after skipping anonymous public SSR.
+  const shouldServeSpaFallback =
+    (acceptsHtml || (acceptsGenericResponse && hasSessionCookie)) && isSpaRoute;
+  if ((acceptsHtml || acceptsGenericResponse) && !hasSessionCookie && isSpaRoute) {
     const publicPageModel = await buildPublicPageModel(
       requestPath,
       c.env,
@@ -1015,6 +1021,7 @@ app.get('*', async (c) => {
         const rendered = renderPublicPageTemplate(template, publicPageModel);
         const html = viteDev ? await viteDev.transformIndexHtml(c.req.path, rendered) : rendered;
         c.header('Cache-Control', publicPageModel.cacheControl);
+        c.header('Vary', 'Accept, Cookie');
         return c.html(html, publicPageModel.status as 200 | 404);
       }
     }
@@ -1022,7 +1029,7 @@ app.get('*', async (c) => {
 
   // Dev: serve Vite-transformed index.html for SPA routes
   if (viteDev) {
-    if (acceptsHtml && !hasFileExtension) {
+    if (shouldServeSpaFallback) {
       const raw = await fs.readFile(path.resolve(viteDev.config.root, 'index.html'), 'utf-8');
       const html = await viteDev.transformIndexHtml(c.req.path, raw);
       return c.html(html);
@@ -1045,7 +1052,7 @@ app.get('*', async (c) => {
       }
     }
 
-    if (acceptsHtml && !hasFileExtension && !isExcludedSpaPath(requestPath)) {
+    if (shouldServeSpaFallback) {
       try {
         const spaEntry = resolveStaticFilePath(webDistDirectory, '/index.html');
         if (spaEntry) {


### PR DESCRIPTION
## Summary
- skip the public SEO SSR shell when a Better Auth session cookie is present
- signed-in users get the normal SPA shell instead, avoiding a public/anonymous page flashing before their authenticated workspace UI
- keep anonymous/generic clients on public SSR HTML for SEO and scraping
- add integration coverage for signed-in public workspace requests returning the SPA shell

## Cloudflare
Updated the live Cloudflare cache rule to avoid public HTML cache hits for Better Auth session cookies:
`not http.cookie contains "better-auth.session_token"`

## Validation
- git diff --check
- targeted biome check was not applicable because backend paths are ignored by the repo Biome config
- backend integration test not run locally because it requires DATABASE_URL/test DB
