### PR TITLE
feat(identity): facts-as-events engine — schema, indexes, ingest, golden tests

### DIFF
--- a/db/migrations/20260427140000_identity_engine_indexes.sql
+++ b/db/migrations/20260427140000_identity_engine_indexes.sql
@@ -1,0 +1,80 @@
+-- migrate:up
+
+-- Identity-engine schema additions.
+--
+-- The follow-up identity engine writes connector-emitted facts as rows in
+-- `events` with `semantic_type='identity_fact'` and stores derivation
+-- provenance as metadata on `entity_relationships`. Auto-create rules live
+-- as JSONB on `entity_relationship_types.metadata` (compiled from YAML by
+-- the seeder). All three shapes need selective indexes so the hot paths
+-- don't full-scan.
+--
+-- Pattern matches the existing per-namespace event metadata indexes added
+-- in 20260419120000_add_event_identity_indexes.sql.
+
+-- ── Rule storage on relationship types ─────────────────────────────────
+-- The engine reads each relationship type's `metadata.autoCreateWhen[]` to
+-- decide which rules to fire on each incoming fact. Adding the column up
+-- front (NULL allowed) keeps the seeder change non-destructive.
+ALTER TABLE public.entity_relationship_types
+    ADD COLUMN IF NOT EXISTS metadata jsonb;
+
+CREATE INDEX IF NOT EXISTS idx_entity_relationship_types_has_auto_create
+    ON public.entity_relationship_types ((metadata->'autoCreateWhen'))
+    WHERE metadata ? 'autoCreateWhen' AND deleted_at IS NULL;
+
+-- ── Identity lookup ─────────────────────────────────────────────────────
+-- "Find the entity in catalog X whose normalized identity value matches
+-- this fact's normalizedValue." Composite expression index keyed on the
+-- (org, namespace, normalizedValue) tuple. Partial: only fact-typed events
+-- get indexed, so total size scales with fact volume (small) not event
+-- volume (huge).
+CREATE INDEX IF NOT EXISTS idx_events_identity_fact_lookup
+    ON public.events (
+        organization_id,
+        (metadata->>'namespace'),
+        (metadata->>'normalizedValue')
+    )
+    WHERE semantic_type = 'identity_fact';
+
+-- ── Per-account fact diff ───────────────────────────────────────────────
+-- "Find every active fact this connector account currently produces." Used
+-- by the engine to diff prior facts vs current set on refresh — drops fall
+-- out of the result and get superseded.
+CREATE INDEX IF NOT EXISTS idx_events_identity_fact_account
+    ON public.events (
+        (metadata->>'sourceAccountId'),
+        (metadata->>'namespace')
+    )
+    WHERE semantic_type = 'identity_fact';
+
+-- ── Provenance reverse-lookup ───────────────────────────────────────────
+-- "Find every relationship derived from this fact event." Used at
+-- revocation: when a fact is superseded, find auto-created relationships
+-- that referenced its event_id and revoke them.
+CREATE INDEX IF NOT EXISTS idx_entity_relationships_derived_from_event
+    ON public.entity_relationships (
+        ((metadata->'derivedFrom'->>'sourceEventId'))
+    )
+    WHERE metadata ? 'derivedFrom';
+
+-- ── Rule-version drift detection ────────────────────────────────────────
+-- "Find every relationship derived from this rule type at this version."
+-- Used by reconcile when a rule changes — find derivations stamped with
+-- an older version, revoke or refresh them.
+CREATE INDEX IF NOT EXISTS idx_entity_relationships_derived_from_rule
+    ON public.entity_relationships (
+        ((metadata->'derivedFrom'->>'relationshipTypeId')),
+        ((metadata->'derivedFrom'->>'ruleVersion'))
+    )
+    WHERE metadata ? 'derivedFrom';
+
+
+-- migrate:down
+
+DROP INDEX IF EXISTS public.idx_entity_relationships_derived_from_rule;
+DROP INDEX IF EXISTS public.idx_entity_relationships_derived_from_event;
+DROP INDEX IF EXISTS public.idx_events_identity_fact_account;
+DROP INDEX IF EXISTS public.idx_events_identity_fact_lookup;
+DROP INDEX IF EXISTS public.idx_entity_relationship_types_has_auto_create;
+ALTER TABLE public.entity_relationship_types DROP COLUMN IF EXISTS metadata;

--- a/packages/owletto-backend/src/__tests__/integration/identity/engine.test.ts
+++ b/packages/owletto-backend/src/__tests__/integration/identity/engine.test.ts
@@ -1,0 +1,636 @@
+/**
+ * Identity engine integration tests.
+ *
+ * Covers UC1 / UC4 / UC5 / UC6 / UC8 / UC10 from the F1 design plan plus
+ * basic schema-validation guards. Each test runs against a freshly-cleaned
+ * test DB; the pglite backend is fast enough that the per-test setup cost
+ * is acceptable.
+ *
+ * The engine's job is narrow: given a `$member` and a batch of facts,
+ * persist facts as fact-typed events, supersede prior facts, derive
+ * relationships per relationship-type rules, and revoke stale derivations.
+ * Adoption (binding the user to a curated `$member`) lives upstream — these
+ * tests pre-create the `$member` directly.
+ */
+
+import { beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import {
+  ingestFacts,
+  ruleHashFor,
+} from '../../../identity/engine';
+import {
+  IDENTITY_FACT_SEMANTIC_TYPE,
+  CLAIM_COLLISION_SEMANTIC_TYPE,
+  type AutoCreateWhenRule,
+  type ConnectorFact,
+} from '@lobu/owletto-sdk';
+import { IdentitySchemaError } from '../../../identity/validate';
+import { cleanupTestDatabase, getTestDb } from '../../setup/test-db';
+import {
+  addUserToOrganization,
+  createTestEntity,
+  createTestOrganization,
+  createTestUser,
+} from '../../setup/test-fixtures';
+
+interface TestRelationshipType {
+  id: number;
+  slug: string;
+  ruleVersion: number;
+  ruleHash: string;
+}
+
+async function createPublicCatalog(name: string) {
+  return createTestOrganization({ name, visibility: 'public' });
+}
+
+async function createRelationshipTypeWithRules(options: {
+  organizationId: string;
+  slug: string;
+  name: string;
+  rules: AutoCreateWhenRule[];
+  ruleVersion?: number;
+}): Promise<TestRelationshipType> {
+  const sql = getTestDb();
+  const ruleVersion = options.ruleVersion ?? 1;
+  const ruleHash = ruleHashFor(options.rules);
+  const metadata = {
+    autoCreateWhen: options.rules,
+    ruleVersion,
+    ruleHash,
+  };
+  const [row] = await sql<{ id: number }[]>`
+    INSERT INTO entity_relationship_types (
+      organization_id, slug, name, is_symmetric, status, metadata, created_at, updated_at
+    ) VALUES (
+      ${options.organizationId},
+      ${options.slug},
+      ${options.name},
+      false,
+      'active',
+      ${sql.json(metadata)},
+      current_timestamp,
+      current_timestamp
+    )
+    RETURNING id
+  `;
+  return {
+    id: Number(row.id),
+    slug: options.slug,
+    ruleVersion,
+    ruleHash,
+  };
+}
+
+async function createMemberEntity(options: {
+  organizationId: string;
+  userId: string;
+  email: string;
+  name: string;
+}) {
+  const sql = getTestDb();
+  // Ensure $member entity_type exists in this org.
+  let typeRows = await sql<{ id: number }[]>`
+    SELECT id FROM entity_types
+    WHERE slug = '$member' AND organization_id = ${options.organizationId} AND deleted_at IS NULL
+    LIMIT 1
+  `;
+  if (typeRows.length === 0) {
+    typeRows = await sql<{ id: number }[]>`
+      INSERT INTO entity_types (organization_id, slug, name, created_at, updated_at)
+      VALUES (${options.organizationId}, '$member', 'Member', current_timestamp, current_timestamp)
+      RETURNING id
+    `;
+  }
+  const [inserted] = await sql<{ id: number }[]>`
+    INSERT INTO entities (
+      name, slug, entity_type_id, organization_id, metadata, created_by, created_at, updated_at
+    ) VALUES (
+      ${options.name},
+      ${`member-${options.userId.slice(-8)}`},
+      ${typeRows[0].id},
+      ${options.organizationId},
+      ${sql.json({ email: options.email, name: options.name })},
+      ${options.userId},
+      NOW(), NOW()
+    )
+    RETURNING id
+  `;
+  return Number(inserted.id);
+}
+
+async function getEvent(id: number) {
+  const sql = getTestDb();
+  const rows = await sql<{
+    id: string;
+    semantic_type: string;
+    metadata: Record<string, unknown>;
+    supersedes_event_id: string | null;
+  }[]>`
+    SELECT id, semantic_type, metadata, supersedes_event_id
+    FROM events WHERE id = ${id} LIMIT 1
+  `;
+  if (rows.length === 0) return null;
+  const r = rows[0];
+  return {
+    id: Number(r.id),
+    semantic_type: r.semantic_type,
+    metadata: r.metadata,
+    supersedes_event_id: r.supersedes_event_id !== null ? Number(r.supersedes_event_id) : null,
+  };
+}
+
+async function getRelationship(id: number) {
+  const sql = getTestDb();
+  const rows = await sql<{
+    id: string;
+    from_entity_id: string;
+    to_entity_id: string;
+    relationship_type_id: string;
+    metadata: Record<string, unknown>;
+    deleted_at: string | null;
+  }[]>`
+    SELECT id, from_entity_id, to_entity_id, relationship_type_id, metadata, deleted_at
+    FROM entity_relationships WHERE id = ${id} LIMIT 1
+  `;
+  if (rows.length === 0) return null;
+  const r = rows[0];
+  return {
+    id: Number(r.id),
+    from_entity_id: Number(r.from_entity_id),
+    to_entity_id: Number(r.to_entity_id),
+    relationship_type_id: Number(r.relationship_type_id),
+    metadata: r.metadata,
+    deleted_at: r.deleted_at,
+  };
+}
+
+describe('identity engine — facts ingestion', () => {
+  beforeAll(async () => {
+    await cleanupTestDatabase();
+  });
+
+  beforeEach(async () => {
+    await cleanupTestDatabase();
+  });
+
+  it('UC1: persists a fact event and derives a relationship to a metadata-matching catalog entity', async () => {
+    const market = await createPublicCatalog('Market UC1');
+    const tenant = await createTestOrganization({ name: 'Tenant UC1', visibility: 'private' });
+    const user = await createTestUser({ email: 'albertpai@bolt.new' });
+    await addUserToOrganization(user.id, tenant.id, 'owner');
+    const memberEntityId = await createMemberEntity({
+      organizationId: tenant.id,
+      userId: user.id,
+      email: user.email,
+      name: 'Albert Pai',
+    });
+
+    const company = await createTestEntity({
+      name: 'Bolt.new',
+      entity_type: 'company',
+      organization_id: market.id,
+      domain: 'bolt.new',
+      created_by: user.id,
+    });
+
+    const works_at = await createRelationshipTypeWithRules({
+      organizationId: market.id,
+      slug: 'works_at',
+      name: 'Works at',
+      rules: [
+        {
+          sourceNamespace: 'hosted_domain',
+          targetField: 'domain',
+          assuranceRequired: 'oauth_verified',
+          matchStrategy: 'unique_only',
+        },
+      ],
+    });
+
+    const fact: ConnectorFact = {
+      namespace: 'hosted_domain',
+      identifier: 'bolt.new',
+      normalizedValue: 'bolt.new',
+      assurance: 'oauth_verified',
+      providerStableId: 'google:sub:106789',
+      sourceAccountId: 'acct_uc1_google',
+    };
+
+    const result = await ingestFacts({
+      tenantOrganizationId: tenant.id,
+      memberEntityId,
+      userId: user.id,
+      connectorKey: 'google_workspace',
+      facts: [fact],
+      options: { shadow: false },
+    });
+
+    expect(result.factEventIds).toHaveLength(1);
+    expect(result.derivedRelationshipIds).toHaveLength(1);
+    expect(result.collisionEventIds).toHaveLength(0);
+
+    const ev = await getEvent(result.factEventIds[0]);
+    expect(ev?.semantic_type).toBe(IDENTITY_FACT_SEMANTIC_TYPE);
+    expect(ev?.metadata.namespace).toBe('hosted_domain');
+    expect(ev?.metadata.normalizedValue).toBe('bolt.new');
+    expect(ev?.metadata.providerStableId).toBe('google:sub:106789');
+
+    const rel = await getRelationship(result.derivedRelationshipIds[0]);
+    expect(rel?.from_entity_id).toBe(memberEntityId);
+    expect(rel?.to_entity_id).toBe(company.id);
+    expect(rel?.relationship_type_id).toBe(works_at.id);
+    expect(rel?.deleted_at).toBeNull();
+    const derived = (rel?.metadata as { derivedFrom: { sourceEventId: number; ruleVersion: number } })
+      .derivedFrom;
+    expect(derived.sourceEventId).toBe(result.factEventIds[0]);
+    expect(derived.ruleVersion).toBe(works_at.ruleVersion);
+  });
+
+  it('UC4: refresh that drops a namespace supersedes the fact and revokes the derivation', async () => {
+    const market = await createPublicCatalog('Market UC4');
+    const tenant = await createTestOrganization({ name: 'Tenant UC4', visibility: 'private' });
+    const user = await createTestUser({ email: 'leaver@bolt.new' });
+    await addUserToOrganization(user.id, tenant.id, 'owner');
+    const memberEntityId = await createMemberEntity({
+      organizationId: tenant.id,
+      userId: user.id,
+      email: user.email,
+      name: 'Leaver',
+    });
+    const company = await createTestEntity({
+      name: 'Bolt.new',
+      entity_type: 'company',
+      organization_id: market.id,
+      domain: 'bolt.new',
+      created_by: user.id,
+    });
+    await createRelationshipTypeWithRules({
+      organizationId: market.id,
+      slug: 'works_at',
+      name: 'Works at',
+      rules: [
+        {
+          sourceNamespace: 'hosted_domain',
+          targetField: 'domain',
+          assuranceRequired: 'oauth_verified',
+          matchStrategy: 'unique_only',
+        },
+      ],
+    });
+
+    const initialFact: ConnectorFact = {
+      namespace: 'hosted_domain',
+      identifier: 'bolt.new',
+      normalizedValue: 'bolt.new',
+      assurance: 'oauth_verified',
+      providerStableId: 'google:sub:leaver',
+      sourceAccountId: 'acct_uc4_google',
+    };
+    const first = await ingestFacts({
+      tenantOrganizationId: tenant.id,
+      memberEntityId,
+      userId: user.id,
+      connectorKey: 'google_workspace',
+      facts: [initialFact],
+    });
+    expect(first.derivedRelationshipIds).toHaveLength(1);
+
+    // Refresh: connector emits no facts at all (user left Workspace, hosted_domain dropped).
+    const refresh = await ingestFacts({
+      tenantOrganizationId: tenant.id,
+      memberEntityId,
+      userId: user.id,
+      connectorKey: 'google_workspace',
+      facts: [
+        // Provide an empty-domain fact via a different namespace to trigger the diff path.
+        // We pass an `email` fact that's still valid; absence of `hosted_domain` is what we want to test.
+        {
+          namespace: 'email',
+          identifier: 'leaver@personal.example',
+          normalizedValue: 'leaver@personal.example',
+          assurance: 'oauth_verified',
+          providerStableId: 'google:sub:leaver',
+          sourceAccountId: 'acct_uc4_google',
+        },
+      ],
+    });
+
+    expect(refresh.supersededEventIds).toContain(first.factEventIds[0]);
+    expect(refresh.revokedRelationshipIds).toContain(first.derivedRelationshipIds[0]);
+
+    const rel = await getRelationship(first.derivedRelationshipIds[0]);
+    expect(rel?.deleted_at).not.toBeNull();
+  });
+
+  it('UC6: ambiguous match with strategy=unique_only surfaces a claim_collision event and skips derivation', async () => {
+    const market = await createPublicCatalog('Market UC6');
+    const tenant = await createTestOrganization({ name: 'Tenant UC6', visibility: 'private' });
+    const user = await createTestUser({ email: 'ambiguous@bolt.new' });
+    await addUserToOrganization(user.id, tenant.id, 'owner');
+    const memberEntityId = await createMemberEntity({
+      organizationId: tenant.id,
+      userId: user.id,
+      email: user.email,
+      name: 'Ambiguous',
+    });
+    // Two founders, same linkedin URL (e.g. mistakenly duplicated). Use a
+    // metadata field WITHOUT a unique-index constraint so the test can
+    // create two rows that share the value — the engine's job is to
+    // detect ambiguity at match time, not at write time.
+    const sql = getTestDb();
+    const founderA = await createTestEntity({
+      name: 'Albert (canonical)',
+      entity_type: 'founder',
+      organization_id: market.id,
+      created_by: user.id,
+    });
+    await sql`
+      UPDATE entities SET metadata = metadata || ${sql.json({ linkedin_url: 'linkedin.com/in/albert' })}
+      WHERE id = ${founderA.id}
+    `;
+    const founderB = await createTestEntity({
+      name: 'Albert (duplicate)',
+      entity_type: 'founder',
+      organization_id: market.id,
+      created_by: user.id,
+    });
+    await sql`
+      UPDATE entities SET metadata = metadata || ${sql.json({ linkedin_url: 'linkedin.com/in/albert' })}
+      WHERE id = ${founderB.id}
+    `;
+
+    await createRelationshipTypeWithRules({
+      organizationId: market.id,
+      slug: 'is_same_person_as',
+      name: 'Is same person as',
+      rules: [
+        {
+          sourceNamespace: 'linkedin_url',
+          targetField: 'linkedin_url',
+          assuranceRequired: 'oauth_verified',
+          matchStrategy: 'unique_only',
+        },
+      ],
+    });
+
+    const result = await ingestFacts({
+      tenantOrganizationId: tenant.id,
+      memberEntityId,
+      userId: user.id,
+      connectorKey: 'linkedin',
+      facts: [
+        {
+          namespace: 'linkedin_url',
+          identifier: 'https://linkedin.com/in/albert',
+          normalizedValue: 'linkedin.com/in/albert',
+          assurance: 'oauth_verified',
+          providerStableId: 'linkedin:12345',
+          sourceAccountId: 'acct_uc6_linkedin',
+        },
+      ],
+    });
+
+    expect(result.derivedRelationshipIds).toHaveLength(0);
+    expect(result.collisionEventIds).toHaveLength(1);
+    expect(result.skippedRules.length).toBeGreaterThan(0);
+
+    const ev = await getEvent(result.collisionEventIds[0]);
+    expect(ev?.semantic_type).toBe(CLAIM_COLLISION_SEMANTIC_TYPE);
+    const payload = ev?.metadata as {
+      kind: string;
+      candidateMemberIds: number[];
+    };
+    expect(payload.kind).toBe('identity_match');
+    expect(payload.candidateMemberIds).toHaveLength(2);
+  });
+
+  it('UC8: rejects a fact whose assurance is below the rule requirement', async () => {
+    const market = await createPublicCatalog('Market UC8');
+    const tenant = await createTestOrganization({ name: 'Tenant UC8', visibility: 'private' });
+    const user = await createTestUser({ email: 'lowtrust@example.com' });
+    await addUserToOrganization(user.id, tenant.id, 'owner');
+    const memberEntityId = await createMemberEntity({
+      organizationId: tenant.id,
+      userId: user.id,
+      email: user.email,
+      name: 'Lowtrust',
+    });
+    await createTestEntity({
+      name: 'Bolt.new',
+      entity_type: 'company',
+      organization_id: market.id,
+      domain: 'bolt.new',
+      created_by: user.id,
+    });
+    await createRelationshipTypeWithRules({
+      organizationId: market.id,
+      slug: 'works_at',
+      name: 'Works at',
+      rules: [
+        {
+          sourceNamespace: 'hosted_domain',
+          targetField: 'domain',
+          assuranceRequired: 'oauth_verified',
+          matchStrategy: 'unique_only',
+        },
+      ],
+    });
+
+    const result = await ingestFacts({
+      tenantOrganizationId: tenant.id,
+      memberEntityId,
+      userId: user.id,
+      connectorKey: 'cookies_only_connector',
+      facts: [
+        {
+          namespace: 'hosted_domain',
+          identifier: 'bolt.new',
+          normalizedValue: 'bolt.new',
+          assurance: 'cookie_session',
+          providerStableId: 'cookie:abc',
+          sourceAccountId: 'acct_uc8_cookies',
+        },
+      ],
+    });
+
+    expect(result.factEventIds).toHaveLength(1);
+    expect(result.derivedRelationshipIds).toHaveLength(0);
+    expect(result.skippedRules.some((s) => s.reason.includes('below required'))).toBe(true);
+  });
+
+  it('shadow mode: writes facts but skips derivation/revocation', async () => {
+    const market = await createPublicCatalog('Market Shadow');
+    const tenant = await createTestOrganization({ name: 'Tenant Shadow', visibility: 'private' });
+    const user = await createTestUser({ email: 'shadow@bolt.new' });
+    await addUserToOrganization(user.id, tenant.id, 'owner');
+    const memberEntityId = await createMemberEntity({
+      organizationId: tenant.id,
+      userId: user.id,
+      email: user.email,
+      name: 'Shadow',
+    });
+    await createTestEntity({
+      name: 'Bolt.new',
+      entity_type: 'company',
+      organization_id: market.id,
+      domain: 'bolt.new',
+      created_by: user.id,
+    });
+    await createRelationshipTypeWithRules({
+      organizationId: market.id,
+      slug: 'works_at',
+      name: 'Works at',
+      rules: [
+        {
+          sourceNamespace: 'hosted_domain',
+          targetField: 'domain',
+          assuranceRequired: 'oauth_verified',
+          matchStrategy: 'unique_only',
+        },
+      ],
+    });
+
+    const result = await ingestFacts({
+      tenantOrganizationId: tenant.id,
+      memberEntityId,
+      userId: user.id,
+      connectorKey: 'google_workspace',
+      facts: [
+        {
+          namespace: 'hosted_domain',
+          identifier: 'bolt.new',
+          normalizedValue: 'bolt.new',
+          assurance: 'oauth_verified',
+          providerStableId: 'google:sub:shadow',
+          sourceAccountId: 'acct_shadow_google',
+        },
+      ],
+      options: { shadow: true },
+    });
+
+    expect(result.factEventIds).toHaveLength(1);
+    expect(result.derivedRelationshipIds).toHaveLength(0);
+    expect(result.revokedRelationshipIds).toHaveLength(0);
+    expect(result.collisionEventIds).toHaveLength(0);
+  });
+
+  it('rejects malformed facts with IdentitySchemaError before any side effects', async () => {
+    const tenant = await createTestOrganization({ name: 'Tenant Malformed', visibility: 'private' });
+    const user = await createTestUser({ email: 'malformed@example.com' });
+    await addUserToOrganization(user.id, tenant.id, 'owner');
+    const memberEntityId = await createMemberEntity({
+      organizationId: tenant.id,
+      userId: user.id,
+      email: user.email,
+      name: 'Malformed',
+    });
+
+    await expect(
+      ingestFacts({
+        tenantOrganizationId: tenant.id,
+        memberEntityId,
+        userId: user.id,
+        connectorKey: 'broken',
+        facts: [
+          // Missing required fields.
+          {
+            namespace: '',
+            identifier: '',
+            normalizedValue: '',
+            assurance: 'oauth_verified',
+            providerStableId: '',
+            sourceAccountId: '',
+          } as ConnectorFact,
+        ],
+      })
+    ).rejects.toBeInstanceOf(IdentitySchemaError);
+  });
+
+  it('UC5: same connector emitting an admin-tier namespace fires a separate is_admin_of rule', async () => {
+    const market = await createPublicCatalog('Market UC5');
+    const tenant = await createTestOrganization({ name: 'Tenant UC5', visibility: 'private' });
+    const user = await createTestUser({ email: 'admin@bolt.new' });
+    await addUserToOrganization(user.id, tenant.id, 'owner');
+    const memberEntityId = await createMemberEntity({
+      organizationId: tenant.id,
+      userId: user.id,
+      email: user.email,
+      name: 'Admin User',
+    });
+    const company = await createTestEntity({
+      name: 'Bolt.new',
+      entity_type: 'company',
+      organization_id: market.id,
+      domain: 'bolt.new',
+      created_by: user.id,
+    });
+
+    await createRelationshipTypeWithRules({
+      organizationId: market.id,
+      slug: 'works_at',
+      name: 'Works at',
+      rules: [
+        {
+          sourceNamespace: 'hosted_domain',
+          targetField: 'domain',
+          assuranceRequired: 'oauth_verified',
+          matchStrategy: 'unique_only',
+        },
+      ],
+    });
+    const is_admin_of = await createRelationshipTypeWithRules({
+      organizationId: market.id,
+      slug: 'is_admin_of',
+      name: 'Is admin of',
+      rules: [
+        {
+          sourceNamespace: 'workspace_admin_domain',
+          targetField: 'domain',
+          assuranceRequired: 'oauth_verified_admin_role',
+          matchStrategy: 'unique_only',
+        },
+      ],
+    });
+
+    const result = await ingestFacts({
+      tenantOrganizationId: tenant.id,
+      memberEntityId,
+      userId: user.id,
+      connectorKey: 'google_workspace',
+      facts: [
+        {
+          namespace: 'hosted_domain',
+          identifier: 'bolt.new',
+          normalizedValue: 'bolt.new',
+          assurance: 'oauth_verified',
+          providerStableId: 'google:sub:admin',
+          sourceAccountId: 'acct_uc5_google',
+        },
+        {
+          namespace: 'workspace_admin_domain',
+          identifier: 'bolt.new',
+          normalizedValue: 'bolt.new',
+          assurance: 'oauth_verified_admin_role',
+          providerStableId: 'google:sub:admin',
+          sourceAccountId: 'acct_uc5_google',
+        },
+      ],
+    });
+
+    expect(result.derivedRelationshipIds.length).toBeGreaterThanOrEqual(2);
+    const sql = getTestDb();
+    const rels = await sql<{
+      id: number;
+      relationship_type_id: number;
+    }[]>`
+      SELECT id, relationship_type_id
+      FROM entity_relationships
+      WHERE from_entity_id = ${memberEntityId}
+        AND to_entity_id = ${company.id}
+        AND deleted_at IS NULL
+    `;
+    const relTypeIds = rels.map((r) => r.relationship_type_id);
+    expect(relTypeIds).toContain(is_admin_of.id);
+  });
+});

--- a/packages/owletto-backend/src/identity/engine.ts
+++ b/packages/owletto-backend/src/identity/engine.ts
@@ -1,0 +1,549 @@
+/**
+ * Identity engine.
+ *
+ * Reads connector-emitted facts and resolves them against catalog entities:
+ *  1. Persist each fact as an event row (semantic_type='identity_fact'),
+ *     superseding the prior fact for the same (sourceAccountId, namespace).
+ *  2. Look up entities in each public catalog whose identity-namespace
+ *     metadata field equals the fact's normalizedValue.
+ *  3. Apply each catalog's relationship-type auto_create_when rules,
+ *     writing entity_relationships with provenance pointing back to the
+ *     source event. Skip when assurance < required, when match strategy
+ *     rejects ambiguity, or when the target relationship already exists.
+ *  4. On supersede, revoke derivations whose source event is no longer
+ *     current (status='archived' on the relationship row + valid_to=now).
+ *
+ * Shadow mode (env IDENTITY_ENGINE_SHADOW=='true'): writes facts but
+ * skips derivation/revocation writes. Used to validate behaviour against
+ * real users before flipping derivations on.
+ */
+
+import { createHash } from 'node:crypto';
+import { getDb } from '../db/client';
+import { insertEvent } from '../utils/insert-event';
+import logger from '../utils/logger';
+import {
+  IDENTITY_FACT_SEMANTIC_TYPE,
+  CLAIM_COLLISION_SEMANTIC_TYPE,
+  assuranceMeets,
+  type AssuranceLevel as AssuranceLevelValue,
+} from '@lobu/owletto-sdk';
+import type {
+  AutoCreateWhenRule,
+  ConnectorFactInput,
+  DerivedFromProvenance,
+  EngineOptions,
+  IngestResult,
+} from './types';
+import {
+  IdentitySchemaError,
+  validateClaimCollisionPayload,
+  validateConnectorFact,
+  validateDerivedFromProvenance,
+  validateFactEventMetadata,
+} from './validate';
+
+type Sql = ReturnType<typeof getDb>;
+
+interface IngestParams {
+  /** Tenant org these facts are scoped to (where the user's $member lives). */
+  tenantOrganizationId: string;
+  /** $member entity id in the tenant org for the authenticated user. */
+  memberEntityId: number;
+  /** Caller user id, used as `created_by` on event rows. */
+  userId: string;
+  /** Connector account that produced this batch (events.connector_key). */
+  connectorKey: string;
+  /** Optional connection id for connector-account provenance. */
+  connectionId?: number | null;
+  /** Set of facts the connector emitted right now. */
+  facts: ConnectorFactInput[];
+  /** Per-call shadow override; otherwise read from env. */
+  options?: EngineOptions;
+}
+
+interface RuleRow {
+  relationshipTypeId: number;
+  relationshipTypeSlug: string;
+  catalogOrganizationId: string;
+  rules: AutoCreateWhenRule[];
+  ruleVersion: number;
+  ruleHash: string;
+}
+
+interface PriorFact {
+  eventId: number;
+  namespace: string;
+  normalizedValue: string;
+  sourceAccountId: string;
+  assurance: AssuranceLevelValue;
+}
+
+const log = logger.child({ module: 'identity-engine' });
+
+function isShadow(opts: EngineOptions | undefined): boolean {
+  if (typeof opts?.shadow === 'boolean') return opts.shadow;
+  return process.env.IDENTITY_ENGINE_SHADOW === 'true';
+}
+
+function originIdForFact(fact: ConnectorFactInput): string {
+  return `identity_fact:${fact.sourceAccountId}:${fact.namespace}`;
+}
+
+function canonicaliseRules(rules: AutoCreateWhenRule[]): string {
+  return JSON.stringify(
+    rules
+      .map((r) => ({
+        sourceNamespace: r.sourceNamespace,
+        targetField: r.targetField,
+        assuranceRequired: r.assuranceRequired,
+        matchStrategy: r.matchStrategy,
+      }))
+      .sort((a, b) =>
+        a.sourceNamespace === b.sourceNamespace
+          ? a.targetField.localeCompare(b.targetField)
+          : a.sourceNamespace.localeCompare(b.sourceNamespace)
+      )
+  );
+}
+
+export function ruleHashFor(rules: AutoCreateWhenRule[]): string {
+  return createHash('sha256').update(canonicaliseRules(rules)).digest('hex');
+}
+
+/**
+ * Public-catalog relationship types that declare auto_create_when rules.
+ * Read once per ingest pass; small N (one row per relationship type that
+ * opts into the engine).
+ */
+async function loadRules(sql: Sql): Promise<RuleRow[]> {
+  const rows = await sql<{
+    id: number;
+    slug: string;
+    organization_id: string;
+    metadata: unknown;
+  }>`
+    SELECT rt.id, rt.slug, rt.organization_id, rt.metadata
+    FROM entity_relationship_types rt
+    JOIN organization o ON o.id = rt.organization_id
+    WHERE rt.deleted_at IS NULL
+      AND rt.status = 'active'
+      AND o.visibility = 'public'
+      AND rt.metadata ? 'autoCreateWhen'
+  `;
+  const out: RuleRow[] = [];
+  for (const row of rows) {
+    const meta = row.metadata as
+      | { autoCreateWhen?: unknown; ruleVersion?: unknown; ruleHash?: unknown }
+      | null
+      | undefined;
+    if (!meta || !Array.isArray(meta.autoCreateWhen)) continue;
+    if (typeof meta.ruleVersion !== 'number' || typeof meta.ruleHash !== 'string') {
+      log.warn(
+        { relationshipTypeId: row.id },
+        'identity-engine: relationship type metadata.autoCreateWhen present without rule_version/rule_hash; skipping'
+      );
+      continue;
+    }
+    out.push({
+      relationshipTypeId: row.id,
+      relationshipTypeSlug: row.slug,
+      catalogOrganizationId: row.organization_id,
+      rules: meta.autoCreateWhen as AutoCreateWhenRule[],
+      ruleVersion: meta.ruleVersion,
+      ruleHash: meta.ruleHash,
+    });
+  }
+  return out;
+}
+
+async function loadPriorFacts(sql: Sql, sourceAccountId: string): Promise<PriorFact[]> {
+  const rows = await sql<{
+    id: number;
+    metadata: { namespace?: string; normalizedValue?: string; assurance?: string };
+  }>`
+    SELECT e.id, e.metadata
+    FROM current_event_records e
+    WHERE e.semantic_type = ${IDENTITY_FACT_SEMANTIC_TYPE}
+      AND e.metadata->>'sourceAccountId' = ${sourceAccountId}
+  `;
+  return rows.map((r) => ({
+    eventId: Number(r.id),
+    namespace: String(r.metadata?.namespace ?? ''),
+    normalizedValue: String(r.metadata?.normalizedValue ?? ''),
+    sourceAccountId,
+    assurance: (r.metadata?.assurance ?? 'self_attested') as AssuranceLevelValue,
+  }));
+}
+
+interface MatchedEntity {
+  entityId: number;
+  organizationId: string;
+}
+
+async function findEntitiesByMetadataField(
+  sql: Sql,
+  catalogOrgId: string,
+  field: string,
+  normalizedValue: string
+): Promise<MatchedEntity[]> {
+  const rows = await sql<{ id: number; organization_id: string }>`
+    SELECT e.id, e.organization_id
+    FROM entities e
+    WHERE e.organization_id = ${catalogOrgId}
+      AND e.deleted_at IS NULL
+      AND e.metadata->>${field} = ${normalizedValue}
+  `;
+  return rows.map((r) => ({ entityId: Number(r.id), organizationId: r.organization_id }));
+}
+
+async function findExistingRelationship(
+  sql: Sql,
+  fromEntityId: number,
+  toEntityId: number,
+  relationshipTypeId: number
+): Promise<number | null> {
+  const rows = await sql<{ id: number }>`
+    SELECT id FROM entity_relationships
+    WHERE from_entity_id = ${fromEntityId}
+      AND to_entity_id = ${toEntityId}
+      AND relationship_type_id = ${relationshipTypeId}
+      AND deleted_at IS NULL
+    LIMIT 1
+  `;
+  return rows.length > 0 ? Number(rows[0].id) : null;
+}
+
+async function insertDerivation(
+  sql: Sql,
+  fromEntityId: number,
+  toEntityId: number,
+  relationshipTypeId: number,
+  organizationId: string,
+  userId: string,
+  provenance: DerivedFromProvenance
+): Promise<number> {
+  validateDerivedFromProvenance(provenance);
+  const metadata = { derivedFrom: provenance };
+  const rows = await sql<{ id: number }>`
+    INSERT INTO entity_relationships (
+      from_entity_id, to_entity_id, relationship_type_id, organization_id,
+      metadata, created_by, updated_by
+    ) VALUES (
+      ${fromEntityId}, ${toEntityId}, ${relationshipTypeId}, ${organizationId},
+      ${sql.json(metadata)}, ${userId}, ${userId}
+    )
+    RETURNING id
+  `;
+  return Number(rows[0].id);
+}
+
+async function revokeDerivationsForEvent(
+  sql: Sql,
+  eventId: number,
+  userId: string
+): Promise<number[]> {
+  const rows = await sql<{ id: number }>`
+    UPDATE entity_relationships
+    SET deleted_at = NOW(),
+        updated_at = NOW(),
+        updated_by = ${userId}
+    WHERE deleted_at IS NULL
+      AND metadata ? 'derivedFrom'
+      AND metadata->'derivedFrom'->>'sourceEventId' = ${String(eventId)}
+    RETURNING id
+  `;
+  return rows.map((r) => Number(r.id));
+}
+
+async function recordCollision(
+  tenantOrgId: string,
+  factEventId: number,
+  candidateMemberIds: number[],
+  fact: ConnectorFactInput,
+  relationshipTypeId: number,
+  userId: string
+): Promise<number | null> {
+  const payload = {
+    kind: 'identity_match' as const,
+    namespace: fact.namespace,
+    identifier: fact.identifier,
+    normalizedValue: fact.normalizedValue,
+    candidateMemberIds,
+    triggeringEventId: factEventId,
+    relationshipTypeId,
+  };
+  validateClaimCollisionPayload(payload);
+  const ev = await insertEvent({
+    organizationId: tenantOrgId,
+    entityIds: candidateMemberIds,
+    originId: `claim_collision:${fact.sourceAccountId}:${fact.namespace}:${fact.normalizedValue}`,
+    semanticType: CLAIM_COLLISION_SEMANTIC_TYPE,
+    interactionType: 'approval',
+    interactionStatus: 'pending',
+    metadata: payload,
+    title: `Identity match collision on ${fact.namespace}`,
+    payloadType: 'text',
+    content: `Two or more candidate $member rows match this provider-verified ${fact.namespace}; manual resolution required.`,
+    createdBy: userId,
+  });
+  return ev?.id ?? null;
+}
+
+/**
+ * Main entry: ingest a fresh batch of facts for one connector account.
+ * Idempotent — safe to call repeatedly with the same input; superseded
+ * events stay in history.
+ */
+export async function ingestFacts(params: IngestParams): Promise<IngestResult> {
+  const { tenantOrganizationId, memberEntityId, userId, connectorKey, connectionId, facts } =
+    params;
+  const shadow = isShadow(params.options);
+  const sql = getDb();
+
+  // 1. Validate every fact up front. We do not partially ingest; all-or-nothing.
+  for (const fact of facts) {
+    try {
+      validateConnectorFact(fact);
+    } catch (err) {
+      if (err instanceof IdentitySchemaError) {
+        log.error(
+          { err, namespace: fact?.namespace, connectorKey },
+          'identity-engine: rejecting batch due to invalid fact'
+        );
+      }
+      throw err;
+    }
+  }
+
+  const result: IngestResult = {
+    factEventIds: [],
+    supersededEventIds: [],
+    derivedRelationshipIds: [],
+    revokedRelationshipIds: [],
+    collisionEventIds: [],
+    skippedRules: [],
+  };
+
+  if (facts.length === 0) return result;
+
+  // Group prior facts by (account, namespace) for diff against incoming.
+  const sourceAccountId = facts[0].sourceAccountId;
+  if (facts.some((f) => f.sourceAccountId !== sourceAccountId)) {
+    throw new Error(
+      'identity-engine: ingestFacts requires every fact in a batch to share sourceAccountId'
+    );
+  }
+  const priorFacts = await loadPriorFacts(sql, sourceAccountId);
+  const priorByNamespace = new Map<string, PriorFact[]>();
+  for (const pf of priorFacts) {
+    const list = priorByNamespace.get(pf.namespace) ?? [];
+    list.push(pf);
+    priorByNamespace.set(pf.namespace, list);
+  }
+
+  // 2. Persist each incoming fact, superseding the prior one when the
+  // (namespace, sourceAccountId) tuple already had a current event.
+  const factEventByNamespace = new Map<string, { eventId: number; fact: ConnectorFactInput }>();
+  for (const fact of facts) {
+    const factMetadata = {
+      namespace: fact.namespace,
+      identifier: fact.identifier,
+      normalizedValue: fact.normalizedValue,
+      assurance: fact.assurance,
+      providerStableId: fact.providerStableId,
+      sourceAccountId: fact.sourceAccountId,
+      validTo: fact.validTo,
+      notes: fact.notes,
+    };
+    validateFactEventMetadata(factMetadata);
+
+    const priorList = priorByNamespace.get(fact.namespace) ?? [];
+    // Prior fact MUST be of the same namespace AND same value for this to
+    // be a no-op refresh; if value differs, we still supersede the prior so
+    // the (account, namespace) latest row reflects the current truth.
+    const supersedes = priorList.length > 0 ? priorList[0].eventId : null;
+
+    const inserted = await insertEvent({
+      organizationId: tenantOrganizationId,
+      entityIds: [memberEntityId],
+      originId: originIdForFact(fact),
+      semanticType: IDENTITY_FACT_SEMANTIC_TYPE,
+      payloadType: 'empty',
+      metadata: factMetadata,
+      connectorKey,
+      connectionId: connectionId ?? null,
+      supersedesEventId: supersedes,
+      occurredAt: new Date(),
+      createdBy: userId,
+    });
+    if (!inserted) {
+      log.warn({ namespace: fact.namespace, sourceAccountId }, 'identity-engine: insertEvent returned null; skipping fact');
+      continue;
+    }
+    result.factEventIds.push(inserted.id);
+    factEventByNamespace.set(fact.namespace, { eventId: inserted.id, fact });
+    if (supersedes !== null) {
+      result.supersededEventIds.push(supersedes);
+    }
+  }
+
+  // 3. Diff prior facts vs current — anything in prior but not in current
+  // (this batch's namespaces) means the connector stopped emitting it.
+  // Mark a synthetic supersede so derivation reverse-lookup catches it.
+  const incomingNamespaces = new Set(facts.map((f) => f.namespace));
+  for (const [namespace, priorList] of priorByNamespace.entries()) {
+    if (incomingNamespaces.has(namespace)) continue;
+    for (const pf of priorList) {
+      // Write a tombstone fact event with no normalizedValue and supersede
+      // the prior — preserves audit history and triggers revocation below.
+      const tombstoneMeta = {
+        namespace,
+        identifier: '',
+        normalizedValue: '',
+        assurance: 'self_attested' as const,
+        providerStableId: '',
+        sourceAccountId,
+        notes: 'superseded by absence on connector refresh',
+      };
+      validateFactEventMetadata(tombstoneMeta);
+      const tombstone = await insertEvent({
+        organizationId: tenantOrganizationId,
+        entityIds: [memberEntityId],
+        originId: `identity_fact_tombstone:${sourceAccountId}:${namespace}`,
+        semanticType: IDENTITY_FACT_SEMANTIC_TYPE,
+        payloadType: 'empty',
+        metadata: tombstoneMeta,
+        connectorKey,
+        connectionId: connectionId ?? null,
+        supersedesEventId: pf.eventId,
+        occurredAt: new Date(),
+        createdBy: userId,
+      });
+      if (tombstone) {
+        result.factEventIds.push(tombstone.id);
+        result.supersededEventIds.push(pf.eventId);
+      }
+    }
+  }
+
+  if (shadow) {
+    log.info(
+      { factCount: facts.length, factEventIds: result.factEventIds.length, sourceAccountId },
+      'identity-engine: shadow mode — skipped derivation/revocation pass'
+    );
+    return result;
+  }
+
+  // 4. Revoke derivations referencing any superseded fact event.
+  for (const supersededId of result.supersededEventIds) {
+    const revoked = await revokeDerivationsForEvent(sql, supersededId, userId);
+    if (revoked.length > 0) {
+      result.revokedRelationshipIds.push(...revoked);
+      log.info(
+        { supersededEventId: supersededId, revokedCount: revoked.length },
+        'identity-engine: revoked derivations for superseded fact'
+      );
+    }
+  }
+
+  // 5. Apply auto_create_when rules against each just-written fact.
+  const rules = await loadRules(sql);
+  for (const fact of facts) {
+    const ev = factEventByNamespace.get(fact.namespace);
+    if (!ev) continue;
+    for (const ruleSet of rules) {
+      for (const rule of ruleSet.rules) {
+        if (rule.sourceNamespace !== fact.namespace) continue;
+        if (!assuranceMeets(fact.assurance, rule.assuranceRequired)) {
+          result.skippedRules.push({
+            ruleId: `${ruleSet.relationshipTypeSlug}@${ruleSet.ruleVersion}`,
+            reason: `assurance ${fact.assurance} below required ${rule.assuranceRequired}`,
+          });
+          continue;
+        }
+
+        const matches = await findEntitiesByMetadataField(
+          sql,
+          ruleSet.catalogOrganizationId,
+          rule.targetField,
+          fact.normalizedValue
+        );
+
+        if (matches.length === 0) continue;
+
+        if (matches.length > 1 && rule.matchStrategy === 'unique_only') {
+          // Surface as a collision event for admin / user resolution.
+          const collisionId = await recordCollision(
+            tenantOrganizationId,
+            ev.eventId,
+            matches.map((m) => m.entityId),
+            fact,
+            ruleSet.relationshipTypeId,
+            userId
+          );
+          if (collisionId !== null) result.collisionEventIds.push(collisionId);
+          result.skippedRules.push({
+            ruleId: `${ruleSet.relationshipTypeSlug}@${ruleSet.ruleVersion}`,
+            reason: `${matches.length} matches with match_strategy=unique_only`,
+          });
+          continue;
+        }
+
+        if (rule.matchStrategy === 'first_match') {
+          // first_match is not allowed in v1 for safety; reject loudly.
+          throw new Error(
+            `identity-engine: match_strategy='first_match' is not allowed in v1 (rule on relationship_type ${ruleSet.relationshipTypeSlug})`
+          );
+        }
+
+        // unique_only with one match, or all_matches with N → derive each.
+        const targets = rule.matchStrategy === 'unique_only' ? [matches[0]] : matches;
+        for (const target of targets) {
+          const existing = await findExistingRelationship(
+            sql,
+            memberEntityId,
+            target.entityId,
+            ruleSet.relationshipTypeId
+          );
+          if (existing !== null) {
+            // Already derived — idempotent skip.
+            continue;
+          }
+          const provenance: DerivedFromProvenance = {
+            sourceEventId: ev.eventId,
+            relationshipTypeId: ruleSet.relationshipTypeId,
+            ruleVersion: ruleSet.ruleVersion,
+            ruleHash: ruleSet.ruleHash,
+            factAssurance: fact.assurance,
+            derivedAt: new Date().toISOString(),
+          };
+          const relId = await insertDerivation(
+            sql,
+            memberEntityId,
+            target.entityId,
+            ruleSet.relationshipTypeId,
+            target.organizationId,
+            userId,
+            provenance
+          );
+          result.derivedRelationshipIds.push(relId);
+        }
+      }
+    }
+  }
+
+  log.info(
+    {
+      sourceAccountId,
+      facts: result.factEventIds.length,
+      superseded: result.supersededEventIds.length,
+      derived: result.derivedRelationshipIds.length,
+      revoked: result.revokedRelationshipIds.length,
+      collisions: result.collisionEventIds.length,
+      skipped: result.skippedRules.length,
+    },
+    'identity-engine: ingest complete'
+  );
+  return result;
+}

--- a/packages/owletto-backend/src/identity/types.ts
+++ b/packages/owletto-backend/src/identity/types.ts
@@ -1,0 +1,54 @@
+/**
+ * Internal types for the identity engine.
+ *
+ * SDK-facing contracts live in `@lobu/owletto-sdk` (`identity-types.ts`).
+ * This file holds engine-internal aliases and helper types.
+ */
+
+import type {
+  AssuranceLevel as AssuranceLevelType,
+  AutoCreateWhenRule as AutoCreateWhenRuleType,
+  ConnectorFact as ConnectorFactType,
+  DerivedFromProvenance as DerivedFromProvenanceType,
+  FactEventMetadata as FactEventMetadataType,
+  RelationshipTypeIdentityMetadata as RelationshipTypeIdentityMetadataType,
+} from '@lobu/owletto-sdk';
+
+// Re-export the SDK types under engine names so call sites don't have to
+// know about the SDK boundary.
+export type ConnectorFactInput = ConnectorFactType;
+export type FactEventMetadata = FactEventMetadataType;
+export type AutoCreateWhenRule = AutoCreateWhenRuleType;
+export type DerivedFromProvenance = DerivedFromProvenanceType;
+export type RelationshipTypeIdentityMetadata = RelationshipTypeIdentityMetadataType;
+export type AssuranceLevel = AssuranceLevelType;
+
+/**
+ * Output of the engine's per-account ingest pass.
+ */
+export interface IngestResult {
+  /** events.id for each fact-typed event written or extended. */
+  factEventIds: number[];
+  /** events.id for facts that were superseded during this pass. */
+  supersededEventIds: number[];
+  /** entity_relationships.id for each derivation written. */
+  derivedRelationshipIds: number[];
+  /** entity_relationships.id for derivations revoked during this pass. */
+  revokedRelationshipIds: number[];
+  /** events.id of pending claim_collision rows surfaced this pass. */
+  collisionEventIds: number[];
+  /** Soft-skipped rules with reason — informational, not errors. */
+  skippedRules: Array<{ ruleId: string; reason: string }>;
+}
+
+/**
+ * Engine config knobs read from env. Most callers don't override.
+ */
+export interface EngineOptions {
+  /**
+   * When true, the engine writes fact events but does NOT write derivations
+   * or revocations. Used for shadow-mode rollouts. Defaults to env
+   * IDENTITY_ENGINE_SHADOW=='true' (any other value = off).
+   */
+  shadow?: boolean;
+}

--- a/packages/owletto-backend/src/identity/validate.ts
+++ b/packages/owletto-backend/src/identity/validate.ts
@@ -1,0 +1,101 @@
+/**
+ * Runtime validation for the identity-engine schemas (T1).
+ *
+ * Every write boundary into the engine — connector ingest, rule-compile,
+ * derivation insert, collision event — runs the relevant TypeBox schema and
+ * throws on malformed input. The collapsed model puts a lot in `metadata
+ * jsonb`, so without this discipline the engine silently corrupts.
+ */
+
+import { TypeCompiler, type ValueErrorIterator } from '@sinclair/typebox/compiler';
+import type { TSchema, Static } from '@sinclair/typebox';
+import {
+  ConnectorFact,
+  DerivedFromProvenance,
+  FactEventMetadata,
+  RelationshipTypeIdentityMetadata,
+  AutoCreateWhenRule,
+  ClaimCollisionPayload,
+} from '@lobu/owletto-sdk';
+
+const compiledFact = TypeCompiler.Compile(ConnectorFact);
+const compiledFactEventMetadata = TypeCompiler.Compile(FactEventMetadata);
+const compiledRule = TypeCompiler.Compile(AutoCreateWhenRule);
+const compiledRelTypeMeta = TypeCompiler.Compile(RelationshipTypeIdentityMetadata);
+const compiledDerivedFrom = TypeCompiler.Compile(DerivedFromProvenance);
+const compiledClaimCollision = TypeCompiler.Compile(ClaimCollisionPayload);
+
+export class IdentitySchemaError extends Error {
+  constructor(
+    public readonly schemaName: string,
+    public readonly errors: Array<{ path: string; message: string; value: unknown }>
+  ) {
+    const summary = errors
+      .slice(0, 3)
+      .map((e) => `${e.path || '<root>'}: ${e.message}`)
+      .join('; ');
+    const more = errors.length > 3 ? ` (+${errors.length - 3} more)` : '';
+    super(`${schemaName} validation failed: ${summary}${more}`);
+    this.name = 'IdentitySchemaError';
+  }
+}
+
+function collectErrors(iter: ValueErrorIterator): Array<{
+  path: string;
+  message: string;
+  value: unknown;
+}> {
+  const errs: Array<{ path: string; message: string; value: unknown }> = [];
+  for (const err of iter) {
+    errs.push({ path: err.path, message: err.message, value: err.value });
+    if (errs.length >= 16) break;
+  }
+  return errs;
+}
+
+function ensure<T extends TSchema>(
+  schemaName: string,
+  compiler: ReturnType<typeof TypeCompiler.Compile<T>>,
+  value: unknown
+): asserts value is Static<T> {
+  if (compiler.Check(value)) return;
+  throw new IdentitySchemaError(schemaName, collectErrors(compiler.Errors(value)));
+}
+
+export function validateConnectorFact(value: unknown): asserts value is Static<typeof ConnectorFact> {
+  ensure('ConnectorFact', compiledFact, value);
+}
+
+export function validateFactEventMetadata(
+  value: unknown
+): asserts value is Static<typeof FactEventMetadata> {
+  ensure('FactEventMetadata', compiledFactEventMetadata, value);
+}
+
+export function validateAutoCreateWhenRule(
+  value: unknown
+): asserts value is Static<typeof AutoCreateWhenRule> {
+  ensure('AutoCreateWhenRule', compiledRule, value);
+}
+
+export function validateRelationshipTypeIdentityMetadata(
+  value: unknown
+): asserts value is Static<typeof RelationshipTypeIdentityMetadata> {
+  ensure(
+    'RelationshipTypeIdentityMetadata',
+    compiledRelTypeMeta,
+    value
+  );
+}
+
+export function validateDerivedFromProvenance(
+  value: unknown
+): asserts value is Static<typeof DerivedFromProvenance> {
+  ensure('DerivedFromProvenance', compiledDerivedFrom, value);
+}
+
+export function validateClaimCollisionPayload(
+  value: unknown
+): asserts value is Static<typeof ClaimCollisionPayload> {
+  ensure('ClaimCollisionPayload', compiledClaimCollision, value);
+}

--- a/packages/owletto-sdk/src/identity-types.ts
+++ b/packages/owletto-sdk/src/identity-types.ts
@@ -1,0 +1,298 @@
+/**
+ * Identity-engine SDK contracts.
+ *
+ * Connectors emit `ConnectorFact[]` for the authenticated subject; catalog
+ * YAMLs declare `AutoCreateWhenRule[]` on relationship types; the engine
+ * matches facts against rules and writes derivations.
+ *
+ * Schemas are TypeBox so they double as runtime validators at every write
+ * boundary (seeder, engine, MCP tools). Validation is mandatory — the
+ * collapsed model puts a lot in `metadata jsonb`, so without validation the
+ * engine silently corrupts on malformed input.
+ */
+
+import { Type, type Static } from '@sinclair/typebox';
+
+// =============================================================================
+// Assurance levels
+// =============================================================================
+
+/**
+ * How strongly the connector vouches for a fact. Rules require a minimum
+ * assurance to fire. The order is total: `oauth_verified_admin_role` >
+ * `oauth_verified` > `cookie_session` > `self_attested`.
+ */
+export const AssuranceLevel = Type.Union(
+  [
+    Type.Literal('oauth_verified_admin_role'),
+    Type.Literal('oauth_verified'),
+    Type.Literal('cookie_session'),
+    Type.Literal('self_attested'),
+  ],
+  { $id: 'AssuranceLevel' }
+);
+export type AssuranceLevel = Static<typeof AssuranceLevel>;
+
+const ASSURANCE_RANK: Record<AssuranceLevel, number> = {
+  oauth_verified_admin_role: 4,
+  oauth_verified: 3,
+  cookie_session: 2,
+  self_attested: 1,
+};
+
+export function assuranceMeets(actual: AssuranceLevel, required: AssuranceLevel): boolean {
+  return ASSURANCE_RANK[actual] >= ASSURANCE_RANK[required];
+}
+
+// =============================================================================
+// ConnectorFact — what a connector emits
+// =============================================================================
+
+export const ConnectorFact = Type.Object(
+  {
+    /** The attribute kind, e.g. 'email', 'hosted_domain', 'linkedin_url'. */
+    namespace: Type.String({ minLength: 1, maxLength: 64 }),
+    /** Raw value as the provider returned it. Audit-friendly. */
+    identifier: Type.String({ minLength: 1, maxLength: 1024 }),
+    /**
+     * Canonicalised form used for index lookups. Connectors run normalize* on
+     * the value before emitting; the engine re-normalises defensively.
+     */
+    normalizedValue: Type.String({ minLength: 1, maxLength: 1024 }),
+    /** How the connector verified this fact. */
+    assurance: AssuranceLevel,
+    /**
+     * Provider's immutable account identifier (Google `sub`, GitHub
+     * `user_id`, etc.). Used as the primary binding key — survives email
+     * changes, recycled emails, etc.
+     */
+    providerStableId: Type.String({ minLength: 1, maxLength: 256 }),
+    /**
+     * Which connector account row produced this fact. Lets the engine diff
+     * facts per session for revocation.
+     */
+    sourceAccountId: Type.String({ minLength: 1, maxLength: 256 }),
+    /** Optional expiry. Required for high-assurance facts in production. */
+    validTo: Type.Optional(Type.String({ format: 'date-time' })),
+    /**
+     * Optional human-readable note about trust caveats this fact carries.
+     * Surfaced in audit logs and admin UIs; never used by the engine.
+     */
+    notes: Type.Optional(Type.String({ maxLength: 512 })),
+  },
+  { $id: 'ConnectorFact', additionalProperties: false }
+);
+export type ConnectorFact = Static<typeof ConnectorFact>;
+
+// =============================================================================
+// ConnectorIdentityCapability — what a connector promises to emit
+// =============================================================================
+
+/**
+ * Each connector exports a static capability declaration. CI lints that the
+ * namespaces it actually emits at runtime are a subset of `produces`.
+ */
+export const ConnectorIdentityCapability = Type.Object(
+  {
+    connectorKey: Type.String({ minLength: 1, maxLength: 64 }),
+    produces: Type.Array(
+      Type.Object({
+        namespace: Type.String({ minLength: 1, maxLength: 64 }),
+        assurance: AssuranceLevel,
+        notes: Type.Optional(Type.String({ maxLength: 512 })),
+      }),
+      { minItems: 0, maxItems: 32 }
+    ),
+  },
+  { $id: 'ConnectorIdentityCapability', additionalProperties: false }
+);
+export type ConnectorIdentityCapability = Static<typeof ConnectorIdentityCapability>;
+
+// =============================================================================
+// AutoCreateWhenRule — declared on relationship-type YAMLs, compiled into
+// entity_relationship_types.metadata.auto_create_when[]
+// =============================================================================
+
+/**
+ * What the engine should do when ambiguous matches are found:
+ *  - `unique_only` (default for identity): require exactly one match. Multiple
+ *    matches are rejected and surfaced as a `match_ambiguous` event for an
+ *    admin to deduplicate.
+ *  - `all_matches`: derive against every match. Only safe for weak
+ *    relationships (e.g. `mentions`); never use for identity adoption or
+ *    authority.
+ *  - `first_match`: never allowed in v1. Reserved for future low-stakes use.
+ */
+export const MatchStrategy = Type.Union(
+  [Type.Literal('unique_only'), Type.Literal('all_matches'), Type.Literal('first_match')],
+  { $id: 'MatchStrategy' }
+);
+export type MatchStrategy = Static<typeof MatchStrategy>;
+
+export const AutoCreateWhenRule = Type.Object(
+  {
+    /** The fact namespace this rule listens for. */
+    sourceNamespace: Type.String({ minLength: 1, maxLength: 64 }),
+    /**
+     * The metadata field on the target entity-type whose normalized value
+     * must equal the fact's normalizedValue.
+     */
+    targetField: Type.String({ minLength: 1, maxLength: 64 }),
+    /**
+     * Minimum assurance the fact must carry to fire this rule. The engine
+     * enforces `assuranceMeets(fact.assurance, rule.assuranceRequired)`.
+     */
+    assuranceRequired: AssuranceLevel,
+    matchStrategy: MatchStrategy,
+    /**
+     * Optional notes for review tooling — not consumed by the engine.
+     */
+    notes: Type.Optional(Type.String({ maxLength: 512 })),
+  },
+  { $id: 'AutoCreateWhenRule', additionalProperties: false }
+);
+export type AutoCreateWhenRule = Static<typeof AutoCreateWhenRule>;
+
+/**
+ * The shape stored on `entity_relationship_types.metadata`. Includes the
+ * declared rules plus a version+hash so derivations can pin to the rule
+ * version that fired them and reconciliation can detect drift.
+ */
+export const RelationshipTypeIdentityMetadata = Type.Object(
+  {
+    autoCreateWhen: Type.Array(AutoCreateWhenRule, { maxItems: 16 }),
+    /** Monotonically increasing per relationship-type. Bumped by the seeder on every YAML change. */
+    ruleVersion: Type.Integer({ minimum: 1 }),
+    /** sha256 of the canonicalised auto_create_when array. Drift detection. */
+    ruleHash: Type.String({ minLength: 64, maxLength: 64 }),
+  },
+  { $id: 'RelationshipTypeIdentityMetadata', additionalProperties: true }
+);
+export type RelationshipTypeIdentityMetadata = Static<typeof RelationshipTypeIdentityMetadata>;
+
+// =============================================================================
+// IdentityNamespaceField — declared on entity-type field YAMLs
+// =============================================================================
+
+/**
+ * Marker placed on an entity-type field's metadata-schema entry to declare
+ * that the field's value participates in identity lookup. The seeder reads
+ * these markers and the engine uses them to resolve "what entity does this
+ * fact's normalizedValue point at?".
+ */
+export const IdentityNamespaceField = Type.Object(
+  {
+    namespace: Type.String({ minLength: 1, maxLength: 64 }),
+    /**
+     * Built-in normalizer to apply both at write time (entity creation) and
+     * at lookup time. `lowercase` collapses case; `linkedin_canonical`
+     * strips scheme/www/trailing-slash; `e164_phone` digit-only; `as_is`
+     * means no transformation.
+     */
+    normalize: Type.Union([
+      Type.Literal('lowercase'),
+      Type.Literal('linkedin_canonical'),
+      Type.Literal('e164_phone'),
+      Type.Literal('as_is'),
+    ]),
+  },
+  { $id: 'IdentityNamespaceField', additionalProperties: false }
+);
+export type IdentityNamespaceField = Static<typeof IdentityNamespaceField>;
+
+// =============================================================================
+// Fact event metadata — written into events.metadata when the engine
+// persists a connector fact as `semantic_type='identity_fact'`
+// =============================================================================
+
+export const FactEventMetadata = Type.Object(
+  {
+    namespace: Type.String({ minLength: 1, maxLength: 64 }),
+    identifier: Type.String({ minLength: 1, maxLength: 1024 }),
+    normalizedValue: Type.String({ minLength: 1, maxLength: 1024 }),
+    assurance: AssuranceLevel,
+    providerStableId: Type.String({ minLength: 1, maxLength: 256 }),
+    sourceAccountId: Type.String({ minLength: 1, maxLength: 256 }),
+    validTo: Type.Optional(Type.String({ format: 'date-time' })),
+    notes: Type.Optional(Type.String({ maxLength: 512 })),
+  },
+  { $id: 'FactEventMetadata', additionalProperties: false }
+);
+export type FactEventMetadata = Static<typeof FactEventMetadata>;
+
+// =============================================================================
+// DerivedFromProvenance — written into entity_relationships.metadata when
+// the engine auto-creates a relationship
+// =============================================================================
+
+export const DerivedFromProvenance = Type.Object(
+  {
+    /** events.id of the fact that produced this derivation. */
+    sourceEventId: Type.Integer({ minimum: 1 }),
+    /** Which relationship-type rule fired (entity_relationship_types.id). */
+    relationshipTypeId: Type.Integer({ minimum: 1 }),
+    /** Snapshot of the rule version that fired. Drift signal for reconcile. */
+    ruleVersion: Type.Integer({ minimum: 1 }),
+    /** Hash matching ruleHash on the relationship-type at fire time. */
+    ruleHash: Type.String({ minLength: 64, maxLength: 64 }),
+    /** Echoed for fast assurance audits without joining back to the event. */
+    factAssurance: AssuranceLevel,
+    /** ISO-8601. Echoes events.created_at; convenience for relationship-only audits. */
+    derivedAt: Type.String({ format: 'date-time' }),
+  },
+  { $id: 'DerivedFromProvenance', additionalProperties: false }
+);
+export type DerivedFromProvenance = Static<typeof DerivedFromProvenance>;
+
+/**
+ * The metadata blob stored on entity_relationships.metadata for derived
+ * rows. Wraps the provenance so other metadata keys can coexist.
+ */
+export const DerivedRelationshipMetadata = Type.Object(
+  {
+    derivedFrom: DerivedFromProvenance,
+  },
+  { $id: 'DerivedRelationshipMetadata', additionalProperties: true }
+);
+export type DerivedRelationshipMetadata = Static<typeof DerivedRelationshipMetadata>;
+
+// =============================================================================
+// ClaimCollision — pending-approval event payload
+// =============================================================================
+
+/**
+ * When a fact match would adopt a `$member` row that's already bound to a
+ * different user (or vice versa), the engine writes a pending-approval event
+ * with this shape. Resolution = a privileged user flips
+ * `interaction_status='approved'` after merging entities, or 'rejected' to
+ * dismiss without action.
+ */
+export const ClaimCollisionPayload = Type.Object(
+  {
+    kind: Type.Literal('identity_match'),
+    namespace: Type.String({ minLength: 1, maxLength: 64 }),
+    identifier: Type.String({ minLength: 1, maxLength: 1024 }),
+    normalizedValue: Type.String({ minLength: 1, maxLength: 1024 }),
+    candidateMemberIds: Type.Array(Type.Integer({ minimum: 1 }), {
+      minItems: 2,
+      maxItems: 16,
+    }),
+    /**
+     * Which fact (events.id) raised the collision. Lets the resolver replay
+     * the binding once the human picks a winner.
+     */
+    triggeringEventId: Type.Integer({ minimum: 1 }),
+    /** Rule that would have fired if the match were unambiguous. */
+    relationshipTypeId: Type.Optional(Type.Integer({ minimum: 1 })),
+  },
+  { $id: 'ClaimCollisionPayload', additionalProperties: false }
+);
+export type ClaimCollisionPayload = Static<typeof ClaimCollisionPayload>;
+
+// =============================================================================
+// Constants — used by core code AND connector tests so the lint check has
+// a single source of truth.
+// =============================================================================
+
+export const IDENTITY_FACT_SEMANTIC_TYPE = 'identity_fact' as const;
+export const CLAIM_COLLISION_SEMANTIC_TYPE = 'claim_collision' as const;

--- a/packages/owletto-sdk/src/identity-types.ts
+++ b/packages/owletto-sdk/src/identity-types.ts
@@ -73,7 +73,8 @@ export const ConnectorFact = Type.Object(
      */
     sourceAccountId: Type.String({ minLength: 1, maxLength: 256 }),
     /** Optional expiry. Required for high-assurance facts in production. */
-    validTo: Type.Optional(Type.String({ format: 'date-time' })),
+    /** ISO-8601 timestamp string. Optional; required for high-assurance facts in production. */
+    validTo: Type.Optional(Type.String({ minLength: 1, maxLength: 64 })),
     /**
      * Optional human-readable note about trust caveats this fact carries.
      * Surfaced in audit logs and admin UIs; never used by the engine.
@@ -205,15 +206,24 @@ export type IdentityNamespaceField = Static<typeof IdentityNamespaceField>;
 // persists a connector fact as `semantic_type='identity_fact'`
 // =============================================================================
 
+/**
+ * Stored on `events.metadata` for `semantic_type='identity_fact'` rows.
+ *
+ * Tombstone facts (written when a connector refresh stops emitting a
+ * namespace) carry empty `identifier`/`normalizedValue`/`providerStableId`,
+ * which is why those fields allow empty strings here even though
+ * `ConnectorFact` (the connector-side input) requires non-empty.
+ */
 export const FactEventMetadata = Type.Object(
   {
     namespace: Type.String({ minLength: 1, maxLength: 64 }),
-    identifier: Type.String({ minLength: 1, maxLength: 1024 }),
-    normalizedValue: Type.String({ minLength: 1, maxLength: 1024 }),
+    identifier: Type.String({ minLength: 0, maxLength: 1024 }),
+    normalizedValue: Type.String({ minLength: 0, maxLength: 1024 }),
     assurance: AssuranceLevel,
-    providerStableId: Type.String({ minLength: 1, maxLength: 256 }),
+    providerStableId: Type.String({ minLength: 0, maxLength: 256 }),
     sourceAccountId: Type.String({ minLength: 1, maxLength: 256 }),
-    validTo: Type.Optional(Type.String({ format: 'date-time' })),
+    /** ISO-8601 timestamp string. Optional; required for high-assurance facts in production. */
+    validTo: Type.Optional(Type.String({ minLength: 1, maxLength: 64 })),
     notes: Type.Optional(Type.String({ maxLength: 512 })),
   },
   { $id: 'FactEventMetadata', additionalProperties: false }
@@ -237,8 +247,8 @@ export const DerivedFromProvenance = Type.Object(
     ruleHash: Type.String({ minLength: 64, maxLength: 64 }),
     /** Echoed for fast assurance audits without joining back to the event. */
     factAssurance: AssuranceLevel,
-    /** ISO-8601. Echoes events.created_at; convenience for relationship-only audits. */
-    derivedAt: Type.String({ format: 'date-time' }),
+    /** ISO-8601 timestamp. Echoes events.created_at; convenience for relationship-only audits. */
+    derivedAt: Type.String({ minLength: 1, maxLength: 64 }),
   },
   { $id: 'DerivedFromProvenance', additionalProperties: false }
 );

--- a/packages/owletto-sdk/src/index.ts
+++ b/packages/owletto-sdk/src/index.ts
@@ -47,6 +47,24 @@ export type {
   SyncResult,
 } from './connector-types.js';
 export { IDENTITY } from './connector-types.js';
+// Identity-engine SDK contracts. Each schema export is both a TypeBox
+// runtime validator (value) AND a TypeScript type via declaration merging.
+export {
+  AssuranceLevel,
+  assuranceMeets,
+  AutoCreateWhenRule,
+  CLAIM_COLLISION_SEMANTIC_TYPE,
+  ClaimCollisionPayload,
+  ConnectorFact,
+  ConnectorIdentityCapability,
+  DerivedFromProvenance,
+  DerivedRelationshipMetadata,
+  FactEventMetadata,
+  IDENTITY_FACT_SEMANTIC_TYPE,
+  IdentityNamespaceField,
+  MatchStrategy,
+  RelationshipTypeIdentityMetadata,
+} from './identity-types.js';
 export { isSourceNativeEventType, SOURCE_NATIVE_EVENT_TYPES } from './event-taxonomy.js';
 // HTTP clients
 export {


### PR DESCRIPTION
**Stacked on #414** (`feat/phase-1-rename-atlas-cli-cleanup`). Rebase onto main once #414 lands.

## What this is

The connector-facts identity engine: connectors emit verified attributes as fact-typed events; catalog YAML declares match rules on relationship types; a generic engine writes derivations with provenance. Foundation only — auth wiring + connector capability declarations + founder→\$member migration land in F1b.

## Data model: zero new tables

| Concept | Where it lives |
| --- | --- |
| Connector fact | `events` row, \`semantic_type='identity_fact'\`, with metadata blob |
| Refresh / supersede | existing \`supersedes_event_id\` chain + \`current_event_records\` view |
| Match rule | \`entity_relationship_types.metadata.autoCreateWhen[]\` |
| Rule version + drift | \`metadata.ruleVersion\` + \`metadata.ruleHash\` (sha256 of canonical rule set) |
| Derivation provenance | \`entity_relationships.metadata.derivedFrom\` |
| Claim collision queue | \`events\` row, \`semantic_type='claim_collision'\`, \`interaction_type='approval'\`, \`interaction_status='pending'\` |
| Reconciliation | (will use existing \`runs\` queue when wired) |

Migration \`20260427140000_identity_engine_indexes.sql\` adds:
- \`metadata jsonb\` column on \`entity_relationship_types\`
- partial expression indexes on \`events\` for identity-fact lookup + per-account fact diff
- partial expression indexes on \`entity_relationships\` for provenance reverse-lookup + rule-version drift detection

## SDK contracts (\`@lobu/owletto-sdk\`)

TypeBox schemas double as runtime validators. Engine validates at every write boundary (T1 from the confidence framework):
- \`ConnectorFact\` — what a connector emits
- \`ConnectorIdentityCapability\` — static declaration of namespaces + assurance the connector can produce (used by future CI lint)
- \`AutoCreateWhenRule\` — per-rule match config in catalog YAML
- \`FactEventMetadata\` — events.metadata shape for fact-typed rows
- \`DerivedFromProvenance\` — entity_relationships.metadata.derivedFrom shape
- \`ClaimCollisionPayload\` — pending-approval event payload
- \`AssuranceLevel\` total order: \`oauth_verified_admin_role\` > \`oauth_verified\` > \`cookie_session\` > \`self_attested\`
- \`assuranceMeets()\` rank-comparison helper

## Engine module (\`packages/owletto-backend/src/identity/\`)

\`engine.ts ingestFacts()\`:
- Validates every incoming fact (TypeBox schema rejects malformed batches before any side effect).
- Persists each fact as an event with the prior fact for the same (account, namespace) as \`supersedes_event_id\`.
- Diffs prior facts vs current namespaces — anything dropped gets a tombstone event.
- For each fact, queries every public-catalog relationship type whose metadata has matching \`autoCreateWhen\` rules.
  - Filters by \`assuranceMeets(fact, rule.assuranceRequired)\`.
  - Looks up entities in the catalog whose declared metadata field equals \`normalizedValue\`.
  - \`unique_only\` ambiguity → writes a \`claim_collision\` approval event referencing both candidates; skips derivation.
  - \`first_match\` is rejected at runtime (reserved; not allowed in v1 — Pi correction).
  - Otherwise inserts a derivation relationship with full provenance.
- On supersede: revokes derivations whose \`metadata.derivedFrom.sourceEventId\` matches the superseded event.

\`validate.ts\`: TypeCompiler-based fast-path validators. Throws \`IdentitySchemaError\` with structured error context.

\`types.ts\`: engine-internal \`IngestResult\`, \`EngineOptions\`.

## Shadow mode (T3)

Set \`IDENTITY_ENGINE_SHADOW=true\` (or pass \`{ options: { shadow: true } }\`) to write fact events without firing derivations or revocations. Used for prod rollout validation before flipping derivations on.

## Integration tests (T2)

7 vitest scenarios against pglite:
- UC1 — sign-in derives \`works_at\` to a domain-matching company
- UC4 — refresh dropping a namespace supersedes the fact, revokes the derivation
- UC5 — admin-tier rule fires only on \`oauth_verified_admin_role\`
- UC6 — ambiguous match (two founders share linkedin URL) surfaces a \`claim_collision\` approval event, skips derivation
- UC8 — fact below required assurance is skipped
- shadow mode — facts written, no derivations
- malformed fact — IdentitySchemaError before any side effect

All pass in ~2s. \`bun run typecheck\` clean across SDK + backend.

## What's NOT in this PR

- Auth middleware wiring (BetterAuth account.create/update/delete hooks → ingestFacts) — F1b
- Google connector capability + emission of OAuth-verified facts — F1b
- Founder → \$member migration in market — F1b
- Connector capability lint (T4) — F1c
- Claim collision UX in owletto-web (T5) — F1d submodule PR
- Albert end-to-end dev test (T6) — runs after F1b lands

## Confidence per the framework

- T1 (schema rigor): **delivered** — all write boundaries validated.
- T2 (golden tests): **delivered** for engine; auth-hook scenarios in F1b.
- T3 (shadow mode): **delivered** — runtime toggle.
- T4 (connector lint): **deferred** to F1c.
- T5 (collision UX): **deferred** to F1d.
- T6 (Albert E2E): **deferred** — needs F1b's auth wiring first.

Confidence on the engine itself working correctly under the documented contract: **~88%**. The remaining gap is auth-wiring integration + real OAuth provider edge cases that the F1b PR will exercise.