### PR TITLE
fix(execute): harden sandbox runtime

### DIFF
--- a/packages/owletto-backend/src/__tests__/unit/sandbox/run-script.test.ts
+++ b/packages/owletto-backend/src/__tests__/unit/sandbox/run-script.test.ts
@@ -2,6 +2,14 @@ import { describe, expect, it } from "bun:test";
 import type { ClientSDK } from "../../../sandbox/client-sdk";
 import { getDefaultLimits, runScript } from "../../../sandbox/run-script";
 
+function skipIfRuntimeUnavailable(
+  result: Awaited<ReturnType<typeof runScript>>,
+): boolean {
+  if (result.error?.name !== "RuntimeUnavailable") return false;
+  expect(result.success).toBe(false);
+  return true;
+}
+
 describe("runScript", () => {
   it("exposes default resource limits", () => {
     const limits = getDefaultLimits();
@@ -33,12 +41,63 @@ describe("runScript", () => {
     // Skip on environments where the optional native module is unavailable
     // (the runner reports RuntimeUnavailable). Otherwise the bridge must
     // succeed and forward the return value.
-    if (result.error?.name === "RuntimeUnavailable") {
-      expect(result.success).toBe(false);
-      return;
-    }
+    if (skipIfRuntimeUnavailable(result)) return;
     expect(result.success).toBe(true);
     expect(result.returnValue).toBe(3);
     expect(result.sdkCalls).toBe(0);
+  });
+
+  it("supports direct client.org(slug).namespace.method() chaining", async () => {
+    const orgSdk = {
+      entities: {
+        get: async () => ({ org: "atlas", id: 123 }),
+      },
+      org: async () => {
+        throw new Error("nested org not expected");
+      },
+      query: async () => [],
+      log: () => undefined,
+    } as unknown as ClientSDK;
+    const stubSdk = {
+      org: async (slug: string) => {
+        expect(slug).toBe("atlas");
+        return orgSdk;
+      },
+      query: async () => [],
+      log: () => undefined,
+    } as unknown as ClientSDK;
+
+    const result = await runScript({
+      source:
+        'export default async (_ctx, client) => client.org("atlas").entities.get({ id: 123 });',
+      sdk: stubSdk,
+    });
+
+    if (skipIfRuntimeUnavailable(result)) return;
+    expect(result.success).toBe(true);
+    expect(result.returnValue).toEqual({ org: "atlas", id: 123 });
+    expect(result.sdkCalls).toBe(1);
+  });
+
+  it("enforces wall-clock timeout while awaiting SDK calls", async () => {
+    const stubSdk = {
+      entities: {
+        list: async () =>
+          new Promise((resolve) => setTimeout(() => resolve([]), 200)),
+      },
+      log: () => undefined,
+    } as unknown as ClientSDK;
+
+    const result = await runScript({
+      source:
+        "export default async (_ctx, client) => client.entities.list({ limit: 1 });",
+      sdk: stubSdk,
+      limits: { timeoutMs: 25 },
+    });
+
+    if (skipIfRuntimeUnavailable(result)) return;
+    expect(result.success).toBe(false);
+    expect(result.error?.name).toBe("TimeoutError");
+    expect(result.sdkCalls).toBe(1);
   });
 });

--- a/packages/owletto-backend/src/sandbox/run-script.ts
+++ b/packages/owletto-backend/src/sandbox/run-script.ts
@@ -71,13 +71,63 @@ const DEFAULT_LIMITS: Required<RunLimits> = {
   outputBytes: 262_144,
 };
 
+function clampNumber(value: number | undefined, fallback: number, min: number, max: number) {
+  const n = Number.isFinite(value) ? value : fallback;
+  return Math.max(min, Math.min(n ?? fallback, max));
+}
+
+function clampLimits(limits?: RunLimits): Required<RunLimits> {
+  return {
+    memoryMb: clampNumber(limits?.memoryMb, DEFAULT_LIMITS.memoryMb, 8, DEFAULT_LIMITS.memoryMb),
+    timeoutMs: clampNumber(limits?.timeoutMs, DEFAULT_LIMITS.timeoutMs, 1, DEFAULT_LIMITS.timeoutMs),
+    sdkCallQuota: clampNumber(
+      limits?.sdkCallQuota,
+      DEFAULT_LIMITS.sdkCallQuota,
+      1,
+      DEFAULT_LIMITS.sdkCallQuota,
+    ),
+    outputBytes: clampNumber(
+      limits?.outputBytes,
+      DEFAULT_LIMITS.outputBytes,
+      1024,
+      DEFAULT_LIMITS.outputBytes,
+    ),
+  };
+}
+
+function withTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => {
+      reject(new Error(`TimeoutError: script exceeded ${timeoutMs}ms wall-clock budget`));
+    }, timeoutMs);
+  });
+  return Promise.race([promise, timeout]).finally(() => {
+    if (timer) clearTimeout(timer);
+  });
+}
+
+type IsolatedVmRuntime = typeof import("isolated-vm");
+
 /**
  * Load `isolated-vm` lazily. Returns null when the optional native module is
  * not installed (e.g. local dev on a Node version without a prebuild).
  */
-async function loadIsolatedVm(): Promise<typeof import("isolated-vm") | null> {
+async function loadIsolatedVm(): Promise<IsolatedVmRuntime | null> {
+  const nodeMajor = Number(process.versions.node?.split(".")[0] ?? 0);
+  // isolated-vm is a native V8 addon. Node 25 currently imports but can crash
+  // the process when constructing an isolate; fail closed instead of taking
+  // down the MCP server. The project pins supported runtime to Node 22–24.
+  if (!Number.isFinite(nodeMajor) || nodeMajor < 22 || nodeMajor >= 25) {
+    return null;
+  }
+
   try {
-    return await import("isolated-vm");
+    const mod = (await import("isolated-vm")) as unknown as IsolatedVmRuntime & {
+      default?: IsolatedVmRuntime;
+      "module.exports"?: IsolatedVmRuntime;
+    };
+    return mod.default ?? mod["module.exports"] ?? mod;
   } catch {
     return null;
   }
@@ -109,7 +159,7 @@ function __makeClient(orgPath) {
       if (__isReservedKey(key)) return undefined;
       const k = String(key);
       if (k === 'org') {
-        return async (slug) => __makeClient([...orgPath, String(slug)]);
+        return (slug) => __makeClient([...orgPath, String(slug)]);
       }
       if (k === 'query' || k === 'log') {
         return async (...args) => {
@@ -167,7 +217,7 @@ export async function runScript(
   options: RunScriptOptions,
 ): Promise<RunScriptResult> {
   const started = Date.now();
-  const limits = { ...DEFAULT_LIMITS, ...(options.limits ?? {}) };
+  const limits = clampLimits(options.limits);
 
   const logs: LogEntry[] = [];
   let sdkCalls = 0;
@@ -220,8 +270,9 @@ export async function runScript(
     };
   }
 
-  const isolate = new ivm.Isolate({ memoryLimit: limits.memoryMb });
+  let isolate: import("isolated-vm").Isolate | null = null;
   try {
+    isolate = new ivm.Isolate({ memoryLimit: limits.memoryMb });
     const context = await isolate.createContext();
     const jail = context.global;
     await jail.set("global", jail.derefInto());
@@ -315,7 +366,10 @@ export async function runScript(
       promise: true,
       copy: true,
     });
-    const returnJson = (await resultPromise) as string | null;
+    const returnJson = (await withTimeout(
+      resultPromise as Promise<string | null>,
+      limits.timeoutMs,
+    )) as string | null;
     if (returnJson) {
       outputBytes += returnJson.length;
       if (outputBytes > limits.outputBytes) {
@@ -335,7 +389,7 @@ export async function runScript(
     };
   } catch (err) {
     const e = err as Error;
-    const isTimeout = /script execution timed out/i.test(e.message);
+    const isTimeout = /script execution timed out|TimeoutError/i.test(e.message);
     const isQuota = /QuotaExceeded/.test(e.message);
     const isOom = /memory|allocation|isolate was disposed/i.test(e.message);
     const name = isTimeout
@@ -353,7 +407,7 @@ export async function runScript(
       sdkCalls,
     };
   } finally {
-    if (!isolate.isDisposed) {
+    if (isolate && !isolate.isDisposed) {
       isolate.dispose();
     }
   }


### PR DESCRIPTION
## Summary\n- normalize isolated-vm ESM/CJS loading and fail closed on unsupported Node runtimes instead of crashing\n- enforce execute wall-clock timeout across awaited SDK calls\n- make documented client.org(slug).namespace.method() chaining work in sandbox scripts\n- add targeted sandbox runner regression coverage\n\n## Validation\n- cd packages/owletto-backend && bun run typecheck --pretty false\n- cd packages/owletto-backend && bun test src/__tests__/unit/sandbox/run-script.test.ts\n- bun run typecheck:owletto\n