### PR TITLE
ci(pr-validation): build owletto-web in build-test job

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -86,6 +86,18 @@ jobs:
       - name: Build packages
         run: bun run build
 
+      # Frontend (owletto-web) ships in the prod app image but isn't covered by
+      # any other PR check: root `bun run build` skips it, and the root
+      # tsconfig excludes packages/owletto-web. Without this gate, a TS error
+      # in the submodule (or a stale submodule pointer) only surfaces when
+      # build-images.yml runs on main — and silently regresses the deploy.
+      # Build owletto-sdk first because owletto-web imports its compiled dist.
+      - name: Build frontend (owletto-web)
+        if: steps.submodule.outputs.stubbed != 'true'
+        run: |
+          cd packages/owletto-sdk && bun run build && cd ../..
+          cd packages/owletto-web && bun run build
+
       - name: Verify no uncommitted changes
         if: steps.submodule.outputs.stubbed != 'true'
         run: |


### PR DESCRIPTION
## Summary
- Adds an owletto-web (`tsc -b && vite build`) step to the existing `build-test` job in `pr-validation.yml`.
- Closes the gap that broke the prod app image build twice in the last two main pushes (#427 and the identity-engine commit), recovered by #428.

## Why this gap existed
- pr-validation.yml's `build-test` runs root `bun run build` → only `core`, `gateway`, `worker`.
- ci.yml's `typecheck` runs root `tsc --noEmit`, but root `tsconfig.json` excludes `packages/owletto-web/**` (and `typecheck:owletto` only covers backend / cli / embeddings / sdk).
- The frontend's first `tsc -b && vite build` was `build-images.yml` on main — too late, deploy already silently regressed.

## Test plan
- [x] Reproduced the original failure locally by checking out the broken `public-org-join-bar.tsx` from commit 7529024 — the new step fails with the same TS errors that broke prod.
- [x] Restored the file (current pinned SHA) — step passes.
- [ ] CI on this PR runs the new step against the current pinned commit (07ae5a1) and passes.

`build-test` is already a required status check per the main branch protection, so this gate now blocks merge automatically.