### PR TITLE
revert(execute): drop runtime swap in #430 — keep prod on bun

### DIFF
--- a/docker/app/start.sh
+++ b/docker/app/start.sh
@@ -3,7 +3,7 @@ set -e
 
 MODE="${1:-server}"
 
-echo "Starting Owletto backend (Node + tsx)"
+echo "Starting Owletto backend (Bun)"
 echo "================================"
 
 echo "Environment:"
@@ -41,16 +41,15 @@ else
   run_migrations
 fi
 
-# Run under Node so V8 native addons (isolated-vm) load.
-# Bun uses JavaScriptCore and cannot link the V8 ABI surface that
-# isolated-vm requires; the execute MCP tool silently degrades to
-# RuntimeUnavailable under bun. tsx provides the TS loader so the
-# source layout stays uncompiled.
-#
-# Keep cwd=/app — gateway services and embedded agent routes resolve
-# bundled config (`config/providers.json`) relative to process.cwd().
-# Use the absolute tsx loader path so the resolution doesn't depend
-# on cwd or PATH.
-exec node \
-  --import "file:///app/packages/owletto-backend/node_modules/tsx/dist/loader.mjs" \
-  /app/packages/owletto-backend/src/server.ts
+# NOTE: prod runs under Bun. The execute MCP tool requires V8
+# (isolated-vm), which Bun's JSC ABI shim cannot load. PR #430 attempted
+# to switch the runtime to `node --import tsx`, but exposed a CJS/ESM
+# interop gap: Node's cjs-module-lexer doesn't detect new named exports
+# of @lobu/core's CJS dist when the static import follows certain
+# reachability paths (e.g. the full server.ts boot chain hits
+# `SyntaxError: ... does not provide an export named 'createBuiltinSecretRef'`,
+# even though a same-imports test entry resolves fine). Reverted on the
+# understanding that fixing properly means making @lobu/core (and other
+# workspace packages) ship dual ESM+CJS output instead of CJS-only with
+# an `import` condition. Tracked separately.
+exec bun /app/packages/owletto-backend/src/server.ts


### PR DESCRIPTION
## Why

PR #430 switched `docker/app/start.sh` from `exec bun src/server.ts` to `exec node --import tsx src/server.ts` so isolated-vm could load. The runtime swap mechanism itself works (verified end-to-end in the live image: runScript() returns the expected result). But the resulting prod image **crashloops on boot**:

```
SyntaxError: The requested module '@lobu/core' does not provide an
export named 'createBuiltinSecretRef'
  at packages/owletto-backend/src/lobu/stores/postgres-secret-store.ts:13
```

The export exists in `@lobu/core/dist/secret-refs.js`. Node's cjs-module-lexer detects it when the file is the sole entry — but fails to detect it when reached via the full `server.ts` boot chain. Bun's CJS↔ESM interop didn't hit this.

Real fix: ship `@lobu/core` (and other workspace packages with the same shape) as dual ESM+CJS instead of CJS-only behind an `import` condition.

## Status

- Old pods (`56765bdd9c-*`) are still Running. RollingUpdate's maxUnavailable check blocked rollover when the new pod crashlooped, so traffic is unaffected.
- Reverting brings the deploy back to a healthy state.
- The execute MCP tool returns to its pre-#430 behavior: `RuntimeUnavailable` (the #427 hardening). Same broken-but-not-crashing state we had this morning.

## Out of scope

- The runtime swap itself (will land separately once @lobu/core ships dual ESM+CJS).
- The CI sandbox runtime test added in #430 stays in place — it correctly fails when isolated-vm can't load and will guard the future runtime swap.

## Test plan

- [ ] CI on this PR passes
- [ ] After merge: build-images succeeds, deploy rolls cleanly, both app pods Running on the new tag (which is functionally equivalent to the pre-#430 image)