### PR TITLE
fix(execute): bundle backend so prod runs under Node + isolated-vm

### DIFF
--- a/docker/app/Dockerfile
+++ b/docker/app/Dockerfile
@@ -44,7 +44,11 @@ RUN mkdir -p packages/cli packages/landing packages/owletto-cli packages/owletto
       done \
     && echo '{"name":"owletto","version":"0.0.0","private":true}' > packages/owletto-cli/package.json
 
-RUN --mount=type=cache,target=/root/.bun/install/cache bun install
+# Hoisted layout (npm-style flat node_modules) is required so the bundled
+# server.bundle.mjs (built below) can resolve transitive npm deps via Node's
+# resolver. Bun's default isolated linker uses .bun/<pkg>@<ver>/ paths that
+# Node doesn't understand.
+RUN --mount=type=cache,target=/root/.bun/install/cache bun install --linker=hoisted
 
 # Force rebuild of source layers
 ARG CACHEBUST=default
@@ -79,6 +83,11 @@ RUN cd packages/core && bunx tsc \
 
 # Type check
 RUN cd packages/owletto-backend && bunx tsc --noEmit
+
+# Bundle the backend so prod runs under Node (so isolated-vm loads). See
+# docker/app/start.sh and packages/owletto-backend/scripts/build-server-bundle.mjs
+# for the full rationale.
+RUN cd packages/owletto-backend && bun run build:server
 
 # Build frontend static assets (production only)
 ARG VITE_API_URL=

--- a/docker/app/start.sh
+++ b/docker/app/start.sh
@@ -3,7 +3,7 @@ set -e
 
 MODE="${1:-server}"
 
-echo "Starting Owletto backend (Bun)"
+echo "Starting Owletto backend (Node)"
 echo "================================"
 
 echo "Environment:"
@@ -41,15 +41,15 @@ else
   run_migrations
 fi
 
-# NOTE: prod runs under Bun. The execute MCP tool requires V8
-# (isolated-vm), which Bun's JSC ABI shim cannot load. PR #430 attempted
-# to switch the runtime to `node --import tsx`, but exposed a CJS/ESM
-# interop gap: Node's cjs-module-lexer doesn't detect new named exports
-# of @lobu/core's CJS dist when the static import follows certain
-# reachability paths (e.g. the full server.ts boot chain hits
-# `SyntaxError: ... does not provide an export named 'createBuiltinSecretRef'`,
-# even though a same-imports test entry resolves fine). Reverted on the
-# understanding that fixing properly means making @lobu/core (and other
-# workspace packages) ship dual ESM+CJS output instead of CJS-only with
-# an `import` condition. Tracked separately.
-exec bun /app/packages/owletto-backend/src/server.ts
+# Run under Node so V8 native addons (isolated-vm) load. Bun uses
+# JavaScriptCore and cannot link the V8 ABI surface that isolated-vm needs;
+# the execute MCP tool silently degrades to RuntimeUnavailable under bun.
+#
+# We run a pre-bundled artifact (built by scripts/build-server-bundle.mjs
+# in the builder stage) instead of TS source via tsx. Bundling at build
+# time inlines workspace packages (@lobu/core et al.) so Node never has to
+# bind named imports against their CJS dist barrels — that's what crashed
+# #430. External npm deps are resolved by Node from node_modules, which
+# is hoisted (see Dockerfile `bun install --linker=hoisted`) so the flat
+# layout matches what Node expects.
+exec node /app/packages/owletto-backend/dist/server.bundle.mjs

--- a/packages/owletto-backend/package.json
+++ b/packages/owletto-backend/package.json
@@ -8,6 +8,7 @@
   "scripts": {
     "dev": "tsx watch --ignore=../owletto-web/** --ignore=../../node_modules/** src/server.ts",
     "start": "tsx src/server.ts",
+    "build:server": "node ./scripts/build-server-bundle.mjs",
     "test": "vitest",
     "test:pglite": "OWLETTO_TEST_BACKEND=pglite vitest",
     "test:sandbox-runtime": "SKIP_TEST_DB_SETUP=1 vitest run src/__tests__/integration/sandbox/run-script-runtime.test.ts",

--- a/packages/owletto-backend/scripts/build-server-bundle.mjs
+++ b/packages/owletto-backend/scripts/build-server-bundle.mjs
@@ -1,0 +1,71 @@
+#!/usr/bin/env node
+/**
+ * Bundle src/server.ts into a single ESM file for production runtime.
+ *
+ * Why: prod runs under Node so isolated-vm (V8 native addon) loads. Running
+ * the TS source through tsx exposes Node's CJS↔ESM lexer interop with
+ * @lobu/core's CJS dist (#430 history). Bundling resolves all workspace
+ * imports at build time, so Node only ever sees the bundle's own ESM
+ * surface plus a small set of npm externals it can load from node_modules.
+ *
+ * Resolution conditions: 'bun' first, so workspace packages resolve to
+ * their TS source (./src/index.ts via the package.json `bun` condition)
+ * instead of their CJS dist. esbuild compiles the TS inline.
+ *
+ * External: bare specifiers stay external (loaded from node_modules at
+ * runtime). The Docker build uses `bun install --linker=hoisted` so Node's
+ * resolver finds them at top-level node_modules. Native addons (isolated-vm)
+ * and packages with require-in-the-middle hooks (Sentry, OpenTelemetry,
+ * pino) MUST stay external to keep their runtime hooks working.
+ */
+
+import esbuild from 'esbuild';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const pkgDir = join(here, '..');
+
+const result = await esbuild.build({
+  absWorkingDir: pkgDir,
+  entryPoints: ['src/server.ts'],
+  bundle: true,
+  outfile: 'dist/server.bundle.mjs',
+  platform: 'node',
+  target: 'node22',
+  format: 'esm',
+  conditions: ['bun', 'import', 'module', 'default'],
+  // Bundle only @lobu/* workspace packages and relative imports. Everything
+  // else stays external.
+  plugins: [
+    {
+      name: 'external-non-workspace',
+      setup(build) {
+        build.onResolve({ filter: /.*/ }, (args) => {
+          if (args.kind === 'entry-point') return null;
+          const id = args.path;
+          if (id.startsWith('.') || id.startsWith('/')) return null;
+          if (id.startsWith('@lobu/')) return null;
+          return { external: true };
+        });
+      },
+    },
+  ],
+  // CJS-style require() shim for any leftover require() calls in bundled
+  // code (esbuild emits these when it inlines CJS-flavoured workspace src).
+  // Don't inject __filename/__dirname here — esbuild emits per-module shims
+  // when bundled CJS source references them; top-level shims would collide.
+  banner: {
+    js: `import { createRequire as __createRequire } from 'module'; const require = __createRequire(import.meta.url);`,
+  },
+  sourcemap: true,
+  metafile: true,
+  logLevel: 'info',
+});
+
+const outPath = join(pkgDir, 'dist/server.bundle.mjs');
+const bytes = result.metafile.outputs[outPath]?.bytes ?? 0;
+console.log(
+  `\n=== bundle ready: dist/server.bundle.mjs (${(bytes / 1024 / 1024).toFixed(2)} MB)`,
+);
+console.log(`    warnings: ${result.warnings.length}, errors: ${result.errors.length}`);


### PR DESCRIPTION
## Why

Execute MCP tool has been broken in prod since launch: the backend runs under Bun (JSC, partial V8 ABI shim) but isolated-vm is a V8 native addon. `isolated_vm.node` fails to dlopen under Bun:
```
undefined symbol: v8::ValueSerializer::Delegate::HasCustomHostObject
```
PR #427 caught this and returned `RuntimeUnavailable`. The hardening worked — the tool itself never ran.

PR #430 tried `exec node --import tsx src/server.ts`. The runtime swap mechanism worked end-to-end (verified isolated-vm + runScript() in the live image). But the actual server boot crashed because Node's `cjs-module-lexer` couldn't detect named exports of `@lobu/core`'s CJS dist barrel when reached via the full `server.ts` import chain. Reverted in #431.

## What

Per a second-opinion review, the cleaner fix is to **bundle** the backend at build time. esbuild resolves all workspace imports inline (using the `bun` condition to pick up TS source rather than the CJS dist), so Node never has to bind named imports against cross-package CJS barrels — the failure mode that broke #430 simply doesn't exist for the bundle.

- `packages/owletto-backend/scripts/build-server-bundle.mjs` — esbuild config that bundles workspace + relative imports, externalizes every bare specifier. ~2.4 MB self-contained ESM, ~100 ms build.
- `packages/owletto-backend/package.json` — `build:server` npm script.
- `docker/app/Dockerfile` — switch `bun install` to `bun install --linker=hoisted` so node_modules is flat (Node's resolver doesn't understand bun's `.bun/<pkg>@<ver>/` isolated layout). Add a `bun run build:server` step in the builder stage.
- `docker/app/start.sh` — `exec node /app/.../dist/server.bundle.mjs` instead of `exec bun src/server.ts`.

## Native addons stay external

isolated-vm, `@sentry/*`, `@opentelemetry/*`, pino, etc. — externalized. They need to load via Node's normal resolver because they use native bindings or require-in-the-middle hooks. The hoisted node_modules layout makes them findable from the bundle's location.

## Verified

Built a local docker image (`docker build -f docker/app/Dockerfile -t lobu-app-spike:bundled .`) and exercised runScript via a small bundled test entry:
```
basic:    {success: true, returnValue: 3}
chaining: {success: true, returnValue: {slug: 'atlas', ok: true}}
```
Both are real V8 isolate executions inside the container, not RuntimeUnavailable.

## Regression guard

The CI sandbox-runtime test added in #430 (`packages/owletto-backend/src/__tests__/integration/sandbox/run-script-runtime.test.ts`) stays in place. It fails loudly when isolated-vm can't load — so any future regression of the runtime contract blocks merge.

## Tradeoffs

- Build adds ~5 s for the esbuild bundle.
- Hoisted layout is npm-style flat: install size similar, but matches what Node expects natively.
- If a native dep was wrongly bundled, it'll surface at boot (not silently) — easier to triage.

## Test plan

- [ ] CI passes (build-test, sandbox-runtime test, all gates)
- [ ] After merge: build-images succeeds, deploy rolls cleanly, both app pods Running on the new tag
- [ ] Smoke: MCP `execute` returns a real result instead of RuntimeUnavailable