### PR TITLE
fix(owletto-backend): re-register list_watchers/get_watcher/read_knowledge for REST

### DIFF
--- a/packages/owletto-backend/src/auth/__tests__/tool-access.test.ts
+++ b/packages/owletto-backend/src/auth/__tests__/tool-access.test.ts
@@ -305,7 +305,7 @@ describe('checkToolAccess', () => {
     ).toThrow(ToolNotRegisteredError);
   });
 
-  it('allows REST compatibility paths to reach legacy internal tools subject to access', () => {
+  it('allows REST compatibility paths to reach internal tools subject to access', () => {
     expect(() =>
       checkToolAccess('manage_entity', { action: 'create' }, {
         ...baseAuth,
@@ -315,6 +315,25 @@ describe('checkToolAccess', () => {
       })
     ).not.toThrow();
   });
+
+  it.each(['list_watchers', 'get_watcher', 'read_knowledge'])(
+    'hides %s from external MCP but keeps it reachable via REST',
+    (toolName) => {
+      // External MCP — must look like an unknown tool to the caller.
+      expect(() =>
+        checkToolAccess(toolName, {}, { ...baseAuth, memberRole: 'owner' })
+      ).toThrow(`Tool not found: ${toolName}`);
+
+      // REST proxy — frontend reaches the same handler.
+      expect(() =>
+        checkToolAccess(
+          toolName,
+          {},
+          { ...baseAuth, memberRole: 'member', allowInternalTools: true }
+        )
+      ).not.toThrow();
+    }
+  );
 
   it('keeps admin-only tools restricted for members', () => {
     // query_sql is the canonical admin-only tool on the post-PR-2 surface.

--- a/packages/owletto-backend/src/auth/__tests__/tool-access.test.ts
+++ b/packages/owletto-backend/src/auth/__tests__/tool-access.test.ts
@@ -353,15 +353,23 @@ describe('checkToolAccess', () => {
   });
 });
 
-describe('frontend apiCall coverage', () => {
-  // owletto-web is a submodule and may be absent on shallow clones.
+describe('first-party tool-name coverage', () => {
+  // Both surfaces share the same dispatch (`POST /api/:orgSlug/:toolName` →
+  // `restToolProxy` → `executeTool` → `getTool(name)`), but the CLI's
+  // browser-auth flow goes through MCP RPC and needs its tools to *also* be
+  // visible on `tools/list` (i.e. NOT `internal: true`). These tests pin both
+  // invariants.
   const __dirname = dirname(fileURLToPath(import.meta.url));
   const webSrcRoot = join(__dirname, '..', '..', '..', '..', 'owletto-web', 'src');
-  let webPresent = true;
-  try {
-    statSync(webSrcRoot);
-  } catch {
-    webPresent = false;
+  const cliSrcRoot = join(__dirname, '..', '..', '..', '..', 'owletto-cli', 'src');
+
+  function present(path: string): boolean {
+    try {
+      statSync(path);
+      return true;
+    } catch {
+      return false;
+    }
   }
 
   function collectTsFiles(dir: string, out: string[] = []): string[] {
@@ -377,11 +385,9 @@ describe('frontend apiCall coverage', () => {
     return out;
   }
 
-  function extractApiCallNames(): Set<string> {
-    const files = collectTsFiles(webSrcRoot);
-    const pattern = /\bapiCall(?:<[^>]*>)?\(\s*['"]([a-zA-Z_][a-zA-Z0-9_]*)['"]/g;
+  function extractMatches(root: string, pattern: RegExp): Set<string> {
     const names = new Set<string>();
-    for (const file of files) {
+    for (const file of collectTsFiles(root)) {
       for (const match of readFileSync(file, 'utf-8').matchAll(pattern)) {
         names.add(match[1]);
       }
@@ -389,23 +395,16 @@ describe('frontend apiCall coverage', () => {
     return names;
   }
 
-  // Names the frontend calls that have no backend handler. Each entry is dead
-  // code (unused hook) — kept here so the test fails the day someone wires it
-  // up without first registering the tool. Empty this set when the frontend
-  // is cleaned up.
+  // Names a first-party caller invokes that have no backend handler. Each
+  // entry is dead code — kept here so the test fails the day someone wires
+  // it up without first registering the tool. Empty this set when cleaned up.
   const KNOWN_DEAD_NAMES = new Set<string>([
-    // useDeleteWindow in packages/owletto-web/src/hooks/use-watchers.ts has
-    // no caller; manage_queue was never registered. Either delete the hook
-    // or add a manage_queue tool.
+    // useDeleteWindow in owletto-web/src/hooks/use-watchers.ts has no caller;
+    // manage_queue was never registered. Delete the hook or add the tool.
     'manage_queue',
   ]);
 
-  it('every apiCall(...) tool name is registered in the backend', () => {
-    if (!webPresent) {
-      // Submodule not checked out (shallow clone). Skip rather than fail.
-      return;
-    }
-    const used = extractApiCallNames();
+  function assertRegistered(used: Set<string>): void {
     const drift: string[] = [];
     const stale: string[] = [];
     for (const name of used) {
@@ -419,5 +418,58 @@ describe('frontend apiCall coverage', () => {
     expect(drift).toEqual([]);
     // If a previously-dead name is now registered, remove it from the allowlist.
     expect(stale).toEqual([]);
+  }
+
+  it('every owletto-web apiCall(...) tool name is registered', () => {
+    if (!present(webSrcRoot)) return; // submodule not checked out (shallow clone)
+    const used = extractMatches(
+      webSrcRoot,
+      /\bapiCall(?:<[^>]*>)?\(\s*['"]([a-zA-Z_][a-zA-Z0-9_]*)['"]/g
+    );
+    assertRegistered(used);
+  });
+
+  it('every owletto-cli REST callTool(ctx, name) is registered', () => {
+    if (!present(cliSrcRoot)) return;
+    const used = extractMatches(
+      cliSrcRoot,
+      /\bcallTool\(\s*[A-Za-z_][A-Za-z0-9_]*\s*,\s*['"]([a-zA-Z_][a-zA-Z0-9_]*)['"]/g
+    );
+    assertRegistered(used);
+  });
+
+  it('every owletto-cli MCP tools/call name is registered AND visible on the public MCP surface', () => {
+    if (!present(cliSrcRoot)) return;
+    // Match `name: 'foo'` literals inside browser-auth.ts (the file using
+    // mcpRpc 'tools/call'). Scoped by file rather than context to keep the
+    // regex simple — false positives on unrelated `name:` literals are caught
+    // by the registry check anyway.
+    const browserAuth = join(cliSrcRoot, 'commands', 'browser-auth.ts');
+    if (!present(browserAuth)) return;
+    const content = readFileSync(browserAuth, 'utf-8');
+    const used = new Set<string>();
+    for (const match of content.matchAll(/\bname:\s*['"]([a-zA-Z_][a-zA-Z0-9_]*)['"]/g)) {
+      used.add(match[1]);
+    }
+    // The defineCommand frontmatter uses `name: 'browser-auth'` — that's not
+    // a tool, just the CLI command's own name. Filter to actually-registered
+    // tools to avoid false positives without hiding genuine drift.
+    const candidates = [...used].filter((n) => getTool(n));
+    expect(candidates.length).toBeGreaterThan(0); // sanity: we found at least one
+
+    const internal: string[] = [];
+    const missing: string[] = [];
+    for (const name of candidates) {
+      const tool = getTool(name);
+      if (!tool) {
+        missing.push(name);
+        continue;
+      }
+      if (tool.internal) internal.push(name);
+    }
+    expect(missing).toEqual([]);
+    // CLI hits these via MCP RPC; flipping any to `internal: true` silently
+    // breaks `owletto browser-auth`. Pin the invariant.
+    expect(internal).toEqual([]);
   });
 });

--- a/packages/owletto-backend/src/auth/__tests__/tool-access.test.ts
+++ b/packages/owletto-backend/src/auth/__tests__/tool-access.test.ts
@@ -4,10 +4,14 @@
  * Tests for requiresOwnerAdmin and isPublicReadable authorization checks.
  */
 
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
+import { ToolNotRegisteredError } from '../../utils/errors';
 import { routeAction } from '../../tools/admin/action-router';
 import { type AuthContext, checkToolAccess } from '../../tools/execute';
-import type { ToolContext } from '../../tools/registry';
+import { getTool, type ToolContext } from '../../tools/registry';
 import {
   getRequiredAccessLevel,
   isPublicReadable,
@@ -289,10 +293,16 @@ describe('checkToolAccess', () => {
     ).not.toThrow();
   });
 
-  it('hides legacy internal tools from external MCP calls even when the name is known', () => {
+  it('hides internal tools from external MCP calls even when the name is known', () => {
     expect(() =>
       checkToolAccess('manage_entity', { action: 'list' }, { ...baseAuth, memberRole: 'owner' })
     ).toThrow('Tool not found: manage_entity');
+  });
+
+  it('throws ToolNotRegisteredError for genuinely unregistered names so REST proxy can alert', () => {
+    expect(() =>
+      checkToolAccess('this_tool_does_not_exist', {}, { ...baseAuth, memberRole: 'owner' })
+    ).toThrow(ToolNotRegisteredError);
   });
 
   it('allows REST compatibility paths to reach legacy internal tools subject to access', () => {
@@ -321,5 +331,74 @@ describe('checkToolAccess', () => {
     ).toThrow(
       'This action requires admin or owner access. Ask an organization owner to grant elevated access.'
     );
+  });
+});
+
+describe('frontend apiCall coverage', () => {
+  // owletto-web is a submodule and may be absent on shallow clones.
+  const __dirname = dirname(fileURLToPath(import.meta.url));
+  const webSrcRoot = join(__dirname, '..', '..', '..', '..', 'owletto-web', 'src');
+  let webPresent = true;
+  try {
+    statSync(webSrcRoot);
+  } catch {
+    webPresent = false;
+  }
+
+  function collectTsFiles(dir: string, out: string[] = []): string[] {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      const full = join(dir, entry.name);
+      if (entry.isDirectory()) {
+        if (entry.name === 'node_modules' || entry.name === 'dist') continue;
+        collectTsFiles(full, out);
+      } else if (/\.(ts|tsx)$/.test(entry.name)) {
+        out.push(full);
+      }
+    }
+    return out;
+  }
+
+  function extractApiCallNames(): Set<string> {
+    const files = collectTsFiles(webSrcRoot);
+    const pattern = /\bapiCall(?:<[^>]*>)?\(\s*['"]([a-zA-Z_][a-zA-Z0-9_]*)['"]/g;
+    const names = new Set<string>();
+    for (const file of files) {
+      for (const match of readFileSync(file, 'utf-8').matchAll(pattern)) {
+        names.add(match[1]);
+      }
+    }
+    return names;
+  }
+
+  // Names the frontend calls that have no backend handler. Each entry is dead
+  // code (unused hook) — kept here so the test fails the day someone wires it
+  // up without first registering the tool. Empty this set when the frontend
+  // is cleaned up.
+  const KNOWN_DEAD_NAMES = new Set<string>([
+    // useDeleteWindow in packages/owletto-web/src/hooks/use-watchers.ts has
+    // no caller; manage_queue was never registered. Either delete the hook
+    // or add a manage_queue tool.
+    'manage_queue',
+  ]);
+
+  it('every apiCall(...) tool name is registered in the backend', () => {
+    if (!webPresent) {
+      // Submodule not checked out (shallow clone). Skip rather than fail.
+      return;
+    }
+    const used = extractApiCallNames();
+    const drift: string[] = [];
+    const stale: string[] = [];
+    for (const name of used) {
+      const registered = !!getTool(name);
+      if (KNOWN_DEAD_NAMES.has(name)) {
+        if (registered) stale.push(name);
+        continue;
+      }
+      if (!registered) drift.push(name);
+    }
+    expect(drift).toEqual([]);
+    // If a previously-dead name is now registered, remove it from the allowlist.
+    expect(stale).toEqual([]);
   });
 });

--- a/packages/owletto-backend/src/auth/__tests__/tool-access.test.ts
+++ b/packages/owletto-backend/src/auth/__tests__/tool-access.test.ts
@@ -420,13 +420,20 @@ describe('first-party tool-name coverage', () => {
     expect(stale).toEqual([]);
   }
 
-  it('every owletto-web apiCall(...) tool name is registered', () => {
+  it('every owletto-web tool reference (apiCall + hook-factory) is registered', () => {
     if (!present(webSrcRoot)) return; // submodule not checked out (shallow clone)
-    const used = extractMatches(
+    // Two patterns: direct `apiCall(<...>?)('foo', …)` and the hook-factory
+    // config form `tool: 'foo'` (used at api/entities.ts:165, api/connections.ts,
+    // etc. — over 30 sites the direct-apiCall regex would otherwise miss).
+    const apiCallNames = extractMatches(
       webSrcRoot,
       /\bapiCall(?:<[^>]*>)?\(\s*['"]([a-zA-Z_][a-zA-Z0-9_]*)['"]/g
     );
-    assertRegistered(used);
+    const hookFactoryNames = extractMatches(
+      webSrcRoot,
+      /\btool:\s*['"]([a-zA-Z_][a-zA-Z0-9_]*)['"]/g
+    );
+    assertRegistered(new Set([...apiCallNames, ...hookFactoryNames]));
   });
 
   it('every owletto-cli REST callTool(ctx, name) is registered', () => {
@@ -438,38 +445,37 @@ describe('first-party tool-name coverage', () => {
     assertRegistered(used);
   });
 
-  it('every owletto-cli MCP tools/call name is registered AND visible on the public MCP surface', () => {
+  // CLI tools that flow through MCP RPC (`mcpRpc(url, 'tools/call', { name })`)
+  // — must be registered AND non-internal, since `tools/list` filters out
+  // `internal: true`. Hardcoded rather than regex-derived so a removal from
+  // the CLI source can't silently shrink the assertion set.
+  const CLI_PUBLIC_MCP_TOOLS = ['manage_connections', 'manage_auth_profiles'] as const;
+
+  it.each(CLI_PUBLIC_MCP_TOOLS)(
+    'CLI MCP tool %s is registered and visible on the public MCP surface',
+    (name) => {
+      const tool = getTool(name);
+      expect(tool).toBeDefined();
+      // `internal: true` would hide the tool from external `tools/list`,
+      // silently breaking `owletto browser-auth`.
+      expect(tool?.internal ?? false).toBe(false);
+    }
+  );
+
+  it('CLI browser-auth tools/call literals match the pinned set', () => {
+    // Drift detector: if browser-auth.ts starts calling a new MCP tool, fail
+    // here rather than silently expand the public-MCP surface unannounced.
     if (!present(cliSrcRoot)) return;
-    // Match `name: 'foo'` literals inside browser-auth.ts (the file using
-    // mcpRpc 'tools/call'). Scoped by file rather than context to keep the
-    // regex simple — false positives on unrelated `name:` literals are caught
-    // by the registry check anyway.
     const browserAuth = join(cliSrcRoot, 'commands', 'browser-auth.ts');
     if (!present(browserAuth)) return;
     const content = readFileSync(browserAuth, 'utf-8');
     const used = new Set<string>();
-    for (const match of content.matchAll(/\bname:\s*['"]([a-zA-Z_][a-zA-Z0-9_]*)['"]/g)) {
+    // Match `mcpRpc(…, 'tools/call', { … name: 'X' … })` across newlines.
+    for (const match of content.matchAll(
+      /'tools\/call'[\s\S]{0,300}?\bname:\s*['"]([a-zA-Z_][a-zA-Z0-9_]*)['"]/g
+    )) {
       used.add(match[1]);
     }
-    // The defineCommand frontmatter uses `name: 'browser-auth'` — that's not
-    // a tool, just the CLI command's own name. Filter to actually-registered
-    // tools to avoid false positives without hiding genuine drift.
-    const candidates = [...used].filter((n) => getTool(n));
-    expect(candidates.length).toBeGreaterThan(0); // sanity: we found at least one
-
-    const internal: string[] = [];
-    const missing: string[] = [];
-    for (const name of candidates) {
-      const tool = getTool(name);
-      if (!tool) {
-        missing.push(name);
-        continue;
-      }
-      if (tool.internal) internal.push(name);
-    }
-    expect(missing).toEqual([]);
-    // CLI hits these via MCP RPC; flipping any to `internal: true` silently
-    // breaks `owletto browser-auth`. Pin the invariant.
-    expect(internal).toEqual([]);
+    expect([...used].sort()).toEqual([...CLI_PUBLIC_MCP_TOOLS].sort());
   });
 });

--- a/packages/owletto-backend/src/rest-api.ts
+++ b/packages/owletto-backend/src/rest-api.ts
@@ -234,8 +234,11 @@ export async function restToolProxy(
     if (error instanceof ToolNotRegisteredError) {
       // Registry/frontend drift — surface to Sentry so the next "Tool not
       // found" outage doesn't sit silent behind a 400 the page swallows.
+      // `tool_name` goes in `extra` (not `tags`) because the URL segment is
+      // attacker-controlled and would otherwise blow up tag cardinality.
       Sentry.captureException(error, {
-        tags: { tool_name: error.toolName, source: 'rest_proxy' },
+        tags: { source: 'rest_proxy' },
+        extra: { tool_name: error.toolName },
       });
     }
     return c.json({ error: errorMessage(error) }, 400);

--- a/packages/owletto-backend/src/rest-api.ts
+++ b/packages/owletto-backend/src/rest-api.ts
@@ -5,6 +5,7 @@
  * for use with ChatGPT, Zapier, and other REST-based integrations
  */
 
+import * as Sentry from '@sentry/node';
 import type { Context } from 'hono';
 import { getDb } from './db/client';
 import * as invalidationEmitter from './events/emitter';
@@ -24,7 +25,7 @@ import { executeTool, extractAuthContext, toToolContext } from './tools/execute'
 import { getContent } from './tools/get_content';
 import { getWatcher } from './tools/get_watchers';
 import { getTool } from './tools/registry';
-import { ToolUserError, errorMessage } from './utils/errors';
+import { ToolNotRegisteredError, ToolUserError, errorMessage } from './utils/errors';
 import { toJsonSafe } from './utils/json';
 import logger from './utils/logger';
 import { ACTIVE_RUN_STATUSES, runStatusLiteral } from './utils/run-statuses';
@@ -229,6 +230,13 @@ export async function restToolProxy(
   } catch (error) {
     if (error instanceof ToolUserError) {
       return c.json({ error: error.message }, error.httpStatus as 400 | 404);
+    }
+    if (error instanceof ToolNotRegisteredError) {
+      // Registry/frontend drift — surface to Sentry so the next "Tool not
+      // found" outage doesn't sit silent behind a 400 the page swallows.
+      Sentry.captureException(error, {
+        tags: { tool_name: error.toolName, source: 'rest_proxy' },
+      });
     }
     return c.json({ error: errorMessage(error) }, 400);
   }

--- a/packages/owletto-backend/src/tools/admin/index.ts
+++ b/packages/owletto-backend/src/tools/admin/index.ts
@@ -1,11 +1,23 @@
 /**
- * Legacy admin tools kept for REST/session callers while external MCP clients
- * use the smaller search/execute surface.
+ * Internal REST/CLI tool surface.
+ *
+ * External MCP clients see the small `search`/`execute`/`save_knowledge`/...
+ * surface from `registry.ts`. The frontend, owletto-cli, and other REST/session
+ * callers reach the named handlers below by `name` via `POST /api/:orgSlug/:toolName`.
+ *
+ * `restToolProxy` sets `allowInternalTools=true` (since the request didn't come
+ * in over `/mcp`), so `internal: true` tools are reachable by REST but hidden
+ * from MCP `tools/list`.
+ *
+ * The two non-internal entries (`manage_connections`, `manage_auth_profiles`)
+ * stay on the public MCP surface for owletto-cli's `browser-auth` flow.
  */
 
-import type { Static } from '@sinclair/typebox';
+import type { TSchema } from '@sinclair/typebox';
 import type { Env } from '../../index';
-import type { ToolContext, ToolDefinition } from '../registry';
+import { GetContentSchema, getContent } from '../get_content';
+import { GetWatcherSchema, getWatcher } from '../get_watchers';
+import type { ToolAnnotations, ToolContext, ToolDefinition } from '../registry';
 import { ManageAuthProfilesSchema, manageAuthProfiles } from './manage_auth_profiles';
 import { ManageClassifiersSchema, manageClassifiers } from './manage_classifiers';
 import { ManageConnectionsSchema, manageConnections } from './manage_connections';
@@ -14,112 +26,120 @@ import { ManageEntitySchemaSchema, manageEntitySchema } from './manage_entity_sc
 import { ManageFeedsSchema, manageFeeds } from './manage_feeds';
 import { ManageOperationsSchema, manageOperations } from './manage_operations';
 import { ManageViewTemplatesSchema, manageViewTemplates } from './manage_view_templates';
-import { ManageWatchersSchema, manageWatchers } from './manage_watchers';
+import {
+  ListWatchersSchema,
+  ManageWatchersSchema,
+  listWatchers,
+  manageWatchers,
+} from './manage_watchers';
 
-export const LEGACY_ADMIN_TOOLS: ToolDefinition[] = [
+interface InternalToolEntry {
+  name: string;
+  description: string;
+  schema: TSchema;
+  handler: (args: any, env: Env, ctx: ToolContext) => Promise<unknown>;
+  /** Defaults to `{ destructiveHint: false }`. */
+  annotations?: ToolAnnotations;
+  /**
+   * `true` (default) hides from MCP `tools/list` — REST/session callers can
+   * still reach it. `false` keeps it on the public MCP surface (currently
+   * just the two CLI browser-auth tools).
+   */
+  internal?: boolean;
+}
+
+const READ_ONLY: ToolAnnotations = { readOnlyHint: true, idempotentHint: true };
+const WRITE: ToolAnnotations = { destructiveHint: false };
+
+const ENTRIES: InternalToolEntry[] = [
   {
     name: 'manage_entity',
-    description:
-      'Legacy internal entity management tool for REST/session callers. External MCP clients should use execute + client.entities instead.',
-    inputSchema: ManageEntitySchema,
-    annotations: { destructiveHint: false },
-    internal: true,
-    handler: async (args: Static<typeof ManageEntitySchema>, env: Env, ctx: ToolContext) => {
-      return await manageEntity(args, env, ctx);
-    },
+    description: 'Entity management. SDK alternative: client.entities.',
+    schema: ManageEntitySchema,
+    handler: manageEntity,
   },
   {
     name: 'manage_entity_schema',
-    description:
-      'Legacy internal schema management tool for REST/session callers. External MCP clients should use execute + client.entitySchema instead.',
-    inputSchema: ManageEntitySchemaSchema,
-    annotations: { destructiveHint: false },
-    internal: true,
-    handler: async (args: Static<typeof ManageEntitySchemaSchema>, env: Env, ctx: ToolContext) => {
-      return await manageEntitySchema(args, env, ctx);
-    },
+    description: 'Entity-type schema management. SDK alternative: client.entitySchema.',
+    schema: ManageEntitySchemaSchema,
+    handler: manageEntitySchema,
   },
   {
-    // Kept on the public MCP surface (not internal) because owletto-cli's
-    // `browser-auth` flow drives connection setup via MCP RPC. New external
-    // clients should still prefer execute + client.connections; we'll flip
-    // this back to internal once the CLI migrates.
     name: 'manage_connections',
     description:
-      'Connection management. New external MCP clients should prefer execute + client.connections; this tool is kept public for the owletto-cli browser-auth flow.',
-    inputSchema: ManageConnectionsSchema,
-    annotations: { destructiveHint: false },
-    handler: async (args: Static<typeof ManageConnectionsSchema>, env: Env, ctx: ToolContext) => {
-      return await manageConnections(args, env, ctx);
-    },
+      'Connection management. Kept on the public MCP surface for the owletto-cli browser-auth flow. SDK alternative: client.connections.',
+    schema: ManageConnectionsSchema,
+    handler: manageConnections,
+    internal: false,
   },
   {
     name: 'manage_feeds',
-    description:
-      'Legacy internal feed management tool for REST/session callers. External MCP clients should use execute + client.feeds instead.',
-    inputSchema: ManageFeedsSchema,
-    annotations: { destructiveHint: false },
-    internal: true,
-    handler: async (args: Static<typeof ManageFeedsSchema>, env: Env, ctx: ToolContext) => {
-      return await manageFeeds(args, env, ctx);
-    },
+    description: 'Feed management. SDK alternative: client.feeds.',
+    schema: ManageFeedsSchema,
+    handler: manageFeeds,
   },
   {
-    // Kept on the public MCP surface (not internal) because owletto-cli's
-    // `browser-auth` flow exchanges credential blobs via MCP RPC. New external
-    // clients should still prefer execute + client.authProfiles; we'll flip
-    // this back to internal once the CLI migrates.
     name: 'manage_auth_profiles',
     description:
-      'Auth-profile management. New external MCP clients should prefer execute + client.authProfiles; this tool is kept public for the owletto-cli browser-auth flow.',
-    inputSchema: ManageAuthProfilesSchema,
-    annotations: { destructiveHint: false },
-    handler: async (args: Static<typeof ManageAuthProfilesSchema>, env: Env, ctx: ToolContext) => {
-      return await manageAuthProfiles(args, env, ctx);
-    },
+      'Auth-profile management. Kept on the public MCP surface for the owletto-cli browser-auth flow. SDK alternative: client.authProfiles.',
+    schema: ManageAuthProfilesSchema,
+    handler: manageAuthProfiles,
+    internal: false,
   },
   {
     name: 'manage_operations',
-    description:
-      'Legacy internal operations tool for REST/session callers. External MCP clients should use execute + client.operations instead.',
-    inputSchema: ManageOperationsSchema,
+    description: 'Operation execution / approval. SDK alternative: client.operations.',
+    schema: ManageOperationsSchema,
+    handler: manageOperations,
     annotations: { destructiveHint: false, openWorldHint: true },
-    internal: true,
-    handler: async (args: Static<typeof ManageOperationsSchema>, env: Env, ctx: ToolContext) => {
-      return await manageOperations(args, env, ctx);
-    },
   },
   {
     name: 'manage_watchers',
+    description: 'Watcher management. SDK alternative: client.watchers.',
+    schema: ManageWatchersSchema,
+    handler: manageWatchers,
+  },
+  {
+    name: 'list_watchers',
+    description: 'List watchers. SDK alternative: client.watchers.list.',
+    schema: ListWatchersSchema,
+    handler: listWatchers,
+    annotations: READ_ONLY,
+  },
+  {
+    name: 'get_watcher',
+    description: 'Watcher detail + windows. SDK alternative: client.watchers.get.',
+    schema: GetWatcherSchema,
+    handler: getWatcher,
+    annotations: READ_ONLY,
+  },
+  {
+    name: 'read_knowledge',
     description:
-      'Legacy internal watcher management tool for REST/session callers. External MCP clients should use execute + client.watchers instead.',
-    inputSchema: ManageWatchersSchema,
-    annotations: { destructiveHint: false },
-    internal: true,
-    handler: async (args: Static<typeof ManageWatchersSchema>, env: Env, ctx: ToolContext) => {
-      return await manageWatchers(args, env, ctx);
-    },
+      'Read content/knowledge. SDK alternatives: search_knowledge, client.knowledge.search.',
+    schema: GetContentSchema,
+    handler: getContent,
+    annotations: READ_ONLY,
   },
   {
     name: 'manage_classifiers',
-    description:
-      'Legacy internal classifier management tool for REST/session callers. External MCP clients should use execute + client.classifiers instead.',
-    inputSchema: ManageClassifiersSchema,
-    annotations: { destructiveHint: false },
-    internal: true,
-    handler: async (args: Static<typeof ManageClassifiersSchema>, env: Env, ctx: ToolContext) => {
-      return await manageClassifiers(args, env, ctx);
-    },
+    description: 'Classifier management. SDK alternative: client.classifiers.',
+    schema: ManageClassifiersSchema,
+    handler: manageClassifiers,
   },
   {
     name: 'manage_view_templates',
-    description:
-      'Legacy internal view-template management tool for REST/session callers. External MCP clients should use execute + client.viewTemplates instead.',
-    inputSchema: ManageViewTemplatesSchema,
-    annotations: { destructiveHint: false },
-    internal: true,
-    handler: async (args: Static<typeof ManageViewTemplatesSchema>, env: Env, ctx: ToolContext) => {
-      return await manageViewTemplates(args, env, ctx);
-    },
+    description: 'View-template management. SDK alternative: client.viewTemplates.',
+    schema: ManageViewTemplatesSchema,
+    handler: manageViewTemplates,
   },
 ];
+
+export const INTERNAL_REST_TOOLS: ToolDefinition[] = ENTRIES.map((entry) => ({
+  name: entry.name,
+  description: entry.description,
+  inputSchema: entry.schema,
+  annotations: entry.annotations ?? WRITE,
+  internal: entry.internal ?? true,
+  handler: entry.handler,
+}));

--- a/packages/owletto-backend/src/tools/execute.ts
+++ b/packages/owletto-backend/src/tools/execute.ts
@@ -8,6 +8,7 @@ import type { Context } from 'hono';
 import { getRequiredAccessLevel, hasRequiredMcpScope, isPublicReadable } from '../auth/tool-access';
 import type { Env } from '../index';
 import { trackMCPToolCall } from '../sentry';
+import { ToolNotRegisteredError } from '../utils/errors';
 import { getConfiguredPublicOrigin } from '../utils/public-origin';
 import { listOrganizations } from './organizations';
 import { getTool, type ToolContext } from './registry';
@@ -80,7 +81,13 @@ export function checkToolAccess(toolName: string, args: unknown, authCtx: AuthCo
   }
 
   const tool = getTool(toolName);
-  if (!tool || (tool.internal && !authCtx.allowInternalTools)) {
+  // Genuinely unregistered → typed error so the REST proxy can fire a Sentry
+  // alert (registry/frontend drift). Internal-tool hidden from MCP → plain
+  // Error to avoid leaking the existence of internal handlers.
+  if (!tool) {
+    throw new ToolNotRegisteredError(toolName);
+  }
+  if (tool.internal && !authCtx.allowInternalTools) {
     throw new Error(`Tool not found: ${toolName}`);
   }
 

--- a/packages/owletto-backend/src/tools/registry.ts
+++ b/packages/owletto-backend/src/tools/registry.ts
@@ -5,10 +5,9 @@
  * Typebox provides compile-time type safety and runtime JSON schema generation.
  */
 
-import type { Static } from '@sinclair/typebox';
 import { getPublicReadableActions, getRequiredAccessLevel } from '../auth/tool-access';
 import type { Env } from '../index';
-import { LEGACY_ADMIN_TOOLS } from './admin';
+import { INTERNAL_REST_TOOLS } from './admin';
 import { QuerySqlSchema, querySql } from './admin/query_sql';
 import { ListOrganizationsSchema } from './organizations';
 import { ResolvePathSchema, resolvePath } from './resolve_path';
@@ -71,6 +70,8 @@ export interface ToolDefinition<T = any> {
   handler: (args: T, env: Env, ctx: ToolContext) => Promise<any>;
 }
 
+const READ_ONLY = { readOnlyHint: true, idempotentHint: true } as const;
+
 const TOOLS: ToolDefinition[] = [
   // ─── Hot-path read/write surface ──────────────────────────────────────────
   {
@@ -78,10 +79,8 @@ const TOOLS: ToolDefinition[] = [
     description:
       'Search the workspace knowledge graph and saved memory for entities and related context. Supports fuzzy matching and filtering by entity_type. Use this as the FIRST step when the user asks about a specific entity. To create or modify entities, use the `execute` tool with a TypeScript script over the `client` SDK.',
     inputSchema: SearchSchema,
-    annotations: { readOnlyHint: true, idempotentHint: true },
-    handler: async (args: Static<typeof SearchSchema>, env: Env, ctx: ToolContext) => {
-      return await search(args, env, ctx);
-    },
+    annotations: READ_ONLY,
+    handler: search,
   },
   {
     name: 'save_knowledge',
@@ -89,19 +88,15 @@ const TOOLS: ToolDefinition[] = [
       "Save knowledge to the workspace, optionally associated with entities via entity_ids. Supports multiple content formats via payload_type: 'text' (default), 'markdown' (rich text), 'json_template' (structured UI with payload_template + payload_data), 'media' (media-focused), 'empty' (metadata only). Metadata is validated against the entity type schema when entities are provided. To update an existing fact, pass supersedes_event_id with the old event ID — the old event is hidden from future searches. Always search first to avoid duplicates.",
     inputSchema: SaveContentSchema,
     annotations: { readOnlyHint: false, destructiveHint: false },
-    handler: async (args: Static<typeof SaveContentSchema>, env: Env, ctx: ToolContext) => {
-      return await saveContent(args, env, ctx);
-    },
+    handler: saveContent,
   },
   {
     name: 'query_sql',
     description:
       'Execute paginated, sortable, searchable read-only SQL queries. Table references are auto-scoped to your organization. Do NOT include ORDER BY/LIMIT/OFFSET or positional parameters in your SQL.',
     inputSchema: QuerySqlSchema,
-    annotations: { readOnlyHint: true, idempotentHint: true },
-    handler: async (args: Static<typeof QuerySqlSchema>, env: Env, ctx: ToolContext) => {
-      return await querySql(args, env, ctx);
-    },
+    annotations: READ_ONLY,
+    handler: querySql,
   },
   // ─── Generic surface: discover + execute over the typed ClientSDK ─────────
   {
@@ -109,10 +104,8 @@ const TOOLS: ToolDefinition[] = [
     description:
       "Discover ClientSDK methods. Pass a namespace ('watchers', 'entities', etc.) for a listing, a dotted path ('watchers.create') for a drill-down with signature/throws/example, or a free-text query for fuzzy matches. Pair with `execute` to actually call methods.",
     inputSchema: SdkSearchSchema,
-    annotations: { readOnlyHint: true, idempotentHint: true },
-    handler: async (args: Static<typeof SdkSearchSchema>, env: Env, ctx: ToolContext) => {
-      return await sdkSearch(args, env, ctx);
-    },
+    annotations: READ_ONLY,
+    handler: sdkSearch,
   },
   {
     name: 'execute',
@@ -122,23 +115,19 @@ const TOOLS: ToolDefinition[] = [
     // The script can delete entities, drop watchers, trigger external operations
     // — host clients should treat it as destructive and require approval.
     annotations: { destructiveHint: true },
-    handler: async (args: Static<typeof ExecuteSchema>, env: Env, ctx: ToolContext) => {
-      return await executeScript(args, env, ctx);
-    },
+    handler: executeScript,
   },
-  // ─── Legacy REST/session-only admin tools ────────────────────────────────
-  ...LEGACY_ADMIN_TOOLS,
+  // ─── REST/session/CLI surface (manage_*, list_watchers, get_watcher, ...) ─
+  ...INTERNAL_REST_TOOLS,
   // ─── Path resolution (frontend internal) ──────────────────────────────────
   {
     name: 'resolve_path',
     description:
       'Resolve a namespace-based URL path like /acme/entity-type/entity-slug into namespace and entity details. Returns template_data with executed data source query results when templates define data_sources.',
     inputSchema: ResolvePathSchema,
-    annotations: { readOnlyHint: true, idempotentHint: true },
+    annotations: READ_ONLY,
     internal: true,
-    handler: async (args: Static<typeof ResolvePathSchema>, env: Env, ctx: ToolContext) => {
-      return await resolvePath(args, env, ctx);
-    },
+    handler: resolvePath,
   },
   // ─── Org discovery (exposed on both unscoped and scoped /mcp endpoints) ───
   {
@@ -146,7 +135,7 @@ const TOOLS: ToolDefinition[] = [
     description:
       'List organizations the authenticated user belongs to, plus any public workspaces the session can read. Use the slug with `client.org(slug)` inside an `execute` script for cross-org reads, or reconnect the MCP client to /mcp/{slug} to pin a different default.',
     inputSchema: ListOrganizationsSchema,
-    annotations: { readOnlyHint: true, idempotentHint: true },
+    annotations: READ_ONLY,
     handler: async () => {
       throw new Error('Handled directly in executeTool');
     },

--- a/packages/owletto-backend/src/utils/errors.ts
+++ b/packages/owletto-backend/src/utils/errors.ts
@@ -17,3 +17,21 @@ export class ToolUserError extends Error {
     this.httpStatus = httpStatus;
   }
 }
+
+/**
+ * Thrown when a tool name reaches `executeTool` but is not registered. Indicates
+ * registry/frontend drift (e.g. frontend `apiCall('foo', …)` references a name
+ * the backend no longer registers) — the kind of regression that produced a
+ * silent prod outage when `list_watchers` was removed without migrating the
+ * frontend. The REST proxy captures this to Sentry so the next drift surfaces
+ * as an alert rather than a 400 the page swallows.
+ */
+export class ToolNotRegisteredError extends Error {
+  readonly toolName: string;
+
+  constructor(toolName: string) {
+    super(`Tool not found: ${toolName}`);
+    this.name = 'ToolNotRegisteredError';
+    this.toolName = toolName;
+  }
+}


### PR DESCRIPTION
## Summary

Hotfix the `Tool not found: list_watchers` error that broke the watchers page in prod. Restores `list_watchers`, `get_watcher`, and `read_knowledge` to the REST/CLI tool surface (still hidden from external MCP `tools/list`), and adds a regression test that catches the same class of drift before it ships again.

## Why it broke

PR #348 deleted these MCP-tool registrations as part of the move to `execute` + `client.<ns>.<method>`. The frontend's `apiCall('list_watchers', …)` in `packages/owletto-web/src/hooks/use-watchers.ts` was never migrated — and `restToolProxy` swallowed the resulting `Tool not found` error as a 400 JSON body, so Sentry never fired. The existing `auth.test.ts` assertion at `expect(toolNames).not.toContain('list_watchers')` codifies the *MCP-surface* removal, which is correct, but no test covers the REST proxy's view of the registry.

## Changes

- **Re-register `list_watchers` / `get_watcher` / `read_knowledge`** as `internal: true` in `INTERNAL_REST_TOOLS` (formerly `LEGACY_ADMIN_TOOLS`). They stay hidden from MCP `tools/list` (which calls `getAllTools({ includeInternalTools: false })`) but `restToolProxy` reaches them because it sets `allowInternalTools=true`.
- **Rename `LEGACY_ADMIN_TOOLS` → `INTERNAL_REST_TOOLS`.** Per the user's framing: the manage_*/list_*/get_* surface isn't legacy, it's the deliberate REST/CLI boundary alongside the smaller MCP boundary.
- **Consolidate the registry boilerplate.** The 12 near-duplicate `ToolDefinition` literals collapse into a compact `ENTRIES` array; handlers are passed directly to `defineTool` instead of via `async (args, env, ctx) => handler(args, env, ctx)` pass-throughs. Same treatment applied to the public `TOOLS` array in `registry.ts`.
- **Surface registry drift to Sentry.** New `ToolNotRegisteredError` thrown from `checkToolAccess` when `getTool()` returns undefined. `restToolProxy` captures it before returning the 400 — internal-tool hiding still throws a plain `Error` so we don't leak handler existence over MCP.
- **Regression test in `tool-access.test.ts`** scans every `apiCall(<…>)('name', …)` call site under `packages/owletto-web/src` and asserts each name is registered. `manage_queue` is in `KNOWN_DEAD_NAMES` (the only caller is the unused `useDeleteWindow` hook); the test will fail if anyone wires it up without registering the backend handler first.

## Verification

- `bun test packages/owletto-backend/src/auth/__tests__/tool-access.test.ts` — 40 pass.
- Sanity-check that the test catches the real bug: removing `list_watchers` from `admin/index.ts` locally produces `Received: ["list_watchers"]` and a red test.
- `bun run typecheck`, `bun run lint`, `bun run format:check` — all green.
- Sandbox suite (`bun test packages/owletto-backend/src/__tests__/unit/sandbox`) — 24 pass.

## Test plan

- [x] Existing tool-access tests still pass.
- [x] New regression test fails when a name is removed from the registry.
- [x] Typecheck + lint + format clean.
- [ ] After merge, watchers page at `https://app.lobu.ai/{slug}/watchers` loads instead of erroring.
- [ ] No new `ToolNotRegisteredError` Sentry alerts in the hour after deploy.