### PR TITLE
fix(watchers): consolidate org watcher list by group; tidy detail header

### DIFF
--- a/packages/owletto-backend/src/tools/admin/manage_watchers.ts
+++ b/packages/owletto-backend/src/tools/admin/manage_watchers.ts
@@ -2073,6 +2073,8 @@ async function handleList(
       i.model_config,
       i.sources,
       i.tags,
+      i.watcher_group_id,
+      i.source_watcher_id,
       wr.id as watcher_run_id,
       wr.status as watcher_run_status,
       wr.error_message as watcher_run_error,


### PR DESCRIPTION
## Summary

Two related fixes for `/$owner/watchers`:

1. **Backend — include `watcher_group_id` (and `source_watcher_id`) in `manage_watchers` list response.** The DB columns exist and the migration backfilled them correctly, but `handleList` was selecting them out of the SELECT clause. Frontend grouping fell back to per-row `watcher_id`, so cloned watchers (e.g. 9 founder activity trackers cloned from one template in venture-capital) showed as 9 separate rows instead of one group with 9 assignments.

2. **UI submodule bump (lobu-ai/owletto-web#45) — version chip inline with the title.** Previously the watcher-group detail header showed `Latest version: v1`, `v1 · 9`, and `9 derived assignments` as a redundant badge row beneath the title. Now `OwnerTabPage` exposes a `setItemAdornment` slot, and the version chip renders next to `<h1>`. Single-version groups get one `v{n}` chip with a tooltip; multi-version groups keep the breakdown + "behind latest" badge. The `derived assignments` badge is dropped (DB lineage detail, not user-facing info).

## Audit

Verified `watcher_group_id` is populated for all watchers across all member orgs (zero nulls). Behavior is unchanged for orgs without clones — they already render 1:1.

Searched for similar dangling-badge patterns elsewhere; none found. `watcher-detail.tsx` has no version chip; `entity-page.tsx` already inlines its badges into the `<h1>` row.

## Test plan

- [ ] `/venture-capital/watchers` — "Founder Activity Tracker" appears as one row with 9 assignments (was 9 separate rows).
- [ ] Click into "Founder Activity Tracker" — single `v1` chip beside the title; tooltip mentions assignment count; no separate badge row.
- [ ] Multi-version group (when one exists) shows breakdown chips + "behind latest" inline beside title.
- [ ] No "Latest version: vN" or "N derived assignments" badges anywhere.