### PR TITLE
feat(owletto-backend): 401 + WWW-Authenticate for unauth /mcp

### DIFF
--- a/packages/owletto-backend/src/__tests__/integration/mcp/auth.test.ts
+++ b/packages/owletto-backend/src/__tests__/integration/mcp/auth.test.ts
@@ -61,7 +61,7 @@ describe('MCP Authentication', () => {
   });
 
   describe('Unauthenticated Requests', () => {
-    it('allows unauthenticated tools/list discovery requests including list_organizations', async () => {
+    it('challenges unauthenticated requests on the unscoped /mcp endpoint with 401 + WWW-Authenticate', async () => {
       const response = await post('/mcp', {
         body: {
           jsonrpc: '2.0',
@@ -71,14 +71,10 @@ describe('MCP Authentication', () => {
         },
       });
 
-      expect(response.status).toBe(200);
-      const body = await response.json();
-      expect(body.error).toBeUndefined();
-      expect(body.result.tools).toBeInstanceOf(Array);
-      expect(body.result.tools.length).toBeGreaterThan(0);
-      const toolNames = body.result.tools.map((t: any) => t.name);
-      expect(toolNames).toContain('list_organizations');
-      expect(toolNames).not.toContain('switch_organization');
+      expect(response.status).toBe(401);
+      expect(response.headers.get('WWW-Authenticate')).toContain(
+        '/.well-known/oauth-protected-resource'
+      );
     });
 
     it('returns an OAuth challenge for anonymous root session stream requests', async () => {

--- a/packages/owletto-backend/src/mcp-handler.ts
+++ b/packages/owletto-backend/src/mcp-handler.ts
@@ -768,10 +768,18 @@ export async function handleMcp(c: Context<{ Bindings: Env }>): Promise<Response
     const initialize = await readInitializeRequest(req);
     const authCtx = await resolveAuthWithInstructions(c, req);
 
-    // Authenticated OAuth/PAT tokens must carry an org binding on the token
-    // itself — `tokenOrganizationId`, not `organizationId`. The latter is
-    // resolved from URL slug on `/mcp/{slug}` and would mask a legacy null-
-    // org token. Sessions/anonymous are unaffected (no token to bind).
+    // Anonymous on the unscoped `/mcp` endpoint has no workspace context —
+    // there's nothing meaningful to serve. Return 401 + WWW-Authenticate so
+    // standards-compliant MCP clients (Claude Desktop, etc.) discover the
+    // OAuth metadata at /.well-known/oauth-protected-resource and trigger the
+    // auth flow. Public workspace browse remains available on /mcp/{slug}.
+    if (!authCtx.isAuthenticated && !authCtx.scopedToOrg) {
+      return buildUnauthorizedResponse(
+        req,
+        'Authentication required for the unscoped /mcp endpoint. OAuth via the resource metadata advertised in WWW-Authenticate, or connect to /mcp/{workspace-slug} for public workspace browse.'
+      );
+    }
+
     if (
       authCtx.isAuthenticated &&
       authCtx.userId &&


### PR DESCRIPTION
## Summary
- Anonymous clients on the unscoped `/mcp` endpoint now get `401 + WWW-Authenticate` pointing at `/.well-known/oauth-protected-resource`, triggering the standard MCP OAuth discovery flow.
- Spec-compliant clients (Claude Desktop, Cursor) now auto-discover the auth requirement instead of caching the publicOnly view as the complete catalog.
- Public workspace browse on `/mcp/{public-slug}` is unchanged — that path has a workspace context and continues to serve the publicOnly view.

## Why
Today the server responds 200 OK with the publicOnly tool list to unauth probes on `/mcp`. Claude Desktop's permissions UI shows only those 6 tools and never triggers OAuth because there's no `WWW-Authenticate` challenge. After this change, the OAuth metadata at `/.well-known/oauth-protected-resource` actually gets used by clients.

## Test plan
- [x] `bun run typecheck` clean
- [x] Sandbox unit tests pass (44/44)
- [x] Updated `auth.test.ts` to assert the new 401 + WWW-Authenticate behavior
- [ ] Post-merge: connect Claude Desktop to `https://lobu.ai/mcp` and verify the OAuth flow triggers, then verify the full 9-tool surface is visible after auth