### PR TITLE
feat!: migrate browser-auth to REST, demote manage_* to internal MCP

### DIFF
--- a/packages/owletto-backend/src/__tests__/integration/mcp/auth.test.ts
+++ b/packages/owletto-backend/src/__tests__/integration/mcp/auth.test.ts
@@ -881,6 +881,8 @@ describe('MCP Authentication', () => {
       // Verify expected tools are present. The legacy `manage_*`,
       // `read_knowledge`, `get_watcher`, `list_watchers` MCP tools are now
       // internal-only and reachable via the SDK from `run` / `query` scripts.
+      // owletto-cli's browser-auth flow now hits the REST proxy, so
+      // `manage_connections` / `manage_auth_profiles` are no longer public-MCP.
       const toolNames = result.tools.map((t: any) => t.name);
       expect(toolNames).toContain('search_knowledge');
       expect(toolNames).toContain('save_knowledge');
@@ -892,10 +894,8 @@ describe('MCP Authentication', () => {
       expect(toolNames).not.toContain('get_watcher');
       expect(toolNames).not.toContain('list_watchers');
       expect(toolNames).not.toContain('manage_entity');
-      // `manage_connections` and `manage_auth_profiles` stay public-MCP for
-      // owletto-cli's browser-auth flow; flip to internal once the CLI migrates.
-      expect(toolNames).toContain('manage_connections');
-      expect(toolNames).toContain('manage_auth_profiles');
+      expect(toolNames).not.toContain('manage_connections');
+      expect(toolNames).not.toContain('manage_auth_profiles');
       expect(toolNames).not.toContain('join_organization');
     });
 

--- a/packages/owletto-backend/src/auth/__tests__/tool-access.test.ts
+++ b/packages/owletto-backend/src/auth/__tests__/tool-access.test.ts
@@ -445,37 +445,37 @@ describe('first-party tool-name coverage', () => {
     assertRegistered(used);
   });
 
-  // CLI tools that flow through MCP RPC (`mcpRpc(url, 'tools/call', { name })`)
-  // — must be registered AND non-internal, since `tools/list` filters out
-  // `internal: true`. Hardcoded rather than regex-derived so a removal from
-  // the CLI source can't silently shrink the assertion set.
-  const CLI_PUBLIC_MCP_TOOLS = ['manage_connections', 'manage_auth_profiles'] as const;
+  // CLI bootstrap tools that the `owletto browser-auth` flow drives via the
+  // REST proxy (`POST /api/{slug}/{toolName}`). They must be registered AND
+  // `internal: true` so they stay off the external MCP surface — no external
+  // MCP client should see CLI bootstrap tools in `tools/list`.
+  const CLI_REST_BOOTSTRAP_TOOLS = ['manage_connections', 'manage_auth_profiles'] as const;
 
-  it.each(CLI_PUBLIC_MCP_TOOLS)(
-    'CLI MCP tool %s is registered and visible on the public MCP surface',
+  it.each(CLI_REST_BOOTSTRAP_TOOLS)(
+    'CLI bootstrap tool %s is registered and hidden from external MCP tools/list',
     (name) => {
       const tool = getTool(name);
       expect(tool).toBeDefined();
-      // `internal: true` would hide the tool from external `tools/list`,
-      // silently breaking `owletto browser-auth`.
-      expect(tool?.internal ?? false).toBe(false);
+      // `internal: true` keeps these tools reachable via the REST proxy
+      // (`allowInternalTools=true` for non-`/mcp` paths) while hiding them
+      // from external MCP clients like Claude Desktop or Cursor.
+      expect(tool?.internal).toBe(true);
     }
   );
 
-  it('CLI browser-auth tools/call literals match the pinned set', () => {
-    // Drift detector: if browser-auth.ts starts calling a new MCP tool, fail
-    // here rather than silently expand the public-MCP surface unannounced.
+  it('CLI browser-auth no longer calls bootstrap tools over MCP RPC', () => {
+    // After the REST migration, browser-auth.ts must use `restToolCall(...)`
+    // for these tools — never `mcpRpc(..., 'tools/call', ...)`. This drift
+    // detector fails the moment someone re-introduces an MCP RPC call site.
     if (!present(cliSrcRoot)) return;
     const browserAuth = join(cliSrcRoot, 'commands', 'browser-auth.ts');
     if (!present(browserAuth)) return;
     const content = readFileSync(browserAuth, 'utf-8');
-    const used = new Set<string>();
-    // Match `mcpRpc(…, 'tools/call', { … name: 'X' … })` across newlines.
-    for (const match of content.matchAll(
-      /'tools\/call'[\s\S]{0,300}?\bname:\s*['"]([a-zA-Z_][a-zA-Z0-9_]*)['"]/g
-    )) {
-      used.add(match[1]);
+    expect(content).not.toMatch(/'tools\/call'/);
+    for (const tool of CLI_REST_BOOTSTRAP_TOOLS) {
+      // The REST helper takes the tool name as the second positional argument.
+      const restPattern = new RegExp(`restToolCall<[^>]*>\\(\\s*\\w+\\s*,\\s*['"]${tool}['"]`);
+      expect(content).toMatch(restPattern);
     }
-    expect([...used].sort()).toEqual([...CLI_PUBLIC_MCP_TOOLS].sort());
   });
 });

--- a/packages/owletto-backend/src/tools/admin/index.ts
+++ b/packages/owletto-backend/src/tools/admin/index.ts
@@ -8,9 +8,6 @@
  * `restToolProxy` sets `allowInternalTools=true` (since the request didn't come
  * in over `/mcp`), so `internal: true` tools are reachable by REST but hidden
  * from MCP `tools/list`.
- *
- * The two non-internal entries (`manage_connections`, `manage_auth_profiles`)
- * stay on the public MCP surface for owletto-cli's `browser-auth` flow.
  */
 
 import type { TSchema } from '@sinclair/typebox';
@@ -42,8 +39,7 @@ interface InternalToolEntry {
   annotations?: ToolAnnotations;
   /**
    * `true` (default) hides from MCP `tools/list` — REST/session callers can
-   * still reach it. `false` keeps it on the public MCP surface (currently
-   * just the two CLI browser-auth tools).
+   * still reach it. `false` keeps it on the public MCP surface.
    */
   internal?: boolean;
 }
@@ -66,11 +62,9 @@ const ENTRIES: InternalToolEntry[] = [
   },
   {
     name: 'manage_connections',
-    description:
-      'Connection management. Kept on the public MCP surface for the owletto-cli browser-auth flow. SDK alternative: client.connections.',
+    description: 'Connection management. SDK alternative: client.connections.',
     schema: ManageConnectionsSchema,
     handler: manageConnections,
-    internal: false,
   },
   {
     name: 'manage_feeds',
@@ -80,11 +74,9 @@ const ENTRIES: InternalToolEntry[] = [
   },
   {
     name: 'manage_auth_profiles',
-    description:
-      'Auth-profile management. Kept on the public MCP surface for the owletto-cli browser-auth flow. SDK alternative: client.authProfiles.',
+    description: 'Auth-profile management. SDK alternative: client.authProfiles.',
     schema: ManageAuthProfilesSchema,
     handler: manageAuthProfiles,
-    internal: false,
   },
   {
     name: 'manage_operations',

--- a/packages/owletto-cli/src/commands/browser-auth.ts
+++ b/packages/owletto-cli/src/commands/browser-auth.ts
@@ -374,15 +374,6 @@ async function extractCookiesCDP(
   }
 }
 
-function parseToolJson(text: string): any {
-  if (!text.trim()) return {};
-  const normalized = text
-    .trim()
-    .replace(/^```json\s*/, '')
-    .replace(/\s*```$/, '');
-  return JSON.parse(normalized);
-}
-
 function scoreAuthCookie(cookie: BrowserCookie): number {
   const name = cookie.name?.toLowerCase() ?? '';
   if (!name) return Number.NEGATIVE_INFINITY;
@@ -415,20 +406,17 @@ async function resolveConnectorDomains(
     return domainsOverride.split(',').map((d) => d.trim());
   }
 
-  const { resolveMcpEndpoint, mcpRpc } = await import('./mcp.ts');
+  const { resolveMcpEndpoint, restToolCall } = await import('./mcp.ts');
   const mcpUrl = resolveMcpEndpoint(cliProfile.config);
   if (!mcpUrl) {
     printText('No MCP URL configured. Use --domains to specify cookie domains manually.');
     return null;
   }
 
-  const result = (await mcpRpc(mcpUrl, 'tools/call', {
-    name: 'manage_connections',
-    arguments: { action: 'list_connector_definitions' },
-  })) as any;
+  const parsed = await restToolCall<any>(mcpUrl, 'manage_connections', {
+    action: 'list_connector_definitions',
+  });
 
-  const text = result?.content?.[0]?.text ?? '';
-  const parsed = parseToolJson(text);
   const connectors: any[] = Array.isArray(parsed)
     ? parsed
     : (parsed?.connector_definitions ?? parsed?.connectors ?? []);
@@ -505,7 +493,7 @@ const browserAuth = defineCommand({
         process.exitCode = 1;
         return;
       }
-      const { resolveMcpEndpoint, mcpRpc } = await import('./mcp.ts');
+      const { resolveMcpEndpoint, restToolCall } = await import('./mcp.ts');
       const mcpUrl = resolveMcpEndpoint(cliProfile.config);
       if (!mcpUrl) {
         printText('No MCP URL configured.');
@@ -513,13 +501,17 @@ const browserAuth = defineCommand({
         return;
       }
 
-      const result = (await mcpRpc(mcpUrl, 'tools/call', {
-        name: 'manage_auth_profiles',
-        arguments: { action: 'test_auth_profile', auth_profile_slug: args.authProfileSlug },
-      })) as any;
-
-      const text = result?.content?.[0]?.text ?? '';
-      const parsed = parseToolJson(text);
+      let parsed: any;
+      try {
+        parsed = await restToolCall<any>(mcpUrl, 'manage_auth_profiles', {
+          action: 'test_auth_profile',
+          auth_profile_slug: args.authProfileSlug,
+        });
+      } catch (err) {
+        printText(`Error: ${err instanceof Error ? err.message : String(err)}`);
+        process.exitCode = 1;
+        return;
+      }
       if (parsed?.error) {
         printText(`Error: ${parsed.error}`);
         process.exitCode = 1;
@@ -612,15 +604,14 @@ const browserAuth = defineCommand({
       }
 
       if (args.authProfileSlug) {
-        const { resolveMcpEndpoint, mcpRpc } = await import('./mcp.ts');
+        const { resolveMcpEndpoint, restToolCall } = await import('./mcp.ts');
         const mcpUrl = resolveMcpEndpoint(cliProfile.config);
 
         if (!mcpUrl) {
           printText('No MCP URL configured. Store the CDP URL on the auth profile manually.');
         } else {
-          const result = (await mcpRpc(mcpUrl, 'tools/call', {
-            name: 'manage_auth_profiles',
-            arguments: {
+          try {
+            const parsed = await restToolCall<any>(mcpUrl, 'manage_auth_profiles', {
               action: 'update_auth_profile',
               auth_profile_slug: args.authProfileSlug,
               auth_data: {
@@ -630,17 +621,18 @@ const browserAuth = defineCommand({
                 browser_profile: profileName,
                 user_data_dir: userDataDir,
               },
-            },
-          })) as any;
-
-          const responseText = result?.content?.[0]?.text ?? '';
-          const parsed = parseToolJson(responseText);
-          if (parsed?.error) {
-            printText(`Error: ${parsed.error}`);
+            });
+            if (parsed?.error) {
+              printText(`Error: ${parsed.error}`);
+              process.exitCode = 1;
+              return;
+            }
+            printText(`CDP URL stored on auth profile ${args.authProfileSlug}.`);
+          } catch (err) {
+            printText(`Error: ${err instanceof Error ? err.message : String(err)}`);
             process.exitCode = 1;
             return;
           }
-          printText(`CDP URL stored on auth profile ${args.authProfileSlug}.`);
         }
       }
 
@@ -729,15 +721,14 @@ const browserAuth = defineCommand({
     if (args.authProfileSlug) {
       printText('Saving cookies to auth profile...');
 
-      const { resolveMcpEndpoint, mcpRpc } = await import('./mcp.ts');
+      const { resolveMcpEndpoint, restToolCall } = await import('./mcp.ts');
       const mcpUrl = resolveMcpEndpoint(cliProfile.config);
 
       if (!mcpUrl) {
         printText('No MCP URL configured. Store cookies manually.');
       } else {
-        const result = (await mcpRpc(mcpUrl, 'tools/call', {
-          name: 'manage_auth_profiles',
-          arguments: {
+        try {
+          const parsed = await restToolCall<any>(mcpUrl, 'manage_auth_profiles', {
             action: 'update_auth_profile',
             auth_profile_slug: args.authProfileSlug,
             auth_data: {
@@ -746,15 +737,14 @@ const browserAuth = defineCommand({
               captured_via: 'cli',
               browser_profile: selectedProfile.name,
             },
-          },
-        })) as any;
-
-        const responseText = result?.content?.[0]?.text ?? '';
-        const parsed = parseToolJson(responseText);
-        if (parsed?.error) {
-          printText(`Error: ${parsed.error}`);
-        } else {
-          printText(`Cookies stored on auth profile ${args.authProfileSlug}.`);
+          });
+          if (parsed?.error) {
+            printText(`Error: ${parsed.error}`);
+          } else {
+            printText(`Cookies stored on auth profile ${args.authProfileSlug}.`);
+          }
+        } catch (err) {
+          printText(`Error: ${err instanceof Error ? err.message : String(err)}`);
         }
       }
     } else {

--- a/packages/owletto-cli/src/commands/mcp.ts
+++ b/packages/owletto-cli/src/commands/mcp.ts
@@ -1,5 +1,5 @@
 import { ApiError } from '../lib/errors.ts';
-import { getUsableToken, resolveServerUrl } from '../lib/openclaw-auth.ts';
+import { getUsableToken, orgFromMcpUrl, resolveServerUrl } from '../lib/openclaw-auth.ts';
 
 const JSON_MCP_ACCEPT = 'application/json';
 
@@ -181,4 +181,58 @@ export async function mcpRpc(mcpUrl: string, method: string, params?: Record<str
   }
 
   return data.result;
+}
+
+/**
+ * Call an Owletto tool over the REST proxy at `POST /api/{orgSlug}/{toolName}`.
+ *
+ * Reuses the same auth resolution and localhost/docker-host fallback as
+ * `mcpRpc`. Returns the raw handler result as parsed JSON (no MCP envelope).
+ * Throws `ApiError` on non-2xx, surfacing the server's `{ error }` message
+ * when present.
+ */
+export async function restToolCall<T = unknown>(
+  mcpUrl: string,
+  toolName: string,
+  args: Record<string, unknown>
+): Promise<T> {
+  const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+  const tokenResult = await getUsableToken(mcpUrl);
+  if (tokenResult) {
+    headers.Authorization = `Bearer ${tokenResult.token}`;
+  }
+
+  // Prefer the org slug pinned in the URL (`/mcp/{slug}`). Fall back to the
+  // session's bound org so callers using a bare `/mcp` URL still resolve.
+  const orgSlug = orgFromMcpUrl(mcpUrl) ?? tokenResult?.session.org ?? null;
+  if (!orgSlug) {
+    throw new ApiError(
+      `Cannot call ${toolName}: no org slug on MCP URL ${mcpUrl} or active session. Reconnect with: owletto login <server>/mcp/<org>`
+    );
+  }
+
+  const baseUrl = new URL(mcpUrl).origin;
+  const endpoint = `${baseUrl}/api/${orgSlug}/${toolName}`;
+
+  const { response: res, usedUrl } = await fetchMcpWithFallback(endpoint, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify(args),
+  });
+
+  const raw = await res.text();
+  if (!res.ok) {
+    let message = `${res.status} ${res.statusText}`;
+    if (raw) {
+      try {
+        const body = JSON.parse(raw) as { error?: string };
+        if (body?.error) message = body.error;
+      } catch {
+        message = raw;
+      }
+    }
+    throw new ApiError(`${toolName} failed via ${usedUrl}: ${message}`, res.status);
+  }
+
+  return (raw.length > 0 ? JSON.parse(raw) : {}) as T;
 }


### PR DESCRIPTION
## Summary

- Migrates `owletto-cli`'s `browser-auth` flow off MCP `tools/call` onto the existing REST proxy at `POST /api/{orgSlug}/{toolName}`.
- Demotes `manage_connections` and `manage_auth_profiles` to `internal: true` on the MCP surface — external MCP clients (Claude Desktop, Cursor, etc.) now see **7 public tools** instead of 9. CLI bootstrap tools no longer leak.
- Adds a single `restToolCall` helper in `packages/owletto-cli/src/commands/mcp.ts` that reuses the same auth/token resolution and localhost/docker-host fallback as `mcpRpc`, with a fallback to the session-bound org when the MCP URL is a bare `/mcp` (no `/{slug}` suffix). All five call sites in `browser-auth.ts` collapse onto it; `parseToolJson` is gone.

## Why

Minimum-surface principle: external MCP clients shouldn't see CLI bootstrap tools (`manage_connections.list_connector_definitions`, `manage_auth_profiles.update_auth_profile`, etc.). The REST proxy was already the right place for these calls — the CLI just hadn't migrated yet.

## Reuse

- One new helper (`restToolCall`) covers all five sites — no inline `fetch` boilerplate at call sites.
- Localhost / `host.docker.internal` fallback comes for free via the existing `fetchMcpWithFallback`.
- Drift detector in `packages/owletto-backend/src/auth/__tests__/tool-access.test.ts` is now inverted: it asserts these tools are `internal: true` AND that `browser-auth.ts` uses `restToolCall(...)` (no more `tools/call`).
- Stale comment block in `packages/owletto-backend/src/tools/admin/index.ts` describing the "two non-internal entries" is gone.

## Breaking change

External MCP clients calling `manage_connections` or `manage_auth_profiles` directly via MCP will receive `Tool not found`. No known external callers — the only first-party caller was the CLI itself, which is migrated in this PR. The `!` in the title signals release-please.

## Test plan

- [x] `bun run typecheck` clean
- [x] `make build-packages` clean
- [x] `bun test packages/owletto-backend/src/auth/__tests__/tool-access.test.ts` — 47/47 pass (drift detector + new REST assertions)
- [x] `cd packages/owletto-backend && bun test src/__tests__/unit/` — 106 pass, 1 pre-existing unrelated failure (`whatsapp.test.ts` import — fails on `main` too)
- [ ] Manual smoke against staging: `owletto browser-auth --connector x --check --authProfileSlug <slug>` and `owletto browser-auth --connector x --launchCdp --authProfileSlug <slug>` — pending operator verification

## Known follow-ups (not blockers)

- `packages/owletto-backend/src/__tests__/integration/entities/manage-connections-feeds.test.ts:81-83` was already broken before this PR (asserts `manage_feeds` in public `tools/list` even though it's been internal since #432). Unchanged here — fix in a follow-up alongside the broader integration-test cleanup tracked in the test-helpers comment.
- pi review skipped after one round: pi credit ran out before round 2 could complete (round 1 caught the bare-`/mcp`-URL regression and the stale drift-detector test, both fixed in this commit).

Predecessor: #432.