### PR TITLE
chore(owletto): post-rest-migration follow-ups

### DIFF
--- a/packages/owletto-backend/src/__tests__/integration/entities/manage-connections-feeds.test.ts
+++ b/packages/owletto-backend/src/__tests__/integration/entities/manage-connections-feeds.test.ts
@@ -1,7 +1,15 @@
 /**
  * Manage Feeds Lifecycle Integration Tests
  *
- * Verifies feed CRUD/trigger behavior via the manage_feeds tool.
+ * Verifies feed CRUD/trigger behavior via the REST proxy at
+ * `POST /api/{orgSlug}/manage_feeds`. The MCP `manage_feeds` tool was demoted
+ * to `internal: true` in PR #432, so it's no longer reachable via MCP
+ * `tools/call`; the REST proxy is now the canonical surface for these
+ * actions and is what owletto-cli + owletto-web both call.
+ *
+ * MCP `tools/list` visibility for the demoted `manage_*` family is asserted
+ * in `integration/mcp/auth.test.ts > tools/list Response` — this file is
+ * exclusively about feed-action behavior.
  */
 
 import { beforeAll, describe, expect, it } from 'vitest';
@@ -17,9 +25,34 @@ import {
   createTestUser,
   seedSystemEntityTypes,
 } from '../../setup/test-fixtures';
-import { mcpListTools, mcpToolsCall } from '../../setup/test-helpers';
+import { post } from '../../setup/test-helpers';
 
-describe('Manage Feeds - Feed Actions', () => {
+/**
+ * Call `manage_feeds` over the REST proxy and parse the JSON body. Mirrors
+ * how owletto-cli's `restToolCall` invokes it (POST raw JSON, Authorization
+ * Bearer token, no MCP envelope).
+ */
+async function callManageFeeds<T = any>(
+  orgSlug: string,
+  args: Record<string, unknown>,
+  token: string
+): Promise<T> {
+  const response = await post(`/api/${orgSlug}/manage_feeds`, {
+    body: args,
+    token,
+  });
+  const body = (await response.json()) as T;
+  if (response.status >= 400) {
+    // Surface the full response so test failures show what the server rejected
+    // instead of a downstream "Cannot read property X of undefined".
+    throw new Error(
+      `manage_feeds REST call failed (${response.status}): ${JSON.stringify(body)}`
+    );
+  }
+  return body;
+}
+
+describe('Manage Feeds - Feed Actions (REST proxy)', () => {
   let tokenA: string;
   let tokenB: string;
   let orgA: Awaited<ReturnType<typeof createTestOrganization>>;
@@ -42,8 +75,17 @@ describe('Manage Feeds - Feed Actions', () => {
     await addUserToOrganization(userB.id, orgB.id, 'owner');
 
     const client = await createTestOAuthClient();
-    tokenA = (await createTestAccessToken(userA.id, orgA.id, client.client_id)).token;
-    tokenB = (await createTestAccessToken(userB.id, orgB.id, client.client_id)).token;
+    // manage_feeds requires admin scope; default scopes are read/write only.
+    tokenA = (
+      await createTestAccessToken(userA.id, orgA.id, client.client_id, {
+        scope: 'mcp:read mcp:write mcp:admin',
+      })
+    ).token;
+    tokenB = (
+      await createTestAccessToken(userB.id, orgB.id, client.client_id, {
+        scope: 'mcp:read mcp:write mcp:admin',
+      })
+    ).token;
 
     await createTestConnectorDefinition({
       key: 'test.feed.connector',
@@ -74,18 +116,9 @@ describe('Manage Feeds - Feed Actions', () => {
     });
   });
 
-  it('exposes manage_feeds and manage_auth_profiles as separate tools', async () => {
-    const list = await mcpListTools({ token: tokenA });
-    const names = list.tools.map((tool) => tool.name);
-
-    expect(names).toContain('manage_connections');
-    expect(names).toContain('manage_feeds');
-    expect(names).toContain('manage_auth_profiles');
-  });
-
   it('supports create/list/update/get/trigger feed lifecycle', async () => {
-    const created = await mcpToolsCall<any>(
-      'manage_feeds',
+    const created = await callManageFeeds<any>(
+      orgA.slug,
       {
         action: 'create_feed',
         connection_id: connectionA.id,
@@ -93,7 +126,7 @@ describe('Manage Feeds - Feed Actions', () => {
         entity_ids: [entityA.id],
         config: { language: 'en' },
       },
-      { token: tokenA }
+      tokenA
     );
 
     expect(created.action).toBe('create_feed');
@@ -103,21 +136,21 @@ describe('Manage Feeds - Feed Actions', () => {
 
     const feedId = Number(created.feed.id);
 
-    const listed = await mcpToolsCall<any>(
-      'manage_feeds',
+    const listed = await callManageFeeds<any>(
+      orgA.slug,
       {
         action: 'list_feeds',
         connection_id: connectionA.id,
       },
-      { token: tokenA }
+      tokenA
     );
 
     expect(listed.action).toBe('list_feeds');
     expect(Array.isArray(listed.feeds)).toBe(true);
     expect(listed.feeds.some((f: any) => Number(f.id) === feedId)).toBe(true);
 
-    const updated = await mcpToolsCall<any>(
-      'manage_feeds',
+    const updated = await callManageFeeds<any>(
+      orgA.slug,
       {
         action: 'update_feed',
         feed_id: feedId,
@@ -125,20 +158,20 @@ describe('Manage Feeds - Feed Actions', () => {
         schedule: '* * * * *',
         config: { language: 'tr' },
       },
-      { token: tokenA }
+      tokenA
     );
 
     expect(updated.action).toBe('update_feed');
     expect(updated.feed.schedule).toBe('* * * * *');
     expect(updated.feed.config).toBeDefined();
 
-    const triggered = await mcpToolsCall<any>(
-      'manage_feeds',
+    const triggered = await callManageFeeds<any>(
+      orgA.slug,
       {
         action: 'trigger_feed',
         feed_id: feedId,
       },
-      { token: tokenA }
+      tokenA
     );
 
     expect(triggered.action).toBe('trigger_feed');
@@ -146,25 +179,25 @@ describe('Manage Feeds - Feed Actions', () => {
     expect(Number(triggered.feed_id)).toBe(feedId);
     expect(typeof triggered.run_id).toBe('number');
 
-    const duplicateTrigger = await mcpToolsCall<any>(
-      'manage_feeds',
+    const duplicateTrigger = await callManageFeeds<any>(
+      orgA.slug,
       {
         action: 'trigger_feed',
         feed_id: feedId,
       },
-      { token: tokenA }
+      tokenA
     );
 
     expect(duplicateTrigger.action).toBe('trigger_feed');
     expect(duplicateTrigger.message).toContain('already pending or running');
 
-    const fetched = await mcpToolsCall<any>(
-      'manage_feeds',
+    const fetched = await callManageFeeds<any>(
+      orgA.slug,
       {
         action: 'get_feed',
         feed_id: feedId,
       },
-      { token: tokenA }
+      tokenA
     );
 
     expect(fetched.action).toBe('get_feed');
@@ -174,55 +207,55 @@ describe('Manage Feeds - Feed Actions', () => {
   });
 
   it('enforces organization scoping for feed actions', async () => {
-    const createdA = await mcpToolsCall<any>(
-      'manage_feeds',
+    const createdA = await callManageFeeds<any>(
+      orgA.slug,
       {
         action: 'create_feed',
         connection_id: connectionA.id,
         feed_key: 'mentions',
       },
-      { token: tokenA }
+      tokenA
     );
 
-    const createdB = await mcpToolsCall<any>(
-      'manage_feeds',
+    const createdB = await callManageFeeds<any>(
+      orgB.slug,
       {
         action: 'create_feed',
         connection_id: connectionB.id,
         feed_key: 'threads',
       },
-      { token: tokenB }
+      tokenB
     );
 
-    const listA = await mcpToolsCall<any>(
-      'manage_feeds',
+    const listA = await callManageFeeds<any>(
+      orgA.slug,
       {
         action: 'list_feeds',
       },
-      { token: tokenA }
+      tokenA
     );
 
     const idsA = new Set(listA.feeds.map((f: any) => Number(f.id)));
     expect(idsA.has(Number(createdA.feed.id))).toBe(true);
     expect(idsA.has(Number(createdB.feed.id))).toBe(false);
 
-    const getCrossOrg = await mcpToolsCall<any>(
-      'manage_feeds',
+    const getCrossOrg = await callManageFeeds<any>(
+      orgA.slug,
       {
         action: 'get_feed',
         feed_id: Number(createdB.feed.id),
       },
-      { token: tokenA }
+      tokenA
     );
     expect(getCrossOrg.error).toBe('Feed not found');
 
-    const triggerCrossOrg = await mcpToolsCall<any>(
-      'manage_feeds',
+    const triggerCrossOrg = await callManageFeeds<any>(
+      orgA.slug,
       {
         action: 'trigger_feed',
         feed_id: Number(createdB.feed.id),
       },
-      { token: tokenA }
+      tokenA
     );
     expect(triggerCrossOrg.error).toBe('Feed not found');
   });
@@ -230,29 +263,21 @@ describe('Manage Feeds - Feed Actions', () => {
   it('prevents duplicate active sync runs under concurrent trigger_feed calls', async () => {
     const sql = getTestDb();
 
-    const created = await mcpToolsCall<any>(
-      'manage_feeds',
+    const created = await callManageFeeds<any>(
+      orgA.slug,
       {
         action: 'create_feed',
         connection_id: connectionA.id,
         feed_key: 'mentions',
       },
-      { token: tokenA }
+      tokenA
     );
 
     const feedId = Number(created.feed.id);
 
     const [a, b] = await Promise.all([
-      mcpToolsCall<any>(
-        'manage_feeds',
-        { action: 'trigger_feed', feed_id: feedId },
-        { token: tokenA }
-      ),
-      mcpToolsCall<any>(
-        'manage_feeds',
-        { action: 'trigger_feed', feed_id: feedId },
-        { token: tokenA }
-      ),
+      callManageFeeds<any>(orgA.slug, { action: 'trigger_feed', feed_id: feedId }, tokenA),
+      callManageFeeds<any>(orgA.slug, { action: 'trigger_feed', feed_id: feedId }, tokenA),
     ]);
 
     const triggeredCount = [a, b].filter((result) => result.triggered === true).length;

--- a/packages/owletto-backend/src/__tests__/integration/mcp/auth.test.ts
+++ b/packages/owletto-backend/src/__tests__/integration/mcp/auth.test.ts
@@ -895,6 +895,7 @@ describe('MCP Authentication', () => {
       expect(toolNames).not.toContain('list_watchers');
       expect(toolNames).not.toContain('manage_entity');
       expect(toolNames).not.toContain('manage_connections');
+      expect(toolNames).not.toContain('manage_feeds');
       expect(toolNames).not.toContain('manage_auth_profiles');
       expect(toolNames).not.toContain('join_organization');
     });

--- a/packages/owletto-cli/package.json
+++ b/packages/owletto-cli/package.json
@@ -19,6 +19,7 @@
     "clean": "rm -rf dist runtime",
     "dev": "tsx src/bin.ts",
     "runtime:prepare": "node ./scripts/prepare-runtime.mjs",
+    "test:smoke": "SMOKE=1 bun test src/__tests__/smoke",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {

--- a/packages/owletto-cli/src/__tests__/smoke/rest-tool-call.smoke.test.ts
+++ b/packages/owletto-cli/src/__tests__/smoke/rest-tool-call.smoke.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Smoke test for `restToolCall` against a deployed Owletto backend.
+ *
+ * Exercises the same code path as `browser-auth.ts`: auth resolution from the
+ * `~/.owletto/openclaw-auth.json` store (with refresh-on-expiry), URL
+ * construction (`/api/{orgSlug}/{toolName}`), POST body shape, and JSON
+ * response parsing — for the two `manage_*` tools that PR #439 demoted to
+ * `internal: true` and migrated off MCP `tools/call`.
+ *
+ * ## Running
+ *
+ * Skipped by default to keep CI green and local `bun test` fast. Opt in:
+ *
+ *     bun run test:smoke
+ *     # or, directly:
+ *     SMOKE=1 bun test src/__tests__/smoke/rest-tool-call.smoke.test.ts
+ *
+ * ## Required state
+ *
+ * - A logged-in CLI session at `~/.owletto/openclaw-auth.json` for the target
+ *   MCP URL (default `https://app.lobu.ai/mcp/commercial-lender-demo`). Run
+ *   `owletto login https://app.lobu.ai/mcp/<org>` once if missing.
+ *
+ * ## Optional env vars
+ *
+ * - `SMOKE_MCP_URL` — override the MCP URL (default
+ *   `https://app.lobu.ai/mcp/commercial-lender-demo`). The host must already
+ *   have a session in the auth store.
+ *
+ * ## What we assert
+ *
+ * 1. `manage_connections` `list_connector_definitions` returns
+ *    `{ action: 'list_connector_definitions', connector_definitions: [...] }`
+ *    (not a 401, not an HTML error page, not the legacy MCP envelope).
+ * 2. `manage_auth_profiles` `list_auth_profiles` returns
+ *    `{ action: 'list_auth_profiles', auth_profiles: [...] }`.
+ *
+ * If either tool resurfaces on the public MCP `tools/list` accidentally, REST
+ * still works — that's a different drift detector (see
+ * `packages/owletto-backend/src/auth/__tests__/tool-access.test.ts`).
+ */
+
+import { describe, expect, test } from 'bun:test';
+import { restToolCall } from '../../commands/mcp.ts';
+
+const SMOKE_ENABLED = process.env.SMOKE === '1';
+const MCP_URL = process.env.SMOKE_MCP_URL ?? 'https://app.lobu.ai/mcp/commercial-lender-demo';
+
+const describeSmoke = SMOKE_ENABLED ? describe : describe.skip;
+
+describeSmoke('restToolCall against deployed backend', () => {
+  test('list_connector_definitions returns a JSON array (not 401, not HTML)', async () => {
+    const result = await restToolCall<{
+      action?: string;
+      connector_definitions?: unknown[];
+      error?: string;
+    }>(MCP_URL, 'manage_connections', { action: 'list_connector_definitions' });
+
+    if (result.error) {
+      throw new Error(`manage_connections returned error: ${result.error}`);
+    }
+
+    expect(result.action).toBe('list_connector_definitions');
+    expect(Array.isArray(result.connector_definitions)).toBe(true);
+  });
+
+  test('list_auth_profiles returns a JSON array (not 401, not HTML)', async () => {
+    const result = await restToolCall<{
+      action?: string;
+      auth_profiles?: unknown[];
+      error?: string;
+    }>(MCP_URL, 'manage_auth_profiles', { action: 'list_auth_profiles' });
+
+    if (result.error) {
+      throw new Error(`manage_auth_profiles returned error: ${result.error}`);
+    }
+
+    expect(result.action).toBe('list_auth_profiles');
+    expect(Array.isArray(result.auth_profiles)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Two follow-ups to **PR #439** (browser-auth REST migration + `manage_*` demotion to internal MCP). Predecessors: #432 (manage_feeds demotion), #439 (manage_connections/manage_auth_profiles demotion + `restToolCall` helper).

### 1. Fix the stale integration test (`manage-connections-feeds.test.ts`)

This test had been broken since PR #432 demoted `manage_feeds` to `internal: true` — every `mcpToolsCall('manage_feeds', ...)` was returning `Tool not found`. PR #439 made it doubly stale by demoting the other two `manage_*` tools.

- **Drop** the redundant `tools/list` visibility assertion (already covered in `integration/mcp/auth.test.ts > tools/list Response`).
- **Migrate** the lifecycle / org-scoping / concurrent-trigger tests to the REST proxy at `POST /api/{orgSlug}/manage_feeds` — the canonical surface those tools now live on (same path `owletto-cli` and `owletto-web` both call).
- **Extend** the canonical `tools/list` assertion in `auth.test.ts` to also pin `manage_feeds` as absent (it was missed when PR #432 landed).
- **Add `mcp:admin` scope** to the test tokens since feed mutations are admin-gated; the previous tests passed via MCP without it because `mcpToolsCall` was failing access-check at the `Tool not found` step before the scope check.

Verified passing against real Postgres 17 (3/3 tests). The pre-existing CI note that the broader vitest integration suite is "stale after the manage_* → execute/search MCP consolidation" still applies — this is one file unstuck, not the whole suite.

### 2. Smoke test the new `restToolCall` path against the deployed backend (Option A)

Adds `packages/owletto-cli/src/__tests__/smoke/rest-tool-call.smoke.test.ts` and a `bun run test:smoke` script. Exercises the same shared mechanics that `browser-auth.ts` relies on:

- Auth-store token resolution + refresh via `getUsableToken` (`~/.owletto/openclaw-auth.json`).
- `/mcp/{org}` → `/api/{org}/{toolName}` URL construction.
- Raw JSON POST body, raw JSON response parsing (no MCP envelope).

Calls run against `https://app.lobu.ai/mcp/commercial-lender-demo`:
- `manage_connections` → `list_connector_definitions`
- `manage_auth_profiles` → `list_auth_profiles`

Asserts response shape (`action` field + array payload), not a 401 / HTML error page / legacy MCP envelope.

**Skipped unless `SMOKE=1`** so CI and local `bun test` stay fast. Run via `bun run test:smoke` (or `SMOKE=1 bun test src/__tests__/smoke/...`). Confirmed passing live: `2 pass / 0 fail` against `app.lobu.ai`.

## pi verdict

**"I would merge."** Both checks signed off:

- (a) The integration-test fix asserts the actually-true post-#432/#439 contract — REST surface, `mcp:admin` for mutations, `internal: true` excludes from MCP. Not papering over a real gap.
- (b) The smoke test exercises `restToolCall`'s key shared mechanics with `browser-auth.ts`: auth-store token resolution, URL construction, raw JSON POST + parsing.

Pi flagged two minor nits, both addressed in the same diff: (1) added the missing `manage_feeds` absence assertion in `auth.test.ts` so the tests stay self-consistent with the comment in the migrated file; (2) updated the smoke-test docstring to point users at `bun run test:smoke`.

## Test plan

- [x] `bun run typecheck` clean
- [x] `make build-packages` clean
- [x] `bun run lint` + `bun run format:check` clean
- [x] `cd packages/owletto-backend && bun test src/__tests__/unit/` — same pass/fail as main (1 pre-existing failure in `whatsapp.test.ts`, unrelated)
- [x] `cd packages/owletto-backend && bun test src/auth/__tests__/tool-access.test.ts` — 47/47 pass
- [x] Migrated test passes against real Postgres: `cd packages/owletto-backend && DATABASE_URL=... bunx vitest run src/__tests__/integration/entities/manage-connections-feeds.test.ts` → 3/3 pass
- [x] Smoke test passes live: `bun run test:smoke` (in `packages/owletto-cli`) → 2/2 pass against `app.lobu.ai`
- [x] Smoke test skips when unset: `bun test` in `packages/owletto-cli` → 2 skipped