### PR TITLE
ci: harden typecheck + 70% coverage gate; fix owletto-backend tsc bug

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -209,8 +209,20 @@ jobs:
       - name: Run TypeScript type check
         run: bun run typecheck
 
-      - name: Type check owletto-backend (excluded from root tsconfig)
-        run: cd packages/owletto-backend && bunx tsc --noEmit
+      - name: Type check packages excluded from root tsconfig
+        # Root tsconfig excludes these packages, so `bun run typecheck`
+        # above never sees them. Run each package's own tsc here so a
+        # type error can't reach main and break docker builds at deploy
+        # time. owletto-connectors and landing are intentionally left
+        # out — they need preconditions (DOM lib, `astro sync`) that
+        # belong to their own build pipelines.
+        run: |
+          set -euo pipefail
+          for pkg in owletto-backend owletto-cli owletto-worker owletto-sdk owletto-openclaw owletto-embeddings owletto-extension cli; do
+            echo "::group::typecheck $pkg"
+            (cd "packages/$pkg" && bunx tsc --noEmit)
+            echo "::endgroup::"
+          done
 
   migrations:
     # Catches the class of bug that has now broken prod twice in one

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -209,6 +209,9 @@ jobs:
       - name: Run TypeScript type check
         run: bun run typecheck
 
+      - name: Type check owletto-backend (excluded from root tsconfig)
+        run: cd packages/owletto-backend && bunx tsc --noEmit
+
   migrations:
     # Catches the class of bug that has now broken prod twice in one
     # session: a migration file that's syntactically a SQL file but that

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -203,8 +203,8 @@ jobs:
       - name: Install dependencies
         run: bun install
 
-      - name: Build core package first
-        run: cd packages/core && bun run build
+      - name: Build workspace packages (needed for downstream tsc resolution)
+        run: make build-packages
 
       - name: Run TypeScript type check
         run: bun run typecheck

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,25 @@
+coverage:
+  status:
+    project:
+      default:
+        target: 70%
+        threshold: 1%
+    patch:
+      default:
+        target: 70%
+        threshold: 1%
+
+comment:
+  layout: "reach, diff, files"
+  behavior: default
+  require_changes: false
+
+ignore:
+  - "**/__tests__/**"
+  - "**/__mocks__/**"
+  - "**/*.test.ts"
+  - "**/*.spec.ts"
+  - "**/dist/**"
+  - "**/node_modules/**"
+  - "scripts/**"
+  - "docs/**"

--- a/packages/owletto-backend/src/tools/delete_content.ts
+++ b/packages/owletto-backend/src/tools/delete_content.ts
@@ -77,7 +77,7 @@ export async function deleteContent(
 
   const sql = getDb();
 
-  const inOrg = await sql<{ id: number }[]>`
+  const inOrg = await sql<{ id: number }>`
     SELECT id FROM events
     WHERE id = ANY(${pgBigintArray(requested)}::bigint[])
       AND organization_id = ${ctx.organizationId}
@@ -88,7 +88,7 @@ export async function deleteContent(
   const candidateIds = [...inOrgIds];
   const alreadySupersededRows =
     candidateIds.length > 0
-      ? await sql<{ supersedes_event_id: number }[]>`
+      ? await sql<{ supersedes_event_id: number }>`
         SELECT supersedes_event_id FROM events
         WHERE supersedes_event_id = ANY(${pgBigintArray(candidateIds)}::bigint[])
       `


### PR DESCRIPTION
## Summary
Closes the deploy-time-only TS gap that caused \`Build and Push Images / build-app\` to fail on b067a944, and tightens up CI/coverage at the same time.

### 1. Fix the actual bug
\`packages/owletto-backend/src/tools/delete_content.ts\` declared \`sql<{ id: number }[]>\` instead of \`sql<{ id: number }>\`. postgres.js's tagged-template generic is the **row** type, so the result became \`{id:number}[][]\` and \`row.id\` did not type-check. Other call sites in the package use the row-only shape.

### 2. Plug the structural gap
The root \`tsconfig.json\` excludes a wide set of packages, so \`bun run typecheck\` (the CI step that gates PRs) never sees them. The owletto-backend bug only surfaced inside the dockerfile at deploy time. CI now loops \`bunx tsc --noEmit\` over the 8 packages that pass clean today:

- owletto-backend, owletto-cli, owletto-worker, owletto-sdk, owletto-openclaw, owletto-embeddings, owletto-extension, cli

Skipped (pre-existing errors, separate concerns):
- \`owletto-connectors\` — uses Playwright \`page.evaluate(() => document...)\` blocks; needs \`lib: ["DOM"]\` in its tsconfig.
- \`landing\` — needs \`astro sync\` to materialize \`astro:content\` virtual modules; its own \`bun run build\` step does this.

### 3. Codecov 70% target
Adds \`codecov.yml\` with project + patch targets at 70% (1% threshold). Tokenless uploads already run on the \`unit\` job (public repo), so the codecov status will start posting on the next push to main. The lcov upload covers \`core/gateway/cli\` only today — extending coverage to other packages is a separate concern.

## Test plan
- [x] \`bunx tsc --noEmit\` reproduces the original failure inside \`packages/owletto-backend\` on main
- [x] All 8 packages typecheck clean locally on this branch
- [x] Pre-commit (biome + root tsc) passes
- [ ] CI \`typecheck\` job goes green
- [ ] Build and Push Images / build-app turns green on the merge commit