### PR TITLE
fix(connectors): bundle pino + link-preview-js instead of externalising

### DIFF
--- a/packages/owletto-backend/src/utils/connector-catalog.ts
+++ b/packages/owletto-backend/src/utils/connector-catalog.ts
@@ -191,7 +191,13 @@ export async function compileConnectorFromFile(filePath: string): Promise<string
         js: `import { createRequire as __createRequire } from 'module'; const require = __createRequire(import.meta.url);`,
       },
       plugins: [npmSpecifierPlugin],
-      external: ['pino', 'playwright', 'sharp', 'jimp', 'link-preview-js'],
+      // Must mirror EXTERNAL_RUNTIME_DEPS in packages/owletto-worker/src/runtime-deps.ts.
+      // Only natives / runtime-installed deps (playwright ships browsers via
+      // `npx playwright install`) belong here. Pure JS deps (pino, link-preview-js)
+      // must be bundled — externalising them previously caused every connector
+      // run to fail with "Cannot find package 'pino'" because the worker image
+      // didn't ship them.
+      external: ['playwright', 'sharp', 'jimp'],
       write: true,
       minify: false,
       sourcemap: false,


### PR DESCRIPTION
## Summary

\`connector-catalog.ts\` externalised \`pino\` + \`link-preview-js\` during esbuild bundling, but the worker image's \`package.json\` never installed them. Every connector run was failing in prod with \`Cannot find package 'pino'\` because the SDK's logger imports pino. (Reddit syncs across both orgs — 8 subreddit feeds — have been failing for hours; my user_activity test sync hit the same wall.)

The canonical externals list lives in \`packages/owletto-worker/src/runtime-deps.ts\` as \`EXTERNAL_RUNTIME_DEPS = ['playwright', 'sharp', 'jimp']\` — natives and runtime-installed deps that legitimately can't be bundled. Sync the esbuild externals to match. Pure-JS deps now bundle inline.

The fix is what the comment in \`runtime-deps.ts:18-22\` already prescribed (\"Pure JS deps like pino or link-preview-js should be bundled instead\"); this commit just applies it.

## Test plan

- [x] Typecheck clean.
- [ ] Post-merge + deploy: trigger a sync on any Reddit feed and confirm it completes (last_sync_status='success'). The on-demand compile path will pick up the new bundling immediately since v1.0.0 has \`compiled_code = NULL\`.
- [ ] Confirm \`runs.error_message\` no longer mentions \`'pino'\` after the deploy.