### PR TITLE
fix(reddit): request identity scope so /api/v1/me works

### DIFF
--- a/packages/owletto-connectors/src/reddit.ts
+++ b/packages/owletto-connectors/src/reddit.ts
@@ -84,7 +84,7 @@ export default class RedditConnector extends ConnectorRuntime {
         {
           type: 'oauth',
           provider: 'reddit',
-          requiredScopes: ['read', 'history'],
+          requiredScopes: ['identity', 'read', 'history'],
           setupInstructions:
             'Create a Reddit app at https://www.reddit.com/prefs/apps — choose "web app" as the type. Set the redirect URI to {{redirect_uri}}, then copy the client ID and secret below.',
         },


### PR DESCRIPTION
## Summary

The new \`user_activity\` feed resolves a missing username via \`GET /api/v1/me\`, which Reddit requires the \`identity\` scope for. The connector previously only requested \`read\` + \`history\`, so user-OAuth profiles can't auto-resolve their own username — the feed has to hard-code \`username\` in config to work, defeating the point of defaulting to the connected account.

Adds \`identity\` to \`requiredScopes\`. Existing OAuth profiles need to re-authenticate to grant the new scope; new profiles get it for free.

## Discovery

While end-to-end testing the user_activity feed: pino-bundling fix from #448 unblocked the connector code path, then sync hit \`Failed to resolve Reddit username via /api/v1/me (403)\`. Workaround was to hardcode the username in feed config; this PR fixes the auto-resolve path properly.

## Test plan

- [x] Typecheck clean.
- [ ] Post-merge + deploy: re-auth Reddit (Reddit re-prompts for the new scope), drop \`username\` from feed 284's config, re-trigger sync, confirm completes.