### PR TITLE
feat(worker): per-exec OS sandbox for spawned binaries in embedded mode

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,26 @@ jobs:
         with:
           bun-version: 1.3.5
 
+      - name: Install bubblewrap (for embedded exec-sandbox tests)
+        # The worker exec-sandbox uses bwrap on Linux; without it, the live
+        # bwrap escape-matrix tests in `packages/worker/src/__tests__/exec-sandbox.test.ts`
+        # auto-skip and we lose the only Linux verification path.
+        # Ubuntu 24.04 (ubuntu-latest) blocks unprivileged user namespaces via
+        # AppArmor by default; bwrap needs them, so flip the sysctl. See
+        # https://ubuntu.com/blog/ubuntu-23-10-restricted-unprivileged-user-namespaces
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y bubblewrap coreutils
+          sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
+          bwrap --version
+          ls -la /usr/bin/true /bin/true 2>&1 || true
+          # Probe with multiple bind mounts. /bin and /usr/bin are sometimes the
+          # same symlinked tree, sometimes not, depending on distro layout.
+          bwrap --unshare-user --unshare-pid \
+            --ro-bind / / \
+            --proc /proc --dev /dev \
+            -- /usr/bin/true && echo "bwrap userns OK"
+
       - name: Install dependencies
         run: bun install
 

--- a/packages/worker/src/__tests__/embedded-just-bash-bootstrap.test.ts
+++ b/packages/worker/src/__tests__/embedded-just-bash-bootstrap.test.ts
@@ -2,14 +2,65 @@ import { afterEach, describe, expect, test } from "bun:test";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { buildBinaryInvocation } from "../embedded/just-bash-bootstrap";
+import { resetSandboxProbeForTests } from "../embedded/exec-sandbox";
+import {
+  buildBinaryInvocation,
+  createEmbeddedBashOps,
+} from "../embedded/just-bash-bootstrap";
 
 const tempDirs: string[] = [];
+const originalEnv = {
+  PATH: process.env.PATH,
+  OWLETTO_EXEC_SANDBOX: process.env.OWLETTO_EXEC_SANDBOX,
+  LOBU_ALLOW_UNSANDBOXED_EXEC: process.env.LOBU_ALLOW_UNSANDBOXED_EXEC,
+};
+
+function restoreEnv(name: keyof typeof originalEnv): void {
+  const value = originalEnv[name];
+  if (value === undefined) {
+    delete process.env[name];
+  } else {
+    process.env[name] = value;
+  }
+}
 
 afterEach(() => {
   for (const dir of tempDirs.splice(0)) {
     fs.rmSync(dir, { recursive: true, force: true });
   }
+  restoreEnv("PATH");
+  restoreEnv("OWLETTO_EXEC_SANDBOX");
+  restoreEnv("LOBU_ALLOW_UNSANDBOXED_EXEC");
+  resetSandboxProbeForTests();
+});
+
+describe("createEmbeddedBashOps", () => {
+  test("does not register spawned PATH binaries without a sandbox or opt-in", async () => {
+    const workspace = fs.realpathSync(
+      fs.mkdtempSync(path.join(os.tmpdir(), "lobu-sandbox-"))
+    );
+    tempDirs.push(workspace);
+
+    const nixBin = path.join(workspace, "nix", "store", "fake", "bin");
+    fs.mkdirSync(nixBin, { recursive: true });
+    const hostCat = path.join(nixBin, "hostcat");
+    fs.writeFileSync(hostCat, '#!/bin/sh\n/bin/cat "$@"\n', "utf8");
+    fs.chmodSync(hostCat, 0o755);
+
+    process.env.PATH = `${nixBin}:${process.env.PATH ?? ""}`;
+    process.env.OWLETTO_EXEC_SANDBOX = "off";
+    delete process.env.LOBU_ALLOW_UNSANDBOXED_EXEC;
+
+    const ops = await createEmbeddedBashOps({ workspaceDir: workspace });
+    const chunks: string[] = [];
+    const result = await ops.exec("hostcat /etc/passwd", "/", {
+      onData: (chunk) => chunks.push(chunk.toString()),
+      timeout: 5,
+    });
+
+    expect(result.exitCode).not.toBe(0);
+    expect(chunks.join("")).not.toContain("root:");
+  });
 });
 
 describe("buildBinaryInvocation", () => {
@@ -51,6 +102,20 @@ describe("buildBinaryInvocation", () => {
     expect(r.args[0]).toBe("-p");
     expect(r.args).toContain("/bin/echo");
     expect(r.args).toContain("hi");
+  });
+
+  test("passes bwrap namespace cwd into the sandbox wrapper", () => {
+    const ws = fs.realpathSync(
+      fs.mkdtempSync(path.join(os.tmpdir(), "lobu-sandbox-"))
+    );
+    tempDirs.push(ws);
+    const r = buildBinaryInvocation("/bin/echo", ["hi"], {
+      strategy: { kind: "bwrap", path: "/usr/bin/bwrap" },
+      workspaceDir: ws,
+      bwrapCwd: "/workspace/subdir",
+    });
+    const chdir = r.args.indexOf("--chdir");
+    expect(r.args[chdir + 1]).toBe("/workspace/subdir");
   });
 
   test("sandbox=none falls through to inner invocation", () => {

--- a/packages/worker/src/__tests__/embedded-just-bash-bootstrap.test.ts
+++ b/packages/worker/src/__tests__/embedded-just-bash-bootstrap.test.ts
@@ -36,4 +36,28 @@ describe("buildBinaryInvocation", () => {
       args: ["hello"],
     });
   });
+
+  test("wraps via sandbox when context provided", () => {
+    const ws = fs.realpathSync(
+      fs.mkdtempSync(path.join(os.tmpdir(), "lobu-sandbox-"))
+    );
+    tempDirs.push(ws);
+    const r = buildBinaryInvocation("/bin/echo", ["hi"], {
+      strategy: { kind: "sandbox-exec", path: "/usr/bin/sandbox-exec" },
+      workspaceDir: ws,
+      allowNet: false,
+    });
+    expect(r.command).toBe("/usr/bin/sandbox-exec");
+    expect(r.args[0]).toBe("-p");
+    expect(r.args).toContain("/bin/echo");
+    expect(r.args).toContain("hi");
+  });
+
+  test("sandbox=none falls through to inner invocation", () => {
+    const r = buildBinaryInvocation("/bin/echo", ["hi"], {
+      strategy: { kind: "none" },
+      workspaceDir: "/tmp",
+    });
+    expect(r).toEqual({ command: "/bin/echo", args: ["hi"] });
+  });
 });

--- a/packages/worker/src/__tests__/exec-sandbox.test.ts
+++ b/packages/worker/src/__tests__/exec-sandbox.test.ts
@@ -185,6 +185,8 @@ describe("wrapInvocation", () => {
     expect(r.args).toContain("--bind");
     expect(r.args).toContain(ws);
     expect(r.args).toContain("/workspace");
+    const chdir = r.args.indexOf("--chdir");
+    expect(r.args[chdir + 1]).toBe("/workspace");
     expect(r.args).toContain("--unshare-net");
     expect(r.args).toContain("--unshare-user");
     expect(r.args).toContain("--new-session");
@@ -192,6 +194,30 @@ describe("wrapInvocation", () => {
     expect(r.args).toContain("--");
     const sep = r.args.indexOf("--");
     expect(r.args.slice(sep + 1)).toEqual(["/bin/cat", "foo"]);
+  });
+
+  test("bwrap honors requested namespace cwd", () => {
+    const ws = tmpWorkspace();
+    cleanups.push(() => fs.rmSync(ws, { recursive: true, force: true }));
+    const r = wrapInvocation(
+      { kind: "bwrap", path: "/usr/bin/bwrap" },
+      { command: "/bin/pwd", args: [] },
+      { workspaceDir: ws, bwrapCwd: "/workspace/subdir" }
+    );
+    const chdir = r.args.indexOf("--chdir");
+    expect(r.args[chdir + 1]).toBe("/workspace/subdir");
+  });
+
+  test("bwrap rejects namespace cwd outside /workspace", () => {
+    const ws = tmpWorkspace();
+    cleanups.push(() => fs.rmSync(ws, { recursive: true, force: true }));
+    expect(() =>
+      wrapInvocation(
+        { kind: "bwrap", path: "/usr/bin/bwrap" },
+        { command: "/bin/pwd", args: [] },
+        { workspaceDir: ws, bwrapCwd: "/usr" }
+      )
+    ).toThrow(/must be \/workspace or below/);
   });
 
   test("sandbox-exec profile denies var/run unix sockets", () => {
@@ -236,6 +262,7 @@ describeDarwin("sandbox-exec escape matrix", () => {
       }
     );
     try {
+      // codeql[js/shell-command-injection-from-environment]: this test intentionally executes the sandbox wrapper via execFile (no shell) to validate isolation.
       const { stdout } = await execFile(r.command, r.args, {
         cwd: workspace,
         timeout: 5000,
@@ -380,7 +407,12 @@ describeBwrap("bwrap escape matrix", () => {
     cleanups.push(() => fs.rmSync(workspace, { recursive: true, force: true }));
   });
 
-  async function runIn(cmd: string, args: string[], allowNet = false) {
+  async function runIn(
+    cmd: string,
+    args: string[],
+    allowNet = false,
+    bwrapCwd = "/workspace"
+  ) {
     if (!strategy || strategy.kind !== "bwrap") {
       return { ok: false, stdout: "", stderr: "skipped", code: -1 };
     }
@@ -390,9 +422,11 @@ describeBwrap("bwrap escape matrix", () => {
       {
         workspaceDir: workspace,
         allowNet,
+        bwrapCwd,
       }
     );
     try {
+      // codeql[js/shell-command-injection-from-environment]: this test intentionally executes the sandbox wrapper via execFile (no shell) to validate isolation.
       const { stdout } = await execFile(r.command, r.args, {
         timeout: 5000,
         env: { PATH: "/usr/bin:/bin", HOME: "/workspace/.sandbox-home" },
@@ -464,6 +498,22 @@ describeBwrap("bwrap escape matrix", () => {
     const r = await runIn("/bin/cat", ["/workspace/hello.txt"]);
     expect(r.ok).toBe(true);
     expect(r.stdout).toContain("hi from workspace");
+  });
+
+  test("runs relative commands from requested bwrap cwd", async () => {
+    fs.mkdirSync(path.join(workspace, "subdir"));
+    fs.writeFileSync(
+      path.join(workspace, "subdir", "local.txt"),
+      "from subdir\n"
+    );
+    const r = await runIn(
+      "/bin/cat",
+      ["local.txt"],
+      false,
+      "/workspace/subdir"
+    );
+    expect(r.ok).toBe(true);
+    expect(r.stdout).toContain("from subdir");
   });
 
   test("allows writing inside /workspace", async () => {

--- a/packages/worker/src/__tests__/exec-sandbox.test.ts
+++ b/packages/worker/src/__tests__/exec-sandbox.test.ts
@@ -1,0 +1,500 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { execFile as execFileCb, execFileSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { promisify } from "node:util";
+import {
+  type SandboxStrategy,
+  probeSandboxStrategy,
+  resetSandboxProbeForTests,
+  wrapInvocation,
+} from "../embedded/exec-sandbox";
+
+const execFile = promisify(execFileCb);
+
+function tmpWorkspace(): string {
+  return fs.realpathSync(
+    fs.mkdtempSync(path.join(os.tmpdir(), "exec-sandbox-test-"))
+  );
+}
+
+const cleanups: (() => void)[] = [];
+afterEach(() => {
+  for (const c of cleanups.splice(0)) c();
+  resetSandboxProbeForTests();
+  delete process.env.OWLETTO_EXEC_SANDBOX;
+});
+
+describe("probeSandboxStrategy", () => {
+  beforeEach(() => {
+    resetSandboxProbeForTests();
+  });
+
+  test("returns kind=none when OWLETTO_EXEC_SANDBOX=off", () => {
+    process.env.OWLETTO_EXEC_SANDBOX = "off";
+    expect(probeSandboxStrategy()).toEqual({ kind: "none" });
+  });
+
+  test("auto-detects sandbox-exec on darwin", () => {
+    if (process.platform !== "darwin") return;
+    const s = probeSandboxStrategy();
+    expect(s.kind).toBe("sandbox-exec");
+    expect(s.path).toMatch(/sandbox-exec$/);
+  });
+
+  test("caches the result across calls", () => {
+    const a = probeSandboxStrategy();
+    const b = probeSandboxStrategy();
+    expect(b).toBe(a);
+  });
+
+  test("ignores unknown override and falls back to auto", () => {
+    process.env.OWLETTO_EXEC_SANDBOX = "garbage";
+    const s = probeSandboxStrategy();
+    if (process.platform === "darwin") {
+      expect(s.kind).toBe("sandbox-exec");
+    } else if (process.platform === "linux") {
+      expect(["bwrap", "none"]).toContain(s.kind);
+    }
+  });
+
+  test("explicit override fails closed when backend unavailable", () => {
+    if (process.platform !== "darwin") return;
+    process.env.OWLETTO_EXEC_SANDBOX = "bwrap";
+    expect(() => probeSandboxStrategy()).toThrow(/bubblewrap is unavailable/);
+  });
+
+  test("cache invalidates when override env changes", () => {
+    process.env.OWLETTO_EXEC_SANDBOX = "off";
+    const a = probeSandboxStrategy();
+    expect(a.kind).toBe("none");
+    process.env.OWLETTO_EXEC_SANDBOX = "auto";
+    const b = probeSandboxStrategy();
+    expect(b).not.toBe(a);
+  });
+});
+
+describe("workspaceDir validation", () => {
+  test("sandbox-exec rejects workspaceDir with double-quote", () => {
+    expect(() =>
+      wrapInvocation(
+        { kind: "sandbox-exec", path: "/usr/bin/sandbox-exec" },
+        { command: "/bin/cat", args: [] },
+        { workspaceDir: '/tmp/evil"; (allow file-read*)', allowNet: false }
+      )
+    ).toThrow(/unsafe characters/);
+  });
+
+  test("sandbox-exec rejects workspaceDir with newline", () => {
+    expect(() =>
+      wrapInvocation(
+        { kind: "sandbox-exec", path: "/usr/bin/sandbox-exec" },
+        { command: "/bin/cat", args: [] },
+        { workspaceDir: "/tmp/evil\n(allow file-read*)", allowNet: false }
+      )
+    ).toThrow(/unsafe characters/);
+  });
+
+  test("bwrap rejects workspaceDir with paren", () => {
+    expect(() =>
+      wrapInvocation(
+        { kind: "bwrap", path: "/usr/bin/bwrap" },
+        { command: "/bin/cat", args: [] },
+        { workspaceDir: "/tmp/(evil)", allowNet: false }
+      )
+    ).toThrow(/unsafe characters/);
+  });
+
+  test("accepts plausible developer paths", () => {
+    expect(() =>
+      wrapInvocation(
+        { kind: "sandbox-exec", path: "/usr/bin/sandbox-exec" },
+        { command: "/bin/cat", args: [] },
+        {
+          workspaceDir: "/Users/dev/.lobu/workspaces/thread-123",
+          allowNet: false,
+        }
+      )
+    ).not.toThrow();
+  });
+
+  test.each([
+    ["/", "root"],
+    ["/tmp//evil", "double-slash"],
+    ["/tmp/../etc", "dotdot segment"],
+    ["/tmp/", "trailing slash"],
+  ])("rejects non-canonical path: %s (%s)", (badPath) => {
+    expect(() =>
+      wrapInvocation(
+        { kind: "sandbox-exec", path: "/usr/bin/sandbox-exec" },
+        { command: "/bin/cat", args: [] },
+        { workspaceDir: badPath, allowNet: false }
+      )
+    ).toThrow();
+  });
+});
+
+describe("wrapInvocation", () => {
+  test("pass-through when strategy.kind === none", () => {
+    const ws = tmpWorkspace();
+    cleanups.push(() => fs.rmSync(ws, { recursive: true, force: true }));
+    const r = wrapInvocation(
+      { kind: "none" },
+      { command: "/bin/echo", args: ["hi"] },
+      { workspaceDir: ws }
+    );
+    expect(r).toEqual({ command: "/bin/echo", args: ["hi"] });
+  });
+
+  test("sandbox-exec wraps with -p <profile> <cmd> <args>", () => {
+    const ws = tmpWorkspace();
+    cleanups.push(() => fs.rmSync(ws, { recursive: true, force: true }));
+    const r = wrapInvocation(
+      { kind: "sandbox-exec", path: "/usr/bin/sandbox-exec" },
+      { command: "/bin/cat", args: ["foo"] },
+      { workspaceDir: ws, allowNet: false }
+    );
+    expect(r.command).toBe("/usr/bin/sandbox-exec");
+    expect(r.args[0]).toBe("-p");
+    expect(r.args[1]).toContain(`(subpath "${ws}")`);
+    expect(r.args[1]).toContain("(deny network*)");
+    expect(r.args.slice(2)).toEqual(["/bin/cat", "foo"]);
+  });
+
+  test("sandbox-exec emits (allow network*) when allowNet=true", () => {
+    const ws = tmpWorkspace();
+    cleanups.push(() => fs.rmSync(ws, { recursive: true, force: true }));
+    const r = wrapInvocation(
+      { kind: "sandbox-exec", path: "/usr/bin/sandbox-exec" },
+      { command: "/bin/cat", args: [] },
+      { workspaceDir: ws, allowNet: true }
+    );
+    expect(r.args[1]).toContain("(allow network*)");
+  });
+
+  test("bwrap wraps with bind mounts + -- <cmd> <args>", () => {
+    const ws = tmpWorkspace();
+    cleanups.push(() => fs.rmSync(ws, { recursive: true, force: true }));
+    const r = wrapInvocation(
+      { kind: "bwrap", path: "/usr/bin/bwrap" },
+      { command: "/bin/cat", args: ["foo"] },
+      { workspaceDir: ws, allowNet: false }
+    );
+    expect(r.command).toBe("/usr/bin/bwrap");
+    expect(r.args).toContain("--bind");
+    expect(r.args).toContain(ws);
+    expect(r.args).toContain("/workspace");
+    expect(r.args).toContain("--unshare-net");
+    expect(r.args).toContain("--unshare-user");
+    expect(r.args).toContain("--new-session");
+    expect(r.args).toContain("--die-with-parent");
+    expect(r.args).toContain("--");
+    const sep = r.args.indexOf("--");
+    expect(r.args.slice(sep + 1)).toEqual(["/bin/cat", "foo"]);
+  });
+
+  test("sandbox-exec profile denies var/run unix sockets", () => {
+    const ws = tmpWorkspace();
+    cleanups.push(() => fs.rmSync(ws, { recursive: true, force: true }));
+    const r = wrapInvocation(
+      { kind: "sandbox-exec", path: "/usr/bin/sandbox-exec" },
+      { command: "/bin/cat", args: [] },
+      { workspaceDir: ws }
+    );
+    expect(r.args[1]).toContain('(subpath "/var/run")');
+    expect(r.args[1]).toContain('(subpath "/private/var/run")');
+    expect(r.args[1]).toContain('(subpath "/Library/Preferences")');
+  });
+});
+
+// Real escape-matrix tests against the live macOS sandbox. Skipped on other
+// platforms — the bwrap counterpart runs under CI on Linux.
+const isDarwin = process.platform === "darwin";
+const describeDarwin = isDarwin ? describe : describe.skip;
+
+describeDarwin("sandbox-exec escape matrix", () => {
+  let strategy: SandboxStrategy;
+  let workspace: string;
+
+  beforeEach(() => {
+    process.env.OWLETTO_EXEC_SANDBOX = "sandbox-exec";
+    resetSandboxProbeForTests();
+    strategy = probeSandboxStrategy();
+    workspace = tmpWorkspace();
+    fs.writeFileSync(path.join(workspace, "hello.txt"), "hi from workspace\n");
+    cleanups.push(() => fs.rmSync(workspace, { recursive: true, force: true }));
+  });
+
+  async function runIn(cmd: string, args: string[]) {
+    const r = wrapInvocation(
+      strategy,
+      { command: cmd, args },
+      {
+        workspaceDir: workspace,
+        allowNet: false,
+      }
+    );
+    try {
+      const { stdout } = await execFile(r.command, r.args, {
+        cwd: workspace,
+        timeout: 5000,
+        env: { PATH: "/usr/bin:/bin:/usr/sbin:/sbin", HOME: workspace },
+      });
+      return { ok: true, stdout: stdout.toString() };
+    } catch (e: unknown) {
+      const err = e as { code?: number; stdout?: string; stderr?: string };
+      return {
+        ok: false,
+        stdout: err.stdout?.toString() ?? "",
+        stderr: err.stderr?.toString() ?? "",
+        code: err.code,
+      };
+    }
+  }
+
+  test("blocks /etc/passwd", async () => {
+    const r = await runIn("/bin/cat", ["/etc/passwd"]);
+    expect(r.ok && r.stdout.includes("root:")).toBe(false);
+  });
+
+  test("blocks listing real /Users", async () => {
+    const r = await runIn("/bin/ls", ["/Users"]);
+    expect(r.ok).toBe(false);
+  });
+
+  test("blocks ../../etc/passwd traversal", async () => {
+    const r = await runIn("/bin/sh", ["-c", "cat ../../etc/passwd"]);
+    expect(r.ok && r.stdout.includes("root:")).toBe(false);
+  });
+
+  test("blocks symlink-to-/etc/passwd", async () => {
+    const r = await runIn("/bin/sh", [
+      "-c",
+      "ln -sf /etc/passwd evil && cat evil",
+    ]);
+    expect(r.ok && r.stdout.includes("root:")).toBe(false);
+  });
+
+  test("blocks write outside workspace", async () => {
+    const r = await runIn("/bin/sh", [
+      "-c",
+      "echo pwn > /tmp/spike-pwn-write && cat /tmp/spike-pwn-write",
+    ]);
+    expect(r.ok).toBe(false);
+  });
+
+  test("blocks home-dir secrets", async () => {
+    const r = await runIn("/bin/sh", [
+      "-c",
+      `cat ${os.homedir()}/.ssh/id_rsa || cat ${os.homedir()}/.ssh/id_ed25519`,
+    ]);
+    expect(r.ok).toBe(false);
+  });
+
+  test("allows reading workspace file", async () => {
+    const r = await runIn("/bin/cat", ["hello.txt"]);
+    expect(r.ok).toBe(true);
+    expect(r.stdout).toContain("hi from workspace");
+  });
+
+  test("allows writing workspace file", async () => {
+    const r = await runIn("/bin/sh", [
+      "-c",
+      "echo wrote > out.txt && cat out.txt",
+    ]);
+    expect(r.ok).toBe(true);
+    expect(r.stdout).toContain("wrote");
+  });
+
+  test("argv injection: shell metacharacters not interpreted by execFile", async () => {
+    const r = await runIn("/bin/cat", ["hello.txt; cat /etc/passwd"]);
+    expect(r.ok && r.stdout.includes("root:")).toBe(false);
+  });
+});
+
+// Real escape-matrix tests against bwrap. Auto-skip when not on Linux, when
+// bwrap isn't on PATH, or when user namespaces are blocked at the OS level
+// (Ubuntu 24.04 / GitHub Actions default until apparmor sysctl is flipped).
+// Probed once at module load so each test starts with a known-good sandbox.
+const isLinux = process.platform === "linux";
+const linuxBwrapWorks = (() => {
+  if (!isLinux) return false;
+  const candidates = ["/usr/bin/bwrap", "/usr/local/bin/bwrap"];
+  const bwrapPath = candidates.find((p) => {
+    try {
+      fs.accessSync(p, fs.constants.X_OK);
+      return true;
+    } catch {
+      return false;
+    }
+  });
+  if (!bwrapPath) return false;
+  try {
+    // Mirror `bwrapDeliversIsolation` in exec-sandbox.ts. /lib64 must be
+    // bound because /usr/bin/true's ELF interpreter is /lib64/ld-linux-*.so.
+    execFileSync(
+      bwrapPath,
+      [
+        "--unshare-user",
+        "--unshare-pid",
+        "--unshare-net",
+        "--ro-bind",
+        "/usr",
+        "/usr",
+        "--ro-bind-try",
+        "/lib",
+        "/lib",
+        "--ro-bind-try",
+        "/lib64",
+        "/lib64",
+        "--ro-bind-try",
+        "/bin",
+        "/bin",
+        "--proc",
+        "/proc",
+        "--dev",
+        "/dev",
+        "--",
+        "/usr/bin/true",
+      ],
+      { stdio: "ignore", timeout: 3000 }
+    );
+    return true;
+  } catch {
+    return false;
+  }
+})();
+const describeBwrap = linuxBwrapWorks ? describe : describe.skip;
+
+describeBwrap("bwrap escape matrix", () => {
+  let strategy: SandboxStrategy;
+  let workspace: string;
+
+  beforeEach(() => {
+    process.env.OWLETTO_EXEC_SANDBOX = "bwrap";
+    resetSandboxProbeForTests();
+    strategy = probeSandboxStrategy();
+    workspace = tmpWorkspace();
+    fs.writeFileSync(path.join(workspace, "hello.txt"), "hi from workspace\n");
+    cleanups.push(() => fs.rmSync(workspace, { recursive: true, force: true }));
+  });
+
+  async function runIn(cmd: string, args: string[], allowNet = false) {
+    if (!strategy || strategy.kind !== "bwrap") {
+      return { ok: false, stdout: "", stderr: "skipped", code: -1 };
+    }
+    const r = wrapInvocation(
+      strategy,
+      { command: cmd, args },
+      {
+        workspaceDir: workspace,
+        allowNet,
+      }
+    );
+    try {
+      const { stdout } = await execFile(r.command, r.args, {
+        timeout: 5000,
+        env: { PATH: "/usr/bin:/bin", HOME: "/workspace/.sandbox-home" },
+      });
+      return { ok: true, stdout: stdout.toString() };
+    } catch (e: unknown) {
+      const err = e as { code?: number; stdout?: string; stderr?: string };
+      return {
+        ok: false,
+        stdout: err.stdout?.toString() ?? "",
+        stderr: err.stderr?.toString() ?? "",
+        code: err.code,
+      };
+    }
+  }
+
+  test("blocks /etc/passwd outside the bind", async () => {
+    // /etc is not bound, so the path doesn't exist inside the namespace at all.
+    const r = await runIn("/bin/cat", ["/etc/passwd"]);
+    expect(r.ok && r.stdout.includes("root:")).toBe(false);
+  });
+
+  test("blocks listing /home", async () => {
+    const r = await runIn("/bin/ls", ["/home"]);
+    // /home is not bound; the path either doesn't exist or returns ENOENT.
+    expect(r.ok).toBe(false);
+  });
+
+  test("blocks ../../etc/passwd traversal from /workspace", async () => {
+    const r = await runIn("/bin/sh", [
+      "-c",
+      "cd /workspace && cat ../../etc/passwd",
+    ]);
+    expect(r.ok && r.stdout.includes("root:")).toBe(false);
+  });
+
+  test("blocks symlink escape from workspace", async () => {
+    fs.symlinkSync("/etc/passwd", path.join(workspace, "evil"));
+    const r = await runIn("/bin/sh", ["-c", "cat /workspace/evil"]);
+    // The symlink target /etc/passwd doesn't exist inside the namespace.
+    expect(r.ok && r.stdout.includes("root:")).toBe(false);
+  });
+
+  test("blocks writes to ro-bound /usr", async () => {
+    // /usr is --ro-bind'd, so writes there are denied at the kernel level
+    // regardless of namespace.
+    const r = await runIn("/bin/sh", ["-c", "echo pwn > /usr/spike-pwn"]);
+    expect(r.ok).toBe(false);
+  });
+
+  test("namespace writes don't escape to host filesystem", async () => {
+    // The namespace's /etc is a writable empty dir created by bwrap (it's the
+    // mountpoint for --ro-bind-try /etc/resolv.conf). Writes there succeed
+    // *inside the namespace* but must not affect the host's /etc.
+    const marker = `/etc/spike-pwn-${process.pid}-${Date.now()}`;
+    await runIn("/bin/sh", ["-c", `echo pwn > ${marker} || true`]);
+    expect(fs.existsSync(marker)).toBe(false);
+  });
+
+  test("blocks read of host root filesystem dirs", async () => {
+    const r = await runIn("/bin/sh", [
+      "-c",
+      "ls -la /root 2>/dev/null || ls -la /var/log 2>/dev/null",
+    ]);
+    expect(r.ok && r.stdout.length > 0).toBe(false);
+  });
+
+  test("allows reading workspace file via /workspace bind", async () => {
+    const r = await runIn("/bin/cat", ["/workspace/hello.txt"]);
+    expect(r.ok).toBe(true);
+    expect(r.stdout).toContain("hi from workspace");
+  });
+
+  test("allows writing inside /workspace", async () => {
+    const r = await runIn("/bin/sh", [
+      "-c",
+      "echo wrote > /workspace/out.txt && cat /workspace/out.txt",
+    ]);
+    expect(r.ok).toBe(true);
+    expect(r.stdout).toContain("wrote");
+    expect(fs.readFileSync(path.join(workspace, "out.txt"), "utf8")).toContain(
+      "wrote"
+    );
+  });
+
+  test("argv injection: shell metacharacters in execFile args don't escape", async () => {
+    const r = await runIn("/bin/cat", [
+      "/workspace/hello.txt; cat /etc/passwd",
+    ]);
+    expect(r.ok && r.stdout.includes("root:")).toBe(false);
+  });
+
+  test("--unshare-net blocks outbound network", async () => {
+    // /usr/bin/getent uses libnss; cleanest is just to try a local socket.
+    const r = await runIn("/bin/sh", [
+      "-c",
+      "exec 3<>/dev/tcp/8.8.8.8/53 2>&1; echo $?",
+    ]);
+    // bwrap's tmpfs at /dev only includes minimal nodes, and --unshare-net
+    // means even if /dev/tcp works there's no route. Either is fine.
+    if (r.ok) {
+      expect(r.stdout.trim()).not.toBe("0");
+    }
+  });
+});

--- a/packages/worker/src/embedded/exec-sandbox.ts
+++ b/packages/worker/src/embedded/exec-sandbox.ts
@@ -1,0 +1,354 @@
+/**
+ * Per-exec sandbox for embedded just-bash custom commands.
+ *
+ * just-bash's interpreter and `ReadWriteFs` already root file ops in the
+ * thread workspace, but spawned binaries (gh, git, owletto, anything from
+ * /nix/store) bypass that — once execFile fires, the child has the host's
+ * full FS view. This module wraps every spawn in an OS sandbox so the child
+ * sees only the workspace + ro system paths.
+ *
+ * Strategies:
+ *   - "sandbox-exec" (macOS) — allow-default profile with denies for personal
+ *     data paths (~/.ssh, ~/.aws, /etc, /Users, keychains, etc.) and writes
+ *     restricted to the workspace.
+ *   - "bwrap" (Linux) — true deny-default via bind mounts; only the workspace
+ *     and ro system paths are visible. Probed at startup with a real spawn
+ *     because `--unshare-user` requires `kernel.unprivileged_userns_clone=1`.
+ *   - "none" — no sandbox available; commands run with host privileges. A
+ *     warning is logged once at probe time.
+ *
+ * Override with OWLETTO_EXEC_SANDBOX={auto,bwrap,sandbox-exec,off}. Explicit
+ * overrides fail closed: requesting `bwrap` on a host without bubblewrap is a
+ * hard error, not a silent fallback to "none".
+ */
+
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+
+export type SandboxKind = "sandbox-exec" | "bwrap" | "none";
+
+export interface SandboxStrategy {
+  kind: SandboxKind;
+  /** Absolute path to the wrapper binary. Absent for "none". */
+  path?: string;
+}
+
+export interface SandboxWrapOptions {
+  /** Workspace dir on the host FS. Wrapped child gets rw access here only. */
+  workspaceDir: string;
+  /**
+   * If false, the child cannot reach the network. just-bash's domain allowlist
+   * still applies inside the interpreter; this controls whether spawned
+   * binaries can open sockets at all. Set true when the gateway HTTP proxy is
+   * the egress path (binaries respect HTTP_PROXY).
+   */
+  allowNet?: boolean;
+}
+
+/** Workspace path is interpolated into SBPL/argv unescaped. Reject anything
+ * that could break out of the SBPL string literal, inject extra rules, or
+ * paper over a non-canonical path. Callers must canonicalize first. */
+const WORKSPACE_DIR_SAFE = /^\/[A-Za-z0-9._\-/+@:]+$/;
+
+interface CacheEntry {
+  key: string;
+  strategy: SandboxStrategy;
+}
+let cached: CacheEntry | null = null;
+let warnedNoSandbox = false;
+
+function cacheKey(): string {
+  return `${process.platform}|${process.env.OWLETTO_EXEC_SANDBOX ?? ""}`;
+}
+
+function which(bin: string): string | null {
+  try {
+    return (
+      execFileSync("/usr/bin/which", [bin], {
+        encoding: "utf8",
+        stdio: ["ignore", "pipe", "ignore"],
+      }).trim() || null
+    );
+  } catch {
+    return null;
+  }
+}
+
+function envOverride(): SandboxKind | null {
+  const v = process.env.OWLETTO_EXEC_SANDBOX?.toLowerCase();
+  if (!v || v === "auto") return null;
+  if (v === "off" || v === "none") return "none";
+  if (v === "bwrap" || v === "sandbox-exec") return v;
+  console.warn(
+    `[exec-sandbox] Unknown OWLETTO_EXEC_SANDBOX=${v}, falling back to auto.`
+  );
+  return null;
+}
+
+/**
+ * Run bwrap with the same unshare flags we use in production but against
+ * `/bin/true`. If user namespaces aren't available (kernel disabled, seccomp
+ * profile blocking `unshare(CLONE_NEWUSER)`), this fails — and we should
+ * surface it rather than silently degrade to "no sandbox".
+ */
+function bwrapDeliversIsolation(bwrapPath: string): boolean {
+  try {
+    execFileSync(
+      bwrapPath,
+      [
+        "--unshare-user",
+        "--unshare-pid",
+        "--unshare-ipc",
+        "--unshare-uts",
+        "--unshare-net",
+        "--ro-bind",
+        "/usr",
+        "/usr",
+        "--ro-bind-try",
+        "/lib",
+        "/lib",
+        "--ro-bind-try",
+        "/lib64",
+        "/lib64",
+        "--ro-bind-try",
+        "/bin",
+        "/bin",
+        "--proc",
+        "/proc",
+        "--dev",
+        "/dev",
+        "--",
+        "/usr/bin/true",
+      ],
+      { stdio: "ignore", timeout: 3000 }
+    );
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function setCache(key: string, strategy: SandboxStrategy): SandboxStrategy {
+  cached = { key, strategy };
+  return strategy;
+}
+
+export function probeSandboxStrategy(): SandboxStrategy {
+  const key = cacheKey();
+  if (cached && cached.key === key) return cached.strategy;
+
+  const override = envOverride();
+
+  if (override === "none") {
+    return setCache(key, { kind: "none" });
+  }
+
+  // Explicit override: try only the requested backend, fail closed.
+  if (override) {
+    if (override === "sandbox-exec") {
+      const p = which("sandbox-exec") ?? "/usr/bin/sandbox-exec";
+      if (fs.existsSync(p)) {
+        return setCache(key, { kind: "sandbox-exec", path: p });
+      }
+      throw new Error(
+        `[exec-sandbox] OWLETTO_EXEC_SANDBOX=sandbox-exec but ${p} not found.`
+      );
+    }
+    if (override === "bwrap") {
+      const p = which("bwrap");
+      if (p && fs.existsSync(p) && bwrapDeliversIsolation(p)) {
+        return setCache(key, { kind: "bwrap", path: p });
+      }
+      throw new Error(
+        `[exec-sandbox] OWLETTO_EXEC_SANDBOX=bwrap but bubblewrap is unavailable ` +
+          `or user namespaces are blocked. Install bubblewrap and ensure ` +
+          `kernel.unprivileged_userns_clone=1 (or seccomp profile permits unshare).`
+      );
+    }
+  }
+
+  // Auto-detect by platform.
+  if (process.platform === "darwin") {
+    const p = which("sandbox-exec") ?? "/usr/bin/sandbox-exec";
+    if (fs.existsSync(p)) {
+      return setCache(key, { kind: "sandbox-exec", path: p });
+    }
+  }
+
+  if (process.platform === "linux") {
+    const p = which("bwrap");
+    if (p && fs.existsSync(p) && bwrapDeliversIsolation(p)) {
+      return setCache(key, { kind: "bwrap", path: p });
+    }
+  }
+
+  if (!warnedNoSandbox) {
+    warnedNoSandbox = true;
+    console.warn(
+      `[exec-sandbox] No sandbox available on platform=${process.platform}. ` +
+        `Spawned binaries will run with host privileges. ` +
+        `Install bubblewrap (Linux) or check sandbox-exec (macOS).`
+    );
+  }
+  return setCache(key, { kind: "none" });
+}
+
+/** For tests: forget the cached strategy + warning state. */
+export function resetSandboxProbeForTests(): void {
+  cached = null;
+  warnedNoSandbox = false;
+}
+
+function assertSafeWorkspacePath(workspaceDir: string): void {
+  if (!WORKSPACE_DIR_SAFE.test(workspaceDir)) {
+    throw new Error(
+      `[exec-sandbox] workspaceDir ${JSON.stringify(workspaceDir)} contains ` +
+        `unsafe characters; only [A-Za-z0-9._\\-/+@:] is allowed.`
+    );
+  }
+  if (
+    workspaceDir === "/" ||
+    workspaceDir.includes("//") ||
+    workspaceDir.split("/").includes("..") ||
+    workspaceDir.endsWith("/")
+  ) {
+    throw new Error(
+      `[exec-sandbox] workspaceDir ${JSON.stringify(workspaceDir)} is not a ` +
+        `canonical absolute path. Pass realpathSync(dir) at boot.`
+    );
+  }
+}
+
+/**
+ * SBPL profile for macOS. Allow-default with targeted denies for personal-data
+ * paths and a write-island scoped to the workspace. Last-match-wins lets the
+ * workspace allow override the broader `/Users` deny when workspaceDir is
+ * under /Users (developer dev machine).
+ */
+function buildSandboxExecProfile(
+  workspaceDir: string,
+  opts: SandboxWrapOptions
+): string {
+  assertSafeWorkspacePath(workspaceDir);
+  return `(version 1)
+(allow default)
+
+;; personal data + system config
+(deny file-read*
+  (subpath "/Users")
+  (subpath "/etc")
+  (subpath "/private/etc")
+  (subpath "/var/log")
+  (subpath "/private/var/log")
+  (subpath "/var/run")
+  (subpath "/private/var/run")
+  (subpath "/Volumes")
+  (subpath "/Library/Keychains")
+  (subpath "/Library/Preferences")
+  (subpath "/Library/Application Support")
+  (subpath "/Library/Cookies")
+  (subpath "/Library/Mail")
+  (subpath "/Library/Messages")
+  (subpath "/Library/Safari")
+  (subpath "/private/tmp")
+  (subpath "/tmp"))
+(allow file-read* (subpath "${workspaceDir}"))
+
+;; writes constrained to workspace
+(deny file-write*)
+(allow file-write* (subpath "${workspaceDir}"))
+
+;; network
+${opts.allowNet ? "(allow network*)" : "(deny network*)"}
+`;
+}
+
+function buildBwrapArgs(
+  workspaceDir: string,
+  opts: SandboxWrapOptions
+): string[] {
+  assertSafeWorkspacePath(workspaceDir);
+  return [
+    "--die-with-parent",
+    "--new-session",
+    "--unshare-user",
+    "--unshare-pid",
+    "--unshare-ipc",
+    "--unshare-uts",
+    "--unshare-cgroup-try",
+    ...(opts.allowNet ? ["--share-net"] : ["--unshare-net"]),
+    "--bind",
+    workspaceDir,
+    "/workspace",
+    "--chdir",
+    "/workspace",
+    "--ro-bind",
+    "/usr",
+    "/usr",
+    "--ro-bind-try",
+    "/lib",
+    "/lib",
+    "--ro-bind-try",
+    "/lib64",
+    "/lib64",
+    "--ro-bind-try",
+    "/bin",
+    "/bin",
+    "--ro-bind-try",
+    "/sbin",
+    "/sbin",
+    "--ro-bind-try",
+    "/nix",
+    "/nix",
+    "--ro-bind-try",
+    "/etc/resolv.conf",
+    "/etc/resolv.conf",
+    "--ro-bind-try",
+    "/etc/ssl",
+    "/etc/ssl",
+    "--ro-bind-try",
+    "/etc/ca-certificates",
+    "/etc/ca-certificates",
+    "--proc",
+    "/proc",
+    "--dev",
+    "/dev",
+    "--tmpfs",
+    "/tmp",
+  ];
+}
+
+/**
+ * Wrap a `(command, args)` invocation with the active sandbox strategy.
+ * Pass-through for `kind: "none"`. The returned shape is what should be handed
+ * to `child_process.execFile`.
+ */
+export function wrapInvocation(
+  strategy: SandboxStrategy,
+  inner: { command: string; args: string[] },
+  opts: SandboxWrapOptions
+): { command: string; args: string[] } {
+  if (strategy.kind === "none" || !strategy.path) return inner;
+
+  if (strategy.kind === "sandbox-exec") {
+    const profile = buildSandboxExecProfile(opts.workspaceDir, opts);
+    return {
+      command: strategy.path,
+      args: ["-p", profile, inner.command, ...inner.args],
+    };
+  }
+
+  if (strategy.kind === "bwrap") {
+    return {
+      command: strategy.path,
+      args: [
+        ...buildBwrapArgs(opts.workspaceDir, opts),
+        "--",
+        inner.command,
+        ...inner.args,
+      ],
+    };
+  }
+
+  return inner;
+}

--- a/packages/worker/src/embedded/exec-sandbox.ts
+++ b/packages/worker/src/embedded/exec-sandbox.ts
@@ -43,6 +43,8 @@ export interface SandboxWrapOptions {
    * the egress path (binaries respect HTTP_PROXY).
    */
   allowNet?: boolean;
+  /** Absolute cwd inside the bwrap namespace. Must be /workspace or below. */
+  bwrapCwd?: string;
 }
 
 /** Workspace path is interpolated into SBPL/argv unescaped. Reject anything
@@ -219,6 +221,20 @@ function assertSafeWorkspacePath(workspaceDir: string): void {
   }
 }
 
+function assertSafeBwrapCwd(bwrapCwd: string): void {
+  if (bwrapCwd !== "/workspace" && !bwrapCwd.startsWith("/workspace/")) {
+    throw new Error(
+      `[exec-sandbox] bwrap cwd ${JSON.stringify(bwrapCwd)} must be ` +
+        `/workspace or below.`
+    );
+  }
+  if (bwrapCwd.includes("\0") || bwrapCwd.split("/").includes("..")) {
+    throw new Error(
+      `[exec-sandbox] bwrap cwd ${JSON.stringify(bwrapCwd)} is unsafe.`
+    );
+  }
+}
+
 /**
  * SBPL profile for macOS. Allow-default with targeted denies for personal-data
  * paths and a write-island scoped to the workspace. Last-match-wins lets the
@@ -268,6 +284,8 @@ function buildBwrapArgs(
   opts: SandboxWrapOptions
 ): string[] {
   assertSafeWorkspacePath(workspaceDir);
+  const bwrapCwd = opts.bwrapCwd ?? "/workspace";
+  assertSafeBwrapCwd(bwrapCwd);
   return [
     "--die-with-parent",
     "--new-session",
@@ -281,7 +299,7 @@ function buildBwrapArgs(
     workspaceDir,
     "/workspace",
     "--chdir",
-    "/workspace",
+    bwrapCwd,
     "--ro-bind",
     "/usr",
     "/usr",

--- a/packages/worker/src/embedded/just-bash-bootstrap.ts
+++ b/packages/worker/src/embedded/just-bash-bootstrap.ts
@@ -16,6 +16,11 @@ import { stripEnv } from "@lobu/core";
 import type { BashOperations } from "@mariozechner/pi-coding-agent";
 import { SENSITIVE_WORKER_ENV_KEYS } from "../shared/worker-env-keys";
 import type { GatewayParams } from "../shared/tool-implementations";
+import {
+  type SandboxStrategy,
+  probeSandboxStrategy,
+  wrapInvocation,
+} from "./exec-sandbox";
 import type { McpCliCommand, McpRuntimeRef } from "./mcp-cli-commands";
 import { buildMcpCliCommands } from "./mcp-cli-commands";
 
@@ -25,21 +30,38 @@ const EMBEDDED_BASH_LIMITS = {
   maxCallDepth: 50,
 } as const;
 
+export interface SandboxContext {
+  strategy: SandboxStrategy;
+  workspaceDir: string;
+  /** Whether the spawned binary may open sockets. just-bash's domain allowlist
+   * still gates the interpreter; this controls the OS network namespace. */
+  allowNet?: boolean;
+}
+
 export function buildBinaryInvocation(
   binaryPath: string,
-  args: string[]
+  args: string[],
+  sandbox?: SandboxContext
 ): { command: string; args: string[] } {
+  let inner: { command: string; args: string[] } = {
+    command: binaryPath,
+    args,
+  };
   try {
     const firstLine =
       fs.readFileSync(binaryPath, "utf8").split("\n", 1)[0] || "";
     if (firstLine === "#!/usr/bin/env node" || firstLine.endsWith("/node")) {
-      return { command: "node", args: [binaryPath, ...args] };
+      inner = { command: "node", args: [binaryPath, ...args] };
     }
   } catch {
     // Fall back to executing the binary directly.
   }
 
-  return { command: binaryPath, args };
+  if (!sandbox) return inner;
+  return wrapInvocation(sandbox.strategy, inner, {
+    workspaceDir: sandbox.workspaceDir,
+    allowNet: sandbox.allowNet ?? true,
+  });
 }
 
 /**
@@ -87,11 +109,50 @@ function discoverBinaries(): Map<string, string> {
 }
 
 /**
+ * Resolve a just-bash virtual cwd to a real on-disk path. just-bash's
+ * `CommandContext.cwd` is rooted at the `ReadWriteFs` root, but `child_process`
+ * needs a host path. We realpath both sides and verify the resolved cwd stays
+ * inside the workspace — defense in depth against a symlink that slipped past
+ * `ReadWriteFs` (e.g. if `allowSymlinks` is ever enabled upstream).
+ */
+function resolveHostCwd(workspaceDir: string, virtualCwd: string): string {
+  const trimmed = virtualCwd.startsWith("/") ? virtualCwd.slice(1) : virtualCwd;
+  const candidate = trimmed ? path.join(workspaceDir, trimmed) : workspaceDir;
+  let realCwd: string;
+  let realWs: string;
+  try {
+    realCwd = fs.realpathSync(candidate);
+    realWs = fs.realpathSync(workspaceDir);
+  } catch {
+    return workspaceDir;
+  }
+  if (realCwd !== realWs && !realCwd.startsWith(realWs + path.sep)) {
+    throw new Error(
+      `[embedded] cwd ${JSON.stringify(virtualCwd)} resolves outside workspace`
+    );
+  }
+  return realCwd;
+}
+
+function ensureSandboxDir(workspaceDir: string, name: string): string {
+  const dir = path.join(workspaceDir, name);
+  try {
+    fs.mkdirSync(dir, { recursive: true });
+  } catch {
+    // best-effort; sandbox profile will surface real errors if it can't create
+  }
+  return dir;
+}
+
+/**
  * Create just-bash customCommands from a map of binary name → full path.
- * Each custom command delegates to the real binary via child_process.execFile.
+ * Each custom command delegates to the real binary via child_process.execFile,
+ * wrapped in the active per-exec sandbox so spawned binaries cannot read
+ * outside the workspace or write outside it.
  */
 async function buildCustomCommands(
-  binaries: Map<string, string>
+  binaries: Map<string, string>,
+  sandbox: SandboxContext
 ): Promise<ReturnType<typeof import("just-bash").defineCommand>[]> {
   const { defineCommand } = await import("just-bash");
   const commands = [];
@@ -99,9 +160,8 @@ async function buildCustomCommands(
   for (const [name, binaryPath] of binaries) {
     commands.push(
       defineCommand(name, async (args: string[], ctx) => {
-        const invocation = buildBinaryInvocation(binaryPath, args);
+        const invocation = buildBinaryInvocation(binaryPath, args, sandbox);
 
-        // Convert ctx.env (Map-like) to a plain Record for child_process
         const envRecord = stripEnv(process.env, SENSITIVE_WORKER_ENV_KEYS);
         if (ctx.env && typeof ctx.env.forEach === "function") {
           ctx.env.forEach((v: string, k: string) => {
@@ -109,6 +169,49 @@ async function buildCustomCommands(
           });
         } else if (ctx.env && typeof ctx.env === "object") {
           Object.assign(envRecord, ctx.env);
+        }
+
+        // Pin HOME / TMPDIR to dedicated subdirs so tool dotfiles (~/.gitconfig,
+        // ~/.cache, ~/.config) and temp files don't collide with workspace
+        // contents. Sandbox profiles already deny outside-workspace writes;
+        // these keep agent-visible files clean.
+        //
+        // bwrap binds the host workspace at `/workspace` inside the namespace,
+        // so the in-namespace HOME/TMPDIR must use the bound path. sandbox-exec
+        // doesn't remap paths, so HOME/TMPDIR stay as host paths.
+        ensureSandboxDir(sandbox.workspaceDir, ".sandbox-home");
+        ensureSandboxDir(sandbox.workspaceDir, ".sandbox-tmp");
+        if (sandbox.strategy.kind === "bwrap") {
+          envRecord.HOME = "/workspace/.sandbox-home";
+          envRecord.TMPDIR = "/workspace/.sandbox-tmp";
+        } else {
+          envRecord.HOME = path.join(sandbox.workspaceDir, ".sandbox-home");
+          envRecord.TMPDIR = path.join(sandbox.workspaceDir, ".sandbox-tmp");
+        }
+
+        // Force gateway proxy env so a malicious agent can't override it via
+        // `export HTTP_PROXY=` to bypass the egress allowlist. NO_PROXY is
+        // stripped for the same reason.
+        if (process.env.HTTP_PROXY)
+          envRecord.HTTP_PROXY = process.env.HTTP_PROXY;
+        if (process.env.HTTPS_PROXY)
+          envRecord.HTTPS_PROXY = process.env.HTTPS_PROXY;
+        if (process.env.http_proxy)
+          envRecord.http_proxy = process.env.http_proxy;
+        if (process.env.https_proxy)
+          envRecord.https_proxy = process.env.https_proxy;
+        delete envRecord.NO_PROXY;
+        delete envRecord.no_proxy;
+
+        let hostCwd: string;
+        try {
+          hostCwd = resolveHostCwd(sandbox.workspaceDir, ctx.cwd ?? "/");
+        } catch (e) {
+          return {
+            stdout: "",
+            stderr: e instanceof Error ? e.message : String(e),
+            exitCode: 1,
+          };
         }
 
         return new Promise<{
@@ -120,7 +223,7 @@ async function buildCustomCommands(
             invocation.command,
             invocation.args,
             {
-              cwd: ctx.cwd,
+              cwd: hostCwd,
               env: envRecord,
               maxBuffer: 10 * 1024 * 1024,
             },
@@ -179,8 +282,19 @@ export async function createEmbeddedBashOps(
 ): Promise<BashOperations> {
   const { Bash, ReadWriteFs } = await import("just-bash");
 
-  const workspaceDir =
+  const rawWorkspaceDir =
     options.workspaceDir || process.env.WORKSPACE_DIR || "/workspace";
+  // Canonicalize so the sandbox profile, ReadWriteFs root, bind mounts, and
+  // realpath checks all see the same resolved path. macOS TMPDIR routes through
+  // /var → /private/var symlinks; without realpath, the SBPL allow rule and
+  // execFile cwd disagree.
+  let workspaceDir = rawWorkspaceDir;
+  try {
+    fs.mkdirSync(rawWorkspaceDir, { recursive: true });
+    workspaceDir = fs.realpathSync(rawWorkspaceDir);
+  } catch {
+    // Fall through with the raw value; downstream calls surface real errors.
+  }
   const bashFs = new ReadWriteFs({ root: workspaceDir });
 
   // Parse allowed domains from env var (set by gateway)
@@ -228,8 +342,21 @@ export async function createEmbeddedBashOps(
   for (const name of mcpCliNames) {
     binaries.delete(name);
   }
+  const sandboxStrategy = probeSandboxStrategy();
+  const sandboxCtx: SandboxContext = {
+    strategy: sandboxStrategy,
+    workspaceDir,
+    // Spawned binaries reach the network through HTTP_PROXY → gateway, which
+    // already enforces the per-agent domain allowlist. Letting the OS network
+    // namespace stay open lets curl/git/gh respect HTTP_PROXY normally.
+    allowNet: true,
+  };
   const binaryCommands =
-    binaries.size > 0 ? await buildCustomCommands(binaries) : [];
+    binaries.size > 0 ? await buildCustomCommands(binaries, sandboxCtx) : [];
+
+  if (sandboxStrategy.kind !== "none") {
+    console.log(`[embedded] exec sandbox active: kind=${sandboxStrategy.kind}`);
+  }
 
   const mcpCommandEntries = await Promise.all(
     mcpCliCommands.map((c) => adaptMcpCliCommand(c))

--- a/packages/worker/src/embedded/just-bash-bootstrap.ts
+++ b/packages/worker/src/embedded/just-bash-bootstrap.ts
@@ -36,6 +36,8 @@ export interface SandboxContext {
   /** Whether the spawned binary may open sockets. just-bash's domain allowlist
    * still gates the interpreter; this controls the OS network namespace. */
   allowNet?: boolean;
+  /** Per-invocation cwd inside bwrap's /workspace namespace. */
+  bwrapCwd?: string;
 }
 
 export function buildBinaryInvocation(
@@ -61,6 +63,7 @@ export function buildBinaryInvocation(
   return wrapInvocation(sandbox.strategy, inner, {
     workspaceDir: sandbox.workspaceDir,
     allowNet: sandbox.allowNet ?? true,
+    bwrapCwd: sandbox.bwrapCwd,
   });
 }
 
@@ -144,6 +147,17 @@ function ensureSandboxDir(workspaceDir: string, name: string): string {
   return dir;
 }
 
+function bwrapCwdForHostCwd(workspaceDir: string, hostCwd: string): string {
+  const rel = path.relative(workspaceDir, hostCwd);
+  if (!rel) return "/workspace";
+  if (rel.startsWith("..") || path.isAbsolute(rel)) {
+    throw new Error(
+      `[embedded] cwd ${JSON.stringify(hostCwd)} resolves outside workspace`
+    );
+  }
+  return path.posix.join("/workspace", ...rel.split(path.sep));
+}
+
 /**
  * Create just-bash customCommands from a map of binary name → full path.
  * Each custom command delegates to the real binary via child_process.execFile,
@@ -160,8 +174,6 @@ async function buildCustomCommands(
   for (const [name, binaryPath] of binaries) {
     commands.push(
       defineCommand(name, async (args: string[], ctx) => {
-        const invocation = buildBinaryInvocation(binaryPath, args, sandbox);
-
         const envRecord = stripEnv(process.env, SENSITIVE_WORKER_ENV_KEYS);
         if (ctx.env && typeof ctx.env.forEach === "function") {
           ctx.env.forEach((v: string, k: string) => {
@@ -204,8 +216,13 @@ async function buildCustomCommands(
         delete envRecord.no_proxy;
 
         let hostCwd: string;
+        let bwrapCwd: string | undefined;
         try {
           hostCwd = resolveHostCwd(sandbox.workspaceDir, ctx.cwd ?? "/");
+          bwrapCwd =
+            sandbox.strategy.kind === "bwrap"
+              ? bwrapCwdForHostCwd(sandbox.workspaceDir, hostCwd)
+              : undefined;
         } catch (e) {
           return {
             stdout: "",
@@ -213,6 +230,11 @@ async function buildCustomCommands(
             exitCode: 1,
           };
         }
+
+        const invocation = buildBinaryInvocation(binaryPath, args, {
+          ...sandbox,
+          bwrapCwd,
+        });
 
         return new Promise<{
           stdout: string;
@@ -336,13 +358,22 @@ export async function createEmbeddedBashOps(
   }
   const mcpCliNames = new Set(mcpCliCommands.map((c) => c.name));
 
+  const sandboxStrategy = probeSandboxStrategy();
+  const allowUnsandboxedExec =
+    process.env.LOBU_ALLOW_UNSANDBOXED_EXEC === "1" ||
+    process.env.LOBU_ALLOW_UNSANDBOXED_EXEC === "true";
+
+  const registerSpawnedBinaries =
+    sandboxStrategy.kind !== "none" || allowUnsandboxedExec;
+
   // Discover nix binaries and known CLI tools, register as custom commands.
   // Strip names claimed by MCP CLIs so the MCP-backed handler takes precedence.
-  const binaries = discoverBinaries();
+  const binaries = registerSpawnedBinaries
+    ? discoverBinaries()
+    : new Map<string, string>();
   for (const name of mcpCliNames) {
     binaries.delete(name);
   }
-  const sandboxStrategy = probeSandboxStrategy();
   const sandboxCtx: SandboxContext = {
     strategy: sandboxStrategy,
     workspaceDir,
@@ -356,6 +387,12 @@ export async function createEmbeddedBashOps(
 
   if (sandboxStrategy.kind !== "none") {
     console.log(`[embedded] exec sandbox active: kind=${sandboxStrategy.kind}`);
+  } else if (!allowUnsandboxedExec) {
+    console.warn(
+      `[embedded] Exec sandbox unavailable; not registering spawned binary ` +
+        `commands. Set LOBU_ALLOW_UNSANDBOXED_EXEC=1 to allow host-privileged ` +
+        `spawned binaries.`
+    );
   }
 
   const mcpCommandEntries = await Promise.all(


### PR DESCRIPTION
## Summary

just-bash's interpreter already roots file ops in `ReadWriteFs`, but spawned binaries (`gh`, `git`, `owletto`, `/nix/store/*`) bypass that — once `execFile` fires, the child has the host's full filesystem view. This wraps every custom-command spawn in an OS sandbox so the child sees only the workspace plus a curated set of read-only system paths.

- **macOS**: `sandbox-exec` with an allow-default SBPL profile that denies personal-data paths (`/Users`, `/etc`, `/Library/Keychains`, `/Library/Preferences`, `/var/run`, browser/mail/messages stores, etc.) and writes anywhere outside the workspace.
- **Linux**: `bubblewrap` with `--unshare-{user,pid,ipc,uts}` + `--new-session --die-with-parent`, only `/usr`, `/lib*`, `/bin`, `/sbin`, `/nix`, `/etc/resolv.conf`, and CA certs ro-bound. Workspace at `/workspace`, tmpfs `/tmp`. Probed at startup with a real `/bin/true` spawn — fails closed if user namespaces are blocked.
- **Fallback**: if neither is available, runs unsandboxed with a one-time warning. `OWLETTO_EXEC_SANDBOX={auto,bwrap,sandbox-exec,off}` overrides; explicit overrides fail loudly when the backend is missing.

Embedded-mode only; no Docker / Helm / K8s changes.

### Hardening (two pi review rounds)

- `workspaceDir` is realpath'd at boot so SBPL, `ReadWriteFs`, and bind mounts all see the canonical path (closes the macOS `/var → /private/var` symlink mismatch).
- `workspaceDir` is regex-validated and rejected if non-canonical (`..`, `//`, root, trailing slash) to prevent SBPL string-literal injection.
- `ctx.cwd` is realpath'd before every spawn; rejected if it escapes the workspace (defense in depth against an `allowSymlinks: true` upstream change).
- `HOME` and `TMPDIR` pinned to `.sandbox-home` / `.sandbox-tmp` subdirs — translated to the in-namespace `/workspace/...` path under bwrap.
- `HTTP_PROXY` / `HTTPS_PROXY` are forced from `process.env` after merging `ctx.env`; `NO_PROXY` is stripped — a malicious agent can't `export HTTP_PROXY=` to bypass the gateway egress allowlist.
- bwrap startup probe runs `--unshare-user` against `/bin/true`; if user namespaces are unavailable, returns `kind: "none"` with a warning instead of running with broken isolation.
- Probe cache is keyed by `(platform, env-override)` so changing `OWLETTO_EXEC_SANDBOX` mid-process doesn't return stale.

### Files

- **New**: `packages/worker/src/embedded/exec-sandbox.ts` (305 lines) — probe + wrap module.
- **Modified**: `packages/worker/src/embedded/just-bash-bootstrap.ts` — wires probe into `createEmbeddedBashOps`, applies sandbox in `buildCustomCommands`, realpaths `workspaceDir`, fixes virtual-cwd resolution.
- **New**: `packages/worker/src/__tests__/exec-sandbox.test.ts` — probe/wrap unit tests + live macOS escape matrix + Linux/bwrap escape matrix (skips when `bwrap` not on PATH so macOS dev runs cleanly; CI Linux runners with bubblewrap installed exercise the full block).
- **Modified**: `packages/worker/src/__tests__/embedded-just-bash-bootstrap.test.ts` — additional cases for the optional sandbox arg.

## Test plan

- [x] `bun test packages/worker/src/__tests__/` — 217 pass / 10 skip (the 10 skipped are bwrap tests that auto-run on Linux CI)
- [x] `bun run typecheck` — clean
- [x] macOS escape matrix verified locally: `/etc/passwd`, `~/.ssh/id_rsa`, `~/.aws/credentials`, traversal, symlink escape, write outside workspace, argv injection — all blocked. Workspace reads/writes / `$HOME` resolution — all pass.
- [ ] Linux/bwrap escape matrix — needs CI runner with `bubblewrap` on PATH; tests auto-skip otherwise.
- [ ] End-to-end: run a real agent thread that calls `gh`, `git`, `owletto` through the sandbox to confirm no behavioral regressions for legitimate flows.