### PR TITLE
fix(embedded): default MEMORY_URL so dispatcher service tokens validate

### DIFF
--- a/packages/owletto-backend/src/lobu/gateway.ts
+++ b/packages/owletto-backend/src/lobu/gateway.ts
@@ -220,6 +220,17 @@ export async function initLobuGateway(): Promise<Hono | null> {
     const publicUrl = new URL('/lobu/', publicWebUrl).toString().replace(/\/$/, '');
     const env = process.env as unknown as Env;
 
+    // Embedded gateway shares the process with the Owletto OIDC provider — use
+    // it as the external auth issuer. Without MEMORY_URL set,
+    // ExternalAuthClient.fromEnv() returns null and the api-auth-middleware
+    // can't validate service tokens, so every dispatcher → /lobu/api/v1/agents
+    // call gets a 401 (silently fails the watcher run). Point at the local
+    // public origin so OIDC discovery + /oauth/userinfo resolve to ourselves.
+    if (!process.env.MEMORY_URL) {
+      process.env.MEMORY_URL = publicWebUrl;
+      logger.info({ memoryUrl: publicWebUrl }, '[Lobu] Defaulted MEMORY_URL for embedded auth');
+    }
+
     const gatewayConfig = buildGatewayConfig({
       queues: { connectionString: redisUrl },
       orchestration: { deploymentMode: 'embedded' },


### PR DESCRIPTION
## Summary

In owletto-backend's embedded gateway path, \`MEMORY_URL\` was never set. \`ExternalAuthClient.fromEnv()\` returns null without it, so the gateway's api-auth-middleware has no way to validate service tokens via the external-OAuth path. Every \`dispatcher → /lobu/api/v1/agents\` call falls through to admin-password + worker-token, both reject the service token, watcher run fails with \`401: {\"success\":false,\"error\":\"Unauthorized\"}\`.

Discovered while validating the new Reddit Digest watcher I just configured in prod — every dispatch attempt 401'd. Ran a query on \`runs WHERE run_type = 'watcher' ORDER BY id DESC\`: this exact 401 has been killing every watcher run **for the past 9 days**, not just my new one. It was silently masked because the old dispatcher \`onResolve\` treated "agent replied" as success regardless of whether \`complete_window\` was actually called. #444's fail-closed change in \`watchers/automation.ts\` made it visible.

## Fix

Default \`MEMORY_URL\` to the local public origin (the same process that hosts the OIDC \`/oauth/userinfo\` endpoint) in \`initLobuGateway\`. The bridge then resolves to a loopback HTTP call against ourselves — discovery hits \`/.well-known/openid-configuration\` (already implemented), userinfo validates the freshly-issued service token. Existing \`MEMORY_URL\` env wins if set, so external deployments are unaffected.

## Test plan

- [x] Typecheck clean.
- [ ] Post-merge + deploy: insert a pending watcher run for #218 and confirm it claims, dispatches, and either completes or fails for a real reason (not auth).
- [ ] \`runs WHERE run_type = 'watcher' AND created_at > NOW() - INTERVAL '5 min'\` — no more 401 entries.