### PR TITLE
fix(owletto-backend): make classification reconciliation candidate query selective

### DIFF
--- a/packages/owletto-backend/src/scheduled/classification-reconciliation.ts
+++ b/packages/owletto-backend/src/scheduled/classification-reconciliation.ts
@@ -16,6 +16,7 @@
 
 import { getDb, pgTextArray } from '../db/client';
 import type { Env } from '../index';
+import { executeClassificationQuery } from '../utils/classification-query';
 import { entityLinkMatchSql } from '../utils/content-search';
 import logger from '../utils/logger';
 
@@ -62,12 +63,43 @@ export async function runClassificationReconciliation(_env: Env): Promise<{
   const sql = getDb();
 
   try {
-    // Candidate entities: have embedded content to classify.
+    // Candidate entities: have at least one recent embedded event missing a
+    // classification for one of their own enabled classifiers. The 7d window
+    // bounds the scan — fresh inserts are handled inline; this safety net
+    // only catches drift (worker crash, restore from backup). Entities that
+    // inherit classifiers (enabled_classifiers IS NULL) are skipped here on
+    // purpose: the inline path covers them, and a query that walked
+    // inheritance would defeat the GIN partial index on enabled_classifiers.
     const entities = await sql<EntityRow>`
-      SELECT DISTINCT e.id as entity_id
-      FROM entities e
-      JOIN current_event_records ev ON e.id = ANY(ev.entity_ids)
-      WHERE ev.embedding IS NOT NULL
+      SELECT DISTINCT ent.id AS entity_id
+      FROM entities ent
+      WHERE ent.enabled_classifiers IS NOT NULL
+        AND cardinality(ent.enabled_classifiers) > 0
+        AND EXISTS (
+          SELECT 1
+          FROM events e
+          JOIN event_embeddings emb ON emb.event_id = e.id
+          WHERE e.entity_ids @> ARRAY[ent.id]
+            AND e.created_at > now() - interval '7 days'
+            AND NOT EXISTS (
+              SELECT 1 FROM events newer WHERE newer.supersedes_event_id = e.id
+            )
+            AND EXISTS (
+              SELECT 1
+              FROM event_classifiers fc
+              JOIN event_classifier_versions fcv
+                ON fcv.classifier_id = fc.id AND fcv.is_current = true
+              WHERE fc.organization_id = ent.organization_id
+                AND fc.status = 'active'
+                AND fc.watcher_id IS NULL
+                AND fc.slug = ANY(ent.enabled_classifiers)
+                AND NOT EXISTS (
+                  SELECT 1 FROM event_classifications ec
+                  WHERE ec.event_id = e.id
+                    AND ec.classifier_version_id = fcv.id
+                )
+            )
+        )
       LIMIT ${MAX_ENTITIES_PER_RUN}
     `;
 
@@ -81,8 +113,6 @@ export async function runClassificationReconciliation(_env: Env): Promise<{
     logger.info(
       `[ClassificationReconciliation] Found ${entities.length} entities needing classification`
     );
-
-    const { executeClassificationQuery } = await import('../utils/classification-query');
 
     let totalClassified = 0;
 


### PR DESCRIPTION
## Summary

- `runClassificationReconciliation` candidate query owned ~65% of prod Postgres exec time (`pg_stat_statements`: 23,746 s cumulative, mean 22 s, 1075 calls). EXPLAIN ANALYZE: ~3M buffer hits + 20k disk reads to return the same 10 rows every tick — a parallel index-only scan over `idx_events_source_embedding` (~541k rows) + nested loops over `events_pkey`/`entities_pkey` + a merge anti-join on `idx_events_superseded_by`. The query selected entities with embedded content but never tied selection to the absence of expected classifications, so the real selectivity ran per-entity afterwards and almost always found nothing.
- Push the "missing classification for an enabled classifier" predicate into the candidate query, scoped to events from the last 7 days. The inline classification path covers fresh inserts; the reconciliation safety net only needs to catch drift (worker crash, restore from backup). 7d is sufficient because the cron tick runs every 60 s — even a one-day outage stays inside the window.
- Drives off `event_embeddings` + `idx_events_entity_ids` (GIN) + the partial GIN on `entities.enabled_classifiers` instead of joining the whole event graph. EXISTS chain short-circuits to zero rows when nothing is pending.
- Hoists the dynamic `await import('../utils/classification-query')` to a static import (no-dynamic-imports rule).

## Behavioral notes

- The candidate query now skips entities with `enabled_classifiers IS NULL` (inheritance-only). Those events are covered by the inline classification path; walking the parent chain in SQL would defeat the partial GIN index. The per-entity inner check (`getEnabledClassifiers` + `missingRows`) is unchanged and still resolves inheritance + identity-graph linking for entities the candidate query returns.
- The 7d window matches the safety-net intent. Older drift accumulates only under catastrophic conditions (DB restore from backup) and is already a manual recovery scenario.

## New candidate query

```sql
SELECT DISTINCT ent.id AS entity_id
FROM entities ent
WHERE ent.enabled_classifiers IS NOT NULL
  AND cardinality(ent.enabled_classifiers) > 0
  AND EXISTS (
    SELECT 1
    FROM events e
    JOIN event_embeddings emb ON emb.event_id = e.id
    WHERE e.entity_ids @> ARRAY[ent.id]
      AND e.created_at > now() - interval '7 days'
      AND NOT EXISTS (
        SELECT 1 FROM events newer WHERE newer.supersedes_event_id = e.id
      )
      AND EXISTS (
        SELECT 1
        FROM event_classifiers fc
        JOIN event_classifier_versions fcv
          ON fcv.classifier_id = fc.id AND fcv.is_current = true
        WHERE fc.organization_id = ent.organization_id
          AND fc.status = 'active'
          AND fc.watcher_id IS NULL
          AND fc.slug = ANY(ent.enabled_classifiers)
          AND NOT EXISTS (
            SELECT 1 FROM event_classifications ec
            WHERE ec.event_id = e.id
              AND ec.classifier_version_id = fcv.id
          )
      )
  )
LIMIT 10
```

## Test plan

- [ ] `bun run typecheck` passes (root)
- [ ] Watch `pg_stat_statements` for the rewritten statement: mean exec time should drop from ~22 s to <100 ms when there is no backlog; buffer hits should drop by orders of magnitude
- [ ] Confirm the cron still classifies real backlog entities when present (e.g. by manually deleting an `event_classifications` row for a recent embedded event and waiting one tick)