### PR TITLE
perf(events): fold visibility into get_content WHERE; drop entity lookup

### DIFF
--- a/packages/owletto-backend/src/__tests__/integration/events/get-content-visibility.test.ts
+++ b/packages/owletto-backend/src/__tests__/integration/events/get-content-visibility.test.ts
@@ -1,0 +1,364 @@
+/**
+ * Integration test: connection-visibility folding in `getContent`.
+ *
+ * Stream B of the atlas-events-fix plan dropped the two-step "first query
+ * private connections, then query visible connections" round trip. Visibility
+ * now lives inline in the list/count WHERE clause via
+ * `buildConnectionVisibilityClause`. This file pins the semantics:
+ *
+ *   - Authed user sees connections with visibility='org' OR created_by=userId.
+ *   - Unauthed sees only visibility='org'.
+ *   - Soft-deleted connections (deleted_at IS NOT NULL) are hidden in both
+ *     cases, even when they're the user's own.
+ *   - Events with connection_id IS NULL (system / non-connection events) are
+ *     visible to authed and unauthed callers.
+ *   - Pagination count matches list cardinality.
+ *   - The default response carries no `view_url` (entity lookup deleted) and
+ *     no `classification_stats` (stats are now opt-in via
+ *     `include_classification: 'summary'`).
+ *
+ * NOTE: vitest is not yet wired into CI for this package. Stream C will fix
+ * that. Until then, these tests run locally against the dev Postgres.
+ */
+
+import { beforeAll, describe, expect, it } from 'vitest';
+import { getContent } from '../../../tools/get_content';
+import type { ToolContext } from '../../../tools/registry';
+import { initWorkspaceProvider } from '../../../workspace';
+import { cleanupTestDatabase, getTestDb } from '../../setup/test-db';
+import {
+  addUserToOrganization,
+  createTestConnection,
+  createTestConnectorDefinition,
+  createTestEntity,
+  createTestEvent,
+  createTestOrganization,
+  createTestUser,
+  seedSystemEntityTypes,
+} from '../../setup/test-fixtures';
+
+describe('getContent > connection visibility folded into WHERE', () => {
+  let org: Awaited<ReturnType<typeof createTestOrganization>>;
+  let aliceUser: Awaited<ReturnType<typeof createTestUser>>;
+  let bobUser: Awaited<ReturnType<typeof createTestUser>>;
+  let entity: Awaited<ReturnType<typeof createTestEntity>>;
+
+  let orgConnId: number;
+  let alicePrivateConnId: number;
+  let bobPrivateConnId: number;
+  let deletedAlicePrivateConnId: number;
+
+  let orgEventId: number;
+  let alicePrivateEventId: number;
+  let bobPrivateEventId: number;
+  let deletedAlicePrivateEventId: number;
+  let systemEventId: number;
+
+  function authedCtx(userId: string): ToolContext {
+    return {
+      organizationId: org.id,
+      userId,
+      memberRole: 'owner',
+      isAuthenticated: true,
+      tokenType: 'oauth',
+      scopedToOrg: false,
+      allowCrossOrg: true,
+      scopes: ['mcp:read'],
+    };
+  }
+
+  function unauthedCtx(): ToolContext {
+    return {
+      organizationId: org.id,
+      userId: null,
+      memberRole: null,
+      isAuthenticated: false,
+      tokenType: 'anonymous',
+      scopedToOrg: true,
+      allowCrossOrg: false,
+    };
+  }
+
+  beforeAll(async () => {
+    await initWorkspaceProvider();
+    await cleanupTestDatabase();
+    await seedSystemEntityTypes();
+
+    org = await createTestOrganization({ name: 'Visibility Org' });
+    aliceUser = await createTestUser({ email: 'alice-vis@example.com' });
+    bobUser = await createTestUser({ email: 'bob-vis@example.com' });
+    await addUserToOrganization(aliceUser.id, org.id, 'owner');
+    await addUserToOrganization(bobUser.id, org.id, 'owner');
+
+    entity = await createTestEntity({
+      name: 'Visibility Entity',
+      organization_id: org.id,
+    });
+
+    await createTestConnectorDefinition({
+      key: 'vis-test-connector',
+      name: 'Vis Test',
+      organization_id: org.id,
+    });
+
+    // Org-visible connection — anyone in the org may read its events.
+    const orgConn = await createTestConnection({
+      organization_id: org.id,
+      connector_key: 'vis-test-connector',
+      entity_ids: [entity.id],
+      visibility: 'org',
+      created_by: aliceUser.id,
+      display_name: 'Org-visible',
+    });
+    orgConnId = orgConn.id;
+
+    // Alice's private connection — only Alice (and presumably admins, but
+    // memberRole isn't part of the fold) sees its events when authed; Bob
+    // and unauthed callers do not.
+    const alicePrivConn = await createTestConnection({
+      organization_id: org.id,
+      connector_key: 'vis-test-connector',
+      entity_ids: [entity.id],
+      visibility: 'private',
+      created_by: aliceUser.id,
+      display_name: 'Alice private',
+    });
+    alicePrivateConnId = alicePrivConn.id;
+
+    // Bob's private connection — Alice and unauthed should not see its events.
+    const bobPrivConn = await createTestConnection({
+      organization_id: org.id,
+      connector_key: 'vis-test-connector',
+      entity_ids: [entity.id],
+      visibility: 'private',
+      created_by: bobUser.id,
+      display_name: 'Bob private',
+    });
+    bobPrivateConnId = bobPrivConn.id;
+
+    // Soft-deleted version of an Alice-private connection. The fold filters
+    // on deleted_at IS NULL, so even Alice should not see its events.
+    const deletedAlicePrivConn = await createTestConnection({
+      organization_id: org.id,
+      connector_key: 'vis-test-connector',
+      entity_ids: [entity.id],
+      visibility: 'private',
+      created_by: aliceUser.id,
+      display_name: 'Alice private (deleted)',
+    });
+    deletedAlicePrivateConnId = deletedAlicePrivConn.id;
+    const sql = getTestDb();
+    await sql`
+      UPDATE connections SET deleted_at = NOW()
+      WHERE id = ${deletedAlicePrivateConnId}
+    `;
+
+    orgEventId = (
+      await createTestEvent({
+        organization_id: org.id,
+        entity_id: entity.id,
+        connection_id: orgConnId,
+        content: 'org-visible connection event',
+      })
+    ).id;
+
+    alicePrivateEventId = (
+      await createTestEvent({
+        organization_id: org.id,
+        entity_id: entity.id,
+        connection_id: alicePrivateConnId,
+        content: 'event from alice private connection',
+      })
+    ).id;
+
+    bobPrivateEventId = (
+      await createTestEvent({
+        organization_id: org.id,
+        entity_id: entity.id,
+        connection_id: bobPrivateConnId,
+        content: 'event from bob private connection',
+      })
+    ).id;
+
+    deletedAlicePrivateEventId = (
+      await createTestEvent({
+        organization_id: org.id,
+        entity_id: entity.id,
+        connection_id: deletedAlicePrivateConnId,
+        content: 'event from deleted alice private connection',
+      })
+    ).id;
+
+    // System event: no connection at all. Must be visible to both authed
+    // and unauthed callers under the new fold.
+    systemEventId = (
+      await createTestEvent({
+        organization_id: org.id,
+        entity_id: entity.id,
+        connection_id: undefined,
+        content: 'system event with no connection',
+      })
+    ).id;
+  });
+
+  it('authed user sees their own private connection events plus org events plus system events', async () => {
+    const result = await getContent(
+      { entity_id: entity.id, limit: 100, sort_by: 'date', sort_order: 'desc' } as never,
+      {} as never,
+      authedCtx(aliceUser.id)
+    );
+    const visibleIds = new Set(result.content.map((c) => c.id));
+
+    expect(visibleIds.has(orgEventId)).toBe(true);
+    expect(visibleIds.has(alicePrivateEventId)).toBe(true);
+    expect(visibleIds.has(systemEventId)).toBe(true);
+
+    // Other user's private connection: hidden.
+    expect(visibleIds.has(bobPrivateEventId)).toBe(false);
+    // Soft-deleted connection: hidden even though Alice owns it.
+    expect(visibleIds.has(deletedAlicePrivateEventId)).toBe(false);
+  });
+
+  it('authed user does NOT see other users private connection events', async () => {
+    const result = await getContent(
+      { entity_id: entity.id, limit: 100, sort_by: 'date', sort_order: 'desc' } as never,
+      {} as never,
+      authedCtx(bobUser.id)
+    );
+    const visibleIds = new Set(result.content.map((c) => c.id));
+
+    expect(visibleIds.has(bobPrivateEventId)).toBe(true);
+    expect(visibleIds.has(orgEventId)).toBe(true);
+    expect(visibleIds.has(systemEventId)).toBe(true);
+    expect(visibleIds.has(alicePrivateEventId)).toBe(false);
+  });
+
+  it('unauthed caller sees only org-visible connection events plus system events', async () => {
+    const result = await getContent(
+      { entity_id: entity.id, limit: 100, sort_by: 'date', sort_order: 'desc' } as never,
+      {} as never,
+      unauthedCtx()
+    );
+    const visibleIds = new Set(result.content.map((c) => c.id));
+
+    expect(visibleIds.has(orgEventId)).toBe(true);
+    expect(visibleIds.has(systemEventId)).toBe(true);
+    expect(visibleIds.has(alicePrivateEventId)).toBe(false);
+    expect(visibleIds.has(bobPrivateEventId)).toBe(false);
+    expect(visibleIds.has(deletedAlicePrivateEventId)).toBe(false);
+  });
+
+  it('total count matches list cardinality across cursor-driven pagination', async () => {
+    const ctx = authedCtx(aliceUser.id);
+
+    // The chronological feed (sort_by=date + sort_order=desc) uses cursor
+    // pagination, not offset, so we walk it via before_occurred_at/before_id
+    // the same way the events tab does in production.
+    const page1 = await getContent(
+      {
+        entity_id: entity.id,
+        limit: 2,
+        sort_by: 'date',
+        sort_order: 'desc',
+      } as never,
+      {} as never,
+      ctx
+    );
+    expect(page1.total).toBe(3);
+    expect(page1.content.length).toBe(2);
+    expect(page1.page.has_older).toBe(true);
+
+    const last = page1.content[page1.content.length - 1];
+    const page2 = await getContent(
+      {
+        entity_id: entity.id,
+        limit: 2,
+        sort_by: 'date',
+        sort_order: 'desc',
+        before_occurred_at: last.occurred_at,
+        before_id: last.id,
+      } as never,
+      {} as never,
+      ctx
+    );
+    expect(page2.total).toBe(3);
+
+    const collected = new Set([
+      ...page1.content.map((c) => c.id),
+      ...page2.content.map((c) => c.id),
+    ]);
+    expect(collected.size).toBe(3);
+    expect(collected.has(orgEventId)).toBe(true);
+    expect(collected.has(alicePrivateEventId)).toBe(true);
+    expect(collected.has(systemEventId)).toBe(true);
+  });
+});
+
+describe('getContent > response shape (no view_url, stats opt-in)', () => {
+  let org: Awaited<ReturnType<typeof createTestOrganization>>;
+  let user: Awaited<ReturnType<typeof createTestUser>>;
+  let emptyEntity: Awaited<ReturnType<typeof createTestEntity>>;
+
+  function ctx(): ToolContext {
+    return {
+      organizationId: org.id,
+      userId: user.id,
+      memberRole: 'owner',
+      isAuthenticated: true,
+      tokenType: 'oauth',
+      scopedToOrg: false,
+      allowCrossOrg: true,
+      scopes: ['mcp:read'],
+    };
+  }
+
+  beforeAll(async () => {
+    await initWorkspaceProvider();
+    await cleanupTestDatabase();
+    await seedSystemEntityTypes();
+
+    org = await createTestOrganization({ name: 'Shape Org' });
+    user = await createTestUser({ email: 'shape@example.com' });
+    await addUserToOrganization(user.id, org.id, 'owner');
+
+    emptyEntity = await createTestEntity({
+      name: 'Empty Entity',
+      organization_id: org.id,
+    });
+  });
+
+  it('empty entity returns content=[], total=0, no view_url, no classification_stats by default', async () => {
+    const result = await getContent(
+      { entity_id: emptyEntity.id, limit: 50, sort_by: 'date', sort_order: 'desc' } as never,
+      {} as never,
+      ctx()
+    );
+
+    expect(result.content).toEqual([]);
+    expect(result.total).toBe(0);
+    expect((result as { view_url?: string }).view_url).toBeUndefined();
+    expect(result.classification_stats).toBeUndefined();
+  });
+
+  it('classification_stats is populated only when include_classification=summary is set', async () => {
+    const withStats = await getContent(
+      {
+        entity_id: emptyEntity.id,
+        limit: 50,
+        include_classification: 'summary',
+        sort_by: 'date',
+        sort_order: 'desc',
+      } as never,
+      {} as never,
+      ctx()
+    );
+    expect(withStats.classification_stats).toBeDefined();
+
+    const withoutStats = await getContent(
+      { entity_id: emptyEntity.id, limit: 50, sort_by: 'date', sort_order: 'desc' } as never,
+      {} as never,
+      ctx()
+    );
+    expect(withoutStats.classification_stats).toBeUndefined();
+  });
+});

--- a/packages/owletto-backend/src/__tests__/integration/events/get-content-visibility.test.ts
+++ b/packages/owletto-backend/src/__tests__/integration/events/get-content-visibility.test.ts
@@ -3,7 +3,8 @@
  *
  * Stream B of the atlas-events-fix plan dropped the two-step "first query
  * private connections, then query visible connections" round trip. Visibility
- * now lives inline in the list/count WHERE clause via
+ * now lives inline in the list/count WHERE clause of every query branch
+ * (`chronological list`, `content_ids`, `include_superseded`, `score`) via
  * `buildConnectionVisibilityClause`. This file pins the semantics:
  *
  *   - Authed user sees connections with visibility='org' OR created_by=userId.
@@ -13,9 +14,12 @@
  *   - Events with connection_id IS NULL (system / non-connection events) are
  *     visible to authed and unauthed callers.
  *   - Pagination count matches list cardinality.
- *   - The default response carries no `view_url` (entity lookup deleted) and
- *     no `classification_stats` (stats are now opt-in via
- *     `include_classification: 'summary'`).
+ *   - The four query branches (chronological list, `content_ids`,
+ *     `include_superseded`, `sort_by=score`) all enforce the same predicate.
+ *   - `view_url` is populated for entity-scoped requests so LLM agents
+ *     reading the response over MCP can include it in chat replies.
+ *   - `classification_stats` only appears when the caller explicitly passes
+ *     `include_classification: 'summary'`.
  *
  * NOTE: vitest is not yet wired into CI for this package. Stream C will fix
  * that. Until then, these tests run locally against the dev Postgres.
@@ -294,7 +298,7 @@ describe('getContent > connection visibility folded into WHERE', () => {
   });
 });
 
-describe('getContent > response shape (no view_url, stats opt-in)', () => {
+describe('getContent > response shape (view_url present, stats opt-in)', () => {
   let org: Awaited<ReturnType<typeof createTestOrganization>>;
   let user: Awaited<ReturnType<typeof createTestUser>>;
   let emptyEntity: Awaited<ReturnType<typeof createTestEntity>>;
@@ -327,7 +331,7 @@ describe('getContent > response shape (no view_url, stats opt-in)', () => {
     });
   });
 
-  it('empty entity returns content=[], total=0, no view_url, no classification_stats by default', async () => {
+  it('empty entity returns content=[], total=0, view_url populated, no classification_stats by default', async () => {
     const result = await getContent(
       { entity_id: emptyEntity.id, limit: 50, sort_by: 'date', sort_order: 'desc' } as never,
       {} as never,
@@ -336,7 +340,11 @@ describe('getContent > response shape (no view_url, stats opt-in)', () => {
 
     expect(result.content).toEqual([]);
     expect(result.total).toBe(0);
-    expect((result as { view_url?: string }).view_url).toBeUndefined();
+    // view_url is consumed by LLM agents reading read_knowledge over MCP.
+    // It must always be populated when an entity is in scope.
+    const viewUrl = (result as { view_url?: string }).view_url;
+    expect(typeof viewUrl).toBe('string');
+    expect(viewUrl).toMatch(/^https?:\/\//);
     expect(result.classification_stats).toBeUndefined();
   });
 
@@ -360,5 +368,161 @@ describe('getContent > response shape (no view_url, stats opt-in)', () => {
       ctx()
     );
     expect(withoutStats.classification_stats).toBeUndefined();
+  });
+});
+
+describe('getContent > visibility on sibling branches (content_ids/include_superseded/score)', () => {
+  let org: Awaited<ReturnType<typeof createTestOrganization>>;
+  let aliceUser: Awaited<ReturnType<typeof createTestUser>>;
+  let bobUser: Awaited<ReturnType<typeof createTestUser>>;
+  let entity: Awaited<ReturnType<typeof createTestEntity>>;
+
+  let orgEventId: number;
+  let alicePrivateEventId: number;
+  let bobPrivateEventId: number;
+
+  function authedCtx(userId: string): ToolContext {
+    return {
+      organizationId: org.id,
+      userId,
+      memberRole: 'owner',
+      isAuthenticated: true,
+      tokenType: 'oauth',
+      scopedToOrg: false,
+      allowCrossOrg: true,
+      scopes: ['mcp:read'],
+    };
+  }
+
+  beforeAll(async () => {
+    await initWorkspaceProvider();
+    await cleanupTestDatabase();
+    await seedSystemEntityTypes();
+
+    org = await createTestOrganization({ name: 'Sibling Branch Org' });
+    aliceUser = await createTestUser({ email: 'alice-branches@example.com' });
+    bobUser = await createTestUser({ email: 'bob-branches@example.com' });
+    await addUserToOrganization(aliceUser.id, org.id, 'owner');
+    await addUserToOrganization(bobUser.id, org.id, 'owner');
+
+    entity = await createTestEntity({
+      name: 'Sibling Branch Entity',
+      organization_id: org.id,
+    });
+
+    await createTestConnectorDefinition({
+      key: 'branch-test-connector',
+      name: 'Branch Test',
+      organization_id: org.id,
+    });
+
+    const orgConn = await createTestConnection({
+      organization_id: org.id,
+      connector_key: 'branch-test-connector',
+      entity_ids: [entity.id],
+      visibility: 'org',
+      created_by: aliceUser.id,
+      display_name: 'Branch org-visible',
+    });
+    const alicePriv = await createTestConnection({
+      organization_id: org.id,
+      connector_key: 'branch-test-connector',
+      entity_ids: [entity.id],
+      visibility: 'private',
+      created_by: aliceUser.id,
+      display_name: 'Branch alice-private',
+    });
+    const bobPriv = await createTestConnection({
+      organization_id: org.id,
+      connector_key: 'branch-test-connector',
+      entity_ids: [entity.id],
+      visibility: 'private',
+      created_by: bobUser.id,
+      display_name: 'Branch bob-private',
+    });
+
+    orgEventId = (
+      await createTestEvent({
+        organization_id: org.id,
+        entity_id: entity.id,
+        connection_id: orgConn.id,
+        content: 'branch org event',
+      })
+    ).id;
+    alicePrivateEventId = (
+      await createTestEvent({
+        organization_id: org.id,
+        entity_id: entity.id,
+        connection_id: alicePriv.id,
+        content: 'branch alice-private event',
+      })
+    ).id;
+    bobPrivateEventId = (
+      await createTestEvent({
+        organization_id: org.id,
+        entity_id: entity.id,
+        connection_id: bobPriv.id,
+        content: 'branch bob-private event',
+      })
+    ).id;
+  });
+
+  it('content_ids branch: requesting another user\'s private event by id returns nothing', async () => {
+    const result = await getContent(
+      {
+        entity_id: entity.id,
+        content_ids: [orgEventId, alicePrivateEventId, bobPrivateEventId],
+        limit: 100,
+      } as never,
+      {} as never,
+      authedCtx(aliceUser.id)
+    );
+    const visibleIds = new Set(result.content.map((c) => c.id));
+
+    // Alice sees the org event and her own private event …
+    expect(visibleIds.has(orgEventId)).toBe(true);
+    expect(visibleIds.has(alicePrivateEventId)).toBe(true);
+    // … but Bob's private event is filtered out even though Alice asked for it by ID.
+    expect(visibleIds.has(bobPrivateEventId)).toBe(false);
+    // total mirrors the visible set, not the requested set.
+    expect(result.total).toBe(2);
+  });
+
+  it('include_superseded branch: another user\'s private events stay hidden in the historical listing', async () => {
+    const result = await getContent(
+      {
+        entity_id: entity.id,
+        include_superseded: true,
+        limit: 100,
+      } as never,
+      {} as never,
+      authedCtx(aliceUser.id)
+    );
+    const visibleIds = new Set(result.content.map((c) => c.id));
+
+    expect(visibleIds.has(orgEventId)).toBe(true);
+    expect(visibleIds.has(alicePrivateEventId)).toBe(true);
+    expect(visibleIds.has(bobPrivateEventId)).toBe(false);
+  });
+
+  it('score branch: another user\'s private events stay hidden when sorting by score', async () => {
+    const result = await getContent(
+      {
+        entity_id: entity.id,
+        sort_by: 'score',
+        limit: 100,
+      } as never,
+      {} as never,
+      authedCtx(aliceUser.id)
+    );
+    const visibleIds = new Set(result.content.map((c) => c.id));
+
+    expect(visibleIds.has(orgEventId)).toBe(true);
+    expect(visibleIds.has(alicePrivateEventId)).toBe(true);
+    expect(visibleIds.has(bobPrivateEventId)).toBe(false);
+    // Count must match list cardinality on the score path too — the legacy
+    // bug leaked Bob's private event into both list and count when the user
+    // didn't pass connection_ids.
+    expect(result.total).toBe(2);
   });
 });

--- a/packages/owletto-backend/src/__tests__/integration/events/get-content-visibility.test.ts
+++ b/packages/owletto-backend/src/__tests__/integration/events/get-content-visibility.test.ts
@@ -593,11 +593,10 @@ describe('getContent > visibility matrix on sibling branches (content_ids/includ
   it.each(BRANCH_CASES)(
     '$branch: unauthed caller sees only org-visible + system events; private events hidden',
     async (spec) => {
-      // include_superseded requires authed access (entity-scoped + has its own
-      // validation), so unauthed is exercised only on the other two branches
-      // that actually run for anonymous public-org reads.
-      if (spec.branch === 'include_superseded') return;
-
+      // requireReadAccess (organization-access.ts:36-48) lets unauthed
+      // callers read entities whose org matches ctx.organizationId, so all
+      // three sibling branches are reachable from an unauthed test caller —
+      // including include_superseded, which only requires entity_id.
       const allIds = [orgEventId, alicePrivateEventId, bobPrivateEventId, systemEventId];
       const result = await getContent(
         buildArgs(spec, allIds) as never,

--- a/packages/owletto-backend/src/__tests__/integration/events/get-content-visibility.test.ts
+++ b/packages/owletto-backend/src/__tests__/integration/events/get-content-visibility.test.ts
@@ -31,6 +31,7 @@
  */
 
 import { beforeAll, describe, expect, it } from 'vitest';
+import { getDb } from '../../../db/client';
 import { getContent } from '../../../tools/get_content';
 import type { ToolContext } from '../../../tools/registry';
 import { initWorkspaceProvider } from '../../../workspace';
@@ -890,5 +891,133 @@ describe('getContent > visibility on the search / query path', () => {
     ]);
     expect(collected.size).toBe(3);
     expect(collected.has(bobPrivateEventId)).toBe(false);
+  });
+});
+
+describe('getContent > empty-entity short-circuit (perf regression guard)', () => {
+  // pi CLI flagged the empty-entity case at 8.4s on real data even after
+  // dropping the classification stats CTE. The dominant cost was the
+  // enrichment chain — thread_meta (recursive), latest_classifications,
+  // parent/root LEFT JOINs — all running BEFORE the planner discovered the
+  // candidate set was empty. Fix: when the cheap count returns 0, skip the
+  // enrichment query entirely. This pins both halves of the contract:
+  //   1. Empty entity hits zero "heavy enrichment" SQL (the chain that
+  //      contains `candidate_set`/`thread_meta`/`latest_classifications`).
+  //   2. Non-empty entity still issues the enrichment query and returns
+  //      content with the same shape as before.
+  let org: Awaited<ReturnType<typeof createTestOrganization>>;
+  let user: Awaited<ReturnType<typeof createTestUser>>;
+  let emptyEntity: Awaited<ReturnType<typeof createTestEntity>>;
+  let populatedEntity: Awaited<ReturnType<typeof createTestEntity>>;
+
+  function ctx(): ToolContext {
+    return {
+      organizationId: org.id,
+      userId: user.id,
+      memberRole: 'owner',
+      isAuthenticated: true,
+      tokenType: 'oauth',
+      scopedToOrg: false,
+      allowCrossOrg: true,
+      scopes: ['mcp:read'],
+    };
+  }
+
+  /**
+   * Wrap `sql.unsafe` to capture the SQL text of every query issued during
+   * the wrapped function's execution. Restores the original method on the
+   * way out so subsequent tests aren't affected.
+   */
+  async function captureUnsafeSql<T>(fn: () => Promise<T>): Promise<{
+    result: T;
+    queries: string[];
+  }> {
+    const sql = getDb() as unknown as {
+      unsafe: (...args: unknown[]) => Promise<unknown>;
+    };
+    const original = sql.unsafe.bind(sql);
+    const queries: string[] = [];
+    sql.unsafe = ((query: string, ...rest: unknown[]) => {
+      queries.push(query);
+      return original(query, ...rest);
+    }) as typeof sql.unsafe;
+    try {
+      const result = await fn();
+      return { result, queries };
+    } finally {
+      sql.unsafe = original;
+    }
+  }
+
+  beforeAll(async () => {
+    await initWorkspaceProvider();
+    await cleanupTestDatabase();
+    await seedSystemEntityTypes();
+
+    org = await createTestOrganization({ name: 'Perf Org' });
+    user = await createTestUser({ email: 'perf@example.com' });
+    await addUserToOrganization(user.id, org.id, 'owner');
+
+    emptyEntity = await createTestEntity({
+      name: 'Empty Perf Entity',
+      organization_id: org.id,
+    });
+    populatedEntity = await createTestEntity({
+      name: 'Populated Perf Entity',
+      organization_id: org.id,
+    });
+
+    // Seed a single event on the populated entity so the non-empty branch
+    // actually runs the enrichment query.
+    await createTestEvent({
+      organization_id: org.id,
+      entity_id: populatedEntity.id,
+      content: 'perf-test event with payload to enrich',
+    });
+  });
+
+  it('empty entity: skips the heavy enrichment query (no candidate_set/thread_meta/latest_classifications scan)', async () => {
+    const { result, queries } = await captureUnsafeSql(() =>
+      getContent(
+        { entity_id: emptyEntity.id, limit: 50, sort_by: 'date', sort_order: 'desc' } as never,
+        {} as never,
+        ctx()
+      )
+    );
+
+    expect(result.content).toEqual([]);
+    expect(result.total).toBe(0);
+
+    // The hot enrichment query is identifiable by its CTE names. None of
+    // them should appear in any SQL issued for an empty entity.
+    const heavyQueries = queries.filter(
+      (q) =>
+        q.includes('candidate_set') ||
+        q.includes('thread_meta') ||
+        q.includes('latest_classifications')
+    );
+    expect(heavyQueries).toEqual([]);
+  });
+
+  it('populated entity: still issues the enrichment query and returns full content shape', async () => {
+    const { result, queries } = await captureUnsafeSql(() =>
+      getContent(
+        { entity_id: populatedEntity.id, limit: 50, sort_by: 'date', sort_order: 'desc' } as never,
+        {} as never,
+        ctx()
+      )
+    );
+
+    expect(result.total).toBe(1);
+    expect(result.content).toHaveLength(1);
+    expect(result.content[0].payload_text).toContain('perf-test event');
+
+    // The enrichment query MUST fire for non-empty results — pin it so a
+    // future refactor that "optimizes" by skipping enrichment universally
+    // doesn't silently regress the response shape.
+    const heavyQueries = queries.filter(
+      (q) => q.includes('candidate_set') || q.includes('thread_meta')
+    );
+    expect(heavyQueries.length).toBeGreaterThan(0);
   });
 });

--- a/packages/owletto-backend/src/__tests__/integration/events/get-content-visibility.test.ts
+++ b/packages/owletto-backend/src/__tests__/integration/events/get-content-visibility.test.ts
@@ -3,9 +3,10 @@
  *
  * Stream B of the atlas-events-fix plan dropped the two-step "first query
  * private connections, then query visible connections" round trip. Visibility
- * now lives inline in the list/count WHERE clause of every query branch
- * (`chronological list`, `content_ids`, `include_superseded`, `score`) via
- * `buildConnectionVisibilityClause`. This file pins the semantics:
+ * now lives inline in the list/count WHERE clause of every query branch in
+ * `get_content.ts` plus the search/text-query path in `content-search.ts`,
+ * all using the same `buildConnectionVisibilityClause` helper. This file
+ * pins the semantics:
  *
  *   - Authed user sees connections with visibility='org' OR created_by=userId.
  *   - Unauthed sees only visibility='org'.
@@ -14,8 +15,12 @@
  *   - Events with connection_id IS NULL (system / non-connection events) are
  *     visible to authed and unauthed callers.
  *   - Pagination count matches list cardinality.
- *   - The four query branches (chronological list, `content_ids`,
- *     `include_superseded`, `sort_by=score`) all enforce the same predicate.
+ *   - All five query branches enforce the same predicate:
+ *       1. chronological list (sort_by=date, no query)
+ *       2. content_ids
+ *       3. include_superseded
+ *       4. sort_by=score
+ *       5. search / text-query (`query` arg set — `searchContentBySingleQuery`)
  *   - `view_url` is populated for entity-scoped requests so LLM agents
  *     reading the response over MCP can include it in chat replies.
  *   - `classification_stats` only appears when the caller explicitly passes
@@ -371,7 +376,7 @@ describe('getContent > response shape (view_url present, stats opt-in)', () => {
   });
 });
 
-describe('getContent > visibility on sibling branches (content_ids/include_superseded/score)', () => {
+describe('getContent > visibility matrix on sibling branches (content_ids/include_superseded/score)', () => {
   let org: Awaited<ReturnType<typeof createTestOrganization>>;
   let aliceUser: Awaited<ReturnType<typeof createTestUser>>;
   let bobUser: Awaited<ReturnType<typeof createTestUser>>;
@@ -380,6 +385,8 @@ describe('getContent > visibility on sibling branches (content_ids/include_super
   let orgEventId: number;
   let alicePrivateEventId: number;
   let bobPrivateEventId: number;
+  let systemEventId: number;
+  let deletedConnEventId: number;
 
   function authedCtx(userId: string): ToolContext {
     return {
@@ -391,6 +398,18 @@ describe('getContent > visibility on sibling branches (content_ids/include_super
       scopedToOrg: false,
       allowCrossOrg: true,
       scopes: ['mcp:read'],
+    };
+  }
+
+  function unauthedCtx(): ToolContext {
+    return {
+      organizationId: org.id,
+      userId: null,
+      memberRole: null,
+      isAuthenticated: false,
+      tokenType: 'anonymous',
+      scopedToOrg: true,
+      allowCrossOrg: false,
     };
   }
 
@@ -440,6 +459,16 @@ describe('getContent > visibility on sibling branches (content_ids/include_super
       created_by: bobUser.id,
       display_name: 'Branch bob-private',
     });
+    const deletedConn = await createTestConnection({
+      organization_id: org.id,
+      connector_key: 'branch-test-connector',
+      entity_ids: [entity.id],
+      visibility: 'org',
+      created_by: aliceUser.id,
+      display_name: 'Branch deleted',
+    });
+    const sql = getTestDb();
+    await sql`UPDATE connections SET deleted_at = NOW() WHERE id = ${deletedConn.id}`;
 
     orgEventId = (
       await createTestEvent({
@@ -465,47 +494,165 @@ describe('getContent > visibility on sibling branches (content_ids/include_super
         content: 'branch bob-private event',
       })
     ).id;
+    // System event: connection_id IS NULL. Must always be visible.
+    systemEventId = (
+      await createTestEvent({
+        organization_id: org.id,
+        entity_id: entity.id,
+        connection_id: undefined,
+        content: 'branch system event',
+      })
+    ).id;
+    // Event from a soft-deleted connection. Must always be hidden, even
+    // though the connection is org-visible and Alice owns it.
+    deletedConnEventId = (
+      await createTestEvent({
+        organization_id: org.id,
+        entity_id: entity.id,
+        connection_id: deletedConn.id,
+        content: 'branch deleted-conn event',
+      })
+    ).id;
   });
 
-  it('content_ids branch: requesting another user\'s private event by id returns nothing', async () => {
-    const result = await getContent(
-      {
-        entity_id: entity.id,
-        content_ids: [orgEventId, alicePrivateEventId, bobPrivateEventId],
+  // Branch-shape descriptors: `args` carry only the bits that select a branch
+  // (content_ids → content_ids; include_superseded → include_superseded;
+  // score → sort_by='score'). Visibility tests assert the same predicate
+  // across all three.
+  const BRANCH_CASES = [
+    {
+      branch: 'content_ids',
+      makeArgs: (eventIds: number[]) => ({
+        entity_id: undefined as number | undefined,
+        content_ids: eventIds,
         limit: 100,
-      } as never,
-      {} as never,
-      authedCtx(aliceUser.id)
-    );
-    const visibleIds = new Set(result.content.map((c) => c.id));
-
-    // Alice sees the org event and her own private event …
-    expect(visibleIds.has(orgEventId)).toBe(true);
-    expect(visibleIds.has(alicePrivateEventId)).toBe(true);
-    // … but Bob's private event is filtered out even though Alice asked for it by ID.
-    expect(visibleIds.has(bobPrivateEventId)).toBe(false);
-    // total mirrors the visible set, not the requested set.
-    expect(result.total).toBe(2);
-  });
-
-  it('include_superseded branch: another user\'s private events stay hidden in the historical listing', async () => {
-    const result = await getContent(
-      {
-        entity_id: entity.id,
+      }),
+      // content_ids needs the explicit ID set so we pass all candidate IDs.
+      includesAllByDefault: false,
+    },
+    {
+      branch: 'include_superseded',
+      makeArgs: (_eventIds: number[]) => ({
+        entity_id: 'ENTITY' as const,
         include_superseded: true,
         limit: 100,
+      }),
+      includesAllByDefault: true,
+    },
+    {
+      branch: 'score',
+      makeArgs: (_eventIds: number[]) => ({
+        entity_id: 'ENTITY' as const,
+        sort_by: 'score' as const,
+        limit: 100,
+      }),
+      includesAllByDefault: true,
+    },
+  ];
+
+  function buildArgs(spec: (typeof BRANCH_CASES)[number], allEventIds: number[]) {
+    const args = spec.makeArgs(allEventIds) as Record<string, unknown>;
+    if (args.entity_id === 'ENTITY') {
+      args.entity_id = entity.id;
+    }
+    return args;
+  }
+
+  it.each(BRANCH_CASES)(
+    "$branch: authed user does not see another user's private events",
+    async (spec) => {
+      const allIds = [orgEventId, alicePrivateEventId, bobPrivateEventId, systemEventId];
+      const result = await getContent(
+        buildArgs(spec, allIds) as never,
+        {} as never,
+        authedCtx(aliceUser.id)
+      );
+      const visibleIds = new Set(result.content.map((c) => c.id));
+
+      expect(visibleIds.has(orgEventId)).toBe(true);
+      expect(visibleIds.has(alicePrivateEventId)).toBe(true);
+      expect(visibleIds.has(bobPrivateEventId)).toBe(false);
+    }
+  );
+
+  it.each(BRANCH_CASES)(
+    '$branch: events with connection_id IS NULL (system events) are visible to authed callers',
+    async (spec) => {
+      const allIds = [orgEventId, alicePrivateEventId, bobPrivateEventId, systemEventId];
+      const result = await getContent(
+        buildArgs(spec, allIds) as never,
+        {} as never,
+        authedCtx(aliceUser.id)
+      );
+      const visibleIds = new Set(result.content.map((c) => c.id));
+
+      expect(visibleIds.has(systemEventId)).toBe(true);
+    }
+  );
+
+  it.each(BRANCH_CASES)(
+    '$branch: unauthed caller sees only org-visible + system events; private events hidden',
+    async (spec) => {
+      // include_superseded requires authed access (entity-scoped + has its own
+      // validation), so unauthed is exercised only on the other two branches
+      // that actually run for anonymous public-org reads.
+      if (spec.branch === 'include_superseded') return;
+
+      const allIds = [orgEventId, alicePrivateEventId, bobPrivateEventId, systemEventId];
+      const result = await getContent(
+        buildArgs(spec, allIds) as never,
+        {} as never,
+        unauthedCtx()
+      );
+      const visibleIds = new Set(result.content.map((c) => c.id));
+
+      expect(visibleIds.has(orgEventId)).toBe(true);
+      expect(visibleIds.has(systemEventId)).toBe(true);
+      expect(visibleIds.has(alicePrivateEventId)).toBe(false);
+      expect(visibleIds.has(bobPrivateEventId)).toBe(false);
+    }
+  );
+
+  it.each(BRANCH_CASES)(
+    '$branch: events from soft-deleted connections are excluded',
+    async (spec) => {
+      const allIds = [
+        orgEventId,
+        alicePrivateEventId,
+        bobPrivateEventId,
+        systemEventId,
+        deletedConnEventId,
+      ];
+      const result = await getContent(
+        buildArgs(spec, allIds) as never,
+        {} as never,
+        authedCtx(aliceUser.id)
+      );
+      const visibleIds = new Set(result.content.map((c) => c.id));
+
+      expect(visibleIds.has(deletedConnEventId)).toBe(false);
+      // Sanity: the visible-and-allowed events still show up.
+      expect(visibleIds.has(orgEventId)).toBe(true);
+      expect(visibleIds.has(systemEventId)).toBe(true);
+    }
+  );
+
+  it('content_ids branch: total count mirrors visible set, not requested set', async () => {
+    const result = await getContent(
+      {
+        entity_id: entity.id,
+        content_ids: [orgEventId, alicePrivateEventId, bobPrivateEventId, systemEventId],
+        limit: 100,
       } as never,
       {} as never,
       authedCtx(aliceUser.id)
     );
-    const visibleIds = new Set(result.content.map((c) => c.id));
-
-    expect(visibleIds.has(orgEventId)).toBe(true);
-    expect(visibleIds.has(alicePrivateEventId)).toBe(true);
-    expect(visibleIds.has(bobPrivateEventId)).toBe(false);
+    // Alice asked for 4 ids; Bob's private one filters out → 3 remain.
+    expect(result.total).toBe(3);
+    expect(result.content).toHaveLength(3);
   });
 
-  it('score branch: another user\'s private events stay hidden when sorting by score', async () => {
+  it('score branch: total count matches list cardinality (no leak via count path)', async () => {
     const result = await getContent(
       {
         entity_id: entity.id,
@@ -515,14 +662,234 @@ describe('getContent > visibility on sibling branches (content_ids/include_super
       {} as never,
       authedCtx(aliceUser.id)
     );
+    expect(result.total).toBe(result.content.length);
+    const visibleIds = new Set(result.content.map((c) => c.id));
+    expect(visibleIds.has(bobPrivateEventId)).toBe(false);
+    expect(visibleIds.has(deletedConnEventId)).toBe(false);
+  });
+});
+
+describe('getContent > visibility on the search / query path', () => {
+  // Pi-CLI flagged this as a live security regression: searchContentBySingleQuery
+  // (the hybrid text + vector path) was scanning current_event_records without the
+  // visibility predicate. Any get_content call with `query` set leaked private
+  // events from other users into both the result set and the total count.
+  let org: Awaited<ReturnType<typeof createTestOrganization>>;
+  let aliceUser: Awaited<ReturnType<typeof createTestUser>>;
+  let bobUser: Awaited<ReturnType<typeof createTestUser>>;
+  let entity: Awaited<ReturnType<typeof createTestEntity>>;
+
+  let orgEventId: number;
+  let alicePrivateEventId: number;
+  let bobPrivateEventId: number;
+  let systemEventId: number;
+
+  // A unique, easy-to-tsquery substring shared by every event so the text
+  // search returns all of them when they're allowed.
+  const SHARED_TOKEN = 'visibilityqueryprobe';
+
+  function authedCtx(userId: string): ToolContext {
+    return {
+      organizationId: org.id,
+      userId,
+      memberRole: 'owner',
+      isAuthenticated: true,
+      tokenType: 'oauth',
+      scopedToOrg: false,
+      allowCrossOrg: true,
+      scopes: ['mcp:read'],
+    };
+  }
+
+  function unauthedCtx(): ToolContext {
+    return {
+      organizationId: org.id,
+      userId: null,
+      memberRole: null,
+      isAuthenticated: false,
+      tokenType: 'anonymous',
+      scopedToOrg: true,
+      allowCrossOrg: false,
+    };
+  }
+
+  beforeAll(async () => {
+    await initWorkspaceProvider();
+    await cleanupTestDatabase();
+    await seedSystemEntityTypes();
+
+    org = await createTestOrganization({ name: 'Search Path Org' });
+    aliceUser = await createTestUser({ email: 'alice-search@example.com' });
+    bobUser = await createTestUser({ email: 'bob-search@example.com' });
+    await addUserToOrganization(aliceUser.id, org.id, 'owner');
+    await addUserToOrganization(bobUser.id, org.id, 'owner');
+
+    entity = await createTestEntity({
+      name: 'Search Path Entity',
+      organization_id: org.id,
+    });
+
+    await createTestConnectorDefinition({
+      key: 'search-path-connector',
+      name: 'Search Path',
+      organization_id: org.id,
+    });
+
+    const orgConn = await createTestConnection({
+      organization_id: org.id,
+      connector_key: 'search-path-connector',
+      entity_ids: [entity.id],
+      visibility: 'org',
+      created_by: aliceUser.id,
+      display_name: 'Search-path org-visible',
+    });
+    const alicePriv = await createTestConnection({
+      organization_id: org.id,
+      connector_key: 'search-path-connector',
+      entity_ids: [entity.id],
+      visibility: 'private',
+      created_by: aliceUser.id,
+      display_name: 'Search-path alice-private',
+    });
+    const bobPriv = await createTestConnection({
+      organization_id: org.id,
+      connector_key: 'search-path-connector',
+      entity_ids: [entity.id],
+      visibility: 'private',
+      created_by: bobUser.id,
+      display_name: 'Search-path bob-private',
+    });
+
+    orgEventId = (
+      await createTestEvent({
+        organization_id: org.id,
+        entity_id: entity.id,
+        connection_id: orgConn.id,
+        content: `${SHARED_TOKEN} org event`,
+      })
+    ).id;
+    alicePrivateEventId = (
+      await createTestEvent({
+        organization_id: org.id,
+        entity_id: entity.id,
+        connection_id: alicePriv.id,
+        content: `${SHARED_TOKEN} alice private event`,
+      })
+    ).id;
+    bobPrivateEventId = (
+      await createTestEvent({
+        organization_id: org.id,
+        entity_id: entity.id,
+        connection_id: bobPriv.id,
+        content: `${SHARED_TOKEN} bob private event`,
+      })
+    ).id;
+    systemEventId = (
+      await createTestEvent({
+        organization_id: org.id,
+        entity_id: entity.id,
+        connection_id: undefined,
+        content: `${SHARED_TOKEN} system event`,
+      })
+    ).id;
+  });
+
+  it('authed user query: another user\'s private events excluded from results AND total', async () => {
+    const result = await getContent(
+      {
+        entity_id: entity.id,
+        query: SHARED_TOKEN,
+        limit: 100,
+      } as never,
+      {} as never,
+      authedCtx(aliceUser.id)
+    );
     const visibleIds = new Set(result.content.map((c) => c.id));
 
     expect(visibleIds.has(orgEventId)).toBe(true);
     expect(visibleIds.has(alicePrivateEventId)).toBe(true);
+    expect(visibleIds.has(systemEventId)).toBe(true);
     expect(visibleIds.has(bobPrivateEventId)).toBe(false);
-    // Count must match list cardinality on the score path too — the legacy
-    // bug leaked Bob's private event into both list and count when the user
-    // didn't pass connection_ids.
-    expect(result.total).toBe(2);
+
+    // The bug-of-record: total used to count events the user couldn't see.
+    expect(result.total).toBe(visibleIds.size);
+  });
+
+  it('authed user query (Bob): sees own private events, not Alice\'s', async () => {
+    const result = await getContent(
+      {
+        entity_id: entity.id,
+        query: SHARED_TOKEN,
+        limit: 100,
+      } as never,
+      {} as never,
+      authedCtx(bobUser.id)
+    );
+    const visibleIds = new Set(result.content.map((c) => c.id));
+
+    expect(visibleIds.has(bobPrivateEventId)).toBe(true);
+    expect(visibleIds.has(orgEventId)).toBe(true);
+    expect(visibleIds.has(systemEventId)).toBe(true);
+    expect(visibleIds.has(alicePrivateEventId)).toBe(false);
+    expect(result.total).toBe(visibleIds.size);
+  });
+
+  it('unauthed query: sees only org + system events; private events hidden', async () => {
+    const result = await getContent(
+      {
+        entity_id: entity.id,
+        query: SHARED_TOKEN,
+        limit: 100,
+      } as never,
+      {} as never,
+      unauthedCtx()
+    );
+    const visibleIds = new Set(result.content.map((c) => c.id));
+
+    expect(visibleIds.has(orgEventId)).toBe(true);
+    expect(visibleIds.has(systemEventId)).toBe(true);
+    expect(visibleIds.has(alicePrivateEventId)).toBe(false);
+    expect(visibleIds.has(bobPrivateEventId)).toBe(false);
+    expect(result.total).toBe(visibleIds.size);
+  });
+
+  it('total + result count both match across pagination on the search path', async () => {
+    // Page through with offset to confirm total stays accurate when results
+    // are paginated. (This is the score-sorted, offset-driven shape — distinct
+    // from the chronological cursor-driven path tested elsewhere.)
+    const ctx = authedCtx(aliceUser.id);
+    const page1 = await getContent(
+      {
+        entity_id: entity.id,
+        query: SHARED_TOKEN,
+        limit: 2,
+        offset: 0,
+        sort_by: 'score',
+      } as never,
+      {} as never,
+      ctx
+    );
+    expect(page1.total).toBe(3); // org + alicePrivate + system
+    expect(page1.content.length).toBeLessThanOrEqual(2);
+
+    const page2 = await getContent(
+      {
+        entity_id: entity.id,
+        query: SHARED_TOKEN,
+        limit: 2,
+        offset: 2,
+        sort_by: 'score',
+      } as never,
+      {} as never,
+      ctx
+    );
+    expect(page2.total).toBe(3);
+
+    const collected = new Set([
+      ...page1.content.map((c) => c.id),
+      ...page2.content.map((c) => c.id),
+    ]);
+    expect(collected.size).toBe(3);
+    expect(collected.has(bobPrivateEventId)).toBe(false);
   });
 });

--- a/packages/owletto-backend/src/__tests__/setup/test-fixtures.ts
+++ b/packages/owletto-backend/src/__tests__/setup/test-fixtures.ts
@@ -540,6 +540,7 @@ export async function createTestConnection(options: {
   status?: string;
   display_name?: string;
   created_by?: string;
+  visibility?: 'org' | 'private';
 }): Promise<TestConnection> {
   const sql = getTestDb();
 
@@ -547,13 +548,14 @@ export async function createTestConnection(options: {
   const [inserted] = await sql`
     INSERT INTO connections (
       organization_id, connector_key, display_name, status,
-      created_by, created_at, updated_at
+      created_by, visibility, created_at, updated_at
     ) VALUES (
       ${options.organization_id},
       ${options.connector_key},
       ${options.display_name ?? `Test Connection ${options.connector_key}`},
       ${options.status ?? 'active'},
       ${options.created_by ?? null},
+      ${options.visibility ?? 'org'},
       NOW(), NOW()
     )
     RETURNING id, connector_key, status

--- a/packages/owletto-backend/src/tools/get_content.ts
+++ b/packages/owletto-backend/src/tools/get_content.ts
@@ -98,9 +98,7 @@ function buildContentQuery(opts: {
 
 import { requireReadAccess } from '../utils/organization-access';
 import {
-  buildContentUrl,
   buildEventPermalink,
-  type EntityInfo,
   getOrganizationSlug,
   getPublicWebUrl,
 } from '../utils/url-builder';
@@ -376,7 +374,6 @@ interface GetContentResult {
       [value: string]: number;
     };
   };
-  view_url?: string;
   // Watcher-mode fields (only present when watcher_id is provided)
   window_token?: string;
   window_start?: string;
@@ -523,12 +520,13 @@ export async function getContent(
   if (args.entity_id) {
     await requireReadAccess(pgSql, args.entity_id, ctx);
   }
-  const includeClassificationSummary =
-    !args.include_classification ||
-    args.include_classification
-      .split(',')
-      .map((v) => v.trim())
-      .includes('summary');
+  // Stats are now opt-in: callers must explicitly pass `include_classification=summary`
+  // (the Atlas events page used to set this unconditionally, which fired a heavy
+  // `WITH matching_content` CTE on every first paint — including empty entities).
+  const includeClassificationSummary = !!args.include_classification
+    ?.split(',')
+    .map((v) => v.trim())
+    .includes('summary');
 
   const limit = args.limit || 50;
   const offset = args.offset || 0;
@@ -546,38 +544,13 @@ export async function getContent(
     // Resolve org slug for permalink generation
     const ownerSlug = await getOrganizationSlug(ctx.organizationId);
 
-    // Get entity info for building view URL (only when entity_id is provided)
-    let entityInfo: EntityInfo | null = null;
-    if (entityId) {
-      // Get entity info from data tables
-      const entityResult = await sql`
-        SELECT
-          e.id,
-          et.slug AS entity_type,
-          e.slug,
-          e.parent_id,
-          parent.slug as parent_slug,
-          pet.slug as parent_entity_type,
-          e.organization_id
-        FROM entities e
-        JOIN entity_types et ON et.id = e.entity_type_id
-        LEFT JOIN entities parent ON e.parent_id = parent.id
-        LEFT JOIN entity_types pet ON pet.id = parent.entity_type_id
-        WHERE e.id = ${entityId}
-      `;
-
-      if (entityResult.length > 0) {
-        entityInfo = ownerSlug
-          ? {
-              ownerSlug,
-              entityType: entityResult[0].entity_type as string,
-              slug: entityResult[0].slug as string,
-              parentType: (entityResult[0].parent_entity_type as string) ?? null,
-              parentSlug: (entityResult[0].parent_slug as string) ?? null,
-            }
-          : null;
-      }
-    }
+    // Visibility scope is folded into the SQL WHERE clause inside
+    // `searchContentByText` / `listContentInternal` via
+    // `buildConnectionVisibilityClause`, so we no longer round-trip to the DB
+    // here just to compute "which connection IDs is this caller allowed to
+    // see?". Events with `connection_id IS NULL` (system events) stay visible
+    // to authed and unauthed callers alike.
+    const visibilityScope = { organizationId: ctx.organizationId, userId: ctx.userId };
 
     // Log incoming classification filters for debugging
     if (args.classification_filters) {
@@ -596,46 +569,6 @@ export async function getContent(
     const platformFilters = (args.platforms ?? []).map((p) => String(p).trim()).filter(Boolean);
 
     let effectiveConnectionIds = args.connection_ids ? [...args.connection_ids] : undefined;
-
-    // Visibility: exclude private connections.
-    // Authenticated users see their own private connections; unauthenticated see only org-visible.
-    {
-      const visibilityRows = ctx.userId
-        ? await sql`
-            SELECT id FROM connections
-            WHERE organization_id = ${ctx.organizationId}
-              AND visibility = 'private'
-              AND created_by != ${ctx.userId}
-              AND deleted_at IS NULL
-          `
-        : await sql`
-            SELECT id FROM connections
-            WHERE organization_id = ${ctx.organizationId}
-              AND visibility = 'private'
-              AND deleted_at IS NULL
-          `;
-      const excludedIds = new Set(visibilityRows.map((r: { id: number }) => r.id));
-      if (excludedIds.size > 0) {
-        if (effectiveConnectionIds) {
-          effectiveConnectionIds = effectiveConnectionIds.filter((id) => !excludedIds.has(id));
-        } else {
-          const visibleRows = ctx.userId
-            ? await sql`
-                SELECT id FROM connections
-                WHERE organization_id = ${ctx.organizationId}
-                  AND (visibility = 'org' OR created_by = ${ctx.userId})
-                  AND deleted_at IS NULL
-              `
-            : await sql`
-                SELECT id FROM connections
-                WHERE organization_id = ${ctx.organizationId}
-                  AND visibility = 'org'
-                  AND deleted_at IS NULL
-              `;
-          effectiveConnectionIds = visibleRows.map((r: { id: number }) => r.id);
-        }
-      }
-    }
 
     let didPlatformFilter = false;
     if (platformFilters.length > 0) {
@@ -703,17 +636,6 @@ export async function getContent(
       };
       if (includeClassificationSummary) {
         result.classification_stats = {};
-      }
-      if (entityInfo) {
-        result.view_url = buildContentUrl(
-          entityInfo,
-          {
-            platform: effectivePlatform,
-            since: args.since,
-            until: args.until,
-          },
-          baseUrl
-        );
       }
       return result;
     }
@@ -920,6 +842,7 @@ export async function getContent(
           entity_id: args.entity_id,
           organization_id: !args.entity_id ? ctx.organizationId : undefined,
           connection_ids: effectiveConnectionIds,
+          visibility_scope: visibilityScope,
           window_id: args.window_id,
           exclude_watcher_id: args.exclude_watcher_id,
           platform: effectivePlatform,
@@ -1192,19 +1115,6 @@ export async function getContent(
 
     if (classificationStats) {
       result.classification_stats = classificationStats;
-    }
-
-    // Add view URL if entity info is available
-    if (entityInfo) {
-      result.view_url = buildContentUrl(
-        entityInfo,
-        {
-          platform: effectivePlatform,
-          since: args.since,
-          until: args.until,
-        },
-        baseUrl
-      );
     }
 
     // Entity summary: when searching org-wide (query provided, no entity_id/watcher_id)

--- a/packages/owletto-backend/src/tools/get_content.ts
+++ b/packages/owletto-backend/src/tools/get_content.ts
@@ -102,6 +102,7 @@ function buildContentQuery(opts: {
 }
 
 import { requireReadAccess } from '../utils/organization-access';
+import { validateNumericId } from '../utils/sql-validation';
 import {
   buildContentUrl,
   buildEventPermalink,
@@ -734,7 +735,7 @@ export async function getContent(
         // skips namespaces this entity doesn't claim. Identifier values are
         // bound params; entity id is inlined as a literal so the planner
         // sees the actual selectivity.
-        const validatedId = (args.entity_id as number) | 0;
+        const validatedId = validateNumericId(args.entity_id as number, 'entity_id');
         const scopes = await fetchEntityIdentityScopes(sql, validatedId);
         const link = buildEntityLinkUnion({
           entityIdLiteral: validatedId,
@@ -794,7 +795,7 @@ export async function getContent(
       // link UNION skips namespaces this entity doesn't claim. Same pattern
       // as listContentInternal. Entity id is inlined as a literal, so it's
       // not a bound param here — identifier values are.
-      const supersededValidatedId = (entityId as number) | 0;
+      const supersededValidatedId = validateNumericId(entityId as number, 'entity_id');
       const supersededScopes = await fetchEntityIdentityScopes(sql, supersededValidatedId);
       const supersededLink = buildEntityLinkUnion({
         entityIdLiteral: supersededValidatedId,
@@ -1009,7 +1010,7 @@ export async function getContent(
         // Use the trimmed UNION here too so the stats CTE doesn't pay for
         // namespaces the entity doesn't have. Identifier values are bound
         // params; entity id is inlined as a literal.
-        const statsValidatedId = (args.entity_id as number) | 0;
+        const statsValidatedId = validateNumericId(args.entity_id as number, 'entity_id');
         const statsScopes = await fetchEntityIdentityScopes(sql, statsValidatedId);
         const statsLink = buildEntityLinkUnion({
           entityIdLiteral: statsValidatedId,

--- a/packages/owletto-backend/src/tools/get_content.ts
+++ b/packages/owletto-backend/src/tools/get_content.ts
@@ -981,7 +981,14 @@ export async function getContent(
         params.push(args.entity_id);
       }
       if (effectiveConnectionIds && effectiveConnectionIds.length > 0) {
-        conditions.push(`f.connection_id IN (${effectiveConnectionIds.join(',')})`);
+        // Parameterize — every other branch in this file does, and an
+        // upstream schema relaxation shouldn't be the thing that turns this
+        // into a string-concat injection sink.
+        const placeholders = effectiveConnectionIds
+          .map(() => `$${paramIndex++}`)
+          .join(',');
+        conditions.push(`f.connection_id IN (${placeholders})`);
+        params.push(...effectiveConnectionIds);
       }
       if (effectivePlatform) {
         conditions.push(`COALESCE(f.connector_key, c.connector_key) = $${paramIndex++}`);

--- a/packages/owletto-backend/src/tools/get_content.ts
+++ b/packages/owletto-backend/src/tools/get_content.ts
@@ -17,7 +17,8 @@ import {
 } from '../utils/content-scoring';
 import {
   buildConnectionVisibilityClause,
-  entityLinkMatchSql,
+  buildEntityLinkUnion,
+  fetchEntityIdentityScopes,
   searchContentByText,
 } from '../utils/content-search';
 import { parseDateAlias, toEndOfDay } from '../utils/date-aliases';
@@ -554,42 +555,42 @@ export async function getContent(
     const sinceDate = args.since ? parseDateAlias(args.since).date : null;
     const untilDate = args.until ? toEndOfDay(parseDateAlias(args.until).date) : null;
 
-    // Resolve org slug for permalink generation
-    const ownerSlug = await getOrganizationSlug(ctx.organizationId);
+    // Run org-slug lookup and entity-info lookup in parallel — they're
+    // independent and on a high-RTT DB the serial form pays the round-trip
+    // twice. view_url builds from both, and we still want it populated for
+    // LLM consumers reading `read_knowledge` over MCP.
+    const [ownerSlug, entityInfoRaw] = await Promise.all([
+      getOrganizationSlug(ctx.organizationId),
+      entityId
+        ? sql`
+          SELECT
+            e.id,
+            et.slug AS entity_type,
+            e.slug,
+            e.parent_id,
+            parent.slug as parent_slug,
+            pet.slug as parent_entity_type,
+            e.organization_id
+          FROM entities e
+          JOIN entity_types et ON et.id = e.entity_type_id
+          LEFT JOIN entities parent ON e.parent_id = parent.id
+          LEFT JOIN entity_types pet ON pet.id = parent.entity_type_id
+          WHERE e.id = ${entityId}
+        `
+        : Promise.resolve([] as Array<Record<string, unknown>>),
+    ]);
 
-    // Get entity info for building view_url. This is a single PK SELECT (~1ms)
-    // and the result is consumed by LLM agents reading `read_knowledge`
-    // responses over MCP — they format `view_url` into chat replies, so the
-    // field has to keep being populated.
     let entityInfo: EntityInfo | null = null;
-    if (entityId) {
-      const entityResult = await sql`
-        SELECT
-          e.id,
-          et.slug AS entity_type,
-          e.slug,
-          e.parent_id,
-          parent.slug as parent_slug,
-          pet.slug as parent_entity_type,
-          e.organization_id
-        FROM entities e
-        JOIN entity_types et ON et.id = e.entity_type_id
-        LEFT JOIN entities parent ON e.parent_id = parent.id
-        LEFT JOIN entity_types pet ON pet.id = parent.entity_type_id
-        WHERE e.id = ${entityId}
-      `;
-
-      if (entityResult.length > 0) {
-        entityInfo = ownerSlug
-          ? {
-              ownerSlug,
-              entityType: entityResult[0].entity_type as string,
-              slug: entityResult[0].slug as string,
-              parentType: (entityResult[0].parent_entity_type as string) ?? null,
-              parentSlug: (entityResult[0].parent_slug as string) ?? null,
-            }
-          : null;
-      }
+    if (entityId && entityInfoRaw.length > 0) {
+      entityInfo = ownerSlug
+        ? {
+            ownerSlug,
+            entityType: entityInfoRaw[0].entity_type as string,
+            slug: entityInfoRaw[0].slug as string,
+            parentType: (entityInfoRaw[0].parent_entity_type as string) ?? null,
+            parentSlug: (entityInfoRaw[0].parent_slug as string) ?? null,
+          }
+        : null;
     }
 
     // Visibility scope is folded into the SQL WHERE clause of every list/count
@@ -729,8 +730,20 @@ export async function getContent(
 
       let entityFilter = '';
       if (args.entity_id) {
-        queryParams.push(args.entity_id);
-        entityFilter = ` AND ${entityLinkMatchSql(`$${queryParams.length}::bigint`)}`;
+        // Use the trimmed entity-link UNION when we know the entity id —
+        // skips namespaces this entity doesn't claim. Identifier values are
+        // bound params; entity id is inlined as a literal so the planner
+        // sees the actual selectivity.
+        const validatedId = (args.entity_id as number) | 0;
+        const scopes = await fetchEntityIdentityScopes(sql, validatedId);
+        const link = buildEntityLinkUnion({
+          entityIdLiteral: validatedId,
+          scopes,
+          alias: 'f',
+          baseParamIndex: queryParams.length + 1,
+        });
+        entityFilter = ` AND ${link.sql}`;
+        queryParams.push(...link.params);
       }
 
       // Visibility: hide events from connections the caller can't see. Inline,
@@ -777,12 +790,28 @@ export async function getContent(
     } else if (args.include_superseded) {
       logger.info('[get_content] Listing content including superseded history');
 
+      // Pre-fetch the entity's identity scopes once so the trimmed entity
+      // link UNION skips namespaces this entity doesn't claim. Same pattern
+      // as listContentInternal. Entity id is inlined as a literal, so it's
+      // not a bound param here — identifier values are.
+      const supersededValidatedId = (entityId as number) | 0;
+      const supersededScopes = await fetchEntityIdentityScopes(sql, supersededValidatedId);
+      const supersededLink = buildEntityLinkUnion({
+        entityIdLiteral: supersededValidatedId,
+        scopes: supersededScopes,
+        alias: 'e',
+        baseParamIndex: 2, // org=$1; identifier params start at $2
+      });
+
       const conditions: string[] = [
         'e.organization_id = $1',
-        entityLinkMatchSql('$2::bigint', 'e'),
+        supersededLink.sql,
       ];
-      const queryParams: Array<string | number | null> = [ctx.organizationId, entityId!];
-      let paramIndex = 3;
+      const queryParams: Array<string | number | null> = [
+        ctx.organizationId,
+        ...supersededLink.params,
+      ];
+      let paramIndex = 2 + supersededLink.params.length;
 
       if (effectiveConnectionIds && effectiveConnectionIds.length > 0) {
         const placeholders = effectiveConnectionIds.map(() => `$${paramIndex++}`).join(',');
@@ -977,8 +1006,20 @@ export async function getContent(
       let paramIndex = 1;
 
       if (args.entity_id) {
-        conditions.push(entityLinkMatchSql(`$${paramIndex++}::bigint`));
-        params.push(args.entity_id);
+        // Use the trimmed UNION here too so the stats CTE doesn't pay for
+        // namespaces the entity doesn't have. Identifier values are bound
+        // params; entity id is inlined as a literal.
+        const statsValidatedId = (args.entity_id as number) | 0;
+        const statsScopes = await fetchEntityIdentityScopes(sql, statsValidatedId);
+        const statsLink = buildEntityLinkUnion({
+          entityIdLiteral: statsValidatedId,
+          scopes: statsScopes,
+          alias: 'f',
+          baseParamIndex: paramIndex,
+        });
+        conditions.push(statsLink.sql);
+        params.push(...statsLink.params);
+        paramIndex += statsLink.params.length;
       }
       if (effectiveConnectionIds && effectiveConnectionIds.length > 0) {
         // Parameterize — every other branch in this file does, and an
@@ -1112,51 +1153,54 @@ export async function getContent(
       );
     }
 
-    // Batch-resolve client_name for items without it (search/score paths don't JOIN oauth_clients)
+    // Batch-resolve client_name and parent_context in parallel — the two
+    // queries are independent (one keys by event id, the other by origin_id)
+    // and on a high-RTT DB the serial form pays the round-trip twice.
     const idsNeedingClientName = rawContent.filter((f) => !f.client_name).map((f) => f.id);
-    const clientNameMap = new Map<number, string>();
-    if (idsNeedingClientName.length > 0) {
-      const idList = `{${idsNeedingClientName.join(',')}}`;
-      const clientRows = await sql`
-        SELECT e.id, oc.client_name
-        FROM current_event_records e
-        JOIN oauth_clients oc ON oc.id = e.client_id
-        WHERE e.id = ANY(${idList}::bigint[])
-          AND e.client_id IS NOT NULL
-      `;
-      for (const row of clientRows) {
-        clientNameMap.set(Number(row.id), String(row.client_name));
-      }
-    }
-
-    // Batch-resolve parent_context for replies whose parent isn't in the current result set
     const parentExternalIds = rawContent
       .filter(
         (f) => f.origin_parent_id && !rawContent.some((r) => r.origin_id === f.origin_parent_id)
       )
       .map((f) => f.origin_parent_id as string);
+    const uniqueParentIds = [...new Set(parentExternalIds)];
+
+    const [clientRows, parentRows] = await Promise.all([
+      idsNeedingClientName.length > 0
+        ? sql`
+          SELECT e.id, oc.client_name
+          FROM current_event_records e
+          JOIN oauth_clients oc ON oc.id = e.client_id
+          WHERE e.id = ANY(${`{${idsNeedingClientName.join(',')}}`}::bigint[])
+            AND e.client_id IS NOT NULL
+        `
+        : Promise.resolve([] as Array<{ id: number; client_name: string }>),
+      uniqueParentIds.length > 0
+        ? sql`
+          SELECT origin_id, author_name, title, payload_text, occurred_at, source_url, score
+          FROM current_event_records
+          WHERE origin_id = ANY(${pgTextArray(uniqueParentIds)}::text[])
+            AND organization_id = ${ctx.organizationId}
+          LIMIT ${uniqueParentIds.length}
+        `
+        : Promise.resolve([] as Array<Record<string, unknown>>),
+    ]);
+
+    const clientNameMap = new Map<number, string>();
+    for (const row of clientRows) {
+      clientNameMap.set(Number(row.id), String(row.client_name));
+    }
+
     const parentContextMap = new Map<string, ContentItem['parent_context']>();
-    if (parentExternalIds.length > 0) {
-      const uniqueIds = [...new Set(parentExternalIds)];
-      const pgArray = pgTextArray(uniqueIds);
-      const parentRows = await sql`
-        SELECT origin_id, author_name, title, payload_text, occurred_at, source_url, score
-        FROM current_event_records
-        WHERE origin_id = ANY(${pgArray}::text[])
-          AND organization_id = ${ctx.organizationId}
-        LIMIT ${uniqueIds.length}
-      `;
-      for (const row of parentRows) {
-        const text = String(row.payload_text ?? '');
-        parentContextMap.set(String(row.origin_id), {
-          author_name: String(row.author_name ?? ''),
-          title: row.title ? String(row.title) : null,
-          text_content: text.length > 200 ? `${text.slice(0, 200)}…` : text,
-          occurred_at: String(row.occurred_at ?? ''),
-          source_url: String(row.source_url ?? ''),
-          score: Number(row.score) || 0,
-        });
-      }
+    for (const row of parentRows) {
+      const text = String(row.payload_text ?? '');
+      parentContextMap.set(String(row.origin_id), {
+        author_name: String(row.author_name ?? ''),
+        title: row.title ? String(row.title) : null,
+        text_content: text.length > 200 ? `${text.slice(0, 200)}…` : text,
+        occurred_at: String(row.occurred_at ?? ''),
+        source_url: String(row.source_url ?? ''),
+        score: Number(row.score) || 0,
+      });
     }
 
     // Map to the canonical content item shape used across the app.

--- a/packages/owletto-backend/src/tools/get_content.ts
+++ b/packages/owletto-backend/src/tools/get_content.ts
@@ -15,7 +15,11 @@ import {
   getNormalizedScoreContent,
   getNormalizedScoreContentCount,
 } from '../utils/content-scoring';
-import { entityLinkMatchSql, searchContentByText } from '../utils/content-search';
+import {
+  buildConnectionVisibilityClause,
+  entityLinkMatchSql,
+  searchContentByText,
+} from '../utils/content-search';
 import { parseDateAlias, toEndOfDay } from '../utils/date-aliases';
 import { type DataSourceContext, executeDataSources } from '../utils/execute-data-sources';
 import { parseJsonObject } from '../utils/json';
@@ -98,7 +102,9 @@ function buildContentQuery(opts: {
 
 import { requireReadAccess } from '../utils/organization-access';
 import {
+  buildContentUrl,
   buildEventPermalink,
+  type EntityInfo,
   getOrganizationSlug,
   getPublicWebUrl,
 } from '../utils/url-builder';
@@ -374,6 +380,13 @@ interface GetContentResult {
       [value: string]: number;
     };
   };
+  /**
+   * Permalink for the entity-scoped events listing in the public web app.
+   * LLM agents calling `read_knowledge` over MCP read this from the response
+   * and format it into chat replies; there is no programmatic consumer in
+   * this repo, but removing the field breaks that user-facing behavior.
+   */
+  view_url?: string;
   // Watcher-mode fields (only present when watcher_id is provided)
   window_token?: string;
   window_start?: string;
@@ -544,12 +557,47 @@ export async function getContent(
     // Resolve org slug for permalink generation
     const ownerSlug = await getOrganizationSlug(ctx.organizationId);
 
-    // Visibility scope is folded into the SQL WHERE clause inside
-    // `searchContentByText` / `listContentInternal` via
-    // `buildConnectionVisibilityClause`, so we no longer round-trip to the DB
-    // here just to compute "which connection IDs is this caller allowed to
-    // see?". Events with `connection_id IS NULL` (system events) stay visible
-    // to authed and unauthed callers alike.
+    // Get entity info for building view_url. This is a single PK SELECT (~1ms)
+    // and the result is consumed by LLM agents reading `read_knowledge`
+    // responses over MCP — they format `view_url` into chat replies, so the
+    // field has to keep being populated.
+    let entityInfo: EntityInfo | null = null;
+    if (entityId) {
+      const entityResult = await sql`
+        SELECT
+          e.id,
+          et.slug AS entity_type,
+          e.slug,
+          e.parent_id,
+          parent.slug as parent_slug,
+          pet.slug as parent_entity_type,
+          e.organization_id
+        FROM entities e
+        JOIN entity_types et ON et.id = e.entity_type_id
+        LEFT JOIN entities parent ON e.parent_id = parent.id
+        LEFT JOIN entity_types pet ON pet.id = parent.entity_type_id
+        WHERE e.id = ${entityId}
+      `;
+
+      if (entityResult.length > 0) {
+        entityInfo = ownerSlug
+          ? {
+              ownerSlug,
+              entityType: entityResult[0].entity_type as string,
+              slug: entityResult[0].slug as string,
+              parentType: (entityResult[0].parent_entity_type as string) ?? null,
+              parentSlug: (entityResult[0].parent_slug as string) ?? null,
+            }
+          : null;
+      }
+    }
+
+    // Visibility scope is folded into the SQL WHERE clause of every list/count
+    // path (chronological list, content_ids, include_superseded, score) via
+    // `buildConnectionVisibilityClause`. The legacy two-step "find private
+    // connections, then find visible connections" round-trip is gone; events
+    // with `connection_id IS NULL` (system events) stay visible to authed and
+    // unauthed callers alike.
     const visibilityScope = { organizationId: ctx.organizationId, userId: ctx.userId };
 
     // Log incoming classification filters for debugging
@@ -637,6 +685,17 @@ export async function getContent(
       if (includeClassificationSummary) {
         result.classification_stats = {};
       }
+      if (entityInfo) {
+        result.view_url = buildContentUrl(
+          entityInfo,
+          {
+            platform: effectivePlatform,
+            since: args.since,
+            until: args.until,
+          },
+          baseUrl
+        );
+      }
       return result;
     }
 
@@ -674,12 +733,21 @@ export async function getContent(
         entityFilter = ` AND ${entityLinkMatchSql(`$${queryParams.length}::bigint`)}`;
       }
 
+      // Visibility: hide events from connections the caller can't see. Inline,
+      // shared with the count below.
+      const visibility = buildConnectionVisibilityClause({
+        organizationId: visibilityScope.organizationId,
+        userId: visibilityScope.userId,
+        baseParamIndex: queryParams.length + 1,
+      });
+      queryParams.push(...visibility.params);
+
       // Query content by IDs with classifications
       const result = await sql.unsafe(
         buildContentQuery({
           table: 'current_event_records',
           alias: 'f',
-          where: `f.id IN (${idPlaceholders}) ${orgScope}${entityFilter}`,
+          where: `f.id IN (${idPlaceholders}) ${orgScope}${entityFilter} ${visibility.sql}`,
           orderBy: 'f.occurred_at DESC',
           limit,
           offset,
@@ -694,6 +762,7 @@ export async function getContent(
         WHERE f.id IN (${idPlaceholders})
           ${orgScope}
           ${entityFilter}
+          ${visibility.sql}
       `,
         queryParams
       );
@@ -770,6 +839,25 @@ export async function getContent(
         paramIndex += 1;
       }
 
+      // Visibility: events from connections the caller can't see drop out.
+      // The clause is appended as an `AND (…)` fragment so it folds cleanly
+      // into the existing `conditions.join(' AND ')`.
+      const visibility = buildConnectionVisibilityClause(
+        {
+          organizationId: visibilityScope.organizationId,
+          userId: visibilityScope.userId,
+          baseParamIndex: paramIndex,
+        },
+        'e'
+      );
+      if (visibility.sql) {
+        // strip the leading "AND " that buildConnectionVisibilityClause emits
+        // since we're joining conditions with ' AND ' ourselves.
+        conditions.push(visibility.sql.replace(/^AND\s+/, ''));
+        queryParams.push(...visibility.params);
+        paramIndex += visibility.params.length;
+      }
+
       const orderDirection = args.sort_order === 'asc' ? 'ASC' : 'DESC';
       const orderBySql = `e.occurred_at ${orderDirection} NULLS LAST, e.id ${orderDirection}`;
 
@@ -820,6 +908,7 @@ export async function getContent(
         ...(args.classification_source && { classification_source: args.classification_source }),
         ...(args.semantic_type && { semantic_type: args.semantic_type }),
         ...(args.interaction_status && { interaction_status: args.interaction_status }),
+        visibility_scope: visibilityScope,
       };
 
       const [contentResult, countResult] = await Promise.all([
@@ -911,6 +1000,19 @@ export async function getContent(
         windowJoinSql = `JOIN watcher_window_events iwf ON iwf.event_id = f.id AND iwf.window_id = $${paramIndex}`;
         params.push(args.window_id);
         paramIndex++;
+      }
+
+      // Visibility: events from connections the caller can't see must not
+      // skew the classification distribution.
+      const statsVisibility = buildConnectionVisibilityClause({
+        organizationId: visibilityScope.organizationId,
+        userId: visibilityScope.userId,
+        baseParamIndex: paramIndex,
+      });
+      if (statsVisibility.sql) {
+        conditions.push(statsVisibility.sql.replace(/^AND\s+/, ''));
+        params.push(...statsVisibility.params);
+        paramIndex += statsVisibility.params.length;
       }
 
       // Stats query WITHOUT classification filters (to show full distribution)
@@ -1115,6 +1217,19 @@ export async function getContent(
 
     if (classificationStats) {
       result.classification_stats = classificationStats;
+    }
+
+    // Add view URL when an entity is in scope. Consumed by LLM agents over MCP.
+    if (entityInfo) {
+      result.view_url = buildContentUrl(
+        entityInfo,
+        {
+          platform: effectivePlatform,
+          since: args.since,
+          until: args.until,
+        },
+        baseUrl
+      );
     }
 
     // Entity summary: when searching org-wide (query provided, no entity_id/watcher_id)

--- a/packages/owletto-backend/src/utils/content-scoring.ts
+++ b/packages/owletto-backend/src/utils/content-scoring.ts
@@ -1,6 +1,6 @@
 import { getDb } from '../db/client';
 import { buildClassificationFilterSQL } from './content-query-filters';
-import { entityLinkMatchSql } from './content-search';
+import { buildConnectionVisibilityClause, entityLinkMatchSql } from './content-search';
 import logger from './logger';
 import { getScoringFormulaSql, resolveStoredScoringProfile } from './scoring-profiles';
 import { validateAndFormatIds, validateNumericId } from './sql-validation';
@@ -19,6 +19,13 @@ interface NormalizedScoreFilters {
   classification_source?: 'user' | 'embedding' | 'llm';
   semantic_type?: string;
   interaction_status?: 'pending' | 'approved' | 'rejected' | 'completed' | 'failed';
+  /**
+   * Connection-visibility scope. Folds into the WHERE so events from
+   * private connections the caller can't see don't appear in score-sorted
+   * results. Mirrors the clause used by `listContentInternal` and the
+   * `content_ids` / `include_superseded` branches in `get_content.ts`.
+   */
+  visibility_scope?: { organizationId: string; userId: string | null };
 }
 
 /**
@@ -152,6 +159,24 @@ function buildFilterConditionsAndJoins(
     filterConditions.push(...classificationConditions);
     params.push(...classificationParams);
     paramIndex += classificationParams.length;
+  }
+
+  if (filters?.visibility_scope) {
+    const visibility = buildConnectionVisibilityClause(
+      {
+        organizationId: filters.visibility_scope.organizationId,
+        userId: filters.visibility_scope.userId,
+        baseParamIndex: paramIndex,
+      },
+      'f'
+    );
+    if (visibility.sql) {
+      // Drop the leading "AND " — `filterConditions` is joined with ' AND '
+      // by callers, so the bare predicate is what we want.
+      filterConditions.push(visibility.sql.replace(/^AND\s+/, ''));
+      params.push(...visibility.params);
+      paramIndex += visibility.params.length;
+    }
   }
 
   return { filterConditions, additionalJoins, params };

--- a/packages/owletto-backend/src/utils/content-scoring.ts
+++ b/packages/owletto-backend/src/utils/content-scoring.ts
@@ -207,6 +207,29 @@ export async function getNormalizedScoreContent(
     params.push(filters.platform);
   }
 
+  // Visibility: keep the discovery scan's connection set in lockstep with the
+  // final scored query. Today the leak isn't directly observable (the final
+  // query is visibility-filtered, so a hidden source produces a CASE WHEN
+  // branch that never fires), but counts/aggregates on this CTE could leak
+  // existence info, and a future refactor that promotes its rows into the
+  // returned set would turn this into a real leak. Same helper as the rest
+  // of get_content's branches use.
+  if (filters?.visibility_scope) {
+    const preVisibility = buildConnectionVisibilityClause(
+      {
+        organizationId: filters.visibility_scope.organizationId,
+        userId: filters.visibility_scope.userId,
+        baseParamIndex: paramIndex,
+      },
+      'f'
+    );
+    if (preVisibility.sql) {
+      conditions.push(preVisibility.sql.replace(/^AND\s+/, ''));
+      params.push(...preVisibility.params);
+      paramIndex += preVisibility.params.length;
+    }
+  }
+
   const sources = await sql.unsafe(
     `
     SELECT DISTINCT

--- a/packages/owletto-backend/src/utils/content-scoring.ts
+++ b/packages/owletto-backend/src/utils/content-scoring.ts
@@ -1,6 +1,12 @@
 import { getDb } from '../db/client';
 import { buildClassificationFilterSQL } from './content-query-filters';
-import { buildConnectionVisibilityClause, entityLinkMatchSql } from './content-search';
+import {
+  buildConnectionVisibilityClause,
+  buildEntityLinkUnion,
+  type EntityIdentityScope,
+  entityLinkMatchSql,
+  fetchEntityIdentityScopes,
+} from './content-search';
 import logger from './logger';
 import { getScoringFormulaSql, resolveStoredScoringProfile } from './scoring-profiles';
 import { validateAndFormatIds, validateNumericId } from './sql-validation';
@@ -84,12 +90,29 @@ interface NormalizedScoreContent {
 function buildFilterConditionsAndJoins(
   entityId: number,
   filters?: NormalizedScoreFilters,
-  baseParamIndex: number = 1
+  baseParamIndex: number = 1,
+  entityScopes?: EntityIdentityScope[]
 ): { filterConditions: string[]; additionalJoins: string[]; params: unknown[] } {
-  const filterConditions: string[] = [entityLinkMatchSql(`${entityId}::bigint`)];
-  const additionalJoins: string[] = [];
-  const params: unknown[] = [];
   let paramIndex = baseParamIndex;
+  const params: unknown[] = [];
+  // Use the trimmed UNION when scopes were pre-fetched. Falls back to the
+  // legacy 7-branch UNION (kept for the few callers that don't pre-fetch).
+  let entityLinkSql: string;
+  if (entityScopes !== undefined) {
+    const link = buildEntityLinkUnion({
+      entityIdLiteral: entityId,
+      scopes: entityScopes,
+      alias: 'f',
+      baseParamIndex: paramIndex,
+    });
+    entityLinkSql = link.sql;
+    params.push(...link.params);
+    paramIndex += link.params.length;
+  } else {
+    entityLinkSql = entityLinkMatchSql(`${entityId}::bigint`);
+  }
+  const filterConditions: string[] = [entityLinkSql];
+  const additionalJoins: string[] = [];
 
   if (filters?.connection_ids && filters.connection_ids.length > 0) {
     const validatedIds = validateAndFormatIds(filters.connection_ids, 'connection_ids');
@@ -193,9 +216,19 @@ export async function getNormalizedScoreContent(
   // Validate entityId to prevent injection
   validateNumericId(entityId, 'entityId');
 
-  const conditions: string[] = [entityLinkMatchSql('$1::bigint')];
-  const params: unknown[] = [entityId];
-  let paramIndex = 2;
+  // Pre-fetch identity scopes once, share across both step 1 (sources) and
+  // step 3 (scored content). Trims unused UNION branches from each.
+  const entityScopes = await fetchEntityIdentityScopes(sql, entityId);
+  const sourcesEntityLink = buildEntityLinkUnion({
+    entityIdLiteral: entityId,
+    scopes: entityScopes,
+    alias: 'f',
+    baseParamIndex: 1,
+  });
+
+  const conditions: string[] = [sourcesEntityLink.sql];
+  const params: unknown[] = [...sourcesEntityLink.params];
+  let paramIndex = 1 + sourcesEntityLink.params.length;
 
   if (filters?.connection_ids && filters.connection_ids.length > 0) {
     // Validate all connection_ids are valid integers before using in SQL
@@ -269,12 +302,13 @@ export async function getNormalizedScoreContent(
 
   const scoringExpression = `CASE ${caseWhenParts.join(' ')} END`;
 
-  // Step 3: Build and execute the dynamic query
+  // Step 3: Build and execute the dynamic query. Pass the pre-fetched
+  // identity scopes through so the trimmed entity-link UNION is used.
   const {
     filterConditions,
     additionalJoins,
     params: filterParams,
-  } = buildFilterConditionsAndJoins(entityId, filters);
+  } = buildFilterConditionsAndJoins(entityId, filters, 1, entityScopes);
   const whereClause = filterConditions.join(' AND ');
   const joinClause = additionalJoins.join(' ');
 
@@ -396,11 +430,16 @@ export async function getNormalizedScoreContentCount(
 
   validateNumericId(entityId, 'entityId');
 
+  // Pre-fetch scopes here too so the count query also uses the trimmed UNION.
+  // Cheap (~1ms) and runs in parallel with the main scored query in
+  // get_content.ts via Promise.all.
+  const entityScopes = await fetchEntityIdentityScopes(sql, entityId);
+
   const {
     filterConditions,
     additionalJoins,
     params: filterParams,
-  } = buildFilterConditionsAndJoins(entityId, filters);
+  } = buildFilterConditionsAndJoins(entityId, filters, 1, entityScopes);
   const whereClause = filterConditions.join(' AND ');
   const joinClause = additionalJoins.join(' ');
 

--- a/packages/owletto-backend/src/utils/content-search.ts
+++ b/packages/owletto-backend/src/utils/content-search.ts
@@ -6,7 +6,7 @@
  * Falls back to ILIKE-only when embeddings cannot be generated.
  */
 
-import { type DbClient, getDb } from '../db/client';
+import { type DbClient, getDb, pgTextArray } from '../db/client';
 import type { Env } from '../index';
 import {
   buildConnectionFilter,
@@ -199,7 +199,106 @@ export function entityLinkMatchSql(paramRef: string, alias = 'f'): string {
   return `${alias}.id IN (\n    ${branches}\n  )`;
 }
 
-const STANDARD_WHERE_SQL = `($1::bigint IS NULL OR ${entityLinkMatchSql('$1::bigint')})
+/**
+ * One identity claim for an entity — `(namespace, identifier)`.
+ *
+ * Used by `fetchEntityIdentityScopes` + `buildEntityLinkUnion` to skip the
+ * UNION branches that would never match for this entity. On a 4.7GB events
+ * table the empty-branches-still-cost-real-time issue is the difference
+ * between 200ms and 1.2s on the candidate_set scan alone.
+ */
+export interface EntityIdentityScope {
+  namespace: string;
+  identifier: string;
+}
+
+/**
+ * Pre-fetch the live `entity_identities` rows for one entity, restricted to
+ * the namespaces we have backing indexes for (`STANDARD_IDENTITY_NAMESPACES`).
+ *
+ * Cheap: indexed scan via `idx_entity_identities_by_entity`. Typical entity
+ * has 0-3 rows. Run once per request, not per query.
+ */
+export async function fetchEntityIdentityScopes(
+  sql: DbClient,
+  entityId: number
+): Promise<EntityIdentityScope[]> {
+  const rows = (await sql`
+    SELECT namespace, identifier
+    FROM entity_identities
+    WHERE entity_id = ${entityId}
+      AND deleted_at IS NULL
+      AND namespace = ANY(${pgTextArray([...STANDARD_IDENTITY_NAMESPACES])}::text[])
+  `) as Array<{ namespace: unknown; identifier: unknown }>;
+  return rows.map((r) => ({
+    namespace: String(r.namespace),
+    identifier: String(r.identifier),
+  }));
+}
+
+/**
+ * Build the same `<alias>.id IN (UNION …)` predicate as `entityLinkMatchSql`,
+ * but emit only the branches an entity actually needs.
+ *
+ * Differences from the legacy helper:
+ *  - The direct `entity_ids @> ARRAY[N]` branch is always included.
+ *  - One `metadata->>'<ns>' = $N` branch per pre-fetched scope (no JOIN to
+ *    `entity_identities`; the identifier is bound as a parameter). For an
+ *    entity with no identities, that's zero extra branches — Postgres only
+ *    plans the direct scan.
+ *  - Uses an inline `entityIdLiteral` (already validated as a numeric id) so
+ *    the planner sees the actual id and picks the entity-specific GIN scan
+ *    instead of building a generic plan.
+ *
+ * Identifier values are bound params (caller appends them to its params
+ * array), defending against tampering even though `entity_identities` is
+ * write-controlled.
+ */
+export function buildEntityLinkUnion(opts: {
+  /** Already-validated entity id, will be inlined as `<id>::bigint`. */
+  entityIdLiteral: number;
+  scopes: EntityIdentityScope[];
+  alias?: string;
+  baseParamIndex: number;
+}): { sql: string; params: string[] } {
+  const alias = opts.alias ?? 'f';
+  const direct = `SELECT e2.id FROM events e2 WHERE e2.entity_ids @> ARRAY[${opts.entityIdLiteral}::bigint]`;
+  const params: string[] = [];
+  let paramIndex = opts.baseParamIndex;
+
+  // Skip namespaces we have no backing index for (e.g. anything outside
+  // STANDARD_IDENTITY_NAMESPACES) — they'd seq-scan events. The fetch helper
+  // already filters to the standard list, but we double-check here so a
+  // future caller that builds scopes manually can't blow up the scan.
+  const indexed = new Set<string>(STANDARD_IDENTITY_NAMESPACES);
+  const scopeBranches: string[] = [];
+  for (const scope of opts.scopes) {
+    if (!indexed.has(scope.namespace)) continue;
+    params.push(scope.identifier);
+    scopeBranches.push(
+      `SELECT e2.id FROM events e2 WHERE e2.metadata->>'${scope.namespace}' = $${paramIndex}`
+    );
+    paramIndex += 1;
+  }
+
+  const branches = [direct, ...scopeBranches].join('\n    UNION\n    ');
+  return {
+    sql: `${alias}.id IN (\n    ${branches}\n  )`,
+    params,
+  };
+}
+
+/**
+ * Build the shared `WHERE` skeleton used by `listContentInternal` for both
+ * its count and list queries.
+ *
+ * `entityLinkSql` is the per-request fragment for "which events belong to
+ * this entity" — see `buildEntityLinkUnion`. Pre-computing it once and
+ * passing it in avoids re-emitting (and re-planning) the 7-branch generic
+ * UNION for every query.
+ */
+function buildStandardWhereSql(entityLinkSql: string): string {
+  return `($1::bigint IS NULL OR ${entityLinkSql})
           AND ($2::text IS NULL OR f.connector_key = $2::text)
           AND ($3::timestamptz IS NULL OR f.occurred_at >= $3::timestamptz)
           AND ($4::timestamptz IS NULL OR f.occurred_at <= $4::timestamptz)
@@ -213,6 +312,7 @@ const STANDARD_WHERE_SQL = `($1::bigint IS NULL OR ${entityLinkMatchSql('$1::big
           ))
           AND ($9::text IS NULL OR f.semantic_type = $9::text)
           AND ($10::text IS NULL OR f.interaction_status = $10::text)`;
+}
 
 const WINDOW_JOIN_SQL = `LEFT JOIN watcher_window_events iwf
           ON iwf.event_id = f.id
@@ -554,7 +654,22 @@ function buildPageInfo(params: {
   };
 }
 
-function buildThreadMetaCteSql(entityIdParam: string, resultSetAlias = 'result_set'): string {
+function buildThreadMetaCteSql(
+  entityIdParam: string,
+  resultSetAlias = 'result_set',
+  entityLinkSql?: string
+): string {
+  // Pre-built scope-aware fragment beats the legacy 7-branch UNION when the
+  // caller has already pre-fetched scopes; fall back to the legacy form for
+  // call sites that haven't been migrated yet.
+  //
+  // When `entityLinkSql` is provided, the caller has already inlined the
+  // entity id (so there's no `$N IS NULL` guard needed). When it isn't
+  // provided, we keep the legacy `(${entityIdParam} IS NULL OR …)` shape so
+  // org-wide callers can pass `$1` and have it dynamically null-checked.
+  const usePrebuilt = entityLinkSql !== undefined;
+  const linkSql = entityLinkSql ?? entityLinkMatchSql(`${entityIdParam}::bigint`, 'p');
+  const entityFilter = usePrebuilt ? linkSql : `(${entityIdParam} IS NULL OR ${linkSql})`;
   return `
     thread_chain AS (
       SELECT
@@ -580,7 +695,7 @@ function buildThreadMetaCteSql(entityIdParam: string, resultSetAlias = 'result_s
       JOIN current_event_records p ON tc.origin_parent_id = p.origin_id
       WHERE tc.origin_parent_id IS NOT NULL
         AND tc.depth < 25
-        AND (${entityIdParam} IS NULL OR ${entityLinkMatchSql(`${entityIdParam}::bigint`, 'p')})
+        AND ${entityFilter}
         AND NOT (COALESCE(p.origin_id, CAST(p.id AS VARCHAR)) = ANY(tc.path))
     ),
     thread_meta AS (
@@ -824,7 +939,14 @@ async function listContentInternal(
   const filtersBySlug = hasClassificationFilters
     ? groupClassificationFilters(classificationFilters)
     : null;
-  const threadMetaCteSql = buildThreadMetaCteSql('$1');
+
+  // Pre-fetch the entity's identity claims so the entity-link UNION only
+  // emits branches for namespaces this entity actually has. For an entity
+  // with 0 identities (~17% of the rows in real data) the legacy
+  // 7-branch UNION takes ~1s on a 4.7GB events table even though every
+  // branch returns 0 rows; the trimmed UNION takes ~200ms.
+  const entityScopes: EntityIdentityScope[] =
+    entityId != null ? await fetchEntityIdentityScopes(sql, entityId) : [];
   const latestClassificationsCteSql = buildLatestClassificationsCteSql();
 
   const listExtraColumns =
@@ -843,9 +965,36 @@ async function listContentInternal(
     const baseConditions: string[] = [];
     const baseParams: any[] = [];
 
+    // Pre-built entity-link fragment for thread_meta's recursive walk.
+    // When entity_id is set we use the trimmed UNION; otherwise threadMeta
+    // doesn't need an entity filter (org-wide listings already constrain
+    // candidates upstream).
+    let threadEntityLinkSql: string | undefined;
     if (entityId != null) {
-      baseParams.push(entityId);
-      baseConditions.push(entityLinkMatchSql(`$${baseParams.length}::bigint`));
+      // Inline the entity id as a literal so the planner picks the
+      // entity-specific GIN scan instead of building a generic plan that
+      // ignores selectivity. The id is already a number from the typed
+      // option; we further validate via validateNumericId below before
+      // passing to buildEntityLinkUnion.
+      const validatedId = validateNumericId(entityId, 'entity_id');
+      const link = buildEntityLinkUnion({
+        entityIdLiteral: validatedId,
+        scopes: entityScopes,
+        alias: 'f',
+        baseParamIndex: baseParams.length + 1,
+      });
+      baseConditions.push(link.sql);
+      baseParams.push(...link.params);
+      // Same shape, alias `p`, for thread_meta's recursive parent walk.
+      threadEntityLinkSql = buildEntityLinkUnion({
+        entityIdLiteral: validatedId,
+        scopes: entityScopes,
+        alias: 'p',
+        // params don't need fresh slots — they're the same identifier values
+        // emitted by the outer `link` already in baseParams. We re-bind them
+        // by reusing the same $N slots.
+        baseParamIndex: baseParams.length - link.params.length + 1,
+      }).sql;
     } else if (organizationId) {
       baseParams.push(organizationId);
       baseConditions.push(
@@ -932,13 +1081,9 @@ async function listContentInternal(
     );
     const total = parseInt(String(countResult[0]?.total ?? '0'), 10);
 
-    // Short-circuit on empty matches. The enrichment query below pulls in
-    // thread_meta (recursive CTE), latest_classifications, parent_context and
-    // root_context joins — for an empty match set, those CTEs still scan
-    // before the planner discovers there are no candidates. On real data this
-    // was the dominant cost on empty-entity loads (per pg_stat_statements:
-    // 6.5s mean vs 3.8ms for the bare count). Returning here trades one
-    // round-trip we already made for skipping the heavy one.
+    // Short-circuit on empty matches — same reasoning as the standard
+    // branch: postgres.js extended protocol pays a real planner cost on
+    // the heavy enrichment query even when server-side execution is fast.
     if (total === 0) {
       return {
         content: [],
@@ -964,9 +1109,14 @@ async function listContentInternal(
     const limitIndex = queryBaseParams.length + 1;
     const offsetIndex = queryBaseParams.length + 2;
     const validatedLimit = validateNumericId(limit, 'limit');
+    const branchThreadMetaCteSql = buildThreadMetaCteSql(
+      '$1',
+      'result_set',
+      threadEntityLinkSql
+    );
     const ctes = needClassifications
-      ? `${threadMetaCteSql},\n        ${latestClassificationsCteSql}`
-      : threadMetaCteSql;
+      ? `${branchThreadMetaCteSql},\n        ${latestClassificationsCteSql}`
+      : branchThreadMetaCteSql;
 
     const contentQuery = useDateFeed
       ? `
@@ -1033,12 +1183,46 @@ async function listContentInternal(
 
   const connectionCondition = buildConnectionFilter(connectionIdsArray);
   const standardParams = buildStandardParams(options, { sinceDate, untilDate });
+
+  // Build the entity-link UNION fragment once so both list and count emit
+  // identical SQL — same shape as before but with namespaces trimmed to the
+  // entity's actual identities. Params slot right after $1-$10 standardParams.
+  let standardEntityLinkSql: string;
+  let standardEntityLinkParams: string[] = [];
+  let standardEntityLinkSqlForP: string | undefined;
+  if (entityId != null) {
+    const validatedId = validateNumericId(entityId, 'entity_id');
+    const link = buildEntityLinkUnion({
+      entityIdLiteral: validatedId,
+      scopes: entityScopes,
+      alias: 'f',
+      baseParamIndex: standardParams.length + 1,
+    });
+    standardEntityLinkSql = link.sql;
+    standardEntityLinkParams = link.params;
+    // thread_meta walks parents (alias `p`); reuse the same param slots so
+    // the params array doesn't grow.
+    standardEntityLinkSqlForP = buildEntityLinkUnion({
+      entityIdLiteral: validatedId,
+      scopes: entityScopes,
+      alias: 'p',
+      baseParamIndex: standardParams.length + 1,
+    }).sql;
+  } else {
+    // Org-wide / no-entity path keeps the legacy 7-branch UNION because the
+    // outer `($1::bigint IS NULL OR …)` short-circuits to true and the SQL
+    // is never evaluated. Cheap.
+    standardEntityLinkSql = entityLinkMatchSql('$1::bigint');
+  }
+  const standardWhereSql = buildStandardWhereSql(standardEntityLinkSql);
+
+  const paramsAfterEntityLink = [...standardParams, ...standardEntityLinkParams];
   const orgScope = buildOrgScopeWhere({
     entity_id: entityId,
     organization_id: organizationId,
-    baseParamIndex: standardParams.length + 1,
+    baseParamIndex: paramsAfterEntityLink.length + 1,
   });
-  const paramsBeforeExclude = [...standardParams, ...orgScope.params];
+  const paramsBeforeExclude = [...paramsAfterEntityLink, ...orgScope.params];
   const excludeClause = buildExcludeWatcherClause(
     options.exclude_watcher_id,
     paramsBeforeExclude.length + 1
@@ -1055,7 +1239,7 @@ async function listContentInternal(
     `SELECT COUNT(*) as total FROM current_event_records f
       LEFT JOIN connections c ON c.id = f.connection_id
       ${WINDOW_JOIN_SQL}
-      WHERE ${STANDARD_WHERE_SQL}
+      WHERE ${standardWhereSql}
         AND ${connectionCondition}
         ${excludeClause.sql}
         ${visibilityClause.sql}
@@ -1064,10 +1248,13 @@ async function listContentInternal(
   );
   const total = parseInt(String(countResult[0]?.total ?? '0'), 10);
 
-  // Short-circuit on empty matches — same reasoning as the
-  // hasClassificationFilters branch above. Skips thread_meta + classifications
-  // + parent/root LEFT JOINs that otherwise scan before the planner notices
-  // the candidate set is empty.
+  // Short-circuit on empty matches. Even with the trimmed entity-link UNION,
+  // the enrichment query — recursive thread_meta + classifications +
+  // parent/root LEFT JOINs — pays a real planner cost on a 4.7GB events
+  // table when run via postgres.js's extended protocol. Empirically that's
+  // ~3-4s of the request even when result_set is empty server-side. Better
+  // to spend one extra round-trip on the cheap count and skip the heavy
+  // query entirely when total=0.
   if (total === 0) {
     return {
       content: [],
@@ -1083,9 +1270,14 @@ async function listContentInternal(
     };
   }
 
+  const standardThreadMetaCteSql = buildThreadMetaCteSql(
+    '$1',
+    'result_set',
+    standardEntityLinkSqlForP
+  );
   const ctes = needClassifications
-    ? `${threadMetaCteSql},\n      ${latestClassificationsCteSql}`
-    : threadMetaCteSql;
+    ? `${standardThreadMetaCteSql},\n      ${latestClassificationsCteSql}`
+    : standardThreadMetaCteSql;
 
   const cursorClause = buildDateCursorClause(
     cursor,
@@ -1106,7 +1298,7 @@ async function listContentInternal(
         FROM current_event_records f
         LEFT JOIN connections c ON c.id = f.connection_id
         ${WINDOW_JOIN_SQL}
-        WHERE ${STANDARD_WHERE_SQL}
+        WHERE ${standardWhereSql}
           AND ${connectionCondition}
           ${excludeClause.sql}
           ${visibilityClause.sql}
@@ -1133,7 +1325,7 @@ async function listContentInternal(
         FROM current_event_records f
         LEFT JOIN connections c ON c.id = f.connection_id
         ${WINDOW_JOIN_SQL}
-        WHERE ${STANDARD_WHERE_SQL}
+        WHERE ${standardWhereSql}
           AND ${connectionCondition}
           ${excludeClause.sql}
           ${visibilityClause.sql}
@@ -1147,6 +1339,7 @@ async function listContentInternal(
   const queryParams = useDateFeed
     ? [...queryBaseParams, fetchLimit]
     : [...queryBaseParams, limit, effectiveOffset];
+
   const rawRows = (await sql.unsafe(querySQL, queryParams)) as any[];
 
   const content = needClassifications
@@ -1275,6 +1468,12 @@ async function searchContentBySingleQuery(
 
   const connectionCondition = buildConnectionFilter(connectionIdsArray);
 
+  // Pre-fetch the entity's identity claims so the entity-link UNION trims
+  // unused namespaces. Search path benefits even more than the chronological
+  // path because filtered_ids re-evaluates on every query variant attempt.
+  const searchEntityScopes: EntityIdentityScope[] =
+    entityId != null ? await fetchEntityIdentityScopes(sql, entityId) : [];
+
   const orgScope = buildOrgScopeWhere({
     entity_id: entityId,
     organization_id: options.organization_id,
@@ -1297,13 +1496,40 @@ async function searchContentBySingleQuery(
     userId: options.visibility_scope?.userId ?? null,
     baseParamIndex: visibilityParamIdx,
   });
-  const baseParamIdx = visibilityParamIdx + visibilityClause.params.length;
+  const entityLinkParamIdx = visibilityParamIdx + visibilityClause.params.length;
+  // Build entity-link UNION (alias `f` for filtered_ids; alias `p` for thread
+  // walk). Params slot after visibility, before vector/min_similarity.
+  let searchEntityLinkSql: string;
+  let searchEntityLinkSqlForP: string | undefined;
+  let searchEntityLinkParams: string[] = [];
+  if (entityId != null) {
+    const validatedId = validateNumericId(entityId, 'entity_id');
+    const link = buildEntityLinkUnion({
+      entityIdLiteral: validatedId,
+      scopes: searchEntityScopes,
+      alias: 'f',
+      baseParamIndex: entityLinkParamIdx,
+    });
+    searchEntityLinkSql = link.sql;
+    searchEntityLinkParams = link.params;
+    searchEntityLinkSqlForP = buildEntityLinkUnion({
+      entityIdLiteral: validatedId,
+      scopes: searchEntityScopes,
+      alias: 'p',
+      baseParamIndex: entityLinkParamIdx,
+    }).sql;
+  } else {
+    // Org-wide path keeps the legacy 7-branch UNION; outer NULL check
+    // short-circuits when entity_id is absent.
+    searchEntityLinkSql = entityLinkMatchSql('$2::bigint');
+  }
+  const baseParamIdx = entityLinkParamIdx + searchEntityLinkParams.length;
   const vectorParamIdx = hasEmbedding ? baseParamIdx : null;
   // Bind min_similarity as a numeric parameter after the vector slot (when
   // present) so a hostile float can't break out of the comparison expression.
   const minSimilarityParamIdx = baseParamIdx + (hasEmbedding ? 1 : 0);
 
-  const standardFiltersSQL = `($2::bigint IS NULL OR ${entityLinkMatchSql('$2::bigint')})
+  const standardFiltersSQL = `($2::bigint IS NULL OR ${searchEntityLinkSql})
           AND ${connectionCondition}
           AND ($3::text IS NULL OR f.connector_key = $3::text)
           AND ($4::timestamptz IS NULL OR f.occurred_at >= $4::timestamptz)
@@ -1389,7 +1615,11 @@ async function searchContentBySingleQuery(
     orderBy: orderByExpr,
   });
 
-  const searchThreadCteSql = buildThreadMetaCteSql('$2');
+  const searchThreadCteSql = buildThreadMetaCteSql(
+    '$2',
+    'result_set',
+    searchEntityLinkSqlForP
+  );
   const latestClassificationsCteSql = buildLatestClassificationsCteSql();
   const ctes = needClassifications
     ? `${searchThreadCteSql},\n      ${latestClassificationsCteSql}`
@@ -1484,6 +1714,7 @@ async function searchContentBySingleQuery(
     ...orgScope.params,
     ...excludeClause.params,
     ...visibilityClause.params,
+    ...searchEntityLinkParams,
     ...(hasEmbedding ? [toVectorLiteral(queryEmbedding!), minSimilarity] : []),
     ...cursorClause.params,
     ...(useDateFeed ? [fetchLimit] : [limit, effectiveOffset]),

--- a/packages/owletto-backend/src/utils/content-search.ts
+++ b/packages/owletto-backend/src/utils/content-search.ts
@@ -265,7 +265,7 @@ export function buildOrgScopeWhere(options: {
   entity_id?: number;
   organization_id?: string;
   baseParamIndex: number;
-}): { sql: string; params: unknown[] } {
+}): { sql: string; params: Array<string | number | null> } {
   if (options.entity_id || !options.organization_id) return { sql: '', params: [] };
 
   const p = `$${options.baseParamIndex}::text`;
@@ -300,7 +300,7 @@ export function buildConnectionVisibilityClause(
     baseParamIndex: number;
   },
   tableAlias: string = 'f'
-): { sql: string; params: unknown[] } {
+): { sql: string; params: Array<string | number | null> } {
   if (!options.organizationId) return { sql: '', params: [] };
 
   const orgParam = `$${options.baseParamIndex}::text`;
@@ -932,6 +932,28 @@ async function listContentInternal(
     );
     const total = parseInt(String(countResult[0]?.total ?? '0'), 10);
 
+    // Short-circuit on empty matches. The enrichment query below pulls in
+    // thread_meta (recursive CTE), latest_classifications, parent_context and
+    // root_context joins — for an empty match set, those CTEs still scan
+    // before the planner discovers there are no candidates. On real data this
+    // was the dominant cost on empty-entity loads (per pg_stat_statements:
+    // 6.5s mean vs 3.8ms for the bare count). Returning here trades one
+    // round-trip we already made for skipping the heavy one.
+    if (total === 0) {
+      return {
+        content: [],
+        total: 0,
+        page: buildPageInfo({
+          limit,
+          offset: effectiveOffset,
+          total: 0,
+          returnedCount: 0,
+          useDateFeed,
+          cursor,
+        }),
+      };
+    }
+
     const cursorClause = buildDateCursorClause(
       cursor,
       'f.occurred_at',
@@ -1041,6 +1063,25 @@ async function listContentInternal(
     countParams
   );
   const total = parseInt(String(countResult[0]?.total ?? '0'), 10);
+
+  // Short-circuit on empty matches — same reasoning as the
+  // hasClassificationFilters branch above. Skips thread_meta + classifications
+  // + parent/root LEFT JOINs that otherwise scan before the planner notices
+  // the candidate set is empty.
+  if (total === 0) {
+    return {
+      content: [],
+      total: 0,
+      page: buildPageInfo({
+        limit,
+        offset: effectiveOffset,
+        total: 0,
+        returnedCount: 0,
+        useDateFeed,
+        cursor,
+      }),
+    };
+  }
 
   const ctes = needClassifications
     ? `${threadMetaCteSql},\n      ${latestClassificationsCteSql}`

--- a/packages/owletto-backend/src/utils/content-search.ts
+++ b/packages/owletto-backend/src/utils/content-search.ts
@@ -279,6 +279,44 @@ export function buildOrgScopeWhere(options: {
 }
 
 /**
+ * Build a connection-visibility WHERE clause that lives inline alongside the
+ * other content filters, so the list and count queries don't need a separate
+ * "which connection ids may I see?" round trip.
+ *
+ * Semantics (must match `getContent`'s legacy two-step flow):
+ *  - Authed user: connections with `visibility='org' OR created_by = $userId`.
+ *  - Unauthed:    connections with `visibility='org'`.
+ *  - Soft-deleted connections (`deleted_at IS NOT NULL`) are excluded.
+ *  - Events with `connection_id IS NULL` (system / non-connection events)
+ *    are visible in both authed and unauthed cases.
+ *
+ * Returns an empty fragment when no scope is requested (callers like the
+ * watcher-mode/condensation path that already select by other constraints).
+ */
+export function buildConnectionVisibilityClause(
+  options: {
+    organizationId?: string;
+    userId?: string | null;
+    baseParamIndex: number;
+  },
+  tableAlias: string = 'f'
+): { sql: string; params: unknown[] } {
+  if (!options.organizationId) return { sql: '', params: [] };
+
+  const orgParam = `$${options.baseParamIndex}::text`;
+  const userParam = `$${options.baseParamIndex + 1}::text`;
+  return {
+    sql: `AND (${tableAlias}.connection_id IS NULL OR ${tableAlias}.connection_id IN (
+      SELECT vc.id FROM connections vc
+      WHERE vc.organization_id = ${orgParam}
+        AND vc.deleted_at IS NULL
+        AND (vc.visibility = 'org' OR (${userParam} IS NOT NULL AND vc.created_by = ${userParam}))
+    ))`,
+    params: [options.organizationId, options.userId ?? null],
+  };
+}
+
+/**
  * Search options for content vector search
  */
 interface ContentSearchOptions {
@@ -287,6 +325,16 @@ interface ContentSearchOptions {
   organization_id?: string; // Required when entity_id is omitted (org-wide mode)
 
   connection_ids?: number[]; // Array of connection IDs to filter by
+  /**
+   * Connection-visibility scope. When set, the SQL WHERE clause inlines a
+   * subquery that hides events from private connections the caller cannot
+   * see. Replaces the older "look up excluded connection ids first, pass them
+   * in as connection_ids" two-query dance that the gateway used to do.
+   *
+   * Authenticated callers pass their user id; unauth callers pass null.
+   * Events with `connection_id IS NULL` are always visible.
+   */
+  visibility_scope?: { organizationId: string; userId: string | null };
   window_id?: number; // Filter by watcher window ID
   exclude_watcher_id?: number; // Exclude content already in any window for this watcher
   platform?: string;
@@ -870,10 +918,16 @@ async function listContentInternal(
       options.exclude_watcher_id,
       filterParamsBeforeExclude.length + 1
     );
-    const allFilterParams = [...filterParamsBeforeExclude, ...excludeClause.params];
+    const filterParamsBeforeVisibility = [...filterParamsBeforeExclude, ...excludeClause.params];
+    const visibilityClause = buildConnectionVisibilityClause({
+      organizationId: options.visibility_scope?.organizationId,
+      userId: options.visibility_scope?.userId ?? null,
+      baseParamIndex: filterParamsBeforeVisibility.length + 1,
+    });
+    const allFilterParams = [...filterParamsBeforeVisibility, ...visibilityClause.params];
 
     const countResult = await sql.unsafe<{ total: number | string }>(
-      `SELECT COUNT(*) as total FROM current_event_records f LEFT JOIN connections c ON c.id = f.connection_id WHERE ${whereSql} ${excludeClause.sql}`,
+      `SELECT COUNT(*) as total FROM current_event_records f LEFT JOIN connections c ON c.id = f.connection_id WHERE ${whereSql} ${excludeClause.sql} ${visibilityClause.sql}`,
       allFilterParams
     );
     const total = parseInt(String(countResult[0]?.total ?? '0'), 10);
@@ -902,6 +956,7 @@ async function listContentInternal(
           LEFT JOIN connections c ON c.id = f.connection_id
           WHERE ${whereSql}
             ${excludeClause.sql}
+            ${visibilityClause.sql}
             ${cursorClause.sql}
           ORDER BY ${buildDateCandidateOrderBy(cursor, 'f')}
           LIMIT $${limitIndex}
@@ -923,7 +978,7 @@ async function listContentInternal(
             NULL::bigint as cursor_fetched_count
           FROM current_event_records f
           LEFT JOIN connections c ON c.id = f.connection_id
-          WHERE ${whereSql} ${excludeClause.sql}
+          WHERE ${whereSql} ${excludeClause.sql} ${visibilityClause.sql}
           ORDER BY ${orderByForResultSet}
           LIMIT $${limitIndex} OFFSET $${offsetIndex}
         ),
@@ -966,7 +1021,13 @@ async function listContentInternal(
     options.exclude_watcher_id,
     paramsBeforeExclude.length + 1
   );
-  const countParams = [...paramsBeforeExclude, ...excludeClause.params];
+  const paramsBeforeVisibility = [...paramsBeforeExclude, ...excludeClause.params];
+  const visibilityClause = buildConnectionVisibilityClause({
+    organizationId: options.visibility_scope?.organizationId,
+    userId: options.visibility_scope?.userId ?? null,
+    baseParamIndex: paramsBeforeVisibility.length + 1,
+  });
+  const countParams = [...paramsBeforeVisibility, ...visibilityClause.params];
 
   const countResult = await sql.unsafe(
     `SELECT COUNT(*) as total FROM current_event_records f
@@ -975,6 +1036,7 @@ async function listContentInternal(
       WHERE ${STANDARD_WHERE_SQL}
         AND ${connectionCondition}
         ${excludeClause.sql}
+        ${visibilityClause.sql}
         ${orgScope.sql}`,
     countParams
   );
@@ -1006,6 +1068,7 @@ async function listContentInternal(
         WHERE ${STANDARD_WHERE_SQL}
           AND ${connectionCondition}
           ${excludeClause.sql}
+          ${visibilityClause.sql}
           ${orgScope.sql}
           ${cursorClause.sql}
         ORDER BY ${buildDateCandidateOrderBy(cursor, 'f')}
@@ -1032,6 +1095,7 @@ async function listContentInternal(
         WHERE ${STANDARD_WHERE_SQL}
           AND ${connectionCondition}
           ${excludeClause.sql}
+          ${visibilityClause.sql}
           ${orgScope.sql}
         ORDER BY ${orderByForResultSet}
         LIMIT $${limitIdx} OFFSET $${offsetIdx}

--- a/packages/owletto-backend/src/utils/content-search.ts
+++ b/packages/owletto-backend/src/utils/content-search.ts
@@ -1246,7 +1246,17 @@ async function searchContentBySingleQuery(
     options.exclude_watcher_id,
     excludeParamIdx
   );
-  const baseParamIdx = excludeParamIdx + excludeClause.params.length;
+  // Connection-visibility predicate. Same helper used by every other
+  // get_content branch, so authed/unauthed/private/system-event semantics
+  // are guaranteed identical across the search/text-query path and the
+  // chronological list path.
+  const visibilityParamIdx = excludeParamIdx + excludeClause.params.length;
+  const visibilityClause = buildConnectionVisibilityClause({
+    organizationId: options.visibility_scope?.organizationId,
+    userId: options.visibility_scope?.userId ?? null,
+    baseParamIndex: visibilityParamIdx,
+  });
+  const baseParamIdx = visibilityParamIdx + visibilityClause.params.length;
   const vectorParamIdx = hasEmbedding ? baseParamIdx : null;
   // Bind min_similarity as a numeric parameter after the vector slot (when
   // present) so a hostile float can't break out of the comparison expression.
@@ -1263,6 +1273,7 @@ async function searchContentBySingleQuery(
           AND ($9::text IS NULL OR f.semantic_type = $9::text)
           AND ($10::text IS NULL OR f.interaction_status = $10::text)
           ${excludeClause.sql}
+          ${visibilityClause.sql}
           ${orgScope.sql}`;
 
   const textDocumentExpr = buildSearchDocumentExpr('f');
@@ -1431,6 +1442,7 @@ async function searchContentBySingleQuery(
     options.interaction_status ?? null,
     ...orgScope.params,
     ...excludeClause.params,
+    ...visibilityClause.params,
     ...(hasEmbedding ? [toVectorLiteral(queryEmbedding!), minSimilarity] : []),
     ...cursorClause.params,
     ...(useDateFeed ? [fetchLimit] : [limit, effectiveOffset]),


### PR DESCRIPTION
## Summary

Stream B of [.plans/atlas-events-fix.md](.plans/atlas-events-fix.md) — backend half of the `/atlas/events` first-paint fix, plus full visibility coverage across every read path in `get_content`, plus the entity-link UNION trim that closes the populated-entity slowness.

## Real-data smoke test (worktree dev against user's local Postgres)

| Case | Pre-PR (#455 branch base) | After this commit | Saved |
|---|---|---|---|
| Empty entity (id 1687, 0 events) | ~10s | ~1.7s warm | ~8.3s |
| Populated entity (id 1507, 3,377 events) | ~9.6s | ~3.5s | ~6.1s |

The user's stated targets (<100ms empty, <500ms populated) are not reachable on this DB without folding org-slug + entity-info + read-access + count + enrichment into one batched query — that's a multi-week refactor of the auth path. The DB's per-query round-trip floor is ~150ms (Tailscale relay), and the request needs at minimum: org-resolve, read-access check, parallel(slug + entity-info), count, enrichment, post-fetch enrichment. Each one of those is a round-trip. We've parallelized the independent ones; the rest are sequenced because the next query's params depend on the previous query's result.

What I shipped vs what'd take a separate PR:
- ✅ Trimmed the 7-branch UNION to actual entity scopes
- ✅ Parallelized org-slug + entity-info
- ✅ Parallelized client_name + parent_context post-fetch
- ❌ Targets <100ms / <500ms — needs a batched stored-procedure or dedicated batch endpoint that fuses auth+read into one round-trip. Out of scope for this PR.

## What this commit changes

### 1. `entityLinkMatchSql` was emitting useless UNION branches

The legacy helper emitted a 7-branch `UNION` over a hardcoded standard-namespaces list (email/phone/wa_jid/slack_user_id/github_login/auth_user_id/google_contact_id) for every entity. On real data, ~17% of entities (including 1687, 1507) have **zero** rows in `entity_identities`. Each unused branch is still a `JOIN entity_identities ei ON ei.entity_id = $1 AND ei.namespace = '<ns>'` that the planner has to think about. Reproduced in psql against the user's DB (entity 1507, 3,377 events, 0 identities):

```
7-branch UNION  →  candidate_set count: 1,152ms
direct branch only  →  candidate_set count:   202ms
```

### 2. New helpers in `utils/content-search.ts`

- `EntityIdentityScope` — `{ namespace, identifier }`.
- `fetchEntityIdentityScopes(sql, entityId)` — single indexed scan over `idx_entity_identities_by_entity`. Filters to `STANDARD_IDENTITY_NAMESPACES` so unindexed namespaces never reach the read path. Cheap (~1ms server-side).
- `buildEntityLinkUnion({ entityIdLiteral, scopes, alias, baseParamIndex })` — emits the direct `entity_ids @> ARRAY[N::bigint]` branch always, plus one `metadata->>'<ns>' = $X` branch per pre-fetched scope. **No JOIN to `entity_identities`** — identifier values are bound params, entity id is an inlined literal.
- `buildStandardWhereSql(entityLinkSql)` — converted from a module-level constant to a function that takes the per-request entity-link fragment.

### 3. Threaded through every read path

| File / function | Change |
|---|---|
| `content-search.ts` `listContentInternal` (standard branch) | Pre-fetch scopes once; build entity-link union for alias `f` (count + list) and alias `p` (thread_meta walk) |
| `content-search.ts` `listContentInternal` (classification-filter branch) | Same |
| `content-search.ts` `searchContentBySingleQuery` (text/vector search) | Same; plumbed through standardFiltersSQL and searchThreadCteSql |
| `content-scoring.ts` `getNormalizedScoreContent` | Pre-fetch once; used in step 1 (sources discovery) AND step 3 (scored CTE). Threaded into `buildFilterConditionsAndJoins` |
| `content-scoring.ts` `getNormalizedScoreContentCount` | Same |
| `get_content.ts` `content_ids` branch | When `entity_id` is also set, pre-fetch + use trimmed UNION |
| `get_content.ts` `include_superseded` branch | Same; entity_id is inlined as literal (was bound `$2` — fixed an unused-param-type error) |
| `get_content.ts` classification-stats CTE | Same |
| `buildThreadMetaCteSql` | Optional `entityLinkSql` parameter; when provided, uses pre-built fragment and skips the legacy `IS NULL` guard |

### 4. Parallelized independent round-trips in `getContent`

- `getOrganizationSlug` + entity-info lookup → `Promise.all` (saves ~150ms on warm requests).
- `client_name` batch + `parent_context` batch → `Promise.all` (saves ~200-700ms on populated, depending on how many parents need backfill).

### 5. What I did NOT change (and why)

- Count and enrichment within `listContentInternal` are NOT parallelized. I tried this and it made empty entities WORSE (4-5s), because postgres.js's extended protocol pays a real planner cost on the recursive enrichment query even when `result_set` ends up empty server-side. Better to keep the cheap-count → empty-short-circuit path for the empty case.
- Legacy `entityLinkMatchSql` kept for callers that build the predicate against a column reference (per-row LATERAL subqueries in admin/internal paths) and can't pre-fetch synchronously: `tools/search.ts:417,452`, `tools/get_watchers.ts:1103`, `tools/admin/manage_watchers.ts:104`, `tools/resolve_path.ts:473,763`, `utils/entity-management.ts:441,766`, `utils/classification-query.ts:170`, `scheduled/classification-reconciliation.ts:149`, `index.ts:752`. These are not in the events-tab read latency budget; converting them is a separate, larger refactor.
- No new index migration. EXPLAIN ANALYZE on this DB confirmed no index gap — the populated query is dominated by network round-trip (24ms server-side, 1500ms client round-trip) and the wasted UNION branches' planning cost. Both are addressed without new indexes.

## Visibility coverage (unchanged from prior commits in this branch, audit grep refreshed)

All five query branches go through `buildConnectionVisibilityClause`:
1. Chronological list (`listContentInternal`)
2. `content_ids` branch
3. `include_superseded` branch
4. `sort_by=score` (`getNormalizedScoreContent` + `getNormalizedScoreContentCount`)
5. Search / text-query (`searchContentBySingleQuery`)
Plus the classification-stats CTE.

## Tests

`packages/owletto-backend/src/__tests__/integration/events/get-content-visibility.test.ts` — 26 tests across five `describe` blocks, all pass under PGlite.

The `include_superseded` branch's signature change (entity_id inlined, not bound) caught a real param-index bug during testing — the unused `$2` placeholder was triggering `could not determine data type of parameter $2`. Fixed in this commit.

## Validation

- [x] Reproduced CI typecheck failure locally first (`cd packages/owletto-backend && bunx tsc --noEmit`); all 8 packages clean after fix.
- [x] `bun run typecheck` clean.
- [x] `make build-packages` clean.
- [x] All 26 visibility tests pass; all 44 events integration tests pass under PGlite.
- [x] Audit grep for `FROM (current_event_records|events)\b` reviewed — every primary scan goes through `buildConnectionVisibilityClause`.
- [x] Real-data smoke test on user's DB (worktree dev, polite shutdown + restart of user's dev): empty 1.7s, populated 3.5s.

## Acceptance from the plan

- [x] No 2-step visibility round-trip on any path
- [x] Visibility enforced by single shared helper across all 5 branches + stats CTE
- [x] Stats gated on explicit `include_classification: 'summary'`
- [x] Empty entity short-circuit closes the empty-CTE-runs-on-empty cost
- [x] Entity-link UNION trim closes the populated 9.4s → 3.5s gap
- [x] CI typecheck green
- [ ] **Empty <100ms / Populated <500ms** — not reached in this PR; needs auth-path batching that's out of scope