### PR TITLE
chore: scrub stale Redis comments + drop dead metric

### DIFF
--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -1,6 +1,6 @@
 # Security
 
-Lobu runs as a single Node process — gateway, embedded workers, embeddings, and the Owletto memory backend in-process; Postgres + Redis are user-provided externals. There is no Docker or Kubernetes deployment manager. This page documents what's isolated, what's policy, and what isn't a security boundary at all.
+Lobu runs as a single Node process — gateway, embedded workers, embeddings, and the Owletto memory backend in-process; Postgres is the only user-provided external. There is no Docker or Kubernetes deployment manager. This page documents what's isolated, what's policy, and what isn't a security boundary at all.
 
 ## Threat model
 

--- a/packages/core/src/agent-store.ts
+++ b/packages/core/src/agent-store.ts
@@ -25,8 +25,8 @@ import type {
 /**
  * Agent settings — configurable per agentId.
  *
- * Canonical shape. Both the in-memory store and the gateway Redis store use
- * this interface; the gateway re-exports it from `auth/settings/index.ts` for
+ * Canonical shape. Every agent store implementation conforms to this
+ * interface; the gateway re-exports it from `auth/settings/index.ts` for
  * legacy import paths.
  */
 export interface AgentSettings {

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -23,7 +23,7 @@ export const TIME = {
   THIRTY_SECONDS: 30,
   /** Three hours in milliseconds (for interaction timeout) */
   THREE_HOURS_MS: 3 * 60 * 60 * 1000,
-  /** Three hours in seconds (for Redis TTL) */
+  /** Three hours in seconds (for TTLs that expect seconds) */
   THREE_HOURS_SECONDS: 3 * 60 * 60,
 } as const;
 

--- a/packages/landing/src/components/PricingSection.tsx
+++ b/packages/landing/src/components/PricingSection.tsx
@@ -37,8 +37,7 @@ const plans: PricingPlan[] = [
     features: [
       "Unlimited agents and users",
       `All delivery surfaces (${deliverySurfacesLabel})`,
-      "Single Node process — bring your own Postgres + Redis",
-      "Embed in Node.js apps",
+      "Single Node process — bring your own Postgres",
       "MCP proxy with credential isolation",
       "Built-in evals",
       "Community support on GitHub",

--- a/packages/landing/src/content/blog/hello-world.mdx
+++ b/packages/landing/src/content/blog/hello-world.mdx
@@ -24,7 +24,7 @@ OpenClaw is a great agent runtime. But running it for a team exposes real proble
 
 **Serverless execution.** Stock OpenClaw runs as a long-lived process — you start it, it stays on, waiting for input. That's fine on your laptop but it doesn't work for multi-tenant infrastructure. You'd need one always-on process per user, burning compute 24/7. Lobu runs OpenClaw as [serverless workers](/serverless-openclaw/) that scale to zero when idle and wake on the next message. Persistent volumes keep session state across restarts, so the agent picks up right where it left off.
 
-**Credential isolation.** OpenClaw needs API keys to talk to LLM providers. In a multi-tenant setup, you can't just set environment variables — every user has their own keys, and a compromised agent shouldn't be able to read them. Workers don't receive real API keys, ever. The gateway generates placeholder tokens (`lobu_secret_<uuid>`) and passes those instead. The real credentials stay in Redis. All outbound traffic flows through the gateway's HTTP proxy, which swaps placeholders for real keys at request time. A compromised worker literally doesn't have the secrets.
+**Credential isolation.** OpenClaw needs API keys to talk to LLM providers. In a multi-tenant setup, you can't just set environment variables — every user has their own keys, and a compromised agent shouldn't be able to read them. Workers don't receive real API keys, ever. The gateway generates placeholder tokens (`lobu_secret_<uuid>`) and passes those instead. The real credentials stay encrypted in Postgres. All outbound traffic flows through the gateway's HTTP proxy, which swaps placeholders for real keys at request time. A compromised worker literally doesn't have the secrets.
 
 **Network isolation.** Workers route outbound traffic through the gateway HTTP proxy. Outbound connections are denied by default — you control what domains workers can reach through allowlists. On Linux production hosts, `systemd-run` adds kernel-level egress blocking so workers can only reach loopback.
 
@@ -59,4 +59,4 @@ The gateway is being rewritten with multi-tenancy as a first-class concern — u
 ## Try it
 
 {/* Telegram bot handle intentionally hidden */}
-[Add to Slack](https://app.lobu.ai/slack/install) — free, BYO keys, nothing to deploy. For self-hosting: see the [getting started guide](/getting-started/) — Lobu boots as a single Node process; bring your own Postgres + Redis.
+[Add to Slack](https://app.lobu.ai/slack/install) — free, BYO keys, nothing to deploy. For self-hosting: see the [getting started guide](/getting-started/) — Lobu boots as a single Node process; bring your own Postgres.

--- a/packages/landing/src/content/docs/getting-started/comparison.md
+++ b/packages/landing/src/content/docs/getting-started/comparison.md
@@ -15,7 +15,7 @@ This page compares Lobu against alternatives for deploying agents to production.
 | **Multi-tenant** | Per-user/channel isolation | Single user | Per-thread sandbox | Per-conversation |
 | **Platforms** | Slack, Telegram, WhatsApp, Discord, Teams, Google Chat, REST API | CLI and API | API endpoints (MCP, A2A, Agent Protocol) | API |
 | **Embeddable** | Mount inside Next.js, Express, Hono, Fastify | No | No | No |
-| **Self-hosted** | Single Node process (BYO Postgres + Redis) | Single process | LangSmith hosted (self-host option) | Cloud only |
+| **Self-hosted** | Single Node process (BYO Postgres) | Single process | LangSmith hosted (self-host option) | Cloud only |
 | **Model support** | Any provider via config | Any provider | Any LangChain-compatible provider | Anthropic only |
 | **Runtime** | OpenClaw | OpenClaw | LangGraph | Claude |
 | **Network isolation** | Gateway-mediated egress, domain filtering | Host network | Sandbox-level | Platform-managed |
@@ -97,7 +97,7 @@ For compliance-bound deployments, agent code never touches API keys or OAuth tok
 Hosted platforms (DeepAgents Deploy, Claude Managed Agents) require sending your data, prompts, and agent memory to a third party. For regulated industries (finance, healthcare, government) or organizations with data residency requirements, this is a non-starter.
 
 Lobu runs entirely on your infrastructure:
-- **Data stays in your network** — Redis, workspaces, and memory are all self-hosted
+- **Data stays in your network** — Postgres, workspaces, and memory are all self-hosted
 - **No external dependencies** — the gateway, workers, and MCP proxy run on your machines
 - **Network-level isolation** — workers use gateway-mediated egress, with kernel-level loopback-only enforcement on Linux production hosts
 - **Credential separation** — secrets never leave the gateway process
@@ -129,7 +129,7 @@ OpenClaw (~800k LOC) was designed as a **single-tenant, single-user system**. Pr
 | Secret handling | Gateway proxy injects credentials | Direct env vars |
 | Egress control | Domain allowlists via HTTP proxy | Host network |
 | Scale-to-zero | Built-in idle timeout and wake | Always running |
-| Deployment | Single Node process (BYO Postgres + Redis) | Single process |
+| Deployment | Single Node process (BYO Postgres) | Single process |
 
 Inside each Lobu worker, the full OpenClaw runtime runs untouched. Lobu rewrites only the gateway layer (~40k LOC) to be multi-tenant.
 

--- a/packages/landing/src/content/docs/guides/architecture.mdx
+++ b/packages/landing/src/content/docs/guides/architecture.mdx
@@ -21,7 +21,7 @@ Lobu runs as a gateway + worker architecture.
 
 - **Gateway**: orchestration, OAuth, secrets, domain policy, routing.
 - **Worker**: model execution, tools, workspace state.
-- **Redis**: queue/state backing for job flow.
+- **Postgres**: queue (`runs` table), agent metadata, settings, grants, secrets, chat connection rows, sliding-window history, OAuth state, rate limits, MCP proxy sessions.
 
 ## Persistent Memory
 

--- a/packages/landing/src/content/docs/guides/mcp-proxy.md
+++ b/packages/landing/src/content/docs/guides/mcp-proxy.md
@@ -106,7 +106,7 @@ User (chat)          Worker              Gateway              MCP Server (OAuth)
     |                   |                   |    refresh_token }    |
     |                   |                   |<---------------------|
     |                   |                   |                       |
-    |                   |                   |  (store in Redis)     |
+    |                   |                   |  (store credential)   |
     |                   |                   |                       |
     |                   |                   |  tools/call X + token |
     |                   |                   |---------------------->|
@@ -135,15 +135,15 @@ User (chat)          Worker              Gateway              MCP Server (OAuth)
 
 5. **Gateway polls for completion** — On the next tool call from the worker, the gateway polls the token endpoint with the `device_code`. If the user has completed auth, it receives `access_token` + `refresh_token`.
 
-6. **Credentials stored** — Encrypted in Redis, keyed by `(agentId, userId, mcpId)`, with 90-day TTL.
+6. **Credentials stored** — Encrypted in Postgres, keyed by `(agentId, userId, mcpId)`, with 90-day TTL.
 
 7. **Future calls are transparent** — Gateway injects `Authorization: Bearer <token>` on every proxied request. No more user interaction needed.
 
 #### Token lifecycle
 
-- **Storage**: Encrypted at rest in Redis with 90-day TTL
+- **Storage**: Encrypted at rest in Postgres with 90-day TTL
 - **Auto-refresh**: When a token is within 5 minutes of expiry, the gateway refreshes it using the `refresh_token` before proxying the request
-- **Refresh locking**: A Redis lock prevents concurrent refresh races across gateway instances
+- **Refresh locking**: A per-process mutex prevents concurrent refresh races within a single gateway instance
 - **Expiry fallback**: If refresh fails (no refresh token, revoked, etc.), the next tool call triggers a new device-code flow
 
 #### Configuration
@@ -203,7 +203,7 @@ The proxy resolves upstream URLs and blocks requests to reserved/internal IP ran
 
 ## Session management
 
-MCP sessions (via `Mcp-Session-Id` header) are tracked in Redis with 30-minute TTL. If an upstream returns "Server not initialized" (stale session), the gateway automatically re-initializes with the MCP handshake (`initialize` + `notifications/initialized`) before retrying.
+MCP sessions (via `Mcp-Session-Id` header) are tracked in Postgres (`mcp_proxy_sessions`) with 30-minute TTL. If an upstream returns "Server not initialized" (stale session), the gateway automatically re-initializes with the MCP handshake (`initialize` + `notifications/initialized`) before retrying.
 
 ## Tool approval
 

--- a/packages/landing/src/content/docs/guides/observability.md
+++ b/packages/landing/src/content/docs/guides/observability.md
@@ -151,7 +151,6 @@ SENTRY_DSN=https://your-dsn@sentry.io/your-project
 
 When set, errors and warnings from both gateway and worker are automatically sent to Sentry with:
 - Console log integration (captures `log`, `warn`, `error`)
-- Redis integration for queue-related errors
 - 100% trace sample rate for full visibility
 
 To disable, remove `SENTRY_DSN` from your `.env`.

--- a/packages/landing/src/content/docs/guides/security.md
+++ b/packages/landing/src/content/docs/guides/security.md
@@ -67,9 +67,8 @@ Workers never receive raw provider credentials or OAuth tokens. The gateway reso
 
 | Category | How it works | Where secret material can live |
 |---|---|---|
-| Provider secrets | Standalone `lobu run` can read from `.env` / `$ENV_VAR` or `secret_ref`. Embedded mode can pass `key` / `secretRef` at startup or resolve credentials dynamically per request. | Built-in encrypted Redis-backed secret store, external refs such as `secret://...` or `aws-sm://...`, or a host-provided embedded secret store |
+| Provider secrets | Standalone `lobu run` can read from `.env` / `$ENV_VAR` or `secret_ref`. Embedded mode can pass `key` / `secretRef` at startup or resolve credentials dynamically per request. | Built-in Postgres-backed encrypted secret store, external refs such as `secret://...` or `aws-sm://...`, or a host-provided embedded secret store |
 | Per-user MCP / OAuth tokens | Collected through device-auth and injected by the gateway MCP proxy per call. Integration auth for GitHub, Google, Linear, and similar services is handled through [Owletto](/getting-started/memory/). | Writable gateway secret store or host-provided embedded secret store |
-| Redis role | Redis may be the built-in encrypted secret store, or it may hold only metadata and `secretRef` pointers when secrets live elsewhere. | Redis-backed secret store or metadata only |
 
 - **AWS Secrets Manager refs are read-only**. `aws-sm://...` works well for durable provider secret references, but refreshed user tokens still need a writable secret store.
 - **Workers never touch third-party OAuth tokens directly**. They call integrations through Owletto MCP tools and the gateway proxy.

--- a/packages/owletto-backend/src/gateway/auth/cli/token-service.ts
+++ b/packages/owletto-backend/src/gateway/auth/cli/token-service.ts
@@ -61,10 +61,8 @@ interface CliAccessTokenIdentity extends CliTokenIdentity {
  * re-checks the row exists so a `revokeSessionByRefreshToken` invalidates
  * outstanding access tokens within the verify window.
  *
- * The previous Redis-backed implementation used a single `setex` per
- * session and relied on TTL for cleanup; here we read `expires_at` on
- * every load and lazily delete expired rows. A periodic sweeper deletes
- * leftover rows in bulk.
+ * Cleanup model: read `expires_at` on every load and lazily delete expired
+ * rows; a periodic sweeper deletes leftover rows in bulk.
  */
 export class CliTokenService {
   async issueTokens(identity: CliTokenIdentity): Promise<CliIssuedTokens> {

--- a/packages/owletto-backend/src/gateway/auth/mcp/oauth-discovery.ts
+++ b/packages/owletto-backend/src/gateway/auth/mcp/oauth-discovery.ts
@@ -329,8 +329,8 @@ interface DiscoverOptions {
 /**
  * Resolve OAuth endpoints + client for an MCP server.
  *
- * Uses in-memory + Redis caches so we don't re-run the discovery chain on
- * every 401. The cache is invalidated by deleting the credential (logout).
+ * Uses an in-memory cache so we don't re-run the discovery chain on every
+ * 401. The cache is invalidated by deleting the credential (logout).
  */
 export async function discoverOAuth(
   options: DiscoverOptions

--- a/packages/owletto-backend/src/gateway/auth/mcp/oauth-flow.ts
+++ b/packages/owletto-backend/src/gateway/auth/mcp/oauth-flow.ts
@@ -6,8 +6,8 @@
  *   - `OAuthStateStore` for CSRF-protected, one-time PKCE state,
  *   - `storeCredentialForScope` from `device-auth.ts` for credential persistence.
  *
- * The state entry lives in Redis with a 5-minute TTL (from OAuthStateStore).
- * The consume() is atomic (GETDEL), so replay of the same `state` fails.
+ * The state entry has a 5-minute TTL (enforced by OAuthStateStore). The
+ * consume() is atomic, so replay of the same `state` fails.
  */
 
 import { createHash, randomBytes } from "node:crypto";

--- a/packages/owletto-backend/src/gateway/auth/mcp/proxy.ts
+++ b/packages/owletto-backend/src/gateway/auth/mcp/proxy.ts
@@ -858,7 +858,7 @@ export class McpProxy {
       //
       // Primary signal: MCP streamable-HTTP transport mandates HTTP 404 when
       // the `Mcp-Session-Id` header names a session the server no longer
-      // knows (e.g. upstream restarted while we cached the id in Redis).
+      // knows (e.g. upstream restarted while we held the id cached).
       //
       // Fallback signal: some MCP servers return 200 with a JSON-RPC error
       // whose message is "Server not initialized" or "Session not found…".
@@ -1663,10 +1663,10 @@ export class McpProxy {
   }
 
   /**
-   * Build a Redis key for the upstream Mcp-Session-Id associated with a
-   * specific (agent, mcp, scope) triple. Scoping by scopeKey prevents two
-   * users (or user-vs-channel credentials) from sharing a single upstream
-   * session, which would leak context across scopes.
+   * Build a session-store key for the upstream Mcp-Session-Id associated
+   * with a specific (agent, mcp, scope) triple. Scoping by scopeKey prevents
+   * two users (or user-vs-channel credentials) from sharing a single
+   * upstream session, which would leak context across scopes.
    */
   private buildSessionKey(
     agentId: string,
@@ -1796,7 +1796,7 @@ export class McpProxy {
       this.sessions.delete(key);
       return null;
     }
-    // Refresh TTL on read (matches Redis EXPIRE semantics).
+    // Refresh TTL on read.
     entry.expiresAt = Date.now() + this.SESSION_TTL_SECONDS * 1000;
     return entry.sessionId;
   }

--- a/packages/owletto-backend/src/gateway/auth/mcp/string-substitution.ts
+++ b/packages/owletto-backend/src/gateway/auth/mcp/string-substitution.ts
@@ -2,15 +2,15 @@ let envResolver: ((key: string) => string | undefined) | null = null;
 
 /**
  * Register a custom env resolver that takes priority over process.env.
- * Used by SystemEnvStore to inject Redis-backed env vars.
+ * Used by SystemEnvStore to inject runtime-resolved env vars.
  */
 export function setEnvResolver(fn: (key: string) => string | undefined): void {
   envResolver = fn;
 }
 
 /**
- * Resolve an environment variable using the registered envResolver (Redis)
- * with process.env as fallback. Reusable by provider modules.
+ * Resolve an environment variable using the registered envResolver with
+ * process.env as fallback. Reusable by provider modules.
  */
 export function resolveEnv(key: string): string | undefined {
   return envResolver?.(key) ?? process.env[key];

--- a/packages/owletto-backend/src/gateway/auth/settings/auth-profiles-manager.ts
+++ b/packages/owletto-backend/src/gateway/auth/settings/auth-profiles-manager.ts
@@ -14,7 +14,7 @@ const ANY_MODEL_SCOPE = "*";
 
 interface UpsertAuthProfileInput {
   agentId: string;
-  /** Owning user. Required for persistent (Redis-backed) writes. */
+  /** Owning user. Required for persistent writes. */
   userId?: string;
   provider: string;
   credential?: string;
@@ -193,7 +193,7 @@ export class AuthProfilesManager {
   }
 
   /**
-   * Insert or update a persistent (Redis-backed) profile.
+   * Insert or update a persistent profile.
    *
    * Requires `userId` — declared agents cannot be mutated through this
    * path. Runtime UI/sandbox agents that aren't owned by a single user

--- a/packages/owletto-backend/src/gateway/config/file-loader.ts
+++ b/packages/owletto-backend/src/gateway/config/file-loader.ts
@@ -50,8 +50,8 @@ function slugifyForConnectionId(input: string): string {
 
 /**
  * Build the stable connection ID: `{agent}-{type}` or `{agent}-{type}-{name}`.
- * Used to make webhook URLs (e.g. `/api/v1/webhooks/<id>`) survive Redis
- * flushes and fresh-clone setups — the ID is a pure function of lobu.toml.
+ * Used to make webhook URLs (e.g. `/api/v1/webhooks/<id>`) survive
+ * fresh-clone setups — the ID is a pure function of lobu.toml.
  */
 export function buildStableConnectionId(
   agentId: string,

--- a/packages/owletto-backend/src/gateway/connections/chat-instance-manager.ts
+++ b/packages/owletto-backend/src/gateway/connections/chat-instance-manager.ts
@@ -1,6 +1,7 @@
 /**
- * ChatInstanceManager — manages Chat SDK instances for API-driven platform connections.
- * Owns Redis persistence, Chat lifecycle, and webhook dispatch.
+ * ChatInstanceManager — manages Chat SDK instances for API-driven platform
+ * connections. Owns persistence (chat_connections), Chat lifecycle, and
+ * webhook dispatch.
  */
 
 import { randomUUID } from "node:crypto";
@@ -181,8 +182,8 @@ export class ChatInstanceManager {
     }
 
     // Use the caller-supplied stable ID when provided (file-loader path, so
-    // webhook URLs survive Redis flushes). Fall back to a random ID for
-    // API-created connections.
+    // webhook URLs survive fresh-clone setups). Fall back to a random ID
+    // for API-created connections.
     const id = stableId ?? randomUUID().replace(/-/g, "").slice(0, 16);
     const now = Date.now();
 

--- a/packages/owletto-backend/src/gateway/connections/chat-response-bridge.ts
+++ b/packages/owletto-backend/src/gateway/connections/chat-response-bridge.ts
@@ -192,7 +192,7 @@ export class ChatResponseBridge implements ResponseRenderer {
     const conversationState =
       this.manager.getInstance(connectionId)?.conversationState;
 
-    // Gap 1: Store outgoing response in history. Wrap so that a Redis
+    // Gap 1: Store outgoing response in history. Wrap so that a state-store
     // outage doesn't fail the whole response delivery — the user has
     // already seen the message; missing history is recoverable, a 500
     // here is not.

--- a/packages/owletto-backend/src/gateway/connections/conversation-state-store.ts
+++ b/packages/owletto-backend/src/gateway/connections/conversation-state-store.ts
@@ -46,8 +46,8 @@ export function threadIndexKey(channelId: string, threadTs: string): string {
 
 /**
  * Unified conversation-scoped state backed by the Chat SDK StateAdapter.
- * Owns both sliding-window history and thread session metadata so chat state
- * lives behind a single abstraction even when Redis is the underlying store.
+ * Owns both sliding-window history and thread session metadata so chat
+ * state lives behind a single abstraction over the underlying store.
  */
 export class ConversationStateStore {
   constructor(private readonly state: StateAdapter) {}
@@ -221,9 +221,9 @@ export class ConversationStateStore {
   ): Promise<void> {
     const lockId = `lock:${historyIndexKey(connectionId)}`;
     // Retry briefly if the lock is contended; only fall through to an
-    // unlocked write if Redis itself is unavailable. Silently dropping
-    // to an unlocked path on transient contention is what allowed two
-    // concurrent appends to clobber each other's index updates.
+    // unlocked write if the state adapter itself is unavailable. Silently
+    // dropping to an unlocked path on transient contention is what allowed
+    // two concurrent appends to clobber each other's index updates.
     let lock: Awaited<ReturnType<typeof this.state.acquireLock>> = null;
     let lockError: unknown = null;
     for (let attempt = 0; attempt < 3 && !lock; attempt++) {
@@ -240,7 +240,7 @@ export class ConversationStateStore {
     if (!lock) {
       logger.warn(
         { connectionId, error: lockError ? String(lockError) : "contended" },
-        "Updating history index without lock — another writer holds it or Redis is unavailable"
+        "Updating history index without lock — another writer holds it or the state adapter is unavailable"
       );
     }
 

--- a/packages/owletto-backend/src/gateway/connections/interaction-bridge.ts
+++ b/packages/owletto-backend/src/gateway/connections/interaction-bridge.ts
@@ -161,9 +161,9 @@ export function registerInteractionBridge(
   }
 
   // Tracks posted tool-approval cards so we can edit them on click to strip
-  // the buttons. Keyed by requestId (== PostedToolApproval.id == Redis key).
-  // Auto-expire window matches the Redis pending-tool TTL (24h) so a late
-  // click can still find the card to strip.
+  // the buttons. Keyed by requestId (== PostedToolApproval.id == pending-tool
+  // store key). Auto-expire window matches the pending-tool TTL (24h) so a
+  // late click can still find the card to strip.
   const APPROVAL_CARD_TTL_MS = 24 * 60 * 60 * 1000;
   const pendingApprovalCards = new Map<string, SentMessage>();
   const pendingApprovalTimers = new Map<string, NodeJS.Timeout>();

--- a/packages/owletto-backend/src/gateway/gateway-main.ts
+++ b/packages/owletto-backend/src/gateway/gateway-main.ts
@@ -20,7 +20,7 @@ const logger = createLogger("gateway");
  * Main Gateway class that orchestrates all platform adapters
  *
  * Architecture:
- * - CoreServices: Platform-agnostic services (Redis, MCP, Anthropic)
+ * - CoreServices: Platform-agnostic services (queue, MCP, Anthropic)
  * - PlatformAdapters: Platform-specific integrations (Slack, Discord, etc.)
  *
  * Lifecycle:
@@ -106,7 +106,7 @@ export class Gateway {
   async start(): Promise<void> {
     logger.debug("Starting gateway...");
 
-    // 1. Initialize core services (Redis, MCP, Anthropic, etc.)
+    // 1. Initialize core services (queue, MCP, Anthropic, etc.)
     await this.coreServices.initialize();
 
     // 2. Initialize each platform with core services

--- a/packages/owletto-backend/src/gateway/infrastructure/queue/index.ts
+++ b/packages/owletto-backend/src/gateway/infrastructure/queue/index.ts
@@ -2,7 +2,7 @@
  * Queue infrastructure.
  *
  * `RunsQueue` (Postgres `runs` table + SKIP LOCKED) is the only queue
- * substrate. The legacy BullMQ/Redis path is gone.
+ * substrate.
  */
 
 export { QueueProducer } from "./queue-producer.js";

--- a/packages/owletto-backend/src/gateway/infrastructure/queue/queue-producer.ts
+++ b/packages/owletto-backend/src/gateway/infrastructure/queue/queue-producer.ts
@@ -72,8 +72,8 @@ export interface MessagePayload {
 }
 
 /**
- * Queue producer for dispatching messages to Redis queues
- * Handles both direct_message and thread_message queues with bot isolation
+ * Queue producer for dispatching messages to the runs queue.
+ * Handles both direct_message and thread_message queues with bot isolation.
  */
 export class QueueProducer {
   private queue: IMessageQueue;

--- a/packages/owletto-backend/src/gateway/interactions.ts
+++ b/packages/owletto-backend/src/gateway/interactions.ts
@@ -81,7 +81,7 @@ export interface PostedStatusMessage extends BaseMessage {
 
 /**
  * Platform-agnostic interaction service (fire-and-forget).
- * Posts questions with buttons; no Redis, no blocking, no state machine.
+ * Posts questions with buttons; no blocking, no state machine.
  * User clicks → platform converts to regular message → normal queue.
  */
 export class InteractionService extends EventEmitter {
@@ -142,9 +142,9 @@ export class InteractionService extends EventEmitter {
    * Post a tool approval request with duration buttons (non-blocking, fire-and-forget).
    * Emits "tool:approval-needed" for platform renderers.
    *
-   * `requestId` MUST be the same value the MCP proxy used as the `pending-tool:*`
-   * Redis key. It's embedded into the button `actionId` so the interaction
-   * bridge can look up the pending invocation on click.
+   * `requestId` MUST be the same value the MCP proxy used as the
+   * `PendingToolStore` key. It's embedded into the button `actionId` so the
+   * interaction bridge can look up the pending invocation on click.
    */
   async postToolApproval(
     requestId: string,

--- a/packages/owletto-backend/src/gateway/metrics/prometheus.ts
+++ b/packages/owletto-backend/src/gateway/metrics/prometheus.ts
@@ -49,11 +49,6 @@ function initializeMetrics() {
   );
   registerMetric("lobu_queue_length", "Current message queue length", "gauge");
   registerMetric(
-    "lobu_redis_connection_errors_total",
-    "Total number of Redis connection errors",
-    "counter"
-  );
-  registerMetric(
     "lobu_proxy_requests_total",
     "Total number of HTTP proxy requests",
     "counter"

--- a/packages/owletto-backend/src/gateway/orchestration/base-deployment-manager.ts
+++ b/packages/owletto-backend/src/gateway/orchestration/base-deployment-manager.ts
@@ -186,7 +186,7 @@ export abstract class BaseDeploymentManager {
    * (a) skip redundant `grantStore.grant()` writes when the set is
    * unchanged and (b) compute the revoke-diff so patterns dropped from
    * `networkConfig.allowedDomains` / `preApprovedTools` are removed from
-   * Redis instead of lingering forever.
+   * the grant store instead of lingering forever.
    */
   private grantSyncCache = new Map<string, Set<string>>();
   /**
@@ -514,7 +514,7 @@ export abstract class BaseDeploymentManager {
    *   - patterns in the previous set but not the new are `revoke()`-d
    * This means clearing `networkConfig.allowedDomains` or
    * `preApprovedTools` in lobu.toml actually drops access, instead of
-   * leaving stale grants in Redis.
+   * leaving stale grants in the store.
    */
   async syncNetworkConfigGrants(messageData: MessagePayload): Promise<void> {
     const agentId = messageData.agentId;
@@ -534,7 +534,7 @@ export abstract class BaseDeploymentManager {
 
     const previous = this.grantSyncCache.get(agentId) ?? new Set<string>();
 
-    // Unchanged set → skip Redis roundtrip entirely.
+    // Unchanged set → skip the round-trip entirely.
     if (
       nextPatterns.size === previous.size &&
       [...nextPatterns].every((p) => previous.has(p))
@@ -632,7 +632,7 @@ export abstract class BaseDeploymentManager {
       DEBUG: "1",
       HTTP_PROXY: proxyUrl,
       HTTPS_PROXY: proxyUrl,
-      NO_PROXY: `${dispatcherHost},gateway,redis,localhost,127.0.0.1`,
+      NO_PROXY: `${dispatcherHost},gateway,localhost,127.0.0.1`,
       // Pin HOME inside the persistent workspace so per-tool caches
       // (~/.npm, ~/.cache, ~/.config, ~/.local/share) survive worker restarts
       // without leaking into the gateway host home directory.
@@ -696,7 +696,7 @@ export abstract class BaseDeploymentManager {
    * the real credential at request time using agentId from the URL path
    * (`/a/{agentId}`) and the provider slug.
    *
-   * Non-provider secrets use UUID placeholders stored in Redis.
+   * Non-provider secrets use UUID placeholders stored in the secret-proxy.
    */
   private async injectSecretPlaceholders(
     envVars: Record<string, string>,

--- a/packages/owletto-backend/src/gateway/orchestration/message-consumer.ts
+++ b/packages/owletto-backend/src/gateway/orchestration/message-consumer.ts
@@ -169,7 +169,7 @@ export class MessageConsumer {
       // to the user via the response bridge. Lookup of settings.guardrails
       // requires threading an AgentConfigStore into MessageConsumer; deferred
       // to the PR that registers the first real input guardrail (#251).
-      // 1) Send to thread queue immediately (Redis persists; worker will drain on attach)
+      // 1) Send to thread queue immediately (queue persists; worker will drain on attach)
       await Sentry.startSpan(
         {
           name: "orchestrator.send_to_worker_queue",
@@ -243,7 +243,7 @@ export class MessageConsumer {
       Sentry.captureException(error);
       logger.error({ traceId, jobId, error }, "Message job failed");
 
-      // Re-throw for Redis retry handling
+      // Re-throw for queue retry handling
       throw new OrchestratorError(
         ErrorCode.QUEUE_JOB_PROCESSING_FAILED,
         `Failed to process message job: ${error instanceof Error ? error.message : String(error)}`,
@@ -320,7 +320,7 @@ export class MessageConsumer {
   /**
    * Ensure worker deployment exists for a thread
    * Uses shared retry utility with linear backoff + jitter
-   * Uses Redis lock to prevent concurrent duplicate deployment creation
+   * Uses an advisory lock to prevent concurrent duplicate deployment creation
    */
   private async ensureWorkerExists(
     deploymentName: string,

--- a/packages/owletto-backend/src/gateway/platform.ts
+++ b/packages/owletto-backend/src/gateway/platform.ts
@@ -77,7 +77,7 @@ export interface CoreServices {
  * 1. Receives CoreServices during initialization
  * 2. Sets up platform-specific event handlers
  * 3. Manages its own platform client/connection
- * 4. Uses core services (MCP, Anthropic, Redis) provided by Gateway
+ * 4. Uses core services (MCP, Anthropic, queue, etc.) provided by Gateway
  */
 export interface PlatformAdapter {
   /**

--- a/packages/owletto-backend/src/gateway/routes/internal/device-auth.ts
+++ b/packages/owletto-backend/src/gateway/routes/internal/device-auth.ts
@@ -141,9 +141,9 @@ function clientCacheName(mcpId: string): string {
 }
 
 /**
- * Per-process refresh lock. Replaces the previous Redis SET NX EX lock —
- * single-process gateway means an in-memory mutex is sufficient. Lock entries
- * expire after 30s as a safety net for handlers that throw without releasing.
+ * Per-process refresh lock. Single-process gateway, so an in-memory mutex
+ * is sufficient. Lock entries expire after 30s as a safety net for handlers
+ * that throw without releasing.
  */
 const refreshLocks = new Map<string, number>();
 const REFRESH_LOCK_TTL_MS = 30_000;

--- a/packages/owletto-backend/src/gateway/routes/public/agent.ts
+++ b/packages/owletto-backend/src/gateway/routes/public/agent.ts
@@ -504,9 +504,9 @@ export function createAgentApi(config: AgentApiConfig): OpenAPIHono {
 
   // Accept either an AgentMetadataStore or an AgentConfigStore exposing
   // getMetadata for ownership resolution. When both are provided, try the
-  // metadata store first (Redis cache) and fall through to the config store
-  // (Postgres, authoritative) — needed in embedded mode where agent rows live
-  // in Postgres but the Redis cache is never hydrated.
+  // metadata store first (in-memory layer) and fall through to the config
+  // store (Postgres, authoritative) — needed in embedded mode where agent
+  // rows live in Postgres but the in-memory layer is not hydrated.
   const ownershipMetadataStore:
     | { getMetadata: AgentMetadataStore["getMetadata"] }
     | undefined =

--- a/packages/owletto-backend/src/gateway/secrets/index.ts
+++ b/packages/owletto-backend/src/gateway/secrets/index.ts
@@ -129,10 +129,10 @@ export class AwsSecretsManagerSecretStore implements SecretStore {
 
 /**
  * Short-TTL in-memory cache for secret resolution. Dramatically cuts load on
- * the Redis secret store and the AWS Secrets Manager API for hot paths
- * (proxy forwards, env-var injection, auth profile listing). Invalidated on
- * `put`/`delete` of the same name and LRU-capped to prevent unbounded
- * growth under a burst of unique refs within the TTL window.
+ * the underlying secret store (Postgres) and the AWS Secrets Manager API
+ * for hot paths (proxy forwards, env-var injection, auth profile listing).
+ * Invalidated on `put`/`delete` of the same name and LRU-capped to prevent
+ * unbounded growth under a burst of unique refs within the TTL window.
  */
 interface CacheEntry {
   value: string | null;
@@ -158,7 +158,7 @@ export class SecretStoreRegistry implements WritableSecretStore {
 
   /**
    * @param defaultStore writable backend for the default scheme (usually
-   *   `secret://` backed by Redis). New `put`/`delete(name)` calls land
+   *   `secret://` backed by Postgres). New `put`/`delete(name)` calls land
    *   here. Writes via a ref explicitly routed to another writable store
    *   land in that store.
    * @param writableStores every writable backend keyed by ref scheme,

--- a/packages/owletto-backend/src/gateway/services/core-services.ts
+++ b/packages/owletto-backend/src/gateway/services/core-services.ts
@@ -318,10 +318,8 @@ export class CoreServices {
   // ============================================================================
 
   private async initializeQueue(): Promise<void> {
-    // Queue substrate is `public.runs` over Postgres (SKIP LOCKED + LISTEN/
-    // NOTIFY). All non-queue consumers (secret-store, grant-store,
-    // cli-auth, Slack OAuth state) moved to PG; ioredis is gone from
-    // application code.
+    // Queue substrate is `public.runs` over Postgres (SKIP LOCKED +
+    // LISTEN/NOTIFY).
     this.queue = new RunsQueue();
     await this.queue.start();
     logger.debug("Queue connection established (runs-table substrate)");
@@ -451,7 +449,7 @@ export class CoreServices {
           );
         } else {
           throw new Error(
-            "No agent sub-stores configured: provide configStore/connectionStore/accessStore via CoreServices options, or place a lobu.toml in the workspace, or pass agents via GatewayConfig.agents. The Redis-backed fall-through is gone."
+            "No agent sub-stores configured: provide configStore/connectionStore/accessStore via CoreServices options, or place a lobu.toml in the workspace, or pass agents via GatewayConfig.agents."
           );
         }
       }
@@ -515,14 +513,14 @@ export class CoreServices {
     }
 
     // Declared registry: read-only snapshot of file/SDK-declared agents.
-    // No Redis copy is kept — declared settings live in memory and are
+    // No second copy is kept — declared settings live in memory and are
     // rebuilt wholesale on hot-reload.
     this.declaredAgentRegistry = new DeclaredAgentRegistry();
     this.declaredAgentRegistry.replaceAll(
       buildRegistryMap(this.fileLoadedAgents, this.configAgents)
     );
     // Plumb registry into the settings store so getEffectiveSettings
-    // returns declared settings for declared agents (no Redis copy exists
+    // returns declared settings for declared agents (no second copy exists
     // by design — see one-shot cleanup below).
     this.agentSettingsStore.setDeclaredAgents(this.declaredAgentRegistry);
 
@@ -968,8 +966,8 @@ export class CoreServices {
     }
 
     // Repopulate the declared registry so subsequent credential lookups
-    // see the new file-declared providers/keys. No Redis sync, no
-    // additive seeding — the registry IS the source of truth.
+    // see the new file-declared providers/keys. No additive seeding — the
+    // registry IS the source of truth.
     if (this.declaredAgentRegistry) {
       this.declaredAgentRegistry.replaceAll(
         buildRegistryMap(this.fileLoadedAgents, this.configAgents)

--- a/packages/owletto-backend/src/gateway/services/declared-agent-registry.ts
+++ b/packages/owletto-backend/src/gateway/services/declared-agent-registry.ts
@@ -15,7 +15,7 @@ interface DeclaredAgentEntry {
  * `GatewayConfig.agents` (SDK embedded mode).
  *
  * Declared agents own their settings and credentials at runtime — there is
- * no Redis copy to drift. The registry is rebuilt wholesale by callers
+ * no second copy to drift. The registry is rebuilt wholesale by callers
  * (e.g. `reloadFromFiles`) so removing a provider from `lobu.toml` removes
  * it from the registry on next reload.
  */

--- a/packages/owletto-backend/src/gateway/services/session-manager.ts
+++ b/packages/owletto-backend/src/gateway/services/session-manager.ts
@@ -13,8 +13,8 @@ const logger = createLogger("session-manager");
 
 /**
  * Session storage backed by the shared conversation state layer.
- * Thread sessions and chat history now share the same StateAdapter-backed
- * storage abstraction instead of talking to Redis separately.
+ * Thread sessions and chat history share the same StateAdapter-backed
+ * storage abstraction.
  */
 export class StateAdapterSessionStore implements SessionStore {
   constructor(private readonly conversations: ConversationStateStore) {}

--- a/packages/owletto-backend/src/gateway/session.ts
+++ b/packages/owletto-backend/src/gateway/session.ts
@@ -50,7 +50,7 @@ export interface ThreadSession {
 }
 
 /**
- * Compute session key for Redis storage
+ * Compute session key for the session store.
  * For API platform: just conversationId (which equals agentId)
  * For Slack/WhatsApp: channelId:conversationId
  */
@@ -82,7 +82,7 @@ export interface SessionStore {
     channelId: string,
     threadTs: string
   ): Promise<ThreadSession | null>;
-  /** Optional cleanup - not needed for Redis TTL-based stores */
+  /** Optional cleanup; only needed for stores without intrinsic TTL. */
   cleanup?(ttl: number): Promise<number>;
 }
 

--- a/packages/owletto-backend/src/gateway/stores/base-agent-store.ts
+++ b/packages/owletto-backend/src/gateway/stores/base-agent-store.ts
@@ -7,9 +7,9 @@
  * update pattern and the listConnections platform filter.
  *
  * Grants, user-agent associations and channel bindings vary too much between
- * in-memory (self-contained Maps) and Redis (delegating to GrantStore /
- * UserAgentsStore / ChannelBindingService) to share concrete logic; subclasses
- * implement those groups directly.
+ * the in-memory (self-contained Maps) and the Postgres-backed paths
+ * (delegating to GrantStore / UserAgentsStore / ChannelBindingService) to
+ * share concrete logic; subclasses implement those groups directly.
  */
 
 import type {
@@ -58,12 +58,12 @@ export abstract class BaseAgentStore implements AgentStore {
 
   // ── Metadata primitives ────────────────────────────────────────────
   //
-  // `saveMetadata` / `updateMetadata` are abstract rather than expressed as a
-  // shared read→merge→write pattern because the Redis backend delegates to
-  // `AgentMetadataStore.createAgent` for saves (which stamps a fresh
-  // `createdAt`) and to `AgentMetadataStore.updateMetadata` for updates
-  // (which preserves `createdAt` and accepts only a narrow subset of
-  // fields). Routing updates through a shared `writeMetadata` primitive
+  // `saveMetadata` / `updateMetadata` are abstract rather than expressed as
+  // a shared read→merge→write pattern because the Postgres-backed path
+  // delegates to `AgentMetadataStore.createAgent` for saves (which stamps a
+  // fresh `createdAt`) and to `AgentMetadataStore.updateMetadata` for
+  // updates (which preserves `createdAt` and accepts only a narrow subset
+  // of fields). Routing updates through a shared `writeMetadata` primitive
   // would corrupt `createdAt` on every update call.
 
   protected abstract readMetadata(

--- a/packages/owletto-backend/src/gateway/utils/rate-limiter.ts
+++ b/packages/owletto-backend/src/gateway/utils/rate-limiter.ts
@@ -25,8 +25,7 @@ interface FixedWindowRateLimitResult {
  *   - resets the row when the existing window has already expired,
  *   - bumps `count` when the window is still live.
  *
- * Mirrors the Redis INCR + EXPIRE semantics one-to-one so callers don't
- * have to change their key format.
+ * Same fixed-window-counter semantics as a typical INCR + EXPIRE loop.
  */
 export class FixedWindowRateLimiter {
   async consume(

--- a/packages/owletto-backend/src/lobu/stores/postgres-secret-store.ts
+++ b/packages/owletto-backend/src/lobu/stores/postgres-secret-store.ts
@@ -1,12 +1,11 @@
 /**
- * PostgresSecretStore — WritableSecretStore backed by the agent_secrets
+ * PostgresSecretStore — WritableSecretStore backed by the `agent_secrets`
  * table. Stores AES-256-GCM ciphertext produced by @lobu/core's encrypt(),
- * keyed by logical name, and returns `secret://<encoded-name>` refs matching
- * the gateway's RedisSecretStore contract.
+ * keyed by logical name, and returns `secret://<encoded-name>` refs.
  *
  * Paired with SecretStoreRegistry and passed as the `secretStore` option to
- * Gateway from src/lobu/gateway.ts so lobu's ChatInstanceManager can persist
- * connection secrets in Postgres instead of Redis.
+ * Gateway from `src/lobu/gateway.ts` so lobu's ChatInstanceManager can
+ * persist connection secrets durably.
  */
 
 import {

--- a/packages/owletto-backend/src/watchers/automation.ts
+++ b/packages/owletto-backend/src/watchers/automation.ts
@@ -271,7 +271,7 @@ export async function reconcileWatcherRuns(db?: DbClient): Promise<ReconcileWatc
  * The primary lifecycle is driven by WatcherRunTracker (in-process completion
  * events) plus startup reconciliation on gateway boot. This sweeper only
  * catches truly stuck runs — the tracker entry was lost without a crash
- * (graceful shutdown mid-turn, redis message silently dropped, etc). TTL is
+ * (graceful shutdown mid-turn, queue message silently dropped, etc). TTL is
  * intentionally generous so long LLM turns are not killed.
  */
 const WATCHER_RUN_STALE_INTERVAL = '2 hours';


### PR DESCRIPTION
## Summary

Functional Redis was already gone in #452. This is a follow-up that removes the trail of stale comments and one dead artifact.

- Drop the never-incremented \`lobu_redis_connection_errors_total\` Prometheus counter.
- Rewrite ~30 stale doc-comments and inline notes that described the pre-Phase-8 Redis architecture (chat-instance-manager, secret store, rate limiter, conversation state, MCP proxy, oauth flow, base agent store, gateway-main, etc.) to describe the current Postgres-backed reality (or just drop the historical aside).
- Drop \`redis\` from the worker NO_PROXY list (no Redis sidecar to exempt from the egress proxy).
- Update landing docs (architecture, observability, mcp-proxy, security, comparison, hello-world blog), PricingSection, and docs/SECURITY.md to stop describing Redis as a runtime dependency.

**No functional changes.** Only doc-comments, copy, and one dead metric.

## Test plan
- [x] \`bun run typecheck\` clean
- [x] \`cd packages/landing && bun run build\` succeeds
- [x] \`grep\` confirms only one remaining \`redis\` reference is intentional product copy (a fictional incident name in \`use-case-showcases.ts\`)