### PR TITLE
refactor: rename connections → platforms (CLI + TOML + server route)

### DIFF
--- a/docs/plans/lobu-apply.md
+++ b/docs/plans/lobu-apply.md
@@ -26,7 +26,7 @@ desired state (lobu.toml + agent dirs)
    CLI: call existing endpoints in order
         │   POST /api/:orgSlug/agents/        (upsert)
         │   PATCH /:agentId/config            (settings + skills_config)
-        │   PUT  /:agentId/connections/by-stable-id/:stableId  (NEW route)
+        │   PUT  /:agentId/platforms/by-stable-id/:stableId  (NEW route)
         │   POST /api/:orgSlug/manage_entity_schema     (existing admin tool)
         │   POST /api/:orgSlug/manage_relationship_schema
         │
@@ -104,11 +104,11 @@ Validation:
 
 **Branch**: `feat/idempotent-apply-endpoints` · **Risk**: Medium · **LOC**: ~150
 
-Today `agent-routes.ts:POST /` returns 409 on same-org duplicate (`agent-routes.ts:319-321`). Connections create with random ID (`POST /:agentId/connections`), no upsert.
+Today `agent-routes.ts:POST /` returns 409 on same-org duplicate (`agent-routes.ts:319-321`). Connections create with random ID (`POST /:agentId/platforms`), no upsert.
 
 Scope:
 - **Modify `POST /` in agent-routes.ts** (around line 293): same-org duplicate returns `200` with the existing agent payload instead of `409`. Cross-org duplicate keeps the existing 409 (separate concern, will be fixed by future org-scoped IDs work). The Owletto-MCP auto-injection in `saveSettings` (line 339-344) must be preserved on first create but skipped on the idempotent-return path.
-- **New route** `PUT /:agentId/connections/by-stable-id/:stableId` mounted in agent-routes.ts. Uses `buildStableConnectionId(agentId, type, name)` from `gateway/config/file-loader.ts:56` for ID generation client-side; route receives the stable ID in URL. Body shape mirrors `POST /:agentId/connections`. Behavior:
+- **New route** `PUT /:agentId/platforms/by-stable-id/:stableId` mounted in agent-routes.ts. Uses `buildStablePlatformId(agentId, type, name)` from `gateway/config/file-loader.ts:56` for ID generation client-side; route receives the stable ID in URL. Body shape mirrors `POST /:agentId/platforms`. Behavior:
   - If stable ID exists: update config in place. If config materially changes, return `{ updated: true, willRestart: true }`. If unchanged, return `{ noop: true }`.
   - If stable ID doesn't exist: create with that ID (skip the random-ID path).
   - Reuses existing `ChatInstanceManager.addConnection` / equivalent — does **not** duplicate connection-creation logic.
@@ -127,7 +127,7 @@ Validation: `bun test packages/owletto-backend/src/lobu`, typecheck, biome, buil
 Scope:
 - New `packages/cli/src/commands/apply.ts` (top-level command).
 - New `packages/cli/src/commands/_lib/apply/`:
-  - `desired-state.ts` — wraps `loadConfig` from `cli/src/config/loader.ts`. Walks `$VAR` refs and produces a `requiredSecrets: string[]` list. Reuses `buildStableConnectionId` (re-export from cli or inline a copy with a comment pointing at the source of truth).
+  - `desired-state.ts` — wraps `loadConfig` from `cli/src/config/loader.ts`. Walks `$VAR` refs and produces a `requiredSecrets: string[]` list. Reuses `buildStablePlatformId` (re-export from cli or inline a copy with a comment pointing at the source of truth).
   - `client.ts` — thin wrapper over fetch using `_lib/openclaw-auth.ts` (`getUsableToken`) and `_lib/openclaw-cmd.ts:postJson` from PR #459. One method per resource: `getAgents`, `upsertAgent`, `patchSettings`, `getConnections`, `upsertConnection`, `getEntityTypes`, `upsertEntityType`, etc.
   - `diff.ts` — given desired and current, return `{ creates, updates, noops, drift }`. Drift = remote has resource not in desired. No deletes (no `--prune` in v1).
   - `render.ts` — pretty diff output via chalk: `+` for creates, `~` for updates, `=` for noops, `?` for drift.

--- a/packages/cli/src/commands/_lib/apply/__tests__/__snapshots__/diff.test.ts.snap
+++ b/packages/cli/src/commands/_lib/apply/__tests__/__snapshots__/diff.test.ts.snap
@@ -62,7 +62,7 @@ Plan:
 Summary: 0 create, 1 update, 1 noop, 0 drift"
 `;
 
-exports[`apply diff — connections create on empty remote 1`] = `
+exports[`apply diff — platforms create on empty remote 1`] = `
 "
 Plan:
 
@@ -72,13 +72,13 @@ Plan:
   settingss:
   + settings triage
 
-  connections:
-  + connection triage/triage-telegram
+  platforms:
+  + platform triage/triage-telegram
 
 Summary: 3 create, 0 update, 0 noop, 0 drift"
 `;
 
-exports[`apply diff — connections update with willRestart when config changes 1`] = `
+exports[`apply diff — platforms update with willRestart when config changes 1`] = `
 "
 Plan:
 
@@ -88,9 +88,9 @@ Plan:
   settingss:
   = settings triage
 
-  connections:
-  ~ connection triage/triage-telegram (config)
-      ⚠ will restart connection — in-flight messages may drop
+  platforms:
+  ~ platform triage/triage-telegram (config)
+      ⚠ will restart platform — in-flight messages may drop
 
 Summary: 0 create, 1 update, 2 noop, 0 drift"
 `;

--- a/packages/cli/src/commands/_lib/apply/__tests__/desired-state.test.ts
+++ b/packages/cli/src/commands/_lib/apply/__tests__/desired-state.test.ts
@@ -2,21 +2,19 @@ import { afterEach, describe, expect, test } from "bun:test";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { buildStableConnectionId, loadDesiredState } from "../desired-state.js";
+import { buildStablePlatformId, loadDesiredState } from "../desired-state.js";
 
-describe("buildStableConnectionId — keep in sync with file-loader.ts:56", () => {
+describe("buildStablePlatformId — keep in sync with file-loader.ts", () => {
   test("two parts when no name", () => {
-    expect(buildStableConnectionId("triage", "telegram")).toBe(
-      "triage-telegram"
-    );
+    expect(buildStablePlatformId("triage", "telegram")).toBe("triage-telegram");
   });
   test("three parts when name provided", () => {
-    expect(buildStableConnectionId("triage", "slack", "ops")).toBe(
+    expect(buildStablePlatformId("triage", "slack", "ops")).toBe(
       "triage-slack-ops"
     );
   });
   test("slugifies non-alphanumeric chars in agent + type + name", () => {
-    expect(buildStableConnectionId("Tri Age", "Slack/Ops", "Bot 1")).toBe(
+    expect(buildStablePlatformId("Tri Age", "Slack/Ops", "Bot 1")).toBe(
       "tri-age-slack-ops-bot-1"
     );
   });
@@ -39,7 +37,7 @@ describe("loadDesiredState", () => {
     return dir;
   }
 
-  test("collects $VAR references from connections + providers", async () => {
+  test("collects $VAR references from platforms + providers", async () => {
     const dir = mkProject(
       `[agents.triage]
 name = "Triage"
@@ -50,9 +48,9 @@ dir = "./agents/triage"
 id = "anthropic"
 key = "$ANTHROPIC_API_KEY"
 
-[[agents.triage.connections]]
+[[agents.triage.platforms]]
 type = "telegram"
-[agents.triage.connections.config]
+[agents.triage.platforms.config]
 botToken = "$TELEGRAM_BOT_TOKEN"
 `
     );
@@ -70,22 +68,22 @@ botToken = "$TELEGRAM_BOT_TOKEN"
     ]);
     expect(state.agents).toHaveLength(1);
     expect(state.agents[0]!.metadata.agentId).toBe("triage");
-    expect(state.agents[0]!.connections).toHaveLength(1);
-    expect(state.agents[0]!.connections[0]!.stableId).toBe("triage-telegram");
-    expect(state.agents[0]!.connections[0]!.config.botToken).toBe(
+    expect(state.agents[0]!.platforms).toHaveLength(1);
+    expect(state.agents[0]!.platforms[0]!.stableId).toBe("triage-telegram");
+    expect(state.agents[0]!.platforms[0]!.config.botToken).toBe(
       "tg-fake-token"
     );
   });
 
-  test("throws when a connection $VAR ref is unset in the apply env", async () => {
+  test("throws when a platform $VAR ref is unset in the apply env", async () => {
     const dir = mkProject(
       `[agents.triage]
 name = "Triage"
 dir = "./agents/triage"
 
-[[agents.triage.connections]]
+[[agents.triage.platforms]]
 type = "telegram"
-[agents.triage.connections.config]
+[agents.triage.platforms.config]
 botToken = "$TELEGRAM_BOT_TOKEN"
 `
     );
@@ -94,25 +92,25 @@ botToken = "$TELEGRAM_BOT_TOKEN"
     );
   });
 
-  test("rejects duplicate (type, name) connection pairs", async () => {
+  test("rejects duplicate (type, name) platform pairs", async () => {
     const dir = mkProject(
       `[agents.triage]
 name = "Triage"
 dir = "./agents/triage"
 
-[[agents.triage.connections]]
+[[agents.triage.platforms]]
 type = "slack"
-[agents.triage.connections.config]
+[agents.triage.platforms.config]
 botToken = "x"
 
-[[agents.triage.connections]]
+[[agents.triage.platforms]]
 type = "slack"
-[agents.triage.connections.config]
+[agents.triage.platforms.config]
 botToken = "y"
 `
     );
     await expect(loadDesiredState({ cwd: dir })).rejects.toThrow(
-      /multiple "slack" connections/
+      /multiple "slack" platforms/
     );
   });
 

--- a/packages/cli/src/commands/_lib/apply/__tests__/diff.test.ts
+++ b/packages/cli/src/commands/_lib/apply/__tests__/diff.test.ts
@@ -16,7 +16,7 @@ function buildDesiredAgent(
   return {
     metadata: { agentId, name: agentId, description: undefined },
     settings: {},
-    connections: [],
+    platforms: [],
     ...overrides,
   };
 }
@@ -33,7 +33,7 @@ function emptyRemote(): RemoteSnapshot {
   return {
     agents: [],
     agentSettings: new Map(),
-    connectionsByAgent: new Map(),
+    platformsByAgent: new Map(),
     entityTypes: [],
     relationshipTypes: [],
   };
@@ -66,7 +66,7 @@ describe("apply diff — agents", () => {
       ...emptyRemote(),
       agents: [{ agentId: "triage", name: "Triage" }],
       agentSettings: new Map([["triage", null]]),
-      connectionsByAgent: new Map([["triage", []]]),
+      platformsByAgent: new Map([["triage", []]]),
     };
     const plan = computeDiff(desired, remote);
     expect(plan.counts.noop).toBeGreaterThan(0);
@@ -85,7 +85,7 @@ describe("apply diff — agents", () => {
       ...emptyRemote(),
       agents: [{ agentId: "triage", name: "Original" }],
       agentSettings: new Map([["triage", null]]),
-      connectionsByAgent: new Map([["triage", []]]),
+      platformsByAgent: new Map([["triage", []]]),
     };
     const plan = computeDiff(desired, remote);
     expect(plan.counts.update).toBeGreaterThan(0);
@@ -126,7 +126,7 @@ describe("apply diff — settings", () => {
           },
         ],
       ]),
-      connectionsByAgent: new Map([["triage", []]]),
+      platformsByAgent: new Map([["triage", []]]),
     };
     const plan = computeDiff(desired, remote);
     const settingsRow = plan.rows.find((r) => r.kind === "settings");
@@ -138,12 +138,12 @@ describe("apply diff — settings", () => {
   });
 });
 
-describe("apply diff — connections", () => {
+describe("apply diff — platforms", () => {
   test("create on empty remote", () => {
     const desired = buildState([
       buildDesiredAgent("triage", {
         metadata: { agentId: "triage", name: "Triage" },
-        connections: [
+        platforms: [
           {
             stableId: "triage-telegram",
             type: "telegram",
@@ -153,8 +153,8 @@ describe("apply diff — connections", () => {
       }),
     ]);
     const plan = computeDiff(desired, emptyRemote());
-    const connRow = plan.rows.find((r) => r.kind === "connection");
-    expect(connRow?.verb).toBe("create");
+    const platformRow = plan.rows.find((r) => r.kind === "platform");
+    expect(platformRow?.verb).toBe("create");
     expect(renderPlan(plan)).toMatchSnapshot();
   });
 
@@ -162,7 +162,7 @@ describe("apply diff — connections", () => {
     const desired = buildState([
       buildDesiredAgent("triage", {
         metadata: { agentId: "triage", name: "Triage" },
-        connections: [
+        platforms: [
           {
             stableId: "triage-telegram",
             type: "telegram",
@@ -175,7 +175,7 @@ describe("apply diff — connections", () => {
       ...emptyRemote(),
       agents: [{ agentId: "triage", name: "Triage" }],
       agentSettings: new Map<string, AgentSettings | null>([["triage", null]]),
-      connectionsByAgent: new Map([
+      platformsByAgent: new Map([
         [
           "triage",
           [
@@ -189,10 +189,10 @@ describe("apply diff — connections", () => {
       ]),
     };
     const plan = computeDiff(desired, remote);
-    const connRow = plan.rows.find((r) => r.kind === "connection");
-    expect(connRow?.verb).toBe("update");
-    if (connRow?.kind === "connection") {
-      expect(connRow.willRestart).toBe(true);
+    const platformRow = plan.rows.find((r) => r.kind === "platform");
+    expect(platformRow?.verb).toBe("update");
+    if (platformRow?.kind === "platform") {
+      expect(platformRow.willRestart).toBe(true);
     }
     expect(renderPlan(plan)).toMatchSnapshot();
   });
@@ -263,7 +263,7 @@ describe("apply diff — empty container preservation", () => {
           },
         ],
       ]),
-      connectionsByAgent: new Map([["triage", []]]),
+      platformsByAgent: new Map([["triage", []]]),
     };
     const plan = computeDiff(desired, remote);
     const settingsRow = plan.rows.find((r) => r.kind === "settings");
@@ -298,7 +298,7 @@ describe("apply diff — empty container preservation", () => {
           },
         ],
       ]),
-      connectionsByAgent: new Map([["triage", []]]),
+      platformsByAgent: new Map([["triage", []]]),
     };
     const plan = computeDiff(desiredEmpty, remoteWithItems);
     expect(plan.counts.update).toBeGreaterThan(0);
@@ -309,7 +309,7 @@ describe("apply diff — empty container preservation", () => {
     const desired = buildState([
       buildDesiredAgent("triage", {
         metadata: { agentId: "triage", name: "Triage" },
-        connections: [
+        platforms: [
           {
             stableId: "triage-telegram",
             type: "telegram",
@@ -322,7 +322,7 @@ describe("apply diff — empty container preservation", () => {
       ...emptyRemote(),
       agents: [{ agentId: "triage", name: "Triage" }],
       agentSettings: new Map<string, AgentSettings | null>([["triage", null]]),
-      connectionsByAgent: new Map([
+      platformsByAgent: new Map([
         [
           "triage",
           [
@@ -336,8 +336,8 @@ describe("apply diff — empty container preservation", () => {
       ]),
     };
     const plan = computeDiff(desired, remote);
-    const connRow = plan.rows.find((r) => r.kind === "connection");
-    expect(connRow?.verb).toBe("update");
+    const platformRow = plan.rows.find((r) => r.kind === "platform");
+    expect(platformRow?.verb).toBe("update");
   });
 });
 

--- a/packages/cli/src/commands/_lib/apply/apply-cmd.ts
+++ b/packages/cli/src/commands/_lib/apply/apply-cmd.ts
@@ -4,7 +4,7 @@ import { printError, printText } from "../../memory/_lib/output.js";
 import {
   type ApplyClient,
   type RemoteAgent,
-  type RemoteConnection,
+  type RemotePlatform,
   resolveApplyClient,
 } from "./client.js";
 import {
@@ -60,7 +60,7 @@ async function fetchRemoteSnapshot(
     string,
     Awaited<ReturnType<ApplyClient["getAgentSettings"]>>
   >();
-  const connectionsByAgent = new Map<string, RemoteConnection[]>();
+  const platformsByAgent = new Map<string, RemotePlatform[]>();
 
   if (only !== "memory") {
     const desiredAgentIds = state.agents.map((a) => a.metadata.agentId);
@@ -72,7 +72,7 @@ async function fetchRemoteSnapshot(
     );
     for (const agentId of targetAgentIds) {
       agentSettings.set(agentId, await client.getAgentSettings(agentId));
-      connectionsByAgent.set(agentId, await client.listConnections(agentId));
+      platformsByAgent.set(agentId, await client.listPlatforms(agentId));
     }
   }
 
@@ -83,7 +83,7 @@ async function fetchRemoteSnapshot(
   return {
     agents,
     agentSettings,
-    connectionsByAgent,
+    platformsByAgent,
     entityTypes,
     relationshipTypes,
   };
@@ -134,12 +134,12 @@ async function executePlan(ctx: ApplyContext): Promise<void> {
     );
   }
 
-  // 3) Connections
-  for (const row of rowsByKind("connection")) {
-    if (row.kind !== "connection") continue;
+  // 3) Platforms
+  for (const row of rowsByKind("platform")) {
+    if (row.kind !== "platform") continue;
     const desired = row.desired;
     if (!desired) continue;
-    const result = await ctx.client.upsertConnection(
+    const result = await ctx.client.upsertPlatform(
       row.agentId,
       desired.stableId,
       {
@@ -154,7 +154,7 @@ async function executePlan(ctx: ApplyContext): Promise<void> {
         ? "(noop on server)"
         : undefined;
     printText(
-      renderProgress(row.verb, "connection", `${row.agentId}/${row.id}`, detail)
+      renderProgress(row.verb, "platform", `${row.agentId}/${row.id}`, detail)
     );
   }
 

--- a/packages/cli/src/commands/_lib/apply/client.ts
+++ b/packages/cli/src/commands/_lib/apply/client.ts
@@ -21,7 +21,7 @@ export interface RemoteAgentDetail extends RemoteAgent {
   settings?: AgentSettings | null;
 }
 
-export interface RemoteConnection {
+export interface RemotePlatform {
   id: string;
   platform: string;
   templateAgentId?: string;
@@ -44,14 +44,14 @@ export interface RemoteRelationshipType {
   rules?: Array<{ source: string; target: string }>;
 }
 
-export interface UpsertConnectionResult {
+export interface UpsertPlatformResult {
   /** Server reports `noop: true` when the desired config matches what's stored. */
   noop?: boolean;
   /** When the config materially changed, the live worker is restarted. */
   willRestart?: boolean;
   updated?: boolean;
   created?: boolean;
-  connection?: RemoteConnection;
+  platform?: RemotePlatform;
 }
 
 export interface UpsertEntityTypeResult {
@@ -282,34 +282,34 @@ export class ApplyClient {
     );
   }
 
-  // ── Connections ───────────────────────────────────────────────────────────
+  // ── Platforms ─────────────────────────────────────────────────────────────
 
-  async listConnections(agentId: string): Promise<RemoteConnection[]> {
-    const { body } = await this.request<{ connections?: RemoteConnection[] }>(
+  async listPlatforms(agentId: string): Promise<RemotePlatform[]> {
+    const { body } = await this.request<{ platforms?: RemotePlatform[] }>(
       "GET",
-      `/api/${this.orgSlug}/agents/${agentId}/connections`
+      `/api/${this.orgSlug}/agents/${agentId}/platforms`
     );
-    return body.connections ?? [];
+    return body.platforms ?? [];
   }
 
   /**
-   * Stable-ID upsert (PR-2 introduces this route).
+   * Stable-ID upsert.
    *
    * Server contract:
-   *   PUT /:agentId/connections/by-stable-id/:stableId
+   *   PUT /:agentId/platforms/by-stable-id/:stableId
    *   body: { platform, name?, config }
-   *   response when unchanged: { noop: true, connection }
-   *   response when changed:   { updated: true, willRestart: true, connection }
-   *   response on first write: { created: true, connection }
+   *   response when unchanged: { noop: true, platform }
+   *   response when changed:   { updated: true, willRestart: true, platform }
+   *   response on first write: { created: true, platform }
    */
-  async upsertConnection(
+  async upsertPlatform(
     agentId: string,
     stableId: string,
     payload: { platform: string; name?: string; config: Record<string, string> }
-  ): Promise<UpsertConnectionResult> {
-    const { body } = await this.request<UpsertConnectionResult>(
+  ): Promise<UpsertPlatformResult> {
+    const { body } = await this.request<UpsertPlatformResult>(
       "PUT",
-      `/api/${this.orgSlug}/agents/${agentId}/connections/by-stable-id/${encodeURIComponent(stableId)}`,
+      `/api/${this.orgSlug}/agents/${agentId}/platforms/by-stable-id/${encodeURIComponent(stableId)}`,
       payload
     );
     return body;

--- a/packages/cli/src/commands/_lib/apply/desired-state.ts
+++ b/packages/cli/src/commands/_lib/apply/desired-state.ts
@@ -9,24 +9,24 @@ import {
   loadConfig,
 } from "../../../config/loader.js";
 
-// ── Stable connection IDs (mirror of file-loader.ts:56) ────────────────────
+// ── Stable platform IDs (mirror of file-loader.ts) ─────────────────────────
 //
-// keep in sync with packages/owletto-backend/src/gateway/config/file-loader.ts:56
-function slugifyForConnectionId(input: string): string {
+// keep in sync with packages/owletto-backend/src/gateway/config/file-loader.ts
+function slugifyForPlatformId(input: string): string {
   return input
     .toLowerCase()
     .replace(/[^a-z0-9]+/g, "-")
     .replace(/^-+|-+$/g, "");
 }
 
-// keep in sync with packages/owletto-backend/src/gateway/config/file-loader.ts:56
-export function buildStableConnectionId(
+// keep in sync with packages/owletto-backend/src/gateway/config/file-loader.ts
+export function buildStablePlatformId(
   agentId: string,
   type: string,
   name?: string
 ): string {
-  const parts = [slugifyForConnectionId(agentId), slugifyForConnectionId(type)];
-  if (name) parts.push(slugifyForConnectionId(name));
+  const parts = [slugifyForPlatformId(agentId), slugifyForPlatformId(type)];
+  if (name) parts.push(slugifyForPlatformId(name));
   return parts.join("-");
 }
 
@@ -38,7 +38,7 @@ export interface DesiredAgentMetadata {
   description?: string;
 }
 
-export interface DesiredConnection {
+export interface DesiredPlatform {
   /** Stable, content-addressed ID derived from `(agentId, type, name?)`. */
   stableId: string;
   type: string;
@@ -76,7 +76,7 @@ export interface DesiredAgent {
    * Persistence of egressConfig/preApprovedTools/guardrails depends on PR-1.
    */
   settings: Partial<AgentSettings>;
-  connections: DesiredConnection[];
+  platforms: DesiredPlatform[];
 }
 
 export interface DesiredState {
@@ -114,8 +114,8 @@ function collectEnvRefs(config: LobuTomlConfig, out: Set<string>): void {
         if (ref) out.add(ref);
       }
     }
-    for (const conn of agentConfig.connections) {
-      for (const value of Object.values(conn.config)) {
+    for (const platform of agentConfig.platforms) {
+      for (const value of Object.values(platform.config)) {
         const ref = asEnvRef(value);
         if (ref) out.add(ref);
       }
@@ -297,7 +297,7 @@ async function readMarkdown(
 
 function resolveConfigValue(
   agentId: string,
-  connType: string,
+  platformType: string,
   key: string,
   value: string,
   env: NodeJS.ProcessEnv
@@ -307,41 +307,41 @@ function resolveConfigValue(
   const resolved = env[ref];
   if (resolved === undefined || resolved === "") {
     throw new ValidationError(
-      `agent "${agentId}" connection "${connType}" config key "${key}" references $${ref}, but it is unset or empty in the apply environment`
+      `agent "${agentId}" platform "${platformType}" config key "${key}" references $${ref}, but it is unset or empty in the apply environment`
     );
   }
   return resolved;
 }
 
-function buildConnections(
+function buildPlatforms(
   agentId: string,
   agentConfig: TomlAgentEntry,
   env: NodeJS.ProcessEnv
-): DesiredConnection[] {
+): DesiredPlatform[] {
   // Reject duplicate (type, name) pairs — same rule the file-loader enforces
   // so stable IDs stay collision-free.
   const seen = new Set<string>();
-  const out: DesiredConnection[] = [];
-  for (const conn of agentConfig.connections) {
-    const key = `${conn.type}:${conn.name ?? ""}`;
+  const out: DesiredPlatform[] = [];
+  for (const platform of agentConfig.platforms) {
+    const key = `${platform.type}:${platform.name ?? ""}`;
     if (seen.has(key)) {
       throw new ValidationError(
-        conn.name
-          ? `agent "${agentId}" has duplicate connection (type=${conn.type}, name=${conn.name})`
-          : `agent "${agentId}" has multiple "${conn.type}" connections — add a unique \`name = "..."\` to each to disambiguate`
+        platform.name
+          ? `agent "${agentId}" has duplicate platform (type=${platform.type}, name=${platform.name})`
+          : `agent "${agentId}" has multiple "${platform.type}" platforms — add a unique \`name = "..."\` to each to disambiguate`
       );
     }
     seen.add(key);
     const resolvedConfig: Record<string, string> = {};
-    for (const [k, v] of Object.entries(conn.config)) {
-      resolvedConfig[k] = resolveConfigValue(agentId, conn.type, k, v, env);
+    for (const [k, v] of Object.entries(platform.config)) {
+      resolvedConfig[k] = resolveConfigValue(agentId, platform.type, k, v, env);
     }
-    const desired: DesiredConnection = {
-      stableId: buildStableConnectionId(agentId, conn.type, conn.name),
-      type: conn.type,
+    const desired: DesiredPlatform = {
+      stableId: buildStablePlatformId(agentId, platform.type, platform.name),
+      type: platform.type,
       config: resolvedConfig,
     };
-    if (conn.name) desired.name = conn.name;
+    if (platform.name) desired.name = platform.name;
     out.push(desired);
   }
   return out;
@@ -532,13 +532,13 @@ export async function loadDesiredState(
     const agentDir = resolve(opts.cwd, agentConfig.dir);
     const markdown = await readMarkdown(agentDir);
     const settings = buildAgentSettings(agentConfig, markdown);
-    const connections = buildConnections(agentId, agentConfig, env);
+    const platforms = buildPlatforms(agentId, agentConfig, env);
     const metadata: DesiredAgentMetadata = {
       agentId,
       name: agentConfig.name,
     };
     if (agentConfig.description) metadata.description = agentConfig.description;
-    agents.push({ metadata, settings, connections });
+    agents.push({ metadata, settings, platforms });
   }
 
   const memorySchema = await loadMemorySchema(config, opts.cwd);

--- a/packages/cli/src/commands/_lib/apply/diff.ts
+++ b/packages/cli/src/commands/_lib/apply/diff.ts
@@ -1,14 +1,14 @@
 import type { AgentSettings } from "@lobu/core";
 import type {
   RemoteAgent,
-  RemoteConnection,
   RemoteEntityType,
+  RemotePlatform,
   RemoteRelationshipType,
 } from "./client.js";
 import type {
   DesiredAgent,
-  DesiredConnection,
   DesiredEntityType,
+  DesiredPlatform,
   DesiredRelationshipType,
 } from "./desired-state.js";
 
@@ -36,11 +36,11 @@ export interface SettingsDiffRow extends BaseRow {
   changedFields?: string[];
 }
 
-export interface ConnectionDiffRow extends BaseRow {
-  kind: "connection";
+export interface PlatformDiffRow extends BaseRow {
+  kind: "platform";
   agentId: string;
-  desired?: DesiredConnection;
-  remote?: RemoteConnection;
+  desired?: DesiredPlatform;
+  remote?: RemotePlatform;
   changedFields?: string[];
   /** True when an update will restart the live worker — surfaced in the plan. */
   willRestart?: boolean;
@@ -63,7 +63,7 @@ export interface RelationshipTypeDiffRow extends BaseRow {
 export type DiffRow =
   | AgentDiffRow
   | SettingsDiffRow
-  | ConnectionDiffRow
+  | PlatformDiffRow
   | EntityTypeDiffRow
   | RelationshipTypeDiffRow;
 
@@ -192,14 +192,14 @@ function diffSettings(
   };
 }
 
-function diffConnection(
+function diffPlatform(
   agentId: string,
-  desired: DesiredConnection,
-  remote: RemoteConnection | undefined
-): ConnectionDiffRow {
+  desired: DesiredPlatform,
+  remote: RemotePlatform | undefined
+): PlatformDiffRow {
   if (!remote) {
     return {
-      kind: "connection",
+      kind: "platform",
       verb: "create",
       id: desired.stableId,
       agentId,
@@ -211,14 +211,14 @@ function diffConnection(
   if (desired.type !== remote.platform) changed.push("type");
   // The route handler stores `platform` inside `config` for stable-id matching,
   // so a noop round-trip from GET will have an extra `platform` key the CLI
-  // never wrote. Strip it before diffing so an unchanged connection doesn't
+  // never wrote. Strip it before diffing so an unchanged platform doesn't
   // show as drift on every plan.
   const remoteConfig: Record<string, unknown> = { ...(remote.config ?? {}) };
   delete remoteConfig.platform;
   if (!deepEqual(desired.config, remoteConfig)) changed.push("config");
   if (changed.length === 0) {
     return {
-      kind: "connection",
+      kind: "platform",
       verb: "noop",
       id: desired.stableId,
       agentId,
@@ -227,7 +227,7 @@ function diffConnection(
     };
   }
   return {
-    kind: "connection",
+    kind: "platform",
     verb: "update",
     id: desired.stableId,
     agentId,
@@ -321,7 +321,7 @@ export interface RemoteSnapshot {
   /** keyed by agentId */
   agentSettings: Map<string, AgentSettings | null>;
   /** keyed by agentId */
-  connectionsByAgent: Map<string, RemoteConnection[]>;
+  platformsByAgent: Map<string, RemotePlatform[]>;
   entityTypes: RemoteEntityType[];
   relationshipTypes: RemoteRelationshipType[];
 }
@@ -375,30 +375,28 @@ export function computeDiff(
         rows.push(settingsRow);
       }
 
-      const remoteConns =
-        remote.connectionsByAgent.get(agent.metadata.agentId) ?? [];
-      const remoteByStableId = new Map(remoteConns.map((c) => [c.id, c]));
-      const desiredStableIds = new Set(
-        agent.connections.map((c) => c.stableId)
-      );
+      const remotePlatforms =
+        remote.platformsByAgent.get(agent.metadata.agentId) ?? [];
+      const remoteByStableId = new Map(remotePlatforms.map((p) => [p.id, p]));
+      const desiredStableIds = new Set(agent.platforms.map((p) => p.stableId));
 
-      for (const conn of agent.connections) {
+      for (const platform of agent.platforms) {
         rows.push(
-          diffConnection(
+          diffPlatform(
             agent.metadata.agentId,
-            conn,
-            remoteByStableId.get(conn.stableId)
+            platform,
+            remoteByStableId.get(platform.stableId)
           )
         );
       }
-      for (const remoteConn of remoteConns) {
-        if (!desiredStableIds.has(remoteConn.id)) {
+      for (const remotePlatform of remotePlatforms) {
+        if (!desiredStableIds.has(remotePlatform.id)) {
           rows.push({
-            kind: "connection",
+            kind: "platform",
             verb: "drift",
-            id: remoteConn.id,
+            id: remotePlatform.id,
             agentId: agent.metadata.agentId,
-            remote: remoteConn,
+            remote: remotePlatform,
           });
         }
       }

--- a/packages/cli/src/commands/_lib/apply/render.ts
+++ b/packages/cli/src/commands/_lib/apply/render.ts
@@ -11,7 +11,7 @@ const VERB_PREFIX = {
 const KIND_LABEL: Record<DiffRow["kind"], string> = {
   agent: "agent",
   settings: "settings",
-  connection: "connection",
+  platform: "platform",
   "entity-type": "entity-type",
   "relationship-type": "relationship-type",
 };
@@ -24,7 +24,7 @@ function fieldsList(fields: string[] | undefined): string {
 function renderRow(row: DiffRow): string[] {
   const prefix = VERB_PREFIX[row.verb];
   const label = chalk.bold(KIND_LABEL[row.kind]);
-  const id = row.kind === "connection" ? `${row.agentId}/${row.id}` : row.id;
+  const id = row.kind === "platform" ? `${row.agentId}/${row.id}` : row.id;
   const lines: string[] = [];
 
   switch (row.verb) {
@@ -33,9 +33,9 @@ function renderRow(row: DiffRow): string[] {
       break;
     case "update":
       lines.push(`  ${prefix} ${label} ${id}${fieldsList(row.changedFields)}`);
-      if (row.kind === "connection" && row.willRestart) {
+      if (row.kind === "platform" && row.willRestart) {
         lines.push(
-          `      ${chalk.yellow("⚠")} will restart connection — in-flight messages may drop`
+          `      ${chalk.yellow("⚠")} will restart platform — in-flight messages may drop`
         );
       }
       break;
@@ -61,7 +61,7 @@ export function renderPlan(plan: DiffPlan): string {
   const order: DiffRow["kind"][] = [
     "agent",
     "settings",
-    "connection",
+    "platform",
     "entity-type",
     "relationship-type",
   ];

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -5,7 +5,7 @@ import { join } from "node:path";
 import { confirm, input, password, select } from "@inquirer/prompts";
 import chalk from "chalk";
 import ora from "ora";
-import { promptPlatformConfig } from "../commands/connections/platforms.js";
+import { promptPlatformConfig } from "../commands/platforms/platform-prompts.js";
 import { secretsSetCommand } from "../commands/secrets.js";
 import {
   getProviderById,
@@ -149,7 +149,7 @@ export async function initCommand(
   // Define skills locally via skills/<name>/SKILL.md or
   // agents/<id>/skills/<name>/SKILL.md.
 
-  // Connection (messaging platform) selection
+  // Chat platform selection
   const platformChoices = [
     { name: "Skip — I'll connect a platform later", value: "" },
     { name: "Telegram", value: "telegram" },
@@ -161,14 +161,14 @@ export async function initCommand(
   ];
 
   const platformType = await select<string>({
-    message: "Connect a messaging platform?",
+    message: "Connect a chat platform?",
     choices: platformChoices,
     default: "",
   });
 
-  const { connectionConfig, connectionSecrets } = platformType
+  const { platformConfig, platformSecrets } = platformType
     ? await promptPlatformConfig(platformType)
-    : { connectionConfig: {}, connectionSecrets: [] };
+    : { platformConfig: {}, platformSecrets: [] };
 
   // Memory
   const memoryChoice = await select<
@@ -286,9 +286,9 @@ export async function initCommand(
       providerId: providerId || undefined,
       providerEnvVar: selectedProvider?.providers?.[0]?.envVarName,
       providerModel: selectedProvider?.providers?.[0]?.defaultModel,
-      connectionType: platformType || undefined,
-      connectionConfig:
-        Object.keys(connectionConfig).length > 0 ? connectionConfig : undefined,
+      platformType: platformType || undefined,
+      platformConfig:
+        Object.keys(platformConfig).length > 0 ? platformConfig : undefined,
       includeOwlettoMemory,
       owlettoOrg: includeOwlettoMemory ? projectName : undefined,
       owlettoName: includeOwlettoMemory ? humanizeSlug(projectName) : undefined,
@@ -325,8 +325,8 @@ export async function initCommand(
       );
     }
 
-    // Save connection secrets to .env
-    for (const secret of connectionSecrets) {
+    // Save platform secrets to .env
+    for (const secret of platformSecrets) {
       await secretsSetCommand(projectDir, secret.envVar, secret.value);
     }
 
@@ -497,8 +497,8 @@ export async function generateLobuToml(
     providerId?: string;
     providerEnvVar?: string;
     providerModel?: string;
-    connectionType?: string;
-    connectionConfig?: Record<string, string>;
+    platformType?: string;
+    platformConfig?: Record<string, string>;
     includeOwlettoMemory?: boolean;
     owlettoOrg?: string;
     owlettoName?: string;
@@ -540,21 +540,21 @@ export async function generateLobuToml(
 
   lines.push("");
 
-  if (options.connectionType && options.connectionConfig) {
+  if (options.platformType && options.platformConfig) {
     lines.push(
-      `[[agents.${id}.connections]]`,
-      `type = "${options.connectionType}"`
+      `[[agents.${id}.platforms]]`,
+      `type = "${options.platformType}"`
     );
-    lines.push(`[agents.${id}.connections.config]`);
-    for (const [key, value] of Object.entries(options.connectionConfig)) {
+    lines.push(`[agents.${id}.platforms.config]`);
+    for (const [key, value] of Object.entries(options.platformConfig)) {
       lines.push(`${key} = "${value}"`);
     }
   } else {
     lines.push(
-      "# Messaging platform (add via the gateway configuration APIs or uncomment below):",
-      `# [[agents.${id}.connections]]`,
+      "# Chat platform (add via the gateway configuration APIs or uncomment below):",
+      `# [[agents.${id}.platforms]]`,
       '# type = "telegram"',
-      `# [agents.${id}.connections.config]`,
+      `# [agents.${id}.platforms.config]`,
       '# botToken = "$TELEGRAM_BOT_TOKEN"'
     );
   }

--- a/packages/cli/src/commands/platforms/add.ts
+++ b/packages/cli/src/commands/platforms/add.ts
@@ -5,7 +5,7 @@ import {
   setSecrets,
 } from "../../config/agent-helpers.js";
 import { CONFIG_FILENAME } from "../../config/loader.js";
-import { PLATFORM_LABELS, promptPlatformConfig } from "./platforms.js";
+import { PLATFORM_LABELS, promptPlatformConfig } from "./platform-prompts.js";
 
 const SUPPORTED = [
   "telegram",
@@ -16,7 +16,7 @@ const SUPPORTED = [
   "gchat",
 ];
 
-export async function connectionsAddCommand(
+export async function platformsAddCommand(
   cwd: string,
   platform: string
 ): Promise<void> {
@@ -29,13 +29,13 @@ export async function connectionsAddCommand(
   const ctx = await loadAgentContext(cwd);
   if (!ctx) return;
 
-  const existing = (ctx.agent.connections ?? []) as Array<
+  const existing = (ctx.agent.platforms ?? []) as Array<
     Record<string, unknown>
   >;
-  if (existing.some((c) => c.type === platform)) {
+  if (existing.some((p) => p.type === platform)) {
     console.log(
       chalk.yellow(
-        `\n  Connection "${platform}" is already configured for agent "${ctx.agentId}".\n`
+        `\n  Platform "${platform}" is already configured for agent "${ctx.agentId}".\n`
       )
     );
     return;
@@ -43,39 +43,37 @@ export async function connectionsAddCommand(
 
   console.log(
     chalk.dim(
-      `\n  Adding ${PLATFORM_LABELS[platform]} connection to agent "${ctx.agentId}".\n`
+      `\n  Adding ${PLATFORM_LABELS[platform]} platform to agent "${ctx.agentId}".\n`
     )
   );
 
-  const { connectionConfig, connectionSecrets } =
+  const { platformConfig, platformSecrets } =
     await promptPlatformConfig(platform);
 
-  if (Object.keys(connectionConfig).length === 0) {
+  if (Object.keys(platformConfig).length === 0) {
     console.log(chalk.yellow("\n  No credentials provided. Aborting.\n"));
     return;
   }
 
   const lines = [
     "",
-    `[[agents.${ctx.agentId}.connections]]`,
+    `[[agents.${ctx.agentId}.platforms]]`,
     `type = "${platform}"`,
     "",
-    `[agents.${ctx.agentId}.connections.config]`,
-    ...Object.entries(connectionConfig).map(
+    `[agents.${ctx.agentId}.platforms.config]`,
+    ...Object.entries(platformConfig).map(
       ([key, value]) => `${key} = "${value}"`
     ),
   ];
   await appendTomlBlock(ctx, lines);
-  await setSecrets(cwd, connectionSecrets);
+  await setSecrets(cwd, platformSecrets);
 
   console.log(
     chalk.green(
-      `\n  Added ${PLATFORM_LABELS[platform]} connection to ${CONFIG_FILENAME}`
+      `\n  Added ${PLATFORM_LABELS[platform]} platform to ${CONFIG_FILENAME}`
     )
   );
   console.log(
-    chalk.dim(
-      "  Run `lobu run -d` to start the stack with the new connection.\n"
-    )
+    chalk.dim("  Run `lobu run -d` to start the stack with the new platform.\n")
   );
 }

--- a/packages/cli/src/commands/platforms/list.ts
+++ b/packages/cli/src/commands/platforms/list.ts
@@ -1,22 +1,20 @@
 import chalk from "chalk";
 import { loadAgentContext } from "../../config/agent-helpers.js";
-import { PLATFORM_LABELS } from "./platforms.js";
+import { PLATFORM_LABELS } from "./platform-prompts.js";
 
-export async function connectionsListCommand(cwd: string): Promise<void> {
+export async function platformsListCommand(cwd: string): Promise<void> {
   const ctx = await loadAgentContext(cwd);
   if (!ctx) return;
 
   console.log();
   for (const [agentId, agent] of Object.entries(ctx.agents)) {
-    const connections = (agent.connections ?? []) as Array<
-      Record<string, unknown>
-    >;
+    const platforms = (agent.platforms ?? []) as Array<Record<string, unknown>>;
     console.log(chalk.bold(`  ${agentId}`));
-    if (connections.length === 0) {
-      console.log(chalk.dim("    (no connections configured)"));
+    if (platforms.length === 0) {
+      console.log(chalk.dim("    (no platforms configured)"));
     } else {
-      for (const c of connections) {
-        const type = c.type as string;
+      for (const p of platforms) {
+        const type = p.type as string;
         const label = PLATFORM_LABELS[type] ?? type;
         console.log(
           `    ${chalk.cyan("●")} ${label} ${chalk.dim(`(${type})`)}`

--- a/packages/cli/src/commands/platforms/platform-prompts.ts
+++ b/packages/cli/src/commands/platforms/platform-prompts.ts
@@ -1,13 +1,13 @@
 /**
- * Shared platform connection prompt/config logic.
- * Used by both `lobu init` and `lobu connections add <platform>`.
+ * Shared platform prompt/config logic.
+ * Used by both `lobu init` and `lobu platforms add <platform>`.
  */
 
 import { input, password } from "@inquirer/prompts";
 
 interface PlatformPromptResult {
-  connectionConfig: Record<string, string>;
-  connectionSecrets: Array<{ envVar: string; value: string }>;
+  platformConfig: Record<string, string>;
+  platformSecrets: Array<{ envVar: string; value: string }>;
 }
 
 export const PLATFORM_LABELS: Record<string, string> = {
@@ -22,8 +22,8 @@ export const PLATFORM_LABELS: Record<string, string> = {
 export async function promptPlatformConfig(
   platform: string
 ): Promise<PlatformPromptResult> {
-  const connectionConfig: Record<string, string> = {};
-  const connectionSecrets: Array<{ envVar: string; value: string }> = [];
+  const platformConfig: Record<string, string> = {};
+  const platformSecrets: Array<{ envVar: string; value: string }> = [];
 
   if (platform === "telegram") {
     const botToken = await password({
@@ -31,8 +31,8 @@ export async function promptPlatformConfig(
       mask: true,
     });
     if (botToken) {
-      connectionConfig.botToken = "$TELEGRAM_BOT_TOKEN";
-      connectionSecrets.push({ envVar: "TELEGRAM_BOT_TOKEN", value: botToken });
+      platformConfig.botToken = "$TELEGRAM_BOT_TOKEN";
+      platformSecrets.push({ envVar: "TELEGRAM_BOT_TOKEN", value: botToken });
     }
   } else if (platform === "slack") {
     console.log(
@@ -68,15 +68,15 @@ export async function promptPlatformConfig(
       mask: true,
     });
     if (slackBotToken) {
-      connectionConfig.botToken = "$SLACK_BOT_TOKEN";
-      connectionSecrets.push({
+      platformConfig.botToken = "$SLACK_BOT_TOKEN";
+      platformSecrets.push({
         envVar: "SLACK_BOT_TOKEN",
         value: slackBotToken,
       });
     }
     if (slackSigningSecret) {
-      connectionConfig.signingSecret = "$SLACK_SIGNING_SECRET";
-      connectionSecrets.push({
+      platformConfig.signingSecret = "$SLACK_SIGNING_SECRET";
+      platformSecrets.push({
         envVar: "SLACK_SIGNING_SECRET",
         value: slackSigningSecret,
       });
@@ -87,8 +87,8 @@ export async function promptPlatformConfig(
       mask: true,
     });
     if (botToken) {
-      connectionConfig.botToken = "$DISCORD_BOT_TOKEN";
-      connectionSecrets.push({ envVar: "DISCORD_BOT_TOKEN", value: botToken });
+      platformConfig.botToken = "$DISCORD_BOT_TOKEN";
+      platformSecrets.push({ envVar: "DISCORD_BOT_TOKEN", value: botToken });
     }
   } else if (platform === "whatsapp") {
     const accessToken = await password({
@@ -99,15 +99,15 @@ export async function promptPlatformConfig(
       message: "WhatsApp phone number ID:",
     });
     if (accessToken) {
-      connectionConfig.accessToken = "$WHATSAPP_ACCESS_TOKEN";
-      connectionSecrets.push({
+      platformConfig.accessToken = "$WHATSAPP_ACCESS_TOKEN";
+      platformSecrets.push({
         envVar: "WHATSAPP_ACCESS_TOKEN",
         value: accessToken,
       });
     }
     if (phoneNumberId) {
-      connectionConfig.phoneNumberId = "$WHATSAPP_PHONE_NUMBER_ID";
-      connectionSecrets.push({
+      platformConfig.phoneNumberId = "$WHATSAPP_PHONE_NUMBER_ID";
+      platformSecrets.push({
         envVar: "WHATSAPP_PHONE_NUMBER_ID",
         value: phoneNumberId,
       });
@@ -121,15 +121,15 @@ export async function promptPlatformConfig(
       mask: true,
     });
     if (appId) {
-      connectionConfig.appId = "$TEAMS_APP_ID";
-      connectionSecrets.push({
+      platformConfig.appId = "$TEAMS_APP_ID";
+      platformSecrets.push({
         envVar: "TEAMS_APP_ID",
         value: appId,
       });
     }
     if (appPassword) {
-      connectionConfig.appPassword = "$TEAMS_APP_PASSWORD";
-      connectionSecrets.push({
+      platformConfig.appPassword = "$TEAMS_APP_PASSWORD";
+      platformSecrets.push({
         envVar: "TEAMS_APP_PASSWORD",
         value: appPassword,
       });
@@ -140,13 +140,13 @@ export async function promptPlatformConfig(
       mask: true,
     });
     if (credentials) {
-      connectionConfig.credentials = "$GOOGLE_CHAT_CREDENTIALS";
-      connectionSecrets.push({
+      platformConfig.credentials = "$GOOGLE_CHAT_CREDENTIALS";
+      platformSecrets.push({
         envVar: "GOOGLE_CHAT_CREDENTIALS",
         value: credentials,
       });
     }
   }
 
-  return { connectionConfig, connectionSecrets };
+  return { platformConfig, platformSecrets };
 }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -377,31 +377,31 @@ export async function runCli(
       await skillsAddCommand(process.cwd(), id, options);
     });
 
-  // ─── connections ────────────────────────────────────────────────────
-  const connections = program
-    .command("connections")
-    .description("Manage messaging platform connections");
+  // ─── platforms ──────────────────────────────────────────────────────
+  const platforms = program
+    .command("platforms")
+    .description("Manage chat platforms");
 
-  connections
+  platforms
     .command("list")
-    .description("List configured connections per agent")
+    .description("List configured platforms per agent")
     .action(async () => {
-      const { connectionsListCommand } = await import(
-        "./commands/connections/list.js"
+      const { platformsListCommand } = await import(
+        "./commands/platforms/list.js"
       );
-      await connectionsListCommand(process.cwd());
+      await platformsListCommand(process.cwd());
     });
 
-  connections
+  platforms
     .command("add <platform>")
     .description(
-      "Add a messaging platform connection (telegram, slack, discord, whatsapp, teams, gchat)"
+      "Add a chat platform (telegram, slack, discord, whatsapp, teams, gchat)"
     )
     .action(async (platform: string) => {
-      const { connectionsAddCommand } = await import(
-        "./commands/connections/add.js"
+      const { platformsAddCommand } = await import(
+        "./commands/platforms/add.js"
       );
-      await connectionsAddCommand(process.cwd(), platform);
+      await platformsAddCommand(process.cwd(), platform);
     });
 
   // ─── doctor ─────────────────────────────────────────────────────────

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -52,8 +52,8 @@ export type {
 // lobu.toml zod schema (canonical — used by CLI and gateway)
 export {
   type AgentEntry as TomlAgentEntry,
-  type ConnectionEntry as TomlConnectionEntry,
   type EgressEntry as TomlEgressEntry,
+  type PlatformEntry as TomlPlatformEntry,
   type LobuTomlConfig,
   lobuConfigSchema,
   type McpServerEntry as TomlMcpServerEntry,

--- a/packages/core/src/lobu-toml-schema.ts
+++ b/packages/core/src/lobu-toml-schema.ts
@@ -23,19 +23,20 @@ const providerSchema = z
     message: "provider must set at most one of `key` or `secret_ref`",
   });
 
-// ── Connection ──────────────────────────────────────────────────────────────
+// ── Platform ────────────────────────────────────────────────────────────────
 
-const connectionSchema = z.object({
+const platformSchema = z.object({
   type: z.string(),
   /**
-   * Optional disambiguator when an agent has multiple connections of the same
-   * type (e.g. two Slack workspaces). Slugged and appended to the stable
-   * connection ID: `{agent}-{type}-{name}`. Omit for single-connection setups.
+   * Optional disambiguator when an agent has multiple platform instances of
+   * the same type (e.g. two Slack workspaces). Slugged and appended to the
+   * stable platform ID: `{agent}-{type}-{name}`. Omit when there is only one
+   * instance per type.
    */
   name: z
     .string()
     .regex(/^[a-z0-9][a-z0-9-]*$/, {
-      message: "connection name must be lowercase alphanumeric with hyphens",
+      message: "platform name must be lowercase alphanumeric with hyphens",
     })
     .optional(),
   /** Platform-specific config (e.g. `{ botToken: "$BOT_TOKEN" }`). */
@@ -180,7 +181,7 @@ const agentEntrySchema = z.object({
   /** Path to agent content directory (IDENTITY.md, SOUL.md, USER.md, skills/). */
   dir: z.string(),
   providers: z.array(providerSchema).default([]),
-  connections: z.array(connectionSchema).default([]),
+  platforms: z.array(platformSchema).default([]),
   skills: skillsSchema.default({}),
   network: networkSchema.optional(),
   egress: egressSchema.optional(),
@@ -221,7 +222,7 @@ export const lobuConfigSchema = z.object({
 export type LobuTomlConfig = z.infer<typeof lobuConfigSchema>;
 export type AgentEntry = z.infer<typeof agentEntrySchema>;
 export type ProviderEntry = z.infer<typeof providerSchema>;
-export type ConnectionEntry = z.infer<typeof connectionSchema>;
+export type PlatformEntry = z.infer<typeof platformSchema>;
 export type McpServerEntry = z.infer<typeof mcpServerSchema>;
 export type SkillsEntry = z.infer<typeof skillsSchema>;
 export type NetworkEntry = z.infer<typeof networkSchema>;

--- a/packages/landing/src/content/docs/platforms/discord.mdx
+++ b/packages/landing/src/content/docs/platforms/discord.mdx
@@ -17,7 +17,7 @@ Under the hood, Lobu uses the Chat SDK Discord adapter to handle DMs and server 
 2. Under **Bot**, create a bot and copy the **bot token**.
 3. Copy the **Application ID** and **Public Key** from the General Information page.
 4. Under **OAuth2 → URL Generator**, select the `bot` scope with `Send Messages`, `Read Message History`, and `Use Slash Commands` permissions. Use the generated URL to invite the bot to your server.
-5. Run `lobu connections add discord` to add the connection (prompts for the bot token), or run `lobu init` to scaffold a new project and pick Discord in the wizard.
+5. Run `lobu platforms add discord` to add the connection (prompts for the bot token), or run `lobu init` to scaffold a new project and pick Discord in the wizard.
 
 
 ## Configuration

--- a/packages/landing/src/content/docs/platforms/google-chat.mdx
+++ b/packages/landing/src/content/docs/platforms/google-chat.mdx
@@ -19,7 +19,7 @@ Under the hood, Lobu uses `@chat-adapter/gchat` with the Google Chat API and Wor
 3. In the [Google Chat API configuration](https://console.cloud.google.com/apis/api/chat.googleapis.com/hangouts-chat), configure the app:
    - Set the **App URL** to your gateway's webhook endpoint: `https://your-gateway/api/v1/webhooks/{connectionId}`
    - Enable **Interactive features** and configure the connection settings.
-4. Run `lobu connections add gchat` to add the connection (prompts for the service account JSON), or run `lobu init` to scaffold a new project and pick Google Chat in the wizard.
+4. Run `lobu platforms add gchat` to add the connection (prompts for the service account JSON), or run `lobu init` to scaffold a new project and pick Google Chat in the wizard.
 
 ## Configuration
 

--- a/packages/landing/src/content/docs/platforms/slack.mdx
+++ b/packages/landing/src/content/docs/platforms/slack.mdx
@@ -16,7 +16,7 @@ Lobu's Slack adapter supports assistant threads, rich UI, and interactive workfl
 
 1. Create a Slack app at [api.slack.com/apps](https://api.slack.com/apps) and install it to your workspace.
 2. Copy the **Signing Secret** and **Bot Token** (`xoxb-...`) from the app settings.
-3. Run `lobu connections add slack` to add the connection to your existing agent (prompts for the bot token and signing secret), or run `lobu init` to scaffold a new project and pick Slack in the wizard.
+3. Run `lobu platforms add slack` to add the connection to your existing agent (prompts for the bot token and signing secret), or run `lobu init` to scaffold a new project and pick Slack in the wizard.
 4. Start the stack with `lobu run -d` — the bot is now live in your Slack workspace.
 
 ## Installation Modes

--- a/packages/landing/src/content/docs/platforms/teams.mdx
+++ b/packages/landing/src/content/docs/platforms/teams.mdx
@@ -16,7 +16,7 @@ Under the hood, Lobu uses the Chat SDK Teams adapter with Azure Bot Framework.
 1. Register a bot in the [Azure Portal](https://portal.azure.com) under **Azure Bot** (or **Bot Framework Registration**).
 2. Note the **App ID**, **App Password** (client secret), and **Tenant ID**.
 3. In the Azure Bot's **Channels** section, enable the **Microsoft Teams** channel.
-4. Run `lobu connections add teams` to add the connection (prompts for the app ID and app password), or run `lobu init` to scaffold a new project and pick Microsoft Teams in the wizard.
+4. Run `lobu platforms add teams` to add the connection (prompts for the app ID and app password), or run `lobu init` to scaffold a new project and pick Microsoft Teams in the wizard.
 
 ## Configuration
 

--- a/packages/landing/src/content/docs/platforms/telegram.mdx
+++ b/packages/landing/src/content/docs/platforms/telegram.mdx
@@ -14,7 +14,7 @@ Under the hood, Lobu uses the Telegram Bot API via `@chat-adapter/telegram`.
 ## Setup
 
 1. Create a bot with [@BotFather](https://t.me/BotFather) on Telegram and copy the bot token.
-2. Run `lobu connections add telegram` to add the connection (prompts for the bot token), or run `lobu init` to scaffold a new project and pick Telegram in the wizard.
+2. Run `lobu platforms add telegram` to add the connection (prompts for the bot token), or run `lobu init` to scaffold a new project and pick Telegram in the wizard.
 3. Start the stack with `lobu run -d` — the bot starts receiving messages immediately.
 
 ## Configuration

--- a/packages/landing/src/content/docs/platforms/whatsapp.mdx
+++ b/packages/landing/src/content/docs/platforms/whatsapp.mdx
@@ -14,7 +14,7 @@ Under the hood, Lobu uses the WhatsApp Business Cloud API for message delivery a
 ## Setup
 
 1. Obtain a WhatsApp Business **access token**, **phone number ID**, **app secret**, and **verify token** from the [Meta Developer Portal](https://developers.facebook.com/).
-2. Run `lobu connections add whatsapp` to add the connection (prompts for the access token and phone number ID), or run `lobu init` to scaffold a new project and pick WhatsApp in the wizard.
+2. Run `lobu platforms add whatsapp` to add the connection (prompts for the access token and phone number ID), or run `lobu init` to scaffold a new project and pick WhatsApp in the wizard.
 3. Configure the webhook URL in the Meta Developer Portal to point to your gateway's webhook endpoint.
 4. Start the stack with `lobu run -d` — the bot starts handling messages on the configured phone number.
 

--- a/packages/landing/src/content/docs/reference/lobu-apply.md
+++ b/packages/landing/src/content/docs/reference/lobu-apply.md
@@ -13,7 +13,7 @@ Mental model: `terraform apply` lite. Files are the source of truth; the cloud i
 lobu apply                       # plan + prompt + apply
 lobu apply --dry-run             # plan only
 lobu apply --yes                 # plan + apply, no prompt (CI)
-lobu apply --only agents         # restrict to agent + connection resources
+lobu apply --only agents         # restrict to agent + platform resources
 lobu apply --only memory         # restrict to entity + relationship types
 lobu apply --org my-org          # override active org
 ```
@@ -24,7 +24,7 @@ Authentication is shared with the rest of the CLI. Run `lobu login` once.
 
 - Agents (metadata: `agentId`, `name`, `description`)
 - Agent settings: `networkConfig`, `egressConfig`, `nixConfig`, `mcpServers`, `skillsConfig`, `toolsConfig`, `guardrails`, `preApprovedTools`, `providerModelPreferences`, `modelSelection`, `IDENTITY.md` / `SOUL.md` / `USER.md`
-- Messaging connections under `[[agents.<id>.connections]]`, keyed by a stable ID derived from `(agentId, type, name?)`
+- Chat platforms under `[[agents.<id>.platforms]]`, keyed by a stable ID derived from `(agentId, type, name?)`
 - Memory entity types and relationship types (from `models/*.yaml` referenced by `[memory.owletto].models`)
 
 ## What is not synced (v1)
@@ -45,7 +45,7 @@ Each row is one of four verbs:
 | `= noop` | resource exists and matches the desired state |
 | `? drift` | cloud has a resource not declared in `lobu.toml` — **reported only**, never deleted in v1 |
 
-When a connection update will restart the live worker, the plan adds an inline warning line.
+When a platform update will restart the live worker, the plan adds an inline warning line.
 
 ## Apply order
 
@@ -56,7 +56,7 @@ upsertAgent          (POST /api/:org/agents/)
         ↓
 patchAgentSettings   (PATCH /api/:org/agents/:id/config)
         ↓
-upsertConnection     (PUT /api/:org/agents/:id/connections/by-stable-id/:stableId)
+upsertPlatform       (PUT /api/:org/agents/:id/platforms/by-stable-id/:stableId)
         ↓
 upsertEntityType        (manage_entity_schema)
         ↓
@@ -70,7 +70,7 @@ If any call fails, the CLI prints partial progress and exits non-zero. Every end
 Before any mutation, `lobu apply` walks `lobu.toml` for `$VAR` references in:
 
 - `[[agents.<id>.providers]]` — `key`, `secret_ref`
-- `[[agents.<id>.connections]]` — every value in `[agents.<id>.connections.config]`
+- `[[agents.<id>.platforms]]` — every value in `[agents.<id>.platforms.config]`
 - `[agents.<id>.skills.mcp.<id>]` — `headers`, `env`, `oauth.client_id`, `oauth.client_secret`
 
 Each name must be set in the apply runner's environment (e.g. via `.env` loaded by your shell). Any missing name short-circuits the apply with a list of every missing var.
@@ -79,17 +79,17 @@ Secret values are never uploaded by `lobu apply`. Use your deployment's secret m
 
 ## Drift
 
-Cloud-side resources not declared in `lobu.toml` are reported but never deleted. v1 has no `--prune`. To remove a cloud-side agent or connection, use the admin UI or the underlying CRUD endpoints directly; the next `lobu apply` will continue to surface it as drift until you remove it from the cloud or add it to your files.
+Cloud-side resources not declared in `lobu.toml` are reported but never deleted. v1 has no `--prune`. To remove a cloud-side agent or platform, use the admin UI or the underlying CRUD endpoints directly; the next `lobu apply` will continue to surface it as drift until you remove it from the cloud or add it to your files.
 
-## Stable connection IDs
+## Stable platform IDs
 
-Each connection's URL — including webhook URLs (`/api/v1/webhooks/<id>`) — is derived from `(agentId, type, name)`:
+Each platform's URL — including webhook URLs (`/api/v1/webhooks/<id>`) — is derived from `(agentId, type, name)`:
 
 ```
 {slugify(agentId)}-{slugify(type)}[-{slugify(name)}]
 ```
 
-When you have more than one connection of the same `type` under the same agent, `name = "..."` is required. The same rule applies in `lobu run` (file-loader.ts) — both paths build identical stable IDs.
+When you have more than one platform of the same `type` under the same agent, `name = "..."` is required. The same rule applies in `lobu run` (file-loader.ts) — both paths build identical stable IDs.
 
 ## CI usage
 

--- a/packages/landing/src/content/docs/reference/lobu-toml.md
+++ b/packages/landing/src/content/docs/reference/lobu-toml.md
@@ -5,7 +5,7 @@ sidebar:
   order: 1
 ---
 
-`lobu.toml` is the project configuration file created by `lobu init`. It defines agents, providers, connections, skills, network access, worker settings, and optional file-first Owletto memory configuration.
+`lobu.toml` is the project configuration file created by `lobu init`. It defines agents, providers, platforms, skills, network access, worker settings, and optional file-first Owletto memory configuration.
 
 ## Minimal example
 
@@ -47,15 +47,15 @@ key = "$OPENROUTER_API_KEY"
 id = "gemini"
 key = "$GEMINI_API_KEY"
 
-# Platform connections
-[[agents.support.connections]]
+# Chat platforms
+[[agents.support.platforms]]
 type = "telegram"
-[agents.support.connections.config]
+[agents.support.platforms.config]
 botToken = "$TELEGRAM_BOT_TOKEN"
 
-[[agents.support.connections]]
+[[agents.support.platforms]]
 type = "slack"
-[agents.support.connections.config]
+[agents.support.platforms.config]
 botToken = "$SLACK_BOT_TOKEN"
 signingSecret = "$SLACK_SIGNING_SECRET"
 
@@ -141,7 +141,7 @@ Top-level table keyed by agent ID. IDs must match `^[a-z0-9][a-z0-9-]*$` (lowerc
 | `description` | string | no | Short description shown in admin UI |
 | `dir` | string | yes | Path to agent content directory containing `IDENTITY.md`, `SOUL.md`, `USER.md`, and optional `skills/` |
 | `providers` | array | no | LLM provider list (order = priority) |
-| `connections` | array | no | Platform connections |
+| `platforms` | array | no | Chat platforms |
 | `skills` | table | no | Skills and MCP servers |
 | `network` | table | no | Network access policy |
 | `tools` | table | no | Tool policy: pre-approval bypass + worker-side visibility |
@@ -160,33 +160,33 @@ Each entry configures an LLM provider. The first available provider is used at r
 
 Provider credentials are optional. A provider entry may omit both `key` and `secret_ref`, or set exactly one of them. Setting both is invalid.
 
-### `[[agents.<id>.connections]]`
+### `[[agents.<id>.platforms]]`
 
-Each entry connects the agent to a messaging platform.
+Each entry connects the agent to a chat platform.
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | `type` | string | yes | Platform type: `telegram`, `slack`, `discord`, `whatsapp`, `teams`, `gchat` |
 | `config` | table | yes | Platform-specific configuration (see below) |
 
-#### Connection config by platform
+#### Platform config by type
 
 **Telegram**
 ```toml
-[agents.x.connections.config]
+[agents.x.platforms.config]
 botToken = "$TELEGRAM_BOT_TOKEN"
 ```
 
 **Slack**
 ```toml
-[agents.x.connections.config]
+[agents.x.platforms.config]
 botToken = "$SLACK_BOT_TOKEN"
 signingSecret = "$SLACK_SIGNING_SECRET"
 ```
 
 **Discord**
 ```toml
-[agents.x.connections.config]
+[agents.x.platforms.config]
 botToken = "$DISCORD_BOT_TOKEN"
 applicationId = "$DISCORD_APPLICATION_ID"
 publicKey = "$DISCORD_PUBLIC_KEY"
@@ -194,7 +194,7 @@ publicKey = "$DISCORD_PUBLIC_KEY"
 
 **WhatsApp** (Cloud API)
 ```toml
-[agents.x.connections.config]
+[agents.x.platforms.config]
 accessToken = "$WHATSAPP_ACCESS_TOKEN"
 phoneNumberId = "$WHATSAPP_PHONE_NUMBER_ID"
 verifyToken = "$WHATSAPP_WEBHOOK_VERIFY_TOKEN"
@@ -203,7 +203,7 @@ appSecret = "$WHATSAPP_APP_SECRET"
 
 **Teams**
 ```toml
-[agents.x.connections.config]
+[agents.x.platforms.config]
 appId = "$TEAMS_APP_ID"
 appPassword = "$TEAMS_APP_PASSWORD"
 appTenantId = "$TEAMS_APP_TENANT_ID"
@@ -212,7 +212,7 @@ appType = "MultiTenant"
 
 **Google Chat**
 ```toml
-[agents.x.connections.config]
+[agents.x.platforms.config]
 credentials = "$GOOGLE_CHAT_CREDENTIALS"
 ```
 

--- a/packages/owletto-backend/src/gateway/__tests__/file-loader-platforms.test.ts
+++ b/packages/owletto-backend/src/gateway/__tests__/file-loader-platforms.test.ts
@@ -1,0 +1,69 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { loadAgentConfigFromFiles } from "../config/file-loader.js";
+
+describe("file-loader platforms key", () => {
+  let projectDir: string;
+
+  beforeEach(() => {
+    projectDir = mkdtempSync(join(tmpdir(), "lobu-file-loader-platforms-"));
+    mkdirSync(join(projectDir, "agents", "support"), { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(projectDir, { recursive: true, force: true });
+  });
+
+  function writeToml(body: string): void {
+    writeFileSync(
+      join(projectDir, "lobu.toml"),
+      `
+[agents.support]
+name = "support"
+dir = "./agents/support"
+
+${body}
+`,
+      "utf-8"
+    );
+  }
+
+  test("accepts the new [[agents.<id>.platforms]] block", async () => {
+    process.env.TEST_TG_TOKEN = "tg-fake";
+    try {
+      writeToml(`
+[[agents.support.platforms]]
+type = "telegram"
+[agents.support.platforms.config]
+botToken = "$TEST_TG_TOKEN"
+`);
+
+      const agents = await loadAgentConfigFromFiles(projectDir);
+      expect(agents).toHaveLength(1);
+      expect(agents[0]?.platforms).toEqual([
+        {
+          id: "support-telegram",
+          type: "telegram",
+          config: { botToken: "tg-fake" },
+        },
+      ]);
+    } finally {
+      delete process.env.TEST_TG_TOKEN;
+    }
+  });
+
+  test("rejects the legacy [[agents.<id>.connections]] block with a clear error", async () => {
+    writeToml(`
+[[agents.support.connections]]
+type = "telegram"
+[agents.support.connections.config]
+botToken = "$TEST_TG_TOKEN"
+`);
+
+    await expect(loadAgentConfigFromFiles(projectDir)).rejects.toThrow(
+      /\[\[agents\.support\.connections\]\] was renamed to \[\[agents\.support\.platforms\]\]/
+    );
+  });
+});

--- a/packages/owletto-backend/src/gateway/cli/gateway.ts
+++ b/packages/owletto-backend/src/gateway/cli/gateway.ts
@@ -1223,31 +1223,31 @@ export async function startGateway(config: GatewayConfig): Promise<void> {
     const fileLoadedAgents = coreServices.getFileLoadedAgents();
     if (fileLoadedAgents.length > 0) {
       for (const agent of fileLoadedAgents) {
-        if (!agent.connections?.length) continue;
+        if (!agent.platforms?.length) continue;
         // Look up by stable id — `(platform, templateAgentId)` alone collapses
-        // multi-connection agents (e.g. two Slack workspaces) into one seed.
+        // multi-platform agents (e.g. two Slack workspaces) into one seed.
         const existingForAgent = await chatInstanceManager.listConnections({
           platform: undefined,
           templateAgentId: agent.agentId,
         });
         const existingIds = new Set(existingForAgent.map((c: any) => c.id));
-        for (const conn of agent.connections) {
-          if (existingIds.has(conn.id)) continue;
+        for (const platform of agent.platforms) {
+          if (existingIds.has(platform.id)) continue;
           try {
             await chatInstanceManager.addConnection(
-              conn.type,
+              platform.type,
               agent.agentId,
-              { platform: conn.type as any, ...conn.config },
+              { platform: platform.type as any, ...platform.config },
               { allowGroups: true },
               {},
-              conn.id
+              platform.id
             );
             logger.debug(
-              `Created ${conn.type} connection for agent "${agent.agentId}" as "${conn.id}"`
+              `Created ${platform.type} platform for agent "${agent.agentId}" as "${platform.id}"`
             );
           } catch (err) {
             logger.error(
-              `Failed to create ${conn.type} connection for agent "${agent.agentId}"`,
+              `Failed to create ${platform.type} platform for agent "${agent.agentId}"`,
               { error: err instanceof Error ? err.message : String(err) }
             );
           }

--- a/packages/owletto-backend/src/gateway/config/file-loader.ts
+++ b/packages/owletto-backend/src/gateway/config/file-loader.ts
@@ -32,7 +32,7 @@ export interface FileLoadedAgent {
     key?: string;
     secretRef?: string;
   }>;
-  connections: Array<{
+  platforms: Array<{
     /** Stable, human-readable ID derived from agentId + type (+ name). */
     id: string;
     type: string;
@@ -40,8 +40,8 @@ export interface FileLoadedAgent {
   }>;
 }
 
-/** Slugify agent IDs and platform names for use in connection IDs. */
-function slugifyForConnectionId(input: string): string {
+/** Slugify agent IDs and platform names for use in stable platform IDs. */
+function slugifyForPlatformId(input: string): string {
   return input
     .toLowerCase()
     .replace(/[^a-z0-9]+/g, "-")
@@ -49,17 +49,17 @@ function slugifyForConnectionId(input: string): string {
 }
 
 /**
- * Build the stable connection ID: `{agent}-{type}` or `{agent}-{type}-{name}`.
+ * Build the stable platform ID: `{agent}-{type}` or `{agent}-{type}-{name}`.
  * Used to make webhook URLs (e.g. `/api/v1/webhooks/<id>`) survive
  * fresh-clone setups — the ID is a pure function of lobu.toml.
  */
-export function buildStableConnectionId(
+export function buildStablePlatformId(
   agentId: string,
   type: string,
   name?: string
 ): string {
-  const parts = [slugifyForConnectionId(agentId), slugifyForConnectionId(type)];
-  if (name) parts.push(slugifyForConnectionId(name));
+  const parts = [slugifyForPlatformId(agentId), slugifyForPlatformId(type)];
+  if (name) parts.push(slugifyForPlatformId(name));
   return parts.join("-");
 }
 
@@ -126,6 +126,17 @@ async function loadAndValidateToml(
     return null;
   }
 
+  // Migration check: the per-agent `connections` key was renamed to
+  // `platforms`. Surface a loud validation error so users update their
+  // lobu.toml instead of silently dropping the now-unknown block.
+  const renamedAgentIds = findAgentsWithLegacyConnectionsKey(parsed);
+  if (renamedAgentIds.length > 0) {
+    const firstAgent = renamedAgentIds[0];
+    throw new Error(
+      `[[agents.${firstAgent}.connections]] was renamed to [[agents.${firstAgent}.platforms]] — update your lobu.toml`
+    );
+  }
+
   const result = lobuConfigSchema.safeParse(parsed);
   if (!result.success) {
     const details = result.error.issues.map(
@@ -136,6 +147,29 @@ async function loadAndValidateToml(
   }
 
   return result.data;
+}
+
+/**
+ * Surface the old `connections` key as a validation error so apply/run users
+ * get a pointer at the new key instead of a silently dropped block. Returns
+ * the agent IDs whose blocks still declare `connections`.
+ */
+function findAgentsWithLegacyConnectionsKey(
+  parsed: Record<string, unknown>
+): string[] {
+  const agents = parsed.agents;
+  if (!agents || typeof agents !== "object") return [];
+  const out: string[] = [];
+  for (const [agentId, agentConfig] of Object.entries(
+    agents as Record<string, unknown>
+  )) {
+    if (!agentConfig || typeof agentConfig !== "object") continue;
+    const value = (agentConfig as Record<string, unknown>).connections;
+    if (Array.isArray(value) && value.length > 0) {
+      out.push(agentId);
+    }
+  }
+  return out;
 }
 
 function normalizeOwlettoMcpBaseUrl(input: string): string | null {
@@ -462,35 +496,35 @@ async function buildAgentConfig(
     }))
     .filter((c) => c.key || c.secretRef);
 
-  // Connections
+  // Platforms
   // Reject duplicate `(type, name)` pairs so the stable ID derivation stays
   // collision-free. Users must set an explicit `name` when they want >1
-  // connection of the same platform under the same agent.
-  const seenConnKeys = new Set<string>();
-  for (const conn of agentConfig.connections) {
-    const key = `${conn.type}:${conn.name ?? ""}`;
-    if (seenConnKeys.has(key)) {
+  // platform instance of the same type under the same agent.
+  const seenPlatformKeys = new Set<string>();
+  for (const platform of agentConfig.platforms) {
+    const key = `${platform.type}:${platform.name ?? ""}`;
+    if (seenPlatformKeys.has(key)) {
       throw new Error(
-        conn.name
-          ? `agent "${agentId}" has duplicate connection (type=${conn.type}, name=${conn.name})`
-          : `agent "${agentId}" has multiple "${conn.type}" connections — add a unique \`name = "..."\` to each to disambiguate`
+        platform.name
+          ? `agent "${agentId}" has duplicate platform (type=${platform.type}, name=${platform.name})`
+          : `agent "${agentId}" has multiple "${platform.type}" platforms — add a unique \`name = "..."\` to each to disambiguate`
       );
     }
-    seenConnKeys.add(key);
+    seenPlatformKeys.add(key);
   }
 
-  const connections = agentConfig.connections
-    .map((conn) => ({
-      id: buildStableConnectionId(agentId, conn.type, conn.name),
-      type: conn.type,
+  const platforms = agentConfig.platforms
+    .map((platform) => ({
+      id: buildStablePlatformId(agentId, platform.type, platform.name),
+      type: platform.type,
       config: Object.fromEntries(
-        Object.entries(conn.config).map(([k, v]) => [
+        Object.entries(platform.config).map(([k, v]) => [
           k,
           resolveEnvVar(v as string),
         ])
       ) as Record<string, string>,
     }))
-    .filter((conn) => Object.values(conn.config).every((v) => v !== ""));
+    .filter((platform) => Object.values(platform.config).every((v) => v !== ""));
 
   return {
     agentId,
@@ -498,7 +532,7 @@ async function buildAgentConfig(
     description: agentConfig.description,
     settings,
     credentials,
-    connections,
+    platforms,
   };
 }
 

--- a/packages/owletto-backend/src/lobu/__tests__/agent-routes-apply.test.ts
+++ b/packages/owletto-backend/src/lobu/__tests__/agent-routes-apply.test.ts
@@ -4,7 +4,7 @@
  *   1. POST /agents — same-org duplicate returns 200 (idempotent), cross-org
  *      collision still 409, and the Owletto MCP auto-injection only runs on
  *      the create path (never on the idempotent return).
- *   2. PUT /agents/:agentId/connections/by-stable-id/:stableId — caller-supplied
+ *   2. PUT /agents/:agentId/platforms/by-stable-id/:stableId — caller-supplied
  *      stable-ID upsert. Same config → noop. Changed config → updated +
  *      willRestart. Missing → create with the supplied ID.
  *
@@ -194,7 +194,7 @@ describe('POST /agents — idempotent same-org create', () => {
   });
 });
 
-describe('PUT /agents/:agentId/connections/by-stable-id/:stableId', () => {
+describe('PUT /agents/:agentId/platforms/by-stable-id/:stableId', () => {
   beforeEach(async () => {
     await resetTestDatabase();
     await seedOrg(ORG_A);
@@ -203,11 +203,11 @@ describe('PUT /agents/:agentId/connections/by-stable-id/:stableId', () => {
     authStash.organizationId = ORG_A;
   });
 
-  test('new stable ID creates a connection with that exact ID', async () => {
+  test('new stable ID creates a platform with that exact ID', async () => {
     const app = await importAgentRoutes();
 
     const response = await app.request(
-      '/host-agent/connections/by-stable-id/host-agent-telegram-prod',
+      '/host-agent/platforms/by-stable-id/host-agent-telegram-prod',
       {
         method: 'PUT',
         headers: { 'content-type': 'application/json' },
@@ -219,7 +219,7 @@ describe('PUT /agents/:agentId/connections/by-stable-id/:stableId', () => {
     );
     expect(response.status).toBe(201);
     const body = (await response.json()) as any;
-    expect(body.connection?.id).toBe('host-agent-telegram-prod');
+    expect(body.platform?.id).toBe('host-agent-telegram-prod');
 
     const { getDb } = await import('../../db/client.js');
     const sql = getDb();
@@ -246,7 +246,7 @@ describe('PUT /agents/:agentId/connections/by-stable-id/:stableId', () => {
 
     // First PUT creates.
     const create = await app.request(
-      `/host-agent/connections/by-stable-id/${stableId}`,
+      `/host-agent/platforms/by-stable-id/${stableId}`,
       {
         method: 'PUT',
         headers: { 'content-type': 'application/json' },
@@ -267,7 +267,7 @@ describe('PUT /agents/:agentId/connections/by-stable-id/:stableId', () => {
     await new Promise((r) => setTimeout(r, 10));
 
     const second = await app.request(
-      `/host-agent/connections/by-stable-id/${stableId}`,
+      `/host-agent/platforms/by-stable-id/${stableId}`,
       {
         method: 'PUT',
         headers: { 'content-type': 'application/json' },
@@ -277,7 +277,7 @@ describe('PUT /agents/:agentId/connections/by-stable-id/:stableId', () => {
     expect(second.status).toBe(200);
     const body = (await second.json()) as any;
     expect(body.noop).toBe(true);
-    expect(body.connection?.id).toBe(stableId);
+    expect(body.platform?.id).toBe(stableId);
 
     const after = await sql`
       SELECT updated_at FROM agent_connections WHERE id = ${stableId}
@@ -293,7 +293,7 @@ describe('PUT /agents/:agentId/connections/by-stable-id/:stableId', () => {
 
     // First create.
     await app.request(
-      `/host-agent/connections/by-stable-id/${stableId}`,
+      `/host-agent/platforms/by-stable-id/${stableId}`,
       {
         method: 'PUT',
         headers: { 'content-type': 'application/json' },
@@ -306,7 +306,7 @@ describe('PUT /agents/:agentId/connections/by-stable-id/:stableId', () => {
 
     // Then PUT with a changed config (different value + new key).
     const response = await app.request(
-      `/host-agent/connections/by-stable-id/${stableId}`,
+      `/host-agent/platforms/by-stable-id/${stableId}`,
       {
         method: 'PUT',
         headers: { 'content-type': 'application/json' },
@@ -320,7 +320,7 @@ describe('PUT /agents/:agentId/connections/by-stable-id/:stableId', () => {
     const body = (await response.json()) as any;
     expect(body.updated).toBe(true);
     expect(body.willRestart).toBe(true);
-    expect(body.connection?.id).toBe(stableId);
+    expect(body.platform?.id).toBe(stableId);
   });
 
   test('PUT with settings-only change returns updated + willRestart', async () => {
@@ -329,7 +329,7 @@ describe('PUT /agents/:agentId/connections/by-stable-id/:stableId', () => {
 
     // First create with default settings.
     const create = await app.request(
-      `/host-agent/connections/by-stable-id/${stableId}`,
+      `/host-agent/platforms/by-stable-id/${stableId}`,
       {
         method: 'PUT',
         headers: { 'content-type': 'application/json' },
@@ -343,7 +343,7 @@ describe('PUT /agents/:agentId/connections/by-stable-id/:stableId', () => {
 
     // Same config, but settings change (allowFrom from undefined to ['user-1']).
     const response = await app.request(
-      `/host-agent/connections/by-stable-id/${stableId}`,
+      `/host-agent/platforms/by-stable-id/${stableId}`,
       {
         method: 'PUT',
         headers: { 'content-type': 'application/json' },
@@ -365,7 +365,7 @@ describe('PUT /agents/:agentId/connections/by-stable-id/:stableId', () => {
     const app = await importAgentRoutes();
 
     const response = await app.request(
-      '/missing-agent/connections/by-stable-id/missing-agent-x-y',
+      '/missing-agent/platforms/by-stable-id/missing-agent-x-y',
       {
         method: 'PUT',
         headers: { 'content-type': 'application/json' },
@@ -475,7 +475,7 @@ describe('concurrent-apply race fixes', () => {
     });
   });
 
-  test('PUT /connections/by-stable-id — two concurrent identical PUTs converge to one row', async () => {
+  test('PUT /platforms/by-stable-id — two concurrent identical PUTs converge to one row', async () => {
     const app = await importAgentRoutes();
     await seedAgent(ORG_A, 'race-host');
 
@@ -483,12 +483,12 @@ describe('concurrent-apply race fixes', () => {
     const config = { chatId: '12345', endpoint: 'https://example.com' };
 
     const [r1, r2] = await Promise.all([
-      app.request(`/race-host/connections/by-stable-id/${stableId}`, {
+      app.request(`/race-host/platforms/by-stable-id/${stableId}`, {
         method: 'PUT',
         headers: { 'content-type': 'application/json' },
         body: JSON.stringify({ platform: 'telegram', config }),
       }),
-      app.request(`/race-host/connections/by-stable-id/${stableId}`, {
+      app.request(`/race-host/platforms/by-stable-id/${stableId}`, {
         method: 'PUT',
         headers: { 'content-type': 'application/json' },
         body: JSON.stringify({ platform: 'telegram', config }),
@@ -498,9 +498,9 @@ describe('concurrent-apply race fixes', () => {
     expect([r1.status, r2.status].sort()).toEqual([200, 201]);
 
     const bodies = [(await r1.json()) as any, (await r2.json()) as any];
-    const created = bodies.find((b) => b.connection && !b.noop && !b.updated);
+    const created = bodies.find((b) => b.platform && !b.noop && !b.updated);
     expect(created).toBeTruthy();
-    expect(created?.connection?.id).toBe(stableId);
+    expect(created?.platform?.id).toBe(stableId);
 
     // The other response must be either noop:true (config unchanged) or
     // updated:true (the loser observed the placeholder/empty config first

--- a/packages/owletto-backend/src/lobu/agent-routes.ts
+++ b/packages/owletto-backend/src/lobu/agent-routes.ts
@@ -661,47 +661,51 @@ routes.patch('/:agentId/config', mcpAuth, async (c) => {
 });
 
 // ============================================================
-// Connection routes (nested under /:agentId/connections)
+// Platform routes (nested under /:agentId/platforms)
+//
+// Storage internals still live in the `agent_connections` table — the rename
+// is user-facing only. ChatInstanceManager and the connection store keep
+// their existing names because they're used by other (chat-side) callers.
 // ============================================================
 
-// ── List connections ─────────────────────────────────────────────────────────
+// ── List platforms ───────────────────────────────────────────────────────────
 
-routes.get('/:agentId/connections', mcpAuth, async (c) => {
+routes.get('/:agentId/platforms', mcpAuth, async (c) => {
   return withOrg(c, async () => {
     const { agentId } = c.req.param();
     if (!(await configStore.hasAgent(agentId))) {
       return c.json({ error: 'Agent not found' }, 404);
     }
     const chatManager = getChatInstanceManager();
-    let connections = await connectionStore.listConnections({
+    let platforms = await connectionStore.listConnections({
       templateAgentId: agentId,
     });
 
     if (chatManager) {
       try {
-        const runtimeConnections = await chatManager.listConnections({
+        const runtimePlatforms = await chatManager.listConnections({
           templateAgentId: agentId,
         });
         await Promise.all(
-          runtimeConnections.map((connection: Record<string, any>) =>
-            persistConnectionSnapshot(connection)
+          runtimePlatforms.map((platform: Record<string, any>) =>
+            persistConnectionSnapshot(platform)
           )
         );
-        if (runtimeConnections.length > 0) {
-          connections = runtimeConnections;
+        if (runtimePlatforms.length > 0) {
+          platforms = runtimePlatforms;
         }
       } catch {
         // Fall back to PostgreSQL snapshot.
       }
     }
 
-    return c.json({ connections });
+    return c.json({ platforms });
   });
 });
 
-// ── Create connection ────────────────────────────────────────────────────────
+// ── Create platform ──────────────────────────────────────────────────────────
 
-routes.post('/:agentId/connections', mcpAuth, async (c) => {
+routes.post('/:agentId/platforms', mcpAuth, async (c) => {
   return withOrg(c, async () => {
     const { agentId } = c.req.param();
     if (!(await configStore.hasAgent(agentId))) {
@@ -719,16 +723,16 @@ routes.post('/:agentId/connections', mcpAuth, async (c) => {
     const chatManager = getChatInstanceManager();
     if (chatManager) {
       try {
-        const connection = await chatManager.addConnection(
+        const created = await chatManager.addConnection(
           platform,
           agentId,
           { platform, ...config },
           { allowGroups: true, ...settings }
         );
-        await persistConnectionSnapshot(connection);
-        return c.json({ connection }, 201);
+        await persistConnectionSnapshot(created);
+        return c.json({ platform: created }, 201);
       } catch (error: any) {
-        return c.json({ error: error.message || 'Failed to create connection' }, 400);
+        return c.json({ error: error.message || 'Failed to create platform' }, 400);
       }
     }
 
@@ -746,19 +750,19 @@ routes.post('/:agentId/connections', mcpAuth, async (c) => {
       createdAt: now,
       updatedAt: now,
     });
-    return c.json({ connection: { id, platform, status: 'stopped' } }, 201);
+    return c.json({ platform: { id, platform, status: 'stopped' } }, 201);
   });
 });
 
-// ── Upsert connection by stable ID ───────────────────────────────────────────
+// ── Upsert platform by stable ID ─────────────────────────────────────────────
 //
 // `lobu apply` derives a deterministic ID from `(agentId, type, name)` via
-// buildStableConnectionId() and PUTs to this endpoint so re-runs converge:
+// buildStablePlatformId() and PUTs to this endpoint so re-runs converge:
 // matching config → noop; changed config → update + restart; missing → create
 // with the supplied ID (not random). The route trusts the stable ID — it's
 // computed by the CLI from the same lobu.toml that produced the body.
 
-routes.put('/:agentId/connections/by-stable-id/:stableId', mcpAuth, async (c) => {
+routes.put('/:agentId/platforms/by-stable-id/:stableId', mcpAuth, async (c) => {
   return withOrg(c, async () => {
     const { agentId, stableId } = c.req.param();
     if (!(await configStore.hasAgent(agentId))) {
@@ -821,7 +825,7 @@ routes.put('/:agentId/connections/by-stable-id/:stableId', mcpAuth, async (c) =>
               stableId
             );
             await persistConnectionSnapshot(created);
-            return c.json({ connection: created }, 201);
+            return c.json({ platform: created }, 201);
           } catch (error: any) {
             // Roll back the placeholder so a retry doesn't see a half-baked
             // row that fails the `existing.templateAgentId` check inconsistently.
@@ -830,7 +834,7 @@ routes.put('/:agentId/connections/by-stable-id/:stableId', mcpAuth, async (c) =>
             } catch {
               // best-effort
             }
-            return c.json({ error: error.message || 'Failed to create connection' }, 400);
+            return c.json({ error: error.message || 'Failed to create platform' }, 400);
           }
         }
 
@@ -853,7 +857,7 @@ routes.put('/:agentId/connections/by-stable-id/:stableId', mcpAuth, async (c) =>
           updatedAt: fallbackNow,
         });
         return c.json(
-          { connection: { id: stableId, platform, status: 'stopped' } },
+          { platform: { id: stableId, platform, status: 'stopped' } },
           201
         );
       }
@@ -867,7 +871,7 @@ routes.put('/:agentId/connections/by-stable-id/:stableId', mcpAuth, async (c) =>
         // and we don't expose a delete that races with create). Treat as a
         // create-failure to surface the inconsistency rather than 200-OK on
         // missing data.
-        return c.json({ error: 'Connection vanished after conflict' }, 500);
+        return c.json({ error: 'Platform vanished after conflict' }, 500);
       }
       if (reread.templateAgentId && reread.templateAgentId !== agentId) {
         return c.json(
@@ -896,14 +900,14 @@ routes.put('/:agentId/connections/by-stable-id/:stableId', mcpAuth, async (c) =>
 
     const configChanged = !configsShallowEqual(merged, previousConfig);
     // Settings (allowFrom, allowGroups, etc.) are persisted alongside the
-    // connection config and are part of "did anything change?" — a
+    // platform config and are part of "did anything change?" — a
     // settings-only update must trigger willRestart, not be silently noop'd.
     const previousSettings = (current.settings ?? {}) as Record<string, unknown>;
     const mergedSettings = { allowGroups: true, ...settings } as Record<string, unknown>;
     const settingsChanged = !configsShallowEqual(mergedSettings, previousSettings);
 
     if (!configChanged && !settingsChanged) {
-      return c.json({ noop: true, connection: current }, 200);
+      return c.json({ noop: true, platform: current }, 200);
     }
 
     if (chatManager) {
@@ -914,11 +918,11 @@ routes.put('/:agentId/connections/by-stable-id/:stableId', mcpAuth, async (c) =>
         });
         await persistConnectionSnapshot(updated);
         return c.json(
-          { updated: true, willRestart: true, connection: updated },
+          { updated: true, willRestart: true, platform: updated },
           200
         );
       } catch (error: any) {
-        return c.json({ error: error.message || 'Failed to update connection' }, 400);
+        return c.json({ error: error.message || 'Failed to update platform' }, 400);
       }
     }
 
@@ -937,7 +941,7 @@ routes.put('/:agentId/connections/by-stable-id/:stableId', mcpAuth, async (c) =>
     });
     const refreshed = await connectionStore.getConnection(stableId);
     return c.json(
-      { updated: true, willRestart: true, connection: refreshed },
+      { updated: true, willRestart: true, platform: refreshed },
       200
     );
   });
@@ -957,103 +961,103 @@ function configsShallowEqual(
   return true;
 }
 
-// ── Get connection ───────────────────────────────────────────────────────────
+// ── Get platform ─────────────────────────────────────────────────────────────
 
-routes.get('/:agentId/connections/:connId', mcpAuth, async (c) => {
+routes.get('/:agentId/platforms/:platformId', mcpAuth, async (c) => {
   return withOrg(c, async () => {
-    const { connId } = c.req.param();
+    const { platformId } = c.req.param();
     const chatManager = getChatInstanceManager();
-    let conn = null;
+    let platform = null;
 
     if (chatManager) {
       try {
-        conn = await chatManager.getConnection(connId);
-        if (conn) {
-          await persistConnectionSnapshot(conn);
+        platform = await chatManager.getConnection(platformId);
+        if (platform) {
+          await persistConnectionSnapshot(platform);
         }
       } catch {
-        conn = null;
+        platform = null;
       }
     }
 
-    if (!conn) {
-      conn = await connectionStore.getConnection(connId);
+    if (!platform) {
+      platform = await connectionStore.getConnection(platformId);
     }
 
-    if (!conn) return c.json({ error: 'Connection not found' }, 404);
-    return c.json(conn);
+    if (!platform) return c.json({ error: 'Platform not found' }, 404);
+    return c.json(platform);
   });
 });
 
-// ── Delete connection ────────────────────────────────────────────────────────
+// ── Delete platform ──────────────────────────────────────────────────────────
 
-routes.delete('/:agentId/connections/:connId', mcpAuth, async (c) => {
+routes.delete('/:agentId/platforms/:platformId', mcpAuth, async (c) => {
   return withOrg(c, async () => {
-    const { connId } = c.req.param();
-    const conn = await connectionStore.getConnection(connId);
-    if (!conn) return c.json({ error: 'Connection not found' }, 404);
+    const { platformId } = c.req.param();
+    const platform = await connectionStore.getConnection(platformId);
+    if (!platform) return c.json({ error: 'Platform not found' }, 404);
 
     const chatManager = getChatInstanceManager();
     if (chatManager) {
       try {
-        await chatManager.removeConnection(connId);
+        await chatManager.removeConnection(platformId);
       } catch {
         // Fall through to direct store delete
       }
     }
-    await connectionStore.deleteConnection(connId);
+    await connectionStore.deleteConnection(platformId);
     return c.json({ success: true });
   });
 });
 
-// ── Start connection ─────────────────────────────────────────────────────────
+// ── Start platform ───────────────────────────────────────────────────────────
 
-routes.post('/:agentId/connections/:connId/start', mcpAuth, async (c) => {
+routes.post('/:agentId/platforms/:platformId/start', mcpAuth, async (c) => {
   return withOrg(c, async () => {
-    const { connId } = c.req.param();
+    const { platformId } = c.req.param();
     const chatManager = getChatInstanceManager();
-    const conn = await connectionStore.getConnection(connId);
-    if (!conn) return c.json({ error: 'Connection not found' }, 404);
+    const platform = await connectionStore.getConnection(platformId);
+    if (!platform) return c.json({ error: 'Platform not found' }, 404);
 
     if (chatManager) {
-      await chatManager.restartConnection(connId);
-      const runtimeConnection = await chatManager.getConnection(connId);
-      if (runtimeConnection) {
-        await persistConnectionSnapshot(runtimeConnection);
-        return c.json({ success: true, connection: runtimeConnection });
+      await chatManager.restartConnection(platformId);
+      const runtimePlatform = await chatManager.getConnection(platformId);
+      if (runtimePlatform) {
+        await persistConnectionSnapshot(runtimePlatform);
+        return c.json({ success: true, platform: runtimePlatform });
       }
     }
 
-    await connectionStore.updateConnection(connId, { status: 'active' });
+    await connectionStore.updateConnection(platformId, { status: 'active' });
     return c.json({
       success: true,
-      connection: await connectionStore.getConnection(connId),
+      platform: await connectionStore.getConnection(platformId),
     });
   });
 });
 
-// ── Stop connection ──────────────────────────────────────────────────────────
+// ── Stop platform ────────────────────────────────────────────────────────────
 
-routes.post('/:agentId/connections/:connId/stop', mcpAuth, async (c) => {
+routes.post('/:agentId/platforms/:platformId/stop', mcpAuth, async (c) => {
   return withOrg(c, async () => {
-    const { connId } = c.req.param();
+    const { platformId } = c.req.param();
     const chatManager = getChatInstanceManager();
-    const conn = await connectionStore.getConnection(connId);
-    if (!conn) return c.json({ error: 'Connection not found' }, 404);
+    const platform = await connectionStore.getConnection(platformId);
+    if (!platform) return c.json({ error: 'Platform not found' }, 404);
 
     if (chatManager) {
-      await chatManager.stopConnection(connId);
-      const runtimeConnection = await chatManager.getConnection(connId);
-      if (runtimeConnection) {
-        await persistConnectionSnapshot(runtimeConnection);
-        return c.json({ success: true, connection: runtimeConnection });
+      await chatManager.stopConnection(platformId);
+      const runtimePlatform = await chatManager.getConnection(platformId);
+      if (runtimePlatform) {
+        await persistConnectionSnapshot(runtimePlatform);
+        return c.json({ success: true, platform: runtimePlatform });
       }
     }
 
-    await connectionStore.updateConnection(connId, { status: 'stopped' });
+    await connectionStore.updateConnection(platformId, { status: 'stopped' });
     return c.json({
       success: true,
-      connection: await connectionStore.getConnection(connId),
+      platform: await connectionStore.getConnection(platformId),
     });
   });
 });

--- a/scripts/e2e-lobu-apply.sh
+++ b/scripts/e2e-lobu-apply.sh
@@ -137,7 +137,7 @@ id = "anthropic"
 model = "claude/sonnet-4-5"
 key = "$ANTHROPIC_API_KEY"
 
-[[agents.triage.connections]]
+[[agents.triage.platforms]]
 type = "telegram"
 config = { botToken = "$TELEGRAM_BOT_TOKEN", chatId = "12345" }
 
@@ -229,8 +229,8 @@ echo "${DRY_OUT}" | grep -E "\+\s+agent\s+triage" >/dev/null || {
   echo "dry-run missing '+ agent triage' line" >&2
   exit 1
 }
-echo "${DRY_OUT}" | grep -E "\+\s+connection" >/dev/null || {
-  echo "dry-run missing '+ connection' line" >&2
+echo "${DRY_OUT}" | grep -E "\+\s+platform" >/dev/null || {
+  echo "dry-run missing '+ platform' line" >&2
   exit 1
 }
 echo "${DRY_OUT}" | grep -E "\+\s+entity[-_]type" >/dev/null || {
@@ -251,17 +251,17 @@ echo "${APPLY_OUT}" | grep -E "Apply complete" >/dev/null || {
 echo "==> step 9: lobu apply --dry-run (expect noop)"
 NOOP_OUT="$(${LOBU} apply --dry-run --org "${ORG_SLUG}" --url "${SERVER_URL}" 2>&1)"
 echo "${NOOP_OUT}" | sed 's/^/    /'
-if echo "${NOOP_OUT}" | grep -E "^\s*\+\s+(agent|connection|entity)" >/dev/null; then
+if echo "${NOOP_OUT}" | grep -E "^\s*\+\s+(agent|platform|entity)" >/dev/null; then
   echo "second dry-run still shows + creates — not idempotent" >&2
   exit 1
 fi
-if echo "${NOOP_OUT}" | grep -E "^\s*~\s+(agent|connection|entity)" >/dev/null; then
+if echo "${NOOP_OUT}" | grep -E "^\s*~\s+(agent|platform|entity)" >/dev/null; then
   echo "second dry-run shows ~ updates — drift detected unexpectedly" >&2
   exit 1
 fi
 
-# ─── 10. mutate connection chatId, expect ~ update ─────────────────────
-echo "==> step 10: edit connection chatId, expect connection update + restart"
+# ─── 10. mutate platform chatId, expect ~ update ──────────────────────
+echo "==> step 10: edit platform chatId, expect platform update + restart"
 
 # Same shape, different chatId.
 sed -i.bak \
@@ -271,12 +271,12 @@ rm -f "${PROJECT_DIR}/lobu.toml.bak"
 
 UPDATE_OUT="$(${LOBU} apply --dry-run --org "${ORG_SLUG}" --url "${SERVER_URL}" 2>&1)"
 echo "${UPDATE_OUT}" | sed 's/^/    /'
-echo "${UPDATE_OUT}" | grep -E "~\s+connection" >/dev/null || {
-  echo "expected '~ connection' line after edit" >&2
+echo "${UPDATE_OUT}" | grep -E "~\s+platform" >/dev/null || {
+  echo "expected '~ platform' line after edit" >&2
   exit 1
 }
 echo "${UPDATE_OUT}" | grep -E "will restart" >/dev/null || {
-  echo "expected 'will restart' marker after connection config change" >&2
+  echo "expected 'will restart' marker after platform config change" >&2
   exit 1
 }
 
@@ -297,10 +297,10 @@ echo "${AGENTS_JSON}" | grep -q '"agentId":"triage"' || {
   exit 1
 }
 
-CONNS_JSON="$(curl -sf -H "Authorization: Bearer ${PAT}" "${SERVER_URL}/api/${ORG_SLUG}/agents/triage/connections")"
-echo "${CONNS_JSON}" | grep -q '"platform":"telegram"' || {
-  echo "telegram connection not found" >&2
-  echo "${CONNS_JSON}"
+PLATFORMS_JSON="$(curl -sf -H "Authorization: Bearer ${PAT}" "${SERVER_URL}/api/${ORG_SLUG}/agents/triage/platforms")"
+echo "${PLATFORMS_JSON}" | grep -q '"platform":"telegram"' || {
+  echo "telegram platform not found" >&2
+  echo "${PLATFORMS_JSON}"
   exit 1
 }
 


### PR DESCRIPTION
## Summary

User-facing rename across the chat-platform CRUD surface, end-to-end. The instance-management surface ("connections") now matches the rest of the product, which already says "platforms" (`PLATFORM_SCHEMAS`, `/api/agents/platforms` schema catalog, web UI).

- **CLI**: `lobu connections (list|add)` → `lobu platforms (list|add)`. Files moved to `packages/cli/src/commands/platforms/`. `init` wizard updated.
- **`lobu.toml`**: `[[agents.<id>.connections]]` → `[[agents.<id>.platforms]]`. The file-loader emits a clear migration error if the legacy key is encountered. **No backwards-compat alias.**
- **Server**: `/api/:org/agents/:id/connections*` → `/platforms*` for list, create, get, delete, start, stop, and stable-id upsert. Body `platform` field unchanged. `agent_connections` DB table + `ChatInstanceManager` keep their internal names — DB schema is out of scope.
- **`lobu apply`**: `DesiredConnection` → `DesiredPlatform`, `buildStableConnectionId` → `buildStablePlatformId`, `rowsByKind('connection')` → `rowsByKind('platform')`, plan rendering, snapshots.
- **Docs**: `lobu-toml.md`, `lobu-apply.md`, every `platforms/*.mdx`, `docs/plans/lobu-apply.md`, e2e script.

## Out of scope (intentionally not changed)

- `agent_connections` / `chat_connections` DB tables — internal.
- `PLATFORM_SCHEMAS` and `/api/agents/platforms` schema catalog — already correct.
- Chat SDK adapter directory `packages/gateway/src/connections/` — internal Chat SDK convention.
- `secret://` ref scheme — unaffected.

## Blocked on

The owletto-web submodule rename (`useAgentConnections` → `useAgentPlatforms` for the instance-CRUD hook, with the existing schema-catalog hook renamed to `usePlatformSchemas` first) is a separate submodule PR. The submodule pointer in this parent PR is **not** bumped — it stays at the current submodule SHA. Owletto-web rename to be opened as a follow-up; current submodule still calls the old route paths until both PRs land together.

## Validation

- `make build-packages` ✅
- `bun run typecheck` ✅
- `bun run check` ✅
- `bun test packages/cli` (30 pass) ✅
- `bun test packages/owletto-backend/src/lobu/__tests__/agent-routes-apply.test.ts` (11 pass) ✅
- `bun test packages/owletto-backend/src/gateway/__tests__/file-loader-platforms.test.ts` (2 pass — new test for the migration-error path) ✅

The e2e script (`scripts/e2e-lobu-apply.sh`) still expects the new route + key names; not run locally as the harness boots a full PGlite + bootstrap-PAT flow.

## Test plan

- [ ] `lobu apply` against a project with `[[agents.<id>.connections]]` produces a clear "renamed to `platforms`" error.
- [ ] `lobu apply` against a project with `[[agents.<id>.platforms]]` round-trips create → noop → update → drift cleanly.
- [ ] `lobu run` boots an agent with the new `platforms` block and connects to Telegram.


---

**pi review**: unavailable (long-prompt timeout this session). Fell back to local validation: typecheck, biome check, CLI tests (30 pass), backend route tests (11 pass), file-loader migration-error test (new, 2 pass). build-test green on CI.
