### PR TITLE
fix(backend): bootstrap PAT mode 0600 + PAT auth source disambiguation

### DIFF
--- a/packages/owletto-backend/src/__tests__/unit/bootstrap-pat-file-mode.test.ts
+++ b/packages/owletto-backend/src/__tests__/unit/bootstrap-pat-file-mode.test.ts
@@ -1,0 +1,45 @@
+/**
+ * Bootstrap PAT file mode contract.
+ *
+ * `start-local.ts` writes the bootstrap PAT to ${OWLETTO_DATA_DIR}/bootstrap-pat.txt
+ * with `writeFileSync(..., { mode: 0o600 })` so the token can't be read by
+ * other local users on shared machines. This test pins the contract:
+ *
+ *   - the source line that writes the file uses `mode: 0o600`
+ *   - a writeFileSync call with `{ mode: 0o600 }` actually produces a file
+ *     whose permission bits are exactly `0o600` on the local filesystem
+ *
+ * The first check guards against accidental edits that drop the mode option;
+ * the second ensures Node's writeFileSync honors the option on this OS.
+ */
+
+import { describe, expect, it } from 'bun:test';
+import { mkdtempSync, readFileSync, statSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+describe('bootstrap PAT file mode', () => {
+  it('start-local.ts writes the PAT with mode: 0o600', () => {
+    const source = readFileSync(
+      new URL('../../start-local.ts', import.meta.url),
+      'utf8'
+    );
+    // The single writeFileSync call for the PAT file. If the call shape changes
+    // (for example, a refactor extracts it into a helper), update both this
+    // pin AND the on-disk mode assertion below.
+    expect(source).toContain('writeFileSync(patFilePath, `${token}\\n`, { mode: 0o600 })');
+  });
+
+  it('writeFileSync with mode 0o600 yields permission bits 0o600', () => {
+    // On Windows, `mode` is largely advisory. The bootstrap path is dev-only
+    // and used by scripts/e2e-lobu-apply.sh on macOS/Linux, so a Windows skip
+    // is acceptable; the suite is currently macOS-first.
+    if (process.platform === 'win32') return;
+
+    const dir = mkdtempSync(join(tmpdir(), 'owletto-bootstrap-pat-'));
+    const file = join(dir, 'bootstrap-pat.txt');
+    writeFileSync(file, 'owl_pat_test\n', { mode: 0o600 });
+    const observed = statSync(file).mode & 0o777;
+    expect(observed).toBe(0o600);
+  });
+});

--- a/packages/owletto-backend/src/auth/middleware.ts
+++ b/packages/owletto-backend/src/auth/middleware.ts
@@ -34,6 +34,18 @@ declare module 'hono' {
     mcpAuthInfo: AuthInfo | null;
     mcpIsAuthenticated: boolean;
     subdomainOrg: string | null;
+    /**
+     * How the current request authenticated. Set by `mcpAuth` /
+     * `MultiTenantProvider.resolveAuth`. Admin-tier routes that previously
+     * implicitly assumed web-session auth use this to refuse weak PATs.
+     *
+     * - `session`     — better-auth session cookie (web app)
+     * - `pat`         — `owl_pat_*` bearer (Personal Access Token)
+     * - `oauth`       — OAuth 2.1 access token bearer
+     * - `cli-token`   — `lobu login` CLI token bearer
+     * - `null`        — anonymous / unauthenticated request
+     */
+    authSource: 'session' | 'pat' | 'oauth' | 'cli-token' | null;
   }
 }
 

--- a/packages/owletto-backend/src/lobu/__tests__/agent-routes-apply.test.ts
+++ b/packages/owletto-backend/src/lobu/__tests__/agent-routes-apply.test.ts
@@ -24,15 +24,24 @@ import {
 const authStash: {
   user: { id: string; name: string; email: string; emailVerified: boolean } | null;
   organizationId: string | null;
+  // `authSource` mirrors the real middleware contract so admin-tier routes
+  // gated by `requireSessionOrAdminPat` see a non-null value. Default to
+  // 'session' — the existing apply tests simulate a web user.
+  authSource: 'session' | 'pat' | 'oauth' | 'cli-token' | null;
+  mcpAuthInfo: { scopes: string[] } | null;
 } = {
   user: { id: 'u1', name: 'Test', email: 'u1@test', emailVerified: true },
   organizationId: 'org-a',
+  authSource: 'session',
+  mcpAuthInfo: null,
 };
 
 mock.module('../../auth/middleware', () => ({
   mcpAuth: async (c: any, next: any) => {
     c.set('user', authStash.user);
     c.set('organizationId', authStash.organizationId);
+    c.set('authSource', authStash.authSource);
+    c.set('mcpAuthInfo', authStash.mcpAuthInfo);
     return next();
   },
   // requireAuth is referenced elsewhere in the module — provide a passthrough
@@ -94,6 +103,8 @@ describe('POST /agents — idempotent same-org create', () => {
     await seedOrg(ORG_B);
     authStash.user = { id: 'u1', name: 'Test', email: 'u1@test', emailVerified: true };
     authStash.organizationId = ORG_A;
+    authStash.authSource = 'session';
+    authStash.mcpAuthInfo = null;
   });
 
   test('first POST creates 201, second returns 200 with existing payload', async () => {
@@ -201,6 +212,8 @@ describe('PUT /agents/:agentId/platforms/by-stable-id/:stableId', () => {
     await seedAgent(ORG_A, 'host-agent');
     authStash.user = { id: 'u1', name: 'Test', email: 'u1@test', emailVerified: true };
     authStash.organizationId = ORG_A;
+    authStash.authSource = 'session';
+    authStash.mcpAuthInfo = null;
   });
 
   test('new stable ID creates a platform with that exact ID', async () => {
@@ -382,6 +395,8 @@ describe('concurrent-apply race fixes', () => {
     await seedOrg(ORG_A);
     authStash.user = { id: 'u1', name: 'Test', email: 'u1@test', emailVerified: true };
     authStash.organizationId = ORG_A;
+    authStash.authSource = 'session';
+    authStash.mcpAuthInfo = null;
   });
 
   test('POST /agents — two concurrent creates resolve to one 201 + one 200, single row', async () => {
@@ -517,5 +532,158 @@ describe('concurrent-apply race fixes', () => {
     expect(rows.length).toBe(1);
     expect(rows[0].agent_id).toBe('race-host');
     expect(rows[0].platform).toBe('telegram');
+  });
+});
+
+describe('admin-tier auth admission (requireSessionOrAdminPat)', () => {
+  // Pi-flagged in #468: PAT/OAuth bearers now hydrate `c.var.user`, so admin
+  // routes that previously implicitly required a web session were exposed to
+  // any PAT. The helper requires either an auth source the user explicitly
+  // opted into (session, cli-token), or a PAT/OAuth token with mcp:admin
+  // scope.
+
+  beforeEach(async () => {
+    await resetTestDatabase();
+    await seedOrg(ORG_A);
+    authStash.user = { id: 'u1', name: 'Test', email: 'u1@test', emailVerified: true };
+    authStash.organizationId = ORG_A;
+    authStash.authSource = 'session';
+    authStash.mcpAuthInfo = null;
+  });
+
+  test('POST /agents accepts a session caller', async () => {
+    const app = await importAgentRoutes();
+    authStash.authSource = 'session';
+    const response = await app.request('/', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ agentId: 'session-agent', name: 'Session' }),
+    });
+    expect(response.status).toBe(201);
+  });
+
+  test('POST /agents accepts a cli-token caller', async () => {
+    const app = await importAgentRoutes();
+    authStash.authSource = 'cli-token';
+    const response = await app.request('/', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ agentId: 'cli-agent', name: 'CLI' }),
+    });
+    expect(response.status).toBe(201);
+  });
+
+  test('POST /agents accepts a PAT with mcp:admin scope', async () => {
+    const app = await importAgentRoutes();
+    authStash.authSource = 'pat';
+    authStash.mcpAuthInfo = { scopes: ['mcp:read', 'mcp:write', 'mcp:admin'] };
+    const response = await app.request('/', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ agentId: 'admin-pat-agent', name: 'Admin PAT' }),
+    });
+    expect(response.status).toBe(201);
+  });
+
+  test('POST /agents rejects a PAT that lacks mcp:admin scope', async () => {
+    const app = await importAgentRoutes();
+    authStash.authSource = 'pat';
+    authStash.mcpAuthInfo = { scopes: ['mcp:read'] };
+    const response = await app.request('/', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ agentId: 'weak-pat-agent', name: 'Weak PAT' }),
+    });
+    expect(response.status).toBe(403);
+    const body = (await response.json()) as any;
+    expect(body.error).toBe('forbidden');
+    expect(body.error_description).toContain('mcp:admin');
+
+    // No row should have been created.
+    const { getDb } = await import('../../db/client.js');
+    const sql = getDb();
+    const rows = await sql`SELECT id FROM agents WHERE id = 'weak-pat-agent'`;
+    expect(rows.length).toBe(0);
+  });
+
+  test('POST /agents rejects a write-scoped PAT (no mcp:admin)', async () => {
+    const app = await importAgentRoutes();
+    authStash.authSource = 'pat';
+    authStash.mcpAuthInfo = { scopes: ['mcp:read', 'mcp:write'] };
+    const response = await app.request('/', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ agentId: 'write-pat-agent', name: 'Write PAT' }),
+    });
+    expect(response.status).toBe(403);
+  });
+
+  test('POST /agents rejects an OAuth bearer that lacks mcp:admin scope', async () => {
+    const app = await importAgentRoutes();
+    authStash.authSource = 'oauth';
+    authStash.mcpAuthInfo = { scopes: ['mcp:read', 'mcp:write'] };
+    const response = await app.request('/', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ agentId: 'weak-oauth-agent', name: 'Weak OAuth' }),
+    });
+    expect(response.status).toBe(403);
+  });
+
+  test('POST /agents rejects an anonymous caller (authSource null)', async () => {
+    const app = await importAgentRoutes();
+    authStash.authSource = null;
+    authStash.mcpAuthInfo = null;
+    const response = await app.request('/', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ agentId: 'anon-agent', name: 'Anon' }),
+    });
+    expect(response.status).toBe(401);
+  });
+
+  test('PATCH /:agentId rejects a read-only PAT', async () => {
+    const app = await importAgentRoutes();
+    await seedAgent(ORG_A, 'patch-target');
+    authStash.authSource = 'pat';
+    authStash.mcpAuthInfo = { scopes: ['mcp:read'] };
+    const response = await app.request('/patch-target', {
+      method: 'PATCH',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ name: 'Should Not Change' }),
+    });
+    expect(response.status).toBe(403);
+  });
+
+  test('DELETE /:agentId rejects a read-only PAT', async () => {
+    const app = await importAgentRoutes();
+    await seedAgent(ORG_A, 'delete-target');
+    authStash.authSource = 'pat';
+    authStash.mcpAuthInfo = { scopes: ['mcp:read'] };
+    const response = await app.request('/delete-target', {
+      method: 'DELETE',
+    });
+    expect(response.status).toBe(403);
+
+    const { getDb } = await import('../../db/client.js');
+    const sql = getDb();
+    const rows = await sql`SELECT id FROM agents WHERE id = 'delete-target'`;
+    expect(rows.length).toBe(1);
+  });
+
+  test('PUT /:agentId/connections/by-stable-id rejects a write-only PAT', async () => {
+    const app = await importAgentRoutes();
+    await seedAgent(ORG_A, 'conn-host');
+    authStash.authSource = 'pat';
+    authStash.mcpAuthInfo = { scopes: ['mcp:read', 'mcp:write'] };
+    const response = await app.request(
+      '/conn-host/connections/by-stable-id/conn-host-tg',
+      {
+        method: 'PUT',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ platform: 'telegram', config: { chatId: '1' } }),
+      }
+    );
+    expect(response.status).toBe(403);
   });
 });

--- a/packages/owletto-backend/src/lobu/agent-routes.ts
+++ b/packages/owletto-backend/src/lobu/agent-routes.ts
@@ -216,6 +216,58 @@ function withOrg(c: any, fn: () => Promise<Response>): Promise<Response> {
   return orgContext.run({ organizationId: orgId }, fn);
 }
 
+/**
+ * Admin-tier auth gate.
+ *
+ * Before #468, agent CRUD + connection mutation routes implicitly required a
+ * web session — `c.get('user')` was null for PAT bearers, so the create-agent
+ * handler short-circuited with a 401. #468 hydrated `c.var.user` for PAT and
+ * OAuth bearers (matching the cli-token branch) so `lobu apply` could call
+ * these endpoints with a PAT. That fix removed the implicit gate.
+ *
+ * This helper restores the gate explicitly: admin-tier routes accept
+ *   - a better-auth session (`authSource === 'session'`),
+ *   - a `lobu login` CLI token (`authSource === 'cli-token'` — already
+ *     anchored to a real user/session pair), OR
+ *   - a PAT/OAuth bearer that carries the `mcp:admin` scope.
+ *
+ * Read-only routes (list, get) keep using `mcpAuth` alone — a `mcp:read` PAT
+ * is fine for those.
+ *
+ * Returns a Response when the request must be rejected; returns null when the
+ * caller should proceed.
+ */
+function requireSessionOrAdminPat(c: any): Response | null {
+  const authSource = c.get('authSource') as
+    | 'session'
+    | 'pat'
+    | 'oauth'
+    | 'cli-token'
+    | null;
+
+  if (authSource === 'session' || authSource === 'cli-token') {
+    return null;
+  }
+
+  if (authSource === 'pat' || authSource === 'oauth') {
+    const authInfo = c.get('mcpAuthInfo');
+    const scopes: string[] = Array.isArray(authInfo?.scopes) ? authInfo.scopes : [];
+    if (scopes.includes('mcp:admin')) {
+      return null;
+    }
+    return c.json(
+      {
+        error: 'forbidden',
+        error_description:
+          'This route requires a web session or a token with mcp:admin scope.',
+      },
+      403
+    );
+  }
+
+  return c.json({ error: 'Authentication required' }, 401);
+}
+
 // ── List agents ──────────────────────────────────────────────────────────────
 
 routes.get('/', mcpAuth, async (c) => {
@@ -291,6 +343,8 @@ routes.get('/', mcpAuth, async (c) => {
 // ── Create agent ─────────────────────────────────────────────────────────────
 
 routes.post('/', mcpAuth, async (c) => {
+  const denied = requireSessionOrAdminPat(c);
+  if (denied) return denied;
   return withOrg(c, async () => {
     const body = await c.req.json<{
       agentId: string;
@@ -420,6 +474,8 @@ routes.get('/:agentId', mcpAuth, async (c) => {
 // ── Update agent metadata ────────────────────────────────────────────────────
 
 routes.patch('/:agentId', mcpAuth, async (c) => {
+  const denied = requireSessionOrAdminPat(c);
+  if (denied) return denied;
   return withOrg(c, async () => {
     const { agentId } = c.req.param();
     const body = await c.req.json<{ name?: string; description?: string }>();
@@ -436,6 +492,8 @@ routes.patch('/:agentId', mcpAuth, async (c) => {
 // ── Delete agent ─────────────────────────────────────────────────────────────
 
 routes.delete('/:agentId', mcpAuth, async (c) => {
+  const denied = requireSessionOrAdminPat(c);
+  if (denied) return denied;
   return withOrg(c, async () => {
     const { agentId } = c.req.param();
 
@@ -537,6 +595,8 @@ routes.get('/:agentId/config/skills/catalog', mcpAuth, async (c) => {
 // ── Start provider OAuth login ───────────────────────────────────────────────
 
 routes.get('/:agentId/providers/:providerId/oauth/start', mcpAuth, async (c) => {
+  const denied = requireSessionOrAdminPat(c);
+  if (denied) return denied;
   return withOrg(c, async () => {
     const { agentId, providerId } = c.req.param();
     const user = c.get('user');
@@ -572,6 +632,8 @@ routes.get('/:agentId/providers/:providerId/oauth/start', mcpAuth, async (c) => 
 // ── Complete provider OAuth login ────────────────────────────────────────────
 
 routes.post('/:agentId/providers/:providerId/oauth/code', mcpAuth, async (c) => {
+  const denied = requireSessionOrAdminPat(c);
+  if (denied) return denied;
   return withOrg(c, async () => {
     const { agentId, providerId } = c.req.param();
     const user = c.get('user');
@@ -647,6 +709,8 @@ routes.post('/:agentId/providers/:providerId/oauth/code', mcpAuth, async (c) => 
 // ── Update agent config (settings) ───────────────────────────────────────────
 
 routes.patch('/:agentId/config', mcpAuth, async (c) => {
+  const denied = requireSessionOrAdminPat(c);
+  if (denied) return denied;
   return withOrg(c, async () => {
     const { agentId } = c.req.param();
     const updates = await c.req.json();
@@ -706,6 +770,8 @@ routes.get('/:agentId/platforms', mcpAuth, async (c) => {
 // ── Create platform ──────────────────────────────────────────────────────────
 
 routes.post('/:agentId/platforms', mcpAuth, async (c) => {
+  const denied = requireSessionOrAdminPat(c);
+  if (denied) return denied;
   return withOrg(c, async () => {
     const { agentId } = c.req.param();
     if (!(await configStore.hasAgent(agentId))) {
@@ -763,6 +829,8 @@ routes.post('/:agentId/platforms', mcpAuth, async (c) => {
 // computed by the CLI from the same lobu.toml that produced the body.
 
 routes.put('/:agentId/platforms/by-stable-id/:stableId', mcpAuth, async (c) => {
+  const denied = requireSessionOrAdminPat(c);
+  if (denied) return denied;
   return withOrg(c, async () => {
     const { agentId, stableId } = c.req.param();
     if (!(await configStore.hasAgent(agentId))) {
@@ -992,6 +1060,8 @@ routes.get('/:agentId/platforms/:platformId', mcpAuth, async (c) => {
 // ── Delete platform ──────────────────────────────────────────────────────────
 
 routes.delete('/:agentId/platforms/:platformId', mcpAuth, async (c) => {
+  const denied = requireSessionOrAdminPat(c);
+  if (denied) return denied;
   return withOrg(c, async () => {
     const { platformId } = c.req.param();
     const platform = await connectionStore.getConnection(platformId);

--- a/packages/owletto-backend/src/start-local.ts
+++ b/packages/owletto-backend/src/start-local.ts
@@ -457,12 +457,18 @@ async function ensureBootstrapPat(dbUrl: string): Promise<void> {
     writeFileSync(patFilePath, `${token}\n`, { mode: 0o600 });
 
     const url = `http://localhost:${PORT}`;
+    // PAT printed once for dev bootstrap; do not redirect this log line through
+    // any remote sink (Sentry, OTEL exporter, etc.). The bootstrap PAT carries
+    // full mcp:admin scope — treat it like a password.
     process.stdout.write(`[bootstrap PAT] ${token}\n`);
     process.stdout.write(`[bootstrap PAT] org=${BOOTSTRAP_ORG_SLUG} url=${url}\n`);
     process.stdout.write(`[bootstrap PAT] saved to ${patFilePath}\n`);
+    process.stdout.write(
+      `[bootstrap PAT] WARNING: this PAT has full mcp:admin scope. Treat it like a password.\n`
+    );
     logger.info(
       { path: patFilePath, org: BOOTSTRAP_ORG_SLUG, url },
-      'Bootstrap PAT minted (printed once)'
+      'Bootstrap PAT minted (printed once, mcp:admin scope)'
     );
   } finally {
     await sql.end();

--- a/packages/owletto-backend/src/workspace/__tests__/multi-tenant-auth-source.test.ts
+++ b/packages/owletto-backend/src/workspace/__tests__/multi-tenant-auth-source.test.ts
@@ -1,0 +1,61 @@
+/**
+ * Pin the `authSource` contract on `MultiTenantProvider.resolveAuth`.
+ *
+ * `c.var.authSource` lets admin-tier routes (see
+ * `requireSessionOrAdminPat` in `lobu/agent-routes.ts`) distinguish how a
+ * caller authenticated. The full middleware exercises better-auth, the OAuth
+ * provider, the PAT service, and the CLI token service — all of which need
+ * a live DB. To avoid duplicating the test-workspace bootstrap, this file
+ * pins the contract via the source: every code path that calls
+ * `setContextAndContinue` MUST pass an `authSource` literal that matches the
+ * branch's auth flavor.
+ *
+ * If the source is restructured so this regex match no longer makes sense
+ * (e.g. the context plumbing moves into a different file), update both this
+ * test AND the moved code together.
+ */
+
+import { describe, expect, it } from 'bun:test';
+import { readFileSync } from 'node:fs';
+
+const SOURCE = readFileSync(
+  new URL('../multi-tenant.ts', import.meta.url),
+  'utf8'
+);
+
+describe('multi-tenant resolveAuth: authSource per branch', () => {
+  it('cli-token branch sets authSource: cli-token', () => {
+    // Two cli-token paths: unscoped /mcp and scoped. Both must label the
+    // source as 'cli-token'.
+    const matches = SOURCE.match(/authSource:\s*'cli-token'/g) ?? [];
+    expect(matches.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('PAT/OAuth branch picks pat or oauth via isPat ternary', () => {
+    // The PAT and OAuth bearers share a code path; the branch picks the
+    // label off the same `isPat` boolean it already used to dispatch
+    // verification.
+    expect(SOURCE).toMatch(/authSource:\s*isPat\s*\?\s*'pat'\s*:\s*'oauth'/);
+  });
+
+  it('session-cookie branch sets authSource: session', () => {
+    // Three session-cookie paths: unscoped /mcp, member, and non-member
+    // public-readable fallthrough. All three must label the source.
+    const matches = SOURCE.match(/authSource:\s*'session'/g) ?? [];
+    expect(matches.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it("initializes c.var.authSource to null at the top of resolveAuth", () => {
+    expect(SOURCE).toContain("c.set('authSource', null)");
+  });
+
+  it('setContextAndContinue threads authSource through', () => {
+    // Defensive — if someone refactors the helper signature, the per-branch
+    // sets above won't actually be applied. Assert the helper accepts and
+    // applies the override.
+    expect(SOURCE).toContain("authSource: 'session' | 'pat' | 'oauth' | 'cli-token' | null;");
+    expect(SOURCE).toContain(
+      "if (overrides.authSource !== undefined) c.set('authSource', overrides.authSource);"
+    );
+  });
+});

--- a/packages/owletto-backend/src/workspace/multi-tenant.ts
+++ b/packages/owletto-backend/src/workspace/multi-tenant.ts
@@ -135,6 +135,7 @@ export class MultiTenantProvider implements WorkspaceProvider {
     c.set('memberRole', null);
     c.set('user', null);
     c.set('session', null);
+    c.set('authSource', null);
 
     let requestedOrgId: string | null = null;
     let requestedOrgVisibility: string | null = null;
@@ -221,6 +222,7 @@ export class MultiTenantProvider implements WorkspaceProvider {
         memberRole: string | null;
         user: unknown;
         session: unknown;
+        authSource: 'session' | 'pat' | 'oauth' | 'cli-token' | null;
       }>
     ) {
       if (overrides.mcpAuthInfo !== undefined) c.set('mcpAuthInfo', overrides.mcpAuthInfo);
@@ -230,6 +232,7 @@ export class MultiTenantProvider implements WorkspaceProvider {
       if (overrides.memberRole !== undefined) c.set('memberRole', overrides.memberRole);
       if (overrides.user !== undefined) c.set('user', overrides.user as any);
       if (overrides.session !== undefined) c.set('session', overrides.session as any);
+      if (overrides.authSource !== undefined) c.set('authSource', overrides.authSource);
       return next();
     }
 
@@ -264,6 +267,7 @@ export class MultiTenantProvider implements WorkspaceProvider {
                   token,
                   expiresAt: new Date(cliIdentity.expiresAt),
                 },
+                authSource: 'cli-token',
               });
               return undefined;
             }
@@ -309,6 +313,7 @@ export class MultiTenantProvider implements WorkspaceProvider {
               expiresAt: new Date(cliIdentity.expiresAt),
               activeOrganizationId: effectiveOrgId,
             },
+            authSource: 'cli-token',
           });
           return undefined;
         }
@@ -357,6 +362,7 @@ export class MultiTenantProvider implements WorkspaceProvider {
             mcpIsAuthenticated: true,
             organizationId: null,
             memberRole: null,
+            authSource: isPat ? 'pat' : 'oauth',
           });
           return undefined;
         }
@@ -428,6 +434,7 @@ export class MultiTenantProvider implements WorkspaceProvider {
         organizationId: effectiveOrgId,
         memberRole: role,
         user: bearerUser,
+        authSource: isPat ? 'pat' : 'oauth',
       });
       return undefined;
     }
@@ -467,6 +474,7 @@ export class MultiTenantProvider implements WorkspaceProvider {
               memberRole: null,
               user: session.user,
               session: session.session,
+              authSource: 'session',
             });
             return undefined;
           }
@@ -484,6 +492,7 @@ export class MultiTenantProvider implements WorkspaceProvider {
             memberRole: role,
             user: session.user,
             session: session.session,
+            authSource: 'session',
           });
           return undefined;
         }
@@ -504,6 +513,7 @@ export class MultiTenantProvider implements WorkspaceProvider {
           memberRole: null,
           user: session.user,
           session: session.session,
+          authSource: 'session',
         });
         return undefined;
       }


### PR DESCRIPTION
## Summary

Two pi-flagged tightenings to merged #468.

**Finding 1 — Bootstrap PAT leak vector**
- `start-local.ts` already wrote `${OWLETTO_DATA_DIR}/bootstrap-pat.txt` with `mode: 0o600` after #468; this PR adds an explicit `mcp:admin` scope warning at the print site (`"WARNING: this PAT has full mcp:admin scope. Treat it like a password."`) plus a comment marking the log line as do-not-redirect-through-remote-sink (Sentry/OTEL).
- Default `OWLETTO_DATA_DIR` is `~/.owletto/data/` (outside the repo). E2E uses `/tmp/e2e-data` (also outside). No `.gitignore` change needed.

**Finding 2 — PAT bearer hydrating `c.var.user` bypass risk**
- `multi-tenant.ts` now stashes `c.var.authSource` (`session` | `pat` | `oauth` | `cli-token` | `null`) on every auth branch.
- `agent-routes.ts` gains `requireSessionOrAdminPat()` and applies it to all admin-tier routes:
  - `POST /agents`, `PATCH /agents/:id`, `DELETE /agents/:id`
  - `PATCH /agents/:id/config`
  - `POST /agents/:id/connections`, `PUT .../by-stable-id/:stableId`, `DELETE .../:connId`
  - `GET /agents/:id/providers/:providerId/oauth/start`, `POST .../oauth/code`
- Web sessions and `lobu login` CLI tokens pass through (already user-bound). PATs and OAuth bearers must carry `mcp:admin` scope; otherwise 403.
- Read-only routes (GET list/detail/config, start/stop) keep the existing `mcpAuth`-only contract — `mcp:read` PATs continue to work.

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun run check` (Biome) — clean
- [x] `bun test packages/owletto-backend` — 1169 pass (17 new), 63 pre-existing failures unchanged from base
- [x] `make build-packages` — clean
- [x] New tests:
  - [x] `bootstrap-pat-file-mode.test.ts` — source contains `mode: 0o600`; on-disk permission bits = `0o600`
  - [x] `multi-tenant-auth-source.test.ts` — source pins authSource literal per auth branch
  - [x] `agent-routes-apply.test.ts` admin-tier admission block — session/cli-token/admin-PAT pass; read-only-PAT/write-only-PAT/weak-OAuth get 403; anonymous gets 401

## Out of scope

This PR targets `feat/owletto-cli-merge` since that's where #468 (and the bootstrap-PAT path it introduced) lives. The `main` branch does not yet contain `start-local.ts`'s bootstrap path, so a `main`-based PR can't fix what isn't there.