### PR TITLE
fix(backend): gate platform start/stop with requireSessionOrAdminPat

### DIFF
--- a/packages/owletto-backend/src/lobu/__tests__/agent-routes-apply.test.ts
+++ b/packages/owletto-backend/src/lobu/__tests__/agent-routes-apply.test.ts
@@ -671,18 +671,42 @@ describe('admin-tier auth admission (requireSessionOrAdminPat)', () => {
     expect(rows.length).toBe(1);
   });
 
-  test('PUT /:agentId/connections/by-stable-id rejects a write-only PAT', async () => {
+  test('PUT /:agentId/platforms/by-stable-id rejects a write-only PAT', async () => {
     const app = await importAgentRoutes();
     await seedAgent(ORG_A, 'conn-host');
     authStash.authSource = 'pat';
     authStash.mcpAuthInfo = { scopes: ['mcp:read', 'mcp:write'] };
     const response = await app.request(
-      '/conn-host/connections/by-stable-id/conn-host-tg',
+      '/conn-host/platforms/by-stable-id/conn-host-tg',
       {
         method: 'PUT',
         headers: { 'content-type': 'application/json' },
         body: JSON.stringify({ platform: 'telegram', config: { chatId: '1' } }),
       }
+    );
+    expect(response.status).toBe(403);
+  });
+
+  test('POST /:agentId/platforms/:platformId/start rejects a write-only PAT', async () => {
+    const app = await importAgentRoutes();
+    await seedAgent(ORG_A, 'lifecycle-host-start');
+    authStash.authSource = 'pat';
+    authStash.mcpAuthInfo = { scopes: ['mcp:read', 'mcp:write'] };
+    const response = await app.request(
+      '/lifecycle-host-start/platforms/some-platform-id/start',
+      { method: 'POST' }
+    );
+    expect(response.status).toBe(403);
+  });
+
+  test('POST /:agentId/platforms/:platformId/stop rejects a write-only PAT', async () => {
+    const app = await importAgentRoutes();
+    await seedAgent(ORG_A, 'lifecycle-host-stop');
+    authStash.authSource = 'pat';
+    authStash.mcpAuthInfo = { scopes: ['mcp:read', 'mcp:write'] };
+    const response = await app.request(
+      '/lifecycle-host-stop/platforms/some-platform-id/stop',
+      { method: 'POST' }
     );
     expect(response.status).toBe(403);
   });

--- a/packages/owletto-backend/src/lobu/agent-routes.ts
+++ b/packages/owletto-backend/src/lobu/agent-routes.ts
@@ -1083,6 +1083,8 @@ routes.delete('/:agentId/platforms/:platformId', mcpAuth, async (c) => {
 // ── Start platform ───────────────────────────────────────────────────────────
 
 routes.post('/:agentId/platforms/:platformId/start', mcpAuth, async (c) => {
+  const denied = requireSessionOrAdminPat(c);
+  if (denied) return denied;
   return withOrg(c, async () => {
     const { platformId } = c.req.param();
     const chatManager = getChatInstanceManager();
@@ -1109,6 +1111,8 @@ routes.post('/:agentId/platforms/:platformId/start', mcpAuth, async (c) => {
 // ── Stop platform ────────────────────────────────────────────────────────────
 
 routes.post('/:agentId/platforms/:platformId/stop', mcpAuth, async (c) => {
+  const denied = requireSessionOrAdminPat(c);
+  if (denied) return denied;
   return withOrg(c, async () => {
     const { platformId } = c.req.param();
     const chatManager = getChatInstanceManager();


### PR DESCRIPTION
## Summary

Pi follow-up to merged #472. Two issues:

1. **Missed routes** — `POST /:agentId/platforms/:platformId/start` and `.../stop` were the only admin-tier mutations still on the bare `mcpAuth` gate after #472. A weak PAT (`mcp:read` or `mcp:read+mcp:write` but no `mcp:admin`) could bounce a connection's lifecycle. Pi flagged this in the #472 review; the comment landed too late to fold into that PR. Add the `requireSessionOrAdminPat` gate + 2 admission tests.
2. **Stale path in test** — #470 renamed the connection route to `/platforms/by-stable-id` but the admission test added in #472 still hit `/connections/by-stable-id`, which now lands in the 404 branch (test passed only by accident — the helper rejects with 403, the unknown route returns 404, and the assertion was for 403 which the wrong endpoint did not produce). Update path + assertion correctly hit the gate now.

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun run check` — clean
- [x] `bun test src/lobu/__tests__/agent-routes-apply.test.ts` — 23/23 (was 21/21 before; +2 new)
- [x] `make build-packages` — clean

## Touch list

- `packages/owletto-backend/src/lobu/agent-routes.ts` — gate /platforms/:id/start, /stop
- `packages/owletto-backend/src/lobu/__tests__/agent-routes-apply.test.ts` — 2 new tests + 1 path fix