### PR TITLE
refactor(owletto-backend): consolidate backend helper ownership

### DIFF
--- a/packages/owletto-backend/src/gateway/auth/settings/agent-settings-store.ts
+++ b/packages/owletto-backend/src/gateway/auth/settings/agent-settings-store.ts
@@ -1,16 +1,17 @@
 import { type AgentSettings, type AuthProfile, createLogger } from "@lobu/core";
 import { getDb } from "../../../db/client.js";
+import {
+  agentSettingsWithDefinedValues,
+  deleteAgentSettingsFromPg,
+  loadAgentSettingsFromPg,
+  saveAgentSettingsToPg,
+  type AgentSettingsContext,
+} from "../../../lobu/stores/agent-settings-persistence.js";
 import { tryGetOrgId } from "../../../lobu/stores/org-context.js";
 import type { DeclaredAgentRegistry } from "../../services/declared-agent-registry.js";
 
 // Re-export so existing imports from this module keep working.
-export type { AgentSettings };
-
-export interface AgentSettingsContext {
-  localSettings: AgentSettings | null;
-  effectiveSettings: AgentSettings | null;
-  templateAgentId?: string;
-}
+export type { AgentSettings, AgentSettingsContext };
 
 const logger = createLogger("agent-settings-store");
 
@@ -37,118 +38,6 @@ export class EphemeralAuthProfileRegistry {
   delete(agentId: string): void {
     this.profiles.delete(agentId);
   }
-}
-
-/** Treat falsy/empty defaults as "not set" so template fallback in
- *  `getSettingsContext` can fill them in from the parent agent. The
- *  `agents` table has DEFAULT '' for the markdown columns and DEFAULT '{}'
- *  for the jsonb settings columns, so a row that was inserted but never had
- *  these fields written would otherwise read as the empty string / object
- *  and shadow the template's value during a merge. */
-function nonEmptyString(value: unknown): string | undefined {
-  if (typeof value !== "string" || value.length === 0) return undefined;
-  return value;
-}
-function nonEmptyObject<T extends Record<string, unknown>>(
-  value: T | null | undefined
-): T | undefined {
-  if (!value || typeof value !== "object") return undefined;
-  if (Array.isArray(value)) {
-    return value.length > 0 ? value : undefined;
-  }
-  return Object.keys(value).length > 0 ? value : undefined;
-}
-
-/** Build an AgentSettings object that *omits* keys whose stored value is the
- *  empty default. The downstream `resolved-settings-view` uses
- *  `Object.hasOwn(settings, key)` to decide whether the local agent has a
- *  local override vs. inheriting from the template, so we must omit absent
- *  keys rather than including them as undefined. The schema has DEFAULT ''
- *  for markdown columns and DEFAULT '{}'/'[]' for JSONB columns; that's
- *  treated as "not set" here. */
-function rowToSettings(row: Record<string, any>): AgentSettings {
-  const out: AgentSettings = {
-    updatedAt:
-      row.updated_at instanceof Date
-        ? row.updated_at.getTime()
-        : (row.updated_at ?? Date.now()),
-  };
-  if (row.model != null) out.model = row.model;
-  const modelSelection = nonEmptyObject(row.model_selection);
-  if (modelSelection !== undefined) out.modelSelection = modelSelection as any;
-  const providerModelPreferences = nonEmptyObject(row.provider_model_preferences);
-  if (providerModelPreferences !== undefined)
-    out.providerModelPreferences = providerModelPreferences as any;
-  const networkConfig = nonEmptyObject(row.network_config);
-  if (networkConfig !== undefined) out.networkConfig = networkConfig as any;
-  const nixConfig = nonEmptyObject(row.nix_config);
-  if (nixConfig !== undefined) out.nixConfig = nixConfig as any;
-  const mcpServers = nonEmptyObject(row.mcp_servers);
-  if (mcpServers !== undefined) out.mcpServers = mcpServers as any;
-  const mcpInstallNotified = nonEmptyObject(row.mcp_install_notified);
-  if (mcpInstallNotified !== undefined)
-    out.mcpInstallNotified = mcpInstallNotified as any;
-  const soulMd = nonEmptyString(row.soul_md);
-  if (soulMd !== undefined) out.soulMd = soulMd;
-  const userMd = nonEmptyString(row.user_md);
-  if (userMd !== undefined) out.userMd = userMd;
-  const identityMd = nonEmptyString(row.identity_md);
-  if (identityMd !== undefined) out.identityMd = identityMd;
-  // skillsConfig has the shape `{ skills: [] }` by default; treat the empty
-  // skills array as "not set" so the template's skillsConfig wins.
-  const skillsConfig = row.skills_config;
-  if (
-    skillsConfig &&
-    Array.isArray(skillsConfig.skills) &&
-    skillsConfig.skills.length > 0
-  ) {
-    out.skillsConfig = skillsConfig;
-  }
-  const toolsConfig = nonEmptyObject(row.tools_config);
-  if (toolsConfig !== undefined) out.toolsConfig = toolsConfig as any;
-  const pluginsConfig = nonEmptyObject(row.plugins_config);
-  if (pluginsConfig !== undefined) out.pluginsConfig = pluginsConfig as any;
-  const authProfiles = nonEmptyObject(row.auth_profiles);
-  if (authProfiles !== undefined) out.authProfiles = authProfiles as any;
-  const installedProviders = nonEmptyObject(row.installed_providers);
-  if (installedProviders !== undefined)
-    out.installedProviders = installedProviders as any;
-  if (row.verbose_logging) out.verboseLogging = true;
-  if (row.template_agent_id) out.templateAgentId = row.template_agent_id;
-  return out;
-}
-
-/**
- * Read agent settings directly from `public.agents`.
- *
- * Worker gateway calls this without orgContext (agent IDs are globally unique
- * and the worker token already proves authenticity), so we fall back to
- * id-only lookup when `tryGetOrgId()` returns null.
- */
-async function loadSettingsFromPg(agentId: string): Promise<AgentSettings | null> {
-  const sql = getDb();
-  const orgId = tryGetOrgId();
-  const rows = orgId
-    ? await sql`
-        SELECT model, model_selection, provider_model_preferences,
-               network_config, nix_config, mcp_servers, mcp_install_notified,
-               soul_md, user_md, identity_md, skills_config, tools_config,
-               plugins_config, auth_profiles, installed_providers,
-               verbose_logging, template_agent_id, updated_at
-        FROM agents
-        WHERE id = ${agentId} AND organization_id = ${orgId}
-      `
-    : await sql`
-        SELECT model, model_selection, provider_model_preferences,
-               network_config, nix_config, mcp_servers, mcp_install_notified,
-               soul_md, user_md, identity_md, skills_config, tools_config,
-               plugins_config, auth_profiles, installed_providers,
-               verbose_logging, template_agent_id, updated_at
-        FROM agents
-        WHERE id = ${agentId}
-      `;
-  if (rows.length === 0) return null;
-  return rowToSettings(rows[0]);
 }
 
 /**
@@ -183,7 +72,9 @@ export class AgentSettingsStore {
    * (e.g., via AuthProfilesManager.listProfiles).
    */
   async getSettings(agentId: string): Promise<AgentSettings | null> {
-    return loadSettingsFromPg(agentId);
+    return loadAgentSettingsFromPg(getDb(), agentId, tryGetOrgId(), {
+      omitEmptyDefaults: true,
+    });
   }
 
   /**
@@ -238,9 +129,7 @@ export class AgentSettingsStore {
       localSettings,
       effectiveSettings: {
         ...templateSettings,
-        ...Object.fromEntries(
-          Object.entries(localSettings).filter(([, v]) => v !== undefined)
-        ),
+        ...agentSettingsWithDefinedValues(localSettings),
         templateAgentId,
       } as AgentSettings,
       templateAgentId,
@@ -293,60 +182,7 @@ export class AgentSettingsStore {
     agentId: string,
     settings: Omit<AgentSettings, "updatedAt">
   ): Promise<void> {
-    const sql = getDb();
-    const orgId = tryGetOrgId();
-    const now = new Date();
-
-    // Saving settings against an agent that doesn't yet exist is a no-op:
-    // the metadata insert in AgentMetadataStore.createAgent must precede
-    // settings writes.
-    if (orgId) {
-      await sql`
-        UPDATE agents SET
-          model = ${settings.model ?? null},
-          model_selection = ${sql.json(settings.modelSelection ?? {})},
-          provider_model_preferences = ${sql.json(settings.providerModelPreferences ?? {})},
-          network_config = ${sql.json(settings.networkConfig ?? {})},
-          nix_config = ${sql.json(settings.nixConfig ?? {})},
-          mcp_servers = ${sql.json(settings.mcpServers ?? {})},
-          mcp_install_notified = ${sql.json(settings.mcpInstallNotified ?? {})},
-          soul_md = ${settings.soulMd ?? ""},
-          user_md = ${settings.userMd ?? ""},
-          identity_md = ${settings.identityMd ?? ""},
-          skills_config = ${sql.json(settings.skillsConfig ?? { skills: [] })},
-          tools_config = ${sql.json(settings.toolsConfig ?? {})},
-          plugins_config = ${sql.json(settings.pluginsConfig ?? {})},
-          auth_profiles = ${sql.json(settings.authProfiles ?? [])},
-          installed_providers = ${sql.json(settings.installedProviders ?? [])},
-          verbose_logging = ${settings.verboseLogging ?? false},
-          template_agent_id = ${settings.templateAgentId ?? null},
-          updated_at = ${now}
-        WHERE id = ${agentId} AND organization_id = ${orgId}
-      `;
-    } else {
-      await sql`
-        UPDATE agents SET
-          model = ${settings.model ?? null},
-          model_selection = ${sql.json(settings.modelSelection ?? {})},
-          provider_model_preferences = ${sql.json(settings.providerModelPreferences ?? {})},
-          network_config = ${sql.json(settings.networkConfig ?? {})},
-          nix_config = ${sql.json(settings.nixConfig ?? {})},
-          mcp_servers = ${sql.json(settings.mcpServers ?? {})},
-          mcp_install_notified = ${sql.json(settings.mcpInstallNotified ?? {})},
-          soul_md = ${settings.soulMd ?? ""},
-          user_md = ${settings.userMd ?? ""},
-          identity_md = ${settings.identityMd ?? ""},
-          skills_config = ${sql.json(settings.skillsConfig ?? { skills: [] })},
-          tools_config = ${sql.json(settings.toolsConfig ?? {})},
-          plugins_config = ${sql.json(settings.pluginsConfig ?? {})},
-          auth_profiles = ${sql.json(settings.authProfiles ?? [])},
-          installed_providers = ${sql.json(settings.installedProviders ?? [])},
-          verbose_logging = ${settings.verboseLogging ?? false},
-          template_agent_id = ${settings.templateAgentId ?? null},
-          updated_at = ${now}
-        WHERE id = ${agentId}
-      `;
-    }
+    await saveAgentSettingsToPg(getDb(), agentId, settings, tryGetOrgId());
 
     logger.info(`Saved settings for agent ${agentId}`);
   }
@@ -355,7 +191,7 @@ export class AgentSettingsStore {
     agentId: string,
     updates: Partial<Omit<AgentSettings, "updatedAt">>
   ): Promise<void> {
-    const existing = await loadSettingsFromPg(agentId);
+    const existing = await this.getSettings(agentId);
     if (!existing) {
       // No row yet — fall through to saveSettings, which create-or-overwrites.
       await this.saveSettings(agentId, updates as Omit<AgentSettings, "updatedAt">);
@@ -365,33 +201,8 @@ export class AgentSettingsStore {
   }
 
   async deleteSettings(agentId: string): Promise<void> {
-    const sql = getDb();
-    const orgId = tryGetOrgId();
     this.ephemeralAuthProfiles.delete(agentId);
-
-    if (orgId) {
-      await sql`
-        UPDATE agents SET
-          model = NULL, model_selection = '{}', provider_model_preferences = '{}',
-          network_config = '{}', nix_config = '{}', mcp_servers = '{}',
-          mcp_install_notified = '{}', soul_md = '', user_md = '', identity_md = '',
-          skills_config = '{"skills": []}', tools_config = '{}', plugins_config = '{}',
-          auth_profiles = '[]', installed_providers = '[]', verbose_logging = false,
-          template_agent_id = NULL, updated_at = now()
-        WHERE id = ${agentId} AND organization_id = ${orgId}
-      `;
-    } else {
-      await sql`
-        UPDATE agents SET
-          model = NULL, model_selection = '{}', provider_model_preferences = '{}',
-          network_config = '{}', nix_config = '{}', mcp_servers = '{}',
-          mcp_install_notified = '{}', soul_md = '', user_md = '', identity_md = '',
-          skills_config = '{"skills": []}', tools_config = '{}', plugins_config = '{}',
-          auth_profiles = '[]', installed_providers = '[]', verbose_logging = false,
-          template_agent_id = NULL, updated_at = now()
-        WHERE id = ${agentId}
-      `;
-    }
+    await deleteAgentSettingsFromPg(getDb(), agentId, tryGetOrgId());
 
     logger.info(`Deleted settings for agent ${agentId}`);
   }

--- a/packages/owletto-backend/src/gateway/connections/chat-instance-manager.ts
+++ b/packages/owletto-backend/src/gateway/connections/chat-instance-manager.ts
@@ -5,7 +5,6 @@
  */
 
 import { randomUUID } from "node:crypto";
-import type { Readable } from "node:stream";
 import { createLogger, isSecretRef } from "@lobu/core";
 import type { CoreServices, PlatformAdapter } from "../platform.js";
 import type { IFileHandler } from "../platform/file-handler.js";
@@ -24,6 +23,7 @@ import {
   type HistoryEntry,
 } from "./conversation-state-store.js";
 import { createGatewayStateAdapter } from "./state-adapter.js";
+import { readStreamToBuffer } from "../../utils/streams.js";
 import { SlackConnectionCoordinator } from "./slack-connection-coordinator.js";
 import { SlackInstructionProvider } from "./slack-instruction-provider.js";
 import { registerSlackPlatformHandlers } from "./slack-platform-bridge.js";
@@ -986,16 +986,6 @@ export class ChatInstanceManager {
         ? connection.metadata.botUsername.replace(/^@/, "")
         : undefined;
 
-    const readStreamToBuffer = async (
-      fileStream: Readable
-    ): Promise<Buffer> => {
-      const chunks: Buffer[] = [];
-      for await (const chunk of fileStream) {
-        chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
-      }
-      return Buffer.concat(chunks);
-    };
-
     const parseTelegramTarget = (
       channelId: string,
       conversationId?: string
@@ -1098,16 +1088,6 @@ export class ChatInstanceManager {
     const chat = instance.chat;
     const platform = instance.connection.platform;
 
-    const readStreamToBuffer = async (
-      fileStream: Readable
-    ): Promise<Buffer> => {
-      const chunks: Buffer[] = [];
-      for await (const chunk of fileStream) {
-        chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
-      }
-      return Buffer.concat(chunks);
-    };
-
     // For Slack, `conversationId` is the Chat SDK's canonical `thread.id`
     // (`slack:{channel}:{parent_thread_ts}`) for group threads, or the bare
     // channel id for DMs/channel-level posts (no thread_ts).
@@ -1197,16 +1177,6 @@ export class ChatInstanceManager {
   private createChatSdkFileHandler(instance: ManagedInstance): IFileHandler {
     const { chat, connection } = instance;
     const platform = connection.platform;
-
-    const readStreamToBuffer = async (
-      fileStream: Readable
-    ): Promise<Buffer> => {
-      const chunks: Buffer[] = [];
-      for await (const chunk of fileStream) {
-        chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
-      }
-      return Buffer.concat(chunks);
-    };
 
     return {
       uploadFile: async (fileStream, options) => {

--- a/packages/owletto-backend/src/index.ts
+++ b/packages/owletto-backend/src/index.ts
@@ -70,6 +70,7 @@ import {
 } from './utils/public-origin';
 import { getClientIP, getRateLimiter, RateLimitPresets } from './utils/rate-limiter';
 import { getRuntimeInfo } from './utils/runtime-info';
+import { sseStreamResponse } from './utils/sse';
 import { getWorkspaceProvider } from './workspace';
 import { joinPublicOrganization } from './workspace/join-public';
 
@@ -825,45 +826,11 @@ app.get('/api/:orgSlug/events', mcpAuth, async (c) => {
   const orgId = c.get('organizationId');
   if (!orgId) return c.json({ error: 'Organization context required' }, 401);
 
-  const encoder = new TextEncoder();
-  let cleanup: (() => void) | null = null;
-
-  const stream = new ReadableStream({
-    start(controller) {
-      controller.enqueue(encoder.encode('event: connected\ndata: {}\n\n'));
-
-      const unsubscribe = invalidationEmitter.subscribe(String(orgId), (event) => {
-        try {
-          const data = JSON.stringify(event);
-          controller.enqueue(encoder.encode(`event: invalidate\ndata: ${data}\n\n`));
-        } catch {
-          // Connection closed
-        }
-      });
-
-      const keepAlive = setInterval(() => {
-        try {
-          controller.enqueue(encoder.encode(': keepalive\n\n'));
-        } catch {
-          clearInterval(keepAlive);
-        }
-      }, 30000);
-
-      cleanup = () => {
-        unsubscribe();
-        clearInterval(keepAlive);
-      };
-    },
-    cancel() {
-      cleanup?.();
-    },
-  });
-
-  c.header('Content-Type', 'text/event-stream');
-  c.header('Cache-Control', 'no-cache');
-  c.header('Connection', 'keep-alive');
-
-  return c.body(stream);
+  return sseStreamResponse(c, (emit) =>
+    invalidationEmitter.subscribe(String(orgId), (event) => {
+      emit('invalidate', event);
+    })
+  );
 });
 
 /**

--- a/packages/owletto-backend/src/lobu/agent-routes.ts
+++ b/packages/owletto-backend/src/lobu/agent-routes.ts
@@ -28,7 +28,7 @@ import { orgContext } from './stores/org-context';
 const routes = new Hono<{ Bindings: Env }>();
 
 const configStore = createPostgresAgentConfigStore();
-const connectionStore = createPostgresAgentConnectionStore();
+const agentPlatformStore = createPostgresAgentConnectionStore();
 
 type ProviderAuthType = 'oauth' | 'device-code' | 'api-key';
 
@@ -192,10 +192,10 @@ function getClaudeOAuthRuntime() {
   };
 }
 
-async function persistConnectionSnapshot(connection: Record<string, any>): Promise<void> {
+async function persistAgentPlatformSnapshot(connection: Record<string, any>): Promise<void> {
   if (!connection?.id) return;
 
-  await connectionStore.saveConnection({
+  await agentPlatformStore.saveConnection({
     id: connection.id,
     platform: connection.platform,
     templateAgentId: connection.templateAgentId,
@@ -739,7 +739,7 @@ routes.get('/:agentId/platforms', mcpAuth, async (c) => {
       return c.json({ error: 'Agent not found' }, 404);
     }
     const chatManager = getChatInstanceManager();
-    let platforms = await connectionStore.listConnections({
+    let platforms = await agentPlatformStore.listConnections({
       templateAgentId: agentId,
     });
 
@@ -750,7 +750,7 @@ routes.get('/:agentId/platforms', mcpAuth, async (c) => {
         });
         await Promise.all(
           runtimePlatforms.map((platform: Record<string, any>) =>
-            persistConnectionSnapshot(platform)
+            persistAgentPlatformSnapshot(platform)
           )
         );
         if (runtimePlatforms.length > 0) {
@@ -793,7 +793,7 @@ routes.post('/:agentId/platforms', mcpAuth, async (c) => {
           { platform, ...config },
           { allowGroups: true, ...settings }
         );
-        await persistConnectionSnapshot(created);
+        await persistAgentPlatformSnapshot(created);
         return c.json({ platform: created }, 201);
       } catch (error: any) {
         return c.json({ error: error.message || 'Failed to create platform' }, 400);
@@ -803,7 +803,7 @@ routes.post('/:agentId/platforms', mcpAuth, async (c) => {
     // Fallback: store directly if ChatInstanceManager not available
     const id = `${platform}-${agentId}-${Date.now()}`;
     const now = Date.now();
-    await connectionStore.saveConnection({
+    await agentPlatformStore.saveConnection({
       id,
       platform,
       templateAgentId: agentId,
@@ -876,7 +876,7 @@ const stablePlatformLockChains: Map<string, Promise<unknown>> = new Map();
  *          gateway processes against the same DB.
  *
  * Wrapping the whole flow in a single `sql.begin(...)` is not viable: the
- * tx connection plus parent-pool writes via `connectionStore` /
+ * tx connection plus parent-pool writes via `agentPlatformStore` /
  * `chatManager.addConnection` would self-deadlock both on the pglite-mode
  * serialized-client queue and on row-level locks against an uncommitted
  * placeholder row from a different connection.
@@ -943,7 +943,7 @@ routes.put('/:agentId/platforms/by-stable-id/:stableId', mcpAuth, async (c) => {
     // queues subsequent PUTs at the chain entry; they only proceed after the
     // first one's manager-side work has fully committed.
     return await withStablePlatformLock(stableId, async () => {
-      let existing = await connectionStore.getConnection(stableId);
+      let existing = await agentPlatformStore.getConnection(stableId);
       if (existing && existing.templateAgentId && existing.templateAgentId !== agentId) {
         return c.json(
           { error: 'Stable ID already used by a different agent' },
@@ -989,13 +989,13 @@ routes.put('/:agentId/platforms/by-stable-id/:stableId', mcpAuth, async (c) => {
                 {},
                 stableId
               );
-              await persistConnectionSnapshot(created);
+              await persistAgentPlatformSnapshot(created);
               return c.json({ platform: created }, 201);
             } catch (error: any) {
               // Roll back the placeholder so a retry doesn't see a half-baked
               // row that fails the `existing.templateAgentId` check inconsistently.
               try {
-                await connectionStore.deleteConnection(stableId);
+                await agentPlatformStore.deleteConnection(stableId);
               } catch {
                 // best-effort
               }
@@ -1010,7 +1010,7 @@ routes.put('/:agentId/platforms/by-stable-id/:stableId', mcpAuth, async (c) => {
           // match the manager-path default — symmetric with the noop comparison
           // below so a follow-up PUT with no settings field round-trips as noop.
           const fallbackNow = Date.now();
-          await connectionStore.saveConnection({
+          await agentPlatformStore.saveConnection({
             id: stableId,
             platform,
             templateAgentId: agentId,
@@ -1031,7 +1031,7 @@ routes.put('/:agentId/platforms/by-stable-id/:stableId', mcpAuth, async (c) => {
         // initial read and INSERT. With the advisory lock held we shouldn't
         // reach this in the same-process case, but keep the re-read as
         // defense-in-depth against multi-host writers that bypass the route.
-        const reread = await connectionStore.getConnection(stableId);
+        const reread = await agentPlatformStore.getConnection(stableId);
         if (!reread) {
           return c.json({ error: 'Platform vanished after conflict' }, 500);
         }
@@ -1078,7 +1078,7 @@ routes.put('/:agentId/platforms/by-stable-id/:stableId', mcpAuth, async (c) => {
             config: { platform, ...config },
             settings: { allowGroups: true, ...settings },
           });
-          await persistConnectionSnapshot(updated);
+          await persistAgentPlatformSnapshot(updated);
           return c.json(
             { updated: true, willRestart: true, platform: updated },
             200
@@ -1090,7 +1090,7 @@ routes.put('/:agentId/platforms/by-stable-id/:stableId', mcpAuth, async (c) => {
 
       // Fallback when ChatInstanceManager is not available (e.g. boot races,
       // tests). Persist the merged config directly.
-      await connectionStore.saveConnection({
+      await agentPlatformStore.saveConnection({
         id: stableId,
         platform,
         templateAgentId: agentId,
@@ -1101,7 +1101,7 @@ routes.put('/:agentId/platforms/by-stable-id/:stableId', mcpAuth, async (c) => {
         createdAt: current.createdAt ?? Date.now(),
         updatedAt: Date.now(),
       });
-      const refreshed = await connectionStore.getConnection(stableId);
+      const refreshed = await agentPlatformStore.getConnection(stableId);
       return c.json(
         { updated: true, willRestart: true, platform: refreshed },
         200
@@ -1131,7 +1131,7 @@ function platformBelongsToAgent(platform: { templateAgentId?: string | null }, a
 }
 
 async function getStoredPlatformForAgent(agentId: string, platformId: string) {
-  const platform = await connectionStore.getConnection(platformId);
+  const platform = await agentPlatformStore.getConnection(platformId);
   if (!platform || !platformBelongsToAgent(platform, agentId)) return null;
   return platform;
 }
@@ -1151,7 +1151,7 @@ routes.get('/:agentId/platforms/:platformId', mcpAuth, async (c) => {
       try {
         const runtimePlatform = await chatManager.getConnection(platformId);
         if (runtimePlatform && platformBelongsToAgent(runtimePlatform, agentId)) {
-          await persistConnectionSnapshot(runtimePlatform);
+          await persistAgentPlatformSnapshot(runtimePlatform);
           return c.json(runtimePlatform);
         }
       } catch {
@@ -1184,7 +1184,7 @@ routes.delete('/:agentId/platforms/:platformId', mcpAuth, async (c) => {
         // Fall through to direct store delete
       }
     }
-    await connectionStore.deleteConnection(platformId);
+    await agentPlatformStore.deleteConnection(platformId);
     return c.json({ success: true });
   });
 });
@@ -1207,15 +1207,15 @@ routes.post('/:agentId/platforms/:platformId/start', mcpAuth, async (c) => {
       await chatManager.restartConnection(platformId);
       const runtimePlatform = await chatManager.getConnection(platformId);
       if (runtimePlatform && platformBelongsToAgent(runtimePlatform, agentId)) {
-        await persistConnectionSnapshot(runtimePlatform);
+        await persistAgentPlatformSnapshot(runtimePlatform);
         return c.json({ success: true, platform: runtimePlatform });
       }
     }
 
-    await connectionStore.updateConnection(platformId, { status: 'active' });
+    await agentPlatformStore.updateConnection(platformId, { status: 'active' });
     return c.json({
       success: true,
-      platform: await connectionStore.getConnection(platformId),
+      platform: await agentPlatformStore.getConnection(platformId),
     });
   });
 });
@@ -1238,15 +1238,15 @@ routes.post('/:agentId/platforms/:platformId/stop', mcpAuth, async (c) => {
       await chatManager.stopConnection(platformId);
       const runtimePlatform = await chatManager.getConnection(platformId);
       if (runtimePlatform && platformBelongsToAgent(runtimePlatform, agentId)) {
-        await persistConnectionSnapshot(runtimePlatform);
+        await persistAgentPlatformSnapshot(runtimePlatform);
         return c.json({ success: true, platform: runtimePlatform });
       }
     }
 
-    await connectionStore.updateConnection(platformId, { status: 'stopped' });
+    await agentPlatformStore.updateConnection(platformId, { status: 'stopped' });
     return c.json({
       success: true,
-      platform: await connectionStore.getConnection(platformId),
+      platform: await agentPlatformStore.getConnection(platformId),
     });
   });
 });

--- a/packages/owletto-backend/src/lobu/stores/agent-settings-persistence.ts
+++ b/packages/owletto-backend/src/lobu/stores/agent-settings-persistence.ts
@@ -1,0 +1,252 @@
+import type { AgentSettings } from '@lobu/core';
+import type { DbClient } from '../../db/client';
+
+export interface AgentSettingsContext {
+  localSettings: AgentSettings | null;
+  effectiveSettings: AgentSettings | null;
+  templateAgentId?: string;
+}
+
+export interface AgentSettingsPersistenceOptions {
+  /** Omit DB defaults so template fallback can distinguish unset from override. */
+  omitEmptyDefaults?: boolean;
+  /** Include host-owned columns round-tripped by the embedded Lobu store. */
+  includeHostFields?: boolean;
+}
+
+type AgentSettingsKey = Extract<keyof AgentSettings, string>;
+type RowMapping = readonly [AgentSettingsKey, string];
+type PersistedColumn = {
+  column: string;
+  jsonb?: boolean;
+  save: (settings: Omit<AgentSettings, 'updatedAt'>) => unknown;
+  reset: unknown;
+};
+
+const SETTINGS_COLUMNS = [
+  'model',
+  'model_selection',
+  'provider_model_preferences',
+  'network_config',
+  'egress_config',
+  'nix_config',
+  'mcp_servers',
+  'mcp_install_notified',
+  'soul_md',
+  'user_md',
+  'identity_md',
+  'skills_config',
+  'tools_config',
+  'plugins_config',
+  'auth_profiles',
+  'installed_providers',
+  'verbose_logging',
+  'template_agent_id',
+  'pre_approved_tools',
+  'guardrails',
+  'updated_at',
+] as const;
+
+const JSON_ROW_FIELDS: RowMapping[] = [
+  ['modelSelection', 'model_selection'],
+  ['providerModelPreferences', 'provider_model_preferences'],
+  ['networkConfig', 'network_config'],
+  ['nixConfig', 'nix_config'],
+  ['mcpServers', 'mcp_servers'],
+  ['mcpInstallNotified', 'mcp_install_notified'],
+  ['toolsConfig', 'tools_config'],
+  ['pluginsConfig', 'plugins_config'],
+  ['authProfiles', 'auth_profiles'],
+  ['installedProviders', 'installed_providers'],
+];
+
+const HOST_JSON_ROW_FIELDS: RowMapping[] = [
+  ['egressConfig', 'egress_config'],
+  ['preApprovedTools', 'pre_approved_tools'],
+  ['guardrails', 'guardrails'],
+];
+
+const STRING_ROW_FIELDS: RowMapping[] = [
+  ['soulMd', 'soul_md'],
+  ['userMd', 'user_md'],
+  ['identityMd', 'identity_md'],
+];
+
+const BASE_PERSISTED_COLUMNS: PersistedColumn[] = [
+  { column: 'model', save: (s) => s.model ?? null, reset: null },
+  { column: 'model_selection', jsonb: true, save: (s) => s.modelSelection ?? {}, reset: {} },
+  {
+    column: 'provider_model_preferences',
+    jsonb: true,
+    save: (s) => s.providerModelPreferences ?? {},
+    reset: {},
+  },
+  { column: 'network_config', jsonb: true, save: (s) => s.networkConfig ?? {}, reset: {} },
+  { column: 'nix_config', jsonb: true, save: (s) => s.nixConfig ?? {}, reset: {} },
+  { column: 'mcp_servers', jsonb: true, save: (s) => s.mcpServers ?? {}, reset: {} },
+  {
+    column: 'mcp_install_notified',
+    jsonb: true,
+    save: (s) => s.mcpInstallNotified ?? {},
+    reset: {},
+  },
+  { column: 'soul_md', save: (s) => s.soulMd ?? '', reset: '' },
+  { column: 'user_md', save: (s) => s.userMd ?? '', reset: '' },
+  { column: 'identity_md', save: (s) => s.identityMd ?? '', reset: '' },
+  {
+    column: 'skills_config',
+    jsonb: true,
+    save: (s) => s.skillsConfig ?? { skills: [] },
+    reset: { skills: [] },
+  },
+  { column: 'tools_config', jsonb: true, save: (s) => s.toolsConfig ?? {}, reset: {} },
+  { column: 'plugins_config', jsonb: true, save: (s) => s.pluginsConfig ?? {}, reset: {} },
+  { column: 'auth_profiles', jsonb: true, save: (s) => s.authProfiles ?? [], reset: [] },
+  {
+    column: 'installed_providers',
+    jsonb: true,
+    save: (s) => s.installedProviders ?? [],
+    reset: [],
+  },
+  { column: 'verbose_logging', save: (s) => s.verboseLogging ?? false, reset: false },
+  { column: 'template_agent_id', save: (s) => s.templateAgentId ?? null, reset: null },
+];
+
+const HOST_PERSISTED_COLUMNS: PersistedColumn[] = [
+  { column: 'egress_config', jsonb: true, save: (s) => s.egressConfig ?? {}, reset: {} },
+  { column: 'pre_approved_tools', jsonb: true, save: (s) => s.preApprovedTools ?? [], reset: [] },
+  { column: 'guardrails', jsonb: true, save: (s) => s.guardrails ?? [], reset: [] },
+];
+
+function nonEmptyString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
+
+function nonEmptyObject(value: unknown): unknown | undefined {
+  if (!value || typeof value !== 'object') return undefined;
+  if (Array.isArray(value)) return value.length > 0 ? value : undefined;
+  return Object.keys(value as Record<string, unknown>).length > 0 ? value : undefined;
+}
+
+function maybeDefault(value: unknown, options: AgentSettingsPersistenceOptions): unknown | undefined {
+  return options.omitEmptyDefaults ? nonEmptyObject(value) : (value ?? undefined);
+}
+
+function maybeString(value: unknown, options: AgentSettingsPersistenceOptions): string | undefined {
+  return options.omitEmptyDefaults ? nonEmptyString(value) : ((value as string | null) ?? undefined);
+}
+
+function setIfDefined(out: AgentSettings, key: AgentSettingsKey, value: unknown): void {
+  if (value !== undefined) (out as unknown as Record<string, unknown>)[key] = value;
+}
+
+export function agentSettingsWithDefinedValues(settings: AgentSettings): Partial<AgentSettings> {
+  return Object.fromEntries(
+    Object.entries(settings).filter(([, field]) => field !== undefined)
+  ) as Partial<AgentSettings>;
+}
+
+export function rowToAgentSettings(
+  row: Record<string, any>,
+  options: AgentSettingsPersistenceOptions = {}
+): AgentSettings {
+  const out: AgentSettings = {
+    updatedAt: row.updated_at instanceof Date ? row.updated_at.getTime() : (row.updated_at ?? Date.now()),
+  };
+
+  if (row.model != null) out.model = row.model;
+  for (const [key, column] of JSON_ROW_FIELDS) setIfDefined(out, key, maybeDefault(row[column], options));
+  if (options.includeHostFields) {
+    for (const [key, column] of HOST_JSON_ROW_FIELDS) setIfDefined(out, key, maybeDefault(row[column], options));
+  }
+  for (const [key, column] of STRING_ROW_FIELDS) setIfDefined(out, key, maybeString(row[column], options));
+
+  const skillsConfig = row.skills_config;
+  if (
+    options.omitEmptyDefaults &&
+    skillsConfig &&
+    Array.isArray(skillsConfig.skills) &&
+    skillsConfig.skills.length === 0
+  ) {
+    // Treat `{ skills: [] }` as "not set" so template skills can inherit.
+  } else if (skillsConfig !== undefined && skillsConfig !== null) {
+    out.skillsConfig = skillsConfig;
+  }
+
+  if (row.verbose_logging) out.verboseLogging = true;
+  if (row.template_agent_id) out.templateAgentId = row.template_agent_id;
+  return out;
+}
+
+function persistedColumns(options: AgentSettingsPersistenceOptions): PersistedColumn[] {
+  return options.includeHostFields
+    ? [...BASE_PERSISTED_COLUMNS, ...HOST_PERSISTED_COLUMNS]
+    : BASE_PERSISTED_COLUMNS;
+}
+
+function buildWhere(values: unknown[], agentId: string, orgId: string | null | undefined): string {
+  values.push(agentId);
+  let where = `id = $${values.length}`;
+  if (orgId) {
+    values.push(orgId);
+    where += ` AND organization_id = $${values.length}`;
+  }
+  return where;
+}
+
+async function updateAgentSettingsRow(
+  sql: DbClient,
+  agentId: string,
+  orgId: string | null | undefined,
+  columns: PersistedColumn[],
+  getValue: (column: PersistedColumn) => unknown
+): Promise<void> {
+  const values: unknown[] = [];
+  const assignments = columns.map((column) => {
+    values.push(column.jsonb ? JSON.stringify(getValue(column)) : getValue(column));
+    return `${column.column} = $${values.length}${column.jsonb ? '::jsonb' : ''}`;
+  });
+  values.push(new Date());
+  assignments.push(`updated_at = $${values.length}`);
+
+  const where = buildWhere(values, agentId, orgId);
+  await sql.unsafe(`UPDATE agents SET ${assignments.join(', ')} WHERE ${where}`, values);
+}
+
+export async function loadAgentSettingsFromPg(
+  sql: DbClient,
+  agentId: string,
+  orgId: string | null | undefined,
+  options: AgentSettingsPersistenceOptions = {}
+): Promise<AgentSettings | null> {
+  const values: unknown[] = [];
+  const where = buildWhere(values, agentId, orgId);
+  const rows = await sql.unsafe<Record<string, any>>(
+    `SELECT ${SETTINGS_COLUMNS.join(', ')} FROM agents WHERE ${where}`,
+    values
+  );
+  return rows.length === 0 ? null : rowToAgentSettings(rows[0], options);
+}
+
+export async function saveAgentSettingsToPg(
+  sql: DbClient,
+  agentId: string,
+  settings: Omit<AgentSettings, 'updatedAt'>,
+  orgId: string | null | undefined,
+  options: AgentSettingsPersistenceOptions = {}
+): Promise<void> {
+  await updateAgentSettingsRow(sql, agentId, orgId, persistedColumns(options), (column) =>
+    column.save(settings)
+  );
+}
+
+export async function deleteAgentSettingsFromPg(
+  sql: DbClient,
+  agentId: string,
+  orgId: string | null | undefined,
+  options: AgentSettingsPersistenceOptions = {}
+): Promise<void> {
+  await updateAgentSettingsRow(sql, agentId, orgId, persistedColumns(options), (column) =>
+    column.reset
+  );
+}

--- a/packages/owletto-backend/src/lobu/stores/postgres-stores.ts
+++ b/packages/owletto-backend/src/lobu/stores/postgres-stores.ts
@@ -10,6 +10,12 @@ import {
   type StoredConnection,
 } from '@lobu/core';
 import { getDb } from '../../db/client';
+import {
+  agentSettingsWithDefinedValues,
+  deleteAgentSettingsFromPg,
+  loadAgentSettingsFromPg,
+  saveAgentSettingsToPg,
+} from './agent-settings-persistence';
 import { getOrgId, tryGetOrgId } from './org-context';
 
 type ExtendedAgentConfigStore = AgentConfigStore & {
@@ -65,33 +71,6 @@ export async function touchAgentLastUsed(organizationId: string, agentId: string
   `;
 }
 
-function rowToSettings(row: Record<string, any>): AgentSettings {
-  return {
-    model: row.model ?? undefined,
-    modelSelection: row.model_selection ?? undefined,
-    providerModelPreferences: row.provider_model_preferences ?? undefined,
-    networkConfig: row.network_config ?? undefined,
-    egressConfig: row.egress_config ?? undefined,
-    nixConfig: row.nix_config ?? undefined,
-    mcpServers: row.mcp_servers ?? undefined,
-    mcpInstallNotified: row.mcp_install_notified ?? undefined,
-    soulMd: row.soul_md ?? undefined,
-    userMd: row.user_md ?? undefined,
-    identityMd: row.identity_md ?? undefined,
-    skillsConfig: row.skills_config ?? undefined,
-    toolsConfig: row.tools_config ?? undefined,
-    pluginsConfig: row.plugins_config ?? undefined,
-    authProfiles: row.auth_profiles ?? undefined,
-    installedProviders: row.installed_providers ?? undefined,
-    verboseLogging: row.verbose_logging ?? undefined,
-    templateAgentId: row.template_agent_id ?? undefined,
-    preApprovedTools: row.pre_approved_tools ?? undefined,
-    guardrails: row.guardrails ?? undefined,
-    updatedAt:
-      row.updated_at instanceof Date ? row.updated_at.getTime() : (row.updated_at ?? Date.now()),
-  };
-}
-
 function rowToMetadata(row: Record<string, any>): AgentMetadata {
   return {
     agentId: row.id,
@@ -111,10 +90,6 @@ function rowToMetadata(row: Record<string, any>): AgentMetadata {
         ? row.last_used_at.getTime()
         : (row.last_used_at ?? undefined),
   };
-}
-
-function withDefinedValues<T extends Record<string, any>>(value: T): T {
-  return Object.fromEntries(Object.entries(value).filter(([, field]) => field !== undefined)) as T;
 }
 
 async function resolveTemplateAgentId(
@@ -240,64 +215,17 @@ function rowToGrant(row: Record<string, any>): Grant {
 export function createPostgresAgentConfigStore(): AgentConfigStore {
   const store: ExtendedAgentConfigStore = {
     async getSettings(agentId) {
-      const sql = getDb();
       // Worker gateway calls this without orgContext — agent IDs are globally
       // unique (primary key on id alone), and the worker token already proves
       // authenticity, so falling back to id-only lookup is safe.
-      const orgId = tryGetOrgId();
-      const rows = orgId
-        ? await sql`
-            SELECT model, model_selection, provider_model_preferences,
-                   network_config, egress_config, nix_config, mcp_servers,
-                   mcp_install_notified, soul_md, user_md, identity_md,
-                   skills_config, tools_config, plugins_config, auth_profiles,
-                   installed_providers, verbose_logging, template_agent_id,
-                   pre_approved_tools, guardrails, updated_at
-            FROM agents
-            WHERE id = ${agentId} AND organization_id = ${orgId}
-          `
-        : await sql`
-            SELECT model, model_selection, provider_model_preferences,
-                   network_config, egress_config, nix_config, mcp_servers,
-                   mcp_install_notified, soul_md, user_md, identity_md,
-                   skills_config, tools_config, plugins_config, auth_profiles,
-                   installed_providers, verbose_logging, template_agent_id,
-                   pre_approved_tools, guardrails, updated_at
-            FROM agents
-            WHERE id = ${agentId}
-          `;
-      if (rows.length === 0) return null;
-      return rowToSettings(rows[0]);
+      return loadAgentSettingsFromPg(getDb(), agentId, tryGetOrgId(), {
+        includeHostFields: true,
+      });
     },
     async saveSettings(agentId, settings) {
-      const sql = getDb();
-      const orgId = getOrgId();
-      const now = new Date();
-      await sql`
-        UPDATE agents SET
-          model = ${settings.model ?? null},
-          model_selection = ${sql.json(settings.modelSelection ?? {})},
-          provider_model_preferences = ${sql.json(settings.providerModelPreferences ?? {})},
-          network_config = ${sql.json(settings.networkConfig ?? {})},
-          egress_config = ${sql.json(settings.egressConfig ?? {})},
-          nix_config = ${sql.json(settings.nixConfig ?? {})},
-          mcp_servers = ${sql.json(settings.mcpServers ?? {})},
-          mcp_install_notified = ${sql.json(settings.mcpInstallNotified ?? {})},
-          soul_md = ${settings.soulMd ?? ''},
-          user_md = ${settings.userMd ?? ''},
-          identity_md = ${settings.identityMd ?? ''},
-          skills_config = ${sql.json(settings.skillsConfig ?? { skills: [] })},
-          tools_config = ${sql.json(settings.toolsConfig ?? {})},
-          plugins_config = ${sql.json(settings.pluginsConfig ?? {})},
-          auth_profiles = ${sql.json(settings.authProfiles ?? [])},
-          installed_providers = ${sql.json(settings.installedProviders ?? [])},
-          verbose_logging = ${settings.verboseLogging ?? false},
-          template_agent_id = ${settings.templateAgentId ?? null},
-          pre_approved_tools = ${sql.json(settings.preApprovedTools ?? [])},
-          guardrails = ${sql.json(settings.guardrails ?? [])},
-          updated_at = ${now}
-        WHERE id = ${agentId} AND organization_id = ${orgId}
-      `;
+      await saveAgentSettingsToPg(getDb(), agentId, settings, getOrgId(), {
+        includeHostFields: true,
+      });
     },
     async updateSettings(agentId, updates) {
       const existing = await store.getSettings(agentId);
@@ -305,20 +233,9 @@ export function createPostgresAgentConfigStore(): AgentConfigStore {
       await store.saveSettings(agentId, { ...existing, ...updates, updatedAt: Date.now() });
     },
     async deleteSettings(agentId) {
-      const sql = getDb();
-      const orgId = getOrgId();
-      await sql`
-        UPDATE agents SET
-          model = NULL, model_selection = '{}', provider_model_preferences = '{}',
-          network_config = '{}', egress_config = '{}', nix_config = '{}',
-          mcp_servers = '{}', mcp_install_notified = '{}',
-          soul_md = '', user_md = '', identity_md = '',
-          skills_config = '{"skills": []}', tools_config = '{}', plugins_config = '{}',
-          auth_profiles = '[]', installed_providers = '[]', verbose_logging = false,
-          template_agent_id = NULL, pre_approved_tools = '[]', guardrails = '[]',
-          updated_at = now()
-        WHERE id = ${agentId} AND organization_id = ${orgId}
-      `;
+      await deleteAgentSettingsFromPg(getDb(), agentId, getOrgId(), {
+        includeHostFields: true,
+      });
     },
     async hasSettings(agentId) {
       return store.hasAgent(agentId);
@@ -352,7 +269,7 @@ export function createPostgresAgentConfigStore(): AgentConfigStore {
         localSettings,
         effectiveSettings: {
           ...templateSettings,
-          ...withDefinedValues(localSettings),
+          ...agentSettingsWithDefinedValues(localSettings),
           templateAgentId,
         },
         templateAgentId,

--- a/packages/owletto-backend/src/rest-api.ts
+++ b/packages/owletto-backend/src/rest-api.ts
@@ -30,6 +30,7 @@ import { toJsonSafe } from './utils/json';
 import logger from './utils/logger';
 import { ACTIVE_RUN_STATUSES, runStatusLiteral } from './utils/run-statuses';
 import { getRuntimeInfo } from './utils/runtime-info';
+import { sseStreamResponse } from './utils/sse';
 
 function clamp(value: number, options?: { min?: number; max?: number }): number {
   let result = value;
@@ -598,47 +599,13 @@ export async function publicRestEventsStream(c: Context<{ Bindings: Env }>) {
   const organizationId = await resolvePublicOrganizationId(orgSlug);
   if (!organizationId) return c.json({ error: 'Not found' }, 404);
 
-  const encoder = new TextEncoder();
-  let cleanup: (() => void) | null = null;
-
-  const stream = new ReadableStream({
-    start(controller) {
-      controller.enqueue(encoder.encode('event: connected\ndata: {}\n\n'));
-
-      const unsubscribe = invalidationEmitter.subscribe(organizationId, (event) => {
-        const publicKeys = event.keys.filter((k) => PUBLIC_INVALIDATION_KEYS.has(k));
-        if (publicKeys.length === 0) return;
-        try {
-          const data = JSON.stringify({ ...event, keys: publicKeys });
-          controller.enqueue(encoder.encode(`event: invalidate\ndata: ${data}\n\n`));
-        } catch {
-          // Connection closed
-        }
-      });
-
-      const keepAlive = setInterval(() => {
-        try {
-          controller.enqueue(encoder.encode(': keepalive\n\n'));
-        } catch {
-          clearInterval(keepAlive);
-        }
-      }, 30000);
-
-      cleanup = () => {
-        unsubscribe();
-        clearInterval(keepAlive);
-      };
-    },
-    cancel() {
-      cleanup?.();
-    },
-  });
-
-  c.header('Content-Type', 'text/event-stream');
-  c.header('Cache-Control', 'no-cache');
-  c.header('Connection', 'keep-alive');
-
-  return c.body(stream);
+  return sseStreamResponse(c, (emit) =>
+    invalidationEmitter.subscribe(organizationId, (event) => {
+      const publicKeys = event.keys.filter((key) => PUBLIC_INVALIDATION_KEYS.has(key));
+      if (publicKeys.length === 0) return;
+      emit('invalidate', { ...event, keys: publicKeys });
+    })
+  );
 }
 
 /**

--- a/packages/owletto-backend/src/utils/json.ts
+++ b/packages/owletto-backend/src/utils/json.ts
@@ -32,19 +32,21 @@ export function toJsonSafe<T>(value: T): T {
  * as a string) into a plain object.  Returns `{}` when the input is falsy,
  * not valid JSON, or not a plain object.
  */
-export function parseJsonObject(value: unknown): Record<string, unknown> {
-  if (!value) return {};
+export function parseJsonValue<T>(value: unknown, fallback: T): T {
+  if (value == null) return fallback;
   if (typeof value === 'string') {
     try {
-      const parsed = JSON.parse(value);
-      return parsed && typeof parsed === 'object' && !Array.isArray(parsed)
-        ? (parsed as Record<string, unknown>)
-        : {};
+      return JSON.parse(value) as T;
     } catch {
-      return {};
+      return fallback;
     }
   }
-  return typeof value === 'object' && !Array.isArray(value)
-    ? (value as Record<string, unknown>)
+  return value as T;
+}
+
+export function parseJsonObject(value: unknown): Record<string, unknown> {
+  const parsed = parseJsonValue<unknown>(value, {});
+  return parsed && typeof parsed === 'object' && !Array.isArray(parsed)
+    ? (parsed as Record<string, unknown>)
     : {};
 }

--- a/packages/owletto-backend/src/utils/sse.ts
+++ b/packages/owletto-backend/src/utils/sse.ts
@@ -1,0 +1,47 @@
+import type { Context } from 'hono';
+
+type Unsubscribe = () => void;
+type RegisterSseHandlers = (emit: (event: string, data: unknown) => void) => Unsubscribe;
+
+export function sseStreamResponse(c: Context<any>, register: RegisterSseHandlers): Response {
+  const encoder = new TextEncoder();
+  let cleanup: (() => void) | null = null;
+
+  const stream = new ReadableStream({
+    start(controller) {
+      controller.enqueue(encoder.encode('event: connected\ndata: {}\n\n'));
+
+      const unsubscribe = register((event, data) => {
+        try {
+          controller.enqueue(
+            encoder.encode(`event: ${event}\ndata: ${JSON.stringify(data)}\n\n`)
+          );
+        } catch {
+          // Connection closed.
+        }
+      });
+
+      const keepAlive = setInterval(() => {
+        try {
+          controller.enqueue(encoder.encode(': keepalive\n\n'));
+        } catch {
+          clearInterval(keepAlive);
+        }
+      }, 30000);
+
+      cleanup = () => {
+        unsubscribe();
+        clearInterval(keepAlive);
+      };
+    },
+    cancel() {
+      cleanup?.();
+    },
+  });
+
+  c.header('Content-Type', 'text/event-stream');
+  c.header('Cache-Control', 'no-cache');
+  c.header('Connection', 'keep-alive');
+
+  return c.body(stream);
+}

--- a/packages/owletto-backend/src/utils/streams.ts
+++ b/packages/owletto-backend/src/utils/streams.ts
@@ -1,0 +1,9 @@
+import type { Readable } from 'node:stream';
+
+export async function readStreamToBuffer(fileStream: Readable): Promise<Buffer> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of fileStream) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  }
+  return Buffer.concat(chunks);
+}

--- a/packages/owletto-backend/src/watchers/automation.ts
+++ b/packages/owletto-backend/src/watchers/automation.ts
@@ -12,6 +12,7 @@ import logger from '../utils/logger';
 import { createWatcherRun, type WatcherRunPayload } from '../utils/queue-helpers';
 import { ACTIVE_RUN_STATUSES, runStatusLiteral } from '../utils/run-statuses';
 import { computePendingWindow } from '../utils/window-utils';
+import { buildWatcherDispatchMessage } from './dispatch-message';
 
 type WatcherRunStatus =
   | 'pending'
@@ -399,50 +400,6 @@ export async function materializeDueWatcherRuns(
   };
 }
 
-function buildDispatchMessage(params: {
-  watcherId: number;
-  runId: number;
-  agentId: string;
-  sessionAgentId: string;
-  payload: WatcherRunPayload;
-}): string {
-  const readKnowledgeSince = new Date(params.payload.window_start).toISOString().split('T')[0];
-  const readKnowledgeUntil = new Date(new Date(params.payload.window_end).getTime() - 1)
-    .toISOString()
-    .split('T')[0];
-
-  return [
-    'Run this Owletto watcher now using the Owletto MCP tools.',
-    '',
-    `Watcher ID: ${params.watcherId}`,
-    `Watcher run ID: ${params.runId}`,
-    `Assigned agent ID: ${params.agentId}`,
-    `Session agent ID: ${params.sessionAgentId}`,
-    `Queued window start: ${params.payload.window_start}`,
-    `Queued window end: ${params.payload.window_end}`,
-    `Dispatch source: ${params.payload.dispatch_source}`,
-    '',
-    'Required steps:',
-    `1. Call read_knowledge with {"watcher_id": ${params.watcherId}, "since": "${readKnowledgeSince}", "until": "${readKnowledgeUntil}"}.`,
-    '2. Analyze the returned content using prompt_rendered and extraction_schema.',
-    '3. Call manage_watchers(action="complete_window") with the returned window_token and your extracted_data.',
-    '4. Include this run_metadata object in complete_window exactly, and add any extra provider/job fields you know:',
-    JSON.stringify(
-      {
-        executor: 'lobu-agent',
-        agent_id: params.agentId,
-        watcher_run_id: params.runId,
-        dispatch_source: params.payload.dispatch_source,
-        session_agent_id: params.sessionAgentId,
-      },
-      null,
-      2
-    ),
-    '',
-    'If there is no content, do not fabricate results.',
-  ].join('\n');
-}
-
 async function failWatcherRun(sql: DbClient, runId: number, message: string): Promise<void> {
   await markWatcherRunFailedIdempotent(sql, runId, message);
 }
@@ -597,7 +554,7 @@ async function dispatchWatcherRun(
       headers,
       body: JSON.stringify({
         messageId,
-        content: buildDispatchMessage({
+        content: buildWatcherDispatchMessage({
           watcherId: run.watcher_id,
           runId: run.id,
           agentId: payload.agent_id,

--- a/packages/owletto-backend/src/watchers/classifier-extraction.ts
+++ b/packages/owletto-backend/src/watchers/classifier-extraction.ts
@@ -15,6 +15,7 @@ import {
   isValidEmbedding,
   validateEmbeddingsService,
 } from '../utils/embeddings';
+import { parseJsonValue } from '../utils/json';
 import logger from '../utils/logger';
 import { cosineSimilarity } from '../utils/vector-math';
 
@@ -140,16 +141,6 @@ function parsePostgresArray(value: string | string[] | null | undefined): string
     }
     return trimmed;
   });
-}
-
-/**
- * Parse a JSONB column value that postgres.js may return as a string.
- * Falls back to the provided default when the value is null/undefined.
- */
-function parseJsonb<T>(raw: unknown, fallback: T): T {
-  if (raw == null) return fallback;
-  if (typeof raw === 'string') return JSON.parse(raw) as T;
-  return raw as T;
 }
 
 // ============================================
@@ -496,7 +487,7 @@ async function updateClassifierValues(
 
   for (const classifier of classifiers as any[]) {
     // Parse extraction_config if it's a string (postgres.js may return JSONB as string)
-    const config = parseJsonb<ClassifierDefinition | null>(classifier.extraction_config, null);
+    const config = parseJsonValue<ClassifierDefinition | null>(classifier.extraction_config, null);
 
     logger.debug(
       { slug: classifier.slug, hasConfig: !!config, sourcePath: config?.source_path },
@@ -527,7 +518,7 @@ async function updateClassifierValues(
     }
 
     // Get existing values (parse if string)
-    const existingValues = parseJsonb<AttributeValues>(classifier.attribute_values, {});
+    const existingValues = parseJsonValue<AttributeValues>(classifier.attribute_values, {});
 
     for (const extracted of extractedValues) {
       if (extracted.embedding !== undefined && !isValidEmbedding(extracted.embedding)) {
@@ -704,7 +695,7 @@ async function updateClassifierValues(
     }
 
     // Parse attribute_values if string (postgres.js may return JSONB as string)
-    const existingValues = parseJsonb<AttributeValues>(parentClassifier.attribute_values, {});
+    const existingValues = parseJsonValue<AttributeValues>(parentClassifier.attribute_values, {});
     const updatedValues: AttributeValues = { ...existingValues };
     let hasChanges = false;
 

--- a/packages/owletto-backend/src/watchers/dispatch-message.ts
+++ b/packages/owletto-backend/src/watchers/dispatch-message.ts
@@ -1,0 +1,39 @@
+import type { WatcherRunPayload } from '../utils/queue-helpers';
+
+export function buildWatcherDispatchMessage(params: {
+  watcherId: number; runId: number; agentId: string; sessionAgentId: string; payload: WatcherRunPayload;
+}): string {
+  const { watcherId, runId, agentId, sessionAgentId, payload } = params;
+  const since = new Date(payload.window_start).toISOString().split('T')[0];
+  const until = new Date(new Date(payload.window_end).getTime() - 1).toISOString().split('T')[0];
+  const metadata = JSON.stringify(
+    {
+      executor: 'lobu-agent',
+      agent_id: agentId,
+      watcher_run_id: runId,
+      dispatch_source: payload.dispatch_source,
+      session_agent_id: sessionAgentId,
+    },
+    null,
+    2
+  );
+
+  return `Run this Owletto watcher now using the Owletto MCP tools.
+
+Watcher ID: ${watcherId}
+Watcher run ID: ${runId}
+Assigned agent ID: ${agentId}
+Session agent ID: ${sessionAgentId}
+Queued window start: ${payload.window_start}
+Queued window end: ${payload.window_end}
+Dispatch source: ${payload.dispatch_source}
+
+Required steps:
+1. Call read_knowledge with {"watcher_id": ${watcherId}, "since": "${since}", "until": "${until}"}.
+2. Analyze the returned content using prompt_rendered and extraction_schema.
+3. Call manage_watchers(action="complete_window") with the returned window_token and your extracted_data.
+4. Include this run_metadata object in complete_window exactly, and add any extra provider/job fields you know:
+${metadata}
+
+If there is no content, do not fabricate results.`;
+}


### PR DESCRIPTION
## Summary
- centralize shared agent settings row mapping and Postgres persistence used by the gateway settings store and embedded Lobu store
- extract duplicate SSE stream and stream-to-buffer helpers
- extract watcher dispatch prompt construction and reuse the shared JSON parsing helper
- rename local agent platform variables in platform routes without changing DB/store compatibility

## Validation
- `cd packages/core && bun run build`
- `cd packages/owletto-sdk && bun run build`
- `cd packages/owletto-backend && bun run typecheck`
- `make build-packages`
- pre-commit: `biome check --config-path config/biome.config.json --write .` and `tsc --noEmit`

## Diff
- 13 files changed, 435 insertions(+), 506 deletions(-)
- Net: -71 LOC

## Notes
- I dropped the internal tool catalog cleanup from this PR because it made ownership clearer but added lines; this PR should be judged by actual deletion/consolidation.
- Targeted agent settings tests reported all assertions passing, but Bun exited 99 after completion in this local worktree; I did not include it as a passing validation line.