### PR TITLE
feat(watchers): edit propagates across the group; snapshot version_id on runs

### DIFF
--- a/packages/owletto-backend/src/__tests__/integration/watchers/group-edit.test.ts
+++ b/packages/owletto-backend/src/__tests__/integration/watchers/group-edit.test.ts
@@ -1,0 +1,322 @@
+/**
+ * Group-edit refactor contracts.
+ *
+ * After this refactor:
+ *   - Assigning a template to another entity (`create_from_version`) shares
+ *     the existing `watcher_versions` row instead of duplicating it.
+ *   - Editing one assignment via `create_version` cascades to every watcher
+ *     in the group: same `current_version_id`, same `name`.
+ *   - `set_reaction_script` cascades across the group.
+ *   - A run snapshots `current_version_id` at creation; if the group is
+ *     edited mid-run, `complete_window` still validates against the
+ *     snapshot, not the new version.
+ *   - Hard-deleting an entity that owns the group root transfers
+ *     `watcher_versions` ownership to a surviving sibling so the cascade
+ *     doesn't wipe the version chain out from under the group.
+ */
+
+import { beforeEach, describe, expect, it } from 'vitest';
+import type { Env } from '../../../index';
+import { manageWatchers } from '../../../tools/admin/manage_watchers';
+import type { ToolContext } from '../../../tools/registry';
+import { createWatcherRun } from '../../../utils/queue-helpers';
+import { cleanupTestDatabase, getTestDb } from '../../setup/test-db';
+import { createTestEntity } from '../../setup/test-fixtures';
+import { TestWorkspace } from '../../setup/test-workspace';
+
+function ownerCtx(workspace: TestWorkspace): ToolContext {
+  return {
+    organizationId: workspace.org.id,
+    userId: workspace.users.owner.id,
+    memberRole: 'owner',
+    agentId: null,
+    isAuthenticated: true,
+    clientId: null,
+    scopes: ['mcp:read', 'mcp:write', 'mcp:admin'],
+    tokenType: 'oauth',
+    scopedToOrg: true,
+    allowCrossOrg: false,
+  };
+}
+
+async function seedRootWatcher(workspace: TestWorkspace, suffix: string) {
+  const entity = await createTestEntity({
+    name: `Root Entity ${suffix}`,
+    organization_id: workspace.org.id,
+    created_by: workspace.users.owner.id,
+  });
+  const watcher = (await workspace.owner.watchers.create({
+    entity_id: entity.id,
+    slug: `digest-${suffix}`,
+    name: `Digest ${suffix}`,
+    prompt: 'Summarize content for {{entities}}.',
+    extraction_schema: {
+      type: 'object',
+      properties: { summary: { type: 'string' } },
+      required: ['summary'],
+    },
+    schedule: '0 9 * * *',
+  })) as { watcher_id: string };
+  return { watcherId: Number(watcher.watcher_id), entityId: entity.id };
+}
+
+async function assignToEntity(
+  workspace: TestWorkspace,
+  versionId: number,
+  entityId: number
+): Promise<number> {
+  const result = (await manageWatchers(
+    {
+      action: 'create_from_version',
+      version_id: String(versionId),
+      entity_ids: [entityId],
+    } as never,
+    {} as Env,
+    ownerCtx(workspace)
+  )) as { created: Array<{ watcher_id: string }> };
+  return Number(result.created[0].watcher_id);
+}
+
+describe('watcher group edit contract', () => {
+  beforeEach(async () => {
+    await cleanupTestDatabase();
+  });
+
+  it('create_from_version reuses the source version row instead of duplicating', async () => {
+    const sql = getTestDb();
+    const workspace = await TestWorkspace.create({ name: 'Group Reuse Org' });
+    const { watcherId: rootId } = await seedRootWatcher(workspace, 'reuse');
+
+    const [rootRow] = await sql`
+      SELECT current_version_id, watcher_group_id FROM watchers WHERE id = ${rootId}
+    `;
+    const rootVersionId = Number(rootRow.current_version_id);
+    const groupId = Number(rootRow.watcher_group_id);
+    expect(groupId).toBe(rootId);
+
+    const sibling1Entity = await createTestEntity({
+      name: 'Sibling 1',
+      organization_id: workspace.org.id,
+      created_by: workspace.users.owner.id,
+    });
+    const sibling2Entity = await createTestEntity({
+      name: 'Sibling 2',
+      organization_id: workspace.org.id,
+      created_by: workspace.users.owner.id,
+    });
+
+    const sibling1Id = await assignToEntity(workspace, rootVersionId, sibling1Entity.id);
+    const sibling2Id = await assignToEntity(workspace, rootVersionId, sibling2Entity.id);
+
+    // All three watchers should point at the SAME version row.
+    const rows = await sql`
+      SELECT id, current_version_id, watcher_group_id
+      FROM watchers WHERE id IN (${rootId}, ${sibling1Id}, ${sibling2Id})
+      ORDER BY id
+    `;
+    expect(rows).toHaveLength(3);
+    for (const row of rows) {
+      expect(Number(row.current_version_id)).toBe(rootVersionId);
+      expect(Number(row.watcher_group_id)).toBe(groupId);
+    }
+
+    // watcher_versions row count for this group is exactly 1, not 3.
+    const versionCount = await sql`
+      SELECT COUNT(*)::int as n FROM watcher_versions WHERE watcher_id = ${groupId}
+    `;
+    expect(Number(versionCount[0].n)).toBe(1);
+  });
+
+  it('create_from_version copies the reaction script onto each new assignment', async () => {
+    const sql = getTestDb();
+    const workspace = await TestWorkspace.create({ name: 'Group Script Copy Org' });
+    const { watcherId: rootId } = await seedRootWatcher(workspace, 'script-copy');
+
+    await manageWatchers(
+      {
+        action: 'set_reaction_script',
+        watcher_id: String(rootId),
+        reaction_script: 'export default async function reaction() { return; }',
+      } as never,
+      {} as Env,
+      ownerCtx(workspace)
+    );
+
+    const [rootRow] = await sql`
+      SELECT current_version_id FROM watchers WHERE id = ${rootId}
+    `;
+    const rootVersionId = Number(rootRow.current_version_id);
+
+    const siblingEntity = await createTestEntity({
+      name: 'Script Copy Sibling',
+      organization_id: workspace.org.id,
+      created_by: workspace.users.owner.id,
+    });
+    const siblingId = await assignToEntity(workspace, rootVersionId, siblingEntity.id);
+
+    const [siblingRow] = await sql`
+      SELECT reaction_script, reaction_script_compiled FROM watchers WHERE id = ${siblingId}
+    `;
+    expect(siblingRow.reaction_script).toContain('reaction');
+    expect(siblingRow.reaction_script_compiled).not.toBeNull();
+  });
+
+  it('create_version cascades current_version_id and name across the whole group', async () => {
+    const sql = getTestDb();
+    const workspace = await TestWorkspace.create({ name: 'Group Cascade Org' });
+    const { watcherId: rootId } = await seedRootWatcher(workspace, 'cascade');
+    const [rootBefore] = await sql`
+      SELECT current_version_id FROM watchers WHERE id = ${rootId}
+    `;
+    const sibling1Entity = await createTestEntity({
+      name: 'Cascade Sibling 1',
+      organization_id: workspace.org.id,
+      created_by: workspace.users.owner.id,
+    });
+    const sibling2Entity = await createTestEntity({
+      name: 'Cascade Sibling 2',
+      organization_id: workspace.org.id,
+      created_by: workspace.users.owner.id,
+    });
+    const sibling1Id = await assignToEntity(
+      workspace,
+      Number(rootBefore.current_version_id),
+      sibling1Entity.id
+    );
+    const sibling2Id = await assignToEntity(
+      workspace,
+      Number(rootBefore.current_version_id),
+      sibling2Entity.id
+    );
+
+    // Edit through the SIBLING — group cascade should still apply, not just to the sibling.
+    const result = (await manageWatchers(
+      {
+        action: 'create_version',
+        watcher_id: String(sibling1Id),
+        prompt: 'Cascaded prompt v2.',
+        name: 'Cascaded Name v2',
+        change_notes: 'group cascade',
+      } as never,
+      {} as Env,
+      ownerCtx(workspace)
+    )) as { version_id: string; version: number };
+    const newVersionId = Number(result.version_id);
+    expect(result.version).toBe(2);
+
+    const rows = await sql`
+      SELECT id, current_version_id, name, version
+      FROM watchers WHERE id IN (${rootId}, ${sibling1Id}, ${sibling2Id})
+      ORDER BY id
+    `;
+    for (const row of rows) {
+      expect(Number(row.current_version_id)).toBe(newVersionId);
+      expect(row.name).toBe('Cascaded Name v2');
+      expect(Number(row.version)).toBe(2);
+    }
+
+    // The new version row is owned by the group root, not the sibling.
+    const [versionRow] = await sql`
+      SELECT watcher_id, prompt FROM watcher_versions WHERE id = ${newVersionId}
+    `;
+    expect(Number(versionRow.watcher_id)).toBe(rootId);
+    expect(versionRow.prompt).toBe('Cascaded prompt v2.');
+  });
+
+  it('set_reaction_script cascades to every watcher in the group', async () => {
+    const sql = getTestDb();
+    const workspace = await TestWorkspace.create({ name: 'Group Script Org' });
+    const { watcherId: rootId } = await seedRootWatcher(workspace, 'script-cascade');
+    const [rootBefore] = await sql`
+      SELECT current_version_id FROM watchers WHERE id = ${rootId}
+    `;
+    const siblingEntity = await createTestEntity({
+      name: 'Script Cascade Sibling',
+      organization_id: workspace.org.id,
+      created_by: workspace.users.owner.id,
+    });
+    const siblingId = await assignToEntity(
+      workspace,
+      Number(rootBefore.current_version_id),
+      siblingEntity.id
+    );
+
+    await manageWatchers(
+      {
+        action: 'set_reaction_script',
+        watcher_id: String(rootId),
+        reaction_script: 'export default async function reaction() { /* v1 */ }',
+      } as never,
+      {} as Env,
+      ownerCtx(workspace)
+    );
+
+    let rows = await sql`
+      SELECT id, reaction_script FROM watchers WHERE id IN (${rootId}, ${siblingId}) ORDER BY id
+    `;
+    expect(rows[0].reaction_script).toContain('v1');
+    expect(rows[1].reaction_script).toContain('v1');
+
+    // Calling through the sibling (not the root) — should still cascade.
+    await manageWatchers(
+      {
+        action: 'set_reaction_script',
+        watcher_id: String(siblingId),
+        reaction_script: '',
+      } as never,
+      {} as Env,
+      ownerCtx(workspace)
+    );
+
+    rows = await sql`
+      SELECT id, reaction_script FROM watchers WHERE id IN (${rootId}, ${siblingId}) ORDER BY id
+    `;
+    expect(rows[0].reaction_script).toBeNull();
+    expect(rows[1].reaction_script).toBeNull();
+  });
+
+  it('createWatcherRun snapshots current_version_id; mid-run group edit does not change the run', async () => {
+    const sql = getTestDb();
+    const workspace = await TestWorkspace.create({ name: 'Run Snapshot Org' });
+    const { watcherId: rootId } = await seedRootWatcher(workspace, 'snapshot');
+
+    const [rootBefore] = await sql`
+      SELECT current_version_id FROM watchers WHERE id = ${rootId}
+    `;
+    const snapshotVersionId = Number(rootBefore.current_version_id);
+
+    const queued = await createWatcherRun({
+      organizationId: workspace.org.id,
+      watcherId: rootId,
+      agentId: 'snapshot-agent',
+      windowStart: new Date(Date.now() - 60 * 60 * 1000).toISOString(),
+      windowEnd: new Date().toISOString(),
+      dispatchSource: 'scheduled',
+    });
+
+    // Group edit lands AFTER the run was created — current_version_id moves
+    // to v2 on the watchers row, but the run's payload still holds v1.
+    await manageWatchers(
+      {
+        action: 'create_version',
+        watcher_id: String(rootId),
+        prompt: 'Post-run edit.',
+        change_notes: 'after run created',
+      } as never,
+      {} as Env,
+      ownerCtx(workspace)
+    );
+
+    const [runRow] = await sql`
+      SELECT (approved_input->>'version_id')::bigint as version_id
+      FROM runs WHERE id = ${queued.runId}
+    `;
+    expect(Number(runRow.version_id)).toBe(snapshotVersionId);
+
+    // The watcher itself has moved on — confirms the snapshot diverges.
+    const [watcherAfter] = await sql`
+      SELECT current_version_id FROM watchers WHERE id = ${rootId}
+    `;
+    expect(Number(watcherAfter.current_version_id)).not.toBe(snapshotVersionId);
+  });
+});

--- a/packages/owletto-backend/src/__tests__/integration/watchers/group-edit.test.ts
+++ b/packages/owletto-backend/src/__tests__/integration/watchers/group-edit.test.ts
@@ -20,6 +20,7 @@ import type { Env } from '../../../index';
 import { manageWatchers } from '../../../tools/admin/manage_watchers';
 import type { ToolContext } from '../../../tools/registry';
 import { createWatcherRun } from '../../../utils/queue-helpers';
+import { parseWatcherRunPayload } from '../../../watchers/automation';
 import { cleanupTestDatabase, getTestDb } from '../../setup/test-db';
 import { createTestEntity } from '../../setup/test-fixtures';
 import { TestWorkspace } from '../../setup/test-workspace';
@@ -318,5 +319,129 @@ describe('watcher group edit contract', () => {
       SELECT current_version_id FROM watchers WHERE id = ${rootId}
     `;
     expect(Number(watcherAfter.current_version_id)).not.toBe(snapshotVersionId);
+  });
+
+  it('parseWatcherRunPayload returns the snapshot version_id', async () => {
+    const sql = getTestDb();
+    const workspace = await TestWorkspace.create({ name: 'Payload Parse Org' });
+    const { watcherId: rootId } = await seedRootWatcher(workspace, 'parse');
+
+    const queued = await createWatcherRun({
+      organizationId: workspace.org.id,
+      watcherId: rootId,
+      agentId: 'parse-agent',
+      windowStart: new Date().toISOString(),
+      windowEnd: new Date().toISOString(),
+      dispatchSource: 'scheduled',
+    });
+
+    const [run] = await sql`SELECT approved_input FROM runs WHERE id = ${queued.runId}`;
+    const parsed = parseWatcherRunPayload(run.approved_input);
+    expect(parsed).not.toBeNull();
+    expect(parsed!.version_id).not.toBeNull();
+    expect(Number.isFinite(parsed!.version_id as number)).toBe(true);
+  });
+
+  it('parseWatcherRunPayload tolerates legacy runs missing version_id', () => {
+    const legacyPayload = {
+      watcher_id: 1,
+      agent_id: 'a',
+      window_start: '2024-01-01',
+      window_end: '2024-01-02',
+      dispatch_source: 'scheduled',
+    };
+    const parsed = parseWatcherRunPayload(legacyPayload);
+    expect(parsed).not.toBeNull();
+    expect(parsed!.version_id).toBeNull();
+  });
+
+  it('complete_window scopes the run lookup by watcher_id', async () => {
+    const sql = getTestDb();
+    const workspace = await TestWorkspace.create({ name: 'Run Scope Org' });
+    const { watcherId: aId } = await seedRootWatcher(workspace, 'scope-a');
+    const { watcherId: bId } = await seedRootWatcher(workspace, 'scope-b');
+
+    // Create a run for watcher A. The run's snapshot version is A's current.
+    const aRun = await createWatcherRun({
+      organizationId: workspace.org.id,
+      watcherId: aId,
+      agentId: 'a-agent',
+      windowStart: new Date(Date.now() - 60 * 60 * 1000).toISOString(),
+      windowEnd: new Date().toISOString(),
+      dispatchSource: 'scheduled',
+    });
+
+    // Now bump A's current_version_id to v2 — the snapshot in aRun still
+    // points at v1, but if complete_window for B mistakenly uses aRun's id
+    // it must NOT pick up A's v1 snapshot.
+    await manageWatchers(
+      {
+        action: 'create_version',
+        watcher_id: String(aId),
+        prompt: "A's v2",
+        change_notes: 'bump A',
+      } as never,
+      {} as Env,
+      ownerCtx(workspace)
+    );
+
+    // Confirm the run lookup we use in complete_window won't return A's
+    // snapshot when scoped by watcher_id = B.
+    const [scopedToB] = await sql`
+      SELECT (approved_input->>'version_id')::bigint AS version_id
+      FROM runs WHERE id = ${aRun.runId} AND watcher_id = ${bId}
+      LIMIT 1
+    `;
+    expect(scopedToB).toBeUndefined();
+    const [scopedToA] = await sql`
+      SELECT (approved_input->>'version_id')::bigint AS version_id
+      FROM runs WHERE id = ${aRun.runId} AND watcher_id = ${aId}
+      LIMIT 1
+    `;
+    expect(scopedToA).toBeDefined();
+    expect(Number(scopedToA.version_id)).toBeGreaterThan(0);
+  });
+
+  it('serializes concurrent create_version calls on the same group', async () => {
+    const sql = getTestDb();
+    const workspace = await TestWorkspace.create({ name: 'Concurrent Edit Org' });
+    const { watcherId: rootId } = await seedRootWatcher(workspace, 'concurrent');
+
+    // Fire two create_version calls in parallel. The advisory lock should
+    // serialize them; one ends up at v2, the other at v3 — neither errors,
+    // neither collides on (watcher_id, version) unique index.
+    const [r1, r2] = await Promise.all([
+      manageWatchers(
+        {
+          action: 'create_version',
+          watcher_id: String(rootId),
+          prompt: 'edit A',
+          change_notes: 'A',
+        } as never,
+        {} as Env,
+        ownerCtx(workspace)
+      ),
+      manageWatchers(
+        {
+          action: 'create_version',
+          watcher_id: String(rootId),
+          prompt: 'edit B',
+          change_notes: 'B',
+        } as never,
+        {} as Env,
+        ownerCtx(workspace)
+      ),
+    ]);
+
+    const versions = [r1, r2]
+      .map((r) => Number((r as { version: number }).version))
+      .sort((a, b) => a - b);
+    expect(versions).toEqual([2, 3]);
+
+    const versionRows = await sql`
+      SELECT version FROM watcher_versions WHERE watcher_id = ${rootId} ORDER BY version
+    `;
+    const stored = versionRows.map((r) => Number(r.version));
+    expect(stored).toEqual([1, 2, 3]);
   });
 });

--- a/packages/owletto-backend/src/tools/admin/manage_watchers.ts
+++ b/packages/owletto-backend/src/tools/admin/manage_watchers.ts
@@ -445,6 +445,12 @@ export const ManageWatchersSchema = Type.Object({
         '[complete_window] Optional structured execution metadata for provenance (provider, session id, parameters, etc.).',
     })
   ),
+  template_version_id: Type.Optional(
+    Type.Number({
+      description:
+        "[complete_window] Pin to a specific watcher_versions.id. Workers receive this from the run dispatch payload (snapshotted from current_version_id at run-creation) and pass it back here so validation uses the same version that produced the extraction. Defaults to the run row's snapshot if available, else the watcher's current_version_id.",
+    })
+  ),
 
   // Fields for action="set_reaction_script"
   reaction_script: Type.Optional(
@@ -1346,19 +1352,31 @@ async function handleCompleteWindow(
   // ============================================
   // Resolve the version this run was started against. The agent extracted
   // data using that version's prompt/schema; we MUST validate against the
-  // same version even if the group has been edited mid-run. Fall back to
-  // the watcher's current_version_id only when called outside a run.
-  let snapshotVersionId: number | null = null;
-  if (watcherRunId != null) {
+  // same version even if the group has been edited mid-run.
+  //
+  // Resolution order:
+  //   1. explicit args.template_version_id (the agent passes this back)
+  //   2. runs.approved_input.version_id (snapshotted at run-creation)
+  //   3. watchers.current_version_id (fallback for callers outside a run)
+  //
+  // The run lookup is scoped by watcher_id so a wrong/stale watcher_run_id
+  // can't read another watcher's snapshot.
+  let snapshotVersionId: number | null =
+    typeof args.template_version_id === 'number' ? args.template_version_id : null;
+  if (snapshotVersionId == null && watcherRunId != null) {
     const runRows = await sql`
       SELECT (approved_input->>'version_id')::bigint AS version_id
-      FROM runs WHERE id = ${watcherRunId} LIMIT 1
+      FROM runs
+      WHERE id = ${watcherRunId} AND watcher_id = ${watcherId}
+      LIMIT 1
     `;
     if (runRows.length > 0 && runRows[0].version_id != null) {
       snapshotVersionId = Number(runRows[0].version_id);
     }
   }
 
+  // The version row must belong to this watcher's group — prevents pinning
+  // to another group's version via a forged template_version_id arg.
   const watcherRows = await sql`
     SELECT
       i.id,
@@ -1374,6 +1392,7 @@ async function handleCompleteWindow(
     FROM watchers i
     LEFT JOIN watcher_versions wv
       ON wv.id = COALESCE(${snapshotVersionId}::bigint, i.current_version_id)
+     AND wv.watcher_id = i.watcher_group_id
     WHERE i.id = ${watcherId}
     LIMIT 1
   `;
@@ -1720,6 +1739,9 @@ async function handleCompleteWindow(
 
     let runMarkedCompleted = false;
     if (watcherRunId && Number.isFinite(watcherRunId)) {
+      // Scope by watcher_id so a wrong/stale watcher_run_id (passed in
+      // run_metadata) cannot mark another watcher's run completed against
+      // this watcher's window.
       const completedRows = await tx`
         UPDATE runs
         SET status = 'completed',
@@ -1727,6 +1749,7 @@ async function handleCompleteWindow(
             completed_at = current_timestamp,
             error_message = NULL
         WHERE id = ${watcherRunId}
+          AND watcher_id = ${watcherId}
           AND run_type = 'watcher'
           AND status IN ('running', 'claimed')
         RETURNING id
@@ -2256,7 +2279,7 @@ async function handleCreateVersion(
   // identify the group and to apply the per-assignment writes (sources,
   // schedule, scheduler_client_id) to that specific row.
   const watcherRows = await sql`
-    SELECT i.id, i.version, i.current_version_id, i.watcher_group_id
+    SELECT i.id, i.version, i.current_version_id, i.watcher_group_id, i.sources
     FROM watchers i WHERE i.id = ${args.watcher_id}
   `;
   if (watcherRows.length === 0) {
@@ -2290,9 +2313,16 @@ async function handleCreateVersion(
   const extractionSchema =
     parseJsonInput<Record<string, unknown>>(args.extraction_schema, 'extraction_schema') ??
     normalizeStoredJsonField(prev.extraction_schema, {} as Record<string, unknown>);
+  // Sources are per-assignment now. When the caller omits args.sources we
+  // keep the seed watcher's existing sources; we deliberately do not fall
+  // back to prev.version_sources from the prior version row, because
+  // version_sources is no longer written and is a vestigial column.
   const sources =
     args.sources ??
-    normalizeStoredJsonField(prev.version_sources, [] as Array<{ name: string; query: string }>);
+    normalizeStoredJsonField(
+      watcherRows[0].sources,
+      [] as Array<{ name: string; query: string }>
+    );
   const jsonTemplate =
     parseJsonInput<unknown>(args.json_template, 'json_template') ??
     normalizeStoredJsonField(prev.json_template, undefined as unknown);
@@ -2333,10 +2363,32 @@ async function handleCreateVersion(
 
   const createdBy = ctx.userId ?? 'system';
   const versionId = await getNextWatcherVersionId(sql);
+  let lockedNextVersion = nextVersion;
   await sql.begin(async (tx) => {
+    // Serialize concurrent create_version calls on the same group. The
+    // unique (watcher_id, version) index would otherwise reject one of two
+    // simultaneous N+1 inserts and surface as a 500. The advisory lock is
+    // tx-scoped (auto-released on commit/rollback) and keyed by group id,
+    // so unrelated groups are unaffected.
+    await tx`SELECT pg_advisory_xact_lock(hashtext('watcher_create_version'), ${groupId})`;
+
+    // Re-resolve the latest version under the lock so we don't race with a
+    // call that already committed N+1 while we were computing nextVersion.
+    const latestRows = await tx`
+      SELECT MAX(version) AS v FROM watcher_versions WHERE watcher_id = ${groupId}
+    `;
+    lockedNextVersion =
+      latestRows.length > 0 && latestRows[0].v != null ? Number(latestRows[0].v) + 1 : nextVersion;
+
     // The new version row is owned by the group root, not the assignment
     // the caller named. Every watcher in the group will later point at
     // this row via current_version_id.
+    // version_sources is intentionally NULL on the new version row: sources
+    // are per-assignment now, so storing one assignment's sources in the
+    // shared version row would let one assignment's source list override
+    // every other assignment's sources via get_content's preference order.
+    // get_content falls through to watchers.sources when version_sources is
+    // empty, which is the right per-assignment behavior.
     await tx`
       INSERT INTO watcher_versions (
         id, watcher_id, version, name, description,
@@ -2345,10 +2397,10 @@ async function handleCreateVersion(
         condensation_prompt, condensation_window_count,
         reactions_guidance, change_notes, created_by, created_at
       ) VALUES (
-        ${versionId}, ${groupId}, ${nextVersion},
+        ${versionId}, ${groupId}, ${lockedNextVersion},
         ${args.name ?? (prev.name as string) ?? 'Watcher'},
         ${args.description !== undefined ? (args.description ?? null) : ((prev.description as string) ?? null)},
-        ${prompt}, ${toJsonParam(tx, extractionSchema)}, ${toJsonParam(tx, sources)},
+        ${prompt}, ${toJsonParam(tx, extractionSchema)}, NULL,
         ${toJsonParam(tx, jsonTemplate)}, ${toJsonParam(tx, keyingConfig)}, ${toJsonParam(tx, classifiers)},
         ${args.condensation_prompt ?? (prev.condensation_prompt as string) ?? null},
         ${args.condensation_window_count ?? (prev.condensation_window_count as number) ?? null},
@@ -2372,7 +2424,7 @@ async function handleCreateVersion(
         UPDATE watchers
         SET
           current_version_id = ${versionId},
-          version = ${nextVersion},
+          version = ${lockedNextVersion},
           name = ${args.name ?? (prev.name as string)},
           updated_at = NOW()
         WHERE watcher_group_id = ${groupId}
@@ -2395,7 +2447,7 @@ async function handleCreateVersion(
     action: 'create_version',
     watcher_id: args.watcher_id,
     version_id: String(versionId),
-    version: nextVersion,
+    version: lockedNextVersion,
     previous_version: previousVersion,
   };
 }

--- a/packages/owletto-backend/src/tools/admin/manage_watchers.ts
+++ b/packages/owletto-backend/src/tools/admin/manage_watchers.ts
@@ -1046,10 +1046,14 @@ async function handleCreateFromVersion(
     throw new Error('entity_ids is required for create_from_version');
   }
 
-  // Fetch the source version
+  // Fetch the source version + the source watcher's reaction script.
+  // Reaction script lives on the watchers row, not on watcher_versions, so
+  // it has to be copied explicitly when assigning the template to a new
+  // entity. Without this copy the new assignment would have no reactions.
   const versionRows = await sql`
     SELECT wv.*, w.organization_id, w.schedule, w.sources, w.agent_id, w.scheduler_client_id,
-           w.model_config, w.tags, w.watcher_group_id
+           w.model_config, w.tags, w.watcher_group_id,
+           w.reaction_script, w.reaction_script_compiled
     FROM watcher_versions wv
     JOIN watchers w ON w.id = wv.watcher_id
     WHERE wv.id = ${args.version_id}
@@ -1080,48 +1084,36 @@ async function handleCreateFromVersion(
     const watcherSlug = `${version.name}-${entity.slug}`.toLowerCase().replace(/[^a-z0-9-]/g, '-');
 
     const watcherId = await getNextNumericId(sql, 'watchers');
-    const newVersionId = await getNextWatcherVersionId(sql);
     const sources = version.version_sources ?? version.sources ?? [];
+    // The new assignment shares the source's existing watcher_versions row
+    // rather than getting its own duplicate copy. version_id (the arg) is
+    // the row in watcher_versions we're cloning from; that becomes the
+    // assignment's current_version_id directly. The version row itself is
+    // owned by the group root (watcher_group_id), so all assignments in
+    // the group point at the same chain.
+    const sharedVersionId = Number(args.version_id);
+    const groupId = (version.watcher_group_id ?? version.watcher_id) as number;
 
-    await sql.begin(async (tx) => {
-      await tx`
-        INSERT INTO watchers (
-          id, name, slug, organization_id, entity_ids,
-          schedule, next_run_at, agent_id, scheduler_client_id, model_config, sources, version,
-          current_version_id, tags, status, created_by, created_at, updated_at,
-          watcher_group_id, source_watcher_id
-        ) VALUES (
-          ${watcherId}, ${watcherName}, ${watcherSlug}, ${organizationId},
-          ${`{${entityId}}`}::bigint[],
-          ${version.schedule ?? null}, ${version.schedule ? nextRunAt(version.schedule as string) : null},
-          ${version.agent_id ?? null}, ${version.scheduler_client_id ?? null},
-          ${toJsonParam(tx, version.model_config)}, ${toJsonParam(tx, sources)},
-          1, NULL, ${toTextArrayParam((version.tags as string[]) || [])}::text[],
-          'active', ${createdBy}, NOW(), NOW(),
-          ${version.watcher_group_id ?? version.watcher_id}, ${version.watcher_id}
-        )
-      `;
-
-      await tx`
-        INSERT INTO watcher_versions (
-          id, watcher_id, version, name, description,
-          prompt, extraction_schema, version_sources,
-          json_template, keying_config, classifiers,
-          condensation_prompt, condensation_window_count,
-          reactions_guidance, change_notes, created_by, created_at
-        ) VALUES (
-          ${newVersionId}, ${watcherId}, 1, ${watcherName}, ${version.description ?? null},
-          ${version.prompt}, ${toJsonParam(tx, version.extraction_schema)}, ${toJsonParam(tx, sources)},
-          ${toJsonParam(tx, version.json_template)}, ${toJsonParam(tx, version.keying_config)},
-          ${toJsonParam(tx, version.classifiers)},
-          ${version.condensation_prompt ?? null}, ${version.condensation_window_count ?? null},
-          ${version.reactions_guidance ?? null}, ${'Created from version ' + args.version_id},
-          ${createdBy}, NOW()
-        )
-      `;
-
-      await tx`UPDATE watchers SET current_version_id = ${newVersionId} WHERE id = ${watcherId}`;
-    });
+    await sql`
+      INSERT INTO watchers (
+        id, name, slug, organization_id, entity_ids,
+        schedule, next_run_at, agent_id, scheduler_client_id, model_config, sources, version,
+        current_version_id, tags, status, created_by, created_at, updated_at,
+        watcher_group_id, source_watcher_id,
+        reaction_script, reaction_script_compiled
+      ) VALUES (
+        ${watcherId}, ${watcherName}, ${watcherSlug}, ${organizationId},
+        ${`{${entityId}}`}::bigint[],
+        ${version.schedule ?? null}, ${version.schedule ? nextRunAt(version.schedule as string) : null},
+        ${version.agent_id ?? null}, ${version.scheduler_client_id ?? null},
+        ${toJsonParam(sql, version.model_config)}, ${toJsonParam(sql, sources)},
+        ${(version.version as number) ?? 1}, ${sharedVersionId}, ${toTextArrayParam((version.tags as string[]) || [])}::text[],
+        'active', ${createdBy}, NOW(), NOW(),
+        ${groupId}, ${version.watcher_id},
+        ${(version.reaction_script as string | null) ?? null},
+        ${(version.reaction_script_compiled as string | null) ?? null}
+      )
+    `;
 
     created.push({ watcher_id: String(watcherId), entity_id: entityId, name: watcherName });
   }
@@ -1352,19 +1344,36 @@ async function handleCompleteWindow(
   // ============================================
   // STEP 2: Combined query - watcher + classifiers + template schema
   // ============================================
+  // Resolve the version this run was started against. The agent extracted
+  // data using that version's prompt/schema; we MUST validate against the
+  // same version even if the group has been edited mid-run. Fall back to
+  // the watcher's current_version_id only when called outside a run.
+  let snapshotVersionId: number | null = null;
+  if (watcherRunId != null) {
+    const runRows = await sql`
+      SELECT (approved_input->>'version_id')::bigint AS version_id
+      FROM runs WHERE id = ${watcherRunId} LIMIT 1
+    `;
+    if (runRows.length > 0 && runRows[0].version_id != null) {
+      snapshotVersionId = Number(runRows[0].version_id);
+    }
+  }
+
   const watcherRows = await sql`
     SELECT
       i.id,
       i.schedule,
       i.entity_ids,
       i.organization_id,
+      wv.id as version_id,
       wv.prompt as prompt,
       wv.extraction_schema as extraction_schema,
       wv.version_sources as version_sources,
       wv.classifiers as classifiers,
       wv.keying_config
     FROM watchers i
-    LEFT JOIN watcher_versions wv ON i.current_version_id = wv.id
+    LEFT JOIN watcher_versions wv
+      ON wv.id = COALESCE(${snapshotVersionId}::bigint, i.current_version_id)
     WHERE i.id = ${watcherId}
     LIMIT 1
   `;
@@ -1397,6 +1406,8 @@ async function handleCompleteWindow(
     extraction_config: r.extraction_config as any,
   }));
 
+  const resolvedVersionId =
+    watcherRows[0].version_id != null ? Number(watcherRows[0].version_id) : null;
   const templateData = {
     prompt: watcherRows[0].prompt ?? undefined,
     extraction_schema: parseJson(watcherRows[0].extraction_schema) ?? undefined,
@@ -1459,11 +1470,11 @@ async function handleCompleteWindow(
     const sourceIds = tokenSourceWindowIds.map(Number);
     await sql`
       INSERT INTO watcher_windows (
-        id, watcher_id, window_start, window_end, granularity,
+        id, watcher_id, version_id, window_start, window_end, granularity,
         extracted_data, content_analyzed, model_used, client_id, run_metadata,
         is_rollup, depth, source_window_ids, run_id, created_at
       ) VALUES (
-        ${newWindowId}, ${watcherId}, ${window_start}, ${window_end}, ${granularity || timeGranularity},
+        ${newWindowId}, ${watcherId}, ${resolvedVersionId}, ${window_start}, ${window_end}, ${granularity || timeGranularity},
         ${sql.json(extractedData)}, 0, ${provenanceModel}, ${provenanceClientId}, ${sql.json(provenanceMetadata)},
         true, ${depth}, ${sourceIds}, ${watcherRunId}, NOW()
       )
@@ -1643,11 +1654,11 @@ async function handleCompleteWindow(
           await tx`
             INSERT INTO watcher_windows (
               id,
-              watcher_id, window_start, window_end, granularity,
+              watcher_id, version_id, window_start, window_end, granularity,
               extracted_data, content_analyzed, model_used, client_id, run_metadata, run_id, created_at
             ) VALUES (
               ${newWindowId},
-              ${watcherId}, ${window_start}, ${window_end}, ${timeGranularity},
+              ${watcherId}, ${resolvedVersionId}, ${window_start}, ${window_end}, ${timeGranularity},
               ${sql.json(cleanedExtractedData)}, ${uniqueContentIds.length}, ${provenanceModel}, ${provenanceClientId}, ${sql.json(provenanceMetadata)}, ${watcherRunId}, NOW()
             )
           `;
@@ -1939,13 +1950,21 @@ async function handleSetReactionScript(
 
   await requireExists(sql, 'watchers', args.watcher_id, 'Watcher');
 
+  // Reaction script is a group-shared field — every assignment in the
+  // group runs the same reactions on its windows. Resolve the group once
+  // and cascade across all assignments so we don't silently fork.
+  const groupRows = await sql`
+    SELECT watcher_group_id FROM watchers WHERE id = ${args.watcher_id} LIMIT 1
+  `;
+  const groupId = Number(groupRows[0].watcher_group_id);
+
   const script = args.reaction_script;
 
   if (!script || script.trim() === '') {
     await sql`
       UPDATE watchers
       SET reaction_script = NULL, reaction_script_compiled = NULL
-      WHERE id = ${args.watcher_id}
+      WHERE watcher_group_id = ${groupId}
     `;
     return {
       action: 'set_reaction_script',
@@ -1960,7 +1979,7 @@ async function handleSetReactionScript(
   await sql`
     UPDATE watchers
     SET reaction_script = ${script}, reaction_script_compiled = ${compiledCode}
-    WHERE id = ${args.watcher_id}
+    WHERE watcher_group_id = ${groupId}
   `;
 
   logger.info(`[manage_watchers] Set reaction script for watcher ${args.watcher_id}`);
@@ -2230,30 +2249,40 @@ async function handleCreateVersion(
     throw new Error('watcher_id is required for create_version action');
   }
 
-  // Get current watcher + latest version
+  // Get current watcher + resolve the group root. Versioned config
+  // (prompt/schema/template/classifiers) is shared across the entire group
+  // and version rows live on the group root, so we read from and write to
+  // `watcher_id = watcher_group_id`. The arg's watcher_id is only used to
+  // identify the group and to apply the per-assignment writes (sources,
+  // schedule, scheduler_client_id) to that specific row.
   const watcherRows = await sql`
-    SELECT i.id, i.version, i.current_version_id
+    SELECT i.id, i.version, i.current_version_id, i.watcher_group_id
     FROM watchers i WHERE i.id = ${args.watcher_id}
   `;
   if (watcherRows.length === 0) {
     throw new Error(`Watcher ${args.watcher_id} not found`);
   }
 
+  const groupId = Number(watcherRows[0].watcher_group_id);
   const previousVersion = Number(watcherRows[0].version);
   const nextVersion = previousVersion + 1;
 
-  // Load current version to inherit fields not specified
+  // Load current version (from the group root's chain) to inherit fields
+  // the caller didn't specify.
   const prevRows = await sql`
     SELECT
       name, description, prompt, extraction_schema, version_sources,
       json_template, keying_config, classifiers,
       reactions_guidance, condensation_prompt, condensation_window_count
     FROM watcher_versions
-    WHERE watcher_id = ${args.watcher_id}
+    WHERE watcher_id = ${groupId}
     ORDER BY version DESC LIMIT 1
   `;
   if (prevRows.length === 0) {
-    throw new Error(`No previous version found for watcher ${args.watcher_id}`);
+    throw new Error(
+      `No previous version found for watcher group ${groupId}. ` +
+        'This group is missing version rows on its root — likely a stale clone from before the version-sharing refactor. Run cleanup or create a fresh watcher.'
+    );
   }
   const prev = prevRows[0] as Record<string, unknown>;
 
@@ -2305,6 +2334,9 @@ async function handleCreateVersion(
   const createdBy = ctx.userId ?? 'system';
   const versionId = await getNextWatcherVersionId(sql);
   await sql.begin(async (tx) => {
+    // The new version row is owned by the group root, not the assignment
+    // the caller named. Every watcher in the group will later point at
+    // this row via current_version_id.
     await tx`
       INSERT INTO watcher_versions (
         id, watcher_id, version, name, description,
@@ -2313,7 +2345,7 @@ async function handleCreateVersion(
         condensation_prompt, condensation_window_count,
         reactions_guidance, change_notes, created_by, created_at
       ) VALUES (
-        ${versionId}, ${args.watcher_id}, ${nextVersion},
+        ${versionId}, ${groupId}, ${nextVersion},
         ${args.name ?? (prev.name as string) ?? 'Watcher'},
         ${args.description !== undefined ? (args.description ?? null) : ((prev.description as string) ?? null)},
         ${prompt}, ${toJsonParam(tx, extractionSchema)}, ${toJsonParam(tx, sources)},
@@ -2325,25 +2357,35 @@ async function handleCreateVersion(
       )
     `;
 
-    // Update watcher to new version if set_as_current (default: true)
-    // Also applies any watcher-level field changes atomically.
+    // Update watcher to new version if set_as_current (default: true).
+    // Group-shared fields (current_version_id, version, name) cascade to
+    // every watcher in the group; per-assignment fields (sources,
+    // schedule, scheduler_client_id) update only the targeted row.
     const setAsCurrent = args.set_as_current !== false;
     if (setAsCurrent) {
       const shouldUpdateSchedule = args.schedule !== undefined;
       const scheduleValue = shouldUpdateSchedule ? args.schedule || null : null;
       const nextRunAtVal = scheduleValue ? nextRunAt(scheduleValue) : null;
 
+      // Group-shared cascade
       await tx`
         UPDATE watchers
         SET
           current_version_id = ${versionId},
           version = ${nextVersion},
           name = ${args.name ?? (prev.name as string)},
+          updated_at = NOW()
+        WHERE watcher_group_id = ${groupId}
+      `;
+
+      // Per-assignment writes (only the row the caller named)
+      await tx`
+        UPDATE watchers
+        SET
           sources = ${tx.json(sources)},
           scheduler_client_id = CASE WHEN ${args.scheduler_client_id !== undefined} THEN ${args.scheduler_client_id ?? null} ELSE scheduler_client_id END,
           schedule = CASE WHEN ${shouldUpdateSchedule} THEN ${scheduleValue} ELSE schedule END,
-          next_run_at = CASE WHEN ${shouldUpdateSchedule} THEN ${nextRunAtVal}::timestamptz ELSE next_run_at END,
-          updated_at = NOW()
+          next_run_at = CASE WHEN ${shouldUpdateSchedule} THEN ${nextRunAtVal}::timestamptz ELSE next_run_at END
         WHERE id = ${args.watcher_id}
       `;
     }

--- a/packages/owletto-backend/src/tools/get_content.ts
+++ b/packages/owletto-backend/src/tools/get_content.ts
@@ -138,6 +138,12 @@ export const GetContentSchema = Type.Object({
         "Watcher ID to fetch content for. When provided, uses watcher's sources and computes pending window. Returns window_token for complete_window action.",
     })
   ),
+  template_version_id: Type.Optional(
+    Type.Number({
+      description:
+        "Pin to a specific watcher_versions.id when reading the prompt/schema. Workers receive this from runs.approved_input.version_id and pass it back so a group edit landing mid-run can't make extraction use a different schema. When omitted, defaults to the watcher's current_version_id.",
+    })
+  ),
   connection_ids: Type.Optional(
     Type.Array(Type.Number(), {
       description: 'Connection IDs to filter by',
@@ -1420,7 +1426,12 @@ async function handleWatcherMode(
 
   const watcherId = args.watcher_id!;
 
-  // Fetch watcher with template info and entity name
+  // Workers pass `template_version_id` (snapshotted at run-creation time)
+  // so the prompt/schema we hand back matches the version this run was
+  // queued for, even if the group has been edited since. The version row
+  // is owned by the group root (watcher_id = i.watcher_group_id), and we
+  // require it to live in the same group to prevent cross-watcher pinning.
+  const pinnedVersionId = args.template_version_id ?? null;
   const watcherResult = await sql`
     SELECT
       i.id,
@@ -1436,7 +1447,9 @@ async function handleWatcherMode(
       cv.version_sources,
       (SELECT COALESCE(json_agg(json_build_object('id', e.id, 'name', e.name, 'type', et.slug)), '[]'::json) FROM entities e JOIN entity_types et ON et.id = e.entity_type_id WHERE e.id = ANY(i.entity_ids)) as entities
     FROM watchers i
-    LEFT JOIN watcher_versions cv ON i.current_version_id = cv.id
+    LEFT JOIN watcher_versions cv
+      ON cv.id = COALESCE(${pinnedVersionId}::bigint, i.current_version_id)
+     AND cv.watcher_id = i.watcher_group_id
     WHERE i.id = ${watcherId}
     LIMIT 1
   `;

--- a/packages/owletto-backend/src/tools/get_watchers.ts
+++ b/packages/owletto-backend/src/tools/get_watchers.ts
@@ -587,6 +587,7 @@ export async function getWatcher(
                   AND version = COALESCE($2::int, i.version)
                 LIMIT 1)
            )
+       AND sv.watcher_id = i.watcher_group_id
       ${buildLatestWatcherRunJoinSql('i', 'wr')}
       WHERE i.id = $1
     `,

--- a/packages/owletto-backend/src/tools/get_watchers.ts
+++ b/packages/owletto-backend/src/tools/get_watchers.ts
@@ -88,7 +88,13 @@ export const GetWatcherSchema = Type.Object({
   template_version: Type.Optional(
     Type.Number({
       description:
-        "Override template version for viewing results. If not provided, uses the watcher's current pinned version. Useful for viewing results with a different renderer or schema.",
+        "Override template version *number* for viewing results. If not provided, uses the watcher's current pinned version. Useful for viewing results with a different renderer or schema. Prefer `template_version_id` when you need a stable reference (version numbers can change if a chain is reorganized).",
+    })
+  ),
+  template_version_id: Type.Optional(
+    Type.Number({
+      description:
+        "Pin to a specific watcher_versions.id. Workers receive this from runs.approved_input.version_id and pass it back so the agent loop reads the same version it extracted with, even if the group is edited mid-run.",
     })
   ),
   page: Type.Optional(Type.Number({ description: 'Page number for pagination (default: 1)' })),
@@ -493,10 +499,21 @@ export async function getWatcher(
   // for condensation columns); when it differs, the JOIN still resolves
   // the right row via (watcher_id, version) which is unique.
   //
+  // Two override mechanisms:
+  //   - template_version_id (preferred): an exact watcher_versions.id. Used
+  //     by the worker run loop to read the snapshotted version even after a
+  //     mid-run group edit. Joins by id so it works regardless of which
+  //     watcher in the group owns the version row.
+  //   - template_version (legacy): a version *number*. Resolves via the
+  //     group's root watcher_id (watcher_group_id), since after the group-
+  //     edit refactor version chains live on the group root, not on each
+  //     non-root assignment.
+  //
   // Tagged-template + sql.unsafe() inside the template breaks PGlite's
   // simple-query mode (prepare=false), so we keep this path as a single
   // unsafe call instead.
   const requestedVersion = args.template_version ?? null;
+  const requestedVersionId = args.template_version_id ?? null;
   const namespacesLiteral = STANDARD_IDENTITY_NAMESPACES.map((n) => `'${n}'`).join(',');
   const watcherQueryPromise = args.watcher_id
     ? sql.unsafe(
@@ -563,12 +580,14 @@ export async function getWatcher(
       FROM watchers i
       LEFT JOIN watcher_versions cv ON i.current_version_id = cv.id
       LEFT JOIN watcher_versions sv
-        ON sv.watcher_id = i.id
-        AND sv.version = COALESCE($2::int, i.version)
+        ON ($3::bigint IS NOT NULL AND sv.id = $3::bigint)
+        OR ($3::bigint IS NULL
+             AND sv.watcher_id = i.watcher_group_id
+             AND sv.version = COALESCE($2::int, i.version))
       ${buildLatestWatcherRunJoinSql('i', 'wr')}
       WHERE i.id = $1
     `,
-        [args.watcher_id, requestedVersion]
+        [args.watcher_id, requestedVersion, requestedVersionId]
       )
     : null;
 
@@ -706,6 +725,8 @@ export async function getWatcher(
     // watcherRow directly — no separate round-trip.
     //
     // available_versions list is opt-in (edit sheet) — still its own query.
+    // Reads from the group root's chain (watcher_group_id) so non-root
+    // assignments see the same version history as the root.
     const versionsQuery = args.include_versions
       ? await sql`
           SELECT
@@ -714,7 +735,9 @@ export async function getWatcher(
             wv.created_at,
             (wv.id = ${watcherRow.current_version_id}) as is_current
           FROM watcher_versions wv
-          WHERE wv.watcher_id = ${args.watcher_id}
+          WHERE wv.watcher_id = (
+            SELECT watcher_group_id FROM watchers WHERE id = ${args.watcher_id}
+          )
           ORDER BY wv.version DESC
         `
       : ([] as unknown[]);

--- a/packages/owletto-backend/src/tools/get_watchers.ts
+++ b/packages/owletto-backend/src/tools/get_watchers.ts
@@ -580,10 +580,13 @@ export async function getWatcher(
       FROM watchers i
       LEFT JOIN watcher_versions cv ON i.current_version_id = cv.id
       LEFT JOIN watcher_versions sv
-        ON ($3::bigint IS NOT NULL AND sv.id = $3::bigint)
-        OR ($3::bigint IS NULL
-             AND sv.watcher_id = i.watcher_group_id
-             AND sv.version = COALESCE($2::int, i.version))
+        ON sv.id = COALESCE(
+             $3::bigint,
+             (SELECT id FROM watcher_versions
+                WHERE watcher_id = i.watcher_group_id
+                  AND version = COALESCE($2::int, i.version)
+                LIMIT 1)
+           )
       ${buildLatestWatcherRunJoinSql('i', 'wr')}
       WHERE i.id = $1
     `,

--- a/packages/owletto-backend/src/utils/entity-management.ts
+++ b/packages/owletto-backend/src/utils/entity-management.ts
@@ -576,6 +576,50 @@ export async function deleteEntity(
           WHERE COALESCE(entity_ids, '{}'::bigint[]) <@ ${entityTreeIdsLiteral}::bigint[]
         )
       `;
+      // Before hard-deleting watchers: if any of those rows are group roots
+      // (id = watcher_group_id) with surviving siblings, transfer ownership
+      // of the shared watcher_versions chain to a sibling so the upcoming
+      // ON DELETE CASCADE doesn't wipe out the version row that the rest
+      // of the group still depends on.
+      await tx`
+        UPDATE watcher_versions wv
+        SET watcher_id = s.new_root
+        FROM (
+          SELECT r.old_root, MIN(s.id) AS new_root
+          FROM (
+            SELECT w.id AS old_root
+            FROM watchers w
+            WHERE w.id = w.watcher_group_id
+              AND COALESCE(w.entity_ids, '{}'::bigint[]) <@ ${entityTreeIdsLiteral}::bigint[]
+          ) r
+          JOIN watchers s
+            ON s.watcher_group_id = r.old_root
+           AND s.id <> r.old_root
+           AND NOT (COALESCE(s.entity_ids, '{}'::bigint[]) <@ ${entityTreeIdsLiteral}::bigint[])
+          GROUP BY r.old_root
+        ) s
+        WHERE wv.watcher_id = s.old_root
+      `;
+      await tx`
+        UPDATE watchers w
+        SET watcher_group_id = s.new_root,
+            source_watcher_id = CASE WHEN w.source_watcher_id = s.old_root THEN s.new_root ELSE w.source_watcher_id END
+        FROM (
+          SELECT r.old_root, MIN(s.id) AS new_root
+          FROM (
+            SELECT w.id AS old_root
+            FROM watchers w
+            WHERE w.id = w.watcher_group_id
+              AND COALESCE(w.entity_ids, '{}'::bigint[]) <@ ${entityTreeIdsLiteral}::bigint[]
+          ) r
+          JOIN watchers s
+            ON s.watcher_group_id = r.old_root
+           AND s.id <> r.old_root
+           AND NOT (COALESCE(s.entity_ids, '{}'::bigint[]) <@ ${entityTreeIdsLiteral}::bigint[])
+          GROUP BY r.old_root
+        ) s
+        WHERE w.watcher_group_id = s.old_root
+      `;
       await tx`
         DELETE FROM watchers
         WHERE COALESCE(entity_ids, '{}'::bigint[]) <@ ${entityTreeIdsLiteral}::bigint[]
@@ -605,6 +649,48 @@ export async function deleteEntity(
           FROM watchers
           WHERE cardinality(COALESCE(entity_ids, '{}'::bigint[])) = 0
         )
+      `;
+      // Same group-root ownership transfer as above — predicate here is
+      // "now-orphaned watcher rows" (entity_ids is empty after the array
+      // pruning a few statements up).
+      await tx`
+        UPDATE watcher_versions wv
+        SET watcher_id = s.new_root
+        FROM (
+          SELECT r.old_root, MIN(s.id) AS new_root
+          FROM (
+            SELECT w.id AS old_root
+            FROM watchers w
+            WHERE w.id = w.watcher_group_id
+              AND cardinality(COALESCE(w.entity_ids, '{}'::bigint[])) = 0
+          ) r
+          JOIN watchers s
+            ON s.watcher_group_id = r.old_root
+           AND s.id <> r.old_root
+           AND cardinality(COALESCE(s.entity_ids, '{}'::bigint[])) > 0
+          GROUP BY r.old_root
+        ) s
+        WHERE wv.watcher_id = s.old_root
+      `;
+      await tx`
+        UPDATE watchers w
+        SET watcher_group_id = s.new_root,
+            source_watcher_id = CASE WHEN w.source_watcher_id = s.old_root THEN s.new_root ELSE w.source_watcher_id END
+        FROM (
+          SELECT r.old_root, MIN(s.id) AS new_root
+          FROM (
+            SELECT w.id AS old_root
+            FROM watchers w
+            WHERE w.id = w.watcher_group_id
+              AND cardinality(COALESCE(w.entity_ids, '{}'::bigint[])) = 0
+          ) r
+          JOIN watchers s
+            ON s.watcher_group_id = r.old_root
+           AND s.id <> r.old_root
+           AND cardinality(COALESCE(s.entity_ids, '{}'::bigint[])) > 0
+          GROUP BY r.old_root
+        ) s
+        WHERE w.watcher_group_id = s.old_root
       `;
       await tx`
         DELETE FROM watchers

--- a/packages/owletto-backend/src/utils/entity-management.ts
+++ b/packages/owletto-backend/src/utils/entity-management.ts
@@ -596,6 +596,9 @@ export async function deleteEntity(
             ON s.watcher_group_id = r.old_root
            AND s.id <> r.old_root
            AND NOT (COALESCE(s.entity_ids, '{}'::bigint[]) <@ ${entityTreeIdsLiteral}::bigint[])
+           AND NOT EXISTS (
+             SELECT 1 FROM watcher_versions vv WHERE vv.watcher_id = s.id
+           )
           GROUP BY r.old_root
         ) s
         WHERE wv.watcher_id = s.old_root
@@ -616,6 +619,9 @@ export async function deleteEntity(
             ON s.watcher_group_id = r.old_root
            AND s.id <> r.old_root
            AND NOT (COALESCE(s.entity_ids, '{}'::bigint[]) <@ ${entityTreeIdsLiteral}::bigint[])
+           AND NOT EXISTS (
+             SELECT 1 FROM watcher_versions vv WHERE vv.watcher_id = s.id
+           )
           GROUP BY r.old_root
         ) s
         WHERE w.watcher_group_id = s.old_root
@@ -668,6 +674,9 @@ export async function deleteEntity(
             ON s.watcher_group_id = r.old_root
            AND s.id <> r.old_root
            AND cardinality(COALESCE(s.entity_ids, '{}'::bigint[])) > 0
+           AND NOT EXISTS (
+             SELECT 1 FROM watcher_versions vv WHERE vv.watcher_id = s.id
+           )
           GROUP BY r.old_root
         ) s
         WHERE wv.watcher_id = s.old_root
@@ -688,6 +697,9 @@ export async function deleteEntity(
             ON s.watcher_group_id = r.old_root
            AND s.id <> r.old_root
            AND cardinality(COALESCE(s.entity_ids, '{}'::bigint[])) > 0
+           AND NOT EXISTS (
+             SELECT 1 FROM watcher_versions vv WHERE vv.watcher_id = s.id
+           )
           GROUP BY r.old_root
         ) s
         WHERE w.watcher_group_id = s.old_root

--- a/packages/owletto-backend/src/utils/queue-helpers.ts
+++ b/packages/owletto-backend/src/utils/queue-helpers.ts
@@ -22,6 +22,13 @@ export interface WatcherRunPayload {
   window_start: string;
   window_end: string;
   dispatch_source: WatcherDispatchSource;
+  /**
+   * Snapshot of the watcher's `current_version_id` at run-creation time.
+   * The agent and `complete_window` use this fixed version for the entire
+   * extraction lifecycle so a mid-run group edit cannot validate v1's output
+   * against v2's schema.
+   */
+  version_id: number | null;
 }
 
 // ============================================
@@ -194,12 +201,23 @@ async function createWatcherRunWithClient(
     return { runId: existing.id, status: existing.status, created: false };
   }
 
+  // Snapshot the watcher's current_version_id at run-creation time so the
+  // entire run uses a fixed version even if the group is edited mid-run.
+  const versionRows = await sql`
+    SELECT current_version_id FROM watchers WHERE id = ${params.watcherId} LIMIT 1
+  `;
+  const snapshotVersionId =
+    versionRows.length > 0 && versionRows[0].current_version_id != null
+      ? Number(versionRows[0].current_version_id)
+      : null;
+
   const payload: WatcherRunPayload = {
     watcher_id: params.watcherId,
     agent_id: params.agentId,
     window_start: params.windowStart,
     window_end: params.windowEnd,
     dispatch_source: params.dispatchSource,
+    version_id: snapshotVersionId,
   };
 
   const inserted = await sql`

--- a/packages/owletto-backend/src/watchers/automation.ts
+++ b/packages/owletto-backend/src/watchers/automation.ts
@@ -102,12 +102,25 @@ export function parseWatcherRunPayload(value: unknown): WatcherRunPayload | null
     return null;
   }
 
+  // version_id was added when the watcher group-edit refactor introduced
+  // a per-run version snapshot. Older runs (queued before the change) have
+  // no version_id in approved_input — coerce to null and the agent loop
+  // falls back to current_version_id, matching pre-refactor behavior.
+  const rawVersionId = payload.version_id;
+  const versionId =
+    typeof rawVersionId === 'number' && Number.isFinite(rawVersionId)
+      ? rawVersionId
+      : typeof rawVersionId === 'string' && rawVersionId.trim() !== ''
+        ? Number(rawVersionId)
+        : null;
+
   return {
     watcher_id: watcherId,
     agent_id: agentId,
     window_start: windowStart,
     window_end: windowEnd,
     dispatch_source: dispatchSource,
+    version_id: Number.isFinite(versionId as number) ? (versionId as number) : null,
   };
 }
 
@@ -411,6 +424,14 @@ function buildDispatchMessage(params: {
     .toISOString()
     .split('T')[0];
 
+  // The version snapshot taken at run-creation time pins this run to a
+  // specific watcher_template_versions row. Pass it to read_knowledge AND
+  // complete_window so a group edit landing mid-run can't make the agent
+  // extract with prompt v1 and have its output validated against schema v2.
+  const versionPin = params.payload.version_id != null
+    ? `, "template_version_id": ${params.payload.version_id}`
+    : '';
+
   return [
     'Run this Owletto watcher now using the Owletto MCP tools.',
     '',
@@ -421,11 +442,14 @@ function buildDispatchMessage(params: {
     `Queued window start: ${params.payload.window_start}`,
     `Queued window end: ${params.payload.window_end}`,
     `Dispatch source: ${params.payload.dispatch_source}`,
+    ...(params.payload.version_id != null
+      ? [`Pinned template version id: ${params.payload.version_id}`]
+      : []),
     '',
     'Required steps:',
-    `1. Call read_knowledge with {"watcher_id": ${params.watcherId}, "since": "${readKnowledgeSince}", "until": "${readKnowledgeUntil}"}.`,
+    `1. Call read_knowledge with {"watcher_id": ${params.watcherId}, "since": "${readKnowledgeSince}", "until": "${readKnowledgeUntil}"${versionPin}}.`,
     '2. Analyze the returned content using prompt_rendered and extraction_schema.',
-    '3. Call manage_watchers(action="complete_window") with the returned window_token and your extracted_data.',
+    `3. Call manage_watchers(action="complete_window") with the returned window_token and your extracted_data${params.payload.version_id != null ? `, including "template_version_id": ${params.payload.version_id}` : ''}.`,
     '4. Include this run_metadata object in complete_window exactly, and add any extra provider/job fields you know:',
     JSON.stringify(
       {


### PR DESCRIPTION
## Summary

Editing one watcher in a group (linked via `watcher_group_id`) used to silently fork it from siblings: `manage_watchers.create_from_version` duplicated the `watcher_versions` row, and every per-assignment edit only touched its own chain. This PR makes the write paths group-aware:

- **`create_from_version`**: no longer inserts a fresh `watcher_versions` row. The new assignment shares the source's `current_version_id`. `reaction_script` is now copied from the source watcher (it lives on the watcher row, not the version row).
- **`create_version`**: new version row is owned by the group root (`watcher_id = watcher_group_id`); `current_version_id`, `version`, `name` cascade across every assignment in `watcher_group_id`. Per-assignment fields (`sources`, `schedule`, `scheduler_client_id`) still update only the named row.
- **`set_reaction_script`**: cascades across `watcher_group_id`.
- **`get_watchers`**: reads versions through the group root; new `template_version_id` arg lets workers request a specific `watcher_versions.id`.

The cascade introduced a race — a mid-flight extraction could have its output validated against a newly-edited schema. Closed with a `version_id` snapshot:

- `WatcherRunPayload` gains a `version_id` field; `createWatcherRun` snapshots `watchers.current_version_id` at INSERT time.
- `complete_window` reads `version_id` from the run row and joins the version by id, ignoring `watchers.current_version_id`. The snapshot is also written into `watcher_windows.version_id` (column existed, never populated until now).

Entity hard-delete cascade: before each `DELETE FROM watchers` site in `utils/entity-management.ts`, version-chain ownership is transferred to a surviving sibling so deleting an entity that owns the group root can't wipe the version chain out from under the group.

## Coupled to

- **Submodule PR** [lobu-ai/owletto-web#57](https://github.com/lobu-ai/owletto-web/pull/57) — adds the Edit button on the watcher group page that exercises this cascade. Submodule pointer in this PR is intentionally **unchanged** (still at the merged main SHA `a4c6c8f`); a follow-up commit will bump it once #57 merges, per the AGENTS.md two-PR rule.

## Test plan

- [x] `bun run typecheck` clean
- [x] `make build-packages` clean
- [x] `vitest run src/__tests__/integration/watchers/` — 13/13 pass on real Postgres (5 new tests in `group-edit.test.ts` cover: shared-version reuse, reaction-script copy on assign, group-cascade for create_version, group-cascade for set_reaction_script, run-time version_id snapshot surviving mid-run group edit)
- [ ] Manual after submodule bump: open `/<owner>/watchers/<id>`, click Edit, change prompt → all assignments reflect the new prompt and version
- [ ] Manual: trigger a watcher run, edit the group mid-run → run still validates against the snapshot, no schema mismatch