### PR TITLE
fix(get_watcher): bound unprocessedCount scan even on fresh watchers

### DIFF
--- a/packages/owletto-backend/src/tools/get_watchers.ts
+++ b/packages/owletto-backend/src/tools/get_watchers.ts
@@ -867,23 +867,20 @@ export async function getWatcher(
     // planner walks the entity's full event history; with it, the planner
     // uses `idx_events_entity_ids_occurred_at` for an indexed range scan.
     //
-    // For fresh watchers (latestEnd === null), we deliberately leave the
-    // scan unbounded so that `unprocessed_count` and `next_window` reflect
-    // the full backlog of pre-existing entity content the user wants to
-    // bootstrap from. This is rare (one-shot per never-run watcher); steady
-    // state is bounded.
-    const occurredAtBound =
-      latestEnd === null ? null : `f.occurred_at >= $${2 + entityLinkParams.length}::timestamptz`;
-    const occurredAtBoundNoWatcher =
-      latestEnd === null
-        ? null
-        : `f.occurred_at >= $${1 + entityLinkOnlyParams.length}::timestamptz`;
-    const watcherScopedParams =
-      latestEnd === null
-        ? [args.watcher_id, ...entityLinkParams]
-        : [args.watcher_id, ...entityLinkParams, latestEnd];
-    const noWatcherParams =
-      latestEnd === null ? entityLinkOnlyParams : [...entityLinkOnlyParams, latestEnd];
+    // For fresh watchers (latestEnd === null), bound by 90 days ago. The
+    // older "unbounded so the badge reflects the full backlog" path blows
+    // the 10s frontend timeout on high-volume entities (e.g. 78K+ events
+    // → 9.5s scan, then "Failed to load watcher"). 90 days matches the
+    // per-month histogram's natural horizon, keeps the scan indexed, and
+    // the badge is a notification — not a backlog audit.
+    const FRESH_WATCHER_LOOKBACK_DAYS = 90;
+    const effectiveBound =
+      latestEnd ??
+      new Date(Date.now() - FRESH_WATCHER_LOOKBACK_DAYS * 24 * 60 * 60 * 1000).toISOString();
+    const occurredAtBound = `f.occurred_at >= $${2 + entityLinkParams.length}::timestamptz`;
+    const occurredAtBoundNoWatcher = `f.occurred_at >= $${1 + entityLinkOnlyParams.length}::timestamptz`;
+    const watcherScopedParams = [args.watcher_id, ...entityLinkParams, effectiveBound];
+    const noWatcherParams = [...entityLinkOnlyParams, effectiveBound];
 
     const notInWindowClause = `NOT EXISTS (
         SELECT 1 FROM watcher_window_events iwc


### PR DESCRIPTION
## Summary

The fresh-watcher path of \`get_watchers.unprocessedCount\` was deliberately unbounded "so the badge reflects the full backlog of pre-existing entity content." On high-volume entities this lights the 10s frontend timeout.

Reproduced live with the user's session against \`https://app.lobu.ai/buremba/watchers/218\` (Reddit Digest, fresh — never run, latestEnd null). The page rendered the user's exact reported error:

> Failed to load watcher
> Request timed out after 10000ms

Prod logs:
\`\`\`
[get_watcher] Found 78457 unprocessed content items for watcher 218
responseTime: 9896
\`\`\`

The \`COUNT(*) FROM current_event_records WHERE entityScope AND notInWindow\` was scanning the full entity tree (162K+ events) because \`occurred_at >= bound\` was only applied when \`latestEnd != null\`.

## Fix

Bound by \`last 90 days\` when \`latestEnd\` is null. The window matches the per-month histogram's natural horizon, keeps the scan indexed via \`idx_events_entity_ids_occurred_at\`, and reframes the badge: it's a notification, not a backlog audit.

## Test plan

- [x] \`bun run typecheck\`
- [x] \`vitest run src/__tests__/integration/watchers/\` — 17/17 pass on real Postgres
- [ ] Deploy and re-test \`https://app.lobu.ai/buremba/watchers/218\` — page loads and Edit button is interactive