### PR TITLE
fix(landing): send start CTAs to app

### DIFF
--- a/packages/landing/src/components/CTA.tsx
+++ b/packages/landing/src/components/CTA.tsx
@@ -1,4 +1,4 @@
-const GITHUB_URL = "https://github.com/lobu-ai/lobu";
+import { getOwlettoBaseUrl } from "../use-case-showcases";
 
 function HexCluster() {
   return (
@@ -36,7 +36,7 @@ function HexCluster() {
   );
 }
 
-export function CTA() {
+export function CTA({ startUrl = getOwlettoBaseUrl() }: { startUrl?: string }) {
   return (
     <section class="px-4 sm:px-6 py-20">
       <div
@@ -57,9 +57,7 @@ export function CTA() {
           </h2>
           <div class="flex flex-wrap gap-3">
             <a
-              href={GITHUB_URL}
-              target="_blank"
-              rel="noopener noreferrer"
+              href={startUrl}
               class="inline-flex items-center text-[14px] font-medium px-5 h-10 rounded-lg transition-opacity hover:opacity-90"
               style={{ background: "#0b0b0d", color: "#ffffff" }}
             >

--- a/packages/landing/src/components/HeroSection.tsx
+++ b/packages/landing/src/components/HeroSection.tsx
@@ -62,6 +62,7 @@ export function HeroSection(props: {
   autoAdvance?: boolean;
   onStopAutoAdvance?: () => void;
   heroCopy?: SurfaceHeroCopy;
+  startUrl: string;
 }) {
   const activeUseCase = getLandingUseCaseShowcase(props.activeUseCaseId);
   const activeStage = props.activeStage ?? "model";
@@ -127,9 +128,7 @@ export function HeroSection(props: {
 
         <div class="hero-rise hero-rise-4 relative z-20 flex flex-wrap gap-3 justify-center items-center">
           <a
-            href={GITHUB_URL}
-            target="_blank"
-            rel="noopener noreferrer"
+            href={props.startUrl}
             class="inline-flex items-center text-[14px] font-medium px-5 h-10 rounded-lg transition-opacity hover:opacity-90"
             style={{
               background: "#0b0b0d",

--- a/packages/landing/src/components/LandingPage.tsx
+++ b/packages/landing/src/components/LandingPage.tsx
@@ -2,6 +2,8 @@ import { useState } from "preact/hooks";
 import type { LandingUseCaseId } from "../use-case-definitions";
 import {
   DEFAULT_LANDING_USE_CASE_ID,
+  getOwlettoBaseUrl,
+  getOwlettoUrl,
   type SurfaceHeroCopy,
 } from "../use-case-showcases";
 import { ArchitectureSection } from "./ArchitectureSection";
@@ -32,6 +34,9 @@ export function LandingPage(props: {
   );
   const [activeStage, setActiveStage] = useState<HeroStageId>("model");
   const [autoAdvance, setAutoAdvance] = useState(true);
+  const startUrl = props.defaultUseCaseId
+    ? getOwlettoUrl(activeUseCaseId)
+    : getOwlettoBaseUrl();
 
   const handleStageChange = (id: HeroStageId) => {
     setAutoAdvance(false);
@@ -47,6 +52,7 @@ export function LandingPage(props: {
         autoAdvance={autoAdvance}
         onStopAutoAdvance={() => setAutoAdvance(false)}
         heroCopy={props.heroCopy}
+        startUrl={startUrl}
       />
 
       <section class="px-4 sm:px-6 pt-2 pb-12">
@@ -147,7 +153,7 @@ export function LandingPage(props: {
         <DataModelSection />
       </div>
 
-      <CTA />
+      <CTA startUrl={startUrl} />
 
       {props.latestPosts?.length ? (
         <LatestBlogPosts posts={props.latestPosts} />

--- a/packages/landing/src/components/Nav.tsx
+++ b/packages/landing/src/components/Nav.tsx
@@ -1,6 +1,9 @@
 import { useEffect, useRef, useState } from "preact/hooks";
+import type { LandingUseCaseId } from "../use-case-definitions";
 import {
+  getOwlettoBaseUrl,
   getOwlettoLoginUrl,
+  getOwlettoUrl,
   landingUseCaseGroupedOptions,
 } from "../use-case-showcases";
 
@@ -292,12 +295,19 @@ function MegaMenuTrigger({
 
 type NavProps = {
   currentPath?: string;
+  startUseCaseId?: LandingUseCaseId;
 };
 
-export function Nav({ currentPath: _currentPath = "/" }: NavProps) {
+export function Nav({
+  currentPath: _currentPath = "/",
+  startUseCaseId,
+}: NavProps) {
   const [openId, setOpenId] = useState<string | null>(null);
   const solutions = buildSolutionsMenu();
   const loginUrl = getOwlettoLoginUrl();
+  const startUrl = startUseCaseId
+    ? getOwlettoUrl(startUseCaseId)
+    : getOwlettoBaseUrl();
 
   useEffect(() => {
     function onKey(e: KeyboardEvent) {
@@ -376,9 +386,7 @@ export function Nav({ currentPath: _currentPath = "/" }: NavProps) {
               Sign in
             </a>
             <a
-              href={GITHUB_URL}
-              target="_blank"
-              rel="noopener noreferrer"
+              href={startUrl}
               class="inline-flex items-center text-[14px] font-medium px-4 h-9 rounded-full transition-opacity hover:opacity-90"
               style={{ background: "#0b0b0d", color: "#ffffff" }}
             >

--- a/packages/landing/src/pages/for/[useCase].astro
+++ b/packages/landing/src/pages/for/[useCase].astro
@@ -34,7 +34,11 @@ const latestPosts = await getLatestPosts(3);
       "--grid-max-w": "72rem",
     }}
   >
-    <Nav client:load currentPath={Astro.url.pathname} />
+    <Nav
+      client:load
+      currentPath={Astro.url.pathname}
+      startUseCaseId={showcase.id}
+    />
     <main class="relative z-[1]">
       <LandingPage
         client:load


### PR DESCRIPTION
## Summary
- route landing “Start for free” CTAs to the Lobu app instead of GitHub
- use the relevant Owletto workspace URL on /for/[useCase] pages
- keep explicit GitHub links pointed at the repository

## Validation
- cd packages/landing && bun run build
- git diff --check