### PR TITLE
feat(landing): dark mode support with system preference detection

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -258,76 +258,6 @@
         "playwright",
       ],
     },
-    "packages/owletto-web": {
-      "name": "@owletto/web",
-      "version": "1.6.0",
-      "dependencies": {
-        "@codemirror/autocomplete": "^6.20.0",
-        "@codemirror/commands": "^6.10.2",
-        "@codemirror/lang-json": "^6.0.2",
-        "@codemirror/language": "^6.12.2",
-        "@codemirror/lint": "^6.9.4",
-        "@codemirror/search": "^6.6.0",
-        "@codemirror/state": "^6.5.4",
-        "@codemirror/view": "^6.39.15",
-        "@daveyplate/better-auth-ui": "^3.3.15",
-        "@jsonforms/core": "^3.7.0",
-        "@jsonforms/react": "^3.7.0",
-        "@lobu/owletto-sdk": "workspace:*",
-        "@radix-ui/react-checkbox": "^1.3.3",
-        "@radix-ui/react-collapsible": "^1.1.12",
-        "@radix-ui/react-dialog": "^1.1.15",
-        "@radix-ui/react-dropdown-menu": "^2.1.16",
-        "@radix-ui/react-label": "^2.1.8",
-        "@radix-ui/react-popover": "^1.1.15",
-        "@radix-ui/react-select": "^2.2.6",
-        "@radix-ui/react-separator": "^1.1.8",
-        "@radix-ui/react-slider": "^1.3.6",
-        "@radix-ui/react-slot": "^1.2.4",
-        "@radix-ui/react-tabs": "^1.1.13",
-        "@radix-ui/react-tooltip": "^1.2.8",
-        "@sentry/react": "^10.51.0",
-        "@tanstack/react-query": "^5.64.0",
-        "@tanstack/react-router": "^1.95.0",
-        "@tanstack/react-table": "^8.21.3",
-        "@tanstack/router-devtools": "^1.95.0",
-        "better-auth": "^1.4.10",
-        "class-variance-authority": "^0.7.1",
-        "clsx": "^2.1.1",
-        "cmdk": "^1.1.1",
-        "date-fns": "^4.1.0",
-        "echarts": "^5.5.0",
-        "framer-motion": "^12.31.0",
-        "lucide-react": "^0.469.0",
-        "qrcode.react": "^4.2.0",
-        "react": "^19.0.0",
-        "react-day-picker": "^9.13.0",
-        "react-dom": "^19.0.0",
-        "react-markdown": "^10.1.0",
-        "simple-icons": "^16.15.0",
-        "sonner": "^2.0.7",
-        "tailwind-merge": "^3.4.0",
-        "zod": "^3.24.0",
-      },
-      "devDependencies": {
-        "@tailwindcss/postcss": "^4.1.17",
-        "@tanstack/router-plugin": "^1.95.0",
-        "@testing-library/jest-dom": "^6.9.1",
-        "@testing-library/react": "^16.3.2",
-        "@testing-library/user-event": "^14.6.1",
-        "@types/react": "^19.0.0",
-        "@types/react-dom": "^19.0.0",
-        "@vitejs/plugin-react": "^4.3.4",
-        "autoprefixer": "^10.4.21",
-        "jsdom": "^29.1.0",
-        "msw": "^2.14.2",
-        "postcss": "^8.5.6",
-        "tailwindcss": "^4.1.17",
-        "typescript": "^5.7.2",
-        "vite": "^6.0.0",
-        "vitest": "^2.1.8",
-      },
-    },
     "packages/owletto-worker": {
       "name": "@lobu/owletto-worker",
       "version": "1.6.0",
@@ -380,10 +310,6 @@
     "@types/node": "20.19.9",
   },
   "packages": {
-    "@adobe/css-tools": ["@adobe/css-tools@4.4.4", "", {}, "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg=="],
-
-    "@alloc/quick-lru": ["@alloc/quick-lru@5.2.0", "", {}, "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw=="],
-
     "@ampproject/remapping": ["@ampproject/remapping@2.3.0", "", { "dependencies": { "@jridgewell/gen-mapping": "^0.3.5", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw=="],
 
     "@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.90.0", "", { "dependencies": { "json-schema-to-ts": "^3.1.1" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["zod"], "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-MzZtPabJF1b0FTDl6Z6H5ljphPwACLGP13lu8MTiB8jXaW/YXlpOp+Po2cVou3MPM5+f5toyLnul9whKCy7fBg=="],
@@ -528,8 +454,6 @@
 
     "@babel/plugin-syntax-jsx": ["@babel/plugin-syntax-jsx@7.28.6", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.28.6" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-wgEmr06G6sIpqr8YDwA2dSRTE3bJ+V0IfpzfSY3Lfgd7YWOaAdlykvJi13ZKBt8cZHfgH1IXN+CL656W3uUa4w=="],
 
-    "@babel/plugin-syntax-typescript": ["@babel/plugin-syntax-typescript@7.28.6", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.28.6" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-+nDNmQye7nlnuuHDboPbGm00Vqg3oO8niRRL27/4LYHUsHYh0zJ1xWOz0uRwNFmM1Avzk8wZbc6rdiYhomzv/A=="],
-
     "@babel/plugin-transform-react-jsx": ["@babel/plugin-transform-react-jsx@7.28.6", "", { "dependencies": { "@babel/helper-annotate-as-pure": "^7.27.3", "@babel/helper-module-imports": "^7.28.6", "@babel/helper-plugin-utils": "^7.28.6", "@babel/plugin-syntax-jsx": "^7.28.6", "@babel/types": "^7.28.6" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-61bxqhiRfAACulXSLd/GxqmAedUSrRZIu/cbaT18T1CetkTmtDN15it7i80ru4DVqRK1WMxQhXs+Lf9kajm5Ow=="],
 
     "@babel/plugin-transform-react-jsx-development": ["@babel/plugin-transform-react-jsx-development@7.27.1", "", { "dependencies": { "@babel/plugin-transform-react-jsx": "^7.27.1" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-ykDdF5yI4f1WrAolLqeF3hmYU12j9ntLQl/AOG1HAS21jxyg1Q0/J/tpREuYLfatGdGmXp/3yS0ZA76kOlVq9Q=="],
@@ -548,8 +472,6 @@
 
     "@bcoe/v8-coverage": ["@bcoe/v8-coverage@0.2.3", "", {}, "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw=="],
 
-    "@better-auth/api-key": ["@better-auth/api-key@1.6.8", "", { "dependencies": { "zod": "^4.3.6" }, "peerDependencies": { "@better-auth/core": "^1.6.8", "@better-auth/utils": "0.4.0", "better-auth": "^1.6.8" } }, "sha512-Sm2NawGFP+bhGjwUorasITjvqII/bxP+Zcjw7tdga2IspeI2IxSQ6sq2jymqGeE5cN5lzC+w9zwOUDsyHeeTLg=="],
-
     "@better-auth/core": ["@better-auth/core@1.6.8", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.39.0", "@standard-schema/spec": "^1.1.0", "zod": "^4.3.6" }, "peerDependencies": { "@better-auth/utils": "0.4.0", "@better-fetch/fetch": "1.1.21", "@cloudflare/workers-types": ">=4", "@opentelemetry/api": "^1.9.0", "better-call": "1.3.5", "jose": "^6.1.0", "kysely": "^0.28.5", "nanostores": "^1.0.1" }, "optionalPeers": ["@cloudflare/workers-types", "@opentelemetry/api"] }, "sha512-YVLkvMvUDeP3W0Wl9PHgwF2etWxKL9rntP0NjZ3YXsiuf05O5Gx0BNvWSeG9fcUaAFjjkiVdFOEvpYtDPpehog=="],
 
     "@better-auth/drizzle-adapter": ["@better-auth/drizzle-adapter@1.6.8", "", { "peerDependencies": { "@better-auth/core": "^1.6.8", "@better-auth/utils": "0.4.0", "drizzle-orm": "^0.45.2" }, "optionalPeers": ["drizzle-orm"] }, "sha512-iAQ8KWPfGppcakZXStbX7aWGeK0pLlDlzkQN6NhFM7Qm2KwBcc0X1EyRGIiLSIiGw8hTNppGp8igliMm2ti0zw=="],
@@ -559,8 +481,6 @@
     "@better-auth/memory-adapter": ["@better-auth/memory-adapter@1.6.8", "", { "peerDependencies": { "@better-auth/core": "^1.6.8", "@better-auth/utils": "0.4.0" } }, "sha512-A/h7Y/AL7dxsff4gNizbpT+O5AppNSvcbRrkrxRrwr8/DvnajnSVxN6bqG/H+SR/L4/nJUDC0p5wMfOJSvTk8Q=="],
 
     "@better-auth/mongo-adapter": ["@better-auth/mongo-adapter@1.6.8", "", { "peerDependencies": { "@better-auth/core": "^1.6.8", "@better-auth/utils": "0.4.0", "mongodb": "^6.0.0 || ^7.0.0" }, "optionalPeers": ["mongodb"] }, "sha512-z2NxSf890g24co33av3SqBKilP8QesNkIp27zIKRE3AqXjii4zQhN7M17DtAsGWJMH2Z336e/mypR2pYYn9DpQ=="],
-
-    "@better-auth/passkey": ["@better-auth/passkey@1.6.8", "", { "dependencies": { "@simplewebauthn/browser": "^13.2.2", "@simplewebauthn/server": "^13.2.3", "zod": "^4.3.6" }, "peerDependencies": { "@better-auth/core": "^1.6.8", "@better-auth/utils": "0.4.0", "@better-fetch/fetch": "1.1.21", "better-auth": "^1.6.8", "better-call": "1.3.5", "nanostores": "^1.0.1" } }, "sha512-7nOyao3YcH8HUCU48SaKBbT0AsnrFqlwoHTq+jW5zLN/zXKeu5VYN7Eumpgep+eY3bb+nBuf/jGMAldQvmx82w=="],
 
     "@better-auth/prisma-adapter": ["@better-auth/prisma-adapter@1.6.8", "", { "peerDependencies": { "@better-auth/core": "^1.6.8", "@better-auth/utils": "0.4.0", "@prisma/client": "^5.0.0 || ^6.0.0 || ^7.0.0", "prisma": "^5.0.0 || ^6.0.0 || ^7.0.0" }, "optionalPeers": ["@prisma/client", "prisma"] }, "sha512-eyPCQwFXFgGo82acjvQpL5iPNi4h3SWhpTG6Ck0mROkqYU9H0v3lpf9vnO/EraOkB6o7VGDPmOirJNYGcFd4lQ=="],
 
@@ -594,10 +514,6 @@
 
     "@capsizecss/unpack": ["@capsizecss/unpack@4.0.0", "", { "dependencies": { "fontkitten": "^1.0.0" } }, "sha512-VERIM64vtTP1C4mxQ5thVT9fK0apjPFobqybMtA1UdUujWka24ERHbRHFGmpbbhp73MhV+KSsHQH9C6uOTdEQA=="],
 
-    "@captchafox/react": ["@captchafox/react@1.12.0", "", { "dependencies": { "@captchafox/types": "^1.4.0" }, "peerDependencies": { "react": ">=16.8.0", "react-dom": ">=16.8.0" } }, "sha512-ALJWVvSBL3H16KMrGg3exO6EufI32zY63LBB0UC0l7jW+Ynz832tG7wwg0PbDWNle0CiN35DAfxDzH/29sDp3g=="],
-
-    "@captchafox/types": ["@captchafox/types@1.5.0", "", {}, "sha512-uReDnNoAarRjhbxC0w4hEueKLCx8w22dv+XqzDjR4rUFo3fCj8Dh3A6D27OFAYlfSr/nwomDatAxz7ixwJ5y5w=="],
-
     "@chat-adapter/discord": ["@chat-adapter/discord@4.26.0", "", { "dependencies": { "@chat-adapter/shared": "4.26.0", "chat": "4.26.0", "discord-api-types": "^0.37.119", "discord-interactions": "^4.4.0", "discord.js": "^14.25.1" } }, "sha512-p0Xm/aPjHP9z87/tXtHz0KFmbUcu7SGPQAAlT8mrKRX49jO77Tognj/5poSmV1XQ1C4BLfxpPvTQlLNK/5omkw=="],
 
     "@chat-adapter/gchat": ["@chat-adapter/gchat@4.26.0", "", { "dependencies": { "@chat-adapter/shared": "4.26.0", "@googleapis/chat": "^44.6.0", "@googleapis/workspaceevents": "^9.1.0", "chat": "4.26.0" } }, "sha512-GOS3hBrjGx/m1NE1HDtwA8st/aeW3W1TaINeXqX7IjCMnO0re1Q31DwhpaPkTD7CraqrSJRUwV37Gz/hCTmWNw=="],
@@ -616,22 +532,6 @@
 
     "@clack/prompts": ["@clack/prompts@1.2.0", "", { "dependencies": { "@clack/core": "1.2.0", "fast-string-width": "^1.1.0", "fast-wrap-ansi": "^0.1.3", "sisteransi": "^1.0.5" } }, "sha512-4jmztR9fMqPMjz6H/UZXj0zEmE43ha1euENwkckKKel4XpSfokExPo5AiVStdHSAlHekz4d0CA/r45Ok1E4D3w=="],
 
-    "@codemirror/autocomplete": ["@codemirror/autocomplete@6.20.1", "", { "dependencies": { "@codemirror/language": "^6.0.0", "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.17.0", "@lezer/common": "^1.0.0" } }, "sha512-1cvg3Vz1dSSToCNlJfRA2WSI4ht3K+WplO0UMOgmUYPivCyy2oueZY6Lx7M9wThm7SDUBViRmuT+OG/i8+ON9A=="],
-
-    "@codemirror/commands": ["@codemirror/commands@6.10.3", "", { "dependencies": { "@codemirror/language": "^6.0.0", "@codemirror/state": "^6.6.0", "@codemirror/view": "^6.27.0", "@lezer/common": "^1.1.0" } }, "sha512-JFRiqhKu+bvSkDLI+rUhJwSxQxYb759W5GBezE8Uc8mHLqC9aV/9aTC7yJSqCtB3F00pylrLCwnyS91Ap5ej4Q=="],
-
-    "@codemirror/lang-json": ["@codemirror/lang-json@6.0.2", "", { "dependencies": { "@codemirror/language": "^6.0.0", "@lezer/json": "^1.0.0" } }, "sha512-x2OtO+AvwEHrEwR0FyyPtfDUiloG3rnVTSZV1W8UteaLL8/MajQd8DpvUb2YVzC+/T18aSDv0H9mu+xw0EStoQ=="],
-
-    "@codemirror/language": ["@codemirror/language@6.12.3", "", { "dependencies": { "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.23.0", "@lezer/common": "^1.5.0", "@lezer/highlight": "^1.0.0", "@lezer/lr": "^1.0.0", "style-mod": "^4.0.0" } }, "sha512-QwCZW6Tt1siP37Jet9Tb02Zs81TQt6qQrZR2H+eGMcFsL1zMrk2/b9CLC7/9ieP1fjIUMgviLWMmgiHoJrj+ZA=="],
-
-    "@codemirror/lint": ["@codemirror/lint@6.9.5", "", { "dependencies": { "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.35.0", "crelt": "^1.0.5" } }, "sha512-GElsbU9G7QT9xXhpUg1zWGmftA/7jamh+7+ydKRuT0ORpWS3wOSP0yT1FOlIZa7mIJjpVPipErsyvVqB9cfTFA=="],
-
-    "@codemirror/search": ["@codemirror/search@6.7.0", "", { "dependencies": { "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.37.0", "crelt": "^1.0.5" } }, "sha512-ZvGm99wc/s2cITtMT15LFdn8aH/aS+V+DqyGq/N5ZlV5vWtH+nILvC2nw0zX7ByNoHHDZ2IxxdW38O0tc5nVHg=="],
-
-    "@codemirror/state": ["@codemirror/state@6.6.0", "", { "dependencies": { "@marijn/find-cluster-break": "^1.0.0" } }, "sha512-4nbvra5R5EtiCzr9BTHiTLc+MLXK2QGiAVYMyi8PkQd3SR+6ixar/Q/01Fa21TBIDOZXgeWV4WppsQolSreAPQ=="],
-
-    "@codemirror/view": ["@codemirror/view@6.41.1", "", { "dependencies": { "@codemirror/state": "^6.6.0", "crelt": "^1.0.6", "style-mod": "^4.1.0", "w3c-keyname": "^2.2.4" } }, "sha512-ToDnWKbBnke+ZLrP6vgTTDScGi5H37YYuZGniQaBzxMVdtCxMrslsmtnOvbPZk4RX9bvkQqnWR/WS/35tJA0qg=="],
-
     "@colors/colors": ["@colors/colors@1.6.0", "", {}, "sha512-Ir+AOibqzrIsL6ajt3Rz3LskB7OiMVHqltZmspbW/TJuTVuyOMirVqAkjfY6JISiLHgyNqicAC8AyHHGzNd/dA=="],
 
     "@csstools/color-helpers": ["@csstools/color-helpers@6.0.2", "", {}, "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q=="],
@@ -649,12 +549,6 @@
     "@ctrl/tinycolor": ["@ctrl/tinycolor@4.2.0", "", {}, "sha512-kzyuwOAQnXJNLS9PSyrk0CWk35nWJW/zl/6KvnTBMFK65gm7U1/Z5BqjxeapjZCIhQcM/DsrEmcbRwDyXyXK4A=="],
 
     "@dabh/diagnostics": ["@dabh/diagnostics@2.0.8", "", { "dependencies": { "@so-ric/colorspace": "^1.1.6", "enabled": "2.0.x", "kuler": "^2.0.0" } }, "sha512-R4MSXTVnuMzGD7bzHdW2ZhhdPC/igELENcq5IjEverBvq5hn1SXCWcsi6eSsdWP0/Ur+SItRRjAktmdoX/8R/Q=="],
-
-    "@date-fns/tz": ["@date-fns/tz@1.4.1", "", {}, "sha512-P5LUNhtbj6YfI3iJjw5EL9eUAG6OitD0W3fWQcpQjDRc/QIsL0tRNuO1PcDvPccWL1fSTXXdE1ds+l95DV/OFA=="],
-
-    "@daveyplate/better-auth-tanstack": ["@daveyplate/better-auth-tanstack@1.3.6", "", { "peerDependencies": { "@tanstack/query-core": ">=5.65.0", "@tanstack/react-query": ">=5.65.0", "better-auth": ">=1.2.8", "react": ">=18.0.0", "react-dom": ">=18.0.0" } }, "sha512-GvIGdbjRMZCEfAffU7LeWpGpie4vSli8V9jmNFCQOziZZMEFbO4cd53HBFmAushC9oEYIyhSNZBgV2ADzW94Ww=="],
-
-    "@daveyplate/better-auth-ui": ["@daveyplate/better-auth-ui@3.4.0", "", { "dependencies": { "@better-auth/api-key": "^1.5.6", "@better-fetch/fetch": "^1.1.21", "@hcaptcha/react-hcaptcha": "^2.0.2", "@noble/hashes": "^2.0.1", "@react-email/components": "^1.0.10", "@wojtekmaj/react-recaptcha-v3": "^0.1.4", "better-call": "2.0.2", "bowser": "^2.11.0", "react-google-recaptcha": "^3.1.0", "react-qr-code": "^2.0.18", "vaul": "^1.1.2" }, "peerDependencies": { "@better-auth/passkey": ">=1.4.6", "@captchafox/react": "^1.10.0", "@daveyplate/better-auth-tanstack": "^1.3.6", "@hookform/resolvers": ">=5.2.0", "@instantdb/react": ">=0.18.0", "@marsidev/react-turnstile": ">=1.1.0", "@radix-ui/react-avatar": ">=1.1.0", "@radix-ui/react-checkbox": ">=1.1.0", "@radix-ui/react-context": ">=1.1.0", "@radix-ui/react-dialog": ">=1.1.0", "@radix-ui/react-dropdown-menu": ">=2.1.0", "@radix-ui/react-label": ">=2.1.0", "@radix-ui/react-primitive": ">=2.0.0", "@radix-ui/react-select": ">=2.2.0", "@radix-ui/react-separator": ">=1.1.0", "@radix-ui/react-slot": ">=1.1.0", "@radix-ui/react-tabs": ">=1.1.0", "@radix-ui/react-tooltip": ">=1.2.0", "@radix-ui/react-use-callback-ref": ">=1.1.0", "@radix-ui/react-use-layout-effect": ">=1.1.0", "@tanstack/react-query": ">=5.66.0", "@triplit/client": ">=1.0.0", "@triplit/react": ">=1.0.0", "better-auth": "^1.4.6", "class-variance-authority": ">=0.7.0", "clsx": ">=2.1.0", "input-otp": ">=1.4.0", "lucide-react": ">=0.469.0", "react": ">=18.0.0", "react-dom": ">=18.0.0", "react-hook-form": ">=7.55.0", "sonner": ">=1.7.0", "tailwind-merge": ">=2.6.0", "tailwindcss": ">=3.0.0", "zod": ">=3.0.0" } }, "sha512-mGA0cKsAk0AcoKkxjff2xQOviMrUDDN+9SsRusURP/kiTmoLvWAv8utaPex0GFLHKm1w3BrLBdJRg9B2LkT7Bw=="],
 
     "@discordjs/builders": ["@discordjs/builders@1.14.1", "", { "dependencies": { "@discordjs/formatters": "^0.6.2", "@discordjs/util": "^1.2.0", "@sapphire/shapeshift": "^4.0.0", "discord-api-types": "^0.38.40", "fast-deep-equal": "^3.1.3", "ts-mixer": "^6.0.4", "tslib": "^2.6.3" } }, "sha512-gSKkhXLqs96TCzk66VZuHHl8z2bQMJFGwrXC0f33ngK+FLNau4hU1PYny3DNJfNdSH+gVMzE85/d5FQ2BpcNwQ=="],
 
@@ -742,14 +636,6 @@
 
     "@fastify/otel": ["@fastify/otel@0.18.0", "", { "dependencies": { "@opentelemetry/core": "^2.0.0", "@opentelemetry/instrumentation": "^0.212.0", "@opentelemetry/semantic-conventions": "^1.28.0", "minimatch": "^10.2.4" }, "peerDependencies": { "@opentelemetry/api": "^1.9.0" } }, "sha512-3TASCATfw+ctICSb4ymrv7iCm0qJ0N9CarB+CZ7zIJ7KqNbwI5JjyDL1/sxoC0ccTO1Zyd1iQ+oqncPg5FJXaA=="],
 
-    "@floating-ui/core": ["@floating-ui/core@1.7.5", "", { "dependencies": { "@floating-ui/utils": "^0.2.11" } }, "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ=="],
-
-    "@floating-ui/dom": ["@floating-ui/dom@1.7.6", "", { "dependencies": { "@floating-ui/core": "^1.7.5", "@floating-ui/utils": "^0.2.11" } }, "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ=="],
-
-    "@floating-ui/react-dom": ["@floating-ui/react-dom@2.1.8", "", { "dependencies": { "@floating-ui/dom": "^1.7.6" }, "peerDependencies": { "react": ">=16.8.0", "react-dom": ">=16.8.0" } }, "sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A=="],
-
-    "@floating-ui/utils": ["@floating-ui/utils@0.2.11", "", {}, "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg=="],
-
     "@google/genai": ["@google/genai@1.34.0", "", { "dependencies": { "google-auth-library": "^10.3.0", "ws": "^8.18.0" }, "peerDependencies": { "@modelcontextprotocol/sdk": "^1.24.0" }, "optionalPeers": ["@modelcontextprotocol/sdk"] }, "sha512-vu53UMPvjmb7PGzlYu6Tzxso8Dfhn+a7eQFaS2uNemVtDZKwzSpJ5+ikqBbXplF7RGB1STcVDqCkPvquiwb2sw=="],
 
     "@googleapis/chat": ["@googleapis/chat@44.6.0", "", { "dependencies": { "googleapis-common": "^8.0.0" } }, "sha512-Bnqzev/bSTXSbE0/N2WS4Stnleo8j9bJJ1LkCBk1fXQnehcArVMv7q543rzPYU6MJql4D34On6diNGAuYtI9xQ=="],
@@ -760,17 +646,11 @@
 
     "@grpc/proto-loader": ["@grpc/proto-loader@0.8.0", "", { "dependencies": { "lodash.camelcase": "^4.3.0", "long": "^5.0.0", "protobufjs": "^7.5.3", "yargs": "^17.7.2" }, "bin": { "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js" } }, "sha512-rc1hOQtjIWGxcxpb9aHAfLpIctjEnsDehj0DAiVfBlmT84uvR0uUtN2hEi/ecvWVjXUGf5qPF4qEgiLOx1YIMQ=="],
 
-    "@hcaptcha/react-hcaptcha": ["@hcaptcha/react-hcaptcha@2.0.2", "", {}, "sha512-VbuH6VJ6m3BHmVBHs0fL9t+suZd7PQEqCzqL2BiUbBvbHI3XfvSgdiug2QiEPN8zskbPTIV/FfGPF53JCckrow=="],
-
-    "@hexagon/base64": ["@hexagon/base64@1.1.28", "", {}, "sha512-lhqDEAvWixy3bZ+UOYbPwUbBkwBq5C1LAJ/xPC8Oi+lL54oyakv/npbA0aU2hgCsx/1NUd4IBvV03+aUBWxerw=="],
-
     "@hono/node-server": ["@hono/node-server@1.19.14", "", { "peerDependencies": { "hono": "^4" } }, "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw=="],
 
     "@hono/zod-openapi": ["@hono/zod-openapi@1.3.0", "", { "dependencies": { "@asteasolutions/zod-to-openapi": "^8.5.0", "@hono/zod-validator": "^0.7.6", "openapi3-ts": "^4.5.0" }, "peerDependencies": { "hono": ">=4.3.6", "zod": "^4.0.0" } }, "sha512-loDVevfMaaNa0slskhpMcqjSdidVXba2QJwNVmnS5Dp6L8AqSgtjJxWGJfRZtosyzYOb5gx4ZzXNCe+QhwY7xw=="],
 
     "@hono/zod-validator": ["@hono/zod-validator@0.7.6", "", { "peerDependencies": { "hono": ">=3.9.0", "zod": "^3.25.0 || ^4.0.0" } }, "sha512-Io1B6d011Gj1KknV4rXYz4le5+5EubcWEU/speUjuw9XMMIaP3n78yXLhjd2A3PXaXaUwEAluOiAyLqhBEJgsw=="],
-
-    "@hookform/resolvers": ["@hookform/resolvers@5.2.2", "", { "dependencies": { "@standard-schema/utils": "^0.3.0" }, "peerDependencies": { "react-hook-form": "^7.55.0" } }, "sha512-A/IxlMLShx3KjV/HeTcTfaMxdwy690+L/ZADoeaTltLx+CVuzkeVIPuybK3jrRfw7YZnmdKsVVHAlEPIAEUNlA=="],
 
     "@huggingface/jinja": ["@huggingface/jinja@0.2.2", "", {}, "sha512-/KPde26khDUIPkTGU82jdtTW9UAuvUTumCAbFs/7giR0SxsvZC4hru51PBvpijH6BVkHcROcvZM/lpy5h1jRRA=="],
 
@@ -855,14 +735,6 @@
     "@inquirer/select": ["@inquirer/select@4.4.2", "", { "dependencies": { "@inquirer/ansi": "^1.0.2", "@inquirer/core": "^10.3.2", "@inquirer/figures": "^1.0.15", "@inquirer/type": "^3.0.10", "yoctocolors-cjs": "^2.1.3" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-l4xMuJo55MAe+N7Qr4rX90vypFwCajSakx59qe/tMaC1aEHWLyw68wF4o0A4SLAY4E0nd+Vt+EyskeDIqu1M6w=="],
 
     "@inquirer/type": ["@inquirer/type@3.0.10", "", { "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-BvziSRxfz5Ov8ch0z/n3oijRSEcEsHnhggm4xFZe93DHcUCTlutlq9Ox4SVENAfcRD22UQq7T/atg9Wr3k09eA=="],
-
-    "@instantdb/core": ["@instantdb/core@1.0.15", "", { "dependencies": { "@instantdb/version": "1.0.15", "mutative": "^1.0.10", "uuid": "^11.1.0" } }, "sha512-1A4n47U0YLHKhvl0G+CiPGfBynq1cj+NqIVRhUMc/yHYT6rePeRWesxvevNiEJU2sLxOKML6Htcbtdh7jUjSQA=="],
-
-    "@instantdb/react": ["@instantdb/react@1.0.15", "", { "dependencies": { "@instantdb/core": "1.0.15", "@instantdb/react-common": "1.0.15", "@instantdb/version": "1.0.15", "eventsource": "^4.0.0" }, "peerDependencies": { "react": ">=16" } }, "sha512-d6Jbl10DaUh9Ni8+C0RLoTTHpB0UP9/8wAznimb6Z5dDhFiQ3gQyXpnz81OPXQEpQmEJUscqdGJul0DL17s8/g=="],
-
-    "@instantdb/react-common": ["@instantdb/react-common@1.0.15", "", { "dependencies": { "@instantdb/core": "1.0.15", "@instantdb/version": "1.0.15" }, "peerDependencies": { "react": ">=16" } }, "sha512-EuDG9DfAx+XLW9UQoGe4lwW7Xos8njIuJp/grm0v7uWvnxlgAqKG+rTKjTDP0P6GfPpRbcZS0Houg0951tQe2g=="],
-
-    "@instantdb/version": ["@instantdb/version@1.0.15", "", {}, "sha512-xHDT23QK0tKAdxC2Z98mBx+znwnVShYWDsp0juY4xxzTGjrb37qNqRYb+6IIJc1J3GZ+xW/fCIexVK3b0B6fog=="],
 
     "@ioredis/commands": ["@ioredis/commands@1.5.1", "", {}, "sha512-JH8ZL/ywcJyR9MmJ5BNqZllXNZQqQbnVZOqpPQqE1vHiFgAw4NHbvE0FOduNU8IX9babitBT46571OnPTT0Zcw=="],
 
@@ -958,20 +830,6 @@
 
     "@jscpd/tokenizer": ["@jscpd/tokenizer@4.0.5", "", { "dependencies": { "@jscpd/core": "4.0.5", "reprism": "^0.0.11", "spark-md5": "^3.0.2" } }, "sha512-WzRujQtN5WedxZVDKuoanxmKAFrxcLrHpcA6kaM4z8AhGtWXZ325yseqgL5TZ8OK7Auwu7kQLlqhfk05fGYG7A=="],
 
-    "@jsonforms/core": ["@jsonforms/core@3.7.0", "", { "dependencies": { "@types/json-schema": "^7.0.3", "ajv": "^8.6.1", "ajv-formats": "^2.1.0", "lodash": "^4.17.21" } }, "sha512-CE9viWtwi9QWLqlWLeOul1/R1GRAyOA9y6OoUpsCc0FhyR+g5p29F3k0fUExHWxL0Sf4KHcXYkfhtqfRBPS8ww=="],
-
-    "@jsonforms/react": ["@jsonforms/react@3.7.0", "", { "dependencies": { "lodash": "^4.17.21" }, "peerDependencies": { "@jsonforms/core": "3.7.0", "react": "^16.12.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-HkY7qAx8vW97wPEgZ7GxCB3iiXG1c95GuObxtcDHGPBJWMwnxWBnVYJmv5h7nthrInKsQKHZL5OusnC/sj/1GQ=="],
-
-    "@levischuck/tiny-cbor": ["@levischuck/tiny-cbor@0.2.11", "", {}, "sha512-llBRm4dT4Z89aRsm6u2oEZ8tfwL/2l6BwpZ7JcyieouniDECM5AqNgr/y08zalEIvW3RSK4upYyybDcmjXqAow=="],
-
-    "@lezer/common": ["@lezer/common@1.5.2", "", {}, "sha512-sxQE460fPZyU3sdc8lafxiPwJHBzZRy/udNFynGQky1SePYBdhkBl1kOagA9uT3pxR8K09bOrmTUqA9wb/PjSQ=="],
-
-    "@lezer/highlight": ["@lezer/highlight@1.2.3", "", { "dependencies": { "@lezer/common": "^1.3.0" } }, "sha512-qXdH7UqTvGfdVBINrgKhDsVTJTxactNNxLk7+UMwZhU13lMHaOBlJe9Vqp907ya56Y3+ed2tlqzys7jDkTmW0g=="],
-
-    "@lezer/json": ["@lezer/json@1.0.3", "", { "dependencies": { "@lezer/common": "^1.2.0", "@lezer/highlight": "^1.0.0", "@lezer/lr": "^1.0.0" } }, "sha512-BP9KzdF9Y35PDpv04r0VeSTKDeox5vVr3efE7eBbx3r4s3oNLfunchejZhjArmeieBH+nVOpgIiBJpEAv8ilqQ=="],
-
-    "@lezer/lr": ["@lezer/lr@1.4.10", "", { "dependencies": { "@lezer/common": "^1.0.0" } }, "sha512-rnCpTIBafOx4mRp43xOxDJbFipJm/c0cia/V5TiGlhmMa+wsSdoGmUN3w5Bqrks/09Q/D4tNAmWaT8p6NRi77A=="],
-
     "@lobu/cli": ["@lobu/cli@workspace:packages/cli"],
 
     "@lobu/core": ["@lobu/core@workspace:packages/core"],
@@ -993,8 +851,6 @@
     "@lobu/owletto-worker": ["@lobu/owletto-worker@workspace:packages/owletto-worker"],
 
     "@lobu/worker": ["@lobu/worker@workspace:packages/worker"],
-
-    "@marijn/find-cluster-break": ["@marijn/find-cluster-break@1.0.2", "", {}, "sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g=="],
 
     "@mariozechner/clipboard": ["@mariozechner/clipboard@0.3.2", "", { "optionalDependencies": { "@mariozechner/clipboard-darwin-arm64": "0.3.2", "@mariozechner/clipboard-darwin-universal": "0.3.2", "@mariozechner/clipboard-darwin-x64": "0.3.2", "@mariozechner/clipboard-linux-arm64-gnu": "0.3.2", "@mariozechner/clipboard-linux-arm64-musl": "0.3.2", "@mariozechner/clipboard-linux-riscv64-gnu": "0.3.2", "@mariozechner/clipboard-linux-x64-gnu": "0.3.2", "@mariozechner/clipboard-linux-x64-musl": "0.3.2", "@mariozechner/clipboard-win32-arm64-msvc": "0.3.2", "@mariozechner/clipboard-win32-x64-msvc": "0.3.2" } }, "sha512-IHQpksNjo7EAtGuHFU+tbWDp5LarH3HU/8WiB9O70ZEoBPHOg0/6afwSLK0QyNMMmx4Bpi/zl6+DcBXe95nWYA=="],
 
@@ -1027,8 +883,6 @@
     "@mariozechner/pi-coding-agent": ["@mariozechner/pi-coding-agent@0.51.6", "", { "dependencies": { "@mariozechner/jiti": "^2.6.2", "@mariozechner/pi-agent-core": "^0.51.6", "@mariozechner/pi-ai": "^0.51.6", "@mariozechner/pi-tui": "^0.51.6", "@silvia-odwyer/photon-node": "^0.3.4", "chalk": "^5.5.0", "cli-highlight": "^2.1.11", "diff": "^8.0.2", "file-type": "^21.1.1", "glob": "^13.0.1", "ignore": "^7.0.5", "marked": "^15.0.12", "minimatch": "^10.1.1", "proper-lockfile": "^4.1.2", "yaml": "^2.8.2" }, "optionalDependencies": { "@mariozechner/clipboard": "^0.3.2" }, "bin": { "pi": "dist/cli.js" } }, "sha512-Rg3/C6a/30E1AoWHShoFUXMlvkvhK9xUEJTdApmIS51kCI4UuPcqw4fe9kq5I8KeMuAlcjo+jweMYrNVVvkNRw=="],
 
     "@mariozechner/pi-tui": ["@mariozechner/pi-tui@0.51.6", "", { "dependencies": { "@types/mime-types": "^2.1.4", "chalk": "^5.5.0", "get-east-asian-width": "^1.3.0", "marked": "^15.0.12", "mime-types": "^3.0.1" } }, "sha512-mG/RH5qArwLXcbnR3BOb8MRDGj4MvUD+c/AYySmC6XTkF+LVDw6Vc14cUcusblIUaE1GNmp+dxsRORmnh+0whg=="],
-
-    "@marsidev/react-turnstile": ["@marsidev/react-turnstile@1.5.0", "", { "peerDependencies": { "react": "^17.0.2 || ^18.0.0 || ^19.0", "react-dom": "^17.0.2 || ^18.0.0 || ^19.0" } }, "sha512-Ph6mcj8u9WBDsBO7s9jKPsyRDz1sBPBJwrk+Ngx09vFInvKsQ6U6kW5amEcGq4dHOreB6DgFrOJk7/fy318YlQ=="],
 
     "@mdx-js/mdx": ["@mdx-js/mdx@3.1.1", "", { "dependencies": { "@types/estree": "^1.0.0", "@types/estree-jsx": "^1.0.0", "@types/hast": "^3.0.0", "@types/mdx": "^2.0.0", "acorn": "^8.0.0", "collapse-white-space": "^2.0.0", "devlop": "^1.0.0", "estree-util-is-identifier-name": "^3.0.0", "estree-util-scope": "^1.0.0", "estree-walker": "^3.0.0", "hast-util-to-jsx-runtime": "^2.0.0", "markdown-extensions": "^2.0.0", "recma-build-jsx": "^1.0.0", "recma-jsx": "^1.0.0", "recma-stringify": "^1.0.0", "rehype-recma": "^1.0.0", "remark-mdx": "^3.0.0", "remark-parse": "^11.0.0", "remark-rehype": "^11.0.0", "source-map": "^0.7.0", "unified": "^11.0.0", "unist-util-position-from-estree": "^2.0.0", "unist-util-stringify-position": "^4.0.0", "unist-util-visit": "^5.0.0", "vfile": "^6.0.0" } }, "sha512-f6ZO2ifpwAQIpzGWaBQT2TXxPv6z3RBzQKpVftEWN78Vl/YweF1uwussDx8ECAXVtr3Rs89fKyG9YlzUs9DyGQ=="],
 
@@ -1184,8 +1038,6 @@
 
     "@oven/bun-windows-x64-baseline": ["@oven/bun-windows-x64-baseline@1.3.13", "", { "os": "win32", "cpu": "x64" }, "sha512-6gy4hhQSjq/T/S9hC9m3NxY0RY+9Ww+XNlB+8koIMTsMSYEjk7Ho+hFHQz1Bn4W61Ub7Vykufg+jgDgPfa2GFA=="],
 
-    "@owletto/web": ["@owletto/web@workspace:packages/owletto-web"],
-
     "@oxc-resolver/binding-android-arm-eabi": ["@oxc-resolver/binding-android-arm-eabi@11.19.1", "", { "os": "android", "cpu": "arm" }, "sha512-aUs47y+xyXHUKlbhqHUjBABjvycq6YSD7bpxSW7vplUmdzAlJ93yXY6ZR0c1o1x5A/QKbENCvs3+NlY8IpIVzg=="],
 
     "@oxc-resolver/binding-android-arm64": ["@oxc-resolver/binding-android-arm64@11.19.1", "", { "os": "android", "cpu": "arm64" }, "sha512-oolbkRX+m7Pq2LNjr/kKgYeC7bRDMVTWPgxBGMjSpZi/+UskVo4jsMU3MLheZV55jL6c3rNelPl4oD60ggYmqA=="],
@@ -1242,30 +1094,6 @@
 
     "@pagefind/windows-x64": ["@pagefind/windows-x64@1.5.2", "", { "os": "win32", "cpu": "x64" }, "sha512-Fa2Iyw7kaDRzGMfNYNUXNW2zbL5FQVDgSOcbDHdzBrDEdpqOqg8TcZ68F22ol6NJ9IGzvUdmeyZypLW5dyhqsg=="],
 
-    "@peculiar/asn1-android": ["@peculiar/asn1-android@2.6.0", "", { "dependencies": { "@peculiar/asn1-schema": "^2.6.0", "asn1js": "^3.0.6", "tslib": "^2.8.1" } }, "sha512-cBRCKtYPF7vJGN76/yG8VbxRcHLPF3HnkoHhKOZeHpoVtbMYfY9ROKtH3DtYUY9m8uI1Mh47PRhHf2hSK3xcSQ=="],
-
-    "@peculiar/asn1-cms": ["@peculiar/asn1-cms@2.6.1", "", { "dependencies": { "@peculiar/asn1-schema": "^2.6.0", "@peculiar/asn1-x509": "^2.6.1", "@peculiar/asn1-x509-attr": "^2.6.1", "asn1js": "^3.0.6", "tslib": "^2.8.1" } }, "sha512-vdG4fBF6Lkirkcl53q6eOdn3XYKt+kJTG59edgRZORlg/3atWWEReRCx5rYE1ZzTTX6vLK5zDMjHh7vbrcXGtw=="],
-
-    "@peculiar/asn1-csr": ["@peculiar/asn1-csr@2.6.1", "", { "dependencies": { "@peculiar/asn1-schema": "^2.6.0", "@peculiar/asn1-x509": "^2.6.1", "asn1js": "^3.0.6", "tslib": "^2.8.1" } }, "sha512-WRWnKfIocHyzFYQTka8O/tXCiBquAPSrRjXbOkHbO4qdmS6loffCEGs+rby6WxxGdJCuunnhS2duHURhjyio6w=="],
-
-    "@peculiar/asn1-ecc": ["@peculiar/asn1-ecc@2.6.1", "", { "dependencies": { "@peculiar/asn1-schema": "^2.6.0", "@peculiar/asn1-x509": "^2.6.1", "asn1js": "^3.0.6", "tslib": "^2.8.1" } }, "sha512-+Vqw8WFxrtDIN5ehUdvlN2m73exS2JVG0UAyfVB31gIfor3zWEAQPD+K9ydCxaj3MLen9k0JhKpu9LqviuCE1g=="],
-
-    "@peculiar/asn1-pfx": ["@peculiar/asn1-pfx@2.6.1", "", { "dependencies": { "@peculiar/asn1-cms": "^2.6.1", "@peculiar/asn1-pkcs8": "^2.6.1", "@peculiar/asn1-rsa": "^2.6.1", "@peculiar/asn1-schema": "^2.6.0", "asn1js": "^3.0.6", "tslib": "^2.8.1" } }, "sha512-nB5jVQy3MAAWvq0KY0R2JUZG8bO/bTLpnwyOzXyEh/e54ynGTatAR+csOnXkkVD9AFZ2uL8Z7EV918+qB1qDvw=="],
-
-    "@peculiar/asn1-pkcs8": ["@peculiar/asn1-pkcs8@2.6.1", "", { "dependencies": { "@peculiar/asn1-schema": "^2.6.0", "@peculiar/asn1-x509": "^2.6.1", "asn1js": "^3.0.6", "tslib": "^2.8.1" } }, "sha512-JB5iQ9Izn5yGMw3ZG4Nw3Xn/hb/G38GYF3lf7WmJb8JZUydhVGEjK/ZlFSWhnlB7K/4oqEs8HnfFIKklhR58Tw=="],
-
-    "@peculiar/asn1-pkcs9": ["@peculiar/asn1-pkcs9@2.6.1", "", { "dependencies": { "@peculiar/asn1-cms": "^2.6.1", "@peculiar/asn1-pfx": "^2.6.1", "@peculiar/asn1-pkcs8": "^2.6.1", "@peculiar/asn1-schema": "^2.6.0", "@peculiar/asn1-x509": "^2.6.1", "@peculiar/asn1-x509-attr": "^2.6.1", "asn1js": "^3.0.6", "tslib": "^2.8.1" } }, "sha512-5EV8nZoMSxeWmcxWmmcolg22ojZRgJg+Y9MX2fnE2bGRo5KQLqV5IL9kdSQDZxlHz95tHvIq9F//bvL1OeNILw=="],
-
-    "@peculiar/asn1-rsa": ["@peculiar/asn1-rsa@2.6.1", "", { "dependencies": { "@peculiar/asn1-schema": "^2.6.0", "@peculiar/asn1-x509": "^2.6.1", "asn1js": "^3.0.6", "tslib": "^2.8.1" } }, "sha512-1nVMEh46SElUt5CB3RUTV4EG/z7iYc7EoaDY5ECwganibQPkZ/Y2eMsTKB/LeyrUJ+W/tKoD9WUqIy8vB+CEdA=="],
-
-    "@peculiar/asn1-schema": ["@peculiar/asn1-schema@2.6.0", "", { "dependencies": { "asn1js": "^3.0.6", "pvtsutils": "^1.3.6", "tslib": "^2.8.1" } }, "sha512-xNLYLBFTBKkCzEZIw842BxytQQATQv+lDTCEMZ8C196iJcJJMBUZxrhSTxLaohMyKK8QlzRNTRkUmanucnDSqg=="],
-
-    "@peculiar/asn1-x509": ["@peculiar/asn1-x509@2.6.1", "", { "dependencies": { "@peculiar/asn1-schema": "^2.6.0", "asn1js": "^3.0.6", "pvtsutils": "^1.3.6", "tslib": "^2.8.1" } }, "sha512-O9jT5F1A2+t3r7C4VT7LYGXqkGLK7Kj1xFpz7U0isPrubwU5PbDoyYtx6MiGst29yq7pXN5vZbQFKRCP+lLZlA=="],
-
-    "@peculiar/asn1-x509-attr": ["@peculiar/asn1-x509-attr@2.6.1", "", { "dependencies": { "@peculiar/asn1-schema": "^2.6.0", "@peculiar/asn1-x509": "^2.6.1", "asn1js": "^3.0.6", "tslib": "^2.8.1" } }, "sha512-tlW6cxoHwgcQghnJwv3YS+9OO1737zgPogZ+CgWRUK4roEwIPzRH4JEiG770xe5HX2ATfCpmX60gurfWIF9dcQ=="],
-
-    "@peculiar/x509": ["@peculiar/x509@1.14.3", "", { "dependencies": { "@peculiar/asn1-cms": "^2.6.0", "@peculiar/asn1-csr": "^2.6.0", "@peculiar/asn1-ecc": "^2.6.0", "@peculiar/asn1-pkcs9": "^2.6.0", "@peculiar/asn1-rsa": "^2.6.0", "@peculiar/asn1-schema": "^2.6.0", "@peculiar/asn1-x509": "^2.6.0", "pvtsutils": "^1.3.6", "reflect-metadata": "^0.2.2", "tslib": "^2.8.1", "tsyringe": "^4.10.0" } }, "sha512-C2Xj8FZ0uHWeCXXqX5B4/gVFQmtSkiuOolzAgutjTfseNOHT3pUjljDZsTSxXFGgio54bCzVFqmEOUrIVk8RDA=="],
-
     "@pinojs/redact": ["@pinojs/redact@0.4.0", "", {}, "sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg=="],
 
     "@pkgjs/parseargs": ["@pkgjs/parseargs@0.11.0", "", {}, "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg=="],
@@ -1307,88 +1135,6 @@
     "@protobufjs/pool": ["@protobufjs/pool@1.1.0", "", {}, "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw=="],
 
     "@protobufjs/utf8": ["@protobufjs/utf8@1.1.0", "", {}, "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="],
-
-    "@radix-ui/number": ["@radix-ui/number@1.1.1", "", {}, "sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g=="],
-
-    "@radix-ui/primitive": ["@radix-ui/primitive@1.1.3", "", {}, "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg=="],
-
-    "@radix-ui/react-arrow": ["@radix-ui/react-arrow@1.1.7", "", { "dependencies": { "@radix-ui/react-primitive": "2.1.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-F+M1tLhO+mlQaOWspE8Wstg+z6PwxwRd8oQ8IXceWz92kfAmalTRf0EjrouQeo7QssEPfCn05B4Ihs1K9WQ/7w=="],
-
-    "@radix-ui/react-avatar": ["@radix-ui/react-avatar@1.1.11", "", { "dependencies": { "@radix-ui/react-context": "1.1.3", "@radix-ui/react-primitive": "2.1.4", "@radix-ui/react-use-callback-ref": "1.1.1", "@radix-ui/react-use-is-hydrated": "0.1.0", "@radix-ui/react-use-layout-effect": "1.1.1" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-0Qk603AHGV28BOBO34p7IgD5m+V5Sg/YovfayABkoDDBM5d3NCx0Mp4gGrjzLGes1jV5eNOE1r3itqOR33VC6Q=="],
-
-    "@radix-ui/react-checkbox": ["@radix-ui/react-checkbox@1.3.3", "", { "dependencies": { "@radix-ui/primitive": "1.1.3", "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-context": "1.1.2", "@radix-ui/react-presence": "1.1.5", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-use-controllable-state": "1.2.2", "@radix-ui/react-use-previous": "1.1.1", "@radix-ui/react-use-size": "1.1.1" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-wBbpv+NQftHDdG86Qc0pIyXk5IR3tM8Vd0nWLKDcX8nNn4nXFOFwsKuqw2okA/1D/mpaAkmuyndrPJTYDNZtFw=="],
-
-    "@radix-ui/react-collapsible": ["@radix-ui/react-collapsible@1.1.12", "", { "dependencies": { "@radix-ui/primitive": "1.1.3", "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-context": "1.1.2", "@radix-ui/react-id": "1.1.1", "@radix-ui/react-presence": "1.1.5", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-use-controllable-state": "1.2.2", "@radix-ui/react-use-layout-effect": "1.1.1" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-Uu+mSh4agx2ib1uIGPP4/CKNULyajb3p92LsVXmH2EHVMTfZWpll88XJ0j4W0z3f8NK1eYl1+Mf/szHPmcHzyA=="],
-
-    "@radix-ui/react-collection": ["@radix-ui/react-collection@1.1.7", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-context": "1.1.2", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-slot": "1.2.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-Fh9rGN0MoI4ZFUNyfFVNU4y9LUz93u9/0K+yLgA2bwRojxM8JU1DyvvMBabnZPBgMWREAJvU2jjVzq+LrFUglw=="],
-
-    "@radix-ui/react-compose-refs": ["@radix-ui/react-compose-refs@1.1.2", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg=="],
-
-    "@radix-ui/react-context": ["@radix-ui/react-context@1.1.2", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA=="],
-
-    "@radix-ui/react-dialog": ["@radix-ui/react-dialog@1.1.15", "", { "dependencies": { "@radix-ui/primitive": "1.1.3", "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-context": "1.1.2", "@radix-ui/react-dismissable-layer": "1.1.11", "@radix-ui/react-focus-guards": "1.1.3", "@radix-ui/react-focus-scope": "1.1.7", "@radix-ui/react-id": "1.1.1", "@radix-ui/react-portal": "1.1.9", "@radix-ui/react-presence": "1.1.5", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-slot": "1.2.3", "@radix-ui/react-use-controllable-state": "1.2.2", "aria-hidden": "^1.2.4", "react-remove-scroll": "^2.6.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-TCglVRtzlffRNxRMEyR36DGBLJpeusFcgMVD9PZEzAKnUs1lKCgX5u9BmC2Yg+LL9MgZDugFFs1Vl+Jp4t/PGw=="],
-
-    "@radix-ui/react-direction": ["@radix-ui/react-direction@1.1.1", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-1UEWRX6jnOA2y4H5WczZ44gOOjTEmlqv1uNW4GAJEO5+bauCBhv8snY65Iw5/VOS/ghKN9gr2KjnLKxrsvoMVw=="],
-
-    "@radix-ui/react-dismissable-layer": ["@radix-ui/react-dismissable-layer@1.1.11", "", { "dependencies": { "@radix-ui/primitive": "1.1.3", "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-use-callback-ref": "1.1.1", "@radix-ui/react-use-escape-keydown": "1.1.1" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-Nqcp+t5cTB8BinFkZgXiMJniQH0PsUt2k51FUhbdfeKvc4ACcG2uQniY/8+h1Yv6Kza4Q7lD7PQV0z0oicE0Mg=="],
-
-    "@radix-ui/react-dropdown-menu": ["@radix-ui/react-dropdown-menu@2.1.16", "", { "dependencies": { "@radix-ui/primitive": "1.1.3", "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-context": "1.1.2", "@radix-ui/react-id": "1.1.1", "@radix-ui/react-menu": "2.1.16", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-use-controllable-state": "1.2.2" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-1PLGQEynI/3OX/ftV54COn+3Sud/Mn8vALg2rWnBLnRaGtJDduNW/22XjlGgPdpcIbiQxjKtb7BkcjP00nqfJw=="],
-
-    "@radix-ui/react-focus-guards": ["@radix-ui/react-focus-guards@1.1.3", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-0rFg/Rj2Q62NCm62jZw0QX7a3sz6QCQU0LpZdNrJX8byRGaGVTqbrW9jAoIAHyMQqsNpeZ81YgSizOt5WXq0Pw=="],
-
-    "@radix-ui/react-focus-scope": ["@radix-ui/react-focus-scope@1.1.7", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-use-callback-ref": "1.1.1" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-t2ODlkXBQyn7jkl6TNaw/MtVEVvIGelJDCG41Okq/KwUsJBwQ4XVZsHAVUkK4mBv3ewiAS3PGuUWuY2BoK4ZUw=="],
-
-    "@radix-ui/react-id": ["@radix-ui/react-id@1.1.1", "", { "dependencies": { "@radix-ui/react-use-layout-effect": "1.1.1" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-kGkGegYIdQsOb4XjsfM97rXsiHaBwco+hFI66oO4s9LU+PLAC5oJ7khdOVFxkhsmlbpUqDAvXw11CluXP+jkHg=="],
-
-    "@radix-ui/react-label": ["@radix-ui/react-label@2.1.8", "", { "dependencies": { "@radix-ui/react-primitive": "2.1.4" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-FmXs37I6hSBVDlO4y764TNz1rLgKwjJMQ0EGte6F3Cb3f4bIuHB/iLa/8I9VKkmOy+gNHq8rql3j686ACVV21A=="],
-
-    "@radix-ui/react-menu": ["@radix-ui/react-menu@2.1.16", "", { "dependencies": { "@radix-ui/primitive": "1.1.3", "@radix-ui/react-collection": "1.1.7", "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-context": "1.1.2", "@radix-ui/react-direction": "1.1.1", "@radix-ui/react-dismissable-layer": "1.1.11", "@radix-ui/react-focus-guards": "1.1.3", "@radix-ui/react-focus-scope": "1.1.7", "@radix-ui/react-id": "1.1.1", "@radix-ui/react-popper": "1.2.8", "@radix-ui/react-portal": "1.1.9", "@radix-ui/react-presence": "1.1.5", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-roving-focus": "1.1.11", "@radix-ui/react-slot": "1.2.3", "@radix-ui/react-use-callback-ref": "1.1.1", "aria-hidden": "^1.2.4", "react-remove-scroll": "^2.6.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-72F2T+PLlphrqLcAotYPp0uJMr5SjP5SL01wfEspJbru5Zs5vQaSHb4VB3ZMJPimgHHCHG7gMOeOB9H3Hdmtxg=="],
-
-    "@radix-ui/react-popover": ["@radix-ui/react-popover@1.1.15", "", { "dependencies": { "@radix-ui/primitive": "1.1.3", "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-context": "1.1.2", "@radix-ui/react-dismissable-layer": "1.1.11", "@radix-ui/react-focus-guards": "1.1.3", "@radix-ui/react-focus-scope": "1.1.7", "@radix-ui/react-id": "1.1.1", "@radix-ui/react-popper": "1.2.8", "@radix-ui/react-portal": "1.1.9", "@radix-ui/react-presence": "1.1.5", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-slot": "1.2.3", "@radix-ui/react-use-controllable-state": "1.2.2", "aria-hidden": "^1.2.4", "react-remove-scroll": "^2.6.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-kr0X2+6Yy/vJzLYJUPCZEc8SfQcf+1COFoAqauJm74umQhta9M7lNJHP7QQS3vkvcGLQUbWpMzwrXYwrYztHKA=="],
-
-    "@radix-ui/react-popper": ["@radix-ui/react-popper@1.2.8", "", { "dependencies": { "@floating-ui/react-dom": "^2.0.0", "@radix-ui/react-arrow": "1.1.7", "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-context": "1.1.2", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-use-callback-ref": "1.1.1", "@radix-ui/react-use-layout-effect": "1.1.1", "@radix-ui/react-use-rect": "1.1.1", "@radix-ui/react-use-size": "1.1.1", "@radix-ui/rect": "1.1.1" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-0NJQ4LFFUuWkE7Oxf0htBKS6zLkkjBH+hM1uk7Ng705ReR8m/uelduy1DBo0PyBXPKVnBA6YBlU94MBGXrSBCw=="],
-
-    "@radix-ui/react-portal": ["@radix-ui/react-portal@1.1.9", "", { "dependencies": { "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-use-layout-effect": "1.1.1" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-bpIxvq03if6UNwXZ+HTK71JLh4APvnXntDc6XOX8UVq4XQOVl7lwok0AvIl+b8zgCw3fSaVTZMpAPPagXbKmHQ=="],
-
-    "@radix-ui/react-presence": ["@radix-ui/react-presence@1.1.5", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-use-layout-effect": "1.1.1" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-/jfEwNDdQVBCNvjkGit4h6pMOzq8bHkopq458dPt2lMjx+eBQUohZNG9A7DtO/O5ukSbxuaNGXMjHicgwy6rQQ=="],
-
-    "@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.4", "", { "dependencies": { "@radix-ui/react-slot": "1.2.4" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-9hQc4+GNVtJAIEPEqlYqW5RiYdrr8ea5XQ0ZOnD6fgru+83kqT15mq2OCcbe8KnjRZl5vF3ks69AKz3kh1jrhg=="],
-
-    "@radix-ui/react-roving-focus": ["@radix-ui/react-roving-focus@1.1.11", "", { "dependencies": { "@radix-ui/primitive": "1.1.3", "@radix-ui/react-collection": "1.1.7", "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-context": "1.1.2", "@radix-ui/react-direction": "1.1.1", "@radix-ui/react-id": "1.1.1", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-use-callback-ref": "1.1.1", "@radix-ui/react-use-controllable-state": "1.2.2" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-7A6S9jSgm/S+7MdtNDSb+IU859vQqJ/QAtcYQcfFC6W8RS4IxIZDldLR0xqCFZ6DCyrQLjLPsxtTNch5jVA4lA=="],
-
-    "@radix-ui/react-select": ["@radix-ui/react-select@2.2.6", "", { "dependencies": { "@radix-ui/number": "1.1.1", "@radix-ui/primitive": "1.1.3", "@radix-ui/react-collection": "1.1.7", "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-context": "1.1.2", "@radix-ui/react-direction": "1.1.1", "@radix-ui/react-dismissable-layer": "1.1.11", "@radix-ui/react-focus-guards": "1.1.3", "@radix-ui/react-focus-scope": "1.1.7", "@radix-ui/react-id": "1.1.1", "@radix-ui/react-popper": "1.2.8", "@radix-ui/react-portal": "1.1.9", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-slot": "1.2.3", "@radix-ui/react-use-callback-ref": "1.1.1", "@radix-ui/react-use-controllable-state": "1.2.2", "@radix-ui/react-use-layout-effect": "1.1.1", "@radix-ui/react-use-previous": "1.1.1", "@radix-ui/react-visually-hidden": "1.2.3", "aria-hidden": "^1.2.4", "react-remove-scroll": "^2.6.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-I30RydO+bnn2PQztvo25tswPH+wFBjehVGtmagkU78yMdwTwVf12wnAOF+AeP8S2N8xD+5UPbGhkUfPyvT+mwQ=="],
-
-    "@radix-ui/react-separator": ["@radix-ui/react-separator@1.1.8", "", { "dependencies": { "@radix-ui/react-primitive": "2.1.4" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-sDvqVY4itsKwwSMEe0jtKgfTh+72Sy3gPmQpjqcQneqQ4PFmr/1I0YA+2/puilhggCe2gJcx5EBAYFkWkdpa5g=="],
-
-    "@radix-ui/react-slider": ["@radix-ui/react-slider@1.3.6", "", { "dependencies": { "@radix-ui/number": "1.1.1", "@radix-ui/primitive": "1.1.3", "@radix-ui/react-collection": "1.1.7", "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-context": "1.1.2", "@radix-ui/react-direction": "1.1.1", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-use-controllable-state": "1.2.2", "@radix-ui/react-use-layout-effect": "1.1.1", "@radix-ui/react-use-previous": "1.1.1", "@radix-ui/react-use-size": "1.1.1" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-JPYb1GuM1bxfjMRlNLE+BcmBC8onfCi60Blk7OBqi2MLTFdS+8401U4uFjnwkOr49BLmXxLC6JHkvAsx5OJvHw=="],
-
-    "@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.4", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-Jl+bCv8HxKnlTLVrcDE8zTMJ09R9/ukw4qBs/oZClOfoQk/cOTbDn+NceXfV7j09YPVQUryJPHurafcSg6EVKA=="],
-
-    "@radix-ui/react-tabs": ["@radix-ui/react-tabs@1.1.13", "", { "dependencies": { "@radix-ui/primitive": "1.1.3", "@radix-ui/react-context": "1.1.2", "@radix-ui/react-direction": "1.1.1", "@radix-ui/react-id": "1.1.1", "@radix-ui/react-presence": "1.1.5", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-roving-focus": "1.1.11", "@radix-ui/react-use-controllable-state": "1.2.2" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-7xdcatg7/U+7+Udyoj2zodtI9H/IIopqo+YOIcZOq1nJwXWBZ9p8xiu5llXlekDbZkca79a/fozEYQXIA4sW6A=="],
-
-    "@radix-ui/react-tooltip": ["@radix-ui/react-tooltip@1.2.8", "", { "dependencies": { "@radix-ui/primitive": "1.1.3", "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-context": "1.1.2", "@radix-ui/react-dismissable-layer": "1.1.11", "@radix-ui/react-id": "1.1.1", "@radix-ui/react-popper": "1.2.8", "@radix-ui/react-portal": "1.1.9", "@radix-ui/react-presence": "1.1.5", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-slot": "1.2.3", "@radix-ui/react-use-controllable-state": "1.2.2", "@radix-ui/react-visually-hidden": "1.2.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-tY7sVt1yL9ozIxvmbtN5qtmH2krXcBCfjEiCgKGLqunJHvgvZG2Pcl2oQ3kbcZARb1BGEHdkLzcYGO8ynVlieg=="],
-
-    "@radix-ui/react-use-callback-ref": ["@radix-ui/react-use-callback-ref@1.1.1", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-FkBMwD+qbGQeMu1cOHnuGB6x4yzPjho8ap5WtbEJ26umhgqVXbhekKUQO+hZEL1vU92a3wHwdp0HAcqAUF5iDg=="],
-
-    "@radix-ui/react-use-controllable-state": ["@radix-ui/react-use-controllable-state@1.2.2", "", { "dependencies": { "@radix-ui/react-use-effect-event": "0.0.2", "@radix-ui/react-use-layout-effect": "1.1.1" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-BjasUjixPFdS+NKkypcyyN5Pmg83Olst0+c6vGov0diwTEo6mgdqVR6hxcEgFuh4QrAs7Rc+9KuGJ9TVCj0Zzg=="],
-
-    "@radix-ui/react-use-effect-event": ["@radix-ui/react-use-effect-event@0.0.2", "", { "dependencies": { "@radix-ui/react-use-layout-effect": "1.1.1" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-Qp8WbZOBe+blgpuUT+lw2xheLP8q0oatc9UpmiemEICxGvFLYmHm9QowVZGHtJlGbS6A6yJ3iViad/2cVjnOiA=="],
-
-    "@radix-ui/react-use-escape-keydown": ["@radix-ui/react-use-escape-keydown@1.1.1", "", { "dependencies": { "@radix-ui/react-use-callback-ref": "1.1.1" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-Il0+boE7w/XebUHyBjroE+DbByORGR9KKmITzbR7MyQ4akpORYP/ZmbhAr0DG7RmmBqoOnZdy2QlvajJ2QA59g=="],
-
-    "@radix-ui/react-use-is-hydrated": ["@radix-ui/react-use-is-hydrated@0.1.0", "", { "dependencies": { "use-sync-external-store": "^1.5.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-U+UORVEq+cTnRIaostJv9AGdV3G6Y+zbVd+12e18jQ5A3c0xL03IhnHuiU4UV69wolOQp5GfR58NW/EgdQhwOA=="],
-
-    "@radix-ui/react-use-layout-effect": ["@radix-ui/react-use-layout-effect@1.1.1", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ=="],
-
-    "@radix-ui/react-use-previous": ["@radix-ui/react-use-previous@1.1.1", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-2dHfToCj/pzca2Ck724OZ5L0EVrr3eHRNsG/b3xQJLA2hZpVCS99bLAX+hm1IHXDEnzU6by5z/5MIY794/a8NQ=="],
-
-    "@radix-ui/react-use-rect": ["@radix-ui/react-use-rect@1.1.1", "", { "dependencies": { "@radix-ui/rect": "1.1.1" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-QTYuDesS0VtuHNNvMh+CjlKJ4LJickCMUAqjlE3+j8w+RlRpwyX3apEQKGFzbZGdo7XNG1tXa+bQqIE7HIXT2w=="],
-
-    "@radix-ui/react-use-size": ["@radix-ui/react-use-size@1.1.1", "", { "dependencies": { "@radix-ui/react-use-layout-effect": "1.1.1" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-ewrXRDTAqAXlkl6t/fkXWNAhFX9I+CkKlw6zjEwk86RSPKwZr3xpBRso655aqYafwtnbpHLj6toFzmd6xdVptQ=="],
-
-    "@radix-ui/react-visually-hidden": ["@radix-ui/react-visually-hidden@1.2.3", "", { "dependencies": { "@radix-ui/react-primitive": "2.1.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-pzJq12tEaaIhqjbzpCuv/OypJY/BPavOofm+dbab+MHLajy277+1lLm6JFcGgF5eskJ6mquGirhXY2GD/8u8Ug=="],
-
-    "@radix-ui/rect": ["@radix-ui/rect@1.1.1", "", {}, "sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw=="],
 
     "@react-email/body": ["@react-email/body@0.3.0", "", { "peerDependencies": { "react": "^18.0 || ^19.0 || ^19.0.0-rc" } }, "sha512-uGo0BOOzjbMUo3lu+BIDWayvn5o6Xyfmnlla5VGf05n8gHMvO1ll7U4FtzWe3hxMLwt53pmc4iE0M+B5slG+Ug=="],
 
@@ -1502,16 +1248,6 @@
 
     "@selderee/plugin-htmlparser2": ["@selderee/plugin-htmlparser2@0.11.0", "", { "dependencies": { "domhandler": "^5.0.3", "selderee": "^0.11.0" } }, "sha512-P33hHGdldxGabLFjPPpaTxVolMrzrcegejx+0GxjrIb9Zv48D8yAIA/QTDR2dFl7Uz7urX8aX6+5bCZslr+gWQ=="],
 
-    "@sentry-internal/browser-utils": ["@sentry-internal/browser-utils@10.51.0", "", { "dependencies": { "@sentry/core": "10.51.0" } }, "sha512-lNKBS4P7RUvf1niojXQWe9bU3gnBUCbST4Dj0pSiyat1N96cXVyHkeE+uGxowD0RrVWhs+kGHiVX3FcmRWF6sA=="],
-
-    "@sentry-internal/feedback": ["@sentry-internal/feedback@10.51.0", "", { "dependencies": { "@sentry/core": "10.51.0" } }, "sha512-bCM95bcpphx28e6aU0bwRLxOgwosYsdNzezM1sM0pVOkb0TB3hDFRamramVDK+/Hp1o8qmRxS4c5w/A7YBZGkA=="],
-
-    "@sentry-internal/replay": ["@sentry-internal/replay@10.51.0", "", { "dependencies": { "@sentry-internal/browser-utils": "10.51.0", "@sentry/core": "10.51.0" } }, "sha512-jCpI5HXSwK6ZT2HX70+mDRciAocHzSiDk4DTgvzV69Wvd+Ei5WLgE+d39eaEPsm8lUC0Ydntb5sJIB6uG9D4bw=="],
-
-    "@sentry-internal/replay-canvas": ["@sentry-internal/replay-canvas@10.51.0", "", { "dependencies": { "@sentry-internal/replay": "10.51.0", "@sentry/core": "10.51.0" } }, "sha512-8PW1Pp+Yl3lPwYqhBCr5SgkuhDanu9ZLzUqD2bPKL/ElqbM2eDVIWxq4z4ZzePrmZa6IcCjTv6sVQJ7Z4dLyLA=="],
-
-    "@sentry/browser": ["@sentry/browser@10.51.0", "", { "dependencies": { "@sentry-internal/browser-utils": "10.51.0", "@sentry-internal/feedback": "10.51.0", "@sentry-internal/replay": "10.51.0", "@sentry-internal/replay-canvas": "10.51.0", "@sentry/core": "10.51.0" } }, "sha512-Zdc0sKfenxUtW/OGhtJ7xHFN44bXR7YqxJ1zBDzlZfW0nTbeTTUZBq9z5NUw6qdS0Vs/i3V4qzAKTbRKWfqSEA=="],
-
     "@sentry/core": ["@sentry/core@10.50.0", "", {}, "sha512-J4A+vzUO3adl0TkFCjaN1+4miamrjHiEIYuLHiuu1lmAjq5WIVw32ObvAh4yMwNtxyaEMosTrrh5M6f12XSJFg=="],
 
     "@sentry/node": ["@sentry/node@10.50.0", "", { "dependencies": { "@fastify/otel": "0.18.0", "@opentelemetry/api": "^1.9.1", "@opentelemetry/core": "^2.6.1", "@opentelemetry/instrumentation": "^0.214.0", "@opentelemetry/instrumentation-amqplib": "0.61.0", "@opentelemetry/instrumentation-connect": "0.57.0", "@opentelemetry/instrumentation-dataloader": "0.31.0", "@opentelemetry/instrumentation-fs": "0.33.0", "@opentelemetry/instrumentation-generic-pool": "0.57.0", "@opentelemetry/instrumentation-graphql": "0.62.0", "@opentelemetry/instrumentation-hapi": "0.60.0", "@opentelemetry/instrumentation-http": "0.214.0", "@opentelemetry/instrumentation-ioredis": "0.62.0", "@opentelemetry/instrumentation-kafkajs": "0.23.0", "@opentelemetry/instrumentation-knex": "0.58.0", "@opentelemetry/instrumentation-koa": "0.62.0", "@opentelemetry/instrumentation-lru-memoizer": "0.58.0", "@opentelemetry/instrumentation-mongodb": "0.67.0", "@opentelemetry/instrumentation-mongoose": "0.60.0", "@opentelemetry/instrumentation-mysql": "0.60.0", "@opentelemetry/instrumentation-mysql2": "0.60.0", "@opentelemetry/instrumentation-pg": "0.66.0", "@opentelemetry/instrumentation-redis": "0.62.0", "@opentelemetry/instrumentation-tedious": "0.33.0", "@opentelemetry/sdk-trace-base": "^2.6.1", "@opentelemetry/semantic-conventions": "^1.40.0", "@prisma/instrumentation": "7.6.0", "@sentry/core": "10.50.0", "@sentry/node-core": "10.50.0", "@sentry/opentelemetry": "10.50.0", "import-in-the-middle": "^3.0.0" } }, "sha512-TvwzFQu8MGKzMQ2/tqxcNzFA8UG2kKTB+GDmA4uOzx3+GT849YZRRSJzEXCmYhk1teVd2fbmgqyYY2nyLF5a+Q=="],
@@ -1519,8 +1255,6 @@
     "@sentry/node-core": ["@sentry/node-core@10.50.0", "", { "dependencies": { "@sentry/core": "10.50.0", "@sentry/opentelemetry": "10.50.0", "import-in-the-middle": "^3.0.0" }, "peerDependencies": { "@opentelemetry/api": "^1.9.0", "@opentelemetry/core": "^1.30.1 || ^2.1.0", "@opentelemetry/exporter-trace-otlp-http": ">=0.57.0 <1", "@opentelemetry/instrumentation": ">=0.57.1 <1", "@opentelemetry/sdk-trace-base": "^1.30.1 || ^2.1.0", "@opentelemetry/semantic-conventions": "^1.39.0" }, "optionalPeers": ["@opentelemetry/api", "@opentelemetry/core", "@opentelemetry/exporter-trace-otlp-http", "@opentelemetry/instrumentation", "@opentelemetry/sdk-trace-base", "@opentelemetry/semantic-conventions"] }, "sha512-Eb1BYf4Lc7ZYmdX3acKP6SgyGikrBA370gbGHaWI5jRu7G7vig8sIu1ghPmY5AlvqBPOetado7GniXr6fAXbTw=="],
 
     "@sentry/opentelemetry": ["@sentry/opentelemetry@10.50.0", "", { "dependencies": { "@sentry/core": "10.50.0" }, "peerDependencies": { "@opentelemetry/api": "^1.9.0", "@opentelemetry/core": "^1.30.1 || ^2.1.0", "@opentelemetry/sdk-trace-base": "^1.30.1 || ^2.1.0", "@opentelemetry/semantic-conventions": "^1.39.0" } }, "sha512-axn3pgDPveGdaMUC0abMCmFN7ux2pA5ebPufCef4lMIsyg7BBQvaEJ+vE19wjstMaBCAJGsdZlL3eeP2rtgRMw=="],
-
-    "@sentry/react": ["@sentry/react@10.51.0", "", { "dependencies": { "@sentry/browser": "10.51.0", "@sentry/core": "10.51.0" }, "peerDependencies": { "react": "^16.14.0 || 17.x || 18.x || 19.x" } }, "sha512-RRHHqjNvjji6ebIqdlAr453AkST8Vm4cxdu1vWm772IgbzTO7Jx46Cj6Bt2/GjMyH0YLE5euDaAOQhFMmpvAOw=="],
 
     "@shikijs/core": ["@shikijs/core@4.0.2", "", { "dependencies": { "@shikijs/primitive": "4.0.2", "@shikijs/types": "4.0.2", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4", "hast-util-to-html": "^9.0.5" } }, "sha512-hxT0YF4ExEqB8G/qFdtJvpmHXBYJ2lWW7qTHDarVkIudPFE6iCIrqdgWxGn5s+ppkGXI0aEGlibI0PAyzP3zlw=="],
 
@@ -1539,10 +1273,6 @@
     "@shikijs/vscode-textmate": ["@shikijs/vscode-textmate@10.0.2", "", {}, "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg=="],
 
     "@silvia-odwyer/photon-node": ["@silvia-odwyer/photon-node@0.3.4", "", {}, "sha512-bnly4BKB3KDTFxrUIcgCLbaeVVS8lrAkri1pEzskpmxu9MdfGQTy8b8EgcD83ywD3RPMsIulY8xJH5Awa+t9fA=="],
-
-    "@simplewebauthn/browser": ["@simplewebauthn/browser@13.3.0", "", {}, "sha512-BE/UWv6FOToAdVk0EokzkqQQDOWtNydYlY6+OrmiZ5SCNmb41VehttboTetUM3T/fr6EAFYVXjz4My2wg230rQ=="],
-
-    "@simplewebauthn/server": ["@simplewebauthn/server@13.3.0", "", { "dependencies": { "@hexagon/base64": "^1.1.27", "@levischuck/tiny-cbor": "^0.2.2", "@peculiar/asn1-android": "^2.6.0", "@peculiar/asn1-ecc": "^2.6.1", "@peculiar/asn1-rsa": "^2.6.1", "@peculiar/asn1-schema": "^2.6.0", "@peculiar/asn1-x509": "^2.6.1", "@peculiar/x509": "^1.14.3" } }, "sha512-MLHYFrYG8/wK2i+86XMhiecK72nMaHKKt4bo+7Q1TbuG9iGjlSdfkPWKO5ZFE/BX+ygCJ7pr8H/AJeyAj1EaTQ=="],
 
     "@sinclair/typebox": ["@sinclair/typebox@0.34.49", "", {}, "sha512-brySQQs7Jtn0joV8Xh9ZV/hZb9Ozb0pmazDIASBkYKCjXrXU3mpcFahmK/z4YDhGkQvP9mWJbVyahdtU5wQA+A=="],
 
@@ -1650,10 +1380,6 @@
 
     "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
 
-    "@standard-schema/utils": ["@standard-schema/utils@0.3.0", "", {}, "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g=="],
-
-    "@tabby_ai/hijri-converter": ["@tabby_ai/hijri-converter@1.0.5", "", {}, "sha512-r5bClKrcIusDoo049dSL8CawnHR6mRdDwhlQuIgZRNty68q0x8k3Lf1BtPAMxRf/GgnHBnIO4ujd3+GQdLWzxQ=="],
-
     "@tailwindcss/node": ["@tailwindcss/node@4.2.4", "", { "dependencies": { "@jridgewell/remapping": "^2.3.5", "enhanced-resolve": "^5.19.0", "jiti": "^2.6.1", "lightningcss": "1.32.0", "magic-string": "^0.30.21", "source-map-js": "^1.2.1", "tailwindcss": "4.2.4" } }, "sha512-Ai7+yQPxz3ddrDQzFfBKdHEVBg0w3Zl83jnjuwxnZOsnH9pGn93QHQtpU0p/8rYWxvbFZHneni6p1BSLK4DkGA=="],
 
     "@tailwindcss/oxide": ["@tailwindcss/oxide@4.2.4", "", { "optionalDependencies": { "@tailwindcss/oxide-android-arm64": "4.2.4", "@tailwindcss/oxide-darwin-arm64": "4.2.4", "@tailwindcss/oxide-darwin-x64": "4.2.4", "@tailwindcss/oxide-freebsd-x64": "4.2.4", "@tailwindcss/oxide-linux-arm-gnueabihf": "4.2.4", "@tailwindcss/oxide-linux-arm64-gnu": "4.2.4", "@tailwindcss/oxide-linux-arm64-musl": "4.2.4", "@tailwindcss/oxide-linux-x64-gnu": "4.2.4", "@tailwindcss/oxide-linux-x64-musl": "4.2.4", "@tailwindcss/oxide-wasm32-wasi": "4.2.4", "@tailwindcss/oxide-win32-arm64-msvc": "4.2.4", "@tailwindcss/oxide-win32-x64-msvc": "4.2.4" } }, "sha512-9El/iI069DKDSXwTvB9J4BwdO5JhRrOweGaK25taBAvBXyXqJAX+Jqdvs8r8gKpsI/1m0LeJLyQYTf/WLrBT1Q=="],
@@ -1682,49 +1408,7 @@
 
     "@tailwindcss/oxide-win32-x64-msvc": ["@tailwindcss/oxide-win32-x64-msvc@4.2.4", "", { "os": "win32", "cpu": "x64" }, "sha512-ESlKG0EpVJQwRjXDDa9rLvhEAh0mhP1sF7sap9dNZT0yyl9SAG6T7gdP09EH0vIv0UNTlo6jPWyujD6559fZvw=="],
 
-    "@tailwindcss/postcss": ["@tailwindcss/postcss@4.2.4", "", { "dependencies": { "@alloc/quick-lru": "^5.2.0", "@tailwindcss/node": "4.2.4", "@tailwindcss/oxide": "4.2.4", "postcss": "^8.5.6", "tailwindcss": "4.2.4" } }, "sha512-wgAVj6nUWAolAu8YFvzT2cTBIElWHkjZwFYovF+xsqKsW2ADxM/X2opxj5NsF/qVccAOjRNe8X2IdPzMsWyHTg=="],
-
     "@tailwindcss/vite": ["@tailwindcss/vite@4.2.4", "", { "dependencies": { "@tailwindcss/node": "4.2.4", "@tailwindcss/oxide": "4.2.4", "tailwindcss": "4.2.4" }, "peerDependencies": { "vite": "^5.2.0 || ^6 || ^7 || ^8" } }, "sha512-pCvohwOCspk3ZFn6eJzrrX3g4n2JY73H6MmYC87XfGPyTty4YsCjYTMArRZm/zOI8dIt3+EcrLHAFPe5A4bgtw=="],
-
-    "@tanstack/history": ["@tanstack/history@1.161.6", "", {}, "sha512-NaOGLRrddszbQj9upGat6HG/4TKvXLvu+osAIgfxPYA+eIvYKv8GKDJOrY2D3/U9MRnKfMWD7bU4jeD4xmqyIg=="],
-
-    "@tanstack/query-core": ["@tanstack/query-core@5.100.1", "", {}, "sha512-awvQhOO/2TrSCHE5LKKsXcvvj6WSBncwEcMFCB/ez0Qs0b17iyyivoGArNV3HFfXryZwCpnb/olsaBBKrIbtSw=="],
-
-    "@tanstack/react-query": ["@tanstack/react-query@5.100.1", "", { "dependencies": { "@tanstack/query-core": "5.100.1" }, "peerDependencies": { "react": "^18 || ^19" } }, "sha512-UgWRLhQKprC37SsO6y1zRabOqDmM2gsdTNPbqTT35yl7kOOhwXU4nyfOiGHXPwoEFJV1IpSk85hjIFjNFWVpzw=="],
-
-    "@tanstack/react-router": ["@tanstack/react-router@1.168.23", "", { "dependencies": { "@tanstack/history": "1.161.6", "@tanstack/react-store": "^0.9.3", "@tanstack/router-core": "1.168.15", "isbot": "^5.1.22" }, "peerDependencies": { "react": ">=18.0.0 || >=19.0.0", "react-dom": ">=18.0.0 || >=19.0.0" } }, "sha512-+GblieDnutG6oipJJPNtRJjrWF8QTZEG/l0532+BngFkVK48oHNOcvIkSoAFYftK1egAwM7KBxXsb0Ou+X6/MQ=="],
-
-    "@tanstack/react-router-devtools": ["@tanstack/react-router-devtools@1.166.13", "", { "dependencies": { "@tanstack/router-devtools-core": "1.167.3" }, "peerDependencies": { "@tanstack/react-router": "^1.168.15", "@tanstack/router-core": "^1.168.11", "react": ">=18.0.0 || >=19.0.0", "react-dom": ">=18.0.0 || >=19.0.0" }, "optionalPeers": ["@tanstack/router-core"] }, "sha512-6yKRFFJrEEOiGp5RAAuGCYsl81M4XAhJmLcu9PKj+HZle4A3dsP60lwHoqQYWHMK9nKKFkdXR+D8qxzxqtQbEA=="],
-
-    "@tanstack/react-store": ["@tanstack/react-store@0.9.3", "", { "dependencies": { "@tanstack/store": "0.9.3", "use-sync-external-store": "^1.6.0" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-y2iHd/N9OkoQbFJLUX1T9vbc2O9tjH0pQRgTcx1/Nz4IlwLvkgpuglXUx+mXt0g5ZDFrEeDnONPqkbfxXJKwRg=="],
-
-    "@tanstack/react-table": ["@tanstack/react-table@8.21.3", "", { "dependencies": { "@tanstack/table-core": "8.21.3" }, "peerDependencies": { "react": ">=16.8", "react-dom": ">=16.8" } }, "sha512-5nNMTSETP4ykGegmVkhjcS8tTLW6Vl4axfEGQN3v0zdHYbK4UfoqfPChclTrJ4EoK9QynqAu9oUf8VEmrpZ5Ww=="],
-
-    "@tanstack/router-core": ["@tanstack/router-core@1.168.15", "", { "dependencies": { "@tanstack/history": "1.161.6", "cookie-es": "^3.0.0", "seroval": "^1.5.0", "seroval-plugins": "^1.5.0" }, "bin": { "intent": "bin/intent.js" } }, "sha512-Wr0424NDtD8fT/uALobMZ9DdcfsTyXtW5IPR++7zvW8/7RaIOeaqXpVDId8ywaGtqPWLWOfaUg2zUtYtukoXYA=="],
-
-    "@tanstack/router-devtools": ["@tanstack/router-devtools@1.166.13", "", { "dependencies": { "@tanstack/react-router-devtools": "1.166.13", "clsx": "^2.1.1", "goober": "^2.1.16" }, "peerDependencies": { "@tanstack/react-router": "^1.168.15", "csstype": "^3.0.10", "react": ">=18.0.0 || >=19.0.0", "react-dom": ">=18.0.0 || >=19.0.0" }, "optionalPeers": ["csstype"] }, "sha512-Qs8gkyI7m+eAxG3VcIOHuTSsUfA5ZxZcOa99ZyIIIJFxW6hy1k+m2s1J0ZYN1SNlip8P2ofd/MHiqmR1IWipMg=="],
-
-    "@tanstack/router-devtools-core": ["@tanstack/router-devtools-core@1.167.3", "", { "dependencies": { "clsx": "^2.1.1", "goober": "^2.1.16" }, "peerDependencies": { "@tanstack/router-core": "^1.168.11", "csstype": "^3.0.10" }, "optionalPeers": ["csstype"] }, "sha512-fJ1VMhyQgnoashTrP763c2HRc9kofgF61L7Jb3F6eTHAmCKtGVx8BRtiFt37sr3U0P0jmaaiiSPGP6nT5JtVNg=="],
-
-    "@tanstack/router-generator": ["@tanstack/router-generator@1.166.33", "", { "dependencies": { "@babel/types": "^7.28.5", "@tanstack/router-core": "1.168.15", "@tanstack/router-utils": "1.161.7", "@tanstack/virtual-file-routes": "1.161.7", "magic-string": "^0.30.21", "prettier": "^3.5.0", "tsx": "^4.19.2", "zod": "^3.24.2" } }, "sha512-MXP1WrEaZ13tlO5iJoXC+ZIFHNj5CtcvWuqlAZ3zXY70Musuq+mfUcKWMVdcIstnNqrZl5M2hfqLh5Zf5t4NVw=="],
-
-    "@tanstack/router-plugin": ["@tanstack/router-plugin@1.167.23", "", { "dependencies": { "@babel/core": "^7.28.5", "@babel/plugin-syntax-jsx": "^7.27.1", "@babel/plugin-syntax-typescript": "^7.27.1", "@babel/template": "^7.27.2", "@babel/traverse": "^7.28.5", "@babel/types": "^7.28.5", "@tanstack/router-core": "1.168.15", "@tanstack/router-generator": "1.166.33", "@tanstack/router-utils": "1.161.7", "@tanstack/virtual-file-routes": "1.161.7", "chokidar": "^3.6.0", "unplugin": "^2.1.2", "zod": "^3.24.2" }, "peerDependencies": { "@rsbuild/core": ">=1.0.2 || ^2.0.0", "@tanstack/react-router": "^1.168.23", "vite": ">=5.0.0 || >=6.0.0 || >=7.0.0 || >=8.0.0", "vite-plugin-solid": "^2.11.10 || ^3.0.0-0", "webpack": ">=5.92.0" }, "optionalPeers": ["@rsbuild/core", "@tanstack/react-router", "vite", "vite-plugin-solid", "webpack"], "bin": { "intent": "bin/intent.js" } }, "sha512-dqfCd8gsZThbVQ8bcYMO62/hW5GCkUoPLnnjOd3fCWoEi+Ei5oWa/GnlgHCpG7bdeGr/K8isnYUmI9Ysq5vLrg=="],
-
-    "@tanstack/router-utils": ["@tanstack/router-utils@1.161.7", "", { "dependencies": { "@babel/core": "^7.28.5", "@babel/generator": "^7.28.5", "@babel/parser": "^7.28.5", "@babel/types": "^7.28.5", "ansis": "^4.1.0", "babel-dead-code-elimination": "^1.0.12", "diff": "^8.0.2", "pathe": "^2.0.3", "tinyglobby": "^0.2.15" } }, "sha512-VkY0u7ax/GD0qU6ZLLnfPC+UMxVzxRbvZp4yV4iUSXjgJZ/siAT5/QlLm9FEDJ9QDoC0VD9W7f00tKKreUI7Ng=="],
-
-    "@tanstack/store": ["@tanstack/store@0.9.3", "", {}, "sha512-8reSzl/qGWGGVKhBoxXPMWzATSbZLZFWhwBAFO9NAyp0TxzfBP0mIrGb8CP8KrQTmvzXlR/vFPPUrHTLBGyFyw=="],
-
-    "@tanstack/table-core": ["@tanstack/table-core@8.21.3", "", {}, "sha512-ldZXEhOBb8Is7xLs01fR3YEc3DERiz5silj8tnGkFZytt1abEvl/GhUmCE0PMLaMPTa3Jk4HbKmRlHmu+gCftg=="],
-
-    "@tanstack/virtual-file-routes": ["@tanstack/virtual-file-routes@1.161.7", "", { "bin": { "intent": "bin/intent.js" } }, "sha512-olW33+Cn+bsCsZKPwEGhlkqS6w3M2slFv11JIobdnCFKMLG97oAI2kWKdx5/zsywTL8flpnoIgaZZPlQTFYhdQ=="],
-
-    "@testing-library/dom": ["@testing-library/dom@10.4.1", "", { "dependencies": { "@babel/code-frame": "^7.10.4", "@babel/runtime": "^7.12.5", "@types/aria-query": "^5.0.1", "aria-query": "5.3.0", "dom-accessibility-api": "^0.5.9", "lz-string": "^1.5.0", "picocolors": "1.1.1", "pretty-format": "^27.0.2" } }, "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg=="],
-
-    "@testing-library/jest-dom": ["@testing-library/jest-dom@6.9.1", "", { "dependencies": { "@adobe/css-tools": "^4.4.0", "aria-query": "^5.0.0", "css.escape": "^1.5.1", "dom-accessibility-api": "^0.6.3", "picocolors": "^1.1.1", "redent": "^3.0.0" } }, "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA=="],
-
-    "@testing-library/react": ["@testing-library/react@16.3.2", "", { "dependencies": { "@babel/runtime": "^7.12.5" }, "peerDependencies": { "@testing-library/dom": "^10.0.0", "@types/react": "^18.0.0 || ^19.0.0", "@types/react-dom": "^18.0.0 || ^19.0.0", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g=="],
-
-    "@testing-library/user-event": ["@testing-library/user-event@14.6.1", "", { "peerDependencies": { "@testing-library/dom": ">=7.21.4" } }, "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw=="],
 
     "@tokenizer/inflate": ["@tokenizer/inflate@0.4.1", "", { "dependencies": { "debug": "^4.4.3", "token-types": "^6.1.1" } }, "sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA=="],
 
@@ -1732,17 +1416,7 @@
 
     "@tootallnate/quickjs-emscripten": ["@tootallnate/quickjs-emscripten@0.23.0", "", {}, "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA=="],
 
-    "@triplit/client": ["@triplit/client@1.0.50", "", { "dependencies": { "@triplit/db": "^1.1.10", "@triplit/logger": "^0.0.3", "comlink": "^4.4.1", "superjson": "^2.2.1" } }, "sha512-3vjXTSdDQ3fzLDrewCK7elkAQc7CiDg0eZEOZInQbVMFRiakdieO5C2voSnNjSepIYHxDxFSBllgg32QsNpL9Q=="],
-
-    "@triplit/db": ["@triplit/db@1.1.10", "", { "dependencies": { "@triplit/logger": "^0.0.3", "core-js": "^3.41.0", "elen": "^1.0.10", "nanoid": "^5.1.0", "sorted-btree": "^1.8.1", "web-worker": "^1.5.0" }, "peerDependencies": { "better-sqlite3": "*", "expo-sqlite": "*", "lmdb": "*", "uuidv7": "*" }, "optionalPeers": ["better-sqlite3", "expo-sqlite", "lmdb", "uuidv7"] }, "sha512-9BHDrlDvJOyA9Wl8AsmbUSLhilaReA8gpFoWYjS9VEcm5d6TtqKazPQrFm0/o2WNJdrs01+qR6CysAo449MAyA=="],
-
-    "@triplit/logger": ["@triplit/logger@0.0.3", "", { "peerDependencies": { "typescript": "^5.0.0" } }, "sha512-hHcoD6/BsNwBtXjEp8Wiy0/YA2SqIYXd1nMukEPBmFkjT7Cd30eqtsBRT0NRq2mIFX2mr5h9JaO27zDToKnwdw=="],
-
-    "@triplit/react": ["@triplit/react@1.0.51", "", { "dependencies": { "@triplit/client": "^1.0.50" }, "peerDependencies": { "react": "*" } }, "sha512-yGmYWACWycrNHMEfnR1k6CQ398ESIBgFeM47fXFhrdhMJ84QgdRk6VF/C21P80D1Rk/AQePfB0TUIaY4U9BRJg=="],
-
     "@tybys/wasm-util": ["@tybys/wasm-util@0.10.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg=="],
-
-    "@types/aria-query": ["@types/aria-query@5.0.4", "", {}, "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw=="],
 
     "@types/babel__core": ["@types/babel__core@7.20.5", "", { "dependencies": { "@babel/parser": "^7.20.7", "@babel/types": "^7.20.7", "@types/babel__generator": "*", "@types/babel__template": "*", "@types/babel__traverse": "*" } }, "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA=="],
 
@@ -1773,8 +1447,6 @@
     "@types/hast": ["@types/hast@3.0.4", "", { "dependencies": { "@types/unist": "*" } }, "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ=="],
 
     "@types/js-yaml": ["@types/js-yaml@4.0.9", "", {}, "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg=="],
-
-    "@types/json-schema": ["@types/json-schema@7.0.15", "", {}, "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="],
 
     "@types/jsonwebtoken": ["@types/jsonwebtoken@9.0.10", "", { "dependencies": { "@types/ms": "*", "@types/node": "*" } }, "sha512-asx5hIG9Qmf/1oStypjanR7iKTv0gXQ1Ov/jfrX6kS/EO0OFni8orbmGCn0672NHR3kXHwpAwR+B368ZGN/2rA=="],
 
@@ -1846,8 +1518,6 @@
 
     "@vladfrangu/async_event_emitter": ["@vladfrangu/async_event_emitter@2.4.7", "", {}, "sha512-Xfe6rpCTxSxfbswi/W/Pz7zp1WWSNn4A0eW4mLkQUewCrXXtMj31lCg+iQyTkh/CkusZSq9eDflu7tjEDXUY6g=="],
 
-    "@wojtekmaj/react-recaptcha-v3": ["@wojtekmaj/react-recaptcha-v3@0.1.4", "", { "dependencies": { "warning": "^4.0.0" }, "peerDependencies": { "@types/react": "^18.0.0 || ^19.0.0", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["@types/react"] }, "sha512-zszMOdgI+y1Dz3496pRFr3t68n9+OmX/puLQNnOBDC7WrjM+nOKGyjIMCTe+3J14KDvzcxETeiglyDMGl0Yh/Q=="],
-
     "@workflow/serde": ["@workflow/serde@4.1.0-beta.2", "", {}, "sha512-8kkeoQKLDaKXefjV5dbhBj2aErfKp1Mc4pb6tj8144cF+Em5SPbyMbyLCHp+BVrFfFVCBluCtMx+jjvaFVZGww=="],
 
     "@xenova/transformers": ["@xenova/transformers@2.17.2", "", { "dependencies": { "@huggingface/jinja": "^0.2.2", "onnxruntime-web": "1.14.0", "sharp": "^0.32.0" }, "optionalDependencies": { "onnxruntime-node": "1.14.0" } }, "sha512-lZmHqzrVIkSvZdKZEx7IYY51TK0WDrC8eR0c5IMnBsO8di8are1zzw8BlLhyO2TklZKLN5UffNGs1IJwT6oOqQ=="],
@@ -1872,8 +1542,6 @@
 
     "ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
-    "ansis": ["ansis@4.2.0", "", {}, "sha512-HqZ5rWlFjGiV0tDm3UxxgNRqsOTniqoKZu0pIAfh7TZQMGuZK+hH0drySty0si0QXj1ieop4+SkSfPZBPPkHig=="],
-
     "any-base": ["any-base@1.1.0", "", {}, "sha512-uMgjozySS8adZZYePpaWs8cxB9/kdzmpX6SgJZ+wbz1K5eYk5QMYDVJaZKhxyIHUdnnJkfR7SVgStgH7LkGUyg=="],
 
     "any-promise": ["any-promise@1.3.0", "", {}, "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A=="],
@@ -1884,15 +1552,11 @@
 
     "argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
 
-    "aria-hidden": ["aria-hidden@1.2.6", "", { "dependencies": { "tslib": "^2.0.0" } }, "sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA=="],
-
     "aria-query": ["aria-query@5.3.2", "", {}, "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw=="],
 
     "array-iterate": ["array-iterate@2.0.1", "", {}, "sha512-I1jXZMjAgCMmxT4qxXfPXa6SthSoE8h6gkSI9BGGNv8mP8G/v0blc+qFnZu6K42vTOiuME596QaLO0TP3Lk0xg=="],
 
     "asap": ["asap@2.0.6", "", {}, "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA=="],
-
-    "asn1js": ["asn1js@3.0.10", "", { "dependencies": { "pvtsutils": "^1.3.6", "pvutils": "^1.1.5", "tslib": "^2.8.1" } }, "sha512-S2s3aOytiKdFRdulw2qPE51MzjzVOisppcVv7jVFR+Kw0kxwvFrDcYA0h7Ndqbmj0HkMIXYWaoj7fli8kgx1eg=="],
 
     "assert-never": ["assert-never@1.4.0", "", {}, "sha512-5oJg84os6NMQNl27T9LnZkvvqzvAnHu03ShCnoj6bsJwS7L8AO4lf+C/XjK/nvzEqQB744moC6V128RucQd1jA=="],
 
@@ -1912,8 +1576,6 @@
 
     "atomic-sleep": ["atomic-sleep@1.0.0", "", {}, "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ=="],
 
-    "autoprefixer": ["autoprefixer@10.5.0", "", { "dependencies": { "browserslist": "^4.28.2", "caniuse-lite": "^1.0.30001787", "fraction.js": "^5.3.4", "picocolors": "^1.1.1", "postcss-value-parser": "^4.2.0" }, "peerDependencies": { "postcss": "^8.1.0" }, "bin": { "autoprefixer": "bin/autoprefixer" } }, "sha512-FMhOoZV4+qR6aTUALKX2rEqGG+oyATvwBt9IIzVR5rMa2HRWPkxf+P+PAJLD1I/H5/II+HuZcBJYEFBpq39ong=="],
-
     "await-to-js": ["await-to-js@3.0.0", "", {}, "sha512-zJAaP9zxTcvTHRlejau3ZOY4V7SRpiByf3/dxx2uyKxxor19tpmpV2QRsTKikckwhaPmr2dVpxxMr7jOCYVp5g=="],
 
     "axios": ["axios@1.15.2", "", { "dependencies": { "follow-redirects": "^1.15.11", "form-data": "^4.0.5", "proxy-from-env": "^2.1.0" } }, "sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A=="],
@@ -1921,8 +1583,6 @@
     "axobject-query": ["axobject-query@4.1.0", "", {}, "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ=="],
 
     "b4a": ["b4a@1.8.0", "", { "peerDependencies": { "react-native-b4a": "*" }, "optionalPeers": ["react-native-b4a"] }, "sha512-qRuSmNSkGQaHwNbM7J78Wwy+ghLEYF1zNrSeMxj4Kgw6y33O3mXcQ6Ie9fRvfU/YnxWkOchPXbaLb73TkIsfdg=="],
-
-    "babel-dead-code-elimination": ["babel-dead-code-elimination@1.0.12", "", { "dependencies": { "@babel/core": "^7.23.7", "@babel/parser": "^7.23.6", "@babel/traverse": "^7.23.7", "@babel/types": "^7.23.6" } }, "sha512-GERT7L2TiYcYDtYk1IpD+ASAYXjKbLTDPhBtYj7X1NuRMDTMtAx9kyBenub1Ev41lo91OHCKdmP+egTDmfQ7Ig=="],
 
     "babel-plugin-transform-hook-names": ["babel-plugin-transform-hook-names@1.0.2", "", { "peerDependencies": { "@babel/core": "^7.12.10" } }, "sha512-5gafyjyyBTTdX/tQQ0hRgu4AhNHG/hqWi0ZZmg2xvs2FgRkJXzDNKBZCyoYqgFkovfDrgM8OoKg8karoUvWeCw=="],
 
@@ -1965,8 +1625,6 @@
     "big-integer": ["big-integer@1.6.52", "", {}, "sha512-QxD8cf2eVqJOOz63z6JIN9BzvVs/dlySa5HGSBH5xtR8dPteIRQnBxxKqkNTiT6jbDTF6jAfrd4oMcND9RGbQg=="],
 
     "bignumber.js": ["bignumber.js@9.3.1", "", {}, "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ=="],
-
-    "binary-extensions": ["binary-extensions@2.3.0", "", {}, "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw=="],
 
     "bl": ["bl@4.1.0", "", { "dependencies": { "buffer": "^5.5.0", "inherits": "^2.0.4", "readable-stream": "^3.4.0" } }, "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w=="],
 
@@ -2030,15 +1688,13 @@
 
     "check-error": ["check-error@2.1.3", "", {}, "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA=="],
 
-    "chokidar": ["chokidar@3.6.0", "", { "dependencies": { "anymatch": "~3.1.2", "braces": "~3.0.2", "glob-parent": "~5.1.2", "is-binary-path": "~2.1.0", "is-glob": "~4.0.1", "normalize-path": "~3.0.0", "readdirp": "~3.6.0" }, "optionalDependencies": { "fsevents": "~2.3.2" } }, "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw=="],
+    "chokidar": ["chokidar@5.0.0", "", { "dependencies": { "readdirp": "^5.0.0" } }, "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw=="],
 
     "chownr": ["chownr@1.1.4", "", {}, "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="],
 
     "ci-info": ["ci-info@4.4.0", "", {}, "sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg=="],
 
     "cjs-module-lexer": ["cjs-module-lexer@2.2.0", "", {}, "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ=="],
-
-    "class-variance-authority": ["class-variance-authority@0.7.1", "", { "dependencies": { "clsx": "^2.1.1" } }, "sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg=="],
 
     "cli-cursor": ["cli-cursor@5.0.0", "", { "dependencies": { "restore-cursor": "^5.0.0" } }, "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw=="],
 
@@ -2050,13 +1706,11 @@
 
     "cli-width": ["cli-width@4.1.0", "", {}, "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ=="],
 
-    "cliui": ["cliui@8.0.1", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.1", "wrap-ansi": "^7.0.0" } }, "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ=="],
+    "cliui": ["cliui@7.0.4", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.0", "wrap-ansi": "^7.0.0" } }, "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ=="],
 
     "clsx": ["clsx@2.1.1", "", {}, "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA=="],
 
     "cluster-key-slot": ["cluster-key-slot@1.1.2", "", {}, "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA=="],
-
-    "cmdk": ["cmdk@1.1.1", "", { "dependencies": { "@radix-ui/react-compose-refs": "^1.1.1", "@radix-ui/react-dialog": "^1.1.6", "@radix-ui/react-id": "^1.1.0", "@radix-ui/react-primitive": "^2.0.2" }, "peerDependencies": { "react": "^18 || ^19 || ^19.0.0-rc", "react-dom": "^18 || ^19 || ^19.0.0-rc" } }, "sha512-Vsv7kFaXm+ptHDMZ7izaRsP70GgrW9NBNGswt9OZaVBLlE0SNpDq8eu/VGXyF9r7M0azK3Wy7OlYXsuyYLFzHg=="],
 
     "collapse-white-space": ["collapse-white-space@2.1.0", "", {}, "sha512-loKTxY1zCOuG4j9f6EPnuyyYkf58RnhhWTvRoZEokgB+WbdXehfjFviyOVYkqzEWz1Q5kRiZdBYS5SwxbQYwzw=="],
 
@@ -2071,8 +1725,6 @@
     "colors": ["colors@1.4.0", "", {}, "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA=="],
 
     "combined-stream": ["combined-stream@1.0.8", "", { "dependencies": { "delayed-stream": "~1.0.0" } }, "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg=="],
-
-    "comlink": ["comlink@4.4.2", "", {}, "sha512-OxGdvBmJuNKSCMO4NTl1L47VRp6xn2wG4F/2hYzB6tiCb709otOxtEYCSvK80PtjODfXXZu8ds+Nw5kVCjqd2g=="],
 
     "comma-separated-tokens": ["comma-separated-tokens@2.0.3", "", {}, "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg=="],
 
@@ -2090,17 +1742,11 @@
 
     "cookie": ["cookie@1.1.1", "", {}, "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ=="],
 
-    "cookie-es": ["cookie-es@3.1.1", "", {}, "sha512-UaXxwISYJPTr9hwQxMFYZ7kNhSXboMXP+Z3TRX6f1/NyaGPfuNUZOWP1pUEb75B2HjfklIYLVRfWiFZJyC6Npg=="],
+    "cookie-es": ["cookie-es@1.2.3", "", {}, "sha512-lXVyvUvrNXblMqzIRrxHb57UUVmqsSWlxqt3XIjCkUP0wDAf6uicO6KMbEgYrMNtEvWgWHwe42CKxPu9MYAnWw=="],
 
     "cookie-signature": ["cookie-signature@1.2.2", "", {}, "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg=="],
 
-    "copy-anything": ["copy-anything@4.0.5", "", { "dependencies": { "is-what": "^5.2.0" } }, "sha512-7Vv6asjS4gMOuILabD3l739tsaxFQmC+a7pLZm02zyvs8p977bL3zEgq3yDk5rn9B0PbYgIv++jmHcuUab4RhA=="],
-
-    "core-js": ["core-js@3.49.0", "", {}, "sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg=="],
-
     "cors": ["cors@2.8.6", "", { "dependencies": { "object-assign": "^4", "vary": "^1" } }, "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw=="],
-
-    "crelt": ["crelt@1.0.6", "", {}, "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g=="],
 
     "cron-parser": ["cron-parser@5.5.0", "", { "dependencies": { "luxon": "^3.7.1" } }, "sha512-oML4lKUXxizYswqmxuOCpgFS8BNUJpIu6k/2HVHyaL8Ynnf3wdf9tkns0yRdJLSIjkJ+b0DXHMZEHGpMwjnPww=="],
 
@@ -2116,8 +1762,6 @@
 
     "css-what": ["css-what@6.2.2", "", {}, "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA=="],
 
-    "css.escape": ["css.escape@1.5.1", "", {}, "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg=="],
-
     "cssesc": ["cssesc@3.0.0", "", { "bin": { "cssesc": "bin/cssesc" } }, "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg=="],
 
     "csso": ["csso@5.0.5", "", { "dependencies": { "css-tree": "~2.2.0" } }, "sha512-0LrrStPOdJj+SPCCrGhzryycLjwcgUSHBtxNA8aIDxf0GLsRh1cKYhB00Gd1lDOS4yGH69+SNn13+TWbVHETFQ=="],
@@ -2127,10 +1771,6 @@
     "data-uri-to-buffer": ["data-uri-to-buffer@6.0.2", "", {}, "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw=="],
 
     "data-urls": ["data-urls@7.0.0", "", { "dependencies": { "whatwg-mimetype": "^5.0.0", "whatwg-url": "^16.0.0" } }, "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA=="],
-
-    "date-fns": ["date-fns@4.1.0", "", {}, "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg=="],
-
-    "date-fns-jalali": ["date-fns-jalali@4.1.0-0", "", {}, "sha512-hTIP/z+t+qKwBDcmmsnmjWTduxCg+5KfdqWQvb2X/8C9+knYY6epN/pfxdDuyVlSVeFz0sM5eEfwIUQ70U4ckg=="],
 
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
@@ -2168,8 +1808,6 @@
 
     "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
 
-    "detect-node-es": ["detect-node-es@1.1.0", "", {}, "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ=="],
-
     "devalue": ["devalue@5.7.1", "", {}, "sha512-MUbZ586EgQqdRnC4yDrlod3BEdyvE4TapGYHMW2CiaW+KkkFmWEFqBUaLltEZCGi0iFXCEjRF0OjF0DV2QHjOA=="],
 
     "devlop": ["devlop@1.1.0", "", { "dependencies": { "dequal": "^2.0.0" } }, "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA=="],
@@ -2187,8 +1825,6 @@
     "dlv": ["dlv@1.1.3", "", {}, "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA=="],
 
     "doctypes": ["doctypes@1.1.0", "", {}, "sha512-LLBi6pEqS6Do3EKQ3J0NqHWV5hhb78Pi8vvESYwyOy2c31ZEZVdtitdzsQsKb7878PEERhzUk0ftqGhG6Mz+pQ=="],
-
-    "dom-accessibility-api": ["dom-accessibility-api@0.6.3", "", {}, "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w=="],
 
     "dom-serializer": ["dom-serializer@2.0.0", "", { "dependencies": { "domelementtype": "^2.3.0", "domhandler": "^5.0.2", "entities": "^4.2.0" } }, "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg=="],
 
@@ -2208,13 +1844,9 @@
 
     "ecdsa-sig-formatter": ["ecdsa-sig-formatter@1.0.11", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ=="],
 
-    "echarts": ["echarts@5.6.0", "", { "dependencies": { "tslib": "2.3.0", "zrender": "5.6.1" } }, "sha512-oTbVTsXfKuEhxftHqL5xprgLoc0k7uScAwtryCgWF6hPYFLRwOUHiFmHGCBKP5NPFNkDVopOieyUqYGH8Fa3kA=="],
-
     "ee-first": ["ee-first@1.1.1", "", {}, "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="],
 
     "electron-to-chromium": ["electron-to-chromium@1.5.344", "", {}, "sha512-4MxfbmNDm+KPh066EZy+eUnkcDPcZ35wNmOWzFuh/ijvHsve6kbLTLURy88uCNK5FbpN+yk2nQY6BYh1GEt+wg=="],
-
-    "elen": ["elen@1.0.10", "", {}, "sha512-ZL799/V/kzxYJ6Wlfktreq6qQWfGc3VkGUQJW5lZQ8/MhsQiKTAwERPfhEwIsV2movRGe2DfV7H2MjRw76Z7Wg=="],
 
     "emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
 
@@ -2228,7 +1860,7 @@
 
     "enhanced-resolve": ["enhanced-resolve@5.21.0", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.3.3" } }, "sha512-otxSQPw4lkOZWkHpB3zaEQs6gWYEsmX4xQF68ElXC/TWvGxGMSGOvoNbaLXm6/cS/fSfHtsEdw90y20PCd+sCA=="],
 
-    "entities": ["entities@8.0.0", "", {}, "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA=="],
+    "entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
 
     "environment": ["environment@1.1.0", "", {}, "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q=="],
 
@@ -2362,10 +1994,6 @@
 
     "forwarded-parse": ["forwarded-parse@2.1.2", "", {}, "sha512-alTFZZQDKMporBH77856pXgzhEzaUVmLCDk+egLgIgHst3Tpndzz8MnKe+GzRJRfvVdn69HhpW7cmXzvtLvJAw=="],
 
-    "fraction.js": ["fraction.js@5.3.4", "", {}, "sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ=="],
-
-    "framer-motion": ["framer-motion@12.38.0", "", { "dependencies": { "motion-dom": "^12.38.0", "motion-utils": "^12.36.0", "tslib": "^2.4.0" }, "peerDependencies": { "@emotion/is-prop-valid": "*", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["@emotion/is-prop-valid", "react", "react-dom"] }, "sha512-rFYkY/pigbcswl1XQSb7q424kSTQ8q6eAC+YUsSKooHQYuLdzdHjrt6uxUC+PRAO++q5IS7+TamgIw1AphxR+g=="],
-
     "fresh": ["fresh@2.0.0", "", {}, "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A=="],
 
     "fs-constants": ["fs-constants@1.0.0", "", {}, "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="],
@@ -2388,8 +2016,6 @@
 
     "get-intrinsic": ["get-intrinsic@1.3.0", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.1.1", "function-bind": "^1.1.2", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "math-intrinsics": "^1.1.0" } }, "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ=="],
 
-    "get-nonce": ["get-nonce@1.0.1", "", {}, "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q=="],
-
     "get-proto": ["get-proto@1.0.1", "", { "dependencies": { "dunder-proto": "^1.0.1", "es-object-atoms": "^1.0.0" } }, "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g=="],
 
     "get-stream": ["get-stream@5.2.0", "", { "dependencies": { "pump": "^3.0.0" } }, "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA=="],
@@ -2407,8 +2033,6 @@
     "glob": ["glob@13.0.6", "", { "dependencies": { "minimatch": "^10.2.2", "minipass": "^7.1.3", "path-scurry": "^2.0.2" } }, "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw=="],
 
     "glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
-
-    "goober": ["goober@2.1.18", "", { "peerDependencies": { "csstype": "^3.0.10" } }, "sha512-2vFqsaDVIT9Gz7N6kAL++pLpp41l3PfDuusHcjnGLfR6+huZkl6ziX+zgVC3ZxpqWhzH6pyDdGrCeDhMIvwaxw=="],
 
     "google-auth-library": ["google-auth-library@10.6.2", "", { "dependencies": { "base64-js": "^1.3.0", "ecdsa-sig-formatter": "^1.0.11", "gaxios": "^7.1.4", "gcp-metadata": "8.1.2", "google-logging-utils": "1.1.3", "jws": "^4.0.0" } }, "sha512-e27Z6EThmVNNvtYASwQxose/G57rkRuaRbQyxM2bvYLLX/GqWZ5chWq2EBoUchJbCc57eC9ArzO5wMsEmWftCw=="],
 
@@ -2482,8 +2106,6 @@
 
     "highlight.js": ["highlight.js@10.7.3", "", {}, "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A=="],
 
-    "hoist-non-react-statics": ["hoist-non-react-statics@3.3.2", "", { "dependencies": { "react-is": "^16.7.0" } }, "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw=="],
-
     "hono": ["hono@4.12.14", "", {}, "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w=="],
 
     "hono-pino": ["hono-pino@0.10.3", "", { "dependencies": { "defu": "^6.1.4" }, "peerDependencies": { "hono": ">=4.0.0", "pino": ">=7.1.0" } }, "sha512-n0RNPIFOoq25Fg8b4D5gus4sVqI0z+8I17ibl96+p43d07UnZ0EMM/It0qSgfc7UtaC+XP5FkFmRHwBp6owsNA=="],
@@ -2493,8 +2115,6 @@
     "html-escaper": ["html-escaper@3.0.3", "", {}, "sha512-RuMffC89BOWQoY0WKGpIhn5gX3iI54O6nRA0yC124NYVtzjmFWBIiFd8M0x+ZdX0P9R4lADg1mgP8C7PxGOWuQ=="],
 
     "html-to-text": ["html-to-text@9.0.5", "", { "dependencies": { "@selderee/plugin-htmlparser2": "^0.11.0", "deepmerge": "^4.3.1", "dom-serializer": "^2.0.0", "htmlparser2": "^8.0.2", "selderee": "^0.11.0" } }, "sha512-qY60FjREgVZL03vJU6IfMV4GDjGBIoOyvuFdpBDIX9yTlDw0TjxVBQp+P8NvpdIXNJvfWBTNul7fsAQJq2FNpg=="],
-
-    "html-url-attributes": ["html-url-attributes@3.0.1", "", {}, "sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ=="],
 
     "html-void-elements": ["html-void-elements@3.0.0", "", {}, "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg=="],
 
@@ -2526,15 +2146,11 @@
 
     "import-in-the-middle": ["import-in-the-middle@3.0.1", "", { "dependencies": { "acorn": "^8.15.0", "acorn-import-attributes": "^1.9.5", "cjs-module-lexer": "^2.2.0", "module-details-from-path": "^1.0.4" } }, "sha512-pYkiyXVL2Mf3pozdlDGV6NAObxQx13Ae8knZk1UJRJ6uRW/ZRmTGHlQYtrsSl7ubuE5F8CD1z+s1n4RHNuTtuA=="],
 
-    "indent-string": ["indent-string@4.0.0", "", {}, "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg=="],
-
     "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
 
     "ini": ["ini@6.0.0", "", {}, "sha512-IBTdIkzZNOpqm7q3dRqJvMaldXjDHWkEDfrwGEQTs5eaQMWV+djAhR+wahyNNMAa+qpbDUhBMVt4ZKNwpPm7xQ=="],
 
     "inline-style-parser": ["inline-style-parser@0.2.7", "", {}, "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA=="],
-
-    "input-otp": ["input-otp@1.4.2", "", { "peerDependencies": { "react": "^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc" } }, "sha512-l3jWwYNvrEa6NTCt7BECfCm48GvwuZzkoeG3gBL2w4CHeOXW3eKFmf9UNYkNfYc3mxMrthMnxjIE07MT0zLBQA=="],
 
     "ioredis": ["ioredis@5.10.1", "", { "dependencies": { "@ioredis/commands": "1.5.1", "cluster-key-slot": "^1.1.0", "debug": "^4.3.4", "denque": "^2.1.0", "lodash.defaults": "^4.2.0", "lodash.isarguments": "^3.1.0", "redis-errors": "^1.2.0", "redis-parser": "^3.0.0", "standard-as-callback": "^2.1.0" } }, "sha512-HuEDBTI70aYdx1v6U97SbNx9F1+svQKBDo30o0b9fw055LMepzpOOd0Ccg9Q6tbqmBSJaMuY0fB7yw9/vjBYCA=="],
 
@@ -2549,8 +2165,6 @@
     "is-alphanumerical": ["is-alphanumerical@2.0.1", "", { "dependencies": { "is-alphabetical": "^2.0.0", "is-decimal": "^2.0.0" } }, "sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw=="],
 
     "is-arrayish": ["is-arrayish@0.3.4", "", {}, "sha512-m6UrgzFVUYawGBh1dUsWR5M2Clqic9RVXC/9f8ceNlv2IcO9j9J/z8UoCLPqtsPBFNzEpfR3xftohbfqDx8EQA=="],
-
-    "is-binary-path": ["is-binary-path@2.1.0", "", { "dependencies": { "binary-extensions": "^2.0.0" } }, "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw=="],
 
     "is-core-module": ["is-core-module@2.16.1", "", { "dependencies": { "hasown": "^2.0.2" } }, "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w=="],
 
@@ -2592,11 +2206,7 @@
 
     "is-unicode-supported": ["is-unicode-supported@2.1.0", "", {}, "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ=="],
 
-    "is-what": ["is-what@5.5.0", "", {}, "sha512-oG7cgbmg5kLYae2N5IVd3jm2s+vldjxJzK1pcu9LfpGuQ93MQSzo0okvRna+7y5ifrD+20FE8FvjusyGaz14fw=="],
-
     "is-wsl": ["is-wsl@3.1.1", "", { "dependencies": { "is-inside-container": "^1.0.0" } }, "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw=="],
-
-    "isbot": ["isbot@5.1.39", "", {}, "sha512-obH0yYahGXdzNxo+djmHhBYThUKDkz565cxkIlt2L9hXfv1NlaLKoDBHo6KxXsYrIXx2RK3x5vY36CfZcobxEw=="],
 
     "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
 
@@ -2736,19 +2346,13 @@
 
     "longest-streak": ["longest-streak@3.1.0", "", {}, "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g=="],
 
-    "loose-envify": ["loose-envify@1.4.0", "", { "dependencies": { "js-tokens": "^3.0.0 || ^4.0.0" }, "bin": { "loose-envify": "cli.js" } }, "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q=="],
-
     "loupe": ["loupe@3.2.1", "", {}, "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ=="],
 
-    "lru-cache": ["lru-cache@11.3.5", "", {}, "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw=="],
+    "lru-cache": ["lru-cache@7.18.3", "", {}, "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA=="],
 
     "lru-memoizer": ["lru-memoizer@2.3.0", "", { "dependencies": { "lodash.clonedeep": "^4.5.0", "lru-cache": "6.0.0" } }, "sha512-GXn7gyHAMhO13WSKrIiNfztwxodVsP8IoZ3XfrJV4yH2x0/OeTO/FIaAHTY5YekdGgW94njfuKmyyt1E0mR6Ug=="],
 
-    "lucide-react": ["lucide-react@0.469.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-28vvUnnKQ/dBwiCQtwJw7QauYnE7yd2Cyp4tTTJpvglX4EMpbflcdBgrgToX2j71B3YvugK/NH3BGUk+E/p/Fw=="],
-
     "luxon": ["luxon@3.7.2", "", {}, "sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew=="],
-
-    "lz-string": ["lz-string@1.5.0", "", { "bin": { "lz-string": "bin/bin.js" } }, "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ=="],
 
     "magic-bytes.js": ["magic-bytes.js@1.13.0", "", {}, "sha512-afO2mnxW7GDTXMm5/AoN1WuOcdoKhtgXjIvHmobqTD1grNplhGdv3PFOyjCVmrnOZBIT/gD/koDKpYG+0mvHcg=="],
 
@@ -2900,8 +2504,6 @@
 
     "mimic-response": ["mimic-response@3.1.0", "", {}, "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ=="],
 
-    "min-indent": ["min-indent@1.0.1", "", {}, "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg=="],
-
     "minimatch": ["minimatch@9.0.9", "", { "dependencies": { "brace-expansion": "^2.0.2" } }, "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg=="],
 
     "minimist": ["minimist@1.2.8", "", {}, "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="],
@@ -2914,17 +2516,11 @@
 
     "module-details-from-path": ["module-details-from-path@1.0.4", "", {}, "sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w=="],
 
-    "motion-dom": ["motion-dom@12.38.0", "", { "dependencies": { "motion-utils": "^12.36.0" } }, "sha512-pdkHLD8QYRp8VfiNLb8xIBJis1byQ9gPT3Jnh2jqfFtAsWUA3dEepDlsWe/xMpO8McV+VdpKVcp+E+TGJEtOoA=="],
-
-    "motion-utils": ["motion-utils@12.36.0", "", {}, "sha512-eHWisygbiwVvf6PZ1vhaHCLamvkSbPIeAYxWUuL3a2PD/TROgE7FvfHWTIH4vMl798QLfMw15nRqIaRDXTlYRg=="],
-
     "mrmime": ["mrmime@2.0.1", "", {}, "sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ=="],
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
     "msw": ["msw@2.14.2", "", { "dependencies": { "@inquirer/confirm": "^6.0.11", "@mswjs/interceptors": "^0.41.3", "@open-draft/deferred-promise": "^3.0.0", "@types/statuses": "^2.0.6", "cookie": "^1.1.1", "graphql": "^16.13.2", "headers-polyfill": "^5.0.1", "is-node-process": "^1.2.0", "outvariant": "^1.4.3", "path-to-regexp": "^6.3.0", "picocolors": "^1.1.1", "rettime": "^0.11.7", "statuses": "^2.0.2", "strict-event-emitter": "^0.5.1", "tough-cookie": "^6.0.1", "type-fest": "^5.5.0", "until-async": "^3.0.2", "yargs": "^17.7.2" }, "peerDependencies": { "typescript": ">= 4.8.x" }, "optionalPeers": ["typescript"], "bin": { "msw": "cli/index.js" } }, "sha512-D2bTe0tpuf9nw4DA39wFaqUD/hRPKj0DKpo2lAqu+A47Ifg4+h0hbfn6QxVOsiUY2uhgEN6TTpGSHDsc+ysYNg=="],
-
-    "mutative": ["mutative@1.3.0", "", {}, "sha512-8MJj6URmOZAV70dpFe1YnSppRTKC4DsMkXQiBDFayLcDI4ljGokHxmpqaBQuDWa4iAxWaJJ1PS8vAmbntjjKmQ=="],
 
     "mute-stream": ["mute-stream@2.0.0", "", {}, "sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA=="],
 
@@ -3058,7 +2654,7 @@
 
     "parse-latin": ["parse-latin@7.0.0", "", { "dependencies": { "@types/nlcst": "^2.0.0", "@types/unist": "^3.0.0", "nlcst-to-string": "^4.0.0", "unist-util-modify-children": "^4.0.0", "unist-util-visit-children": "^3.0.0", "vfile": "^6.0.0" } }, "sha512-mhHgobPPua5kZ98EF4HWiH167JWBfl4pvAIXXdbaVohtK7a6YBOy56kvhCqduqyo/f3yrHFWmqmiMg/BkBkYYQ=="],
 
-    "parse5": ["parse5@8.0.1", "", { "dependencies": { "entities": "^8.0.0" } }, "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw=="],
+    "parse5": ["parse5@5.1.1", "", {}, "sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug=="],
 
     "parse5-htmlparser2-tree-adapter": ["parse5-htmlparser2-tree-adapter@6.0.1", "", { "dependencies": { "parse5": "^6.0.1" } }, "sha512-qPuWvbLgvDGilKc5BoicRovlT4MtYT6JfJyBOMDsKoiT+GiuP5qyrPCnR9HcPECIJJmZh5jRndyNThnhhb/vlA=="],
 
@@ -3078,7 +2674,7 @@
 
     "path-scurry": ["path-scurry@2.0.2", "", { "dependencies": { "lru-cache": "^11.0.0", "minipass": "^7.1.2" } }, "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg=="],
 
-    "path-to-regexp": ["path-to-regexp@6.3.0", "", {}, "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ=="],
+    "path-to-regexp": ["path-to-regexp@8.4.2", "", {}, "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA=="],
 
     "pathe": ["pathe@1.1.2", "", {}, "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ=="],
 
@@ -3132,8 +2728,6 @@
 
     "postcss-selector-parser": ["postcss-selector-parser@6.1.2", "", { "dependencies": { "cssesc": "^3.0.0", "util-deprecate": "^1.0.2" } }, "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg=="],
 
-    "postcss-value-parser": ["postcss-value-parser@4.2.0", "", {}, "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ=="],
-
     "postgres": ["postgres@3.4.9", "", {}, "sha512-GD3qdB0x1z9xgFI6cdRD6xu2Sp2WCOEoe3mtnyB5Ee0XrrL5Pe+e4CCnJrRMnL1zYtRDZmQQVbvOttLnKDLnaw=="],
 
     "postgres-array": ["postgres-array@2.0.0", "", {}, "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA=="],
@@ -3152,15 +2746,11 @@
 
     "prettier": ["prettier@3.8.3", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw=="],
 
-    "pretty-format": ["pretty-format@27.5.1", "", { "dependencies": { "ansi-regex": "^5.0.1", "ansi-styles": "^5.0.0", "react-is": "^17.0.1" } }, "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ=="],
-
     "prismjs": ["prismjs@1.30.0", "", {}, "sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw=="],
 
     "process-warning": ["process-warning@5.0.0", "", {}, "sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA=="],
 
     "promise": ["promise@7.3.1", "", { "dependencies": { "asap": "~2.0.3" } }, "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg=="],
-
-    "prop-types": ["prop-types@15.8.1", "", { "dependencies": { "loose-envify": "^1.4.0", "object-assign": "^4.1.1", "react-is": "^16.13.1" } }, "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg=="],
 
     "proper-lockfile": ["proper-lockfile@4.1.2", "", { "dependencies": { "graceful-fs": "^4.2.4", "retry": "^0.12.0", "signal-exit": "^3.0.2" } }, "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA=="],
 
@@ -3202,14 +2792,6 @@
 
     "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
 
-    "pvtsutils": ["pvtsutils@1.3.6", "", { "dependencies": { "tslib": "^2.8.1" } }, "sha512-PLgQXQ6H2FWCaeRak8vvk1GW462lMxB5s3Jm673N82zI4vqtVUPuZdffdZbPDFRoU8kAhItWFtPCWiPpp4/EDg=="],
-
-    "pvutils": ["pvutils@1.1.5", "", {}, "sha512-KTqnxsgGiQ6ZAzZCVlJH5eOjSnvlyEgx1m8bkRJfOhmGRqfo5KLvmAlACQkrjEtOQ4B7wF9TdSLIs9O90MX9xA=="],
-
-    "qr.js": ["qr.js@0.0.0", "", {}, "sha512-c4iYnWb+k2E+vYpRimHqSu575b1/wKl4XFeJGpFmrJQz5I88v9aY2czh7s0w36srfCM1sXgC/xpoJz5dJfq+OQ=="],
-
-    "qrcode.react": ["qrcode.react@4.2.0", "", { "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-QpgqWi8rD9DsS9EP3z7BT+5lY5SFhsqGjpgW5DY/i3mK4M9DTBNz3ErMi8BWYEfI3L0d8GIbGmcdFAS1uIRGjA=="],
-
     "qs": ["qs@6.15.1", "", { "dependencies": { "side-channel": "^1.1.0" } }, "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg=="],
 
     "queue-microtask": ["queue-microtask@1.2.3", "", {}, "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="],
@@ -3232,33 +2814,13 @@
 
     "react": ["react@19.2.5", "", {}, "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA=="],
 
-    "react-async-script": ["react-async-script@1.2.0", "", { "dependencies": { "hoist-non-react-statics": "^3.3.0", "prop-types": "^15.5.0" }, "peerDependencies": { "react": ">=16.4.1" } }, "sha512-bCpkbm9JiAuMGhkqoAiC0lLkb40DJ0HOEJIku+9JDjxX3Rcs+ztEOG13wbrOskt3n2DTrjshhaQ/iay+SnGg5Q=="],
-
-    "react-day-picker": ["react-day-picker@9.14.0", "", { "dependencies": { "@date-fns/tz": "^1.4.1", "@tabby_ai/hijri-converter": "1.0.5", "date-fns": "^4.1.0", "date-fns-jalali": "4.1.0-0" }, "peerDependencies": { "react": ">=16.8.0" } }, "sha512-tBaoDWjPwe0M5pGrum4H0SR6Lyk+BO9oHnp9JbKpGKW2mlraNPgP9BMfsg5pWpwrssARmeqk7YBl2oXutZTaHA=="],
-
     "react-dom": ["react-dom@19.2.5", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.5" } }, "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag=="],
-
-    "react-google-recaptcha": ["react-google-recaptcha@3.1.0", "", { "dependencies": { "prop-types": "^15.5.0", "react-async-script": "^1.2.0" }, "peerDependencies": { "react": ">=16.4.1" } }, "sha512-cYW2/DWas8nEKZGD7SCu9BSuVz8iOcOLHChHyi7upUuVhkpkhYG/6N3KDiTQ3XAiZ2UAZkfvYKMfAHOzBOcGEg=="],
-
-    "react-hook-form": ["react-hook-form@7.73.1", "", { "peerDependencies": { "react": "^16.8.0 || ^17 || ^18 || ^19" } }, "sha512-VAfVYOPcx3piiEVQy95vyFmBwbVUsP/AUIN+mpFG8h11yshDd444nn0VyfaGWSRnhOLVgiDu7HIuBtAIzxn9dA=="],
-
-    "react-is": ["react-is@17.0.2", "", {}, "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="],
-
-    "react-markdown": ["react-markdown@10.1.0", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/mdast": "^4.0.0", "devlop": "^1.0.0", "hast-util-to-jsx-runtime": "^2.0.0", "html-url-attributes": "^3.0.0", "mdast-util-to-hast": "^13.0.0", "remark-parse": "^11.0.0", "remark-rehype": "^11.0.0", "unified": "^11.0.0", "unist-util-visit": "^5.0.0", "vfile": "^6.0.0" }, "peerDependencies": { "@types/react": ">=18", "react": ">=18" } }, "sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ=="],
-
-    "react-qr-code": ["react-qr-code@2.0.18", "", { "dependencies": { "prop-types": "^15.8.1", "qr.js": "0.0.0" }, "peerDependencies": { "react": "*" } }, "sha512-v1Jqz7urLMhkO6jkgJuBYhnqvXagzceg3qJUWayuCK/c6LTIonpWbwxR1f1APGd4xrW/QcQEovNrAojbUz65Tg=="],
 
     "react-refresh": ["react-refresh@0.17.0", "", {}, "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ=="],
 
-    "react-remove-scroll": ["react-remove-scroll@2.7.2", "", { "dependencies": { "react-remove-scroll-bar": "^2.3.7", "react-style-singleton": "^2.2.3", "tslib": "^2.1.0", "use-callback-ref": "^1.3.3", "use-sidecar": "^1.1.3" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q=="],
-
-    "react-remove-scroll-bar": ["react-remove-scroll-bar@2.3.8", "", { "dependencies": { "react-style-singleton": "^2.2.2", "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" }, "optionalPeers": ["@types/react"] }, "sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q=="],
-
-    "react-style-singleton": ["react-style-singleton@2.2.3", "", { "dependencies": { "get-nonce": "^1.0.0", "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ=="],
-
     "readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
 
-    "readdirp": ["readdirp@3.6.0", "", { "dependencies": { "picomatch": "^2.2.1" } }, "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA=="],
+    "readdirp": ["readdirp@5.0.0", "", {}, "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ=="],
 
     "real-require": ["real-require@0.2.0", "", {}, "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg=="],
 
@@ -3269,8 +2831,6 @@
     "recma-parse": ["recma-parse@1.0.0", "", { "dependencies": { "@types/estree": "^1.0.0", "esast-util-from-js": "^2.0.0", "unified": "^11.0.0", "vfile": "^6.0.0" } }, "sha512-OYLsIGBB5Y5wjnSnQW6t3Xg7q3fQ7FWbw/vcXtORTnyaSFscOtABg+7Pnz6YZ6c27fG1/aN8CjfwoUEUIdwqWQ=="],
 
     "recma-stringify": ["recma-stringify@1.0.0", "", { "dependencies": { "@types/estree": "^1.0.0", "estree-util-to-js": "^2.0.0", "unified": "^11.0.0", "vfile": "^6.0.0" } }, "sha512-cjwII1MdIIVloKvC9ErQ+OgAtwHBmcZ0Bg4ciz78FtbT8In39aAYbaA7zvxQ61xVMSPE8WxhLwLbhif4Js2C+g=="],
-
-    "redent": ["redent@3.0.0", "", { "dependencies": { "indent-string": "^4.0.0", "strip-indent": "^3.0.0" } }, "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg=="],
 
     "redis-errors": ["redis-errors@1.2.0", "", {}, "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w=="],
 
@@ -3376,10 +2936,6 @@
 
     "send": ["send@1.2.1", "", { "dependencies": { "debug": "^4.4.3", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "fresh": "^2.0.0", "http-errors": "^2.0.1", "mime-types": "^3.0.2", "ms": "^2.1.3", "on-finished": "^2.4.1", "range-parser": "^1.2.1", "statuses": "^2.0.2" } }, "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ=="],
 
-    "seroval": ["seroval@1.5.2", "", {}, "sha512-xcRN39BdsnO9Tf+VzsE7b3JyTJASItIV1FVFewJKCFcW4s4haIKS3e6vj8PGB9qBwC7tnuOywQMdv5N4qkzi7Q=="],
-
-    "seroval-plugins": ["seroval-plugins@1.5.2", "", { "peerDependencies": { "seroval": "^1.0" } }, "sha512-qpY0Cl+fKYFn4GOf3cMiq6l72CpuVaawb6ILjubOQ+diJ54LfOWaSSPsaswN8DRPIPW4Yq+tE1k5aKd7ILyaFg=="],
-
     "serve-static": ["serve-static@2.2.1", "", { "dependencies": { "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "parseurl": "^1.3.3", "send": "^1.2.0" } }, "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw=="],
 
     "set-cookie-parser": ["set-cookie-parser@3.1.0", "", {}, "sha512-kjnC1DXBHcxaOaOXBHBeRtltsDG2nUiUni+jP92M9gYdW12rsmx92UsfpH7o5tDRs7I1ZZPSQJQGv3UaRfCiuw=="],
@@ -3414,8 +2970,6 @@
 
     "simple-get": ["simple-get@4.0.1", "", { "dependencies": { "decompress-response": "^6.0.0", "once": "^1.3.1", "simple-concat": "^1.0.0" } }, "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA=="],
 
-    "simple-icons": ["simple-icons@16.17.0", "", {}, "sha512-bRrGtzM6NLgxeMWmRcfDdrRksECk101lRrCn6jjj6qzUB6lQ+E5smnr52rqS1kLPmbLpS/g6iF463j50M4BT7A=="],
-
     "simple-swizzle": ["simple-swizzle@0.2.4", "", { "dependencies": { "is-arrayish": "^0.3.1" } }, "sha512-nAu1WFPQSMNr2Zn9PGSZK9AGn4t/y97lEm+MXTtUDwfP0ksAIX4nO+6ruD9Jwut4C49SB1Ws+fbXsm/yScWOHw=="],
 
     "simple-xml-to-json": ["simple-xml-to-json@1.2.7", "", {}, "sha512-mz9VXphOxQWX3eQ/uXCtm6upltoN0DLx8Zb5T4TFC4FHB7S9FDPGre8CfLWqPWQQH/GrQYd2AXhhVM5LDpYx6Q=="],
@@ -3435,10 +2989,6 @@
     "socks-proxy-agent": ["socks-proxy-agent@8.0.5", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "^4.3.4", "socks": "^2.8.3" } }, "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw=="],
 
     "sonic-boom": ["sonic-boom@4.2.1", "", { "dependencies": { "atomic-sleep": "^1.0.0" } }, "sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q=="],
-
-    "sonner": ["sonner@2.0.7", "", { "peerDependencies": { "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc", "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc" } }, "sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w=="],
-
-    "sorted-btree": ["sorted-btree@1.8.1", "", {}, "sha512-395+XIP+wqNn3USkFSrNz7G3Ss/MXlZEqesxvzCRFwL14h6e8LukDHdLBePn5pwbm5OQ9vGu8mDyz2lLDIqamQ=="],
 
     "source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
 
@@ -3488,21 +3038,15 @@
 
     "strip-final-newline": ["strip-final-newline@2.0.0", "", {}, "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA=="],
 
-    "strip-indent": ["strip-indent@3.0.0", "", { "dependencies": { "min-indent": "^1.0.0" } }, "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ=="],
-
     "strip-json-comments": ["strip-json-comments@5.0.3", "", {}, "sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw=="],
 
     "strnum": ["strnum@2.2.3", "", {}, "sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg=="],
 
     "strtok3": ["strtok3@10.3.5", "", { "dependencies": { "@tokenizer/token": "^0.3.0" } }, "sha512-ki4hZQfh5rX0QDLLkOCj+h+CVNkqmp/CMf8v8kZpkNVK6jGQooMytqzLZYUVYIZcFZ6yDB70EfD8POcFXiF5oA=="],
 
-    "style-mod": ["style-mod@4.1.3", "", {}, "sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ=="],
-
     "style-to-js": ["style-to-js@1.1.21", "", { "dependencies": { "style-to-object": "1.0.14" } }, "sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ=="],
 
     "style-to-object": ["style-to-object@1.0.14", "", { "dependencies": { "inline-style-parser": "0.2.7" } }, "sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw=="],
-
-    "superjson": ["superjson@2.2.6", "", { "dependencies": { "copy-anything": "^4" } }, "sha512-H+ue8Zo4vJmV2nRjpx86P35lzwDT3nItnIsocgumgr0hHMQ+ZGq5vrERg9kJBo5AWGmxZDhzDo+WVIJqkB0cGA=="],
 
     "supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
 
@@ -3517,8 +3061,6 @@
     "symbol-tree": ["symbol-tree@3.2.4", "", {}, "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw=="],
 
     "tagged-tag": ["tagged-tag@1.0.0", "", {}, "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng=="],
-
-    "tailwind-merge": ["tailwind-merge@3.5.0", "", {}, "sha512-I8K9wewnVDkL1NTGoqWmVEIlUcB9gFriAEkXkfCjX5ib8ezGxtR3xD7iZIxrfArjEsH7F1CHD4RFUtxefdqV/A=="],
 
     "tailwindcss": ["tailwindcss@4.2.4", "", {}, "sha512-HhKppgO81FQof5m6TEnuBWCZGgfRAWbaeOaGT00KOy/Pf/j6oUihdvBpA7ltCeAvZpFhW3j0PTclkxsd4IXYDA=="],
 
@@ -3592,8 +3134,6 @@
 
     "tsx": ["tsx@4.21.0", "", { "dependencies": { "esbuild": "~0.27.0", "get-tsconfig": "^4.7.5" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "bin": { "tsx": "dist/cli.mjs" } }, "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw=="],
 
-    "tsyringe": ["tsyringe@4.10.0", "", { "dependencies": { "tslib": "^1.9.3" } }, "sha512-axr3IdNuVIxnaK5XGEUFTu3YmAQ6lllgrvqfEoR16g/HGnYY/6We4oWENtAnzK6/LpJ2ur9PAb80RBt7/U4ugw=="],
-
     "tunnel-agent": ["tunnel-agent@0.6.0", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w=="],
 
     "turndown": ["turndown@7.2.4", "", { "dependencies": { "@mixmark-io/domino": "^2.2.0" } }, "sha512-I8yFsfRzmzK0WV1pNNOA4A7y4RDfFxPRxb3t+e3ui14qSGOxGtiSP6GjeX+Y6CHb7HYaFj7ECUD7VE5kQMZWGQ=="],
@@ -3650,8 +3190,6 @@
 
     "unpipe": ["unpipe@1.0.0", "", {}, "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="],
 
-    "unplugin": ["unplugin@2.3.11", "", { "dependencies": { "@jridgewell/remapping": "^2.3.5", "acorn": "^8.15.0", "picomatch": "^4.0.3", "webpack-virtual-modules": "^0.6.2" } }, "sha512-5uKD0nqiYVzlmCRs01Fhs2BdkEgBS3SAVP6ndrBsuK42iC2+JHyxM05Rm9G8+5mkmRtzMZGY8Ct5+mliZxU/Ww=="],
-
     "unstorage": ["unstorage@1.17.5", "", { "dependencies": { "anymatch": "^3.1.3", "chokidar": "^5.0.0", "destr": "^2.0.5", "h3": "^1.15.10", "lru-cache": "^11.2.7", "node-fetch-native": "^1.6.7", "ofetch": "^1.5.1", "ufo": "^1.6.3" }, "peerDependencies": { "@azure/app-configuration": "^1.8.0", "@azure/cosmos": "^4.2.0", "@azure/data-tables": "^13.3.0", "@azure/identity": "^4.6.0", "@azure/keyvault-secrets": "^4.9.0", "@azure/storage-blob": "^12.26.0", "@capacitor/preferences": "^6 || ^7 || ^8", "@deno/kv": ">=0.9.0", "@netlify/blobs": "^6.5.0 || ^7.0.0 || ^8.1.0 || ^9.0.0 || ^10.0.0", "@planetscale/database": "^1.19.0", "@upstash/redis": "^1.34.3", "@vercel/blob": ">=0.27.1", "@vercel/functions": "^2.2.12 || ^3.0.0", "@vercel/kv": "^1 || ^2 || ^3", "aws4fetch": "^1.0.20", "db0": ">=0.2.1", "idb-keyval": "^6.2.1", "ioredis": "^5.4.2", "uploadthing": "^7.4.4" }, "optionalPeers": ["@azure/app-configuration", "@azure/cosmos", "@azure/data-tables", "@azure/identity", "@azure/keyvault-secrets", "@azure/storage-blob", "@capacitor/preferences", "@deno/kv", "@netlify/blobs", "@planetscale/database", "@upstash/redis", "@vercel/blob", "@vercel/functions", "@vercel/kv", "aws4fetch", "db0", "idb-keyval", "ioredis", "uploadthing"] }, "sha512-0i3iqvRfx29hkNntHyQvJTpf5W9dQ9ZadSoRU8+xVlhVtT7jAX57fazYO9EHvcRCfBCyi5YRya7XCDOsbTgkPg=="],
 
     "until-async": ["until-async@3.0.2", "", {}, "sha512-IiSk4HlzAMqTUseHHe3VhIGyuFmN90zMTpD3Z3y8jeQbzLIq500MVM7Jq2vUAnTKAFPJrqwkzr6PoTcPhGcOiw=="],
@@ -3660,12 +3198,6 @@
 
     "url-template": ["url-template@2.0.8", "", {}, "sha512-XdVKMF4SJ0nP/O7XIPB0JwAEuT9lDIYnNsK8yGVe43y0AWoKeJNdv3ZNWh7ksJ6KqQFjOO6ox/VEitLnaVNufw=="],
 
-    "use-callback-ref": ["use-callback-ref@1.3.3", "", { "dependencies": { "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg=="],
-
-    "use-sidecar": ["use-sidecar@1.1.3", "", { "dependencies": { "detect-node-es": "^1.1.0", "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ=="],
-
-    "use-sync-external-store": ["use-sync-external-store@1.6.0", "", { "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w=="],
-
     "utif2": ["utif2@4.1.0", "", { "dependencies": { "pako": "^1.0.11" } }, "sha512-+oknB9FHrJ7oW7A2WZYajOcv4FcDR4CfoGB0dPNfxbi4GO05RRnFmt5oa23+9w32EanrYcSJWspUiJkLMs+37w=="],
 
     "util-deprecate": ["util-deprecate@1.0.2", "", {}, "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="],
@@ -3673,8 +3205,6 @@
     "uuid": ["uuid@10.0.0", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ=="],
 
     "vary": ["vary@1.1.2", "", {}, "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="],
-
-    "vaul": ["vaul@1.1.2", "", { "dependencies": { "@radix-ui/react-dialog": "^1.1.1" }, "peerDependencies": { "react": "^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc" } }, "sha512-ZFkClGpWyI2WUQjdLJ/BaGuV6AVQiJ3uELGk3OYtP+B6yCO7Cmn9vPFXVJkRaGkOJu3m8bQMgtyzNHixULceQA=="],
 
     "vfile": ["vfile@6.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "vfile-message": "^4.0.0" } }, "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q=="],
 
@@ -3694,23 +3224,15 @@
 
     "void-elements": ["void-elements@3.1.0", "", {}, "sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w=="],
 
-    "w3c-keyname": ["w3c-keyname@2.2.8", "", {}, "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ=="],
-
     "w3c-xmlserializer": ["w3c-xmlserializer@5.0.0", "", { "dependencies": { "xml-name-validator": "^5.0.0" } }, "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA=="],
 
     "walk-up-path": ["walk-up-path@4.0.0", "", {}, "sha512-3hu+tD8YzSLGuFYtPRb48vdhKMi0KQV5sn+uWr8+7dMEq/2G/dtLrdDinkLjqq5TIbIBjYJ4Ax/n3YiaW7QM8A=="],
-
-    "warning": ["warning@4.0.3", "", { "dependencies": { "loose-envify": "^1.0.0" } }, "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w=="],
 
     "web-namespaces": ["web-namespaces@2.0.1", "", {}, "sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ=="],
 
     "web-streams-polyfill": ["web-streams-polyfill@3.3.3", "", {}, "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw=="],
 
-    "web-worker": ["web-worker@1.5.0", "", {}, "sha512-RiMReJrTAiA+mBjGONMnjVDP2u3p9R1vkcGz6gDIrOMT3oGuYwX2WRMYI9ipkphSuE5XKEhydbhNEJh4NY9mlw=="],
-
     "webidl-conversions": ["webidl-conversions@8.0.1", "", {}, "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ=="],
-
-    "webpack-virtual-modules": ["webpack-virtual-modules@0.6.2", "", {}, "sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ=="],
 
     "whatwg-mimetype": ["whatwg-mimetype@5.0.0", "", {}, "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw=="],
 
@@ -3760,7 +3282,7 @@
 
     "yaml": ["yaml@2.8.3", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg=="],
 
-    "yargs": ["yargs@17.7.2", "", { "dependencies": { "cliui": "^8.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "require-directory": "^2.1.1", "string-width": "^4.2.3", "y18n": "^5.0.5", "yargs-parser": "^21.1.1" } }, "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w=="],
+    "yargs": ["yargs@16.2.0", "", { "dependencies": { "cliui": "^7.0.2", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "require-directory": "^2.1.1", "string-width": "^4.2.0", "y18n": "^5.0.5", "yargs-parser": "^20.2.2" } }, "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw=="],
 
     "yargs-parser": ["yargs-parser@22.0.0", "", {}, "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw=="],
 
@@ -3775,8 +3297,6 @@
     "zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
     "zod-to-json-schema": ["zod-to-json-schema@3.25.2", "", { "peerDependencies": { "zod": "^3.25.28 || ^4" } }, "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA=="],
-
-    "zrender": ["zrender@5.6.1", "", { "dependencies": { "tslib": "2.3.0" } }, "sha512-OFXkDJKcrlx5su2XbzJvj/34Q3m6PvyCZkVPHGYpcCJ52ek4U/ymZyfuV1nKE23AyBJ51E/6Yr0mhZ7xGTO4ag=="],
 
     "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
 
@@ -3797,8 +3317,6 @@
     "@babel/helper-compilation-targets/lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
 
     "@babel/helper-compilation-targets/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
-
-    "@daveyplate/better-auth-ui/better-call": ["better-call@2.0.2", "", { "dependencies": { "@better-auth/utils": "^0.3.1", "@better-fetch/fetch": "^1.1.21", "rou3": "^0.7.12", "set-cookie-parser": "^3.0.1" }, "peerDependencies": { "zod": "^4.0.0" }, "optionalPeers": ["zod"] }, "sha512-QqSKtfJD/ZzQdlm7BTUxT9RCA0AxcrZEMyU/yl7/uoFDoR7YCTdc555xQXjReo75M6/xkskPawPdhbn3fge4Cg=="],
 
     "@discordjs/builders/discord-api-types": ["discord-api-types@0.38.47", "", {}, "sha512-XgXQodHQBAE6kfD7kMvVo30863iHX1LHSqNq6MGUTDwIFCCvHva13+rwxyxVXDqudyApMNAd32PGjgVETi5rjA=="],
 
@@ -3828,11 +3346,9 @@
 
     "@grpc/proto-loader/long": ["long@5.3.2", "", {}, "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA=="],
 
+    "@grpc/proto-loader/yargs": ["yargs@17.7.2", "", { "dependencies": { "cliui": "^8.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "require-directory": "^2.1.1", "string-width": "^4.2.3", "y18n": "^5.0.5", "yargs-parser": "^21.1.1" } }, "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w=="],
+
     "@inquirer/core/signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
-
-    "@instantdb/core/uuid": ["uuid@11.1.0", "", { "bin": { "uuid": "dist/esm/bin/uuid" } }, "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A=="],
-
-    "@instantdb/react/eventsource": ["eventsource@4.1.0", "", { "dependencies": { "eventsource-parser": "^3.0.1" } }, "sha512-2GuF51iuHX6A9xdTccMTsNb7VO0lHZihApxhvQzJB5A03DvHDd2FQepodbMaztPBmBcE/ox7o2gqaxGhYB9LhQ=="],
 
     "@isaacs/cliui/string-width": ["string-width@5.1.2", "", { "dependencies": { "eastasianwidth": "^0.2.0", "emoji-regex": "^9.2.2", "strip-ansi": "^7.0.1" } }, "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA=="],
 
@@ -3869,8 +3385,6 @@
     "@jimp/plugin-threshold/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
     "@jimp/types/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
-
-    "@jsonforms/core/ajv-formats": ["ajv-formats@2.1.1", "", { "dependencies": { "ajv": "^8.0.0" } }, "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA=="],
 
     "@lobu/owletto-backend/@sentry/node": ["@sentry/node@9.47.1", "", { "dependencies": { "@opentelemetry/api": "^1.9.0", "@opentelemetry/context-async-hooks": "^1.30.1", "@opentelemetry/core": "^1.30.1", "@opentelemetry/instrumentation": "^0.57.2", "@opentelemetry/instrumentation-amqplib": "^0.46.1", "@opentelemetry/instrumentation-connect": "0.43.1", "@opentelemetry/instrumentation-dataloader": "0.16.1", "@opentelemetry/instrumentation-express": "0.47.1", "@opentelemetry/instrumentation-fs": "0.19.1", "@opentelemetry/instrumentation-generic-pool": "0.43.1", "@opentelemetry/instrumentation-graphql": "0.47.1", "@opentelemetry/instrumentation-hapi": "0.45.2", "@opentelemetry/instrumentation-http": "0.57.2", "@opentelemetry/instrumentation-ioredis": "0.47.1", "@opentelemetry/instrumentation-kafkajs": "0.7.1", "@opentelemetry/instrumentation-knex": "0.44.1", "@opentelemetry/instrumentation-koa": "0.47.1", "@opentelemetry/instrumentation-lru-memoizer": "0.44.1", "@opentelemetry/instrumentation-mongodb": "0.52.0", "@opentelemetry/instrumentation-mongoose": "0.46.1", "@opentelemetry/instrumentation-mysql": "0.45.1", "@opentelemetry/instrumentation-mysql2": "0.45.2", "@opentelemetry/instrumentation-pg": "0.51.1", "@opentelemetry/instrumentation-redis-4": "0.46.1", "@opentelemetry/instrumentation-tedious": "0.18.1", "@opentelemetry/instrumentation-undici": "0.10.1", "@opentelemetry/resources": "^1.30.1", "@opentelemetry/sdk-trace-base": "^1.30.1", "@opentelemetry/semantic-conventions": "^1.34.0", "@prisma/instrumentation": "6.11.1", "@sentry/core": "9.47.1", "@sentry/node-core": "9.47.1", "@sentry/opentelemetry": "9.47.1", "import-in-the-middle": "^1.14.2", "minimatch": "^9.0.0" } }, "sha512-CDbkasBz3fnWRKSFs6mmaRepM2pa+tbZkrqhPWifFfIkJDidtVW40p6OnquTvPXyPAszCnDZRnZT14xyvNmKPQ=="],
 
@@ -3932,61 +3446,9 @@
 
     "@opentelemetry/sql-common/@opentelemetry/core": ["@opentelemetry/core@2.7.0", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-DT12SXVwV2eoJrGf4nnsvZojxxeQo+LlNAsoYGRRObPWTeN6APiqZ2+nqDCQDvQX40eLi1AePONS0onoASp3yQ=="],
 
-    "@owletto/web/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
-
     "@prefresh/vite/@rollup/pluginutils": ["@rollup/pluginutils@4.2.1", "", { "dependencies": { "estree-walker": "^2.0.1", "picomatch": "^2.2.2" } }, "sha512-iKnFXr7NkdZAIHiIWE+BX5ULi/ucVFYWD6TbAV+rZctiRTY2PL6tsIKhoIOaoskiWAkgu+VsbXgUVDNLHf+InQ=="],
 
     "@prisma/instrumentation/@opentelemetry/instrumentation": ["@opentelemetry/instrumentation@0.207.0", "", { "dependencies": { "@opentelemetry/api-logs": "0.207.0", "import-in-the-middle": "^2.0.0", "require-in-the-middle": "^8.0.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-y6eeli9+TLKnznrR8AZlQMSJT7wILpXH+6EYq5Vf/4Ao+huI7EedxQHwRgVUOMLFbe7VFDvHJrX9/f4lcwnJsA=="],
-
-    "@radix-ui/react-arrow/@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.3", "", { "dependencies": { "@radix-ui/react-slot": "1.2.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ=="],
-
-    "@radix-ui/react-avatar/@radix-ui/react-context": ["@radix-ui/react-context@1.1.3", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-ieIFACdMpYfMEjF0rEf5KLvfVyIkOz6PDGyNnP+u+4xQ6jny3VCgA4OgXOwNx2aUkxn8zx9fiVcM8CfFYv9Lxw=="],
-
-    "@radix-ui/react-checkbox/@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.3", "", { "dependencies": { "@radix-ui/react-slot": "1.2.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ=="],
-
-    "@radix-ui/react-collapsible/@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.3", "", { "dependencies": { "@radix-ui/react-slot": "1.2.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ=="],
-
-    "@radix-ui/react-collection/@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.3", "", { "dependencies": { "@radix-ui/react-slot": "1.2.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ=="],
-
-    "@radix-ui/react-collection/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
-
-    "@radix-ui/react-dialog/@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.3", "", { "dependencies": { "@radix-ui/react-slot": "1.2.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ=="],
-
-    "@radix-ui/react-dialog/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
-
-    "@radix-ui/react-dismissable-layer/@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.3", "", { "dependencies": { "@radix-ui/react-slot": "1.2.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ=="],
-
-    "@radix-ui/react-dropdown-menu/@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.3", "", { "dependencies": { "@radix-ui/react-slot": "1.2.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ=="],
-
-    "@radix-ui/react-focus-scope/@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.3", "", { "dependencies": { "@radix-ui/react-slot": "1.2.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ=="],
-
-    "@radix-ui/react-menu/@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.3", "", { "dependencies": { "@radix-ui/react-slot": "1.2.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ=="],
-
-    "@radix-ui/react-menu/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
-
-    "@radix-ui/react-popover/@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.3", "", { "dependencies": { "@radix-ui/react-slot": "1.2.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ=="],
-
-    "@radix-ui/react-popover/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
-
-    "@radix-ui/react-popper/@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.3", "", { "dependencies": { "@radix-ui/react-slot": "1.2.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ=="],
-
-    "@radix-ui/react-portal/@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.3", "", { "dependencies": { "@radix-ui/react-slot": "1.2.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ=="],
-
-    "@radix-ui/react-roving-focus/@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.3", "", { "dependencies": { "@radix-ui/react-slot": "1.2.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ=="],
-
-    "@radix-ui/react-select/@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.3", "", { "dependencies": { "@radix-ui/react-slot": "1.2.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ=="],
-
-    "@radix-ui/react-select/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
-
-    "@radix-ui/react-slider/@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.3", "", { "dependencies": { "@radix-ui/react-slot": "1.2.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ=="],
-
-    "@radix-ui/react-tabs/@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.3", "", { "dependencies": { "@radix-ui/react-slot": "1.2.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ=="],
-
-    "@radix-ui/react-tooltip/@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.3", "", { "dependencies": { "@radix-ui/react-slot": "1.2.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ=="],
-
-    "@radix-ui/react-tooltip/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
-
-    "@radix-ui/react-visually-hidden/@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.3", "", { "dependencies": { "@radix-ui/react-slot": "1.2.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ=="],
 
     "@react-email/components/@react-email/render": ["@react-email/render@2.0.6", "", { "dependencies": { "html-to-text": "^9.0.5", "prettier": "^3.5.3" }, "peerDependencies": { "react": "^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^18.0 || ^19.0 || ^19.0.0-rc" } }, "sha512-xOzaYkH3jLZKqN5MqrTXYnmqBYUnZSVbkxdb5PGGmDcK6sKDVMliaDiSwfXajRC9JtSHTcGc2tmGLHWuCgVpog=="],
 
@@ -3994,21 +3456,9 @@
 
     "@scalar/types/nanoid": ["nanoid@5.1.9", "", { "bin": { "nanoid": "bin/nanoid.js" } }, "sha512-ZUvP7KeBLe3OZ1ypw6dI/TzYJuvHP77IM4Ry73waSQTLn8/g8rpdjfyVAh7t1/+FjBtG4lCP42MEbDxOsRpBMw=="],
 
-    "@sentry-internal/browser-utils/@sentry/core": ["@sentry/core@10.51.0", "", {}, "sha512-Y45V/YXvVLEXmOdkbD1oG1gkRWFi9guCEGg3PlIlIpRjAbZUrvLGgjRJIc1E7XpSzmOnWbs5BbUxMv4PDaPj2w=="],
-
-    "@sentry-internal/feedback/@sentry/core": ["@sentry/core@10.51.0", "", {}, "sha512-Y45V/YXvVLEXmOdkbD1oG1gkRWFi9guCEGg3PlIlIpRjAbZUrvLGgjRJIc1E7XpSzmOnWbs5BbUxMv4PDaPj2w=="],
-
-    "@sentry-internal/replay/@sentry/core": ["@sentry/core@10.51.0", "", {}, "sha512-Y45V/YXvVLEXmOdkbD1oG1gkRWFi9guCEGg3PlIlIpRjAbZUrvLGgjRJIc1E7XpSzmOnWbs5BbUxMv4PDaPj2w=="],
-
-    "@sentry-internal/replay-canvas/@sentry/core": ["@sentry/core@10.51.0", "", {}, "sha512-Y45V/YXvVLEXmOdkbD1oG1gkRWFi9guCEGg3PlIlIpRjAbZUrvLGgjRJIc1E7XpSzmOnWbs5BbUxMv4PDaPj2w=="],
-
-    "@sentry/browser/@sentry/core": ["@sentry/core@10.51.0", "", {}, "sha512-Y45V/YXvVLEXmOdkbD1oG1gkRWFi9guCEGg3PlIlIpRjAbZUrvLGgjRJIc1E7XpSzmOnWbs5BbUxMv4PDaPj2w=="],
-
     "@sentry/node/@opentelemetry/core": ["@opentelemetry/core@2.7.0", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-DT12SXVwV2eoJrGf4nnsvZojxxeQo+LlNAsoYGRRObPWTeN6APiqZ2+nqDCQDvQX40eLi1AePONS0onoASp3yQ=="],
 
     "@sentry/node/@opentelemetry/sdk-trace-base": ["@opentelemetry/sdk-trace-base@2.7.0", "", { "dependencies": { "@opentelemetry/core": "2.7.0", "@opentelemetry/resources": "2.7.0", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-Yg9zEXJB50DLVLpsKPk7NmNqlPlS+OvqhJGh0A8oawIOTPOwlm4eXs9BMJV7L79lvEwI+dWtAj+YjTyddV336A=="],
-
-    "@sentry/react/@sentry/core": ["@sentry/core@10.51.0", "", {}, "sha512-Y45V/YXvVLEXmOdkbD1oG1gkRWFi9guCEGg3PlIlIpRjAbZUrvLGgjRJIc1E7XpSzmOnWbs5BbUxMv4PDaPj2w=="],
 
     "@slack/web-api/p-queue": ["p-queue@6.6.2", "", { "dependencies": { "eventemitter3": "^4.0.4", "p-timeout": "^3.2.0" } }, "sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ=="],
 
@@ -4028,18 +3478,6 @@
 
     "@tailwindcss/oxide-wasm32-wasi/tslib": ["tslib@2.8.1", "", { "bundled": true }, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
-    "@tanstack/router-generator/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
-
-    "@tanstack/router-plugin/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
-
-    "@tanstack/router-utils/pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
-
-    "@testing-library/dom/aria-query": ["aria-query@5.3.0", "", { "dependencies": { "dequal": "^2.0.3" } }, "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A=="],
-
-    "@testing-library/dom/dom-accessibility-api": ["dom-accessibility-api@0.5.16", "", {}, "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg=="],
-
-    "@triplit/db/nanoid": ["nanoid@5.1.9", "", { "bin": { "nanoid": "bin/nanoid.js" } }, "sha512-ZUvP7KeBLe3OZ1ypw6dI/TzYJuvHP77IM4Ry73waSQTLn8/g8rpdjfyVAh7t1/+FjBtG4lCP42MEbDxOsRpBMw=="],
-
     "@types/pg-pool/@types/pg": ["@types/pg@8.20.0", "", { "dependencies": { "@types/node": "*", "pg-protocol": "*", "pg-types": "^2.2.0" } }, "sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow=="],
 
     "@vitest/coverage-v8/magicast": ["magicast@0.3.5", "", { "dependencies": { "@babel/parser": "^7.25.4", "@babel/types": "^7.25.4", "source-map-js": "^1.2.0" } }, "sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ=="],
@@ -4058,10 +3496,6 @@
 
     "cli-highlight/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
-    "cli-highlight/parse5": ["parse5@5.1.1", "", {}, "sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug=="],
-
-    "cli-highlight/yargs": ["yargs@16.2.0", "", { "dependencies": { "cliui": "^7.0.2", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "require-directory": "^2.1.1", "string-width": "^4.2.0", "y18n": "^5.0.5", "yargs-parser": "^20.2.2" } }, "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw=="],
-
     "cli-table3/@colors/colors": ["@colors/colors@1.5.0", "", {}, "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ=="],
 
     "cli-table3/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
@@ -4078,10 +3512,6 @@
 
     "discord.js/undici": ["undici@6.24.1", "", {}, "sha512-sC+b0tB1whOCzbtlx20fx3WgCXwkW627p4EA9uM+/tNNPkSS+eSEld6pAs9nDv7WbY1UUljBMYPtu9BCOrCWKA=="],
 
-    "dom-serializer/entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
-
-    "echarts/tslib": ["tslib@2.3.0", "", {}, "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="],
-
     "estree-util-build-jsx/estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
 
     "estree-util-to-js/source-map": ["source-map@0.7.6", "", {}, "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ=="],
@@ -4096,21 +3526,19 @@
 
     "glob/minimatch": ["minimatch@10.2.5", "", { "dependencies": { "brace-expansion": "^5.0.5" } }, "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg=="],
 
-    "h3/cookie-es": ["cookie-es@1.2.3", "", {}, "sha512-lXVyvUvrNXblMqzIRrxHb57UUVmqsSWlxqt3XIjCkUP0wDAf6uicO6KMbEgYrMNtEvWgWHwe42CKxPu9MYAnWw=="],
-
     "hast-util-from-html/parse5": ["parse5@7.3.0", "", { "dependencies": { "entities": "^6.0.0" } }, "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw=="],
 
     "hast-util-raw/parse5": ["parse5@7.3.0", "", { "dependencies": { "entities": "^6.0.0" } }, "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw=="],
-
-    "hoist-non-react-statics/react-is": ["react-is@16.13.1", "", {}, "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="],
-
-    "htmlparser2/entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
 
     "is-expression/acorn": ["acorn@7.4.1", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A=="],
 
     "istanbul-reports/html-escaper": ["html-escaper@2.0.2", "", {}, "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg=="],
 
     "jscpd/commander": ["commander@5.1.0", "", {}, "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg=="],
+
+    "jsdom/lru-cache": ["lru-cache@11.3.5", "", {}, "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw=="],
+
+    "jsdom/parse5": ["parse5@8.0.1", "", { "dependencies": { "entities": "^8.0.0" } }, "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw=="],
 
     "jstransformer/is-promise": ["is-promise@2.2.2", "", {}, "sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ=="],
 
@@ -4130,6 +3558,10 @@
 
     "msw/@inquirer/confirm": ["@inquirer/confirm@6.0.12", "", { "dependencies": { "@inquirer/core": "^11.1.9", "@inquirer/type": "^4.0.5" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-h9FgGun3QwVYNj5TWIZZ+slii73bMoBFjPfVIGtnFuL4t8gBiNDV9PcSfIzkuxvgquJKt9nr1QzszpBzTbH8Og=="],
 
+    "msw/path-to-regexp": ["path-to-regexp@6.3.0", "", {}, "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ=="],
+
+    "msw/yargs": ["yargs@17.7.2", "", { "dependencies": { "cliui": "^8.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "require-directory": "^2.1.1", "string-width": "^4.2.3", "y18n": "^5.0.5", "yargs-parser": "^21.1.1" } }, "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w=="],
+
     "node-fetch/data-uri-to-buffer": ["data-uri-to-buffer@4.0.1", "", {}, "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A=="],
 
     "node-liblzma/node-addon-api": ["node-addon-api@8.7.0", "", {}, "sha512-9MdFxmkKaOYVTV+XVRG8ArDwwQ77XIgIPyKASB1k3JPq3M8fGQQQE3YpMOrKm6g//Ktx8ivZr8xo1Qmtqub+GA=="],
@@ -4140,31 +3572,21 @@
 
     "parse5-htmlparser2-tree-adapter/parse5": ["parse5@6.0.1", "", {}, "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw=="],
 
+    "path-scurry/lru-cache": ["lru-cache@11.3.5", "", {}, "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw=="],
+
     "pixelmatch/pngjs": ["pngjs@6.0.0", "", {}, "sha512-TRzzuFRRmEoSW/p1KVAmiOgPco2Irlah+bGFCeNfJXxxYGwSw7YwAOAcd7X28K/m5bjBWKsC29KyoMfHbypayg=="],
 
     "prebuild-install/tar-fs": ["tar-fs@2.1.4", "", { "dependencies": { "chownr": "^1.1.1", "mkdirp-classic": "^0.5.2", "pump": "^3.0.0", "tar-stream": "^2.1.4" } }, "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ=="],
-
-    "pretty-format/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
-
-    "pretty-format/ansi-styles": ["ansi-styles@5.2.0", "", {}, "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA=="],
-
-    "prop-types/react-is": ["react-is@16.13.1", "", {}, "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="],
 
     "proper-lockfile/retry": ["retry@0.12.0", "", {}, "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow=="],
 
     "protobufjs/long": ["long@5.3.2", "", {}, "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA=="],
 
-    "proxy-agent/lru-cache": ["lru-cache@7.18.3", "", {}, "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA=="],
-
     "rc/ini": ["ini@1.3.8", "", {}, "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="],
 
     "rc/strip-json-comments": ["strip-json-comments@2.0.1", "", {}, "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ=="],
 
-    "readdirp/picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
-
     "restore-cursor/signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
-
-    "router/path-to-regexp": ["path-to-regexp@8.4.2", "", {}, "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA=="],
 
     "seek-bzip/commander": ["commander@6.2.1", "", {}, "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA=="],
 
@@ -4184,11 +3606,9 @@
 
     "tsx/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
-    "tsyringe/tslib": ["tslib@1.14.1", "", {}, "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="],
-
     "type-is/mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
 
-    "unstorage/chokidar": ["chokidar@5.0.0", "", { "dependencies": { "readdirp": "^5.0.0" } }, "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw=="],
+    "unstorage/lru-cache": ["lru-cache@11.3.5", "", {}, "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw=="],
 
     "vite/esbuild": ["esbuild@0.25.12", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.25.12", "@esbuild/android-arm": "0.25.12", "@esbuild/android-arm64": "0.25.12", "@esbuild/android-x64": "0.25.12", "@esbuild/darwin-arm64": "0.25.12", "@esbuild/darwin-x64": "0.25.12", "@esbuild/freebsd-arm64": "0.25.12", "@esbuild/freebsd-x64": "0.25.12", "@esbuild/linux-arm": "0.25.12", "@esbuild/linux-arm64": "0.25.12", "@esbuild/linux-ia32": "0.25.12", "@esbuild/linux-loong64": "0.25.12", "@esbuild/linux-mips64el": "0.25.12", "@esbuild/linux-ppc64": "0.25.12", "@esbuild/linux-riscv64": "0.25.12", "@esbuild/linux-s390x": "0.25.12", "@esbuild/linux-x64": "0.25.12", "@esbuild/netbsd-arm64": "0.25.12", "@esbuild/netbsd-x64": "0.25.12", "@esbuild/openbsd-arm64": "0.25.12", "@esbuild/openbsd-x64": "0.25.12", "@esbuild/openharmony-arm64": "0.25.12", "@esbuild/sunos-x64": "0.25.12", "@esbuild/win32-arm64": "0.25.12", "@esbuild/win32-ia32": "0.25.12", "@esbuild/win32-x64": "0.25.12" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg=="],
 
@@ -4216,15 +3636,11 @@
 
     "yargs/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
-    "yargs/yargs-parser": ["yargs-parser@21.1.1", "", {}, "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw=="],
-
-    "zrender/tslib": ["tslib@2.3.0", "", {}, "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="],
+    "yargs/yargs-parser": ["yargs-parser@20.2.9", "", {}, "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w=="],
 
     "@aws-crypto/sha256-browser/@smithy/util-utf8/@smithy/util-buffer-from": ["@smithy/util-buffer-from@2.2.0", "", { "dependencies": { "@smithy/is-array-buffer": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA=="],
 
     "@aws-crypto/util/@smithy/util-utf8/@smithy/util-buffer-from": ["@smithy/util-buffer-from@2.2.0", "", { "dependencies": { "@smithy/is-array-buffer": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA=="],
-
-    "@daveyplate/better-auth-ui/better-call/@better-auth/utils": ["@better-auth/utils@0.3.1", "", {}, "sha512-+CGp4UmZSUrHHnpHhLPYu6cV+wSUSvVbZbNykxhUDocpVNTo9uFFxw/NqJlh1iC4wQ9HKKWGCKuZ5wUgS0v6Kg=="],
 
     "@expressive-code/plugin-shiki/shiki/@shikijs/core": ["@shikijs/core@3.23.0", "", { "dependencies": { "@shikijs/types": "3.23.0", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4", "hast-util-to-html": "^9.0.5" } }, "sha512-NSWQz0riNb67xthdm5br6lAkvpDJRTgB36fxlo37ZzM2yq0PQFFzbd8psqC2XMPgCzo1fW6cVi18+ArJ44wqgA=="],
 
@@ -4243,6 +3659,12 @@
     "@fastify/otel/@opentelemetry/instrumentation/import-in-the-middle": ["import-in-the-middle@2.0.6", "", { "dependencies": { "acorn": "^8.15.0", "acorn-import-attributes": "^1.9.5", "cjs-module-lexer": "^2.2.0", "module-details-from-path": "^1.0.4" } }, "sha512-3vZV3jX0XRFW3EJDTwzWoZa+RH1b8eTTx6YOCjglrLyPuepwoBti1k3L2dKwdCUrnVEfc5CuRuGstaC/uQJJaw=="],
 
     "@fastify/otel/minimatch/brace-expansion": ["brace-expansion@5.0.5", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ=="],
+
+    "@grpc/proto-loader/yargs/cliui": ["cliui@8.0.1", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.1", "wrap-ansi": "^7.0.0" } }, "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ=="],
+
+    "@grpc/proto-loader/yargs/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
+
+    "@grpc/proto-loader/yargs/yargs-parser": ["yargs-parser@21.1.1", "", {}, "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw=="],
 
     "@isaacs/cliui/string-width/emoji-regex": ["emoji-regex@9.2.2", "", {}, "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="],
 
@@ -4320,30 +3742,6 @@
 
     "@prisma/instrumentation/@opentelemetry/instrumentation/import-in-the-middle": ["import-in-the-middle@2.0.6", "", { "dependencies": { "acorn": "^8.15.0", "acorn-import-attributes": "^1.9.5", "cjs-module-lexer": "^2.2.0", "module-details-from-path": "^1.0.4" } }, "sha512-3vZV3jX0XRFW3EJDTwzWoZa+RH1b8eTTx6YOCjglrLyPuepwoBti1k3L2dKwdCUrnVEfc5CuRuGstaC/uQJJaw=="],
 
-    "@radix-ui/react-arrow/@radix-ui/react-primitive/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
-
-    "@radix-ui/react-checkbox/@radix-ui/react-primitive/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
-
-    "@radix-ui/react-collapsible/@radix-ui/react-primitive/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
-
-    "@radix-ui/react-dismissable-layer/@radix-ui/react-primitive/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
-
-    "@radix-ui/react-dropdown-menu/@radix-ui/react-primitive/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
-
-    "@radix-ui/react-focus-scope/@radix-ui/react-primitive/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
-
-    "@radix-ui/react-popper/@radix-ui/react-primitive/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
-
-    "@radix-ui/react-portal/@radix-ui/react-primitive/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
-
-    "@radix-ui/react-roving-focus/@radix-ui/react-primitive/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
-
-    "@radix-ui/react-slider/@radix-ui/react-primitive/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
-
-    "@radix-ui/react-tabs/@radix-ui/react-primitive/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
-
-    "@radix-ui/react-visually-hidden/@radix-ui/react-primitive/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
-
     "@sentry/node/@opentelemetry/sdk-trace-base/@opentelemetry/resources": ["@opentelemetry/resources@2.7.0", "", { "dependencies": { "@opentelemetry/core": "2.7.0", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-K+oi0hNMv94EpZbnW3eyu2X6SGVpD3O5DhG2NIp65Hc7lhAj9brRXTAVzh3wB82+q3ThakEf7Zd7RsFUqcTc7A=="],
 
     "@slack/web-api/p-queue/eventemitter3": ["eventemitter3@4.0.7", "", {}, "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="],
@@ -4357,12 +3755,6 @@
     "accepts/mime-types/mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
 
     "astro/vite/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
-
-    "cli-highlight/yargs/cliui": ["cliui@7.0.4", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.0", "wrap-ansi": "^7.0.0" } }, "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ=="],
-
-    "cli-highlight/yargs/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
-
-    "cli-highlight/yargs/yargs-parser": ["yargs-parser@20.2.9", "", {}, "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w=="],
 
     "cli-table3/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
 
@@ -4382,6 +3774,8 @@
 
     "hast-util-raw/parse5/entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
 
+    "jsdom/parse5/entities": ["entities@8.0.0", "", {}, "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA=="],
+
     "just-bash/minimatch/brace-expansion": ["brace-expansion@5.0.5", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ=="],
 
     "lru-memoizer/lru-cache/yallist": ["yallist@4.0.0", "", {}, "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="],
@@ -4389,6 +3783,12 @@
     "msw/@inquirer/confirm/@inquirer/core": ["@inquirer/core@11.1.9", "", { "dependencies": { "@inquirer/ansi": "^2.0.5", "@inquirer/figures": "^2.0.5", "@inquirer/type": "^4.0.5", "cli-width": "^4.1.0", "fast-wrap-ansi": "^0.2.0", "mute-stream": "^3.0.0", "signal-exit": "^4.1.0" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-BDE4fG22uYh1bGSifcj7JSx119TVYNViMhMu85usp4Fswrzh6M0DV3yld64jA98uOAa2GSQ4Bg4bZRm2d2cwSg=="],
 
     "msw/@inquirer/confirm/@inquirer/type": ["@inquirer/type@4.0.5", "", { "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-aetVUNeKNc/VriqXlw1NRSW0zhMBB0W4bNbWRJgzRl/3d0QNDQFfk0GO5SDdtjMZVg6o8ZKEiadd7SCCzoOn5Q=="],
+
+    "msw/yargs/cliui": ["cliui@8.0.1", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.1", "wrap-ansi": "^7.0.0" } }, "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ=="],
+
+    "msw/yargs/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
+
+    "msw/yargs/yargs-parser": ["yargs-parser@21.1.1", "", {}, "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw=="],
 
     "prebuild-install/tar-fs/tar-stream": ["tar-stream@2.2.0", "", { "dependencies": { "bl": "^4.0.3", "end-of-stream": "^1.4.1", "fs-constants": "^1.0.0", "inherits": "^2.0.3", "readable-stream": "^3.1.1" } }, "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ=="],
 
@@ -4403,8 +3803,6 @@
     "test-exclude/minimatch/brace-expansion": ["brace-expansion@5.0.5", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ=="],
 
     "type-is/mime-types/mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
-
-    "unstorage/chokidar/readdirp": ["readdirp@5.0.0", "", {}, "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ=="],
 
     "vite-node/vite/esbuild": ["esbuild@0.21.5", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.21.5", "@esbuild/android-arm": "0.21.5", "@esbuild/android-arm64": "0.21.5", "@esbuild/android-x64": "0.21.5", "@esbuild/darwin-arm64": "0.21.5", "@esbuild/darwin-x64": "0.21.5", "@esbuild/freebsd-arm64": "0.21.5", "@esbuild/freebsd-x64": "0.21.5", "@esbuild/linux-arm": "0.21.5", "@esbuild/linux-arm64": "0.21.5", "@esbuild/linux-ia32": "0.21.5", "@esbuild/linux-loong64": "0.21.5", "@esbuild/linux-mips64el": "0.21.5", "@esbuild/linux-ppc64": "0.21.5", "@esbuild/linux-riscv64": "0.21.5", "@esbuild/linux-s390x": "0.21.5", "@esbuild/linux-x64": "0.21.5", "@esbuild/netbsd-x64": "0.21.5", "@esbuild/openbsd-x64": "0.21.5", "@esbuild/sunos-x64": "0.21.5", "@esbuild/win32-arm64": "0.21.5", "@esbuild/win32-ia32": "0.21.5", "@esbuild/win32-x64": "0.21.5" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw=="],
 
@@ -4484,6 +3882,14 @@
 
     "@fastify/otel/minimatch/brace-expansion/balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
 
+    "@grpc/proto-loader/yargs/cliui/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
+    "@grpc/proto-loader/yargs/cliui/wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
+
+    "@grpc/proto-loader/yargs/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+
+    "@grpc/proto-loader/yargs/string-width/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
     "@lobu/owletto-backend/@sentry/node/@opentelemetry/instrumentation/require-in-the-middle": ["require-in-the-middle@7.5.2", "", { "dependencies": { "debug": "^4.3.5", "module-details-from-path": "^1.0.3", "resolve": "^1.22.8" } }, "sha512-gAZ+kLqBdHarXB64XpAe2VCjB7rIRv+mU8tfRWziHRJ5umKsIHN2tLLv6EtMw7WCdP19S0ERVMldNvxYCHnhSQ=="],
 
     "@lobu/owletto-backend/@sentry/node/@opentelemetry/instrumentation-http/@opentelemetry/semantic-conventions": ["@opentelemetry/semantic-conventions@1.28.0", "", {}, "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA=="],
@@ -4514,14 +3920,6 @@
 
     "@so-ric/colorspace/color/color-string/color-name": ["color-name@2.1.0", "", {}, "sha512-1bPaDNFm0axzE4MEAzKPuqKWeRaT43U/hyxKPBdqTfmPF+d6n7FSoTFxLVULUJOmiLp01KjhIPPH+HrXZJN4Rg=="],
 
-    "cli-highlight/yargs/cliui/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
-
-    "cli-highlight/yargs/cliui/wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
-
-    "cli-highlight/yargs/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
-
-    "cli-highlight/yargs/string-width/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
-
     "cli-table3/string-width/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
     "glob/minimatch/brace-expansion/balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
@@ -4537,6 +3935,14 @@
     "msw/@inquirer/confirm/@inquirer/core/mute-stream": ["mute-stream@3.0.0", "", {}, "sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw=="],
 
     "msw/@inquirer/confirm/@inquirer/core/signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
+
+    "msw/yargs/cliui/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
+    "msw/yargs/cliui/wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
+
+    "msw/yargs/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+
+    "msw/yargs/string-width/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
     "test-exclude/glob/path-scurry/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
 
@@ -4636,13 +4042,17 @@
 
     "yargs/string-width/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
+    "@grpc/proto-loader/yargs/cliui/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
+    "@grpc/proto-loader/yargs/string-width/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
     "@lobu/owletto-backend/@sentry/node/@opentelemetry/instrumentation-pg/@types/pg-pool/@types/pg": ["@types/pg@8.20.0", "", { "dependencies": { "@types/node": "*", "pg-protocol": "*", "pg-types": "^2.2.0" } }, "sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow=="],
 
-    "cli-highlight/yargs/cliui/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
-
-    "cli-highlight/yargs/string-width/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
-
     "msw/@inquirer/confirm/@inquirer/core/fast-wrap-ansi/fast-string-width": ["fast-string-width@3.0.2", "", { "dependencies": { "fast-string-truncated-width": "^3.0.2" } }, "sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg=="],
+
+    "msw/yargs/cliui/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
+    "msw/yargs/string-width/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
     "msw/@inquirer/confirm/@inquirer/core/fast-wrap-ansi/fast-string-width/fast-string-truncated-width": ["fast-string-truncated-width@3.0.3", "", {}, "sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g=="],
   }

--- a/packages/cli/src/__tests__/token.test.ts
+++ b/packages/cli/src/__tests__/token.test.ts
@@ -44,7 +44,9 @@ describe("token create", () => {
     });
     const originalFetch = globalThis.fetch;
     globalThis.fetch = fetchMock as unknown as typeof fetch;
-    const writeSpy = spyOn(process.stdout, "write").mockImplementation(() => true);
+    const writeSpy = spyOn(process.stdout, "write").mockImplementation(
+      () => true
+    );
 
     try {
       await tokenCreateCommand({ org: "acme", name: "prod-server", raw: true });

--- a/packages/cli/src/__tests__/token.test.ts
+++ b/packages/cli/src/__tests__/token.test.ts
@@ -1,0 +1,58 @@
+import { afterEach, describe, expect, mock, spyOn, test } from "bun:test";
+import { tokenCreateCommand } from "../commands/token";
+import * as context from "../internal/context";
+import * as credentials from "../internal/credentials";
+
+describe("token create", () => {
+  afterEach(() => {
+    mock.restore();
+    delete process.env.LOBU_API_TOKEN;
+  });
+
+  test("creates an org-scoped PAT using the current OAuth login", async () => {
+    spyOn(context, "resolveContext").mockResolvedValue({
+      name: "prod",
+      apiUrl: "https://app.lobu.ai/api/v1",
+      source: "config",
+    });
+    spyOn(credentials, "getToken").mockResolvedValue("oauth-access-token");
+
+    const fetchMock = mock(async (url: string, init?: RequestInit) => {
+      expect(url).toBe("https://app.lobu.ai/api/acme/tokens");
+      expect(init?.method).toBe("POST");
+      expect(init?.headers).toMatchObject({
+        Authorization: "Bearer oauth-access-token",
+      });
+      expect(JSON.parse(String(init?.body))).toEqual({
+        name: "prod-server",
+        scope: "mcp:read mcp:write",
+      });
+      return new Response(
+        JSON.stringify({
+          token: {
+            id: 1,
+            token: "owl_pat_test",
+            token_prefix: "owl_pat_test",
+            name: "prod-server",
+            scope: "mcp:read mcp:write",
+            expires_at: null,
+            created_at: "2026-01-01T00:00:00.000Z",
+          },
+        }),
+        { status: 201, headers: { "Content-Type": "application/json" } }
+      );
+    });
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+    const writeSpy = spyOn(process.stdout, "write").mockImplementation(() => true);
+
+    try {
+      await tokenCreateCommand({ org: "acme", name: "prod-server", raw: true });
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(writeSpy).toHaveBeenCalledWith("owl_pat_test\n");
+  });
+});

--- a/packages/cli/src/commands/token.ts
+++ b/packages/cli/src/commands/token.ts
@@ -1,5 +1,27 @@
 import chalk from "chalk";
 import { getToken, resolveContext } from "../internal/index.js";
+import { resolveApiClient } from "../internal/api-client.js";
+
+interface TokenCreateOptions {
+  context?: string;
+  org?: string;
+  name?: string;
+  description?: string;
+  scope?: string;
+  expiresInDays?: number;
+  raw?: boolean;
+  json?: boolean;
+}
+
+interface CreatedPersonalAccessToken {
+  id: number;
+  token: string;
+  token_prefix: string;
+  name: string;
+  scope: string | null;
+  expires_at: string | null;
+  created_at: string;
+}
 
 export async function tokenCommand(options: {
   context?: string;
@@ -22,4 +44,54 @@ export async function tokenCommand(options: {
   console.log(chalk.cyan(`\n  Context: ${target.name}`));
   console.log(chalk.dim(`  API URL: ${target.apiUrl}`));
   console.log("  Token: available (use `lobu token --raw` to print it)\n");
+}
+
+export async function tokenCreateCommand(
+  options: TokenCreateOptions
+): Promise<void> {
+  const { client, orgSlug, contextName } = await resolveApiClient({
+    context: options.context,
+    org: options.org,
+  });
+  const name = options.name?.trim() || defaultTokenName();
+  const scope = options.scope?.trim() || "mcp:read mcp:write";
+
+  const response = await client.post<{ token: CreatedPersonalAccessToken }>(
+    `/api/${encodeURIComponent(orgSlug)}/tokens`,
+    {
+      name,
+      scope,
+      ...(options.description ? { description: options.description } : {}),
+      ...(options.expiresInDays !== undefined
+        ? { expiresInDays: options.expiresInDays }
+        : {}),
+    }
+  );
+
+  if (options.raw) {
+    process.stdout.write(`${response.token.token}\n`);
+    return;
+  }
+
+  if (options.json) {
+    process.stdout.write(`${JSON.stringify(response.token, null, 2)}\n`);
+    return;
+  }
+
+  console.log(chalk.cyan("\n  Personal access token created"));
+  console.log(chalk.dim(`  Context: ${contextName}`));
+  console.log(chalk.dim(`  Org:     ${orgSlug}`));
+  console.log(chalk.dim(`  Name:    ${response.token.name}`));
+  console.log(chalk.dim(`  Scope:   ${response.token.scope ?? scope}`));
+  console.log(
+    chalk.dim(
+      `  Expires: ${response.token.expires_at ? new Date(response.token.expires_at).toISOString() : "never"}`
+    )
+  );
+  console.log(chalk.yellow("\n  Save this token now; it will not be shown again:"));
+  console.log(`  ${response.token.token}\n`);
+}
+
+function defaultTokenName(): string {
+  return `lobu-cli-${new Date().toISOString().slice(0, 10)}`;
 }

--- a/packages/cli/src/commands/token.ts
+++ b/packages/cli/src/commands/token.ts
@@ -88,7 +88,9 @@ export async function tokenCreateCommand(
       `  Expires: ${response.token.expires_at ? new Date(response.token.expires_at).toISOString() : "never"}`
     )
   );
-  console.log(chalk.yellow("\n  Save this token now; it will not be shown again:"));
+  console.log(
+    chalk.yellow("\n  Save this token now; it will not be shown again:")
+  );
   console.log(`  ${response.token.token}\n`);
 }
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -256,13 +256,17 @@ export async function runCli(
       "--scope <scope>",
       "Space-separated scopes (default: mcp:read mcp:write)"
     )
-    .option("--expires-in-days <days>", "Expire token after N days", (value) => {
-      const days = Number(value);
-      if (!Number.isInteger(days) || days < 1) {
-        throw new Error("--expires-in-days must be a positive integer");
+    .option(
+      "--expires-in-days <days>",
+      "Expire token after N days",
+      (value) => {
+        const days = Number(value);
+        if (!Number.isInteger(days) || days < 1) {
+          throw new Error("--expires-in-days must be a positive integer");
+        }
+        return days;
       }
-      return days;
-    })
+    )
     .option("--raw", "Print token only")
     .option("--json", "Print JSON response")
     .action(

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -517,6 +517,22 @@ export async function runCli(
     );
 
   memory
+    .command("exec <script>")
+    .description("Run a TypeScript ClientSDK script via the memory MCP")
+    .option("--url <url>", "Server URL override")
+    .option("--org <slug>", "Org slug override")
+    .option("-c, --context <name>", "Use a named context")
+    .action(
+      async (
+        script: string,
+        options: { url?: string; org?: string; context?: string }
+      ) => {
+        const { memoryRunCommand } = await import("./commands/memory/run.js");
+        await memoryRunCommand("run", JSON.stringify({ script }), options);
+      }
+    );
+
+  memory
     .command("health")
     .description("Validate Lobu login + MCP connectivity")
     .option("--url <url>", "Server URL override")

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -235,15 +235,51 @@ export async function runCli(
     });
 
   // ─── token ──────────────────────────────────────────────────────────
-  program
+  const token = program
     .command("token")
-    .description("Print the current Lobu access token")
+    .description("Print or create Lobu access tokens")
     .option("-c, --context <name>", "Use a named context")
     .option("--raw", "Print token only (no labels)")
     .action(async (options: { context?: string; raw?: boolean }) => {
       const { tokenCommand } = await import("./commands/token.js");
       await tokenCommand(options);
     });
+
+  token
+    .command("create")
+    .description("Create an org-scoped personal access token for servers/CI")
+    .option("-c, --context <name>", "Use a named context")
+    .option("--org <slug>", "Org slug override")
+    .option("--name <name>", "Token name (default: lobu-cli-YYYY-MM-DD)")
+    .option("--description <text>", "Token description")
+    .option(
+      "--scope <scope>",
+      "Space-separated scopes (default: mcp:read mcp:write)"
+    )
+    .option("--expires-in-days <days>", "Expire token after N days", (value) => {
+      const days = Number(value);
+      if (!Number.isInteger(days) || days < 1) {
+        throw new Error("--expires-in-days must be a positive integer");
+      }
+      return days;
+    })
+    .option("--raw", "Print token only")
+    .option("--json", "Print JSON response")
+    .action(
+      async (options: {
+        context?: string;
+        org?: string;
+        name?: string;
+        description?: string;
+        scope?: string;
+        expiresInDays?: number;
+        raw?: boolean;
+        json?: boolean;
+      }) => {
+        const { tokenCreateCommand } = await import("./commands/token.js");
+        await tokenCreateCommand(options);
+      }
+    );
 
   // ─── context ────────────────────────────────────────────────────────
   const context = program

--- a/packages/landing/astro.config.mjs
+++ b/packages/landing/astro.config.mjs
@@ -54,7 +54,7 @@ export default defineConfig({
         "./src/styles/starlight-theme.css",
       ],
       expressiveCode: {
-        themes: ["github-light"],
+        themes: ["github-light", "github-dark"],
       },
       components: {
         Head: "./src/components/starlight/Head.astro",

--- a/packages/landing/src/components/CTA.tsx
+++ b/packages/landing/src/components/CTA.tsx
@@ -16,8 +16,8 @@ function HexCluster() {
           <g key={i} transform={`translate(${x},90)`}>
             <polygon
               points="-30,0 -15,-26 15,-26 30,0 15,26 -15,26"
-              fill="#ffffff"
-              stroke="rgba(0,0,0,0.18)"
+              fill="var(--color-page-text-inverted)"
+              stroke="var(--color-page-hex-stroke)"
               stroke-width="1.2"
             />
             <line
@@ -25,7 +25,7 @@ function HexCluster() {
               y1="-26"
               x2="15"
               y2="26"
-              stroke="rgba(0,0,0,0.08)"
+              stroke="var(--color-page-hex-line)"
               stroke-width="1"
               stroke-dasharray="2 3"
             />
@@ -59,7 +59,10 @@ export function CTA({ startUrl = getOwlettoBaseUrl() }: { startUrl?: string }) {
             <a
               href={startUrl}
               class="inline-flex items-center text-[14px] font-medium px-5 h-10 rounded-lg transition-opacity hover:opacity-90"
-              style={{ background: "#0b0b0d", color: "#ffffff" }}
+              style={{
+                background: "var(--color-page-bg-inverted)",
+                color: "var(--color-page-text-inverted)",
+              }}
             >
               Start for free
             </a>

--- a/packages/landing/src/components/DataModelSection.tsx
+++ b/packages/landing/src/components/DataModelSection.tsx
@@ -56,7 +56,7 @@ const RELATIONSHIPS: { afterIndex: number; label: string }[] = [
 function EntityCardView({ entity }: { entity: EntityCard }) {
   return (
     <div
-      class="rounded-xl bg-white shadow-sm w-full"
+      class="rounded-xl bg-[var(--color-page-surface)] shadow-sm w-full"
       style={{ border: "1px solid var(--color-page-border)" }}
     >
       <div

--- a/packages/landing/src/components/FeatureGraphics.tsx
+++ b/packages/landing/src/components/FeatureGraphics.tsx
@@ -86,7 +86,7 @@ export function MemoryGraphic() {
   return (
     <div class="w-full max-w-md flex flex-col gap-4">
       <div
-        class="rounded-xl p-4 bg-white"
+        class="rounded-xl p-4 bg-[var(--color-page-surface)]"
         style={{ border: "1px solid var(--color-page-border)" }}
       >
         <div
@@ -190,7 +190,7 @@ export function SharedMemoryGraphic() {
       </div>
 
       <div
-        class="rounded-xl bg-white shadow-sm"
+        class="rounded-xl bg-[var(--color-page-surface)] shadow-sm"
         style={{ border: "1px solid var(--color-page-border)" }}
       >
         <div
@@ -269,7 +269,7 @@ function MemoryAgentCard({
 }) {
   return (
     <div
-      class="rounded-xl bg-white shadow-sm"
+      class="rounded-xl bg-[var(--color-page-surface)] shadow-sm"
       style={{ border: "1px solid var(--color-page-border)" }}
     >
       <div class="flex flex-col items-center px-2 py-3 text-center">
@@ -304,7 +304,7 @@ function MemoryAgentCard({
 export function SkillsGraphic() {
   return (
     <div
-      class="w-full max-w-md rounded-xl overflow-hidden bg-white"
+      class="w-full max-w-md rounded-xl overflow-hidden bg-[var(--color-page-surface)]"
       style={{ border: "1px solid var(--color-page-border)" }}
     >
       <div
@@ -389,7 +389,7 @@ export function HostingGraphic() {
           ) : null}
           <div
             key={card.label}
-            class="rounded-xl p-4 bg-white"
+            class="rounded-xl p-4 bg-[var(--color-page-surface)]"
             style={{ border: "1px solid var(--color-page-border)" }}
           >
             <div class="flex items-center justify-between mb-3">
@@ -443,7 +443,7 @@ export function BenchmarkGraphic() {
 
   return (
     <div
-      class="w-full max-w-md rounded-xl p-5 bg-white"
+      class="w-full max-w-md rounded-xl p-5 bg-[var(--color-page-surface)]"
       style={{ border: "1px solid var(--color-page-border)" }}
     >
       <div class="flex items-center justify-between mb-4">
@@ -509,7 +509,7 @@ export function WatcherGraphic() {
   return (
     <div class="w-full max-w-md flex flex-col gap-3">
       <div
-        class="rounded-xl p-4 bg-white"
+        class="rounded-xl p-4 bg-[var(--color-page-surface)]"
         style={{ border: "1px solid var(--color-page-border)" }}
       >
         <div class="flex items-center justify-between mb-3">
@@ -571,7 +571,7 @@ export function WatcherGraphic() {
         ↓
       </div>
       <div
-        class="rounded-xl p-3.5 bg-white flex items-center gap-2.5 text-[13px]"
+        class="rounded-xl p-3.5 bg-[var(--color-page-surface)] flex items-center gap-2.5 text-[13px]"
         style={{ border: "1px solid var(--color-page-border)" }}
       >
         <span aria-hidden="true">🏢</span>
@@ -617,7 +617,7 @@ export function PlatformsGraphic() {
   return (
     <div class="w-full max-w-md flex flex-col gap-3">
       <div
-        class="rounded-xl p-4 bg-white"
+        class="rounded-xl p-4 bg-[var(--color-page-surface)]"
         style={{ border: "1px solid var(--color-page-border)" }}
       >
         <div
@@ -641,7 +641,7 @@ export function PlatformsGraphic() {
         </div>
       </div>
       <div
-        class="rounded-xl p-4 bg-white"
+        class="rounded-xl p-4 bg-[var(--color-page-surface)]"
         style={{ border: "1px solid var(--color-page-border)" }}
       >
         <div class="flex items-center justify-between mb-3">

--- a/packages/landing/src/components/FeatureGraphics.tsx
+++ b/packages/landing/src/components/FeatureGraphics.tsx
@@ -131,7 +131,7 @@ export function MemoryGraphic() {
             <div
               class="w-10 h-10 rounded-lg flex items-center justify-center font-mono text-[12px] font-semibold"
               style={{
-                background: "white",
+                background: "var(--color-page-surface)",
                 border: "1px solid var(--color-page-border)",
                 color: "var(--color-page-text)",
               }}
@@ -318,7 +318,7 @@ export function SkillsGraphic() {
         <span
           class="px-2 py-0.5 rounded"
           style={{
-            background: "white",
+            background: "var(--color-page-surface)",
             border: "1px solid var(--color-page-border)",
             color: "var(--color-page-text)",
           }}

--- a/packages/landing/src/components/HeroProductCard.tsx
+++ b/packages/landing/src/components/HeroProductCard.tsx
@@ -636,11 +636,11 @@ function Sidebar({
   onStageChange?: (stage: HeroStageId) => void;
   entities: EntityNavItem[];
 }) {
-  const sidebarBg = "#fafafa";
-  const fg = "#0b0b0d";
-  const fgMuted = "rgba(11,11,13,0.55)";
-  const fgFaint = "rgba(11,11,13,0.4)";
-  const accentBg = "rgba(0,0,0,0.05)";
+  const sidebarBg = "var(--color-page-surface-dim)";
+  const fg = "var(--color-page-text)";
+  const fgMuted = "var(--color-page-text-muted)";
+  const fgFaint = "var(--color-page-text-muted)";
+  const accentBg = "var(--color-page-surface-dim)";
 
   function NavRow({
     icon,
@@ -898,7 +898,7 @@ function AppShell({
 }) {
   return (
     <div
-      class="max-w-[72rem] mx-auto rounded-2xl overflow-hidden grid grid-cols-1 md:grid-cols-[232px_1fr] relative bg-white"
+      class="max-w-[72rem] mx-auto rounded-2xl overflow-hidden grid grid-cols-1 md:grid-cols-[232px_1fr] relative bg-[var(--color-page-surface)]"
       style={{
         border: "1px solid var(--color-page-border)",
         boxShadow: "0 8px 28px rgba(0,0,0,0.06)",
@@ -976,10 +976,14 @@ function PrimaryButton({
     <span
       class="inline-flex items-center gap-1.5 h-8 px-3 rounded-md text-[13px] font-medium"
       style={{
-        background: active ? "#0b0b0d" : "white",
-        color: active ? "white" : "var(--color-page-text)",
+        background: active
+          ? "var(--color-page-bg-inverted)"
+          : "var(--color-page-surface)",
+        color: active
+          ? "var(--color-page-text-inverted)"
+          : "var(--color-page-text)",
         border: active
-          ? "1px solid #0b0b0d"
+          ? "1px solid var(--color-page-bg-inverted)"
           : "1px solid var(--color-page-border)",
       }}
     >
@@ -1002,7 +1006,7 @@ function GhostButton({
       style={{
         color: "var(--color-page-text)",
         border: "1px solid var(--color-page-border)",
-        background: "white",
+        background: "var(--color-page-surface)",
       }}
     >
       {icon}
@@ -1016,7 +1020,7 @@ function SearchInput() {
     <span
       class="hidden sm:inline-flex items-center gap-2 h-8 px-3 rounded-md text-[13px]"
       style={{
-        background: "white",
+        background: "var(--color-page-surface)",
         color: "var(--color-page-text-muted)",
         border: "1px solid var(--color-page-border)",
         minWidth: "0",
@@ -1133,7 +1137,7 @@ const DEFAULT_RECORD_ROWS: RecordRow[] = [
 function MembersTable({ rows }: { rows: RecordRow[] }) {
   return (
     <div
-      class="rounded-lg overflow-hidden bg-white"
+      class="rounded-lg overflow-hidden bg-[var(--color-page-surface)]"
       style={{ border: "1px solid var(--color-page-border)" }}
     >
       <div
@@ -1224,7 +1228,7 @@ function EntitySchemaSummary({
 }) {
   return (
     <div
-      class="rounded-lg bg-white p-3"
+      class="rounded-lg bg-[var(--color-page-surface)] p-3"
       style={{ border: "1px solid var(--color-page-border)" }}
     >
       <div class="flex flex-wrap items-start gap-3">
@@ -1337,7 +1341,7 @@ function SummaryChip({ children }: { children: ComponentChildren }) {
     <span
       class="inline-flex items-center gap-1.5 rounded px-1.5 py-0.5 text-[11px]"
       style={{
-        background: "white",
+        background: "var(--color-page-surface)",
         border: "1px solid var(--color-page-border)",
         color: "var(--color-page-text)",
       }}
@@ -1617,7 +1621,7 @@ function ConnectorsTable({ connectors }: { connectors: ConnectorRow[] }) {
 
   return (
     <div
-      class="rounded-lg overflow-hidden bg-white"
+      class="rounded-lg overflow-hidden bg-[var(--color-page-surface)]"
       style={{ border: "1px solid var(--color-page-border)" }}
     >
       <div
@@ -1734,7 +1738,7 @@ function WatchersTable({ rows }: { rows: WatcherRow[] }) {
   const cols = "1.6fr 0.7fr 1.1fr 0.7fr 1fr 0.7fr";
   return (
     <div
-      class="rounded-lg overflow-hidden bg-white"
+      class="rounded-lg overflow-hidden bg-[var(--color-page-surface)]"
       style={{ border: "1px solid var(--color-page-border)" }}
     >
       <div
@@ -2041,7 +2045,7 @@ function KnowledgeFeed({ rows }: { rows?: KnowledgeRow[] }) {
 function UseCaseKnowledgeCard({ row }: { row: KnowledgeRow }) {
   return (
     <article
-      class="rounded-lg bg-white p-4 flex flex-col gap-3"
+      class="rounded-lg bg-[var(--color-page-surface)] p-4 flex flex-col gap-3"
       style={{ border: "1px solid var(--color-page-border)" }}
     >
       <header class="flex items-start gap-3">
@@ -2134,7 +2138,7 @@ function UseCaseKnowledgeCard({ row }: { row: KnowledgeRow }) {
 function KnowledgeFilterBar() {
   return (
     <div
-      class="rounded-lg bg-white px-3 py-2 flex flex-wrap items-center gap-x-3 gap-y-1.5"
+      class="rounded-lg bg-[var(--color-page-surface)] px-3 py-2 flex flex-wrap items-center gap-x-3 gap-y-1.5"
       style={{ border: "1px solid var(--color-page-border)" }}
     >
       {KNOWLEDGE_CHIPS.map((group, gi) => (
@@ -2160,8 +2164,12 @@ function KnowledgeFilterBar() {
                 key={v}
                 class="inline-flex items-center px-2 py-0.5 rounded text-[11px]"
                 style={{
-                  background: isActive ? "var(--color-page-text)" : "white",
-                  color: isActive ? "white" : "var(--color-page-text)",
+                  background: isActive
+                    ? "var(--color-page-bg-inverted)"
+                    : "var(--color-page-surface)",
+                  color: isActive
+                    ? "var(--color-page-text-inverted)"
+                    : "var(--color-page-text)",
                   border: isActive
                     ? "1px solid var(--color-page-text)"
                     : "1px solid var(--color-page-border)",
@@ -2181,7 +2189,7 @@ function KnowledgeFilterBar() {
 function KnowledgeCard({ item }: { item: KnowledgeMemoryItem }) {
   return (
     <article
-      class="rounded-lg bg-white p-4 flex flex-col gap-2"
+      class="rounded-lg bg-[var(--color-page-surface)] p-4 flex flex-col gap-2"
       style={{ border: "1px solid var(--color-page-border)" }}
     >
       <header class="flex items-start gap-3">
@@ -2243,7 +2251,7 @@ function KnowledgeCard({ item }: { item: KnowledgeMemoryItem }) {
             style={{
               color: "var(--color-page-text-muted)",
               border: "1px solid var(--color-page-border)",
-              background: "white",
+              background: "var(--color-page-surface)",
             }}
             aria-hidden="true"
           >
@@ -2254,7 +2262,7 @@ function KnowledgeCard({ item }: { item: KnowledgeMemoryItem }) {
             style={{
               color: "var(--color-page-text-muted)",
               border: "1px solid var(--color-page-border)",
-              background: "white",
+              background: "var(--color-page-surface)",
             }}
             aria-hidden="true"
           >
@@ -2336,7 +2344,7 @@ function KnowledgeActionCard({ item }: { item: KnowledgeActionItem }) {
         <span
           class="inline-flex items-center justify-center w-7 h-7 rounded-md mt-0.5"
           style={{
-            background: "white",
+            background: "var(--color-page-surface)",
             border: "1px solid var(--color-page-border)",
             color: "var(--color-page-text)",
           }}
@@ -2362,7 +2370,7 @@ function KnowledgeActionCard({ item }: { item: KnowledgeActionItem }) {
             <span
               class="font-mono text-[11px] px-1.5 py-0.5 rounded"
               style={{
-                background: "white",
+                background: "var(--color-page-surface)",
                 color: "var(--color-page-text-muted)",
                 border: "1px solid var(--color-page-border)",
               }}
@@ -2387,7 +2395,7 @@ function KnowledgeActionCard({ item }: { item: KnowledgeActionItem }) {
             <span
               class="inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px]"
               style={{
-                background: "white",
+                background: "var(--color-page-surface)",
                 border: "1px solid var(--color-page-border)",
               }}
             >
@@ -2399,7 +2407,7 @@ function KnowledgeActionCard({ item }: { item: KnowledgeActionItem }) {
       </header>
 
       <div
-        class="rounded-md bg-white p-3 flex flex-col gap-2"
+        class="rounded-md bg-[var(--color-page-surface)] p-3 flex flex-col gap-2"
         style={{ border: "1px solid var(--color-page-border)" }}
       >
         <div
@@ -2480,7 +2488,9 @@ function ActionField({
           .filter(Boolean)
           .join(" ")}
         style={{
-          background: editable ? "white" : "var(--color-page-surface-dim)",
+          background: editable
+            ? "var(--color-page-surface)"
+            : "var(--color-page-surface-dim)",
           color: "var(--color-page-text)",
           border: "1px solid var(--color-page-border)",
         }}
@@ -2503,7 +2513,7 @@ function AgentsConnect({
   return (
     <div class="flex flex-col gap-4">
       <div
-        class="rounded-2xl bg-white p-4 flex items-center gap-4"
+        class="rounded-2xl bg-[var(--color-page-surface)] p-4 flex items-center gap-4"
         style={{ border: "1px solid var(--color-page-border)" }}
       >
         <div class="flex items-center gap-2 shrink-0">
@@ -2529,7 +2539,7 @@ function AgentsConnect({
           <span
             class="inline-flex items-center h-6 px-2 rounded text-[11px] font-medium"
             style={{
-              background: "white",
+              background: "var(--color-page-surface)",
               color: "var(--color-page-text)",
               border: "1px solid var(--color-page-border)",
             }}
@@ -2583,7 +2593,7 @@ const DEFAULT_AGENT_ROWS: AgentRow[] = [
 function AlwaysOnAgentsTable({ rows }: { rows: AgentRow[] }) {
   return (
     <div
-      class="rounded-2xl bg-white overflow-hidden"
+      class="rounded-2xl bg-[var(--color-page-surface)] overflow-hidden"
       style={{ border: "1px solid var(--color-page-border)" }}
     >
       <div

--- a/packages/landing/src/components/HeroSection.tsx
+++ b/packages/landing/src/components/HeroSection.tsx
@@ -131,8 +131,8 @@ export function HeroSection(props: {
             href={props.startUrl}
             class="inline-flex items-center text-[14px] font-medium px-5 h-10 rounded-lg transition-opacity hover:opacity-90"
             style={{
-              background: "#0b0b0d",
-              color: "#ffffff",
+              background: "var(--color-page-bg-inverted)",
+              color: "var(--color-page-text-inverted)",
             }}
           >
             Start for free
@@ -144,7 +144,7 @@ export function HeroSection(props: {
             class="inline-flex items-center gap-2 text-[14px] font-medium px-5 h-10 rounded-lg transition-colors hover:bg-[color:var(--color-page-surface-dim)]"
             style={{
               color: "var(--color-page-text)",
-              background: "#ffffff",
+              background: "var(--color-page-surface)",
               border: "1px solid var(--color-page-border)",
             }}
           >

--- a/packages/landing/src/components/Nav.tsx
+++ b/packages/landing/src/components/Nav.tsx
@@ -138,6 +138,87 @@ function GitHubMark() {
   );
 }
 
+function ThemeToggle() {
+  const [theme, setTheme] = useState<"light" | "dark" | null>(null);
+
+  useEffect(() => {
+    const stored = localStorage.getItem("theme");
+    if (stored === "light" || stored === "dark") {
+      setTheme(stored);
+    } else {
+      setTheme(null); // auto
+    }
+  }, []);
+
+  function cycle() {
+    const current =
+      theme ??
+      (window.matchMedia("(prefers-color-scheme: dark)").matches
+        ? "dark"
+        : "light");
+    const next = current === "light" ? "dark" : "light";
+    document.documentElement.setAttribute("data-theme", next);
+    localStorage.setItem("theme", next);
+    setTheme(next);
+  }
+
+  const isDark =
+    theme === "dark" ||
+    (theme === null &&
+      typeof window !== "undefined" &&
+      window.matchMedia("(prefers-color-scheme: dark)").matches);
+
+  return (
+    <button
+      type="button"
+      onClick={cycle}
+      aria-label={isDark ? "Switch to light mode" : "Switch to dark mode"}
+      class="inline-flex items-center justify-center w-9 h-9 rounded-full transition-colors hover:bg-[color:var(--color-page-surface-dim)]"
+      style={{ color: "var(--color-page-text-muted)" }}
+    >
+      {isDark ? (
+        <svg
+          role="img"
+          aria-hidden="true"
+          width="16"
+          height="16"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+        >
+          <circle cx="12" cy="12" r="5" />
+          <line x1="12" y1="1" x2="12" y2="3" />
+          <line x1="12" y1="21" x2="12" y2="23" />
+          <line x1="4.22" y1="4.22" x2="5.64" y2="5.64" />
+          <line x1="18.36" y1="18.36" x2="19.78" y2="19.78" />
+          <line x1="1" y1="12" x2="3" y2="12" />
+          <line x1="21" y1="12" x2="23" y2="12" />
+          <line x1="4.22" y1="19.78" x2="5.64" y2="18.36" />
+          <line x1="18.36" y1="5.64" x2="19.78" y2="4.22" />
+        </svg>
+      ) : (
+        <svg
+          role="img"
+          aria-hidden="true"
+          width="16"
+          height="16"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+        >
+          <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
+        </svg>
+      )}
+    </button>
+  );
+}
+
 function MegaMenuPanel({
   menu,
   left,
@@ -158,11 +239,12 @@ function MegaMenuPanel({
       onMouseLeave={onMouseLeave}
     >
       <div
-        class="rounded-2xl bg-white p-4 grid gap-x-6 gap-y-2"
+        class="rounded-2xl p-4 grid gap-x-6 gap-y-2"
         style={{
           gridTemplateColumns: `repeat(${menu.columns.length}, minmax(0, 1fr))`,
+          background: "var(--color-page-surface)",
           border: "1px solid var(--color-page-border)",
-          boxShadow: "0 12px 32px rgba(0,0,0,0.08), 0 2px 6px rgba(0,0,0,0.04)",
+          boxShadow: "var(--color-page-shadow-md)",
         }}
       >
         {menu.columns.map((col) => (
@@ -385,10 +467,14 @@ export function Nav({
             >
               Sign in
             </a>
+            <ThemeToggle />
             <a
               href={startUrl}
               class="inline-flex items-center text-[14px] font-medium px-4 h-9 rounded-full transition-opacity hover:opacity-90"
-              style={{ background: "#0b0b0d", color: "#ffffff" }}
+              style={{
+                background: "var(--color-page-bg-inverted)",
+                color: "var(--color-page-text-inverted)",
+              }}
             >
               Start for free
             </a>

--- a/packages/landing/src/components/Nav.tsx
+++ b/packages/landing/src/components/Nav.tsx
@@ -1,10 +1,6 @@
 import { useEffect, useRef, useState } from "preact/hooks";
 import type { LandingUseCaseId } from "../use-case-definitions";
 import {
-  dark as darkTokens,
-  light as lightTokens,
-} from "../styles/theme-tokens";
-import {
   getOwlettoBaseUrl,
   getOwlettoLoginUrl,
   getOwlettoUrl,
@@ -139,98 +135,6 @@ function GitHubMark() {
     >
       <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z" />
     </svg>
-  );
-}
-
-function ThemeToggle() {
-  const [theme, setTheme] = useState<"light" | "dark" | null>(null);
-
-  useEffect(() => {
-    const stored = localStorage.getItem("theme");
-    if (stored === "light" || stored === "dark") {
-      setTheme(stored);
-    } else {
-      setTheme(null); // auto
-    }
-  }, []);
-
-  function applyVars(name: "light" | "dark") {
-    const s = document.documentElement.style;
-    // Import tokens dynamically — the bundler inlines them
-    if (name === "dark") {
-      for (const [k, v] of Object.entries(darkTokens)) s.setProperty(k, v);
-    } else {
-      for (const [k, v] of Object.entries(lightTokens)) s.setProperty(k, v);
-    }
-  }
-
-  function cycle() {
-    const current =
-      theme ??
-      (window.matchMedia("(prefers-color-scheme: dark)").matches
-        ? "dark"
-        : "light");
-    const next = current === "light" ? "dark" : "light";
-    applyVars(next);
-    document.documentElement.setAttribute("data-theme", next);
-    localStorage.setItem("theme", next);
-    setTheme(next);
-  }
-
-  const isDark =
-    theme === "dark" ||
-    (theme === null &&
-      typeof window !== "undefined" &&
-      window.matchMedia("(prefers-color-scheme: dark)").matches);
-
-  return (
-    <button
-      type="button"
-      onClick={cycle}
-      aria-label={isDark ? "Switch to light mode" : "Switch to dark mode"}
-      class="inline-flex items-center justify-center w-9 h-9 rounded-full transition-colors hover:bg-[color:var(--color-page-surface-dim)]"
-      style={{ color: "var(--color-page-text-muted)" }}
-    >
-      {isDark ? (
-        <svg
-          role="img"
-          aria-hidden="true"
-          width="16"
-          height="16"
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="currentColor"
-          stroke-width="2"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-        >
-          <circle cx="12" cy="12" r="5" />
-          <line x1="12" y1="1" x2="12" y2="3" />
-          <line x1="12" y1="21" x2="12" y2="23" />
-          <line x1="4.22" y1="4.22" x2="5.64" y2="5.64" />
-          <line x1="18.36" y1="18.36" x2="19.78" y2="19.78" />
-          <line x1="1" y1="12" x2="3" y2="12" />
-          <line x1="21" y1="12" x2="23" y2="12" />
-          <line x1="4.22" y1="19.78" x2="5.64" y2="18.36" />
-          <line x1="18.36" y1="5.64" x2="19.78" y2="4.22" />
-        </svg>
-      ) : (
-        <svg
-          role="img"
-          aria-hidden="true"
-          width="16"
-          height="16"
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="currentColor"
-          stroke-width="2"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-        >
-          <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
-        </svg>
-      )}
-    </button>
   );
 }
 
@@ -482,7 +386,6 @@ export function Nav({
             >
               Sign in
             </a>
-            <ThemeToggle />
             <a
               href={startUrl}
               class="inline-flex items-center text-[14px] font-medium px-4 h-9 rounded-full transition-opacity hover:opacity-90"

--- a/packages/landing/src/components/Nav.tsx
+++ b/packages/landing/src/components/Nav.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from "preact/hooks";
 import type { LandingUseCaseId } from "../use-case-definitions";
+import { dark as darkTokens, light as lightTokens } from "../styles/theme-tokens";
 import {
   getOwlettoBaseUrl,
   getOwlettoLoginUrl,
@@ -150,6 +151,16 @@ function ThemeToggle() {
     }
   }, []);
 
+  function applyVars(name: "light" | "dark") {
+    const s = document.documentElement.style;
+    // Import tokens dynamically — the bundler inlines them
+    if (name === "dark") {
+      for (const [k, v] of Object.entries(darkTokens)) s.setProperty(k, v);
+    } else {
+      for (const [k, v] of Object.entries(lightTokens)) s.setProperty(k, v);
+    }
+  }
+
   function cycle() {
     const current =
       theme ??
@@ -157,6 +168,7 @@ function ThemeToggle() {
         ? "dark"
         : "light");
     const next = current === "light" ? "dark" : "light";
+    applyVars(next);
     document.documentElement.setAttribute("data-theme", next);
     localStorage.setItem("theme", next);
     setTheme(next);

--- a/packages/landing/src/components/Nav.tsx
+++ b/packages/landing/src/components/Nav.tsx
@@ -1,6 +1,9 @@
 import { useEffect, useRef, useState } from "preact/hooks";
 import type { LandingUseCaseId } from "../use-case-definitions";
-import { dark as darkTokens, light as lightTokens } from "../styles/theme-tokens";
+import {
+  dark as darkTokens,
+  light as lightTokens,
+} from "../styles/theme-tokens";
 import {
   getOwlettoBaseUrl,
   getOwlettoLoginUrl,

--- a/packages/landing/src/components/ServerlessSection.tsx
+++ b/packages/landing/src/components/ServerlessSection.tsx
@@ -75,7 +75,7 @@ export function ServerlessSection() {
           <div
             class="inline-flex p-1 rounded-xl border"
             style={{
-              backgroundColor: "rgba(255, 255, 255, 0.03)",
+              backgroundColor: "var(--color-page-surface-dim)",
               borderColor: "var(--color-page-border)",
             }}
           >

--- a/packages/landing/src/components/starlight/Head.astro
+++ b/packages/landing/src/components/starlight/Head.astro
@@ -2,6 +2,7 @@
 import DefaultHead from "@astrojs/starlight/components/Head.astro";
 import PosthogAnalytics from "../PosthogAnalytics.astro";
 import WebMCP from "../WebMCP.astro";
+import { themeScript } from "../../styles/theme-script";
 
 const markdownPath =
   Astro.url.pathname === "/"
@@ -11,6 +12,7 @@ const markdownURL = new URL(markdownPath, Astro.site);
 ---
 
 <DefaultHead />
+<script is:inline set:html={themeScript(Astro)} />
 <PosthogAnalytics />
 <WebMCP />
 

--- a/packages/landing/src/globals.css
+++ b/packages/landing/src/globals.css
@@ -6,12 +6,19 @@
 /*
  * Theme tokens
  *
- * Tailwind's @theme block requires static values, so we define the light
- * palette here. Dark mode overrides live in the :root[data-theme="dark"]
- * and @media (prefers-color-scheme: dark) blocks below — they simply
- * reassign the same custom properties.
+ * Only structural/design tokens go in @theme (fonts, spacing, radii).
+ * Color tokens are defined as plain :root custom properties so our dark-mode
+ * overrides (below) can win over the cascade without fighting @layer theme.
  */
 @theme {
+  --font-sans: "Inter", "Inter Fallback", system-ui, -apple-system, sans-serif;
+  --font-display:
+    "Inter Tight", "Inter", "Inter Fallback", system-ui, -apple-system,
+    sans-serif;
+}
+
+/* ─── Light (default) tokens ─── */
+:root {
   --color-page-bg: #ffffff;
   --color-page-bg-elevated: #fafafa;
   --color-page-bg-overlay: rgba(255, 255, 255, 0.85);
@@ -32,17 +39,6 @@
   --color-tg-text: white;
   --color-tg-meta: rgba(255, 255, 255, 0.533);
 
-  --font-sans: "Inter", "Inter Fallback", system-ui, -apple-system, sans-serif;
-  --font-display:
-    "Inter Tight", "Inter", "Inter Fallback", system-ui, -apple-system,
-    sans-serif;
-}
-
-/*
- * Additional semantic tokens not in @theme (used as raw CSS vars in
- * inline styles). These are overridden by dark-mode rules below.
- */
-:root {
   --color-page-bg-inverted: #0b0b0d;
   --color-page-text-inverted: #ffffff;
   --color-page-dotted: rgba(0, 0, 0, 0.08);
@@ -64,7 +60,6 @@
   --color-page-dialog-close-hover: rgba(0, 0, 0, 0.7);
   --color-page-meta-theme: #ffffff;
 
-  /* Persisted theme preference ("light" | "dark" | null = auto) */
   color-scheme: light;
 }
 

--- a/packages/landing/src/globals.css
+++ b/packages/landing/src/globals.css
@@ -4,21 +4,17 @@
 @source "../../gateway/src/routes/public/settings-page/**/*.tsx";
 
 /*
- * Theme tokens
- *
- * Only structural/design tokens go in @theme (fonts, spacing, radii).
- * Color tokens are defined as plain :root custom properties so our dark-mode
- * overrides (below) can win over the cascade without fighting @layer theme.
+ * Color tokens are registered in @theme so Tailwind can resolve arbitrary-value
+ * classes like bg-[var(--color-page-surface)].  The *runtime* values are set
+ * by the inline theme script in BaseLayout.astro, which writes directly to
+ * element.style — winning over every CSS rule including @layer theme.
  */
 @theme {
   --font-sans: "Inter", "Inter Fallback", system-ui, -apple-system, sans-serif;
   --font-display:
     "Inter Tight", "Inter", "Inter Fallback", system-ui, -apple-system,
     sans-serif;
-}
 
-/* ─── Light (default) tokens ─── */
-:root {
   --color-page-bg: #ffffff;
   --color-page-bg-elevated: #fafafa;
   --color-page-bg-overlay: rgba(255, 255, 255, 0.85);
@@ -38,111 +34,6 @@
   --color-tg-border: rgb(48, 48, 48);
   --color-tg-text: white;
   --color-tg-meta: rgba(255, 255, 255, 0.533);
-
-  --color-page-bg-inverted: #0b0b0d;
-  --color-page-text-inverted: #ffffff;
-  --color-page-dotted: rgba(0, 0, 0, 0.08);
-  --color-page-grid: rgba(0, 0, 0, 0.06);
-  --color-page-divider-mark: rgba(0, 0, 0, 0.18);
-  --color-page-overlay-backdrop: rgba(0, 0, 0, 0.7);
-  --color-page-code-bg: rgba(0, 0, 0, 0.04);
-  --color-page-code-border: rgba(0, 0, 0, 0.08);
-  --color-page-pre-bg-from: rgba(20, 20, 24, 0.98);
-  --color-page-pre-bg-to: rgba(12, 12, 16, 0.98);
-  --color-page-pre-border: rgba(255, 255, 255, 0.09);
-  --color-page-prose-text: rgba(11, 11, 13, 0.82);
-  --color-page-prose-blockquote: rgba(11, 11, 13, 0.7);
-  --color-page-hex-stroke: rgba(0, 0, 0, 0.18);
-  --color-page-hex-line: rgba(0, 0, 0, 0.08);
-  --color-page-shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.05);
-  --color-page-shadow-md: 0 12px 32px rgba(0, 0, 0, 0.08), 0 2px 6px rgba(0, 0, 0, 0.04);
-  --color-page-dialog-close-bg: rgba(0, 0, 0, 0.5);
-  --color-page-dialog-close-hover: rgba(0, 0, 0, 0.7);
-  --color-page-meta-theme: #ffffff;
-
-  color-scheme: light;
-}
-
-/* ─── Dark mode overrides ─── */
-/* Applied when: user explicitly toggled dark, or OS prefers dark (and no explicit choice). */
-:root[data-theme="dark"] {
-  color-scheme: dark;
-  --color-page-bg: #0a0a0b;
-  --color-page-bg-elevated: #111113;
-  --color-page-bg-overlay: rgba(10, 10, 11, 0.85);
-  --color-page-surface: #161618;
-  --color-page-surface-dim: #1c1c1f;
-  --color-page-border: rgba(255, 255, 255, 0.08);
-  --color-page-border-active: rgba(255, 255, 255, 0.16);
-  --color-page-text: #f0f0f2;
-  --color-page-text-muted: #9ca3af;
-
-  --color-tg-bg: rgb(22, 22, 24);
-  --color-tg-bg-secondary: rgb(10, 10, 11);
-  --color-tg-bubble-in: rgb(22, 22, 24);
-  --color-tg-border: rgb(48, 48, 48);
-
-  --color-page-bg-inverted: #f0f0f2;
-  --color-page-text-inverted: #0a0a0b;
-  --color-page-dotted: rgba(255, 255, 255, 0.06);
-  --color-page-grid: rgba(255, 255, 255, 0.04);
-  --color-page-divider-mark: rgba(255, 255, 255, 0.14);
-  --color-page-overlay-backdrop: rgba(0, 0, 0, 0.8);
-  --color-page-code-bg: rgba(255, 255, 255, 0.06);
-  --color-page-code-border: rgba(255, 255, 255, 0.08);
-  --color-page-pre-bg-from: rgba(20, 20, 24, 0.98);
-  --color-page-pre-bg-to: rgba(12, 12, 16, 0.98);
-  --color-page-pre-border: rgba(255, 255, 255, 0.09);
-  --color-page-prose-text: rgba(240, 240, 242, 0.82);
-  --color-page-prose-blockquote: rgba(240, 240, 242, 0.7);
-  --color-page-hex-stroke: rgba(255, 255, 255, 0.14);
-  --color-page-hex-line: rgba(255, 255, 255, 0.06);
-  --color-page-shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.3);
-  --color-page-shadow-md: 0 12px 32px rgba(0, 0, 0, 0.4), 0 2px 6px rgba(0, 0, 0, 0.2);
-  --color-page-dialog-close-bg: rgba(255, 255, 255, 0.15);
-  --color-page-dialog-close-hover: rgba(255, 255, 255, 0.25);
-  --color-page-meta-theme: #0a0a0b;
-}
-
-@media (prefers-color-scheme: dark) {
-  :root:not([data-theme="light"]) {
-    color-scheme: dark;
-    --color-page-bg: #0a0a0b;
-    --color-page-bg-elevated: #111113;
-    --color-page-bg-overlay: rgba(10, 10, 11, 0.85);
-    --color-page-surface: #161618;
-    --color-page-surface-dim: #1c1c1f;
-    --color-page-border: rgba(255, 255, 255, 0.08);
-    --color-page-border-active: rgba(255, 255, 255, 0.16);
-    --color-page-text: #f0f0f2;
-    --color-page-text-muted: #9ca3af;
-
-    --color-tg-bg: rgb(22, 22, 24);
-    --color-tg-bg-secondary: rgb(10, 10, 11);
-    --color-tg-bubble-in: rgb(22, 22, 24);
-    --color-tg-border: rgb(48, 48, 48);
-
-    --color-page-bg-inverted: #f0f0f2;
-    --color-page-text-inverted: #0a0a0b;
-    --color-page-dotted: rgba(255, 255, 255, 0.06);
-    --color-page-grid: rgba(255, 255, 255, 0.04);
-    --color-page-divider-mark: rgba(255, 255, 255, 0.14);
-    --color-page-overlay-backdrop: rgba(0, 0, 0, 0.8);
-    --color-page-code-bg: rgba(255, 255, 255, 0.06);
-    --color-page-code-border: rgba(255, 255, 255, 0.08);
-    --color-page-pre-bg-from: rgba(20, 20, 24, 0.98);
-    --color-page-pre-bg-to: rgba(12, 12, 16, 0.98);
-    --color-page-pre-border: rgba(255, 255, 255, 0.09);
-    --color-page-prose-text: rgba(240, 240, 242, 0.82);
-    --color-page-prose-blockquote: rgba(240, 240, 242, 0.7);
-    --color-page-hex-stroke: rgba(255, 255, 255, 0.14);
-    --color-page-hex-line: rgba(255, 255, 255, 0.06);
-    --color-page-shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.3);
-    --color-page-shadow-md: 0 12px 32px rgba(0, 0, 0, 0.4), 0 2px 6px rgba(0, 0, 0, 0.2);
-    --color-page-dialog-close-bg: rgba(255, 255, 255, 0.15);
-    --color-page-dialog-close-hover: rgba(255, 255, 255, 0.25);
-    --color-page-meta-theme: #0a0a0b;
-  }
 }
 
 button {

--- a/packages/landing/src/globals.css
+++ b/packages/landing/src/globals.css
@@ -3,6 +3,14 @@
 /* Scan gateway settings components so their Tailwind classes are generated */
 @source "../../gateway/src/routes/public/settings-page/**/*.tsx";
 
+/*
+ * Theme tokens
+ *
+ * Tailwind's @theme block requires static values, so we define the light
+ * palette here. Dark mode overrides live in the :root[data-theme="dark"]
+ * and @media (prefers-color-scheme: dark) blocks below — they simply
+ * reassign the same custom properties.
+ */
 @theme {
   --color-page-bg: #ffffff;
   --color-page-bg-elevated: #fafafa;
@@ -28,6 +36,118 @@
   --font-display:
     "Inter Tight", "Inter", "Inter Fallback", system-ui, -apple-system,
     sans-serif;
+}
+
+/*
+ * Additional semantic tokens not in @theme (used as raw CSS vars in
+ * inline styles). These are overridden by dark-mode rules below.
+ */
+:root {
+  --color-page-bg-inverted: #0b0b0d;
+  --color-page-text-inverted: #ffffff;
+  --color-page-dotted: rgba(0, 0, 0, 0.08);
+  --color-page-grid: rgba(0, 0, 0, 0.06);
+  --color-page-divider-mark: rgba(0, 0, 0, 0.18);
+  --color-page-overlay-backdrop: rgba(0, 0, 0, 0.7);
+  --color-page-code-bg: rgba(0, 0, 0, 0.04);
+  --color-page-code-border: rgba(0, 0, 0, 0.08);
+  --color-page-pre-bg-from: rgba(20, 20, 24, 0.98);
+  --color-page-pre-bg-to: rgba(12, 12, 16, 0.98);
+  --color-page-pre-border: rgba(255, 255, 255, 0.09);
+  --color-page-prose-text: rgba(11, 11, 13, 0.82);
+  --color-page-prose-blockquote: rgba(11, 11, 13, 0.7);
+  --color-page-hex-stroke: rgba(0, 0, 0, 0.18);
+  --color-page-hex-line: rgba(0, 0, 0, 0.08);
+  --color-page-shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.05);
+  --color-page-shadow-md: 0 12px 32px rgba(0, 0, 0, 0.08), 0 2px 6px rgba(0, 0, 0, 0.04);
+  --color-page-dialog-close-bg: rgba(0, 0, 0, 0.5);
+  --color-page-dialog-close-hover: rgba(0, 0, 0, 0.7);
+  --color-page-meta-theme: #ffffff;
+
+  /* Persisted theme preference ("light" | "dark" | null = auto) */
+  color-scheme: light;
+}
+
+/* ─── Dark mode overrides ─── */
+/* Applied when: user explicitly toggled dark, or OS prefers dark (and no explicit choice). */
+:root[data-theme="dark"] {
+  color-scheme: dark;
+  --color-page-bg: #0a0a0b;
+  --color-page-bg-elevated: #111113;
+  --color-page-bg-overlay: rgba(10, 10, 11, 0.85);
+  --color-page-surface: #161618;
+  --color-page-surface-dim: #1c1c1f;
+  --color-page-border: rgba(255, 255, 255, 0.08);
+  --color-page-border-active: rgba(255, 255, 255, 0.16);
+  --color-page-text: #f0f0f2;
+  --color-page-text-muted: #9ca3af;
+
+  --color-tg-bg: rgb(22, 22, 24);
+  --color-tg-bg-secondary: rgb(10, 10, 11);
+  --color-tg-bubble-in: rgb(22, 22, 24);
+  --color-tg-border: rgb(48, 48, 48);
+
+  --color-page-bg-inverted: #f0f0f2;
+  --color-page-text-inverted: #0a0a0b;
+  --color-page-dotted: rgba(255, 255, 255, 0.06);
+  --color-page-grid: rgba(255, 255, 255, 0.04);
+  --color-page-divider-mark: rgba(255, 255, 255, 0.14);
+  --color-page-overlay-backdrop: rgba(0, 0, 0, 0.8);
+  --color-page-code-bg: rgba(255, 255, 255, 0.06);
+  --color-page-code-border: rgba(255, 255, 255, 0.08);
+  --color-page-pre-bg-from: rgba(20, 20, 24, 0.98);
+  --color-page-pre-bg-to: rgba(12, 12, 16, 0.98);
+  --color-page-pre-border: rgba(255, 255, 255, 0.09);
+  --color-page-prose-text: rgba(240, 240, 242, 0.82);
+  --color-page-prose-blockquote: rgba(240, 240, 242, 0.7);
+  --color-page-hex-stroke: rgba(255, 255, 255, 0.14);
+  --color-page-hex-line: rgba(255, 255, 255, 0.06);
+  --color-page-shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.3);
+  --color-page-shadow-md: 0 12px 32px rgba(0, 0, 0, 0.4), 0 2px 6px rgba(0, 0, 0, 0.2);
+  --color-page-dialog-close-bg: rgba(255, 255, 255, 0.15);
+  --color-page-dialog-close-hover: rgba(255, 255, 255, 0.25);
+  --color-page-meta-theme: #0a0a0b;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme="light"]) {
+    color-scheme: dark;
+    --color-page-bg: #0a0a0b;
+    --color-page-bg-elevated: #111113;
+    --color-page-bg-overlay: rgba(10, 10, 11, 0.85);
+    --color-page-surface: #161618;
+    --color-page-surface-dim: #1c1c1f;
+    --color-page-border: rgba(255, 255, 255, 0.08);
+    --color-page-border-active: rgba(255, 255, 255, 0.16);
+    --color-page-text: #f0f0f2;
+    --color-page-text-muted: #9ca3af;
+
+    --color-tg-bg: rgb(22, 22, 24);
+    --color-tg-bg-secondary: rgb(10, 10, 11);
+    --color-tg-bubble-in: rgb(22, 22, 24);
+    --color-tg-border: rgb(48, 48, 48);
+
+    --color-page-bg-inverted: #f0f0f2;
+    --color-page-text-inverted: #0a0a0b;
+    --color-page-dotted: rgba(255, 255, 255, 0.06);
+    --color-page-grid: rgba(255, 255, 255, 0.04);
+    --color-page-divider-mark: rgba(255, 255, 255, 0.14);
+    --color-page-overlay-backdrop: rgba(0, 0, 0, 0.8);
+    --color-page-code-bg: rgba(255, 255, 255, 0.06);
+    --color-page-code-border: rgba(255, 255, 255, 0.08);
+    --color-page-pre-bg-from: rgba(20, 20, 24, 0.98);
+    --color-page-pre-bg-to: rgba(12, 12, 16, 0.98);
+    --color-page-pre-border: rgba(255, 255, 255, 0.09);
+    --color-page-prose-text: rgba(240, 240, 242, 0.82);
+    --color-page-prose-blockquote: rgba(240, 240, 242, 0.7);
+    --color-page-hex-stroke: rgba(255, 255, 255, 0.14);
+    --color-page-hex-line: rgba(255, 255, 255, 0.06);
+    --color-page-shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.3);
+    --color-page-shadow-md: 0 12px 32px rgba(0, 0, 0, 0.4), 0 2px 6px rgba(0, 0, 0, 0.2);
+    --color-page-dialog-close-bg: rgba(255, 255, 255, 0.15);
+    --color-page-dialog-close-hover: rgba(255, 255, 255, 0.25);
+    --color-page-meta-theme: #0a0a0b;
+  }
 }
 
 button {
@@ -58,7 +178,7 @@ h3,
 
 /* Vercel-style edge lines */
 .grid-lines {
-  --grid-color: rgba(0, 0, 0, 0.06);
+  --grid-color: var(--color-page-grid);
   --grid-max-w: 64rem;
   position: relative;
 }
@@ -95,7 +215,7 @@ h3,
   font-size: 13px;
   font-weight: 300;
   line-height: 1;
-  color: rgba(0, 0, 0, 0.18);
+  color: var(--color-page-divider-mark);
 }
 
 .section-divider::before {
@@ -137,7 +257,7 @@ h3,
 /* Dotted background used in attio's feature panels */
 .dotted-bg {
   background-image: radial-gradient(
-    rgba(0, 0, 0, 0.08) 1px,
+    var(--color-page-dotted) 1px,
     transparent 1px
   );
   background-size: 14px 14px;
@@ -174,7 +294,7 @@ button.chat-action-btn:hover {
 }
 
 .schedule-dialog::backdrop {
-  background: rgba(0, 0, 0, 0.7);
+  background: var(--color-page-overlay-backdrop);
   backdrop-filter: blur(4px);
 }
 
@@ -182,7 +302,7 @@ button.chat-action-btn:hover {
   position: relative;
   border-radius: 16px;
   overflow: hidden;
-  background: #fff;
+  background: var(--color-page-surface);
 }
 
 .schedule-dialog-close {
@@ -193,8 +313,8 @@ button.chat-action-btn:hover {
   width: 32px;
   height: 32px;
   border: none;
-  background: rgba(0, 0, 0, 0.5);
-  color: #fff;
+  background: var(--color-page-dialog-close-bg);
+  color: var(--color-page-text-inverted);
   font-size: 20px;
   line-height: 1;
   border-radius: 50%;
@@ -205,7 +325,7 @@ button.chat-action-btn:hover {
 }
 
 .schedule-dialog-close:hover {
-  background: rgba(0, 0, 0, 0.7);
+  background: var(--color-page-dialog-close-hover);
 }
 
 .schedule-dialog-iframe {
@@ -239,7 +359,7 @@ button.chat-action-btn:hover {
 .blog-prose li,
 .blog-prose td,
 .blog-prose blockquote {
-  color: rgba(11, 11, 13, 0.82);
+  color: var(--color-page-prose-text);
 }
 
 .blog-prose h2,
@@ -298,7 +418,7 @@ button.chat-action-btn:hover {
 .blog-prose blockquote {
   border-left: 3px solid rgba(194, 65, 12, 0.45);
   padding: 0.125rem 0 0.125rem 1rem;
-  color: rgba(11, 11, 13, 0.7);
+  color: var(--color-page-prose-blockquote);
 }
 
 .blog-prose code {
@@ -306,8 +426,8 @@ button.chat-action-btn:hover {
     "SFMono-Regular", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
     "Liberation Mono", "Courier New", monospace;
   font-size: 0.92em;
-  background: rgba(0, 0, 0, 0.04);
-  border: 1px solid rgba(0, 0, 0, 0.08);
+  background: var(--color-page-code-bg);
+  border: 1px solid var(--color-page-code-border);
   border-radius: 0.4rem;
   padding: 0.15rem 0.35rem;
 }
@@ -316,8 +436,8 @@ button.chat-action-btn:hover {
   position: relative;
   overflow-x: auto;
   border-radius: 0.9rem;
-  border: 1px solid rgba(255, 255, 255, 0.09);
-  background: linear-gradient(180deg, rgba(20, 20, 24, 0.98), rgba(12, 12, 16, 0.98));
+  border: 1px solid var(--color-page-pre-border);
+  background: linear-gradient(180deg, var(--color-page-pre-bg-from), var(--color-page-pre-bg-to));
   padding: 1rem 1.1rem;
 }
 
@@ -340,7 +460,7 @@ button.chat-action-btn:hover {
 .blog-prose td {
   text-align: left;
   padding: 0.85rem 1rem;
-  border-bottom: 1px solid rgba(0, 0, 0, 0.08);
+  border-bottom: 1px solid var(--color-page-border);
   vertical-align: top;
 }
 
@@ -355,7 +475,7 @@ button.chat-action-btn:hover {
 
 .blog-prose hr {
   border: 0;
-  border-top: 1px solid rgba(0, 0, 0, 0.08);
+  border-top: 1px solid var(--color-page-border);
   margin: 2.5rem 0;
 }
 

--- a/packages/landing/src/layouts/BaseLayout.astro
+++ b/packages/landing/src/layouts/BaseLayout.astro
@@ -42,7 +42,17 @@ const hasMarkdownTwin = existsSync(markdownFileURL);
     <link rel="canonical" href={canonicalURL} />
     <link rel="icon" href="/favicon.ico" />
     <link rel="icon" type="image/png" href="/lobster-icon.png" />
-    <meta name="theme-color" content="#ffffff" />
+    <meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+    <meta name="theme-color" content="#0a0a0b" media="(prefers-color-scheme: dark)" />
+    <!-- Apply persisted theme before paint to prevent flash -->
+    <script is:inline>
+      (function() {
+        var t = localStorage.getItem('theme');
+        if (t === 'dark' || t === 'light') {
+          document.documentElement.setAttribute('data-theme', t);
+        }
+      })();
+    </script>
 
     <!-- Open Graph -->
     <meta property="og:type" content={ogType} />

--- a/packages/landing/src/layouts/BaseLayout.astro
+++ b/packages/landing/src/layouts/BaseLayout.astro
@@ -20,6 +20,7 @@ const {
 import { existsSync } from "node:fs";
 import PosthogAnalytics from "../components/PosthogAnalytics.astro";
 import WebMCP from "../components/WebMCP.astro";
+import { themeScript } from "../styles/theme-script";
 
 const canonicalURL = new URL(Astro.url.pathname, Astro.site);
 const ogImage = new URL("/lobster-icon.png", Astro.site);
@@ -44,15 +45,6 @@ const hasMarkdownTwin = existsSync(markdownFileURL);
     <link rel="icon" type="image/png" href="/lobster-icon.png" />
     <meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
     <meta name="theme-color" content="#0a0a0b" media="(prefers-color-scheme: dark)" />
-    <!-- Apply persisted theme before paint to prevent flash -->
-    <script is:inline>
-      (function() {
-        var t = localStorage.getItem('theme');
-        if (t === 'dark' || t === 'light') {
-          document.documentElement.setAttribute('data-theme', t);
-        }
-      })();
-    </script>
 
     <!-- Open Graph -->
     <meta property="og:type" content={ogType} />
@@ -110,6 +102,8 @@ const hasMarkdownTwin = existsSync(markdownFileURL);
     <link rel="api-catalog" href="/.well-known/api-catalog" />
   </head>
   <body>
+    <!-- Apply theme tokens via inline styles to defeat Tailwind v4 @layer cascade -->
+    <script is:inline set:html={themeScript(Astro)} />
     <slot />
   </body>
 </html>

--- a/packages/landing/src/styles/starlight-shared.css
+++ b/packages/landing/src/styles/starlight-shared.css
@@ -7,6 +7,14 @@
 
 /* Import the same theme tokens as globals.css */
 @theme {
+  --font-sans: "Inter", "Inter Fallback", system-ui, -apple-system, sans-serif;
+  --font-display:
+    "Inter Tight", "Inter", "Inter Fallback", system-ui, -apple-system,
+    sans-serif;
+}
+
+/* Color tokens defined as plain :root custom properties */
+:root {
   --color-page-bg: #ffffff;
   --color-page-bg-elevated: #fafafa;
   --color-page-bg-overlay: rgba(255, 255, 255, 0.85);

--- a/packages/landing/src/styles/starlight-shared.css
+++ b/packages/landing/src/styles/starlight-shared.css
@@ -28,6 +28,43 @@
   --color-tg-meta: rgba(255, 255, 255, 0.533);
 }
 
+/* Dark mode tokens for Starlight pages */
+:root[data-theme="dark"] {
+  --color-page-bg: #0a0a0b;
+  --color-page-bg-elevated: #111113;
+  --color-page-bg-overlay: rgba(10, 10, 11, 0.85);
+  --color-page-surface: #161618;
+  --color-page-surface-dim: #1c1c1f;
+  --color-page-border: rgba(255, 255, 255, 0.08);
+  --color-page-border-active: rgba(255, 255, 255, 0.16);
+  --color-page-text: #f0f0f2;
+  --color-page-text-muted: #9ca3af;
+
+  --color-tg-bg: rgb(22, 22, 24);
+  --color-tg-bg-secondary: rgb(10, 10, 11);
+  --color-tg-bubble-in: rgb(22, 22, 24);
+  --color-tg-border: rgb(48, 48, 48);
+}
+
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme="light"]) {
+    --color-page-bg: #0a0a0b;
+    --color-page-bg-elevated: #111113;
+    --color-page-bg-overlay: rgba(10, 10, 11, 0.85);
+    --color-page-surface: #161618;
+    --color-page-surface-dim: #1c1c1f;
+    --color-page-border: rgba(255, 255, 255, 0.08);
+    --color-page-border-active: rgba(255, 255, 255, 0.16);
+    --color-page-text: #f0f0f2;
+    --color-page-text-muted: #9ca3af;
+
+    --color-tg-bg: rgb(22, 22, 24);
+    --color-tg-bg-secondary: rgb(10, 10, 11);
+    --color-tg-bubble-in: rgb(22, 22, 24);
+    --color-tg-border: rgb(48, 48, 48);
+  }
+}
+
 /* Prevent Tailwind's preflight from resetting Starlight's list styles */
 @layer base {
   .sl-markdown-content ul {

--- a/packages/landing/src/styles/starlight-theme.css
+++ b/packages/landing/src/styles/starlight-theme.css
@@ -25,30 +25,53 @@
     ui-monospace, SFMono-Regular, Consolas, "Liberation Mono", Menlo, monospace;
 }
 
-/* Force-light: Starlight ships a `[data-theme=dark]` block that overrides the
-   :root tokens above. Mirror our light values onto it so the docs always
-   render light regardless of the user's OS preference. */
+/* Dark mode overrides for Starlight docs */
 :root[data-theme="dark"] {
-  --sl-color-bg: #ffffff;
-  --sl-color-bg-nav: #ffffff;
-  --sl-color-bg-sidebar: #fafafa;
-  --sl-color-hairline: rgba(0, 0, 0, 0.08);
-  --sl-color-hairline-light: rgba(0, 0, 0, 0.05);
-  --sl-color-text: #0b0b0d;
-  --sl-color-text-accent: #b45309;
-  --sl-color-text-invert: #ffffff;
-  --sl-color-white: #0b0b0d;
-  --sl-color-gray-1: #1f2937;
-  --sl-color-gray-2: #374151;
+  --sl-color-bg: #0a0a0b;
+  --sl-color-bg-nav: #0a0a0b;
+  --sl-color-bg-sidebar: #111113;
+  --sl-color-hairline: rgba(255, 255, 255, 0.08);
+  --sl-color-hairline-light: rgba(255, 255, 255, 0.05);
+  --sl-color-text: #f0f0f2;
+  --sl-color-text-accent: #f59e0b;
+  --sl-color-text-invert: #0a0a0b;
+  --sl-color-white: #f0f0f2;
+  --sl-color-gray-1: #d1d5db;
+  --sl-color-gray-2: #9ca3af;
   --sl-color-gray-3: #6b7280;
-  --sl-color-gray-4: rgba(0, 0, 0, 0.08);
-  --sl-color-gray-5: #f5f5f7;
-  --sl-color-gray-6: #fafafa;
-  --sl-color-gray-7: #f5f5f7;
-  --sl-color-black: #ffffff;
-  --sl-color-accent-low: rgba(194, 65, 12, 0.12);
-  --sl-color-accent: #c2410c;
-  --sl-color-accent-high: #9a3412;
+  --sl-color-gray-4: rgba(255, 255, 255, 0.08);
+  --sl-color-gray-5: #1c1c1f;
+  --sl-color-gray-6: #111113;
+  --sl-color-gray-7: #1c1c1f;
+  --sl-color-black: #0a0a0b;
+  --sl-color-accent-low: rgba(194, 65, 12, 0.18);
+  --sl-color-accent: #ea580c;
+  --sl-color-accent-high: #fb923c;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme="light"]) {
+    --sl-color-bg: #0a0a0b;
+    --sl-color-bg-nav: #0a0a0b;
+    --sl-color-bg-sidebar: #111113;
+    --sl-color-hairline: rgba(255, 255, 255, 0.08);
+    --sl-color-hairline-light: rgba(255, 255, 255, 0.05);
+    --sl-color-text: #f0f0f2;
+    --sl-color-text-accent: #f59e0b;
+    --sl-color-text-invert: #0a0a0b;
+    --sl-color-white: #f0f0f2;
+    --sl-color-gray-1: #d1d5db;
+    --sl-color-gray-2: #9ca3af;
+    --sl-color-gray-3: #6b7280;
+    --sl-color-gray-4: rgba(255, 255, 255, 0.08);
+    --sl-color-gray-5: #1c1c1f;
+    --sl-color-gray-6: #111113;
+    --sl-color-gray-7: #1c1c1f;
+    --sl-color-black: #0a0a0b;
+    --sl-color-accent-low: rgba(194, 65, 12, 0.18);
+    --sl-color-accent: #ea580c;
+    --sl-color-accent-high: #fb923c;
+  }
 }
 
 /* Hide right TOC panel; keep Starlight header/sidebar */

--- a/packages/landing/src/styles/theme-script.ts
+++ b/packages/landing/src/styles/theme-script.ts
@@ -1,0 +1,22 @@
+import type { AstroGlobal } from "astro";
+import { dark, light } from "../styles/theme-tokens";
+
+function varsToJs(vars: Record<string, string>) {
+  return Object.entries(vars)
+    .map(([k, v]) => `s.setProperty("${k}","${v.replace(/"/g, '\\"')}");`)
+    .join("");
+}
+
+/**
+ * Returns a `<script is:inline>` string that:
+ *  1. Reads `localStorage.theme` (explicit toggle) or `prefers-color-scheme`
+ *  2. Applies the matching palette via inline `style` on `<html>`
+ *  3. Runs before paint so there's no FOUC
+ *
+ * Inline styles on the element win over every CSS rule (layers, !important
+ * in @theme, etc.), which is exactly what we need to defeat Tailwind v4's
+ * @layer theme hoisting of custom properties.
+ */
+export function themeScript(_astro: AstroGlobal) {
+  return `(function(){var s=document.documentElement.style;var L=function(){${varsToJs(light)}};var D=function(){${varsToJs(dark)}};var t=localStorage.getItem("theme");if(t==="dark"){D()}else if(t==="light"){L()}else if(window.matchMedia("(prefers-color-scheme:dark)").matches){D()}else{L()}})();`;
+}

--- a/packages/landing/src/styles/theme-script.ts
+++ b/packages/landing/src/styles/theme-script.ts
@@ -12,10 +12,10 @@ function varsToJs(vars: Record<string, string>) {
  *  1. Checks `location.hash` for `#theme=dark` or `#theme=light` (testing override)
  *  2. Falls back to `prefers-color-scheme` media query (OS preference)
  *  3. Applies the matching palette via inline `style` on `<html>`
- *  4. Sets `data-theme` attribute for CSS selectors (Starlight docs, etc.)
- *  5. Queues `dark-mode`/`light-mode` class on `<body>` for Scalar API Reference
+ *  4. Sets `data-theme` attribute + `starlight-theme` localStorage so Starlight stays in sync
+ *  5. Adds `dark-mode`/`light-mode` class on `<body>` for Scalar API Reference
  *  6. Runs before paint so there's no FOUC
  */
 export function themeScript(_astro: AstroGlobal) {
-  return `(function(){var e=document.documentElement;var s=e.style;var n;var L=function(){n="light";${varsToJs(light)};e.setAttribute("data-theme","light")};var D=function(){n="dark";${varsToJs(dark)};e.setAttribute("data-theme","dark")};var h=location.hash.match(/[#&]theme=(dark|light)\\b/);if(h){if(h[1]==="dark"){D()}else{L()}}else if(window.matchMedia("(prefers-color-scheme:dark)").matches){D()}else{L()}var b=document.body;if(b){b.classList.add(n+"-mode");b.classList.remove(n==="dark"?"light-mode":"dark-mode")}else{document.addEventListener("DOMContentLoaded",function(){document.body.classList.add(n+"-mode");document.body.classList.remove(n==="dark"?"light-mode":"dark-mode")})}})();`;
+  return `(function(){var e=document.documentElement;var s=e.style;var n;var apply=function(){e.setAttribute("data-theme",n);try{localStorage.setItem("starlight-theme",n)}catch(x){}var b=document.body;if(b){b.classList.add(n+"-mode");b.classList.remove(n==="dark"?"light-mode":"dark-mode")}else{document.addEventListener("DOMContentLoaded",function(){document.body.classList.add(n+"-mode");document.body.classList.remove(n==="dark"?"light-mode":"dark-mode")})}};var L=function(){n="light";${varsToJs(light)};apply()};var D=function(){n="dark";${varsToJs(dark)};apply()};var h=location.hash.match(/[#&]theme=(dark|light)\\b/);if(h){if(h[1]==="dark"){D()}else{L()}}else if(window.matchMedia("(prefers-color-scheme:dark)").matches){D()}else{L()}})();`;
 }

--- a/packages/landing/src/styles/theme-script.ts
+++ b/packages/landing/src/styles/theme-script.ts
@@ -12,12 +12,10 @@ function varsToJs(vars: Record<string, string>) {
  *  1. Checks `location.hash` for `#theme=dark` or `#theme=light` (testing override)
  *  2. Falls back to `prefers-color-scheme` media query (OS preference)
  *  3. Applies the matching palette via inline `style` on `<html>`
- *  4. Runs before paint so there's no FOUC
- *
- * Inline styles on the element win over every CSS rule (layers, !important
- * in @theme, etc.), which is exactly what we need to defeat Tailwind v4's
- * @layer theme hoisting of custom properties.
+ *  4. Sets `data-theme` attribute for CSS selectors (Starlight docs, etc.)
+ *  5. Queues `dark-mode`/`light-mode` class on `<body>` for Scalar API Reference
+ *  6. Runs before paint so there's no FOUC
  */
 export function themeScript(_astro: AstroGlobal) {
-  return `(function(){var s=document.documentElement.style;var L=function(){${varsToJs(light)}};var D=function(){${varsToJs(dark)}};var h=location.hash.match(/[#&]theme=(dark|light)\\b/);if(h){if(h[1]==="dark"){D()}else{L()}}else if(window.matchMedia("(prefers-color-scheme:dark)").matches){D()}else{L()}})();`;
+  return `(function(){var e=document.documentElement;var s=e.style;var n;var L=function(){n="light";${varsToJs(light)};e.setAttribute("data-theme","light")};var D=function(){n="dark";${varsToJs(dark)};e.setAttribute("data-theme","dark")};var h=location.hash.match(/[#&]theme=(dark|light)\\b/);if(h){if(h[1]==="dark"){D()}else{L()}}else if(window.matchMedia("(prefers-color-scheme:dark)").matches){D()}else{L()}var b=document.body;if(b){b.classList.add(n+"-mode");b.classList.remove(n==="dark"?"light-mode":"dark-mode")}else{document.addEventListener("DOMContentLoaded",function(){document.body.classList.add(n+"-mode");document.body.classList.remove(n==="dark"?"light-mode":"dark-mode")})}})();`;
 }

--- a/packages/landing/src/styles/theme-script.ts
+++ b/packages/landing/src/styles/theme-script.ts
@@ -8,15 +8,16 @@ function varsToJs(vars: Record<string, string>) {
 }
 
 /**
- * Returns a `<script is:inline>` string that:
- *  1. Reads `localStorage.theme` (explicit toggle) or `prefers-color-scheme`
- *  2. Applies the matching palette via inline `style` on `<html>`
- *  3. Runs before paint so there's no FOUC
+ * Returns a `<script is:inline>` body that:
+ *  1. Checks `location.hash` for `#theme=dark` or `#theme=light` (testing override)
+ *  2. Falls back to `prefers-color-scheme` media query (OS preference)
+ *  3. Applies the matching palette via inline `style` on `<html>`
+ *  4. Runs before paint so there's no FOUC
  *
  * Inline styles on the element win over every CSS rule (layers, !important
  * in @theme, etc.), which is exactly what we need to defeat Tailwind v4's
  * @layer theme hoisting of custom properties.
  */
 export function themeScript(_astro: AstroGlobal) {
-  return `(function(){var s=document.documentElement.style;var L=function(){${varsToJs(light)}};var D=function(){${varsToJs(dark)}};var t=localStorage.getItem("theme");if(t==="dark"){D()}else if(t==="light"){L()}else if(window.matchMedia("(prefers-color-scheme:dark)").matches){D()}else{L()}})();`;
+  return `(function(){var s=document.documentElement.style;var L=function(){${varsToJs(light)}};var D=function(){${varsToJs(dark)}};var h=location.hash.match(/[#&]theme=(dark|light)\\b/);if(h){if(h[1]==="dark"){D()}else{L()}}else if(window.matchMedia("(prefers-color-scheme:dark)").matches){D()}else{L()}})();`;
 }

--- a/packages/landing/src/styles/theme-tokens.ts
+++ b/packages/landing/src/styles/theme-tokens.ts
@@ -1,0 +1,94 @@
+// Theme tokens for the landing page.
+//
+// This module is inlined as a <script is:inline> in BaseLayout.astro so it
+// runs before paint, bypassing Tailwind's CSS cascade entirely.  It sets CSS
+// custom properties directly on document.documentElement.style — which wins
+// over any stylesheet rule.
+//
+// Components reference these via var(--color-page-*) in inline styles and
+// Tailwind arbitrary-value classes like bg-[var(--color-page-surface)].
+
+/** Light palette (default) */
+export const light = {
+  "--color-page-bg": "#ffffff",
+  "--color-page-bg-elevated": "#fafafa",
+  "--color-page-bg-overlay": "rgba(255, 255, 255, 0.85)",
+  "--color-page-surface": "#ffffff",
+  "--color-page-surface-dim": "#f5f5f7",
+  "--color-page-border": "rgba(0, 0, 0, 0.08)",
+  "--color-page-border-active": "rgba(0, 0, 0, 0.16)",
+  "--color-page-text": "#0b0b0d",
+  "--color-page-text-muted": "#6b7280",
+
+  "--color-tg-bg": "rgb(33, 33, 33)",
+  "--color-tg-bg-secondary": "rgb(15, 15, 15)",
+  "--color-tg-bubble-out": "#c2410c",
+  "--color-tg-bubble-in": "rgb(33, 33, 33)",
+  "--color-tg-accent": "#c2410c",
+  "--color-tg-accent-rgb": "194, 65, 12",
+  "--color-tg-border": "rgb(48, 48, 48)",
+  "--color-tg-text": "white",
+  "--color-tg-meta": "rgba(255, 255, 255, 0.533)",
+
+  "--color-page-bg-inverted": "#0b0b0d",
+  "--color-page-text-inverted": "#ffffff",
+  "--color-page-dotted": "rgba(0, 0, 0, 0.08)",
+  "--color-page-grid": "rgba(0, 0, 0, 0.06)",
+  "--color-page-divider-mark": "rgba(0, 0, 0, 0.18)",
+  "--color-page-overlay-backdrop": "rgba(0, 0, 0, 0.7)",
+  "--color-page-code-bg": "rgba(0, 0, 0, 0.04)",
+  "--color-page-code-border": "rgba(0, 0, 0, 0.08)",
+  "--color-page-pre-bg-from": "rgba(20, 20, 24, 0.98)",
+  "--color-page-pre-bg-to": "rgba(12, 12, 16, 0.98)",
+  "--color-page-pre-border": "rgba(255, 255, 255, 0.09)",
+  "--color-page-prose-text": "rgba(11, 11, 13, 0.82)",
+  "--color-page-prose-blockquote": "rgba(11, 11, 13, 0.7)",
+  "--color-page-hex-stroke": "rgba(0, 0, 0, 0.18)",
+  "--color-page-hex-line": "rgba(0, 0, 0, 0.08)",
+  "--color-page-shadow-sm": "0 1px 2px rgba(0, 0, 0, 0.05)",
+  "--color-page-shadow-md":
+    "0 12px 32px rgba(0, 0, 0, 0.08), 0 2px 6px rgba(0, 0, 0, 0.04)",
+  "--color-page-dialog-close-bg": "rgba(0, 0, 0, 0.5)",
+  "--color-page-dialog-close-hover": "rgba(0, 0, 0, 0.7)",
+  "--color-page-meta-theme": "#ffffff",
+} as const;
+
+/** Dark palette */
+export const dark = {
+  "--color-page-bg": "#0a0a0b",
+  "--color-page-bg-elevated": "#111113",
+  "--color-page-bg-overlay": "rgba(10, 10, 11, 0.85)",
+  "--color-page-surface": "#161618",
+  "--color-page-surface-dim": "#1c1c1f",
+  "--color-page-border": "rgba(255, 255, 255, 0.08)",
+  "--color-page-border-active": "rgba(255, 255, 255, 0.16)",
+  "--color-page-text": "#f0f0f2",
+  "--color-page-text-muted": "#9ca3af",
+
+  "--color-tg-bg": "rgb(22, 22, 24)",
+  "--color-tg-bg-secondary": "rgb(10, 10, 11)",
+  "--color-tg-bubble-in": "rgb(22, 22, 24)",
+  "--color-tg-border": "rgb(48, 48, 48)",
+
+  "--color-page-bg-inverted": "#f0f0f2",
+  "--color-page-text-inverted": "#0a0a0b",
+  "--color-page-dotted": "rgba(255, 255, 255, 0.06)",
+  "--color-page-grid": "rgba(255, 255, 255, 0.04)",
+  "--color-page-divider-mark": "rgba(255, 255, 255, 0.14)",
+  "--color-page-overlay-backdrop": "rgba(0, 0, 0, 0.8)",
+  "--color-page-code-bg": "rgba(255, 255, 255, 0.06)",
+  "--color-page-code-border": "rgba(255, 255, 255, 0.08)",
+  "--color-page-pre-bg-from": "rgba(20, 20, 24, 0.98)",
+  "--color-page-pre-bg-to": "rgba(12, 12, 16, 0.98)",
+  "--color-page-pre-border": "rgba(255, 255, 255, 0.09)",
+  "--color-page-prose-text": "rgba(240, 240, 242, 0.82)",
+  "--color-page-prose-blockquote": "rgba(240, 240, 242, 0.7)",
+  "--color-page-hex-stroke": "rgba(255, 255, 255, 0.14)",
+  "--color-page-hex-line": "rgba(255, 255, 255, 0.06)",
+  "--color-page-shadow-sm": "0 1px 2px rgba(0, 0, 0, 0.3)",
+  "--color-page-shadow-md":
+    "0 12px 32px rgba(0, 0, 0, 0.4), 0 2px 6px rgba(0, 0, 0, 0.2)",
+  "--color-page-dialog-close-bg": "rgba(255, 255, 255, 0.15)",
+  "--color-page-dialog-close-hover": "rgba(255, 255, 255, 0.25)",
+  "--color-page-meta-theme": "#0a0a0b",
+} as const;

--- a/packages/owletto-backend/src/__tests__/unit/sandbox/method-metadata.test.ts
+++ b/packages/owletto-backend/src/__tests__/unit/sandbox/method-metadata.test.ts
@@ -4,106 +4,50 @@ import {
   METHOD_METADATA,
   type MethodAccess,
 } from "../../../sandbox/method-metadata";
+import { buildClientSDK } from "../../../sandbox/client-sdk";
+import type { Env } from "../../../index";
+import type { ToolContext } from "../../../tools/registry";
 
-/**
- * Static surface description of every namespace method. Hand-maintained — when
- * a namespace adds a method, this list must add it too, and a metadata entry
- * must exist. The coverage test below enforces the latter.
- */
-const NAMESPACE_METHODS: Record<string, readonly string[]> = {
-  entities: [
-    "list",
-    "get",
-    "create",
-    "update",
-    "delete",
-    "link",
-    "unlink",
-    "updateLink",
-    "listLinks",
-    "search",
-  ],
-  entitySchema: [
-    "listTypes",
-    "getType",
-    "createType",
-    "updateType",
-    "deleteType",
-    "auditType",
-    "listRelTypes",
-    "getRelType",
-    "createRelType",
-    "updateRelType",
-    "deleteRelType",
-    "addRule",
-    "removeRule",
-    "listRules",
-  ],
-  connections: [
-    "list",
-    "listConnectorDefinitions",
-    "get",
-    "create",
-    "connect",
-    "update",
-    "delete",
-    "test",
-    "installConnector",
-    "uninstallConnector",
-    "toggleConnectorLogin",
-    "updateConnectorAuth",
-  ],
-  feeds: ["list", "get", "create", "update", "delete", "trigger"],
-  authProfiles: ["list", "get", "test", "create", "update", "delete"],
-  operations: [
-    "listAvailable",
-    "execute",
-    "listRuns",
-    "getRun",
-    "approve",
-    "reject",
-  ],
-  watchers: [
-    "list",
-    "get",
-    "create",
-    "update",
-    "delete",
-    "setReactionScript",
-    "completeWindow",
-  ],
-  classifiers: [
-    "list",
-    "create",
-    "createVersion",
-    "getVersions",
-    "setCurrentVersion",
-    "generateEmbeddings",
-    "delete",
-    "classify",
-  ],
-  viewTemplates: ["get", "set", "rollback", "removeTab"],
-  knowledge: ["search", "save", "read", "delete"],
-  organizations: ["list", "current"],
+const testEnv: Env = { ENVIRONMENT: "test" } as Env;
+const testCtx: ToolContext = {
+  organizationId: "test-org",
+  userId: "test-user",
+  memberRole: "owner",
+  isAuthenticated: true,
+  tokenType: "oauth",
+  scopedToOrg: false,
+  allowCrossOrg: true,
 };
 
-/** Top-level SDK methods that aren't inside a namespace. */
-const TOP_LEVEL_METHODS = ["query", "log", "org"] as const;
+function enumerateSdkMethods(): { namespaceMethods: string[]; topLevelMethods: string[] } {
+  const sdk = buildClientSDK(testCtx, testEnv);
+  const namespaceMethods: string[] = [];
+  const topLevelMethods: string[] = [];
+
+  for (const [name, value] of Object.entries(sdk)) {
+    if (typeof value === "function") {
+      topLevelMethods.push(name);
+      continue;
+    }
+    if (!value || typeof value !== "object") continue;
+    for (const method of Object.keys(value)) {
+      namespaceMethods.push(`${name}.${method}`);
+    }
+  }
+
+  return { namespaceMethods, topLevelMethods };
+}
 
 describe("method-metadata", () => {
-  it("has at least one entry per namespace method", () => {
-    const missing: string[] = [];
-    for (const [ns, methods] of Object.entries(NAMESPACE_METHODS)) {
-      for (const m of methods) {
-        const key = `${ns}.${m}`;
-        if (!(key in METHOD_METADATA)) missing.push(key);
-      }
-    }
+  it("has metadata for every namespace method", () => {
+    const { namespaceMethods } = enumerateSdkMethods();
+    const missing = namespaceMethods.filter((path) => !(path in METHOD_METADATA));
     expect(missing).toEqual([]);
   });
 
   it("has entries for top-level methods", () => {
-    for (const m of TOP_LEVEL_METHODS) {
+    const { topLevelMethods } = enumerateSdkMethods();
+    for (const m of topLevelMethods) {
       expect(METHOD_METADATA).toHaveProperty(m);
     }
   });
@@ -135,6 +79,7 @@ describe("method-metadata", () => {
   it("classifies external side-effects correctly for known methods", () => {
     expect(METHOD_METADATA["operations.execute"].access).toBe("external");
     expect(METHOD_METADATA["feeds.trigger"].access).toBe("external");
+    expect(METHOD_METADATA["watchers.trigger"].access).toBe("external");
     expect(METHOD_METADATA["connections.test"].access).toBe("external");
     expect(METHOD_METADATA["authProfiles.test"].access).toBe("external");
   });

--- a/packages/owletto-backend/src/auth/__tests__/token-routes.test.ts
+++ b/packages/owletto-backend/src/auth/__tests__/token-routes.test.ts
@@ -1,0 +1,87 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { PersonalAccessTokenService } from '../tokens';
+import { getTestDb, cleanupTestDatabase } from '../../__tests__/setup/test-db';
+import {
+  addUserToOrganization,
+  createTestAccessToken,
+  createTestOAuthClient,
+  createTestOrganization,
+  createTestPAT,
+  createTestUser,
+} from '../../__tests__/setup/test-fixtures';
+import { post } from '../../__tests__/setup/test-helpers';
+
+describe('org-scoped token creation route', () => {
+  beforeEach(async () => {
+    await cleanupTestDatabase();
+  });
+
+  it('lets an org owner with OAuth mcp:admin create a server PAT', async () => {
+    const org = await createTestOrganization({ slug: 'token-route-org' });
+    const user = await createTestUser({ email: 'token-owner@test.example.com' });
+    await addUserToOrganization(user.id, org.id, 'owner');
+    const client = await createTestOAuthClient();
+    const { token: oauthToken } = await createTestAccessToken(user.id, org.id, client.client_id, {
+      scope: 'mcp:read mcp:write mcp:admin profile:read',
+    });
+
+    const response = await post(`/api/${org.slug}/tokens`, {
+      token: oauthToken,
+      body: {
+        name: 'prod-server',
+        description: 'server token created from CLI OAuth login',
+        scope: 'mcp:read mcp:write',
+        expiresInDays: 30,
+      },
+    });
+
+    expect(response.status).toBe(201);
+    const body = await response.json();
+    expect(body.token.token).toMatch(/^owl_pat_/);
+    expect(body.token.name).toBe('prod-server');
+    expect(body.token.scope).toBe('mcp:read mcp:write');
+    expect(body.token.expires_at).toBeTruthy();
+
+    const verified = await new PersonalAccessTokenService(getTestDb()).verify(body.token.token);
+    expect(verified?.userId).toBe(user.id);
+    expect(verified?.organizationId).toBe(org.id);
+    expect(verified?.scopes).toEqual(['mcp:read', 'mcp:write']);
+  });
+
+  it('rejects OAuth tokens without mcp:admin scope', async () => {
+    const org = await createTestOrganization({ slug: 'token-no-admin-scope' });
+    const user = await createTestUser({ email: 'token-no-admin@test.example.com' });
+    await addUserToOrganization(user.id, org.id, 'owner');
+    const client = await createTestOAuthClient();
+    const { token: oauthToken } = await createTestAccessToken(user.id, org.id, client.client_id, {
+      scope: 'mcp:read mcp:write profile:read',
+    });
+
+    const response = await post(`/api/${org.slug}/tokens`, {
+      token: oauthToken,
+      body: { name: 'should-not-create' },
+    });
+
+    expect(response.status).toBe(403);
+    expect(await response.json()).toMatchObject({
+      error: 'Token creation requires mcp:admin scope',
+    });
+  });
+
+  it('rejects creating a PAT from an existing PAT', async () => {
+    const org = await createTestOrganization({ slug: 'token-from-pat' });
+    const user = await createTestUser({ email: 'token-pat@test.example.com' });
+    await addUserToOrganization(user.id, org.id, 'owner');
+    const { token: pat } = await createTestPAT(user.id, org.id);
+
+    const response = await post(`/api/${org.slug}/tokens`, {
+      token: pat,
+      body: { name: 'should-not-create' },
+    });
+
+    expect(response.status).toBe(403);
+    expect(await response.json()).toMatchObject({
+      error: 'Use `lobu login` with OAuth or a web session to create server tokens',
+    });
+  });
+});

--- a/packages/owletto-backend/src/auth/credentials.ts
+++ b/packages/owletto-backend/src/auth/credentials.ts
@@ -99,7 +99,7 @@ export class CredentialService {
     return result;
   }
 
-  private async persistAccountTokens
+  private async persistAccountTokens(
     accountId: string,
     tokens: { accessToken: string; expiresAt: Date; refreshToken?: string }
   ): Promise<void> {

--- a/packages/owletto-backend/src/auth/credentials.ts
+++ b/packages/owletto-backend/src/auth/credentials.ts
@@ -1,35 +1,11 @@
 /**
- * Credential Management Service
+ * Credential Service — OAuth token resolution and refresh
  *
- * Handles linking OAuth accounts to connectors and managing credentials for source authentication.
+ * Used by execution-context.ts and mcp-proxy/credential-resolver.ts to
+ * resolve and auto-refresh OAuth tokens for upstream API calls.
  */
 
 import type { DbClient } from '../db/client';
-import type { Env } from '../index';
-import {
-  getEnabledLoginProviderConfigs,
-  resolveDefaultOrganizationId,
-  resolveLoginProviderCredentials,
-} from './config';
-
-/**
- * User credential with account info
- */
-interface UserCredential {
-  id: number;
-  userId: string;
-  accountId: string;
-  connectorKeys: string[];
-  displayName: string;
-  isActive: boolean;
-  lastUsedAt: Date | null;
-  createdAt: Date;
-  // From joined account table
-  providerId: string;
-  hasAccessToken: boolean;
-  hasRefreshToken: boolean;
-  accessTokenExpiresAt: Date | null;
-}
 
 /**
  * Credential tokens for sync execution
@@ -42,9 +18,6 @@ interface CredentialTokens {
   scope: string | null;
 }
 
-/**
- * Credential Management Service
- */
 const TOKEN_EXPIRY_BUFFER_MS = 5 * 60 * 1000;
 
 function isTokenExpiringSoon(expiresAt: Date | string | null): boolean {
@@ -52,276 +25,8 @@ function isTokenExpiringSoon(expiresAt: Date | string | null): boolean {
   return new Date(expiresAt).getTime() <= Date.now() + TOKEN_EXPIRY_BUFFER_MS;
 }
 
-const USER_CREDENTIAL_SELECT = `
-  uc.id,
-  uc.user_id as "userId",
-  uc.account_id as "accountId",
-  uc.crawler_types as "connectorKeys",
-  uc.display_name as "displayName",
-  uc.is_active as "isActive",
-  uc.last_used_at as "lastUsedAt",
-  uc.created_at as "createdAt",
-  a."providerId",
-  a."accessToken" IS NOT NULL as "hasAccessToken",
-  a."refreshToken" IS NOT NULL as "hasRefreshToken",
-  a."accessTokenExpiresAt"
-` as const;
-
 export class CredentialService {
   constructor(private sql: DbClient) {}
-
-  /**
-   * List user's credentials with account info
-   */
-  async getUserCredentials(userId: string): Promise<UserCredential[]> {
-    const result = await this.sql`
-      SELECT ${this.sql.unsafe(USER_CREDENTIAL_SELECT)}
-      FROM user_credentials uc
-      JOIN "account" a ON uc.account_id = a.id
-      WHERE uc.user_id = ${userId}
-      ORDER BY uc.created_at DESC
-    `;
-    return result as unknown as UserCredential[];
-  }
-
-  /**
-   * List active credentials for a connector + provider pair.
-   */
-  async listCredentialsForConnector(
-    userId: string,
-    connectorKey: string,
-    provider: string
-  ): Promise<UserCredential[]> {
-    const normalizedConnectorKey = connectorKey.toLowerCase();
-    const normalizedProvider = provider.toLowerCase();
-    const result = await this.sql`
-      SELECT ${this.sql.unsafe(USER_CREDENTIAL_SELECT)}
-      FROM user_credentials uc
-      JOIN "account" a ON uc.account_id = a.id
-      WHERE uc.user_id = ${userId}
-        AND uc.is_active = TRUE
-        AND LOWER(a."providerId") = ${normalizedProvider}
-        AND (
-          array_length(uc.crawler_types, 1) IS NULL
-          OR ${normalizedConnectorKey} = ANY(uc.crawler_types)
-        )
-      ORDER BY uc.last_used_at DESC NULLS LAST, uc.created_at DESC
-    `;
-    return result as unknown as UserCredential[];
-  }
-
-  /**
-   * Get user's linked OAuth accounts (from better-auth)
-   */
-  async getUserAccounts(userId: string) {
-    const result = await this.sql`
-      SELECT
-        id,
-        "accountId",
-        "providerId",
-        "accessToken" IS NOT NULL as "hasAccessToken",
-        "refreshToken" IS NOT NULL as "hasRefreshToken",
-        "accessTokenExpiresAt",
-        scope,
-        "createdAt"
-      FROM "account"
-      WHERE "userId" = ${userId}
-      ORDER BY "createdAt" DESC
-    `;
-    return result;
-  }
-
-  /**
-   * Find the preferred credential for a connector/provider in the current org.
-   * Preference order:
-   * 1) Credential previously linked to a connection of same connector key in this org
-   * 2) Most recently used active credential for this connector/provider
-   */
-  async resolvePreferredCredentialForConnector(params: {
-    userId: string;
-    organizationId: string;
-    connectorKey: string;
-    provider: string;
-  }): Promise<UserCredential | null> {
-    const normalizedConnectorKey = params.connectorKey.toLowerCase();
-    const normalizedProvider = params.provider.toLowerCase();
-
-    const linkedResult = await this.sql`
-      SELECT ${this.sql.unsafe(USER_CREDENTIAL_SELECT)}
-      FROM connections c
-      JOIN auth_profiles ap ON ap.id = c.auth_profile_id
-      JOIN user_credentials uc ON uc.account_id = ap.account_id
-      JOIN "account" a ON a.id = ap.account_id
-      WHERE uc.user_id = ${params.userId}
-        AND uc.is_active = TRUE
-        AND c.organization_id = ${params.organizationId}
-        AND LOWER(c.connector_key) = ${normalizedConnectorKey}
-        AND LOWER(a."providerId") = ${normalizedProvider}
-        AND c.deleted_at IS NULL
-      ORDER BY uc.last_used_at DESC NULLS LAST, c.updated_at DESC
-      LIMIT 1
-    `;
-
-    if (linkedResult.length > 0) {
-      return linkedResult[0] as unknown as UserCredential;
-    }
-
-    const available = await this.listCredentialsForConnector(
-      params.userId,
-      normalizedConnectorKey,
-      normalizedProvider
-    );
-    return available.length > 0 ? available[0] : null;
-  }
-
-  /**
-   * Ensure there is an active credential for one of the user's linked OAuth accounts.
-   * If account is linked but credential row does not exist, this will create one.
-   */
-  async ensureCredentialFromLinkedAccount(
-    userId: string,
-    provider: string,
-    connectorKey: string
-  ): Promise<UserCredential | null> {
-    const normalizedProvider = provider.toLowerCase();
-    const normalizedConnectorKey = connectorKey.toLowerCase();
-
-    const existing = await this.listCredentialsForConnector(
-      userId,
-      normalizedConnectorKey,
-      normalizedProvider
-    );
-    if (existing.length > 0) {
-      return existing[0];
-    }
-
-    const accountRows = await this.sql`
-      SELECT
-        id,
-        "providerId",
-        "accountId",
-        "createdAt"
-      FROM "account"
-      WHERE "userId" = ${userId}
-        AND LOWER("providerId") = ${normalizedProvider}
-      ORDER BY "createdAt" DESC
-      LIMIT 1
-    `;
-    if (accountRows.length === 0) {
-      return null;
-    }
-
-    const account = accountRows[0] as {
-      id: string;
-      providerId: string;
-      accountId: string | null;
-    };
-    const fallbackName = account.accountId?.trim() || account.id.slice(0, 8);
-    const displayName = `${account.providerId} ${fallbackName}`.trim();
-
-    const upserted = await this.sql`
-      INSERT INTO user_credentials (user_id, account_id, crawler_types, display_name, is_active)
-      VALUES (${userId}, ${account.id}, ${[normalizedConnectorKey]}, ${displayName}, TRUE)
-      ON CONFLICT (user_id, account_id)
-      DO UPDATE SET
-        crawler_types = (
-          SELECT ARRAY(
-            SELECT DISTINCT x
-            FROM unnest(COALESCE(user_credentials.crawler_types, '{}') || EXCLUDED.crawler_types) AS t(x)
-          )
-        ),
-        is_active = TRUE,
-        updated_at = NOW()
-      RETURNING id
-    `;
-
-    const credentialId = Number((upserted[0] as { id: number }).id);
-    const allCredentials = await this.getUserCredentials(userId);
-    return allCredentials.find((credential) => credential.id === credentialId) ?? null;
-  }
-
-  /**
-   * Create a credential from an OAuth account
-   */
-  async createCredentialFromAccount(
-    userId: string,
-    accountId: string,
-    connectorKeys: string[],
-    displayName: string
-  ): Promise<UserCredential> {
-    // Verify account belongs to user
-    const account = await this.sql`
-      SELECT id, "providerId" FROM "account"
-      WHERE id = ${accountId} AND "userId" = ${userId}
-    `;
-
-    if (account.length === 0) {
-      throw new Error('Account not found or does not belong to user');
-    }
-
-    const result = await this.sql`
-      INSERT INTO user_credentials (user_id, account_id, crawler_types, display_name)
-      VALUES (${userId}, ${accountId}, ${connectorKeys}, ${displayName})
-      ON CONFLICT (user_id, account_id)
-      DO UPDATE SET
-        crawler_types = EXCLUDED.crawler_types,
-        display_name = EXCLUDED.display_name,
-        updated_at = NOW()
-      RETURNING *
-    `;
-
-    // Return with full credential info
-    const credentials = await this.getUserCredentials(userId);
-    const credential = credentials.find((c) => c.id === result[0].id);
-    if (!credential) {
-      throw new Error('Credential lookup failed after upsert');
-    }
-    return credential;
-  }
-
-  /**
-   * Update credential's connector keys
-   */
-  async updateCredentialConnectorKeys(
-    credentialId: number,
-    userId: string,
-    connectorKeys: string[]
-  ): Promise<void> {
-    const result = await this.sql`
-      UPDATE user_credentials
-      SET crawler_types = ${connectorKeys}, updated_at = NOW()
-      WHERE id = ${credentialId} AND user_id = ${userId}
-    `;
-
-    if (result.count === 0) {
-      throw new Error('Credential not found or does not belong to user');
-    }
-  }
-
-  /**
-   * Deactivate a credential
-   */
-  async deactivateCredential(credentialId: number, userId: string): Promise<void> {
-    await this.sql`
-      UPDATE user_credentials
-      SET is_active = false, updated_at = NOW()
-      WHERE id = ${credentialId} AND user_id = ${userId}
-    `;
-  }
-
-  /**
-   * Delete a credential (will fail if sources are linked)
-   */
-  async deleteCredential(credentialId: number, userId: string): Promise<void> {
-    const result = await this.sql`
-      DELETE FROM user_credentials
-      WHERE id = ${credentialId} AND user_id = ${userId}
-    `;
-
-    if (result.count === 0) {
-      throw new Error('Credential not found or does not belong to user');
-    }
-  }
 
   /**
    * Get OAuth tokens for a connection (V1 integration platform).
@@ -355,19 +60,11 @@ export class CredentialService {
 
     // Check if token needs refresh
     if (tokens.expiresAt) {
-      if (isTokenExpiringSoon(tokens.expiresAt) && tokens.refreshToken) {
-        let newTokens: { accessToken: string; expiresAt: Date; refreshToken?: string } | null =
-          null;
-
-        if (oauthConfig) {
-          // Use generic refresh with provided OAuth config
-          newTokens = await this.refreshTokenGeneric({
-            ...oauthConfig,
-            refreshToken: tokens.refreshToken,
-          });
-        }
-        // Note: without oauthConfig, non-generic refresh is handled by
-        // refreshTokenIfNeeded() which has access to Env.
+      if (isTokenExpiringSoon(tokens.expiresAt) && tokens.refreshToken && oauthConfig) {
+        const newTokens = await this.refreshTokenGeneric({
+          ...oauthConfig,
+          refreshToken: tokens.refreshToken,
+        });
 
         if (newTokens) {
           await this.persistAccountTokens(accountId, newTokens);
@@ -384,60 +81,25 @@ export class CredentialService {
   }
 
   /**
-   * Refresh OAuth token if expired
-   * Returns true if token is valid (either still valid or successfully refreshed)
+   * Public method for refreshing tokens with explicit OAuth config.
+   * Used by the MCP proxy to refresh tokens using connector-specific OAuth settings.
    */
-  async refreshTokenIfNeeded(credentialId: number, env: Env): Promise<boolean> {
-    const credential = await this.sql`
-      SELECT
-        uc.id,
-        a."providerId",
-        a."refreshToken",
-        a."accessTokenExpiresAt"
-      FROM user_credentials uc
-      JOIN "account" a ON uc.account_id = a.id
-      WHERE uc.id = ${credentialId}
-    `;
+  async refreshWithConfig(config: {
+    tokenUrl: string;
+    clientId: string;
+    clientSecret?: string;
+    refreshToken: string;
+    authMethod?: 'client_secret_post' | 'client_secret_basic' | 'none';
+    accountId: string;
+  }): Promise<{ accessToken: string; expiresAt: Date; refreshToken?: string } | null> {
+    const result = await this.refreshTokenGeneric(config);
+    if (!result) return null;
 
-    if (credential.length === 0 || !credential[0].refreshToken) {
-      return false;
-    }
-
-    if (!isTokenExpiringSoon(credential[0].accessTokenExpiresAt)) {
-      return true;
-    }
-
-    const newTokens = await this.refreshOAuthToken(
-      credential[0].providerId,
-      credential[0].refreshToken,
-      env
-    );
-
-    if (!newTokens) return false;
-
-    // Update tokens in database
-    await this.sql`
-      UPDATE "account"
-      SET
-        "accessToken" = ${newTokens.accessToken},
-        "accessTokenExpiresAt" = ${newTokens.expiresAt},
-        "updatedAt" = NOW()
-      WHERE id = (
-        SELECT account_id FROM user_credentials WHERE id = ${credentialId}
-      )
-    `;
-
-    // Update last_refresh_at
-    await this.sql`
-      UPDATE user_credentials
-      SET last_refresh_at = NOW()
-      WHERE id = ${credentialId}
-    `;
-
-    return true;
+    await this.persistAccountTokens(config.accountId, result);
+    return result;
   }
 
-  private async persistAccountTokens(
+  private async persistAccountTokens
     accountId: string,
     tokens: { accessToken: string; expiresAt: Date; refreshToken?: string }
   ): Promise<void> {
@@ -449,58 +111,6 @@ export class CredentialService {
           "updatedAt" = NOW()
       WHERE id = ${accountId}
     `;
-  }
-
-  private async refreshOAuthToken(
-    provider: string,
-    refreshToken: string,
-    env: Env
-  ): Promise<{ accessToken: string; expiresAt: Date } | null> {
-    const normalizedProvider = provider.toLowerCase();
-    const organizationId = await resolveDefaultOrganizationId();
-    const configs = await getEnabledLoginProviderConfigs(organizationId);
-    const config = configs.find((c) => c.provider === normalizedProvider);
-
-    if (!config) {
-      console.warn(
-        `[Credentials] No login-enabled connector found for provider '${provider}'; cannot refresh token.`
-      );
-      return null;
-    }
-
-    if (!config.tokenUrl) {
-      console.warn(
-        `[Credentials] Connector '${config.connectorKey}' for provider '${provider}' ` +
-          `does not declare 'tokenUrl'; cannot refresh token.`
-      );
-      return null;
-    }
-
-    const { clientId, clientSecret } = await resolveLoginProviderCredentials({
-      env,
-      provider: normalizedProvider,
-      connectorKey: config.connectorKey,
-      clientIdKey: config.clientIdKey,
-      clientSecretKey: config.clientSecretKey,
-      organizationId,
-    });
-
-    if (!clientId) {
-      console.warn(`[Credentials] Missing OAuth client credentials for provider '${provider}'.`);
-      return null;
-    }
-
-    const newTokens = await this.refreshTokenGeneric({
-      tokenUrl: config.tokenUrl,
-      clientId,
-      clientSecret: clientSecret ?? undefined,
-      refreshToken,
-      authMethod: config.tokenEndpointAuthMethod,
-    });
-
-    if (!newTokens) return null;
-
-    return { accessToken: newTokens.accessToken, expiresAt: newTokens.expiresAt };
   }
 
   /**
@@ -561,24 +171,5 @@ export class CredentialService {
       console.error('[Credentials] Generic token refresh error:', error);
       return null;
     }
-  }
-
-  /**
-   * Public method for refreshing tokens with explicit OAuth config.
-   * Used by the MCP proxy to refresh tokens using connector-specific OAuth settings.
-   */
-  async refreshWithConfig(config: {
-    tokenUrl: string;
-    clientId: string;
-    clientSecret?: string;
-    refreshToken: string;
-    authMethod?: 'client_secret_post' | 'client_secret_basic' | 'none';
-    accountId: string;
-  }): Promise<{ accessToken: string; expiresAt: Date; refreshToken?: string } | null> {
-    const result = await this.refreshTokenGeneric(config);
-    if (!result) return null;
-
-    await this.persistAccountTokens(config.accountId, result);
-    return result;
   }
 }

--- a/packages/owletto-backend/src/auth/routes.ts
+++ b/packages/owletto-backend/src/auth/routes.ts
@@ -4,14 +4,14 @@
  * REST endpoints for account and token management:
  * - GET /api/accounts - List user's linked OAuth accounts
  * - GET /api/agents - List OAuth agents (clients) for an organization
- * - CRUD /api/tokens - Personal access token management
+ * - POST /api/:orgSlug/tokens - Create org-scoped personal access tokens
  */
 
 import { type Context, Hono } from 'hono';
 import { createDbClientFromEnv } from '../db/client';
 import type { Env } from '../index';
 import { errorMessage } from '../utils/errors';
-import { requireAuth } from './middleware';
+import { mcpAuth, requireAuth } from './middleware';
 import { OAuthClientsStore } from './oauth/clients';
 import { PersonalAccessTokenService } from './tokens';
 
@@ -98,154 +98,104 @@ credentialRoutes.get('/agents', requireAuth, async (c) => {
 });
 
 // ============================================
-// Personal Access Token Routes
+// Org-scoped Personal Access Token Routes
 // ============================================
 
-/**
- * List user's tokens
- */
-credentialRoutes.get('/tokens', requireAuth, async (c) => {
-  const user = getAuthenticatedUser(c);
-  const sql = createDbClientFromEnv(c.env);
-  const patService = new PersonalAccessTokenService(sql);
+const AVAILABLE_PAT_SCOPES = new Set(['mcp:read', 'mcp:write', 'mcp:admin', 'profile:read']);
+const DEFAULT_PAT_SCOPE = 'mcp:read mcp:write';
+const MAX_PAT_EXPIRY_DAYS = 3650;
 
-  const tokens = await patService.list(user.id);
-  return c.json({ tokens });
-});
+function authorizeTokenCreation(c: Context<{ Bindings: Env }>) {
+  const user = c.get('user');
+  if (!user?.id) {
+    return { error: c.json({ error: 'Unauthorized', message: 'Authentication required' }, 401) };
+  }
+
+  const organizationId = c.get('organizationId');
+  if (!organizationId) {
+    return { error: c.json({ error: 'Organization slug is required in URL' }, 400) };
+  }
+
+  const role = c.get('memberRole');
+  if (role !== 'owner' && role !== 'admin') {
+    return { error: c.json({ error: 'Token creation requires org owner or admin access' }, 403) };
+  }
+
+  const authSource = c.get('authSource');
+  if (authSource === 'pat') {
+    return {
+      error: c.json(
+        { error: 'Use `lobu login` with OAuth or a web session to create server tokens' },
+        403
+      ),
+    };
+  }
+
+  const scopes = c.get('mcpAuthInfo')?.scopes ?? [];
+  if (authSource === 'oauth' && !scopes.includes('mcp:admin')) {
+    return { error: c.json({ error: 'Token creation requires mcp:admin scope' }, 403) };
+  }
+
+  return { user, organizationId };
+}
+
+function normalizePatScope(scope: unknown): string | undefined {
+  if (scope === undefined || scope === null || scope === '') return DEFAULT_PAT_SCOPE;
+  if (typeof scope !== 'string') {
+    throw new Error('scope must be a space-separated string');
+  }
+  const scopes = Array.from(new Set(scope.split(/\s+/).map((value) => value.trim()).filter(Boolean)));
+  if (scopes.length === 0) return DEFAULT_PAT_SCOPE;
+  const invalid = scopes.filter((value) => !AVAILABLE_PAT_SCOPES.has(value));
+  if (invalid.length > 0) {
+    throw new Error(`Invalid scope(s): ${invalid.join(', ')}`);
+  }
+  return scopes.join(' ');
+}
+
+function normalizeExpiryDays(value: unknown): number | undefined {
+  if (value === undefined || value === null || value === '') return undefined;
+  const days = Number(value);
+  if (!Number.isInteger(days) || days < 1 || days > MAX_PAT_EXPIRY_DAYS) {
+    throw new Error(`expiresInDays must be an integer between 1 and ${MAX_PAT_EXPIRY_DAYS}`);
+  }
+  return days;
+}
 
 /**
- * Create new token
+ * Create an org-scoped Personal Access Token for servers/CI.
+ * Requires an owner/admin web session or OAuth bearer with mcp:admin scope.
  */
-credentialRoutes.post('/tokens', requireAuth, async (c) => {
-  const user = getAuthenticatedUser(c);
+credentialRoutes.post('/:orgSlug/tokens', mcpAuth, async (c) => {
+  const authorized = authorizeTokenCreation(c);
+  if ('error' in authorized) return authorized.error;
+
   const body = await c.req.json<{
-    name: string;
-    org_slug: string;
+    name?: string;
     description?: string;
     scope?: string;
     expiresInDays?: number;
   }>();
 
-  if (!body.name) {
+  const name = body.name?.trim();
+  if (!name) {
     return c.json({ error: 'name is required' }, 400);
   }
-  if (!body.org_slug) {
-    return c.json({ error: 'org_slug is required' }, 400);
-  }
 
+  const description = typeof body.description === 'string' ? body.description.trim() : undefined;
   const sql = createDbClientFromEnv(c.env);
   const patService = new PersonalAccessTokenService(sql);
 
   try {
-    const membership = await sql`
-      SELECT m."organizationId" as organization_id
-      FROM "member" m
-      JOIN "organization" o ON o.id = m."organizationId"
-      WHERE m."userId" = ${user.id}
-        AND o.slug = ${body.org_slug}
-      LIMIT 1
-    `;
-
-    if (membership.length === 0) {
-      return c.json({ error: `Not a member of organization '${body.org_slug}'` }, 403);
-    }
-
-    const organizationId = membership[0].organization_id as string;
-
-    const token = await patService.create(user.id, organizationId, body.name, {
-      description: body.description,
-      scope: body.scope,
-      expiresInDays: body.expiresInDays,
+    const token = await patService.create(authorized.user.id, authorized.organizationId, name, {
+      ...(description ? { description } : {}),
+      scope: normalizePatScope(body.scope),
+      expiresInDays: normalizeExpiryDays(body.expiresInDays),
     });
     return c.json({ token }, 201);
   } catch (error) {
     return c.json({ error: errorMessage(error) }, 400);
   }
-});
-
-/**
- * Get a specific token
- */
-credentialRoutes.get('/tokens/:id', requireAuth, async (c) => {
-  const user = getAuthenticatedUser(c);
-  const tokenId = parseInt(c.req.param('id') ?? '', 10);
-  if (Number.isNaN(tokenId)) {
-    return c.json({ error: 'Invalid token ID' }, 400);
-  }
-
-  const sql = createDbClientFromEnv(c.env);
-  const patService = new PersonalAccessTokenService(sql);
-
-  const token = await patService.get(tokenId, user.id);
-  if (!token) {
-    return c.json({ error: 'Token not found' }, 404);
-  }
-
-  return c.json({ token });
-});
-
-/**
- * Update token metadata
- */
-credentialRoutes.patch('/tokens/:id', requireAuth, async (c) => {
-  const user = getAuthenticatedUser(c);
-  const tokenId = parseInt(c.req.param('id') ?? '', 10);
-  if (Number.isNaN(tokenId)) {
-    return c.json({ error: 'Invalid token ID' }, 400);
-  }
-  const body = await c.req.json<{
-    name?: string;
-    description?: string;
-  }>();
-
-  const sql = createDbClientFromEnv(c.env);
-  const patService = new PersonalAccessTokenService(sql);
-
-  try {
-    const success = await patService.update(tokenId, user.id, body);
-    if (!success) {
-      return c.json({ error: 'Token not found or no changes made' }, 404);
-    }
-
-    const token = await patService.get(tokenId, user.id);
-    return c.json({ token });
-  } catch (error) {
-    return c.json({ error: errorMessage(error) }, 400);
-  }
-});
-
-/**
- * Revoke token
- */
-credentialRoutes.delete('/tokens/:id', requireAuth, async (c) => {
-  const user = getAuthenticatedUser(c);
-  const tokenId = parseInt(c.req.param('id') ?? '', 10);
-  if (Number.isNaN(tokenId)) {
-    return c.json({ error: 'Invalid token ID' }, 400);
-  }
-
-  const sql = createDbClientFromEnv(c.env);
-  const patService = new PersonalAccessTokenService(sql);
-
-  const success = await patService.revoke(tokenId, user.id);
-  if (!success) {
-    return c.json({ error: 'Token not found' }, 404);
-  }
-
-  return c.json({ success: true });
-});
-
-/**
- * Revoke all tokens
- */
-credentialRoutes.delete('/tokens', requireAuth, async (c) => {
-  const user = getAuthenticatedUser(c);
-
-  const sql = createDbClientFromEnv(c.env);
-  const patService = new PersonalAccessTokenService(sql);
-
-  const count = await patService.revokeAll(user.id);
-  return c.json({ success: true, revoked_count: count });
 });
 
 export { credentialRoutes };

--- a/packages/owletto-backend/src/auth/routes.ts
+++ b/packages/owletto-backend/src/auth/routes.ts
@@ -1,18 +1,16 @@
 /**
- * Authentication & Credential Routes
+ * Authentication & Account Routes
  *
- * Provides REST endpoints for credential management:
- * - GET /api/credentials - List user's credentials
- * - POST /api/credentials - Create credential from OAuth account
- * - PATCH /api/credentials/:id - Update credential
- * - DELETE /api/credentials/:id - Delete credential
+ * REST endpoints for account and token management:
+ * - GET /api/accounts - List user's linked OAuth accounts
+ * - GET /api/agents - List OAuth agents (clients) for an organization
+ * - CRUD /api/tokens - Personal access token management
  */
 
 import { type Context, Hono } from 'hono';
 import { createDbClientFromEnv } from '../db/client';
 import type { Env } from '../index';
 import { errorMessage } from '../utils/errors';
-import { CredentialService } from './credentials';
 import { requireAuth } from './middleware';
 import { OAuthClientsStore } from './oauth/clients';
 import { PersonalAccessTokenService } from './tokens';
@@ -28,116 +26,27 @@ function getAuthenticatedUser(c: Context<{ Bindings: Env }>) {
 }
 
 /**
- * List user's credentials
- */
-credentialRoutes.get('/credentials', requireAuth, async (c) => {
-  const user = getAuthenticatedUser(c);
-  const sql = createDbClientFromEnv(c.env);
-  const credentialService = new CredentialService(sql);
-
-  const credentials = await credentialService.getUserCredentials(user.id);
-  return c.json({ credentials });
-});
-
-/**
  * List user's linked OAuth accounts
  */
 credentialRoutes.get('/accounts', requireAuth, async (c) => {
   const user = getAuthenticatedUser(c);
   const sql = createDbClientFromEnv(c.env);
-  const credentialService = new CredentialService(sql);
 
-  const accounts = await credentialService.getUserAccounts(user.id);
-  return c.json({ accounts });
-});
-
-/**
- * Create credential from OAuth account
- */
-credentialRoutes.post('/credentials', requireAuth, async (c) => {
-  const user = getAuthenticatedUser(c);
-  const body = await c.req.json<{
-    accountId: string;
-    connectorKeys: string[];
-    displayName: string;
-  }>();
-
-  if (!body.accountId || !body.displayName) {
-    return c.json({ error: 'accountId and displayName are required' }, 400);
-  }
-
-  const sql = createDbClientFromEnv(c.env);
-  const credentialService = new CredentialService(sql);
-
-  try {
-    const credential = await credentialService.createCredentialFromAccount(
-      user.id,
-      body.accountId,
-      body.connectorKeys || [],
-      body.displayName
-    );
-    return c.json({ credential });
-  } catch (error) {
-    return c.json({ error: errorMessage(error) }, 400);
-  }
-});
-
-/**
- * Update credential
- */
-credentialRoutes.patch('/credentials/:id', requireAuth, async (c) => {
-  const user = getAuthenticatedUser(c);
-  const credentialId = parseInt(c.req.param('id') ?? '', 10);
-  if (Number.isNaN(credentialId)) {
-    return c.json({ error: 'Invalid credential ID' }, 400);
-  }
-  const body = await c.req.json<{
-    connectorKeys?: string[];
-    isActive?: boolean;
-  }>();
-
-  const sql = createDbClientFromEnv(c.env);
-  const credentialService = new CredentialService(sql);
-
-  try {
-    if (body.connectorKeys) {
-      await credentialService.updateCredentialConnectorKeys(
-        credentialId,
-        user.id,
-        body.connectorKeys
-      );
-    }
-    if (body.isActive === false) {
-      await credentialService.deactivateCredential(credentialId, user.id);
-    }
-
-    const credentials = await credentialService.getUserCredentials(user.id);
-    const credential = credentials.find((c) => c.id === credentialId);
-    return c.json({ credential });
-  } catch (error) {
-    return c.json({ error: errorMessage(error) }, 400);
-  }
-});
-
-/**
- * Delete credential
- */
-credentialRoutes.delete('/credentials/:id', requireAuth, async (c) => {
-  const user = getAuthenticatedUser(c);
-  const credentialId = parseInt(c.req.param('id') ?? '', 10);
-  if (Number.isNaN(credentialId)) {
-    return c.json({ error: 'Invalid credential ID' }, 400);
-  }
-
-  const sql = createDbClientFromEnv(c.env);
-  const credentialService = new CredentialService(sql);
-
-  try {
-    await credentialService.deleteCredential(credentialId, user.id);
-    return c.json({ success: true });
-  } catch (error) {
-    return c.json({ error: errorMessage(error) }, 400);
-  }
+  const result = await sql`
+    SELECT
+      id,
+      "accountId",
+      "providerId",
+      "accessToken" IS NOT NULL as "hasAccessToken",
+      "refreshToken" IS NOT NULL as "hasRefreshToken",
+      "accessTokenExpiresAt",
+      scope,
+      "createdAt"
+    FROM "account"
+    WHERE "userId" = ${user.id}
+    ORDER BY "createdAt" DESC
+  `;
+  return c.json({ accounts: result });
 });
 
 // ============================================

--- a/packages/owletto-backend/src/auth/tokens.ts
+++ b/packages/owletto-backend/src/auth/tokens.ts
@@ -2,7 +2,8 @@
  * Personal Access Token (PAT) Service
  *
  * Manages PATs for workers, CLI tools, and MCP clients.
- * Users generate tokens from the web UI and use them for programmatic access.
+ * Users generate tokens from the CLI or an authenticated control-plane session
+ * and use them for programmatic access.
  */
 
 import type { DbClient } from '../db/client';

--- a/packages/owletto-backend/src/gateway/api/response-renderer.ts
+++ b/packages/owletto-backend/src/gateway/api/response-renderer.ts
@@ -10,6 +10,7 @@ import type { ThreadResponsePayload } from "../infrastructure/queue/types.js";
 import type { ResponseRenderer } from "../platform/response-renderer.js";
 import type { SseManager } from "../services/sse-manager.js";
 import type { WatcherRunTracker } from "../watchers/run-tracker.js";
+import { resolveWatcherRunsByMessageIds } from "../../watchers/run-completion";
 
 const logger = createLogger("api-response-renderer");
 
@@ -130,6 +131,7 @@ export class ApiResponseRenderer implements ResponseRenderer {
     for (const id of payload.processedMessageIds ?? []) {
       if (id) ids.add(id);
     }
+    await resolveWatcherRunsByMessageIds(ids, result);
     for (const id of ids) {
       await this.watcherRunTracker.resolve(id, result);
     }

--- a/packages/owletto-backend/src/gateway/auth/external/client.ts
+++ b/packages/owletto-backend/src/gateway/auth/external/client.ts
@@ -14,7 +14,7 @@ const EXTERNAL_AUTH_CACHE_KEY = "external:auth:client:v3";
 const DISCOVERY_CACHE_TTL_MS = 5 * 60 * 1000;
 const DEFAULT_SCOPE = "profile:read";
 
-interface ExternalAuthConfig {
+export interface ExternalAuthConfig {
   issuerUrl: string;
   clientId?: string;
   clientSecret?: string;
@@ -237,23 +237,23 @@ export class ExternalAuthClient {
     };
   }
 
-  static isConfigured(): boolean {
-    return !!process.env.MEMORY_URL;
+  static isConfigured(config?: { issuerUrl?: string | null }): boolean {
+    return !!config?.issuerUrl?.trim();
   }
 
-  static fromEnv(
-    publicGatewayUrl: string,
-    cacheStore?: ExternalAuthConfig["cacheStore"]
-  ): ExternalAuthClient | null {
-    const authMcpUrl = process.env.MEMORY_URL;
-    if (!authMcpUrl) return null;
+  static fromConfig(config: {
+    issuerUrl?: string | null;
+    publicGatewayUrl: string;
+    cacheStore?: ExternalAuthConfig["cacheStore"];
+  }): ExternalAuthClient | null {
+    const issuerUrl = config.issuerUrl?.trim().replace(/\/+$/, "");
+    if (!issuerUrl) return null;
 
-    const issuerUrl = authMcpUrl.replace(/\/+$/, "");
     const callbackPath = "/connect/oauth/callback";
 
     // Register redirect URIs for both the configured public URL and localhost
-    // so OAuth works regardless of how the user accesses the gateway
-    const redirectUri = `${publicGatewayUrl}${callbackPath}`;
+    // so OAuth works regardless of how the user accesses the gateway.
+    const redirectUri = `${config.publicGatewayUrl}${callbackPath}`;
     const additionalRedirectUris = [
       `http://localhost:8080${callbackPath}`,
     ].filter((uri) => uri !== redirectUri);
@@ -263,7 +263,7 @@ export class ExternalAuthClient {
       redirectUri,
       additionalRedirectUris,
       scope: DEFAULT_SCOPE,
-      cacheStore,
+      cacheStore: config.cacheStore,
     });
   }
 

--- a/packages/owletto-backend/src/gateway/auth/mcp/config-service.ts
+++ b/packages/owletto-backend/src/gateway/auth/mcp/config-service.ts
@@ -7,6 +7,7 @@ import type { ProviderConfigResolver } from "../../services/provider-config-reso
 import type { AgentSettingsStore } from "../settings/agent-settings-store.js";
 
 const logger = createLogger("mcp-config-service");
+const LOBU_MEMORY_MCP_ID = "lobu-memory";
 
 interface McpInput {
   type: "promptString";
@@ -50,16 +51,22 @@ interface LoadedConfig {
 interface McpConfigServiceOptions {
   agentSettingsStore?: AgentSettingsStore;
   configResolver?: ProviderConfigResolver;
+  lobuMemory?: {
+    publicBaseUrl?: string;
+    resolveOrgSlug?: (agentId: string) => Promise<string | null>;
+  };
 }
 
 export class McpConfigService {
   private cache?: LoadedConfig;
   private agentSettingsStore?: AgentSettingsStore;
   private configResolver?: ProviderConfigResolver;
+  private lobuMemory?: McpConfigServiceOptions["lobuMemory"];
 
   constructor(options: McpConfigServiceOptions = {}) {
     this.agentSettingsStore = options.agentSettingsStore;
     this.configResolver = options.configResolver;
+    this.lobuMemory = options.lobuMemory;
     logger.debug(`McpConfigService initialized`);
   }
 
@@ -157,17 +164,13 @@ export class McpConfigService {
       workerConfig.mcpServers[id] = cloned;
     }
 
-    // Merge per-agent MCPs from live agent settings
+    // Merge per-agent MCPs from live agent settings. Per-agent entries always
+    // win over global defaults; otherwise a broken global MCP can silently
+    // shadow the exact server an agent was configured to use.
     const agentSettingsMcpServers =
       (await this.getAgentMcpServers(effectiveAgentId)) || {};
     for (const [id, serverConfig] of Object.entries(agentSettingsMcpServers)) {
-      if (workerConfig.mcpServers[id]) {
-        logger.warn(
-          `Per-agent MCP ${id} skipped - global MCP with same ID exists`
-        );
-        continue;
-      }
-
+      const overridesGlobal = !!workerConfig.mcpServers[id];
       const cloned = cloneConfig(serverConfig);
 
       if (cloned.enabled === false) {
@@ -188,6 +191,9 @@ export class McpConfigService {
       }
 
       workerConfig.mcpServers[id] = cloned;
+      if (overridesGlobal) {
+        logger.info(`Per-agent MCP ${id} overrides global MCP with same ID`);
+      }
     }
 
     if (Object.keys(agentSettingsMcpServers).length > 0) {
@@ -260,10 +266,11 @@ export class McpConfigService {
     if (agentId) {
       const agentMcpServers = await this.getAgentMcpServers(agentId);
       for (const [id, serverConfig] of Object.entries(agentMcpServers)) {
-        if (merged.has(id)) continue;
         const httpServer = toHttpServerConfig(id, serverConfig);
         if (httpServer) {
           merged.set(id, httpServer);
+        } else if (merged.has(id)) {
+          merged.delete(id);
         }
       }
     }
@@ -298,19 +305,49 @@ export class McpConfigService {
   private async getAgentMcpServers(
     agentId: string
   ): Promise<Record<string, any>> {
-    if (!this.agentSettingsStore) {
-      return {};
+    let servers: Record<string, any> = {};
+
+    if (this.agentSettingsStore) {
+      try {
+        const settings =
+          await this.agentSettingsStore.getEffectiveSettings(agentId);
+        servers = { ...(settings?.mcpServers || {}) };
+      } catch (error) {
+        logger.warn(`Failed to load per-agent MCP settings for ${agentId}`, {
+          error,
+        });
+      }
     }
 
+    if (!servers[LOBU_MEMORY_MCP_ID]) {
+      const derived = await this.resolveLobuMemoryServer(agentId);
+      if (derived) {
+        servers[LOBU_MEMORY_MCP_ID] = derived;
+      }
+    }
+
+    return servers;
+  }
+
+  private async resolveLobuMemoryServer(
+    agentId: string
+  ): Promise<Record<string, any> | null> {
+    const baseUrl = this.lobuMemory?.publicBaseUrl?.trim();
+    const resolveOrgSlug = this.lobuMemory?.resolveOrgSlug;
+    if (!baseUrl || !resolveOrgSlug) return null;
+
     try {
-      const settings =
-        await this.agentSettingsStore.getEffectiveSettings(agentId);
-      return settings?.mcpServers || {};
+      const orgSlug = await resolveOrgSlug(agentId);
+      if (!orgSlug) return null;
+      return {
+        url: buildLobuMemoryScopedMcpUrl(baseUrl, orgSlug),
+        type: "streamable-http",
+      };
     } catch (error) {
-      logger.warn(`Failed to load per-agent MCP settings for ${agentId}`, {
+      logger.warn(`Failed to resolve ${LOBU_MEMORY_MCP_ID} for ${agentId}`, {
         error,
       });
-      return {};
+      return null;
     }
   }
 
@@ -451,6 +488,14 @@ function parseAuthScope(raw: any): "user" | "channel" | undefined {
 
 function cloneConfig(config: any) {
   return JSON.parse(JSON.stringify(config));
+}
+
+export function buildLobuMemoryScopedMcpUrl(baseUrl: string, orgSlug: string): string {
+  const url = new URL(baseUrl);
+  url.pathname = `/mcp/${orgSlug}`;
+  url.hash = "";
+  url.search = "";
+  return url.toString().replace(/\/+$/, "");
 }
 
 function isHttpUrl(candidate: string): boolean {

--- a/packages/owletto-backend/src/gateway/config/index.ts
+++ b/packages/owletto-backend/src/gateway/config/index.ts
@@ -117,6 +117,14 @@ export interface GatewayConfig {
   mcp: {
     publicGatewayUrl: string;
   };
+  auth: {
+    /** OIDC issuer used to validate external/service tokens. */
+    issuerUrl?: string;
+  };
+  lobuMemory: {
+    /** Public origin that serves org-scoped LOBU memory MCP endpoints under /mcp/:orgSlug. */
+    publicBaseUrl?: string;
+  };
   secrets: {
     /** Read-only AWS Secrets Manager backend for `aws-sm://` refs. */
     aws: {
@@ -260,7 +268,7 @@ export function buildMemoryPlugins(options?: {
       slot: "memory",
       enabled: true,
       config: {
-        mcpUrl: `${gatewayUrl}/mcp/owletto`,
+        mcpUrl: `${gatewayUrl}/mcp/lobu-memory`,
         gatewayAuthUrl: gatewayUrl,
       },
     },
@@ -487,6 +495,12 @@ export function buildGatewayConfig(
     },
     mcp: {
       publicGatewayUrl,
+    },
+    auth: {
+      issuerUrl: getOptionalEnv("EXTERNAL_AUTH_ISSUER_URL", undefined),
+    },
+    lobuMemory: {
+      publicBaseUrl: getOptionalEnv("LOBU_MEMORY_PUBLIC_BASE_URL", undefined),
     },
     secrets: {
       aws: {

--- a/packages/owletto-backend/src/gateway/routes/public/agent.ts
+++ b/packages/owletto-backend/src/gateway/routes/public/agent.ts
@@ -54,7 +54,7 @@ const NetworkConfigSchema = z.object({
 
 const McpServerConfigSchema = z.object({
   url: z.string().optional(),
-  type: z.enum(["sse", "stdio"]).optional(),
+  type: z.enum(["sse", "stdio", "streamable-http"]).optional(),
   command: z.string().optional(),
   args: z.array(z.string()).optional(),
   env: z.record(z.string(), z.string()).optional(),
@@ -67,6 +67,12 @@ const NixConfigSchema = z.object({
   packages: z.array(z.string()).optional(),
 });
 
+const WatcherRunIntentSchema = z.object({
+  kind: z.literal("watcher_run"),
+  runId: z.number().int().positive(),
+  watcherId: z.number().int().positive(),
+});
+
 const CreateAgentRequestSchema = z.object({
   provider: z.string().default("claude").optional(),
   model: z.string().optional(),
@@ -75,6 +81,7 @@ const CreateAgentRequestSchema = z.object({
   thread: z.string().optional(),
   forceNew: z.boolean().optional(),
   dryRun: z.boolean().optional(),
+  intent: WatcherRunIntentSchema.optional(),
   networkConfig: NetworkConfigSchema.optional(),
   mcpServers: z.record(z.string(), McpServerConfigSchema).optional(),
   nix: NixConfigSchema.optional(),
@@ -619,6 +626,7 @@ export function createAgentApi(config: AgentApiConfig): OpenAPIHono {
       thread,
       forceNew,
       dryRun,
+      intent,
       networkConfig,
       mcpServers,
       nix: nixConfig,
@@ -717,18 +725,28 @@ export function createAgentApi(config: AgentApiConfig): OpenAPIHono {
       }
     }
 
-    const userId = requestedUserId || agentId;
+    const watcherIntent = intent?.kind === "watcher_run" ? intent : null;
+    const userId = watcherIntent
+      ? `watcher_${watcherIntent.watcherId}`
+      : requestedUserId || agentId;
+    const effectiveThread = watcherIntent
+      ? `run_${watcherIntent.runId}`
+      : thread;
+    const effectiveForceNew = watcherIntent ? true : forceNew;
+    const effectiveDryRun = watcherIntent ? false : dryRun || false;
 
-    // Build composite conversationId for user-specific sessions
-    // Uses _ separator (colons not allowed in BullMQ custom IDs)
-    const conversationId = thread
-      ? `${agentId}_${userId}_${thread}`
+    // Build composite conversationId for user-specific sessions.
+    // Uses _ separator (colons not allowed in BullMQ custom IDs). Watcher
+    // automation gets one deterministic one-shot session per run and never
+    // resumes human/API sessions such as marketing_marketing.
+    const conversationId = effectiveThread
+      ? `${agentId}_${userId}_${effectiveThread}`
       : `${agentId}_${userId}`;
     const channelId = `api_${userId}`;
     const deploymentName = `api-${agentId.slice(0, 8)}`;
 
     // Try to resume existing session (unless forceNew is requested)
-    if (!forceNew) {
+    if (!effectiveForceNew) {
       const existing = await sessMgr.getSession(conversationId);
       if (existing) {
         // Reuse existing session — touch lastActivity and return existing token
@@ -792,7 +810,8 @@ export function createAgentApi(config: AgentApiConfig): OpenAPIHono {
         : undefined,
       nixConfig,
       agentId,
-      dryRun: dryRun || false,
+      dryRun: effectiveDryRun,
+      intent: watcherIntent ?? undefined,
       isEphemeral,
     };
     await sessMgr.setSession(session);
@@ -1214,9 +1233,10 @@ export function createAgentApi(config: AgentApiConfig): OpenAPIHono {
         messageText: messageContent,
         platformMetadata: {
           agentId: realAgentId,
-          source: "direct-api",
+          source: session.intent?.kind === "watcher_run" ? "watcher-run" : "direct-api",
           traceparent: traceparent || undefined,
           dryRun: session.dryRun || false,
+          intent: session.intent,
         },
         agentOptions: remainingOptions,
         networkConfig: session.networkConfig || settingsNetwork,

--- a/packages/owletto-backend/src/gateway/services/core-services.ts
+++ b/packages/owletto-backend/src/gateway/services/core-services.ts
@@ -58,6 +58,7 @@ import {
 import { InteractionService } from "../interactions.js";
 import { getModelProviderModules } from "../modules/module-system.js";
 import { GrantStore } from "../permissions/grant-store.js";
+import { getDb } from "../../db/client";
 import { PolicyStore } from "../permissions/policy-store.js";
 import { SecretProxy } from "../proxy/secret-proxy.js";
 import { TokenRefreshJob } from "../proxy/token-refresh-job.js";
@@ -457,7 +458,10 @@ export class CoreServices {
     // (the `state` parameter is opaque to the AS, so any replica can verify).
     const externalAuthKv = new Map<string, { value: string; expiresAt: number }>();
     this.externalAuthClient =
-      ExternalAuthClient.fromEnv(this.config.mcp.publicGatewayUrl, {
+      ExternalAuthClient.fromConfig({
+        issuerUrl: this.config.auth.issuerUrl,
+        publicGatewayUrl: this.config.mcp.publicGatewayUrl,
+        cacheStore: {
         get: async (key) => {
           const entry = externalAuthKv.get(key);
           if (!entry) return null;
@@ -473,7 +477,8 @@ export class CoreServices {
             expiresAt: Date.now() + ttlSeconds * 1000,
           });
         },
-      }) ?? undefined;
+      },
+    }) ?? undefined;
     if (this.externalAuthClient) {
       logger.debug("External OAuth client initialized");
     }
@@ -726,9 +731,21 @@ export class CoreServices {
     this.mcpConfigService = new McpConfigService({
       agentSettingsStore: this.agentSettingsStore,
       configResolver: this.providerConfigResolver,
+      lobuMemory: {
+        publicBaseUrl: this.config.lobuMemory.publicBaseUrl,
+        resolveOrgSlug: async (agentId: string) => {
+          const rows = await getDb()`
+            SELECT o.slug
+            FROM agents a
+            JOIN organization o ON o.id = a.organization_id
+            WHERE a.id = ${agentId}
+            LIMIT 1
+          `;
+          const slug = rows[0]?.slug;
+          return typeof slug === "string" && slug.trim() ? slug.trim() : null;
+        },
+      },
     });
-
-    this.syncOwlettoMcpFromEnv();
 
     // Initialize instruction service (needed by WorkerGateway)
     this.instructionService = new InstructionService(
@@ -854,30 +871,6 @@ export class CoreServices {
   // File-First Helpers
   // ============================================================================
 
-  /**
-   * Mirror the resolved `MEMORY_URL` env var into the MCP config service as a
-   * global `owletto` server. Without this, requests to `/mcp/owletto` (issued
-   * by the Owletto plugin running inside workers) fail with "MCP server
-   * 'owletto' not found" because `getHttpServer("owletto")` would otherwise
-   * return undefined — the upstream URL only lives in env, not in any
-   * agent settings entry.
-   *
-   * NOTE: do NOT set `oauth: {}` here. Owletto auth is owned by the
-   * worker-side `owletto_login` plugin tool (device-code flow). Adding
-   * `oauth: {}` would trigger the gateway's MCP OAuth auth-code/PKCE
-   * discovery as a parallel flow, producing two competing login links
-   * for the user.
-   */
-  private syncOwlettoMcpFromEnv(): void {
-    if (!this.mcpConfigService) return;
-    const memoryUrl = process.env.MEMORY_URL?.trim();
-    if (!memoryUrl) return;
-    this.mcpConfigService.upsertGlobalServer("owletto", {
-      url: memoryUrl,
-      type: "streamable-http",
-    });
-  }
-
   private async populateStoreFromFiles(
     store: InMemoryAgentStore,
     agents: FileLoadedAgent[]
@@ -929,7 +922,6 @@ export class CoreServices {
     }
 
     await applyOwlettoMemoryEnvFromProject(this.projectPath);
-    this.syncOwlettoMcpFromEnv();
 
     // Re-load from disk
     this.fileLoadedAgents = await loadAgentConfigFromFiles(this.projectPath);

--- a/packages/owletto-backend/src/gateway/services/platform-helpers.ts
+++ b/packages/owletto-backend/src/gateway/services/platform-helpers.ts
@@ -35,7 +35,7 @@ function readOwlettoRuntimeDefaults(): PluginConfig | null {
     slot: "memory",
     enabled: true,
     config: {
-      mcpUrl: `${gatewayUrl}/mcp/owletto`,
+      mcpUrl: `${gatewayUrl}/mcp/lobu-memory`,
       gatewayAuthUrl: gatewayUrl,
     },
   };
@@ -74,7 +74,7 @@ function normalizeOwlettoPluginConfig(
     typeof storedMcpUrl === "string" &&
     typeof runtimeMcpUrl === "string" &&
     runtimeMcpUrl !== storedMcpUrl &&
-    /^https?:\/\/gateway(?::\d+)?\/mcp\/owletto\/?$/.test(storedMcpUrl);
+    /^https?:\/\/gateway(?::\d+)?\/mcp\/lobu-memory\/?$/.test(storedMcpUrl);
   const shouldReplaceGatewayAuthUrl =
     typeof storedGatewayAuthUrl === "string" &&
     typeof runtimeGatewayAuthUrl === "string" &&

--- a/packages/owletto-backend/src/gateway/session.ts
+++ b/packages/owletto-backend/src/gateway/session.ts
@@ -39,6 +39,8 @@ export interface ThreadSession {
   agentId?: string;
   /** Process without persisting history */
   dryRun?: boolean;
+  /** Internal automation intent for one-shot system sessions. */
+  intent?: { kind: "watcher_run"; runId: number; watcherId: number };
   /**
    * True when the session was created without a caller-supplied agentId and
    * the gateway auto-provisioned both the agent and its settings. Only

--- a/packages/owletto-backend/src/lobu/gateway.ts
+++ b/packages/owletto-backend/src/lobu/gateway.ts
@@ -146,19 +146,13 @@ export async function initLobuGateway(): Promise<Hono | null> {
     const publicUrl = new URL('/lobu/', publicWebUrl).toString().replace(/\/$/, '');
     const env = process.env as unknown as Env;
 
-    // Embedded gateway shares the process with the Owletto OIDC provider — use
-    // it as the external auth issuer. Without MEMORY_URL set,
-    // ExternalAuthClient.fromEnv() returns null and the api-auth-middleware
-    // can't validate service tokens, so every dispatcher → /lobu/api/v1/agents
-    // call gets a 401 (silently fails the watcher run). Point at the local
-    // public origin so OIDC discovery + /oauth/userinfo resolve to ourselves.
-    if (!process.env.MEMORY_URL) {
-      process.env.MEMORY_URL = publicWebUrl;
-      logger.info({ memoryUrl: publicWebUrl }, '[Lobu] Defaulted MEMORY_URL for embedded auth');
-    }
-
+    // Embedded gateway shares the process with the app's OIDC provider — pass
+    // that issuer explicitly instead of overloading MEMORY_URL. LOBU memory MCP
+    // endpoints are resolved separately per organization/agent.
     const gatewayConfig = buildGatewayConfig({
       mcp: { publicGatewayUrl: publicUrl },
+      auth: { issuerUrl: publicWebUrl },
+      lobuMemory: { publicBaseUrl: publicWebUrl },
     });
 
     logger.info('[Lobu] Starting embedded orchestrator');

--- a/packages/owletto-backend/src/mcp-handler.ts
+++ b/packages/owletto-backend/src/mcp-handler.ts
@@ -800,7 +800,7 @@ export async function handleMcp(c: Context<{ Bindings: Env }>): Promise<Response
       const reauthOrigin = getConfiguredPublicOrigin() ?? new URL(req.url).origin;
       const remediation =
         authCtx.tokenType === 'pat'
-          ? `Reissue this PAT bound to a workspace (settings → personal access tokens) at ${reauthOrigin}.`
+          ? `Reissue this PAT bound to a workspace with \`lobu token create --org <workspace>\` against ${reauthOrigin}.`
           : `Re-authorize the OAuth client and pick a workspace at ${reauthOrigin}/oauth/authorize.`;
       return buildJsonRpcErrorResponse(
         `This token has no organization binding and cannot connect to /mcp. ${remediation}`,

--- a/packages/owletto-backend/src/sandbox/method-metadata.ts
+++ b/packages/owletto-backend/src/sandbox/method-metadata.ts
@@ -32,6 +32,10 @@ export const METHOD_METADATA: Record<string, MethodMetadata> = {
   },
 
   // entities
+  "entities.manage": {
+    summary: "Raw manage_entity action wrapper. Prefer named methods.",
+    access: "write",
+  },
   "entities.list": {
     summary:
       "List entities in the current organization with optional filters. Returns `{ action, entities, metadata }` where `entities` is the page and `metadata` carries `total_count`, `has_more`, `limit`, `offset`.",
@@ -101,6 +105,10 @@ export default async (_ctx, client) => {
   },
 
   // entitySchema
+  "entitySchema.manage": {
+    summary: "Raw manage_entity_schema action wrapper. Prefer named methods.",
+    access: "write",
+  },
   "entitySchema.listTypes": {
     summary: "List entity types in the organization.",
     access: "read",
@@ -198,6 +206,12 @@ export default async (_ctx, client) => {
   },
 
   // watchers
+  "watchers.manage": {
+    summary:
+      "Raw manage_watchers action wrapper. Prefer named methods such as watchers.trigger or watchers.createVersion.",
+    access: "external",
+    example: "await client.watchers.manage({ action: 'trigger', watcher_id: '42' });",
+  },
   "watchers.list": {
     summary:
       "List watchers, optionally filtered by entity. Returns `{ watchers: [...] }`.",
@@ -230,8 +244,24 @@ export default async (_ctx, client) => {
 };`,
   },
   "watchers.update": {
-    summary: "Update watcher config (schedule, model, sources).",
+    summary: "Update watcher config (schedule, agent, model, sources).",
     access: "write",
+  },
+  "watchers.createVersion": {
+    summary: "Create a new watcher template version.",
+    access: "write",
+  },
+  "watchers.upgrade": {
+    summary: "Move a watcher to another template version.",
+    access: "write",
+  },
+  "watchers.trigger": {
+    summary: "Trigger an immediate watcher run and dispatch it to its assigned agent.",
+    access: "external",
+    example: "await client.watchers.trigger(42);",
+    usageExample: `export default async (_ctx, client) => {
+  return client.watchers.trigger(42);
+};`,
   },
   "watchers.delete": {
     summary: "Delete one or more watchers.",
@@ -248,8 +278,36 @@ export default async (_ctx, client) => {
       "Submit LLM-extracted data for a watcher window. Requires a signed window_token.",
     access: "write",
   },
+  "watchers.getVersions": {
+    summary: "List template versions for a watcher.",
+    access: "read",
+  },
+  "watchers.getVersionDetails": {
+    summary: "Fetch a specific watcher template version.",
+    access: "read",
+  },
+  "watchers.getComponentReference": {
+    summary: "Return watcher UI/component reference documentation.",
+    access: "read",
+  },
+  "watchers.submitFeedback": {
+    summary: "Submit field-level corrections for a watcher window.",
+    access: "write",
+  },
+  "watchers.getFeedback": {
+    summary: "Read field-level feedback for a watcher, optionally scoped to a window.",
+    access: "read",
+  },
+  "watchers.createFromVersion": {
+    summary: "Create watchers for multiple entities from an existing watcher version.",
+    access: "write",
+  },
 
   // connections
+  "connections.manage": {
+    summary: "Raw manage_connections action wrapper. Prefer named methods.",
+    access: "external",
+  },
   "connections.list": {
     summary: "List configured connections in the current organization.",
     access: "read",
@@ -274,6 +332,10 @@ export default async (_ctx, client) => {
     access: "write",
   },
   "connections.delete": { summary: "Delete a connection.", access: "write" },
+  "connections.reauthenticate": {
+    summary: "Start a fresh auth flow for an existing connection.",
+    access: "write",
+  },
   "connections.test": {
     summary: "Test connection credentials (sends an external probe).",
     access: "external",
@@ -294,8 +356,24 @@ export default async (_ctx, client) => {
     summary: "Update org-wide auth config for a connector.",
     access: "write",
   },
+  "connections.updateConnectorDefaultConfig": {
+    summary: "Update a connector definition's default connection config.",
+    access: "write",
+  },
+  "connections.setConnectorEntityLinkOverrides": {
+    summary: "Set connector-level entity-link overrides.",
+    access: "write",
+  },
+  "connections.updateConnectorDefaultRepairAgent": {
+    summary: "Set or clear the connector's default repair agent.",
+    access: "write",
+  },
 
   // operations
+  "operations.manage": {
+    summary: "Raw manage_operations action wrapper. Prefer named methods.",
+    access: "external",
+  },
   "operations.listAvailable": {
     summary: "List operations exposed by the active connections.",
     access: "read",
@@ -320,6 +398,10 @@ export default async (_ctx, client) => {
   },
 
   // feeds
+  "feeds.manage": {
+    summary: "Raw manage_feeds action wrapper. Prefer named methods.",
+    access: "external",
+  },
   "feeds.list": { summary: "List data-sync feeds.", access: "read" },
   "feeds.get": { summary: "Get a feed by id.", access: "read" },
   "feeds.create": {
@@ -334,6 +416,10 @@ export default async (_ctx, client) => {
   },
 
   // authProfiles
+  "authProfiles.manage": {
+    summary: "Raw manage_auth_profiles action wrapper. Prefer named methods.",
+    access: "external",
+  },
   "authProfiles.list": {
     summary: "List reusable auth profiles.",
     access: "read",
@@ -360,6 +446,10 @@ export default async (_ctx, client) => {
   },
 
   // classifiers
+  "classifiers.manage": {
+    summary: "Raw manage_classifiers action wrapper. Prefer named methods.",
+    access: "write",
+  },
   "classifiers.list": {
     summary: "List classifier templates.",
     access: "read",
@@ -396,6 +486,10 @@ export default async (_ctx, client) => {
   },
 
   // viewTemplates
+  "viewTemplates.manage": {
+    summary: "Raw manage_view_templates action wrapper. Prefer named methods.",
+    access: "write",
+  },
   "viewTemplates.get": {
     summary: "Get the active view template for a resource.",
     access: "read",

--- a/packages/owletto-backend/src/sandbox/namespaces/action-call.ts
+++ b/packages/owletto-backend/src/sandbox/namespaces/action-call.ts
@@ -1,0 +1,16 @@
+import type { Env } from "../../index";
+import type { ToolContext } from "../../tools/registry";
+
+type AdminHandler = (args: any, env: Env, ctx: ToolContext) => Promise<unknown>;
+
+export function createActionCaller(handler: AdminHandler, env: Env, ctx: ToolContext) {
+  const manage = <T>(payload: Record<string, unknown>): Promise<T> =>
+    handler(payload as never, env, ctx) as Promise<T>;
+
+  const action = <T>(
+    actionName: string,
+    input: Record<string, unknown> = {},
+  ): Promise<T> => manage({ action: actionName, ...input });
+
+  return { manage, action };
+}

--- a/packages/owletto-backend/src/sandbox/namespaces/auth-profiles.ts
+++ b/packages/owletto-backend/src/sandbox/namespaces/auth-profiles.ts
@@ -14,6 +14,7 @@
 import type { Env } from "../../index";
 import { manageAuthProfiles } from "../../tools/admin/manage_auth_profiles";
 import type { ToolContext } from "../../tools/registry";
+import { createActionCaller } from "./action-call";
 
 export type AuthProfileKind =
   | "env"
@@ -46,6 +47,7 @@ export interface AuthProfileUpdateInput {
 }
 
 export interface AuthProfilesNamespace {
+  manage(input: Record<string, unknown>): Promise<unknown>;
   list(input?: {
     connector_key?: string;
     provider?: string;
@@ -65,22 +67,18 @@ export function buildAuthProfilesNamespace(
   ctx: ToolContext,
   env: Env,
 ): AuthProfilesNamespace {
-  const call = <T>(payload: Record<string, unknown>): Promise<T> =>
-    manageAuthProfiles(payload as never, env, ctx) as Promise<T>;
+  const { manage, action } = createActionCaller(manageAuthProfiles, env, ctx);
 
   return {
-    list: (input) => call({ action: "list_auth_profiles", ...input }),
+    manage,
+    list: (input) => action("list_auth_profiles", input),
     get: (auth_profile_slug) =>
-      call({ action: "get_auth_profile", auth_profile_slug }),
+      action("get_auth_profile", { auth_profile_slug }),
     test: (auth_profile_slug) =>
-      call({ action: "test_auth_profile", auth_profile_slug }),
-    create: (input) => call({ action: "create_auth_profile", ...input }),
-    update: (input) => call({ action: "update_auth_profile", ...input }),
+      action("test_auth_profile", { auth_profile_slug }),
+    create: (input) => action("create_auth_profile", input),
+    update: (input) => action("update_auth_profile", input),
     delete: (auth_profile_slug, options) =>
-      call({
-        action: "delete_auth_profile",
-        auth_profile_slug,
-        ...options,
-      }),
+      action("delete_auth_profile", { auth_profile_slug, ...options }),
   };
 }

--- a/packages/owletto-backend/src/sandbox/namespaces/classifiers.ts
+++ b/packages/owletto-backend/src/sandbox/namespaces/classifiers.ts
@@ -8,6 +8,7 @@
 import type { Env } from "../../index";
 import { manageClassifiers } from "../../tools/admin/manage_classifiers";
 import type { ToolContext } from "../../tools/registry";
+import { createActionCaller } from "./action-call";
 
 export interface ClassifierCreateInput {
   slug: string;
@@ -50,6 +51,7 @@ export interface ClassifierClassifyInput {
 }
 
 export interface ClassifiersNamespace {
+  manage(input: Record<string, unknown>): Promise<unknown>;
   list(input?: { entity_id?: number; status?: string }): Promise<unknown>;
   create(input: ClassifierCreateInput): Promise<unknown>;
   createVersion(input: ClassifierCreateVersionInput): Promise<unknown>;
@@ -70,20 +72,18 @@ export function buildClassifiersNamespace(
   ctx: ToolContext,
   env: Env,
 ): ClassifiersNamespace {
-  const call = <T>(payload: Record<string, unknown>): Promise<T> =>
-    manageClassifiers(payload as never, env, ctx) as Promise<T>;
+  const { manage, action } = createActionCaller(manageClassifiers, env, ctx);
 
   return {
-    list: (input) => call({ action: "list", ...input }),
-    create: (input) => call({ action: "create", ...input }),
-    createVersion: (input) => call({ action: "create_version", ...input }),
+    manage,
+    list: (input) => action("list", input),
+    create: (input) => action("create", input),
+    createVersion: (input) => action("create_version", input),
     getVersions: (classifier_id) =>
-      call({ action: "get_versions", classifier_id }),
-    setCurrentVersion: (input) =>
-      call({ action: "set_current_version", ...input }),
-    generateEmbeddings: (input) =>
-      call({ action: "generate_embeddings", ...input }),
-    delete: (classifier_id) => call({ action: "delete", classifier_id }),
-    classify: (input) => call({ action: "classify", ...input }),
+      action("get_versions", { classifier_id }),
+    setCurrentVersion: (input) => action("set_current_version", input),
+    generateEmbeddings: (input) => action("generate_embeddings", input),
+    delete: (classifier_id) => action("delete", { classifier_id }),
+    classify: (input) => action("classify", input),
   };
 }

--- a/packages/owletto-backend/src/sandbox/namespaces/connections.ts
+++ b/packages/owletto-backend/src/sandbox/namespaces/connections.ts
@@ -1,14 +1,15 @@
 /**
- * ClientSDK `connections` namespace. Thin wrapper over `manageConnections`.
+ * ClientSDK `connections` namespace. Thin, action-complete wrapper over
+ * `manageConnections`.
  *
- * `connect` is the entry point for setting up a new authenticated connection —
- * the handler returns a `connect_url` that the caller must surface to the
- * user's browser. Field names follow the handler schema.
+ * `connect` / `reauthenticate` return a `connect_url` the caller should show to
+ * the user. Field names follow the handler schema.
  */
 
 import type { Env } from "../../index";
 import { manageConnections } from "../../tools/admin/manage_connections";
 import type { ToolContext } from "../../tools/registry";
+import { createActionCaller } from "./action-call";
 
 export interface ConnectionsConnectInput {
   connector_key: string;
@@ -16,14 +17,10 @@ export interface ConnectionsConnectInput {
   auth_profile_slug?: string;
   app_auth_profile_slug?: string;
   config?: Record<string, unknown>;
+  entity_link_overrides?: Record<string, unknown> | null;
 }
 
-export interface ConnectionsCreateInput {
-  connector_key: string;
-  display_name?: string;
-  auth_profile_slug?: string;
-  app_auth_profile_slug?: string;
-  config?: Record<string, unknown>;
+export interface ConnectionsCreateInput extends ConnectionsConnectInput {
   created_by?: string;
 }
 
@@ -48,16 +45,27 @@ export interface ConnectionsInstallConnectorInput {
   compiled?: boolean;
   mcp_url?: string;
   auth_values?: Record<string, string>;
+  entity_link_overrides?: Record<string, unknown> | null;
 }
 
 export interface ConnectionsNamespace {
-  list(input?: { connector_key?: string }): Promise<unknown>;
-  listConnectorDefinitions(): Promise<unknown>;
+  /** Raw escape hatch for any manage_connections action. Prefer named methods. */
+  manage(input: Record<string, unknown>): Promise<unknown>;
+  list(input?: {
+    connector_key?: string;
+    status?: string;
+    entity_id?: number;
+    created_by?: string;
+    limit?: number;
+    offset?: number;
+  }): Promise<unknown>;
+  listConnectorDefinitions(input?: { include_installable?: boolean }): Promise<unknown>;
   get(connection_id: number): Promise<unknown>;
   create(input: ConnectionsCreateInput): Promise<unknown>;
   connect(input: ConnectionsConnectInput): Promise<unknown>;
   update(input: ConnectionsUpdateInput): Promise<unknown>;
   delete(connection_id: number): Promise<unknown>;
+  reauthenticate(connection_id: number): Promise<unknown>;
   test(connection_id: number): Promise<unknown>;
   installConnector(input: ConnectionsInstallConnectorInput): Promise<unknown>;
   uninstallConnector(connector_key: string): Promise<unknown>;
@@ -69,32 +77,49 @@ export interface ConnectionsNamespace {
     connector_key: string;
     auth_values: Record<string, string>;
   }): Promise<unknown>;
+  updateConnectorDefaultConfig(input: {
+    connector_key: string;
+    default_connection_config: Record<string, unknown>;
+  }): Promise<unknown>;
+  setConnectorEntityLinkOverrides(input: {
+    connector_key: string;
+    overrides: Record<string, unknown> | null;
+  }): Promise<unknown>;
+  updateConnectorDefaultRepairAgent(input: {
+    connector_key: string;
+    default_repair_agent_id: string | null;
+  }): Promise<unknown>;
 }
 
 export function buildConnectionsNamespace(
   ctx: ToolContext,
   env: Env,
 ): ConnectionsNamespace {
-  const call = <T>(payload: Record<string, unknown>): Promise<T> =>
-    manageConnections(payload as never, env, ctx) as Promise<T>;
+  const { manage, action } = createActionCaller(manageConnections, env, ctx);
 
   return {
-    list: (input) => call({ action: "list", ...input }),
-    listConnectorDefinitions: () =>
-      call({ action: "list_connector_definitions" }),
-    get: (connection_id) => call({ action: "get", connection_id }),
-    create: (input) => call({ action: "create", ...input }),
-    connect: (input) => call({ action: "connect", ...input }),
-    update: (input) => call({ action: "update", ...input }),
-    delete: (connection_id) => call({ action: "delete", connection_id }),
-    test: (connection_id) => call({ action: "test", connection_id }),
-    installConnector: (input) =>
-      call({ action: "install_connector", ...input }),
+    manage,
+    list: (input) => action("list", input),
+    listConnectorDefinitions: (input) =>
+      action("list_connector_definitions", input),
+    get: (connection_id) => action("get", { connection_id }),
+    create: (input) => action("create", input),
+    connect: (input) => action("connect", input),
+    update: (input) => action("update", input),
+    delete: (connection_id) => action("delete", { connection_id }),
+    reauthenticate: (connection_id) =>
+      action("reauthenticate", { connection_id }),
+    test: (connection_id) => action("test", { connection_id }),
+    installConnector: (input) => action("install_connector", input),
     uninstallConnector: (connector_key) =>
-      call({ action: "uninstall_connector", connector_key }),
-    toggleConnectorLogin: (input) =>
-      call({ action: "toggle_connector_login", ...input }),
-    updateConnectorAuth: (input) =>
-      call({ action: "update_connector_auth", ...input }),
+      action("uninstall_connector", { connector_key }),
+    toggleConnectorLogin: (input) => action("toggle_connector_login", input),
+    updateConnectorAuth: (input) => action("update_connector_auth", input),
+    updateConnectorDefaultConfig: (input) =>
+      action("update_connector_default_config", input),
+    setConnectorEntityLinkOverrides: (input) =>
+      action("set_connector_entity_link_overrides", input),
+    updateConnectorDefaultRepairAgent: (input) =>
+      action("update_connector_default_repair_agent", input),
   };
 }

--- a/packages/owletto-backend/src/sandbox/namespaces/entities.ts
+++ b/packages/owletto-backend/src/sandbox/namespaces/entities.ts
@@ -8,6 +8,7 @@
 import type { Env } from "../../index";
 import { manageEntity } from "../../tools/admin/manage_entity";
 import type { ToolContext } from "../../tools/registry";
+import { createActionCaller } from "./action-call";
 
 export interface EntityListFilter {
   entity_type?: string;
@@ -48,6 +49,7 @@ export interface EntityLinkInput {
 }
 
 export interface EntitiesNamespace {
+  manage(input: Record<string, unknown>): Promise<unknown>;
   list(filter?: EntityListFilter): Promise<unknown>;
   get(entity_id: number): Promise<unknown>;
   create(input: EntityCreateInput): Promise<unknown>;
@@ -81,82 +83,47 @@ export function buildEntitiesNamespace(
   ctx: ToolContext,
   env: Env
 ): EntitiesNamespace {
+  const { manage, action } = createActionCaller(manageEntity, env, ctx);
+
   return {
+    manage,
     list(filter) {
-      return manageEntity(
-        { action: "list", ...filter } as never,
-        env,
-        ctx
-      ) as Promise<unknown>;
+      return action("list", filter);
     },
     get(entity_id) {
-      return manageEntity(
-        { action: "get", entity_id } as never,
-        env,
-        ctx
-      ) as Promise<unknown>;
+      return action("get", { entity_id });
     },
     create(input) {
-      return manageEntity(
-        {
-          action: "create",
-          entity_type: input.type,
-          name: input.name,
-          slug: input.slug,
-          content: input.content,
-          parent_id: input.parent_id,
-          metadata: input.metadata,
-          enabled_classifiers: input.enabled_classifiers,
-        } as never,
-        env,
-        ctx
-      ) as Promise<unknown>;
+      return action("create", {
+        entity_type: input.type,
+        name: input.name,
+        slug: input.slug,
+        content: input.content,
+        parent_id: input.parent_id,
+        metadata: input.metadata,
+        enabled_classifiers: input.enabled_classifiers,
+      });
     },
     update(input) {
-      return manageEntity(
-        { action: "update", ...input } as never,
-        env,
-        ctx
-      ) as Promise<unknown>;
+      return action("update", input);
     },
     delete(entity_id, options) {
-      return manageEntity(
-        {
-          action: "delete",
-          entity_id,
-          force_delete_tree: options?.force_delete_tree,
-        } as never,
-        env,
-        ctx
-      ) as Promise<unknown>;
+      return action("delete", {
+        entity_id,
+        force_delete_tree: options?.force_delete_tree,
+      });
     },
     link(input) {
-      return manageEntity(
-        { action: "link", ...input } as never,
-        env,
-        ctx
-      ) as Promise<unknown>;
+      return action("link", input);
     },
     unlink(input) {
-      return manageEntity(
-        { action: "unlink", ...input } as never,
-        env,
-        ctx
-      ) as Promise<unknown>;
+      return action("unlink", input);
     },
     updateLink(input) {
-      return manageEntity(
-        { action: "update_link", ...input } as never,
-        env,
-        ctx
-      ) as Promise<unknown>;
+      return action("update_link", input);
     },
     listLinks(input) {
-      return manageEntity(
-        { action: "list_links", ...input } as never,
-        env,
-        ctx
-      ) as Promise<unknown>;
+      return action("list_links", input);
     },
     async search(query, options) {
       const { search } = await import("../../tools/search");

--- a/packages/owletto-backend/src/sandbox/namespaces/entity-schema.ts
+++ b/packages/owletto-backend/src/sandbox/namespaces/entity-schema.ts
@@ -11,6 +11,7 @@
 import type { Env } from "../../index";
 import { manageEntitySchema } from "../../tools/admin/manage_entity_schema";
 import type { ToolContext } from "../../tools/registry";
+import { createActionCaller } from "./action-call";
 
 export interface EntitySchemaAddRuleInput {
   slug: string;
@@ -21,6 +22,7 @@ export interface EntitySchemaAddRuleInput {
 }
 
 export interface EntitySchemaNamespace {
+  manage(input: Record<string, unknown>): Promise<unknown>;
   listTypes(): Promise<unknown>;
   getType(slug: string): Promise<unknown>;
   createType(input: {
@@ -69,20 +71,14 @@ export function buildEntitySchemaNamespace(
   ctx: ToolContext,
   env: Env,
 ): EntitySchemaNamespace {
+  const { manage, action } = createActionCaller(manageEntitySchema, env, ctx);
   const callEntity = <T>(payload: Record<string, unknown>): Promise<T> =>
-    manageEntitySchema(
-      { schema_type: "entity_type", ...payload } as never,
-      env,
-      ctx,
-    ) as Promise<T>;
+    action(payload.action as string, { schema_type: "entity_type", ...payload });
   const callRel = <T>(payload: Record<string, unknown>): Promise<T> =>
-    manageEntitySchema(
-      { schema_type: "relationship_type", ...payload } as never,
-      env,
-      ctx,
-    ) as Promise<T>;
+    action(payload.action as string, { schema_type: "relationship_type", ...payload });
 
   return {
+    manage,
     listTypes: () => callEntity({ action: "list" }),
     getType: (slug) => callEntity({ action: "get", slug }),
     createType: (input) => callEntity({ action: "create", ...input }),

--- a/packages/owletto-backend/src/sandbox/namespaces/feeds.ts
+++ b/packages/owletto-backend/src/sandbox/namespaces/feeds.ts
@@ -8,6 +8,7 @@
 import type { Env } from "../../index";
 import { manageFeeds } from "../../tools/admin/manage_feeds";
 import type { ToolContext } from "../../tools/registry";
+import { createActionCaller } from "./action-call";
 
 export interface FeedsCreateInput {
   connection_id: number;
@@ -19,6 +20,7 @@ export interface FeedsCreateInput {
 }
 
 export interface FeedsNamespace {
+  manage(input: Record<string, unknown>): Promise<unknown>;
   list(input?: { connection_id?: number }): Promise<unknown>;
   get(feed_id: number): Promise<unknown>;
   create(input: FeedsCreateInput): Promise<unknown>;
@@ -38,15 +40,15 @@ export function buildFeedsNamespace(
   ctx: ToolContext,
   env: Env,
 ): FeedsNamespace {
-  const call = <T>(payload: Record<string, unknown>): Promise<T> =>
-    manageFeeds(payload as never, env, ctx) as Promise<T>;
+  const { manage, action } = createActionCaller(manageFeeds, env, ctx);
 
   return {
-    list: (input) => call({ action: "list_feeds", ...input }),
-    get: (feed_id) => call({ action: "get_feed", feed_id }),
-    create: (input) => call({ action: "create_feed", ...input }),
-    update: (input) => call({ action: "update_feed", ...input }),
-    delete: (feed_id) => call({ action: "delete_feed", feed_id }),
-    trigger: (feed_id) => call({ action: "trigger_feed", feed_id }),
+    manage,
+    list: (input) => action("list_feeds", input),
+    get: (feed_id) => action("get_feed", { feed_id }),
+    create: (input) => action("create_feed", input),
+    update: (input) => action("update_feed", input),
+    delete: (feed_id) => action("delete_feed", { feed_id }),
+    trigger: (feed_id) => action("trigger_feed", { feed_id }),
   };
 }

--- a/packages/owletto-backend/src/sandbox/namespaces/operations.ts
+++ b/packages/owletto-backend/src/sandbox/namespaces/operations.ts
@@ -8,6 +8,7 @@
 import type { Env } from "../../index";
 import { manageOperations } from "../../tools/admin/manage_operations";
 import type { ToolContext } from "../../tools/registry";
+import { createActionCaller } from "./action-call";
 
 export interface OperationsExecuteInput {
   connection_id: number;
@@ -21,6 +22,7 @@ export interface OperationsExecuteInput {
 }
 
 export interface OperationsNamespace {
+  manage(input: Record<string, unknown>): Promise<unknown>;
   listAvailable(input?: { entity_id?: number }): Promise<unknown>;
   execute(input: OperationsExecuteInput): Promise<unknown>;
   listRuns(input?: {
@@ -43,15 +45,15 @@ export function buildOperationsNamespace(
   ctx: ToolContext,
   env: Env,
 ): OperationsNamespace {
-  const call = <T>(payload: Record<string, unknown>): Promise<T> =>
-    manageOperations(payload as never, env, ctx) as Promise<T>;
+  const { manage, action } = createActionCaller(manageOperations, env, ctx);
 
   return {
-    listAvailable: (input) => call({ action: "list_available", ...input }),
-    execute: (input) => call({ action: "execute", ...input }),
-    listRuns: (input) => call({ action: "list_runs", ...input }),
-    getRun: (run_id) => call({ action: "get_run", run_id }),
-    approve: (input) => call({ action: "approve", ...input }),
-    reject: (input) => call({ action: "reject", ...input }),
+    manage,
+    listAvailable: (input) => action("list_available", input),
+    execute: (input) => action("execute", input),
+    listRuns: (input) => action("list_runs", input),
+    getRun: (run_id) => action("get_run", { run_id }),
+    approve: (input) => action("approve", input),
+    reject: (input) => action("reject", input),
   };
 }

--- a/packages/owletto-backend/src/sandbox/namespaces/view-templates.ts
+++ b/packages/owletto-backend/src/sandbox/namespaces/view-templates.ts
@@ -10,6 +10,7 @@
 import type { Env } from "../../index";
 import { manageViewTemplates } from "../../tools/admin/manage_view_templates";
 import type { ToolContext } from "../../tools/registry";
+import { createActionCaller } from "./action-call";
 
 type ResourceType = "entity_type" | "entity";
 type ResourceId = string | number;
@@ -24,6 +25,7 @@ export interface ViewTemplateSetInput {
 }
 
 export interface ViewTemplatesNamespace {
+  manage(input: Record<string, unknown>): Promise<unknown>;
   get(input: {
     resource_type: ResourceType;
     resource_id: ResourceId;
@@ -48,13 +50,13 @@ export function buildViewTemplatesNamespace(
   ctx: ToolContext,
   env: Env,
 ): ViewTemplatesNamespace {
-  const call = <T>(payload: Record<string, unknown>): Promise<T> =>
-    manageViewTemplates(payload as never, env, ctx) as Promise<T>;
+  const { manage, action } = createActionCaller(manageViewTemplates, env, ctx);
 
   return {
-    get: (input) => call({ action: "get", ...input }),
-    set: (input) => call({ action: "set", ...input }),
-    rollback: (input) => call({ action: "rollback", ...input }),
-    removeTab: (input) => call({ action: "remove_tab", ...input }),
+    manage,
+    get: (input) => action("get", input),
+    set: (input) => action("set", input),
+    rollback: (input) => action("rollback", input),
+    removeTab: (input) => action("remove_tab", input),
   };
 }

--- a/packages/owletto-backend/src/sandbox/namespaces/watchers.ts
+++ b/packages/owletto-backend/src/sandbox/namespaces/watchers.ts
@@ -1,21 +1,26 @@
 /**
- * ClientSDK `watchers` namespace. Thin wrapper over `manageWatchers` +
- * `listWatchers` + `getWatcher`.
+ * ClientSDK `watchers` namespace. Thin, action-complete wrapper over
+ * `manageWatchers` + `listWatchers` + `getWatcher`.
  *
- * Field names mirror the underlying handlers (see
- * `packages/owletto-backend/src/tools/admin/manage_watchers.ts`):
- * - `watcher_id` is a numeric string
- * - `delete` takes `watcher_ids: string[]`
- * - `complete_window` requires `window_token` (JWT) not a raw window id
- * - `set_reaction_script` uses `reaction_script` as the source field
+ * Keep this surface in sync with `ManageWatchersSchema`: every
+ * `manage_watchers.action` should either have a named SDK method below or be
+ * reachable via `watchers.manage({ action, ... })`.
  */
 
 import type { Env } from "../../index";
 import {
   listWatchers,
   manageWatchers,
+  type ManageWatchersArgs,
 } from "../../tools/admin/manage_watchers";
 import type { ToolContext } from "../../tools/registry";
+import { createActionCaller } from "./action-call";
+
+type WatcherId = string | number;
+type Source = { name: string; query: string };
+type WatcherActionInput = Omit<ManageWatchersArgs, "action" | "watcher_id"> & {
+  watcher_id?: WatcherId;
+};
 
 export interface WatcherListFilter {
   entity_id?: number;
@@ -28,7 +33,7 @@ export interface WatcherCreateInput {
   entity_id: number;
   prompt: string;
   extraction_schema: Record<string, unknown>;
-  sources?: Array<{ name: string; query: string }>;
+  sources?: Source[];
   schedule?: string;
   slug?: string;
   name?: string;
@@ -37,63 +42,132 @@ export interface WatcherCreateInput {
   keying_config?: Record<string, unknown>;
   classifiers?: Record<string, unknown>;
   condensation_prompt?: string;
+  condensation_window_count?: number;
   reactions_guidance?: string;
   agent_id?: string;
+  scheduler_client_id?: string;
+  model_config?: Record<string, unknown>;
   tags?: string[];
 }
 
 export interface WatcherUpdateInput {
-  watcher_id: string;
+  watcher_id: WatcherId;
   schedule?: string;
   agent_id?: string;
+  scheduler_client_id?: string;
   model_config?: Record<string, unknown>;
-  sources?: Array<{ name: string; query: string }>;
+  sources?: Source[];
 }
 
 export interface WatcherCompleteWindowInput {
-  watcher_id: string;
+  watcher_id: WatcherId;
   /** JWT obtained from read_knowledge(watcher_id, since, until). */
   window_token: string;
   extracted_data: Record<string, unknown>;
   replace_existing?: boolean;
+  client_id?: string;
   model?: string;
   run_metadata?: Record<string, unknown>;
+  template_version_id?: number;
+}
+
+export interface WatcherCreateVersionInput extends WatcherActionInput {
+  watcher_id: WatcherId;
+}
+
+export interface WatcherUpgradeInput {
+  watcher_id: WatcherId;
+  target_version?: number;
+  version?: number;
+}
+
+export interface WatcherVersionDetailsInput {
+  watcher_id: WatcherId;
+  version?: number;
+}
+
+export interface WatcherSubmitFeedbackInput {
+  watcher_id: WatcherId;
+  window_id: number;
+  corrections: Array<{
+    field_path: string;
+    mutation?: "set" | "remove" | "add";
+    value?: unknown;
+    note?: string;
+  }>;
+}
+
+export interface WatcherGetFeedbackInput {
+  watcher_id: WatcherId;
+  window_id?: number;
+  limit?: number;
+}
+
+export interface WatcherCreateFromVersionInput {
+  version_id: number;
+  entity_ids: number[];
+  name_pattern?: string;
 }
 
 export interface WatchersNamespace {
+  /** Raw escape hatch for any manage_watchers action. Prefer named methods. */
+  manage(input: ManageWatchersArgs): Promise<unknown>;
   list(filter?: WatcherListFilter): Promise<unknown>;
-  get(watcher_id: string | number): Promise<unknown>;
+  get(watcher_id: WatcherId): Promise<unknown>;
   create(input: WatcherCreateInput): Promise<unknown>;
   update(input: WatcherUpdateInput): Promise<unknown>;
-  /**
-   * Delete one or more watchers. Accepts a single id or an array; internally
-   * dispatched as `watcher_ids`.
-   */
-  delete(watcher_id: string | string[]): Promise<unknown>;
+  createVersion(input: WatcherCreateVersionInput): Promise<unknown>;
+  upgrade(input: WatcherUpgradeInput): Promise<unknown>;
+  completeWindow(input: WatcherCompleteWindowInput): Promise<unknown>;
+  trigger(watcher_id: WatcherId): Promise<unknown>;
+  /** Delete one or more watchers. */
+  delete(watcher_id: WatcherId | WatcherId[]): Promise<unknown>;
   setReactionScript(input: {
-    watcher_id: string;
-    /** TypeScript source. Empty string removes the script. */
+    watcher_id: WatcherId;
+    /** TypeScript source. Empty string removes it. */
     reaction_script: string;
   }): Promise<unknown>;
-  completeWindow(input: WatcherCompleteWindowInput): Promise<unknown>;
+  getVersions(watcher_id: WatcherId): Promise<unknown>;
+  getVersionDetails(input: WatcherId | WatcherVersionDetailsInput): Promise<unknown>;
+  getComponentReference(): Promise<unknown>;
+  submitFeedback(input: WatcherSubmitFeedbackInput): Promise<unknown>;
+  getFeedback(input: WatcherGetFeedbackInput): Promise<unknown>;
+  createFromVersion(input: WatcherCreateFromVersionInput): Promise<unknown>;
 }
 
-function asWatcherIdString(v: string | number): string {
+function asWatcherIdString(v: WatcherId): string {
   return typeof v === "number" ? String(v) : v;
+}
+
+function normalizeWatcherId<T extends { watcher_id?: WatcherId }>(
+  input: T,
+): Omit<T, "watcher_id"> & { watcher_id?: string } {
+  return {
+    ...input,
+    ...(input.watcher_id !== undefined
+      ? { watcher_id: asWatcherIdString(input.watcher_id) }
+      : {}),
+  };
+}
+
+function normalizeVersionDetailsInput(
+  input: WatcherId | WatcherVersionDetailsInput,
+): { watcher_id: string; version?: number } {
+  if (typeof input === "string" || typeof input === "number") {
+    return { watcher_id: asWatcherIdString(input) };
+  }
+  return normalizeWatcherId(input) as { watcher_id: string; version?: number };
 }
 
 export function buildWatchersNamespace(
   ctx: ToolContext,
   env: Env,
 ): WatchersNamespace {
+  const { manage, action } = createActionCaller(manageWatchers, env, ctx);
+
   return {
-    list(filter) {
-      return listWatchers(
-        (filter ?? {}) as never,
-        env,
-        ctx,
-      ) as Promise<unknown>;
-    },
+    manage: (input) => manage(input as Record<string, unknown>),
+    list: (filter) => listWatchers((filter ?? {}) as never, env, ctx) as Promise<unknown>,
     async get(watcher_id) {
       const { getWatcher } = await import("../../tools/get_watchers");
       return getWatcher(
@@ -102,55 +176,25 @@ export function buildWatchersNamespace(
         ctx,
       ) as Promise<unknown>;
     },
-    create(input) {
-      return manageWatchers(
-        { action: "create", ...input } as never,
-        env,
-        ctx,
-      ) as Promise<unknown>;
-    },
-    update(input) {
-      return manageWatchers(
-        {
-          action: "update",
-          ...input,
-          watcher_id: asWatcherIdString(input.watcher_id),
-        } as never,
-        env,
-        ctx,
-      ) as Promise<unknown>;
-    },
+    create: (input) => action("create", input),
+    update: (input) => action("update", normalizeWatcherId(input)),
+    createVersion: (input) => action("create_version", normalizeWatcherId(input)),
+    upgrade: (input) => action("upgrade", normalizeWatcherId(input)),
+    completeWindow: (input) => action("complete_window", normalizeWatcherId(input)),
+    trigger: (watcher_id) => action("trigger", { watcher_id: asWatcherIdString(watcher_id) }),
     delete(watcher_id) {
       const watcher_ids = Array.isArray(watcher_id)
         ? watcher_id.map(asWatcherIdString)
         : [asWatcherIdString(watcher_id)];
-      return manageWatchers(
-        { action: "delete", watcher_ids } as never,
-        env,
-        ctx,
-      ) as Promise<unknown>;
+      return action("delete", { watcher_ids });
     },
-    setReactionScript(input) {
-      return manageWatchers(
-        {
-          action: "set_reaction_script",
-          watcher_id: asWatcherIdString(input.watcher_id),
-          reaction_script: input.reaction_script,
-        } as never,
-        env,
-        ctx,
-      ) as Promise<unknown>;
-    },
-    completeWindow(input) {
-      return manageWatchers(
-        {
-          action: "complete_window",
-          ...input,
-          watcher_id: asWatcherIdString(input.watcher_id),
-        } as never,
-        env,
-        ctx,
-      ) as Promise<unknown>;
-    },
+    setReactionScript: (input) => action("set_reaction_script", normalizeWatcherId(input)),
+    getVersions: (watcher_id) =>
+      action("get_versions", { watcher_id: asWatcherIdString(watcher_id) }),
+    getVersionDetails: (input) => action("get_version_details", normalizeVersionDetailsInput(input)),
+    getComponentReference: () => action("get_component_reference"),
+    submitFeedback: (input) => action("submit_feedback", normalizeWatcherId(input)),
+    getFeedback: (input) => action("get_feedback", normalizeWatcherId(input)),
+    createFromVersion: (input) => action("create_from_version", input),
   };
 }

--- a/packages/owletto-backend/src/tools/admin/__tests__/query_sql.test.ts
+++ b/packages/owletto-backend/src/tools/admin/__tests__/query_sql.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+import type { ToolContext } from '../../registry';
+import { querySql } from '../query_sql';
+
+type QuerySqlArgs = Parameters<typeof querySql>[0];
+
+const ctx: ToolContext = {
+  organizationId: 'org_123',
+  userId: 'user_123',
+  memberRole: 'admin',
+  isAuthenticated: true,
+  tokenType: 'oauth',
+  scopedToOrg: false,
+  allowCrossOrg: true,
+};
+
+describe('querySql input validation', () => {
+  it('returns a structured error when callers send query instead of sql', async () => {
+    const result = await querySql(
+      { query: 'select * from events', sort_by: 'id' } as unknown as QuerySqlArgs,
+      {},
+      ctx
+    );
+
+    expect(result.error).toBe('sql (string) is required.');
+    expect(result.rows).toEqual([]);
+    expect(result.total_count).toBe(0);
+  });
+
+  it('returns a structured error when tool arguments are not an object', async () => {
+    const result = await querySql(null as unknown as QuerySqlArgs, {}, ctx);
+
+    expect(result.error).toBe('Tool arguments must be an object.');
+    expect(result.rows).toEqual([]);
+    expect(result.total_count).toBe(0);
+  });
+
+  it('requires an explicit sort_by column before building SQL', async () => {
+    const result = await querySql(
+      { sql: 'select * from events' } as unknown as QuerySqlArgs,
+      {},
+      ctx
+    );
+
+    expect(result.error).toBe('sort_by (string column name) is required.');
+  });
+});

--- a/packages/owletto-backend/src/tools/admin/manage_watchers.ts
+++ b/packages/owletto-backend/src/tools/admin/manage_watchers.ts
@@ -523,7 +523,7 @@ export const ManageWatchersSchema = Type.Object({
 // Type Definitions
 // ============================================
 
-type ManageWatchersArgs = Static<typeof ManageWatchersSchema>;
+export type ManageWatchersArgs = Static<typeof ManageWatchersSchema>;
 
 interface WatcherOperationResult {
   watcher_id: string;

--- a/packages/owletto-backend/src/watchers/automation.ts
+++ b/packages/owletto-backend/src/watchers/automation.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from 'node:crypto';
+import { generateWorkerToken } from '@lobu/core';
 import { inferWatcherGranularityFromSchedule } from '@lobu/owletto-sdk';
 import type { DbClient } from '../db/client';
 import { getDb } from '../db/client';
@@ -433,7 +434,7 @@ function buildDispatchMessage(params: {
     : '';
 
   return [
-    'Run this Owletto watcher now using the Owletto MCP tools.',
+    'Run this watcher now using the lobu-memory MCP tools.',
     '',
     `Watcher ID: ${params.watcherId}`,
     `Watcher run ID: ${params.runId}`,
@@ -524,6 +525,61 @@ async function ensureWatcherAgentExists(
   return rows.length > 0;
 }
 
+const LOBU_MEMORY_MCP_ID = 'lobu-memory';
+const WATCHER_REQUIRED_TOOLS = ['read_knowledge', 'manage_watchers'];
+
+async function preflightWatcherMemoryTools(params: {
+  port: string;
+  agentId: string;
+  runId: number;
+}): Promise<{ ok: true } | { ok: false; error: string }> {
+  const conversationId = `${params.agentId}_watcher_${params.runId}_preflight`;
+  const token = generateWorkerToken(params.agentId, conversationId, `watcher-${params.runId}`, {
+    channelId: `api_watcher_${params.runId}`,
+    agentId: params.agentId,
+    platform: 'api',
+    sessionKey: `watcher_${params.runId}`,
+  });
+  const url = `http://127.0.0.1:${params.port}/lobu/mcp/${LOBU_MEMORY_MCP_ID}/tools`;
+
+  try {
+    const response = await fetch(url, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    const body = (await response.json().catch(() => null)) as
+      | { tools?: Array<{ name?: unknown }>; error?: unknown }
+      | null;
+
+    if (!response.ok) {
+      const detail = typeof body?.error === 'string' ? body.error : response.statusText;
+      return {
+        ok: false,
+        error: `${LOBU_MEMORY_MCP_ID} tools preflight failed (${response.status}): ${detail}`,
+      };
+    }
+
+    const toolNames = new Set(
+      (body?.tools ?? [])
+        .map((tool) => (typeof tool.name === 'string' ? tool.name : ''))
+        .filter(Boolean)
+    );
+    const missing = WATCHER_REQUIRED_TOOLS.filter((name) => !toolNames.has(name));
+    if (missing.length > 0) {
+      return {
+        ok: false,
+        error: `${LOBU_MEMORY_MCP_ID} tools preflight failed: missing ${missing.join(', ')}`,
+      };
+    }
+
+    return { ok: true };
+  } catch (error) {
+    return {
+      ok: false,
+      error: `${LOBU_MEMORY_MCP_ID} tools preflight failed: ${error instanceof Error ? error.message : String(error)}`,
+    };
+  }
+}
+
 async function dispatchWatcherRun(
   sql: DbClient,
   run: ClaimedWatcherRunRow
@@ -562,6 +618,16 @@ async function dispatchWatcherRun(
   }
 
   const port = process.env.PORT || '8787';
+  const preflight = await preflightWatcherMemoryTools({
+    port,
+    agentId: payload.agent_id,
+    runId: run.id,
+  });
+  if (!preflight.ok) {
+    await failWatcherRun(sql, run.id, preflight.error);
+    return 'failed';
+  }
+
   const baseUrl = `http://127.0.0.1:${port}/lobu/api/v1/agents`;
   const headers = {
     Authorization: `Bearer ${serviceToken}`,
@@ -573,7 +639,12 @@ async function dispatchWatcherRun(
     const sessionResponse = await fetch(baseUrl, {
       method: 'POST',
       headers,
-      body: JSON.stringify({ agentId: payload.agent_id }),
+      body: JSON.stringify({
+        agentId: payload.agent_id,
+        forceNew: true,
+        dryRun: false,
+        intent: { kind: 'watcher_run', runId: run.id, watcherId: run.watcher_id },
+      }),
     });
 
     if (!sessionResponse.ok) {
@@ -682,7 +753,7 @@ function registerWatcherRunHandle(params: {
         return;
       }
       // Fail closed when the agent's reply finished but no window was
-      // produced. Without this guard a no-op agent (no Owletto MCP, missing
+      // produced. Without this guard a no-op agent (no lobu-memory MCP, missing
       // tools, or a chatty reply that skipped read_knowledge / complete_window)
       // would silently mark the run "completed" — which is what masked the
       // Reddit watcher being broken for a week. complete_window is the only
@@ -693,7 +764,7 @@ function registerWatcherRunHandle(params: {
           db,
           params.runId,
           'Agent reply finished without calling manage_watchers(action="complete_window"). ' +
-            'Check that the assigned agent has the Owletto MCP attached and that read_knowledge / ' +
+            'Check that the assigned agent has the lobu-memory MCP attached and that read_knowledge / ' +
             'manage_watchers tools are approved for it.'
         );
         return;

--- a/packages/owletto-backend/src/watchers/run-completion.ts
+++ b/packages/owletto-backend/src/watchers/run-completion.ts
@@ -1,0 +1,96 @@
+import type { DbClient } from '../db/client';
+import { getDb } from '../db/client';
+import { ACTIVE_RUN_STATUSES, runStatusLiteral } from '../utils/run-statuses';
+
+export type WatcherTerminalResult = { ok: true } | { ok: false; error: string };
+
+async function findWindowIdForRun(sql: DbClient, runId: number): Promise<number | null> {
+  const rows = await sql`
+    SELECT id
+    FROM watcher_windows
+    WHERE run_id = ${runId}
+    ORDER BY id DESC
+    LIMIT 1
+  `;
+
+  return rows.length > 0 ? Number((rows[0] as { id: unknown }).id) : null;
+}
+
+async function markWatcherRunCompleted(
+  sql: DbClient,
+  runId: number,
+  windowId: number | null
+): Promise<void> {
+  await sql`
+    UPDATE runs
+    SET status = 'completed',
+        window_id = ${windowId},
+        completed_at = current_timestamp,
+        error_message = NULL
+    WHERE id = ${runId}
+      AND status = ANY(${runStatusLiteral(ACTIVE_RUN_STATUSES)}::text[])
+  `;
+}
+
+async function markWatcherRunFailed(
+  sql: DbClient,
+  runId: number,
+  message: string
+): Promise<void> {
+  await sql`
+    UPDATE runs
+    SET status = 'failed',
+        completed_at = current_timestamp,
+        error_message = ${message}
+    WHERE id = ${runId}
+      AND status = ANY(${runStatusLiteral(ACTIVE_RUN_STATUSES)}::text[])
+  `;
+}
+
+export async function resolveWatcherRunsByMessageIds(
+  messageIds: Iterable<string>,
+  result: WatcherTerminalResult,
+  db?: DbClient
+): Promise<{ resolved: number }> {
+  const ids = Array.from(new Set(Array.from(messageIds).filter(Boolean)));
+  if (ids.length === 0) return { resolved: 0 };
+
+  const sql = db ?? getDb();
+  const rows = await sql`
+    SELECT id
+    FROM runs
+    WHERE run_type = 'watcher'
+      AND dispatched_message_id = ANY(${ids}::text[])
+      AND status = ANY(${runStatusLiteral(ACTIVE_RUN_STATUSES)}::text[])
+  `;
+
+  let resolved = 0;
+  for (const row of rows) {
+    const runId = Number((row as { id: unknown }).id);
+    if (!Number.isFinite(runId)) continue;
+
+    if (!result.ok) {
+      await markWatcherRunFailed(sql, runId, result.error);
+      resolved++;
+      continue;
+    }
+
+    const windowId = await findWindowIdForRun(sql, runId);
+    if (windowId === null) {
+      await markWatcherRunFailed(
+        sql,
+        runId,
+        'Agent reply finished without calling manage_watchers(action="complete_window"). ' +
+          'Check that the assigned agent has the lobu-memory MCP attached and that read_knowledge / ' +
+          'manage_watchers tools are approved for it.'
+      );
+      resolved++;
+      continue;
+    }
+
+    await markWatcherRunCompleted(sql, runId, windowId);
+    resolved++;
+  }
+
+  return { resolved };
+}


### PR DESCRIPTION
## Summary

Adds dark mode support to the landing page with automatic system preference detection and hash-based override.

### Changes
- **Dark mode foundation**: Add CSS custom properties for light/dark color tokens with `prefers-color-scheme` media queries
- **Tailwind v4 cascade fix**: Move color tokens out of `@theme` and apply via inline script to beat Tailwind's cascade ordering
- **Hardcoded color cleanup**: Replace remaining hardcoded white backgrounds in skills & hosting graphics with theme tokens
- **Theme toggle removal**: Remove manual toggle in favor of system preference with `#dark`/`#light` hash override
- **Docs dark mode**: Apply dark theme to Starlight docs, code blocks, and API reference pages
- **Starlight sync**: Sync `starlight-theme` localStorage so docs respect the hash override

### Testing
- Verify landing page renders correctly in both light and dark mode (toggle via system preferences or URL hash `#dark`/`#light`)
- Verify docs pages follow the same theme
- Verify code blocks and API reference respect dark mode
