### PR TITLE
fix: remove @types/node from overrides to resolve EOVERRIDE

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,4 @@
   "patchedDependencies": {
     "@chat-adapter/telegram@4.20.0": "patches/@chat-adapter%2Ftelegram@4.20.0.patch"
   },
-  "overrides": {
-    "@types/node": "20.19.9"
-  }
 }


### PR DESCRIPTION
## Problem

Users running the CLI init command from the repo root hit an immediate failure:

```
error code EOVERRIDE
Override for @types/node@^20.0.0 conflicts with direct dependency
```

## Root cause

`package.json` declares `@types/node` in two conflicting places:

```json
"devDependencies": {
  "@types/node": "^20.0.0"
},
"overrides": {
  "@types/node": "20.19.9"
}
```

The package manager spec forbids an `overrides` entry from targeting a direct dependency. `bun install` is lenient and silently ignores this — which is why it was never caught during development. But the `npx` resolver enforces the rule strictly, causing every CLI invocation from the repo directory to fail before even downloading the package.

## Fix

Remove the `@types/node` entry from `overrides`. It is redundant — `20.19.9` already satisfies `^20.0.0`.

## How to test

1. Restore the `overrides` block temporarily
2. Run `npx @lobu/cli@latest` from the repo root — observe `EOVERRIDE`
3. Remove the `overrides` block
4. Run `npx @lobu/cli@latest` again — CLI launches normally

Alternatively: `bun install` should complete cleanly with no warnings.

Fixes #500
