### PR TITLE
docs(agents): simplify submodule rule + persist app workspaces via PVC

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,7 @@
 - When fixing unused-parameter errors, delete the parameter rather than prefixing with `_`.
 
 ### Submodules
-`packages/web` is a submodule of `lobu-ai/owletto-web`. Every change there ships as **two PRs**: (1) land the submodule PR; (2) open a parent PR that bumps the pointer. Never push a parent commit that references an unmerged submodule SHA — production resolves SHAs from the parent and will break. After the submodule PR merges: `git -C packages/web pull --ff-only origin main`, stage the submodule in the parent, open the bump PR.
+`packages/web` is a submodule of `lobu-ai/owletto-web`. Push the submodule change to a reachable branch first (usually `main`), then bump the pointer in the parent — the parent must never point at an unreachable SHA, or production cloning will fail.
 
 ### Frontend (web)
 When editing UI under `packages/web`, follow the design rules in @packages/web/DESIGN_GUIDELINES.md — confirmations, surfaces, empty states, selection, forms, page copy, radius, Sheet vs Dialog. Match the existing components and exemplar files referenced there; do not introduce new primitives without updating the guideline in the same PR.


### PR DESCRIPTION
## Summary

- **AGENTS.md**: drop the strict "two PRs in sequence" submodule ceremony; keep the one underlying correctness rule (parent must never point at an unreachable submodule SHA).
- **Pairs with submodule PR**: [lobu-ai/owletto-web#62](https://github.com/lobu-ai/owletto-web/pull/62) — adds an RWO PVC mounted at `/app/workspaces` so per-session OpenClaw state (`session.jsonl`) survives pod restarts. Today the dir lives in the container overlay layer and is wiped on every restart/redeploy/OOM, silently resetting agent context across deploys.

## Why

Production today silently loses session state on every pod restart because nothing mounts at `workspaces/`. The PVC fixes that with the same RWO + `Recreate` strategy pattern already used by the worker/embeddings cache PVCs.

## Test plan

- [x] `helm template` / `helm lint` clean on the submodule PR
- [ ] After lobu-ai/owletto-web#62 merges, this PR will get a follow-up commit bumping the submodule pointer
- [ ] Deploy to a test cluster, restart pod, confirm `workspaces/` survives
- [ ] First prod deploy will trigger ~10-30s downtime (rolling → Recreate transition)

## Sequencing

Per the new AGENTS.md rule, this parent PR will only get the submodule pointer bump *after* the submodule PR merges to `lobu-ai/owletto-web` main, so the SHA stays reachable.