### PR TITLE
fix(publish): add re-export shims to deprecated redirect packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,18 @@ packages/**/*.d.ts.map
 !packages/cli/bin/*.js
 # Hand-authored type shims for optional native modules (not build output)
 !packages/**/src/types/*.d.ts
+# Redirect packages publish a hand-written index.js + index.d.ts shim
+# (no build step — they re-export from the renamed package).
+!packages/owletto-sdk/index.js
+!packages/owletto-sdk/index.d.ts
+!packages/owletto-connectors/index.js
+!packages/owletto-connectors/index.d.ts
+!packages/owletto-worker/index.js
+!packages/owletto-worker/index.d.ts
+!packages/owletto-embeddings/index.js
+!packages/owletto-embeddings/index.d.ts
+!packages/owletto-openclaw/index.js
+!packages/owletto-openclaw/index.d.ts
 tsconfig.tsbuildinfo
 **/tsconfig.tsbuildinfo
 

--- a/packages/owletto-connectors/index.d.ts
+++ b/packages/owletto-connectors/index.d.ts
@@ -1,0 +1,1 @@
+export * from "@lobu/connectors";

--- a/packages/owletto-connectors/index.js
+++ b/packages/owletto-connectors/index.js
@@ -1,0 +1,2 @@
+// Compatibility redirect: this package was renamed to @lobu/connectors.
+export * from "@lobu/connectors";

--- a/packages/owletto-embeddings/index.d.ts
+++ b/packages/owletto-embeddings/index.d.ts
@@ -1,0 +1,1 @@
+export * from "@lobu/embeddings";

--- a/packages/owletto-embeddings/index.js
+++ b/packages/owletto-embeddings/index.js
@@ -1,0 +1,2 @@
+// Compatibility redirect: this package was renamed to @lobu/embeddings.
+export * from "@lobu/embeddings";

--- a/packages/owletto-openclaw/index.d.ts
+++ b/packages/owletto-openclaw/index.d.ts
@@ -1,0 +1,2 @@
+export { default } from "@lobu/openclaw-plugin";
+export * from "@lobu/openclaw-plugin";

--- a/packages/owletto-openclaw/index.js
+++ b/packages/owletto-openclaw/index.js
@@ -1,0 +1,5 @@
+// Compatibility redirect: this package was renamed to @lobu/openclaw-plugin.
+// Re-export the default plugin object plus any named exports so OpenClaw
+// runtime (which loads via openclaw.plugin.json's `entry` field) keeps working.
+export { default } from "@lobu/openclaw-plugin";
+export * from "@lobu/openclaw-plugin";

--- a/packages/owletto-sdk/index.d.ts
+++ b/packages/owletto-sdk/index.d.ts
@@ -1,0 +1,1 @@
+export * from "@lobu/connector-sdk";

--- a/packages/owletto-sdk/index.js
+++ b/packages/owletto-sdk/index.js
@@ -1,0 +1,3 @@
+// Compatibility redirect: this package was renamed to @lobu/connector-sdk.
+// Re-export everything so existing `import … from '@lobu/owletto-sdk'` works.
+export * from "@lobu/connector-sdk";

--- a/packages/owletto-worker/index.d.ts
+++ b/packages/owletto-worker/index.d.ts
@@ -1,0 +1,1 @@
+export * from "@lobu/connector-worker";

--- a/packages/owletto-worker/index.js
+++ b/packages/owletto-worker/index.js
@@ -1,0 +1,2 @@
+// Compatibility redirect: this package was renamed to @lobu/connector-worker.
+export * from "@lobu/connector-worker";


### PR DESCRIPTION
## Summary
The five redirect packages (`@lobu/owletto-{sdk,connectors,worker,embeddings,openclaw}`) declare `main: index.js` but had no `index.js` on disk. Published tarballs contained only `package.json`, so anyone migrating gradually after #499 hit `ERR_MODULE_NOT_FOUND` on `import … from '@lobu/owletto-sdk'`.

This adds hand-written `index.js` + `index.d.ts` re-export shims to each redirect package. `owletto-openclaw` also forwards the default export (the OpenClaw plugin object). `.gitignore` gets an allowlist so the existing `packages/**/*.js` dist-suppression rule doesn't strip these source files.

## Why this wasn't caught
The publish dry-run that PR #499 ran (`npm pack --dry-run --json`) succeeded — npm doesn't verify that the files declared in `package.json` actually exist. The breakage only surfaces at `require`/`import` time on a real install. Verified now end-to-end (see Test plan).

## Test plan
- [x] `bunx --bun npm pack --dry-run` shows index.js + index.d.ts in every redirect tarball.
- [x] `bun run typecheck` clean.
- [x] Real install: packed `@lobu/owletto-sdk@6.0.0`, installed in a fresh project alongside `@lobu/connector-sdk`, ran `import * as m from '@lobu/owletto-sdk'` → 71 named exports forwarded, `ConnectorRuntime` resolves, deprecation message present in `package.json`.
- [x] `bun -e "import plugin from '@lobu/owletto-openclaw'"` returns the OpenClaw plugin object with `id`, `name`, `description`, `kind`, `register`.

## Out of scope
- `@lobu/connectors` itself uses Bun-specific `import 'npm:turndown@7.2.2'` syntax that doesn't resolve under standard Node ESM. Pre-existing in the package source — not introduced by this PR or by #499. Worth a follow-up but separate concern.