### PR TITLE
fix(ci): restore owletto-* image names so prod can pull them

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -16,8 +16,8 @@ env:
   # tracking ghcr.io/lobu-ai/owletto-{app,worker,embeddings} after the
   # owletto -> lobu monorepo consolidation.
   IMAGE_NAME_APP: lobu-ai/owletto-app
-  IMAGE_NAME_WORKER: lobu-ai/connector-worker
-  IMAGE_NAME_EMBEDDINGS: lobu-ai/embeddings
+  IMAGE_NAME_WORKER: lobu-ai/owletto-worker
+  IMAGE_NAME_EMBEDDINGS: lobu-ai/owletto-embeddings
 
 jobs:
   generate-tag:
@@ -140,7 +140,7 @@ jobs:
             -H "Accept: application/vnd.github+json" \
             -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
-            https://api.github.com/user/packages/container/connector-worker/visibility \
+            https://api.github.com/user/packages/container/owletto-worker/visibility \
             -d '{"visibility":"public"}' || true
 
   build-embeddings-service:
@@ -190,5 +190,5 @@ jobs:
             -H "Accept: application/vnd.github+json" \
             -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
-            https://api.github.com/user/packages/container/embeddings/visibility \
+            https://api.github.com/user/packages/container/owletto-embeddings/visibility \
             -d '{"visibility":"public"}' || true


### PR DESCRIPTION
## Summary

Restore the docker image names for worker and embeddings that PR #499 inadvertently broke. Chart and Flux image-automation expect \`owletto-worker\` and \`owletto-embeddings\`; #499 changed only the build env vars to \`connector-worker\` and \`embeddings\` to match the new npm package names, leaving the chart and Flux pointing at images that no longer exist.

## What broke

- \`packages/web/deploy/charts/owletto/templates/_helpers.tpl:88,96\` computes image names as \`{repository}-{worker,embeddings}\` from \`image.repository = lobu-ai/owletto\`. Result: chart wants \`ghcr.io/lobu-ai/owletto-{worker,embeddings}:TAG\`.
- \`packages/web/deploy/k8s/infrastructure/image-automation/image-{policies,repositories}.yaml\` watches \`ghcr.io/lobu-ai/owletto-{worker,embeddings}\` for new tags.
- The build env vars in this file have been pushing to \`ghcr.io/lobu-ai/connector-worker\` and \`lobu-ai/embeddings\` since #499.

Result: every Helm upgrade since #499 fails (ImagePullBackOff on worker + embeddings → 15-min Helm timeout → rollback → loop). Currently observed in summaries-prod, blocking the workspaces PVC rollout from #507/#509.

## Why revert here vs. update the chart

The npm package renames (\`@lobu/connector-worker\`, \`@lobu/embeddings\`) are intentional — those publish to npm and the rename is appropriate. Docker image names don't have to match npm package names. Reverting just the docker image names is a 4-line change with no chart/automation surface area; the alternative (rename chart helpers + image policies + image repositories + chart version bump + parent submodule bump) is much wider and re-tags an active prod registry.

## Test plan

- [x] Diff is purely env-var rename + visibility URL rename
- [ ] After merge, build job pushes \`owletto-worker:TAG\` + \`owletto-embeddings:TAG\` again
- [ ] Flux image-automation picks up the new tag (1m polling), updates HelmRelease values
- [ ] Helm upgrade to chart 0.1.14 with replicaCount=1 + PVC mount completes successfully in summaries-prod
- [ ] One app pod running, PVC bound, worker + embeddings pods Ready