### PR TITLE
fix(connectors): use claimed_at instead of nonexistent started_at on runs

### DIFF
--- a/packages/server/src/__tests__/unit/connectors/repair-agent.test.ts
+++ b/packages/server/src/__tests__/unit/connectors/repair-agent.test.ts
@@ -89,7 +89,7 @@ function feedRow(overrides: Partial<Record<string, any>> = {}): any {
 const RUN_ROW = {
   id: 99,
   status: 'failed',
-  started_at: new Date(NOW - 5 * 60 * 1000),
+  claimed_at: new Date(NOW - 5 * 60 * 1000),
   completed_at: new Date(NOW),
   error_message: 'token expired',
   exit_reason: 'error_message',
@@ -265,7 +265,7 @@ describe('hashFailureSignature', () => {
     const a: DiagnosticRunRow = {
       id: 1,
       status: 'failed',
-      startedAt: null,
+      claimedAt: null,
       completedAt: null,
       durationMs: null,
       errorMessage: 'boom',
@@ -282,7 +282,7 @@ describe('hashFailureSignature', () => {
     const a: DiagnosticRunRow = {
       id: 1,
       status: 'failed',
-      startedAt: null,
+      claimedAt: null,
       completedAt: null,
       durationMs: null,
       errorMessage: 'boom',
@@ -325,7 +325,7 @@ describe('buildOpenPacket', () => {
         {
           id: 99,
           status: 'failed',
-          startedAt: '2026-04-25T11:55:00.000Z',
+          claimedAt: '2026-04-25T11:55:00.000Z',
           completedAt: '2026-04-25T12:00:00.000Z',
           durationMs: 300000,
           errorMessage: 'token expired',

--- a/packages/server/src/connectors/repair-agent-packet.ts
+++ b/packages/server/src/connectors/repair-agent-packet.ts
@@ -11,7 +11,7 @@
 export interface DiagnosticRunRow {
   id: number;
   status: string;
-  startedAt: string | null;
+  claimedAt: string | null;
   completedAt: string | null;
   durationMs: number | null;
   errorMessage: string | null;
@@ -41,7 +41,7 @@ function fmtRun(run: DiagnosticRunRow): string {
   const lines: string[] = [];
   lines.push(`- id: ${run.id}`);
   lines.push(`  status: ${run.status}`);
-  if (run.startedAt) lines.push(`  started_at: ${run.startedAt}`);
+  if (run.claimedAt) lines.push(`  claimed_at: ${run.claimedAt}`);
   if (run.completedAt) lines.push(`  completed_at: ${run.completedAt}`);
   if (run.durationMs != null) lines.push(`  duration_ms: ${run.durationMs}`);
   if (run.errorMessage) lines.push(`  error_message: ${run.errorMessage}`);

--- a/packages/server/src/connectors/repair-agent.ts
+++ b/packages/server/src/connectors/repair-agent.ts
@@ -123,7 +123,7 @@ async function loadRecentRuns(
   limit = 10
 ): Promise<DiagnosticRunRow[]> {
   const rows = (await sql`
-    SELECT id, status, started_at, completed_at, error_message,
+    SELECT id, status, claimed_at, completed_at, error_message,
            exit_reason, exit_code, exit_signal, output_tail
     FROM runs
     WHERE feed_id = ${feedId}
@@ -132,7 +132,7 @@ async function loadRecentRuns(
   `) as unknown as Array<{
     id: number;
     status: string;
-    started_at: Date | null;
+    claimed_at: Date | null;
     completed_at: Date | null;
     error_message: string | null;
     exit_reason: string | null;
@@ -143,11 +143,11 @@ async function loadRecentRuns(
   return rows.map((r) => ({
     id: Number(r.id),
     status: r.status,
-    startedAt: r.started_at ? new Date(r.started_at).toISOString() : null,
+    claimedAt: r.claimed_at ? new Date(r.claimed_at).toISOString() : null,
     completedAt: r.completed_at ? new Date(r.completed_at).toISOString() : null,
     durationMs:
-      r.started_at && r.completed_at
-        ? new Date(r.completed_at).getTime() - new Date(r.started_at).getTime()
+      r.claimed_at && r.completed_at
+        ? new Date(r.completed_at).getTime() - new Date(r.claimed_at).getTime()
         : null,
     errorMessage: r.error_message,
     exitReason: r.exit_reason,


### PR DESCRIPTION
## Summary

\`packages/server/src/connectors/repair-agent.ts\` queries the \`runs\` table for column \`started_at\`, which doesn't exist. The actual timestamp columns on \`runs\` are \`claimed_at\`, \`completed_at\`, \`last_heartbeat_at\`, \`created_at\`, \`run_at\`. \`claimed_at\` is the semantic equivalent — it's when the worker started processing a run.

## Why

Confirmed in prod logs — every worker job completion currently emits:

\`\`\`
warn: column "started_at" does not exist
msg: [completeWorkerJob] maybeOpenOrAppendRepairThread threw
\`\`\`

The HTTP \`/api/workers/complete\` returns 200 (the throw is caught), but the repair-thread-open path for failed feed runs is silently dead — connectors that fail repeatedly never get a repair thread opened. That feature is broken in production.

## Changes

- \`repair-agent.ts\` SQL query + result row type: \`started_at\` → \`claimed_at\`
- Mapped field name: \`startedAt\` → \`claimedAt\`
- Diagnostic-packet label (text shown to the LLM in the repair packet): \`started_at\` → \`claimed_at\`
- Test fixture and assertions updated

## Test plan

- [x] \`bun test packages/server/src/__tests__/unit/connectors/repair-agent.test.ts\` → 9/9 pass
- [x] \`bun run typecheck\` clean
- [ ] After merge + deploy, prod logs no longer emit "column \"started_at\" does not exist" on \`/api/workers/complete\`