### PR TITLE
fix: format tools.ts (collapse stripEnv to one line)

### DIFF
--- a/packages/agent-worker/src/openclaw/tools.ts
+++ b/packages/agent-worker/src/openclaw/tools.ts
@@ -167,10 +167,7 @@ export function createOpenClawTools(
     }) => ({
       command: params.command,
       cwd: params.cwd,
-      env: stripEnv(
-        params.env,
-        SENSITIVE_WORKER_ENV_KEYS
-      ) as NodeJS.ProcessEnv,
+      env: stripEnv(params.env, SENSITIVE_WORKER_ENV_KEYS) as NodeJS.ProcessEnv,
     }),
   };
   const bash = wrapBashWithProxyHint(createBashTool(cwd, bashToolOpts));


### PR DESCRIPTION
Unblocks main format-lint after #506. One-line collapse, no behavior change.