### PR TITLE
fix: unblock npx install (#500) and onboard DeepSeek V4 default (#503)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -417,9 +417,6 @@
       },
     },
   },
-  "overrides": {
-    "@types/node": "20.19.9",
-  },
   "packages": {
     "@adobe/css-tools": ["@adobe/css-tools@4.4.4", "", {}, "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg=="],
 

--- a/config/providers.json
+++ b/config/providers.json
@@ -149,7 +149,7 @@
     {
       "id": "deepseek",
       "name": "DeepSeek",
-      "description": "DeepSeek reasoning and coding models",
+      "description": "DeepSeek V4 models — fast and reasoning variants",
       "providers": [
         {
           "displayName": "DeepSeek",
@@ -159,7 +159,7 @@
           "apiKeyInstructions": "Get your API key from <a href=\"https://platform.deepseek.com/api_keys\" target=\"_blank\" class=\"text-blue-600 hover:underline\">DeepSeek Platform</a>",
           "apiKeyPlaceholder": "sk-...",
           "sdkCompat": "openai",
-          "defaultModel": "deepseek-chat",
+          "defaultModel": "deepseek-v4-flash",
           "modelsEndpoint": "/v1/models"
         }
       ]

--- a/package.json
+++ b/package.json
@@ -58,8 +58,5 @@
   },
   "patchedDependencies": {
     "@chat-adapter/telegram@4.20.0": "patches/@chat-adapter%2Ftelegram@4.20.0.patch"
-  },
-  "overrides": {
-    "@types/node": "20.19.9"
   }
 }


### PR DESCRIPTION
## Summary

Bundles two small, mechanical fixes raised in open issues:

- **#500** — Remove `@types/node` from `package.json` `overrides`. npm rejects overrides that target a direct dependency with `EOVERRIDE`, which breaks `npx @lobu/cli@latest` in the repo root. The pinned `20.19.9` already satisfies the `^20.0.0` devDependency, so the override is redundant.
- **#503** — Switch the DeepSeek provider default in `config/providers.json` from the deprecated `deepseek-chat` to `deepseek-v4-flash` ahead of the 2026/07/24 cutoff. DeepSeek V4 stays OpenAI-compatible at the same base URL, so no resolver/worker code changes are needed.

## Issues triaged but not included

- **#502** (Discord token missing from generated `docker-compose.yml`) — premise is invalid. `lobu init` does not generate a `docker-compose.yml`; CLAUDE.md is explicit that lobu is embedded-only with "no Docker or Kubernetes deployment manager," and there is no compose template in the repo. Recommend closing the issue.
- **#495** (Helm install template) — there is no `charts/lobu` directory in this repo either. Best handled separately, possibly by pointing users at the existing example in `owletto-web`.
- **#496 / #99 / #98** — large features that need a design pass; out of scope for a mechanical-fix PR.

## Test plan

- [x] `bun install` succeeds (lockfile unchanged after restoring submodule-induced drift).
- [x] `biome check` clean.
- [x] `tsc --noEmit` clean (pre-commit hook).
- [ ] Manual: `npx @lobu/cli@latest` no longer hits `EOVERRIDE` after publish.
- [ ] Manual: a DeepSeek-configured agent resolves `deepseek-v4-flash` through the OpenAI-compat path.

https://claude.ai/code/session_01VUYkEFaWYQsz7MgRooasyx

---
_Generated by [Claude Code](https://claude.ai/code/session_01VUYkEFaWYQsz7MgRooasyx)_