### PR TITLE
fix: bugs surfaced by parallel bug-hunting subagents

### DIFF
--- a/packages/cli/src/commands/login.ts
+++ b/packages/cli/src/commands/login.ts
@@ -136,10 +136,21 @@ export async function loginCommand(options: LoginOptions): Promise<void> {
     console.log();
   }
 
+  // Refuse to hand a non-https URL (e.g. javascript:, data:, file:) to the
+  // OS's `open` handler. A compromised/misconfigured discovery endpoint
+  // could otherwise redirect the user's browser into running attacker code.
+  let canOpen = false;
   try {
-    await open(verificationUrl);
+    canOpen = new URL(verificationUrl).protocol === "https:";
   } catch {
-    // The URL is printed above; opening is best-effort.
+    canOpen = false;
+  }
+  if (canOpen) {
+    try {
+      await open(verificationUrl);
+    } catch {
+      // The URL is printed above; opening is best-effort.
+    }
   }
 
   const spinner = ora("Waiting for authorization...").start();

--- a/packages/cli/src/internal/credentials.ts
+++ b/packages/cli/src/internal/credentials.ts
@@ -1,4 +1,4 @@
-import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { chmod, mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import {
   DEFAULT_CONTEXT_NAME,
@@ -83,6 +83,10 @@ export async function saveCredentials(
   await writeFile(CREDENTIALS_FILE, JSON.stringify(store, null, 2), {
     mode: 0o600,
   });
+  // writeFile's `mode` only applies on file creation; if the file existed
+  // with looser perms (e.g. from an older CLI release), the mode would
+  // silently stay 0o644. chmod after write makes the perms unconditional.
+  await chmod(CREDENTIALS_FILE, 0o600).catch(() => undefined);
   credentialsCache.set(target.name, creds);
 }
 
@@ -104,6 +108,7 @@ export async function clearCredentials(contextName?: string): Promise<void> {
   await writeFile(CREDENTIALS_FILE, JSON.stringify(store, null, 2), {
     mode: 0o600,
   });
+  await chmod(CREDENTIALS_FILE, 0o600).catch(() => undefined);
 }
 
 /**

--- a/packages/server/src/gateway/__tests__/egress-judge.test.ts
+++ b/packages/server/src/gateway/__tests__/egress-judge.test.ts
@@ -116,7 +116,9 @@ describe("EgressJudge.decide", () => {
       rule()
     );
     expect(decision.verdict).toBe("deny");
-    expect(decision.source).toBe("circuit-open");
+    // A single judge-call failure is not the same as the breaker being
+    // open; audit logs need to distinguish them.
+    expect(decision.source).toBe("judge-error");
   });
 
   test("trips the circuit after consecutive failures and stops calling the client", async () => {

--- a/packages/server/src/gateway/connections/interaction-bridge.ts
+++ b/packages/server/src/gateway/connections/interaction-bridge.ts
@@ -151,12 +151,16 @@ export function registerInteractionBridge(
   // Per-connection state (avoids cross-contamination between connections)
   const handledEvents = new Set<string>();
   const activeTimers = new Set<NodeJS.Timeout>();
+  // Slack retries event_callback webhooks at ~1s/2s/5s/30s/60s/3min on
+  // missed acks; a 30s dedup window let late retries through and
+  // double-processed the event. 5min covers the full retry envelope.
+  const HANDLED_EVENT_TTL_MS = 5 * 60_000;
   function markHandled(id: string): void {
     handledEvents.add(id);
     const timer = setTimeout(() => {
       handledEvents.delete(id);
       activeTimers.delete(timer);
-    }, 30_000);
+    }, HANDLED_EVENT_TTL_MS);
     activeTimers.add(timer);
   }
 

--- a/packages/server/src/gateway/orchestration/impl/embedded-deployment.ts
+++ b/packages/server/src/gateway/orchestration/impl/embedded-deployment.ts
@@ -102,6 +102,8 @@ function buildSystemdRunArgs(opts: {
     "-p",
     "IPAddressAllow=127.0.0.1",
     "-p",
+    "IPAddressAllow=::1",
+    "-p",
     "CapabilityBoundingSet=",
     "-p",
     "RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6",
@@ -246,8 +248,17 @@ export class EmbeddedDeploymentManager extends BaseDeploymentManager {
         "Missing agentId in message payload"
       );
     }
+    // agentId is interpolated into a filesystem path and into the systemd
+    // unit name; reject anything that could escape the workspaces tree or
+    // smuggle shell metacharacters into nix-shell / systemd-run argv below.
+    if (!/^[A-Za-z0-9_-]{1,64}$/.test(agentId)) {
+      throw new OrchestratorError(
+        ErrorCode.DEPLOYMENT_CREATE_FAILED,
+        `Invalid agentId: must be 1-64 chars of [A-Za-z0-9_-]`
+      );
+    }
     const workspaceDir = path.resolve(`workspaces/${agentId}`);
-    fs.mkdirSync(workspaceDir, { recursive: true });
+    fs.mkdirSync(workspaceDir, { recursive: true, mode: 0o700 });
 
     const commonEnvVars = await this.generateEnvironmentVariables(
       username,
@@ -283,6 +294,18 @@ export class EmbeddedDeploymentManager extends BaseDeploymentManager {
     let spawnArgs: string[];
 
     if (nixPackages.length > 0) {
+      // Each entry is passed to `nix-shell -p`, which evaluates it as a Nix
+      // expression — `pkgs.foo; rm -rf /` would execute as a shell side
+      // effect. Restrict to bare attribute names; operators that need a
+      // richer expression should pre-build the shell.
+      for (const pkg of nixPackages) {
+        if (!/^[A-Za-z0-9._-]+$/.test(pkg)) {
+          throw new OrchestratorError(
+            ErrorCode.DEPLOYMENT_CREATE_FAILED,
+            `Invalid nix package name: ${pkg}`
+          );
+        }
+      }
       // Wrap in nix-shell so nix binaries are on PATH.
       command = "nix-shell";
       spawnArgs = [

--- a/packages/server/src/gateway/proxy/egress-judge/judge.ts
+++ b/packages/server/src/gateway/proxy/egress-judge/judge.ts
@@ -149,7 +149,7 @@ export class EgressJudge {
       return {
         verdict: "deny",
         reason: "Judge call failed; request denied",
-        source: "circuit-open",
+        source: "judge-error",
         latencyMs: Date.now() - started,
         policyHash: rule.policyHash,
         judgeName: rule.judgeName,

--- a/packages/server/src/gateway/proxy/egress-judge/types.ts
+++ b/packages/server/src/gateway/proxy/egress-judge/types.ts
@@ -27,7 +27,7 @@ export interface JudgeVerdict {
  * emit accurate audit events.
  */
 export interface JudgeDecision extends JudgeVerdict {
-  source: "judge" | "cache" | "circuit-open";
+  source: "judge" | "cache" | "circuit-open" | "judge-error";
   latencyMs: number;
   policyHash: string;
   judgeName: string;

--- a/packages/server/src/gateway/proxy/secret-proxy.ts
+++ b/packages/server/src/gateway/proxy/secret-proxy.ts
@@ -236,8 +236,13 @@ export class SecretProxy {
     if (value.includes(PLACEHOLDER_PREFIX)) {
       const resolved = await this.resolveSecret(value);
       if (!resolved) {
+        // Fail closed: forwarding the literal placeholder upstream would
+        // surface it in the provider's error response (and thus in worker
+        // logs / user-facing messages), giving an attacker a stable handle
+        // to enumerate. An empty string fails the auth check upstream
+        // without exposing the ref.
         logger.warn("Failed to resolve secret placeholder");
-        return value;
+        return "";
       }
       return resolved;
     }

--- a/packages/server/src/watchers/automation.ts
+++ b/packages/server/src/watchers/automation.ts
@@ -813,7 +813,9 @@ function registerWatcherRunHandle(params: {
 
 function unregisterWatcherRunHandle(messageId: string): void {
   const coreServices = getLobuCoreServices();
-  coreServices?.getWatcherRunTracker().unregister(messageId);
+  const tracker = coreServices?.getWatcherRunTracker();
+  if (!tracker) return;
+  tracker.unregister(messageId);
 }
 
 export async function dispatchPendingWatcherRuns(

--- a/packages/server/src/workspace/multi-tenant.ts
+++ b/packages/server/src/workspace/multi-tenant.ts
@@ -459,8 +459,14 @@ export class MultiTenantProvider implements WorkspaceProvider {
       if (!cacheHit) {
         const auth = await createAuth(c.env);
         session = await auth.api.getSession({ headers: c.req.raw.headers });
-        if (sessionCacheKey) {
-          sessionCache.set(sessionCacheKey, session ?? null);
+        // Only cache valid sessions. Caching `null` would let an explicitly
+        // revoked or expired session continue to resolve to "no auth" for
+        // the cache TTL (30s) instead of returning the upstream's fresh
+        // verdict — fine on its own, but it also masks the inverse case
+        // where the user just logged in: the prior `null` answer keeps
+        // them logged out until the entry expires.
+        if (sessionCacheKey && session?.user && session.session) {
+          sessionCache.set(sessionCacheKey, session);
         }
       }
 


### PR DESCRIPTION
## Summary

Spawned 15 read-only Explore subagents over distinct subsystems (HTTP proxy, secret proxy, worker sandbox, Slack/Telegram/Discord/WhatsApp/Teams adapters, OpenClaw runtime, MCP proxy, auth, scheduled jobs, events store, DB layer, guardrails, connectors, CLI), triaged ~60 reported findings, and fixed the 10 that were verified against source and self-contained.

## Fixes (severity → area)

- **CRITICAL** — `agentId` path-traversal in worker spawn (`embedded-deployment.ts`). `path.resolve("workspaces/" + agentId)` accepted any string; now `[A-Za-z0-9_-]{1,64}` enforced before the path is built and before the value is interpolated into a systemd unit name.
- **CRITICAL** — Nix expression injection. `nixPackages` was passed straight to `nix-shell -p`, which evaluates each entry as Nix — a `;`-laden entry executed shell. Same regex gate applied.
- **HIGH** — IPv6 `::1` egress bypass on the systemd-run sandbox. `IPAddressAllow` only listed `127.0.0.1`; added `::1` so workers can't reach a service bound to `[::1]:port`.
- **HIGH** — Secret placeholder leak. `swap()` returned the literal `lobu_secret_<uuid>` upstream on resolution failure, surfacing refs in provider error bodies and logs. Now fails closed with `""`.
- **HIGH** — Slack event dedup window was 30s; Slack retries up to ~3min. Bumped to 5min.
- **HIGH** — CLI credentials file mode wasn't enforced after first write. `writeFile`'s `mode` only applies on creation, so a file left at 0o644 by an older CLI silently kept those perms across token refreshes. Added explicit `chmod 0o600` after every write.
- **HIGH** — Watcher null-deref in `unregisterWatcherRunHandle`: only `coreServices?.` was guarded, not `getWatcherRunTracker()`.
- **MEDIUM** — Egress-judge audit log mislabeled single judge-call failures as `circuit-open`. New `judge-error` source distinguishes them from a real breaker trip; existing test updated.
- **MEDIUM** — `MultiTenantProvider` cached `null` sessions for 30s, so a freshly-logged-in user kept being treated as unauthenticated until the entry expired. Now only valid sessions are cached.
- **MEDIUM** — CLI OAuth `verificationUrl` was handed to `open()` without protocol validation. A compromised discovery endpoint could hand back `javascript:` / `data:`. Now requires `https:`.

## Out of scope (left for follow-ups)

The hunt also surfaced architectural issues that don't fit a "bug fix" PR — each is its own concern:
- Rate limiter on `/api/auth/*` (better-auth routes)
- Stale-claim sweeper for connector runs (heartbeat-based recovery)
- MCP session reaper (TTL'd map without periodic cleanup)
- Default expiry on PATs (currently null = never expires)
- Transactional wrapping of `completeWorkerJob`
- Batched + non-`DO NOTHING` embedding inserts
- Tombstone filtering in `current_event_records` / `content-search`

## Test plan

- [x] `bun run typecheck` clean
- [x] `make build-packages` clean (core, agent-worker, server, cli, etc.)
- [x] `bun test packages/server/src/gateway/__tests__/{egress-judge,secret-proxy,http-proxy-judge}.test.ts` — 20/20 pass
- [x] biome + tsc pre-commit hook pass
- [ ] Integration tests requiring Postgres (not runnable in this sandbox; same constraint applies to `main`)

https://claude.ai/code/session_01Jo771T1Cd3dP4VgB1FHSMf

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jo771T1Cd3dP4VgB1FHSMf)_