### PR TITLE
fix: drop @types/node override, align embeddings to 20.19.9

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -7,7 +7,7 @@
       "devDependencies": {
         "@biomejs/biome": "^2.2.2",
         "@types/bun": "1.2.11",
-        "@types/node": "^20.0.0",
+        "@types/node": "20.19.9",
         "husky": "^9.1.7",
         "jscpd": "^4.0.5",
         "knip": "^5.66.3",
@@ -64,7 +64,7 @@
         "lobu": "bin/lobu.js",
       },
       "dependencies": {
-        "@anthropic-ai/sdk": "^0.90.0",
+        "@anthropic-ai/sdk": "^0.92.0",
         "@aws-sdk/client-bedrock": "^3.1028.0",
         "@aws-sdk/client-secrets-manager": "^3.1028.0",
         "@chat-adapter/discord": "4.26.0",
@@ -215,7 +215,7 @@
         "hono": "^4.10.4",
       },
       "devDependencies": {
-        "@types/node": "^22.10.2",
+        "@types/node": "20.19.9",
         "tsx": "^4.19.2",
         "typescript": "^5.7.2",
       },
@@ -416,9 +416,6 @@
         "vitest": "^2.1.8",
       },
     },
-  },
-  "overrides": {
-    "@types/node": "20.19.9",
   },
   "packages": {
     "@adobe/css-tools": ["@adobe/css-tools@4.4.4", "", {}, "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg=="],

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   "devDependencies": {
     "@biomejs/biome": "^2.2.2",
     "@types/bun": "1.2.11",
-    "@types/node": "^20.0.0",
+    "@types/node": "20.19.9",
     "husky": "^9.1.7",
     "jscpd": "^4.0.5",
     "knip": "^5.66.3",
@@ -58,8 +58,5 @@
   },
   "patchedDependencies": {
     "@chat-adapter/telegram@4.20.0": "patches/@chat-adapter%2Ftelegram@4.20.0.patch"
-  },
-  "overrides": {
-    "@types/node": "20.19.9"
   }
 }

--- a/packages/embeddings/package.json
+++ b/packages/embeddings/package.json
@@ -17,7 +17,7 @@
     "hono": "^4.10.4"
   },
   "devDependencies": {
-    "@types/node": "^22.10.2",
+    "@types/node": "20.19.9",
     "tsx": "^4.19.2",
     "typescript": "^5.7.2"
   },


### PR DESCRIPTION
## Summary

Replaces #501 (kept the diagnosis, broadened the fix). Closes #500.

The original PR removed `@types/node` from the root `overrides` block. That clears the npx EOVERRIDE error, but it's not a safe drop on its own:

- `packages/embeddings/package.json` declares `@types/node: ^22.10.2`. The root override was silently pinning it down to `20.19.9`, keeping the workspace on a single Node-types line.
- Without the override, resolution would split into a parallel `@types/node@22.x` for `embeddings`. That's a real semantic change — separate decision from the EOVERRIDE bug.

## Fix

- Drop the root `overrides` block (kills EOVERRIDE).
- Pin root devDep `@types/node` to `20.19.9` exactly (preserves the prior pin behavior).
- Align `packages/embeddings` `@types/node` to `20.19.9` so resolution stays single-version.

## Why not move the whole monorepo to `@types/node@22.x`?

`engines.node` is `>=22 <25`, so `@types/node@22.x` would be the more correct long-term move. But that's a wider change — touches every transitive that consumes Node types, and is a separate PR. This PR is the minimum-blast-radius fix that unblocks `npx @lobu/cli@latest`.

## Test plan

- [x] `bun run typecheck` clean at repo root.
- [x] `bun run typecheck` clean inside `packages/embeddings`.
- [x] Lockfile spec ranges updated by hand to match manifests; the resolved `@types/node@20.19.9` entry is unchanged.
- [ ] CI `bun install --frozen-lockfile` against the repo with submodule initialized.
- [ ] Manual: `npx @lobu/cli@latest` from repo root no longer hits EOVERRIDE.

Credit to @mengmengmengqiang for the original diagnosis in #501.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AvxUt73JMTVZ1W5Z1FiD6K)_