### PR TITLE
fix(db): guard chat_connections copy on table existence

### DIFF
--- a/db/migrations/20260502000000_drop_chat_connections.sql
+++ b/db/migrations/20260502000000_drop_chat_connections.sql
@@ -15,16 +15,24 @@
 -- agent_connections.agent_id is NOT NULL, but chat_connections.template_agent_id
 -- was nullable. Skip orphaned rows (no parent agent) — they could not start
 -- in the current model anyway.
-INSERT INTO public.agent_connections (
-    id, agent_id, platform, config, settings, metadata,
-    status, error_message, created_at, updated_at
-)
-SELECT
-    id, template_agent_id, platform, config, settings, metadata,
-    status, error_message, created_at, updated_at
-FROM public.chat_connections
-WHERE template_agent_id IS NOT NULL
-ON CONFLICT (id) DO NOTHING;
+-- Guarded by to_regclass: deployments that never had chat_connections
+-- (table created with IF NOT EXISTS in 20260429140000 and never used) skip
+-- the copy entirely instead of erroring on the missing relation.
+DO $$
+BEGIN
+    IF to_regclass('public.chat_connections') IS NOT NULL THEN
+        INSERT INTO public.agent_connections (
+            id, agent_id, platform, config, settings, metadata,
+            status, error_message, created_at, updated_at
+        )
+        SELECT
+            id, template_agent_id, platform, config, settings, metadata,
+            status, error_message, created_at, updated_at
+        FROM public.chat_connections
+        WHERE template_agent_id IS NOT NULL
+        ON CONFLICT (id) DO NOTHING;
+    END IF;
+END $$;
 
 DROP TABLE IF EXISTS public.chat_connections;
 


### PR DESCRIPTION
## Summary
- Migration `20260502000000_drop_chat_connections.sql` was failing the pre-upgrade Helm hook on `summaries-prod` (`HelmRelease/summaries-app` stalled, `BackoffLimitExceeded` on `summaries-app-owletto-migrate`).
- Root cause: the migration ran `INSERT INTO agent_connections ... FROM public.chat_connections` unconditionally. Prod's DB never had `chat_connections` (the originating `IF NOT EXISTS` table from #506-era migration was no-op'd or already cleaned up), so Postgres errored with `relation "public.chat_connections" does not exist` before reaching `DROP TABLE IF EXISTS`.
- Fix: wrap the data-copy in a `DO` block guarded by `to_regclass('public.chat_connections') IS NOT NULL`. Idempotent on both fresh deployments (no source table) and live deployments (rows copied as before).

## Test plan
- [x] Dry-run executed against prod DB inside `BEGIN...ROLLBACK` — completed without error.
- [ ] Merge → image build → Flux retries `summaries-app-owletto-migrate` → HelmRelease goes Ready.
- [ ] Verify on a DB that DOES have `chat_connections` rows that the copy still occurs (not currently in any environment, but logic preserved).