### PR TITLE
chore: scaffold multi-tenant wedge tests + wire Sentry release

### DIFF
--- a/packages/server/src/gateway/connections/__tests__/multi-tenant-integration.test.ts
+++ b/packages/server/src/gateway/connections/__tests__/multi-tenant-integration.test.ts
@@ -1,0 +1,19 @@
+import { describe, it } from 'vitest';
+
+describe('multi-tenant gateway/connections', () => {
+  it.todo(
+    "routes a Slack message from org A user 5 to that user's isolated worker, not org B's"
+  );
+
+  it.todo(
+    'gives two users in the same org separate sandbox filesystems (no cross-read)'
+  );
+
+  it.todo(
+    'never exposes raw provider API keys to the worker — only lobu_secret_<uuid> placeholders'
+  );
+
+  it.todo(
+    'rejects an agent run triggered by a user from org B against an agent owned by org A'
+  );
+});

--- a/packages/server/src/instrument.ts
+++ b/packages/server/src/instrument.ts
@@ -19,6 +19,7 @@ if (dsn) {
   Sentry.init({
     dsn,
     environment: process.env.ENVIRONMENT || 'production',
+    release: process.env.SENTRY_RELEASE || process.env.GIT_COMMIT_SHA || undefined,
     tracesSampleRate: isDev ? 1.0 : 0.1,
     // The NodeSystemError integration calls util.getSystemErrorMap(), which
     // some Node builds we run under (notably v24.x in our app image) don't


### PR DESCRIPTION
## Summary
- Adds 4 `it.todo` wedge tests under `packages/server/src/gateway/connections/__tests__/multi-tenant-integration.test.ts` covering the homepage's multi-tenant security claim (org isolation, per-user sandboxes, secret-placeholder-only worker view, cross-org agent-run rejection). Public commitment; making them pass is followup work.
- Wires Sentry `release` from `SENTRY_RELEASE` / `GIT_COMMIT_SHA` in `packages/server/src/instrument.ts` so issues attribute to a deploy SHA.

## Test plan
- [x] `bun run check` — biome clean (only pre-existing JSON-size warning)
- [x] `bun run typecheck` — passes
- [x] `bun test packages/server/src/gateway/connections/__tests__/multi-tenant-integration.test.ts` — reports 4 todos, 0 failures