### PR TITLE
chore: prune env-var clutter and consolidate scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,10 +47,6 @@ dev: ensure-submodule
 setup:
 	@./scripts/setup-dev.sh
 
-# Catch-all target to prevent errors when passing arguments
-%:
-	@:
-
 # Run test bot
 test:
 	@./scripts/test-bot.sh "@me test from make command"

--- a/docs/plans/owletto-absorption.md
+++ b/docs/plans/owletto-absorption.md
@@ -42,7 +42,7 @@ Scope:
   - `sync-owletto-guidance.ts`
   - `run-memory-benchmark.ts`, `prepare-locomo-suite.ts`, `prepare-longmemeval-suite.ts`
   - `install-connectors.ts`, `dry-run-connector.ts`, `sync-local.ts`, `test-mcp-server.ts`
-- Update `package.json` script refs (e.g. `"bench:memory": "bun scripts/owletto/run-memory-benchmark.ts"`)
+- Update `package.json` script refs (e.g. `"bench:memory": "bun scripts/owletto/run-memory-benchmark.ts"`) — DONE: each `scripts/owletto/*.ts` is now wired as `owletto:*` in root `package.json`
 - Fix `packages/server/src/utils/__tests__/owletto-guidance-sync.test.ts:9` — it reads `skills/owletto/SKILL.md` via `process.cwd()`; confirm it resolves after the copy
 
 Validation:
@@ -77,17 +77,6 @@ Scope:
 - Check for hardcoded `packages/cli/` string refs
 
 Validation: `bun run typecheck`, `bun run build`, CI lint.
-
-## PR-4: Gateway de-duplication audit
-
-Scope — investigate only, convert findings into a follow-up PR if warranted:
-- `packages/gateway` is lobu-native (357 files)
-- `packages/server/src/lobu/gateway.ts` is a thin adapter
-- Determine: is the adapter live (hit by server routes) or dead code from the pre-merge era?
-- If dead → delete in the same PR
-- If live → document the boundary in a 1-line header comment and close the audit
-
-Reuses the grep pattern `grep -rn "from.*lobu/gateway" packages/server/src`.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -28,7 +28,13 @@
     "slack:manifest:print": "bun run scripts/slack-manifest.ts print",
     "slack:manifest:validate": "bun run scripts/slack-manifest.ts validate",
     "slack:manifest:update": "bun run scripts/slack-manifest.ts update",
-    "owletto:feeds:sync": "bun run scripts/owletto/sync-local.ts"
+    "owletto:feeds:sync": "bun run scripts/owletto/sync-local.ts",
+    "owletto:guidance:sync": "bun run scripts/owletto/sync-owletto-guidance.ts",
+    "owletto:bench:memory": "bun run scripts/owletto/run-memory-benchmark.ts",
+    "owletto:bench:locomo:prepare": "bun run scripts/owletto/prepare-locomo-suite.ts",
+    "owletto:bench:longmemeval:prepare": "bun run scripts/owletto/prepare-longmemeval-suite.ts",
+    "owletto:connectors:install": "bun run scripts/owletto/install-connectors.ts",
+    "owletto:connectors:dry-run": "bun run scripts/owletto/dry-run-connector.ts"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.2.2",

--- a/packages/server/src/auth/base-url.ts
+++ b/packages/server/src/auth/base-url.ts
@@ -1,8 +1,8 @@
 /**
  * Shared base URL resolution for auth module.
  *
- * Uses PUBLIC_WEB_URL as the canonical public origin, with LOBU_URL,
- * forwarded-header, and request-URL fallbacks for environments where it isn't set.
+ * Uses PUBLIC_WEB_URL as the canonical public origin, with forwarded-header
+ * and request-URL fallbacks for environments where it isn't set.
  */
 
 import { getConfiguredPublicOrigin } from '../utils/public-origin';
@@ -35,7 +35,7 @@ interface ResolveBaseUrlOptions {
   url?: string;
   /** Fallback when nothing else resolves. Defaults to `http://localhost:8787`. */
   fallback?: string;
-  /** Skip PUBLIC_WEB_URL / LOBU_URL env override — use the actual serving domain. */
+  /** Skip PUBLIC_WEB_URL env override — use the actual serving domain. */
   skipEnvOverride?: boolean;
 }
 
@@ -44,10 +44,9 @@ interface ResolveBaseUrlOptions {
  *
  * Resolution order:
  * 1. `PUBLIC_WEB_URL` environment variable
- * 2. `LOBU_URL` environment variable
- * 3. `x-forwarded-proto` + (`x-forwarded-host` || `host`) headers
- * 4. The request/URL origin
- * 5. The provided fallback (default: `http://localhost:8787`)
+ * 2. `x-forwarded-proto` + (`x-forwarded-host` || `host`) headers
+ * 3. The request/URL origin
+ * 4. The provided fallback (default: `http://localhost:8787`)
  */
 export function resolveBaseUrl(options: ResolveBaseUrlOptions = {}): string {
   const { request, fallback = 'http://localhost:8787' } = options;
@@ -58,7 +57,7 @@ export function resolveBaseUrl(options: ResolveBaseUrlOptions = {}): string {
     return request?.headers.get(name) ?? undefined;
   };
 
-  // 1. PUBLIC_WEB_URL / LOBU_URL from environment
+  // 1. PUBLIC_WEB_URL from environment
   if (!options.skipEnvOverride) {
     const fromEnv = getConfiguredPublicOrigin();
     if (fromEnv) return fromEnv;

--- a/packages/server/src/auth/oauth/routes.ts
+++ b/packages/server/src/auth/oauth/routes.ts
@@ -52,7 +52,7 @@ async function parseRequestBody(c: {
  * Helper to get API base URL from a Hono-style context.
  * Delegates to the shared `resolveBaseUrl()` utility.
  *
- * Skips PUBLIC_WEB_URL / LOBU_URL so OAuth discovery and endpoints always
+ * Skips PUBLIC_WEB_URL so OAuth discovery and endpoints always
  * reflect the domain that actually serves them (e.g. owletto.com), not a
  * downstream gateway domain that would need to proxy every /oauth/* request.
  */

--- a/packages/server/src/gateway/connections/slack-connection-coordinator.ts
+++ b/packages/server/src/gateway/connections/slack-connection-coordinator.ts
@@ -237,17 +237,14 @@ export class SlackConnectionCoordinator {
     requireOAuth?: boolean;
   }): PlatformAdapterConfig {
     const currentConfig = this.deps.getCurrentSlackConfig();
-    const signingSecret =
-      process.env.SLACK_SIGNING_SECRET || currentConfig.signingSecret;
-    const clientId = process.env.SLACK_CLIENT_ID || currentConfig.clientId;
-    const clientSecret =
-      process.env.SLACK_CLIENT_SECRET || currentConfig.clientSecret;
-    const encryptionKey =
-      process.env.SLACK_ENCRYPTION_KEY || currentConfig.encryptionKey;
-    const installationKeyPrefix =
-      process.env.SLACK_INSTALLATION_KEY_PREFIX ||
-      currentConfig.installationKeyPrefix;
-    const userName = process.env.SLACK_BOT_USERNAME || currentConfig.userName;
+    const {
+      signingSecret,
+      clientId,
+      clientSecret,
+      encryptionKey,
+      installationKeyPrefix,
+      userName,
+    } = currentConfig;
 
     if (!signingSecret) {
       throw new Error("Slack signing secret is not configured");
@@ -256,7 +253,7 @@ export class SlackConnectionCoordinator {
     if (options?.requireOAuth) {
       if (!clientId || !clientSecret) {
         throw new Error(
-          "Slack OAuth is not configured. Set SLACK_CLIENT_ID and SLACK_CLIENT_SECRET."
+          "Slack OAuth is not configured. Set client ID and secret on the connection."
         );
       }
 
@@ -271,10 +268,10 @@ export class SlackConnectionCoordinator {
       };
     }
 
-    const botToken = process.env.SLACK_BOT_TOKEN || currentConfig.botToken;
+    const botToken = currentConfig.botToken;
     if (!botToken && (!clientId || !clientSecret)) {
       throw new Error(
-        "Slack adapter is not configured. Provide SLACK_BOT_TOKEN or Slack OAuth credentials."
+        "Slack adapter is not configured. Provide a bot token or OAuth credentials on the connection."
       );
     }
 

--- a/packages/server/src/instrument.ts
+++ b/packages/server/src/instrument.ts
@@ -19,7 +19,7 @@ if (dsn) {
   Sentry.init({
     dsn,
     environment: process.env.ENVIRONMENT || 'production',
-    release: process.env.SENTRY_RELEASE || process.env.GIT_COMMIT_SHA || undefined,
+    release: process.env.SENTRY_RELEASE || process.env.APP_GIT_SHA || undefined,
     tracesSampleRate: isDev ? 1.0 : 0.1,
     // The NodeSystemError integration calls util.getSystemErrorMap(), which
     // some Node builds we run under (notably v24.x in our app image) don't

--- a/packages/server/src/utils/__tests__/url-builder.test.ts
+++ b/packages/server/src/utils/__tests__/url-builder.test.ts
@@ -5,7 +5,7 @@ import { HOSTED_UI_FALLBACK_ORIGIN } from '../public-origin';
 /**
  * Behavior contract for `getPublicWebUrl`:
  *   1. Explicit `baseUrl` argument wins.
- *   2. `PUBLIC_WEB_URL` (preferred) or `LOBU_URL` env wins next.
+ *   2. `PUBLIC_WEB_URL` env wins next.
  *   3. With no local frontend bundled, fall back to the hosted-UI origin
  *      (`HOSTED_UI_FALLBACK_ORIGIN`) so backend-only self-hosters still emit
  *      usable links. The `requestUrl` is only consulted when a local frontend
@@ -14,11 +14,9 @@ import { HOSTED_UI_FALLBACK_ORIGIN } from '../public-origin';
  */
 describe('getPublicWebUrl', () => {
   const originalWebUrl = process.env.PUBLIC_WEB_URL;
-  const originalLobuUrl = process.env.LOBU_URL;
 
   beforeEach(() => {
     delete process.env.PUBLIC_WEB_URL;
-    delete process.env.LOBU_URL;
   });
 
   afterEach(() => {
@@ -26,12 +24,6 @@ describe('getPublicWebUrl', () => {
       process.env.PUBLIC_WEB_URL = originalWebUrl;
     } else {
       delete process.env.PUBLIC_WEB_URL;
-    }
-
-    if (originalLobuUrl !== undefined) {
-      process.env.LOBU_URL = originalLobuUrl;
-    } else {
-      delete process.env.LOBU_URL;
     }
   });
 
@@ -56,11 +48,6 @@ describe('getPublicWebUrl', () => {
   it('prefers PUBLIC_WEB_URL env var when no explicit baseUrl', () => {
     process.env.PUBLIC_WEB_URL = 'https://env.owletto.com';
     expect(getPublicWebUrl('https://request.owletto.com/mcp')).toBe('https://env.owletto.com');
-  });
-
-  it('falls back to LOBU_URL when PUBLIC_WEB_URL is not set', () => {
-    process.env.LOBU_URL = 'https://community.lobu.ai';
-    expect(getPublicWebUrl('https://request.owletto.com/mcp')).toBe('https://community.lobu.ai');
   });
 
   it('falls back to HOSTED_UI_FALLBACK_ORIGIN when no env, no baseUrl, no local frontend', () => {

--- a/packages/server/src/utils/public-origin.ts
+++ b/packages/server/src/utils/public-origin.ts
@@ -1,9 +1,5 @@
 /**
- * Canonical public origin resolution.
- *
- * PUBLIC_WEB_URL remains the explicit override.
- * LOBU_URL is the next fallback so hosted Owletto instances can surface under
- * the Lobu community URL without hardcoding a domain in application code.
+ * Canonical public origin resolution. PUBLIC_WEB_URL is the explicit override.
  */
 
 import fs from 'node:fs';
@@ -22,7 +18,7 @@ function toOrigin(value?: string | null): string | undefined {
 }
 
 export function getConfiguredPublicOrigin(): string | undefined {
-  return toOrigin(process.env.PUBLIC_WEB_URL) ?? toOrigin(process.env.LOBU_URL);
+  return toOrigin(process.env.PUBLIC_WEB_URL);
 }
 
 const APP_ROOT = path.resolve(fileURLToPath(new URL('.', import.meta.url)), '../..');
@@ -31,8 +27,8 @@ let localFrontendCache: boolean | undefined;
 
 /**
  * Sync check for a locally available frontend. Used by MCP URL builders to
- * decide whether to return the hosted UI fallback when neither PUBLIC_WEB_URL
- * nor LOBU_URL is configured.
+ * decide whether to return the hosted UI fallback when PUBLIC_WEB_URL is not
+ * configured.
  *
  * Always matches a built bundle (`packages/web/dist/index.html`). In
  * development it additionally matches a source checkout

--- a/packages/server/src/utils/runtime-info.ts
+++ b/packages/server/src/utils/runtime-info.ts
@@ -4,10 +4,7 @@ interface RuntimeEnvLike {
   ENVIRONMENT?: string;
   NODE_ENV?: string;
   APP_GIT_SHA?: string;
-  GIT_SHA?: string;
-  COMMIT_SHA?: string;
   APP_BUILD_TIME?: string;
-  BUILD_TIME?: string;
 }
 
 function cleanString(value: unknown): string | undefined {
@@ -29,17 +26,11 @@ export function getRuntimeInfo(env?: RuntimeEnvLike | null) {
     version: packageJson.version,
     revision:
       cleanString(env?.APP_GIT_SHA) ||
-      cleanString(env?.GIT_SHA) ||
-      cleanString(env?.COMMIT_SHA) ||
       cleanString(process.env.APP_GIT_SHA) ||
-      cleanString(process.env.GIT_SHA) ||
-      cleanString(process.env.COMMIT_SHA) ||
       'unknown',
     build_time:
       cleanString(env?.APP_BUILD_TIME) ||
-      cleanString(env?.BUILD_TIME) ||
       cleanString(process.env.APP_BUILD_TIME) ||
-      cleanString(process.env.BUILD_TIME) ||
       null,
     environment: resolveRuntimeEnvironment(env),
   };


### PR DESCRIPTION
## Summary

Audit cleanup — removes duplicated/dead env vars, deletes a Makefile footgun, and wires six previously-orphaned `scripts/owletto/*` scripts.

### Env vars
- **Build/SHA aliases dropped.** `runtime-info.ts` was reading six env names (`APP_GIT_SHA || GIT_SHA || COMMIT_SHA` + `APP_BUILD_TIME || BUILD_TIME`) for what amounts to two values, and `instrument.ts` added a seventh (`GIT_COMMIT_SHA`) for Sentry release. CI and the Dockerfile only ever set `APP_GIT_SHA` / `APP_BUILD_TIME`. Keep those, drop the rest. Sentry release now falls back to `APP_GIT_SHA`, matching the runtime-info value.
- **`LOBU_URL` dropped.** `PUBLIC_WEB_URL` is the documented var in `.env.example`; `LOBU_URL` was a redundant fallback in `public-origin.ts` / `base-url.ts`.
- **Slack per-connection env fallbacks removed.** `slack-connection-coordinator.ts` was reading seven `SLACK_*` env vars as fallbacks over the DB config (`process.env.SLACK_X || dbConfig.x`). That contradicts AGENTS.md ("no per-platform env vars"). DB config is now the only source. The `/slack/install` global install endpoint still reads `SLACK_CLIENT_ID` — that's an operator-wide install link, not per-connection, so it stays.

### Scripts
- **`scripts/owletto/*` wired in `package.json`.** Six scripts (`run-memory-benchmark`, `prepare-locomo-suite`, `prepare-longmemeval-suite`, `install-connectors`, `dry-run-connector`, `sync-owletto-guidance`) had no callers. Wired under the existing `owletto:*` prefix, completing PR-1 of `docs/plans/owletto-absorption.md`.
- **Makefile `%:` catch-all deleted.** It silently swallowed any extra arg passed to `make`, masking typos. The `eval` target ignores positional args anyway.
- **Absorption plan PR-4 removed.** It planned to audit `packages/gateway` — that directory doesn't exist, so the audit's premise is dead.

### Not touched (deliberate)
- `MEMORY_URL` (gateway) vs `LOBU_MEMORY_URL` (CLI) — flagged in the audit, but they serve different audiences (deployed gateway vs CLI pointing at any server, matching the `LOBU_*` user-namespace pattern).
- `WORKER_TOKEN` (per-spawn JWT for agent-worker) vs `WORKER_API_TOKEN` (bootstrap bearer for connector-worker daemon) — confusing names, but distinct purposes.
- `scripts/e2e-lobu-apply.sh` — referenced from `docs/plans/lobu-apply.md` as the golden e2e test for `lobu apply`. Not orphaned.
- `REDIS_PASSWORD` in the provider-registry blocklist — defense-in-depth, intentional.

## Test plan
- [x] Pre-commit hooks: `biome check` + `tsc --noEmit` pass clean
- [x] `runtime-info.test.ts` — 3/3 pass
- [x] `url-builder.test.ts` — 8/8 pass (covers `PUBLIC_WEB_URL` only path)
- [x] `slack-connection-coordinator.test.ts` — 4/4 pass (covers DB-only resolution)
- [ ] Verify nothing in deployment pipelines (Helm charts, k8s configs, ops runbooks) still sets `GIT_SHA` / `COMMIT_SHA` / `BUILD_TIME` / `GIT_COMMIT_SHA` / `LOBU_URL`
- [ ] Verify ops aren't relying on the removed Slack env fallbacks (most likely already migrated to DB config)

https://claude.ai/code/session_01X1K7tmqfo7h4eugYFDEmNR

---
_Generated by [Claude Code](https://claude.ai/code/session_01X1K7tmqfo7h4eugYFDEmNR)_