### PR TITLE
fix: address unaddressed Codex review comments from #478 / #498 / #521

### DIFF
--- a/packages/cli/src/commands/dev.ts
+++ b/packages/cli/src/commands/dev.ts
@@ -88,18 +88,18 @@ export async function devCommand(
 
   spinner.succeed("Environment ready");
 
-  const port =
+  const portRaw =
     options.port ?? mergedEnv.GATEWAY_PORT ?? mergedEnv.PORT ?? "8787";
-  const portNum = Number(port);
+  const portNum = Number(portRaw);
   if (!Number.isInteger(portNum) || portNum < 1 || portNum > 65535) {
-    console.error(chalk.red(`\n  Invalid port "${port}" — must be 1-65535.\n`));
+    console.error(chalk.red(`\n  Invalid port — must be an integer in 1-65535.\n`));
     process.exit(1);
   }
-  const gatewayUrl = `http://localhost:${port}`;
+  const gatewayUrl = `http://localhost:${portNum}`;
 
   const portFree = await isPortFree(portNum);
   if (!portFree) {
-    console.error(chalk.red(`\n  Port ${port} is already in use.`));
+    console.error(chalk.red(`\n  Port ${portNum} is already in use.`));
     console.error(
       chalk.dim(
         "  Stop the other process, or pass `--port <n>` / set `GATEWAY_PORT` to a free port.\n"
@@ -108,8 +108,8 @@ export async function devCommand(
     console.error(
       chalk.dim(
         process.platform === "darwin" || process.platform === "linux"
-          ? `  Find what's holding it: lsof -iTCP:${port} -sTCP:LISTEN\n`
-          : `  Find what's holding it: netstat -ano | findstr :${port}\n`
+          ? `  Find what's holding it: lsof -iTCP:${portNum} -sTCP:LISTEN\n`
+          : `  Find what's holding it: netstat -ano | findstr :${portNum}\n`
       )
     );
     process.exit(1);
@@ -136,8 +136,8 @@ export async function devCommand(
     ...mergedEnv,
     LOBU_DEV_PROJECT_PATH:
       process.env.LOBU_DEV_PROJECT_PATH || envVars.LOBU_DEV_PROJECT_PATH || cwd,
-    PORT: port,
-    GATEWAY_PORT: port,
+    PORT: String(portNum),
+    GATEWAY_PORT: String(portNum),
     ...(logLevel ? { LOG_LEVEL: logLevel } : {}),
   };
 

--- a/packages/cli/src/commands/dev.ts
+++ b/packages/cli/src/commands/dev.ts
@@ -92,7 +92,9 @@ export async function devCommand(
     options.port ?? mergedEnv.GATEWAY_PORT ?? mergedEnv.PORT ?? "8787";
   const portNum = Number(portRaw);
   if (!Number.isInteger(portNum) || portNum < 1 || portNum > 65535) {
-    console.error(chalk.red(`\n  Invalid port — must be an integer in 1-65535.\n`));
+    console.error(
+      chalk.red(`\n  Invalid port — must be an integer in 1-65535.\n`)
+    );
     process.exit(1);
   }
   const gatewayUrl = `http://localhost:${portNum}`;

--- a/packages/server/src/gateway/auth/mcp/config-service.ts
+++ b/packages/server/src/gateway/auth/mcp/config-service.ts
@@ -322,9 +322,17 @@ export class McpConfigService {
     const servers = await this.getAgentMcpServers(agentId);
     const derived = await this.deriveLobuMemoryServer(agentId);
     if (!derived) {
-      const withoutLobuMemory = { ...servers };
-      delete withoutLobuMemory["lobu-memory"];
-      return withoutLobuMemory;
+      // Only drop the entry when it was derived (internal). A manually
+      // configured `lobu-memory` server in agent settings should survive a
+      // transient derive failure (DB blip, slug not yet resolvable, etc.) —
+      // otherwise a recoverable error silently disables memory tools.
+      const existing = servers["lobu-memory"];
+      if (existing && typeof existing === "object" && existing.internal === true) {
+        const withoutLobuMemory = { ...servers };
+        delete withoutLobuMemory["lobu-memory"];
+        return withoutLobuMemory;
+      }
+      return servers;
     }
 
     const existing = servers["lobu-memory"];

--- a/packages/server/src/gateway/auth/mcp/proxy.ts
+++ b/packages/server/src/gateway/auth/mcp/proxy.ts
@@ -659,7 +659,8 @@ export class McpProxy {
         mcpId,
         toolName,
         agentId,
-        auth.tokenData
+        auth.tokenData,
+        auth.token
       );
       if (found && requiresToolApproval(annotations)) {
         const pattern = `/mcp/${mcpId}/tools/${toolName}`;
@@ -1074,7 +1075,8 @@ export class McpProxy {
               mcpId!,
               toolName,
               agentId,
-              tokenData
+              tokenData,
+              sessionToken
             );
             if (found && requiresToolApproval(annotations)) {
               const pattern = `/mcp/${mcpId}/tools/${toolName}`;
@@ -1191,7 +1193,8 @@ export class McpProxy {
     mcpId: string,
     toolName: string,
     agentId: string,
-    tokenData: any
+    tokenData: any,
+    workerToken?: string
   ): Promise<{ found: boolean; annotations?: McpTool["annotations"] }> {
     let tools: McpTool[] | null = null;
     if (this.toolCache) {
@@ -1199,7 +1202,16 @@ export class McpProxy {
     }
 
     if (!tools) {
-      const result = await this.fetchToolsForMcp(mcpId, agentId, tokenData);
+      // Forward the worker JWT so internal MCPs (lobu-memory) can enumerate
+      // tools — without it the discovery call goes unauthenticated and
+      // returns an empty list, which would silently bypass the approval gate
+      // (`found=false` means "no approval needed" at call sites).
+      const result = await this.fetchToolsForMcp(
+        mcpId,
+        agentId,
+        tokenData,
+        workerToken
+      );
       tools = result.tools;
     }
 

--- a/packages/server/src/scheduled/task-scheduler.ts
+++ b/packages/server/src/scheduled/task-scheduler.ts
@@ -157,8 +157,13 @@ export class TaskScheduler {
       } catch (err) {
         logger.error(
           { err, taskName: reg.name, cron: reg.cron },
-          '[task-scheduler] Failed to seed cron row at boot',
+          '[task-scheduler] Failed to seed cron row at boot; will retry in background',
         );
+        // Periodic tasks self-seed via line ~216 once they dispatch, but a
+        // task with no prior cron row stays idle until a successful seed.
+        // Retry in the background so a transient DB hiccup at boot doesn't
+        // disable the task until the next pod restart.
+        this.retrySeedInBackground(reg);
       }
     }
 
@@ -169,6 +174,31 @@ export class TaskScheduler {
       { total: this.handlers.size, periodic },
       '[task-scheduler] Started',
     );
+  }
+
+  private retrySeedInBackground(reg: TaskRegistration): void {
+    const delays = [5_000, 15_000, 60_000];
+    const attempt = (i: number): void => {
+      if (!this.started || i >= delays.length) return;
+      setTimeout(() => {
+        if (!this.started) return;
+        this.seedNextCronTick(reg)
+          .then(() =>
+            logger.info(
+              { taskName: reg.name, cron: reg.cron, attempt: i + 1 },
+              '[task-scheduler] Recovered cron seed in background',
+            ),
+          )
+          .catch((err) => {
+            logger.error(
+              { err, taskName: reg.name, cron: reg.cron, attempt: i + 1 },
+              '[task-scheduler] Background cron seed retry failed',
+            );
+            attempt(i + 1);
+          });
+      }, delays[i]).unref();
+    };
+    attempt(0);
   }
 
   /** Stop dispatching. The underlying queue handles in-flight drain on its


### PR DESCRIPTION
## Summary

Sweeps a handful of unresolved Codex P1/P2 review threads from already-merged PRs (#478, #498, #521). Each call site below was verified against current `main`.

### Changes

- **`task-scheduler.ts` (#478)** — `start()` previously logged + swallowed `seedNextCronTick` failures, so a transient DB hiccup at boot could leave a periodic task permanently idle until the next pod restart (no self-seed path). Now retries in the background at 5s / 15s / 60s before giving up.

- **`gateway/auth/mcp/proxy.ts` (#498)** — `getToolAnnotations` did not forward the worker JWT to `fetchToolsForMcp`, so uncached `tools/list` discovery for internal MCPs (`lobu-memory`) went upstream unauthenticated, returned an empty list, and silently bypassed `requiresToolApproval` (`found=false` was treated as "no approval needed"). Forwards `auth.token` / `sessionToken` through both call sites.

- **`gateway/auth/mcp/config-service.ts` (#498)** — `getEffectiveAgentMcpServers` previously deleted the `lobu-memory` entry whenever `deriveLobuMemoryServer` returned `null` (transient DB error, slug not yet resolvable). A manually configured `lobu-memory` server in agent settings would silently disappear. Now only drops the entry when it was derived (`internal === true`).

- **`cli/commands/dev.ts` (#521)** — Clears CodeQL clear-text-logging alerts (#228, #229, #230, #231) by logging the validated `portNum` instead of the raw env-sourced port string.

### Verified-already-fixed (no change)
- #478 orphan watcher reset already gates on `claimed_at < now() - ORPHANED_CLAIM_THRESHOLD`.
- #491 `lobu apply --url` token resolution and per-context active org are already wired correctly.
- #459 multi-tenant cli-token bypass and `resolveServerUrl` were addressed by later refactors (#506).
- #485 watcher version chain uses an advisory lock + `WHERE watcher_id = groupId`.

## Test plan

- [x] `make build-packages` is green
- [x] Pre-commit Biome + tsc pass
- [ ] CI green
- [ ] Manual: confirm `lobu run` with invalid `PORT` still surfaces a helpful error
- [ ] Manual: confirm an internal MCP tool call still hits the approval gate when no grant exists

https://claude.ai/code/session_01NLSbCEn2nJijWa6ZzhixYz

---
_Generated by [Claude Code](https://claude.ai/code/session_01NLSbCEn2nJijWa6ZzhixYz)_