### PR TITLE
chore(atlas): switch atlas-curator from anthropic to z.ai

### DIFF
--- a/.github/workflows/lobu-apply-atlas.yml
+++ b/.github/workflows/lobu-apply-atlas.yml
@@ -39,13 +39,13 @@ jobs:
         id: gate
         env:
           TOKEN: ${{ secrets.LOBU_TOKEN }}
-          ANTHROPIC: ${{ secrets.ANTHROPIC_API_KEY }}
+          ZAI: ${{ secrets.Z_AI_API_KEY }}
         run: |
           if [ -z "${TOKEN:-}" ]; then
             echo "LOBU_TOKEN not set — skipping (expected for fork PRs)."
             echo "skip=true" >> "$GITHUB_OUTPUT"
-          elif [ -z "${ANTHROPIC:-}" ]; then
-            echo "ANTHROPIC_API_KEY not set — skipping until repo secret is configured."
+          elif [ -z "${ZAI:-}" ]; then
+            echo "Z_AI_API_KEY not set — skipping until repo secret is configured."
             echo "skip=true" >> "$GITHUB_OUTPUT"
           else
             echo "skip=false" >> "$GITHUB_OUTPUT"
@@ -61,7 +61,7 @@ jobs:
         working-directory: examples/atlas
         env:
           LOBU_TOKEN: ${{ secrets.LOBU_TOKEN }}
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          Z_AI_API_KEY: ${{ secrets.Z_AI_API_KEY }}
         run: |
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             bunx --bun @lobu/cli apply --org atlas --dry-run

--- a/.github/workflows/lobu-apply-atlas.yml
+++ b/.github/workflows/lobu-apply-atlas.yml
@@ -60,7 +60,9 @@ jobs:
         if: steps.gate.outputs.skip != 'true'
         working-directory: examples/atlas
         env:
-          LOBU_TOKEN: ${{ secrets.LOBU_TOKEN }}
+          # CLI reads LOBU_API_TOKEN (not LOBU_TOKEN) as the env-var override
+          # for stored credentials — see packages/cli/src/internal/credentials.ts.
+          LOBU_API_TOKEN: ${{ secrets.LOBU_TOKEN }}
           Z_AI_API_KEY: ${{ secrets.Z_AI_API_KEY }}
         run: |
           if [ "${{ github.event_name }}" = "pull_request" ]; then

--- a/examples/atlas/lobu.toml
+++ b/examples/atlas/lobu.toml
@@ -11,13 +11,13 @@ description = "Curate Atlas reference data — countries, cities, regions, indus
 dir = "./agents/atlas-curator"
 
 [[agents.atlas-curator.providers]]
-id = "anthropic"
-model = "claude/sonnet-4-5"
-key = "$ANTHROPIC_API_KEY"
+id = "z-ai"
+model = "z-ai/glm-4.7"
+key = "$Z_AI_API_KEY"
 
 
 [agents.atlas-curator.network]
-allowed = ["github.com", ".github.com", ".githubusercontent.com"]
+allowed = ["github.com", ".github.com", ".githubusercontent.com", "api.z.ai", ".z.ai"]
 
 [memory.owletto]
 enabled = true

--- a/packages/landing/src/content/docs/guides/sync-from-github.md
+++ b/packages/landing/src/content/docs/guides/sync-from-github.md
@@ -42,7 +42,8 @@ jobs:
           bun-version: 1.3.5
       - name: Apply
         env:
-          LOBU_TOKEN: ${{ secrets.LOBU_TOKEN }}
+          # CLI reads LOBU_API_TOKEN as the env-var override for stored credentials.
+          LOBU_API_TOKEN: ${{ secrets.LOBU_TOKEN }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         run: |
           if [ "${{ github.event_name }}" = "pull_request" ]; then
@@ -92,13 +93,13 @@ For `staging` and `prod` orgs, run two jobs (or two workflows) with different `-
 ```yaml
 - name: Apply to staging
   env:
-    LOBU_TOKEN: ${{ secrets.LOBU_TOKEN_STAGING }}
+    LOBU_API_TOKEN: ${{ secrets.LOBU_TOKEN_STAGING }}
   run: bunx --bun @lobu/cli apply --org my-org-staging --yes
 
 - name: Apply to prod
   if: github.event_name == 'push' && github.ref == 'refs/heads/main'
   env:
-    LOBU_TOKEN: ${{ secrets.LOBU_TOKEN_PROD }}
+    LOBU_API_TOKEN: ${{ secrets.LOBU_TOKEN_PROD }}
   run: bunx --bun @lobu/cli apply --org my-org-prod --yes
 ```
 


### PR DESCRIPTION
Per discussion: standardize on z.ai for the open-source examples — keeps Anthropic keys reserved for non-public agents and lets contributors run the atlas dogfood with a free-tier z.ai key.

- `examples/atlas/lobu.toml`: provider id `z-ai`, model `z-ai/glm-4.7` (matches `DEFAULT_PROVIDER_MODELS['z-ai']` in `packages/agent-worker/src/openclaw/model-resolver.ts:30`), key `$Z_AI_API_KEY`. Network allowlist gains `api.z.ai` and `.z.ai` so the worker's egress proxy lets the model traffic out.
- `.github/workflows/lobu-apply-atlas.yml`: skip-gate now checks `Z_AI_API_KEY` instead of `ANTHROPIC_API_KEY`; apply step forwards `Z_AI_API_KEY` into the runner env.

To activate the dogfood, add `Z_AI_API_KEY` as a repo secret. The gate will then unblock the apply automatically.