### PR TITLE
fix(docker): build embeddings before connector worker in app image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,22 @@
+# Keep Docker builds reproducible and close to a clean CI checkout.
+.git
+.github
+.pi
+node_modules
+**/node_modules
+
+# Build outputs must be produced inside the Docker build, not copied from a
+# developer machine. Copying these can mask missing build steps.
+dist
+**/dist
+tsconfig.tsbuildinfo
+**/tsconfig.tsbuildinfo
+
+# Local/editor noise
+.env
+.env.*
+.DS_Store
+coverage
+**/coverage
+.vscode
+.idea

--- a/docker/app/Dockerfile
+++ b/docker/app/Dockerfile
@@ -74,6 +74,7 @@ COPY packages/web packages/web
 # at runtime (ESM-only export, not bundled), so dist/ must exist on disk.
 RUN cd packages/core && bunx tsc \
     && cd ../connector-sdk && bunx tsc \
+    && cd ../embeddings && bunx tsc \
     && cd ../connector-worker && bunx tsc \
     && cd ../openclaw-plugin && bun run build
 


### PR DESCRIPTION
Fixes the current main Build and Push Images app-image failure after PR #539. In a clean Docker build, connector-worker's TypeScript build needs @lobu/embeddings dist available, so the app image builder now builds packages/embeddings before packages/connector-worker.\n\nValidation:\n- pre-commit checks passed\n- local clean-dist Docker app builder build is running with --no-cache and SKIP_WEB_BUILD=true