### PR TITLE
fix(connectors): recover reddit sync and watcher memory auth

### DIFF
--- a/docker/worker/Dockerfile
+++ b/docker/worker/Dockerfile
@@ -48,9 +48,12 @@ COPY packages/connectors/ packages/connectors/
 COPY packages/embeddings/ packages/embeddings/
 COPY packages/connector-worker/ packages/connector-worker/
 
-# Build core dist before connector-sdk (connector-sdk imports @lobu/core)
+# Build workspace dists required by runtime source imports.
+# connector-sdk imports @lobu/core; connector-worker/src/embeddings.ts imports
+# @lobu/embeddings, whose package exports point at dist/.
 RUN cd packages/core && bunx tsc \
-    && cd ../connector-sdk && bunx tsc
+    && cd ../connector-sdk && bunx tsc \
+    && cd ../embeddings && bunx tsc
 
 # ===========================================
 # Runtime

--- a/packages/server/src/gateway/auth/mcp/proxy.ts
+++ b/packages/server/src/gateway/auth/mcp/proxy.ts
@@ -583,7 +583,8 @@ export class McpProxy {
         mcpId,
         "POST",
         jsonRpcBody,
-        scopeKey
+        scopeKey,
+        httpServer.internal === true ? auth.token : undefined
       );
 
       const data = (await parseJsonRpcResponse(response)) as JsonRpcResponse;

--- a/packages/server/src/utils/connector-catalog.ts
+++ b/packages/server/src/utils/connector-catalog.ts
@@ -118,8 +118,12 @@ function getDefaultConnectorCatalogUri(): string {
 }
 
 export function findBundledConnectorFile(key: string): string | null {
-  const filePath = resolve(getDefaultConnectorCatalogDir(), `${key.replace(/\./g, '_')}.ts`);
-  return existsSync(filePath) ? filePath : null;
+  const fileName = `${key.replace(/\./g, '_')}.ts`;
+  for (const candidate of DEFAULT_CONNECTOR_DIR_CANDIDATES) {
+    const filePath = resolve(candidate, fileName);
+    if (existsSync(filePath)) return filePath;
+  }
+  return null;
 }
 
 export function normalizeFileSourceUri(value: string): string | null {

--- a/packages/server/src/utils/queue-helpers.ts
+++ b/packages/server/src/utils/queue-helpers.ts
@@ -10,6 +10,7 @@
 import type { DbClient } from '../db/client';
 import { getDb } from '../db/client';
 import type { Env } from '../index';
+import { findBundledConnectorFile } from './connector-catalog';
 import logger from '../utils/logger';
 import { isUniqueViolation } from '../utils/pg-errors';
 import { ACTIVE_RUN_STATUSES, runStatusLiteral } from './run-statuses';
@@ -109,13 +110,13 @@ async function createSyncRunWithClient(sql: DbClient, feedId: number): Promise<n
     );
   }
 
-  const { compiled_code, source_path } = versionRows[0] as {
+  const { compiled_code } = versionRows[0] as {
     compiled_code: string | null;
     source_path: string | null;
   };
-  if (!compiled_code && !source_path) {
+  if (!compiled_code && !findBundledConnectorFile(feed.connector_key)) {
     throw new Error(
-      `Connector '${feed.connector_key}' has no compiled code or source_path for version '${connectorVersion}'.`
+      `Connector '${feed.connector_key}' has no compiled code and no bundled source file for version '${connectorVersion}'.`
     );
   }
 

--- a/packages/server/src/worker-api.ts
+++ b/packages/server/src/worker-api.ts
@@ -183,6 +183,27 @@ export async function pollWorkerJob(c: Context<{ Bindings: Env }>) {
     auth_profile_auth_data: Record<string, unknown> | null;
   };
 
+  let compiledCode: string | undefined;
+  if (row.connector_key) {
+    try {
+      compiledCode = await resolveConnectorCode(row.connector_key, row.compiled_code);
+    } catch (err) {
+      const message = errorMessage(err);
+      await sql`
+        UPDATE runs
+        SET status = 'failed',
+            completed_at = current_timestamp,
+            error_message = ${message}
+        WHERE id = ${row.run_id}
+      `;
+      logger.error(
+        { run_id: row.run_id, connector_key: row.connector_key, err },
+        'Failed to resolve connector code for claimed worker run'
+      );
+      return c.json({ next_poll_seconds: 1, skipped_run_id: row.run_id, error: message });
+    }
+  }
+
   const { credentials, connectionCredentials, sessionState } = row.connection_id
     ? await resolveExecutionAuth({
         organizationId: row.organization_id,
@@ -213,9 +234,7 @@ export async function pollWorkerJob(c: Context<{ Bindings: Env }>) {
     credentials,
     connection_credentials:
       Object.keys(connectionCredentials).length > 0 ? connectionCredentials : undefined,
-    compiled_code: row.connector_key
-      ? await resolveConnectorCode(row.connector_key, row.compiled_code)
-      : undefined,
+    compiled_code: compiledCode,
     session_state: sessionState ?? undefined,
     action_key: row.action_key ?? undefined,
     action_input: (row as any).approved_input ?? row.action_input ?? undefined,


### PR DESCRIPTION
## Summary\n- build embeddings dist in the worker image (existing branch fix)\n- resolve bundled connector files across all runtime candidate directories so Reddit can compile from packages/connectors/src in the app image\n- mark claimed worker runs failed when connector code cannot be resolved instead of leaving them running until timeout\n- validate new sync runs against actual bundled source availability\n- forward worker JWT for internal lobu-memory tool-listing so watcher preflight direct auth works\n\n## Validation\n- bun run typecheck\n- bun run check (existing large JSON warning only)\n\n## Production recovery after merge\n- rollout app/worker images\n- terminalize stale Reddit connection 212 sync runs\n- trigger Reddit feeds and watcher 218\n