### PR TITLE
fix(gateway): handle missing Lobu org context

### DIFF
--- a/packages/server/src/lobu/gateway.ts
+++ b/packages/server/src/lobu/gateway.ts
@@ -42,7 +42,7 @@ const defaultOrgCache = new Map<string, { orgId: string | null; expiresAt: numbe
 async function resolveDefaultOrgId(userId: string): Promise<string | null> {
   const cached = defaultOrgCache.get(userId);
   if (cached && cached.expiresAt > Date.now()) return cached.orgId;
-  let orgId: string | null = null;
+
   try {
     const sql = getDb();
     const rows = await sql`
@@ -52,18 +52,20 @@ async function resolveDefaultOrgId(userId: string): Promise<string | null> {
       ORDER BY m."createdAt" ASC
       LIMIT 1
     `;
-    orgId = (rows[0]?.organization_id as string | undefined) ?? null;
+    const orgId = (rows[0]?.organization_id as string | undefined) ?? null;
+    if (orgId) {
+      defaultOrgCache.set(userId, { orgId, expiresAt: Date.now() + DEFAULT_ORG_TTL_MS });
+    }
+    return orgId;
   } catch (err) {
-    // The DB may not be reachable yet at request time (e.g. boot races) —
-    // fail open so the rest of the request can still proceed; the route
-    // handler will surface its own error if it actually needs the org.
+    // The DB may not be reachable yet at request time (e.g. boot races).
+    // Do not cache that transient miss; callers decide how to surface it.
     logger.warn(
       { err: err instanceof Error ? err.message : String(err) },
-      '[Lobu] resolveDefaultOrgId: lookup failed, returning null'
+      '[Lobu] resolveDefaultOrgId: lookup failed'
     );
+    throw err;
   }
-  defaultOrgCache.set(userId, { orgId, expiresAt: Date.now() + DEFAULT_ORG_TTL_MS });
-  return orgId;
 }
 
 type EmbeddedSettingsSession = {
@@ -284,10 +286,14 @@ export async function initLobuGateway(): Promise<Hono | null> {
         await next();
         return;
       }
-      const orgId = await resolveDefaultOrgId(user.id);
+      let orgId: string | null;
+      try {
+        orgId = await resolveDefaultOrgId(user.id);
+      } catch {
+        return c.json({ error: 'Unable to resolve organization membership' }, 503);
+      }
       if (!orgId) {
-        await next();
-        return;
+        return c.json({ error: 'No organization membership found' }, 404);
       }
       c.set('organizationId', orgId);
       await orgContext.run({ organizationId: orgId }, () => next());

--- a/scripts/run-e2e.sh
+++ b/scripts/run-e2e.sh
@@ -37,6 +37,37 @@ USE_FAKE_LLM="${LOBU_E2E_FAKE_LLM:-1}"
 FAKE_LLM_PORT="${LOBU_E2E_FAKE_LLM_PORT:-9876}"
 FAKE_LLM_BASE_URL="http://127.0.0.1:${FAKE_LLM_PORT}"
 
+process_cwd() {
+  lsof -a -p "$1" -d cwd -Fn 2>/dev/null | sed -n 's/^n//p' | head -1
+}
+
+is_repo_process() {
+  local cwd
+  cwd="$(process_cwd "$1")"
+  [[ "$cwd" == "$REPO_ROOT" || "$cwd" == "$REPO_ROOT"/* ]]
+}
+
+kill_repo_pid() {
+  local pid="$1"
+  if [[ -n "$pid" ]] && kill -0 "$pid" 2>/dev/null && is_repo_process "$pid"; then
+    kill "$pid" 2>/dev/null || true
+    for _ in 1 2 3 4 5; do
+      kill -0 "$pid" 2>/dev/null || return 0
+      sleep 1
+    done
+    kill -9 "$pid" 2>/dev/null || true
+  fi
+}
+
+kill_repo_dev_processes() {
+  local pattern pid
+  for pattern in 'tsx watch.*src/server.ts' 'node.*src/server.ts'; do
+    while IFS= read -r pid; do
+      kill_repo_pid "$pid"
+    done < <(pgrep -f "$pattern" 2>/dev/null || true)
+  done
+}
+
 cleanup() {
   for pidfile in "$PIDFILE" "$FAKE_LLM_PIDFILE"; do
     if [[ -s "$pidfile" ]]; then
@@ -51,16 +82,18 @@ cleanup() {
       fi
     fi
   done
-  # tsx watch fork-spawns a child node that holds :8118 / :8787 — pkill the
-  # whole tree, then double-check via port owner so a stale orphan from a
-  # crashed prior run can't keep the next run from booting.
-  pkill -f 'tsx watch.*src/server.ts' 2>/dev/null || true
-  pkill -f 'node.*src/server.ts' 2>/dev/null || true
-  for port in 8118 8787 "$FAKE_LLM_PORT"; do
-    holder=$(lsof -ti :"$port" 2>/dev/null || true)
-    if [[ -n "$holder" ]]; then
-      kill -9 $holder 2>/dev/null || true
-    fi
+  # tsx watch fork-spawns child processes that can hold :8118 / $PORT after
+  # the parent exits. Only kill processes whose cwd is this checkout so a
+  # sibling dev server in another worktree survives cleanup.
+  kill_repo_dev_processes
+  ports=(8118 "$PORT")
+  if [[ "$USE_FAKE_LLM" != "0" ]]; then
+    ports+=("$FAKE_LLM_PORT")
+  fi
+  for port in "${ports[@]}"; do
+    while IFS= read -r holder; do
+      kill_repo_pid "$holder"
+    done < <(lsof -ti :"$port" 2>/dev/null || true)
   done
   rm -f "$PIDFILE" "$FAKE_LLM_PIDFILE"
   echo "  server log retained at: $LOG"
@@ -96,14 +129,21 @@ fi
 if [[ "$USE_FAKE_LLM" != "0" ]]; then
   echo "Starting fake LLM server on ${FAKE_LLM_BASE_URL}..."
   (
-    bun -e "
-      import('${REPO_ROOT}/packages/server/src/__tests__/fixtures/fake-llm-server.ts').then(async ({ startFakeLlmServer }) => {
-        const handle = await startFakeLlmServer({ port: ${FAKE_LLM_PORT} });
-        process.stdout.write('fake-llm listening at ' + handle.url + '\\n');
+    FAKE_LLM_MODULE="${REPO_ROOT}/packages/server/src/__tests__/fixtures/fake-llm-server.ts" \
+    FAKE_LLM_PORT="$FAKE_LLM_PORT" \
+    bun -e '
+      const modulePath = process.env.FAKE_LLM_MODULE;
+      const port = Number(process.env.FAKE_LLM_PORT);
+      if (!modulePath || !Number.isInteger(port)) {
+        throw new Error("FAKE_LLM_MODULE and numeric FAKE_LLM_PORT are required");
+      }
+      import(modulePath).then(async ({ startFakeLlmServer }) => {
+        const handle = await startFakeLlmServer({ port });
+        process.stdout.write("fake-llm listening at " + handle.url + "\n");
         // Keep the process alive
         setInterval(() => {}, 1 << 30);
       }).catch((err) => { console.error(err); process.exit(1); });
-    " >"$FAKE_LLM_LOG" 2>&1 &
+    ' >"$FAKE_LLM_LOG" 2>&1 &
     echo $! > "$FAKE_LLM_PIDFILE"
   ) || true
   # Wait for the fake to bind
@@ -143,6 +183,11 @@ echo "Server healthy"
 
 # 6. Run the e2e suite
 echo "Running openclaw-plugin e2e..."
-APP_URL="$APP_URL" \
-LOBU_E2E_FAKE_LLM_URL="${FAKE_LLM_BASE_URL}" \
-  bun run --cwd packages/openclaw-plugin test:e2e
+if [[ "$USE_FAKE_LLM" != "0" ]]; then
+  APP_URL="$APP_URL" \
+  LOBU_E2E_FAKE_LLM_URL="${FAKE_LLM_BASE_URL}" \
+    bun run --cwd packages/openclaw-plugin test:e2e
+else
+  APP_URL="$APP_URL" \
+    bun run --cwd packages/openclaw-plugin test:e2e
+fi


### PR DESCRIPTION
## Summary
- avoid caching failed/missing default-org lookups as null
- return explicit Lobu org resolution errors instead of letting orgContext-dependent routes 500
- scope run-e2e cleanup to the current checkout, honor $PORT, and only expose fake-LLM env when enabled
- pass the fake-LLM module path to bun via env instead of interpolating REPO_ROOT into JS

## Validation
- bash -n scripts/run-e2e.sh
- make build-packages
- bun run typecheck
- read-only reviewer subagent: LGTM
