### PR TITLE
fix(gateway): initialize memory tool listing

### DIFF
--- a/packages/server/src/gateway/auth/mcp/proxy.ts
+++ b/packages/server/src/gateway/auth/mcp/proxy.ts
@@ -570,6 +570,48 @@ export class McpProxy {
     }
 
     try {
+      try {
+        const initBody = JSON.stringify({
+          jsonrpc: "2.0",
+          method: "initialize",
+          params: {
+            protocolVersion: "2024-11-05",
+            capabilities: {},
+            clientInfo: { name: "lobu-gateway", version: "1.0.0" },
+          },
+          id: 0,
+        });
+        await this.sendUpstreamRequest(
+          httpServer,
+          agentId,
+          mcpId,
+          "POST",
+          initBody,
+          scopeKey,
+          httpServer.internal === true ? auth.token : undefined
+        );
+        const notifyBody = JSON.stringify({
+          jsonrpc: "2.0",
+          method: "notifications/initialized",
+        });
+        await this.sendUpstreamRequest(
+          httpServer,
+          agentId,
+          mcpId,
+          "POST",
+          notifyBody,
+          scopeKey,
+          httpServer.internal === true ? auth.token : undefined
+        ).catch(() => {
+          /* noop */
+        });
+      } catch (initError) {
+        logger.warn("MCP initialize failed before listing tools", {
+          mcpId,
+          error: initError instanceof Error ? initError.message : String(initError),
+        });
+      }
+
       const jsonRpcBody = JSON.stringify({
         jsonrpc: "2.0",
         method: "tools/list",


### PR DESCRIPTION
## Summary\n- initialize MCP streamable-HTTP sessions before GET /:mcpId/tools performs tools/list\n- keeps worker JWT forwarding for internal lobu-memory direct auth\n- fixes watcher preflight failures with 'Server not initialized'\n\n## Validation\n- bun run typecheck\n- bun run check\n