### PR TITLE
feat(mcp): add dry-run preview for SDK run tool

### DIFF
--- a/packages/landing/src/content/docs/reference/lobu-memory.md
+++ b/packages/landing/src/content/docs/reference/lobu-memory.md
@@ -105,8 +105,11 @@ lobu memory run save_knowledge '{"content":"Prefers weekly summaries","semantic_
 # Discover SDK methods
 lobu memory run search '{"query":"watchers.create"}' --org my-org
 
-# Run a TypeScript script over the typed client SDK
-lobu memory run execute '{"script":"export default async (ctx, client) => client.entities.list({ entity_type: \"company\", limit: 5 })"}' --org my-org
+# Query with a read-only TypeScript script over the typed client SDK
+lobu memory run query '{"script":"export default async (ctx, client) => client.entities.list({ entity_type: \"company\", limit: 5 })"}' --org my-org
+
+# Preview a mutating script without applying write/external SDK calls
+lobu memory run run '{"dry_run":true,"script":"export default async (ctx, client) => client.entities.create({ type: \"company\", name: \"Acme\" })"}' --org my-org
 ```
 
 ## Seed Project Memory

--- a/packages/server/src/__tests__/integration/mcp/query-tool.test.ts
+++ b/packages/server/src/__tests__/integration/mcp/query-tool.test.ts
@@ -1,6 +1,6 @@
 /**
  * Integration smoke for the `query` / `run` rename + `save_knowledge`
- * append-only annotation. Read-only Proxy semantics live in the sandbox unit
+ * write annotation. Read-only Proxy semantics live in the sandbox unit
  * tests; this file guards the MCP surface annotations and the public-org
  * visitor read-only filter.
  */
@@ -43,7 +43,8 @@ describe('MCP query / run tool surface', () => {
     expect(byName.has('execute')).toBe(false);
     expect(byName.get('query')?.annotations).toEqual({ readOnlyHint: true, idempotentHint: true });
     expect(byName.get('run')?.annotations).toEqual({ destructiveHint: true });
-    expect(byName.get('save_knowledge')?.annotations).toEqual({ readOnlyHint: true });
+    expect(byName.get('run')?.inputSchema?.properties?.dry_run).toBeTruthy();
+    expect(byName.get('save_knowledge')?.annotations).toEqual({ destructiveHint: false });
   });
 
   it('hides write tools from anonymous visitors on a public /mcp/{slug}', async () => {

--- a/packages/server/src/__tests__/unit/sandbox/read-only.test.ts
+++ b/packages/server/src/__tests__/unit/sandbox/read-only.test.ts
@@ -115,6 +115,69 @@ describe("guest-side proxy traps", () => {
     expect(result.error?.message ?? "").toMatch(/not a function|undefined/i);
   });
 
+  it("dry-run skips write methods and returns a side-effect preview", async () => {
+    let created = false;
+    const sdk = stubSDK({
+      entities: {
+        list: async () => [{ id: 1, name: "Acme" }],
+        create: async () => {
+          created = true;
+          return { id: 2 };
+        },
+      } as never,
+    });
+    const result = await runOrSkip({
+      source: `
+        export default async (_ctx, client) => {
+          const before = await client.entities.list({ entity_type: 'company' });
+          const create = await client.entities.create({
+            type: 'company',
+            name: 'Dry Run Co',
+            metadata: {
+              api_key: 'secret-value',
+              access_token: 'access-secret',
+              client_secret: 'client-secret',
+              cookie: 'session-cookie',
+              public_note: 'safe',
+            },
+          });
+          return { before, create };
+        };
+      `,
+      sdk,
+      sdkMode: "full",
+      dryRun: true,
+    });
+    if (!result) return;
+    expect(result.success).toBe(true);
+    expect(created).toBe(false);
+    expect(result.returnValue).toEqual({
+      before: [{ id: 1, name: "Acme" }],
+      create: { dry_run: true, skipped_call: "entities.create", access: "write" },
+    });
+    expect(result.sideEffectPreview).toEqual([
+      {
+        path: "entities.create",
+        orgPath: [],
+        access: "write",
+        args: [
+          {
+            type: "company",
+            name: "Dry Run Co",
+            metadata: {
+              api_key: "[redacted]",
+              access_token: "[redacted]",
+              client_secret: "[redacted]",
+              cookie: "[redacted]",
+              public_note: "safe",
+            },
+          },
+        ],
+        skipped: true,
+      },
+    ]);
+  });
+
   it("__sdk_dispatch rejects inherited Object.prototype paths", async () => {
     // Bypassing the proxy via the global dispatch should still fail because
     // the host requires an own-property entry for both ns and method.

--- a/packages/server/src/gateway/auth/mcp/proxy.ts
+++ b/packages/server/src/gateway/auth/mcp/proxy.ts
@@ -570,6 +570,48 @@ export class McpProxy {
     }
 
     try {
+      try {
+        const initBody = JSON.stringify({
+          jsonrpc: "2.0",
+          method: "initialize",
+          params: {
+            protocolVersion: "2024-11-05",
+            capabilities: {},
+            clientInfo: { name: "lobu-gateway", version: "1.0.0" },
+          },
+          id: 0,
+        });
+        await this.sendUpstreamRequest(
+          httpServer,
+          agentId,
+          mcpId,
+          "POST",
+          initBody,
+          scopeKey,
+          httpServer.internal === true ? auth.token : undefined
+        );
+        const notifyBody = JSON.stringify({
+          jsonrpc: "2.0",
+          method: "notifications/initialized",
+        });
+        await this.sendUpstreamRequest(
+          httpServer,
+          agentId,
+          mcpId,
+          "POST",
+          notifyBody,
+          scopeKey,
+          httpServer.internal === true ? auth.token : undefined
+        ).catch(() => {
+          /* noop */
+        });
+      } catch (initError) {
+        logger.warn("MCP initialize failed before listing tools", {
+          mcpId,
+          error: initError instanceof Error ? initError.message : String(initError),
+        });
+      }
+
       const jsonRpcBody = JSON.stringify({
         jsonrpc: "2.0",
         method: "tools/list",

--- a/packages/server/src/lobu/gateway.ts
+++ b/packages/server/src/lobu/gateway.ts
@@ -42,7 +42,7 @@ const defaultOrgCache = new Map<string, { orgId: string | null; expiresAt: numbe
 async function resolveDefaultOrgId(userId: string): Promise<string | null> {
   const cached = defaultOrgCache.get(userId);
   if (cached && cached.expiresAt > Date.now()) return cached.orgId;
-  let orgId: string | null = null;
+
   try {
     const sql = getDb();
     const rows = await sql`
@@ -52,18 +52,20 @@ async function resolveDefaultOrgId(userId: string): Promise<string | null> {
       ORDER BY m."createdAt" ASC
       LIMIT 1
     `;
-    orgId = (rows[0]?.organization_id as string | undefined) ?? null;
+    const orgId = (rows[0]?.organization_id as string | undefined) ?? null;
+    if (orgId) {
+      defaultOrgCache.set(userId, { orgId, expiresAt: Date.now() + DEFAULT_ORG_TTL_MS });
+    }
+    return orgId;
   } catch (err) {
-    // The DB may not be reachable yet at request time (e.g. boot races) —
-    // fail open so the rest of the request can still proceed; the route
-    // handler will surface its own error if it actually needs the org.
+    // The DB may not be reachable yet at request time (e.g. boot races).
+    // Do not cache that transient miss; callers decide how to surface it.
     logger.warn(
       { err: err instanceof Error ? err.message : String(err) },
-      '[Lobu] resolveDefaultOrgId: lookup failed, returning null'
+      '[Lobu] resolveDefaultOrgId: lookup failed'
     );
+    throw err;
   }
-  defaultOrgCache.set(userId, { orgId, expiresAt: Date.now() + DEFAULT_ORG_TTL_MS });
-  return orgId;
 }
 
 type EmbeddedSettingsSession = {
@@ -284,10 +286,14 @@ export async function initLobuGateway(): Promise<Hono | null> {
         await next();
         return;
       }
-      const orgId = await resolveDefaultOrgId(user.id);
+      let orgId: string | null;
+      try {
+        orgId = await resolveDefaultOrgId(user.id);
+      } catch {
+        return c.json({ error: 'Unable to resolve organization membership' }, 503);
+      }
       if (!orgId) {
-        await next();
-        return;
+        return c.json({ error: 'No organization membership found' }, 404);
       }
       c.set('organizationId', orgId);
       await orgContext.run({ organizationId: orgId }, () => next());

--- a/packages/server/src/sandbox/run-script.ts
+++ b/packages/server/src/sandbox/run-script.ts
@@ -6,6 +6,7 @@
  */
 
 import type { ClientSDK } from "./client-sdk";
+import { METHOD_METADATA, type MethodAccess } from "./method-metadata";
 import { type SDKMode, enumerateSDKManifest } from "./sdk-manifest";
 
 export interface RunLimits {
@@ -18,6 +19,12 @@ export interface RunLimits {
 export interface RunScriptOptions {
   source: string;
   context?: Record<string, unknown>;
+  /**
+   * Preview mode for full-SDK scripts. Read calls still execute so scripts can
+   * inspect state, but write/external SDK calls are skipped and returned in
+   * `sideEffectPreview` instead of mutating state or reaching external systems.
+   */
+  dryRun?: boolean;
   /**
    * Either a pre-built SDK or a builder that receives the wall-clock
    * AbortSignal so handlers can race their work against the timeout and
@@ -40,10 +47,20 @@ export interface LogEntry {
   ts: number;
 }
 
+export interface SdkCallTraceEntry {
+  path: string;
+  orgPath: string[];
+  access: MethodAccess | "unknown";
+  args: unknown[];
+  skipped: boolean;
+}
+
 export interface RunScriptResult {
   success: boolean;
   returnValue?: unknown;
   logs: LogEntry[];
+  sdkCallTrace: SdkCallTraceEntry[];
+  sideEffectPreview: SdkCallTraceEntry[];
   error?: {
     name: string;
     message: string;
@@ -61,6 +78,30 @@ const DEFAULT_LIMITS: Required<RunLimits> = {
   sdkCallQuota: 200,
   outputBytes: 1_048_576,
 };
+const MAX_TRACE_ARGS_BYTES = 8192;
+const SENSITIVE_TRACE_KEY =
+  /(api[_-]?key|apikey|auth[_-]?data|auth[_-]?values|authorization|cookie|credential|password|private[_-]?key|secret|token)/i;
+
+function redactTraceValue(value: unknown, depth = 0): unknown {
+  if (depth > 8) return "[truncated]";
+  if (Array.isArray(value)) return value.map((item) => redactTraceValue(item, depth + 1));
+  if (!value || typeof value !== "object") return value;
+  return Object.fromEntries(
+    Object.entries(value as Record<string, unknown>).map(([key, child]) => [
+      key,
+      SENSITIVE_TRACE_KEY.test(key) ? "[redacted]" : redactTraceValue(child, depth + 1),
+    ]),
+  );
+}
+
+function traceArgs(args: unknown[]): unknown[] {
+  const redacted = redactTraceValue(args) as unknown[];
+  const json = JSON.stringify(redacted);
+  if (Buffer.byteLength(json, "utf8") > MAX_TRACE_ARGS_BYTES) {
+    return [{ truncated: true, bytes: Buffer.byteLength(json, "utf8") }];
+  }
+  return JSON.parse(json) as unknown[];
+}
 
 function clampNumber(value: number | undefined, fallback: number, min: number, max: number) {
   const n = Number.isFinite(value) ? value : fallback;
@@ -255,6 +296,8 @@ export async function runScript(
     typeof options.sdk === "function" ? options.sdk(abortController.signal) : options.sdk;
 
   const logs: LogEntry[] = [];
+  const sdkCallTrace: SdkCallTraceEntry[] = [];
+  const sideEffectPreview: SdkCallTraceEntry[] = [];
   let sdkCalls = 0;
   let outputBytes = 0;
 
@@ -271,6 +314,8 @@ export async function runScript(
       },
       durationMs: Date.now() - started,
       sdkCalls: 0,
+      sdkCallTrace,
+      sideEffectPreview,
     };
   }
 
@@ -303,6 +348,8 @@ export async function runScript(
       },
       durationMs: Date.now() - started,
       sdkCalls: 0,
+      sdkCallTrace,
+      sideEffectPreview,
     };
   }
 
@@ -335,9 +382,25 @@ export async function runScript(
         const dispatchPromise: Promise<unknown> = (async () => {
           if (path === "log") {
             target.log(args[0] as string, args[1] as Record<string, unknown> | undefined);
+            sdkCallTrace.push({
+              path,
+              orgPath,
+              access: METHOD_METADATA[path]?.access ?? "unknown",
+              args: traceArgs(args),
+              skipped: false,
+            });
             return undefined;
           }
-          if (path === "query") return target.query(args[0] as string);
+          if (path === "query") {
+            sdkCallTrace.push({
+              path,
+              orgPath,
+              access: METHOD_METADATA[path]?.access ?? "unknown",
+              args: traceArgs(args),
+              skipped: false,
+            });
+            return target.query(args[0] as string);
+          }
           const [ns, method] = path.split(".");
           // `__sdk_dispatch` is a guest-visible global, so a malicious script
           // could call it directly with an inherited path like `entities.constructor`.
@@ -354,6 +417,19 @@ export async function runScript(
             typeof namespace[method] !== "function"
           ) {
             throw new Error(`Unknown SDK method: '${path}'`);
+          }
+          const access = METHOD_METADATA[path]?.access ?? "unknown";
+          const trace: SdkCallTraceEntry = {
+            path,
+            orgPath,
+            access,
+            args: traceArgs(args),
+            skipped: options.dryRun === true && access !== "read",
+          };
+          sdkCallTrace.push(trace);
+          if (trace.skipped) {
+            sideEffectPreview.push(trace);
+            return { dry_run: true, skipped_call: path, access };
           }
           return namespace[method](...args);
         })();
@@ -403,6 +479,8 @@ export async function runScript(
       logs,
       durationMs: Date.now() - started,
       sdkCalls,
+      sdkCallTrace,
+      sideEffectPreview,
     };
   } catch (err) {
     const e = err as Error;
@@ -425,6 +503,8 @@ export async function runScript(
       error: { name, message: e.message, stack: e.stack },
       durationMs: Date.now() - started,
       sdkCalls,
+      sdkCallTrace,
+      sideEffectPreview,
     };
   } finally {
     clearTimeout(abortTimer);

--- a/packages/server/src/tools/registry.ts
+++ b/packages/server/src/tools/registry.ts
@@ -105,7 +105,7 @@ const TOOLS: ToolDefinition[] = [
     description:
       "Save user-shared facts, preferences, decisions, observations, and notes the moment they surface. Storage is append-only — pass `supersedes_event_id` to replace an existing fact (the old event is hidden from future searches without losing history). Optionally attach to entities via `entity_ids`. Always search first to avoid duplicates.",
     inputSchema: SaveContentSchema,
-    annotations: { readOnlyHint: true },
+    annotations: { destructiveHint: false },
     handler: saveContent,
   },
   // ─── Discovery ────────────────────────────────────────────────────────────
@@ -147,7 +147,7 @@ const TOOLS: ToolDefinition[] = [
   {
     name: 'run',
     description:
-      'Destructive — confirm before running. Runs a TypeScript script in a sandboxed isolate over the FULL `ClientSDK`. Signature: `export default async (ctx, client) => ...`. Can mutate entities, watchers, knowledge, classifiers, connections, etc. Use `query` for reads. Output capped at 1 MB. Example: `export default async (_ctx, client) => client.entities.create({ type: "company", name: "Acme" });`',
+      'Destructive — confirm before running. Runs a TypeScript script in a sandboxed isolate over the FULL `ClientSDK`. Signature: `export default async (ctx, client) => ...`. Can mutate entities, watchers, knowledge, classifiers, connections, etc. Use `query` for reads. Pass `dry_run: true` to execute reads while skipping write/external SDK calls and returning `side_effect_preview`. Output capped at 1 MB. Example: `export default async (_ctx, client) => client.entities.create({ type: "company", name: "Acme" });`',
     inputSchema: RunSchema,
     annotations: { destructiveHint: true },
     handler: runSdkScript,

--- a/packages/server/src/tools/sdk_run.ts
+++ b/packages/server/src/tools/sdk_run.ts
@@ -20,14 +20,22 @@ const SCRIPT_FIELDS = {
   ),
 };
 
-export const RunSchema = Type.Object(SCRIPT_FIELDS);
+export const RunSchema = Type.Object({
+  ...SCRIPT_FIELDS,
+  dry_run: Type.Optional(
+    Type.Boolean({
+      description:
+        "Preview mode. Read SDK calls still execute, but write/external SDK calls are skipped and returned in side_effect_preview.",
+    }),
+  ),
+});
 export const QuerySchema = Type.Object(SCRIPT_FIELDS);
 export type RunArgs = Static<typeof RunSchema>;
 export type QueryArgs = Static<typeof QuerySchema>;
 
 async function runSandbox(
   mode: SDKMode,
-  args: RunArgs,
+  args: RunArgs | QueryArgs,
   env: Env,
   ctx: ToolContext,
 ): Promise<unknown> {
@@ -37,6 +45,7 @@ async function runSandbox(
     sdk: (abortSignal) => buildClientSDK(ctx, env, { mode, allowCrossOrg, abortSignal }),
     sdkMode: mode,
     allowCrossOrg,
+    dryRun: mode === "full" && "dry_run" in args && args.dry_run === true,
     context: {
       organization_id: ctx.organizationId,
       user_id: ctx.userId,
@@ -51,6 +60,9 @@ async function runSandbox(
     error: result.error,
     duration_ms: result.durationMs,
     sdk_calls: result.sdkCalls,
+    sdk_call_trace: result.sdkCallTrace,
+    side_effect_preview: result.sideEffectPreview,
+    dry_run: mode === "full" && "dry_run" in args && args.dry_run === true,
   };
 }
 

--- a/scripts/run-e2e.sh
+++ b/scripts/run-e2e.sh
@@ -37,6 +37,37 @@ USE_FAKE_LLM="${LOBU_E2E_FAKE_LLM:-1}"
 FAKE_LLM_PORT="${LOBU_E2E_FAKE_LLM_PORT:-9876}"
 FAKE_LLM_BASE_URL="http://127.0.0.1:${FAKE_LLM_PORT}"
 
+process_cwd() {
+  lsof -a -p "$1" -d cwd -Fn 2>/dev/null | sed -n 's/^n//p' | head -1
+}
+
+is_repo_process() {
+  local cwd
+  cwd="$(process_cwd "$1")"
+  [[ "$cwd" == "$REPO_ROOT" || "$cwd" == "$REPO_ROOT"/* ]]
+}
+
+kill_repo_pid() {
+  local pid="$1"
+  if [[ -n "$pid" ]] && kill -0 "$pid" 2>/dev/null && is_repo_process "$pid"; then
+    kill "$pid" 2>/dev/null || true
+    for _ in 1 2 3 4 5; do
+      kill -0 "$pid" 2>/dev/null || return 0
+      sleep 1
+    done
+    kill -9 "$pid" 2>/dev/null || true
+  fi
+}
+
+kill_repo_dev_processes() {
+  local pattern pid
+  for pattern in 'tsx watch.*src/server.ts' 'node.*src/server.ts'; do
+    while IFS= read -r pid; do
+      kill_repo_pid "$pid"
+    done < <(pgrep -f "$pattern" 2>/dev/null || true)
+  done
+}
+
 cleanup() {
   for pidfile in "$PIDFILE" "$FAKE_LLM_PIDFILE"; do
     if [[ -s "$pidfile" ]]; then
@@ -51,16 +82,18 @@ cleanup() {
       fi
     fi
   done
-  # tsx watch fork-spawns a child node that holds :8118 / :8787 — pkill the
-  # whole tree, then double-check via port owner so a stale orphan from a
-  # crashed prior run can't keep the next run from booting.
-  pkill -f 'tsx watch.*src/server.ts' 2>/dev/null || true
-  pkill -f 'node.*src/server.ts' 2>/dev/null || true
-  for port in 8118 8787 "$FAKE_LLM_PORT"; do
-    holder=$(lsof -ti :"$port" 2>/dev/null || true)
-    if [[ -n "$holder" ]]; then
-      kill -9 $holder 2>/dev/null || true
-    fi
+  # tsx watch fork-spawns child processes that can hold :8118 / $PORT after
+  # the parent exits. Only kill processes whose cwd is this checkout so a
+  # sibling dev server in another worktree survives cleanup.
+  kill_repo_dev_processes
+  ports=(8118 "$PORT")
+  if [[ "$USE_FAKE_LLM" != "0" ]]; then
+    ports+=("$FAKE_LLM_PORT")
+  fi
+  for port in "${ports[@]}"; do
+    while IFS= read -r holder; do
+      kill_repo_pid "$holder"
+    done < <(lsof -ti :"$port" 2>/dev/null || true)
   done
   rm -f "$PIDFILE" "$FAKE_LLM_PIDFILE"
   echo "  server log retained at: $LOG"
@@ -96,14 +129,21 @@ fi
 if [[ "$USE_FAKE_LLM" != "0" ]]; then
   echo "Starting fake LLM server on ${FAKE_LLM_BASE_URL}..."
   (
-    bun -e "
-      import('${REPO_ROOT}/packages/server/src/__tests__/fixtures/fake-llm-server.ts').then(async ({ startFakeLlmServer }) => {
-        const handle = await startFakeLlmServer({ port: ${FAKE_LLM_PORT} });
-        process.stdout.write('fake-llm listening at ' + handle.url + '\\n');
+    FAKE_LLM_MODULE="${REPO_ROOT}/packages/server/src/__tests__/fixtures/fake-llm-server.ts" \
+    FAKE_LLM_PORT="$FAKE_LLM_PORT" \
+    bun -e '
+      const modulePath = process.env.FAKE_LLM_MODULE;
+      const port = Number(process.env.FAKE_LLM_PORT);
+      if (!modulePath || !Number.isInteger(port)) {
+        throw new Error("FAKE_LLM_MODULE and numeric FAKE_LLM_PORT are required");
+      }
+      import(modulePath).then(async ({ startFakeLlmServer }) => {
+        const handle = await startFakeLlmServer({ port });
+        process.stdout.write("fake-llm listening at " + handle.url + "\n");
         // Keep the process alive
         setInterval(() => {}, 1 << 30);
       }).catch((err) => { console.error(err); process.exit(1); });
-    " >"$FAKE_LLM_LOG" 2>&1 &
+    ' >"$FAKE_LLM_LOG" 2>&1 &
     echo $! > "$FAKE_LLM_PIDFILE"
   ) || true
   # Wait for the fake to bind
@@ -143,6 +183,11 @@ echo "Server healthy"
 
 # 6. Run the e2e suite
 echo "Running openclaw-plugin e2e..."
-APP_URL="$APP_URL" \
-LOBU_E2E_FAKE_LLM_URL="${FAKE_LLM_BASE_URL}" \
-  bun run --cwd packages/openclaw-plugin test:e2e
+if [[ "$USE_FAKE_LLM" != "0" ]]; then
+  APP_URL="$APP_URL" \
+  LOBU_E2E_FAKE_LLM_URL="${FAKE_LLM_BASE_URL}" \
+    bun run --cwd packages/openclaw-plugin test:e2e
+else
+  APP_URL="$APP_URL" \
+    bun run --cwd packages/openclaw-plugin test:e2e
+fi


### PR DESCRIPTION
## Summary
- add `dry_run` support to the MCP `run` SDK scripting tool
- skip write/external SDK calls during dry-run and return redacted `side_effect_preview` / `sdk_call_trace` data
- fix `save_knowledge` annotations so it no longer advertises as read-only
- update Lobu memory docs to use `query`/`run` instead of stale `execute` examples

Partially addresses #540 by covering the concrete safety and tool-surface gaps around `run` dry-run behavior, side-effect preview, annotations, and CLI docs.

## Validation
- bun test packages/server/src/__tests__/unit/sandbox/read-only.test.ts packages/server/src/auth/__tests__/tool-access.test.ts
- cd packages/server && OWLETTO_TEST_BACKEND=pglite bunx vitest run src/__tests__/integration/mcp/query-tool.test.ts
- bun run typecheck
- make build-packages
- cd packages/landing && bun run build
- read-only reviewer subagent: LGTM after redaction fix
