### PR TITLE
fix(worker): accept nested platform metadata

### DIFF
--- a/packages/agent-worker/src/__tests__/sse-client.test.ts
+++ b/packages/agent-worker/src/__tests__/sse-client.test.ts
@@ -8,6 +8,48 @@ describe("GatewayClient heartbeat ACKs", () => {
     globalThis.fetch = originalFetch;
   });
 
+  test("accepts nested platform metadata on job events", async () => {
+    const client = new GatewayClient(
+      "https://gateway.example.com",
+      "worker-token",
+      "user-1",
+      "worker-1"
+    );
+    const handleThreadMessage = mock(async () => undefined);
+    (client as any).handleThreadMessage = handleThreadMessage;
+
+    await (client as any).handleEvent(
+      "job",
+      JSON.stringify({
+        payload: {
+          botId: "lobu-api",
+          userId: "watcher_218",
+          agentId: "marketing",
+          conversationId: "marketing_watcher_218_run_120947",
+          platform: "api",
+          channelId: "api_watcher_218",
+          messageId: "message-1",
+          messageText: "run watcher",
+          platformMetadata: {
+            agentId: "marketing",
+            source: "watcher-run",
+            intent: { kind: "watcher_run", runId: 120947, watcherId: 218 },
+          },
+          agentOptions: {},
+        },
+      })
+    );
+
+    expect(handleThreadMessage).toHaveBeenCalledTimes(1);
+    expect(
+      handleThreadMessage.mock.calls[0]?.[0].platformMetadata.intent
+    ).toEqual({
+      kind: "watcher_run",
+      runId: 120947,
+      watcherId: 218,
+    });
+  });
+
   test("ACKs heartbeat pings over the worker response endpoint", async () => {
     const fetchMock = mock(
       async (_url: string | URL | Request, _options?: RequestInit) =>

--- a/packages/agent-worker/src/gateway/sse-client.ts
+++ b/packages/agent-worker/src/gateway/sse-client.ts
@@ -48,7 +48,10 @@ const ConnectedEventSchema = z.object({
   deploymentName: z.string(),
 });
 
-// PlatformMetadata has known fields plus string index signature
+// Platform metadata is a transport envelope for platform-specific details.
+// Known chat fields are typed below, but gateway callers may include nested
+// objects such as watcher run intent metadata, file descriptors, or provider
+// context. Preserve those values instead of rejecting otherwise valid jobs.
 const PlatformMetadataSchema = z
   .object({
     team_id: z.string().optional(),
@@ -57,18 +60,7 @@ const PlatformMetadataSchema = z
     thread_ts: z.string().optional(),
     files: z.array(z.any()).optional(),
   })
-  .and(
-    z.record(
-      z.string(),
-      z.union([
-        z.string(),
-        z.number(),
-        z.boolean(),
-        z.array(z.any()),
-        z.undefined(),
-      ])
-    )
-  );
+  .catchall(z.unknown());
 
 // AgentOptions has known fields plus arbitrary extra fields (including nested objects)
 const AgentOptionsSchema = z

--- a/packages/agent-worker/src/gateway/types.ts
+++ b/packages/agent-worker/src/gateway/types.ts
@@ -14,7 +14,7 @@ interface PlatformMetadata {
   thread_ts?: string;
   files?: unknown[];
   traceId?: string; // Trace ID for end-to-end observability
-  [key: string]: string | number | boolean | unknown[] | undefined;
+  [key: string]: unknown;
 }
 
 /**


### PR DESCRIPTION
## Summary
- allow nested platform metadata objects in agent-worker SSE job validation
- widen the platform metadata TypeScript index signature to match transport usage
- cover watcher-run intent metadata in the SSE client test

## Validation
- bun test packages/agent-worker/src/__tests__/sse-client.test.ts
- bun run typecheck
- bun run check