### PR TITLE
fix(watchers): harden window completion

### DIFF
--- a/packages/server/src/tools/admin/manage_watchers.ts
+++ b/packages/server/src/tools/admin/manage_watchers.ts
@@ -458,6 +458,12 @@ export const ManageWatchersSchema = Type.Object({
         '[complete_window] Optional structured execution metadata for provenance (provider, session id, parameters, etc.).',
     })
   ),
+  watcher_run_id: Type.Optional(
+    Type.Number({
+      description:
+        '[complete_window] Optional watcher run id for run completion/provenance. Workers should pass the Watcher run ID from the dispatch prompt.',
+    })
+  ),
   template_version_id: Type.Optional(
     Type.Number({
       description:
@@ -1285,8 +1291,8 @@ async function handleCompleteWindow(
     args.run_metadata && typeof args.run_metadata === 'object' && !Array.isArray(args.run_metadata)
       ? (args.run_metadata as Record<string, unknown>)
       : {};
-  const watcherRunIdRaw = provenanceMetadata.watcher_run_id;
-  const watcherRunId =
+  const watcherRunIdRaw = args.watcher_run_id ?? provenanceMetadata.watcher_run_id;
+  let watcherRunId =
     watcherRunIdRaw !== undefined && watcherRunIdRaw !== null && Number.isFinite(Number(watcherRunIdRaw))
       ? Number(watcherRunIdRaw)
       : null;
@@ -1359,6 +1365,24 @@ async function handleCompleteWindow(
   const MAX_ROLLUP_DEPTH = 3;
   if (tokenIsRollup && tokenDepth != null && tokenDepth > MAX_ROLLUP_DEPTH) {
     throw new Error(`Rollup depth ${tokenDepth} exceeds maximum of ${MAX_ROLLUP_DEPTH}`);
+  }
+
+  if (watcherRunId == null && ctx.userId === `watcher_${watcherId}`) {
+    const runRows = await sql`
+      SELECT id
+      FROM runs
+      WHERE watcher_id = ${watcherId}
+        AND run_type = 'watcher'
+        AND status = 'running'
+      ORDER BY created_at DESC
+      LIMIT 1
+    `;
+    if (runRows.length > 0 && runRows[0].id != null) {
+      watcherRunId = Number(runRows[0].id);
+      provenanceMetadata.watcher_run_id = watcherRunId;
+    }
+  } else if (watcherRunId != null && provenanceMetadata.watcher_run_id == null) {
+    provenanceMetadata.watcher_run_id = watcherRunId;
   }
 
   // ============================================

--- a/packages/server/src/utils/__tests__/date-aliases.test.ts
+++ b/packages/server/src/utils/__tests__/date-aliases.test.ts
@@ -92,9 +92,15 @@ describe('parseDateAlias', () => {
       expect(result.date.getDate()).toBe(15);
     });
 
-    // Note: ISO datetime with T separator doesn't work because the function
-    // lowercases the input, turning T→t which doesn't match the internal regex.
-    // This tests the actual behavior of the function.
+    it('should parse ISO datetime string', () => {
+      const result = parseDateAlias('2025-01-15T12:30:00Z', ref);
+      expect(result.date.toISOString()).toBe('2025-01-15T12:30:00.000Z');
+    });
+
+    it('should parse quoted ISO datetime string', () => {
+      const result = parseDateAlias('"2025-01-15T12:30:00Z"', ref);
+      expect(result.date.toISOString()).toBe('2025-01-15T12:30:00.000Z');
+    });
   });
 
   describe('invalid inputs', () => {

--- a/packages/server/src/utils/date-aliases.ts
+++ b/packages/server/src/utils/date-aliases.ts
@@ -22,7 +22,13 @@ interface ParsedDateAlias {
  * @throws Error if the alias is invalid
  */
 export function parseDateAlias(alias: string, referenceDate: Date = new Date()): ParsedDateAlias {
-  const trimmed = alias.trim().toLowerCase();
+  const raw = alias.trim();
+  const unquoted =
+    raw.length >= 2 &&
+    ((raw.startsWith('"') && raw.endsWith('"')) || (raw.startsWith("'") && raw.endsWith("'")))
+      ? raw.slice(1, -1).trim()
+      : raw;
+  const trimmed = unquoted.toLowerCase();
 
   // Named aliases
   const namedAliases: Record<string, () => Date> = {
@@ -106,9 +112,9 @@ export function parseDateAlias(alias: string, referenceDate: Date = new Date()):
   }
 
   // ISO 8601 with time (YYYY-MM-DDTHH:MM:SS or with timezone)
-  const isoWithTimeMatch = trimmed.match(/^\d{4}-\d{2}-\d{2}T/);
+  const isoWithTimeMatch = unquoted.match(/^\d{4}-\d{2}-\d{2}T/i);
   if (isoWithTimeMatch) {
-    const date = new Date(alias); // Use original casing for ISO parsing
+    const date = new Date(unquoted); // Use unquoted original casing for ISO parsing
     if (Number.isNaN(date.getTime())) {
       throw new Error(`Invalid ISO datetime: "${alias}"`);
     }

--- a/packages/server/src/watchers/automation.ts
+++ b/packages/server/src/watchers/automation.ts
@@ -485,7 +485,7 @@ function buildDispatchMessage(params: {
     'Required steps:',
     `1. Call read_knowledge with {"watcher_id": ${params.watcherId}, "since": "${readKnowledgeSince}", "until": "${readKnowledgeUntil}"${versionPin}}.`,
     '2. Analyze the returned content using prompt_rendered and extraction_schema.',
-    `3. Call manage_watchers(action="complete_window") with the returned window_token and your extracted_data${params.payload.version_id != null ? `, including "template_version_id": ${params.payload.version_id}` : ''}.`,
+    `3. Call manage_watchers(action="complete_window") with the returned window_token, extracted_data, and "watcher_run_id": ${params.runId}${params.payload.version_id != null ? `, including "template_version_id": ${params.payload.version_id}` : ''}.`,
     '4. Include this run_metadata object in complete_window exactly, and add any extra provider/job fields you know:',
     JSON.stringify(
       {


### PR DESCRIPTION
## Summary
- parse ISO datetime aliases with a case-insensitive T separator
- tolerate paired quotes around date aliases from tool-call arguments
- allow complete_window to carry watcher_run_id directly and infer the running watcher run for watcher automation sessions
- make watcher dispatch prompt explicitly include watcher_run_id in complete_window
- cover quoted and unquoted ISO datetime aliases in tests

## Validation
- bun test packages/server/src/utils/__tests__/date-aliases.test.ts
- bun run typecheck
- bun run check