### PR TITLE
fix(watchers): infer running completion run

### DIFF
--- a/packages/server/src/tools/admin/action-router.ts
+++ b/packages/server/src/tools/admin/action-router.ts
@@ -62,7 +62,14 @@ export async function routeAction<TResult>(
   try {
     return await handler();
   } catch (error) {
-    logger.error({ error }, `${toolName} error:`);
+    logger.error(
+      {
+        error,
+        error_message: error instanceof Error ? error.message : String(error),
+        error_stack: error instanceof Error ? error.stack : undefined,
+      },
+      `${toolName} error:`
+    );
     throw error;
   }
 }

--- a/packages/server/src/tools/admin/manage_watchers.ts
+++ b/packages/server/src/tools/admin/manage_watchers.ts
@@ -1367,7 +1367,7 @@ async function handleCompleteWindow(
     throw new Error(`Rollup depth ${tokenDepth} exceeds maximum of ${MAX_ROLLUP_DEPTH}`);
   }
 
-  if (watcherRunId == null && ctx.userId === `watcher_${watcherId}`) {
+  if (watcherRunId == null) {
     const runRows = await sql`
       SELECT id
       FROM runs
@@ -1381,7 +1381,7 @@ async function handleCompleteWindow(
       watcherRunId = Number(runRows[0].id);
       provenanceMetadata.watcher_run_id = watcherRunId;
     }
-  } else if (watcherRunId != null && provenanceMetadata.watcher_run_id == null) {
+  } else if (provenanceMetadata.watcher_run_id == null) {
     provenanceMetadata.watcher_run_id = watcherRunId;
   }
 


### PR DESCRIPTION
## Summary
- infer the active watcher run when complete_window omits watcher_run_id
- keep inferred run id in stored run_metadata so completion reconciliation can link the window
- log action-router error messages/stacks so tool failures are diagnosable

## Validation
- bun run typecheck
- bun run check