### PR TITLE
feat(auth): send welcome email on signup

### DIFF
--- a/packages/server/src/auth/index.tsx
+++ b/packages/server/src/auth/index.tsx
@@ -16,6 +16,7 @@ import {
 	PasswordResetEmail,
 	passwordResetSubject,
 } from "../email/templates/password-reset";
+import { WelcomeEmail, welcomeSubject } from "../email/templates/welcome";
 import { notifyInvitationReceived } from "../notifications/triggers";
 import {
 	deleteMemberEntity,
@@ -463,7 +464,7 @@ export async function createAuth(env: Env, request?: Request) {
 						}
 						return { data: user };
 					},
-					after: async (user) => {
+					after: async (user, context) => {
 						try {
 							const { ensurePersonalOrganization } = await import(
 								"./personal-org-provisioning"
@@ -482,6 +483,32 @@ export async function createAuth(env: Env, request?: Request) {
 							}
 						} catch (error) {
 							console.error("[Auth] Failed to provision personal org:", error);
+						}
+
+						try {
+							if (!env.RESEND_API_KEY && runtimeNodeEnv !== "production") {
+								console.info(
+									{ email: user.email },
+									"[Auth] Development signup welcome email skipped (RESEND_API_KEY not configured)",
+								);
+								return;
+							}
+							await sendTransactionalEmail({
+								env,
+								to: user.email,
+								category: "auth",
+								subject: welcomeSubject,
+								react: (
+									<WelcomeEmail
+										name={user.name}
+										appUrl={resolveBaseUrl({
+											request: context?.request ?? undefined,
+										})}
+									/>
+								),
+							});
+						} catch (error) {
+							console.error("[Auth] Failed to send signup welcome email:", error);
 						}
 					},
 				},

--- a/packages/server/src/email/templates/welcome.tsx
+++ b/packages/server/src/email/templates/welcome.tsx
@@ -1,0 +1,24 @@
+import { BrandedEmail } from './BrandedEmail';
+
+export interface WelcomeProps {
+  name?: string | null;
+  appUrl: string;
+}
+
+export function WelcomeEmail({ name, appUrl }: WelcomeProps) {
+  const trimmedName = name?.trim();
+  const greeting = trimmedName ? `Welcome to Lobu, ${trimmedName}` : 'Welcome to Lobu';
+
+  return (
+    <BrandedEmail
+      preview="Welcome to Lobu"
+      heading={greeting}
+      intro="Your account is ready. Lobu helps your team turn messages, tools, and knowledge into AI agents that remember the context that matters."
+      cta={{ href: appUrl, label: 'Open Lobu' }}
+      afterCta="Start by creating an agent or connecting the apps where your work already happens."
+      footerNote="If you didn't create this account, you can safely ignore this email."
+    />
+  );
+}
+
+export const welcomeSubject = 'Welcome to Lobu';


### PR DESCRIPTION
## Summary
- add a branded welcome email template for new Lobu signups
- send it from the BetterAuth user-create hook without blocking signup on delivery failures
- reuse the existing auth transactional email channel and dev skip behavior when Resend is not configured

## Validation
- bun run typecheck
- make build-packages