### PR TITLE
fix(web): redirect root visitors to login

### DIFF
--- a/packages/landing/src/connect-from-config.ts
+++ b/packages/landing/src/connect-from-config.ts
@@ -96,7 +96,7 @@ const connectFromClientConfigs: Record<
       "Enable the connector and choose the workspace Claude should use.",
     ],
     docsSetupNote:
-      "For Claude Code, run `claude mcp add --transport http owletto https://lobu.ai/mcp` instead and complete the OAuth flow when prompted.",
+      "For Claude Code, run `claude mcp add --transport http lobu https://lobu.ai/mcp` instead and complete the OAuth flow when prompted.",
     docsExtraSection: {
       title: "Claude Code and Claude Desktop",
       paragraphs: [

--- a/packages/landing/src/pages/mcp.astro
+++ b/packages/landing/src/pages/mcp.astro
@@ -5,7 +5,7 @@ import { Footer } from "../components/Footer";
 import { Nav } from "../components/Nav";
 
 const mcpUrl = "https://lobu.ai/mcp";
-const claudeCodeCommand = `claude mcp add --transport http owletto ${mcpUrl}`;
+const claudeCodeCommand = `claude mcp add --transport http lobu ${mcpUrl}`;
 const openClawCommand = `lobu memory configure --url ${mcpUrl} --org <org-slug>`;
 
 const clients = [

--- a/packages/server/src/utils/__tests__/mcp-install-targets.test.ts
+++ b/packages/server/src/utils/__tests__/mcp-install-targets.test.ts
@@ -44,7 +44,7 @@ describeIfSubmodule('getMcpInstallTargets', () => {
     expect(codex?.actions).toContainEqual({
       type: 'command',
       label: 'Add MCP server',
-      value: `codex mcp add owletto --url ${mcpUrl}`,
+      value: `codex mcp add lobu --url ${mcpUrl}`,
     });
 
     expect(openclaw?.actions).toContainEqual({
@@ -79,7 +79,7 @@ describeIfSubmodule('getMcpInstallTargets', () => {
     expect(link?.type).toBe('link');
 
     const href = new URL((link as { href: string }).href);
-    expect(href.searchParams.get('name')).toBe('owletto');
+    expect(href.searchParams.get('name')).toBe('lobu');
 
     const encodedConfig = href.searchParams.get('config');
     expect(encodedConfig).toBeTruthy();


### PR DESCRIPTION
## Summary
- bump packages/web to include the root redirect change
- removes the unauthenticated How it works/discovery landing from the app shell

## Submodule
- https://github.com/lobu-ai/owletto-web/pull/66

## Validation
- cd packages/web && bun run test -- src/app/__smoke__/all-routes.test.tsx
- cd packages/web && bun run build