### PR TITLE
fix(watchers): page source reads by cursor

### DIFF
--- a/packages/server/src/__tests__/integration/watchers/automation-contract.test.ts
+++ b/packages/server/src/__tests__/integration/watchers/automation-contract.test.ts
@@ -200,6 +200,74 @@ describe('watcher automation contract', () => {
     expect(Number(run.window_id)).toBe(completion.window_id);
   });
 
+  it('paginates watcher reads by cursor and completes from multiple page tokens', async () => {
+    const { sql, workspace, api, entityId, watcherId } = await createAutomatedWatcher();
+
+    const base = Date.UTC(2026, 0, 2, 12, 0, 0);
+    const events = [];
+    for (let i = 0; i < 5; i++) {
+      events.push(
+        await createTestEvent({
+          entity_id: entityId,
+          organization_id: workspace.org.id,
+          title: `Paginated event ${i}`,
+          content: `Paginated watcher content ${i}`,
+          occurred_at: new Date(base - i * 60_000),
+        })
+      );
+    }
+
+    const page1 = (await api.knowledge.read({
+      watcher_id: watcherId,
+      since: '2026-01-02',
+      until: '2026-01-02',
+      limit: 2,
+    })) as {
+      content: Array<{ id: number; occurred_at: string }>;
+      window_token: string;
+      page: { has_more: boolean; next_cursor?: { occurred_at: string; id: number } };
+    };
+
+    expect(page1.content.map((item) => item.id)).toEqual([events[0].id, events[1].id]);
+    expect(page1.page.has_more).toBe(true);
+    expect(page1.page.next_cursor).toBeDefined();
+
+    const page2 = (await api.knowledge.read({
+      watcher_id: watcherId,
+      since: '2026-01-02',
+      until: '2026-01-02',
+      limit: 2,
+      before_occurred_at: page1.page.next_cursor!.occurred_at,
+      before_id: page1.page.next_cursor!.id,
+    })) as {
+      content: Array<{ id: number }>;
+      window_token: string;
+      page: { has_more: boolean; next_cursor?: { occurred_at: string; id: number } };
+    };
+
+    expect(page2.content.map((item) => item.id)).toEqual([events[2].id, events[3].id]);
+    expect(page2.page.has_more).toBe(true);
+
+    const completion = (await api.watchers.completeWindow({
+      watcher_id: String(watcherId),
+      window_tokens: [page1.window_token, page2.window_token],
+      extracted_data: { summary: 'Summary across two pages' },
+    })) as { action: string; window_id: number; content_linked: number };
+
+    const links = await sql`
+      SELECT event_id
+      FROM watcher_window_events
+      WHERE window_id = ${completion.window_id}
+      ORDER BY event_id
+    `;
+
+    expect(completion.action).toBe('complete_window');
+    expect(completion.content_linked).toBe(4);
+    expect(links.map((row) => Number(row.event_id)).sort((a, b) => a - b)).toEqual(
+      [events[0].id, events[1].id, events[2].id, events[3].id].sort((a, b) => a - b)
+    );
+  });
+
   it('links the exact signed content IDs without re-running watcher sources', async () => {
     const { sql, workspace, api, entityId, watcherId } = await createAutomatedWatcher();
 

--- a/packages/server/src/sandbox/namespaces/knowledge.ts
+++ b/packages/server/src/sandbox/namespaces/knowledge.ts
@@ -40,6 +40,8 @@ export interface KnowledgeReadInput {
   since?: string;
   until?: string;
   limit?: number;
+  before_occurred_at?: string;
+  before_id?: number;
   entity_ids?: number[];
 }
 

--- a/packages/server/src/sandbox/namespaces/watchers.ts
+++ b/packages/server/src/sandbox/namespaces/watchers.ts
@@ -62,7 +62,9 @@ export interface WatcherUpdateInput {
 export interface WatcherCompleteWindowInput {
   watcher_id: WatcherId;
   /** JWT obtained from read_knowledge(watcher_id, since, until). */
-  window_token: string;
+  window_token?: string;
+  /** Multiple page JWTs obtained from read_knowledge for the same watcher window. */
+  window_tokens?: string[];
   extracted_data: Record<string, unknown>;
   replace_existing?: boolean;
   client_id?: string;

--- a/packages/server/src/tools/admin/manage_watchers.ts
+++ b/packages/server/src/tools/admin/manage_watchers.ts
@@ -390,7 +390,13 @@ export const ManageWatchersSchema = Type.Object({
   window_token: Type.Optional(
     Type.String({
       description:
-        '[complete_window] Required. JWT from read_knowledge(watcher_id, since, until). Contains signed window parameters.',
+        '[complete_window] JWT from read_knowledge(watcher_id, since, until). Pass this or window_tokens.',
+    })
+  ),
+  window_tokens: Type.Optional(
+    Type.Array(Type.String(), {
+      description:
+        '[complete_window] Multiple page JWTs from read_knowledge for the same watcher window. Content IDs are unioned and linked atomically.',
     })
   ),
   client_id: Type.Optional(
@@ -1252,10 +1258,16 @@ async function handleCompleteWindow(
   // ============================================
   // STEP 1: Validate inputs (no DB calls)
   // ============================================
-  if (!args.window_token) {
+  const windowTokens =
+    Array.isArray(args.window_tokens) && args.window_tokens.length > 0
+      ? args.window_tokens
+      : args.window_token
+        ? [args.window_token]
+        : [];
+  if (windowTokens.length === 0) {
     throw new Error(
-      'window_token is required for complete_window action. ' +
-        'Get this token from read_knowledge({ watcher_id: ... }) response.'
+      'window_token or window_tokens is required for complete_window action. ' +
+        'Get tokens from read_knowledge({ watcher_id: ... }) responses.'
     );
   }
   if (!args.extracted_data) {
@@ -1266,20 +1278,18 @@ async function handleCompleteWindow(
   }
   const extractedData = normalizeExtractedData(args.extracted_data);
 
-  // Verify and decode JWT window token (in-memory)
-  let tokenPayload: {
-    watcher_id: number;
-    window_start: string;
-    window_end: string;
-    granularity: string;
-    window_id?: number;
-    content_count: number;
-    content_ids: number[];
-    iat: number;
+  // Verify and decode JWT window token(s) (in-memory)
+  type VerifiedWindowToken = Awaited<ReturnType<typeof verifyWindowToken>> & {
+    is_rollup?: boolean;
+    source_window_ids?: number[];
+    depth?: number;
   };
+  let tokenPayloads: VerifiedWindowToken[];
 
   try {
-    tokenPayload = await verifyWindowToken(args.window_token, env);
+    tokenPayloads = (await Promise.all(
+      windowTokens.map((token) => verifyWindowToken(token, env))
+    )) as VerifiedWindowToken[];
   } catch (error) {
     const errorMsg = error instanceof Error ? error.message : String(error);
     throw new Error(
@@ -1289,23 +1299,33 @@ async function handleCompleteWindow(
     );
   }
 
+  const firstToken = tokenPayloads[0];
   const {
     watcher_id: watcherId,
     window_start,
     window_end,
     granularity,
     window_id: tokenWindowId,
-    content_count: tokenContentCount,
-    content_ids: tokenContentIds,
-    iat: tokenIssuedAt,
     is_rollup: tokenIsRollup,
     source_window_ids: tokenSourceWindowIds,
     depth: tokenDepth,
-  } = tokenPayload as typeof tokenPayload & {
-    is_rollup?: boolean;
-    source_window_ids?: number[];
-    depth?: number;
-  };
+  } = firstToken;
+
+  for (const token of tokenPayloads) {
+    if (
+      token.watcher_id !== watcherId ||
+      token.window_start !== window_start ||
+      token.window_end !== window_end ||
+      token.granularity !== granularity ||
+      token.window_id !== tokenWindowId
+    ) {
+      throw new Error('All window_tokens must belong to the same watcher window.');
+    }
+  }
+
+  if (tokenPayloads.length > 1 && tokenIsRollup) {
+    throw new Error('Rollup completion accepts exactly one window_token.');
+  }
 
   const MAX_ROLLUP_DEPTH = 3;
   if (tokenIsRollup && tokenDepth != null && tokenDepth > MAX_ROLLUP_DEPTH) {
@@ -1504,31 +1524,39 @@ async function handleCompleteWindow(
   // ============================================
   // STEP 3: Resolve the exact content IDs analyzed by the worker
   // ============================================
-  if (!Array.isArray(tokenContentIds)) {
-    throw new Error(
-      'Invalid window_token: content_ids is required. Get a fresh token from read_knowledge({ watcher_id: ... }).'
-    );
+  const perTokenIds = tokenPayloads.map((token) => {
+    if (!Array.isArray(token.content_ids)) {
+      throw new Error(
+        'Invalid window_token: content_ids is required. Get a fresh token from read_knowledge({ watcher_id: ... }).'
+      );
+    }
+    const ids = [
+      ...new Set(
+        token.content_ids
+          .map((id) => Number(id))
+          .filter((id) => Number.isFinite(id) && id > 0)
+          .map((id) => Math.trunc(id))
+      ),
+    ];
+    if (ids.length !== token.content_count) {
+      throw new Error(
+        `Invalid window_token: content_ids has ${ids.length} IDs, but content_count is ${token.content_count}. ` +
+          'Get a fresh token from read_knowledge({ watcher_id: ... }).'
+      );
+    }
+    return ids;
+  });
+
+  const batchContentIds = [...new Set(perTokenIds.flat())];
+  const summedContentCount = perTokenIds.reduce((sum, ids) => sum + ids.length, 0);
+  if (batchContentIds.length !== summedContentCount) {
+    throw new Error('window_tokens contain overlapping content IDs. Pass each read_knowledge page token once.');
   }
 
-  const batchContentIds = [
-    ...new Set(
-      tokenContentIds
-        .map((id) => Number(id))
-        .filter((id) => Number.isFinite(id) && id > 0)
-        .map((id) => Math.trunc(id))
-    ),
-  ];
-
-  if (batchContentIds.length !== tokenContentCount) {
-    throw new Error(
-      `Invalid window_token: content_ids has ${batchContentIds.length} IDs, but content_count is ${tokenContentCount}. ` +
-        'Get a fresh token from read_knowledge({ watcher_id: ... }).'
-    );
-  }
-
-  const tokenAge = Math.floor(Date.now() / 1000) - tokenIssuedAt;
+  const oldestTokenIssuedAt = Math.min(...tokenPayloads.map((token) => token.iat));
+  const tokenAge = Math.floor(Date.now() / 1000) - oldestTokenIssuedAt;
   logger.info(
-    `[complete_window] Token valid: ${batchContentIds.length} content items, token age: ${tokenAge}s`
+    `[complete_window] Token valid: ${batchContentIds.length} content items across ${tokenPayloads.length} page(s), oldest token age: ${tokenAge}s`
   );
 
   // ============================================

--- a/packages/server/src/tools/get_content.ts
+++ b/packages/server/src/tools/get_content.ts
@@ -382,6 +382,10 @@ interface GetContentResult {
     has_more: boolean;
     has_older?: boolean;
     has_newer?: boolean;
+    next_cursor?: {
+      occurred_at: string;
+      id: number;
+    };
   };
   classification_stats?: {
     [classifierSlug: string]: {
@@ -1351,6 +1355,12 @@ interface ContentQueryParams {
   window_end: string;
   organizationId: string;
   entityIds?: number[];
+  page?: {
+    sourceName: string;
+    limit: number;
+    beforeOccurredAt?: string;
+    beforeId?: number;
+  };
 }
 
 function buildContentQueryContext(params: ContentQueryParams): DataSourceContext {
@@ -1365,8 +1375,68 @@ function buildContentQueryContext(params: ContentQueryParams): DataSourceContext
 async function queryContentData(
   sql: DbClient,
   params: ContentQueryParams
-): Promise<{ sourcesContent: Record<string, unknown[]>; allContent: unknown[] }> {
-  const results = await executeDataSources(params.sources, buildContentQueryContext(params), sql);
+): Promise<{
+  sourcesContent: Record<string, unknown[]>;
+  allContent: unknown[];
+  page?: { has_more: boolean; next_cursor?: { occurred_at: string; id: number } };
+}> {
+  const page = params.page;
+  const results = await executeDataSources(params.sources, buildContentQueryContext(params), sql, {
+    wrapQuery: page
+      ? (scopedQuery, queryParams, sourceName) => {
+          if (sourceName !== page.sourceName) return scopedQuery;
+
+          const nextParams = [...queryParams];
+          const where: string[] = [
+            '_watcher_page.id IS NOT NULL',
+            '_watcher_page.occurred_at IS NOT NULL',
+          ];
+          if (page.beforeOccurredAt && page.beforeId) {
+            nextParams.push(page.beforeOccurredAt);
+            const occurredAtParam = `$${nextParams.length}`;
+            nextParams.push(page.beforeId);
+            const idParam = `$${nextParams.length}`;
+            where.push(
+              `(_watcher_page.occurred_at < ${occurredAtParam}::timestamptz OR ` +
+                `(_watcher_page.occurred_at = ${occurredAtParam}::timestamptz AND _watcher_page.id < ${idParam}::bigint))`
+            );
+          }
+          nextParams.push(page.limit + 1);
+          const limitParam = `$${nextParams.length}`;
+
+          return {
+            sql:
+              `SELECT * FROM (${scopedQuery}) AS _watcher_page ` +
+              `WHERE ${where.join(' AND ')} ` +
+              'ORDER BY _watcher_page.occurred_at DESC NULLS LAST, _watcher_page.id DESC ' +
+              `LIMIT ${limitParam}`,
+            params: nextParams,
+          };
+        }
+      : undefined,
+  });
+
+  let pageResult: { has_more: boolean; next_cursor?: { occurred_at: string; id: number } } | undefined;
+  if (page) {
+    const rows = results[page.sourceName] ?? [];
+    const trimmed = rows.slice(0, page.limit);
+    const hasMore = rows.length > page.limit;
+    results[page.sourceName] = trimmed;
+    const last = trimmed[trimmed.length - 1] as Record<string, unknown> | undefined;
+    const lastOccurredAt = last?.occurred_at;
+    const lastId = Number(last?.id);
+    pageResult = {
+      has_more: hasMore,
+      ...(hasMore && lastOccurredAt && Number.isFinite(lastId)
+        ? {
+            next_cursor: {
+              occurred_at: new Date(lastOccurredAt as string | Date).toISOString(),
+              id: Math.trunc(lastId),
+            },
+          }
+        : {}),
+    };
+  }
 
   const seen = new Set<number>();
   const allContent: unknown[] = [];
@@ -1407,7 +1477,7 @@ async function queryContentData(
     }
   }
 
-  return { sourcesContent: results as Record<string, unknown[]>, allContent };
+  return { sourcesContent: results as Record<string, unknown[]>, allContent, page: pageResult };
 }
 
 // ============================================
@@ -1586,7 +1656,7 @@ async function handleWatcherMode(
   // NOTE: Window creation is deferred to complete_window action
   // This allows batched processing where each batch creates its own window
 
-  const contentLimit = Math.min(args.limit || 500, 2000); // Max 2000 per source
+  const contentLimit = Math.min(Math.max(args.limit || 100, 1), 1000); // Page size; agents can request more pages with next_cursor.
   const contentOffset = args.offset || 0;
   const windowStartIso = windowStart.toISOString();
   const windowEndIso = windowEnd.toISOString();
@@ -1602,6 +1672,12 @@ async function handleWatcherMode(
       window_end: windowEndIso,
       organizationId: watcher.organization_id as string,
       entityIds: watcherEntityIds,
+      page: {
+        sourceName: 'content',
+        limit: contentLimit,
+        beforeOccurredAt: args.before_occurred_at,
+        beforeId: args.before_id,
+      },
     }),
     sql.unsafe(
       `
@@ -1616,7 +1692,7 @@ async function handleWatcherMode(
       [...sourceEntityIds, windowStartIso, windowEndIso]
     ),
   ]);
-  const { sourcesContent, allContent } = contentData;
+  const { sourcesContent, allContent, page: contentPage } = contentData;
   const totalCount = Number(totalStatsResult[0]?.total_count || 0);
   const totalCountChars = Number(totalStatsResult[0]?.total_chars || 0);
 
@@ -1771,6 +1847,12 @@ async function handleWatcherMode(
 
   // Append past reactions, feedback, and guidance to the rendered prompt
   let enrichedPrompt = promptRendered;
+  if (enrichedPrompt && contentPage?.has_more) {
+    enrichedPrompt +=
+      '\n\n## Pagination\n' +
+      `This page includes ${allContent.length} content items and more items are available in this same watcher window. ` +
+      'If you need more evidence before completing the window, call read_knowledge again with the same watcher_id/since/until and page.next_cursor as before_occurred_at/before_id.';
+  }
   if (enrichedPrompt) {
     if (reactionsGuidance) {
       enrichedPrompt += `\n\n## Reactions Guidance\n${reactionsGuidance}`;
@@ -1789,7 +1871,8 @@ async function handleWatcherMode(
     page: {
       limit: contentLimit,
       offset: contentOffset,
-      has_more: contentOffset + allContent.length < totalCount,
+      has_more: contentPage?.has_more ?? false,
+      ...(contentPage?.next_cursor ? { next_cursor: contentPage.next_cursor } : {}),
     },
     window_token: windowToken,
     window_start: windowStartIso,

--- a/packages/server/src/utils/execute-data-sources.ts
+++ b/packages/server/src/utils/execute-data-sources.ts
@@ -420,8 +420,12 @@ export async function executeDataSources(
   context: DataSourceContext,
   sql: DbClient,
   options?: {
-    /** Transform the scoped SQL before execution (e.g. wrap for ID-only extraction). */
-    wrapQuery?: (scopedSql: string) => string;
+    /** Transform the scoped SQL before execution (e.g. wrap for ID-only extraction or pagination). */
+    wrapQuery?: (
+      scopedSql: string,
+      params: unknown[],
+      sourceName: string
+    ) => string | { sql: string; params: unknown[] };
   }
 ): Promise<Record<string, unknown[]>> {
   const results: Record<string, unknown[]> = {};
@@ -449,7 +453,13 @@ export async function executeDataSources(
         }
 
         if (options?.wrapQuery) {
-          scopedQuery = options.wrapQuery(scopedQuery);
+          const wrapped = options.wrapQuery(scopedQuery, params, name);
+          if (typeof wrapped === 'string') {
+            scopedQuery = wrapped;
+          } else {
+            scopedQuery = wrapped.sql;
+            params = wrapped.params;
+          }
         }
 
         const rows = await sql.begin(async (tx) => {


### PR DESCRIPTION
## Summary
- paginate watcher content source reads in read_knowledge with stable occurred_at/id cursors
- return next_cursor and page has_more to agents so they can keep reading the same watcher window
- allow complete_window to accept multiple page tokens and link the union of signed content IDs
- add integration coverage for two-page watcher reads completing one window

## Validation
- bun run typecheck
- packages/server tsc --noEmit
- make build-packages
- local targeted integration could not run without a local DATABASE_URL; CI integration covers it

## Smoke plan after merge/deploy
- call read_knowledge for watcher 218 with limit=2, then read next page using next_cursor, then verify distinct ordered pages