### PR TITLE
fix: scaffold provider and platform env placeholders

### DIFF
--- a/packages/cli/src/__tests__/init-memory.test.ts
+++ b/packages/cli/src/__tests__/init-memory.test.ts
@@ -8,7 +8,7 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { generateLobuToml } from "../commands/init";
+import { generateLobuToml, initCommand } from "../commands/init";
 
 describe("init memory scaffolding", () => {
   let projectDir: string;
@@ -55,5 +55,28 @@ describe("init memory scaffolding", () => {
 
     expect(content).toContain('org = "support"');
     expect(content).toContain('name = "Support"');
+  });
+
+  test("init --yes writes empty env entries for generated provider and platform refs", async () => {
+    await initCommand(projectDir, "my-agent", {
+      yes: true,
+      provider: "openrouter",
+      platform: "slack",
+      memory: "lobu-cloud",
+      noSentry: true,
+    });
+
+    const env = readFileSync(join(projectDir, "my-agent", ".env"), "utf-8");
+    const toml = readFileSync(
+      join(projectDir, "my-agent", "lobu.toml"),
+      "utf-8"
+    );
+
+    expect(toml).toContain('key = "$OPENROUTER_API_KEY"');
+    expect(toml).toContain('botToken = "$SLACK_BOT_TOKEN"');
+    expect(toml).toContain('signingSecret = "$SLACK_SIGNING_SECRET"');
+    expect(env).toContain("OPENROUTER_API_KEY=");
+    expect(env).toContain("SLACK_BOT_TOKEN=");
+    expect(env).toContain("SLACK_SIGNING_SECRET=");
   });
 });

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -442,6 +442,18 @@ export async function initCommand(
 
     await renderTemplate(".env.tmpl", variables, join(projectDir, ".env"));
 
+    const envVarsToFill = new Set<string>();
+    if (selectedProvider?.providers?.[0]?.envVarName) {
+      envVarsToFill.add(selectedProvider.providers[0].envVarName);
+    }
+    for (const value of Object.values(platformConfig)) {
+      const envVar = extractEnvVarRef(value);
+      if (envVar) envVarsToFill.add(envVar);
+    }
+    for (const envVar of envVarsToFill) {
+      await setLocalEnvValue(projectDir, envVar, "");
+    }
+
     if (publicGatewayUrl) {
       await setLocalEnvValue(
         projectDir,
@@ -613,14 +625,29 @@ const PLATFORM_PLACEHOLDERS: Record<PlatformChoice, Record<string, string>> = {
     botToken: "$SLACK_BOT_TOKEN",
     signingSecret: "$SLACK_SIGNING_SECRET",
   },
-  discord: { botToken: "$DISCORD_BOT_TOKEN" },
+  discord: {
+    botToken: "$DISCORD_BOT_TOKEN",
+    applicationId: "$DISCORD_APPLICATION_ID",
+    publicKey: "$DISCORD_PUBLIC_KEY",
+  },
   whatsapp: {
     accessToken: "$WHATSAPP_ACCESS_TOKEN",
     phoneNumberId: "$WHATSAPP_PHONE_NUMBER_ID",
+    verifyToken: "$WHATSAPP_WEBHOOK_VERIFY_TOKEN",
+    appSecret: "$WHATSAPP_APP_SECRET",
   },
-  teams: { appId: "$TEAMS_APP_ID", appPassword: "$TEAMS_APP_PASSWORD" },
+  teams: {
+    appId: "$TEAMS_APP_ID",
+    appPassword: "$TEAMS_APP_PASSWORD",
+    appType: "MultiTenant",
+  },
   gchat: { credentials: "$GOOGLE_CHAT_CREDENTIALS" },
 };
+
+function extractEnvVarRef(value: string): string | null {
+  const match = value.match(/^\$([A-Z_][A-Z0-9_]*)$/);
+  return match?.[1] ?? null;
+}
 
 function humanizeSlug(slug: string): string {
   return slug
@@ -674,8 +701,8 @@ export async function generateLobuToml(
     lines.push(
       "# Add providers via the gateway configuration APIs or uncomment below:",
       `# [[agents.${id}.providers]]`,
-      '# id = "anthropic"',
-      '# key = "$ANTHROPIC_API_KEY"'
+      '# id = "openrouter"',
+      '# key = "$OPENROUTER_API_KEY"'
     );
   }
 

--- a/packages/cli/src/commands/platforms/platform-prompts.ts
+++ b/packages/cli/src/commands/platforms/platform-prompts.ts
@@ -77,9 +77,27 @@ export async function promptPlatformConfig(
       message: "Discord bot token:",
       mask: true,
     });
+    const applicationId = await input({
+      message: "Discord application ID:",
+    });
+    const publicKey = await password({
+      message: "Discord application public key:",
+      mask: true,
+    });
     if (botToken) {
       platformConfig.botToken = "$DISCORD_BOT_TOKEN";
       platformSecrets.push({ envVar: "DISCORD_BOT_TOKEN", value: botToken });
+    }
+    if (applicationId) {
+      platformConfig.applicationId = "$DISCORD_APPLICATION_ID";
+      platformSecrets.push({
+        envVar: "DISCORD_APPLICATION_ID",
+        value: applicationId,
+      });
+    }
+    if (publicKey) {
+      platformConfig.publicKey = "$DISCORD_PUBLIC_KEY";
+      platformSecrets.push({ envVar: "DISCORD_PUBLIC_KEY", value: publicKey });
     }
   } else if (platform === "whatsapp") {
     const accessToken = await password({
@@ -88,6 +106,14 @@ export async function promptPlatformConfig(
     });
     const phoneNumberId = await input({
       message: "WhatsApp phone number ID:",
+    });
+    const verifyToken = await password({
+      message: "WhatsApp webhook verify token:",
+      mask: true,
+    });
+    const appSecret = await password({
+      message: "WhatsApp app secret:",
+      mask: true,
     });
     if (accessToken) {
       platformConfig.accessToken = "$WHATSAPP_ACCESS_TOKEN";
@@ -103,6 +129,20 @@ export async function promptPlatformConfig(
         value: phoneNumberId,
       });
     }
+    if (verifyToken) {
+      platformConfig.verifyToken = "$WHATSAPP_WEBHOOK_VERIFY_TOKEN";
+      platformSecrets.push({
+        envVar: "WHATSAPP_WEBHOOK_VERIFY_TOKEN",
+        value: verifyToken,
+      });
+    }
+    if (appSecret) {
+      platformConfig.appSecret = "$WHATSAPP_APP_SECRET";
+      platformSecrets.push({
+        envVar: "WHATSAPP_APP_SECRET",
+        value: appSecret,
+      });
+    }
   } else if (platform === "teams") {
     const appId = await input({
       message: "Teams App ID (from Azure Bot):",
@@ -110,6 +150,9 @@ export async function promptPlatformConfig(
     const appPassword = await password({
       message: "Teams App Password (client secret):",
       mask: true,
+    });
+    const appTenantId = await input({
+      message: "Teams App Tenant ID (leave empty for multi-tenant apps):",
     });
     if (appId) {
       platformConfig.appId = "$TEAMS_APP_ID";
@@ -124,6 +167,16 @@ export async function promptPlatformConfig(
         envVar: "TEAMS_APP_PASSWORD",
         value: appPassword,
       });
+    }
+    if (appTenantId) {
+      platformConfig.appTenantId = "$TEAMS_APP_TENANT_ID";
+      platformSecrets.push({
+        envVar: "TEAMS_APP_TENANT_ID",
+        value: appTenantId,
+      });
+      platformConfig.appType = "SingleTenant";
+    } else if (appId || appPassword) {
+      platformConfig.appType = "MultiTenant";
     }
   } else if (platform === "gchat") {
     const credentials = await password({

--- a/packages/cli/src/templates/README.md.tmpl
+++ b/packages/cli/src/templates/README.md.tmpl
@@ -41,14 +41,15 @@ Edit `.env` to configure:
 
 ### Platform Connections
 
-Platforms (Slack, Telegram, Discord, WhatsApp, Teams) are configured through the gateway APIs — no per-platform env vars are required in `.env`. Manage connections against `{PUBLIC_GATEWAY_URL}/api/v1/connections` and related auth/config endpoints.
+If you selected a platform during `lobu init`, fill the generated platform variables in `.env` (for example `TELEGRAM_BOT_TOKEN` or `SLACK_BOT_TOKEN`) before starting Lobu. Otherwise, manage platform connections through the gateway APIs at `{PUBLIC_GATEWAY_URL}/api/v1/connections` and related auth/config endpoints.
 
 ### Worker Customization
 
 Worker behavior is controlled by:
 
-- `[agents.<id>.skills]` blocks in `lobu.toml` — declare MCP servers, OAuth, and tool policy.
-- `nixPackages` per agent — pulls binaries onto the worker's `PATH` via `nix-shell`. The worker uses [just-bash](https://github.com/nicholasgasior/just-bash) to wrap shell commands; interpreters and package managers are excluded from the allowlist by default. Set `LOBU_ALLOW_UNSANDBOXED_EXEC=1` per-agent to opt back in if you genuinely need them.
+- `[agents.<id>.skills]` blocks in `lobu.toml` — declare custom MCP servers and OAuth.
+- `[agents.<id>.tools]` blocks — configure tool visibility and MCP approval bypasses.
+- `[agents.<id>.worker].nix_packages` — pulls binaries onto the worker's `PATH` via `nix-shell`. The worker uses [just-bash](https://github.com/nicholasgasior/just-bash) to wrap shell commands; interpreters and package managers are excluded from the allowlist by default. Set `LOBU_ALLOW_UNSANDBOXED_EXEC=1` per-agent to opt back in if you genuinely need them.
 
 ## Learn More
 

--- a/packages/landing/src/content/docs/getting-started/index.mdx
+++ b/packages/landing/src/content/docs/getting-started/index.mdx
@@ -40,10 +40,11 @@ my-agent/
 │   ├── skills/                # skills scoped to this agent only
 │   └── evals/
 │       └── ping.yaml          # test cases for agent quality
-├── skills/                    # skills shared across all agents
-├── models/                    # Lobu entity schemas (if memory enabled)
-└── data/                      # Lobu seed entities and relationships
+├── data/                      # local runtime data; memory seeds when enabled
+└── skills/                    # skills shared across all agents
 ```
+
+If you enable Lobu memory during `init`, the scaffold also creates `models/` plus `data/entities/` and `data/relationships/`.
 
 | Path | Docs |
 |------|------|
@@ -51,7 +52,7 @@ my-agent/
 | `agents/*/IDENTITY.md`, `SOUL.md`, `USER.md` | [Agent Workspace](/guides/agent-prompts/) |
 | `agents/*/skills/`, `skills/` | [SKILL.md reference](/reference/skill-md/), [Skills](/getting-started/skills/) |
 | `agents/*/evals/` | [Evaluations](/guides/evals/) |
-| `models/`, `data/` | [Memory](/getting-started/memory/) |
+| `models/`, `data/entities/`, `data/relationships/` | [Memory](/getting-started/memory/) |
 | `.env` | [CLI reference](/reference/cli/) |
 
 ## Develop your agent

--- a/packages/landing/src/content/docs/getting-started/skills.mdx
+++ b/packages/landing/src/content/docs/getting-started/skills.mdx
@@ -12,15 +12,11 @@ A **skill** is a reusable capability bundle for an agent. In Lobu, skills can ad
 - system packages
 - network requirements
 
-Lobu still discovers local `SKILL.md` files at runtime. The CLI starter-skill commands simply copy a bundled skill folder into your local `skills/` directory so you can commit it and customize it.
+Lobu still discovers local `SKILL.md` files at runtime. Bundled skills are enabled from the agent settings UI; local skills live in your project so you can commit and customize them.
 
 ## Bundled Starter Skill
 
-The bundled Lobu starter skill includes project, runtime, and memory guidance.
-
-```bash
-# Enable the Lobu skill from the agent settings UI
-```
+The bundled Lobu starter skill includes project, runtime, and memory guidance. Enable it from the agent settings UI.
 
 Use the **Lobu** skill when the agent should understand Lobu projects, `lobu.toml`, prompt files, evals, project structure, memory tools, watchers, and client setup.
 

--- a/packages/landing/src/content/docs/reference/lobu-toml.md
+++ b/packages/landing/src/content/docs/reference/lobu-toml.md
@@ -153,7 +153,7 @@ Each entry configures an LLM provider. The first available provider is used at r
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `id` | string | yes | Provider identifier (e.g. `openrouter`, `anthropic`, `gemini`, `openai`) |
+| `id` | string | yes | Provider identifier from `config/providers.json` (e.g. `openrouter`, `gemini`, `openai`) |
 | `model` | string | no | Model override (e.g. `anthropic/claude-sonnet-4`) |
 | `key` | string | no | API key — literal value or `$ENV_VAR` reference |
 | `secret_ref` | string | no | Durable secret reference (for example `secret://...`) |
@@ -206,8 +206,10 @@ appSecret = "$WHATSAPP_APP_SECRET"
 [agents.x.platforms.config]
 appId = "$TEAMS_APP_ID"
 appPassword = "$TEAMS_APP_PASSWORD"
-appTenantId = "$TEAMS_APP_TENANT_ID"
 appType = "MultiTenant"
+# For single-tenant Azure apps, use:
+# appTenantId = "$TEAMS_APP_TENANT_ID"
+# appType = "SingleTenant"
 ```
 
 **Google Chat**


### PR DESCRIPTION
## Summary
- write empty `.env` entries for provider and platform references generated by `lobu init --yes`
- expand generated Discord, WhatsApp, and Teams platform config placeholders to match the public connection schemas
- refresh CLI template and docs for memory layout, skills setup, provider examples, and Teams app types
- bump the web submodule to include the merged connector empty-state UI fix

## Validation
- `bun test packages/cli/src/__tests__/init-memory.test.ts`
- `make build-packages`
- `cd packages/web && bun run build`
- `cd packages/landing && bun run build`
- `bun run check`
- `bun run typecheck`
