### PR TITLE
fix: workspace membership consistency

### DIFF
--- a/packages/server/src/tools/execute.ts
+++ b/packages/server/src/tools/execute.ts
@@ -112,7 +112,7 @@ export function checkToolAccess(toolName: string, args: unknown, authCtx: AuthCo
   if (!role && !isPublicReadable(toolName, args)) {
     if (authCtx.userId) {
       throw new Error(
-        'This public workspace is read-only for your account. Ask an organization owner for an invite to unlock write access.'
+        'This public workspace is read-only for your account. Join the workspace to unlock write access.'
       );
     }
     throw new Error(

--- a/packages/server/src/workspace/join-public.ts
+++ b/packages/server/src/workspace/join-public.ts
@@ -14,8 +14,8 @@ interface JoinPublicParams {
 }
 
 /**
- * Self-serve join for a public organization. Used by the REST /join endpoint
- * and the join_organization MCP tool. Idempotent.
+ * Self-serve join for a public organization. Used by the REST /join endpoint.
+ * Idempotent.
  *
  * Replicates the side effects of Better Auth's afterAddMember hook
  * (ensureMemberEntity + invalidateMembershipRoleCache) since Better Auth's


### PR DESCRIPTION
## Summary
- Update the public-workspace write denial to tell signed-in visitors to join the workspace.
- Remove stale `join_organization` MCP-tool commentary from the public join helper.
- Bump `packages/web` to the submodule fix that gates visitor/member UI consistently.

## Web submodule
- https://github.com/lobu-ai/owletto-web/pull/72

## Validation
- `packages/web`: `bun run build` passed using the shared dependency install from the existing checkout because this fresh worktree could not complete a second `bun install` due to local disk space.
- Parent repo: `make build-packages` passed using the same shared dependency install.

## Root cause
Several frontend tabs treated a signed-in public-workspace visitor as a workspace member and attempted member-only API paths or showed management controls. The backend already enforced membership, so the UI and copy needed to align with the existing auth model.