### PR TITLE
feat(charts): add public Helm install chart

### DIFF
--- a/.github/workflows/helm-chart.yml
+++ b/.github/workflows/helm-chart.yml
@@ -1,0 +1,77 @@
+name: Helm Chart
+
+on:
+  pull_request:
+    paths:
+      - "charts/lobu/**"
+      - ".github/workflows/helm-chart.yml"
+      - "release-please-config.json"
+  push:
+    branches:
+      - main
+    paths:
+      - "charts/lobu/**"
+      - ".github/workflows/helm-chart.yml"
+      - "release-please-config.json"
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      publish:
+        description: "Publish the chart to GHCR"
+        required: false
+        default: false
+        type: boolean
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: azure/setup-helm@v4
+
+      - name: Lint chart
+        run: helm lint charts/lobu
+
+      - name: Render default values
+        run: helm template lobu charts/lobu --namespace lobu >/tmp/lobu-default.yaml
+
+      - name: Render install example
+        run: helm template lobu charts/lobu --namespace lobu -f charts/lobu/values.example.yaml >/tmp/lobu-example.yaml
+
+  publish:
+    needs: lint
+    if: ${{ github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && inputs.publish) }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.release.tag_name || github.ref }}
+
+      - uses: azure/setup-helm@v4
+
+      - name: Log in to GHCR
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | helm registry login ghcr.io --username "${{ github.actor }}" --password-stdin
+
+      - name: Package chart
+        run: helm package charts/lobu --destination /tmp
+
+      - name: Push chart
+        run: |
+          chart_package="$(ls /tmp/lobu-*.tgz | head -1)"
+          helm push "$chart_package" oci://ghcr.io/${{ github.repository_owner }}/charts
+
+      - name: Make chart package public
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          OWNER: ${{ github.repository_owner }}
+        run: |
+          gh api -X PATCH "/orgs/${OWNER}/packages/container/charts%2Flobu/visibility" \
+            -f visibility=public || true

--- a/README.md
+++ b/README.md
@@ -44,10 +44,16 @@ Local `lobu.toml` projects are still useful for `lobu validate` and `lobu apply`
 
 ### Deployment
 
-Single-process Node app. Run it however you run Node — `node`, `pm2`, `systemd`, or another process supervisor. The app needs `DATABASE_URL` (Postgres + pgvector) reachable from its environment; no orchestrator is required and there is no Helm chart to install.
+Single-process Node remains the simplest deployment: run it with `node`, `pm2`, `systemd`, or another process supervisor. The app needs `DATABASE_URL` (Postgres + pgvector) reachable from its environment.
 
 - **Local dev** (contributing to Lobu itself): clone, `make setup`, `make dev` (boots embedded gateway + workers + Vite HMR on `:8787`).
-- **Production**: `bun run --cwd packages/server build:server`, then `node packages/server/dist/server.bundle.mjs` under your process supervisor of choice.
+- **Production (VM/bare metal)**: `bun run --cwd packages/server build:server`, then `node packages/server/dist/server.bundle.mjs` under your process supervisor of choice.
+- **Production (Kubernetes)**: use the public Helm chart in `charts/lobu`:
+  ```bash
+  helm install lobu oci://ghcr.io/lobu-ai/charts/lobu \
+    --namespace lobu --create-namespace \
+    -f charts/lobu/values.example.yaml
+  ```
 
 ## Architecture
 

--- a/charts/lobu/.helmignore
+++ b/charts/lobu/.helmignore
@@ -1,0 +1,6 @@
+# Patterns to ignore when building packages.
+.DS_Store
+.git/
+.gitignore
+*.swp
+*.tmp

--- a/charts/lobu/Chart.yaml
+++ b/charts/lobu/Chart.yaml
@@ -1,0 +1,17 @@
+apiVersion: v2
+name: lobu
+description: Lobu self-hosted AI agent platform
+type: application
+version: 6.1.1
+appVersion: "6.1.1"
+keywords:
+  - lobu
+  - agents
+  - ai
+  - memory
+home: https://github.com/lobu-ai/lobu
+sources:
+  - https://github.com/lobu-ai/lobu
+maintainers:
+  - name: lobu-ai
+    email: emre@lobu.ai

--- a/charts/lobu/templates/NOTES.txt
+++ b/charts/lobu/templates/NOTES.txt
@@ -1,0 +1,32 @@
+Lobu has been installed.
+
+{{- if .Values.ingress.enabled }}
+Application URL:
+{{- range .Values.ingress.hosts }}
+  https://{{ . }}
+{{- end }}
+{{- else }}
+Port-forward the app service:
+  kubectl -n {{ .Release.Namespace }} port-forward svc/{{ include "lobu.fullname" . }}-app {{ .Values.service.port }}:{{ .Values.service.port }}
+  open http://localhost:{{ .Values.service.port }}
+{{- end }}
+
+Secrets:
+{{- $secretName := include "lobu.secretName" . }}
+{{- if $secretName }}
+  Using runtime secret: {{ $secretName }}
+{{- else }}
+  No runtime secret configured. Create a Secret with JWT_SECRET, BETTER_AUTH_SECRET,
+  provider API keys, and other Lobu settings, then set secretName.
+{{- end }}
+
+Database:
+{{- if .Values.database.existingSecret }}
+  DATABASE_URL comes from Secret {{ .Values.database.existingSecret }} key {{ .Values.database.existingSecretKey }}.
+{{- else }}
+  Ensure DATABASE_URL is present in the runtime secret.
+{{- end }}
+
+Useful checks:
+  kubectl -n {{ .Release.Namespace }} get pods -l app.kubernetes.io/instance={{ .Release.Name }}
+  kubectl -n {{ .Release.Namespace }} logs deploy/{{ include "lobu.fullname" . }}-app

--- a/charts/lobu/templates/_helpers.tpl
+++ b/charts/lobu/templates/_helpers.tpl
@@ -1,0 +1,94 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "lobu.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+*/}}
+{{- define "lobu.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by labels.
+*/}}
+{{- define "lobu.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels.
+*/}}
+{{- define "lobu.labels" -}}
+helm.sh/chart: {{ include "lobu.chart" . }}
+{{ include "lobu.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels.
+*/}}
+{{- define "lobu.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "lobu.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{- define "lobu.appSelectorLabels" -}}
+{{ include "lobu.selectorLabels" . }}
+app.kubernetes.io/component: api
+{{- end }}
+
+{{- define "lobu.workerSelectorLabels" -}}
+{{ include "lobu.selectorLabels" . }}
+app.kubernetes.io/component: worker
+{{- end }}
+
+{{- define "lobu.embeddingsSelectorLabels" -}}
+{{ include "lobu.selectorLabels" . }}
+app.kubernetes.io/component: embeddings
+{{- end }}
+
+{{/*
+Resolve the image tag.
+*/}}
+{{- define "lobu.imageTag" -}}
+{{- default .Chart.AppVersion .Values.image.tag }}
+{{- end }}
+
+{{- define "lobu.appImage" -}}
+{{- printf "%s/%s-app:%s" .Values.image.registry .Values.image.repository (include "lobu.imageTag" .) }}
+{{- end }}
+
+{{- define "lobu.workerImage" -}}
+{{- printf "%s/%s-worker:%s" .Values.image.registry .Values.image.repository (include "lobu.imageTag" .) }}
+{{- end }}
+
+{{- define "lobu.embeddingsImage" -}}
+{{- printf "%s/%s-embeddings:%s" .Values.image.registry .Values.image.repository (include "lobu.imageTag" .) }}
+{{- end }}
+
+{{/*
+The Secret loaded into pods via envFrom, if configured.
+*/}}
+{{- define "lobu.secretName" -}}
+{{- if .Values.secrets.create }}
+{{- default (printf "%s-secrets" (include "lobu.fullname" .)) .Values.secrets.name }}
+{{- else }}
+{{- .Values.secretName }}
+{{- end }}
+{{- end }}

--- a/charts/lobu/templates/app-pvc.yaml
+++ b/charts/lobu/templates/app-pvc.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.app.workspaces.enabled }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "lobu.fullname" . }}-app-workspaces
+  labels:
+    {{- include "lobu.labels" . | nindent 4 }}
+    app.kubernetes.io/component: api
+spec:
+  accessModes:
+    {{- toYaml .Values.app.workspaces.accessModes | nindent 4 }}
+  {{- if .Values.app.workspaces.storageClass }}
+  storageClassName: {{ .Values.app.workspaces.storageClass | quote }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.app.workspaces.size }}
+{{- end }}

--- a/charts/lobu/templates/deployment.yaml
+++ b/charts/lobu/templates/deployment.yaml
@@ -1,0 +1,125 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "lobu.fullname" . }}-app
+  labels:
+    {{- include "lobu.labels" . | nindent 4 }}
+    app.kubernetes.io/component: api
+spec:
+  replicas: {{ .Values.app.replicaCount }}
+  {{- with .Values.app.strategy }}
+  strategy:
+    {{- toYaml . | nindent 4 }}
+  {{- else }}
+  {{- if .Values.app.workspaces.enabled }}
+  strategy:
+    type: Recreate
+  {{- end }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "lobu.appSelectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "lobu.appSelectorLabels" . | nindent 8 }}
+      {{- with .Values.app.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.app.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: app
+          image: {{ include "lobu.appImage" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- with .Values.app.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          ports:
+            - name: http
+              containerPort: 8787
+              protocol: TCP
+          env:
+            {{- range $key, $value := .Values.app.env }}
+            - name: {{ $key }}
+              value: {{ $value | quote }}
+            {{- end }}
+            {{- if .Values.ingress.hosts }}
+            - name: BASE_URL
+              value: {{ printf "https://%s" (first .Values.ingress.hosts) | quote }}
+            {{- end }}
+            {{- if .Values.embeddings.service.port }}
+            {{- if .Values.embeddings.serviceUrl }}
+            - name: EMBEDDINGS_SERVICE_URL
+              value: {{ .Values.embeddings.serviceUrl | quote }}
+            {{- else if .Values.embeddings.enabled }}
+            - name: EMBEDDINGS_SERVICE_URL
+              value: {{ printf "http://%s-embeddings:%d" (include "lobu.fullname" .) (.Values.embeddings.service.port | int) | quote }}
+            {{- end }}
+            {{- end }}
+            {{- if .Values.database.existingSecret }}
+            {{- if .Values.database.usePooler }}
+            - name: DB_USER
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.database.existingSecret }}
+                  key: username
+            - name: DB_PASS
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.database.existingSecret }}
+                  key: password
+            - name: DATABASE_URL
+              value: "postgresql://$(DB_USER):$(DB_PASS)@{{ .Values.database.poolerService }}:5432/{{ .Values.database.name }}?sslmode=disable"
+            {{- else }}
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.database.existingSecret }}
+                  key: {{ .Values.database.existingSecretKey }}
+            {{- end }}
+            {{- end }}
+          {{- $secretName := include "lobu.secretName" . }}
+          {{- if $secretName }}
+          envFrom:
+            - secretRef:
+                name: {{ $secretName }}
+          {{- end }}
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: {{ .Values.healthCheck.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.healthCheck.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.healthCheck.readinessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.healthCheck.readinessProbe.failureThreshold }}
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: {{ .Values.healthCheck.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.healthCheck.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.healthCheck.livenessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.healthCheck.livenessProbe.failureThreshold }}
+          {{- if .Values.app.workspaces.enabled }}
+          volumeMounts:
+            - name: workspaces
+              mountPath: /app/workspaces
+          {{- end }}
+          resources:
+            {{- toYaml .Values.app.resources | nindent 12 }}
+      {{- if .Values.app.workspaces.enabled }}
+      volumes:
+        - name: workspaces
+          persistentVolumeClaim:
+            claimName: {{ include "lobu.fullname" . }}-app-workspaces
+      {{- end }}

--- a/charts/lobu/templates/deployment.yaml
+++ b/charts/lobu/templates/deployment.yaml
@@ -53,8 +53,8 @@ spec:
             - name: {{ $key }}
               value: {{ $value | quote }}
             {{- end }}
-            {{- if .Values.ingress.hosts }}
-            - name: BASE_URL
+            {{- if and .Values.ingress.hosts (not (hasKey .Values.app.env "PUBLIC_WEB_URL")) }}
+            - name: PUBLIC_WEB_URL
               value: {{ printf "https://%s" (first .Values.ingress.hosts) | quote }}
             {{- end }}
             {{- if .Values.embeddings.service.port }}

--- a/charts/lobu/templates/embeddings-deployment.yaml
+++ b/charts/lobu/templates/embeddings-deployment.yaml
@@ -1,0 +1,96 @@
+{{- if .Values.embeddings.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "lobu.fullname" . }}-embeddings
+  labels:
+    {{- include "lobu.labels" . | nindent 4 }}
+    app.kubernetes.io/component: embeddings
+spec:
+  replicas: {{ .Values.embeddings.replicaCount }}
+  {{- with .Values.embeddings.strategy }}
+  strategy:
+    {{- toYaml . | nindent 4 }}
+  {{- else }}
+  {{- if .Values.embeddings.cache.enabled }}
+  strategy:
+    type: Recreate
+  {{- end }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "lobu.embeddingsSelectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "lobu.embeddingsSelectorLabels" . | nindent 8 }}
+      {{- with .Values.embeddings.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.embeddings.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: embeddings
+          image: {{ include "lobu.embeddingsImage" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- with .Values.embeddings.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.embeddings.service.port }}
+              protocol: TCP
+          env:
+            - name: PORT
+              value: {{ .Values.embeddings.service.port | quote }}
+            - name: TRANSFORMERS_CACHE
+              value: /app/.cache/transformers
+            {{- range $key, $value := .Values.embeddings.env }}
+            - name: {{ $key }}
+              value: {{ $value | quote }}
+            {{- end }}
+          {{- $secretName := include "lobu.secretName" . }}
+          {{- if $secretName }}
+          envFrom:
+            - secretRef:
+                name: {{ $secretName }}
+          {{- end }}
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: {{ .Values.healthCheck.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.healthCheck.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.healthCheck.readinessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.healthCheck.readinessProbe.failureThreshold }}
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: {{ .Values.healthCheck.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.healthCheck.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.healthCheck.livenessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.healthCheck.livenessProbe.failureThreshold }}
+          {{- if .Values.embeddings.cache.enabled }}
+          volumeMounts:
+            - name: embeddings-cache
+              mountPath: /app/.cache
+          {{- end }}
+          resources:
+            {{- toYaml .Values.embeddings.resources | nindent 12 }}
+      {{- if .Values.embeddings.cache.enabled }}
+      volumes:
+        - name: embeddings-cache
+          persistentVolumeClaim:
+            claimName: {{ include "lobu.fullname" . }}-embeddings-cache
+      {{- end }}
+{{- end }}

--- a/charts/lobu/templates/embeddings-pvc.yaml
+++ b/charts/lobu/templates/embeddings-pvc.yaml
@@ -1,0 +1,18 @@
+{{- if and .Values.embeddings.enabled .Values.embeddings.cache.enabled }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "lobu.fullname" . }}-embeddings-cache
+  labels:
+    {{- include "lobu.labels" . | nindent 4 }}
+    app.kubernetes.io/component: embeddings
+spec:
+  accessModes:
+    {{- toYaml .Values.embeddings.cache.accessModes | nindent 4 }}
+  {{- if .Values.embeddings.cache.storageClass }}
+  storageClassName: {{ .Values.embeddings.cache.storageClass | quote }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.embeddings.cache.size }}
+{{- end }}

--- a/charts/lobu/templates/embeddings-service.yaml
+++ b/charts/lobu/templates/embeddings-service.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.embeddings.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "lobu.fullname" . }}-embeddings
+  labels:
+    {{- include "lobu.labels" . | nindent 4 }}
+    app.kubernetes.io/component: embeddings
+spec:
+  type: ClusterIP
+  ports:
+    - port: {{ .Values.embeddings.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "lobu.embeddingsSelectorLabels" . | nindent 4 }}
+{{- end }}

--- a/charts/lobu/templates/ingress.yaml
+++ b/charts/lobu/templates/ingress.yaml
@@ -1,0 +1,39 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "lobu.fullname" . }}
+  labels:
+    {{- include "lobu.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ . | quote }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "lobu.fullname" $ }}-app
+                port:
+                  number: {{ $.Values.service.port }}
+    {{- end }}
+{{- end }}

--- a/charts/lobu/templates/migration-job.yaml
+++ b/charts/lobu/templates/migration-job.yaml
@@ -72,6 +72,10 @@ spec:
             - name: DB_PREFLIGHT_TIMEOUT_SECONDS
               value: {{ .Values.releaseGates.databasePreflight.timeoutSeconds | quote }}
             {{- end }}
+            {{- if and .Values.secrets.create (hasKey .Values.secrets.stringData "DATABASE_URL") (not .Values.migrations.database.existingSecret) (not (hasKey .Values.app.env "DATABASE_URL")) }}
+            - name: DATABASE_URL
+              value: {{ index .Values.secrets.stringData "DATABASE_URL" | quote }}
+            {{- end }}
             {{- if .Values.migrations.database.existingSecret }}
             {{- if .Values.migrations.database.usePooler }}
             - name: DB_USER
@@ -95,7 +99,7 @@ spec:
             {{- end }}
             {{- end }}
           {{- $secretName := include "lobu.secretName" . }}
-          {{- if $secretName }}
+          {{- if and $secretName (not .Values.secrets.create) }}
           envFrom:
             - secretRef:
                 name: {{ $secretName }}

--- a/charts/lobu/templates/migration-job.yaml
+++ b/charts/lobu/templates/migration-job.yaml
@@ -1,0 +1,103 @@
+{{- if .Values.migrations.enabled }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "lobu.fullname" . }}-migrate
+  labels:
+    {{- include "lobu.labels" . | nindent 4 }}
+    app.kubernetes.io/component: migrate
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: 1
+  template:
+    metadata:
+      labels:
+        {{- include "lobu.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: migrate
+    spec:
+      restartPolicy: Never
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: migrate
+          image: {{ include "lobu.appImage" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command:
+            - /bin/bash
+            - -ec
+            - |
+              {{- if .Values.releaseGates.databasePreflight.enabled }}
+              echo "checking migration database connectivity"
+              node --input-type=module <<'NODE'
+              import postgres from "postgres";
+
+              const databaseUrl = process.env.DATABASE_URL;
+              const timeoutSeconds = Number(process.env.DB_PREFLIGHT_TIMEOUT_SECONDS || 10);
+
+              if (!databaseUrl) {
+                console.error("ERROR: DATABASE_URL not set");
+                process.exit(1);
+              }
+
+              const sql = postgres(databaseUrl, {
+                max: 1,
+                connect_timeout: timeoutSeconds,
+                idle_timeout: 1,
+                onnotice: () => {},
+              });
+
+              try {
+                const rows = await sql`select current_database() as database`;
+                console.log(`migration database preflight passed (${rows[0]?.database ?? "unknown"})`);
+              } catch (error) {
+                console.error("ERROR: migration database preflight failed");
+                console.error(error instanceof Error ? error.message : String(error));
+                process.exit(1);
+              } finally {
+                await sql.end({ timeout: 1 }).catch(() => {});
+              }
+              NODE
+              {{- end }}
+              exec /app/start.sh migrate
+          env:
+            {{- range $key, $value := .Values.app.env }}
+            - name: {{ $key }}
+              value: {{ $value | quote }}
+            {{- end }}
+            {{- if .Values.releaseGates.databasePreflight.enabled }}
+            - name: DB_PREFLIGHT_TIMEOUT_SECONDS
+              value: {{ .Values.releaseGates.databasePreflight.timeoutSeconds | quote }}
+            {{- end }}
+            {{- if .Values.migrations.database.existingSecret }}
+            {{- if .Values.migrations.database.usePooler }}
+            - name: DB_USER
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.migrations.database.existingSecret }}
+                  key: username
+            - name: DB_PASS
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.migrations.database.existingSecret }}
+                  key: password
+            - name: DATABASE_URL
+              value: "postgresql://$(DB_USER):$(DB_PASS)@{{ .Values.migrations.database.poolerService }}:5432/{{ .Values.migrations.database.name }}?sslmode=disable"
+            {{- else }}
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.migrations.database.existingSecret }}
+                  key: {{ .Values.migrations.database.existingSecretKey }}
+            {{- end }}
+            {{- end }}
+          {{- $secretName := include "lobu.secretName" . }}
+          {{- if $secretName }}
+          envFrom:
+            - secretRef:
+                name: {{ $secretName }}
+          {{- end }}
+{{- end }}

--- a/charts/lobu/templates/secret.yaml
+++ b/charts/lobu/templates/secret.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.secrets.create }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "lobu.secretName" . }}
+  labels:
+    {{- include "lobu.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  {{- range $key, $value := .Values.secrets.stringData }}
+  {{ $key }}: {{ $value | quote }}
+  {{- end }}
+{{- end }}

--- a/charts/lobu/templates/service.yaml
+++ b/charts/lobu/templates/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "lobu.fullname" . }}-app
+  labels:
+    {{- include "lobu.labels" . | nindent 4 }}
+    app.kubernetes.io/component: api
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "lobu.appSelectorLabels" . | nindent 4 }}

--- a/charts/lobu/templates/smoke-test-job.yaml
+++ b/charts/lobu/templates/smoke-test-job.yaml
@@ -1,0 +1,54 @@
+{{- if .Values.releaseGates.smokeTest.enabled }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "lobu.fullname" . }}-smoke-test
+  labels:
+    {{- include "lobu.labels" . | nindent 4 }}
+    app.kubernetes.io/component: smoke-test
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: 0
+  activeDeadlineSeconds: {{ add (.Values.releaseGates.smokeTest.timeoutSeconds | int) 30 }}
+  template:
+    metadata:
+      labels:
+        {{- include "lobu.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: smoke-test
+    spec:
+      restartPolicy: Never
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: smoke-test
+          image: {{ include "lobu.appImage" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command:
+            - /bin/bash
+            - -ec
+            - |
+              url="http://{{ include "lobu.fullname" . }}-app:{{ .Values.service.port }}{{ .Values.releaseGates.smokeTest.path }}"
+              deadline=$((SECONDS + {{ .Values.releaseGates.smokeTest.timeoutSeconds | int }}))
+              echo "waiting for $url"
+
+              while true; do
+                if curl -fsS --max-time 5 "$url" >/tmp/lobu-smoke-response 2>/tmp/lobu-smoke-error; then
+                  echo "smoke test passed"
+                  cat /tmp/lobu-smoke-response
+                  exit 0
+                fi
+
+                if [ "$SECONDS" -ge "$deadline" ]; then
+                  echo "smoke test timed out" >&2
+                  echo "last curl error:" >&2
+                  cat /tmp/lobu-smoke-error >&2 || true
+                  exit 1
+                fi
+
+                sleep {{ .Values.releaseGates.smokeTest.intervalSeconds | int }}
+              done
+{{- end }}

--- a/charts/lobu/templates/worker-deployment.yaml
+++ b/charts/lobu/templates/worker-deployment.yaml
@@ -1,0 +1,137 @@
+{{- if .Values.worker.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "lobu.fullname" . }}-worker
+  labels:
+    {{- include "lobu.labels" . | nindent 4 }}
+    app.kubernetes.io/component: worker
+spec:
+  replicas: {{ .Values.worker.replicaCount }}
+  {{- with .Values.worker.strategy }}
+  strategy:
+    {{- toYaml . | nindent 4 }}
+  {{- else }}
+  {{- if .Values.worker.cache.enabled }}
+  strategy:
+    type: Recreate
+  {{- end }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "lobu.workerSelectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "lobu.workerSelectorLabels" . | nindent 8 }}
+      {{- with .Values.worker.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.worker.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      initContainers:
+        - name: wait-for-app
+          image: {{ include "lobu.workerImage" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command:
+            - sh
+            - -c
+            - |
+              url="http://{{ include "lobu.fullname" . }}-app:{{ .Values.service.port }}/health"
+              echo "waiting for $url"
+              for i in $(seq 1 120); do
+                if curl -sf --max-time 2 "$url" >/dev/null 2>&1; then
+                  echo "app ready after $i attempts"
+                  exit 0
+                fi
+                sleep 2
+              done
+              echo "timed out after 4 minutes" >&2
+              exit 1
+          resources:
+            requests:
+              cpu: 10m
+              memory: 16Mi
+            limits:
+              cpu: 100m
+              memory: 64Mi
+      containers:
+        - name: worker
+          image: {{ include "lobu.workerImage" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- with .Values.worker.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          env:
+            - name: API_URL
+              value: http://{{ include "lobu.fullname" . }}-app:{{ .Values.service.port }}
+            - name: WORKER_ID
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: TRANSFORMERS_CACHE
+              value: /app/.cache/transformers
+            {{- if .Values.embeddings.service.port }}
+            {{- if .Values.embeddings.serviceUrl }}
+            - name: EMBEDDINGS_SERVICE_URL
+              value: {{ .Values.embeddings.serviceUrl | quote }}
+            {{- else if .Values.embeddings.enabled }}
+            - name: EMBEDDINGS_SERVICE_URL
+              value: {{ printf "http://%s-embeddings:%d" (include "lobu.fullname" .) (.Values.embeddings.service.port | int) | quote }}
+            {{- end }}
+            {{- end }}
+            {{- range $key, $value := .Values.worker.env }}
+            - name: {{ $key }}
+              value: {{ $value | quote }}
+            {{- end }}
+            {{- if .Values.database.existingSecret }}
+            {{- if .Values.database.usePooler }}
+            - name: DB_USER
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.database.existingSecret }}
+                  key: username
+            - name: DB_PASS
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.database.existingSecret }}
+                  key: password
+            - name: DATABASE_URL
+              value: "postgresql://$(DB_USER):$(DB_PASS)@{{ .Values.database.poolerService }}:5432/{{ .Values.database.name }}?sslmode=disable"
+            {{- else }}
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.database.existingSecret }}
+                  key: {{ .Values.database.existingSecretKey }}
+            {{- end }}
+            {{- end }}
+          {{- $secretName := include "lobu.secretName" . }}
+          {{- if $secretName }}
+          envFrom:
+            - secretRef:
+                name: {{ $secretName }}
+          {{- end }}
+          {{- if .Values.worker.cache.enabled }}
+          volumeMounts:
+            - name: worker-cache
+              mountPath: /app/.cache
+          {{- end }}
+          resources:
+            {{- toYaml .Values.worker.resources | nindent 12 }}
+      {{- if .Values.worker.cache.enabled }}
+      volumes:
+        - name: worker-cache
+          persistentVolumeClaim:
+            claimName: {{ include "lobu.fullname" . }}-worker-cache
+      {{- end }}
+{{- end }}

--- a/charts/lobu/templates/worker-pvc.yaml
+++ b/charts/lobu/templates/worker-pvc.yaml
@@ -1,0 +1,18 @@
+{{- if and .Values.worker.enabled .Values.worker.cache.enabled }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "lobu.fullname" . }}-worker-cache
+  labels:
+    {{- include "lobu.labels" . | nindent 4 }}
+    app.kubernetes.io/component: worker
+spec:
+  accessModes:
+    {{- toYaml .Values.worker.cache.accessModes | nindent 4 }}
+  {{- if .Values.worker.cache.storageClass }}
+  storageClassName: {{ .Values.worker.cache.storageClass | quote }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.worker.cache.size }}
+{{- end }}

--- a/charts/lobu/values.example.yaml
+++ b/charts/lobu/values.example.yaml
@@ -36,6 +36,8 @@ app:
   replicaCount: 1
   env:
     NODE_ENV: production
+    # PUBLIC_WEB_URL is derived from ingress.hosts[0] below. Set it here only
+    # when your public URL differs from that host.
     # Migrations are handled by the Helm pre-install/pre-upgrade Job below.
     SKIP_MIGRATIONS: "1"
     # Optional but recommended: start restrictive and add domains needed by
@@ -63,6 +65,9 @@ embeddings:
 
 migrations:
   enabled: true
+  # If you use secrets.create and place DATABASE_URL in secrets.stringData
+  # instead of the external lobu-db Secret above, leave this database block empty;
+  # the migration hook reads secrets.stringData.DATABASE_URL directly.
   database:
     existingSecret: lobu-db
     existingSecretKey: uri

--- a/charts/lobu/values.example.yaml
+++ b/charts/lobu/values.example.yaml
@@ -1,0 +1,82 @@
+# Minimal public Helm install template for Lobu.
+#
+# 1. Create the namespace and secrets:
+#
+#    kubectl create namespace lobu
+#    kubectl -n lobu create secret generic lobu-db \
+#      --from-literal=uri='postgresql://USER:PASSWORD@HOST:5432/lobu?sslmode=require'
+#    kubectl -n lobu create secret generic lobu-secrets \
+#      --from-literal=JWT_SECRET='replace-with-a-long-random-value' \
+#      --from-literal=BETTER_AUTH_SECRET='replace-with-a-long-random-value' \
+#      --from-literal=ANTHROPIC_API_KEY='sk-ant-...'
+#
+# 2. Copy this file, fill in your hostname/storage classes as needed, then run:
+#
+#    helm install lobu oci://ghcr.io/lobu-ai/charts/lobu \
+#      --namespace lobu --create-namespace \
+#      -f values.example.yaml
+
+image:
+  # The image pipeline publishes timestamp tags plus latest. Pin a timestamp
+  # tag from GHCR in production; latest keeps first-time installs simple.
+  tag: "latest"
+
+# Existing Secret loaded into all Lobu pods. Put JWT_SECRET,
+# BETTER_AUTH_SECRET, provider API keys, OAuth client secrets, and other Lobu
+# runtime secrets here. DATABASE_URL can live here too if you leave
+# database.existingSecret empty.
+secretName: lobu-secrets
+
+database:
+  # Secret key must contain a full Postgres URL. Postgres must have pgvector.
+  existingSecret: lobu-db
+  existingSecretKey: uri
+
+app:
+  replicaCount: 1
+  env:
+    NODE_ENV: production
+    # Migrations are handled by the Helm pre-install/pre-upgrade Job below.
+    SKIP_MIGRATIONS: "1"
+    # Optional but recommended: start restrictive and add domains needed by
+    # your enabled skills/connectors. Use "*" only for trusted dev clusters.
+    WORKER_ALLOWED_DOMAINS: ""
+  workspaces:
+    enabled: true
+    size: 20Gi
+    # storageClass: fast-ssd
+
+worker:
+  enabled: true
+  replicaCount: 1
+  cache:
+    enabled: true
+    size: 5Gi
+    # storageClass: fast-ssd
+
+embeddings:
+  enabled: true
+  cache:
+    enabled: true
+    size: 5Gi
+    # storageClass: fast-ssd
+
+migrations:
+  enabled: true
+  database:
+    existingSecret: lobu-db
+    existingSecretKey: uri
+
+ingress:
+  enabled: true
+  className: nginx
+  annotations:
+    # Uncomment when using cert-manager.
+    # cert-manager.io/cluster-issuer: letsencrypt-prod
+  hosts:
+    - lobu.example.com
+  tls:
+    # Uncomment after configuring TLS for your ingress controller.
+    # - secretName: lobu-tls
+    #   hosts:
+    #     - lobu.example.com

--- a/charts/lobu/values.yaml
+++ b/charts/lobu/values.yaml
@@ -1,0 +1,173 @@
+# Default values for the public Lobu chart.
+# See values.example.yaml for a minimal copy/paste install template.
+
+nameOverride: ""
+fullnameOverride: ""
+
+image:
+  registry: ghcr.io
+  # The chart appends -app, -worker, and -embeddings for the three images.
+  repository: lobu-ai/lobu
+  pullPolicy: IfNotPresent
+  # The image pipeline publishes timestamp tags plus latest. Pin a timestamp
+  # tag for production upgrades; latest keeps first-time installs simple.
+  tag: "latest"
+
+# Public images do not require pull secrets. Set this if your cluster must
+# authenticate to GHCR or you mirror images into a private registry.
+imagePullSecrets: []
+
+# Existing Kubernetes Secret loaded into app, worker, embeddings, and migration
+# pods via envFrom. It commonly contains DATABASE_URL, JWT_SECRET,
+# BETTER_AUTH_SECRET, provider API keys, and integration OAuth credentials.
+secretName: ""
+
+# Optional chart-managed Secret. Prefer an external secret manager for
+# production; this is here for small test clusters and quick demos.
+secrets:
+  create: false
+  name: ""
+  stringData: {}
+
+app:
+  replicaCount: 1
+  strategy: {}
+  podAnnotations: {}
+  podSecurityContext: {}
+  securityContext: {}
+
+  resources:
+    requests:
+      cpu: 100m
+      memory: 512Mi
+    limits:
+      cpu: 2000m
+      memory: 2Gi
+
+  env:
+    NODE_ENV: production
+
+  # Persistent workspaces volume. Embedded agent workers store session and
+  # workspace state below /app/workspaces.
+  workspaces:
+    enabled: true
+    size: 20Gi
+    storageClass: ""
+    accessModes:
+      - ReadWriteOnce
+
+worker:
+  # Connector ingestion worker. Disable if you only need the API/chat gateway.
+  enabled: true
+  replicaCount: 1
+  strategy: {}
+  podAnnotations: {}
+  podSecurityContext:
+    fsGroup: 1001
+    fsGroupChangePolicy: OnRootMismatch
+  securityContext: {}
+
+  resources:
+    requests:
+      cpu: 500m
+      memory: 2Gi
+    limits:
+      cpu: 2000m
+      memory: 4Gi
+
+  env:
+    POLL_INTERVAL_MS: "10000"
+
+  cache:
+    enabled: true
+    size: 5Gi
+    storageClass: ""
+    accessModes:
+      - ReadWriteOnce
+
+embeddings:
+  enabled: true
+  replicaCount: 1
+  strategy: {}
+  podAnnotations: {}
+  podSecurityContext:
+    fsGroup: 1001
+    fsGroupChangePolicy: OnRootMismatch
+  securityContext: {}
+
+  # If set, app and worker use this URL instead of the in-chart service.
+  serviceUrl: ""
+
+  resources:
+    requests:
+      cpu: 500m
+      memory: 1Gi
+    limits:
+      memory: 3Gi
+
+  env: {}
+
+  service:
+    port: 8790
+
+  cache:
+    enabled: true
+    size: 5Gi
+    storageClass: ""
+    accessModes:
+      - ReadWriteOnce
+
+service:
+  type: ClusterIP
+  port: 8787
+
+# Optional Ingress for public webhooks and the admin UI.
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+  hosts: []
+  tls: []
+
+# Database configuration. For most installs, create a Secret with DATABASE_URL
+# and set database.existingSecret below. Alternatively, keep database empty and
+# provide DATABASE_URL through secretName/secrets.
+database:
+  existingSecret: ""
+  existingSecretKey: uri
+  name: app
+  usePooler: false
+  poolerService: ""
+
+healthCheck:
+  readinessProbe:
+    initialDelaySeconds: 10
+    periodSeconds: 10
+    timeoutSeconds: 3
+    failureThreshold: 6
+  livenessProbe:
+    initialDelaySeconds: 30
+    periodSeconds: 20
+    timeoutSeconds: 3
+    failureThreshold: 3
+
+migrations:
+  # When enabled, Helm runs migrations as a pre-install/pre-upgrade Job and you
+  # should set app.env.SKIP_MIGRATIONS: "1" so app pods do not repeat them.
+  enabled: false
+  database:
+    existingSecret: ""
+    existingSecretKey: uri
+    name: app
+    usePooler: false
+    poolerService: ""
+
+releaseGates:
+  databasePreflight:
+    enabled: true
+    timeoutSeconds: 10
+  smokeTest:
+    enabled: true
+    path: /api/health
+    timeoutSeconds: 300
+    intervalSeconds: 2

--- a/charts/lobu/values.yaml
+++ b/charts/lobu/values.yaml
@@ -121,7 +121,9 @@ service:
   type: ClusterIP
   port: 8787
 
-# Optional Ingress for public webhooks and the admin UI.
+# Optional Ingress for public webhooks and the admin UI. When hosts are set,
+# the app Deployment derives PUBLIC_WEB_URL from the first host unless you set
+# app.env.PUBLIC_WEB_URL explicitly.
 ingress:
   enabled: false
   className: ""
@@ -131,7 +133,10 @@ ingress:
 
 # Database configuration. For most installs, create a Secret with DATABASE_URL
 # and set database.existingSecret below. Alternatively, keep database empty and
-# provide DATABASE_URL through secretName/secrets.
+# provide DATABASE_URL through secretName/secrets. When migrations.enabled and
+# secrets.create are both true, put DATABASE_URL in secrets.stringData or set
+# migrations.database.existingSecret so the hook does not depend on a Secret
+# that Helm has not created yet.
 database:
   existingSecret: ""
   existingSecretKey: uri
@@ -153,7 +158,10 @@ healthCheck:
 
 migrations:
   # When enabled, Helm runs migrations as a pre-install/pre-upgrade Job and you
-  # should set app.env.SKIP_MIGRATIONS: "1" so app pods do not repeat them.
+  # should set app.env.SKIP_MIGRATIONS: "1" so app pods do not repeat them. If
+  # secrets.create is true and DATABASE_URL lives in that chart-managed Secret,
+  # the Job reads secrets.stringData.DATABASE_URL directly because normal chart
+  # resources are not created before pre-install hooks run.
   enabled: false
   database:
     existingSecret: ""

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -55,6 +55,16 @@
           "type": "json",
           "path": "packages/embeddings/package.json",
           "jsonpath": "$.version"
+        },
+        {
+          "type": "yaml",
+          "path": "charts/lobu/Chart.yaml",
+          "jsonpath": "$.version"
+        },
+        {
+          "type": "yaml",
+          "path": "charts/lobu/Chart.yaml",
+          "jsonpath": "$.appVersion"
         }
       ]
     }


### PR DESCRIPTION
## Summary
- add a public `charts/lobu` Helm chart based on the internal Lobu Cloud deployment pattern
- include `values.example.yaml` with the minimal secrets/database/ingress template for first-time installs
- add Helm CI/publish workflow to lint/render the chart and publish `oci://ghcr.io/lobu-ai/charts/lobu` on releases
- wire Chart.yaml version/appVersion into release-please and update README deployment notes

Closes #495

## Validation
- `helm lint --strict charts/lobu`
- `helm template lobu charts/lobu --namespace lobu`
- `helm template lobu charts/lobu --namespace lobu -f charts/lobu/values.example.yaml`
- `helm package charts/lobu --destination /tmp/lobu-chart-package`
