### PR TITLE
chore(landing): align landing copy around multi-user agent backend positioning

### DIFF
--- a/packages/landing/src/components/CTA.tsx
+++ b/packages/landing/src/components/CTA.tsx
@@ -51,9 +51,9 @@ export function CTA({ startUrl = getLobuBaseUrl() }: { startUrl?: string }) {
               letterSpacing: "-0.025em",
             }}
           >
-            Start with the
+            Build your first
             <br />
-            free open-source build.
+            multi-user agent.
           </h2>
           <div class="flex flex-wrap gap-3">
             <a
@@ -64,7 +64,7 @@ export function CTA({ startUrl = getLobuBaseUrl() }: { startUrl?: string }) {
                 color: "var(--color-page-text-inverted)",
               }}
             >
-              Start for free
+              Start building
             </a>
             <a
               href="/getting-started"

--- a/packages/landing/src/components/DataModelSection.tsx
+++ b/packages/landing/src/components/DataModelSection.tsx
@@ -1,3 +1,6 @@
+import type { LandingUseCaseId } from "../use-case-definitions";
+import { landingUseCases } from "../use-case-definitions";
+
 type Attribute = { name: string; icon: string };
 
 type EntityCard = {
@@ -9,36 +12,83 @@ type EntityCard = {
   moreCount: number;
 };
 
-const ENTITIES: EntityCard[] = [
+const ENTITY_EMOJI_FALLBACKS: Record<string, string> = {
+  Member: "👤",
+  Person: "👤",
+  Company: "🏢",
+  Founder: "🧑‍🚀",
+  Investor: "🏦",
+  "Fund Round": "💰",
+  Sector: "🏭",
+  Contract: "📜",
+  Clause: "📑",
+  Risk: "⚠️",
+  Incident: "🚨",
+  Service: "🧩",
+  Deploy: "🚀",
+  "Pull Request": "🔧",
+  Customer: "👥",
+  Ticket: "🎫",
+  Issue: "🐞",
+  Organization: "🏢",
+  Deal: "💰",
+  Task: "✅",
+  Project: "📐",
+  Decision: "✅",
+  Topic: "🗂",
+  Match: "🔗",
+  Post: "📝",
+};
+
+const ATTRIBUTE_ICONS: Record<string, string> = {
+  Type: "🏷",
+  Name: "🪪",
+  Company: "🏢",
+  Founder: "🧑‍🚀",
+  Founders: "🧑‍🚀",
+  Funding: "💰",
+  Stage: "📈",
+  Valuation: "📊",
+  Sector: "🏭",
+  Role: "👤",
+  Amount: "💸",
+  Lead: "🏦",
+  Risk: "⚠️",
+  Status: "✅",
+  Owner: "🧑‍💼",
+  Source: "🔗",
+};
+
+const FALLBACK_ENTITIES: EntityCard[] = [
   {
-    id: "member",
-    label: "Member",
+    id: "user",
+    label: "User",
     emoji: "👤",
-    badge: "Standard",
+    badge: "Entity",
     attributes: [
       { name: "Identity", icon: "🪪" },
-      { name: "Preferences", icon: "⚙" },
-      { name: "Decisions", icon: "✅" },
-    ],
-    moreCount: 5,
-  },
-  {
-    id: "asset",
-    label: "Asset",
-    emoji: "💼",
-    badge: "Standard",
-    attributes: [
-      { name: "Valuation", icon: "📊" },
-      { name: "Transaction", icon: "💸" },
-      { name: "Source", icon: "🔗" },
+      { name: "Sources", icon: "🔗" },
+      { name: "Preferences", icon: "⚙️" },
     ],
     moreCount: 3,
+  },
+  {
+    id: "source",
+    label: "Source",
+    emoji: "📄",
+    badge: "Entity",
+    attributes: [
+      { name: "Content", icon: "📝" },
+      { name: "Evidence", icon: "🔎" },
+      { name: "Owner", icon: "🧑‍💼" },
+    ],
+    moreCount: 2,
   },
   {
     id: "topic",
     label: "Topic",
     emoji: "🗂",
-    badge: "Standard",
+    badge: "Entity",
     attributes: [
       { name: "Summary", icon: "📝" },
       { name: "Watchers", icon: "🔔" },
@@ -48,10 +98,87 @@ const ENTITIES: EntityCard[] = [
   },
 ];
 
-const RELATIONSHIPS: { afterIndex: number; label: string }[] = [
-  { afterIndex: 0, label: "owns" },
-  { afterIndex: 1, label: "linked to" },
-];
+function entityEmoji(label: string): string {
+  if (ENTITY_EMOJI_FALLBACKS[label]) return ENTITY_EMOJI_FALLBACKS[label];
+  if (label.endsWith("s") && ENTITY_EMOJI_FALLBACKS[label.slice(0, -1)]) {
+    return ENTITY_EMOJI_FALLBACKS[label.slice(0, -1)];
+  }
+  return "📄";
+}
+
+function attributeIcon(label: string): string {
+  return ATTRIBUTE_ICONS[label] ?? "•";
+}
+
+function buildUseCaseCards(useCaseId?: LandingUseCaseId): {
+  entities: EntityCard[];
+  relationships: { afterIndex: number; label: string }[];
+  description: string;
+} {
+  const useCase = useCaseId ? landingUseCases[useCaseId] : null;
+  if (!useCase) {
+    return {
+      entities: FALLBACK_ENTITIES,
+      relationships: [
+        { afterIndex: 0, label: "connects" },
+        { afterIndex: 1, label: "links to" },
+      ],
+      description:
+        "Users, sources, and topics become typed memory. Extend the schema with your own objects and relationships.",
+    };
+  }
+
+  const children = useCase.memory.recordTree.children ?? [];
+  const entities = useCase.model.entities.slice(0, 3).map((label) => {
+    const selectedId = useCase.memory.entitySelections?.[label];
+    const child = children.find((node) => node.kind === label);
+    const highlights =
+      (selectedId && useCase.memory.nodeHighlights?.[selectedId]) ||
+      (child && useCase.memory.nodeHighlights?.[child.id]) ||
+      [];
+    const attributes = (
+      highlights.length ? highlights : useCase.memory.highlights
+    )
+      .slice(0, 3)
+      .map((field) => ({
+        name: field.label,
+        icon: attributeIcon(field.label),
+      }));
+
+    return {
+      id: selectedId ?? child?.id ?? label.toLowerCase().replace(/\s+/g, "-"),
+      label,
+      emoji: entityEmoji(label),
+      badge: "Entity",
+      attributes,
+      moreCount: Math.max(0, highlights.length - attributes.length),
+    };
+  });
+
+  const relationships = entities.slice(0, -1).map((entity, index) => {
+    const next = entities[index + 1];
+    const matchingRelation = useCase.memory.relations.find((rel) => {
+      const sourceType = rel.sourceType.toLowerCase().replace(/_/g, " ");
+      const targetType = rel.targetType.toLowerCase().replace(/_/g, " ");
+      const left = entity.label.toLowerCase();
+      const right = next.label.toLowerCase();
+      return (
+        (sourceType === left && targetType === right) ||
+        (sourceType === right && targetType === left)
+      );
+    });
+    return {
+      afterIndex: index,
+      label: matchingRelation?.label.replace(/_/g, " ") ?? "linked to",
+    };
+  });
+
+  return {
+    entities: entities.length ? entities : FALLBACK_ENTITIES,
+    relationships,
+    description: `${useCase.label} agents use ${useCase.model.entities.slice(0, 5).join(", ")} as typed memory. Add your own entities and relationships as the workflow grows.`,
+  };
+}
 
 function EntityCardView({ entity }: { entity: EntityCard }) {
   return (
@@ -189,7 +316,13 @@ function MobileConnector({ label }: { label: string }) {
   );
 }
 
-export function DataModelSection() {
+export function DataModelSection({
+  useCaseId,
+}: {
+  useCaseId?: LandingUseCaseId;
+}) {
+  const { entities, relationships, description } = buildUseCaseCards(useCaseId);
+
   return (
     <section class="relative px-4 sm:px-6 max-w-[72rem] mx-auto">
       <div
@@ -216,23 +349,21 @@ export function DataModelSection() {
             class="text-[15px] leading-relaxed max-w-xl"
             style={{ color: "var(--color-page-text-muted)" }}
           >
-            Members, assets, topics. Extend the schema with your own objects and
-            define how they relate. Lobu Memory routes events, embeddings, and
-            watchers along those edges automatically.
+            {description}
           </p>
         </div>
 
         <div class="px-6 sm:px-10 pt-6 pb-10">
           <div class="hidden md:flex items-stretch gap-3">
-            {ENTITIES.map((entity, i) => (
+            {entities.map((entity, i) => (
               <>
                 <div key={entity.id} class="flex-1 min-w-0">
                   <EntityCardView entity={entity} />
                 </div>
-                {RELATIONSHIPS.find((r) => r.afterIndex === i) ? (
+                {relationships.find((r) => r.afterIndex === i) ? (
                   <Connector
                     key={`rel-${i}`}
-                    label={RELATIONSHIPS.find((r) => r.afterIndex === i)!.label}
+                    label={relationships.find((r) => r.afterIndex === i)!.label}
                   />
                 ) : null}
               </>
@@ -244,8 +375,8 @@ export function DataModelSection() {
           </div>
 
           <div class="md:hidden flex flex-col gap-3">
-            {ENTITIES.map((entity, i) => {
-              const rel = RELATIONSHIPS.find((r) => r.afterIndex === i);
+            {entities.map((entity, i) => {
+              const rel = relationships.find((r) => r.afterIndex === i);
               return (
                 <>
                   <EntityCardView key={entity.id} entity={entity} />

--- a/packages/landing/src/components/Footer.tsx
+++ b/packages/landing/src/components/Footer.tsx
@@ -77,8 +77,8 @@ export function Footer() {
               class="mt-4 text-[13px] leading-relaxed max-w-xs"
               style={{ color: "var(--color-page-text-muted)" }}
             >
-              Open-source platform for autonomous, persistent agents.
-              Self-hostable, sandboxed, and proactive.
+              Open-source backend for multi-user AI agents. Self-hostable,
+              isolated, and source-backed.
             </p>
           </div>
           {COLUMNS.map((col) => (

--- a/packages/landing/src/components/HeroSection.tsx
+++ b/packages/landing/src/components/HeroSection.tsx
@@ -87,11 +87,11 @@ export function HeroSection(props: {
     setCycleSeed((s) => s + 1);
   };
 
-  const headlineText = "Proactive agents that never forget.";
-  const headlineHighlight = "never forget";
+  const headlineText = "The open-source backend for multi-user AI agents.";
+  const headlineHighlight = "multi-user AI agents";
   const subhead =
     props.heroCopy?.description ??
-    "Build autonomous agents that take action and stay reachable from any chat or AI client.";
+    "Give every user an isolated agent workspace with OAuth, connected sources, shared memory, watchers, and secrets agents never see.";
 
   return (
     <section class="pt-16 pb-8 px-6 relative">
@@ -104,7 +104,7 @@ export function HeroSection(props: {
             border: "1px solid var(--color-page-border)",
           }}
         >
-          Lobu Memory scores 87.1% on LongMemEval, highest of any system
+          Multi-tenant agents with per-user OAuth isolation
           <ArrowRightIcon />
         </a>
 
@@ -135,7 +135,7 @@ export function HeroSection(props: {
               color: "var(--color-page-text-inverted)",
             }}
           >
-            Start for free
+            Start building
           </a>
           <a
             href={GITHUB_URL}

--- a/packages/landing/src/components/HeroSection.tsx
+++ b/packages/landing/src/components/HeroSection.tsx
@@ -87,7 +87,7 @@ export function HeroSection(props: {
     setCycleSeed((s) => s + 1);
   };
 
-  const headlineText = "The open-source backend for multi-user AI agents.";
+  const headlineText = "Open-source backend for multi-user AI agents";
   const headlineHighlight = "multi-user AI agents";
   const subhead =
     props.heroCopy?.description ??

--- a/packages/landing/src/components/LandingPage.tsx
+++ b/packages/landing/src/components/LandingPage.tsx
@@ -72,9 +72,9 @@ export function LandingPage(props: {
         id="memory"
       >
         <FeatureBlock
-          eyebrow="Shared memory for every agent"
-          title="Turn data into shared, structured memory."
-          description="Tell one agent something and the rest already know. Lobu Memory gives every agent the same typed entities and event history, recalled through MCP when it matters."
+          eyebrow="Shared org memory"
+          title="Give agents the same source-backed context."
+          description="Connect sources once. Lobu turns them into typed memory that agents can search, cite, and reuse across users."
           ctaLabel="Read the memory guide"
           ctaHref="/getting-started/memory/"
           graphic={<SharedMemoryGraphic />}
@@ -88,9 +88,9 @@ export function LandingPage(props: {
         id="skills"
       >
         <FeatureBlock
-          eyebrow="Drop in, ready to work"
-          title="Give your agent new capabilities."
-          description="A skill bundles everything an agent needs to do something: instructions, tools, and access, all in one folder. No glue code, no IT ticket. Drop it in and the agent picks it up."
+          eyebrow="Capabilities"
+          title="Add tools without glue code."
+          description="Skills bundle instructions, tools, packages, and network access so agents can pick up new workflows safely."
           ctaLabel="Explore skills"
           ctaHref="/getting-started/skills/"
           graphic={<SkillsGraphic />}
@@ -105,9 +105,9 @@ export function LandingPage(props: {
         id="autonomous"
       >
         <FeatureBlock
-          eyebrow="Working while you're away"
-          title="Turn schedules into agents that act on their own."
-          description="A watcher wakes on a schedule, reads recent activity, filters with a prompt you wrote, and writes the signal (not the noise) into entity memory. The agent isn't online, but the memory is moving."
+          eyebrow="Watchers"
+          title="Turn recurring work into reports and memory."
+          description="Watchers read new activity on a schedule, extract the signal, and write source-backed updates your agents can use."
           ctaLabel="How watchers work"
           ctaHref="/getting-started/memory/#watchers"
           graphic={<WatcherGraphic />}
@@ -121,9 +121,9 @@ export function LandingPage(props: {
         id="platforms"
       >
         <FeatureBlock
-          eyebrow="Built into your tools"
-          title="Talk to your agents from any chat or AI client."
-          description="Lobu agents live where your team already works: Slack, Telegram, Discord, Teams, WhatsApp, Google Chat. Or pull them into ChatGPT, Claude, Cursor, and any MCP-capable client over the same protocol."
+          eyebrow="Multi-user delivery"
+          title="Reach agents from chat, apps, and MCP clients."
+          description="Route Slack, Telegram, REST, OpenClaw, ChatGPT, Claude, and other MCP clients through the same org-scoped backend."
           ctaLabel="Connect via MCP"
           ctaHref="/mcp/"
           graphic={<PlatformsGraphic />}
@@ -139,8 +139,8 @@ export function LandingPage(props: {
       >
         <FeatureBlock
           eyebrow="Self-host or managed"
-          title="You own your data."
-          description="Run open-source Lobu on your own servers for full control over your data and credentials, or use our managed runtime. With per-second billing you only pay for the time your agents are awake."
+          title="Keep data and credentials under control."
+          description="Run the open-source engine on your infrastructure or use Lobu Cloud. Workers stay isolated and never receive raw secrets."
           ctaLabel="Self-host guide"
           ctaHref="/getting-started/"
           graphic={<HostingGraphic />}
@@ -150,7 +150,7 @@ export function LandingPage(props: {
       <ArchitectureSection activeUseCaseId={activeUseCaseId} />
 
       <div class="py-20" id="data-model">
-        <DataModelSection />
+        <DataModelSection useCaseId={activeUseCaseId} />
       </div>
 
       <CTA startUrl={startUrl} />

--- a/packages/landing/src/components/Nav.tsx
+++ b/packages/landing/src/components/Nav.tsx
@@ -394,7 +394,7 @@ export function Nav({
                 color: "var(--color-page-text-inverted)",
               }}
             >
-              Start for free
+              Start building
             </a>
           </div>
         </div>

--- a/packages/landing/src/connect-from-config.ts
+++ b/packages/landing/src/connect-from-config.ts
@@ -48,7 +48,7 @@ type ConnectFromClientConfig = {
 
 const mcpClientDescribe =
   (label: string) => (showcase: LandingUseCaseShowcase) =>
-    `Use ${label} on top of the ${showcase.label.toLowerCase()} workspace so it can read and write the same shared memory shown in this example.`;
+    `Use ${label} with the ${showcase.label.toLowerCase()} workspace so it can use the same org-scoped memory, sources, and tools shown here.`;
 
 const connectFromClientConfigs: Record<
   ConnectFromClientId,
@@ -118,7 +118,7 @@ const connectFromClientConfigs: Record<
     valueProp:
       "Layer structured, shareable Lobu memory on top of OpenClaw's built-in filesystem memory — the plugin extends OpenClaw's filesystem plugin and can optionally take over its memory slot, so different OpenClaw agents can talk to each other through the same Lobu graph.",
     installPrompt:
-      "Install Lobu memory in OpenClaw. Run:\n\n  openclaw plugins install @lobu/openclaw-plugin\n  lobu login\n  lobu memory configure --url https://lobu.ai/mcp --org <org-slug>\n  lobu memory health --url https://lobu.ai/mcp --org <org-slug>\n\nThe plugin extends OpenClaw's filesystem plugin and can replace its memory slot. After install, point me at the Lobu memory workspace I should use as shared memory across my OpenClaw agents.",
+      "Connect OpenClaw to Lobu. Run:\n\n  openclaw plugins install @lobu/openclaw-plugin\n  lobu login\n  lobu memory configure --url https://lobu.ai/mcp --org <org-slug>\n  lobu memory health --url https://lobu.ai/mcp --org <org-slug>\n\nUse Lobu as the multi-user backend for OpenClaw: org-scoped memory, connected sources, watchers, and credentials that stay behind the gateway.",
     npmPackage: {
       name: "@lobu/openclaw-plugin",
       registryUrl: "https://www.npmjs.com/package/@lobu/openclaw-plugin",

--- a/packages/landing/src/content/docs/getting-started/comparison.md
+++ b/packages/landing/src/content/docs/getting-started/comparison.md
@@ -3,15 +3,15 @@ title: Comparison
 description: How Lobu compares to other agent deployment options.
 ---
 
-Lobu is multi-tenant agent infrastructure. It handles sandboxing, persistence, platform delivery, and network isolation so you can ship agents to your users without building that plumbing yourself.
+Lobu is the open-source backend for multi-user AI agents. It handles isolation, per-user OAuth, connected sources, shared memory, and platform delivery so you can ship agents without rebuilding that plumbing.
 
-This page compares Lobu against alternatives for deploying agents to production.
+This page compares Lobu against other ways to run agents for multiple users.
 
 ## At a glance
 
 | | Lobu | OpenClaw (direct) | DeepAgents Deploy | Claude Managed Agents |
 |---|---|---|---|---|
-| **What it is** | Self-hosted multi-tenant gateway | Single-user agent runtime | Hosted agent deployment (LangSmith) | Hosted managed agents |
+| **What it is** | Open-source backend for multi-user agents | Single-user agent runtime | Hosted agent deployment (LangSmith) | Hosted managed agents |
 | **Multi-tenant** | Per-user/channel isolation | Single user | Per-thread sandbox | Per-conversation |
 | **Platforms** | Slack, Telegram, WhatsApp, Discord, Teams, Google Chat, REST API | CLI and API | API endpoints (MCP, A2A, Agent Protocol) | API |
 | **Embeddable** | Mount inside Next.js, Express, Hono, Fastify | No | No | No |
@@ -106,7 +106,7 @@ Lobu runs entirely on your infrastructure:
 
 ## When to use Lobu
 
-Lobu is the right choice when you need to **give multiple users their own agents**:
+Use Lobu when your agent needs more than one isolated user or channel:
 
 - **SaaS products** — embed agents in your app where each user gets isolated persistence, tools, and context.
 - **Internal teams** — deploy a single bot to Slack or Teams where every employee gets their own sandboxed agent.
@@ -117,7 +117,7 @@ If you need a single personal agent for yourself, use OpenClaw directly.
 
 ## Lobu vs OpenClaw
 
-Lobu and OpenClaw are complementary. OpenClaw is the agent runtime — the execution engine that runs tools, manages sessions, and talks to LLM providers. Lobu is the infrastructure layer that deploys, isolates, and delivers that runtime to multiple users.
+Lobu and OpenClaw are complementary. OpenClaw is the single-user runtime. Lobu is the multi-user backend around it: routing, isolation, credentials, memory, and delivery.
 
 OpenClaw (~800k LOC) was designed as a **single-tenant, single-user system**. Production deployments need multi-tenant isolation, platform routing, credential separation, network control, and scale-to-zero — concerns OpenClaw doesn't have opinions about.
 

--- a/packages/landing/src/content/docs/getting-started/index.mdx
+++ b/packages/landing/src/content/docs/getting-started/index.mdx
@@ -1,9 +1,9 @@
 ---
 title: Getting Started
-description: Choose between managed community access and self-hosted deployment.
+description: Build with Lobu, the open-source backend for multi-user AI agents.
 ---
 
-Deploy sandboxed, persistent AI agents to your infrastructure — one isolated agent per user and channel, from a single deploy.
+Lobu is an open-source, multi-tenant agent backend. It gives every user or channel an isolated agent workspace with connected sources, shared memory, and per-user OAuth isolation.
 
 ## Quick start
 

--- a/packages/landing/src/content/docs/guides/security.md
+++ b/packages/landing/src/content/docs/guides/security.md
@@ -3,7 +3,7 @@ title: Security
 description: Isolation, network policy, credentials, and MCP proxy behavior.
 ---
 
-Lobu is built so a compromised worker session cannot leak secrets or reach arbitrary networks. Secrets and outbound policy live on the gateway; workers run sandboxed with no ambient trust.
+Lobu is built for multi-user agents: each user or channel gets an isolated worker, while secrets and outbound policy stay on the gateway. A compromised worker should not see raw credentials or reach arbitrary networks.
 
 ## Core Model
 

--- a/packages/landing/src/layouts/BaseLayout.astro
+++ b/packages/landing/src/layouts/BaseLayout.astro
@@ -11,8 +11,8 @@ interface Props {
 }
 
 const {
-  title = "Lobu - Deploy autonomous AI agents",
-  description = "Open-source platform for persistent, sandboxed AI agents with shared memory, installable skills, chat integrations, and MCP access.",
+  title = "Lobu - Open-source backend for multi-user AI agents",
+  description = "Open-source, multi-tenant agent backend with isolated workers, per-user OAuth, connected sources, shared memory, and secrets agents never see.",
   ogType = "website",
   article,
 } = Astro.props;
@@ -86,7 +86,7 @@ const hasMarkdownTwin = existsSync(markdownFileURL);
       "name": "Lobu",
       "url": "https://lobu.ai",
       "logo": "https://lobu.ai/lobster-icon.png",
-      "description": "Open-source platform for persistent, sandboxed AI agents with shared memory, installable skills, chat integrations, and MCP access.",
+      "description": "Open-source, multi-tenant agent backend with isolated workers, per-user OAuth, connected sources, shared memory, and secrets agents never see.",
       "sameAs": [
         "https://github.com/lobu-ai/lobu",
         "https://x.com/bu7emba"

--- a/packages/landing/src/pages/mcp.astro
+++ b/packages/landing/src/pages/mcp.astro
@@ -35,8 +35,8 @@ const clients = [
 ---
 
 <BaseLayout
-  title="Lobu MCP - Connect any agent to your shared memory"
-  description="https://lobu.ai/mcp is the canonical MCP endpoint. Sign in once, then list and switch between organizations from any MCP-capable agent."
+  title="Lobu MCP - Connect agents to your multi-user backend"
+  description="https://lobu.ai/mcp is the canonical MCP endpoint. Sign in once, then use org-scoped memory, connectors, watchers, and tools from any MCP-capable agent."
 >
   <div
     class="min-h-screen grid-lines"
@@ -58,18 +58,15 @@ const clients = [
           class="text-4xl sm:text-5xl font-bold tracking-tight mb-6"
           style={{ color: "var(--color-page-text)" }}
         >
-          Connect any agent to Lobu
+          Connect agents to your Lobu backend
         </h1>
         <p
           class="text-lg leading-relaxed mb-8"
           style={{ color: "var(--color-page-text-muted)" }}
         >
-          The URL below is a Streamable HTTP MCP server. Paste it into any
-          MCP-capable client. After OAuth, the server exposes
-          <code class="font-mono text-sm">list_organizations</code> and
-          <code class="font-mono text-sm">switch_organization</code> so the
-          agent can see every workspace you belong to and pick one per
-          conversation.
+          Paste this Streamable HTTP MCP URL into any compatible client. After
+          OAuth, agents can use org-scoped memory, connectors, watchers, and
+          tools without seeing raw credentials.
         </p>
 
         <div

--- a/packages/landing/src/pages/privacy.astro
+++ b/packages/landing/src/pages/privacy.astro
@@ -30,7 +30,7 @@ import { Nav } from "../components/Nav";
             Introduction
           </h2>
           <p class="mb-4 leading-relaxed" style={{ color: "var(--color-page-text-muted)" }}>
-            Lobu is an open-source platform for deploying autonomous AI agents. We are committed to protecting your privacy and being transparent about the data we collect and how we use it.
+            Lobu is an open-source backend for multi-user AI agents. We are committed to protecting your privacy and being transparent about the data we collect and how we use it.
           </p>
         </section>
 

--- a/packages/landing/src/pages/terms.astro
+++ b/packages/landing/src/pages/terms.astro
@@ -39,7 +39,7 @@ import { Nav } from "../components/Nav";
             2. Description of Service
           </h2>
           <p class="mb-4 leading-relaxed" style={{ color: "var(--color-page-text-muted)" }}>
-            Lobu is an open-source platform for deploying autonomous AI agents. We offer both a self-hosted open-source version and a managed cloud service. These terms apply to your use of our website, managed cloud service, and related APIs.
+            Lobu is an open-source backend for multi-user AI agents. We offer both a self-hosted open-source version and a managed cloud service. These terms apply to your use of our website, managed cloud service, and related APIs.
           </p>
         </section>
 


### PR DESCRIPTION
## Summary

Align landing/docs copy around the concise positioning:

> The open-source backend for multi-user AI agents.

Changes:
- Replaces the broad homepage hero with the multi-user agent backend positioning.
- Moves the hero away from memory-led copy and toward isolation/OAuth/connected sources/secrets.
- Tightens landing feature sections to reduce text.
- Updates default SEO metadata, footer, CTA, MCP page, and key getting-started/security docs for consistency.
- Keeps memory/watchers/connectors as product capabilities rather than the top-level category.

## Validation

- `cd packages/landing && bun run build`
