### PR TITLE
docs(landing): restore deployment docs

### DIFF
--- a/packages/landing/public/index.md
+++ b/packages/landing/public/index.md
@@ -27,7 +27,10 @@ The canonical MCP endpoint at [https://lobu.ai/mcp](https://lobu.ai/mcp) lets MC
 
 ## Deployment
 
-- [Getting started](https://lobu.ai/getting-started/): Boot Lobu as a single Node process (`lobu run`)
+- [Lobu Cloud](https://lobu.ai/deployment/cloud/): Managed deployment with no infrastructure to run
+- [Docker](https://lobu.ai/deployment/docker/): Run the Lobu app container on a single host
+- [Kubernetes](https://lobu.ai/deployment/kubernetes/): Deploy Lobu with the public Helm chart
+- [Getting started](https://lobu.ai/getting-started/): Boot Lobu locally with `lobu run`
 - [Architecture](https://lobu.ai/guides/architecture/): Embedded gateway + worker deployment model
 
 ## Messaging platforms

--- a/packages/landing/public/llms.txt
+++ b/packages/landing/public/llms.txt
@@ -19,7 +19,10 @@
 
 ## Deployment
 
-- [Getting started](https://lobu.ai/getting-started/): Boot Lobu as a single Node process (`lobu run`)
+- [Lobu Cloud](https://lobu.ai/deployment/cloud/): Managed deployment with no infrastructure to run
+- [Docker](https://lobu.ai/deployment/docker/): Run the Lobu app container on a single host
+- [Kubernetes](https://lobu.ai/deployment/kubernetes/): Deploy Lobu with the public Helm chart
+- [Getting started](https://lobu.ai/getting-started/): Boot Lobu locally with `lobu run`
 - [Architecture](https://lobu.ai/guides/architecture/): Embedded gateway + worker deployment model
 
 ## Messaging platforms

--- a/packages/landing/src/content/docs/deployment/cloud.mdx
+++ b/packages/landing/src/content/docs/deployment/cloud.mdx
@@ -1,0 +1,48 @@
+---
+title: Lobu Cloud
+sidebar:
+  label: Lobu Cloud
+  order: 1
+description: Use the managed Lobu service instead of running infrastructure yourself.
+---
+
+Lobu Cloud is the managed deployment option for teams that want Lobu without operating a server, containers, Kubernetes, ingress, database migrations, or chat-platform webhooks.
+
+## When to use Lobu Cloud
+
+Use Lobu Cloud when you want:
+
+- A hosted public URL for Slack, Telegram, Discord, WhatsApp, Teams, Google Chat, and REST API webhooks.
+- Managed runtime updates and database migrations.
+- The same admin UI for agents, providers, skills, platform connections, and tool policy.
+- Lobu-managed OAuth and integration credentials so workers never receive raw secrets.
+- A fast path to production without provisioning Postgres or Kubernetes.
+
+## Get started
+
+Open [app.lobu.ai](https://app.lobu.ai) and create or select an organization.
+
+From there you can:
+
+1. Create an agent.
+2. Add model providers and choose default models.
+3. Connect chat platforms from the agent's settings.
+4. Enable skills and set worker network policy.
+5. Invite teammates or wire automation with [`lobu apply`](/reference/lobu-apply/).
+
+## Cloud vs self-hosted
+
+| | Lobu Cloud | Self-hosted |
+|---|---|---|
+| Runtime | Managed by Lobu | You run it |
+| Public URL | Included | You provide ingress/tunnel/DNS |
+| Database | Managed | Bring Postgres with pgvector |
+| Updates | Automatic | You deploy upgrades |
+| Secrets | Lobu-managed OAuth + secret proxy | Your secret manager / env |
+| Data residency | Lobu-managed | Your infrastructure |
+
+## Next steps
+
+- [Sync agents from GitHub](/guides/sync-from-github/) with `lobu apply`.
+- Configure chat platforms under [Platforms](/platforms/slack/).
+- Review [tool policy](/guides/tool-policy/) before pre-approving MCP tools.

--- a/packages/landing/src/content/docs/deployment/docker.mdx
+++ b/packages/landing/src/content/docs/deployment/docker.mdx
@@ -1,0 +1,66 @@
+---
+title: Docker
+sidebar:
+  label: Docker
+  order: 2
+description: Run the Lobu app container on a single host.
+---
+
+Use Docker when you want a simple self-hosted deployment on one machine. The container runs the same embedded Lobu app as `lobu run`: gateway, admin UI/API, embedded agent workers, and migrations in one Node process. Postgres with pgvector is the only required external service.
+
+:::note
+Docker is a packaging option, not a separate worker orchestration mode. Lobu no longer creates one Docker container per conversation; the app container spawns local worker subprocesses.
+:::
+
+## Images
+
+Public images are published to GitHub Container Registry:
+
+| Image | Purpose |
+|---|---|
+| `ghcr.io/lobu-ai/lobu-app` | App, API, admin UI, chat gateway, migrations |
+| `ghcr.io/lobu-ai/lobu-worker` | Connector ingestion worker used by the Helm chart |
+| `ghcr.io/lobu-ai/lobu-embeddings` | Embeddings service used by the Helm chart |
+
+For a single-host Docker deployment, start with `lobu-app`.
+
+## Run the app container
+
+```bash
+docker volume create lobu-workspaces
+
+docker run --rm \
+  --name lobu \
+  -p 8787:8787 \
+  -v lobu-workspaces:/app/workspaces \
+  -e NODE_ENV=production \
+  -e PUBLIC_WEB_URL=https://lobu.example.com \
+  -e DATABASE_URL='postgresql://USER:PASSWORD@HOST:5432/lobu?sslmode=require' \
+  -e JWT_SECRET='replace-with-a-long-random-value' \
+  -e BETTER_AUTH_SECRET='replace-with-a-long-random-value' \
+  -e ANTHROPIC_API_KEY='sk-ant-...' \
+  ghcr.io/lobu-ai/lobu-app:latest
+```
+
+The container runs database migrations on startup. Set `SKIP_MIGRATIONS=1` only when another release step has already run migrations.
+
+## Verify
+
+```bash
+curl http://localhost:8787/health
+
+docker logs -f lobu
+```
+
+Put a reverse proxy or tunnel in front of port `8787` for public webhooks. Set `PUBLIC_WEB_URL` to the public HTTPS origin so OAuth redirects, invitation links, MCP URLs, and platform webhook URLs use the correct host.
+
+## Production notes
+
+- Pin timestamp image tags instead of `latest` for repeatable upgrades.
+- Store secrets in your host's secret manager instead of shell history.
+- Mount `/app/workspaces` on persistent storage so agent workspaces survive restarts.
+- Start with `WORKER_ALLOWED_DOMAINS=""` and explicitly add the domains required by your skills/connectors.
+
+## Kubernetes
+
+If you already run Kubernetes, use the [Kubernetes Helm chart](/deployment/kubernetes/) instead of hand-assembling the three containers.

--- a/packages/landing/src/content/docs/deployment/kubernetes.mdx
+++ b/packages/landing/src/content/docs/deployment/kubernetes.mdx
@@ -1,0 +1,122 @@
+---
+title: Kubernetes
+sidebar:
+  label: Kubernetes
+  order: 3
+description: Deploy Lobu to Kubernetes with the public Helm chart.
+---
+
+Use the public Helm chart when you want to run Lobu on Kubernetes instead of a VM or local `lobu run` process. The chart deploys the API/chat gateway, connector worker, embeddings service, persistent volumes, optional ingress, and an optional migration hook.
+
+## Prerequisites
+
+- A Kubernetes cluster with an ingress controller, if you want public webhooks or the admin UI.
+- Helm 3 with OCI registry support.
+- A reachable Postgres database with pgvector enabled.
+- Runtime secrets for Lobu (`JWT_SECRET`, `BETTER_AUTH_SECRET`, provider API keys, OAuth client secrets, and connector credentials as needed).
+
+## Create secrets
+
+Create a namespace and store the database URL and runtime secrets in Kubernetes Secrets:
+
+```bash
+kubectl create namespace lobu
+
+kubectl -n lobu create secret generic lobu-db \
+  --from-literal=uri='postgresql://USER:PASSWORD@HOST:5432/lobu?sslmode=require'
+
+kubectl -n lobu create secret generic lobu-secrets \
+  --from-literal=JWT_SECRET='replace-with-a-long-random-value' \
+  --from-literal=BETTER_AUTH_SECRET='replace-with-a-long-random-value' \
+  --from-literal=ANTHROPIC_API_KEY='sk-ant-...'
+```
+
+Add any other provider, platform, or OAuth secrets your deployment needs to `lobu-secrets`.
+
+## Prepare values
+
+Start from the chart's example values file:
+
+```bash
+curl -fsSLo values.yaml \
+  https://raw.githubusercontent.com/lobu-ai/lobu/main/charts/lobu/values.example.yaml
+```
+
+Edit at least these fields:
+
+```yaml
+secretName: lobu-secrets
+
+database:
+  existingSecret: lobu-db
+  existingSecretKey: uri
+
+app:
+  env:
+    NODE_ENV: production
+    SKIP_MIGRATIONS: "1"
+    WORKER_ALLOWED_DOMAINS: ""
+
+ingress:
+  enabled: true
+  className: nginx
+  hosts:
+    - lobu.example.com
+```
+
+When `ingress.hosts` is set, the app derives `PUBLIC_WEB_URL` from the first host. If your public URL differs from that host, set `app.env.PUBLIC_WEB_URL` explicitly.
+
+## Install
+
+```bash
+helm install lobu oci://ghcr.io/lobu-ai/charts/lobu \
+  --namespace lobu --create-namespace \
+  -f values.yaml
+```
+
+The example values enable the Helm migration job and set `SKIP_MIGRATIONS: "1"` so app pods do not repeat migrations on startup.
+
+## Verify
+
+```bash
+kubectl -n lobu get pods -l app.kubernetes.io/instance=lobu
+kubectl -n lobu logs deploy/lobu-app
+kubectl -n lobu get ingress
+```
+
+If ingress is not enabled, port-forward the app service:
+
+```bash
+kubectl -n lobu port-forward svc/lobu-app 8787:8787
+open http://localhost:8787
+```
+
+Check health through your public URL or the port-forward:
+
+```bash
+curl https://lobu.example.com/health
+# or
+curl http://localhost:8787/health
+```
+
+## Upgrade
+
+Pin image tags for production upgrades, then run:
+
+```bash
+helm upgrade lobu oci://ghcr.io/lobu-ai/charts/lobu \
+  --namespace lobu \
+  -f values.yaml
+```
+
+## Chart-managed secrets
+
+For production, prefer an external secret manager or pre-created Kubernetes Secrets. For demos, the chart can create a Secret with `secrets.create: true`.
+
+If you enable both `secrets.create` and `migrations.enabled` and put `DATABASE_URL` in `secrets.stringData`, leave `migrations.database.existingSecret` empty. Pre-install hooks run before normal Helm resources are created, so the migration job reads `secrets.stringData.DATABASE_URL` directly in that setup.
+
+## Next steps
+
+- Configure chat platforms from the [admin UI](/guides/admin-ui/) or the connection API.
+- Review [security](/guides/security/) before enabling broad worker network access.
+- Use [observability](/guides/observability/) for tracing, logs, and error monitoring.


### PR DESCRIPTION
## Summary
- restore non-empty Deployment docs for Lobu Cloud, Docker, and Kubernetes
- document the current Docker packaging model and public Helm chart path
- update llms/index deployment links so the landing docs point at live pages

## Validation
- Wrote 6 platform configs to /Users/burakemre/Code/lobu-kubernetes-docs/packages/landing/src/generated/platform-configs.json
gen-markdown-twins: wrote 39 files (4 drafts skipped) to /Users/burakemre/Code/lobu-kubernetes-docs/packages/landing/public
19:27:23 [content] Syncing content
19:27:23 [content] Synced content
19:27:23 [types] Generated 434ms
19:27:23 [build] output: "static"
19:27:23 [build] mode: "static"
19:27:23 [build] directory: /Users/burakemre/Code/lobu-kubernetes-docs/packages/landing/dist/
19:27:23 [build] Collecting build info...
19:27:23 [build] ✓ Completed in 625ms.
19:27:23 [build] Building static entrypoints...
19:27:25 [vite] ✓ built in 1.51s
19:27:25 [vite] ✓ built in 304ms
19:27:25 [build] Rearranging server assets...

 generating static routes 
19:27:25   ├─ /404.html (+6ms) 
19:27:25   ├─ /blog/index.html (+6ms) 
19:27:25   ├─ /blog/filesystem-vs-database-agent-memory/index.html (+7ms) 
19:27:25   ├─ /blog/hello-world/index.html (+4ms) 
19:27:25   ├─ /blog/mcp-is-overengineered-skills-are-too-primitive/index.html (+2ms) 
19:27:25   ├─ /connect-from/chatgpt/for/careops/index.html (+1ms) 
19:27:25   ├─ /connect-from/claude/for/careops/index.html (+1ms) 
19:27:25   ├─ /connect-from/openclaw/for/careops/index.html (+1ms) 
19:27:25   ├─ /connect-from/chatgpt/for/legal/index.html (+14ms) 
19:27:25   ├─ /connect-from/chatgpt/for/engineering/index.html (+5ms) 
19:27:25   ├─ /connect-from/chatgpt/for/support/index.html (+4ms) 
19:27:25   ├─ /connect-from/chatgpt/for/finance/index.html (+3ms) 
19:27:25   ├─ /connect-from/chatgpt/for/sales/index.html (+4ms) 
19:27:25   ├─ /connect-from/chatgpt/for/leadership/index.html (+3ms) 
19:27:25   ├─ /connect-from/chatgpt/for/agent-community/index.html (+5ms) 
19:27:25   ├─ /connect-from/chatgpt/for/market/index.html (+4ms) 
19:27:25   ├─ /connect-from/chatgpt/for/venture-capital/index.html (+3ms) 
19:27:25   ├─ /connect-from/chatgpt/for/market-intelligence/index.html (+3ms) 
19:27:25   ├─ /connect-from/claude/for/legal/index.html (+3ms) 
19:27:25   ├─ /connect-from/claude/for/engineering/index.html (+3ms) 
19:27:25   ├─ /connect-from/claude/for/support/index.html (+3ms) 
19:27:25   ├─ /connect-from/claude/for/finance/index.html (+5ms) 
19:27:25   ├─ /connect-from/claude/for/sales/index.html (+3ms) 
19:27:25   ├─ /connect-from/claude/for/leadership/index.html (+3ms) 
19:27:25   ├─ /connect-from/claude/for/agent-community/index.html (+3ms) 
19:27:25   ├─ /connect-from/claude/for/market/index.html (+3ms) 
19:27:25   ├─ /connect-from/claude/for/venture-capital/index.html (+3ms) 
19:27:25   ├─ /connect-from/claude/for/market-intelligence/index.html (+5ms) 
19:27:25   ├─ /connect-from/openclaw/for/legal/index.html (+3ms) 
19:27:25   ├─ /connect-from/openclaw/for/engineering/index.html (+3ms) 
19:27:25   ├─ /connect-from/openclaw/for/support/index.html (+3ms) 
19:27:25   ├─ /connect-from/openclaw/for/finance/index.html (+3ms) 
19:27:25   ├─ /connect-from/openclaw/for/sales/index.html (+2ms) 
19:27:25   ├─ /connect-from/openclaw/for/leadership/index.html (+2ms) 
19:27:25   ├─ /connect-from/openclaw/for/agent-community/index.html (+5ms) 
19:27:25   ├─ /connect-from/openclaw/for/market/index.html (+3ms) 
19:27:25   ├─ /connect-from/openclaw/for/venture-capital/index.html (+3ms) 
19:27:25   ├─ /connect-from/openclaw/for/market-intelligence/index.html (+3ms) 
19:27:25   ├─ /for/careops/index.html (+1ms) 
19:27:25   ├─ /for/legal/index.html (+7ms) 
19:27:25   ├─ /for/engineering/index.html (+3ms) 
19:27:25   ├─ /for/support/index.html (+3ms) 
19:27:25   ├─ /for/finance/index.html (+5ms) 
19:27:25   ├─ /for/sales/index.html (+3ms) 
19:27:25   ├─ /for/leadership/index.html (+3ms) 
19:27:25   ├─ /for/agent-community/index.html (+2ms) 
19:27:25   ├─ /for/market/index.html (+3ms) 
19:27:25   ├─ /for/venture-capital/index.html (+3ms) 
19:27:25   ├─ /for/market-intelligence/index.html (+3ms) 
19:27:25   ├─ /mcp/index.html (+2ms) 
19:27:25   ├─ /memory/index.html (+1ms) 
19:27:25   ├─ /pricing/index.html (+1ms) 
19:27:25   ├─ /privacy/index.html (+1ms) 
19:27:25   ├─ /reference/api-reference/index.html (+680ms) 
19:27:26   ├─ /serverless-openclaw/index.html (+2ms) 
19:27:26   ├─ /skills/index.html (+1ms) 
19:27:26   ├─ /terms/index.html (+5ms) 
19:27:26   ├─ /index.html (+47ms) 
19:27:26   ├─ /connect-from/chatgpt/index.html (+4ms) 
19:27:26   ├─ /connect-from/claude/index.html (+3ms) 
19:27:26   ├─ /connect-from/openclaw/index.html (+3ms) 
19:27:26   ├─ /deployment/cloud/index.html (+2ms) 
19:27:26   ├─ /deployment/docker/index.html (+2ms) 
19:27:26   ├─ /deployment/kubernetes/index.html (+2ms) 
19:27:26   ├─ /getting-started/index.html (+2ms) 
19:27:26   ├─ /getting-started/comparison/index.html (+1ms) 
19:27:26   ├─ /getting-started/memory/index.html (+3ms) 
19:27:26   ├─ /getting-started/skills/index.html (+2ms) 
19:27:26   ├─ /guides/admin-ui/index.html (+1ms) 
19:27:26   ├─ /guides/agent-prompts/index.html (+1ms) 
19:27:26   ├─ /guides/agent-settings/index.html (+1ms) 
19:27:26   ├─ /guides/architecture/index.html (+2ms) 
19:27:26   ├─ /guides/evals/index.html (+1ms) 
19:27:26   ├─ /guides/mcp-proxy/index.html (+1ms) 
19:27:26   ├─ /guides/memory-benchmarks/index.html (+1ms) 
19:27:26   ├─ /guides/observability/index.html (+3ms) 
19:27:26   ├─ /guides/security/index.html (+2ms) 
19:27:26   ├─ /guides/sync-from-github/index.html (+1ms) 
19:27:26   ├─ /guides/testing/index.html (+1ms) 
19:27:26   ├─ /guides/tool-policy/index.html (+1ms) 
19:27:26   ├─ /guides/troubleshooting/index.html (+1ms) 
19:27:26   ├─ /platforms/discord/index.html (+4ms) 
19:27:26   ├─ /platforms/google-chat/index.html (+2ms) 
19:27:26   ├─ /platforms/rest-api/index.html (+1ms) 
19:27:26   ├─ /platforms/slack/index.html (+2ms) 
19:27:26   ├─ /platforms/teams/index.html (+2ms) 
19:27:26   ├─ /platforms/telegram/index.html (+2ms) 
19:27:26   ├─ /platforms/whatsapp/index.html (+3ms) 
19:27:26   ├─ /reference/cli/index.html (+1ms) 
19:27:26   ├─ /reference/lobu-apply/index.html (+3ms) 
19:27:26   ├─ /reference/lobu-memory/index.html (+2ms) 
19:27:26   ├─ /reference/lobu-toml/index.html (+1ms) 
19:27:26   ├─ /reference/providers/index.html (+3ms) 
19:27:26   ├─ /reference/skill-md/index.html (+1ms) 
19:27:26 ✓ Completed in 1.03s.

19:27:26 [build] ✓ Completed in 2.88s.
19:27:26 [starlight:pagefind] Building search index with Pagefind...
19:27:26 [starlight:pagefind] Found 94 HTML files.
19:27:26 [starlight:pagefind] Finished building search index in 90ms.
19:27:26 [@astrojs/sitemap] `sitemap-index.xml` created at `dist`
19:27:26 [build] 89 page(s) built in 3.62s
19:27:26 [build] Complete!