### PR TITLE
feat(dev): per-worktree port overrides via .env.local

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -133,6 +133,21 @@ make dev                  # boots embedded gateway + workers + Vite HMR on :8787
 make clean-workers        # kill orphaned worker subprocesses if a crash leaves any
 ```
 
+To run multiple worktrees in parallel, drop a gitignored `.env.local` in each
+worktree's repo root with non-default ports — it's sourced after `.env` so it
+overrides:
+
+```bash
+# packages/lobu-other-worktree/.env.local
+PORT=8788
+WORKER_PROXY_PORT=8119
+```
+
+The Tailscale tunnel only forwards to one local port at a time, so whichever
+worktree owns `:8787` is what `https://...ts.net:8443` serves. Other worktrees
+are reachable on `http://localhost:8788` etc. — fine for UI work; only
+webhook/OAuth-callback testing actually needs the public URL.
+
 ### Validation after code changes
 
 Run the validation that matches what you touched:

--- a/scripts/dev-native.sh
+++ b/scripts/dev-native.sh
@@ -2,13 +2,18 @@
 # Run the embedded Lobu stack natively.
 #
 # What runs:
-#   - server (Hono + tsx watch) on :8787
-#   - embedded gateway (in-process) with HTTP egress proxy on :8118
+#   - server (Hono + tsx watch) on :$PORT (default 8787)
+#   - embedded gateway (in-process) with HTTP egress proxy on :$WORKER_PROXY_PORT (default 8118)
 #   - embedded workers (spawned as Bun subprocesses on demand)
-#   - Vite dev middleware for web on the same :8787 (HMR via WS)
+#   - Vite dev middleware for web on the same :$PORT (HMR via WS)
 #
 # Requires, managed outside this script:
 #   - Postgres reachable via DATABASE_URL in .env
+#
+# Per-worktree port overrides: drop a gitignored `.env.local` in the repo root
+# with `PORT=8788` and `WORKER_PROXY_PORT=8119` (or similar) to run multiple
+# worktrees side-by-side without colliding on :8787 / :8118. .env.local takes
+# precedence over .env.
 #
 # Skipped vs production: external managed services and cloud backfill workers.
 
@@ -46,6 +51,8 @@ _PRESET_HOST_SET="${HOST+x}"
 _PRESET_HOST="${HOST-}"
 _PRESET_PORT_SET="${PORT+x}"
 _PRESET_PORT="${PORT-}"
+_PRESET_WORKER_PROXY_PORT_SET="${WORKER_PROXY_PORT+x}"
+_PRESET_WORKER_PROXY_PORT="${WORKER_PROXY_PORT-}"
 _PRESET_PUBLIC_WEB_URL_SET="${PUBLIC_WEB_URL+x}"
 _PRESET_PUBLIC_WEB_URL="${PUBLIC_WEB_URL-}"
 _PRESET_LOBU_PROVIDER_REGISTRY_PATH_SET="${LOBU_PROVIDER_REGISTRY_PATH+x}"
@@ -58,12 +65,19 @@ _PRESET_FAKE_LLM_BASE_URL="${FAKE_LLM_BASE_URL-}"
 set -a
 # shellcheck disable=SC1091
 source .env
+# .env.local is gitignored and intended for per-worktree overrides
+# (e.g. PORT/WORKER_PROXY_PORT so two worktrees can run side-by-side).
+if [ -f .env.local ]; then
+  # shellcheck disable=SC1091
+  source .env.local
+fi
 set +a
 
 if [[ -n "$_PRESET_DATABASE_URL_SET" ]]; then export DATABASE_URL="$_PRESET_DATABASE_URL"; fi
 if [[ -n "$_PRESET_PGSSLMODE_SET" ]]; then export PGSSLMODE="$_PRESET_PGSSLMODE"; fi
 if [[ -n "$_PRESET_HOST_SET" ]]; then export HOST="$_PRESET_HOST"; fi
 if [[ -n "$_PRESET_PORT_SET" ]]; then export PORT="$_PRESET_PORT"; fi
+if [[ -n "$_PRESET_WORKER_PROXY_PORT_SET" ]]; then export WORKER_PROXY_PORT="$_PRESET_WORKER_PROXY_PORT"; fi
 if [[ -n "$_PRESET_PUBLIC_WEB_URL_SET" ]]; then export PUBLIC_WEB_URL="$_PRESET_PUBLIC_WEB_URL"; fi
 if [[ -n "$_PRESET_LOBU_PROVIDER_REGISTRY_PATH_SET" ]]; then export LOBU_PROVIDER_REGISTRY_PATH="$_PRESET_LOBU_PROVIDER_REGISTRY_PATH"; fi
 if [[ -n "$_PRESET_FAKE_LLM_API_KEY_SET" ]]; then export FAKE_LLM_API_KEY="$_PRESET_FAKE_LLM_API_KEY"; fi
@@ -73,6 +87,7 @@ export NODE_ENV="${NODE_ENV:-development}"
 export ENVIRONMENT="${ENVIRONMENT:-development}"
 export HOST="${HOST:-127.0.0.1}"
 export PORT="${PORT:-8787}"
+export WORKER_PROXY_PORT="${WORKER_PROXY_PORT:-8118}"
 export PUBLIC_WEB_URL="${PUBLIC_WEB_URL:-http://localhost:${PORT}}"
 export PGSSLMODE="${PGSSLMODE:-require}"
 export LOBU_PROVIDER_REGISTRY_PATH="${LOBU_PROVIDER_REGISTRY_PATH:-$REPO_ROOT/config/providers.json}"
@@ -89,7 +104,7 @@ fi
 # --- Run -------------------------------------------------------------------
 
 echo "→ server on http://${HOST}:${PORT}"
-echo "→ embedded gateway proxy on :8118"
+echo "→ embedded gateway proxy on :${WORKER_PROXY_PORT}"
 echo "→ Vite HMR in-process (same port)"
 echo ""
 


### PR DESCRIPTION
## Summary
- Adds `.env.local` overlay (sourced after `.env`, gitignored already by `.env.*`) so each worktree can pin its own `PORT` and `WORKER_PROXY_PORT` without forking secrets.
- `WORKER_PROXY_PORT` is now preserved-then-overlaid like the other env vars and defaults to 8118; the boot log surfaces the actual value instead of always claiming `:8118`.
- Documents the convention at the top of `dev-native.sh` and in the Development section of `AGENTS.md`.

The plumbing for both env vars was already in `proxy-manager.ts` and `base-deployment-manager.ts` — this PR just stops the Make target from being the only thing standing in the way.

## Validation
- Verified two worktrees side-by-side: personal-collector on `:8787` + `:8118`, this worktree on `:8788` + `:8119`. Both serve the SPA on `Accept: text/html` and respond on `/api/health`. No port collisions.
- `bash -n scripts/dev-native.sh` — syntax OK.

## Test plan
- [ ] CI green
- [ ] In a second worktree: drop `.env.local` with `PORT=8788`, run `make dev`, confirm boot log says `:8788` and `:8119` (or whatever you set), `curl http://localhost:8788/api/health` works.