### PR TITLE
fix(openclaw): bound memory-wiki compat fanouts with per-call timeout

### DIFF
--- a/packages/openclaw-plugin/openclaw.plugin.json
+++ b/packages/openclaw-plugin/openclaw.plugin.json
@@ -58,6 +58,13 @@
               "enabled": {
                 "type": "boolean",
                 "default": false
+              },
+              "fanoutTimeoutMs": {
+                "type": "integer",
+                "minimum": 1000,
+                "maximum": 90000,
+                "default": 30000,
+                "description": "Per-fanout timeout (ms) for SDK-backed wiki calls. Slow paths are dropped and the tool returns partial results with a degraded marker. Defaults to 30000."
               }
             }
           }

--- a/packages/openclaw-plugin/src/index.ts
+++ b/packages/openclaw-plugin/src/index.ts
@@ -70,7 +70,8 @@ const MCP_PROTOCOL_VERSION = '2025-03-26';
 async function mcpFetch(
   url: string,
   body: unknown,
-  extraHeaders?: Record<string, string>
+  extraHeaders?: Record<string, string>,
+  signal?: AbortSignal
 ): Promise<{ data: unknown; response: Response }> {
   const headers: Record<string, string> = {
     'Content-Type': 'application/json',
@@ -85,6 +86,7 @@ async function mcpFetch(
     method: 'POST',
     headers,
     body: JSON.stringify(body),
+    signal,
   });
 
   const newSessionId = response.headers.get('mcp-session-id');
@@ -217,14 +219,33 @@ function asPositiveInt(value: unknown, fallback: number): number {
   return n > 0 ? n : fallback;
 }
 
-function resolveMemoryWikiCompatConfig(value: unknown): { enabled: boolean } {
+const DEFAULT_WIKI_FANOUT_TIMEOUT_MS = 30_000;
+const MIN_WIKI_FANOUT_TIMEOUT_MS = 1_000;
+const MAX_WIKI_FANOUT_TIMEOUT_MS = 90_000;
+
+function clampFanoutTimeoutMs(value: unknown): number {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    return DEFAULT_WIKI_FANOUT_TIMEOUT_MS;
+  }
+  if (value < MIN_WIKI_FANOUT_TIMEOUT_MS) return MIN_WIKI_FANOUT_TIMEOUT_MS;
+  if (value > MAX_WIKI_FANOUT_TIMEOUT_MS) return MAX_WIKI_FANOUT_TIMEOUT_MS;
+  return Math.floor(value);
+}
+
+function resolveMemoryWikiCompatConfig(value: unknown): {
+  enabled: boolean;
+  fanoutTimeoutMs: number;
+} {
   if (typeof value === 'boolean') {
-    return { enabled: value };
+    return { enabled: value, fanoutTimeoutMs: DEFAULT_WIKI_FANOUT_TIMEOUT_MS };
   }
   if (isRecord(value)) {
-    return { enabled: asBoolean(value.enabled, false) };
+    return {
+      enabled: asBoolean(value.enabled, false),
+      fanoutTimeoutMs: clampFanoutTimeoutMs(value.fanoutTimeoutMs),
+    };
   }
-  return { enabled: false };
+  return { enabled: false, fanoutTimeoutMs: DEFAULT_WIKI_FANOUT_TIMEOUT_MS };
 }
 
 function getLogger(api: Record<string, unknown>): PluginLogger {
@@ -710,7 +731,7 @@ async function callMcpTool(
   config: ResolvedPluginConfig,
   toolName: string,
   args: Record<string, unknown>,
-  options?: { rawJson?: boolean }
+  options?: { rawJson?: boolean; signal?: AbortSignal }
 ): Promise<McpToolResponse | null> {
   if (!config.mcpUrl) return null;
   const token = await resolveAuthToken(config);
@@ -733,7 +754,7 @@ async function callMcpTool(
 
   let result: { data: unknown; response: Response };
   try {
-    result = await mcpFetch(config.mcpUrl, rpcBody, authHeaders);
+    result = await mcpFetch(config.mcpUrl, rpcBody, authHeaders, options?.signal);
   } catch (err) {
     throw new Error(`MCP fetch failed: ${err instanceof Error ? err.message : String(err)}`);
   }
@@ -746,7 +767,7 @@ async function callMcpTool(
     if (refreshed && sessionToken) {
       authHeaders.Authorization = `Bearer ${sessionToken}`;
       const retryBody = { ...rpcBody, id: `${rpcId}-retry` };
-      const retry = await mcpFetch(config.mcpUrl, retryBody, authHeaders);
+      const retry = await mcpFetch(config.mcpUrl, retryBody, authHeaders, options?.signal);
       data = retry.data;
       response = retry.response;
     }
@@ -768,7 +789,7 @@ async function callMcpTool(
       const newSession = await reinitializeMcpSession(config);
       if (newSession) {
         const retryBody = { ...rpcBody, id: `${rpcId}-reinit` };
-        const retry = await mcpFetch(config.mcpUrl!, retryBody, authHeaders);
+        const retry = await mcpFetch(config.mcpUrl!, retryBody, authHeaders, options?.signal);
         data = retry.data;
         response = retry.response;
       }

--- a/packages/openclaw-plugin/src/memory-wiki-compat.ts
+++ b/packages/openclaw-plugin/src/memory-wiki-compat.ts
@@ -7,15 +7,77 @@ type PluginLogger = {
   debug?(message: string, ...args: unknown[]): void;
 };
 
+type McpToolCallOptions = { rawJson?: boolean; signal?: AbortSignal };
+
 type McpToolCaller = (
   config: ResolvedPluginConfig,
   toolName: string,
   args: Record<string, unknown>,
-  options?: { rawJson?: boolean }
+  options?: McpToolCallOptions
 ) => Promise<McpToolResponse | null>;
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null;
+}
+
+type FanoutOutcome<T> =
+  | { ok: true; value: T; durationMs: number }
+  | { ok: false; reason: 'timeout' | 'error'; error: string; durationMs: number };
+
+/**
+ * Race a fanout part against a wall-clock timeout. Returns a tagged result so
+ * callers can return partial responses (with a `degraded`/`timeouts` marker)
+ * instead of letting one slow upstream block the whole wiki tool response.
+ *
+ * If the underlying MCP caller supports AbortSignal, the timeout also aborts
+ * the in-flight request so CLI harnesses and long-lived plugin hosts don't
+ * accumulate orphaned HTTP calls after returning a degraded partial result.
+ */
+async function raceFanout<T>(
+  label: string,
+  start: (signal: AbortSignal) => Promise<T>,
+  timeoutMs: number
+): Promise<FanoutOutcome<T>> {
+  // Defensive: callers occasionally pass an unresolved or non-finite timeout
+  // (e.g. a third-party config that didn't go through `resolveMemoryWikiCompatConfig`).
+  // Fall back to a safe default rather than letting `setTimeout(undefined)` fire immediately.
+  const safeTimeoutMs =
+    typeof timeoutMs === 'number' && Number.isFinite(timeoutMs) && timeoutMs >= 1
+      ? Math.floor(timeoutMs)
+      : 30_000;
+  const started = Date.now();
+  const controller = new AbortController();
+  let timer: ReturnType<typeof setTimeout> | null = null;
+  const timeoutPromise = new Promise<FanoutOutcome<T>>((resolve) => {
+    timer = setTimeout(() => {
+      controller.abort(`${label} timed out after ${safeTimeoutMs}ms`);
+      resolve({
+        ok: false,
+        reason: 'timeout',
+        error: `${label} timed out after ${safeTimeoutMs}ms`,
+        durationMs: Date.now() - started,
+      });
+    }, safeTimeoutMs);
+  });
+  const settled = start(controller.signal).then<FanoutOutcome<T>, FanoutOutcome<T>>(
+    (value) => ({ ok: true, value, durationMs: Date.now() - started }),
+    (error) => ({
+      ok: false,
+      reason: controller.signal.aborted ? 'timeout' : 'error',
+      error:
+        error instanceof Error
+          ? error.message
+          : typeof controller.signal.reason === 'string'
+            ? controller.signal.reason
+            : String(error),
+      durationMs: Date.now() - started,
+    })
+  );
+  try {
+    return await Promise.race([settled, timeoutPromise]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
 }
 
 function asString(value: unknown): string | null {
@@ -43,9 +105,10 @@ async function callMcpToolJson<T = unknown>(
   callMcpTool: McpToolCaller,
   config: ResolvedPluginConfig,
   toolName: string,
-  args: Record<string, unknown>
+  args: Record<string, unknown>,
+  options?: Pick<McpToolCallOptions, 'signal'>
 ): Promise<T | null> {
-  const result = await callMcpTool(config, toolName, args, { rawJson: true });
+  const result = await callMcpTool(config, toolName, args, { rawJson: true, signal: options?.signal });
   if (!result) return null;
   if (result.isError) {
     throw new Error(`MCP tool ${toolName} returned error: ${extractTextFromContent(result.content).slice(0, 240)}`);
@@ -68,10 +131,11 @@ async function runSdkScript<T = unknown>(
   callMcpTool: McpToolCaller,
   config: ResolvedPluginConfig,
   mode: 'read' | 'write',
-  script: string
+  script: string,
+  options?: Pick<McpToolCallOptions, 'signal'>
 ): Promise<T | null> {
   const toolName = mode === 'read' ? 'query_sdk' : 'run_sdk';
-  const raw = await callMcpTool(config, toolName, { script }, { rawJson: true });
+  const raw = await callMcpTool(config, toolName, { script }, { rawJson: true, signal: options?.signal });
   if (!raw) return null;
   if (raw.isError) {
     throw new Error(`MCP tool ${toolName} returned error: ${extractTextFromContent(raw.content).slice(0, 240)}`);
@@ -249,7 +313,8 @@ async function searchMemoryCorpus(
   callMcpTool: McpToolCaller,
   config: ResolvedPluginConfig,
   query: string,
-  maxResults: number
+  maxResults: number,
+  options?: Pick<McpToolCallOptions, 'signal'>
 ): Promise<WikiSearchResult[]> {
   const raw = await callMcpToolJson(callMcpTool, config, 'search_memory', {
     query,
@@ -257,7 +322,7 @@ async function searchMemoryCorpus(
     content_limit: maxResults,
     include_connections: false,
     limit: maxResults,
-  });
+  }, options);
   return memoryResultsFromSearch(raw, maxResults);
 }
 
@@ -340,7 +405,8 @@ async function searchWikiCorpus(
   callMcpTool: McpToolCaller,
   config: ResolvedPluginConfig,
   query: string,
-  maxResults: number
+  maxResults: number,
+  options?: Pick<McpToolCallOptions, 'signal'>
 ): Promise<WikiSearchResult[]> {
   const includeContent = query.length >= 3;
   const script = `
@@ -364,7 +430,7 @@ export default async (_ctx, client) => {
     watchers: unknown;
     claims: unknown;
     syntheses: unknown;
-  }>(callMcpTool, config, 'read', script);
+  }>(callMcpTool, config, 'read', script, options);
   if (!sdkResult) return [];
   return [
     ...contentResultsFromReadKnowledge(sdkResult.claims, 'claim', maxResults),
@@ -375,17 +441,27 @@ export default async (_ctx, client) => {
     .slice(0, maxResults);
 }
 
-function formatWikiSearchResults(query: string, corpus: WikiCorpus, results: WikiSearchResult[]): string {
+function formatWikiSearchResults(
+  query: string,
+  corpus: WikiCorpus,
+  results: WikiSearchResult[],
+  meta: { degraded: boolean; timeouts: string[] } = { degraded: false, timeouts: [] }
+): string {
+  const degradedSuffix = meta.degraded
+    ? `\nWarning: partial results — fanout ${meta.timeouts.length ? `timed out on [${meta.timeouts.join(', ')}]` : 'reported errors'}.`
+    : '';
   if (results.length === 0) {
-    return `No Lobu wiki compatibility results for ${JSON.stringify(query)} in corpus=${corpus}.`;
+    return `No Lobu wiki compatibility results for ${JSON.stringify(query)} in corpus=${corpus}.${degradedSuffix}`;
   }
-  return [
-    `Lobu memory-wiki compatibility search for ${JSON.stringify(query)} (corpus=${corpus}).`,
-    ...results.map((result, index) => {
-      const source = result.source_url ? ` — ${result.source_url}` : '';
-      return `${index + 1}. ${result.title} (${result.corpus}/${result.kind}, path=${result.path}, score=${result.score.toFixed(2)})${source}\n   ${result.snippet}`;
-    }),
-  ].join('\n');
+  return (
+    [
+      `Lobu memory-wiki compatibility search for ${JSON.stringify(query)} (corpus=${corpus}).`,
+      ...results.map((result, index) => {
+        const source = result.source_url ? ` — ${result.source_url}` : '';
+        return `${index + 1}. ${result.title} (${result.corpus}/${result.kind}, path=${result.path}, score=${result.score.toFixed(2)})${source}\n   ${result.snippet}`;
+      }),
+    ].join('\n') + degradedSuffix
+  );
 }
 
 async function runWikiSearch(
@@ -396,18 +472,42 @@ async function runWikiSearch(
   const query = asString(args.query) ?? '';
   const corpus = normalizeCorpus(args.corpus);
   const maxResults = readPositiveNumber(args.maxResults, 8, 25);
-  const [memory, wiki] = await Promise.all([
-    corpus === 'memory' || corpus === 'all'
-      ? searchMemoryCorpus(callMcpTool, config, query, maxResults)
-      : Promise.resolve<WikiSearchResult[]>([]),
-    corpus === 'wiki' || corpus === 'all'
-      ? searchWikiCorpus(callMcpTool, config, query, maxResults)
-      : Promise.resolve<WikiSearchResult[]>([]),
+  const timeoutMs = config.memoryWikiCompat.fanoutTimeoutMs;
+  const wantMemory = corpus === 'memory' || corpus === 'all';
+  const wantWiki = corpus === 'wiki' || corpus === 'all';
+  const [memoryOutcome, wikiOutcome] = await Promise.all([
+    wantMemory
+      ? raceFanout(
+          'wiki_search:memory',
+          (signal) => searchMemoryCorpus(callMcpTool, config, query, maxResults, { signal }),
+          timeoutMs
+        )
+      : Promise.resolve<FanoutOutcome<WikiSearchResult[]>>({ ok: true, value: [], durationMs: 0 }),
+    wantWiki
+      ? raceFanout(
+          'wiki_search:wiki',
+          (signal) => searchWikiCorpus(callMcpTool, config, query, maxResults, { signal }),
+          timeoutMs
+        )
+      : Promise.resolve<FanoutOutcome<WikiSearchResult[]>>({ ok: true, value: [], durationMs: 0 }),
   ]);
+  const memory = memoryOutcome.ok ? memoryOutcome.value : [];
+  const wiki = wikiOutcome.ok ? wikiOutcome.value : [];
   const results = [...wiki, ...memory].sort((a, b) => b.score - a.score).slice(0, maxResults);
+  const timeouts: string[] = [];
+  const fanoutErrors: Array<{ part: string; reason: string; error: string }> = [];
+  if (wantMemory && !memoryOutcome.ok) {
+    if (memoryOutcome.reason === 'timeout') timeouts.push('memory');
+    fanoutErrors.push({ part: 'memory', reason: memoryOutcome.reason, error: memoryOutcome.error });
+  }
+  if (wantWiki && !wikiOutcome.ok) {
+    if (wikiOutcome.reason === 'timeout') timeouts.push('wiki');
+    fanoutErrors.push({ part: 'wiki', reason: wikiOutcome.reason, error: wikiOutcome.error });
+  }
+  const degraded = fanoutErrors.length > 0;
   return {
-    text: formatWikiSearchResults(query, corpus, results),
-    details: { query, corpus, results },
+    text: formatWikiSearchResults(query, corpus, results, { degraded, timeouts }),
+    details: { query, corpus, results, degraded, timeouts, fanout_errors: fanoutErrors },
   };
 }
 
@@ -450,7 +550,27 @@ async function runWikiGet(
     script = `export default async (_ctx, client) => client.knowledge.read({ query: ${JSON.stringify(lookup)}, limit: 1 });`;
   }
 
-  const raw = await runSdkScript<unknown>(callMcpTool, config, 'read', script);
+  const outcome = await raceFanout(
+    'wiki_get',
+    (signal) => runSdkScript<unknown>(callMcpTool, config, 'read', script, { signal }),
+    config.memoryWikiCompat.fanoutTimeoutMs
+  );
+  if (!outcome.ok) {
+    const reason = outcome.reason === 'timeout' ? 'timeout' : 'error';
+    return {
+      text: `Lobu memory-wiki compatibility get (${sourceTool}, lookup=${lookup}) — ${reason}: ${outcome.error}`,
+      details: {
+        lookup,
+        parsed,
+        sourceTool,
+        result: null,
+        degraded: true,
+        timeout: outcome.reason === 'timeout',
+        error: outcome.error,
+      },
+    };
+  }
+  const raw = outcome.value;
   const text = stringifyResult(raw ?? { message: `No result for ${lookup}` });
   return {
     text: `Lobu memory-wiki compatibility get (${sourceTool}, lookup=${lookup})\n\n${text}`,
@@ -606,33 +726,61 @@ export function registerMemoryWikiCompatTools(
   const r = await client.watchers.list({ include_details: false }).catch((e) => ({ error: String(e) }));
   return r;
 };`;
-      const [watchers, memoryProbe] = await Promise.all([
-        runSdkScript<unknown>(callMcpTool, config, 'read', watcherCountScript).catch((error) => ({ error: String(error) })),
-        callMcpToolJson(callMcpTool, config, 'search_memory', {
-          query: 'memory wiki compatibility status',
-          include_content: false,
-          include_connections: false,
-          limit: 1,
-        }).catch((error) => ({ error: String(error) })),
+      const timeoutMs = config.memoryWikiCompat.fanoutTimeoutMs;
+      const [watchersOutcome, memoryOutcome] = await Promise.all([
+        raceFanout(
+          'wiki_status:watchers',
+          (signal) => runSdkScript<unknown>(callMcpTool, config, 'read', watcherCountScript, { signal }),
+          timeoutMs
+        ),
+        raceFanout(
+          'wiki_status:memory',
+          (signal) => callMcpToolJson(callMcpTool, config, 'search_memory', {
+            query: 'memory wiki compatibility status',
+            include_content: false,
+            include_connections: false,
+            limit: 1,
+          }, { signal }),
+          timeoutMs
+        ),
       ]);
+      const watchers = watchersOutcome.ok ? watchersOutcome.value : null;
       const watcherCount =
         isRecord(watchers) && Array.isArray((watchers as { watchers?: unknown }).watchers)
           ? ((watchers as { watchers: unknown[] }).watchers.length)
           : null;
+      const timeouts: string[] = [];
+      const fanoutErrors: Array<{ part: string; reason: string; error: string }> = [];
+      if (!watchersOutcome.ok) {
+        if (watchersOutcome.reason === 'timeout') timeouts.push('watchers');
+        fanoutErrors.push({ part: 'watchers', reason: watchersOutcome.reason, error: watchersOutcome.error });
+      }
+      if (!memoryOutcome.ok) {
+        if (memoryOutcome.reason === 'timeout') timeouts.push('memory');
+        fanoutErrors.push({ part: 'memory', reason: memoryOutcome.reason, error: memoryOutcome.error });
+      }
       const status = {
         mode: 'lobu-memory-wiki-compat',
         source_of_truth: 'lobu-memory-mcp',
         corpus: ['memory', 'wiki', 'all'],
         tools: ['wiki_status', 'wiki_search', 'wiki_get', 'wiki_apply', 'wiki_lint', 'memory_search', 'memory_get'],
         watcher_count: watcherCount,
-        memory_available: !isRecord(memoryProbe) || !('error' in memoryProbe),
+        memory_available: memoryOutcome.ok,
+        degraded: !watchersOutcome.ok || !memoryOutcome.ok,
+        timeouts,
+        fanout_errors: fanoutErrors,
+        fanout_timeout_ms: timeoutMs,
         notes: [
           'corpus is memory|wiki|all within the authenticated Lobu org; it is not an org selector.',
           'wiki corpus is a virtual projection over Lobu claims, syntheses, watchers, reports, and sources.',
           'no separate Markdown vault is written by this spike.',
         ],
       };
-      recordCall('wiki_status', {}, { watcherCount, memoryAvailable: status.memory_available });
+      recordCall(
+        'wiki_status',
+        {},
+        { watcherCount, memoryAvailable: status.memory_available, degraded: status.degraded }
+      );
       return { text: stringifyResult(status), details: status };
     }
   );

--- a/packages/openclaw-plugin/src/types.ts
+++ b/packages/openclaw-plugin/src/types.ts
@@ -5,6 +5,15 @@
 export interface MemoryWikiCompatConfig {
   /** Enable OpenClaw memory-wiki compatible tools backed by Lobu MCP primitives. */
   enabled?: boolean;
+  /**
+   * Per-fanout timeout (ms) for SDK-backed wiki tool calls (`wiki_status`,
+   * `wiki_search` corpus=all|wiki, `wiki_get`). When a single fanout exceeds
+   * this budget, the slow side is dropped and the tool returns partial results
+   * with a `degraded`/`timeouts` marker rather than blocking the whole call.
+   * Defaults to 30000 (well under Cloudflare's 100s edge timeout). Clamped to
+   * [1000, 90000].
+   */
+  fanoutTimeoutMs?: number;
 }
 
 export interface PluginConfig {
@@ -33,6 +42,7 @@ export interface ResolvedPluginConfig {
   recallLimit: number;
   memoryWikiCompat: {
     enabled: boolean;
+    fanoutTimeoutMs: number;
   };
 }
 

--- a/packages/openclaw-plugin/test/unit/memory-wiki-compat.test.ts
+++ b/packages/openclaw-plugin/test/unit/memory-wiki-compat.test.ts
@@ -10,9 +10,16 @@ type RegisteredTool = {
   execute: (id: string, args: Record<string, unknown>) => Promise<McpToolResponse & { details: Record<string, unknown> }>;
 };
 
-type FakeCall = { tool: string; args: Record<string, unknown> };
+type FakeCall = { tool: string; args: Record<string, unknown>; options?: { signal?: AbortSignal } };
 
 function makeConfig(overrides: Partial<ResolvedPluginConfig> = {}): ResolvedPluginConfig {
+  const baseWikiCompat: ResolvedPluginConfig['memoryWikiCompat'] = {
+    enabled: true,
+    fanoutTimeoutMs: 30_000,
+  };
+  const overriddenWikiCompat = overrides.memoryWikiCompat
+    ? { ...baseWikiCompat, ...overrides.memoryWikiCompat }
+    : baseWikiCompat;
   return {
     mcpUrl: 'http://localhost:8787/mcp',
     webUrl: null,
@@ -23,8 +30,8 @@ function makeConfig(overrides: Partial<ResolvedPluginConfig> = {}): ResolvedPlug
     autoRecall: false,
     autoCapture: false,
     recallLimit: 10,
-    memoryWikiCompat: { enabled: true },
     ...overrides,
+    memoryWikiCompat: overriddenWikiCompat,
   };
 }
 
@@ -51,6 +58,7 @@ type Harness = {
   calls: FakeCall[];
   responses: Map<string, McpToolResponse | null>;
   setResponse(tool: string, response: McpToolResponse | null): void;
+  setDelay(tool: string, ms: number): void;
   invoke(name: string, args?: Record<string, unknown>): ReturnType<RegisteredTool['execute']>;
 };
 
@@ -58,15 +66,31 @@ function makeHarness(overrideConfig: Partial<ResolvedPluginConfig> = {}): Harnes
   const tools = new Map<string, RegisteredTool>();
   const calls: FakeCall[] = [];
   const responses = new Map<string, McpToolResponse | null>();
+  const delays = new Map<string, number>();
   const registerTool = (def: Record<string, unknown>): void => {
     tools.set(def.name as string, def as unknown as RegisteredTool);
   };
   const callMcpTool = async (
     _config: ResolvedPluginConfig,
     toolName: string,
-    args: Record<string, unknown>
+    args: Record<string, unknown>,
+    options?: { signal?: AbortSignal }
   ): Promise<McpToolResponse | null> => {
-    calls.push({ tool: toolName, args });
+    calls.push({ tool: toolName, args, options });
+    const delay = delays.get(toolName);
+    if (delay && delay > 0) {
+      await new Promise((resolve, reject) => {
+        const timer = setTimeout(resolve, delay);
+        options?.signal?.addEventListener(
+          'abort',
+          () => {
+            clearTimeout(timer);
+            reject(new Error('aborted'));
+          },
+          { once: true }
+        );
+      });
+    }
     return responses.has(toolName) ? (responses.get(toolName) ?? null) : null;
   };
   registerMemoryWikiCompatTools(makeConfig(overrideConfig), registerTool, noopLogger(), callMcpTool);
@@ -76,6 +100,9 @@ function makeHarness(overrideConfig: Partial<ResolvedPluginConfig> = {}): Harnes
     responses,
     setResponse(tool, response) {
       responses.set(tool, response);
+    },
+    setDelay(tool, ms) {
+      delays.set(tool, ms);
     },
     invoke(name, args = {}) {
       const tool = tools.get(name);
@@ -169,14 +196,24 @@ describe('wiki_search corpus routing', () => {
   });
 });
 
-describe('upstream failures propagate', () => {
-  it('wiki_search corpus=wiki throws when query_sdk returns isError', async () => {
+describe('upstream failures degrade gracefully', () => {
+  it('wiki_search corpus=wiki returns degraded empty result when query_sdk returns isError', async () => {
     const h = makeHarness();
     h.setResponse('query_sdk', { content: [{ type: 'text', text: 'Tool not found: query_sdk' }], isError: true });
-    await expect(h.invoke('wiki_search', { query: 'anything', corpus: 'wiki' })).rejects.toThrow(/query_sdk/);
+    const result = await h.invoke('wiki_search', { query: 'anything', corpus: 'wiki' });
+    const details = result.details as {
+      results: unknown[];
+      degraded: boolean;
+      fanout_errors: Array<{ part: string; reason: string; error: string }>;
+    };
+    expect(details.degraded).toBe(true);
+    expect(details.results).toEqual([]);
+    expect(details.fanout_errors[0]?.part).toBe('wiki');
+    expect(details.fanout_errors[0]?.reason).toBe('error');
+    expect(details.fanout_errors[0]?.error).toMatch(/query_sdk/);
   });
 
-  it('runSdkScript surfaces sandbox success=false envelope as a thrown error', async () => {
+  it('wiki_get surfaces sandbox success=false envelope as a degraded error result (not a thrown exception)', async () => {
     const h = makeHarness();
     h.setResponse(
       'query_sdk',
@@ -185,7 +222,12 @@ describe('upstream failures propagate', () => {
         error: { name: 'RuntimeUnavailable', message: 'isolated-vm is not installed' },
       })
     );
-    await expect(h.invoke('wiki_get', { lookup: 'watcher:42' })).rejects.toThrow(/RuntimeUnavailable/);
+    const result = await h.invoke('wiki_get', { lookup: 'watcher:42' });
+    const details = result.details as Record<string, unknown>;
+    expect(details.degraded).toBe(true);
+    expect(details.timeout).toBe(false);
+    expect(details.result).toBeNull();
+    expect(String(details.error)).toMatch(/RuntimeUnavailable/);
   });
 
   it('wiki_get returns null cleanly when the SDK script return_value is explicitly null', async () => {
@@ -397,5 +439,77 @@ describe('wiki_lint session-aware', () => {
     const result = await h.invoke('wiki_lint');
     const report = result.details as { warnings: Array<{ reason: string }> };
     expect(report.warnings.every((w) => !/no evidence/.test(w.reason))).toBe(true);
+  });
+});
+
+describe('fanout timeout (slow upstreams do not block whole tool call)', () => {
+  it('wiki_status returns partial status when watchers fanout times out', async () => {
+    const h = makeHarness({ memoryWikiCompat: { enabled: true, fanoutTimeoutMs: 50 } });
+    h.setResponse('query_sdk', jsonContent({ watchers: [{ watcher_id: 1 }] }));
+    h.setDelay('query_sdk', 200);
+    h.setResponse('search_memory', jsonContent({ content: [] }));
+
+    const started = Date.now();
+    const result = await h.invoke('wiki_status');
+    const elapsed = Date.now() - started;
+
+    const status = result.details as Record<string, unknown>;
+    expect(elapsed).toBeLessThan(180);
+    expect(status.degraded).toBe(true);
+    expect(status.timeouts).toEqual(['watchers']);
+    expect(status.watcher_count).toBeNull();
+    expect(status.memory_available).toBe(true);
+    expect(Array.isArray(status.fanout_errors)).toBe(true);
+    expect(h.calls.find((call) => call.tool === 'query_sdk')?.options?.signal?.aborted).toBe(true);
+  });
+
+  it('wiki_search corpus=all merges partial results when one side times out', async () => {
+    const h = makeHarness({ memoryWikiCompat: { enabled: true, fanoutTimeoutMs: 50 } });
+    h.setResponse('search_memory', jsonContent({ content: [{ id: 1, title: 'memory hit', text_content: 'hi' }] }));
+    h.setResponse('query_sdk', jsonContent({ watchers: { watchers: [] }, claims: null, syntheses: null }));
+    h.setDelay('query_sdk', 200);
+
+    const started = Date.now();
+    const result = await h.invoke('wiki_search', { query: 'hi', corpus: 'all' });
+    const elapsed = Date.now() - started;
+
+    const details = result.details as {
+      results: Array<{ corpus: string }>;
+      degraded: boolean;
+      timeouts: string[];
+    };
+    expect(elapsed).toBeLessThan(180);
+    expect(details.degraded).toBe(true);
+    expect(details.timeouts).toEqual(['wiki']);
+    expect(details.results.some((r) => r.corpus === 'memory')).toBe(true);
+    expect(result.content[0]!.text).toMatch(/partial results/);
+  });
+
+  it('wiki_get reports a clean timeout error when the SDK script hangs', async () => {
+    const h = makeHarness({ memoryWikiCompat: { enabled: true, fanoutTimeoutMs: 50 } });
+    h.setResponse('query_sdk', jsonContent({ id: 7 }));
+    h.setDelay('query_sdk', 200);
+
+    const started = Date.now();
+    const result = await h.invoke('wiki_get', { lookup: 'watcher:7' });
+    const elapsed = Date.now() - started;
+
+    const details = result.details as Record<string, unknown>;
+    expect(elapsed).toBeLessThan(180);
+    expect(details.degraded).toBe(true);
+    expect(details.timeout).toBe(true);
+    expect(details.result).toBeNull();
+    expect(result.content[0]!.text).toMatch(/timeout/);
+  });
+
+  it('wiki_search corpus=all does not flag degraded when both sides return in time', async () => {
+    const h = makeHarness({ memoryWikiCompat: { enabled: true, fanoutTimeoutMs: 200 } });
+    h.setResponse('search_memory', jsonContent({ content: [{ id: 1, title: 'm', text_content: 'x' }] }));
+    h.setResponse('query_sdk', jsonContent({ watchers: { watchers: [] }, claims: null, syntheses: null }));
+
+    const result = await h.invoke('wiki_search', { query: 'hi', corpus: 'all' });
+    const details = result.details as { degraded: boolean; timeouts: string[] };
+    expect(details.degraded).toBe(false);
+    expect(details.timeouts).toEqual([]);
   });
 });

--- a/scripts/lobu/run-memory-wiki-compat-trace.ts
+++ b/scripts/lobu/run-memory-wiki-compat-trace.ts
@@ -97,11 +97,11 @@ class McpJsonClient {
     private readonly token?: string
   ) {}
 
-  private async fetchJson(body: Record<string, unknown>): Promise<Response> {
+  private async fetchJson(body: Record<string, unknown>, signal?: AbortSignal): Promise<Response> {
     const headers: Record<string, string> = { 'Content-Type': 'application/json', Accept: 'application/json' };
     if (this.token) headers.Authorization = `Bearer ${this.token}`;
     if (this.sessionId) headers['mcp-session-id'] = this.sessionId;
-    const res = await fetch(this.url, { method: 'POST', headers, body: JSON.stringify(body) });
+    const res = await fetch(this.url, { method: 'POST', headers, body: JSON.stringify(body), signal });
     if (!res.ok) throw new Error(`MCP HTTP ${res.status} ${res.statusText}`);
     return res;
   }
@@ -120,9 +120,9 @@ class McpJsonClient {
     await this.fetchJson({ jsonrpc: '2.0', method: 'notifications/initialized' });
   }
 
-  async callTool(name: string, args: Record<string, unknown>): Promise<McpToolResponse> {
+  async callTool(name: string, args: Record<string, unknown>, options?: { signal?: AbortSignal }): Promise<McpToolResponse> {
     await this.init();
-    const res = await this.fetchJson({ jsonrpc: '2.0', id: 1, method: 'tools/call', params: { name, arguments: args } });
+    const res = await this.fetchJson({ jsonrpc: '2.0', id: 1, method: 'tools/call', params: { name, arguments: args } }, options?.signal);
     const json = (await res.json()) as { error?: { message: string }; result?: McpToolResponse };
     if (json.error) throw new Error(json.error.message);
     return json.result ?? { content: [], isError: false };
@@ -178,9 +178,9 @@ async function runCompat(client: McpJsonClient, tools: Map<string, RegisteredToo
   let upstreamCalls = 0;
   // Patch the client.callTool to count upstream MCP calls for the duration of this probe.
   const original = client.callTool.bind(client);
-  client.callTool = async (name, args) => {
+  client.callTool = async (name, args, options) => {
     upstreamCalls += 1;
-    return original(name, args);
+    return original(name, args, options);
   };
   try {
     const res = await tool.execute('trace', probe.compatArgs);
@@ -255,7 +255,7 @@ function makeResolvedConfig(mcpUrl: string, token: string | null): ResolvedPlugi
     autoRecall: false,
     autoCapture: false,
     recallLimit: 10,
-    memoryWikiCompat: { enabled: true },
+    memoryWikiCompat: { enabled: true, fanoutTimeoutMs: 30_000 },
   };
 }
 
@@ -276,10 +276,11 @@ async function main(): Promise<void> {
   const callMcpTool = async (
     _config: ResolvedPluginConfig,
     name: string,
-    args: Record<string, unknown>
+    args: Record<string, unknown>,
+    options?: { signal?: AbortSignal }
   ): Promise<McpToolResponse | null> => {
     try {
-      return await client.callTool(name, args);
+      return await client.callTool(name, args, options);
     } catch (error) {
       return { content: [{ type: 'text', text: `ERROR: ${error instanceof Error ? error.message : String(error)}` }], isError: true };
     }


### PR DESCRIPTION
## Summary

The wiki compat tools (`wiki_status`, `wiki_search` corpus=all|wiki, `wiki_get`) fan out to multiple upstreams — `search_memory` over MCP and the SDK sandbox (`query_sdk` for `watchers.list` / `knowledge.read`). When one upstream is slow, `Promise.all` blocked the entire tool response. Against the public Lobu MCP at `lobu.ai`, this exceeded **Cloudflare's 100 s edge timeout** and the agent got a hard **HTTP 524** instead of any data.

This bounds each fanout with a per-call timeout. Slow paths are dropped and the tool returns whatever the fast side produced, marked `degraded: true` with a `timeouts`/`fanout_errors` breakdown. The timeout now also passes an `AbortSignal` through the plugin MCP caller and the trace harness, so timed-out fetches are aborted instead of lingering after the degraded result is returned.

### Live trace (`scripts/lobu/run-memory-wiki-compat-trace.ts` against `https://lobu.ai/mcp/buremba`)

| Probe | Before | After |
|---|---:|---:|
| `wiki_status` | 125 025 ms | bounded to ~30 000 ms when a fanout is slow; faster when both sides return |
| `wiki_search corpus=all` | 125 034 ms → HTTP 524 | ~30 000 ms (degraded, partial) |
| `wiki_search corpus=wiki` | 658 ms | ~600–900 ms (unchanged — was already fast) |
| `wiki_lint` | 1 ms | 1 ms |

Compat output for the degraded case includes a clear marker:
> `No Lobu wiki compatibility results for "recent activity" in corpus=all. Warning: partial results — fanout timed out on [memory].`

### Contract change

The two pre-existing "upstream failures propagate" tests asserted that errors threw. They now assert the new graceful-degrade contract (degraded result with `fanout_errors`). Hard exceptions are worse than degraded responses for agents that can already inspect `details.degraded`.

### Out of scope

The underlying prod-side slowness (`search_memory` with text query taking 60+ s, `query_sdk` sometimes taking 30–60+ s per call) is real but lives in `packages/server/` — separate work to add isolate pooling, fail-fast embeddings, etc. This PR keeps the compat tool surface usable for agents while that work happens.

## Test plan

- [x] `cd packages/openclaw-plugin && bun run typecheck` — clean
- [x] `cd packages/openclaw-plugin && bun test test/unit/memory-wiki-compat.test.ts` — **32 tests pass** (timeout/degraded coverage, including abort signal propagation)
- [x] `make build-packages` — clean
- [x] Live trace against `https://lobu.ai/mcp/buremba` exits successfully; slow fanouts return degraded output instead of HTTP 524/hanging past the edge timeout
- [x] Built the plugin (`6.2.0-canary.202605110106.9a13194e.abort`), deployed to a Home Assistant OpenClaw addon (v0.5.72), restarted, doctor reports `registered 7 MCP tools`, `registered memory-wiki compatibility tools`, and `initialized (configured=true, tools=true)`.
