### PR TITLE
docs(landing): document npx skills add install flow

### DIFF
--- a/packages/landing/src/content/blog/mcp-is-overengineered-skills-are-too-primitive.mdx
+++ b/packages/landing/src/content/blog/mcp-is-overengineered-skills-are-too-primitive.mdx
@@ -66,7 +66,7 @@ Over 100,000 packages on [Nixpkgs](https://search.nixos.org/packages). Every CLI
 
 Now the other half.
 
-Look at [skills.sh](https://skills.sh/). It's a directory of SKILL.md files you can install into Claude Code, Cursor, Copilot, and other agents. You search, find a skill, run `npx skillsadd owner/repo`, and it drops a markdown file into your project. [ClawHub](https://clawhub.ai/skills) does the same for the OpenClaw ecosystem. The discovery experience is genuinely good.
+Look at [skills.sh](https://skills.sh/). It's a directory of SKILL.md files you can install into Claude Code, Cursor, Copilot, and other agents. You search, find a skill, run `npx skills add owner/repo`, and it drops a markdown file into your project. [ClawHub](https://clawhub.ai/skills) does the same for the OpenClaw ecosystem. The discovery experience is genuinely good.
 
 But what _is_ a skill in these systems? A markdown file with instructions. "Use ffmpeg to process video." "Run ripgrep for code search." "Use the GitHub API to manage pull requests."
 

--- a/packages/landing/src/content/docs/getting-started/index.mdx
+++ b/packages/landing/src/content/docs/getting-started/index.mdx
@@ -57,7 +57,15 @@ If you enable Lobu memory during `init`, the scaffold also creates `models/` plu
 
 ## Develop your agent
 
-The fastest way to build your agent is to point a coding agent at the generated project. Open [Claude Code](https://claude.ai/claude-code), [Codex](https://openai.com/index/codex/), [OpenCode](https://opencode.ai), or any coding agent and paste this prompt:
+Install the Lobu skill into your coding agent so it already understands the project layout, `lobu.toml`, evals, memory wiring, and client setup:
+
+```bash
+npx skills add lobu-ai/lobu --skill lobu
+```
+
+The [vercel-labs/skills](https://github.com/vercel-labs/skills) CLI auto-detects [Claude Code](https://claude.ai/claude-code), [Codex](https://openai.com/index/codex/), [OpenCode](https://opencode.ai), Cursor, and OpenClaw, and drops `SKILL.md` in the right directory. Pin one host with `-a <agent>` (e.g. `-a claude-code`) to scope it.
+
+With the skill installed, open your coding agent in the project and start shaping behavior — it already knows how Lobu works. If you'd rather prime it manually, paste this prompt:
 
 ```
 I am building a Lobu agent in this repository.

--- a/packages/landing/src/content/docs/getting-started/memory.mdx
+++ b/packages/landing/src/content/docs/getting-started/memory.mdx
@@ -93,7 +93,13 @@ If you only need a working directory for one session, the filesystem is enough.
 
 ## Set it up
 
-Lobu memory wiring (TOML config, plugin install, CLI) is covered in the [Getting Started guide](/getting-started/) and the [Lobu Memory CLI reference](/reference/lobu-memory/).
+The fastest path is to install the Lobu skill into your coding agent and let it do the wiring — it knows the TOML config, plugin install, and CLI flow:
+
+```bash
+npx skills add lobu-ai/lobu --skill lobu
+```
+
+For the step-by-step manual setup, see the [Getting Started guide](/getting-started/) and the [Lobu Memory CLI reference](/reference/lobu-memory/).
 
 ## Read next
 

--- a/packages/landing/src/content/docs/getting-started/skills.mdx
+++ b/packages/landing/src/content/docs/getting-started/skills.mdx
@@ -14,11 +14,23 @@ A **skill** is a reusable capability bundle for an agent. In Lobu, skills can ad
 
 Lobu still discovers local `SKILL.md` files at runtime. Bundled skills are enabled from the agent settings UI; local skills live in your project so you can commit and customize them.
 
-## Bundled Starter Skill
+## Lobu Starter Skill
 
-The bundled Lobu starter skill includes project, runtime, and memory guidance. Enable it from the agent settings UI.
+The bundled Lobu skill teaches an agent the project layout, `lobu.toml`, prompt files, evals, memory tools, watchers, and client setup. Two places to install it:
 
-Use the **Lobu** skill when the agent should understand Lobu projects, `lobu.toml`, prompt files, evals, project structure, memory tools, watchers, and client setup.
+### In your coding agent
+
+Drop `SKILL.md` into Claude Code, Cursor, Codex, OpenCode, or OpenClaw with one command:
+
+```bash
+npx skills add lobu-ai/lobu --skill lobu
+```
+
+The [vercel-labs/skills](https://github.com/vercel-labs/skills) CLI auto-detects your editor and writes to the right directory. Pin one host with `-a <agent>` (e.g. `-a claude-code`, `-a cursor`).
+
+### In a Lobu agent
+
+Enable the bundled skill from the agent settings UI in [app.lobu.ai](https://app.lobu.ai). Local `SKILL.md` files under `skills/` and `agents/<id>/skills/` are also loaded at runtime — see [Local Skill Locations](#local-skill-locations) below.
 
 <SkillsRegistryTable client:load />
 

--- a/packages/server/src/gateway/services/instruction-service.ts
+++ b/packages/server/src/gateway/services/instruction-service.ts
@@ -34,7 +34,7 @@ interface SessionContextData {
 /**
  * Provides instructions from enabled skills for the agent.
  * Fetches skill content from AgentSettings and injects as instructions.
- * Falls back to generic skills.sh discovery instructions if no skills configured.
+ * Falls back to generic skill discovery instructions if no skills configured.
  */
 class SkillsInstructionProvider extends BaseInstructionProvider {
   readonly name = "skills";
@@ -47,7 +47,7 @@ class SkillsInstructionProvider extends BaseInstructionProvider {
   protected async buildInstructions(
     context: InstructionContext
   ): Promise<string> {
-    // If no settings store or agentId, return generic skills.sh instructions
+    // If no settings store or agentId, return generic skill discovery instructions
     if (!this.agentSettingsStore || !context.agentId) {
       return this.getGenericSkillsInstructions();
     }


### PR DESCRIPTION
## Summary
- Surface `npx skills add lobu-ai/lobu --skill lobu` in `getting-started/{index,memory,skills}.mdx` as the recommended way to drop the Lobu SKILL.md into Claude Code, Cursor, Codex, OpenCode, or OpenClaw — no submission to any third-party registry needed (the [vercel-labs/skills](https://github.com/vercel-labs/skills) CLI resolves arbitrary GitHub paths).
- Fix the stale `npx skillsadd owner/repo` snippet in the *MCP is overengineered, skills are too primitive* blog post — the real CLI is `npx skills add` (two words). The `skillsadd` package on npm is name-squatted by an unrelated project (skills.ws) and marked deprecated.
- Drop the misleading `.sh` suffix from internal `getGenericSkillsInstructions` comments in `instruction-service.ts` (the function never referenced skills.sh in its output).

## Test plan
- [ ] `cd packages/landing && bun run build` succeeds; `prebuild` regenerates the `public/*.md` twins.
- [ ] Skim the rendered `/getting-started/`, `/getting-started/memory/`, `/getting-started/skills/` pages and confirm the new install snippet is the first thing a reader sees in each.
- [ ] Confirm the blog post still reads naturally with the corrected command.