### PR TITLE
feat(openclaw-plugin): publish Lobu plugin to ClawHub

### DIFF
--- a/packages/openclaw-plugin/openclaw.plugin.json
+++ b/packages/openclaw-plugin/openclaw.plugin.json
@@ -1,5 +1,6 @@
 {
   "id": "openclaw-lobu",
+  "name": "Lobu",
   "kind": "memory",
   "description": "Lobu memory over MCP. Set mcpUrl to enable. Authentication via token, tokenCommand, or interactive device login.",
   "entry": "./dist/index.js",

--- a/packages/openclaw-plugin/package.json
+++ b/packages/openclaw-plugin/package.json
@@ -26,7 +26,13 @@
   "openclaw": {
     "extensions": [
       "./dist/index.js"
-    ]
+    ],
+    "compat": {
+      "pluginApi": ">=2026.4.0"
+    },
+    "build": {
+      "openclawVersion": "2026.5.7"
+    }
   },
   "devDependencies": {
     "@types/node": "^20.10.0",

--- a/scripts/publish-packages.mjs
+++ b/scripts/publish-packages.mjs
@@ -12,7 +12,8 @@
 
 import { spawnSync } from "node:child_process";
 import { readdirSync, readFileSync } from "node:fs";
-import { readFile, writeFile } from "node:fs/promises";
+import { cp, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
 import path from "node:path";
 import process from "node:process";
 
@@ -27,7 +28,7 @@ const PACKAGES = [
   {
     dir: "packages/openclaw-plugin",
     transform: rewriteWorkspaceRefs,
-    clawhub: { displayName: "Lobu", family: "code-plugin" },
+    clawhub: { slug: "lobu", displayName: "Lobu", family: "code-plugin" },
   },
   { dir: "packages/connectors", transform: rewriteWorkspaceRefs },
   { dir: "packages/connector-worker", transform: rewriteWorkspaceRefs },
@@ -176,45 +177,69 @@ function gitCommitSha() {
 // done locally (`clawhub login` then `clawhub package publish`) to claim the
 // slug; after that, register this workflow as the trusted publisher and CI
 // takes over.
+//
+// ClawHub forces the catalog slug to equal the package's `package.json` name,
+// so to publish under a clean `lobu` slug without renaming the npm package
+// (which `@lobu/openclaw-plugin` consumers depend on), we publish from a temp
+// copy whose `package.json` name is the slug. The npm tarball is unaffected.
 async function publishToClawhub({ dir, clawhub }) {
   const absDir = path.join(REPO_ROOT, dir);
   const pkg = JSON.parse(
     await readFile(path.join(absDir, "package.json"), "utf8")
   );
-  const { displayName, family } = clawhub;
+  const { slug, displayName, family } = clawhub;
   const version = pkg.version;
-  // ClawHub enforces slug === npm package.json name, then strips the scope
-  // server-side. So `@lobu/openclaw-plugin` lands at slug `openclaw-plugin`.
-  const slug = pkg.name.replace(/^@[^/]+\//, "");
 
   if (isClawhubVersionPublished(slug, version)) {
     console.log(`  → ${slug}@${version} already on ClawHub, skipping`);
     return;
   }
 
-  const commit = gitCommitSha();
-  console.log(`  → publishing ${slug}@${version} to ClawHub`);
-  run("npx", [
-    "--yes",
-    "clawhub@latest",
-    "package",
-    "publish",
-    absDir,
-    "--family",
-    family,
-    "--display-name",
-    displayName,
-    "--version",
-    version,
-    "--tags",
-    "latest",
-    "--source-repo",
-    CLAWHUB_SOURCE_REPO,
-    "--source-commit",
-    commit,
-    "--source-path",
-    dir,
-  ]);
+  const stageDir = await mkdtemp(path.join(os.tmpdir(), "clawhub-stage-"));
+  try {
+    await cp(absDir, stageDir, {
+      recursive: true,
+      filter: (src) =>
+        !src.split(path.sep).includes("node_modules") &&
+        !src.split(path.sep).includes(".git"),
+    });
+    const stagedPkgPath = path.join(stageDir, "package.json");
+    const stagedPkg = JSON.parse(await readFile(stagedPkgPath, "utf8"));
+    stagedPkg.name = slug;
+    await writeFile(
+      stagedPkgPath,
+      `${JSON.stringify(stagedPkg, null, 2)}\n`,
+      "utf8"
+    );
+
+    const commit = gitCommitSha();
+    console.log(`  → publishing ${slug}@${version} to ClawHub`);
+    run("npx", [
+      "--yes",
+      "clawhub@latest",
+      "package",
+      "publish",
+      stageDir,
+      "--family",
+      family,
+      "--name",
+      slug,
+      "--display-name",
+      displayName,
+      "--version",
+      version,
+      "--tags",
+      "latest",
+      "--source-repo",
+      CLAWHUB_SOURCE_REPO,
+      "--source-commit",
+      commit,
+      "--source-path",
+      dir,
+    ]);
+  } finally {
+    await rm(stageDir, { recursive: true, force: true });
+  }
 }
 
 function publishArgs(otp) {

--- a/scripts/publish-packages.mjs
+++ b/scripts/publish-packages.mjs
@@ -24,10 +24,16 @@ const PACKAGES = [
   { dir: "packages/agent-worker", transform: rewriteWorkspaceRefs },
   { dir: "packages/embeddings", transform: rewriteWorkspaceRefs },
   { dir: "packages/cli", transform: rewriteWorkspaceRefs },
-  { dir: "packages/openclaw-plugin", transform: rewriteWorkspaceRefs },
+  {
+    dir: "packages/openclaw-plugin",
+    transform: rewriteWorkspaceRefs,
+    clawhub: { displayName: "Lobu", family: "code-plugin" },
+  },
   { dir: "packages/connectors", transform: rewriteWorkspaceRefs },
   { dir: "packages/connector-worker", transform: rewriteWorkspaceRefs },
 ];
+
+const CLAWHUB_SOURCE_REPO = "lobu-ai/lobu";
 
 // Published package names that don't use the @lobu/ scope. The unscoped
 // `lobu` package was retired when the CLI merged into @lobu/cli; the
@@ -135,6 +141,82 @@ function isVersionPublished(name, version) {
   return result.status === 0 && result.stdout.trim() === version;
 }
 
+function isClawhubVersionPublished(slug, version) {
+  const result = spawnSync(
+    "npx",
+    [
+      "--yes",
+      "clawhub@latest",
+      "package",
+      "inspect",
+      slug,
+      "--version",
+      version,
+      "--json",
+    ],
+    { stdio: ["ignore", "pipe", "pipe"], encoding: "utf8" }
+  );
+  return result.status === 0;
+}
+
+function gitCommitSha() {
+  const result = spawnSync("git", ["rev-parse", "HEAD"], {
+    stdio: ["ignore", "pipe", "pipe"],
+    encoding: "utf8",
+  });
+  if (result.status !== 0) {
+    throw new Error("git rev-parse HEAD failed");
+  }
+  return result.stdout.trim();
+}
+
+// ClawHub publish via `clawhub package publish`. Auth in CI uses GitHub
+// Actions OIDC automatically when `id-token: write` is granted AND the package
+// is registered as a trusted publisher in ClawHub. First-ever publish must be
+// done locally (`clawhub login` then `clawhub package publish`) to claim the
+// slug; after that, register this workflow as the trusted publisher and CI
+// takes over.
+async function publishToClawhub({ dir, clawhub }) {
+  const absDir = path.join(REPO_ROOT, dir);
+  const pkg = JSON.parse(
+    await readFile(path.join(absDir, "package.json"), "utf8")
+  );
+  const { displayName, family } = clawhub;
+  const version = pkg.version;
+  // ClawHub enforces slug === npm package.json name, then strips the scope
+  // server-side. So `@lobu/openclaw-plugin` lands at slug `openclaw-plugin`.
+  const slug = pkg.name.replace(/^@[^/]+\//, "");
+
+  if (isClawhubVersionPublished(slug, version)) {
+    console.log(`  → ${slug}@${version} already on ClawHub, skipping`);
+    return;
+  }
+
+  const commit = gitCommitSha();
+  console.log(`  → publishing ${slug}@${version} to ClawHub`);
+  run("npx", [
+    "--yes",
+    "clawhub@latest",
+    "package",
+    "publish",
+    absDir,
+    "--family",
+    family,
+    "--display-name",
+    displayName,
+    "--version",
+    version,
+    "--tags",
+    "latest",
+    "--source-repo",
+    CLAWHUB_SOURCE_REPO,
+    "--source-commit",
+    commit,
+    "--source-path",
+    dir,
+  ]);
+}
+
 function publishArgs(otp) {
   const args = ["publish", "--access", "public"];
   if (otp) args.push(`--otp=${otp}`);
@@ -196,26 +278,34 @@ async function main() {
   const { bump, otp, skipBuild, skipBump } = parseArgs(process.argv.slice(2));
 
   if (skipBump) {
-    console.log("\n[1/3] Skipping version bump (--skip-bump)");
+    console.log("\n[1/4] Skipping version bump (--skip-bump)");
   } else {
-    console.log(`\n[1/3] Bumping version (${bump})`);
+    console.log(`\n[1/4] Bumping version (${bump})`);
     run("node", ["scripts/bump-version.mjs", bump]);
   }
 
   if (skipBuild) {
-    console.log("\n[2/3] Skipping build (--skip-build)");
+    console.log("\n[2/4] Skipping build (--skip-build)");
   } else {
-    console.log("\n[2/3] Building packages");
+    console.log("\n[2/4] Building packages");
     run("bun", ["run", "build:packages"]);
     run("bun", ["run", "build:lobu"]);
   }
 
-  console.log("\n[3/3] Publishing to npm");
+  console.log("\n[3/4] Publishing to npm");
   if (otp) {
     console.log("  (using --otp from command line or $NPM_OTP)");
   }
   for (const pkg of PACKAGES) {
     await publishPackage(pkg, otp);
+  }
+
+  const clawhubTargets = PACKAGES.filter((pkg) => pkg.clawhub);
+  if (clawhubTargets.length > 0) {
+    console.log("\n[4/4] Publishing to ClawHub");
+    for (const pkg of clawhubTargets) {
+      await publishToClawhub(pkg);
+    }
   }
 
   console.log("\nDone.");


### PR DESCRIPTION
## Summary
- Adds the `openclaw.compat.pluginApi` / `openclaw.build.openclawVersion` fields ClawHub requires for code plugins, and names the OpenClaw manifest `"Lobu"` (drives the catalog display name).
- Extends `scripts/publish-packages.mjs` with a fourth step: after the npm publish loop, publish `@lobu/openclaw-plugin` to ClawHub. CI auth uses the GitHub Actions OIDC token automatically (the workflow already grants `id-token: write`).
- ClawHub locks the catalog slug to `package.json:name`, so the step stages a temp copy with `name: "lobu"` and publishes that — the npm package stays `@lobu/openclaw-plugin`; only the ClawHub artifact carries the short `lobu` slug. Target URL: `clawhub.ai/<owner>/lobu`.

## Follow-up (manual, one-time)
1. `cd packages/openclaw-plugin && npx clawhub@latest login` then `npx clawhub@latest package publish <staged-copy> --family code-plugin --name lobu ...` to claim the `lobu` slug under your account. (Or just merge this and run `node scripts/publish-packages.mjs --skip-bump --skip-build` once locally.)
2. In ClawHub → package settings → Trusted Publisher, register this repo's `publish-packages.yml` workflow so CI can publish future versions via OIDC.

## Test plan
- [x] `clawhub package publish --dry-run` from a staged copy resolves `Name: lobu`, `Display: Lobu`, correct compat fields, 20 files.
- [x] `node --check scripts/publish-packages.mjs` passes; biome + tsc pre-commit pass.
- [ ] First real publish claims the slug (manual, see follow-up).
- [ ] CI publish on next release (after trusted publisher registered).