### PR TITLE
fix(openclaw-plugin): declare contracts.tools and bound the autoRecall hook

### DIFF
--- a/packages/openclaw-plugin/openclaw.plugin.json
+++ b/packages/openclaw-plugin/openclaw.plugin.json
@@ -4,6 +4,26 @@
   "kind": "memory",
   "description": "Lobu memory over MCP. Set mcpUrl to enable. Authentication via token, tokenCommand, or interactive device login.",
   "entry": "./dist/index.js",
+  "contracts": {
+    "tools": [
+      "lobu_login",
+      "lobu_login_check",
+      "lobu_search_memory",
+      "lobu_save_memory",
+      "lobu_list_organizations",
+      "lobu_search_sdk",
+      "lobu_query_sdk",
+      "lobu_query_sql",
+      "lobu_run_sdk",
+      "wiki_status",
+      "wiki_search",
+      "wiki_get",
+      "wiki_apply",
+      "wiki_lint",
+      "memory_search",
+      "memory_get"
+    ]
+  },
   "configSchema": {
     "type": "object",
     "additionalProperties": false,

--- a/packages/openclaw-plugin/src/index.ts
+++ b/packages/openclaw-plugin/src/index.ts
@@ -30,6 +30,58 @@ const AUTH_REQUIRED_MSG =
   'Lobu memory is not connected. Call the lobu_login tool to authenticate, then show the user the login URL and code. After the user completes login in their browser, call lobu_login_check to finish authentication.';
 const DEFAULT_RECALL_LIMIT = 6;
 
+// Lobu MCP server tools exposed via `tools/list` (see packages/server/src/tools/registry.ts).
+// Each is registered with OpenClaw as `lobu_<name>`. OpenClaw 2026.5.x requires every
+// runtime-registered tool to appear in `contracts.tools` in openclaw.plugin.json — keep the
+// `lobu_*` entries there in sync with this set (a unit test enforces it). Server tools not
+// listed here are skipped rather than registered (and rejected) until this plugin is updated
+// to declare them.
+export const KNOWN_MCP_TOOL_NAMES = new Set([
+  'search_memory',
+  'save_memory',
+  'list_organizations',
+  'search_sdk',
+  'query_sdk',
+  'query_sql',
+  'run_sdk',
+]);
+
+// Auth tools the plugin always registers in standalone mode (see register()).
+export const LOGIN_TOOL_NAMES = ['lobu_login', 'lobu_login_check'] as const;
+
+// `before_prompt_build` / `before_agent_start` run inside OpenClaw's hook budget
+// (~15s) — a slow `search_memory` must not blow that. Bound the recall round-trip
+// well under it and degrade to "no recall" rather than letting OpenClaw kill the hook.
+const RECALL_TIMEOUT_MS = 8_000;
+
+/**
+ * Run `work` with a hard wall-clock deadline. On timeout, the supplied
+ * `AbortSignal` is aborted (so an in-flight `fetch` cancels instead of
+ * lingering) and `onTimeout` is returned regardless of what is still pending.
+ * `work` is responsible for swallowing its own rejections; if it rejects after
+ * the deadline, the rejection is observed and ignored.
+ */
+export async function runWithAbortDeadline<T>(
+  work: (signal: AbortSignal) => Promise<T>,
+  timeoutMs: number,
+  onTimeout: T
+): Promise<T> {
+  const controller = new AbortController();
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const deadline = new Promise<T>((resolveDeadline) => {
+    timer = setTimeout(() => {
+      controller.abort();
+      resolveDeadline(onTimeout);
+    }, timeoutMs);
+  });
+  const guarded = work(controller.signal).catch(() => onTimeout);
+  try {
+    return await Promise.race([guarded, deadline]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
 // Minimal fallback context used before the workspace instructions are fetched.
 // Initialized lazily per mode (gateway vs standalone) in register().
 let FALLBACK_SYSTEM_CONTEXT: string | null = null;
@@ -976,7 +1028,14 @@ function registerMcpTools(
     return;
   }
 
+  let registered = 0;
   for (const tool of tools) {
+    if (!KNOWN_MCP_TOOL_NAMES.has(tool.name)) {
+      log.warn(
+        `lobu: MCP server exposes tool "${tool.name}" not declared in contracts.tools; skipping. Update @lobu/openclaw-plugin to register it.`
+      );
+      continue;
+    }
     registerTool({
       name: `lobu_${tool.name}`,
       label: tool.name.replace(/_/g, ' '),
@@ -987,9 +1046,10 @@ function registerMcpTools(
         return { content: result?.content ?? [], details: {} };
       },
     });
+    registered++;
   }
 
-  log.info(`lobu: registered ${tools.length} MCP tools`);
+  log.info(`lobu: registered ${registered} MCP tools`);
 }
 
 const plugin = {
@@ -1403,19 +1463,20 @@ const plugin = {
         cachedWorkspaceInstructions
           ? `<lobu-system>\n${cachedWorkspaceInstructions}\n</lobu-system>`
           : FALLBACK_SYSTEM_CONTEXT;
-      const doRecall = async (query: string): Promise<string> => {
-        if (!config.autoRecall || !hasAuthConfigured(config)) {
-          return '';
-        }
-
+      const recallOnce = async (query: string, signal: AbortSignal): Promise<string> => {
         try {
-          const result = await callMcpTool(config, 'search_memory', {
-            query,
-            include_content: true,
-            content_limit: config.recallLimit,
-            include_connections: false,
-            limit: 3,
-          });
+          const result = await callMcpTool(
+            config,
+            'search_memory',
+            {
+              query,
+              include_content: true,
+              content_limit: config.recallLimit,
+              include_connections: false,
+              limit: 3,
+            },
+            { signal }
+          );
           if (!result) return '';
 
           const text = extractTextFromContent(result.content);
@@ -1429,12 +1490,30 @@ const plugin = {
             '\n</lobu-memory>'
           );
         } catch (err) {
-          if (err instanceof LobuAuthError) {
+          if (err instanceof LobuAuthError) return '';
+          if (
+            signal.aborted ||
+            (err instanceof Error && (err.name === 'AbortError' || err.name === 'TimeoutError'))
+          ) {
+            log.warn(`lobu recall skipped: search_memory exceeded ${RECALL_TIMEOUT_MS}ms`);
             return '';
           }
           log.error(`lobu recall failed: ${err instanceof Error ? err.message : String(err)}`);
           return '';
         }
+      };
+      // Hard-bound the recall round-trip so it can never blow OpenClaw's hook
+      // budget: abort the in-flight MCP fetch at RECALL_TIMEOUT_MS and degrade
+      // to "no recall" no matter what is still pending (token command, network).
+      const doRecall = async (query: string): Promise<string> => {
+        if (!config.autoRecall || !hasAuthConfigured(config)) {
+          return '';
+        }
+        return runWithAbortDeadline(
+          (signal) => recallOnce(query, signal),
+          RECALL_TIMEOUT_MS,
+          ''
+        );
       };
       const buildPrependContext = (recallBlock: string) => ({
         prependContext: getSystemContext() + (recallBlock ? '\n' + recallBlock : ''),

--- a/packages/openclaw-plugin/src/memory-wiki-compat.ts
+++ b/packages/openclaw-plugin/src/memory-wiki-compat.ts
@@ -673,6 +673,19 @@ type SessionCall = {
 
 const SESSION_BUFFER_CAP = 32;
 
+// Agent tools registered by registerMemoryWikiCompatTools() when memoryWikiCompat
+// is enabled. OpenClaw 2026.5.x requires these to appear in `contracts.tools` in
+// openclaw.plugin.json — a unit test enforces the manifest stays in sync.
+export const MEMORY_WIKI_COMPAT_TOOL_NAMES = [
+  'wiki_status',
+  'wiki_search',
+  'wiki_get',
+  'wiki_apply',
+  'wiki_lint',
+  'memory_search',
+  'memory_get',
+] as const;
+
 export function registerMemoryWikiCompatTools(
   config: ResolvedPluginConfig,
   registerTool: (def: Record<string, unknown>) => void,

--- a/packages/openclaw-plugin/test/unit/manifest-contracts.test.ts
+++ b/packages/openclaw-plugin/test/unit/manifest-contracts.test.ts
@@ -1,0 +1,36 @@
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import { KNOWN_MCP_TOOL_NAMES, LOGIN_TOOL_NAMES } from '../../src/index.js';
+import { MEMORY_WIKI_COMPAT_TOOL_NAMES } from '../../src/memory-wiki-compat.js';
+
+const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), '../..');
+const manifest = JSON.parse(
+  readFileSync(resolve(packageRoot, 'openclaw.plugin.json'), 'utf-8')
+) as { contracts?: { tools?: unknown } };
+
+// Every tool the plugin can register at runtime, derived from the same constants
+// the runtime uses, so the manifest can't silently drift away from the code.
+const expectedTools = [
+  ...LOGIN_TOOL_NAMES,
+  ...[...KNOWN_MCP_TOOL_NAMES].map((name) => `lobu_${name}`),
+  ...MEMORY_WIKI_COMPAT_TOOL_NAMES,
+];
+
+describe('openclaw.plugin.json contracts.tools', () => {
+  it('declares contracts.tools (OpenClaw 2026.5.x rejects registerTool without it)', () => {
+    expect(Array.isArray(manifest.contracts?.tools)).toBe(true);
+    expect((manifest.contracts!.tools as string[]).length).toBeGreaterThan(0);
+  });
+
+  it('matches exactly the set of tools the plugin registers', () => {
+    const declared = (manifest.contracts!.tools as string[]).slice().sort();
+    expect(declared).toEqual([...expectedTools].sort());
+  });
+
+  it('has no duplicate entries', () => {
+    const declared = manifest.contracts!.tools as string[];
+    expect(new Set(declared).size).toBe(declared.length);
+  });
+});

--- a/packages/openclaw-plugin/test/unit/recall-deadline.test.ts
+++ b/packages/openclaw-plugin/test/unit/recall-deadline.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import { runWithAbortDeadline } from '../../src/index.js';
+
+describe('runWithAbortDeadline', () => {
+  it('returns the work result when it finishes before the deadline', async () => {
+    const result = await runWithAbortDeadline(async () => 'ok', 1_000, 'TIMEOUT');
+    expect(result).toBe('ok');
+  });
+
+  it('returns the sentinel and aborts the signal when work hangs past the deadline', async () => {
+    let abortedDuringWork = false;
+    const result = await runWithAbortDeadline<string>(
+      (signal) =>
+        new Promise((resolve) => {
+          signal.addEventListener('abort', () => {
+            abortedDuringWork = true;
+            resolve('late'); // ignored — the deadline already won the race
+          });
+        }),
+      30,
+      'TIMEOUT'
+    );
+    expect(result).toBe('TIMEOUT');
+    expect(abortedDuringWork).toBe(true);
+  });
+
+  it('swallows a rejection from work and returns the sentinel', async () => {
+    const result = await runWithAbortDeadline(async () => {
+      throw new Error('boom');
+    }, 1_000, 'FALLBACK');
+    expect(result).toBe('FALLBACK');
+  });
+});


### PR DESCRIPTION
## Why
Tested `@lobu/openclaw-plugin` end-to-end against a live OpenClaw 2026.5.x gateway and found it half-functional:

1. **MCP tools never registered.** OpenClaw 2026.5.x logs `[plugins] plugin must declare contracts.tools before registering agent tools (plugin=openclaw-lobu)` and rejects every `api.registerTool(...)` call. So `lobu_search_memory`, `lobu_save_memory`, `lobu_run_sdk`, the `wiki_*`/`memory_*` compat tools, and `lobu_login`/`lobu_login_check` were all dropped — recall still ran (it's a prompt hook), but the agent had no memory tools to call.
2. **autoRecall blew the hook budget.** `before_prompt_build` / `before_agent_start` run inside OpenClaw's ~15s hook ceiling. A slow `search_memory` exceeded it (`[hooks] before_prompt_build handler from openclaw-lobu failed: timed out after 15000ms`), so the gateway killed the hook and the recall block was lost.

## What
- **`openclaw.plugin.json`**: declare `contracts.tools` with all 16 tools the plugin can register (`lobu_login`, `lobu_login_check`, `lobu_<server tool>` ×7, `wiki_*`/`memory_*` ×7).
- **`registerMcpTools`**: only register server tools whose `lobu_<name>` is in the declared set (`KNOWN_MCP_TOOL_NAMES`); skip + warn on anything new so the plugin can't trip the `contracts.tools` guard again before it's updated.
- **autoRecall**: new `runWithAbortDeadline` caps the recall round-trip at `RECALL_TIMEOUT_MS` (8 s — comfortably under OpenClaw's 15 s), aborts the in-flight MCP `fetch`, and degrades to "no recall" instead of hanging. `before_agent_start` gets the same bound (shared `doRecall`).
- Exported `KNOWN_MCP_TOOL_NAMES`, `LOGIN_TOOL_NAMES`, `MEMORY_WIKI_COMPAT_TOOL_NAMES` so a unit test can verify the manifest stays in sync with the code.
- Adds `test/unit/manifest-contracts.test.ts` (manifest ↔ code consistency) and `test/unit/recall-deadline.test.ts` (the deadline helper).

Backward-compatible: older OpenClaw ignores the unknown `contracts` field. The `memoryWikiCompat` `fanoutTimeoutMs` (30 s) is unchanged — those tools are agent-invoked, not on the hook path.

## Test plan
- [x] `bun run typecheck` (package + repo-wide) — clean
- [x] `bun run test:unit` — 38 passed (incl. the 6 new)
- [x] `bun run build` — emits `dist/openclaw.plugin.json` with `contracts.tools`
- [ ] Re-verify on the live gateway after the next plugin publish: `lobu_*` + `wiki_*` tools appear in the agent's tool surface; no `contracts.tools` / hook-timeout errors in gateway logs.