### PR TITLE
fix(server): unify content search on hybrid index-driven candidate path

### DIFF
--- a/packages/server/src/__tests__/integration/events/search-content-exact-score.test.ts
+++ b/packages/server/src/__tests__/integration/events/search-content-exact-score.test.ts
@@ -1,0 +1,157 @@
+/**
+ * Regression coverage for exact org-wide score searches. The bounded hybrid
+ * candidate path is only safe for recall snippets; user-visible get_content
+ * searches still need exact title matching, filters, totals, and offsets.
+ */
+
+import { beforeAll, describe, expect, it } from 'vitest';
+import { searchContentByText } from '../../../utils/content-search';
+import { cleanupTestDatabase } from '../../setup/test-db';
+import {
+  addUserToOrganization,
+  createTestConnection,
+  createTestConnectorDefinition,
+  createTestEntity,
+  createTestEvent,
+  createTestOrganization,
+  createTestUser,
+  seedSystemEntityTypes,
+} from '../../setup/test-fixtures';
+
+const EMBEDDING_DIM = 768;
+
+function axisVec(axis: 0 | 1): number[] {
+  const v = new Array(EMBEDDING_DIM).fill(0);
+  v[axis] = 1;
+  return v;
+}
+
+async function createOrgFixture(name: string) {
+  const org = await createTestOrganization({ name });
+  const user = await createTestUser({ email: `${name.toLowerCase().replace(/[^a-z0-9]+/g, '-')}@example.com` });
+  await addUserToOrganization(user.id, org.id, 'owner');
+  const entity = await createTestEntity({ name: `${name} Entity`, organization_id: org.id });
+  await createTestConnectorDefinition({
+    key: `${name.toLowerCase().replace(/[^a-z0-9]+/g, '-')}-connector`,
+    name: `${name} Connector`,
+    organization_id: org.id,
+  });
+  const connection = await createTestConnection({
+    organization_id: org.id,
+    connector_key: `${name.toLowerCase().replace(/[^a-z0-9]+/g, '-')}-connector`,
+    entity_ids: [entity.id],
+  });
+  return { org, entity, connection };
+}
+
+describe('searchContentByText > exact org-wide score semantics', () => {
+  beforeAll(async () => {
+    await cleanupTestDatabase();
+    await seedSystemEntityTypes();
+  });
+
+  it('keeps exact title-only matches on the default path', async () => {
+    const { org, entity, connection } = await createOrgFixture('Exact Title Search Org');
+    const titleOnly = await createTestEvent({
+      entity_id: entity.id,
+      connection_id: connection.id,
+      title: 'Project Moonbase final decision',
+      content: 'The body intentionally does not contain the lookup word.',
+      organization_id: org.id,
+    });
+
+    const result = await searchContentByText('moonbase', {
+      organization_id: org.id,
+      limit: 10,
+      sort_by: 'score',
+    });
+
+    expect(result.content.map((c) => c.id)).toContain(titleOnly.id);
+  });
+
+  it('keeps exact totals and offsets beyond the recall candidate cap', async () => {
+    const { org, entity, connection } = await createOrgFixture('Exact Pagination Org');
+
+    for (let i = 0; i < 205; i++) {
+      await createTestEvent({
+        entity_id: entity.id,
+        connection_id: connection.id,
+        content: `pagerneedle item ${i}`,
+        occurred_at: new Date(`2025-04-${String((i % 28) + 1).padStart(2, '0')}T10:00:00Z`),
+        organization_id: org.id,
+      });
+    }
+
+    const result = await searchContentByText('pagerneedle', {
+      organization_id: org.id,
+      limit: 10,
+      offset: 200,
+      sort_by: 'score',
+    });
+
+    expect(result.total).toBe(205);
+    expect(result.content).toHaveLength(5);
+    expect(result.page.has_more).toBe(false);
+
+    const emptyLaterPage = await searchContentByText('pagerneedle', {
+      organization_id: org.id,
+      limit: 10,
+      offset: 300,
+      sort_by: 'score',
+    });
+    expect(emptyLaterPage.total).toBe(205);
+    expect(emptyLaterPage.content).toHaveLength(0);
+    expect(emptyLaterPage.page.has_more).toBe(false);
+  });
+
+  it('applies filters before the opt-in recall candidate limit', async () => {
+    const { org, entity, connection: decoyConnection } = await createOrgFixture(
+      'Approx Candidate Filter Org'
+    );
+    const targetConnection = await createTestConnection({
+      organization_id: org.id,
+      connector_key: decoyConnection.connector_key,
+      entity_ids: [entity.id],
+    });
+
+    for (let i = 0; i < 205; i++) {
+      await createTestEvent({
+        entity_id: entity.id,
+        connection_id: decoyConnection.id,
+        content: `vector decoy ${i}`,
+        occurred_at: new Date(`2025-05-${String((i % 28) + 1).padStart(2, '0')}T10:00:00Z`),
+        organization_id: org.id,
+        embedding: axisVec(0),
+      });
+    }
+
+    const target = await createTestEvent({
+      entity_id: entity.id,
+      connection_id: targetConnection.id,
+      content: 'filtered vector target',
+      occurred_at: new Date('2025-06-01T10:00:00Z'),
+      organization_id: org.id,
+      embedding: axisVec(0),
+    });
+    await createTestEvent({
+      entity_id: entity.id,
+      connection_id: targetConnection.id,
+      content: 'orthogonal filtered decoy',
+      occurred_at: new Date('2025-06-02T10:00:00Z'),
+      organization_id: org.id,
+      embedding: axisVec(1),
+    });
+
+    const result = await searchContentByText(null, {
+      organization_id: org.id,
+      connection_ids: [targetConnection.id],
+      limit: 10,
+      min_similarity: 0.9,
+      query_embedding: axisVec(0),
+      sort_by: 'score',
+      approximate_candidate_search: true,
+    });
+
+    expect(result.content.map((c) => c.id)).toEqual([target.id]);
+  });
+});

--- a/packages/server/src/tools/search.ts
+++ b/packages/server/src/tools/search.ts
@@ -262,9 +262,10 @@ async function fetchContentSnippets(
       min_similarity: 0.4,
       query_embedding: queryEmbedding,
       // Recall wants the most *relevant* matching content, not the most recent.
-      // This also opts into the fast vector-primary content path (the implicit
+      // This also opts into the bounded recall-only candidate path (the implicit
       // default is a chronological date feed).
       sort_by: 'score',
+      approximate_candidate_search: true,
     },
     env
   );

--- a/packages/server/src/tools/search.ts
+++ b/packages/server/src/tools/search.ts
@@ -261,6 +261,10 @@ async function fetchContentSnippets(
       limit: contentLimit,
       min_similarity: 0.4,
       query_embedding: queryEmbedding,
+      // Recall wants the most *relevant* matching content, not the most recent.
+      // This also opts into the fast vector-primary content path (the implicit
+      // default is a chronological date feed).
+      sort_by: 'score',
     },
     env
   );

--- a/packages/server/src/utils/content-search.ts
+++ b/packages/server/src/utils/content-search.ts
@@ -1438,6 +1438,25 @@ const STOPWORDS = [
   'approved',
   'made',
 ];
+const STOPWORDS_SET = new Set(STOPWORDS);
+
+/**
+ * Build a `tsquery` *string* (OR of clean lexemes, e.g. `"project | codename"`)
+ * from a free-text query — the JS mirror of NORMALIZED_QUERY_SQL/TSQUERY_SQL.
+ * Returning a plain string lets callers bind it as a parameter to
+ * `to_tsquery('english', $N)` so Postgres can use the fulltext GIN index
+ * (the in-SQL CASE+regexp form is opaque to the planner). Returns `null` when
+ * nothing usable survives normalization.
+ */
+function buildTsqueryString(queryText: string): string | null {
+  const tokens = queryText
+    .toLowerCase()
+    .replace(/[^a-z0-9\s]+/g, ' ')
+    .split(/\s+/)
+    .filter((t) => t.length > 0 && !STOPWORDS_SET.has(t));
+  return tokens.length > 0 ? tokens.join(' | ') : null;
+}
+
 const NORMALIZED_QUERY_SQL = `trim(regexp_replace(regexp_replace(lower($1), '\\m(${STOPWORDS.join('|')})\\M', ' ', 'g'), '[^a-z0-9\\s]+', ' ', 'g'))`;
 const TSQUERY_SQL = `CASE WHEN NULLIF(${NORMALIZED_QUERY_SQL}, '') IS NOT NULL THEN to_tsquery('english', regexp_replace(${NORMALIZED_QUERY_SQL}, '\\s+', ' | ', 'g')) ELSE NULL END`;
 
@@ -1827,13 +1846,22 @@ async function searchContentCandidatesFast(
   const vectorWeight = Number.isFinite(rawVectorWeight) ? Math.max(0, Math.min(1, rawVectorWeight)) : 0.6;
   const textWeight = 1 - vectorWeight;
 
-  // Param layout: $1 query text (used by TSQUERY_SQL), $2 organization_id,
-  // then [$N vector literal, $N minSim] when an embedding is in play.
-  // canUseFastCandidatePath guarantees no other row filters / offset, so the
-  // candidate scans stay index-friendly and the final select only re-applies
-  // the org guard (defense in depth — IDs are already org-scoped).
-  const params: unknown[] = [trimmedQuery, orgId];
-  const orgIdx = 2;
+  // The tsquery is computed + sanitized in JS to `^[a-z0-9 |]+$` and inlined as
+  // a literal (not bound) so Postgres can estimate selectivity and pick the
+  // bitmap-index plan; `to_tsquery('english', $N)` with a parameter yields a
+  // generic plan that falls back to an org-btree scan re-building tsvectors per
+  // row over the whole org. The sanitization makes literal inlining injection-safe.
+  let tsqueryStr = trimmedQuery.length > 0 ? buildTsqueryString(trimmedQuery) : null;
+  if (tsqueryStr && !/^[a-z0-9 |]+$/.test(tsqueryStr)) {
+    // buildTsqueryString should never produce this; bail to vector-only rather
+    // than risk inlining anything unexpected.
+    tsqueryStr = null;
+  }
+
+  // Param layout: $1 organization_id, [$N vector literal, $N minSim] when an
+  // embedding is in play. canUseFastCandidatePath guarantees no other filters.
+  const params: unknown[] = [orgId];
+  const orgIdx = 1;
   let vecIdx: number | null = null;
   let minSimIdx: number | null = null;
   if (hasEmbedding) {
@@ -1845,27 +1873,24 @@ async function searchContentCandidatesFast(
 
   const vecLiteralRef = vecIdx ? `$${vecIdx}::vector` : null;
   const minSimRef = minSimIdx ? `$${minSimIdx}::float8` : null;
-  // Match the exact expression `idx_events_fulltext` is built on
-  // (`to_tsvector('english', COALESCE(payload_text, ''))`) so the GIN index is
-  // usable. The richer title-weighted document expr is reserved for ranking the
-  // small candidate set in the final select.
+  const tsqRef = tsqueryStr ? `to_tsquery('english', '${tsqueryStr}')` : null;
   const indexedTsvE = `to_tsvector('english', COALESCE(e.payload_text, ''))`;
   const richDocF = buildSearchDocumentExpr('f');
 
-  // Text candidates: GIN fulltext via the tsquery (which already ORs the query
-  // tokens), org-scoped via the btree index. No ORDER BY here — the planner can
-  // stop at the first ${CANDIDATE_TEXT_LIMIT} matches; the final select re-ranks.
-  const textCte =
-    trimmedQuery.length > 0
-      ? `text_cands AS (
+  // Text candidates: GIN fulltext (`tsv @@ to_tsquery(...)` matches the index
+  // expr; the tsquery already ORs the query tokens). ORDER BY ts_rank LIMIT k
+  // pushes the planner to the bitmap-index path (org btree ∩ fulltext GIN) +
+  // sort rather than an org-btree early-stop that re-builds tsvectors per row.
+  const textCte = tsqRef
+    ? `text_cands AS (
         SELECT e.id, NULL::float8 AS sim, 1 AS from_text
         FROM events e
         WHERE e.organization_id = $${orgIdx}::text
-          AND ${TSQUERY_SQL} IS NOT NULL
-          AND ${indexedTsvE} @@ ${TSQUERY_SQL}
+          AND ${indexedTsvE} @@ ${tsqRef}
+        ORDER BY ts_rank_cd(${indexedTsvE}, ${tsqRef}) DESC
         LIMIT ${CANDIDATE_TEXT_LIMIT}
       )`
-      : null;
+    : null;
   // Vector candidates: ivfflat ANN on event_embeddings (`ORDER BY <=> LIMIT k` —
   // the only shape the index can serve), org-scoped via the join + iterative scan.
   const vecCte = vecLiteralRef
@@ -1895,7 +1920,7 @@ async function searchContentCandidatesFast(
     .filter(Boolean)
     .join('\n        UNION ALL\n        ');
 
-  const textRankF = `COALESCE(ts_rank_cd(${richDocF}, ${TSQUERY_SQL}), 0)::float8`;
+  const textRankF = tsqRef ? `COALESCE(ts_rank_cd(${richDocF}, ${tsqRef}), 0)::float8` : '0::float8';
   const combinedScoreSql = vecLiteralRef
     ? `(COALESCE(r.sim, 0) * ${vectorWeight} + ${textRankF} * ${textWeight})`
     : textRankF;

--- a/packages/server/src/utils/content-search.ts
+++ b/packages/server/src/utils/content-search.ts
@@ -1783,10 +1783,8 @@ async function searchContentBySingleQuery(
   };
 }
 
-// Candidate fan-out sizes for the index-driven org-wide path. Each side feeds
-// into a small re-ranked merge, so a few hundred is plenty for any sane
-// content_limit while keeping the candidate scans cheap.
-const CANDIDATE_TEXT_LIMIT = 200;
+// ANN fan-out for the index-driven org-wide path — a few hundred is plenty for
+// any sane content_limit while keeping the ivfflat scan cheap.
 const CANDIDATE_VECTOR_LIMIT = 200;
 // Backstop so a pathological candidate scan can't hang the request. Callers
 // (search_memory) already tolerate an empty content list, so failing fast and
@@ -1794,17 +1792,21 @@ const CANDIDATE_VECTOR_LIMIT = 200;
 const CANDIDATE_QUERY_TIMEOUT_MS = 6000;
 
 /**
- * Index-driven org-wide relevance search.
+ * Index-driven org-wide relevance search (vector-primary).
  *
  * The legacy single-query path ORs a text predicate with `embedding <=> $vec >=
- * threshold` in one WHERE; Postgres can't use the fulltext GIN, the trgm GIN,
- * or the ivfflat ANN index for that, so it sequential-scans the org's events
- * (tens of seconds — 27–210s on a ~720k-event org). Here we run the text side
- * against the GIN indexes and the vector side against the ivfflat ANN index
- * (`ORDER BY embedding <=> $vec LIMIT k`, which the index *can* serve, with
- * pgvector 0.8 iterative scan handling the org filter), then merge + re-rank a
- * few hundred candidates. Only used for the org-wide, non-chronological,
- * no-classifications search path; everything else stays on
+ * threshold` in one WHERE; Postgres can't use the fulltext GIN or the ivfflat
+ * ANN index for that, so it sequential-scans the org's events — tens of seconds
+ * (27–210s on a ~720k-event org), and `searchContentByText` runs it up to 8×.
+ *
+ * Here the candidates come from the ivfflat ANN index alone
+ * (`ORDER BY embedding <=> $vec LIMIT k` — the only shape the index serves,
+ * with pgvector 0.8 iterative scan handling the org filter), then ~200 are
+ * re-ranked with cosine + a title-weighted `ts_rank` (computed only over that
+ * small set). No fulltext-candidate scan — `events` has no stored `tsvector`
+ * column, so any fulltext candidate query is the same per-row tsvector rebuild
+ * the legacy path suffers; semantic recall covers the recall use case. Only
+ * used when an embedding is available; everything else stays on
  * `searchContentBySingleQuery`.
  */
 async function searchContentCandidatesFast(
@@ -1835,121 +1837,57 @@ async function searchContentCandidatesFast(
     } catch (err) {
       logger.warn(
         { err: err instanceof Error ? err.message : String(err) },
-        '[content-search] embedding generation failed; text-only candidates'
+        '[content-search] embedding generation failed; fast path returns no content'
       );
     }
   }
-  const hasEmbedding = queryEmbedding !== null;
-  const rawMinSim = Number(options.min_similarity ?? 0.3);
-  const minSim = Number.isFinite(rawMinSim) ? Math.max(0, Math.min(1, rawMinSim)) : 0.3;
-  const rawVectorWeight = Number(options.vector_weight ?? 0.6);
-  const vectorWeight = Number.isFinite(rawVectorWeight) ? Math.max(0, Math.min(1, rawVectorWeight)) : 0.6;
-  const textWeight = 1 - vectorWeight;
-
-  // The tsquery is computed + sanitized in JS to `^[a-z0-9 |]+$` and inlined as
-  // a literal (not bound) so Postgres can estimate selectivity and pick the
-  // bitmap-index plan; `to_tsquery('english', $N)` with a parameter yields a
-  // generic plan that falls back to an org-btree scan re-building tsvectors per
-  // row over the whole org. The sanitization makes literal inlining injection-safe.
-  let tsqueryStr = trimmedQuery.length > 0 ? buildTsqueryString(trimmedQuery) : null;
-  if (tsqueryStr && !/^[a-z0-9 |]+$/.test(tsqueryStr)) {
-    // buildTsqueryString should never produce this; bail to vector-only rather
-    // than risk inlining anything unexpected.
-    tsqueryStr = null;
-  }
-
-  // Param layout: $1 organization_id, [$N vector literal, $N minSim] when an
-  // embedding is in play. canUseFastCandidatePath guarantees no other filters.
-  const params: unknown[] = [orgId];
-  const orgIdx = 1;
-  let vecIdx: number | null = null;
-  let minSimIdx: number | null = null;
-  if (hasEmbedding) {
-    vecIdx = params.length + 1;
-    params.push(toVectorLiteral(queryEmbedding!));
-    minSimIdx = params.length + 1;
-    params.push(minSim);
-  }
-
-  const vecLiteralRef = vecIdx ? `$${vecIdx}::vector` : null;
-  const minSimRef = minSimIdx ? `$${minSimIdx}::float8` : null;
-  const tsqRef = tsqueryStr ? `to_tsquery('english', '${tsqueryStr}')` : null;
-  const indexedTsvE = `to_tsvector('english', COALESCE(e.payload_text, ''))`;
-  const richDocF = buildSearchDocumentExpr('f');
-
-  // Text candidates: GIN fulltext (`tsv @@ to_tsquery(...)` matches the index
-  // expr; the tsquery already ORs the query tokens). ORDER BY ts_rank LIMIT k
-  // pushes the planner to the bitmap-index path (org btree ∩ fulltext GIN) +
-  // sort rather than an org-btree early-stop that re-builds tsvectors per row.
-  const textCte = tsqRef
-    ? `text_cands AS (
-        SELECT e.id, NULL::float8 AS sim, 1 AS from_text
-        FROM events e
-        WHERE e.organization_id = $${orgIdx}::text
-          AND ${indexedTsvE} @@ ${tsqRef}
-        ORDER BY ts_rank_cd(${indexedTsvE}, ${tsqRef}) DESC
-        LIMIT ${CANDIDATE_TEXT_LIMIT}
-      )`
-    : null;
-  // Vector candidates: ivfflat ANN on event_embeddings (`ORDER BY <=> LIMIT k` —
-  // the only shape the index can serve), org-scoped via the join + iterative scan.
-  const vecCte = vecLiteralRef
-    ? `vec_cands AS (
-        SELECT emb.event_id AS id,
-          (1 - (emb.embedding <=> ${vecLiteralRef}))::float8 AS sim,
-          0 AS from_text
-        FROM event_embeddings emb
-        JOIN events e ON e.id = emb.event_id
-        WHERE e.organization_id = $${orgIdx}::text
-        ORDER BY emb.embedding <=> ${vecLiteralRef}
-        LIMIT ${CANDIDATE_VECTOR_LIMIT}
-      )`
-    : null;
-  const cteList = [textCte, vecCte].filter(Boolean) as string[];
-  if (cteList.length === 0) {
+  if (queryEmbedding === null) {
+    // No embedding → nothing the fast path can do (callers gate on an embedding
+    // source; this is the transient-generation-failure case). search_memory
+    // already tolerates an empty content list.
     return {
       content: [],
       total: 0,
       page: buildPageInfo({ limit, offset, total: 0, returnedCount: 0, useDateFeed: false, cursor: null }),
     };
   }
-  const unionSelects = [
-    textCte ? 'SELECT id, sim, from_text FROM text_cands' : null,
-    vecCte ? 'SELECT id, sim, from_text FROM vec_cands' : null,
-  ]
-    .filter(Boolean)
-    .join('\n        UNION ALL\n        ');
+  const rawMinSim = Number(options.min_similarity ?? 0.3);
+  const minSim = Number.isFinite(rawMinSim) ? Math.max(0, Math.min(1, rawMinSim)) : 0.3;
+  const rawVectorWeight = Number(options.vector_weight ?? 0.6);
+  const vectorWeight = Number.isFinite(rawVectorWeight) ? Math.max(0, Math.min(1, rawVectorWeight)) : 0.6;
+  const textWeight = 1 - vectorWeight;
 
-  const textRankF = tsqRef ? `COALESCE(ts_rank_cd(${richDocF}, ${tsqRef}), 0)::float8` : '0::float8';
-  const combinedScoreSql = vecLiteralRef
-    ? `(COALESCE(r.sim, 0) * ${vectorWeight} + ${textRankF} * ${textWeight})`
-    : textRankF;
-  // A text candidate is always kept (it matched the tsquery). A vector-only
-  // candidate is kept only if it clears the similarity floor.
-  const keepSql =
-    vecLiteralRef && minSimRef
-      ? `(is_text OR (sim IS NOT NULL AND sim >= ${minSimRef}))`
-      : 'is_text';
+  // tsquery for the title-weighted re-rank over the ~200 candidate rows.
+  // Computed + sanitized in JS to `^[a-z0-9 |]+$` and inlined as a literal so
+  // it's injection-safe and cheap (no per-row work in the candidate scan).
+  let tsqueryStr = trimmedQuery.length > 0 ? buildTsqueryString(trimmedQuery) : null;
+  if (tsqueryStr && !/^[a-z0-9 |]+$/.test(tsqueryStr)) tsqueryStr = null;
+  const tsqRef = tsqueryStr ? `to_tsquery('english', '${tsqueryStr}')` : null;
+  const richDocF = buildSearchDocumentExpr('f');
+  const textRankF = tsqRef ? `COALESCE(ts_rank_cd(${richDocF}, ${tsqRef}), 0)::float8` : null;
+  const combinedScoreSql = textRankF
+    ? `(v.sim * ${vectorWeight} + ${textRankF} * ${textWeight})`
+    : 'v.sim';
+
+  // Param layout: $1 organization_id, $2 vector literal, $3 minSim.
+  const params: unknown[] = [orgId, toVectorLiteral(queryEmbedding), minSim];
   const querySql = `
-    WITH ${cteList.join(',\n    ')},
-    merged AS (
-      SELECT id, MAX(sim) AS sim, bool_or(from_text > 0) AS is_text
-      FROM (
-        ${unionSelects}
-      ) u
-      GROUP BY id
-    ),
-    ranked AS (
-      SELECT id, sim FROM merged WHERE ${keepSql}
+    WITH vec_cands AS (
+      SELECT emb.event_id AS id, (1 - (emb.embedding <=> $2::vector))::float8 AS sim
+      FROM event_embeddings emb
+      JOIN events e ON e.id = emb.event_id
+      WHERE e.organization_id = $1::text
+      ORDER BY emb.embedding <=> $2::vector
+      LIMIT ${CANDIDATE_VECTOR_LIMIT}
     )
     SELECT ${BASE_COLUMNS_SQL},
       NULL as classifications,
       f.created_at,
-      r.sim as similarity,
+      v.sim as similarity,
       ${combinedScoreSql} as combined_score
-    FROM ranked r
-    JOIN current_event_records f ON f.id = r.id
-    WHERE f.organization_id = $${orgIdx}::text
+    FROM vec_cands v
+    JOIN current_event_records f ON f.id = v.id
+    WHERE f.organization_id = $1::text AND v.sim >= $3::float8
     ORDER BY combined_score DESC, (f.id % 997) ASC, f.occurred_at DESC, f.id DESC
     LIMIT ${validateNumericId(limit, 'limit')}`;
 
@@ -2037,7 +1975,11 @@ export async function searchContentByText(
 
   // Org-wide relevance search → index-driven candidate path (no 8× variant
   // loop; the tsquery already ORs query tokens).
-  if (canUseFastCandidatePath(queryText, options)) {
+  // Fast vector-primary path: only when an embedding is available (a precomputed
+  // query_embedding or an embeddings service to generate one) — without one
+  // there's no fast candidate source.
+  const embeddingAvailable = !!options.query_embedding?.length || !!env?.EMBEDDINGS_SERVICE_URL;
+  if (embeddingAvailable && canUseFastCandidatePath(queryText, options)) {
     return await searchContentCandidatesFast(sql, queryText, options, env);
   }
 

--- a/packages/server/src/utils/content-search.ts
+++ b/packages/server/src/utils/content-search.ts
@@ -1823,20 +1823,15 @@ async function searchContentCandidatesFast(
   const hasEmbedding = queryEmbedding !== null;
   const rawMinSim = Number(options.min_similarity ?? 0.3);
   const minSim = Number.isFinite(rawMinSim) ? Math.max(0, Math.min(1, rawMinSim)) : 0.3;
-  const vectorWeight = Math.max(0, Math.min(1, options.vector_weight ?? 0.6));
+  const rawVectorWeight = Number(options.vector_weight ?? 0.6);
+  const vectorWeight = Number.isFinite(rawVectorWeight) ? Math.max(0, Math.min(1, rawVectorWeight)) : 0.6;
   const textWeight = 1 - vectorWeight;
 
-  const sinceDate = options.since ? parseDateAlias(options.since).date : null;
-  const untilDate = options.until ? toEndOfDay(parseDateAlias(options.until).date) : null;
-
-  // Param layout (built incrementally so optional fragments don't desync $N):
-  //   $1 query text (used by TSQUERY_SQL + ILIKE)
-  //   $2 organization_id (candidate scans — kept simple so the org btree /
-  //      ivfflat indexes stay usable; the org-bridge branches in
-  //      buildOrgScopeWhere are deliberately skipped here)
-  //   [$N vector literal, $N minSim] when an embedding is in play
-  //   $N platform, $N since, $N until — applied on the small candidate set
-  //   visibility params (when a visibility_scope is supplied)
+  // Param layout: $1 query text (used by TSQUERY_SQL), $2 organization_id,
+  // then [$N vector literal, $N minSim] when an embedding is in play.
+  // canUseFastCandidatePath guarantees no other row filters / offset, so the
+  // candidate scans stay index-friendly and the final select only re-applies
+  // the org guard (defense in depth — IDs are already org-scoped).
   const params: unknown[] = [trimmedQuery, orgId];
   const orgIdx = 2;
   let vecIdx: number | null = null;
@@ -1847,21 +1842,6 @@ async function searchContentCandidatesFast(
     minSimIdx = params.length + 1;
     params.push(minSim);
   }
-  const platformIdx = params.length + 1;
-  params.push(options.platform ?? null);
-  const sinceIdx = params.length + 1;
-  params.push(sinceDate?.toISOString() ?? null);
-  const untilIdx = params.length + 1;
-  params.push(untilDate?.toISOString() ?? null);
-  const visibility = buildConnectionVisibilityClause(
-    {
-      organizationId: options.visibility_scope?.organizationId,
-      userId: options.visibility_scope?.userId ?? null,
-      baseParamIndex: params.length + 1,
-    },
-    'f'
-  );
-  params.push(...visibility.params);
 
   const vecLiteralRef = vecIdx ? `$${vecIdx}::vector` : null;
   const minSimRef = minSimIdx ? `$${minSimIdx}::float8` : null;
@@ -1944,10 +1924,7 @@ async function searchContentCandidatesFast(
       ${combinedScoreSql} as combined_score
     FROM ranked r
     JOIN current_event_records f ON f.id = r.id
-    WHERE ($${platformIdx}::text IS NULL OR f.connector_key = $${platformIdx}::text)
-      AND ($${sinceIdx}::timestamptz IS NULL OR f.occurred_at >= $${sinceIdx}::timestamptz)
-      AND ($${untilIdx}::timestamptz IS NULL OR f.occurred_at <= $${untilIdx}::timestamptz)
-      ${visibility.sql}
+    WHERE f.organization_id = $${orgIdx}::text
     ORDER BY combined_score DESC, (f.id % 997) ASC, f.occurred_at DESC, f.id DESC
     LIMIT ${validateNumericId(limit, 'limit')}`;
 
@@ -1979,14 +1956,35 @@ async function searchContentCandidatesFast(
   };
 }
 
-function canUseFastCandidatePath(queryText: string, options: ContentSearchOptions): boolean {
+// The fast path only handles the plain org-wide relevance shape (which is what
+// search_memory recall uses): no entity scope, no classifications, no
+// chronological/date-feed ordering, and none of the extra row filters — those
+// are applied only to the post-candidate set, so allowing them could
+// under-return when the candidate cap is hit. Everything else stays on
+// searchContentBySingleQuery.
+function canUseFastCandidatePath(
+  queryText: string,
+  options: ContentSearchOptions & { offset?: number }
+): boolean {
   return (
     queryText.trim().length >= 3 &&
     options.entity_id == null &&
     !!options.organization_id &&
+    (options.offset ?? 0) === 0 &&
     !options.include_classifications &&
     !(options.classification_filters && options.classification_filters.length > 0) &&
     !options.classification_source &&
+    !options.connection_ids?.length &&
+    !options.visibility_scope &&
+    options.platform == null &&
+    options.since == null &&
+    options.until == null &&
+    options.engagement_min == null &&
+    options.engagement_max == null &&
+    options.semantic_type == null &&
+    options.interaction_status == null &&
+    options.window_id == null &&
+    options.exclude_watcher_id == null &&
     options.sort_by !== 'date' &&
     !isDateFeedMode(options)
   );

--- a/packages/server/src/utils/content-search.ts
+++ b/packages/server/src/utils/content-search.ts
@@ -488,6 +488,11 @@ interface ContentSearchOptions {
   // regeneration step inside searchContentBySingleQuery — useful when the caller
   // already computed an embedding (e.g. search_memory receiving query_embedding).
   query_embedding?: number[];
+
+  // Internal recall-only performance hint. When true, org-wide score searches may
+  // use a bounded hybrid candidate set instead of the exact full match set. Do
+  // not use for user-visible get_content pagination/totals.
+  approximate_candidate_search?: boolean;
 }
 
 /**
@@ -1683,65 +1688,60 @@ async function searchContentBySingleQuery(
   const offsetParamIdx = limitParamIdx + 1;
   const validatedLimit = validateNumericId(limit, 'limit');
 
-  // ── Index-driven candidate path (org-wide relevance) ──────────────────────
-  // For org-wide queries that aren't the chronological date feed, instead of
-  // letting `filtered_ids` seq-scan the org's events behind a non-indexable
-  // WHERE (ILIKE OR per-row to_tsvector OR `embedding <=> $vec >= thr`), pull a
-  // few hundred candidate ids from the indexes that already serve those shapes —
-  // the ivfflat ANN, the fulltext GIN (`idx_events_fulltext`), and the trigram
-  // GIN (`idx_events_raw_content_trgm`) — each org-scoped via the same
-  // `buildOrgScopeWhere` triple-OR (entity/connection-bridged events stay
-  // visible), then run the unchanged filter/score/thread/classification
-  // machinery over just that set. Entity-scoped queries (the entity link
-  // already pre-trims the scan) and date-feed-with-query (needs the full match
-  // set for the cursor + count) stay on the legacy `WHERE ${searchWhereSQL}`.
+  // ── Recall-only index-driven candidate path ──────────────────────────────
+  // Exact org-wide search keeps using `searchWhereSQL` so title-only matches,
+  // filtered result sets, totals, and offsets retain their historical semantics.
+  // The bounded candidate path is opt-in for recall/search_memory snippets: the
+  // caller ignores exact totals/pagination and only needs a small set of highly
+  // relevant rows under the OpenClaw recall timeout.
   const useCandidatePath =
+    options.approximate_candidate_search === true &&
     entityId == null &&
     options.organization_id != null &&
     !useDateFeed &&
-    (hasEmbedding || trimmedQuery.length >= 3);
+    effectiveOffset === 0 &&
+    hasEmbedding;
   const hasTextCandidates = useCandidatePath && trimmedQuery.length >= 3;
   let searchCandidatesCteSql = '';
   if (useCandidatePath) {
     // $tsq is appended last in queryParams; offsetParamIdx is the current tail
     // (useDateFeed is false here, so there is no cursor block before it).
     const tsqueryParamIdx = offsetParamIdx + 1;
-    // buildOrgScopeWhere was given baseParamIndex 11 and, for an org-wide query
-    // (entity_id null), emits exactly one param there — the organization id.
-    const candOrgScope = `(ce.organization_id = $11::text
-            OR EXISTS (SELECT 1 FROM entities cent WHERE cent.id = ANY(ce.entity_ids) AND cent.organization_id = $11::text)
-            OR cc.organization_id = $11::text)`;
+    const candidateFilterJoins = `LEFT JOIN connections c ON c.id = f.connection_id
+          LEFT JOIN watcher_window_events iwf
+            ON iwf.event_id = f.id
+            AND ($6::int IS NOT NULL)
+            AND iwf.window_id = $6::int`;
     const branches: string[] = [];
-    if (hasEmbedding) {
-      // ivfflat ANN — the only shape that index serves; pgvector 0.8 iterative
-      // scan applies the org filter + min_similarity floor as it walks the
-      // index, so the LIMIT 200 returns the closest 200 *above* the threshold
-      // rather than the global top 200 (which could all be below it).
-      branches.push(`SELECT emb.event_id AS id
+    // ivfflat ANN — the only shape that index serves. Apply the same downstream
+    // filters before the candidate LIMIT so a filtered recall does not discard
+    // all relevant rows after picking 200 unfiltered org-wide ids.
+    branches.push(`SELECT emb.event_id AS id
           FROM event_embeddings emb
-          JOIN events ce ON ce.id = emb.event_id
-          LEFT JOIN connections cc ON cc.id = ce.connection_id
-          WHERE ${candOrgScope}
+          JOIN current_event_records f ON f.id = emb.event_id
+          ${candidateFilterJoins}
+          WHERE ${standardFiltersSQL}
             AND (1 - (emb.embedding <=> ${vecParam})) >= ${minSimilarityParam}
           ORDER BY emb.embedding <=> ${vecParam}
           LIMIT ${CANDIDATE_VECTOR_LIMIT}`);
-    }
     if (hasTextCandidates) {
       // fulltext GIN — the `@@` is index-served; no `ts_rank` here (that would
       // rebuild the tsvector per matched row over the whole org). The rank is
       // computed downstream over just the merged candidate set.
       branches.push(`SELECT ce.id AS id
           FROM events ce
-          LEFT JOIN connections cc ON cc.id = ce.connection_id
+          JOIN current_event_records f ON f.id = ce.id
+          ${candidateFilterJoins}
           WHERE to_tsvector('english', COALESCE(ce.payload_text, '')) @@ to_tsquery('english', $${tsqueryParamIdx})
-            AND ${candOrgScope}
+            AND ${standardFiltersSQL}
           LIMIT ${CANDIDATE_VECTOR_LIMIT}`);
-      // trigram GIN — preserves the ILIKE substring match (exact strings, ids).
+      // trigram GIN — preserves the payload substring match (exact strings, ids).
       branches.push(`SELECT ce.id AS id
           FROM events ce
-          LEFT JOIN connections cc ON cc.id = ce.connection_id
+          JOIN current_event_records f ON f.id = ce.id
+          ${candidateFilterJoins}
           WHERE ce.payload_text ILIKE '%' || $1 || '%'
-            AND ${candOrgScope}
+            AND ${standardFiltersSQL}
           LIMIT ${CANDIDATE_VECTOR_LIMIT}`);
     }
     // Each branch has its own ORDER BY/LIMIT and must therefore be
@@ -1752,6 +1752,18 @@ async function searchContentBySingleQuery(
       ),
       `;
   }
+
+  const nonDateFilteredIdsCteSql = `filtered_ids AS (
+        SELECT f.id, f.score, f.occurred_at, f.title, f.payload_text, f.embedding
+        FROM current_event_records f
+        ${useCandidatePath ? 'JOIN search_candidates sc ON sc.id = f.id' : ''}
+        LEFT JOIN connections c ON c.id = f.connection_id
+        LEFT JOIN watcher_window_events iwf
+          ON iwf.event_id = f.id
+          AND ($6::int IS NOT NULL)
+          AND iwf.window_id = $6::int
+        WHERE ${useCandidatePath ? standardFiltersSQL : searchWhereSQL}
+      )`;
 
   const querySQL = useDateFeed
     ? `
@@ -1795,16 +1807,9 @@ async function searchContentBySingleQuery(
       ${ctes}
       ${searchFinalSelect}`
     : `
-      WITH RECURSIVE ${useCandidatePath ? searchCandidatesCteSql : ''}filtered_ids AS (
-        SELECT f.id, f.score, f.occurred_at, f.title, f.payload_text, f.embedding
-        FROM current_event_records f
-        ${useCandidatePath ? 'JOIN search_candidates sc ON sc.id = f.id' : ''}
-        LEFT JOIN connections c ON c.id = f.connection_id
-        LEFT JOIN watcher_window_events iwf
-          ON iwf.event_id = f.id
-          AND ($6::int IS NOT NULL)
-          AND iwf.window_id = $6::int
-        WHERE ${useCandidatePath ? standardFiltersSQL : searchWhereSQL}
+      WITH RECURSIVE ${useCandidatePath ? searchCandidatesCteSql : ''}${nonDateFilteredIdsCteSql},
+      full_count AS (
+        SELECT COUNT(*) as total_count FROM filtered_ids
       ),
       result_set AS (
         SELECT
@@ -1812,7 +1817,7 @@ async function searchContentBySingleQuery(
           ${textRankExpr} as text_rank,
           ${similarityExpr} as similarity,
           ${combinedScoreExpr} as combined_score,
-          COUNT(*) OVER() as total_count,
+          (SELECT total_count FROM full_count) as total_count,
           NULL::bigint as cursor_fetched_count
         FROM filtered_ids fi
         ORDER BY ${resultSetOrderBy}
@@ -1866,7 +1871,21 @@ async function searchContentBySingleQuery(
   } else {
     rawRows = (await sql.unsafe(querySQL, queryParams)) as any[];
   }
-  const total = rawRows.length > 0 ? parseInt(String(rawRows[0].total_count ?? '0'), 10) : 0;
+
+  let emptyPageTotal: number | null = null;
+  if (!useDateFeed && rawRows.length === 0 && effectiveOffset > 0) {
+    const countSQL = `
+      WITH RECURSIVE ${useCandidatePath ? searchCandidatesCteSql : ''}${nonDateFilteredIdsCteSql}
+      SELECT COUNT(*) as total_count FROM filtered_ids`;
+    const countParams = useCandidatePath ? queryParams : queryParams.slice(0, cursorBaseParamIdx - 1);
+    const countRows = (await sql.unsafe(countSQL, countParams)) as any[];
+    emptyPageTotal = parseInt(String(countRows[0]?.total_count ?? '0'), 10);
+  }
+
+  const total =
+    rawRows.length > 0
+      ? parseInt(String(rawRows[0].total_count ?? '0'), 10)
+      : (emptyPageTotal ?? 0);
   const content = needClassifications
     ? deduplicateWithClassifications(rawRows)
     : (rawRows as any as ContentSearchResult[]);

--- a/packages/server/src/utils/content-search.ts
+++ b/packages/server/src/utils/content-search.ts
@@ -1764,6 +1764,234 @@ async function searchContentBySingleQuery(
   };
 }
 
+// Candidate fan-out sizes for the index-driven org-wide path. Each side feeds
+// into a small re-ranked merge, so a few hundred is plenty for any sane
+// content_limit while keeping the candidate scans cheap.
+const CANDIDATE_TEXT_LIMIT = 200;
+const CANDIDATE_VECTOR_LIMIT = 200;
+// Backstop so a pathological candidate scan can't hang the request. Callers
+// (search_memory) already tolerate an empty content list, so failing fast and
+// degrading to "no content" beats a multi-minute query.
+const CANDIDATE_QUERY_TIMEOUT_MS = 6000;
+
+/**
+ * Index-driven org-wide relevance search.
+ *
+ * The legacy single-query path ORs a text predicate with `embedding <=> $vec >=
+ * threshold` in one WHERE; Postgres can't use the fulltext GIN, the trgm GIN,
+ * or the ivfflat ANN index for that, so it sequential-scans the org's events
+ * (tens of seconds — 27–210s on a ~720k-event org). Here we run the text side
+ * against the GIN indexes and the vector side against the ivfflat ANN index
+ * (`ORDER BY embedding <=> $vec LIMIT k`, which the index *can* serve, with
+ * pgvector 0.8 iterative scan handling the org filter), then merge + re-rank a
+ * few hundred candidates. Only used for the org-wide, non-chronological,
+ * no-classifications search path; everything else stays on
+ * `searchContentBySingleQuery`.
+ */
+async function searchContentCandidatesFast(
+  sql: DbClient,
+  queryText: string,
+  options: ContentSearchOptions & { offset?: number },
+  env?: Env
+): Promise<ContentSearchResponse> {
+  const limit = Math.min(options.limit ?? 50, 500);
+  const offset = options.offset ?? 0;
+  const trimmedQuery = queryText.trim();
+  const orgId = options.organization_id;
+  if (!orgId) {
+    return {
+      content: [],
+      total: 0,
+      page: buildPageInfo({ limit, offset, total: 0, returnedCount: 0, useDateFeed: false, cursor: null }),
+    };
+  }
+
+  let queryEmbedding: number[] | null = options.query_embedding?.length
+    ? options.query_embedding
+    : null;
+  if (!queryEmbedding && env?.EMBEDDINGS_SERVICE_URL) {
+    try {
+      const embs = await generateEmbeddings([trimmedQuery], env);
+      queryEmbedding = embs[0] ?? null;
+    } catch (err) {
+      logger.warn(
+        { err: err instanceof Error ? err.message : String(err) },
+        '[content-search] embedding generation failed; text-only candidates'
+      );
+    }
+  }
+  const hasEmbedding = queryEmbedding !== null;
+  const rawMinSim = Number(options.min_similarity ?? 0.3);
+  const minSim = Number.isFinite(rawMinSim) ? Math.max(0, Math.min(1, rawMinSim)) : 0.3;
+  const vectorWeight = Math.max(0, Math.min(1, options.vector_weight ?? 0.6));
+  const textWeight = 1 - vectorWeight;
+
+  const sinceDate = options.since ? parseDateAlias(options.since).date : null;
+  const untilDate = options.until ? toEndOfDay(parseDateAlias(options.until).date) : null;
+
+  // Param layout (built incrementally so optional fragments don't desync $N):
+  //   $1 query text (used by TSQUERY_SQL + ILIKE)
+  //   $2 organization_id (candidate scans — kept simple so the org btree /
+  //      ivfflat indexes stay usable; the org-bridge branches in
+  //      buildOrgScopeWhere are deliberately skipped here)
+  //   [$N vector literal, $N minSim] when an embedding is in play
+  //   $N platform, $N since, $N until — applied on the small candidate set
+  //   visibility params (when a visibility_scope is supplied)
+  const params: unknown[] = [trimmedQuery, orgId];
+  const orgIdx = 2;
+  let vecIdx: number | null = null;
+  let minSimIdx: number | null = null;
+  if (hasEmbedding) {
+    vecIdx = params.length + 1;
+    params.push(toVectorLiteral(queryEmbedding!));
+    minSimIdx = params.length + 1;
+    params.push(minSim);
+  }
+  const platformIdx = params.length + 1;
+  params.push(options.platform ?? null);
+  const sinceIdx = params.length + 1;
+  params.push(sinceDate?.toISOString() ?? null);
+  const untilIdx = params.length + 1;
+  params.push(untilDate?.toISOString() ?? null);
+  const visibility = buildConnectionVisibilityClause(
+    {
+      organizationId: options.visibility_scope?.organizationId,
+      userId: options.visibility_scope?.userId ?? null,
+      baseParamIndex: params.length + 1,
+    },
+    'f'
+  );
+  params.push(...visibility.params);
+
+  const vecLiteralRef = vecIdx ? `$${vecIdx}::vector` : null;
+  const minSimRef = minSimIdx ? `$${minSimIdx}::float8` : null;
+  // Match the exact expression `idx_events_fulltext` is built on
+  // (`to_tsvector('english', COALESCE(payload_text, ''))`) so the GIN index is
+  // usable. The richer title-weighted document expr is reserved for ranking the
+  // small candidate set in the final select.
+  const indexedTsvE = `to_tsvector('english', COALESCE(e.payload_text, ''))`;
+  const richDocF = buildSearchDocumentExpr('f');
+
+  // Text candidates: GIN fulltext via the tsquery (which already ORs the query
+  // tokens), org-scoped via the btree index. No ORDER BY here — the planner can
+  // stop at the first ${CANDIDATE_TEXT_LIMIT} matches; the final select re-ranks.
+  const textCte =
+    trimmedQuery.length > 0
+      ? `text_cands AS (
+        SELECT e.id, NULL::float8 AS sim, 1 AS from_text
+        FROM events e
+        WHERE e.organization_id = $${orgIdx}::text
+          AND ${TSQUERY_SQL} IS NOT NULL
+          AND ${indexedTsvE} @@ ${TSQUERY_SQL}
+        LIMIT ${CANDIDATE_TEXT_LIMIT}
+      )`
+      : null;
+  // Vector candidates: ivfflat ANN on event_embeddings (`ORDER BY <=> LIMIT k` —
+  // the only shape the index can serve), org-scoped via the join + iterative scan.
+  const vecCte = vecLiteralRef
+    ? `vec_cands AS (
+        SELECT emb.event_id AS id,
+          (1 - (emb.embedding <=> ${vecLiteralRef}))::float8 AS sim,
+          0 AS from_text
+        FROM event_embeddings emb
+        JOIN events e ON e.id = emb.event_id
+        WHERE e.organization_id = $${orgIdx}::text
+        ORDER BY emb.embedding <=> ${vecLiteralRef}
+        LIMIT ${CANDIDATE_VECTOR_LIMIT}
+      )`
+    : null;
+  const cteList = [textCte, vecCte].filter(Boolean) as string[];
+  if (cteList.length === 0) {
+    return {
+      content: [],
+      total: 0,
+      page: buildPageInfo({ limit, offset, total: 0, returnedCount: 0, useDateFeed: false, cursor: null }),
+    };
+  }
+  const unionSelects = [
+    textCte ? 'SELECT id, sim, from_text FROM text_cands' : null,
+    vecCte ? 'SELECT id, sim, from_text FROM vec_cands' : null,
+  ]
+    .filter(Boolean)
+    .join('\n        UNION ALL\n        ');
+
+  const textRankF = `COALESCE(ts_rank_cd(${richDocF}, ${TSQUERY_SQL}), 0)::float8`;
+  const combinedScoreSql = vecLiteralRef
+    ? `(COALESCE(r.sim, 0) * ${vectorWeight} + ${textRankF} * ${textWeight})`
+    : textRankF;
+  // A text candidate is always kept (it matched the tsquery). A vector-only
+  // candidate is kept only if it clears the similarity floor.
+  const keepSql =
+    vecLiteralRef && minSimRef
+      ? `(is_text OR (sim IS NOT NULL AND sim >= ${minSimRef}))`
+      : 'is_text';
+  const querySql = `
+    WITH ${cteList.join(',\n    ')},
+    merged AS (
+      SELECT id, MAX(sim) AS sim, bool_or(from_text > 0) AS is_text
+      FROM (
+        ${unionSelects}
+      ) u
+      GROUP BY id
+    ),
+    ranked AS (
+      SELECT id, sim FROM merged WHERE ${keepSql}
+    )
+    SELECT ${BASE_COLUMNS_SQL},
+      NULL as classifications,
+      f.created_at,
+      r.sim as similarity,
+      ${combinedScoreSql} as combined_score
+    FROM ranked r
+    JOIN current_event_records f ON f.id = r.id
+    WHERE ($${platformIdx}::text IS NULL OR f.connector_key = $${platformIdx}::text)
+      AND ($${sinceIdx}::timestamptz IS NULL OR f.occurred_at >= $${sinceIdx}::timestamptz)
+      AND ($${untilIdx}::timestamptz IS NULL OR f.occurred_at <= $${untilIdx}::timestamptz)
+      ${visibility.sql}
+    ORDER BY combined_score DESC, (f.id % 997) ASC, f.occurred_at DESC, f.id DESC
+    LIMIT ${validateNumericId(limit, 'limit')}`;
+
+  let rows: any[];
+  try {
+    rows = (await sql.begin(async (tx: DbClient) => {
+      await tx.unsafe(`SET LOCAL statement_timeout = ${CANDIDATE_QUERY_TIMEOUT_MS}`);
+      return await tx.unsafe(querySql, params);
+    })) as any[];
+  } catch (err) {
+    logger.warn(
+      { err: err instanceof Error ? err.message : String(err) },
+      '[content-search] fast candidate query failed; returning empty content'
+    );
+    rows = [];
+  }
+  const content = rows as any as ContentSearchResult[];
+  return {
+    content,
+    total: content.length,
+    page: buildPageInfo({
+      limit,
+      offset,
+      total: content.length,
+      returnedCount: content.length,
+      useDateFeed: false,
+      cursor: null,
+    }),
+  };
+}
+
+function canUseFastCandidatePath(queryText: string, options: ContentSearchOptions): boolean {
+  return (
+    queryText.trim().length >= 3 &&
+    options.entity_id == null &&
+    !!options.organization_id &&
+    !options.include_classifications &&
+    !(options.classification_filters && options.classification_filters.length > 0) &&
+    !options.classification_source &&
+    options.sort_by !== 'date' &&
+    !isDateFeedMode(options)
+  );
+}
+
 export async function searchContentByText(
   queryText: string | null,
   options: ContentSearchOptions & { offset?: number },
@@ -1782,6 +2010,12 @@ export async function searchContentByText(
       return await searchContentBySingleQuery(sql, '', options, env);
     }
     return await listContentInternal(sql, options, limit, offset);
+  }
+
+  // Org-wide relevance search → index-driven candidate path (no 8× variant
+  // loop; the tsquery already ORs query tokens).
+  if (canUseFastCandidatePath(queryText, options)) {
+    return await searchContentCandidatesFast(sql, queryText, options, env);
   }
 
   const queryVariants = expandSearchQueries(queryText, { maxVariants: 8 });

--- a/packages/server/src/utils/content-search.ts
+++ b/packages/server/src/utils/content-search.ts
@@ -18,7 +18,6 @@ import { parseDateAlias, toEndOfDay } from './date-aliases';
 import { generateEmbeddings } from './embeddings';
 import { toVectorLiteral } from './entity-management';
 import logger from './logger';
-import { expandSearchQueries } from './query-expansion';
 import { validateNumericId } from './sql-validation';
 
 const CONTEXT_CASE_SQL = `
@@ -1460,6 +1459,15 @@ function buildTsqueryString(queryText: string): string | null {
 const NORMALIZED_QUERY_SQL = `trim(regexp_replace(regexp_replace(lower($1), '\\m(${STOPWORDS.join('|')})\\M', ' ', 'g'), '[^a-z0-9\\s]+', ' ', 'g'))`;
 const TSQUERY_SQL = `CASE WHEN NULLIF(${NORMALIZED_QUERY_SQL}, '') IS NOT NULL THEN to_tsquery('english', regexp_replace(${NORMALIZED_QUERY_SQL}, '\\s+', ' | ', 'g')) ELSE NULL END`;
 
+// Per-source fan-out for the index-driven candidate path — a few hundred from
+// each of the ivfflat ANN / fulltext GIN / trigram GIN is plenty for any sane
+// content_limit while keeping each index scan cheap.
+const CANDIDATE_VECTOR_LIMIT = 200;
+// Backstop so a pathological candidate scan can't hang the request. Every caller
+// tolerates an empty content list, so failing fast and degrading to "no content"
+// beats a multi-minute query.
+const CANDIDATE_QUERY_TIMEOUT_MS = 6000;
+
 async function searchContentBySingleQuery(
   sql: DbClient,
   queryText: string,
@@ -1674,6 +1682,77 @@ async function searchContentBySingleQuery(
   const limitParamIdx = cursorBaseParamIdx + cursorClause.params.length;
   const offsetParamIdx = limitParamIdx + 1;
   const validatedLimit = validateNumericId(limit, 'limit');
+
+  // ── Index-driven candidate path (org-wide relevance) ──────────────────────
+  // For org-wide queries that aren't the chronological date feed, instead of
+  // letting `filtered_ids` seq-scan the org's events behind a non-indexable
+  // WHERE (ILIKE OR per-row to_tsvector OR `embedding <=> $vec >= thr`), pull a
+  // few hundred candidate ids from the indexes that already serve those shapes —
+  // the ivfflat ANN, the fulltext GIN (`idx_events_fulltext`), and the trigram
+  // GIN (`idx_events_raw_content_trgm`) — each org-scoped via the same
+  // `buildOrgScopeWhere` triple-OR (entity/connection-bridged events stay
+  // visible), then run the unchanged filter/score/thread/classification
+  // machinery over just that set. Entity-scoped queries (the entity link
+  // already pre-trims the scan) and date-feed-with-query (needs the full match
+  // set for the cursor + count) stay on the legacy `WHERE ${searchWhereSQL}`.
+  const useCandidatePath =
+    entityId == null &&
+    options.organization_id != null &&
+    !useDateFeed &&
+    (hasEmbedding || trimmedQuery.length >= 3);
+  const hasTextCandidates = useCandidatePath && trimmedQuery.length >= 3;
+  let searchCandidatesCteSql = '';
+  if (useCandidatePath) {
+    // $tsq is appended last in queryParams; offsetParamIdx is the current tail
+    // (useDateFeed is false here, so there is no cursor block before it).
+    const tsqueryParamIdx = offsetParamIdx + 1;
+    // buildOrgScopeWhere was given baseParamIndex 11 and, for an org-wide query
+    // (entity_id null), emits exactly one param there — the organization id.
+    const candOrgScope = `(ce.organization_id = $11::text
+            OR EXISTS (SELECT 1 FROM entities cent WHERE cent.id = ANY(ce.entity_ids) AND cent.organization_id = $11::text)
+            OR cc.organization_id = $11::text)`;
+    const branches: string[] = [];
+    if (hasEmbedding) {
+      // ivfflat ANN — the only shape that index serves; pgvector 0.8 iterative
+      // scan applies the org filter + min_similarity floor as it walks the
+      // index, so the LIMIT 200 returns the closest 200 *above* the threshold
+      // rather than the global top 200 (which could all be below it).
+      branches.push(`SELECT emb.event_id AS id
+          FROM event_embeddings emb
+          JOIN events ce ON ce.id = emb.event_id
+          LEFT JOIN connections cc ON cc.id = ce.connection_id
+          WHERE ${candOrgScope}
+            AND (1 - (emb.embedding <=> ${vecParam})) >= ${minSimilarityParam}
+          ORDER BY emb.embedding <=> ${vecParam}
+          LIMIT ${CANDIDATE_VECTOR_LIMIT}`);
+    }
+    if (hasTextCandidates) {
+      // fulltext GIN — the `@@` is index-served; no `ts_rank` here (that would
+      // rebuild the tsvector per matched row over the whole org). The rank is
+      // computed downstream over just the merged candidate set.
+      branches.push(`SELECT ce.id AS id
+          FROM events ce
+          LEFT JOIN connections cc ON cc.id = ce.connection_id
+          WHERE to_tsvector('english', COALESCE(ce.payload_text, '')) @@ to_tsquery('english', $${tsqueryParamIdx})
+            AND ${candOrgScope}
+          LIMIT ${CANDIDATE_VECTOR_LIMIT}`);
+      // trigram GIN — preserves the ILIKE substring match (exact strings, ids).
+      branches.push(`SELECT ce.id AS id
+          FROM events ce
+          LEFT JOIN connections cc ON cc.id = ce.connection_id
+          WHERE ce.payload_text ILIKE '%' || $1 || '%'
+            AND ${candOrgScope}
+          LIMIT ${CANDIDATE_VECTOR_LIMIT}`);
+    }
+    // Each branch has its own ORDER BY/LIMIT and must therefore be
+    // parenthesized for the UNION to parse. `UNION` (not UNION ALL) dedupes
+    // ids that several sources surface — cheap over ≤200 rows per branch.
+    searchCandidatesCteSql = `search_candidates AS (
+        ${branches.map((b) => `(${b})`).join('\n        UNION\n        ')}
+      ),
+      `;
+  }
+
   const querySQL = useDateFeed
     ? `
       WITH RECURSIVE filtered_ids AS (
@@ -1716,15 +1795,16 @@ async function searchContentBySingleQuery(
       ${ctes}
       ${searchFinalSelect}`
     : `
-      WITH RECURSIVE filtered_ids AS (
+      WITH RECURSIVE ${useCandidatePath ? searchCandidatesCteSql : ''}filtered_ids AS (
         SELECT f.id, f.score, f.occurred_at, f.title, f.payload_text, f.embedding
         FROM current_event_records f
+        ${useCandidatePath ? 'JOIN search_candidates sc ON sc.id = f.id' : ''}
         LEFT JOIN connections c ON c.id = f.connection_id
         LEFT JOIN watcher_window_events iwf
           ON iwf.event_id = f.id
           AND ($6::int IS NOT NULL)
           AND iwf.window_id = $6::int
-        WHERE ${searchWhereSQL}
+        WHERE ${useCandidatePath ? standardFiltersSQL : searchWhereSQL}
       ),
       result_set AS (
         SELECT
@@ -1761,8 +1841,31 @@ async function searchContentBySingleQuery(
     ...cursorClause.params,
     ...(useDateFeed ? [fetchLimit] : [limit, effectiveOffset]),
   ];
+  if (hasTextCandidates) {
+    // $tsq for the fulltext candidate branch. null (all-stopword query) →
+    // to_tsquery('english', NULL) → `@@ NULL` → that branch matches nothing.
+    queryParams.push(buildTsqueryString(trimmedQuery));
+  }
 
-  const rawRows = (await sql.unsafe(querySQL, queryParams)) as any[];
+  let rawRows: any[];
+  if (useCandidatePath) {
+    // Backstop: a pathological candidate scan degrades to "no content" (every
+    // caller tolerates an empty list) rather than hanging the request.
+    try {
+      rawRows = (await sql.begin(async (tx: DbClient) => {
+        await tx.unsafe(`SET LOCAL statement_timeout = ${CANDIDATE_QUERY_TIMEOUT_MS}`);
+        return await tx.unsafe(querySQL, queryParams);
+      })) as any[];
+    } catch (err) {
+      logger.warn(
+        { err: err instanceof Error ? err.message : String(err) },
+        '[content-search] candidate query failed; returning empty content'
+      );
+      rawRows = [];
+    }
+  } else {
+    rawRows = (await sql.unsafe(querySQL, queryParams)) as any[];
+  }
   const total = rawRows.length > 0 ? parseInt(String(rawRows[0].total_count ?? '0'), 10) : 0;
   const content = needClassifications
     ? deduplicateWithClassifications(rawRows)
@@ -1781,176 +1884,6 @@ async function searchContentBySingleQuery(
       fetchedCount: rawRows[0]?.cursor_fetched_count,
     }),
   };
-}
-
-// ANN fan-out for the index-driven org-wide path — a few hundred is plenty for
-// any sane content_limit while keeping the ivfflat scan cheap.
-const CANDIDATE_VECTOR_LIMIT = 200;
-// Backstop so a pathological candidate scan can't hang the request. Callers
-// (search_memory) already tolerate an empty content list, so failing fast and
-// degrading to "no content" beats a multi-minute query.
-const CANDIDATE_QUERY_TIMEOUT_MS = 6000;
-
-/**
- * Index-driven org-wide relevance search (vector-primary).
- *
- * The legacy single-query path ORs a text predicate with `embedding <=> $vec >=
- * threshold` in one WHERE; Postgres can't use the fulltext GIN or the ivfflat
- * ANN index for that, so it sequential-scans the org's events — tens of seconds
- * (27–210s on a ~720k-event org), and `searchContentByText` runs it up to 8×.
- *
- * Here the candidates come from the ivfflat ANN index alone
- * (`ORDER BY embedding <=> $vec LIMIT k` — the only shape the index serves,
- * with pgvector 0.8 iterative scan handling the org filter), then ~200 are
- * re-ranked with cosine + a title-weighted `ts_rank` (computed only over that
- * small set). No fulltext-candidate scan — `events` has no stored `tsvector`
- * column, so any fulltext candidate query is the same per-row tsvector rebuild
- * the legacy path suffers; semantic recall covers the recall use case. Only
- * used when an embedding is available; everything else stays on
- * `searchContentBySingleQuery`.
- */
-async function searchContentCandidatesFast(
-  sql: DbClient,
-  queryText: string,
-  options: ContentSearchOptions & { offset?: number },
-  env?: Env
-): Promise<ContentSearchResponse> {
-  const limit = Math.min(options.limit ?? 50, 500);
-  const offset = options.offset ?? 0;
-  const trimmedQuery = queryText.trim();
-  const orgId = options.organization_id;
-  if (!orgId) {
-    return {
-      content: [],
-      total: 0,
-      page: buildPageInfo({ limit, offset, total: 0, returnedCount: 0, useDateFeed: false, cursor: null }),
-    };
-  }
-
-  let queryEmbedding: number[] | null = options.query_embedding?.length
-    ? options.query_embedding
-    : null;
-  if (!queryEmbedding && env?.EMBEDDINGS_SERVICE_URL) {
-    try {
-      const embs = await generateEmbeddings([trimmedQuery], env);
-      queryEmbedding = embs[0] ?? null;
-    } catch (err) {
-      logger.warn(
-        { err: err instanceof Error ? err.message : String(err) },
-        '[content-search] embedding generation failed; fast path returns no content'
-      );
-    }
-  }
-  if (queryEmbedding === null) {
-    // No embedding → nothing the fast path can do (callers gate on an embedding
-    // source; this is the transient-generation-failure case). search_memory
-    // already tolerates an empty content list.
-    return {
-      content: [],
-      total: 0,
-      page: buildPageInfo({ limit, offset, total: 0, returnedCount: 0, useDateFeed: false, cursor: null }),
-    };
-  }
-  const rawMinSim = Number(options.min_similarity ?? 0.3);
-  const minSim = Number.isFinite(rawMinSim) ? Math.max(0, Math.min(1, rawMinSim)) : 0.3;
-  const rawVectorWeight = Number(options.vector_weight ?? 0.6);
-  const vectorWeight = Number.isFinite(rawVectorWeight) ? Math.max(0, Math.min(1, rawVectorWeight)) : 0.6;
-  const textWeight = 1 - vectorWeight;
-
-  // tsquery for the title-weighted re-rank over the ~200 candidate rows.
-  // Computed + sanitized in JS to `^[a-z0-9 |]+$` and inlined as a literal so
-  // it's injection-safe and cheap (no per-row work in the candidate scan).
-  let tsqueryStr = trimmedQuery.length > 0 ? buildTsqueryString(trimmedQuery) : null;
-  if (tsqueryStr && !/^[a-z0-9 |]+$/.test(tsqueryStr)) tsqueryStr = null;
-  const tsqRef = tsqueryStr ? `to_tsquery('english', '${tsqueryStr}')` : null;
-  const richDocF = buildSearchDocumentExpr('f');
-  const textRankF = tsqRef ? `COALESCE(ts_rank_cd(${richDocF}, ${tsqRef}), 0)::float8` : null;
-  const combinedScoreSql = textRankF
-    ? `(v.sim * ${vectorWeight} + ${textRankF} * ${textWeight})`
-    : 'v.sim';
-
-  // Param layout: $1 organization_id, $2 vector literal, $3 minSim.
-  const params: unknown[] = [orgId, toVectorLiteral(queryEmbedding), minSim];
-  const querySql = `
-    WITH vec_cands AS (
-      SELECT emb.event_id AS id, (1 - (emb.embedding <=> $2::vector))::float8 AS sim
-      FROM event_embeddings emb
-      JOIN events e ON e.id = emb.event_id
-      WHERE e.organization_id = $1::text
-      ORDER BY emb.embedding <=> $2::vector
-      LIMIT ${CANDIDATE_VECTOR_LIMIT}
-    )
-    SELECT ${BASE_COLUMNS_SQL},
-      NULL as classifications,
-      f.created_at,
-      v.sim as similarity,
-      ${combinedScoreSql} as combined_score
-    FROM vec_cands v
-    JOIN current_event_records f ON f.id = v.id
-    WHERE f.organization_id = $1::text AND v.sim >= $3::float8
-    ORDER BY combined_score DESC, (f.id % 997) ASC, f.occurred_at DESC, f.id DESC
-    LIMIT ${validateNumericId(limit, 'limit')}`;
-
-  let rows: any[];
-  try {
-    rows = (await sql.begin(async (tx: DbClient) => {
-      await tx.unsafe(`SET LOCAL statement_timeout = ${CANDIDATE_QUERY_TIMEOUT_MS}`);
-      return await tx.unsafe(querySql, params);
-    })) as any[];
-  } catch (err) {
-    logger.warn(
-      { err: err instanceof Error ? err.message : String(err) },
-      '[content-search] fast candidate query failed; returning empty content'
-    );
-    rows = [];
-  }
-  const content = rows as any as ContentSearchResult[];
-  return {
-    content,
-    total: content.length,
-    page: buildPageInfo({
-      limit,
-      offset,
-      total: content.length,
-      returnedCount: content.length,
-      useDateFeed: false,
-      cursor: null,
-    }),
-  };
-}
-
-// The fast path only handles the plain org-wide relevance shape (which is what
-// search_memory recall uses): no entity scope, no classifications, no
-// chronological/date-feed ordering, and none of the extra row filters — those
-// are applied only to the post-candidate set, so allowing them could
-// under-return when the candidate cap is hit. Everything else stays on
-// searchContentBySingleQuery.
-function canUseFastCandidatePath(
-  queryText: string,
-  options: ContentSearchOptions & { offset?: number }
-): boolean {
-  return (
-    queryText.trim().length >= 3 &&
-    options.entity_id == null &&
-    !!options.organization_id &&
-    (options.offset ?? 0) === 0 &&
-    !options.include_classifications &&
-    !(options.classification_filters && options.classification_filters.length > 0) &&
-    !options.classification_source &&
-    !options.connection_ids?.length &&
-    !options.visibility_scope &&
-    options.platform == null &&
-    options.since == null &&
-    options.until == null &&
-    options.engagement_min == null &&
-    options.engagement_max == null &&
-    options.semantic_type == null &&
-    options.interaction_status == null &&
-    options.window_id == null &&
-    options.exclude_watcher_id == null &&
-    options.sort_by !== 'date' &&
-    !isDateFeedMode(options)
-  );
 }
 
 export async function searchContentByText(
@@ -1973,38 +1906,11 @@ export async function searchContentByText(
     return await listContentInternal(sql, options, limit, offset);
   }
 
-  // Org-wide relevance search → index-driven candidate path (no 8× variant
-  // loop; the tsquery already ORs query tokens).
-  // Fast vector-primary path: only when an embedding is available (a precomputed
-  // query_embedding or an embeddings service to generate one) — without one
-  // there's no fast candidate source.
-  const embeddingAvailable = !!options.query_embedding?.length || !!env?.EMBEDDINGS_SERVICE_URL;
-  if (embeddingAvailable && canUseFastCandidatePath(queryText, options)) {
-    return await searchContentCandidatesFast(sql, queryText, options, env);
-  }
-
-  const queryVariants = expandSearchQueries(queryText, { maxVariants: 8 });
-  let lastResult: ContentSearchResponse | null = null;
-
-  for (const variant of queryVariants) {
-    const result = await searchContentBySingleQuery(sql, variant, options, env);
-    if (result.content.length > 0) {
-      if (variant !== queryText.trim()) {
-        logger.info(
-          { originalQuery: queryText.trim(), fallbackQuery: variant },
-          '[content-search] recovered results via fallback query variant'
-        );
-      }
-      return result;
-    }
-    lastResult = result;
-  }
-
-  return (
-    lastResult ?? {
-      content: [],
-      total: 0,
-      page: { limit, offset, has_more: false },
-    }
-  );
+  // One pass through searchContentBySingleQuery. For an org-wide query it takes
+  // the index-driven candidate path internally (ivfflat ANN ∪ fulltext GIN ∪
+  // trigram GIN, merged + re-ranked); entity-scoped queries use the entity-link
+  // join. The old per-variant retry loop is gone — the candidate query's
+  // to_tsquery already ORs the query's tokens, which is what the variants were
+  // approximating.
+  return await searchContentBySingleQuery(sql, queryText, options, env);
 }


### PR DESCRIPTION
## Why

`search_memory` recall (`include_content: true` is the default — the OpenClaw plugin's `autoRecall` calls it before every prompt) was taking **27–210 s** on large orgs. Root cause: `searchContentBySingleQuery` built `filtered_ids` by scanning `current_event_records` behind a `WHERE` that ORed three non-indexable predicates (`payload_text ILIKE '%…%'` OR per-row `to_tsvector(title)||to_tsvector(payload_text) @@ tsquery` OR `embedding <=> $vec >= $minSim`) — Postgres couldn't use the fulltext GIN, the trigram GIN, or the ivfflat ANN, so it sequential-scanned the org's events. Then `searchContentByText` ran that **up to 8×** (one call per `expandSearchQueries` variant). With the OpenClaw plugin's 8 s recall bound, recall always timed out.

## What

One index-driven candidate path, for **org-wide relevance** queries (the `search_memory` shape *and* `get_content`-with-a-query, which defaults `sort_by='score'`): instead of letting `filtered_ids` seq-scan the org's events, pull a few hundred candidate ids from the three indexes that already serve those shapes, then run the **unchanged** filter / score / thread / classification machinery over just that set.

```sql
WITH RECURSIVE search_candidates AS (
  -- ① ivfflat ANN (idx_events_embedding) — min_similarity floor pushed into
  --    the candidate scan so LIMIT 200 returns the closest 200 *above* the
  --    threshold, not the global top 200.
  (SELECT emb.event_id FROM event_embeddings emb
   JOIN events ce ON ce.id = emb.event_id
   LEFT JOIN connections cc ON cc.id = ce.connection_id
   WHERE <buildOrgScopeWhere triple-OR>
     AND (1 - (emb.embedding <=> $vec)) >= $minSim
   ORDER BY emb.embedding <=> $vec LIMIT 200)
  UNION
  -- ② fulltext GIN (idx_events_fulltext) — NO ts_rank here (that was the
  --    trap an earlier WIP commit hit, ~4s per-row tsvector rebuild over
  --    the whole org); rank is computed downstream over ≤600 candidates.
  (SELECT ce.id FROM events ce
   LEFT JOIN connections cc ON cc.id = ce.connection_id
   WHERE to_tsvector('english', COALESCE(ce.payload_text, '')) @@ to_tsquery('english', $tsq)
     AND <triple-OR> LIMIT 200)
  UNION
  -- ③ trigram GIN (idx_events_raw_content_trgm) — preserves the exact-string
  --    / id-search behaviour of the legacy ILIKE branch.
  (SELECT ce.id FROM events ce
   LEFT JOIN connections cc ON cc.id = ce.connection_id
   WHERE ce.payload_text ILIKE '%' || $1 || '%'
     AND <triple-OR> LIMIT 200)
),
filtered_ids AS (
  SELECT f.id, … FROM current_event_records f
  JOIN search_candidates sc ON sc.id = f.id
  LEFT JOIN connections c ON c.id = f.connection_id
  LEFT JOIN watcher_window_events iwf …
  WHERE ${standardFiltersSQL}        -- entity-link, connection_ids, since/until,
)                                    --   window, engagement, semantic_type,
…unchanged result_set / thread_meta  --   interaction_status, exclude-watcher,
…unchanged final_select              --   visibility-scope, org-scope
```

Each candidate branch is **org-scoped via the same `buildOrgScopeWhere` triple-OR** (direct org / entity bridge / connection bridge) — that fixes the codex P1 from the previous vector-only fast path: cross-linked events stamped to org B but tagged with one of caller-org A's entities (pinned by `search-content-org-scope.test.ts`) stay visible. Wrapped in `sql.begin` + `SET LOCAL statement_timeout = 6000`; on trip the catch returns empty content (every caller already tolerates that).

Because the *downstream* filter / score / thread / classification machinery is untouched, this path also serves `get_content` org-wide-with-query (which always sets `include_classifications: true` and so couldn't opt into the previous vector-only fast path).

**Entity-scoped** queries and **date-feed-with-query** intentionally stay on the legacy `WHERE ${searchWhereSQL}` branch — the entity link already pre-trims the scan, and the date feed needs the full match set for its cursor + COUNT. So `searchContentBySingleQuery`, `matchCondition`, `TSQUERY_SQL`, `buildEntityLinkUnion`, the date-feed CTE branch — all stay *used*, not dead.

**Deleted, not left dead:** the 8× `expandSearchQueries` retry loop in `searchContentByText` (the candidate `to_tsquery` already ORs the query's tokens — that's what the variants were approximating), `searchContentCandidatesFast` (~110 lines, the earlier vector-only fast path), `canUseFastCandidatePath` (~25 lines), and the `expandSearchQueries` import in `content-search.ts` (`query-expansion.ts` itself stays — `search.ts:364`'s entity-name fallback still uses it).

**No schema change, no migration, no backfill, no new background job.** All three indexes already exist (`idx_events_embedding` ivfflat, `idx_events_fulltext` GIN, `idx_events_raw_content_trgm` GIN). Net branch diff vs `main`: **+209 / −206** across `content-search.ts` and `search.ts` (`content-search.ts` itself shrinks by 94 lines, +114 / −208).

## Validation

- `bun run typecheck` (workspace-wide `tsc --noEmit`): clean.
- `make build-packages`: clean (all bundles produced).
- vitest against a throwaway `pgvector/pgvector:pg16` docker (the dev `DATABASE_URL` is prod, so it was never touched — the docker DB had migrations applied via `globalSetup`):

  | File | Result |
  | --- | --- |
  | `search-content-org-scope.test.ts` | **6/6** — all six visibility cases, incl. the cross-linked-via-entity-bridge case (codex P1 fix verified) |
  | `search-content-embedding-only.test.ts` | **3/3** — cosine-ranked, no match-all degeneration, listContentInternal fallback |
  | `get-content-visibility.test.ts` | 12/13 — the 1 fail is the pre-existing `view_url toMatch(/^https?:\/\//)` env-config thing (also fails on `main`) |
  | `content-distribution-contract.test.ts` | 2/2 |
  | `delete-content-tombstone.test.ts` | pass |
  | `scheduling-contract.test.ts` | 3/3 |

  Full vitest sweep: **589 pass / 6 fail / 4 skipped** — the 6 failures are all pre-existing and unrelated to content search (3 × `sandbox/run-script-runtime.test.ts` `isolated-vm` not loadable, 2 × `url-builder.test.ts > HOSTED_UI_FALLBACK_ORIGIN`, 1 × the `view_url` test above).
- `EXPLAIN` on the multi-branch candidate query parses and uses per-branch index scans; PR #586's earlier prod `EXPLAIN ANALYZE` already verified the ivfflat ANN branch at ~14.7 ms.

## Follow-ups (not here)

- Move entity-scoped searches onto the candidate path too (push the entity-link 7-branch identity-namespace UNION into the candidate query) — then `searchContentBySingleQuery`'s legacy `matchCondition` branch can go entirely. Today entity-scoped searches don't have the perf problem (the entity link pre-trims the scan).
- Same for the date-feed-with-query case — needs a different shape (no candidate `LIMIT`) because the chronological cursor + `COUNT(*)` want the full match set.
- Wire vitest integration tests into CI (project memory: `vitest CI gap` — 38 files, none run today).
