### PR TITLE
chore(docs): accuracy pass + remove stale Redis references

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@
 - **`packages/agent-worker`**: Agent execution via OpenClaw runtime in `src/openclaw/`. Worker talks only to gateway and agent. No platform knowledge.
 
 ### Module Boundaries
-- Gateway: Connections → `src/connections/`, orchestration → `src/orchestration/`, Slack OAuth routes → `src/routes/public/slack.ts`
+- Gateway: Connections → `src/gateway/connections/`, orchestration → `src/gateway/orchestration/`, Slack OAuth routes → `src/gateway/routes/public/slack.ts`
 - Worker: Platform-agnostic, agent logic isolated to `src/openclaw/`
 - Core: Shared interfaces, utils, types for gateway+worker
 - **Platform isolation**: InteractionService events (e.g. `link-button:created`) carry an explicit `platform` field. Each platform renderer MUST filter on its own platform identity (`platform === "telegram"`, `platform === "slack"`). Never reference another platform's identifier.
@@ -19,7 +19,7 @@
 - When fixing unused-parameter errors, delete the parameter rather than prefixing with `_`.
 
 ### Submodules
-`packages/web` is a submodule of `lobu-ai/lobu-web`. Push the submodule change to a reachable branch first (usually `main`), then bump the pointer in the parent — the parent must never point at an unreachable SHA, or production cloning will fail.
+`packages/web` is a submodule of `lobu-ai/owletto-web`. Push the submodule change to a reachable branch first (usually `main`), then bump the pointer in the parent — the parent must never point at an unreachable SHA, or production cloning will fail.
 
 ### Frontend (web)
 When editing UI under `packages/web`, follow the design rules in @packages/web/DESIGN_GUIDELINES.md — confirmations, surfaces, empty states, selection, forms, page copy, radius, Sheet vs Dialog. Match the existing components and exemplar files referenced there; do not introduce new primitives without updating the guideline in the same PR.
@@ -29,11 +29,11 @@ When editing UI under `packages/web`, follow the design rules in @packages/web/D
 #### Platform
 All chat platforms (Telegram, Slack, Discord, WhatsApp, Teams) run through Chat SDK adapters in `packages/server/src/gateway/connections/`. Connections are created via the `/agents` admin UI or the connections CRUD API — no per-platform env vars. Each connection has a typed config schema (bot token for Telegram, signing secret + bot token for Slack, etc.). Gateway also exposes a public endpoint that triggers an agent run. Settings-page provider order is drag-sortable, with per-provider model selection inline.
 
-**One transport per platform: webhooks via the Chat SDK adapter.** Don't add per-platform alternative transports (Slack Socket Mode, Telegram long-polling, Discord Gateway WebSocket bridges, etc.) or extra runtime SDKs to support them. Local dev for webhook-only platforms uses a tunnel (cloudflared / ngrok / Tailscale Funnel); Lobu Cloud users get a public URL for free. Sticking to the Chat SDK keeps one delivery story, one set of retries, and zero extra dependencies.
+**Webhooks via the Chat SDK adapter are the default transport.** Don't add new per-platform alternative transports (Slack Socket Mode, Discord Gateway WebSocket bridges, etc.) or extra runtime SDKs. The lone exception is Telegram, whose connection config exposes an optional `polling` mode (`mode: "auto" | "webhook" | "polling"`) implemented inside the Chat SDK adapter — still no extra SDK. Local dev for webhook-only platforms uses a tunnel (cloudflared / ngrok / Tailscale Funnel); Lobu Cloud users get a public URL for free. Sticking to the Chat SDK keeps one delivery story, one set of retries, and zero extra dependencies.
 
 #### Orchestration
 - **Embedded-only deployment.** Gateway, workers, embeddings, and the Lobu memory backend run in a single Node process (`lobu run`, or `bun run dev` in the monorepo). Workers spawn as `child_process.spawn` subprocesses on the same host; on Linux the spawn path uses `systemd-run --user --scope` for cgroup limits + IPAddressDeny + capability drops. There is no Docker or Kubernetes deployment manager.
-- Postgres (with pgvector) is the only user-provided external. The Node process connects out via `DATABASE_URL`. Runtime state that previously lived in Redis (queues, chat connection rows, grant cache, MCP proxy sessions) is now in dedicated Postgres tables.
+- Postgres (with pgvector) is the only user-provided external. The Node process connects out via `DATABASE_URL`. Runtime state — queues, chat connection rows, grant cache, MCP proxy sessions — lives in dedicated Postgres tables.
 - Workers are sandboxed and **never see real credentials**. The gateway's `secret-proxy` swaps `lobu_secret_<uuid>` placeholders for real keys at egress; workers receive only the placeholders.
 
 #### MCP

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 OpenClaw is a full agent runtime (~800k LOC) but it's [single-tenant by design](https://x.com/steipete/status/2026092642623201379) — every user shares the same filesystem and bash session. Lobu rewrites only the gateway layer (~40k LOC) to be multi-tenant and keeps OpenClaw's Pi harness untouched inside each worker.
 
-**Embedded mode** uses [just-bash](https://github.com/nicholasgasior/just-bash) + Nix for reproducible packages. Each user gets an isolated virtual filesystem and bash session at ~50MB per instance — tested at 300 concurrent instances on a single machine, no Docker needed.
+**Embedded mode** uses [just-bash](https://www.npmjs.com/package/just-bash) + Nix for reproducible packages. Each user gets an isolated virtual filesystem and bash session at ~50MB per instance — tested at 300 concurrent instances on a single machine, no Docker needed.
 
 Embed OpenClaw-powered agents into your product, or give your team agents without managing a separate instance per person.
 

--- a/benchmarks/memory/README.md
+++ b/benchmarks/memory/README.md
@@ -2,7 +2,7 @@
 
 This folder holds the reproducible memory benchmark harness used to compare Lobu against external memory systems (Mem0, Supermemory, Letta, Zep) on public datasets.
 
-The headline result tables are published in the [main README](../../README.md#benchmarks). This document covers **how to reproduce them**, how the harness is structured, and what caveats matter when interpreting the results.
+The headline result tables are published in the [memory benchmarks guide](../../packages/landing/src/content/docs/guides/memory-benchmarks.md). This document covers **how to reproduce them**, how the harness is structured, and what caveats matter when interpreting the results.
 
 ## Layout
 
@@ -23,7 +23,7 @@ benchmarks/memory/
 └── config.*.json          # Per-scenario run configs
 ```
 
-The TypeScript runner lives at `src/benchmarks/memory/`. Each adapter implements `reset` / `setup` / `ingestScenario` / `retrieve` / `dispose`. Python adapters share a long-lived JSONL-over-stdin protocol so the per-op fork+exec cost stays out of the wall clock.
+The TypeScript runner lives at `packages/server/src/benchmarks/memory/runner.ts`, driven by `scripts/lobu/run-memory-benchmark.ts`. Each adapter implements `reset` / `setup` / `ingestScenario` / `retrieve` / `dispose`. Python adapters share a long-lived JSONL-over-stdin protocol so the per-op fork+exec cost stays out of the wall clock.
 
 ## Methodology guardrails
 
@@ -54,7 +54,7 @@ The Lobu adapter chunks each session by turn at ingest, then reconstructs the fu
 
 ### Prerequisites
 
-- Node.js 20+, pnpm 9+, Docker
+- Bun, Node 22.x–24.x
 - `ZAI_API_KEY` (z.ai, used as the answerer model `glm-5.1`)
 - API keys for every external system you want to include:
   - `MEM0_API_KEY`
@@ -64,37 +64,39 @@ The Lobu adapter chunks each session by turn at ingest, then reconstructs the fu
 
 Public compare/full-QA presets in this folder default to **3 trials**. Retrieval-only smoke configs remain single-trial for speed.
 
+All invocations below use the runner script directly; `bun run lobu:bench:memory` (defined in the root `package.json`) is a shortcut for `bun run scripts/lobu/run-memory-benchmark.ts`.
+
 ### LongMemEval oracle-50, all systems
 
 ```bash
 ZAI_API_KEY=... MEM0_API_KEY=... SUPERMEMORY_API_KEY=... LETTA_API_KEY=... \
-  pnpm benchmark:memory --config benchmarks/memory/config.longmemeval.oracle.50.compare.all.zai.json
+  bun run scripts/lobu/run-memory-benchmark.ts --config benchmarks/memory/config.longmemeval.oracle.50.compare.all.zai.json
 ```
 
 ### LoCoMo-50, three-way (Lobu vs Mem0 vs Supermemory)
 
 ```bash
 ZAI_API_KEY=... MEM0_API_KEY=... SUPERMEMORY_API_KEY=... \
-  pnpm benchmark:memory --config benchmarks/memory/config.locomo.50.compare.top-memory.zai.json
+  bun run scripts/lobu/run-memory-benchmark.ts --config benchmarks/memory/config.locomo.50.compare.top-memory.zai.json
 ```
 
 ### Lobu-only, no external API keys needed
 
 ```bash
 # Retrieval-only (no answerer)
-pnpm benchmark:memory --config benchmarks/memory/config.longmemeval.oracle.50.json
+bun run scripts/lobu/run-memory-benchmark.ts --config benchmarks/memory/config.longmemeval.oracle.50.json
 
 # Full QA with z.ai answerer
-ZAI_API_KEY=... pnpm benchmark:memory --config benchmarks/memory/config.longmemeval.oracle.50.zai.json
-ZAI_API_KEY=... pnpm benchmark:memory --config benchmarks/memory/config.locomo.50.zai.json
+ZAI_API_KEY=... bun run scripts/lobu/run-memory-benchmark.ts --config benchmarks/memory/config.longmemeval.oracle.50.zai.json
+ZAI_API_KEY=... bun run scripts/lobu/run-memory-benchmark.ts --config benchmarks/memory/config.locomo.50.zai.json
 ```
 
 ### Smaller LoCoMo slices (faster iteration)
 
 ```bash
-pnpm benchmark:memory --config benchmarks/memory/config.locomo.5.local.json
-pnpm benchmark:memory --config benchmarks/memory/config.locomo.10.compare.top-memory.zai.json
-pnpm benchmark:memory --config benchmarks/memory/config.locomo.30.local.json
+bun run scripts/lobu/run-memory-benchmark.ts --config benchmarks/memory/config.locomo.5.local.json
+bun run scripts/lobu/run-memory-benchmark.ts --config benchmarks/memory/config.locomo.10.compare.top-memory.zai.json
+bun run scripts/lobu/run-memory-benchmark.ts --config benchmarks/memory/config.locomo.30.local.json
 ```
 
 ## Available configs
@@ -183,4 +185,4 @@ A minimal single-query Lobu fast-path is not part of the published runs.
 
 ## Open levers / next steps
 
-The current weakest categories and the most actionable improvements are tracked in [`docs/memory-benchmark-next-steps.md`](../../docs/memory-benchmark-next-steps.md).
+The current weakest categories and the most actionable improvements are tracked alongside the harness in this folder's configs and the [memory benchmarks guide](../../packages/landing/src/content/docs/guides/memory-benchmarks.md).

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,14 +1,14 @@
 # Releasing
 
-The published packages ship as a synchronized release: `@lobu/core`, `@lobu/worker`, `@lobu/cli`, `@lobu/connector-sdk`, `@lobu/connectors`, `@lobu/connector-worker`, `@lobu/embeddings`, and `@lobu/openclaw-plugin`. The old `@lobu/lobu-*` package names are published as deprecated compatibility redirects to the renamed packages. (The previously published `lobu` unscoped package was retired when its commands moved into `@lobu/cli` as the `lobu memory` namespace.) [release-please](https://github.com/googleapis/release-please) reads conventional commits on `main` and drives versioning; publishing uses npm OIDC trusted publishing (no `NPM_TOKEN`, no OTP).
+The published packages ship as a synchronized release: `@lobu/core`, `@lobu/worker`, `@lobu/cli`, `@lobu/connector-sdk`, `@lobu/connectors`, `@lobu/connector-worker`, `@lobu/embeddings`, and `@lobu/openclaw-plugin`. (The previously published `lobu` unscoped package was retired when its commands moved into `@lobu/cli` as the `lobu memory` namespace.) [release-please](https://github.com/googleapis/release-please) reads conventional commits on `main` and drives versioning; publishing uses npm OIDC trusted publishing (no `NPM_TOKEN`, no OTP).
 
 ## Flow
 
 1. Merge feature PRs into `main` with conventional commit messages.
-2. release-please opens a `chore(release): <version>` PR with bumped `package.json`s and a generated `CHANGELOG.md`.
-3. Merge the release PR (squash). This creates the `v<version>` tag + GitHub release and publishes to npm via `publish-packages.yml`.
+2. release-please opens a `chore(main): release lobu <version>` PR with bumped `package.json`s and a generated `CHANGELOG.md`.
+3. Merge the release PR (squash). This creates the `lobu-v<version>` tag + GitHub release and publishes to npm via `publish-packages.yml`.
 
-Edit the release PR title if you want a specific version (e.g. `3.2.0-beta.1`) — release-please honors it.
+Edit the release PR title if you want a specific version (e.g. `6.2.0-beta.1`) — release-please honors it.
 
 ## Commit prefixes → version bump
 
@@ -30,10 +30,11 @@ BREAKING CHANGE: RuntimeProviderCredentialResolver now returns
 
 ## Adding a new published package
 
-1. `release-please-config.json` — add to `extra-files[]`:
+1. `release-please-config.json` — add to `packages["."].extra-files[]`:
    ```json
    { "type": "json", "path": "packages/<new-pkg>/package.json", "jsonpath": "$.version" }
    ```
+   (`extra-files[]` is also where the synchronized version is propagated to `charts/lobu/Chart.yaml` — both `$.version` and `$.appVersion` are bumped there on every release.)
 2. `scripts/publish-packages.mjs` — add to the `PACKAGES` array (use `transform: rewriteWorkspaceRefs` if it has `workspace:*` deps).
 
 ## Recovery
@@ -46,7 +47,7 @@ BREAKING CHANGE: RuntimeProviderCredentialResolver now returns
 ```bash
 npm deprecate '@lobu/core@<bad-version>' "broken build, use <good-version>"
 ```
-Then land a fix and let release-please cut a patch.
+Then land a fix and let release-please cut a patch (e.g. `6.1.2`).
 
 ## Manual publish fallback
 
@@ -55,11 +56,11 @@ If CI is broken and you need a hotfix:
 ```bash
 npm login --auth-type=web
 node scripts/publish-packages.mjs patch        # bump + build + publish
-node scripts/publish-packages.mjs 3.1.0        # explicit version
+node scripts/publish-packages.mjs 6.2.0        # explicit version
 node scripts/publish-packages.mjs --skip-bump  # publish current version
 ```
 
-After a local publish, land a `chore(release)` commit on `main` so `.release-please-manifest.json` stays in sync.
+After a local publish, land a `chore(main): release lobu <version>` commit on `main` so `.release-please-manifest.json` stays in sync.
 
 ## Verify
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -21,7 +21,7 @@ If your threat model includes hostile code execution, run Lobu inside a stronger
 
 ## What `just-bash` actually is
 
-`just-bash` (`@mariozechner/pi-coding-agent`) is the shell sandbox the worker uses for every shell command an agent issues. It enforces:
+`just-bash` is the shell sandbox the worker uses for every shell command an agent issues (it's a separate dependency from `@mariozechner/pi-coding-agent`, which is the Pi harness). It enforces:
 
 - `maxCommandCount: 50_000`, `maxLoopIterations: 50_000`, `maxCallDepth: 50` — these help against DoS, **not** sandbox escape.
 - A binary allowlist scoped to `/nix/store/` plus a known list (`lobu`, etc.). The allowlist is built at worker spawn from the agent's `nixPackages` config.

--- a/packages/connectors/src/README.md
+++ b/packages/connectors/src/README.md
@@ -465,7 +465,7 @@ Browser connectors use `patchright` (an npm alias for Playwright). The SDK also 
 
 Connector code runs in a worker subprocess with a restricted environment. Key things to know:
 
-- **Minimal env vars**: Only `PATH`, `HOME`, `TMPDIR`, `TZ`, `NODE_ENV`, and `NODE_PATH` are available. No access to the host's env vars.
+- **Minimal env vars**: Only `PATH`, `HOME`, `TMPDIR`, `TZ`, `NODE_ENV`, `NODE_PATH`, and `PLAYWRIGHT_BROWSERS_PATH` are available. No access to the host's env vars.
 - **Secrets via ctx**: API keys and tokens flow through `ctx.credentials` and `ctx.config`, not environment variables. The `env_keys` auth method stores secrets on auth profiles, and the platform injects them into `ctx.config` at sync time.
 - **No filesystem persistence**: Don't write to disk expecting it to survive between syncs. Use `checkpoint` for state.
 
@@ -506,7 +506,7 @@ Connectors can also be installed manually via `client.connections.installConnect
 2. If `compiled_code` is NULL (bundled connectors), it compiles from `connectors/{source_path}` on disk via esbuild
 3. The compiled code is sent to the worker, written to a temp file (`.connector-child-{pid}.mjs`), and loaded via dynamic `import()`
 4. Each sync/action runs in an **isolated child process** with a 10-minute timeout and 512MB memory limit
-5. The child process has a restricted environment — only `PATH`, `HOME`, `TMPDIR`, `TZ`, `NODE_ENV`, and `PLAYWRIGHT_BROWSERS_PATH` are available as env vars
+5. The child process has a restricted environment — only `PATH`, `HOME`, `TMPDIR`, `TZ`, `NODE_ENV`, `NODE_PATH`, and `PLAYWRIGHT_BROWSERS_PATH` are available as env vars
 6. Secrets flow through `ctx.credentials` and `ctx.config`, not environment variables
 
 This means edits to `.ts` files in `connectors/` take effect on the next sync without reinstalling.

--- a/packages/landing/src/content/docs/getting-started/comparison.md
+++ b/packages/landing/src/content/docs/getting-started/comparison.md
@@ -15,7 +15,7 @@ This page compares Lobu against other ways to run agents for multiple users.
 | **Multi-tenant** | Per-user/channel isolation | Single user | Per-thread sandbox | Per-conversation |
 | **Platforms** | Slack, Telegram, WhatsApp, Discord, Teams, Google Chat, REST API | CLI and API | API endpoints (MCP, A2A, Agent Protocol) | API |
 | **Embeddable** | Mount inside Next.js, Express, Hono, Fastify | No | No | No |
-| **Self-hosted** | Single Node process (BYO Postgres) | Single process | LangSmith hosted (self-host option) | Cloud only |
+| **Self-hosted** | Single Node process (bundled PGlite, or BYO Postgres) | Single process | LangSmith hosted (self-host option) | Cloud only |
 | **Model support** | Any provider via config | Any provider | Any LangChain-compatible provider | Anthropic only |
 | **Runtime** | OpenClaw | OpenClaw | LangGraph | Claude |
 | **Network isolation** | Gateway-mediated egress, domain filtering | Host network | Sandbox-level | Platform-managed |
@@ -24,7 +24,7 @@ This page compares Lobu against other ways to run agents for multiple users.
 | **Agent Protocol / A2A** | Not yet | No | Yes | No |
 | **Built-in evals** | YAML eval framework with model comparison | No | No | No |
 | **Memory** | Self-hosted Lobu plugin | Local | LangSmith APIs | Platform-managed |
-| **Scale-to-zero** | Built-in idle timeout | Always running | Managed by LangSmith | Managed |
+| **Worker lifecycle** | Persistent subprocess per channel; reaped on config change / shutdown | Always running | Managed by LangSmith | Managed |
 | **Config format** | `lobu.toml` + IDENTITY/SOUL/USER.md | CLI flags | `deepagents.toml` + AGENTS.md | Dashboard |
 | **License** | Open source | Open source | MIT (harness), proprietary (hosting) | Proprietary |
 
@@ -58,9 +58,9 @@ See the [memory benchmarks methodology](/guides/memory-benchmarks/) for fairness
 
 Lobu runs as a single Node process. Each user/channel gets its own worker subprocess that the gateway spawns on demand.
 
-### Single-process (BYO Postgres)
+### Single-process
 
-Uses [just-bash](https://github.com/nicholasgasior/just-bash) (virtual bash) + **Nix** for reproducible packages. Each user gets an isolated virtual filesystem and bash session at ~50MB memory footprint. Tested at **300 concurrent instances on a single machine**.
+Uses [just-bash](https://www.npmjs.com/package/just-bash) (virtual bash) + **Nix** for reproducible packages. Each user gets an isolated virtual filesystem and bash session at ~50MB memory footprint. Tested at **300 concurrent instances on a single machine**.
 
 - **Subprocess boundary per user** — `child_process.spawn` per session; SIGKILL recoverable.
 - **Workspace persistence** — `./workspaces/{agentId}/` survives gateway restarts.
@@ -119,7 +119,7 @@ If you need a single personal agent for yourself, use OpenClaw directly.
 
 Lobu and OpenClaw are complementary. OpenClaw is the single-user runtime. Lobu is the multi-user backend around it: routing, isolation, credentials, memory, and delivery.
 
-OpenClaw (~800k LOC) was designed as a **single-tenant, single-user system**. Production deployments need multi-tenant isolation, platform routing, credential separation, network control, and scale-to-zero — concerns OpenClaw doesn't have opinions about.
+OpenClaw (~800k LOC) was designed as a **single-tenant, single-user system**. Production deployments need multi-tenant isolation, platform routing, credential separation, and network control — concerns OpenClaw doesn't have opinions about.
 
 | Capability | Lobu | OpenClaw |
 |---|---|---|
@@ -128,8 +128,8 @@ OpenClaw (~800k LOC) was designed as a **single-tenant, single-user system**. Pr
 | Worker isolation | Subprocess + just-bash + (Linux) systemd-run hardening | Runs on host |
 | Secret handling | Gateway proxy injects credentials | Direct env vars |
 | Egress control | Domain allowlists via HTTP proxy | Host network |
-| Scale-to-zero | Built-in idle timeout and wake | Always running |
-| Deployment | Single Node process (BYO Postgres) | Single process |
+| Worker lifecycle | Persistent subprocess per channel | Always running |
+| Deployment | Single Node process (bundled PGlite or BYO Postgres) | Single process |
 
 Inside each Lobu worker, the full OpenClaw runtime runs untouched. Lobu rewrites only the gateway layer (~40k LOC) to be multi-tenant.
 
@@ -180,11 +180,10 @@ Claude Managed Agents is Anthropic's hosted agent platform.
 What "we'll build it ourselves" entails:
 
 - **Sandboxing**: per-user worker lifecycle with workspace persistence
-- **Platform adapters**: Slack Events API, Telegram long-polling, WhatsApp webhooks, each with their own auth flows
+- **Platform adapters**: Slack Events API, Telegram, WhatsApp webhooks, each with their own auth flows
 - **Credential isolation**: proxy layer that injects secrets without exposing them to agent code
 - **Network policy**: domain-filtered egress through a gateway proxy
 - **MCP proxy**: secret injection, OAuth token refresh, and routing for MCP servers
-- **Scale-to-zero**: idle detection, teardown, and wake-on-message
 - **Eval framework**: automated quality testing across models
 - **Admin UI**: per-agent configuration, connection management, status monitoring
 

--- a/packages/landing/src/content/docs/getting-started/index.mdx
+++ b/packages/landing/src/content/docs/getting-started/index.mdx
@@ -63,24 +63,7 @@ Install the Lobu skill into your coding agent so it already understands the proj
 npx skills add lobu-ai/lobu --skill lobu
 ```
 
-The [vercel-labs/skills](https://github.com/vercel-labs/skills) CLI auto-detects [Claude Code](https://claude.ai/claude-code), [Codex](https://openai.com/index/codex/), [OpenCode](https://opencode.ai), Cursor, and OpenClaw, and drops `SKILL.md` in the right directory. Pin one host with `-a <agent>` (e.g. `-a claude-code`) to scope it.
-
-With the skill installed, open your coding agent in the project and start shaping behavior — it already knows how Lobu works. If you'd rather prime it manually, paste this prompt:
-
-```
-I am building a Lobu agent in this repository.
-
-Please:
-1. Read AGENTS.md, lobu.toml, and agents/my-agent/{IDENTITY,SOUL,USER}.md first.
-2. Help me shape the agent behavior by editing those files directly.
-3. Use Lobu skills when they make sense: https://lobu.ai/getting-started/skills/
-4. Suggest any provider, skill, or connection changes needed in lobu.toml.
-5. Keep the project runnable with `npx @lobu/cli@latest run`.
-
-Explain what you change and why.
-```
-
-### What to ask for
+See [Skills](/getting-started/skills/) for which coding agents this supports and how to scope it. With the skill installed, open your coding agent in the project and shape behavior by editing `agents/my-agent/{IDENTITY,SOUL,USER}.md`, `lobu.toml`, and `agents/my-agent/evals/` — then re-run `npx @lobu/cli@latest chat "…"` and `npx @lobu/cli@latest eval` after each change.
 
 | File | What to ask for |
 |------|----------------|
@@ -91,34 +74,16 @@ Explain what you change and why.
 | `agents/my-agent/evals/` | "Write an eval that tests the agent follows the cancellation rule" |
 | `agents/my-agent/skills/` | "Create a custom skill for our internal API" |
 
-After each change, test with:
-
-```bash
-npx @lobu/cli@latest chat "Hello, can you cancel my subscription?"
-npx @lobu/cli@latest eval
-```
-
 ## Configuration
 
-Lobu supports two configuration approaches depending on how you deploy:
+`lobu.toml` plus the files under `agents/<id>/` are the source of truth — agents, providers, enabled skills, MCP servers, network policy, and (optionally) memory. Edit them locally and `lobu run` picks them up immediately.
 
-### CLI
-
-Runtime agent configuration lives in the web app/API. Use the UI for providers, platforms, and skills; use local files for validate/apply workflows:
+To run an agent on **Lobu Cloud**, push the same files up with `lobu apply`:
 
 ```bash
-# Select the target org and inspect remote agents
-npx @lobu/cli@latest org set my-org
-npx @lobu/cli@latest agent list
-
-# Validate/apply local artifacts when you are using a checked-out project
-npx @lobu/cli@latest validate
-npx @lobu/cli@latest apply --org my-org
-
-# Run the embedded app/server locally
-npx @lobu/cli@latest run
+npx @lobu/cli@latest login              # authenticate
+npx @lobu/cli@latest validate           # check lobu.toml + agent files
+npx @lobu/cli@latest apply --org my-org # sync to your Cloud org
 ```
 
-See the [CLI Reference](/reference/cli/) for all available commands.
-
-The web app and CLI use the same org-scoped REST API for runtime management — adding providers, connections, skills, and viewing agent status.
+The Cloud web app and the CLI talk to the same org-scoped REST API, so anything you do in the UI (add providers, connections, skills; view agent status) you can also drive from `lobu.toml` + `lobu apply`. See the [CLI Reference](/reference/cli/) and [`lobu apply`](/reference/lobu-apply/) for the full surface.

--- a/packages/landing/src/content/docs/getting-started/memory.mdx
+++ b/packages/landing/src/content/docs/getting-started/memory.mdx
@@ -8,7 +8,7 @@ import { WatcherTraceCard } from "../../../components/memory/WatcherTraceCard";
 
 Most agent memory systems are flat files scoped to one user. The agent appends notes, then re-scans them every turn to recall context. That works for a personal assistant. It breaks the moment two agents — or a watcher, or another teammate — need to converge on the same fact.
 
-Lobu uses **entity-based memory** through [Lobu](https://app.lobu.ai). Facts attach to typed entities (Company, Project, Member), so any agent in your org reads the same record.
+Lobu's memory layer is **entity-based**: facts attach to typed entities (Company, Project, Member), so any agent in your org reads the same record.
 
 ## Filesystem vs entity memory
 

--- a/packages/landing/src/content/docs/getting-started/skills.mdx
+++ b/packages/landing/src/content/docs/getting-started/skills.mdx
@@ -12,7 +12,7 @@ A **skill** is a reusable capability bundle for an agent. In Lobu, skills can ad
 - system packages
 - network requirements
 
-Lobu still discovers local `SKILL.md` files at runtime. Bundled skills are enabled from the agent settings UI; local skills live in your project so you can commit and customize them.
+Lobu discovers local `SKILL.md` files at runtime. Bundled skills are enabled from the agent settings UI; local skills live in your project so you can commit and customize them.
 
 ## Lobu Starter Skill
 
@@ -78,13 +78,10 @@ See [Tool Policy](/guides/tool-policy/) for that split.
 
 ## Skills Vs Memory
 
-Skills and memory are related but different:
-
 - **Skills** teach the agent how to work and what capabilities to request.
-- **Lobu memory** is the long-term memory and integrations surface.
-- **Lobu** can enable memory through `[memory]` in `lobu.toml`.
+- **Memory** is the long-term, shared knowledge surface — enabled per-project via `[memory]` in [`lobu.toml`](/reference/lobu-toml/).
 
-Installing the Lobu starter skill teaches the agent the workflow; runtime wiring still lives in Lobu configuration. See [Memory](/getting-started/memory/) for that setup.
+Installing the Lobu starter skill teaches the workflow; the memory wiring itself lives in `lobu.toml`. See [Memory](/getting-started/memory/).
 
 ## Read Next
 

--- a/packages/landing/src/content/docs/guides/admin-ui.md
+++ b/packages/landing/src/content/docs/guides/admin-ui.md
@@ -152,6 +152,10 @@ curl http://localhost:8787/api/v1/agents/support/channels \
   -H "Authorization: Bearer $LOBU_API_TOKEN"
 ```
 
+## Platform connections
+
+Platform connections (Telegram, Slack, Discord, WhatsApp, Teams bots) are created and managed either from the `/agents` admin UI or via the `/api/v1/connections` CRUD API — each connection has a typed config schema (bot token for Telegram, signing secret + bot token for Slack, etc.). See the OpenAPI spec at `/api/docs` for the connection endpoints.
+
 ## Interactive API reference
 
 All endpoints are documented in the OpenAPI spec at `/api/docs` on your running gateway. Browse it for request/response schemas and try requests directly.

--- a/packages/landing/src/content/docs/guides/agent-settings.md
+++ b/packages/landing/src/content/docs/guides/agent-settings.md
@@ -7,8 +7,14 @@ Agent settings control behavior of each worker session.
 
 ## What You Can Configure
 
+Two surfaces feed an agent's effective config:
+
+- **Runtime config** — the camelCase keys below, stored per agent and edited through the web UI or the settings API.
+- **`lobu.toml` operator config** — file-first declarations (e.g. `[agents.<id>.tools]`, `[agents.<id>.egress]`, guardrails) applied with `lobu apply`.
+
+Runtime config keys:
+
 - **Provider and model** — `model`, `modelSelection` (auto/pinned), `providerModelPreferences`, `installedProviders`
-- **Allowed/disallowed tools** — configured in `[agents.<id>.tools]` in `lobu.toml`
 - **Skills/plugins and MCP server config** — `skillsConfig`, `mcpServers`, `pluginsConfig`
 - **Permission grants (network domains)** — `networkConfig`
 - **Agent prompts** — `identityMd`, `soulMd`, `userMd`
@@ -16,6 +22,8 @@ Agent settings control behavior of each worker session.
 - **Worker environment** — `nixConfig` for Nix packages
 - **Verbose logging** — `verboseLogging` to show tool calls and reasoning
 - **Template inheritance** — `templateAgentId` for settings fallback from a template agent
+
+Allowed/disallowed tools are part of the `lobu.toml` operator surface — `[agents.<id>.tools]`.
 
 ## How Settings Apply
 
@@ -43,7 +51,7 @@ Memory is pluggable. In file-first projects, the gateway first checks `[memory]`
 | `[memory]` enabled | `@lobu/openclaw-plugin` — the OpenClaw memory plugin for Lobu. It translates OpenClaw memory calls into Lobu MCP requests via the gateway's `/mcp/lobu` proxy. Cross-session, shareable across agents. |
 | `MEMORY_URL` set | Used as the base Lobu MCP endpoint before Lobu scopes it to the org from `[memory]` in `lobu.toml`. Useful for local or custom Lobu deployments. |
 
-`lobu init` now scaffolds the file-first Lobu memory layout for memory-enabled projects:
+`lobu init` scaffolds the file-first Lobu memory layout for memory-enabled projects:
 
 - `[memory]` in `lobu.toml` (org, name, description, models, data)
 - `models/`

--- a/packages/landing/src/content/docs/guides/architecture.mdx
+++ b/packages/landing/src/content/docs/guides/architecture.mdx
@@ -5,7 +5,7 @@ description: End-to-end request flow across gateway, worker, tools, and platform
 
 import { ArchitectureDiagram } from "../../../components/ArchitectureDiagram";
 
-Lobu runs as a gateway + worker architecture.
+Lobu is embedded-only: the gateway, agent workers, the embeddings model, and the Lobu memory backend all run inside **one Node process** (`lobu run`, or `make dev` / `bun run dev` in the monorepo). Workers are not separate services — the gateway spawns each one as a `child_process.spawn` subprocess on the same host (wrapped in a `systemd-run --user --scope` on Linux for cgroup limits and capability drops). There is no Docker or Kubernetes deployment manager and no per-conversation container.
 
 <ArchitectureDiagram client:load />
 
@@ -13,41 +13,24 @@ Lobu runs as a gateway + worker architecture.
 
 1. User sends a message from Slack, Telegram, WhatsApp, or API.
 2. Gateway receives it, resolves agent settings, and routes a job.
-3. A worker executes the prompt using OpenClaw runtime.
+3. A worker subprocess executes the prompt using the OpenClaw runtime.
 4. Worker uses tools/MCP through gateway-controlled paths.
 5. Gateway streams output back to the platform thread.
 
 ## Runtime Boundaries
 
-- **Gateway**: orchestration, OAuth, secrets, domain policy, routing.
-- **Worker**: model execution, tools, workspace state.
-- **Postgres**: queue (`runs` table), agent metadata, settings, grants, secrets, chat connection rows, sliding-window history, OAuth state, rate limits, MCP proxy sessions.
+- **Gateway**: orchestration, OAuth, secrets, domain policy, routing — all in the host Node process.
+- **Worker**: model execution, tools, workspace state — a sandboxed subprocess that never sees real credentials.
+- **Postgres (with pgvector)**: the only external dependency Lobu ever needs. Holds the run queue, agent settings, grants, secrets, chat history, and MCP proxy sessions. Scaffolded projects (`lobu init` / `lobu run`) default to an **in-process PGlite** database, so `DATABASE_URL` is optional there; only the monorepo `make dev` requires an external Postgres. There is no Redis anywhere.
 
 ## Persistent Memory
 
-In file-first projects, Lobu resolves persistent memory from `[memory]` in `lobu.toml`.
+Memory is pluggable per agent. In file-first projects the gateway resolves the default memory plugin from `[memory]` in `lobu.toml`: when enabled it wires `@lobu/openclaw-plugin` (OpenClaw memory calls become Lobu MCP requests through the gateway proxy — cross-session, shared across agents); otherwise it uses `@openclaw/native-memory` (files in the worker's local workspace — short-term, not shared). `MEMORY_URL` is an optional base-endpoint override for custom Lobu deployments.
 
-- **`[memory]` enabled**: Lobu derives a Lobu MCP endpoint and uses `@lobu/openclaw-plugin`, falling back to native memory if the plugin is unavailable.
-- **`MEMORY_URL`**: still supported as an optional base-endpoint override for local or custom Lobu deployments.
-- **No Lobu config resolved**: uses `@openclaw/native-memory`, which is effectively filesystem-backed short-term memory inside the agent's local workspace.
-
-Memory plugins are configurable per agent through `pluginsConfig` in agent settings. The split is intentional:
-
-- **Filesystem** is per channel or user space — the agent's working area for artifacts such as PDFs, images, scripts, CSVs, and temporary outputs.
-- **Lobu** is long-term organizational memory. Agents write durable facts into entities so other sessions, users, and agents can query and reuse that knowledge later.
-
-### How It Works
-
-1. Gateway resolves an effective Lobu endpoint from `[memory]` (and optional `MEMORY_URL` override), then selects the default memory plugin and sets it in `agentDefaults.pluginsConfig`.
-2. Worker fetches session context from gateway and passes `pluginsConfig` into OpenClaw runtime startup.
-3. OpenClaw loads enabled plugins for that agent session.
-4. If memory is set to `@lobu/openclaw-plugin`, that plugin converts OpenClaw memory reads/writes into Lobu MCP calls through the gateway proxy.
-5. The memory plugin handles persistent memory operations so context can be reused across future runs.
-
-In short: local filesystem for short-term working state; Lobu for long-term shared knowledge.
+See [Agent Settings → Memory Plugins](/guides/agent-settings/) for the full table, per-agent overrides, and the `pluginsConfig` schema.
 
 ## Security-Critical Path
 
-- Workers do not directly own global provider secrets.
-- Outbound access is controlled via gateway proxy and domain policy.
-- MCP credentials are resolved by the gateway proxy. Integration auth is handled by Lobu.
+- Workers never see real credentials. They receive `lobu_secret_<uuid>` placeholders; the gateway's secret-proxy swaps in the real keys at egress.
+- Outbound access is controlled via the gateway HTTP proxy and domain policy.
+- MCP credentials are resolved by the gateway proxy. Third-party integration OAuth (GitHub, Google, Linear, etc.) lives in Lobu MCP servers — workers never hold those tokens.

--- a/packages/landing/src/content/docs/guides/evals.md
+++ b/packages/landing/src/content/docs/guides/evals.md
@@ -15,7 +15,7 @@ npx @lobu/cli@latest eval
 npx @lobu/cli@latest eval ping
 
 # Run with a different model
-npx @lobu/cli@latest eval --model anthropic/claude-sonnet-4
+npx @lobu/cli@latest eval --model claude/sonnet-4-5
 
 # CI mode (JSON output, exit 1 on failure)
 npx @lobu/cli@latest eval --ci --output results.json
@@ -190,7 +190,7 @@ When a rubric is present, its score is weighted 50% alongside assertion scores (
 |------|-------------|
 | `-a, --agent <id>` | Agent ID (defaults to first in `lobu.toml`) |
 | `-g, --gateway <url>` | Gateway URL (default: from `.env` or `http://localhost:8787`) |
-| `-m, --model <model>` | Model to evaluate (e.g., `anthropic/claude-sonnet-4`) |
+| `-m, --model <model>` | Model to evaluate (e.g., `claude/sonnet-4-5`) |
 | `--trials <n>` | Override trial count for all evals |
 | `--ci` | CI mode: JSON output, exit code 1 on any failure |
 | `--output <file>` | Write results to a JSON file |

--- a/packages/landing/src/content/docs/guides/mcp-proxy.md
+++ b/packages/landing/src/content/docs/guides/mcp-proxy.md
@@ -21,10 +21,10 @@ Workers call `tools/list` and `tools/call` — credential handling is invisible.
 
 MCP servers come from two sources, merged per agent:
 
-1. **Agent settings + local skills** — MCP servers come from per-agent settings and local `SKILL.md` files.
-2. **Per-agent settings** — MCPs added through the settings page or agent-driven install.
+1. **Per-agent settings + local skills** — MCPs added through the settings page or an agent-driven install, plus any declared in local `SKILL.md` files.
+2. **Global MCPs** — servers registered with the gateway at boot time, available to every agent.
 
-Global MCPs take precedence when IDs collide.
+When an ID collides, the **per-agent definition overrides the global one** — global MCPs are the fallback.
 
 ## Authentication methods
 
@@ -36,21 +36,22 @@ There are three ways an MCP server can authenticate:
 | **Device-code OAuth** | `oauth` on the MCP server | Per-user OAuth — each user authenticates in their browser |
 | **Lobu-managed** | N/A (Lobu handles internally) | Third-party APIs (GitHub, Google, Linear, etc.) |
 
+Each MCP server is configured under `[agents.<id>.skills.mcp.<name>]` in [`lobu.toml`](/reference/lobu-toml/), under `mcpServers.<name>` in a skill's [`SKILL.md`](/reference/skill-md/) frontmatter, or in the agent's settings. The JSON snippets below show the fields a single server config accepts:
+
+### No auth
+
+```json
+{ "id": "my-mcp", "name": "My MCP", "url": "https://mcp.example.com", "type": "sse" }
+```
+
 ### Static headers
 
 For MCP servers that use a shared API key or service token. The header value supports `${env:VAR_NAME}` substitution so secrets stay in environment variables.
 
 ```json
 {
-  "id": "my-mcp",
-  "mcpServers": [{
-    "id": "my-mcp",
-    "url": "https://mcp.example.com",
-    "type": "sse",
-    "headers": {
-      "Authorization": "Bearer ${env:MY_MCP_TOKEN}"
-    }
-  }]
+  "id": "my-mcp", "name": "My MCP", "url": "https://mcp.example.com", "type": "sse",
+  "headers": { "Authorization": "Bearer ${env:MY_MCP_TOKEN}" }
 }
 ```
 
@@ -59,65 +60,6 @@ No user interaction needed. The gateway injects the header on every request.
 ### Device-code OAuth (per-user auth)
 
 For MCP servers that implement the [OAuth 2.0 Device Authorization Grant](https://datatracker.ietf.org/doc/html/rfc8628). Each user authenticates individually by clicking a link and logging in via their browser.
-
-#### How it works
-
-```
-User (chat)          Worker              Gateway              MCP Server (OAuth)
-    |                   |                   |                       |
-    |  "use tool X"     |                   |                       |
-    |------------------>|                   |                       |
-    |                   |  tools/call X     |                       |
-    |                   |------------------>|                       |
-    |                   |                   |  tools/call X         |
-    |                   |                   |---------------------->|
-    |                   |                   |  401 Unauthorized     |
-    |                   |                   |<---------------------|
-    |                   |                   |                       |
-    |                   |                   |  POST /oauth/register |
-    |                   |                   |---------------------->|
-    |                   |                   |  { client_id }        |
-    |                   |                   |<---------------------|
-    |                   |                   |                       |
-    |                   |                   |  POST /oauth/device_authorization
-    |                   |                   |---------------------->|
-    |                   |                   |  { device_code,       |
-    |                   |                   |    user_code,         |
-    |                   |                   |    verification_uri } |
-    |                   |                   |<---------------------|
-    |                   |                   |                       |
-    |                   |  login_required   |                       |
-    |                   |  + link + code    |                       |
-    |                   |<------------------|                       |
-    |  "Click this link |                   |                       |
-    |   and enter code  |                   |                       |
-    |   ABCD-1234"      |                   |                       |
-    |<------------------|                   |                       |
-    |                   |                   |                       |
-    |  (user clicks link, logs in via browser)                     |
-    |                   |                   |                       |
-    |  "done, try again"|                   |                       |
-    |------------------>|                   |                       |
-    |                   |  tools/call X     |                       |
-    |                   |------------------>|                       |
-    |                   |                   |  poll device_code     |
-    |                   |                   |---------------------->|
-    |                   |                   |  { access_token,      |
-    |                   |                   |    refresh_token }    |
-    |                   |                   |<---------------------|
-    |                   |                   |                       |
-    |                   |                   |  (store credential)   |
-    |                   |                   |                       |
-    |                   |                   |  tools/call X + token |
-    |                   |                   |---------------------->|
-    |                   |                   |  { result }           |
-    |                   |                   |<---------------------|
-    |                   |  { result }       |                       |
-    |                   |<------------------|                       |
-    |  "Here's the      |                   |                       |
-    |   result..."      |                   |                       |
-    |<------------------|                   |                       |
-```
 
 #### Step by step
 
@@ -148,7 +90,16 @@ User (chat)          Worker              Gateway              MCP Server (OAuth)
 
 #### Configuration
 
-By default, the gateway auto-derives OAuth endpoints from the MCP server's URL origin:
+By default, the gateway auto-derives OAuth endpoints from the MCP server's URL origin — so the minimal config is just an empty `oauth` object:
+
+```json
+{
+  "id": "my-mcp", "name": "My MCP", "url": "https://mcp.example.com", "type": "sse",
+  "oauth": {}
+}
+```
+
+The auto-derived endpoints are:
 
 - Registration: `{origin}/oauth/register`
 - Device authorization: `{origin}/oauth/device_authorization`
@@ -208,54 +159,3 @@ MCP sessions (via `Mcp-Session-Id` header) are tracked in Postgres (`mcp_proxy_s
 ## Tool approval
 
 MCP tools can declare [annotations](https://modelcontextprotocol.io/docs/concepts/tool-annotations) indicating whether they are destructive or have side effects. The gateway checks these annotations and may require explicit user approval before executing a tool call. Grants are stored per agent and checked on each call.
-
-## Configuration reference
-
-### Adding an MCP via local skills or agent settings
-
-Skills-registry entries wrap one or more MCP server definitions:
-
-```json
-{
-  "id": "my-mcp",
-  "name": "My MCP Server",
-  "description": "What this MCP does",
-  "mcpServers": [ /* one of the server configs below */ ]
-}
-```
-
-The inner `mcpServers[]` entry varies by auth mode:
-
-**No auth**
-```json
-{ "id": "my-mcp", "name": "My MCP", "url": "https://mcp.example.com", "type": "sse" }
-```
-
-**Static auth headers** (`${env:VAR}` substitution)
-```json
-{
-  "id": "my-mcp", "name": "My MCP", "url": "https://mcp.example.com", "type": "sse",
-  "headers": { "Authorization": "Bearer ${env:MY_MCP_TOKEN}" }
-}
-```
-
-**Per-user OAuth, auto-derived endpoints**
-```json
-{
-  "id": "my-mcp", "name": "My MCP", "url": "https://mcp.example.com", "type": "sse",
-  "oauth": {}
-}
-```
-
-**Per-user OAuth, pre-registered client or custom endpoints**
-```json
-{
-  "id": "my-mcp", "name": "My MCP", "url": "https://mcp.example.com", "type": "sse",
-  "oauth": {
-    "clientId": "my-pre-registered-client",
-    "tokenUrl": "https://auth.example.com/oauth/token",
-    "deviceAuthorizationUrl": "https://auth.example.com/oauth/device_authorization",
-    "scopes": ["read", "write"]
-  }
-}
-```

--- a/packages/landing/src/content/docs/guides/memory-benchmarks.md
+++ b/packages/landing/src/content/docs/guides/memory-benchmarks.md
@@ -47,45 +47,47 @@ Latency is **retrieval-only latency**, not end-to-end wall clock. It is not full
 
 ## Reproducing the results
 
-The full harness lives in the [`lobu` repo](https://github.com/lobu-ai/lobu) under [`benchmarks/memory/`](https://github.com/lobu-ai/lobu/tree/main/benchmarks/memory). The TypeScript runner is at `src/benchmarks/memory/`. External systems are integrated as long-lived Python adapter subprocesses framed over JSONL-on-stdin, which avoids per-op fork/exec cost.
+The full harness lives in the [`lobu` repo](https://github.com/lobu-ai/lobu) under [`benchmarks/memory/`](https://github.com/lobu-ai/lobu/tree/main/benchmarks/memory). The TypeScript runner is at `packages/server/src/benchmarks/memory/runner.ts`, driven by `scripts/lobu/run-memory-benchmark.ts` (root `package.json` exposes it as `bun run lobu:bench:memory`). External systems are integrated as long-lived Python adapter subprocesses framed over JSONL-on-stdin, which avoids per-op fork/exec cost.
 
 ### Prerequisites
 
-- Node.js 20+, pnpm 9+, Docker
+- Bun and Node.js 22.x–24.x
 - `ZAI_API_KEY` (z.ai, used as the answerer model `glm-5.1`)
 - API keys for any external systems you want to include: `MEM0_API_KEY`, `SUPERMEMORY_API_KEY`, `LETTA_API_KEY`, `ZEP_API_KEY`
+
+Run the harness with `bun run scripts/lobu/run-memory-benchmark.ts --config <path>` (or the shortcut `bun run lobu:bench:memory --config <path>`).
 
 ### LongMemEval oracle-50, all systems
 
 ```bash
 ZAI_API_KEY=... MEM0_API_KEY=... SUPERMEMORY_API_KEY=... LETTA_API_KEY=... \
-  pnpm benchmark:memory --config benchmarks/memory/config.longmemeval.oracle.50.compare.all.zai.json
+  bun run scripts/lobu/run-memory-benchmark.ts --config benchmarks/memory/config.longmemeval.oracle.50.compare.all.zai.json
 ```
 
 ### LoCoMo-50, three-way (Lobu vs Mem0 vs Supermemory)
 
 ```bash
 ZAI_API_KEY=... MEM0_API_KEY=... SUPERMEMORY_API_KEY=... \
-  pnpm benchmark:memory --config benchmarks/memory/config.locomo.50.compare.top-memory.zai.json
+  bun run scripts/lobu/run-memory-benchmark.ts --config benchmarks/memory/config.locomo.50.compare.top-memory.zai.json
 ```
 
 ### Lobu-only, no external API keys
 
 ```bash
 # Retrieval-only (no answerer)
-pnpm benchmark:memory --config benchmarks/memory/config.longmemeval.oracle.50.json
+bun run scripts/lobu/run-memory-benchmark.ts --config benchmarks/memory/config.longmemeval.oracle.50.json
 
 # Full QA with z.ai answerer
-ZAI_API_KEY=... pnpm benchmark:memory --config benchmarks/memory/config.longmemeval.oracle.50.zai.json
-ZAI_API_KEY=... pnpm benchmark:memory --config benchmarks/memory/config.locomo.50.zai.json
+ZAI_API_KEY=... bun run scripts/lobu/run-memory-benchmark.ts --config benchmarks/memory/config.longmemeval.oracle.50.zai.json
+ZAI_API_KEY=... bun run scripts/lobu/run-memory-benchmark.ts --config benchmarks/memory/config.locomo.50.zai.json
 ```
 
 ### Smaller LoCoMo slices
 
 ```bash
-pnpm benchmark:memory --config benchmarks/memory/config.locomo.5.local.json
-pnpm benchmark:memory --config benchmarks/memory/config.locomo.10.compare.top-memory.zai.json
-pnpm benchmark:memory --config benchmarks/memory/config.locomo.30.local.json
+bun run scripts/lobu/run-memory-benchmark.ts --config benchmarks/memory/config.locomo.5.local.json
+bun run scripts/lobu/run-memory-benchmark.ts --config benchmarks/memory/config.locomo.10.compare.top-memory.zai.json
+bun run scripts/lobu/run-memory-benchmark.ts --config benchmarks/memory/config.locomo.30.local.json
 ```
 
 A complete table of available configs is documented in [`benchmarks/memory/README.md`](https://github.com/lobu-ai/lobu/blob/main/benchmarks/memory/README.md#available-configs).

--- a/packages/landing/src/content/docs/guides/observability.md
+++ b/packages/landing/src/content/docs/guides/observability.md
@@ -17,14 +17,13 @@ Each incoming message creates a root span that propagates through the full reque
 
 1. **message_received** — gateway ingests message from API or platform (Slack, Telegram, etc.)
 2. **queue_processing** — message consumer picks up the job
-3. **worker_creation** — gateway spawns the worker subprocess
-4. **job_received** — worker receives the job
-5. **exec_execution** — sandbox command execution (if applicable)
-6. **agent_execution** — agent runs the prompt
+3. **job_received** — worker receives the job
+4. **exec_execution** — sandbox command execution (if applicable)
+5. **agent_execution** — agent runs the prompt
 
 **Response path (worker → platform):**
 
-8. **response_delivery** — gateway receives worker response and routes to platform renderer
+6. **response_delivery** — gateway receives worker response and routes to platform renderer
 
 Spans are linked via W3C `traceparent` headers propagated through the queue, so a single trace ID connects the full round-trip from message ingestion through agent execution to response delivery. All entry points (API, Slack, Telegram, Discord, etc.) create root spans.
 
@@ -50,7 +49,7 @@ Lobu doesn't bundle observability infrastructure. Run Tempo and Grafana however 
 For a minimal local stack:
 
 ```bash
-docker run -d --name tempo -p 4318:4318 -p 3200:3200 \
+docker run -d --name tempo -p 4317:4317 -p 3200:3200 \
   -v "$PWD/tempo.yaml:/etc/tempo.yaml" -v tempo-data:/var/tempo \
   grafana/tempo:latest -config.file=/etc/tempo.yaml
 
@@ -59,7 +58,7 @@ docker run -d --name grafana -p 3001:3000 \
   -v grafana-data:/var/lib/grafana grafana/grafana:latest
 ```
 
-Minimal `tempo.yaml`:
+Minimal `tempo.yaml` — Lobu's exporter speaks OTLP **gRPC**, so enable the `grpc` receiver (port 4317):
 
 ```yaml
 server:
@@ -69,8 +68,8 @@ distributor:
   receivers:
     otlp:
       protocols:
-        http:
-          endpoint: "0.0.0.0:4318"
+        grpc:
+          endpoint: "0.0.0.0:4317"
 
 storage:
   trace:

--- a/packages/landing/src/content/docs/guides/sync-from-github.md
+++ b/packages/landing/src/content/docs/guides/sync-from-github.md
@@ -10,7 +10,7 @@ There is no Lobu-side sync feature. The repo is the source of truth and CI is th
 ## What you need
 
 1. A git repo with a `lobu.toml` at the root (or in a subdirectory).
-2. A `LOBU_TOKEN` secret in the repo (`Settings → Secrets and variables → Actions`). Mint one with `lobu auth tokens create --scope apply` from a logged-in shell.
+2. A `LOBU_TOKEN` secret in the repo (`Settings → Secrets and variables → Actions`). Mint one with `lobu token create` from a logged-in shell (it defaults to the `mcp:read mcp:write` scope, which `lobu apply` uses).
 3. Any provider keys your agents reference (`ANTHROPIC_API_KEY`, etc.) added as repo secrets too — `lobu apply` reads them via `$VAR` interpolation in `lobu.toml`.
 
 ## Drop-in workflow
@@ -108,7 +108,7 @@ Stage on push-to-main, prod on tag, prod-on-approval — all standard Actions pa
 ## What `lobu apply` will not do
 
 - It will not edit secrets in your provider accounts. `$VAR` references are resolved at apply time from the runner's environment; the values never leave the runner.
-- It will not import existing cloud-side agents into your repo. If you've been editing in the admin UI and want to flip to git-managed, run `lobu pull` (planned) or hand-write `lobu.toml` against the current state.
+- It will not import existing cloud-side agents into your repo. If you've been editing in the admin UI and want to flip to git-managed, hand-write `lobu.toml` against the current state. (A `lobu pull` to scaffold this automatically is not yet implemented.)
 - It will not silently overwrite manual UI edits without showing the diff. Every apply prints the plan; `--dry-run` lets you preview without converging.
 
 ## Drift between UI and git

--- a/packages/landing/src/content/docs/guides/testing.md
+++ b/packages/landing/src/content/docs/guides/testing.md
@@ -99,7 +99,8 @@ TEST_PLATFORM=whatsapp TEST_CHANNEL=+1234567890 ./scripts/test-bot.sh "Hello"
 | Variable | Description |
 |----------|-------------|
 | `TEST_PLATFORM` | Force platform: `telegram`, `slack`, `whatsapp` (auto-detected if unset) |
-| `TEST_CHANNEL` | Channel/chat ID for the target platform |
+| `TEST_CHANNEL` | Channel/chat ID for the target platform (generic; overrides the per-platform fallbacks below) |
+| `QA_SLACK_CHANNEL` | Slack channel ID (fallback for Slack when `TEST_CHANNEL` is unset) |
 | `TEST_TIMEOUT` | Response timeout in seconds (default: 120) |
 | `TEST_AGENT_ID` | Agent ID to test (default: `test-{platform}`) |
 | `GATEWAY_URL` | Gateway URL (default: `http://localhost:8787`) |
@@ -176,11 +177,11 @@ psql "$DATABASE_URL" -c \
 For automated quality checks, use the `eval` command:
 
 ```bash
-npx @lobu/cli@latest eval                           # run all evals
-npx @lobu/cli@latest eval basic-qa                  # run a specific eval
-npx @lobu/cli@latest eval --model claude/sonnet     # eval with a specific model
+npx @lobu/cli@latest eval                              # run all evals
+npx @lobu/cli@latest eval basic-qa                     # run a specific eval
+npx @lobu/cli@latest eval --model claude/sonnet        # eval with a specific model
 npx @lobu/cli@latest eval --list                       # list available evals
-npx @lobu/cli@latest eval --ci --output results.json  # CI mode
+npx @lobu/cli@latest eval --ci --output results.json   # CI mode
 ```
 
 Eval files live in the agent directory and define test cases with expected outcomes. Use `--ci` for non-zero exit codes on failure in CI/CD pipelines.

--- a/packages/landing/src/content/docs/guides/troubleshooting.md
+++ b/packages/landing/src/content/docs/guides/troubleshooting.md
@@ -3,7 +3,7 @@ title: Troubleshooting
 description: Common issues and how to fix them.
 ---
 
-Lobu boots as a single Node process (`lobu run` / `node packages/server/dist/server.bundle.mjs`). Postgres (with pgvector) is the only user-provided external, reached via `DATABASE_URL`. Worker subprocesses are spawned by the gateway's `EmbeddedDeploymentManager`.
+Lobu boots as a single Node process: `lobu run`. A scaffolded project defaults to an **in-process PGlite** database (entry `start-local.bundle.mjs`), so `DATABASE_URL` is optional — set it only when you want an external Postgres (with pgvector), in which case the entry is `server.bundle.mjs`. The monorepo `make dev` always requires `DATABASE_URL`. Worker subprocesses are spawned by the gateway's `EmbeddedDeploymentManager`. There is no Redis.
 
 ## Worker won't start
 
@@ -21,7 +21,8 @@ make clean-workers   # in the monorepo
 
 # Common causes:
 # - Port 8787 already in use → Change GATEWAY_PORT or PORT in .env
-# - DATABASE_URL not reachable → see "Agent not responding" below
+# - DATABASE_URL set but not reachable → see "Agent not responding" below
+#   (with the default PGlite backend there's no DATABASE_URL to misconfigure)
 # - Invalid lobu.toml → npx @lobu/cli@latest validate
 ```
 
@@ -31,7 +32,8 @@ make clean-workers   # in the monorepo
 # Check if Lobu is running
 curl http://localhost:8787/health
 
-# Check Postgres connection
+# If you've configured an external Postgres, check the connection
+# (skip this with the default in-process PGlite backend)
 psql "$DATABASE_URL" -c 'select 1'
 
 # Clear stale chat history (for stuck conversations).
@@ -101,8 +103,9 @@ curl -v http://localhost:8118
 ## Out of memory / disk space
 
 ```bash
-# Check Node process memory
-ps -o pid,rss,command -p "$(pgrep -f 'server/dist/server.bundle.mjs')"
+# Check Node process memory (the entry is server.bundle.mjs with an external
+# Postgres, or start-local.bundle.mjs with the default PGlite backend)
+ps -o pid,rss,command -p "$(pgrep -f '(server|start-local)\.bundle\.mjs')"
 
 # Workspaces accumulate per agent under ./workspaces/
 # Clear stale ones if disk is filling up:
@@ -136,6 +139,8 @@ npx @lobu/cli@latest memory health
 ```
 
 ## Postgres not reachable
+
+Only relevant if you've configured an external Postgres via `DATABASE_URL` — the default scaffolded backend is in-process PGlite and has nothing to connect to.
 
 ```bash
 # Verify DATABASE_URL in .env

--- a/packages/landing/src/content/docs/platforms/discord.mdx
+++ b/packages/landing/src/content/docs/platforms/discord.mdx
@@ -16,7 +16,7 @@ Under the hood, Lobu uses the Chat SDK Discord adapter to handle DMs and server 
 1. Create a Discord application at the [Discord Developer Portal](https://discord.com/developers/applications).
 2. Under **Bot**, create a bot and copy the **bot token**.
 3. Copy the **Application ID** and **Public Key** from the General Information page.
-4. Under **OAuth2 → URL Generator**, select the `bot` scope with `Send Messages`, `Read Message History`, and `Use Slash Commands` permissions. Use the generated URL to invite the bot to your server.
+4. Under **OAuth2 → URL Generator**, select the `bot` scope plus message-send, read-history, and slash-command permissions. Use the generated URL to invite the bot to your server.
 5. Use Agents → Platforms in the web app to add Discord to your agent, or run `lobu init` to scaffold a local project and pick Discord in the wizard.
 
 
@@ -28,7 +28,7 @@ Under the hood, Lobu uses the Chat SDK Discord adapter to handle DMs and server 
 
 - **Direct messages** and **server channel mentions** trigger the agent.
 - **Role-based triggers** — configure specific roles that activate the agent beyond direct mentions.
-- **Streaming responses** with throttled message edits (updates every 2s).
+- **Streaming responses** with throttled message edits.
 - **Markdown formatting** — agent responses render as Discord-flavored markdown.
 - **Interactive elements** — buttons and cards for user prompts, permission grants, and configuration.
 - **Access control** — restrict which users or groups can interact with the agent.

--- a/packages/landing/src/content/docs/platforms/rest-api.md
+++ b/packages/landing/src/content/docs/platforms/rest-api.md
@@ -28,7 +28,19 @@ curl -X POST http://localhost:8787/api/v1/agents/{agentId}/messages \
   -H "Content-Type: application/json" \
   -d '{
     "platform": "api",
-    "channel": "test",
+    "content": "Hello!"
+  }'
+```
+
+To route the message into a Slack workspace instead, set `platform` to `slack` and include a `slack` routing object:
+
+```bash
+curl -X POST http://localhost:8787/api/v1/agents/{agentId}/messages \
+  -H "Authorization: Bearer $LOBU_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "platform": "slack",
+    "slack": { "channel": "C0123456789", "thread": "1700000000.000100" },
     "content": "Hello!"
   }'
 ```

--- a/packages/landing/src/content/docs/platforms/slack.mdx
+++ b/packages/landing/src/content/docs/platforms/slack.mdx
@@ -12,40 +12,36 @@ Lobu's Slack adapter supports assistant threads, rich UI, and interactive workfl
 
 ## Setup
 
-### Single-workspace setup
+Lobu supports two Slack installation models:
+
+- **Single-workspace connection** — for self-hosted deployments. You create your own Slack app, install it to one workspace, then configure Lobu with the **Signing Secret** and **Bot Token**.
+- **OAuth / multi-workspace distribution** — for shared deployments. Users install a shared Slack app through an install link, Slack redirects back to Lobu, and Lobu creates or updates one Slack connection per workspace. Incoming events are routed by Slack `team_id`, so each installed workspace is isolated behind its own Lobu connection even when many workspaces share the same app.
+
+### Single-workspace connection
 
 1. Create a Slack app at [api.slack.com/apps](https://api.slack.com/apps) and install it to your workspace.
 2. Copy the **Signing Secret** and **Bot Token** (`xoxb-...`) from the app settings.
 3. Use Agents → Platforms in the web app to add Slack to your agent, or run `lobu init` to scaffold a local project and pick Slack in the wizard.
-4. Start the stack with `lobu run -d` — the bot is now live in your Slack workspace.
-
-## Installation Modes
-
-Lobu supports two Slack installation models:
-
-- **Single-workspace connection** for self-hosted deployments. You create your own Slack app, install it to one workspace, then configure Lobu with the **Signing Secret** and **Bot Token**.
-- **OAuth / multi-workspace distribution** for shared deployments. In this mode, users install a shared Slack app through an install link, Slack redirects back to Lobu, and Lobu creates or updates one Slack connection per Slack workspace.
-
-For OAuth distribution, incoming Slack events are routed by Slack `team_id`, so each installed workspace is isolated behind its own Lobu connection even when many workspaces share the same app.
+4. Start the stack with `lobu run` — the bot is now live in your Slack workspace.
 
 ### Shared OAuth distribution
 
-If you want one Slack app that many workspaces can install, create the app for your public Lobu deployment and wire Slack back to these Lobu endpoints:
+Create the app for your public Lobu deployment and wire Slack back to these Lobu endpoints:
 
 - **Install URL for users:** `https://<your-lobu-base-url>/slack/install`
 - **OAuth redirect URL:** `https://<your-lobu-base-url>/slack/oauth_callback`
 - **Events / interactivity / slash commands URL:** `https://<your-lobu-base-url>/slack/events`
 
-Minimum setup:
+Steps:
 
 1. Create a Slack app for your public Lobu domain.
-2. Configure the app's OAuth redirect URL to `https://<your-lobu-base-url>/slack/oauth_callback`.
+2. Set the app's OAuth redirect URL to `https://<your-lobu-base-url>/slack/oauth_callback`.
 3. Point event subscriptions, interactive requests, and slash commands to `https://<your-lobu-base-url>/slack/events`.
 4. Add the bot scopes your Lobu deployment needs.
 5. Configure Lobu with the Slack app's **Client ID**, **Client Secret**, and **Signing Secret**.
-6. Share `https://<your-lobu-base-url>/slack/install` with users who should install the app to their Slack workspace.
+6. Share `https://<your-lobu-base-url>/slack/install` with users who should install the app.
 
-When a user completes the Slack install flow, Lobu exchanges the OAuth code, stores the workspace installation, and creates or updates the Lobu Slack connection for that workspace automatically.
+When a user completes the install flow, Lobu exchanges the OAuth code, stores the workspace installation, and creates or updates the Lobu Slack connection for that workspace automatically.
 
 ## Configuration
 

--- a/packages/landing/src/content/docs/platforms/telegram.mdx
+++ b/packages/landing/src/content/docs/platforms/telegram.mdx
@@ -15,7 +15,7 @@ Under the hood, Lobu uses the Telegram Bot API via `@chat-adapter/telegram`.
 
 1. Create a bot with [@BotFather](https://t.me/BotFather) on Telegram and copy the bot token.
 2. Use Agents → Platforms in the web app to add Telegram to your agent, or run `lobu init` to scaffold a local project and pick Telegram in the wizard.
-3. Start the stack with `lobu run -d` — the bot starts receiving messages immediately.
+3. Start the stack with `lobu run` — the bot starts receiving messages immediately.
 
 ## Configuration
 

--- a/packages/landing/src/content/docs/platforms/whatsapp.mdx
+++ b/packages/landing/src/content/docs/platforms/whatsapp.mdx
@@ -16,7 +16,7 @@ Under the hood, Lobu uses the WhatsApp Business Cloud API for message delivery a
 1. Obtain a WhatsApp Business **access token**, **phone number ID**, **app secret**, and **verify token** from the [Meta Developer Portal](https://developers.facebook.com/).
 2. Use Agents → Platforms in the web app to add WhatsApp to your agent, or run `lobu init` to scaffold a local project and pick WhatsApp in the wizard.
 3. Configure the webhook URL in the Meta Developer Portal to point to your gateway's webhook endpoint.
-4. Start the stack with `lobu run -d` — the bot starts handling messages on the configured phone number.
+4. Start the stack with `lobu run` — the bot starts handling messages on the configured phone number.
 
 ## Configuration
 

--- a/packages/landing/src/content/docs/reference/cli.md
+++ b/packages/landing/src/content/docs/reference/cli.md
@@ -40,13 +40,22 @@ Interactive prompts guide you through provider, platform, network access policy,
 
 ---
 
-### `run`
+### `run` (aliases: `dev`, `start`)
 
 Run the embedded Lobu stack. `lobu.toml` is not required. With no `DATABASE_URL`, the command starts bundled local PGlite and stores data under `~/.lobu/data` (override with `LOBU_DATA_DIR`). If `DATABASE_URL` is set in the environment or `.env`, Lobu uses that external Postgres instead.
 
 ```bash
 npx @lobu/cli@latest run
+npx @lobu/cli@latest run --port 9000
+npx @lobu/cli@latest dev --verbose       # `dev` and `start` are aliases for `run`
 ```
+
+| Flag | Description |
+|------|-------------|
+| `--port <port>` | Gateway port (overrides `GATEWAY_PORT` in `.env`) |
+| `--quiet` | Suppress the startup banner; raise log level to `warn` |
+| `--verbose` | Lower log level to `debug` |
+| `--log-level <level>` | Forwarded as `LOG_LEVEL` to the bundled server |
 
 The command spawns the bundled Node server and forwards stdio. Ctrl+C cleanly stops the server and worker subprocesses.
 
@@ -112,6 +121,12 @@ npx @lobu/cli@latest agent update my-agent --description "Handles support"
 npx @lobu/cli@latest agent delete my-agent --yes
 ```
 
+`agent scaffold <agentId>` adds a new local agent (`agents/<id>/*` plus an entry in `lobu.toml`) without touching existing agents — the local-files counterpart of `agent create`:
+
+```bash
+npx @lobu/cli@latest agent scaffold support-bot --name "Support Bot" --description "Handles tickets"
+```
+
 Config helpers use the web app's `/config` API:
 
 ```bash
@@ -131,17 +146,23 @@ Send a prompt to an agent and stream the response to the terminal.
 npx @lobu/cli@latest chat "What is the weather?"
 npx @lobu/cli@latest chat "Hello" --agent my-agent --thread conv-123
 npx @lobu/cli@latest chat "Check my PRs" --user telegram:12345
+npx @lobu/cli@latest chat "Where did we leave off?" --continue
 npx @lobu/cli@latest chat "Status update" -c staging
 ```
+
+`-u/--user` impersonates a platform user ID (`telegram:<numeric-id>`, `slack:<member-id>`), which routes the message through that platform instead of replying directly in the terminal.
 
 | Flag | Description |
 |------|-------------|
 | `-a, --agent <id>` | Agent ID (defaults to first agent in local `lobu.toml` when present) |
-| `-u, --user <id>` | Route through a platform (e.g. `telegram:12345`, `slack:C0123`) |
+| `-u, --user <id>` | User ID to impersonate, e.g. `telegram:12345`. With this flag the message routes through the user's platform (Telegram/Slack) |
 | `-t, --thread <id>` | Thread/conversation ID for multi-turn conversations |
 | `-g, --gateway <url>` | Gateway URL (default: `http://localhost:8787` or from `.env`) |
 | `--dry-run` | Process without persisting history |
-| `--new` | Force a new session |
+| `--new` | Force a new session (ignore an existing one) |
+| `-C, --continue` | Resume the last thread for this `(context, agent)` |
+| `--auto-approve` | Auto-approve every tool call — use only in trusted environments |
+| `--json` | Emit raw SSE events as JSON lines instead of rendered text |
 | `-c, --context <name>` | Use a named context for gateway URL and credentials |
 
 ---
@@ -161,11 +182,26 @@ npx @lobu/cli@latest eval --ci --output results.json
 |------|-------------|
 | `-a, --agent <id>` | Agent ID (defaults to first in local `lobu.toml`) |
 | `-g, --gateway <url>` | Gateway URL (default: `http://localhost:8787`) |
-| `-m, --model <model>` | Model to evaluate |
+| `-m, --model <model>` | Model to evaluate (e.g. `claude/sonnet`, `openai/gpt-4.1`) |
 | `--trials <n>` | Override trial count |
 | `--ci` | CI mode: JSON output, non-zero exit on failure |
 | `--output <file>` | Write results to JSON file |
 | `--list` | List available evals without running them |
+| `-c, --context <name>` | Use a named context |
+
+#### `eval new <name>`
+
+Scaffold a new YAML eval into the agent's `evals/` directory.
+
+```bash
+npx @lobu/cli@latest eval new smoke-test --description "Quick smoke test" --trials 3
+```
+
+| Flag | Description |
+|------|-------------|
+| `-a, --agent <id>` | Agent ID (defaults to first in local `lobu.toml`) |
+| `--description <text>` | Eval description |
+| `--trials <n>` | Trial count |
 
 ---
 
@@ -181,14 +217,27 @@ Returns exit code `1` if validation fails.
 
 ---
 
-### `apply`
+### `apply` (alias: `deploy`)
 
-Sync local `lobu.toml` and agent directories to a Lobu org.
+Sync local `lobu.toml` and agent directories to a Lobu Cloud org. Idempotent, prompt-confirmed, one-way (files are the source of truth).
 
 ```bash
-npx @lobu/cli@latest apply --org my-org
-npx @lobu/cli@latest apply --dry-run
+npx @lobu/cli@latest apply                  # plan + prompt + apply
+npx @lobu/cli@latest apply --dry-run         # plan only, no mutations
+npx @lobu/cli@latest apply --yes --org my-org   # CI mode, no prompt
+npx @lobu/cli@latest deploy --only agents    # `deploy` is an alias
 ```
+
+| Flag | Description |
+|------|-------------|
+| `--dry-run` | Show the plan and exit without mutating |
+| `--yes` | Skip the confirmation prompt (CI mode) |
+| `--only <kind>` | Restrict to one resource family: `agents` or `memory` |
+| `--org <slug>` | Org slug override (defaults to the active session) |
+| `--url <url>` | Server URL override |
+| `--force` | Bypass the project-link guard if `context`/`org` don't match `.lobu/project.json` |
+
+See [`lobu apply`](/reference/lobu-apply/) for the full flow — plan output, apply order, stable platform IDs, drift, and required-secret checks.
 
 ---
 
@@ -203,6 +252,58 @@ npx @lobu/cli@latest status --org my-org
 
 ---
 
+### `link` / `unlink`
+
+`link` binds the current directory to a `(context, org)` pair, written to `.lobu/project.json`. Subsequent commands in this directory default to that context and org, and `lobu apply` refuses to run against a different pair unless you pass `--force`. `unlink` removes the file.
+
+```bash
+npx @lobu/cli@latest link --org my-org
+npx @lobu/cli@latest link -c staging --org my-org
+npx @lobu/cli@latest unlink
+```
+
+| Flag | Description |
+|------|-------------|
+| `-c, --context <name>` | Use a named context |
+| `--org <slug>` | Org slug to link (defaults to the active org) |
+
+---
+
+### `doctor`
+
+Run local health checks: dependencies, `DATABASE_URL` reachability, pgvector, ports, and provider keys.
+
+```bash
+npx @lobu/cli@latest doctor
+npx @lobu/cli@latest doctor --memory-only      # only check memory MCP connectivity + auth
+```
+
+| Flag | Description |
+|------|-------------|
+| `--memory-only` | Only check memory MCP connectivity and authentication |
+
+---
+
+### `telemetry`
+
+Show or toggle anonymous error reporting (Sentry). With no subcommand, prints the current status.
+
+```bash
+npx @lobu/cli@latest telemetry            # same as `telemetry status`
+npx @lobu/cli@latest telemetry status
+npx @lobu/cli@latest telemetry on         # writes SENTRY_DSN to .env
+npx @lobu/cli@latest telemetry on --dsn https://...@sentry.example.com/1
+npx @lobu/cli@latest telemetry off        # removes SENTRY_DSN from .env
+```
+
+| Subcommand | Description |
+|------------|-------------|
+| `status` | Show whether telemetry is on or off (default) |
+| `on` | Enable telemetry — accepts `--dsn <dsn>` to override Lobu's default DSN |
+| `off` | Disable telemetry |
+
+---
+
 ### `logout`, `whoami`, `token`
 
 ```bash
@@ -210,6 +311,25 @@ npx @lobu/cli@latest whoami
 npx @lobu/cli@latest token --raw
 npx @lobu/cli@latest logout
 ```
+
+`token` (no subcommand) prints the stored session token. `token create` mints an **org-scoped personal access token** suitable for servers and CI — it survives a `lobu logout` and is not tied to the device-code session:
+
+```bash
+npx @lobu/cli@latest token create --org my-org --name ci-token --scope "mcp:read mcp:write" --expires-in-days 90
+npx @lobu/cli@latest token create --org my-org --raw      # token only, for scripting
+npx @lobu/cli@latest token create --org my-org --json
+```
+
+| Flag | Description |
+|------|-------------|
+| `--org <slug>` | Org slug override |
+| `--name <name>` | Token name (default: `lobu-cli-YYYY-MM-DD`) |
+| `--description <text>` | Token description |
+| `--scope <scope>` | Space-separated scopes (default: `mcp:read mcp:write`) |
+| `--expires-in-days <days>` | Expire the token after N days (positive integer) |
+| `--raw` | Print the token only, no labels |
+| `--json` | Print the full JSON response |
+| `-c, --context <name>` | Use a named context |
 
 ## Typical workflow
 

--- a/packages/landing/src/content/docs/reference/lobu-apply.md
+++ b/packages/landing/src/content/docs/reference/lobu-apply.md
@@ -16,7 +16,19 @@ lobu apply --yes                 # plan + apply, no prompt (CI)
 lobu apply --only agents         # restrict to agent + platform resources
 lobu apply --only memory         # restrict to entity + relationship types
 lobu apply --org my-org          # override active org
+lobu apply --url https://...     # override the server URL
+lobu apply --force               # bypass the .lobu/project.json link guard
+lobu deploy                      # `deploy` is an alias for `apply`
 ```
+
+| Flag | Description |
+| --- | --- |
+| `--dry-run` | Show the plan and exit without mutating |
+| `--yes` | Skip the confirmation prompt (CI mode) |
+| `--only <kind>` | Restrict to one resource family: `agents` or `memory` |
+| `--org <slug>` | Org slug override (defaults to the active session) |
+| `--url <url>` | Server URL override |
+| `--force` | Bypass the project-link guard when `.lobu/project.json` points at a different `(context, org)` |
 
 Authentication is shared with the rest of the CLI. Run `lobu login` once.
 

--- a/packages/landing/src/content/docs/reference/lobu-memory.md
+++ b/packages/landing/src/content/docs/reference/lobu-memory.md
@@ -36,12 +36,19 @@ lobu run
 
 ### `lobu memory init`
 
-Configures local MCP-capable clients to use a Lobu memory MCP endpoint.
+Wires an existing project's agents to a memory MCP endpoint and configures local MCP-capable clients.
 
 ```bash
 lobu memory init
 lobu memory init --url http://localhost:8787/mcp
+lobu memory init --agent support-bot --skip-auth
 ```
+
+| Flag | Description |
+|------|-------------|
+| `--url <url>` | MCP server URL (skips the picker) |
+| `--agent <id>` | Configure a specific agent only |
+| `--skip-auth` | Skip the authentication step |
 
 The wizard detects supported clients and auto-configures them when possible. Browser-managed clients fall back to manual setup instructions.
 
@@ -112,6 +119,17 @@ lobu memory run query_sdk '{"script":"export default async (ctx, client) => clie
 lobu memory run run_sdk '{"dry_run":true,"script":"export default async (ctx, client) => client.entities.create({ type: \"company\", name: \"Acme\" })"}' --org my-org
 ```
 
+### `lobu memory exec <script>`
+
+Sugar for `lobu memory run run_sdk '{"script": ...}'` — runs the given TypeScript ClientSDK script source via the memory MCP without hand-quoting the JSON wrapper. `<script>` is the script text itself, so pipe a file in with `$(cat ...)`.
+
+```bash
+lobu memory exec 'export default async (ctx, client) => client.entities.list({ entity_type: "company", limit: 5 })' --org my-org
+lobu memory exec "$(cat script.ts)" --url https://lobu.ai/mcp --org my-org
+```
+
+Accepts the same `--url`, `--org`, and `-c/--context` flags as `lobu memory run`.
+
 ## Seed Project Memory
 
 ### `lobu memory seed`
@@ -128,25 +146,31 @@ lobu memory seed --org my-org --url https://lobu.ai/mcp
 
 ### `lobu memory browser-auth`
 
-Captures browser cookie state for connectors that rely on a real browser session.
+Captures cookie state from your local Chrome for connectors that rely on a real browser session. `--connector` is required.
 
 ```bash
 lobu memory browser-auth --connector x --auth-profile-slug my-profile
 lobu memory browser-auth --connector x --auth-profile-slug my-profile --check
+lobu memory browser-auth --connector x --launch-cdp --remote-debug-port 9222
 ```
 
-Useful flags:
-
-- `--chrome-profile <name>` chooses a local Chrome profile
-- `--launch-cdp` launches a dedicated remote-debugging Chrome profile
-- `--dedicated-profile <name>` names the dedicated profile
+| Flag | Description |
+|------|-------------|
+| `--connector <key>` | **Required.** Connector key (e.g. `x`) |
+| `--domains <list>` | Comma-separated cookie-domain override |
+| `--chrome-profile <name>` | Chrome profile name (prompts interactively if omitted) |
+| `--auth-profile-slug <slug>` | Browser auth profile slug to store cookies on |
+| `--launch-cdp` | Launch a dedicated Chrome user-data-dir with remote debugging enabled |
+| `--remote-debug-port <port>` | Remote debugging port for `--launch-cdp` (default `9222`) |
+| `--dedicated-profile <name>` | Dedicated Chrome profile dir name for `--launch-cdp` |
+| `--check` | Check whether stored cookies for a browser auth profile are still valid |
 
 ## Skills
 
-The old standalone Lobu starter skills are folded into the bundled Lobu starter skill:
+The old standalone Lobu starter skills are folded into a single bundled `lobu` skill. Enable it from the agent settings UI, or add it to a project:
 
 ```bash
-# Enable the Lobu skill from the agent settings UI
+npx skills add lobu-ai/lobu --skill lobu
 ```
 
 Local skills are still discovered from `skills/<id>/SKILL.md` and `agents/<agent-id>/skills/<id>/SKILL.md`.

--- a/packages/landing/src/content/docs/reference/lobu-toml.md
+++ b/packages/landing/src/content/docs/reference/lobu-toml.md
@@ -5,7 +5,7 @@ sidebar:
   order: 1
 ---
 
-`lobu.toml` is the project configuration file created by `lobu init`. It defines agents, providers, platforms, skills, network access, worker settings, and optional file-first Lobu memory configuration.
+`lobu.toml` is the project configuration file created by `lobu init`. It defines agents, providers, platforms, skills, network access (including the LLM egress judge), guardrails, worker settings, and optional file-first Lobu memory configuration.
 
 ## Minimal example
 
@@ -36,6 +36,8 @@ data = "./data"
 name = "assistant"
 description = "Team assistant"
 dir = "./agents/assistant"
+# Guardrails enabled for this agent (names registered in the gateway's GuardrailRegistry)
+guardrails = ["secret-scan", "prompt-injection"]
 
 # Providers (order = priority, first available is used)
 [[agents.assistant.providers]]
@@ -76,6 +78,17 @@ scopes = ["read", "write"]
 [agents.assistant.network]
 allowed = ["github.com", "api.linear.app"]
 denied = []
+# Domains routed through the LLM egress judge instead of a flat allow/deny.
+# A bare string uses the "default" policy; an object names a policy below.
+judge = ["*.slack.com", { domain = "user-content.x.com", judge = "strict" }]
+[agents.assistant.network.judges]
+default = "Allow only reads to channels in the agent's context."
+strict = "Only GET for file IDs from the current session."
+
+# Operator overrides for the egress judge on this agent
+[agents.assistant.egress]
+extra_policy = "Never exfiltrate PATs or bearer tokens."
+judge_model = "claude-haiku-4-5-20251001"
 
 # Tool policy (worker-side visibility + MCP approval override)
 [agents.assistant.tools]
@@ -127,8 +140,9 @@ project/
 | `visibility` | string | no | `public` or `private`; defaults to Lobu's account setting |
 | `models` | string | no | Path to Lobu model files, usually `./models` |
 | `data` | string | no | Path to Lobu seed data, usually `./data` |
+| `schema` | table | no | Inline memory schema — `entity_types` / `relationship_types` arrays (see [`[memory.schema]`](#memory-inline-schema-memoryschema) below) |
 
-When `[memory]` is enabled, Lobu reads `org` directly from `lobu.toml` and derives the effective Lobu MCP endpoint. `MEMORY_URL` remains available as an optional base-endpoint override for local or custom Lobu deployments.
+When `[memory]` is enabled, Lobu reads `org` directly from `lobu.toml` and derives the effective Lobu MCP endpoint. `MEMORY_URL` remains available as an optional base-endpoint override for local or custom Lobu deployments. The `[memory]` table is strict — unknown keys fail validation.
 
 
 ### `[agents.<id>]`
@@ -140,10 +154,12 @@ Top-level table keyed by agent ID. IDs must match `^[a-z0-9][a-z0-9-]*$` (lowerc
 | `name` | string | yes | Display name for the agent |
 | `description` | string | no | Short description shown in admin UI |
 | `dir` | string | yes | Path to agent content directory containing `IDENTITY.md`, `SOUL.md`, `USER.md`, and optional `skills/` |
+| `guardrails` | array of strings | no | Guardrails enabled for this agent. Each name must match a guardrail registered in the gateway's `GuardrailRegistry` at startup |
 | `providers` | array | no | LLM provider list (order = priority) |
 | `platforms` | array | no | Chat platforms |
 | `skills` | table | no | Skills and MCP servers |
-| `network` | table | no | Network access policy |
+| `network` | table | no | Network access policy + LLM egress-judge config |
+| `egress` | table | no | Operator overrides for the LLM egress judge on this agent |
 | `tools` | table | no | Tool policy: pre-approval bypass + worker-side visibility |
 | `worker` | table | no | Worker customization |
 
@@ -230,14 +246,16 @@ Each entry defines a custom MCP server.
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `url` | string | no | SSE/Streamable HTTP endpoint URL |
+| `url` | string | no | HTTP endpoint URL (streamable-HTTP or SSE transport) |
+| `type` | `streamable-http` \| `sse` \| `stdio` | no | Transport kind. Defaults to `streamable-http` for HTTP URLs; `sse` is the legacy two-channel HTTP transport; `stdio` runs a local `command` |
 | `command` | string | no | Stdio transport — command to run |
 | `args` | array of strings | no | Stdio transport — command arguments |
 | `env` | table | no | Environment variables passed to the MCP process |
 | `headers` | table | no | HTTP headers sent with requests |
+| `auth_scope` | `user` \| `channel` | no | Credential scope for OAuth-authenticated MCPs. `user` (default): each chat user logs in separately. `channel`: one credential shared across all users in a channel — only for shared-data integrations where per-user attribution isn't needed |
 | `oauth` | table | no | OAuth configuration (see below) |
 
-Specify either `url` (SSE/HTTP transport) or `command` (stdio transport), not both.
+Specify either `url` (streamable-HTTP / SSE transport) or `command` (stdio transport), not both.
 
 ### `[agents.<id>.skills.mcp.<name>.oauth]`
 
@@ -254,14 +272,40 @@ OAuth configuration for MCP servers that require authenticated access.
 
 ### `[agents.<id>.network]`
 
-Controls which domains the worker can reach through the gateway proxy.
+Controls which domains the worker can reach through the gateway proxy, plus per-agent rules for the LLM egress judge.
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | `allowed` | array of strings | no | Domains to allow. Empty = no access. Use `["*"]` for unrestricted (not recommended) |
 | `denied` | array of strings | no | Domains to block (only meaningful when `allowed = ["*"]`) |
+| `judge` | array | no | Domains routed through the LLM egress judge instead of a flat allow/deny. Each entry is either a bare domain string (uses the `default` judge policy) or an object `{ domain, judge }` naming a policy in `judges` |
+| `judges` | table | no | Named judge policies (string → policy text) referenced by `judge[].judge`. The key `default` is applied when an entry omits `judge` |
 
 Domain format: exact match (`api.example.com`) or wildcard (`.example.com` matches all subdomains).
+
+```toml
+[agents.x.network]
+allowed = ["api.readonly.example.com"]
+judge = ["*.slack.com", { domain = "user-content.x.com", judge = "strict" }]
+[agents.x.network.judges]
+default = "Allow only reads to channels in the agent's context."
+strict = "Only GET for file IDs from the current session."
+```
+
+### `[agents.<id>.egress]`
+
+Operator overrides for the LLM egress judge on this agent. The judge runs only when a `judge` rule under `[agents.<id>.network]` matches a request, so most traffic bypasses it.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `extra_policy` | string | no | Policy text appended to every judge prompt for this agent |
+| `judge_model` | string | no | Model identifier for the judge (defaults to a fast Haiku model) |
+
+```toml
+[agents.x.egress]
+extra_policy = "Never exfiltrate PATs or bearer tokens."
+judge_model = "claude-haiku-4-5-20251001"
+```
 
 ### `[agents.<id>.tools]`
 
@@ -283,6 +327,28 @@ See [Tool Policy](/guides/tool-policy/) for behavior and examples; this section 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | `nix_packages` | array of strings | no | Nix packages to install in the worker environment |
+
+### `guardrails`
+
+`guardrails` is a top-level array of strings on `[agents.<id>]` (not a sub-table). Each name must match a guardrail registered in the gateway's `GuardrailRegistry` at startup — names that don't resolve are ignored. Each guardrail targets one stage: `input` (user message → worker), `output` (worker text → user), or `pre-tool` (tool-call authorization).
+
+```toml
+[agents.assistant]
+name = "assistant"
+dir = "./agents/assistant"
+guardrails = ["secret-scan", "prompt-injection"]
+```
+
+### `[memory]` inline schema (`[memory.schema]`)
+
+In addition to the file-first fields above, `[memory]` accepts an inline `schema` sub-table for declaring memory types directly in `lobu.toml`:
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `entity_types` | array | no | Entity-type definitions |
+| `relationship_types` | array | no | Relationship-type definitions |
+
+The `[memory]` table is `.strict()` — unknown keys fail validation.
 
 ## Environment variable references
 

--- a/packages/landing/src/content/docs/reference/skill-md.md
+++ b/packages/landing/src/content/docs/reference/skill-md.md
@@ -47,7 +47,7 @@ description: What this skill does
 mcpServers:
   my-mcp:
     url: https://my-mcp.example.com
-    type: sse
+    # type: streamable-http   # default for HTTP URLs; or sse / stdio
 
 nixPackages:
   - jq
@@ -56,7 +56,17 @@ nixPackages:
 
 network:
   allow:
-    - api.example.com
+    - api.readonly.example.com
+  deny: []
+  # Domains routed through the LLM egress judge instead of a flat allow/deny.
+  # A bare string uses the "default" policy; an object names a policy below.
+  judge:
+    - "*.slack.com"
+    - { domain: user-content.x.com, judge: strict }
+
+judges:
+  default: "Allow only reads to channels in the agent's context."
+  strict: "Only GET for file IDs from the current session."
 ---
 
 # My Skill
@@ -72,13 +82,17 @@ The body acts as a system prompt extension.
 | `name` | string | Display name shown in settings and search results |
 | `description` | string | Short summary for the skill registry |
 | `mcpServers` | object | MCP server connections keyed by server ID |
-| `mcpServers.<id>.url` | string | Server endpoint URL |
-| `mcpServers.<id>.type` | `sse` \| `stdio` | Transport type |
+| `mcpServers.<id>.url` | string | HTTP endpoint URL (streamable-HTTP or SSE transport) |
+| `mcpServers.<id>.type` | `streamable-http` \| `sse` \| `stdio` | Transport type. Omit it for an HTTP `url` and the connection defaults to streamable-HTTP; `sse` is the legacy two-channel HTTP transport; `stdio` runs a local `command` |
 | `mcpServers.<id>.command` | string | Command for stdio MCP servers |
 | `mcpServers.<id>.args` | string[] | Arguments for stdio MCP servers |
 | `nixPackages` | string[] | System packages to install in the worker |
 | `network.allow` | string[] | Domains the worker sandbox can reach |
 | `network.deny` | string[] | Domains to block |
+| `network.judge` | array | Domains routed through the LLM egress judge. Each entry is a bare domain string (uses the `default` judge policy) or an object `{ domain, judge }` naming a policy in the top-level `judges` map |
+| `judges` | object | Named judge policies (string → policy text) referenced by `network.judge[].judge`; the `default` key applies when an entry omits `judge` |
+
+Skill MCP entries support only `url` / `type` / `command` / `args` — for `headers`, `env`, `oauth`, or `auth_scope`, configure the MCP server on the agent in [`lobu.toml`](/reference/lobu-toml/) under `[agents.<id>.skills.mcp.<name>]`.
 
 ## Markdown Body
 
@@ -87,6 +101,8 @@ The markdown body after the frontmatter is appended to the agent's prompt when t
 ## Notes
 
 - `SKILL.md` frontmatter does not configure tool approval or `pre_approved` MCP tools.
+- `contracts.tools` belongs in an OpenClaw plugin manifest (`openclaw.plugin.json`), not in `SKILL.md` frontmatter — the skill parser ignores it.
+- When both a skill and the agent declare egress-judge rules, the `lobu.toml` policy wins on named judges and judged-domain rules.
 - For MCP servers that should live directly on the agent rather than inside a skill, configure them in [`lobu.toml`](/reference/lobu-toml/).
 
 ## Related Docs

--- a/packages/openclaw-plugin/test/e2e/device-auth.test.ts
+++ b/packages/openclaw-plugin/test/e2e/device-auth.test.ts
@@ -5,7 +5,7 @@
  * Lobu backend. No LLM needed — pure HTTP calls.
  *
  * Prerequisites:
- *   - docker compose up (at least: app, redis)
+ *   - docker compose up (at least: app)
  *   - DATABASE_URL in env (or .env)
  */
 

--- a/packages/openclaw-plugin/test/e2e/mcp-tools.test.ts
+++ b/packages/openclaw-plugin/test/e2e/mcp-tools.test.ts
@@ -8,7 +8,7 @@
  * No LLM needed — pure HTTP JSON-RPC calls.
  *
  * Prerequisites:
- *   - docker compose up (at least: app, redis, postgres, embeddings)
+ *   - docker compose up (at least: app, postgres, embeddings)
  *   - DATABASE_URL in env (or .env)
  */
 

--- a/packages/openclaw-plugin/test/e2e/memory-loop.test.ts
+++ b/packages/openclaw-plugin/test/e2e/memory-loop.test.ts
@@ -9,7 +9,7 @@
  * injected the memory from the MCP server.
  *
  * Prerequisites:
- *   - docker compose up (app, redis, embeddings, openclaw)
+ *   - docker compose up (app, embeddings, openclaw)
  *   - DATABASE_URL, BETTER_AUTH_SECRET, ZAI_API_KEY in env (or .env)
  *   - zai model provider configured in the openclaw container
  */

--- a/packages/server/src/__tests__/setup/test-db.ts
+++ b/packages/server/src/__tests__/setup/test-db.ts
@@ -257,9 +257,8 @@ export async function cleanupTestDatabase(): Promise<void> {
  */
 async function fixSchemaConstraints(db: postgres.Sql): Promise<void> {
   try {
-    // runs.run_type needs the connector lanes plus the lobu-queue lanes that
-    // landed in the Phase 5 redis -> runs migration. Keep this in sync with
-    // db/migrations/20260429060000_extend_runs_for_lobu_queue.sql.
+    // runs.run_type needs the connector lanes plus the lobu-queue lanes. Keep
+    // this in sync with db/migrations/20260429060000_extend_runs_for_lobu_queue.sql.
     await db.unsafe(`
       ALTER TABLE IF EXISTS runs DROP CONSTRAINT IF EXISTS runs_run_type_check;
       ALTER TABLE IF EXISTS runs ADD CONSTRAINT runs_run_type_check

--- a/packages/server/src/__tests__/unit/lobu/gateway.test.ts
+++ b/packages/server/src/__tests__/unit/lobu/gateway.test.ts
@@ -17,7 +17,7 @@ afterEach(() => {
 });
 
 describe('ensureEmbeddedGatewaySecrets', () => {
-  it('throws when REDIS-backed embedded mode has no stable encryption key', () => {
+  it('throws when embedded mode has no stable encryption key', () => {
     delete process.env.ENCRYPTION_KEY;
     delete process.env.LOBU_ALLOW_EPHEMERAL_ENCRYPTION_KEY;
 

--- a/packages/server/src/gateway/__tests__/core-services-store-selection.test.ts
+++ b/packages/server/src/gateway/__tests__/core-services-store-selection.test.ts
@@ -136,9 +136,9 @@ describe("CoreServices store selection", () => {
     });
     (coreServices as any).queue = new MockMessageQueue();
 
-    // After Phase 6 the Redis-backed default sub-store is gone; if the host
-    // doesn't provide config/connection/access stores AND no lobu.toml is
-    // present, initializeSessionServices throws.
+    // There is no default sub-store; if the host doesn't provide
+    // config/connection/access stores AND no lobu.toml is present,
+    // initializeSessionServices throws.
     await expect(
       (coreServices as any).initializeSessionServices()
     ).rejects.toThrow(/No agent sub-stores configured/);

--- a/packages/server/src/gateway/__tests__/device-auth.test.ts
+++ b/packages/server/src/gateway/__tests__/device-auth.test.ts
@@ -177,9 +177,9 @@ describe("device auth secret storage", () => {
 
     expect(started?.userCode).toBe("user-code-123");
 
-    // Pending device-auth state is now stored directly under the secret name
-    // (no Redis pointer). The blob still encrypts via PostgresSecretStore in
-    // production; the in-memory test store keeps the JSON plaintext.
+    // Pending device-auth state is stored directly under the secret name. The
+    // blob encrypts via PostgresSecretStore in production; the in-memory test
+    // store keeps the JSON plaintext.
     const pendingEntries = await secretStore.list(
       "mcp-auth/agent-1/user-1/github/device-auth"
     );

--- a/packages/server/src/gateway/__tests__/fixtures/in-memory-state-adapter.ts
+++ b/packages/server/src/gateway/__tests__/fixtures/in-memory-state-adapter.ts
@@ -1,6 +1,6 @@
 /**
  * Minimal in-memory StateAdapter for Chat SDK tests.
- * Implements the full StateAdapter interface so a real `Chat` can boot without Redis.
+ * Implements the full StateAdapter interface so a real `Chat` can boot without an external state store.
  */
 import type { Lock, StateAdapter } from "chat";
 

--- a/packages/server/src/gateway/__tests__/helpers/db-setup.ts
+++ b/packages/server/src/gateway/__tests__/helpers/db-setup.ts
@@ -1,11 +1,10 @@
 /**
  * Bun:test PG harness shared across the gateway test suite.
  *
- * Some store tests in this directory previously ran entirely on a
- * MockRedisClient. After Phase 6 the stores read/write Postgres directly,
- * so callers need a real DB. We boot an ephemeral PGlite once per test
- * process the first time `ensurePgliteForGatewayTests()` is called, run
- * migrations, and reuse it for the rest of the suite.
+ * Store tests in this directory read/write Postgres directly, so callers
+ * need a real DB. We boot an ephemeral PGlite once per test process the
+ * first time `ensurePgliteForGatewayTests()` is called, run migrations, and
+ * reuse it for the rest of the suite.
  *
  * Tests that don't need PG (pure helpers, classification logic, etc.) can
  * skip calling this entirely and pay no cost.

--- a/packages/server/src/gateway/__tests__/http-proxy.test.ts
+++ b/packages/server/src/gateway/__tests__/http-proxy.test.ts
@@ -247,7 +247,7 @@ describe("HTTP Proxy Startup", () => {
 
 // ─── Domain filtering tests ──────────────────────────────────────────────────
 // Global config is WORKER_ALLOWED_DOMAINS=* (unrestricted), so all domains pass.
-// Domain restriction via per-agent grants requires Redis and is tested separately.
+// Domain restriction via per-agent grants is tested separately.
 
 describe("HTTP Proxy Domain Filtering (unrestricted mode)", () => {
   const deploymentName = "domain-test-worker";

--- a/packages/server/src/gateway/__tests__/platform-adapter-slack-send.test.ts
+++ b/packages/server/src/gateway/__tests__/platform-adapter-slack-send.test.ts
@@ -3,7 +3,7 @@ import { ChatInstanceManager } from "../connections/chat-instance-manager.js";
 
 /**
  * Helper: create a ChatInstanceManager with mocked internals for testing
- * sendPlatformMessage without requiring Redis.
+ * sendPlatformMessage without a live gateway.
  */
 function createTestManager(overrides: {
   listConnections: (...args: any[]) => Promise<any[]>;

--- a/packages/server/src/gateway/__tests__/runs-queue-integration.test.ts
+++ b/packages/server/src/gateway/__tests__/runs-queue-integration.test.ts
@@ -1,10 +1,9 @@
 /**
  * Integration tests for RunsQueue against a real Postgres (PGlite in CI).
  *
- * Phase 10 of Redis -> Postgres migration: covers the production behaviors
- * that unit-level mocking cannot exercise — SKIP LOCKED concurrency,
- * graceful shutdown release, priority + expires_at + retryDelay options,
- * startup recovery scan.
+ * Covers the production behaviors that unit-level mocking cannot exercise —
+ * SKIP LOCKED concurrency, graceful shutdown release, priority + expires_at +
+ * retryDelay options, startup recovery scan.
  *
  * PGlite is a single-process WASM Postgres so the SKIP LOCKED concurrency
  * test cannot exercise real cross-process contention. We assert the

--- a/packages/server/src/gateway/__tests__/secret-store.test.ts
+++ b/packages/server/src/gateway/__tests__/secret-store.test.ts
@@ -21,9 +21,8 @@ const TEST_ENCRYPTION_KEY =
   "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
 
 /**
- * In-memory writable secret store. Replaces the deleted RedisSecretStore in
- * tests — the production substrate is now PostgresSecretStore (covered by
- * its own test file).
+ * In-memory writable secret store for tests — the production substrate is
+ * PostgresSecretStore (covered by its own test file).
  */
 class InMemoryWritableStore implements WritableSecretStore {
   private readonly entries = new Map<

--- a/packages/server/src/gateway/__tests__/setup.ts
+++ b/packages/server/src/gateway/__tests__/setup.ts
@@ -1,7 +1,7 @@
 /**
  * Test setup and utilities for Gateway tests.
  *
- * Shared mocks (Redis, Queue, fetch, factories) live in @lobu/core fixtures.
+ * Shared mocks (Queue, fetch, factories) live in @lobu/core fixtures.
  * This file re-exports them and adds gateway-specific helpers.
  */
 

--- a/packages/server/src/gateway/orchestration/base-deployment-manager.ts
+++ b/packages/server/src/gateway/orchestration/base-deployment-manager.ts
@@ -705,9 +705,7 @@ export abstract class BaseDeploymentManager {
     context?: ProviderCredentialContext
   ): Promise<Record<string, string>> {
     // Tests that exercise deployment lifecycle without a secret store can
-    // skip placeholder injection (no secrets to swap). Previously this short-
-    // circuited on the absent redisClient; now the secretStore plays the
-    // same role.
+    // skip placeholder injection (no secrets to swap).
     if (!this.secretStore) return envVars;
     const secretStore = this.secretStore;
 

--- a/packages/server/src/gateway/services/provider-registry-service.ts
+++ b/packages/server/src/gateway/services/provider-registry-service.ts
@@ -11,10 +11,6 @@ const logger = createLogger("provider-registry-service");
 const ENV_SUBSTITUTION_BLOCKLIST = new Set([
   "ENCRYPTION_KEY",
   "DATABASE_URL",
-  // Kept defense-in-depth: even though the runtime no longer uses Redis, an
-  // operator may still set REDIS_PASSWORD in their environment for unrelated
-  // tooling and we don't want it surfacing through provider-config substitution.
-  "REDIS_PASSWORD",
   "SLACK_CLIENT_SECRET",
   "SLACK_SIGNING_SECRET",
   "GH_TOKEN",

--- a/packages/server/src/lobu/stores/postgres-secret-store.ts
+++ b/packages/server/src/lobu/stores/postgres-secret-store.ts
@@ -57,7 +57,7 @@ function escapeLikePrefix(prefix: string): string {
 
 /**
  * Resolve a name-or-ref input to a plain logical name. Throws on refs that
- * target a non-default scheme, matching RedisSecretStore's behavior.
+ * target a non-default scheme.
  */
 function resolveName(nameOrRef: string): string {
   const parsed = parseSecretRef(nameOrRef);

--- a/packages/server/vitest.config.ts
+++ b/packages/server/vitest.config.ts
@@ -17,8 +17,7 @@ export default defineConfig({
     // bun:test-style unit tests live alongside vitest integration tests — skip
     // those for vitest. They run via `bun test` (see the existing CI command).
     // Anything under `src/gateway/**/__tests__` is bun:test-style (carried over
-    // from the merged @lobu/gateway package, plus the Phase-2/-5 caches+queue
-    // unit tests added during the Redis removal).
+    // from the merged @lobu/gateway package, plus the caches + queue unit tests).
     exclude: [
       "src/__tests__/unit/**",
       "src/gateway/**/__tests__/**",

--- a/skills/lobu-operator/SKILL.md
+++ b/skills/lobu-operator/SKILL.md
@@ -5,36 +5,38 @@ description: Repo-specific operational skill for Lobu-managed agents working ins
 
 # Lobu Operator — Repo Guide
 
-For external coding-agent orientation, see `CLAUDE.md`.
+`CLAUDE.md` (which includes `AGENTS.md`) is the source of truth for this repo's layout, build system, validation, and constraints. Read those first — this skill is just a fast index.
 
 ## Before You Act
 
-1. Read `lobu.toml` for workspace configuration.
-2. List agent directories to know which agents are defined.
-3. Check enabled skills — capabilities depend on workspace config.
-
-Do not assume the repo layout. Inspect it.
+1. Read `CLAUDE.md` and `AGENTS.md`.
+2. Read `lobu.toml` for workspace configuration.
+3. Inspect the agent directories and enabled `skills/` — the layout is data-driven, don't assume it.
 
 ## Dev Workflow
 
 ```bash
-make dev   # boots the embedded Lobu stack (gateway + workers + Vite HMR)
+./scripts/setup-dev.sh   # first-time setup (builds packages, checks bun)
+make dev                 # embedded gateway + workers + Vite HMR on :8787
+make clean-workers       # kill orphaned worker subprocesses
 ```
 
-Requires local Redis on `:6379` and `DATABASE_URL` reachable in `.env`.
+Prerequisites: Bun, Node 22.x–24.x, and a reachable Postgres (with pgvector) via `DATABASE_URL` in `.env`. There is no Redis and no Docker/Kubernetes — everything runs in one embedded Node process.
 
-## Validation Order
+## Validation
 
-1. `bun run typecheck`
-2. `bun run check`
-3. `bun test packages/<changed-package>/src`
-4. `make build-packages` if `packages/{core,gateway,worker,cli}/*` changed
+| Change | Command |
+| --- | --- |
+| `packages/landing/*` | `cd packages/landing && bun run build` |
+| `packages/{core,server,agent-worker,cli}/*` | `make build-packages` |
+| Broad TS check | `bun run typecheck` |
+| Any package source | `bun test packages/<pkg>/src` |
+| Lint / format | `bun run check` (or `check:fix`) |
 
-Package manager: **bun** (not npm, yarn, or pnpm). Ignore `dist/` directories — work from source.
+After editing `packages/agent-worker/*`, run `make clean-workers`.
 
 ## Constraints
 
 - All rules in `CLAUDE.md` and `AGENTS.md` apply.
-- No backwards compatibility required.
-- Do not create documentation files unless explicitly requested.
-- Zero hardcoding: all behavior is data-driven.
+- Package manager is **bun** — never npm/yarn/pnpm. Ignore `dist/` directories; work from source.
+- No backwards-compat shims. Don't create `*.md` files unless explicitly asked. Zero hardcoding — behavior is data-driven.


### PR DESCRIPTION
Repo-wide cleanup found by auditing `AGENTS.md`, the bundled skills, and the docs site against the actual code. **No behavior change** — docs, comments, and one redundant constant removal.

## Redis
No `redis`/`ioredis` dependency exists anywhere; removed all stale references — `AGENTS.md`, `skills/lobu-operator/SKILL.md`, code comments (`provider-registry-service.ts`, `base-deployment-manager.ts`, `postgres-secret-store.ts`, `vitest.config.ts`), test comments/names, and the openclaw-plugin e2e test headers. The explicit `"REDIS_PASSWORD"` entry in `ENV_SUBSTITUTION_BLOCKLIST` was dropped since `/(^|_)PASSWORD$/i` already covers it.

## AGENTS.md
- Fixed gateway source paths (`src/gateway/connections/`, `src/gateway/orchestration/`, `src/gateway/routes/public/slack.ts`).
- Submodule is `lobu-ai/owletto-web`, not `lobu-ai/lobu-web`.
- Softened the "one transport per platform" line to acknowledge Telegram's `mode: "auto" | "webhook" | "polling"` option (the code supports it).

## `skills/lobu-operator/SKILL.md`
Rewritten to a thin, accurate index of `CLAUDE.md`/`AGENTS.md`. The old copy was stale: "Requires local Redis on :6379", `packages/{core,gateway,worker,cli}` (now `{core,server,agent-worker,cli}`), wrong validation order.

## Reference docs
Verified against the implementation and filled in:
- **cli.md** — `agent scaffold`, `eval new`, `token create`, `doctor`, `telemetry`, `link`/`unlink`; `run` flags + `dev`/`start` aliases; `chat` `-C/--continue` / `--auto-approve` / `--json`; fixed the misleading `--user slack:C0123` example; reconciled the `apply` flag set with lobu-apply.md.
- **lobu-toml.md** — `[agents.<id>.egress]`, `[agents.<id>] guardrails`, `[agents.<id>.network] judge`/`judges`, MCP server `type`/`auth_scope`, `[memory.schema]`.
- **skill-md.md** — `network.judge` + `judges`; reconciled the MCP `type` list; note that `contracts.tools` lives in `openclaw.plugin.json`.
- **lobu-memory.md** — `memory exec`; completed `memory init` / `memory browser-auth` flags (the required `--connector` was missing); replaced the empty Skills stub.
- **lobu-apply.md** — `--url`, `--force`, `deploy` alias.

## Guides / getting-started / platforms
- PGlite is the scaffolded default; external Postgres via `DATABASE_URL` is optional (was presented as mandatory) — `architecture.mdx`, `troubleshooting.md`, `comparison.md`.
- `lobu run -d` → `lobu run` (no such flag) — `telegram.mdx`, `slack.mdx`, `whatsapp.mdx`.
- `getting-started/index.mdx` — rewrote the broken "Configuration" section (promised two approaches, listed one, contradicted the Quick Start) and trimmed verbose hand-holding.
- `mcp-proxy.md` — "Configuration sources" was incoherent and said precedence backwards (per-agent overrides global); cut the redundant ASCII diagram and merged duplicated config snippets.
- `observability.md` — removed the fictitious `worker_creation` span + numbering gap; Tempo example now uses OTLP **gRPC** (4317), matching the exporter.
- `sync-from-github.md` — `lobu token create` (not `lobu auth tokens create`); `lobu pull` no longer presented as runnable.
- `evals.md` — `claude/sonnet-4-5` (not the non-catalog `anthropic/claude-sonnet-4`).
- `memory-benchmarks.md` + `benchmarks/memory/README.md` — Bun + Node 22–24 (not "Node 20+, pnpm 9+"); real invocation `bun run scripts/lobu/run-memory-benchmark.ts` / `bun run lobu:bench:memory`; correct runner path; dead links removed.
- `comparison.md` — removed the "scale-to-zero / idle timeout / wake-on-message" claims (no such feature; workers are persistent subprocesses); fixed the fabricated just-bash GitHub link → npm.
- `README.md` + `docs/SECURITY.md` — `just-bash` no longer conflated with `@mariozechner/pi-coding-agent` (separate deps); fabricated `github.com/nicholasgasior/just-bash` link → npm.
- `packages/connectors/src/README.md` — the two contradictory env-allowlists reconciled to the real `SYSTEM_ENV_KEYS`.
- `docs/RELEASING.md` — removed the false "`@lobu/lobu-*` deprecated redirect packages" claim; corrected the release-PR title (`chore(main): release lobu X.Y.Z`) and tag format (`lobu-vX.Y.Z`); refreshed stale version examples; noted the `charts/lobu/Chart.yaml` bump.
- Misc de-dup, wording, and rename-artifact cleanup across the guides.

The `packages/landing/public/*.md` twins are gitignored build artifacts (regenerated by `gen-markdown-twins.ts`); only `src/content/docs/` sources are changed here. `cd packages/landing && bun run build` passes (81 pages); `bun run typecheck` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)