### PR TITLE
feat(connectors): add Revolut transactions connector (browser/CDP)

### DIFF
--- a/packages/connectors/src/index.ts
+++ b/packages/connectors/src/index.ts
@@ -14,6 +14,7 @@ export * from './linkedin.ts';
 export * from './microsoft_outlook.ts';
 export * from './producthunt.ts';
 export * from './reddit.ts';
+export * from './revolut.ts';
 export * from './rss.ts';
 export * from './spotify.ts';
 export * from './trustpilot.ts';

--- a/packages/connectors/src/revolut.ts
+++ b/packages/connectors/src/revolut.ts
@@ -1,0 +1,565 @@
+/**
+ * Revolut Connector (V1 runtime)
+ *
+ * Revolut has no public personal-banking API, so this connector drives the
+ * Revolut web app and captures the JSON it fetches from
+ * `app.revolut.com/api/retail/user/current/transactions/last?...` while
+ * paginating the transaction list (the `to=<ms>` param walks back in time).
+ *
+ * Auth: CDP only. Revolut's `app.revolut.com` access token (`credentials`
+ * cookie) is bound to the browser that minted it (a per-request `x-device-id`
+ * header + Cloudflare/TLS fingerprint), so exported cookies replayed in a fresh
+ * headless browser get a 401 on `/api/retail/...` and bounce to
+ * `sso.revolut.com/passcode`. The connector therefore connects over CDP to a
+ * Chrome that already holds the live session — see the auth-schema notes.
+ *
+ * The emitted event shape matches the original file-import Revolut connector
+ * (`semantic_type: "transaction"`, metadata `{ date, description, amount,
+ * direction, balance, currency }`) so historical imports stay uniform.
+ */
+
+import {
+	type ActionContext,
+	type ActionResult,
+	browserNetworkSync,
+	type ConnectorDefinition,
+	ConnectorRuntime,
+	type EventEnvelope,
+	type SyncContext,
+	type SyncResult,
+} from "@lobu/connector-sdk";
+import {
+	getBrowserCookies,
+	validateCookieNotExpired,
+} from "./browser-scraper-utils";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface RevolutCheckpoint {
+	last_transaction_id?: string;
+	last_timestamp?: string;
+}
+
+export interface RevolutTransaction {
+	id: string;
+	description: string;
+	/** Absolute value in major currency units (e.g. 20.0 for £20.00). */
+	amount: number;
+	direction: "in" | "out";
+	/** Account balance after the transaction, in major units (may be absent). */
+	balance?: number;
+	currency: string;
+	/** ISO calendar date (YYYY-MM-DD) the transaction settled / started. */
+	date: string;
+	/** Full settlement timestamp. */
+	occurredAt: Date;
+	/** Revolut transaction type, e.g. CARD_PAYMENT, TRANSFER, TOPUP. */
+	type?: string;
+	/** Revolut state, e.g. COMPLETED, PENDING. */
+	state?: string;
+}
+
+// Currencies with zero minor units — Revolut returns these amounts unscaled.
+const ZERO_DECIMAL_CURRENCIES = new Set([
+	"JPY",
+	"KRW",
+	"VND",
+	"CLP",
+	"ISK",
+	"XAF",
+	"XOF",
+	"BIF",
+	"DJF",
+	"GNF",
+	"KMF",
+	"MGA",
+	"PYG",
+	"RWF",
+	"UGX",
+	"VUV",
+	"XPF",
+]);
+
+// Transaction states worth keeping. DECLINED/FAILED/REVERTED never settled.
+const KEPT_STATES = new Set(["COMPLETED", "PENDING", "CONFIRMED", "SETTLED"]);
+
+// Fields the web app uses for the transaction timestamp, best first.
+const TIMESTAMP_FIELDS = [
+	"completedDate",
+	"completed_date",
+	"completedAt",
+	"bookingDate",
+	"booking_date",
+	"valueDate",
+	"value_date",
+	"startedDate",
+	"started_date",
+	"createdDate",
+	"created_date",
+	"createdAt",
+	"date",
+];
+
+// ---------------------------------------------------------------------------
+// Parsing
+// ---------------------------------------------------------------------------
+
+function minorUnitsToMajor(raw: number, currency: string): number {
+	const exponent = ZERO_DECIMAL_CURRENCIES.has(currency.toUpperCase()) ? 0 : 2;
+	return raw / 10 ** exponent;
+}
+
+function coerceTimestamp(value: unknown): Date | null {
+	if (typeof value === "number" && Number.isFinite(value)) {
+		// Revolut uses ms-epoch; treat 10-digit values as seconds defensively.
+		const ms = value < 1e12 ? value * 1000 : value;
+		const d = new Date(ms);
+		return Number.isNaN(d.getTime()) ? null : d;
+	}
+	if (typeof value === "string" && value.trim()) {
+		const d = new Date(value);
+		return Number.isNaN(d.getTime()) ? null : d;
+	}
+	return null;
+}
+
+function extractAmountAndCurrency(
+	record: Record<string, unknown>,
+): { amount: number; currency: string } | null {
+	// Flat shape: { amount: -2000, currency: "GBP" }
+	if (
+		typeof record.amount === "number" &&
+		typeof record.currency === "string"
+	) {
+		return { amount: record.amount, currency: record.currency };
+	}
+	// Nested money shape: { amount: { value: -2000, currency: "GBP" } } or
+	// { amount: { amount: -20.0, currency: "GBP" } }.
+	const amt = record.amount;
+	if (amt && typeof amt === "object") {
+		const obj = amt as Record<string, unknown>;
+		const value =
+			typeof obj.value === "number"
+				? obj.value
+				: typeof obj.amount === "number"
+					? obj.amount
+					: null;
+		const currency = typeof obj.currency === "string" ? obj.currency : null;
+		if (value !== null && currency) return { amount: value, currency };
+	}
+	return null;
+}
+
+function nameOf(node: unknown): string | null {
+	if (!node || typeof node !== "object") return null;
+	const obj = node as Record<string, unknown>;
+	for (const key of ["name", "legalName", "username", "displayName"]) {
+		const v = obj[key];
+		if (typeof v === "string" && v.trim()) return v.trim();
+	}
+	return null;
+}
+
+function describeTransaction(record: Record<string, unknown>): string {
+	// Card payments carry a clean `merchant.name` ("OpenAI") alongside a noisy
+	// raw descriptor ("Openai *chatgpt Subscr") — prefer the merchant name, which
+	// is also what the Revolut UI shows and what the legacy import used. Transfers
+	// and top-ups have no merchant, so fall back to the human description.
+	const merchant = nameOf(record.merchant);
+	if (merchant) return merchant;
+	for (const key of [
+		"description",
+		"localisedDescription",
+		"reference",
+		"comment",
+	]) {
+		const v = record[key];
+		if (typeof v === "string" && v.trim()) return v.trim();
+	}
+	for (const key of [
+		"counterpart",
+		"counterparty",
+		"recipient",
+		"sender",
+		"beneficiary",
+	]) {
+		const v = nameOf(record[key]);
+		if (v) return v;
+	}
+	const type = record.type;
+	return typeof type === "string" && type.trim()
+		? type.replace(/_/g, " ")
+		: "Transaction";
+}
+
+function extractBalance(
+	record: Record<string, unknown>,
+	currency: string,
+): number | undefined {
+	const raw =
+		typeof record.balance === "number"
+			? record.balance
+			: record.balance && typeof record.balance === "object"
+				? ((record.balance as Record<string, unknown>).value ??
+					(record.balance as Record<string, unknown>).amount)
+				: undefined;
+	if (typeof raw !== "number" || !Number.isFinite(raw)) return undefined;
+	return Number.isInteger(raw) ? minorUnitsToMajor(raw, currency) : raw;
+}
+
+function parseTransactionRecord(
+	record: Record<string, unknown>,
+): RevolutTransaction | null {
+	const money = extractAmountAndCurrency(record);
+	if (!money) return null;
+
+	const id = record.id ?? record.legId ?? record.transactionId ?? record.code;
+	if (typeof id !== "string" && typeof id !== "number") return null;
+
+	let occurredAt: Date | null = null;
+	for (const field of TIMESTAMP_FIELDS) {
+		occurredAt = coerceTimestamp(record[field]);
+		if (occurredAt) break;
+	}
+	if (!occurredAt) return null;
+
+	const state =
+		typeof record.state === "string" ? record.state.toUpperCase() : undefined;
+	if (state && !KEPT_STATES.has(state)) return null;
+
+	const currency = money.currency.toUpperCase();
+	// Revolut's retail API returns integer minor units; some endpoints return a
+	// decimal already in major units — fractional values mean "already major".
+	const value = Number.isInteger(money.amount)
+		? minorUnitsToMajor(money.amount, currency)
+		: money.amount;
+
+	return {
+		id: String(id),
+		description: describeTransaction(record),
+		amount: Math.abs(value),
+		direction: value < 0 ? "out" : "in",
+		balance: extractBalance(record, currency),
+		currency,
+		date: occurredAt.toISOString().slice(0, 10),
+		occurredAt,
+		type: typeof record.type === "string" ? record.type : undefined,
+		state,
+	};
+}
+
+/**
+ * Walk an arbitrary JSON value and pull out anything that looks like a Revolut
+ * transaction. The web app's responses vary (bare arrays, `{ items: [...] }`,
+ * paginated envelopes, single-transaction detail endpoints), so we recurse
+ * rather than assume one shape. A record only counts as a transaction if it
+ * carries both an amount/currency and a timestamp, which keeps merchant/budget
+ * objects out.
+ */
+export function extractTransactionsFromResponse(
+	json: unknown,
+): RevolutTransaction[] {
+	const found: RevolutTransaction[] = [];
+	const seen = new Set<object>();
+
+	const visit = (node: unknown): void => {
+		if (!node || typeof node !== "object") return;
+		if (seen.has(node as object)) return;
+		seen.add(node as object);
+
+		if (Array.isArray(node)) {
+			for (const item of node) {
+				const parsed =
+					item && typeof item === "object" && !Array.isArray(item)
+						? parseTransactionRecord(item as Record<string, unknown>)
+						: null;
+				if (parsed) found.push(parsed);
+				else visit(item);
+			}
+			return;
+		}
+
+		const record = node as Record<string, unknown>;
+		const asTxn = parseTransactionRecord(record);
+		if (asTxn) {
+			found.push(asTxn);
+			return;
+		}
+		for (const value of Object.values(record)) visit(value);
+	};
+
+	visit(json);
+	return found;
+}
+
+// ---------------------------------------------------------------------------
+// Checkpoint filtering
+// ---------------------------------------------------------------------------
+
+export function filterTransactionsSinceCheckpoint(
+	transactions: RevolutTransaction[],
+	checkpoint: RevolutCheckpoint | null | undefined,
+): RevolutTransaction[] {
+	const lastTs = checkpoint?.last_timestamp
+		? new Date(checkpoint.last_timestamp).getTime()
+		: null;
+	const lastId = checkpoint?.last_transaction_id;
+	const seen = new Set<string>();
+	return transactions.filter((t) => {
+		if (seen.has(t.id)) return false;
+		seen.add(t.id);
+		if (lastId && t.id === lastId) return false;
+		if (
+			lastTs !== null &&
+			Number.isFinite(lastTs) &&
+			t.occurredAt.getTime() <= lastTs
+		) {
+			return false;
+		}
+		return true;
+	});
+}
+
+// ---------------------------------------------------------------------------
+// Event mapping (matches the original file-import Revolut connector)
+// ---------------------------------------------------------------------------
+
+function currencySymbol(currency: string): string {
+	switch (currency.toUpperCase()) {
+		case "GBP":
+			return "£";
+		case "USD":
+			return "$";
+		case "EUR":
+			return "€";
+		default:
+			return `${currency} `;
+	}
+}
+
+export function transactionToEvent(t: RevolutTransaction): EventEnvelope {
+	const sign = t.direction === "out" ? "-" : "+";
+	return {
+		origin_id: `revolut-${t.id}`,
+		payload_text: `${t.description} ${sign}${currencySymbol(t.currency)}${t.amount} on ${t.date}`,
+		occurred_at: t.occurredAt,
+		semantic_type: "transaction",
+		metadata: {
+			date: t.date,
+			description: t.description,
+			amount: t.amount,
+			direction: t.direction,
+			...(t.balance !== undefined ? { balance: t.balance } : {}),
+			currency: t.currency,
+			...(t.type ? { transaction_type: t.type } : {}),
+			...(t.state ? { state: t.state } : {}),
+		},
+	};
+}
+
+// ---------------------------------------------------------------------------
+// Sync
+// ---------------------------------------------------------------------------
+
+// The Revolut web app fetches account history from
+// `app.revolut.com/api/retail/user/current/transactions/last?count=N&to=<ms>&internalPocketId=<uuid>`
+// (the `to` param walks back in time as you scroll). These patterns also cover
+// plausible alternates without catching unrelated `/api/retail/...` calls.
+const TRANSACTION_API_PATTERNS: RegExp[] = [
+	/\/api\/retail\/.*transactions?(?:\/|\b)/i,
+	/\/api\/.*\/transactions(?:\b|\?|\/|$)/i,
+	/transactions?[./](?:last|recent|history|search)/i,
+];
+
+const REVOLUT_AUTH_DOMAINS = ["app.revolut.com", ".revolut.com"];
+// `/transactions` shows the full, infinitely-scrollable history for the default
+// account; `/home` only shows the latest ~10. Per-pocket history lives at
+// `/transactions?accountType=pocket&walletId=<uuid>&pocketId=<uuid>` — point a
+// second feed's `start_url` there to sync a non-default currency pocket.
+const DEFAULT_START_URL = "https://app.revolut.com/transactions";
+
+function isLoggedIn(url: string): boolean {
+	let host: string;
+	try {
+		host = new URL(url).hostname;
+	} catch {
+		return false;
+	}
+	// An unauthenticated session is bounced to sso.revolut.com/passcode.
+	if (host !== "app.revolut.com") return false;
+	return !/\/(?:start|signin|login|verify|onboarding)\b/i.test(url);
+}
+
+const configSchema = {
+	type: "object",
+	properties: {
+		start_url: {
+			type: "string",
+			default: DEFAULT_START_URL,
+			description:
+				"Revolut web app URL to open. Defaults to the full transactions view for the primary account; set it to a per-pocket /transactions?...pocketId=<uuid> URL to sync a different currency pocket.",
+		},
+		currency_filter: {
+			type: "string",
+			description:
+				'If set, keep only transactions in this ISO 4217 currency (e.g. "GBP").',
+		},
+		max_scrolls: {
+			type: "integer",
+			minimum: 1,
+			maximum: 100,
+			default: 20,
+			description:
+				"Maximum scroll iterations to paginate older transactions (default: 20).",
+		},
+	},
+};
+
+const transactionMetadataSchema = {
+	type: "object",
+	properties: {
+		date: { type: "string", format: "date" },
+		description: { type: "string" },
+		amount: { type: "number" },
+		direction: { type: "string", enum: ["in", "out"] },
+		balance: { type: "number" },
+		currency: { type: "string" },
+		transaction_type: { type: "string" },
+		state: { type: "string" },
+	},
+};
+
+export default class RevolutConnector extends ConnectorRuntime {
+	readonly definition: ConnectorDefinition = {
+		key: "revolut",
+		name: "Revolut",
+		description:
+			"Syncs Revolut account transactions from the Revolut web app (no public API). Requires a Chrome instance, with remote debugging enabled, that stays logged in to app.revolut.com.",
+		version: "2.0.0",
+		faviconDomain: "app.revolut.com",
+		authSchema: {
+			methods: [
+				// CDP only — *not* `cli` cookie capture. Revolut's `app.revolut.com`
+				// access token (the `credentials` cookie) is bound to the browser that
+				// minted it (device-id header + Cloudflare/TLS fingerprint), so cookies
+				// exported from Chrome and replayed in a fresh headless browser get a 401
+				// on /api/retail/... and bounce to sso.revolut.com/passcode. The only
+				// path that authenticates is connecting over CDP to the *same* Chrome
+				// that holds the live session — keep one logged in and reachable.
+				{
+					type: "browser",
+					capture: "cdp",
+					defaultCdpUrl: "http://127.0.0.1:9222",
+					requiredDomains: REVOLUT_AUTH_DOMAINS,
+					description:
+						"Connect over CDP to a Chrome logged in to app.revolut.com: lobu memory browser-auth --connector revolut --launch-cdp (log in there, re-enter the passcode whenever Revolut expires the session).",
+				},
+			],
+		},
+		feeds: {
+			transactions: {
+				key: "transactions",
+				name: "Transactions",
+				description: "Account transactions pulled from the Revolut web app.",
+				configSchema,
+				eventKinds: {
+					transaction: {
+						description: "A bank transaction",
+						metadataSchema: transactionMetadataSchema,
+					},
+				},
+			},
+		},
+		optionsSchema: configSchema,
+	};
+
+	async sync(ctx: SyncContext): Promise<SyncResult> {
+		const config = (ctx.config ?? {}) as Record<string, unknown>;
+		const checkpoint = (ctx.checkpoint ?? {}) as RevolutCheckpoint;
+
+		const startUrl =
+			typeof config.start_url === "string" && config.start_url.trim()
+				? config.start_url.trim()
+				: DEFAULT_START_URL;
+		const currencyFilter =
+			typeof config.currency_filter === "string" &&
+			config.currency_filter.trim()
+				? config.currency_filter.trim().toUpperCase()
+				: null;
+		const maxScrolls = Math.max(
+			1,
+			Math.min(100, Number(config.max_scrolls ?? 20) || 20),
+		);
+
+		// Primary auth is CDP (connect to the Chrome that holds the live Revolut
+		// session). Stored cookies are only a best-effort fallback for the
+		// Playwright path — see the auth-schema comment on why they rarely suffice
+		// for Revolut. Don't fail the sync just because there are none.
+		let cookies: ReturnType<typeof getBrowserCookies> = [];
+		try {
+			cookies = getBrowserCookies(
+				ctx.checkpoint as Record<string, unknown> | null,
+				ctx.sessionState,
+				"revolut",
+			);
+			validateCookieNotExpired(cookies, "credentials", "revolut");
+		} catch {
+			cookies = [];
+		}
+
+		const result = await browserNetworkSync<RevolutTransaction>({
+			config: {
+				interceptPatterns: TRANSACTION_API_PATTERNS,
+				authDomains: REVOLUT_AUTH_DOMAINS,
+				maxScrolls,
+				scrollDelayMs: 2500,
+				responseTimeoutMs: 8000,
+				navigationTimeoutMs: 20000,
+				stealth: true,
+			},
+			url: startUrl,
+			cdpUrl: "auto",
+			cookies,
+			parseResponse: (_url, json) => extractTransactionsFromResponse(json),
+			checkAuth: async (page) => isLoggedIn(page.url()),
+		});
+
+		let transactions = filterTransactionsSinceCheckpoint(
+			result.items,
+			checkpoint,
+		);
+		if (currencyFilter) {
+			transactions = transactions.filter((t) => t.currency === currencyFilter);
+		}
+		transactions.sort(
+			(a, b) => b.occurredAt.getTime() - a.occurredAt.getTime(),
+		);
+
+		const events: EventEnvelope[] = transactions.map(transactionToEvent);
+		const newest = transactions[0];
+		const newCheckpoint: RevolutCheckpoint = newest
+			? {
+					last_transaction_id: newest.id,
+					last_timestamp: newest.occurredAt.toISOString(),
+				}
+			: checkpoint;
+
+		return {
+			events,
+			checkpoint: newCheckpoint as unknown as Record<string, unknown>,
+			auth_update: { cookies: result.cookies },
+			metadata: {
+				items_found: events.length,
+				api_calls: result.apiCallCount,
+				backend: result.backend,
+				...(currencyFilter ? { currency_filter: currencyFilter } : {}),
+			},
+		};
+	}
+
+	async execute(_ctx: ActionContext): Promise<ActionResult> {
+		return { success: false, error: "Actions not supported" };
+	}
+}

--- a/packages/server/src/__tests__/unit/connectors/revolut.test.ts
+++ b/packages/server/src/__tests__/unit/connectors/revolut.test.ts
@@ -1,0 +1,182 @@
+import { describe, expect, it } from "vitest";
+import {
+	extractTransactionsFromResponse,
+	filterTransactionsSinceCheckpoint,
+	type RevolutTransaction,
+	transactionToEvent,
+} from "../../../../../connectors/src/revolut";
+
+describe("Revolut transaction parsing", () => {
+	it("parses the legacy retail transaction shape (minor units, ms epoch)", () => {
+		const response = {
+			transactions: [
+				{
+					id: "tx_1",
+					type: "CARD_PAYMENT",
+					state: "COMPLETED",
+					startedDate: 1719705600000,
+					completedDate: 1719705660000, // 2024-06-30
+					amount: -2000,
+					currency: "GBP",
+					balance: 1740589,
+					description: "The Chancellors",
+				},
+				{
+					id: "tx_2",
+					type: "TOPUP",
+					state: "COMPLETED",
+					completedDate: 1721318400000, // 2024-07-18
+					amount: 5000,
+					currency: "GBP",
+					balance: 1745589,
+					merchant: { name: "Apple Pay top-up" },
+				},
+			],
+		};
+
+		const txns = extractTransactionsFromResponse(response);
+		expect(txns).toHaveLength(2);
+
+		const [a, b] = txns;
+		expect(a).toMatchObject({
+			id: "tx_1",
+			description: "The Chancellors",
+			amount: 20,
+			direction: "out",
+			balance: 17405.89,
+			currency: "GBP",
+			date: "2024-06-30",
+			type: "CARD_PAYMENT",
+			state: "COMPLETED",
+		});
+		expect(b).toMatchObject({
+			id: "tx_2",
+			description: "Apple Pay top-up",
+			amount: 50,
+			direction: "in",
+			balance: 17455.89,
+			currency: "GBP",
+		});
+	});
+
+	it("handles nested money objects and ISO timestamps", () => {
+		const txns = extractTransactionsFromResponse([
+			{
+				id: "tx_3",
+				state: "PENDING",
+				valueDate: "2025-01-15T09:30:00.000Z",
+				amount: { value: -799, currency: "EUR" },
+				description: "Spotify",
+			},
+		]);
+		expect(txns).toEqual([
+			expect.objectContaining({
+				id: "tx_3",
+				amount: 7.99,
+				direction: "out",
+				currency: "EUR",
+				date: "2025-01-15",
+				state: "PENDING",
+			}),
+		]);
+	});
+
+	it("keeps zero-decimal currencies unscaled", () => {
+		const [txn] = extractTransactionsFromResponse([
+			{
+				id: "tx_vnd",
+				state: "COMPLETED",
+				completedDate: "2024-07-19",
+				amount: -120000,
+				currency: "VND",
+				description: "Song Que Cafe",
+			},
+		]);
+		expect(txn.amount).toBe(120000);
+		expect(txn.currency).toBe("VND");
+	});
+
+	it("skips records without a timestamp or without money, and declined states", () => {
+		const txns = extractTransactionsFromResponse({
+			budgets: [{ amount: 50000, currency: "GBP", name: "Groceries" }], // no date
+			pending: [
+				{
+					id: "x",
+					state: "DECLINED",
+					completedDate: 1719705600000,
+					amount: -1,
+					currency: "GBP",
+				},
+			],
+			misc: { hello: "world" },
+		});
+		expect(txns).toEqual([]);
+	});
+});
+
+describe("Revolut checkpoint filtering", () => {
+	const make = (id: string, iso: string): RevolutTransaction => ({
+		id,
+		description: id,
+		amount: 1,
+		direction: "out",
+		currency: "GBP",
+		date: iso.slice(0, 10),
+		occurredAt: new Date(iso),
+	});
+
+	it("drops transactions at or before the saved timestamp and dedups by id", () => {
+		const txns = [
+			make("103", "2026-03-29T12:00:00.000Z"),
+			make("102", "2026-03-28T12:00:00.000Z"),
+			make("102", "2026-03-28T12:00:00.000Z"),
+			make("101", "2026-03-27T12:00:00.000Z"),
+		];
+		expect(
+			filterTransactionsSinceCheckpoint(txns, {
+				last_transaction_id: "102",
+				last_timestamp: "2026-03-28T12:00:00.000Z",
+			}).map((t) => t.id),
+		).toEqual(["103"]);
+	});
+
+	it("returns everything when there is no checkpoint", () => {
+		const txns = [
+			make("2", "2026-03-29T12:00:00.000Z"),
+			make("1", "2026-03-28T12:00:00.000Z"),
+		];
+		expect(
+			filterTransactionsSinceCheckpoint(txns, null).map((t) => t.id),
+		).toEqual(["2", "1"]);
+	});
+});
+
+describe("Revolut event mapping", () => {
+	it("produces the legacy event shape", () => {
+		const event = transactionToEvent({
+			id: "tx_1",
+			description: "The Chancellors",
+			amount: 20,
+			direction: "out",
+			balance: 17405.89,
+			currency: "GBP",
+			date: "2024-06-30",
+			occurredAt: new Date("2024-06-30T12:01:00.000Z"),
+			type: "CARD_PAYMENT",
+			state: "COMPLETED",
+		});
+		expect(event.origin_id).toBe("revolut-tx_1");
+		expect(event.semantic_type).toBe("transaction");
+		expect(event.payload_text).toBe("The Chancellors -£20 on 2024-06-30");
+		expect(event.metadata).toMatchObject({
+			date: "2024-06-30",
+			description: "The Chancellors",
+			amount: 20,
+			direction: "out",
+			balance: 17405.89,
+			currency: "GBP",
+			transaction_type: "CARD_PAYMENT",
+			state: "COMPLETED",
+		});
+	});
+});


### PR DESCRIPTION
Adds a `revolut` connector that syncs Revolut account transactions by driving the Revolut web app and intercepting the JSON it fetches from `app.revolut.com/api/retail/user/current/transactions/last` (the `to=<ms>` query param walks back in time as the list scrolls). Emits the same `semantic_type: "transaction"` event shape (`metadata: { date, description, amount, direction, balance, currency, transaction_type, state }`) as the old org-scoped file-import stub, so historical imports stay uniform.

## Auth: CDP only

Revolut's `app.revolut.com` access token (the `credentials` cookie) is bound to the browser that minted it — API calls carry a per-request `x-device-id` header the SPA computes from browser state, plus Cloudflare/TLS fingerprinting. Verified empirically: cookies exported from a logged-in Chrome and replayed in a fresh stealth browser (even within ~1s of capture) get a **401** on `/api/retail/...` and bounce to `sso.revolut.com/passcode`. So the X/LinkedIn `lobu memory browser-auth` cookie-capture model does not work here.

The connector therefore uses `capture: 'cdp'` (same model as the Google connector): it connects over CDP to a Chrome that already holds the live session. Setup:

```
lobu memory browser-auth --connector revolut --launch-cdp   # log in there (passcode)
```

Keep that Chrome running and reachable from the connector worker. Workers need `app.revolut.com` + `.revolut.com` in `WORKER_ALLOWED_DOMAINS`.

## What's verified

- Connector compiles via the runtime esbuild path, appears in the catalog, instantiates, `sync()` wired correctly.
- Parser run against a **real 52-transaction API response**: 38 events emitted (11 `DECLINED` + 3 `REVERTED` correctly skipped), minor→major amount scaling incl. zero-decimal currencies, running `balance`, clean `merchant.name` over the raw descriptor, ISO dates from `startedDate`.
- Pagination confirmed: the `/transactions` view does infinite scroll, firing `?to=<oldest_ms>&count=50` going back in time → `browserNetworkSync`'s scroll loop walks history.
- 7 unit tests; biome + `tsc --noEmit` clean.
- **Not verified end-to-end**: `connectOverCDP` against a `--launch-cdp` Chrome (couldn't be tested autonomously — agent-browser doesn't expose a Playwright-compatible CDP endpoint). The `cdpUrl: 'auto'` discovery (:9222/:9229 via `DevToolsActivePort`) is SDK infrastructure already used by the Google connector.

## Notes

- The legacy org-scoped `revolut` connector def + its broken connection/feeds were retired out-of-band so this catalog connector takes over; the historical transaction events were kept.
- ToS-grey (Revolut prohibits automated access); the internal endpoint can change without notice — the parser is defensive but not immune.