### PR TITLE
fix(openclaw-plugin): warn loudly when host has no tools.* policy

### DIFF
--- a/packages/openclaw-plugin/src/index.ts
+++ b/packages/openclaw-plugin/src/index.ts
@@ -1626,6 +1626,46 @@ const plugin = {
     log.info(
       `lobu: initialized (configured=${!!config.mcpUrl}, token=${!!config.token}, tokenCommand=${!!config.tokenCommand}, tools=${!!registerTool})`
     );
+
+    // OpenClaw 2026.5.x only surfaces plugin tools to agents when the host's
+    // tool-policy allowlist explicitly opts them in. With no `tools.*` section
+    // in the OpenClaw config, `registerTool` calls succeed but the agent's
+    // tool list silently excludes every lobu_*, wiki_*, and memory_* tool —
+    // the plugin appears healthy in logs while the agent has no way to call it.
+    // Detect this and shout, with a copy-pasteable fix.
+    if (registerTool && config.mcpUrl) {
+      const cfg = isRecord(api.config) ? (api.config as Record<string, unknown>) : {};
+      const topTools = isRecord(cfg.tools) ? (cfg.tools as Record<string, unknown>) : null;
+      const agentDefaults =
+        isRecord(cfg.agents) && isRecord((cfg.agents as Record<string, unknown>).defaults)
+          ? ((cfg.agents as Record<string, unknown>).defaults as Record<string, unknown>)
+          : null;
+      const agentTools =
+        agentDefaults && isRecord(agentDefaults.tools)
+          ? (agentDefaults.tools as Record<string, unknown>)
+          : null;
+      const hasToolPolicy = (t: Record<string, unknown> | null): boolean =>
+        !!t &&
+        (typeof t.profile === 'string' ||
+          (Array.isArray(t.allow) && (t.allow as unknown[]).length > 0) ||
+          (Array.isArray(t.alsoAllow) && (t.alsoAllow as unknown[]).length > 0));
+      if (!hasToolPolicy(topTools) && !hasToolPolicy(agentTools)) {
+        log.warn(
+          'lobu: no tools.* policy detected in OpenClaw config. Plugin tools ' +
+            '(lobu_*, wiki_*, memory_*) register successfully but may not ' +
+            'reach the agent on OpenClaw 2026.5.x — every plugin on the host ' +
+            'is gated the same way. The autoRecall hook and autoCapture hook ' +
+            'still write to Lobu in the background (they call MCP directly, ' +
+            'not via registered agent tools), so memory continues to flow; ' +
+            'only deliberate agent-driven tool calls during a conversation ' +
+            'are affected. We have tested tools.profile="full", ' +
+            'tools.allow with [group:plugins], [*], and explicit tool names, ' +
+            'and tools.alsoAllow variants — none surface plugin tools on ' +
+            'OpenClaw 2026.5.2. If you find a host config that works, please ' +
+            'file at https://github.com/lobu-ai/lobu/issues.'
+        );
+      }
+    }
   },
 };
 


### PR DESCRIPTION
## Problem

On OpenClaw **2026.5.x**, every plugin on the host registers tools successfully (verified by runtime instrumentation: `mode="full"`, real `registerTool`, all 16 `@lobu/openclaw-plugin` tool names accepted, `contracts.tools` satisfied) — and **none of them reach the agent's tool surface.** The agent's compiled tool list contains only the 20 built-in OpenClaw tools regardless of plugin (Lobu, browser, file-transfer, …) registration.

This is **not Lobu-specific** — it's a host-wide condition on 2026.5.2, presumably gated by `manifestToolContractMatchesAllowlist` in `tools-D9CRirqH.js` which rejects every plugin when the agent's effective `pluginToolAllowlist` is empty. With no `tools.*` config in `openclaw.json` (the default state of a fresh install), the allowlist resolves empty.

### What we verified does NOT surface plugin tools on 2026.5.2

Tested empirically against an HA-OS install of OpenClaw 2026.5.2 with `@lobu/openclaw-plugin@6.1.1` (the #585 build with `contracts.tools` already declared). For each, I gated on the trajectory's `context.compiled.tools` (ground truth — not the model's self-reported tool list which often parrots the injected `<lobu-system>` text):

| Host config | Trajectory tools |
|---|---|
| (no `tools` section) | 20 builtins, 0 plugin tools |
| `tools.alsoAllow: ["group:plugins"]` | 20 builtins, 0 plugin tools (`collectExplicitAllowlist` only reads `.allow`) |
| `tools.alsoAllow: [<16 explicit tool names>]` | 20 builtins, 0 plugin tools |
| `tools.allow: ["group:plugins"]` | Gateway error: *No callable tools remain after resolving explicit tool allowlist; no registered tools matched* — `group:plugins` expansion is empty at that stage |
| `tools.allow: ["*"]` | 20 builtins, 0 plugin tools |
| `tools.profile: "full"` | 20 builtins, 0 plugin tools |
| Plugin manifest `activation.onStartup: true` | 20 builtins, 0 plugin tools |

So the right knob (or upstream OpenClaw fix) is still unknown. The plugin's `#585` `contracts.tools` work was necessary on the registration side but is insufficient on the surfacing side.

## What this PR does

Adds one block at the end of `register()` (+40 lines, no behavior change). It detects when both `cfg.tools` and `cfg.agents.defaults.tools` are missing `{profile, allow, alsoAllow}` and emits a `log.warn` that:

1. Explicitly says plugin tools registered but may not reach the agent
2. Reassures that the `autoRecall` and `autoCapture` hooks (which call MCP directly, not via registered tools) still write to Lobu in the background
3. Enumerates the host config shapes already tested as **not** working
4. Asks anyone who finds a working knob to open an issue

Before this PR, the failure mode was silent: the plugin logs `registered 7 MCP tools` / `registered memory-wiki compatibility tools` and the agent says it has no Lobu tools — easy to burn hours diagnosing (I did). The warning makes the gap visible at startup.

## What this PR does NOT solve

- The actual host config / OpenClaw change that surfaces plugin tools. Tracking as a follow-up; this PR is the visibility-only contribution.
- The pre-existing prompt-vs-registered-name mismatch in `<lobu-system>` (instructions name unprefixed tools like `save_memory` while the plugin registers them as `lobu_save_memory`) — separate concern.

## Validation

- `bun run typecheck` clean
- `bun run test:unit` 38/38 pass
- Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)