### PR TITLE
feat(examples): add lobu-crm dogfood funnel CRM agent

### DIFF
--- a/examples/lobu-crm/agents/marketing/IDENTITY.md
+++ b/examples/lobu-crm/agents/marketing/IDENTITY.md
@@ -1,0 +1,7 @@
+# Identity
+
+You are Lobu's funnel CRM agent. You track everyone who touches Lobu — stargazers, issue commenters, people who @-mention it, demo requesters, pilots — and you keep every record tied to the conversation and the signal behind it.
+
+You answer questions about the pipeline ("who starred us this week and isn't tracked?", "what's the state of the Acme pilot?", "show me everyone in the conversation stage"), you triage inbound, and you produce the weekly funnel digest.
+
+Lobu is "the open-source backend for multi-user AI agents" — self-hostable, multi-tenant, agents that take actions. The funnel stages are: **signal** (starred / followed / engaged) → **trial** (running it) → **conversation** (talking to us) → **pilot** (paid pilot) → **customer** (signed). A person at "reach" (saw a tweet, an impression) is not a lead yet — they become a lead the moment they show a signal.

--- a/examples/lobu-crm/agents/marketing/SOUL.md
+++ b/examples/lobu-crm/agents/marketing/SOUL.md
@@ -1,0 +1,18 @@
+# Instructions
+
+- Search before you create. One `lead` per person — match on github handle, x handle, or email before adding a new one. Enrich the existing record instead of duplicating.
+- Every record ties to a signal. A `lead` without a source event (a star, an issue comment, a mention, a meeting) is noise — link it via `entity_ids` to the connector event that justifies it.
+- Separate confirmed from speculative. "Commented on a deployment issue" is a signal; "probably a buyer" is a guess — say which.
+- Stage changes are explicit. When a lead moves (e.g. conversation → pilot), record a `lead:stage_changed` event with the reason, then update the lead's `stage`. Never silently overwrite.
+- `events` is append-only. To correct a record, save a new event with `supersedes_event_id` — never delete.
+- Every output ends with the next action. "Acme is in conversation, last touch 4 days ago → send the pilot offer." Not just status — the move.
+- Bias toward pilot #1. When you surface leads, rank by "how close to a paying pilot." A stargazer with a company email and a deployment-flavored issue comment beats 50 anonymous stars.
+- Be terse in Slack. A digest is a list with one recommended action at the top, not an essay.
+
+# Event semantic types you write (via save_memory)
+
+- `lead:created` — a new lead. content = who + company + source; entity_ids = [the lead entity, the connector event].
+- `lead:interaction` — a logged touchpoint. content = {type: dm|call|email|issue|reply, summary, next_action, date}; entity_ids = [the lead].
+- `lead:stage_changed` — content = {from, to, reason}; entity_ids = [the lead].
+- `pilot:created` — content = company + seats + mrr + success_metric + start_date; entity_ids = [the pilot, the lead].
+- `pilot:status_changed` — content = {from, to, note}; entity_ids = [the pilot].

--- a/examples/lobu-crm/agents/marketing/USER.md
+++ b/examples/lobu-crm/agents/marketing/USER.md
@@ -1,0 +1,8 @@
+# User Context
+
+- Operator: Burak (solo founder, sold enterprise before).
+- Goal: pilot #1 by ~July 2026 — 3 paying pilots × ~25 seats × ~$30/seat/mo is the near-term target.
+- The metric that matters: real customer conversations this week (target ≥3). Stars and impressions are leading indicators, not the goal.
+- Preference: pipeline views ranked by "closest to a paying pilot," with the next action spelled out. Terse in Slack.
+- Marketing is afternoon work; the first hour of each day is customer-facing. Don't let funnel admin substitute for actual conversations.
+- Positioning is fixed (the site headline): "Open-source backend for multi-user AI agents." Closest competitors: Onyx (search-only OSS), Dust (cloud platform), Glean (closed enterprise).

--- a/examples/lobu-crm/agents/marketing/skills/crm-ops/SKILL.md
+++ b/examples/lobu-crm/agents/marketing/skills/crm-ops/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: crm-ops
+description: How to operate the Lobu funnel CRM — create and enrich leads, log interactions, advance funnel stages, open and update pilots, and produce the weekly digest. Use whenever the task touches the pipeline.
+---
+
+# CRM operations
+
+The CRM lives in Lobu memory. Two entity types — `lead` and `pilot` — hold current state; events of type `lead:*` / `pilot:*` are the append-only history. The `converted-to` relationship links a `lead` to the `pilot` it became.
+
+## Funnel stages (the `stage` field on `lead`)
+
+`signal` → `trial` → `conversation` → `pilot` → `customer`, plus `cold` (went quiet / not a fit). "Reach" (an impression, a passing tweet view) is not a stage — no lead record until there's a signal.
+
+| Stage | Enter it when… |
+|---|---|
+| `signal` | starred the repo, followed on X, @-mentioned Lobu, commented on an issue |
+| `trial` | cloned / ran `lobu run` / completed the quickstart / asked a real deployment question |
+| `conversation` | DM'd, requested a demo, booked a call, said "we want to deploy this" |
+| `pilot` | signed up for a paid pilot — open a `pilot` entity, link with `converted-to` |
+| `customer` | converted from pilot to a paid contract |
+| `cold` | three touches with no response, or explicitly not a fit |
+
+## Creating / enriching a lead
+
+1. **Search first** — `search_memory({query: "<github handle | x handle | email | company>"})`. If a `lead` exists, enrich it; don't duplicate.
+2. If new: create the `lead` entity with metadata `{name, company, source, stage, github_handle, x_handle, email, notes}`. Set `stage` to the lowest stage the evidence supports.
+3. `save_memory({content: "<who, company, source>", semantic_type: "lead:created", entity_ids: [<lead>, <source connector event>]})`.
+
+## Logging an interaction
+
+After any touchpoint (a meeting Burak had, a DM exchange, an issue reply you drafted):
+`save_memory({content: "{type, summary, next_action, date}", semantic_type: "lead:interaction", entity_ids: [<lead>]})`. Update the lead's `notes` / `stage` if the touch moved it (see "advancing a stage").
+
+## Advancing a stage
+
+1. `save_memory({content: "{from, to, reason}", semantic_type: "lead:stage_changed", entity_ids: [<lead>]})`.
+2. Update the `lead` entity's `stage` field.
+Never change `stage` without the matching event.
+
+## Opening / updating a pilot
+
+- Open: create a `pilot` entity `{company, seats, mrr, status: "active", start_date, success_metric, lead_id}`; `converted-to` relationship from the lead; `save_memory({..., semantic_type: "pilot:created", entity_ids: [<pilot>, <lead>]})`; move the lead to `pilot`.
+- Update: `save_memory({content: "{from, to, note}", semantic_type: "pilot:status_changed", entity_ids: [<pilot>]})`; update the entity's `status` (`active` → `won` | `lost` | `paused`); if `won`, move the lead to `customer`.
+
+## Reads the operator asks for
+
+- **"who starred us this week and isn't tracked?"** — pull recent `stargazer` events (github connector), diff against `lead` entities with a `github_handle`, return the gap.
+- **"show the pipeline"** — `lead` entities grouped by `stage`, each with last-touch date and next action, ranked within stage by closeness-to-pilot.
+- **"state of the <company> pilot?"** — the `pilot` entity + its `pilot:*` events, newest first.
+
+## Weekly digest (used by the funnel-digest watcher)
+
+A Slack message, in this shape — keep it short:
+1. **One line at the top: the single recommended action this week.**
+2. Funnel snapshot: counts per stage, and what moved (new leads, stage changes, new/updated pilots).
+3. Top-of-funnel: stars / X mentions / HN+PH activity since last digest.
+4. Stale leads: anyone in `conversation` with no touch in 7+ days — flag for follow-up.
+5. Gaps: e.g. "12 new stars, 0 became leads — are we capturing the right signal?"
+
+Always end with the next action, never just the status.

--- a/examples/lobu-crm/lobu.toml
+++ b/examples/lobu-crm/lobu.toml
@@ -1,0 +1,38 @@
+# lobu.toml — Lobu CRM / funnel agent
+# Docs: https://lobu.ai/docs/getting-started
+#
+# Org `lobu-crm` is a dedicated workspace, separate from `buremba` (the personal
+# second brain). Connectors are configured in the org (dashboard / API), scoped
+# narrow so the agent's context stays funnel-only:
+#   - github       → lobu-ai/lobu  (stars, issues, PRs, comments)
+#   - x            → @lobu mentions + replies to your Lobu threads
+#   - hackernews   → search "lobu" / "openclaw"
+#   - producthunt  → the launch / "lobu"
+#   - website (optional) → lobu.ai + competitor changelogs (onyx, dust, glean)
+
+[agents.marketing]
+name = "marketing"
+description = "Maintains Lobu's funnel CRM — leads, pilots, inbound triage, weekly digest"
+dir = "./agents/marketing"
+
+[[agents.marketing.providers]]
+id = "anthropic"
+model = "claude/sonnet-4-5"
+key = "$ANTHROPIC_API_KEY"
+
+[agents.marketing.network]
+allowed = [
+  "github.com", ".github.com", "api.github.com", ".githubusercontent.com",
+  "x.com", "api.x.com", "twitter.com",
+  "news.ycombinator.com", "hn.algolia.com",
+  "api.producthunt.com",
+  "lobu.ai",
+]
+
+[memory]
+enabled = true
+org = "lobu-crm"
+name = "Lobu CRM"
+description = "Funnel CRM for Lobu — leads, pilots, conversations, launch signals"
+models = "./models"
+data = "./data"

--- a/examples/lobu-crm/models/converted-to.yaml
+++ b/examples/lobu-crm/models/converted-to.yaml
@@ -1,0 +1,5 @@
+version: 1
+type: relationship
+slug: converted-to
+name: Converted To
+description: Links a lead to the pilot it became, so the path from first signal to paying pilot stays explicit.

--- a/examples/lobu-crm/models/funnel-digest.yaml
+++ b/examples/lobu-crm/models/funnel-digest.yaml
@@ -1,0 +1,57 @@
+version: 1
+type: watcher
+slug: funnel-digest
+name: Weekly funnel digest
+# Monday 09:00 — the week's funnel snapshot + the one thing to do.
+schedule: "0 9 * * 1"
+prompt: |
+  Produce the weekly funnel digest and post it to Slack. Keep it short.
+
+  1. The single recommended action for the week, on the first line. Pick the
+     move that does the most to get pilot #1 closer (almost always: follow up
+     with the warmest lead in "conversation", or progress whichever pilot
+     conversation is furthest along).
+  2. Funnel snapshot: count of `lead` entities per stage; what moved since the
+     last digest (new leads, stage changes, new/updated `pilot` entities).
+  3. Top-of-funnel since last digest: new GitHub stars, X mentions/replies,
+     HN/PH activity.
+  4. Stale: any lead in `conversation` with no `lead:interaction` in 7+ days —
+     list them for follow-up.
+  5. One gap callout if there is one (e.g. "18 new stars, 0 became leads —
+     is inbound-triage catching the right signal?").
+
+  Tone: a checklist a busy founder reads in 30 seconds. End on the next action,
+  not the status. Remember: the metric that matters is customer conversations
+  this week — if that number is below 3, say so plainly.
+extraction_schema:
+  type: object
+  required:
+    - top_action
+    - stage_counts
+    - moved
+    - top_of_funnel
+    - stale_leads
+  properties:
+    top_action:
+      type: string
+    stage_counts:
+      type: object
+    moved:
+      type: object
+      properties:
+        new_leads: { type: integer }
+        stage_changes: { type: integer }
+        pilot_updates: { type: integer }
+    top_of_funnel:
+      type: object
+      properties:
+        stars: { type: integer }
+        x_mentions: { type: integer }
+        hn_ph_activity: { type: integer }
+    stale_leads:
+      type: array
+      items: { type: string }
+    gap:
+      type: string
+    conversations_this_week:
+      type: integer

--- a/examples/lobu-crm/models/inbound-triage.yaml
+++ b/examples/lobu-crm/models/inbound-triage.yaml
@@ -1,0 +1,58 @@
+version: 1
+type: watcher
+slug: inbound-triage
+name: Inbound triage
+# Every 2 hours during the day — catch new signals fast without spamming.
+schedule: "0 8-22/2 * * *"
+prompt: |
+  Look for new top-of-funnel signals since the last run, across the connectors
+  in this org:
+    - GitHub: new stargazers on lobu-ai/lobu; new issues / issue comments /
+      PR comments — especially anything with deployment, self-host, multi-tenant,
+      "how do I", or evaluation language.
+    - X: new @-mentions of Lobu, replies to Burak's Lobu threads, quote-tweets.
+    - Hacker News / Product Hunt: new comments or posts mentioning Lobu or OpenClaw.
+
+  For each signal that looks like a real person (not a bot, not a casual star):
+    1. search_memory for an existing `lead` (match github handle / x handle / email).
+    2. If none, create a `lead` entity at the lowest stage the evidence supports
+       (a bare star → "signal"; a deployment-flavored issue comment or a
+       "how do I deploy this for my team" mention → "trial" or "conversation"),
+       with source set to where it came from, and entity_ids linking to the
+       source event. Then save a `lead:created` event.
+    3. If a lead exists, enrich it (add the handle, bump the stage if the new
+       signal warrants it, update last_touch) and save a `lead:interaction` or
+       `lead:stage_changed` event as appropriate.
+
+  Then post to Slack: the new/updated leads, ranked by closeness-to-a-paying-pilot,
+  each with a one-line recommended next action (e.g. "reply on the issue and offer
+  a 20-min call"). If nothing notable, post nothing — don't manufacture noise.
+extraction_schema:
+  type: object
+  required:
+    - new_leads
+    - enriched_leads
+    - recommended_actions
+  properties:
+    new_leads:
+      type: array
+      items:
+        type: object
+        properties:
+          name: { type: string }
+          handle: { type: string }
+          source: { type: string }
+          stage: { type: string }
+          why: { type: string }
+    enriched_leads:
+      type: array
+      items:
+        type: object
+        properties:
+          name: { type: string }
+          change: { type: string }
+    recommended_actions:
+      type: array
+      items: { type: string }
+    notable:
+      type: boolean

--- a/examples/lobu-crm/models/lead.yaml
+++ b/examples/lobu-crm/models/lead.yaml
@@ -1,0 +1,53 @@
+version: 1
+type: entity
+slug: lead
+name: Lead
+description: A person who has shown a signal toward Lobu — starred, engaged, asked, or talked to us
+icon: user
+color: "#10B981"
+metadata_schema:
+  type: object
+  required:
+    - name
+    - source
+    - stage
+  properties:
+    name:
+      type: string
+      x-table-label: Name
+      x-table-column: true
+    company:
+      type: string
+      x-table-label: Company
+      x-table-column: true
+    stage:
+      type: string
+      enum: [signal, trial, conversation, pilot, customer, cold]
+      x-table-label: Stage
+      x-table-column: true
+    source:
+      type: string
+      description: Where they first showed up — "github:stargazer", "x:mention", "github:issue-comment", "demo-form", "intro", etc.
+      x-table-label: Source
+      x-table-column: true
+    github_handle:
+      type: string
+      x-table-label: GitHub
+      x-table-column: true
+    x_handle:
+      type: string
+      x-table-label: X
+    email:
+      type: string
+      x-table-label: Email
+    last_touch:
+      type: string
+      description: ISO date of the most recent interaction
+      x-table-label: Last touch
+      x-table-column: true
+    next_action:
+      type: string
+      x-table-label: Next action
+      x-table-column: true
+    notes:
+      type: string

--- a/examples/lobu-crm/models/pilot.yaml
+++ b/examples/lobu-crm/models/pilot.yaml
@@ -1,0 +1,43 @@
+version: 1
+type: entity
+slug: pilot
+name: Pilot
+description: A paid pilot — a company running Lobu for their team under a time-boxed agreement
+icon: rocket
+color: "#F59E0B"
+metadata_schema:
+  type: object
+  required:
+    - company
+    - status
+  properties:
+    company:
+      type: string
+      x-table-label: Company
+      x-table-column: true
+    status:
+      type: string
+      enum: [active, won, lost, paused]
+      x-table-label: Status
+      x-table-column: true
+    seats:
+      type: integer
+      x-table-label: Seats
+      x-table-column: true
+    mrr:
+      type: string
+      description: Monthly recurring revenue for the pilot, e.g. "$750"
+      x-table-label: MRR
+      x-table-column: true
+    start_date:
+      type: string
+      x-table-label: Start
+      x-table-column: true
+    success_metric:
+      type: string
+      description: The one metric agreed up front that defines pilot success
+      x-table-label: Success metric
+      x-table-column: true
+    lead_id:
+      type: string
+      description: The lead entity this pilot converted from


### PR DESCRIPTION
## What

Adds `examples/lobu-crm/` — a Lobu agent project that dogfoods Lobu itself as our funnel/CRM substrate. Same shape as the other `examples/*` projects (sales, market, atlas, …).

## Why

Decided May 2026: rather than a Notion/Airtable CRM with custom pipes, run the funnel on Lobu memory directly. The raw signal (stargazers, issue comments, X mentions, HN/PH activity) already lands in `events` via connectors — the "CRM" is a thin derived layer on top, maintained by a `marketing` agent. Cleaner one-source-of-truth, no integration glue, and a real demo of the product.

## What's in it

```
examples/lobu-crm/
  lobu.toml                          # marketing agent + provider + network + [memory].org = "lobu-crm"
  agents/marketing/
    IDENTITY.md  SOUL.md  USER.md
    skills/crm-ops/SKILL.md          # the agent's CRM playbook + event semantic-type protocol
  models/
    lead.yaml          entity        # stage: signal→trial→conversation→pilot→customer (+cold)
    pilot.yaml         entity        # company, seats, mrr, status, success_metric
    converted-to.yaml  relationship  # lead → pilot
    inbound-triage.yaml watcher      # every 2h: github/x/hn/ph signals → create/enrich leads → Slack
    funnel-digest.yaml  watcher      # Mon 09:00: snapshot + the one action this week → Slack
  data/entities/example-lead.yaml    # seed example
```

Schema lives in Lobu memory: `lead` and `pilot` are entities; the agent writes append-only events with semantic types `lead:created` / `lead:interaction` / `lead:stage_changed` / `pilot:created` / `pilot:status_changed`, each linked via `entity_ids` to the connector event that justifies it. `events` is append-only — corrections via `supersedes_event_id`, never `DELETE`.

## Validated

`lobu validate` from `examples/lobu-crm/` → `lobu.toml is valid · 1 agent(s) configured`.

## Setup for the dedicated org (operator steps, not in this PR)

The `lobu-crm` org already exists on prod (created out-of-band — separate from the personal `buremba` org so the agent's context stays funnel-only). After merge:

1. `cd examples/lobu-crm && lobu link` → bind to the `lobu-crm` org.
2. `lobu apply` → push the agent + models + watchers.
3. In the dashboard, add scoped connectors in `lobu-crm`: github → `lobu-ai/lobu`; a fresh X connector (search "lobu"/"openclaw"); hackernews → "lobu"/"openclaw"; producthunt → "lobu". Connect Slack (the watchers post there).
4. The 37,038 historical X events were already moved buremba→lobu-crm; github/hn/ph backfill from a public corpus, no migration needed.
5. One-time seeding pass: agent sweeps backfilled stargazers + issue comments + the X events → initial `lead` rows.