### PR TITLE
chore(lobu-crm): switch marketing agent to z.ai provider

### DIFF
--- a/examples/lobu-crm/lobu.toml
+++ b/examples/lobu-crm/lobu.toml
@@ -16,9 +16,9 @@ description = "Maintains Lobu's funnel CRM — leads, pilots, inbound triage, we
 dir = "./agents/marketing"
 
 [[agents.marketing.providers]]
-id = "anthropic"
-model = "claude/sonnet-4-5"
-key = "$ANTHROPIC_API_KEY"
+id = "z-ai"
+model = "z-ai/glm-4.7"
+key = "$Z_AI_API_KEY"
 
 [agents.marketing.network]
 allowed = [
@@ -26,6 +26,7 @@ allowed = [
   "x.com", "api.x.com", "twitter.com",
   "news.ycombinator.com", "hn.algolia.com",
   "api.producthunt.com",
+  "api.z.ai", ".z.ai",
   "lobu.ai",
 ]
 


### PR DESCRIPTION
Use `z-ai/glm-4.7` ($Z_AI_API_KEY) instead of `anthropic/claude-sonnet-4-5` for the `marketing` agent in `examples/lobu-crm/`. Same provider already wired in `examples/atlas/`. Adds `api.z.ai` to the network allowlist. `lobu validate` passes.