### PR TITLE
feat(watchers): allow org-scoped watchers + sync them in lobu apply

### DIFF
--- a/packages/cli/src/commands/_lib/apply/__tests__/client.test.ts
+++ b/packages/cli/src/commands/_lib/apply/__tests__/client.test.ts
@@ -25,4 +25,57 @@ describe("ApplyClient", () => {
       description: "Updated",
     });
   });
+
+  test("listWatchers GETs /watchers and unwraps the list", async () => {
+    const calls: Array<{ url: string; init?: RequestInit }> = [];
+    const client = new ApplyClient(
+      { apiBaseUrl: "https://example.test", orgSlug: "acme", token: "tok" },
+      (async (url, init) => {
+        calls.push({ url: String(url), init });
+        return new Response(
+          JSON.stringify({ watchers: [{ slug: "digest", name: "Digest" }] }),
+          { status: 200 }
+        );
+      }) as typeof fetch
+    );
+
+    const watchers = await client.listWatchers();
+    expect(calls[0]?.url).toBe("https://example.test/api/acme/watchers");
+    expect(calls[0]?.init?.method).toBe("GET");
+    expect(watchers).toEqual([{ slug: "digest", name: "Digest" }]);
+  });
+
+  test("createWatcher POSTs manage_watchers with action=create and no entity_id", async () => {
+    const calls: Array<{ url: string; init?: RequestInit }> = [];
+    const client = new ApplyClient(
+      { apiBaseUrl: "https://example.test", orgSlug: "acme", token: "tok" },
+      (async (url, init) => {
+        calls.push({ url: String(url), init });
+        return new Response(JSON.stringify({ action: "create" }), {
+          status: 200,
+        });
+      }) as typeof fetch
+    );
+
+    await client.createWatcher({
+      slug: "digest",
+      name: "Digest",
+      prompt: "Produce a digest.",
+      extraction_schema: { type: "object" },
+      schedule: "0 9 * * 1",
+    });
+
+    expect(calls[0]?.url).toBe("https://example.test/api/acme/manage_watchers");
+    expect(calls[0]?.init?.method).toBe("POST");
+    const body = JSON.parse(String(calls[0]?.init?.body));
+    expect(body).toEqual({
+      action: "create",
+      slug: "digest",
+      name: "Digest",
+      prompt: "Produce a digest.",
+      extraction_schema: { type: "object" },
+      schedule: "0 9 * * 1",
+    });
+    expect("entity_id" in body).toBe(false);
+  });
 });

--- a/packages/cli/src/commands/_lib/apply/__tests__/desired-state.test.ts
+++ b/packages/cli/src/commands/_lib/apply/__tests__/desired-state.test.ts
@@ -171,7 +171,62 @@ models = "./custom-models"
     await expect(loadDesiredState({ cwd: dir })).rejects.toThrow(/lobu/);
   });
 
-  test("rejects watcher blocks (v1 doesn't sync watchers)", async () => {
+  test("loads watcher model files into state.watchers", async () => {
+    const dir = mkProject(
+      `[agents.triage]
+name = "Triage"
+dir = "./agents/triage"
+
+[memory]
+enabled = true
+org = "dev"
+models = "./models"
+`
+    );
+    const modelsDir = join(dir, "models");
+    mkdirSync(modelsDir, { recursive: true });
+    writeFileSync(
+      join(modelsDir, "digest.yaml"),
+      `version: 1
+type: watcher
+slug: weekly-digest
+name: Weekly digest
+description: A short weekly summary.
+schedule: "0 9 * * 1"
+prompt: |
+  Produce a short weekly digest.
+extraction_schema:
+  type: object
+  required: [summary]
+  properties:
+    summary: { type: string }
+sources:
+  - name: content
+    query: SELECT * FROM events ORDER BY occurred_at DESC
+`
+    );
+
+    const { state } = await loadDesiredState({ cwd: dir });
+    expect(state.watchers).toHaveLength(1);
+    const w = state.watchers[0]!;
+    expect(w.slug).toBe("weekly-digest");
+    expect(w.name).toBe("Weekly digest");
+    expect(w.description).toBe("A short weekly summary.");
+    expect(w.schedule).toBe("0 9 * * 1");
+    expect(w.prompt).toContain("weekly digest");
+    expect(w.extractionSchema).toMatchObject({
+      type: "object",
+      required: ["summary"],
+    });
+    expect(w.sources).toEqual([
+      {
+        name: "content",
+        query: "SELECT * FROM events ORDER BY occurred_at DESC",
+      },
+    ]);
+  });
+
+  test("rejects watcher blocks in lobu.toml (apply syncs models/*.yaml watchers, not toml)", async () => {
     const dir = mkProject(
       `[agents.triage]
 name = "Triage"

--- a/packages/cli/src/commands/_lib/apply/__tests__/diff.test.ts
+++ b/packages/cli/src/commands/_lib/apply/__tests__/diff.test.ts
@@ -21,11 +21,16 @@ function buildDesiredAgent(
   };
 }
 
-function buildState(agents: DesiredAgent[]): DesiredState {
+function buildState(
+  agents: DesiredAgent[],
+  overrides: Partial<DesiredState> = {}
+): DesiredState {
   return {
     agents,
     memorySchema: { entityTypes: [], relationshipTypes: [] },
+    watchers: [],
     requiredSecrets: [],
+    ...overrides,
   };
 }
 
@@ -36,6 +41,7 @@ function emptyRemote(): RemoteSnapshot {
     platformsByAgent: new Map(),
     entityTypes: [],
     relationshipTypes: [],
+    watchers: [],
   };
 }
 
@@ -266,6 +272,7 @@ describe("apply diff — memory schema", () => {
           },
         ],
       },
+      watchers: [],
       requiredSecrets: [],
     };
     const plan = computeDiff(desired, emptyRemote());
@@ -280,6 +287,7 @@ describe("apply diff — memory schema", () => {
         entityTypes: [{ slug: "company", name: "Company" }],
         relationshipTypes: [],
       },
+      watchers: [],
       requiredSecrets: [],
     };
     const remote: RemoteSnapshot = {
@@ -392,6 +400,48 @@ describe("apply diff — empty container preservation", () => {
     const plan = computeDiff(desired, remote);
     const platformRow = plan.rows.find((r) => r.kind === "platform");
     expect(platformRow?.verb).toBe("update");
+  });
+});
+
+describe("apply diff — watchers", () => {
+  const desiredWatcher = {
+    slug: "weekly-digest",
+    name: "Weekly digest",
+    prompt: "Produce a digest.",
+    extractionSchema: { type: "object" as const },
+    schedule: "0 9 * * 1",
+  };
+
+  test("create when watcher missing remotely", () => {
+    const desired = buildState([], { watchers: [desiredWatcher] });
+    const plan = computeDiff(desired, emptyRemote());
+    const row = plan.rows.find((r) => r.kind === "watcher");
+    expect(row?.verb).toBe("create");
+    expect(row?.id).toBe("weekly-digest");
+  });
+
+  test("noop when watcher already exists remotely", () => {
+    const desired = buildState([], { watchers: [desiredWatcher] });
+    const remote: RemoteSnapshot = {
+      ...emptyRemote(),
+      watchers: [{ slug: "weekly-digest", name: "Weekly digest" }],
+    };
+    const plan = computeDiff(desired, remote);
+    const row = plan.rows.find((r) => r.kind === "watcher");
+    expect(row?.verb).toBe("noop");
+    expect(plan.counts.create).toBe(0);
+  });
+
+  test("drift when remote watcher not declared in models", () => {
+    const desired = buildState([], { watchers: [] });
+    const remote: RemoteSnapshot = {
+      ...emptyRemote(),
+      watchers: [{ slug: "orphan-watcher" }],
+    };
+    const plan = computeDiff(desired, remote);
+    const row = plan.rows.find((r) => r.kind === "watcher");
+    expect(row?.verb).toBe("drift");
+    expect(plan.counts.drift).toBe(1);
   });
 });
 

--- a/packages/cli/src/commands/_lib/apply/apply-cmd.ts
+++ b/packages/cli/src/commands/_lib/apply/apply-cmd.ts
@@ -82,6 +82,7 @@ async function fetchRemoteSnapshot(
   const entityTypes = only === "agents" ? [] : await client.listEntityTypes();
   const relationshipTypes =
     only === "agents" ? [] : await client.listRelationshipTypes();
+  const watchers = only === "agents" ? [] : await client.listWatchers();
 
   return {
     agents,
@@ -89,6 +90,7 @@ async function fetchRemoteSnapshot(
     platformsByAgent,
     entityTypes,
     relationshipTypes,
+    watchers,
   };
 }
 
@@ -182,6 +184,23 @@ async function executePlan(ctx: ApplyContext): Promise<void> {
     if (!row.desired) continue;
     await ctx.client.upsertRelationshipType(row.desired);
     printText(renderProgress(row.verb, "relationship-type", row.id));
+  }
+
+  // 6) Watchers (create-only; drift ignored)
+  for (const row of rowsByKind("watcher")) {
+    if (row.kind !== "watcher") continue;
+    if (!row.desired) continue;
+    const w = row.desired;
+    await ctx.client.createWatcher({
+      slug: w.slug,
+      name: w.name,
+      description: w.description,
+      prompt: w.prompt,
+      extraction_schema: w.extractionSchema,
+      schedule: w.schedule,
+      sources: w.sources,
+    });
+    printText(renderProgress(row.verb, "watcher", row.id));
   }
 }
 

--- a/packages/cli/src/commands/_lib/apply/client.ts
+++ b/packages/cli/src/commands/_lib/apply/client.ts
@@ -37,6 +37,12 @@ export interface RemoteRelationshipType {
   rules?: Array<{ source: string; target: string }>;
 }
 
+export interface RemoteWatcher {
+  slug: string;
+  name?: string;
+  watcher_id?: string;
+}
+
 export interface UpsertPlatformResult {
   /** Server reports `noop: true` when the desired config matches what's stored. */
   noop?: boolean;
@@ -369,6 +375,43 @@ export class ApplyClient {
       }
     }
     return result;
+  }
+
+  // ── Watchers ──────────────────────────────────────────────────────────────
+
+  async listWatchers(): Promise<RemoteWatcher[]> {
+    const { body } = await this.request<{ watchers?: RemoteWatcher[] }>(
+      "GET",
+      `/api/${this.orgSlug}/watchers`
+    );
+    return body.watchers ?? [];
+  }
+
+  /**
+   * Create an org-scoped (entity-less) watcher. `extraction_schema` is sent as
+   * a JSON object — the `manage_watchers` tool accepts `Type.Any()` there and
+   * normalizes string-or-object internally. Duplicate-slug surfaces as a
+   * structured error the caller swallows for idempotency.
+   */
+  async createWatcher(payload: {
+    slug: string;
+    name?: string;
+    description?: string;
+    prompt: string;
+    extraction_schema: Record<string, unknown>;
+    schedule?: string;
+    sources?: Array<{ name: string; query: string }>;
+  }): Promise<void> {
+    await this.request("POST", `/api/${this.orgSlug}/manage_watchers`, {
+      action: "create",
+      slug: payload.slug,
+      ...(payload.name ? { name: payload.name } : {}),
+      ...(payload.description ? { description: payload.description } : {}),
+      prompt: payload.prompt,
+      extraction_schema: payload.extraction_schema,
+      ...(payload.schedule ? { schedule: payload.schedule } : {}),
+      ...(payload.sources?.length ? { sources: payload.sources } : {}),
+    });
   }
 }
 

--- a/packages/cli/src/commands/_lib/apply/desired-state.ts
+++ b/packages/cli/src/commands/_lib/apply/desired-state.ts
@@ -64,6 +64,18 @@ export interface DesiredRelationshipType {
   metadata?: Record<string, unknown>;
 }
 
+export interface DesiredWatcher {
+  slug: string;
+  name?: string;
+  description?: string;
+  schedule?: string;
+  prompt: string;
+  /** Parsed JSON Schema object describing the LLM output. */
+  extractionSchema: Record<string, unknown>;
+  /** Optional SQL data sources; server applies a default when omitted. */
+  sources?: Array<{ name: string; query: string }>;
+}
+
 export interface DesiredAgent {
   metadata: DesiredAgentMetadata;
   /**
@@ -85,6 +97,8 @@ export interface DesiredState {
     entityTypes: DesiredEntityType[];
     relationshipTypes: DesiredRelationshipType[];
   };
+  /** Watchers declared as `type: watcher` in `models/*.yaml`. */
+  watchers: DesiredWatcher[];
   /**
    * Names of env vars referenced as `$NAME` anywhere in lobu.toml. The CLI
    * surfaces these to the user before mutating remote state so missing
@@ -593,6 +607,40 @@ function parseEntityType(raw: unknown): DesiredEntityType {
   return out;
 }
 
+function parseWatcher(raw: unknown): DesiredWatcher {
+  if (!isRecord(raw) || typeof raw.slug !== "string") {
+    throw new ValidationError(
+      `watcher model files must be objects with a "slug" string field; got ${JSON.stringify(raw)}`
+    );
+  }
+  if (typeof raw.prompt !== "string" || !raw.prompt.trim()) {
+    throw new ValidationError(
+      `watcher "${raw.slug}" is missing a "prompt" string`
+    );
+  }
+  const extractionSchema = isRecord(raw.extraction_schema)
+    ? raw.extraction_schema
+    : {};
+  const out: DesiredWatcher = {
+    slug: raw.slug,
+    prompt: raw.prompt,
+    extractionSchema,
+  };
+  if (typeof raw.name === "string") out.name = raw.name;
+  if (typeof raw.description === "string") out.description = raw.description;
+  if (typeof raw.schedule === "string") out.schedule = raw.schedule;
+  if (Array.isArray(raw.sources)) {
+    out.sources = raw.sources
+      .filter(isRecord)
+      .filter(
+        (s): s is { name: string; query: string } & Record<string, unknown> =>
+          typeof s.name === "string" && typeof s.query === "string"
+      )
+      .map((s) => ({ name: s.name, query: s.query }));
+  }
+  return out;
+}
+
 function parseRelationshipType(raw: unknown): DesiredRelationshipType {
   if (!isRecord(raw) || typeof raw.slug !== "string") {
     throw new ValidationError(
@@ -619,18 +667,28 @@ function parseRelationshipType(raw: unknown): DesiredRelationshipType {
   return out;
 }
 
+interface LoadedMemoryModels {
+  entityTypes: DesiredEntityType[];
+  relationshipTypes: DesiredRelationshipType[];
+  watchers: DesiredWatcher[];
+}
+
 /**
  * Read memory schema files referenced by `[memory].models`. Each YAML
- * file in that directory should declare `type: entity_type` or
- * `type: relationship_type` (matches the seed-cmd schema).
- *
- * v1: parse only entity_type and relationship_type. Watchers are deferred.
+ * file in that directory should declare `type: entity_type`,
+ * `type: relationship_type`, or `type: watcher` (matches the seed-cmd
+ * schema). `lobu apply` syncs entity types, relationship types, and
+ * watchers from these files; watcher sync is create-only (drift ignored).
  */
-async function loadMemorySchema(
+async function loadMemoryModels(
   config: LobuTomlConfig,
   projectRoot: string
-): Promise<DesiredState["memorySchema"]> {
-  const empty = { entityTypes: [], relationshipTypes: [] };
+): Promise<LoadedMemoryModels> {
+  const empty: LoadedMemoryModels = {
+    entityTypes: [],
+    relationshipTypes: [],
+    watchers: [],
+  };
   const mem = config.memory;
   if (!mem || mem.enabled === false) return empty;
 
@@ -647,6 +705,7 @@ async function loadMemorySchema(
     return {
       entityTypes: entityTypesRaw.map(parseEntityType),
       relationshipTypes: relTypesRaw.map(parseRelationshipType),
+      watchers: [],
     };
   }
 
@@ -661,6 +720,7 @@ async function loadMemorySchema(
 
   const entityTypes: DesiredEntityType[] = [];
   const relationshipTypes: DesiredRelationshipType[] = [];
+  const watchers: DesiredWatcher[] = [];
 
   const files = readdirSync(modelsPath)
     .filter((f) => f.endsWith(".yaml") || f.endsWith(".yml"))
@@ -677,11 +737,12 @@ async function loadMemorySchema(
       parsed.type === "relationship"
     ) {
       relationshipTypes.push(parseRelationshipType(parsed));
+    } else if (parsed.type === "watcher") {
+      watchers.push(parseWatcher(parsed));
     }
-    // watcher files are out of scope for v1 apply
   }
 
-  return { entityTypes, relationshipTypes };
+  return { entityTypes, relationshipTypes, watchers };
 }
 
 /**
@@ -712,7 +773,7 @@ async function rejectUnsupportedAgentShapes(cwd: string): Promise<void> {
     const watchers = (agentConfig as Record<string, unknown>).watchers;
     if (Array.isArray(watchers) && watchers.length > 0) {
       throw new ValidationError(
-        `agent "${agentId}" declares [[agents.${agentId}.watchers]] — \`lobu apply\` does not sync watchers in v1. Remove the block or use \`lobu memory seed\`.`
+        `agent "${agentId}" declares [[agents.${agentId}.watchers]] — \`lobu apply\` syncs watchers from \`models/*.yaml\` (\`type: watcher\`), not from lobu.toml. Move the watcher to a model file or use \`lobu memory seed\`.`
       );
     }
   }
@@ -763,12 +824,16 @@ export async function loadDesiredState(
     agents.push({ metadata, settings, platforms });
   }
 
-  const memorySchema = await loadMemorySchema(config, opts.cwd);
+  const { entityTypes, relationshipTypes, watchers } = await loadMemoryModels(
+    config,
+    opts.cwd
+  );
 
   return {
     state: {
       agents,
-      memorySchema,
+      memorySchema: { entityTypes, relationshipTypes },
+      watchers,
       requiredSecrets: [...requiredSecrets].sort(),
     },
     configPath,

--- a/packages/cli/src/commands/_lib/apply/diff.ts
+++ b/packages/cli/src/commands/_lib/apply/diff.ts
@@ -4,12 +4,14 @@ import type {
   RemoteEntityType,
   RemotePlatform,
   RemoteRelationshipType,
+  RemoteWatcher,
 } from "./client.js";
 import type {
   DesiredAgent,
   DesiredEntityType,
   DesiredPlatform,
   DesiredRelationshipType,
+  DesiredWatcher,
 } from "./desired-state.js";
 
 // ── Diff verbs ──────────────────────────────────────────────────────────────
@@ -60,12 +62,21 @@ export interface RelationshipTypeDiffRow extends BaseRow {
   changedFields?: string[];
 }
 
+export interface WatcherDiffRow extends BaseRow {
+  kind: "watcher";
+  desired?: DesiredWatcher;
+  remote?: RemoteWatcher;
+  /** Always absent — watchers are create-or-noop, never updated by apply. */
+  changedFields?: string[];
+}
+
 export type DiffRow =
   | AgentDiffRow
   | SettingsDiffRow
   | PlatformDiffRow
   | EntityTypeDiffRow
-  | RelationshipTypeDiffRow;
+  | RelationshipTypeDiffRow
+  | WatcherDiffRow;
 
 export interface DiffPlan {
   rows: DiffRow[];
@@ -332,6 +343,29 @@ function diffRelationshipType(
   };
 }
 
+/**
+ * Watchers are sync-on-create only: a model file declares a watcher, and the
+ * first apply creates it. Subsequent applies see the slug remotely and noop.
+ * Remote watchers without a desired model are reported as drift, never
+ * deleted — and we deliberately don't diff prompt/schema/schedule changes in
+ * v1, so editing a watcher in the UI won't be clobbered by apply.
+ */
+function diffWatcher(
+  desired: DesiredWatcher,
+  remote: RemoteWatcher | undefined
+): WatcherDiffRow {
+  if (!remote) {
+    return { kind: "watcher", verb: "create", id: desired.slug, desired };
+  }
+  return {
+    kind: "watcher",
+    verb: "noop",
+    id: desired.slug,
+    desired,
+    remote,
+  };
+}
+
 // ── Top-level diff ─────────────────────────────────────────────────────────
 
 export interface RemoteSnapshot {
@@ -342,6 +376,7 @@ export interface RemoteSnapshot {
   platformsByAgent: Map<string, RemotePlatform[]>;
   entityTypes: RemoteEntityType[];
   relationshipTypes: RemoteRelationshipType[];
+  watchers: RemoteWatcher[];
 }
 
 export interface DesiredStateForDiff {
@@ -350,6 +385,7 @@ export interface DesiredStateForDiff {
     entityTypes: DesiredEntityType[];
     relationshipTypes: DesiredRelationshipType[];
   };
+  watchers: DesiredWatcher[];
 }
 
 export interface ComputeDiffOptions {
@@ -470,6 +506,24 @@ export function computeDiff(
           verb: "drift",
           id: remoteRel.slug,
           remote: remoteRel,
+        });
+      }
+    }
+
+    const remoteWatcherBySlug = new Map(
+      remote.watchers.map((w) => [w.slug, w])
+    );
+    const desiredWatcherSlugs = new Set(desired.watchers.map((w) => w.slug));
+    for (const watcher of desired.watchers) {
+      rows.push(diffWatcher(watcher, remoteWatcherBySlug.get(watcher.slug)));
+    }
+    for (const remoteWatcher of remote.watchers) {
+      if (!desiredWatcherSlugs.has(remoteWatcher.slug)) {
+        rows.push({
+          kind: "watcher",
+          verb: "drift",
+          id: remoteWatcher.slug,
+          remote: remoteWatcher,
         });
       }
     }

--- a/packages/cli/src/commands/_lib/apply/render.ts
+++ b/packages/cli/src/commands/_lib/apply/render.ts
@@ -14,6 +14,7 @@ const KIND_LABEL: Record<DiffRow["kind"], string> = {
   platform: "platform",
   "entity-type": "entity-type",
   "relationship-type": "relationship-type",
+  watcher: "watcher",
 };
 
 function fieldsList(fields: string[] | undefined): string {
@@ -64,6 +65,7 @@ export function renderPlan(plan: DiffPlan): string {
     "platform",
     "entity-type",
     "relationship-type",
+    "watcher",
   ];
   for (const kind of order) {
     const rowsForKind = plan.rows.filter((row) => row.kind === kind);

--- a/packages/server/src/__tests__/integration/watchers/watchers-crud.test.ts
+++ b/packages/server/src/__tests__/integration/watchers/watchers-crud.test.ts
@@ -71,6 +71,38 @@ describe('watcher CRUD', () => {
     expect(list.watchers?.some((w) => w.watcher_id === watcherId)).toBe(false);
   });
 
+  it('creates an org-scoped watcher with no entity_id', async () => {
+    const created = (await owner.watchers.create({
+      slug: 'org-scoped-watcher',
+      name: 'Org Scoped',
+      prompt: 'Track org-wide signals.',
+      extraction_schema: {
+        type: 'object',
+        properties: { signals: { type: 'array', items: { type: 'string' } } },
+      },
+    })) as { watcher_id: string };
+    expect(created.watcher_id).toBeDefined();
+
+    const got = (await owner.watchers.get(created.watcher_id)) as {
+      watcher?: { entity_ids?: number[] };
+    };
+    expect(got.watcher?.entity_ids ?? []).toEqual([]);
+
+    await owner.watchers.delete([created.watcher_id]);
+  });
+
+  it('rejects an org-scoped watcher when there is no organization context', async () => {
+    const noOrg = owner.withAuth({ organizationId: null });
+    await expect(
+      noOrg.watchers.create({
+        slug: 'no-org-watcher',
+        name: 'No Org',
+        prompt: 'should fail',
+        extraction_schema: { type: 'object', properties: {} },
+      })
+    ).rejects.toThrow(/organization|entity_id/i);
+  });
+
   it('blocks a member from deleting watchers (admin-only)', async () => {
     const created = (await owner.watchers.create({
       entity_id: entityId,

--- a/packages/server/src/__tests__/setup/test-mcp-client.ts
+++ b/packages/server/src/__tests__/setup/test-mcp-client.ts
@@ -252,7 +252,10 @@ export class TestApiClient {
       (this.ctx.userId !== null ? ('oauth' as TokenType) : ('anonymous' as TokenType));
     const scopedToOrg = overrides.scopedToOrg ?? this.ctx.scopedToOrg ?? true;
     const ctx: ToolContext = {
-      organizationId: overrides.organizationId ?? this.ctx.organizationId,
+      organizationId:
+        overrides.organizationId !== undefined
+          ? overrides.organizationId
+          : this.ctx.organizationId,
       userId: overrides.userId !== undefined ? overrides.userId : this.ctx.userId,
       memberRole:
         overrides.memberRole !== undefined

--- a/packages/server/src/sandbox/namespaces/watchers.ts
+++ b/packages/server/src/sandbox/namespaces/watchers.ts
@@ -30,7 +30,8 @@ export interface WatcherListFilter {
 }
 
 export interface WatcherCreateInput {
-  entity_id: number;
+  /** Attach the watcher to an entity. Omit for an org-scoped/global watcher. */
+  entity_id?: number;
   prompt: string;
   extraction_schema: Record<string, unknown>;
   sources?: Source[];

--- a/packages/server/src/tools/admin/manage_watchers.ts
+++ b/packages/server/src/tools/admin/manage_watchers.ts
@@ -27,7 +27,11 @@ import { nextRunAt, validateSchedule } from '../../utils/cron';
 import { recordChangeEvent } from '../../utils/insert-event';
 import { verifyWindowToken } from '../../utils/jwt';
 import logger from '../../utils/logger';
-import { requireReadAccess, requireWriteAccess } from '../../utils/organization-access';
+import {
+  requireOrgWriteAccess,
+  requireReadAccess,
+  requireWriteAccess,
+} from '../../utils/organization-access';
 import { resolveUsernames } from '../../utils/resolve-usernames';
 import { computeStableKeys } from '../../utils/stable-keys';
 import {
@@ -265,7 +269,8 @@ export const ManageWatchersSchema = Type.Object({
   ),
   entity_id: Type.Optional(
     Type.Number({
-      description: 'Entity ID. Required for create. Optional for list.',
+      description:
+        'Entity ID. Optional for create — provide it to attach the watcher to an entity; omit it for an org-scoped/global watcher. Optional for list.',
     })
   ),
   entity_ids: Type.Optional(
@@ -602,8 +607,12 @@ export async function manageWatchers(
   const pgSql = createDbClientFromEnv(env);
 
   // Validate organization access based on action type
-  if (args.action === 'create' && args.entity_id) {
-    await requireWriteAccess(pgSql, args.entity_id, ctx);
+  if (args.action === 'create') {
+    if (args.entity_id) {
+      await requireWriteAccess(pgSql, args.entity_id, ctx);
+    } else {
+      await requireOrgWriteAccess(pgSql, ctx);
+    }
   } else if (args.action === 'update' && args.watcher_id) {
     const entityId = await getWatcherEntityId(args.watcher_id);
     if (entityId) await requireWriteAccess(pgSql, entityId, ctx);
@@ -821,11 +830,7 @@ async function handleCreate(
     throw new Error('extraction_schema is required for create action');
   }
 
-  // Require entity_id
-  if (!args.entity_id) {
-    throw new Error('entity_id is required');
-  }
-
+  // entity_id is optional: omit it for an org-scoped/global watcher.
   const entityId = args.entity_id;
 
   // Parse JSON inputs
@@ -883,22 +888,31 @@ async function handleCreate(
   let organizationId: string | null = ctx.organizationId ?? null;
   let organizationSlug: string | null = null;
 
-  const entityResult = await sql`
-    SELECT
-      e.id, et.slug AS entity_type, e.parent_id, e.slug, e.organization_id,
-      parent.slug as parent_slug, pet.slug as parent_entity_type
-    FROM entities e
-    JOIN entity_types et ON et.id = e.entity_type_id
-    LEFT JOIN entities parent ON e.parent_id = parent.id
-    LEFT JOIN entity_types pet ON pet.id = parent.entity_type_id
-    WHERE e.id = ${entityId}
-  `;
-  if (entityResult.length === 0) {
-    throw new Error(`Entity with ID ${entityId} not found`);
+  if (entityId) {
+    const entityResult = await sql`
+      SELECT
+        e.id, et.slug AS entity_type, e.parent_id, e.slug, e.organization_id,
+        parent.slug as parent_slug, pet.slug as parent_entity_type
+      FROM entities e
+      JOIN entity_types et ON et.id = e.entity_type_id
+      LEFT JOIN entities parent ON e.parent_id = parent.id
+      LEFT JOIN entity_types pet ON pet.id = parent.entity_type_id
+      WHERE e.id = ${entityId}
+    `;
+    if (entityResult.length === 0) {
+      throw new Error(`Entity with ID ${entityId} not found`);
+    }
+    entityRow = entityResult[0] as EntityRow;
+    organizationId = entityRow.organization_id;
+    organizationSlug = await getOrganizationSlug(organizationId);
+  } else {
+    if (!organizationId) {
+      throw new Error(
+        'entity_id or an organization context is required to create a watcher'
+      );
+    }
+    organizationSlug = await getOrganizationSlug(organizationId);
   }
-  entityRow = entityResult[0] as EntityRow;
-  organizationId = entityRow.organization_id;
-  organizationSlug = await getOrganizationSlug(organizationId);
 
   // Check slug uniqueness within org
   const existingSlug = await sql`

--- a/packages/server/src/utils/organization-access.ts
+++ b/packages/server/src/utils/organization-access.ts
@@ -108,3 +108,35 @@ export async function requireWriteAccess(
     throw new Error(`Access denied: entity ${entityId} does not belong to your organization`);
   }
 }
+
+/**
+ * Check if the caller may write at the organization level (no entity scope).
+ * Used by org-scoped resources like watchers that have their own organization_id.
+ */
+async function canWriteOrg(sql: DbClient, ctx: ToolContext): Promise<boolean> {
+  if (!ctx.organizationId) return false;
+
+  // System/internal calls (e.g. reaction scripts) — authenticated context is sufficient
+  if (!ctx.userId && ctx.isAuthenticated) return true;
+  if (!ctx.userId) return false;
+
+  const membership = await sql`
+    SELECT 1
+    FROM "member"
+    WHERE "organizationId" = ${ctx.organizationId}
+      AND "userId" = ${ctx.userId}
+      AND role IN ('owner', 'admin')
+    LIMIT 1
+  `;
+  return membership.length > 0;
+}
+
+/**
+ * Require organization-level write access or throw.
+ */
+export async function requireOrgWriteAccess(sql: DbClient, ctx: ToolContext): Promise<void> {
+  const ok = await canWriteOrg(sql, ctx);
+  if (!ok) {
+    throw new Error('Access denied: organization-level write access is required');
+  }
+}


### PR DESCRIPTION
## What

Two-part change so `lobu apply` can deploy watchers declared in `models/*.yaml` (`type: watcher`) — today it silently skips them.

### Part 1 — server: allow entity-less (org-scoped) watcher creation
`manage_watchers` `create` previously hard-required `entity_id` and derived the org from the entity. But watchers don't need an entity: `public.watchers` has its own `organization_id` column and `entity_ids bigint[]` is nullable.

- `entity_id` present → existing path unchanged (entity lookup, org from entity, `entity_ids = [entityId]`, view_url).
- `entity_id` absent → skip the entity lookup; org = `ctx.organizationId` (clear error if also unset); `entity_ids` inserted as `'{}'::bigint[]`. Slug-uniqueness, schedule validation, and both INSERTs unchanged.
- Authorization for entity-less creates goes through a new `requireOrgWriteAccess(sql, ctx)` helper (owner/admin membership on the org, or an authenticated system context) — create stays authenticated.
- `entity_id` param description updated to note it's optional.

### Part 2 — CLI: sync watchers in `lobu apply`
Mirrors the entity-type code paths. **Conservative scoping: create-only.**
- `desired-state.ts`: `DesiredWatcher` interface + `watchers: DesiredWatcher[]` on `DesiredState`; `models/*.yaml` loop now parses `type: watcher` via a `parseWatcher` helper (`extraction_schema` → `extractionSchema`, `sources` kept as `{name, query}[]`). Stale "watchers are deferred" comments updated.
- `client.ts`: `RemoteWatcher` type, `listWatchers()` (`GET /api/:org/watchers`, unwraps `{ watchers: [...] }`), `createWatcher(payload)` (`POST /api/:org/manage_watchers` with `action: create`, no `entity_id`; `extraction_schema` sent as an object since the tool param is `Type.Any()`).
- `diff.ts`: watcher diffing — desired-not-in-remote → `create`; in-both → `noop`; remote-not-desired → `drift` (reported, never deleted; prompt/schedule changes deliberately not diffed, so UI edits aren't clobbered).
- `apply-cmd.ts`: fetches watchers in the snapshot (when `only !== 'agents'`) and adds a watcher apply step.
- `render.ts`: `watchers:` section in the `Plan:` output.

## Why entity-less is fine
`public.watchers.organization_id` is the watcher's owning org; `entity_ids` is an optional `bigint[]` link, nullable in the schema and already handled as `entityId ? [entityId] : []` in the insert.

## Validation
- `bun run typecheck` — clean.
- `make build-packages` — succeeds.
- CLI: `bun test packages/cli/src/commands/_lib/apply` — **30/30 pass** (new: `desired-state` watcher-model test, `diff` create/noop/drift watcher tests, `client` listWatchers/createWatcher tests).
- Server: `vitest run src/__tests__/integration/watchers/watchers-crud.test.ts` under pglite — **4/4 pass**, including new cases: create with `entity_id` (regression), create without `entity_id` succeeds with `ctx.organizationId` set and yields `entity_ids = []`, create without `entity_id` AND without org context throws. (Note: the pglite backend is flaky under parallel-process port contention — this same file intermittently fails on pristine `origin/main` for the same reason; it passes when the env is quiet.)
- Smoke: `lobu apply --org lobu-crm --dry-run` (worktree CLI) now plans:
  ```
    watchers:
    + watcher funnel-digest
    + watcher inbound-triage
  Summary: 2 create, 0 update, 5 noop, 96 drift
  ```
  The live `--yes` create against `app.lobu.ai` still errors with the old `entity_id is required` — that's the deployed server, not this branch. Once this PR's server change ships, re-running `lobu apply --org lobu-crm --yes` creates both watchers with `entity_ids = {}`.

## Files
`packages/server/src/tools/admin/manage_watchers.ts`, `packages/server/src/utils/organization-access.ts`, `packages/server/src/sandbox/namespaces/watchers.ts`, `packages/server/src/__tests__/setup/test-mcp-client.ts`, `packages/server/src/__tests__/integration/watchers/watchers-crud.test.ts`, `packages/cli/src/commands/_lib/apply/{desired-state,client,diff,render,apply-cmd}.ts`, `packages/cli/src/commands/_lib/apply/__tests__/{desired-state,diff,client}.test.ts`.