### PR TITLE
fix(watchers): enforce org access for scoped watchers

### DIFF
--- a/packages/server/src/__tests__/integration/watchers/watchers-crud.test.ts
+++ b/packages/server/src/__tests__/integration/watchers/watchers-crud.test.ts
@@ -17,6 +17,7 @@ import { cleanupTestDatabase } from '../../setup/test-db';
 
 describe('watcher CRUD', () => {
   let owner: TestApiClient;
+  let intruder: TestApiClient;
   let entityId: number;
 
   beforeAll(async () => {
@@ -27,6 +28,15 @@ describe('watcher CRUD', () => {
     owner = await TestApiClient.for({
       organizationId: org.id,
       userId: user.id,
+      memberRole: 'owner',
+    });
+
+    const otherOrg = await createTestOrganization({ name: 'Watcher Other Org' });
+    const otherUser = await createTestUser({ email: 'watcher-other@test.com' });
+    await addUserToOrganization(otherUser.id, otherOrg.id, 'owner');
+    intruder = await TestApiClient.for({
+      organizationId: otherOrg.id,
+      userId: otherUser.id,
       memberRole: 'owner',
     });
 
@@ -101,6 +111,38 @@ describe('watcher CRUD', () => {
         extraction_schema: { type: 'object', properties: {} },
       })
     ).rejects.toThrow(/organization|entity_id/i);
+  });
+
+  it('blocks cross-org reads and writes for org-scoped watchers', async () => {
+    const created = (await owner.watchers.create({
+      slug: 'cross-org-org-scoped-watcher',
+      name: 'Cross Org Protected',
+      prompt: 'Track org-wide signals.',
+      extraction_schema: {
+        type: 'object',
+        properties: { signals: { type: 'array', items: { type: 'string' } } },
+      },
+    })) as { watcher_id: string };
+
+    await expect(intruder.watchers.get(created.watcher_id)).rejects.toThrow(
+      /access|organization/i
+    );
+    await expect(
+      intruder.watchers.update({
+        watcher_id: created.watcher_id,
+        schedule: '0 11 * * *',
+      })
+    ).rejects.toThrow(/access|organization/i);
+    await expect(intruder.watchers.delete([created.watcher_id])).rejects.toThrow(
+      /access|organization/i
+    );
+
+    const got = (await owner.watchers.get(created.watcher_id)) as {
+      watcher?: { schedule: string | null };
+    };
+    expect(got.watcher?.schedule).toBeNull();
+
+    await owner.watchers.delete([created.watcher_id]);
   });
 
   it('blocks a member from deleting watchers (admin-only)', async () => {

--- a/packages/server/src/tools/admin/manage_watchers.ts
+++ b/packages/server/src/tools/admin/manage_watchers.ts
@@ -28,6 +28,7 @@ import { recordChangeEvent } from '../../utils/insert-event';
 import { verifyWindowToken } from '../../utils/jwt';
 import logger from '../../utils/logger';
 import {
+  requireOrgReadAccess,
   requireOrgWriteAccess,
   requireReadAccess,
   requireWriteAccess,
@@ -614,33 +615,33 @@ export async function manageWatchers(
       await requireOrgWriteAccess(pgSql, ctx);
     }
   } else if (args.action === 'update' && args.watcher_id) {
-    const entityId = await getWatcherEntityId(args.watcher_id);
-    if (entityId) await requireWriteAccess(pgSql, entityId, ctx);
+    await requireWatcherAccess(pgSql, [args.watcher_id], ctx, 'write');
   } else if (args.action === 'trigger' && args.watcher_id) {
-    const entityId = await getWatcherEntityId(args.watcher_id);
-    if (entityId) await requireWriteAccess(pgSql, entityId, ctx);
+    await requireWatcherAccess(pgSql, [args.watcher_id], ctx, 'write');
   } else if (args.action === 'delete' && args.watcher_ids && args.watcher_ids.length > 0) {
-    const entityIds = await getWatchersEntityIds(args.watcher_ids);
-    for (const entityId of entityIds) {
-      await requireWriteAccess(pgSql, entityId, ctx);
-    }
+    await requireWatcherAccess(pgSql, args.watcher_ids, ctx, 'write');
   } else if (args.action === 'upgrade') {
     if (args.watcher_ids && args.watcher_ids.length > 0) {
-      const entityIds = await getWatchersEntityIds(args.watcher_ids);
-      for (const entityId of entityIds) {
-        await requireWriteAccess(pgSql, entityId, ctx);
-      }
+      await requireWatcherAccess(pgSql, args.watcher_ids, ctx, 'write');
+    } else if (args.watcher_id) {
+      await requireWatcherAccess(pgSql, [args.watcher_id], ctx, 'write');
     } else if (args.entity_id) {
       await requireWriteAccess(pgSql, args.entity_id, ctx);
     }
   } else if (args.action === 'complete_window' && args.entity_id) {
     await requireWriteAccess(pgSql, args.entity_id, ctx);
+  } else if (args.action === 'create_version' && args.watcher_id) {
+    await requireWatcherAccess(pgSql, [args.watcher_id], ctx, 'write');
+  } else if (args.action === 'set_reaction_script' && args.watcher_id) {
+    await requireWatcherAccess(pgSql, [args.watcher_id], ctx, 'write');
   } else if (args.action === 'submit_feedback' && args.watcher_id) {
-    const entityId = await getWatcherEntityId(args.watcher_id);
-    if (entityId) await requireWriteAccess(pgSql, entityId, ctx);
+    await requireWatcherAccess(pgSql, [args.watcher_id], ctx, 'write');
   } else if (args.action === 'get_feedback' && args.watcher_id) {
-    const entityId = await getWatcherEntityId(args.watcher_id);
-    if (entityId) await requireReadAccess(pgSql, entityId, ctx);
+    await requireWatcherAccess(pgSql, [args.watcher_id], ctx, 'read');
+  } else if (args.action === 'get_versions' && args.watcher_id) {
+    await requireWatcherAccess(pgSql, [args.watcher_id], ctx, 'read');
+  } else if (args.action === 'get_version_details' && args.watcher_id) {
+    await requireWatcherAccess(pgSql, [args.watcher_id], ctx, 'read');
   } else if (args.action === 'create_from_version' && args.entity_ids) {
     for (const eid of args.entity_ids) {
       await requireWriteAccess(pgSql, eid, ctx);
@@ -673,40 +674,75 @@ export async function listWatchers(
   const pgSql = createDbClientFromEnv(env);
   if (args.entity_id) {
     await requireReadAccess(pgSql, args.entity_id, ctx);
+  } else {
+    await requireOrgReadAccess(pgSql, ctx);
   }
   return handleList(args, env, ctx);
 }
 
-/**
- * Helper: Get first entity_id from a single watcher (uses entity_ids bigint[])
- */
-async function getWatcherEntityId(watcherId: string): Promise<number | null> {
-  const sql = getDb();
-  const result = await sql`
-    SELECT entity_ids FROM watchers WHERE id = ${watcherId}
-  `;
-  if (result.length === 0) return null;
-  const raw = result[0].entity_ids;
-  const ids: number[] = Array.isArray(raw)
-    ? raw.map(Number)
-    : typeof raw === 'string'
-      ? (raw as string).replace(/[{}]/g, '').split(',').filter(Boolean).map(Number)
-      : [];
-  return ids[0] ?? null;
+type WatcherAccessMode = 'read' | 'write';
+
+interface WatcherAccessRow {
+  id: string | number;
+  organization_id: string | null;
+  entity_ids: unknown;
 }
 
-/**
- * Helper: Get unique entity_ids from multiple watchers (uses entity_ids bigint[])
- */
-async function getWatchersEntityIds(watcherIds: string[]): Promise<number[]> {
+function parseWatcherEntityIds(raw: unknown): number[] {
+  if (Array.isArray(raw)) return raw.map(Number).filter((id) => Number.isFinite(id));
+  if (typeof raw === 'string') {
+    return raw
+      .replace(/[{}]/g, '')
+      .split(',')
+      .filter(Boolean)
+      .map(Number)
+      .filter((id) => Number.isFinite(id));
+  }
+  return [];
+}
+
+async function getWatcherAccessRows(watcherIds: string[]): Promise<WatcherAccessRow[]> {
   if (watcherIds.length === 0) return [];
   const sql = getDb();
   const placeholders = watcherIds.map((_, idx) => `$${idx + 1}`).join(',');
-  const result = await sql.unsafe(
-    `SELECT DISTINCT unnest(entity_ids) as entity_id FROM watchers WHERE id IN (${placeholders})`,
+  return sql.unsafe<WatcherAccessRow>(
+    `SELECT id, organization_id, entity_ids FROM watchers WHERE id IN (${placeholders})`,
     watcherIds
   );
-  return result.map((r) => Number(r.entity_id));
+}
+
+async function requireWatcherAccess(
+  sql: DbClient,
+  watcherIds: string[],
+  ctx: ToolContext,
+  mode: WatcherAccessMode
+): Promise<void> {
+  const rows = await getWatcherAccessRows(watcherIds);
+
+  for (const row of rows) {
+    const watcherOrgId = row.organization_id ? String(row.organization_id) : null;
+    if (!watcherOrgId || watcherOrgId !== ctx.organizationId) {
+      throw new Error(`Access denied: watcher ${row.id} does not belong to your organization`);
+    }
+
+    const entityIds = parseWatcherEntityIds(row.entity_ids);
+    if (entityIds.length > 0) {
+      for (const entityId of entityIds) {
+        if (mode === 'write') {
+          await requireWriteAccess(sql, entityId, ctx);
+        } else {
+          await requireReadAccess(sql, entityId, ctx);
+        }
+      }
+      continue;
+    }
+
+    if (mode === 'write') {
+      await requireOrgWriteAccess(sql, ctx);
+    } else {
+      await requireOrgReadAccess(sql, ctx);
+    }
+  }
 }
 
 // ============================================
@@ -1059,6 +1095,11 @@ async function handleCreateFromVersion(
   if (versionRows.length === 0) throw new Error(`Version ${args.version_id} not found`);
   const version = versionRows[0];
   const organizationId = version.organization_id as string;
+  if (!organizationId || organizationId !== ctx.organizationId) {
+    throw new Error(
+      `Access denied: watcher version ${args.version_id} does not belong to your organization`
+    );
+  }
 
   // Fetch entity names for name pattern substitution
   const entityRows = await sql`
@@ -1340,6 +1381,9 @@ async function handleCompleteWindow(
   if (tokenPayloads.length > 1 && tokenIsRollup) {
     throw new Error('Rollup completion accepts exactly one window_token.');
   }
+
+  const pgSql = createDbClientFromEnv(env);
+  await requireWatcherAccess(pgSql, [String(watcherId)], ctx, 'write');
 
   const MAX_ROLLUP_DEPTH = 3;
   if (tokenIsRollup && tokenDepth != null && tokenDepth > MAX_ROLLUP_DEPTH) {

--- a/packages/server/src/tools/get_watchers.ts
+++ b/packages/server/src/tools/get_watchers.ts
@@ -12,7 +12,7 @@ import {
   type WatcherTimeGranularity,
 } from '@lobu/connector-sdk';
 import { type Static, Type } from '@sinclair/typebox';
-import { createDbClientFromEnv, getDb } from '../db/client';
+import { createDbClientFromEnv, type DbClient, getDb } from '../db/client';
 import type { Env } from '../index';
 import type {
   PendingAnalysis,
@@ -34,7 +34,10 @@ import {
 } from '../utils/date-aliases';
 import { parseJsonObject } from '@lobu/core';
 import logger from '../utils/logger';
-import { requireReadAccess } from '../utils/organization-access';
+import {
+  requireOrgReadAccess,
+  requireReadAccess,
+} from '../utils/organization-access';
 
 import { renderPromptPreview } from '../utils/template-renderer';
 import { buildWatchersUrl, type EntityInfo, getPublicWebUrl } from '../utils/url-builder';
@@ -283,6 +286,36 @@ async function buildEntityInfo(entityRow: Record<string, unknown>): Promise<{
   };
 }
 
+async function requireWatcherReadAccess(
+  sql: DbClient,
+  watcherId: string,
+  ctx: ToolContext
+): Promise<void> {
+  const rows = await sql`
+    SELECT organization_id, entity_ids
+    FROM watchers
+    WHERE id = ${watcherId}
+    LIMIT 1
+  `;
+  if (rows.length === 0) return;
+
+  const row = rows[0] as { organization_id: string | null; entity_ids: unknown };
+  if (!row.organization_id || row.organization_id !== ctx.organizationId) {
+    throw new Error(
+      `Access denied: watcher ${watcherId} is not accessible to your organization`
+    );
+  }
+
+  const entityIds = parseBigintArray(row.entity_ids);
+  if (entityIds.length > 0) {
+    for (const entityId of entityIds) {
+      await requireReadAccess(sql, entityId, ctx);
+    }
+  } else {
+    await requireOrgReadAccess(sql, ctx);
+  }
+}
+
 // ============================================
 // Tool Implementation
 // ============================================
@@ -321,6 +354,8 @@ export async function getWatcher(
   if (!args.watcher_id) {
     throw new Error('watcher_id is required. Use list_watchers to discover available watchers.');
   }
+
+  await requireWatcherReadAccess(pgSql, args.watcher_id, ctx);
 
   // Entity resolution is deferred — for the typical case (only watcher_id
   // given), the watcher metadata query below already returns the watcher's

--- a/packages/server/src/utils/organization-access.ts
+++ b/packages/server/src/utils/organization-access.ts
@@ -132,6 +132,29 @@ async function canWriteOrg(sql: DbClient, ctx: ToolContext): Promise<boolean> {
 }
 
 /**
+ * Check if the caller may read at the organization level (no entity scope).
+ * Mirrors entity read behavior: once the request is scoped to the organization,
+ * anonymous/system contexts are allowed and authenticated users must be members.
+ */
+async function canReadOrg(sql: DbClient, ctx: ToolContext): Promise<boolean> {
+  if (!ctx.organizationId) return false;
+  if (!ctx.userId) return true;
+
+  const orgRole = await getWorkspaceRole(sql, ctx.organizationId, ctx.userId);
+  return orgRole !== null;
+}
+
+/**
+ * Require organization-level read access or throw.
+ */
+export async function requireOrgReadAccess(sql: DbClient, ctx: ToolContext): Promise<void> {
+  const ok = await canReadOrg(sql, ctx);
+  if (!ok) {
+    throw new Error('Access denied: organization-level read access is required');
+  }
+}
+
+/**
  * Require organization-level write access or throw.
  */
 export async function requireOrgWriteAccess(sql: DbClient, ctx: ToolContext): Promise<void> {


### PR DESCRIPTION
## Summary
- require org/entity access for org-scoped watcher reads and mutations
- authorize complete_window after decoding the watcher token
- add cross-org coverage for org-scoped watcher access

## Validation
- bun run typecheck
- make build-packages
- bun run check

Follow-up fix for #596.