### PR TITLE
feat(web): Home/Inbox/Search sidebar nav

### DIFF
--- a/packages/server/src/utils/reserved.ts
+++ b/packages/server/src/utils/reserved.ts
@@ -28,6 +28,7 @@ export const RESERVED_PATHS = [
   ...OWNER_ROUTE_SEGMENTS,
   'auth',
   'api',
+  'inbox',
   'templates',
   'help',
   'account',


### PR DESCRIPTION
Bumps the `packages/web` submodule to pull in owletto-web#75 and reserves the `inbox` path server-side.

### owletto-web#75 — Home/Inbox/Search sidebar nav, remove notification bell
- **Dashboard → Home** (renamed nav item, Home icon)
- **Inbox** — new `/inbox` page replacing the notification-bell popover; sidebar nav item with unread-count badge; reuses existing notification hooks/components
- **Search** — sidebar item that opens the ⌘K command palette; standalone header ⌘K button removed (global shortcut still works); "Inbox" command added to the palette
- Notification bell removed from desktop + mobile headers; unused `notification-bell.tsx` / `notification-panel.tsx` deleted

### This repo
- `packages/server/src/utils/reserved.ts` — reserve `inbox` so it can't collide with an org slug / entity type (mirrors the frontend `RESERVED_PATHS` change)
- Submodule pointer → owletto-web `main`

### Test
- web: `bun run test` 112 passed, `tsc -b` clean
- `make build-packages` clean