### PR TITLE
fix(web): favicon + SEO meta; dedupe public-page head

### DIFF
--- a/packages/server/src/public-pages.ts
+++ b/packages/server/src/public-pages.ts
@@ -824,7 +824,33 @@ function buildNotFoundModel(
   };
 }
 
+// Per-page meta the base index.html ships sensible defaults for; we replace
+// rather than append so a public page never ends up with two of each.
+const OVERRIDDEN_META = [
+  'description',
+  'og:title',
+  'og:description',
+  'og:type',
+  'og:url',
+  'og:image',
+  'twitter:card',
+  'twitter:title',
+  'twitter:description',
+  'twitter:image',
+];
+
+function stripOverriddenHead(templateHtml: string): string {
+  const metaPattern = new RegExp(
+    `<meta\\s+(?:name|property)="(?:${OVERRIDDEN_META.join('|')})"[^>]*>\\s*`,
+    'gi'
+  );
+  return templateHtml
+    .replace(metaPattern, '')
+    .replace(/<link\s+rel="canonical"[^>]*>\s*/gi, '');
+}
+
 function injectIntoTemplate(templateHtml: string, model: PublicPageModel): string {
+  const ogImage = model.openGraphImage || `${new URL(model.canonicalUrl).origin}/lobu-og.png`;
   const headTags = [
     `<meta name="description" content="${escapeAttribute(model.description)}" />`,
     `<meta name="robots" content="${escapeAttribute(model.robots)}" />`,
@@ -833,15 +859,11 @@ function injectIntoTemplate(templateHtml: string, model: PublicPageModel): strin
     `<meta property="og:description" content="${escapeAttribute(model.description)}" />`,
     `<meta property="og:type" content="website" />`,
     `<meta property="og:url" content="${escapeAttribute(model.canonicalUrl)}" />`,
-    `<meta name="twitter:card" content="${model.openGraphImage ? 'summary_large_image' : 'summary'}" />`,
+    `<meta property="og:image" content="${escapeAttribute(ogImage)}" />`,
+    `<meta name="twitter:card" content="summary_large_image" />`,
     `<meta name="twitter:title" content="${escapeAttribute(model.title)}" />`,
     `<meta name="twitter:description" content="${escapeAttribute(model.description)}" />`,
-    model.openGraphImage
-      ? `<meta property="og:image" content="${escapeAttribute(model.openGraphImage)}" />`
-      : '',
-    model.openGraphImage
-      ? `<meta name="twitter:image" content="${escapeAttribute(model.openGraphImage)}" />`
-      : '',
+    `<meta name="twitter:image" content="${escapeAttribute(ogImage)}" />`,
     ...model.structuredData.map(
       (item) => `<script type="application/ld+json">${serializeForScript(item)}</script>`
     ),
@@ -849,7 +871,7 @@ function injectIntoTemplate(templateHtml: string, model: PublicPageModel): strin
     .filter(Boolean)
     .join('\n');
 
-  const withTitle = templateHtml.replace(
+  const withTitle = stripOverriddenHead(templateHtml).replace(
     /<title>.*?<\/title>/is,
     `<title>${escapeHtml(model.title)}</title>`
   );


### PR DESCRIPTION
Bumps `packages/web` to pull in owletto-web#76 (real favicon / web manifest / default OG meta) and updates server-rendered public pages to match.

### owletto-web#76 — favicon + SEO
The app shipped the Vite scaffold defaults (`<link rel="icon" href="/vite.svg">`, no `public/` dir) — favicon 404'd, no apple-touch icon, manifest, theme-color, description, or OG/Twitter meta. Now ships the lobster mark + a manifest + sensible default head meta.

### This repo — `packages/server/src/public-pages.ts`
`injectIntoTemplate` now **strips** the per-page meta tags that the base `index.html` ships defaults for (`description`, `og:*`, `twitter:*`, `canonical`) before injecting its own, so public pages don't end up with duplicates. Also always emits an `og:image`, falling back to `/lobu-og.png` when the org has no logo (previously: no OG image at all).

### Test
- web: `bun run build` (dist includes icons + manifest), `bun run test` 112 passed
- `make build-packages` clean, `tsc -b` clean