### PR TITLE
fix(server): no-store on unknown-path discovery JSON (stop CDN caching it)

### DIFF
--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -1279,6 +1279,11 @@ app.get('*', async (c) => {
   }
 
   const baseUrl = new URL(c.req.url).origin;
+  // Unknown paths fall through to this discovery blob. Browsers hit it for
+  // `/favicon.ico`, `/apple-touch-icon.png`, etc. before those assets exist —
+  // without `no-store` a CDN caches the JSON for that path and keeps serving it
+  // even after a deploy ships the real file. Don't let that happen.
+  c.header('Cache-Control', 'no-store');
   return c.json({
     status: 'ok',
     mcp_endpoint: new URL('/mcp', baseUrl).toString(),


### PR DESCRIPTION
### Bug
After deploying the favicon/SEO PR (#600), `https://app.lobu.ai/favicon.ico` and `/apple-touch-icon.png` still return `{"status":"ok","mcp_endpoint":...}` with `cf-cache-status: HIT` — Cloudflare cached the catch-all discovery JSON for those paths *before* the assets existed (the response had no `Cache-Control` header, so the edge applied a default TTL to the 200), and keeps serving it even though origin now returns the real files.

### Fix
Set `Cache-Control: no-store` on the catch-all `{ status: 'ok', ... }` response in `packages/server/src/index.ts`. It's a discovery blob for unknown paths — browsers hit it for `/favicon.ico` etc. before those assets ship — and there's no reason for a CDN to cache it. Prevents this whole class of stale-asset-after-deploy bug.

(The currently-poisoned `/favicon.ico` and `/apple-touch-icon.png` edge entries will age out on their own; this stops it recurring. The real files are served correctly by origin and the new `index.html` head — confirmed live.)

### Test
`tsc --noEmit` clean.