### PR TITLE
feat(mac): build the DMG as part of release CD; in-app update link

### DIFF
--- a/.github/workflows/mac-release.yml
+++ b/.github/workflows/mac-release.yml
@@ -2,10 +2,12 @@ name: mac-release
 
 # Builds, signs, notarizes and ships Lobu for Mac.
 #
-# Trigger by pushing a tag like `mac-v0.1.0`, or run manually with a version.
-# Produces a notarized Lobu.dmg attached to a GitHub Release and bumps the
-# Homebrew cask in lobu-ai/homebrew-tap so `brew install --cask lobu-ai/tap/lobu`
-# always tracks the latest build.
+# Runs automatically as part of release CD: when release-please cuts a release,
+# release-please.yml dispatches this workflow with that version. Can also be run
+# manually (workflow_dispatch) with a version. It attaches a notarized Lobu.dmg
+# to the existing `lobu-v<version>` GitHub Release — so `releases/latest/download/
+# Lobu.dmg` always points at the current build — and bumps the Homebrew cask in
+# lobu-ai/homebrew-tap so `brew install --cask lobu-ai/tap/lobu` tracks it too.
 #
 # Required repo secrets (Settings → Secrets and variables → Actions):
 #   APPLE_CERT_P12_BASE64   base64 of a "Developer ID Application" .p12
@@ -30,12 +32,10 @@ name: mac-release
 #                                  PROVISIONING_PROFILE_SPECIFIER).
 
 on:
-  push:
-    tags: ['mac-v*']
   workflow_dispatch:
     inputs:
       version:
-        description: 'Version to build, e.g. 0.1.0'
+        description: 'Release version, e.g. 0.42.0 (must have a lobu-v<version> release)'
         required: true
 
 permissions:
@@ -49,12 +49,7 @@ jobs:
 
       - name: Resolve version
         id: v
-        run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            echo "version=${{ github.event.inputs.version }}" >> "$GITHUB_OUTPUT"
-          else
-            echo "version=${GITHUB_REF_NAME#mac-v}" >> "$GITHUB_OUTPUT"
-          fi
+        run: echo "version=${{ github.event.inputs.version }}" >> "$GITHUB_OUTPUT"
 
       - name: Import signing certificate
         env:
@@ -131,12 +126,12 @@ jobs:
         id: sum
         run: echo "sha256=$(shasum -a 256 "$RUNNER_TEMP/Lobu.dmg" | cut -d' ' -f1)" >> "$GITHUB_OUTPUT"
 
-      - name: Publish GitHub Release
+      - name: Attach DMG to the release
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: mac-v${{ steps.v.outputs.version }}
-          name: Lobu for Mac ${{ steps.v.outputs.version }}
+          tag_name: lobu-v${{ steps.v.outputs.version }}
           files: ${{ runner.temp }}/Lobu.dmg
+          fail_on_unmatched_files: true
 
       - name: Update Homebrew tap
         env:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -47,3 +47,21 @@ jobs:
             --repo ${{ github.repository }} \
             --ref main \
             -f bump=skip
+
+  mac:
+    needs: release-please
+    if: ${{ needs.release-please.outputs.release_created == 'true' }}
+    runs-on: ubuntu-latest
+    permissions:
+      # Dispatch mac-release.yml, which builds/signs/notarizes the DMG on macOS
+      # and attaches it to the release-please release.
+      actions: write
+    steps:
+      - name: Trigger mac-release workflow
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
+        run: |
+          gh workflow run mac-release.yml \
+            --repo ${{ github.repository }} \
+            --ref main \
+            -f version=${{ needs.release-please.outputs.version }}

--- a/apps/mac/Lobu/MenuBarContent.swift
+++ b/apps/mac/Lobu/MenuBarContent.swift
@@ -421,20 +421,33 @@ struct MenuBarContent: View {
     // MARK: Footer
     // -------------------------------------------------------------------------
 
+    /// Where new builds are published by the `mac-release` CI job (one DMG per
+    /// Lobu release). "Check for updates" just opens this page.
+    private static let releasesURL = URL(string: "https://github.com/lobu-ai/lobu/releases/latest")!
+
+    private var appVersion: String {
+        let v = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String
+        return v.map { "v\($0)" } ?? ""
+    }
+
     private var footerRow: some View {
-        HStack {
+        HStack(spacing: 10) {
             Button("Quit Lobu") {
                 state.stopLocalLobu()
                 NSApplication.shared.terminate(nil)
             }
                 .buttonStyle(.plain)
                 .font(.caption)
+            Button("Check for Updates \u{2197}") {
+                NSWorkspace.shared.open(Self.releasesURL)
+            }
+                .buttonStyle(.plain)
+                .font(.caption)
             Spacer()
-            Text(state.baseURL.replacingOccurrences(of: "https://", with: ""))
+            Text(appVersion)
                 .font(.caption2)
                 .foregroundStyle(.tertiary)
                 .lineLimit(1)
-                .truncationMode(.middle)
         }
         .menuRow()
     }

--- a/apps/mac/homebrew/lobu.rb.tmpl
+++ b/apps/mac/homebrew/lobu.rb.tmpl
@@ -5,7 +5,7 @@ cask "lobu" do
   version "@VERSION@"
   sha256 "@SHA256@"
 
-  url "https://github.com/lobu-ai/lobu/releases/download/mac-v#{version}/Lobu.dmg",
+  url "https://github.com/lobu-ai/lobu/releases/download/lobu-v#{version}/Lobu.dmg",
       verified: "github.com/lobu-ai/lobu/"
   name "Lobu"
   desc "Menu bar app that syncs on-device data into your Lobu workspace"


### PR DESCRIPTION
Follow-up to #607 (which landed `mac-release.yml` + the cask template).

## Changes
- **`release-please.yml`** — when release-please cuts a release, it now also dispatches `mac-release.yml` with that version (a sibling of the existing npm-publish dispatch). So the Mac DMG is built/signed/notarized as part of normal release CD — no separate tag to push.
- **`mac-release.yml`** — dropped the standalone `mac-v*` tag trigger; it takes `version` as input and **attaches `Lobu.dmg` to the existing `lobu-v<version>` release**. That makes `https://github.com/lobu-ai/lobu/releases/latest/download/Lobu.dmg` (already linked from the Devices page) always resolve to the current build.
- **`apps/mac/homebrew/lobu.rb.tmpl`** — cask `url` now points at the `lobu-v<version>` release asset.
- **`apps/mac/Lobu/MenuBarContent.swift`** — footer gains a **"Check for Updates ↗"** link to the releases page and shows the running app version. (Builds clean — `xcodebuild ... build` ✓.)

## Setup state
- ✅ `lobu-ai/homebrew-tap` repo created (empty `Casks/` until the first release populates `lobu.rb`).
- ⏳ Still needs the Apple secrets + `APPLE_PROVISION_PROFILE_NAME` variable (see header comment in `mac-release.yml`) before the first release actually produces a signed DMG. The `mac` job in `release-please.yml` will just dispatch the workflow regardless; it'll fail at the signing step until those exist — which is loud and harmless.
- `actionlint` clean on both workflows.