### PR TITLE
fix(gateway): guard optional agentSettingsStore in agentOwnerResolver

### DIFF
--- a/packages/server/src/gateway/services/core-services.ts
+++ b/packages/server/src/gateway/services/core-services.ts
@@ -470,7 +470,7 @@ export class CoreServices {
       secretStore: this.secretStore,
       runtimeCredentialResolver: this.options?.providerCredentialResolver,
       agentOwnerResolver: async (agentId) =>
-        (await this.agentSettingsStore.getMetadata(agentId))?.owner.userId,
+        (await this.agentSettingsStore?.getMetadata(agentId))?.owner.userId,
     });
     this.transcriptionService = new TranscriptionService(
       this.authProfilesManager


### PR DESCRIPTION
Hotfix for #609 — the Docker image build's `cd packages/server && bunx tsc --noEmit` (stricter than the root typecheck) flagged TS2532 because `agentSettingsStore` is optional and TS can't narrow it inside the deferred resolver closure. Optional chaining; a missing store just yields no owner (no owner-credential fallback).

🤖 Generated with [Claude Code](https://claude.com/claude-code)