### PR TITLE
fix(sentry): stop polluting Sentry with tool-validation noise + sweeper info

### DIFF
--- a/packages/server/src/gateway/infrastructure/queue/runs-queue.ts
+++ b/packages/server/src/gateway/infrastructure/queue/runs-queue.ts
@@ -70,16 +70,6 @@ function shouldEmitSentryAlert(runId: number): boolean {
   return true;
 }
 
-const sentryAlertedTags = new Map<string, number>();
-
-function shouldEmitSentryAlertByTag(tag: string): boolean {
-  const now = Date.now();
-  const last = sentryAlertedTags.get(tag);
-  if (last && now - last < SENTRY_DEDUPE_WINDOW_MS) return false;
-  sentryAlertedTags.set(tag, now);
-  return true;
-}
-
 function queueBreadcrumb(
   category: string,
   message: string,
@@ -839,21 +829,13 @@ export class RunsQueue implements IMessageQueue {
            RETURNING id`,
         );
         if (result.count > 0) {
+          // Operational housekeeping, not an incident — log it, but don't
+          // page Sentry (Seer flagged the alert super-low actionability).
           logger.warn(
             `Reclaimed ${result.count} stale runs (claimed > ${
               CLAIM_VISIBILITY_TIMEOUT_MS / 1000
             }s ago)`,
           );
-          if (shouldEmitSentryAlertByTag("stale-claim-sweeper")) {
-            try {
-              Sentry.captureMessage(
-                `Stale-claim sweeper reclaimed ${result.count} run(s)`,
-                { level: "warning", extra: { count: result.count } },
-              );
-            } catch {
-              // ignore
-            }
-          }
         }
       } catch (err) {
         logger.warn(

--- a/packages/server/src/tools/admin/manage_watchers.ts
+++ b/packages/server/src/tools/admin/manage_watchers.ts
@@ -23,6 +23,7 @@ import type { Env } from '../../index';
 import { isLobuGatewayRunning } from '../../lobu/gateway';
 import type { ComponentReferenceDocumentation } from '../../types/templates';
 import { entityLinkMatchSql } from '../../utils/content-search';
+import { ToolUserError } from '../../utils/errors';
 import { nextRunAt, validateSchedule } from '../../utils/cron';
 import { recordChangeEvent } from '../../utils/insert-event';
 import { verifyWindowToken } from '../../utils/jwt';
@@ -857,13 +858,13 @@ async function handleCreate(
 
   // Require slug + prompt + extraction_schema for create
   if (!args.slug) {
-    throw new Error('slug is required for create action');
+    throw new ToolUserError('slug is required for create action');
   }
   if (!args.prompt) {
-    throw new Error('prompt is required for create action');
+    throw new ToolUserError('prompt is required for create action');
   }
   if (!args.extraction_schema) {
-    throw new Error('extraction_schema is required for create action');
+    throw new ToolUserError('extraction_schema is required for create action');
   }
 
   // entity_id is optional: omit it for an org-scoped/global watcher.
@@ -892,7 +893,7 @@ async function handleCreate(
     sources,
   });
   if (validation) {
-    throw new Error(`Watcher validation failed: ${validation}`);
+    throw new ToolUserError(`Watcher validation failed: ${validation}`, 422);
   }
 
   if (classifiers && extractionSchema) {
@@ -901,14 +902,14 @@ async function handleCreate(
       extractionSchema
     );
     if (classifierValidation) {
-      throw new Error(`Classifier-schema compatibility error: ${classifierValidation}`);
+      throw new ToolUserError(`Classifier-schema compatibility error: ${classifierValidation}`, 422);
     }
   }
 
   if (args.schedule) {
     const scheduleError = validateSchedule(args.schedule);
     if (scheduleError) {
-      throw new Error(scheduleError);
+      throw new ToolUserError(scheduleError);
     }
   }
 
@@ -936,14 +937,14 @@ async function handleCreate(
       WHERE e.id = ${entityId}
     `;
     if (entityResult.length === 0) {
-      throw new Error(`Entity with ID ${entityId} not found`);
+      throw new ToolUserError(`Entity with ID ${entityId} not found`, 404);
     }
     entityRow = entityResult[0] as EntityRow;
     organizationId = entityRow.organization_id;
     organizationSlug = await getOrganizationSlug(organizationId);
   } else {
     if (!organizationId) {
-      throw new Error(
+      throw new ToolUserError(
         'entity_id or an organization context is required to create a watcher'
       );
     }
@@ -957,7 +958,10 @@ async function handleCreate(
     LIMIT 1
   `;
   if (existingSlug.length > 0) {
-    throw new Error(`Watcher with slug '${args.slug}' already exists in this organization`);
+    throw new ToolUserError(
+      `Watcher with slug '${args.slug}' already exists in this organization`,
+      409
+    );
   }
 
   // Validate schedule if provided
@@ -2396,7 +2400,7 @@ async function handleCreateVersion(
     sources,
   });
   if (validation) {
-    throw new Error(`Watcher validation failed: ${validation}`);
+    throw new ToolUserError(`Watcher validation failed: ${validation}`, 422);
   }
 
   if (classifiers && extractionSchema) {
@@ -2405,7 +2409,7 @@ async function handleCreateVersion(
       extractionSchema
     );
     if (classifierValidation) {
-      throw new Error(`Classifier-schema compatibility error: ${classifierValidation}`);
+      throw new ToolUserError(`Classifier-schema compatibility error: ${classifierValidation}`, 422);
     }
   }
 

--- a/packages/server/src/tools/save_content.ts
+++ b/packages/server/src/tools/save_content.ts
@@ -13,6 +13,7 @@ import { hasRequiredMcpScope } from '../auth/tool-access';
 import { getDb } from '../db/client';
 import type { Env } from '../index';
 import { autoLinkEvent } from '../utils/auto-linker';
+import { ToolUserError } from '../utils/errors';
 import { validateSaveContentSemanticType } from '../utils/event-kind-validation';
 import { insertEvent } from '../utils/insert-event';
 import logger from '../utils/logger';
@@ -137,10 +138,10 @@ export async function saveContent(
   const isSystem = ctx.userId === null && ctx.isAuthenticated;
   if (!isSystem) {
     if (!ctx.memberRole) {
-      throw new Error('save_memory requires workspace membership with write access.');
+      throw new ToolUserError('save_memory requires workspace membership with write access.', 403);
     }
     if (!hasRequiredMcpScope('write', ctx.scopes)) {
-      throw new Error('save_memory requires an MCP session with write access.');
+      throw new ToolUserError('save_memory requires an MCP session with write access.', 403);
     }
   }
 
@@ -151,16 +152,16 @@ export async function saveContent(
 
   const entityIds: number[] = args.entity_ids ?? [];
   const semanticType = args.semantic_type;
-  if (!semanticType) throw new Error('semantic_type is required');
+  if (!semanticType) throw new ToolUserError('semantic_type is required');
 
   const payloadType = args.payload_type ?? 'text';
 
   // Validate content requirement based on payload_type
   if ((payloadType === 'text' || payloadType === 'markdown') && !args.content) {
-    throw new Error(`content is required for payload_type '${payloadType}'`);
+    throw new ToolUserError(`content is required for payload_type '${payloadType}'`);
   }
   if (payloadType === 'json_template' && !args.payload_template) {
-    throw new Error("payload_template is required when payload_type is 'json_template'");
+    throw new ToolUserError("payload_template is required when payload_type is 'json_template'");
   }
 
   // 1. Require write access for each entity
@@ -176,7 +177,7 @@ export async function saveContent(
     entityIds.length > 0 ? entityIds : undefined
   );
   if (!kindValidation.valid) {
-    throw new Error(kindValidation.errors.join('\n'));
+    throw new ToolUserError(kindValidation.errors.join('\n'), 422);
   }
 
   // 3. Validate event metadata against entity type's event kind schema (if entity-associated)


### PR DESCRIPTION
Cleans up the recurring Sentry noise found while triaging `lobu-ai` (every issue is now triaged: 26 resolved, 17 archived, 0 unresolved).

### Changes
- **MCP tool validation → `ToolUserError`**: `save_memory` (`save_content.ts`) and `manage_watchers` (create path) threw bare `Error` on input-validation failures, so `trackMCPToolCall` reported them to Sentry. They now throw `ToolUserError` (with appropriate HTTP status), which the wrapper deliberately skips. Fixes `LOBU-BACKEND-J` (`semantic_type is required`), `LOBU-BACKEND-N` (watcher `entity_id`), `LOBU-BACKEND-H` (invalid event kind).
- **runs-queue stale-claim sweeper**: dropped the `Sentry.captureMessage` (and the now-unused `shouldEmitSentryAlertByTag` helper) — reclaiming stale runs is routine housekeeping, not an incident (Seer rated it super-low actionability). Kept the `logger.warn`. Fixes `LOBU-BACKEND-5`.
- **`packages/web` bump** → owletto-web#81: browser Sentry now no-ops on `localhost` / `.ts.net` / `.local` / bare-IP hosts, so CI / evals / agent-browser runs against a local backend stop spraying `TypeError: Failed to fetch (localhost:...)` into the prod project. Fixes the `LOBU-FRONTEND-3*` family (was the top noise source, 150+ events, escalating).

### Tests
`make build-packages`, `bun run typecheck`, `bun run check` clean. `bun run test` (413) green; the 116 unit tests touching `manage_watchers` / `save_content` / `runs-queue` / `query_sql` / `tool-access` all pass. (The DB-backed integration/contract tests fail locally without `DATABASE_URL` — pre-existing, unrelated.)