### PR TITLE
test(db): pin the test-DB pool to 1 connection on PGlite

### DIFF
--- a/packages/server/src/__tests__/setup/test-db.ts
+++ b/packages/server/src/__tests__/setup/test-db.ts
@@ -56,9 +56,15 @@ export function getTestDb(): postgres.Sql {
           'Example: DATABASE_URL=postgresql://localhost:5432/lobu_test'
       );
     }
+    // The PGlite socket server is happiest with very few, short-lived
+    // connections (same reason `db/client.ts` pins the embedded pool to 1).
+    // A 5-connection pool that lingers 20s after idle churns the socket and
+    // has been observed to drop connections mid-suite (ECONNRESET in the
+    // cleanup hook). Against real Postgres the wider pool is fine.
+    const isPglite = process.env.LOBU_DISABLE_PREPARE === '1';
     sql = postgres(url, {
-      max: 5,
-      idle_timeout: 20,
+      max: isPglite ? 1 : 5,
+      idle_timeout: isPglite ? 0 : 20,
       // Integration tests trigger many CASCADE/TRUNCATE notices; suppress them to
       // reduce noisy output and hook slowdowns.
       onnotice: () => {},


### PR DESCRIPTION
The vitest test-DB helper (`packages/server/src/__tests__/setup/test-db.ts`) opened a 5-connection postgres.js pool with a 20s idle timeout. Against the PGlite socket server (`LOBU_TEST_BACKEND=pglite`) that connection churn drops connections mid-suite — surfacing as `ECONNRESET` inside `cleanupTestDatabase()`'s `SELECT tablename FROM pg_tables`, which then cascades to skip the remaining tests in that file (observed on ~4 suites). Mirror what `db/client.ts` already does for the embedded pool: when on PGlite use `max: 1` / `idle_timeout: 0`; real Postgres keeps `max: 5`. Verified locally: re-running `LOBU_TEST_BACKEND=pglite vitest run` no longer produces the ECONNRESET cleanup-hook failures. (Note: the full PGlite suite still has a few unrelated failures on current main — separate from this change.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)