### PR TITLE
feat(mac): make HealthKit optional so release CD works without an Apple provisioning profile

### DIFF
--- a/.github/workflows/mac-release.yml
+++ b/.github/workflows/mac-release.yml
@@ -16,20 +16,10 @@ name: mac-release
 #   APPLE_ID                Apple ID email used for notarization
 #   APPLE_APP_PASSWORD      app-specific password for that Apple ID
 #   HOMEBREW_TAP_TOKEN      PAT with write access to lobu-ai/homebrew-tap
-#   APPLE_PROVISION_PROFILE_BASE64
-#                           base64 of a "Developer ID" provisioning profile for
-#                           the ai.lobu.mac App ID. Required because the app uses
-#                           the restricted `com.apple.developer.healthkit`
-#                           entitlement, which only validates when an embedded
-#                           profile grants it. Create it at developer.apple.com
-#                           (Certificates → Profiles → Developer ID) after
-#                           enabling HealthKit on the App ID.
 # An ephemeral keychain password is generated per run; no secret needed for it.
-#
-# Required repo variable (Settings → Secrets and variables → Actions → Variables):
-#   APPLE_PROVISION_PROFILE_NAME   the profile's "Name" exactly as shown in the
-#                                  Apple Developer portal (used as
-#                                  PROVISIONING_PROFILE_SPECIFIER).
+# No provisioning profile is required — the app ships only standard
+# Developer-ID entitlements (HealthKit is disabled; re-adding the
+# `com.apple.developer.healthkit` entitlement would reintroduce that need).
 
 on:
   workflow_dispatch:
@@ -67,14 +57,6 @@ jobs:
           security list-keychains -d user -s "$KEYCHAIN"
           security default-keychain -s "$KEYCHAIN"
 
-      - name: Install provisioning profile
-        env:
-          PROFILE_BASE64: ${{ secrets.APPLE_PROVISION_PROFILE_BASE64 }}
-        run: |
-          DEST="$HOME/Library/MobileDevice/Provisioning Profiles"
-          mkdir -p "$DEST"
-          echo "$PROFILE_BASE64" | base64 --decode > "$DEST/lobu_mac.provisionprofile"
-
       - name: Archive
         run: |
           xcodebuild \
@@ -86,7 +68,6 @@ jobs:
             CODE_SIGN_STYLE=Manual \
             CODE_SIGN_IDENTITY="Developer ID Application" \
             DEVELOPMENT_TEAM="${{ secrets.APPLE_TEAM_ID }}" \
-            PROVISIONING_PROFILE_SPECIFIER="${{ vars.APPLE_PROVISION_PROFILE_NAME }}" \
             ENABLE_HARDENED_RUNTIME=YES \
             MARKETING_VERSION="${{ steps.v.outputs.version }}"
 

--- a/apps/mac/Lobu.xcodeproj/project.pbxproj
+++ b/apps/mac/Lobu.xcodeproj/project.pbxproj
@@ -119,11 +119,6 @@
 				TargetAttributes = {
 					B50000000000000000000001 = {
 						CreatedOnToolsVersion = 26.2;
-						SystemCapabilities = {
-							com.apple.HealthKit = {
-								enabled = 1;
-							};
-						};
 					};
 				};
 			};

--- a/apps/mac/Lobu/HealthKitSyncService.swift
+++ b/apps/mac/Lobu/HealthKitSyncService.swift
@@ -23,6 +23,12 @@ struct HealthKitOutput {
 /// (which can backfill hours later) still get picked up. Origin ids are stable
 /// per day / per workout uuid, so server-side `onConflictUpdate` dedup absorbs
 /// the overlap as no-op upserts.
+///
+/// NOTE: shipping builds currently omit the `com.apple.developer.healthkit`
+/// entitlement (see Lobu.entitlements for why), so `isAvailable()` returns
+/// false and this service is dormant. It's kept wired up on purpose —
+/// re-adding the entitlement + a Developer ID provisioning profile is all it
+/// takes to switch Apple Health back on.
 enum HealthKitSyncService {
     enum HealthKitError: LocalizedError {
         case unavailable

--- a/apps/mac/Lobu/Lobu.entitlements
+++ b/apps/mac/Lobu/Lobu.entitlements
@@ -8,7 +8,18 @@
 	<true/>
 	<key>com.apple.security.files.user-selected.read-only</key>
 	<true/>
-	<key>com.apple.developer.healthkit</key>
-	<true/>
+	<!--
+	  HealthKit is intentionally disabled here, not removed. The
+	  `com.apple.developer.healthkit` entitlement is "restricted" — notarized
+	  Developer ID builds only accept it with an embedded provisioning profile
+	  (needs an App ID + Developer ID profile created in the Apple portal). The
+	  Apple Health integration code (HealthKitSyncService, the AppState glue,
+	  the menu-bar row) is kept and stays inert: HealthKitSyncService.isAvailable()
+	  checks hasHealthKitEntitlement(), so without this entitlement the feature
+	  reports "not available" and never errors. To re-enable, add back:
+	      <key>com.apple.developer.healthkit</key><true/>
+	  and wire APPLE_PROVISION_PROFILE_BASE64 / APPLE_PROVISION_PROFILE_NAME into
+	  .github/workflows/mac-release.yml.
+	-->
 </dict>
 </plist>


### PR DESCRIPTION
## Why
`com.apple.developer.healthkit` is a *restricted* entitlement: a notarized Developer ID build only validates it with an embedded provisioning profile, which requires App-ID + Developer-ID-profile setup in the Apple portal. That was the one blocker keeping the `mac-release` CD from producing a signed DMG today.

## Change
- **`Lobu.entitlements` / `project.pbxproj`** — remove the HealthKit entitlement + `SystemCapabilities` entry. Left a comment in the entitlements file explaining it's *disabled, not deleted*, and how to turn it back on.
- The Apple Health integration code is **kept intact** (`HealthKitSyncService`, the `AppState` glue, the menu-bar row). It already gated everything on `hasHealthKitEntitlement()`, so `isAvailable()` now returns `false`, the row shows "not available", and nothing errors. Added a note at the top of `HealthKitSyncService` to that effect.
- **`mac-release.yml`** — drop the provisioning-profile install step, the `PROVISIONING_PROFILE_SPECIFIER`, and the now-unneeded `APPLE_PROVISION_PROFILE_*` secret/variable. Signing is now just the Developer ID cert + notarization creds.

## Verification
- `xcodebuild ... build` ✓ (app still compiles with the HealthKit code present, entitlement absent).
- `plutil -lint` ✓ on the entitlements + pbxproj.
- `actionlint` ✓ on the workflow.

## Remaining setup for the first signed release
Just: `APPLE_CERT_P12_BASE64`, `APPLE_CERT_PASSWORD`, `APPLE_TEAM_ID`, `APPLE_ID`, `APPLE_APP_PASSWORD`, `HOMEBREW_TAP_TOKEN`. No Apple-portal work needed.