### PR TITLE
feat(mac): unsigned-DMG stopgap for mac-release (auto-upgrades to signed when secrets land)

### DIFF
--- a/.github/workflows/mac-release.yml
+++ b/.github/workflows/mac-release.yml
@@ -1,25 +1,33 @@
 name: mac-release
 
-# Builds, signs, notarizes and ships Lobu for Mac.
+# Builds and ships Lobu for Mac, then attaches Lobu.dmg to the existing
+# `lobu-v<version>` GitHub Release (so releases/latest/download/Lobu.dmg always
+# resolves) and writes the Homebrew cask to lobu-ai/homebrew-tap.
 #
-# Runs automatically as part of release CD: when release-please cuts a release,
-# release-please.yml dispatches this workflow with that version. Can also be run
-# manually (workflow_dispatch) with a version. It attaches a notarized Lobu.dmg
-# to the existing `lobu-v<version>` GitHub Release — so `releases/latest/download/
-# Lobu.dmg` always points at the current build — and bumps the Homebrew cask in
-# lobu-ai/homebrew-tap so `brew install --cask lobu-ai/tap/lobu` tracks it too.
+# Two modes, picked automatically from whether the Developer ID cert secret is
+# set — adding the secrets is the *only* thing needed to flip from stopgap to
+# production; nothing in this file changes:
 #
-# Required repo secrets (Settings → Secrets and variables → Actions):
+#   • SIGNED (production)  — APPLE_CERT_P12_BASE64 present: Developer ID
+#       codesign + hardened runtime + notarize + staple. DMG opens with no
+#       Gatekeeper warning.
+#   • UNSIGNED (stopgap)   — that secret empty: ad-hoc-signed app, no
+#       notarization. Works, but the first launch needs right-click → Open
+#       ("unidentified developer"). This is what runs until the Apple Developer
+#       Program membership + Developer ID cert exist.
+#
+# ── To switch to SIGNED: add these repo secrets, that's it ──────────────────
 #   APPLE_CERT_P12_BASE64   base64 of a "Developer ID Application" .p12
 #   APPLE_CERT_PASSWORD     password for that .p12
 #   APPLE_TEAM_ID           10-char Apple Developer team id
 #   APPLE_ID                Apple ID email used for notarization
 #   APPLE_APP_PASSWORD      app-specific password for that Apple ID
-#   HOMEBREW_TAP_TOKEN      PAT with write access to lobu-ai/homebrew-tap
-# An ephemeral keychain password is generated per run; no secret needed for it.
-# No provisioning profile is required — the app ships only standard
-# Developer-ID entitlements (HealthKit is disabled; re-adding the
-# `com.apple.developer.healthkit` entitlement would reintroduce that need).
+#
+# HOMEBREW_TAP_TOKEN (PAT with write access to lobu-ai/homebrew-tap) is used in
+# both modes for the cask push; if it's absent the cask step is skipped (the DMG
+# still ships on the release). No provisioning profile is required — the app
+# ships only standard entitlements (the HealthKit entitlement is disabled; see
+# apps/mac/Lobu/Lobu.entitlements).
 
 on:
   workflow_dispatch:
@@ -41,7 +49,24 @@ jobs:
         id: v
         run: echo "version=${{ github.event.inputs.version }}" >> "$GITHUB_OUTPUT"
 
+      - name: Detect signing mode
+        id: mode
+        env:
+          CERT_P12_BASE64: ${{ secrets.APPLE_CERT_P12_BASE64 }}
+          TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+        run: |
+          if [ -n "$CERT_P12_BASE64" ]; then
+            echo "signed=true" >> "$GITHUB_OUTPUT"
+            echo "::notice::Building a SIGNED + notarized DMG."
+          else
+            echo "signed=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::APPLE_CERT_P12_BASE64 not set — building an UNSIGNED DMG (Gatekeeper warns on first open). Add the signing secrets to get a notarized build."
+          fi
+          if [ -n "$TAP_TOKEN" ]; then echo "tap=true" >> "$GITHUB_OUTPUT"; else echo "tap=false" >> "$GITHUB_OUTPUT"; echo "::warning::HOMEBREW_TAP_TOKEN not set — skipping the Homebrew cask update."; fi
+
+      # ── SIGNED path: import the Developer ID cert into an ephemeral keychain ──
       - name: Import signing certificate
+        if: steps.mode.outputs.signed == 'true'
         env:
           CERT_P12_BASE64: ${{ secrets.APPLE_CERT_P12_BASE64 }}
           CERT_PASSWORD: ${{ secrets.APPLE_CERT_PASSWORD }}
@@ -57,44 +82,47 @@ jobs:
           security list-keychains -d user -s "$KEYCHAIN"
           security default-keychain -s "$KEYCHAIN"
 
-      - name: Archive
+      - name: Archive (signed)
+        if: steps.mode.outputs.signed == 'true'
         run: |
           xcodebuild \
-            -project apps/mac/Lobu.xcodeproj \
-            -scheme Lobu \
-            -configuration Release \
-            -archivePath "$RUNNER_TEMP/Lobu.xcarchive" \
-            archive \
+            -project apps/mac/Lobu.xcodeproj -scheme Lobu -configuration Release \
+            -archivePath "$RUNNER_TEMP/Lobu.xcarchive" archive \
             CODE_SIGN_STYLE=Manual \
             CODE_SIGN_IDENTITY="Developer ID Application" \
             DEVELOPMENT_TEAM="${{ secrets.APPLE_TEAM_ID }}" \
             ENABLE_HARDENED_RUNTIME=YES \
             MARKETING_VERSION="${{ steps.v.outputs.version }}"
 
+      - name: Archive (unsigned, ad-hoc)
+        if: steps.mode.outputs.signed != 'true'
+        run: |
+          xcodebuild \
+            -project apps/mac/Lobu.xcodeproj -scheme Lobu -configuration Release \
+            -archivePath "$RUNNER_TEMP/Lobu.xcarchive" archive \
+            CODE_SIGNING_ALLOWED=NO \
+            MARKETING_VERSION="${{ steps.v.outputs.version }}"
+          # arm64 apps must carry at least an ad-hoc signature to launch at all;
+          # this also lets users do right-click → Open past "unidentified
+          # developer". A real Developer ID + notarization removes that prompt.
+          codesign --force --deep --sign - "$RUNNER_TEMP/Lobu.xcarchive/Products/Applications/Lobu.app"
+
       - name: Build DMG
         run: |
-          # The archived app is already signed with Developer ID + hardened
-          # runtime by the Archive step, so we package it straight from the
-          # xcarchive — no -exportArchive / ExportOptions.plist dance needed.
           APP="$RUNNER_TEMP/Lobu.xcarchive/Products/Applications/Lobu.app"
           test -d "$APP" || { echo "::error::Lobu.app missing from archive"; exit 1; }
-          STAGE="$RUNNER_TEMP/dmg-stage"
-          mkdir -p "$STAGE"
-          cp -R "$APP" "$STAGE/"
+          STAGE="$RUNNER_TEMP/dmg-stage"; mkdir -p "$STAGE"; cp -R "$APP" "$STAGE/"
           brew install create-dmg
           # create-dmg can exit non-zero on cosmetic AppleScript hiccups while
           # still producing the image, so verify the artifact instead of $?.
           create-dmg \
-            --volname "Lobu" \
-            --window-size 540 380 \
-            --icon-size 100 \
-            --icon "Lobu.app" 140 190 \
-            --app-drop-link 400 190 \
-            "$RUNNER_TEMP/Lobu.dmg" \
-            "$STAGE" || true
+            --volname "Lobu" --window-size 540 380 --icon-size 100 \
+            --icon "Lobu.app" 140 190 --app-drop-link 400 190 \
+            "$RUNNER_TEMP/Lobu.dmg" "$STAGE" || true
           test -f "$RUNNER_TEMP/Lobu.dmg" || { echo "::error::DMG was not created"; exit 1; }
 
       - name: Notarize and staple
+        if: steps.mode.outputs.signed == 'true'
         run: |
           xcrun notarytool submit "$RUNNER_TEMP/Lobu.dmg" \
             --apple-id "${{ secrets.APPLE_ID }}" \
@@ -115,6 +143,7 @@ jobs:
           fail_on_unmatched_files: true
 
       - name: Update Homebrew tap
+        if: steps.mode.outputs.tap == 'true'
         env:
           GH_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
         run: |
@@ -122,11 +151,16 @@ jobs:
           SHA="${{ steps.sum.outputs.sha256 }}"
           git clone "https://x-access-token:${GH_TOKEN}@github.com/lobu-ai/homebrew-tap.git" tap
           mkdir -p tap/Casks
-          sed -e "s/@VERSION@/$VERSION/g" -e "s/@SHA256@/$SHA/g" \
+          if [ "${{ steps.mode.outputs.signed }}" = "true" ]; then
+            CAVEATS=""
+          else
+            CAVEATS='caveats "Lobu for Mac is not notarized yet — the first time you open it, right-click Lobu in Applications and choose Open, then confirm. You only need to do this once."'
+          fi
+          sed -e "s|@VERSION@|$VERSION|g" -e "s|@SHA256@|$SHA|g" -e "s|@CAVEATS@|$CAVEATS|" \
             apps/mac/homebrew/lobu.rb.tmpl > tap/Casks/lobu.rb
           cd tap
           git config user.name "lobu-bot"
           git config user.email "bot@lobu.ai"
           git add Casks/lobu.rb
-          git commit -m "lobu ${VERSION}"
+          git diff --cached --quiet || git commit -m "lobu ${VERSION}"
           git push origin HEAD:refs/heads/main

--- a/apps/mac/homebrew/lobu.rb.tmpl
+++ b/apps/mac/homebrew/lobu.rb.tmpl
@@ -13,6 +13,10 @@ cask "lobu" do
 
   depends_on macos: ">= :sonoma"
 
+  # Filled in by the mac-release workflow: a "right-click → Open" caveat while
+  # the build is unsigned, or empty once it ships notarized.
+  @CAVEATS@
+
   app "Lobu.app"
 
   zap trash: [


### PR DESCRIPTION
Lets us ship a downloadable **Download for Mac** DMG + working `brew install --cask lobu-ai/tap/lobu` today, without an Apple Developer Program membership — and flip to a fully-notarized build later by just adding secrets.

## How it works
`mac-release.yml` detects its mode from whether `APPLE_CERT_P12_BASE64` is set:
- **Unsigned (now):** `xcodebuild CODE_SIGNING_ALLOWED=NO` → `codesign --sign -` (ad-hoc — needed for arm64 to launch at all, and lets users do right-click → Open past "unidentified developer") → DMG → attach to the `lobu-v<version>` release. The Homebrew cask gets a one-time "right-click → Open" caveat.
- **Signed (later):** add the five `APPLE_*` secrets and the next run does Developer ID codesign + hardened runtime + notarize + staple — the DMG opens with no Gatekeeper prompt. **Nothing in the workflow needs to change**; the header block lists exactly which secrets to add.

Also: the Homebrew-tap push is skipped (with a warning) if `HOMEBREW_TAP_TOKEN` isn't set, so the DMG still ships on the release; and a no-op cask re-commit no longer fails the run.

## Verification
- `actionlint` ✓ on the workflow.
- Simulated the cask generation for both modes — valid Ruby either way.

## After merge
Set `HOMEBREW_TAP_TOKEN` (a GitHub PAT with write to `lobu-ai/homebrew-tap`), then either wait for the next release-please release (auto-dispatches `mac-release`) or `gh workflow run mac-release.yml -f version=6.1.1`. That run produces the (unsigned) DMG + populates the cask. Adding the `APPLE_*` secrets later upgrades all subsequent runs to notarized with zero further changes.