### PR TITLE
fix(mac): tap-token fallback + tidy cask template

### DIFF
--- a/.github/workflows/mac-release.yml
+++ b/.github/workflows/mac-release.yml
@@ -23,10 +23,11 @@ name: mac-release
 #   APPLE_ID                Apple ID email used for notarization
 #   APPLE_APP_PASSWORD      app-specific password for that Apple ID
 #
-# HOMEBREW_TAP_TOKEN (PAT with write access to lobu-ai/homebrew-tap) is used in
-# both modes for the cask push; if it's absent the cask step is skipped (the DMG
-# still ships on the release). No provisioning profile is required — the app
-# ships only standard entitlements (the HealthKit entitlement is disabled; see
+# The cask push uses HOMEBREW_TAP_TOKEN if set, else falls back to
+# RELEASE_PLEASE_TOKEN (any PAT with write access to lobu-ai/homebrew-tap works);
+# if neither exists the cask step is skipped and the DMG still ships on the
+# release. No provisioning profile is required — the app ships only standard
+# entitlements (the HealthKit entitlement is disabled; see
 # apps/mac/Lobu/Lobu.entitlements).
 
 on:
@@ -53,7 +54,7 @@ jobs:
         id: mode
         env:
           CERT_P12_BASE64: ${{ secrets.APPLE_CERT_P12_BASE64 }}
-          TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN || secrets.RELEASE_PLEASE_TOKEN }}
         run: |
           if [ -n "$CERT_P12_BASE64" ]; then
             echo "signed=true" >> "$GITHUB_OUTPUT"
@@ -62,7 +63,7 @@ jobs:
             echo "signed=false" >> "$GITHUB_OUTPUT"
             echo "::warning::APPLE_CERT_P12_BASE64 not set — building an UNSIGNED DMG (Gatekeeper warns on first open). Add the signing secrets to get a notarized build."
           fi
-          if [ -n "$TAP_TOKEN" ]; then echo "tap=true" >> "$GITHUB_OUTPUT"; else echo "tap=false" >> "$GITHUB_OUTPUT"; echo "::warning::HOMEBREW_TAP_TOKEN not set — skipping the Homebrew cask update."; fi
+          if [ -n "$TAP_TOKEN" ]; then echo "tap=true" >> "$GITHUB_OUTPUT"; else echo "tap=false" >> "$GITHUB_OUTPUT"; echo "::warning::No HOMEBREW_TAP_TOKEN / RELEASE_PLEASE_TOKEN — skipping the Homebrew cask update."; fi
 
       # ── SIGNED path: import the Developer ID cert into an ephemeral keychain ──
       - name: Import signing certificate
@@ -145,19 +146,21 @@ jobs:
       - name: Update Homebrew tap
         if: steps.mode.outputs.tap == 'true'
         env:
-          GH_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          GH_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN || secrets.RELEASE_PLEASE_TOKEN }}
         run: |
           VERSION="${{ steps.v.outputs.version }}"
           SHA="${{ steps.sum.outputs.sha256 }}"
           git clone "https://x-access-token:${GH_TOKEN}@github.com/lobu-ai/homebrew-tap.git" tap
           mkdir -p tap/Casks
+          # build the cask from the template: strip the leading doc comment,
+          # fill version/sha, and keep/drop the caveats block per signing mode.
+          sed '/^cask "lobu" do$/,$!d' apps/mac/homebrew/lobu.rb.tmpl > tap/Casks/lobu.rb
           if [ "${{ steps.mode.outputs.signed }}" = "true" ]; then
-            CAVEATS=""
+            sed -i '' '/# @CAVEATS_START@/,/# @CAVEATS_END@/d' tap/Casks/lobu.rb
           else
-            CAVEATS='caveats "Lobu for Mac is not notarized yet — the first time you open it, right-click Lobu in Applications and choose Open, then confirm. You only need to do this once."'
+            sed -i '' '/# @CAVEATS_START@/d;/# @CAVEATS_END@/d' tap/Casks/lobu.rb
           fi
-          sed -e "s|@VERSION@|$VERSION|g" -e "s|@SHA256@|$SHA|g" -e "s|@CAVEATS@|$CAVEATS|" \
-            apps/mac/homebrew/lobu.rb.tmpl > tap/Casks/lobu.rb
+          sed -i '' "s|@VERSION@|$VERSION|g;s|@SHA256@|$SHA|g" tap/Casks/lobu.rb
           cd tap
           git config user.name "lobu-bot"
           git config user.email "bot@lobu.ai"

--- a/apps/mac/homebrew/lobu.rb.tmpl
+++ b/apps/mac/homebrew/lobu.rb.tmpl
@@ -1,6 +1,10 @@
-# Source template for the Homebrew cask. The mac-release workflow fills in
-# @VERSION@ / @SHA256@ and commits the result to lobu-ai/homebrew-tap as
-# Casks/lobu.rb, so users can `brew install --cask lobu-ai/tap/lobu`.
+# Source template for the Homebrew cask. The mac-release workflow:
+#   - drops everything above the `cask` line (this comment block),
+#   - fills in @VERSION@ / @SHA256@,
+#   - for a notarized build, deletes the @CAVEATS_START@..@CAVEATS_END@ block;
+#     for an unsigned build, keeps it and just removes the marker comment lines,
+# then commits the result to lobu-ai/homebrew-tap as Casks/lobu.rb so
+# `brew install --cask lobu-ai/tap/lobu` works.
 cask "lobu" do
   version "@VERSION@"
   sha256 "@SHA256@"
@@ -13,10 +17,6 @@ cask "lobu" do
 
   depends_on macos: ">= :sonoma"
 
-  # Filled in by the mac-release workflow: a "right-click → Open" caveat while
-  # the build is unsigned, or empty once it ships notarized.
-  @CAVEATS@
-
   app "Lobu.app"
 
   zap trash: [
@@ -24,4 +24,11 @@ cask "lobu" do
     "~/Library/Caches/ai.lobu.mac",
     "~/Library/Preferences/ai.lobu.mac.plist",
   ]
+  # @CAVEATS_START@
+
+  caveats <<~EOS
+    Lobu for Mac is not notarized yet. The first time you open it, right-click
+    Lobu in Applications and choose Open, then confirm — once only.
+  EOS
+  # @CAVEATS_END@
 end


### PR DESCRIPTION
Small follow-up to the mac-release pipeline.

- **Tap token fallback** — `mac-release.yml` now uses `HOMEBREW_TAP_TOKEN` if present, otherwise falls back to `RELEASE_PLEASE_TOKEN`. That existing secret (release-please's PAT) already has write access to `lobu-ai/homebrew-tap`, so the cask updates automatically with **no new secret needed**. (You can still add a dedicated `HOMEBREW_TAP_TOKEN` if you want isolation.)
- **Cask template tidy** — the generated `Casks/lobu.rb` no longer carries the template's doc comment, and the "right-click → Open" caveat lives in a `@CAVEATS_START@..@CAVEATS_END@` block after `zap` (correct stanza order). The workflow keeps it for unsigned builds, drops it for notarized ones. Verified both generated casks pass `brew style` (in a tap context) and `brew audit --online`.

Context: the unsigned DMG is already live on `lobu-v6.1.1`, and the cask is already published to `lobu-ai/homebrew-tap` — `brew install --cask lobu-ai/tap/lobu` works today (tested: tap → audit → install → uninstall, app installs ad-hoc-signed). This PR just makes the *automated* path (next release) keep it that way without a manual token step.