### PR TITLE
feat(connectors): pin connections to a device worker (run-on-device + shared-org device connectors)

### DIFF
--- a/db/migrations/20260512000000_device_worker_connection_binding.sql
+++ b/db/migrations/20260512000000_device_worker_connection_binding.sql
@@ -1,0 +1,105 @@
+-- migrate:up
+
+-- Make a connection's execution target explicit. Until now, device connectors
+-- (connector_definitions.required_capability IS NOT NULL) reached an org only
+-- by silent auto-wire into the polling user's personal org, and there was no
+-- way to (a) back a connector with a member's device in a shared org, (b) pick
+-- which device runs a connector, or (c) run an otherwise-cloud connector on a
+-- specific device.
+--
+-- connections.device_worker_id (nullable) is the binding:
+--   NULL  -> runs on the cloud connector-worker pool (today's behavior)
+--   set   -> runs are pinned to that device worker
+-- For device-type connectors the binding is mandatory; for cloud connectors
+-- it's an optional override.
+--
+-- device_worker_org_grants lets a device owner explicitly allow a device to
+-- back connectors in a non-personal org. Org-sharing is always an explicit
+-- grant, never inferred from "active org at device login".
+
+-- Surrogate key for device_workers so connections / grants / UI can reference a
+-- device by a single stable id. The (user_id, worker_id) primary key stays.
+ALTER TABLE public.device_workers
+    ADD COLUMN IF NOT EXISTS id uuid NOT NULL DEFAULT gen_random_uuid();
+
+CREATE UNIQUE INDEX IF NOT EXISTS device_workers_id_key
+    ON public.device_workers (id);
+
+ALTER TABLE public.connections
+    ADD COLUMN IF NOT EXISTS device_worker_id uuid;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint WHERE conname = 'connections_device_worker_id_fkey'
+    ) THEN
+        ALTER TABLE public.connections
+            ADD CONSTRAINT connections_device_worker_id_fkey
+            FOREIGN KEY (device_worker_id)
+            REFERENCES public.device_workers (id)
+            ON DELETE SET NULL;
+    END IF;
+END$$;
+
+CREATE INDEX IF NOT EXISTS idx_connections_device_worker_id
+    ON public.connections (device_worker_id)
+    WHERE device_worker_id IS NOT NULL;
+
+CREATE TABLE IF NOT EXISTS public.device_worker_org_grants (
+    device_worker_id uuid NOT NULL REFERENCES public.device_workers (id) ON DELETE CASCADE,
+    organization_id text NOT NULL,
+    granted_by text NOT NULL,
+    granted_at timestamptz NOT NULL DEFAULT now(),
+    PRIMARY KEY (device_worker_id, organization_id)
+);
+
+CREATE INDEX IF NOT EXISTS device_worker_org_grants_org_idx
+    ON public.device_worker_org_grants (organization_id);
+
+-- Backfill: existing auto-wired personal-org device connections (created_by
+-- set, no auth profile) whose owner has exactly one device get pinned to that
+-- device — but at most one per (org, connector_key, owner) so the unique index
+-- created below can never be violated. Ambiguous ones stay NULL and the UI
+-- prompts for a device.
+UPDATE public.connections c
+SET device_worker_id = dw.id
+FROM (
+    SELECT user_id, min(id) AS id
+    FROM public.device_workers
+    GROUP BY user_id
+    HAVING count(*) = 1
+) dw
+WHERE c.created_by = dw.user_id
+  AND c.device_worker_id IS NULL
+  AND c.deleted_at IS NULL
+  AND c.auth_profile_id IS NULL
+  AND c.connector_key IN (
+      SELECT key FROM public.connector_definitions WHERE required_capability IS NOT NULL
+  )
+  AND c.id = (
+      SELECT min(c2.id) FROM public.connections c2
+      WHERE c2.organization_id = c.organization_id
+        AND c2.connector_key = c.connector_key
+        AND c2.created_by = c.created_by
+        AND c2.deleted_at IS NULL
+  );
+
+-- One active connection per (org, connector, device). A second device backing
+-- the same connector is a second connection. Doubles as DB-level idempotency
+-- for the create-vs-auto-wire race. Created AFTER the backfill above.
+DROP INDEX IF EXISTS public.idx_connections_org_connector_device_live;
+CREATE UNIQUE INDEX idx_connections_org_connector_device_live
+    ON public.connections (organization_id, connector_key, device_worker_id)
+    WHERE deleted_at IS NULL AND device_worker_id IS NOT NULL;
+
+-- migrate:down
+
+DROP TABLE IF EXISTS public.device_worker_org_grants;
+DROP INDEX IF EXISTS public.idx_connections_org_connector_device_live;
+DROP INDEX IF EXISTS public.idx_connections_device_worker_id;
+ALTER TABLE public.connections
+    DROP CONSTRAINT IF EXISTS connections_device_worker_id_fkey,
+    DROP COLUMN IF EXISTS device_worker_id;
+DROP INDEX IF EXISTS public.device_workers_id_key;
+ALTER TABLE public.device_workers
+    DROP COLUMN IF EXISTS id;

--- a/db/migrations/20260512000000_device_worker_connection_binding.sql
+++ b/db/migrations/20260512000000_device_worker_connection_binding.sql
@@ -64,10 +64,14 @@ CREATE INDEX IF NOT EXISTS device_worker_org_grants_org_idx
 UPDATE public.connections c
 SET device_worker_id = dw.id
 FROM (
-    SELECT user_id, min(id) AS id
-    FROM public.device_workers
-    GROUP BY user_id
-    HAVING count(*) = 1
+    -- Users with exactly one device worker (no min(uuid) needed — and Postgres
+    -- has no aggregate for uuid anyway).
+    SELECT dw1.user_id, dw1.id
+    FROM public.device_workers dw1
+    WHERE NOT EXISTS (
+        SELECT 1 FROM public.device_workers dw2
+        WHERE dw2.user_id = dw1.user_id AND dw2.id <> dw1.id
+    )
 ) dw
 WHERE c.created_by = dw.user_id
   AND c.device_worker_id IS NULL

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -63,6 +63,26 @@ This closes most of the gap between "subprocess on the same host" and what Docke
 
 A compromised worker session cannot leak global platform tokens or MCP client secrets.
 
+### Device-pinned connectors
+
+A connection can be pinned to a *device worker* (`connections.device_worker_id`) so its
+syncs/actions run on a specific user-owned device (Lobu for Mac/iPhone) instead of the cloud
+connector-worker pool — mandatory for device-only connectors (`required_capability`, e.g.
+Apple Health), optional for any other connector ("run the Reddit connector on my Mac").
+
+Implications, by design:
+- **Credentials run on the device.** When a pinned connection has an auth profile, the gateway
+  delivers the resolved connection credentials to that device worker over its own user-scoped
+  token — the same path the cloud worker uses. The trust boundary is the user: they own both the
+  device and the data the connector reads. Capability-matched (unpinned) device connectors are
+  no-auth by construction and still receive no credentials.
+- **Egress uses the device's network.** Connector traffic from a device worker is not subject to
+  the gateway's allowlist/blocklist/egress-judge — those govern locally-spawned workers, not a
+  remote device. Treat a device-pinned cloud connector as running on that machine's network.
+- **Binding is authorized at bind time.** A connection can only be pinned to a device the requester
+  owns, or one explicitly granted to the org by its owner (`device_worker_org_grants`); revoking a
+  grant un-pins that org's connections.
+
 ## Skills and policy
 
 Skills are executable, security-sensitive input:

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -586,6 +586,7 @@ import {
   getAuthRun,
   heartbeat,
   listDeviceWorkers,
+  setDeviceOrgGrant,
   pollAuthSignal,
   pollWorkerJob,
   postAuthSignal,
@@ -691,6 +692,8 @@ app.post('/api/workers/complete-auth', completeAuthRun);
 // devices. Lives under /api/me/ so the workspace resolver treats it as
 // user-scoped (no org slug in the URL).
 app.get('/api/me/devices', mcpAuth, listDeviceWorkers);
+app.post('/api/me/device-grants', mcpAuth, (c) => setDeviceOrgGrant(c, true));
+app.delete('/api/me/device-grants', mcpAuth, (c) => setDeviceOrgGrant(c, false));
 // UI → worker signal channel. Separate path prefix so the worker API auth
 // middleware above doesn't cover it (this one is hit from the web session).
 app.get('/api/auth-runs/active', getActiveAuthRun);

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -649,18 +649,18 @@ app.use('/api/workers/*', async (c, next) => {
         return c.json({ error: 'Worker token missing device_worker:run scope' }, 403);
       }
       const userId = c.var.user.id;
-      // mcpAuth already verified the token resolves to (and the user is a
-      // member of) `c.var.organizationId`. A device worker is scoped to that
-      // org plus the user's personal org (the auto-wire target), and nothing
-      // else.
+      // A device worker is scoped to the org its token is bound to (if any —
+      // mcpAuth verified membership) plus the user's personal org, the
+      // auto-wire target. Device-code tokens (Lobu for Mac/iPhone) often aren't
+      // bound to any org, so the personal org alone is a valid scope.
       const boundOrgId = c.var.organizationId;
-      if (!boundOrgId) {
-        return c.json({ error: 'Worker token must be bound to an organization' }, 403);
-      }
       const personalOrg = await findExistingPersonalOrg(userId, getDb());
-      const orgIds = personalOrg
-        ? Array.from(new Set([boundOrgId, personalOrg.id]))
-        : [boundOrgId];
+      const orgIds = Array.from(
+        new Set([boundOrgId, personalOrg?.id].filter((id): id is string => !!id))
+      );
+      if (orgIds.length === 0) {
+        return c.json({ error: 'No organization in scope for this worker token' }, 403);
+      }
       c.set('workerAuthMode', 'user');
       c.set('workerUserId', userId);
       c.set('workerOrgIds', orgIds);

--- a/packages/server/src/start-local.ts
+++ b/packages/server/src/start-local.ts
@@ -459,6 +459,63 @@ const EMBEDDED_SCHEMA_PATCHES: EmbeddedSchemaPatch[] = [
       `);
     },
   },
+  {
+    // Mirrors db/migrations/20260512000000_device_worker_connection_binding.sql
+    // for already-initialized embedded/PGlite databases (where dbmate
+    // migrations don't run).
+    id: 'device-worker-connection-binding',
+    apply: async (sql) => {
+      await sql.unsafe(`
+        ALTER TABLE public.device_workers
+        ADD COLUMN IF NOT EXISTS id uuid NOT NULL DEFAULT gen_random_uuid()
+      `);
+      await sql.unsafe(`
+        CREATE UNIQUE INDEX IF NOT EXISTS device_workers_id_key
+        ON public.device_workers (id)
+      `);
+      await sql.unsafe(`
+        ALTER TABLE public.connections
+        ADD COLUMN IF NOT EXISTS device_worker_id uuid
+      `);
+      await sql.unsafe(`
+        DO $$
+        BEGIN
+          IF NOT EXISTS (
+            SELECT 1 FROM pg_constraint WHERE conname = 'connections_device_worker_id_fkey'
+          ) THEN
+            ALTER TABLE public.connections
+              ADD CONSTRAINT connections_device_worker_id_fkey
+              FOREIGN KEY (device_worker_id)
+              REFERENCES public.device_workers (id)
+              ON DELETE SET NULL;
+          END IF;
+        END $$;
+      `);
+      await sql.unsafe(`
+        CREATE INDEX IF NOT EXISTS idx_connections_device_worker_id
+        ON public.connections (device_worker_id)
+        WHERE device_worker_id IS NOT NULL
+      `);
+      await sql.unsafe(`
+        CREATE UNIQUE INDEX IF NOT EXISTS idx_connections_org_connector_device_live
+        ON public.connections (organization_id, connector_key, device_worker_id)
+        WHERE deleted_at IS NULL AND device_worker_id IS NOT NULL
+      `);
+      await sql.unsafe(`
+        CREATE TABLE IF NOT EXISTS public.device_worker_org_grants (
+          device_worker_id uuid NOT NULL REFERENCES public.device_workers (id) ON DELETE CASCADE,
+          organization_id text NOT NULL,
+          granted_by text NOT NULL,
+          granted_at timestamptz NOT NULL DEFAULT now(),
+          PRIMARY KEY (device_worker_id, organization_id)
+        )
+      `);
+      await sql.unsafe(`
+        CREATE INDEX IF NOT EXISTS device_worker_org_grants_org_idx
+        ON public.device_worker_org_grants (organization_id)
+      `);
+    },
+  },
 ];
 
 async function applyEmbeddedSchemaPatches(sql: MigrationSqlClient) {

--- a/packages/server/src/tools/admin/manage_connections.ts
+++ b/packages/server/src/tools/admin/manage_connections.ts
@@ -55,6 +55,7 @@ import {
   installConnectorDefinitionFromSource,
   installConnectorFromMcpUrl,
   listScopedConnectorDefinitions,
+  type ScopedConnectorDefinitionRow,
   toggleConnectorLoginEnabled,
   uninstallConnectorDefinition,
 } from './connector-definition-helpers';
@@ -145,6 +146,12 @@ const CreateAction = Type.Object({
       description: 'Override the connection owner (admin/owner only). Defaults to current user.',
     })
   ),
+  device_worker_id: Type.Optional(
+    Type.String({
+      description:
+        "Run this connection's syncs/actions on a specific device worker (its device_workers.id) instead of the cloud pool. Required for connectors that declare a required_capability; optional otherwise. The device must belong to you or be granted to this org.",
+    })
+  ),
   entity_link_overrides: Type.Optional(EntityLinkOverridesSchema),
 });
 
@@ -156,6 +163,12 @@ const UpdateAction = Type.Object({
   auth_profile_slug: Type.Optional(Type.Union([Type.String(), Type.Null()])),
   app_auth_profile_slug: Type.Optional(Type.Union([Type.String(), Type.Null()])),
   config: Type.Optional(Type.Record(Type.String(), Type.Any())),
+  device_worker_id: Type.Optional(
+    Type.Union([Type.String(), Type.Null()], {
+      description:
+        'Reassign which device worker runs this connection. Null moves it back to the cloud pool (only allowed if the connector has no required_capability).',
+    })
+  ),
 });
 
 const DeleteAction = Type.Object({
@@ -488,6 +501,10 @@ async function handleList(
            app.display_name AS app_auth_profile_name,
            app.status AS app_auth_profile_status,
            app.profile_kind AS app_auth_profile_kind,
+           dw.label AS device_label,
+           dw.platform AS device_platform,
+           dw.worker_id AS device_worker_handle,
+           (dw.id IS NOT NULL AND dw.last_seen_at > now() - interval '20 minutes') AS device_online,
            (SELECT COUNT(*) FROM current_event_records e WHERE e.connection_id = c.id)::int AS event_count,
            (SELECT COUNT(*) FROM feeds f WHERE f.connection_id = c.id AND f.deleted_at IS NULL)::int AS feed_count,
            (SELECT ct.token FROM connect_tokens ct
@@ -511,6 +528,7 @@ async function handleList(
     ) cd ON TRUE
     LEFT JOIN auth_profiles ap ON ap.id = c.auth_profile_id
     LEFT JOIN auth_profiles app ON app.id = c.app_auth_profile_id
+    LEFT JOIN device_workers dw ON dw.id = c.device_worker_id
     WHERE c.organization_id = ${organizationId} AND c.deleted_at IS NULL
   `;
 
@@ -591,6 +609,10 @@ async function handleGet(
            app.display_name AS app_auth_profile_name,
            app.status AS app_auth_profile_status,
            app.profile_kind AS app_auth_profile_kind,
+           dw.label AS device_label,
+           dw.platform AS device_platform,
+           dw.worker_id AS device_worker_handle,
+           (dw.id IS NOT NULL AND dw.last_seen_at > now() - interval '20 minutes') AS device_online,
            (SELECT COUNT(*) FROM current_event_records e WHERE e.connection_id = c.id)::int AS event_count
     FROM connections c
     LEFT JOIN LATERAL (
@@ -604,6 +626,7 @@ async function handleGet(
     ) cd ON TRUE
     LEFT JOIN auth_profiles ap ON ap.id = c.auth_profile_id
     LEFT JOIN auth_profiles app ON app.id = c.app_auth_profile_id
+    LEFT JOIN device_workers dw ON dw.id = c.device_worker_id
     WHERE c.id = ${args.connection_id}
       AND c.organization_id = ${organizationId}
       AND c.deleted_at IS NULL
@@ -653,6 +676,78 @@ async function handleGet(
   };
 }
 
+/**
+ * Validate + normalize a connection's device-worker binding (the "Run on"
+ * target). Returns the resolved id (or `null` = cloud pool) or an error string.
+ *
+ *  - A connector that declares `required_capability` MUST be pinned to a device,
+ *    and that device must currently advertise the capability.
+ *  - Any other connector may optionally be pinned to a device (run-on-device).
+ *  - The requester may pin a device they own, or one explicitly granted to this
+ *    org via `device_worker_org_grants`.
+ */
+async function resolveDeviceBinding(params: {
+  organizationId: string;
+  userId: string | null | undefined;
+  connector: ScopedConnectorDefinitionRow;
+  deviceWorkerId: string | null | undefined;
+}): Promise<{ error: string } | { deviceWorkerId: string | null }> {
+  const sql = getDb();
+  const requiredCapability = params.connector.required_capability ?? null;
+  const deviceWorkerId = params.deviceWorkerId?.trim() || null;
+
+  if (!deviceWorkerId) {
+    if (requiredCapability) {
+      return {
+        error: `Connector '${params.connector.key}' runs on a device — pass device_worker_id for a device that has granted the '${requiredCapability}' permission.`,
+      };
+    }
+    return { deviceWorkerId: null };
+  }
+
+  const rows = (await sql`
+    SELECT dw.id, dw.user_id, dw.capabilities, dw.label
+    FROM device_workers dw
+    WHERE dw.id = ${deviceWorkerId}
+    LIMIT 1
+  `) as unknown as Array<{
+    id: string;
+    user_id: string;
+    capabilities: unknown;
+    label: string | null;
+  }>;
+  const device = rows[0];
+  if (!device) {
+    return { error: `Device worker '${deviceWorkerId}' not found.` };
+  }
+
+  const ownsDevice = !!params.userId && device.user_id === params.userId;
+  if (!ownsDevice) {
+    const granted = (await sql`
+      SELECT 1 FROM device_worker_org_grants
+      WHERE device_worker_id = ${deviceWorkerId}
+        AND organization_id = ${params.organizationId}
+      LIMIT 1
+    `) as unknown as Array<unknown>;
+    if (granted.length === 0) {
+      return {
+        error: `You don't have access to device '${device.label ?? deviceWorkerId}'. The device owner must grant it to this org first.`,
+      };
+    }
+  }
+
+  if (requiredCapability) {
+    const caps = Array.isArray(device.capabilities) ? (device.capabilities as string[]) : [];
+    if (!caps.includes(requiredCapability)) {
+      return {
+        error: `Device '${device.label ?? deviceWorkerId}' hasn't granted the '${requiredCapability}' permission required by '${params.connector.key}'.`,
+      };
+    }
+  }
+
+  return { deviceWorkerId };
+}
+
 async function handleCreate(
   args: Extract<ConnectionsArgs, { action: 'create' }>,
   _env: Env,
@@ -682,6 +777,29 @@ async function handleCreate(
 
   if (!connector) {
     return { error: `Connector '${args.connector_key}' not found or not active` };
+  }
+
+  const deviceBinding = await resolveDeviceBinding({
+    organizationId,
+    userId,
+    connector,
+    deviceWorkerId: args.device_worker_id,
+  });
+  if ('error' in deviceBinding) return deviceBinding;
+  if (deviceBinding.deviceWorkerId) {
+    const dup = (await sql`
+      SELECT id FROM connections
+      WHERE organization_id = ${organizationId}
+        AND connector_key = ${args.connector_key}
+        AND device_worker_id = ${deviceBinding.deviceWorkerId}
+        AND deleted_at IS NULL
+      LIMIT 1
+    `) as unknown as Array<{ id: number }>;
+    if (dup.length > 0) {
+      return {
+        error: `A ${connector.name} connection (id: ${dup[0].id}) is already assigned to that device in this org.`,
+      };
+    }
   }
 
   if (args.entity_link_overrides !== undefined) {
@@ -833,7 +951,7 @@ async function handleCreate(
   const inserted = await sql`
     INSERT INTO connections (
       organization_id, connector_key, display_name, status,
-      auth_profile_id, app_auth_profile_id, config, created_by, visibility
+      auth_profile_id, app_auth_profile_id, config, created_by, visibility, device_worker_id
     ) VALUES (
       ${organizationId}, ${args.connector_key},
       ${displayName},
@@ -842,7 +960,8 @@ async function handleCreate(
       ${authSelection?.appAuthProfile?.id ?? null},
       ${splitConfig.connectionConfig ? sql.json(splitConfig.connectionConfig) : null},
       ${effectiveCreatedBy},
-      ${visibility}
+      ${visibility},
+      ${deviceBinding.deviceWorkerId}
     )
     RETURNING *
   `;
@@ -1206,6 +1325,28 @@ async function handleUpdate(
 
   const hasAuthProfileArg = Object.hasOwn(args, 'auth_profile_slug');
   const hasAppAuthProfileArg = Object.hasOwn(args, 'app_auth_profile_slug');
+  const hasDeviceWorkerArg = Object.hasOwn(args, 'device_worker_id');
+
+  // Resolve the new device-worker binding up front so a bad value rejects the
+  // whole update.
+  let nextDeviceWorkerId: string | null = null;
+  if (hasDeviceWorkerArg) {
+    const connectorDef = await getScopedConnectorDefinition({
+      organizationId,
+      connectorKey: existing.connector_key,
+    });
+    if (!connectorDef) {
+      return { error: `Connector '${existing.connector_key}' not found or not active` };
+    }
+    const binding = await resolveDeviceBinding({
+      organizationId,
+      userId: ctx.userId,
+      connector: connectorDef,
+      deviceWorkerId: args.device_worker_id,
+    });
+    if ('error' in binding) return binding;
+    nextDeviceWorkerId = binding.deviceWorkerId;
+  }
 
   const authSelection = await resolveConnectionAuthSelection({
     organizationId,
@@ -1293,6 +1434,15 @@ async function handleUpdate(
     WHERE id = ${args.connection_id} AND organization_id = ${organizationId}
     RETURNING *
   `;
+
+  if (hasDeviceWorkerArg) {
+    await sql`
+      UPDATE connections
+      SET device_worker_id = ${nextDeviceWorkerId}, updated_at = NOW()
+      WHERE id = ${args.connection_id} AND organization_id = ${organizationId}
+    `;
+    (updated[0] as Record<string, unknown>).device_worker_id = nextDeviceWorkerId;
+  }
 
   const updatedConnection = updated[0] as {
     id: number;

--- a/packages/server/src/tools/admin/manage_connections.ts
+++ b/packages/server/src/tools/admin/manage_connections.ts
@@ -811,22 +811,26 @@ async function handleCreate(
     if (err) return { error: err };
   }
 
-  // No-auth connectors: one connection per user
+  // No-auth connectors are limited to one connection per user — except when the
+  // connection is pinned to a device worker, where the cardinality is "one per
+  // (org, connector, device)" (enforced just above + by the unique index), so a
+  // user's second device can back the same connector with its own connection.
   const authMethods =
     (connector.auth_schema as { methods?: Array<{ type: string }> })?.methods ?? [];
   const isNoAuth = authMethods.length > 0 && authMethods.every((m) => m.type === 'none');
-  if (isNoAuth) {
+  if (isNoAuth && !deviceBinding.deviceWorkerId) {
     const existing = await sql`
       SELECT id FROM connections
       WHERE organization_id = ${organizationId}
         AND connector_key = ${args.connector_key}
         AND created_by = ${effectiveCreatedBy}
+        AND device_worker_id IS NULL
         AND deleted_at IS NULL
       LIMIT 1
     `;
     if (existing.length > 0) {
       return {
-        error: `This user already has a ${connector.name} connection (id: ${existing[0].id}). No-auth connectors are limited to one connection per user.`,
+        error: `This user already has a ${connector.name} connection (id: ${existing[0].id}). No-auth connectors are limited to one connection per user (unless pinned to different devices).`,
       };
     }
   }

--- a/packages/server/src/worker-api.ts
+++ b/packages/server/src/worker-api.ts
@@ -37,6 +37,7 @@ import { validateConnectorEventSemanticType } from './utils/event-kind-validatio
 import { mergeExecutionConfig, resolveExecutionAuth } from './utils/execution-context';
 import { insertEvent } from './utils/insert-event';
 import logger from './utils/logger';
+import { getWorkspaceRole } from './utils/organization-access';
 
 function parseEntityIds(raw: unknown): number[] {
   if (Array.isArray(raw)) return raw.map(Number);
@@ -78,6 +79,12 @@ function normalizeAdvertisedCapabilities(capabilities: Record<string, boolean>):
  * The per-(user, connector) advisory lock serializes concurrent polls / multiple
  * devices so they don't race past the existence checks and create duplicates.
  * Best-effort: failures are logged but never surface to the poll response.
+ *
+ * Note: the connection it creates is intentionally left *unpinned*
+ * (`device_worker_id = NULL`). "Unpinned" means "any of this user's fresh
+ * devices that advertise the capability" — exactly the right semantics for a
+ * personal-org auto-wire. An explicit per-device binding is something the user
+ * sets via `manage_connections`; per-device auto-wire is a possible follow-up.
  */
 async function ensureDeviceConnectorWired(
   userId: string,
@@ -331,11 +338,15 @@ async function reconcileDeviceCapabilities(userId: string): Promise<void> {
 
 /**
  * Verify that the request's worker auth scope is allowed to touch this run.
- * Trusted/anonymous workers see everything; user-scoped device workers can only
- * touch a run that (a) belongs to one of the user's orgs, (b) is currently
- * `running`, and (c) — when the caller passes its worker id — was claimed by
- * that same worker. That last check stops one device from streaming/completing
- * another worker's run; (b) stops it from re-touching a pending/finished run.
+ * Trusted/anonymous workers see everything; a user-scoped device worker can
+ * only touch a run that (a) is currently `running`, (b) — when the caller
+ * passes its worker id, always required here — was claimed by that same
+ * `worker_id`, and (c) is in scope for this worker: either in one of the
+ * user's orgs, or whose connection is pinned to a device this user owns.
+ * `worker_id` is client-supplied and only unique per install, so (b) alone is
+ * not a sufficient gate — (c) keeps a worker from heartbeating/completing some
+ * unrelated org's run by guessing a `(run_id, worker_id)` pair. (a) stops
+ * re-touching a pending/finished run.
  *
  * Returns a Hono response on rejection, or null on pass.
  */
@@ -347,19 +358,30 @@ async function authorizeRunForWorker(
   if (c.var.workerAuthMode !== 'user') {
     return null;
   }
+  const workerUserId = c.var.workerUserId;
   const orgIds = c.var.workerOrgIds ?? [];
-  if (orgIds.length === 0) {
-    return c.json({ error: 'Forbidden' }, 403);
-  }
   const sql = getDb();
   const rows = (await sql`
-    SELECT organization_id, status, claimed_by FROM runs WHERE id = ${runId} LIMIT 1
-  `) as unknown as Array<{ organization_id: string; status: string; claimed_by: string | null }>;
+    SELECT r.status, r.claimed_by, r.organization_id, dw.user_id AS device_owner
+    FROM runs r
+    LEFT JOIN connections con ON con.id = r.connection_id
+    LEFT JOIN device_workers dw ON dw.id = con.device_worker_id
+    WHERE r.id = ${runId}
+    LIMIT 1
+  `) as unknown as Array<{
+    status: string;
+    claimed_by: string | null;
+    organization_id: string;
+    device_owner: string | null;
+  }>;
   if (rows.length === 0) {
     return c.json({ error: 'Run not found' }, 404);
   }
   const run = rows[0];
-  if (!orgIds.includes(run.organization_id)) {
+  const inScope =
+    orgIds.includes(run.organization_id) ||
+    (!!workerUserId && run.device_owner === workerUserId);
+  if (!inScope) {
     return c.json({ error: 'Forbidden' }, 403);
   }
   if (run.status !== 'running') {
@@ -424,12 +446,18 @@ export async function pollWorkerJob(c: Context<{ Bindings: Env }>) {
   // Device-worker registry: upsert device_workers row for user-scoped workers
   // so /api/me/devices can enumerate them. Also ensure advertised capability
   // connectors are fully wired. Best-effort — never fail the poll.
+  //
+  // `deviceWorkerId` is this device's surrogate id; a pending run whose
+  // connection is pinned to it (connections.device_worker_id) is claimable
+  // regardless of the connector's required_capability — that's how an
+  // otherwise-cloud connector (Reddit, …) ends up running on a chosen device.
   const workerUserId = c.var.workerUserId;
+  let deviceWorkerId: string | null = null;
   if (workerUserId) {
     try {
       const incomingCaps = advertisedCapabilities;
 
-      await sql`
+      const upserted = (await sql`
         INSERT INTO device_workers (user_id, worker_id, platform, app_version, capabilities, label)
         VALUES (
           ${workerUserId}, ${worker_id}, ${platform}, ${app_version},
@@ -441,7 +469,9 @@ export async function pollWorkerJob(c: Context<{ Bindings: Env }>) {
           capabilities = EXCLUDED.capabilities,
           label = COALESCE(EXCLUDED.label, device_workers.label),
           last_seen_at = now()
-      `;
+        RETURNING id
+      `) as unknown as Array<{ id: string }>;
+      deviceWorkerId = upserted[0]?.id ?? null;
 
       // Reconcile this user's device connectors against the capabilities their
       // whole fleet currently advertises: auto-wire / re-activate the ones that
@@ -480,6 +510,7 @@ export async function pollWorkerJob(c: Context<{ Bindings: Env }>) {
       WITH next_run AS (
         SELECT r.id
         FROM runs r
+        LEFT JOIN connections con ON con.id = r.connection_id
         LEFT JOIN LATERAL (
           SELECT cd.api_type, cd.required_capability
           FROM connector_definitions cd
@@ -497,9 +528,47 @@ export async function pollWorkerJob(c: Context<{ Bindings: Env }>) {
           AND r.run_type IN ('sync', 'action', 'embed_backfill', 'auth')
           AND (r.approval_status = 'auto' OR r.approval_status = 'approved')
           AND (${hasBrowser} OR COALESCE(cd.api_type, 'api') = 'api')
-          AND COALESCE(cd.required_capability, '') = ANY(${pgTextArray(capabilityMatchSet)}::text[])
-          AND (${!isUserScopedWorker} OR cd.required_capability IS NOT NULL)
-          AND (${!orgScopeActive} OR r.organization_id = ANY(${pgTextArray(orgScopeIds)}::text[]))
+          AND (
+            -- (A) trusted/anonymous fleet worker: the no-capability cloud
+            --     connectors plus any capability it happens to advertise, in
+            --     any org — but NEVER a connection pinned to a device.
+            (
+              ${!isUserScopedWorker}
+              AND COALESCE(cd.required_capability, '') = ANY(${pgTextArray(capabilityMatchSet)}::text[])
+              AND con.device_worker_id IS NULL
+            )
+            -- (B) user-scoped device worker: an unpinned capability-matched
+            --     device connector in an org this worker can see ...
+            OR (
+              ${isUserScopedWorker}
+              AND cd.required_capability IS NOT NULL
+              AND cd.required_capability = ANY(${pgTextArray(advertisedCapabilities)}::text[])
+              AND con.device_worker_id IS NULL
+              AND r.organization_id = ANY(${pgTextArray(orgScopeIds)}::text[])
+            )
+            -- ... or any connection explicitly pinned to THIS device (this is
+            --     "run the Reddit connector on my Mac"). Still: a device-only
+            --     connector needs the capability currently advertised, and the
+            --     pin only counts in an org this worker can see or that the
+            --     device owner has granted the device to.
+            OR (
+              ${isUserScopedWorker}
+              AND ${deviceWorkerId}::uuid IS NOT NULL
+              AND con.device_worker_id = ${deviceWorkerId}::uuid
+              AND (
+                cd.required_capability IS NULL
+                OR cd.required_capability = ANY(${pgTextArray(advertisedCapabilities)}::text[])
+              )
+              AND (
+                r.organization_id = ANY(${pgTextArray(orgScopeIds)}::text[])
+                OR EXISTS (
+                  SELECT 1 FROM device_worker_org_grants g
+                  WHERE g.device_worker_id = ${deviceWorkerId}::uuid
+                    AND g.organization_id = r.organization_id
+                )
+              )
+            )
+          )
         ORDER BY
           CASE WHEN r.run_type = 'auth' THEN 0 ELSE 1 END,
           r.created_at ASC
@@ -543,6 +612,7 @@ export async function pollWorkerJob(c: Context<{ Bindings: Env }>) {
         conn.auth_profile_id,
         conn.app_auth_profile_id,
         conn.config AS connection_config,
+        conn.device_worker_id AS connection_device_worker_id,
         cv.compiled_code,
         ap.auth_data AS auth_profile_auth_data
       FROM runs r
@@ -601,6 +671,7 @@ export async function pollWorkerJob(c: Context<{ Bindings: Env }>) {
     auth_profile_id: number | null;
     app_auth_profile_id: number | null;
     connection_config: Record<string, unknown> | null;
+    connection_device_worker_id: string | null;
     compiled_code: string | null;
     // Watcher run fields (populated via LEFT JOINs)
     watcher_id: number | null;
@@ -632,28 +703,31 @@ export async function pollWorkerJob(c: Context<{ Bindings: Env }>) {
     }
   }
 
-  // User-scoped device workers (Lobu for Mac etc.) only ever run no-auth bundled
-  // connectors gated by `required_capability`. Never hand a user OAuth/PAT
-  // client real connection credentials or auth-profile state — strip them
-  // unconditionally, so a connector that's misconfigured with both a
-  // `required_capability` and an auth profile can't leak secrets to a device.
-  // (`isUserScopedWorker` is computed above for the capability-match set.)
-  const { credentials, connectionCredentials, sessionState } =
-    !isUserScopedWorker && row.connection_id
-      ? await resolveExecutionAuth({
-          organizationId: row.organization_id,
-          connectionId: row.connection_id,
-          authProfileId: row.auth_profile_id,
-          appAuthProfileId: row.app_auth_profile_id,
-          credentialDb: sql,
-          logContext: { run_id: row.run_id },
-          logMessage: 'Failed to resolve connection credentials for worker poll',
-        })
-      : {
-          credentials: null,
-          connectionCredentials: {},
-          sessionState: null,
-        };
+  // Credential delivery:
+  //  - trusted/anonymous fleet workers always resolve connection credentials;
+  //  - a user-scoped device worker only gets real credentials when the run's
+  //    connection is *explicitly pinned to a device* (connections.device_worker_id),
+  //    which was authorized at bind time. A device connector reached via the
+  //    capability match (no pin) is no-auth by construction, so it gets nothing —
+  //    a connector misconfigured with both a `required_capability` and an auth
+  //    profile still can't leak secrets to an arbitrary capability-matched device.
+  const connectionIsDevicePinned = row.connection_device_worker_id != null;
+  const deliverConnectionAuth = !!row.connection_id && (!isUserScopedWorker || connectionIsDevicePinned);
+  const { credentials, connectionCredentials, sessionState } = deliverConnectionAuth
+    ? await resolveExecutionAuth({
+        organizationId: row.organization_id,
+        connectionId: row.connection_id!,
+        authProfileId: row.auth_profile_id,
+        appAuthProfileId: row.app_auth_profile_id,
+        credentialDb: sql,
+        logContext: { run_id: row.run_id },
+        logMessage: 'Failed to resolve connection credentials for worker poll',
+      })
+    : {
+        credentials: null,
+        connectionCredentials: {},
+        sessionState: null,
+      };
 
   return c.json({
     run_id: row.run_id,
@@ -673,8 +747,8 @@ export async function pollWorkerJob(c: Context<{ Bindings: Env }>) {
     session_state: sessionState ?? undefined,
     action_key: row.action_key ?? undefined,
     action_input: (row as any).approved_input ?? row.action_input ?? undefined,
-    auth_profile_id: isUserScopedWorker ? undefined : (row.run_auth_profile_id ?? undefined),
-    previous_credentials: isUserScopedWorker ? undefined : (row.auth_profile_auth_data ?? undefined),
+    auth_profile_id: deliverConnectionAuth ? (row.run_auth_profile_id ?? undefined) : undefined,
+    previous_credentials: deliverConnectionAuth ? (row.auth_profile_auth_data ?? undefined) : undefined,
   });
 }
 
@@ -1662,7 +1736,9 @@ export async function completeActionRun(c: Context<{ Bindings: Env }>) {
 /**
  * GET /api/me/devices
  *
- * Returns the calling user's registered device workers.
+ * Returns the calling user's registered device workers, each with its surrogate
+ * id (used as `device_worker_id` when pinning a connection), the orgs the user
+ * has granted it to, and how many connections are pinned to it.
  * Requires session / PAT / OAuth authentication (mcpAuth).
  */
 export async function listDeviceWorkers(c: Context<{ Bindings: Env }>) {
@@ -1674,17 +1750,24 @@ export async function listDeviceWorkers(c: Context<{ Bindings: Env }>) {
     const sql = getDb();
     const rows = (await sql`
       SELECT
-        worker_id,
-        platform,
-        app_version,
-        capabilities,
-        label,
-        last_seen_at,
-        (last_seen_at > now() - interval '20 minutes') AS online
-      FROM device_workers
-      WHERE user_id = ${userId}
-      ORDER BY last_seen_at DESC
+        dw.id,
+        dw.worker_id,
+        dw.platform,
+        dw.app_version,
+        dw.capabilities,
+        dw.label,
+        dw.last_seen_at,
+        (dw.last_seen_at > now() - interval '20 minutes') AS online,
+        COALESCE(
+          (SELECT array_agg(g.organization_id) FROM device_worker_org_grants g WHERE g.device_worker_id = dw.id),
+          ARRAY[]::text[]
+        ) AS granted_org_ids,
+        (SELECT count(*) FROM connections cn WHERE cn.device_worker_id = dw.id AND cn.deleted_at IS NULL)::int AS connector_count
+      FROM device_workers dw
+      WHERE dw.user_id = ${userId}
+      ORDER BY dw.last_seen_at DESC
     `) as unknown as Array<{
+      id: string;
       worker_id: string;
       platform: string | null;
       app_version: string | null;
@@ -1692,9 +1775,12 @@ export async function listDeviceWorkers(c: Context<{ Bindings: Env }>) {
       label: string | null;
       last_seen_at: string;
       online: boolean;
+      granted_org_ids: string[];
+      connector_count: number;
     }>;
     return c.json({
       devices: rows.map((r) => ({
+        id: r.id,
         worker_id: r.worker_id,
         platform: r.platform,
         app_version: r.app_version,
@@ -1702,10 +1788,89 @@ export async function listDeviceWorkers(c: Context<{ Bindings: Env }>) {
         label: r.label,
         last_seen_at: r.last_seen_at,
         online: r.online,
+        granted_org_ids: Array.isArray(r.granted_org_ids) ? r.granted_org_ids : [],
+        connector_count: r.connector_count ?? 0,
       })),
     });
   } catch (err: unknown) {
     logger.error({ error: errorMessage(err) }, '[listDeviceWorkers] Error');
+    return c.json({ error: errorMessage(err) }, 500);
+  }
+}
+
+/**
+ * POST /api/me/device-grants  { device_worker_id, organization_id }
+ * DELETE /api/me/device-grants { device_worker_id, organization_id }
+ *
+ * Lets a device owner allow (or stop allowing) one of their devices to back
+ * connectors in an org they're a member of. Org-sharing is always explicit.
+ */
+export async function setDeviceOrgGrant(c: Context<{ Bindings: Env }>, grant: boolean) {
+  const userId = c.var.user?.id;
+  if (!userId) {
+    return c.json({ error: 'Unauthorized' }, 401);
+  }
+  let deviceWorkerId: string;
+  let organizationId: string;
+  try {
+    const body = await c.req.json<{ device_worker_id?: string; organization_id?: string }>();
+    deviceWorkerId = (body.device_worker_id ?? '').trim();
+    organizationId = (body.organization_id ?? '').trim();
+    if (!deviceWorkerId || !organizationId) {
+      return c.json({ error: 'device_worker_id and organization_id are required' }, 400);
+    }
+  } catch {
+    return c.json({ error: 'Invalid or missing JSON body' }, 400);
+  }
+  try {
+    const sql = getDb();
+    const owned = (await sql`
+      SELECT 1 FROM device_workers WHERE id = ${deviceWorkerId} AND user_id = ${userId} LIMIT 1
+    `) as unknown as Array<unknown>;
+    if (owned.length === 0) {
+      return c.json({ error: 'Device not found or not owned by you' }, 404);
+    }
+    const role = await getWorkspaceRole(sql, organizationId, userId);
+    if (!role) {
+      return c.json({ error: 'You are not a member of that organization' }, 403);
+    }
+    if (grant) {
+      await sql`
+        INSERT INTO device_worker_org_grants (device_worker_id, organization_id, granted_by)
+        VALUES (${deviceWorkerId}, ${organizationId}, ${userId})
+        ON CONFLICT (device_worker_id, organization_id) DO NOTHING
+      `;
+    } else {
+      await sql.begin(async (tx) => {
+        await tx`
+          DELETE FROM device_worker_org_grants
+          WHERE device_worker_id = ${deviceWorkerId} AND organization_id = ${organizationId}
+        `;
+        // Un-pin and pause connections in that org that were backed by this
+        // device — they can't run anywhere now; the owner re-pins (or
+        // re-grants) to bring them back. Personal-org auto-wired connections
+        // are unpinned and unaffected.
+        const affected = (await tx`
+          UPDATE connections
+          SET device_worker_id = NULL,
+              status = 'paused',
+              error_message = 'Device access to this organization was revoked',
+              updated_at = NOW()
+          WHERE device_worker_id = ${deviceWorkerId} AND organization_id = ${organizationId}
+          RETURNING id
+        `) as unknown as Array<{ id: number }>;
+        const ids = affected.map((r) => r.id);
+        if (ids.length > 0) {
+          await tx`
+            UPDATE feeds SET status = 'paused', updated_at = NOW()
+            WHERE connection_id = ANY(${ids}::bigint[]) AND deleted_at IS NULL AND status = 'active'
+          `;
+        }
+      });
+    }
+    return c.json({ ok: true });
+  } catch (err: unknown) {
+    logger.error({ error: errorMessage(err) }, '[setDeviceOrgGrant] Error');
     return c.json({ error: errorMessage(err) }, 500);
   }
 }

--- a/packages/server/src/workspace/multi-tenant.ts
+++ b/packages/server/src/workspace/multi-tenant.ts
@@ -30,8 +30,13 @@ const sessionCache = new TtlCache<{ user: any; session: any } | null>(30_000); /
  * these resolve to "authenticated user, no active org" instead of failing on
  * a missing orgSlug. The bare `/mcp` endpoint is handled separately because
  * it's an exact-match, not a prefix.
+ *
+ * `/api/workers/` is here because device workers (Lobu for Mac/iPhone) poll
+ * those endpoints with a user token that may not be bound to any org — the
+ * `/api/workers/*` middleware in index.ts does the per-endpoint authz and
+ * falls back to the user's personal org.
  */
-const UNSCOPED_PATH_PREFIXES = ['/mcp/', '/api/me/'];
+const UNSCOPED_PATH_PREFIXES = ['/mcp/', '/api/me/', '/api/workers/'];
 
 export function invalidateMembershipRoleCache(
   organizationId: string,


### PR DESCRIPTION
## What

Adds `connections.device_worker_id` so a connection's syncs/actions can run on a **specific device worker** (Lobu for Mac/iPhone) instead of the cloud `connector-worker` pool.

- **Mandatory** for device-only connectors (`connector_definitions.required_capability`, e.g. Apple Health / Screen Time / local directory).
- **Optional override** for any other connector — "run the Reddit connector on my Mac".
- The cloud pool is the default whenever a connection isn't pinned.

Closes the "run a connector on a chosen device" + "back a connector with a member's device in a shared org" gaps. Cloud-worker autoscaling / "org default device" stays out of scope (lobu-ai/lobu#615).

## Changes

**Migration** (`20260512000000_device_worker_connection_binding.sql`)
- `device_workers.id` surrogate `uuid` (keeps the `(user_id, worker_id)` PK).
- `connections.device_worker_id uuid` FK → `device_workers(id)` `ON DELETE SET NULL`.
- `device_worker_org_grants` — a device owner explicitly allows a device to back connectors in a non-personal org.
- Unique partial index `(organization_id, connector_key, device_worker_id) WHERE deleted_at IS NULL` (cardinality + create/auto-wire idempotency); created **after** a single-device backfill of existing auto-wired device connections so it can't be violated.

**Run dispatch** (`worker-api.ts`)
- Poll resolves the caller's `device_workers.id` (via `RETURNING id` on the device upsert).
- Claim query: a user-scoped device worker claims (a) unpinned capability-matched device connectors in its org scope, **or** (b) *any* connection pinned to this device — gated by current-capability (for `required_capability` connectors) and org/grant scope. The trusted cloud worker now excludes device-pinned connections (`device_worker_id IS NULL`) so it never races a device.
- Credentials: a user-scoped worker gets real connection credentials when the run's connection is device-pinned (authorized at bind time); capability-matched (unpinned) device connectors are no-auth and still get nothing.
- `authorizeRunForWorker` re-checks org/owner scope in addition to `claimed_by` — `worker_id` is client-supplied and only unique per install, so the `claimed_by` match alone isn't a sufficient gate.

**Connection management** (`manage_connections.ts`)
- `device_worker_id` on `create` and `update`, validated: device exists, requester owns it or it's granted to the org, and (for device-type connectors) the device currently advertises the capability; `device_worker_id` is required for `required_capability` connectors.
- Pre-check rejects a duplicate "connector already assigned to that device in this org" with a friendly error (the unique index is the backstop).
- `list` / `get` surface `device_label`, `device_platform`, `device_online`, `device_worker_handle`.

**Endpoints**
- `GET /api/me/devices` extended with `id`, `granted_org_ids`, `connector_count`.
- `POST` / `DELETE /api/me/device-grants` `{ device_worker_id, organization_id }` — device owner only, must be an org member. Revoking a grant un-pins and pauses that org's affected connections (`error_message = 'Device access to this organization was revoked'`).

**Docs** — `docs/SECURITY.md`: device-pinned connectors run with the user's connection credentials on the user's device and use the device's network (the gateway's allowlist/blocklist/egress-judge govern locally-spawned workers, not a remote device); binding is authorized at bind time and revoking a grant un-pins.

## Review

Reviewed with `pi` (default model); applied its findings — restored worker scope checks in `authorizeRunForWorker`, added capability + org/grant predicates to the pinned-claim branch, reordered the migration so the unique index follows the dedup'd backfill, and made grant-revoke un-pin + pause affected connections.

## Not in this PR (follow-ups)

- **Web UI** (in the `owletto-web` submodule, separate repo): a "Run on" picker in the connection sheet (required for device-type, "Cloud (default)" + your/granted devices otherwise), bound-device on the connector detail page, connector-count column on the Devices page.
- **Per-device auto-wire**: `ensureDeviceConnectorWired()` still creates *unpinned* personal-org connections by design ("any of my devices with the permission"); making auto-wire pin per-device is a possible follow-up.
- **Atomicity polish**: `resolveDeviceBinding` validates before the write (tiny TOCTOU window, low severity); `handleUpdate` does the main update and the `device_worker_id` update as two statements.
- **Membership-leave reconcile**: device-grant cleanup currently triggers on explicit revoke and device deletion (FK cascade), not on a member being removed from an org.
- The `connect` action (OAuth-combined flow) doesn't take `device_worker_id` yet — device-type connectors are no-auth so they use `create`; cloud-on-device can also use `create`.

## Verification done

- `make build-packages` green.
- Migration SQL reviewed (not applied — `DATABASE_URL` here points at prod).
- Dispatch / authz logic walked through against the scenarios in the plan; runtime exercise of the poll/claim path and a scratch-DB migration apply still to do.