### PR TITLE
feat(cli): sync data-source connectors in lobu apply

### DIFF
--- a/examples/lobu-crm/connectors/changelog-watch.yaml
+++ b/examples/lobu-crm/connectors/changelog-watch.yaml
@@ -1,0 +1,25 @@
+# Competitor & own changelog watcher.
+# Connector definition: packages/connectors/src/website.ts (no auth).
+---
+version: 1
+type: connection
+slug: competitor-changelogs
+connector: website
+name: Competitor changelogs
+config:
+  urls:
+    - https://lobu.ai/changelog
+    - https://docs.dust.tt/changelog
+    - https://www.glean.com/release-notes
+  max_pages: 10
+feeds:
+  - feed: pages
+    name: Changelog pages
+    schedule: "0 7 * * *"
+    config:
+      urls:
+        - https://lobu.ai/changelog
+        - https://docs.dust.tt/changelog
+        - https://www.glean.com/release-notes
+      max_pages: 10
+      parse_sections: false

--- a/examples/lobu-crm/connectors/funnel-form.connector.ts
+++ b/examples/lobu-crm/connectors/funnel-form.connector.ts
@@ -1,0 +1,179 @@
+/**
+ * Funnel-form connector — pulls demo-request form submissions from a small
+ * JSON API (`config.endpoint` returns `{ submissions: [...] }`) and emits one
+ * event per new submission. Modeled on packages/connectors/src/rss.ts.
+ *
+ * No auth (`authSchema: { methods: [{ type: 'none' }] }`); a single
+ * `submissions` feed; dedup via a checkpoint of seen submission IDs.
+ *
+ * Auto-discovered by `lobu apply` because the filename ends in
+ * `.connector.ts` — the CLI ships the raw source to the server, which
+ * compiles it and reads `definition.key` (`funnel-form`).
+ */
+
+import {
+  type ActionContext,
+  type ActionResult,
+  type ConnectorDefinition,
+  ConnectorRuntime,
+  type EventEnvelope,
+  type SyncContext,
+  type SyncResult,
+} from "@lobu/connector-sdk";
+
+interface FunnelFormConfig {
+  endpoint: string;
+}
+
+interface FunnelFormCheckpoint {
+  seen_ids: string[];
+}
+
+interface FunnelSubmission {
+  id: string;
+  name?: string;
+  email?: string;
+  company?: string;
+  message?: string;
+  submitted_at?: string;
+  source_url?: string;
+}
+
+const MAX_DEDUP_IDS = 1000;
+const FETCH_TIMEOUT_MS = 15_000;
+
+export default class FunnelFormConnector extends ConnectorRuntime {
+  readonly definition: ConnectorDefinition = {
+    key: "funnel-form",
+    name: "Funnel form",
+    description:
+      "Collects demo-request form submissions from a JSON API endpoint.",
+    version: "1.0.0",
+    authSchema: { methods: [{ type: "none" }] },
+    feeds: {
+      submissions: {
+        key: "submissions",
+        name: "Form submissions",
+        description: "New submissions to the demo-request form.",
+        configSchema: {
+          type: "object",
+          required: ["endpoint"],
+          properties: {
+            endpoint: {
+              type: "string",
+              format: "uri",
+              description:
+                "JSON API URL returning { submissions: [{ id, name, email, company, message, submitted_at }] }.",
+            },
+          },
+        },
+        eventKinds: {
+          form_submission: {
+            description: "A demo-request form submission.",
+            metadataSchema: {
+              type: "object",
+              properties: {
+                company: { type: "string" },
+                email: { type: "string" },
+              },
+            },
+          },
+        },
+      },
+    },
+    optionsSchema: {
+      type: "object",
+      required: ["endpoint"],
+      properties: {
+        endpoint: {
+          type: "string",
+          format: "uri",
+          description: "JSON API URL returning { submissions: [...] }.",
+        },
+      },
+    },
+  };
+
+  async sync(ctx: SyncContext): Promise<SyncResult> {
+    const config = ctx.config as unknown as FunnelFormConfig;
+    if (!config?.endpoint) {
+      throw new Error("funnel-form: `endpoint` is required");
+    }
+
+    const checkpoint = (ctx.checkpoint as FunnelFormCheckpoint | null) ?? {
+      seen_ids: [],
+    };
+    const seen = new Set<string>(checkpoint.seen_ids ?? []);
+
+    const submissions = await this.fetchSubmissions(config.endpoint);
+    submissions.sort(
+      (a, b) =>
+        this.toTime(b.submitted_at).getTime() -
+        this.toTime(a.submitted_at).getTime()
+    );
+
+    const events: EventEnvelope[] = [];
+    const newIds: string[] = [];
+    for (const submission of submissions) {
+      if (!submission?.id || seen.has(submission.id)) continue;
+      seen.add(submission.id);
+      newIds.push(submission.id);
+      events.push({
+        origin_id: submission.id,
+        origin_type: "form_submission",
+        title: submission.company
+          ? `Demo request — ${submission.company}`
+          : `Demo request — ${submission.name ?? submission.email ?? submission.id}`,
+        payload_text: submission.message ?? "",
+        author_name: submission.name || undefined,
+        source_url: submission.source_url || config.endpoint,
+        occurred_at: this.toTime(submission.submitted_at),
+        metadata: {
+          company: submission.company,
+          email: submission.email,
+        },
+      });
+    }
+
+    const allKnown = [...(checkpoint.seen_ids ?? []), ...newIds];
+    const trimmed = allKnown.slice(-MAX_DEDUP_IDS);
+
+    return {
+      events,
+      checkpoint: { seen_ids: trimmed } as unknown as Record<string, unknown>,
+      metadata: { items_found: events.length },
+    };
+  }
+
+  async execute(_ctx: ActionContext): Promise<ActionResult> {
+    return { success: false, error: "Actions not supported" };
+  }
+
+  private async fetchSubmissions(
+    endpoint: string
+  ): Promise<FunnelSubmission[]> {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+    try {
+      const response = await fetch(endpoint, {
+        signal: controller.signal,
+        headers: { Accept: "application/json" },
+      });
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+      }
+      const body = (await response.json()) as {
+        submissions?: FunnelSubmission[];
+      };
+      return Array.isArray(body?.submissions) ? body.submissions : [];
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+
+  private toTime(value: string | undefined): Date {
+    if (!value) return new Date();
+    const parsed = new Date(value);
+    return Number.isNaN(parsed.getTime()) ? new Date() : parsed;
+  }
+}

--- a/examples/lobu-crm/connectors/funnel-form.yaml
+++ b/examples/lobu-crm/connectors/funnel-form.yaml
@@ -1,0 +1,15 @@
+# Demo-request form submissions — backed by the custom funnel-form.connector.ts.
+---
+version: 1
+type: connection
+slug: funnel-form-submissions
+connector: funnel-form
+name: Demo-request form submissions
+config:
+  endpoint: "https://lobu.ai/api/demo-requests"
+feeds:
+  - feed: submissions
+    name: Form submissions
+    schedule: "*/15 * * * *"
+    config:
+      endpoint: "https://lobu.ai/api/demo-requests"

--- a/examples/lobu-crm/connectors/github.yaml
+++ b/examples/lobu-crm/connectors/github.yaml
@@ -1,0 +1,64 @@
+# GitHub — funnel signals from lobu-ai/lobu (stars, issues, PRs, comments).
+# Connector definition: packages/connectors/src/github.ts
+#
+# Two auth profiles: an `oauth_app` (the registered GitHub OAuth App's client
+# credentials, from env) referenced via `app_auth:`, and an `oauth_account`
+# (the actual access token) referenced via `auth:`. The account profile has no
+# credentials here — `lobu apply` never writes OAuth tokens; finish the OAuth
+# flow via the connect URL printed after apply (or in the dashboard).
+---
+version: 1
+type: auth_profile
+slug: github-app
+connector: github
+kind: oauth_app
+name: GitHub OAuth App
+credentials:
+  GITHUB_CLIENT_ID: $GITHUB_CLIENT_ID
+  GITHUB_CLIENT_SECRET: $GITHUB_CLIENT_SECRET
+---
+version: 1
+type: auth_profile
+slug: github-account
+connector: github
+kind: oauth_account
+name: GitHub — lobu-ai
+---
+version: 1
+type: connection
+slug: github-lobu
+connector: github
+name: GitHub — lobu-ai/lobu
+auth: github-account
+app_auth: github-app
+config:
+  repo_owner: lobu-ai
+  repo_name: lobu
+feeds:
+  - feed: stargazers
+    name: Stars — lobu-ai/lobu
+    schedule: "0 */6 * * *"
+    config:
+      repo_owner: lobu-ai
+      repo_name: lobu
+  - feed: issues
+    name: Issues — lobu-ai/lobu
+    schedule: "15 */6 * * *"
+    config:
+      repo_owner: lobu-ai
+      repo_name: lobu
+      lookback_days: 90
+  - feed: issue_comments
+    name: Issue comments — lobu-ai/lobu
+    schedule: "30 */6 * * *"
+    config:
+      repo_owner: lobu-ai
+      repo_name: lobu
+      lookback_days: 90
+  - feed: pr_comments
+    name: PR comments — lobu-ai/lobu
+    schedule: "45 */6 * * *"
+    config:
+      repo_owner: lobu-ai
+      repo_name: lobu
+      lookback_days: 90

--- a/examples/lobu-crm/connectors/hackernews.yaml
+++ b/examples/lobu-crm/connectors/hackernews.yaml
@@ -1,0 +1,18 @@
+# Hacker News — mentions of "lobu" / "openclaw".
+# Connector definition: packages/connectors/src/hackernews.ts (no auth).
+---
+version: 1
+type: connection
+slug: hn-lobu
+connector: hackernews
+name: Hacker News — lobu / openclaw
+config:
+  search_query: lobu OR openclaw
+  lookback_days: 180
+feeds:
+  - feed: stories
+    name: HN stories — lobu / openclaw
+    schedule: "0 */4 * * *"
+    config:
+      search_query: lobu OR openclaw
+      lookback_days: 180

--- a/examples/lobu-crm/connectors/x.yaml
+++ b/examples/lobu-crm/connectors/x.yaml
@@ -1,0 +1,31 @@
+# X — @lobu mentions & replies.
+# Connector definition: packages/connectors/src/x.ts
+---
+version: 1
+type: auth_profile
+slug: x-account
+connector: x
+kind: oauth_account
+name: X — @lobu
+# No credentials here on purpose: `lobu apply` never writes OAuth tokens.
+# After `lobu apply`, finish the OAuth flow via the connect URL it prints
+# (or in the dashboard) to make this profile `active`.
+---
+version: 1
+type: connection
+slug: x-mentions
+connector: x
+name: X — @lobu mentions & replies
+auth: x-account
+config:
+  search_query: "@lobu OR lobu.ai"
+  search_filter: live
+  max_scrolls: 10
+feeds:
+  - feed: tweets
+    name: X mentions — @lobu
+    schedule: "0 */3 * * *"
+    config:
+      search_query: "@lobu OR lobu.ai"
+      search_filter: live
+      max_scrolls: 10

--- a/examples/lobu-crm/lobu.toml
+++ b/examples/lobu-crm/lobu.toml
@@ -28,6 +28,8 @@ allowed = [
   "api.producthunt.com",
   "api.z.ai", ".z.ai",
   "lobu.ai",
+  # Competitor changelog pages scraped by the `website` connector
+  ".dust.tt", ".glean.com",
 ]
 
 [memory]
@@ -37,3 +39,7 @@ name = "Lobu CRM"
 description = "Funnel CRM for Lobu — leads, pilots, conversations, launch signals"
 models = "./models"
 data = "./data"
+# Data-source connectors (`*.connector.ts` + `type: connection|auth_profile|connector`
+# manifests). Synced by `lobu apply`; interactive-auth profiles (oauth_account)
+# are finished in the dashboard.
+connectors = "./connectors"

--- a/packages/cli/src/commands/_lib/apply/__tests__/__snapshots__/diff.test.ts.snap
+++ b/packages/cli/src/commands/_lib/apply/__tests__/__snapshots__/diff.test.ts.snap
@@ -109,3 +109,24 @@ Summary: 2 create, 0 update, 0 noop, 0 drift"
 `;
 
 exports[`renderSummary renders zero-row plan 1`] = `"Summary: 0 create, 0 update, 0 noop, 0 drift"`;
+
+exports[`apply diff — connectors render includes the connectors sections 1`] = `
+"
+Plan:
+
+  connector-definitions:
+  + connector-definition acme (from connectors/acme.connector.ts)
+
+  auth-profiles:
+  + auth-profile hn-token
+  + auth-profile x-account
+      ⚠ interactive auth — complete it via the connect URL printed after apply
+
+  connections:
+  + connection hn-frontpage
+
+  feeds:
+  + feed hn-frontpage/stories
+
+Summary: 5 create, 0 update, 0 noop, 0 drift"
+`;

--- a/packages/cli/src/commands/_lib/apply/__tests__/apply-cmd.test.ts
+++ b/packages/cli/src/commands/_lib/apply/__tests__/apply-cmd.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, test } from "bun:test";
+import {
+  locallyDeclaredConnectorKeys,
+  readBoundedBody,
+  validateConnectorState,
+} from "../apply-cmd.js";
+import type { RemoteConnectorDefinition } from "../client.js";
+import type { DesiredState } from "../desired-state.js";
+
+// Minimal DesiredState with just the connectors slice populated.
+function stateWith(connectors: DesiredState["connectors"]): DesiredState {
+  return {
+    agents: [],
+    memorySchema: { entityTypes: [], relationshipTypes: [] },
+    watchers: [],
+    connectors,
+    requiredSecrets: [],
+  };
+}
+
+function makeResponse(body: string): Response {
+  // Use the real Web Response so it exposes a streaming `body`.
+  return new Response(body, { headers: { "content-type": "text/plain" } });
+}
+
+describe("readBoundedBody (#3 — bounded source_url fetch)", () => {
+  test("reads a small body in full", async () => {
+    const text = await readBoundedBody(
+      makeResponse("hello world"),
+      1024,
+      () => {
+        throw new Error("should not overflow");
+      }
+    );
+    expect(text).toBe("hello world");
+  });
+
+  test("aborts + throws as soon as the running byte total exceeds the cap", async () => {
+    // 4 KiB body, 1 KiB cap.
+    const big = "x".repeat(4096);
+    let overflowed = false;
+    await expect(
+      readBoundedBody(makeResponse(big), 1024, () => {
+        overflowed = true;
+        throw new Error("body exceeds the 1024-byte cap");
+      })
+    ).rejects.toThrow(/exceeds the 1024-byte cap/);
+    expect(overflowed).toBe(true);
+  });
+
+  test("counts BYTES, not UTF-16 code units (multi-byte chars)", async () => {
+    // 200 "€" chars = 600 UTF-8 bytes but only 200 UTF-16 code units.
+    const euros = "€".repeat(200);
+    await expect(
+      readBoundedBody(makeResponse(euros), 400, () => {
+        throw new Error("body exceeds the 400-byte cap");
+      })
+    ).rejects.toThrow(/exceeds the 400-byte cap/);
+    // Same content fits under a 1 KiB cap.
+    const ok = await readBoundedBody(makeResponse(euros), 1024, () => {
+      throw new Error("should not overflow");
+    });
+    expect(ok).toBe(euros);
+  });
+});
+
+describe("validateConnectorState — skip stale schema for locally-declared keys (#2)", () => {
+  const localDef = {
+    key: "myconn",
+    sourcePath: "/proj/connectors/myconn.connector.ts",
+    sourceCode: "export default class {}",
+    sourceFile: "connectors/myconn.connector.ts",
+  };
+  const connectors: DesiredState["connectors"] = {
+    definitions: [localDef],
+    authProfiles: [],
+    connections: [
+      {
+        slug: "c1",
+        connector: "myconn",
+        // valid only against the *new* schema (string `mode`); the stale remote
+        // schema below requires `mode` to be a number.
+        config: { mode: "fast" },
+        feeds: [],
+        sourceFile: "connectors/myconn.yaml",
+      },
+    ],
+  };
+  // The "stale" installed catalog: `myconn` exists with an old optionsSchema
+  // that would reject `{ mode: "fast" }`.
+  const staleCatalog: RemoteConnectorDefinition[] = [
+    {
+      key: "myconn",
+      installed: true,
+      installable: false,
+      options_schema: {
+        type: "object",
+        properties: { mode: { type: "number" } },
+        required: ["mode"],
+        additionalProperties: false,
+      },
+    },
+  ];
+
+  test("does NOT validate config against the stale schema when the key is locally declared", () => {
+    expect(() =>
+      validateConnectorState(
+        stateWith(connectors),
+        staleCatalog,
+        locallyDeclaredConnectorKeys(stateWith(connectors))
+      )
+    ).not.toThrow();
+  });
+
+  test("WOULD reject the config if the key were not locally declared (sanity check)", () => {
+    expect(() =>
+      validateConnectorState(stateWith(connectors), staleCatalog)
+    ).toThrow(/connection "c1" config/);
+  });
+
+  test("structural checks still run for locally-declared connectors (bad auth-profile ref)", () => {
+    const bad: DesiredState["connectors"] = {
+      definitions: [localDef],
+      authProfiles: [],
+      connections: [
+        {
+          slug: "c2",
+          connector: "myconn",
+          authProfileSlug: "nope", // not declared anywhere
+          feeds: [],
+          sourceFile: "connectors/myconn.yaml",
+        },
+      ],
+    };
+    expect(() =>
+      validateConnectorState(
+        stateWith(bad),
+        staleCatalog,
+        locallyDeclaredConnectorKeys(stateWith(bad))
+      )
+    ).toThrow(/references auth profile "nope"/);
+  });
+});

--- a/packages/cli/src/commands/_lib/apply/__tests__/apply-cmd.test.ts
+++ b/packages/cli/src/commands/_lib/apply/__tests__/apply-cmd.test.ts
@@ -104,11 +104,11 @@ describe("validateConnectorState — skip stale schema for locally-declared keys
 
   test("does NOT validate config against the stale schema when the key is locally declared", () => {
     expect(() =>
-      validateConnectorState(
-        stateWith(connectors),
-        staleCatalog,
-        locallyDeclaredConnectorKeys(stateWith(connectors))
-      )
+      validateConnectorState(stateWith(connectors), staleCatalog, {
+        skipSchemaForConnectorKeys: locallyDeclaredConnectorKeys(
+          stateWith(connectors)
+        ),
+      })
     ).not.toThrow();
   });
 
@@ -133,11 +133,97 @@ describe("validateConnectorState — skip stale schema for locally-declared keys
       ],
     };
     expect(() =>
-      validateConnectorState(
-        stateWith(bad),
-        staleCatalog,
-        locallyDeclaredConnectorKeys(stateWith(bad))
-      )
+      validateConnectorState(stateWith(bad), staleCatalog, {
+        skipSchemaForConnectorKeys: locallyDeclaredConnectorKeys(
+          stateWith(bad)
+        ),
+      })
     ).toThrow(/references auth profile "nope"/);
+  });
+
+  test("requireInstalled: errors when a referenced connector is not in the fresh catalog", () => {
+    const connectors: DesiredState["connectors"] = {
+      definitions: [],
+      authProfiles: [],
+      connections: [
+        {
+          slug: "c-typo",
+          connector: "doesnt-exist",
+          feeds: [],
+          sourceFile: "connectors/x.yaml",
+        },
+      ],
+    };
+    expect(() =>
+      validateConnectorState(stateWith(connectors), [], {
+        requireInstalled: true,
+      })
+    ).toThrow(
+      /connector "doesnt-exist" referenced by connection "c-typo" is not installed/
+    );
+  });
+
+  test("requireInstalled: errors when a referenced connector is present but not installed", () => {
+    const connectors: DesiredState["connectors"] = {
+      definitions: [],
+      authProfiles: [],
+      connections: [
+        {
+          slug: "c1",
+          connector: "catalog-only",
+          feeds: [],
+          sourceFile: "connectors/x.yaml",
+        },
+      ],
+    };
+    // present in the catalog but installable-not-installed (e.g. a bundled
+    // connector that was never installed for the org).
+    expect(() =>
+      validateConnectorState(
+        stateWith(connectors),
+        [{ key: "catalog-only", installed: false, installable: true }],
+        { requireInstalled: true }
+      )
+    ).toThrow(
+      /connector "catalog-only" referenced by connection "c1" is not installed/
+    );
+  });
+
+  test("requireInstalled: passes when the referenced connector is installed", () => {
+    const connectors: DesiredState["connectors"] = {
+      definitions: [],
+      authProfiles: [
+        {
+          slug: "ap",
+          connector: "myconn",
+          kind: "env",
+          credentials: { K: "v" },
+          sourceFile: "connectors/x.yaml",
+        },
+      ],
+      connections: [
+        {
+          slug: "c1",
+          connector: "myconn",
+          authProfileSlug: "ap",
+          feeds: [],
+          sourceFile: "connectors/x.yaml",
+        },
+      ],
+    };
+    expect(() =>
+      validateConnectorState(
+        stateWith(connectors),
+        [
+          {
+            key: "myconn",
+            installed: true,
+            installable: false,
+            auth_schema: { methods: [{ type: "env_keys" }] },
+          },
+        ],
+        { requireInstalled: true }
+      )
+    ).not.toThrow();
   });
 });

--- a/packages/cli/src/commands/_lib/apply/__tests__/desired-state.test.ts
+++ b/packages/cli/src/commands/_lib/apply/__tests__/desired-state.test.ts
@@ -416,4 +416,93 @@ source_url: https://example.com/acme.ts
       )
     ).toThrow(/connection "bad" config/);
   });
+
+  // ── round-2 ──────────────────────────────────────────────────────────────
+
+  test("rejects a non-canonical connection slug", async () => {
+    const dir = mkConnectorsProject({
+      "x.yaml": `version: 1
+type: connection
+slug: My_Connection
+connector: hackernews
+`,
+    });
+    await expect(loadDesiredState({ cwd: dir, env: {} })).rejects.toThrow(
+      /connection slug "My_Connection" must match/
+    );
+  });
+
+  test("rejects an invalid feed cron schedule", async () => {
+    const dir = mkConnectorsProject({
+      "x.yaml": `version: 1
+type: connection
+slug: hn
+connector: hackernews
+feeds:
+  - feed: stories
+    schedule: "not a cron"
+`,
+    });
+    await expect(loadDesiredState({ cwd: dir, env: {} })).rejects.toThrow(
+      /invalid cron expression/
+    );
+  });
+
+  test("rejects duplicate connector keys across definitions", async () => {
+    const dir = mkConnectorsProject({
+      "a.yaml": `version: 1
+type: connector
+key: dup
+source_url: https://example.com/a.ts
+---
+version: 1
+type: connector
+key: dup
+source_url: https://example.com/b.ts
+`,
+    });
+    await expect(loadDesiredState({ cwd: dir, env: {} })).rejects.toThrow(
+      /duplicate connector key "dup"|connector key "dup" is declared by more than one/
+    );
+  });
+
+  test("rejects duplicate connector keys across separate files", async () => {
+    const dir = mkConnectorsProject({
+      "a.yaml": `version: 1
+type: connector
+key: dup2
+source_url: https://example.com/a.ts
+`,
+      "b.yaml": `version: 1
+type: connector
+key: dup2
+source_url: https://example.com/b.ts
+`,
+    });
+    await expect(loadDesiredState({ cwd: dir, env: {} })).rejects.toThrow(
+      /duplicate connector key "dup2"|connector key "dup2" is declared by more than one/
+    );
+  });
+
+  test("--only agents skips the connectors dir (no connector-secret expansion)", async () => {
+    const dir = mkConnectorsProject({
+      "auth.yaml": `version: 1
+type: auth_profile
+slug: hn-token
+connector: hackernews
+kind: env
+credentials:
+  HN_TOKEN: $HN_API_TOKEN
+`,
+    });
+    // $HN_API_TOKEN is unset, but --only agents must not load/expand it.
+    const { state } = await loadDesiredState({
+      cwd: dir,
+      env: {},
+      only: "agents",
+    });
+    expect(state.connectors.authProfiles).toHaveLength(0);
+    expect(state.connectors.connections).toHaveLength(0);
+    expect(state.requiredSecrets).not.toContain("HN_API_TOKEN");
+  });
 });

--- a/packages/cli/src/commands/_lib/apply/__tests__/desired-state.test.ts
+++ b/packages/cli/src/commands/_lib/apply/__tests__/desired-state.test.ts
@@ -238,4 +238,182 @@ slug = "stale"
     );
     await expect(loadDesiredState({ cwd: dir })).rejects.toThrow(/watchers/);
   });
+
+  // ── Connectors ────────────────────────────────────────────────────────────
+
+  const TOML_WITH_MEMORY = `[agents.triage]
+name = "Triage"
+dir = "./agents/triage"
+
+[memory]
+connectors = "./connectors"
+`;
+
+  function mkConnectorsProject(files: Record<string, string>): string {
+    const dir = mkProject(TOML_WITH_MEMORY);
+    mkdirSync(join(dir, "connectors"));
+    for (const [name, body] of Object.entries(files)) {
+      writeFileSync(join(dir, "connectors", name), body);
+    }
+    return dir;
+  }
+
+  test("loads built-in connection + auth_profile + custom .connector.ts", async () => {
+    const dir = mkConnectorsProject({
+      "acme.connector.ts": "export default class Acme {}\n",
+      "hackernews.yaml": `version: 1
+type: auth_profile
+slug: hn-token
+connector: hackernews
+kind: env
+credentials:
+  HN_TOKEN: $HN_TOKEN
+---
+version: 1
+type: connection
+slug: hn-frontpage
+connector: hackernews
+name: HN front page
+auth: hn-token
+feeds:
+  - feed: stories
+    schedule: "0 * * * *"
+`,
+      "x.yaml": `version: 1
+type: auth_profile
+slug: x-account
+connector: x
+kind: oauth_account
+`,
+    });
+
+    const { state } = await loadDesiredState({
+      cwd: dir,
+      env: { HN_TOKEN: "secret-token" },
+    });
+    expect(state.connectors.definitions).toHaveLength(1);
+    expect(state.connectors.definitions[0]!.sourceCode).toContain("class Acme");
+    expect(state.connectors.definitions[0]!.key).toBeNull();
+    expect(state.connectors.authProfiles.map((p) => p.slug).sort()).toEqual([
+      "hn-token",
+      "x-account",
+    ]);
+    expect(
+      state.connectors.authProfiles.find((p) => p.slug === "hn-token")!
+        .credentials
+    ).toEqual({ HN_TOKEN: "secret-token" });
+    const conn = state.connectors.connections[0]!;
+    expect(conn.slug).toBe("hn-frontpage");
+    expect(conn.authProfileSlug).toBe("hn-token");
+    expect(conn.feeds).toEqual([{ feedKey: "stories", schedule: "0 * * * *" }]);
+  });
+
+  test("collects $ENV refs from auth_profile credentials and expands them", async () => {
+    const dir = mkConnectorsProject({
+      "auth.yaml": `version: 1
+type: auth_profile
+slug: hn-token
+connector: hackernews
+kind: env
+credentials:
+  HN_TOKEN: $HN_API_TOKEN
+`,
+    });
+    const { state } = await loadDesiredState({
+      cwd: dir,
+      env: { HN_API_TOKEN: "abc123" },
+    });
+    expect(state.requiredSecrets).toContain("HN_API_TOKEN");
+    expect(state.connectors.authProfiles[0]!.credentials).toEqual({
+      HN_TOKEN: "abc123",
+    });
+  });
+
+  test("fails loudly when an auth_profile credential references an unset env var", async () => {
+    const dir = mkConnectorsProject({
+      "auth.yaml": `version: 1
+type: auth_profile
+slug: hn-token
+connector: hackernews
+kind: env
+credentials:
+  HN_TOKEN: $HN_API_TOKEN
+`,
+    });
+    await expect(loadDesiredState({ cwd: dir, env: {} })).rejects.toThrow(
+      /references \$HN_API_TOKEN/
+    );
+  });
+
+  test("rejects credentials on oauth_account auth profiles", async () => {
+    const dir = mkConnectorsProject({
+      "auth.yaml": `version: 1
+type: auth_profile
+slug: x-account
+connector: x
+kind: oauth_account
+credentials:
+  token: nope
+`,
+    });
+    await expect(loadDesiredState({ cwd: dir, env: {} })).rejects.toThrow(
+      /credentials must not be set/
+    );
+  });
+
+  test("rejects an unknown auth_profile kind", async () => {
+    const dir = mkConnectorsProject({
+      "auth.yaml": `version: 1
+type: auth_profile
+slug: x-account
+connector: x
+kind: bogus
+`,
+    });
+    await expect(loadDesiredState({ cwd: dir, env: {} })).rejects.toThrow(
+      /kind.*must be one of/
+    );
+  });
+
+  test("rejects a connector doc declaring both source_path and source_url", async () => {
+    const dir = mkConnectorsProject({
+      "acme.yaml": `version: 1
+type: connector
+key: acme
+source_path: ./acme.ts
+source_url: https://example.com/acme.ts
+`,
+    });
+    await expect(loadDesiredState({ cwd: dir, env: {} })).rejects.toThrow(
+      /exactly one of/
+    );
+  });
+
+  test("validates connection config against the connector optionsSchema", async () => {
+    const { validateConnectionAgainstConnector, resolveConnectorSchemas } =
+      await import("../desired-state.js");
+    const schemas = resolveConnectorSchemas({
+      options_schema: {
+        type: "object",
+        properties: { limit: { type: "number" } },
+        required: ["limit"],
+        additionalProperties: false,
+      },
+      feeds_schema: { stories: { configSchema: { type: "object" } } },
+      auth_schema: { methods: [{ type: "env_keys" }] },
+    });
+    expect(() =>
+      validateConnectionAgainstConnector(
+        {
+          slug: "bad",
+          connector: "demo",
+          config: { limit: "oops" },
+          feeds: [],
+          sourceFile: "connectors/demo.yaml",
+        },
+        new Map(),
+        schemas
+      )
+    ).toThrow(/connection "bad" config/);
+  });
 });

--- a/packages/cli/src/commands/_lib/apply/__tests__/desired-state.test.ts
+++ b/packages/cli/src/commands/_lib/apply/__tests__/desired-state.test.ts
@@ -462,7 +462,7 @@ source_url: https://example.com/b.ts
 `,
     });
     await expect(loadDesiredState({ cwd: dir, env: {} })).rejects.toThrow(
-      /duplicate connector key "dup"|connector key "dup" is declared by more than one/
+      /connector key "dup" is declared twice/
     );
   });
 
@@ -480,7 +480,7 @@ source_url: https://example.com/b.ts
 `,
     });
     await expect(loadDesiredState({ cwd: dir, env: {} })).rejects.toThrow(
-      /duplicate connector key "dup2"|connector key "dup2" is declared by more than one/
+      /connector key "dup2" is declared twice/
     );
   });
 
@@ -504,5 +504,60 @@ credentials:
     expect(state.connectors.authProfiles).toHaveLength(0);
     expect(state.connectors.connections).toHaveLength(0);
     expect(state.requiredSecrets).not.toContain("HN_API_TOKEN");
+  });
+
+  // ── round-3 ──────────────────────────────────────────────────────────────
+
+  test("rejects two type:connector docs with the same key (cites both files)", async () => {
+    const dir = mkConnectorsProject({
+      "a.yaml": `version: 1
+type: connector
+key: dup3
+source_url: https://example.com/a.ts
+`,
+      "b.yaml": `version: 1
+type: connector
+key: dup3
+source_url: https://example.com/b.ts
+`,
+    });
+    let msg = "";
+    await loadDesiredState({ cwd: dir, env: {} }).catch((e) => {
+      msg = e instanceof Error ? e.message : String(e);
+    });
+    expect(msg).toMatch(/connector key "dup3" is declared twice/);
+    expect(msg).toMatch(/a\.yaml/);
+    expect(msg).toMatch(/b\.yaml/);
+  });
+
+  test("rejects two type:connector docs with the same key in one file", async () => {
+    const dir = mkConnectorsProject({
+      "a.yaml": `version: 1
+type: connector
+key: dup4
+source_url: https://example.com/a.ts
+---
+version: 1
+type: connector
+key: dup4
+source_url: https://example.com/b.ts
+`,
+    });
+    await expect(loadDesiredState({ cwd: dir, env: {} })).rejects.toThrow(
+      /connector key "dup4" is declared twice/
+    );
+  });
+
+  test("rejects a non-https connector source_url", async () => {
+    const dir = mkConnectorsProject({
+      "a.yaml": `version: 1
+type: connector
+key: insecure
+source_url: http://example.com/a.ts
+`,
+    });
+    await expect(loadDesiredState({ cwd: dir, env: {} })).rejects.toThrow(
+      /source_url must use https/
+    );
   });
 });

--- a/packages/cli/src/commands/_lib/apply/__tests__/desired-state.test.ts
+++ b/packages/cli/src/commands/_lib/apply/__tests__/desired-state.test.ts
@@ -462,7 +462,7 @@ source_url: https://example.com/b.ts
 `,
     });
     await expect(loadDesiredState({ cwd: dir, env: {} })).rejects.toThrow(
-      /connector key "dup" is declared twice/
+      /connector key "dup" is declared (twice|by two)/
     );
   });
 
@@ -480,7 +480,7 @@ source_url: https://example.com/b.ts
 `,
     });
     await expect(loadDesiredState({ cwd: dir, env: {} })).rejects.toThrow(
-      /connector key "dup2" is declared twice/
+      /connector key "dup2" is declared (twice|by two)/
     );
   });
 
@@ -525,7 +525,7 @@ source_url: https://example.com/b.ts
     await loadDesiredState({ cwd: dir, env: {} }).catch((e) => {
       msg = e instanceof Error ? e.message : String(e);
     });
-    expect(msg).toMatch(/connector key "dup3" is declared twice/);
+    expect(msg).toMatch(/connector key "dup3" is declared (twice|by two)/);
     expect(msg).toMatch(/a\.yaml/);
     expect(msg).toMatch(/b\.yaml/);
   });
@@ -544,7 +544,7 @@ source_url: https://example.com/b.ts
 `,
     });
     await expect(loadDesiredState({ cwd: dir, env: {} })).rejects.toThrow(
-      /connector key "dup4" is declared twice/
+      /connector key "dup4" is declared (twice|by two)/
     );
   });
 

--- a/packages/cli/src/commands/_lib/apply/__tests__/diff.test.ts
+++ b/packages/cli/src/commands/_lib/apply/__tests__/diff.test.ts
@@ -688,4 +688,147 @@ describe("apply diff — connectors", () => {
     });
     expect(renderPlan(plan)).toMatchSnapshot();
   });
+
+  // ── round-2 ──────────────────────────────────────────────────────────────
+
+  test("connection slug bound to a different connector remotely is a hard error", () => {
+    expect(() =>
+      computeDiff(connectorState(), {
+        ...emptyRemote(),
+        connectorDefinitions: [builtinConnectorDef],
+        connections: [
+          {
+            id: 9,
+            slug: "hn-frontpage",
+            connector_key: "rss",
+            status: "active",
+            auth_profile_slug: null,
+            app_auth_profile_slug: null,
+            config: {},
+          },
+        ],
+      })
+    ).toThrow(/bound to connector "rss" remotely.*declares "hackernews"/);
+  });
+
+  test("auth-profile slug bound to a different kind remotely is a hard error", () => {
+    expect(() =>
+      computeDiff(connectorState(), {
+        ...emptyRemote(),
+        connectorDefinitions: [builtinConnectorDef],
+        authProfiles: [
+          {
+            slug: "hn-token",
+            connector_key: "hackernews",
+            profile_kind: "oauth_app",
+            status: "active",
+          },
+        ],
+      })
+    ).toThrow(/auth_profile "hn-token" is bound to hackernews\/oauth_app/);
+  });
+
+  test("credential rotation re-pushes: env profile shows update (credentials)", () => {
+    const plan = computeDiff(connectorState(), {
+      ...emptyRemote(),
+      connectorDefinitions: [builtinConnectorDef],
+      authProfiles: [
+        {
+          slug: "hn-token",
+          display_name: "HN token",
+          connector_key: "hackernews",
+          profile_kind: "env",
+          status: "active",
+        },
+      ],
+    });
+    const row = plan.rows.find(
+      (r) => r.kind === "auth-profile" && r.id === "hn-token"
+    );
+    expect(row?.verb).toBe("update");
+    expect(row && "changedFields" in row ? row.changedFields : []).toContain(
+      "credentials"
+    );
+  });
+
+  test("a fully-converged remote state produces no connector create/update (except idempotent connector-def re-push)", () => {
+    // Build a remote snapshot that exactly mirrors connectorState(): the env
+    // auth profile has no declared-credential drift suppression, so it would
+    // re-push (update credentials). The acme connector def is installed, so it
+    // shows as a (no-op-on-server) "update". Everything else is noop.
+    const remote: RemoteSnapshot = {
+      ...emptyRemote(),
+      connectorDefinitions: [
+        { key: "hackernews", installed: false, installable: true },
+        { key: "x", installed: false, installable: true },
+        { key: "acme", installed: true, installable: false },
+      ],
+      authProfiles: [
+        {
+          slug: "hn-token",
+          display_name: "HN token",
+          connector_key: "hackernews",
+          profile_kind: "env",
+          status: "active",
+        },
+        {
+          slug: "x-account",
+          connector_key: "x",
+          profile_kind: "oauth_account",
+          status: "active",
+        },
+      ],
+      connections: [
+        {
+          id: 7,
+          slug: "hn-frontpage",
+          connector_key: "hackernews",
+          display_name: "HN front page",
+          status: "active",
+          auth_profile_slug: "hn-token",
+          app_auth_profile_slug: null,
+          config: {},
+        },
+      ],
+      feedsByConnectionId: new Map([
+        [
+          7,
+          [
+            {
+              id: 11,
+              connection_id: 7,
+              feed_key: "stories",
+              status: "active",
+              schedule: "0 * * * *",
+              config: {},
+            },
+          ],
+        ],
+      ]),
+    };
+    const plan = computeDiff(connectorState(), remote);
+    // Only "update" rows allowed: the connector-def re-push and the
+    // env-credential re-push — both idempotent on the server.
+    const nonIdempotentChurn = plan.rows.filter(
+      (r) =>
+        (r.verb === "create" || r.verb === "update") &&
+        !(r.kind === "connector-definition") &&
+        !(r.kind === "auth-profile" && r.id === "hn-token")
+    );
+    expect(nonIdempotentChurn).toEqual([]);
+    expect(plan.notes).toEqual([]);
+  });
+
+  test("connector-definition with an already-installed key renders as update, not create", () => {
+    const installedAcme = { key: "acme", installed: true, installable: false };
+    const plan = computeDiff(connectorState(), {
+      ...emptyRemote(),
+      connectorDefinitions: [builtinConnectorDef, installedAcme],
+    });
+    // connectorState()'s acme def has key:"acme"; it is installed remotely.
+    const row = plan.rows.find(
+      (r) => r.kind === "connector-definition" && r.id?.startsWith("acme")
+    );
+    expect(row?.verb).toBe("update");
+  });
 });

--- a/packages/cli/src/commands/_lib/apply/__tests__/diff.test.ts
+++ b/packages/cli/src/commands/_lib/apply/__tests__/diff.test.ts
@@ -831,4 +831,71 @@ describe("apply diff — connectors", () => {
     );
     expect(row?.verb).toBe("update");
   });
+
+  // ── round-4 ──────────────────────────────────────────────────────────────
+
+  test("referenced-but-not-installed bundled connector becomes a connector-definition create row", () => {
+    const plan = computeDiff(connectorState(), {
+      ...emptyRemote(),
+      connectorDefinitions: [
+        // hackernews: installable + has a server-side source_uri, not installed
+        {
+          key: "hackernews",
+          installed: false,
+          installable: true,
+          source_uri: "file:///app/connectors/hackernews.ts",
+        },
+        // x: same
+        {
+          key: "x",
+          installed: false,
+          installable: true,
+          source_uri: "file:///app/connectors/x.ts",
+        },
+      ],
+    });
+    const hn = plan.rows.find(
+      (r) => r.kind === "connector-definition" && r.id === "hackernews"
+    );
+    expect(hn?.verb).toBe("create");
+    const x = plan.rows.find(
+      (r) => r.kind === "connector-definition" && r.id === "x"
+    );
+    expect(x?.verb).toBe("create");
+    // acme is locally declared (sourcePath) — it still gets its own row.
+    expect(
+      plan.rows.some(
+        (r) => r.kind === "connector-definition" && r.id?.startsWith("acme")
+      )
+    ).toBe(true);
+  });
+
+  test("a locally-supplied connector key is NOT also a bundled-install row (no double mutation)", () => {
+    // Pretend "acme" is *also* in the bundled catalog with a source_uri; the
+    // local .connector.ts should win — no bundled row for "acme".
+    const state = connectorState();
+    // Make a connection reference "acme" so it's in referencedConnectorKeys.
+    state.connectors.connections.push({
+      slug: "acme-conn",
+      connector: "acme",
+      feeds: [],
+      sourceFile: "connectors/acme.yaml",
+    });
+    const plan = computeDiff(state, {
+      ...emptyRemote(),
+      connectorDefinitions: [
+        {
+          key: "acme",
+          installed: false,
+          installable: true,
+          source_uri: "file:///app/connectors/acme.ts",
+        },
+      ],
+    });
+    const acmeRows = plan.rows.filter(
+      (r) => r.kind === "connector-definition" && r.id?.startsWith("acme")
+    );
+    // Exactly one row — the locally-declared def — never a bundled duplicate.
+    expect(acmeRows).toHaveLength(1);
+  });
 });

--- a/packages/cli/src/commands/_lib/apply/__tests__/diff.test.ts
+++ b/packages/cli/src/commands/_lib/apply/__tests__/diff.test.ts
@@ -29,6 +29,7 @@ function buildState(
     agents,
     memorySchema: { entityTypes: [], relationshipTypes: [] },
     watchers: [],
+    connectors: { definitions: [], authProfiles: [], connections: [] },
     requiredSecrets: [],
     ...overrides,
   };
@@ -42,6 +43,10 @@ function emptyRemote(): RemoteSnapshot {
     entityTypes: [],
     relationshipTypes: [],
     watchers: [],
+    connectorDefinitions: [],
+    authProfiles: [],
+    connections: [],
+    feedsByConnectionId: new Map(),
   };
 }
 
@@ -450,5 +455,237 @@ describe("renderSummary", () => {
     const desired = buildState([]);
     const plan = computeDiff(desired, emptyRemote());
     expect(renderSummary(plan)).toMatchSnapshot();
+  });
+});
+
+describe("apply diff — connectors", () => {
+  const builtinConnectorDef = {
+    key: "hackernews",
+    name: "Hacker News",
+    installed: false,
+    installable: true,
+  };
+
+  function connectorState() {
+    return buildState([], {
+      connectors: {
+        definitions: [
+          {
+            key: "acme",
+            sourcePath: "/proj/connectors/acme.connector.ts",
+            sourceCode: "export default class {}",
+            sourceFile: "connectors/acme.connector.ts",
+          },
+        ],
+        authProfiles: [
+          {
+            slug: "hn-token",
+            connector: "hackernews",
+            kind: "env" as const,
+            name: "HN token",
+            credentials: { HN_TOKEN: "$HN_TOKEN" },
+            sourceFile: "connectors/hackernews.yaml",
+          },
+          {
+            slug: "x-account",
+            connector: "x",
+            kind: "oauth_account" as const,
+            sourceFile: "connectors/x.yaml",
+          },
+        ],
+        connections: [
+          {
+            slug: "hn-frontpage",
+            connector: "hackernews",
+            name: "HN front page",
+            authProfileSlug: "hn-token",
+            feeds: [{ feedKey: "stories", schedule: "0 * * * *" }],
+            sourceFile: "connectors/hackernews.yaml",
+          },
+        ],
+      },
+    });
+  }
+
+  test("create verbs for new connector def, auth profile, connection, feed", () => {
+    const plan = computeDiff(connectorState(), {
+      ...emptyRemote(),
+      connectorDefinitions: [builtinConnectorDef],
+    });
+    const def = plan.rows.find((r) => r.kind === "connector-definition");
+    expect(def?.verb).toBe("create");
+    const authEnv = plan.rows.find(
+      (r) => r.kind === "auth-profile" && r.id === "hn-token"
+    );
+    expect(authEnv?.verb).toBe("create");
+    const authOauth = plan.rows.find(
+      (r) => r.kind === "auth-profile" && r.id === "x-account"
+    );
+    expect(authOauth?.verb).toBe("create");
+    expect(
+      authOauth && "needsAuth" in authOauth ? authOauth.needsAuth : undefined
+    ).toBe(true);
+    const conn = plan.rows.find((r) => r.kind === "connection");
+    expect(conn?.verb).toBe("create");
+    const feed = plan.rows.find((r) => r.kind === "feed");
+    expect(feed?.verb).toBe("create");
+    expect(feed?.id).toBe("hn-frontpage/stories");
+  });
+
+  test("noop when connection + feed already match remotely", () => {
+    const remote: RemoteSnapshot = {
+      ...emptyRemote(),
+      connectorDefinitions: [builtinConnectorDef],
+      authProfiles: [
+        {
+          slug: "hn-token",
+          display_name: "HN token",
+          connector_key: "hackernews",
+          profile_kind: "env",
+          status: "active",
+        },
+        {
+          slug: "x-account",
+          connector_key: "x",
+          profile_kind: "oauth_account",
+          status: "active",
+        },
+      ],
+      connections: [
+        {
+          id: 7,
+          slug: "hn-frontpage",
+          connector_key: "hackernews",
+          display_name: "HN front page",
+          status: "active",
+          auth_profile_slug: "hn-token",
+          app_auth_profile_slug: null,
+          config: {},
+        },
+      ],
+      feedsByConnectionId: new Map([
+        [
+          7,
+          [
+            {
+              id: 11,
+              connection_id: 7,
+              feed_key: "stories",
+              status: "active",
+              schedule: "0 * * * *",
+              config: {},
+            },
+          ],
+        ],
+      ]),
+    };
+    const plan = computeDiff(connectorState(), remote);
+    expect(plan.rows.find((r) => r.kind === "connection")?.verb).toBe("noop");
+    expect(plan.rows.find((r) => r.kind === "feed")?.verb).toBe("noop");
+    expect(
+      plan.rows.find((r) => r.kind === "auth-profile" && r.id === "x-account")
+        ?.verb
+    ).toBe("noop");
+  });
+
+  test("update when feed schedule changes; needs-auth when oauth profile inactive", () => {
+    const remote: RemoteSnapshot = {
+      ...emptyRemote(),
+      connectorDefinitions: [builtinConnectorDef],
+      authProfiles: [
+        {
+          slug: "hn-token",
+          display_name: "HN token",
+          connector_key: "hackernews",
+          profile_kind: "env",
+          status: "active",
+        },
+        {
+          slug: "x-account",
+          connector_key: "x",
+          profile_kind: "oauth_account",
+          status: "pending_auth",
+        },
+      ],
+      connections: [
+        {
+          id: 7,
+          slug: "hn-frontpage",
+          connector_key: "hackernews",
+          display_name: "HN front page",
+          status: "active",
+          auth_profile_slug: "hn-token",
+          app_auth_profile_slug: null,
+          config: {},
+        },
+      ],
+      feedsByConnectionId: new Map([
+        [
+          7,
+          [
+            {
+              id: 11,
+              connection_id: 7,
+              feed_key: "stories",
+              status: "active",
+              schedule: "0 0 * * *",
+              config: {},
+            },
+          ],
+        ],
+      ]),
+    };
+    const plan = computeDiff(connectorState(), remote);
+    const feed = plan.rows.find((r) => r.kind === "feed");
+    expect(feed?.verb).toBe("update");
+    expect(feed && "changedFields" in feed ? feed.changedFields : []).toEqual([
+      "schedule",
+    ]);
+    const authOauth = plan.rows.find(
+      (r) => r.kind === "auth-profile" && r.id === "x-account"
+    );
+    expect(
+      authOauth && "needsAuth" in authOauth ? authOauth.needsAuth : undefined
+    ).toBe(true);
+  });
+
+  test("undeclared remote connector becomes an informational note (no uninstall)", () => {
+    const remote: RemoteSnapshot = {
+      ...emptyRemote(),
+      connectorDefinitions: [
+        builtinConnectorDef,
+        {
+          key: "legacy",
+          name: "Legacy",
+          installed: true,
+          installable: false,
+        },
+      ],
+    };
+    const plan = computeDiff(connectorState(), remote);
+    expect(plan.notes.some((n) => n.includes('"legacy"'))).toBe(true);
+    expect(
+      plan.rows.some(
+        (r) => r.kind === "connector-definition" && r.id === "legacy"
+      )
+    ).toBe(false);
+  });
+
+  test("connectors are skipped when --only is set", () => {
+    const plan = computeDiff(connectorState(), emptyRemote(), {
+      only: "agents",
+    });
+    expect(plan.rows.some((r) => r.kind === "connection")).toBe(false);
+    expect(plan.rows.some((r) => r.kind === "connector-definition")).toBe(
+      false
+    );
+  });
+
+  test("render includes the connectors sections", () => {
+    const plan = computeDiff(connectorState(), {
+      ...emptyRemote(),
+      connectorDefinitions: [builtinConnectorDef],
+    });
+    expect(renderPlan(plan)).toMatchSnapshot();
   });
 });

--- a/packages/cli/src/commands/_lib/apply/apply-cmd.ts
+++ b/packages/cli/src/commands/_lib/apply/apply-cmd.ts
@@ -389,10 +389,28 @@ async function installConnectorDefinitions(
  * avoids rejecting a connection's config against a stale installed schema when
  * the same apply updates that connector.
  */
+export interface ValidateConnectorStateOptions {
+  /**
+   * Connector keys whose JSON-schema validation should be skipped in this pass
+   * (the locally-declared ones in the *pre*-install pass — they're schema-
+   * validated post-install against the fresh catalog).
+   */
+  skipSchemaForConnectorKeys?: ReadonlySet<string>;
+  /**
+   * When true (the *post*-install pass), every connector key referenced by a
+   * desired auth profile or connection must be present in the catalog with
+   * `installed === true` — otherwise a hard `ValidationError` before any
+   * `executePlan` mutation. Catches a typo'd `connector:` ref, or a local
+   * `*.connector.ts` whose compiled `definition.key` differs from what the
+   * manifest assumed (so it never got installed under the expected key).
+   */
+  requireInstalled?: boolean;
+}
+
 export function validateConnectorState(
   state: DesiredState,
   connectorDefinitions: RemoteConnectorDefinition[],
-  skipSchemaForConnectorKeys?: ReadonlySet<string>
+  opts: ValidateConnectorStateOptions = {}
 ): void {
   const defByKey = new Map<string, RemoteConnectorDefinition>(
     connectorDefinitions.map((d) => [d.key, d])
@@ -400,8 +418,30 @@ export function validateConnectorState(
   const authProfilesBySlug = new Map(
     state.connectors.authProfiles.map((p) => [p.slug, p])
   );
+
+  if (opts.requireInstalled) {
+    const refs: Array<{ connector: string; ref: string }> = [
+      ...state.connectors.authProfiles.map((p) => ({
+        connector: p.connector,
+        ref: `auth profile "${p.slug}"`,
+      })),
+      ...state.connectors.connections.map((c) => ({
+        connector: c.connector,
+        ref: `connection "${c.slug}"`,
+      })),
+    ];
+    for (const { connector, ref } of refs) {
+      const def = defByKey.get(connector);
+      if (!def || def.installed !== true) {
+        throw new ValidationError(
+          `connector "${connector}" referenced by ${ref} is not installed in the org — check the \`connector\` key (and, for a local \`*.connector.ts\`, that its \`definition.key\` matches)`
+        );
+      }
+    }
+  }
+
   const schemasFor = (connectorKey: string) => {
-    if (skipSchemaForConnectorKeys?.has(connectorKey)) return null;
+    if (opts.skipSchemaForConnectorKeys?.has(connectorKey)) return null;
     const def = defByKey.get(connectorKey);
     return def ? resolveConnectorSchemas(def) : null;
   };
@@ -464,7 +504,7 @@ async function executePlan(
       ctx.remote.connectorDefinitions,
       ctx.plan
     );
-    validateConnectorState(ctx.state, freshCatalog);
+    validateConnectorState(ctx.state, freshCatalog, { requireInstalled: true });
   }
 
   // 1) Agents
@@ -781,11 +821,9 @@ export async function applyCommand(opts: ApplyOptions = {}): Promise<void> {
   // schema-validated later (post-install, against the fresh catalog) inside
   // `executePlan`. Structural checks (auth-slug existence, connector match)
   // still run here for every connection.
-  validateConnectorState(
-    state,
-    remote.connectorDefinitions,
-    locallyDeclaredConnectorKeys(state)
-  );
+  validateConnectorState(state, remote.connectorDefinitions, {
+    skipSchemaForConnectorKeys: locallyDeclaredConnectorKeys(state),
+  });
 
   const plan = computeDiff(state, remote, { only: opts.only });
   printText(renderPlan(plan));

--- a/packages/cli/src/commands/_lib/apply/apply-cmd.ts
+++ b/packages/cli/src/commands/_lib/apply/apply-cmd.ts
@@ -61,6 +61,116 @@ function checkRequiredSecrets(state: DesiredState): { missing: string[] } {
   return { missing };
 }
 
+// ── source_url: confirmed-before-fetch, https-only, bounded fetch ──────────
+
+const CONNECTOR_SOURCE_MAX_BYTES = 2 * 1024 * 1024; // 2 MiB
+const CONNECTOR_SOURCE_FETCH_TIMEOUT_MS = 15_000;
+
+async function materializeConnectorSource(
+  defs: DesiredConnectorDefinition[],
+  fetchImpl: typeof fetch
+): Promise<void> {
+  for (const def of defs) {
+    if (def.sourceCode !== undefined || !def.sourceUrl) continue;
+    let url: URL;
+    try {
+      url = new URL(def.sourceUrl);
+    } catch {
+      throw new ValidationError(
+        `${def.sourceFile}: connector source_url is not a valid URL: ${def.sourceUrl}`
+      );
+    }
+    if (url.protocol !== "https:") {
+      throw new ValidationError(
+        `${def.sourceFile}: connector source_url must use https (got ${url.protocol}//): ${def.sourceUrl}`
+      );
+    }
+    const controller = new AbortController();
+    const timer = setTimeout(
+      () => controller.abort(),
+      CONNECTOR_SOURCE_FETCH_TIMEOUT_MS
+    );
+    let res: Response;
+    try {
+      res = await fetchImpl(def.sourceUrl, { signal: controller.signal });
+    } catch (err) {
+      throw new ValidationError(
+        `${def.sourceFile}: failed to fetch connector source_url ${def.sourceUrl} — ${err instanceof Error ? err.message : String(err)}`
+      );
+    } finally {
+      clearTimeout(timer);
+    }
+    if (!res.ok) {
+      throw new ValidationError(
+        `${def.sourceFile}: connector source_url ${def.sourceUrl} returned HTTP ${res.status} ${res.statusText}`
+      );
+    }
+    const contentType = (res.headers.get("content-type") ?? "").toLowerCase();
+    if (
+      contentType &&
+      !/(text\/|application\/(typescript|javascript|x-typescript|octet-stream))/.test(
+        contentType
+      )
+    ) {
+      throw new ValidationError(
+        `${def.sourceFile}: connector source_url ${def.sourceUrl} returned unexpected content-type "${contentType}" — expected text/*, application/typescript, or application/javascript`
+      );
+    }
+    const body = await res.text();
+    if (body.length > CONNECTOR_SOURCE_MAX_BYTES) {
+      throw new ValidationError(
+        `${def.sourceFile}: connector source_url ${def.sourceUrl} body is ${body.length} bytes — exceeds the ${CONNECTOR_SOURCE_MAX_BYTES}-byte cap`
+      );
+    }
+    if (!body.trim()) {
+      throw new ValidationError(
+        `${def.sourceFile}: connector source_url ${def.sourceUrl} returned an empty body`
+      );
+    }
+    def.sourceCode = body;
+  }
+}
+
+/**
+ * Warn + require confirmation BEFORE the CLI fetches any `source_url` or
+ * uploads any custom connector source for compilation on the gateway.
+ *
+ * SECURITY: `install_connector` compiles + imports + instantiates the connector
+ * runtime class on the gateway. The server-side compiler currently runs with
+ * full gateway env/fs/network and only blocks relative imports — this consent
+ * gate is the operator's last line of defence. (TODO(security): sandbox the
+ * server-side connector compiler — tracked separately, out of scope here.)
+ */
+async function confirmCustomConnectorSource(
+  defs: DesiredConnectorDefinition[],
+  yes: boolean
+): Promise<void> {
+  if (defs.length === 0) return;
+  printText(
+    chalk.yellow(
+      `\n  ⚠ This project ships ${defs.length} custom connector source ${defs.length === 1 ? "definition" : "definitions"}:`
+    )
+  );
+  for (const def of defs) {
+    printText(
+      chalk.yellow(
+        def.sourceUrl
+          ? `    - ${def.sourceFile} → fetches ${def.sourceUrl}`
+          : `    - ${def.sourceFile}`
+      )
+    );
+  }
+  printText(
+    chalk.yellow(
+      "  `lobu apply` will fetch (https) and UPLOAD this source; the gateway will COMPILE and EXECUTE it.\n  Only proceed if you trust this code."
+    )
+  );
+  const ok = await confirmCustomConnectors(yes);
+  if (!ok) {
+    throw new ValidationError("Cancelled — custom connectors not confirmed.");
+  }
+}
+
 // ── Snapshot ───────────────────────────────────────────────────────────────
 
 async function fetchRemoteSnapshot(
@@ -129,37 +239,31 @@ async function fetchRemoteSnapshot(
   };
 }
 
-// ── Connector definitions (phase 1: install/update, then refetch catalog) ──
+// ── Connector definition install (runs INSIDE executePlan, after confirm) ──
 
 /**
- * Install/update the project's custom connector definitions, then install any
- * *bundled* connectors referenced by an auth-profile / connection (the server
- * only resolves *installed* defs in `create_auth_profile` / `create_feed`, not
- * the catalog). Returns the fresh connector-definition catalog so config
- * validation runs against the now-current schemas — fixing the "validate
- * against stale remote schema before installing the local connector" bug.
- *
- * SECURITY: `install_connector` compiles + imports + instantiates the connector
- * runtime class on the gateway. Custom connector source must already have been
- * confirmed by the operator (see `confirmCustomConnectorSource`). The CLI
- * fetches `source_url` content client-side (no gateway-side fetch from a
- * manifest URL) — see `materializeConnectorSource`.
- * TODO(security): the server-side connector compiler/metadata-extractor still
- * runs with full gateway env/fs/network and only blocks relative imports — it
- * should run sandboxed (no secrets, restricted fs/net, block node:* / dynamic
- * import / require). Tracked separately; out of scope for this PR.
+ * Install/update the project's custom connector definitions, then any *bundled*
+ * connectors referenced by an auth-profile / connection (the server only
+ * resolves *installed* defs in `create_auth_profile` / `create_feed`, not the
+ * catalog). Returns the fresh connector-definition catalog.
  */
 async function installConnectorDefinitions(
   client: ApplyClient,
   state: DesiredState,
-  catalog: RemoteConnectorDefinition[]
+  catalog: RemoteConnectorDefinition[],
+  plan: DiffPlan
 ): Promise<RemoteConnectorDefinition[]> {
   const installedKeys = new Set(
     catalog.filter((d) => d.installed).map((d) => d.key)
   );
   let mutated = false;
 
-  for (const def of state.connectors.definitions) {
+  // Iterate the plan's connector-definition rows so progress mirrors the plan.
+  for (const row of plan.rows) {
+    if (row.kind !== "connector-definition") continue;
+    if (row.verb === "noop" || row.verb === "drift") continue;
+    const def = row.desired;
+    if (!def) continue;
     const result =
       def.sourceCode !== undefined
         ? await client.installConnector({ sourceCode: def.sourceCode })
@@ -167,7 +271,7 @@ async function installConnectorDefinitions(
     mutated = true;
     printText(
       renderProgress(
-        "update",
+        row.verb,
         "connector-definition",
         result.connectorKey || def.key || def.sourceFile,
         result.updated ? "(installed)" : "(unchanged)"
@@ -193,7 +297,7 @@ async function installConnectorDefinitions(
     mutated = true;
     printText(
       renderProgress(
-        "update",
+        "create",
         "connector-definition",
         result.connectorKey || key,
         result.updated ? "(installed bundled)" : "(bundled — unchanged)"
@@ -204,7 +308,7 @@ async function installConnectorDefinitions(
   return mutated ? await client.listConnectorDefinitions(true) : catalog;
 }
 
-// ── Connector validation (against the now-current catalog) ─────────────────
+// ── Connector config validation (against a given catalog) ──────────────────
 
 function validateConnectorState(
   state: DesiredState,
@@ -233,65 +337,7 @@ function validateConnectorState(
   }
 }
 
-// ── source_url fetched client-side; security confirmation gate ─────────────
-
-async function materializeConnectorSource(
-  defs: DesiredConnectorDefinition[],
-  fetchImpl: typeof fetch
-): Promise<void> {
-  for (const def of defs) {
-    if (def.sourceCode !== undefined || !def.sourceUrl) continue;
-    let res: Response;
-    try {
-      res = await fetchImpl(def.sourceUrl);
-    } catch (err) {
-      throw new ValidationError(
-        `${def.sourceFile}: failed to fetch connector source_url ${def.sourceUrl} — ${err instanceof Error ? err.message : String(err)}`
-      );
-    }
-    if (!res.ok) {
-      throw new ValidationError(
-        `${def.sourceFile}: connector source_url ${def.sourceUrl} returned HTTP ${res.status} ${res.statusText}`
-      );
-    }
-    def.sourceCode = await res.text();
-    if (!def.sourceCode.trim()) {
-      throw new ValidationError(
-        `${def.sourceFile}: connector source_url ${def.sourceUrl} returned an empty body`
-      );
-    }
-  }
-}
-
-async function confirmCustomConnectorSource(
-  defs: DesiredConnectorDefinition[],
-  yes: boolean
-): Promise<void> {
-  if (defs.length === 0) return;
-  printText(
-    chalk.yellow(
-      `\n  ⚠ This project ships ${defs.length} custom connector source file${defs.length === 1 ? "" : "s"}:`
-    )
-  );
-  for (const def of defs) {
-    printText(
-      chalk.yellow(
-        `    - ${def.sourceFile}${def.sourceUrl ? ` (from ${def.sourceUrl})` : ""}`
-      )
-    );
-  }
-  printText(
-    chalk.yellow(
-      "  `lobu apply` will upload this source and the gateway will COMPILE and EXECUTE it.\n  Only proceed if you trust this code."
-    )
-  );
-  const ok = await confirmCustomConnectors(yes);
-  if (!ok) {
-    throw new ValidationError("Cancelled — custom connectors not confirmed.");
-  }
-}
-
-// ── Apply executor (auth profiles → connections → feeds) ───────────────────
+// ── Apply executor ─────────────────────────────────────────────────────────
 
 interface ApplyContext {
   client: ApplyClient;
@@ -399,10 +445,25 @@ async function executePlan(
     printText(renderProgress(row.verb, "watcher", row.id));
   }
 
-  // Connector definitions are installed in phase 1 (before validation), so no
-  // `connector-definition` rows are executed here.
+  // 7) Connector definitions (install — happens AFTER the plan was confirmed),
+  //    then refetch the catalog and validate connection/feed config against the
+  //    now-current schemas (so an updated custom connector's new schema is what
+  //    the connection config is checked against).
+  const hasConnectorWork =
+    ctx.state.connectors.definitions.length > 0 ||
+    ctx.state.connectors.authProfiles.length > 0 ||
+    ctx.state.connectors.connections.length > 0;
+  if (hasConnectorWork) {
+    const freshCatalog = await installConnectorDefinitions(
+      ctx.client,
+      ctx.state,
+      ctx.remote.connectorDefinitions,
+      ctx.plan
+    );
+    validateConnectorState(ctx.state, freshCatalog);
+  }
 
-  // 7) Auth profiles (create / update; interactive kinds → punch-list)
+  // 8) Auth profiles (create / update; interactive kinds → punch-list)
   for (const row of rowsByKind("auth-profile")) {
     if (row.kind !== "auth-profile") continue;
     const desired = ctx.state.connectors.authProfiles.find(
@@ -437,7 +498,7 @@ async function executePlan(
     printText(renderProgress(row.verb, "auth-profile", row.id));
   }
 
-  // 8) Connections, keyed by slug.
+  // 9) Connections, keyed by slug.
   const remoteConnBySlug = new Map(
     ctx.remote.connections.map((c) => [c.slug, c])
   );
@@ -473,7 +534,7 @@ async function executePlan(
     printText(renderProgress(row.verb, "connection", row.id));
   }
 
-  // 9) Feeds (per connection — covers feeds whose connection itself was a noop)
+  // 10) Feeds (per connection — covers feeds whose connection itself was a noop)
   for (const row of rowsByKind("feed")) {
     if (row.kind !== "feed") continue;
     if (!row.desired) continue;
@@ -595,46 +656,37 @@ export async function applyCommand(opts: ApplyOptions = {}): Promise<void> {
     }
   }
 
-  // SECURITY (#2): fetch any `source_url` connector content client-side so the
-  // gateway never fetches a URL from a project manifest, then require explicit
-  // confirmation before uploading custom connector source for compilation.
-  await materializeConnectorSource(state.connectors.definitions, fetchImpl);
+  // SECURITY (#4): confirm BEFORE fetching any `source_url` or uploading custom
+  // connector source — `lobu apply --dry-run` should never hit a manifest URL.
   if (!opts.dryRun) {
     await confirmCustomConnectorSource(
       state.connectors.definitions,
       opts.yes ?? false
     );
+    await materializeConnectorSource(state.connectors.definitions, fetchImpl);
   }
 
-  // Snapshot the remote state.
+  // Snapshot remote state. Connector-def rows in the plan are computed against
+  // this (current/stale) catalog — "create" when the key isn't installed,
+  // "update" when it is. Connector defs are NOT installed here; that happens in
+  // `executePlan`, AFTER plan confirmation.
   const remote = await fetchRemoteSnapshot(client, state, opts.only);
 
-  // Phase 1 (#5): install/update connector definitions FIRST, then refetch the
-  // connector-definition catalog so validation runs against current schemas.
-  let connectorDefinitions = remote.connectorDefinitions;
-  if (!opts.dryRun && !opts.only) {
-    connectorDefinitions = await installConnectorDefinitions(
-      client,
-      state,
-      remote.connectorDefinitions
-    );
-  }
+  // Validate connection/auth-profile config against the catalog we have now.
+  // Connectors that only exist locally (not yet installed) are skipped — the
+  // server validates those on install / create_feed, and `executePlan`
+  // re-validates against the fresh post-install catalog.
+  validateConnectorState(state, remote.connectorDefinitions);
 
-  // Validate connection / auth-profile config against the (now-current) catalog.
-  validateConnectorState(state, connectorDefinitions);
-
-  // Diff using the refreshed catalog (so an updated custom connector's new
-  // schema is what the connection config is checked against).
-  const diffSnapshot: RemoteSnapshot = {
-    ...remote,
-    connectorDefinitions,
-  };
-  const plan = computeDiff(state, diffSnapshot, { only: opts.only });
-
+  const plan = computeDiff(state, remote, { only: opts.only });
   printText(renderPlan(plan));
 
   if (opts.dryRun) {
-    printText(chalk.dim("\nDry run — no changes applied."));
+    printText(
+      chalk.dim(
+        "\nDry run — no changes applied. (Connector-definition install + post-install schema validation are skipped in dry-run.)"
+      )
+    );
     return;
   }
 
@@ -647,8 +699,6 @@ export async function applyCommand(opts: ApplyOptions = {}): Promise<void> {
     return;
   }
 
-  // Confirm the plan (unless --yes). Even a plan with only pending-auth rows
-  // is "actionable" — we re-issue connect tokens.
   const { create, update, noop, drift } = plan.counts;
   const summaryLine = `${create} create, ${update} update, ${noop} noop, ${drift} drift${hasPendingAuth ? " + pending auth" : ""}`;
   const approved = await confirmPlan({
@@ -665,10 +715,7 @@ export async function applyCommand(opts: ApplyOptions = {}): Promise<void> {
   if (plan.counts.create > 0 || plan.counts.update > 0) {
     printText(chalk.bold("\nApplying:"));
     try {
-      await executePlan(
-        { client, state, plan, remote: diffSnapshot },
-        pendingAuth
-      );
+      await executePlan({ client, state, plan, remote }, pendingAuth);
       printText(chalk.green("\nApply complete."));
     } catch (err) {
       applyErr = err;

--- a/packages/cli/src/commands/_lib/apply/apply-cmd.ts
+++ b/packages/cli/src/commands/_lib/apply/apply-cmd.ts
@@ -18,13 +18,14 @@ import {
   type RemoteSnapshot,
 } from "./diff.js";
 import {
+  type DesiredConnectorDefinition,
   type DesiredState,
   loadDesiredState,
   resolveConnectorSchemas,
   validateAuthProfileAgainstConnector,
   validateConnectionAgainstConnector,
 } from "./desired-state.js";
-import { confirmPlan } from "./prompt.js";
+import { confirmCustomConnectors, confirmPlan } from "./prompt.js";
 import {
   renderMissingSecrets,
   renderPlan,
@@ -45,17 +46,14 @@ export interface ApplyOptions {
   fetchImpl?: typeof fetch;
 }
 
+interface PendingAuthEntry {
+  slug: string;
+  kind: string;
+  connectUrl?: string;
+}
+
 // ── Required-secrets check ─────────────────────────────────────────────────
 
-/**
- * v1 secret check: every `$VAR` referenced in lobu.toml must be present in
- * the apply runner's environment. The file-loader already substitutes envs
- * in-place during gateway boot, so this is the same set of names operators
- * must satisfy at runtime — surfacing it pre-mutation gives the operator
- * a cleaner failure than a silent empty-string config push.
- *
- * Plan §7 reserves cloud-side secret-list cross-checks for v3.
- */
 function checkRequiredSecrets(state: DesiredState): { missing: string[] } {
   const missing = state.requiredSecrets.filter(
     (name) => process.env[name] === undefined || process.env[name] === ""
@@ -81,8 +79,6 @@ async function fetchRemoteSnapshot(
   if (only !== "memory") {
     const desiredAgentIds = state.agents.map((a) => a.metadata.agentId);
     const remoteAgentIds = new Set(agents.map((a) => a.agentId));
-    // Only GET settings for agents that exist; new agents have no remote
-    // settings to compare against.
     const targetAgentIds = desiredAgentIds.filter((id) =>
       remoteAgentIds.has(id)
     );
@@ -133,21 +129,89 @@ async function fetchRemoteSnapshot(
   };
 }
 
-// ── Connector validation ───────────────────────────────────────────────────
+// ── Connector definitions (phase 1: install/update, then refetch catalog) ──
 
 /**
- * Validate declared connections / auth profiles against the connector
- * definitions the server knows about (bundled catalog + installed custom).
- * Connectors that only exist as a local `.ts` not yet compiled by the server
- * are skipped — the server validates those at `install_connector` /
- * `create_feed` time. Schema mismatches throw `ValidationError`.
+ * Install/update the project's custom connector definitions, then install any
+ * *bundled* connectors referenced by an auth-profile / connection (the server
+ * only resolves *installed* defs in `create_auth_profile` / `create_feed`, not
+ * the catalog). Returns the fresh connector-definition catalog so config
+ * validation runs against the now-current schemas — fixing the "validate
+ * against stale remote schema before installing the local connector" bug.
+ *
+ * SECURITY: `install_connector` compiles + imports + instantiates the connector
+ * runtime class on the gateway. Custom connector source must already have been
+ * confirmed by the operator (see `confirmCustomConnectorSource`). The CLI
+ * fetches `source_url` content client-side (no gateway-side fetch from a
+ * manifest URL) — see `materializeConnectorSource`.
+ * TODO(security): the server-side connector compiler/metadata-extractor still
+ * runs with full gateway env/fs/network and only blocks relative imports — it
+ * should run sandboxed (no secrets, restricted fs/net, block node:* / dynamic
+ * import / require). Tracked separately; out of scope for this PR.
  */
+async function installConnectorDefinitions(
+  client: ApplyClient,
+  state: DesiredState,
+  catalog: RemoteConnectorDefinition[]
+): Promise<RemoteConnectorDefinition[]> {
+  const installedKeys = new Set(
+    catalog.filter((d) => d.installed).map((d) => d.key)
+  );
+  let mutated = false;
+
+  for (const def of state.connectors.definitions) {
+    const result =
+      def.sourceCode !== undefined
+        ? await client.installConnector({ sourceCode: def.sourceCode })
+        : await client.installConnector({ sourceUrl: def.sourceUrl });
+    mutated = true;
+    printText(
+      renderProgress(
+        "update",
+        "connector-definition",
+        result.connectorKey || def.key || def.sourceFile,
+        result.updated ? "(installed)" : "(unchanged)"
+      )
+    );
+  }
+
+  // Bundled connectors referenced by an auth-profile / connection.
+  const catalogByKey = new Map(
+    catalog.filter((d) => d.installable && d.source_uri).map((d) => [d.key, d])
+  );
+  const referenced = new Set<string>([
+    ...state.connectors.authProfiles.map((p) => p.connector),
+    ...state.connectors.connections.map((c) => c.connector),
+  ]);
+  for (const key of [...referenced].sort()) {
+    if (installedKeys.has(key)) continue;
+    const entry = catalogByKey.get(key);
+    if (!entry?.source_uri) continue; // custom local-only — handled above
+    const result = await client.installConnector({
+      sourceUri: entry.source_uri,
+    });
+    mutated = true;
+    printText(
+      renderProgress(
+        "update",
+        "connector-definition",
+        result.connectorKey || key,
+        result.updated ? "(installed bundled)" : "(bundled — unchanged)"
+      )
+    );
+  }
+
+  return mutated ? await client.listConnectorDefinitions(true) : catalog;
+}
+
+// ── Connector validation (against the now-current catalog) ─────────────────
+
 function validateConnectorState(
   state: DesiredState,
-  remote: RemoteSnapshot
+  connectorDefinitions: RemoteConnectorDefinition[]
 ): void {
   const defByKey = new Map<string, RemoteConnectorDefinition>(
-    remote.connectorDefinitions.map((d) => [d.key, d])
+    connectorDefinitions.map((d) => [d.key, d])
   );
   const authProfilesBySlug = new Map(
     state.connectors.authProfiles.map((p) => [p.slug, p])
@@ -169,7 +233,65 @@ function validateConnectorState(
   }
 }
 
-// ── Apply executor ─────────────────────────────────────────────────────────
+// ── source_url fetched client-side; security confirmation gate ─────────────
+
+async function materializeConnectorSource(
+  defs: DesiredConnectorDefinition[],
+  fetchImpl: typeof fetch
+): Promise<void> {
+  for (const def of defs) {
+    if (def.sourceCode !== undefined || !def.sourceUrl) continue;
+    let res: Response;
+    try {
+      res = await fetchImpl(def.sourceUrl);
+    } catch (err) {
+      throw new ValidationError(
+        `${def.sourceFile}: failed to fetch connector source_url ${def.sourceUrl} — ${err instanceof Error ? err.message : String(err)}`
+      );
+    }
+    if (!res.ok) {
+      throw new ValidationError(
+        `${def.sourceFile}: connector source_url ${def.sourceUrl} returned HTTP ${res.status} ${res.statusText}`
+      );
+    }
+    def.sourceCode = await res.text();
+    if (!def.sourceCode.trim()) {
+      throw new ValidationError(
+        `${def.sourceFile}: connector source_url ${def.sourceUrl} returned an empty body`
+      );
+    }
+  }
+}
+
+async function confirmCustomConnectorSource(
+  defs: DesiredConnectorDefinition[],
+  yes: boolean
+): Promise<void> {
+  if (defs.length === 0) return;
+  printText(
+    chalk.yellow(
+      `\n  ⚠ This project ships ${defs.length} custom connector source file${defs.length === 1 ? "" : "s"}:`
+    )
+  );
+  for (const def of defs) {
+    printText(
+      chalk.yellow(
+        `    - ${def.sourceFile}${def.sourceUrl ? ` (from ${def.sourceUrl})` : ""}`
+      )
+    );
+  }
+  printText(
+    chalk.yellow(
+      "  `lobu apply` will upload this source and the gateway will COMPILE and EXECUTE it.\n  Only proceed if you trust this code."
+    )
+  );
+  const ok = await confirmCustomConnectors(yes);
+  if (!ok) {
+    throw new ValidationError("Cancelled — custom connectors not confirmed.");
+  }
+}
+
+// ── Apply executor (auth profiles → connections → feeds) ───────────────────
 
 interface ApplyContext {
   client: ApplyClient;
@@ -178,25 +300,10 @@ interface ApplyContext {
   remote: RemoteSnapshot;
 }
 
-interface PendingAuthEntry {
-  slug: string;
-  kind: string;
-  connectUrl?: string;
-}
-
-/**
- * Execute the plan in dependency order:
- *   agents → settings → platforms → entity types → relationship types →
- *   watchers → connector definitions → auth profiles → connections (+ feeds)
- *
- * No retry loop, no topological sort. First failure prints partial progress
- * and re-throws. Returns the post-apply punch-list (pending interactive-auth
- * profiles + informational notes).
- */
 async function executePlan(
-  ctx: ApplyContext
-): Promise<{ pendingAuth: PendingAuthEntry[] }> {
-  const pendingAuth: PendingAuthEntry[] = [];
+  ctx: ApplyContext,
+  pendingAuth: PendingAuthEntry[]
+): Promise<void> {
   const rowsByKind = (kind: DiffRow["kind"]) =>
     ctx.plan.rows.filter(
       (row) => row.kind === kind && row.verb !== "noop" && row.verb !== "drift"
@@ -292,86 +399,30 @@ async function executePlan(
     printText(renderProgress(row.verb, "watcher", row.id));
   }
 
-  // 7) Connector definitions (idempotent install — server compiles the source)
-  for (const row of rowsByKind("connector-definition")) {
-    if (row.kind !== "connector-definition") continue;
-    if (!row.desired) continue;
-    const def = row.desired;
-    const result = await ctx.client.installConnector(
-      def.sourceCode !== undefined
-        ? { sourceCode: def.sourceCode }
-        : { sourceUrl: def.sourceUrl }
-    );
-    printText(
-      renderProgress(
-        "create",
-        "connector-definition",
-        result.connectorKey || def.key || def.sourceFile,
-        result.updated ? "(installed)" : "(unchanged)"
-      )
-    );
-  }
+  // Connector definitions are installed in phase 1 (before validation), so no
+  // `connector-definition` rows are executed here.
 
-  // 7b) Bundled connectors referenced by an auth profile / connection must be
-  //     installed into the org before `create_auth_profile` (which only finds
-  //     installed defs, not the catalog). Install from the catalog's
-  //     server-side source URI; skip ones already installed or custom.
-  {
-    const installedKeys = new Set(
-      (ctx.remote.connectorDefinitions ?? [])
-        .filter((d) => d.installed)
-        .map((d) => d.key)
-    );
-    const catalogByKey = new Map(
-      (ctx.remote.connectorDefinitions ?? [])
-        .filter((d) => d.installable && d.source_uri)
-        .map((d) => [d.key, d])
-    );
-    const referenced = new Set<string>([
-      ...ctx.state.connectors.authProfiles.map((p) => p.connector),
-      ...ctx.state.connectors.connections.map((c) => c.connector),
-    ]);
-    for (const key of [...referenced].sort()) {
-      if (installedKeys.has(key)) continue;
-      const catalog = catalogByKey.get(key);
-      if (!catalog?.source_uri) continue; // custom local-only connector handled above
-      const result = await ctx.client.installConnector({
-        sourceUri: catalog.source_uri,
-      });
-      printText(
-        renderProgress(
-          "create",
-          "connector-definition",
-          result.connectorKey || key,
-          result.updated ? "(installed bundled)" : "(bundled — unchanged)"
-        )
-      );
-    }
-  }
-
-  // 8) Auth profiles (create / update; interactive kinds → punch-list)
+  // 7) Auth profiles (create / update; interactive kinds → punch-list)
   for (const row of rowsByKind("auth-profile")) {
     if (row.kind !== "auth-profile") continue;
     const desired = ctx.state.connectors.authProfiles.find(
       (p) => p.slug === row.id
     );
     if (!desired) continue;
-    let result;
-    if (row.verb === "create") {
-      result = await ctx.client.createAuthProfile({
-        slug: desired.slug,
-        connector: desired.connector,
-        kind: desired.kind,
-        name: desired.name,
-        credentials: desired.credentials,
-      });
-    } else {
-      result = await ctx.client.updateAuthProfile({
-        slug: desired.slug,
-        name: desired.name,
-        credentials: desired.credentials,
-      });
-    }
+    const result =
+      row.verb === "create"
+        ? await ctx.client.createAuthProfile({
+            slug: desired.slug,
+            connector: desired.connector,
+            kind: desired.kind,
+            name: desired.name,
+            credentials: desired.credentials,
+          })
+        : await ctx.client.updateAuthProfile({
+            slug: desired.slug,
+            name: desired.name,
+            credentials: desired.credentials,
+          });
     if (
       (desired.kind === "oauth_account" ||
         desired.kind === "browser_session") &&
@@ -385,27 +436,8 @@ async function executePlan(
     }
     printText(renderProgress(row.verb, "auth-profile", row.id));
   }
-  // Interactive-auth profiles that were unchanged but still pending — re-issue
-  // a connect token so the operator gets a fresh URL.
-  for (const row of ctx.plan.rows) {
-    if (row.kind !== "auth-profile" || row.verb !== "noop") continue;
-    if (!row.needsAuth || !row.desired) continue;
-    if (pendingAuth.some((p) => p.slug === row.desired?.slug)) continue;
-    let connectUrl: string | undefined;
-    if (row.desired.kind === "oauth_account") {
-      connectUrl = await ctx.client
-        .reconnectAuthProfile(row.desired.slug)
-        .catch(() => undefined);
-    }
-    pendingAuth.push({
-      slug: row.desired.slug,
-      kind: row.desired.kind,
-      ...(connectUrl ? { connectUrl } : {}),
-    });
-  }
 
-  // 9) Connections, keyed by slug. Track resolved connection IDs (existing or
-  //    just-created) so feed sync can address them afterwards.
+  // 8) Connections, keyed by slug.
   const remoteConnBySlug = new Map(
     ctx.remote.connections.map((c) => [c.slug, c])
   );
@@ -441,7 +473,7 @@ async function executePlan(
     printText(renderProgress(row.verb, "connection", row.id));
   }
 
-  // 10) Feeds (per connection — covers feeds whose connection itself was a noop)
+  // 9) Feeds (per connection — covers feeds whose connection itself was a noop)
   for (const row of rowsByKind("feed")) {
     if (row.kind !== "feed") continue;
     if (!row.desired) continue;
@@ -475,15 +507,45 @@ async function executePlan(
     }
     printText(renderProgress(row.verb, "feed", row.id));
   }
+}
 
-  return { pendingAuth };
+// Collect pending interactive-auth profiles from a (no-op) plan and re-issue a
+// fresh connect URL — used both when "nothing to apply" and on partial failure.
+async function collectPendingAuthFromPlan(
+  client: ApplyClient,
+  plan: DiffPlan,
+  already: PendingAuthEntry[]
+): Promise<PendingAuthEntry[]> {
+  const out = [...already];
+  for (const row of plan.rows) {
+    if (row.kind !== "auth-profile" || !("needsAuth" in row) || !row.needsAuth)
+      continue;
+    if (!row.desired) continue;
+    if (out.some((p) => p.slug === row.desired?.slug)) continue;
+    let connectUrl: string | undefined;
+    if (row.desired.kind === "oauth_account") {
+      connectUrl = await client
+        .reconnectAuthProfile(row.desired.slug)
+        .catch(() => undefined);
+    }
+    out.push({
+      slug: row.desired.slug,
+      kind: row.desired.kind,
+      ...(connectUrl ? { connectUrl } : {}),
+    });
+  }
+  return out;
 }
 
 // ── Top-level command ──────────────────────────────────────────────────────
 
 export async function applyCommand(opts: ApplyOptions = {}): Promise<void> {
   const cwd = opts.cwd ?? process.cwd();
-  const { state, configPath } = await loadDesiredState({ cwd });
+  const fetchImpl = opts.fetchImpl ?? fetch;
+  const { state, configPath } = await loadDesiredState({
+    cwd,
+    ...(opts.only ? { only: opts.only } : {}),
+  });
 
   printText(chalk.dim(`Config: ${configPath}`));
 
@@ -533,11 +595,41 @@ export async function applyCommand(opts: ApplyOptions = {}): Promise<void> {
     }
   }
 
+  // SECURITY (#2): fetch any `source_url` connector content client-side so the
+  // gateway never fetches a URL from a project manifest, then require explicit
+  // confirmation before uploading custom connector source for compilation.
+  await materializeConnectorSource(state.connectors.definitions, fetchImpl);
+  if (!opts.dryRun) {
+    await confirmCustomConnectorSource(
+      state.connectors.definitions,
+      opts.yes ?? false
+    );
+  }
+
+  // Snapshot the remote state.
   const remote = await fetchRemoteSnapshot(client, state, opts.only);
-  // Validate connector configs against the connector definitions the server
-  // knows about — fails loud before any mutation.
-  validateConnectorState(state, remote);
-  const plan = computeDiff(state, remote, { only: opts.only });
+
+  // Phase 1 (#5): install/update connector definitions FIRST, then refetch the
+  // connector-definition catalog so validation runs against current schemas.
+  let connectorDefinitions = remote.connectorDefinitions;
+  if (!opts.dryRun && !opts.only) {
+    connectorDefinitions = await installConnectorDefinitions(
+      client,
+      state,
+      remote.connectorDefinitions
+    );
+  }
+
+  // Validate connection / auth-profile config against the (now-current) catalog.
+  validateConnectorState(state, connectorDefinitions);
+
+  // Diff using the refreshed catalog (so an updated custom connector's new
+  // schema is what the connection config is checked against).
+  const diffSnapshot: RemoteSnapshot = {
+    ...remote,
+    connectorDefinitions,
+  };
+  const plan = computeDiff(state, diffSnapshot, { only: opts.only });
 
   printText(renderPlan(plan));
 
@@ -546,15 +638,19 @@ export async function applyCommand(opts: ApplyOptions = {}): Promise<void> {
     return;
   }
 
-  if (plan.counts.create === 0 && plan.counts.update === 0) {
+  const hasPendingAuth = plan.rows.some(
+    (r) => r.kind === "auth-profile" && "needsAuth" in r && r.needsAuth
+  );
+
+  if (plan.counts.create === 0 && plan.counts.update === 0 && !hasPendingAuth) {
     printText(chalk.green("\nNothing to apply."));
     return;
   }
 
-  // Build a plain-text summary for the inquirer prompt — chalk-decorated
-  // text confuses some terminals when re-printed by the prompt library.
+  // Confirm the plan (unless --yes). Even a plan with only pending-auth rows
+  // is "actionable" — we re-issue connect tokens.
   const { create, update, noop, drift } = plan.counts;
-  const summaryLine = `${create} create, ${update} update, ${noop} noop, ${drift} drift`;
+  const summaryLine = `${create} create, ${update} update, ${noop} noop, ${drift} drift${hasPendingAuth ? " + pending auth" : ""}`;
   const approved = await confirmPlan({
     yes: opts.yes ?? false,
     summaryLine,
@@ -564,26 +660,37 @@ export async function applyCommand(opts: ApplyOptions = {}): Promise<void> {
     return;
   }
 
-  printText(chalk.bold("\nApplying:"));
-  try {
-    const { pendingAuth } = await executePlan({ client, state, plan, remote });
-    printText(chalk.green("\nApply complete."));
-    const punchList = renderPostApplyPunchList({
-      pendingAuth,
-      notes: plan.notes,
-    });
-    if (punchList) printText(punchList);
-  } catch (err) {
-    if (err instanceof ApiError) {
-      printError(`\n${err.message}`);
-    } else if (err instanceof Error) {
-      printError(`\n${err.message}`);
-    } else {
-      printError(`\n${String(err)}`);
+  const pendingAuth: PendingAuthEntry[] = [];
+  let applyErr: unknown;
+  if (plan.counts.create > 0 || plan.counts.update > 0) {
+    printText(chalk.bold("\nApplying:"));
+    try {
+      await executePlan(
+        { client, state, plan, remote: diffSnapshot },
+        pendingAuth
+      );
+      printText(chalk.green("\nApply complete."));
+    } catch (err) {
+      applyErr = err;
+      printError(`\n${err instanceof Error ? err.message : String(err)}`);
+      printError(
+        "Apply halted on first failure. Re-run `lobu apply` once the underlying issue is resolved — every endpoint is idempotent."
+      );
     }
-    printError(
-      "Apply halted on first failure. Re-run `lobu apply` once the underlying issue is resolved — every endpoint is idempotent."
-    );
-    throw err;
   }
+
+  // Always render the punch-list — even on partial failure, so the operator
+  // keeps the connect URLs and the informational notes.
+  const finalPending = await collectPendingAuthFromPlan(
+    client,
+    plan,
+    pendingAuth
+  );
+  const punchList = renderPostApplyPunchList({
+    pendingAuth: finalPending,
+    notes: plan.notes,
+  });
+  if (punchList) printText(punchList);
+
+  if (applyErr) throw applyErr;
 }

--- a/packages/cli/src/commands/_lib/apply/apply-cmd.ts
+++ b/packages/cli/src/commands/_lib/apply/apply-cmd.ts
@@ -66,6 +66,48 @@ function checkRequiredSecrets(state: DesiredState): { missing: string[] } {
 const CONNECTOR_SOURCE_MAX_BYTES = 2 * 1024 * 1024; // 2 MiB
 const CONNECTOR_SOURCE_FETCH_TIMEOUT_MS = 15_000;
 
+/**
+ * Read a response body as a stream, counting *bytes* and aborting as soon as
+ * the running total exceeds `maxBytes` — before buffering the rest. Decodes to
+ * UTF-8 text only after the (bounded) body is in hand. Exported for testing.
+ */
+export async function readBoundedBody(
+  res: Response,
+  maxBytes: number,
+  onOverflow: () => never
+): Promise<string> {
+  const reader = res.body?.getReader();
+  if (!reader) {
+    // No streaming body (rare; e.g. a mock). Fall back to text() + a byte check.
+    const text = await res.text();
+    if (Buffer.byteLength(text, "utf8") > maxBytes) onOverflow();
+    return text;
+  }
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      if (value) {
+        total += value.byteLength;
+        if (total > maxBytes) {
+          await reader.cancel().catch(() => undefined);
+          onOverflow();
+        }
+        chunks.push(value);
+      }
+    }
+  } finally {
+    try {
+      reader.releaseLock?.();
+    } catch {
+      // already released by cancel() — ignore
+    }
+  }
+  return Buffer.concat(chunks.map((c) => Buffer.from(c))).toString("utf8");
+}
+
 async function materializeConnectorSource(
   defs: DesiredConnectorDefinition[],
   fetchImpl: typeof fetch
@@ -86,41 +128,51 @@ async function materializeConnectorSource(
       );
     }
     const controller = new AbortController();
+    // Single timer covering the whole exchange — connect AND body consumption.
     const timer = setTimeout(
       () => controller.abort(),
       CONNECTOR_SOURCE_FETCH_TIMEOUT_MS
     );
-    let res: Response;
+    let body: string;
     try {
-      res = await fetchImpl(def.sourceUrl, { signal: controller.signal });
-    } catch (err) {
-      throw new ValidationError(
-        `${def.sourceFile}: failed to fetch connector source_url ${def.sourceUrl} — ${err instanceof Error ? err.message : String(err)}`
-      );
+      let res: Response;
+      try {
+        res = await fetchImpl(def.sourceUrl, { signal: controller.signal });
+      } catch (err) {
+        throw new ValidationError(
+          `${def.sourceFile}: failed to fetch connector source_url ${def.sourceUrl} — ${err instanceof Error ? err.message : String(err)}`
+        );
+      }
+      if (!res.ok) {
+        throw new ValidationError(
+          `${def.sourceFile}: connector source_url ${def.sourceUrl} returned HTTP ${res.status} ${res.statusText}`
+        );
+      }
+      const contentType = (res.headers.get("content-type") ?? "").toLowerCase();
+      if (
+        contentType &&
+        !/(text\/|application\/(typescript|javascript|x-typescript|octet-stream))/.test(
+          contentType
+        )
+      ) {
+        throw new ValidationError(
+          `${def.sourceFile}: connector source_url ${def.sourceUrl} returned unexpected content-type "${contentType}" — expected text/*, application/typescript, or application/javascript`
+        );
+      }
+      try {
+        body = await readBoundedBody(res, CONNECTOR_SOURCE_MAX_BYTES, () => {
+          throw new ValidationError(
+            `${def.sourceFile}: connector source_url ${def.sourceUrl} body exceeds the ${CONNECTOR_SOURCE_MAX_BYTES}-byte cap`
+          );
+        });
+      } catch (err) {
+        if (err instanceof ValidationError) throw err;
+        throw new ValidationError(
+          `${def.sourceFile}: failed to read connector source_url ${def.sourceUrl} — ${err instanceof Error ? err.message : String(err)}`
+        );
+      }
     } finally {
       clearTimeout(timer);
-    }
-    if (!res.ok) {
-      throw new ValidationError(
-        `${def.sourceFile}: connector source_url ${def.sourceUrl} returned HTTP ${res.status} ${res.statusText}`
-      );
-    }
-    const contentType = (res.headers.get("content-type") ?? "").toLowerCase();
-    if (
-      contentType &&
-      !/(text\/|application\/(typescript|javascript|x-typescript|octet-stream))/.test(
-        contentType
-      )
-    ) {
-      throw new ValidationError(
-        `${def.sourceFile}: connector source_url ${def.sourceUrl} returned unexpected content-type "${contentType}" — expected text/*, application/typescript, or application/javascript`
-      );
-    }
-    const body = await res.text();
-    if (body.length > CONNECTOR_SOURCE_MAX_BYTES) {
-      throw new ValidationError(
-        `${def.sourceFile}: connector source_url ${def.sourceUrl} body is ${body.length} bytes — exceeds the ${CONNECTOR_SOURCE_MAX_BYTES}-byte cap`
-      );
     }
     if (!body.trim()) {
       throw new ValidationError(
@@ -256,6 +308,17 @@ async function installConnectorDefinitions(
   const installedKeys = new Set(
     catalog.filter((d) => d.installed).map((d) => d.key)
   );
+  // Connector keys this project supplies its own source for — these must NEVER
+  // be replaced by a bundled `source_uri` install, even if a bundled connector
+  // shares the key. (`null` keys — auto-discovered `*.connector.ts` whose key
+  // the server resolves at compile time — are added to this set below as soon
+  // as `install_connector` returns the resolved key, so the bundled loop can't
+  // race them either.)
+  const locallySuppliedKeys = new Set<string>(
+    state.connectors.definitions
+      .map((d) => d.key)
+      .filter((k): k is string => !!k)
+  );
   let mutated = false;
 
   // Iterate the plan's connector-definition rows so progress mirrors the plan.
@@ -268,6 +331,10 @@ async function installConnectorDefinitions(
       def.sourceCode !== undefined
         ? await client.installConnector({ sourceCode: def.sourceCode })
         : await client.installConnector({ sourceUrl: def.sourceUrl });
+    if (result.connectorKey) {
+      locallySuppliedKeys.add(result.connectorKey);
+      installedKeys.add(result.connectorKey);
+    }
     mutated = true;
     printText(
       renderProgress(
@@ -279,7 +346,10 @@ async function installConnectorDefinitions(
     );
   }
 
-  // Bundled connectors referenced by an auth-profile / connection.
+  // Bundled connectors referenced by an auth-profile / connection — installed
+  // ONLY if the org doesn't already have that key (installed in a prior apply
+  // or just installed from local source above). A locally-supplied key is never
+  // overwritten by the bundled `source_uri`.
   const catalogByKey = new Map(
     catalog.filter((d) => d.installable && d.source_uri).map((d) => [d.key, d])
   );
@@ -288,7 +358,7 @@ async function installConnectorDefinitions(
     ...state.connectors.connections.map((c) => c.connector),
   ]);
   for (const key of [...referenced].sort()) {
-    if (installedKeys.has(key)) continue;
+    if (installedKeys.has(key) || locallySuppliedKeys.has(key)) continue;
     const entry = catalogByKey.get(key);
     if (!entry?.source_uri) continue; // custom local-only — handled above
     const result = await client.installConnector({
@@ -310,9 +380,19 @@ async function installConnectorDefinitions(
 
 // ── Connector config validation (against a given catalog) ──────────────────
 
-function validateConnectorState(
+/**
+ * Validate connection / auth-profile config against the connector definitions
+ * the server knows about. When `skipSchemaForConnectorKeys` is given, those
+ * connector keys (the locally-declared `*.connector.ts` / `type: connector`
+ * ones) get only the structural checks here — full JSON-schema validation runs
+ * later, after install + catalog refetch, against the *fresh* schemas. This
+ * avoids rejecting a connection's config against a stale installed schema when
+ * the same apply updates that connector.
+ */
+export function validateConnectorState(
   state: DesiredState,
-  connectorDefinitions: RemoteConnectorDefinition[]
+  connectorDefinitions: RemoteConnectorDefinition[],
+  skipSchemaForConnectorKeys?: ReadonlySet<string>
 ): void {
   const defByKey = new Map<string, RemoteConnectorDefinition>(
     connectorDefinitions.map((d) => [d.key, d])
@@ -320,21 +400,34 @@ function validateConnectorState(
   const authProfilesBySlug = new Map(
     state.connectors.authProfiles.map((p) => [p.slug, p])
   );
+  const schemasFor = (connectorKey: string) => {
+    if (skipSchemaForConnectorKeys?.has(connectorKey)) return null;
+    const def = defByKey.get(connectorKey);
+    return def ? resolveConnectorSchemas(def) : null;
+  };
   for (const profile of state.connectors.authProfiles) {
-    const def = defByKey.get(profile.connector);
-    validateAuthProfileAgainstConnector(
-      profile,
-      def ? resolveConnectorSchemas(def) : null
-    );
+    validateAuthProfileAgainstConnector(profile, schemasFor(profile.connector));
   }
   for (const connection of state.connectors.connections) {
-    const def = defByKey.get(connection.connector);
     validateConnectionAgainstConnector(
       connection,
       authProfilesBySlug,
-      def ? resolveConnectorSchemas(def) : null
+      schemasFor(connection.connector)
     );
   }
+}
+
+// Connector keys declared locally (`*.connector.ts` / `type: connector`).
+// We don't know the key for an auto-discovered `*.connector.ts` until the
+// server compiles it — those have `key === null` — so they can't be in the
+// skip set; their connections are validated only after install (when the key
+// is known and the def is in the refreshed catalog).
+export function locallyDeclaredConnectorKeys(state: DesiredState): Set<string> {
+  return new Set(
+    state.connectors.definitions
+      .map((d) => d.key)
+      .filter((k): k is string => !!k)
+  );
 }
 
 // ── Apply executor ─────────────────────────────────────────────────────────
@@ -354,6 +447,25 @@ async function executePlan(
     ctx.plan.rows.filter(
       (row) => row.kind === kind && row.verb !== "noop" && row.verb !== "drift"
     );
+
+  // 0) Connector definitions FIRST — install/update them (the plan was already
+  //    confirmed), refetch the catalog, then re-validate connection/feed config
+  //    against the now-current schemas. Doing this before any other resource
+  //    means a post-install schema rejection halts apply before mutating
+  //    anything unrelated.
+  const hasConnectorWork =
+    ctx.state.connectors.definitions.length > 0 ||
+    ctx.state.connectors.authProfiles.length > 0 ||
+    ctx.state.connectors.connections.length > 0;
+  if (hasConnectorWork) {
+    const freshCatalog = await installConnectorDefinitions(
+      ctx.client,
+      ctx.state,
+      ctx.remote.connectorDefinitions,
+      ctx.plan
+    );
+    validateConnectorState(ctx.state, freshCatalog);
+  }
 
   // 1) Agents
   for (const row of rowsByKind("agent")) {
@@ -445,25 +557,7 @@ async function executePlan(
     printText(renderProgress(row.verb, "watcher", row.id));
   }
 
-  // 7) Connector definitions (install — happens AFTER the plan was confirmed),
-  //    then refetch the catalog and validate connection/feed config against the
-  //    now-current schemas (so an updated custom connector's new schema is what
-  //    the connection config is checked against).
-  const hasConnectorWork =
-    ctx.state.connectors.definitions.length > 0 ||
-    ctx.state.connectors.authProfiles.length > 0 ||
-    ctx.state.connectors.connections.length > 0;
-  if (hasConnectorWork) {
-    const freshCatalog = await installConnectorDefinitions(
-      ctx.client,
-      ctx.state,
-      ctx.remote.connectorDefinitions,
-      ctx.plan
-    );
-    validateConnectorState(ctx.state, freshCatalog);
-  }
-
-  // 8) Auth profiles (create / update; interactive kinds → punch-list)
+  // Auth profiles (create / update; interactive kinds → punch-list)
   for (const row of rowsByKind("auth-profile")) {
     if (row.kind !== "auth-profile") continue;
     const desired = ctx.state.connectors.authProfiles.find(
@@ -582,18 +676,27 @@ async function collectPendingAuthFromPlan(
     if (row.kind !== "auth-profile" || !("needsAuth" in row) || !row.needsAuth)
       continue;
     if (!row.desired) continue;
-    if (out.some((p) => p.slug === row.desired?.slug)) continue;
-    let connectUrl: string | undefined;
-    if (row.desired.kind === "oauth_account") {
-      connectUrl = await client
-        .reconnectAuthProfile(row.desired.slug)
+    const desired = row.desired;
+    if (out.some((p) => p.slug === desired.slug)) continue;
+    if (desired.kind === "oauth_account") {
+      // A successful reconnect implies the profile exists remotely (and yields
+      // a fresh connect URL). If it fails, the profile may not exist (a failed
+      // create in a partial apply) — don't tell the operator to go finish auth
+      // for something that isn't there; just skip it.
+      const connectUrl = await client
+        .reconnectAuthProfile(desired.slug)
         .catch(() => undefined);
+      if (!connectUrl) continue;
+      out.push({ slug: desired.slug, kind: desired.kind, connectUrl });
+      continue;
     }
-    out.push({
-      slug: row.desired.slug,
-      kind: row.desired.kind,
-      ...(connectUrl ? { connectUrl } : {}),
-    });
+    // browser_session (no reconnect endpoint): include only if the profile row
+    // actually exists remotely.
+    const exists = await client
+      .getAuthProfileBySlug(desired.slug)
+      .catch(() => null);
+    if (!exists) continue;
+    out.push({ slug: desired.slug, kind: desired.kind });
   }
   return out;
 }
@@ -672,11 +775,17 @@ export async function applyCommand(opts: ApplyOptions = {}): Promise<void> {
   // `executePlan`, AFTER plan confirmation.
   const remote = await fetchRemoteSnapshot(client, state, opts.only);
 
-  // Validate connection/auth-profile config against the catalog we have now.
-  // Connectors that only exist locally (not yet installed) are skipped — the
-  // server validates those on install / create_feed, and `executePlan`
-  // re-validates against the fresh post-install catalog.
-  validateConnectorState(state, remote.connectorDefinitions);
+  // Validate connection/auth-profile config against the catalog we have now,
+  // but SKIP schema validation for connector keys declared locally — those
+  // might update an already-installed schema in this same apply, so they're
+  // schema-validated later (post-install, against the fresh catalog) inside
+  // `executePlan`. Structural checks (auth-slug existence, connector match)
+  // still run here for every connection.
+  validateConnectorState(
+    state,
+    remote.connectorDefinitions,
+    locallyDeclaredConnectorKeys(state)
+  );
 
   const plan = computeDiff(state, remote, { only: opts.only });
   printText(renderPlan(plan));

--- a/packages/cli/src/commands/_lib/apply/apply-cmd.ts
+++ b/packages/cli/src/commands/_lib/apply/apply-cmd.ts
@@ -6,6 +6,8 @@ import { printError, printText } from "../../memory/_lib/output.js";
 import {
   type ApplyClient,
   type RemoteAgent,
+  type RemoteConnectorDefinition,
+  type RemoteFeed,
   type RemotePlatform,
   resolveApplyClient,
 } from "./client.js";
@@ -15,9 +17,20 @@ import {
   type DiffRow,
   type RemoteSnapshot,
 } from "./diff.js";
-import { type DesiredState, loadDesiredState } from "./desired-state.js";
+import {
+  type DesiredState,
+  loadDesiredState,
+  resolveConnectorSchemas,
+  validateAuthProfileAgainstConnector,
+  validateConnectionAgainstConnector,
+} from "./desired-state.js";
 import { confirmPlan } from "./prompt.js";
-import { renderMissingSecrets, renderPlan, renderProgress } from "./render.js";
+import {
+  renderMissingSecrets,
+  renderPlan,
+  renderPostApplyPunchList,
+  renderProgress,
+} from "./render.js";
 
 export interface ApplyOptions {
   cwd?: string;
@@ -84,6 +97,28 @@ async function fetchRemoteSnapshot(
     only === "agents" ? [] : await client.listRelationshipTypes();
   const watchers = only === "agents" ? [] : await client.listWatchers();
 
+  // Connectors run only on a full apply (`--only` skips them).
+  const hasConnectors =
+    state.connectors.definitions.length > 0 ||
+    state.connectors.authProfiles.length > 0 ||
+    state.connectors.connections.length > 0;
+  const connectorDefinitions =
+    only || !hasConnectors ? [] : await client.listConnectorDefinitions(true);
+  const authProfiles =
+    only || !hasConnectors ? [] : await client.listAuthProfiles();
+  const connections =
+    only || !hasConnectors ? [] : await client.listConnections();
+  const feedsByConnectionId = new Map<number, RemoteFeed[]>();
+  if (!only && hasConnectors) {
+    const desiredConnSlugs = new Set(
+      state.connectors.connections.map((c) => c.slug)
+    );
+    for (const conn of connections) {
+      if (!desiredConnSlugs.has(conn.slug)) continue;
+      feedsByConnectionId.set(conn.id, await client.listFeeds(conn.id));
+    }
+  }
+
   return {
     agents,
     agentSettings,
@@ -91,7 +126,47 @@ async function fetchRemoteSnapshot(
     entityTypes,
     relationshipTypes,
     watchers,
+    connectorDefinitions,
+    authProfiles,
+    connections,
+    feedsByConnectionId,
   };
+}
+
+// ── Connector validation ───────────────────────────────────────────────────
+
+/**
+ * Validate declared connections / auth profiles against the connector
+ * definitions the server knows about (bundled catalog + installed custom).
+ * Connectors that only exist as a local `.ts` not yet compiled by the server
+ * are skipped — the server validates those at `install_connector` /
+ * `create_feed` time. Schema mismatches throw `ValidationError`.
+ */
+function validateConnectorState(
+  state: DesiredState,
+  remote: RemoteSnapshot
+): void {
+  const defByKey = new Map<string, RemoteConnectorDefinition>(
+    remote.connectorDefinitions.map((d) => [d.key, d])
+  );
+  const authProfilesBySlug = new Map(
+    state.connectors.authProfiles.map((p) => [p.slug, p])
+  );
+  for (const profile of state.connectors.authProfiles) {
+    const def = defByKey.get(profile.connector);
+    validateAuthProfileAgainstConnector(
+      profile,
+      def ? resolveConnectorSchemas(def) : null
+    );
+  }
+  for (const connection of state.connectors.connections) {
+    const def = defByKey.get(connection.connector);
+    validateConnectionAgainstConnector(
+      connection,
+      authProfilesBySlug,
+      def ? resolveConnectorSchemas(def) : null
+    );
+  }
 }
 
 // ── Apply executor ─────────────────────────────────────────────────────────
@@ -100,14 +175,28 @@ interface ApplyContext {
   client: ApplyClient;
   state: DesiredState;
   plan: DiffPlan;
+  remote: RemoteSnapshot;
+}
+
+interface PendingAuthEntry {
+  slug: string;
+  kind: string;
+  connectUrl?: string;
 }
 
 /**
- * Execute the plan in dependency order. Plan §footgun-7: agents → settings →
- * connections → entity types → relationship types. No retry loop, no
- * topological sort. First failure prints partial progress and re-throws.
+ * Execute the plan in dependency order:
+ *   agents → settings → platforms → entity types → relationship types →
+ *   watchers → connector definitions → auth profiles → connections (+ feeds)
+ *
+ * No retry loop, no topological sort. First failure prints partial progress
+ * and re-throws. Returns the post-apply punch-list (pending interactive-auth
+ * profiles + informational notes).
  */
-async function executePlan(ctx: ApplyContext): Promise<void> {
+async function executePlan(
+  ctx: ApplyContext
+): Promise<{ pendingAuth: PendingAuthEntry[] }> {
+  const pendingAuth: PendingAuthEntry[] = [];
   const rowsByKind = (kind: DiffRow["kind"]) =>
     ctx.plan.rows.filter(
       (row) => row.kind === kind && row.verb !== "noop" && row.verb !== "drift"
@@ -202,6 +291,192 @@ async function executePlan(ctx: ApplyContext): Promise<void> {
     });
     printText(renderProgress(row.verb, "watcher", row.id));
   }
+
+  // 7) Connector definitions (idempotent install — server compiles the source)
+  for (const row of rowsByKind("connector-definition")) {
+    if (row.kind !== "connector-definition") continue;
+    if (!row.desired) continue;
+    const def = row.desired;
+    const result = await ctx.client.installConnector(
+      def.sourceCode !== undefined
+        ? { sourceCode: def.sourceCode }
+        : { sourceUrl: def.sourceUrl }
+    );
+    printText(
+      renderProgress(
+        "create",
+        "connector-definition",
+        result.connectorKey || def.key || def.sourceFile,
+        result.updated ? "(installed)" : "(unchanged)"
+      )
+    );
+  }
+
+  // 7b) Bundled connectors referenced by an auth profile / connection must be
+  //     installed into the org before `create_auth_profile` (which only finds
+  //     installed defs, not the catalog). Install from the catalog's
+  //     server-side source URI; skip ones already installed or custom.
+  {
+    const installedKeys = new Set(
+      (ctx.remote.connectorDefinitions ?? [])
+        .filter((d) => d.installed)
+        .map((d) => d.key)
+    );
+    const catalogByKey = new Map(
+      (ctx.remote.connectorDefinitions ?? [])
+        .filter((d) => d.installable && d.source_uri)
+        .map((d) => [d.key, d])
+    );
+    const referenced = new Set<string>([
+      ...ctx.state.connectors.authProfiles.map((p) => p.connector),
+      ...ctx.state.connectors.connections.map((c) => c.connector),
+    ]);
+    for (const key of [...referenced].sort()) {
+      if (installedKeys.has(key)) continue;
+      const catalog = catalogByKey.get(key);
+      if (!catalog?.source_uri) continue; // custom local-only connector handled above
+      const result = await ctx.client.installConnector({
+        sourceUri: catalog.source_uri,
+      });
+      printText(
+        renderProgress(
+          "create",
+          "connector-definition",
+          result.connectorKey || key,
+          result.updated ? "(installed bundled)" : "(bundled — unchanged)"
+        )
+      );
+    }
+  }
+
+  // 8) Auth profiles (create / update; interactive kinds → punch-list)
+  for (const row of rowsByKind("auth-profile")) {
+    if (row.kind !== "auth-profile") continue;
+    const desired = ctx.state.connectors.authProfiles.find(
+      (p) => p.slug === row.id
+    );
+    if (!desired) continue;
+    let result;
+    if (row.verb === "create") {
+      result = await ctx.client.createAuthProfile({
+        slug: desired.slug,
+        connector: desired.connector,
+        kind: desired.kind,
+        name: desired.name,
+        credentials: desired.credentials,
+      });
+    } else {
+      result = await ctx.client.updateAuthProfile({
+        slug: desired.slug,
+        name: desired.name,
+        credentials: desired.credentials,
+      });
+    }
+    if (
+      (desired.kind === "oauth_account" ||
+        desired.kind === "browser_session") &&
+      result.status !== "active"
+    ) {
+      pendingAuth.push({
+        slug: desired.slug,
+        kind: desired.kind,
+        ...(result.connectUrl ? { connectUrl: result.connectUrl } : {}),
+      });
+    }
+    printText(renderProgress(row.verb, "auth-profile", row.id));
+  }
+  // Interactive-auth profiles that were unchanged but still pending — re-issue
+  // a connect token so the operator gets a fresh URL.
+  for (const row of ctx.plan.rows) {
+    if (row.kind !== "auth-profile" || row.verb !== "noop") continue;
+    if (!row.needsAuth || !row.desired) continue;
+    if (pendingAuth.some((p) => p.slug === row.desired?.slug)) continue;
+    let connectUrl: string | undefined;
+    if (row.desired.kind === "oauth_account") {
+      connectUrl = await ctx.client
+        .reconnectAuthProfile(row.desired.slug)
+        .catch(() => undefined);
+    }
+    pendingAuth.push({
+      slug: row.desired.slug,
+      kind: row.desired.kind,
+      ...(connectUrl ? { connectUrl } : {}),
+    });
+  }
+
+  // 9) Connections, keyed by slug. Track resolved connection IDs (existing or
+  //    just-created) so feed sync can address them afterwards.
+  const remoteConnBySlug = new Map(
+    ctx.remote.connections.map((c) => [c.slug, c])
+  );
+  const connectionIdBySlug = new Map<string, number>(
+    ctx.remote.connections.map((c) => [c.slug, c.id])
+  );
+  for (const row of rowsByKind("connection")) {
+    if (row.kind !== "connection") continue;
+    const desired = ctx.state.connectors.connections.find(
+      (c) => c.slug === row.id
+    );
+    if (!desired) continue;
+    const existing = remoteConnBySlug.get(desired.slug);
+    if (existing && row.verb === "update") {
+      const updated = await ctx.client.updateConnection(existing.id, {
+        name: desired.name,
+        authProfileSlug: desired.authProfileSlug ?? null,
+        appAuthProfileSlug: desired.appAuthProfileSlug ?? null,
+        config: desired.config ?? {},
+      });
+      connectionIdBySlug.set(desired.slug, updated.id);
+    } else {
+      const created = await ctx.client.createConnection({
+        slug: desired.slug,
+        connector: desired.connector,
+        name: desired.name,
+        authProfileSlug: desired.authProfileSlug,
+        appAuthProfileSlug: desired.appAuthProfileSlug,
+        config: desired.config,
+      });
+      connectionIdBySlug.set(desired.slug, created.id);
+    }
+    printText(renderProgress(row.verb, "connection", row.id));
+  }
+
+  // 10) Feeds (per connection — covers feeds whose connection itself was a noop)
+  for (const row of rowsByKind("feed")) {
+    if (row.kind !== "feed") continue;
+    if (!row.desired) continue;
+    const feed = row.desired;
+    const connectionId = connectionIdBySlug.get(row.connectionSlug);
+    if (connectionId === undefined) {
+      throw new ApiError(
+        `feed "${feed.feedKey}" references connection "${row.connectionSlug}" which has no remote ID — connection create may have failed`
+      );
+    }
+    const existingConn = remoteConnBySlug.get(row.connectionSlug);
+    const remoteFeed = existingConn
+      ? (ctx.remote.feedsByConnectionId.get(existingConn.id) ?? []).find(
+          (f) => f.feed_key === feed.feedKey
+        )
+      : undefined;
+    if (remoteFeed && row.verb === "update") {
+      await ctx.client.updateFeed(remoteFeed.id, {
+        name: feed.name,
+        schedule: feed.schedule,
+        config: feed.config ?? {},
+      });
+    } else {
+      await ctx.client.createFeed({
+        connectionId,
+        feedKey: feed.feedKey,
+        name: feed.name,
+        schedule: feed.schedule,
+        config: feed.config,
+      });
+    }
+    printText(renderProgress(row.verb, "feed", row.id));
+  }
+
+  return { pendingAuth };
 }
 
 // ── Top-level command ──────────────────────────────────────────────────────
@@ -259,6 +534,9 @@ export async function applyCommand(opts: ApplyOptions = {}): Promise<void> {
   }
 
   const remote = await fetchRemoteSnapshot(client, state, opts.only);
+  // Validate connector configs against the connector definitions the server
+  // knows about — fails loud before any mutation.
+  validateConnectorState(state, remote);
   const plan = computeDiff(state, remote, { only: opts.only });
 
   printText(renderPlan(plan));
@@ -288,8 +566,13 @@ export async function applyCommand(opts: ApplyOptions = {}): Promise<void> {
 
   printText(chalk.bold("\nApplying:"));
   try {
-    await executePlan({ client, state, plan });
+    const { pendingAuth } = await executePlan({ client, state, plan, remote });
     printText(chalk.green("\nApply complete."));
+    const punchList = renderPostApplyPunchList({
+      pendingAuth,
+      notes: plan.notes,
+    });
+    if (punchList) printText(punchList);
   } catch (err) {
     if (err instanceof ApiError) {
       printError(`\n${err.message}`);

--- a/packages/cli/src/commands/_lib/apply/client.ts
+++ b/packages/cli/src/commands/_lib/apply/client.ts
@@ -59,6 +59,71 @@ export interface UpsertEntityTypeResult {
   noop?: boolean;
 }
 
+// ── Connectors / auth profiles / connections wire types ────────────────────
+
+export interface RemoteConnectorDefinition {
+  key: string;
+  name?: string;
+  version?: string;
+  options_schema?: Record<string, unknown> | null;
+  feeds_schema?: Record<string, unknown> | null;
+  auth_schema?: Record<string, unknown> | null;
+  installed?: boolean;
+  installable?: boolean;
+  catalog_origin?: string;
+  /** `file://` URI of the bundled source on the server host (catalog entries). */
+  source_uri?: string | null;
+}
+
+export interface RemoteAuthProfile {
+  id?: number;
+  slug: string;
+  display_name?: string;
+  connector_key: string;
+  profile_kind: string;
+  status: string;
+}
+
+export interface RemoteConnection {
+  id: number;
+  slug: string;
+  connector_key: string;
+  display_name?: string;
+  status: string;
+  auth_profile_slug?: string | null;
+  app_auth_profile_slug?: string | null;
+  config?: Record<string, unknown> | null;
+}
+
+export interface RemoteFeed {
+  id: number;
+  connection_id: number;
+  feed_key: string;
+  display_name?: string;
+  status: string;
+  schedule?: string | null;
+  config?: Record<string, unknown> | null;
+}
+
+export interface InstallConnectorResult {
+  connectorKey: string;
+  updated: boolean;
+  version?: string;
+}
+
+/**
+ * Result of ensuring an auth profile exists. For interactive kinds
+ * (`oauth_account` / `browser_session`) `connectUrl` carries the URL the
+ * operator must open to complete auth; `status` is the state the server
+ * reports (`pending_auth` until auth completes).
+ */
+export interface EnsureAuthProfileResult {
+  created: boolean;
+  updated: boolean;
+  status?: string;
+  connectUrl?: string;
+}
+
 // ── Shape predicates ───────────────────────────────────────────────────────
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -412,6 +477,314 @@ export class ApplyClient {
       ...(payload.schedule ? { schedule: payload.schedule } : {}),
       ...(payload.sources?.length ? { sources: payload.sources } : {}),
     });
+  }
+
+  // ── Connector definitions ─────────────────────────────────────────────────
+
+  private async connectionsTool<T>(body: Record<string, unknown>): Promise<T> {
+    const { body: parsed } = await this.request<T>(
+      "POST",
+      `/api/${this.orgSlug}/manage_connections`,
+      body
+    );
+    return parsed;
+  }
+
+  private async feedsTool<T>(body: Record<string, unknown>): Promise<T> {
+    const { body: parsed } = await this.request<T>(
+      "POST",
+      `/api/${this.orgSlug}/manage_feeds`,
+      body
+    );
+    return parsed;
+  }
+
+  private async authProfilesTool<T>(body: Record<string, unknown>): Promise<T> {
+    const { body: parsed } = await this.request<T>(
+      "POST",
+      `/api/${this.orgSlug}/manage_auth_profiles`,
+      body
+    );
+    return parsed;
+  }
+
+  /** Installed org connectors + (with `includeInstallable`) the bundled catalog. */
+  async listConnectorDefinitions(
+    includeInstallable = true
+  ): Promise<RemoteConnectorDefinition[]> {
+    const body = await this.connectionsTool<{
+      connector_definitions?: RemoteConnectorDefinition[];
+    }>({
+      action: "list_connector_definitions",
+      include_installable: includeInstallable,
+    });
+    return body.connector_definitions ?? [];
+  }
+
+  /**
+   * Idempotent connector install. The CLI passes raw TypeScript source
+   * (`compiled: false`) or a `source_url`; the server compiles + extracts
+   * metadata and returns the resolved `connectorKey` plus `updated` (false
+   * when the installed code is byte-identical).
+   */
+  async installConnector(payload: {
+    sourceCode?: string;
+    sourceUrl?: string;
+    /** `file://` URI of a bundled connector source on the server host. */
+    sourceUri?: string;
+  }): Promise<InstallConnectorResult> {
+    const body = await this.connectionsTool<{
+      installed?: boolean;
+      connector_key?: string;
+      version?: string;
+      updated?: boolean;
+    }>({
+      action: "install_connector",
+      ...(payload.sourceCode !== undefined
+        ? { source_code: payload.sourceCode, compiled: false }
+        : {}),
+      ...(payload.sourceUrl ? { source_url: payload.sourceUrl } : {}),
+      ...(payload.sourceUri ? { source_uri: payload.sourceUri } : {}),
+    });
+    return {
+      connectorKey: body.connector_key ?? "",
+      updated: body.updated ?? false,
+      ...(body.version ? { version: body.version } : {}),
+    };
+  }
+
+  async uninstallConnector(connectorKey: string): Promise<void> {
+    await this.connectionsTool({
+      action: "uninstall_connector",
+      connector_key: connectorKey,
+    });
+  }
+
+  // ── Auth profiles ─────────────────────────────────────────────────────────
+
+  async listAuthProfiles(): Promise<RemoteAuthProfile[]> {
+    const body = await this.authProfilesTool<{
+      auth_profiles?: RemoteAuthProfile[];
+    }>({ action: "list_auth_profiles" });
+    return body.auth_profiles ?? [];
+  }
+
+  async getAuthProfileBySlug(slug: string): Promise<RemoteAuthProfile | null> {
+    try {
+      const body = await this.authProfilesTool<{
+        auth_profile?: RemoteAuthProfile;
+      }>({ action: "get_auth_profile", auth_profile_slug: slug });
+      return body.auth_profile ?? null;
+    } catch (err) {
+      if (err instanceof ApiError && err.status === 404) return null;
+      throw err;
+    }
+  }
+
+  async createAuthProfile(payload: {
+    slug: string;
+    connector: string;
+    kind: string;
+    name?: string;
+    credentials?: Record<string, string>;
+  }): Promise<EnsureAuthProfileResult> {
+    const body = await this.authProfilesTool<{
+      auth_profile?: { status?: string };
+      connect_url?: string;
+    }>({
+      action: "create_auth_profile",
+      connector_key: payload.connector,
+      profile_kind: payload.kind,
+      display_name: payload.name ?? payload.slug,
+      slug: payload.slug,
+      ...(payload.credentials && Object.keys(payload.credentials).length > 0
+        ? { credentials: payload.credentials }
+        : {}),
+    });
+    return {
+      created: true,
+      updated: false,
+      ...(body.auth_profile?.status
+        ? { status: body.auth_profile.status }
+        : {}),
+      ...(body.connect_url ? { connectUrl: body.connect_url } : {}),
+    };
+  }
+
+  async updateAuthProfile(payload: {
+    slug: string;
+    name?: string;
+    credentials?: Record<string, string>;
+  }): Promise<EnsureAuthProfileResult> {
+    const body = await this.authProfilesTool<{
+      auth_profile?: { status?: string };
+      connect_url?: string;
+    }>({
+      action: "update_auth_profile",
+      auth_profile_slug: payload.slug,
+      ...(payload.name ? { display_name: payload.name } : {}),
+      ...(payload.credentials && Object.keys(payload.credentials).length > 0
+        ? { credentials: payload.credentials }
+        : {}),
+    });
+    return {
+      created: false,
+      updated: true,
+      ...(body.auth_profile?.status
+        ? { status: body.auth_profile.status }
+        : {}),
+      ...(body.connect_url ? { connectUrl: body.connect_url } : {}),
+    };
+  }
+
+  /** Re-issue a connect token for an existing interactive-auth profile. */
+  async reconnectAuthProfile(slug: string): Promise<string | undefined> {
+    const body = await this.authProfilesTool<{ connect_url?: string }>({
+      action: "update_auth_profile",
+      auth_profile_slug: slug,
+      reconnect: true,
+    });
+    return body.connect_url;
+  }
+
+  async deleteAuthProfile(slug: string): Promise<void> {
+    await this.authProfilesTool({
+      action: "delete_auth_profile",
+      auth_profile_slug: slug,
+    });
+  }
+
+  // ── Connections ───────────────────────────────────────────────────────────
+
+  async listConnections(): Promise<RemoteConnection[]> {
+    const body = await this.connectionsTool<{
+      connections?: RemoteConnection[];
+    }>({ action: "list", limit: 500 });
+    return body.connections ?? [];
+  }
+
+  async createConnection(payload: {
+    slug: string;
+    connector: string;
+    name?: string;
+    authProfileSlug?: string;
+    appAuthProfileSlug?: string;
+    config?: Record<string, unknown>;
+  }): Promise<RemoteConnection> {
+    const body = await this.connectionsTool<{ connection?: RemoteConnection }>({
+      action: "create",
+      connector_key: payload.connector,
+      slug: payload.slug,
+      ...(payload.name ? { display_name: payload.name } : {}),
+      ...(payload.authProfileSlug
+        ? { auth_profile_slug: payload.authProfileSlug }
+        : {}),
+      ...(payload.appAuthProfileSlug
+        ? { app_auth_profile_slug: payload.appAuthProfileSlug }
+        : {}),
+      ...(payload.config ? { config: payload.config } : {}),
+    });
+    if (!body.connection) {
+      throw new ApiError(
+        `create connection "${payload.slug}" returned no connection payload`
+      );
+    }
+    return body.connection;
+  }
+
+  async updateConnection(
+    connectionId: number,
+    payload: {
+      name?: string;
+      authProfileSlug?: string | null;
+      appAuthProfileSlug?: string | null;
+      config?: Record<string, unknown>;
+    }
+  ): Promise<RemoteConnection> {
+    const body = await this.connectionsTool<{ connection?: RemoteConnection }>({
+      action: "update",
+      connection_id: connectionId,
+      ...(payload.name !== undefined ? { display_name: payload.name } : {}),
+      ...(payload.authProfileSlug !== undefined
+        ? { auth_profile_slug: payload.authProfileSlug }
+        : {}),
+      ...(payload.appAuthProfileSlug !== undefined
+        ? { app_auth_profile_slug: payload.appAuthProfileSlug }
+        : {}),
+      ...(payload.config !== undefined ? { config: payload.config } : {}),
+    });
+    if (!body.connection) {
+      throw new ApiError(
+        `update connection #${connectionId} returned no connection payload`
+      );
+    }
+    return body.connection;
+  }
+
+  async deleteConnection(connectionId: number): Promise<void> {
+    await this.connectionsTool({
+      action: "delete",
+      connection_id: connectionId,
+    });
+  }
+
+  // ── Feeds (managed per-connection) ────────────────────────────────────────
+
+  async listFeeds(connectionId: number): Promise<RemoteFeed[]> {
+    const body = await this.feedsTool<{ feeds?: RemoteFeed[] }>({
+      action: "list_feeds",
+      connection_id: connectionId,
+      limit: 500,
+    });
+    return body.feeds ?? [];
+  }
+
+  async createFeed(payload: {
+    connectionId: number;
+    feedKey: string;
+    name?: string;
+    schedule?: string;
+    config?: Record<string, unknown>;
+  }): Promise<RemoteFeed> {
+    const body = await this.feedsTool<{ feed?: RemoteFeed }>({
+      action: "create_feed",
+      connection_id: payload.connectionId,
+      feed_key: payload.feedKey,
+      ...(payload.name ? { display_name: payload.name } : {}),
+      ...(payload.schedule ? { schedule: payload.schedule } : {}),
+      ...(payload.config ? { config: payload.config } : {}),
+    });
+    if (!body.feed) {
+      throw new ApiError(
+        `create feed "${payload.feedKey}" returned no feed payload`
+      );
+    }
+    return body.feed;
+  }
+
+  async updateFeed(
+    feedId: number,
+    payload: {
+      name?: string;
+      schedule?: string;
+      config?: Record<string, unknown>;
+    }
+  ): Promise<RemoteFeed> {
+    const body = await this.feedsTool<{ feed?: RemoteFeed }>({
+      action: "update_feed",
+      feed_id: feedId,
+      ...(payload.name !== undefined ? { display_name: payload.name } : {}),
+      ...(payload.schedule !== undefined ? { schedule: payload.schedule } : {}),
+      ...(payload.config !== undefined ? { config: payload.config } : {}),
+    });
+    if (!body.feed) {
+      throw new ApiError(`update feed #${feedId} returned no feed payload`);
+    }
+    return body.feed;
+  }
+
+  async deleteFeed(feedId: number): Promise<void> {
+    await this.feedsTool({ action: "delete_feed", feed_id: feedId });
   }
 }
 

--- a/packages/cli/src/commands/_lib/apply/client.ts
+++ b/packages/cli/src/commands/_lib/apply/client.ts
@@ -711,7 +711,11 @@ export class ApplyClient {
       ...(payload.appAuthProfileSlug !== undefined
         ? { app_auth_profile_slug: payload.appAuthProfileSlug }
         : {}),
-      ...(payload.config !== undefined ? { config: payload.config } : {}),
+      // `lobu apply` is declarative — replace, don't merge, so removed
+      // manifest keys disappear remotely (server defaults to merge).
+      ...(payload.config !== undefined
+        ? { config: payload.config, replace_config: true }
+        : {}),
     });
     if (!body.connection) {
       throw new ApiError(
@@ -775,7 +779,9 @@ export class ApplyClient {
       feed_id: feedId,
       ...(payload.name !== undefined ? { display_name: payload.name } : {}),
       ...(payload.schedule !== undefined ? { schedule: payload.schedule } : {}),
-      ...(payload.config !== undefined ? { config: payload.config } : {}),
+      ...(payload.config !== undefined
+        ? { config: payload.config, replace_config: true }
+        : {}),
     });
     if (!body.feed) {
       throw new ApiError(`update feed #${feedId} returned no feed payload`);

--- a/packages/cli/src/commands/_lib/apply/desired-state.ts
+++ b/packages/cli/src/commands/_lib/apply/desired-state.ts
@@ -15,6 +15,31 @@ import {
   isLoadError,
   loadConfig,
 } from "../../../config/loader.js";
+import { CronExpressionParser } from "cron-parser";
+
+// ── Connector slug / schedule validators (round-2) ─────────────────────────
+// Mirror packages/server/src/utils/connections.ts CONNECTION_SLUG_PATTERN and
+// the server's validateSchedule (packages/server/src/utils/cron.ts) so the CLI
+// fails loud *before* any mutation instead of getting a server 4xx.
+const CONNECTION_SLUG_PATTERN = /^[a-z0-9][a-z0-9-]{0,62}$/;
+// auth_profiles slugs are sanitized server-side; require canonical form so the
+// diff key matches what is stored (server cap is 80 chars).
+const AUTH_PROFILE_SLUG_PATTERN = /^[a-z0-9][a-z0-9-]{0,79}$/;
+const MIN_CRON_INTERVAL_MS = 60_000;
+
+function cronError(schedule: string): string | null {
+  try {
+    const it = CronExpressionParser.parse(schedule);
+    const first = it.next().toDate();
+    const second = it.next().toDate();
+    if (second.getTime() - first.getTime() < MIN_CRON_INTERVAL_MS) {
+      return `schedule "${schedule}" is too frequent (minimum interval is 1 minute)`;
+    }
+    return null;
+  } catch (err) {
+    return `invalid cron expression "${schedule}" — ${err instanceof Error ? err.message : String(err)}`;
+  }
+}
 
 // ── Stable platform IDs (mirror of file-loader.ts) ─────────────────────────
 //
@@ -882,6 +907,11 @@ function parseConnectionDoc(
       `${file}: \`type: connection\` doc is missing a "slug" string`
     );
   }
+  if (!CONNECTION_SLUG_PATTERN.test(slug)) {
+    throw new ValidationError(
+      `${file}: connection slug "${slug}" must match /^[a-z0-9][a-z0-9-]{0,62}$/ (lowercase letters/digits/hyphens, no leading hyphen, ≤63 chars)`
+    );
+  }
   const connector = asString(raw.connector);
   if (!connector) {
     throw new ValidationError(
@@ -937,7 +967,15 @@ function parseConnectionDoc(
       const feedName = asString(entry.name);
       if (feedName) feed.name = feedName;
       const schedule = asString(entry.schedule);
-      if (schedule) feed.schedule = schedule;
+      if (schedule) {
+        const err = cronError(schedule);
+        if (err) {
+          throw new ValidationError(
+            `${file}: connection "${slug}" feed "${feedKey}" ${err}`
+          );
+        }
+        feed.schedule = schedule;
+      }
       if (entry.config !== undefined) {
         if (!isRecord(entry.config)) {
           throw new ValidationError(
@@ -960,6 +998,11 @@ function parseAuthProfileDoc(
   if (!slug) {
     throw new ValidationError(
       `${file}: \`type: auth_profile\` doc is missing a "slug" string`
+    );
+  }
+  if (!AUTH_PROFILE_SLUG_PATTERN.test(slug)) {
+    throw new ValidationError(
+      `${file}: auth_profile slug "${slug}" must match /^[a-z0-9][a-z0-9-]{0,79}$/ (lowercase letters/digits/hyphens, no leading hyphen, ≤80 chars)`
     );
   }
   const connector = asString(raw.connector);
@@ -1191,7 +1234,10 @@ async function loadConnectors(
             sourceFile: rel,
           });
         } else if (parsed.sourcePath) {
-          const abs = resolve(projectRoot, parsed.sourcePath);
+          // `source_path` is resolved relative to the manifest YAML file's
+          // directory (the connectors/ dir), matching the watcher-classifier
+          // `source_path` convention.
+          const abs = resolve(dirPath, parsed.sourcePath);
           if (tsFileDefinitions.has(abs)) {
             // Already auto-discovered; the `type: connector` doc is redundant
             // but harmless — just record the declared key for clearer output.
@@ -1222,11 +1268,20 @@ async function loadConnectors(
     }
   }
 
+  const allDefs = [...definitionsByKey.values(), ...tsFileDefinitions.values()];
+  const seenKeys = new Set<string>();
+  for (const def of allDefs) {
+    if (def.key === null) continue;
+    if (seenKeys.has(def.key)) {
+      throw new ValidationError(
+        `${dirRel}/: connector key "${def.key}" is declared by more than one connector definition (a \`type: connector\` doc and/or a \`*.connector.ts\` file) — keys must be unique`
+      );
+    }
+    seenKeys.add(def.key);
+  }
+
   return {
-    definitions: [
-      ...definitionsByKey.values(),
-      ...tsFileDefinitions.values(),
-    ].sort((a, b) =>
+    definitions: allDefs.sort((a, b) =>
       (a.key ?? a.sourceFile).localeCompare(b.key ?? b.sourceFile)
     ),
     authProfiles: [...authProfiles.values()].sort((a, b) =>
@@ -1243,7 +1298,9 @@ async function loadConnectors(
 export interface ResolvedConnectorSchemas {
   /** Connector key → `optionsSchema` (JSON Schema), if declared. */
   optionsSchema?: Record<string, unknown>;
-  /** Feed key → `configSchema` (JSON Schema). */
+  /** Every feed key declared by the connector (`connector.feeds` keys). */
+  feedKeys: Set<string>;
+  /** Feed key → `configSchema` (JSON Schema), for keys that declare one. */
   feedConfigSchemas: Map<string, Record<string, unknown>>;
   /** Allowed auth-profile kinds for the connector (from `authSchema.methods`). */
   authKinds: Set<string>;
@@ -1299,12 +1356,14 @@ export function resolveConnectorSchemas(
     ("auth_schema" in def ? (def.auth_schema ?? undefined) : undefined) ??
     undefined;
 
+  const feedKeys = new Set<string>();
   const feedConfigSchemas = new Map<string, Record<string, unknown>>();
   if (feedsRaw && typeof feedsRaw === "object") {
     for (const [feedKey, feedDef] of Object.entries(
       feedsRaw as Record<string, FeedDefinition | Record<string, unknown>>
     )) {
       if (!feedDef || typeof feedDef !== "object") continue;
+      feedKeys.add(feedKey);
       const cfg = (feedDef as { configSchema?: unknown }).configSchema;
       if (cfg && typeof cfg === "object") {
         feedConfigSchemas.set(feedKey, cfg as Record<string, unknown>);
@@ -1314,6 +1373,7 @@ export function resolveConnectorSchemas(
 
   return {
     ...(optionsSchema ? { optionsSchema } : {}),
+    feedKeys,
     feedConfigSchemas,
     authKinds: schemaFromAuthMethods(authSchema),
   };
@@ -1376,12 +1436,9 @@ export function validateConnectionAgainstConnector(
   }
   for (const feed of connection.feeds) {
     if (!schemas) continue;
-    if (
-      schemas.feedConfigSchemas.size > 0 &&
-      !schemas.feedConfigSchemas.has(feed.feedKey)
-    ) {
+    if (schemas.feedKeys.size > 0 && !schemas.feedKeys.has(feed.feedKey)) {
       throw new ValidationError(
-        `${connection.sourceFile}: connection "${connection.slug}" references unknown feed "${feed.feedKey}" for connector "${connection.connector}"`
+        `${connection.sourceFile}: connection "${connection.slug}" references unknown feed "${feed.feedKey}" for connector "${connection.connector}" (known feeds: ${[...schemas.feedKeys].sort().join(", ") || "(none)"})`
       );
     }
     const feedSchema = schemas.feedConfigSchemas.get(feed.feedKey);
@@ -1459,6 +1516,12 @@ export interface LoadDesiredStateOptions {
   cwd: string;
   /** Env to resolve `$VAR` refs against; defaults to `process.env`. */
   env?: NodeJS.ProcessEnv;
+  /**
+   * When set, only the named resource family is loaded — `"agents"` and
+   * `"memory"` both skip the `connectors/` dir (and its `$VAR` credential
+   * expansion), so `--only agents` doesn't require connector secrets.
+   */
+  only?: "agents" | "memory";
 }
 
 export async function loadDesiredState(
@@ -1502,12 +1565,9 @@ export async function loadDesiredState(
     opts.cwd
   );
 
-  const connectors = await loadConnectors(
-    config,
-    opts.cwd,
-    env,
-    requiredSecrets
-  );
+  const connectors = opts.only
+    ? { definitions: [], authProfiles: [], connections: [] }
+    : await loadConnectors(config, opts.cwd, env, requiredSecrets);
 
   return {
     state: {

--- a/packages/cli/src/commands/_lib/apply/desired-state.ts
+++ b/packages/cli/src/commands/_lib/apply/desired-state.ts
@@ -1137,6 +1137,10 @@ async function loadConnectors(
   const { parseAllDocuments } = await import("yaml");
 
   const definitionsByKey = new Map<string, DesiredConnectorDefinition>();
+  // Keys explicitly declared by a `type: connector` doc (vs auto-discovered
+  // from a `*.connector.ts` filename). A given connector key may be declared by
+  // at most one such doc — even two docs pointing at the same `source_path`.
+  const connectorDocKeyDeclaredBy = new Map<string, string>();
   // `.connector.ts` files keyed by their *absolute path* — we don't know the
   // connector key until the server compiles them. `type: connector` docs with
   // `source_path:` that point at one of these files just dedupe to the file.
@@ -1237,6 +1241,13 @@ async function loadConnectors(
         authProfiles.set(profile.slug, profile);
       } else if (type === "connector") {
         const parsed = parseConnectorDoc(doc, rel);
+        const priorDoc = connectorDocKeyDeclaredBy.get(parsed.key);
+        if (priorDoc) {
+          throw new ValidationError(
+            `connector key "${parsed.key}" is declared by two \`type: connector\` docs — ${priorDoc} and ${rel}; keys must be unique`
+          );
+        }
+        connectorDocKeyDeclaredBy.set(parsed.key, rel);
         if (parsed.sourceUrl) {
           const prior = definitionsByKey.get(parsed.key);
           if (prior) {

--- a/packages/cli/src/commands/_lib/apply/desired-state.ts
+++ b/packages/cli/src/commands/_lib/apply/desired-state.ts
@@ -1,6 +1,13 @@
 import { readdir, readFile, stat } from "node:fs/promises";
 import { join, resolve } from "node:path";
+import type {
+  ConnectorAuthSchema,
+  ConnectorDefinition,
+  FeedDefinition,
+} from "@lobu/connector-sdk";
 import type { AgentSettings, LobuTomlConfig, TomlAgentEntry } from "@lobu/core";
+import Ajv from "ajv";
+import addFormats from "ajv-formats";
 import { parse as parseToml } from "smol-toml";
 import { ValidationError } from "../../memory/_lib/errors.js";
 import {
@@ -76,6 +83,68 @@ export interface DesiredWatcher {
   sources?: Array<{ name: string; query: string }>;
 }
 
+export interface DesiredFeed {
+  /** Feed key from the connector definition (`FeedDefinition.key`). */
+  feedKey: string;
+  name?: string;
+  schedule?: string;
+  config?: Record<string, unknown>;
+}
+
+export interface DesiredConnection {
+  /** Stable public identifier — diff key. */
+  slug: string;
+  /** Connector key (e.g. `github`, `hackernews`). */
+  connector: string;
+  name?: string;
+  /** Slug of the runtime/account auth profile (`auth:` in the manifest). */
+  authProfileSlug?: string;
+  /** Slug of the OAuth-app auth profile (`app_auth:` in the manifest). */
+  appAuthProfileSlug?: string;
+  config?: Record<string, unknown>;
+  feeds: DesiredFeed[];
+  /** Relative path of the YAML file the doc came from (for error messages). */
+  sourceFile: string;
+}
+
+export type DesiredAuthProfileKind =
+  | "env"
+  | "oauth_app"
+  | "oauth_account"
+  | "browser_session";
+
+export interface DesiredAuthProfile {
+  /** Stable slug — diff key. */
+  slug: string;
+  connector: string;
+  kind: DesiredAuthProfileKind;
+  name?: string;
+  /**
+   * key→value credentials. Values may be `$ENV` references (collected into
+   * `requiredSecrets`). Only meaningful for `kind: env | oauth_app`; must be
+   * absent/empty for `oauth_account | browser_session`.
+   */
+  credentials?: Record<string, string>;
+  sourceFile: string;
+}
+
+export interface DesiredConnectorDefinition {
+  /** Connector key — diff key (`null` until the server compiles a `.ts`). */
+  key: string | null;
+  /** Local `.ts` path (absolute) — mutually exclusive with `sourceUrl`. */
+  sourcePath?: string;
+  /** Remote URL — mutually exclusive with `sourcePath`. */
+  sourceUrl?: string;
+  /**
+   * Raw TypeScript source read from `sourcePath`, pushed verbatim to the
+   * server (which compiles, extracts metadata, and returns the real `key`).
+   * Absent when `sourceUrl` is used.
+   */
+  sourceCode?: string;
+  /** For error messages — the `.connector.ts` file or `type: connector` doc. */
+  sourceFile: string;
+}
+
 export interface DesiredAgent {
   metadata: DesiredAgentMetadata;
   /**
@@ -100,9 +169,20 @@ export interface DesiredState {
   /** Watchers declared as `type: watcher` in `models/*.yaml`. */
   watchers: DesiredWatcher[];
   /**
-   * Names of env vars referenced as `$NAME` anywhere in lobu.toml. The CLI
-   * surfaces these to the user before mutating remote state so missing
-   * secrets fail loud instead of expanding to empty strings.
+   * Data-source connectors declared in `[memory].connectors` dir:
+   * `*.connector.ts` files (+ `type: connector` manifests), `type: connection`
+   * docs, and `type: auth_profile` docs.
+   */
+  connectors: {
+    definitions: DesiredConnectorDefinition[];
+    authProfiles: DesiredAuthProfile[];
+    connections: DesiredConnection[];
+  };
+  /**
+   * Names of env vars referenced as `$NAME` anywhere in lobu.toml or in
+   * connector auth-profile credentials. The CLI surfaces these to the user
+   * before mutating remote state so missing secrets fail loud instead of
+   * expanding to empty strings.
    */
   requiredSecrets: string[];
 }
@@ -779,6 +859,599 @@ async function rejectUnsupportedAgentShapes(cwd: string): Promise<void> {
   }
 }
 
+// ── Connectors (data-source connectors) ───────────────────────────────────
+
+const AUTH_PROFILE_KINDS: ReadonlySet<string> = new Set([
+  "env",
+  "oauth_app",
+  "oauth_account",
+  "browser_session",
+]);
+
+function asString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value : undefined;
+}
+
+function parseConnectionDoc(
+  raw: Record<string, unknown>,
+  file: string
+): DesiredConnection {
+  const slug = asString(raw.slug);
+  if (!slug) {
+    throw new ValidationError(
+      `${file}: \`type: connection\` doc is missing a "slug" string`
+    );
+  }
+  const connector = asString(raw.connector);
+  if (!connector) {
+    throw new ValidationError(
+      `${file}: connection "${slug}" is missing a "connector" key`
+    );
+  }
+  const out: DesiredConnection = {
+    slug,
+    connector,
+    feeds: [],
+    sourceFile: file,
+  };
+  const name = asString(raw.name);
+  if (name) out.name = name;
+  const auth = asString(raw.auth);
+  if (auth) out.authProfileSlug = auth;
+  const appAuth = asString(raw.app_auth);
+  if (appAuth) out.appAuthProfileSlug = appAuth;
+  if (raw.config !== undefined) {
+    if (!isRecord(raw.config)) {
+      throw new ValidationError(
+        `${file}: connection "${slug}" \`config\` must be an object`
+      );
+    }
+    out.config = raw.config;
+  }
+  if (raw.feeds !== undefined) {
+    if (!Array.isArray(raw.feeds)) {
+      throw new ValidationError(
+        `${file}: connection "${slug}" \`feeds\` must be an array`
+      );
+    }
+    const seen = new Set<string>();
+    for (const entry of raw.feeds) {
+      if (!isRecord(entry)) {
+        throw new ValidationError(
+          `${file}: connection "${slug}" feed entries must be objects`
+        );
+      }
+      const feedKey = asString(entry.feed);
+      if (!feedKey) {
+        throw new ValidationError(
+          `${file}: connection "${slug}" feed entry is missing a "feed" key`
+        );
+      }
+      if (seen.has(feedKey)) {
+        throw new ValidationError(
+          `${file}: connection "${slug}" declares feed "${feedKey}" twice`
+        );
+      }
+      seen.add(feedKey);
+      const feed: DesiredFeed = { feedKey };
+      const feedName = asString(entry.name);
+      if (feedName) feed.name = feedName;
+      const schedule = asString(entry.schedule);
+      if (schedule) feed.schedule = schedule;
+      if (entry.config !== undefined) {
+        if (!isRecord(entry.config)) {
+          throw new ValidationError(
+            `${file}: connection "${slug}" feed "${feedKey}" \`config\` must be an object`
+          );
+        }
+        feed.config = entry.config;
+      }
+      out.feeds.push(feed);
+    }
+  }
+  return out;
+}
+
+function parseAuthProfileDoc(
+  raw: Record<string, unknown>,
+  file: string
+): DesiredAuthProfile {
+  const slug = asString(raw.slug);
+  if (!slug) {
+    throw new ValidationError(
+      `${file}: \`type: auth_profile\` doc is missing a "slug" string`
+    );
+  }
+  const connector = asString(raw.connector);
+  if (!connector) {
+    throw new ValidationError(
+      `${file}: auth_profile "${slug}" is missing a "connector" key`
+    );
+  }
+  const kind = asString(raw.kind);
+  if (!kind || !AUTH_PROFILE_KINDS.has(kind)) {
+    throw new ValidationError(
+      `${file}: auth_profile "${slug}" \`kind\` must be one of env|oauth_app|oauth_account|browser_session (got ${JSON.stringify(raw.kind)})`
+    );
+  }
+  const out: DesiredAuthProfile = {
+    slug,
+    connector,
+    kind: kind as DesiredAuthProfileKind,
+    sourceFile: file,
+  };
+  const name = asString(raw.name);
+  if (name) out.name = name;
+  if (raw.credentials !== undefined) {
+    if (!isRecord(raw.credentials)) {
+      throw new ValidationError(
+        `${file}: auth_profile "${slug}" \`credentials\` must be an object`
+      );
+    }
+    const creds: Record<string, string> = {};
+    for (const [k, v] of Object.entries(raw.credentials)) {
+      if (typeof v !== "string") {
+        throw new ValidationError(
+          `${file}: auth_profile "${slug}" credential "${k}" must be a string (use $ENV for secrets)`
+        );
+      }
+      creds[k] = v;
+    }
+    if (kind === "oauth_account" || kind === "browser_session") {
+      if (Object.keys(creds).length > 0) {
+        throw new ValidationError(
+          `${file}: auth_profile "${slug}" has \`kind: ${kind}\` — credentials must not be set; \`lobu apply\` never writes interactive-auth tokens (complete auth via the connect URL).`
+        );
+      }
+    } else {
+      out.credentials = creds;
+    }
+  }
+  return out;
+}
+
+function parseConnectorDoc(
+  raw: Record<string, unknown>,
+  file: string
+): { key: string; sourcePath?: string; sourceUrl?: string } {
+  const key = asString(raw.key);
+  if (!key) {
+    throw new ValidationError(
+      `${file}: \`type: connector\` doc is missing a "key" string`
+    );
+  }
+  const sourcePath = asString(raw.source_path);
+  const sourceUrl = asString(raw.source_url);
+  if (!!sourcePath === !!sourceUrl) {
+    throw new ValidationError(
+      `${file}: connector "${key}" must declare exactly one of \`source_path\` or \`source_url\``
+    );
+  }
+  return {
+    key,
+    ...(sourcePath ? { sourcePath } : {}),
+    ...(sourceUrl ? { sourceUrl } : {}),
+  };
+}
+
+interface LoadedConnectors {
+  definitions: DesiredConnectorDefinition[];
+  authProfiles: DesiredAuthProfile[];
+  connections: DesiredConnection[];
+}
+
+const EMPTY_CONNECTORS: LoadedConnectors = {
+  definitions: [],
+  authProfiles: [],
+  connections: [],
+};
+
+/**
+ * Load the `[memory].connectors` directory:
+ *  - every `*.connector.ts` is auto-discovered as a connector definition
+ *    (raw source pushed to the server, which compiles + extracts the key)
+ *  - `*.yaml` files are multi-doc (`---`-separated); each doc carries
+ *    `version: 1` and a `type:` of `connection`, `auth_profile`, or `connector`
+ *
+ * `connector:` config validation against the connector's `optionsSchema` /
+ * feed `configSchema` / `authSchema` happens later (in `apply-cmd`) once the
+ * remote connector-definition catalog is available — the CLI never compiles
+ * connectors locally.
+ */
+async function loadConnectors(
+  config: LobuTomlConfig,
+  projectRoot: string,
+  env: NodeJS.ProcessEnv,
+  envRefs: Set<string>
+): Promise<LoadedConnectors> {
+  const mem = config.memory;
+  if (!mem || mem.enabled === false) return EMPTY_CONNECTORS;
+  const dirRel = mem.connectors?.trim() || "./connectors";
+  const dirPath = resolve(projectRoot, dirRel);
+
+  let entries: string[];
+  try {
+    entries = (await readdir(dirPath)).sort();
+  } catch {
+    return EMPTY_CONNECTORS;
+  }
+
+  const { parseAllDocuments } = await import("yaml");
+
+  const definitionsByKey = new Map<string, DesiredConnectorDefinition>();
+  // `.connector.ts` files keyed by their *absolute path* — we don't know the
+  // connector key until the server compiles them. `type: connector` docs with
+  // `source_path:` that point at one of these files just dedupe to the file.
+  const tsFileDefinitions = new Map<string, DesiredConnectorDefinition>();
+  const authProfiles = new Map<string, DesiredAuthProfile>();
+  const connections = new Map<string, DesiredConnection>();
+
+  for (const entry of entries) {
+    const entryPath = join(dirPath, entry);
+    let entryStat;
+    try {
+      entryStat = await stat(entryPath);
+    } catch {
+      continue;
+    }
+    if (!entryStat.isFile()) continue;
+
+    // Auto-discovered local connector definition.
+    if (entry.endsWith(".connector.ts")) {
+      const sourceCode = await readFile(entryPath, "utf-8");
+      tsFileDefinitions.set(entryPath, {
+        key: null,
+        sourcePath: entryPath,
+        sourceCode,
+        sourceFile: `${dirRel}/${entry}`,
+      });
+      continue;
+    }
+
+    if (!entry.endsWith(".yaml") && !entry.endsWith(".yml")) continue;
+
+    const rel = `${dirRel}/${entry}`;
+    const raw = await readFile(entryPath, "utf-8");
+    let docs: unknown[];
+    try {
+      docs = parseAllDocuments(raw)
+        .map((doc) => doc.toJSON() as unknown)
+        .filter((doc) => doc !== null && doc !== undefined);
+    } catch (err) {
+      throw new ValidationError(
+        `${rel}: failed to parse YAML — ${err instanceof Error ? err.message : String(err)}`
+      );
+    }
+
+    for (const doc of docs) {
+      if (!isRecord(doc)) {
+        throw new ValidationError(
+          `${rel}: each connectors doc must be a mapping with \`version\` and \`type\``
+        );
+      }
+      const type = asString(doc.type);
+      if (!type) {
+        throw new ValidationError(
+          `${rel}: connectors doc is missing a "type" (connection|auth_profile|connector)`
+        );
+      }
+      if (doc.version !== undefined && doc.version !== 1) {
+        throw new ValidationError(
+          `${rel}: unsupported connectors doc version ${JSON.stringify(doc.version)} (expected 1)`
+        );
+      }
+      if (type === "connection") {
+        const conn = parseConnectionDoc(doc, rel);
+        if (connections.has(conn.slug)) {
+          throw new ValidationError(
+            `${rel}: duplicate connection slug "${conn.slug}"`
+          );
+        }
+        connections.set(conn.slug, conn);
+      } else if (type === "auth_profile") {
+        const profile = parseAuthProfileDoc(doc, rel);
+        if (authProfiles.has(profile.slug)) {
+          throw new ValidationError(
+            `${rel}: duplicate auth_profile slug "${profile.slug}"`
+          );
+        }
+        if (profile.credentials) {
+          // Expand `$ENV` refs in-place (collect them too, so the apply
+          // secrets gate fails loud) — never push literal `$NAME` strings.
+          const resolved: Record<string, string> = {};
+          for (const [k, v] of Object.entries(profile.credentials)) {
+            const ref = asEnvRef(v);
+            if (!ref) {
+              resolved[k] = v;
+              continue;
+            }
+            envRefs.add(ref);
+            const value = env[ref];
+            if (value === undefined || value === "") {
+              throw new ValidationError(
+                `${rel}: auth_profile "${profile.slug}" credential "${k}" references $${ref}, but it is unset or empty in the apply environment`
+              );
+            }
+            resolved[k] = value;
+          }
+          profile.credentials = resolved;
+        }
+        authProfiles.set(profile.slug, profile);
+      } else if (type === "connector") {
+        const parsed = parseConnectorDoc(doc, rel);
+        if (parsed.sourceUrl) {
+          if (definitionsByKey.has(parsed.key)) {
+            throw new ValidationError(
+              `${rel}: duplicate connector key "${parsed.key}"`
+            );
+          }
+          definitionsByKey.set(parsed.key, {
+            key: parsed.key,
+            sourceUrl: parsed.sourceUrl,
+            sourceFile: rel,
+          });
+        } else if (parsed.sourcePath) {
+          const abs = resolve(projectRoot, parsed.sourcePath);
+          if (tsFileDefinitions.has(abs)) {
+            // Already auto-discovered; the `type: connector` doc is redundant
+            // but harmless — just record the declared key for clearer output.
+            const existing = tsFileDefinitions.get(abs);
+            if (existing) existing.key = parsed.key;
+          } else {
+            let sourceCode: string;
+            try {
+              sourceCode = await readFile(abs, "utf-8");
+            } catch {
+              throw new ValidationError(
+                `${rel}: connector "${parsed.key}" \`source_path\` ${parsed.sourcePath} does not exist`
+              );
+            }
+            tsFileDefinitions.set(abs, {
+              key: parsed.key,
+              sourcePath: abs,
+              sourceCode,
+              sourceFile: rel,
+            });
+          }
+        }
+      } else {
+        throw new ValidationError(
+          `${rel}: unknown connectors doc type "${type}" (expected connection|auth_profile|connector)`
+        );
+      }
+    }
+  }
+
+  return {
+    definitions: [
+      ...definitionsByKey.values(),
+      ...tsFileDefinitions.values(),
+    ].sort((a, b) =>
+      (a.key ?? a.sourceFile).localeCompare(b.key ?? b.sourceFile)
+    ),
+    authProfiles: [...authProfiles.values()].sort((a, b) =>
+      a.slug.localeCompare(b.slug)
+    ),
+    connections: [...connections.values()].sort((a, b) =>
+      a.slug.localeCompare(b.slug)
+    ),
+  };
+}
+
+// ── Connector-config validation (used by apply-cmd with remote catalog) ────
+
+export interface ResolvedConnectorSchemas {
+  /** Connector key → `optionsSchema` (JSON Schema), if declared. */
+  optionsSchema?: Record<string, unknown>;
+  /** Feed key → `configSchema` (JSON Schema). */
+  feedConfigSchemas: Map<string, Record<string, unknown>>;
+  /** Allowed auth-profile kinds for the connector (from `authSchema.methods`). */
+  authKinds: Set<string>;
+}
+
+function schemaFromAuthMethods(
+  authSchema: ConnectorAuthSchema | Record<string, unknown> | null | undefined
+): Set<string> {
+  const kinds = new Set<string>();
+  if (!authSchema || typeof authSchema !== "object") return kinds;
+  const methods = (authSchema as { methods?: unknown }).methods;
+  if (!Array.isArray(methods)) return kinds;
+  for (const method of methods) {
+    if (!isRecord(method)) continue;
+    const t = asString(method.type);
+    // ConnectorAuthMethod `type` ∈ env_keys | oauth | browser | interactive | none
+    if (t === "env_keys") kinds.add("env");
+    else if (t === "oauth") {
+      kinds.add("oauth_app");
+      kinds.add("oauth_account");
+    } else if (t === "browser" || t === "interactive") {
+      kinds.add("browser_session");
+    }
+  }
+  return kinds;
+}
+
+/**
+ * Build per-connector validation schemas from a connector definition. Accepts
+ * either a typed `ConnectorDefinition` (from `@lobu/connector-sdk`) or the
+ * snake_cased shape the server's `manage_connections list_connector_definitions`
+ * returns (`options_schema`, `feeds_schema`, `auth_schema`).
+ */
+export function resolveConnectorSchemas(
+  def:
+    | ConnectorDefinition
+    | {
+        options_schema?: Record<string, unknown> | null;
+        feeds_schema?: Record<string, unknown> | null;
+        auth_schema?: Record<string, unknown> | null;
+      }
+): ResolvedConnectorSchemas {
+  const optionsSchema =
+    ("optionsSchema" in def ? def.optionsSchema : undefined) ??
+    ("options_schema" in def ? (def.options_schema ?? undefined) : undefined) ??
+    undefined;
+  const feedsRaw =
+    ("feeds" in def ? def.feeds : undefined) ??
+    ("feeds_schema" in def ? (def.feeds_schema ?? undefined) : undefined) ??
+    undefined;
+  const authSchema =
+    ("authSchema" in def ? def.authSchema : undefined) ??
+    ("auth_schema" in def ? (def.auth_schema ?? undefined) : undefined) ??
+    undefined;
+
+  const feedConfigSchemas = new Map<string, Record<string, unknown>>();
+  if (feedsRaw && typeof feedsRaw === "object") {
+    for (const [feedKey, feedDef] of Object.entries(
+      feedsRaw as Record<string, FeedDefinition | Record<string, unknown>>
+    )) {
+      if (!feedDef || typeof feedDef !== "object") continue;
+      const cfg = (feedDef as { configSchema?: unknown }).configSchema;
+      if (cfg && typeof cfg === "object") {
+        feedConfigSchemas.set(feedKey, cfg as Record<string, unknown>);
+      }
+    }
+  }
+
+  return {
+    ...(optionsSchema ? { optionsSchema } : {}),
+    feedConfigSchemas,
+    authKinds: schemaFromAuthMethods(authSchema),
+  };
+}
+
+let sharedAjv: Ajv | null = null;
+function getAjv(): Ajv {
+  if (!sharedAjv) {
+    sharedAjv = new Ajv({ allErrors: true, strict: false });
+    addFormats(sharedAjv);
+  }
+  return sharedAjv;
+}
+
+function validateAgainstSchema(
+  schema: Record<string, unknown>,
+  value: unknown,
+  context: string
+): void {
+  const ajv = getAjv();
+  let validate;
+  try {
+    validate = ajv.compile(schema);
+  } catch (err) {
+    // A malformed connector schema is the connector author's problem, not the
+    // operator's — surface it but don't block the whole apply on it.
+    throw new ValidationError(
+      `${context}: connector declares an invalid JSON schema — ${err instanceof Error ? err.message : String(err)}`
+    );
+  }
+  if (!validate(value ?? {})) {
+    const detail = (validate.errors ?? [])
+      .map((e) => `${e.instancePath || "(root)"} ${e.message ?? ""}`.trim())
+      .join("; ");
+    throw new ValidationError(
+      `${context}: ${detail || "does not match the connector schema"}`
+    );
+  }
+}
+
+/**
+ * Validate a single connection (+ its feeds) and its referenced auth-profile
+ * kinds against a resolved connector schema. Pass `null` to skip schema
+ * checks (e.g. a connector that only exists as a local `.ts` not yet
+ * compiled by the server) — structural checks have already run at load time.
+ */
+export function validateConnectionAgainstConnector(
+  connection: DesiredConnection,
+  authProfiles: ReadonlyMap<string, DesiredAuthProfile>,
+  schemas: ResolvedConnectorSchemas | null
+): void {
+  // Validate against `{}` when config is omitted too — that surfaces missing
+  // required keys instead of letting an empty config slip through.
+  if (schemas?.optionsSchema) {
+    validateAgainstSchema(
+      schemas.optionsSchema,
+      connection.config ?? {},
+      `${connection.sourceFile}: connection "${connection.slug}" config`
+    );
+  }
+  for (const feed of connection.feeds) {
+    if (!schemas) continue;
+    if (
+      schemas.feedConfigSchemas.size > 0 &&
+      !schemas.feedConfigSchemas.has(feed.feedKey)
+    ) {
+      throw new ValidationError(
+        `${connection.sourceFile}: connection "${connection.slug}" references unknown feed "${feed.feedKey}" for connector "${connection.connector}"`
+      );
+    }
+    const feedSchema = schemas.feedConfigSchemas.get(feed.feedKey);
+    if (feedSchema) {
+      validateAgainstSchema(
+        feedSchema,
+        feed.config ?? {},
+        `${connection.sourceFile}: connection "${connection.slug}" feed "${feed.feedKey}" config`
+      );
+    }
+  }
+  // `auth:` must reference a runtime/account profile (never `oauth_app`);
+  // `app_auth:` must reference an `oauth_app` profile.
+  if (connection.authProfileSlug) {
+    const profile = requireAuthProfile(
+      connection,
+      authProfiles,
+      connection.authProfileSlug
+    );
+    if (profile.kind === "oauth_app") {
+      throw new ValidationError(
+        `${connection.sourceFile}: connection "${connection.slug}" \`auth\` references auth profile "${connection.authProfileSlug}" of kind \`oauth_app\` — use \`app_auth\` for OAuth-app credentials and \`auth\` for the account/runtime profile`
+      );
+    }
+  }
+  if (connection.appAuthProfileSlug) {
+    const profile = requireAuthProfile(
+      connection,
+      authProfiles,
+      connection.appAuthProfileSlug
+    );
+    if (profile.kind !== "oauth_app") {
+      throw new ValidationError(
+        `${connection.sourceFile}: connection "${connection.slug}" \`app_auth\` must reference an \`oauth_app\` auth profile (got \`${profile.kind}\`)`
+      );
+    }
+  }
+}
+
+function requireAuthProfile(
+  connection: DesiredConnection,
+  authProfiles: ReadonlyMap<string, DesiredAuthProfile>,
+  slugRef: string
+): DesiredAuthProfile {
+  const profile = authProfiles.get(slugRef);
+  if (!profile) {
+    throw new ValidationError(
+      `${connection.sourceFile}: connection "${connection.slug}" references auth profile "${slugRef}" which is not declared in any \`type: auth_profile\` doc`
+    );
+  }
+  if (profile.connector !== connection.connector) {
+    throw new ValidationError(
+      `${connection.sourceFile}: connection "${connection.slug}" references auth profile "${slugRef}" for connector "${profile.connector}", but the connection uses connector "${connection.connector}"`
+    );
+  }
+  return profile;
+}
+
+export function validateAuthProfileAgainstConnector(
+  profile: DesiredAuthProfile,
+  schemas: ResolvedConnectorSchemas | null
+): void {
+  if (!schemas) return;
+  if (schemas.authKinds.size > 0 && !schemas.authKinds.has(profile.kind)) {
+    throw new ValidationError(
+      `${profile.sourceFile}: auth_profile "${profile.slug}" uses \`kind: ${profile.kind}\`, but connector "${profile.connector}" supports: ${[...schemas.authKinds].sort().join(", ") || "(none)"}`
+    );
+  }
+}
+
 // ── Public API ─────────────────────────────────────────────────────────────
 
 export interface LoadDesiredStateOptions {
@@ -829,11 +1502,19 @@ export async function loadDesiredState(
     opts.cwd
   );
 
+  const connectors = await loadConnectors(
+    config,
+    opts.cwd,
+    env,
+    requiredSecrets
+  );
+
   return {
     state: {
       agents,
       memorySchema: { entityTypes, relationshipTypes },
       watchers,
+      connectors,
       requiredSecrets: [...requiredSecrets].sort(),
     },
     configPath,

--- a/packages/cli/src/commands/_lib/apply/desired-state.ts
+++ b/packages/cli/src/commands/_lib/apply/desired-state.ts
@@ -1070,6 +1070,21 @@ function parseConnectorDoc(
       `${file}: connector "${key}" must declare exactly one of \`source_path\` or \`source_url\``
     );
   }
+  if (sourceUrl) {
+    let parsed: URL;
+    try {
+      parsed = new URL(sourceUrl);
+    } catch {
+      throw new ValidationError(
+        `${file}: connector "${key}" source_url is not a valid URL: ${sourceUrl}`
+      );
+    }
+    if (parsed.protocol !== "https:") {
+      throw new ValidationError(
+        `${file}: connector "${key}" source_url must use https (got ${parsed.protocol}//)`
+      );
+    }
+  }
   return {
     key,
     ...(sourcePath ? { sourcePath } : {}),
@@ -1223,9 +1238,18 @@ async function loadConnectors(
       } else if (type === "connector") {
         const parsed = parseConnectorDoc(doc, rel);
         if (parsed.sourceUrl) {
-          if (definitionsByKey.has(parsed.key)) {
+          const prior = definitionsByKey.get(parsed.key);
+          if (prior) {
             throw new ValidationError(
-              `${rel}: duplicate connector key "${parsed.key}"`
+              `connector key "${parsed.key}" is declared twice — in ${prior.sourceFile} and ${rel}; keys must be unique`
+            );
+          }
+          const priorTs = [...tsFileDefinitions.values()].find(
+            (d) => d.key === parsed.key
+          );
+          if (priorTs) {
+            throw new ValidationError(
+              `connector key "${parsed.key}" is declared twice — in ${priorTs.sourceFile} and ${rel}; keys must be unique`
             );
           }
           definitionsByKey.set(parsed.key, {
@@ -1238,11 +1262,29 @@ async function loadConnectors(
           // directory (the connectors/ dir), matching the watcher-classifier
           // `source_path` convention.
           const abs = resolve(dirPath, parsed.sourcePath);
+          // The declared key must not collide with another connector definition.
+          const keyClash =
+            definitionsByKey.get(parsed.key) ??
+            [...tsFileDefinitions.entries()].find(
+              ([p, d]) => d.key === parsed.key && p !== abs
+            )?.[1];
+          if (keyClash) {
+            throw new ValidationError(
+              `connector key "${parsed.key}" is declared twice — in ${keyClash.sourceFile} and ${rel}; keys must be unique`
+            );
+          }
           if (tsFileDefinitions.has(abs)) {
-            // Already auto-discovered; the `type: connector` doc is redundant
-            // but harmless — just record the declared key for clearer output.
+            // Already auto-discovered as a `*.connector.ts` file; the
+            // `type: connector` doc just declares its key for clearer output.
             const existing = tsFileDefinitions.get(abs);
-            if (existing) existing.key = parsed.key;
+            if (existing) {
+              if (existing.key !== null && existing.key !== parsed.key) {
+                throw new ValidationError(
+                  `${existing.sourceFile} declares connector key "${existing.key}" but ${rel} declares "${parsed.key}" for the same file — they must agree`
+                );
+              }
+              existing.key = parsed.key;
+            }
           } else {
             let sourceCode: string;
             try {
@@ -1269,15 +1311,16 @@ async function loadConnectors(
   }
 
   const allDefs = [...definitionsByKey.values(), ...tsFileDefinitions.values()];
-  const seenKeys = new Set<string>();
+  const seenKeys = new Map<string, string>();
   for (const def of allDefs) {
     if (def.key === null) continue;
-    if (seenKeys.has(def.key)) {
+    const prior = seenKeys.get(def.key);
+    if (prior) {
       throw new ValidationError(
-        `${dirRel}/: connector key "${def.key}" is declared by more than one connector definition (a \`type: connector\` doc and/or a \`*.connector.ts\` file) — keys must be unique`
+        `connector key "${def.key}" is declared twice — in ${prior} and ${def.sourceFile}; keys must be unique`
       );
     }
-    seenKeys.add(def.key);
+    seenKeys.set(def.key, def.sourceFile);
   }
 
   return {

--- a/packages/cli/src/commands/_lib/apply/diff.ts
+++ b/packages/cli/src/commands/_lib/apply/diff.ts
@@ -1,4 +1,5 @@
 import type { AgentSettings } from "@lobu/core";
+import { ValidationError } from "../../memory/_lib/errors.js";
 import type {
   RemoteAgent,
   RemoteAuthProfile,
@@ -437,17 +438,18 @@ function diffConnectorDefinition(
   installedKeys: ReadonlySet<string>
 ): ConnectorDefinitionDiffRow {
   const id = connectorDefinitionId(desired);
-  // We can only assert "noop" when the key is known *and* installed — but the
-  // CLI can't compare source hashes (no local compile), so even an installed
-  // key gets a "create" row that `install_connector` resolves to a no-op on
-  // apply if the code is byte-identical. Keeping it as "create" is the
-  // conservative, honest plan output.
+  // The CLI can't compare source hashes (the server compiles, and the stored
+  // hash is of the *compiled* output) — so we always emit a "sync" row;
+  // `install_connector` is idempotent and reports `updated:false` on apply
+  // when the code is byte-identical, so this never churns remote state.
   const installedRemotely = desired.key
     ? installedKeys.has(desired.key)
     : false;
   return {
     kind: "connector-definition",
-    verb: "create",
+    // "update" (re-push) when already installed; `install_connector` is
+    // idempotent and reports `updated:false` if the code is unchanged.
+    verb: installedRemotely ? "update" : "create",
     id,
     desired,
     installedRemotely,
@@ -467,14 +469,30 @@ function diffAuthProfile(
       needsAuth: INTERACTIVE_AUTH_KINDS.has(desired.kind),
     };
   }
+  // `connector` / `kind` are immutable — `update_auth_profile` can't change
+  // them, so reusing a slug for a different connector/kind would silently push
+  // credentials into the wrong profile. Hard-stop instead.
+  if (
+    remote.connector_key !== desired.connector ||
+    remote.profile_kind !== desired.kind
+  ) {
+    throw new ValidationError(
+      `${desired.sourceFile}: auth_profile "${desired.slug}" is bound to ${remote.connector_key}/${remote.profile_kind} remotely, but the manifest declares ${desired.connector}/${desired.kind} — delete it manually or use a new slug`
+    );
+  }
   const changed: string[] = [];
   if ((desired.name ?? "") !== (remote.display_name ?? "")) {
     changed.push("name");
   }
-  // Credentials are never read back from the server in cleartext — the CLI
-  // cannot diff them. We re-push them every apply only when the manifest
-  // declares them; treat "has declared credentials" as an always-update so
-  // rotated secrets propagate, but only for non-interactive kinds.
+  // Credentials can't be read back from the server (write-only secrets). For
+  // non-interactive kinds with declared credentials, always re-push them
+  // (idempotent) so rotated secrets propagate — show as a redacted "credentials"
+  // change. Interactive kinds never carry credentials in the manifest.
+  const declaresCredentials =
+    !INTERACTIVE_AUTH_KINDS.has(desired.kind) &&
+    desired.credentials !== undefined &&
+    Object.keys(desired.credentials).length > 0;
+  if (declaresCredentials) changed.push("credentials");
   const needsAuth =
     INTERACTIVE_AUTH_KINDS.has(desired.kind) && remote.status !== "active";
   if (changed.length === 0 && !needsAuth) {
@@ -488,7 +506,7 @@ function diffAuthProfile(
   }
   return {
     kind: "auth-profile",
-    verb: needsAuth && changed.length === 0 ? "noop" : "update",
+    verb: changed.length > 0 ? "update" : "noop",
     id: desired.slug,
     desired,
     remote,
@@ -509,11 +527,18 @@ function diffConnection(
       desired,
     };
   }
+  // `connector` is immutable — `update` can't change `connector_key`, so a
+  // slug bound to a different connector remotely must be a hard error, never
+  // an "update" that mutates auth/config on the wrong connector.
+  if (remote.connector_key !== desired.connector) {
+    throw new ValidationError(
+      `${desired.sourceFile}: connection "${desired.slug}" is bound to connector "${remote.connector_key}" remotely, but the manifest declares "${desired.connector}" — delete it manually or use a new slug`
+    );
+  }
   const changed: string[] = [];
   if ((desired.name ?? "") !== (remote.display_name ?? "")) {
     changed.push("name");
   }
-  if (desired.connector !== remote.connector_key) changed.push("connector");
   if (
     (desired.authProfileSlug ?? null) !== (remote.auth_profile_slug ?? null)
   ) {

--- a/packages/cli/src/commands/_lib/apply/diff.ts
+++ b/packages/cli/src/commands/_lib/apply/diff.ts
@@ -1,14 +1,22 @@
 import type { AgentSettings } from "@lobu/core";
 import type {
   RemoteAgent,
+  RemoteAuthProfile,
+  RemoteConnection,
+  RemoteConnectorDefinition,
   RemoteEntityType,
+  RemoteFeed,
   RemotePlatform,
   RemoteRelationshipType,
   RemoteWatcher,
 } from "./client.js";
 import type {
   DesiredAgent,
+  DesiredAuthProfile,
+  DesiredConnection,
+  DesiredConnectorDefinition,
   DesiredEntityType,
+  DesiredFeed,
   DesiredPlatform,
   DesiredRelationshipType,
   DesiredWatcher,
@@ -70,18 +78,65 @@ export interface WatcherDiffRow extends BaseRow {
   changedFields?: string[];
 }
 
+export interface ConnectorDefinitionDiffRow extends BaseRow {
+  kind: "connector-definition";
+  desired?: DesiredConnectorDefinition;
+  /**
+   * Whether the desired connector is currently installed remotely. When the
+   * connector key isn't known up front (a local `.ts` the server hasn't
+   * compiled), this is `false` and the verb is "create" — `install_connector`
+   * is idempotent and reports `updated: false` on apply if nothing changed.
+   */
+  installedRemotely?: boolean;
+}
+
+export interface AuthProfileDiffRow extends BaseRow {
+  kind: "auth-profile";
+  desired?: DesiredAuthProfile;
+  remote?: RemoteAuthProfile;
+  changedFields?: string[];
+  /** True for `oauth_account` / `browser_session` profiles not yet `active`. */
+  needsAuth?: boolean;
+}
+
+export interface ConnectionDiffRow extends BaseRow {
+  kind: "connection";
+  desired?: DesiredConnection;
+  remote?: RemoteConnection;
+  changedFields?: string[];
+}
+
+export interface FeedDiffRow extends BaseRow {
+  kind: "feed";
+  /** Owning connection slug. */
+  connectionSlug: string;
+  desired?: DesiredFeed;
+  remote?: RemoteFeed;
+  changedFields?: string[];
+}
+
 export type DiffRow =
   | AgentDiffRow
   | SettingsDiffRow
   | PlatformDiffRow
   | EntityTypeDiffRow
   | RelationshipTypeDiffRow
-  | WatcherDiffRow;
+  | WatcherDiffRow
+  | ConnectorDefinitionDiffRow
+  | AuthProfileDiffRow
+  | ConnectionDiffRow
+  | FeedDiffRow;
 
 export interface DiffPlan {
   rows: DiffRow[];
   /** Aggregate counters for the summary line. */
   counts: { create: number; update: number; noop: number; drift: number };
+  /**
+   * Informational, non-actionable notes — e.g. "connector X is installed
+   * remotely but not declared locally". Rendered after the plan; never block
+   * apply.
+   */
+  notes: string[];
 }
 
 // ── Equality helpers ───────────────────────────────────────────────────────
@@ -366,6 +421,170 @@ function diffWatcher(
   };
 }
 
+// ── Connectors ─────────────────────────────────────────────────────────────
+
+const INTERACTIVE_AUTH_KINDS: ReadonlySet<string> = new Set([
+  "oauth_account",
+  "browser_session",
+]);
+
+function connectorDefinitionId(def: DesiredConnectorDefinition): string {
+  return def.key ?? def.sourceFile;
+}
+
+function diffConnectorDefinition(
+  desired: DesiredConnectorDefinition,
+  installedKeys: ReadonlySet<string>
+): ConnectorDefinitionDiffRow {
+  const id = connectorDefinitionId(desired);
+  // We can only assert "noop" when the key is known *and* installed — but the
+  // CLI can't compare source hashes (no local compile), so even an installed
+  // key gets a "create" row that `install_connector` resolves to a no-op on
+  // apply if the code is byte-identical. Keeping it as "create" is the
+  // conservative, honest plan output.
+  const installedRemotely = desired.key
+    ? installedKeys.has(desired.key)
+    : false;
+  return {
+    kind: "connector-definition",
+    verb: "create",
+    id,
+    desired,
+    installedRemotely,
+  };
+}
+
+function diffAuthProfile(
+  desired: DesiredAuthProfile,
+  remote: RemoteAuthProfile | undefined
+): AuthProfileDiffRow {
+  if (!remote) {
+    return {
+      kind: "auth-profile",
+      verb: "create",
+      id: desired.slug,
+      desired,
+      needsAuth: INTERACTIVE_AUTH_KINDS.has(desired.kind),
+    };
+  }
+  const changed: string[] = [];
+  if ((desired.name ?? "") !== (remote.display_name ?? "")) {
+    changed.push("name");
+  }
+  // Credentials are never read back from the server in cleartext — the CLI
+  // cannot diff them. We re-push them every apply only when the manifest
+  // declares them; treat "has declared credentials" as an always-update so
+  // rotated secrets propagate, but only for non-interactive kinds.
+  const needsAuth =
+    INTERACTIVE_AUTH_KINDS.has(desired.kind) && remote.status !== "active";
+  if (changed.length === 0 && !needsAuth) {
+    return {
+      kind: "auth-profile",
+      verb: "noop",
+      id: desired.slug,
+      desired,
+      remote,
+    };
+  }
+  return {
+    kind: "auth-profile",
+    verb: needsAuth && changed.length === 0 ? "noop" : "update",
+    id: desired.slug,
+    desired,
+    remote,
+    ...(changed.length > 0 ? { changedFields: changed } : {}),
+    ...(needsAuth ? { needsAuth: true } : {}),
+  };
+}
+
+function diffConnection(
+  desired: DesiredConnection,
+  remote: RemoteConnection | undefined
+): ConnectionDiffRow {
+  if (!remote) {
+    return {
+      kind: "connection",
+      verb: "create",
+      id: desired.slug,
+      desired,
+    };
+  }
+  const changed: string[] = [];
+  if ((desired.name ?? "") !== (remote.display_name ?? "")) {
+    changed.push("name");
+  }
+  if (desired.connector !== remote.connector_key) changed.push("connector");
+  if (
+    (desired.authProfileSlug ?? null) !== (remote.auth_profile_slug ?? null)
+  ) {
+    changed.push("auth");
+  }
+  if (
+    (desired.appAuthProfileSlug ?? null) !==
+    (remote.app_auth_profile_slug ?? null)
+  ) {
+    changed.push("app_auth");
+  }
+  if (!deepEqual(desired.config ?? {}, remote.config ?? {})) {
+    changed.push("config");
+  }
+  if (changed.length === 0) {
+    return {
+      kind: "connection",
+      verb: "noop",
+      id: desired.slug,
+      desired,
+      remote,
+    };
+  }
+  return {
+    kind: "connection",
+    verb: "update",
+    id: desired.slug,
+    desired,
+    remote,
+    changedFields: changed,
+  };
+}
+
+function diffFeed(
+  connectionSlug: string,
+  desired: DesiredFeed,
+  remote: RemoteFeed | undefined
+): FeedDiffRow {
+  const id = `${connectionSlug}/${desired.feedKey}`;
+  if (!remote) {
+    return {
+      kind: "feed",
+      verb: "create",
+      id,
+      connectionSlug,
+      desired,
+    };
+  }
+  const changed: string[] = [];
+  if ((desired.name ?? "") !== (remote.display_name ?? ""))
+    changed.push("name");
+  if ((desired.schedule ?? null) !== (remote.schedule ?? null)) {
+    changed.push("schedule");
+  }
+  if (!deepEqual(desired.config ?? {}, remote.config ?? {})) {
+    changed.push("config");
+  }
+  if (changed.length === 0) {
+    return { kind: "feed", verb: "noop", id, connectionSlug, desired, remote };
+  }
+  return {
+    kind: "feed",
+    verb: "update",
+    id,
+    connectionSlug,
+    desired,
+    remote,
+    changedFields: changed,
+  };
+}
+
 // ── Top-level diff ─────────────────────────────────────────────────────────
 
 export interface RemoteSnapshot {
@@ -377,6 +596,11 @@ export interface RemoteSnapshot {
   entityTypes: RemoteEntityType[];
   relationshipTypes: RemoteRelationshipType[];
   watchers: RemoteWatcher[];
+  connectorDefinitions: RemoteConnectorDefinition[];
+  authProfiles: RemoteAuthProfile[];
+  connections: RemoteConnection[];
+  /** Feeds keyed by connection ID. */
+  feedsByConnectionId: Map<number, RemoteFeed[]>;
 }
 
 export interface DesiredStateForDiff {
@@ -386,6 +610,11 @@ export interface DesiredStateForDiff {
     relationshipTypes: DesiredRelationshipType[];
   };
   watchers: DesiredWatcher[];
+  connectors: {
+    definitions: DesiredConnectorDefinition[];
+    authProfiles: DesiredAuthProfile[];
+    connections: DesiredConnection[];
+  };
 }
 
 export interface ComputeDiffOptions {
@@ -529,8 +758,136 @@ export function computeDiff(
     }
   }
 
+  const notes: string[] = [];
+
+  // Connectors run only on a full apply (`--only agents|memory` skips them).
+  const desiredConnectors = desired.connectors ?? {
+    definitions: [],
+    authProfiles: [],
+    connections: [],
+  };
+  // Sort remote collections so drift rows + notes render deterministically
+  // regardless of server response ordering.
+  const remoteConnectorDefinitions = [
+    ...(remote.connectorDefinitions ?? []),
+  ].sort((a, b) => a.key.localeCompare(b.key));
+  const remoteAuthProfiles = [...(remote.authProfiles ?? [])].sort((a, b) =>
+    a.slug.localeCompare(b.slug)
+  );
+  const remoteConnections = [...(remote.connections ?? [])].sort((a, b) =>
+    a.slug.localeCompare(b.slug)
+  );
+  const remoteFeedsByConnectionId =
+    remote.feedsByConnectionId ?? new Map<number, RemoteFeed[]>();
+  if (!only) {
+    const installedKeys = new Set(
+      remoteConnectorDefinitions.filter((d) => d.installed).map((d) => d.key)
+    );
+    const declaredKeys = new Set(
+      desiredConnectors.definitions
+        .map((d) => d.key)
+        .filter((k): k is string => !!k)
+    );
+    // Connectors referenced by a desired auth profile / connection are (or
+    // will be) installed in the org too — bundled ones included — so they
+    // aren't "undeclared".
+    const referencedConnectorKeys = new Set<string>([
+      ...desiredConnectors.authProfiles.map((p) => p.connector),
+      ...desiredConnectors.connections.map((c) => c.connector),
+    ]);
+    // Auto-discovered `.connector.ts` files whose key the CLI can't know up
+    // front (the server compiles them). When any exist, suppress the
+    // "undeclared remote connector" notes entirely — we can't tell which
+    // remote connector corresponds to which local file.
+    const hasUnnamedLocalDefs = desiredConnectors.definitions.some(
+      (d) => d.key === null
+    );
+    for (const def of desiredConnectors.definitions) {
+      rows.push(diffConnectorDefinition(def, installedKeys));
+    }
+    // Conservative: never auto-uninstall remote connector definitions that
+    // aren't declared/referenced locally — just note them.
+    if (!hasUnnamedLocalDefs) {
+      for (const def of remoteConnectorDefinitions) {
+        if (
+          def.installed &&
+          !declaredKeys.has(def.key) &&
+          !referencedConnectorKeys.has(def.key)
+        ) {
+          notes.push(
+            `connector "${def.key}" is installed remotely but not declared in connectors/ — uninstall it manually if it's no longer wanted (lobu apply never auto-uninstalls connectors).`
+          );
+        }
+      }
+    }
+
+    const remoteAuthBySlug = new Map(
+      remoteAuthProfiles.map((p) => [p.slug, p])
+    );
+    const desiredAuthSlugs = new Set(
+      desiredConnectors.authProfiles.map((p) => p.slug)
+    );
+    for (const profile of desiredConnectors.authProfiles) {
+      rows.push(diffAuthProfile(profile, remoteAuthBySlug.get(profile.slug)));
+    }
+    for (const remoteProfile of remoteAuthProfiles) {
+      if (!desiredAuthSlugs.has(remoteProfile.slug)) {
+        rows.push({
+          kind: "auth-profile",
+          verb: "drift",
+          id: remoteProfile.slug,
+          remote: remoteProfile,
+        });
+      }
+    }
+
+    const remoteConnBySlug = new Map(remoteConnections.map((c) => [c.slug, c]));
+    const desiredConnSlugs = new Set(
+      desiredConnectors.connections.map((c) => c.slug)
+    );
+    for (const conn of desiredConnectors.connections) {
+      const remoteConn = remoteConnBySlug.get(conn.slug);
+      rows.push(diffConnection(conn, remoteConn));
+      // Nested feeds — diffed by feed_key within the connection. Only diffable
+      // when the connection already exists remotely; for a new connection the
+      // feeds are created right after the connection-creation step.
+      const remoteFeeds = remoteConn
+        ? [...(remoteFeedsByConnectionId.get(remoteConn.id) ?? [])].sort(
+            (a, b) => a.feed_key.localeCompare(b.feed_key)
+          )
+        : [];
+      const remoteFeedByKey = new Map(remoteFeeds.map((f) => [f.feed_key, f]));
+      const desiredFeedKeys = new Set(conn.feeds.map((f) => f.feedKey));
+      for (const feed of conn.feeds) {
+        rows.push(diffFeed(conn.slug, feed, remoteFeedByKey.get(feed.feedKey)));
+      }
+      for (const remoteFeed of remoteFeeds) {
+        if (!desiredFeedKeys.has(remoteFeed.feed_key)) {
+          rows.push({
+            kind: "feed",
+            verb: "drift",
+            id: `${conn.slug}/${remoteFeed.feed_key}`,
+            connectionSlug: conn.slug,
+            remote: remoteFeed,
+          });
+        }
+      }
+    }
+    for (const remoteConn of remoteConnections) {
+      if (!desiredConnSlugs.has(remoteConn.slug)) {
+        rows.push({
+          kind: "connection",
+          verb: "drift",
+          id: remoteConn.slug,
+          remote: remoteConn,
+        });
+      }
+    }
+  }
+
   const counts = { create: 0, update: 0, noop: 0, drift: 0 };
   for (const row of rows) counts[row.verb]++;
 
-  return { rows, counts };
+  notes.sort();
+  return { rows, counts, notes };
 }

--- a/packages/cli/src/commands/_lib/apply/diff.ts
+++ b/packages/cli/src/commands/_lib/apply/diff.ts
@@ -830,6 +830,30 @@ export function computeDiff(
     for (const def of desiredConnectors.definitions) {
       rows.push(diffConnectorDefinition(def, installedKeys));
     }
+    // Bundled connectors referenced by a desired auth-profile / connection that
+    // the org doesn't have installed yet — `lobu apply` will install them from
+    // the catalog's server-side `source_uri`. Surface them as plan rows so the
+    // operator approves these connector-definition mutations too. (Skipped when
+    // a locally-supplied connector declares the same key — that one wins.)
+    const installableByKey = new Map(
+      remoteConnectorDefinitions
+        .filter((d) => d.installable && d.source_uri)
+        .map((d) => [d.key, d])
+    );
+    for (const key of [...referencedConnectorKeys].sort()) {
+      if (installedKeys.has(key)) continue;
+      if (declaredKeys.has(key)) continue; // a local def supplies this key
+      const entry = installableByKey.get(key);
+      if (!entry?.source_uri) continue;
+      rows.push({
+        kind: "connector-definition",
+        verb: "create",
+        id: key,
+        // No `desired` — this is a bundled install, handled by
+        // `installConnectorDefinitions`'s bundled-referenced loop, not the
+        // plan-row loop. The render falls back to `id` (the connector key).
+      });
+    }
     // Conservative: never auto-uninstall remote connector definitions that
     // aren't declared/referenced locally — just note them.
     if (!hasUnnamedLocalDefs) {

--- a/packages/cli/src/commands/_lib/apply/prompt.ts
+++ b/packages/cli/src/commands/_lib/apply/prompt.ts
@@ -25,3 +25,21 @@ export async function confirmPlan(opts: ConfirmOptions): Promise<boolean> {
     default: false,
   });
 }
+
+/**
+ * Confirm uploading + compiling custom connector source on the gateway.
+ * `yes` short-circuits to true; non-TTY without `--yes` throws rather than
+ * hanging on a closed stdin.
+ */
+export async function confirmCustomConnectors(yes: boolean): Promise<boolean> {
+  if (yes) return true;
+  if (!process.stdin.isTTY || !process.stdout.isTTY) {
+    throw new ValidationError(
+      "Custom connector source present and --yes was not supplied. Re-run with --yes once you've reviewed the connector code."
+    );
+  }
+  return confirm({
+    message: "Compile & execute these connectors on the gateway?",
+    default: false,
+  });
+}

--- a/packages/cli/src/commands/_lib/apply/render.ts
+++ b/packages/cli/src/commands/_lib/apply/render.ts
@@ -15,6 +15,10 @@ const KIND_LABEL: Record<DiffRow["kind"], string> = {
   "entity-type": "entity-type",
   "relationship-type": "relationship-type",
   watcher: "watcher",
+  "connector-definition": "connector-definition",
+  "auth-profile": "auth-profile",
+  connection: "connection",
+  feed: "feed",
 };
 
 function fieldsList(fields: string[] | undefined): string {
@@ -22,26 +26,69 @@ function fieldsList(fields: string[] | undefined): string {
   return chalk.dim(` (${fields.join(", ")})`);
 }
 
+function rowId(row: DiffRow): string {
+  if (row.kind === "platform") return `${row.agentId}/${row.id}`;
+  if (
+    row.kind === "connector-definition" &&
+    row.desired?.key &&
+    row.desired.sourcePath
+  ) {
+    return `${row.desired.key} (from ${row.desired.sourceFile})`;
+  }
+  if (row.kind === "connector-definition" && row.desired) {
+    return row.desired.sourceUrl
+      ? `${row.desired.sourceFile} (${row.desired.sourceUrl})`
+      : row.desired.sourceFile;
+  }
+  return row.id;
+}
+
 function renderRow(row: DiffRow): string[] {
   const prefix = VERB_PREFIX[row.verb];
   const label = chalk.bold(KIND_LABEL[row.kind]);
-  const id = row.kind === "platform" ? `${row.agentId}/${row.id}` : row.id;
+  const id = rowId(row);
   const lines: string[] = [];
 
   switch (row.verb) {
     case "create":
       lines.push(`  ${prefix} ${label} ${id}`);
+      if (
+        row.kind === "connector-definition" &&
+        row.installedRemotely &&
+        row.desired?.key
+      ) {
+        lines.push(
+          `      ${chalk.dim("(already installed — apply re-pushes source; no-op if unchanged)")}`
+        );
+      }
+      if (row.kind === "auth-profile" && row.needsAuth) {
+        lines.push(
+          `      ${chalk.yellow("⚠")} interactive auth — complete it via the connect URL printed after apply`
+        );
+      }
       break;
     case "update":
-      lines.push(`  ${prefix} ${label} ${id}${fieldsList(row.changedFields)}`);
+      lines.push(
+        `  ${prefix} ${label} ${id}${fieldsList("changedFields" in row ? row.changedFields : undefined)}`
+      );
       if (row.kind === "platform" && row.willRestart) {
         lines.push(
           `      ${chalk.yellow("⚠")} will restart platform — in-flight messages may drop`
         );
       }
+      if (row.kind === "auth-profile" && row.needsAuth) {
+        lines.push(
+          `      ${chalk.yellow("⚠")} interactive auth — complete it via the connect URL printed after apply`
+        );
+      }
       break;
     case "noop":
       lines.push(`  ${prefix} ${label} ${id}`);
+      if (row.kind === "auth-profile" && row.needsAuth) {
+        lines.push(
+          `      ${chalk.yellow("⚠")} interactive auth still pending — complete it via the connect URL printed after apply`
+        );
+      }
       break;
     case "drift":
       lines.push(
@@ -66,6 +113,10 @@ export function renderPlan(plan: DiffPlan): string {
     "entity-type",
     "relationship-type",
     "watcher",
+    "connector-definition",
+    "auth-profile",
+    "connection",
+    "feed",
   ];
   for (const kind of order) {
     const rowsForKind = plan.rows.filter((row) => row.kind === kind);
@@ -77,8 +128,41 @@ export function renderPlan(plan: DiffPlan): string {
     }
   }
 
+  const notes = plan.notes ?? [];
+  if (notes.length > 0) {
+    lines.push("");
+    lines.push(chalk.bold("  Notes:"));
+    for (const note of notes) {
+      lines.push(`  ${chalk.cyan("•")} ${note}`);
+    }
+  }
+
   lines.push("");
   lines.push(renderSummary(plan));
+  return lines.join("\n");
+}
+
+/** Post-apply punch-list: pending interactive auth + informational notes. */
+export function renderPostApplyPunchList(items: {
+  pendingAuth: Array<{ slug: string; kind: string; connectUrl?: string }>;
+  notes: string[];
+}): string | null {
+  if (items.pendingAuth.length === 0 && items.notes.length === 0) return null;
+  const lines: string[] = [chalk.bold("\nNext steps:")];
+  for (const item of items.pendingAuth) {
+    if (item.connectUrl) {
+      lines.push(
+        `  ${chalk.yellow("→")} auth profile ${chalk.bold(item.slug)} (${item.kind}) needs authorization: ${chalk.underline(item.connectUrl)}`
+      );
+    } else {
+      lines.push(
+        `  ${chalk.yellow("→")} auth profile ${chalk.bold(item.slug)} (${item.kind}) needs a session — set it up in the connections UI`
+      );
+    }
+  }
+  for (const note of items.notes) {
+    lines.push(`  ${chalk.cyan("•")} ${note}`);
+  }
   return lines.join("\n");
 }
 

--- a/packages/core/src/lobu-toml-schema.ts
+++ b/packages/core/src/lobu-toml-schema.ts
@@ -210,6 +210,7 @@ const memorySchema = z
     visibility: z.enum(["public", "private"]).optional(),
     models: z.string().optional(),
     data: z.string().optional(),
+    connectors: z.string().optional(),
     schema: memoryInlineSchema.optional(),
   })
   .strict();

--- a/packages/server/src/__tests__/integration/connectors/pending-auth-connection.test.ts
+++ b/packages/server/src/__tests__/integration/connectors/pending-auth-connection.test.ts
@@ -1,0 +1,167 @@
+/**
+ * Round-3 regression: a connection referencing a freshly-created `pending_auth`
+ * `oauth_account` auth profile in the *same* `lobu apply` must succeed — the
+ * connection is created `pending_auth` and the OAuth callback flips both to
+ * `active`. Previously `manage_auth_profiles.create_auth_profile` for
+ * `oauth_account` returned a token-only response (no row), so the connection's
+ * `auth_profile_slug` lookup failed; and even after persisting the row, the
+ * connection *create* path still rejected a non-`active` auth profile.
+ */
+
+import { beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import type { Env } from '../../../index';
+import type { ToolContext } from '../../../tools/registry';
+import { manageAuthProfiles } from '../../../tools/admin/manage_auth_profiles';
+import { manageConnections } from '../../../tools/admin/manage_connections';
+import { getTestDb, cleanupTestDatabase } from '../../setup/test-db';
+import { initWorkspaceProvider } from '../../../workspace';
+import {
+  addUserToOrganization,
+  createTestConnectorDefinition,
+  createTestOrganization,
+  createTestUser,
+} from '../../setup/test-fixtures';
+
+const TEST_ENV = {} as Env;
+
+function ctxFor(organizationId: string, userId: string): ToolContext {
+  return {
+    organizationId,
+    userId,
+    memberRole: 'owner',
+    agentId: null,
+    isAuthenticated: true,
+    clientId: null,
+    scopes: ['mcp:read', 'mcp:write', 'mcp:admin'],
+    tokenType: 'oauth',
+    scopedToOrg: true,
+    allowCrossOrg: false,
+  } as ToolContext;
+}
+
+describe('connectors — pending-auth oauth_account in the same apply', () => {
+  beforeAll(async () => {
+    await initWorkspaceProvider();
+  });
+
+  beforeEach(async () => {
+    await cleanupTestDatabase();
+  });
+
+  it('creates a pending_auth auth profile row + connect token, then a pending_auth connection that references it', async () => {
+    const org = await createTestOrganization({ name: 'Pending Auth Org' });
+    const user = await createTestUser({ name: 'Pending Auth User' });
+    await addUserToOrganization(user.id, org.id, 'owner');
+    const ctx = ctxFor(org.id, user.id);
+    // Org-scoped connector with an OAuth method (so oauth_account/oauth_app are valid).
+    await createTestConnectorDefinition({
+      key: 'demo.oauth',
+      name: 'Demo OAuth',
+      organization_id: org.id,
+      auth_schema: {
+        methods: [
+          {
+            type: 'oauth',
+            provider: 'demo',
+            requiredScopes: ['read'],
+            clientIdKey: 'DEMO_CLIENT_ID',
+            clientSecretKey: 'DEMO_CLIENT_SECRET',
+          },
+        ],
+      },
+      feeds_schema: { items: {} },
+    });
+
+    // App-credentials profile (active — carries client id/secret).
+    const appRes = await manageAuthProfiles(
+      {
+        action: 'create_auth_profile',
+        connector_key: 'demo.oauth',
+        profile_kind: 'oauth_app',
+        display_name: 'Demo OAuth App',
+        slug: 'demo-app',
+        credentials: { DEMO_CLIENT_ID: 'cid', DEMO_CLIENT_SECRET: 'csec' },
+      },
+      TEST_ENV,
+      ctx
+    );
+    expect('auth_profile' in appRes && appRes.auth_profile).toBeTruthy();
+
+    // Account profile — must persist a real pending_auth row + connect token.
+    const accRes = await manageAuthProfiles(
+      {
+        action: 'create_auth_profile',
+        connector_key: 'demo.oauth',
+        profile_kind: 'oauth_account',
+        display_name: 'Demo Account',
+        slug: 'demo-account',
+      },
+      TEST_ENV,
+      ctx
+    );
+    expect('auth_profile' in accRes).toBe(true);
+    if ('auth_profile' in accRes) {
+      expect(accRes.auth_profile.status).toBe('pending_auth');
+      expect(accRes.auth_profile.slug).toBe('demo-account');
+    }
+    expect('connect_url' in accRes && accRes.connect_url).toBeTruthy();
+    expect('connect_token' in accRes && accRes.connect_token).toBeTruthy();
+
+    const sql = getTestDb();
+    const rows = await sql`
+      SELECT status, profile_kind FROM auth_profiles
+      WHERE organization_id = ${org.id} AND slug = 'demo-account'
+    `;
+    expect(rows).toHaveLength(1);
+    expect((rows[0] as { status: string }).status).toBe('pending_auth');
+
+    // The connect token must be linked to the profile (so the callback updates it).
+    const profileId = (
+      (await sql`SELECT id FROM auth_profiles WHERE organization_id = ${org.id} AND slug = 'demo-account'`)[0] as {
+        id: number;
+      }
+    ).id;
+    const tokenRows = await sql`
+      SELECT auth_profile_id FROM connect_tokens
+      WHERE organization_id = ${org.id} AND connector_key = 'demo.oauth' AND status = 'pending'
+    `;
+    expect(tokenRows).toHaveLength(1);
+    expect(String((tokenRows[0] as { auth_profile_id: unknown }).auth_profile_id)).toBe(String(profileId));
+
+    // Now create a connection referencing the pending_auth account profile in the
+    // same "apply" — it must succeed and land in pending_auth.
+    const connRes = await manageConnections(
+      {
+        action: 'create',
+        connector_key: 'demo.oauth',
+        slug: 'demo-conn',
+        display_name: 'Demo Connection',
+        auth_profile_slug: 'demo-account',
+        app_auth_profile_slug: 'demo-app',
+      },
+      TEST_ENV,
+      ctx
+    );
+    expect('error' in connRes).toBe(false);
+    if ('connection' in connRes) {
+      expect((connRes.connection as { status: string }).status).toBe('pending_auth');
+      expect((connRes.connection as { slug: string }).slug).toBe('demo-conn');
+    }
+
+    // Re-creating the account profile is idempotent — reuses the row, returns a fresh token.
+    const accRes2 = await manageAuthProfiles(
+      {
+        action: 'create_auth_profile',
+        connector_key: 'demo.oauth',
+        profile_kind: 'oauth_account',
+        display_name: 'Demo Account',
+        slug: 'demo-account',
+      },
+      TEST_ENV,
+      ctx
+    );
+    expect('connect_url' in accRes2 && accRes2.connect_url).toBeTruthy();
+    const rows2 = await sql`SELECT count(*)::int AS n FROM auth_profiles WHERE organization_id = ${org.id} AND slug = 'demo-account'`;
+    expect((rows2[0] as { n: number }).n).toBe(1);
+  });
+});

--- a/packages/server/src/__tests__/integration/connectors/pending-auth-connection.test.ts
+++ b/packages/server/src/__tests__/integration/connectors/pending-auth-connection.test.ts
@@ -13,6 +13,7 @@ import type { Env } from '../../../index';
 import type { ToolContext } from '../../../tools/registry';
 import { manageAuthProfiles } from '../../../tools/admin/manage_auth_profiles';
 import { manageConnections } from '../../../tools/admin/manage_connections';
+import { manageFeeds } from '../../../tools/admin/manage_feeds';
 import { getTestDb, cleanupTestDatabase } from '../../setup/test-db';
 import { initWorkspaceProvider } from '../../../workspace';
 import {
@@ -143,10 +144,39 @@ describe('connectors — pending-auth oauth_account in the same apply', () => {
       ctx
     );
     expect('error' in connRes).toBe(false);
+    let connectionId = 0;
     if ('connection' in connRes) {
       expect((connRes.connection as { status: string }).status).toBe('pending_auth');
       expect((connRes.connection as { slug: string }).slug).toBe('demo-conn');
+      connectionId = (connRes.connection as { id: number }).id;
     }
+
+    // A feed created for a pending_auth connection must land 'paused' with no
+    // next_run_at (the feeds.status CHECK only allows active|paused|error; the
+    // OAuth callback un-pauses it when it activates the connection).
+    const feedRes = await manageFeeds(
+      {
+        action: 'create_feed',
+        connection_id: connectionId,
+        feed_key: 'items',
+        display_name: 'Demo Feed',
+        schedule: '0 */6 * * *',
+      },
+      TEST_ENV,
+      ctx
+    );
+    expect('error' in feedRes).toBe(false);
+    if ('feed' in feedRes) {
+      expect((feedRes.feed as { status: string }).status).toBe('paused');
+      expect((feedRes.feed as { next_run_at: unknown }).next_run_at ?? null).toBeNull();
+    }
+    const feedRows = await sql`
+      SELECT status, next_run_at FROM feeds
+      WHERE organization_id = ${org.id} AND connection_id = ${connectionId}
+    `;
+    expect(feedRows).toHaveLength(1);
+    expect((feedRows[0] as { status: string }).status).toBe('paused');
+    expect((feedRows[0] as { next_run_at: unknown }).next_run_at).toBeNull();
 
     // Re-creating the account profile is idempotent — reuses the row, returns a fresh token.
     const accRes2 = await manageAuthProfiles(

--- a/packages/server/src/tools/admin/manage_auth_profiles.ts
+++ b/packages/server/src/tools/admin/manage_auth_profiles.ts
@@ -487,7 +487,7 @@ async function handleCreateAuthProfile(
       // Best-effort cleanup so a token-insert failure doesn't orphan a
       // `pending_auth` profile. (The orphan is self-healing — a retry reuses
       // the row and issues a fresh token — but cleaning up keeps state tidy.)
-      await deleteAuthProfile(ctx.organizationId, authProfile.slug).catch(() => {});
+      await deleteAuthProfile(ctx.organizationId, authProfile.slug).catch(() => undefined);
       throw err;
     }
 

--- a/packages/server/src/tools/admin/manage_auth_profiles.ts
+++ b/packages/server/src/tools/admin/manage_auth_profiles.ts
@@ -416,34 +416,75 @@ async function handleCreateAuthProfile(
       return { error: `Connector '${args.connector_key}' does not support OAuth account profiles` };
     }
 
-    // Don't create the profile yet — store metadata in the connect token and
-    // create the real profile as active in the OAuth callback.
-    const pendingSlug = normalizeAuthProfileSlug(
-      args.slug,
-      args.display_name || `${connector.name} ${oauthMethod.provider} Account`
-    );
+    const displayName =
+      args.display_name || `${connector.name} ${oauthMethod.provider} Account`;
+    // Idempotent: if a profile with this slug already exists, reuse it (issue a
+    // fresh connect token if it still needs auth). This lets a connection
+    // reference `auth_profile_slug = <slug>` in the *same* `lobu apply` —
+    // previously this branch never persisted a row, so the slug didn't resolve.
+    const existing = args.slug
+      ? await getAuthProfileBySlug(ctx.organizationId, normalizeAuthProfileSlug(args.slug, displayName))
+      : null;
+    if (existing) {
+      if (existing.profile_kind !== 'oauth_account' || existing.connector_key !== args.connector_key) {
+        return {
+          error: `Auth profile '${existing.slug}' already exists with a different kind/connector (${existing.profile_kind} / ${existing.connector_key}) — use a new slug`,
+        };
+      }
+      if (existing.status === 'active') {
+        return { action: 'create_auth_profile', auth_profile: serializeAuthProfile(existing) };
+      }
+      const requestedScopes = resolveRequestedOAuthScopes(oauthMethod, args.requested_scopes);
+      const connectToken = await createConnectToken({
+        organizationId: ctx.organizationId,
+        connectorKey: args.connector_key,
+        authType: 'oauth',
+        authProfileId: existing.id,
+        authConfig: {
+          ...buildOAuthConnectConfig(oauthMethod, requestedScopes),
+          requestedScopes,
+        },
+        createdBy: ctx.userId,
+      });
+      return {
+        action: 'create_auth_profile',
+        auth_profile: serializeAuthProfile(existing),
+        connect_url: `${getConnectBaseUrl(ctx)}/connect/${connectToken.token}/oauth/start`,
+        connect_token: connectToken.token,
+      };
+    }
+
+    // Create a real `pending_auth` row up front so downstream
+    // `auth_profile_slug` lookups (connection create, etc.) resolve. The OAuth
+    // callback flips it to `active` once the user finishes authorization.
+    const authProfile = await createAuthProfile({
+      organizationId: ctx.organizationId,
+      connectorKey: args.connector_key,
+      displayName,
+      slug: args.slug,
+      profileKind: 'oauth_account',
+      authData: {},
+      provider: oauthMethod.provider.toLowerCase(),
+      status: 'pending_auth',
+      createdBy: ctx.userId ?? 'api',
+    });
 
     const requestedScopes = resolveRequestedOAuthScopes(oauthMethod, args.requested_scopes);
     const connectToken = await createConnectToken({
       organizationId: ctx.organizationId,
       connectorKey: args.connector_key,
       authType: 'oauth',
+      authProfileId: authProfile.id,
       authConfig: {
         ...buildOAuthConnectConfig(oauthMethod, requestedScopes),
         requestedScopes,
-        pendingProfileMeta: {
-          displayName: args.display_name || `${connector.name} ${oauthMethod.provider} Account`,
-          slug: pendingSlug,
-          connectorKey: args.connector_key,
-          provider: oauthMethod.provider,
-        },
       },
       createdBy: ctx.userId,
     });
 
     return {
       action: 'create_auth_profile',
-      pending_slug: pendingSlug,
+      auth_profile: serializeAuthProfile(authProfile),
       connect_url: `${getConnectBaseUrl(ctx)}/connect/${connectToken.token}/oauth/start`,
       connect_token: connectToken.token,
     };

--- a/packages/server/src/tools/admin/manage_auth_profiles.ts
+++ b/packages/server/src/tools/admin/manage_auth_profiles.ts
@@ -470,17 +470,26 @@ async function handleCreateAuthProfile(
     });
 
     const requestedScopes = resolveRequestedOAuthScopes(oauthMethod, args.requested_scopes);
-    const connectToken = await createConnectToken({
-      organizationId: ctx.organizationId,
-      connectorKey: args.connector_key,
-      authType: 'oauth',
-      authProfileId: authProfile.id,
-      authConfig: {
-        ...buildOAuthConnectConfig(oauthMethod, requestedScopes),
-        requestedScopes,
-      },
-      createdBy: ctx.userId,
-    });
+    let connectToken: Awaited<ReturnType<typeof createConnectToken>>;
+    try {
+      connectToken = await createConnectToken({
+        organizationId: ctx.organizationId,
+        connectorKey: args.connector_key,
+        authType: 'oauth',
+        authProfileId: authProfile.id,
+        authConfig: {
+          ...buildOAuthConnectConfig(oauthMethod, requestedScopes),
+          requestedScopes,
+        },
+        createdBy: ctx.userId,
+      });
+    } catch (err) {
+      // Best-effort cleanup so a token-insert failure doesn't orphan a
+      // `pending_auth` profile. (The orphan is self-healing — a retry reuses
+      // the row and issues a fresh token — but cleaning up keeps state tidy.)
+      await deleteAuthProfile(ctx.organizationId, authProfile.slug).catch(() => {});
+      throw err;
+    }
 
     return {
       action: 'create_auth_profile',

--- a/packages/server/src/tools/admin/manage_connections.ts
+++ b/packages/server/src/tools/admin/manage_connections.ts
@@ -186,6 +186,12 @@ const UpdateAction = Type.Object({
         'Reassign which device worker runs this connection. Null moves it back to the cloud pool (only allowed if the connector has no required_capability).',
     })
   ),
+  replace_config: Type.Optional(
+    Type.Boolean({
+      description:
+        'When true and `config` is provided, replace the stored connection config with exactly that object (declarative apply); when false/omitted, merge into the existing config (default).',
+    })
+  ),
 });
 
 const DeleteAction = Type.Object({
@@ -1516,6 +1522,12 @@ async function handleUpdate(
     };
   }
 
+  // Config write mode: declarative `lobu apply` passes `replace_config: true`
+  // so a removed manifest key actually disappears remotely. Default (merge)
+  // is preserved for the web UI / partial updates.
+  const replaceConfig = args.replace_config === true && args.config !== undefined;
+  const connectionConfigForReplace = splitConfig.connectionConfig ?? {};
+
   // Slug is only ever changed when the caller passes one explicitly — a
   // display_name change never touches it (that's the whole point of a stable
   // identity for `lobu apply`). An explicit slug is validated for format and
@@ -1547,7 +1559,11 @@ async function handleUpdate(
           status = COALESCE(${effectiveStatus}, status),
           auth_profile_id = ${nextAuthProfileId},
           app_auth_profile_id = ${nextAppAuthProfileId},
-          config = CASE WHEN ${splitConfig.connectionConfig ? sql.json(splitConfig.connectionConfig) : null}::jsonb IS NOT NULL THEN COALESCE(config, '{}'::jsonb) || ${splitConfig.connectionConfig ? sql.json(splitConfig.connectionConfig) : null}::jsonb ELSE config END,
+          config = ${
+            replaceConfig
+              ? sql`${sql.json(connectionConfigForReplace)}::jsonb`
+              : sql`CASE WHEN ${splitConfig.connectionConfig ? sql.json(splitConfig.connectionConfig) : null}::jsonb IS NOT NULL THEN COALESCE(config, '{}'::jsonb) || ${splitConfig.connectionConfig ? sql.json(splitConfig.connectionConfig) : null}::jsonb ELSE config END`
+          },
           updated_at = NOW()
       WHERE id = ${args.connection_id} AND organization_id = ${organizationId} AND deleted_at IS NULL
       RETURNING *

--- a/packages/server/src/tools/admin/manage_connections.ts
+++ b/packages/server/src/tools/admin/manage_connections.ts
@@ -903,18 +903,27 @@ async function handleCreate(
           .usable
       : false;
 
-  // A `pending_auth` auth profile is OK on create — the connection is created
-  // in `pending_auth` and the OAuth/connect callback flips both the profile and
-  // the connection to `active`. This lets a connection reference a freshly
-  // created oauth_account profile in the same `lobu apply`.
+  // A `pending_auth` auth profile is OK on create *only* for kinds that can
+  // actually become active out of band — `oauth_account` (OAuth callback) and
+  // `browser_session` (already handled above). The connection is created
+  // `pending_auth` and the callback flips both to `active`. This lets a
+  // connection reference a freshly created oauth_account profile in the same
+  // `lobu apply`. An `env`/`oauth_app` profile that's not active is an error.
   if (
     authSelection?.authProfile &&
     authSelection.authProfile.profile_kind !== 'browser_session' &&
     authSelection.authProfile.status !== 'active' &&
-    authSelection.authProfile.status !== 'pending_auth'
+    !(
+      authSelection.authProfile.status === 'pending_auth' &&
+      authSelection.authProfile.profile_kind === 'oauth_account'
+    )
   ) {
     return {
-      error: `Selected auth profile '${authSelection.authProfile.slug}' is ${authSelection.authProfile.status} — must be active or pending_auth.`,
+      error: `Selected auth profile '${authSelection.authProfile.slug}' is ${authSelection.authProfile.status}${
+        authSelection.authProfile.profile_kind === 'oauth_account'
+          ? ' — must be active or pending_auth'
+          : ' — must be active'
+      }.`,
     };
   }
 

--- a/packages/server/src/tools/admin/manage_connections.ts
+++ b/packages/server/src/tools/admin/manage_connections.ts
@@ -903,13 +903,18 @@ async function handleCreate(
           .usable
       : false;
 
+  // A `pending_auth` auth profile is OK on create — the connection is created
+  // in `pending_auth` and the OAuth/connect callback flips both the profile and
+  // the connection to `active`. This lets a connection reference a freshly
+  // created oauth_account profile in the same `lobu apply`.
   if (
     authSelection?.authProfile &&
     authSelection.authProfile.profile_kind !== 'browser_session' &&
-    authSelection.authProfile.status !== 'active'
+    authSelection.authProfile.status !== 'active' &&
+    authSelection.authProfile.status !== 'pending_auth'
   ) {
     return {
-      error: `Selected auth profile '${authSelection.authProfile.slug}' is not active.`,
+      error: `Selected auth profile '${authSelection.authProfile.slug}' is ${authSelection.authProfile.status} — must be active or pending_auth.`,
     };
   }
 
@@ -977,9 +982,11 @@ async function handleCreate(
     interactiveAuthProfileId = profile.id;
   }
 
-  const connectionStatus = interactiveMethod
-    ? 'pending_auth'
-    : authSelection?.authProfile?.profile_kind === 'browser_session' && !browserProfileUsable
+  const connectionStatus =
+    interactiveMethod ||
+    (authSelection?.authProfile?.profile_kind === 'browser_session' &&
+      !browserProfileUsable) ||
+    authSelection?.authProfile?.status === 'pending_auth'
       ? 'pending_auth'
       : 'active';
 

--- a/packages/server/src/tools/admin/manage_feeds.ts
+++ b/packages/server/src/tools/admin/manage_feeds.ts
@@ -68,6 +68,12 @@ const UpdateFeedAction = Type.Object({
   display_name: Type.Optional(Type.String()),
   entity_ids: Type.Optional(Type.Array(Type.Number())),
   config: Type.Optional(Type.Record(Type.String(), Type.Any())),
+  replace_config: Type.Optional(
+    Type.Boolean({
+      description:
+        'When true and `config` is provided, replace the stored feed config with exactly that object (declarative apply); when false/omitted, merge into the existing config (default).',
+    })
+  ),
   schedule: Type.Optional(Type.String({ description: 'Cron expression for sync schedule' })),
   repair_agent_id: Type.Optional(
     Type.Union([Type.String(), Type.Null()], {
@@ -346,12 +352,20 @@ async function handleUpdateFeed(
   const hasRepairAgentArg = Object.hasOwn(args, 'repair_agent_id');
   const repairAgentValue = hasRepairAgentArg ? (args.repair_agent_id ?? null) : null;
 
+  // Declarative `lobu apply` passes `replace_config: true` so removed manifest
+  // keys disappear remotely; default (merge) is preserved for the web UI.
+  const replaceFeedConfig = args.replace_config === true && args.config !== undefined;
+
   const updated = await sql`
     UPDATE feeds
     SET display_name = COALESCE(${args.display_name ?? null}::text, display_name),
         status = COALESCE(${args.status ?? null}::text, status),
         entity_ids = COALESCE(${entityIdsValue}::bigint[], entity_ids),
-        config = CASE WHEN ${args.config ? sql.json(args.config) : null}::jsonb IS NOT NULL THEN COALESCE(config, '{}'::jsonb) || ${args.config ? sql.json(args.config) : null}::jsonb ELSE config END,
+        config = ${
+          replaceFeedConfig
+            ? sql`${sql.json(args.config ?? {})}::jsonb`
+            : sql`CASE WHEN ${args.config ? sql.json(args.config) : null}::jsonb IS NOT NULL THEN COALESCE(config, '{}'::jsonb) || ${args.config ? sql.json(args.config) : null}::jsonb ELSE config END`
+        },
         schedule = COALESCE(${args.schedule ?? null}::text, schedule),
         next_run_at = CASE WHEN ${args.schedule ?? null}::text IS NOT NULL THEN ${args.schedule ? nextRunAt(args.schedule) : null}::timestamptz ELSE next_run_at END,
         repair_agent_id = CASE WHEN ${hasRepairAgentArg} THEN ${repairAgentValue}::text ELSE repair_agent_id END,

--- a/packages/server/src/tools/admin/manage_feeds.ts
+++ b/packages/server/src/tools/admin/manage_feeds.ts
@@ -260,12 +260,13 @@ async function handleCreateFeed(
   }
 
   const conn = connRows[0] as any;
-  // A `pending_auth` connection is OK — the feed is created paused; the
-  // OAuth/connect callback activates the connection AND its feeds together.
+  // A `pending_auth` connection is OK — the feed is created `paused` (the
+  // `feeds.status` CHECK only allows active|paused|error). The OAuth/connect
+  // callback un-pauses the connection's feeds when it activates the connection.
   if (conn.status !== 'active' && conn.status !== 'pending_auth') {
     return { error: `Connection is ${conn.status}, must be active or pending_auth to create feeds` };
   }
-  const feedInitialStatus = conn.status === 'pending_auth' ? 'pending_auth' : 'active';
+  const feedInitialStatus = conn.status === 'active' ? 'active' : 'paused';
 
   const feedsSchema = conn.feeds_schema as Record<string, any> | null;
   if (feedsSchema && !feedsSchema[args.feed_key]) {

--- a/packages/server/src/tools/admin/manage_feeds.ts
+++ b/packages/server/src/tools/admin/manage_feeds.ts
@@ -260,9 +260,12 @@ async function handleCreateFeed(
   }
 
   const conn = connRows[0] as any;
-  if (conn.status !== 'active') {
-    return { error: `Connection is ${conn.status}, must be active to create feeds` };
+  // A `pending_auth` connection is OK — the feed is created paused; the
+  // OAuth/connect callback activates the connection AND its feeds together.
+  if (conn.status !== 'active' && conn.status !== 'pending_auth') {
+    return { error: `Connection is ${conn.status}, must be active or pending_auth to create feeds` };
   }
+  const feedInitialStatus = conn.status === 'pending_auth' ? 'pending_auth' : 'active';
 
   const feedsSchema = conn.feeds_schema as Record<string, any> | null;
   if (feedsSchema && !feedsSchema[args.feed_key]) {
@@ -276,7 +279,8 @@ async function handleCreateFeed(
   if (scheduleError) {
     return { error: scheduleError };
   }
-  const nextRunAtVal = nextRunAt(schedule);
+  // Don't schedule a first run for a feed whose connection is still pending auth.
+  const nextRunAtVal = feedInitialStatus === 'active' ? nextRunAt(schedule) : null;
   const entityIdsValue =
     args.entity_ids && args.entity_ids.length > 0 ? pgBigintArray(args.entity_ids) : null;
 
@@ -293,7 +297,7 @@ async function handleCreateFeed(
       organization_id, connection_id, feed_key, display_name, status,
       entity_ids, config, schedule, next_run_at
     ) VALUES (
-      ${organizationId}, ${args.connection_id}, ${args.feed_key}, ${displayName}, 'active',
+      ${organizationId}, ${args.connection_id}, ${args.feed_key}, ${displayName}, ${feedInitialStatus},
       ${entityIdsValue}::bigint[],
       ${args.config ? sql.json(args.config) : null},
       ${schedule}, ${nextRunAtVal}


### PR DESCRIPTION
**Stacks on #619** (`feat/connections-slug` — adds `slug` to connections). Review/merge #619 first; this targets that branch, not `main`.

## What

Extends `lobu apply` to sync a project's `connectors/` directory — data-source connectors (the `manage_connections` / `manage_feeds` / `manage_auth_profiles` world) — in the same desired-state → diff → render → apply shape as agents / platforms / watchers.

### `[memory] connectors` config key
New optional `connectors` dir path under `[memory]` in `lobu.toml`, alongside `models` / `data` (`packages/core/src/lobu-toml-schema.ts`). Defaults to `./connectors`.

### `connectors/` manifests — three doc types
Multi-doc YAML (`---`-separated), each with `version: 1` and a `type:`:

- **`type: connection`** — `slug` (diff key), `connector` (connector key), `name`, `auth` / `app_auth` (auth-profile slugs), `config` (validated against the connector's `optionsSchema`), `feeds` (`[{ feed, name?, schedule?, config? }]`; each `config` validated against that feed's `configSchema`).
- **`type: auth_profile`** — `slug`, `connector`, `kind` (`env|oauth_app|oauth_account|browser_session`), `name`, `credentials` (key→value; `$ENV` refs are expanded and added to the required-secrets gate). For `oauth_account` / `browser_session`, `credentials` must be absent — `lobu apply` never writes interactive-auth tokens; it ensures the profile exists and adds it to a post-apply punch-list with the server's `connect_url`.
- **`type: connector`** — `key` + exactly one of `source_path` (local `.ts`) or `source_url` (remote). Plus: any `*.connector.ts` in the `connectors/` dir is auto-discovered as a connector definition without needing a `type: connector` doc.

### CLI pushes raw connector source — the server compiles
The CLI never compiles connectors locally. For each `*.connector.ts` (and `type: connector` with `source_path:`) it reads the file as raw text and pushes it via `manage_connections install_connector` (`compiled: false`); the server compiles, extracts metadata, and returns the connector key. `source_url` is passed straight through. Bundled connectors referenced by a connection/auth-profile are installed first from the catalog's server-side source URI (so `create_auth_profile`, which only resolves *installed* defs, succeeds). Config / feed-config / auth-kind validation uses the remote connector-definition catalog (Ajv); structural validation runs at load time. Type reuse: `ConnectorDefinition` / `FeedDefinition` / `ConnectorAuthSchema` from `@lobu/connector-sdk` — no parallel interfaces, no `@lobu/server` dependency added to the CLI.

### Diff / apply
- Connector definitions keyed by `key` (or, for a not-yet-compiled local `.ts`, rendered as a `sync` action that `install_connector` resolves to a no-op when the code is byte-identical). Auth profiles / connections / feeds by slug / `feed_key`. `config` / `schedule` changes are updates, not recreates.
- **Conservative — no auto-delete / no auto-uninstall.** Undeclared remote auth profiles / connections / feeds are reported as drift, never deleted; undeclared remote connector definitions become an informational note (suppressed when the project has auto-discovered `.connector.ts` files whose keys the CLI can't know up front). Apply order: connector defs → bundled-connector pre-install → auth profiles → connections → feeds.
- Post-apply punch-list lists every `oauth_account` / `browser_session` profile that isn't `active` with its `connect_url`, plus the undeclared-connector notes. Renders are deterministic (desired ordering; remote drift / notes sorted by slug / key).

### `examples/lobu-crm/connectors/*`
Wired through `[memory].connectors = "./connectors"`:
- `github.yaml` — `oauth_app` (client creds from env) + `oauth_account` (no creds — finish in dashboard) + connection on `lobu-ai/lobu` with stargazers / issues / issue-comments / pr-comments feeds.
- `hackernews.yaml` — no-auth connection searching `lobu OR openclaw` (+ `stories` feed).
- `x.yaml` — `oauth_account` (no creds) + `@lobu` mentions connection (+ `tweets` feed).
- `changelog-watch.yaml` — `website` connection scraping lobu.ai + competitor changelogs (+ `pages` feed); competitor domains added to `network.allowed`.
- `funnel-form.connector.ts` — a small custom no-auth connector (modeled on `rss.ts`) pulling demo-request form submissions from a JSON API, with `funnel-form.yaml` wiring its `submissions` feed.

All example manifests pass `lobu apply`'s desired-state + connector-schema validation (verified against the bundled connector definitions).

## Tests
`packages/cli/src/commands/_lib/apply/__tests__/` — desired-state loading/validation of `connectors/` (built-in connection + auth profiles, custom `.connector.ts`, `oauth_account` ref, `$ENV` expansion + missing-env failure, bad config / kind / `source_path`+`source_url`), diff verbs (create / update / noop / drift / needs-auth), the undeclared-connector note, `--only` skipping connectors, and the render snapshot for the connectors sections. `make build-packages` + `bun run typecheck` green.

## Out of scope (PR 3)
Embedded-gateway loading of the `connectors/` dir.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Round 2 — hardening (server PR #619 also updated; this rebased onto it)

**Server (`packages/server/src/tools/admin/`):**
- `manage_auth_profiles.create_auth_profile` for `oauth_account` now persists a real `auth_profiles` row in `status='pending_auth'` immediately (linked to the connect token) instead of returning a token-only response — so a connection declared in the *same* `lobu apply` can reference the profile by slug. The OAuth callback flips it to `active`. Re-creating is idempotent (reuses the row, issues a fresh connect token if still pending).
- `manage_connections.update` and `manage_feeds.update_feed` gain a `replace_config` flag: with an explicit `config`, the stored config is *replaced* (not merged) so a removed manifest key actually disappears remotely and `lobu apply` converges. Default behavior stays merge (web UI / partial updates unaffected). `lobu apply` always passes `replace_config: true`.

**`lobu apply` (CLI):**
- **Security:** `source_url` connector content is fetched **client-side** and uploaded as `source_code` (the gateway never fetches a URL from a project manifest → no SSRF from a manifest). When the project ships custom connector source (`*.connector.ts` / `type: connector`), apply prints a "this will compile & execute connector code on the gateway" warning and requires `--yes`/interactive confirm before uploading. *(Follow-up, out of scope: the server-side connector compiler/metadata-extractor still runs with full gateway env/fs/network and only blocks relative imports — it should run sandboxed. `TODO(security)` left near the install call.)*
- Apply order reworked: **install/update connector definitions → refetch the connector-definition catalog → validate connection/feed config against the now-current schemas → diff → apply auth profiles → connections → feeds.** Fixes validating a connection's config against a *stale* remote connector schema before the declared local connector is installed.
- Reusing a connection `slug` bound to a different `connector` remotely — or an auth-profile `slug` bound to a different `connector`/`kind` — is now a hard `ValidationError` (those fields are immutable server-side), never a silent `update` onto the wrong resource.
- `env`/`oauth_app` auth profiles with declared `credentials` always re-push (idempotent) so rotated secrets propagate — rendered as a redacted `update (credentials)`.
- The post-apply punch-list (pending interactive-auth profiles + connect URLs + informational notes) is **always rendered**, including on partial failure; a plan with only pending-auth rows is treated as actionable, not "nothing to apply".
- `loadDesiredState` validates connection/auth-profile slug format (`^[a-z0-9][a-z0-9-]{0,62}$` / ≤80) and feed cron syntax *before any mutation*; rejects duplicate connector keys across definitions; resolves `type: connector` `source_path` relative to the manifest YAML's directory; `--only agents|memory` skips the `connectors/` dir entirely (so it doesn't require connector secrets).
- Unknown feed keys are rejected for *all* connector feeds (not just those with a `configSchema`). Connector-def diff renders as `update` (re-push) when the key is already installed, not `create`.

**Tests:** slug/cron/dup-key validation, `--only agents` skip, immutable connector/kind mismatch, credential rotation, connector-def update verb, and a convergence check (a fully-mirrored remote state yields no non-idempotent churn).


---

## Round 3 — pre-install plan confirmation, create-path pending auth, dup-key detection (rebased onto the latest #619)

**Server:**
- `manage_connections.create` now accepts a `pending_auth` (or `browser_session`) auth profile — the connection is created `pending_auth` and the OAuth/connect callback flips both the profile and the connection to `active`. This lets a connection reference a freshly-created `oauth_account` profile in the **same** `lobu apply` (round 2 only covered the *update* path; *create* still rejected a non-`active` profile).
- `manage_feeds.create_feed` accepts a `pending_auth` connection — the feed is created `pending_auth` with no `next_run_at` (the connect callback activates feeds together with the connection).
- `manage_auth_profiles.create_auth_profile` (`oauth_account`) deletes the freshly-created `pending_auth` profile if the connect-token insert fails, so a crash between the two can't orphan a row. *(Best-effort cleanup — the orphan is self-healing via retry-reuse anyway; not wrapped in a DB transaction since the underlying helpers don't accept a tx handle, which would be a broader refactor.)*

**`lobu apply` (CLI):**
- **The plan is rendered and confirmed BEFORE any connector definition is installed.** Connector-def install (custom `*.connector.ts` / `type: connector` + bundled-referenced connectors) moved into `executePlan`, after the confirm; its progress rows mirror the plan. `--dry-run` installs nothing and says so. After install, the connector-def catalog is refetched and connection/feed config is re-validated against the now-current schemas (so an updated custom connector's new schema is what the connection config is checked against; a fail there halts the apply with a clear message — the already-installed defs are idempotent).
- **`source_url` is fetched ONLY after the consent gate** ("`lobu apply` will fetch and upload this source; the gateway will compile and execute it"). The fetch is **https-only** (rejected at load time *and* at fetch time), with a **15 s timeout**, a **2 MiB body cap**, and a **content-type sanity check** — `lobu apply` / `--dry-run` never hits a manifest URL without consent.
- **Duplicate `type: connector` keys are now actually detected** — the `source_url`/`source_path` branches and the final all-definitions sweep all cite *both* source files; a `*.connector.ts` and a `type: connector` doc that declare conflicting keys for the same file error out.

**Tests:** a connection referencing a `pending_auth` `oauth_account` profile in the same apply succeeds (connection created `pending_auth`; profile row + linked connect token persisted; re-create is idempotent); duplicate `type: connector` keys → `ValidationError` citing both files (cross-file *and* same-file); non-https `source_url` rejected.

**Outstanding follow-up (unchanged):** the server-side connector compiler/metadata-extractor still runs with full gateway env/fs/network and only blocks relative imports — it should run sandboxed. Tracked separately; `TODO(security)` left near the install path.


---

## Round 4 — paused feeds for pending connections, skip stale-schema prevalidation, bound `source_url` fetch

**Server:**
- `manage_feeds.create_feed` for a `pending_auth` connection now creates the feed as **`paused`** (not `pending_auth` — the `feeds.status` CHECK only allows `active|paused|error`, so round 3's value would have violated the constraint in the very same-apply oauth_account flow it was meant to fix) with no `next_run_at`. The OAuth/connect callback un-pauses the connection's feeds when it activates the connection (and `syncOAuthConnectionsForAuthProfile` already maps a non-active connection to `paused` feeds — `paused` is the consistent value).
- `manage_connections.create` accepts a `pending_auth` auth profile **only for kind `oauth_account`** (which can become active via the OAuth callback); `browser_session` is handled separately; an `env`/`oauth_app` profile that isn't `active` is still an error.

**`lobu apply` (CLI):**
- Pre-install schema validation no longer rejects a connection's config against a *stale* installed connector schema: `validateConnectorState` takes a `skipSchemaForConnectorKeys` set; connector keys declared locally (`*.connector.ts` / `type: connector` with a known key) get only the **structural** checks (auth-slug existence, connector match) in the pre-pass — full JSON-schema validation for those runs **after install + catalog refetch** inside `executePlan`. Connections whose connector isn't locally declared are still validated against the remote catalog up front.
- `source_url` connector content is now read as a **stream**: a single abort timer covers connect *and* body consumption; chunks accumulate counting **bytes** (`chunk.byteLength`) and the fetch is **aborted + an error thrown as soon as the running total exceeds the 2 MiB cap** — before buffering the rest; the body is decoded to UTF-8 only after the bounded read. (Round 3's check ran `res.text()` to completion with no live timeout and compared UTF-16 code units.) `readBoundedBody` is extracted + exported and unit-tested.
- Connector-definition install + post-install schema re-validation moved to the **start of `executePlan`** (before agents/settings/platforms/memory/watchers), so a post-install schema rejection halts the apply before mutating anything unrelated.
- The post-apply punch-list no longer lists auth profiles that don't exist remotely: an `oauth_account` row is included only if `reconnectAuthProfile` succeeded (⇒ the profile exists and got a fresh connect URL); a `browser_session` row only if `getAuthProfileBySlug` found it.
- `desired-state` rejects two `type: connector` docs declaring the same key **even when they point at the same `source_path`** (a key may be declared by at most one `type: connector` doc), citing both files.

**Tests:** a feed created under a `pending_auth` connection lands `paused` with no `next_run_at` (and `create_feed` doesn't blow up); `readBoundedBody` aborts on overflow and counts bytes not UTF-16 code units; `validateConnectorState` skips the stale schema for locally-declared keys but still runs structural checks; duplicate `type: connector` keys (incl. same-`source_path`) → `ValidationError` citing both files.


**Round-4 follow-ups from a `pi` pass on this round:**
- A bundled connector referenced by a connection/auth-profile is never overwritten by the bundled `source_uri` install when the project supplies its own source for that key — the resolved key is added to the already-installed / locally-supplied sets as soon as `install_connector` returns, so the bundled-install loop can't race a just-installed local connector.
- Referenced-but-not-installed bundled connectors now appear as `connector-definition` create rows in the plan (and counts), so the operator approves those connector-definition mutations too — previously they were installed inside `executePlan` without a plan row.
- Verified both `pending_auth` activation paths un-pause feeds: the OAuth callback (`oauth_account`) and `syncConnectionsForBrowserAuthProfile(..., true)` (`browser_session`) — so the `paused`-feed-on-`pending_auth`-connection behavior is safe for both.
- `reader.releaseLock()` in `readBoundedBody`'s `finally` is wrapped (it's a no-op after `cancel()`, but a throw there would mask the overflow error).

**Not done (declined / out of scope):** the `pi` pass flagged that `install_connector` *activates* the new connector definition before `lobu apply` validates desired connection/feed config against the fresh schema — so a manifest config typo could leave the org with new connector code + old configs (the operator then re-runs apply with the config fixed; the connector-def install is idempotent). A "compile/extract/validate in a staging mode, then activate" shape would close that, but it's a non-trivial server change to the `install_connector` path (same area as the already-noted `TODO(security)` about sandboxing the compiler) — tracked separately, not in this PR. `manage_auth_profiles.create_auth_profile`'s profile-row + connect-token pair is still not wrapped in a DB transaction (the helpers don't accept a tx handle); best-effort orphan cleanup is in place and the orphan is self-healing via retry-reuse.


**Round-5 (final `pi` follow-up):** the post-install connector re-validation is now **strict** — after install + catalog refetch, every connector key referenced by a desired auth profile or connection must be present in the fresh catalog with `installed === true`, else a hard `ValidationError` *before* `executePlan` mutates any agent/setting/platform/memory/watcher (the connector-def install + this check are the first thing `executePlan` does). Previously a typo'd `connector:` ref — or a local `*.connector.ts` whose compiled `definition.key` differs from what the manifest assumed — got `null` schemas and was silently skipped, so apply only failed much later at auth-profile/connection creation. (`validateConnectorState` now takes an options object: `{ skipSchemaForConnectorKeys }` for the pre-install pass, `{ requireInstalled: true }` for the post-install pass.)
