### PR TITLE
fix(test): list connections.device_worker_id in QUERYABLE_SCHEMA

### DIFF
--- a/packages/server/src/utils/table-schema.ts
+++ b/packages/server/src/utils/table-schema.ts
@@ -108,7 +108,8 @@ export const QUERYABLE_SCHEMA = {
         'app_auth_profile_id',
         'visibility',
         'deleted_at',
-        'agent_id'
+        'agent_id',
+        'device_worker_id'
       ),
     },
     // watchers


### PR DESCRIPTION
Follow-up to #620 — the device-pin migration added `connections.device_worker_id`, which broke the `QUERYABLE_SCHEMA` drift test in `table-schema.test.ts` (the `integration` CI job). Adds the column to the allowlist.