### PR TITLE
feat(connectors): device-pinning follow-ups (#620)

### DIFF
--- a/packages/server/src/tools/admin/manage_connections.ts
+++ b/packages/server/src/tools/admin/manage_connections.ts
@@ -267,6 +267,12 @@ const ConnectAction = Type.Object({
   config: Type.Optional(
     Type.Record(Type.String(), Type.Any(), { description: 'Connection config' })
   ),
+  device_worker_id: Type.Optional(
+    Type.String({
+      description:
+        "Run this connection's syncs/actions on a specific device worker (its device_workers.id) instead of the cloud pool. Required for connectors that declare a required_capability; optional otherwise. The device must belong to you or be granted to this org.",
+    })
+  ),
   entity_link_overrides: Type.Optional(EntityLinkOverridesSchema),
 });
 
@@ -1101,6 +1107,29 @@ async function handleConnect(
     };
   }
 
+  const deviceBinding = await resolveDeviceBinding({
+    organizationId,
+    userId,
+    connector,
+    deviceWorkerId: args.device_worker_id,
+  });
+  if ('error' in deviceBinding) return deviceBinding;
+  if (deviceBinding.deviceWorkerId) {
+    const dup = (await sql`
+      SELECT id FROM connections
+      WHERE organization_id = ${organizationId}
+        AND connector_key = ${args.connector_key}
+        AND device_worker_id = ${deviceBinding.deviceWorkerId}
+        AND deleted_at IS NULL
+      LIMIT 1
+    `) as unknown as Array<{ id: number }>;
+    if (dup.length > 0) {
+      return {
+        error: `A ${connector.name} connection (id: ${dup[0].id}) is already assigned to that device in this org.`,
+      };
+    }
+  }
+
   if (args.entity_link_overrides !== undefined) {
     const err = await applyEntityLinkOverrides(
       organizationId,
@@ -1134,6 +1163,7 @@ async function handleConnect(
       AND c.status = 'pending_auth'
       AND c.deleted_at IS NULL
       ${explicitSlug ? sql`AND c.slug = ${explicitSlug}` : sql``}
+      ${deviceBinding.deviceWorkerId ? sql`AND c.device_worker_id = ${deviceBinding.deviceWorkerId}` : sql``}
       ${userId ? sql`AND c.created_by = ${userId}` : sql``}
     ORDER BY ct.created_at DESC
     LIMIT 1
@@ -1256,7 +1286,7 @@ async function handleConnect(
       doInsert: (slug) => sql`
         INSERT INTO connections (
           organization_id, connector_key, slug, display_name, status,
-          auth_profile_id, app_auth_profile_id, config, created_by, visibility
+          auth_profile_id, app_auth_profile_id, config, created_by, visibility, device_worker_id
         ) VALUES (
           ${organizationId}, ${args.connector_key},
           ${slug},
@@ -1266,7 +1296,8 @@ async function handleConnect(
           ${authSelection.appAuthProfile?.id ?? null},
           ${splitConfig.connectionConfig ? sql.json(splitConfig.connectionConfig) : null},
           ${userId},
-          ${connectVisibility}
+          ${connectVisibility},
+          ${deviceBinding.deviceWorkerId}
         )
         RETURNING *
       `,

--- a/packages/server/src/worker-api.ts
+++ b/packages/server/src/worker-api.ts
@@ -9,7 +9,7 @@ import { basename } from 'node:path';
 import type { Context } from 'hono';
 import { createAuth } from './auth';
 import { findExistingPersonalOrg } from './auth/personal-org-provisioning';
-import { getDb, pgTextArray } from './db/client';
+import { getDb, pgBigintArray, pgTextArray } from './db/client';
 import { emit } from './events/emitter';
 import type { Env } from './index';
 import { notifyBrowserAuthExpired } from './notifications/triggers';
@@ -108,7 +108,7 @@ async function ensureDeviceConnectorWired(
       SET device_worker_id = ${target}::uuid, updated_at = NOW()
       WHERE id = ${connectionId}
         AND device_worker_id IS DISTINCT FROM ${target}::uuid
-        AND (device_worker_id IS NULL OR NOT (device_worker_id = ANY(${matchingDeviceIds}::uuid[])))
+        AND (device_worker_id IS NULL OR NOT (device_worker_id = ANY(${pgTextArray(matchingDeviceIds)}::uuid[])))
     `;
   };
 
@@ -121,9 +121,13 @@ async function ensureDeviceConnectorWired(
       SELECT
         c.id AS connection_id,
         cv.connector_key AS version_key,
+        -- jsonb_agg, not array_agg: postgres.js (fetch_types:false) returns a
+        -- text[] result column as the literal string "{a,b}", which would make
+        -- the fast-path feed check below silently always miss. jsonb arrays are
+        -- parsed to JS arrays by the db client's value transform.
         COALESCE(
-          array_agg(f.feed_key) FILTER (WHERE f.id IS NOT NULL),
-          ARRAY[]::text[]
+          jsonb_agg(f.feed_key) FILTER (WHERE f.id IS NOT NULL),
+          '[]'::jsonb
         ) AS active_feed_keys
       FROM connector_definitions cd
       LEFT JOIN connector_versions cv
@@ -423,7 +427,7 @@ async function reconcileStaleDeviceGrants(userId: string): Promise<void> {
         if (ids.length > 0) {
           await tx`
             UPDATE feeds SET status = 'paused', updated_at = NOW()
-            WHERE connection_id = ANY(${ids}::bigint[]) AND deleted_at IS NULL AND status = 'active'
+            WHERE connection_id = ANY(${pgBigintArray(ids)}::bigint[]) AND deleted_at IS NULL AND status = 'active'
           `;
         }
       }
@@ -1865,9 +1869,12 @@ export async function listDeviceWorkers(c: Context<{ Bindings: Env }>) {
         dw.label,
         dw.last_seen_at,
         (dw.last_seen_at > now() - interval '20 minutes') AS online,
-        COALESCE(
-          (SELECT array_agg(g.organization_id) FROM device_worker_org_grants g WHERE g.device_worker_id = dw.id),
-          ARRAY[]::text[]
+        -- jsonb_agg (not array_agg): postgres.js runs with fetch_types:false and
+        -- leaves a text[] result column as the raw literal string "{a,b}"; jsonb
+        -- arrays are parsed to JS arrays by the db client's value transform.
+        (
+          SELECT COALESCE(jsonb_agg(g.organization_id), '[]'::jsonb)
+          FROM device_worker_org_grants g WHERE g.device_worker_id = dw.id
         ) AS granted_org_ids,
         (SELECT count(*) FROM connections cn WHERE cn.device_worker_id = dw.id AND cn.deleted_at IS NULL)::int AS connector_count
       FROM device_workers dw
@@ -1970,7 +1977,7 @@ export async function setDeviceOrgGrant(c: Context<{ Bindings: Env }>, grant: bo
         if (ids.length > 0) {
           await tx`
             UPDATE feeds SET status = 'paused', updated_at = NOW()
-            WHERE connection_id = ANY(${ids}::bigint[]) AND deleted_at IS NULL AND status = 'active'
+            WHERE connection_id = ANY(${pgBigintArray(ids)}::bigint[]) AND deleted_at IS NULL AND status = 'active'
           `;
         }
       });

--- a/packages/server/src/worker-api.ts
+++ b/packages/server/src/worker-api.ts
@@ -81,19 +81,37 @@ function normalizeAdvertisedCapabilities(capabilities: Record<string, boolean>):
  * devices so they don't race past the existence checks and create duplicates.
  * Best-effort: failures are logged but never surface to the poll response.
  *
- * Note: the connection it creates is intentionally left *unpinned*
- * (`device_worker_id = NULL`). "Unpinned" means "any of this user's fresh
- * devices that advertise the capability" — exactly the right semantics for a
- * personal-org auto-wire. An explicit per-device binding is something the user
- * sets via `manage_connections`; per-device auto-wire is a possible follow-up.
+ * Device pin (`connections.device_worker_id`): when exactly one of the user's
+ * fresh devices advertises the capability, the connection is auto-pinned to it
+ * (a deterministic 1:1 binding the Devices page can show); when several qualify
+ * it's left unpinned ("any of my fresh devices that advertise the capability").
+ * A pin to a device that's still in the fresh set is treated as deliberate and
+ * never overridden; a pin to a device that has dropped out is repaired (to the
+ * sole remaining fresh device, or NULL) so the connection keeps running.
  */
 async function ensureDeviceConnectorWired(
   userId: string,
   organizationId: string,
   connectorKey: string,
-  declaredFeedKeys: string[]
+  declaredFeedKeys: string[],
+  matchingDeviceIds: string[]
 ): Promise<void> {
   const sql = getDb();
+
+  // Self-heal the device pin against the user's current fleet. Cheap, idempotent
+  // (the WHERE matches nothing when the pin is already a valid fresh device), and
+  // runs even on the fast path so a stale pin doesn't silently strand the feeds.
+  const reconcilePin = async (db: typeof sql, connectionId: number) => {
+    const target = matchingDeviceIds.length === 1 ? matchingDeviceIds[0] : null;
+    await db`
+      UPDATE connections
+      SET device_worker_id = ${target}::uuid, updated_at = NOW()
+      WHERE id = ${connectionId}
+        AND device_worker_id IS DISTINCT FROM ${target}::uuid
+        AND (device_worker_id IS NULL OR NOT (device_worker_id = ANY(${matchingDeviceIds}::uuid[])))
+    `;
+  };
+
   try {
     // Fast path: definition + version + connection + EVERY declared feed active
     // → nothing to repair or re-activate. The feed list comes from the bundled
@@ -129,6 +147,9 @@ async function ensureDeviceConnectorWired(
       version_key: string | null;
       active_feed_keys: string[] | null;
     }>;
+    if (existingReady[0]?.connection_id) {
+      await reconcilePin(sql, existingReady[0].connection_id);
+    }
     const activeFeedKeys = new Set(existingReady[0]?.active_feed_keys ?? []);
     if (
       existingReady[0]?.connection_id &&
@@ -242,6 +263,10 @@ async function ensureDeviceConnectorWired(
           `;
         }
       }
+
+      // Pin the (possibly just-created) connection to the sole fresh device
+      // serving the capability, or leave it unpinned when several do.
+      await reconcilePin(tx, connectionId);
     });
 
     if (connectionId) {
@@ -317,15 +342,20 @@ async function reconcileDeviceCapabilities(userId: string): Promise<void> {
   }
   if (deviceConnectors.length === 0) return;
 
-  let liveCaps = new Set<string>();
+  // deviceId → capabilities it currently advertises (fresh devices only). Used
+  // both to decide which connectors to wire and which device to pin them to.
+  const deviceCaps = new Map<string, Set<string>>();
   try {
     const rows = (await sql`
-      SELECT DISTINCT jsonb_array_elements_text(capabilities) AS cap
+      SELECT id, capabilities
       FROM device_workers
       WHERE user_id = ${userId}
         AND last_seen_at > now() - ${DEVICE_WORKER_FRESH_INTERVAL}::interval
-    `) as unknown as Array<{ cap: string }>;
-    liveCaps = new Set(rows.map((r) => r.cap));
+    `) as unknown as Array<{ id: string; capabilities: unknown }>;
+    for (const r of rows) {
+      const caps = Array.isArray(r.capabilities) ? (r.capabilities as string[]) : [];
+      deviceCaps.set(r.id, new Set(caps));
+    }
   } catch (err) {
     logger.warn(
       { userId, err: errorMessage(err) },
@@ -333,6 +363,8 @@ async function reconcileDeviceCapabilities(userId: string): Promise<void> {
     );
     return;
   }
+  const devicesWithCapability = (capability: string): string[] =>
+    [...deviceCaps.entries()].filter(([, caps]) => caps.has(capability)).map(([id]) => id);
 
   const personalOrg = await findExistingPersonalOrg(userId, sql).catch(() => null);
   if (!personalOrg) {
@@ -341,12 +373,71 @@ async function reconcileDeviceCapabilities(userId: string): Promise<void> {
   }
 
   await Promise.allSettled(
-    deviceConnectors.map((dc) =>
-      liveCaps.has(dc.requiredCapability)
-        ? ensureDeviceConnectorWired(userId, personalOrg.id, dc.key, dc.feedKeys)
-        : pauseStaleDeviceFeeds(userId, personalOrg.id, dc.key)
-    )
+    deviceConnectors.map((dc) => {
+      const matchingDeviceIds = devicesWithCapability(dc.requiredCapability);
+      return matchingDeviceIds.length > 0
+        ? ensureDeviceConnectorWired(
+            userId,
+            personalOrg.id,
+            dc.key,
+            dc.feedKeys,
+            matchingDeviceIds
+          )
+        : pauseStaleDeviceFeeds(userId, personalOrg.id, dc.key);
+    })
   );
+}
+
+/**
+ * Drop this user's device→org grants for orgs they're no longer a member of, and
+ * un-pin + pause the connections those grants backed (same effect as the owner
+ * explicitly revoking the grant via `DELETE /api/me/device-grants`). Membership
+ * changes happen in Better Auth without a hook into the gateway, so this runs
+ * opportunistically on every user-scoped poll. Best-effort; never throws.
+ */
+async function reconcileStaleDeviceGrants(userId: string): Promise<void> {
+  const sql = getDb();
+  try {
+    await sql.begin(async (tx) => {
+      const stale = (await tx`
+        DELETE FROM device_worker_org_grants g
+        WHERE g.device_worker_id IN (SELECT id FROM device_workers WHERE user_id = ${userId})
+          AND NOT EXISTS (
+            SELECT 1 FROM "member" m
+            WHERE m."userId" = ${userId} AND m."organizationId" = g.organization_id
+          )
+        RETURNING g.device_worker_id, g.organization_id
+      `) as unknown as Array<{ device_worker_id: string; organization_id: string }>;
+      if (stale.length === 0) return;
+      for (const { device_worker_id, organization_id } of stale) {
+        const affected = (await tx`
+          UPDATE connections
+          SET device_worker_id = NULL,
+              status = 'paused',
+              error_message = 'Device access to this organization was revoked',
+              updated_at = NOW()
+          WHERE device_worker_id = ${device_worker_id} AND organization_id = ${organization_id}
+          RETURNING id
+        `) as unknown as Array<{ id: number }>;
+        const ids = affected.map((r) => r.id);
+        if (ids.length > 0) {
+          await tx`
+            UPDATE feeds SET status = 'paused', updated_at = NOW()
+            WHERE connection_id = ANY(${ids}::bigint[]) AND deleted_at IS NULL AND status = 'active'
+          `;
+        }
+      }
+      logger.info(
+        { userId, grants: stale.length },
+        '[device-connectors] Reconciled stale device→org grants'
+      );
+    });
+  } catch (err) {
+    logger.warn(
+      { userId, err: errorMessage(err) },
+      '[device-connectors] Failed to reconcile stale device→org grants'
+    );
+  }
 }
 
 /**
@@ -492,6 +583,9 @@ export async function pollWorkerJob(c: Context<{ Bindings: Env }>) {
       // the ones that have gone away. The just-upserted row above is already
       // visible to this query, so the polling device's capabilities count.
       await reconcileDeviceCapabilities(workerUserId);
+      // Membership changes (leaving an org) happen outside the gateway; drop any
+      // now-orphaned device→org grants and pause the connections they backed.
+      await reconcileStaleDeviceGrants(workerUserId);
     } catch (err) {
       logger.error(
         { worker_id, err: errorMessage(err) },


### PR DESCRIPTION
Follow-ups deferred from #620 (device-pinned connectors). **End-to-end tested** against a fresh Postgres + `make dev` — see "Validation" below.

## What's in here

### `manage_connections(action='connect')` takes `device_worker_id`
`connect` previously couldn't pin the connection it creates — only `create`/`update` could. It now accepts `device_worker_id`, runs it through the same `resolveDeviceBinding` validation (owner-or-grant + capability + one-per-device), threads it into the inserted row, and only reuses a *matching* pending-auth connection on the idempotent path. Required-capability connectors created via `connect` therefore work the same as via `create`.

### Auto-wired device connectors self-heal their device pin
`reconcileDeviceCapabilities` now looks at *which* fresh devices advertise each capability, not just whether any does. `ensureDeviceConnectorWired` reconciles `connections.device_worker_id`:
- exactly one fresh device serves the capability → pin to it (deterministic 1:1, surfaces in the Devices "Connectors" column);
- several serve it → leave unpinned (`NULL` = "any of my fresh devices", as before);
- pinned to a device that's no longer fresh → repointed to the sole remaining fresh device, or `NULL`, so the feeds aren't stranded on a dead device;
- pinned to a device that's *still* fresh → treated as deliberate, never overridden.

Runs on the fast path too (cheap idempotent `UPDATE` whose `WHERE` matches nothing when the pin is already valid).

### Membership-leave grant reconcile
Better Auth handles org member removal with no hook into the gateway, so on every user-scoped worker poll we now also drop the user's `device_worker_org_grants` rows for orgs they're no longer a member of and un-pin + pause the connections those grants backed — same effect as the owner calling `DELETE /api/me/device-grants`.

### Devices page: share a device with a workspace (owletto-web bump)
New per-row **Share** action on `/$owner/devices` opening a sheet that lists the workspaces the device owner belongs to. Granting is one click; revoking uses the inline two-step confirm (per the design guidelines — it pauses that workspace's connectors on the device). Built entirely on the `granted_org_ids` field returned by `GET /api/me/devices` and the existing `POST/DELETE /api/me/device-grants` endpoints; no new server endpoint. owletto-web: lobu-ai/owletto-web@ecb2eb2.

### Drive-by fixes (uncovered by the e2e run — pre-existing #620 bugs)
- `listDeviceWorkers` returned `granted_org_ids` as the raw `text[]` literal string `'{a,b}'` — postgres.js runs with `fetch_types:false` and doesn't parse `text[]` result columns — so `/api/me/devices` always reported `[]` and a device could never show as shared in the new UI. Switched the subquery to `jsonb_agg` (the db client's value transform parses jsonb to a JS array). Same fix for `active_feed_keys` in `ensureDeviceConnectorWired`, whose fast-path feed check silently always missed → every poll re-ran the full wiring transaction.
- `setDeviceOrgGrant`'s revoke branch passed a JS array straight into `ANY(${ids}::bigint[])` → `malformed array literal` at runtime, so revoking never actually un-pinned/paused the connections. Now uses `pgBigintArray()`/`pgTextArray()` literals like the rest of `worker-api.ts` (also applied to `reconcileStaleDeviceGrants` and `reconcilePin`).

## Validation
- `tsc -p packages/server` ✓, `tsc -b` (web) ✓, root `tsc --noEmit` (pre-commit) ✓, Biome ✓
- web routes smoke test (31 tests) ✓
- **e2e against a fresh migrated Postgres + `make dev`:**
  - grant → `granted_org_ids` updates in API and UI; second grant; revoke → un-pins + pauses the org's pinned connection and its feed, `connector_count` and `granted_org_ids` reflect it
  - share sheet: open, grant (toast + live re-render to "Shared"/"Revoke"), two-step revoke confirm, table row "N workspaces" badge
  - error cases: grant to a non-member org → 403, grant unknown device → 404
  - `reconcilePin` SQL exercised across all device-fleet states (unpinned→pin sole device, preserve manual pin to fresh device, repoint off stale device, NULL when ambiguous)
  - `connect`-action insert with `device_worker_id` validated against the schema

🤖 Generated with [Claude Code](https://claude.com/claude-code)