### PR TITLE
refactor(cli): standardize entity-type metadata on metadata_schema

### DIFF
--- a/packages/cli/src/commands/_lib/apply/__tests__/desired-state.test.ts
+++ b/packages/cli/src/commands/_lib/apply/__tests__/desired-state.test.ts
@@ -357,6 +357,46 @@ entities:
     ]);
   });
 
+  test("reads inline [memory.schema] entity/relationship types with metadata_schema", async () => {
+    const dir = mkProject(
+      `[agents.triage]
+name = "Triage"
+dir = "./agents/triage"
+
+[memory]
+enabled = true
+org = "dev"
+
+[[memory.schema.entity_types]]
+slug = "account"
+name = "Account"
+metadata_schema = { type = "object", required = ["tier"], properties = { tier = { type = "string" } } }
+
+[[memory.schema.relationship_types]]
+slug = "owns"
+name = "Owns"
+rules = [{ source = "account", target = "product" }]
+`
+    );
+
+    const { state } = await loadDesiredState({ cwd: dir });
+    expect(state.memorySchema.entityTypes).toEqual([
+      {
+        slug: "account",
+        name: "Account",
+        required: ["tier"],
+        properties: { tier: { type: "string" } },
+      },
+    ]);
+    expect(state.memorySchema.relationshipTypes).toEqual([
+      {
+        slug: "owns",
+        name: "Owns",
+        rules: [{ source: "account", target: "product" }],
+      },
+    ]);
+  });
+
   test("surfaces a YAML syntax error with file context", async () => {
     const dir = mkProject(
       `[agents.triage]

--- a/packages/cli/src/commands/_lib/apply/desired-state.ts
+++ b/packages/cli/src/commands/_lib/apply/desired-state.ts
@@ -718,12 +718,6 @@ function parseEntityType(raw: unknown): DesiredEntityType {
       out.properties = raw.metadata_schema.properties;
     }
   }
-  if (Array.isArray(raw.required)) {
-    out.required = raw.required.filter(
-      (v): v is string => typeof v === "string"
-    );
-  }
-  if (isRecord(raw.properties)) out.properties = raw.properties;
   if (isRecord(raw.metadata)) out.metadata = raw.metadata;
   return out;
 }

--- a/packages/landing/src/content/docs/reference/lobu-toml.md
+++ b/packages/landing/src/content/docs/reference/lobu-toml.md
@@ -348,6 +348,20 @@ In addition to the file-first fields above, `[memory]` accepts an inline `schema
 | `entity_types` | array | no | Entity-type definitions |
 | `relationship_types` | array | no | Relationship-type definitions |
 
+Each entity type takes `slug` (required), optional `name` / `description`, and an optional JSON-Schema `metadata_schema`; each relationship type takes `slug`, optional `name` / `description`, and optional `rules` (`{ source, target }` entity-type pairs) — the same shapes used by `version: 2` model bundles under `[memory].models`.
+
+```toml
+[[memory.schema.entity_types]]
+slug = "account"
+name = "Account"
+metadata_schema = { type = "object", required = ["tier"], properties = { tier = { type = "string" } } }
+
+[[memory.schema.relationship_types]]
+slug = "owns"
+name = "Owns"
+rules = [{ source = "account", target = "product" }]
+```
+
 The `[memory]` table is `.strict()` — unknown keys fail validation.
 
 ## Environment variable references


### PR DESCRIPTION
Remove the legacy top-level required/properties parsing from parseEntityType;
`version: 2` model bundles and inline [memory.schema] both use a JSON-Schema
`metadata_schema` object. Document the inline-schema item shapes.
