### PR TITLE
feat(cli)!: remove inline [memory.schema] from lobu.toml

### DIFF
--- a/packages/cli/src/commands/_lib/apply/__tests__/desired-state.test.ts
+++ b/packages/cli/src/commands/_lib/apply/__tests__/desired-state.test.ts
@@ -357,7 +357,7 @@ entities:
     ]);
   });
 
-  test("reads inline [memory.schema] entity/relationship types with metadata_schema", async () => {
+  test("rejects the removed inline [memory.schema] block", async () => {
     const dir = mkProject(
       `[agents.triage]
 name = "Triage"
@@ -370,31 +370,10 @@ org = "dev"
 [[memory.schema.entity_types]]
 slug = "account"
 name = "Account"
-metadata_schema = { type = "object", required = ["tier"], properties = { tier = { type = "string" } } }
-
-[[memory.schema.relationship_types]]
-slug = "owns"
-name = "Owns"
-rules = [{ source = "account", target = "product" }]
 `
     );
 
-    const { state } = await loadDesiredState({ cwd: dir });
-    expect(state.memorySchema.entityTypes).toEqual([
-      {
-        slug: "account",
-        name: "Account",
-        required: ["tier"],
-        properties: { tier: { type: "string" } },
-      },
-    ]);
-    expect(state.memorySchema.relationshipTypes).toEqual([
-      {
-        slug: "owns",
-        name: "Owns",
-        rules: [{ source: "account", target: "product" }],
-      },
-    ]);
+    await expect(loadDesiredState({ cwd: dir })).rejects.toThrow();
   });
 
   test("surfaces a YAML syntax error with file context", async () => {

--- a/packages/cli/src/commands/_lib/apply/desired-state.ts
+++ b/packages/cli/src/commands/_lib/apply/desired-state.ts
@@ -690,11 +690,6 @@ function buildPlatforms(
   return out;
 }
 
-interface RawMemorySchema {
-  entity_types?: unknown;
-  relationship_types?: unknown;
-}
-
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
@@ -702,7 +697,7 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 function parseEntityType(raw: unknown): DesiredEntityType {
   if (!isRecord(raw) || typeof raw.slug !== "string") {
     throw new ValidationError(
-      `memory.entity_types entries must be objects with a "slug" string field; got ${JSON.stringify(raw)}`
+      `model-bundle "entities" entries must be objects with a "slug" string field; got ${JSON.stringify(raw)}`
     );
   }
   const out: DesiredEntityType = { slug: raw.slug };
@@ -759,7 +754,7 @@ function parseWatcher(raw: unknown): DesiredWatcher {
 function parseRelationshipType(raw: unknown): DesiredRelationshipType {
   if (!isRecord(raw) || typeof raw.slug !== "string") {
     throw new ValidationError(
-      `memory.relationship_types entries must be objects with a "slug" string field; got ${JSON.stringify(raw)}`
+      `model-bundle "relationships" entries must be objects with a "slug" string field; got ${JSON.stringify(raw)}`
     );
   }
   const out: DesiredRelationshipType = { slug: raw.slug };
@@ -806,23 +801,6 @@ async function loadMemoryModels(
   };
   const mem = config.memory;
   if (!mem || mem.enabled === false) return empty;
-
-  const inline = config.memory as unknown as
-    | { schema?: RawMemorySchema }
-    | undefined;
-  if (inline?.schema) {
-    const entityTypesRaw = Array.isArray(inline.schema.entity_types)
-      ? inline.schema.entity_types
-      : [];
-    const relTypesRaw = Array.isArray(inline.schema.relationship_types)
-      ? inline.schema.relationship_types
-      : [];
-    return {
-      entityTypes: entityTypesRaw.map(parseEntityType),
-      relationshipTypes: relTypesRaw.map(parseRelationshipType),
-      watchers: [],
-    };
-  }
 
   // Models directory (matches seed-cmd's resolution rules).
   const modelsRel = mem.models?.trim() || "./models";

--- a/packages/core/src/__tests__/lobu-toml-schema.test.ts
+++ b/packages/core/src/__tests__/lobu-toml-schema.test.ts
@@ -53,7 +53,7 @@ models = "./custom-models"
     });
   }
 
-  test("keeps inline [memory.schema] support", () => {
+  test("rejects the removed inline [memory.schema] block", () => {
     const parsed = parseToml(`${BASE_AGENT}
 [memory]
 enabled = true
@@ -66,9 +66,6 @@ slug = "person"
 
     const result = lobuConfigSchema.safeParse(parsed);
 
-    expect(result.success).toBe(true);
-    if (result.success) {
-      expect(result.data.memory?.schema?.entity_types).toHaveLength(1);
-    }
+    expect(result.success).toBe(false);
   });
 });

--- a/packages/core/src/lobu-toml-schema.ts
+++ b/packages/core/src/lobu-toml-schema.ts
@@ -196,11 +196,6 @@ const agentEntrySchema = z.object({
 
 // ── Memory ─────────────────────────────────────────────────────────────────
 
-const memoryInlineSchema = z.object({
-  entity_types: z.array(z.unknown()).optional(),
-  relationship_types: z.array(z.unknown()).optional(),
-});
-
 const memorySchema = z
   .object({
     enabled: z.boolean().optional(),
@@ -211,7 +206,6 @@ const memorySchema = z
     models: z.string().optional(),
     data: z.string().optional(),
     connectors: z.string().optional(),
-    schema: memoryInlineSchema.optional(),
   })
   .strict();
 

--- a/packages/landing/src/content/docs/reference/lobu-toml.md
+++ b/packages/landing/src/content/docs/reference/lobu-toml.md
@@ -140,7 +140,6 @@ project/
 | `visibility` | string | no | `public` or `private`; defaults to Lobu's account setting |
 | `models` | string | no | Path to Lobu `version: 2` model bundle YAML files, usually `./models` |
 | `data` | string | no | Path to Lobu seed data, usually `./data` |
-| `schema` | table | no | Inline memory schema — `entity_types` / `relationship_types` arrays (see [`[memory.schema]`](#memory-inline-schema-memoryschema) below) |
 
 When `[memory]` is enabled, Lobu reads `org` directly from `lobu.toml` and derives the effective Lobu MCP endpoint. `MEMORY_URL` remains available as an optional base-endpoint override for local or custom Lobu deployments. The `[memory]` table is strict — unknown keys fail validation.
 
@@ -339,30 +338,9 @@ dir = "./agents/assistant"
 guardrails = ["secret-scan", "prompt-injection"]
 ```
 
-### `[memory]` inline schema (`[memory.schema]`)
+### Memory model schema
 
-In addition to the file-first fields above, `[memory]` accepts an inline `schema` sub-table for declaring memory types directly in `lobu.toml`:
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `entity_types` | array | no | Entity-type definitions |
-| `relationship_types` | array | no | Relationship-type definitions |
-
-Each entity type takes `slug` (required), optional `name` / `description`, and an optional JSON-Schema `metadata_schema`; each relationship type takes `slug`, optional `name` / `description`, and optional `rules` (`{ source, target }` entity-type pairs) — the same shapes used by `version: 2` model bundles under `[memory].models`.
-
-```toml
-[[memory.schema.entity_types]]
-slug = "account"
-name = "Account"
-metadata_schema = { type = "object", required = ["tier"], properties = { tier = { type = "string" } } }
-
-[[memory.schema.relationship_types]]
-slug = "owns"
-name = "Owns"
-rules = [{ source = "account", target = "product" }]
-```
-
-The `[memory]` table is `.strict()` — unknown keys fail validation.
+Entity types, relationship types, and watchers are declared in `version: 2` model bundle YAML files under the directory `[memory].models` points at (usually `./models`) — see [`lobu memory seed`](/reference/lobu-memory/) and [`lobu apply`](/reference/lobu-apply/) for the bundle format. The `[memory]` table itself is `.strict()` — unknown keys (including the removed inline `schema` sub-table) fail validation.
 
 ## Environment variable references
 


### PR DESCRIPTION
Entity types, relationship types, and watchers are now declared exclusively in
`version: 2` model bundle YAML files under `[memory].models`. The `[memory]`
table is strict, so a leftover `[memory.schema]` block now fails validation —
move those definitions into a `models/*.yaml` bundle.
