### PR TITLE
feat(cli): `lobu apply` bootstraps a missing org from [memory].org

### DIFF
--- a/packages/cli/src/commands/_lib/apply/__tests__/client.test.ts
+++ b/packages/cli/src/commands/_lib/apply/__tests__/client.test.ts
@@ -78,4 +78,65 @@ describe("ApplyClient", () => {
     });
     expect("entity_id" in body).toBe(false);
   });
+
+  test("listOrgs GETs the better-auth org-list endpoint and tolerates a bare array", async () => {
+    const client = new ApplyClient(
+      { apiBaseUrl: "https://example.test", orgSlug: "acme", token: "tok" },
+      (async (url, init) => {
+        expect(String(url)).toBe(
+          "https://example.test/api/auth/organization/list"
+        );
+        expect(init?.method).toBe("GET");
+        return new Response(
+          JSON.stringify([{ id: "org_1", slug: "acme", name: "Acme" }]),
+          { status: 200 }
+        );
+      }) as typeof fetch
+    );
+
+    expect(await client.listOrgs()).toEqual([
+      { id: "org_1", slug: "acme", name: "Acme" },
+    ]);
+  });
+
+  test("createOrg POSTs name+slug to the better-auth org-create endpoint", async () => {
+    const calls: Array<{ url: string; init?: RequestInit }> = [];
+    const client = new ApplyClient(
+      {
+        apiBaseUrl: "https://example.test",
+        orgSlug: "office-bot",
+        token: "tok",
+      },
+      (async (url, init) => {
+        calls.push({ url: String(url), init });
+        return new Response(
+          JSON.stringify({
+            id: "org_2",
+            slug: "office-bot",
+            name: "Office Bot",
+          }),
+          { status: 200 }
+        );
+      }) as typeof fetch
+    );
+
+    const org = await client.createOrg({
+      slug: "office-bot",
+      name: "Office Bot",
+    });
+    expect(calls[0]?.url).toBe(
+      "https://example.test/api/auth/organization/create"
+    );
+    expect(calls[0]?.init?.method).toBe("POST");
+    expect(JSON.parse(String(calls[0]?.init?.body))).toEqual({
+      name: "Office Bot",
+      slug: "office-bot",
+      keepCurrentActiveOrganization: true,
+    });
+    expect(org).toEqual({
+      id: "org_2",
+      slug: "office-bot",
+      name: "Office Bot",
+    });
+  });
 });

--- a/packages/cli/src/commands/_lib/apply/apply-cmd.ts
+++ b/packages/cli/src/commands/_lib/apply/apply-cmd.ts
@@ -1,6 +1,9 @@
 import chalk from "chalk";
 import { resolveContext } from "../../../internal/context.js";
-import { loadProjectLink } from "../../../internal/project-link.js";
+import {
+  loadProjectLink,
+  saveProjectLink,
+} from "../../../internal/project-link.js";
 import { ApiError, ValidationError } from "../../memory/_lib/errors.js";
 import { printError, printText } from "../../memory/_lib/output.js";
 import {
@@ -25,7 +28,11 @@ import {
   validateAuthProfileAgainstConnector,
   validateConnectionAgainstConnector,
 } from "./desired-state.js";
-import { confirmCustomConnectors, confirmPlan } from "./prompt.js";
+import {
+  confirmCreateOrg,
+  confirmCustomConnectors,
+  confirmPlan,
+} from "./prompt.js";
 import {
   renderMissingSecrets,
   renderPlan,
@@ -743,6 +750,17 @@ async function collectPendingAuthFromPlan(
 
 // ── Top-level command ──────────────────────────────────────────────────────
 
+/** "office-bot" → "Office Bot" — default display name for a bootstrapped org. */
+function slugToTitle(slug: string): string {
+  return (
+    slug
+      .split(/[-_]+/)
+      .filter(Boolean)
+      .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+      .join(" ") || slug
+  );
+}
+
 export async function applyCommand(opts: ApplyOptions = {}): Promise<void> {
   const cwd = opts.cwd ?? process.cwd();
   const fetchImpl = opts.fetchImpl ?? fetch;
@@ -762,9 +780,12 @@ export async function applyCommand(opts: ApplyOptions = {}): Promise<void> {
     );
   }
 
+  // Org slug resolution: explicit --org ▸ active-session org ▸ `[memory].org`
+  // from lobu.toml. The toml slug is the declarative default — if no org with
+  // that slug exists yet, `lobu apply` offers to provision it (below).
   const { client, orgSlug } = await resolveApplyClient({
     url: opts.url,
-    org: opts.org,
+    org: opts.org ?? state.memory?.org,
     fetchImpl: opts.fetchImpl,
   });
   printText(chalk.dim(`Org: ${orgSlug}`));
@@ -797,6 +818,41 @@ export async function applyCommand(opts: ApplyOptions = {}): Promise<void> {
       );
       throw new ValidationError("project-link mismatch");
     }
+  }
+
+  // Bootstrap a missing org. If the resolved slug doesn't match one of the
+  // operator's orgs, offer to create it (Railway `init`-style) and record the
+  // resolved id in `.lobu/project.json`. Older servers without the org-list
+  // endpoint return null → skip the check and let the normal flow surface any
+  // org error.
+  const myOrgs = await client.listOrgs().catch(() => null);
+  if (myOrgs !== null && !myOrgs.some((o) => o.slug === orgSlug)) {
+    const orgName = state.memory?.name ?? slugToTitle(orgSlug);
+    if (opts.dryRun) {
+      printText(
+        chalk.cyan(`\n  + org ${orgSlug} (${orgName}) — would be created`)
+      );
+      printText(
+        chalk.dim(
+          `  then sync ${state.agents.length} agent(s), ${state.watchers.length} watcher(s), ${state.memorySchema.entityTypes.length} entity type(s) into it.\n`
+        )
+      );
+      printText(chalk.dim("Dry run — no changes applied."));
+      return;
+    }
+    const ok = await confirmCreateOrg(orgSlug, orgName, opts.yes ?? false);
+    if (!ok) {
+      printText(chalk.dim("\nCancelled."));
+      return;
+    }
+    const created = await client.createOrg({ slug: orgSlug, name: orgName });
+    const ctx = await resolveContext().catch(() => null);
+    await saveProjectLink(cwd, {
+      context: ctx?.name ?? link?.context ?? "prod",
+      org: created.slug || orgSlug,
+      ...(created.id ? { organizationId: created.id } : {}),
+    });
+    printText(chalk.green(`  ✓ created org ${created.slug || orgSlug}`));
   }
 
   // SECURITY (#4): confirm BEFORE fetching any `source_url` or uploading custom

--- a/packages/cli/src/commands/_lib/apply/client.ts
+++ b/packages/cli/src/commands/_lib/apply/client.ts
@@ -261,14 +261,15 @@ export class ApplyClient {
    * member of, surfaces as a structured error the caller turns into a
    * "pick another slug" message rather than a silent failure.
    */
-  async createOrg(input: {
-    slug: string;
-    name: string;
-  }): Promise<RemoteOrg> {
+  async createOrg(input: { slug: string; name: string }): Promise<RemoteOrg> {
     const { body } = await this.request<RemoteOrg>(
       "POST",
       `/api/auth/organization/create`,
-      { name: input.name, slug: input.slug, keepCurrentActiveOrganization: true },
+      {
+        name: input.name,
+        slug: input.slug,
+        keepCurrentActiveOrganization: true,
+      },
       [200, 201]
     );
     return body;

--- a/packages/cli/src/commands/_lib/apply/client.ts
+++ b/packages/cli/src/commands/_lib/apply/client.ts
@@ -37,6 +37,12 @@ export interface RemoteRelationshipType {
   rules?: Array<{ source: string; target: string }>;
 }
 
+export interface RemoteOrg {
+  id: string;
+  slug: string;
+  name?: string;
+}
+
 export interface RemoteWatcher {
   slug: string;
   name?: string;
@@ -232,6 +238,40 @@ export class ApplyClient {
     }
 
     return { status: res.status, body: parsed as T };
+  }
+
+  // ── Organization (better-auth org plugin, mounted at /api/auth) ───────────
+
+  /**
+   * Orgs the current session is a member of. Used to decide whether the
+   * `[memory].org` slug already resolves to one of the operator's orgs (use
+   * it as-is) or needs creating. Does not depend on `this.orgSlug`.
+   */
+  async listOrgs(): Promise<RemoteOrg[]> {
+    const { body } = await this.request<RemoteOrg[] | { value?: RemoteOrg[] }>(
+      "GET",
+      `/api/auth/organization/list`
+    );
+    return Array.isArray(body) ? body : (body.value ?? []);
+  }
+
+  /**
+   * Create an organization with an explicit slug (the `[memory].org` value).
+   * A reserved slug, or one already owned by an org the session isn't a
+   * member of, surfaces as a structured error the caller turns into a
+   * "pick another slug" message rather than a silent failure.
+   */
+  async createOrg(input: {
+    slug: string;
+    name: string;
+  }): Promise<RemoteOrg> {
+    const { body } = await this.request<RemoteOrg>(
+      "POST",
+      `/api/auth/organization/create`,
+      { name: input.name, slug: input.slug, keepCurrentActiveOrganization: true },
+      [200, 201]
+    );
+    return body;
   }
 
   // ── Agents ────────────────────────────────────────────────────────────────

--- a/packages/cli/src/commands/_lib/apply/desired-state.ts
+++ b/packages/cli/src/commands/_lib/apply/desired-state.ts
@@ -193,6 +193,12 @@ export interface DesiredAgent {
 
 export interface DesiredState {
   agents: DesiredAgent[];
+  /**
+   * `[memory]` metadata from lobu.toml — the org slug `lobu apply` defaults to,
+   * and (when that org doesn't exist yet) the name/description it bootstraps the
+   * new org with.
+   */
+  memory?: { org?: string; name?: string; description?: string };
   memorySchema: {
     entityTypes: DesiredEntityType[];
     relationshipTypes: DesiredRelationshipType[];
@@ -1639,9 +1645,21 @@ export async function loadDesiredState(
     ? { definitions: [], authProfiles: [], connections: [] }
     : await loadConnectors(config, opts.cwd, env, requiredSecrets);
 
+  const memory =
+    config.memory && config.memory.enabled !== false
+      ? {
+          ...(config.memory.org ? { org: config.memory.org } : {}),
+          ...(config.memory.name ? { name: config.memory.name } : {}),
+          ...(config.memory.description
+            ? { description: config.memory.description }
+            : {}),
+        }
+      : undefined;
+
   return {
     state: {
       agents,
+      ...(memory ? { memory } : {}),
       memorySchema: { entityTypes, relationshipTypes },
       watchers,
       connectors,

--- a/packages/cli/src/commands/_lib/apply/prompt.ts
+++ b/packages/cli/src/commands/_lib/apply/prompt.ts
@@ -27,6 +27,28 @@ export async function confirmPlan(opts: ConfirmOptions): Promise<boolean> {
 }
 
 /**
+ * Confirm provisioning a new organization — the `[memory].org` slug (or
+ * `--org`) doesn't resolve to one of the operator's orgs yet. `yes`
+ * short-circuits to true; non-TTY without `--yes` throws.
+ */
+export async function confirmCreateOrg(
+  slug: string,
+  name: string,
+  yes: boolean
+): Promise<boolean> {
+  if (yes) return true;
+  if (!process.stdin.isTTY || !process.stdout.isTTY) {
+    throw new ValidationError(
+      `Organization "${slug}" doesn't exist and --yes was not supplied. Re-run with --yes to create it non-interactively.`
+    );
+  }
+  return confirm({
+    message: `Organization "${slug}" doesn't exist. Create it now as "${name}"?`,
+    default: false,
+  });
+}
+
+/**
  * Confirm uploading + compiling custom connector source on the gateway.
  * `yes` short-circuits to true; non-TTY without `--yes` throws rather than
  * hanging on a closed stdin.

--- a/packages/cli/src/internal/project-link.ts
+++ b/packages/cli/src/internal/project-link.ts
@@ -7,6 +7,9 @@ const LINK_FILE = "project.json";
 export interface ProjectLink {
   context: string;
   org: string;
+  /** Resolved organization id — recorded when `lobu apply` provisions or
+   *  resolves the org, so later commands can skip the slug→id lookup. */
+  organizationId?: string;
   /** ISO timestamp the link was written. */
   linkedAt: string;
 }
@@ -31,6 +34,9 @@ export async function loadProjectLink(
     return {
       context: parsed.context,
       org: parsed.org,
+      ...(typeof parsed.organizationId === "string"
+        ? { organizationId: parsed.organizationId }
+        : {}),
       linkedAt: parsed.linkedAt,
     };
   } catch {


### PR DESCRIPTION
`lobu apply` no longer dead-ends with `GET /api/<slug>/agents failed: invalid_request` when the org doesn't exist yet — it offers to provision it, Railway `init`-style.

**Behavior**
- Org slug resolution: `--org` ▸ active-session org ▸ `[memory].org` from `lobu.toml` (the declarative default).
- If that slug doesn't match one of the operator's orgs:
  - `--dry-run` → prints `+ org <slug> (<name>) — would be created` plus a project summary, then stops (no mutation).
  - otherwise → prompts to create it (`confirmCreateOrg`); `--yes` skips the prompt; non-TTY without `--yes` errors instead of hanging. **Never silent.**
  - on confirm → creates the org via better-auth's organization plugin (`POST /api/auth/organization/create`), then writes the resolved org id into `.lobu/project.json` so later commands skip the slug→id lookup.
- Older servers without `GET /api/auth/organization/list` → the existence check is a no-op (`.catch(() => null)`), normal flow unchanged.

**Shape changes**
- `DesiredState` now carries `memory?: { org, name, description }` from `[memory]`.
- `ProjectLink` gains an optional `organizationId`.
- `ApplyClient.listOrgs()` / `createOrg()` (better-auth org plugin wrappers).

**Tests**: new `ApplyClient` tests for the org endpoints; full `_lib/apply` suite green (74 pass). `tsc` clean (`@lobu/core` rebuilt — its `dist` was stale w.r.t. the just-merged `[memory].connectors` schema field; `make build-packages` fixed it, no source change needed there).

Follow-up (not in this PR): when no org slug is configured *anywhere*, prompt for one and write it into `lobu.toml` (`lobu init`-style). Today `resolveApplyClient`'s existing "not logged in / no org" error covers that path.

Companion to #631 (the `examples/office-bot/` project, whose `[memory].org = "office-bot"` is the motivating case).

🤖 Generated with [Claude Code](https://claude.com/claude-code)