### PR TITLE
fix(cli): lobu apply resolves the org via userinfo; no headless org-create

### DIFF
--- a/packages/cli/src/commands/_lib/apply/__tests__/client.test.ts
+++ b/packages/cli/src/commands/_lib/apply/__tests__/client.test.ts
@@ -79,16 +79,21 @@ describe("ApplyClient", () => {
     expect("entity_id" in body).toBe(false);
   });
 
-  test("listOrgs GETs the better-auth org-list endpoint and tolerates a bare array", async () => {
+  test("listOrgs reads organizations from the OAuth userinfo endpoint", async () => {
     const client = new ApplyClient(
       { apiBaseUrl: "https://example.test", orgSlug: "acme", token: "tok" },
       (async (url, init) => {
-        expect(String(url)).toBe(
-          "https://example.test/api/auth/organization/list"
-        );
+        expect(String(url)).toBe("https://example.test/oauth/userinfo");
         expect(init?.method).toBe("GET");
         return new Response(
-          JSON.stringify([{ id: "org_1", slug: "acme", name: "Acme" }]),
+          JSON.stringify({
+            sub: "u1",
+            organizations: [
+              { id: "org_1", slug: "acme", name: "Acme", role: "owner" },
+              { id: "org_2", slug: "office-bot" },
+              { slug: "no-id-skip" },
+            ],
+          }),
           { status: 200 }
         );
       }) as typeof fetch
@@ -96,47 +101,18 @@ describe("ApplyClient", () => {
 
     expect(await client.listOrgs()).toEqual([
       { id: "org_1", slug: "acme", name: "Acme" },
+      { id: "org_2", slug: "office-bot" },
     ]);
   });
 
-  test("createOrg POSTs name+slug to the better-auth org-create endpoint", async () => {
-    const calls: Array<{ url: string; init?: RequestInit }> = [];
+  test("listOrgs returns [] when userinfo has no organizations", async () => {
     const client = new ApplyClient(
-      {
-        apiBaseUrl: "https://example.test",
-        orgSlug: "office-bot",
-        token: "tok",
-      },
-      (async (url, init) => {
-        calls.push({ url: String(url), init });
-        return new Response(
-          JSON.stringify({
-            id: "org_2",
-            slug: "office-bot",
-            name: "Office Bot",
-          }),
-          { status: 200 }
-        );
-      }) as typeof fetch
+      { apiBaseUrl: "https://example.test", orgSlug: "acme", token: "tok" },
+      (async () =>
+        new Response(JSON.stringify({ sub: "u1" }), {
+          status: 200,
+        })) as typeof fetch
     );
-
-    const org = await client.createOrg({
-      slug: "office-bot",
-      name: "Office Bot",
-    });
-    expect(calls[0]?.url).toBe(
-      "https://example.test/api/auth/organization/create"
-    );
-    expect(calls[0]?.init?.method).toBe("POST");
-    expect(JSON.parse(String(calls[0]?.init?.body))).toEqual({
-      name: "Office Bot",
-      slug: "office-bot",
-      keepCurrentActiveOrganization: true,
-    });
-    expect(org).toEqual({
-      id: "org_2",
-      slug: "office-bot",
-      name: "Office Bot",
-    });
+    expect(await client.listOrgs()).toEqual([]);
   });
 });

--- a/packages/cli/src/commands/_lib/apply/apply-cmd.ts
+++ b/packages/cli/src/commands/_lib/apply/apply-cmd.ts
@@ -1,9 +1,9 @@
+import { readFile, writeFile } from "node:fs/promises";
+import { join } from "node:path";
 import chalk from "chalk";
 import { resolveContext } from "../../../internal/context.js";
-import {
-  loadProjectLink,
-  saveProjectLink,
-} from "../../../internal/project-link.js";
+import { loadProjectLink } from "../../../internal/project-link.js";
+import { CONFIG_FILENAME } from "../../../config/loader.js";
 import { ApiError, ValidationError } from "../../memory/_lib/errors.js";
 import { printError, printText } from "../../memory/_lib/output.js";
 import {
@@ -28,17 +28,38 @@ import {
   validateAuthProfileAgainstConnector,
   validateConnectionAgainstConnector,
 } from "./desired-state.js";
-import {
-  confirmCreateOrg,
-  confirmCustomConnectors,
-  confirmPlan,
-} from "./prompt.js";
+import { confirmCustomConnectors, confirmPlan } from "./prompt.js";
 import {
   renderMissingSecrets,
   renderPlan,
   renderPostApplyPunchList,
   renderProgress,
 } from "./render.js";
+
+/**
+ * Write `organization_id = "<id>"` into the `[memory]` section of lobu.toml —
+ * replacing an existing value or inserting it just under the `[memory]` header.
+ * Surgical text edit; preserves comments and the rest of the file.
+ */
+async function writeMemoryOrganizationId(
+  cwd: string,
+  organizationId: string
+): Promise<void> {
+  const path = join(cwd, CONFIG_FILENAME);
+  const raw = await readFile(path, "utf-8");
+  const line = `organization_id = "${organizationId}"`;
+
+  if (/^\s*organization_id\s*=.*$/m.test(raw)) {
+    const next = raw.replace(/^\s*organization_id\s*=.*$/m, line);
+    if (next !== raw) await writeFile(path, next);
+    return;
+  }
+
+  const header = raw.match(/^\[memory\][^\n]*$/m);
+  if (!header || header.index === undefined) return;
+  const at = header.index + header[0].length;
+  await writeFile(path, `${raw.slice(0, at)}\n${line}${raw.slice(at)}`);
+}
 
 export interface ApplyOptions {
   cwd?: string;
@@ -783,7 +804,7 @@ export async function applyCommand(opts: ApplyOptions = {}): Promise<void> {
   // Org slug resolution: explicit --org ▸ active-session org ▸ `[memory].org`
   // from lobu.toml. The toml slug is the declarative default — if no org with
   // that slug exists yet, `lobu apply` offers to provision it (below).
-  const { client, orgSlug } = await resolveApplyClient({
+  const { client, orgSlug, apiBaseUrl } = await resolveApplyClient({
     url: opts.url,
     org: opts.org ?? state.memory?.org,
     fetchImpl: opts.fetchImpl,
@@ -820,39 +841,38 @@ export async function applyCommand(opts: ApplyOptions = {}): Promise<void> {
     }
   }
 
-  // Bootstrap a missing org. If the resolved slug doesn't match one of the
-  // operator's orgs, offer to create it (Railway `init`-style) and record the
-  // resolved id in `.lobu/project.json`. Older servers without the org-list
-  // endpoint return null → skip the check and let the normal flow surface any
-  // org error.
+  // Check the resolved org exists / the operator is a member. `lobu apply`
+  // can't create an org headlessly — that needs a logged-in browser session —
+  // so a missing org stops here with a link to create it. `listOrgs()` failing
+  // (old server, or a token the userinfo endpoint rejects) → null → skip the
+  // check and let the normal flow surface any org error.
   const myOrgs = await client.listOrgs().catch(() => null);
-  if (myOrgs !== null && !myOrgs.some((o) => o.slug === orgSlug)) {
+  const resolvedOrg =
+    myOrgs?.find((o) => o.slug === orgSlug) ??
+    (state.memory?.organizationId
+      ? myOrgs?.find((o) => o.id === state.memory?.organizationId)
+      : undefined);
+  if (myOrgs !== null && !resolvedOrg) {
     const orgName = state.memory?.name ?? slugToTitle(orgSlug);
-    if (opts.dryRun) {
-      printText(
-        chalk.cyan(`\n  + org ${orgSlug} (${orgName}) — would be created`)
-      );
-      printText(
-        chalk.dim(
-          `  then sync ${state.agents.length} agent(s), ${state.watchers.length} watcher(s), ${state.memorySchema.entityTypes.length} entity type(s) into it.\n`
-        )
-      );
-      printText(chalk.dim("Dry run — no changes applied."));
-      return;
-    }
-    const ok = await confirmCreateOrg(orgSlug, orgName, opts.yes ?? false);
-    if (!ok) {
-      printText(chalk.dim("\nCancelled."));
-      return;
-    }
-    const created = await client.createOrg({ slug: orgSlug, name: orgName });
-    const ctx = await resolveContext().catch(() => null);
-    await saveProjectLink(cwd, {
-      context: ctx?.name ?? link?.context ?? "prod",
-      org: created.slug || orgSlug,
-      ...(created.id ? { organizationId: created.id } : {}),
-    });
-    printText(chalk.green(`  ✓ created org ${created.slug || orgSlug}`));
+    const createUrl = `${apiBaseUrl}/orgs/new?slug=${encodeURIComponent(orgSlug)}&name=${encodeURIComponent(orgName)}`;
+    printError(
+      [
+        "",
+        `Organization "${orgSlug}" not found, or you're not a member.`,
+        "",
+        `  Create it:  ${createUrl}`,
+        `  (or:        \`lobu org create ${orgSlug}\`)`,
+        "",
+        "then re-run `lobu apply`. (Or target an existing org with `--org <slug>`.)",
+      ].join("\n")
+    );
+    throw new ValidationError(`organization "${orgSlug}" not found`);
+  }
+
+  // Persist the resolved org id back into lobu.toml so the whole team applies
+  // to the same org. Best-effort — a read-only lobu.toml must not fail apply.
+  if (resolvedOrg && state.memory?.organizationId !== resolvedOrg.id) {
+    await writeMemoryOrganizationId(cwd, resolvedOrg.id).catch(() => undefined);
   }
 
   // SECURITY (#4): confirm BEFORE fetching any `source_url` or uploading custom

--- a/packages/cli/src/commands/_lib/apply/client.ts
+++ b/packages/cli/src/commands/_lib/apply/client.ts
@@ -240,39 +240,34 @@ export class ApplyClient {
     return { status: res.status, body: parsed as T };
   }
 
-  // ── Organization (better-auth org plugin, mounted at /api/auth) ───────────
+  // ── Organization ──────────────────────────────────────────────────────────
 
   /**
-   * Orgs the current session is a member of. Used to decide whether the
-   * `[memory].org` slug already resolves to one of the operator's orgs (use
-   * it as-is) or needs creating. Does not depend on `this.orgSlug`.
+   * Orgs the authenticated user belongs to, read from the OAuth userinfo
+   * endpoint — the same source `lobu org list` uses. Used to check whether the
+   * `[memory].org` slug already resolves to one of the operator's orgs. Does
+   * not depend on `this.orgSlug`. (`lobu apply` can't create an org headlessly
+   * — that needs a logged-in browser session — so there is no `createOrg`.)
    */
   async listOrgs(): Promise<RemoteOrg[]> {
-    const { body } = await this.request<RemoteOrg[] | { value?: RemoteOrg[] }>(
+    const { body } = await this.request<{ organizations?: unknown }>(
       "GET",
-      `/api/auth/organization/list`
+      `/oauth/userinfo`
     );
-    return Array.isArray(body) ? body : (body.value ?? []);
-  }
-
-  /**
-   * Create an organization with an explicit slug (the `[memory].org` value).
-   * A reserved slug, or one already owned by an org the session isn't a
-   * member of, surfaces as a structured error the caller turns into a
-   * "pick another slug" message rather than a silent failure.
-   */
-  async createOrg(input: { slug: string; name: string }): Promise<RemoteOrg> {
-    const { body } = await this.request<RemoteOrg>(
-      "POST",
-      `/api/auth/organization/create`,
-      {
-        name: input.name,
-        slug: input.slug,
-        keepCurrentActiveOrganization: true,
-      },
-      [200, 201]
-    );
-    return body;
+    const orgs = Array.isArray(body.organizations) ? body.organizations : [];
+    const out: RemoteOrg[] = [];
+    for (const entry of orgs) {
+      if (!isRecord(entry)) continue;
+      const id = typeof entry.id === "string" ? entry.id : "";
+      const slug = typeof entry.slug === "string" ? entry.slug : "";
+      if (!id || !slug) continue;
+      out.push({
+        id,
+        slug,
+        ...(typeof entry.name === "string" ? { name: entry.name } : {}),
+      });
+    }
+    return out;
   }
 
   // ── Agents ────────────────────────────────────────────────────────────────

--- a/packages/cli/src/commands/_lib/apply/desired-state.ts
+++ b/packages/cli/src/commands/_lib/apply/desired-state.ts
@@ -195,10 +195,15 @@ export interface DesiredState {
   agents: DesiredAgent[];
   /**
    * `[memory]` metadata from lobu.toml — the org slug `lobu apply` defaults to,
-   * and (when that org doesn't exist yet) the name/description it bootstraps the
-   * new org with.
+   * the resolved `organization_id` (written back once known), and the
+   * name/description shown when telling the operator to create the org.
    */
-  memory?: { org?: string; name?: string; description?: string };
+  memory?: {
+    org?: string;
+    organizationId?: string;
+    name?: string;
+    description?: string;
+  };
   memorySchema: {
     entityTypes: DesiredEntityType[];
     relationshipTypes: DesiredRelationshipType[];
@@ -1649,6 +1654,9 @@ export async function loadDesiredState(
     config.memory && config.memory.enabled !== false
       ? {
           ...(config.memory.org ? { org: config.memory.org } : {}),
+          ...(config.memory.organization_id
+            ? { organizationId: config.memory.organization_id }
+            : {}),
           ...(config.memory.name ? { name: config.memory.name } : {}),
           ...(config.memory.description
             ? { description: config.memory.description }

--- a/packages/cli/src/commands/_lib/apply/prompt.ts
+++ b/packages/cli/src/commands/_lib/apply/prompt.ts
@@ -27,28 +27,6 @@ export async function confirmPlan(opts: ConfirmOptions): Promise<boolean> {
 }
 
 /**
- * Confirm provisioning a new organization — the `[memory].org` slug (or
- * `--org`) doesn't resolve to one of the operator's orgs yet. `yes`
- * short-circuits to true; non-TTY without `--yes` throws.
- */
-export async function confirmCreateOrg(
-  slug: string,
-  name: string,
-  yes: boolean
-): Promise<boolean> {
-  if (yes) return true;
-  if (!process.stdin.isTTY || !process.stdout.isTTY) {
-    throw new ValidationError(
-      `Organization "${slug}" doesn't exist and --yes was not supplied. Re-run with --yes to create it non-interactively.`
-    );
-  }
-  return confirm({
-    message: `Organization "${slug}" doesn't exist. Create it now as "${name}"?`,
-    default: false,
-  });
-}
-
-/**
  * Confirm uploading + compiling custom connector source on the gateway.
  * `yes` short-circuits to true; non-TTY without `--yes` throws rather than
  * hanging on a closed stdin.

--- a/packages/cli/src/commands/org.ts
+++ b/packages/cli/src/commands/org.ts
@@ -1,4 +1,5 @@
 import chalk from "chalk";
+import open from "open";
 import {
   getActiveOrg,
   listOrganizations,
@@ -53,4 +54,19 @@ export async function orgSetCommand(
   console.log(
     chalk.green(`\n  Active org for context ${target.name} set to ${slug}\n`)
   );
+}
+
+export async function orgCreateCommand(
+  slug: string,
+  options?: { name?: string; context?: string }
+): Promise<void> {
+  const target = await resolveContext(options?.context);
+  const origin = new URL(target.apiUrl).origin;
+  const name = options?.name?.trim() || slug;
+  const url = `${origin}/orgs/new?slug=${encodeURIComponent(slug)}&name=${encodeURIComponent(name)}`;
+  console.log(
+    chalk.bold(`\n  Opening ${url}`) +
+      chalk.dim("\n  (paste it into your browser if it doesn't open)\n")
+  );
+  await open(url).catch(() => undefined);
 }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -505,6 +505,18 @@ Memory:
       await orgSetCommand(slug, options);
     });
 
+  org
+    .command("create <slug>")
+    .description("Open the browser to create an organization (slug pre-filled)")
+    .option("-n, --name <name>", "Organization display name")
+    .option("-c, --context <name>", "Use a named context")
+    .action(
+      async (slug: string, options: { name?: string; context?: string }) => {
+        const { orgCreateCommand } = await import("./commands/org.js");
+        await orgCreateCommand(slug, options);
+      }
+    );
+
   // ─── link / unlink ──────────────────────────────────────────────────
   program
     .command("link")

--- a/packages/cli/src/internal/project-link.ts
+++ b/packages/cli/src/internal/project-link.ts
@@ -7,9 +7,6 @@ const LINK_FILE = "project.json";
 export interface ProjectLink {
   context: string;
   org: string;
-  /** Resolved organization id — recorded when `lobu apply` provisions or
-   *  resolves the org, so later commands can skip the slug→id lookup. */
-  organizationId?: string;
   /** ISO timestamp the link was written. */
   linkedAt: string;
 }
@@ -34,9 +31,6 @@ export async function loadProjectLink(
     return {
       context: parsed.context,
       org: parsed.org,
-      ...(typeof parsed.organizationId === "string"
-        ? { organizationId: parsed.organizationId }
-        : {}),
       linkedAt: parsed.linkedAt,
     };
   } catch {

--- a/packages/core/src/lobu-toml-schema.ts
+++ b/packages/core/src/lobu-toml-schema.ts
@@ -200,6 +200,9 @@ const memorySchema = z
   .object({
     enabled: z.boolean().optional(),
     org: z.string().optional(),
+    /** Resolved organization id, written back by `lobu apply` once the org is
+     *  resolved or created. Committed so the whole team applies to the same org. */
+    organization_id: z.string().optional(),
     name: z.string().optional(),
     description: z.string().optional(),
     visibility: z.enum(["public", "private"]).optional(),


### PR DESCRIPTION
## Why

#632 added "org-bootstrap" to `lobu apply` but it never actually worked:
`ApplyClient.listOrgs()` called better-auth's `GET /api/auth/organization/list` with a `Bearer` token, but the server's better-auth has **no `bearer()` plugin** — `/api/auth/*` is cookie-session only — so it 401s. `apply-cmd.ts`'s `.catch(() => null)` swallowed that, the org-create branch never ran, and `lobu apply --org <missing>` fell straight through to `GET /api/<slug>/agents → 404 invalid_request`. (`bearer()` wouldn't fix it either — it validates better-auth *session* tokens; the CLI carries an OAuth access token / PAT.) The 74 apply unit tests passed only because they stub `fetchImpl`.

Verified by running `make dev` against a real DB and probing: `/api/auth/organization/list` → 401; `/api/<existing-slug>/agents` → 200 (so apply against an *existing* org is fine).

## What

- **`ApplyClient.listOrgs()`** now reads `organizations` from `/oauth/userinfo` — the same source `lobu org list` uses; works with real `lobu login` tokens. **Removed `ApplyClient.createOrg()` and `confirmCreateOrg()`** — `lobu apply` no longer creates orgs (creating a tenant needs a logged-in browser session, not a CLI bearer token).
- **Actionable error on a missing org**: a `<server-origin>/orgs/new?slug=…&name=…` link, a `lobu org create <slug>` hint, and the `--org <slug>` escape hatch — instead of `... failed: invalid_request`.
- **New `lobu org create <slug> [--name]`** — opens the browser to the org-create page with the slug pre-filled (`open` is already a CLI dep, used by `lobu login`).
- **`[memory].organization_id` in `lobu.toml`** (committed, team-shared): `lobu apply` writes the resolved org id back into it (surgical text edit — preserves comments). Resolution order: `--org` ▸ `[memory].organization_id` ▸ active-session org ▸ `[memory].org` slug.
- **Dropped `organizationId` from `.lobu/project.json`** (`ProjectLink`) — it lives in `lobu.toml` now; `project.json` keeps only `context`.

## Follow-up (PR2)

The `packages/web` `/orgs/new?slug=&name=` route these links point at (small prefilled "Create organization" form lifting the logic out of `organization-dropdown.tsx`). Until that lands the link 404s; the `--org <slug>` path and creating the org via the existing org-switcher dropdown both still work.

## Test

`make build-packages` ✓, `tsc --noEmit` ✓, `bun test packages/cli/src` → 156 pass / 1 skip / 0 fail (apply `client.test.ts` updated for the userinfo shape).