### PR TITLE
chore(submodule): bump owletto-web — /orgs/new create-org page

### DIFF
--- a/packages/landing/src/components/LandingPage.tsx
+++ b/packages/landing/src/components/LandingPage.tsx
@@ -63,7 +63,7 @@ export function LandingPage(props: {
         />
       </section>
 
-      <LogoStrip />
+      {/* <LogoStrip /> */}
 
       <SectionCornerLabels
         index={1}


### PR DESCRIPTION
Bumps `packages/web` to include owletto-web#83 (the `/orgs/new?slug=&name=` create-organization page). Completes the org-resolution work: `lobu apply`'s missing-org message and `lobu org create <slug>` now link to a real page. Submodule fast-forwarded on owletto-web/main.