### PR TITLE
fix(apply): userinfo returns org id; dry-run read-only; fix plan heading

### DIFF
--- a/packages/cli/src/commands/_lib/apply/__tests__/__snapshots__/diff.test.ts.snap
+++ b/packages/cli/src/commands/_lib/apply/__tests__/__snapshots__/diff.test.ts.snap
@@ -7,7 +7,7 @@ Plan:
   agents:
   + agent triage
 
-  settingss:
+  settings:
   + settings triage
 
 Summary: 2 create, 0 update, 0 noop, 0 drift"
@@ -20,7 +20,7 @@ Plan:
   agents:
   = agent triage
 
-  settingss:
+  settings:
   = settings triage
 
 Summary: 0 create, 0 update, 2 noop, 0 drift"
@@ -33,7 +33,7 @@ Plan:
   agents:
   ~ agent triage (name)
 
-  settingss:
+  settings:
   = settings triage
 
 Summary: 0 create, 1 update, 1 noop, 0 drift"
@@ -56,7 +56,7 @@ Plan:
   agents:
   = agent triage
 
-  settingss:
+  settings:
   ~ settings triage (networkConfig)
 
 Summary: 0 create, 1 update, 1 noop, 0 drift"
@@ -69,7 +69,7 @@ Plan:
   agents:
   + agent triage
 
-  settingss:
+  settings:
   + settings triage
 
   platforms:
@@ -85,7 +85,7 @@ Plan:
   agents:
   = agent triage
 
-  settingss:
+  settings:
   = settings triage
 
   platforms:

--- a/packages/cli/src/commands/_lib/apply/apply-cmd.ts
+++ b/packages/cli/src/commands/_lib/apply/apply-cmd.ts
@@ -871,7 +871,12 @@ export async function applyCommand(opts: ApplyOptions = {}): Promise<void> {
 
   // Persist the resolved org id back into lobu.toml so the whole team applies
   // to the same org. Best-effort — a read-only lobu.toml must not fail apply.
-  if (resolvedOrg && state.memory?.organizationId !== resolvedOrg.id) {
+  // Skipped on `--dry-run`: that flag promises no mutation, local files included.
+  if (
+    !opts.dryRun &&
+    resolvedOrg &&
+    state.memory?.organizationId !== resolvedOrg.id
+  ) {
     await writeMemoryOrganizationId(cwd, resolvedOrg.id).catch(() => undefined);
   }
 

--- a/packages/cli/src/commands/_lib/apply/render.ts
+++ b/packages/cli/src/commands/_lib/apply/render.ts
@@ -21,6 +21,19 @@ const KIND_LABEL: Record<DiffRow["kind"], string> = {
   feed: "feed",
 };
 
+const KIND_HEADING: Record<DiffRow["kind"], string> = {
+  agent: "agents",
+  settings: "settings",
+  platform: "platforms",
+  "entity-type": "entity-types",
+  "relationship-type": "relationship-types",
+  watcher: "watchers",
+  "connector-definition": "connector-definitions",
+  "auth-profile": "auth-profiles",
+  connection: "connections",
+  feed: "feeds",
+};
+
 function fieldsList(fields: string[] | undefined): string {
   if (!fields?.length) return "";
   return chalk.dim(` (${fields.join(", ")})`);
@@ -122,7 +135,7 @@ export function renderPlan(plan: DiffPlan): string {
     const rowsForKind = plan.rows.filter((row) => row.kind === kind);
     if (rowsForKind.length === 0) continue;
     lines.push("");
-    lines.push(chalk.bold(`  ${KIND_LABEL[kind]}s:`));
+    lines.push(chalk.bold(`  ${KIND_HEADING[kind]}:`));
     for (const row of rowsForKind) {
       lines.push(...renderRow(row));
     }

--- a/packages/server/src/auth/oauth/provider.ts
+++ b/packages/server/src/auth/oauth/provider.ts
@@ -398,7 +398,7 @@ export class OAuthProvider {
     email: string;
     name: string | null;
     organization_slug: string | null;
-    organizations: { slug: string; name: string }[];
+    organizations: { id: string; slug: string; name: string }[];
   } | null> {
     const authInfo = await this.verifyAccessToken(token);
     if (!authInfo) return null;
@@ -423,7 +423,7 @@ export class OAuthProvider {
     }
 
     const orgs = await this.sql`
-      SELECT o.slug, o.name
+      SELECT o.id, o.slug, o.name
       FROM "member" m
       JOIN "organization" o ON o.id = m."organizationId"
       WHERE m."userId" = ${authInfo.userId}
@@ -436,7 +436,11 @@ export class OAuthProvider {
       email: user.email,
       name: user.name,
       organization_slug: organizationSlug,
-      organizations: orgs.map((o) => ({ slug: o.slug as string, name: o.name as string })),
+      organizations: orgs.map((o) => ({
+        id: o.id as string,
+        slug: o.slug as string,
+        name: o.name as string,
+      })),
     };
   }
 


### PR DESCRIPTION
## What

Follow-ups to #634 (`lobu apply` resolves the org via `/oauth/userinfo`), found while running the apply-org-resolution flow end-to-end against a local gateway:

1. **`/oauth/userinfo` now includes each org's `id`.** `ApplyClient.listOrgs()` parses `{ id, slug, name }` and drops entries without an `id`; `getUserInfo` only returned `{ slug, name }`, so `listOrgs()` always came back empty — a valid `--org <slug>` was either reported "not found" or fell through to a 404 against `/api/<slug>/agents`. The extra field is ignored by `lobu org list` (which only reads `slug`/`name`), so no client needs updating.
2. **`lobu apply --dry-run` no longer writes `[memory].organization_id` into `lobu.toml`.** `--dry-run` promises no mutation; that includes local files. The write-back now runs only on a real apply.
3. **Plan heading typo:** `settingss:` → `settings:` (was `${KIND_LABEL[kind]}s`; added a dedicated plural map).

## Verified

Against a local `make dev` gateway (officebot_dev DB) with a real OAuth token:
- `lobu apply --dry-run --org verify-user` → plan renders, `lobu.toml` untouched, heading reads `settings:`
- `lobu apply --org no-such-org` → prints the actionable "Organization not found" block with the `/orgs/new` link + `lobu org create` hint, exits non-zero
- `/orgs/new?slug=office-bot&name=Office+Bot` → form prefilled, submit creates the org and redirects to `/office-bot`
- `lobu apply` against the new org → writes `organization_id = "<id>"` under `[memory]`, idempotent on re-run
- `lobu org list` → still parses orgs correctly (regression)