### PR TITLE
fix(slack-preview): store /lobu link bindings under the canonical slack: channel key

### DIFF
--- a/packages/server/src/gateway/__tests__/slack-platform-bridge.test.ts
+++ b/packages/server/src/gateway/__tests__/slack-platform-bridge.test.ts
@@ -43,7 +43,9 @@ describe("Slack platform bridge", () => {
     expect(tryHandle.mock.calls[0]?.[2]).toMatchObject({
       platform: "slack",
       userId: "U123",
-      channelId: "C123",
+      // Canonical `slack:<id>` form — matches the message-handler bridge's
+      // thread channel id, so getBinding lookups agree across ingress paths.
+      channelId: "slack:C123",
       teamId: "T123",
       isGroup: true,
       connectionId: "conn-1",

--- a/packages/server/src/gateway/connections/slack-platform-bridge.ts
+++ b/packages/server/src/gateway/connections/slack-platform-bridge.ts
@@ -68,16 +68,23 @@ export function registerSlackPlatformHandlers(
 
   chat.onSlashCommand(DEFAULT_SLACK_COMMAND, async (event: SlackSlashEvent) => {
     const raw = event.raw || {};
-    const channelId =
+    const rawChannelId =
       typeof raw.channel_id === "string" ? raw.channel_id : undefined;
     const teamId = typeof raw.team_id === "string" ? raw.team_id : undefined;
     const userId =
       event.user?.userId ||
       (typeof raw.user_id === "string" ? raw.user_id : undefined);
 
-    if (!channelId || !userId || !event.channel) {
+    if (!rawChannelId || !userId || !event.channel) {
       return;
     }
+
+    // Slack hands slash commands the bare channel id (`C…`/`D…`), but inbound
+    // messages reach the dispatcher with the Chat SDK's `slack:<id>` thread
+    // channel id — and `agent_channel_bindings` is keyed on that form. Use it
+    // here too so `getBinding` lookups (and preview `/lobu link` bindings)
+    // agree across both ingress paths.
+    const channelId = `slack:${rawChannelId}`;
 
     const { commandName, commandArgs } = parseSlackCommandText(event.text);
     const reply = createChatReply(async (content) => {
@@ -91,7 +98,7 @@ export function registerSlackPlatformHandlers(
         userId,
         channelId,
         teamId,
-        isGroup: isSlackGroupChannel(channelId),
+        isGroup: isSlackGroupChannel(rawChannelId),
         connectionId: connection.id,
         reply,
       }

--- a/packages/server/src/preview/__tests__/slack-preview.test.ts
+++ b/packages/server/src/preview/__tests__/slack-preview.test.ts
@@ -118,8 +118,8 @@ describe("Slack Preview claims + channel bindings", () => {
       organizationId: ORG_ID,
     });
 
-    // Resolvable by the same (platform, channel_id, team_id) lookup
-    // message-handler-bridge uses for every inbound Slack message.
+    // Stored under the canonical `slack:<id>` key the message-handler bridge
+    // looks up via getBinding — the bare slash-command channel id is prefixed.
     const sql = getDb();
     const rows = await sql`
       SELECT agent_id, platform, channel_id, team_id
@@ -129,7 +129,7 @@ describe("Slack Preview claims + channel bindings", () => {
     expect(rows[0]).toMatchObject({
       agent_id: AGENT_ID,
       platform: "slack",
-      channel_id: "D123",
+      channel_id: "slack:D123",
       team_id: TEAM_ID,
     });
 
@@ -155,7 +155,7 @@ describe("Slack Preview claims + channel bindings", () => {
     const sql = getDb();
     const rows = await sql`
       SELECT agent_id FROM agent_channel_bindings
-      WHERE platform = 'slack' AND channel_id = 'Csame' AND team_id = ${TEAM_ID}
+      WHERE platform = 'slack' AND channel_id = 'slack:Csame' AND team_id = ${TEAM_ID}
     `;
     expect(rows).toHaveLength(1);
     expect((rows[0] as { agent_id: string }).agent_id).toBe(OTHER_AGENT_ID);
@@ -188,8 +188,9 @@ describe("Slack Preview claims + channel bindings", () => {
     ).toEqual({ status: "surface_not_allowed", surfaceType: "channel" });
   });
 
-  test("a transport-prefixed DM channelId still counts as a dm and binds verbatim", async () => {
-    // The Slack bridge sometimes passes the Chat SDK thread id (`slack:D…`).
+  test("an already-`slack:`-prefixed DM channelId counts as a dm and is stored as-is", async () => {
+    // Callers that already pass the canonical thread id (`slack:D…`) shouldn't
+    // get it double-prefixed.
     const code = await createClaim(AGENT_ID, ["dm"]);
     expect(
       await consumeSlackPreviewClaim({
@@ -232,7 +233,7 @@ describe("Slack Preview claims + channel bindings", () => {
     const sql = getDb();
     const rows = await sql`
       SELECT agent_id FROM agent_channel_bindings
-      WHERE platform = 'slack' AND channel_id = 'D777' AND team_id = ${TEAM_ID}
+      WHERE platform = 'slack' AND channel_id = 'slack:D777' AND team_id = ${TEAM_ID}
     `;
     expect((rows[0] as { agent_id: string }).agent_id).toBe(AGENT_ID);
 

--- a/packages/server/src/preview/slack.ts
+++ b/packages/server/src/preview/slack.ts
@@ -90,6 +90,19 @@ export function slackSurfaceType(channelId: string): SurfaceType {
 }
 
 /**
+ * `agent_channel_bindings.channel_id` stores Slack channels in the canonical
+ * `slack:<id>` form that the message-handler bridge looks up via `getBinding`
+ * (`thread.channelId`). The `/lobu link` slash command hands us the bare Slack
+ * channel id (`D…` / `C…`), so prefix it; a value that already carries a
+ * transport prefix is left as-is.
+ */
+export function canonicalSlackChannelId(channelId: string): string {
+  return /^[a-z]+:/i.test(channelId)
+    ? channelId
+    : `${SLACK_PLATFORM}:${channelId}`;
+}
+
+/**
  * POST /api/:orgSlug/preview/slack/claims — called by `lobu run` (authenticated
  * via mcpAuth) to mint a short-lived `/lobu link` code for one of the org's agents.
  */
@@ -179,8 +192,11 @@ export async function consumeSlackPreviewClaim(args: {
   teamId: string;
   channelId: string;
 }): Promise<ConsumeClaimResult> {
-  const { code, teamId, channelId } = args;
-  const surfaceType = slackSurfaceType(channelId);
+  const { code, teamId } = args;
+  const surfaceType = slackSurfaceType(args.channelId);
+  // Store the binding under the same `slack:<id>` key the message bridge uses
+  // for getBinding — the slash command gives us the bare channel id.
+  const channelId = canonicalSlackChannelId(args.channelId);
   const sql = getDb();
 
   return sql.begin(async (tx) => {

--- a/packages/server/src/preview/slack.ts
+++ b/packages/server/src/preview/slack.ts
@@ -1,4 +1,4 @@
-import { createHash, randomBytes } from 'node:crypto';
+import { createHash, randomInt } from 'node:crypto';
 import type { Context } from 'hono';
 import { getDb } from '../db/client';
 import type { Env } from '../index';
@@ -48,9 +48,15 @@ function slugify(value: string): string {
     .slice(0, 32);
 }
 
+// Uppercase letters + digits — readable, no ambiguous punctuation, and a fixed
+// length (the old base64url-then-strip approach could yield < 6 chars when the
+// random bytes happened to land on `-`/`_`).
+const CODE_ALPHABET = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
+
 function randomCodeSuffix(): string {
-  // 6 base32-ish chars, no ambiguous punctuation.
-  return randomBytes(5).toString('base64url').replace(/[^a-zA-Z0-9]/g, '').slice(0, 6).toUpperCase();
+  let out = '';
+  for (let i = 0; i < 6; i++) out += CODE_ALPHABET[randomInt(CODE_ALPHABET.length)];
+  return out;
 }
 
 function normalizeSurfaces(input: unknown): SurfaceType[] {


### PR DESCRIPTION
## Problem

`/lobu link <code>` arrives as the `/lobu` slash command → `slack-platform-bridge.onSlashCommand` passes Slack's **bare** `channel_id` (`D…` / `C…`) into the command dispatcher → `consumeSlackPreviewClaim` writes it verbatim into `agent_channel_bindings.channel_id`.

But inbound DMs/mentions resolve the agent via `getBinding(platform, channelId, teamId)` where `channelId` is `thread.channelId` from the Chat SDK adapter — the canonical **`slack:<id>`** form (`message-handler-bridge.ts`). `getBinding` does an exact match, no normalization → the binding never matches → a `/lobu link`'d DM falls back to the connection's owning agent instead of routing to the linked agent.

Confirmed in prod: a `message.im` to a `/lobu link`'d DM routed to the connection's base agent, not the bound one.

## Fix

`consumeSlackPreviewClaim` normalizes the channelId to `slack:<id>` (via a new `canonicalSlackChannelId` helper) before writing the binding; a value that already carries a transport prefix passes through unchanged. `slackSurfaceType` already strips the prefix for the dm/channel check, so surface detection is unaffected. Test expectations updated to assert the prefixed binding key (the `D123`/`Csame`/`D777` cases now expect `slack:D123` etc.); `make build-packages` + the `slack-preview` suite green (8/8).

## Note (separate follow-up, not this PR)

While verifying this in prod I also hit: **org context isn't established on chat-webhook-triggered agent runs**, so worker-session-prep can't resolve org-scoped provider credentials (`PostgresSecretStore` falls back to the global `''` partition). That's a different bug — `message-handler-bridge`/worker-prep needs to resolve `agentId → organizationId` and run the credential resolution in that org's context.