### PR TITLE
Fold Watchers into the Agents page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,3 +86,6 @@ packages/*/~/
 # Cleaned up on success; can leak when a run or test is killed.
 .connector-child-*.mjs
 **/.connector-child-*.mjs
+
+# Embedded PGlite dev data (make dev without DATABASE_URL)
+.lobu-dev/

--- a/examples/agent-community/models/schema.yaml
+++ b/examples/agent-community/models/schema.yaml
@@ -86,6 +86,7 @@ relationships:
     description: Capture blog posts, newsletters, and public writing so matching includes current thinking, not just static bios.
 watchers:
   - slug: opportunity-matcher
+    agent: agent-community
     name: Opportunity matcher
     schedule: 0 */12 * * *
     prompt: |

--- a/examples/delivery/models/schema.yaml
+++ b/examples/delivery/models/schema.yaml
@@ -107,6 +107,7 @@ relationships:
     description: Keep project ownership queryable across updates and artifacts.
 watchers:
   - slug: phoenix-rollout-tracker
+    agent: delivery
     name: Phoenix rollout tracker
     schedule: 0 9 * * 1
     prompt: |

--- a/examples/ecommerce/models/schema.yaml
+++ b/examples/ecommerce/models/schema.yaml
@@ -108,6 +108,7 @@ relationships:
     description: Track which plans and products each customer subscribes to.
 watchers:
   - slug: customer-activity-tracker
+    agent: ecommerce-ops
     name: Customer activity tracker
     schedule: 0 */6 * * *
     prompt: |

--- a/examples/finance/models/schema.yaml
+++ b/examples/finance/models/schema.yaml
@@ -108,6 +108,7 @@ relationships:
     description: Let agents trace reporting outputs back to the supporting data.
 watchers:
   - slug: reconciliation-monitor
+    agent: finance
     name: Reconciliation monitor
     schedule: 0 6 * * 1-5
     prompt: |

--- a/examples/leadership/models/schema.yaml
+++ b/examples/leadership/models/schema.yaml
@@ -131,6 +131,7 @@ relationships:
     description: Attach blocked decisions to the dependency that is holding them up.
 watchers:
   - slug: board-action-tracker
+    agent: leadership
     name: Board action tracker
     schedule: 0 8 * * *
     prompt: |

--- a/examples/legal/models/schema.yaml
+++ b/examples/legal/models/schema.yaml
@@ -111,6 +111,7 @@ relationships:
     description: Keep legal risk linked to the clause or term that caused it.
 watchers:
   - slug: contract-review-tracker
+    agent: legal-review
     name: Contract review tracker
     schedule: 0 8 * * 1-5
     prompt: |

--- a/examples/lobu-crm/models/schema.yaml
+++ b/examples/lobu-crm/models/schema.yaml
@@ -108,6 +108,7 @@ relationships:
     description: Links a lead to the pilot it became, so the path from first signal to paying pilot stays explicit.
 watchers:
   - slug: funnel-digest
+    agent: crm
     name: Weekly funnel digest
     schedule: 0 9 * * 1
     prompt: |
@@ -169,6 +170,7 @@ watchers:
         conversations_this_week:
           type: integer
   - slug: inbound-triage
+    agent: crm
     name: Inbound triage
     schedule: 0 8-22/2 * * *
     prompt: |

--- a/examples/market/models/schema.yaml
+++ b/examples/market/models/schema.yaml
@@ -531,6 +531,7 @@ relationships:
         matchStrategy: unique_only
 watchers:
   - slug: founder-activity-tracker
+    agent: vc-tracking
     name: Founder Activity Tracker
     schedule: 0 10 * * *
     prompt: |
@@ -643,6 +644,7 @@ watchers:
       Track founders going quiet as a potential concern.
       Alert on any public statements about competitors or market conditions.
   - slug: opportunity-matcher
+    agent: vc-tracking
     name: Opportunity Matcher
     schedule: 0 */12 * * *
     prompt: |

--- a/examples/office-bot/models/lunch.yaml
+++ b/examples/office-bot/models/lunch.yaml
@@ -56,6 +56,7 @@ entities:
 
 watchers:
   - slug: lunch-open
+    agent: food-ordering
     name: Open the lunch run
     # Workdays 11:00 Europe/London — post the lunch call and open the thread.
     schedule: "0 11 * * 1-5"
@@ -89,6 +90,7 @@ watchers:
           type: string
 
   - slug: lunch-finalize
+    agent: food-ordering
     name: Collect orders and hand off
     # Workdays 11:35 Europe/London — read the thread, post options/collect orders,
     # build the Deliveroo basket, post the summary, hand off to a human.

--- a/examples/personal-finance/models/schema.yaml
+++ b/examples/personal-finance/models/schema.yaml
@@ -1159,6 +1159,7 @@ relationships:
           description: Which leg this row represents — outbound (debit on source) or inbound (credit on destination)
 watchers:
   - slug: gmail-tx
+    agent: personal-finance
     name: Gmail financial-event extractor
     schedule: '*/30 * * * *'
     prompt: |

--- a/examples/sales/models/schema.yaml
+++ b/examples/sales/models/schema.yaml
@@ -131,6 +131,7 @@ relationships:
     description: Link the internal team or customer function to the pilot they own.
 watchers:
   - slug: account-health-monitor
+    agent: sales
     name: Account health monitor
     schedule: 0 */12 * * *
     prompt: |

--- a/packages/cli/src/commands/_lib/apply/__tests__/client.test.ts
+++ b/packages/cli/src/commands/_lib/apply/__tests__/client.test.ts
@@ -59,6 +59,7 @@ describe("ApplyClient", () => {
 
     await client.createWatcher({
       slug: "digest",
+      agentId: "triage",
       name: "Digest",
       prompt: "Produce a digest.",
       extraction_schema: { type: "object" },
@@ -71,6 +72,7 @@ describe("ApplyClient", () => {
     expect(body).toEqual({
       action: "create",
       slug: "digest",
+      agent_id: "triage",
       name: "Digest",
       prompt: "Produce a digest.",
       extraction_schema: { type: "object" },

--- a/packages/cli/src/commands/_lib/apply/__tests__/desired-state.test.ts
+++ b/packages/cli/src/commands/_lib/apply/__tests__/desired-state.test.ts
@@ -190,6 +190,7 @@ models = "./models"
       `version: 2
 watchers:
   - slug: weekly-digest
+    agent: triage
     name: Weekly digest
     description: A short weekly summary.
     schedule: "0 9 * * 1"
@@ -210,6 +211,7 @@ watchers:
     expect(state.watchers).toHaveLength(1);
     const w = state.watchers[0]!;
     expect(w.slug).toBe("weekly-digest");
+    expect(w.agent).toBe("triage");
     expect(w.name).toBe("Weekly digest");
     expect(w.description).toBe("A short weekly summary.");
     expect(w.schedule).toBe("0 9 * * 1");
@@ -260,6 +262,7 @@ relationships:
         target: product
 watchers:
   - slug: account-digest
+    agent: triage
     name: Account digest
     schedule: "0 9 * * 1"
     prompt: Summarize account changes.

--- a/packages/cli/src/commands/_lib/apply/apply-cmd.ts
+++ b/packages/cli/src/commands/_lib/apply/apply-cmd.ts
@@ -615,6 +615,7 @@ async function executePlan(
     const w = row.desired;
     await ctx.client.createWatcher({
       slug: w.slug,
+      agentId: w.agent,
       name: w.name,
       description: w.description,
       prompt: w.prompt,

--- a/packages/cli/src/commands/_lib/apply/client.ts
+++ b/packages/cli/src/commands/_lib/apply/client.ts
@@ -489,13 +489,14 @@ export class ApplyClient {
   }
 
   /**
-   * Create an org-scoped (entity-less) watcher. `extraction_schema` is sent as
-   * a JSON object — the `manage_watchers` tool accepts `Type.Any()` there and
+   * Create a watcher owned by `agentId`. `extraction_schema` is sent as a JSON
+   * object — the `manage_watchers` tool accepts `Type.Any()` there and
    * normalizes string-or-object internally. Duplicate-slug surfaces as a
    * structured error the caller swallows for idempotency.
    */
   async createWatcher(payload: {
     slug: string;
+    agentId: string;
     name?: string;
     description?: string;
     prompt: string;
@@ -506,6 +507,7 @@ export class ApplyClient {
     await this.request("POST", `/api/${this.orgSlug}/manage_watchers`, {
       action: "create",
       slug: payload.slug,
+      agent_id: payload.agentId,
       ...(payload.name ? { name: payload.name } : {}),
       ...(payload.description ? { description: payload.description } : {}),
       prompt: payload.prompt,

--- a/packages/cli/src/commands/_lib/apply/desired-state.ts
+++ b/packages/cli/src/commands/_lib/apply/desired-state.ts
@@ -104,6 +104,8 @@ export interface DesiredRelationshipType {
 
 export interface DesiredWatcher {
   slug: string;
+  /** Owning agent id. Every watcher belongs to exactly one agent. */
+  agent: string;
   name?: string;
   description?: string;
   schedule?: string;
@@ -739,11 +741,17 @@ function parseWatcher(raw: unknown): DesiredWatcher {
       `watcher "${raw.slug}" is missing a "prompt" string`
     );
   }
+  if (typeof raw.agent !== "string" || !raw.agent.trim()) {
+    throw new ValidationError(
+      `watcher "${raw.slug}" is missing an "agent" field — every watcher must name the agent that owns it (e.g. \`agent: my-agent\`, matching an \`[agents.<id>]\` block in lobu.toml)`
+    );
+  }
   const extractionSchema = isRecord(raw.extraction_schema)
     ? raw.extraction_schema
     : {};
   const out: DesiredWatcher = {
     slug: raw.slug,
+    agent: raw.agent,
     prompt: raw.prompt,
     extractionSchema,
   };
@@ -905,7 +913,7 @@ async function rejectUnsupportedAgentShapes(cwd: string): Promise<void> {
     const watchers = (agentConfig as Record<string, unknown>).watchers;
     if (Array.isArray(watchers) && watchers.length > 0) {
       throw new ValidationError(
-        `agent "${agentId}" declares [[agents.${agentId}.watchers]] — \`lobu apply\` syncs watchers from YAML files under \`[memory].models\`, not from lobu.toml. Move the watcher to a model file or use \`lobu memory seed\`.`
+        `agent "${agentId}" declares [[agents.${agentId}.watchers]] in lobu.toml — watchers live in a \`[memory].models\` YAML bundle (the same file as your entity types), each with an \`agent: ${agentId}\` field pointing back here. Move the watcher there.`
       );
     }
   }
@@ -1645,6 +1653,14 @@ export async function loadDesiredState(
     config,
     opts.cwd
   );
+
+  for (const watcher of watchers) {
+    if (!config.agents[watcher.agent]) {
+      throw new ValidationError(
+        `watcher "${watcher.slug}" names agent "${watcher.agent}", but there is no \`[agents.${watcher.agent}]\` block in lobu.toml`
+      );
+    }
+  }
 
   const connectors = opts.only
     ? { definitions: [], authProfiles: [], connections: [] }

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -10,6 +10,7 @@
   },
   "scripts": {
     "dev": "tsx watch --ignore=../web/** --ignore=../../node_modules/** src/server.ts",
+    "dev:local": "tsx watch --ignore=../web/** --ignore=../../node_modules/** src/start-local.ts",
     "start": "tsx src/server.ts",
     "build:server": "node ./scripts/build-server-bundle.mjs",
     "test": "vitest",

--- a/packages/server/src/dev-vite.ts
+++ b/packages/server/src/dev-vite.ts
@@ -1,0 +1,91 @@
+/**
+ * Shared Vite dev-server middleware wiring.
+ *
+ * Both server entry points use this in development: `server.ts` (external
+ * Postgres) and `start-local.ts` (embedded PGlite). It attaches a Vite dev
+ * server in middleware mode to the given HTTP server so the SPA is served with
+ * HMR, and falls unmatched requests through to the Hono listener.
+ */
+
+import { existsSync } from 'node:fs';
+import type http from 'node:http';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { setViteDev } from './index';
+import logger from './utils/logger';
+
+// …/packages/server/src/dev-vite.ts → repo root
+const PACKAGE_REPO_ROOT = path.resolve(
+  fileURLToPath(new URL('.', import.meta.url)),
+  '../../..'
+);
+
+function resolveWebSourceRoot(): string {
+  const explicit = process.env.WEB_SOURCE_DIR?.trim();
+  if (explicit) {
+    if (!existsSync(path.join(explicit, 'index.html'))) {
+      throw new Error(`WEB_SOURCE_DIR set but no index.html found: ${explicit}`);
+    }
+    return explicit;
+  }
+
+  const projectRoot = process.env.LOBU_DEV_PROJECT_PATH || PACKAGE_REPO_ROOT;
+  const webSourceDir = path.resolve(projectRoot, 'packages/web');
+  if (!existsSync(path.join(webSourceDir, 'index.html'))) {
+    throw new Error(
+      `Lobu web source directory not found: ${webSourceDir}. ` +
+        `Set WEB_SOURCE_DIR or LOBU_DEV_PROJECT_PATH to the monorepo root.`
+    );
+  }
+  return webSourceDir;
+}
+
+type HttpListener = (req: http.IncomingMessage, res: http.ServerResponse) => void;
+
+/**
+ * In development, start a Vite dev server in middleware mode on `httpServer`,
+ * appending `honoListener` as the fallback for everything Vite doesn't handle.
+ * Returns the Vite server (so the caller can `.close()` it on shutdown) or
+ * `null` when not in development or when Vite failed to start — in which case
+ * the caller MUST wire `honoListener` onto `httpServer` itself.
+ */
+export async function mountViteDev(
+  httpServer: http.Server,
+  honoListener: HttpListener
+): Promise<{ close: () => Promise<void> } | null> {
+  if (process.env.NODE_ENV !== 'development') return null;
+  try {
+    const { createServer } = await import('vite');
+    const vite = await createServer({
+      root: resolveWebSourceRoot(),
+      server: {
+        middlewareMode: true,
+        hmr: { server: httpServer },
+        // The worker scratch dir (packages/server/workspaces/<agent>/.openclaw/*)
+        // is written constantly while an agent runs; without this Vite triggers
+        // a full browser page reload on every session.jsonl write, which kills
+        // the in-flight chat SSE connection.
+        watch: {
+          ignored: [
+            '**/workspaces/**',
+            '**/.openclaw/**',
+            '**/dist/**',
+            '**/node_modules/**',
+          ],
+        },
+      },
+      appType: 'custom',
+    });
+    // Append Hono as the fallback — Vite handles its paths, rest goes to Hono.
+    vite.middlewares.use((req: http.IncomingMessage, res: http.ServerResponse) => {
+      honoListener(req, res);
+    });
+    setViteDev(vite);
+    httpServer.on('request', vite.middlewares);
+    logger.info('Vite dev server started in middleware mode');
+    return vite;
+  } catch (err) {
+    logger.warn({ err }, 'Failed to start Vite dev server — frontend will not be available');
+    return null;
+  }
+}

--- a/packages/server/src/lobu/agent-routes.ts
+++ b/packages/server/src/lobu/agent-routes.ts
@@ -415,20 +415,19 @@ routes.get('/', mcpAuth, async (c) => {
     `;
     const platformsMap = new Map(platformRows.map((r: any) => [r.agent_id, (r.platforms ?? []) as string[]]));
 
-    // Provider ids per agent, derived from the row's auth_profiles + installed_providers.
+    // Provider ids per agent, derived from the row's installed_providers
+    // (plus auth_profiles when that column is present on this schema).
     const providerRows = await sql`
-      SELECT id, auth_profiles, installed_providers
+      SELECT id, installed_providers
       FROM agents
       WHERE organization_id = ${orgId}
     `;
     const providersMap = new Map<string, string[]>();
     for (const r of providerRows) {
       const set = new Set<string>();
-      for (const p of ((r as any).auth_profiles ?? []) as any[]) {
-        if (p?.provider) set.add(String(p.provider));
-      }
       for (const p of ((r as any).installed_providers ?? []) as any[]) {
         if (p?.providerId) set.add(String(p.providerId));
+        else if (p?.provider) set.add(String(p.provider));
       }
       providersMap.set((r as any).id, [...set]);
     }

--- a/packages/server/src/lobu/agent-routes.ts
+++ b/packages/server/src/lobu/agent-routes.ts
@@ -386,12 +386,63 @@ routes.get('/', mcpAuth, async (c) => {
       for (const clientId of runtimeIds) ids.add(clientId);
     }
 
+    // Watchers owned by each agent (active only).
+    const watcherCounts = await sql`
+      SELECT agent_id, count(*)::int as count
+      FROM watchers
+      WHERE organization_id = ${orgId} AND status = 'active' AND agent_id IS NOT NULL
+      GROUP BY agent_id
+    `;
+    const watcherCountMap = new Map(watcherCounts.map((r: any) => [r.agent_id, r.count]));
+
+    // Distinct end-users per agent across messaging platforms.
+    const userCounts = await sql`
+      SELECT u.agent_id, count(DISTINCT (u.platform, u.user_id))::int as count
+      FROM agent_users u
+      JOIN agents a ON a.id = u.agent_id
+      WHERE a.organization_id = ${orgId}
+      GROUP BY u.agent_id
+    `;
+    const userCountMap = new Map(userCounts.map((r: any) => [r.agent_id, r.count]));
+
+    // Distinct connection platforms per agent.
+    const platformRows = await sql`
+      SELECT c.agent_id, array_agg(DISTINCT c.platform) as platforms
+      FROM agent_connections c
+      JOIN agents a ON a.id = c.agent_id
+      WHERE a.organization_id = ${orgId}
+      GROUP BY c.agent_id
+    `;
+    const platformsMap = new Map(platformRows.map((r: any) => [r.agent_id, (r.platforms ?? []) as string[]]));
+
+    // Provider ids per agent, derived from the row's auth_profiles + installed_providers.
+    const providerRows = await sql`
+      SELECT id, auth_profiles, installed_providers
+      FROM agents
+      WHERE organization_id = ${orgId}
+    `;
+    const providersMap = new Map<string, string[]>();
+    for (const r of providerRows) {
+      const set = new Set<string>();
+      for (const p of ((r as any).auth_profiles ?? []) as any[]) {
+        if (p?.provider) set.add(String(p.provider));
+      }
+      for (const p of ((r as any).installed_providers ?? []) as any[]) {
+        if (p?.providerId) set.add(String(p.providerId));
+      }
+      providersMap.set((r as any).id, [...set]);
+    }
+
     return c.json({
       agents: agents.map((a) => ({
         ...a,
         connectionCount: countMap.get(a.agentId) ?? 0,
         activeConnectionCount: activeCountMap.get(a.agentId) ?? 0,
         clientCount: clientCountMap.get(a.agentId)?.size ?? 0,
+        watcherCount: watcherCountMap.get(a.agentId) ?? 0,
+        userCount: userCountMap.get(a.agentId) ?? 0,
+        platforms: platformsMap.get(a.agentId) ?? [],
+        providers: providersMap.get(a.agentId) ?? [],
         status: (activeCountMap.get(a.agentId) ?? 0) > 0 ? 'active' : 'idle',
       })),
     });

--- a/packages/server/src/lobu/agent-routes.ts
+++ b/packages/server/src/lobu/agent-routes.ts
@@ -415,19 +415,21 @@ routes.get('/', mcpAuth, async (c) => {
     `;
     const platformsMap = new Map(platformRows.map((r: any) => [r.agent_id, (r.platforms ?? []) as string[]]));
 
-    // Provider ids per agent, derived from the row's installed_providers
-    // (plus auth_profiles when that column is present on this schema).
+    // Provider ids per agent, derived from the row's auth_profiles +
+    // installed_providers.
     const providerRows = await sql`
-      SELECT id, installed_providers
+      SELECT id, auth_profiles, installed_providers
       FROM agents
       WHERE organization_id = ${orgId}
     `;
     const providersMap = new Map<string, string[]>();
     for (const r of providerRows) {
       const set = new Set<string>();
+      for (const p of ((r as any).auth_profiles ?? []) as any[]) {
+        if (p?.provider) set.add(String(p.provider));
+      }
       for (const p of ((r as any).installed_providers ?? []) as any[]) {
         if (p?.providerId) set.add(String(p.providerId));
-        else if (p?.provider) set.add(String(p.provider));
       }
       providersMap.set((r as any).id, [...set]);
     }

--- a/packages/server/src/lobu/agent-routes.ts
+++ b/packages/server/src/lobu/agent-routes.ts
@@ -415,21 +415,19 @@ routes.get('/', mcpAuth, async (c) => {
     `;
     const platformsMap = new Map(platformRows.map((r: any) => [r.agent_id, (r.platforms ?? []) as string[]]));
 
-    // Provider ids per agent, derived from the row's auth_profiles +
-    // installed_providers.
+    // Provider ids per agent, from the agent row's installed_providers list
+    // (the canonical "which providers does this agent have" set).
     const providerRows = await sql`
-      SELECT id, auth_profiles, installed_providers
+      SELECT id, installed_providers
       FROM agents
       WHERE organization_id = ${orgId}
     `;
     const providersMap = new Map<string, string[]>();
     for (const r of providerRows) {
       const set = new Set<string>();
-      for (const p of ((r as any).auth_profiles ?? []) as any[]) {
-        if (p?.provider) set.add(String(p.provider));
-      }
       for (const p of ((r as any).installed_providers ?? []) as any[]) {
-        if (p?.providerId) set.add(String(p.providerId));
+        const id = p?.providerId ?? p?.provider;
+        if (id) set.add(String(id));
       }
       providersMap.set((r as any).id, [...set]);
     }

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -22,15 +22,15 @@ import dotenv from 'dotenv';
 
 dotenv.config();
 
-import { existsSync } from 'node:fs';
 import http from 'node:http';
 import { createRequire } from 'node:module';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { getRequestListener } from '@hono/node-server';
 import { Hono } from 'hono';
+import { mountViteDev } from './dev-vite';
 import type { Env } from './index';
-import { app as mainApp, setViteDev } from './index';
+import { app as mainApp } from './index';
 import { assertExternalDepsResolvable } from '../../connector-worker/src/runtime-deps';
 import { getEnvFromProcess } from './utils/env';
 import logger from './utils/logger';
@@ -56,32 +56,6 @@ const PACKAGE_REPO_ROOT = path.resolve(
 // paths; without this fallback they'd resolve against process.cwd().
 if (!process.env.LOBU_DEV_PROJECT_PATH) {
   process.env.LOBU_DEV_PROJECT_PATH = PACKAGE_REPO_ROOT;
-}
-
-function resolveWebSourceRoot(): string {
-  const explicit = process.env.WEB_SOURCE_DIR?.trim();
-  if (explicit) {
-    if (!existsSync(path.join(explicit, 'index.html'))) {
-      throw new Error(
-        `WEB_SOURCE_DIR set but no index.html found: ${explicit}`
-      );
-    }
-    return explicit;
-  }
-
-  const projectRoot =
-    process.env.LOBU_DEV_PROJECT_PATH || PACKAGE_REPO_ROOT;
-  const webSourceDir = path.resolve(
-    projectRoot,
-    'packages/web'
-  );
-  if (!existsSync(path.join(webSourceDir, 'index.html'))) {
-    throw new Error(
-      `Lobu web source directory not found: ${webSourceDir}. ` +
-        `Set WEB_SOURCE_DIR or LOBU_DEV_PROJECT_PATH to the monorepo root.`
-    );
-  }
-  return webSourceDir;
 }
 
 // Inject environment variables into Hono context
@@ -155,47 +129,10 @@ async function main() {
   httpServer.keepAliveTimeout = 75_000; // 75 s — above typical 60 s LB idle timeout
   httpServer.headersTimeout = 76_000; // must be strictly > keepAliveTimeout
 
-  let vite: any;
-
-  // In development, start Vite dev server in middleware mode (same port, same process).
-  // Vite handles its own paths (/@vite/*, source transforms, HMR).
-  // Everything Vite doesn't match falls through to Hono via the appended middleware.
-  if (process.env.NODE_ENV === 'development') {
-    try {
-      const { createServer } = await import('vite');
-      vite = await createServer({
-        root: resolveWebSourceRoot(),
-        server: {
-          middlewareMode: true,
-          hmr: { server: httpServer },
-          // The worker scratch dir (packages/server/workspaces/<agent>/.openclaw/*)
-          // is written constantly while an agent runs; without this Vite triggers
-          // a full browser page reload on every session.jsonl write, which kills
-          // the in-flight chat SSE connection.
-          watch: {
-            ignored: [
-              '**/workspaces/**',
-              '**/.openclaw/**',
-              '**/dist/**',
-              '**/node_modules/**',
-            ],
-          },
-        },
-        appType: 'custom',
-      });
-      // Append Hono as the fallback — Vite handles its paths, rest goes to Hono
-      vite.middlewares.use((req: http.IncomingMessage, res: http.ServerResponse) => {
-        honoListener(req, res);
-      });
-      setViteDev(vite);
-      httpServer.on('request', vite.middlewares);
-      logger.info('Vite dev server started in middleware mode');
-    } catch (err) {
-      logger.warn({ err }, 'Failed to start Vite dev server — frontend will not be available');
-    }
-  }
-
-  // Prod: Hono handles all requests directly
+  // In development this attaches a Vite dev server (middleware mode, HMR) and
+  // returns it; in prod (or if Vite fails) it returns null and Hono handles
+  // every request directly.
+  const vite = await mountViteDev(httpServer, honoListener);
   if (!vite) {
     httpServer.on('request', honoListener);
   }

--- a/packages/server/src/start-local.ts
+++ b/packages/server/src/start-local.ts
@@ -153,13 +153,27 @@ async function main() {
   });
   wrapper.route('/', mainApp);
 
-  const httpServer = http.createServer(getRequestListener(wrapper.fetch));
+  const honoListener = getRequestListener(wrapper.fetch);
+  const httpServer = http.createServer();
+  // SSE streams (MCP) must survive idle periods — Node defaults to 5s.
+  httpServer.keepAliveTimeout = 75_000;
+  httpServer.headersTimeout = 76_000;
+
+  // In development, serve the SPA with Vite HMR (middleware mode); otherwise
+  // Hono handles every request directly. Dynamically imported so this entry
+  // keeps its lazy-load discipline (assert-node-version / instrument first).
+  const { mountViteDev } = await import('./dev-vite');
+  const vite = await mountViteDev(httpServer, honoListener);
+  if (!vite) {
+    httpServer.on('request', honoListener);
+  }
 
   // ─── Graceful Shutdown ───────────────────────────────────────
 
   const shutdown = async (signal: string) => {
     logger.info({ signal }, 'Shutting down');
     stopScheduler();
+    await vite?.close();
     httpServer.close();
     embeddingsChild?.kill();
     await socketServer.stop();
@@ -210,7 +224,11 @@ async function runMigrations(dbUrl: string) {
       // under dist/db/migrations.
       join(fileURLToPath(new URL('.', import.meta.url)), 'db', 'migrations'),
       join(APP_ROOT, 'db', 'migrations'),
-      join(process.cwd(), 'db', 'migrations')
+      // Monorepo `bun run --filter @lobu/server dev:local`: APP_ROOT is
+      // packages/server/, so the migrations live two levels up at repo root.
+      join(APP_ROOT, '..', '..', 'db', 'migrations'),
+      join(process.cwd(), 'db', 'migrations'),
+      join(process.cwd(), '..', '..', 'db', 'migrations')
     );
     if (!migrationsDir) {
       throw new Error('Migrations directory not found.');

--- a/packages/server/src/tools/admin/manage_watchers.ts
+++ b/packages/server/src/tools/admin/manage_watchers.ts
@@ -582,6 +582,11 @@ export const ListWatchersSchema = Type.Object({
       description: 'Optional entity ID to list watchers attached to a specific entity',
     })
   ),
+  agent_id: Type.Optional(
+    Type.String({
+      description: 'Optional agent ID to list watchers owned by a specific agent',
+    })
+  ),
   status: Type.Optional(
     Type.String({
       description: 'Optional status filter. Use "active" or "archived". Omit to include all.',
@@ -2235,6 +2240,12 @@ async function handleList(
   if (args.watcher_id) {
     conditions.push(`i.id = $${paramCount}`);
     params.push(args.watcher_id);
+    paramCount++;
+  }
+
+  if (args.agent_id) {
+    conditions.push(`i.agent_id = $${paramCount}`);
+    params.push(args.agent_id);
     paramCount++;
   }
 

--- a/scripts/dev-native.sh
+++ b/scripts/dev-native.sh
@@ -104,19 +104,31 @@ export HOST="${HOST:-127.0.0.1}"
 export PORT="${PORT:-8787}"
 export WORKER_PROXY_PORT="${WORKER_PROXY_PORT:-8118}"
 export PUBLIC_WEB_URL="${PUBLIC_WEB_URL:-http://localhost:${PORT}}"
-export PGSSLMODE="${PGSSLMODE:-require}"
 export LOBU_PROVIDER_REGISTRY_PATH="${LOBU_PROVIDER_REGISTRY_PATH:-$REPO_ROOT/config/providers.json}"
 export LOBU_DEV_PROJECT_PATH="${LOBU_DEV_PROJECT_PATH:-$REPO_ROOT}"
 export LOBU_WORKSPACE_ROOT="${LOBU_WORKSPACE_ROOT:-$REPO_ROOT/workspaces}"
 
 mkdir -p "$LOBU_WORKSPACE_ROOT"
 
+# --- Run -------------------------------------------------------------------
+
 if [ -z "${DATABASE_URL:-}" ]; then
-  echo "❌ DATABASE_URL not set in .env"
-  exit 1
+  # No external Postgres → boot the embedded PGlite backend (src/start-local.ts).
+  # First run mints a web login (dev@lobu.local / lobudev123, org "dev") and a
+  # bootstrap PAT under LOBU_DATA_DIR. Vite HMR still runs in-process.
+  export LOBU_DATA_DIR="${LOBU_DATA_DIR:-$REPO_ROOT/.lobu-dev}"
+  export PGSSLMODE=disable
+  mkdir -p "$LOBU_DATA_DIR"
+  echo "→ no DATABASE_URL set — booting embedded PGlite"
+  echo "→ server on http://${HOST}:${PORT}   (Vite HMR in-process)"
+  echo "→ data dir: $LOBU_DATA_DIR"
+  echo "→ first run seeds a web login: dev@lobu.local / lobudev123   (org 'dev')"
+  echo "→ then run \`lobu apply\` from a project dir to sync its lobu.toml"
+  echo ""
+  exec bun run --filter '@lobu/server' dev:local
 fi
 
-# --- Run -------------------------------------------------------------------
+export PGSSLMODE="${PGSSLMODE:-require}"
 
 echo "→ server on http://${HOST}:${PORT}"
 echo "→ embedded gateway proxy on :${WORKER_PROXY_PORT}"


### PR DESCRIPTION
Replaces the standalone **Watchers** page with a unified **Agents** surface, and makes `make dev` work out of the box without an external Postgres.

## Agents page
- List view is now a **table**: Agent · Users · Watchers · Platforms · Providers · ›. The persistent left sidebar is gone — the table is the index.
- Server: `GET /api/{slug}/agents` also returns `watcherCount`, `userCount` (distinct end-users from `agent_users`), `platforms[]`, `providers[]` (cheap aggregates, no N+1).
- Agent detail is full-width with a breadcrumb `Agents › [ <agent> ▾ ]` searchable switcher (no sidebar). Tabs: **Conversations · Watchers · Connect · Identity · Providers · Skills · Platforms**.
  - **Watchers** tab — lists watchers owned by the agent (`watchers.agent_id`), with a "Runs via" column ("Lobu worker" or a linked MCP client when `scheduler_client_id` is set). `?tab=watchers&w=<id>` deep-links a watcher.
  - **Connect** tab — `McpConnect` (org-scoped MCP URL + per-client setup accordion) plus a list of clients connected to this agent.
- `list_watchers` tool accepts an `agent_id` filter; new `useAgentWatchersList` hook.

## Routes / nav
- Removed the top-level `/$owner/watchers` list route; `/$owner/watchers/$watcherId` redirects into the agent's Watchers tab. Sidebar / command-palette / dashboard links repointed. The entity-page Watchers tab is unchanged.

## `make dev` without DATABASE_URL
- `scripts/dev-native.sh`: when `DATABASE_URL` is unset, boot the embedded PGlite backend (`@lobu/server dev:local` → `src/start-local.ts`) instead of erroring. First run seeds a web login **`dev@lobu.local` / `lobudev123`** (org `dev`) + a bootstrap PAT under `LOBU_DATA_DIR` (`./.lobu-dev`).
- Extracted the Vite-middleware wiring into `packages/server/src/dev-vite.ts` (`mountViteDev`) so `start-local.ts` also serves the SPA with HMR.
- `start-local.ts` also looks for `db/migrations` at the monorepo root (tsx run, not just the published bundle).

## Submodule
Web changes are in `lobu-ai/owletto-web#feat/watchers-into-agents` (parent points at that branch's SHA).

## Verified locally
- External-Postgres `make dev`: Agents table renders with the new counts/icons; agent detail Watchers tab shows "Runs via: Lobu worker"; `/watchers/1` redirects correctly; `tsc --noEmit` clean; web route smoke 31/31.
- `DATABASE_URL= make dev`: PGlite boots, migrations run, Vite HMR up, `dev@lobu.local`/`lobudev123` login works, Agents page renders.

## Known follow-ups
- `McpConnect` URL is org-scoped, so a freshly-connected client isn't auto-assigned to the specific agent (needs server support).
- `agent-editor-form` empty-state CTAs for bare agents not added (forms render normally when empty).
- `/$owner/watchers` at the *workspace* level still soft-resolves to an org-wide list via `owner-resolver` (shared `EntityTabName` machinery; nav no longer points there).
- One-off prod migration before this ships: `UPDATE watchers SET agent_id=… WHERE agent_id IS NULL`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)