### PR TITLE
fix(gateway): resolve provider credentials in the agent's org context for chat-webhook runs

### DIFF
--- a/packages/server/src/gateway/auth/settings/__tests__/auth-profiles-manager-org-context.test.ts
+++ b/packages/server/src/gateway/auth/settings/__tests__/auth-profiles-manager-org-context.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, mock, test } from "bun:test";
+import { orgContext, tryGetOrgId } from "../../../../lobu/stores/org-context.js";
+import { AuthProfilesManager } from "../auth-profiles-manager.js";
+
+const PROFILE = {
+  id: "p1",
+  provider: "z-ai",
+  model: "*",
+  authType: "api-key" as const,
+  credentialRef: "secret://users/owner/agents/a1/auth-profiles/p1/credential",
+  createdAt: 0,
+};
+
+function makeManager(opts: {
+  ownerUserId?: string;
+  organizationId?: string;
+  ownerProfiles?: unknown[];
+}) {
+  const seenOrgs: Array<string | null> = [];
+  const secretStore = {
+    get: mock(async (_ref: string) => {
+      seenOrgs.push(tryGetOrgId());
+      return "resolved-secret-value";
+    }),
+    put: mock(async (name: string) => `secret://${name}`),
+    delete: mock(async () => {}),
+  };
+  const manager = new AuthProfilesManager({
+    ephemeralProfiles: { get: () => undefined } as never,
+    declaredAgents: { get: () => undefined } as never,
+    userAuthProfiles: {
+      list: mock(async (uid: string) =>
+        uid === opts.ownerUserId ? (opts.ownerProfiles ?? []) : []
+      ),
+    } as never,
+    secretStore: secretStore as never,
+    agentOwnerResolver: async () => opts.ownerUserId,
+    agentOrgResolver: async () => opts.organizationId,
+  });
+  return { manager, secretStore, seenOrgs };
+}
+
+describe("AuthProfilesManager — org context for credential-ref reads", () => {
+  test("wraps the secret read in the agent's org when no context is set (chat-webhook path)", async () => {
+    expect(tryGetOrgId()).toBeNull(); // sanity: outside any org context
+    const { manager, secretStore, seenOrgs } = makeManager({
+      ownerUserId: "owner",
+      organizationId: "org-A",
+      ownerProfiles: [PROFILE],
+    });
+
+    const profiles = await manager.getProviderProfiles("a1", "z-ai", "run-user");
+
+    expect(profiles).toHaveLength(1);
+    expect(profiles[0]?.credential).toBe("resolved-secret-value");
+    expect(secretStore.get).toHaveBeenCalledTimes(1);
+    // the org-scoped credential is read inside the agent's org, not the global partition
+    expect(seenOrgs).toEqual(["org-A"]);
+  });
+
+  test("honors an already-established org context (HTTP route / token-refresh job)", async () => {
+    const { manager, seenOrgs } = makeManager({
+      ownerUserId: "owner",
+      organizationId: "org-A",
+      ownerProfiles: [PROFILE],
+    });
+
+    await orgContext.run({ organizationId: "req-org" }, async () => {
+      const profiles = await manager.getProviderProfiles(
+        "a1",
+        "z-ai",
+        "run-user"
+      );
+      expect(profiles[0]?.credential).toBe("resolved-secret-value");
+    });
+
+    expect(seenOrgs).toEqual(["req-org"]); // caller's context wins, not overridden
+  });
+
+  test("falls through without org context when the agent's org can't be resolved", async () => {
+    const { manager, seenOrgs } = makeManager({
+      ownerUserId: "owner",
+      organizationId: undefined, // resolver yields nothing
+      ownerProfiles: [PROFILE],
+    });
+
+    const profiles = await manager.getProviderProfiles("a1", "z-ai", "run-user");
+
+    expect(profiles[0]?.credential).toBe("resolved-secret-value");
+    expect(seenOrgs).toEqual([null]);
+  });
+});

--- a/packages/server/src/gateway/auth/settings/auth-profiles-manager.ts
+++ b/packages/server/src/gateway/auth/settings/auth-profiles-manager.ts
@@ -1,4 +1,5 @@
 import { type AuthProfile, createLogger } from "@lobu/core";
+import { orgContext, tryGetOrgId } from "../../../lobu/stores/org-context.js";
 import type {
   ProviderCredentialContext,
   RuntimeProviderCredentialResolver,
@@ -58,6 +59,16 @@ interface AuthProfilesManagerOptions {
    * fall back to the owner's user-scoped profiles via this resolver.
    */
   agentOwnerResolver?: (agentId: string) => Promise<string | undefined>;
+  /**
+   * Resolve an agent's organization id. Credentials are stored in the
+   * org-partitioned secret store (`PostgresSecretStore`, keyed by
+   * AsyncLocalStorage org context). Agent runs triggered by a chat-platform
+   * webhook reach this manager with no org context established (the webhook
+   * route has no `:orgSlug`), so without this resolver the credential-ref read
+   * falls back to the global partition and misses the org-scoped value. When
+   * no org context is set, `listProfiles` wraps the read in this agent's org.
+   */
+  agentOrgResolver?: (agentId: string) => Promise<string | undefined>;
 }
 
 /**
@@ -84,13 +95,23 @@ export class AuthProfilesManager {
   private readonly agentOwnerResolver?: (
     agentId: string
   ) => Promise<string | undefined>;
+  private readonly agentOrgResolver?: (
+    agentId: string
+  ) => Promise<string | undefined>;
   /** Short-lived `agentId → ownerUserId` cache — owner lookups happen on the
    *  credential hot path (per proxy request), the owner rarely changes. */
   private readonly agentOwnerCache = new Map<
     string,
     { ownerUserId: string | undefined; expiresAt: number }
   >();
+  /** Short-lived `agentId → organizationId` cache — same hot path as the owner
+   *  cache; an agent doesn't change org. */
+  private readonly agentOrgCache = new Map<
+    string,
+    { organizationId: string | undefined; expiresAt: number }
+  >();
   private static readonly AGENT_OWNER_CACHE_TTL_MS = 60_000;
+  private static readonly AGENT_ORG_CACHE_TTL_MS = 60_000;
   private lazyRefreshHooks?: LazyRefreshHooks;
 
   constructor(options: AuthProfilesManagerOptions) {
@@ -100,6 +121,7 @@ export class AuthProfilesManager {
     this.secretStore = options.secretStore;
     this.runtimeCredentialResolver = options.runtimeCredentialResolver;
     this.agentOwnerResolver = options.agentOwnerResolver;
+    this.agentOrgResolver = options.agentOrgResolver;
   }
 
   /** Wired by boot after TaskScheduler is up. Until then, lazy refresh is a
@@ -215,6 +237,32 @@ export class AuthProfilesManager {
     return ownerUserId;
   }
 
+  private async resolveAgentOrgId(
+    agentId: string
+  ): Promise<string | undefined> {
+    if (!this.agentOrgResolver) return undefined;
+    const cached = this.agentOrgCache.get(agentId);
+    if (cached && cached.expiresAt > Date.now()) return cached.organizationId;
+    let organizationId: string | undefined;
+    try {
+      organizationId = await this.agentOrgResolver(agentId);
+    } catch (error) {
+      logger.warn(
+        {
+          agentId,
+          error: error instanceof Error ? error.message : String(error),
+        },
+        "agent org resolver failed; credential reads run without org context"
+      );
+      return undefined;
+    }
+    this.agentOrgCache.set(agentId, {
+      organizationId,
+      expiresAt: Date.now() + AuthProfilesManager.AGENT_ORG_CACHE_TTL_MS,
+    });
+    return organizationId;
+  }
+
   private async listAgentOwnerProfiles(
     agentId: string,
     requestingUserId?: string
@@ -230,6 +278,26 @@ export class AuthProfilesManager {
   }
 
   async listProfiles(agentId: string, userId?: string): Promise<AuthProfile[]> {
+    // Credential refs resolve through the org-partitioned secret store. If the
+    // caller already established an org context (HTTP route, token-refresh job),
+    // honor it. Otherwise — chat-platform webhook → worker-session-prep, which
+    // has none — run the lookup inside this agent's org so the org-scoped
+    // credential is found instead of falling back to the global partition.
+    if (tryGetOrgId()) {
+      return this.listProfilesInOrgContext(agentId, userId);
+    }
+    const organizationId = await this.resolveAgentOrgId(agentId);
+    return organizationId
+      ? orgContext.run({ organizationId }, () =>
+          this.listProfilesInOrgContext(agentId, userId)
+        )
+      : this.listProfilesInOrgContext(agentId, userId);
+  }
+
+  private async listProfilesInOrgContext(
+    agentId: string,
+    userId?: string
+  ): Promise<AuthProfile[]> {
     const userProfiles = userId
       ? await this.userAuthProfiles.list(userId, agentId)
       : [];

--- a/packages/server/src/gateway/services/core-services.ts
+++ b/packages/server/src/gateway/services/core-services.ts
@@ -471,6 +471,12 @@ export class CoreServices {
       runtimeCredentialResolver: this.options?.providerCredentialResolver,
       agentOwnerResolver: async (agentId) =>
         (await this.agentSettingsStore?.getMetadata(agentId))?.owner.userId,
+      agentOrgResolver: async (agentId) => {
+        const rows = (await getDb()`
+          SELECT organization_id FROM agents WHERE id = ${agentId} LIMIT 1
+        `) as Array<{ organization_id?: string }>;
+        return rows[0]?.organization_id ?? undefined;
+      },
     });
     this.transcriptionService = new TranscriptionService(
       this.authProfilesManager


### PR DESCRIPTION
## Problem

Provider / BYOK credentials live in the **org-partitioned** secret store (`PostgresSecretStore` — keyed by `(organization_id, name)`, with the org id threaded via AsyncLocalStorage). HTTP routes under `/api/:orgSlug/...` and the token-refresh job establish that org context before reading secrets.

But an agent run triggered by a **chat-platform webhook** reaches worker-session-prep via `POST /api/v1/webhooks/:connectionId` — which has **no `:orgSlug`** and so no org-context middleware. `AuthProfilesManager.listProfiles` → `resolveProfile` → `secretStore.get(credentialRef)` then ran with `tryGetOrgId() === null` → fell back to the global (`''`) partition → missed the org-scoped credential → the worker dropped the auth profile (`auth-profiles-manager: "Dropping auth profile with unresolvable secret ref"`) → ran with `provider: none` → failed with `❌ To use <model>, an admin needs to connect <provider> on the base agent` — even though the credential was correctly connected through the UI.

Surfaced while bringing up Slack Preview in prod: the `preview-concierge` agent's z-ai credential (and `link-test`'s) couldn't be resolved on the inbound-DM path. (The Slack connection's *own* secrets — `botToken` / `signingSecret` — resolve fine only because they're read at connection-startup, which *does* have org context, and cached on the in-memory chat instance; they're never re-resolved per message.)

## Fix

`AuthProfilesManager.listProfiles` now establishes the agent's org context around credential resolution **when the caller hasn't already set one**:
- If `tryGetOrgId()` is set (HTTP route, token-refresh job), it's honored unchanged.
- Otherwise, resolve `agentId → organizations.organization_id` via a new `agentOrgResolver` (wired in `core-services.ts`, cached like the existing `agentOwnerResolver`), and run the lookup inside `orgContext.run({ organizationId }, …)`.
- If the org can't be resolved (embedded SDK mode / no DB row), fall through unwrapped — preserves current behavior.

New bun:test (`auth-profiles-manager-org-context.test.ts`) covers all three cases: no context → wrapped in the agent's org; existing context → honored; unresolvable org → unwrapped.

## Notes

- A temporary workaround is currently live in prod for the `market` org: the `preview-concierge` / `link-test` z-ai credentials were duplicated into the global (`''`) secret partition so the unscoped read finds them. Once this deploys, those duplicates can be deleted (the canonical org-scoped copies are still there).
- This is the other half of what surfaced during the Slack Preview prod bring-up; the `/lobu link` channel-id mismatch was fixed in #638.
- Build + typecheck clean; the 4 pre-existing failures in `user-auth-profile-store.test.ts` / connector `auth-profiles.test.ts` are unrelated (stale-test backlog) — they fail on `main` too.