### PR TITLE
feat(slack-preview): deterministic "link this chat" reply for unlinked DMs/channels

### DIFF
--- a/packages/server/src/gateway/__tests__/message-handler-bridge.test.ts
+++ b/packages/server/src/gateway/__tests__/message-handler-bridge.test.ts
@@ -427,3 +427,74 @@ describe("MessageHandlerBridge.handleMessage — thread backfill", () => {
     expect(entries).toHaveLength(2);
   });
 });
+
+describe("MessageHandlerBridge.handleMessage — Slack Preview unlinked chat", () => {
+  function makePreviewHarness(opts: { binding?: { agentId: string } | null }) {
+    const state = new InMemoryStateAdapter();
+    const conversationState = new ConversationStateStore(state);
+    const connection: PlatformConnection = {
+      id: CONN_ID,
+      platform: "slack",
+      agentId: TEMPLATE_AGENT_ID,
+      config: { platform: "slack" } as any,
+      settings: { allowGroups: true, previewMode: true },
+      metadata: { botUsername: "testbot", botUserId: "U_BOT" },
+      status: "active",
+      createdAt: 1,
+      updatedAt: 1,
+    };
+    const enqueueMessage = mock(async () => undefined);
+    const channelBindingService =
+      opts.binding === undefined
+        ? undefined
+        : { getBinding: mock(async () => opts.binding) };
+    const services = {
+      getArtifactStore: () => null,
+      getPublicGatewayUrl: () => "https://gateway.example.com",
+      getChannelBindingService: () => channelBindingService,
+      getAgentMetadataStore: () => undefined,
+      getUserAgentsStore: () => undefined,
+      getTranscriptionService: () => undefined,
+      getAgentSettingsStore: () => undefined,
+      getDeclaredAgentRegistry: () => undefined,
+      getQueueProducer: () => ({ enqueueMessage }),
+    } as any;
+    const manager = {
+      has: () => true,
+      getInstance: () => ({ connection, conversationState }),
+    } as any;
+    const bridge = new MessageHandlerBridge(connection, services, manager);
+    return { bridge, enqueueMessage };
+  }
+
+  test("unlinked chat → posts /lobu link instructions, no agent run", async () => {
+    const { bridge, enqueueMessage } = makePreviewHarness({ binding: null });
+    const thread = makeThread(undefined);
+
+    await bridge.handleMessage(thread, makeMessage(), "mention");
+
+    expect(thread.post).toHaveBeenCalledTimes(1);
+    expect(String(thread.post.mock.calls[0]?.[0])).toContain("/lobu link");
+    expect(enqueueMessage).not.toHaveBeenCalled();
+  });
+
+  test("linked chat → routes to the bound agent, no notice", async () => {
+    const { bridge, enqueueMessage } = makePreviewHarness({
+      binding: { agentId: "linked-agent" },
+    });
+    const thread = makeThread(undefined);
+
+    await bridge.handleMessage(thread, makeMessage(), "mention");
+
+    expect(enqueueMessage).toHaveBeenCalledTimes(1);
+    const payload = enqueueMessage.mock.calls[0]?.[0] as any;
+    expect(payload.agentId ?? payload.platformMetadata?.agentId).toBe(
+      "linked-agent"
+    );
+    expect(
+      thread.post.mock.calls.every(
+        (c: unknown[]) => !String(c[0]).includes("/lobu link")
+      )
+    ).toBe(true);
+  });
+});

--- a/packages/server/src/gateway/connections/message-handler-bridge.ts
+++ b/packages/server/src/gateway/connections/message-handler-bridge.ts
@@ -10,6 +10,7 @@ import {
   flushTracing,
   generateTraceId,
 } from "@lobu/core";
+import { SLACK_PREVIEW_UNLINKED_NOTICE } from "../../preview/slack.js";
 import type { CommandDispatcher } from "../commands/command-dispatcher.js";
 import { createChatReply } from "../commands/command-reply-adapters.js";
 import type { ArtifactStore } from "../files/artifact-store.js";
@@ -307,6 +308,25 @@ export class MessageHandlerBridge {
       );
       return;
     }
+
+    // Preview connection (the hosted "Lobu" Slack workspace bot today): an
+    // unlinked DM/@-mention. Don't run the connection's placeholder owning
+    // agent — reply with the `/lobu link` instructions and stop here.
+    // (`/lobu link <code>` itself arrives as a slash command, not through this
+    // path, so linking still works.)
+    if (
+      resolved.source === "connection" &&
+      this.connection.settings?.previewMode === true &&
+      platform === "slack"
+    ) {
+      logger.info(
+        { platform, channelId, teamId, connectionId: this.connection.id },
+        "Preview connection: unlinked chat — replying with link instructions"
+      );
+      await thread.post(SLACK_PREVIEW_UNLINKED_NOTICE);
+      return;
+    }
+
     const agentId = resolved.agentId;
 
     // Track first-time-seen user → agent association for visibility in the

--- a/packages/server/src/gateway/connections/types.ts
+++ b/packages/server/src/gateway/connections/types.ts
@@ -77,6 +77,15 @@ export interface ConnectionSettings {
   allowFrom?: string[];
   allowGroups?: boolean;
   userConfigScopes?: UserConfigScope[];
+  /**
+   * Marks this connection as a hosted "Preview" workspace bot (today: Slack —
+   * the public "Lobu" workspace). When a DM/@-mention arrives for a chat that
+   * hasn't been linked to an agent yet, the message-handler replies with the
+   * linking instructions instead of running the connection's (placeholder)
+   * owning agent. The connection's `platform` determines which notice/link
+   * mechanism applies.
+   */
+  previewMode?: boolean;
 }
 
 /** Heuristic: field names matching these patterns contain secrets and must be encrypted at rest. */

--- a/packages/server/src/preview/slack.ts
+++ b/packages/server/src/preview/slack.ts
@@ -28,6 +28,23 @@ const SURFACES = new Set(['dm', 'channel']);
 
 export type SurfaceType = 'dm' | 'channel';
 
+/**
+ * Reply posted by a Slack-Preview connection when a DM/@-mention arrives for a
+ * chat that hasn't been `/lobu link`'d yet. Deterministic — no LLM agent runs
+ * for unlinked chats; this is the whole response.
+ */
+export const SLACK_PREVIEW_UNLINKED_NOTICE = [
+  "👋 This chat isn't linked to a Lobu agent yet.",
+  '',
+  'To talk to your own agent here:',
+  '1. In your agent project\'s `lobu.toml`: `[agents.<id>.preview.slack]` → `enabled = true` (add `surfaces = ["channel"]` to use it in channels too).',
+  '2. Run `lobu apply` to register the agent in Lobu Cloud.',
+  '3. Run `lobu run` — it prints a `/lobu link <code>`.',
+  '4. Send that `/lobu link <code>` here.',
+  '',
+  'After that, every message in this chat goes to your agent.',
+].join('\n');
+
 interface ClaimPayload {
   organizationId: string;
   agentId: string;


### PR DESCRIPTION
## What

When someone DMs the hosted Slack-Preview bot (or @-mentions it in a channel) and that chat hasn't been `/lobu link`'d, the message used to fall through to the connection's *owning agent* and run it as an LLM — so the "you need to link first" reply was only as reliable as that agent's prompt. With a small model (glm-4.7) it just ignores the prompt and acts as a generic assistant. (Saw this live: `@lobu` in an unlinked channel answered "I'm ready to help with coding, file operations…" instead of the linking instructions.)

This makes the unlinked-chat reply **deterministic** — no LLM agent runs for unlinked chats.

## How

- New `ConnectionSettings.slackPreview?: boolean` — set on the hosted "Lobu" Slack connection to mark it as the preview workspace bot.
- In `MessageHandlerBridge.handleMessage`: when `resolveAgentId` falls back to the connection's owning agent (`source === "connection"`, i.e. no `agent_channel_bindings` row) **and** `connection.settings.slackPreview === true`, the bridge posts a fixed notice (`SLACK_PREVIEW_UNLINKED_NOTICE` — "👋 this chat isn't linked; `lobu run` → `/lobu link <code>`") and returns. No worker run, no LLM.
- Linked chats (binding present → `source === "binding"`) route to the bound agent unchanged. `/lobu link <code>` itself arrives as a slash command, not through `handleMessage`, so linking still works in an unlinked chat.
- Net: no LLM "concierge" agent needed for the fallback — the connection's `agent_id` is just an unused FK placeholder.

Two new `message-handler-bridge` tests (unlinked → notice, no enqueue; linked → routes to the bound agent, no notice). `make build-packages` + `bun test` + typecheck clean.

## Operator note / follow-ups

- The hosted connection needs `settings.slackPreview = true` — for the existing `slack-lobu-preview` connection in prod that's a one-line `settings` update (or re-PUT via the platforms API). The connections UI in `packages/web` should grow a "Slack Preview workspace" toggle — follow-up.
- The `preview-concierge` agent in the `market` org becomes unused (it was a stopgap LLM fallback); it can be deleted, or kept as a no-op FK target.
- Independent of #641 (org-context fix). Both came out of the Slack-Preview prod bring-up.