### PR TITLE
feat(device-workers): device home org follows the workspace picked on the OAuth page

### DIFF
--- a/packages/server/src/__tests__/integration/mcp/auth.test.ts
+++ b/packages/server/src/__tests__/integration/mcp/auth.test.ts
@@ -1005,5 +1005,43 @@ describe('MCP Authentication', () => {
       const body = await response.json();
       expect(body.error).toBe('access_denied');
     });
+
+    it('attaches a polling device worker to the org its token was approved for', async () => {
+      const dc = await createTestDeviceCode(deviceClient.client_id);
+
+      // User approves the device on the OAuth page, picking `org`.
+      const approveRes = await post('/oauth/device/approve', {
+        body: { user_code: dc.userCode, approved: true, organization_id: org.id },
+        cookie: sessionCookie,
+        headers: { Origin: 'http://localhost' },
+      });
+      expect(approveRes.status).toBe(200);
+
+      // The device exchanges its device code for an access token.
+      const tokenRes = await post('/oauth/token', {
+        body: {
+          grant_type: 'urn:ietf:params:oauth:grant-type:device_code',
+          device_code: dc.deviceCode,
+          client_id: deviceClient.client_id,
+          client_secret: deviceClient.client_secret,
+        },
+      });
+      expect(tokenRes.status).toBe(200);
+      const { access_token: accessToken } = (await tokenRes.json()) as { access_token: string };
+      expect(accessToken).toBeTruthy();
+
+      // First poll registers the device worker; its home is the approved org.
+      const workerId = `test-mac-${Date.now()}`;
+      const pollRes = await post('/api/workers/poll', {
+        body: { worker_id: workerId, capabilities: {} },
+        headers: { Authorization: `Bearer ${accessToken}` },
+      });
+      expect(pollRes.status).toBe(200);
+
+      const rows = (await getTestDb()`
+        SELECT organization_id FROM device_workers WHERE worker_id = ${workerId} LIMIT 1
+      `) as Array<{ organization_id: string | null }>;
+      expect(rows[0]?.organization_id).toBe(org.id);
+    });
   });
 });

--- a/packages/server/src/worker-api.ts
+++ b/packages/server/src/worker-api.ts
@@ -507,6 +507,11 @@ export async function pollWorkerJob(c: Context<{ Bindings: Env }>) {
   // regardless of the connector's required_capability — that's how an
   // otherwise-cloud connector (Reddit, …) ends up running on a chosen device.
   const workerUserId = c.var.workerUserId;
+  // The org the device's token was issued for — the workspace the user picked on
+  // the OAuth device-authorization page. Falls back to the owner's personal
+  // workspace for tokens not bound to any org. Sets the device's home only on
+  // first registration; moving an existing device is the Devices-page action.
+  const workerTokenOrgId = c.var.organizationId ?? null;
   let deviceWorkerId: string | null = null;
   if (workerUserId) {
     try {
@@ -517,7 +522,10 @@ export async function pollWorkerJob(c: Context<{ Bindings: Env }>) {
         VALUES (
           ${workerUserId}, ${worker_id}, ${platform}, ${app_version},
           ${sql.json(incomingCaps)}, ${label},
-          (SELECT id FROM organization WHERE (metadata::jsonb)->>'personal_org_for_user_id' = ${workerUserId} LIMIT 1)
+          COALESCE(
+            ${workerTokenOrgId}::text,
+            (SELECT id FROM organization WHERE (metadata::jsonb)->>'personal_org_for_user_id' = ${workerUserId} LIMIT 1)
+          )
         )
         ON CONFLICT (user_id, worker_id) DO UPDATE SET
           platform = EXCLUDED.platform,


### PR DESCRIPTION
Follow-up to #639. A device's home workspace (`device_workers.organization_id`) should be the one the user picks when they approve the Mac/CLI on the OAuth **device-authorization page** — not a separate "org picker at setup".

That picker already exists end-to-end:
- **web** — `/oauth/device` renders a workspace `<Select>` (`useOrgPreselect`) and sends `organization_id`; handles `org_selection_required`.
- **server** — `/oauth/device/approve` resolves & validates the org (`resolveOrganizationForGrant`) and binds it to the issued token via `approveDeviceCode(...)`; the workspace resolver then surfaces it as `c.var.organizationId`.

This PR connects the last wire: `pollWorkerJob`'s device-registry upsert stamps `device_workers.organization_id` from the polling token's bound org (`c.var.organizationId`), falling back to the owner's personal workspace only for tokens not bound to any org. It sets the home on **first registration** only — re-authorizing later doesn't auto-move a device (that would silently pause its connections); moving a device stays the Devices-page Select from #639.

### Test
Added `mcp/auth.test.ts` → "attaches a polling device worker to the org its token was approved for": create a device code → approve it with `organization_id: org.id` → exchange for an access token → `POST /api/workers/poll` with that token → assert `device_workers.organization_id == org.id`. (Runs in the `integration` CI job; I can't run the integration suite locally — its DB is the shared/prod one over Tailscale and the harness calls `cleanupTestDatabase()`.) `bun run typecheck` ✓, `make build-packages` ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)