### PR TITLE
refactor(preview): make the /lobu link claim machinery platform-agnostic

### DIFF
--- a/packages/core/src/command-registry.ts
+++ b/packages/core/src/command-registry.ts
@@ -11,6 +11,8 @@ export interface CommandContext {
   channelId: string;
   /** Workspace/team id for platforms that have one (Slack). Undefined elsewhere. */
   teamId?: string;
+  /** True if this is a group/channel rather than a 1:1 DM with the bot. */
+  isGroup?: boolean;
   conversationId?: string;
   connectionId?: string;
   agentId?: string;

--- a/packages/server/src/gateway/commands/built-in-commands.ts
+++ b/packages/server/src/gateway/commands/built-in-commands.ts
@@ -1,5 +1,8 @@
 import type { CommandContext, CommandRegistry } from "@lobu/core";
-import { consumeSlackPreviewClaim } from "../../preview/slack.js";
+import {
+  canonicalSlackChannelId,
+  consumePreviewClaim,
+} from "../../preview/slack.js";
 import type { AgentSettingsStore } from "../auth/settings/agent-settings-store.js";
 import {
   getModelSelectionState,
@@ -89,20 +92,26 @@ export function registerBuiltInCommands(
       "Link this chat to a Lobu agent using a code from `lobu run` (Slack Preview)",
     handler: async (ctx: CommandContext) => {
       const code = ctx.args.trim();
+      const cmd = ctx.platform === "slack" ? "/lobu link" : "/link";
       if (!code) {
         await ctx.reply(
-          "Usage: `/lobu link <code>` — get a code by running `lobu run` on a Slack-Preview-enabled agent."
+          `Usage: \`${cmd} <code>\` — get a code by running \`lobu run\` on a Preview-enabled agent.`
         );
         return;
       }
-      if (ctx.platform !== "slack" || !ctx.teamId) {
-        await ctx.reply("`/lobu link` only works in Slack.");
-        return;
-      }
-      const result = await consumeSlackPreviewClaim({
+      const surfaceType: "dm" | "channel" = ctx.isGroup ? "channel" : "dm";
+      // The message handler looks bindings up by the platform's canonical
+      // channel-id form; Slack slash commands hand us the bare id.
+      const channelId =
+        ctx.platform === "slack"
+          ? canonicalSlackChannelId(ctx.channelId)
+          : ctx.channelId;
+      const result = await consumePreviewClaim({
         code,
+        platform: ctx.platform,
         teamId: ctx.teamId,
-        channelId: ctx.channelId,
+        channelId,
+        surfaceType,
       });
       switch (result.status) {
         case "bound":
@@ -117,7 +126,7 @@ export function registerBuiltInCommands(
           return;
         case "surface_not_allowed":
           await ctx.reply(
-            `This code can't be used in a ${result.surfaceType === "dm" ? "DM" : "channel"}. Check the agent's \`preview.slack.surfaces\` setting.`
+            `This code can't be used in a ${result.surfaceType === "dm" ? "DM" : "channel"}. Check the agent's \`preview.${ctx.platform}.surfaces\` setting.`
           );
           return;
       }

--- a/packages/server/src/gateway/commands/command-dispatcher.ts
+++ b/packages/server/src/gateway/commands/command-dispatcher.ts
@@ -65,6 +65,7 @@ export class CommandDispatcher {
       userId: input.userId,
       channelId: input.channelId,
       teamId: input.teamId,
+      isGroup: input.isGroup,
       conversationId: input.conversationId,
       connectionId: input.connectionId,
       agentId,

--- a/packages/server/src/preview/__tests__/slack-preview.test.ts
+++ b/packages/server/src/preview/__tests__/slack-preview.test.ts
@@ -9,7 +9,12 @@ import {
 import { getDb } from "../../db/client.js";
 import { registerBuiltInCommands } from "../../gateway/commands/built-in-commands.js";
 import type { Env } from "../../index";
-import { consumeSlackPreviewClaim, createSlackPreviewClaim } from "../slack";
+import {
+  canonicalSlackChannelId,
+  consumePreviewClaim,
+  createSlackPreviewClaim,
+  slackSurfaceType,
+} from "../slack";
 
 const AGENT_ID = "demo-agent";
 const OTHER_AGENT_ID = "other-agent";
@@ -17,6 +22,19 @@ const TEAM_ID = "T_DEVELOPER";
 
 let ORG_ID = "";
 const USER_ID = "user-slack-preview";
+
+// The `link` command computes platform/surface/canonical-channel from the
+// command context before calling `consumePreviewClaim`; mirror that here so the
+// direct-call tests exercise the same shape a real Slack `/lobu link` produces.
+function consumeSlack(args: { code: string; teamId: string; channelId: string }) {
+  return consumePreviewClaim({
+    code: args.code,
+    platform: "slack",
+    teamId: args.teamId,
+    channelId: canonicalSlackChannelId(args.channelId),
+    surfaceType: slackSurfaceType(args.channelId),
+  });
+}
 
 interface FakeResponse {
   status: number;
@@ -107,7 +125,7 @@ describe("Slack Preview claims + channel bindings", () => {
 
   test("consume binds the Slack channel to the agent and is one-time-use", async () => {
     const code = await createClaim(AGENT_ID);
-    const bound = await consumeSlackPreviewClaim({
+    const bound = await consumeSlack({
       code,
       teamId: TEAM_ID,
       channelId: "D123",
@@ -135,17 +153,17 @@ describe("Slack Preview claims + channel bindings", () => {
 
     // Claim consumed; replay fails.
     expect(
-      await consumeSlackPreviewClaim({ code, teamId: TEAM_ID, channelId: "D123" })
+      await consumeSlack({ code, teamId: TEAM_ID, channelId: "D123" })
     ).toEqual({ status: "not_found" });
   });
 
   test("re-linking a channel rebinds it to the new agent (last link wins)", async () => {
-    await consumeSlackPreviewClaim({
+    await consumeSlack({
       code: await createClaim(AGENT_ID),
       teamId: TEAM_ID,
       channelId: "Csame",
     });
-    const rebound = await consumeSlackPreviewClaim({
+    const rebound = await consumeSlack({
       code: await createClaim(OTHER_AGENT_ID),
       teamId: TEAM_ID,
       channelId: "Csame",
@@ -163,7 +181,7 @@ describe("Slack Preview claims + channel bindings", () => {
 
   test("expired or unknown code → not_found, nothing bound", async () => {
     expect(
-      await consumeSlackPreviewClaim({
+      await consumeSlack({
         code: "demo-agent-NOPE00",
         teamId: TEAM_ID,
         channelId: "D1",
@@ -174,7 +192,7 @@ describe("Slack Preview claims + channel bindings", () => {
     const sql = getDb();
     await sql`UPDATE oauth_states SET expires_at = now() - interval '1 minute' WHERE scope = 'slack-preview-claim'`;
     expect(
-      await consumeSlackPreviewClaim({ code, teamId: TEAM_ID, channelId: "D1" })
+      await consumeSlack({ code, teamId: TEAM_ID, channelId: "D1" })
     ).toEqual({ status: "not_found" });
     const bindings =
       await sql`SELECT 1 FROM agent_channel_bindings WHERE platform = 'slack'`;
@@ -184,7 +202,7 @@ describe("Slack Preview claims + channel bindings", () => {
   test("using a dm-only code in a channel → surface_not_allowed", async () => {
     const code = await createClaim(AGENT_ID, ["dm"]);
     expect(
-      await consumeSlackPreviewClaim({ code, teamId: TEAM_ID, channelId: "C9" })
+      await consumeSlack({ code, teamId: TEAM_ID, channelId: "C9" })
     ).toEqual({ status: "surface_not_allowed", surfaceType: "channel" });
   });
 
@@ -193,7 +211,7 @@ describe("Slack Preview claims + channel bindings", () => {
     // get it double-prefixed.
     const code = await createClaim(AGENT_ID, ["dm"]);
     expect(
-      await consumeSlackPreviewClaim({
+      await consumeSlack({
         code,
         teamId: TEAM_ID,
         channelId: "slack:D999",
@@ -221,6 +239,7 @@ describe("Slack Preview claims + channel bindings", () => {
       userId: "U1",
       channelId: "D777",
       teamId: TEAM_ID,
+      isGroup: false,
       platform: "slack",
       args: code,
       reply: async (text: string) => {
@@ -243,6 +262,7 @@ describe("Slack Preview claims + channel bindings", () => {
       userId: "U1",
       channelId: "D777",
       teamId: TEAM_ID,
+      isGroup: false,
       platform: "slack",
       args: "demo-agent-BADBAD",
       reply: async (text: string) => {

--- a/packages/server/src/preview/slack.ts
+++ b/packages/server/src/preview/slack.ts
@@ -205,21 +205,25 @@ export type ConsumeClaimResult =
   | { status: 'surface_not_allowed'; surfaceType: SurfaceType };
 
 /**
- * Consume a `/lobu link` code and bind the originating Slack channel/DM to the
- * agent the code was minted for. One-time use; last link for a surface wins
+ * Consume a `/lobu link` (a.k.a. `/link`) code and bind the originating chat to
+ * the agent the code was minted for. One-time use; last link for a surface wins
  * (re-linking just rebinds — there's no separate unlink step). Called from the
  * `link` chat command, so it never touches HTTP.
+ *
+ * Platform-agnostic: the caller supplies the `platform`, the canonical
+ * `channelId` form that platform's message handler looks bindings up by (for
+ * Slack: `canonicalSlackChannelId`), the workspace/`teamId` if the platform has
+ * one, and the resolved `surfaceType` (dm vs channel).
  */
-export async function consumeSlackPreviewClaim(args: {
+export async function consumePreviewClaim(args: {
   code: string;
-  teamId: string;
+  platform: string;
+  /** Workspace id for platforms that have one (Slack); undefined otherwise. */
+  teamId?: string;
   channelId: string;
+  surfaceType: SurfaceType;
 }): Promise<ConsumeClaimResult> {
-  const { code, teamId } = args;
-  const surfaceType = slackSurfaceType(args.channelId);
-  // Store the binding under the same `slack:<id>` key the message bridge uses
-  // for getBinding — the slash command gives us the bare channel id.
-  const channelId = canonicalSlackChannelId(args.channelId);
+  const { code, platform, teamId, channelId, surfaceType } = args;
   const sql = getDb();
 
   return sql.begin(async (tx) => {
@@ -236,13 +240,25 @@ export async function consumeSlackPreviewClaim(args: {
       return { status: 'surface_not_allowed' as const, surfaceType };
     }
 
-    // Mirrors ChannelBindingService.createBinding's upsert for the team-set
-    // case — last link wins.
-    await tx`
-      INSERT INTO agent_channel_bindings (agent_id, platform, channel_id, team_id, created_at)
-      VALUES (${claim.agentId}, ${SLACK_PLATFORM}, ${channelId}, ${teamId}, now())
-      ON CONFLICT (platform, channel_id, team_id) DO UPDATE SET agent_id = EXCLUDED.agent_id
-    `;
+    // Upsert the binding — last link for this chat wins. `ON CONFLICT` can't
+    // target a NULL `team_id`, so for platforms without a workspace concept
+    // (team_id null) we delete-then-insert inside the tx instead.
+    if (teamId) {
+      await tx`
+        INSERT INTO agent_channel_bindings (agent_id, platform, channel_id, team_id, created_at)
+        VALUES (${claim.agentId}, ${platform}, ${channelId}, ${teamId}, now())
+        ON CONFLICT (platform, channel_id, team_id) DO UPDATE SET agent_id = EXCLUDED.agent_id
+      `;
+    } else {
+      await tx`
+        DELETE FROM agent_channel_bindings
+        WHERE platform = ${platform} AND channel_id = ${channelId} AND team_id IS NULL
+      `;
+      await tx`
+        INSERT INTO agent_channel_bindings (agent_id, platform, channel_id, team_id, created_at)
+        VALUES (${claim.agentId}, ${platform}, ${channelId}, NULL, now())
+      `;
+    }
 
     return {
       status: 'bound' as const,


### PR DESCRIPTION
**Stacked on #644** (targets `feat/slack-preview-unlinked-notice`; rebase onto `main` once #644 lands).

## Why

The "link this chat to my agent via a `/lobu link <code>`" mechanism was named "Slack" all over but isn't structurally Slack-specific — it sits on the generic `agent_channel_bindings` table, the generic `link` chat command, and platform-agnostic message routing. The only real ties to Slack were naming and a hard `ctx.platform !== "slack"` gate. This de-Slack-ifies the core so the next platform (Telegram, Discord, …) is "stand up a hosted bot + set `connection.settings.previewMode`" — no new claim/binding/command code.

## Changes

- `consumeSlackPreviewClaim` → `consumePreviewClaim({ code, platform, teamId?, channelId, surfaceType })`. Binding written with the caller's `platform`; `teamId` optional (NULL `team_id` for workspace-less platforms — handled via delete-then-insert since `ON CONFLICT` can't target NULL); caller supplies the resolved `surfaceType` and the canonical channel-id form.
- `built-in-commands` `link` handler: drops the Slack-only gate; derives `surfaceType` from the new `CommandContext.isGroup`; canonicalizes the channel id for Slack and passes it through otherwise; reply copy is platform-neutral.
- `@lobu/core` `CommandContext` gains `isGroup?: boolean`; `CommandDispatcher` threads it through (the per-platform bridges already compute it).
- `slack-preview.test.ts` updated for the new signature (a small `consumeSlack(...)` wrapper mirrors what a real Slack `/lobu link` produces).

## Still Slack-only (deliberately, follow-up)

The hosted bot itself, the mint endpoint `/api/<org>/preview/slack/claims`, the `lobu.toml` `[agents.<id>.preview.slack]` schema, and `lobu run`'s link-code printing remain Slack-named — those generalize when a second hosted bot actually exists (Telegram is the obvious next; Lobu already runs `@clawdotfreebot` / `@lobuaibot`). The unlinked-notice text (from #644) is also Slack-phrased and gated on `platform === "slack"` for now.

slack-preview vitest 8/8, `message-handler-bridge` + `slack-platform-bridge` bun tests green, build + typecheck clean.