### PR TITLE
feat(preview): chat-user identity on /lobu link + codeless re-link by agent id

### DIFF
--- a/db/migrations/20260513000000_chat_user_identities.sql
+++ b/db/migrations/20260513000000_chat_user_identities.sql
@@ -1,0 +1,24 @@
+-- migrate:up
+
+-- Maps a chat-platform user (Slack `U…`, …) to a Lobu account. Recorded as a
+-- side effect of `/lobu link <code>` — the code is minted by an authenticated
+-- `lobu run`, so `oauth_states.payload.createdBy` is the Lobu user. Once a user
+-- is linked here, they can re-bind any chat to an agent they can manage via
+-- `/lobu link <agentId>` without minting a fresh code.
+
+CREATE TABLE IF NOT EXISTS public.chat_user_identities (
+    platform          text NOT NULL,
+    team_id           text NOT NULL DEFAULT '',  -- workspace id; '' for platforms without one
+    platform_user_id  text NOT NULL,
+    lobu_user_id      text NOT NULL REFERENCES public."user"(id) ON DELETE CASCADE,
+    created_at        timestamptz NOT NULL DEFAULT now(),
+    updated_at        timestamptz NOT NULL DEFAULT now(),
+    PRIMARY KEY (platform, team_id, platform_user_id)
+);
+
+CREATE INDEX IF NOT EXISTS chat_user_identities_lobu_user_idx
+    ON public.chat_user_identities (lobu_user_id);
+
+-- migrate:down
+
+DROP TABLE IF EXISTS public.chat_user_identities;

--- a/packages/server/src/gateway/commands/built-in-commands.ts
+++ b/packages/server/src/gateway/commands/built-in-commands.ts
@@ -1,10 +1,12 @@
 import type { CommandContext, CommandRegistry } from "@lobu/core";
 import {
+  bindChatToAgentForOwner,
   bindChatToPreviewAgent,
   canonicalSlackChannelId,
   consumePreviewClaim,
   listPreviewAgents,
   previewAgentMenu,
+  resolveChatUserIdentity,
 } from "../../preview/slack.js";
 import type { AgentSettingsStore } from "../auth/settings/agent-settings-store.js";
 import {
@@ -159,13 +161,13 @@ export function registerBuiltInCommands(
   registry.register({
     name: "link",
     description:
-      "Link this chat to a Lobu agent using a code from `lobu run` (Slack Preview)",
+      "Link this chat to a Lobu agent — `<code>` from `lobu run`, or `<agentId>` once you've linked here before",
     handler: async (ctx: CommandContext) => {
-      const code = ctx.args.trim();
+      const arg = ctx.args.trim();
       const cmd = ctx.platform === "slack" ? "/lobu link" : "/link";
-      if (!code) {
+      if (!arg) {
         await ctx.reply(
-          `Usage: \`${cmd} <code>\` — get a code by running \`lobu run\` on a Preview-enabled agent.`
+          `Usage: \`${cmd} <code>\` — get a code by running \`lobu run\` on a Preview-enabled agent. (Once you've linked here once, \`${cmd} <agentId>\` works too.)`
         );
         return;
       }
@@ -177,11 +179,12 @@ export function registerBuiltInCommands(
           ? canonicalSlackChannelId(ctx.channelId)
           : ctx.channelId;
       const result = await consumePreviewClaim({
-        code,
+        code: arg,
         platform: ctx.platform,
         teamId: ctx.teamId,
         channelId,
         surfaceType,
+        platformUserId: ctx.userId,
       });
       switch (result.status) {
         case "bound":
@@ -189,16 +192,43 @@ export function registerBuiltInCommands(
             `Linked this chat to agent \`${result.agentId}\`. Say hi — I'll reply here from now on.`
           );
           return;
-        case "not_found":
-          await ctx.reply(
-            "That link code is invalid or expired. Run `lobu run` again to get a fresh one."
-          );
-          return;
         case "surface_not_allowed":
           await ctx.reply(
             `This code can't be used in a ${result.surfaceType === "dm" ? "DM" : "channel"}. Check the agent's \`preview.${ctx.platform}.surfaces\` setting.`
           );
           return;
+        case "not_found": {
+          // Not a valid code — but if this user has linked here before, treat
+          // the arg as an agent id and re-bind directly (no fresh code needed).
+          const lobuUserId = await resolveChatUserIdentity(
+            ctx.platform,
+            ctx.teamId,
+            ctx.userId
+          );
+          if (lobuUserId) {
+            const bound = await bindChatToAgentForOwner({
+              platform: ctx.platform,
+              teamId: ctx.teamId,
+              channelId,
+              agentId: arg,
+              lobuUserId,
+            });
+            if (bound.status === "bound") {
+              await ctx.reply(
+                `Linked this chat to agent \`${arg}\`. Say hi — I'll reply here from now on.`
+              );
+              return;
+            }
+            await ctx.reply(
+              `No agent \`${arg}\` you can manage in your orgs. Either run \`lobu apply\` to register it, or paste a fresh \`/lobu link <code>\` from \`lobu run\`.`
+            );
+            return;
+          }
+          await ctx.reply(
+            "That link code is invalid or expired. Run `lobu run` again to get a fresh one."
+          );
+          return;
+        }
       }
     },
   });

--- a/packages/server/src/preview/__tests__/slack-preview.test.ts
+++ b/packages/server/src/preview/__tests__/slack-preview.test.ts
@@ -3,19 +3,23 @@ import type { Context } from "hono";
 import { beforeAll, beforeEach, describe, expect, test } from "vitest";
 import { cleanupTestDatabase } from "../../__tests__/setup/test-db.js";
 import {
+  addUserToOrganization,
   createTestAgent,
   createTestOrganization,
+  createTestUser,
 } from "../../__tests__/setup/test-fixtures.js";
 import { getDb } from "../../db/client.js";
 import { registerBuiltInCommands } from "../../gateway/commands/built-in-commands.js";
 import type { Env } from "../../index";
 import {
+  bindChatToAgentForOwner,
   bindChatToPreviewAgent,
   canonicalSlackChannelId,
   consumePreviewClaim,
   createPreviewClaim,
   listPreviewAgents,
   previewAgentMenu,
+  resolveChatUserIdentity,
   slackSurfaceType,
 } from "../slack";
 
@@ -24,7 +28,9 @@ const OTHER_AGENT_ID = "other-agent";
 const TEAM_ID = "T_DEVELOPER";
 
 let ORG_ID = "";
-const USER_ID = "user-slack-preview";
+// A real `user` row — `consumePreviewClaim` records `chat_user_identities`
+// (FK → "user"), so the claim's `createdBy` must be an actual user.
+let USER_ID = "";
 
 // The `link` command computes platform/surface/canonical-channel from the
 // command context before calling `consumePreviewClaim`; mirror that here so the
@@ -85,6 +91,9 @@ describe("Slack Preview claims + channel bindings", () => {
       slug: "slack-preview-org",
     });
     ORG_ID = org.id;
+    const user = await createTestUser({ email: "slack-preview@test.example.com" });
+    USER_ID = user.id;
+    await addUserToOrganization(USER_ID, ORG_ID);
     await createTestAgent({ organizationId: ORG_ID, agentId: AGENT_ID, name: "Demo" });
     await createTestAgent({
       organizationId: ORG_ID,
@@ -96,6 +105,7 @@ describe("Slack Preview claims + channel bindings", () => {
   beforeEach(async () => {
     const sql = getDb();
     await sql`DELETE FROM agent_channel_bindings`;
+    await sql`DELETE FROM chat_user_identities`;
     await sql`DELETE FROM oauth_states WHERE scope = 'slack-preview-claim'`;
   });
 
@@ -295,7 +305,9 @@ describe("Slack Preview claims + channel bindings", () => {
     `;
     expect((rows[0] as { agent_id: string }).agent_id).toBe(AGENT_ID);
 
-    // A bad code via the command surfaces the friendly error, no throw.
+    // After a successful link this user's identity is recorded, so a non-code
+    // arg is treated as an agent id — an unknown one surfaces the friendly
+    // "no agent" message, no throw.
     const replies2: string[] = [];
     await registry.tryHandle("link", {
       userId: "U1",
@@ -308,7 +320,7 @@ describe("Slack Preview claims + channel bindings", () => {
         replies2.push(text);
       },
     });
-    expect(replies2.join("\n")).toMatch(/invalid or expired/i);
+    expect(replies2.join("\n")).toMatch(/no agent `demo-agent-BADBAD`/i);
   });
 });
 
@@ -478,5 +490,156 @@ describe("Public preview — /lobu try a demo agent", () => {
     expect(previewAgentMenu("telegram", [
       { agentId: DEMO_A, name: "Food Ordering", description: null },
     ])).toContain(`/try ${DEMO_A}`);
+  });
+});
+
+describe("chat-user identity + codeless re-link by agent id", () => {
+  const ID_TEAM = "T_IDENTITY";
+  const ID_AGENT = "owned-agent";
+  let idOrgId = "";
+  let lobuUserId = "";
+  const SLACK_USER = "U_IDENTITY";
+
+  function ownerContext(jsonBody: unknown): Context<{ Bindings: Env }> {
+    return {
+      var: { organizationId: idOrgId, session: { userId: lobuUserId } },
+      req: { json: async () => jsonBody, header: () => undefined },
+      json: (body: Record<string, unknown>, status = 200): FakeResponse => ({
+        status,
+        body,
+      }),
+    } as unknown as Context<{ Bindings: Env }>;
+  }
+
+  beforeAll(async () => {
+    await cleanupTestDatabase();
+    const org = await createTestOrganization({ name: "Identity Org", slug: "identity-org" });
+    idOrgId = org.id;
+    const user = await createTestUser({ email: "identity@test.example.com" });
+    lobuUserId = user.id;
+    await addUserToOrganization(lobuUserId, idOrgId);
+    await createTestAgent({ organizationId: idOrgId, agentId: ID_AGENT, name: "Owned" });
+    await createTestAgent({ organizationId: idOrgId, agentId: "second-agent", name: "Second" });
+  });
+
+  beforeEach(async () => {
+    const sql = getDb();
+    await sql`DELETE FROM agent_channel_bindings`;
+    await sql`DELETE FROM chat_user_identities`;
+    await sql`DELETE FROM oauth_states WHERE scope = 'slack-preview-claim'`;
+  });
+
+  async function mintAndConsume(agentId: string, channelId: string) {
+    const res = await createPreviewClaim(
+      ownerContext({ agent_id: agentId, platform: "slack", surfaces: ["dm"] })
+    );
+    if (!isFakeResponse(res)) throw new Error("not a json response");
+    expect(res.status).toBe(200);
+    const code = res.body.code as string;
+    return consumePreviewClaim({
+      code,
+      platform: "slack",
+      teamId: ID_TEAM,
+      channelId: canonicalSlackChannelId(channelId),
+      surfaceType: "dm",
+      platformUserId: SLACK_USER,
+    });
+  }
+
+  test("consuming a code records the chat-user → Lobu-user identity", async () => {
+    const bound = await mintAndConsume(ID_AGENT, "D900");
+    expect(bound).toMatchObject({ status: "bound", agentId: ID_AGENT });
+
+    const rows = await getDb()`
+      SELECT lobu_user_id FROM chat_user_identities
+      WHERE platform = 'slack' AND team_id = ${ID_TEAM} AND platform_user_id = ${SLACK_USER}
+    `;
+    expect(rows).toHaveLength(1);
+    expect((rows[0] as { lobu_user_id: string }).lobu_user_id).toBe(lobuUserId);
+
+    expect(await resolveChatUserIdentity("slack", ID_TEAM, SLACK_USER)).toBe(lobuUserId);
+    expect(await resolveChatUserIdentity("slack", ID_TEAM, "U_NOBODY")).toBeNull();
+  });
+
+  test("bindChatToAgentForOwner re-binds to an agent in the user's org, refuses others", async () => {
+    expect(
+      await bindChatToAgentForOwner({
+        platform: "slack",
+        teamId: ID_TEAM,
+        channelId: canonicalSlackChannelId("D901"),
+        agentId: "second-agent",
+        lobuUserId,
+      })
+    ).toEqual({ status: "bound" });
+    const rows = await getDb()`
+      SELECT agent_id FROM agent_channel_bindings WHERE channel_id = 'slack:D901' AND team_id = ${ID_TEAM}
+    `;
+    expect((rows[0] as { agent_id: string }).agent_id).toBe("second-agent");
+
+    expect(
+      await bindChatToAgentForOwner({
+        platform: "slack",
+        teamId: ID_TEAM,
+        channelId: canonicalSlackChannelId("D902"),
+        agentId: "agent-in-another-org",
+        lobuUserId,
+      })
+    ).toEqual({ status: "forbidden" });
+  });
+
+  test("/lobu link <agentId> re-binds without a code once the user has linked here", async () => {
+    // First, a real link establishes the identity.
+    await mintAndConsume(ID_AGENT, "D903");
+
+    const registry = new CommandRegistry();
+    registerBuiltInCommands(registry, { agentSettingsStore: {} as never });
+
+    const replies: string[] = [];
+    await registry.tryHandle("link", {
+      userId: SLACK_USER,
+      channelId: "D903",
+      teamId: ID_TEAM,
+      isGroup: false,
+      platform: "slack",
+      args: "second-agent",
+      reply: async (text: string) => {
+        replies.push(text);
+      },
+    });
+    expect(replies.join("\n")).toContain("`second-agent`");
+    const rows = await getDb()`
+      SELECT agent_id FROM agent_channel_bindings WHERE channel_id = 'slack:D903' AND team_id = ${ID_TEAM}
+    `;
+    expect((rows[0] as { agent_id: string }).agent_id).toBe("second-agent");
+
+    // An unknown agent id surfaces the friendly error, no throw.
+    const replies2: string[] = [];
+    await registry.tryHandle("link", {
+      userId: SLACK_USER,
+      channelId: "D903",
+      teamId: ID_TEAM,
+      isGroup: false,
+      platform: "slack",
+      args: "agent-in-another-org",
+      reply: async (text: string) => {
+        replies2.push(text);
+      },
+    });
+    expect(replies2.join("\n")).toMatch(/no agent `agent-in-another-org`/i);
+
+    // A user who has never linked here just gets the "invalid code" message.
+    const replies3: string[] = [];
+    await registry.tryHandle("link", {
+      userId: "U_STRANGER",
+      channelId: "D999",
+      teamId: ID_TEAM,
+      isGroup: false,
+      platform: "slack",
+      args: "second-agent",
+      reply: async (text: string) => {
+        replies3.push(text);
+      },
+    });
+    expect(replies3.join("\n")).toMatch(/invalid or expired/i);
   });
 });

--- a/packages/server/src/preview/slack.ts
+++ b/packages/server/src/preview/slack.ts
@@ -230,6 +230,35 @@ export type ConsumeClaimResult =
   | { status: 'not_found' }
   | { status: 'surface_not_allowed'; surfaceType: SurfaceType };
 
+// `agent_channel_bindings` upsert — last link for this chat wins. `ON CONFLICT`
+// can't target a NULL `team_id`, so for platforms without a workspace concept
+// (team_id null) we delete-then-insert instead. `tx` is a `sql` or a `sql.begin`
+// transaction handle.
+async function upsertBinding(
+  tx: ReturnType<typeof getDb>,
+  platform: string,
+  channelId: string,
+  teamId: string | undefined,
+  agentId: string
+): Promise<void> {
+  if (teamId) {
+    await tx`
+      INSERT INTO agent_channel_bindings (agent_id, platform, channel_id, team_id, created_at)
+      VALUES (${agentId}, ${platform}, ${channelId}, ${teamId}, now())
+      ON CONFLICT (platform, channel_id, team_id) DO UPDATE SET agent_id = EXCLUDED.agent_id
+    `;
+  } else {
+    await tx`
+      DELETE FROM agent_channel_bindings
+      WHERE platform = ${platform} AND channel_id = ${channelId} AND team_id IS NULL
+    `;
+    await tx`
+      INSERT INTO agent_channel_bindings (agent_id, platform, channel_id, team_id, created_at)
+      VALUES (${agentId}, ${platform}, ${channelId}, NULL, now())
+    `;
+  }
+}
+
 /**
  * Consume a `/lobu link` (a.k.a. `/link`) code and bind the originating chat to
  * the agent the code was minted for. One-time use; last link for a surface wins
@@ -239,7 +268,9 @@ export type ConsumeClaimResult =
  * Platform-agnostic: the caller supplies the `platform`, the canonical
  * `channelId` form that platform's message handler looks bindings up by (for
  * Slack: `canonicalSlackChannelId`), the workspace/`teamId` if the platform has
- * one, and the resolved `surfaceType` (dm vs channel).
+ * one, the resolved `surfaceType` (dm vs channel), and — when available — the
+ * sender's platform user id, which is recorded against the code-minter's Lobu
+ * account in `chat_user_identities` so later links can skip the code.
  */
 export async function consumePreviewClaim(args: {
   code: string;
@@ -248,8 +279,10 @@ export async function consumePreviewClaim(args: {
   teamId?: string;
   channelId: string;
   surfaceType: SurfaceType;
+  /** Sender's platform user id (e.g. Slack `U…`), if known. */
+  platformUserId?: string;
 }): Promise<ConsumeClaimResult> {
-  const { code, platform, teamId, channelId, surfaceType } = args;
+  const { code, platform, teamId, channelId, surfaceType, platformUserId } = args;
   const sql = getDb();
 
   return sql.begin(async (tx) => {
@@ -266,23 +299,17 @@ export async function consumePreviewClaim(args: {
       return { status: 'surface_not_allowed' as const, surfaceType };
     }
 
-    // Upsert the binding — last link for this chat wins. `ON CONFLICT` can't
-    // target a NULL `team_id`, so for platforms without a workspace concept
-    // (team_id null) we delete-then-insert inside the tx instead.
-    if (teamId) {
+    await upsertBinding(tx, platform, channelId, teamId, claim.agentId);
+
+    // The code was minted by an authenticated `lobu run`, so the sender is the
+    // same Lobu user. Record the chat-platform → Lobu-user link so they can
+    // re-bind chats with `/lobu link <agentId>` without a fresh code.
+    if (claim.createdBy && platformUserId) {
       await tx`
-        INSERT INTO agent_channel_bindings (agent_id, platform, channel_id, team_id, created_at)
-        VALUES (${claim.agentId}, ${platform}, ${channelId}, ${teamId}, now())
-        ON CONFLICT (platform, channel_id, team_id) DO UPDATE SET agent_id = EXCLUDED.agent_id
-      `;
-    } else {
-      await tx`
-        DELETE FROM agent_channel_bindings
-        WHERE platform = ${platform} AND channel_id = ${channelId} AND team_id IS NULL
-      `;
-      await tx`
-        INSERT INTO agent_channel_bindings (agent_id, platform, channel_id, team_id, created_at)
-        VALUES (${claim.agentId}, ${platform}, ${channelId}, NULL, now())
+        INSERT INTO chat_user_identities (platform, team_id, platform_user_id, lobu_user_id, updated_at)
+        VALUES (${platform}, ${teamId ?? ''}, ${platformUserId}, ${claim.createdBy}, now())
+        ON CONFLICT (platform, team_id, platform_user_id)
+          DO UPDATE SET lobu_user_id = EXCLUDED.lobu_user_id, updated_at = now()
       `;
     }
 
@@ -452,4 +479,48 @@ export async function previewUnlinkedNotice(
     '',
     `Run \`lobu apply\` then \`lobu run\` to get a \`${linkCommand(platform)} <code>\`, and send it here.`,
   ].join('\n');
+}
+
+/** The Lobu user id a chat-platform user has linked to, or null. */
+export async function resolveChatUserIdentity(
+  platform: string,
+  teamId: string | undefined,
+  platformUserId: string
+): Promise<string | null> {
+  const rows = await getDb()<{ lobu_user_id: string }>`
+    SELECT lobu_user_id FROM chat_user_identities
+    WHERE platform = ${platform} AND team_id = ${teamId ?? ''} AND platform_user_id = ${platformUserId}
+    LIMIT 1
+  `;
+  return rows[0]?.lobu_user_id ?? null;
+}
+
+export type BindForOwnerResult =
+  | { status: 'bound' }
+  | { status: 'forbidden' };
+
+/**
+ * Re-bind a chat to one of the caller's agents by id, without a code — only
+ * works after the caller has linked at least once (so we know their Lobu user)
+ * and only for agents in an org they're a member of.
+ */
+export async function bindChatToAgentForOwner(args: {
+  platform: string;
+  teamId?: string;
+  channelId: string;
+  agentId: string;
+  lobuUserId: string;
+}): Promise<BindForOwnerResult> {
+  const { platform, teamId, channelId, agentId, lobuUserId } = args;
+  const sql = getDb();
+  const owned = await sql<{ one: number }>`
+    SELECT 1 AS one
+    FROM agents a
+    JOIN "member" m ON m."organizationId" = a.organization_id
+    WHERE a.id = ${agentId} AND m."userId" = ${lobuUserId}
+    LIMIT 1
+  `;
+  if (owned.length === 0) return { status: 'forbidden' };
+  await sql.begin((tx) => upsertBinding(tx, platform, channelId, teamId, agentId));
+  return { status: 'bound' };
 }


### PR DESCRIPTION
## Why

`/lobu link <code>` already requires the code to come from an authenticated `lobu run`, so the person typing it is a known Lobu user — we just weren't recording that. This persists the chat-platform → Lobu-user link, which lets a user who's linked here once skip the code on subsequent links: `/lobu link <agentId>` binds the current chat to any agent in an org they're a member of. (The friction-killer from the design discussion.)

## Changes

- **migration** `20260513000000_chat_user_identities.sql` — `(platform, team_id, platform_user_id) → lobu_user_id` (FK → `"user"(id)` ON DELETE CASCADE; `team_id` defaults `''` for platforms without a workspace).
- **`preview/slack.ts`** — `consumePreviewClaim` gains an optional `platformUserId`; on a successful bind it upserts the identity row (sender → the code-minter's Lobu user). New `resolveChatUserIdentity(platform, teamId, platformUserId)` and `bindChatToAgentForOwner({platform, teamId?, channelId, agentId, lobuUserId})` (ownership check = `agents JOIN "member"` on the agent's org). Extracted `upsertBinding` so the code-path and the codeless-path share the same binding logic (incl. the NULL-`team_id` delete-then-insert case).
- **`built-in-commands` `link`** — passes `platformUserId: ctx.userId`; when `consumePreviewClaim` returns `not_found`, if the user is identified, treats the arg as an agent id and `bindChatToAgentForOwner`s it; un-identified users still get the "invalid or expired code" reply. Usage/description updated.

Platform-agnostic — uses `ctx.platform` / `ctx.isGroup` throughout, so it'll work for the next preview platform too.

## Notes / not in scope

- "auto-route an unbound DM to the identified user's default agent" needs a notion of a *default* agent — not built; this PR just enables codeless re-link via an explicit `/lobu link <agentId>`.
- The error copy when an already-linked user passes a bad code is now "No agent `<arg>` you can manage in your orgs… or paste a fresh `/lobu link <code>`" (covers both "not a real agent id" and "expired code" reasonably, since codes and agent ids can overlap syntactically).

slack-preview vitest 11/11, `message-handler-bridge` + `slack-platform-bridge` bun tests green, `make build-packages` + typecheck clean.