### PR TITLE
chore(office-bot): enable Slack Preview for food-ordering

### DIFF
--- a/examples/office-bot/lobu.toml
+++ b/examples/office-bot/lobu.toml
@@ -31,6 +31,16 @@ id = "z-ai"
 model = "z-ai/glm-4.7"
 key = "$Z_AI_API_KEY"
 
+# Public Slack Preview (the hosted "Lobu Developer" workspace) — `lobu run`
+# prints a `/lobu link <code>` you redeem in that workspace, then messages there
+# route to this agent. Lets you demo the lunch flow without standing up your own
+# Slack app. `channel` surface so it works in a channel, not just a DM.
+[agents.food-ordering.preview.slack]
+enabled = true
+provider = "lobu-public"
+surfaces = ["dm", "channel"]
+code_ttl_minutes = 15
+
 [agents.food-ordering.network]
 # The chat transport (Slack) is the gateway's job, not the worker's — the worker
 # only needs to fetch playwright/chromium for the deliveroo-order skill.


### PR DESCRIPTION
## What

`examples/office-bot/lobu.toml`: enable Slack Preview on the `food-ordering` agent — `[agents.food-ordering.preview.slack]` with `enabled = true` and `surfaces = ["dm", "channel"]`. Lets the lunch flow be demoed through the hosted "Lobu Developer" Slack workspace (`lobu run` prints a `/lobu link <code>` you redeem there) without standing up a bot token.

`[memory].org` stays the project-specific `office-bot` slug (the declarative default `lobu apply` uses) — earlier revision changed it to `lobu-team`; reverted per review since this is a public example and that would break `lobu apply` for non-members. The internal `lobu-team` deployment already passes `--org lobu-team`.

## Validation

- `lobu validate` passes (pre-commit hook ran biome + `tsc --noEmit` clean).
- End-to-end smoke against a local `lobu run` (embedded stack, `officebot_dev`): `lobu chat -a food-ordering "…"` returns real agent responses, multi-turn, with the `deliveroo-order` skill loaded (falls back to a manual order list with no chromium/cookies, as designed).

## Follow-ups (filed separately, not addressed here)

`lobu run` from a project subdir inside the monorepo needs `LOBU_WORKER_ENTRYPOINT` + `LOBU_PROVIDER_REGISTRY_PATH` env overrides to work:
- #656 — CJS worker dist can't `require()` the ESM-only `@mariozechner/pi-coding-agent`
- #657 — `config/providers.json` resolved relative to `process.cwd()`