### PR TITLE
refactor(preview): generalize the preview mint side beyond Slack

### DIFF
--- a/packages/cli/src/__tests__/cli-ux.test.ts
+++ b/packages/cli/src/__tests__/cli-ux.test.ts
@@ -118,7 +118,6 @@ describe("lobu init --yes", () => {
     const toml = readFileSync(join(cwd, "preview-on", "lobu.toml"), "utf-8");
     expect(toml).toContain("[agents.preview-on.preview.slack]");
     expect(toml).toContain("enabled = true");
-    expect(toml).toContain('provider = "lobu-public"');
     expect(toml).toContain('surfaces = ["dm"]');
   });
 

--- a/packages/cli/src/commands/dev.ts
+++ b/packages/cli/src/commands/dev.ts
@@ -107,7 +107,7 @@ export async function devCommand(
   }
 
   if (!options.quiet) {
-    await printSlackPreviewInstructions(cwd);
+    await printPreviewInstructions(cwd);
     console.log(chalk.cyan(`\n  Starting Lobu...\n`));
     console.log(chalk.dim(`  bundle:        ${bundlePath}`));
     if (hasDatabaseUrl) {
@@ -230,14 +230,22 @@ export function isPortFree(port: number): Promise<boolean> {
   });
 }
 
-async function printSlackPreviewInstructions(cwd: string): Promise<void> {
+async function printPreviewInstructions(cwd: string): Promise<void> {
   const loaded = await loadConfig(cwd);
   if (isLoadError(loaded)) return;
 
-  const enabledAgents = Object.entries(loaded.config.agents).filter(
-    ([, agent]) => agent.preview?.slack?.enabled === true
-  );
-  if (enabledAgents.length === 0) return;
+  // `agent.preview` is a record keyed by chat platform (`slack`, `telegram`, …).
+  const enabled: Array<{
+    agentId: string;
+    platform: string;
+    cfg: { surfaces?: string[]; code_ttl_minutes?: number };
+  }> = [];
+  for (const [agentId, agent] of Object.entries(loaded.config.agents)) {
+    for (const [platform, cfg] of Object.entries(agent.preview ?? {})) {
+      if (cfg?.enabled === true) enabled.push({ agentId, platform, cfg });
+    }
+  }
+  if (enabled.length === 0) return;
 
   let clientInfo: Awaited<ReturnType<typeof resolveApiClient>>;
   try {
@@ -246,47 +254,51 @@ async function printSlackPreviewInstructions(cwd: string): Promise<void> {
       context: projectLink?.context,
       org: projectLink?.org,
     });
-  } catch (error) {
+  } catch {
     console.log(
       chalk.yellow(
-        "\n  Slack Preview is enabled, but no Lobu Cloud session is available."
+        "\n  Preview is enabled, but no Lobu Cloud session is available."
       )
     );
     console.log(
       chalk.dim(
-        "  Run `lobu login`, `lobu org set <slug>`, and `lobu apply`; then restart `lobu run` to get a Slack link code.\n"
+        "  Run `lobu login`, `lobu org set <slug>`, and `lobu apply`; then restart `lobu run` to get a link code.\n"
       )
     );
     return;
   }
 
-  console.log(chalk.cyan("\n  Slack Preview"));
-  for (const [agentId, agent] of enabledAgents) {
-    const slack = agent.preview?.slack;
+  console.log(chalk.cyan("\n  Preview"));
+  for (const { agentId, platform, cfg } of enabled) {
     try {
       const claim = await clientInfo.client.post<{
         code: string;
         command: string;
-        slack_url: string;
+        join_url: string;
         expires_at: string;
         allowed_surfaces: string[];
-      }>(`/api/${clientInfo.orgSlug}/preview/slack/claims`, {
+      }>(`/api/${clientInfo.orgSlug}/preview/claims`, {
         agent_id: agentId,
-        surfaces: slack?.surfaces ?? ["dm"],
-        ttl_minutes: slack?.code_ttl_minutes ?? 15,
+        platform,
+        surfaces: cfg.surfaces ?? ["dm"],
+        ttl_minutes: cfg.code_ttl_minutes ?? 15,
       });
       console.log(chalk.dim(`  agent:        ${agentId}`));
-      console.log(chalk.dim(`  slack:        ${claim.slack_url}`));
+      console.log(chalk.dim(`  platform:     ${platform}`));
+      if (claim.join_url)
+        console.log(chalk.dim(`  join:         ${claim.join_url}`));
       console.log(chalk.dim(`  command:      ${claim.command}`));
       console.log(chalk.dim(`  expires:      ${claim.expires_at}`));
       console.log(
         chalk.dim(
-          "  In the public Lobu Developer Slack, DM @Lobu Developer with the command above."
+          `  Join the hosted Lobu ${platform} workspace and send the command above to @Lobu.`
         )
       );
     } catch (error) {
       console.log(
-        chalk.yellow(`  Could not create Slack Preview code for ${agentId}.`)
+        chalk.yellow(
+          `  Could not create a ${platform} preview code for ${agentId}.`
+        )
       );
       console.log(
         chalk.dim(

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -778,11 +778,11 @@ export async function generateLobuToml(
   if (options.enableSlackPreview) {
     lines.push(
       "",
-      "# Public Slack Preview (Lobu Developer) — `lobu run` prints a `/lobu link <code>`",
-      "# you redeem by DMing the hosted Lobu Developer Slack bot.",
+      "# Hosted preview — `lobu run` prints a `/lobu link <code>` you redeem by",
+      "# DMing the hosted Lobu Slack bot. The block key is the chat platform;",
+      "# `[agents.<id>.preview.telegram]` works the same way (redeem with `/link <code>`).",
       `[agents.${id}.preview.slack]`,
       "enabled = true",
-      'provider = "lobu-public"',
       'surfaces = ["dm"]',
       "code_ttl_minutes = 15"
     );

--- a/packages/core/src/__tests__/lobu-toml-schema.test.ts
+++ b/packages/core/src/__tests__/lobu-toml-schema.test.ts
@@ -9,13 +9,15 @@ dir = "./agents/triage"
 `;
 
 describe("lobu.toml preview schema", () => {
-  test("accepts public Slack Preview config", () => {
+  test("accepts a per-platform preview block", () => {
     const parsed = parseToml(`${BASE_AGENT}
 [agents.triage.preview.slack]
 enabled = true
-provider = "lobu-public"
 surfaces = ["dm", "channel"]
 code_ttl_minutes = 15
+
+[agents.triage.preview.telegram]
+enabled = true
 `);
 
     const result = lobuConfigSchema.safeParse(parsed);
@@ -26,6 +28,7 @@ code_ttl_minutes = 15
         "dm",
         "channel",
       ]);
+      expect(result.data.agents.triage?.preview?.telegram?.enabled).toBe(true);
     }
   });
 
@@ -34,6 +37,15 @@ code_ttl_minutes = 15
 [agents.triage.preview.slack]
 enabled = true
 surfaces = ["thread"]
+`);
+    expect(lobuConfigSchema.safeParse(parsed).success).toBe(false);
+  });
+
+  test("rejects an unknown key in a preview block", () => {
+    const parsed = parseToml(`${BASE_AGENT}
+[agents.triage.preview.slack]
+enabled = true
+provider = "lobu-public"
 `);
     expect(lobuConfigSchema.safeParse(parsed).success).toBe(false);
   });

--- a/packages/core/src/lobu-toml-schema.ts
+++ b/packages/core/src/lobu-toml-schema.ts
@@ -175,24 +175,22 @@ const workerSchema = z.object({
 
 // ── Preview ─────────────────────────────────────────────────────────────────
 
-const previewSlackSchema = z
+// Per-platform "try this agent in the hosted Lobu workspace" config — the key
+// in `[agents.<id>.preview.<platform>]` is the chat platform (slack, telegram,
+// …). `lobu run` prints a `/lobu link <code>` (`/link <code>` on Telegram) for
+// each enabled platform; redeem it by DMing the hosted bot.
+const previewPlatformSchema = z
   .object({
-    /** Enable Lobu Developer public Slack preview for this agent. */
+    /** Enable the hosted Lobu preview bot for this agent on this platform. */
     enabled: z.boolean().optional(),
-    /** Hosted preview provider. Additional providers can be added later. */
-    provider: z.literal("lobu-public").optional(),
-    /** Slack surfaces this preview code can bind (a DM with the bot, or a channel it's in). */
+    /** Surfaces a preview code can bind: a DM with the bot, or a channel it's in. */
     surfaces: z.array(z.enum(["dm", "channel"])).optional(),
-    /** Short-lived claim code TTL. Capped by the hosted preview API. */
+    /** Short-lived claim-code TTL. Capped by the hosted preview API. */
     code_ttl_minutes: z.number().int().positive().max(60).optional(),
   })
   .strict();
 
-const previewSchema = z
-  .object({
-    slack: previewSlackSchema.optional(),
-  })
-  .strict();
+const previewSchema = z.record(z.string(), previewPlatformSchema);
 
 // ── Agent ───────────────────────────────────────────────────────────────────
 

--- a/packages/server/src/gateway/connections/message-handler-bridge.ts
+++ b/packages/server/src/gateway/connections/message-handler-bridge.ts
@@ -10,7 +10,7 @@ import {
   flushTracing,
   generateTraceId,
 } from "@lobu/core";
-import { SLACK_PREVIEW_UNLINKED_NOTICE } from "../../preview/slack.js";
+import { PREVIEW_UNLINKED_NOTICE } from "../../preview/slack.js";
 import type { CommandDispatcher } from "../commands/command-dispatcher.js";
 import { createChatReply } from "../commands/command-reply-adapters.js";
 import type { ArtifactStore } from "../files/artifact-store.js";
@@ -309,21 +309,22 @@ export class MessageHandlerBridge {
       return;
     }
 
-    // Preview connection (the hosted "Lobu" Slack workspace bot today): an
-    // unlinked DM/@-mention. Don't run the connection's placeholder owning
-    // agent — reply with the `/lobu link` instructions and stop here.
-    // (`/lobu link <code>` itself arrives as a slash command, not through this
-    // path, so linking still works.)
+    // Preview connection (a hosted Lobu workspace bot — Slack, Telegram, …):
+    // an unlinked DM/@-mention. Don't run the connection's placeholder owning
+    // agent — reply with the link instructions for this platform and stop here.
+    // (The `/lobu link <code>` / `/link <code>` redemption itself arrives as a
+    // slash command, not through this path, so linking still works.)
+    const unlinkedNotice = PREVIEW_UNLINKED_NOTICE[platform];
     if (
       resolved.source === "connection" &&
       this.connection.settings?.previewMode === true &&
-      platform === "slack"
+      unlinkedNotice
     ) {
       logger.info(
         { platform, channelId, teamId, connectionId: this.connection.id },
         "Preview connection: unlinked chat — replying with link instructions"
       );
-      await thread.post(SLACK_PREVIEW_UNLINKED_NOTICE);
+      await thread.post(unlinkedNotice);
       return;
     }
 

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -36,7 +36,7 @@ import {
   restMarkAllAsRead,
   restMarkAsRead,
 } from './notifications/routes';
-import { createSlackPreviewClaim } from './preview/slack';
+import { createPreviewClaim } from './preview/slack';
 import {
   buildPublicPageModel,
   buildRobotsTxt,
@@ -735,9 +735,9 @@ app.get('/api/organizations', async (c) => {
   return c.json({ organizations: orgs });
 });
 
-// Slack Preview: mint a `/link <code>` for an agent. The code is redeemed by
-// DMing the hosted "Lobu Developer" Slack bot — no relay endpoint here.
-app.post('/api/:orgSlug/preview/slack/claims', mcpAuth, createSlackPreviewClaim);
+// Preview: mint a link code for an agent on a hosted preview bot (Slack,
+// Telegram, …). The code is redeemed by DMing that bot — no relay endpoint here.
+app.post('/api/:orgSlug/preview/claims', mcpAuth, createPreviewClaim);
 
 // Notifications
 app.get('/api/:orgSlug/notifications', mcpAuth, restListNotifications);

--- a/packages/server/src/preview/__tests__/slack-preview.test.ts
+++ b/packages/server/src/preview/__tests__/slack-preview.test.ts
@@ -12,7 +12,7 @@ import type { Env } from "../../index";
 import {
   canonicalSlackChannelId,
   consumePreviewClaim,
-  createSlackPreviewClaim,
+  createPreviewClaim,
   slackSurfaceType,
 } from "../slack";
 
@@ -63,10 +63,11 @@ function orgUserContext(jsonBody: unknown): Context<{ Bindings: Env }> {
 
 async function createClaim(
   agentId: string,
-  surfaces: string[] = ["dm", "channel"]
+  surfaces: string[] = ["dm", "channel"],
+  platform = "slack"
 ): Promise<string> {
-  const res = await createSlackPreviewClaim(
-    orgUserContext({ agent_id: agentId, surfaces })
+  const res = await createPreviewClaim(
+    orgUserContext({ agent_id: agentId, platform, surfaces })
   );
   if (!isFakeResponse(res)) throw new Error("not a json response");
   expect(res.status).toBe(200);
@@ -96,13 +97,14 @@ describe("Slack Preview claims + channel bindings", () => {
   });
 
   test("claim mints a /lobu link code in oauth_states under the dedicated scope", async () => {
-    const res = await createSlackPreviewClaim(
-      orgUserContext({ agent_id: AGENT_ID, surfaces: ["dm", "channel"] })
+    const res = await createPreviewClaim(
+      orgUserContext({ agent_id: AGENT_ID, platform: "slack", surfaces: ["dm", "channel"] })
     );
     if (!isFakeResponse(res)) throw new Error("not a json response");
     expect(res.status).toBe(200);
     const code = res.body.code as string;
     expect(code).toMatch(/^demo-agent-[A-Z0-9]{6}$/);
+    expect(res.body.provider).toBe("lobu-public-slack");
     expect(res.body.command).toBe(`/lobu link ${code}`);
     expect(res.body.allowed_surfaces).toEqual(["dm", "channel"]);
 
@@ -116,11 +118,45 @@ describe("Slack Preview claims + channel bindings", () => {
   });
 
   test("claim for an agent outside the caller's org → 404", async () => {
-    const res = await createSlackPreviewClaim(
-      orgUserContext({ agent_id: "nope" })
+    const res = await createPreviewClaim(
+      orgUserContext({ agent_id: "nope", platform: "slack" })
     );
     if (!isFakeResponse(res)) throw new Error("not a json response");
     expect(res.status).toBe(404);
+  });
+
+  test("claim with an unsupported platform → 400", async () => {
+    const res = await createPreviewClaim(
+      orgUserContext({ agent_id: AGENT_ID, platform: "discord" })
+    );
+    if (!isFakeResponse(res)) throw new Error("not a json response");
+    expect(res.status).toBe(400);
+  });
+
+  test("a telegram claim mints a /link code and is consumable without a teamId", async () => {
+    const res = await createPreviewClaim(
+      orgUserContext({ agent_id: AGENT_ID, platform: "telegram", surfaces: ["dm"] })
+    );
+    if (!isFakeResponse(res)) throw new Error("not a json response");
+    expect(res.status).toBe(200);
+    const code = res.body.code as string;
+    expect(res.body.provider).toBe("lobu-public-telegram");
+    expect(res.body.command).toBe(`/link ${code}`);
+
+    const bound = await consumePreviewClaim({
+      code,
+      platform: "telegram",
+      channelId: "12345",
+      surfaceType: "dm",
+    });
+    expect(bound).toMatchObject({ status: "bound", agentId: AGENT_ID });
+
+    const sql = getDb();
+    const rows = await sql`
+      SELECT channel_id, team_id FROM agent_channel_bindings WHERE platform = 'telegram'
+    `;
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({ channel_id: "12345", team_id: null });
   });
 
   test("consume binds the Slack channel to the agent and is one-time-use", async () => {

--- a/packages/server/src/preview/slack.ts
+++ b/packages/server/src/preview/slack.ts
@@ -16,34 +16,53 @@ import logger from '../utils/logger';
 //     route through the exact same Chat SDK adapter path every other platform
 //     connection uses.
 
-const PROVIDER = 'lobu-public-slack';
-// Preview bindings are plain Slack bindings; the workspace's team_id keeps them
-// from colliding with anyone's own bot. Slack DM channel ids start with `D`.
+// Slack DM channel ids start with `D`; the canonical binding key is `slack:<id>`.
 const SLACK_PLATFORM = 'slack';
 const CLAIM_SCOPE = 'slack-preview-claim';
-const DEFAULT_SLACK_PREVIEW_URL = 'https://lobu.ai/slack/developer';
 const DEFAULT_TTL_MINUTES = 15;
 const MAX_TTL_MINUTES = 60;
 const SURFACES = new Set(['dm', 'channel']);
 
+// Hosted preview bots — the platforms a `preview.<platform>` block / claim mint
+// is allowed for, and the default "join the workspace" links.
+const PREVIEW_PLATFORMS = new Set(['slack', 'telegram']);
+const PREVIEW_JOIN_DEFAULTS: Record<string, string> = {
+  slack: 'https://lobu.ai/slack',
+  telegram: 'https://t.me/lobuaibot',
+};
+
 export type SurfaceType = 'dm' | 'channel';
 
 /**
- * Reply posted by a Slack-Preview connection when a DM/@-mention arrives for a
- * chat that hasn't been `/lobu link`'d yet. Deterministic — no LLM agent runs
- * for unlinked chats; this is the whole response.
+ * Reply posted by a `previewMode` connection when a DM/@-mention arrives for a
+ * chat that hasn't been linked yet — keyed by platform. Deterministic: no LLM
+ * runs for unlinked chats; this is the whole response. A platform without an
+ * entry here means an unlinked chat just falls through (the bridge skips it).
  */
-export const SLACK_PREVIEW_UNLINKED_NOTICE = [
-  "👋 This chat isn't linked to a Lobu agent yet.",
-  '',
-  'To talk to your own agent here:',
-  '1. In your agent project\'s `lobu.toml`: `[agents.<id>.preview.slack]` → `enabled = true` (add `surfaces = ["channel"]` to use it in channels too).',
-  '2. Run `lobu apply` to register the agent in Lobu Cloud.',
-  '3. Run `lobu run` — it prints a `/lobu link <code>`.',
-  '4. Send that `/lobu link <code>` here.',
-  '',
-  'After that, every message in this chat goes to your agent.',
-].join('\n');
+export const PREVIEW_UNLINKED_NOTICE: Record<string, string> = {
+  slack: [
+    "👋 This chat isn't linked to a Lobu agent yet.",
+    '',
+    'To talk to your own agent here:',
+    '1. In your agent project\'s `lobu.toml`: `[agents.<id>.preview.slack]` → `enabled = true` (add `surfaces = ["channel"]` to use it in channels too).',
+    '2. Run `lobu apply` to register the agent in Lobu Cloud.',
+    '3. Run `lobu run` — it prints a `/lobu link <code>`.',
+    '4. Send that `/lobu link <code>` here.',
+    '',
+    'After that, every message in this chat goes to your agent.',
+  ].join('\n'),
+  telegram: [
+    "👋 This chat isn't linked to a Lobu agent yet.",
+    '',
+    'To talk to your own agent here:',
+    '1. In your agent project\'s `lobu.toml`: `[agents.<id>.preview.telegram]` → `enabled = true`.',
+    '2. Run `lobu apply` to register the agent in Lobu Cloud.',
+    '3. Run `lobu run` — it prints a `/link <code>`.',
+    '4. Send that `/link <code>` here.',
+    '',
+    'After that, every message in this chat goes to your agent.',
+  ].join('\n'),
+};
 
 interface ClaimPayload {
   organizationId: string;
@@ -97,8 +116,19 @@ function requireOrgUser(c: Context<{ Bindings: Env }>): { organizationId: string
   return { organizationId, userId };
 }
 
-function slackPreviewUrl(): string {
-  return process.env.LOBU_DEVELOPER_SLACK_URL || DEFAULT_SLACK_PREVIEW_URL;
+// "Join the hosted workspace" link for a preview platform — overridable per
+// platform via `LOBU_PREVIEW_<PLATFORM>_URL` on the deployment.
+function previewJoinUrl(platform: string): string {
+  return (
+    process.env[`LOBU_PREVIEW_${platform.toUpperCase()}_URL`] ||
+    PREVIEW_JOIN_DEFAULTS[platform] ||
+    ''
+  );
+}
+
+/** The slash command to send to the hosted bot to redeem a code. */
+function previewLinkCommand(platform: string, code: string): string {
+  return platform === 'slack' ? `/lobu link ${code}` : `/link ${code}`;
 }
 
 /**
@@ -126,10 +156,11 @@ export function canonicalSlackChannelId(channelId: string): string {
 }
 
 /**
- * POST /api/:orgSlug/preview/slack/claims — called by `lobu run` (authenticated
- * via mcpAuth) to mint a short-lived `/lobu link` code for one of the org's agents.
+ * POST /api/:orgSlug/preview/claims — called by `lobu run` (mcpAuth) to mint a
+ * short-lived link code for one of the org's agents on a hosted preview platform.
+ * Body: `{ agent_id, platform, surfaces?, ttl_minutes? }`.
  */
-export async function createSlackPreviewClaim(c: Context<{ Bindings: Env }>) {
+export async function createPreviewClaim(c: Context<{ Bindings: Env }>) {
   const auth = requireOrgUser(c);
   if (!auth) return c.json({ error: 'Unauthorized' }, 401);
 
@@ -142,6 +173,18 @@ export async function createSlackPreviewClaim(c: Context<{ Bindings: Env }>) {
 
   const agentId = typeof body.agent_id === 'string' ? body.agent_id.trim() : '';
   if (!agentId) return c.json({ error: 'agent_id is required' }, 400);
+
+  const platform =
+    typeof body.platform === 'string' ? body.platform.trim().toLowerCase() : '';
+  if (!PREVIEW_PLATFORMS.has(platform)) {
+    return c.json(
+      {
+        error: 'Unsupported preview platform',
+        message: `platform must be one of: ${[...PREVIEW_PLATFORMS].join(', ')}`,
+      },
+      400
+    );
+  }
 
   const surfaces = normalizeSurfaces(body.surfaces);
   const ttlMinutes = normalizeTtlMinutes(body.ttl_minutes);
@@ -159,7 +202,7 @@ export async function createSlackPreviewClaim(c: Context<{ Bindings: Env }>) {
     return c.json(
       {
         error: 'Agent not found',
-        message: 'Run `lobu apply` first so Slack Preview can bind to this agent in Lobu Cloud.',
+        message: 'Run `lobu apply` first so the preview bot can bind to this agent in Lobu Cloud.',
       },
       404
     );
@@ -182,16 +225,17 @@ export async function createSlackPreviewClaim(c: Context<{ Bindings: Env }>) {
         VALUES (${codeHash(code)}, ${CLAIM_SCOPE}, ${sql.json(payload)}, ${expiresAt})
       `;
       return c.json({
-        provider: PROVIDER,
+        provider: `lobu-public-${platform}`,
+        platform,
         code,
-        command: `/lobu link ${code}`,
-        slack_url: slackPreviewUrl(),
+        command: previewLinkCommand(platform, code),
+        join_url: previewJoinUrl(platform),
         expires_at: expiresAt.toISOString(),
         allowed_surfaces: surfaces,
       });
     } catch (err: unknown) {
       if ((err as { code?: string }).code === '23505') continue;
-      logger.error({ err: errorMessage(err) }, '[SlackPreview] create claim failed');
+      logger.error({ err: errorMessage(err), platform }, '[preview] create claim failed');
       return c.json({ error: errorMessage(err) }, 500);
     }
   }


### PR DESCRIPTION
## What

The consume side (#647) is already platform-agnostic; the mint side was still Slack-named. This generalizes it so a second hosted preview bot (Telegram — Lobu already runs `@lobuaibot`) is just "stand up a connection + a notice string", with no new claim/command code.

- `createSlackPreviewClaim` → `createPreviewClaim`: `platform` is now a required body field, validated against the known preview platforms (`slack`, `telegram`); the response carries `provider: lobu-public-<platform>`, the platform-appropriate redeem command (`/lobu link <code>` on Slack, `/link <code>` elsewhere), and a `join_url` resolved from `LOBU_PREVIEW_<PLATFORM>_URL` with a per-platform default.
- Route `/api/:orgSlug/preview/slack/claims` → `/api/:orgSlug/preview/claims`.
- `SLACK_PREVIEW_UNLINKED_NOTICE` → `PREVIEW_UNLINKED_NOTICE`, keyed by platform; `message-handler-bridge` posts the entry for the inbound platform instead of hardcoding `platform === "slack"`. A platform with no entry just falls through (unchanged behavior for everything else).
- `lobu.toml` `preview` is now a `[agents.<id>.preview.<platform>]` record (drops the per-block `provider` field; each entry is `.strict()`).
- `lobu run` iterates every enabled `preview.<platform>` and prints each platform's link command + join URL; `lobu init`'s generated comment updated.

Standing up the hosted Telegram preview bot itself (a Telegram `agent_connections` row with `settings.previewMode = true` owning a thin concierge agent) is prod ops, not part of this PR.

## Test

- `make build-packages`, `bun run typecheck`
- `LOBU_TEST_BACKEND=pglite vitest run src/preview/__tests__/slack-preview.test.ts` — incl. new "unsupported platform → 400" and "telegram claim mints `/link`, consumable without a teamId" cases (10 pass)
- `bun test packages/server/src/gateway/__tests__/message-handler-bridge.test.ts` (19 pass)
- `bun test packages/core/src/__tests__/lobu-toml-schema.test.ts` (7 pass), `bun test packages/cli/src/__tests__/cli-ux.test.ts` (13 pass)