### PR TITLE
fix(agents): coerce list-agents platforms to a string[]

### DIFF
--- a/packages/server/src/__tests__/setup/test-fixtures.ts
+++ b/packages/server/src/__tests__/setup/test-fixtures.ts
@@ -6,6 +6,7 @@
  */
 
 import { serializeSigned } from 'hono/utils/cookie';
+import { hashClientSecret } from '../../auth/oauth/clients';
 import { generateSecureToken, hashToken } from '../../auth/oauth/utils';
 import { pgTextArray } from '../../db/client';
 import { ensureUniqueConnectionSlug } from '../../utils/connections';
@@ -363,7 +364,7 @@ export async function createTestOAuthClient(options?: {
       token_endpoint_auth_method, client_name, software_id, software_version, metadata, created_at, updated_at
     ) VALUES (
       ${client_id},
-      ${hashToken(client_secret)},
+      ${hashClientSecret(client_secret)},
       ${pgTextArray(redirect_uris)}::text[],
       ${pgTextArray(grant_types)}::text[],
       ${pgTextArray(['code'])}::text[],

--- a/packages/server/src/auth/oauth/clients.ts
+++ b/packages/server/src/auth/oauth/clients.ts
@@ -15,7 +15,7 @@ import { generateClientId, generateClientSecret } from './utils';
  * Hash a client secret using scrypt (similar security to bcrypt)
  * Format: salt:hash (both hex encoded)
  */
-function hashClientSecret(secret: string): string {
+export function hashClientSecret(secret: string): string {
   const salt = randomBytes(16);
   const hash = scryptSync(secret, salt, 64);
   return `${salt.toString('hex')}:${hash.toString('hex')}`;

--- a/packages/server/src/gateway/__tests__/platform-file-handler.test.ts
+++ b/packages/server/src/gateway/__tests__/platform-file-handler.test.ts
@@ -19,7 +19,7 @@ describe("ChatInstanceManager platform file handlers", () => {
           connection: {
             id: "conn-1",
             platform: "telegram",
-            config: { botToken: "telegram-token" },
+            config: { platform: "telegram", botToken: "telegram-token" },
             metadata: { botUsername: "lobubot" },
           },
           chat: {},

--- a/packages/server/src/lobu/agent-routes.ts
+++ b/packages/server/src/lobu/agent-routes.ts
@@ -27,6 +27,22 @@ import { orgContext } from './stores/org-context';
 
 const routes = new Hono<{ Bindings: Env }>();
 
+/**
+ * Coerce an `array_agg` result into a real `string[]`. With the `::text` cast
+ * the driver returns a JS array, but if some schema still hands back a raw
+ * Postgres array literal (`'{telegram,slack}'`) we parse it rather than letting
+ * a string leak to the UI, where `.map` would throw.
+ */
+function toStringArray(value: unknown): string[] {
+  if (Array.isArray(value)) return value.map(String);
+  if (typeof value === 'string') {
+    const inner = value.replace(/^\{/, '').replace(/\}$/, '').trim();
+    if (!inner) return [];
+    return inner.split(',').map((s) => s.replace(/^"|"$/g, '').trim());
+  }
+  return [];
+}
+
 const configStore = createPostgresAgentConfigStore();
 const connectionStore = createPostgresAgentConnectionStore();
 
@@ -408,15 +424,20 @@ routes.get('/', async (c) => {
   `;
   const userCountMap = new Map(userCounts.map((r: any) => [r.agent_id, r.count]));
 
-  // Distinct connection platforms per agent.
+  // Distinct connection platforms per agent. Cast to text so the driver always
+  // returns a JS array — array_agg over an enum/varchar column can come back as
+  // a raw `'{telegram,slack}'` string when postgres.js has no array parser for
+  // the element OID, which then blows up `.map` in the UI.
   const platformRows = await sql`
-    SELECT c.agent_id, array_agg(DISTINCT c.platform) as platforms
+    SELECT c.agent_id, array_agg(DISTINCT c.platform::text) as platforms
     FROM agent_connections c
     JOIN agents a ON a.id = c.agent_id
     WHERE a.organization_id = ${orgId}
     GROUP BY c.agent_id
   `;
-  const platformsMap = new Map(platformRows.map((r: any) => [r.agent_id, (r.platforms ?? []) as string[]]));
+  const platformsMap = new Map(
+    platformRows.map((r: any) => [r.agent_id, toStringArray(r.platforms)])
+  );
 
   // Provider ids per agent, from the agent row's installed_providers list
   // (the canonical "which providers does this agent have" set).


### PR DESCRIPTION
## What

The `/buremba/agents` page crashed in prod with `o.original.platforms.map is not a function`.

`GET /agents` builds the platforms list from `array_agg(DISTINCT c.platform)`. When the aggregated column's element OID isn't one postgres.js has an array parser for, the driver returns the raw Postgres array literal **string** (`'{telegram,slack}'`) instead of a JS array — `.length` is truthy, `.map` is undefined, the agents table cell throws, and TanStack Router's built-in error boundary catches it (and never reports to Sentry, which is why we got no alert).

## Changes

- **server** (`agent-routes.ts`): `array_agg(DISTINCT c.platform::text)` so the driver always returns a JS array; `toStringArray()` normalizes defensively.
- **web** (submodule bump → lobu-ai/owletto-web#90):
  - `asArray()` guard on the Platforms/Providers columns so a bad response can't take the page down.
  - `defaultErrorComponent` on the router that renders TanStack's `ErrorComponent` **and** `Sentry.captureException` — route-render errors are now visible in Sentry instead of being silently swallowed.

## Test

`make build-packages` ✓, web `tsc` clean on touched files (pre-existing `@lobu/connector-sdk` resolution errors are unrelated).