### PR TITLE
feat(apply): declarative Slack channel routing on platforms

### DIFF
--- a/packages/cli/src/commands/_lib/apply/__tests__/desired-state.test.ts
+++ b/packages/cli/src/commands/_lib/apply/__tests__/desired-state.test.ts
@@ -114,6 +114,62 @@ botToken = "y"
     );
   });
 
+  test("carries Slack platform `channels` onto the desired platform", async () => {
+    const dir = mkProject(
+      `[agents.triage]
+name = "Triage"
+dir = "./agents/triage"
+
+[[agents.triage.platforms]]
+type = "slack"
+channels = ["T0ABCDEF/C0123ABCD", "T0ABCDEF/C0456WXYZ"]
+[agents.triage.platforms.config]
+botToken = "x"
+`
+    );
+    const { state } = await loadDesiredState({ cwd: dir });
+    expect(state.agents[0]!.platforms[0]!.channels).toEqual([
+      "T0ABCDEF/C0123ABCD",
+      "T0ABCDEF/C0456WXYZ",
+    ]);
+  });
+
+  test("rejects malformed Slack `channels` entries", async () => {
+    const dir = mkProject(
+      `[agents.triage]
+name = "Triage"
+dir = "./agents/triage"
+
+[[agents.triage.platforms]]
+type = "slack"
+channels = ["C0123ABCD"]
+[agents.triage.platforms.config]
+botToken = "x"
+`
+    );
+    await expect(loadDesiredState({ cwd: dir })).rejects.toThrow(
+      /<teamId>\/<channelId>/
+    );
+  });
+
+  test("rejects `channels` on a non-Slack platform", async () => {
+    const dir = mkProject(
+      `[agents.triage]
+name = "Triage"
+dir = "./agents/triage"
+
+[[agents.triage.platforms]]
+type = "telegram"
+channels = ["T0ABCDEF/C0123ABCD"]
+[agents.triage.platforms.config]
+botToken = "x"
+`
+    );
+    await expect(loadDesiredState({ cwd: dir })).rejects.toThrow(
+      /only supported for Slack/
+    );
+  });
+
   test("loads local skills and merges skill network, nix, and MCP declarations", async () => {
     const dir = mkProject(
       `[agents.triage]

--- a/packages/cli/src/commands/_lib/apply/apply-cmd.ts
+++ b/packages/cli/src/commands/_lib/apply/apply-cmd.ts
@@ -592,6 +592,28 @@ async function executePlan(
     );
   }
 
+  // 3b) Declarative channel bindings — reconcile after the platform upserts
+  // above so the connection rows exist. Runs for every agent/platform that
+  // declares `channels` (the server reconcile is idempotent), independent of
+  // whether the platform's config changed in this plan.
+  for (const agent of ctx.state.agents) {
+    for (const platform of agent.platforms) {
+      if (!platform.channels || platform.channels.length === 0) continue;
+      const res = await ctx.client.syncPlatformChannels(
+        agent.metadata.agentId,
+        platform.stableId,
+        platform.channels
+      );
+      const detail =
+        res.removed.length > 0
+          ? `(${res.bound.length} bound, ${res.removed.length} unbound)`
+          : `(${res.bound.length} bound)`;
+      printText(
+        `  ${chalk.cyan("↻")} ${chalk.bold("channels")} ${agent.metadata.agentId}/${platform.stableId} ${chalk.dim(detail)}`
+      );
+    }
+  }
+
   // 4) Entity types
   for (const row of rowsByKind("entity-type")) {
     if (row.kind !== "entity-type") continue;

--- a/packages/cli/src/commands/_lib/apply/client.ts
+++ b/packages/cli/src/commands/_lib/apply/client.ts
@@ -384,6 +384,30 @@ export class ApplyClient {
     return body;
   }
 
+  /**
+   * Reconcile a platform's declarative channel bindings.
+   *
+   * Server contract:
+   *   POST /:agentId/platforms/:platformId/sync-channels
+   *   body: { channels: string[] }   // each "<teamId>/<channelId>"
+   *   response: { bound: string[], removed: string[] }
+   */
+  async syncPlatformChannels(
+    agentId: string,
+    platformId: string,
+    channels: string[]
+  ): Promise<{ bound: string[]; removed: string[] }> {
+    const { body } = await this.request<{
+      bound?: string[];
+      removed?: string[];
+    }>(
+      "POST",
+      `/api/${this.orgSlug}/agents/${encodeURIComponent(agentId)}/platforms/${encodeURIComponent(platformId)}/sync-channels`,
+      { channels }
+    );
+    return { bound: body.bound ?? [], removed: body.removed ?? [] };
+  }
+
   // ── Memory schema ─────────────────────────────────────────────────────────
 
   async listEntityTypes(): Promise<RemoteEntityType[]> {

--- a/packages/cli/src/commands/_lib/apply/desired-state.ts
+++ b/packages/cli/src/commands/_lib/apply/desired-state.ts
@@ -83,6 +83,8 @@ export interface DesiredPlatform {
   name?: string;
   /** Raw config from lobu.toml — values may still contain `$VAR` references. */
   config: Record<string, string>;
+  /** Declarative channel bindings (`"<teamId>/<channelId>"`); Slack only. */
+  channels?: string[];
 }
 
 export interface DesiredEntityType {
@@ -696,6 +698,21 @@ function buildPlatforms(
       config: resolvedConfig,
     };
     if (platform.name) desired.name = platform.name;
+    if (platform.channels && platform.channels.length > 0) {
+      if (platform.type !== "slack") {
+        throw new ValidationError(
+          `agent "${agentId}" platform "${platform.type}": \`channels\` is only supported for Slack`
+        );
+      }
+      for (const entry of platform.channels) {
+        if (!/^[^/\s]+\/[^/\s]+$/.test(entry.trim())) {
+          throw new ValidationError(
+            `agent "${agentId}" Slack \`channels\` entry "${entry}" must be in "<teamId>/<channelId>" form (e.g. "T0ABCDEF/C0123ABCD")`
+          );
+        }
+      }
+      desired.channels = platform.channels.map((e) => e.trim());
+    }
     out.push(desired);
   }
   return out;

--- a/packages/core/src/lobu-toml-schema.ts
+++ b/packages/core/src/lobu-toml-schema.ts
@@ -41,6 +41,16 @@ const platformSchema = z.object({
     .optional(),
   /** Platform-specific config (e.g. `{ botToken: "$BOT_TOKEN" }`). */
   config: z.record(z.string(), z.string()),
+  /**
+   * Declarative channel routing (Slack only, for now): chat channels this agent
+   * should be reachable in. Each entry is `"<teamId>/<channelId>"` — e.g.
+   * `"T0ABCDEF/C0123ABCD"` (both appear in any Slack channel URL). `lobu apply`
+   * reconciles `agent_channel_bindings` to exactly this list for this agent on
+   * this connection: listed channels get bound, ones no longer listed get
+   * unbound. Channels linked ad-hoc via `/lobu link` on *other* connections are
+   * left alone.
+   */
+  channels: z.array(z.string()).optional(),
 });
 
 // ── MCP Server ──────────────────────────────────────────────────────────────

--- a/packages/landing/src/content/docs/reference/lobu-toml.md
+++ b/packages/landing/src/content/docs/reference/lobu-toml.md
@@ -182,7 +182,24 @@ Each entry connects the agent to a chat platform.
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | `type` | string | yes | Platform type: `telegram`, `slack`, `discord`, `whatsapp`, `teams`, `gchat` |
+| `name` | string | no | Disambiguator when an agent has multiple platforms of the same type |
 | `config` | table | yes | Platform-specific configuration (see below) |
+| `channels` | array | no | Slack only — declarative channel routing (see below) |
+
+#### Declarative channel routing (Slack)
+
+By default an agent is reachable in a Slack channel only after someone runs `/lobu link <code>` there. To route channels to the agent as config-as-code, list them on the Slack platform entry:
+
+```toml
+[[agents.x.platforms]]
+type = "slack"
+channels = ["T0ABCDEF/C0123ABCD", "T0ABCDEF/C0456WXYZ"]
+[agents.x.platforms.config]
+botToken = "$SLACK_BOT_TOKEN"
+signingSecret = "$SLACK_SIGNING_SECRET"
+```
+
+Each entry is `"<teamId>/<channelId>"` — both appear in any Slack channel URL (`https://app.slack.com/client/<teamId>/<channelId>`). `lobu apply` reconciles `agent_channel_bindings` to exactly this list for this agent on the teams referenced: listed channels get bound, ones no longer listed get unbound. Channels linked ad-hoc via `/lobu link` on other teams/connections are left alone. (Channel changes are applied during `lobu apply`; they don't appear in `lobu apply --dry-run` output.)
 
 #### Platform config by type
 

--- a/packages/server/src/lobu/agent-routes.ts
+++ b/packages/server/src/lobu/agent-routes.ts
@@ -1345,6 +1345,88 @@ routes.delete('/:agentId/platforms/:platformId', async (c) => {
   return c.json({ success: true });
 });
 
+// ── Sync declarative channel bindings ────────────────────────────────────────
+//
+// `lobu apply` POSTs the `channels` declared on a Slack platform here; we
+// reconcile `agent_channel_bindings` to match — for this agent, on the
+// teams referenced in the list. Channels bound ad-hoc (`/lobu link`) on
+// other teams/connections are untouched. Each entry is `"<teamId>/<channelId>"`.
+
+routes.post('/:agentId/platforms/:platformId/sync-channels', async (c) => {
+  const denied = requireSessionOrAdminPat(c);
+  if (denied) return denied;
+  const { agentId, platformId } = c.req.param();
+  const guard = await requireStoredPlatform(c, agentId, platformId);
+  if ('response' in guard) return guard.response;
+  if (guard.platform.platform !== 'slack') {
+    return c.json(
+      { error: 'sync-channels is only supported for Slack connections' },
+      400
+    );
+  }
+
+  let body: { channels?: unknown };
+  try {
+    body = await c.req.json();
+  } catch {
+    return c.json({ error: 'Invalid or missing JSON body' }, 400);
+  }
+  if (!Array.isArray(body.channels)) {
+    return c.json({ error: 'channels must be an array' }, 400);
+  }
+
+  // Parse "<teamId>/<channelId>" → canonical `slack:<channelId>` keyed by team.
+  const desired = new Map<string, { teamId: string; channelId: string }>();
+  for (const entry of body.channels) {
+    if (typeof entry !== 'string') {
+      return c.json({ error: 'channel entries must be strings' }, 400);
+    }
+    const m = entry.trim().match(/^([^/\s]+)\/([^/\s]+)$/);
+    if (!m) {
+      return c.json(
+        {
+          error: `invalid channel entry "${entry}" — expected "<teamId>/<channelId>" (e.g. "T0ABCDEF/C0123ABCD")`,
+        },
+        400
+      );
+    }
+    const teamId = m[1]!;
+    const channelId = m[2]!.startsWith('slack:') ? m[2]! : `slack:${m[2]}`;
+    desired.set(`${teamId} ${channelId}`, { teamId, channelId });
+  }
+  const desiredTeams = new Set([...desired.values()].map((d) => d.teamId));
+
+  const sql = getDb();
+  const existing = (await sql`
+    SELECT channel_id, team_id FROM agent_channel_bindings
+    WHERE agent_id = ${agentId} AND platform = 'slack'
+  `) as Array<{ channel_id: string; team_id: string | null }>;
+
+  const bound: string[] = [];
+  for (const { teamId, channelId } of desired.values()) {
+    await sql`
+      INSERT INTO agent_channel_bindings (agent_id, platform, channel_id, team_id, created_at)
+      VALUES (${agentId}, 'slack', ${channelId}, ${teamId}, now())
+      ON CONFLICT (platform, channel_id, team_id) DO UPDATE SET agent_id = EXCLUDED.agent_id
+    `;
+    bound.push(`${teamId}/${channelId}`);
+  }
+
+  const removed: string[] = [];
+  for (const row of existing) {
+    if (!row.team_id || !desiredTeams.has(row.team_id)) continue;
+    if (desired.has(`${row.team_id} ${row.channel_id}`)) continue;
+    await sql`
+      DELETE FROM agent_channel_bindings
+      WHERE agent_id = ${agentId} AND platform = 'slack'
+        AND channel_id = ${row.channel_id} AND team_id = ${row.team_id}
+    `;
+    removed.push(`${row.team_id}/${row.channel_id}`);
+  }
+
+  return c.json({ bound, removed });
+});
+
 // ── Start platform ───────────────────────────────────────────────────────────
 
 routes.post('/:agentId/platforms/:platformId/start', async (c) => {


### PR DESCRIPTION
Workstream B from the chat-preview plan — config-as-code for the multi-channel production path. Independent of #658/#660.

## What
Adds an optional `channels` array to `[[agents.<id>.platforms]]` (Slack only):
```toml
[[agents.support.platforms]]
type = "slack"
channels = ["T0ABCDEF/C0123ABCD", "T0ABCDEF/C0456WXYZ"]
[agents.support.platforms.config]
botToken = "$SLACK_BOT_TOKEN"
signingSecret = "$SLACK_SIGNING_SECRET"
```
Each entry is `"<teamId>/<channelId>"` (both appear in any Slack channel URL). `lobu apply`, after upserting the platform, POSTs them to a new **`POST /api/<org>/agents/<id>/platforms/<id>/sync-channels`** endpoint that reconciles `agent_channel_bindings` to exactly that list for this agent on the referenced teams — listed channels get bound, dropped ones get unbound. Ad-hoc `/lobu link` bindings on other teams/connections are untouched.

Kept deliberately minimal: no Slack API call (channel names→ids resolution), no new `connections` schema block — `channels` rides on the existing platform entry; the server reconcile is idempotent and runs on every `lobu apply` for agents that declare it. (Channel changes apply during `lobu apply`; they don't show in `--dry-run`.)

## Files
- `packages/core/src/lobu-toml-schema.ts` — `platformSchema.channels`
- `packages/cli/src/commands/_lib/apply/{desired-state,client,apply-cmd}.ts` (+ desired-state validation: rejects malformed entries / `channels` on non-Slack)
- `packages/server/src/lobu/agent-routes.ts` — `sync-channels` route
- `packages/landing/.../reference/lobu-toml.md`

## Test
`make build-packages`, `bun run typecheck`; `bun test packages/cli/src/commands/_lib/apply/` (77 pass, incl. 3 new channels cases); `bun test packages/core/.../lobu-toml-schema.test.ts`; `packages/landing` build.