### PR TITLE
feat(preview): /lobu try — self-serve demo agents in the public preview bot

### DIFF
--- a/packages/server/src/gateway/commands/built-in-commands.ts
+++ b/packages/server/src/gateway/commands/built-in-commands.ts
@@ -1,7 +1,10 @@
 import type { CommandContext, CommandRegistry } from "@lobu/core";
 import {
+  bindChatToPreviewAgent,
   canonicalSlackChannelId,
   consumePreviewClaim,
+  listPreviewAgents,
+  previewAgentMenu,
 } from "../../preview/slack.js";
 import type { AgentSettingsStore } from "../auth/settings/agent-settings-store.js";
 import {
@@ -79,6 +82,73 @@ export function registerBuiltInCommands(
       ];
 
       await ctx.reply(parts.join("\n"));
+    },
+  });
+
+  // Public preview: bind this chat to one of the demo agents in the preview
+  // connection's org. `/lobu try <agentId>` (no code, no CLI); `/lobu try` /
+  // `/lobu agents` with no arg lists them. Re-running with another agent
+  // rebinds. (Reached as the `try` / `agents` subcommand on Slack.)
+  const replyDemoMenu = async (ctx: CommandContext, prefix?: string) => {
+    if (!ctx.connectionId) {
+      await ctx.reply("Couldn't identify this workspace — try again in a moment.");
+      return;
+    }
+    const agents = await listPreviewAgents(ctx.connectionId);
+    const menu = previewAgentMenu(ctx.platform, agents);
+    await ctx.reply(prefix ? `${prefix}\n\n${menu}` : menu);
+  };
+
+  registry.register({
+    name: "try",
+    description:
+      "Try a demo agent in this workspace — `try <agentId>` (no arg lists them)",
+    handler: async (ctx: CommandContext) => {
+      const agentId = ctx.args.trim();
+      if (!agentId) {
+        await replyDemoMenu(ctx);
+        return;
+      }
+      if (!ctx.connectionId) {
+        await ctx.reply("Couldn't identify this workspace — try again in a moment.");
+        return;
+      }
+      // Bindings are keyed on the canonical channel-id form; Slack slash
+      // commands hand us the bare id.
+      const channelId =
+        ctx.platform === "slack"
+          ? canonicalSlackChannelId(ctx.channelId)
+          : ctx.channelId;
+      const result = await bindChatToPreviewAgent({
+        connectionId: ctx.connectionId,
+        agentId,
+        platform: ctx.platform,
+        teamId: ctx.teamId,
+        channelId,
+      });
+      switch (result.status) {
+        case "bound":
+          await ctx.reply(
+            `Now talking to \`${result.agentId}\`. Say hi — I'll reply here from now on.`
+          );
+          return;
+        case "not_available":
+          await replyDemoMenu(ctx, `No demo agent \`${agentId}\` here.`);
+          return;
+        case "no_connection":
+          await ctx.reply(
+            "This chat isn't connected to a Lobu preview workspace."
+          );
+          return;
+      }
+    },
+  });
+
+  registry.register({
+    name: "agents",
+    description: "List the demo agents you can try here",
+    handler: async (ctx: CommandContext) => {
+      await replyDemoMenu(ctx);
     },
   });
 

--- a/packages/server/src/gateway/connections/message-handler-bridge.ts
+++ b/packages/server/src/gateway/connections/message-handler-bridge.ts
@@ -10,7 +10,7 @@ import {
   flushTracing,
   generateTraceId,
 } from "@lobu/core";
-import { PREVIEW_UNLINKED_NOTICE } from "../../preview/slack.js";
+import { previewUnlinkedNotice } from "../../preview/slack.js";
 import type { CommandDispatcher } from "../commands/command-dispatcher.js";
 import { createChatReply } from "../commands/command-reply-adapters.js";
 import type { ArtifactStore } from "../files/artifact-store.js";
@@ -311,21 +311,23 @@ export class MessageHandlerBridge {
 
     // Preview connection (a hosted Lobu workspace bot — Slack, Telegram, …):
     // an unlinked DM/@-mention. Don't run the connection's placeholder owning
-    // agent — reply with the link instructions for this platform and stop here.
-    // (The `/lobu link <code>` / `/link <code>` redemption itself arrives as a
-    // slash command, not through this path, so linking still works.)
-    const unlinkedNotice = PREVIEW_UNLINKED_NOTICE[platform];
+    // agent — reply with the "pick a demo agent" menu (or, if the connection's
+    // org has no demo agents, the "wire your own agent" instructions) and stop.
+    // (`/lobu try <id>` / `/lobu link <code>` themselves arrive as slash
+    // commands, not through this path, so picking/linking still works.)
     if (
       resolved.source === "connection" &&
-      this.connection.settings?.previewMode === true &&
-      unlinkedNotice
+      this.connection.settings?.previewMode === true
     ) {
-      logger.info(
-        { platform, channelId, teamId, connectionId: this.connection.id },
-        "Preview connection: unlinked chat — replying with link instructions"
-      );
-      await thread.post(unlinkedNotice);
-      return;
+      const notice = await previewUnlinkedNotice(platform, this.connection.id);
+      if (notice) {
+        logger.info(
+          { platform, channelId, teamId, connectionId: this.connection.id },
+          "Preview connection: unlinked chat — replying with demo-agent menu"
+        );
+        await thread.post(notice);
+        return;
+      }
     }
 
     const agentId = resolved.agentId;

--- a/packages/server/src/preview/__tests__/slack-preview.test.ts
+++ b/packages/server/src/preview/__tests__/slack-preview.test.ts
@@ -10,9 +10,12 @@ import { getDb } from "../../db/client.js";
 import { registerBuiltInCommands } from "../../gateway/commands/built-in-commands.js";
 import type { Env } from "../../index";
 import {
+  bindChatToPreviewAgent,
   canonicalSlackChannelId,
   consumePreviewClaim,
   createPreviewClaim,
+  listPreviewAgents,
+  previewAgentMenu,
   slackSurfaceType,
 } from "../slack";
 
@@ -306,5 +309,174 @@ describe("Slack Preview claims + channel bindings", () => {
       },
     });
     expect(replies2.join("\n")).toMatch(/invalid or expired/i);
+  });
+});
+
+describe("Public preview — /lobu try a demo agent", () => {
+  const PREVIEW_CONN = "conn-preview";
+  const CONCIERGE = "preview-concierge";
+  const DEMO_A = "food-ordering";
+  const DEMO_B = "lunch-bot";
+  let PREVIEW_ORG = "";
+  let OTHER_ORG = "";
+
+  beforeAll(async () => {
+    await cleanupTestDatabase();
+    const org = await createTestOrganization({
+      name: "Public Preview Org",
+      slug: "public-preview-org",
+    });
+    PREVIEW_ORG = org.id;
+    const other = await createTestOrganization({
+      name: "Some Other Org",
+      slug: "some-other-org",
+    });
+    OTHER_ORG = other.id;
+    await createTestAgent({ organizationId: PREVIEW_ORG, agentId: CONCIERGE, name: "Concierge" });
+    await createTestAgent({
+      organizationId: PREVIEW_ORG,
+      agentId: DEMO_A,
+      name: "Food Ordering",
+      description: "Orders lunch from Deliveroo",
+    });
+    await createTestAgent({ organizationId: PREVIEW_ORG, agentId: DEMO_B, name: "Lunch Bot" });
+    await createTestAgent({ organizationId: OTHER_ORG, agentId: "private-agent", name: "Private" });
+
+    const sql = getDb();
+    await sql`
+      INSERT INTO agent_connections (id, agent_id, platform, config, settings, metadata, status, created_at, updated_at)
+      VALUES (${PREVIEW_CONN}, ${CONCIERGE}, 'slack', ${sql.json({ platform: "slack" })},
+              ${sql.json({ previewMode: true })}, ${sql.json({})}, 'active', now(), now())
+    `;
+  });
+
+  beforeEach(async () => {
+    await getDb()`DELETE FROM agent_channel_bindings`;
+  });
+
+  test("listPreviewAgents returns the org's agents, excluding the connection's owning agent", async () => {
+    const agents = await listPreviewAgents(PREVIEW_CONN);
+    expect(agents.map((a) => a.agentId).sort()).toEqual([DEMO_A, DEMO_B]);
+    expect(agents.find((a) => a.agentId === DEMO_A)?.description).toBe(
+      "Orders lunch from Deliveroo"
+    );
+  });
+
+  test("listPreviewAgents returns [] for an unknown connection", async () => {
+    expect(await listPreviewAgents("conn-does-not-exist")).toEqual([]);
+  });
+
+  test("bindChatToPreviewAgent binds a DM to a demo agent in the connection's org", async () => {
+    const res = await bindChatToPreviewAgent({
+      connectionId: PREVIEW_CONN,
+      agentId: DEMO_A,
+      platform: "slack",
+      teamId: TEAM_ID,
+      channelId: canonicalSlackChannelId("D100"),
+    });
+    expect(res).toEqual({ status: "bound", agentId: DEMO_A });
+
+    const rows = await getDb()`
+      SELECT agent_id, channel_id, team_id FROM agent_channel_bindings WHERE platform = 'slack'
+    `;
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({ agent_id: DEMO_A, channel_id: "slack:D100", team_id: TEAM_ID });
+  });
+
+  test("re-binding switches the chat to the new demo agent (last wins)", async () => {
+    await bindChatToPreviewAgent({
+      connectionId: PREVIEW_CONN, agentId: DEMO_A, platform: "slack",
+      teamId: TEAM_ID, channelId: canonicalSlackChannelId("Dswap"),
+    });
+    const res = await bindChatToPreviewAgent({
+      connectionId: PREVIEW_CONN, agentId: DEMO_B, platform: "slack",
+      teamId: TEAM_ID, channelId: canonicalSlackChannelId("Dswap"),
+    });
+    expect(res).toMatchObject({ status: "bound", agentId: DEMO_B });
+    const rows = await getDb()`
+      SELECT agent_id FROM agent_channel_bindings WHERE channel_id = 'slack:Dswap' AND team_id = ${TEAM_ID}
+    `;
+    expect(rows).toHaveLength(1);
+    expect((rows[0] as { agent_id: string }).agent_id).toBe(DEMO_B);
+  });
+
+  test("won't bind an agent that isn't in the connection's org", async () => {
+    expect(
+      await bindChatToPreviewAgent({
+        connectionId: PREVIEW_CONN, agentId: "private-agent", platform: "slack",
+        teamId: TEAM_ID, channelId: canonicalSlackChannelId("D200"),
+      })
+    ).toEqual({ status: "not_available" });
+    expect(
+      await bindChatToPreviewAgent({
+        connectionId: PREVIEW_CONN, agentId: "no-such-agent", platform: "slack",
+        teamId: TEAM_ID, channelId: canonicalSlackChannelId("D200"),
+      })
+    ).toEqual({ status: "not_available" });
+    expect(await getDb()`SELECT 1 FROM agent_channel_bindings`).toHaveLength(0);
+  });
+
+  test("reports no_connection for an unknown connection id", async () => {
+    expect(
+      await bindChatToPreviewAgent({
+        connectionId: "conn-nope", agentId: DEMO_A, platform: "slack",
+        teamId: TEAM_ID, channelId: canonicalSlackChannelId("D300"),
+      })
+    ).toEqual({ status: "no_connection" });
+  });
+
+  test("the /lobu try chat command binds end to end", async () => {
+    const registry = new CommandRegistry();
+    registerBuiltInCommands(registry, { agentSettingsStore: {} as never });
+
+    const replies: string[] = [];
+    const handled = await registry.tryHandle("try", {
+      userId: "U1",
+      channelId: "D777",
+      teamId: TEAM_ID,
+      isGroup: false,
+      platform: "slack",
+      connectionId: PREVIEW_CONN,
+      args: DEMO_A,
+      reply: async (text: string) => {
+        replies.push(text);
+      },
+    });
+    expect(handled).toBe(true);
+    expect(replies.join("\n")).toContain(`\`${DEMO_A}\``);
+    const rows = await getDb()`
+      SELECT agent_id FROM agent_channel_bindings WHERE channel_id = 'slack:D777' AND team_id = ${TEAM_ID}
+    `;
+    expect((rows[0] as { agent_id: string }).agent_id).toBe(DEMO_A);
+
+    // No arg → menu listing the demo agents, no throw.
+    const menuReplies: string[] = [];
+    await registry.tryHandle("try", {
+      userId: "U1", channelId: "D777", teamId: TEAM_ID, isGroup: false,
+      platform: "slack", connectionId: PREVIEW_CONN, args: "",
+      reply: async (text: string) => { menuReplies.push(text); },
+    });
+    expect(menuReplies.join("\n")).toContain(`/lobu try ${DEMO_A}`);
+
+    // Unknown agent → friendly "no demo agent" + the menu.
+    const badReplies: string[] = [];
+    await registry.tryHandle("try", {
+      userId: "U1", channelId: "D777", teamId: TEAM_ID, isGroup: false,
+      platform: "slack", connectionId: PREVIEW_CONN, args: "nope",
+      reply: async (text: string) => { badReplies.push(text); },
+    });
+    expect(badReplies.join("\n")).toMatch(/no demo agent `nope`/i);
+  });
+
+  test("previewAgentMenu lists agents (or says none)", () => {
+    expect(previewAgentMenu("slack", [])).toMatch(/no demo agents/i);
+    const menu = previewAgentMenu("slack", [
+      { agentId: DEMO_A, name: "Food Ordering", description: "Orders lunch" },
+    ]);
+    expect(menu).toContain(`/lobu try ${DEMO_A}`);
+    expect(menu).toContain("Orders lunch");
+    expect(previewAgentMenu("telegram", [
+      { agentId: DEMO_A, name: "Food Ordering", description: null },
+    ])).toContain(`/try ${DEMO_A}`);
   });
 });

--- a/packages/server/src/preview/slack.ts
+++ b/packages/server/src/preview/slack.ts
@@ -33,36 +33,18 @@ const PREVIEW_JOIN_DEFAULTS: Record<string, string> = {
 
 export type SurfaceType = 'dm' | 'channel';
 
-/**
- * Reply posted by a `previewMode` connection when a DM/@-mention arrives for a
- * chat that hasn't been linked yet — keyed by platform. Deterministic: no LLM
- * runs for unlinked chats; this is the whole response. A platform without an
- * entry here means an unlinked chat just falls through (the bridge skips it).
- */
-export const PREVIEW_UNLINKED_NOTICE: Record<string, string> = {
-  slack: [
-    "👋 This chat isn't linked to a Lobu agent yet.",
-    '',
-    'To talk to your own agent here:',
-    '1. In your agent project\'s `lobu.toml`: `[agents.<id>.preview.slack]` → `enabled = true` (add `surfaces = ["channel"]` to use it in channels too).',
-    '2. Run `lobu apply` to register the agent in Lobu Cloud.',
-    '3. Run `lobu run` — it prints a `/lobu link <code>`.',
-    '4. Send that `/lobu link <code>` here.',
-    '',
-    'After that, every message in this chat goes to your agent.',
-  ].join('\n'),
-  telegram: [
-    "👋 This chat isn't linked to a Lobu agent yet.",
-    '',
-    'To talk to your own agent here:',
-    '1. In your agent project\'s `lobu.toml`: `[agents.<id>.preview.telegram]` → `enabled = true`.',
-    '2. Run `lobu apply` to register the agent in Lobu Cloud.',
-    '3. Run `lobu run` — it prints a `/link <code>`.',
-    '4. Send that `/link <code>` here.',
-    '',
-    'After that, every message in this chat goes to your agent.',
-  ].join('\n'),
-};
+// Slash-command spellings differ by platform: Slack only delivers the
+// natively-registered `/lobu`, so its subcommands are `/lobu try` etc.; other
+// platforms register each command directly (`/try`, `/agents`, `/link`).
+function tryCommand(platform: string): string {
+  return platform === 'slack' ? '/lobu try' : '/try';
+}
+function listCommand(platform: string): string {
+  return platform === 'slack' ? '/lobu agents' : '/agents';
+}
+function linkCommand(platform: string): string {
+  return platform === 'slack' ? '/lobu link' : '/link';
+}
 
 interface ClaimPayload {
   organizationId: string;
@@ -310,4 +292,164 @@ export async function consumePreviewClaim(args: {
       organizationId: claim.organizationId,
     };
   });
+}
+
+// ── Public-preview "try a demo agent" ────────────────────────────────────────
+//
+// A `previewMode` connection (the hosted "Lobu" workspace bot) exposes every
+// agent in *its own org* as a self-serve demo: `/lobu try <agentId>` binds the
+// chat to that agent — no claim code, no ownership check, no CLI. "The org" is
+// whatever org owns the preview connection's agent; drop your demo agents in it
+// (via `lobu apply` / the agents UI) and they show up here automatically. The
+// connection's own placeholder/concierge agent is excluded from the list.
+
+export interface PreviewAgent {
+  agentId: string;
+  name: string;
+  description: string | null;
+}
+
+/**
+ * Resolve the org a preview connection's demo agents live in (the org of its
+ * owning agent), plus that owning agent's id (excluded from the demo list).
+ * Returns null when the connection or its owning agent can't be resolved.
+ */
+async function resolvePreviewConnectionOrg(
+  connectionId: string
+): Promise<{ organizationId: string; owningAgentId: string } | null> {
+  const sql = getDb();
+  const rows = (await sql`
+    SELECT a.organization_id, c.agent_id
+    FROM agent_connections c
+    JOIN agents a ON a.id = c.agent_id
+    WHERE c.id = ${connectionId}
+    LIMIT 1
+  `) as Array<{ organization_id: string | null; agent_id: string | null }>;
+  const row = rows[0];
+  if (!row?.organization_id || !row.agent_id) return null;
+  return { organizationId: row.organization_id, owningAgentId: row.agent_id };
+}
+
+/**
+ * Demo agents reachable via `/lobu try` through this preview connection. Best
+ * effort: returns `[]` (and logs) on any DB error rather than throwing — this
+ * runs on the hot path of every unlinked message and the worst case is a
+ * fallback notice instead of the menu.
+ */
+export async function listPreviewAgents(connectionId: string): Promise<PreviewAgent[]> {
+  try {
+    const org = await resolvePreviewConnectionOrg(connectionId);
+    if (!org) return [];
+    const sql = getDb();
+    const rows = (await sql`
+      SELECT id, name, description
+      FROM agents
+      WHERE organization_id = ${org.organizationId}
+        AND id <> ${org.owningAgentId}
+      ORDER BY name NULLS LAST, id
+    `) as Array<{ id: string; name: string | null; description: string | null }>;
+    return rows.map((r) => ({
+      agentId: r.id,
+      name: r.name ?? r.id,
+      description: r.description ?? null,
+    }));
+  } catch (err) {
+    logger.warn(
+      { err: errorMessage(err), connectionId },
+      '[preview] listPreviewAgents failed'
+    );
+    return [];
+  }
+}
+
+export type BindPreviewAgentResult =
+  | { status: 'bound'; agentId: string }
+  | { status: 'not_available' }
+  | { status: 'no_connection' };
+
+/**
+ * Bind a chat to a demo agent for a preview connection. The agent must live in
+ * the connection's org — that's the allowlist; there's no per-caller ownership
+ * check (that's the whole point: anyone in the hosted workspace can try them).
+ * Last bind wins; re-running with another agent just rebinds.
+ */
+export async function bindChatToPreviewAgent(args: {
+  connectionId: string;
+  agentId: string;
+  platform: string;
+  /** Workspace id for platforms that have one (Slack); undefined otherwise. */
+  teamId?: string;
+  /** Canonical channel id the message handler looks bindings up by. */
+  channelId: string;
+}): Promise<BindPreviewAgentResult> {
+  const org = await resolvePreviewConnectionOrg(args.connectionId);
+  if (!org) return { status: 'no_connection' };
+  const sql = getDb();
+  const agentRows = (await sql`
+    SELECT id FROM agents
+    WHERE id = ${args.agentId} AND organization_id = ${org.organizationId}
+    LIMIT 1
+  `) as Array<{ id: string }>;
+  const target = agentRows[0];
+  if (!target) return { status: 'not_available' };
+
+  const { platform, teamId, channelId } = args;
+  if (teamId) {
+    await sql`
+      INSERT INTO agent_channel_bindings (agent_id, platform, channel_id, team_id, created_at)
+      VALUES (${target.id}, ${platform}, ${channelId}, ${teamId}, now())
+      ON CONFLICT (platform, channel_id, team_id) DO UPDATE SET agent_id = EXCLUDED.agent_id
+    `;
+  } else {
+    await sql`
+      DELETE FROM agent_channel_bindings
+      WHERE platform = ${platform} AND channel_id = ${channelId} AND team_id IS NULL
+    `;
+    await sql`
+      INSERT INTO agent_channel_bindings (agent_id, platform, channel_id, team_id, created_at)
+      VALUES (${target.id}, ${platform}, ${channelId}, NULL, now())
+    `;
+  }
+  return { status: 'bound', agentId: target.id };
+}
+
+/** The "pick a demo agent" menu — shown on `/lobu try` / `/lobu agents`. */
+export function previewAgentMenu(platform: string, agents: PreviewAgent[]): string {
+  if (agents.length === 0) {
+    return 'No demo agents are available here yet.';
+  }
+  return [
+    'Demo agents you can try here:',
+    ...agents.map(
+      (a) => `• \`${tryCommand(platform)} ${a.agentId}\` — ${a.description || a.name}`
+    ),
+    '',
+    `Pick one, then just send a message. \`${listCommand(platform)}\` shows this list again.`,
+  ].join('\n');
+}
+
+/**
+ * Reply for a `previewMode` connection when an unlinked chat arrives. If the
+ * connection's org has demo agents, it's the `/lobu try` menu; otherwise it
+ * falls back to "wire your own agent" instructions. Returns null only when
+ * there's nothing useful to say (unknown platform).
+ */
+export async function previewUnlinkedNotice(
+  platform: string,
+  connectionId: string
+): Promise<string | null> {
+  if (!PREVIEW_PLATFORMS.has(platform)) return null;
+  const agents = await listPreviewAgents(connectionId);
+  if (agents.length > 0) {
+    return [
+      `👋 Welcome! ${previewAgentMenu(platform, agents)}`,
+      '',
+      `(Building your own agent? Run \`lobu run\` and send the \`${linkCommand(platform)} <code>\` it prints.)`,
+    ].join('\n');
+  }
+  return [
+    "👋 This chat isn't linked to a Lobu agent yet.",
+    '',
+    `Run \`lobu apply\` then \`lobu run\` to get a \`${linkCommand(platform)} <code>\`, and send it here.`,
+  ].join('\n');
 }


### PR DESCRIPTION
Stacked on #658. The zero-setup path for "let people try our demo agents (food-ordering, community bot, …) in the public Lobu Slack."

## What
A `previewMode` connection (the hosted Lobu workspace bot) now exposes **every agent in its own org** as a self-serve demo:
- **`/lobu try <agentId>`** — binds this DM/channel to that agent. No claim code, no ownership check, no CLI. Re-running with another agent rebinds.
- **`/lobu try` / `/lobu agents`** (no arg) — list the available demo agents.
- The **unlinked-DM notice** is now that menu ("👋 Welcome! Demo agents you can try here: …"); if the connection's org has no demo agents it falls back to the old "wire your own agent" instructions. Defensive: a DB hiccup degrades to the fallback notice rather than throwing.
- `/lobu link <code>` is unchanged — that's still the path for a *builder* trying *their own* agent from `lobu run`. `try` = our curated demos for evaluators, `link` = your own agent.

The allowlist is "agent is in the preview connection's org" — no per-agent flag. The connection's own placeholder/concierge agent is excluded from the list automatically.

## Ops (not code)
Put the demo agents (`food-ordering`, etc.) in the same org as the `slack-lobu-preview` connection (via `lobu apply` / the agents UI). That's the only config — being in that org *is* the opt-in.

## Files
- `packages/server/src/preview/slack.ts` — `listPreviewAgents`, `bindChatToPreviewAgent`, `previewAgentMenu`, `previewUnlinkedNotice` (replaces the static `PREVIEW_UNLINKED_NOTICE`)
- `packages/server/src/gateway/commands/built-in-commands.ts` — `try` + `agents` commands
- `packages/server/src/gateway/connections/message-handler-bridge.ts` — unlinked notice now async/dynamic

## Test
`make build-packages`, `bun run typecheck`; `LOBU_TEST_BACKEND=pglite vitest run src/preview/__tests__/slack-preview.test.ts` (18 pass, incl. 8 new: list/bind/rebind/not-in-org/no-connection/`/lobu try` end-to-end/menu); `bun test packages/server/src/gateway/__tests__/message-handler-bridge.test.ts` (19 pass).