### PR TITLE
fix(slack): publish Home view through the initialized adapter

### DIFF
--- a/packages/server/src/gateway/connections/chat-instance-manager.ts
+++ b/packages/server/src/gateway/connections/chat-instance-manager.ts
@@ -586,6 +586,9 @@ export class ChatInstanceManager {
       );
       registerSlackPlatformHandlers(chat, connection, commandDispatcher);
       registerSlackAppHome(chat, connection, {
+        // The initialized adapter (with the live Slack WebClient) — `chat.initialize()`
+        // below mutates it to add `.client`; event handlers fire only afterwards.
+        adapter,
         mcpConfigService: this.services.getMcpConfigService(),
         secretStore: this.services.getSecretStore(),
         publicGatewayUrl: this.publicGatewayUrl,

--- a/packages/server/src/gateway/connections/slack-platform-bridge.ts
+++ b/packages/server/src/gateway/connections/slack-platform-bridge.ts
@@ -149,6 +149,13 @@ type SlackActionEvent = {
 
 /** Dependencies the App Home tab needs to render status and run OAuth. */
 export interface SlackAppHomeDeps {
+  /**
+   * The initialized Slack adapter — the one with the live `@slack/web-api`
+   * client. The adapter handed to event handlers via `event.adapter` is the
+   * webhook-dispatch instance and has no `client`, so `publishHomeView` must
+   * go through this one.
+   */
+  adapter?: SlackHomeAdapter;
   mcpConfigService?: McpConfigService;
   secretStore?: WritableSecretStore;
   /** Public origin of the gateway — used to build the OAuth redirect URI. */
@@ -481,7 +488,7 @@ export function registerSlackAppHome(
   }
 
   chat.onAppHomeOpened(async (event: SlackAppHomeEvent) => {
-    await publishHome(event.adapter, {
+    await publishHome(deps.adapter ?? event.adapter, {
       connection,
       deps,
       userId: event.userId,
@@ -516,7 +523,7 @@ export function registerSlackAppHome(
             );
           }
         }
-        await publishHome(event.adapter, { connection, deps, userId });
+        await publishHome(deps.adapter ?? event.adapter, { connection, deps, userId });
         return;
       }
 
@@ -537,7 +544,7 @@ export function registerSlackAppHome(
           "Failed to start MCP OAuth flow from Slack home tab"
         );
       }
-      await publishHome(event.adapter, {
+      await publishHome(deps.adapter ?? event.adapter, {
         connection,
         deps,
         userId,


### PR DESCRIPTION
Follow-up to #653/#663. Prod logs showed the Home publish failing with `Cannot read properties of undefined (reading 'client')` — `event.adapter` from webhook-dispatched Slack events is a separate, uninitialized adapter instance (no `@slack/web-api` client), so `publishHomeView` blew up. Pass the registered/initialized adapter through `SlackAppHomeDeps.adapter` and use it for `publishHomeView`; `event.adapter` stays as a fallback. Tests/build/typecheck green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)