### PR TITLE
fix(connectors): always recompile bundled connectors from disk, ignore stale persisted artifact

### DIFF
--- a/packages/server/src/utils/connector-catalog.ts
+++ b/packages/server/src/utils/connector-catalog.ts
@@ -5,6 +5,7 @@ import { tmpdir } from 'node:os';
 import { basename, extname, join, resolve } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import { build, type Plugin } from 'esbuild';
+import { EXTERNAL_RUNTIME_DEPS } from '../../../connector-worker/src/runtime-deps';
 import { extractConnectorMetadata } from './connector-compiler';
 import logger from './logger';
 
@@ -126,13 +127,24 @@ function getDefaultConnectorCatalogUri(): string {
   return pathToFileURL(getDefaultConnectorCatalogDir()).toString();
 }
 
+// Bundled connector files don't appear/disappear at runtime, and this is now
+// consulted on every feed sync / worker poll — memoise the lookup.
+const bundledFileCache = new Map<string, string | null>();
+
 export function findBundledConnectorFile(key: string): string | null {
+  const cached = bundledFileCache.get(key);
+  if (cached !== undefined) return cached;
   const fileName = `${key.replace(/\./g, '_')}.ts`;
+  let found: string | null = null;
   for (const candidate of DEFAULT_CONNECTOR_DIR_CANDIDATES) {
     const filePath = resolve(candidate, fileName);
-    if (existsSync(filePath)) return filePath;
+    if (existsSync(filePath)) {
+      found = filePath;
+      break;
+    }
   }
-  return null;
+  bundledFileCache.set(key, found);
+  return found;
 }
 
 export function normalizeFileSourceUri(value: string): string | null {
@@ -187,7 +199,23 @@ export function getConfiguredConnectorCatalogUris(rawUris?: string): string[] {
   return [...normalized];
 }
 
+// Compiling a connector spawns esbuild; on the hot paths (feed sync, worker
+// poll) the same bundled .ts file is recompiled repeatedly. Cache the output
+// keyed by file mtime so a recompile only happens when the source actually
+// changes. Process restart (= deploy, = SDK rebuild) clears it, same as
+// `metadataCache` above.
+const compiledFileCache = new Map<string, { mtimeMs: number; code: string }>();
+
 export async function compileConnectorFromFile(filePath: string): Promise<string> {
+  let mtimeMs: number | null = null;
+  try {
+    mtimeMs = (await stat(filePath)).mtimeMs;
+    const cached = compiledFileCache.get(filePath);
+    if (cached && cached.mtimeMs === mtimeMs) return cached.code;
+  } catch {
+    // stat failed — fall through and let the build surface the real error.
+  }
+
   const tmpDir = await mkdtemp(join(tmpdir(), 'lobu-connector-'));
   const outPath = join(tmpDir, 'out.mjs');
 
@@ -204,19 +232,22 @@ export async function compileConnectorFromFile(filePath: string): Promise<string
         js: `import { createRequire as __createRequire } from 'module'; const require = __createRequire(import.meta.url);`,
       },
       plugins: [npmSpecifierPlugin],
-      // Must mirror EXTERNAL_RUNTIME_DEPS in packages/connector-worker/src/runtime-deps.ts.
-      // Only natives / runtime-installed deps (playwright ships browsers via
-      // `npx playwright install`) belong here. Pure JS deps (pino, link-preview-js)
-      // must be bundled — externalising them previously caused every connector
-      // run to fail with "Cannot find package 'pino'" because the worker image
-      // didn't ship them.
-      external: ['playwright', 'sharp', 'jimp'],
+      // Single source of truth: EXTERNAL_RUNTIME_DEPS in
+      // packages/connector-worker/src/runtime-deps.ts. Only natives /
+      // runtime-installed deps belong there (playwright ships browsers via
+      // `npx playwright install`). Pure JS deps (pino, link-preview-js) must be
+      // bundled — externalising them previously caused every connector run to
+      // fail with "Cannot find package 'pino'" because the worker image didn't
+      // ship them.
+      external: [...EXTERNAL_RUNTIME_DEPS],
       write: true,
       minify: false,
       sourcemap: false,
     });
 
-    return await readFile(outPath, 'utf-8');
+    const code = await readFile(outPath, 'utf-8');
+    if (mtimeMs !== null) compiledFileCache.set(filePath, { mtimeMs, code });
+    return code;
   } finally {
     await rm(tmpDir, { recursive: true, force: true });
   }

--- a/packages/server/src/utils/ensure-connector-installed.ts
+++ b/packages/server/src/utils/ensure-connector-installed.ts
@@ -18,19 +18,25 @@ import logger from './logger';
 
 /**
  * Resolve compiled connector code at runtime.
- * If compiledCode is already available, returns it directly.
- * Otherwise, compiles from the bundled source file on disk.
+ *
+ * If the connector ships as a bundled source file on disk, that file is the
+ * source of truth — recompile from it and IGNORE any persisted `compiled_code`.
+ * A persisted artifact is only ever produced by an older server build (e.g.
+ * before `pino` was bundled instead of externalised); trusting it would shadow
+ * the up-to-date source indefinitely and break feed sync. The recompile is
+ * cheap because `compileConnectorFromFile` caches by mtime.
+ *
+ * Only connectors with no on-disk source (genuinely user-uploaded via
+ * `source_code` / `source_url`) fall back to the persisted `compiled_code`.
  */
 export async function resolveConnectorCode(
   connectorKey: string,
   compiledCode: string | null
 ): Promise<string> {
-  if (compiledCode) return compiledCode;
   const filePath = findBundledConnectorFile(connectorKey);
-  if (!filePath) {
-    throw new Error(`No compiled code for '${connectorKey}' and source not found on disk.`);
-  }
-  return compileConnectorFromFile(filePath);
+  if (filePath) return compileConnectorFromFile(filePath);
+  if (compiledCode) return compiledCode;
+  throw new Error(`No compiled code for '${connectorKey}' and source not found on disk.`);
 }
 
 export async function ensureConnectorInstalled(params: {


### PR DESCRIPTION
## Problem

The Spotify connector in the `buremba` org had been failing **every feed sync for 80+ runs** (since 2026-04-27) with:

> Connector requires 'pino' but it's not installed in the runtime image …

It's not an auth problem — the OAuth tokens are fine. `resolveConnectorCode` short-circuits on any non-null `connector_versions.compiled_code`, so a compiled artifact baked by an older server build (compiled 2026-04-14, back when `pino` was still in the esbuild `external` list) permanently shadowed the up-to-date on-disk `spotify.ts` (which now bundles `pino` via `@lobu/connector-sdk`). The connector-worker child can't resolve the bare `import pino from 'pino'` → `ERR_MODULE_NOT_FOUND` on every run. `rss` (row 121) had the same latent shape.

## Fix

- **`resolveConnectorCode`**: if a bundled source file exists for the key, always recompile from it and **ignore** the persisted `compiled_code`. Persisted code is only a fallback for genuinely user-uploaded connectors with no on-disk source. This self-heals every stale row at read time.
- **`compileConnectorFromFile`**: mtime-keyed output cache so the recompile on the hot paths (feed sync, `/api/workers/poll`) only re-runs esbuild when the source actually changes. Cleared on process restart, same contract as `metadataCache`.
- **`findBundledConnectorFile`**: memoise the lookup (now consulted per sync/poll).
- **`connector-catalog`**: import `EXTERNAL_RUNTIME_DEPS` instead of a hand-copied `['playwright','sharp','jimp']` list with a "must mirror" comment — single source of truth (this *is* the bug class that bit us).

## Prod hotfix already applied

Nulled `connector_versions.compiled_code`/`compiled_code_hash` for the stale Spotify row (id 191) and reset the two failing feeds (`saved_tracks`, `playlists`) — prod's current code already has the disk fallback once `compiled_code` is null, so it self-heals on the next sync without waiting for this deploy.

## Validation

- `make build-packages` ✅, `bun run typecheck` ✅
- Manual: `compileConnectorFromFile(spotify.ts)` produces a bundle with no bare `pino` import; second call returns the cached reference.
- Not run: vitest suite (needs a Postgres global-setup; only DB handy is prod). `connector-catalog.test.ts` worth a look on a proper test DB.