### PR TITLE
refactor(connections): rename cloud→serverless / embedded-server wording

### DIFF
--- a/packages/server/src/db/embedded-schema-patches.ts
+++ b/packages/server/src/db/embedded-schema-patches.ts
@@ -206,7 +206,7 @@ export const EMBEDDED_SCHEMA_PATCHES: EmbeddedSchemaPatch[] = [
     apply: async (sql) => {
       // `runtime` carries platform metadata for device-bound connectors
       // (e.g. apple.screen_time / local.directory, which run inside the Lobu
-      // Lobu for Mac). NULL = cloud connector.
+      // Lobu for Mac). NULL = embedded server.
       await sql.unsafe(`
         ALTER TABLE public.connector_definitions
         ADD COLUMN IF NOT EXISTS runtime jsonb

--- a/packages/server/src/tools/admin/manage_connections.ts
+++ b/packages/server/src/tools/admin/manage_connections.ts
@@ -167,7 +167,7 @@ const CreateAction = Type.Object({
   device_worker_id: Type.Optional(
     Type.String({
       description:
-        "Run this connection's syncs/actions on a specific device worker (its device_workers.id) instead of the cloud pool. Required for connectors that declare a required_capability; optional otherwise. The device must belong to you or be granted to this org.",
+        "Run this connection's syncs/actions on a specific device worker (its device_workers.id) instead of the Lobu server (runs serverless). Required for connectors that declare a required_capability; optional otherwise. The device must belong to you or be granted to this org.",
     })
   ),
   entity_link_overrides: Type.Optional(EntityLinkOverridesSchema),
@@ -187,7 +187,7 @@ const UpdateAction = Type.Object({
   device_worker_id: Type.Optional(
     Type.Union([Type.String(), Type.Null()], {
       description:
-        'Reassign which device worker runs this connection. Null moves it back to the cloud pool (only allowed if the connector has no required_capability).',
+        'Reassign which device worker runs this connection. Null moves it back to the Lobu server, runs serverless (only allowed if the connector has no required_capability).',
     })
   ),
   replace_config: Type.Optional(
@@ -274,7 +274,7 @@ const ConnectAction = Type.Object({
   device_worker_id: Type.Optional(
     Type.String({
       description:
-        "Run this connection's syncs/actions on a specific device worker (its device_workers.id) instead of the cloud pool. Required for connectors that declare a required_capability; optional otherwise. The device must belong to you or be granted to this org.",
+        "Run this connection's syncs/actions on a specific device worker (its device_workers.id) instead of the Lobu server (runs serverless). Required for connectors that declare a required_capability; optional otherwise. The device must belong to you or be granted to this org.",
     })
   ),
   entity_link_overrides: Type.Optional(EntityLinkOverridesSchema),
@@ -705,7 +705,7 @@ async function handleGet(
 
 /**
  * Validate + normalize a connection's device-worker binding (the "Run on"
- * target). Returns the resolved id (or `null` = cloud pool) or an error string.
+ * target). Returns the resolved id (or `null` = serverless, in the Lobu server) or an error string.
  *
  *  - A connector that declares `required_capability` MUST be pinned to a device,
  *    and that device must currently advertise the capability.

--- a/packages/server/src/worker-api.ts
+++ b/packages/server/src/worker-api.ts
@@ -149,9 +149,9 @@ export async function pollWorkerJob(c: Context<{ Bindings: Env }>) {
   // below) belongs in their match set. User-scoped workers — the Lobu Mac
   // Bridge, anything in `workerAuthMode === 'user'` — are *device* workers:
   // they may ONLY claim runs whose connector declares a `required_capability`
-  // they advertise, never the cloud connectors. So '' is excluded for them,
+  // they advertise, never the embedded-server connectors. So '' is excluded for them,
   // which means a bridge with no granted capabilities claims *nothing* instead
-  // of hijacking-and-failing arbitrary cloud-connector runs (e.g. hackernews).
+  // of hijacking-and-failing arbitrary embedded-server connector runs (e.g. hackernews).
   const isUserScopedWorker = c.var.workerAuthMode === 'user';
   const capabilityMatchSet = isUserScopedWorker
     ? advertisedCapabilities
@@ -164,7 +164,7 @@ export async function pollWorkerJob(c: Context<{ Bindings: Env }>) {
   // `deviceWorkerId` is this device's surrogate id; a pending run whose
   // connection is pinned to it (connections.device_worker_id) is claimable
   // regardless of the connector's required_capability — that's how an
-  // otherwise-cloud connector (Reddit, …) ends up running on a chosen device.
+  // otherwise-embedded connector (Reddit, …) ends up running on a chosen device.
   const workerUserId = c.var.workerUserId;
   // The org the device's token was issued for — the workspace the user picked on
   // the OAuth device-authorization page. Falls back to the owner's personal


### PR DESCRIPTION
Backend mirror of the owletto-web rename (#95, merged). A connection with no `device_worker_id` runs *serverless* inside the embedded Lobu server — not a "cloud connector pool". Updates:

- `manage_connections` tool: `device_worker_id` / `reassign_device_worker` parameter descriptions + the device-target resolver doc comment.
- `worker-api.ts`: device-claim comments ("embedded-server connectors" instead of "cloud connectors").
- `embedded-schema-patches.ts`: `device_worker_id` column comment ("NULL = embedded server").

Pure wording — no behavior change.