### PR TITLE
fix(cli): resolve providers.json + worker entry relative to enclosing monorepo root

### DIFF
--- a/packages/agent-worker/package.json
+++ b/packages/agent-worker/package.json
@@ -8,8 +8,18 @@
     "lobu-worker": "./dist/index.js"
   },
   "files": [
-    "dist"
+    "dist",
+    "src"
   ],
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "bun": "./src/index.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.js"
+    },
+    "./package.json": "./package.json"
+  },
   "scripts": {
     "build": "tsc",
     "dev": "tsc --watch",

--- a/packages/cli/src/__tests__/dev.test.ts
+++ b/packages/cli/src/__tests__/dev.test.ts
@@ -10,7 +10,10 @@ import {
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
-import { resolveBackendBundle } from "../commands/dev";
+import {
+  findEnclosingMonorepoRoot,
+  resolveBackendBundle,
+} from "../commands/dev";
 
 const here = dirname(fileURLToPath(import.meta.url));
 const repoRoot = join(here, "..", "..", "..", "..");
@@ -108,6 +111,39 @@ describe("lobu run backend bundle resolution", () => {
     for (const name of ["playwright", "sharp", "jimp"]) {
       expect(cliRuntimeDeps[name]).toBeDefined();
     }
+  });
+
+  test("findEnclosingMonorepoRoot walks up from a project subdir", () => {
+    const root = mkdtempSync(join(tmpdir(), "lobu-cli-monorepo-"));
+    tempDirs.push(root);
+    writeFileSync(
+      join(root, "package.json"),
+      JSON.stringify({ name: "root", workspaces: ["packages/*"] })
+    );
+    mkdirSync(join(root, "packages", "agent-worker", "src"), {
+      recursive: true,
+    });
+    writeFileSync(
+      join(root, "packages", "agent-worker", "src", "index.ts"),
+      "// worker"
+    );
+    const subdir = join(root, "examples", "office-bot");
+    mkdirSync(subdir, { recursive: true });
+
+    expect(findEnclosingMonorepoRoot(subdir)).toBe(root);
+    expect(findEnclosingMonorepoRoot(root)).toBe(root);
+
+    const lone = mkdtempSync(join(tmpdir(), "lobu-cli-lone-"));
+    tempDirs.push(lone);
+    expect(findEnclosingMonorepoRoot(lone)).toBeNull();
+  });
+
+  test("findEnclosingMonorepoRoot resolves this repo's root", () => {
+    const found = findEnclosingMonorepoRoot(here);
+    expect(found).not.toBeNull();
+    expect(
+      existsSync(join(found!, "packages", "agent-worker", "src", "index.ts"))
+    ).toBe(true);
   });
 
   test("CLI build copies local runtime assets for installed lobu run", () => {

--- a/packages/cli/src/commands/dev.ts
+++ b/packages/cli/src/commands/dev.ts
@@ -1,9 +1,9 @@
 import { spawn } from "node:child_process";
-import { existsSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { readFile } from "node:fs/promises";
 import { createRequire } from "node:module";
 import { createServer } from "node:net";
-import { dirname, join } from "node:path";
+import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import chalk from "chalk";
 import ora from "ora";
@@ -131,12 +131,34 @@ export async function devCommand(
     (options.quiet ? "warn" : options.verbose ? "debug" : undefined);
 
   // Pass-through env: process.env wins so users can override per-invocation,
-  // .env values fill in the rest. LOBU_DEV_PROJECT_PATH is optional and only
-  // used by file-first local workflows that still have a lobu.toml.
+  // .env values fill in the rest.
+  //
+  // LOBU_DEV_PROJECT_PATH points the embedded server at the monorepo root so
+  // it can find the `packages/agent-worker/src/index.ts` worker entry (and
+  // packages/web). When `lobu run` is invoked from a project subdir inside the
+  // monorepo, cwd is *not* the root — walk up to the enclosing workspace root.
+  const enclosingRoot = findEnclosingMonorepoRoot(cwd);
+  const projectPath =
+    process.env.LOBU_DEV_PROJECT_PATH ||
+    envVars.LOBU_DEV_PROJECT_PATH ||
+    enclosingRoot ||
+    cwd;
+
+  // Bundled CLIs (and `lobu run` from anywhere) ship providers.json next to
+  // the server bundle; point the gateway at it unless the user already set the
+  // path in their env or .env.
+  const bundledProvidersPath = join(dirname(bundlePath), "providers.json");
+  const providerRegistryPath =
+    process.env.LOBU_PROVIDER_REGISTRY_PATH ||
+    envVars.LOBU_PROVIDER_REGISTRY_PATH ||
+    (existsSync(bundledProvidersPath) ? bundledProvidersPath : undefined);
+
   const childEnv: Record<string, string> = {
     ...mergedEnv,
-    LOBU_DEV_PROJECT_PATH:
-      process.env.LOBU_DEV_PROJECT_PATH || envVars.LOBU_DEV_PROJECT_PATH || cwd,
+    LOBU_DEV_PROJECT_PATH: projectPath,
+    ...(providerRegistryPath
+      ? { LOBU_PROVIDER_REGISTRY_PATH: providerRegistryPath }
+      : {}),
     PORT: String(portNum),
     GATEWAY_PORT: String(portNum),
     ...(logLevel ? { LOG_LEVEL: logLevel } : {}),
@@ -175,6 +197,45 @@ export async function devCommand(
     }
     process.exit(code ?? 0);
   });
+}
+
+/**
+ * Walk up from `startDir` looking for the Lobu monorepo workspace root: a
+ * `package.json` with a non-empty `workspaces` field AND a
+ * `packages/agent-worker/src/index.ts` underneath it. Returns the absolute
+ * path, or `null`. (Mirrors `@lobu/server`'s `findEnclosingMonorepoRoot` — kept
+ * local so the CLI doesn't take a dep on the server package.)
+ */
+export function findEnclosingMonorepoRoot(startDir: string): string | null {
+  let cur = resolve(startDir);
+  for (let i = 0; i < 64; i++) {
+    const pkgPath = join(cur, "package.json");
+    if (existsSync(pkgPath)) {
+      let hasWorkspaces = false;
+      try {
+        const pkg = JSON.parse(readFileSync(pkgPath, "utf-8")) as {
+          workspaces?: unknown;
+        };
+        hasWorkspaces =
+          pkg.workspaces != null &&
+          (Array.isArray(pkg.workspaces)
+            ? pkg.workspaces.length > 0
+            : typeof pkg.workspaces === "object");
+      } catch {
+        hasWorkspaces = false;
+      }
+      if (
+        hasWorkspaces &&
+        existsSync(join(cur, "packages/agent-worker/src/index.ts"))
+      ) {
+        return cur;
+      }
+    }
+    const parent = dirname(cur);
+    if (parent === cur) break;
+    cur = parent;
+  }
+  return null;
 }
 
 export function resolveBackendBundle(

--- a/packages/server/src/gateway/__tests__/provider-registry-service.test.ts
+++ b/packages/server/src/gateway/__tests__/provider-registry-service.test.ts
@@ -1,7 +1,17 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import {
+  existsSync,
+  mkdtempSync,
+  realpathSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
   ProviderRegistryService,
   resolveProviderRegistryFromRaw,
+  resolveProviderRegistryPath,
 } from "../services/provider-registry-service.js";
 
 const testConfig = {
@@ -123,5 +133,51 @@ describe("ProviderRegistryService", () => {
 
   test("resolveProviderRegistryFromRaw rejects malformed payloads", () => {
     expect(resolveProviderRegistryFromRaw("{}")).toBeNull();
+  });
+});
+
+describe("resolveProviderRegistryPath", () => {
+  const savedEnv = process.env.LOBU_PROVIDER_REGISTRY_PATH;
+  const savedCwd = process.cwd();
+  const tempDirs: string[] = [];
+
+  afterEach(() => {
+    if (savedEnv === undefined) delete process.env.LOBU_PROVIDER_REGISTRY_PATH;
+    else process.env.LOBU_PROVIDER_REGISTRY_PATH = savedEnv;
+    process.chdir(savedCwd);
+    while (tempDirs.length) {
+      const d = tempDirs.pop();
+      if (d) rmSync(d, { recursive: true, force: true });
+    }
+  });
+
+  test("LOBU_PROVIDER_REGISTRY_PATH always wins (incl. http URLs)", () => {
+    process.env.LOBU_PROVIDER_REGISTRY_PATH = "https://example.com/p.json";
+    expect(resolveProviderRegistryPath()).toBe("https://example.com/p.json");
+  });
+
+  test("falls back to <cwd>/config/providers.json when present", () => {
+    delete process.env.LOBU_PROVIDER_REGISTRY_PATH;
+    const dir = realpathSync(mkdtempSync(join(tmpdir(), "lobu-cwd-prov-")));
+    tempDirs.push(dir);
+    const cfgDir = join(dir, "config");
+    require("node:fs").mkdirSync(cfgDir);
+    writeFileSync(join(cfgDir, "providers.json"), '{"providers":[]}');
+    process.chdir(dir);
+    expect(resolveProviderRegistryPath()).toBe(
+      join(dir, "config/providers.json")
+    );
+  });
+
+  test("returns a path that exists, or undefined — never a bogus cwd path", () => {
+    delete process.env.LOBU_PROVIDER_REGISTRY_PATH;
+    const dir = mkdtempSync(join(tmpdir(), "lobu-empty-prov-"));
+    tempDirs.push(dir);
+    process.chdir(dir);
+    const resolved = resolveProviderRegistryPath();
+    if (resolved !== undefined) {
+      // bundle-relative providers.json (only present in built dist) — must exist
+      expect(existsSync(resolved)).toBe(true);
+    }
   });
 });

--- a/packages/server/src/gateway/config/index.ts
+++ b/packages/server/src/gateway/config/index.ts
@@ -16,6 +16,7 @@ import {
 } from "@lobu/core";
 import { config as dotenvConfig } from "dotenv";
 import type { OrchestratorConfig } from "../orchestration/base-deployment-manager.js";
+import { findEnclosingMonorepoRoot } from "../../utils/monorepo-root.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const logger = createLogger("cli-config");
@@ -296,28 +297,37 @@ function buildEmbeddedWorkerPaths(projectRoot: string): {
   // path.resolve so a relative LOBU_DEV_PROJECT_PATH still yields absolute
   // paths — workers are spawned with cwd=workspaceDir, so relative entries
   // would resolve against the workspace and fail.
-  const root = path.resolve(projectRoot);
   const explicitEntryPoint = process.env.LOBU_WORKER_ENTRYPOINT;
   const explicitBinPathEntries = process.env.LOBU_WORKER_BIN_PATHS?.split(
     path.delimiter
   ).filter(Boolean);
-  const monorepoEntryPoint = path.join(root, "packages/agent-worker/src/index.ts");
-  const monorepoBinPathEntries = [
+
+  const binPathsFor = (root: string) => [
     path.join(root, "node_modules/.bin"),
     path.join(root, "packages/agent-worker/node_modules/.bin"),
   ];
 
+  // The passed root (LOBU_DEV_PROJECT_PATH / cwd) may be a project subdir
+  // inside the monorepo — in that case the `src/index.ts` worker entry lives
+  // at the enclosing workspace root, not under the subdir. Resolve it.
+  const passedRoot = path.resolve(projectRoot);
+  const monorepoRoot =
+    existsSync(path.join(passedRoot, "packages/agent-worker/src/index.ts"))
+      ? passedRoot
+      : findEnclosingMonorepoRoot(passedRoot);
+
   if (explicitEntryPoint) {
     return {
       entryPoint: path.resolve(explicitEntryPoint),
-      binPathEntries: explicitBinPathEntries ?? monorepoBinPathEntries,
+      binPathEntries:
+        explicitBinPathEntries ?? binPathsFor(monorepoRoot ?? passedRoot),
     };
   }
 
-  if (existsSync(monorepoEntryPoint)) {
+  if (monorepoRoot) {
     return {
-      entryPoint: monorepoEntryPoint,
-      binPathEntries: monorepoBinPathEntries,
+      entryPoint: path.join(monorepoRoot, "packages/agent-worker/src/index.ts"),
+      binPathEntries: binPathsFor(monorepoRoot),
     };
   }
 
@@ -326,8 +336,17 @@ function buildEmbeddedWorkerPaths(projectRoot: string): {
       "@lobu/worker/package.json"
     );
     const workerPackageRoot = path.dirname(workerPackageJson);
+    // Prefer the ESM TypeScript source (spawned via `bun run`): the published
+    // CJS `dist/index.js` is a dead end because `@mariozechner/pi-coding-agent`
+    // only exposes an `import` condition, so a `node`-loaded `require()` of it
+    // throws ERR_PACKAGE_PATH_NOT_EXPORTED. The package ships `src/` and a
+    // `bun` exports condition for exactly this path. `bun` is a declared
+    // peerDependency of `@lobu/worker`.
+    const workerSrcEntry = path.join(workerPackageRoot, "src/index.ts");
     return {
-      entryPoint: path.join(workerPackageRoot, "dist/index.js"),
+      entryPoint: existsSync(workerSrcEntry)
+        ? workerSrcEntry
+        : path.join(workerPackageRoot, "dist/index.js"),
       binPathEntries: [
         path.join(workerPackageRoot, "node_modules/.bin"),
         path.resolve(workerPackageRoot, "..", "..", ".bin"),
@@ -335,8 +354,11 @@ function buildEmbeddedWorkerPaths(projectRoot: string): {
     };
   } catch {
     return {
-      entryPoint: monorepoEntryPoint,
-      binPathEntries: monorepoBinPathEntries,
+      entryPoint: path.join(
+        passedRoot,
+        "packages/agent-worker/src/index.ts"
+      ),
+      binPathEntries: binPathsFor(passedRoot),
     };
   }
 }

--- a/packages/server/src/gateway/services/core-services.ts
+++ b/packages/server/src/gateway/services/core-services.ts
@@ -74,7 +74,10 @@ import { SessionManager, StateAdapterSessionStore } from "./session-manager.js";
 import { SseManager } from "./sse-manager.js";
 import { WatcherRunTracker } from "../watchers/run-tracker.js";
 import { ProviderConfigResolver } from "./provider-config-resolver.js";
-import { ProviderRegistryService } from "./provider-registry-service.js";
+import {
+  ProviderRegistryService,
+  resolveProviderRegistryPath,
+} from "./provider-registry-service.js";
 import { TranscriptionService } from "./transcription-service.js";
 
 const logger = createLogger("core-services");
@@ -573,22 +576,32 @@ export class CoreServices {
     logger.debug("Bedrock provider module registered");
 
     // Initialize bundled provider registry — use injected providers if
-    // provided, else load from config/providers.json.
+    // provided, else load from the resolved providers registry path
+    // (LOBU_PROVIDER_REGISTRY_PATH → <cwd>/config/providers.json → the
+    // providers.json shipped next to the server bundle).
     const injectedProviders = this.options?.providerRegistry;
     if (injectedProviders) {
       this.providerRegistryService = new ProviderRegistryService(
         undefined,
         injectedProviders
       );
-    } else {
-      this.providerRegistryService = new ProviderRegistryService(
-        process.env.LOBU_PROVIDER_REGISTRY_PATH || "config/providers.json"
+      logger.debug(
+        `Provider registry initialized from injected providers (${injectedProviders.length})`
       );
+    } else {
+      const registryPath = resolveProviderRegistryPath();
+      this.providerRegistryService = new ProviderRegistryService(registryPath);
+      if (registryPath) {
+        logger.info(`Provider registry path: ${registryPath}`);
+      } else {
+        logger.warn(
+          "No providers registry found (set LOBU_PROVIDER_REGISTRY_PATH or run from a dir with config/providers.json) — config-driven providers will be unavailable"
+        );
+      }
     }
     this.providerConfigResolver = new ProviderConfigResolver(
       this.providerRegistryService
     );
-    logger.debug("Provider registry service initialized");
 
     this.transcriptionService?.setProviderConfigSource(() =>
       this.providerConfigResolver
@@ -599,6 +612,9 @@ export class CoreServices {
     // Register config-driven providers from the bundled providers registry
     const configProviders =
       await this.providerConfigResolver.getProviderConfigs();
+    logger.info(
+      `Provider registry loaded ${Object.keys(configProviders).length} config-driven provider(s)`
+    );
     const registeredIds = new Set(
       getModelProviderModules().map((m) => m.providerId)
     );

--- a/packages/server/src/gateway/services/provider-registry-service.ts
+++ b/packages/server/src/gateway/services/provider-registry-service.ts
@@ -1,4 +1,7 @@
+import { existsSync } from "node:fs";
 import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 import type {
   ProviderConfigEntry,
   ProviderRegistryEntry,
@@ -7,6 +10,37 @@ import type {
 import { createLogger } from "@lobu/core";
 
 const logger = createLogger("provider-registry-service");
+
+/**
+ * Resolve the path/URL of the bundled providers registry.
+ *
+ * Tries, first-that-exists:
+ *  1. `LOBU_PROVIDER_REGISTRY_PATH` — always wins. `http(s)://` URLs pass
+ *     through untouched (loadConfig fetches them).
+ *  2. `<cwd>/config/providers.json` — preserves the historical behavior of
+ *     invoking the gateway from the monorepo root.
+ *  3. Bundle-relative `providers.json` — sits next to `server.bundle.mjs` /
+ *     `start-local.bundle.mjs` (also copied into `packages/cli/dist/`).
+ *
+ * No fuzzy ancestor walk-up: a project subdir resolves to the bundled file,
+ * which is the correct default for both published CLIs and `lobu run`.
+ */
+export function resolveProviderRegistryPath(): string | undefined {
+  const explicit = process.env.LOBU_PROVIDER_REGISTRY_PATH?.trim();
+  if (explicit) return explicit;
+
+  const cwdPath = path.resolve(process.cwd(), "config/providers.json");
+  if (existsSync(cwdPath)) return cwdPath;
+
+  const bundleDir = path.dirname(fileURLToPath(import.meta.url));
+  // From the bundled server: dist/server.bundle.mjs → dist/providers.json.
+  // From source (tsc dist): dist/gateway/services → walk up to dist, then to
+  // the package root where the monorepo config dir is reachable via repo root.
+  const bundleSibling = path.join(bundleDir, "providers.json");
+  if (existsSync(bundleSibling)) return bundleSibling;
+
+  return undefined;
+}
 
 const ENV_SUBSTITUTION_BLOCKLIST = new Set([
   "ENCRYPTION_KEY",

--- a/packages/server/src/utils/__tests__/monorepo-root.test.ts
+++ b/packages/server/src/utils/__tests__/monorepo-root.test.ts
@@ -1,0 +1,85 @@
+import {
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { findEnclosingMonorepoRoot } from "../monorepo-root";
+
+const tempDirs: string[] = [];
+
+function makeFakeMonorepo(): string {
+  const root = mkdtempSync(join(tmpdir(), "lobu-monorepo-"));
+  tempDirs.push(root);
+  writeFileSync(
+    join(root, "package.json"),
+    JSON.stringify({ name: "fake-root", workspaces: ["packages/*"] })
+  );
+  mkdirSync(join(root, "packages/agent-worker/src"), { recursive: true });
+  writeFileSync(join(root, "packages/agent-worker/src/index.ts"), "// worker");
+  return root;
+}
+
+afterEach(() => {
+  while (tempDirs.length) {
+    const d = tempDirs.pop();
+    if (d) rmSync(d, { recursive: true, force: true });
+  }
+});
+
+describe("findEnclosingMonorepoRoot", () => {
+  it("returns the root when called from the root itself", () => {
+    const root = makeFakeMonorepo();
+    expect(findEnclosingMonorepoRoot(root)).toBe(root);
+  });
+
+  it("walks up from a project subdir to the enclosing root", () => {
+    const root = makeFakeMonorepo();
+    const subdir = join(root, "examples", "office-bot");
+    mkdirSync(subdir, { recursive: true });
+    expect(findEnclosingMonorepoRoot(subdir)).toBe(root);
+  });
+
+  it("returns null when no enclosing workspace root exists", () => {
+    const lone = mkdtempSync(join(tmpdir(), "lobu-lone-"));
+    tempDirs.push(lone);
+    expect(findEnclosingMonorepoRoot(lone)).toBeNull();
+  });
+
+  it("does not false-positive on a workspace root without the worker entry", () => {
+    const root = mkdtempSync(join(tmpdir(), "lobu-otherws-"));
+    tempDirs.push(root);
+    writeFileSync(
+      join(root, "package.json"),
+      JSON.stringify({ name: "other", workspaces: ["packages/*"] })
+    );
+    mkdirSync(join(root, "packages/something"), { recursive: true });
+    expect(findEnclosingMonorepoRoot(root)).toBeNull();
+  });
+
+  it("ignores a package.json without a workspaces field", () => {
+    const root = mkdtempSync(join(tmpdir(), "lobu-nows-"));
+    tempDirs.push(root);
+    writeFileSync(
+      join(root, "package.json"),
+      JSON.stringify({ name: "no-workspaces" })
+    );
+    mkdirSync(join(root, "packages/agent-worker/src"), { recursive: true });
+    writeFileSync(join(root, "packages/agent-worker/src/index.ts"), "// worker");
+    expect(findEnclosingMonorepoRoot(root)).toBeNull();
+  });
+
+  it("finds the real lobu monorepo from this test file", () => {
+    const found = findEnclosingMonorepoRoot(__dirname);
+    expect(found).not.toBeNull();
+    // Sanity: the discovered root must actually carry the worker entry.
+    expect(
+      require("node:fs").existsSync(
+        join(found!, "packages/agent-worker/src/index.ts")
+      )
+    ).toBe(true);
+  });
+});

--- a/packages/server/src/utils/monorepo-root.ts
+++ b/packages/server/src/utils/monorepo-root.ts
@@ -1,0 +1,45 @@
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+
+/**
+ * Walk up from `startDir` looking for the Lobu monorepo workspace root: a
+ * `package.json` whose `workspaces` field is set AND which has
+ * `packages/agent-worker/src/index.ts` underneath it. The worker-entry check
+ * keeps us from false-positiving on unrelated Bun/npm workspace roots that
+ * happen to enclose the start dir.
+ *
+ * Returns the absolute path to that directory, or `null` if none is found.
+ */
+export function findEnclosingMonorepoRoot(startDir: string): string | null {
+  let cur = path.resolve(startDir);
+  // Hard cap on iterations as a guard against pathological inputs.
+  for (let i = 0; i < 64; i++) {
+    const pkgPath = path.join(cur, "package.json");
+    if (existsSync(pkgPath)) {
+      let hasWorkspaces = false;
+      try {
+        const pkg = JSON.parse(readFileSync(pkgPath, "utf-8")) as {
+          workspaces?: unknown;
+        };
+        hasWorkspaces =
+          pkg.workspaces !== undefined &&
+          pkg.workspaces !== null &&
+          (Array.isArray(pkg.workspaces)
+            ? pkg.workspaces.length > 0
+            : typeof pkg.workspaces === "object");
+      } catch {
+        hasWorkspaces = false;
+      }
+      if (
+        hasWorkspaces &&
+        existsSync(path.join(cur, "packages/agent-worker/src/index.ts"))
+      ) {
+        return cur;
+      }
+    }
+    const parent = path.dirname(cur);
+    if (parent === cur) break;
+    cur = parent;
+  }
+  return null;
+}


### PR DESCRIPTION
## Problem

`lobu run` from a project subdir inside the monorepo (e.g. `cd examples/office-bot && lobu run`) broke two ways, both rooted in cwd-relative path resolution:

- **#656** — worker-entry resolution computed the monorepo root from `process.cwd()`, so from a subdir `<cwd>/packages/agent-worker/src/index.ts` didn't exist → fell through to the published CJS `@lobu/worker/dist/index.js` (spawned via `node`), which `require()`s `@mariozechner/pi-coding-agent` — a package whose `exports` map only has an `import` condition → `ERR_PACKAGE_PATH_NOT_EXPORTED` ("No \"exports\" main defined"). Every agent run died immediately. The CJS dist is also a dead end for published non-monorepo `@lobu/cli` installs.
- **#657** — `config/providers.json` resolved relative to `process.cwd()`, so from a subdir the gateway loaded **zero** config-driven providers → the `z-ai` / `Z_AI_API_KEY` mapping never registered → agent runs failed with *"an admin needs to connect zai on the base agent"* even though `Z_AI_API_KEY` was set.

## Changes

- **`packages/server/src/utils/monorepo-root.ts`** (new) — `findEnclosingMonorepoRoot(startDir)`: walk up for a `package.json` with a non-empty `workspaces` field **and** `packages/agent-worker/src/index.ts` underneath (so it doesn't false-positive on unrelated workspace roots). Mirrored as a small local helper in `packages/cli/src/commands/dev.ts` to keep the CLI off a `@lobu/server` dep.
- **`buildEmbeddedWorkerPaths`** (`packages/server/src/gateway/config/index.ts`) — if the passed root lacks the worker entry, resolve the enclosing monorepo root before falling back to the installed `@lobu/worker` package; the published fallback now prefers the package's ESM `src/index.ts` (spawned via `bun run`) over the CJS `dist/index.js`. Explicit `LOBU_WORKER_ENTRYPOINT` still wins over everything.
- **`packages/agent-worker/package.json`** — ship `src/` in `files`; add an `exports` map with a `bun` condition → `./src/index.ts` (mirrors `@lobu/core`). `bun` is already a declared peerDependency.
- **`resolveProviderRegistryPath()`** (`packages/server/src/gateway/services/provider-registry-service.ts`, new) — first-that-exists: `LOBU_PROVIDER_REGISTRY_PATH` (always wins; `http(s)://` URLs pass through), then `<cwd>/config/providers.json` (preserves current behavior), then the bundle-relative `providers.json` shipped next to `server.bundle.mjs` (also copied into `packages/cli/dist/`). No fuzzy ancestor walk-up. `core-services.ts` uses it and logs which path loaded + how many providers came in.
- **`lobu run`** (`packages/cli/src/commands/dev.ts`) — point `LOBU_DEV_PROJECT_PATH` at the enclosing monorepo root (not raw cwd; also silences the harmless `packages/web` Vite-mount warning) and inject `LOBU_PROVIDER_REGISTRY_PATH` at the bundled `providers.json` when present. Both only when the user hasn't already set them (env or project `.env`). Covers both the postgres (`server.bundle.mjs`) and pglite (`start-local.bundle.mjs`) bundle paths.

No backwards-compat shims — the old cwd-relative defaults are replaced outright.

## Validation

- `make build-packages` + CLI build — green; `packages/cli/dist/providers.json` still emitted next to the bundles.
- `bun run typecheck` — green.
- New unit tests: `findEnclosingMonorepoRoot` (server `src/utils/__tests__/monorepo-root.test.ts` + CLI `dev.test.ts`) and `resolveProviderRegistryPath` (extends `provider-registry-service.test.ts`). All pass.
- Worker still loadable: `node -e 'require.resolve("@lobu/worker/package.json")'` ✅, `bun -e 'import("@lobu/worker")'` resolves via the new `bun` condition to `src/index.ts` ✅, `node -e 'require("@lobu/worker")'` ✅ (CJS dist still works as the non-bun fallback).
- Repro trace from `examples/office-bot`: `findEnclosingMonorepoRoot(cwd)` → repo root; `packages/agent-worker/src/index.ts` and `packages/cli/dist/providers.json` both exist there. Not run fully end-to-end (would need to mutate the user's `.env` — which currently has the `LOBU_WORKER_ENTRYPOINT` workaround that, by design, still wins — and start a long-running server against the dev DB); verified statically + via the unit tests.
- Regression: running from the repo root still hits the cwd path; explicit `LOBU_PROVIDER_REGISTRY_PATH` / `LOBU_WORKER_ENTRYPOINT` / `LOBU_DEV_PROJECT_PATH` still take precedence (covered by the resolver/precedence ordering and tests).

Closes #656
Closes #657