### PR TITLE
feat(connections): cross-link devices ↔ connections, waiting-on-device state

### DIFF
--- a/packages/server/src/tools/admin/manage_connections.ts
+++ b/packages/server/src/tools/admin/manage_connections.ts
@@ -531,7 +531,13 @@ async function handleList(
            dw.label AS device_label,
            dw.platform AS device_platform,
            dw.worker_id AS device_worker_handle,
+           dw.last_seen_at AS device_last_seen_at,
            (dw.id IS NOT NULL AND dw.last_seen_at > now() - interval '20 minutes') AS device_online,
+           CASE
+             WHEN c.device_worker_id IS NOT NULL
+              AND NOT (dw.id IS NOT NULL AND dw.last_seen_at > now() - interval '20 minutes')
+             THEN 'offline'
+           END AS device_status,
            (SELECT COUNT(*) FROM current_event_records e WHERE e.connection_id = c.id)::int AS event_count,
            (SELECT COUNT(*) FROM feeds f WHERE f.connection_id = c.id AND f.deleted_at IS NULL)::int AS feed_count,
            (SELECT ct.token FROM connect_tokens ct
@@ -639,7 +645,13 @@ async function handleGet(
            dw.label AS device_label,
            dw.platform AS device_platform,
            dw.worker_id AS device_worker_handle,
+           dw.last_seen_at AS device_last_seen_at,
            (dw.id IS NOT NULL AND dw.last_seen_at > now() - interval '20 minutes') AS device_online,
+           CASE
+             WHEN c.device_worker_id IS NOT NULL
+              AND NOT (dw.id IS NOT NULL AND dw.last_seen_at > now() - interval '20 minutes')
+             THEN 'offline'
+           END AS device_status,
            (SELECT COUNT(*) FROM current_event_records e WHERE e.connection_id = c.id)::int AS event_count
     FROM connections c
     LEFT JOIN LATERAL (

--- a/packages/server/src/tools/admin/manage_feeds.ts
+++ b/packages/server/src/tools/admin/manage_feeds.ts
@@ -155,6 +155,16 @@ async function handleListFeeds(
   let query = sql`
     SELECT f.*, c.connector_key, c.display_name AS connection_name,
            c.status AS connection_status,
+           c.device_worker_id,
+           dw.label AS device_label,
+           dw.platform AS device_platform,
+           dw.last_seen_at AS device_last_seen_at,
+           (dw.id IS NOT NULL AND dw.last_seen_at > now() - interval '20 minutes') AS device_online,
+           CASE
+             WHEN c.device_worker_id IS NOT NULL
+              AND NOT (dw.id IS NOT NULL AND dw.last_seen_at > now() - interval '20 minutes')
+             THEN 'offline'
+           END AS device_status,
            cd.name AS connector_name,
            ap.profile_kind AS auth_profile_kind,
            ap.status AS auth_profile_status,
@@ -167,6 +177,7 @@ async function handleListFeeds(
            (SELECT COUNT(*) FROM current_event_records e WHERE e.connection_id = f.connection_id AND e.feed_key = f.feed_key)::int AS event_count
     FROM feeds f
     JOIN connections c ON c.id = f.connection_id
+    LEFT JOIN device_workers dw ON dw.id = c.device_worker_id
     LEFT JOIN LATERAL (
       SELECT name
       FROM connector_definitions

--- a/packages/server/src/worker-api.ts
+++ b/packages/server/src/worker-api.ts
@@ -1485,7 +1485,30 @@ export async function listDeviceWorkers(c: Context<{ Bindings: Env }>) {
           SELECT max(f.last_sync_at) FROM feeds f
           JOIN connections cn ON cn.id = f.connection_id
           WHERE cn.device_worker_id = dw.id AND f.deleted_at IS NULL
-        ) AS last_sync_at
+        ) AS last_sync_at,
+        (
+          SELECT coalesce(
+            json_agg(
+              json_build_object(
+                'connection_id', cn.id,
+                'connector_key', cn.connector_key,
+                'display_name', coalesce(cd.name, cn.connector_key),
+                'status', cn.status,
+                'organization_slug', cno.slug
+              )
+              ORDER BY cn.created_at
+            ),
+            '[]'::json
+          )
+          FROM connections cn
+          LEFT JOIN organization cno ON cno.id = cn.organization_id
+          LEFT JOIN LATERAL (
+            SELECT name FROM connector_definitions
+            WHERE key = cn.connector_key AND status = 'active' AND organization_id = cn.organization_id
+            ORDER BY updated_at DESC LIMIT 1
+          ) cd ON TRUE
+          WHERE cn.device_worker_id = dw.id AND cn.deleted_at IS NULL
+        ) AS connectors
       FROM device_workers dw
       LEFT JOIN organization o ON o.id = dw.organization_id
       WHERE dw.user_id = ${userId}
@@ -1505,6 +1528,13 @@ export async function listDeviceWorkers(c: Context<{ Bindings: Env }>) {
       connector_count: number;
       connector_error_count: number;
       last_sync_at: string | null;
+      connectors: Array<{
+        connection_id: number;
+        connector_key: string;
+        display_name: string;
+        status: string;
+        organization_slug: string | null;
+      }>;
     }>;
     return c.json({
       devices: rows.map((r) => ({
@@ -1522,6 +1552,7 @@ export async function listDeviceWorkers(c: Context<{ Bindings: Env }>) {
         connector_count: r.connector_count ?? 0,
         connector_error_count: r.connector_error_count ?? 0,
         last_sync_at: r.last_sync_at,
+        connectors: Array.isArray(r.connectors) ? r.connectors : [],
       })),
     });
   } catch (err: unknown) {


### PR DESCRIPTION
Polish for #597 — most of the device-binding work shipped in #587 / #620 / #662 (the `connections.device_worker_id` FK, capability-gated + pinned claim path, `reconcileDeviceCapabilities()` auto-wire, the `/devices` page, the "Run on" picker). This PR adds the remaining cross-linking + waiting-on-device UI.

## What changed

**Server (read-time joins only — no migration):**
- `GET /api/me/devices` now returns a small `connectors: [{ connection_id, connector_key, display_name, status, organization_slug }]` array per device, alongside the existing `connector_count`.
- `manage_connections` `list`/`get`: return `device_last_seen_at`, and derive `device_status: 'offline'` when the connection is pinned to a device (`device_worker_id IS NOT NULL`) that hasn't checked in within 20 min.
- `manage_feeds` `list_feeds`: join `device_workers` so feed rows carry the parent connection's `device_worker_id` / `device_label` / `device_platform` / `device_last_seen_at` / `device_online` / `device_status`.

**Web (`packages/web` submodule bump → owletto-web `main` 7e73aa3):**
- `/devices` page: each device's pinned connectors now render as router `<Link>`s into `/$owner/connectors/$connectorKey` (instead of a bare count).
- Connection detail (`connector-detail-view.tsx`): the "On <device>" badge is now a `<Link>` to `/$owner/devices`; when the bound device is offline it becomes a non-destructive `secondary` "Waiting for <device> to come online" badge.
- Connection sheet header: shows "Connected through <device> · last seen 3h ago" (or "· offline"), device name links to `/$owner/devices`.
- Feed rows (`feed-expanded-row.tsx`): same non-error waiting-on-device badge.

Follows DESIGN_GUIDELINES (rounded-lg badges, no dashed borders, no modal confirms, secondary variant for the non-error waiting state).

## #615

Item 4 ("Lobu Cloud pool offline" parity) was **deferred**: there is no existing liveness signal for the cloud `connector-worker` pool — `last_heartbeat_at` is per-run, there's no worker-registry / last-poll row for trusted server workers, and the brief said not to build one or add k8s calls. Follow-up: when a cloud-worker liveness signal exists (heartbeat row or last-poll timestamp), surface a "Lobu Cloud" pseudo-entry with a "waiting — cloud pool offline" state mirroring the device case.

Item 5 ("pick which device owns <connector>" nudge) was also deferred — it's more than a small banner (needs to derive unpinned-but-required-capability connections with >1 eligible fresh device, plus wire to the existing "Run on" picker). Worth a small follow-up.

## Validation
- `cd packages/web && bun run build` — passes (tsc -b + vite build).
- `make build-packages` + `bun run typecheck` at repo root — passes.
- Biome: no new lint errors in touched files (pre-existing repo-wide warnings only).
- Not browser-verified from the worktree; verified statically — single-device auto-wire is unchanged (no changes to `reconcileDeviceCapabilities` or the claim path; the new fields are additive and `device_status` is `null` for unpinned/serverless connections).

Closes #597