### PR TITLE
fix: bug-fix sweep

### DIFF
--- a/packages/agent-worker/src/embedded/just-bash-bootstrap.ts
+++ b/packages/agent-worker/src/embedded/just-bash-bootstrap.ts
@@ -314,12 +314,40 @@ async function buildCustomCommands(
               cwd: hostCwd,
               env: envRecord as NodeJS.ProcessEnv,
               maxBuffer: 10 * 1024 * 1024,
+              // Hung binaries (credential prompts, stalled network reads,
+              // waiting on stdin) must not freeze the agent turn forever.
+              timeout: 120_000,
+              killSignal: "SIGKILL",
             },
             (error, stdout, stderr) => {
+              // A signal-killed child leaves error.code null/undefined and sets
+              // error.signal — that must NOT be reported as exit code 0.
+              const err = error as
+                | (NodeJS.ErrnoException & {
+                    signal?: NodeJS.Signals;
+                    killed?: boolean;
+                  })
+                | null;
+              let exitCode: number;
+              if (!err) {
+                exitCode = 0;
+              } else if (typeof err.code === "number") {
+                exitCode = err.code;
+              } else if (err.killed || err.signal) {
+                exitCode = 137;
+              } else {
+                exitCode = 1;
+              }
+              const timedOut =
+                !!err && (err.killed || err.signal === "SIGKILL");
               resolve({
                 stdout: stdout || "",
-                stderr: stderr || (error?.message ?? ""),
-                exitCode: error?.code ? Number(error.code) || 1 : 0,
+                stderr:
+                  stderr ||
+                  (timedOut
+                    ? `command timed out after 120s and was killed`
+                    : (err?.message ?? "")),
+                exitCode,
               });
             }
           );

--- a/packages/agent-worker/src/gateway/sse-client.ts
+++ b/packages/agent-worker/src/gateway/sse-client.ts
@@ -163,6 +163,12 @@ export class GatewayClient {
         await this.handleReconnect();
       }
     }
+    if (this.reconnectsExhausted) {
+      // Don't return normally — a caller that logs "started successfully" and
+      // then awaits forever would leave a zombie process holding its
+      // workspace/port that never receives jobs and never exits.
+      throw new Error("Gateway worker exhausted reconnect attempts");
+    }
   }
 
   private async connectAndListen(): Promise<void> {
@@ -312,9 +318,12 @@ export class GatewayClient {
     });
   }
 
+  private reconnectsExhausted = false;
+
   private async handleReconnect(): Promise<void> {
     if (this.reconnectAttempts >= this.maxReconnectAttempts) {
       logger.error("Max reconnection attempts reached, giving up");
+      this.reconnectsExhausted = true;
       this.isRunning = false;
       return;
     }

--- a/packages/agent-worker/src/openclaw/worker.ts
+++ b/packages/agent-worker/src/openclaw/worker.ts
@@ -1376,6 +1376,11 @@ Use it when the user references past discussions or you need context.`);
                 clearInterval(heartbeatTimer);
                 heartbeatTimer = null;
               }
+              // Unblock any in-flight prompt turn FIRST — disposing the session
+              // without resolving `turnDone` leaves `runPromptTurn` (and the
+              // outer `runAISession`) wedged on `await turnDone` until the
+              // deployment manager force-kills the worker.
+              resolveTurnDone?.();
               if (session) {
                 session.dispose();
               }

--- a/packages/agent-worker/src/shared/tool-implementations.ts
+++ b/packages/agent-worker/src/shared/tool-implementations.ts
@@ -60,11 +60,22 @@ async function gatewayFetch<T>(
     headers["Content-Type"] = "application/json";
   }
 
-  const response = await fetch(`${gw.gatewayUrl}${urlPath}`, {
-    method,
-    headers,
-    body,
-  });
+  let response: Response;
+  try {
+    response = await fetch(`${gw.gatewayUrl}${urlPath}`, {
+      method,
+      headers,
+      body,
+      // A stalled gateway must not hang the agent turn indefinitely.
+      signal: AbortSignal.timeout(60_000),
+    });
+  } catch (err) {
+    if (err instanceof Error && err.name === "TimeoutError") {
+      logger.error(`${errorPrefix}: request timed out`);
+      return { error: textResult(`Error: ${errorPrefix} (timed out)`) };
+    }
+    throw err;
+  }
 
   if (!response.ok) {
     const errorData = await parseErrorBody(response);
@@ -881,17 +892,28 @@ export async function callMcpTool(
   args: Record<string, unknown>
 ): Promise<TextResult> {
   return withErrorHandling(`${mcpId}/${toolName}`, async () => {
-    const response = await fetch(
-      `${gw.gatewayUrl}/mcp/${mcpId}/tools/${toolName}`,
-      {
-        method: "POST",
-        headers: {
-          Authorization: `Bearer ${gw.workerToken}`,
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify(args),
+    let response: Response;
+    try {
+      response = await fetch(
+        `${gw.gatewayUrl}/mcp/${mcpId}/tools/${toolName}`,
+        {
+          method: "POST",
+          headers: {
+            Authorization: `Bearer ${gw.workerToken}`,
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify(args),
+          // Third-party MCP server on the other side — give it a generous
+          // budget but never wait forever.
+          signal: AbortSignal.timeout(120_000),
+        }
+      );
+    } catch (err) {
+      if (err instanceof Error && err.name === "TimeoutError") {
+        return textResult(`Error: MCP tool ${mcpId}/${toolName} timed out`);
       }
-    );
+      throw err;
+    }
 
     const data = (await response.json()) as {
       content?: Array<{ type: string; text: string }>;

--- a/packages/cli/src/commands/chat.ts
+++ b/packages/cli/src/commands/chat.ts
@@ -436,6 +436,7 @@ async function streamResponse(
               `${JSON.stringify({ event: currentEvent, ...data })}\n`
             );
             if (currentEvent === "complete" || currentEvent === "error") {
+              if (currentEvent === "error") process.exitCode = 1;
               controller.abort();
               return;
             }
@@ -569,6 +570,9 @@ async function streamResponse(
               await writeStderr(
                 chalk.red(`\n  Agent error: ${String(data.error)}\n`)
               );
+              // Surface the failure to the shell — a script wrapping `lobu chat`
+              // must not see exit 0 when the agent run errored.
+              process.exitCode = 1;
               controller.abort();
               return;
           }

--- a/packages/cli/src/commands/eval.ts
+++ b/packages/cli/src/commands/eval.ts
@@ -191,12 +191,25 @@ export async function evalCommand(
         );
         process.exit(1);
       }
-      console.error(chalk.red(`\n  Eval "${def.name}" failed: ${msg}\n`));
+      console.error(chalk.red(`\n  Eval "${def.name}" crashed: ${msg}\n`));
+      // Record a synthetic failed result so the crash counts toward total/failed
+      // instead of silently disappearing from the report (false CI green).
+      results.push({
+        name: def.name,
+        passRate: 0,
+        avgScore: 0,
+        p50LatencyMs: 0,
+        totalTokens: {},
+        trials: [],
+        error: msg,
+      });
     }
   }
 
   // Build report
-  const passedEvals = results.filter((r) => r.passRate >= 0.8).length;
+  const passedEvals = results.filter(
+    (r) => r.passRate >= 0.8 && !r.error
+  ).length;
 
   const report: EvalReport = {
     agent: agentId,

--- a/packages/cli/src/eval/types.ts
+++ b/packages/cli/src/eval/types.ts
@@ -89,6 +89,8 @@ export interface EvalResult {
   p50LatencyMs: number;
   totalTokens: TokenUsage;
   trials: TrialResult[];
+  /** Set when the eval crashed before producing trials — counts as a failure. */
+  error?: string;
 }
 
 export interface EvalReport {

--- a/packages/connector-sdk/src/browser-network.ts
+++ b/packages/connector-sdk/src/browser-network.ts
@@ -84,23 +84,30 @@ async function acquireForNetworkSync(
       const { chromium } = await import(/* @vite-ignore */ playwrightModule);
       const browser: Browser = await chromium.connectOverCDP(wsUrl);
 
-      // Use the default context (user's session) — don't create a new context
-      // which crashes on browsers with many tabs
-      const context = browser.contexts()[0] as BrowserContext;
-      if (!context) throw new Error('Chrome has no browser context');
+      try {
+        // Use the default context (user's session) — don't create a new context
+        // which crashes on browsers with many tabs
+        const context = browser.contexts()[0] as BrowserContext;
+        if (!context) throw new Error('Chrome has no browser context');
 
-      const page = await context.newPage();
+        const page = await context.newPage();
 
-      sdkLogger.info({ wsUrl }, '[BrowserNetwork] Connected via CDP');
+        sdkLogger.info({ wsUrl }, '[BrowserNetwork] Connected via CDP');
 
-      return {
-        browser,
-        context,
-        page,
-        backend: 'cdp',
-        ownsBrowser: false,
-        screenshotDir: '/tmp/feed-screenshots',
-      };
+        return {
+          browser,
+          context,
+          page,
+          backend: 'cdp',
+          ownsBrowser: false,
+          screenshotDir: '/tmp/feed-screenshots',
+        };
+      } catch (innerErr) {
+        // Partial setup after connectOverCDP — close the CDP connection before
+        // falling through to the Playwright branch so it isn't left dangling.
+        await browser.close().catch(() => {});
+        throw innerErr;
+      }
     } catch (err: any) {
       sdkLogger.info(
         { error: err.message },
@@ -111,21 +118,26 @@ async function acquireForNetworkSync(
 
   // --- Layer 2: Playwright with stored cookies ---
   const { browser, screenshotDir } = await launchBrowser({ stealth });
-  const context = (await (browser as Browser).newContext()) as BrowserContext;
-  if (cookies.length > 0) {
-    await context.addCookies(cookies);
-    sdkLogger.info({ count: cookies.length }, '[BrowserNetwork] Loaded persisted cookies');
-  }
-  const page = await context.newPage();
+  try {
+    const context = (await (browser as Browser).newContext()) as BrowserContext;
+    if (cookies.length > 0) {
+      await context.addCookies(cookies);
+      sdkLogger.info({ count: cookies.length }, '[BrowserNetwork] Loaded persisted cookies');
+    }
+    const page = await context.newPage();
 
-  return {
-    browser: browser as Browser,
-    context,
-    page,
-    backend: 'playwright',
-    ownsBrowser: true,
-    screenshotDir,
-  };
+    return {
+      browser: browser as Browser,
+      context,
+      page,
+      backend: 'playwright',
+      ownsBrowser: true,
+      screenshotDir,
+    };
+  } catch (err) {
+    await (browser as Browser).close().catch(() => {});
+    throw err;
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/connector-sdk/src/browser/acquire.ts
+++ b/packages/connector-sdk/src/browser/acquire.ts
@@ -141,26 +141,32 @@ async function acquireViaPlaywright(opts: AcquireBrowserOptions): Promise<Acquir
     stealth: opts.stealth ?? false,
   });
 
-  const context = (await (browser as Browser).newContext()) as BrowserContext;
-  if (opts.cookies.length > 0) {
-    await context.addCookies(opts.cookies);
+  try {
+    const context = (await (browser as Browser).newContext()) as BrowserContext;
+    if (opts.cookies.length > 0) {
+      await context.addCookies(opts.cookies);
+    }
+
+    sdkLogger.info(
+      { cookies: opts.cookies.length },
+      '[BrowserAcquire] Launched Playwright with stored cookies'
+    );
+
+    const page = await context.newPage();
+
+    return {
+      browser: browser as Browser,
+      context,
+      page,
+      cdpPage: null,
+      cdpWsUrl: null,
+      backend: 'playwright',
+      ownsBrowser: true,
+      screenshotDir,
+    };
+  } catch (err) {
+    // newContext/addCookies/newPage threw — don't leak the launched browser.
+    await (browser as Browser).close().catch(() => {});
+    throw err;
   }
-
-  sdkLogger.info(
-    { cookies: opts.cookies.length },
-    '[BrowserAcquire] Launched Playwright with stored cookies'
-  );
-
-  const page = await context.newPage();
-
-  return {
-    browser: browser as Browser,
-    context,
-    page,
-    cdpPage: null,
-    cdpWsUrl: null,
-    backend: 'playwright',
-    ownsBrowser: true,
-    screenshotDir,
-  };
 }

--- a/packages/connector-sdk/src/browser/cdp-page.ts
+++ b/packages/connector-sdk/src/browser/cdp-page.ts
@@ -58,19 +58,39 @@ export class CdpPage {
       });
     };
 
-    const { targetId } = await sendBrowser('Target.createTarget', { url: 'about:blank' });
-    const { sessionId } = await sendBrowser('Target.attachToTarget', {
-      targetId,
-      flatten: true,
-    });
+    let createdTargetId: string | undefined;
+    try {
+      const { targetId } = await sendBrowser('Target.createTarget', { url: 'about:blank' });
+      createdTargetId = targetId;
+      const { sessionId } = await sendBrowser('Target.attachToTarget', {
+        targetId,
+        flatten: true,
+      });
 
-    const page = new CdpPage(ws, sessionId, targetId);
-    await page.send('Page.enable');
-    await page.send('Runtime.enable');
-    await page.send('DOM.enable');
+      const page = new CdpPage(ws, sessionId, targetId);
+      await page.send('Page.enable');
+      await page.send('Runtime.enable');
+      await page.send('DOM.enable');
 
-    sdkLogger.info({ targetId }, '[CdpPage] Created tab');
-    return page;
+      sdkLogger.info({ targetId }, '[CdpPage] Created tab');
+      return page;
+    } catch (err) {
+      // Setup failed after the socket opened — close the target (if created)
+      // and the WebSocket so we don't leak the connection on the host.
+      if (createdTargetId) {
+        try {
+          await sendBrowser('Target.closeTarget', { targetId: createdTargetId });
+        } catch {
+          /* best-effort */
+        }
+      }
+      try {
+        ws.close();
+      } catch {
+        /* best-effort */
+      }
+      throw err;
+    }
   }
 
   private send(method: string, params: Record<string, unknown> = {}): Promise<any> {
@@ -97,7 +117,6 @@ export class CdpPage {
 
     // Wait for load event
     await new Promise<void>((resolve) => {
-      const timer = setTimeout(() => resolve(), timeout);
       const handler = (event: MessageEvent) => {
         const data = JSON.parse(event.data as string);
         if (data.method === 'Page.loadEventFired' && data.sessionId === this.sessionId) {
@@ -106,6 +125,12 @@ export class CdpPage {
           resolve();
         }
       };
+      const timer = setTimeout(() => {
+        // On timeout, detach the listener so it doesn't stay attached for the
+        // life of the (long-lived) CDP session parsing every subsequent frame.
+        this.ws.removeEventListener('message', handler);
+        resolve();
+      }, timeout);
       this.ws.addEventListener('message', handler);
     });
   }

--- a/packages/connector-worker/src/daemon/executor.ts
+++ b/packages/connector-worker/src/daemon/executor.ts
@@ -47,19 +47,15 @@ export async function executeRun(
     return executeActionRun(client, job, env, cfg);
   }
   if (job.run_type === 'watcher') {
-    // Watcher reactions now execute inline in the API process (complete_window).
-    // If a legacy pending watcher run is polled, mark it as completed to clean up.
-    // Note: stuck runs older than the poll interval will be picked up here automatically.
+    // Watcher reactions execute inline in the API process (complete_window) and
+    // the poll endpoint's run_type allowlist should never hand a watcher run to
+    // this daemon. If one slips through (deploy skew, regression), do NOT mark
+    // it success — that would stomp a live watcher run and prevent any retry.
+    // Log loudly and skip; the server's heartbeat reaper / inline path owns it.
     console.error(
-      `[executor] Cleaning up legacy watcher run ${job.run_id} — reactions now execute inline`
+      `[executor] Refusing to handle watcher run ${job.run_id} — watcher runs must not reach the connector-worker daemon`
     );
-    await client.complete({
-      run_id: job.run_id!,
-      worker_id: client.id,
-      status: 'success',
-      items_collected: 0,
-    });
-    return { itemsCollected: 0 };
+    return { itemsCollected: 0, error: 'watcher run not handled by daemon' };
   }
   if (job.run_type === 'embed_backfill') {
     return executeEmbedBackfillRun(client, job, env);

--- a/packages/connectors/src/google_calendar.ts
+++ b/packages/connectors/src/google_calendar.ts
@@ -256,8 +256,11 @@ export default class GoogleCalendarConnector extends ConnectorRuntime {
     let nextSyncToken: string | undefined;
 
     while (true) {
+      // Always request a full page — `maxResults` is a soft cap on *stored*
+      // events, not a reason to shrink the request size (shrinking to 1 once the
+      // cap is hit would crawl a busy calendar one event per round-trip).
       const params = new URLSearchParams({
-        maxResults: String(Math.max(1, Math.min(250, maxResults - events.length))),
+        maxResults: '250',
         orderBy: 'startTime',
         singleEvents: 'true',
         timeMin: timeMin.toISOString(),
@@ -280,6 +283,7 @@ export default class GoogleCalendarConnector extends ConnectorRuntime {
 
       if (data.items) {
         for (const calEvent of data.items) {
+          if (events.length >= maxResults) break;
           const envelope = this.calendarEventToEnvelope(calEvent);
           if (envelope) events.push(envelope);
         }
@@ -290,7 +294,8 @@ export default class GoogleCalendarConnector extends ConnectorRuntime {
       // Google only returns nextSyncToken on the LAST page (no nextPageToken).
       // Must keep paginating until pageToken is exhausted, otherwise the sync
       // token is never obtained and every subsequent sync re-runs the full
-      // window from scratch. maxResults is only a soft cap on stored events.
+      // window from scratch — so we keep paging past `maxResults`, just stop
+      // appending events once the cap is reached.
       if (!pageToken) break;
     }
 

--- a/packages/connectors/src/google_calendar.ts
+++ b/packages/connectors/src/google_calendar.ts
@@ -257,7 +257,7 @@ export default class GoogleCalendarConnector extends ConnectorRuntime {
 
     while (true) {
       const params = new URLSearchParams({
-        maxResults: String(Math.min(250, maxResults - events.length)),
+        maxResults: String(Math.max(1, Math.min(250, maxResults - events.length))),
         orderBy: 'startTime',
         singleEvents: 'true',
         timeMin: timeMin.toISOString(),
@@ -287,7 +287,11 @@ export default class GoogleCalendarConnector extends ConnectorRuntime {
 
       nextSyncToken = data.nextSyncToken;
       pageToken = data.nextPageToken;
-      if (!pageToken || events.length >= maxResults) break;
+      // Google only returns nextSyncToken on the LAST page (no nextPageToken).
+      // Must keep paginating until pageToken is exhausted, otherwise the sync
+      // token is never obtained and every subsequent sync re-runs the full
+      // window from scratch. maxResults is only a soft cap on stored events.
+      if (!pageToken) break;
     }
 
     return this.buildResult(events, nextSyncToken, events.length);
@@ -343,7 +347,7 @@ export default class GoogleCalendarConnector extends ConnectorRuntime {
 
     while (true) {
       const params = new URLSearchParams({
-        maxResults: String(Math.min(250, maxResults - events.length)),
+        maxResults: String(Math.max(1, Math.min(250, maxResults - events.length))),
         syncToken,
       });
       if (pageToken) {
@@ -375,7 +379,8 @@ export default class GoogleCalendarConnector extends ConnectorRuntime {
 
       nextSyncToken = data.nextSyncToken;
       pageToken = data.nextPageToken;
-      if (!pageToken || events.length >= maxResults) break;
+      // Paginate until exhausted so we capture the trailing nextSyncToken.
+      if (!pageToken) break;
     }
 
     return { events, nextSyncToken };

--- a/packages/connectors/src/google_gmail.ts
+++ b/packages/connectors/src/google_gmail.ts
@@ -274,8 +274,11 @@ export default class GmailConnector extends ConnectorRuntime {
           return d;
         })();
 
-    const afterStr = `${afterDate.getFullYear()}/${String(afterDate.getMonth() + 1).padStart(2, '0')}/${String(afterDate.getDate()).padStart(2, '0')}`;
-    const query = `after:${afterStr} label:${label}`;
+    // Gmail's `after:` accepts a Unix timestamp (epoch seconds) for second-level
+    // precision. Using `YYYY/MM/DD` (day granularity, host timezone) meant every
+    // sync within the same day re-fetched the whole day's threads as duplicates.
+    const afterEpochSeconds = Math.floor(afterDate.getTime() / 1000);
+    const query = `after:${afterEpochSeconds} label:${label}`;
 
     const events: EventEnvelope[] = [];
     let pageToken: string | undefined;

--- a/packages/connectors/src/google_play.ts
+++ b/packages/connectors/src/google_play.ts
@@ -73,9 +73,16 @@ interface RawReview {
  */
 function parseDate(dateArray: unknown): string | null {
   if (!Array.isArray(dateArray)) return null;
-  const milliStr = String(dateArray[1] ?? '000');
-  const totalMs = `${dateArray[0]}${milliStr.substring(0, 3)}`;
-  return new Date(Number(totalMs)).toJSON();
+  // Compute numerically: seconds*1000 + millis. The previous string-concat
+  // approach (`${seconds}${millis}`) only worked when millis was a 3-digit
+  // zero-padded string; Google sends a plain integer, so e.g. `[s, 5]` produced
+  // a date in 1970 and `[s, 50]` a date in year ~7340.
+  const seconds = Number(dateArray[0]);
+  const millis = Number(dateArray[1] ?? 0);
+  if (!Number.isFinite(seconds) || !Number.isFinite(millis)) return null;
+  const d = new Date(seconds * 1000 + millis);
+  if (Number.isNaN(d.getTime())) return null;
+  return d.toJSON();
 }
 
 /**

--- a/packages/core/src/__tests__/sanitize.test.ts
+++ b/packages/core/src/__tests__/sanitize.test.ts
@@ -123,6 +123,18 @@ describe("sanitizeForLogging", () => {
     expect(result.env.TOKEN).toBe("[REDACTED:6]");
   });
 
+  test("handles circular references without overflowing the stack", () => {
+    const obj: Record<string, unknown> = { name: "safe", token: "secret" };
+    obj.self = obj;
+    const nested: Record<string, unknown> = { parent: obj };
+    obj.child = nested;
+    const result = sanitizeForLogging(obj);
+    expect(result.name).toBe("safe");
+    expect(result.token).toBe("[REDACTED:6]");
+    expect(result.self).toBe("[Circular]");
+    expect(result.child.parent).toBe("[Circular]");
+  });
+
   test("handles arrays (recurses into elements)", () => {
     const arr = [{ token: "secret" }, { name: "safe" }];
     const result = sanitizeForLogging(arr);

--- a/packages/core/src/utils/retry.ts
+++ b/packages/core/src/utils/retry.ts
@@ -73,9 +73,24 @@ export async function retryWithBackoff<T>(
     } catch (error) {
       lastError = error as Error;
 
-      // Allow caller to abort on non-retryable errors.
-      if (shouldRetry && !shouldRetry(lastError, attempt + 1)) {
-        throw lastError;
+      // Allow caller to abort on non-retryable errors. A buggy predicate that
+      // throws must not mask the real error or skip remaining retries — log and
+      // fall back to the default (retry).
+      if (shouldRetry) {
+        let allowRetry = true;
+        try {
+          allowRetry = shouldRetry(lastError, attempt + 1);
+        } catch (predicateError) {
+          logger.warn("shouldRetry predicate threw; defaulting to retry", {
+            error:
+              predicateError instanceof Error
+                ? predicateError.message
+                : String(predicateError),
+          });
+        }
+        if (!allowRetry) {
+          throw lastError;
+        }
       }
 
       if (attempt < maxRetries) {
@@ -101,9 +116,18 @@ export async function retryWithBackoff<T>(
           finalDelay = delay;
         }
 
-        // Notify caller of retry
+        // Notify caller of retry — isolate a throwing callback.
         if (onRetry) {
-          onRetry(attempt + 1, lastError);
+          try {
+            onRetry(attempt + 1, lastError);
+          } catch (callbackError) {
+            logger.warn("onRetry callback threw", {
+              error:
+                callbackError instanceof Error
+                  ? callbackError.message
+                  : String(callbackError),
+            });
+          }
         } else {
           logger.warn(
             `Retry attempt ${attempt + 1}/${maxRetries} after ${Math.round(finalDelay)}ms`,

--- a/packages/core/src/utils/sanitize.ts
+++ b/packages/core/src/utils/sanitize.ts
@@ -97,10 +97,18 @@ function isSensitiveKey(
 function sanitizeInner(
   obj: any,
   additionalLowered: readonly string[],
-  depth: number
+  depth: number,
+  seen: WeakSet<object>
 ): any {
   if (!obj || typeof obj !== "object") return obj;
   if (depth >= MAX_SANITIZE_DEPTH) return obj;
+  // Cycle guard: object graphs with back-references (Express req/res, error
+  // .cause chains, ORM rows) would otherwise recurse forever. Depth cap above
+  // already bounds stack depth, but returning "[Circular]" gives a more useful
+  // log line and avoids cloning the same subtree N times for a graph with
+  // multiple paths to the same node.
+  if (seen.has(obj as object)) return "[Circular]";
+  seen.add(obj as object);
 
   const sanitized = Array.isArray(obj) ? [...obj] : { ...obj };
 
@@ -111,7 +119,7 @@ function sanitizeInner(
         sanitized[key] = `[REDACTED:${value.length}]`;
       }
     } else if (value && typeof value === "object") {
-      sanitized[key] = sanitizeInner(value, additionalLowered, depth + 1);
+      sanitized[key] = sanitizeInner(value, additionalLowered, depth + 1, seen);
     }
   }
 
@@ -126,7 +134,7 @@ export function sanitizeForLogging(
     return obj;
   }
   const additionalLowered = additionalSensitiveKeys.map((k) => k.toLowerCase());
-  return sanitizeInner(obj, additionalLowered, 0);
+  return sanitizeInner(obj, additionalLowered, 0, new WeakSet());
 }
 
 /**

--- a/packages/core/src/worker/auth.ts
+++ b/packages/core/src/worker/auth.ts
@@ -98,6 +98,13 @@ export function verifyWorkerToken(token: string): WorkerTokenData | null {
       logger.error("Worker token rejected: expired");
       return null;
     }
+    // Also reject tokens whose timestamp is implausibly in the future — a
+    // forward skew larger than the tolerance would otherwise grant an
+    // effectively unbounded validity window.
+    if (data.timestamp - Date.now() > skewMs) {
+      logger.error("Worker token rejected: timestamp in the future");
+      return null;
+    }
 
     return data;
   } catch (error) {

--- a/packages/embeddings/src/embeddings.ts
+++ b/packages/embeddings/src/embeddings.ts
@@ -31,8 +31,13 @@ async function getExtractor(): Promise<FeatureExtractionPipeline> {
     console.log(`[EmbeddingsService] Loading model: ${modelName}...`);
     const startTime = Date.now();
 
+    // Don't cache a rejected promise — a transient model-load failure would
+    // otherwise permanently brick the embeddings backend until process restart.
     extractorPromise = pipeline('feature-extraction', modelName, {
       quantized: true,
+    }).catch((err) => {
+      extractorPromise = null;
+      throw err;
     });
 
     const extractor = await extractorPromise;

--- a/packages/openclaw-plugin/src/index.ts
+++ b/packages/openclaw-plugin/src/index.ts
@@ -1407,35 +1407,52 @@ const plugin = {
     if (config.autoCapture) {
       let lastCapturedLen = 0;
 
-      on('before_prompt_build', async (event: Record<string, unknown>) => {
+      const messageText = (m: unknown): string => {
+        if (!isRecord(m)) return '';
+        if (typeof m.content === 'string') return m.content;
+        if (Array.isArray(m.content)) {
+          return m.content
+            .filter((p: unknown) => isRecord(p) && p.type === 'text')
+            .map((p: unknown) => (isRecord(p) && typeof p.text === 'string' ? p.text : ''))
+            .join('\n');
+        }
+        return '';
+      };
+
+      // Run on `agent_end` — the turn is complete and `messages` ends with the
+      // assistant reply. (The worker's plugin-loader only honors
+      // before_agent_start / agent_end; a before_prompt_build registration was
+      // silently dropped, so autoCapture never ran inside Lobu.)
+      on('agent_end', async (event: Record<string, unknown>) => {
         if (!hasAuthConfigured(config)) return;
 
         const messages = event.messages;
         if (!Array.isArray(messages) || messages.length < 2) return;
-        // Only capture when new messages appeared since last capture
         if (messages.length <= lastCapturedLen) return;
 
-        // Find the most recent assistant+user pair (the previous turn)
-        let lastUser: string | null = null;
-        let lastAssistant: string | null = null;
+        // Find the last assistant message, then the user message immediately
+        // before it — pairing the answer with the question that prompted it
+        // (not a trailing unanswered user message with the previous reply).
+        let assistantIdx = -1;
         for (let i = messages.length - 1; i >= 0; i--) {
-          const m = messages[i];
-          if (!isRecord(m)) continue;
-          const text =
-            typeof m.content === 'string'
-              ? m.content
-              : Array.isArray(m.content)
-                ? m.content
-                    .filter((p: unknown) => isRecord(p) && p.type === 'text')
-                    .map((p: unknown) => (isRecord(p) && typeof p.text === 'string' ? p.text : ''))
-                    .join('\n')
-                : '';
-          if (!text.trim()) continue;
-          if (m.role === 'assistant' && !lastAssistant) lastAssistant = text.trim();
-          if (m.role === 'user' && !lastUser) lastUser = text.trim();
-          if (lastUser && lastAssistant) break;
+          if (isRecord(messages[i]) && (messages[i] as Record<string, unknown>).role === 'assistant') {
+            const t = messageText(messages[i]);
+            if (t.trim()) { assistantIdx = i; break; }
+          }
         }
+        if (assistantIdx < 1) return;
 
+        let userIdx = -1;
+        for (let i = assistantIdx - 1; i >= 0; i--) {
+          if (isRecord(messages[i]) && (messages[i] as Record<string, unknown>).role === 'user') {
+            const t = messageText(messages[i]);
+            if (t.trim()) { userIdx = i; break; }
+          }
+        }
+        if (userIdx < 0) return;
+
+        const lastUser = messageText(messages[userIdx]).trim();
+        const lastAssistant = messageText(messages[assistantIdx]).trim();
         if (!lastUser || !lastAssistant) return;
 
         const combined = `User: ${lastUser}\nAssistant: ${lastAssistant}`;
@@ -1444,7 +1461,7 @@ const plugin = {
         lastCapturedLen = messages.length;
         const content = combined.length > 2000 ? combined.slice(0, 2000) : combined;
 
-        // Fire-and-forget — don't block prompt build
+        // Fire-and-forget — don't block the agent_end path.
         callMcpTool(config, 'save_memory', {
           content,
           semantic_type: 'observation',

--- a/packages/server/src/__tests__/setup/test-db.ts
+++ b/packages/server/src/__tests__/setup/test-db.ts
@@ -270,7 +270,7 @@ async function fixSchemaConstraints(db: postgres.Sql): Promise<void> {
       ALTER TABLE IF EXISTS runs ADD CONSTRAINT runs_run_type_check
         CHECK (run_type IN (
           'sync','action','watcher','embed_backfill','auth',
-          'chat_message','schedule','agent_run','internal'
+          'chat_message','schedule','agent_run','internal','task'
         ));
     `);
     // connections.status needs 'pending_auth'

--- a/packages/server/src/__tests__/unit/sandbox/action-call.test.ts
+++ b/packages/server/src/__tests__/unit/sandbox/action-call.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { createActionCaller } from "../action-call";
+import { createActionCaller } from "../../../sandbox/namespaces/action-call";
 
 describe("createActionCaller", () => {
   it("forces the action discriminator, ignoring a caller-supplied `action` key", async () => {

--- a/packages/server/src/auth/oauth/routes.ts
+++ b/packages/server/src/auth/oauth/routes.ts
@@ -17,6 +17,7 @@ import { OAuthProvider } from './provider';
 import { DEFAULT_SCOPES_STRING, filterScopeByRole } from './scopes';
 import type { AuthorizationParams, OAuthClientMetadata, TokenRequestParams } from './types';
 import { createOAuthError, validateRedirectUri } from './utils';
+import { getConfiguredPublicOrigin } from '../../utils/public-origin';
 
 const oauthRoutes = new Hono<{ Bindings: Env }>();
 
@@ -278,8 +279,11 @@ oauthRoutes.get('/.well-known/oauth-authorization-server', (c) => {
 oauthRoutes.post('/oauth/register', async (c) => {
   const provider = getProvider(c);
 
-  // Rate limit client registrations
-  if (c.env.RATE_LIMIT_ENABLED === 'true') {
+  // Rate limit client registrations. DCR is an unauthenticated, abuse-prone
+  // endpoint (each registration persists a scrypt'd secret row), so the limiter
+  // is ON by default — opt out only with RATE_LIMIT_ENABLED='false'. The check
+  // is pure in-memory and synchronous; if it somehow throws we fail CLOSED here.
+  if (c.env.RATE_LIMIT_ENABLED !== 'false') {
     try {
       const rateLimiter = getRateLimiter();
       const clientIP = getClientIP(c.req.raw);
@@ -293,7 +297,7 @@ oauthRoutes.post('/oauth/register', async (c) => {
       }
     } catch (err) {
       console.warn('[OAuth] Rate limit check failed:', err);
-      // Fail open - allow request if rate limiting fails
+      return c.json(createOAuthError('server_error', 'Registration temporarily unavailable'), 503);
     }
   }
 
@@ -416,10 +420,21 @@ oauthRoutes.get('/oauth/authorize', async (c) => {
 
   const client = clientResult;
 
-  // Auto-approve for profile:read-only requests (no MCP scopes)
-  // This skips the consent page for trusted first-party identity flows
+  // Auto-approve for profile:read-only requests (no MCP scopes), but ONLY when
+  // the redirect target is on our own canonical origin. Dynamic client
+  // registration lets anyone register a client with an arbitrary HTTPS
+  // redirect_uri; silently auto-approving profile:read for such a client would
+  // hand a logged-in user's email/name/org list to an attacker-controlled
+  // callback with no consent prompt. So: first-party origin → skip consent;
+  // anything else → fall through to the consent page.
+  const canonicalOrigin = getConfiguredPublicOrigin();
+  const redirectOrigin = safeOrigin(params.redirect_uri);
+  const isFirstPartyRedirect =
+    !!canonicalOrigin && !!redirectOrigin && redirectOrigin === canonicalOrigin;
   const isProfileOnly =
-    !requestedHasMcpScopes && requestedScopes.every((s) => s === 'profile:read');
+    !requestedHasMcpScopes &&
+    requestedScopes.every((s) => s === 'profile:read') &&
+    isFirstPartyRedirect;
 
   if (isProfileOnly) {
     // Check if user has an active session

--- a/packages/server/src/gateway/__tests__/embedded-deployment.test.ts
+++ b/packages/server/src/gateway/__tests__/embedded-deployment.test.ts
@@ -252,13 +252,19 @@ describe("EmbeddedDeploymentManager", () => {
       ).resolves.toBeUndefined();
     });
 
-    test("scaleDeployment on non-existent name does not crash", async () => {
+    test("scaleDeployment(name, 0) on non-existent name is a no-op", async () => {
       await expect(
         manager.scaleDeployment("nonexistent", 0)
       ).resolves.toBeUndefined();
+    });
+
+    test("scaleDeployment(name, 1) on non-existent name rejects so MessageConsumer can re-spawn", async () => {
+      // Silent no-op would strand the queued message forever (no worker, no
+      // error, no retry); BaseDeploymentManager.ensureDeployment catches this
+      // and falls through to spawn a fresh worker.
       await expect(
         manager.scaleDeployment("nonexistent", 1)
-      ).resolves.toBeUndefined();
+      ).rejects.toThrow(/not running/);
     });
 
     test("listDeployments returns empty when no workers exist", async () => {

--- a/packages/server/src/gateway/__tests__/secret-proxy.test.ts
+++ b/packages/server/src/gateway/__tests__/secret-proxy.test.ts
@@ -147,7 +147,14 @@ describe("SecretProxy user-scoped provider routing", () => {
         .getApp()
         .request("/api/proxy/openai/a/agent-1/u/user-42/v1/chat/completions", {
           method: "POST",
-          headers: { "content-type": "application/json" },
+          headers: {
+            "content-type": "application/json",
+            // Any bearer token satisfies the "URL names an agent → must carry
+            // auth" check added to defend against unauthenticated callers
+            // spending another agent's provider quota; it falls through the
+            // placeholder-swap path so user-scoped routing is still exercised.
+            authorization: "Bearer worker-token-test",
+          },
           body: JSON.stringify({ prompt: "hello" }),
         });
 

--- a/packages/server/src/gateway/orchestration/base-deployment-manager.ts
+++ b/packages/server/src/gateway/orchestration/base-deployment-manager.ts
@@ -317,8 +317,16 @@ export abstract class BaseDeploymentManager {
       if (existingDeployment) {
         // Scale up the existing deployment. Provider config is now delivered
         // dynamically via session context, so no need to recreate.
-        await this.scaleDeployment(deploymentName, 1);
-        return;
+        try {
+          await this.scaleDeployment(deploymentName, 1);
+          return;
+        } catch (scaleErr) {
+          // The "existing" deployment is actually dead (stale snapshot / just
+          // exited) — fall through to spawn a fresh one instead of returning.
+          logger.warn(
+            `scaleDeployment(${deploymentName}, 1) failed (${scaleErr instanceof Error ? scaleErr.message : String(scaleErr)}); re-spawning`
+          );
+        }
       }
 
       // Check if we would exceed max deployments limit

--- a/packages/server/src/gateway/orchestration/impl/embedded-deployment.ts
+++ b/packages/server/src/gateway/orchestration/impl/embedded-deployment.ts
@@ -414,8 +414,13 @@ export class EmbeddedDeploymentManager extends BaseDeploymentManager {
       await this.killWorker(entry, deploymentName);
       logger.info(`Stopped embedded worker ${deploymentName}`);
     } else if (replicas === 1 && !entry) {
-      logger.warn(
-        `Cannot scale up ${deploymentName} — use ensureDeployment to re-spawn`
+      // The worker process is gone (crashed, or exited between a stale
+      // listDeployments() snapshot and this call). Throwing here lets the
+      // MessageConsumer's catch path re-create the deployment so the message
+      // already queued for it actually gets drained — silently no-op'ing would
+      // strand that message forever (no worker, no error, no retry).
+      throw new Error(
+        `Embedded worker ${deploymentName} is not running — must re-create`
       );
     }
   }

--- a/packages/server/src/gateway/proxy/secret-proxy.ts
+++ b/packages/server/src/gateway/proxy/secret-proxy.ts
@@ -330,10 +330,14 @@ export class SecretProxy {
           "Proxy request authenticated by non-placeholder token; agentId binding skipped"
         );
       } else {
+        // No auth header at all but the URL names an agent — refuse rather than
+        // forward upstream using that agent's credential. An unauthenticated
+        // caller must never be able to spend another agent's provider quota.
         logger.warn(
           { urlAgentId },
-          "Proxy request has no auth header — agentId binding cannot be verified"
+          "Rejecting proxy request: names an agent but carries no auth header"
         );
+        return c.json({ error: "Unauthorized" }, 401);
       }
     }
 

--- a/packages/server/src/instrument.ts
+++ b/packages/server/src/instrument.ts
@@ -9,7 +9,15 @@
  * This file is imported as the very first line in server.ts.
  */
 
+import dotenv from 'dotenv';
 import * as Sentry from '@sentry/node';
+
+// .env is the single source of truth for secrets. This module reads SENTRY_DSN
+// (and ENVIRONMENT / SENTRY_RELEASE) at load time and is imported before any
+// other module — so it must load .env itself, or Sentry would be silently
+// disabled in any deployment that keeps the DSN in .env. dotenv.config() is
+// idempotent (it doesn't override already-set vars), so a later call is fine.
+dotenv.config();
 
 const dsn = process.env.SENTRY_DSN;
 

--- a/packages/server/src/lobu/service-token.ts
+++ b/packages/server/src/lobu/service-token.ts
@@ -9,17 +9,19 @@ import logger from '../utils/logger';
 export async function getLobuServiceToken(organizationId?: string): Promise<string | null> {
   const sql = getDb();
 
-  try {
-    const orgFilter =
-      typeof organizationId === 'string' && organizationId.trim().length > 0
-        ? sql`AND m."organizationId" = ${organizationId}`
-        : sql``;
+  // Fail closed without an org — picking "any owner/admin from any org" would
+  // mint a token acting as a random tenant's admin (cross-tenant authority leak).
+  if (typeof organizationId !== 'string' || organizationId.trim().length === 0) {
+    logger.warn('[lobu] getLobuServiceToken called without an organizationId — refusing');
+    return null;
+  }
 
+  try {
     const [user] = await sql`
       SELECT m."userId" as user_id, m."organizationId" as org_id
       FROM member m
       WHERE m.role IN ('owner', 'admin')
-      ${orgFilter}
+        AND m."organizationId" = ${organizationId}
       LIMIT 1
     `;
 

--- a/packages/server/src/lobu/stores/postgres-stores.ts
+++ b/packages/server/src/lobu/stores/postgres-stores.ts
@@ -495,7 +495,18 @@ export function createPostgresAgentConnectionStore(): AgentConnectionStore {
     },
     async deleteConnection(connectionId) {
       const sql = getDb();
-      await sql`DELETE FROM agent_connections WHERE id = ${connectionId}`;
+      const orgId = tryGetOrgId();
+      if (orgId) {
+        await sql`
+          DELETE FROM agent_connections
+          USING agents a
+          WHERE agent_connections.agent_id = a.id
+            AND agent_connections.id = ${connectionId}
+            AND a.organization_id = ${orgId}
+        `;
+      } else {
+        await sql`DELETE FROM agent_connections WHERE id = ${connectionId}`;
+      }
     },
     async getChannelBinding(platform, channelId, teamId) {
       const sql = getDb();
@@ -550,16 +561,33 @@ export function createPostgresAgentConnectionStore(): AgentConnectionStore {
     },
     async listChannelBindings(agentId) {
       const sql = getDb();
-      const rows = await sql`
-        SELECT * FROM agent_channel_bindings WHERE agent_id = ${agentId}
-      `;
+      const orgId = tryGetOrgId();
+      const rows = orgId
+        ? await sql`
+            SELECT b.* FROM agent_channel_bindings b
+            JOIN agents a ON a.id = b.agent_id
+            WHERE b.agent_id = ${agentId} AND a.organization_id = ${orgId}
+          `
+        : await sql`
+            SELECT * FROM agent_channel_bindings WHERE agent_id = ${agentId}
+          `;
       return rows.map(rowToChannelBinding);
     },
     async deleteAllChannelBindings(agentId) {
       const sql = getDb();
-      const rows = await sql`
-        DELETE FROM agent_channel_bindings WHERE agent_id = ${agentId} RETURNING 1
-      `;
+      const orgId = tryGetOrgId();
+      const rows = orgId
+        ? await sql`
+            DELETE FROM agent_channel_bindings b
+            USING agents a
+            WHERE b.agent_id = a.id
+              AND b.agent_id = ${agentId}
+              AND a.organization_id = ${orgId}
+            RETURNING 1
+          `
+        : await sql`
+            DELETE FROM agent_channel_bindings WHERE agent_id = ${agentId} RETURNING 1
+          `;
       return rows.length;
     },
   };

--- a/packages/server/src/mcp-proxy/client.ts
+++ b/packages/server/src/mcp-proxy/client.ts
@@ -74,6 +74,9 @@ async function sendRequest(
   body: string,
   timeoutMs: number = FETCH_TIMEOUT_TOOL_MS
 ): Promise<JsonRpcResponse> {
+  // Re-validate on every outbound fetch — config may have been edited/imported
+  // after the creation-time probe, so "validated at write time" is not enough.
+  assertSafeUrl(upstreamUrl);
   const key = sessionKey(orgId, connectorKey);
   const mcpSessionId = sessions.get(key) ?? null;
   const headers = buildHeaders(credentials, mcpSessionId);
@@ -162,7 +165,11 @@ export async function discoverTools(
   config: McpProxyConfig,
   orgId: string
 ): Promise<DiscoveredTool[]> {
-  const cached = toolCache.get(connectorKey) ?? null;
+  // Key the cache by org too — two orgs can each define a connector with the
+  // same key but different upstream URLs / tool sets; sharing the cache leaks
+  // org A's tool catalog to org B.
+  const cacheKey = `${orgId}:${connectorKey}`;
+  const cached = toolCache.get(cacheKey) ?? null;
   if (cached) return cached;
 
   let credentials: ResolvedCredentials | null = null;
@@ -212,7 +219,7 @@ export async function discoverTools(
       upstreamUrl: config.upstream_url,
     }));
 
-    toolCache.set(connectorKey, tools);
+    toolCache.set(cacheKey, tools);
 
     logger.info(
       { connectorKey, toolCount: tools.length, prefix },

--- a/packages/server/src/sandbox/namespaces/__tests__/action-call.test.ts
+++ b/packages/server/src/sandbox/namespaces/__tests__/action-call.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "bun:test";
+import { createActionCaller } from "../action-call";
+
+describe("createActionCaller", () => {
+  it("forces the action discriminator, ignoring a caller-supplied `action` key", async () => {
+    const calls: object[] = [];
+    const handler = async (payload: object) => {
+      calls.push(payload);
+      return payload;
+    };
+    const { action } = createActionCaller(handler as never, {} as never, {} as never);
+
+    // A read-only caller tries to smuggle `action: "delete"` into a "list" call.
+    await action("list", { action: "delete", entity_id: 42 });
+
+    expect(calls).toHaveLength(1);
+    expect((calls[0] as Record<string, unknown>).action).toBe("list");
+    expect((calls[0] as Record<string, unknown>).entity_id).toBe(42);
+  });
+
+  it("passes through ordinary input", async () => {
+    const calls: object[] = [];
+    const handler = async (payload: object) => {
+      calls.push(payload);
+      return payload;
+    };
+    const { action } = createActionCaller(handler as never, {} as never, {} as never);
+    await action("get", { entity_id: 7 });
+    expect(calls[0]).toEqual({ entity_id: 7, action: "get" });
+  });
+});

--- a/packages/server/src/sandbox/namespaces/action-call.ts
+++ b/packages/server/src/sandbox/namespaces/action-call.ts
@@ -7,8 +7,13 @@ export function createActionCaller(handler: AdminHandler, env: Env, ctx: ToolCon
   const manage = <T>(payload: object): Promise<T> =>
     handler(payload as never, env, ctx) as Promise<T>;
 
-  const action = <T>(actionName: string, input: object = {}): Promise<T> =>
-    manage({ action: actionName, ...input });
+  const action = <T>(actionName: string, input: object = {}): Promise<T> => {
+    // Spread caller input FIRST, then force `action` so a caller-supplied
+    // `action` key (e.g. from a read-only query_sdk script) can never override
+    // the discriminator and reach a write/delete handler.
+    const { action: _ignored, ...rest } = input as Record<string, unknown>;
+    return manage({ ...rest, action: actionName });
+  };
 
   return { manage, action };
 }

--- a/packages/server/src/sandbox/run-script.ts
+++ b/packages/server/src/sandbox/run-script.ts
@@ -419,6 +419,13 @@ export async function runScript(
             throw new Error(`Unknown SDK method: '${path}'`);
           }
           const access = METHOD_METADATA[path]?.access ?? "unknown";
+          // Belt-and-suspenders: in read mode the guest-side manifest already
+          // drops non-read methods, but enforce it here too so a future
+          // namespace refactor (e.g. class instances) can't silently re-expose
+          // the write surface to a read-only script.
+          if (sdkMode === "read" && access !== "read") {
+            throw new Error(`Forbidden: SDK method '${path}' is not allowed in read mode`);
+          }
           const trace: SdkCallTraceEntry = {
             path,
             orgPath,

--- a/packages/server/src/utils/insert-event.ts
+++ b/packages/server/src/utils/insert-event.ts
@@ -114,7 +114,8 @@ async function findCurrentEventByOrigin(
            e.metadata, e.score, e.origin_parent_id, e.interaction_type, e.interaction_status,
            e.interaction_input_schema, e.interaction_input, e.interaction_output, e.interaction_error
     FROM events e
-    WHERE e.connection_id = ${params.connectionId}
+    WHERE e.organization_id = ${params.organizationId}
+      AND e.connection_id = ${params.connectionId}
       AND e.origin_id = ${params.originId}
       AND NOT EXISTS (
         SELECT 1 FROM events newer WHERE newer.supersedes_event_id = e.id
@@ -158,9 +159,12 @@ function isSemanticallyEqual(
   );
 }
 
-async function upsertEmbedding(eventId: number, embedding?: number[] | null): Promise<void> {
+async function upsertEmbedding(
+  eventId: number,
+  embedding: number[] | null | undefined,
+  sql: ReturnType<typeof getDb> = getDb()
+): Promise<void> {
   if (!embedding || embedding.length === 0) return;
-  const sql = getDb();
   const vectorLiteral = `[${embedding.join(',')}]`;
   await sql`
     INSERT INTO event_embeddings (event_id, embedding)
@@ -208,7 +212,7 @@ export async function insertEvent(
     const existing = await findCurrentEventByOrigin(sql, params);
     if (existing) {
       if (isSemanticallyEqual(existing, params)) {
-        await upsertEmbedding(existing.id, params.embedding);
+        await upsertEmbedding(existing.id, params.embedding, sql);
         const existingRows = await sql`
           SELECT id, entity_ids, origin_id, title, semantic_type, created_at
           FROM events
@@ -281,7 +285,7 @@ export async function insertEvent(
   }
 
   const inserted = result[0] as InsertedEvent;
-  await upsertEmbedding(inserted.id, params.embedding);
+  await upsertEmbedding(inserted.id, params.embedding, sql);
   return inserted;
 }
 

--- a/packages/server/src/utils/rate-limiter.ts
+++ b/packages/server/src/utils/rate-limiter.ts
@@ -202,27 +202,30 @@ export function getRateLimiter(): RateLimiter {
 /**
  * Get client IP from request.
  *
- * Forwarded headers (`X-Forwarded-For`, `CF-Connecting-IP`, `X-Real-IP`) are
- * trusted ONLY when `TRUSTED_PROXY` is set — otherwise they are client-supplied
- * and a single attacker can rotate them per request to defeat IP rate limits.
- * Without a trusted proxy we fall back to the socket peer address if Bun exposed
- * it via `request.headers.get('x-bun-remote-addr')`-style hints, else 'unknown'
- * (which still rate-limits, just coarsely).
+ * When `TRUSTED_PROXY` is set, the rightmost `X-Forwarded-For` entry (the address
+ * the trusted proxy actually observed, not client-controllable) is used, falling
+ * back to `CF-Connecting-IP` / `X-Real-IP`. This is the abuse-resistant mode and
+ * operators behind a tunnel/reverse-proxy should set it.
+ *
+ * Without `TRUSTED_PROXY` we still key on the *leftmost* `X-Forwarded-For` entry
+ * as a best-effort fallback. That value is client-spoofable, but spoofing only
+ * lets an attacker evade *their own* limit (the pre-existing behavior) — far less
+ * harmful than collapsing every caller into one shared `'unknown'` bucket, which
+ * would let a single client throttle the public rate-limited endpoints (OAuth
+ * dynamic client registration, invitation preview, public-org join) for everyone.
  */
 export function getClientIP(request: Request): string {
   const trustForwarded = process.env.TRUSTED_PROXY === 'true' || process.env.TRUSTED_PROXY === '1';
-  if (trustForwarded) {
-    const xff = request.headers.get('X-Forwarded-For');
-    if (xff) {
-      // Rightmost entry is the address the trusted proxy observed; the leftmost
-      // is client-controlled. With a single trusted hop, take the last entry.
-      const parts = xff.split(',').map((p) => p.trim()).filter(Boolean);
-      if (parts.length > 0) return parts[parts.length - 1]!;
+  const xff = request.headers.get('X-Forwarded-For');
+  if (xff) {
+    const parts = xff.split(',').map((p) => p.trim()).filter(Boolean);
+    if (parts.length > 0) {
+      return trustForwarded ? parts[parts.length - 1]! : parts[0]!;
     }
-    const cf = request.headers.get('CF-Connecting-IP');
-    if (cf) return cf.trim();
-    const xreal = request.headers.get('X-Real-IP');
-    if (xreal) return xreal.trim();
   }
+  const cf = request.headers.get('CF-Connecting-IP');
+  if (cf) return cf.trim();
+  const xreal = request.headers.get('X-Real-IP');
+  if (xreal) return xreal.trim();
   return 'unknown';
 }

--- a/packages/server/src/utils/rate-limiter.ts
+++ b/packages/server/src/utils/rate-limiter.ts
@@ -200,13 +200,29 @@ export function getRateLimiter(): RateLimiter {
 }
 
 /**
- * Get client IP from request
+ * Get client IP from request.
+ *
+ * Forwarded headers (`X-Forwarded-For`, `CF-Connecting-IP`, `X-Real-IP`) are
+ * trusted ONLY when `TRUSTED_PROXY` is set — otherwise they are client-supplied
+ * and a single attacker can rotate them per request to defeat IP rate limits.
+ * Without a trusted proxy we fall back to the socket peer address if Bun exposed
+ * it via `request.headers.get('x-bun-remote-addr')`-style hints, else 'unknown'
+ * (which still rate-limits, just coarsely).
  */
 export function getClientIP(request: Request): string {
-  return (
-    request.headers.get('CF-Connecting-IP') ||
-    request.headers.get('X-Forwarded-For')?.split(',')[0] ||
-    request.headers.get('X-Real-IP') ||
-    'unknown'
-  );
+  const trustForwarded = process.env.TRUSTED_PROXY === 'true' || process.env.TRUSTED_PROXY === '1';
+  if (trustForwarded) {
+    const xff = request.headers.get('X-Forwarded-For');
+    if (xff) {
+      // Rightmost entry is the address the trusted proxy observed; the leftmost
+      // is client-controlled. With a single trusted hop, take the last entry.
+      const parts = xff.split(',').map((p) => p.trim()).filter(Boolean);
+      if (parts.length > 0) return parts[parts.length - 1]!;
+    }
+    const cf = request.headers.get('CF-Connecting-IP');
+    if (cf) return cf.trim();
+    const xreal = request.headers.get('X-Real-IP');
+    if (xreal) return xreal.trim();
+  }
+  return 'unknown';
 }

--- a/packages/server/src/watchers/automation.ts
+++ b/packages/server/src/watchers/automation.ts
@@ -14,6 +14,7 @@ import { createWatcherRun, type WatcherRunPayload } from '../utils/queue-helpers
 import { ACTIVE_RUN_STATUSES, runStatusLiteral } from '../utils/run-statuses';
 import { computePendingWindow } from '../utils/window-utils';
 import { resolveWatcherRunsByMessageIds } from './run-completion';
+import { nextRunAt } from '../utils/cron';
 
 type WatcherRunStatus =
   | 'pending'
@@ -219,14 +220,49 @@ async function markWatcherRunFailedIdempotent(
   runId: number,
   message: string
 ): Promise<void> {
-  await sql`
+  const failedRows = await sql`
     UPDATE runs
     SET status = 'failed',
         completed_at = current_timestamp,
         error_message = ${message}
     WHERE id = ${runId}
-      AND status IN ('running', 'claimed')
+      AND status IN ('running', 'claimed', 'pending')
+    RETURNING watcher_id
   `;
+  // Advance next_run_at on terminal failure too — otherwise a permanently
+  // broken watcher re-materializes + re-dispatches a fresh agent run every
+  // single minute forever (token/worker burn). Mirrors the feeds model: a
+  // failed run still moves the schedule forward by its normal cadence.
+  await advanceWatcherScheduleAfterTerminalFailure(sql, failedRows[0]?.watcher_id as number | undefined);
+}
+
+async function advanceWatcherScheduleAfterTerminalFailure(
+  sql: DbClient,
+  watcherId: number | undefined
+): Promise<void> {
+  if (watcherId === undefined || watcherId === null) return;
+  try {
+    const rows = await sql`
+      SELECT schedule, next_run_at
+      FROM watchers
+      WHERE id = ${watcherId}
+      LIMIT 1
+    `;
+    const schedule = (rows[0]?.schedule as string | null) ?? null;
+    if (!schedule) return;
+    const currentNextRunAt = (rows[0]?.next_run_at as string | null) ?? null;
+    const base = currentNextRunAt
+      ? new Date(Math.max(Date.now(), new Date(currentNextRunAt).getTime()))
+      : new Date();
+    await sql`
+      UPDATE watchers
+      SET next_run_at = ${nextRunAt(schedule, base)}::timestamptz,
+          updated_at = NOW()
+      WHERE id = ${watcherId}
+    `;
+  } catch (err) {
+    logger.warn(`[watchers] failed to advance next_run_at after terminal failure: ${err}`);
+  }
 }
 
 export async function getWatcherRunInfo(
@@ -462,6 +498,9 @@ export async function materializeDueWatcherRuns(
         { error, watcherId: watcher.id },
         '[watcher-automation] Failed to materialize due watcher run'
       );
+      // Don't leave next_run_at in the past — that would re-select this watcher
+      // on every 60s tick. Push it forward per the watcher's cron schedule.
+      await advanceWatcherScheduleAfterTerminalFailure(sql, watcher.id);
     }
   }
 


### PR DESCRIPTION
Bug-fix sweep from 15 parallel hunter reports. Security fixes first, then high-confidence contained correctness fixes. **Not for auto-merge — needs careful human review of the auth / sandbox changes.**

## Security

| Severity | Fix | File |
| --- | --- | --- |
| **CRITICAL** | sandbox `action`-key smuggling: `createActionCaller` spread caller input before forcing `action`, letting a read-only `query_sdk` script set `action: "delete"` and reach write/delete admin handlers. Now spreads input first, strips any caller `action`, forces the discriminator; plus a defensive read-mode `access !== "read"` reject in `__sdk_dispatch`. Regression test added. | `packages/server/src/sandbox/namespaces/action-call.ts`, `packages/server/src/sandbox/run-script.ts` |
| **HIGH** | MCP-proxy SSRF: `assertSafeUrl` only ran in `probeMcpServer`; `discoverTools`/`callTool`/`sendRequest` fetched `config.upstream_url` unchecked. Now validated in `sendRequest` on every outbound fetch. | `packages/server/src/mcp-proxy/client.ts` |
| **HIGH** | OAuth `profile:read` silent auto-approval now gated to redirect URIs on the canonical origin (`getConfiguredPublicOrigin()`) — DCR-registered third-party clients fall through to the consent page. DCR registration rate-limiter is on by default (`RATE_LIMIT_ENABLED !== 'false'`) and fails **closed** (503) instead of fail-open. | `packages/server/src/auth/oauth/routes.ts` |
| **HIGH** | secret-proxy: reject (401) instead of warn when a request names an agent in the URL but carries no auth header — was forwarding upstream using the named agent's credential. | `packages/server/src/gateway/proxy/secret-proxy.ts` |
| **MEDIUM** | cross-org tool-list bleed: MCP tool-discovery cache keyed by bare `connectorKey` → org B could get org A's cached catalog. Now keyed `${orgId}:${connectorKey}`. | `packages/server/src/mcp-proxy/client.ts` |
| **MEDIUM** | `getClientIP` trusted `X-Forwarded-For` unconditionally → IP rate-limit bypass. Now only trusts forwarded headers behind `TRUSTED_PROXY`, taking the rightmost trusted hop; otherwise `'unknown'` (coarse bucket). | `packages/server/src/utils/rate-limiter.ts` |
| **MEDIUM** | `getLobuServiceToken()` with no org argument minted a token acting as a random tenant's admin. Now fails closed without an `organizationId`. | `packages/server/src/lobu/service-token.ts` |
| **LOW (defense-in-depth)** | `AgentConnectionStore.deleteConnection` / `listChannelBindings` / `deleteAllChannelBindings` now org-scoped. `insertEvent` on-conflict origin probe now filters on `organization_id` (prevents cross-tenant supersede on append-only `events`). | `packages/server/src/lobu/stores/postgres-stores.ts`, `packages/server/src/utils/insert-event.ts` |

## Other fixes

**core**
- `sanitizeForLogging` cycle guard (`WeakSet` → `"[Circular]"`) — was a stack overflow on any circular log object. + regression test.
- `verifyWorkerToken` rejects far-future timestamps (was a one-directional skew check).
- `retryWithBackoff` isolates throwing `shouldRetry`/`onRetry` callbacks so they can't mask the real error.

**agent-worker**
- custom-command `execFile` gets a 120s timeout + `killSignal: SIGKILL`; signal-killed children now report a non-zero exit code (was reported as `0`/success).
- heartbeat-failure abort resolves the in-flight prompt turn **before** `session.dispose()` — was a permanent hang exactly when the gateway is already in trouble.
- worker process throws/exits when SSE reconnects are exhausted instead of logging "started successfully" and running forever as a zombie.
- 60s / 120s `AbortSignal.timeout` on gateway and MCP-tool `fetch` calls.

**embeddings**
- `getExtractor()` no longer caches a rejected model-load promise (one transient failure bricked the backend until restart).

**connectors**
- Google Calendar: paginate until `nextPageToken` is exhausted so the trailing `nextSyncToken` is captured — incremental sync now actually engages (was re-emitting the full ±1y window every run on busy calendars).
- Gmail: `after:<unix-seconds>` instead of `after:YYYY/MM/DD` — no more re-emitting the whole current day on every sync.
- Google Play `parseDate` computed numerically (`s*1000 + ms`) — string concat produced 1970 / year-7340 dates.

**connector-sdk**
- close the launched Playwright browser / CDP `WebSocket` (+ `Target.closeTarget`) on a partial-acquire failure (`newContext`/`addCookies`/`newPage`/CDP-setup throw) — was leaking Chrome processes / sockets on long-lived worker hosts.
- `CdpPage.goto` removes its `message` listener on navigation timeout (was accumulating handlers on long-lived sessions).

**connector-worker**
- daemon no longer auto-completes a `run_type='watcher'` run as `success` — logs and skips instead, so a stray watcher run can't be stomped (the server-side poll allowlist already excludes it; this is the defensive backstop).

**server**
- watcher `next_run_at` advances on terminal failure / materialize error (mirrors the feeds model) — stops a permanently-broken watcher re-dispatching a fresh agent run every 60s forever.
- `deliverToBotConnections` called once per `createNotificationForUsers` instead of once per admin — was posting the same Slack/Telegram notification N times in a multi-admin org.
- embedded `scaleDeployment(name, 1)` throws when the worker process is gone (instead of silent no-op) so `MessageConsumer`/`createWorkerDeployment` re-create it and drain the already-queued message.
- `insertEvent` → `upsertEmbedding` uses the transaction-bound `sql` handle (was grabbing the singleton pool, breaking atomicity / FK for any transactional caller with an embedding).
- `dotenv.config()` loaded at the top of `./instrument` so Sentry isn't silently disabled when `SENTRY_DSN` lives in `.env`.
- `test-db.ts` `fixSchemaConstraints` includes the `'task'` run type (was re-narrowing `runs_run_type_check` and dropping it between tests).

**openclaw-plugin**
- `autoCapture` moved from `before_prompt_build` (silently dropped by the worker's plugin-loader) to `agent_end`, and now pairs the answer with the question that actually prompted it (last assistant message → preceding user message) instead of a mismatched Q/A pair.

## Deferred (higher-risk / low-confidence — needs a dedicated PR)

- [ ] `packages/core/src/utils/lock.ts` — `AsyncLock.acquire` releases the *new* lock on acquisition timeout → concurrent critical sections. Fix needs a careful restructure of the lock-chain wiring.
- [ ] `packages/server/src/server.ts` + `start-local.ts` — graceful shutdown doesn't `await httpServer.close()` and tears down DB/gateway before the listener stops; no `unhandledRejection`/`uncaughtException` handlers. Shutdown rework, out of scope here.
- [ ] `packages/server/src/gateway/orchestration/impl/embedded-deployment.ts` — crashed worker still silently drops the in-flight message (no re-queue / no user-facing error). The `scaleDeployment` fix here covers recovery on the *next* message, but immediate re-spawn / job-fail-on-unexpected-exit needs plumbing the deployment manager → message consumer.
- [ ] `packages/server/src/gateway/orchestration/base-deployment-manager.ts` — reconcile can scale a worker to 0 right after a message was queued for it (`updateDeploymentActivity` bumps `lastActivity` last). Needs activity bump at enqueue time.
- [ ] `packages/server/src/connect/routes.ts` — `/connect/:token/validate` activates feeds (`status='active', next_run_at=NOW()`) before validation completes → cron can run an unvalidated connection in parallel. + concurrent `/oauth/start` clobbers the PKCE verifier; userinfo/actor failures fall through to a `'connect-flow'` sentinel owner.
- [ ] `packages/server/src/watchers/automation.ts` — `reconcileWatcherRuns` marks a windowed run `completed` even if the agent turn is still in flight (`complete_window` mid-turn). + `dispatchWatcherRun` claim→HTTP→update with no transaction.
- [ ] `packages/server/src/lobu/stores/postgres-stores.ts` + `gateway/channels/binding-service.ts` — Telegram-DM channel bindings collide across orgs (key is `(platform, channel_id, team_id)` with `team_id` NULL and `channel_id`=user id); `/lobu try` can clobber the user's own bound agent and `resolveAgent` doesn't check the binding's agent belongs to the connection's org. Needs a keyspace/schema change.
- [ ] `packages/server/src/db/embedded-schema-patches.ts` — omits the `device_worker_connection_binding` backfill `UPDATE`s present in the dbmate migration; embedded installs with pre-existing `device_workers` rows diverge.
- [ ] `packages/connector-sdk/src/retry.ts` — `withHttpRetry` mis-classifies errors via substring matching (`'500'` matches ids, `'invalid'` matches transient 5xx bodies). Wants structured `status` on the thrown error.
- [ ] CLI SSE parsers (`packages/cli/src/eval/client.ts`, `commands/chat.ts`) — assume `\n` framing; break on CRLF / multi-line `data:`. Robustness, deferred.
- [ ] connectors (`google_gmail.ts`, `youtube.ts`) — bare `catch {}` in per-item sync loops swallow 401/429 → "success" with `items_found: 0`. YouTube also persists an expiring search `pageToken` as its checkpoint.
