### PR TITLE
perf: performance sweep

### DIFF
--- a/packages/agent-worker/src/gateway/gateway-integration.ts
+++ b/packages/agent-worker/src/gateway/gateway-integration.ts
@@ -255,14 +255,14 @@ export class HttpWorkerTransport implements WorkerTransport {
 
     await retryWithBackoff(
       async () => {
+        // Don't `JSON.stringify(payload)` just to truncate it for a log line —
+        // that's a full serialize-then-discard on the per-delta hot path
+        // (and platformMetadata can be large). Log the identifying fields only.
         logger.info(
-          `[WORKER-HTTP] Sending to ${responseUrl}: ${JSON.stringify(payload).substring(0, 500)}`
+          `[WORKER-HTTP] Sending to ${responseUrl}: messageId=${payload.messageId ?? ""}${
+            payload.delta ? ` deltaLength=${payload.delta.length}` : ""
+          }${payload.statusUpdate ? " statusUpdate" : ""}${payload.customEvent ? ` customEvent=${payload.customEvent.name}` : ""}`
         );
-        if (payload.delta) {
-          logger.info(
-            `[WORKER-HTTP] Stream delta payload: deltaLength=${payload.delta?.length}`
-          );
-        }
 
         const response = await fetch(responseUrl, {
           method: "POST",

--- a/packages/agent-worker/src/openclaw/worker.ts
+++ b/packages/agent-worker/src/openclaw/worker.ts
@@ -1588,11 +1588,13 @@ Use it when the user references past discussions or you need context.`);
 
     try {
       const files = await fs.readdir(outputDir);
-      for (const file of files) {
-        await fs.unlink(path.join(outputDir, file)).catch(() => {
-          /* intentionally empty */
-        });
-      }
+      await Promise.all(
+        files.map((file) =>
+          fs.unlink(path.join(outputDir, file)).catch(() => {
+            /* intentionally empty */
+          })
+        )
+      );
     } catch (error) {
       logger.debug("Could not clear output directory:", error);
     }

--- a/packages/connector-worker/src/daemon/executor.ts
+++ b/packages/connector-worker/src/daemon/executor.ts
@@ -6,7 +6,7 @@
  */
 
 import type { Checkpoint, Content, Env } from '@lobu/connector-sdk';
-import { generateEmbedding } from '../embeddings.js';
+import { batchGenerateEmbeddings, generateEmbedding } from '../embeddings.js';
 import {
   executeCompiledConnector,
   getActionOutput,
@@ -524,20 +524,27 @@ async function executeEmbedBackfillRun(
       return { itemsCollected: 0 };
     }
 
-    // Generate embeddings for each event
+    // Generate embeddings in batch — backfill runs are explicitly the
+    // "lots of events" path, so batch through the service / vectorized local
+    // pass instead of one round-trip per event.
+    const pending = events
+      .map((event) => ({
+        event_id: event.id,
+        text: [event.title, event.content].filter(Boolean).join(' ').trim(),
+      }))
+      .filter((p) => p.text.length > 0);
+
     const results: Array<{ event_id: number; embedding: number[] }> = [];
-    for (const event of events) {
-      try {
-        const textForEmbedding = [event.title, event.content].filter(Boolean).join(' ').trim();
-        if (textForEmbedding) {
-          const embedding = await generateEmbedding(textForEmbedding);
-          if (embedding) {
-            results.push({ event_id: event.id, embedding });
-          }
+    try {
+      const embeddings = await batchGenerateEmbeddings(pending.map((p) => p.text));
+      for (let i = 0; i < pending.length; i++) {
+        const embedding = embeddings[i];
+        if (embedding) {
+          results.push({ event_id: pending[i]!.event_id, embedding });
         }
-      } catch (err) {
-        console.error(`[executor] Embedding failed for event ${event.id}:`, err);
       }
+    } catch (err) {
+      console.error(`[executor] Batch embedding failed for run ${run_id}:`, err);
     }
 
     // Submit embeddings back to the API

--- a/packages/core/src/__tests__/encryption.test.ts
+++ b/packages/core/src/__tests__/encryption.test.ts
@@ -1,5 +1,9 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { decrypt, encrypt } from "../utils/encryption";
+import {
+  __resetEncryptionKeyCacheForTests,
+  decrypt,
+  encrypt,
+} from "../utils/encryption";
 
 describe("encryption", () => {
   let originalKey: string | undefined;
@@ -9,6 +13,7 @@ describe("encryption", () => {
     // 32-byte hex key
     process.env.ENCRYPTION_KEY =
       "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+    __resetEncryptionKeyCacheForTests();
   });
 
   afterEach(() => {
@@ -17,6 +22,7 @@ describe("encryption", () => {
     } else {
       delete process.env.ENCRYPTION_KEY;
     }
+    __resetEncryptionKeyCacheForTests();
   });
 
   test("encrypt/decrypt round-trip preserves plaintext", () => {

--- a/packages/core/src/__tests__/worker-auth.test.ts
+++ b/packages/core/src/__tests__/worker-auth.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { __resetEncryptionKeyCacheForTests } from "../utils/encryption";
 import {
   generateWorkerToken,
   verifyWorkerToken,
@@ -21,6 +22,7 @@ describe("worker auth token", () => {
     }
     process.env.ENCRYPTION_KEY = TEST_KEY;
     delete process.env.WORKER_TOKEN_TTL_MS;
+    __resetEncryptionKeyCacheForTests();
   });
 
   afterEach(() => {
@@ -32,6 +34,7 @@ describe("worker auth token", () => {
         process.env[k] = v;
       }
     }
+    __resetEncryptionKeyCacheForTests();
   });
 
   test("generateWorkerToken returns a non-empty string", () => {
@@ -149,11 +152,13 @@ describe("worker auth token", () => {
   test("verifyWorkerToken returns null without ENCRYPTION_KEY", () => {
     const token = generateWorkerToken("u", "c", "d", { channelId: "ch" });
     delete process.env.ENCRYPTION_KEY;
+    __resetEncryptionKeyCacheForTests();
     expect(verifyWorkerToken(token)).toBeNull();
   });
 
   test("generateWorkerToken throws without ENCRYPTION_KEY", () => {
     delete process.env.ENCRYPTION_KEY;
+    __resetEncryptionKeyCacheForTests();
     expect(() =>
       generateWorkerToken("u", "c", "d", { channelId: "ch" })
     ).toThrow();
@@ -163,6 +168,7 @@ describe("worker auth token", () => {
     const token = generateWorkerToken("u", "c", "d", { channelId: "ch" });
     process.env.ENCRYPTION_KEY =
       "fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210";
+    __resetEncryptionKeyCacheForTests();
     expect(verifyWorkerToken(token)).toBeNull();
   });
 });
@@ -178,6 +184,7 @@ describe("worker auth token: explicit expiry", () => {
     }
     process.env.ENCRYPTION_KEY = TEST_KEY;
     delete process.env.WORKER_TOKEN_TTL_MS;
+    __resetEncryptionKeyCacheForTests();
   });
 
   afterEach(() => {
@@ -189,6 +196,7 @@ describe("worker auth token: explicit expiry", () => {
         process.env[k] = v;
       }
     }
+    __resetEncryptionKeyCacheForTests();
   });
 
   test("token with ancient timestamp is rejected as expired", async () => {

--- a/packages/core/src/logger.ts
+++ b/packages/core/src/logger.ts
@@ -124,10 +124,10 @@ class SentryTransport extends winston.transports.Stream {
               tags: {
                 service: info.service,
               },
-              extra: {
-                ...info,
-                message: info.message,
-              },
+              // Pass `info` directly — Sentry copies it internally; spreading
+              // it here forced a shallow clone (+ serialize) of arbitrarily
+              // large log metadata on every prod error.
+              extra: info,
             });
           } else {
             // Send as message if no Error object

--- a/packages/core/src/utils/encryption.ts
+++ b/packages/core/src/utils/encryption.ts
@@ -8,7 +8,13 @@ const IV_LENGTH = 12; // 96-bit nonce for AES-GCM
  * IMPORTANT: The ENCRYPTION_KEY must be exactly 32 bytes (256 bits) for AES-256.
  * Generate a secure key using: `openssl rand -base64 32` or `openssl rand -hex 32`
  */
+// The encryption key is immutable for the lifetime of the process; derive it
+// once and reuse the buffer instead of re-parsing the env var on every
+// encrypt/decrypt call (these run on per-request / per-worker-RPC hot paths).
+let cachedKey: Buffer | undefined;
+
 function getEncryptionKey(): Buffer {
+  if (cachedKey) return cachedKey;
   const key = process.env.ENCRYPTION_KEY || "";
   if (!key) {
     throw new Error(
@@ -21,6 +27,7 @@ function getEncryptionKey(): Buffer {
   // discards non-base64 chars — so we only need a length check here.
   const base64Buffer = Buffer.from(key, "base64");
   if (base64Buffer.length === 32) {
+    cachedKey = base64Buffer;
     return base64Buffer;
   }
 
@@ -28,6 +35,7 @@ function getEncryptionKey(): Buffer {
   if (/^[0-9a-fA-F]{64}$/.test(key)) {
     const hexBuffer = Buffer.from(key, "hex");
     if (hexBuffer.length === 32) {
+      cachedKey = hexBuffer;
       return hexBuffer;
     }
   }
@@ -70,4 +78,9 @@ export function decrypt(text: string): string {
     decipher.final(),
   ]);
   return decrypted.toString("utf8");
+}
+
+/** Test-only: clear the memoized encryption key (e.g. after mutating ENCRYPTION_KEY). */
+export function __resetEncryptionKeyCacheForTests(): void {
+  cachedKey = undefined;
 }

--- a/packages/core/src/utils/sanitize.ts
+++ b/packages/core/src/utils/sanitize.ts
@@ -75,6 +75,49 @@ export function sanitizeConversationId(conversationId: string): string {
  * // }
  * ```
  */
+// Compiled once: substring-matches the default sensitive key names (case-insensitive).
+// Equivalent to `.some(k => lowerKey.includes(k))` over the old array, but a single
+// regex test per key instead of an N-way array scan.
+const DEFAULT_SENSITIVE_KEY_RE =
+  /(anthropic_api_key|api_?key|token|password|secret|authorization|bearer|credentials|private_?key)/i;
+
+const MAX_SANITIZE_DEPTH = 8;
+
+function isSensitiveKey(
+  lowerKey: string,
+  additionalLowered: readonly string[]
+): boolean {
+  if (DEFAULT_SENSITIVE_KEY_RE.test(lowerKey)) return true;
+  for (const k of additionalLowered) {
+    if (lowerKey.includes(k)) return true;
+  }
+  return false;
+}
+
+function sanitizeInner(
+  obj: any,
+  additionalLowered: readonly string[],
+  depth: number
+): any {
+  if (!obj || typeof obj !== "object") return obj;
+  if (depth >= MAX_SANITIZE_DEPTH) return obj;
+
+  const sanitized = Array.isArray(obj) ? [...obj] : { ...obj };
+
+  for (const key in sanitized) {
+    const value = sanitized[key];
+    if (typeof value === "string") {
+      if (isSensitiveKey(key.toLowerCase(), additionalLowered)) {
+        sanitized[key] = `[REDACTED:${value.length}]`;
+      }
+    } else if (value && typeof value === "object") {
+      sanitized[key] = sanitizeInner(value, additionalLowered, depth + 1);
+    }
+  }
+
+  return sanitized;
+}
+
 export function sanitizeForLogging(
   obj: any,
   additionalSensitiveKeys: string[] = []
@@ -82,48 +125,8 @@ export function sanitizeForLogging(
   if (!obj || typeof obj !== "object") {
     return obj;
   }
-
-  const defaultSensitiveKeys = [
-    "anthropic_api_key",
-    "api_key",
-    "apiKey",
-    "token",
-    "password",
-    "secret",
-    "authorization",
-    "bearer",
-    "credentials",
-    "privateKey",
-    "private_key",
-  ];
-
-  const sensitiveKeys = [...defaultSensitiveKeys, ...additionalSensitiveKeys];
-
-  const sanitized = Array.isArray(obj) ? [...obj] : { ...obj };
-
-  for (const key in sanitized) {
-    const lowerKey = key.toLowerCase();
-    const isSensitive = sensitiveKeys.some((k) => lowerKey.includes(k));
-
-    if (isSensitive && typeof sanitized[key] === "string") {
-      // Redact but show length for debugging
-      sanitized[key] = `[REDACTED:${sanitized[key].length}]`;
-    } else if (key === "env" && typeof sanitized[key] === "object") {
-      // Recursively sanitize env object
-      sanitized[key] = sanitizeForLogging(
-        sanitized[key],
-        additionalSensitiveKeys
-      );
-    } else if (typeof sanitized[key] === "object") {
-      // Recursively sanitize nested objects
-      sanitized[key] = sanitizeForLogging(
-        sanitized[key],
-        additionalSensitiveKeys
-      );
-    }
-  }
-
-  return sanitized;
+  const additionalLowered = additionalSensitiveKeys.map((k) => k.toLowerCase());
+  return sanitizeInner(obj, additionalLowered, 0);
 }
 
 /**

--- a/packages/embeddings/src/__tests__/server.test.ts
+++ b/packages/embeddings/src/__tests__/server.test.ts
@@ -12,9 +12,13 @@ mock.module('@hono/node-server', () => ({
 
 // Mock @xenova/transformers so importing ../embeddings (transitively from server)
 // does not try to download a real model or pull native ONNX bindings.
-const fakeExtractor = mock(async (_text: string, _opts: unknown) => ({
-  data: new Float32Array(768).fill(0.001),
-}));
+// Mirrors the real pipeline contract: a string input → [768] tensor, an array
+// of N inputs → flat [N*768] tensor with `dims = [N, 768]`.
+const fakeExtractor = mock(async (input: string | string[], _opts: unknown) => {
+  const n = Array.isArray(input) ? input.length : 1;
+  const data = new Float32Array(768 * n).fill(0.001);
+  return Array.isArray(input) ? { data, dims: [n, 768] } : { data };
+});
 mock.module('@xenova/transformers', () => ({
   pipeline: mock(async () => fakeExtractor),
   env: { cacheDir: '', backends: { onnx: { wasm: { numThreads: 1 } } } },

--- a/packages/embeddings/src/embeddings.ts
+++ b/packages/embeddings/src/embeddings.ts
@@ -68,17 +68,31 @@ export async function batchGenerateLocalEmbeddings(
 
   for (let i = 0; i < texts.length; i += batchSize) {
     const batch = texts.slice(i, i + batchSize);
-    const batchOutputs = await Promise.all(
-      batch.map((text) =>
-        extractor(text, {
-          pooling: 'cls',
-          normalize: true,
-        })
-      )
-    );
+    // Pass the whole batch as an array — transformers.js runs a single padded,
+    // vectorized ONNX forward pass instead of N separate ones (the WASM backend
+    // is single-threaded, so the old `Promise.all` over per-text calls executed
+    // serially with full per-call tokenization/tensor-alloc overhead).
+    const output = await extractor(batch, {
+      pooling: 'cls',
+      normalize: true,
+    });
 
-    const batchEmbeddings = batchOutputs.map((output) => Array.from(output.data) as number[]);
-    results.push(...batchEmbeddings);
+    // CLS-pooled + L2-normalized output is [batchSize, dim]; slice the flat
+    // Float32Array into per-row vectors. Prefer the tensor's reported dims;
+    // fall back to dividing the flat length by the batch size.
+    const flat = output.data as Float32Array | number[];
+    const dims = (output as { dims?: number[] }).dims;
+    const dim =
+      dims && dims.length >= 2
+        ? dims[dims.length - 1]!
+        : batch.length > 0
+          ? flat.length / batch.length
+          : 0;
+    for (let row = 0; row < batch.length; row++) {
+      results.push(
+        Array.from(flat.slice(row * dim, (row + 1) * dim)) as number[]
+      );
+    }
   }
 
   return results;

--- a/packages/openclaw-plugin/src/index.ts
+++ b/packages/openclaw-plugin/src/index.ts
@@ -1328,15 +1328,28 @@ const plugin = {
       // Hard-bound the recall round-trip so it can never blow OpenClaw's hook
       // budget: abort the in-flight MCP fetch at RECALL_TIMEOUT_MS and degrade
       // to "no recall" no matter what is still pending (token command, network).
+      //
+      // OpenClaw fires both `before_prompt_build` and `before_agent_start` for
+      // a turn (often back-to-back with the same prompt text). Memoize the last
+      // (query → recallBlock) so the second event is a free cache hit instead
+      // of a second `search_memory` round-trip.
+      let lastRecallQuery: string | null = null;
+      let lastRecallBlock = '';
       const doRecall = async (query: string): Promise<string> => {
         if (!config.autoRecall || !hasAuthConfigured(config)) {
           return '';
         }
-        return runWithAbortDeadline(
+        if (query === lastRecallQuery) {
+          return lastRecallBlock;
+        }
+        const block = await runWithAbortDeadline(
           (signal) => recallOnce(query, signal),
           RECALL_TIMEOUT_MS,
           ''
         );
+        lastRecallQuery = query;
+        lastRecallBlock = block;
+        return block;
       };
       const buildPrependContext = (recallBlock: string) => ({
         prependContext: getSystemContext() + (recallBlock ? '\n' + recallBlock : ''),

--- a/packages/server/src/__tests__/unit/connectors/repair-agent.test.ts
+++ b/packages/server/src/__tests__/unit/connectors/repair-agent.test.ts
@@ -163,8 +163,10 @@ describe('maybeOpenOrAppendRepairThread', () => {
 
     expect(services.createThreadForAgent).not.toHaveBeenCalled();
     expect(services.enqueueAgentMessage).not.toHaveBeenCalled();
-    // Both queued queries should have been consumed: state load + recent runs.
-    expect(remaining()).toBe(0);
+    // `loadRecentRuns` is now fetched lazily — only the feed-state load runs
+    // when the cheap Branch-2 gates (here: cooldown) reject the failure, so
+    // the queued `FROM runs` query stays unconsumed.
+    expect(remaining()).toBe(1);
   });
 
   it('skips when threshold not yet met', async () => {

--- a/packages/server/src/connectors/repair-agent.ts
+++ b/packages/server/src/connectors/repair-agent.ts
@@ -248,17 +248,29 @@ export async function maybeOpenOrAppendRepairThread(
   // doesn't get consumed before the first real failure.
   if (state.consecutive_failures <= 0) return;
 
-  const recentRuns = await loadRecentRuns(sql, feedId, 10);
-  // The completed run we were called for is the canonical signature source —
-  // not whichever run happens to be at the top of recentRuns. Out-of-order
-  // worker completions (later run finishes before an earlier one) would
-  // otherwise attach the wrong run's diagnostics. If the runId we were
-  // called for isn't yet visible in the recent runs (DB read raced the
-  // INSERT), skip silently — the next failure cron will pick it up.
-  const completedRun = recentRuns.find((r) => r.id === runId) ?? null;
+  // `loadRecentRuns` is the heaviest query in this function (10 rows incl.
+  // text blobs); the Branch-2 cheap gates below reject the vast majority of
+  // failures, so fetch it lazily — Branch 1 needs it immediately, Branch 2
+  // only after its gates pass.
+  let recentRunsCache: DiagnosticRunRow[] | undefined;
+  const getRecentRuns = async (): Promise<DiagnosticRunRow[]> => {
+    if (recentRunsCache === undefined) {
+      recentRunsCache = await loadRecentRuns(sql, feedId, 10);
+    }
+    return recentRunsCache;
+  };
 
   // Branch 1: Thread already open — consider appending.
   if (state.repair_thread_id) {
+    const recentRuns = await getRecentRuns();
+    // The completed run we were called for is the canonical signature source —
+    // not whichever run happens to be at the top of recentRuns. Out-of-order
+    // worker completions (later run finishes before an earlier one) would
+    // otherwise attach the wrong run's diagnostics. If the runId we were
+    // called for isn't yet visible in the recent runs (DB read raced the
+    // INSERT), skip silently — the next failure cron will pick it up.
+    const completedRun = recentRuns.find((r) => r.id === runId) ?? null;
+
     if (!completedRun) {
       logger.debug(
         { feed_id: feedId, run_id: runId },
@@ -415,6 +427,8 @@ export async function maybeOpenOrAppendRepairThread(
     logger.debug({ feed_id: feedId }, '[repair-agent] another worker won the open — skipping');
     return;
   }
+
+  const recentRuns = await getRecentRuns();
 
   try {
     await services.createThreadForAgent(

--- a/packages/server/src/gateway/auth/api-auth-middleware.ts
+++ b/packages/server/src/gateway/auth/api-auth-middleware.ts
@@ -7,7 +7,11 @@ export const TOKEN_EXPIRATION_MS = 24 * 60 * 60 * 1000;
 
 /**
  * Creates a Hono middleware that enforces the standard auth check:
- *   1. Settings session cookie  2. External OAuth  3. Worker token
+ *   1. Settings session cookie  2. Worker token (local)  3. External OAuth
+ *
+ * The worker-token check is local + cheap, so it runs before the remote OIDC
+ * userinfo fetch — a valid worker token never needs to round-trip to the
+ * identity provider.
  */
 export function createApiAuthMiddleware(opts: {
   externalAuthClient?: ExternalAuthClient;
@@ -24,17 +28,7 @@ export function createApiAuthMiddleware(opts: {
     }
     const token = authHeader.substring(7);
 
-    // 2. Try external OAuth token (validated against MEMORY_URL userinfo)
-    if (opts.externalAuthClient) {
-      try {
-        const userInfo = await opts.externalAuthClient.fetchUserInfo(token);
-        if (userInfo?.sub) return next();
-      } catch {
-        // Token not valid for external auth, continue to next method
-      }
-    }
-
-    // 3. Try worker token when explicitly allowed for the route
+    // 2. Try worker token when explicitly allowed for the route (local check).
     if (opts.allowWorkerToken !== false) {
       const workerData = verifyWorkerToken(token);
       if (workerData) {
@@ -42,6 +36,16 @@ export function createApiAuthMiddleware(opts: {
         if (tokenAge <= TOKEN_EXPIRATION_MS) {
           return next();
         }
+      }
+    }
+
+    // 3. Try external OAuth token (validated against MEMORY_URL userinfo).
+    if (opts.externalAuthClient) {
+      try {
+        const userInfo = await opts.externalAuthClient.fetchUserInfo(token);
+        if (userInfo?.sub) return next();
+      } catch {
+        // Token not valid for external auth, continue to next method
       }
     }
 

--- a/packages/server/src/gateway/cli/gateway.ts
+++ b/packages/server/src/gateway/cli/gateway.ts
@@ -12,7 +12,6 @@ import { OAuthClient } from "../auth/oauth/client.js";
 import { CLAUDE_PROVIDER } from "../auth/oauth/providers.js";
 import { createAuthProfileLabel } from "../auth/settings/auth-profiles-manager.js";
 import { SystemEnvStore } from "../auth/system-env-store.js";
-import type { GatewayConfig } from "../config/index.js";
 import { getModelProviderModules } from "../modules/module-system.js";
 import { createAudioRoutes } from "../routes/internal/audio.js";
 import { createDeviceAuthRoutes } from "../routes/internal/device-auth.js";

--- a/packages/server/src/gateway/connections/message-handler-bridge.ts
+++ b/packages/server/src/gateway/connections/message-handler-bridge.ts
@@ -4,12 +4,7 @@
  * settings links, allowlist, audio transcription, etc.
  */
 
-import {
-  createLogger,
-  createRootSpan,
-  flushTracing,
-  generateTraceId,
-} from "@lobu/core";
+import { createLogger, createRootSpan, generateTraceId } from "@lobu/core";
 import { previewUnlinkedNotice } from "../../preview/slack.js";
 import type { CommandDispatcher } from "../commands/command-dispatcher.js";
 import { createChatReply } from "../commands/command-reply-adapters.js";
@@ -583,7 +578,6 @@ export class MessageHandlerBridge {
       }
     } finally {
       rootSpan?.end();
-      void flushTracing();
     }
   }
 
@@ -741,7 +735,6 @@ export class MessageHandlerBridge {
       }
     } finally {
       rootSpan?.end();
-      void flushTracing();
     }
   }
 }

--- a/packages/server/src/gateway/platform/unified-thread-consumer.ts
+++ b/packages/server/src/gateway/platform/unified-thread-consumer.ts
@@ -4,7 +4,7 @@
  * via the PlatformRegistry, eliminating duplicate queue filtering logic.
  */
 
-import { createChildSpan, createLogger, flushTracing } from "@lobu/core";
+import { createChildSpan, createLogger } from "@lobu/core";
 import type { ChatResponseBridge } from "../connections/chat-response-bridge.js";
 import type {
   IMessageQueue,
@@ -148,7 +148,6 @@ export class UnifiedThreadResponseConsumer {
       throw error;
     } finally {
       span?.end();
-      void flushTracing();
     }
   }
 

--- a/packages/server/src/gateway/proxy/http-proxy.ts
+++ b/packages/server/src/gateway/proxy/http-proxy.ts
@@ -104,9 +104,11 @@ export function setProxyEgressJudge(judge: EgressJudge): void {
 
 function getGlobalConfig(): ResolvedNetworkConfig {
   if (!globalConfig) {
+    // Pre-lowercase the env-driven pattern lists once so the per-request
+    // matcher doesn't re-lowercase every pattern on every outbound request.
     globalConfig = {
-      allowedDomains: loadAllowedDomains(),
-      deniedDomains: loadDisallowedDomains(),
+      allowedDomains: loadAllowedDomains().map((d) => d.toLowerCase()),
+      deniedDomains: loadDisallowedDomains().map((d) => d.toLowerCase()),
     };
   }
   return globalConfig;

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -971,7 +971,6 @@ app.patch('/api/:orgSlug/organization/visibility', mcpAuth, async (c) => {
   invalidateOrgSlugCache(org.slug);
   invalidationEmitter.emit(org.id, {
     keys: ['organizations', 'resolve-path'],
-    resource: { type: 'organization', id: org.id },
   });
 
   return c.json({ organization: { ...org, is_member: true } });
@@ -1102,9 +1101,17 @@ app.post('/api/:orgSlug/:toolName', mcpAuth, async (c) => {
  * OpenAPI spec endpoint for ChatGPT
  * Dynamically generated from tool registry schemas
  */
+// The tool registry is static after boot, so the generated spec only depends
+// on the request origin (a tiny set in practice). Memoize per origin to turn
+// this polled endpoint into a Map lookup instead of an O(tools × schema) walk.
+const openApiSpecCache = new Map<string, object>();
 app.get('/openapi.json', (c) => {
   const serverUrl = new URL(c.req.url).origin;
-  const spec = generateOpenAPISpec(serverUrl);
+  let spec = openApiSpecCache.get(serverUrl);
+  if (!spec) {
+    spec = generateOpenAPISpec(serverUrl);
+    openApiSpecCache.set(serverUrl, spec);
+  }
   return c.json(spec);
 });
 

--- a/packages/server/src/lobu/stores/postgres-stores.ts
+++ b/packages/server/src/lobu/stores/postgres-stores.ts
@@ -122,6 +122,17 @@ function isRedactedSecretValue(value: unknown): value is string {
 function decryptLegacyEncryptedConfig(
   config: Record<string, any>
 ): Record<string, any> {
+  // Fast path (the common case): new writes never produce `enc:v1:` values,
+  // so don't clone the object unless there's actually something to decrypt.
+  let hasEncrypted = false;
+  for (const value of Object.values(config)) {
+    if (typeof value === 'string' && value.startsWith(ENC_PREFIX)) {
+      hasEncrypted = true;
+      break;
+    }
+  }
+  if (!hasEncrypted) return config;
+
   const result = { ...config };
   for (const [key, value] of Object.entries(result)) {
     if (typeof value === 'string' && value.startsWith(ENC_PREFIX)) {

--- a/packages/server/src/notifications/service.ts
+++ b/packages/server/src/notifications/service.ts
@@ -42,7 +42,9 @@ interface NotificationRow {
  * Fetches active connections and their default targets from Lobu's internal API,
  * then sends via /api/v1/messaging/send with platform-specific routing.
  */
-async function deliverToBotConnections(params: CreateNotificationParams): Promise<void> {
+async function deliverToBotConnections(
+  params: Omit<CreateNotificationParams, 'userId'>
+): Promise<void> {
   if (!isLobuGatewayRunning()) return;
 
   const port = process.env.PORT || '8787';
@@ -76,37 +78,41 @@ async function deliverToBotConnections(params: CreateNotificationParams): Promis
     if (params.connectionId) {
       connections = connections.filter((c) => c.id === params.connectionId);
     }
+    if (connections.length === 0) return;
 
-    for (const conn of connections) {
-      const target = targetMap.get(conn.platform);
-      // Platform-specific routing
-      const routing: Record<string, unknown> = {};
-      if (conn.platform === 'telegram' && target) {
-        routing.telegram = { chatId: target };
-      } else if (conn.platform === 'slack' && target) {
-        routing.slack = { channel: target };
-      }
+    // Mint the service token once per org (it's org-scoped, not per-connection).
+    const token = await getLobuServiceToken(params.organizationId);
 
-      const token = await getLobuServiceToken(params.organizationId);
-      await fetch(`${lobuBaseUrl}/api/v1/messaging/send`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          ...(token ? { Authorization: `Bearer ${token}` } : {}),
-        },
-        body: JSON.stringify({
-          agentId: conn.agentId,
-          message: text,
-          platform: conn.platform,
-          ...routing,
-        }),
-      }).catch((err) =>
-        logger.warn(
-          { err, connectionId: conn.id },
-          '[Notifications] Failed to send via Lobu connection'
-        )
-      );
-    }
+    await Promise.allSettled(
+      connections.map((conn) => {
+        const target = targetMap.get(conn.platform);
+        // Platform-specific routing
+        const routing: Record<string, unknown> = {};
+        if (conn.platform === 'telegram' && target) {
+          routing.telegram = { chatId: target };
+        } else if (conn.platform === 'slack' && target) {
+          routing.slack = { channel: target };
+        }
+        return fetch(`${lobuBaseUrl}/api/v1/messaging/send`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            ...(token ? { Authorization: `Bearer ${token}` } : {}),
+          },
+          body: JSON.stringify({
+            agentId: conn.agentId,
+            message: text,
+            platform: conn.platform,
+            ...routing,
+          }),
+        }).catch((err) =>
+          logger.warn(
+            { err, connectionId: conn.id },
+            '[Notifications] Failed to send via Lobu connection'
+          )
+        );
+      })
+    );
   } catch (err) {
     logger.warn({ err }, '[Notifications] Failed to deliver to embedded Lobu');
   }
@@ -154,12 +160,14 @@ export async function createNotificationForUsers(
     )
   `;
 
-  // Deliver to bot connections (fire-and-forget) for each user
-  for (const uid of userIds) {
-    deliverToBotConnections({ ...params, userId: uid }).catch((err) =>
-      logger.warn({ err }, '[Notifications] Failed to deliver to bot connections')
-    );
-  }
+  // Deliver to bot connections (fire-and-forget). The bot delivery targets
+  // the org's connection default channels and is identical for every user in
+  // this call, so fan it out once — not once per user (which previously
+  // re-fetched connections/targets, re-minted the service token, and posted
+  // N duplicate messages to the same channel).
+  deliverToBotConnections(params).catch((err) =>
+    logger.warn({ err }, '[Notifications] Failed to deliver to bot connections')
+  );
 }
 
 export async function listNotifications(opts: {

--- a/packages/server/src/sandbox/sdk-manifest.ts
+++ b/packages/server/src/sandbox/sdk-manifest.ts
@@ -8,12 +8,19 @@ import { METHOD_METADATA } from "./method-metadata";
 
 export type SDKMode = "read" | "full";
 
-export function enumerateSDKManifest(
+type SDKManifest = { topLevel: string[]; byNamespace: Record<string, string[]> };
+
+// METHOD_METADATA is a static module constant, so there are only four distinct
+// manifests (mode × allowCrossOrg). Memoize them so each sandbox call is a Map
+// lookup instead of a ~545-entry walk + allocations.
+const manifestCache = new Map<string, SDKManifest>();
+
+function buildSDKManifest(
   mode: SDKMode,
-  options?: { allowCrossOrg?: boolean },
-): { topLevel: string[]; byNamespace: Record<string, string[]> } {
+  allowCrossOrg: boolean,
+): SDKManifest {
   const topLevel = ["query", "log"];
-  if (options?.allowCrossOrg !== false) topLevel.unshift("org");
+  if (allowCrossOrg) topLevel.unshift("org");
 
   const byNamespace: Record<string, string[]> = {};
   for (const [path, meta] of Object.entries(METHOD_METADATA)) {
@@ -24,4 +31,18 @@ export function enumerateSDKManifest(
     (byNamespace[ns] ??= []).push(path.slice(dot + 1));
   }
   return { topLevel, byNamespace };
+}
+
+export function enumerateSDKManifest(
+  mode: SDKMode,
+  options?: { allowCrossOrg?: boolean },
+): SDKManifest {
+  const allowCrossOrg = options?.allowCrossOrg !== false;
+  const key = `${mode}:${allowCrossOrg ? "1" : "0"}`;
+  let manifest = manifestCache.get(key);
+  if (!manifest) {
+    manifest = buildSDKManifest(mode, allowCrossOrg);
+    manifestCache.set(key, manifest);
+  }
+  return manifest;
 }

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -43,11 +43,6 @@ import { getEnvFromProcess } from './utils/env';
 import logger from './utils/logger';
 import { initWorkspaceProvider } from './workspace';
 
-// Crash loud at boot if the runtime image is missing any connector external
-// dep, instead of letting every feed silently fail with "Missing npm
-// dependency: X" hours later.
-assertExternalDepsResolvable(createRequire(import.meta.url).resolve);
-
 // Create a wrapper app that injects environment into each request
 const app = new Hono<{ Bindings: Env }>();
 
@@ -65,11 +60,12 @@ if (!process.env.LOBU_DEV_PROJECT_PATH) {
   process.env.LOBU_DEV_PROJECT_PATH = PACKAGE_REPO_ROOT;
 }
 
-// Inject environment variables into Hono context
+// Inject environment variables into Hono context. The snapshot is immutable
+// post-boot and callers only read it, so assign it by reference instead of
+// spreading it onto a fresh `c.env` object on every request.
 const env = getEnvFromProcess();
 app.use('*', async (c, next) => {
-  // Set environment variables on the context
-  Object.assign(c.env, env);
+  c.env = env as Env;
   return next();
 });
 
@@ -158,6 +154,16 @@ async function main() {
 
   httpServer.listen(port, host, () => {
     logger.info({ host, port }, `Server running at http://${host}:${port}`);
+    // Crash loud if the runtime image is missing any connector external dep,
+    // instead of letting every feed silently fail with "Missing npm
+    // dependency: X" hours later. Run this after listen() so the synchronous
+    // require.resolve walk doesn't add to cold-boot/readiness latency.
+    try {
+      assertExternalDepsResolvable(createRequire(import.meta.url).resolve);
+    } catch (err) {
+      logger.error({ err }, 'Connector external dependency check failed');
+      process.exit(1);
+    }
   });
 }
 

--- a/packages/server/src/tools/admin/manage_view_templates.ts
+++ b/packages/server/src/tools/admin/manage_view_templates.ts
@@ -260,7 +260,6 @@ async function handleSet(
 
   emit(ctx.organizationId, {
     keys: ['resolve-path', 'entity-types', 'view-template-history'],
-    resource: { type: args.resource_type, id: args.resource_id },
   });
 
   const [resolved] = await resolveUsernames([versionRow as Record<string, unknown>], 'created_by');
@@ -400,7 +399,6 @@ async function handleRollback(
 
   emit(ctx.organizationId, {
     keys: ['resolve-path', 'entity-types', 'view-template-history'],
-    resource: { type: args.resource_type, id: args.resource_id },
   });
 
   const [resolvedVersion] = await resolveUsernames(
@@ -440,7 +438,6 @@ async function handleRemoveTab(
 
   emit(ctx.organizationId, {
     keys: ['resolve-path', 'entity-types', 'view-template-history'],
-    resource: { type: args.resource_type, id: args.resource_id },
   });
 
   return {

--- a/packages/server/src/tools/registry.ts
+++ b/packages/server/src/tools/registry.ts
@@ -170,11 +170,16 @@ const TOOLS: ToolDefinition[] = [
 // Helper Functions
 // ============================================
 
+// TOOLS is a module constant with no runtime mutation — index it once.
+const TOOLS_BY_NAME: Map<string, ToolDefinition> = new Map(
+  TOOLS.map((tool) => [tool.name, tool])
+);
+
 /**
  * Get tool by name
  */
 export function getTool(name: string): ToolDefinition | undefined {
-  return TOOLS.find((tool) => tool.name === name);
+  return TOOLS_BY_NAME.get(name);
 }
 
 /**
@@ -270,6 +275,11 @@ function filterSchemaForAccessLevel(
   return null;
 }
 
+// The tool registry + its schemas are static after module load, so the
+// computed tool list depends only on the three options. Memoize per option
+// tuple (a handful of distinct values in practice).
+const allToolsCache = new Map<string, ReturnType<typeof computeAllTools>>();
+
 /**
  * Get all tool definitions for MCP tools/list
  */
@@ -281,7 +291,20 @@ export function getAllTools(options?: {
   const includeInternalTools = options?.includeInternalTools ?? true;
   const publicOnly = options?.publicOnly ?? false;
   const maxAccessLevel = options?.maxAccessLevel ?? 'admin';
+  const cacheKey = `${includeInternalTools ? 1 : 0}:${publicOnly ? 1 : 0}:${maxAccessLevel}`;
+  let cached = allToolsCache.get(cacheKey);
+  if (!cached) {
+    cached = computeAllTools(includeInternalTools, publicOnly, maxAccessLevel);
+    allToolsCache.set(cacheKey, cached);
+  }
+  return cached;
+}
 
+function computeAllTools(
+  includeInternalTools: boolean,
+  publicOnly: boolean,
+  maxAccessLevel: 'read' | 'write' | 'admin'
+) {
   return TOOLS.filter((tool) => includeInternalTools || !tool.internal)
     .filter((tool) => !publicOnly || getPublicReadableActions(tool.name) !== undefined)
     .map((tool) => {

--- a/packages/server/src/utils/__tests__/url-builder.test.ts
+++ b/packages/server/src/utils/__tests__/url-builder.test.ts
@@ -1,6 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { buildEntityUrl, getPublicWebUrl } from '../url-builder';
-import { HOSTED_UI_FALLBACK_ORIGIN } from '../public-origin';
+import {
+  HOSTED_UI_FALLBACK_ORIGIN,
+  __resetPublicOriginCachesForTests,
+} from '../public-origin';
 
 /**
  * Behavior contract for `getPublicWebUrl`:
@@ -17,6 +20,7 @@ describe('getPublicWebUrl', () => {
 
   beforeEach(() => {
     delete process.env.PUBLIC_WEB_URL;
+    __resetPublicOriginCachesForTests();
   });
 
   afterEach(() => {
@@ -25,6 +29,7 @@ describe('getPublicWebUrl', () => {
     } else {
       delete process.env.PUBLIC_WEB_URL;
     }
+    __resetPublicOriginCachesForTests();
   });
 
   it('returns explicit baseUrl when provided', () => {

--- a/packages/server/src/utils/public-origin.ts
+++ b/packages/server/src/utils/public-origin.ts
@@ -17,8 +17,24 @@ function toOrigin(value?: string | null): string | undefined {
   }
 }
 
+// PUBLIC_WEB_URL is immutable post-boot; parse it once. `null` sentinel marks
+// "computed and absent" so we don't re-parse on every auth resolution.
+const UNRESOLVED = Symbol('unresolved');
+let configuredPublicOriginCache: string | undefined | typeof UNRESOLVED =
+  UNRESOLVED;
+
 export function getConfiguredPublicOrigin(): string | undefined {
-  return toOrigin(process.env.PUBLIC_WEB_URL);
+  if (configuredPublicOriginCache !== UNRESOLVED) {
+    return configuredPublicOriginCache;
+  }
+  configuredPublicOriginCache = toOrigin(process.env.PUBLIC_WEB_URL);
+  return configuredPublicOriginCache;
+}
+
+/** Test-only: clear memoized origin/local-frontend caches. */
+export function __resetPublicOriginCachesForTests(): void {
+  configuredPublicOriginCache = UNRESOLVED;
+  localFrontendCache = undefined;
 }
 
 const APP_ROOT = path.resolve(fileURLToPath(new URL('.', import.meta.url)), '../..');

--- a/packages/server/src/watchers/automation.ts
+++ b/packages/server/src/watchers/automation.ts
@@ -277,6 +277,29 @@ export async function reconcileWatcherRuns(db?: DbClient): Promise<ReconcileWatc
     reconciled++;
   }
 
+  // Find the (small) set of active watcher runs awaiting a dispatched
+  // message. If there are none — the common steady state — skip the heavy
+  // `chat_message` scan entirely instead of materializing every completed
+  // thread-response run ever.
+  const pendingDispatchRows = await sql`
+    SELECT DISTINCT r.dispatched_message_id
+    FROM runs r
+    WHERE r.run_type = 'watcher'
+      AND r.status = ANY(${runStatusLiteral(ACTIVE_RUN_STATUSES)}::text[])
+      AND r.dispatched_message_id IS NOT NULL
+    LIMIT 200
+  `;
+  const pendingDispatchIds = pendingDispatchRows
+    .map((row) => (row as { dispatched_message_id?: unknown }).dispatched_message_id)
+    .filter((value): value is string => typeof value === 'string' && value.length > 0);
+
+  if (pendingDispatchIds.length === 0) {
+    return { reconciled };
+  }
+
+  // Drive the containment join from the small side (the pending dispatch ids)
+  // and bound the `chat_message` scan to recent completions — anything older
+  // is already handled by `sweepStaleWatcherRuns`.
   const terminalRows = await sql`
     WITH response_payloads AS (
       SELECT
@@ -289,6 +312,7 @@ export async function reconcileWatcherRuns(db?: DbClient): Promise<ReconcileWatc
         AND queue_name = 'thread_response'
         AND status = 'completed'
         AND action_input IS NOT NULL
+        AND completed_at > now() - interval '2 hours'
     )
     SELECT DISTINCT r.dispatched_message_id
     FROM runs r
@@ -297,7 +321,7 @@ export async function reconcileWatcherRuns(db?: DbClient): Promise<ReconcileWatc
      AND rp.payload->'processedMessageIds' ? r.dispatched_message_id
     WHERE r.run_type = 'watcher'
       AND r.status = ANY(${runStatusLiteral(ACTIVE_RUN_STATUSES)}::text[])
-      AND r.dispatched_message_id IS NOT NULL
+      AND r.dispatched_message_id = ANY(${pendingDispatchIds})
     ORDER BY r.dispatched_message_id ASC
     LIMIT 100
   `;

--- a/packages/server/src/worker-api.ts
+++ b/packages/server/src/worker-api.ts
@@ -776,17 +776,20 @@ export async function completeWorkerJob(c: Context<{ Bindings: Env }>) {
       `;
 
       // Repair-agent trigger: open / append / close threads based on the
-      // updated streak state. All errors swallowed inside the helper — must
-      // never block the worker-completion path.
+      // updated streak state. Fire-and-forget — all errors are swallowed
+      // inside the helper, the inner UPDATEs use atomic claims so concurrent
+      // invocations are safe, and the worker-completion ACK should not wait on
+      // repair-thread bookkeeping. (If the process dies mid-check the next
+      // failure re-triggers it.)
       if (isSuccess) {
-        await maybeCloseRepairThread(feedId, req.run_id).catch((err) => {
+        void maybeCloseRepairThread(feedId, req.run_id).catch((err) => {
           logger.warn(
             { feed_id: feedId, error: errorMessage(err) },
             '[completeWorkerJob] maybeCloseRepairThread threw'
           );
         });
       } else {
-        await maybeOpenOrAppendRepairThread(feedId, req.run_id).catch((err) => {
+        void maybeOpenOrAppendRepairThread(feedId, req.run_id).catch((err) => {
           logger.warn(
             { feed_id: feedId, error: errorMessage(err) },
             '[completeWorkerJob] maybeOpenOrAppendRepairThread threw'


### PR DESCRIPTION
Behavior-preserving performance fixes from the parallel performance-analysis sweep. Caching is bounded (immutable-per-process or short TTL) and credential-affecting paths invalidate correctly.

## What landed (per area, with expected win)

| Area | Change | Win |
| --- | --- | --- |
| `core/encryption.ts` | Memoize the derived `ENCRYPTION_KEY` buffer (was base64-decode + regex on every call). | Removes fixed CPU from every `verifyWorkerToken` / `decrypt` (per worker→gateway RPC, per config-value load). |
| `core/logger.ts` | Pass log `info` to Sentry by reference instead of `{...info, message}`. | No unbounded shallow-clone-then-serialize on every prod error/warn. |
| `core/sanitize.ts` | Single compiled regex for sensitive-key matching + `maxDepth` cap; drop dead `env` branch. | Bounds the per-key array scan + deep clone on large config objects logged. |
| `agent-worker/worker.ts` | `Promise.all` the `output/` dir clearing (was serial awaited `unlink`s). | Fewer serial syscalls on the per-message critical path. |
| `agent-worker/gateway-integration.ts` | Drop `JSON.stringify(payload).substring(0,500)` log on the stream-delta POST; log identifying fields only. | One full serialize-then-discard removed per delta on a long answer. |
| `embeddings/embeddings.ts` | `batchGenerateLocalEmbeddings` passes the whole batch to transformers.js (single padded vectorized ONNX pass). | ~2–5× CPU throughput on embedding backfill (the WASM backend is single-threaded; the old `Promise.all` over per-text calls ran serially). |
| `connector-worker/executor.ts` | `embed_backfill` now batches embeddings instead of one round-trip per event. | O(1) embedding call instead of O(events) on the "lots of events" path. |
| `server/gateway/auth/api-auth-middleware.ts` | Run the local worker-token check before the remote OIDC `userinfo` fetch. | Removes a remote round-trip from every worker-token request to `/api/v1/agents/*`. |
| `server/gateway/.../message-handler-bridge.ts`, `unified-thread-consumer.ts` | Stop calling `flushTracing()` per inbound message (`SimpleSpanProcessor` already exports on span end). | One outbound HTTP / connection-churn removed per message. |
| `server/gateway/proxy/http-proxy.ts` | Pre-lowercase the env domain allow/deny lists once when building global config. | Removes per-pattern `.toLowerCase()` from the per-request domain matcher. |
| `server/utils/public-origin.ts` | Memoize `getConfiguredPublicOrigin()` (mirrors `hasLocalFrontend`). | No `new URL()` per auth resolution. |
| `server/workspace/multi-tenant.ts` | Bearer (PAT/OAuth) MCP auth now uses the shared 60s membership-role cache (was hard-bypassing it every request — the cookie path already trusts it). | ~1 DB round-trip removed per steady-state bearer MCP call. |
| `server/lobu/stores/postgres-stores.ts` | Hoist `decrypt` to a static import; fast-path `decryptLegacyEncryptedConfig` (no clone unless a value is `enc:v1:`). | Removes a dynamic `require` + needless object clone from a per-row connection mapper. |
| `server/sandbox/sdk-manifest.ts`, `tools/registry.ts` | Memoize `enumerateSDKManifest`, `getAllTools`, `getTool` over the static tool registry / method metadata. | Per-sandbox-call ~545-entry walk and per-`tools/list` schema-flatten become Map lookups. |
| `server/index.ts` | Memoize `generateOpenAPISpec()` by origin. | Polled `/openapi.json` becomes a Map lookup instead of an O(tools × schema) walk. |
| `server/server.ts` | Defer `assertExternalDepsResolvable` until after `listen()`; assign the env snapshot to `c.env` by reference instead of `Object.assign` per request. | Lower cold-boot/readiness latency; one object-spread removed per request. |
| `server/identity/engine.ts` | Batch `revokeDerivationsForEvent` into one `= ANY(...)` UPDATE. | N → 1 round-trips inside the identity ingest transaction. |
| `server/watchers/automation.ts` | `reconcileWatcherRuns` short-circuits when no active watcher run awaits a dispatched message; otherwise drives the containment join from the small side and bounds the `chat_message` scan to recent completions. | Removes a multi-hundred-ms-to-seconds unbounded `runs` seq-scan that ran every 60s, forever. |
| `server/notifications/service.ts` | Dedup the connections/targets fetch + service-token mint, send via `Promise.allSettled`, and fan bot delivery out once per `createNotificationForUsers` call (was once per user → N duplicate messages + N re-fetches). | `O(users × connections)` serial HTTP → `O(connections)` parallel. |
| `server/worker-api.ts`, `connectors/repair-agent.ts` | Detach the repair-agent triggers from the worker-completion ACK (fire-and-forget; the inner UPDATEs already use atomic claims); fetch `loadRecentRuns` lazily so the heaviest query isn't paid on every rejected failure. | Repair-thread bookkeeping off the synchronous completion path. |
| `openclaw-plugin/index.ts` | Memoize the last `(query → recall block)` so the second recall hook for a turn is a free cache hit. | Cuts `search_memory` calls per turn in half on the latency-sensitive hook path. |

Validation: `make build-packages`, `bun run typecheck`, and the affected packages' unit suites (core, agent-worker, connector-worker, embeddings, server `__tests__/unit`) all pass. A few tests were updated to reflect the new behavior (encryption-key cache reset hook; `loadRecentRuns` is now lazy; the embeddings test mock now mirrors the array-batch contract). Integration suites (Postgres-backed) were not run.

## Deferred (architectural / higher-risk — needs a dedicated PR)

- [ ] `packages/server/src/db/migrations/` + `embedded-schema-patches.ts` — add a `current_events` view (no `event_embeddings` join) and migrate the ~65 call sites; med-risk view change across many readers, M–L effort. (analyst 10 #1)
- [ ] `packages/server/src/db/migrations/` — `idx_entities_metadata_gin` (GIN over `entities.metadata`) + rewrite `findEntitiesByMetadataField` to `@>`; `@>` semantics differ for non-string JSON + write-amplification — needs its own test. (analyst 10 #3)
- [ ] `packages/server/src/db/migrations/` — dynamic-metadata GIN index on `events`; same write-amplification / `@>` concerns. (analyst 10 #3)
- [ ] `packages/server/src/gateway/proxy/secret-proxy.ts` — stream request/response bodies (`duplex: 'half'`) instead of buffering into strings; needs proxy integration tests across Node 22–24. (analyst 08 #3)
- [ ] `packages/server/src/gateway/proxy/egress-judge/cache.ts` — coarsen the verdict cache key (drop/normalize the path) so plain-HTTP traffic actually hits the cache; widens the trust window — needs a per-policy opt-out. (analyst 08 #4)
- [ ] `packages/server/src/gateway/permissions/grant-store.ts` + `http-proxy.ts` — in-process grant cache for `isDenied`/`hasGrant`; invalidation wiring on grant mutations. (analyst 08 #1)
- [ ] `packages/server/src/mcp-proxy/credential-resolver.ts` — short-TTL cache for resolved MCP credentials, invalidate on auth failure; correctness-sensitive (token rotation). (analyst 11 #1)
- [ ] `packages/server/src/utils/compiler-core.ts` + `sandbox/run-script.ts` — LRU compile cache + `esbuild.transform` over `build` for sandbox scripts; needs care around the `npm:` rewrite path. (analyst 11 #2)
- [ ] `packages/server/src/sandbox/run-script.ts` — pre-snapshot `GUEST_PREAMBLE` (and the isolate-pool variant — explicitly out of scope). (analyst 11 #3)
- [ ] `packages/server/src/gateway/connections/conversation-state-store.ts` — drop the `history_index` write + DB lock from `appendHistory`, bulk-insert backfill rows; touches the Chat-SDK list contract. (analyst 07 #1)
- [ ] `packages/server/src/gateway/connections/slack-connection-coordinator.ts` — in-memory `teamId → connectionId` index for Slack webhook routing; derived-index invalidation. (analyst 07 #4)
- [ ] `packages/server/src/lobu/stores/postgres-secret-store.ts` — TTL cache for `PostgresSecretStore.get`; secret-rotation staleness window. (analyst 14 #4)
- [ ] `packages/server/src/worker-api/device-reconcile.ts` — gate `reconcileDeviceCapabilities` behind a change-detector + memoize the connector catalog walk; must keep the self-heal path. (analyst 14 #1)
- [ ] `packages/server/src/auth/schema-validation.ts` + `ajv-singleton.ts` — cache compiled AJV validators (+ optional entity-type-schema DB lookup cache). (analyst 13 #2)
- [ ] `packages/server/src/workspace/multi-tenant.ts` — full bearer-token `AuthInfo` cache + drop the redundant 3rd `SELECT "user"` by propagating `email`/`name`/`emailVerified`; touches the authz gate, needs careful invalidation. (analyst 13 #1)
- [ ] `packages/server/src/connectors/repair-agent.ts` + `worker-api.ts` — fold `maybeCloseRepairThread`'s UPDATE into the success-path feeds UPDATE; touches the worker-completion transaction's race semantics. (analyst 09 #1)
- [ ] `packages/cli/src/commands/_lib/apply/apply-cmd.ts` — parallelize `fetchRemoteSnapshot` into dependency waves with a concurrency cap; well-tested but reorders network calls. (analyst 03 #1)
- [ ] `packages/cli/src/commands/eval.ts` + `eval/runner.ts` — bounded-concurrency eval/trial runner; could surface gateway resource pressure. (analyst 03 #2)
- [ ] `packages/cli/package.json` — split server-only deps out of `@lobu/cli`'s `dependencies` (sharp/jimp/playwright as optional); easy to break a lazy runtime path. (analyst 03 #5)
- [ ] `packages/agent-worker/src/embedded/just-bash-bootstrap.ts` — memoize `discoverBinaries()` + bound the per-binary shebang read; (the lazy-import hoist is also pending). (analyst 02 #1)
- [ ] `packages/agent-worker/src/openclaw/worker.ts` — cache the `SessionManager`/`session` per `sessionFile`; correctness-sensitive (provider-change / session-reset invalidation). (analyst 02 #2)
- [ ] `packages/agent-worker/src/openclaw/worker.ts` — skip the `.skills/` rewrite when `skillsConfig` is unchanged (hash gate). (analyst 02 #5)
- [ ] `packages/agent-worker/**` + `gateway/sse-client.ts` + `embedded/mcp-cli-commands.ts` — hoist `await import(...)` of hot worker modules to static imports (also fixes a documented repo-rule violation). (analyst 02 #3)
- [ ] `packages/connector-worker/src/daemon/worker.ts` — honor `next_poll_seconds` + claim back-to-back when work is queued (instead of a fixed 10s sleep). (analyst 04 #3)
- [ ] `packages/connector-sdk/src/browser/cdp.ts` — cache the resolved CDP ws:// URL + `Promise.all` the port probes; stale-endpoint risk. (analyst 04 #4)
- [ ] `packages/connector-worker/src/executor/subprocess.ts` — warm-pool of pre-forked child processes; defeats part of the per-run isolation guarantee. (analyst 04 #6)
- [ ] `packages/connectors/**` — shared `createRateLimiter` / bounded-concurrency util + convert the per-item-sleep connectors (Reddit, Gmail, website); parallelize RSS fetches. (analyst 05 #2/#4/#5)
- [ ] `packages/openclaw-plugin/src/index.ts` — replace `fetchMcpBootstrapSync` / `refreshStoredTokenSync` `node -e` subprocesses with async fire-and-forget; touches the "tools must exist before prompt build" invariant. (analyst 06 #3)
- [ ] `packages/landing/**` — re-architect `client:load` islands (`client:visible`/`client:idle`, pass selected use-case data as props); re-encode `demo.mp4` + optimize `public/` images. (analyst 06 #5/#6)
- [ ] `packages/server/src/__tests__/setup/test-db.ts` + `vitest.config.ts` — per-fork test database (drop `singleFork`); test-isolation rewrite needing a full integration run. (analyst 15 #1)