### PR TITLE
test(connections): pin webhook signature verification contract

### DIFF
--- a/packages/server/src/__tests__/webhook-signatures.test.ts
+++ b/packages/server/src/__tests__/webhook-signatures.test.ts
@@ -1,0 +1,166 @@
+/**
+ * Webhook signature verification — regression tests.
+ *
+ * Inbound chat-platform webhooks are authenticated by the Chat SDK adapter,
+ * not the HTTP route. These tests pin that contract:
+ *
+ *  1. The Slack adapter (`@chat-adapter/slack`) rejects a forged
+ *     `x-slack-signature` with HTTP 401 and accepts a correctly-signed
+ *     payload — proving the HMAC-SHA256(`v0:{ts}:{rawBody}`) check is live.
+ *  2. The `/slack/events` route keeps its edge-layer freshness-window check
+ *     (replay defense) and forwards everything else to
+ *     `ChatInstanceManager.handleSlackAppWebhook`, which fans out to the
+ *     adapter described above.
+ */
+
+import { createHmac } from "node:crypto";
+import { createSlackAdapter } from "@chat-adapter/slack";
+import { describe, expect, it, vi } from "vitest";
+import { createSlackRoutes } from "../gateway/routes/public/slack.js";
+import type { ChatInstanceManager } from "../gateway/connections/chat-instance-manager.js";
+
+const SIGNING_SECRET = "8f742231b10e8888abcd99yyyzzz85a5";
+
+function slackSignature(body: string, timestamp: string): string {
+  const base = `v0:${timestamp}:${body}`;
+  return `v0=${createHmac("sha256", SIGNING_SECRET).update(base).digest("hex")}`;
+}
+
+function nowTs(): string {
+  return String(Math.floor(Date.now() / 1000));
+}
+
+describe("Slack adapter webhook signature verification", () => {
+  const adapter = createSlackAdapter({
+    signingSecret: SIGNING_SECRET,
+    botToken: "xoxb-test",
+    logger: { debug() {}, info() {}, warn() {}, error() {}, child() { return this; } } as never,
+  });
+
+  it("rejects a payload with a forged signature (401)", async () => {
+    const body = JSON.stringify({ type: "url_verification", challenge: "abc" });
+    const ts = nowTs();
+    const req = new Request("https://example.test/slack/events", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-slack-request-timestamp": ts,
+        // Wrong secret → signature won't match.
+        "x-slack-signature": `v0=${createHmac("sha256", "not-the-secret")
+          .update(`v0:${ts}:${body}`)
+          .digest("hex")}`,
+      },
+      body,
+    });
+
+    const res = await adapter.handleWebhook(req);
+    expect(res.status).toBe(401);
+  });
+
+  it("rejects a payload with no signature header (401)", async () => {
+    const body = JSON.stringify({ type: "url_verification", challenge: "abc" });
+    const req = new Request("https://example.test/slack/events", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-slack-request-timestamp": nowTs(),
+      },
+      body,
+    });
+
+    const res = await adapter.handleWebhook(req);
+    expect(res.status).toBe(401);
+  });
+
+  it("rejects a stale-but-correctly-signed payload (replay, 401)", async () => {
+    const body = JSON.stringify({ type: "url_verification", challenge: "abc" });
+    const ts = String(Math.floor(Date.now() / 1000) - 60 * 60); // 1h old
+    const req = new Request("https://example.test/slack/events", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-slack-request-timestamp": ts,
+        "x-slack-signature": slackSignature(body, ts),
+      },
+      body,
+    });
+
+    const res = await adapter.handleWebhook(req);
+    expect(res.status).toBe(401);
+  });
+
+  it("accepts a correctly-signed url_verification challenge", async () => {
+    const challenge = "test-challenge-123";
+    const body = JSON.stringify({ type: "url_verification", challenge });
+    const ts = nowTs();
+    const req = new Request("https://example.test/slack/events", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-slack-request-timestamp": ts,
+        "x-slack-signature": slackSignature(body, ts),
+      },
+      body,
+    });
+
+    const res = await adapter.handleWebhook(req);
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as { challenge: string };
+    expect(json.challenge).toBe(challenge);
+  });
+});
+
+describe("/slack/events route", () => {
+  function makeRouter(handleSlackAppWebhook: (req: Request) => Promise<Response>) {
+    const manager = {
+      handleSlackAppWebhook,
+      getServices: () => ({ getPublicGatewayUrl: () => undefined }),
+    } as unknown as ChatInstanceManager;
+    return createSlackRoutes(manager);
+  }
+
+  it("rejects a stale timestamp at the edge before delegating", async () => {
+    const handler = vi.fn(async () => new Response("ok"));
+    const router = makeRouter(handler);
+    const staleTs = String(Math.floor(Date.now() / 1000) - 60 * 60);
+
+    const res = await router.request("/slack/events", {
+      method: "POST",
+      headers: { "x-slack-request-timestamp": staleTs },
+      body: "{}",
+    });
+
+    expect(res.status).toBe(400);
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("delegates a fresh request to ChatInstanceManager.handleSlackAppWebhook", async () => {
+    const handler = vi.fn(async () => new Response("forwarded", { status: 200 }));
+    const router = makeRouter(handler);
+
+    const res = await router.request("/slack/events", {
+      method: "POST",
+      headers: { "x-slack-request-timestamp": nowTs() },
+      body: JSON.stringify({ type: "event_callback" }),
+    });
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe("forwarded");
+  });
+
+  it("surfaces a 500 when delegation throws", async () => {
+    const handler = vi.fn(async () => {
+      throw new Error("boom");
+    });
+    const router = makeRouter(handler);
+
+    const res = await router.request("/slack/events", {
+      method: "POST",
+      headers: { "x-slack-request-timestamp": nowTs() },
+      body: "{}",
+    });
+
+    expect(res.status).toBe(500);
+  });
+});

--- a/packages/server/src/gateway/connections/chat-instance-manager.ts
+++ b/packages/server/src/gateway/connections/chat-instance-manager.ts
@@ -440,6 +440,19 @@ export class ChatInstanceManager {
       return new Response("Connection not found", { status: 404 });
     }
 
+    // Inbound webhook authentication is performed by the platform's Chat SDK
+    // adapter, which owns the per-platform secret and the documented scheme:
+    //   - slack    → HMAC-SHA256 over `v0:{ts}:{rawBody}` vs `x-slack-signature`
+    //                (`@chat-adapter/slack` `verifySignature`, 401 on mismatch)
+    //   - telegram → constant-time compare of `x-telegram-bot-api-secret-token`
+    //                to the configured `secretToken` (`@chat-adapter/telegram`)
+    //   - discord  → Ed25519 verify of `x-signature-ed25519` /
+    //                `x-signature-timestamp` with the app public key
+    //   - whatsapp → HMAC-SHA256 over the raw body vs `x-hub-signature-256`
+    //                using the Meta app secret
+    //   - teams    → Bot Framework bearer-JWT validation in `bridgeAdapter`
+    // Each adapter returns 401/403 on failure, so a forged payload never
+    // reaches the message pipeline below.
     const { platform } = instance.connection;
     const webhookHandler = instance.chat.webhooks?.[platform];
     if (!webhookHandler) {

--- a/packages/server/src/gateway/routes/public/slack.ts
+++ b/packages/server/src/gateway/routes/public/slack.ts
@@ -160,9 +160,20 @@ export function createSlackRoutes(manager: ChatInstanceManager): Hono {
 
   router.post("/slack/events", async (c) => {
     // Reject webhooks whose timestamp is outside Slack's 5-minute window.
-    // The Chat SDK adapter does its own signature check, but enforcing the
-    // freshness window at the edge defends against replay of an intercepted
-    // (still-signed) payload regardless of what the adapter does.
+    //
+    // HMAC signature verification proper happens downstream in the Chat SDK
+    // Slack adapter — `@chat-adapter/slack`'s `SlackAdapter.handleWebhook()`
+    // recomputes `v0={HMAC-SHA256(signingSecret, "v0:{ts}:{rawBody}")}` and
+    // `timingSafeEqual`s it against `x-slack-signature`, returning a 401 on
+    // mismatch (see `verifySignature`). Every path out of this route reaches
+    // that adapter: `manager.handleSlackAppWebhook` → `SlackConnection
+    // Coordinator.handleAppWebhook` → `forwardWebhook` → `ChatInstanceManager
+    // .handleWebhook` → `chat.webhooks.slack` (the adapter), or the OAuth
+    // fallback chat that calls `adapter.handleWebhook` directly.
+    //
+    // Enforcing the freshness window here as well is cheap defense-in-depth:
+    // it rejects replays of an intercepted (still-signed) payload before any
+    // body parsing, independent of the adapter.
     const tsHeader = c.req.header("x-slack-request-timestamp");
     if (tsHeader) {
       const ts = Number(tsHeader);


### PR DESCRIPTION
## What

Webhook signature verification work-stream (WS1).

**Finding:** the Slack `/slack/events` route and the generic `/api/v1/webhooks/:id` dispatch in `ChatInstanceManager.handleWebhook()` delegate signature verification to the Chat SDK adapters. I audited the bundled adapters and confirmed each one genuinely performs the documented scheme and returns 401/403 on mismatch:

| Platform | Scheme | Where |
| --- | --- | --- |
| Slack | HMAC-SHA256 over `v0:{ts}:{rawBody}` vs `x-slack-signature`, `timingSafeEqual` | `@chat-adapter/slack` `verifySignature` |
| Telegram | constant-time compare of `x-telegram-bot-api-secret-token` to configured `secretToken` | `@chat-adapter/telegram` |
| Discord | Ed25519 verify of `x-signature-ed25519` / `x-signature-timestamp` | `@chat-adapter/discord` `verifyKey` |
| WhatsApp | HMAC-SHA256 over the raw body vs `x-hub-signature-256` (Meta app secret) | `@chat-adapter/whatsapp` `verifySignature` |
| Teams | Bot Framework bearer-JWT validation | `@chat-adapter/teams` `bridgeAdapter.dispatch` |

So no edge-layer half-checks were added (they would duplicate the secret handling and risk drift). Instead this PR:

- **Pins the contract with a regression test** (`packages/server/src/__tests__/webhook-signatures.test.ts`) that drives the real `@chat-adapter/slack` adapter: forged signature → 401, missing signature → 401, stale-but-correctly-signed replay → 401, correctly-signed `url_verification` challenge → 200. Plus route-level tests that `/slack/events` keeps its 5-minute freshness-window check at the edge and forwards fresh requests to `ChatInstanceManager.handleSlackAppWebhook`, and surfaces 500 on delegation failure.
- **Documents** where verification happens (comments in `slack.ts` and `ChatInstanceManager.handleWebhook()`), replacing the vague "the adapter does its own signature check" line with the concrete path + per-platform scheme.

## Validation

- `make build-packages` ✓
- `bun run typecheck` ✓
- `SKIP_TEST_DB_SETUP=1 bunx vitest run src/__tests__/webhook-signatures.test.ts` → 7/7 ✓

## Files changed

- `packages/server/src/gateway/routes/public/slack.ts` — comment
- `packages/server/src/gateway/connections/chat-instance-manager.ts` — comment
- `packages/server/src/__tests__/webhook-signatures.test.ts` — new test