### PR TITLE
fix(secret-proxy): 24h orphan TTL + per-source failed-resolution throttle

### DIFF
--- a/packages/server/src/__tests__/unit/secret-proxy-lifecycle.test.ts
+++ b/packages/server/src/__tests__/unit/secret-proxy-lifecycle.test.ts
@@ -1,0 +1,218 @@
+/**
+ * Secret-proxy lifecycle & rate-limiting contract.
+ *
+ *  - placeholder mappings past their TTL are not resolved (orphan GC)
+ *  - repeated bad placeholders from one source get throttled after the
+ *    threshold (compromised-worker probe / log-spam guard)
+ *  - a valid placeholder always resolves and is swapped into the auth header
+ *  - a placeholder bound to agent A used on agent B's URL is still 403
+ *    (cross-agent credential theft — unchanged behaviour, pinned here)
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import type { SecretStore } from "../../gateway/secrets/index.js";
+import {
+  __resetPlaceholderCacheForTests,
+  generatePlaceholder,
+  SecretProxy,
+  storeSecretMapping,
+} from "../../gateway/proxy/secret-proxy.js";
+
+const PLACEHOLDER_PREFIX = "lobu_secret_";
+
+function makeSecretStore(value: string): SecretStore {
+  return {
+    async get() {
+      return value;
+    },
+  } as unknown as SecretStore;
+}
+
+interface CapturedRequest {
+  url: string;
+  headers: Record<string, string>;
+}
+
+let captured: CapturedRequest[] = [];
+let originalFetch: typeof fetch;
+
+beforeEach(() => {
+  __resetPlaceholderCacheForTests();
+  captured = [];
+  originalFetch = globalThis.fetch;
+  globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    captured.push({
+      url: String(input),
+      headers: { ...(init?.headers as Record<string, string>) },
+    });
+    return new Response("ok", { status: 200 });
+  }) as typeof fetch;
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  __resetPlaceholderCacheForTests();
+});
+
+function makeProxy(secret = "real-secret"): SecretProxy {
+  return new SecretProxy(
+    { defaultUpstreamUrl: "https://upstream.example.com" },
+    makeSecretStore(secret)
+  );
+}
+
+async function callProxy(
+  proxy: SecretProxy,
+  path: string,
+  bearer: string,
+  headers: Record<string, string> = {}
+): Promise<Response> {
+  return proxy.getApp().request(`http://proxy.local${path}`, {
+    method: "POST",
+    headers: { authorization: `Bearer ${bearer}`, ...headers },
+    body: "{}",
+  });
+}
+
+describe("secret-proxy placeholder TTL", () => {
+  it("does not resolve a mapping past its TTL", async () => {
+    const uuid = crypto.randomUUID();
+    // Negative TTL → already expired.
+    storeSecretMapping(
+      uuid,
+      {
+        agentId: "agent-a",
+        envVarName: "MY_TOKEN",
+        secretRef: "builtin:deployments/d/agent-a/MY_TOKEN",
+        deploymentName: "d",
+      },
+      -1
+    );
+    const proxy = makeProxy("real-secret");
+    await callProxy(proxy, "/v1/thing", `${PLACEHOLDER_PREFIX}${uuid}`);
+    expect(captured).toHaveLength(1);
+    // Expired mapping → fail closed → empty auth forwarded.
+    expect(captured[0]!.headers.authorization).toBe("Bearer ");
+  });
+
+  it("resolves a live mapping and swaps the real secret into the auth header", async () => {
+    const placeholder = generatePlaceholder(
+      "agent-a",
+      "MY_TOKEN",
+      "builtin:deployments/d/agent-a/MY_TOKEN",
+      "d"
+    );
+    const proxy = makeProxy("real-secret");
+    await callProxy(proxy, "/v1/thing", placeholder);
+    expect(captured).toHaveLength(1);
+    expect(captured[0]!.headers.authorization).toBe("Bearer real-secret");
+  });
+});
+
+describe("secret-proxy failed-resolution throttle", () => {
+  it("throttles a source after repeated bad placeholders, even for a later valid one", async () => {
+    const proxy = makeProxy("real-secret");
+    const source = "203.0.113.7";
+
+    // 20 bad lookups: each fails closed but is still attempted.
+    for (let i = 0; i < 20; i++) {
+      await callProxy(
+        proxy,
+        "/v1/thing",
+        `${PLACEHOLDER_PREFIX}${crypto.randomUUID()}`,
+        { "x-forwarded-for": source }
+      );
+    }
+    // Now register a genuinely valid placeholder...
+    const placeholder = generatePlaceholder(
+      "agent-a",
+      "MY_TOKEN",
+      "builtin:deployments/d/agent-a/MY_TOKEN",
+      "d"
+    );
+    // ...and call from the throttled source: still fails closed (empty auth).
+    await callProxy(proxy, "/v1/thing", placeholder, {
+      "x-forwarded-for": source,
+    });
+    expect(captured[captured.length - 1]!.headers.authorization).toBe(
+      "Bearer "
+    );
+
+    // A different source with the same valid placeholder still works.
+    await callProxy(proxy, "/v1/thing", placeholder, {
+      "x-forwarded-for": "198.51.100.2",
+    });
+    expect(captured[captured.length - 1]!.headers.authorization).toBe(
+      "Bearer real-secret"
+    );
+  });
+
+  it("does not throttle a source doing many valid lookups", async () => {
+    const proxy = makeProxy("real-secret");
+    const placeholder = generatePlaceholder(
+      "agent-a",
+      "MY_TOKEN",
+      "builtin:deployments/d/agent-a/MY_TOKEN",
+      "d"
+    );
+    for (let i = 0; i < 50; i++) {
+      await callProxy(proxy, "/v1/thing", placeholder, {
+        "x-forwarded-for": "203.0.113.99",
+      });
+    }
+    expect(captured[captured.length - 1]!.headers.authorization).toBe(
+      "Bearer real-secret"
+    );
+  });
+});
+
+describe("secret-proxy cross-agent binding (unchanged)", () => {
+  it("rejects a placeholder bound to agent A used on agent B's URL with 403", async () => {
+    const proxy = new SecretProxy(
+      {
+        defaultUpstreamUrl: "https://upstream.example.com",
+        providerUpstreams: [
+          { slug: "anthropic", upstreamBaseUrl: "https://api.anthropic.com" },
+        ],
+      },
+      makeSecretStore("real-secret")
+    );
+    const placeholder = generatePlaceholder(
+      "agent-a",
+      "ANTHROPIC_API_KEY",
+      "builtin:deployments/d/agent-a/ANTHROPIC_API_KEY",
+      "d"
+    );
+    const res = await callProxy(
+      proxy,
+      "/api/proxy/anthropic/a/agent-b/v1/messages",
+      placeholder
+    );
+    expect(res.status).toBe(403);
+    expect(captured).toHaveLength(0);
+  });
+
+  it("allows a placeholder used on its own agent's URL", async () => {
+    const proxy = new SecretProxy(
+      {
+        defaultUpstreamUrl: "https://upstream.example.com",
+        providerUpstreams: [
+          { slug: "anthropic", upstreamBaseUrl: "https://api.anthropic.com" },
+        ],
+      },
+      makeSecretStore("real-secret")
+    );
+    const placeholder = generatePlaceholder(
+      "agent-a",
+      "ANTHROPIC_API_KEY",
+      "builtin:deployments/d/agent-a/ANTHROPIC_API_KEY",
+      "d"
+    );
+    const res = await callProxy(
+      proxy,
+      "/api/proxy/anthropic/a/agent-a/v1/messages",
+      placeholder
+    );
+    expect(res.status).toBe(200);
+  });
+});

--- a/packages/server/src/gateway/orchestration/base-deployment-manager.ts
+++ b/packages/server/src/gateway/orchestration/base-deployment-manager.ts
@@ -28,8 +28,20 @@ export type { MessagePayload };
 
 const logger = createLogger("orchestrator");
 
-/** TTL applied to non-provider secret env var placeholders. */
-const SECRET_PLACEHOLDER_TTL_SECONDS = 7 * 24 * 60 * 60;
+/**
+ * TTL applied to non-provider secret env var placeholders. Mappings are
+ * cascade-deleted on deployment teardown; this only bounds how long an
+ * orphaned mapping (pod crash, agent deleted mid-day) survives. 24h default,
+ * overridable via `SECRET_PLACEHOLDER_TTL_MS`.
+ */
+const SECRET_PLACEHOLDER_TTL_SECONDS = (() => {
+  const raw = process.env.SECRET_PLACEHOLDER_TTL_MS;
+  if (raw) {
+    const ms = Number(raw);
+    if (Number.isFinite(ms) && ms > 0) return Math.floor(ms / 1000);
+  }
+  return 24 * 60 * 60;
+})();
 
 /**
  * Maximum number of agents tracked in the grant-sync LRU. Oldest entry is
@@ -738,7 +750,8 @@ export abstract class BaseDeploymentManager {
             agentId,
             key,
             secretRef,
-            deploymentName
+            deploymentName,
+            SECRET_PLACEHOLDER_TTL_SECONDS
           );
           envVars[key] = placeholder;
           hasSecrets = true;
@@ -964,7 +977,7 @@ export abstract class BaseDeploymentManager {
       // Cascade-delete the underlying non-provider secrets written by
       // `injectSecretPlaceholders` under `deployments/{deploymentName}/`.
       // Without this, the placeholder mappings are gone but the backing
-      // secret entries linger until their 7-day TTL expires (and AWS SM
+      // secret entries linger until their TTL expires (and AWS SM
       // entries would leak forever).
       if (this.secretStore) {
         try {

--- a/packages/server/src/gateway/proxy/secret-proxy.ts
+++ b/packages/server/src/gateway/proxy/secret-proxy.ts
@@ -5,10 +5,94 @@ import type { AuthProfilesManager } from "../auth/settings/auth-profiles-manager
 import type { ProviderCredentialContext } from "../embedded.js";
 import type { ProviderUpstreamConfig } from "../modules/module-system.js";
 import type { SecretStore } from "../secrets/index.js";
+import { getClientIp } from "../utils/rate-limiter.js";
 
 const logger = createLogger("secret-proxy");
 
 const PLACEHOLDER_PREFIX = "lobu_secret_";
+
+/**
+ * Default TTL for orphaned placeholder→secret mappings. Mappings are
+ * cascade-deleted on deployment teardown (`deleteSecretMappings`); this TTL
+ * only bounds how long a mapping survives if teardown never runs (worker pod
+ * crash, agent deleted mid-day). 24h instead of the old ~7 days narrows the
+ * window an orphaned `lobu_secret_<uuid>` stays live. Configurable via
+ * `SECRET_PLACEHOLDER_TTL_MS`.
+ */
+function defaultPlaceholderTtlSeconds(): number {
+  const raw = process.env.SECRET_PLACEHOLDER_TTL_MS;
+  if (raw) {
+    const ms = Number(raw);
+    if (Number.isFinite(ms) && ms > 0) return Math.floor(ms / 1000);
+  }
+  return 24 * 60 * 60;
+}
+
+/**
+ * Per-source cap on *failed* placeholder resolutions. A compromised worker can
+ * probe the proxy with bogus `lobu_secret_<uuid>` tokens; without a cap each
+ * miss is logged, so it doubles as a log-spam vector. Once a source exceeds
+ * the threshold within the window, further resolutions hard-fail and we log
+ * the throttle once instead of per-attempt. Only failures count — legitimate
+ * high-throughput valid lookups are never throttled.
+ */
+const RESOLVE_FAILURE_THRESHOLD = 20;
+const RESOLVE_FAILURE_WINDOW_MS = 5 * 60 * 1000;
+
+interface FailureBucket {
+  count: number;
+  windowStartMs: number;
+  throttledLogged: boolean;
+}
+
+class ResolutionFailureLimiter {
+  private readonly buckets = new Map<string, FailureBucket>();
+
+  /** Returns true if the source is currently throttled (over threshold). */
+  isThrottled(source: string): boolean {
+    const bucket = this.buckets.get(source);
+    if (!bucket) return false;
+    if (Date.now() - bucket.windowStartMs >= RESOLVE_FAILURE_WINDOW_MS) {
+      this.buckets.delete(source);
+      return false;
+    }
+    return bucket.count >= RESOLVE_FAILURE_THRESHOLD;
+  }
+
+  /**
+   * Record a failed resolution for a source. Returns whether the caller
+   * should log this particular failure (true the first time the threshold is
+   * crossed — the "source throttled" line — and for every failure below it;
+   * false once we've already logged the throttle for this window).
+   */
+  recordFailure(source: string): { shouldLog: boolean; nowThrottled: boolean } {
+    const now = Date.now();
+    let bucket = this.buckets.get(source);
+    if (!bucket || now - bucket.windowStartMs >= RESOLVE_FAILURE_WINDOW_MS) {
+      bucket = { count: 0, windowStartMs: now, throttledLogged: false };
+      this.buckets.set(source, bucket);
+    }
+    bucket.count += 1;
+    const nowThrottled = bucket.count >= RESOLVE_FAILURE_THRESHOLD;
+    if (nowThrottled) {
+      if (bucket.throttledLogged) return { shouldLog: false, nowThrottled };
+      bucket.throttledLogged = true;
+      return { shouldLog: true, nowThrottled };
+    }
+    return { shouldLog: true, nowThrottled };
+  }
+
+  /** Record a successful resolution — clears the source's failure bucket. */
+  recordSuccess(source: string): void {
+    this.buckets.delete(source);
+  }
+
+  reset(): void {
+    this.buckets.clear();
+  }
+}
+
+const resolutionFailureLimiter = new ResolutionFailureLimiter();
 
 /**
  * In-memory placeholder→SecretMapping cache. Per-pod by design: workers are
@@ -231,9 +315,17 @@ export class SecretProxy {
   /**
    * If the value contains a UUID placeholder prefix, resolve the real secret.
    * Returns the value unchanged if it's not a recognized pattern.
+   *
+   * `source` identifies the caller (best available identity: bound agentId or
+   * remote address) for per-source failed-resolution rate limiting.
    */
-  private async swap(value: string): Promise<string> {
+  private async swap(value: string, source: string): Promise<string> {
     if (value.includes(PLACEHOLDER_PREFIX)) {
+      if (resolutionFailureLimiter.isThrottled(source)) {
+        // Source has burned through its failure budget — hard-fail without
+        // touching the cache or logging another line.
+        return "";
+      }
       const resolved = await this.resolveSecret(value);
       if (!resolved) {
         // Fail closed: forwarding the literal placeholder upstream would
@@ -241,9 +333,21 @@ export class SecretProxy {
         // logs / user-facing messages), giving an attacker a stable handle
         // to enumerate. An empty string fails the auth check upstream
         // without exposing the ref.
-        logger.warn("Failed to resolve secret placeholder");
+        const { shouldLog, nowThrottled } =
+          resolutionFailureLimiter.recordFailure(source);
+        if (shouldLog) {
+          if (nowThrottled) {
+            logger.warn(
+              { source },
+              "Throttling placeholder resolution for source after repeated failures"
+            );
+          } else {
+            logger.warn({ source }, "Failed to resolve secret placeholder");
+          }
+        }
         return "";
       }
+      resolutionFailureLimiter.recordSuccess(source);
       return resolved;
     }
 
@@ -419,9 +523,15 @@ export class SecretProxy {
       // Legacy path: swap UUID placeholders in auth headers (non-provider secrets).
       // Read the originals from the request because we strip them from the
       // forwarded headers map above.
+      const source =
+        urlAgentId ??
+        getClientIp({
+          forwardedFor: c.req.header("x-forwarded-for"),
+          realIp: c.req.header("x-real-ip"),
+        });
       const apiKey = c.req.header("x-api-key");
       if (apiKey) {
-        headers["x-api-key"] = await this.swap(apiKey);
+        headers["x-api-key"] = await this.swap(apiKey, source);
       }
 
       const auth =
@@ -429,7 +539,7 @@ export class SecretProxy {
       if (auth) {
         const parts = auth.split(" ");
         if (parts.length === 2 && parts[0]?.toLowerCase() === "bearer") {
-          const swapped = await this.swap(parts[1]!);
+          const swapped = await this.swap(parts[1]!, source);
           headers.authorization = `Bearer ${swapped}`;
         }
       }
@@ -499,7 +609,7 @@ export class SecretProxy {
 export function storeSecretMapping(
   uuid: string,
   mapping: SecretMapping,
-  ttlSeconds: number = 7 * 24 * 60 * 60 // 7 days default
+  ttlSeconds: number = defaultPlaceholderTtlSeconds()
 ): void {
   placeholderCache.set(uuid, mapping, ttlSeconds);
 }
@@ -533,7 +643,8 @@ export function generatePlaceholder(
   return `${PLACEHOLDER_PREFIX}${uuid}`;
 }
 
-/** Test-only: drop every placeholder. */
+/** Test-only: drop every placeholder and reset the failure limiter. */
 export function __resetPlaceholderCacheForTests(): void {
   (placeholderCache as unknown as { entries: Map<string, unknown> }).entries.clear();
+  resolutionFailureLimiter.reset();
 }


### PR DESCRIPTION
## What

Secret-proxy lifecycle & rate-limiting hardening (security work-stream WS4).

1. **Shorter orphan TTL.** The `lobu_secret_<uuid>` -> real-secret mapping cache defaulted to ~7 days. Mappings are cascade-deleted on deployment teardown, but an orphan (worker pod crash, agent deleted mid-day) stayed valid for a week. Default is now **24h**, overridable via `SECRET_PLACEHOLDER_TTL_MS` (ms). Lazy GC sweep and teardown cascade unchanged. Both the mapping TTL and the backing-secret-store TTL in `base-deployment-manager.ts` now use the same value.

2. **Per-source failed-resolution throttle.** A compromised worker could probe the proxy with bogus placeholders unbounded — each miss was logged, so also a log-spam vector. New in-memory `ResolutionFailureLimiter` keyed by the best caller identity the proxy already has (bound `agentId`, else client IP from `x-forwarded-for`/`x-real-ip`): after **20 failed resolutions in 5 min** the source hard-fails (empty auth forwarded, fails closed upstream) and we log the throttle **once** instead of per-attempt. A successful lookup clears the source's bucket, so legitimate high-throughput valid traffic is never throttled.

3. The cross-agent placeholder-binding 403 is **untouched**.

## Files

- `packages/server/src/gateway/proxy/secret-proxy.ts` — TTL helper, `ResolutionFailureLimiter`, `swap()` now takes a `source` and consults the limiter, test reset helper resets it too.
- `packages/server/src/gateway/orchestration/base-deployment-manager.ts` — `SECRET_PLACEHOLDER_TTL_SECONDS` now 24h / env-configurable; `generatePlaceholder` call passes it explicitly so mapping + secret-store TTLs match; stale "7-day" comment fixed.
- `packages/server/src/__tests__/unit/secret-proxy-lifecycle.test.ts` (new) — TTL-expired mapping not resolved; 20 bad placeholders from one source -> later valid one from that source still fails closed while a different source's valid lookup works; 50 valid lookups from one source never throttled; cross-agent placeholder still 403; own-agent placeholder 200.

## Test

`bun test packages/server/src/__tests__/unit/secret-proxy-lifecycle.test.ts` — 6 pass. `make build-packages` + `bun run typecheck` green.

## Note

Repo-wide CLAUDE.md points at `/Users/burakemre/Code/lobu` as "the source repo"; my first edit pass landed there by mistake (it was mid-checkout on another work-stream's branch). I reverted those files in the main checkout — only `http-proxy.ts`/`slack.ts`/auth files etc. from the *other* agent remained, my two files + test were cleanly reverted — and redid the change in this worktree. No cross-contamination in the final state.