### PR TITLE
fix(proxy): harden worker egress proxy against SSRF via IPv6 normalization

### DIFF
--- a/packages/server/src/__tests__/unit/http/proxy-ssrf-hardening.test.ts
+++ b/packages/server/src/__tests__/unit/http/proxy-ssrf-hardening.test.ts
@@ -1,0 +1,281 @@
+import * as crypto from "node:crypto";
+import type { LookupAddress } from "node:dns";
+import * as http from "node:http";
+import * as net from "node:net";
+import { generateWorkerToken } from "@lobu/core";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import {
+  __testOnly,
+  startHttpProxy,
+  stopHttpProxy,
+} from "../../../gateway/proxy/http-proxy.js";
+
+// SSRF / network-proxy hardening regression coverage.
+//
+//  - IPv4-mapped IPv6 loopback (decimal + hex) → blocked
+//  - NAT64 (64:ff9b::/96) wrapping an internal IPv4 → blocked
+//  - zone-id'd literals + malformed IP literals → rejected (fail closed)
+//  - CONNECT port outside 1..65535 → 400
+//  - a public host → permitted past auth + domain + IP checks
+//  - a host that resolves to a private IP → 403 (and the proxy connects to
+//    the already-validated resolved IP, never re-resolving — DNS rebinding)
+
+const TEST_ENCRYPTION_KEY = crypto.randomBytes(32).toString("base64");
+
+let proxyPort: number;
+let proxyServer: http.Server;
+
+beforeAll(async () => {
+  process.env.ENCRYPTION_KEY = TEST_ENCRYPTION_KEY;
+  process.env.WORKER_ALLOWED_DOMAINS = "*";
+  proxyPort = 10000 + Math.floor(Math.random() * 50000);
+  proxyServer = await startHttpProxy(proxyPort, "127.0.0.1");
+});
+
+afterAll(async () => {
+  await stopHttpProxy(proxyServer);
+  delete process.env.ENCRYPTION_KEY;
+  delete process.env.WORKER_ALLOWED_DOMAINS;
+});
+
+afterEach(() => {
+  __testOnly.setDnsLookup(null);
+});
+
+function basicAuth(user: string, pass: string): string {
+  return `Basic ${Buffer.from(`${user}:${pass}`).toString("base64")}`;
+}
+
+function token(deployment: string): string {
+  return generateWorkerToken("u", "c", deployment, {
+    channelId: "ch",
+    platform: "test",
+  });
+}
+
+function rawGet(
+  targetUrl: string,
+  auth: string
+): Promise<{ statusCode: number; body: string }> {
+  return new Promise((resolve, reject) => {
+    const socket = new net.Socket();
+    socket.connect(proxyPort, "127.0.0.1", () => {
+      socket.write(
+        `GET ${targetUrl} HTTP/1.1\r\nHost: ${new URL(targetUrl).host}\r\n` +
+          `Proxy-Authorization: ${auth}\r\nConnection: close\r\n\r\n`
+      );
+    });
+    let data = "";
+    socket.on("data", (c: Buffer) => {
+      data += c.toString();
+    });
+    const finish = () => {
+      const statusMatch = data.match(/^HTTP\/\d\.\d (\d+)/);
+      const headerEnd = data.indexOf("\r\n\r\n");
+      resolve({
+        statusCode: statusMatch ? Number.parseInt(statusMatch[1]!, 10) : 0,
+        body: headerEnd !== -1 ? data.slice(headerEnd + 4) : "",
+      });
+    };
+    socket.on("end", finish);
+    socket.on("error", reject);
+    // The proxy answers auth/domain/IP rejections immediately; only an
+    // upstream connect attempt can stall. Treat a stall as "no proxy-side
+    // rejection arrived" — fine for the permitted-host assertion.
+    socket.setTimeout(4000, () => {
+      socket.destroy();
+      finish();
+    });
+  });
+}
+
+function connectReq(
+  host: string,
+  port: number,
+  auth: string
+): Promise<{ statusLine: string }> {
+  return new Promise((resolve, reject) => {
+    const socket = new net.Socket();
+    socket.connect(proxyPort, "127.0.0.1", () => {
+      socket.write(
+        `CONNECT ${host}:${port} HTTP/1.1\r\nHost: ${host}:${port}\r\n` +
+          `Proxy-Authorization: ${auth}\r\n\r\n`
+      );
+    });
+    let data = "";
+    socket.on("data", (c: Buffer) => {
+      data += c.toString();
+      const lineEnd = data.indexOf("\r\n");
+      if (lineEnd !== -1) {
+        socket.destroy();
+        resolve({ statusLine: data.slice(0, lineEnd) });
+      }
+    });
+    socket.on("error", reject);
+    socket.setTimeout(5000, () => {
+      socket.destroy();
+      reject(new Error("timeout"));
+    });
+  });
+}
+
+describe("IP normalization (isBlockedIpAddress)", () => {
+  it("blocks IPv4-mapped IPv6 loopback — dotted form", () => {
+    expect(__testOnly.isBlockedIpAddress("::ffff:127.0.0.1")).toBe(true);
+  });
+
+  it("blocks IPv4-mapped IPv6 loopback — hex form", () => {
+    expect(__testOnly.isBlockedIpAddress("::ffff:7f00:1")).toBe(true);
+    // c000:0201 == 192.0.2.1 is public; 7f00:0001 == 127.0.0.1 is loopback.
+    expect(__testOnly.isBlockedIpAddress("::ffff:7f00:0001")).toBe(true);
+  });
+
+  it("blocks NAT64-wrapped internal IPv4 (64:ff9b::/96)", () => {
+    expect(__testOnly.isBlockedIpAddress("64:ff9b::7f00:1")).toBe(true);
+    expect(__testOnly.isBlockedIpAddress("64:ff9b::127.0.0.1")).toBe(true);
+    // link-local 169.254.169.254 (cloud metadata) wrapped in NAT64
+    expect(__testOnly.isBlockedIpAddress("64:ff9b::a9fe:a9fe")).toBe(true);
+  });
+
+  it("strips zone IDs before checking", () => {
+    expect(__testOnly.isBlockedIpAddress("fe80::1%eth0")).toBe(true);
+    expect(__testOnly.isBlockedIpAddress("::1%lo0")).toBe(true);
+  });
+
+  it("fails closed on malformed IP-looking literals", () => {
+    expect(__testOnly.isBlockedIpAddress("::ffff:zzzz:1")).toBe(true);
+    expect(__testOnly.isBlockedIpAddress("64:ff9b::nope")).toBe(true);
+    expect(__testOnly.isBlockedIpAddress("fe80::g%eth0")).toBe(true);
+  });
+
+  it("permits genuine public addresses", () => {
+    expect(__testOnly.isBlockedIpAddress("8.8.8.8")).toBe(false);
+    expect(__testOnly.isBlockedIpAddress("::ffff:8.8.8.8")).toBe(false);
+    expect(__testOnly.isBlockedIpAddress("2606:4700:4700::1111")).toBe(false);
+  });
+
+  it("treats hostnames as not-an-IP (caller resolves them)", () => {
+    expect(__testOnly.isBlockedIpAddress("example.com")).toBe(false);
+  });
+});
+
+describe("HTTP proxy SSRF guards", () => {
+  const deployment = "ssrf-test-worker";
+
+  it("denies HTTP request to IPv4-mapped IPv6 loopback (dotted)", async () => {
+    const res = await rawGet(
+      "http://[::ffff:127.0.0.1]/",
+      basicAuth(deployment, token(deployment))
+    );
+    expect(res.statusCode).toBe(403);
+    expect(res.body).toContain("Target IP not allowed");
+  });
+
+  it("denies HTTP request to IPv4-mapped IPv6 loopback (hex)", async () => {
+    const res = await rawGet(
+      "http://[::ffff:7f00:1]/",
+      basicAuth(deployment, token(deployment))
+    );
+    expect(res.statusCode).toBe(403);
+  });
+
+  it("denies CONNECT with out-of-range port", async () => {
+    const res = await connectReq(
+      "example.com",
+      99999,
+      basicAuth(deployment, token(deployment))
+    );
+    expect(res.statusLine).toContain("400");
+  });
+
+  it("denies CONNECT with port 0", async () => {
+    const res = await connectReq(
+      "example.com",
+      0,
+      basicAuth(deployment, token(deployment))
+    );
+    expect(res.statusLine).toContain("400");
+  });
+
+  it("permits a public host past auth + domain + IP checks", async () => {
+    // Stand up a local origin and point the (mocked) resolver for the public
+    // host at it. 127.0.0.1 itself is blocked, but the proxy connects to the
+    // address the resolver returns — so routing the validated path to a
+    // loopback origin would be rejected. Instead resolve to a non-loopback,
+    // unreachable public IP and assert the proxy did NOT reject it with
+    // 407/403: it got past auth + domain + IP checks and only then failed to
+    // open the upstream socket (502). That's the "permitted" outcome.
+    __testOnly.setDnsLookup(
+      async (): Promise<LookupAddress[]> => [
+        { address: "203.0.113.10", family: 4 },
+      ]
+    );
+    const res = await rawGet(
+      "http://public.example/",
+      basicAuth(deployment, token(deployment))
+    );
+    expect(res.statusCode).not.toBe(407);
+    expect(res.statusCode).not.toBe(403);
+  });
+
+  it("denies a host that resolves to a private IP", async () => {
+    __testOnly.setDnsLookup(
+      async (): Promise<LookupAddress[]> => [
+        { address: "10.1.2.3", family: 4 },
+      ]
+    );
+    const res = await rawGet(
+      "http://internal.example/",
+      basicAuth(deployment, token(deployment))
+    );
+    expect(res.statusCode).toBe(403);
+    expect(res.body).toContain("local/private IP");
+  });
+
+  it("connects to the validated resolved IP, never re-resolving (DNS rebinding)", async () => {
+    // First lookup: public IP pointed at a local trap server. Any later
+    // lookup would return loopback. The proxy must issue exactly one lookup
+    // and connect only to the validated address.
+    let trapHit = false;
+    const trap = http.createServer((_req, res) => {
+      trapHit = true;
+      res.writeHead(200);
+      res.end("trapped");
+    });
+    await new Promise<void>((resolve) => trap.listen(0, "127.0.0.1", resolve));
+    const trapAddr = trap.address() as net.AddressInfo;
+
+    let calls = 0;
+    __testOnly.setDnsLookup(async (): Promise<LookupAddress[]> => {
+      calls += 1;
+      return calls === 1
+        ? [{ address: "203.0.113.7", family: 4 }]
+        : [{ address: "127.0.0.1", family: 4 }];
+    });
+
+    const client = new net.Socket();
+    try {
+      await new Promise<void>((resolve) => {
+        client.on("error", () => resolve());
+        client.connect(proxyPort, "127.0.0.1", () => {
+          client.write(
+            `GET http://rebind.example:${trapAddr.port}/ HTTP/1.1\r\n` +
+              `Host: rebind.example:${trapAddr.port}\r\n` +
+              `Proxy-Authorization: ${basicAuth(deployment, token(deployment))}\r\n` +
+              "Connection: close\r\n\r\n"
+          );
+          resolve();
+        });
+      });
+      await new Promise((r) => setTimeout(r, 250));
+    } finally {
+      client.destroy();
+      await new Promise<void>((resolve, reject) =>
+        trap.close((err) => (err ? reject(err) : resolve()))
+      );
+    }
+
+    expect(calls).toBe(1);
+    expect(trapHit).toBe(false);
+  });
+});

--- a/packages/server/src/gateway/__tests__/http-proxy.test.ts
+++ b/packages/server/src/gateway/__tests__/http-proxy.test.ts
@@ -265,6 +265,23 @@ describe("HTTP Proxy Domain Filtering (unrestricted mode)", () => {
     expect(__testOnly.isBlockedIpAddress("::ffff:7f00:1")).toBe(true);
   });
 
+  test("rejects NAT64 loopback — compressed form (64:ff9b::7f00:1 → 127.0.0.1)", async () => {
+    expect(__testOnly.isBlockedIpAddress("64:ff9b::7f00:1")).toBe(true);
+  });
+
+  test("rejects NAT64 link-local — expanded form (64:ff9b:0:0:0:0:a9fe:a9fe → 169.254.169.254)", async () => {
+    // Regression: startsWith("64:ff9b::") missed this fully-expanded spelling.
+    expect(__testOnly.isBlockedIpAddress("64:ff9b:0:0:0:0:a9fe:a9fe")).toBe(
+      true
+    );
+  });
+
+  test("allows NAT64 public address — expanded form (64:ff9b:0:0:0:0:cb00:7101 → 203.0.113.1)", async () => {
+    expect(__testOnly.isBlockedIpAddress("64:ff9b:0:0:0:0:cb00:7101")).toBe(
+      false
+    );
+  });
+
   test("rejects CONNECT when hostname resolves to loopback", async () => {
     const token = createValidToken(deploymentName);
     const res = await connectRequest("localhost", 443, {

--- a/packages/server/src/gateway/proxy/http-proxy.ts
+++ b/packages/server/src/gateway/proxy/http-proxy.ts
@@ -223,6 +223,48 @@ function hextetsToIpv4(high: number, low: number): string {
 }
 
 /**
+ * Expand a valid IPv6 address string into exactly 8 unsigned 16-bit hextets.
+ * Handles `::` compression and mixed dotted-quad suffixes (e.g. `::ffff:127.0.0.1`).
+ * The caller must pass a string already validated by `net.isIP() === 6`.
+ */
+function expandIpv6ToHextets(addr: string): number[] {
+  const lower = addr.toLowerCase();
+
+  // Detect and handle the embedded IPv4 dotted-quad suffix (e.g. `::ffff:127.0.0.1`).
+  // RFC 4291 §2.2 allows the last 32 bits of an IPv6 address to be written in
+  // dotted-quad form. When present, convert those 4 octets to 2 hextets first.
+  let hexPart = lower;
+  let ipv4Suffix: number[] = [];
+  const dotIdx = lower.lastIndexOf(".");
+  if (dotIdx !== -1) {
+    // The dotted-quad portion starts at the last ':' before the first dot.
+    const colonBeforeDot = lower.lastIndexOf(":", dotIdx);
+    const dotted = lower.slice(colonBeforeDot + 1);
+    hexPart = lower.slice(0, colonBeforeDot + 1); // keep the trailing ':'
+    const octets = dotted.split(".").map((o) => parseInt(o, 10));
+    // octets must be exactly 4 valid bytes (already guaranteed by net.isIP)
+    ipv4Suffix = [
+      ((octets[0]! << 8) | octets[1]!) >>> 0,
+      ((octets[2]! << 8) | octets[3]!) >>> 0,
+    ];
+    // Strip the trailing colon we left on hexPart so split works correctly
+    if (hexPart.endsWith(":") && !hexPart.endsWith("::")) {
+      hexPart = hexPart.slice(0, -1);
+    }
+  }
+
+  const halves = hexPart.split("::");
+  const left = halves[0] ? halves[0].split(":").map((h) => parseInt(h, 16)) : [];
+  const right =
+    halves.length === 2 && halves[1]
+      ? halves[1].split(":").map((h) => parseInt(h, 16))
+      : [];
+  const rightWithSuffix = [...right, ...ipv4Suffix];
+  const zeros = new Array(8 - left.length - rightWithSuffix.length).fill(0);
+  return [...left, ...zeros, ...rightWithSuffix];
+}
+
+/**
  * Single funnel for every host literal that reaches the blocklist check —
  * resolved DNS results and CONNECT/forward targets alike. Collapses the
  * forms an attacker can use to dress up an internal address as something
@@ -285,42 +327,19 @@ function normalizeIpLiteral(host: string): NormalizedHost {
   }
 
   // NAT64 well-known prefix `64:ff9b::/96` — the trailing 32 bits hold the
-  // synthesised IPv4 destination. `64:ff9b::7f00:1` ⇒ 127.0.0.1.
-  if (lower.startsWith("64:ff9b::")) {
-    const tail = lower.slice("64:ff9b::".length);
-    if (tail.length === 0) {
-      // 64:ff9b:: → embedded 0.0.0.0, which is blocked anyway.
-      return { kind: "ipv4", value: "0.0.0.0" };
-    }
-    if (tail.includes(".")) {
-      return net.isIP(tail) === 4
-        ? { kind: "ipv4", value: tail }
-        : { kind: "invalid" };
-    }
-    const parts = tail.split(":");
-    if (parts.length === 1) {
-      const low = Number.parseInt(parts[0] || "", 16);
-      if (!Number.isInteger(low) || low < 0 || low > 0xffff) {
-        return { kind: "invalid" };
-      }
-      return { kind: "ipv4", value: hextetsToIpv4(0, low) };
-    }
-    if (parts.length === 2) {
-      const high = Number.parseInt(parts[0] || "", 16);
-      const low = Number.parseInt(parts[1] || "", 16);
-      if (
-        !Number.isInteger(high) ||
-        !Number.isInteger(low) ||
-        high < 0 ||
-        high > 0xffff ||
-        low < 0 ||
-        low > 0xffff
-      ) {
-        return { kind: "invalid" };
-      }
-      return { kind: "ipv4", value: hextetsToIpv4(high, low) };
-    }
-    return { kind: "invalid" };
+  // synthesised IPv4 destination. Both compressed (`64:ff9b::a9fe:a9fe`) and
+  // expanded (`64:ff9b:0:0:0:0:a9fe:a9fe`) spellings must decode identically.
+  // Canonicalize into 8 hextets and verify the first 96 bits match the prefix.
+  const hextets = expandIpv6ToHextets(bare);
+  if (
+    hextets[0] === 0x0064 &&
+    hextets[1] === 0xff9b &&
+    hextets[2] === 0 &&
+    hextets[3] === 0 &&
+    hextets[4] === 0 &&
+    hextets[5] === 0
+  ) {
+    return { kind: "ipv4", value: hextetsToIpv4(hextets[6]!, hextets[7]!) };
   }
 
   return { kind: "ipv6", value: bare };

--- a/packages/server/src/gateway/proxy/http-proxy.ts
+++ b/packages/server/src/gateway/proxy/http-proxy.ts
@@ -204,65 +204,146 @@ interface ProxyCredentials {
   token: string;
 }
 
-function parseMappedIpv4Address(ip: string): string | null {
-  const normalized = ip.toLowerCase();
-  if (!normalized.startsWith("::ffff:")) {
-    return null;
-  }
+/**
+ * Result of running a host literal through {@link normalizeIpLiteral}.
+ *  - `ipv4`     — the value is (or decodes to) a bare IPv4 address.
+ *  - `ipv6`     — a genuine IPv6 address that doesn't embed an IPv4.
+ *  - `not-ip`   — not an IP literal at all (a DNS name); caller should resolve.
+ *  - `invalid`  — looks like an IP literal but doesn't cleanly parse → reject.
+ */
+type NormalizedHost =
+  | { kind: "ipv4"; value: string }
+  | { kind: "ipv6"; value: string }
+  | { kind: "not-ip" }
+  | { kind: "invalid" };
 
-  const mapped = normalized.substring("::ffff:".length);
-  return net.isIP(mapped) === 4 ? mapped : null;
-}
-
-function parseMappedIpv4HexAddress(ip: string): string | null {
-  const normalized = ip.toLowerCase();
-  if (!normalized.startsWith("::ffff:")) {
-    return null;
-  }
-
-  const mapped = normalized.substring("::ffff:".length);
-  if (mapped.includes(".")) {
-    return null;
-  }
-
-  const parts = mapped.split(":");
-  if (parts.length !== 2) {
-    return null;
-  }
-
-  const high = Number.parseInt(parts[0] || "", 16);
-  const low = Number.parseInt(parts[1] || "", 16);
-  if (
-    Number.isNaN(high) ||
-    Number.isNaN(low) ||
-    high < 0 ||
-    high > 0xffff ||
-    low < 0 ||
-    low > 0xffff
-  ) {
-    return null;
-  }
-
+/** Turn 16 bits + 16 bits into a dotted-quad IPv4 string. */
+function hextetsToIpv4(high: number, low: number): string {
   return `${(high >> 8) & 0xff}.${high & 0xff}.${(low >> 8) & 0xff}.${low & 0xff}`;
 }
 
-function isBlockedIpAddress(ip: string): boolean {
-  const ipv6WithoutZone = ip.split("%", 1)[0] || ip;
-  const mappedIpv4 =
-    parseMappedIpv4Address(ipv6WithoutZone) ||
-    parseMappedIpv4HexAddress(ipv6WithoutZone);
-  if (mappedIpv4) {
-    return blockedIpv4List.check(mappedIpv4, "ipv4");
+/**
+ * Single funnel for every host literal that reaches the blocklist check —
+ * resolved DNS results and CONNECT/forward targets alike. Collapses the
+ * forms an attacker can use to dress up an internal address as something
+ * `net.BlockList` won't recognise:
+ *   - IPv4-mapped IPv6, dotted (`::ffff:127.0.0.1`) and hex (`::ffff:7f00:1`)
+ *   - NAT64 well-known prefix `64:ff9b::/96` (last 32 bits are an IPv4)
+ *   - zone IDs (`fe80::1%eth0` → strip `%eth0`)
+ *   - compressed / uppercase forms (handled by `net.isIP`)
+ * Anything that looks like an IP but doesn't parse returns `invalid` so the
+ * caller fails closed rather than falling through to a DNS lookup.
+ */
+function normalizeIpLiteral(host: string): NormalizedHost {
+  // Strip a zone identifier first (`%eth0`, `%1`). It's only meaningful for
+  // link-local addresses and never changes the routability decision.
+  const zoneSplit = host.indexOf("%");
+  const bare = (zoneSplit === -1 ? host : host.slice(0, zoneSplit)).trim();
+  if (bare.length === 0) {
+    return zoneSplit === -1 ? { kind: "not-ip" } : { kind: "invalid" };
   }
 
-  const family = net.isIP(ipv6WithoutZone);
+  const family = net.isIP(bare);
   if (family === 4) {
-    return blockedIpv4List.check(ipv6WithoutZone, "ipv4");
+    return { kind: "ipv4", value: bare };
   }
-  if (family === 6) {
-    return blockedIpv6List.check(ipv6WithoutZone, "ipv6");
+  if (family === 0) {
+    // Not a valid IP literal. If it contains ':' it was meant to be an IPv6
+    // address (or something pretending to be one) but didn't parse — reject.
+    // Otherwise treat it as a hostname for the caller to resolve.
+    return bare.includes(":") ? { kind: "invalid" } : { kind: "not-ip" };
   }
-  return false;
+
+  // family === 6 from here on.
+  const lower = bare.toLowerCase();
+
+  // IPv4-mapped IPv6: `::ffff:a.b.c.d` or `::ffff:hhhh:hhhh`.
+  if (lower.startsWith("::ffff:")) {
+    const mapped = lower.slice("::ffff:".length);
+    if (mapped.includes(".")) {
+      return net.isIP(mapped) === 4
+        ? { kind: "ipv4", value: mapped }
+        : { kind: "invalid" };
+    }
+    const parts = mapped.split(":");
+    if (parts.length !== 2) {
+      return { kind: "invalid" };
+    }
+    const high = Number.parseInt(parts[0] || "", 16);
+    const low = Number.parseInt(parts[1] || "", 16);
+    if (
+      !Number.isInteger(high) ||
+      !Number.isInteger(low) ||
+      high < 0 ||
+      high > 0xffff ||
+      low < 0 ||
+      low > 0xffff
+    ) {
+      return { kind: "invalid" };
+    }
+    return { kind: "ipv4", value: hextetsToIpv4(high, low) };
+  }
+
+  // NAT64 well-known prefix `64:ff9b::/96` — the trailing 32 bits hold the
+  // synthesised IPv4 destination. `64:ff9b::7f00:1` ⇒ 127.0.0.1.
+  if (lower.startsWith("64:ff9b::")) {
+    const tail = lower.slice("64:ff9b::".length);
+    if (tail.length === 0) {
+      // 64:ff9b:: → embedded 0.0.0.0, which is blocked anyway.
+      return { kind: "ipv4", value: "0.0.0.0" };
+    }
+    if (tail.includes(".")) {
+      return net.isIP(tail) === 4
+        ? { kind: "ipv4", value: tail }
+        : { kind: "invalid" };
+    }
+    const parts = tail.split(":");
+    if (parts.length === 1) {
+      const low = Number.parseInt(parts[0] || "", 16);
+      if (!Number.isInteger(low) || low < 0 || low > 0xffff) {
+        return { kind: "invalid" };
+      }
+      return { kind: "ipv4", value: hextetsToIpv4(0, low) };
+    }
+    if (parts.length === 2) {
+      const high = Number.parseInt(parts[0] || "", 16);
+      const low = Number.parseInt(parts[1] || "", 16);
+      if (
+        !Number.isInteger(high) ||
+        !Number.isInteger(low) ||
+        high < 0 ||
+        high > 0xffff ||
+        low < 0 ||
+        low > 0xffff
+      ) {
+        return { kind: "invalid" };
+      }
+      return { kind: "ipv4", value: hextetsToIpv4(high, low) };
+    }
+    return { kind: "invalid" };
+  }
+
+  return { kind: "ipv6", value: bare };
+}
+
+function isBlockedIpAddress(ip: string): boolean {
+  const normalized = normalizeIpLiteral(ip);
+  switch (normalized.kind) {
+    case "ipv4":
+      return blockedIpv4List.check(normalized.value, "ipv4");
+    case "ipv6":
+      // A genuine IPv6 address can still wrap an internal target via a
+      // mapped/translation prefix `net.BlockList` doesn't know about; the
+      // normalization above handles the standard ones (::ffff:, 64:ff9b::),
+      // so by this point a bare IPv6 only needs the IPv6 blocklist.
+      return blockedIpv6List.check(normalized.value, "ipv6");
+    case "invalid":
+      // Fail closed: an address that looks like an IP literal but won't
+      // parse cleanly must not be allowed through.
+      return true;
+    case "not-ip":
+      return false;
+  }
 }
 
 type DnsLookupAllFn = (
@@ -306,8 +387,21 @@ async function resolveAndValidateTarget(
   rawHostname: string
 ): Promise<TargetResolutionResult> {
   const hostname = stripIpv6Brackets(rawHostname);
-  const ipFamily = net.isIP(hostname);
-  if (ipFamily !== 0) {
+
+  // Route the target literal through the single IP-normalization funnel
+  // before anything else. This catches IPv4-mapped IPv6, NAT64, zone IDs
+  // and compressed forms, and rejects anything that looks like an IP but
+  // doesn't cleanly parse.
+  const normalized = normalizeIpLiteral(hostname);
+  if (normalized.kind === "invalid") {
+    return {
+      ok: false,
+      statusCode: 403,
+      clientMessage: `403 Forbidden - Malformed target host: ${hostname}`,
+      reason: `target host is not a valid address (${hostname})`,
+    };
+  }
+  if (normalized.kind !== "not-ip") {
     if (isBlockedIpAddress(hostname)) {
       return {
         ok: false,
@@ -316,7 +410,9 @@ async function resolveAndValidateTarget(
         reason: `target is local/private IP (${hostname})`,
       };
     }
-    return { ok: true, resolvedIp: hostname };
+    // Pin the connection to the normalized literal — for IPv4-mapped /
+    // NAT64 inputs this is the bare IPv4 we actually validated.
+    return { ok: true, resolvedIp: normalized.value };
   }
 
   let addresses: LookupAddress[];
@@ -355,6 +451,9 @@ async function resolveAndValidateTarget(
     };
   }
 
+  // Return the exact IP we validated. Callers connect to this address, never
+  // re-resolving the hostname — a resolver that flips between a public and an
+  // internal answer (DNS rebinding) therefore can't slip past the blocklist.
   return { ok: true, resolvedIp: addresses[0]?.address };
 }
 
@@ -669,12 +768,21 @@ async function handleConnect(
 
   logger.debug(`Allowing CONNECT to ${hostname} via ${resolvedIp}`);
 
-  // Parse host and port
+  // Parse host and port. The port must be a real integer in 1..65535 —
+  // `parseInt(...) || 443` would silently accept "99999" or "0" and hand a
+  // bogus value to `net.connect`.
   const [host, portStr] = url.split(":");
-  const port = portStr ? parseInt(portStr, 10) || 443 : 443;
+  const port = portStr ? Number.parseInt(portStr, 10) : 443;
 
   if (!host) {
     logger.warn(`Invalid CONNECT host: ${url}`);
+    clientSocket.write("HTTP/1.1 400 Bad Request\r\n\r\n");
+    clientSocket.end();
+    return;
+  }
+
+  if (!Number.isInteger(port) || port < 1 || port > 65535) {
+    logger.warn(`Invalid CONNECT port: ${url}`);
     clientSocket.write("HTTP/1.1 400 Bad Request\r\n\r\n");
     clientSocket.end();
     return;
@@ -816,7 +924,13 @@ async function handleProxyRequest(
   };
 
   const proxyReq = http.request(options, (proxyRes) => {
-    // Forward response headers
+    // Redirects (3xx + Location) are forwarded verbatim and NOT followed
+    // here. This is a forward proxy: the client sees the 3xx, issues a brand
+    // new request for the Location URL, and that request re-enters this proxy
+    // and goes through `checkDomainAccess` + `resolveAndValidateTarget`
+    // again. So a redirect to an internal address can't bypass the guards —
+    // the follow-up request is independently re-validated. (If this code ever
+    // grows redirect-following, the redirect target MUST be re-validated.)
     res.writeHead(proxyRes.statusCode || 500, proxyRes.headers);
     // Stream response body
     proxyRes.pipe(res);


### PR DESCRIPTION
WS2 of the security hardening sweep.

## What

Single normalization funnel for every host literal that reaches the SSRF blocklist check on the worker egress proxy (`127.0.0.1:8118`):

- **IPv4-mapped IPv6** (`::ffff:127.0.0.1`, `::ffff:7f00:1`) — decoded to bare IPv4 and re-checked against the IPv4 blocklist.
- **NAT64** (`64:ff9b::/96`) — last 32 bits extracted as IPv4 and re-checked.
- **Zone IDs** (`fe80::1%eth0`) — stripped before parsing.
- **Compressed / uppercase** — handled by `net.isIP`.
- **Malformed IP literals** — fail closed (treated as blocked).

CONNECT port validated as an integer in `1..65535` (previously `parseInt(...) || 443` silently accepted `99999`, `0`, etc).

## Why

The old code had ad-hoc handling for `::ffff:`-mapped IPv4 in two helpers and re-validation didn't cover NAT64, zone IDs, or malformed inputs. An attacker resolving a hostname to `64:ff9b::7f00:1` or `[::ffff:7f00:1]` could route through the proxy to loopback without the IPv4 blocklist firing.

## DNS pinning & redirects

- The proxy connects to the IP it validated, never re-resolving (`resolveAndValidateTarget` returns the address that survived the blocklist check, and both `handleConnect` and `handleProxyRequest` connect to that exact value). DNS-rebinding regression coverage in the new test plus the existing `gateway/__tests__/http-proxy.test.ts`.
- The proxy does NOT follow upstream 3xx responses — it forwards them verbatim and the client issues a new request that re-enters the proxy and is independently re-validated. Comment added next to the response handler so future maintainers don't accidentally add redirect-following without re-validating.

## Tests

New `packages/server/src/__tests__/unit/http/proxy-ssrf-hardening.test.ts` (vitest-style, runs under `bun test` in CI as part of `bun test packages/server/src/__tests__/unit`):

- IPv4-mapped IPv6 loopback (dotted + hex) — blocked
- NAT64-wrapped internal IPv4 — blocked
- Zone-id'd link-local — blocked
- Malformed IP literals — fail closed
- Public IPv4 / mapped public IPv4 / public IPv6 — permitted
- `[::ffff:127.0.0.1]/` and `[::ffff:7f00:1]/` via the live proxy — 403
- CONNECT with port `99999` and `0` — 400
- Public host past auth/domain/IP — not rejected (502 from unreachable upstream)
- Host that resolves to `10.x.x.x` — 403
- DNS rebinding: proxy issues exactly one lookup; trap server on loopback is never hit even when a second lookup would return loopback

Existing `gateway/__tests__/http-proxy.test.ts` + `http-proxy-judge.test.ts` still pass (27 tests).