### PR TITLE
fix(server): restore getClientIp helper for secret-proxy

### DIFF
--- a/packages/core/src/__tests__/command-registry.test.ts
+++ b/packages/core/src/__tests__/command-registry.test.ts
@@ -20,7 +20,9 @@ function makeCtx(overrides?: Partial<CommandContext>): CommandContext {
     channelId: "C1",
     args: "",
     platform: "slack",
-    reply: mock(async () => {}),
+    reply: mock(async () => {
+      /* noop */
+    }),
     ...overrides,
   };
 }
@@ -33,7 +35,9 @@ describe("CommandRegistry.register / get / getAll", () => {
     const cmd: CommandDefinition = {
       name: "help",
       description: "Show help",
-      handler: async () => {},
+      handler: async () => {
+        /* noop */
+      },
     };
     registry.register(cmd);
     expect(registry.get("help")).toBe(cmd);
@@ -49,12 +53,16 @@ describe("CommandRegistry.register / get / getAll", () => {
     const a: CommandDefinition = {
       name: "a",
       description: "A",
-      handler: async () => {},
+      handler: async () => {
+        /* noop */
+      },
     };
     const b: CommandDefinition = {
       name: "b",
       description: "B",
-      handler: async () => {},
+      handler: async () => {
+        /* noop */
+      },
     };
     registry.register(a);
     registry.register(b);
@@ -73,12 +81,16 @@ describe("CommandRegistry.register / get / getAll", () => {
     const first: CommandDefinition = {
       name: "ping",
       description: "v1",
-      handler: async () => {},
+      handler: async () => {
+        /* noop */
+      },
     };
     const second: CommandDefinition = {
       name: "ping",
       description: "v2",
-      handler: async () => {},
+      handler: async () => {
+        /* noop */
+      },
     };
     registry.register(first);
     registry.register(second);
@@ -99,7 +111,9 @@ describe("CommandRegistry.tryHandle", () => {
 
   test("returns true and calls handler for registered command", async () => {
     const registry = new CommandRegistry();
-    const handlerFn = mock(async () => {});
+    const handlerFn = mock(async () => {
+      /* noop */
+    });
     registry.register({
       name: "ping",
       description: "Ping",
@@ -143,7 +157,9 @@ describe("CommandRegistry.tryHandle", () => {
       },
     });
 
-    const replyFn = mock(async () => {});
+    const replyFn = mock(async () => {
+      /* noop */
+    });
     const ctx = makeCtx({ reply: replyFn });
     const handled = await registry.tryHandle("boom", ctx);
 
@@ -157,7 +173,9 @@ describe("CommandRegistry.tryHandle", () => {
 
   test("reply is NOT called when handler succeeds", async () => {
     const registry = new CommandRegistry();
-    const replyFn = mock(async () => {});
+    const replyFn = mock(async () => {
+      /* noop */
+    });
     registry.register({
       name: "ok",
       description: "OK",
@@ -181,7 +199,9 @@ describe("CommandRegistry.tryHandle", () => {
     r1.register({
       name: "shared",
       description: "In r1",
-      handler: async () => {},
+      handler: async () => {
+        /* noop */
+      },
     });
 
     expect(r1.get("shared")).toBeDefined();

--- a/packages/server/src/gateway/utils/rate-limiter.ts
+++ b/packages/server/src/gateway/utils/rate-limiter.ts
@@ -1,5 +1,22 @@
 import { getDb } from "../../db/client.js";
 
+export function getClientIp(headers: {
+  forwardedFor?: string;
+  realIp?: string;
+}): string {
+  const forwarded = headers.forwardedFor?.split(",")[0]?.trim().toLowerCase();
+  if (forwarded) {
+    return forwarded;
+  }
+
+  const realIp = headers.realIp?.trim().toLowerCase();
+  if (realIp) {
+    return realIp;
+  }
+
+  return "unknown";
+}
+
 /**
  * Sweep expired `public.rate_limits` rows. Safe to call periodically.
  *


### PR DESCRIPTION
## Summary

- **Root cause:** #672 deleted `getClientIp` from `packages/server/src/gateway/utils/rate-limiter.ts` as dead code; #692 (hardening sweep) then imported it + called it from `packages/server/src/gateway/proxy/secret-proxy.ts`. `main` ships a dangling import.
- **Impact:** Running the gateway from source (`make dev`, `lobu run` from a checkout) crashes at boot with `SyntaxError: The requested module '../utils/rate-limiter.js' does not provide an export named 'getClientIp'`. The prod bundle isn't crashlooping today only because the currently-deployed image (`20260513-130030`) was built from `242b5bf0` — i.e. before #692 landed. The next deploy would either fail to start or silently call `undefined()` on the legacy non-provider secret-swap path (esbuild emits a warning, not an error, on the missing export).
- **Fix:** restore `getClientIp` in `rate-limiter.ts` (verbatim from pre-#672).
- **Bundled lint fix:** `command-registry.test.ts` (added in #685 today) has 10 `mock(async () => {})` bodies that trip `biome/lint/suspicious/noEmptyBlockStatements`, blocking the pre-commit hook on main. Added `/* noop */` to each so any subsequent fix PR isn't blocked.

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun run check:fix` clean
- [x] Local `make dev` boots and `/dev/devices` renders + `GET /api/me/devices` returns 200 with the bootstrap PAT
- [ ] Prod deploy boots cleanly and `app.lobu.ai/<owner>/devices` loads