### PR TITLE
feat(auth): save password credential on email+password sign-in

### DIFF
--- a/packages/core/src/__tests__/command-registry.test.ts
+++ b/packages/core/src/__tests__/command-registry.test.ts
@@ -20,7 +20,7 @@ function makeCtx(overrides?: Partial<CommandContext>): CommandContext {
     channelId: "C1",
     args: "",
     platform: "slack",
-    reply: mock(async () => {}),
+    reply: mock(async () => undefined),
     ...overrides,
   };
 }
@@ -33,7 +33,7 @@ describe("CommandRegistry.register / get / getAll", () => {
     const cmd: CommandDefinition = {
       name: "help",
       description: "Show help",
-      handler: async () => {},
+      handler: async () => undefined,
     };
     registry.register(cmd);
     expect(registry.get("help")).toBe(cmd);
@@ -49,12 +49,12 @@ describe("CommandRegistry.register / get / getAll", () => {
     const a: CommandDefinition = {
       name: "a",
       description: "A",
-      handler: async () => {},
+      handler: async () => undefined,
     };
     const b: CommandDefinition = {
       name: "b",
       description: "B",
-      handler: async () => {},
+      handler: async () => undefined,
     };
     registry.register(a);
     registry.register(b);
@@ -73,12 +73,12 @@ describe("CommandRegistry.register / get / getAll", () => {
     const first: CommandDefinition = {
       name: "ping",
       description: "v1",
-      handler: async () => {},
+      handler: async () => undefined,
     };
     const second: CommandDefinition = {
       name: "ping",
       description: "v2",
-      handler: async () => {},
+      handler: async () => undefined,
     };
     registry.register(first);
     registry.register(second);
@@ -99,7 +99,7 @@ describe("CommandRegistry.tryHandle", () => {
 
   test("returns true and calls handler for registered command", async () => {
     const registry = new CommandRegistry();
-    const handlerFn = mock(async () => {});
+    const handlerFn = mock(async () => undefined);
     registry.register({
       name: "ping",
       description: "Ping",
@@ -143,7 +143,7 @@ describe("CommandRegistry.tryHandle", () => {
       },
     });
 
-    const replyFn = mock(async () => {});
+    const replyFn = mock(async () => undefined);
     const ctx = makeCtx({ reply: replyFn });
     const handled = await registry.tryHandle("boom", ctx);
 
@@ -157,7 +157,7 @@ describe("CommandRegistry.tryHandle", () => {
 
   test("reply is NOT called when handler succeeds", async () => {
     const registry = new CommandRegistry();
-    const replyFn = mock(async () => {});
+    const replyFn = mock(async () => undefined);
     registry.register({
       name: "ok",
       description: "OK",
@@ -181,7 +181,7 @@ describe("CommandRegistry.tryHandle", () => {
     r1.register({
       name: "shared",
       description: "In r1",
-      handler: async () => {},
+      handler: async () => undefined,
     });
 
     expect(r1.get("shared")).toBeDefined();


### PR DESCRIPTION
## Summary
- Bumps `packages/web` to include [owletto-web#97](https://github.com/lobu-ai/owletto-web/pull/97), which calls `navigator.credentials.store()` with a `PasswordCredential` after successful email+password sign-in or sign-up. Chrome's form-detection heuristic never fires on better-auth's fetch-based flow, so the **Save password?** prompt didn't appear — including on `http://localhost` dev URLs. The explicit Credential Management API call bypasses that.
- Drive-by: replaces `async () => {}` with `async () => undefined` in `command-registry.test.ts` mocks to unblock pre-commit (biome's `noEmptyBlockStatements` was failing on `main` after #685).
- Submodule bump also folds in 14 unrelated web commits accumulated since the last pointer move.

## Test plan
- [ ] On `http://localhost:8787`, sign up with email+password → Chrome offers to save the credential.
- [ ] Sign in with stored credential → Chrome autofills the form.
- [ ] Firefox / Safari (no `PasswordCredential` support) → sign-in still completes without errors.