### PR TITLE
fix(core/tests): unblock Docker tsc on main

### DIFF
--- a/packages/core/src/__tests__/command-registry.test.ts
+++ b/packages/core/src/__tests__/command-registry.test.ts
@@ -130,21 +130,21 @@ describe("CommandRegistry.tryHandle", () => {
 
   test("handler receives the correct context", async () => {
     const registry = new CommandRegistry();
-    let receivedCtx: CommandContext | null = null;
+    const captured: { ctx: CommandContext | null } = { ctx: null };
     registry.register({
       name: "inspect",
       description: "Inspect context",
       handler: async (ctx) => {
-        receivedCtx = ctx;
+        captured.ctx = ctx;
       },
     });
 
     const ctx = makeCtx({ userId: "u-42", channelId: "C99", args: "foo bar" });
     await registry.tryHandle("inspect", ctx);
 
-    expect(receivedCtx?.userId).toBe("u-42");
-    expect(receivedCtx?.channelId).toBe("C99");
-    expect(receivedCtx?.args).toBe("foo bar");
+    expect(captured.ctx?.userId).toBe("u-42");
+    expect(captured.ctx?.channelId).toBe("C99");
+    expect(captured.ctx?.args).toBe("foo bar");
   });
 
   test("handler error: still returns true and sends error reply", async () => {

--- a/packages/core/src/__tests__/utils-json.test.ts
+++ b/packages/core/src/__tests__/utils-json.test.ts
@@ -12,23 +12,23 @@ import { parseJsonObject, safeJsonParse, toJsonSafe } from "../utils/json";
 
 describe("safeJsonParse", () => {
   test("parses valid JSON object", () => {
-    expect(safeJsonParse('{"a":1}')).toEqual({ a: 1 });
+    expect(safeJsonParse<{ a: number }>('{"a":1}')).toEqual({ a: 1 });
   });
 
   test("parses valid JSON array", () => {
-    expect(safeJsonParse("[1,2,3]")).toEqual([1, 2, 3]);
+    expect(safeJsonParse<number[]>("[1,2,3]")).toEqual([1, 2, 3]);
   });
 
   test("parses valid JSON string value", () => {
-    expect(safeJsonParse('"hello"')).toBe("hello");
+    expect(safeJsonParse<string>('"hello"')).toBe("hello");
   });
 
   test("parses valid JSON number", () => {
-    expect(safeJsonParse("42")).toBe(42);
+    expect(safeJsonParse<number>("42")).toBe(42);
   });
 
   test("parses valid JSON boolean", () => {
-    expect(safeJsonParse("true")).toBe(true);
+    expect(safeJsonParse<boolean>("true")).toBe(true);
   });
 
   test("parses null JSON literal", () => {
@@ -67,25 +67,25 @@ describe("toJsonSafe", () => {
   });
 
   test("converts a safe BigInt to a number", () => {
-    const result = toJsonSafe({ count: BigInt(42) });
+    const result = toJsonSafe({ count: BigInt(42) }) as { count: unknown };
     expect(result.count).toBe(42);
     expect(typeof result.count).toBe("number");
   });
 
   test("converts an unsafe BigInt to a string", () => {
     const big = BigInt(Number.MAX_SAFE_INTEGER) + 1n;
-    const result = toJsonSafe({ id: big });
+    const result = toJsonSafe({ id: big }) as { id: unknown };
     expect(typeof result.id).toBe("string");
     expect(result.id).toBe(big.toString());
   });
 
   test("nested BigInt fields are converted", () => {
     const result = toJsonSafe({ nested: { x: BigInt(7) } });
-    expect((result as any).nested.x).toBe(7);
+    expect((result as { nested: { x: unknown } }).nested.x).toBe(7);
   });
 
   test("arrays with BigInt elements are converted", () => {
-    const result = toJsonSafe([BigInt(1), BigInt(2)]);
+    const result = toJsonSafe([BigInt(1), BigInt(2)]) as unknown[];
     expect(result).toEqual([1, 2]);
   });
 });


### PR DESCRIPTION
## Summary

The "Build and Push Images" workflow has been red since #685 landed at 12:59 UTC. The Dockerfile runs `bunx tsc` *inside each package* during the image build; that uses each package's local tsconfig and picks up `src/__tests__/**`. The root-level `bun run typecheck` (and pre-commit hook) uses a different tsconfig that excludes those tests, which is why these slipped through.

Two test files from #685 had typecheck failures:

- `packages/core/src/__tests__/command-registry.test.ts`: TS narrows `let receivedCtx: CommandContext | null = null` to `null` after the synchronous init; the assignment inside the async handler closure doesn't propagate, so later `receivedCtx?.args` resolves to `never.args`. Captured via an object field so the type stays the union.
- `packages/core/src/__tests__/utils-json.test.ts`: `safeJsonParse('{"a":1}')` infers `T = null` from the default parameter, making the return type `null` and breaking `toEqual(...)`. Added explicit type params. For `toJsonSafe(...)`, the runtime bigint conversion isn't visible in the static type, so assertions disagree — cast results before comparing.

Together with #694, this restores the image build path so #692's hardening sweep and #694's `getClientIp` fix can actually reach prod.

## Test plan

- [x] `cd packages/core && bunx tsc` clean
- [x] `cd packages/connector-sdk && bunx tsc` clean
- [x] `cd packages/embeddings && bunx tsc` clean
- [x] Root `bun run typecheck` clean
- [x] Pre-commit hook (biome + tsc) green
- [ ] "Build and Push Images" workflow green after merge