### PR TITLE
refactor(sec): slim revocation test import graph (WS10 follow-up)

### DIFF
--- a/packages/server/src/__tests__/setup/mcp-session-cache.ts
+++ b/packages/server/src/__tests__/setup/mcp-session-cache.ts
@@ -1,0 +1,24 @@
+/**
+ * Tiny standalone module for the test-only MCP session cache.
+ *
+ * Kept separate from `test-helpers.ts` so that `test-db.ts` can clear the
+ * cache without statically (or dynamically) loading the rest of
+ * `test-helpers.ts`, which transitively imports the entire server app
+ * (`../../index`) and every workspace dep it pulls in (e.g.
+ * `@lobu/connector-sdk`). Gateway-only `bun:test` runs never need the
+ * full app graph; this module is the leaf they touch instead.
+ */
+
+/**
+ * Cache of initialized MCP sessions keyed by composite auth context.
+ * Each entry stores the session ID returned by the server after
+ * `initialize`.
+ */
+export const mcpSessions = new Map<string, string>();
+
+/**
+ * Clear cached MCP sessions (call between test suites if needed).
+ */
+export function clearMcpSessions(): void {
+  mcpSessions.clear();
+}

--- a/packages/server/src/__tests__/setup/test-db.ts
+++ b/packages/server/src/__tests__/setup/test-db.ts
@@ -9,6 +9,9 @@ import { existsSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import postgres from 'postgres';
 import { listMigrationFiles, loadMigrationUpSection } from '../../db/migration-loader';
+import { clearInMemoryMcpSessionsForTests } from '../../mcp-session-state';
+import { clearMultiTenantCachesForTests } from '../../workspace/multi-tenant-caches';
+import { clearMcpSessions } from './mcp-session-cache';
 
 /**
  * Walk up from startDir looking for `db/migrations`. Falls back to cwd so the
@@ -217,15 +220,18 @@ async function ensureSeedUserIfPossible(db: postgres.Sql): Promise<void> {
  * Called between tests to ensure isolation
  */
 export async function cleanupTestDatabase(): Promise<void> {
-  // Clear cached MCP sessions so stale auth contexts don't leak between test files
-  const { clearMcpSessions } = await import('./test-helpers');
+  // All three clearers live in dedicated leaf modules so this path never
+  // statically (or dynamically) loads `test-helpers`, `mcp-handler`, or
+  // `workspace/multi-tenant` — those files transitively pull in
+  // `@lobu/connector-sdk` via the full app graph, which breaks gateway-only
+  // `bun:test` runs that don't have the workspace `dist/` built. The cache
+  // *instances* are still the same singletons read/written by production
+  // code; only the test clearer is exported from a leaf.
   clearMcpSessions();
-  const { clearInMemoryMcpSessionsForTests } = await import('../../mcp-handler');
   clearInMemoryMcpSessionsForTests();
   // Multi-tenant auth TTL caches (orgSlug/memberRole/owner/session) survive across
   // requests by design. Without this, a test that recreates the org with the same slug
   // but a different UUID gets a 403 because requests still see the stale orgId.
-  const { clearMultiTenantCachesForTests } = await import('../../workspace/multi-tenant');
   clearMultiTenantCachesForTests();
 
   const db = getTestDb();

--- a/packages/server/src/__tests__/setup/test-helpers.ts
+++ b/packages/server/src/__tests__/setup/test-helpers.ts
@@ -115,11 +115,14 @@ export const del = (path: string, options?: Omit<Parameters<typeof testRequest>[
 // MCP Session Management
 // ============================================
 
+import { clearMcpSessions as clearMcpSessionsShared, mcpSessions } from './mcp-session-cache';
+
 /**
- * Cache of initialized MCP sessions keyed by (token ?? '__anonymous__').
- * Each entry stores the session ID returned by the server after initialize.
+ * Re-export so existing call sites (`import { clearMcpSessions } from
+ * './test-helpers'`) keep working; the actual cache lives in
+ * `./mcp-session-cache` to keep `test-db.ts` off the full-app import graph.
  */
-const mcpSessions = new Map<string, string>();
+export const clearMcpSessions = clearMcpSessionsShared;
 
 /**
  * Get or create an initialized MCP session for the given auth token.
@@ -189,12 +192,6 @@ async function ensureMcpSession(options?: {
   return sessionId;
 }
 
-/**
- * Clear cached MCP sessions (call between test suites if needed)
- */
-export function clearMcpSessions(): void {
-  mcpSessions.clear();
-}
 
 // ============================================
 // MCP JSON-RPC Helpers

--- a/packages/server/src/mcp-handler.ts
+++ b/packages/server/src/mcp-handler.ts
@@ -22,6 +22,10 @@ import { createDbClientFromEnv } from './db/client';
 import type { Env } from './index';
 import { agentExistsInOrganization, isValidAgentId, touchAgentLastUsed } from './lobu/stores/postgres-stores';
 import { McpSessionStore, type PersistedMcpSession } from './mcp-session-store';
+import {
+  clearInMemoryMcpSessionsForTests as clearInMemoryMcpSessionsForTestsShared,
+  mcpSessionMap,
+} from './mcp-session-state';
 import { type AuthContext, executeTool, extractAuthContext } from './tools/execute';
 import { getAllTools } from './tools/registry';
 import { formatToolResult } from './utils/markdown-formatter';
@@ -45,7 +49,9 @@ interface SessionEntry {
   lastAccessedAt: number;
 }
 
-const sessions = new Map<string, SessionEntry>();
+// Typed view over the shared raw Map in `./mcp-session-state` so the test
+// cleanup path can clear it without loading the rest of this module.
+const sessions = mcpSessionMap as Map<string, SessionEntry>;
 const mcpSessionStore = new McpSessionStore();
 
 type SessionAuthContext = AuthContext & { instructions?: string };
@@ -70,9 +76,10 @@ export async function cleanupExpiredMcpSessions(): Promise<void> {
   await mcpSessionStore.deleteExpiredSessions();
 }
 
-export function clearInMemoryMcpSessionsForTests(): void {
-  sessions.clear();
-}
+// Re-export the test-only clearer; the actual implementation lives in
+// `./mcp-session-state` so callers can clear sessions without statically
+// loading this file (and its `@lobu/connector-sdk`-dependent tool registry).
+export const clearInMemoryMcpSessionsForTests = clearInMemoryMcpSessionsForTestsShared;
 
 export async function revokeInMemoryMcpSessionsForClient(
   clientId: string,

--- a/packages/server/src/mcp-session-state.ts
+++ b/packages/server/src/mcp-session-state.ts
@@ -1,0 +1,22 @@
+/**
+ * Leaf module for the in-memory MCP transport session map's test-only
+ * clear hook. Hoisted out of `mcp-handler.ts` so the test cleanup path
+ * (`cleanupTestDatabase`) can clear it without statically importing
+ * `mcp-handler.ts` — that file loads the entire tool registry, which
+ * transitively pulls in `@lobu/connector-sdk`. Gateway-only `bun:test`
+ * suites that don't have the workspace `dist/` built need the clear
+ * without paying that import cost.
+ *
+ * The map itself is owned here so this module stays dep-free; the typed
+ * lifecycle (insert / lookup / close transport) is implemented in
+ * `mcp-handler.ts` against this same Map instance.
+ */
+
+// Loosely-typed on purpose — see the typed wrappers in `mcp-handler.ts`.
+// Keeping this file dep-free is the whole point.
+export const mcpSessionMap = new Map<string, unknown>();
+
+/** Test-only: clear the in-memory MCP transport session map. */
+export function clearInMemoryMcpSessionsForTests(): void {
+  mcpSessionMap.clear();
+}

--- a/packages/server/src/workspace/multi-tenant-caches.ts
+++ b/packages/server/src/workspace/multi-tenant-caches.ts
@@ -1,0 +1,31 @@
+/**
+ * Multi-tenant auth TTL caches, isolated in a leaf module.
+ *
+ * Hoisted out of `multi-tenant.ts` so test cleanup (`cleanupTestDatabase`)
+ * can clear them without statically importing `multi-tenant.ts` — that file
+ * loads the entire auth stack (better-auth, OAuth provider, tool-access
+ * registry, etc.) and transitively pulls in `@lobu/connector-sdk`. Tests
+ * that don't have the workspace `dist/` built (gateway-only `bun:test`
+ * suites) need to clear caches without paying that import cost.
+ */
+
+import { TtlCache } from '../utils/ttl-cache';
+import type { ResolvedOwner } from './types';
+
+// Caches – module-level singletons (survive across requests).
+export const orgSlugCache = new TtlCache<{ id: string; visibility: string }>(60_000); // 60s
+export const memberRoleCache = new TtlCache<string | null>(60_000); // 60s
+export const ownerCache = new TtlCache<ResolvedOwner | null>(300_000); // 5min
+export const sessionCache = new TtlCache<{ user: any; session: any } | null>(30_000); // 30s
+
+/**
+ * Test-only: clear all multi-tenant auth caches so a freshly-reset database
+ * (new org/user/token IDs) is not shadowed by TTL'd entries from the previous
+ * run. Referenced from cleanupTestDatabase().
+ */
+export function clearMultiTenantCachesForTests(): void {
+  orgSlugCache.clear();
+  memberRoleCache.clear();
+  ownerCache.clear();
+  sessionCache.clear();
+}

--- a/packages/server/src/workspace/multi-tenant.ts
+++ b/packages/server/src/workspace/multi-tenant.ts
@@ -10,7 +10,6 @@ import { getDb, simpleQuery } from '../db/client';
 import type { Env } from '../index';
 import logger from '../utils/logger';
 import { getConfiguredPublicOrigin } from '../utils/public-origin';
-import { TtlCache } from '../utils/ttl-cache';
 import type {
   AuthConfigData,
   HonoContext,
@@ -18,12 +17,19 @@ import type {
   ResolvedOwner,
   WorkspaceProvider,
 } from './types';
+import {
+  clearMultiTenantCachesForTests as clearMultiTenantCachesForTestsShared,
+  memberRoleCache,
+  orgSlugCache,
+  ownerCache,
+  sessionCache,
+} from './multi-tenant-caches';
 
-// Caches – module-level singletons (survive across requests).
-const orgSlugCache = new TtlCache<{ id: string; visibility: string }>(60_000); // 60s
-const memberRoleCache = new TtlCache<string | null>(60_000); // 60s
-const ownerCache = new TtlCache<ResolvedOwner | null>(300_000); // 5min
-const sessionCache = new TtlCache<{ user: any; session: any } | null>(30_000); // 30s
+// Re-export the test-only cache clearer so existing imports
+// (`from '../workspace/multi-tenant'`) keep working; the cache instances
+// themselves live in `./multi-tenant-caches` to keep test cleanup off this
+// file's heavy import graph.
+export const clearMultiTenantCachesForTests = clearMultiTenantCachesForTestsShared;
 
 /**
  * Path namespaces that don't carry an org context. Authenticated requests to
@@ -117,17 +123,6 @@ export async function getOrgById(
   };
 }
 
-/**
- * Test-only: clear all multi-tenant auth caches so a freshly-reset database
- * (new org/user/token IDs) is not shadowed by TTL'd entries from the previous run.
- * Referenced from cleanupTestDatabase().
- */
-export function clearMultiTenantCachesForTests(): void {
-  orgSlugCache.clear();
-  memberRoleCache.clear();
-  ownerCache.clear();
-  sessionCache.clear();
-}
 
 export class MultiTenantProvider implements WorkspaceProvider {
   async init(): Promise<void> {


### PR DESCRIPTION
Follow-up to the WS1–WS9 security sweep.

## Why

The `Security tests (bun:test)` job builds only `packages/core` and then runs the security suites directly with `bun test`. After WS9 (#693) wired additional revocation call sites into the gateway, that job started failing in `revoked-token-store.test.ts` with:

```
Cannot find module '@lobu/connector-sdk' from .../packages/server/src/identity/capability-registry.ts
Cannot find module '@lobu/connector-sdk' from .../packages/server/src/tools/save_content.ts
```

`@lobu/connector-sdk` is a workspace package whose `dist/` is only built by `make build-packages`. The intent of the security workflow is to keep that pre-build off the hot path. Adding `make build-packages` back was tried and reverted — this PR is the slim alternative.

## Root cause

`cleanupTestDatabase` (called from every gateway test via `resetTestDatabase`) used three `await import(...)` calls to clear process-wide caches:

- `import('./test-helpers')` → `import('../../index')` → full app graph
- `import('../../mcp-handler')` → `auth/tool-access` → `tools/admin/manage_entity_schema` → `identity/rules` → `@lobu/connector-sdk`
- `import('../../workspace/multi-tenant')` → full auth stack

Each of those leaves the failing test only one transitive hop away from `@lobu/connector-sdk`. Pre-WS9, the revocation enforcement lived only in `api-auth-middleware.ts` (already async); the new call sites broadened the surface but the import-graph problem is in test cleanup, not in revocation itself.

## Fix

Hoist each clearer into a dedicated leaf module that imports only the data it owns (a `Map`, a `clear()`):

- `packages/server/src/__tests__/setup/mcp-session-cache.ts` — test-only MCP session map.
- `packages/server/src/mcp-session-state.ts` — in-memory MCP transport session Map (shared via a loosely-typed re-export; `mcp-handler.ts` keeps the typed view).
- `packages/server/src/workspace/multi-tenant-caches.ts` — the four auth TTL caches.

`mcp-handler.ts` and `multi-tenant.ts` now read from the shared instances and re-export the test clearers so existing imports (`from '../../mcp-handler'`, `from '../workspace/multi-tenant'`) keep working. `cleanupTestDatabase` switches to **static** imports of the three leaf modules — no dynamic imports, no repo-policy violation.

No revocation enforcement change. Same caches, same singletons, same logical paths still 401 a revoked jti.

## Verification

Matches what the workflow runs (only `packages/core` built):

```
cd packages/core && bun run build && cd ../..
bun test packages/server/src/gateway/__tests__/revoked-token-store.test.ts   # 11 pass
bun test packages/server/src/gateway/__tests__/proxy-hardening.test.ts        # 72 pass
```

Also verified no regressions on the wider suites:

```
bun test packages/server/src/__tests__/unit/                # 166 pass / 16 skip
bun test packages/server/src/gateway/__tests__/              # 789 pass
```

`bun run typecheck` clean.

## Notes / blockers

- **PIECE B (real Nix integration test for WS3)** — skipped per task spec: real `nix-shell -E` exercise requires `cachix/install-nix-action`, Postgres, a worker-spawn path through the orchestrator, and a label gate. Significant lift; the existing pure-unit `nix-package-attr-ref.test.ts` already covers the validator's reject path (`pkgs.x; touch /tmp/pwn` etc.).
- **`make build-packages` is broken on `main` independently** of this PR — `packages/server/src/gateway/utils/rate-limiter.ts` has a duplicate `getClientIp` export (PR #694 added it, then WS9 / #693 re-added it on merge). That dup is unrelated to this PR and pre-exists at `origin/main`; the security-tests workflow does not run `make build-packages` so it is unblocked. Should be cleaned up in a separate small PR.