### PR TITLE
ci(migrations): immutability + snapshot + smoke-test schema check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -297,6 +297,8 @@ jobs:
           --health-retries 5
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Lint migration directives
         # Sub-second pre-flight: every file under db/migrations/ must
@@ -310,6 +312,25 @@ jobs:
             exit 1
           fi
 
+      - name: Migration immutability — fail on edits to applied migrations
+        # dbmate keys migrations by their version filename. Once a migration
+        # has shipped to main, editing it silently no-ops in any environment
+        # whose schema_migrations row already lists that version (i.e. prod).
+        # The fresh-Postgres `dbmate up` below applies the latest text of every
+        # file and stays green, so edits-after-apply are invisible to that job.
+        # Fail the PR when a migration file changes (rather than is added)
+        # relative to main; force authors to ship a new dated file instead.
+        if: github.event_name == 'pull_request'
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          edited=$(git diff --name-only --diff-filter=MRD "$BASE_SHA"...HEAD -- db/migrations/ || true)
+          if [ -n "$edited" ]; then
+            echo "::error::Migration files were modified or renamed — applied migrations are immutable. Add a new dated migration instead."
+            echo "$edited"
+            exit 1
+          fi
+
       - name: Install dbmate
         run: |
           curl -fsSL -o /usr/local/bin/dbmate \
@@ -319,7 +340,10 @@ jobs:
       - name: Apply all migrations against an empty Postgres
         env:
           DATABASE_URL: postgres://postgres:postgres@localhost:5432/lobu_ci?sslmode=disable
-        run: dbmate --migrations-dir db/migrations up
+        # `dbmate up` dumps `db/schema.sql` after running. The drift check below
+        # diffs that file against the committed version after stripping volatile
+        # lines (see `scripts/normalize-schema.sh`).
+        run: dbmate --migrations-dir db/migrations --schema-file db/schema.sql up
 
       - name: Verify migrations are listed in the schema_migrations table
         env:
@@ -330,5 +354,30 @@ jobs:
           pending=$(dbmate --migrations-dir db/migrations status | grep -c '^\[ \]' || true)
           if [ "$pending" != "0" ]; then
             echo "::error::$pending migrations still pending after dbmate up"
+            exit 1
+          fi
+
+      - name: Normalize generated schema.sql for comparison
+        # pg_dump emits non-deterministic / env-dependent lines that vary
+        # across pg_dump versions and runs: `\restrict <random_token>`,
+        # `\unrestrict <random_token>`, `-- Dumped from database version ...`,
+        # `-- Dumped by pg_dump version ...`, and `SET transaction_timeout = 0;`
+        # (pg17+ only). Strip them so the drift check is purely about the
+        # actual schema. The committed `db/schema.sql` is in the same stripped
+        # form; devs reproducing locally should run `scripts/normalize-schema.sh
+        # db/schema.sql` after `dbmate ... dump`.
+        run: scripts/normalize-schema.sh db/schema.sql
+
+      - name: Schema snapshot drift — db/schema.sql must match `dbmate up` output
+        # Independent backstop against editing applied migrations. The
+        # immutability check above looks at the migration file set; this looks
+        # at the end-state schema. They catch the same class of bug from
+        # opposite sides — a buggy edit could in principle pass one and trip
+        # the other (e.g. rename + edit). Failure mode is concrete: regenerate
+        # `db/schema.sql` locally (`dbmate --schema-file db/schema.sql dump`),
+        # run `scripts/normalize-schema.sh db/schema.sql`, and commit.
+        run: |
+          if ! git diff --exit-code -- db/schema.sql; then
+            echo "::error::db/schema.sql is stale. Regenerate with \`dbmate --migrations-dir db/migrations --schema-file db/schema.sql dump && scripts/normalize-schema.sh db/schema.sql\` and commit the result."
             exit 1
           fi

--- a/charts/lobu/templates/smoke-test-job.yaml
+++ b/charts/lobu/templates/smoke-test-job.yaml
@@ -27,6 +27,13 @@ spec:
         - name: smoke-test
           image: {{ include "lobu.appImage" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+            {{- if and .Values.secrets.create (hasKey .Values.secrets.stringData "DATABASE_URL") }}
+            - name: DATABASE_URL
+              value: {{ index .Values.secrets.stringData "DATABASE_URL" | quote }}
+            {{- end }}
+            - name: REQUIRED_SCHEMA
+              value: {{ join "," (default (list) .Values.releaseGates.smokeTest.requiredSchema) | quote }}
           command:
             - /bin/bash
             - -ec
@@ -37,13 +44,13 @@ spec:
 
               while true; do
                 if curl -fsS --max-time 5 "$url" >/tmp/lobu-smoke-response 2>/tmp/lobu-smoke-error; then
-                  echo "smoke test passed"
+                  echo "health endpoint OK"
                   cat /tmp/lobu-smoke-response
-                  exit 0
+                  break
                 fi
 
                 if [ "$SECONDS" -ge "$deadline" ]; then
-                  echo "smoke test timed out" >&2
+                  echo "smoke test timed out waiting for $url" >&2
                   echo "last curl error:" >&2
                   cat /tmp/lobu-smoke-error >&2 || true
                   exit 1
@@ -51,4 +58,67 @@ spec:
 
                 sleep {{ .Values.releaseGates.smokeTest.intervalSeconds | int }}
               done
+
+              if [ -z "${REQUIRED_SCHEMA}" ]; then
+                echo "no requiredSchema configured — skipping schema check"
+                exit 0
+              fi
+              if [ -z "${DATABASE_URL}" ]; then
+                echo "DATABASE_URL not set in smoke-test env — skipping schema check" >&2
+                exit 0
+              fi
+
+              echo "checking required schema columns: ${REQUIRED_SCHEMA}"
+              node --input-type=module <<'NODE'
+              import postgres from "postgres";
+
+              const required = (process.env.REQUIRED_SCHEMA || "")
+                .split(",")
+                .map((s) => s.trim())
+                .filter(Boolean)
+                .map((entry) => {
+                  const [table, column] = entry.split(".");
+                  if (!table || !column) {
+                    console.error(`ERROR: bad requiredSchema entry "${entry}" — must be table.column`);
+                    process.exit(2);
+                  }
+                  return { table, column };
+                });
+
+              const sql = postgres(process.env.DATABASE_URL, {
+                max: 1,
+                connect_timeout: 10,
+                idle_timeout: 1,
+                onnotice: () => {},
+              });
+
+              try {
+                const missing = [];
+                for (const { table, column } of required) {
+                  const rows = await sql`
+                    SELECT 1 FROM information_schema.columns
+                    WHERE table_schema = 'public'
+                      AND table_name = ${table}
+                      AND column_name = ${column}
+                    LIMIT 1
+                  `;
+                  if (rows.length === 0) {
+                    missing.push(`${table}.${column}`);
+                  }
+                }
+                if (missing.length > 0) {
+                  console.error("ERROR: required schema columns missing after migrate:");
+                  for (const m of missing) console.error(`  - ${m}`);
+                  console.error(
+                    "This usually means a migration in db/migrations/ was edited after\n" +
+                    "it was first applied to this database. Ship a new dated migration\n" +
+                    "instead of editing an existing one."
+                  );
+                  process.exit(1);
+                }
+                console.log(`schema check passed — all ${required.length} required column(s) present`);
+              } finally {
+                await sql.end({ timeout: 1 }).catch(() => {});
+              }
+              NODE
 {{- end }}

--- a/charts/lobu/values.yaml
+++ b/charts/lobu/values.yaml
@@ -179,3 +179,16 @@ releaseGates:
     path: /api/health
     timeoutSeconds: 300
     intervalSeconds: 2
+    # Post-migration schema verification. Each entry is `<table>.<column>`;
+    # the smoke job fails the rollout if any listed column is missing from
+    # `information_schema.columns`. Catches the case where a migration was
+    # edited after it was first applied to prod — the new ALTER never re-runs
+    # (its version is already in `schema_migrations`), but `dbmate up` on a
+    # fresh DB applies the edited file cleanly, so PR CI stays green.
+    # Add a column here whenever a new migration introduces one that app
+    # routes assume exists.
+    requiredSchema:
+      - device_workers.id
+      - device_workers.organization_id
+      - connections.device_worker_id
+      - connections.organization_id

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -1,12 +1,6 @@
-\restrict M2CVBCWaQpZ2IaSZ0tLvIsiZcxaeHAXCvAhTje2jQXnlRxfcYhzgFruwfb40Hgl
-
--- Dumped from database version 18.1 (Debian 18.1-1.pgdg13+2)
--- Dumped by pg_dump version 18.1 (Homebrew)
-
 SET statement_timeout = 0;
 SET lock_timeout = 0;
 SET idle_in_transaction_session_timeout = 0;
-SET transaction_timeout = 0;
 SET client_encoding = 'UTF8';
 SET standard_conforming_strings = on;
 SELECT pg_catalog.set_config('search_path', '', false);
@@ -16,46 +10,10 @@ SET client_min_messages = warning;
 SET row_security = off;
 
 --
--- Name: public; Type: SCHEMA; Schema: -; Owner: -
---
-
--- *not* creating schema, since initdb creates it
-
-
---
 -- Name: SCHEMA public; Type: COMMENT; Schema: -; Owner: -
 --
 
 COMMENT ON SCHEMA public IS '';
-
-
---
--- Name: dblink; Type: EXTENSION; Schema: -; Owner: -
---
-
-CREATE EXTENSION IF NOT EXISTS dblink WITH SCHEMA public;
-
-
---
--- Name: EXTENSION dblink; Type: COMMENT; Schema: -; Owner: -
---
-
-COMMENT ON EXTENSION dblink IS 'connect to other PostgreSQL databases from within a database';
-
-
---
--- Name: pg_stat_statements; Type: EXTENSION; Schema: -; Owner: -
---
-
-CREATE EXTENSION IF NOT EXISTS pg_stat_statements WITH SCHEMA public;
-
-
---
--- Name: EXTENSION pg_stat_statements; Type: COMMENT; Schema: -; Owner: -
---
-
-COMMENT ON EXTENSION pg_stat_statements IS 'track planning and execution statistics of all SQL statements executed';
-
 
 --
 -- Name: pg_trgm; Type: EXTENSION; Schema: -; Owner: -
@@ -63,27 +21,11 @@ COMMENT ON EXTENSION pg_stat_statements IS 'track planning and execution statist
 
 CREATE EXTENSION IF NOT EXISTS pg_trgm WITH SCHEMA public;
 
-
 --
 -- Name: EXTENSION pg_trgm; Type: COMMENT; Schema: -; Owner: -
 --
 
 COMMENT ON EXTENSION pg_trgm IS 'text similarity measurement and index searching based on trigrams';
-
-
---
--- Name: pgcrypto; Type: EXTENSION; Schema: -; Owner: -
---
-
-CREATE EXTENSION IF NOT EXISTS pgcrypto WITH SCHEMA public;
-
-
---
--- Name: EXTENSION pgcrypto; Type: COMMENT; Schema: -; Owner: -
---
-
-COMMENT ON EXTENSION pgcrypto IS 'cryptographic functions';
-
 
 --
 -- Name: vector; Type: EXTENSION; Schema: -; Owner: -
@@ -91,13 +33,11 @@ COMMENT ON EXTENSION pgcrypto IS 'cryptographic functions';
 
 CREATE EXTENSION IF NOT EXISTS vector WITH SCHEMA public;
 
-
 --
 -- Name: EXTENSION vector; Type: COMMENT; Schema: -; Owner: -
 --
 
 COMMENT ON EXTENSION vector IS 'vector data type and ivfflat and hnsw access methods';
-
 
 --
 -- Name: prevent_entity_cycles(); Type: FUNCTION; Schema: public; Owner: -
@@ -140,7 +80,6 @@ BEGIN
 END;
 $$;
 
-
 SET default_tablespace = '';
 
 SET default_table_access_method = heap;
@@ -165,7 +104,6 @@ CREATE TABLE public.account (
     "updatedAt" timestamp with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL
 );
 
-
 --
 -- Name: agent_channel_bindings; Type: TABLE; Schema: public; Owner: -
 --
@@ -177,7 +115,6 @@ CREATE TABLE public.agent_channel_bindings (
     team_id text,
     created_at timestamp with time zone DEFAULT now() NOT NULL
 );
-
 
 --
 -- Name: agent_connections; Type: TABLE; Schema: public; Owner: -
@@ -197,7 +134,6 @@ CREATE TABLE public.agent_connections (
     CONSTRAINT agent_connections_status_check CHECK ((status = ANY (ARRAY['active'::text, 'stopped'::text, 'error'::text])))
 );
 
-
 --
 -- Name: agent_grants; Type: TABLE; Schema: public; Owner: -
 --
@@ -210,7 +146,6 @@ CREATE TABLE public.agent_grants (
     granted_at timestamp with time zone DEFAULT now() NOT NULL,
     denied boolean DEFAULT false
 );
-
 
 --
 -- Name: agent_grants_id_seq; Type: SEQUENCE; Schema: public; Owner: -
@@ -225,7 +160,6 @@ ALTER TABLE public.agent_grants ALTER COLUMN id ADD GENERATED ALWAYS AS IDENTITY
     CACHE 1
 );
 
-
 --
 -- Name: agent_secrets; Type: TABLE; Schema: public; Owner: -
 --
@@ -239,13 +173,11 @@ CREATE TABLE public.agent_secrets (
     organization_id text DEFAULT ''::text NOT NULL
 );
 
-
 --
 -- Name: TABLE agent_secrets; Type: COMMENT; Schema: public; Owner: -
 --
 
 COMMENT ON TABLE public.agent_secrets IS 'Encrypted secret values referenced via secret:// refs. Backs the PostgresSecretStore implementation of @lobu/gateway WritableSecretStore.';
-
 
 --
 -- Name: agent_users; Type: TABLE; Schema: public; Owner: -
@@ -258,7 +190,6 @@ CREATE TABLE public.agent_users (
     created_at timestamp with time zone DEFAULT now() NOT NULL
 );
 
-
 --
 -- Name: agents; Type: TABLE; Schema: public; Owner: -
 --
@@ -270,8 +201,6 @@ CREATE TABLE public.agents (
     description text,
     owner_platform text,
     owner_user_id text,
-    template_agent_id text,
-    parent_connection_id text,
     is_workspace_agent boolean DEFAULT false,
     workspace_id text,
     model text,
@@ -280,7 +209,6 @@ CREATE TABLE public.agents (
     network_config jsonb DEFAULT '{}'::jsonb,
     nix_config jsonb DEFAULT '{}'::jsonb,
     mcp_servers jsonb DEFAULT '{}'::jsonb,
-    mcp_install_notified jsonb DEFAULT '{}'::jsonb,
     agent_integrations jsonb DEFAULT '{}'::jsonb,
     soul_md text DEFAULT ''::text,
     user_md text DEFAULT ''::text,
@@ -289,18 +217,16 @@ CREATE TABLE public.agents (
     skill_auto_granted_domains jsonb DEFAULT '[]'::jsonb,
     tools_config jsonb DEFAULT '{}'::jsonb,
     plugins_config jsonb DEFAULT '{}'::jsonb,
-    auth_profiles jsonb DEFAULT '[]'::jsonb,
     installed_providers jsonb DEFAULT '[]'::jsonb,
     skill_registries jsonb DEFAULT '[]'::jsonb,
     verbose_logging boolean DEFAULT false,
-    egress_config jsonb DEFAULT '{}'::jsonb,
-    pre_approved_tools jsonb DEFAULT '[]'::jsonb,
-    guardrails jsonb DEFAULT '[]'::jsonb,
     created_at timestamp with time zone DEFAULT now() NOT NULL,
     updated_at timestamp with time zone DEFAULT now() NOT NULL,
-    last_used_at timestamp with time zone
+    last_used_at timestamp with time zone,
+    egress_config jsonb DEFAULT '{}'::jsonb,
+    pre_approved_tools jsonb DEFAULT '[]'::jsonb,
+    guardrails jsonb DEFAULT '[]'::jsonb
 );
-
 
 --
 -- Name: auth_profiles; Type: TABLE; Schema: public; Owner: -
@@ -314,7 +240,7 @@ CREATE TABLE public.auth_profiles (
     connector_key text NOT NULL,
     profile_kind text NOT NULL,
     status text DEFAULT 'active'::text NOT NULL,
-    auth_data jsonb DEFAULT '{}'::jsonb CONSTRAINT auth_profiles_credentials_not_null NOT NULL,
+    auth_data jsonb DEFAULT '{}'::jsonb NOT NULL,
     account_id text,
     provider text,
     created_by text,
@@ -324,7 +250,6 @@ CREATE TABLE public.auth_profiles (
     CONSTRAINT auth_profiles_profile_kind_check CHECK ((profile_kind = ANY (ARRAY['env'::text, 'oauth_app'::text, 'oauth_account'::text, 'browser_session'::text, 'interactive'::text]))),
     CONSTRAINT auth_profiles_status_check CHECK ((status = ANY (ARRAY['active'::text, 'pending_auth'::text, 'error'::text, 'revoked'::text])))
 );
-
 
 --
 -- Name: auth_profiles_id_seq; Type: SEQUENCE; Schema: public; Owner: -
@@ -339,125 +264,18 @@ ALTER TABLE public.auth_profiles ALTER COLUMN id ADD GENERATED BY DEFAULT AS IDE
     CACHE 1
 );
 
-
 --
--- Name: chat_connections; Type: TABLE; Schema: public; Owner: -
+-- Name: chat_user_identities; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.chat_connections (
-    id text NOT NULL,
+CREATE TABLE public.chat_user_identities (
     platform text NOT NULL,
-    template_agent_id text,
-    config jsonb NOT NULL,
-    settings jsonb DEFAULT '{}'::jsonb NOT NULL,
-    metadata jsonb DEFAULT '{}'::jsonb NOT NULL,
-    status text DEFAULT 'active'::text NOT NULL,
-    error_message text,
+    team_id text DEFAULT ''::text NOT NULL,
+    platform_user_id text NOT NULL,
+    lobu_user_id text NOT NULL,
     created_at timestamp with time zone DEFAULT now() NOT NULL,
     updated_at timestamp with time zone DEFAULT now() NOT NULL
 );
-
-
---
--- Name: chat_state_cache; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.chat_state_cache (
-    key_prefix text NOT NULL,
-    cache_key text NOT NULL,
-    value text NOT NULL,
-    expires_at timestamp with time zone,
-    updated_at timestamp with time zone DEFAULT now() NOT NULL
-);
-
-
---
--- Name: chat_state_lists; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.chat_state_lists (
-    key_prefix text NOT NULL,
-    list_key text NOT NULL,
-    seq bigint NOT NULL,
-    value text NOT NULL,
-    expires_at timestamp with time zone
-);
-
-
---
--- Name: chat_state_lists_seq_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.chat_state_lists_seq_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: chat_state_lists_seq_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
---
-
-ALTER SEQUENCE public.chat_state_lists_seq_seq OWNED BY public.chat_state_lists.seq;
-
-
---
--- Name: chat_state_locks; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.chat_state_locks (
-    key_prefix text NOT NULL,
-    thread_id text NOT NULL,
-    token text NOT NULL,
-    expires_at timestamp with time zone NOT NULL,
-    updated_at timestamp with time zone DEFAULT now() NOT NULL
-);
-
-
---
--- Name: chat_state_queues; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.chat_state_queues (
-    key_prefix text NOT NULL,
-    thread_id text NOT NULL,
-    seq bigint NOT NULL,
-    value text NOT NULL,
-    expires_at timestamp with time zone NOT NULL
-);
-
-
---
--- Name: chat_state_queues_seq_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.chat_state_queues_seq_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: chat_state_queues_seq_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
---
-
-ALTER SEQUENCE public.chat_state_queues_seq_seq OWNED BY public.chat_state_queues.seq;
-
-
---
--- Name: chat_state_subscriptions; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.chat_state_subscriptions (
-    key_prefix text NOT NULL,
-    thread_id text NOT NULL,
-    created_at timestamp with time zone DEFAULT now() NOT NULL
-);
-
 
 --
 -- Name: connect_tokens; Type: TABLE; Schema: public; Owner: -
@@ -481,7 +299,6 @@ CREATE TABLE public.connect_tokens (
     CONSTRAINT connect_tokens_status_check CHECK ((status = ANY (ARRAY['pending'::text, 'completed'::text, 'expired'::text])))
 );
 
-
 --
 -- Name: connect_tokens_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
@@ -493,13 +310,11 @@ CREATE SEQUENCE public.connect_tokens_id_seq
     NO MAXVALUE
     CACHE 1;
 
-
 --
 -- Name: connect_tokens_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
 ALTER SEQUENCE public.connect_tokens_id_seq OWNED BY public.connect_tokens.id;
-
 
 --
 -- Name: connections; Type: TABLE; Schema: public; Owner: -
@@ -513,6 +328,7 @@ CREATE TABLE public.connections (
     status text DEFAULT 'active'::text NOT NULL,
     account_id text,
     credentials jsonb,
+    entity_ids bigint[],
     config jsonb,
     error_message text,
     created_by text,
@@ -523,9 +339,10 @@ CREATE TABLE public.connections (
     visibility text DEFAULT 'org'::text NOT NULL,
     deleted_at timestamp with time zone,
     agent_id text,
+    device_worker_id uuid,
+    slug text NOT NULL,
     CONSTRAINT connections_status_check CHECK ((status = ANY (ARRAY['active'::text, 'paused'::text, 'error'::text, 'revoked'::text, 'pending_auth'::text])))
 );
-
 
 --
 -- Name: connections_id_seq; Type: SEQUENCE; Schema: public; Owner: -
@@ -538,13 +355,11 @@ CREATE SEQUENCE public.connections_id_seq
     NO MAXVALUE
     CACHE 1;
 
-
 --
 -- Name: connections_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
 ALTER SEQUENCE public.connections_id_seq OWNED BY public.connections.id;
-
 
 --
 -- Name: connector_definitions; Type: TABLE; Schema: public; Owner: -
@@ -573,16 +388,16 @@ CREATE TABLE public.connector_definitions (
     default_connection_config jsonb,
     entity_link_overrides jsonb,
     default_repair_agent_id text,
+    required_capability text,
+    runtime jsonb,
     CONSTRAINT connector_definitions_status_check CHECK ((status = ANY (ARRAY['active'::text, 'archived'::text, 'draft'::text])))
 );
-
 
 --
 -- Name: COLUMN connector_definitions.entity_link_overrides; Type: COMMENT; Schema: public; Owner: -
 --
 
 COMMENT ON COLUMN public.connector_definitions.entity_link_overrides IS 'Per-install override of connector entityLinks rules. See resolveEntityLinkRules() for merge semantics.';
-
 
 --
 -- Name: connector_definitions_id_seq; Type: SEQUENCE; Schema: public; Owner: -
@@ -596,13 +411,11 @@ CREATE SEQUENCE public.connector_definitions_id_seq
     NO MAXVALUE
     CACHE 1;
 
-
 --
 -- Name: connector_definitions_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
 ALTER SEQUENCE public.connector_definitions_id_seq OWNED BY public.connector_definitions.id;
-
 
 --
 -- Name: connector_versions; Type: TABLE; Schema: public; Owner: -
@@ -619,7 +432,6 @@ CREATE TABLE public.connector_versions (
     source_path text
 );
 
-
 --
 -- Name: connector_versions_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
@@ -632,20 +444,18 @@ CREATE SEQUENCE public.connector_versions_id_seq
     NO MAXVALUE
     CACHE 1;
 
-
 --
 -- Name: connector_versions_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
 ALTER SEQUENCE public.connector_versions_id_seq OWNED BY public.connector_versions.id;
 
-
 --
 -- Name: events; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE public.events (
-    id bigint CONSTRAINT event_id_not_null NOT NULL,
+    id bigint NOT NULL,
     organization_id text NOT NULL,
     entity_ids bigint[],
     origin_id text,
@@ -685,6 +495,35 @@ CREATE TABLE public.events (
     CONSTRAINT events_semantic_type_not_empty CHECK ((length(btrim(semantic_type)) > 0))
 );
 
+--
+-- Name: TABLE events; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON TABLE public.events IS 'Append-only event log for source ingests, user-authored knowledge, and operation history';
+
+--
+-- Name: COLUMN events.id; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.events.id IS 'Primary key (BIGSERIAL) - exposed to MCP tools';
+
+--
+-- Name: COLUMN events.score; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.events.score IS 'Normalized 0-100 score for ranking';
+
+--
+-- Name: COLUMN events.origin_type; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.events.origin_type IS 'Source-native item type (post, comment, review, issue, etc.)';
+
+--
+-- Name: COLUMN events.run_id; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.events.run_id IS 'Links the event to the run that produced or acted on it';
 
 --
 -- Name: content_id_seq; Type: SEQUENCE; Schema: public; Owner: -
@@ -697,13 +536,11 @@ CREATE SEQUENCE public.content_id_seq
     NO MAXVALUE
     CACHE 1;
 
-
 --
 -- Name: content_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
 ALTER SEQUENCE public.content_id_seq OWNED BY public.events.id;
-
 
 --
 -- Name: event_embeddings; Type: TABLE; Schema: public; Owner: -
@@ -714,7 +551,6 @@ CREATE TABLE public.event_embeddings (
     embedding public.vector(768) NOT NULL,
     created_at timestamp with time zone DEFAULT now() NOT NULL
 );
-
 
 --
 -- Name: current_event_records; Type: VIEW; Schema: public; Owner: -
@@ -762,6 +598,22 @@ CREATE VIEW public.current_event_records AS
            FROM public.events newer
           WHERE (newer.supersedes_event_id = e.id))));
 
+--
+-- Name: device_workers; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.device_workers (
+    user_id text NOT NULL,
+    worker_id text NOT NULL,
+    platform text,
+    app_version text,
+    capabilities jsonb DEFAULT '[]'::jsonb NOT NULL,
+    label text,
+    first_seen_at timestamp with time zone DEFAULT now() NOT NULL,
+    last_seen_at timestamp with time zone DEFAULT now() NOT NULL,
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    organization_id text
+);
 
 --
 -- Name: entities; Type: TABLE; Schema: public; Owner: -
@@ -787,13 +639,11 @@ CREATE TABLE public.entities (
     entity_type_id integer NOT NULL
 );
 
-
 --
 -- Name: TABLE entities; Type: COMMENT; Schema: public; Owner: -
 --
 
 COMMENT ON TABLE public.entities IS 'Unified entity table (brands, products, and future entity types)';
-
 
 --
 -- Name: COLUMN entities.parent_id; Type: COMMENT; Schema: public; Owner: -
@@ -801,13 +651,11 @@ COMMENT ON TABLE public.entities IS 'Unified entity table (brands, products, and
 
 COMMENT ON COLUMN public.entities.parent_id IS 'Hierarchical parent (products → brands, brands → parent brands)';
 
-
 --
 -- Name: COLUMN entities.enabled_classifiers; Type: COMMENT; Schema: public; Owner: -
 --
 
 COMMENT ON COLUMN public.entities.enabled_classifiers IS 'Classifiers enabled for this entity (inherited from parent if NULL)';
-
 
 --
 -- Name: entities_id_seq; Type: SEQUENCE; Schema: public; Owner: -
@@ -820,13 +668,11 @@ CREATE SEQUENCE public.entities_id_seq
     NO MAXVALUE
     CACHE 1;
 
-
 --
 -- Name: entities_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
 ALTER SEQUENCE public.entities_id_seq OWNED BY public.entities.id;
-
 
 --
 -- Name: entity_identities; Type: TABLE; Schema: public; Owner: -
@@ -844,13 +690,11 @@ CREATE TABLE public.entity_identities (
     deleted_at timestamp with time zone
 );
 
-
 --
 -- Name: TABLE entity_identities; Type: COMMENT; Schema: public; Owner: -
 --
 
 COMMENT ON TABLE public.entity_identities IS 'Normalized identifier claims per entity. See docs/identity-linking.md for the full pattern.';
-
 
 --
 -- Name: COLUMN entity_identities.namespace; Type: COMMENT; Schema: public; Owner: -
@@ -858,20 +702,17 @@ COMMENT ON TABLE public.entity_identities IS 'Normalized identifier claims per e
 
 COMMENT ON COLUMN public.entity_identities.namespace IS 'Identifier kind. Standard values: phone, email, wa_jid, slack_user_id, github_login, auth_user_id, google_contact_id. Custom namespaces allowed but connectors sharing a namespace must agree on its format.';
 
-
 --
 -- Name: COLUMN entity_identities.identifier; Type: COMMENT; Schema: public; Owner: -
 --
 
 COMMENT ON COLUMN public.entity_identities.identifier IS 'Normalized identifier value (E.164 digits for phone, lowercase for email, etc.). Normalizers in @lobu/connector-sdk own the canonical form.';
 
-
 --
 -- Name: COLUMN entity_identities.source_connector; Type: COMMENT; Schema: public; Owner: -
 --
 
 COMMENT ON COLUMN public.entity_identities.source_connector IS 'Who claimed this identifier: "connector:whatsapp", "manual", or null when seeded by migration.';
-
 
 --
 -- Name: entity_identities_id_seq; Type: SEQUENCE; Schema: public; Owner: -
@@ -884,32 +725,11 @@ CREATE SEQUENCE public.entity_identities_id_seq
     NO MAXVALUE
     CACHE 1;
 
-
 --
 -- Name: entity_identities_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
 ALTER SEQUENCE public.entity_identities_id_seq OWNED BY public.entity_identities.id;
-
-
---
--- Name: entity_read_grant; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.entity_read_grant (
-    id text NOT NULL,
-    grantor_org_id text NOT NULL,
-    entity_id bigint NOT NULL,
-    grantee_user_id text NOT NULL,
-    scope text DEFAULT 'read-once'::text NOT NULL,
-    expires_at timestamp with time zone NOT NULL,
-    single_use boolean DEFAULT true NOT NULL,
-    consumed_at timestamp with time zone,
-    triggering_relationship_id bigint,
-    created_at timestamp with time zone DEFAULT now() NOT NULL,
-    CONSTRAINT entity_read_grant_scope_check CHECK ((scope = ANY (ARRAY['read-once'::text, 'read-n'::text, 'read-window'::text])))
-);
-
 
 --
 -- Name: entity_relationship_type_rules; Type: TABLE; Schema: public; Owner: -
@@ -925,7 +745,6 @@ CREATE TABLE public.entity_relationship_type_rules (
     updated_at timestamp with time zone DEFAULT now()
 );
 
-
 --
 -- Name: entity_relationship_type_rules_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
@@ -938,13 +757,11 @@ CREATE SEQUENCE public.entity_relationship_type_rules_id_seq
     NO MAXVALUE
     CACHE 1;
 
-
 --
 -- Name: entity_relationship_type_rules_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
 ALTER SEQUENCE public.entity_relationship_type_rules_id_seq OWNED BY public.entity_relationship_type_rules.id;
-
 
 --
 -- Name: entity_relationship_types; Type: TABLE; Schema: public; Owner: -
@@ -968,7 +785,6 @@ CREATE TABLE public.entity_relationship_types (
     CONSTRAINT entity_relationship_types_status_check CHECK ((status = ANY (ARRAY['active'::text, 'archived'::text])))
 );
 
-
 --
 -- Name: entity_relationship_types_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
@@ -981,13 +797,11 @@ CREATE SEQUENCE public.entity_relationship_types_id_seq
     NO MAXVALUE
     CACHE 1;
 
-
 --
 -- Name: entity_relationship_types_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
 ALTER SEQUENCE public.entity_relationship_types_id_seq OWNED BY public.entity_relationship_types.id;
-
 
 --
 -- Name: entity_relationships; Type: TABLE; Schema: public; Owner: -
@@ -1009,7 +823,6 @@ CREATE TABLE public.entity_relationships (
     updated_at timestamp with time zone DEFAULT now()
 );
 
-
 --
 -- Name: entity_relationships_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
@@ -1022,13 +835,11 @@ CREATE SEQUENCE public.entity_relationships_id_seq
     NO MAXVALUE
     CACHE 1;
 
-
 --
 -- Name: entity_relationships_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
 ALTER SEQUENCE public.entity_relationships_id_seq OWNED BY public.entity_relationships.id;
-
 
 --
 -- Name: entity_type_audit; Type: TABLE; Schema: public; Owner: -
@@ -1045,7 +856,6 @@ CREATE TABLE public.entity_type_audit (
     CONSTRAINT entity_type_audit_action_check CHECK ((action = ANY (ARRAY['create'::text, 'update'::text, 'delete'::text])))
 );
 
-
 --
 -- Name: entity_type_audit_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
@@ -1058,13 +868,11 @@ CREATE SEQUENCE public.entity_type_audit_id_seq
     NO MAXVALUE
     CACHE 1;
 
-
 --
 -- Name: entity_type_audit_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
 ALTER SEQUENCE public.entity_type_audit_id_seq OWNED BY public.entity_type_audit.id;
-
 
 --
 -- Name: entity_types; Type: TABLE; Schema: public; Owner: -
@@ -1088,7 +896,6 @@ CREATE TABLE public.entity_types (
     event_kinds jsonb
 );
 
-
 --
 -- Name: entity_types_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
@@ -1101,13 +908,11 @@ CREATE SEQUENCE public.entity_types_id_seq
     NO MAXVALUE
     CACHE 1;
 
-
 --
 -- Name: entity_types_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
 ALTER SEQUENCE public.entity_types_id_seq OWNED BY public.entity_types.id;
-
 
 --
 -- Name: event_classifications; Type: TABLE; Schema: public; Owner: -
@@ -1134,7 +939,6 @@ CREATE TABLE public.event_classifications (
     CONSTRAINT event_classifications_values_not_empty CHECK ((cardinality("values") > 0))
 );
 
-
 --
 -- Name: event_classifications_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
@@ -1146,13 +950,11 @@ CREATE SEQUENCE public.event_classifications_id_seq
     NO MAXVALUE
     CACHE 1;
 
-
 --
 -- Name: event_classifications_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
 ALTER SEQUENCE public.event_classifications_id_seq OWNED BY public.event_classifications.id;
-
 
 --
 -- Name: event_classifier_versions; Type: TABLE; Schema: public; Owner: -
@@ -1173,13 +975,11 @@ CREATE TABLE public.event_classifier_versions (
     extraction_config jsonb
 );
 
-
 --
 -- Name: COLUMN event_classifier_versions.preferred_model; Type: COMMENT; Schema: public; Owner: -
 --
 
 COMMENT ON COLUMN public.event_classifier_versions.preferred_model IS 'AI model to use for LLM fallback. Use 8B for simple classifiers (cheap), 70B for complex reasoning (expensive). Default: 8B';
-
 
 --
 -- Name: event_classifier_versions_id_seq; Type: SEQUENCE; Schema: public; Owner: -
@@ -1192,13 +992,11 @@ CREATE SEQUENCE public.event_classifier_versions_id_seq
     NO MAXVALUE
     CACHE 1;
 
-
 --
 -- Name: event_classifier_versions_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
 ALTER SEQUENCE public.event_classifier_versions_id_seq OWNED BY public.event_classifier_versions.id;
-
 
 --
 -- Name: event_classifiers; Type: TABLE; Schema: public; Owner: -
@@ -1221,7 +1019,6 @@ CREATE TABLE public.event_classifiers (
     CONSTRAINT event_classifiers_status_check CHECK ((status = ANY (ARRAY['active'::text, 'deprecated'::text])))
 );
 
-
 --
 -- Name: event_classifiers_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
@@ -1233,13 +1030,11 @@ CREATE SEQUENCE public.event_classifiers_id_seq
     NO MAXVALUE
     CACHE 1;
 
-
 --
 -- Name: event_classifiers_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
 ALTER SEQUENCE public.event_classifiers_id_seq OWNED BY public.event_classifiers.id;
-
 
 --
 -- Name: feeds; Type: TABLE; Schema: public; Owner: -
@@ -1250,6 +1045,7 @@ CREATE TABLE public.feeds (
     organization_id text NOT NULL,
     connection_id bigint NOT NULL,
     feed_key text NOT NULL,
+    display_name text,
     status text DEFAULT 'active'::text NOT NULL,
     entity_ids bigint[],
     config jsonb,
@@ -1265,7 +1061,6 @@ CREATE TABLE public.feeds (
     deleted_at timestamp with time zone,
     schedule text,
     next_run_at timestamp with time zone,
-    display_name text,
     repair_agent_id text,
     repair_thread_id text,
     repair_attempt_count integer DEFAULT 0 NOT NULL,
@@ -1274,7 +1069,6 @@ CREATE TABLE public.feeds (
     last_repair_post_hash text,
     CONSTRAINT feeds_status_check CHECK ((status = ANY (ARRAY['active'::text, 'paused'::text, 'error'::text])))
 );
-
 
 --
 -- Name: feeds_id_seq; Type: SEQUENCE; Schema: public; Owner: -
@@ -1287,13 +1081,11 @@ CREATE SEQUENCE public.feeds_id_seq
     NO MAXVALUE
     CACHE 1;
 
-
 --
 -- Name: feeds_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
 ALTER SEQUENCE public.feeds_id_seq OWNED BY public.feeds.id;
-
 
 --
 -- Name: grants; Type: TABLE; Schema: public; Owner: -
@@ -1307,7 +1099,6 @@ CREATE TABLE public.grants (
     granted_at timestamp with time zone DEFAULT now() NOT NULL,
     denied boolean DEFAULT false NOT NULL
 );
-
 
 --
 -- Name: invitation; Type: TABLE; Schema: public; Owner: -
@@ -1323,7 +1114,6 @@ CREATE TABLE public.invitation (
     "createdAt" timestamp with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
     "inviterId" text
 );
-
 
 --
 -- Name: latest_event_classifications; Type: TABLE; Schema: public; Owner: -
@@ -1344,7 +1134,6 @@ CREATE TABLE public.latest_event_classifications (
     created_at timestamp with time zone NOT NULL
 );
 
-
 --
 -- Name: mcp_proxy_sessions; Type: TABLE; Schema: public; Owner: -
 --
@@ -1355,7 +1144,6 @@ CREATE TABLE public.mcp_proxy_sessions (
     expires_at timestamp with time zone NOT NULL,
     updated_at timestamp with time zone DEFAULT now() NOT NULL
 );
-
 
 --
 -- Name: mcp_sessions; Type: TABLE; Schema: public; Owner: -
@@ -1374,13 +1162,11 @@ CREATE TABLE public.mcp_sessions (
     expires_at timestamp with time zone NOT NULL
 );
 
-
 --
 -- Name: TABLE mcp_sessions; Type: COMMENT; Schema: public; Owner: -
 --
 
 COMMENT ON TABLE public.mcp_sessions IS 'Persisted MCP streamable HTTP sessions for restart and cross-replica recovery';
-
 
 --
 -- Name: member; Type: TABLE; Schema: public; Owner: -
@@ -1394,6 +1180,51 @@ CREATE TABLE public.member (
     "createdAt" timestamp with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL
 );
 
+--
+-- Name: migration_20260315300000_entity_type_org_backfill; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.migration_20260315300000_entity_type_org_backfill (
+    entity_type_id integer NOT NULL
+);
+
+--
+-- Name: migration_20260316100000_created_entity_types; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.migration_20260316100000_created_entity_types (
+    entity_type_id integer NOT NULL
+);
+
+--
+-- Name: migration_20260316100000_deleted_default_entity_types; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.migration_20260316100000_deleted_default_entity_types (
+    id integer NOT NULL,
+    slug text NOT NULL,
+    name text NOT NULL,
+    description text,
+    icon text,
+    color text,
+    metadata_schema jsonb,
+    organization_id text NOT NULL,
+    created_by text,
+    updated_by text,
+    deleted_at timestamp with time zone,
+    created_at timestamp with time zone,
+    updated_at timestamp with time zone,
+    current_view_template_version_id integer
+);
+
+--
+-- Name: migration_20260316100000_events_kind_backup; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.migration_20260316100000_events_kind_backup (
+    event_id bigint NOT NULL,
+    old_kind text
+);
 
 --
 -- Name: namespace; Type: TABLE; Schema: public; Owner: -
@@ -1406,7 +1237,6 @@ CREATE TABLE public.namespace (
     created_at timestamp with time zone DEFAULT now(),
     CONSTRAINT namespace_type_check CHECK ((type = ANY (ARRAY['user'::text, 'organization'::text])))
 );
-
 
 --
 -- Name: notifications; Type: TABLE; Schema: public; Owner: -
@@ -1423,9 +1253,9 @@ CREATE TABLE public.notifications (
     resource_id text,
     resource_url text,
     is_read boolean DEFAULT false NOT NULL,
-    created_at timestamp with time zone DEFAULT now() NOT NULL
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    CONSTRAINT notifications_type_check CHECK ((type = ANY (ARRAY['action_approval_needed'::text, 'connection_permission_request'::text, 'invitation_received'::text, 'generic'::text, 'agent_message'::text])))
 );
-
 
 --
 -- Name: notifications_id_seq; Type: SEQUENCE; Schema: public; Owner: -
@@ -1438,13 +1268,11 @@ CREATE SEQUENCE public.notifications_id_seq
     NO MAXVALUE
     CACHE 1;
 
-
 --
 -- Name: notifications_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
 ALTER SEQUENCE public.notifications_id_seq OWNED BY public.notifications.id;
-
 
 --
 -- Name: oauth_authorization_codes; Type: TABLE; Schema: public; Owner: -
@@ -1466,13 +1294,11 @@ CREATE TABLE public.oauth_authorization_codes (
     created_at timestamp with time zone DEFAULT now() NOT NULL
 );
 
-
 --
 -- Name: TABLE oauth_authorization_codes; Type: COMMENT; Schema: public; Owner: -
 --
 
 COMMENT ON TABLE public.oauth_authorization_codes IS 'Short-lived authorization codes for PKCE flow';
-
 
 --
 -- Name: oauth_clients; Type: TABLE; Schema: public; Owner: -
@@ -1503,13 +1329,11 @@ CREATE TABLE public.oauth_clients (
     metadata jsonb DEFAULT '{}'::jsonb NOT NULL
 );
 
-
 --
 -- Name: TABLE oauth_clients; Type: COMMENT; Schema: public; Owner: -
 --
 
 COMMENT ON TABLE public.oauth_clients IS 'OAuth 2.1 dynamic client registration for MCP clients';
-
 
 --
 -- Name: oauth_device_codes; Type: TABLE; Schema: public; Owner: -
@@ -1530,13 +1354,11 @@ CREATE TABLE public.oauth_device_codes (
     CONSTRAINT oauth_device_codes_status_check CHECK ((status = ANY (ARRAY['pending'::text, 'approved'::text, 'denied'::text, 'expired'::text])))
 );
 
-
 --
 -- Name: TABLE oauth_device_codes; Type: COMMENT; Schema: public; Owner: -
 --
 
 COMMENT ON TABLE public.oauth_device_codes IS 'Device codes for OAuth Device Authorization Grant (RFC 8628)';
-
 
 --
 -- Name: oauth_states; Type: TABLE; Schema: public; Owner: -
@@ -1549,7 +1371,6 @@ CREATE TABLE public.oauth_states (
     expires_at timestamp with time zone NOT NULL,
     created_at timestamp with time zone DEFAULT now() NOT NULL
 );
-
 
 --
 -- Name: oauth_tokens; Type: TABLE; Schema: public; Owner: -
@@ -1571,13 +1392,11 @@ CREATE TABLE public.oauth_tokens (
     CONSTRAINT oauth_tokens_token_type_check CHECK ((token_type = ANY (ARRAY['access'::text, 'refresh'::text])))
 );
 
-
 --
 -- Name: TABLE oauth_tokens; Type: COMMENT; Schema: public; Owner: -
 --
 
 COMMENT ON TABLE public.oauth_tokens IS 'Access and refresh tokens issued by OAuth server';
-
 
 --
 -- Name: organization; Type: TABLE; Schema: public; Owner: -
@@ -1590,12 +1409,11 @@ CREATE TABLE public.organization (
     logo text,
     "createdAt" timestamp with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
     metadata text,
-    visibility text DEFAULT 'private'::text NOT NULL,
     description text,
+    visibility text DEFAULT 'private'::text NOT NULL,
     repair_agents_enabled boolean DEFAULT true NOT NULL,
     CONSTRAINT org_slug_not_reserved CHECK ((slug <> ALL (ARRAY['settings'::text, 'auth'::text, 'api'::text, 'templates'::text, 'help'::text, 'account'::text, 'admin'::text, 'health'::text, 'login'::text, 'logout'::text, 'signup'::text, 'register'::text, 'www'::text, 'mcp'::text, 'static'::text, 'assets'::text, 'cdn'::text, 'docs'::text, 'mail'::text])))
 );
-
 
 --
 -- Name: organization_lobu_links; Type: TABLE; Schema: public; Owner: -
@@ -1608,7 +1426,6 @@ CREATE TABLE public.organization_lobu_links (
     created_at timestamp with time zone DEFAULT now() NOT NULL,
     updated_at timestamp with time zone DEFAULT now() NOT NULL
 );
-
 
 --
 -- Name: personal_access_tokens; Type: TABLE; Schema: public; Owner: -
@@ -1630,13 +1447,11 @@ CREATE TABLE public.personal_access_tokens (
     updated_at timestamp with time zone DEFAULT now() NOT NULL
 );
 
-
 --
 -- Name: TABLE personal_access_tokens; Type: COMMENT; Schema: public; Owner: -
 --
 
 COMMENT ON TABLE public.personal_access_tokens IS 'Personal Access Tokens for workers, CLI tools, and MCP clients';
-
 
 --
 -- Name: personal_access_tokens_id_seq; Type: SEQUENCE; Schema: public; Owner: -
@@ -1649,13 +1464,11 @@ CREATE SEQUENCE public.personal_access_tokens_id_seq
     NO MAXVALUE
     CACHE 1;
 
-
 --
 -- Name: personal_access_tokens_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
 ALTER SEQUENCE public.personal_access_tokens_id_seq OWNED BY public.personal_access_tokens.id;
-
 
 --
 -- Name: rate_limits; Type: TABLE; Schema: public; Owner: -
@@ -1668,7 +1481,6 @@ CREATE TABLE public.rate_limits (
     expires_at timestamp with time zone NOT NULL,
     updated_at timestamp with time zone DEFAULT now() NOT NULL
 );
-
 
 --
 -- Name: runs; Type: TABLE; Schema: public; Owner: -
@@ -1697,7 +1509,6 @@ CREATE TABLE public.runs (
     created_at timestamp with time zone DEFAULT now() NOT NULL,
     watcher_id integer,
     window_id bigint,
-    approved_input jsonb,
     auth_profile_id bigint,
     auth_signal jsonb,
     created_by_user_id text,
@@ -1706,6 +1517,7 @@ CREATE TABLE public.runs (
     exit_code integer,
     exit_signal text,
     exit_reason text,
+    approved_input jsonb,
     queue_name text,
     idempotency_key text,
     attempts integer DEFAULT 0 NOT NULL,
@@ -1720,7 +1532,6 @@ CREATE TABLE public.runs (
     CONSTRAINT runs_status_check CHECK ((status = ANY (ARRAY['pending'::text, 'claimed'::text, 'running'::text, 'completed'::text, 'failed'::text, 'cancelled'::text, 'timeout'::text])))
 );
 
-
 --
 -- Name: runs_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
@@ -1732,13 +1543,11 @@ CREATE SEQUENCE public.runs_id_seq
     NO MAXVALUE
     CACHE 1;
 
-
 --
 -- Name: runs_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
 ALTER SEQUENCE public.runs_id_seq OWNED BY public.runs.id;
-
 
 --
 -- Name: schema_migrations; Type: TABLE; Schema: public; Owner: -
@@ -1747,7 +1556,6 @@ ALTER SEQUENCE public.runs_id_seq OWNED BY public.runs.id;
 CREATE TABLE public.schema_migrations (
     version character varying(128) NOT NULL
 );
-
 
 --
 -- Name: session; Type: TABLE; Schema: public; Owner: -
@@ -1764,7 +1572,6 @@ CREATE TABLE public.session (
     "userId" text NOT NULL,
     "activeOrganizationId" text
 );
-
 
 --
 -- Name: user; Type: TABLE; Schema: public; Owner: -
@@ -1784,7 +1591,6 @@ CREATE TABLE public."user" (
     CONSTRAINT username_not_reserved CHECK ((username <> ALL (ARRAY['settings'::text, 'auth'::text, 'api'::text, 'templates'::text, 'help'::text, 'account'::text, 'admin'::text, 'health'::text, 'login'::text, 'logout'::text, 'signup'::text, 'register'::text])))
 );
 
-
 --
 -- Name: user_auth_profiles; Type: TABLE; Schema: public; Owner: -
 --
@@ -1796,7 +1602,6 @@ CREATE TABLE public.user_auth_profiles (
     updated_at timestamp with time zone DEFAULT now() NOT NULL
 );
 
-
 --
 -- Name: user_model_preferences; Type: TABLE; Schema: public; Owner: -
 --
@@ -1807,7 +1612,6 @@ CREATE TABLE public.user_model_preferences (
     model text NOT NULL,
     updated_at timestamp with time zone DEFAULT now() NOT NULL
 );
-
 
 --
 -- Name: verification; Type: TABLE; Schema: public; Owner: -
@@ -1821,7 +1625,6 @@ CREATE TABLE public.verification (
     "createdAt" timestamp with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
     "updatedAt" timestamp with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL
 );
-
 
 --
 -- Name: view_template_active_tabs; Type: TABLE; Schema: public; Owner: -
@@ -1838,7 +1641,6 @@ CREATE TABLE public.view_template_active_tabs (
     CONSTRAINT view_template_active_tabs_resource_type_check CHECK ((resource_type = ANY (ARRAY['entity_type'::text, 'entity'::text])))
 );
 
-
 --
 -- Name: view_template_active_tabs_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
@@ -1851,13 +1653,11 @@ CREATE SEQUENCE public.view_template_active_tabs_id_seq
     NO MAXVALUE
     CACHE 1;
 
-
 --
 -- Name: view_template_active_tabs_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
 ALTER SEQUENCE public.view_template_active_tabs_id_seq OWNED BY public.view_template_active_tabs.id;
-
 
 --
 -- Name: view_template_versions; Type: TABLE; Schema: public; Owner: -
@@ -1878,7 +1678,6 @@ CREATE TABLE public.view_template_versions (
     CONSTRAINT view_template_versions_resource_type_check CHECK ((resource_type = ANY (ARRAY['entity_type'::text, 'entity'::text])))
 );
 
-
 --
 -- Name: view_template_versions_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
@@ -1891,13 +1690,11 @@ CREATE SEQUENCE public.view_template_versions_id_seq
     NO MAXVALUE
     CACHE 1;
 
-
 --
 -- Name: view_template_versions_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
 ALTER SEQUENCE public.view_template_versions_id_seq OWNED BY public.view_template_versions.id;
-
 
 --
 -- Name: watcher_reactions; Type: TABLE; Schema: public; Owner: -
@@ -1917,7 +1714,6 @@ CREATE TABLE public.watcher_reactions (
     created_at timestamp with time zone DEFAULT now()
 );
 
-
 --
 -- Name: watcher_reactions_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
@@ -1929,33 +1725,31 @@ CREATE SEQUENCE public.watcher_reactions_id_seq
     NO MAXVALUE
     CACHE 1;
 
-
 --
 -- Name: watcher_reactions_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
 ALTER SEQUENCE public.watcher_reactions_id_seq OWNED BY public.watcher_reactions.id;
 
-
 --
 -- Name: watcher_versions; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE public.watcher_versions (
-    id integer CONSTRAINT insight_template_versions_id_not_null NOT NULL,
-    version integer CONSTRAINT insight_template_versions_version_not_null NOT NULL,
-    name text CONSTRAINT insight_template_versions_name_not_null NOT NULL,
+    id integer NOT NULL,
+    version integer NOT NULL,
+    name text NOT NULL,
     description text,
     change_notes text,
-    created_by text CONSTRAINT insight_template_versions_created_by_not_null NOT NULL,
+    created_by text NOT NULL,
     created_at timestamp with time zone DEFAULT now(),
     keying_config jsonb,
     json_template jsonb,
-    prompt text CONSTRAINT insight_template_versions_prompt_not_null NOT NULL,
-    extraction_schema jsonb CONSTRAINT insight_template_versions_extraction_schema_not_null NOT NULL,
+    prompt text NOT NULL,
+    extraction_schema jsonb NOT NULL,
     classifiers jsonb,
-    required_source_types text[] DEFAULT '{}'::text[] CONSTRAINT insight_template_versions_required_source_types_not_null NOT NULL,
-    recommended_source_types text[] DEFAULT '{}'::text[] CONSTRAINT insight_template_versions_recommended_source_types_not_null NOT NULL,
+    required_source_types text[] DEFAULT '{}'::text[] NOT NULL,
+    recommended_source_types text[] DEFAULT '{}'::text[] NOT NULL,
     reactions_guidance text,
     condensation_prompt text,
     condensation_window_count integer DEFAULT 4,
@@ -1963,13 +1757,11 @@ CREATE TABLE public.watcher_versions (
     version_sources jsonb
 );
 
-
 --
 -- Name: COLUMN watcher_versions.json_template; Type: COMMENT; Schema: public; Owner: -
 --
 
 COMMENT ON COLUMN public.watcher_versions.json_template IS 'JSON-based template definition for React rendering. Replaces Svelte-based renderer_component.';
-
 
 --
 -- Name: COLUMN watcher_versions.prompt; Type: COMMENT; Schema: public; Owner: -
@@ -1977,13 +1769,11 @@ COMMENT ON COLUMN public.watcher_versions.json_template IS 'JSON-based template 
 
 COMMENT ON COLUMN public.watcher_versions.prompt IS 'Handlebars prompt template used for insight extraction.';
 
-
 --
 -- Name: COLUMN watcher_versions.extraction_schema; Type: COMMENT; Schema: public; Owner: -
 --
 
 COMMENT ON COLUMN public.watcher_versions.extraction_schema IS 'JSON Schema defining LLM output structure for this template version.';
-
 
 --
 -- Name: COLUMN watcher_versions.classifiers; Type: COMMENT; Schema: public; Owner: -
@@ -1991,13 +1781,11 @@ COMMENT ON COLUMN public.watcher_versions.extraction_schema IS 'JSON Schema defi
 
 COMMENT ON COLUMN public.watcher_versions.classifiers IS 'Optional classifier definitions attached to this template version.';
 
-
 --
 -- Name: COLUMN watcher_versions.required_source_types; Type: COMMENT; Schema: public; Owner: -
 --
 
 COMMENT ON COLUMN public.watcher_versions.required_source_types IS 'Source type slugs that must exist for selected source entities before insight creation.';
-
 
 --
 -- Name: COLUMN watcher_versions.recommended_source_types; Type: COMMENT; Schema: public; Owner: -
@@ -2005,13 +1793,11 @@ COMMENT ON COLUMN public.watcher_versions.required_source_types IS 'Source type 
 
 COMMENT ON COLUMN public.watcher_versions.recommended_source_types IS 'Source type slugs recommended for better insight quality.';
 
-
 --
 -- Name: COLUMN watcher_versions.reactions_guidance; Type: COMMENT; Schema: public; Owner: -
 --
 
 COMMENT ON COLUMN public.watcher_versions.reactions_guidance IS 'Optional guidance text for LLM agents on what reactions to take after analyzing a watcher window.';
-
 
 --
 -- Name: COLUMN watcher_versions.condensation_prompt; Type: COMMENT; Schema: public; Owner: -
@@ -2019,13 +1805,11 @@ COMMENT ON COLUMN public.watcher_versions.reactions_guidance IS 'Optional guidan
 
 COMMENT ON COLUMN public.watcher_versions.condensation_prompt IS 'Handlebars prompt for condensing completed windows into a rollup. Receives {{windows}} array.';
 
-
 --
 -- Name: COLUMN watcher_versions.condensation_window_count; Type: COMMENT; Schema: public; Owner: -
 --
 
 COMMENT ON COLUMN public.watcher_versions.condensation_window_count IS 'How many leaf windows to condense into one rollup. Default 4.';
-
 
 --
 -- Name: watcher_template_versions_id_seq; Type: SEQUENCE; Schema: public; Owner: -
@@ -2038,25 +1822,22 @@ CREATE SEQUENCE public.watcher_template_versions_id_seq
     NO MAXVALUE
     CACHE 1;
 
-
 --
 -- Name: watcher_template_versions_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
 ALTER SEQUENCE public.watcher_template_versions_id_seq OWNED BY public.watcher_versions.id;
 
-
 --
 -- Name: watcher_window_events; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE public.watcher_window_events (
-    id bigint CONSTRAINT insight_window_content_id_not_null NOT NULL,
-    window_id bigint CONSTRAINT insight_window_content_window_id_not_null NOT NULL,
-    event_id bigint CONSTRAINT insight_window_content_content_id_not_null NOT NULL,
+    id bigint NOT NULL,
+    window_id bigint NOT NULL,
+    event_id bigint NOT NULL,
     created_at timestamp with time zone DEFAULT now()
 );
-
 
 --
 -- Name: watcher_window_content_id_seq; Type: SEQUENCE; Schema: public; Owner: -
@@ -2069,13 +1850,11 @@ CREATE SEQUENCE public.watcher_window_content_id_seq
     NO MAXVALUE
     CACHE 1;
 
-
 --
 -- Name: watcher_window_content_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
 ALTER SEQUENCE public.watcher_window_content_id_seq OWNED BY public.watcher_window_events.id;
-
 
 --
 -- Name: watcher_window_field_feedback; Type: TABLE; Schema: public; Owner: -
@@ -2095,7 +1874,6 @@ CREATE TABLE public.watcher_window_field_feedback (
     CONSTRAINT watcher_window_field_feedback_mutation_check CHECK ((mutation = ANY (ARRAY['set'::text, 'remove'::text, 'add'::text])))
 );
 
-
 --
 -- Name: watcher_window_field_feedback_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
@@ -2107,27 +1885,25 @@ CREATE SEQUENCE public.watcher_window_field_feedback_id_seq
     NO MAXVALUE
     CACHE 1;
 
-
 --
 -- Name: watcher_window_field_feedback_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
 ALTER SEQUENCE public.watcher_window_field_feedback_id_seq OWNED BY public.watcher_window_field_feedback.id;
 
-
 --
 -- Name: watcher_windows; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE public.watcher_windows (
-    id integer CONSTRAINT insight_windows_id_not_null NOT NULL,
-    watcher_id integer CONSTRAINT insight_windows_insight_id_not_null NOT NULL,
+    id integer NOT NULL,
+    watcher_id integer NOT NULL,
     parent_window_id integer,
-    granularity text CONSTRAINT insight_windows_granularity_not_null NOT NULL,
-    window_start timestamp with time zone CONSTRAINT insight_windows_window_start_not_null NOT NULL,
-    window_end timestamp with time zone CONSTRAINT insight_windows_window_end_not_null NOT NULL,
-    content_analyzed integer CONSTRAINT insight_windows_content_analyzed_not_null NOT NULL,
-    extracted_data jsonb CONSTRAINT insight_windows_extracted_data_not_null NOT NULL,
+    granularity text NOT NULL,
+    window_start timestamp with time zone NOT NULL,
+    window_end timestamp with time zone NOT NULL,
+    content_analyzed integer NOT NULL,
+    extracted_data jsonb NOT NULL,
     model_used text,
     execution_time_ms integer,
     is_rollup boolean DEFAULT false,
@@ -2140,13 +1916,11 @@ CREATE TABLE public.watcher_windows (
     run_id bigint
 );
 
-
 --
 -- Name: TABLE watcher_windows; Type: COMMENT; Schema: public; Owner: -
 --
 
 COMMENT ON TABLE public.watcher_windows IS 'Time-series watcher results with hierarchical rollups';
-
 
 --
 -- Name: COLUMN watcher_windows.parent_window_id; Type: COMMENT; Schema: public; Owner: -
@@ -2154,13 +1928,11 @@ COMMENT ON TABLE public.watcher_windows IS 'Time-series watcher results with hie
 
 COMMENT ON COLUMN public.watcher_windows.parent_window_id IS 'Rollup hierarchy (daily->weekly->monthly->quarterly)';
 
-
 --
 -- Name: COLUMN watcher_windows.depth; Type: COMMENT; Schema: public; Owner: -
 --
 
 COMMENT ON COLUMN public.watcher_windows.depth IS 'Condensation depth: 0=leaf, 1+=rollup tiers';
-
 
 --
 -- Name: watcher_windows_id_seq; Type: SEQUENCE; Schema: public; Owner: -
@@ -2173,26 +1945,24 @@ CREATE SEQUENCE public.watcher_windows_id_seq
     NO MAXVALUE
     CACHE 1;
 
-
 --
 -- Name: watcher_windows_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
 ALTER SEQUENCE public.watcher_windows_id_seq OWNED BY public.watcher_windows.id;
 
-
 --
 -- Name: watchers; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE public.watchers (
-    id integer CONSTRAINT insights_id_not_null NOT NULL,
+    id integer NOT NULL,
     model_config jsonb DEFAULT '{}'::jsonb,
     status text DEFAULT 'active'::text NOT NULL,
     created_at timestamp with time zone DEFAULT now(),
     updated_at timestamp with time zone DEFAULT now(),
     sources jsonb DEFAULT '[]'::jsonb,
-    created_by text CONSTRAINT insights_created_by_not_null NOT NULL,
+    created_by text NOT NULL,
     entity_ids bigint[],
     reaction_script text,
     reaction_script_compiled text,
@@ -2213,13 +1983,11 @@ CREATE TABLE public.watchers (
     CONSTRAINT insights_status_check CHECK ((status = ANY (ARRAY['active'::text, 'archived'::text])))
 );
 
-
 --
 -- Name: COLUMN watchers.status; Type: COMMENT; Schema: public; Owner: -
 --
 
 COMMENT ON COLUMN public.watchers.status IS 'Status of insight: active (recurring), paused (recurring), failed (recurring), completed (one-off)';
-
 
 --
 -- Name: COLUMN watchers.sources; Type: COMMENT; Schema: public; Owner: -
@@ -2227,20 +1995,17 @@ COMMENT ON COLUMN public.watchers.status IS 'Status of insight: active (recurrin
 
 COMMENT ON COLUMN public.watchers.sources IS 'Array of data sources: [{name: string, entity_id: number, filters: {min_score?, platforms?, search_query?}}]. Each source defines an entity and its filters for content fetching.';
 
-
 --
 -- Name: COLUMN watchers.reaction_script; Type: COMMENT; Schema: public; Owner: -
 --
 
 COMMENT ON COLUMN public.watchers.reaction_script IS 'TypeScript source for automated reaction script.';
 
-
 --
 -- Name: COLUMN watchers.reaction_script_compiled; Type: COMMENT; Schema: public; Owner: -
 --
 
 COMMENT ON COLUMN public.watchers.reaction_script_compiled IS 'Compiled JavaScript from reaction_script.';
-
 
 --
 -- Name: watchers_id_seq; Type: SEQUENCE; Schema: public; Owner: -
@@ -2253,27 +2018,11 @@ CREATE SEQUENCE public.watchers_id_seq
     NO MAXVALUE
     CACHE 1;
 
-
 --
 -- Name: watchers_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
 ALTER SEQUENCE public.watchers_id_seq OWNED BY public.watchers.id;
-
-
---
--- Name: chat_state_lists seq; Type: DEFAULT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.chat_state_lists ALTER COLUMN seq SET DEFAULT nextval('public.chat_state_lists_seq_seq'::regclass);
-
-
---
--- Name: chat_state_queues seq; Type: DEFAULT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.chat_state_queues ALTER COLUMN seq SET DEFAULT nextval('public.chat_state_queues_seq_seq'::regclass);
-
 
 --
 -- Name: connect_tokens id; Type: DEFAULT; Schema: public; Owner: -
@@ -2281,13 +2030,11 @@ ALTER TABLE ONLY public.chat_state_queues ALTER COLUMN seq SET DEFAULT nextval('
 
 ALTER TABLE ONLY public.connect_tokens ALTER COLUMN id SET DEFAULT nextval('public.connect_tokens_id_seq'::regclass);
 
-
 --
 -- Name: connections id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.connections ALTER COLUMN id SET DEFAULT nextval('public.connections_id_seq'::regclass);
-
 
 --
 -- Name: connector_definitions id; Type: DEFAULT; Schema: public; Owner: -
@@ -2295,13 +2042,11 @@ ALTER TABLE ONLY public.connections ALTER COLUMN id SET DEFAULT nextval('public.
 
 ALTER TABLE ONLY public.connector_definitions ALTER COLUMN id SET DEFAULT nextval('public.connector_definitions_id_seq'::regclass);
 
-
 --
 -- Name: connector_versions id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.connector_versions ALTER COLUMN id SET DEFAULT nextval('public.connector_versions_id_seq'::regclass);
-
 
 --
 -- Name: entities id; Type: DEFAULT; Schema: public; Owner: -
@@ -2309,13 +2054,11 @@ ALTER TABLE ONLY public.connector_versions ALTER COLUMN id SET DEFAULT nextval('
 
 ALTER TABLE ONLY public.entities ALTER COLUMN id SET DEFAULT nextval('public.entities_id_seq'::regclass);
 
-
 --
 -- Name: entity_identities id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.entity_identities ALTER COLUMN id SET DEFAULT nextval('public.entity_identities_id_seq'::regclass);
-
 
 --
 -- Name: entity_relationship_type_rules id; Type: DEFAULT; Schema: public; Owner: -
@@ -2323,13 +2066,11 @@ ALTER TABLE ONLY public.entity_identities ALTER COLUMN id SET DEFAULT nextval('p
 
 ALTER TABLE ONLY public.entity_relationship_type_rules ALTER COLUMN id SET DEFAULT nextval('public.entity_relationship_type_rules_id_seq'::regclass);
 
-
 --
 -- Name: entity_relationship_types id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.entity_relationship_types ALTER COLUMN id SET DEFAULT nextval('public.entity_relationship_types_id_seq'::regclass);
-
 
 --
 -- Name: entity_relationships id; Type: DEFAULT; Schema: public; Owner: -
@@ -2337,13 +2078,11 @@ ALTER TABLE ONLY public.entity_relationship_types ALTER COLUMN id SET DEFAULT ne
 
 ALTER TABLE ONLY public.entity_relationships ALTER COLUMN id SET DEFAULT nextval('public.entity_relationships_id_seq'::regclass);
 
-
 --
 -- Name: entity_type_audit id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.entity_type_audit ALTER COLUMN id SET DEFAULT nextval('public.entity_type_audit_id_seq'::regclass);
-
 
 --
 -- Name: entity_types id; Type: DEFAULT; Schema: public; Owner: -
@@ -2351,13 +2090,11 @@ ALTER TABLE ONLY public.entity_type_audit ALTER COLUMN id SET DEFAULT nextval('p
 
 ALTER TABLE ONLY public.entity_types ALTER COLUMN id SET DEFAULT nextval('public.entity_types_id_seq'::regclass);
 
-
 --
 -- Name: event_classifications id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.event_classifications ALTER COLUMN id SET DEFAULT nextval('public.event_classifications_id_seq'::regclass);
-
 
 --
 -- Name: event_classifier_versions id; Type: DEFAULT; Schema: public; Owner: -
@@ -2365,13 +2102,11 @@ ALTER TABLE ONLY public.event_classifications ALTER COLUMN id SET DEFAULT nextva
 
 ALTER TABLE ONLY public.event_classifier_versions ALTER COLUMN id SET DEFAULT nextval('public.event_classifier_versions_id_seq'::regclass);
 
-
 --
 -- Name: event_classifiers id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.event_classifiers ALTER COLUMN id SET DEFAULT nextval('public.event_classifiers_id_seq'::regclass);
-
 
 --
 -- Name: events id; Type: DEFAULT; Schema: public; Owner: -
@@ -2379,13 +2114,11 @@ ALTER TABLE ONLY public.event_classifiers ALTER COLUMN id SET DEFAULT nextval('p
 
 ALTER TABLE ONLY public.events ALTER COLUMN id SET DEFAULT nextval('public.content_id_seq'::regclass);
 
-
 --
 -- Name: feeds id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.feeds ALTER COLUMN id SET DEFAULT nextval('public.feeds_id_seq'::regclass);
-
 
 --
 -- Name: notifications id; Type: DEFAULT; Schema: public; Owner: -
@@ -2393,13 +2126,11 @@ ALTER TABLE ONLY public.feeds ALTER COLUMN id SET DEFAULT nextval('public.feeds_
 
 ALTER TABLE ONLY public.notifications ALTER COLUMN id SET DEFAULT nextval('public.notifications_id_seq'::regclass);
 
-
 --
 -- Name: personal_access_tokens id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.personal_access_tokens ALTER COLUMN id SET DEFAULT nextval('public.personal_access_tokens_id_seq'::regclass);
-
 
 --
 -- Name: runs id; Type: DEFAULT; Schema: public; Owner: -
@@ -2407,13 +2138,11 @@ ALTER TABLE ONLY public.personal_access_tokens ALTER COLUMN id SET DEFAULT nextv
 
 ALTER TABLE ONLY public.runs ALTER COLUMN id SET DEFAULT nextval('public.runs_id_seq'::regclass);
 
-
 --
 -- Name: view_template_active_tabs id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.view_template_active_tabs ALTER COLUMN id SET DEFAULT nextval('public.view_template_active_tabs_id_seq'::regclass);
-
 
 --
 -- Name: view_template_versions id; Type: DEFAULT; Schema: public; Owner: -
@@ -2421,13 +2150,11 @@ ALTER TABLE ONLY public.view_template_active_tabs ALTER COLUMN id SET DEFAULT ne
 
 ALTER TABLE ONLY public.view_template_versions ALTER COLUMN id SET DEFAULT nextval('public.view_template_versions_id_seq'::regclass);
 
-
 --
 -- Name: watcher_reactions id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.watcher_reactions ALTER COLUMN id SET DEFAULT nextval('public.watcher_reactions_id_seq'::regclass);
-
 
 --
 -- Name: watcher_versions id; Type: DEFAULT; Schema: public; Owner: -
@@ -2435,13 +2162,11 @@ ALTER TABLE ONLY public.watcher_reactions ALTER COLUMN id SET DEFAULT nextval('p
 
 ALTER TABLE ONLY public.watcher_versions ALTER COLUMN id SET DEFAULT nextval('public.watcher_template_versions_id_seq'::regclass);
 
-
 --
 -- Name: watcher_window_events id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.watcher_window_events ALTER COLUMN id SET DEFAULT nextval('public.watcher_window_content_id_seq'::regclass);
-
 
 --
 -- Name: watcher_window_field_feedback id; Type: DEFAULT; Schema: public; Owner: -
@@ -2449,20 +2174,17 @@ ALTER TABLE ONLY public.watcher_window_events ALTER COLUMN id SET DEFAULT nextva
 
 ALTER TABLE ONLY public.watcher_window_field_feedback ALTER COLUMN id SET DEFAULT nextval('public.watcher_window_field_feedback_id_seq'::regclass);
 
-
 --
 -- Name: watcher_windows id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.watcher_windows ALTER COLUMN id SET DEFAULT nextval('public.watcher_windows_id_seq'::regclass);
 
-
 --
 -- Name: watchers id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.watchers ALTER COLUMN id SET DEFAULT nextval('public.watchers_id_seq'::regclass);
-
 
 --
 -- Name: account account_pkey; Type: CONSTRAINT; Schema: public; Owner: -
@@ -2471,14 +2193,12 @@ ALTER TABLE ONLY public.watchers ALTER COLUMN id SET DEFAULT nextval('public.wat
 ALTER TABLE ONLY public.account
     ADD CONSTRAINT account_pkey PRIMARY KEY (id);
 
-
 --
 -- Name: agent_channel_bindings agent_channel_bindings_platform_channel_id_team_id_key; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.agent_channel_bindings
     ADD CONSTRAINT agent_channel_bindings_platform_channel_id_team_id_key UNIQUE (platform, channel_id, team_id);
-
 
 --
 -- Name: agent_connections agent_connections_pkey; Type: CONSTRAINT; Schema: public; Owner: -
@@ -2487,14 +2207,12 @@ ALTER TABLE ONLY public.agent_channel_bindings
 ALTER TABLE ONLY public.agent_connections
     ADD CONSTRAINT agent_connections_pkey PRIMARY KEY (id);
 
-
 --
 -- Name: agent_grants agent_grants_agent_id_pattern_key; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.agent_grants
     ADD CONSTRAINT agent_grants_agent_id_pattern_key UNIQUE (agent_id, pattern);
-
 
 --
 -- Name: agent_grants agent_grants_pkey; Type: CONSTRAINT; Schema: public; Owner: -
@@ -2503,14 +2221,12 @@ ALTER TABLE ONLY public.agent_grants
 ALTER TABLE ONLY public.agent_grants
     ADD CONSTRAINT agent_grants_pkey PRIMARY KEY (id);
 
-
 --
 -- Name: agent_secrets agent_secrets_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.agent_secrets
     ADD CONSTRAINT agent_secrets_pkey PRIMARY KEY (organization_id, name);
-
 
 --
 -- Name: agent_users agent_users_pkey; Type: CONSTRAINT; Schema: public; Owner: -
@@ -2519,14 +2235,12 @@ ALTER TABLE ONLY public.agent_secrets
 ALTER TABLE ONLY public.agent_users
     ADD CONSTRAINT agent_users_pkey PRIMARY KEY (agent_id, platform, user_id);
 
-
 --
 -- Name: agents agents_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.agents
     ADD CONSTRAINT agents_pkey PRIMARY KEY (id);
-
 
 --
 -- Name: auth_profiles auth_profiles_org_id_unique; Type: CONSTRAINT; Schema: public; Owner: -
@@ -2535,7 +2249,6 @@ ALTER TABLE ONLY public.agents
 ALTER TABLE ONLY public.auth_profiles
     ADD CONSTRAINT auth_profiles_org_id_unique UNIQUE (organization_id, id);
 
-
 --
 -- Name: auth_profiles auth_profiles_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
@@ -2543,54 +2256,12 @@ ALTER TABLE ONLY public.auth_profiles
 ALTER TABLE ONLY public.auth_profiles
     ADD CONSTRAINT auth_profiles_pkey PRIMARY KEY (id);
 
-
 --
--- Name: chat_connections chat_connections_pkey; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.chat_connections
-    ADD CONSTRAINT chat_connections_pkey PRIMARY KEY (id);
-
-
---
--- Name: chat_state_cache chat_state_cache_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: chat_user_identities chat_user_identities_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.chat_state_cache
-    ADD CONSTRAINT chat_state_cache_pkey PRIMARY KEY (key_prefix, cache_key);
-
-
---
--- Name: chat_state_lists chat_state_lists_pkey; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.chat_state_lists
-    ADD CONSTRAINT chat_state_lists_pkey PRIMARY KEY (key_prefix, list_key, seq);
-
-
---
--- Name: chat_state_locks chat_state_locks_pkey; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.chat_state_locks
-    ADD CONSTRAINT chat_state_locks_pkey PRIMARY KEY (key_prefix, thread_id);
-
-
---
--- Name: chat_state_queues chat_state_queues_pkey; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.chat_state_queues
-    ADD CONSTRAINT chat_state_queues_pkey PRIMARY KEY (key_prefix, thread_id, seq);
-
-
---
--- Name: chat_state_subscriptions chat_state_subscriptions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.chat_state_subscriptions
-    ADD CONSTRAINT chat_state_subscriptions_pkey PRIMARY KEY (key_prefix, thread_id);
-
+ALTER TABLE ONLY public.chat_user_identities
+    ADD CONSTRAINT chat_user_identities_pkey PRIMARY KEY (platform, team_id, platform_user_id);
 
 --
 -- Name: connect_tokens connect_tokens_pkey; Type: CONSTRAINT; Schema: public; Owner: -
@@ -2599,14 +2270,12 @@ ALTER TABLE ONLY public.chat_state_subscriptions
 ALTER TABLE ONLY public.connect_tokens
     ADD CONSTRAINT connect_tokens_pkey PRIMARY KEY (id);
 
-
 --
 -- Name: connect_tokens connect_tokens_token_key; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.connect_tokens
     ADD CONSTRAINT connect_tokens_token_key UNIQUE (token);
-
 
 --
 -- Name: connections connections_pkey; Type: CONSTRAINT; Schema: public; Owner: -
@@ -2615,14 +2284,12 @@ ALTER TABLE ONLY public.connect_tokens
 ALTER TABLE ONLY public.connections
     ADD CONSTRAINT connections_pkey PRIMARY KEY (id);
 
-
 --
 -- Name: connector_definitions connector_definitions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.connector_definitions
     ADD CONSTRAINT connector_definitions_pkey PRIMARY KEY (id);
-
 
 --
 -- Name: connector_versions connector_versions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
@@ -2631,6 +2298,12 @@ ALTER TABLE ONLY public.connector_definitions
 ALTER TABLE ONLY public.connector_versions
     ADD CONSTRAINT connector_versions_pkey PRIMARY KEY (id);
 
+--
+-- Name: device_workers device_workers_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.device_workers
+    ADD CONSTRAINT device_workers_pkey PRIMARY KEY (user_id, worker_id);
 
 --
 -- Name: entities entities_pkey; Type: CONSTRAINT; Schema: public; Owner: -
@@ -2639,22 +2312,12 @@ ALTER TABLE ONLY public.connector_versions
 ALTER TABLE ONLY public.entities
     ADD CONSTRAINT entities_pkey PRIMARY KEY (id);
 
-
 --
 -- Name: entity_identities entity_identities_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.entity_identities
     ADD CONSTRAINT entity_identities_pkey PRIMARY KEY (id);
-
-
---
--- Name: entity_read_grant entity_read_grant_pkey; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.entity_read_grant
-    ADD CONSTRAINT entity_read_grant_pkey PRIMARY KEY (id);
-
 
 --
 -- Name: entity_relationship_type_rules entity_relationship_type_rules_pkey; Type: CONSTRAINT; Schema: public; Owner: -
@@ -2663,14 +2326,12 @@ ALTER TABLE ONLY public.entity_read_grant
 ALTER TABLE ONLY public.entity_relationship_type_rules
     ADD CONSTRAINT entity_relationship_type_rules_pkey PRIMARY KEY (id);
 
-
 --
 -- Name: entity_relationship_types entity_relationship_types_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.entity_relationship_types
     ADD CONSTRAINT entity_relationship_types_pkey PRIMARY KEY (id);
-
 
 --
 -- Name: entity_relationships entity_relationships_pkey; Type: CONSTRAINT; Schema: public; Owner: -
@@ -2679,14 +2340,12 @@ ALTER TABLE ONLY public.entity_relationship_types
 ALTER TABLE ONLY public.entity_relationships
     ADD CONSTRAINT entity_relationships_pkey PRIMARY KEY (id);
 
-
 --
 -- Name: entity_type_audit entity_type_audit_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.entity_type_audit
     ADD CONSTRAINT entity_type_audit_pkey PRIMARY KEY (id);
-
 
 --
 -- Name: entity_types entity_types_pkey; Type: CONSTRAINT; Schema: public; Owner: -
@@ -2695,14 +2354,12 @@ ALTER TABLE ONLY public.entity_type_audit
 ALTER TABLE ONLY public.entity_types
     ADD CONSTRAINT entity_types_pkey PRIMARY KEY (id);
 
-
 --
 -- Name: event_classifications event_classifications_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.event_classifications
     ADD CONSTRAINT event_classifications_pkey PRIMARY KEY (id);
-
 
 --
 -- Name: event_classifier_versions event_classifier_versions_classifier_id_version_key; Type: CONSTRAINT; Schema: public; Owner: -
@@ -2711,14 +2368,12 @@ ALTER TABLE ONLY public.event_classifications
 ALTER TABLE ONLY public.event_classifier_versions
     ADD CONSTRAINT event_classifier_versions_classifier_id_version_key UNIQUE (classifier_id, version);
 
-
 --
 -- Name: event_classifier_versions event_classifier_versions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.event_classifier_versions
     ADD CONSTRAINT event_classifier_versions_pkey PRIMARY KEY (id);
-
 
 --
 -- Name: event_classifiers event_classifiers_pkey; Type: CONSTRAINT; Schema: public; Owner: -
@@ -2727,14 +2382,12 @@ ALTER TABLE ONLY public.event_classifier_versions
 ALTER TABLE ONLY public.event_classifiers
     ADD CONSTRAINT event_classifiers_pkey PRIMARY KEY (id);
 
-
 --
 -- Name: event_classifiers event_classifiers_unique_per_insight; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.event_classifiers
     ADD CONSTRAINT event_classifiers_unique_per_insight UNIQUE NULLS NOT DISTINCT (entity_id, watcher_id, slug);
-
 
 --
 -- Name: event_embeddings event_embeddings_pkey; Type: CONSTRAINT; Schema: public; Owner: -
@@ -2743,14 +2396,12 @@ ALTER TABLE ONLY public.event_classifiers
 ALTER TABLE ONLY public.event_embeddings
     ADD CONSTRAINT event_embeddings_pkey PRIMARY KEY (event_id);
 
-
 --
 -- Name: events event_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.events
     ADD CONSTRAINT event_pkey PRIMARY KEY (id);
-
 
 --
 -- Name: feeds feeds_pkey; Type: CONSTRAINT; Schema: public; Owner: -
@@ -2759,14 +2410,12 @@ ALTER TABLE ONLY public.events
 ALTER TABLE ONLY public.feeds
     ADD CONSTRAINT feeds_pkey PRIMARY KEY (id);
 
-
 --
 -- Name: grants grants_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.grants
     ADD CONSTRAINT grants_pkey PRIMARY KEY (agent_id, kind, pattern);
-
 
 --
 -- Name: watcher_versions insight_template_versions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
@@ -2775,14 +2424,12 @@ ALTER TABLE ONLY public.grants
 ALTER TABLE ONLY public.watcher_versions
     ADD CONSTRAINT insight_template_versions_pkey PRIMARY KEY (id);
 
-
 --
 -- Name: watcher_window_events insight_window_content_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.watcher_window_events
     ADD CONSTRAINT insight_window_content_pkey PRIMARY KEY (id);
-
 
 --
 -- Name: watcher_window_events insight_window_content_window_id_content_id_key; Type: CONSTRAINT; Schema: public; Owner: -
@@ -2791,14 +2438,12 @@ ALTER TABLE ONLY public.watcher_window_events
 ALTER TABLE ONLY public.watcher_window_events
     ADD CONSTRAINT insight_window_content_window_id_content_id_key UNIQUE (window_id, event_id);
 
-
 --
 -- Name: watcher_windows insight_windows_insight_id_granularity_window_start_key; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.watcher_windows
     ADD CONSTRAINT insight_windows_insight_id_granularity_window_start_key UNIQUE (watcher_id, granularity, window_start);
-
 
 --
 -- Name: watcher_windows insight_windows_pkey; Type: CONSTRAINT; Schema: public; Owner: -
@@ -2807,14 +2452,12 @@ ALTER TABLE ONLY public.watcher_windows
 ALTER TABLE ONLY public.watcher_windows
     ADD CONSTRAINT insight_windows_pkey PRIMARY KEY (id);
 
-
 --
 -- Name: watchers insights_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.watchers
     ADD CONSTRAINT insights_pkey PRIMARY KEY (id);
-
 
 --
 -- Name: invitation invitation_pkey; Type: CONSTRAINT; Schema: public; Owner: -
@@ -2823,14 +2466,12 @@ ALTER TABLE ONLY public.watchers
 ALTER TABLE ONLY public.invitation
     ADD CONSTRAINT invitation_pkey PRIMARY KEY (id);
 
-
 --
 -- Name: latest_event_classifications latest_event_classifications_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.latest_event_classifications
     ADD CONSTRAINT latest_event_classifications_pkey PRIMARY KEY (event_id, classifier_id);
-
 
 --
 -- Name: mcp_proxy_sessions mcp_proxy_sessions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
@@ -2839,14 +2480,12 @@ ALTER TABLE ONLY public.latest_event_classifications
 ALTER TABLE ONLY public.mcp_proxy_sessions
     ADD CONSTRAINT mcp_proxy_sessions_pkey PRIMARY KEY (session_key);
 
-
 --
 -- Name: mcp_sessions mcp_sessions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.mcp_sessions
     ADD CONSTRAINT mcp_sessions_pkey PRIMARY KEY (session_id);
-
 
 --
 -- Name: member member_organizationId_userId_key; Type: CONSTRAINT; Schema: public; Owner: -
@@ -2855,7 +2494,6 @@ ALTER TABLE ONLY public.mcp_sessions
 ALTER TABLE ONLY public.member
     ADD CONSTRAINT "member_organizationId_userId_key" UNIQUE ("organizationId", "userId");
 
-
 --
 -- Name: member member_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
@@ -2863,6 +2501,33 @@ ALTER TABLE ONLY public.member
 ALTER TABLE ONLY public.member
     ADD CONSTRAINT member_pkey PRIMARY KEY (id);
 
+--
+-- Name: migration_20260315300000_entity_type_org_backfill migration_20260315300000_entity_type_org_backfill_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.migration_20260315300000_entity_type_org_backfill
+    ADD CONSTRAINT migration_20260315300000_entity_type_org_backfill_pkey PRIMARY KEY (entity_type_id);
+
+--
+-- Name: migration_20260316100000_created_entity_types migration_20260316100000_created_entity_types_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.migration_20260316100000_created_entity_types
+    ADD CONSTRAINT migration_20260316100000_created_entity_types_pkey PRIMARY KEY (entity_type_id);
+
+--
+-- Name: migration_20260316100000_deleted_default_entity_types migration_20260316100000_deleted_default_entity_types_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.migration_20260316100000_deleted_default_entity_types
+    ADD CONSTRAINT migration_20260316100000_deleted_default_entity_types_pkey PRIMARY KEY (id);
+
+--
+-- Name: migration_20260316100000_events_kind_backup migration_20260316100000_events_kind_backup_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.migration_20260316100000_events_kind_backup
+    ADD CONSTRAINT migration_20260316100000_events_kind_backup_pkey PRIMARY KEY (event_id);
 
 --
 -- Name: namespace namespace_pkey; Type: CONSTRAINT; Schema: public; Owner: -
@@ -2871,14 +2536,12 @@ ALTER TABLE ONLY public.member
 ALTER TABLE ONLY public.namespace
     ADD CONSTRAINT namespace_pkey PRIMARY KEY (slug);
 
-
 --
 -- Name: notifications notifications_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.notifications
     ADD CONSTRAINT notifications_pkey PRIMARY KEY (id);
-
 
 --
 -- Name: oauth_authorization_codes oauth_authorization_codes_pkey; Type: CONSTRAINT; Schema: public; Owner: -
@@ -2887,14 +2550,12 @@ ALTER TABLE ONLY public.notifications
 ALTER TABLE ONLY public.oauth_authorization_codes
     ADD CONSTRAINT oauth_authorization_codes_pkey PRIMARY KEY (code);
 
-
 --
 -- Name: oauth_clients oauth_clients_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.oauth_clients
     ADD CONSTRAINT oauth_clients_pkey PRIMARY KEY (id);
-
 
 --
 -- Name: oauth_device_codes oauth_device_codes_pkey; Type: CONSTRAINT; Schema: public; Owner: -
@@ -2903,14 +2564,12 @@ ALTER TABLE ONLY public.oauth_clients
 ALTER TABLE ONLY public.oauth_device_codes
     ADD CONSTRAINT oauth_device_codes_pkey PRIMARY KEY (device_code);
 
-
 --
 -- Name: oauth_states oauth_states_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.oauth_states
     ADD CONSTRAINT oauth_states_pkey PRIMARY KEY (id);
-
 
 --
 -- Name: oauth_tokens oauth_tokens_pkey; Type: CONSTRAINT; Schema: public; Owner: -
@@ -2919,14 +2578,12 @@ ALTER TABLE ONLY public.oauth_states
 ALTER TABLE ONLY public.oauth_tokens
     ADD CONSTRAINT oauth_tokens_pkey PRIMARY KEY (id);
 
-
 --
 -- Name: oauth_tokens oauth_tokens_token_hash_key; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.oauth_tokens
     ADD CONSTRAINT oauth_tokens_token_hash_key UNIQUE (token_hash);
-
 
 --
 -- Name: organization_lobu_links organization_lobu_links_pkey; Type: CONSTRAINT; Schema: public; Owner: -
@@ -2935,14 +2592,12 @@ ALTER TABLE ONLY public.oauth_tokens
 ALTER TABLE ONLY public.organization_lobu_links
     ADD CONSTRAINT organization_lobu_links_pkey PRIMARY KEY (organization_id);
 
-
 --
 -- Name: organization organization_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.organization
     ADD CONSTRAINT organization_pkey PRIMARY KEY (id);
-
 
 --
 -- Name: organization organization_slug_key; Type: CONSTRAINT; Schema: public; Owner: -
@@ -2951,14 +2606,12 @@ ALTER TABLE ONLY public.organization
 ALTER TABLE ONLY public.organization
     ADD CONSTRAINT organization_slug_key UNIQUE (slug);
 
-
 --
 -- Name: personal_access_tokens personal_access_tokens_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.personal_access_tokens
     ADD CONSTRAINT personal_access_tokens_pkey PRIMARY KEY (id);
-
 
 --
 -- Name: personal_access_tokens personal_access_tokens_token_hash_key; Type: CONSTRAINT; Schema: public; Owner: -
@@ -2967,14 +2620,12 @@ ALTER TABLE ONLY public.personal_access_tokens
 ALTER TABLE ONLY public.personal_access_tokens
     ADD CONSTRAINT personal_access_tokens_token_hash_key UNIQUE (token_hash);
 
-
 --
 -- Name: rate_limits rate_limits_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.rate_limits
     ADD CONSTRAINT rate_limits_pkey PRIMARY KEY (key);
-
 
 --
 -- Name: runs runs_pkey; Type: CONSTRAINT; Schema: public; Owner: -
@@ -2983,14 +2634,12 @@ ALTER TABLE ONLY public.rate_limits
 ALTER TABLE ONLY public.runs
     ADD CONSTRAINT runs_pkey PRIMARY KEY (id);
 
-
 --
 -- Name: schema_migrations schema_migrations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.schema_migrations
     ADD CONSTRAINT schema_migrations_pkey PRIMARY KEY (version);
-
 
 --
 -- Name: session session_pkey; Type: CONSTRAINT; Schema: public; Owner: -
@@ -2999,14 +2648,12 @@ ALTER TABLE ONLY public.schema_migrations
 ALTER TABLE ONLY public.session
     ADD CONSTRAINT session_pkey PRIMARY KEY (id);
 
-
 --
 -- Name: session session_token_key; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.session
     ADD CONSTRAINT session_token_key UNIQUE (token);
-
 
 --
 -- Name: user_auth_profiles user_auth_profiles_pkey; Type: CONSTRAINT; Schema: public; Owner: -
@@ -3015,14 +2662,12 @@ ALTER TABLE ONLY public.session
 ALTER TABLE ONLY public.user_auth_profiles
     ADD CONSTRAINT user_auth_profiles_pkey PRIMARY KEY (user_id, agent_id);
 
-
 --
 -- Name: user user_email_key; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public."user"
     ADD CONSTRAINT user_email_key UNIQUE (email);
-
 
 --
 -- Name: user_model_preferences user_model_preferences_pkey; Type: CONSTRAINT; Schema: public; Owner: -
@@ -3031,14 +2676,12 @@ ALTER TABLE ONLY public."user"
 ALTER TABLE ONLY public.user_model_preferences
     ADD CONSTRAINT user_model_preferences_pkey PRIMARY KEY (user_id, provider_id);
 
-
 --
 -- Name: user user_phoneNumber_key; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public."user"
     ADD CONSTRAINT "user_phoneNumber_key" UNIQUE ("phoneNumber");
-
 
 --
 -- Name: user user_pkey; Type: CONSTRAINT; Schema: public; Owner: -
@@ -3047,14 +2690,12 @@ ALTER TABLE ONLY public."user"
 ALTER TABLE ONLY public."user"
     ADD CONSTRAINT user_pkey PRIMARY KEY (id);
 
-
 --
 -- Name: verification verification_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.verification
     ADD CONSTRAINT verification_pkey PRIMARY KEY (id);
-
 
 --
 -- Name: view_template_active_tabs view_template_active_tabs_pkey; Type: CONSTRAINT; Schema: public; Owner: -
@@ -3063,14 +2704,12 @@ ALTER TABLE ONLY public.verification
 ALTER TABLE ONLY public.view_template_active_tabs
     ADD CONSTRAINT view_template_active_tabs_pkey PRIMARY KEY (id);
 
-
 --
 -- Name: view_template_active_tabs view_template_active_tabs_unique; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.view_template_active_tabs
     ADD CONSTRAINT view_template_active_tabs_unique UNIQUE (resource_type, resource_id, organization_id, tab_name);
-
 
 --
 -- Name: view_template_versions view_template_versions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
@@ -3079,14 +2718,12 @@ ALTER TABLE ONLY public.view_template_active_tabs
 ALTER TABLE ONLY public.view_template_versions
     ADD CONSTRAINT view_template_versions_pkey PRIMARY KEY (id);
 
-
 --
 -- Name: view_template_versions view_template_versions_unique; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.view_template_versions
     ADD CONSTRAINT view_template_versions_unique UNIQUE NULLS NOT DISTINCT (resource_type, resource_id, organization_id, tab_name, version);
-
 
 --
 -- Name: watcher_reactions watcher_reactions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
@@ -3095,7 +2732,6 @@ ALTER TABLE ONLY public.view_template_versions
 ALTER TABLE ONLY public.watcher_reactions
     ADD CONSTRAINT watcher_reactions_pkey PRIMARY KEY (id);
 
-
 --
 -- Name: watcher_window_field_feedback watcher_window_field_feedback_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
@@ -3103,13 +2739,11 @@ ALTER TABLE ONLY public.watcher_reactions
 ALTER TABLE ONLY public.watcher_window_field_feedback
     ADD CONSTRAINT watcher_window_field_feedback_pkey PRIMARY KEY (id);
 
-
 --
 -- Name: account_providerId_accountId_uidx; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE UNIQUE INDEX "account_providerId_accountId_uidx" ON public.account USING btree ("providerId", "accountId");
-
 
 --
 -- Name: account_providerId_idx; Type: INDEX; Schema: public; Owner: -
@@ -3117,13 +2751,11 @@ CREATE UNIQUE INDEX "account_providerId_accountId_uidx" ON public.account USING 
 
 CREATE INDEX "account_providerId_idx" ON public.account USING btree ("providerId");
 
-
 --
 -- Name: account_userId_idx; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX "account_userId_idx" ON public.account USING btree ("userId");
-
 
 --
 -- Name: agent_channel_bindings_agent_id_idx; Type: INDEX; Schema: public; Owner: -
@@ -3131,13 +2763,11 @@ CREATE INDEX "account_userId_idx" ON public.account USING btree ("userId");
 
 CREATE INDEX agent_channel_bindings_agent_id_idx ON public.agent_channel_bindings USING btree (agent_id);
 
-
 --
 -- Name: agent_channel_bindings_no_team_unique; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE UNIQUE INDEX agent_channel_bindings_no_team_unique ON public.agent_channel_bindings USING btree (platform, channel_id) WHERE (team_id IS NULL);
-
 
 --
 -- Name: agent_connections_agent_id_idx; Type: INDEX; Schema: public; Owner: -
@@ -3145,13 +2775,11 @@ CREATE UNIQUE INDEX agent_channel_bindings_no_team_unique ON public.agent_channe
 
 CREATE INDEX agent_connections_agent_id_idx ON public.agent_connections USING btree (agent_id);
 
-
 --
 -- Name: agent_connections_platform_idx; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX agent_connections_platform_idx ON public.agent_connections USING btree (platform);
-
 
 --
 -- Name: agent_grants_agent_id_idx; Type: INDEX; Schema: public; Owner: -
@@ -3159,20 +2787,11 @@ CREATE INDEX agent_connections_platform_idx ON public.agent_connections USING bt
 
 CREATE INDEX agent_grants_agent_id_idx ON public.agent_grants USING btree (agent_id);
 
-
 --
 -- Name: agent_secrets_expires_at_idx; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX agent_secrets_expires_at_idx ON public.agent_secrets USING btree (expires_at) WHERE (expires_at IS NOT NULL);
-
-
---
--- Name: agent_secrets_org_id_idx; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX agent_secrets_org_id_idx ON public.agent_secrets USING btree (organization_id);
-
 
 --
 -- Name: agent_secrets_name_prefix_idx; Type: INDEX; Schema: public; Owner: -
@@ -3180,6 +2799,11 @@ CREATE INDEX agent_secrets_org_id_idx ON public.agent_secrets USING btree (organ
 
 CREATE INDEX agent_secrets_name_prefix_idx ON public.agent_secrets USING btree (name text_pattern_ops);
 
+--
+-- Name: agent_secrets_org_id_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX agent_secrets_org_id_idx ON public.agent_secrets USING btree (organization_id);
 
 --
 -- Name: agents_organization_id_idx; Type: INDEX; Schema: public; Owner: -
@@ -3187,27 +2811,11 @@ CREATE INDEX agent_secrets_name_prefix_idx ON public.agent_secrets USING btree (
 
 CREATE INDEX agents_organization_id_idx ON public.agents USING btree (organization_id);
 
-
---
--- Name: agents_parent_connection_id_idx; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX agents_parent_connection_id_idx ON public.agents USING btree (parent_connection_id);
-
-
---
--- Name: agents_template_agent_id_idx; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX agents_template_agent_id_idx ON public.agents USING btree (template_agent_id);
-
-
 --
 -- Name: auth_profiles_connector_kind_idx; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX auth_profiles_connector_kind_idx ON public.auth_profiles USING btree (organization_id, connector_key, profile_kind, status);
-
 
 --
 -- Name: auth_profiles_org_slug_unique; Type: INDEX; Schema: public; Owner: -
@@ -3215,55 +2823,41 @@ CREATE INDEX auth_profiles_connector_kind_idx ON public.auth_profiles USING btre
 
 CREATE UNIQUE INDEX auth_profiles_org_slug_unique ON public.auth_profiles USING btree (organization_id, slug);
 
-
 --
 -- Name: auth_profiles_pending_unique; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE UNIQUE INDEX auth_profiles_pending_unique ON public.auth_profiles USING btree (organization_id, connector_key, profile_kind, provider) WHERE (status = 'pending_auth'::text);
 
-
 --
--- Name: chat_connections_platform_idx; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX chat_connections_platform_idx ON public.chat_connections USING btree (platform);
-
-
---
--- Name: chat_connections_template_agent_id_idx; Type: INDEX; Schema: public; Owner: -
+-- Name: chat_user_identities_lobu_user_idx; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX chat_connections_template_agent_id_idx ON public.chat_connections USING btree (template_agent_id) WHERE (template_agent_id IS NOT NULL);
-
-
---
--- Name: chat_state_cache_expires_idx; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX chat_state_cache_expires_idx ON public.chat_state_cache USING btree (expires_at);
-
+CREATE INDEX chat_user_identities_lobu_user_idx ON public.chat_user_identities USING btree (lobu_user_id);
 
 --
--- Name: chat_state_lists_expires_idx; Type: INDEX; Schema: public; Owner: -
+-- Name: connections_org_slug_unique; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX chat_state_lists_expires_idx ON public.chat_state_lists USING btree (expires_at);
-
-
---
--- Name: chat_state_locks_expires_idx; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX chat_state_locks_expires_idx ON public.chat_state_locks USING btree (expires_at);
-
+CREATE UNIQUE INDEX connections_org_slug_unique ON public.connections USING btree (organization_id, slug) WHERE (deleted_at IS NULL);
 
 --
--- Name: chat_state_queues_expires_idx; Type: INDEX; Schema: public; Owner: -
+-- Name: connector_definitions_required_capability_idx; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX chat_state_queues_expires_idx ON public.chat_state_queues USING btree (expires_at);
+CREATE INDEX connector_definitions_required_capability_idx ON public.connector_definitions USING btree (required_capability) WHERE (required_capability IS NOT NULL);
 
+--
+-- Name: device_workers_id_key; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX device_workers_id_key ON public.device_workers USING btree (id);
+
+--
+-- Name: device_workers_user_id_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX device_workers_user_id_idx ON public.device_workers USING btree (user_id);
 
 --
 -- Name: entities_slug_idx; Type: INDEX; Schema: public; Owner: -
@@ -3271,13 +2865,11 @@ CREATE INDEX chat_state_queues_expires_idx ON public.chat_state_queues USING btr
 
 CREATE INDEX entities_slug_idx ON public.entities USING btree (slug);
 
-
 --
 -- Name: entities_slug_parent_unique; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE UNIQUE INDEX entities_slug_parent_unique ON public.entities USING btree (organization_id, COALESCE(parent_id, (0)::bigint), slug);
-
 
 --
 -- Name: feeds_open_repair_thread_uniq; Type: INDEX; Schema: public; Owner: -
@@ -3285,13 +2877,11 @@ CREATE UNIQUE INDEX entities_slug_parent_unique ON public.entities USING btree (
 
 CREATE UNIQUE INDEX feeds_open_repair_thread_uniq ON public.feeds USING btree (id) WHERE (repair_thread_id IS NOT NULL);
 
-
 --
 -- Name: grants_agent_id_idx; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX grants_agent_id_idx ON public.grants USING btree (agent_id);
-
 
 --
 -- Name: grants_expires_at_idx; Type: INDEX; Schema: public; Owner: -
@@ -3299,13 +2889,11 @@ CREATE INDEX grants_agent_id_idx ON public.grants USING btree (agent_id);
 
 CREATE INDEX grants_expires_at_idx ON public.grants USING btree (expires_at) WHERE (expires_at IS NOT NULL);
 
-
 --
 -- Name: idx_cc_classifier_version_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX idx_cc_classifier_version_id ON public.event_classifications USING btree (classifier_version_id);
-
 
 --
 -- Name: idx_cc_content_id; Type: INDEX; Schema: public; Owner: -
@@ -3313,13 +2901,11 @@ CREATE INDEX idx_cc_classifier_version_id ON public.event_classifications USING 
 
 CREATE INDEX idx_cc_content_id ON public.event_classifications USING btree (event_id);
 
-
 --
 -- Name: idx_cc_source; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX idx_cc_source ON public.event_classifications USING btree (source);
-
 
 --
 -- Name: idx_cc_unique_per_source; Type: INDEX; Schema: public; Owner: -
@@ -3327,13 +2913,11 @@ CREATE INDEX idx_cc_source ON public.event_classifications USING btree (source);
 
 CREATE UNIQUE INDEX idx_cc_unique_per_source ON public.event_classifications USING btree (event_id, classifier_version_id, source, COALESCE(watcher_id, (0)::bigint));
 
-
 --
 -- Name: idx_cc_values_gin; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX idx_cc_values_gin ON public.event_classifications USING gin ("values");
-
 
 --
 -- Name: idx_cc_watcher_id; Type: INDEX; Schema: public; Owner: -
@@ -3341,13 +2925,11 @@ CREATE INDEX idx_cc_values_gin ON public.event_classifications USING gin ("value
 
 CREATE INDEX idx_cc_watcher_id ON public.event_classifications USING btree (watcher_id) WHERE (watcher_id IS NOT NULL);
 
-
 --
 -- Name: idx_cc_window_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX idx_cc_window_id ON public.event_classifications USING btree (window_id) WHERE (window_id IS NOT NULL);
-
 
 --
 -- Name: idx_connect_tokens_connection_id; Type: INDEX; Schema: public; Owner: -
@@ -3355,13 +2937,11 @@ CREATE INDEX idx_cc_window_id ON public.event_classifications USING btree (windo
 
 CREATE INDEX idx_connect_tokens_connection_id ON public.connect_tokens USING btree (connection_id);
 
-
 --
 -- Name: idx_connect_tokens_status_expires; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX idx_connect_tokens_status_expires ON public.connect_tokens USING btree (status, expires_at) WHERE (status = 'pending'::text);
-
 
 --
 -- Name: idx_connect_tokens_token; Type: INDEX; Schema: public; Owner: -
@@ -3369,13 +2949,11 @@ CREATE INDEX idx_connect_tokens_status_expires ON public.connect_tokens USING bt
 
 CREATE INDEX idx_connect_tokens_token ON public.connect_tokens USING btree (token);
 
-
 --
 -- Name: idx_connections_account; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX idx_connections_account ON public.connections USING btree (account_id);
-
 
 --
 -- Name: idx_connections_agent_id; Type: INDEX; Schema: public; Owner: -
@@ -3383,13 +2961,11 @@ CREATE INDEX idx_connections_account ON public.connections USING btree (account_
 
 CREATE INDEX idx_connections_agent_id ON public.connections USING btree (agent_id) WHERE (agent_id IS NOT NULL);
 
-
 --
 -- Name: idx_connections_connector_key; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX idx_connections_connector_key ON public.connections USING btree (connector_key);
-
 
 --
 -- Name: idx_connections_deleted_at; Type: INDEX; Schema: public; Owner: -
@@ -3397,6 +2973,17 @@ CREATE INDEX idx_connections_connector_key ON public.connections USING btree (co
 
 CREATE INDEX idx_connections_deleted_at ON public.connections USING btree (deleted_at) WHERE (deleted_at IS NULL);
 
+--
+-- Name: idx_connections_device_worker_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_connections_device_worker_id ON public.connections USING btree (device_worker_id) WHERE (device_worker_id IS NOT NULL);
+
+--
+-- Name: idx_connections_entity_ids; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_connections_entity_ids ON public.connections USING gin (entity_ids);
 
 --
 -- Name: idx_connections_org; Type: INDEX; Schema: public; Owner: -
@@ -3404,13 +2991,17 @@ CREATE INDEX idx_connections_deleted_at ON public.connections USING btree (delet
 
 CREATE INDEX idx_connections_org ON public.connections USING btree (organization_id);
 
-
 --
 -- Name: idx_connections_org_connector_account_live; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE UNIQUE INDEX idx_connections_org_connector_account_live ON public.connections USING btree (organization_id, connector_key, account_id) WHERE ((deleted_at IS NULL) AND (account_id IS NOT NULL));
 
+--
+-- Name: idx_connections_org_connector_device_live; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX idx_connections_org_connector_device_live ON public.connections USING btree (organization_id, connector_key, device_worker_id) WHERE ((deleted_at IS NULL) AND (device_worker_id IS NOT NULL));
 
 --
 -- Name: idx_connections_status; Type: INDEX; Schema: public; Owner: -
@@ -3418,13 +3009,11 @@ CREATE UNIQUE INDEX idx_connections_org_connector_account_live ON public.connect
 
 CREATE INDEX idx_connections_status ON public.connections USING btree (status);
 
-
 --
 -- Name: idx_connections_visibility; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX idx_connections_visibility ON public.connections USING btree (organization_id, visibility);
-
 
 --
 -- Name: idx_connector_defs_org_key; Type: INDEX; Schema: public; Owner: -
@@ -3432,20 +3021,11 @@ CREATE INDEX idx_connections_visibility ON public.connections USING btree (organ
 
 CREATE UNIQUE INDEX idx_connector_defs_org_key ON public.connector_definitions USING btree (organization_id, key) WHERE ((organization_id IS NOT NULL) AND (status = 'active'::text));
 
-
 --
 -- Name: idx_connector_defs_status; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX idx_connector_defs_status ON public.connector_definitions USING btree (status);
-
-
---
--- Name: idx_connector_defs_system_key; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE UNIQUE INDEX idx_connector_defs_system_key ON public.connector_definitions USING btree (key) WHERE ((organization_id IS NULL) AND (status = 'active'::text));
-
 
 --
 -- Name: idx_connector_versions_key_version; Type: INDEX; Schema: public; Owner: -
@@ -3453,6 +3033,11 @@ CREATE UNIQUE INDEX idx_connector_defs_system_key ON public.connector_definition
 
 CREATE UNIQUE INDEX idx_connector_versions_key_version ON public.connector_versions USING btree (connector_key, version);
 
+--
+-- Name: idx_device_workers_organization_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_device_workers_organization_id ON public.device_workers USING btree (organization_id) WHERE (organization_id IS NOT NULL);
 
 --
 -- Name: idx_ec_has_excerpts; Type: INDEX; Schema: public; Owner: -
@@ -3460,13 +3045,11 @@ CREATE UNIQUE INDEX idx_connector_versions_key_version ON public.connector_versi
 
 CREATE INDEX idx_ec_has_excerpts ON public.event_classifications USING btree (((excerpts <> '{}'::jsonb))) WHERE (excerpts <> '{}'::jsonb);
 
-
 --
 -- Name: idx_entities_by_parent; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX idx_entities_by_parent ON public.entities USING btree (parent_id, id) WHERE (parent_id IS NOT NULL);
-
 
 --
 -- Name: idx_entities_classifiers; Type: INDEX; Schema: public; Owner: -
@@ -3474,13 +3057,11 @@ CREATE INDEX idx_entities_by_parent ON public.entities USING btree (parent_id, i
 
 CREATE INDEX idx_entities_classifiers ON public.entities USING gin (enabled_classifiers) WHERE (enabled_classifiers IS NOT NULL);
 
-
 --
 -- Name: idx_entities_content_hash; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX idx_entities_content_hash ON public.entities USING btree (organization_id, content_hash) WHERE ((content_hash IS NOT NULL) AND (deleted_at IS NULL));
-
 
 --
 -- Name: idx_entities_content_tsv; Type: INDEX; Schema: public; Owner: -
@@ -3488,13 +3069,11 @@ CREATE INDEX idx_entities_content_hash ON public.entities USING btree (organizat
 
 CREATE INDEX idx_entities_content_tsv ON public.entities USING gin (content_tsv) WHERE (deleted_at IS NULL);
 
-
 --
 -- Name: idx_entities_created_by; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX idx_entities_created_by ON public.entities USING btree (created_by);
-
 
 --
 -- Name: idx_entities_embedding; Type: INDEX; Schema: public; Owner: -
@@ -3502,13 +3081,11 @@ CREATE INDEX idx_entities_created_by ON public.entities USING btree (created_by)
 
 CREATE INDEX idx_entities_embedding ON public.entities USING ivfflat (embedding public.vector_cosine_ops) WITH (lists='100') WHERE ((embedding IS NOT NULL) AND (deleted_at IS NULL));
 
-
 --
 -- Name: idx_entities_entity_type_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX idx_entities_entity_type_id ON public.entities USING btree (entity_type_id) WHERE (deleted_at IS NULL);
-
 
 --
 -- Name: idx_entities_metadata_domain; Type: INDEX; Schema: public; Owner: -
@@ -3516,13 +3093,11 @@ CREATE INDEX idx_entities_entity_type_id ON public.entities USING btree (entity_
 
 CREATE UNIQUE INDEX idx_entities_metadata_domain ON public.entities USING btree (((metadata ->> 'domain'::text)), organization_id) WHERE ((metadata ->> 'domain'::text) IS NOT NULL);
 
-
 --
 -- Name: idx_entities_metadata_email; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX idx_entities_metadata_email ON public.entities USING btree (((metadata ->> 'email'::text)), organization_id) WHERE (((metadata ->> 'email'::text) IS NOT NULL) AND (deleted_at IS NULL));
-
 
 --
 -- Name: idx_entities_metadata_github_handle; Type: INDEX; Schema: public; Owner: -
@@ -3530,13 +3105,11 @@ CREATE INDEX idx_entities_metadata_email ON public.entities USING btree (((metad
 
 CREATE INDEX idx_entities_metadata_github_handle ON public.entities USING btree (((metadata ->> 'github_handle'::text)), organization_id) WHERE (((metadata ->> 'github_handle'::text) IS NOT NULL) AND (deleted_at IS NULL));
 
-
 --
 -- Name: idx_entities_metadata_linkedin_url; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX idx_entities_metadata_linkedin_url ON public.entities USING btree (((metadata ->> 'linkedin_url'::text)), organization_id) WHERE (((metadata ->> 'linkedin_url'::text) IS NOT NULL) AND (deleted_at IS NULL));
-
 
 --
 -- Name: idx_entities_metadata_twitter_handle; Type: INDEX; Schema: public; Owner: -
@@ -3544,13 +3117,11 @@ CREATE INDEX idx_entities_metadata_linkedin_url ON public.entities USING btree (
 
 CREATE INDEX idx_entities_metadata_twitter_handle ON public.entities USING btree (((metadata ->> 'twitter_handle'::text)), organization_id) WHERE (((metadata ->> 'twitter_handle'::text) IS NOT NULL) AND (deleted_at IS NULL));
 
-
 --
 -- Name: idx_entities_name; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX idx_entities_name ON public.entities USING btree (lower(name));
-
 
 --
 -- Name: idx_entities_organization_id; Type: INDEX; Schema: public; Owner: -
@@ -3558,13 +3129,11 @@ CREATE INDEX idx_entities_name ON public.entities USING btree (lower(name));
 
 CREATE INDEX idx_entities_organization_id ON public.entities USING btree (organization_id);
 
-
 --
 -- Name: idx_entity_identities_by_entity; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX idx_entity_identities_by_entity ON public.entity_identities USING btree (entity_id) WHERE (deleted_at IS NULL);
-
 
 --
 -- Name: idx_entity_identities_live_unique; Type: INDEX; Schema: public; Owner: -
@@ -3572,34 +3141,11 @@ CREATE INDEX idx_entity_identities_by_entity ON public.entity_identities USING b
 
 CREATE UNIQUE INDEX idx_entity_identities_live_unique ON public.entity_identities USING btree (organization_id, namespace, identifier) WHERE (deleted_at IS NULL);
 
-
 --
 -- Name: idx_entity_identities_lookup; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX idx_entity_identities_lookup ON public.entity_identities USING btree (organization_id, namespace, identifier) WHERE (deleted_at IS NULL);
-
-
---
--- Name: idx_entity_read_grant_entity_active; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_entity_read_grant_entity_active ON public.entity_read_grant USING btree (entity_id, expires_at) WHERE (consumed_at IS NULL);
-
-
---
--- Name: idx_entity_read_grant_grantee_entity_active; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_entity_read_grant_grantee_entity_active ON public.entity_read_grant USING btree (grantee_user_id, entity_id, expires_at) WHERE (consumed_at IS NULL);
-
-
---
--- Name: idx_entity_read_grant_idempotency; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE UNIQUE INDEX idx_entity_read_grant_idempotency ON public.entity_read_grant USING btree (grantor_org_id, entity_id, grantee_user_id, triggering_relationship_id) WHERE (consumed_at IS NULL);
-
 
 --
 -- Name: idx_entity_rel_type_rules_type; Type: INDEX; Schema: public; Owner: -
@@ -3607,13 +3153,11 @@ CREATE UNIQUE INDEX idx_entity_read_grant_idempotency ON public.entity_read_gran
 
 CREATE INDEX idx_entity_rel_type_rules_type ON public.entity_relationship_type_rules USING btree (relationship_type_id);
 
-
 --
 -- Name: idx_entity_rel_types_org_slug; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE UNIQUE INDEX idx_entity_rel_types_org_slug ON public.entity_relationship_types USING btree (organization_id, slug) WHERE (status = 'active'::text);
-
 
 --
 -- Name: idx_entity_relationship_types_has_auto_create; Type: INDEX; Schema: public; Owner: -
@@ -3621,13 +3165,11 @@ CREATE UNIQUE INDEX idx_entity_rel_types_org_slug ON public.entity_relationship_
 
 CREATE INDEX idx_entity_relationship_types_has_auto_create ON public.entity_relationship_types USING btree (((metadata -> 'autoCreateWhen'::text))) WHERE ((metadata ? 'autoCreateWhen'::text) AND (deleted_at IS NULL));
 
-
 --
 -- Name: idx_entity_relationships_derived_from_event; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX idx_entity_relationships_derived_from_event ON public.entity_relationships USING btree ((((metadata -> 'derivedFrom'::text) ->> 'sourceEventId'::text))) WHERE (metadata ? 'derivedFrom'::text);
-
 
 --
 -- Name: idx_entity_relationships_derived_from_rule; Type: INDEX; Schema: public; Owner: -
@@ -3635,13 +3177,11 @@ CREATE INDEX idx_entity_relationships_derived_from_event ON public.entity_relati
 
 CREATE INDEX idx_entity_relationships_derived_from_rule ON public.entity_relationships USING btree ((((metadata -> 'derivedFrom'::text) ->> 'relationshipTypeId'::text)), (((metadata -> 'derivedFrom'::text) ->> 'ruleVersion'::text))) WHERE (metadata ? 'derivedFrom'::text);
 
-
 --
 -- Name: idx_entity_relationships_from; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX idx_entity_relationships_from ON public.entity_relationships USING btree (from_entity_id);
-
 
 --
 -- Name: idx_entity_relationships_live_triple; Type: INDEX; Schema: public; Owner: -
@@ -3649,13 +3189,11 @@ CREATE INDEX idx_entity_relationships_from ON public.entity_relationships USING 
 
 CREATE UNIQUE INDEX idx_entity_relationships_live_triple ON public.entity_relationships USING btree (from_entity_id, to_entity_id, relationship_type_id) WHERE (deleted_at IS NULL);
 
-
 --
 -- Name: idx_entity_relationships_org; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX idx_entity_relationships_org ON public.entity_relationships USING btree (organization_id);
-
 
 --
 -- Name: idx_entity_relationships_to; Type: INDEX; Schema: public; Owner: -
@@ -3663,13 +3201,11 @@ CREATE INDEX idx_entity_relationships_org ON public.entity_relationships USING b
 
 CREATE INDEX idx_entity_relationships_to ON public.entity_relationships USING btree (to_entity_id);
 
-
 --
 -- Name: idx_entity_relationships_type; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX idx_entity_relationships_type ON public.entity_relationships USING btree (relationship_type_id);
-
 
 --
 -- Name: idx_entity_type_audit_action; Type: INDEX; Schema: public; Owner: -
@@ -3677,13 +3213,11 @@ CREATE INDEX idx_entity_relationships_type ON public.entity_relationships USING 
 
 CREATE INDEX idx_entity_type_audit_action ON public.entity_type_audit USING btree (action);
 
-
 --
 -- Name: idx_entity_type_audit_type_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX idx_entity_type_audit_type_id ON public.entity_type_audit USING btree (entity_type_id);
-
 
 --
 -- Name: idx_entity_types_active; Type: INDEX; Schema: public; Owner: -
@@ -3691,13 +3225,11 @@ CREATE INDEX idx_entity_type_audit_type_id ON public.entity_type_audit USING btr
 
 CREATE INDEX idx_entity_types_active ON public.entity_types USING btree (id) WHERE (deleted_at IS NULL);
 
-
 --
 -- Name: idx_entity_types_org_slug; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE UNIQUE INDEX idx_entity_types_org_slug ON public.entity_types USING btree (organization_id, slug) WHERE ((organization_id IS NOT NULL) AND (deleted_at IS NULL));
-
 
 --
 -- Name: idx_event_classifications_source; Type: INDEX; Schema: public; Owner: -
@@ -3705,13 +3237,11 @@ CREATE UNIQUE INDEX idx_entity_types_org_slug ON public.entity_types USING btree
 
 CREATE INDEX idx_event_classifications_source ON public.event_classifications USING btree (source);
 
-
 --
 -- Name: idx_event_classifier_versions_classifier; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX idx_event_classifier_versions_classifier ON public.event_classifier_versions USING btree (classifier_id);
-
 
 --
 -- Name: idx_event_classifier_versions_created_by; Type: INDEX; Schema: public; Owner: -
@@ -3719,13 +3249,11 @@ CREATE INDEX idx_event_classifier_versions_classifier ON public.event_classifier
 
 CREATE INDEX idx_event_classifier_versions_created_by ON public.event_classifier_versions USING btree (created_by);
 
-
 --
 -- Name: idx_event_classifier_versions_current; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE UNIQUE INDEX idx_event_classifier_versions_current ON public.event_classifier_versions USING btree (classifier_id) WHERE (is_current = true);
-
 
 --
 -- Name: idx_event_classifiers_created_by; Type: INDEX; Schema: public; Owner: -
@@ -3733,13 +3261,11 @@ CREATE UNIQUE INDEX idx_event_classifier_versions_current ON public.event_classi
 
 CREATE INDEX idx_event_classifiers_created_by ON public.event_classifiers USING btree (created_by);
 
-
 --
 -- Name: idx_event_classifiers_entity_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX idx_event_classifiers_entity_id ON public.event_classifiers USING btree (entity_id) WHERE (entity_id IS NOT NULL);
-
 
 --
 -- Name: idx_event_classifiers_entity_ids; Type: INDEX; Schema: public; Owner: -
@@ -3747,13 +3273,11 @@ CREATE INDEX idx_event_classifiers_entity_id ON public.event_classifiers USING b
 
 CREATE INDEX idx_event_classifiers_entity_ids ON public.event_classifiers USING gin (entity_ids);
 
-
 --
 -- Name: idx_event_classifiers_insight_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX idx_event_classifiers_insight_id ON public.event_classifiers USING btree (watcher_id) WHERE (watcher_id IS NOT NULL);
-
 
 --
 -- Name: idx_event_classifiers_organization_id; Type: INDEX; Schema: public; Owner: -
@@ -3761,13 +3285,11 @@ CREATE INDEX idx_event_classifiers_insight_id ON public.event_classifiers USING 
 
 CREATE INDEX idx_event_classifiers_organization_id ON public.event_classifiers USING btree (organization_id);
 
-
 --
 -- Name: idx_event_classifiers_slug; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX idx_event_classifiers_slug ON public.event_classifiers USING btree (slug);
-
 
 --
 -- Name: idx_event_classifiers_status; Type: INDEX; Schema: public; Owner: -
@@ -3775,13 +3297,11 @@ CREATE INDEX idx_event_classifiers_slug ON public.event_classifiers USING btree 
 
 CREATE INDEX idx_event_classifiers_status ON public.event_classifiers USING btree (status);
 
-
 --
 -- Name: idx_events_client_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX idx_events_client_id ON public.events USING btree (client_id) WHERE (client_id IS NOT NULL);
-
 
 --
 -- Name: idx_events_connection_id; Type: INDEX; Schema: public; Owner: -
@@ -3789,13 +3309,11 @@ CREATE INDEX idx_events_client_id ON public.events USING btree (client_id) WHERE
 
 CREATE INDEX idx_events_connection_id ON public.events USING btree (connection_id);
 
-
 --
 -- Name: idx_events_connection_origin_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX idx_events_connection_origin_id ON public.events USING btree (connection_id, origin_id, created_at DESC) WHERE (connection_id IS NOT NULL);
-
 
 --
 -- Name: idx_events_connector_key; Type: INDEX; Schema: public; Owner: -
@@ -3803,13 +3321,11 @@ CREATE INDEX idx_events_connection_origin_id ON public.events USING btree (conne
 
 CREATE INDEX idx_events_connector_key ON public.events USING btree (connector_key);
 
-
 --
 -- Name: idx_events_created_at; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX idx_events_created_at ON public.events USING btree (created_at);
-
 
 --
 -- Name: idx_events_created_by; Type: INDEX; Schema: public; Owner: -
@@ -3817,13 +3333,11 @@ CREATE INDEX idx_events_created_at ON public.events USING btree (created_at);
 
 CREATE INDEX idx_events_created_by ON public.events USING btree (created_by) WHERE (created_by IS NOT NULL);
 
-
 --
 -- Name: idx_events_embedding; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX idx_events_embedding ON public.event_embeddings USING ivfflat (embedding public.vector_cosine_ops) WITH (lists='1000');
-
 
 --
 -- Name: idx_events_entity_ids; Type: INDEX; Schema: public; Owner: -
@@ -3831,13 +3345,11 @@ CREATE INDEX idx_events_embedding ON public.event_embeddings USING ivfflat (embe
 
 CREATE INDEX idx_events_entity_ids ON public.events USING gin (entity_ids);
 
-
 --
 -- Name: idx_events_entity_ids_occurred_at; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX idx_events_entity_ids_occurred_at ON public.events USING btree ((entity_ids[1]), occurred_at DESC, id DESC) WHERE ((entity_ids IS NOT NULL) AND (entity_ids <> '{}'::bigint[]));
-
 
 --
 -- Name: idx_events_feed_id; Type: INDEX; Schema: public; Owner: -
@@ -3845,13 +3357,11 @@ CREATE INDEX idx_events_entity_ids_occurred_at ON public.events USING btree ((en
 
 CREATE INDEX idx_events_feed_id ON public.events USING btree (feed_id);
 
-
 --
 -- Name: idx_events_fulltext; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX idx_events_fulltext ON public.events USING gin (to_tsvector('english'::regconfig, COALESCE(payload_text, ''::text)));
-
 
 --
 -- Name: idx_events_identity_fact_account; Type: INDEX; Schema: public; Owner: -
@@ -3859,13 +3369,11 @@ CREATE INDEX idx_events_fulltext ON public.events USING gin (to_tsvector('englis
 
 CREATE INDEX idx_events_identity_fact_account ON public.events USING btree (connector_key, ((metadata ->> 'providerStableId'::text)), ((metadata ->> 'namespace'::text))) WHERE (semantic_type = 'identity_fact'::text);
 
-
 --
 -- Name: idx_events_identity_fact_lookup; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX idx_events_identity_fact_lookup ON public.events USING btree (organization_id, ((metadata ->> 'namespace'::text)), ((metadata ->> 'normalizedValue'::text))) WHERE (semantic_type = 'identity_fact'::text);
-
 
 --
 -- Name: idx_events_metadata_auth_user_id; Type: INDEX; Schema: public; Owner: -
@@ -3873,13 +3381,11 @@ CREATE INDEX idx_events_identity_fact_lookup ON public.events USING btree (organ
 
 CREATE INDEX idx_events_metadata_auth_user_id ON public.events USING btree (((metadata ->> 'auth_user_id'::text))) WHERE (metadata ? 'auth_user_id'::text);
 
-
 --
 -- Name: idx_events_metadata_email; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX idx_events_metadata_email ON public.events USING btree (((metadata ->> 'email'::text))) WHERE (metadata ? 'email'::text);
-
 
 --
 -- Name: idx_events_metadata_github_login; Type: INDEX; Schema: public; Owner: -
@@ -3887,13 +3393,11 @@ CREATE INDEX idx_events_metadata_email ON public.events USING btree (((metadata 
 
 CREATE INDEX idx_events_metadata_github_login ON public.events USING btree (((metadata ->> 'github_login'::text))) WHERE (metadata ? 'github_login'::text);
 
-
 --
 -- Name: idx_events_metadata_google_contact_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX idx_events_metadata_google_contact_id ON public.events USING btree (((metadata ->> 'google_contact_id'::text))) WHERE (metadata ? 'google_contact_id'::text);
-
 
 --
 -- Name: idx_events_metadata_phone; Type: INDEX; Schema: public; Owner: -
@@ -3901,13 +3405,11 @@ CREATE INDEX idx_events_metadata_google_contact_id ON public.events USING btree 
 
 CREATE INDEX idx_events_metadata_phone ON public.events USING btree (((metadata ->> 'phone'::text))) WHERE (metadata ? 'phone'::text);
 
-
 --
 -- Name: idx_events_metadata_slack_user_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX idx_events_metadata_slack_user_id ON public.events USING btree (((metadata ->> 'slack_user_id'::text))) WHERE (metadata ? 'slack_user_id'::text);
-
 
 --
 -- Name: idx_events_metadata_wa_jid; Type: INDEX; Schema: public; Owner: -
@@ -3915,13 +3417,11 @@ CREATE INDEX idx_events_metadata_slack_user_id ON public.events USING btree (((m
 
 CREATE INDEX idx_events_metadata_wa_jid ON public.events USING btree (((metadata ->> 'wa_jid'::text))) WHERE (metadata ? 'wa_jid'::text);
 
-
 --
 -- Name: idx_events_missing_embedding_backfill; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX idx_events_missing_embedding_backfill ON public.events USING btree (created_at, id) WHERE ((payload_text IS NOT NULL) AND (payload_text <> ''::text));
-
 
 --
 -- Name: idx_events_organization_id; Type: INDEX; Schema: public; Owner: -
@@ -3929,13 +3429,11 @@ CREATE INDEX idx_events_missing_embedding_backfill ON public.events USING btree 
 
 CREATE INDEX idx_events_organization_id ON public.events USING btree (organization_id) WHERE (organization_id IS NOT NULL);
 
-
 --
 -- Name: idx_events_origin_parent_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX idx_events_origin_parent_id ON public.events USING btree (origin_parent_id);
-
 
 --
 -- Name: idx_events_raw_content_trgm; Type: INDEX; Schema: public; Owner: -
@@ -3943,13 +3441,11 @@ CREATE INDEX idx_events_origin_parent_id ON public.events USING btree (origin_pa
 
 CREATE INDEX idx_events_raw_content_trgm ON public.events USING gin (payload_text public.gin_trgm_ops);
 
-
 --
 -- Name: idx_events_run_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX idx_events_run_id ON public.events USING btree (run_id);
-
 
 --
 -- Name: idx_events_semantic_type; Type: INDEX; Schema: public; Owner: -
@@ -3957,13 +3453,11 @@ CREATE INDEX idx_events_run_id ON public.events USING btree (run_id);
 
 CREATE INDEX idx_events_semantic_type ON public.events USING btree (semantic_type);
 
-
 --
 -- Name: idx_events_source_embedding; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX idx_events_source_embedding ON public.event_embeddings USING btree (event_id);
-
 
 --
 -- Name: idx_events_superseded_by; Type: INDEX; Schema: public; Owner: -
@@ -3971,13 +3465,11 @@ CREATE INDEX idx_events_source_embedding ON public.event_embeddings USING btree 
 
 CREATE UNIQUE INDEX idx_events_superseded_by ON public.events USING btree (supersedes_event_id) WHERE (supersedes_event_id IS NOT NULL);
 
-
 --
 -- Name: idx_events_thread_lookup; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX idx_events_thread_lookup ON public.events USING btree (origin_parent_id, occurred_at) WHERE (origin_parent_id IS NOT NULL);
-
 
 --
 -- Name: idx_events_type; Type: INDEX; Schema: public; Owner: -
@@ -3985,13 +3477,11 @@ CREATE INDEX idx_events_thread_lookup ON public.events USING btree (origin_paren
 
 CREATE INDEX idx_events_type ON public.events USING btree (origin_type) WHERE (origin_type IS NOT NULL);
 
-
 --
 -- Name: idx_feeds_connection; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX idx_feeds_connection ON public.feeds USING btree (connection_id);
-
 
 --
 -- Name: idx_feeds_deleted_at; Type: INDEX; Schema: public; Owner: -
@@ -3999,13 +3489,11 @@ CREATE INDEX idx_feeds_connection ON public.feeds USING btree (connection_id);
 
 CREATE INDEX idx_feeds_deleted_at ON public.feeds USING btree (deleted_at) WHERE (deleted_at IS NULL);
 
-
 --
 -- Name: idx_feeds_entity_ids; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX idx_feeds_entity_ids ON public.feeds USING gin (entity_ids);
-
 
 --
 -- Name: idx_feeds_next_run_at; Type: INDEX; Schema: public; Owner: -
@@ -4013,13 +3501,11 @@ CREATE INDEX idx_feeds_entity_ids ON public.feeds USING gin (entity_ids);
 
 CREATE INDEX idx_feeds_next_run_at ON public.feeds USING btree (next_run_at) WHERE ((status = 'active'::text) AND (deleted_at IS NULL));
 
-
 --
 -- Name: idx_feeds_org; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX idx_feeds_org ON public.feeds USING btree (organization_id);
-
 
 --
 -- Name: idx_feeds_status; Type: INDEX; Schema: public; Owner: -
@@ -4027,13 +3513,11 @@ CREATE INDEX idx_feeds_org ON public.feeds USING btree (organization_id);
 
 CREATE INDEX idx_feeds_status ON public.feeds USING btree (status);
 
-
 --
 -- Name: idx_latest_ec_classifier_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX idx_latest_ec_classifier_id ON public.latest_event_classifications USING btree (classifier_id);
-
 
 --
 -- Name: idx_latest_ec_event_id; Type: INDEX; Schema: public; Owner: -
@@ -4041,13 +3525,11 @@ CREATE INDEX idx_latest_ec_classifier_id ON public.latest_event_classifications 
 
 CREATE INDEX idx_latest_ec_event_id ON public.latest_event_classifications USING btree (event_id);
 
-
 --
 -- Name: idx_latest_ec_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE UNIQUE INDEX idx_latest_ec_id ON public.latest_event_classifications USING btree (id);
-
 
 --
 -- Name: idx_latest_ec_source; Type: INDEX; Schema: public; Owner: -
@@ -4055,13 +3537,11 @@ CREATE UNIQUE INDEX idx_latest_ec_id ON public.latest_event_classifications USIN
 
 CREATE INDEX idx_latest_ec_source ON public.latest_event_classifications USING btree (source);
 
-
 --
 -- Name: idx_latest_ec_values_gin; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX idx_latest_ec_values_gin ON public.latest_event_classifications USING gin ("values");
-
 
 --
 -- Name: idx_notifications_listing; Type: INDEX; Schema: public; Owner: -
@@ -4069,13 +3549,11 @@ CREATE INDEX idx_latest_ec_values_gin ON public.latest_event_classifications USI
 
 CREATE INDEX idx_notifications_listing ON public.notifications USING btree (organization_id, user_id, created_at DESC);
 
-
 --
 -- Name: idx_notifications_unread; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX idx_notifications_unread ON public.notifications USING btree (organization_id, user_id, is_read, created_at DESC);
-
 
 --
 -- Name: idx_runs_active_auth_per_profile; Type: INDEX; Schema: public; Owner: -
@@ -4083,13 +3561,11 @@ CREATE INDEX idx_notifications_unread ON public.notifications USING btree (organ
 
 CREATE UNIQUE INDEX idx_runs_active_auth_per_profile ON public.runs USING btree (auth_profile_id) WHERE ((run_type = 'auth'::text) AND (auth_profile_id IS NOT NULL) AND (status = ANY (ARRAY['pending'::text, 'claimed'::text, 'running'::text])));
 
-
 --
 -- Name: idx_runs_active_embed_backfill_per_org; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE UNIQUE INDEX idx_runs_active_embed_backfill_per_org ON public.runs USING btree (organization_id) WHERE ((run_type = 'embed_backfill'::text) AND (status = ANY (ARRAY['pending'::text, 'claimed'::text, 'running'::text])));
-
 
 --
 -- Name: idx_runs_active_sync_per_feed; Type: INDEX; Schema: public; Owner: -
@@ -4097,13 +3573,11 @@ CREATE UNIQUE INDEX idx_runs_active_embed_backfill_per_org ON public.runs USING 
 
 CREATE UNIQUE INDEX idx_runs_active_sync_per_feed ON public.runs USING btree (feed_id) WHERE ((run_type = 'sync'::text) AND (feed_id IS NOT NULL) AND (status = ANY (ARRAY['pending'::text, 'claimed'::text, 'running'::text])));
 
-
 --
 -- Name: idx_runs_active_watcher_per_watcher; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE UNIQUE INDEX idx_runs_active_watcher_per_watcher ON public.runs USING btree (watcher_id) WHERE ((run_type = 'watcher'::text) AND (watcher_id IS NOT NULL) AND (status = ANY (ARRAY['pending'::text, 'claimed'::text, 'running'::text])));
-
 
 --
 -- Name: idx_runs_connection; Type: INDEX; Schema: public; Owner: -
@@ -4111,13 +3585,11 @@ CREATE UNIQUE INDEX idx_runs_active_watcher_per_watcher ON public.runs USING btr
 
 CREATE INDEX idx_runs_connection ON public.runs USING btree (connection_id);
 
-
 --
 -- Name: idx_runs_created_by_user; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX idx_runs_created_by_user ON public.runs USING btree (created_by_user_id) WHERE (created_by_user_id IS NOT NULL);
-
 
 --
 -- Name: idx_runs_dispatched_message_id; Type: INDEX; Schema: public; Owner: -
@@ -4125,13 +3597,11 @@ CREATE INDEX idx_runs_created_by_user ON public.runs USING btree (created_by_use
 
 CREATE UNIQUE INDEX idx_runs_dispatched_message_id ON public.runs USING btree (dispatched_message_id) WHERE (dispatched_message_id IS NOT NULL);
 
-
 --
 -- Name: idx_runs_feed; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX idx_runs_feed ON public.runs USING btree (feed_id);
-
 
 --
 -- Name: idx_runs_org; Type: INDEX; Schema: public; Owner: -
@@ -4139,13 +3609,11 @@ CREATE INDEX idx_runs_feed ON public.runs USING btree (feed_id);
 
 CREATE INDEX idx_runs_org ON public.runs USING btree (organization_id);
 
-
 --
 -- Name: idx_runs_pending; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX idx_runs_pending ON public.runs USING btree (status, created_at) WHERE (status = 'pending'::text);
-
 
 --
 -- Name: idx_runs_status; Type: INDEX; Schema: public; Owner: -
@@ -4153,13 +3621,11 @@ CREATE INDEX idx_runs_pending ON public.runs USING btree (status, created_at) WH
 
 CREATE INDEX idx_runs_status ON public.runs USING btree (status);
 
-
 --
 -- Name: idx_runs_type; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX idx_runs_type ON public.runs USING btree (run_type);
-
 
 --
 -- Name: idx_runs_watcher_id; Type: INDEX; Schema: public; Owner: -
@@ -4167,13 +3633,11 @@ CREATE INDEX idx_runs_type ON public.runs USING btree (run_type);
 
 CREATE INDEX idx_runs_watcher_id ON public.runs USING btree (watcher_id) WHERE (watcher_id IS NOT NULL);
 
-
 --
 -- Name: idx_view_template_versions_resource; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX idx_view_template_versions_resource ON public.view_template_versions USING btree (resource_type, resource_id, organization_id);
-
 
 --
 -- Name: idx_watcher_reactions_org; Type: INDEX; Schema: public; Owner: -
@@ -4181,13 +3645,11 @@ CREATE INDEX idx_view_template_versions_resource ON public.view_template_version
 
 CREATE INDEX idx_watcher_reactions_org ON public.watcher_reactions USING btree (organization_id);
 
-
 --
 -- Name: idx_watcher_reactions_window; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX idx_watcher_reactions_window ON public.watcher_reactions USING btree (watcher_id, window_id);
-
 
 --
 -- Name: idx_watcher_template_versions_created_by; Type: INDEX; Schema: public; Owner: -
@@ -4195,13 +3657,11 @@ CREATE INDEX idx_watcher_reactions_window ON public.watcher_reactions USING btre
 
 CREATE INDEX idx_watcher_template_versions_created_by ON public.watcher_versions USING btree (created_by);
 
-
 --
 -- Name: idx_watcher_versions_watcher_version; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE UNIQUE INDEX idx_watcher_versions_watcher_version ON public.watcher_versions USING btree (watcher_id, version);
-
 
 --
 -- Name: idx_watcher_window_events_event; Type: INDEX; Schema: public; Owner: -
@@ -4209,13 +3669,11 @@ CREATE UNIQUE INDEX idx_watcher_versions_watcher_version ON public.watcher_versi
 
 CREATE INDEX idx_watcher_window_events_event ON public.watcher_window_events USING btree (event_id);
 
-
 --
 -- Name: idx_watcher_window_events_unique; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE UNIQUE INDEX idx_watcher_window_events_unique ON public.watcher_window_events USING btree (window_id, event_id);
-
 
 --
 -- Name: idx_watcher_window_events_window; Type: INDEX; Schema: public; Owner: -
@@ -4223,13 +3681,11 @@ CREATE UNIQUE INDEX idx_watcher_window_events_unique ON public.watcher_window_ev
 
 CREATE INDEX idx_watcher_window_events_window ON public.watcher_window_events USING btree (window_id);
 
-
 --
 -- Name: idx_watcher_windows_parent; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX idx_watcher_windows_parent ON public.watcher_windows USING btree (parent_window_id) WHERE (parent_window_id IS NOT NULL);
-
 
 --
 -- Name: idx_watcher_windows_run_id; Type: INDEX; Schema: public; Owner: -
@@ -4237,13 +3693,11 @@ CREATE INDEX idx_watcher_windows_parent ON public.watcher_windows USING btree (p
 
 CREATE INDEX idx_watcher_windows_run_id ON public.watcher_windows USING btree (run_id) WHERE (run_id IS NOT NULL);
 
-
 --
 -- Name: idx_watcher_windows_template_version; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX idx_watcher_windows_template_version ON public.watcher_windows USING btree (version_id);
-
 
 --
 -- Name: idx_watcher_windows_unique_period; Type: INDEX; Schema: public; Owner: -
@@ -4251,13 +3705,11 @@ CREATE INDEX idx_watcher_windows_template_version ON public.watcher_windows USIN
 
 CREATE UNIQUE INDEX idx_watcher_windows_unique_period ON public.watcher_windows USING btree (watcher_id, window_start, window_end) WHERE (is_rollup = false);
 
-
 --
 -- Name: idx_watcher_windows_watcher; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX idx_watcher_windows_watcher ON public.watcher_windows USING btree (watcher_id, granularity, window_start DESC);
-
 
 --
 -- Name: idx_watchers_agent_id; Type: INDEX; Schema: public; Owner: -
@@ -4265,13 +3717,11 @@ CREATE INDEX idx_watcher_windows_watcher ON public.watcher_windows USING btree (
 
 CREATE INDEX idx_watchers_agent_id ON public.watchers USING btree (agent_id) WHERE (agent_id IS NOT NULL);
 
-
 --
 -- Name: idx_watchers_connection_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX idx_watchers_connection_id ON public.watchers USING btree (connection_id) WHERE (connection_id IS NOT NULL);
-
 
 --
 -- Name: idx_watchers_created_by; Type: INDEX; Schema: public; Owner: -
@@ -4279,13 +3729,11 @@ CREATE INDEX idx_watchers_connection_id ON public.watchers USING btree (connecti
 
 CREATE INDEX idx_watchers_created_by ON public.watchers USING btree (created_by);
 
-
 --
 -- Name: idx_watchers_entity_ids; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX idx_watchers_entity_ids ON public.watchers USING gin (entity_ids);
-
 
 --
 -- Name: idx_watchers_next_run_at; Type: INDEX; Schema: public; Owner: -
@@ -4293,13 +3741,11 @@ CREATE INDEX idx_watchers_entity_ids ON public.watchers USING gin (entity_ids);
 
 CREATE INDEX idx_watchers_next_run_at ON public.watchers USING btree (next_run_at) WHERE ((schedule IS NOT NULL) AND (status = 'active'::text));
 
-
 --
 -- Name: idx_watchers_org_group; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX idx_watchers_org_group ON public.watchers USING btree (organization_id, watcher_group_id);
-
 
 --
 -- Name: idx_watchers_org_slug; Type: INDEX; Schema: public; Owner: -
@@ -4307,13 +3753,11 @@ CREATE INDEX idx_watchers_org_group ON public.watchers USING btree (organization
 
 CREATE UNIQUE INDEX idx_watchers_org_slug ON public.watchers USING btree (organization_id, slug) WHERE (slug IS NOT NULL);
 
-
 --
 -- Name: idx_watchers_organization_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX idx_watchers_organization_id ON public.watchers USING btree (organization_id) WHERE (organization_id IS NOT NULL);
-
 
 --
 -- Name: idx_watchers_watcher_group_id; Type: INDEX; Schema: public; Owner: -
@@ -4321,13 +3765,11 @@ CREATE INDEX idx_watchers_organization_id ON public.watchers USING btree (organi
 
 CREATE INDEX idx_watchers_watcher_group_id ON public.watchers USING btree (watcher_group_id);
 
-
 --
 -- Name: idx_wwff_watcher_field_recent; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX idx_wwff_watcher_field_recent ON public.watcher_window_field_feedback USING btree (watcher_id, field_path, created_at DESC);
-
 
 --
 -- Name: idx_wwff_window; Type: INDEX; Schema: public; Owner: -
@@ -4335,13 +3777,11 @@ CREATE INDEX idx_wwff_watcher_field_recent ON public.watcher_window_field_feedba
 
 CREATE INDEX idx_wwff_window ON public.watcher_window_field_feedback USING btree (window_id);
 
-
 --
 -- Name: invitation_email_idx; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX invitation_email_idx ON public.invitation USING btree (email);
-
 
 --
 -- Name: invitation_organizationId_idx; Type: INDEX; Schema: public; Owner: -
@@ -4349,13 +3789,11 @@ CREATE INDEX invitation_email_idx ON public.invitation USING btree (email);
 
 CREATE INDEX "invitation_organizationId_idx" ON public.invitation USING btree ("organizationId");
 
-
 --
 -- Name: mcp_proxy_sessions_expires_at_idx; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX mcp_proxy_sessions_expires_at_idx ON public.mcp_proxy_sessions USING btree (expires_at);
-
 
 --
 -- Name: mcp_sessions_client_id_idx; Type: INDEX; Schema: public; Owner: -
@@ -4363,13 +3801,11 @@ CREATE INDEX mcp_proxy_sessions_expires_at_idx ON public.mcp_proxy_sessions USIN
 
 CREATE INDEX mcp_sessions_client_id_idx ON public.mcp_sessions USING btree (client_id);
 
-
 --
 -- Name: mcp_sessions_expires_at_idx; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX mcp_sessions_expires_at_idx ON public.mcp_sessions USING btree (expires_at);
-
 
 --
 -- Name: mcp_sessions_user_id_idx; Type: INDEX; Schema: public; Owner: -
@@ -4377,13 +3813,11 @@ CREATE INDEX mcp_sessions_expires_at_idx ON public.mcp_sessions USING btree (exp
 
 CREATE INDEX mcp_sessions_user_id_idx ON public.mcp_sessions USING btree (user_id);
 
-
 --
 -- Name: member_organizationId_idx; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX "member_organizationId_idx" ON public.member USING btree ("organizationId");
-
 
 --
 -- Name: member_userId_idx; Type: INDEX; Schema: public; Owner: -
@@ -4391,13 +3825,11 @@ CREATE INDEX "member_organizationId_idx" ON public.member USING btree ("organiza
 
 CREATE INDEX "member_userId_idx" ON public.member USING btree ("userId");
 
-
 --
 -- Name: namespace_ref_id_idx; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX namespace_ref_id_idx ON public.namespace USING btree (ref_id);
-
 
 --
 -- Name: namespace_type_idx; Type: INDEX; Schema: public; Owner: -
@@ -4405,13 +3837,11 @@ CREATE INDEX namespace_ref_id_idx ON public.namespace USING btree (ref_id);
 
 CREATE INDEX namespace_type_idx ON public.namespace USING btree (type);
 
-
 --
 -- Name: oauth_authorization_codes_client_id_idx; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX oauth_authorization_codes_client_id_idx ON public.oauth_authorization_codes USING btree (client_id);
-
 
 --
 -- Name: oauth_authorization_codes_expires_at_idx; Type: INDEX; Schema: public; Owner: -
@@ -4419,13 +3849,11 @@ CREATE INDEX oauth_authorization_codes_client_id_idx ON public.oauth_authorizati
 
 CREATE INDEX oauth_authorization_codes_expires_at_idx ON public.oauth_authorization_codes USING btree (expires_at);
 
-
 --
 -- Name: oauth_clients_organization_id_idx; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX oauth_clients_organization_id_idx ON public.oauth_clients USING btree (organization_id);
-
 
 --
 -- Name: oauth_clients_software_id_idx; Type: INDEX; Schema: public; Owner: -
@@ -4433,13 +3861,11 @@ CREATE INDEX oauth_clients_organization_id_idx ON public.oauth_clients USING btr
 
 CREATE INDEX oauth_clients_software_id_idx ON public.oauth_clients USING btree (software_id);
 
-
 --
 -- Name: oauth_clients_user_id_idx; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX oauth_clients_user_id_idx ON public.oauth_clients USING btree (user_id);
-
 
 --
 -- Name: oauth_device_codes_client_id_idx; Type: INDEX; Schema: public; Owner: -
@@ -4447,13 +3873,11 @@ CREATE INDEX oauth_clients_user_id_idx ON public.oauth_clients USING btree (user
 
 CREATE INDEX oauth_device_codes_client_id_idx ON public.oauth_device_codes USING btree (client_id);
 
-
 --
 -- Name: oauth_device_codes_expires_at_idx; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX oauth_device_codes_expires_at_idx ON public.oauth_device_codes USING btree (expires_at);
-
 
 --
 -- Name: oauth_device_codes_user_code_idx; Type: INDEX; Schema: public; Owner: -
@@ -4461,13 +3885,11 @@ CREATE INDEX oauth_device_codes_expires_at_idx ON public.oauth_device_codes USIN
 
 CREATE UNIQUE INDEX oauth_device_codes_user_code_idx ON public.oauth_device_codes USING btree (user_code);
 
-
 --
 -- Name: oauth_states_expires_at_idx; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX oauth_states_expires_at_idx ON public.oauth_states USING btree (expires_at);
-
 
 --
 -- Name: oauth_states_scope_idx; Type: INDEX; Schema: public; Owner: -
@@ -4475,13 +3897,11 @@ CREATE INDEX oauth_states_expires_at_idx ON public.oauth_states USING btree (exp
 
 CREATE INDEX oauth_states_scope_idx ON public.oauth_states USING btree (scope);
 
-
 --
 -- Name: oauth_tokens_active_idx; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX oauth_tokens_active_idx ON public.oauth_tokens USING btree (user_id, expires_at) WHERE (revoked_at IS NULL);
-
 
 --
 -- Name: oauth_tokens_client_id_idx; Type: INDEX; Schema: public; Owner: -
@@ -4489,13 +3909,11 @@ CREATE INDEX oauth_tokens_active_idx ON public.oauth_tokens USING btree (user_id
 
 CREATE INDEX oauth_tokens_client_id_idx ON public.oauth_tokens USING btree (client_id);
 
-
 --
 -- Name: oauth_tokens_expires_at_idx; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX oauth_tokens_expires_at_idx ON public.oauth_tokens USING btree (expires_at);
-
 
 --
 -- Name: oauth_tokens_token_hash_idx; Type: INDEX; Schema: public; Owner: -
@@ -4503,13 +3921,11 @@ CREATE INDEX oauth_tokens_expires_at_idx ON public.oauth_tokens USING btree (exp
 
 CREATE INDEX oauth_tokens_token_hash_idx ON public.oauth_tokens USING btree (token_hash);
 
-
 --
 -- Name: oauth_tokens_user_id_idx; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX oauth_tokens_user_id_idx ON public.oauth_tokens USING btree (user_id);
-
 
 --
 -- Name: personal_access_tokens_active_idx; Type: INDEX; Schema: public; Owner: -
@@ -4517,13 +3933,11 @@ CREATE INDEX oauth_tokens_user_id_idx ON public.oauth_tokens USING btree (user_i
 
 CREATE INDEX personal_access_tokens_active_idx ON public.personal_access_tokens USING btree (user_id, expires_at) WHERE (revoked_at IS NULL);
 
-
 --
 -- Name: personal_access_tokens_organization_id_idx; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX personal_access_tokens_organization_id_idx ON public.personal_access_tokens USING btree (organization_id);
-
 
 --
 -- Name: personal_access_tokens_token_hash_idx; Type: INDEX; Schema: public; Owner: -
@@ -4531,13 +3945,11 @@ CREATE INDEX personal_access_tokens_organization_id_idx ON public.personal_acces
 
 CREATE INDEX personal_access_tokens_token_hash_idx ON public.personal_access_tokens USING btree (token_hash);
 
-
 --
 -- Name: personal_access_tokens_token_prefix_idx; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX personal_access_tokens_token_prefix_idx ON public.personal_access_tokens USING btree (token_prefix);
-
 
 --
 -- Name: personal_access_tokens_user_id_idx; Type: INDEX; Schema: public; Owner: -
@@ -4545,13 +3957,11 @@ CREATE INDEX personal_access_tokens_token_prefix_idx ON public.personal_access_t
 
 CREATE INDEX personal_access_tokens_user_id_idx ON public.personal_access_tokens USING btree (user_id);
 
-
 --
 -- Name: rate_limits_expires_at_idx; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX rate_limits_expires_at_idx ON public.rate_limits USING btree (expires_at);
-
 
 --
 -- Name: runs_expires_at_idx; Type: INDEX; Schema: public; Owner: -
@@ -4559,13 +3969,11 @@ CREATE INDEX rate_limits_expires_at_idx ON public.rate_limits USING btree (expir
 
 CREATE INDEX runs_expires_at_idx ON public.runs USING btree (expires_at) WHERE (expires_at IS NOT NULL);
 
-
 --
 -- Name: runs_idempotency_key_uniq; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE UNIQUE INDEX runs_idempotency_key_uniq ON public.runs USING btree (idempotency_key) WHERE ((idempotency_key IS NOT NULL) AND (status = ANY (ARRAY['pending'::text, 'claimed'::text, 'running'::text])));
-
 
 --
 -- Name: runs_lobu_claim_idx; Type: INDEX; Schema: public; Owner: -
@@ -4573,13 +3981,11 @@ CREATE UNIQUE INDEX runs_idempotency_key_uniq ON public.runs USING btree (idempo
 
 CREATE INDEX runs_lobu_claim_idx ON public.runs USING btree (run_type, queue_name, priority DESC, run_at, id) WHERE ((status = 'pending'::text) AND (run_type = ANY (ARRAY['chat_message'::text, 'schedule'::text, 'agent_run'::text, 'internal'::text, 'task'::text])));
 
-
 --
 -- Name: session_expiresAt_idx; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX "session_expiresAt_idx" ON public.session USING btree ("expiresAt");
-
 
 --
 -- Name: session_token_idx; Type: INDEX; Schema: public; Owner: -
@@ -4587,13 +3993,11 @@ CREATE INDEX "session_expiresAt_idx" ON public.session USING btree ("expiresAt")
 
 CREATE INDEX session_token_idx ON public.session USING btree (token);
 
-
 --
 -- Name: session_userId_idx; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX "session_userId_idx" ON public.session USING btree ("userId");
-
 
 --
 -- Name: user_auth_profiles_agent_id_idx; Type: INDEX; Schema: public; Owner: -
@@ -4601,13 +4005,11 @@ CREATE INDEX "session_userId_idx" ON public.session USING btree ("userId");
 
 CREATE INDEX user_auth_profiles_agent_id_idx ON public.user_auth_profiles USING btree (agent_id);
 
-
 --
 -- Name: user_username_unique; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE UNIQUE INDEX user_username_unique ON public."user" USING btree (username);
-
 
 --
 -- Name: verification_expiresAt_idx; Type: INDEX; Schema: public; Owner: -
@@ -4615,20 +4017,17 @@ CREATE UNIQUE INDEX user_username_unique ON public."user" USING btree (username)
 
 CREATE INDEX "verification_expiresAt_idx" ON public.verification USING btree ("expiresAt");
 
-
 --
 -- Name: verification_identifier_idx; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX verification_identifier_idx ON public.verification USING btree (identifier);
 
-
 --
 -- Name: entities check_entity_cycles; Type: TRIGGER; Schema: public; Owner: -
 --
 
 CREATE TRIGGER check_entity_cycles BEFORE INSERT OR UPDATE ON public.entities FOR EACH ROW EXECUTE FUNCTION public.prevent_entity_cycles();
-
 
 --
 -- Name: account account_userId_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
@@ -4637,14 +4036,12 @@ CREATE TRIGGER check_entity_cycles BEFORE INSERT OR UPDATE ON public.entities FO
 ALTER TABLE ONLY public.account
     ADD CONSTRAINT "account_userId_fkey" FOREIGN KEY ("userId") REFERENCES public."user"(id) ON DELETE CASCADE;
 
-
 --
 -- Name: agent_channel_bindings agent_channel_bindings_agent_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.agent_channel_bindings
     ADD CONSTRAINT agent_channel_bindings_agent_id_fkey FOREIGN KEY (agent_id) REFERENCES public.agents(id) ON DELETE CASCADE;
-
 
 --
 -- Name: agent_connections agent_connections_agent_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
@@ -4653,14 +4050,12 @@ ALTER TABLE ONLY public.agent_channel_bindings
 ALTER TABLE ONLY public.agent_connections
     ADD CONSTRAINT agent_connections_agent_id_fkey FOREIGN KEY (agent_id) REFERENCES public.agents(id) ON DELETE CASCADE;
 
-
 --
 -- Name: agent_grants agent_grants_agent_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.agent_grants
     ADD CONSTRAINT agent_grants_agent_id_fkey FOREIGN KEY (agent_id) REFERENCES public.agents(id) ON DELETE CASCADE;
-
 
 --
 -- Name: agent_users agent_users_agent_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
@@ -4669,22 +4064,12 @@ ALTER TABLE ONLY public.agent_grants
 ALTER TABLE ONLY public.agent_users
     ADD CONSTRAINT agent_users_agent_id_fkey FOREIGN KEY (agent_id) REFERENCES public.agents(id) ON DELETE CASCADE;
 
-
 --
 -- Name: agents agents_organization_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.agents
     ADD CONSTRAINT agents_organization_id_fkey FOREIGN KEY (organization_id) REFERENCES public.organization(id) ON DELETE CASCADE;
-
-
---
--- Name: agents agents_template_agent_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.agents
-    ADD CONSTRAINT agents_template_agent_id_fkey FOREIGN KEY (template_agent_id) REFERENCES public.agents(id) ON DELETE SET NULL;
-
 
 --
 -- Name: auth_profiles auth_profiles_account_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
@@ -4693,7 +4078,6 @@ ALTER TABLE ONLY public.agents
 ALTER TABLE ONLY public.auth_profiles
     ADD CONSTRAINT auth_profiles_account_id_fkey FOREIGN KEY (account_id) REFERENCES public.account(id) ON DELETE SET NULL;
 
-
 --
 -- Name: auth_profiles auth_profiles_organization_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
@@ -4701,14 +4085,12 @@ ALTER TABLE ONLY public.auth_profiles
 ALTER TABLE ONLY public.auth_profiles
     ADD CONSTRAINT auth_profiles_organization_id_fkey FOREIGN KEY (organization_id) REFERENCES public.organization(id) ON DELETE CASCADE;
 
-
 --
--- Name: chat_connections chat_connections_template_agent_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: chat_user_identities chat_user_identities_lobu_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.chat_connections
-    ADD CONSTRAINT chat_connections_template_agent_id_fkey FOREIGN KEY (template_agent_id) REFERENCES public.agents(id) ON DELETE CASCADE;
-
+ALTER TABLE ONLY public.chat_user_identities
+    ADD CONSTRAINT chat_user_identities_lobu_user_id_fkey FOREIGN KEY (lobu_user_id) REFERENCES public."user"(id) ON DELETE CASCADE;
 
 --
 -- Name: connect_tokens connect_tokens_auth_profile_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
@@ -4717,14 +4099,12 @@ ALTER TABLE ONLY public.chat_connections
 ALTER TABLE ONLY public.connect_tokens
     ADD CONSTRAINT connect_tokens_auth_profile_id_fkey FOREIGN KEY (auth_profile_id) REFERENCES public.auth_profiles(id) ON DELETE SET NULL;
 
-
 --
 -- Name: connect_tokens connect_tokens_connection_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.connect_tokens
     ADD CONSTRAINT connect_tokens_connection_id_fkey FOREIGN KEY (connection_id) REFERENCES public.connections(id) ON DELETE CASCADE;
-
 
 --
 -- Name: connections connections_account_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
@@ -4733,14 +4113,12 @@ ALTER TABLE ONLY public.connect_tokens
 ALTER TABLE ONLY public.connections
     ADD CONSTRAINT connections_account_id_fkey FOREIGN KEY (account_id) REFERENCES public.account(id) ON DELETE SET NULL;
 
-
 --
 -- Name: connections connections_app_auth_profile_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.connections
     ADD CONSTRAINT connections_app_auth_profile_id_fkey FOREIGN KEY (organization_id, app_auth_profile_id) REFERENCES public.auth_profiles(organization_id, id) ON DELETE SET NULL;
-
 
 --
 -- Name: connections connections_auth_profile_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
@@ -4749,7 +4127,6 @@ ALTER TABLE ONLY public.connections
 ALTER TABLE ONLY public.connections
     ADD CONSTRAINT connections_auth_profile_id_fkey FOREIGN KEY (organization_id, auth_profile_id) REFERENCES public.auth_profiles(organization_id, id) ON DELETE SET NULL;
 
-
 --
 -- Name: connections connections_created_by_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
@@ -4757,6 +4134,12 @@ ALTER TABLE ONLY public.connections
 ALTER TABLE ONLY public.connections
     ADD CONSTRAINT connections_created_by_fkey FOREIGN KEY (created_by) REFERENCES public."user"(id) ON DELETE SET NULL;
 
+--
+-- Name: connections connections_device_worker_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.connections
+    ADD CONSTRAINT connections_device_worker_id_fkey FOREIGN KEY (device_worker_id) REFERENCES public.device_workers(id) ON DELETE SET NULL;
 
 --
 -- Name: connections connections_organization_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
@@ -4765,14 +4148,12 @@ ALTER TABLE ONLY public.connections
 ALTER TABLE ONLY public.connections
     ADD CONSTRAINT connections_organization_id_fkey FOREIGN KEY (organization_id) REFERENCES public.organization(id) ON DELETE CASCADE;
 
-
 --
 -- Name: connector_definitions connector_definitions_organization_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.connector_definitions
     ADD CONSTRAINT connector_definitions_organization_id_fkey FOREIGN KEY (organization_id) REFERENCES public.organization(id) ON DELETE CASCADE;
-
 
 --
 -- Name: entities entities_created_by_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
@@ -4781,14 +4162,12 @@ ALTER TABLE ONLY public.connector_definitions
 ALTER TABLE ONLY public.entities
     ADD CONSTRAINT entities_created_by_fkey FOREIGN KEY (created_by) REFERENCES public."user"(id) ON DELETE RESTRICT;
 
-
 --
 -- Name: entities entities_entity_type_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.entities
     ADD CONSTRAINT entities_entity_type_id_fkey FOREIGN KEY (entity_type_id) REFERENCES public.entity_types(id);
-
 
 --
 -- Name: entities entities_organization_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
@@ -4797,14 +4176,12 @@ ALTER TABLE ONLY public.entities
 ALTER TABLE ONLY public.entities
     ADD CONSTRAINT entities_organization_id_fkey FOREIGN KEY (organization_id) REFERENCES public.organization(id) ON DELETE CASCADE;
 
-
 --
 -- Name: entities entities_parent_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.entities
     ADD CONSTRAINT entities_parent_id_fkey FOREIGN KEY (parent_id) REFERENCES public.entities(id) ON DELETE RESTRICT;
-
 
 --
 -- Name: entities entities_view_template_version_fk; Type: FK CONSTRAINT; Schema: public; Owner: -
@@ -4813,14 +4190,12 @@ ALTER TABLE ONLY public.entities
 ALTER TABLE ONLY public.entities
     ADD CONSTRAINT entities_view_template_version_fk FOREIGN KEY (current_view_template_version_id) REFERENCES public.view_template_versions(id);
 
-
 --
 -- Name: entity_identities entity_identities_entity_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.entity_identities
     ADD CONSTRAINT entity_identities_entity_id_fkey FOREIGN KEY (entity_id) REFERENCES public.entities(id) ON DELETE CASCADE;
-
 
 --
 -- Name: entity_identities entity_identities_organization_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
@@ -4829,38 +4204,12 @@ ALTER TABLE ONLY public.entity_identities
 ALTER TABLE ONLY public.entity_identities
     ADD CONSTRAINT entity_identities_organization_id_fkey FOREIGN KEY (organization_id) REFERENCES public.organization(id) ON DELETE CASCADE;
 
-
---
--- Name: entity_read_grant entity_read_grant_entity_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.entity_read_grant
-    ADD CONSTRAINT entity_read_grant_entity_id_fkey FOREIGN KEY (entity_id) REFERENCES public.entities(id) ON DELETE CASCADE;
-
-
---
--- Name: entity_read_grant entity_read_grant_grantee_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.entity_read_grant
-    ADD CONSTRAINT entity_read_grant_grantee_user_id_fkey FOREIGN KEY (grantee_user_id) REFERENCES public."user"(id) ON DELETE CASCADE;
-
-
---
--- Name: entity_read_grant entity_read_grant_grantor_org_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.entity_read_grant
-    ADD CONSTRAINT entity_read_grant_grantor_org_id_fkey FOREIGN KEY (grantor_org_id) REFERENCES public.organization(id) ON DELETE CASCADE;
-
-
 --
 -- Name: entity_relationship_type_rules entity_relationship_type_rules_relationship_type_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.entity_relationship_type_rules
     ADD CONSTRAINT entity_relationship_type_rules_relationship_type_id_fkey FOREIGN KEY (relationship_type_id) REFERENCES public.entity_relationship_types(id) ON DELETE CASCADE;
-
 
 --
 -- Name: entity_relationship_types entity_relationship_types_created_by_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
@@ -4869,14 +4218,12 @@ ALTER TABLE ONLY public.entity_relationship_type_rules
 ALTER TABLE ONLY public.entity_relationship_types
     ADD CONSTRAINT entity_relationship_types_created_by_fkey FOREIGN KEY (created_by) REFERENCES public."user"(id) ON DELETE SET NULL;
 
-
 --
 -- Name: entity_relationship_types entity_relationship_types_inverse_type_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.entity_relationship_types
     ADD CONSTRAINT entity_relationship_types_inverse_type_id_fkey FOREIGN KEY (inverse_type_id) REFERENCES public.entity_relationship_types(id) ON DELETE SET NULL;
-
 
 --
 -- Name: entity_relationship_types entity_relationship_types_organization_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
@@ -4885,14 +4232,12 @@ ALTER TABLE ONLY public.entity_relationship_types
 ALTER TABLE ONLY public.entity_relationship_types
     ADD CONSTRAINT entity_relationship_types_organization_id_fkey FOREIGN KEY (organization_id) REFERENCES public.organization(id) ON DELETE CASCADE;
 
-
 --
 -- Name: entity_relationships entity_relationships_created_by_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.entity_relationships
     ADD CONSTRAINT entity_relationships_created_by_fkey FOREIGN KEY (created_by) REFERENCES public."user"(id) ON DELETE SET NULL;
-
 
 --
 -- Name: entity_relationships entity_relationships_from_entity_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
@@ -4901,14 +4246,12 @@ ALTER TABLE ONLY public.entity_relationships
 ALTER TABLE ONLY public.entity_relationships
     ADD CONSTRAINT entity_relationships_from_entity_id_fkey FOREIGN KEY (from_entity_id) REFERENCES public.entities(id) ON DELETE CASCADE;
 
-
 --
 -- Name: entity_relationships entity_relationships_organization_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.entity_relationships
     ADD CONSTRAINT entity_relationships_organization_id_fkey FOREIGN KEY (organization_id) REFERENCES public.organization(id) ON DELETE CASCADE;
-
 
 --
 -- Name: entity_relationships entity_relationships_relationship_type_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
@@ -4917,14 +4260,12 @@ ALTER TABLE ONLY public.entity_relationships
 ALTER TABLE ONLY public.entity_relationships
     ADD CONSTRAINT entity_relationships_relationship_type_id_fkey FOREIGN KEY (relationship_type_id) REFERENCES public.entity_relationship_types(id) ON DELETE CASCADE;
 
-
 --
 -- Name: entity_relationships entity_relationships_to_entity_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.entity_relationships
     ADD CONSTRAINT entity_relationships_to_entity_id_fkey FOREIGN KEY (to_entity_id) REFERENCES public.entities(id) ON DELETE CASCADE;
-
 
 --
 -- Name: entity_relationships entity_relationships_updated_by_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
@@ -4933,14 +4274,12 @@ ALTER TABLE ONLY public.entity_relationships
 ALTER TABLE ONLY public.entity_relationships
     ADD CONSTRAINT entity_relationships_updated_by_fkey FOREIGN KEY (updated_by) REFERENCES public."user"(id) ON DELETE SET NULL;
 
-
 --
 -- Name: entity_type_audit entity_type_audit_actor_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.entity_type_audit
     ADD CONSTRAINT entity_type_audit_actor_fkey FOREIGN KEY (actor) REFERENCES public."user"(id) ON DELETE SET NULL;
-
 
 --
 -- Name: entity_type_audit entity_type_audit_entity_type_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
@@ -4949,14 +4288,12 @@ ALTER TABLE ONLY public.entity_type_audit
 ALTER TABLE ONLY public.entity_type_audit
     ADD CONSTRAINT entity_type_audit_entity_type_id_fkey FOREIGN KEY (entity_type_id) REFERENCES public.entity_types(id) ON DELETE CASCADE;
 
-
 --
 -- Name: entity_types entity_types_created_by_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.entity_types
     ADD CONSTRAINT entity_types_created_by_fkey FOREIGN KEY (created_by) REFERENCES public."user"(id) ON DELETE SET NULL;
-
 
 --
 -- Name: entity_types entity_types_organization_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
@@ -4965,14 +4302,12 @@ ALTER TABLE ONLY public.entity_types
 ALTER TABLE ONLY public.entity_types
     ADD CONSTRAINT entity_types_organization_id_fkey FOREIGN KEY (organization_id) REFERENCES public.organization(id) ON DELETE CASCADE;
 
-
 --
 -- Name: entity_types entity_types_updated_by_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.entity_types
     ADD CONSTRAINT entity_types_updated_by_fkey FOREIGN KEY (updated_by) REFERENCES public."user"(id) ON DELETE SET NULL;
-
 
 --
 -- Name: entity_types entity_types_view_template_version_fk; Type: FK CONSTRAINT; Schema: public; Owner: -
@@ -4981,14 +4316,12 @@ ALTER TABLE ONLY public.entity_types
 ALTER TABLE ONLY public.entity_types
     ADD CONSTRAINT entity_types_view_template_version_fk FOREIGN KEY (current_view_template_version_id) REFERENCES public.view_template_versions(id);
 
-
 --
 -- Name: event_classifications event_classifications_classifier_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.event_classifications
     ADD CONSTRAINT event_classifications_classifier_id_fkey FOREIGN KEY (classifier_version_id) REFERENCES public.event_classifier_versions(id);
-
 
 --
 -- Name: event_classifications event_classifications_classifier_version_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
@@ -4997,14 +4330,12 @@ ALTER TABLE ONLY public.event_classifications
 ALTER TABLE ONLY public.event_classifications
     ADD CONSTRAINT event_classifications_classifier_version_id_fkey FOREIGN KEY (classifier_version_id) REFERENCES public.event_classifier_versions(id) ON DELETE RESTRICT;
 
-
 --
 -- Name: event_classifications event_classifications_event_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.event_classifications
     ADD CONSTRAINT event_classifications_event_id_fkey FOREIGN KEY (event_id) REFERENCES public.events(id) ON DELETE CASCADE;
-
 
 --
 -- Name: event_classifications event_classifications_insight_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
@@ -5013,14 +4344,12 @@ ALTER TABLE ONLY public.event_classifications
 ALTER TABLE ONLY public.event_classifications
     ADD CONSTRAINT event_classifications_insight_id_fkey FOREIGN KEY (watcher_id) REFERENCES public.watchers(id) ON DELETE CASCADE;
 
-
 --
 -- Name: event_classifications event_classifications_window_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.event_classifications
     ADD CONSTRAINT event_classifications_window_id_fkey FOREIGN KEY (window_id) REFERENCES public.watcher_windows(id) ON DELETE CASCADE;
-
 
 --
 -- Name: event_classifier_versions event_classifier_versions_classifier_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
@@ -5029,14 +4358,12 @@ ALTER TABLE ONLY public.event_classifications
 ALTER TABLE ONLY public.event_classifier_versions
     ADD CONSTRAINT event_classifier_versions_classifier_id_fkey FOREIGN KEY (classifier_id) REFERENCES public.event_classifiers(id) ON DELETE CASCADE;
 
-
 --
 -- Name: event_classifier_versions event_classifier_versions_created_by_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.event_classifier_versions
     ADD CONSTRAINT event_classifier_versions_created_by_fkey FOREIGN KEY (created_by) REFERENCES public."user"(id) ON DELETE RESTRICT;
-
 
 --
 -- Name: event_classifiers event_classifiers_created_by_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
@@ -5045,14 +4372,12 @@ ALTER TABLE ONLY public.event_classifier_versions
 ALTER TABLE ONLY public.event_classifiers
     ADD CONSTRAINT event_classifiers_created_by_fkey FOREIGN KEY (created_by) REFERENCES public."user"(id) ON DELETE RESTRICT;
 
-
 --
 -- Name: event_classifiers event_classifiers_insight_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.event_classifiers
     ADD CONSTRAINT event_classifiers_insight_id_fkey FOREIGN KEY (watcher_id) REFERENCES public.watchers(id) ON DELETE CASCADE;
-
 
 --
 -- Name: event_classifiers event_classifiers_organization_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
@@ -5061,14 +4386,12 @@ ALTER TABLE ONLY public.event_classifiers
 ALTER TABLE ONLY public.event_classifiers
     ADD CONSTRAINT event_classifiers_organization_id_fkey FOREIGN KEY (organization_id) REFERENCES public.organization(id) ON DELETE CASCADE;
 
-
 --
 -- Name: event_embeddings event_embeddings_event_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.event_embeddings
     ADD CONSTRAINT event_embeddings_event_id_fkey FOREIGN KEY (event_id) REFERENCES public.events(id) ON DELETE CASCADE;
-
 
 --
 -- Name: events events_client_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
@@ -5077,14 +4400,12 @@ ALTER TABLE ONLY public.event_embeddings
 ALTER TABLE ONLY public.events
     ADD CONSTRAINT events_client_id_fkey FOREIGN KEY (client_id) REFERENCES public.oauth_clients(id) ON DELETE SET NULL;
 
-
 --
 -- Name: events events_connection_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.events
     ADD CONSTRAINT events_connection_id_fkey FOREIGN KEY (connection_id) REFERENCES public.connections(id) ON DELETE SET NULL;
-
 
 --
 -- Name: events events_created_by_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
@@ -5093,14 +4414,12 @@ ALTER TABLE ONLY public.events
 ALTER TABLE ONLY public.events
     ADD CONSTRAINT events_created_by_fkey FOREIGN KEY (created_by) REFERENCES public."user"(id) ON DELETE SET NULL;
 
-
 --
 -- Name: events events_feed_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.events
     ADD CONSTRAINT events_feed_id_fkey FOREIGN KEY (feed_id) REFERENCES public.feeds(id) ON DELETE SET NULL;
-
 
 --
 -- Name: events events_organization_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
@@ -5109,14 +4428,12 @@ ALTER TABLE ONLY public.events
 ALTER TABLE ONLY public.events
     ADD CONSTRAINT events_organization_id_fkey FOREIGN KEY (organization_id) REFERENCES public.organization(id) ON DELETE CASCADE;
 
-
 --
 -- Name: events events_run_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.events
     ADD CONSTRAINT events_run_id_fkey FOREIGN KEY (run_id) REFERENCES public.runs(id) ON DELETE SET NULL;
-
 
 --
 -- Name: events events_supersedes_event_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
@@ -5125,14 +4442,12 @@ ALTER TABLE ONLY public.events
 ALTER TABLE ONLY public.events
     ADD CONSTRAINT events_supersedes_event_id_fkey FOREIGN KEY (supersedes_event_id) REFERENCES public.events(id) ON DELETE SET NULL;
 
-
 --
 -- Name: feeds feeds_connection_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.feeds
     ADD CONSTRAINT feeds_connection_id_fkey FOREIGN KEY (connection_id) REFERENCES public.connections(id) ON DELETE CASCADE;
-
 
 --
 -- Name: feeds feeds_organization_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
@@ -5141,14 +4456,12 @@ ALTER TABLE ONLY public.feeds
 ALTER TABLE ONLY public.feeds
     ADD CONSTRAINT feeds_organization_id_fkey FOREIGN KEY (organization_id) REFERENCES public.organization(id) ON DELETE CASCADE;
 
-
 --
 -- Name: event_classifiers fk_event_classifiers_entity; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.event_classifiers
     ADD CONSTRAINT fk_event_classifiers_entity FOREIGN KEY (entity_id) REFERENCES public.entities(id) ON DELETE CASCADE;
-
 
 --
 -- Name: event_classifiers fk_event_classifiers_insight; Type: FK CONSTRAINT; Schema: public; Owner: -
@@ -5157,14 +4470,12 @@ ALTER TABLE ONLY public.event_classifiers
 ALTER TABLE ONLY public.event_classifiers
     ADD CONSTRAINT fk_event_classifiers_insight FOREIGN KEY (watcher_id) REFERENCES public.watchers(id) ON DELETE SET NULL;
 
-
 --
 -- Name: grants grants_agent_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.grants
     ADD CONSTRAINT grants_agent_id_fkey FOREIGN KEY (agent_id) REFERENCES public.agents(id) ON DELETE CASCADE;
-
 
 --
 -- Name: watcher_versions insight_template_versions_created_by_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
@@ -5173,14 +4484,12 @@ ALTER TABLE ONLY public.grants
 ALTER TABLE ONLY public.watcher_versions
     ADD CONSTRAINT insight_template_versions_created_by_fkey FOREIGN KEY (created_by) REFERENCES public."user"(id) ON DELETE RESTRICT;
 
-
 --
 -- Name: watcher_window_events insight_window_events_event_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.watcher_window_events
     ADD CONSTRAINT insight_window_events_event_id_fkey FOREIGN KEY (event_id) REFERENCES public.events(id) ON DELETE CASCADE;
-
 
 --
 -- Name: watcher_window_events insight_window_events_window_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
@@ -5189,14 +4498,12 @@ ALTER TABLE ONLY public.watcher_window_events
 ALTER TABLE ONLY public.watcher_window_events
     ADD CONSTRAINT insight_window_events_window_id_fkey FOREIGN KEY (window_id) REFERENCES public.watcher_windows(id) ON DELETE CASCADE;
 
-
 --
 -- Name: watcher_windows insight_windows_insight_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.watcher_windows
     ADD CONSTRAINT insight_windows_insight_id_fkey FOREIGN KEY (watcher_id) REFERENCES public.watchers(id) ON DELETE CASCADE;
-
 
 --
 -- Name: watcher_windows insight_windows_parent_window_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
@@ -5205,14 +4512,12 @@ ALTER TABLE ONLY public.watcher_windows
 ALTER TABLE ONLY public.watcher_windows
     ADD CONSTRAINT insight_windows_parent_window_id_fkey FOREIGN KEY (parent_window_id) REFERENCES public.watcher_windows(id) ON DELETE CASCADE;
 
-
 --
 -- Name: watchers insights_created_by_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.watchers
     ADD CONSTRAINT insights_created_by_fkey FOREIGN KEY (created_by) REFERENCES public."user"(id) ON DELETE RESTRICT;
-
 
 --
 -- Name: invitation invitation_inviterId_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
@@ -5221,14 +4526,12 @@ ALTER TABLE ONLY public.watchers
 ALTER TABLE ONLY public.invitation
     ADD CONSTRAINT "invitation_inviterId_fkey" FOREIGN KEY ("inviterId") REFERENCES public."user"(id) ON DELETE SET NULL;
 
-
 --
 -- Name: invitation invitation_organizationId_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.invitation
     ADD CONSTRAINT "invitation_organizationId_fkey" FOREIGN KEY ("organizationId") REFERENCES public.organization(id) ON DELETE CASCADE;
-
 
 --
 -- Name: mcp_sessions mcp_sessions_client_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
@@ -5237,14 +4540,12 @@ ALTER TABLE ONLY public.invitation
 ALTER TABLE ONLY public.mcp_sessions
     ADD CONSTRAINT mcp_sessions_client_id_fkey FOREIGN KEY (client_id) REFERENCES public.oauth_clients(id) ON DELETE CASCADE;
 
-
 --
 -- Name: mcp_sessions mcp_sessions_organization_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.mcp_sessions
     ADD CONSTRAINT mcp_sessions_organization_id_fkey FOREIGN KEY (organization_id) REFERENCES public.organization(id) ON DELETE CASCADE;
-
 
 --
 -- Name: mcp_sessions mcp_sessions_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
@@ -5253,14 +4554,12 @@ ALTER TABLE ONLY public.mcp_sessions
 ALTER TABLE ONLY public.mcp_sessions
     ADD CONSTRAINT mcp_sessions_user_id_fkey FOREIGN KEY (user_id) REFERENCES public."user"(id) ON DELETE CASCADE;
 
-
 --
 -- Name: member member_organizationId_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.member
     ADD CONSTRAINT "member_organizationId_fkey" FOREIGN KEY ("organizationId") REFERENCES public.organization(id) ON DELETE CASCADE;
-
 
 --
 -- Name: member member_userId_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
@@ -5269,14 +4568,12 @@ ALTER TABLE ONLY public.member
 ALTER TABLE ONLY public.member
     ADD CONSTRAINT "member_userId_fkey" FOREIGN KEY ("userId") REFERENCES public."user"(id) ON DELETE CASCADE;
 
-
 --
 -- Name: oauth_authorization_codes oauth_authorization_codes_client_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.oauth_authorization_codes
     ADD CONSTRAINT oauth_authorization_codes_client_id_fkey FOREIGN KEY (client_id) REFERENCES public.oauth_clients(id) ON DELETE CASCADE;
-
 
 --
 -- Name: oauth_authorization_codes oauth_authorization_codes_organization_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
@@ -5285,14 +4582,12 @@ ALTER TABLE ONLY public.oauth_authorization_codes
 ALTER TABLE ONLY public.oauth_authorization_codes
     ADD CONSTRAINT oauth_authorization_codes_organization_id_fkey FOREIGN KEY (organization_id) REFERENCES public.organization(id) ON DELETE SET NULL;
 
-
 --
 -- Name: oauth_authorization_codes oauth_authorization_codes_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.oauth_authorization_codes
     ADD CONSTRAINT oauth_authorization_codes_user_id_fkey FOREIGN KEY (user_id) REFERENCES public."user"(id) ON DELETE CASCADE;
-
 
 --
 -- Name: oauth_clients oauth_clients_organization_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
@@ -5301,14 +4596,12 @@ ALTER TABLE ONLY public.oauth_authorization_codes
 ALTER TABLE ONLY public.oauth_clients
     ADD CONSTRAINT oauth_clients_organization_id_fkey FOREIGN KEY (organization_id) REFERENCES public.organization(id) ON DELETE CASCADE;
 
-
 --
 -- Name: oauth_clients oauth_clients_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.oauth_clients
     ADD CONSTRAINT oauth_clients_user_id_fkey FOREIGN KEY (user_id) REFERENCES public."user"(id) ON DELETE CASCADE;
-
 
 --
 -- Name: oauth_device_codes oauth_device_codes_client_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
@@ -5317,14 +4610,12 @@ ALTER TABLE ONLY public.oauth_clients
 ALTER TABLE ONLY public.oauth_device_codes
     ADD CONSTRAINT oauth_device_codes_client_id_fkey FOREIGN KEY (client_id) REFERENCES public.oauth_clients(id) ON DELETE CASCADE;
 
-
 --
 -- Name: oauth_device_codes oauth_device_codes_organization_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.oauth_device_codes
     ADD CONSTRAINT oauth_device_codes_organization_id_fkey FOREIGN KEY (organization_id) REFERENCES public.organization(id) ON DELETE SET NULL;
-
 
 --
 -- Name: oauth_device_codes oauth_device_codes_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
@@ -5333,14 +4624,12 @@ ALTER TABLE ONLY public.oauth_device_codes
 ALTER TABLE ONLY public.oauth_device_codes
     ADD CONSTRAINT oauth_device_codes_user_id_fkey FOREIGN KEY (user_id) REFERENCES public."user"(id) ON DELETE CASCADE;
 
-
 --
 -- Name: oauth_tokens oauth_tokens_client_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.oauth_tokens
     ADD CONSTRAINT oauth_tokens_client_id_fkey FOREIGN KEY (client_id) REFERENCES public.oauth_clients(id) ON DELETE CASCADE;
-
 
 --
 -- Name: oauth_tokens oauth_tokens_organization_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
@@ -5349,14 +4638,12 @@ ALTER TABLE ONLY public.oauth_tokens
 ALTER TABLE ONLY public.oauth_tokens
     ADD CONSTRAINT oauth_tokens_organization_id_fkey FOREIGN KEY (organization_id) REFERENCES public.organization(id) ON DELETE SET NULL;
 
-
 --
 -- Name: oauth_tokens oauth_tokens_parent_token_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.oauth_tokens
     ADD CONSTRAINT oauth_tokens_parent_token_id_fkey FOREIGN KEY (parent_token_id) REFERENCES public.oauth_tokens(id) ON DELETE SET NULL;
-
 
 --
 -- Name: oauth_tokens oauth_tokens_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
@@ -5365,14 +4652,12 @@ ALTER TABLE ONLY public.oauth_tokens
 ALTER TABLE ONLY public.oauth_tokens
     ADD CONSTRAINT oauth_tokens_user_id_fkey FOREIGN KEY (user_id) REFERENCES public."user"(id) ON DELETE CASCADE;
 
-
 --
 -- Name: organization_lobu_links organization_lobu_links_created_by_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.organization_lobu_links
     ADD CONSTRAINT organization_lobu_links_created_by_fkey FOREIGN KEY (created_by) REFERENCES public."user"(id) ON DELETE SET NULL;
-
 
 --
 -- Name: organization_lobu_links organization_lobu_links_organization_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
@@ -5381,14 +4666,12 @@ ALTER TABLE ONLY public.organization_lobu_links
 ALTER TABLE ONLY public.organization_lobu_links
     ADD CONSTRAINT organization_lobu_links_organization_id_fkey FOREIGN KEY (organization_id) REFERENCES public.organization(id) ON DELETE CASCADE;
 
-
 --
 -- Name: personal_access_tokens personal_access_tokens_organization_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.personal_access_tokens
     ADD CONSTRAINT personal_access_tokens_organization_id_fkey FOREIGN KEY (organization_id) REFERENCES public.organization(id) ON DELETE SET NULL;
-
 
 --
 -- Name: personal_access_tokens personal_access_tokens_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
@@ -5397,14 +4680,12 @@ ALTER TABLE ONLY public.personal_access_tokens
 ALTER TABLE ONLY public.personal_access_tokens
     ADD CONSTRAINT personal_access_tokens_user_id_fkey FOREIGN KEY (user_id) REFERENCES public."user"(id) ON DELETE CASCADE;
 
-
 --
 -- Name: runs runs_auth_profile_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.runs
     ADD CONSTRAINT runs_auth_profile_id_fkey FOREIGN KEY (auth_profile_id) REFERENCES public.auth_profiles(id) ON DELETE CASCADE;
-
 
 --
 -- Name: runs runs_connection_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
@@ -5413,14 +4694,12 @@ ALTER TABLE ONLY public.runs
 ALTER TABLE ONLY public.runs
     ADD CONSTRAINT runs_connection_id_fkey FOREIGN KEY (connection_id) REFERENCES public.connections(id) ON DELETE SET NULL;
 
-
 --
 -- Name: runs runs_created_by_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.runs
     ADD CONSTRAINT runs_created_by_user_id_fkey FOREIGN KEY (created_by_user_id) REFERENCES public."user"(id) ON DELETE SET NULL;
-
 
 --
 -- Name: runs runs_feed_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
@@ -5429,14 +4708,12 @@ ALTER TABLE ONLY public.runs
 ALTER TABLE ONLY public.runs
     ADD CONSTRAINT runs_feed_id_fkey FOREIGN KEY (feed_id) REFERENCES public.feeds(id) ON DELETE SET NULL;
 
-
 --
 -- Name: runs runs_organization_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.runs
     ADD CONSTRAINT runs_organization_id_fkey FOREIGN KEY (organization_id) REFERENCES public.organization(id) ON DELETE CASCADE;
-
 
 --
 -- Name: runs runs_watcher_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
@@ -5445,14 +4722,12 @@ ALTER TABLE ONLY public.runs
 ALTER TABLE ONLY public.runs
     ADD CONSTRAINT runs_watcher_id_fkey FOREIGN KEY (watcher_id) REFERENCES public.watchers(id) ON DELETE SET NULL;
 
-
 --
 -- Name: runs runs_window_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.runs
     ADD CONSTRAINT runs_window_id_fkey FOREIGN KEY (window_id) REFERENCES public.watcher_windows(id) ON DELETE SET NULL;
-
 
 --
 -- Name: session session_activeOrganizationId_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
@@ -5461,14 +4736,12 @@ ALTER TABLE ONLY public.runs
 ALTER TABLE ONLY public.session
     ADD CONSTRAINT "session_activeOrganizationId_fkey" FOREIGN KEY ("activeOrganizationId") REFERENCES public.organization(id) ON DELETE SET NULL;
 
-
 --
 -- Name: session session_userId_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.session
     ADD CONSTRAINT "session_userId_fkey" FOREIGN KEY ("userId") REFERENCES public."user"(id) ON DELETE CASCADE;
-
 
 --
 -- Name: view_template_active_tabs view_template_active_tabs_version_fk; Type: FK CONSTRAINT; Schema: public; Owner: -
@@ -5477,14 +4750,12 @@ ALTER TABLE ONLY public.session
 ALTER TABLE ONLY public.view_template_active_tabs
     ADD CONSTRAINT view_template_active_tabs_version_fk FOREIGN KEY (current_version_id) REFERENCES public.view_template_versions(id);
 
-
 --
 -- Name: watcher_reactions watcher_reactions_watcher_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.watcher_reactions
     ADD CONSTRAINT watcher_reactions_watcher_id_fkey FOREIGN KEY (watcher_id) REFERENCES public.watchers(id) ON DELETE CASCADE;
-
 
 --
 -- Name: watcher_reactions watcher_reactions_window_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
@@ -5493,14 +4764,12 @@ ALTER TABLE ONLY public.watcher_reactions
 ALTER TABLE ONLY public.watcher_reactions
     ADD CONSTRAINT watcher_reactions_window_id_fkey FOREIGN KEY (window_id) REFERENCES public.watcher_windows(id) ON DELETE CASCADE;
 
-
 --
 -- Name: watcher_versions watcher_versions_watcher_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.watcher_versions
     ADD CONSTRAINT watcher_versions_watcher_id_fkey FOREIGN KEY (watcher_id) REFERENCES public.watchers(id) ON DELETE CASCADE;
-
 
 --
 -- Name: watcher_window_field_feedback watcher_window_field_feedback_watcher_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
@@ -5509,14 +4778,12 @@ ALTER TABLE ONLY public.watcher_versions
 ALTER TABLE ONLY public.watcher_window_field_feedback
     ADD CONSTRAINT watcher_window_field_feedback_watcher_id_fkey FOREIGN KEY (watcher_id) REFERENCES public.watchers(id) ON DELETE CASCADE;
 
-
 --
 -- Name: watcher_window_field_feedback watcher_window_field_feedback_window_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.watcher_window_field_feedback
     ADD CONSTRAINT watcher_window_field_feedback_window_id_fkey FOREIGN KEY (window_id) REFERENCES public.watcher_windows(id) ON DELETE CASCADE;
-
 
 --
 -- Name: watcher_windows watcher_windows_run_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
@@ -5525,7 +4792,6 @@ ALTER TABLE ONLY public.watcher_window_field_feedback
 ALTER TABLE ONLY public.watcher_windows
     ADD CONSTRAINT watcher_windows_run_id_fkey FOREIGN KEY (run_id) REFERENCES public.runs(id) ON DELETE SET NULL;
 
-
 --
 -- Name: watcher_windows watcher_windows_version_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
@@ -5533,14 +4799,12 @@ ALTER TABLE ONLY public.watcher_windows
 ALTER TABLE ONLY public.watcher_windows
     ADD CONSTRAINT watcher_windows_version_id_fkey FOREIGN KEY (version_id) REFERENCES public.watcher_versions(id);
 
-
 --
 -- Name: watchers watchers_current_version_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.watchers
-    ADD CONSTRAINT watchers_current_version_id_fkey FOREIGN KEY (current_version_id) REFERENCES public.watcher_versions(id) ON DELETE SET NULL DEFERRABLE INITIALLY DEFERRED;
-
+    ADD CONSTRAINT watchers_current_version_id_fkey FOREIGN KEY (current_version_id) REFERENCES public.watcher_versions(id) ON DELETE SET NULL;
 
 --
 -- Name: watchers watchers_organization_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
@@ -5549,13 +4813,9 @@ ALTER TABLE ONLY public.watchers
 ALTER TABLE ONLY public.watchers
     ADD CONSTRAINT watchers_organization_id_fkey FOREIGN KEY (organization_id) REFERENCES public.organization(id) ON DELETE CASCADE;
 
-
 --
 -- PostgreSQL database dump complete
 --
-
-\unrestrict M2CVBCWaQpZ2IaSZ0tLvIsiZcxaeHAXCvAhTje2jQXnlRxfcYhzgFruwfb40Hgl
-
 
 --
 -- Dbmate schema migrations
@@ -5563,15 +4823,6 @@ ALTER TABLE ONLY public.watchers
 
 INSERT INTO public.schema_migrations (version) VALUES
     ('00000000000000'),
-    ('20260328180843'),
-    ('20260328182759'),
-    ('20260328200000'),
-    ('20260329120000'),
-    ('20260329210753'),
-    ('20260330110000'),
-    ('20260330143000'),
-    ('20260331120000'),
-    ('20260402120000'),
     ('20260405193000'),
     ('20260408120000'),
     ('20260408120001'),
@@ -5609,5 +4860,15 @@ INSERT INTO public.schema_migrations (version) VALUES
     ('20260429140000'),
     ('20260429140100'),
     ('20260429180000'),
+    ('20260430005614'),
+    ('20260430022231'),
     ('20260430151215'),
-    ('20260501000000');
+    ('20260501000000'),
+    ('20260501133000'),
+    ('20260502000000'),
+    ('20260503000000'),
+    ('20260504000000'),
+    ('20260510220000'),
+    ('20260512000000'),
+    ('20260512131703'),
+    ('20260513000000');

--- a/packages/server/src/start-local.ts
+++ b/packages/server/src/start-local.ts
@@ -254,9 +254,42 @@ async function runMigrations(dbUrl: string) {
 }
 
 async function applyEmbeddedSchemaPatches(sql: MigrationSqlClient) {
+  // Embedded patches mirror DDL from `db/migrations/*.sql`. When a patch
+  // actually changes the schema (column count delta), that's a drift signal:
+  // the canonical migration didn't run for this database, either because a
+  // dev edited an already-applied migration (the #639 footgun) or because
+  // dbmate isn't wired up. Surface that loudly so it doesn't silently mask
+  // the same bug class in dev that would crash in prod.
+  async function schemaSnapshot(): Promise<{ columns: number; indexes: number }> {
+    try {
+      const rows = (await sql.unsafe(`
+        SELECT
+          (SELECT count(*) FROM information_schema.columns WHERE table_schema = 'public')::int AS columns,
+          (SELECT count(*) FROM pg_indexes WHERE schemaname = 'public')::int AS indexes
+      `)) as Array<{ columns: number; indexes: number }>;
+      return rows[0] ?? { columns: 0, indexes: 0 };
+    } catch {
+      return { columns: 0, indexes: 0 };
+    }
+  }
+
   for (const patch of EMBEDDED_SCHEMA_PATCHES) {
     logger.info({ patch: patch.id }, 'Applying embedded schema patch');
+    const before = await schemaSnapshot();
     await patch.apply(sql);
+    const after = await schemaSnapshot();
+    if (after.columns !== before.columns || after.indexes !== before.indexes) {
+      logger.warn(
+        {
+          patch: patch.id,
+          columnDelta: after.columns - before.columns,
+          indexDelta: after.indexes - before.indexes,
+        },
+        'Embedded patch modified schema — the matching db/migrations/*.sql ' +
+          'did not run for this database. If you just edited a migration, ' +
+          'roll it back and ship a new dated migration file instead.'
+      );
+    }
   }
 }
 

--- a/scripts/normalize-schema.sh
+++ b/scripts/normalize-schema.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Strip non-deterministic / env-dependent lines from a pg_dump output so the
+# file is byte-stable across pg_dump versions and runs. Used by the
+# `migrations` CI job's schema-drift check.
+#
+# Lines removed:
+#   \restrict <random>     — pg17+ session token at the top of the dump
+#   \unrestrict <random>   — matching footer
+#   -- Dumped from database version <...>
+#   -- Dumped by pg_dump version <...>
+#   SET transaction_timeout = 0;   — emitted only by pg17+
+#
+# Adjacent blank lines that result from deletions are collapsed and any
+# leading blanks at the top of the file are dropped, so the output is the
+# same regardless of which lines were originally present.
+#
+# Usage: scripts/normalize-schema.sh db/schema.sql
+set -euo pipefail
+file="${1:?usage: $0 <schema.sql>}"
+tmp="$(mktemp)"
+awk '
+  /^\\restrict [^[:space:]]+$/   { next }
+  /^\\unrestrict [^[:space:]]+$/ { next }
+  /^-- Dumped from database version / { next }
+  /^-- Dumped by pg_dump version /    { next }
+  /^SET transaction_timeout = 0;$/    { next }
+  /^$/ {
+    # Drop leading blanks before any content. Once content has been emitted,
+    # collapse runs of blank lines: queue one and emit it before the next
+    # non-blank line.
+    if (!seen) next
+    pending_blank = 1
+    next
+  }
+  {
+    if (pending_blank) { print ""; pending_blank = 0 }
+    print
+    seen = 1
+  }
+' "$file" >"$tmp"
+mv "$tmp" "$file"


### PR DESCRIPTION
## Why

PR #639 edited `db/migrations/20260512000000_device_worker_connection_binding.sql` *after* it had been applied to prod. dbmate keys migrations by version, so the new ALTER for `device_workers.organization_id` never re-ran on prod. `/api/me/devices` returned 500 on `app.lobu.ai` until I hot-patched the column today. Every existing safety net missed it.

Diagnosis with the four gaps and the plug for each:

| # | Gap | Plug |
|---|-----|------|
| 1 | No migration-immutability check | New `ci.yml` step fails PRs that modify (rather than add) `db/migrations/*.sql` |
| 2 | No schema-snapshot drift check | `dbmate up --schema-file db/schema.sql` regenerates the dump; CI fails on diff. `db/schema.sql` was 12 migrations stale — regenerated in this PR. |
| 3 | Embedded patches mask drift locally | `applyEmbeddedSchemaPatches` now snapshots column/index counts and WARNs on any actual mutation, so devs see the drift in `make dev` logs |
| 4 | Smoke test too shallow | Helm `releaseGates.smokeTest.requiredSchema` lists `<table>.<column>` entries; job queries `information_schema.columns` after `/api/health` passes and fails the rollout if any are missing |

Gaps 1 and 4 are belt-and-suspenders for the same bug class — 1 prevents the merge, 4 fails the deploy if a similar bug slips in through another path. Gap 2 catches a *different* angle (intentional schema changes that don't propagate to `db/schema.sql`). Gap 3 makes the bug observable in dev when it inevitably recurs in some new form.

## Test plan

- [x] Helm `helm lint charts/lobu` and `helm template lobu charts/lobu` both clean
- [x] Root `bun run typecheck` clean
- [x] Pre-commit (biome + tsc) green
- [x] `db/schema.sql` regenerated against an empty Postgres; contains `device_workers.organization_id` (line 662)
- [ ] CI `migrations` job green on this PR (proves the new checks don't false-positive on the fix itself)
- [ ] Smoke test green on next deploy (proves the schema-column probe is wired up correctly)

## Out of scope

- The prod schema was hot-patched manually today to unblock `/api/me/devices`. That's documented in the PR description but not in code. If a similar drift recurs, follow the same pattern: write the ALTER as a new dated migration, run it locally, ship a PR.
- Sentry backend alerting on 500s wasn't paging during the #639 outage. Worth a follow-up to verify the `lobu-backend` Sentry project is wired to a pager.