### PR TITLE
fix(server): drop duplicate getClientIp export in rate-limiter

### DIFF
--- a/packages/server/src/gateway/utils/rate-limiter.ts
+++ b/packages/server/src/gateway/utils/rate-limiter.ts
@@ -1,22 +1,5 @@
 import { getDb } from "../../db/client.js";
 
-export function getClientIp(headers: {
-  forwardedFor?: string;
-  realIp?: string;
-}): string {
-  const forwarded = headers.forwardedFor?.split(",")[0]?.trim().toLowerCase();
-  if (forwarded) {
-    return forwarded;
-  }
-
-  const realIp = headers.realIp?.trim().toLowerCase();
-  if (realIp) {
-    return realIp;
-  }
-
-  return "unknown";
-}
-
 /**
  * Extract the client IP for rate-limit / abuse-tracking purposes from the
  * inbound proxy headers. Prefers the first hop in `x-forwarded-for`, falling


### PR DESCRIPTION
Surfaced by the WS9/WS10 sweep — PR #694 restored the helper but the merge of #693 left an earlier copy intact. esbuild fails `make build-packages` with:

```
src/gateway/utils/rate-limiter.ts:26:16: ERROR: Multiple exports with the same name "getClientIp"
```

That cascades through `typecheck` and `integration` on main. Drops the older un-documented copy, keeps the JSDoc'd one (functionally identical). `make build-packages` + `bun run typecheck` both green locally.