### PR TITLE
fix(server): capture all 5xx + thrown HTTP errors in Sentry

### DIFF
--- a/packages/server/src/sentry.ts
+++ b/packages/server/src/sentry.ts
@@ -5,8 +5,52 @@
  * This module provides the MCP tool call tracking wrapper.
  */
 
+import type { Context } from 'hono';
 import * as Sentry from '@sentry/node';
 import { ToolUserError } from './utils/errors';
+
+const SENTRY_CAPTURED_FLAG = 'sentryErrorCaptured';
+
+/**
+ * Mark the current request as already reported to Sentry so the response-level
+ * post-middleware doesn't double-count it.
+ */
+export function markSentryReported(c: Context): void {
+  c.set(SENTRY_CAPTURED_FLAG as never, true as never);
+}
+
+export function isSentryReported(c: Context): boolean {
+  return Boolean(c.get(SENTRY_CAPTURED_FLAG as never));
+}
+
+/**
+ * Capture a server-side error from inside a route's catch block. Use this when
+ * the handler swallows the exception and returns a 500 JSON response — the
+ * top-level `app.onError` only sees exceptions that bubble up, so without this
+ * call the error never reaches Sentry. ToolUserError (4xx, user fault) is
+ * skipped to keep the alert feed clean.
+ *
+ * After calling, set `markSentryReported(c)` is implicit so the response-level
+ * post-middleware skips the same request.
+ */
+export function captureServerError(
+  c: Context,
+  error: unknown,
+  source: string
+): void {
+  if (error instanceof ToolUserError) return;
+  Sentry.captureException(error, {
+    tags: {
+      source,
+      http_method: c.req.method,
+    },
+    extra: {
+      path: c.req.path,
+      url: c.req.url,
+    },
+  });
+  markSentryReported(c);
+}
 
 /**
  * Track an MCP tool call with Sentry

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -38,7 +38,9 @@ import {
   stopLobuGateway,
 } from './lobu/gateway';
 import { bootTaskScheduler } from './scheduled/jobs';
+import * as Sentry from '@sentry/node';
 import { assertExternalDepsResolvable } from '../../connector-worker/src/runtime-deps';
+import { isSentryReported, markSentryReported } from './sentry';
 import { getEnvFromProcess } from './utils/env';
 import logger from './utils/logger';
 import { initWorkspaceProvider } from './workspace';
@@ -67,6 +69,68 @@ const env = getEnvFromProcess();
 app.use('*', async (c, next) => {
   c.env = env as Env;
   return next();
+});
+
+// Server-error capture. Two layers because routes split into two shapes:
+//
+//   (a) routes that throw and let the framework respond — caught by
+//       `app.onError` below, preserving the full stack trace.
+//   (b) routes that try/catch internally and `return c.json(..., 500)` — the
+//       framework never sees the exception, so onError doesn't fire. The
+//       post-response middleware below catches anything with `status >= 500`
+//       so silent 500s still reach Sentry, even if the stack is gone.
+//
+// Either layer marks the request as reported so we don't double-count when
+// both paths converge (e.g. an inner catch already called captureServerError).
+app.use('*', async (c, next) => {
+  await next();
+  if (c.res.status >= 500 && !isSentryReported(c)) {
+    let body: unknown = null;
+    try {
+      body = await c.res.clone().json();
+    } catch {
+      // response wasn't JSON; ignore
+    }
+    const message =
+      (body && typeof body === 'object' && 'error' in body && typeof (body as { error?: unknown }).error === 'string'
+        ? (body as { error: string }).error
+        : null) ?? `HTTP ${c.res.status} from ${c.req.method} ${c.req.path}`;
+    Sentry.captureMessage(message, {
+      level: 'error',
+      tags: {
+        source: 'http_response',
+        http_method: c.req.method,
+        http_status: String(c.res.status),
+      },
+      extra: {
+        path: c.req.path,
+        url: c.req.url,
+        response_body: body,
+      },
+    });
+    markSentryReported(c);
+  }
+});
+
+// Catch-all error handler for thrown exceptions that bubble past route catches.
+// Preserves the original stack trace and returns a generic 500 so handlers
+// don't have to remember to wrap themselves.
+app.onError((err, c) => {
+  if (!isSentryReported(c)) {
+    Sentry.captureException(err, {
+      tags: {
+        source: 'app_onError',
+        http_method: c.req.method,
+      },
+      extra: {
+        path: c.req.path,
+        url: c.req.url,
+      },
+    });
+    markSentryReported(c);
+  }
+  logger.error({ err, path: c.req.path }, 'Unhandled error in HTTP handler');
+  return c.json({ error: 'Internal server error' }, 500);
 });
 
 /**

--- a/packages/server/src/worker-api.ts
+++ b/packages/server/src/worker-api.ts
@@ -18,6 +18,7 @@ import {
   maybeCloseRepairThread,
   maybeOpenOrAppendRepairThread,
 } from './connectors/repair-agent';
+import { captureServerError } from './sentry';
 import { autoLinkEvent } from './utils/auto-linker';
 import { nextRunAt as nextRunAtFromCron } from './utils/cron';
 import { reconcileDeviceCapabilities } from './worker-api/device-reconcile';
@@ -1560,6 +1561,7 @@ export async function listDeviceWorkers(c: Context<{ Bindings: Env }>) {
     });
   } catch (err: unknown) {
     logger.error({ error: errorMessage(err) }, '[listDeviceWorkers] Error');
+    captureServerError(c, err, 'listDeviceWorkers');
     return c.json({ error: errorMessage(err) }, 500);
   }
 }


### PR DESCRIPTION
## Why

Final gap from the #639 outage diagnosis: every REST handler in the gateway catches its own exceptions and returns a JSON 500, so the framework never sees them and Sentry never receives them.

\`\`\`
try { ... } catch (err) {
  logger.error(...);
  return c.json({ error: errorMessage(err) }, 500);
}
\`\`\`

There are ~50 instances of this in \`worker-api.ts\` alone. \`@sentry/node\`'s auto-instrumentation only captures *unhandled* exceptions, and no top-level \`app.onError\` exists. So #639's \`column \"dw.organization_id\" does not exist\` errors fired in prod for ~13h and zero events reached the \`lobu-backend\` Sentry project (confirmed via \`mcp__sentry__search_issues\` over a 24h window — only 4 unrelated issues, none from the device endpoint).

## What

Three layers of capture so nothing slips through:

1. **Top-level \`app.onError\`** on the wrapper Hono in \`server.ts\`. Catches anything that bubbles past route try/catch — preserves the stack trace, returns generic 500.
2. **Post-response middleware** that runs after \`next()\` and inspects \`c.res.status\`. Catches the swallow-and-return pattern via \`Sentry.captureMessage\` (no stack but at least a signal). \`isSentryReported(c)\` flag avoids double-counting.
3. **\`captureServerError(c, err, source)\` helper** in \`sentry.ts\` for routes that want a real stack trace before returning 500. Applied to \`listDeviceWorkers\` as the canonical example.

Future routes should call the helper in their catch. The middleware backstops the ones that don't get migrated.

## Test plan

- [x] \`bun run typecheck\` clean
- [x] Pre-commit (biome + tsc) green
- [ ] CI green
- [ ] Deploy + synthetic-error verification in prod (trigger a known-500, confirm it appears in lobu-ai/lobu-backend within 60s)