### PR TITLE
fix(auth): wire personal_org_for_user_id through manual org creation + device-auth

### DIFF
--- a/packages/server/src/auth/index.tsx
+++ b/packages/server/src/auth/index.tsx
@@ -30,6 +30,7 @@ import {
 } from "../utils/public-origin";
 import { TtlCache } from "../utils/ttl-cache";
 import { resolveBaseUrl, safeParseUrl } from "./base-url";
+import { findExistingPersonalOrg } from "./personal-org-provisioning";
 import {
 	getAuthConfig as getAuthConfigFromEnv,
 	getEnabledLoginProviderConfigs,
@@ -219,6 +220,42 @@ export async function createAuth(env: Env, request?: Request) {
 				allowUserToCreateOrganization: true,
 				creatorRole: "owner",
 				organizationHooks: {
+					// If a user manually creates a private org while they have no
+					// personal-org marker yet, tag it as their personal one. Without
+					// this, `personal_org_for_user_id` only gets set by the
+					// auto-provisioner in `databaseHooks.user.create.after` — anyone
+					// whose auto-provisioned org was deleted, or who manually created
+					// their first org via the UI, ends up with NULL `workerOrgIds`
+					// in the device-worker auth middleware (index.ts:602-607), so
+					// their Lobu bridge gets a 403 on every poll.
+					afterCreateOrganization: async ({
+						organization: org,
+						user,
+					}) => {
+						try {
+							if (org.visibility !== "private") return;
+							const sql = getDb();
+							const existing = await findExistingPersonalOrg(
+								user.id,
+								sql,
+							);
+							if (existing) return;
+							await sql`
+								UPDATE "organization"
+								SET metadata = jsonb_set(
+									COALESCE(metadata::jsonb, '{}'::jsonb),
+									'{personal_org_for_user_id}',
+									to_jsonb(${user.id}::text)
+								)::text
+								WHERE id = ${org.id}
+							`;
+						} catch (err) {
+							console.error(
+								"[Auth] Failed to mark created org as personal:",
+								err,
+							);
+						}
+					},
 					afterAddMember: async ({ member, user, organization: org }) => {
 						try {
 							await ensureMemberEntity({

--- a/packages/server/src/auth/oauth/routes.ts
+++ b/packages/server/src/auth/oauth/routes.ts
@@ -13,6 +13,7 @@ import { getClientIP, getRateLimiter, RateLimitPresets } from '../../utils/rate-
 import { resolveBaseUrl, safeOrigin, safeParseUrl } from '../base-url';
 import { createAuth } from '../index';
 import { requireAuth } from '../middleware';
+import { findExistingPersonalOrg } from '../personal-org-provisioning';
 import { OAuthProvider } from './provider';
 import { DEFAULT_SCOPES_STRING, filterScopeByRole } from './scopes';
 import type { AuthorizationParams, OAuthClientMetadata, TokenRequestParams } from './types';
@@ -191,7 +192,7 @@ async function resolveOrganizationForGrant(params: {
   }
 
   const memberships = await sql`
-    SELECT m."organizationId" as organization_id, o.name, o.slug
+    SELECT m."organizationId" as organization_id, m.role, o.name, o.slug
     FROM "member" m
     JOIN "organization" o ON o.id = m."organizationId"
     WHERE m."userId" = ${userId}
@@ -203,6 +204,25 @@ async function resolveOrganizationForGrant(params: {
       error: createOAuthError('access_denied', 'No organization membership found for MCP scopes'),
       status: 403,
     };
+  }
+
+  // If the user has a personal-org marker (`organization.metadata.personal_org_for_user_id`),
+  // bind device tokens to it without prompting. This matches what the
+  // device-worker auth middleware in `index.ts:602-607` resolves to anyway —
+  // skipping the consent picker just avoids a step the user almost always
+  // answers the same way. They can still bind to a different org by passing
+  // an explicit `organization_id` (UI path) or a `resource` slug (API path).
+  const personalOrg = await findExistingPersonalOrg(userId, sql);
+  if (personalOrg) {
+    const personalMember = memberships.find(
+      (m) => m.organization_id === personalOrg.id
+    );
+    if (personalMember) {
+      return {
+        organizationId: personalOrg.id,
+        memberRole: (personalMember.role as string | null) ?? null,
+      };
+    }
   }
 
   return {


### PR DESCRIPTION
## Summary

Two gaps in the personal-org-marker plumbing that both surface as `No organization in scope for this worker token` (403) on the device-worker auth middleware (`packages/server/src/index.ts:602-607`):

1. **Manual org creation didn't set the marker.** The auto-provisioner in `databaseHooks.user.create.after` (PR #352, 2026-04-26) is the only writer today. Any user who deletes their auto-provisioned personal org and creates a new one via the UI — or signed up before the provisioner shipped — never gets a marker. New `afterCreateOrganization` hook stamps the marker on the first private org created by a user who has no existing marker.

2. **The device-code consent flow always prompted for org selection** when no `resource` slug and no explicit `organization_id` were provided. For users with a personal-org marker the answer is almost always "use my personal org" — exactly what the worker-auth middleware resolves to anyway. `resolveOrganizationForGrant` now returns the personal org directly in that case. Users who want to bind a token to a different org still can, via either `organization_id` (UI) or `resource` slug (API).

Together these prevent the regression class we hit debugging the Mac bridge against the `buremba` org: org owned by a pre-provisioner user, no marker, no token binding → 403 on every poll → bridge claims nothing.

## Why not a one-shot migration

The historical inconsistency was already patched in prod by hand for the 9 affected users with single-private-owner orgs. The fix is forward-looking — anyone who creates an org from now on gets the marker the first time it matters.

## Test plan

- [ ] Sign up a fresh user (auto-provisioner path) — personal org created with marker (existing behavior)
- [ ] As an existing user with no marker, create a private org via the UI — `afterCreateOrganization` stamps the marker on that org
- [ ] Same user, create a second private org — marker stays on the first one (`findExistingPersonalOrg` short-circuits)
- [ ] Create a public org — marker NOT set (visibility check)
- [ ] Device-code consent flow for a user with a personal-org marker — no org-selection prompt; token binds to the personal org
- [ ] Device-code consent flow for a user with no marker but multiple memberships — prompt still shown (existing behavior)
- [ ] Device-code consent flow with `resource=<other-org-slug>` — overrides personal-org default (existing behavior)