### PR TITLE
ops(sentry): stop queue-noise capture + sample errors at 50% in prod

### DIFF
--- a/packages/server/src/gateway/infrastructure/queue/runs-queue.ts
+++ b/packages/server/src/gateway/infrastructure/queue/runs-queue.ts
@@ -49,27 +49,6 @@ const STALE_SWEEP_INTERVAL_MS = 30_000;
 /** Max time to wait for in-flight handlers during graceful stop. */
 const SHUTDOWN_DRAIN_MS = 30_000;
 
-/**
- * Sentry alert dedupe. Repeated heartbeat-failure / DLQ alerts for the same
- * runs.id within DEDUPE_WINDOW_MS collapse to a single captureMessage call
- * so a single bad row doesn't spam Sentry.
- */
-const SENTRY_DEDUPE_WINDOW_MS = 5 * 60 * 1000;
-const sentryAlertedRuns = new Map<number, number>();
-
-function shouldEmitSentryAlert(runId: number): boolean {
-  const now = Date.now();
-  const last = sentryAlertedRuns.get(runId);
-  if (last && now - last < SENTRY_DEDUPE_WINDOW_MS) return false;
-  sentryAlertedRuns.set(runId, now);
-  if (sentryAlertedRuns.size > 1000) {
-    for (const [id, ts] of sentryAlertedRuns) {
-      if (now - ts > SENTRY_DEDUPE_WINDOW_MS) sentryAlertedRuns.delete(id);
-    }
-  }
-  return true;
-}
-
 function queueBreadcrumb(
   category: string,
   message: string,
@@ -699,19 +678,14 @@ export class RunsQueue implements IMessageQueue {
         AND status = 'claimed'
         AND claimed_by = ${this.claimedBy}
     `;
+    // Logged as a warning; not emitted to Sentry. Per-run terminal failures
+    // are high-volume and low-actionable (each is a separate event in Sentry,
+    // burning the org quota with no per-incident signal beyond the log).
+    // The aggregate "we have failed runs" signal belongs on a metric/dash,
+    // not in the error feed.
     logger.warn(
       `Run ${runId} failed after retries: ${message}`,
     );
-    if (shouldEmitSentryAlert(runId)) {
-      try {
-        Sentry.captureMessage(`Queue run failed after retries: ${runId}`, {
-          level: "warning",
-          extra: { runId, message },
-        });
-      } catch {
-        // ignore
-      }
-    }
   }
 
   private async scheduleRetry(

--- a/packages/server/src/instrument.ts
+++ b/packages/server/src/instrument.ts
@@ -29,6 +29,13 @@ if (dsn) {
     environment: process.env.ENVIRONMENT || 'production',
     release: process.env.SENTRY_RELEASE || process.env.APP_GIT_SHA || undefined,
     tracesSampleRate: isDev ? 1.0 : 0.1,
+    // Error events: 100% in dev, 50% in prod. The org quota was previously
+    // exhausted by background-job captureMessage spam (since removed — see
+    // runs-queue.ts); sampling at 0.5 buys ~2x quota headroom while still
+    // giving plenty of signal for new issues. A fingerprint-level beforeSend
+    // filter would be more precise but adds maintenance — bump back to 1.0
+    // here if the Sentry plan/quota gets raised.
+    sampleRate: isDev ? 1.0 : 0.5,
     // The NodeSystemError integration calls util.getSystemErrorMap(), which
     // some Node builds we run under (notably v24.x in our app image) don't
     // expose. The integration itself then throws inside the event processor


### PR DESCRIPTION
## Why

Followup to #701. Verified end-to-end that the new HTTP-error capture is wired correctly — but every event was being rejected at the Sentry ingest:

\`\`\`
HTTP/2 429
retry-after: 60
x-sentry-rate-limits: 60:default;error;security;attachment:organization:error_usage_exceeded
\`\`\`

The org-wide quota was exhausted. Dominant contributor: \`Queue run failed after retries: <runId>\` (LOBU-BACKEND-C, 300 events). Each distinct runId became its own Sentry issue and burned quota with no per-incident signal beyond the matching \`logger.warn\`.

## What

- Remove the \`Sentry.captureMessage\` call (and the now-unused \`shouldEmitSentryAlert\` dedupe helper) in \`runs-queue.ts\`. The \`logger.warn\` line stays — that's where the actionable signal belongs.
- Add \`sampleRate: 0.5\` in prod \`Sentry.init\` so the next noise spike has ~2x quota headroom. Dev stays at 1.0.

## Follow-up the user has to do manually

- Archive LOBU-BACKEND-C in the Sentry UI: https://lobu-ai.sentry.io/issues/LOBU-BACKEND-C/  
  (Sentry MCP is read-only — can't do this from here.)

## Test plan

- [x] \`bun run typecheck\` clean
- [x] Pre-commit (biome + tsc) green
- [ ] CI green
- [ ] After deploy: trigger a synthetic 500 (\`PATCH /api/me/devices/not-a-valid-uuid\`) and confirm it appears in Sentry (verifies both #701's capture + this PR's sampling let the event through)