### PR TITLE
feat(notifications): unify with events; per-user delivery via notification_targets

### DIFF
--- a/db/migrations/20260513200000_notifications_as_events.sql
+++ b/db/migrations/20260513200000_notifications_as_events.sql
@@ -1,0 +1,86 @@
+-- migrate:up
+
+-- Unify notifications with events.
+--
+-- A notification was a (org, user, title, body, type, resource_url) row in
+-- its own table with per-user `is_read`. Conceptually it's an event with a
+-- particular kind + per-user delivery / read-state. This migration turns
+-- every notification into:
+--   1. an event with semantic_type='notification' (org-wide visibility in
+--      the events stream — searchable, addressable, links into knowledge);
+--   2. a notification_targets row (event_id, user_id, delivered_at, read_at)
+--      so the inbox still scopes to the targeted user.
+--
+-- After this, "send to admins" inserts one event + N targets; "mark read"
+-- updates a target row; "unread count" counts target rows without read_at.
+-- Search across events naturally includes notifications, but a user's
+-- inbox is still private to them.
+
+CREATE TABLE public.notification_targets (
+    event_id bigint NOT NULL REFERENCES public.events(id) ON DELETE CASCADE,
+    user_id text NOT NULL,
+    delivered_at timestamp with time zone NOT NULL DEFAULT now(),
+    read_at timestamp with time zone,
+    PRIMARY KEY (event_id, user_id)
+);
+
+-- Fast inbox lookups: list a user's unread notifications, newest first.
+CREATE INDEX idx_notification_targets_user_unread
+    ON public.notification_targets (user_id, delivered_at DESC)
+    WHERE read_at IS NULL;
+
+-- All of a user's notifications, newest first (for read-list pagination).
+CREATE INDEX idx_notification_targets_user_all
+    ON public.notification_targets (user_id, delivered_at DESC);
+
+-- Backfill existing notifications. We keep 1:1 row mapping (one event per
+-- legacy notification) for safety — at scale the right model is "one event,
+-- many targets" but the old schema didn't capture that and we can't
+-- retroactively coalesce without an oracle.
+WITH legacy AS (
+    SELECT id, organization_id, user_id, type, title, body,
+           resource_type, resource_id, resource_url, is_read, created_at
+    FROM public.notifications
+    ORDER BY id ASC
+),
+inserted AS (
+    INSERT INTO public.events
+        (organization_id, title, payload_text, payload_type, semantic_type,
+         occurred_at, created_at, metadata, origin_id)
+    SELECT
+        l.organization_id,
+        l.title,
+        l.body,
+        'text',
+        'notification',
+        l.created_at,
+        l.created_at,
+        jsonb_build_object(
+            'notification_type', l.type,
+            'resource_type', l.resource_type,
+            'resource_id', l.resource_id,
+            'resource_url', l.resource_url,
+            'legacy_notification_id', l.id
+        ),
+        'notification:legacy:' || l.id::text
+    FROM legacy l
+    RETURNING id AS event_id, (metadata->>'legacy_notification_id')::bigint AS legacy_id
+)
+INSERT INTO public.notification_targets (event_id, user_id, delivered_at, read_at)
+SELECT
+    i.event_id,
+    l.user_id,
+    l.created_at,
+    CASE WHEN l.is_read THEN l.created_at ELSE NULL END
+FROM inserted i
+JOIN public.notifications l ON l.id = i.legacy_id;
+
+-- Drop the legacy table. All readers/writers go through the new service.
+DROP TABLE public.notifications;
+
+-- migrate:down
+
+-- One-way migration. Recovery is from backup; events created here stay
+-- (deleting them would also wipe their notification_targets via CASCADE).
+-- If you really need to roll back: re-create the table, copy notifications
+-- back out of events + notification_targets, drop the event rows.

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -1239,40 +1239,15 @@ CREATE TABLE public.namespace (
 );
 
 --
--- Name: notifications; Type: TABLE; Schema: public; Owner: -
+-- Name: notification_targets; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.notifications (
-    id bigint NOT NULL,
-    organization_id text NOT NULL,
+CREATE TABLE public.notification_targets (
+    event_id bigint NOT NULL,
     user_id text NOT NULL,
-    type text NOT NULL,
-    title text NOT NULL,
-    body text,
-    resource_type text,
-    resource_id text,
-    resource_url text,
-    is_read boolean DEFAULT false NOT NULL,
-    created_at timestamp with time zone DEFAULT now() NOT NULL,
-    CONSTRAINT notifications_type_check CHECK ((type = ANY (ARRAY['action_approval_needed'::text, 'connection_permission_request'::text, 'invitation_received'::text, 'generic'::text, 'agent_message'::text])))
+    delivered_at timestamp with time zone DEFAULT now() NOT NULL,
+    read_at timestamp with time zone
 );
-
---
--- Name: notifications_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.notifications_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
---
--- Name: notifications_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
---
-
-ALTER SEQUENCE public.notifications_id_seq OWNED BY public.notifications.id;
 
 --
 -- Name: oauth_authorization_codes; Type: TABLE; Schema: public; Owner: -
@@ -2121,12 +2096,6 @@ ALTER TABLE ONLY public.events ALTER COLUMN id SET DEFAULT nextval('public.conte
 ALTER TABLE ONLY public.feeds ALTER COLUMN id SET DEFAULT nextval('public.feeds_id_seq'::regclass);
 
 --
--- Name: notifications id; Type: DEFAULT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.notifications ALTER COLUMN id SET DEFAULT nextval('public.notifications_id_seq'::regclass);
-
---
 -- Name: personal_access_tokens id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -2537,11 +2506,11 @@ ALTER TABLE ONLY public.namespace
     ADD CONSTRAINT namespace_pkey PRIMARY KEY (slug);
 
 --
--- Name: notifications notifications_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: notification_targets notification_targets_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.notifications
-    ADD CONSTRAINT notifications_pkey PRIMARY KEY (id);
+ALTER TABLE ONLY public.notification_targets
+    ADD CONSTRAINT notification_targets_pkey PRIMARY KEY (event_id, user_id);
 
 --
 -- Name: oauth_authorization_codes oauth_authorization_codes_pkey; Type: CONSTRAINT; Schema: public; Owner: -
@@ -3544,16 +3513,16 @@ CREATE INDEX idx_latest_ec_source ON public.latest_event_classifications USING b
 CREATE INDEX idx_latest_ec_values_gin ON public.latest_event_classifications USING gin ("values");
 
 --
--- Name: idx_notifications_listing; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_notification_targets_user_all; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX idx_notifications_listing ON public.notifications USING btree (organization_id, user_id, created_at DESC);
+CREATE INDEX idx_notification_targets_user_all ON public.notification_targets USING btree (user_id, delivered_at DESC);
 
 --
--- Name: idx_notifications_unread; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_notification_targets_user_unread; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX idx_notifications_unread ON public.notifications USING btree (organization_id, user_id, is_read, created_at DESC);
+CREATE INDEX idx_notification_targets_user_unread ON public.notification_targets USING btree (user_id, delivered_at DESC) WHERE (read_at IS NULL);
 
 --
 -- Name: idx_runs_active_auth_per_profile; Type: INDEX; Schema: public; Owner: -
@@ -4569,6 +4538,13 @@ ALTER TABLE ONLY public.member
     ADD CONSTRAINT "member_userId_fkey" FOREIGN KEY ("userId") REFERENCES public."user"(id) ON DELETE CASCADE;
 
 --
+-- Name: notification_targets notification_targets_event_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.notification_targets
+    ADD CONSTRAINT notification_targets_event_id_fkey FOREIGN KEY (event_id) REFERENCES public.events(id) ON DELETE CASCADE;
+
+--
 -- Name: oauth_authorization_codes oauth_authorization_codes_client_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -4871,4 +4847,5 @@ INSERT INTO public.schema_migrations (version) VALUES
     ('20260510220000'),
     ('20260512000000'),
     ('20260512131703'),
-    ('20260513000000');
+    ('20260513000000'),
+    ('20260513200000');

--- a/packages/server/src/auth/__tests__/oauth-utils.test.ts
+++ b/packages/server/src/auth/__tests__/oauth-utils.test.ts
@@ -5,7 +5,7 @@
  * validation without requiring a database connection.
  */
 
-import { describe, expect, test } from "bun:test";
+import { describe, expect, test } from "vitest";
 import {
   generatePAT,
   generateUserCode,

--- a/packages/server/src/db/embedded-schema-patches.ts
+++ b/packages/server/src/db/embedded-schema-patches.ts
@@ -290,4 +290,69 @@ export const EMBEDDED_SCHEMA_PATCHES: EmbeddedSchemaPatch[] = [
       await sql.unsafe(`DROP TABLE IF EXISTS public.device_worker_org_grants`);
     },
   },
+  {
+    // Mirrors db/migrations/20260513200000_notifications_as_events.sql.
+    // Idempotent: only migrates rows from `notifications` if the table still
+    // exists; subsequent boots no-op.
+    id: 'notifications-as-events',
+    apply: async (sql) => {
+      await sql.unsafe(`
+        CREATE TABLE IF NOT EXISTS public.notification_targets (
+          event_id bigint NOT NULL REFERENCES public.events(id) ON DELETE CASCADE,
+          user_id text NOT NULL,
+          delivered_at timestamp with time zone NOT NULL DEFAULT now(),
+          read_at timestamp with time zone,
+          PRIMARY KEY (event_id, user_id)
+        )
+      `);
+      await sql.unsafe(`
+        CREATE INDEX IF NOT EXISTS idx_notification_targets_user_unread
+          ON public.notification_targets (user_id, delivered_at DESC)
+          WHERE read_at IS NULL
+      `);
+      await sql.unsafe(`
+        CREATE INDEX IF NOT EXISTS idx_notification_targets_user_all
+          ON public.notification_targets (user_id, delivered_at DESC)
+      `);
+      // Backfill from the legacy table if it still exists.
+      const legacyExists = (await sql.unsafe(
+        `SELECT to_regclass('public.notifications') IS NOT NULL AS exists`
+      )) as Array<{ exists: boolean }>;
+      if (legacyExists[0]?.exists) {
+        await sql.unsafe(`
+          WITH legacy AS (
+            SELECT id, organization_id, user_id, type, title, body,
+                   resource_type, resource_id, resource_url, is_read, created_at
+            FROM public.notifications
+            ORDER BY id ASC
+          ),
+          inserted AS (
+            INSERT INTO public.events
+              (organization_id, title, payload_text, payload_type, semantic_type,
+               occurred_at, created_at, metadata, origin_id)
+            SELECT
+              l.organization_id, l.title, l.body, 'text', 'notification',
+              l.created_at, l.created_at,
+              jsonb_build_object(
+                'notification_type', l.type,
+                'resource_type', l.resource_type,
+                'resource_id', l.resource_id,
+                'resource_url', l.resource_url,
+                'legacy_notification_id', l.id
+              ),
+              'notification:legacy:' || l.id::text
+            FROM legacy l
+            RETURNING id AS event_id,
+                      (metadata->>'legacy_notification_id')::bigint AS legacy_id
+          )
+          INSERT INTO public.notification_targets (event_id, user_id, delivered_at, read_at)
+          SELECT i.event_id, l.user_id, l.created_at,
+                 CASE WHEN l.is_read THEN l.created_at ELSE NULL END
+          FROM inserted i
+          JOIN public.notifications l ON l.id = i.legacy_id
+        `);
+        await sql.unsafe(`DROP TABLE public.notifications`);
+      }
+    },
+  },
 ];

--- a/packages/server/src/notifications/service.ts
+++ b/packages/server/src/notifications/service.ts
@@ -118,6 +118,18 @@ async function deliverToBotConnections(
   }
 }
 
+/**
+ * Notifications are events + per-user targets.
+ *
+ * The `events` table stores the notification's content (org-wide visibility,
+ * searchable, addressable from the knowledge view); `notification_targets`
+ * scopes inbox / read-state to the addressed users. "Send to admins" inserts
+ * ONE event + N targets; "mark read" updates a target row; "unread count"
+ * counts target rows without `read_at`.
+ *
+ * The legacy public.notifications table was migrated by
+ * 20260513200000_notifications_as_events.sql and dropped.
+ */
 export async function createNotificationForUsers(
   userIds: string[],
   params: Omit<CreateNotificationParams, 'userId'>
@@ -125,46 +137,41 @@ export async function createNotificationForUsers(
   if (userIds.length === 0) return;
   const sql = getDb();
 
-  const values = userIds.map((uid) => ({
-    organization_id: params.organizationId,
-    user_id: uid,
-    type: params.type,
-    title: params.title,
-    body: params.body ?? null,
-    resource_type: params.resourceType ?? null,
-    resource_id: params.resourceId ?? null,
-    resource_url: params.resourceUrl ?? null,
-  }));
+  await sql.begin(async (tx) => {
+    const inserted = (await tx`
+      INSERT INTO events
+        (organization_id, title, payload_text, payload_type, semantic_type,
+         occurred_at, metadata)
+      VALUES (
+        ${params.organizationId},
+        ${params.title},
+        ${params.body ?? null},
+        'text',
+        'notification',
+        now(),
+        ${sql.json({
+          notification_type: params.type,
+          resource_type: params.resourceType ?? null,
+          resource_id: params.resourceId ?? null,
+          resource_url: params.resourceUrl ?? null,
+        })}
+      )
+      RETURNING id
+    `) as unknown as Array<{ id: number }>;
+    const eventId = inserted[0]?.id;
+    if (!eventId) return;
 
-  // Batch insert using unnest for efficiency
-  const orgIds = values.map((v) => v.organization_id);
-  const uids = values.map((v) => v.user_id);
-  const types = values.map((v) => v.type);
-  const titles = values.map((v) => v.title);
-  const bodies = values.map((v) => v.body);
-  const resourceTypes = values.map((v) => v.resource_type);
-  const resourceIds = values.map((v) => v.resource_id);
-  const resourceUrls = values.map((v) => v.resource_url);
-
-  await sql`
-    INSERT INTO notifications (organization_id, user_id, type, title, body, resource_type, resource_id, resource_url)
-    SELECT * FROM unnest(
-      ${pgTextArray(orgIds)}::text[],
-      ${pgTextArray(uids)}::text[],
-      ${pgTextArray(types)}::text[],
-      ${pgTextArray(titles)}::text[],
-      ${pgTextArray(bodies)}::text[],
-      ${pgTextArray(resourceTypes)}::text[],
-      ${pgTextArray(resourceIds)}::text[],
-      ${pgTextArray(resourceUrls)}::text[]
-    )
-  `;
+    await tx`
+      INSERT INTO notification_targets (event_id, user_id)
+      SELECT ${eventId}, uid
+      FROM unnest(${pgTextArray(userIds)}::text[]) AS u(uid)
+      ON CONFLICT DO NOTHING
+    `;
+  });
 
   // Deliver to bot connections (fire-and-forget). The bot delivery targets
   // the org's connection default channels and is identical for every user in
-  // this call, so fan it out once — not once per user (which previously
-  // re-fetched connections/targets, re-minted the service token, and posted
-  // N duplicate messages to the same channel).
+  // this call, so fan it out once — not once per user.
   deliverToBotConnections(params).catch((err) =>
     logger.warn({ err }, '[Notifications] Failed to deliver to bot connections')
   );
@@ -182,16 +189,28 @@ export async function listNotifications(opts: {
   const cursor = opts.cursor ?? null;
   const unreadOnly = opts.unreadOnly ?? false;
 
-  const rows = await sql<NotificationRow>`
-    SELECT *
-    FROM notifications
-    WHERE organization_id = ${opts.organizationId}
-      AND user_id = ${opts.userId}
-      AND (${cursor}::bigint IS NULL OR id < ${cursor})
-      AND (${!unreadOnly} OR is_read = false)
-    ORDER BY id DESC
+  const rows = (await sql`
+    SELECT
+      e.id,
+      e.organization_id,
+      t.user_id,
+      COALESCE(e.metadata->>'notification_type', 'generic') AS type,
+      e.title,
+      e.payload_text AS body,
+      e.metadata->>'resource_type' AS resource_type,
+      e.metadata->>'resource_id' AS resource_id,
+      e.metadata->>'resource_url' AS resource_url,
+      (t.read_at IS NOT NULL) AS is_read,
+      t.delivered_at AS created_at
+    FROM notification_targets t
+    JOIN events e ON e.id = t.event_id
+    WHERE e.organization_id = ${opts.organizationId}
+      AND t.user_id = ${opts.userId}
+      AND (${cursor}::bigint IS NULL OR e.id < ${cursor})
+      AND (${!unreadOnly} OR t.read_at IS NULL)
+    ORDER BY t.delivered_at DESC, e.id DESC
     LIMIT ${limit + 1}
-  `;
+  `) as unknown as NotificationRow[];
 
   const hasMore = rows.length > limit;
   const notifications = hasMore ? rows.slice(0, limit) : rows;
@@ -202,13 +221,14 @@ export async function listNotifications(opts: {
 
 export async function getUnreadCount(organizationId: string, userId: string): Promise<number> {
   const sql = getDb();
-  const rows = await sql<{ count: number }>`
+  const rows = (await sql`
     SELECT COUNT(*)::int AS count
-    FROM notifications
-    WHERE organization_id = ${organizationId}
-      AND user_id = ${userId}
-      AND is_read = false
-  `;
+    FROM notification_targets t
+    JOIN events e ON e.id = t.event_id
+    WHERE e.organization_id = ${organizationId}
+      AND t.user_id = ${userId}
+      AND t.read_at IS NULL
+  `) as unknown as Array<{ count: number }>;
   return rows[0].count;
 }
 
@@ -218,43 +238,54 @@ export async function markAsRead(
   notificationId: number
 ): Promise<boolean> {
   const sql = getDb();
-  const rows = await sql`
-    UPDATE notifications
-    SET is_read = true
-    WHERE id = ${notificationId}
-      AND organization_id = ${organizationId}
-      AND user_id = ${userId}
-      AND is_read = false
-    RETURNING id
-  `;
+  const rows = (await sql`
+    UPDATE notification_targets t
+    SET read_at = now()
+    FROM events e
+    WHERE t.event_id = e.id
+      AND e.id = ${notificationId}
+      AND e.organization_id = ${organizationId}
+      AND t.user_id = ${userId}
+      AND t.read_at IS NULL
+    RETURNING t.event_id
+  `) as unknown as Array<{ event_id: number }>;
   return rows.length > 0;
 }
 
 export async function markAllAsRead(organizationId: string, userId: string): Promise<number> {
   const sql = getDb();
-  const rows = await sql`
-    UPDATE notifications
-    SET is_read = true
-    WHERE organization_id = ${organizationId}
-      AND user_id = ${userId}
-      AND is_read = false
-    RETURNING id
-  `;
+  const rows = (await sql`
+    UPDATE notification_targets t
+    SET read_at = now()
+    FROM events e
+    WHERE t.event_id = e.id
+      AND e.organization_id = ${organizationId}
+      AND t.user_id = ${userId}
+      AND t.read_at IS NULL
+    RETURNING t.event_id
+  `) as unknown as Array<{ event_id: number }>;
   return rows.length;
 }
 
+/**
+ * "Deleting" a notification is a per-user concern — the event stays in the
+ * org-wide knowledge stream. We just drop the target row so it disappears
+ * from this user's inbox.
+ */
 export async function deleteNotification(
   organizationId: string,
   userId: string,
   notificationId: number
 ): Promise<boolean> {
   const sql = getDb();
-  const rows = await sql`
-    DELETE FROM notifications
-    WHERE id = ${notificationId}
-      AND organization_id = ${organizationId}
-      AND user_id = ${userId}
-    RETURNING id
-  `;
+  const rows = (await sql`
+    DELETE FROM notification_targets t
+    USING events e
+    WHERE t.event_id = e.id
+      AND e.id = ${notificationId}
+      AND e.organization_id = ${organizationId}
+      AND t.user_id = ${userId}
+    RETURNING t.event_id
+  `) as unknown as Array<{ event_id: number }>;
   return rows.length > 0;
 }

--- a/packages/server/src/notifications/service.ts
+++ b/packages/server/src/notifications/service.ts
@@ -208,7 +208,11 @@ export async function listNotifications(opts: {
       AND t.user_id = ${opts.userId}
       AND (${cursor}::bigint IS NULL OR e.id < ${cursor})
       AND (${!unreadOnly} OR t.read_at IS NULL)
-    ORDER BY t.delivered_at DESC, e.id DESC
+    -- Order strictly by e.id so the (e.id < cursor) keyset pagination is
+    -- consistent. delivered_at would tie-break for concurrent inserts but
+    -- doesn't match the cursor — using it as the primary key risked
+    -- skipping notifications when delivered_at and e.id disagreed.
+    ORDER BY e.id DESC
     LIMIT ${limit + 1}
   `) as unknown as NotificationRow[];
 


### PR DESCRIPTION
## Summary

Notifications used to be their own table with per-user `is_read`. They're now events with `semantic_type='notification'` + a thin `notification_targets(event_id, user_id, delivered_at, read_at)` table for per-user delivery / read state.

- The **content** lives in `events`: searchable, addressable, linkable from `/<slug>/knowledge?event=<id>`. Watchers/agents that already emit events get a notification surface for free.
- The **inbox** is just `events ⋈ notification_targets WHERE user_id = me`. Scoping is preserved: org membership + matching `user_id` are still required to read/write your inbox; another org member never sees your inbox rows even though they can see the underlying event in the org-wide stream.
- "Send to admins" now inserts ONE event + N target rows in a transaction (instead of N duplicated content rows).
- "Delete a notification" drops the user's target row only — the event stays.

## Migration

`20260513200000_notifications_as_events.sql` backfills every existing notification into:

1. An event row (semantic_type=notification; metadata holds notification_type + resource_url + the legacy id for traceability).
2. A notification_targets row (delivered_at = original created_at, read_at = original is_read ? created_at : null).

Then drops `public.notifications`. One-way migration — recovery is from backup.

Embedded-schema patch mirrors this for PGlite dev DBs (no-op when the legacy table is absent).

## API compatibility

`NotificationRow` shape is preserved — `id` is now the event id (still bigint), `is_read` is derived from `t.read_at IS NOT NULL`. REST endpoints (`/api/<slug>/notifications/*`), the Mac client (`LobuNotification`), and the web inbox UI all see the same wire shape. Zero client-side changes needed.

## Test plan

- [x] `dbmate up` against a fresh Postgres applies migration cleanly + dumps stable schema.
- [x] `make build-packages` clean, `bun run typecheck` clean.
- [ ] Send a notification on a fresh local server → list it → mark read → unread count goes from 1 → 0.
- [ ] Same flow on a DB with legacy `notifications` rows → backfill preserves title, body, user assignment, is_read state.
- [ ] Verify another org member can't see the inbox row (cross-user privacy).
- [ ] Verify the underlying event is visible in the org-wide knowledge stream for everyone (search + /knowledge).

## Follow-ups (separate PRs)

- Mac/web click handler: when a notification has no `resource_url`, deep-link to `/<slug>/knowledge?event=<id>` (already partially done in #706's Mac fallback).
- `events.recipient_user_id` for genuinely private events (auth-token-expired, billing) where even the org-wide stream shouldn't surface them. Today's model treats those the same as any event; future PR can add a visibility filter when the use case crystallizes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Moved notification storage to an events-backed model with per-user delivery records, backfilled legacy notifications, and removed the old notifications table; notification actions (create, list, unread count, mark-as-read, delete) now operate on the new model while preserving behavior.
* **Chore**
  * Added a boot-time, one-way migration to ensure data is migrated on startup.
  * Updated web submodule pointer.
* **Tests**
  * Switched an OAuth test to a new test runner.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lobu-ai/lobu/pull/707)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->