### PR TITLE
feat(mac+server): WhatsApp voice notes — ingest + transcribe

### DIFF
--- a/apps/mac/Lobu/LobuClient.swift
+++ b/apps/mac/Lobu/LobuClient.swift
@@ -141,6 +141,38 @@ struct WorkerStreamItem: Encodable {
     let occurred_at: String
     let semantic_type: String
     let metadata: [String: AnyEncodable]
+    let attachments: [WorkerStreamAttachment]?
+
+    init(
+        id: String,
+        title: String?,
+        payload_text: String,
+        occurred_at: String,
+        semantic_type: String,
+        metadata: [String: AnyEncodable],
+        attachments: [WorkerStreamAttachment]? = nil
+    ) {
+        self.id = id
+        self.title = title
+        self.payload_text = payload_text
+        self.occurred_at = occurred_at
+        self.semantic_type = semantic_type
+        self.metadata = metadata
+        self.attachments = attachments
+    }
+}
+
+/// Connector-emitted file blob. The gateway side decodes `data` (base64) into
+/// the ArtifactStore and replaces the bytes with `{artifact_id, download_url}`
+/// before the row hits `events.attachments`. Audio attachments additionally
+/// trigger background transcription via TranscriptionService.
+struct WorkerStreamAttachment: Encodable {
+    let kind: String
+    let filename: String
+    let mime_type: String
+    let data: String
+    let size_bytes: Int
+    let duration_ms: Int?
 }
 
 struct AnyEncodable: Encodable {

--- a/apps/mac/Lobu/WhatsAppLocalSyncService.swift
+++ b/apps/mac/Lobu/WhatsAppLocalSyncService.swift
@@ -42,9 +42,24 @@ enum WhatsAppLocalSyncService {
     /// Apple Core Data timestamps are seconds since 2001-01-01 UTC.
     private static let macEpochOffset: Double = 978307200
 
+    /// Hard cap on a single voice note we'll inline into the stream payload.
+    /// WhatsApp voice notes ~50–200KB for a 30-60s clip; anything over this is
+    /// almost certainly not a voice note and we skip it to keep the JSON body
+    /// bounded. The check is also a guard against arbitrary file reads (e.g.
+    /// a malicious / corrupt `ZMEDIALOCALPATH` value pointing at a large file).
+    private static let maxAudioAttachmentBytes = 2 * 1024 * 1024
+
     static func sourceDatabaseURL() -> URL {
         URL(fileURLWithPath: NSHomeDirectory())
             .appendingPathComponent("Library/Group Containers/group.net.whatsapp.WhatsApp.shared/ChatStorage.sqlite")
+    }
+
+    /// `ZWAMEDIAITEM.ZMEDIALOCALPATH` is relative to the `Message/` directory
+    /// inside the WhatsApp Group Container. Resolves to e.g.
+    /// `~/Library/Group Containers/group.net.whatsapp.WhatsApp.shared/Message/Media/<jid>/<id>.opus`.
+    private static func mediaBaseURL() -> URL {
+        URL(fileURLWithPath: NSHomeDirectory())
+            .appendingPathComponent("Library/Group Containers/group.net.whatsapp.WhatsApp.shared/Message")
     }
 
     /// True if the WhatsApp Desktop archive is on disk and openable. The bridge
@@ -137,7 +152,9 @@ enum WhatsAppLocalSyncService {
             let toJID = cString(stmt, 3)
             let isFromMe = sqlite3_column_int(stmt, 4) != 0
             let msgType = Int(sqlite3_column_int(stmt, 5))
-            let groupEvent = Int(sqlite3_column_int(stmt, 6))
+            // Column 6 (ZGROUPEVENTTYPE) is selected so the SELECT shape stays
+            // stable across schemas, but it's no longer a system-event signal
+            // — see the `isSystemEvent` line below.
             let stanzaId = cString(stmt, 7)
             let chatJID = cString(stmt, 8)
             let partnerName = cString(stmt, 9)
@@ -161,7 +178,13 @@ enum WhatsAppLocalSyncService {
             if chatFilter == "group" && !isGroup { continue }
 
             let mediaType = mediaTypeName(forZMessageType: msgType)
-            let isSystemEvent = msgType == 6 || groupEvent != 0
+            // Only ZMESSAGETYPE 6 is a true system/info message ("Alice joined",
+            // "Bob changed the photo"). ZGROUPEVENTTYPE is non-zero on plenty
+            // of non-system rows in newer schemas (media messages in groups
+            // tag it with the membership-event slot), so `groupEvent != 0`
+            // alone was misclassifying every group media message as a system
+            // event and wiping the placeholder back to `[system event]`.
+            let isSystemEvent = msgType == 6
             let occurredAt = Date(timeIntervalSince1970: msgDate + macEpochOffset)
 
             // Sender resolution by chat shape:
@@ -218,6 +241,13 @@ enum WhatsAppLocalSyncService {
             if let mediaPath { metadata["media_local_path"] = AnyEncodable(mediaPath) }
             if isSystemEvent { metadata["is_system_event"] = AnyEncodable(true) }
 
+            // Audio-only attachment ingest. Other media types still get a
+            // labeled placeholder ([image], [video], etc.) but we don't ship
+            // their bytes — non-audio is a separate feature.
+            let attachments: [WorkerStreamAttachment]? = (mediaType == "audio")
+                ? readAudioAttachment(relativePath: mediaPath).map { [$0] }
+                : nil
+
             items.append(
                 WorkerStreamItem(
                     id: originId,
@@ -228,7 +258,8 @@ enum WhatsAppLocalSyncService {
                     // definition's feeds_schema; the gateway's
                     // validateConnectorEventSemanticType drops events that don't.
                     semantic_type: "message",
-                    metadata: metadata
+                    metadata: metadata,
+                    attachments: attachments
                 )
             )
         }
@@ -313,9 +344,14 @@ enum WhatsAppLocalSyncService {
     private static func makePayloadText(text: String?, msgType: Int, mediaTitle: String?, isSystem: Bool) -> String {
         if let text, !text.isEmpty { return text }
         if let mediaTitle { return mediaTitle }
+        // Media-type label wins over the system-event fallback so a media row
+        // never collapses to `[system event]`. The transcription pipeline
+        // later replaces this placeholder for audio.
+        if let kind = mediaTypeName(forZMessageType: msgType) {
+            return kind == "audio" ? "[voice note]" : "[\(kind)]"
+        }
         if isSystem { return "[system event]" }
-        guard let kind = mediaTypeName(forZMessageType: msgType) else { return "" }
-        return "[\(kind)]"
+        return ""
     }
 
     private static func makeTitle(
@@ -330,6 +366,48 @@ enum WhatsAppLocalSyncService {
         if isFromMe { return "→ \(chatLabel)" }
         if isGroup, let sender = pushName { return "\(chatLabel): \(sender)" }
         return chatLabel
+    }
+
+    /// Resolve a WhatsApp Desktop voice-note path on disk and read it as a
+    /// base64-encoded attachment. Returns nil for missing files (WhatsApp
+    /// Desktop downloads media on-demand — a row without a played-back voice
+    /// note has no file at the path), oversized files, or read errors. Any
+    /// failure is silent: voice-note ingest is best-effort and never blocks
+    /// the sync's text-message ingest.
+    private static func readAudioAttachment(relativePath: String?) -> WorkerStreamAttachment? {
+        guard let relativePath, !relativePath.isEmpty else { return nil }
+        let fm = FileManager.default
+        let absoluteURL = mediaBaseURL().appendingPathComponent(relativePath)
+        guard fm.fileExists(atPath: absoluteURL.path) else { return nil }
+        let attrs = try? fm.attributesOfItem(atPath: absoluteURL.path)
+        let size = (attrs?[.size] as? NSNumber)?.intValue ?? 0
+        if size <= 0 || size > maxAudioAttachmentBytes { return nil }
+        guard let data = try? Data(contentsOf: absoluteURL) else { return nil }
+        let filename = absoluteURL.lastPathComponent
+        let mime = mimeTypeForExtension(absoluteURL.pathExtension.lowercased())
+        return WorkerStreamAttachment(
+            kind: "audio",
+            filename: filename,
+            mime_type: mime,
+            data: data.base64EncodedString(),
+            size_bytes: size,
+            duration_ms: nil
+        )
+    }
+
+    private static func mimeTypeForExtension(_ ext: String) -> String {
+        // WhatsApp voice notes ship as Opus in an OGG container (.opus or
+        // .ogg). Other audio attachments may be m4a or wav. Fall back to
+        // application/octet-stream so the gateway still stores them.
+        switch ext {
+        case "opus": return "audio/opus"
+        case "ogg": return "audio/ogg"
+        case "m4a": return "audio/m4a"
+        case "mp4": return "audio/mp4"
+        case "mp3": return "audio/mpeg"
+        case "wav": return "audio/wav"
+        default: return "application/octet-stream"
+        }
     }
 
     private static func extractPhoneFromJID(_ jid: String) -> String? {

--- a/apps/mac/Lobu/WhatsAppLocalSyncService.swift
+++ b/apps/mac/Lobu/WhatsAppLocalSyncService.swift
@@ -376,8 +376,20 @@ enum WhatsAppLocalSyncService {
     /// the sync's text-message ingest.
     private static func readAudioAttachment(relativePath: String?) -> WorkerStreamAttachment? {
         guard let relativePath, !relativePath.isEmpty else { return nil }
+        // Reject absolute paths up front — `appendingPathComponent` on a `/`
+        // -prefixed string still ends up at the root, not under mediaBaseURL.
+        guard !relativePath.hasPrefix("/") else { return nil }
         let fm = FileManager.default
-        let absoluteURL = mediaBaseURL().appendingPathComponent(relativePath)
+        // Canonicalize the media root once, then build the candidate and
+        // verify by-prefix containment. `..`, symlink escapes, and any other
+        // path-traversal trick on the (untrusted) ZMEDIALOCALPATH string land
+        // outside the prefix and get dropped.
+        let baseURL = mediaBaseURL().resolvingSymlinksInPath().standardizedFileURL
+        let absoluteURL = baseURL
+            .appendingPathComponent(relativePath)
+            .resolvingSymlinksInPath()
+            .standardizedFileURL
+        guard absoluteURL.path.hasPrefix(baseURL.path + "/") else { return nil }
         guard fm.fileExists(atPath: absoluteURL.path) else { return nil }
         let attrs = try? fm.attributesOfItem(atPath: absoluteURL.path)
         let size = (attrs?[.size] as? NSNumber)?.intValue ?? 0

--- a/packages/server/src/utils/inline-attachments.ts
+++ b/packages/server/src/utils/inline-attachments.ts
@@ -27,6 +27,15 @@ import { getConfiguredPublicOrigin } from "./public-origin";
 import { insertEvent } from "./insert-event";
 import logger from "./logger";
 
+/**
+ * Hard cap on a single decoded attachment we'll publish. Server-side guard so
+ * a compromised or buggy worker can't force unbounded memory + artifact-store
+ * writes. Matches the Mac bridge's client-side 2MB cap for voice notes; if a
+ * future connector legitimately needs to ship something larger, push it
+ * through a multipart upload endpoint instead of inline base64.
+ */
+const MAX_INLINE_ATTACHMENT_BYTES = 2 * 1024 * 1024;
+
 interface InlineAttachment {
   kind?: string;
   filename?: string;
@@ -119,6 +128,17 @@ export async function materializeInlineAttachments<T extends StreamItemLike>(
         logger.warn(
           { item_id: item.id },
           "[inline-attachments] base64 decoded to 0 bytes — dropping attachment"
+        );
+        continue;
+      }
+      if (buffer.length > MAX_INLINE_ATTACHMENT_BYTES) {
+        logger.warn(
+          {
+            item_id: item.id,
+            size_bytes: buffer.length,
+            cap: MAX_INLINE_ATTACHMENT_BYTES,
+          },
+          "[inline-attachments] attachment exceeds server cap — dropping attachment"
         );
         continue;
       }

--- a/packages/server/src/utils/inline-attachments.ts
+++ b/packages/server/src/utils/inline-attachments.ts
@@ -1,0 +1,341 @@
+/**
+ * Connector-emitted inline attachments → ArtifactStore + transcription.
+ *
+ * Connectors (today: the Mac bridge's whatsapp.local) ship binary attachments
+ * inline inside a stream batch:
+ *
+ *   { kind: 'audio', filename: 'AUD-…opus', mime_type: 'audio/opus',
+ *     data: '<base64 bytes>', size_bytes: 23456 }
+ *
+ * Before the row hits `events.attachments` we strip the bytes out — events
+ * are not a binary store — and put them in the ArtifactStore, then leave a
+ * lightweight reference behind:
+ *
+ *   { kind: 'audio', filename: '…', mime_type: '…', artifact_id: '<uuid>',
+ *     download_url: 'https://…/lobu/api/v1/files/<id>?token=…',
+ *     size_bytes: 23456 }
+ *
+ * Audio attachments additionally enqueue background transcription via
+ * TranscriptionService. On success a superseding event is written so the
+ * `current_event_records` view exposes the transcribed text. Failures are
+ * swallowed — the unsuperseded `[voice note]` placeholder remains usable.
+ */
+import { getDb } from "../db/client";
+import { getLobuCoreServices } from "../lobu/gateway";
+import { getConfiguredPublicOrigin } from "./public-origin";
+import { insertEvent } from "./insert-event";
+import logger from "./logger";
+
+interface InlineAttachment {
+  kind?: string;
+  filename?: string;
+  mime_type?: string;
+  data?: string;
+  size_bytes?: number;
+  duration_ms?: number | null;
+  [extra: string]: unknown;
+}
+
+interface MaterializedAttachment {
+  kind: string;
+  filename: string;
+  mime_type: string;
+  artifact_id: string;
+  download_url: string;
+  size_bytes: number;
+  duration_ms?: number | null;
+}
+
+export interface StreamItemLike {
+  id: string;
+  attachments?: unknown[];
+  metadata?: Record<string, unknown>;
+}
+
+/** Per-item record of audio attachments that the gateway should transcribe. */
+export interface AudioTranscriptionPending {
+  originId: string;
+  artifactId: string;
+  filename: string;
+  mimeType: string;
+}
+
+function publicGatewayUrl(): string {
+  const origin =
+    getConfiguredPublicOrigin() ||
+    `http://localhost:${process.env.PORT || "8787"}`;
+  return new URL("/lobu/", origin).toString().replace(/\/$/, "");
+}
+
+/**
+ * Walk a batch of stream items, replace any inline base64 `data` on
+ * attachments with an ArtifactStore reference, and return the rewritten items
+ * plus a list of audio attachments to transcribe after insert.
+ *
+ * Items without attachments pass through unchanged. Attachments missing
+ * `data` are also passed through (a connector may pre-publish and reference
+ * an existing artifact).
+ */
+export async function materializeInlineAttachments<T extends StreamItemLike>(
+  items: T[]
+): Promise<{ items: T[]; pendingTranscriptions: AudioTranscriptionPending[] }> {
+  const coreServices = getLobuCoreServices();
+  const artifactStore = coreServices?.getArtifactStore?.();
+  if (!artifactStore) {
+    return { items, pendingTranscriptions: [] };
+  }
+
+  const baseUrl = publicGatewayUrl();
+  const pendingTranscriptions: AudioTranscriptionPending[] = [];
+  const out: T[] = [];
+
+  for (const item of items) {
+    const attachments = item.attachments;
+    if (!Array.isArray(attachments) || attachments.length === 0) {
+      out.push(item);
+      continue;
+    }
+
+    const rewritten: unknown[] = [];
+    for (const raw of attachments) {
+      if (!raw || typeof raw !== "object") {
+        rewritten.push(raw);
+        continue;
+      }
+      const att = raw as InlineAttachment;
+      if (!att.data || typeof att.data !== "string") {
+        rewritten.push(att);
+        continue;
+      }
+      const filename = att.filename || "attachment";
+      const mime = att.mime_type || "application/octet-stream";
+      const kind = att.kind || inferKindFromMime(mime);
+      let buffer: Buffer;
+      try {
+        buffer = Buffer.from(att.data, "base64");
+      } catch (err) {
+        logger.warn(
+          { item_id: item.id, err: String(err) },
+          "[inline-attachments] base64 decode failed — dropping attachment"
+        );
+        continue;
+      }
+      if (buffer.length === 0) continue;
+
+      const published = await artifactStore.publish({
+        buffer,
+        filename,
+        contentType: mime,
+        publicGatewayUrl: baseUrl,
+      });
+
+      const materialized: MaterializedAttachment = {
+        kind,
+        filename: published.filename,
+        mime_type: published.contentType,
+        artifact_id: published.artifactId,
+        download_url: published.downloadUrl,
+        size_bytes: published.size,
+        duration_ms: att.duration_ms ?? null,
+      };
+      rewritten.push(materialized);
+
+      if (kind === "audio") {
+        pendingTranscriptions.push({
+          originId: item.id,
+          artifactId: published.artifactId,
+          filename: published.filename,
+          mimeType: published.contentType,
+        });
+      }
+    }
+
+    out.push({ ...item, attachments: rewritten });
+  }
+
+  return { items: out, pendingTranscriptions };
+}
+
+function inferKindFromMime(mime: string): string {
+  if (mime.startsWith("audio/")) return "audio";
+  if (mime.startsWith("image/")) return "image";
+  if (mime.startsWith("video/")) return "video";
+  return "file";
+}
+
+/**
+ * Fire-and-forget transcription for each audio attachment that was just
+ * materialized. On success, writes a superseding event whose payload_text
+ * carries the transcript, so `current_event_records` exposes the
+ * transcribed message while the original `[voice note]` row stays as
+ * recoverable history.
+ *
+ * Picks the first agent in the org whose auth profiles include an STT
+ * provider (OpenAI, Gemini, or ElevenLabs). If none exists, leaves the
+ * placeholder untouched — graceful degradation.
+ */
+export function triggerAudioTranscriptions(
+  organizationId: string,
+  pending: AudioTranscriptionPending[]
+): void {
+  if (pending.length === 0) return;
+
+  void (async () => {
+    const coreServices = getLobuCoreServices();
+    const transcriptionService = coreServices?.getTranscriptionService?.();
+    const artifactStore = coreServices?.getArtifactStore?.();
+    if (!transcriptionService || !artifactStore) {
+      logger.info(
+        { organizationId, pending: pending.length },
+        "[inline-attachments] transcription skipped — coreServices unavailable"
+      );
+      return;
+    }
+
+    const agentId = await pickTranscriptionAgent(
+      organizationId,
+      transcriptionService
+    );
+    if (!agentId) {
+      logger.info(
+        { organizationId, pending: pending.length },
+        "[inline-attachments] no STT-capable agent in org — leaving voice-note placeholders"
+      );
+      return;
+    }
+
+    for (const job of pending) {
+      try {
+        await transcribeOne(job, organizationId, agentId);
+      } catch (err) {
+        logger.warn(
+          { origin_id: job.originId, err: String(err) },
+          "[inline-attachments] transcription job failed"
+        );
+      }
+    }
+  })();
+}
+
+async function pickTranscriptionAgent(
+  organizationId: string,
+  transcriptionService: NonNullable<
+    ReturnType<NonNullable<ReturnType<typeof getLobuCoreServices>>["getTranscriptionService"]>
+  >
+): Promise<string | null> {
+  const sql = getDb();
+  const rows = (await sql`
+    SELECT id FROM agents
+    WHERE organization_id = ${organizationId}
+    ORDER BY created_at ASC
+  `) as Array<{ id: string }>;
+  for (const row of rows) {
+    const cfg = await transcriptionService.getConfig(row.id);
+    if (cfg) return row.id;
+  }
+  return null;
+}
+
+async function transcribeOne(
+  job: AudioTranscriptionPending,
+  organizationId: string,
+  agentId: string
+): Promise<void> {
+  const coreServices = getLobuCoreServices();
+  const artifactStore = coreServices!.getArtifactStore();
+  const transcriptionService = coreServices!.getTranscriptionService();
+  if (!artifactStore || !transcriptionService) return;
+
+  const stored = await artifactStore.read(job.artifactId);
+  if (!stored) {
+    logger.warn(
+      { artifact_id: job.artifactId },
+      "[inline-attachments] artifact missing — cannot transcribe"
+    );
+    return;
+  }
+  const { readFile } = await import("node:fs/promises");
+  const buffer = await readFile(stored.filePath);
+
+  const result = await transcriptionService.transcribe(
+    buffer,
+    agentId,
+    job.mimeType
+  );
+  if ("error" in result) {
+    logger.info(
+      { origin_id: job.originId, error: result.error },
+      "[inline-attachments] transcription returned error — keeping placeholder"
+    );
+    return;
+  }
+
+  const transcript = result.text.trim();
+  if (!transcript) return;
+
+  const sql = getDb();
+  const baseRows = (await sql`
+    SELECT id, entity_ids, title, payload_type, payload_data, attachments,
+           author_name, source_url, occurred_at, metadata, semantic_type,
+           origin_type, connector_key, connection_id, feed_key, feed_id,
+           score, origin_parent_id
+    FROM events
+    WHERE organization_id = ${organizationId}
+      AND origin_id = ${job.originId}
+      AND NOT EXISTS (
+        SELECT 1 FROM events newer WHERE newer.supersedes_event_id = events.id
+      )
+    ORDER BY created_at DESC, id DESC
+    LIMIT 1
+  `) as Array<{
+    id: number;
+    entity_ids: number[] | null;
+    title: string | null;
+    payload_type: string;
+    payload_data: Record<string, unknown> | null;
+    attachments: unknown[] | null;
+    author_name: string | null;
+    source_url: string | null;
+    occurred_at: string | null;
+    metadata: Record<string, unknown> | null;
+    semantic_type: string;
+    origin_type: string | null;
+    connector_key: string | null;
+    connection_id: number | null;
+    feed_key: string | null;
+    feed_id: number | null;
+    score: number | null;
+    origin_parent_id: string | null;
+  }>;
+  const base = baseRows[0];
+  if (!base) return;
+
+  const meta = { ...(base.metadata ?? {}), transcript_provider: result.provider };
+
+  // Tombstone-style supersede: insert a new event that points at the current
+  // row. The `current_event_records` view (and findCurrentEventByOrigin) will
+  // surface this one going forward; the original stays in history.
+  await insertEvent({
+    entityIds: base.entity_ids ?? [],
+    organizationId,
+    originId: `${job.originId}#transcript`,
+    title: base.title,
+    payloadType: (base.payload_type as never) || "text",
+    content: transcript,
+    payloadData: base.payload_data ?? {},
+    attachments: base.attachments ?? [],
+    authorName: base.author_name,
+    sourceUrl: base.source_url,
+    occurredAt: base.occurred_at,
+    semanticType: base.semantic_type,
+    originType: base.origin_type,
+    metadata: meta,
+    connectorKey: base.connector_key,
+    connectionId: base.connection_id,
+    feedKey: base.feed_key,
+    feedId: base.feed_id,
+    parentOriginId: base.origin_parent_id,
+    score: base.score,
+    supersedesEventId: base.id,
+  });
+}

--- a/packages/server/src/utils/inline-attachments.ts
+++ b/packages/server/src/utils/inline-attachments.ts
@@ -20,6 +20,7 @@
  * `current_event_records` view exposes the transcribed text. Failures are
  * swallowed — the unsuperseded `[voice note]` placeholder remains usable.
  */
+import { readFile } from "node:fs/promises";
 import { getDb } from "../db/client";
 import { getLobuCoreServices } from "../lobu/gateway";
 import { getConfiguredPublicOrigin } from "./public-origin";
@@ -110,17 +111,17 @@ export async function materializeInlineAttachments<T extends StreamItemLike>(
       const filename = att.filename || "attachment";
       const mime = att.mime_type || "application/octet-stream";
       const kind = att.kind || inferKindFromMime(mime);
-      let buffer: Buffer;
-      try {
-        buffer = Buffer.from(att.data, "base64");
-      } catch (err) {
+      // `Buffer.from(str, 'base64')` never throws on malformed input — it
+      // silently ignores non-base64 chars. An empty result is the only signal
+      // we get that the input was junk, so guard on length here.
+      const buffer = Buffer.from(att.data, "base64");
+      if (buffer.length === 0) {
         logger.warn(
-          { item_id: item.id, err: String(err) },
-          "[inline-attachments] base64 decode failed — dropping attachment"
+          { item_id: item.id },
+          "[inline-attachments] base64 decoded to 0 bytes — dropping attachment"
         );
         continue;
       }
-      if (buffer.length === 0) continue;
 
       const published = await artifactStore.publish({
         buffer,
@@ -180,49 +181,58 @@ export function triggerAudioTranscriptions(
 ): void {
   if (pending.length === 0) return;
 
+  // Fire-and-forget. The outer try/catch is the safety net for anything
+  // that escapes the per-job catch below — a DB hiccup in
+  // `pickTranscriptionAgent`, an unexpected throw from getLobuCoreServices,
+  // etc. — so a transcription failure cannot crash the stream-batch ack
+  // that already returned.
   void (async () => {
-    const coreServices = getLobuCoreServices();
-    const transcriptionService = coreServices?.getTranscriptionService?.();
-    const artifactStore = coreServices?.getArtifactStore?.();
-    if (!transcriptionService || !artifactStore) {
-      logger.info(
-        { organizationId, pending: pending.length },
-        "[inline-attachments] transcription skipped — coreServices unavailable"
-      );
-      return;
-    }
-
-    const agentId = await pickTranscriptionAgent(
-      organizationId,
-      transcriptionService
-    );
-    if (!agentId) {
-      logger.info(
-        { organizationId, pending: pending.length },
-        "[inline-attachments] no STT-capable agent in org — leaving voice-note placeholders"
-      );
-      return;
-    }
-
-    for (const job of pending) {
-      try {
-        await transcribeOne(job, organizationId, agentId);
-      } catch (err) {
-        logger.warn(
-          { origin_id: job.originId, err: String(err) },
-          "[inline-attachments] transcription job failed"
+    try {
+      const coreServices = getLobuCoreServices();
+      const transcriptionService = coreServices?.getTranscriptionService?.();
+      const artifactStore = coreServices?.getArtifactStore?.();
+      if (!transcriptionService || !artifactStore) {
+        logger.info(
+          { organizationId, pending: pending.length },
+          "[inline-attachments] transcription skipped — coreServices unavailable"
         );
+        return;
       }
+
+      const agentId = await pickTranscriptionAgent(organizationId);
+      if (!agentId) {
+        logger.info(
+          { organizationId, pending: pending.length },
+          "[inline-attachments] no STT-capable agent in org — leaving voice-note placeholders"
+        );
+        return;
+      }
+
+      for (const job of pending) {
+        try {
+          await transcribeOne(job, organizationId, agentId);
+        } catch (err) {
+          logger.warn(
+            { origin_id: job.originId, err: String(err) },
+            "[inline-attachments] transcription job failed"
+          );
+        }
+      }
+    } catch (err) {
+      logger.warn(
+        { organizationId, err: String(err) },
+        "[inline-attachments] transcription orchestrator threw"
+      );
     }
   })();
 }
 
 async function pickTranscriptionAgent(
-  organizationId: string,
-  transcriptionService: NonNullable<
-    ReturnType<NonNullable<ReturnType<typeof getLobuCoreServices>>["getTranscriptionService"]>
-  >
+  organizationId: string
 ): Promise<string | null> {
+  const coreServices = getLobuCoreServices();
+  const transcriptionService = coreServices?.getTranscriptionService?.();
+  if (!transcriptionService) return null;
   const sql = getDb();
   const rows = (await sql`
     SELECT id FROM agents
@@ -254,7 +264,6 @@ async function transcribeOne(
     );
     return;
   }
-  const { readFile } = await import("node:fs/promises");
   const buffer = await readFile(stored.filePath);
 
   const result = await transcriptionService.transcribe(

--- a/packages/server/src/worker-api.ts
+++ b/packages/server/src/worker-api.ts
@@ -27,6 +27,10 @@ import { applyEntityLinks } from './utils/entity-link-upsert';
 import { errorMessage } from './utils/errors';
 import { validateConnectorEventSemanticType } from './utils/event-kind-validation';
 import { mergeExecutionConfig, resolveExecutionAuth } from './utils/execution-context';
+import {
+  materializeInlineAttachments,
+  triggerAudioTranscriptions,
+} from './utils/inline-attachments';
 import { insertEvent } from './utils/insert-event';
 import logger from './utils/logger';
 import { getWorkspaceRole } from './utils/organization-access';
@@ -561,6 +565,15 @@ export async function streamContent(c: Context<{ Bindings: Env }>) {
     const run = runRows[0];
     const entityIds = parsePgNumberArray(run.entity_ids);
 
+    // Connector-emitted inline attachments (e.g. whatsapp.local voice notes)
+    // come over the wire as base64 in `attachment.data`. Materialize each into
+    // the ArtifactStore before the row hits events.attachments — the events
+    // table is not a binary store. Audio attachments are queued for async
+    // transcription after insert.
+    const { items: materializedItems, pendingTranscriptions } =
+      await materializeInlineAttachments(batch.items);
+    batch.items = materializedItems as typeof batch.items;
+
     // Auto-create dimension entities declared via eventKinds[kind].entityLinks
     // before inserting events. One query per (entityType, matchField) per
     // batch — cheap compared to the per-event inserts that follow.
@@ -662,6 +675,10 @@ export async function streamContent(c: Context<{ Bindings: Env }>) {
         throw err;
       }
     }
+
+    // Kick off background transcription for any audio attachments
+    // materialized above. Runs detached — never blocks the stream-batch ack.
+    triggerAudioTranscriptions(run.organization_id, pendingTranscriptions);
 
     // Update feed + run checkpoint if provided (so mid-run state like QR codes
     // surface in UI via recent_runs[0].checkpoint before the run completes).


### PR DESCRIPTION
## Summary

Voice notes flowing from `whatsapp.local` into Lobu, now with audio bytes ingested and transcripts written back into the event stream. Bundles three changes that show up in the same data path:

1. **Label fix** — `[system event]` placeholder no longer eats every media row. The connector now emits `[voice note]` / `[image]` / `[video]` / etc. Was caused by `isSystemEvent = msgType == 6 || ZGROUPEVENTTYPE != 0` lighting up on every group media row, combined with the system-event branch winning over the media-type branch in `makePayloadText`.
2. **Audio ingest** — when the WhatsApp Desktop archive has a downloaded `.opus` for a row (i.e. the user has played the voice note inside WA Desktop — Mac WA fetches media on demand), the Mac bridge reads up to 2MB of bytes and ships them as an inline-base64 attachment on the WorkerStreamItem. `WorkerStreamItem` gains an optional `attachments` field; `WorkerStreamAttachment` carries `kind/filename/mime_type/data/size_bytes/duration_ms`.
3. **Server-side materialization + transcription** — new helper `packages/server/src/utils/inline-attachments.ts` runs inside `/api/workers/stream` between the worker batch and `insertEvent`. It moves the bytes out of the JSON into the existing `ArtifactStore`, leaving `{artifact_id, download_url}` on `events.attachments`. Audio attachments are queued for async transcription against the org's first STT-capable agent (OpenAI Whisper → Gemini → ElevenLabs via the existing `TranscriptionService`). On success a superseding event carries the transcript in `payload_text`; the original `[voice note]` row stays as history. Failures are swallowed — no STT-capable agent in the org → placeholder stays.

## Why bundle these three

They share a single data path. Shipping (1) without (2)/(3) would still leave audio messages unreadable past a stale label. Shipping (2)/(3) without (1) would leave the `[system event]` corpus untouched.

## Out of scope (intentionally)

- Non-audio media (images, video, documents). Same code path will accept their bytes once the bridge ships them.
- Local Whisper on the Mac (whisper.cpp / WhisperKit). Server-side first for now.
- Backfill of existing `[system event]` rows. The connector uses a forward-only `last_pk` checkpoint, so historical rows keep their stale labels until the org re-syncs from PK 0 (separate decision).

## Test plan

- [ ] Deploy server. Manually queue a `whatsapp.local` sync against an org with a played-back voice note in WA Desktop. Verify a fresh event row's `attachments[0]` carries `{artifact_id, download_url, mime_type: "audio/opus"}` (no `data` field).
- [ ] Verify the `download_url` resolves to the `.opus` bytes through `/lobu/api/v1/files/<id>?token=…`.
- [ ] Wait for the async transcription. Confirm a second event row appears with `supersedes_event_id` pointing at the original and `payload_text = "<transcript>"`. The original stays queryable via `include_superseded`.
- [ ] Sanity-check non-audio: image/video rows still get `[image]` / `[video]` placeholders, no attachment bytes, no transcription attempt.
- [ ] Mac bridge needs a rebuild (`xcodebuild` or run from Xcode) for the Swift side to take effect — the server-side materialization and transcription path is a no-op for old-Mac-bridge clients (they never send `attachments`).
- [ ] Confirm graceful degradation when no STT agent is installed in the org: events still appear with the `[voice note]` placeholder; no superseding row written; warn-level log line emitted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Streamed items can include file attachments with metadata (filename, type, size, duration).
  * WhatsApp voice-note audio streaming is supported, with media-aware payload labels.
  * Inline attachments are now materialized into stored artifacts and served via artifact references.
  * Audio attachments trigger asynchronous transcription jobs; successful transcripts replace placeholders.

* **Bug Fixes / Improvements**
  * Improved media vs. system-event labeling to show media placeholders when applicable.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lobu-ai/lobu/pull/708)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->