### PR TITLE
feat(web): surface connector actions on detail + empty state

### DIFF
--- a/packages/connector-worker/package.json
+++ b/packages/connector-worker/package.json
@@ -14,7 +14,8 @@
     "./embeddings": {
       "import": "./dist/embeddings.js",
       "types": "./dist/embeddings.d.ts"
-    }
+    },
+    "./executor/child-runner": "./dist/executor/child-runner.js"
   },
   "files": [
     "dist",

--- a/packages/connector-worker/src/executor/subprocess.ts
+++ b/packages/connector-worker/src/executor/subprocess.ts
@@ -8,6 +8,7 @@
 
 import { fork } from 'node:child_process';
 import { existsSync } from 'node:fs';
+import { createRequire } from 'node:module';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import type { ExecutionHooks, FeedSyncResult, SyncContext, SyncExecutor } from './interface.js';
@@ -139,6 +140,21 @@ export class SubprocessExecutor implements SyncExecutor {
         // loader.mjs invokes module.register('./cjs/index.cjs') with a parent
         // URL that Bun's resolver treats as empty. Skip --import tsx on Bun.
         if (!isBun) execArgv.unshift('--import', 'tsx');
+      } else if (!existsSync(childRunnerPath)) {
+        // Bundled runtime: this module is bundled into another package's
+        // dist (e.g. packages/server/dist/server.bundle.mjs), so __dirname
+        // is the bundle's directory rather than the sibling executor dir.
+        // child-runner.js lives in connector-worker's own dist — resolve it
+        // through Node's module resolver instead of by path arithmetic.
+        try {
+          const requireFromHere = createRequire(import.meta.url);
+          childRunnerPath = requireFromHere.resolve(
+            '@lobu/connector-worker/executor/child-runner'
+          );
+        } catch {
+          // Fall through with the original join() path; fork() will surface
+          // the missing-file error on the next tick.
+        }
       }
 
       // Node subprocess execution is process isolation, not a security sandbox.


### PR DESCRIPTION
## Summary

Two-part fix for connector actions:

**1. UI surface** — bumps `packages/web` to include [owletto-web #104](https://github.com/lobu-ai/owletto-web/pull/104):
- `/<org>/connections/<connectorKey>` empty state previews the connector's available actions.
- `/<org>/connections/<connectorKey>/<id>` settings tab lists the connection's operations alongside Status / Auth / Activity.

**2. Runtime fix** — `connector-worker/src/executor/subprocess.ts` resolves `child-runner.js` via package `exports` when the sibling sibling path doesn't exist. Without this every action run failed in prod with `write EPIPE` because the bundled `server.bundle.mjs` (where `subprocess.ts` is inlined) has `__dirname` = `/app/packages/server/dist/`, and `join(__dirname, 'child-runner.js')` points at a path that doesn't exist. The forked Node process crashed with `Cannot find module`, and the parent's first `child.send()` hit EPIPE.

## Why

The connector "actions" feature was unreachable from two angles:
- UI never surfaced the action list outside of a buried edit sheet.
- Even if you triggered an action, the prod runtime had never executed one successfully (3 attempts in history, all failed).

This PR fixes both so the path from "see Gmail's actions" → "run Search Emails" works end-to-end.

## Test plan

- [ ] Open a connector's overview with zero connections → Actions preview lists ops with `Requires approval` badges.
- [ ] Open a connection settings tab → Actions section lists the operations.
- [ ] Connector with no actions_schema → no Actions section rendered.
- [ ] Execute `search` on a Gmail connection via `POST /api/<org>/actions/execute` → run completes with status `completed` (not `failed: write EPIPE`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the web subproject pointer to a new pinned commit.

* **Bug Fixes**
  * Fixed package exports mapping so subpath exports are correctly recognized.
  * Improved runtime module resolution with a safe fallback when running from bundled distributions to prevent missing-file errors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lobu-ai/lobu/pull/711)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->