### PR TITLE
fix(server): device-reconcile adopts orphan connections + web bump

### DIFF
--- a/packages/server/src/worker-api/device-reconcile.ts
+++ b/packages/server/src/worker-api/device-reconcile.ts
@@ -92,7 +92,7 @@ async function ensureDeviceConnectorWired(
       LEFT JOIN connections c
         ON c.organization_id = cd.organization_id
        AND c.connector_key = cd.key
-       AND c.created_by = ${userId}
+       AND c.auth_profile_id IS NULL
        AND c.deleted_at IS NULL
       LEFT JOIN feeds f
         ON f.connection_id = c.id
@@ -162,16 +162,30 @@ async function ensureDeviceConnectorWired(
         },
       });
 
-      // 3. Reuse or create the connection (no-auth, active, private).
+      // 3. Reuse or create the connection (no-auth, active, private). Match on
+      //    (org, connector, no auth_profile) — the device-connector identity —
+      //    rather than created_by, so orphan rows (created_by IS NULL, or
+      //    created by a different user/token) get adopted and self-healed
+      //    instead of stranded behind a slug-collision insert.
       const existingConn = (await tx`
-        SELECT id FROM connections
+        SELECT id, created_by FROM connections
         WHERE organization_id = ${organizationId}
           AND connector_key = ${connectorKey}
-          AND created_by = ${userId}
+          AND auth_profile_id IS NULL
           AND deleted_at IS NULL
+        ORDER BY id ASC
         LIMIT 1
-      `) as unknown as Array<{ id: number }>;
+      `) as unknown as Array<{ id: number; created_by: string | null }>;
       connectionId = existingConn[0]?.id;
+      if (connectionId && existingConn[0].created_by == null) {
+        // Backfill ownership so future per-user queries (e.g. /api/me/devices)
+        // attribute the connection to the user whose poll wired it.
+        await tx`
+          UPDATE connections
+          SET created_by = ${userId}, updated_at = NOW()
+          WHERE id = ${connectionId} AND created_by IS NULL
+        `;
+      }
       if (!connectionId) {
         // Stable slug for `lobu apply` diffing — same generation path as
         // manage_connections. No insert-retry here: this whole block runs


### PR DESCRIPTION
## Summary

- **Server fix:** `reconcileDeviceCapabilities` (worker poll auto-wire) couldn't repair a device-connector row whose `created_by` didn't match the polling user. Both the fast-path JOIN and the slow-path reuse-check filtered by `c.created_by = \${userId}`, so an orphan row (e.g. `created_by IS NULL` from older reconcile code, or rows inserted by `lobu apply` with a no-user token) was invisible. The fall-through INSERT then collided with the orphan's slug, aborted the txn, and the pin never landed. Result: the row sat unpinned forever and the UI hid it (sidebar device-grouping requires `device_worker_id`).
  - Drop the `created_by` predicate from both lookups — match on `(org, connector_key, auth_profile_id IS NULL, deleted_at IS NULL)` instead. There's at most one such row per org, so no ambiguity.
  - When the adopted row has `created_by IS NULL`, backfill it under the lock so `/api/me/devices` and friends start attributing it correctly.
- **Web submodule bump** (4d9a17f) for lobu-ai/owletto-web#105 — borderless inline pages + `/$owner` → `/events` redirect.

Hit this against buremba's `whatsapp.local` (connection id 361, `created_by` was NULL, never got a pin). Backfilled prod with the explicit pin + owner so the row is usable immediately; the code fix prevents new orphans from getting stranded the same way.

## Test plan

- [ ] Worker poll from Lobu for Mac auto-wires + pins a fresh `whatsapp.local` connection in a new org (no orphan in the DB) — unchanged behaviour.
- [ ] Same flow with a pre-existing `whatsapp.local` row whose `created_by` is NULL or a different user — the row is adopted, `device_worker_id` set, `created_by` backfilled.
- [ ] `make build-packages` + `bun run typecheck` clean.
- [ ] Web changes (border cleanup + `/$owner` redirect) load via the bumped submodule.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced device-connector reconciliation to better identify and reuse connections during installation and wiring workflows. Previously orphaned or unattached connections can now be properly adopted by users, streamlining the connection management and setup process.

* **Chores**
  * Updated web subproject reference.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lobu-ai/lobu/pull/714)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->