### PR TITLE
chore(dev): auto-detect Homebrew node@22-24 in make dev

### DIFF
--- a/scripts/dev-native.sh
+++ b/scripts/dev-native.sh
@@ -31,12 +31,29 @@ command -v bun >/dev/null || { echo "bun is required: curl -fsSL https://bun.sh/
 # call-site gate in packages/server/src/sandbox/run-script.ts only surfaces
 # this when an agent invokes the sandbox; we fail fast here so `make dev`
 # itself refuses to boot under an unsupported Node major.
-node_major=$(node -p 'process.versions.node.split(".")[0]' 2>/dev/null || true)
-if [ -z "$node_major" ] || [ "$node_major" -lt 22 ] || [ "$node_major" -ge 25 ]; then
+node_supported() {
+  local bin=$1
+  [ -x "$bin" ] || return 1
+  local major
+  major=$("$bin" -p 'process.versions.node.split(".")[0]' 2>/dev/null || echo "")
+  [ -n "$major" ] && [ "$major" -ge 22 ] && [ "$major" -lt 25 ]
+}
+
+if ! node_supported "$(command -v node || true)"; then
+  for candidate in /opt/homebrew/opt/node@22/bin /opt/homebrew/opt/node@23/bin /opt/homebrew/opt/node@24/bin /usr/local/opt/node@22/bin /usr/local/opt/node@23/bin /usr/local/opt/node@24/bin; do
+    if node_supported "$candidate/node"; then
+      echo "↪︎  Using $($candidate/node -v) from $candidate (system node is unsupported)"
+      export PATH="$candidate:$PATH"
+      break
+    fi
+  done
+fi
+
+if ! node_supported "$(command -v node || true)"; then
   current=$(node -v 2>/dev/null || echo 'unknown')
   echo "❌ Unsupported Node.js runtime: $current (required: 22.x–24.x)"
   echo "   isolated-vm has no Node 25+ build yet — see https://github.com/laverdet/isolated-vm/issues/553"
-  echo "   Quick fix on macOS: brew install node@22 && PATH=/opt/homebrew/opt/node@22/bin:\$PATH make dev"
+  echo "   Quick fix on macOS: brew install node@22 (this script auto-detects Homebrew node@22-24)"
   echo "   Or use a version manager (nvm, fnm, mise, asdf, volta) that honours .nvmrc / .node-version."
   exit 1
 fi


### PR DESCRIPTION
## Summary
- When the system `node` is outside the supported 22.x-24.x range (e.g. brew updated to v26), `scripts/dev-native.sh` now probes common Homebrew prefixes (`node@22`, `node@23`, `node@24` under both `/opt/homebrew` and `/usr/local`) and prepends the first match to `PATH` before booting.
- Falls back to the existing fail-fast message if none are installed.

## Test plan
- [x] Smoke-tested the detection block under system Node 26 — resolves to `/opt/homebrew/opt/node@22/bin/node` (v22.22.2).
- [ ] `make dev` boots cleanly on a host with Node 26 in `PATH` but `node@22` installed via Homebrew.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced Node.js version validation for local development with automatic detection of supported versions (22–24) from system installation paths.
  * Improved error messaging to provide runtime details and guidance when incompatible Node versions are detected, simplifying troubleshooting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lobu-ai/lobu/pull/715)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->