### PR TITLE
fix(server): orchestration-harden test no longer wipes shared DATABASE_URL

### DIFF
--- a/packages/server/src/gateway/__tests__/orchestration-harden.test.ts
+++ b/packages/server/src/gateway/__tests__/orchestration-harden.test.ts
@@ -640,6 +640,7 @@ describe("WORKER_ENV_* env-var passthrough", () => {
   });
 
   test("DATABASE_URL is not forwarded to workers", async () => {
+    const prev = process.env.DATABASE_URL;
     process.env.DATABASE_URL = "postgres://secret:password@host/db";
     const mgr = makeManager();
     const mkdirSpy = spyOn(fs, "mkdirSync").mockReturnValue(undefined);
@@ -653,7 +654,8 @@ describe("WORKER_ENV_* env-var passthrough", () => {
       expect(spawnOpts?.env?.DATABASE_URL).toBeUndefined();
     } finally {
       mkdirSpy.mockRestore();
-      delete process.env.DATABASE_URL;
+      if (prev === undefined) delete process.env.DATABASE_URL;
+      else process.env.DATABASE_URL = prev;
     }
   });
 });


### PR DESCRIPTION
## Summary
- `packages/server/src/gateway/__tests__/orchestration-harden.test.ts:642` (the *"DATABASE_URL is not forwarded to workers"* test) set `process.env.DATABASE_URL = "postgres://secret:password@host/db"` and then **unconditionally `delete process.env.DATABASE_URL`** in its `finally`.
- `bun test src/gateway/__tests__/` (the integration-job's gateway sub-step) runs every file in one process. `orchestration-harden.test.ts` alphabetically precedes `runs-queue-integration.test.ts`, so by the time the latter ran `process.env.DATABASE_URL` was gone and every `new RunsQueue()` threw `RunsQueue: DATABASE_URL is required`.
- Fix: snapshot the previous value and restore it (delete only if it was originally unset).

## Why this kept slipping past local
The CI integration job sets `DATABASE_URL` at the job level. Locally most contributors run individual files, not the whole `src/gateway/__tests__` directory in one go, so the cross-file env leak doesn't surface.

## Failure scope this unblocks (last 5+ main runs)
Every `RunsQueue` integration assertion failed with the same stack:
```
error: RunsQueue: DATABASE_URL is required
  at new RunsQueue (.../infrastructure/queue/runs-queue.ts:156:17)
  at .../runs-queue-integration.test.ts:39:11
```

## Test plan
- [x] `bun test src/gateway/__tests__/orchestration-harden.test.ts src/gateway/__tests__/runs-queue-integration.test.ts` no longer prints `DATABASE_URL is required` (the only remaining local fail is `ECONNREFUSED 127.0.0.1:5433` because there's no Postgres on this dev box).
- [ ] CI integration job's `server gateway suite (bun:test, needs Postgres)` step turns green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test stability by enhancing environment variable cleanup logic to properly preserve and restore pre-existing values instead of unconditionally removing them.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lobu-ai/lobu/pull/716)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->