### PR TITLE
feat(server): get_content semantic_type accepts string or array

### DIFF
--- a/examples/lobu-crm/connectors/hackernews.yaml
+++ b/examples/lobu-crm/connectors/hackernews.yaml
@@ -1,18 +1,18 @@
-# Hacker News — mentions of "lobu" / "openclaw".
+# Hacker News — mentions of "lobu".
 # Connector definition: packages/connectors/src/hackernews.ts (no auth).
 ---
 version: 1
 type: connection
 slug: hn-lobu
 connector: hackernews
-name: Hacker News — lobu / openclaw
+name: Hacker News — lobu
 config:
-  search_query: lobu OR openclaw
+  search_query: lobu
   lookback_days: 180
 feeds:
   - feed: stories
-    name: HN stories — lobu / openclaw
+    name: HN stories — lobu
     schedule: "0 */4 * * *"
     config:
-      search_query: lobu OR openclaw
+      search_query: lobu
       lookback_days: 180

--- a/examples/lobu-crm/lobu.toml
+++ b/examples/lobu-crm/lobu.toml
@@ -6,7 +6,7 @@
 # narrow so the agent's context stays funnel-only:
 #   - github       → lobu-ai/lobu  (stars, issues, PRs, comments)
 #   - x            → @lobu mentions + replies to your Lobu threads
-#   - hackernews   → search "lobu" / "openclaw"
+#   - hackernews   → search "lobu"
 #   - producthunt  → the launch / "lobu"
 #   - website (optional) → lobu.ai + competitor changelogs (onyx, dust, glean)
 

--- a/packages/connectors/src/google_gmail.ts
+++ b/packages/connectors/src/google_gmail.ts
@@ -135,7 +135,7 @@ export default class GmailConnector extends ConnectorRuntime {
             },
             entityLinks: [
               {
-                entityType: '$member',
+                entityType: 'person',
                 autoCreate: true,
                 titlePath: 'metadata.from_name',
                 identities: [{ namespace: IDENTITY.EMAIL, eventPath: 'metadata.from_email' }],

--- a/packages/connectors/src/whatsapp.ts
+++ b/packages/connectors/src/whatsapp.ts
@@ -179,7 +179,7 @@ export default class WhatsAppConnector extends ConnectorRuntime {
             },
             entityLinks: [
               {
-                entityType: '$member',
+                entityType: 'person',
                 autoCreate: true,
                 titlePath: 'metadata.push_name',
                 identities: [

--- a/packages/connectors/src/whatsapp_local.ts
+++ b/packages/connectors/src/whatsapp_local.ts
@@ -90,7 +90,7 @@ export default class WhatsAppLocalConnector extends ConnectorRuntime {
             },
             entityLinks: [
               {
-                entityType: '$member',
+                entityType: 'person',
                 autoCreate: true,
                 titlePath: 'metadata.push_name',
                 identities: [

--- a/packages/server/src/tools/get_content.ts
+++ b/packages/server/src/tools/get_content.ts
@@ -301,10 +301,16 @@ export const GetContentSchema = Type.Object({
     })
   ),
   semantic_type: Type.Optional(
-    Type.String({
-      description:
-        'Filter by semantic type (e.g. note, summary, decision, observation). Matches the semantic_type set via save_memory.',
-    })
+    Type.Union(
+      [
+        Type.String(),
+        Type.Array(Type.String(), { minItems: 1 }),
+      ],
+      {
+        description:
+          'Filter by semantic type. Pass a single value (e.g. "note") or an array (e.g. ["note","summary"]) to match any. Matches the semantic_type set via save_memory.',
+      }
+    )
   ),
   interaction_status: Type.Optional(
     Type.Union(
@@ -866,8 +872,11 @@ export async function getContent(
         paramIndex += 1;
       }
       if (args.semantic_type) {
-        conditions.push(`e.semantic_type = $${paramIndex}`);
-        queryParams.push(args.semantic_type);
+        const types = Array.isArray(args.semantic_type)
+          ? args.semantic_type
+          : [args.semantic_type];
+        conditions.push(`e.semantic_type = ANY($${paramIndex}::text[])`);
+        queryParams.push(pgTextArray(types));
         paramIndex += 1;
       }
       if (args.interaction_status) {

--- a/packages/server/src/utils/content-search.ts
+++ b/packages/server/src/utils/content-search.ts
@@ -147,7 +147,15 @@ function buildStandardParams(
     options.engagement_min ?? null,
     options.engagement_max ?? null,
     options.classification_source ?? null,
-    options.semantic_type ?? null,
+    // Slot $9 binds a Postgres `text[]` literal (e.g. `'{note,summary}'`); the
+    // standard WHERE template uses `= ANY($9::text[])`, covering single- and
+    // multi-type callers with one predicate. We hand-format the literal because
+    // `sql.unsafe(...)` binding doesn't auto-cast JS arrays.
+    options.semantic_type
+      ? pgTextArray(
+          Array.isArray(options.semantic_type) ? options.semantic_type : [options.semantic_type]
+        )
+      : null,
     options.interaction_status ?? null,
   ];
 }
@@ -324,7 +332,7 @@ function buildStandardWhereSql(entityLinkSql: string): string {
             WHERE lc_source.event_id = f.id
               AND lc_source.source = $8::text
           ))
-          AND ($9::text IS NULL OR f.semantic_type = $9::text)
+          AND ($9::text[] IS NULL OR f.semantic_type = ANY($9::text[]))
           AND ($10::text IS NULL OR f.interaction_status = $10::text)`;
 }
 
@@ -459,7 +467,7 @@ interface ContentSearchOptions {
   min_similarity?: number; // 0.0 - 1.0, default: 0.6
   limit?: number; // default: 50, max: 100
   content_ids?: number[]; // Filter to specific content IDs
-  semantic_type?: string; // Filter by semantic type (e.g. note, summary, decision)
+  semantic_type?: string | string[]; // Filter by semantic type — single value or array (matches any)
   interaction_status?: 'pending' | 'approved' | 'rejected' | 'completed' | 'failed';
 
   // Classification options (only JOINs when needed)
@@ -1207,8 +1215,13 @@ async function listContentInternal(
       baseConditions.push(`f.score <= $${baseParams.length}`);
     }
     if (options.semantic_type) {
-      baseParams.push(options.semantic_type);
-      baseConditions.push(`f.semantic_type = $${baseParams.length}`);
+      // Match any of the requested types — single-string callers get wrapped
+      // into a one-element Postgres array literal so the same predicate fits.
+      const types = Array.isArray(options.semantic_type)
+        ? options.semantic_type
+        : [options.semantic_type];
+      baseParams.push(pgTextArray(types));
+      baseConditions.push(`f.semantic_type = ANY($${baseParams.length}::text[])`);
     }
     if (options.interaction_status) {
       baseParams.push(options.interaction_status);
@@ -1538,7 +1551,7 @@ async function searchContentBySingleQuery(
           AND ($6::int IS NULL OR iwf.window_id = $6::int)
           AND ($7::numeric IS NULL OR f.score >= $7::numeric)
           AND ($8::numeric IS NULL OR f.score <= $8::numeric)
-          AND ($9::text IS NULL OR f.semantic_type = $9::text)
+          AND ($9::text[] IS NULL OR f.semantic_type = ANY($9::text[]))
           AND ($10::text IS NULL OR f.interaction_status = $10::text)
           ${excludeClause.sql}
           ${visibilityClause.sql}
@@ -1782,7 +1795,13 @@ async function searchContentBySingleQuery(
     options.window_id ?? null,
     options.engagement_min ?? null,
     options.engagement_max ?? null,
-    options.semantic_type ?? null,
+    // Same Postgres `text[]` literal wrap as buildStandardParams — slot $9 in
+    // the search template is `= ANY($9::text[])`.
+    options.semantic_type
+      ? pgTextArray(
+          Array.isArray(options.semantic_type) ? options.semantic_type : [options.semantic_type]
+        )
+      : null,
     options.interaction_status ?? null,
     ...orgScope.params,
     ...excludeClause.params,


### PR DESCRIPTION
## Summary
\`read_knowledge\` / \`get_content\`'s \`semantic_type\` filter now takes either a single string (\`\"note\"\`) or an array (\`[\"note\",\"summary\"]\`). All three execution paths — date-feed list, vector search, and include-superseded — bind the value as a Postgres \`text[]\` literal and use \`= ANY(\$N::text[])\`. Single-string callers are wrapped to a one-element array so the same predicate covers both.

Bumps \`packages/web\` to pick up [owletto-web#108](https://github.com/lobu-ai/owletto-web/pull/108) — the All / Notifications / Memory bucket selector that drives this filter from the Knowledge page.

## Why
The Knowledge page can now double as the notifications inbox without building a separate \`/inbox\` route. The cmdk \"See all\" link can deep-link via \`?semantic_types=notification\` (follow-up).

## Test plan
- [x] \`semantic_type: 'note'\` → 7 results (matches DB)
- [x] \`semantic_type: ['note','summary',...8 types]\` → 43 results (matches DB sum)
- [x] \`semantic_type: 'notification'\` → 51 results (matches DB)
- [x] \`bun run typecheck\` clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Content filtering now supports multiple semantic types simultaneously.

* **Bug Fixes**
  * Fixed entity type classification in Gmail and WhatsApp connectors to correctly identify people instead of members.

* **Chores**
  * Hacker News connector configuration updated to focus on "lobu" content only.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lobu-ai/lobu/pull/719)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->