### PR TITLE
feat(server): drop connector_key gating from browser_session profiles

### DIFF
--- a/apps/mac/Lobu/BrowserProfilesView.swift
+++ b/apps/mac/Lobu/BrowserProfilesView.swift
@@ -116,13 +116,13 @@ struct SingleBrowserRow: View {
         HStack(alignment: .center, spacing: 6) {
             VStack(alignment: .leading, spacing: 0) {
                 Text(profile.display_name).font(.caption)
-                Text("\(profile.connector_key) · \(profile.status)")
+                Text(profile.status)
                     .font(.caption2).foregroundStyle(.secondary)
             }
             Spacer()
             if profile.status == "pending_auth", let dir = profile.user_data_dir {
-                Button("Log in") {
-                    openManagedChrome(dirPath: dir, connectorKey: profile.connector_key)
+                Button("Open") {
+                    openManagedChrome(dirPath: dir)
                 }
                 .buttonStyle(.plain).font(.caption2).foregroundStyle(.orange)
             }
@@ -143,9 +143,9 @@ struct SingleBrowserRow: View {
         .padding(.vertical, 1)
     }
 
-    private func openManagedChrome(dirPath: String, connectorKey: String) {
+    private func openManagedChrome(dirPath: String) {
         let dir = URL(fileURLWithPath: dirPath)
-        let landing = landingURL(for: connectorKey)
+        let landing = URL(string: "about:blank")!
         Task { @MainActor in
             do {
                 try await BrowserProfileManager.launchManaged(
@@ -155,19 +155,6 @@ struct SingleBrowserRow: View {
                 hub.loadError = "Could not launch \(browser.kind.displayName): \(error.localizedDescription)"
             }
         }
-    }
-
-    private func landingURL(for connectorKey: String) -> URL {
-        let map: [String: String] = [
-            "capterra": "https://www.capterra.com/",
-            "g2": "https://www.g2.com/",
-            "glassdoor": "https://www.glassdoor.com/",
-            "trustpilot": "https://www.trustpilot.com/",
-            "linkedin": "https://www.linkedin.com/login",
-            "x": "https://x.com/login",
-            "revolut": "https://app.revolut.com/",
-        ]
-        return URL(string: map[connectorKey] ?? "about:blank")!
     }
 
     @MainActor
@@ -197,8 +184,6 @@ struct CreateBrowserProfileInlineForm: View {
 
     @State private var sourceProfiles: [InstalledBrowserProfile] = []
     @State private var selectedSourceProfile: InstalledBrowserProfile?
-    @State private var connectorOptions: [WorkerClient.BrowserConnectorOption] = []
-    @State private var connectorKey: String = ""
     @State private var displayName: String = ""
     @State private var mode: Mode = .copy
     @State private var cdpPortText: String = ""
@@ -240,17 +225,6 @@ struct CreateBrowserProfileInlineForm: View {
                     }
                     .buttonStyle(.plain).font(.caption2).foregroundStyle(.blue)
                 }
-                Picker("", selection: $connectorKey) {
-                    if connectorOptions.isEmpty {
-                        Text("Loading…").tag("")
-                    } else {
-                        ForEach(connectorOptions) { c in
-                            Text(c.name).tag(c.key)
-                        }
-                    }
-                }
-                .labelsHidden().font(.caption2).controlSize(.mini)
-                .disabled(connectorOptions.isEmpty)
             }
             if mode == .cdp, let url = detectedCdpUrl {
                 Text("Detected: \(url)").font(.caption2).foregroundStyle(.green)
@@ -274,28 +248,11 @@ struct CreateBrowserProfileInlineForm: View {
         .onAppear {
             sourceProfiles = BrowserProfileManager.sourceProfiles(for: browser)
             selectedSourceProfile = sourceProfiles.first
-            Task { await loadConnectorOptions() }
-        }
-    }
-
-    @MainActor
-    private func loadConnectorOptions() async {
-        guard let client = state.workerClient() else { return }
-        do {
-            let workerId = LobuWorkerIdentity.current()
-            let options = try await client.listBrowserConnectors(workerId: workerId)
-            connectorOptions = options
-            if connectorKey.isEmpty, let first = options.first?.key {
-                connectorKey = first
-            }
-        } catch {
-            self.error = "Could not load connectors: \(error.localizedDescription)"
         }
     }
 
     private var canSubmit: Bool {
         if displayName.trimmingCharacters(in: .whitespaces).isEmpty { return false }
-        if connectorKey.isEmpty { return false }
         switch mode {
         case .copy: return selectedSourceProfile != nil
         case .cdp: return parsedCdpPort != nil
@@ -327,7 +284,6 @@ struct CreateBrowserProfileInlineForm: View {
                 do {
                     profile = try await client.createMyBrowserAuthProfile(
                         workerId: workerId,
-                        connectorKey: connectorKey,
                         displayName: displayName,
                         browserKind: browser.kind.rawValue,
                         userDataDir: target.path,
@@ -348,7 +304,6 @@ struct CreateBrowserProfileInlineForm: View {
                 let cdpUrl = "http://127.0.0.1:\(port)"
                 profile = try await client.createMyBrowserAuthProfile(
                     workerId: workerId,
-                    connectorKey: connectorKey,
                     displayName: displayName,
                     browserKind: browser.kind.rawValue,
                     userDataDir: nil,

--- a/apps/mac/Lobu/LobuClient.swift
+++ b/apps/mac/Lobu/LobuClient.swift
@@ -353,7 +353,7 @@ final class WorkerClient {
         let id: Int
         let slug: String
         let display_name: String
-        let connector_key: String
+        let connector_key: String?
         let profile_kind: String
         let status: String
         let browser_kind: String?
@@ -384,7 +384,6 @@ final class WorkerClient {
 
     func createMyBrowserAuthProfile(
         workerId: String,
-        connectorKey: String,
         displayName: String,
         browserKind: String,
         userDataDir: String?,
@@ -392,7 +391,6 @@ final class WorkerClient {
     ) async throws -> BrowserAuthProfile {
         struct Body: Encodable {
             let worker_id: String
-            let connector_key: String
             let display_name: String
             let browser_kind: String
             let user_data_dir: String?
@@ -402,7 +400,6 @@ final class WorkerClient {
             "/api/workers/me/auth-profiles",
             body: Body(
                 worker_id: workerId,
-                connector_key: connectorKey,
                 display_name: displayName,
                 browser_kind: browserKind,
                 user_data_dir: userDataDir,
@@ -485,27 +482,6 @@ final class WorkerClient {
             )
         )
         return try decoder.decode(Envelope.self, from: data).feed
-    }
-
-    struct BrowserConnectorOption: Decodable, Identifiable, Equatable, Hashable {
-        let key: String
-        let name: String
-        let favicon_domain: String?
-        var id: String { key }
-    }
-
-    private struct BrowserConnectorsResponse: Decodable {
-        let connectors: [BrowserConnectorOption]
-    }
-
-    func listBrowserConnectors(workerId: String) async throws -> [BrowserConnectorOption] {
-        guard var components = URLComponents(string: "\(baseURL.trimmedTrailingSlash())/api/workers/me/browser-connectors") else {
-            throw URLError(.badURL)
-        }
-        components.queryItems = [URLQueryItem(name: "worker_id", value: workerId)]
-        guard let url = components.url else { throw URLError(.badURL) }
-        let data = try await getRaw(url: url, path: "/api/workers/me/browser-connectors")
-        return try decoder.decode(BrowserConnectorsResponse.self, from: data).connectors
     }
 
     func deleteMyDeviceFeed(workerId: String, connectorKey: String, feedId: Int) async throws {

--- a/db/migrations/20260514120000_auth_profiles_connector_key_nullable.sql
+++ b/db/migrations/20260514120000_auth_profiles_connector_key_nullable.sql
@@ -1,0 +1,42 @@
+-- migrate:up
+
+-- Drop the NOT NULL on auth_profiles.connector_key so browser_session
+-- profiles can be device-bound resources without a connector binding.
+--
+-- A browser_session profile is physically (device, browser_kind, user_data_dir
+-- XOR cdp_url) — the connector_key was always a hint, not a gate. One CDP
+-- attach on a Mac already has cookies for every site the user is logged into;
+-- forcing one row per connector against the same cdp_url was bookkeeping for
+-- the DB's benefit, not the user's. Connection resolution falls back to
+-- "browser_session on the connection's device_worker_id" when no exact
+-- connector match exists.
+--
+-- Other profile kinds (env, oauth_app, oauth_account, interactive) remain
+-- per-connector; the new check constraint keeps them honest.
+
+ALTER TABLE public.auth_profiles
+    ALTER COLUMN connector_key DROP NOT NULL;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint WHERE conname = 'auth_profiles_connector_key_required'
+    ) THEN
+        ALTER TABLE public.auth_profiles
+            ADD CONSTRAINT auth_profiles_connector_key_required
+            CHECK (
+                connector_key IS NOT NULL
+                OR profile_kind = 'browser_session'
+            );
+    END IF;
+END$$;
+
+-- migrate:down
+
+ALTER TABLE public.auth_profiles
+    DROP CONSTRAINT IF EXISTS auth_profiles_connector_key_required;
+
+-- Restoring NOT NULL would fail if any browser_session rows now have
+-- connector_key = NULL. Backfill with a placeholder before running this.
+ALTER TABLE public.auth_profiles
+    ALTER COLUMN connector_key SET NOT NULL;

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -237,7 +237,7 @@ CREATE TABLE public.auth_profiles (
     organization_id text NOT NULL,
     slug text NOT NULL,
     display_name text NOT NULL,
-    connector_key text NOT NULL,
+    connector_key text,
     profile_kind text NOT NULL,
     status text DEFAULT 'active'::text NOT NULL,
     auth_data jsonb DEFAULT '{}'::jsonb NOT NULL,
@@ -252,6 +252,7 @@ CREATE TABLE public.auth_profiles (
     user_data_dir text,
     cdp_url text,
     CONSTRAINT auth_profiles_browser_kind_check CHECK (((browser_kind IS NULL) OR (browser_kind = ANY (ARRAY['chrome'::text, 'brave'::text, 'arc'::text, 'edge'::text])))),
+    CONSTRAINT auth_profiles_connector_key_required CHECK (((connector_key IS NOT NULL) OR (profile_kind = 'browser_session'::text))),
     CONSTRAINT auth_profiles_device_browser_path_xor CHECK (((device_worker_id IS NULL) OR (profile_kind <> 'browser_session'::text) OR (((user_data_dir IS NOT NULL) AND (cdp_url IS NULL)) OR ((user_data_dir IS NULL) AND (cdp_url IS NOT NULL))))),
     CONSTRAINT auth_profiles_profile_kind_check CHECK ((profile_kind = ANY (ARRAY['env'::text, 'oauth_app'::text, 'oauth_account'::text, 'browser_session'::text, 'interactive'::text]))),
     CONSTRAINT auth_profiles_status_check CHECK ((status = ANY (ARRAY['active'::text, 'pending_auth'::text, 'error'::text, 'revoked'::text])))
@@ -4948,4 +4949,5 @@ INSERT INTO public.schema_migrations (version) VALUES
     ('20260513120000'),
     ('20260513150000'),
     ('20260513200000'),
-    ('20260514000000');
+    ('20260514000000'),
+    ('20260514120000');

--- a/packages/server/src/db/embedded-schema-patches.ts
+++ b/packages/server/src/db/embedded-schema-patches.ts
@@ -491,4 +491,31 @@ export const EMBEDDED_SCHEMA_PATCHES: EmbeddedSchemaPatch[] = [
       `);
     },
   },
+  {
+    // Mirrors db/migrations/20260514120000_auth_profiles_connector_key_nullable.sql.
+    // Drops NOT NULL on auth_profiles.connector_key so browser_session profiles
+    // (a device-bound resource) no longer require a per-connector binding.
+    id: 'auth-profiles-connector-key-nullable',
+    apply: async (sql) => {
+      await sql.unsafe(`
+        ALTER TABLE public.auth_profiles
+        ALTER COLUMN connector_key DROP NOT NULL
+      `);
+      await sql.unsafe(`
+        DO $$
+        BEGIN
+          IF NOT EXISTS (
+            SELECT 1 FROM pg_constraint WHERE conname = 'auth_profiles_connector_key_required'
+          ) THEN
+            ALTER TABLE public.auth_profiles
+              ADD CONSTRAINT auth_profiles_connector_key_required
+              CHECK (
+                connector_key IS NOT NULL
+                OR profile_kind = 'browser_session'
+              );
+          END IF;
+        END $$;
+      `);
+    },
+  },
 ];

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -535,7 +535,6 @@ import {
   heartbeat,
   deleteDeviceWorker,
   listDeviceWorkers,
-  listBrowserConnectors,
   listMyDeviceAuthProfiles,
   listMyDeviceFeeds,
   updateDeviceWorkerOrg,
@@ -591,12 +590,10 @@ app.use('/api/workers/*', async (c, next) => {
       const requestPath = new URL(c.req.url).pathname;
       const isAuthProfileSubpath = requestPath.startsWith('/api/workers/me/auth-profiles');
       const isFeedSubpath = requestPath.startsWith('/api/workers/me/feeds');
-      const isBrowserConnectorsPath = requestPath === '/api/workers/me/browser-connectors';
       if (
         !allowedPathsForUserWorker.has(requestPath) &&
         !isAuthProfileSubpath &&
-        !isFeedSubpath &&
-        !isBrowserConnectorsPath
+        !isFeedSubpath
       ) {
         return c.json({ error: 'Endpoint not available to user-scoped workers' }, 403);
       }
@@ -654,7 +651,6 @@ app.delete('/api/workers/me/auth-profiles/:id', deleteMyDeviceAuthProfile);
 app.get('/api/workers/me/feeds', listMyDeviceFeeds);
 app.post('/api/workers/me/feeds', createMyDeviceFeed);
 app.delete('/api/workers/me/feeds/:id', deleteMyDeviceFeed);
-app.get('/api/workers/me/browser-connectors', listBrowserConnectors);
 // Device worker registry. Authenticated (mcpAuth); returns the calling user's
 // devices. Lives under /api/me/ so the workspace resolver treats it as
 // user-scoped (no org slug in the URL).

--- a/packages/server/src/tools/admin/helpers/connection-helpers.ts
+++ b/packages/server/src/tools/admin/helpers/connection-helpers.ts
@@ -416,6 +416,7 @@ export async function resolveConnectionAuthSelection(params: {
     | undefined;
   authProfileSlug?: string | null;
   appAuthProfileSlug?: string | null;
+  deviceWorkerId?: string | null;
 }): Promise<AuthSelectionResult> {
   const { organizationId, connectorKey } = params;
   const oauthMethod = getOAuthMethods(params.authSchema)[0] ?? null;
@@ -439,6 +440,7 @@ export async function resolveConnectionAuthSelection(params: {
           organizationId,
           connectorKey,
           profileKind: 'browser_session',
+          deviceWorkerId: params.deviceWorkerId ?? null,
         })
       : null) ??
     (preferredMethodType === 'oauth' && oauthMethod

--- a/packages/server/src/tools/admin/manage_auth_profiles.ts
+++ b/packages/server/src/tools/admin/manage_auth_profiles.ts
@@ -629,11 +629,13 @@ async function handleUpdateAuthProfile(
   if (
     authProfile.profile_kind === 'oauth_account' &&
     authProfileProvider &&
-    args.requested_scopes
+    args.requested_scopes &&
+    authProfile.connector_key
   ) {
+    const profileConnectorKey = authProfile.connector_key;
     const connector = await getScopedConnectorDefinition({
       organizationId: ctx.organizationId,
-      connectorKey: authProfile.connector_key,
+      connectorKey: profileConnectorKey,
     });
     const oauthMethod = connector
       ? getOAuthMethods(connector.auth_schema).find((m) => m.provider === authProfileProvider)
@@ -653,10 +655,16 @@ async function handleUpdateAuthProfile(
     }
   }
 
-  if (args.reconnect && authProfile.profile_kind === 'oauth_account' && authProfileProvider) {
+  if (
+    args.reconnect &&
+    authProfile.profile_kind === 'oauth_account' &&
+    authProfileProvider &&
+    authProfile.connector_key
+  ) {
+    const profileConnectorKey = authProfile.connector_key;
     const connector = await getScopedConnectorDefinition({
       organizationId: ctx.organizationId,
-      connectorKey: authProfile.connector_key,
+      connectorKey: profileConnectorKey,
     });
     const oauthMethod = connector
       ? getOAuthMethods(connector.auth_schema).find((m) => m.provider === authProfileProvider)
@@ -682,7 +690,7 @@ async function handleUpdateAuthProfile(
       const connectToken = await createConnectToken({
         organizationId: ctx.organizationId,
         authProfileId: authProfile.id,
-        connectorKey: authProfile.connector_key,
+        connectorKey: profileConnectorKey,
         authType: 'oauth',
         authConfig: {
           ...buildOAuthConnectConfig(oauthMethod, requestedScopes),

--- a/packages/server/src/tools/admin/manage_auth_profiles.ts
+++ b/packages/server/src/tools/admin/manage_auth_profiles.ts
@@ -73,7 +73,12 @@ const TestAuthProfileAction = Type.Object({
 
 const CreateAuthProfileAction = Type.Object({
   action: Type.Literal('create_auth_profile'),
-  connector_key: Type.String({ description: 'Connector key (e.g. x, google.gmail)' }),
+  connector_key: Type.Optional(
+    Type.String({
+      description:
+        'Connector key (e.g. x, google.gmail). Required for env/oauth profiles; optional for browser_session (device-scoped resource).',
+    })
+  ),
   profile_kind: Type.Union([
     Type.Literal('env'),
     Type.Literal('oauth_app'),
@@ -401,19 +406,35 @@ async function handleCreateAuthProfile(
   args: Extract<AuthProfilesArgs, { action: 'create_auth_profile' }>,
   ctx: ToolContext
 ): Promise<ManageAuthProfilesResult> {
-  const connector = await getScopedConnectorDefinition({
-    organizationId: ctx.organizationId,
-    connectorKey: args.connector_key,
-  });
+  // browser_session profiles are device-scoped; connector_key is optional
+  // (only used as a hint to look up a default cdp_url). Other kinds remain
+  // per-connector and require it.
+  const connector = args.connector_key
+    ? await getScopedConnectorDefinition({
+        organizationId: ctx.organizationId,
+        connectorKey: args.connector_key,
+      })
+    : null;
 
-  if (!connector) {
+  if (args.connector_key && !connector) {
     return { error: `Connector '${args.connector_key}' not found or not active` };
   }
+
+  // Handle browser_session up front — it's the only kind that may skip
+  // connector_key entirely. Everything below assumes a connector context.
+  if (args.profile_kind === 'browser_session') {
+    return handleCreateBrowserSessionProfile(args, ctx, connector);
+  }
+
+  if (!args.connector_key || !connector) {
+    return { error: `connector_key is required for ${args.profile_kind} auth profiles` };
+  }
+  const connectorKey: string = args.connector_key;
 
   if (args.profile_kind === 'oauth_account') {
     const oauthMethod = getOAuthMethods(connector.auth_schema)[0];
     if (!oauthMethod) {
-      return { error: `Connector '${args.connector_key}' does not support OAuth account profiles` };
+      return { error: `Connector '${connectorKey}' does not support OAuth account profiles` };
     }
 
     const displayName =
@@ -426,7 +447,7 @@ async function handleCreateAuthProfile(
       ? await getAuthProfileBySlug(ctx.organizationId, normalizeAuthProfileSlug(args.slug, displayName))
       : null;
     if (existing) {
-      if (existing.profile_kind !== 'oauth_account' || existing.connector_key !== args.connector_key) {
+      if (existing.profile_kind !== 'oauth_account' || existing.connector_key !== connectorKey) {
         return {
           error: `Auth profile '${existing.slug}' already exists with a different kind/connector (${existing.profile_kind} / ${existing.connector_key}) — use a new slug`,
         };
@@ -437,7 +458,7 @@ async function handleCreateAuthProfile(
       const requestedScopes = resolveRequestedOAuthScopes(oauthMethod, args.requested_scopes);
       const connectToken = await createConnectToken({
         organizationId: ctx.organizationId,
-        connectorKey: args.connector_key,
+        connectorKey,
         authType: 'oauth',
         authProfileId: existing.id,
         authConfig: {
@@ -459,7 +480,7 @@ async function handleCreateAuthProfile(
     // callback flips it to `active` once the user finishes authorization.
     const authProfile = await createAuthProfile({
       organizationId: ctx.organizationId,
-      connectorKey: args.connector_key,
+      connectorKey,
       displayName,
       slug: args.slug,
       profileKind: 'oauth_account',
@@ -474,7 +495,7 @@ async function handleCreateAuthProfile(
     try {
       connectToken = await createConnectToken({
         organizationId: ctx.organizationId,
-        connectorKey: args.connector_key,
+        connectorKey,
         authType: 'oauth',
         authProfileId: authProfile.id,
         authConfig: {
@@ -497,41 +518,6 @@ async function handleCreateAuthProfile(
       connect_url: `${getConnectBaseUrl(ctx)}/connect/${connectToken.token}/oauth/start`,
       connect_token: connectToken.token,
     };
-  }
-
-  if (args.profile_kind === 'browser_session') {
-    const browserMethod = getBrowserMethods(connector.auth_schema)[0];
-    if (!browserMethod) {
-      return { error: `Connector '${args.connector_key}' does not support browser auth profiles` };
-    }
-
-    const authData =
-      browserMethod.capture === 'cdp'
-        ? {
-            cdp_url:
-              typeof args.auth_data?.cdp_url === 'string' &&
-              args.auth_data.cdp_url.trim().length > 0
-                ? args.auth_data.cdp_url.trim()
-                : browserMethod.defaultCdpUrl || 'auto',
-          }
-        : ((args.auth_data as Record<string, unknown> | undefined) ?? {});
-    const browserSessionReady =
-      browserMethod.capture === 'cdp'
-        ? (await getBrowserSessionReadiness(authData, args.connector_key)).usable
-        : false;
-
-    const authProfile = await createAuthProfile({
-      organizationId: ctx.organizationId,
-      connectorKey: args.connector_key,
-      displayName: args.display_name,
-      slug: args.slug,
-      profileKind: 'browser_session',
-      authData,
-      status: browserSessionReady ? 'active' : 'pending_auth',
-      createdBy: ctx.userId ?? 'api',
-    });
-
-    return { action: 'create_auth_profile', auth_profile: serializeAuthProfile(authProfile) };
   }
 
   const credentials = normalizeAuthValues(args.credentials ?? {});
@@ -562,12 +548,54 @@ async function handleCreateAuthProfile(
 
   const authProfile = await createAuthProfile({
     organizationId: ctx.organizationId,
-    connectorKey: args.connector_key,
+    connectorKey,
     displayName: args.display_name,
     slug: args.slug,
     profileKind: args.profile_kind,
     authData: credentials,
     provider,
+    createdBy: ctx.userId ?? 'api',
+  });
+
+  return { action: 'create_auth_profile', auth_profile: serializeAuthProfile(authProfile) };
+}
+
+async function handleCreateBrowserSessionProfile(
+  args: Extract<AuthProfilesArgs, { action: 'create_auth_profile' }>,
+  ctx: ToolContext,
+  connector: Awaited<ReturnType<typeof getScopedConnectorDefinition>>
+): Promise<ManageAuthProfilesResult> {
+  // browser_session profiles are device-scoped resources — connector_key, if
+  // provided, is just a hint for picking a default cdp_url from a known
+  // connector's browser method. The stored profile is not connector-bound.
+  const browserMethod = connector
+    ? (getBrowserMethods(connector.auth_schema)[0] ?? null)
+    : null;
+  const captureMode = browserMethod?.capture ?? 'cdp';
+
+  const authData =
+    captureMode === 'cdp'
+      ? {
+          cdp_url:
+            typeof args.auth_data?.cdp_url === 'string' &&
+            args.auth_data.cdp_url.trim().length > 0
+              ? args.auth_data.cdp_url.trim()
+              : browserMethod?.defaultCdpUrl || 'auto',
+        }
+      : ((args.auth_data as Record<string, unknown> | undefined) ?? {});
+  const browserSessionReady =
+    captureMode === 'cdp'
+      ? (await getBrowserSessionReadiness(authData, null)).usable
+      : false;
+
+  const authProfile = await createAuthProfile({
+    organizationId: ctx.organizationId,
+    connectorKey: null,
+    displayName: args.display_name,
+    slug: args.slug,
+    profileKind: 'browser_session',
+    authData,
+    status: browserSessionReady ? 'active' : 'pending_auth',
     createdBy: ctx.userId ?? 'api',
   });
 

--- a/packages/server/src/tools/admin/manage_connections.ts
+++ b/packages/server/src/tools/admin/manage_connections.ts
@@ -881,6 +881,7 @@ async function handleCreate(
         authSchema: connector.auth_schema,
         authProfileSlug: args.auth_profile_slug,
         appAuthProfileSlug: args.app_auth_profile_slug,
+        deviceWorkerId: deviceBinding.deviceWorkerId,
       });
 
   if (authSelection) {
@@ -1233,6 +1234,7 @@ async function handleConnect(
     authSchema: connector.auth_schema,
     authProfileSlug: args.auth_profile_slug,
     appAuthProfileSlug: args.app_auth_profile_slug,
+    deviceWorkerId: deviceBinding.deviceWorkerId,
   });
 
   const hasNoAuth =
@@ -1585,6 +1587,7 @@ async function handleUpdate(
     authSchema: existing.auth_schema,
     authProfileSlug: args.auth_profile_slug,
     appAuthProfileSlug: args.app_auth_profile_slug,
+    deviceWorkerId: nextDeviceWorkerId,
   });
 
   if (args.auth_profile_slug && !authSelection.authProfile) {

--- a/packages/server/src/utils/auth-profiles.ts
+++ b/packages/server/src/utils/auth-profiles.ts
@@ -16,7 +16,7 @@ export interface AuthProfileRow {
   organization_id: string;
   slug: string;
   display_name: string;
-  connector_key: string;
+  connector_key: string | null;
   profile_kind: AuthProfileKind;
   status: AuthProfileStatus;
   auth_data: Record<string, unknown>;
@@ -253,7 +253,9 @@ export async function listAuthProfiles(params: {
   const sql = getDb();
 
   // oauth_app profiles are provider-scoped — include them when filtering by connector_key
-  // if the connector has an OAuth provider
+  // if the connector has an OAuth provider.
+  // browser_session profiles are device-scoped resources; their connector_key is
+  // optional, so they always show up regardless of the connector filter.
   const rows = await sql`
     SELECT ${sql.unsafe(AUTH_PROFILE_COLUMNS)}
     FROM auth_profiles
@@ -263,9 +265,10 @@ export async function listAuthProfiles(params: {
       AND (
         ${params.connectorKey ?? null}::text IS NULL
         OR connector_key = ${params.connectorKey ?? null}
+        OR profile_kind = 'browser_session'
         OR (profile_kind = 'oauth_app' AND ${params.provider ?? null}::text IS NOT NULL AND lower(provider) = lower(${params.provider ?? null}))
       )
-    ORDER BY connector_key ASC, profile_kind ASC, display_name ASC, slug ASC
+    ORDER BY connector_key ASC NULLS LAST, profile_kind ASC, display_name ASC, slug ASC
   `;
 
   return rows as unknown as AuthProfileRow[];
@@ -307,7 +310,7 @@ export async function getAuthProfileById(
 
 export async function createAuthProfile(params: {
   organizationId: string;
-  connectorKey: string;
+  connectorKey: string | null;
   displayName: string;
   slug?: string | null;
   profileKind: AuthProfileKind;
@@ -347,7 +350,7 @@ export async function createAuthProfile(params: {
       ${params.organizationId},
       ${slug},
       ${params.displayName},
-      ${params.connectorKey},
+      ${params.connectorKey ?? null},
       ${params.profileKind},
       ${params.status ?? 'active'},
       ${sql.json(normalizeAuthData(params.profileKind, params.authData ?? {}))},
@@ -430,6 +433,7 @@ export async function getPrimaryAuthProfileForKind(params: {
   connectorKey: string;
   profileKind: AuthProfileKind;
   provider?: string | null;
+  deviceWorkerId?: string | null;
 }): Promise<AuthProfileRow | null> {
   const sql = getDb();
 
@@ -445,6 +449,36 @@ export async function getPrimaryAuthProfileForKind(params: {
           OR lower(provider) = lower(${params.provider})
         )
       ORDER BY
+        CASE WHEN connector_key = ${params.connectorKey} THEN 0 ELSE 1 END,
+        updated_at DESC,
+        id DESC
+      LIMIT 1
+    `;
+
+    return rows.length > 0 ? (rows[0] as AuthProfileRow) : null;
+  }
+
+  // browser_session is device-scoped, not connector-scoped: any active profile
+  // on the connection's device can serve any connector run pinned to that
+  // device. One CDP attach holds cookies for every site in that Chrome; a
+  // managed user-data-dir can be authenticated against multiple sites by the
+  // user. Connector_key on the profile, when set, is just a legacy hint —
+  // never a gate.
+  if (params.profileKind === 'browser_session') {
+    const deviceWorkerId = params.deviceWorkerId ?? null;
+    const rows = await sql`
+      SELECT ${sql.unsafe(AUTH_PROFILE_COLUMNS)}
+      FROM auth_profiles
+      WHERE organization_id = ${params.organizationId}
+        AND profile_kind = 'browser_session'
+        AND status = 'active'
+        AND (
+          ${deviceWorkerId}::uuid IS NULL
+          OR device_worker_id = ${deviceWorkerId}::uuid
+          OR device_worker_id IS NULL
+        )
+      ORDER BY
+        CASE WHEN device_worker_id = ${deviceWorkerId}::uuid THEN 0 ELSE 1 END,
         CASE WHEN connector_key = ${params.connectorKey} THEN 0 ELSE 1 END,
         updated_at DESC,
         id DESC
@@ -478,10 +512,12 @@ export async function resolveAuthProfileSlugToId(params: {
   const profile = await getAuthProfileBySlug(params.organizationId, params.slug.trim());
   if (!profile) return null;
   if (params.expectedKind && profile.profile_kind !== params.expectedKind) return null;
-  // oauth_app profiles are provider-scoped, so skip connector_key check for them
+  // oauth_app profiles are provider-scoped, and browser_session profiles are
+  // device-scoped; both opt out of the per-connector slug check.
   if (
     params.connectorKey &&
     profile.profile_kind !== 'oauth_app' &&
+    profile.profile_kind !== 'browser_session' &&
     profile.connector_key !== params.connectorKey
   )
     return null;

--- a/packages/server/src/worker-api.ts
+++ b/packages/server/src/worker-api.ts
@@ -1777,15 +1777,16 @@ export async function listMyDeviceAuthProfiles(c: Context<{ Bindings: Env }>) {
 /**
  * POST /api/workers/me/auth-profiles
  *
- * Body: { worker_id, connector_key, display_name, browser_kind, user_data_dir }
+ * Body: { worker_id, display_name, browser_kind, user_data_dir | cdp_url }
  *
  * Create a browser-session auth profile bound to this device. Cookies stay on
- * the device — server's auth_data is empty.
+ * the device — server's auth_data is empty. A browser session is a
+ * device-scoped resource: any connection pinned to this device can use it,
+ * regardless of connector.
  */
 export async function createMyDeviceAuthProfile(c: Context<{ Bindings: Env }>) {
   let body: {
     worker_id?: string;
-    connector_key?: string;
     display_name?: string;
     browser_kind?: string;
     user_data_dir?: string;
@@ -1797,13 +1798,12 @@ export async function createMyDeviceAuthProfile(c: Context<{ Bindings: Env }>) {
     return c.json({ error: 'Invalid JSON body' }, 400);
   }
   const workerId = (body.worker_id ?? '').trim();
-  const connectorKey = (body.connector_key ?? '').trim();
   const displayName = (body.display_name ?? '').trim();
   const browserKind = (body.browser_kind ?? '').trim() as BrowserKind;
   const userDataDir = (body.user_data_dir ?? '').trim();
   const cdpUrl = (body.cdp_url ?? '').trim();
-  if (!workerId || !connectorKey || !displayName || !browserKind) {
-    return c.json({ error: 'worker_id, connector_key, display_name, browser_kind are required' }, 400);
+  if (!workerId || !displayName || !browserKind) {
+    return c.json({ error: 'worker_id, display_name, browser_kind are required' }, 400);
   }
   if (!BROWSER_KIND_SET.has(browserKind)) {
     return c.json({ error: `browser_kind must be one of: ${[...BROWSER_KIND_SET].join(', ')}` }, 400);
@@ -1821,7 +1821,7 @@ export async function createMyDeviceAuthProfile(c: Context<{ Bindings: Env }>) {
   try {
     const profile = await createAuthProfile({
       organizationId: device!.organization_id,
-      connectorKey,
+      connectorKey: null,
       displayName,
       profileKind: 'browser_session',
       status: 'pending_auth',
@@ -2084,45 +2084,3 @@ export async function deleteMyDeviceFeed(c: Context<{ Bindings: Env }>) {
   }
 }
 
-/**
- * GET /api/workers/me/browser-connectors?worker_id=...
- *
- * Returns connectors whose auth_schema declares a `browser` method, scoped to
- * the device's home organization. The Mac app uses this to populate the
- * "Connector" picker when creating a browser auth profile — keeps the picker
- * in sync with whatever connectors are installed in the user's org.
- */
-export async function listBrowserConnectors(c: Context<{ Bindings: Env }>) {
-  const workerId = (c.req.query('worker_id') ?? '').trim();
-  if (!workerId) {
-    return c.json({ error: 'worker_id is required' }, 400);
-  }
-  const { device, error } = await resolveDeviceWorkerForRequest(c, workerId);
-  if (error || !device) return error ?? c.json({ connectors: [] });
-  try {
-    const sql = getDb();
-    const rows = (await sql`
-      SELECT DISTINCT ON (key) key, name, favicon_domain
-      FROM connector_definitions
-      WHERE organization_id = ${device.organization_id}
-        AND status = 'active'
-        AND auth_schema IS NOT NULL
-        AND jsonb_typeof(auth_schema::jsonb -> 'methods') = 'array'
-        AND EXISTS (
-          SELECT 1 FROM jsonb_array_elements(auth_schema::jsonb -> 'methods') m
-          WHERE m->>'type' = 'browser'
-        )
-      ORDER BY key, updated_at DESC
-    `) as unknown as Array<{ key: string; name: string; favicon_domain: string | null }>;
-    return c.json({
-      connectors: rows.map((r) => ({
-        key: r.key,
-        name: r.name,
-        favicon_domain: r.favicon_domain,
-      })),
-    });
-  } catch (err) {
-    logger.error({ error: errorMessage(err) }, '[listBrowserConnectors] Error');
-    return c.json({ error: errorMessage(err) }, 500);
-  }
-}


### PR DESCRIPTION
## Summary
- A browser_session auth profile is a device-scoped resource: cookies live in a managed `--user-data-dir` or behind a `127.0.0.1` CDP endpoint, both pinned to one Mac. The previous "one profile per connector" model forced N rows of the same Chrome attach to serve N connectors — visible in the Mac Integrations panel as a connector picker awkwardly wedged next to the port input.
- Make `auth_profiles.connector_key` nullable for `browser_session`; resolution picks any browser_session on the connection's `device_worker_id`. Env / OAuth / interactive kinds keep the NOT NULL invariant via a new check constraint.
- Drop the connector picker and landing-URL auto-navigate from the Mac CreateBrowserProfileInlineForm. Drop the now-unused `GET /api/workers/me/browser-connectors` endpoint it fed.

## Migration
- `db/migrations/20260514120000_auth_profiles_connector_key_nullable.sql`: `ALTER COLUMN connector_key DROP NOT NULL` + `CHECK (connector_key IS NOT NULL OR profile_kind = 'browser_session')`.
- Mirrored in `packages/server/src/db/embedded-schema-patches.ts` (idempotent on boot).
- No backfill needed — existing rows keep their `connector_key` (which now reads as a legacy hint, ignored at resolution time).

## Test plan
- [ ] Migration applies cleanly to a populated dev DB.
- [ ] Mac app's Integrations "Add browser profile" form has no connector dropdown; Copy and CDP modes both create profiles that show "pending_auth" in the row (no `linkedin · pending_auth`).
- [ ] Adding a browser-based connection in the web "New connection" sheet auto-selects the first browser_session profile and pins the connection to its device.
- [ ] A single CDP profile serves multiple connector connections on the same device (LinkedIn + G2 + etc.).
- [ ] `lobu apply` paths through `manage_auth_profiles` still reject env/oauth profiles missing `connector_key`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Browser profiles can be created and stored without selecting a connector, including browser-session profiles.

* **Improvements**
  * Simplified profile creation UI by removing connector selection and related loading.
  * Profile rows show status directly; pending-auth profiles now open a fixed landing page when launched.

* **Chores**
  * Database schema relaxed to allow null connector bindings for browser-session profiles; migration and server patches applied.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lobu-ai/lobu/pull/720)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->