### PR TITLE
fix(server): semantic_type array in scored path + bump owletto-web

### DIFF
--- a/packages/server/src/utils/content-scoring.ts
+++ b/packages/server/src/utils/content-scoring.ts
@@ -23,7 +23,7 @@ interface NormalizedScoreFilters {
   exclude_watcher_id?: number; // Exclude content already in any window for this watcher
   classification_filters?: Array<{ classifier_slug: string; value: string }>;
   classification_source?: 'user' | 'embedding' | 'llm';
-  semantic_type?: string;
+  semantic_type?: string | string[];
   interaction_status?: 'pending' | 'approved' | 'rejected' | 'completed' | 'failed';
   /**
    * Connection-visibility scope. Folds into the WHERE so events from
@@ -162,8 +162,11 @@ function buildFilterConditionsAndJoins(
   }
 
   if (filters?.semantic_type) {
-    params.push(filters.semantic_type);
-    filterConditions.push(`f.semantic_type = $${paramIndex++}`);
+    const types = Array.isArray(filters.semantic_type)
+      ? filters.semantic_type
+      : [filters.semantic_type];
+    params.push(`{${types.map((t) => `"${t.replace(/"/g, '\\"')}"`).join(',')}}`);
+    filterConditions.push(`f.semantic_type = ANY($${paramIndex++}::text[])`);
   }
 
   if (filters?.interaction_status) {


### PR DESCRIPTION
## Summary
Unblocks the release-please 7.0.0 PR (#573). Two regressions on main:

- **typecheck**: PR #719 widened `get_content`'s `semantic_type` filter to `string | string[]` but only patched the date-feed/vector paths. The normalized-score path still typed `NormalizedScoreFilters.semantic_type` as `string`, breaking the inline filters object at `get_content.ts:942`. Widen the type and use `= ANY($N::text[])` in both the scored builder (`content-scoring.ts:164`) and the date-feed builder (`get_content.ts:868`).
- **check-drift**: owletto-web/main has an unmerged non-bot commit past the pinned SHA (`4012dcc feat(events): All/Notifications/Memory bucket selector`). Bump `packages/web` to `3c28db6` (owletto-web main HEAD).

## Test plan
- [ ] CI typecheck + check-drift pass.
- [ ] release-please regenerates #573 against this commit; admin-merge unblocks lobu-v7.0.0 tag + npm publish + DMG.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced content filtering to support multiple semantic types in addition to single type selection.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lobu-ai/lobu/pull/721)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->