### PR TITLE
feat(knowledge): filter content by feed_ids / run_ids / connection_ids

### DIFF
--- a/packages/server/src/rest-api.ts
+++ b/packages/server/src/rest-api.ts
@@ -274,6 +274,15 @@ export async function restToolProxy(
  * - before_occurred_at / before_id (optional): Fetch the next older chronological slice
  * - after_occurred_at / after_id (optional): Fetch the next newer chronological slice
  */
+function parseIdListParam(raw: string | undefined): number[] | undefined {
+  if (!raw) return undefined;
+  const ids = raw
+    .split(',')
+    .map((id) => safeParseInt(id.trim(), { min: 1 }))
+    .filter((id): id is number => id !== undefined);
+  return ids.length > 0 ? ids : undefined;
+}
+
 export async function restSearchKnowledge(c: Context<{ Bindings: Env }>) {
   try {
     const query = c.req.query('query');
@@ -286,7 +295,11 @@ export async function restSearchKnowledge(c: Context<{ Bindings: Env }>) {
     const params = {
       query,
       entity_id: safeParseInt(c.req.query('entity_id'), { min: 1 }),
-      connection_ids: connectionId ? [connectionId] : undefined,
+      connection_ids:
+        parseIdListParam(c.req.query('connection_ids')) ??
+        (connectionId ? [connectionId] : undefined),
+      feed_ids: parseIdListParam(c.req.query('feed_ids')),
+      run_ids: parseIdListParam(c.req.query('run_ids')),
       platform: c.req.query('platform'),
       platforms: platforms
         ? platforms
@@ -327,7 +340,11 @@ export async function publicRestSearchKnowledge(c: Context<{ Bindings: Env }>) {
     const params = {
       query: query?.trim() || undefined,
       entity_id: safeParseInt(c.req.query('entity_id'), { min: 1 }),
-      connection_ids: connectionId ? [connectionId] : undefined,
+      connection_ids:
+        parseIdListParam(c.req.query('connection_ids')) ??
+        (connectionId ? [connectionId] : undefined),
+      feed_ids: parseIdListParam(c.req.query('feed_ids')),
+      run_ids: parseIdListParam(c.req.query('run_ids')),
       platform: c.req.query('platform'),
       platforms: platforms
         ? platforms

--- a/packages/server/src/tools/get_content.ts
+++ b/packages/server/src/tools/get_content.ts
@@ -159,6 +159,16 @@ export const GetContentSchema = Type.Object({
       description: 'Connection IDs to filter by',
     })
   ),
+  feed_ids: Type.Optional(
+    Type.Array(Type.Number(), {
+      description: 'Feed IDs to filter by (events.feed_id)',
+    })
+  ),
+  run_ids: Type.Optional(
+    Type.Array(Type.Number(), {
+      description: 'Run IDs to filter by (events.run_id — the run that produced the event)',
+    })
+  ),
   platforms: Type.Optional(
     Type.Array(Type.String(), {
       description: 'Platform types to filter by (reddit, trustpilot, etc.)',
@@ -832,6 +842,16 @@ export async function getContent(
         conditions.push(`e.connection_id IN (${placeholders})`);
         queryParams.push(...effectiveConnectionIds);
       }
+      if (args.feed_ids && args.feed_ids.length > 0) {
+        const placeholders = args.feed_ids.map(() => `$${paramIndex++}`).join(',');
+        conditions.push(`e.feed_id IN (${placeholders})`);
+        queryParams.push(...args.feed_ids);
+      }
+      if (args.run_ids && args.run_ids.length > 0) {
+        const placeholders = args.run_ids.map(() => `$${paramIndex++}`).join(',');
+        conditions.push(`e.run_id IN (${placeholders})`);
+        queryParams.push(...args.run_ids);
+      }
       if (effectivePlatform) {
         conditions.push(`COALESCE(e.connector_key, c.connector_key) = $${paramIndex}`);
         queryParams.push(effectivePlatform);
@@ -941,6 +961,8 @@ export async function getContent(
 
       const filters: Parameters<typeof getNormalizedScoreContent>[3] = {
         ...(effectiveConnectionIds?.length && { connection_ids: effectiveConnectionIds }),
+        ...(args.feed_ids?.length && { feed_ids: args.feed_ids }),
+        ...(args.run_ids?.length && { run_ids: args.run_ids }),
         ...(effectivePlatform && { platform: effectivePlatform }),
         ...(sinceDate && { since: sinceDate }),
         ...(untilDate && { until: untilDate }),
@@ -977,6 +999,8 @@ export async function getContent(
           entity_id: args.entity_id,
           organization_id: !args.entity_id ? ctx.organizationId : undefined,
           connection_ids: effectiveConnectionIds,
+          feed_ids: args.feed_ids,
+          run_ids: args.run_ids,
           visibility_scope: visibilityScope,
           window_id: args.window_id,
           exclude_watcher_id: args.exclude_watcher_id,

--- a/packages/server/src/tools/get_content.ts
+++ b/packages/server/src/tools/get_content.ts
@@ -843,14 +843,20 @@ export async function getContent(
         queryParams.push(...effectiveConnectionIds);
       }
       if (args.feed_ids && args.feed_ids.length > 0) {
-        const placeholders = args.feed_ids.map(() => `$${paramIndex++}`).join(',');
-        conditions.push(`e.feed_id IN (${placeholders})`);
-        queryParams.push(...args.feed_ids);
+        const validFeedIds = args.feed_ids.filter((id) => Number.isInteger(id));
+        if (validFeedIds.length > 0) {
+          const placeholders = validFeedIds.map(() => `$${paramIndex++}`).join(',');
+          conditions.push(`e.feed_id IN (${placeholders})`);
+          queryParams.push(...validFeedIds);
+        }
       }
       if (args.run_ids && args.run_ids.length > 0) {
-        const placeholders = args.run_ids.map(() => `$${paramIndex++}`).join(',');
-        conditions.push(`e.run_id IN (${placeholders})`);
-        queryParams.push(...args.run_ids);
+        const validRunIds = args.run_ids.filter((id) => Number.isInteger(id));
+        if (validRunIds.length > 0) {
+          const placeholders = validRunIds.map(() => `$${paramIndex++}`).join(',');
+          conditions.push(`e.run_id IN (${placeholders})`);
+          queryParams.push(...validRunIds);
+        }
       }
       if (effectivePlatform) {
         conditions.push(`COALESCE(e.connector_key, c.connector_key) = $${paramIndex}`);

--- a/packages/server/src/utils/__tests__/content-query-filters.test.ts
+++ b/packages/server/src/utils/__tests__/content-query-filters.test.ts
@@ -8,7 +8,9 @@ import {
   buildConnectionFilter,
   buildDateFilterSQL,
   buildEngagementFilterSQL,
+  buildFeedFilter,
   buildOrderByClause,
+  buildRunFilter,
   groupClassificationFilters,
 } from '../content-query-filters';
 
@@ -122,6 +124,25 @@ describe('buildConnectionFilter', () => {
 
   it('should use custom table alias', () => {
     expect(buildConnectionFilter([1], 'e')).toBe('e.connection_id IN (1)');
+  });
+});
+
+describe('buildFeedFilter', () => {
+  it('builds an IN clause on feed_id', () => {
+    expect(buildFeedFilter([7, 8])).toBe('f.feed_id IN (7,8)');
+  });
+  it('returns 1=1 for empty/null', () => {
+    expect(buildFeedFilter(null)).toBe('1=1');
+    expect(buildFeedFilter([])).toBe('1=1');
+  });
+});
+
+describe('buildRunFilter', () => {
+  it('builds an IN clause on run_id', () => {
+    expect(buildRunFilter([42], 'e')).toBe('e.run_id IN (42)');
+  });
+  it('returns 1=1 for empty/null', () => {
+    expect(buildRunFilter(null)).toBe('1=1');
   });
 });
 

--- a/packages/server/src/utils/content-query-filters.ts
+++ b/packages/server/src/utils/content-query-filters.ts
@@ -154,39 +154,51 @@ export function buildClassificationFilterSQL(
 }
 
 // ============================================
-// Connection Filter Utilities
+// Id-IN Filter Utilities
 // ============================================
 
 /**
- * Build connection ID filter condition.
+ * Build an `<alias>.<column> IN (...)` filter from an integer array.
  *
- * This is needed because postgres.js with fetch_types: false
- * doesn't properly serialize JavaScript arrays to PostgreSQL arrays.
- * Using IN clause with joined IDs avoids this issue.
+ * postgres.js with `fetch_types: false` doesn't serialize JS arrays to PG arrays
+ * cleanly, so we emit a literal `IN (1,2,3)` clause. Inputs are filtered to
+ * safe integers to avoid SQL injection.
  *
- * @param connectionIds - Array of connection IDs or null
- * @param tableAlias - Table alias for connection_id column (default: 'f')
- * @returns SQL condition string like "f.connection_id IN (1,2,3)" or "1=1"
+ * Returns `'1=1'` when no ids are supplied so the caller can splice the result
+ * into a `WHERE ... AND <clause>` without conditional logic.
  */
-export function buildConnectionFilter(
-  connectionIds: number[] | null | undefined,
+function buildIdInFilter(
+  ids: number[] | null | undefined,
+  column: 'connection_id' | 'feed_id' | 'run_id',
   tableAlias: string = 'f'
 ): string {
-  if (!connectionIds || connectionIds.length === 0) {
-    // Use 1=1 instead of TRUE to avoid postgres.js treating it as a column identifier
-    return '1=1';
-  }
-
-  // Ensure all values are valid numbers to prevent SQL injection
-  const safeIds = connectionIds.filter(
+  if (!ids || ids.length === 0) return '1=1';
+  const safeIds = ids.filter(
     (n) => typeof n === 'number' && !Number.isNaN(n) && Number.isInteger(n)
   );
+  if (safeIds.length === 0) return '1=1';
+  return `${tableAlias}.${column} IN (${safeIds.join(',')})`;
+}
 
-  if (safeIds.length === 0) {
-    return '1=1';
-  }
+export function buildConnectionFilter(
+  ids: number[] | null | undefined,
+  tableAlias: string = 'f'
+): string {
+  return buildIdInFilter(ids, 'connection_id', tableAlias);
+}
 
-  return `${tableAlias}.connection_id IN (${safeIds.join(',')})`;
+export function buildFeedFilter(
+  ids: number[] | null | undefined,
+  tableAlias: string = 'f'
+): string {
+  return buildIdInFilter(ids, 'feed_id', tableAlias);
+}
+
+export function buildRunFilter(
+  ids: number[] | null | undefined,
+  tableAlias: string = 'f'
+): string {
+  return buildIdInFilter(ids, 'run_id', tableAlias);
 }
 
 // ============================================

--- a/packages/server/src/utils/content-scoring.ts
+++ b/packages/server/src/utils/content-scoring.ts
@@ -1,5 +1,9 @@
 import { getDb } from '../db/client';
-import { buildClassificationFilterSQL } from './content-query-filters';
+import {
+  buildClassificationFilterSQL,
+  buildFeedFilter,
+  buildRunFilter,
+} from './content-query-filters';
 import {
   buildConnectionVisibilityClause,
   buildEntityLinkUnion,
@@ -13,6 +17,8 @@ import { validateAndFormatIds, validateNumericId } from './sql-validation';
 
 interface NormalizedScoreFilters {
   connection_ids?: number[];
+  feed_ids?: number[];
+  run_ids?: number[];
   platform?: string;
   since?: Date;
   until?: Date;
@@ -117,6 +123,12 @@ function buildFilterConditionsAndJoins(
   if (filters?.connection_ids && filters.connection_ids.length > 0) {
     const validatedIds = validateAndFormatIds(filters.connection_ids, 'connection_ids');
     filterConditions.push(`f.connection_id IN (${validatedIds})`);
+  }
+  if (filters?.feed_ids && filters.feed_ids.length > 0) {
+    filterConditions.push(buildFeedFilter(filters.feed_ids, 'f'));
+  }
+  if (filters?.run_ids && filters.run_ids.length > 0) {
+    filterConditions.push(buildRunFilter(filters.run_ids, 'f'));
   }
 
   if (filters?.platform) {

--- a/packages/server/src/utils/content-search.ts
+++ b/packages/server/src/utils/content-search.ts
@@ -10,7 +10,9 @@ import { type DbClient, getDb, pgTextArray } from '../db/client';
 import type { Env } from '../index';
 import {
   buildConnectionFilter,
+  buildFeedFilter,
   buildOrderByClause,
+  buildRunFilter,
   type ClassificationFilter,
   groupClassificationFilters,
 } from './content-query-filters';
@@ -447,6 +449,8 @@ interface ContentSearchOptions {
   organization_id?: string; // Required when entity_id is omitted (org-wide mode)
 
   connection_ids?: number[]; // Array of connection IDs to filter by
+  feed_ids?: number[]; // Array of feed IDs to filter by
+  run_ids?: number[]; // Array of run IDs (events.run_id) to filter by
   /**
    * Connection-visibility scope. When set, the SQL WHERE clause inlines a
    * subquery that hides events from private connections the caller cannot
@@ -1099,6 +1103,10 @@ async function listContentInternal(
   const untilDate = options.until ? toEndOfDay(parseDateAlias(options.until).date) : null;
   const connectionIdsArray =
     options.connection_ids && options.connection_ids.length > 0 ? options.connection_ids : null;
+  const feedIdsArray =
+    options.feed_ids && options.feed_ids.length > 0 ? options.feed_ids : null;
+  const runIdsArray =
+    options.run_ids && options.run_ids.length > 0 ? options.run_ids : null;
 
   const orderByForResultSet = buildOrderByClause(
     options.sort_by,
@@ -1145,6 +1153,8 @@ async function listContentInternal(
   if (hasClassificationFilters && filtersBySlug) {
     const classifierVersionIds = await resolveClassifierVersionIds(sql, filtersBySlug, entityId);
     const connectionFilterClause = buildConnectionFilter(connectionIdsArray);
+    const feedFilterClause = buildFeedFilter(feedIdsArray);
+    const runFilterClause = buildRunFilter(runIdsArray);
 
     const baseConditions: string[] = [];
     const baseParams: any[] = [];
@@ -1187,6 +1197,8 @@ async function listContentInternal(
     }
 
     baseConditions.push(connectionFilterClause);
+    baseConditions.push(feedFilterClause);
+    baseConditions.push(runFilterClause);
 
     if (options.platform) {
       baseParams.push(options.platform);
@@ -1272,6 +1284,8 @@ async function listContentInternal(
   }
 
   const connectionCondition = buildConnectionFilter(connectionIdsArray);
+  const feedCondition = buildFeedFilter(feedIdsArray);
+  const runCondition = buildRunFilter(runIdsArray);
   const standardParams = buildStandardParams(options, { sinceDate, untilDate });
 
   // Build the entity-link UNION fragment once so both list and count emit
@@ -1330,6 +1344,8 @@ async function listContentInternal(
     joinSql: WINDOW_JOIN_SQL,
     whereExpr: `${standardWhereSql}
           AND ${connectionCondition}
+          AND ${feedCondition}
+          AND ${runCondition}
           ${excludeClause.sql}
           ${visibilityClause.sql}
           ${orgScope.sql}`,
@@ -1475,12 +1491,18 @@ async function searchContentBySingleQuery(
   const untilDate = options.until ? toEndOfDay(parseDateAlias(options.until).date) : null;
   const connectionIdsArray =
     options.connection_ids && options.connection_ids.length > 0 ? options.connection_ids : null;
+  const feedIdsArray =
+    options.feed_ids && options.feed_ids.length > 0 ? options.feed_ids : null;
+  const runIdsArray =
+    options.run_ids && options.run_ids.length > 0 ? options.run_ids : null;
 
   const needClassifications =
     options.include_classifications ||
     (options.classification_filters && options.classification_filters.length > 0);
 
   const connectionCondition = buildConnectionFilter(connectionIdsArray);
+  const feedCondition = buildFeedFilter(feedIdsArray);
+  const runCondition = buildRunFilter(runIdsArray);
 
   // Pre-fetch the entity's identity claims so the entity-link UNION trims
   // unused namespaces. Search path benefits even more than the chronological
@@ -1545,6 +1567,8 @@ async function searchContentBySingleQuery(
 
   const standardFiltersSQL = `($2::bigint IS NULL OR ${searchEntityLinkSql})
           AND ${connectionCondition}
+          AND ${feedCondition}
+          AND ${runCondition}
           AND ($3::text IS NULL OR f.connector_key = $3::text)
           AND ($4::timestamptz IS NULL OR f.occurred_at >= $4::timestamptz)
           AND ($5::timestamptz IS NULL OR f.occurred_at <= $5::timestamptz)


### PR DESCRIPTION
## Summary

- Adds `feed_ids` and `run_ids` filters to the `read_knowledge` MCP tool (`GetContentSchema`) and the public REST search endpoint, mirroring the existing `connection_ids` filter. Powers the "View in knowledge" affordances from feed/run/connection rows in [owletto-web#109](https://github.com/lobu-ai/owletto-web/pull/109).
- Generalizes the connection-only `buildConnectionFilter` helper into a shared `buildIdInFilter`, so all three columns share the same int-validation + serialization. `buildConnectionFilter` stays as a thin wrapper for back-compat; `buildFeedFilter` / `buildRunFilter` are new siblings.
- Filters are applied in every WHERE-emitting path: the classification-filter branch, the chronological list path, the search path (text + vector), the score path (`getNormalizedScoreContent`), and the `include_superseded` direct-events query.
- Bumps the `packages/web` submodule pointer to the matching PR's HEAD (`c7eac36`).

## Test plan

- [x] `bunx tsc -b packages/server --noEmit` clean (apart from pre-existing zod/openapi errors in `gateway/routes/public/agent.ts` on `main`).
- [x] Verified live on dev (`buraks-macbook-pro-1.brill-kanyu.ts.net:8443`) against the `buremba` org:
  - `read_knowledge` with `feed_ids:[261]` → 8,495 events
  - `read_knowledge` with `run_ids:[154620]` → 95 events
  - `read_knowledge` with `connection_ids:[342]` → 9,495 events
  - Spot-checked returned event IDs against `SELECT … FROM events WHERE run_id = …` — all match.
- [x] Existing `buildConnectionFilter` tests still pass; added unit tests for `buildFeedFilter` / `buildRunFilter`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Filter content by multiple feed IDs, run IDs, and connection IDs (comma-separated) across search, listing, and scoring endpoints.
  * Query parsing now accepts comma-separated multi-ID params and ignores empty/invalid values.

* **Tests**
  * Added tests verifying feed/run ID filter generation and empty-input handling.

* **Chores**
  * Updated web subproject pointer.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lobu-ai/lobu/pull/722)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->