### PR TITLE
chore: bump web submodule for #118 — connectors UX sweep

### DIFF
--- a/packages/server/src/utils/__tests__/mcp-install-targets.test.ts
+++ b/packages/server/src/utils/__tests__/mcp-install-targets.test.ts
@@ -47,25 +47,15 @@ describeIfSubmodule('getMcpInstallTargets', () => {
       value: `codex mcp add lobu --url ${mcpUrl}`,
     });
 
+    // openclaw's four install steps were consolidated into a single chained
+    // command for tile-grid parity with the other CLI targets (#118).
     expect(openclaw?.actions).toContainEqual({
       type: 'command',
-      label: 'Install plugin',
-      value: 'openclaw plugins install @lobu/openclaw-plugin',
-    });
-    expect(openclaw?.actions).toContainEqual({
-      type: 'command',
-      label: 'Log in to Lobu',
-      value: 'lobu login',
-    });
-    expect(openclaw?.actions).toContainEqual({
-      type: 'command',
-      label: 'Write plugin config',
-      value: `lobu memory configure --url ${mcpUrl}`,
-    });
-    expect(openclaw?.actions).toContainEqual({
-      type: 'command',
-      label: 'Verify connectivity',
-      value: `lobu memory health --url ${mcpUrl}`,
+      label: 'Install and configure',
+      value: `openclaw plugins install @lobu/openclaw-plugin
+lobu login
+lobu memory configure --url ${mcpUrl}
+lobu memory health --url ${mcpUrl}`,
     });
   });
 


### PR DESCRIPTION
Bumps `packages/web` to `2efbd87` (owletto-web #118 — connectors UX sweep + clients/connect + agents page redesign).

Triggers prod image build via `build-images.yml` push-on-main, then GitOps picks up the new tag and deploys.

## Test plan
- [ ] CI build passes
- [ ] Image lands in ghcr.io
- [ ] Pod rolls in `summaries-prod`
- [ ] `https://app.lobu.ai/<owner>/connectors` shows the redesigned page
- [ ] `https://app.lobu.ai/<owner>/clients/connect` shows the 2-col MCP/Skills + 4-col app grid

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the web package/subproject reference.

* **Tests**
  * Adjusted MCP install-targets test to expect a consolidated "Install and configure" multi-step command for the openclaw target rather than separate-step assertions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lobu-ai/lobu/pull/729)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->