### PR TITLE
fix(cli): connector run uses agent API origin, not memory MCP URL

### DIFF
--- a/packages/cli/src/commands/_lib/connector-run-cmd.ts
+++ b/packages/cli/src/commands/_lib/connector-run-cmd.ts
@@ -26,11 +26,8 @@ import { homedir } from "node:os";
 import { join } from "node:path";
 import { printText } from "../memory/_lib/output.js";
 
-import {
-  getUsableToken,
-  resolveOrg,
-  resolveServerUrl,
-} from "../memory/_lib/openclaw-auth.js";
+import { resolveContext } from "../../internal/context.js";
+import { getUsableToken, resolveOrg } from "../memory/_lib/openclaw-auth.js";
 import {
   compileConnectorFromFile,
   findBundledConnectorFile,
@@ -88,11 +85,13 @@ interface ResolvedFeed {
   checkpoint: Record<string, unknown> | null;
 }
 
-// The new connector-run REST routes live on the main app (mounted at `/`),
-// not under the Agent API (`/lobu`) or the MCP path. Collapse the resolved
-// server URL to just its origin so we can append `/api/<orgSlug>/...`.
-function apiBaseFrom(serverUrl: string): string {
-  const { origin } = new URL(serverUrl);
+// The connector-run REST routes live on the main app (mounted at `/`),
+// not under the Agent API (`/lobu`) or the MCP path. We resolve the
+// app origin from the context's agent API URL — *not* the memory MCP
+// URL, which historically defaulted to lobu.ai/mcp and pointed the
+// connector-run client at the marketing site (404).
+function apiBaseFrom(agentApiUrl: string): string {
+  const { origin } = new URL(agentApiUrl);
   return origin;
 }
 
@@ -160,18 +159,34 @@ export async function connectorRun(
 ): Promise<void> {
   ensurePlaywrightAvailable();
 
-  // Resolve API endpoint + auth via the same path the rest of the CLI uses.
-  // LOBU_API_TOKEN short-circuits the credential store — useful for testing
-  // against a dev backend you haven't `lobu login`'d into.
-  const baseMcpUrl = await resolveServerUrl(args.url, args.context);
+  // Resolve API endpoint + auth from the chosen context. The agent API URL
+  // (e.g. https://app.lobu.ai/api/v1) shares an origin with the connector-run
+  // REST routes — unlike the memory MCP URL, which historically defaulted to
+  // lobu.ai/mcp and pointed this client at the marketing site.
+  //
+  // --url is an explicit override (for testing); LOBU_API_TOKEN short-circuits
+  // the credential store.
+  const ctx = await resolveContext(args.context);
+  const explicitUrl = args.url?.trim();
+  const apiBase = explicitUrl
+    ? new URL(explicitUrl).origin
+    : apiBaseFrom(ctx.apiUrl);
+
   const envToken = process.env.LOBU_API_TOKEN?.trim();
   let token: string;
   let resolvedContextName: string | undefined;
   if (envToken) {
     token = envToken;
-    resolvedContextName = args.context;
+    resolvedContextName = ctx.name;
+  } else if (explicitUrl) {
+    // Refuse to silently forward the context's stored credentials to a URL the
+    // user typed on the command line — that's how tokens leak to the wrong
+    // backend. Pair --url with LOBU_API_TOKEN explicitly.
+    throw new Error(
+      "--url requires LOBU_API_TOKEN to be set (refuse to forward stored credentials to an explicit override)."
+    );
   } else {
-    const tokenInfo = await getUsableToken(baseMcpUrl, args.context);
+    const tokenInfo = await getUsableToken(undefined, ctx.name);
     if (!tokenInfo) {
       throw new Error(
         "Not logged in. Run `lobu login` first (or set LOBU_API_TOKEN; or pass --context <name>)."
@@ -186,7 +201,6 @@ export async function connectorRun(
       "No active org. Run `lobu org use <slug>` or pass --org <slug>."
     );
   }
-  const apiBase = apiBaseFrom(baseMcpUrl);
 
   // Resolve auth profile and (optionally) feed in parallel.
   let feed: ResolvedFeed | null = null;


### PR DESCRIPTION
## Summary

`lobu connector run` was building its REST URL from `getMemoryUrl()`, which defaults to `https://lobu.ai/mcp`. The origin collapsed to `https://lobu.ai` — the marketing site — so every hosted-prod user ran into:

```
Error: GET https://lobu.ai/api/buremba/connector-run/auth-profile/<slug> → 404 — <!DOCTYPE html>…
```

The connector-run REST routes live on the main app (`/api/:orgSlug/connector-run/*`), same origin as the agent API URL configured per context. Switch to `resolveContext().apiUrl` and everything resolves correctly on every configured context (`community.lobu.ai`, `app.lobu.ai`, local dev).

`--url` remains an explicit override but now requires `LOBU_API_TOKEN` — we refuse to forward the context's stored credentials to a URL the user typed on the command line.

## Repro before the fix

```
$ lobu connector run revolut --auth-profile google-chrome-burak-emre --check
Error: GET https://lobu.ai/api/buremba/connector-run/auth-profile/google-chrome-burak-emre → 404 — <!DOCTYPE html>…
```

After:
```
$ lobu connector run revolut --auth-profile google-chrome-burak-emre --check
Resolved auth profile 'google-chrome-burak-emre' (browser_session, status=active)
✓ All resolved. Re-run without --check to execute.
```

## Test plan
- [x] Manual e2e against prod (`community.lobu.ai` origin) with stored credentials — `--check` resolves, profile returns
- [x] Manual e2e with `--url https://app.lobu.ai` + `LOBU_API_TOKEN` — works
- [x] `--url` without `LOBU_API_TOKEN` — explicit error, no silent credential forwarding
- [x] `bun test packages/cli` — 114 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed incorrect API endpoint routing in the connector-run command to ensure requests reach the correct destination.
  * Strengthened authentication: when using the `--url` flag, you must now provide an explicit API token instead of relying on stored credentials.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lobu-ai/lobu/pull/730)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->