### PR TITLE
fix(connector-sdk): use vanilla Playwright for CDP attach (fixes Frame was detached)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -105,6 +105,7 @@
         "ora": "^8.0.1",
         "pino": "^10.1.0",
         "playwright": "npm:patchright@^1.57.0",
+        "playwright-vanilla": "npm:playwright@^1.60.0",
         "postgres": "^3.4.7",
         "react": "^19.2.5",
         "resend": "^6.6.0",
@@ -137,9 +138,11 @@
       },
       "peerDependencies": {
         "playwright": "npm:patchright@^1.57.0",
+        "playwright-vanilla": "npm:playwright@^1.60.0",
       },
       "optionalPeers": [
         "playwright",
+        "playwright-vanilla",
       ],
     },
     "packages/connector-worker": {
@@ -155,6 +158,7 @@
         "@xenova/transformers": "^2.17.2",
         "jimp": "^1.6.0",
         "playwright": "npm:patchright@^1.57.0",
+        "playwright-vanilla": "npm:playwright@^1.60.0",
         "sharp": "^0.34.4",
       },
       "devDependencies": {
@@ -170,6 +174,7 @@
         "@lobu/connector-sdk": "workspace:*",
         "baileys": "7.0.0-rc.9",
         "playwright": "npm:patchright@^1.57.0",
+        "playwright-vanilla": "npm:playwright@^1.60.0",
         "turndown": "7.2.2",
       },
       "devDependencies": {
@@ -3182,6 +3187,10 @@
     "platform": ["platform@1.3.6", "", {}, "sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg=="],
 
     "playwright": ["patchright@1.59.4", "", { "dependencies": { "patchright-core": "v1.59.4" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "patchright": "cli.js" } }, "sha512-RDZ40tBZHZtTAMoUoct/IpMA1wrozPZGU2RFk8NIDEndOEBbLxS0dH2fRLiwsNrgXgjZGA/3krrTlzK+uFGgoQ=="],
+
+    "playwright-core": ["playwright-core@1.60.0", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA=="],
+
+    "playwright-vanilla": ["playwright@1.60.0", "", { "dependencies": { "playwright-core": "1.60.0" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA=="],
 
     "pngjs": ["pngjs@7.0.0", "", {}, "sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow=="],
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -82,6 +82,7 @@
     "ora": "^8.0.1",
     "pino": "^10.1.0",
     "playwright": "npm:patchright@^1.57.0",
+    "playwright-vanilla": "npm:playwright@^1.60.0",
     "postgres": "^3.4.7",
     "react": "^19.2.5",
     "resend": "^6.6.0",

--- a/packages/connector-sdk/package.json
+++ b/packages/connector-sdk/package.json
@@ -43,10 +43,14 @@
     "ky": "^1.14.0"
   },
   "peerDependencies": {
-    "playwright": "npm:patchright@^1.57.0"
+    "playwright": "npm:patchright@^1.57.0",
+    "playwright-vanilla": "npm:playwright@^1.60.0"
   },
   "peerDependenciesMeta": {
     "playwright": {
+      "optional": true
+    },
+    "playwright-vanilla": {
       "optional": true
     }
   },

--- a/packages/connector-sdk/src/browser-network.ts
+++ b/packages/connector-sdk/src/browser-network.ts
@@ -127,8 +127,16 @@ async function acquireForNetworkSync(
         preferRealBrowser: true,
       });
 
-      const playwrightModule = 'playwright';
-      const { chromium } = await import(/* @vite-ignore */ playwrightModule);
+      // Use vanilla Playwright for CDP attach. Patchright's FrameSession
+      // initialization walks the entire frame tree on connect and throws
+      // "Frame was detached" the moment it hits a stale frame in any of
+      // the user's other tabs — which is a near-certainty on a real
+      // Chrome (we hit it deterministically with 42 open tabs). Vanilla
+      // Playwright is tolerant. The stealth patches patchright provides
+      // are irrelevant here: this is the user's real browser, the
+      // strongest possible cloak.
+      const vanillaPwModule = 'playwright-vanilla';
+      const { chromium } = await import(/* @vite-ignore */ vanillaPwModule);
       const browser: Browser = await chromium.connectOverCDP(wsUrl);
 
       try {

--- a/packages/connector-worker/package.json
+++ b/packages/connector-worker/package.json
@@ -44,6 +44,7 @@
     "@xenova/transformers": "^2.17.2",
     "jimp": "^1.6.0",
     "playwright": "npm:patchright@^1.57.0",
+    "playwright-vanilla": "npm:playwright@^1.60.0",
     "sharp": "^0.34.4"
   },
   "devDependencies": {

--- a/packages/connectors/package.json
+++ b/packages/connectors/package.json
@@ -11,6 +11,7 @@
     "@lobu/connector-sdk": "workspace:*",
     "baileys": "7.0.0-rc.9",
     "playwright": "npm:patchright@^1.57.0",
+    "playwright-vanilla": "npm:playwright@^1.60.0",
     "turndown": "7.2.2"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

Mirror-mode + \"Use my Chrome\" was crashing with `Frame was detached` before any `page.goto` ever fired. Tracked it to **patchright** (the stealth-patched Playwright fork we use): its `FrameSession._initialize` walks every existing frame tree on `connectOverCDP` and throws the moment it touches a stale frame in any unrelated tab. With 42 open tabs in a normal user's Chrome, that's a near-certainty.

Spike that isolated the bug:
- Patchright 1.59.4 against same Chrome → throws inside `FrameSession._initialize`, no goto runs.
- Vanilla `playwright@1.60.0` against the same Chrome → every probe passes (about:blank, example.com, LinkedIn, Revolut all navigate cleanly).

## Fix

Add `playwright-vanilla: npm:playwright@^1.60.0` alongside the existing `playwright: npm:patchright@^1.57.0` alias, and use vanilla **only for the CDP-attach branch** in `packages/connector-sdk/src/browser-network.ts`. Persistent-profile launches and headless-stealth launches keep using patchright where stealth actually matters. The CDP attach path runs inside the user's real browser — already the strongest cloak, no stealth patches needed there.

## Verified end-to-end

```
$ lobu connector run linkedin --auth-profile google-chrome-burak-emre \
    --org buremba --max-items 1 \
    --config '{\"company_url\":\"https://www.linkedin.com/company/anthropic/\"}'
...
[BrowserNetwork] Connected via CDP
[BrowserNetwork] Navigating https://www.linkedin.com/company/anthropic/posts/
[BrowserNetwork] No new API response, stopping
✓ Completed in 26.1s
```

## Known follow-up (not in this PR)

Revolut still fails — but now with a different, much smaller, connector-level error: `Authentication check failed via CDP — you may not be logged in to this site in Chrome`. The cause is `revolut.ts`'s `checkAuth` firing 8s after `page.goto` while the new tab is still on `sso.revolut.com/passcode` mid-OAuth handshake (it'd land back on `app.revolut.com` a few seconds later). That needs a fix in `packages/connectors/src/revolut.ts` to wait for the redirect back, not in the SDK.

## Test plan
- [x] Repro confirmed: patchright crashes pre-goto on 42-tab Chrome, vanilla doesn't
- [x] LinkedIn via lobu connector run → success
- [x] Revolut via lobu connector run → no more Frame-detach (different failure, separate ticket)
- [x] `cd packages/connector-sdk && bun run build` clean
- [x] biome + tsc clean (pre-commit hook)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added `playwright-vanilla` as a dependency across multiple packages for improved browser connection handling.
  * Updated internal browser network connection logic to use the new Playwright variant.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lobu-ai/lobu/pull/731)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->