### PR TITLE
fix(apply): surface config path, auto-load .env, schema-prep for per-org agent IDs

### DIFF
--- a/db/migrations/20260515120000_agents_per_org_pk.sql
+++ b/db/migrations/20260515120000_agents_per_org_pk.sql
@@ -1,0 +1,66 @@
+-- migrate:up
+-- Phase A of moving `agents` from a globally-unique `id` PK to a per-org
+-- composite PK `(organization_id, id)`. The application has always treated
+-- agents as org-scoped (every read/delete/list filters by organization_id),
+-- so the global PK is a latent footgun: two orgs cannot share an agent ID,
+-- and a stale agent in one org silently blocks another org from using the
+-- same name.
+--
+-- This phase is INTENTIONALLY NON-BREAKING. It only:
+--   1. Adds an `organization_id` column to each FK-holding child table
+--      (NULLABLE — backfilled here, set NOT NULL in a later phase once the
+--      app-code refactor lands so every INSERT writes the value).
+--   2. Backfills `organization_id` from agents (no orphan rows in prod).
+--   3. Adds a parallel UNIQUE constraint on `agents (organization_id, id)`
+--      so the schema is ready for the eventual PK swap.
+--   4. Adds composite indexes on each child table so the upcoming
+--      org-scoped query patterns are fast from day one.
+--
+-- The single-column PK on agents and the single-column FKs on child tables
+-- stay in place. App code keeps working unmodified. The PK swap and FK
+-- composite migration ship in a separate PR after the storage interfaces
+-- are plumbed with `organization_id`.
+
+-- ── 1. Add organization_id columns (nullable for now).
+ALTER TABLE agent_grants            ADD COLUMN organization_id text;
+ALTER TABLE agent_connections       ADD COLUMN organization_id text;
+ALTER TABLE agent_users             ADD COLUMN organization_id text;
+ALTER TABLE agent_channel_bindings  ADD COLUMN organization_id text;
+ALTER TABLE grants                  ADD COLUMN organization_id text;
+
+-- ── 2. Backfill from agents.
+UPDATE agent_grants           SET organization_id = a.organization_id FROM agents a WHERE agent_grants.agent_id            = a.id;
+UPDATE agent_connections      SET organization_id = a.organization_id FROM agents a WHERE agent_connections.agent_id       = a.id;
+UPDATE agent_users            SET organization_id = a.organization_id FROM agents a WHERE agent_users.agent_id             = a.id;
+UPDATE agent_channel_bindings SET organization_id = a.organization_id FROM agents a WHERE agent_channel_bindings.agent_id  = a.id;
+UPDATE grants                 SET organization_id = a.organization_id FROM agents a WHERE grants.agent_id                  = a.id;
+
+-- ── 3. Parallel UNIQUE on agents (organization_id, id). The single-column
+--     PK on (id) stays — this is purely additive and signals to readers
+--     that org-scoped uniqueness is the eventual model. The PK swap in a
+--     later migration will drop this UNIQUE and reuse the index for the
+--     new composite PK.
+ALTER TABLE agents
+  ADD CONSTRAINT agents_organization_id_id_key UNIQUE (organization_id, id);
+
+-- ── 4. Composite indexes on child tables for upcoming org-scoped queries.
+CREATE INDEX agent_grants_org_agent_idx           ON agent_grants           (organization_id, agent_id);
+CREATE INDEX agent_connections_org_agent_idx      ON agent_connections      (organization_id, agent_id);
+CREATE INDEX agent_users_org_agent_idx            ON agent_users            (organization_id, agent_id);
+CREATE INDEX agent_channel_bindings_org_agent_idx ON agent_channel_bindings (organization_id, agent_id);
+CREATE INDEX grants_org_agent_idx                 ON grants                 (organization_id, agent_id);
+
+-- migrate:down
+DROP INDEX IF EXISTS grants_org_agent_idx;
+DROP INDEX IF EXISTS agent_channel_bindings_org_agent_idx;
+DROP INDEX IF EXISTS agent_users_org_agent_idx;
+DROP INDEX IF EXISTS agent_connections_org_agent_idx;
+DROP INDEX IF EXISTS agent_grants_org_agent_idx;
+
+ALTER TABLE agents DROP CONSTRAINT IF EXISTS agents_organization_id_id_key;
+
+ALTER TABLE grants                  DROP COLUMN IF EXISTS organization_id;
+ALTER TABLE agent_channel_bindings  DROP COLUMN IF EXISTS organization_id;
+ALTER TABLE agent_users             DROP COLUMN IF EXISTS organization_id;
+ALTER TABLE agent_connections       DROP COLUMN IF EXISTS organization_id;
+ALTER TABLE agent_grants            DROP COLUMN IF EXISTS organization_id;

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -113,7 +113,8 @@ CREATE TABLE public.agent_channel_bindings (
     platform text NOT NULL,
     channel_id text NOT NULL,
     team_id text,
-    created_at timestamp with time zone DEFAULT now() NOT NULL
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    organization_id text
 );
 
 --
@@ -131,6 +132,7 @@ CREATE TABLE public.agent_connections (
     error_message text,
     created_at timestamp with time zone DEFAULT now() NOT NULL,
     updated_at timestamp with time zone DEFAULT now() NOT NULL,
+    organization_id text,
     CONSTRAINT agent_connections_status_check CHECK ((status = ANY (ARRAY['active'::text, 'stopped'::text, 'error'::text])))
 );
 
@@ -144,7 +146,8 @@ CREATE TABLE public.agent_grants (
     pattern text NOT NULL,
     expires_at timestamp with time zone,
     granted_at timestamp with time zone DEFAULT now() NOT NULL,
-    denied boolean DEFAULT false
+    denied boolean DEFAULT false,
+    organization_id text
 );
 
 --
@@ -187,7 +190,8 @@ CREATE TABLE public.agent_users (
     agent_id text NOT NULL,
     platform text NOT NULL,
     user_id text NOT NULL,
-    created_at timestamp with time zone DEFAULT now() NOT NULL
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    organization_id text
 );
 
 --
@@ -1104,7 +1108,8 @@ CREATE TABLE public.grants (
     pattern text NOT NULL,
     expires_at timestamp with time zone,
     granted_at timestamp with time zone DEFAULT now() NOT NULL,
-    denied boolean DEFAULT false NOT NULL
+    denied boolean DEFAULT false NOT NULL,
+    organization_id text
 );
 
 --
@@ -1561,7 +1566,7 @@ CREATE TABLE public.scheduled_jobs (
 --
 
 CREATE TABLE public.schema_migrations (
-    version character varying(128) NOT NULL
+    version character varying NOT NULL
 );
 
 --
@@ -2237,6 +2242,13 @@ ALTER TABLE ONLY public.agent_users
     ADD CONSTRAINT agent_users_pkey PRIMARY KEY (agent_id, platform, user_id);
 
 --
+-- Name: agents agents_organization_id_id_key; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.agents
+    ADD CONSTRAINT agents_organization_id_id_key UNIQUE (organization_id, id);
+
+--
 -- Name: agents agents_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -2778,10 +2790,22 @@ CREATE INDEX agent_channel_bindings_agent_id_idx ON public.agent_channel_binding
 CREATE UNIQUE INDEX agent_channel_bindings_no_team_unique ON public.agent_channel_bindings USING btree (platform, channel_id) WHERE (team_id IS NULL);
 
 --
+-- Name: agent_channel_bindings_org_agent_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX agent_channel_bindings_org_agent_idx ON public.agent_channel_bindings USING btree (organization_id, agent_id);
+
+--
 -- Name: agent_connections_agent_id_idx; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX agent_connections_agent_id_idx ON public.agent_connections USING btree (agent_id);
+
+--
+-- Name: agent_connections_org_agent_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX agent_connections_org_agent_idx ON public.agent_connections USING btree (organization_id, agent_id);
 
 --
 -- Name: agent_connections_platform_idx; Type: INDEX; Schema: public; Owner: -
@@ -2794,6 +2818,12 @@ CREATE INDEX agent_connections_platform_idx ON public.agent_connections USING bt
 --
 
 CREATE INDEX agent_grants_agent_id_idx ON public.agent_grants USING btree (agent_id);
+
+--
+-- Name: agent_grants_org_agent_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX agent_grants_org_agent_idx ON public.agent_grants USING btree (organization_id, agent_id);
 
 --
 -- Name: agent_secrets_expires_at_idx; Type: INDEX; Schema: public; Owner: -
@@ -2812,6 +2842,12 @@ CREATE INDEX agent_secrets_name_prefix_idx ON public.agent_secrets USING btree (
 --
 
 CREATE INDEX agent_secrets_org_id_idx ON public.agent_secrets USING btree (organization_id);
+
+--
+-- Name: agent_users_org_agent_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX agent_users_org_agent_idx ON public.agent_users USING btree (organization_id, agent_id);
 
 --
 -- Name: agents_organization_id_idx; Type: INDEX; Schema: public; Owner: -
@@ -2902,6 +2938,12 @@ CREATE INDEX grants_agent_id_idx ON public.grants USING btree (agent_id);
 --
 
 CREATE INDEX grants_expires_at_idx ON public.grants USING btree (expires_at) WHERE (expires_at IS NOT NULL);
+
+--
+-- Name: grants_org_agent_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX grants_org_agent_idx ON public.grants USING btree (organization_id, agent_id);
 
 --
 -- Name: idx_cc_classifier_version_id; Type: INDEX; Schema: public; Owner: -
@@ -4952,4 +4994,5 @@ INSERT INTO public.schema_migrations (version) VALUES
     ('20260514000000'),
     ('20260514120000'),
     ('20260514130000'),
-    ('20260514160000');
+    ('20260514160000'),
+    ('20260515120000');

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -1566,7 +1566,7 @@ CREATE TABLE public.scheduled_jobs (
 --
 
 CREATE TABLE public.schema_migrations (
-    version character varying NOT NULL
+    version character varying(128) NOT NULL
 );
 
 --

--- a/examples/office-bot/lobu.toml
+++ b/examples/office-bot/lobu.toml
@@ -37,7 +37,6 @@ key = "$Z_AI_API_KEY"
 # Slack app. `channel` surface so it works in a channel, not just a DM.
 [agents.food-ordering.preview.slack]
 enabled = true
-provider = "lobu-public"
 surfaces = ["dm", "channel"]
 code_ttl_minutes = 15
 
@@ -69,8 +68,8 @@ fail closed and deny with a reason.
 
 [memory]
 enabled = true
-org = "office-bot"
-name = "Office Bot"
+org = "lobu-team"
+name = "Lobu Team"
 description = "Office-ops agents — first up: the weekday lunch order"
 models = "./models"
 data = "./data"

--- a/packages/cli/src/commands/_lib/apply/apply-cmd.ts
+++ b/packages/cli/src/commands/_lib/apply/apply-cmd.ts
@@ -2,6 +2,7 @@ import { readFile, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import chalk from "chalk";
 import { resolveContext } from "../../../internal/context.js";
+import { parseEnvContent } from "../../../internal/env-file.js";
 import { loadProjectLink } from "../../../internal/project-link.js";
 import { CONFIG_FILENAME } from "../../../config/loader.js";
 import { ApiError, ValidationError } from "../../memory/_lib/errors.js";
@@ -87,6 +88,26 @@ function checkRequiredSecrets(state: DesiredState): { missing: string[] } {
     (name) => process.env[name] === undefined || process.env[name] === ""
   );
   return { missing };
+}
+
+/**
+ * Merge `.env` values from the project dir into `process.env` (without
+ * overriding values already set in the shell). Quietly noop if the file
+ * doesn't exist or can't be parsed — `checkRequiredSecrets` will surface a
+ * clear "Missing required secret" error downstream.
+ */
+async function loadProjectEnvFile(cwd: string): Promise<void> {
+  const envPath = join(cwd, ".env");
+  let raw: string;
+  try {
+    raw = await readFile(envPath, "utf-8");
+  } catch {
+    return;
+  }
+  const vars = parseEnvContent(raw);
+  for (const [key, value] of Object.entries(vars)) {
+    if (process.env[key] === undefined) process.env[key] = value;
+  }
 }
 
 // ── source_url: confirmed-before-fetch, https-only, bounded fetch ──────────
@@ -808,6 +829,12 @@ function slugToTitle(slug: string): string {
 export async function applyCommand(opts: ApplyOptions = {}): Promise<void> {
   const cwd = opts.cwd ?? process.cwd();
   const fetchImpl = opts.fetchImpl ?? fetch;
+
+  // Auto-load `.env` from the project dir so $VAR refs in lobu.toml resolve
+  // without the user having to `set -a; source .env; set +a`. Mirrors what
+  // `lobu dev` does. Existing process.env values win (don't clobber the shell).
+  await loadProjectEnvFile(cwd);
+
   const { state, configPath } = await loadDesiredState({
     cwd,
     ...(opts.only ? { only: opts.only } : {}),

--- a/packages/cli/src/config/loader.ts
+++ b/packages/cli/src/config/loader.ts
@@ -36,7 +36,7 @@ export async function loadConfig(cwd: string): Promise<LoadResult | LoadError> {
     parsed = parseToml(raw) as Record<string, unknown>;
   } catch (err) {
     return {
-      error: `Invalid TOML syntax in ${CONFIG_FILENAME}`,
+      error: `Invalid TOML syntax in ${configPath}`,
       details: [err instanceof Error ? err.message : String(err)],
     };
   }
@@ -46,7 +46,7 @@ export async function loadConfig(cwd: string): Promise<LoadResult | LoadError> {
     const details = result.error.issues.map(
       (issue) => `${issue.path.join(".")}: ${issue.message}`
     );
-    return { error: `Invalid ${CONFIG_FILENAME}`, details };
+    return { error: `Invalid ${configPath}`, details };
   }
 
   return { config: result.data, path: configPath };

--- a/packages/server/src/db/embedded-schema-patches.ts
+++ b/packages/server/src/db/embedded-schema-patches.ts
@@ -518,4 +518,48 @@ export const EMBEDDED_SCHEMA_PATCHES: EmbeddedSchemaPatch[] = [
       `);
     },
   },
+  {
+    // Mirrors db/migrations/20260515120000_agents_per_org_pk.sql — phase A only.
+    // Adds organization_id (NULLABLE) to the 5 FK-holding child tables, backfills
+    // from agents, adds a parallel UNIQUE (organization_id, id) on agents, and
+    // creates composite indexes for upcoming org-scoped queries. The PK swap
+    // and FK composite migration ship in a later phase once the storage
+    // interfaces are plumbed with organization_id everywhere.
+    id: 'agents-per-org-pk-phase-a',
+    apply: async (sql) => {
+      for (const t of [
+        'agent_grants',
+        'agent_connections',
+        'agent_users',
+        'agent_channel_bindings',
+        'grants',
+      ]) {
+        await sql.unsafe(`
+          ALTER TABLE public.${t}
+          ADD COLUMN IF NOT EXISTS organization_id text
+        `);
+        await sql.unsafe(`
+          UPDATE public.${t} c
+          SET organization_id = a.organization_id
+          FROM public.agents a
+          WHERE c.agent_id = a.id AND c.organization_id IS NULL
+        `);
+        await sql.unsafe(`
+          CREATE INDEX IF NOT EXISTS ${t}_org_agent_idx
+          ON public.${t} (organization_id, agent_id)
+        `);
+      }
+      await sql.unsafe(`
+        DO $$
+        BEGIN
+          IF NOT EXISTS (
+            SELECT 1 FROM pg_constraint WHERE conname = 'agents_organization_id_id_key'
+          ) THEN
+            ALTER TABLE public.agents
+              ADD CONSTRAINT agents_organization_id_id_key UNIQUE (organization_id, id);
+          END IF;
+        END$$;
+      `);
+    },
+  },
 ];


### PR DESCRIPTION
## Why

While debugging why `lobu apply` silently failed against `examples/office-bot`, three distinct issues compounded into the same observable: nothing landed in the target org. This PR fixes the two CLI ergonomics problems that hide root cause, plus phase A of the actual schema fix.

The original failure chain was:
1. `examples/office-bot/lobu.toml` had `provider = "lobu-public"` under `[agents.<id>.preview.slack]`. The schema is `.strict()` so validation aborted before *any* row was written. The error message was `Invalid lobu.toml: …` — no file path.
2. After fixing the toml, apply failed `Missing required secret: $Z_AI_API_KEY`. The key was in `examples/office-bot/.env` but `lobu apply` doesn't auto-load `.env` (only `lobu dev` does).
3. After exporting the key, apply failed `Agent ID already exists in another organization`. `agents.id` is the PK alone — globally unique — so a stale `food-ordering` agent in the `market` org silently blocked `lobu-team` from creating one with the same name. The application has always treated agents as org-scoped (`getOrgId()` filters on every read/delete/list); the global PK is a latent footgun.

## Summary

- **`Invalid lobu.toml` → `Invalid <absolute path>`** for both schema and TOML-syntax errors. Users can now click the path in their terminal.
- **`lobu apply` auto-loads `.env`** from cwd before resolving `\$VAR` refs (shell env wins). Mirrors `lobu dev`.
- **Phase A schema migration** (non-breaking): adds `organization_id text NULL` to the 5 child tables that FK on `agents.id` (`agent_grants`, `agent_connections`, `agent_users`, `agent_channel_bindings`, `grants`), backfills from `agents`, adds parallel `UNIQUE (organization_id, id)` on `agents`, plus composite indexes for the upcoming org-scoped query patterns. Existing PK and FKs stay. **App code unchanged.**

Phases B + C of the per-org PK migration ship in separate PRs:
- **Phase B**: plumb `organization_id` through ~67 storage call sites in `packages/server/src` that currently key only on `agent_id`. Many lack org context in their immediate scope (`agent_users.addUserAgent(platform, userId, agentId)` is the worst). Bigger refactor; deserves its own review pass.
- **Phase C**: drop old single-column PK on agents, swap to composite, add composite FKs. Tiny PR; schema-only after Phase B is in.

## Test plan

- [x] `bun run typecheck` clean
- [x] `make build-packages` clean
- [x] `bun test packages/cli/src/commands/_lib/apply` — 114 pass, 0 fail
- [x] PGlite smoke: fresh DB boots cleanly with the new embedded patch; second boot is idempotent (no errors)
- [x] Verified the new column / unique / indexes exist after first boot
- [x] `lobu apply --dry-run --org lobu-team` from `examples/office-bot` (no manual `set -a; source .env`) — picks up `Z_AI_API_KEY` from `.env`, plan renders correctly
- [x] Schema error includes file path: injected the bad `provider = "lobu-public"` key, got `Error: Invalid /private/tmp/lobu-test-bad/lobu.toml`
- [ ] Migration applies cleanly against the prod-shape DB (dbmate up) — verify before merge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CLI auto-loads local .env files to resolve environment variables during configuration/apply.

* **Improvements**
  * Configuration error messages now show the full resolved config file path for clearer diagnostics.
  * Example agent preview identity updated (display/org name changes).

* **Database**
  * Added organization_id to agent-related tables and grants, backfilled values, added composite org+agent indexes, and introduced an additive uniqueness constraint on agents to support org-scoped lookups.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lobu-ai/lobu/pull/734)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->