### PR TITLE
fix(core): accept URL-safe base64 in ENCRYPTION_KEY validator (prod hotfix)

### DIFF
--- a/packages/core/src/__tests__/encryption-key-validation.test.ts
+++ b/packages/core/src/__tests__/encryption-key-validation.test.ts
@@ -42,6 +42,15 @@ describe("ENCRYPTION_KEY validation", () => {
     expect(decrypt(enc)).toBe("base64 secret");
   });
 
+  test("valid 32-byte URL-safe base64 key round-trips encrypt/decrypt", () => {
+    // Historical keys were sometimes generated with `openssl rand -base64 32 |
+    // tr +/ -_` and stored in URL-safe form (alphabet [A-Za-z0-9_-], no
+    // padding). Same 32 bytes — must be accepted.
+    process.env.ENCRYPTION_KEY = Buffer.alloc(32, 99).toString("base64url");
+    const enc = encrypt("urlsafe secret");
+    expect(decrypt(enc)).toBe("urlsafe secret");
+  });
+
   test("valid 64-char hex key round-trips encrypt/decrypt", () => {
     process.env.ENCRYPTION_KEY =
       "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";

--- a/packages/core/src/utils/encryption.ts
+++ b/packages/core/src/utils/encryption.ts
@@ -34,6 +34,21 @@ function getEncryptionKey(): Buffer {
     }
   }
 
+  // Try as URL-safe base64 (alphabet [A-Za-z0-9_-], no padding). Historically
+  // some keys were generated as `openssl rand -base64 32 | tr +/ -_` and stored
+  // in this form; same 32 bytes, just a different alphabet. Apply the same
+  // round-trip check so typos still get rejected.
+  if (/^[A-Za-z0-9_-]+$/.test(key)) {
+    const urlsafeBuffer = Buffer.from(key, "base64url");
+    if (
+      urlsafeBuffer.length === 32 &&
+      urlsafeBuffer.toString("base64url") === key
+    ) {
+      cachedKey = urlsafeBuffer;
+      return urlsafeBuffer;
+    }
+  }
+
   // Try as hex (must be exactly 64 hex characters for 32 bytes), again
   // verifying the round-trip so partially-valid input is rejected.
   if (/^[0-9a-fA-F]+$/.test(key) && key.length % 2 === 0) {


### PR DESCRIPTION
## Why — prod is broken right now

PR #692 ("sec: hardening sweep — encryption-key", merged 2026-05-13) tightened `getEncryptionKey()` in `packages/core/src/utils/encryption.ts` to require strict canonical base64 (`[A-Za-z0-9+/]`).

Prod's existing `ENCRYPTION_KEY` is **URL-safe base64** (uses `_`/`-` instead of `+`/`/`) — generated historically with `openssl rand -base64 32 | tr +/ -_`. Decodes to the same 32 bytes; the alphabet is the only difference. The new regex rejects it.

**Effect**: every call to `encrypt()` / `decrypt()` 500s in prod. App-pod logs show:

```
[worker-auth] Error verifying token: ENCRYPTION_KEY must be a canonical base64...
  at getEncryptionKey
  at encrypt
  at generateWorkerToken
  at /lobu/api/v1/agents
```

`lobu chat` against any agent on `app.lobu.ai` returns `Internal server error`. The food-ordering watchers (`lunch-open` / `lunch-finalize`, scheduled Mon-Fri 11:00 / 11:35 UTC in `lobu-team`) will fail when they fire on Monday — same code path.

## Fix

Add a parallel branch that accepts URL-safe base64 (`[A-Za-z0-9_-]`, no padding), with the same round-trip + length check so typo'd keys are still rejected.

No key rotation needed — URL-safe and standard base64 decode to identical 32 bytes.

## Test plan

- [x] `bun test packages/core/src/__tests__/encryption-key-validation.test.ts` — 7 pass (added one for URL-safe).
- [x] `bun run typecheck` clean.
- [ ] **Post-deploy**: `lobu chat -c lobu -a food-ordering "ping"` against `lobu-team` returns a real reply (currently 500s).
- [ ] **Post-deploy**: `[worker-auth] Error verifying token` lines stop appearing in `summaries-app-lobu-app` pod logs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Encryption keys now support URL-safe base64 format in addition to existing formats.

* **Tests**
  * Added regression test to validate URL-safe base64 encryption key handling with round-trip encryption and decryption.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lobu-ai/lobu/pull/735)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->