### PR TITLE
feat(mac): collapse Chrome profile rows behind a disclosure

### DIFF
--- a/apps/mac/Lobu/BrowserProfilesView.swift
+++ b/apps/mac/Lobu/BrowserProfilesView.swift
@@ -75,6 +75,12 @@ struct SingleBrowserRow: View {
     /// via DevToolsActivePort at sync time"; non-empty pins a specific
     /// port for unusual Chrome launches.
     @State private var cdpPortText: String = ""
+    /// Whether the un-mirrored source profiles list is expanded.
+    /// Mirrored profiles are always visible (they're active integrations);
+    /// the unmirrored ones are hidden by default since they're "available
+    /// to add" — Chrome typically has 3-10+ system/sign-in profiles and
+    /// rendering them all inline drowns out everything else in the menu.
+    @State private var expanded: Bool = false
 
     private var myProfiles: [WorkerClient.BrowserAuthProfile] {
         hub.profiles.filter { $0.browser_kind == browser.kind.rawValue }
@@ -89,50 +95,95 @@ struct SingleBrowserRow: View {
     }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 2) {
+        // Split into "mirrored" (active integrations — always visible) and
+        // "unmirrored" (available-to-add — hidden behind the disclosure).
+        let mirroredSources = sourceProfiles.filter { mirroredProfile(for: $0) != nil }
+        let unmirroredSources = sourceProfiles.filter { mirroredProfile(for: $0) == nil }
+
+        return VStack(alignment: .leading, spacing: 2) {
             HStack(spacing: 8) {
                 Image(systemName: "globe")
                     .foregroundStyle(.blue)
                     .frame(width: 18)
                 VStack(alignment: .leading, spacing: 1) {
                     Text(browser.kind.displayName).font(.caption)
-                    Text(headerStatus())
-                        .font(.caption2).foregroundStyle(.secondary)
+                    Text(headerStatus(
+                        mirroredCount: mirroredSources.count,
+                        totalCount: sourceProfiles.count
+                    ))
+                    .font(.caption2).foregroundStyle(.secondary)
                 }
                 Spacer()
-                // Single browser-level CDP control: port input +
-                // checkbox. One Chrome process = one CDP server, so this
-                // applies to every profile under this browser. Hidden
-                // entirely when DevToolsActivePort hasn't found a live
-                // listener — there's nothing meaningful to attach to.
-                if detectedCdpPort != nil {
-                    TextField(
-                        detectedCdpPort.map(String.init) ?? "port",
-                        text: $cdpPortText
-                    )
-                    .textFieldStyle(.roundedBorder)
-                    .controlSize(.mini).font(.caption2)
-                    .frame(maxWidth: 60)
-                    Toggle("Use my Chrome", isOn: $allowCdp)
-                        .toggleStyle(.checkbox)
-                        .controlSize(.mini).font(.caption2)
-                        .help(
-                            "Run connectors inside your real Chrome (best for sites like Revolut that pin sessions to a browser fingerprint). Off = Lobu only reads cookies, never touches the live browser process."
-                        )
+                // Disclosure chevron. Always shown so the CDP controls
+                // (live behind the disclosure) remain reachable; the only
+                // case where we hide it is when there is literally nothing
+                // to show under the disclosure either.
+                let hasExpandableContent =
+                    !unmirroredSources.isEmpty
+                    || sourceProfiles.isEmpty
+                    || detectedCdpPort != nil
+                if hasExpandableContent {
+                    Button {
+                        withAnimation(.easeInOut(duration: 0.15)) { expanded.toggle() }
+                    } label: {
+                        Image(systemName: "chevron.right")
+                            .font(.caption2)
+                            .foregroundStyle(.tertiary)
+                            .rotationEffect(.degrees(expanded ? 90 : 0))
+                            .frame(width: 12, height: 12)
+                    }
+                    .buttonStyle(.plain)
+                    .help(expanded ? "Hide other profiles" : "Show options")
                 }
             }
             .padding(.vertical, 4)
             .padding(.horizontal, 6)
 
-            ForEach(sourceProfiles) { src in
+            // Active integrations — always visible.
+            ForEach(mirroredSources) { src in
                 sourceProfileRow(src)
                     .padding(.leading, 32).padding(.trailing, 6)
             }
-            if sourceProfiles.isEmpty {
-                Text("No \(browser.kind.displayName) profiles found on this Mac.")
-                    .font(.caption2).foregroundStyle(.secondary)
-                    .padding(.leading, 32).padding(.bottom, 4)
+
+            // Available-to-add profiles + browser-level CDP controls +
+            // empty-state — only when expanded.
+            if expanded {
+                // Browser-level CDP control. One Chrome process = one CDP
+                // server, so this applies to every profile under this
+                // browser. Hidden when DevToolsActivePort hasn't found a
+                // live listener — there's nothing meaningful to attach to.
+                if detectedCdpPort != nil {
+                    HStack(spacing: 6) {
+                        Toggle("Use my Chrome", isOn: $allowCdp)
+                            .toggleStyle(.checkbox)
+                            .controlSize(.mini).font(.caption2)
+                            .help(
+                                "Run connectors inside your real Chrome (best for sites like Revolut that pin sessions to a browser fingerprint). Off = Lobu only reads cookies, never touches the live browser process."
+                            )
+                        Spacer()
+                        Text("Port").font(.caption2).foregroundStyle(.secondary)
+                        TextField(
+                            detectedCdpPort.map(String.init) ?? "port",
+                            text: $cdpPortText
+                        )
+                        .textFieldStyle(.roundedBorder)
+                        .controlSize(.mini).font(.caption2)
+                        .frame(maxWidth: 60)
+                    }
+                    .padding(.leading, 32).padding(.trailing, 6).padding(.bottom, 2)
+                }
+
+                ForEach(unmirroredSources) { src in
+                    sourceProfileRow(src)
+                        .padding(.leading, 32).padding(.trailing, 6)
+                }
+                if sourceProfiles.isEmpty {
+                    Text("No \(browser.kind.displayName) profiles found on this Mac.")
+                        .font(.caption2).foregroundStyle(.secondary)
+                        .padding(.leading, 32).padding(.bottom, 4)
+                }
             }
+
             // Surface any save / fetch failure inline so the user sees
             // what's wrong instead of "I clicked Mirror and nothing
             // happened." Stays as long as hub.loadError is non-nil; the
@@ -163,7 +214,14 @@ struct SingleBrowserRow: View {
         }
     }
 
-    private func headerStatus() -> String {
+    private func headerStatus(mirroredCount: Int, totalCount: Int) -> String {
+        // When the user already has profiles mirrored, the count is the
+        // most useful summary — the descriptive blurbs belong on the
+        // first run / discovery experience, not on the steady-state UI.
+        if totalCount > 0 {
+            let suffix = totalCount == 1 ? "profile" : "profiles"
+            return "\(mirroredCount) of \(totalCount) \(suffix) mirrored"
+        }
         if detectedCdpPort != nil {
             return
                 "Your Chrome is reachable. Check 'Use my Chrome' to let Lobu run inside it for sites that need a live session."

--- a/apps/mac/Lobu/BrowserProfilesView.swift
+++ b/apps/mac/Lobu/BrowserProfilesView.swift
@@ -61,26 +61,14 @@ struct SingleBrowserRow: View {
 
     @State private var sourceProfiles: [InstalledBrowserProfile] = []
     @State private var savingDir: String?
-    @State private var confirmingDeleteId: Int?
-    /// Detected CDP port via DevToolsActivePort on view appear. Pre-fills
-    /// the browser-level port input. nil when Chrome isn't exposing
-    /// remote debugging.
+    /// Detected CDP port via DevToolsActivePort on view appear. Surfaced
+    /// inline in the "Connect to my Chrome" menu row; nil when Chrome
+    /// isn't exposing remote debugging.
     @State private var detectedCdpPort: Int?
     /// Single browser-level opt-in to CDP attach. Chrome runs one CDP
-    /// server per user-data root, so the consent + port input live at
-    /// the browser header — every profile under this Chrome inherits the
-    /// same setting when the user clicks Mirror.
+    /// server per user-data root, so the consent is browser-wide — every
+    /// profile under this Chrome inherits this setting on the next mirror.
     @State private var allowCdp: Bool = false
-    /// Browser-level CDP port override. Empty string means "auto-discover
-    /// via DevToolsActivePort at sync time"; non-empty pins a specific
-    /// port for unusual Chrome launches.
-    @State private var cdpPortText: String = ""
-    /// Whether the un-mirrored source profiles list is expanded.
-    /// Mirrored profiles are always visible (they're active integrations);
-    /// the unmirrored ones are hidden by default since they're "available
-    /// to add" — Chrome typically has 3-10+ system/sign-in profiles and
-    /// rendering them all inline drowns out everything else in the menu.
-    @State private var expanded: Bool = false
 
     private var myProfiles: [WorkerClient.BrowserAuthProfile] {
         hub.profiles.filter { $0.browser_kind == browser.kind.rawValue }
@@ -95,94 +83,68 @@ struct SingleBrowserRow: View {
     }
 
     var body: some View {
-        // Split into "mirrored" (active integrations — always visible) and
-        // "unmirrored" (available-to-add — hidden behind the disclosure).
-        let mirroredSources = sourceProfiles.filter { mirroredProfile(for: $0) != nil }
-        let unmirroredSources = sourceProfiles.filter { mirroredProfile(for: $0) == nil }
+        let mirroredCount = sourceProfiles.filter { mirroredProfile(for: $0) != nil }.count
 
         return VStack(alignment: .leading, spacing: 2) {
-            HStack(spacing: 8) {
-                Image(systemName: "globe")
-                    .foregroundStyle(.blue)
-                    .frame(width: 18)
-                VStack(alignment: .leading, spacing: 1) {
-                    Text(browser.kind.displayName).font(.caption)
-                    Text(headerStatus(
-                        mirroredCount: mirroredSources.count,
-                        totalCount: sourceProfiles.count
-                    ))
-                    .font(.caption2).foregroundStyle(.secondary)
-                }
-                Spacer()
-                // Disclosure chevron. Always shown so the CDP controls
-                // (live behind the disclosure) remain reachable; the only
-                // case where we hide it is when there is literally nothing
-                // to show under the disclosure either.
-                let hasExpandableContent =
-                    !unmirroredSources.isEmpty
-                    || sourceProfiles.isEmpty
-                    || detectedCdpPort != nil
-                if hasExpandableContent {
-                    Button {
-                        withAnimation(.easeInOut(duration: 0.15)) { expanded.toggle() }
-                    } label: {
-                        Image(systemName: "chevron.right")
-                            .font(.caption2)
-                            .foregroundStyle(.tertiary)
-                            .rotationEffect(.degrees(expanded ? 90 : 0))
-                            .frame(width: 12, height: 12)
-                    }
-                    .buttonStyle(.plain)
-                    .help(expanded ? "Hide other profiles" : "Show options")
-                }
-            }
-            .padding(.vertical, 4)
-            .padding(.horizontal, 6)
-
-            // Active integrations — always visible.
-            ForEach(mirroredSources) { src in
-                sourceProfileRow(src)
-                    .padding(.leading, 32).padding(.trailing, 6)
-            }
-
-            // Available-to-add profiles + browser-level CDP controls +
-            // empty-state — only when expanded.
-            if expanded {
-                // Browser-level CDP control. One Chrome process = one CDP
-                // server, so this applies to every profile under this
-                // browser. Hidden when DevToolsActivePort hasn't found a
-                // live listener — there's nothing meaningful to attach to.
-                if detectedCdpPort != nil {
-                    HStack(spacing: 6) {
-                        Text("Port").font(.caption2).foregroundStyle(.secondary)
-                        TextField(
-                            detectedCdpPort.map(String.init) ?? "port",
-                            text: $cdpPortText
+            Menu {
+                // CDP attach row — only when DevToolsActivePort detected a
+                // live Chrome listener. One Chrome process = one CDP server,
+                // so this is browser-wide, sits above the per-profile
+                // section. The label embeds the detected port so the user
+                // sees what they're attaching to without a separate textfield
+                // (NSMenu can't host one cleanly anyway).
+                if let port = detectedCdpPort {
+                    Section("Live browser session") {
+                        Toggle(
+                            "Connect to my Chrome (port \(port))",
+                            isOn: $allowCdp
                         )
-                        .textFieldStyle(.roundedBorder)
-                        .controlSize(.mini).font(.caption2)
-                        .frame(maxWidth: 60)
-                        Spacer()
-                        Toggle("Use my Chrome", isOn: $allowCdp)
-                            .toggleStyle(.checkbox)
-                            .controlSize(.mini).font(.caption2)
-                            .help(
-                                "Run connectors inside your real Chrome (best for sites like Revolut that pin sessions to a browser fingerprint). Off = Lobu only reads cookies, never touches the live browser process."
-                            )
+                        if allowCdp {
+                            Button("Disconnect Chrome", role: .destructive) {
+                                allowCdp = false
+                            }
+                        }
                     }
-                    .padding(.leading, 32).padding(.trailing, 6).padding(.bottom, 2)
                 }
 
-                ForEach(unmirroredSources) { src in
-                    sourceProfileRow(src)
-                        .padding(.leading, 32).padding(.trailing, 6)
+                Section(sourceProfiles.isEmpty ? "" : "Profiles") {
+                    ForEach(sourceProfiles) { src in
+                        Toggle(
+                            isOn: profileBinding(for: src)
+                        ) {
+                            Text(src.displayName)
+                        }
+                        .disabled(savingDir == src.directoryName)
+                    }
+                    if sourceProfiles.isEmpty {
+                        Text("No \(browser.kind.displayName) profiles found")
+                    }
                 }
-                if sourceProfiles.isEmpty {
-                    Text("No \(browser.kind.displayName) profiles found on this Mac.")
+            } label: {
+                HStack(spacing: 8) {
+                    Image(systemName: "globe")
+                        .foregroundStyle(.blue)
+                        .frame(width: 18)
+                    VStack(alignment: .leading, spacing: 1) {
+                        Text(browser.kind.displayName).font(.caption)
+                        Text(headerStatus(
+                            mirroredCount: mirroredCount,
+                            totalCount: sourceProfiles.count
+                        ))
                         .font(.caption2).foregroundStyle(.secondary)
-                        .padding(.leading, 32).padding(.bottom, 4)
+                    }
+                    Spacer()
+                    Image(systemName: "chevron.right")
+                        .font(.caption2)
+                        .foregroundStyle(.tertiary)
                 }
+                .padding(.vertical, 4)
+                .padding(.horizontal, 6)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .contentShape(Rectangle())
             }
+            .menuStyle(.borderlessButton)
+            .menuIndicator(.hidden)  // we draw our own chevron to match the other Integration rows
 
             // Surface any save / fetch failure inline so the user sees
             // what's wrong instead of "I clicked Mirror and nothing
@@ -230,55 +192,22 @@ struct SingleBrowserRow: View {
             "Cookies stay on this Mac. Connectors run headless."
     }
 
-    @ViewBuilder
-    private func sourceProfileRow(_ source: InstalledBrowserProfile) -> some View {
-        let mirrored = mirroredProfile(for: source)
-        let isMirrored = mirrored != nil
-        HStack(alignment: .center, spacing: 6) {
-            VStack(alignment: .leading, spacing: 0) {
-                Text(source.displayName).font(.caption)
-                if isMirrored {
-                    Text(mirroredStatus(mirrored!))
-                        .font(.caption2).foregroundStyle(.secondary)
+    /// Binding wired into a profile-checkbox row. Reads the current
+    /// mirror state for `source`; flipping the binding kicks off the
+    /// async mirror / delete operation without dismissing the menu.
+    /// Errors land in `hub.loadError` and surface as the inline banner
+    /// under the row.
+    private func profileBinding(for source: InstalledBrowserProfile) -> Binding<Bool> {
+        Binding(
+            get: { mirroredProfile(for: source) != nil },
+            set: { wantsMirror in
+                if wantsMirror {
+                    Task { await mirror(source) }
+                } else if let existing = mirroredProfile(for: source) {
+                    Task { await delete(existing) }
                 }
             }
-            Spacer()
-            if !isMirrored {
-                Button(action: { Task { await mirror(source) } }) {
-                    HStack(spacing: 2) {
-                        Image(systemName: "plus").font(.caption2)
-                        Text("Mirror").font(.caption)
-                    }
-                    .foregroundStyle(.blue)
-                }
-                .buttonStyle(.plain)
-                .disabled(savingDir == source.directoryName)
-            } else if let m = mirrored, confirmingDeleteId == m.id {
-                Button("Confirm", role: .destructive) {
-                    Task { await delete(m) }
-                }
-                .buttonStyle(.plain).font(.caption2).foregroundStyle(.red)
-                Button("Cancel") { confirmingDeleteId = nil }
-                    .buttonStyle(.plain).font(.caption2).foregroundStyle(.secondary)
-            } else if let m = mirrored {
-                Button(action: { confirmingDeleteId = m.id }) {
-                    Image(systemName: "trash").font(.caption2)
-                }
-                .buttonStyle(.plain).foregroundStyle(.secondary)
-            }
-        }
-        .padding(.vertical, 1)
-    }
-
-    private func mirroredStatus(_ p: WorkerClient.BrowserAuthProfile) -> String {
-        let allowed = p.auth_data?.allow_cdp_attach == true
-        if allowed && detectedCdpPort != nil {
-            return "mirrored · uses live Chrome"
-        }
-        if allowed {
-            return "mirrored · would use live Chrome (not running with debug)"
-        }
-        return "mirrored · cookies only"
+        )
     }
 
     @MainActor
@@ -289,26 +218,15 @@ struct SingleBrowserRow: View {
         }
         savingDir = source.directoryName
         defer { savingDir = nil }
-        // Three browser-level knobs (shared across profiles under this
-        // Chrome — Chrome runs one CDP server per user-data root, so
-        // per-profile controls would be lying about the architecture):
-        //   - allow_cdp_attach (checkbox): the consent. Off (default)
-        //     means Lobu never touches the live Chrome.
-        //   - cdpPortText (port input): a pinned override. When set,
-        //     the connector subprocess uses exactly this port at sync
-        //     time, skipping DevToolsActivePort discovery.
-        //   - If the box is on and no port is given, DevToolsActivePort
-        //     auto-discovery kicks in at sync time.
-        let pinnedPort: Int? = {
-            let raw = cdpPortText.trimmingCharacters(in: .whitespaces)
-            guard !raw.isEmpty,
-                  let port = Int(raw),
-                  port > 0, port < 65536
-            else { return nil }
-            return port
-        }()
-        let cdpUrl: String? = (allowCdp && pinnedPort != nil)
-            ? "http://127.0.0.1:\(pinnedPort!)"
+        // allow_cdp_attach is the single browser-level consent. When the
+        // user has connected Chrome (`allowCdp`) AND DevToolsActivePort
+        // surfaced a live port, pin that port for the new profile so the
+        // connector subprocess attaches directly at sync time. When the
+        // user is connected but the port wasn't detected at view-appear
+        // time, leave cdpUrl nil — the worker re-reads DevToolsActivePort
+        // on every sync, so a Chrome that starts later still attaches.
+        let cdpUrl: String? = (allowCdp && detectedCdpPort != nil)
+            ? "http://127.0.0.1:\(detectedCdpPort!)"
             : nil
         do {
             let workerId = LobuWorkerIdentity.current()
@@ -339,7 +257,6 @@ struct SingleBrowserRow: View {
         do {
             try await client.deleteMyBrowserAuthProfile(workerId: workerId, profileId: profile.id)
             hub.remove(profile)
-            confirmingDeleteId = nil
         } catch {
             hub.loadError = error.localizedDescription
         }

--- a/apps/mac/Lobu/BrowserProfilesView.swift
+++ b/apps/mac/Lobu/BrowserProfilesView.swift
@@ -154,13 +154,6 @@ struct SingleBrowserRow: View {
                 // live listener — there's nothing meaningful to attach to.
                 if detectedCdpPort != nil {
                     HStack(spacing: 6) {
-                        Toggle("Use my Chrome", isOn: $allowCdp)
-                            .toggleStyle(.checkbox)
-                            .controlSize(.mini).font(.caption2)
-                            .help(
-                                "Run connectors inside your real Chrome (best for sites like Revolut that pin sessions to a browser fingerprint). Off = Lobu only reads cookies, never touches the live browser process."
-                            )
-                        Spacer()
                         Text("Port").font(.caption2).foregroundStyle(.secondary)
                         TextField(
                             detectedCdpPort.map(String.init) ?? "port",
@@ -169,6 +162,13 @@ struct SingleBrowserRow: View {
                         .textFieldStyle(.roundedBorder)
                         .controlSize(.mini).font(.caption2)
                         .frame(maxWidth: 60)
+                        Spacer()
+                        Toggle("Use my Chrome", isOn: $allowCdp)
+                            .toggleStyle(.checkbox)
+                            .controlSize(.mini).font(.caption2)
+                            .help(
+                                "Run connectors inside your real Chrome (best for sites like Revolut that pin sessions to a browser fingerprint). Off = Lobu only reads cookies, never touches the live browser process."
+                            )
                     }
                     .padding(.leading, 32).padding(.trailing, 6).padding(.bottom, 2)
                 }


### PR DESCRIPTION
## Summary

- Mirrored Chrome profiles stay visible in the menu bar; un-mirrored ones move behind a per-browser chevron disclosure.
- Browser-level CDP controls (\"Use my Chrome\" + port) also move into the expanded section — the collapsed row stays clean.
- Header secondary line becomes a count summary (\"2 of 4 profiles mirrored\") when there are profiles, falling back to the prior descriptive copy when there are none.
- Chevron hidden when there's nothing to expand (all mirrored, no CDP, no empty-state message).

Pure presentation change. No mirror / remove / CDP-attach flow changes.

## Test plan

- [ ] Chrome row shows \"N of M profiles mirrored\" when there are profiles.
- [ ] Mirrored profile rows are visible without expanding.
- [ ] Clicking chevron reveals un-mirrored profile rows + the CDP controls (when DevToolsActivePort detected a listener).
- [ ] Mirror / Remove flow on a profile still works, with or without the row expanded.
- [ ] Chevron is hidden when there's nothing to expand.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Profiles split into mirrored and unmirrored sections; unmirrored profiles shown only when expanded.
  * Header shows "X of Y profiles mirrored" when profiles exist.
  * Chevron shown only when expansion is meaningful (unmirrored profiles, empty state, or detected port).
  * CDP controls and port input appear only in the expanded view; empty-state messaging shown when expanded and no profiles.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lobu-ai/lobu/pull/736)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->