### PR TITLE
fix(server): bundle build copies connectors next to server.bundle.mjs

### DIFF
--- a/packages/server/scripts/build-server-bundle.mjs
+++ b/packages/server/scripts/build-server-bundle.mjs
@@ -22,6 +22,7 @@
  */
 
 import esbuild from 'esbuild';
+import { cpSync, existsSync, mkdirSync, rmSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 
@@ -82,3 +83,14 @@ async function buildBundle(entryPoint, outfile) {
 
 await buildBundle('src/server.ts', 'dist/server.bundle.mjs');
 await buildBundle('src/start-local.ts', 'dist/start-local.bundle.mjs');
+
+const connectorsSrc = join(pkgDir, '..', 'connectors', 'src');
+const connectorsDest = join(pkgDir, 'dist', 'connectors');
+if (existsSync(connectorsSrc)) {
+  if (existsSync(connectorsDest)) {
+    rmSync(connectorsDest, { recursive: true, force: true });
+  }
+  mkdirSync(dirname(connectorsDest), { recursive: true });
+  cpSync(connectorsSrc, connectorsDest, { recursive: true });
+  console.log(`\n=== copied connectors: ${connectorsDest}`);
+}


### PR DESCRIPTION
## Symptom

`app.lobu.ai/<org>/connectors` shows "No connectors found" on Lobu Cloud prod — the catalog scanner returns an empty list.

## Root cause

`packages/server/src/utils/connector-catalog.ts` resolves `DEFAULT_CONNECTOR_DIR_CANDIDATES` relative to `import.meta.dirname`. In prod the server runs as `/app/packages/server/dist/server.bundle.mjs`, so the candidates become:

1. `/app/packages/server/dist/connectors` — does not exist (the server bundle build didn't copy connectors here; only the CLI build did, in `packages/cli/scripts/build.cjs`).
2. `/app/connectors/src` — does not exist.
3. `/app/packages/connectors` — exists (the Dockerfile copies the whole `packages/connectors/` dir), **but it is the package root**. The `.ts` connector files live in `src/` underneath it.

`getDefaultConnectorCatalogDir()` returns candidate #3. `listCatalogConnectorDefinitions()` then `readdir`s it and filters to top-level `*.ts` — zero matches → empty catalog → "No connectors found".

In dev (`make dev` via `tsx watch`), `import.meta.dirname` is the source path, so candidate `../../../connectors/src` correctly resolves and dev works fine.

## Fix

Mirror the CLI build: after both bundles are emitted, copy `packages/connectors/src` to `packages/server/dist/connectors`. Candidate #1 now wins in prod and the server bundle is self-contained the same way `lobu run` already is.

## Test plan

- [x] `cd packages/server && bun run build:server` — emits `dist/connectors/` with 29 `.ts` files
- [x] `bun run typecheck` — clean
- [ ] Deploy to prod and confirm the connectors page populates

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced build process to ensure connectors are properly included in the bundled output.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lobu-ai/lobu/pull/739)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->