### PR TITLE
feat(apply): org-shared provider keys end-to-end

### DIFF
--- a/packages/cli/src/commands/_lib/apply/__tests__/desired-state.test.ts
+++ b/packages/cli/src/commands/_lib/apply/__tests__/desired-state.test.ts
@@ -37,6 +37,32 @@ describe("loadDesiredState", () => {
     return dir;
   }
 
+  test("resolves provider $VAR keys onto DesiredAgent.providerKeys", async () => {
+    const dir = mkProject(
+      `[agents.triage]
+name = "Triage"
+dir = "./agents/triage"
+
+[[agents.triage.providers]]
+id = "anthropic"
+key = "$ANTHROPIC_API_KEY"
+
+[[agents.triage.providers]]
+id = "openai"
+# Intentionally no key — operator wires via UI / per-user auth profile.
+`
+    );
+    const { state } = await loadDesiredState({
+      cwd: dir,
+      env: { ANTHROPIC_API_KEY: "sk-anth-real-value" },
+    });
+    expect(state.agents[0]!.providerKeys).toEqual([
+      { providerId: "anthropic", value: "sk-anth-real-value" },
+    ]);
+    // Sanity: settings still record both providers as installed.
+    expect(state.agents[0]!.settings.installedProviders).toHaveLength(2);
+  });
+
   test("collects $VAR references from platforms + providers", async () => {
     const dir = mkProject(
       `[agents.triage]

--- a/packages/cli/src/commands/_lib/apply/apply-cmd.ts
+++ b/packages/cli/src/commands/_lib/apply/apply-cmd.ts
@@ -587,6 +587,15 @@ async function executePlan(
         row.changedFields ? `(${row.changedFields.join(", ")})` : undefined
       )
     );
+    // 2b) Provider API keys — pushed as org-shared `agent_secrets` rows so
+    // the worker can inject them at runtime without a per-user auth profile.
+    // Idempotent (PUT); same value → 200, different value → rotation. Not in
+    // the plan/diff because the value lives only in the operator's env at
+    // apply time; we push it every run and let the server upsert.
+    for (const { providerId, value } of desired.providerKeys) {
+      await ctx.client.setProviderApiKey(row.id, providerId, value);
+      printText(chalk.dim(`  ↻ provider-key ${row.id}/${providerId}`));
+    }
   }
 
   // 3) Platforms

--- a/packages/cli/src/commands/_lib/apply/client.ts
+++ b/packages/cli/src/commands/_lib/apply/client.ts
@@ -351,6 +351,22 @@ export class ApplyClient {
     );
   }
 
+  /**
+   * Set (or rotate) the org-shared API key for a provider. Idempotent.
+   * Lands in `agent_secrets` under `provider:<id>:apiKey`, scoped to the org.
+   */
+  async setProviderApiKey(
+    agentId: string,
+    providerId: string,
+    value: string
+  ): Promise<void> {
+    await this.request(
+      "PUT",
+      `/api/${this.orgSlug}/agents/${encodeURIComponent(agentId)}/providers/${encodeURIComponent(providerId)}/api-key`,
+      { value }
+    );
+  }
+
   // ── Platforms ─────────────────────────────────────────────────────────────
 
   async listPlatforms(agentId: string): Promise<RemotePlatform[]> {

--- a/packages/cli/src/commands/_lib/apply/desired-state.ts
+++ b/packages/cli/src/commands/_lib/apply/desired-state.ts
@@ -193,6 +193,13 @@ export interface DesiredAgent {
    */
   settings: Partial<AgentSettings>;
   platforms: DesiredPlatform[];
+  /**
+   * Provider API keys resolved from `[[providers]] key = "$VAR"` in lobu.toml
+   * that need to be pushed into `agent_secrets` after the settings PATCH.
+   * Empty when no provider declared a `key` (or all keys are empty/unset).
+   * The actual secret value lives only in process memory; never serialized.
+   */
+  providerKeys: { providerId: string; value: string }[];
 }
 
 export interface DesiredState {
@@ -1674,12 +1681,24 @@ export async function loadDesiredState(
     ]);
     const settings = buildAgentSettings(agentConfig, markdown, skillFiles);
     const platforms = buildPlatforms(agentId, agentConfig, env);
+    // Resolve `[[providers]] key = "$VAR"` against the apply env. The
+    // required-secrets gate in apply-cmd already failed loudly if any $VAR
+    // is unset, so a missing value here means the operator omitted `key`
+    // entirely (BYOK / web-UI flow); silently skip those.
+    const providerKeys: { providerId: string; value: string }[] = [];
+    for (const provider of agentConfig.providers) {
+      if (!provider.key) continue;
+      const ref = asEnvRef(provider.key);
+      const resolved = ref ? env[ref] : provider.key;
+      if (!resolved) continue;
+      providerKeys.push({ providerId: provider.id, value: resolved });
+    }
     const metadata: DesiredAgentMetadata = {
       agentId,
       name: agentConfig.name,
     };
     if (agentConfig.description) metadata.description = agentConfig.description;
-    agents.push({ metadata, settings, platforms });
+    agents.push({ metadata, settings, platforms, providerKeys });
   }
 
   const { entityTypes, relationshipTypes, watchers } = await loadMemoryModels(

--- a/packages/server/src/gateway/auth/base-provider-module.ts
+++ b/packages/server/src/gateway/auth/base-provider-module.ts
@@ -1,5 +1,8 @@
-import { createLogger } from "@lobu/core";
+import { createLogger, decrypt } from "@lobu/core";
 import { Hono } from "hono";
+import { getDb } from "../../db/client.js";
+import { tryGetOrgId } from "../../lobu/stores/org-context.js";
+import { providerOrgSecretName } from "../../lobu/stores/provider-secrets.js";
 import type { ProviderCredentialContext } from "../embedded.js";
 import {
   BaseModule,
@@ -10,6 +13,38 @@ import { resolveEnv } from "./mcp/string-substitution.js";
 import type { AuthProfilesManager } from "./settings/auth-profiles-manager.js";
 
 const logger = createLogger("base-provider-module");
+
+/**
+ * Look up the org-shared API key for this provider. Used as the second-tier
+ * fallback after per-user `auth_profiles` and before deployment-wide
+ * `process.env`. Returns null when no org context is set, no row exists, or
+ * the ciphertext fails to decrypt — every miss path is silent so the caller
+ * can keep walking the resolution chain.
+ */
+async function readOrgSharedProviderKey(
+  providerId: string
+): Promise<string | null> {
+  const orgId = tryGetOrgId();
+  if (!orgId) return null;
+  const sql = getDb();
+  const rows = (await sql`
+    SELECT ciphertext FROM agent_secrets
+    WHERE organization_id = ${orgId}
+      AND name = ${providerOrgSecretName(providerId)}
+      AND (expires_at IS NULL OR expires_at > now())
+    LIMIT 1
+  `) as Array<{ ciphertext: string }>;
+  const ciphertext = rows[0]?.ciphertext;
+  if (!ciphertext) return null;
+  try {
+    return decrypt(ciphertext);
+  } catch (error) {
+    logger.warn(
+      `Failed to decrypt org-shared key for provider ${providerId}: ${error instanceof Error ? error.message : String(error)}`
+    );
+    return null;
+  }
+}
 
 interface BaseProviderConfig {
   providerId: string;
@@ -205,6 +240,16 @@ export abstract class BaseProviderModule
           `Injecting ${credVar} for agent ${agentId} (${this.providerId})`
         );
         envVars[credVar] = credential;
+      } else {
+        // No per-user auth profile — fall back to the org-shared API key
+        // declared via `lobu apply` (`provider:<id>:apiKey` in agent_secrets).
+        const orgKey = await readOrgSharedProviderKey(this.providerId);
+        if (orgKey) {
+          logger.info(
+            `Injecting ${credVar} for agent ${agentId} (${this.providerId}) from org-shared secret`
+          );
+          envVars[credVar] = orgKey;
+        }
       }
     }
     return envVars;
@@ -233,6 +278,8 @@ export abstract class BaseProviderModule
     if (credential) {
       return credential;
     }
+    const orgKey = await readOrgSharedProviderKey(this.providerId);
+    if (orgKey) return orgKey;
     const sysVar =
       this.providerConfig.systemEnvVarName ||
       this.providerConfig.credentialEnvVarName;

--- a/packages/server/src/lobu/agent-routes.ts
+++ b/packages/server/src/lobu/agent-routes.ts
@@ -6,10 +6,11 @@
 
 import { readFile } from 'node:fs/promises';
 import { resolve } from 'node:path';
-import type { AuthProfile, SkillConfig } from '@lobu/core';
+import { encrypt, type AuthProfile, type SkillConfig } from '@lobu/core';
 import { Hono } from 'hono';
 import { mcpAuth } from '../auth/middleware';
 import { getDb } from '../db/client';
+import { providerOrgSecretName } from './stores/provider-secrets';
 import { OAuthClient } from '../gateway/auth/oauth/client';
 import { CLAUDE_PROVIDER } from '../gateway/auth/oauth/providers';
 import { ChannelBindingService } from '../gateway/channels/binding-service';
@@ -822,6 +823,56 @@ routes.post('/:agentId/providers/:providerId/oauth/code', async (c) => {
       400
     );
   }
+});
+
+// ── Set the org-shared API key for a provider ────────────────────────────────
+//
+// Writes (or rotates) the org-wide API key declared via `lobu apply` from
+// `[[agents.<id>.providers]] key = "$VAR"`. The key lands in `agent_secrets`
+// under `provider:<id>:apiKey`, scoped to the org. The worker's credential
+// resolution (base-provider-module.ts) checks per-user `auth_profiles` first,
+// then this row, then `process.env` — so per-user BYOK still wins.
+//
+// `:agentId` is in the path so the auth/admin gate matches the rest of this
+// router; the secret itself is org-scoped, not per-agent (one z-ai key for the
+// whole org). PUT is idempotent; same name overwrites.
+
+routes.put('/:agentId/providers/:providerId/api-key', async (c) => {
+  const denied = requireSessionOrAdminPat(c);
+  if (denied) return denied;
+  const { agentId, providerId } = c.req.param();
+
+  if (!(await configStore.hasAgent(agentId))) {
+    return c.json({ error: 'Agent not found' }, 404);
+  }
+
+  let body: { value?: unknown };
+  try {
+    body = await c.req.json();
+  } catch {
+    return c.json({ error: 'Invalid or missing JSON body' }, 400);
+  }
+  const value = typeof body.value === 'string' ? body.value : '';
+  if (!value) {
+    return c.json({ error: 'Body must include a non-empty `value` string' }, 400);
+  }
+
+  const ciphertext = encrypt(value);
+  const name = providerOrgSecretName(providerId);
+  const orgId = await getAgentOrganizationId(agentId);
+  if (!orgId) {
+    return c.json({ error: 'Agent has no organization' }, 500);
+  }
+
+  const sql = getDb();
+  await sql`
+    INSERT INTO agent_secrets (organization_id, name, ciphertext, created_at, updated_at)
+    VALUES (${orgId}, ${name}, ${ciphertext}, now(), now())
+    ON CONFLICT (organization_id, name) DO UPDATE SET
+      ciphertext = EXCLUDED.ciphertext,
+      updated_at = now()
+  `;
+  return c.json({ success: true, name });
 });
 
 // ── Update agent config (settings) ───────────────────────────────────────────

--- a/packages/server/src/lobu/stores/provider-secrets.ts
+++ b/packages/server/src/lobu/stores/provider-secrets.ts
@@ -1,0 +1,18 @@
+/**
+ * Org-shared provider credentials live in `agent_secrets` under a documented
+ * naming convention so the worker's credential-resolution path and `lobu apply`
+ * agree on where to read/write the same row.
+ *
+ * Resolution order (worker side, see base-provider-module.ts):
+ *   1. Per-user `auth_profiles` (BYOK / personal OAuth)
+ *   2. Org-shared `agent_secrets` row (this name) — declarative, set via
+ *      `lobu apply` from `[[agents.<id>.providers]] key = "$VAR"`
+ *   3. Deployment-wide `process.env` (operator's machine, last resort)
+ *
+ * The org-scoping is enforced by `(organization_id, name)` PK on the table;
+ * no per-agent override exists today (the same key is used by every agent in
+ * the org that calls this provider).
+ */
+export function providerOrgSecretName(providerId: string): string {
+  return `provider:${providerId}:apiKey`;
+}


### PR DESCRIPTION
## Why

Today \`lobu apply\` validates that \`[[providers]] key = \"\$VAR\"\` resolves to a real env var, then silently throws the value away. The agent row records \`installedProviders: [{providerId}]\` but the actual key never reaches the gateway, so \`lobu chat\` against a freshly-applied agent dies with:

\`\`\`
To use <model>, an admin needs to connect <provider> on the base agent.
\`\`\`

The architectural reason was real — \`auth_profiles\` requires a \`userId\` because user-owned credentials (BYOK, personal OAuth) are scoped to humans. But that left no path for the most common case: an **org-wide provider key** that should be wired declaratively (one z-ai key for the whole org, paid by the company).

## Design

Org-shared provider credentials live in \`agent_secrets\` under a documented naming convention \`provider:<id>:apiKey\`, scoped by \`(organization_id, name)\`. No schema change — the table already exists and is AES-256-GCM encrypted.

**Worker credential resolution order** (see \`base-provider-module.ts\`):
1. Per-user \`auth_profiles\` (BYOK / personal OAuth) — wins over org defaults.
2. **NEW**: Org-shared \`agent_secrets\` row (this PR) — declarative, set via \`lobu apply\`.
3. Deployment-wide \`process.env\` (operator's machine, last resort).

**Apply path**: \`PUT /api/<org>/agents/<id>/providers/<providerId>/api-key\` (admin-PAT gated, idempotent), called by \`lobu apply\` after the settings PATCH for every provider that declares a \`key\`. The resolved value lives only in process memory at apply time; never serialized into the desired-state snapshot.

## Three pieces in one PR (small, tightly coupled)

1. **\`packages/server/src/lobu/stores/provider-secrets.ts\`** — naming convention helper so worker + apply agree on the row name.
2. **\`packages/server/src/gateway/auth/base-provider-module.ts\`** — adds the org-shared lookup as tier 2 in \`buildEnvVars\` and \`getCredential\`.
3. **\`packages/server/src/lobu/agent-routes.ts\`** + **\`packages/cli/src/commands/_lib/apply/{apply-cmd,client,desired-state}.ts\`** — REST endpoint + CLI integration.

## Test plan

- [x] \`bun test packages/cli/src/commands/_lib/apply\` — 114 pass; 1 new test covers \`providerKeys\` resolution from \`\$VAR\` env refs.
- [x] \`bun run typecheck\` clean.
- [x] \`make build-packages\` clean.
- [ ] **Post-deploy**: re-run \`lobu apply\` for the \`food-ordering\` agent in \`lobu-team\`; confirm \`agent_secrets\` row \`provider:z-ai:apiKey\` lands; \`lobu chat\` returns a real reply (currently dies on missing zai connection).

Unblocks the prod agent that was the motivation for this whole thread.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  - Added organization-level provider API key management to the CLI and server.
  - Provider API keys can now be configured in configuration files using environment variable placeholders and applied to agents.
  - Server now falls back to organization-shared provider credentials when user-specific authentication is unavailable.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lobu-ai/lobu/pull/740)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->