### PR TITLE
docs(landing): tighten memory + skills section copy

### DIFF
--- a/packages/landing/src/components/LandingPage.tsx
+++ b/packages/landing/src/components/LandingPage.tsx
@@ -58,9 +58,9 @@ export function LandingPage(props: {
         class="relative px-4 sm:px-6 max-w-[72rem] mx-auto pt-10"
       >
         <FeatureBlock
-          eyebrow="Memory that grows itself"
-          title="Source-backed context, kept fresh automatically."
-          description="Connect sources once. Lobu turns them into typed memory that agents can search and cite. Watchers run on a schedule to extract new signal and write back."
+          eyebrow="Memory"
+          title="Source-backed context, kept fresh."
+          description="Connect a source once. Lobu types it into memory agents can search and cite. Watchers refresh it on schedule."
           ctaLabel="Read the memory guide"
           ctaHref="/getting-started/memory/"
           graphic={<SharedMemoryGraphic />}
@@ -72,9 +72,9 @@ export function LandingPage(props: {
         class="relative px-4 sm:px-6 max-w-[72rem] mx-auto pt-10"
       >
         <FeatureBlock
-          eyebrow="One backend, every surface"
-          title="Add tools without glue code. Reach users where they already are."
-          description="Skills bundle instructions, tools, packages, and network access. The same agent runs in Slack, Telegram, REST, MCP clients, and ChatGPT — no per-platform plumbing."
+          eyebrow="Skills"
+          title="One agent, every surface."
+          description="Bundle tools, packages, and network access into a skill. The same agent runs in Slack, Telegram, REST, MCP, and ChatGPT — no per-platform plumbing."
           ctaLabel="Explore skills"
           ctaHref="/getting-started/skills/"
           graphic={<SkillsGraphic />}


### PR DESCRIPTION
## Summary

Trim the two feature blocks below the hero so each carries one clean idea instead of two-sentence crammed titles.

### Before / after

**Memory**
- Eyebrow `Memory that grows itself` → `Memory` (matches the sidebar pill / pillar trio).
- Title `Source-backed context, kept fresh automatically.` → `Source-backed context, kept fresh.`
- Body `Connect sources once. Lobu turns them into typed memory that agents can search and cite. Watchers run on a schedule to extract new signal and write back.` → `Connect a source once. Lobu types it into memory agents can search and cite. Watchers refresh it on schedule.`

**Skills**
- Eyebrow `One backend, every surface` → `Skills`.
- Title `Add tools without glue code. Reach users where they already are.` → `One agent, every surface.` (same payoff, single sentence).
- Body now starts with what skills *are* (bundles of tools/packages/network access) instead of what they aren't (glue code).

## Test plan

- [x] Typecheck clean.
- [x] Visual check at desktop and mobile widths.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated landing page copy for Memory and Skills feature sections with revised descriptions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lobu-ai/lobu/pull/744)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->