### PR TITLE
chore: session followups — CI greens, AGENTS.md auth scope, lobu run shared-DB guard

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -189,6 +189,8 @@ Local dev Telegram bot: `@clawdotfreebot`. Production: `@lobuaibot`.
 
 For any UI verification that needs a signed-in session (anything past the auth wall), use the `agent-browser` CLI with a session cookie minted from the DB. The user's regular Chrome doesn't expose a remote-debug port, so `--auto-connect` will land on a wrong tab; mint a cookie instead.
 
+**Scope of this recipe.** The forged session cookie authenticates the **web admin REST mounted at `/`** (`/api/auth/*`, `/api/<orgSlug>/...`, the SPA — anything `lobu apply` and the web app talk to). It does **NOT** authenticate the **public Agent API at `/lobu`** (`/lobu/api/v1/agents/*`, `/lobu/api/v1/agents/<id>/sessions`) — that path expects a JWT bearer token from the OAuth device flow (`lobu login`) or a PAT. If `/lobu/api/v1/agents` returns `401 Unauthorized` despite a valid cookie, that's why; switch to `lobu chat` / `lobu token` to talk to the Agent API.
+
 **Pick a target.** Local dev backend (with prod DB attached over Tailscale) is reachable at `https://buraks-macbook-pro-1.brill-kanyu.ts.net:8443` — use this when you only need to verify behavior end-to-end without a fresh prod deploy. For prod itself use `https://app.lobu.ai`.
 
 **Grab the secret + a session token.**

--- a/packages/cli/src/__tests__/dev.test.ts
+++ b/packages/cli/src/__tests__/dev.test.ts
@@ -12,6 +12,7 @@ import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import {
   findEnclosingMonorepoRoot,
+  isSharedDatabaseUrl,
   resolveBackendBundle,
 } from "../commands/dev";
 
@@ -144,6 +145,31 @@ describe("lobu run backend bundle resolution", () => {
     expect(
       existsSync(join(found!, "packages", "agent-worker", "src", "index.ts"))
     ).toBe(true);
+  });
+
+  test("isSharedDatabaseUrl flags non-loopback hosts only", () => {
+    // Loopback variants are NOT shared.
+    expect(isSharedDatabaseUrl("postgres://user@localhost:5432/db")).toBe(
+      false
+    );
+    expect(isSharedDatabaseUrl("postgres://user@127.0.0.1:5432/db")).toBe(
+      false
+    );
+    expect(isSharedDatabaseUrl("postgres://user@[::1]:5432/db")).toBe(false);
+
+    // Tailnet, prod, private LAN — all shared.
+    expect(
+      isSharedDatabaseUrl(
+        "postgres://u:p@summaries-db.brill-kanyu.ts.net:5432/owletto"
+      )
+    ).toBe(true);
+    expect(isSharedDatabaseUrl("postgres://u:p@db.example.com:5432/prod")).toBe(
+      true
+    );
+    expect(isSharedDatabaseUrl("postgres://u:p@10.0.0.5:5432/dev")).toBe(true);
+
+    // Garbage URL → not "shared" (the boot path will fail elsewhere).
+    expect(isSharedDatabaseUrl("not-a-url")).toBe(false);
   });
 
   test("CLI build copies local runtime assets for installed lobu run", () => {

--- a/packages/cli/src/commands/dev.ts
+++ b/packages/cli/src/commands/dev.ts
@@ -17,6 +17,32 @@ export interface DevOptions {
   quiet?: boolean;
   verbose?: boolean;
   logLevel?: string;
+  /**
+   * Acknowledge that `lobu run` is about to point at a shared/non-local
+   * Postgres inherited from the shell. Required when the project's own .env
+   * doesn't pin DATABASE_URL — protects against the silent footgun of running
+   * "local dev" against a teammate's tailnet DB or, worse, prod.
+   */
+  unsafeSharedDb?: boolean;
+}
+
+/**
+ * Treat any DATABASE_URL whose host isn't loopback as "shared". The check
+ * is intentionally crude — anything resolvable from the network counts,
+ * including tailnet (`*.ts.net`), private IPs, and prod hostnames.
+ *
+ * Exported for unit tests; the safety gate in `devCommand` is the consumer.
+ */
+export function isSharedDatabaseUrl(databaseUrl: string): boolean {
+  try {
+    const url = new URL(databaseUrl);
+    // `new URL("postgres://[::1]:5432/x").hostname` returns `[::1]` with the
+    // brackets, so strip them before comparing.
+    const host = url.hostname.toLowerCase().replace(/^\[|\]$/g, "");
+    return host !== "localhost" && host !== "127.0.0.1" && host !== "::1";
+  } catch {
+    return false;
+  }
 }
 
 type BackendBundleKind = "postgres" | "pglite";
@@ -45,6 +71,57 @@ export async function devCommand(
 
   const mergedEnv = { ...envVars, ...(process.env as Record<string, string>) };
   const hasDatabaseUrl = Boolean(mergedEnv.DATABASE_URL?.trim());
+
+  // Refuse to boot against a shared/non-local DATABASE_URL that came from the
+  // parent shell rather than the project's own .env — a common footgun where
+  // "local lobu run" silently writes into prod / a teammate's tailnet DB.
+  // The project pinning its own DATABASE_URL is treated as explicit consent.
+  if (
+    hasDatabaseUrl &&
+    !envVars.DATABASE_URL?.trim() &&
+    isSharedDatabaseUrl(mergedEnv.DATABASE_URL!) &&
+    !options.unsafeSharedDb
+  ) {
+    spinner.fail("DATABASE_URL inherited from shell points at a shared DB");
+    console.error(
+      chalk.red(
+        `\n  Refusing to start: DATABASE_URL=${redactUrl(mergedEnv.DATABASE_URL!)}\n`
+      )
+    );
+    console.error(
+      chalk.dim(
+        `  This URL is set in your shell environment, not in ${envPath}.`
+      )
+    );
+    console.error(
+      chalk.dim(
+        "  Its host isn't loopback — likely a teammate's tailnet DB or prod."
+      )
+    );
+    console.error(
+      chalk.dim(
+        "  Local dev runs against this DB silently mutate shared data and"
+      )
+    );
+    console.error(
+      chalk.dim("  let prod workers race local-dev runs (see AGENTS.md).\n")
+    );
+    console.error(chalk.dim("  Fix one of:"));
+    console.error(
+      chalk.dim(
+        `    • pin a project-local DB in ${envPath} (e.g. postgres://localhost/<project>_dev)`
+      )
+    );
+    console.error(
+      chalk.dim("    • unset DATABASE_URL in this shell (PGlite will be used)")
+    );
+    console.error(
+      chalk.dim(
+        "    • pass --unsafe-shared-db if you really mean to share this DB\n"
+      )
+    );
+    process.exit(1);
+  }
   const bundleKind: BackendBundleKind = hasDatabaseUrl ? "postgres" : "pglite";
   const bundlePath = resolveBackendBundle(undefined, bundleKind);
   if (!bundlePath) {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -354,12 +354,17 @@ Memory:
     .option("--quiet", "Suppress startup banner; raise log level to warn")
     .option("--verbose", "Lower log level to debug")
     .option("--log-level <level>", "Forwarded as LOG_LEVEL to the bundle")
+    .option(
+      "--unsafe-shared-db",
+      "Allow running against a non-loopback DATABASE_URL inherited from the shell"
+    )
     .action(
       async (options: {
         port?: string;
         quiet?: boolean;
         verbose?: boolean;
         logLevel?: string;
+        unsafeSharedDb?: boolean;
       }) => {
         const { devCommand } = await import("./commands/dev.js");
         await devCommand(process.cwd(), options);

--- a/packages/landing/src/components/FeatureGraphics.tsx
+++ b/packages/landing/src/components/FeatureGraphics.tsx
@@ -353,4 +353,3 @@ export function SkillsGraphic() {
     </div>
   );
 }
-

--- a/packages/server/src/utils/__tests__/mcp-install-targets.test.ts
+++ b/packages/server/src/utils/__tests__/mcp-install-targets.test.ts
@@ -26,12 +26,14 @@ describeIfSubmodule('getMcpInstallTargets', () => {
     const targets = getMcpInstallTargets(mcpUrl);
 
     expect(targets.map((target) => target.id)).toEqual([
+      'skills',
       'codex',
       'chatgpt',
       'claude-desktop',
       'claude-code',
       'gemini-cli',
       'cursor',
+      'lobu-cli',
       'openclaw',
     ]);
   });


### PR DESCRIPTION
Cleans up four loose ends surfaced while debugging the food-ordering agent end-to-end (PRs #734, #735, #740). Each piece is independent; bundled because they're all small and tightly related to the auth/run footguns we hit.

## What

1. **format-lint green again** — `packages/landing/src/components/FeatureGraphics.tsx:357` had a trailing blank line that biome rejected. The CI \`format-lint\` job has been red on `main` since this slipped in; this unblocks every PR's CI.

2. **integration green again** — `packages/server/src/utils/__tests__/mcp-install-targets.test.ts:28` expected the legacy 7-element list of first-class MCP install targets, but the source list now has 9 (\`skills\` and \`lobu-cli\` added without updating the test). CI \`integration\` job goes from red to green on `main`.

3. **AGENTS.md auth-scope clarification** — the "Browser-driven verification" section's forged-session-cookie recipe authenticates only the web admin REST mounted at `/`, NOT the public Agent API at `/lobu`. The missing distinction caused an hour of debugging in the previous session.

4. **\`lobu run\` refuses non-loopback \`DATABASE_URL\` inherited from shell** — if \`DATABASE_URL\` is set in \`process.env\` but NOT in the project's \`.env\`, AND its host isn't loopback, refuse to start. The error spells out three remediations (pin in .env, unset, or pass the new \`--unsafe-shared-db\` escape hatch). Closes the footgun where a parent shell carries a tailnet/prod URL into a freshly-cloned project's \`lobu run\`, racing prod workers and mutating shared data.

## Out of scope

PR #734's Phase B/C of the agents per-org PK refactor (~67 storage call sites + composite FK swap). Multi-day; separate branch and review pass.

## Test plan

- [x] \`bun test packages/cli/src/__tests__/dev.test.ts\` — 6 pass; new test covers \`isSharedDatabaseUrl\` for loopback / tailnet / prod / IPv6 / garbage cases.
- [x] \`bunx vitest run mcp-install-targets.test.ts\` — 3 pass.
- [x] \`bun run typecheck\` clean.
- [x] \`bun run format:check\` clean.
- [x] \`make build-packages\` clean.
- [ ] Verify in CI that the previously-red \`format-lint\` and \`integration\` jobs flip to green on this PR.