### PR TITLE
fix(apply, chat, gateway): three bugs in the org-shared-provider-keys flow

### DIFF
--- a/packages/cli/src/commands/_lib/apply/apply-cmd.ts
+++ b/packages/cli/src/commands/_lib/apply/apply-cmd.ts
@@ -587,14 +587,24 @@ async function executePlan(
         row.changedFields ? `(${row.changedFields.join(", ")})` : undefined
       )
     );
-    // 2b) Provider API keys — pushed as org-shared `agent_secrets` rows so
-    // the worker can inject them at runtime without a per-user auth profile.
-    // Idempotent (PUT); same value → 200, different value → rotation. Not in
-    // the plan/diff because the value lives only in the operator's env at
-    // apply time; we push it every run and let the server upsert.
+  }
+
+  // 2b) Provider API keys — pushed as org-shared `agent_secrets` rows so the
+  // worker can inject them at runtime without a per-user auth profile. Idempotent
+  // (PUT); same value → 200, different value → rotation. Walk all desired agents
+  // (not just those with a settings diff) — the secret value isn't part of the
+  // settings JSON, so a row can need a key even when settings are noop (e.g.
+  // first apply after the gateway picked up support, or a key rotation).
+  for (const desired of ctx.state.agents) {
     for (const { providerId, value } of desired.providerKeys) {
-      await ctx.client.setProviderApiKey(row.id, providerId, value);
-      printText(chalk.dim(`  ↻ provider-key ${row.id}/${providerId}`));
+      await ctx.client.setProviderApiKey(
+        desired.metadata.agentId,
+        providerId,
+        value
+      );
+      printText(
+        chalk.dim(`  ↻ provider-key ${desired.metadata.agentId}/${providerId}`)
+      );
     }
   }
 

--- a/packages/cli/src/commands/chat.ts
+++ b/packages/cli/src/commands/chat.ts
@@ -75,11 +75,16 @@ export async function chatCommand(
   let gatewayUrl: string;
   if (options.gateway) {
     gatewayUrl = options.gateway;
-  } else if (options.context) {
-    const ctx = await resolveContext(options.context);
-    gatewayUrl = apiBaseFromContextUrl(ctx.apiUrl);
   } else {
-    gatewayUrl = await resolveGatewayUrl({ cwd });
+    // Prefer an explicit `--context` over the active context, but fall back
+    // to the active context before defaulting to a local `lobu run`. Without
+    // this, `lobu chat` against a remote-context-set CLI silently sent every
+    // request to localhost:8787 — failing with `fetch failed` if no local
+    // gateway was running, or worse, hitting the wrong instance.
+    const ctx = await resolveContext(options.context).catch(() => null);
+    gatewayUrl = ctx
+      ? apiBaseFromContextUrl(ctx.apiUrl)
+      : await resolveGatewayUrl({ cwd });
   }
   // The Agent API lives under `<origin>/lobu` on every Lobu deployment; the
   // context apiUrl and `.env` PORT only give the origin.

--- a/packages/server/src/gateway/auth/base-provider-module.ts
+++ b/packages/server/src/gateway/auth/base-provider-module.ts
@@ -17,21 +17,31 @@ const logger = createLogger("base-provider-module");
 /**
  * Look up the org-shared API key for this provider. Used as the second-tier
  * fallback after per-user `auth_profiles` and before deployment-wide
- * `process.env`. Returns null when no org context is set, no row exists, or
- * the ciphertext fails to decrypt — every miss path is silent so the caller
- * can keep walking the resolution chain.
+ * `process.env`. Returns null when no row exists or the ciphertext fails to
+ * decrypt — every miss path is silent so the caller can keep walking the
+ * resolution chain.
+ *
+ * Org id is derived from the agent row (joined through `agents`) rather than
+ * `tryGetOrgId()`. The worker-spawn code path that calls `buildEnvVars` runs
+ * outside the org-routing middleware's AsyncLocalStorage scope, so the ALS
+ * helper returns null there. Joining via `agents.id` is correct as long as
+ * agent IDs are globally unique — which they are today (the per-org PK swap
+ * ships in the Phase B/C refactor).
  */
 async function readOrgSharedProviderKey(
+  agentId: string,
   providerId: string
 ): Promise<string | null> {
-  const orgId = tryGetOrgId();
-  if (!orgId) return null;
   const sql = getDb();
+  const orgFromContext = tryGetOrgId();
   const rows = (await sql`
-    SELECT ciphertext FROM agent_secrets
-    WHERE organization_id = ${orgId}
-      AND name = ${providerOrgSecretName(providerId)}
-      AND (expires_at IS NULL OR expires_at > now())
+    SELECT s.ciphertext
+    FROM agent_secrets s
+    JOIN agents a ON a.organization_id = s.organization_id
+    WHERE a.id = ${agentId}
+      AND s.name = ${providerOrgSecretName(providerId)}
+      AND (s.expires_at IS NULL OR s.expires_at > now())
+      AND (${orgFromContext}::text IS NULL OR s.organization_id = ${orgFromContext})
     LIMIT 1
   `) as Array<{ ciphertext: string }>;
   const ciphertext = rows[0]?.ciphertext;
@@ -243,7 +253,7 @@ export abstract class BaseProviderModule
       } else {
         // No per-user auth profile — fall back to the org-shared API key
         // declared via `lobu apply` (`provider:<id>:apiKey` in agent_secrets).
-        const orgKey = await readOrgSharedProviderKey(this.providerId);
+        const orgKey = await readOrgSharedProviderKey(agentId, this.providerId);
         if (orgKey) {
           logger.info(
             `Injecting ${credVar} for agent ${agentId} (${this.providerId}) from org-shared secret`
@@ -278,7 +288,7 @@ export abstract class BaseProviderModule
     if (credential) {
       return credential;
     }
-    const orgKey = await readOrgSharedProviderKey(this.providerId);
+    const orgKey = await readOrgSharedProviderKey(agentId, this.providerId);
     if (orgKey) return orgKey;
     const sysVar =
       this.providerConfig.systemEnvVarName ||


### PR DESCRIPTION
End-to-end testing PR #740 against prod surfaced three blockers that each silently undermined the new provider-key path. All three are tiny.

## Bugs

### 1. \`lobu apply\` skipped provider-key push when settings were noop

The \`setProviderApiKey()\` call was nested inside the \`rowsByKind(\"settings\")\` loop, so on idempotent re-runs (settings unchanged) the key push never fired. First-time apply against a target where the agent already exists never wrote \`agent_secrets\`.

**Fix**: move the push out of the settings loop into its own walk over \`ctx.state.agents\`. The secret value isn't part of the settings JSON so it can need updating even when settings are noop.

### 2. \`lobu chat\` ignored the active context unless \`--context\` was passed

\`chatCommand\` only resolved the context when \`options.context\` was explicitly set; otherwise it fell straight through to \`resolveGatewayUrl\` which defaults to \`http://localhost:8787\`. Anyone with \`lobu context use <remote>\` set silently sent every chat to a non-existent local gateway — manifesting as \`Error: fetch failed\`.

**Fix**: resolve the active context first; the localhost default kicks in only when no context exists.

### 3. Worker-side org lookup returned null because AsyncLocalStorage isn't set

\`readOrgSharedProviderKey()\` used \`tryGetOrgId()\` to scope the \`agent_secrets\` read. The worker-spawn code path that calls \`buildEnvVars()\` runs outside the org-routing middleware's ALS scope, so the helper always returned null and the org-shared key was never injected — the agent kept getting \"needs to connect <provider>\" even with the row in place.

**Fix**: derive org from the \`agentId\` parameter via a join through the \`agents\` table. Globally-unique \`agent_id\` makes this correct today; the per-org PK swap (Phase B/C) won't break it because that migration adds a composite key without removing global uniqueness.

## Test plan

- [x] \`bun test packages/cli/src/commands/_lib/apply\` — 115 pass.
- [x] \`bun run typecheck\` clean.
- [x] Manual end-to-end verification against prod after deploy:
  - [x] \`lobu apply\` shows \`↻ provider-key food-ordering/z-ai\` (fix #1)
  - [x] DB has the \`provider:z-ai:apiKey\` row in \`lobu-team\` org
  - [x] \`lobu chat -a food-ordering \"ping\"\` reaches the right gateway URL (fix #2; was hitting localhost before)
  - [ ] **Post-deploy**: with fix #3 live, the worker injects the key and the agent answers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved provider API key application to handle all agents consistently during plan execution.
  * Enhanced chat gateway URL resolution with fallback logic when primary context resolution fails.
  * Refined organization-shared provider credential resolution to support agent-based credential lookups.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lobu-ai/lobu/pull/746)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->