### PR TITLE
fix(schema): drop agents_organization_id_id_key — broke ON CONFLICT (id) callers

### DIFF
--- a/db/migrations/20260515160000_drop_agents_org_id_unique.sql
+++ b/db/migrations/20260515160000_drop_agents_org_id_unique.sql
@@ -1,0 +1,24 @@
+-- migrate:up
+-- Drop the parallel `UNIQUE (organization_id, id)` added in 20260515120000.
+-- It was meant as schema-prep for the eventual PK swap to (organization_id,
+-- id), but it actively broke `ON CONFLICT (id) DO NOTHING/UPDATE` callers.
+--
+-- Why: Postgres' `ON CONFLICT (X)` only suppresses violations of the unique
+-- constraint matching exactly column set X. Adding a second unique constraint
+-- that overlaps with the PK means inserts can fail on the new constraint
+-- before reaching the PK conflict — and ON CONFLICT (id) doesn't catch it.
+-- Surfaced in `__tests__/integration/.../race-mcp` where parallel inserts of
+-- `(org-a, race-mcp-0)` started throwing `agents_organization_id_id_key`
+-- duplicates instead of being silently de-duped by the existing
+-- `ON CONFLICT (id) DO NOTHING` clause.
+--
+-- The PK on `(id)` already enforces global uniqueness, which subsumes
+-- `(organization_id, id)` uniqueness — the new constraint was logically
+-- redundant. Phase C of the per-org PK migration will swap the PK directly
+-- without needing a parallel constraint as a stepping stone.
+
+ALTER TABLE agents DROP CONSTRAINT IF EXISTS agents_organization_id_id_key;
+
+-- migrate:down
+ALTER TABLE agents
+  ADD CONSTRAINT agents_organization_id_id_key UNIQUE (organization_id, id);

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -1566,7 +1566,7 @@ CREATE TABLE public.scheduled_jobs (
 --
 
 CREATE TABLE public.schema_migrations (
-    version character varying NOT NULL
+    version character varying(128) NOT NULL
 );
 
 --

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -1566,7 +1566,7 @@ CREATE TABLE public.scheduled_jobs (
 --
 
 CREATE TABLE public.schema_migrations (
-    version character varying(128) NOT NULL
+    version character varying NOT NULL
 );
 
 --
@@ -2240,13 +2240,6 @@ ALTER TABLE ONLY public.agent_secrets
 
 ALTER TABLE ONLY public.agent_users
     ADD CONSTRAINT agent_users_pkey PRIMARY KEY (agent_id, platform, user_id);
-
---
--- Name: agents agents_organization_id_id_key; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.agents
-    ADD CONSTRAINT agents_organization_id_id_key UNIQUE (organization_id, id);
 
 --
 -- Name: agents agents_pkey; Type: CONSTRAINT; Schema: public; Owner: -
@@ -4996,4 +4989,5 @@ INSERT INTO public.schema_migrations (version) VALUES
     ('20260514130000'),
     ('20260514160000'),
     ('20260515120000'),
-    ('20260515150000');
+    ('20260515150000'),
+    ('20260515160000');

--- a/packages/server/src/db/embedded-schema-patches.ts
+++ b/packages/server/src/db/embedded-schema-patches.ts
@@ -549,17 +549,23 @@ export const EMBEDDED_SCHEMA_PATCHES: EmbeddedSchemaPatch[] = [
           ON public.${t} (organization_id, agent_id)
         `);
       }
-      await sql.unsafe(`
-        DO $$
-        BEGIN
-          IF NOT EXISTS (
-            SELECT 1 FROM pg_constraint WHERE conname = 'agents_organization_id_id_key'
-          ) THEN
-            ALTER TABLE public.agents
-              ADD CONSTRAINT agents_organization_id_id_key UNIQUE (organization_id, id);
-          END IF;
-        END$$;
-      `);
+      // Note: an earlier revision of this patch added a parallel UNIQUE
+      // (organization_id, id) on agents. It was reverted in
+      // db/migrations/20260515160000_drop_agents_org_id_unique.sql because
+      // it broke `ON CONFLICT (id) DO NOTHING/UPDATE` callers — Postgres
+      // can violate the new constraint before reaching the PK conflict,
+      // and ON CONFLICT (id) only suppresses the named constraint. The
+      // PK on (id) already enforces global uniqueness. Phase C of the
+      // per-org PK migration will swap the PK directly.
+    },
+  },
+  {
+    // Mirrors db/migrations/20260515160000_drop_agents_org_id_unique.sql.
+    id: 'drop-agents-org-id-unique',
+    apply: async (sql) => {
+      await sql.unsafe(
+        `ALTER TABLE public.agents DROP CONSTRAINT IF EXISTS agents_organization_id_id_key`
+      );
     },
   },
 ];


### PR DESCRIPTION
## Why

PR #734 added a parallel \`UNIQUE (organization_id, id)\` on \`agents\` as schema-prep for the eventual per-org PK swap. It actively broke any \`ON CONFLICT (id) DO NOTHING/UPDATE\` callers.

**Postgres semantics**: \`ON CONFLICT (X)\` only suppresses violations of the unique constraint matching column set X. Adding a *second* unique constraint that overlaps with the PK means inserts can fail on the new constraint **before** reaching the PK conflict — and \`ON CONFLICT (id)\` doesn't catch the violation of the wider one.

Surfaced in the \`__tests__/integration/.../race-mcp\` test where parallel inserts of \`(org-a, race-mcp-0)\` started throwing \`agents_organization_id_id_key\` duplicates instead of being silently de-duped:

\`\`\`
PostgresError: duplicate key value violates unique constraint
"agents_organization_id_id_key"
detail: Key (organization_id, id)=(org-a, race-mcp-0) already exists.
\`\`\`

CI's \`integration\` job has been red on \`main\` since #734 merged for this reason.

## Fix

Drop the constraint. The PK on \`(id)\` already enforces global uniqueness, which strictly subsumes \`(organization_id, id)\` uniqueness — the new constraint was logically redundant. Phase C of the per-org PK migration will swap the PK directly without needing a parallel constraint as a stepping stone.

Mirrored in \`embedded-schema-patches.ts\` (idempotent \`DROP CONSTRAINT IF EXISTS\`).

## Test plan

- [x] \`bun run typecheck\` clean.
- [x] \`dbmate up\` applies cleanly against a fresh pgvector PG; \`db/schema.sql\` regenerated to match.
- [ ] CI \`integration\` job goes from red to green on this PR (the race-mcp test should stop throwing).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated database schema to remove a constraint that was preventing certain database operations from functioning correctly. This change enables improved conflict resolution handling at the database level without affecting end-user functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lobu-ai/lobu/pull/747)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->