### PR TITLE
fix(connectors): add faviconDomain to github + reddit

### DIFF
--- a/packages/connectors/src/github.ts
+++ b/packages/connectors/src/github.ts
@@ -208,6 +208,7 @@ export default class GitHubConnector extends ConnectorRuntime {
     name: 'GitHub',
     description: 'Collects GitHub issues/discussions and executes repo actions.',
     version: '1.2.0',
+    faviconDomain: 'github.com',
     authSchema: {
       methods: [
         {

--- a/packages/connectors/src/reddit.ts
+++ b/packages/connectors/src/reddit.ts
@@ -79,6 +79,7 @@ export default class RedditConnector extends ConnectorRuntime {
     name: 'Reddit',
     description: 'Fetches posts and comments from Reddit subreddits or search queries.',
     version: '1.0.0',
+    faviconDomain: 'reddit.com',
     authSchema: {
       methods: [
         {


### PR DESCRIPTION
## Summary
- GitHub and Reddit were the only bundled connectors missing `faviconDomain`, so the sidebar's `ConnectorTinyMark` dropped through to a 2-char monogram ("GI" / "RE") while every other connector rendered a brand glyph.
- Added `faviconDomain: 'github.com'` and `faviconDomain: 'reddit.com'` in the same slot every other connector uses.

## Notes
- Existing `connector_definitions` rows were backfilled manually against the dev DB. `ensureConnectorInstalled` early-returns when a row already exists, so the new field doesn't propagate to existing installs without a one-shot UPDATE. Same will be needed in prod on deploy.

## Test plan
- [x] Audited all 27 connector source files — github + reddit were the only two without `faviconDomain`.
- [x] `make build-packages` clean.
- [ ] Verify sidebar renders Google favicons for GitHub / Reddit after deploy + DB backfill.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Added favicon support to GitHub and Reddit connectors for improved visual identification in the interface

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lobu-ai/lobu/pull/754)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->