### PR TITLE
feat(metric_series): events-sourced stat trends + lifecycle emitters

### DIFF
--- a/packages/server/src/lobu/stores/postgres-stores.ts
+++ b/packages/server/src/lobu/stores/postgres-stores.ts
@@ -11,6 +11,7 @@ import {
   type StoredConnection,
 } from '@lobu/core';
 import { getDb } from '../../db/client';
+import { recordLifecycleEvent } from '../../utils/insert-event';
 import { getOrgId, tryGetOrgId } from './org-context';
 
 export const AGENT_ID_PATTERN = /^[a-z][a-z0-9-]{2,59}$/;
@@ -288,7 +289,9 @@ export function createPostgresAgentConfigStore(): AgentConfigStore {
       // The PK is (organization_id, id) — UPSERT on the composite key. Two
       // orgs can independently own an agent with the same id; the conflict
       // path here only triggers for re-saves within the *same* org.
-      await sql`
+      // `xmax = 0` on the returning row distinguishes a fresh INSERT from
+      // a CONFLICT UPDATE so we can emit the right lifecycle event.
+      const rows = await sql`
         INSERT INTO agents (id, organization_id, name, description, owner_platform, owner_user_id,
                             is_workspace_agent, workspace_id, created_at)
         VALUES (
@@ -306,7 +309,18 @@ export function createPostgresAgentConfigStore(): AgentConfigStore {
           workspace_id = EXCLUDED.workspace_id,
           last_used_at = ${metadata.lastUsedAt ? new Date(metadata.lastUsedAt) : null},
           updated_at = ${now}
+        RETURNING (xmax = 0) AS inserted
       `;
+      const inserted = rows[0]?.inserted === true;
+      recordLifecycleEvent({
+        organizationId: orgId,
+        entityType: 'agent',
+        op: inserted ? 'created' : 'updated',
+        entityId: agentId,
+        summary: inserted
+          ? `Agent "${metadata.name}" created`
+          : `Agent "${metadata.name}" updated`,
+      });
     },
     async updateMetadata(agentId, updates) {
       const existing = await store.getMetadata(agentId);
@@ -316,7 +330,20 @@ export function createPostgresAgentConfigStore(): AgentConfigStore {
     async deleteMetadata(agentId) {
       const sql = getDb();
       const orgId = getOrgId();
-      await sql`DELETE FROM agents WHERE id = ${agentId} AND organization_id = ${orgId}`;
+      const rows = await sql`
+        DELETE FROM agents
+        WHERE id = ${agentId} AND organization_id = ${orgId}
+        RETURNING name
+      `;
+      if (rows.length > 0) {
+        recordLifecycleEvent({
+          organizationId: orgId,
+          entityType: 'agent',
+          op: 'deleted',
+          entityId: agentId,
+          summary: `Agent "${rows[0].name ?? agentId}" deleted`,
+        });
+      }
     },
     async hasAgent(agentId) {
       const sql = getDb();

--- a/packages/server/src/tools/admin/manage_connections.ts
+++ b/packages/server/src/tools/admin/manage_connections.ts
@@ -48,7 +48,7 @@ import {
 } from '../../utils/connections';
 import { ensureConnectorInstalled } from '../../utils/ensure-connector-installed';
 import { applyEntityLinkOverrides } from '../../utils/entity-link-overrides';
-import { recordChangeEvent } from '../../utils/insert-event';
+import { recordChangeEvent, recordLifecycleEvent } from '../../utils/insert-event';
 import logger from '../../utils/logger';
 import { syncOAuthConnectionsForAuthProfile } from '../../utils/oauth-connection-state';
 import { getWorkspaceRole } from '../../utils/organization-access';
@@ -1104,6 +1104,15 @@ async function handleCreate(
     'Connection created'
   );
 
+  recordLifecycleEvent({
+    organizationId,
+    entityType: 'connection',
+    op: 'created',
+    entityId: inserted[0].id,
+    summary: `Connection "${displayName}" created`,
+    extra: { connector_key: args.connector_key, slug: inserted[0].slug },
+  });
+
   return {
     action: 'create',
     connection: enrichWithAuthProfiles(
@@ -1408,6 +1417,15 @@ async function handleConnect(
     },
     'Connection created via connect flow'
   );
+
+  recordLifecycleEvent({
+    organizationId,
+    entityType: 'connection',
+    op: 'created',
+    entityId: connection.id,
+    summary: `Connection "${connectDisplayName}" created`,
+    extra: { connector_key: args.connector_key, slug: connection.slug, via: 'connect' },
+  });
 
   // If active immediately, return simple result
   if (!needsConnectFlow && !needsBrowserAuth) {
@@ -1828,6 +1846,14 @@ async function handleDelete(
       slug: conn.slug,
       display_name: conn.display_name,
     },
+  });
+  recordLifecycleEvent({
+    organizationId,
+    entityType: 'connection',
+    op: 'deleted',
+    entityId: args.connection_id,
+    summary: `Connection "${connName}" deleted`,
+    extra: { connector_key: conn.connector_key, slug: conn.slug },
   });
 
   return {

--- a/packages/server/src/tools/admin/manage_watchers.ts
+++ b/packages/server/src/tools/admin/manage_watchers.ts
@@ -25,7 +25,7 @@ import type { ComponentReferenceDocumentation } from '../../types/templates';
 import { entityLinkMatchSql } from '../../utils/content-search';
 import { ToolUserError } from '../../utils/errors';
 import { nextRunAt, validateSchedule } from '../../utils/cron';
-import { recordChangeEvent } from '../../utils/insert-event';
+import { recordChangeEvent, recordLifecycleEvent } from '../../utils/insert-event';
 import { verifyWindowToken } from '../../utils/jwt';
 import logger from '../../utils/logger';
 import {
@@ -1072,6 +1072,15 @@ async function handleCreate(
 
   logger.info(`[manage_watchers] Created watcher ${watcherId} with slug '${args.slug}'`);
 
+  recordLifecycleEvent({
+    organizationId,
+    entityType: 'watcher',
+    op: 'created',
+    entityId: watcherId,
+    summary: `Watcher "${args.name ?? args.slug}" created`,
+    extra: { slug: args.slug, agent_id: args.agent_id ?? null },
+  });
+
   return {
     action: 'create',
     watcher_id: String(watcherId),
@@ -1172,6 +1181,15 @@ async function handleCreateFromVersion(
     `;
 
     created.push({ watcher_id: String(watcherId), entity_id: entityId, name: watcherName });
+
+    recordLifecycleEvent({
+      organizationId,
+      entityType: 'watcher',
+      op: 'created',
+      entityId: watcherId,
+      summary: `Watcher "${watcherName}" created`,
+      extra: { slug: watcherSlug, via: 'create_from_version' },
+    });
   }
 
   return { action: 'create_from_version', created };
@@ -2133,6 +2151,15 @@ async function handleDelete(args: ManageWatchersArgs): Promise<{
               watcher_id: watcherId,
               watcher_name: watcher.name,
             },
+          });
+        }
+        if (watcher.organization_id) {
+          recordLifecycleEvent({
+            organizationId: watcher.organization_id as string,
+            entityType: 'watcher',
+            op: 'deleted',
+            entityId: watcherId,
+            summary: `Watcher "${watcher.name || watcherId}" archived`,
           });
         }
 

--- a/packages/server/src/tools/admin/metric_series.ts
+++ b/packages/server/src/tools/admin/metric_series.ts
@@ -1,0 +1,80 @@
+/**
+ * Tool: metric_series
+ *
+ * Generic read-only SQL endpoint for dashboard sparklines + stat chips.
+ * The caller passes a single SELECT statement that returns N columns of
+ * time-bucketed counts (e.g. one bucket column + one column per stat). The
+ * query is validated and auto-scoped to the caller's organization via the
+ * same `validateAndScopeQuery` guard that powers `query_sql`, so:
+ *
+ *   - mutations are rejected
+ *   - table references are restricted to the allowlist
+ *   - `$1` is always the caller's `organization_id` (server-injected)
+ *
+ * Returns `{ columns: string[], rows: unknown[][] }` — a standard tabular
+ * shape the frontend pivots into per-stat series for the StatsStrip chips.
+ */
+
+import { type Static, Type } from '@sinclair/typebox';
+import { getDb } from '../../db/client';
+import { validateAndScopeQuery } from '../../utils/execute-data-sources';
+import logger from '../../utils/logger';
+import { raceAbort } from '../../utils/race-abort';
+import type { ToolContext } from '../registry';
+
+export const MetricSeriesSchema = Type.Object({
+  sql: Type.String({
+    description:
+      'A single SELECT returning a bucket column plus one or more numeric stat columns. Table references are auto-scoped to the caller\'s organization; `$1` is the organization id (injected — do not pass it).',
+  }),
+});
+
+type MetricSeriesArgs = Static<typeof MetricSeriesSchema>;
+
+// Statement timeout in ms. Dashboards refresh frequently — keep tight.
+const STATEMENT_TIMEOUT_MS = 5000;
+
+export interface MetricSeriesResult {
+  columns: string[];
+  rows: unknown[][];
+}
+
+export async function metricSeries(
+  args: MetricSeriesArgs,
+  _env: unknown,
+  ctx: ToolContext
+): Promise<MetricSeriesResult> {
+  const orgId = ctx.organizationId;
+  if (!orgId) {
+    throw new Error('metric_series: caller must be scoped to an organization');
+  }
+
+  const { sql: scopedSql, params } = validateAndScopeQuery(args.sql, orgId);
+  const db = getDb();
+
+  const exec = (async () => {
+    // Postgres statement timeout for this connection only.
+    await db`SET LOCAL statement_timeout = ${STATEMENT_TIMEOUT_MS}`;
+    return db.unsafe(scopedSql, params as unknown[]);
+  })();
+
+  let rows: Record<string, unknown>[];
+  try {
+    rows = (await raceAbort(exec, STATEMENT_TIMEOUT_MS, 'metric_series')) as Record<
+      string,
+      unknown
+    >[];
+  } catch (err) {
+    logger.warn({ err, orgId }, '[metric_series] query failed');
+    throw err;
+  }
+
+  // postgres.js returns Array<Record<column, value>>. Flatten to a tabular
+  // result so the frontend doesn't have to know column order.
+  if (rows.length === 0) {
+    return { columns: [], rows: [] };
+  }
+  const columns = Object.keys(rows[0]);
+  const tabular = rows.map((r) => columns.map((c) => r[c]));
+  return { columns, rows: tabular };
+}

--- a/packages/server/src/tools/registry.ts
+++ b/packages/server/src/tools/registry.ts
@@ -8,6 +8,7 @@
 import { getPublicReadableActions, getRequiredAccessLevel } from '../auth/tool-access';
 import type { Env } from '../index';
 import { INTERNAL_REST_TOOLS } from './admin';
+import { MetricSeriesSchema, metricSeries } from './admin/metric_series';
 import { QuerySqlSchema, querySql } from './admin/query_sql';
 import { ListOrganizationsSchema } from './organizations';
 import { ResolvePathSchema, resolvePath } from './resolve_path';
@@ -143,6 +144,15 @@ const TOOLS: ToolDefinition[] = [
     inputSchema: QuerySqlSchema,
     annotations: READ_ONLY,
     handler: querySql,
+  },
+  {
+    name: 'metric_series',
+    description:
+      'Run a read-only time-series SQL for dashboard sparklines. Caller passes a single SELECT returning a bucket column + N numeric stat columns; the same validator/auto-scoper that powers `query_sql` injects `$1 = organization_id`. Returns `{ columns, rows }` for direct frontend consumption.',
+    inputSchema: MetricSeriesSchema,
+    annotations: READ_ONLY,
+    internal: true,
+    handler: metricSeries,
   },
   {
     name: 'run_sdk',

--- a/packages/server/src/utils/insert-event.ts
+++ b/packages/server/src/utils/insert-event.ts
@@ -343,3 +343,68 @@ export function recordChangeEvent(params: ChangeEventParams): void {
     logger.warn({ err, title: params.title }, 'Failed to record change event');
   });
 }
+
+// ============================================
+// Lifecycle Event (entity create / update / delete)
+// ============================================
+
+export type LifecycleEntityType =
+  | 'agent'
+  | 'connection'
+  | 'watcher'
+  | 'device'
+  | 'member';
+
+export type LifecycleOp = 'created' | 'updated' | 'deleted';
+
+interface LifecycleEventParams {
+  organizationId: string;
+  entityType: LifecycleEntityType;
+  op: LifecycleOp;
+  entityId: string | number;
+  /** Human-readable summary (e.g. "Agent 'Marketing' created"). */
+  summary: string;
+  /** Optional extra metadata merged under `metadata.extra`. */
+  extra?: Record<string, unknown>;
+  createdBy?: string | null;
+}
+
+/**
+ * Record an entity-lifecycle change as a `semantic_type='change'` event.
+ * Used by the metric_series SQL to compute cumulative counts (agents,
+ * connections, …) and the dashboard sparklines. Fire-and-forget.
+ *
+ * Metadata shape (queryable via `metadata->>'category'`, etc.):
+ *   {
+ *     "category": "lifecycle",
+ *     "entity_type": "connection",
+ *     "op": "created",
+ *     "entity_id": "...",
+ *     "extra": { ... }    // optional
+ *   }
+ */
+export function recordLifecycleEvent(params: LifecycleEventParams): void {
+  const externalId = `lifecycle_${params.entityType}_${params.op}_${params.entityId}_${Date.now()}`;
+
+  insertEvent({
+    entityIds: [],
+    organizationId: params.organizationId,
+    originId: externalId,
+    title: params.summary,
+    semanticType: 'change',
+    originType: `${params.entityType}_${params.op}`,
+    metadata: {
+      category: 'lifecycle',
+      entity_type: params.entityType,
+      op: params.op,
+      entity_id: String(params.entityId),
+      ...(params.extra ? { extra: params.extra } : {}),
+    },
+    createdBy: params.createdBy ?? null,
+  }).catch((err) => {
+    logger.warn(
+      { err, entityType: params.entityType, op: params.op },
+      '[insert-event] failed to record lifecycle event'
+    );
+  });
+}


### PR DESCRIPTION
## Summary

### Backend
- **New `metric_series` MCP tool** (admin/internal) in `packages/server/src/tools/admin/metric_series.ts`. Generic read-only SQL endpoint for dashboard sparklines. Reuses `validateAndScopeQuery` (the same guard `query_sql` uses) so it auto-injects `$1 = organization_id`, enforces the table allowlist, rejects mutations, and applies a 5s statement timeout. Returns `{ columns, rows }`.
- **`recordLifecycleEvent(...)`** helper in `utils/insert-event.ts` — emits a `semantic_type='change'` event with structured metadata:
  ```
  { category: 'lifecycle', entity_type, op, entity_id, extra? }
  ```
  so dashboard SQL can pivot entity CRUD via `metadata->>'category'` instead of parsing free-text titles.
- **Wired emitters** on entity write paths:
  - agents — `postgres-stores.ts` saveMetadata (detects insert vs update via `xmax = 0`); deleteMetadata emits `deleted`
  - connections — `manage_connections.ts` both create branches; existing delete handler now emits a structured lifecycle row alongside the human-readable change event
  - watchers — `manage_watchers.ts` create + create_from_version + archive

Devices + members emitters are a follow-up.

### Frontend
Bumps web submodule to lobu-ai/owletto-web#130 — sparkline chip with inline delta/14d label, `useMetricSeries` hook, per-page SQL for `/connectors` + `/agents`. Single SQL per page returns all stats as columns.

## Test plan
- [x] `make build-packages` green
- [x] Web `bunx tsc -b --noEmit` green
- [ ] Visual: `/buremba/connectors` and `/buremba/agents` show sparkline chips after deploy
- [ ] Trends fill in over ~14 days as lifecycle events accumulate

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added metric series analysis tool for querying organization-scoped time-series data with automatic timeout protection.

* **Chores**
  * Enhanced lifecycle audit event tracking for agents, connections, watchers, devices, and members (creation, updates, and deletion events).
  * Updated web dependencies.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lobu-ai/lobu/pull/756)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->