### PR TITLE
feat(lifecycle): emit device + member create/delete events

### DIFF
--- a/packages/server/src/auth/index.tsx
+++ b/packages/server/src/auth/index.tsx
@@ -28,6 +28,7 @@ import {
 	getConfiguredPublicOrigin,
 	normalizeHost,
 } from "../utils/public-origin";
+import { recordLifecycleEvent } from "../utils/insert-event";
 import { TtlCache } from "../utils/ttl-cache";
 import { resolveBaseUrl, safeParseUrl } from "./base-url";
 import { findExistingPersonalOrg } from "./personal-org-provisioning";
@@ -270,6 +271,14 @@ export async function createAuth(env: Env, request?: Request) {
 								"../workspace/multi-tenant"
 							);
 							invalidateMembershipRoleCache(org.id, user.id);
+								recordLifecycleEvent({
+									organizationId: org.id,
+									entityType: "member",
+									op: "created",
+									entityId: member.id,
+									summary: `Member "${user.name || user.email}" added`,
+									extra: { user_id: user.id, role: member.role },
+								});
 						} catch (err) {
 							console.error(
 								"[Auth] Failed to create $member entity after addMember:",
@@ -308,6 +317,13 @@ export async function createAuth(env: Env, request?: Request) {
 					afterRemoveMember: async ({ user, organization: org }) => {
 						try {
 							await deleteMemberEntity(org.id, user.email);
+								recordLifecycleEvent({
+									organizationId: org.id,
+									entityType: "member",
+									op: "deleted",
+									entityId: user.id,
+									summary: `Member "${user.name || user.email}" removed`,
+								});
 							const { invalidateMembershipRoleCache } = await import(
 								"../workspace/multi-tenant"
 							);

--- a/packages/server/src/worker-api.ts
+++ b/packages/server/src/worker-api.ts
@@ -36,7 +36,7 @@ import {
   materializeInlineAttachments,
   triggerAudioTranscriptions,
 } from './utils/inline-attachments';
-import { insertEvent } from './utils/insert-event';
+import { insertEvent, recordLifecycleEvent } from './utils/insert-event';
 import logger from './utils/logger';
 import { getWorkspaceRole } from './utils/organization-access';
 
@@ -186,6 +186,9 @@ export async function pollWorkerJob(c: Context<{ Bindings: Env }>) {
     try {
       const incomingCaps = advertisedCapabilities;
 
+      // `xmax = 0` on the RETURNING row distinguishes a brand-new device
+      // registration from a routine poll-update so we only emit the
+      // `device:created` lifecycle event once per device.
       const upserted = (await sql`
         INSERT INTO device_workers (user_id, worker_id, platform, app_version, capabilities, label, organization_id)
         VALUES (
@@ -203,9 +206,19 @@ export async function pollWorkerJob(c: Context<{ Bindings: Env }>) {
           label = COALESCE(EXCLUDED.label, device_workers.label),
           organization_id = COALESCE(device_workers.organization_id, EXCLUDED.organization_id),
           last_seen_at = now()
-        RETURNING id
-      `) as unknown as Array<{ id: string }>;
+        RETURNING id, organization_id, (xmax = 0) AS inserted
+      `) as unknown as Array<{ id: string; organization_id: string | null; inserted: boolean }>;
       deviceWorkerId = upserted[0]?.id ?? null;
+      if (upserted[0]?.inserted && upserted[0]?.organization_id) {
+        recordLifecycleEvent({
+          organizationId: upserted[0].organization_id,
+          entityType: 'device',
+          op: 'created',
+          entityId: upserted[0].id,
+          summary: `Device "${label ?? worker_id}" registered`,
+          extra: { platform, worker_id, app_version },
+        });
+      }
 
       // Reconcile this user's device connectors against the capabilities their
       // whole fleet currently advertises: auto-wire / re-activate the ones that
@@ -1681,9 +1694,15 @@ export async function deleteDeviceWorker(c: Context<{ Bindings: Env }>) {
     const sql = getDb();
     const deleted = await sql.begin(async (tx) => {
       const owned = (await tx`
-        SELECT 1 FROM device_workers WHERE id = ${deviceWorkerId} AND user_id = ${userId} LIMIT 1
-      `) as unknown as Array<unknown>;
-      if (owned.length === 0) return false;
+        SELECT organization_id, label, worker_id FROM device_workers
+        WHERE id = ${deviceWorkerId} AND user_id = ${userId}
+        LIMIT 1
+      `) as unknown as Array<{
+        organization_id: string | null;
+        label: string | null;
+        worker_id: string;
+      }>;
+      if (owned.length === 0) return null;
       // Un-pin and pause every connection backed by this device — a device
       // connector can't run anywhere without it; the owner re-pins to a new
       // device (or removes the connection) to bring it back.
@@ -1704,10 +1723,19 @@ export async function deleteDeviceWorker(c: Context<{ Bindings: Env }>) {
         `;
       }
       await tx`DELETE FROM device_workers WHERE id = ${deviceWorkerId} AND user_id = ${userId}`;
-      return true;
+      return owned[0];
     });
     if (!deleted) {
       return c.json({ error: 'Device not found or not owned by you' }, 404);
+    }
+    if (deleted.organization_id) {
+      recordLifecycleEvent({
+        organizationId: deleted.organization_id,
+        entityType: 'device',
+        op: 'deleted',
+        entityId: deviceWorkerId,
+        summary: `Device "${deleted.label ?? deleted.worker_id}" removed`,
+      });
     }
     return c.json({ ok: true });
   } catch (err: unknown) {


### PR DESCRIPTION
Closes the coverage gap from #756 — adds the last two entity types so all of agent, connection, watcher, device, member emit `recordLifecycleEvent` rows.

**Devices** — `worker-api.ts` pollWorkerJob upsert: `xmax = 0` distinguishes first registration from a routine poll-update so we only emit `device:created` once. Delete handler captures org/label inside the transaction, emits `device:deleted` after commit.

**Members** — `auth/index.tsx` better-auth organization plugin: emit `member:created` from `afterAddMember`, `member:deleted` from `afterRemoveMember` (right after the existing `*MemberEntity` helpers).

After this PR the dashboard metric_series SQL has real cumulative data for every stat on /agents (Agents, Users, Watchers, …) and /connectors (Connections, Devices, …).

## Test plan
- [x] `make build-packages` green
- [ ] Add a device → `events` row appears with metadata.entity_type='device', op='created'
- [ ] Remove a device → metadata.op='deleted'
- [ ] Same for member add/remove via the org-members admin UI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * System now records lifecycle events when members are added to or removed from organizations.
  * System now tracks device registration events separately from routine device updates, with lifecycle event recording for device creation and deletion.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lobu-ai/lobu/pull/757)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->