### PR TITLE
fix(metric_series): tsc errors that broke the build-app image

### DIFF
--- a/packages/server/src/tools/admin/manage_watchers.ts
+++ b/packages/server/src/tools/admin/manage_watchers.ts
@@ -1072,14 +1072,16 @@ async function handleCreate(
 
   logger.info(`[manage_watchers] Created watcher ${watcherId} with slug '${args.slug}'`);
 
-  recordLifecycleEvent({
-    organizationId,
-    entityType: 'watcher',
-    op: 'created',
-    entityId: watcherId,
-    summary: `Watcher "${args.name ?? args.slug}" created`,
-    extra: { slug: args.slug, agent_id: args.agent_id ?? null },
-  });
+  if (organizationId) {
+    recordLifecycleEvent({
+      organizationId,
+      entityType: 'watcher',
+      op: 'created',
+      entityId: watcherId,
+      summary: `Watcher "${args.name ?? args.slug}" created`,
+      extra: { slug: args.slug, agent_id: args.agent_id ?? null },
+    });
+  }
 
   return {
     action: 'create',

--- a/packages/server/src/tools/admin/metric_series.ts
+++ b/packages/server/src/tools/admin/metric_series.ts
@@ -19,7 +19,6 @@ import { type Static, Type } from '@sinclair/typebox';
 import { getDb } from '../../db/client';
 import { validateAndScopeQuery } from '../../utils/execute-data-sources';
 import logger from '../../utils/logger';
-import { raceAbort } from '../../utils/race-abort';
 import type { ToolContext } from '../registry';
 
 export const MetricSeriesSchema = Type.Object({
@@ -52,18 +51,13 @@ export async function metricSeries(
   const { sql: scopedSql, params } = validateAndScopeQuery(args.sql, orgId);
   const db = getDb();
 
-  const exec = (async () => {
-    // Postgres statement timeout for this connection only.
-    await db`SET LOCAL statement_timeout = ${STATEMENT_TIMEOUT_MS}`;
-    return db.unsafe(scopedSql, params as unknown[]);
-  })();
-
+  // Run inside a transaction so SET LOCAL applies for the user query only.
   let rows: Record<string, unknown>[];
   try {
-    rows = (await raceAbort(exec, STATEMENT_TIMEOUT_MS, 'metric_series')) as Record<
-      string,
-      unknown
-    >[];
+    rows = (await db.begin(async (tx) => {
+      await tx`SET LOCAL statement_timeout = ${STATEMENT_TIMEOUT_MS}`;
+      return tx.unsafe(scopedSql, params as unknown[]);
+    })) as Record<string, unknown>[];
   } catch (err) {
     logger.warn({ err, orgId }, '[metric_series] query failed');
     throw err;


### PR DESCRIPTION
Two TS errors slipped past my local `make build-packages` because that pass uses the bundler's relaxed checker. The Dockerfile runs `bunx tsc --noEmit` strictly and caught them:
- `metric_series.ts` — `raceAbort` signature is `(promise, signal?)` not `(promise, timeoutMs, label)`. Replaced with `db.begin` so `SET LOCAL statement_timeout` actually scopes to the user query.
- `manage_watchers.ts handleCreate` — `organizationId` is `string | null` here; added a guard around the recordLifecycleEvent call.

Unblocks the build-app pipeline that was failing on #756.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Resolved a critical issue where watcher creation could fail in organization-less or global contexts by ensuring proper event lifecycle processing throughout the creation workflow.

* **Refactor**
  * Enhanced metric series query execution with improved timeout handling mechanisms to provide greater reliability and stability for metric data retrieval operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lobu-ai/lobu/pull/758)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->