### PR TITLE
feat(lifecycle): MCP-client emitter + strict typecheck Makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Development Makefile for Lobu
 
-.PHONY: help setup build test eval clean dev build-packages ensure-submodule clean-workers test-unit test-integration test-e2e
+.PHONY: help setup build test eval clean dev build-packages ensure-submodule clean-workers test-unit test-integration test-e2e typecheck
 
 # Default target
 help:
@@ -14,6 +14,18 @@ help:
 	@echo "  make test-e2e                              - Boot the dev server + run openclaw-plugin e2e against it"
 	@echo "  make eval                                  - Run agent evals"
 	@echo "  make clean-workers                         - Stop any running embedded worker subprocesses"
+	@echo "  make typecheck                             - Strict typecheck (same as Dockerfile) for server + web"
+
+# Strict typecheck — mirrors the Dockerfile so local matches CI. Catches
+# what `build-packages` (relaxed, bundler-only) misses.
+typecheck:
+	@echo "🔎 Strict typecheck: packages/server..."
+	@( cd packages/server && bunx tsc --noEmit ) || exit $$?
+	@if [ -d packages/web/src ]; then \
+		echo "🔎 Strict typecheck: packages/web..."; \
+		( cd packages/web && bunx tsc -b --noEmit ) || exit $$?; \
+	fi
+	@echo "✅ Typecheck clean."
 
 # Build all TypeScript packages in dependency order
 build-packages:

--- a/packages/server/src/auth/oauth/clients.ts
+++ b/packages/server/src/auth/oauth/clients.ts
@@ -8,6 +8,7 @@
 import { randomBytes, scryptSync, timingSafeEqual } from 'node:crypto';
 import type { DbClient } from '../../db/client';
 import { pgTextArray } from '../../db/client';
+import { recordLifecycleEvent } from '../../utils/insert-event';
 import type { OAuthClient, OAuthClientMetadata, StoredOAuthClient } from './types';
 import { generateClientId, generateClientSecret } from './utils';
 
@@ -157,6 +158,17 @@ export class OAuthClientsStore {
       )
     `;
 
+    if (organizationId) {
+      recordLifecycleEvent({
+        organizationId,
+        entityType: 'client',
+        op: 'created',
+        entityId: clientId,
+        summary: `Connected app "${metadata.client_name || clientId}" registered`,
+        extra: { user_id: userId ?? null },
+      });
+    }
+
     return {
       ...metadata,
       client_id: clientId,
@@ -207,9 +219,24 @@ export class OAuthClientsStore {
   async deleteClient(clientId: string): Promise<boolean> {
     const result = await this.sql`
       DELETE FROM oauth_clients WHERE id = ${clientId}
-      RETURNING id
+      RETURNING id, organization_id, client_name
     `;
-    return result.length > 0;
+    if (result.length === 0) return false;
+    const row = result[0] as {
+      id: string;
+      organization_id: string | null;
+      client_name: string | null;
+    };
+    if (row.organization_id) {
+      recordLifecycleEvent({
+        organizationId: row.organization_id,
+        entityType: 'client',
+        op: 'deleted',
+        entityId: clientId,
+        summary: `Connected app "${row.client_name || clientId}" removed`,
+      });
+    }
+    return true;
   }
 
   /**

--- a/packages/server/src/utils/insert-event.ts
+++ b/packages/server/src/utils/insert-event.ts
@@ -348,18 +348,17 @@ export function recordChangeEvent(params: ChangeEventParams): void {
 // Lifecycle Event (entity create / update / delete)
 // ============================================
 
-export type LifecycleEntityType =
-  | 'agent'
-  | 'connection'
-  | 'watcher'
-  | 'device'
-  | 'member';
-
 export type LifecycleOp = 'created' | 'updated' | 'deleted';
 
 interface LifecycleEventParams {
   organizationId: string;
-  entityType: LifecycleEntityType;
+  /**
+   * Entity-type slug used by dashboard SQL to pivot lifecycle rows
+   * (`metadata->>'entity_type'`). Kept as a free-form string so new entity
+   * types can emit without touching this file — keep slugs short, lowercase,
+   * singular: `agent`, `connection`, `watcher`, `device`, `member`, `client`.
+   */
+  entityType: string;
   op: LifecycleOp;
   entityId: string | number;
   /** Human-readable summary (e.g. "Agent 'Marketing' created"). */


### PR DESCRIPTION
Wraps up the dashboard-stats follow-ups.

**Server**
- `auth/oauth/clients.ts` — emit `recordLifecycleEvent({entity_type:'client'})` on register/delete. Completes lifecycle coverage for the `Connected apps` chip on /agents.
- `utils/insert-event.ts` — drop the `LifecycleEntityType` enum so adding a new entity type is just `entityType: 'foo'` at the call site, no central registry to update.

**Tooling**
- `make typecheck` — runs the same strict `bunx tsc --noEmit` the Dockerfile uses. `build-packages` (bundler-only, relaxed) let two TS errors slip into #756; this target catches them locally.

**Submodule**
- Bumps web to lobu-ai/owletto-web#133 — `useMetricSeries` wired on /events, `Connected apps` sparkline on /agents, `lifecycleCumulativeStatsSql` builder makes adding new stats one-line.

## Test plan
- [x] `make typecheck` clean (catches what #756's build did)
- [ ] After deploy: register a new OAuth client → `events` row with `metadata.entity_type='client', op='created'`
- [ ] /events StatsStrip shows Events + Connections sparklines, Entities/Entity types value-only

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * OAuth client lifecycle events are now recorded when clients are created or deleted, enabling enhanced audit tracking.

* **Chores**
  * Added TypeScript strict type-checking build target.
  * Updated web package version.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lobu-ai/lobu/pull/761)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->