### PR TITLE
fix(metric_series): inline statement_timeout (SET LOCAL rejects params)

### DIFF
--- a/packages/server/src/tools/admin/metric_series.ts
+++ b/packages/server/src/tools/admin/metric_series.ts
@@ -52,10 +52,12 @@ export async function metricSeries(
   const db = getDb();
 
   // Run inside a transaction so SET LOCAL applies for the user query only.
+  // `SET LOCAL` doesn't accept prepared parameters, so the timeout literal is
+  // interpolated directly (safe — it's a module-level number).
   let rows: Record<string, unknown>[];
   try {
     rows = (await db.begin(async (tx) => {
-      await tx`SET LOCAL statement_timeout = ${STATEMENT_TIMEOUT_MS}`;
+      await tx.unsafe(`SET LOCAL statement_timeout = ${STATEMENT_TIMEOUT_MS}`);
       return tx.unsafe(scopedSql, params as unknown[]);
     })) as Record<string, unknown>[];
   } catch (err) {


### PR DESCRIPTION
Live probe of `POST /api/<org>/metric_series` against prod surfaced `syntax error at or near "$1"` on every call. Root cause: postgres.js's tagged-template `SET LOCAL statement_timeout = ${value}` binds the value as `$1`, but PG `SET LOCAL` doesn't accept prepared parameters. Switched to `tx.unsafe` with the literal interpolated directly. Constant is module-level so the interpolation is safe.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized database timeout configuration for improved system reliability during metrics operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lobu-ai/lobu/pull/762)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->