### PR TITLE
perf(events): stored fulltext column + lifecycle partial index

### DIFF
--- a/db/migrations/20260516200000_events_search_tsv.sql
+++ b/db/migrations/20260516200000_events_search_tsv.sql
@@ -16,11 +16,11 @@
 --      plus title's), so we drop the old index and recover its write
 --      amplification on every events insert.
 --
--- Operational note: ADD COLUMN ... GENERATED STORED rewrites the table and
--- takes ACCESS EXCLUSIVE for the duration. On a 1M-row events table expect
--- on the order of a minute; run during a quiet window. CONCURRENTLY does not
--- apply to ADD COLUMN; it only applies to CREATE INDEX, which we do below
--- separately so it doesn't block writes.
+-- Operational note: ADD COLUMN ... GENERATED STORED rewrites the events
+-- table under ACCESS EXCLUSIVE. On a 1M-row table expect on the order of a
+-- minute; run during a quiet window. CONCURRENTLY does not apply to ADD
+-- COLUMN; it only applies to CREATE INDEX, which is a separate statement
+-- below.
 
 ALTER TABLE public.events
     ADD COLUMN search_tsv tsvector GENERATED ALWAYS AS (
@@ -32,7 +32,101 @@ CREATE INDEX idx_events_search_tsv ON public.events USING gin (search_tsv);
 
 DROP INDEX IF EXISTS public.idx_events_fulltext;
 
+-- Recreate the current_event_records view so it exposes search_tsv to
+-- callers that go through the supersession filter (the view materializes
+-- its column list at create time, so `e.*`-style auto-pickup doesn't
+-- apply). buildSearchDocumentExpr() reads `f.search_tsv` / `fi.search_tsv`
+-- where f and fi are this view's aliases, so without this the view-backed
+-- queries fail with "column ... does not exist".
+
+DROP VIEW IF EXISTS public.current_event_records;
+CREATE VIEW public.current_event_records AS
+ SELECT e.id,
+    e.organization_id,
+    e.entity_ids,
+    e.origin_id,
+    e.title,
+    e.payload_type,
+    e.payload_text,
+    e.payload_data,
+    e.payload_template,
+    e.attachments,
+    e.metadata,
+    e.score,
+    emb.embedding,
+    e.author_name,
+    e.source_url,
+    e.occurred_at,
+    e.created_at,
+    e.origin_parent_id,
+    COALESCE(length(e.payload_text), 0) AS content_length,
+    e.search_tsv,
+    e.origin_type,
+    e.connector_key,
+    e.connection_id,
+    e.feed_key,
+    e.feed_id,
+    e.run_id,
+    e.semantic_type,
+    e.client_id,
+    e.created_by,
+    e.interaction_type,
+    e.interaction_status,
+    e.interaction_input_schema,
+    e.interaction_input,
+    e.interaction_output,
+    e.interaction_error,
+    e.supersedes_event_id
+   FROM (public.events e
+     LEFT JOIN public.event_embeddings emb ON ((emb.event_id = e.id)))
+  WHERE (NOT (EXISTS ( SELECT 1
+           FROM public.events newer
+          WHERE (newer.supersedes_event_id = e.id))));
+
 -- migrate:down
+
+DROP VIEW IF EXISTS public.current_event_records;
+CREATE VIEW public.current_event_records AS
+ SELECT e.id,
+    e.organization_id,
+    e.entity_ids,
+    e.origin_id,
+    e.title,
+    e.payload_type,
+    e.payload_text,
+    e.payload_data,
+    e.payload_template,
+    e.attachments,
+    e.metadata,
+    e.score,
+    emb.embedding,
+    e.author_name,
+    e.source_url,
+    e.occurred_at,
+    e.created_at,
+    e.origin_parent_id,
+    COALESCE(length(e.payload_text), 0) AS content_length,
+    e.origin_type,
+    e.connector_key,
+    e.connection_id,
+    e.feed_key,
+    e.feed_id,
+    e.run_id,
+    e.semantic_type,
+    e.client_id,
+    e.created_by,
+    e.interaction_type,
+    e.interaction_status,
+    e.interaction_input_schema,
+    e.interaction_input,
+    e.interaction_output,
+    e.interaction_error,
+    e.supersedes_event_id
+   FROM (public.events e
+     LEFT JOIN public.event_embeddings emb ON ((emb.event_id = e.id)))
+  WHERE (NOT (EXISTS ( SELECT 1
+           FROM public.events newer
+          WHERE (newer.supersedes_event_id = e.id))));
 
 CREATE INDEX idx_events_fulltext ON public.events
     USING gin (to_tsvector('english'::regconfig, COALESCE(payload_text, ''::text)));

--- a/db/migrations/20260516200000_events_search_tsv.sql
+++ b/db/migrations/20260516200000_events_search_tsv.sql
@@ -1,0 +1,40 @@
+-- migrate:up
+
+-- Materialize the fulltext search vector as a STORED column.
+--
+-- Why a real column instead of the previous expression-indexed `to_tsvector(payload_text)`:
+--   1. It includes both `title` (weight A) and `payload_text` (weight B) — the
+--      same shape buildSearchDocumentExpr() in content-search.ts uses for
+--      ranking. Retrieval (@@) and ts_rank_cd now read the same vector, so
+--      title-only hits surface correctly and ranking doesn't recompute the
+--      vector per matched row at query time.
+--   2. Planner-stable: `search_tsv @@ to_tsquery(...)` is a plain column
+--      reference — no expression-shape matching, no aliasing risk where the
+--      GIN gets skipped because the WHERE expression isn't byte-identical to
+--      the indexed expression.
+--   3. The new GIN strictly subsumes the old payload-only one (same lexemes
+--      plus title's), so we drop the old index and recover its write
+--      amplification on every events insert.
+--
+-- Operational note: ADD COLUMN ... GENERATED STORED rewrites the table and
+-- takes ACCESS EXCLUSIVE for the duration. On a 1M-row events table expect
+-- on the order of a minute; run during a quiet window. CONCURRENTLY does not
+-- apply to ADD COLUMN; it only applies to CREATE INDEX, which we do below
+-- separately so it doesn't block writes.
+
+ALTER TABLE public.events
+    ADD COLUMN search_tsv tsvector GENERATED ALWAYS AS (
+        setweight(to_tsvector('english', COALESCE(title, '')), 'A') ||
+        setweight(to_tsvector('english', COALESCE(payload_text, '')), 'B')
+    ) STORED;
+
+CREATE INDEX idx_events_search_tsv ON public.events USING gin (search_tsv);
+
+DROP INDEX IF EXISTS public.idx_events_fulltext;
+
+-- migrate:down
+
+CREATE INDEX idx_events_fulltext ON public.events
+    USING gin (to_tsvector('english'::regconfig, COALESCE(payload_text, ''::text)));
+DROP INDEX IF EXISTS public.idx_events_search_tsv;
+ALTER TABLE public.events DROP COLUMN search_tsv;

--- a/db/migrations/20260516200100_events_lifecycle_changes_index.sql
+++ b/db/migrations/20260516200100_events_lifecycle_changes_index.sql
@@ -1,0 +1,25 @@
+-- migrate:up
+
+-- Partial index for the dashboard's 14-day lifecycle-cumulative-stats query
+-- (lifecycleCumulativeStatsSql in packages/web/src/lib/api/metric-series.ts).
+--
+-- The query reads events older than `now() - interval '14 days'` and
+-- aggregates by date_trunc('day', created_at), with every COUNT FILTER
+-- already gated on semantic_type='change' AND metadata->>'category'='lifecycle'.
+-- A partial index whose predicate matches that gate prunes the scan from
+-- "all events in the last 14 days for the org" to "just the lifecycle
+-- changes" — typically a small slice of total events. The aggregation
+-- itself is cheap once the row set is narrow.
+--
+-- Why not a materialized view: at current scale the bottleneck is the row
+-- scan, not the per-bucket COUNT FILTER work. A partial index removes the
+-- scan cost without introducing a refresh job or staleness. Revisit if the
+-- post-prune row count grows into the millions.
+
+CREATE INDEX idx_events_lifecycle_changes
+    ON public.events (organization_id, created_at)
+    WHERE semantic_type = 'change' AND metadata->>'category' = 'lifecycle';
+
+-- migrate:down
+
+DROP INDEX IF EXISTS public.idx_events_lifecycle_changes;

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -500,6 +500,7 @@ CREATE TABLE public.events (
     interaction_error text,
     supersedes_event_id bigint,
     content_length integer GENERATED ALWAYS AS (COALESCE(length(payload_text), 0)) STORED,
+    search_tsv tsvector GENERATED ALWAYS AS ((setweight(to_tsvector('english'::regconfig, COALESCE(title, ''::text)), 'A'::"char") || setweight(to_tsvector('english'::regconfig, COALESCE(payload_text, ''::text)), 'B'::"char"))) STORED,
     CONSTRAINT events_interaction_status_check CHECK ((interaction_status = ANY (ARRAY['pending'::text, 'approved'::text, 'rejected'::text, 'completed'::text, 'failed'::text]))),
     CONSTRAINT events_interaction_type_check CHECK ((interaction_type = ANY (ARRAY['none'::text, 'approval'::text]))),
     CONSTRAINT events_payload_type_check CHECK ((payload_type = ANY (ARRAY['text'::text, 'markdown'::text, 'json_template'::text, 'media'::text, 'empty'::text]))),
@@ -3407,12 +3408,6 @@ CREATE INDEX idx_events_entity_ids_occurred_at ON public.events USING btree ((en
 CREATE INDEX idx_events_feed_id ON public.events USING btree (feed_id);
 
 --
--- Name: idx_events_fulltext; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_events_fulltext ON public.events USING gin (to_tsvector('english'::regconfig, COALESCE(payload_text, ''::text)));
-
---
 -- Name: idx_events_identity_fact_account; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -3423,6 +3418,12 @@ CREATE INDEX idx_events_identity_fact_account ON public.events USING btree (conn
 --
 
 CREATE INDEX idx_events_identity_fact_lookup ON public.events USING btree (organization_id, ((metadata ->> 'namespace'::text)), ((metadata ->> 'normalizedValue'::text))) WHERE (semantic_type = 'identity_fact'::text);
+
+--
+-- Name: idx_events_lifecycle_changes; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_events_lifecycle_changes ON public.events USING btree (organization_id, created_at) WHERE ((semantic_type = 'change'::text) AND ((metadata ->> 'category'::text) = 'lifecycle'::text));
 
 --
 -- Name: idx_events_metadata_auth_user_id; Type: INDEX; Schema: public; Owner: -
@@ -3495,6 +3496,12 @@ CREATE INDEX idx_events_raw_content_trgm ON public.events USING gin (payload_tex
 --
 
 CREATE INDEX idx_events_run_id ON public.events USING btree (run_id);
+
+--
+-- Name: idx_events_search_tsv; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_events_search_tsv ON public.events USING gin (search_tsv);
 
 --
 -- Name: idx_events_semantic_type; Type: INDEX; Schema: public; Owner: -
@@ -4991,4 +4998,6 @@ INSERT INTO public.schema_migrations (version) VALUES
     ('20260515120000'),
     ('20260515150000'),
     ('20260515160000'),
-    ('20260516120000');
+    ('20260516120000'),
+    ('20260516200000'),
+    ('20260516200100');

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -588,6 +588,7 @@ CREATE VIEW public.current_event_records AS
     e.created_at,
     e.origin_parent_id,
     COALESCE(length(e.payload_text), 0) AS content_length,
+    e.search_tsv,
     e.origin_type,
     e.connector_key,
     e.connection_id,

--- a/packages/server/src/utils/content-search.ts
+++ b/packages/server/src/utils/content-search.ts
@@ -1383,7 +1383,12 @@ async function listContentInternal(
  * ```
  */
 function buildSearchDocumentExpr(alias: string): string {
-  return `setweight(to_tsvector('english', COALESCE(${alias}.title, '')), 'A') || setweight(to_tsvector('english', COALESCE(${alias}.payload_text, '')), 'B')`;
+  // Reads the GENERATED STORED `search_tsv` column populated by the events
+  // table — same shape (title weighted A, payload_text weighted B) the
+  // expression used to compute inline, but precomputed at row insert so
+  // retrieval (@@) and ranking (ts_rank_cd) hit the same indexed value
+  // without rebuilding the vector per matched row.
+  return `${alias}.search_tsv`;
 }
 
 const STOPWORDS = [
@@ -1715,7 +1720,7 @@ async function searchContentBySingleQuery(
           FROM events ce
           JOIN current_event_records f ON f.id = ce.id
           ${candidateFilterJoins}
-          WHERE to_tsvector('english', COALESCE(ce.payload_text, '')) @@ to_tsquery('english', $${tsqueryParamIdx})
+          WHERE ce.search_tsv @@ to_tsquery('english', $${tsqueryParamIdx})
             AND ${standardFiltersSQL}
           LIMIT ${CANDIDATE_VECTOR_LIMIT}`);
       // trigram GIN — preserves the payload substring match (exact strings, ids).

--- a/packages/server/src/utils/content-search.ts
+++ b/packages/server/src/utils/content-search.ts
@@ -1742,7 +1742,7 @@ async function searchContentBySingleQuery(
   }
 
   const nonDateFilteredIdsCteSql = `filtered_ids AS (
-        SELECT f.id, f.score, f.occurred_at, f.title, f.payload_text, f.embedding
+        SELECT f.id, f.score, f.occurred_at, f.title, f.payload_text, f.embedding, f.search_tsv
         FROM current_event_records f
         ${useCandidatePath ? 'JOIN search_candidates sc ON sc.id = f.id' : ''}
         LEFT JOIN connections c ON c.id = f.connection_id
@@ -1756,7 +1756,7 @@ async function searchContentBySingleQuery(
   const querySQL = useDateFeed
     ? `
       WITH RECURSIVE filtered_ids AS (
-        SELECT f.id, f.score, f.occurred_at, f.title, f.payload_text, f.embedding
+        SELECT f.id, f.score, f.occurred_at, f.title, f.payload_text, f.embedding, f.search_tsv
         FROM current_event_records f
         LEFT JOIN connections c ON c.id = f.connection_id
         LEFT JOIN watcher_window_events iwf

--- a/packages/server/src/utils/table-schema.ts
+++ b/packages/server/src/utils/table-schema.ts
@@ -77,6 +77,7 @@ export const QUERYABLE_SCHEMA = {
         'run_id',
         'semantic_type',
         'content_length',
+        'search_tsv',
         'client_id',
         'created_by',
         'interaction_type',


### PR DESCRIPTION
## Summary

Two index changes to address the slowest paths on the `events` table — without reaching for partitioning, TimescaleDB, or a matview pipeline.

### 1. `events.search_tsv` GENERATED STORED column

- Pre-computes `setweight(to_tsvector(title), 'A') || setweight(to_tsvector(payload_text), 'B')` at row insert.
- New `idx_events_search_tsv` GIN drives both retrieval (`@@`) and ranking (`ts_rank_cd`) — the previous `idx_events_fulltext` only indexed `payload_text` so title-only hits leaked past it and `ts_rank_cd` had to rebuild the vector per matched row.
- Planner sees a plain column reference instead of a complex expression — eliminates the class of misses where the expression in the WHERE clause wasn't byte-identical to the indexed one (the issue called out in the `search_memory` slow-path memory note).
- Drops the now-redundant `idx_events_fulltext`. The new index strictly subsumes its lexeme set.

### 2. `idx_events_lifecycle_changes` partial btree

- `(organization_id, created_at) WHERE semantic_type='change' AND metadata->>'category'='lifecycle'`
- Targets `lifecycleCumulativeStatsSql` in `packages/web/src/lib/api/metric-series.ts` — the dashboard's 14-day rollup. The partial predicate matches the COUNT FILTER gates exactly, so the scan is pruned to the lifecycle slice (~1% of events) instead of "all events from the last 14 days for the org".

### Why an index, not a materialized view, for the rollup

At current scale (~722k events in the largest org per the search-memory memory note), the bottleneck is the row scan, not the per-bucket `COUNT FILTER` aggregation. A matview adds refresh-job complexity and staleness for negligible speedup. Revisit once the post-prune row count grows into the millions.

### Why no partitioning yet

`events` is multi-tenant temporal: org-scoped first, time-bounded second. At ~722k rows partition pruning overhead would outweigh gains, and the slow `search_memory` path is index-shape-bottlenecked, not table-size-bottlenecked. When the time comes, native PG `RANGE` partitioning on `created_at` is the better fit than TimescaleDB (TSL license, per-chunk vector indexes degrade ANN recall, custom CNPG image already carries postgis).

## Verification

Bench against a scratch PG17 DB with realistic volume:

| Query | Index used | Rows touched | Wall time |
| --- | --- | --- | --- |
| Lifecycle rollup, 14-day, 50k events | `idx_events_lifecycle_changes` | 500 (just the lifecycle changes) | 0.16ms |
| Fulltext `search_tsv @@ to_tsquery(...)` @ 500k events | `idx_events_search_tsv` (Bitmap Heap Scan) | 1 (`Rows Removed by Filter: 0`) | 0.5ms |

At sub-50k events the planner correctly stays on seq scan for the GIN — flips automatically as volume grows.

Strict typecheck clean (`make typecheck`).

## Operational note

Migration `20260516200000_events_search_tsv.sql` does `ADD COLUMN ... GENERATED STORED` which rewrites the events table under `ACCESS EXCLUSIVE`. On a 1M-row table expect ~minute-long hold; schedule during a quiet window.

## Test plan

- [ ] CI passes (schema-drift check + typecheck)
- [ ] Apply migration in dev DB; confirm `events.search_tsv` populated + `idx_events_search_tsv` present
- [ ] Search latency on the largest org observably improves once index used
- [ ] Lifecycle rollup latency on `/dashboard` improves

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved full‑text search by adding a precomputed, weighted search column for better relevance and faster queries.
  * Added a targeted index for lifecycle-change events to speed up filtering and retrieval.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lobu-ai/lobu/pull/765)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->