### PR TITLE
perf(server): SIGUSR2 writes V8 heap snapshot

### DIFF
--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -214,24 +214,49 @@ async function main() {
   process.on('SIGTERM', () => shutdown('SIGTERM'));
   process.on('SIGINT', () => shutdown('SIGINT'));
 
-  // SIGUSR2 → V8 heap snapshot. Blocks the event loop for ~seconds (size of
-  // heap), so only trigger via an explicit `kubectl exec` when investigating
-  // a leak — not from any automated source. Writes to /tmp so it can be
-  // copied out with `kubectl cp <pod>:/tmp/<file> .heapsnapshot`, then opened
-  // in Chrome DevTools → Memory → Load.
-  process.on('SIGUSR2', () => {
-    const snapshotPath = `/tmp/lobu-${process.pid}-${Date.now()}.heapsnapshot`;
+  // SIGUSR2 → V8 heap snapshot. Off by default because snapshots contain
+  // in-memory secrets (DB URL, OAuth tokens, secret-proxy cache) and
+  // workers spawn as the same Linux UID. Operator opts in by setting
+  // ALLOW_HEAP_SNAPSHOT=1 on the pod, sends `kubectl exec ... kill -USR2 1`,
+  // copies the file out, then unsets the env / rolls the pod.
+  //
+  // Blocks the event loop for ~seconds (proportional to heap size) and
+  // requires ~heap-size extra memory while writing. Don't trigger from a
+  // pod close to the cgroup limit or it will OOM mid-snapshot. Trigger
+  // also blocks /health/ready (DB SELECT 1) — drain via Service first if
+  // multi-replica.
+  //
+  // Single-flight + fixed filename: subsequent signals while a snapshot is
+  // in progress are ignored, and the path is `/tmp/lobu.heapsnapshot`
+  // (overwritten each time) so a stuck-on flag can't fill the tmpfs.
+  if (process.env.ALLOW_HEAP_SNAPSHOT === '1') {
+    const SNAPSHOT_PATH = '/tmp/lobu.heapsnapshot';
+    let inProgress = false;
+    process.on('SIGUSR2', () => {
+      if (inProgress) {
+        logger.warn('[heap] SIGUSR2 ignored — snapshot already in progress');
+        return;
+      }
+      inProgress = true;
+      logger.warn(
+        { path: SNAPSHOT_PATH },
+        '[heap] SIGUSR2 received — writing heap snapshot (blocks event loop)'
+      );
+      try {
+        v8.writeHeapSnapshot(SNAPSHOT_PATH);
+        logger.warn({ path: SNAPSHOT_PATH }, '[heap] snapshot written');
+      } catch (err) {
+        logger.error({ err }, '[heap] writeHeapSnapshot failed');
+      } finally {
+        inProgress = false;
+      }
+    });
     logger.warn(
-      { path: snapshotPath },
-      '[heap] SIGUSR2 received — writing heap snapshot (blocks event loop)'
+      '[heap] ALLOW_HEAP_SNAPSHOT=1 — SIGUSR2 will write heap dumps to ' +
+        SNAPSHOT_PATH +
+        '. Unset and roll the pod when done; snapshots contain secrets.'
     );
-    try {
-      v8.writeHeapSnapshot(snapshotPath);
-      logger.warn({ path: snapshotPath }, '[heap] snapshot written');
-    } catch (err) {
-      logger.error({ err }, '[heap] writeHeapSnapshot failed');
-    }
-  });
+  }
 
   // Start HTTP server
   logger.info({ port }, 'Starting server');

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -26,6 +26,7 @@ import http from 'node:http';
 import { createRequire } from 'node:module';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import v8 from 'node:v8';
 import { getRequestListener } from '@hono/node-server';
 import { Hono } from 'hono';
 import { closeDbSingleton, probeListenNotify } from './db/client';
@@ -212,6 +213,25 @@ async function main() {
   };
   process.on('SIGTERM', () => shutdown('SIGTERM'));
   process.on('SIGINT', () => shutdown('SIGINT'));
+
+  // SIGUSR2 → V8 heap snapshot. Blocks the event loop for ~seconds (size of
+  // heap), so only trigger via an explicit `kubectl exec` when investigating
+  // a leak — not from any automated source. Writes to /tmp so it can be
+  // copied out with `kubectl cp <pod>:/tmp/<file> .heapsnapshot`, then opened
+  // in Chrome DevTools → Memory → Load.
+  process.on('SIGUSR2', () => {
+    const snapshotPath = `/tmp/lobu-${process.pid}-${Date.now()}.heapsnapshot`;
+    logger.warn(
+      { path: snapshotPath },
+      '[heap] SIGUSR2 received — writing heap snapshot (blocks event loop)'
+    );
+    try {
+      v8.writeHeapSnapshot(snapshotPath);
+      logger.warn({ path: snapshotPath }, '[heap] snapshot written');
+    } catch (err) {
+      logger.error({ err }, '[heap] writeHeapSnapshot failed');
+    }
+  });
 
   // Start HTTP server
   logger.info({ port }, 'Starting server');


### PR DESCRIPTION
## Why

Post-incident measurement (see [lobu#767](https://github.com/lobu-ai/lobu/pull/767)): with the queue healthy again, the app pod still grows from baseline toward the 1Gi limit. Without an inspector port we can't see what's allocating.

Sample taken from \`summaries-app-lobu-app-77756ccdd7-dkh2l\`:

| T+ | RSS | cgroup.memory.current |
|---|---|---|
| 90 min | 649 MB | 690 MB |
| 90.5 min | 652 MB | 693 MB |

That's ~3 MB / 30s of slow growth. Pre-fix the same pod hit 1Gi in 70 min from the same baseline (driven by the schema-mismatch error pile-up). Post-fix it's slower but not zero — there's a residual leak.

## What

\`process.on('SIGUSR2', () => v8.writeHeapSnapshot('/tmp/...'))\` so we can dump on demand:

\`\`\`
POD=\$(kubectl get pod -n summaries-prod -l app.kubernetes.io/component=api -o name | head -1)
kubectl exec -n summaries-prod \$POD -- kill -USR2 1
# wait for "snapshot written" log line, then:
kubectl cp summaries-prod/\$(basename \$POD):/tmp/<file>.heapsnapshot ./lobu.heapsnapshot
# open in Chrome DevTools → Memory → Load
\`\`\`

## Notes

- \`writeHeapSnapshot\` is synchronous and blocks the event loop for seconds proportional to heap size. Only trigger manually when investigating.
- SIGUSR2 is free on Node (SIGUSR1 is the one Node reserves for the inspector).
- No security risk — triggering requires \`kubectl exec\` access.

## Test plan

- [x] \`make typecheck\` clean
- [x] \`make build-packages\` builds
- [ ] After merge: deploy, send SIGUSR2 once, confirm a .heapsnapshot lands in /tmp and is openable in DevTools.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Server now supports on-demand heap snapshot diagnostics when enabled.
  * Snapshots are written to a temporary location and logged on success or failure.
  * Additional snapshot requests are ignored while a snapshot is in progress to avoid conflicts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lobu-ai/lobu/pull/768?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->