### PR TITLE
perf(events): has_embedding column + maintenance triggers

### DIFF
--- a/db/migrations/20260517000000_events_has_embedding.sql
+++ b/db/migrations/20260517000000_events_has_embedding.sql
@@ -1,0 +1,56 @@
+-- migrate:up
+
+-- has_embedding mirrors "does event_embeddings have a row for this event_id".
+-- The embed-backfill scheduler today does a 1.27s seq scan + hash anti-join
+-- on the 1.15M-row events table every 5 min (pg_stat_statements rank #1 by
+-- total_exec_time, see lobu#767 postmortem). With this column + a partial
+-- index (added in a follow-up migration after backfill), the scheduler
+-- becomes a tiny index lookup over the actually-missing-embedding rows.
+--
+-- This migration only adds the column and the maintenance triggers. The
+-- column is intentionally:
+--   * nullable: ADD COLUMN <bool> NULL is O(1) metadata-only in PG 11+; a
+--     DEFAULT would rewrite all 1.15M rows under ACCESS EXCLUSIVE (the same
+--     trap that timed out 20260516200000_events_search_tsv).
+--   * not backfilled here: existing rows are populated by a batched script
+--     (scripts/backfill-events-has-embedding.sql) that runs outside the
+--     Helm hook so it can pace itself with statement_timeout headroom.
+--
+-- Until backfill finishes, has_embedding IS NULL means "unknown" for old
+-- rows; new rows get has_embedding flipped by the triggers below. The
+-- partial index (next migration) treats NULL the same as FALSE so the
+-- scheduler keeps working.
+
+ALTER TABLE public.events ADD COLUMN has_embedding boolean;
+
+CREATE OR REPLACE FUNCTION public.event_embeddings_after_insert() RETURNS trigger AS $$
+BEGIN
+  UPDATE public.events SET has_embedding = true WHERE id = NEW.event_id;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION public.event_embeddings_after_delete() RETURNS trigger AS $$
+BEGIN
+  UPDATE public.events SET has_embedding = false WHERE id = OLD.event_id;
+  RETURN OLD;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trg_event_embeddings_after_insert ON public.event_embeddings;
+CREATE TRIGGER trg_event_embeddings_after_insert
+  AFTER INSERT ON public.event_embeddings
+  FOR EACH ROW EXECUTE FUNCTION public.event_embeddings_after_insert();
+
+DROP TRIGGER IF EXISTS trg_event_embeddings_after_delete ON public.event_embeddings;
+CREATE TRIGGER trg_event_embeddings_after_delete
+  AFTER DELETE ON public.event_embeddings
+  FOR EACH ROW EXECUTE FUNCTION public.event_embeddings_after_delete();
+
+-- migrate:down
+
+DROP TRIGGER IF EXISTS trg_event_embeddings_after_insert ON public.event_embeddings;
+DROP TRIGGER IF EXISTS trg_event_embeddings_after_delete ON public.event_embeddings;
+DROP FUNCTION IF EXISTS public.event_embeddings_after_insert();
+DROP FUNCTION IF EXISTS public.event_embeddings_after_delete();
+ALTER TABLE public.events DROP COLUMN IF EXISTS has_embedding;

--- a/scripts/backfill-events-has-embedding.sh
+++ b/scripts/backfill-events-has-embedding.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+# Batched backfill for events.has_embedding (added in migration
+# 20260517000000_events_has_embedding.sql).
+#
+# Why batched and not in the migration: a single UPDATE over 1.15M rows
+# would hold an exclusive row-level lock for ~minute on a hot table while
+# WAL-amplifying every row. Doing it in batches of 10k means each transaction
+# is bounded (~1s) so VACUUM can keep up, autovacuum doesn't fall behind, and
+# the API stays responsive.
+#
+# Idempotent: only touches rows where has_embedding IS NULL, so re-running
+# after a partial run picks up where it left off.
+#
+# Run from the repo root:
+#   DATABASE_URL="postgres://..." ./scripts/backfill-events-has-embedding.sh
+#
+# Operational note: takes ~5-10 min for 1.15M rows on a small Postgres. Safe
+# to ctrl-C and resume; safe to run alongside live traffic.
+
+set -euo pipefail
+
+if [ -z "${DATABASE_URL:-}" ]; then
+  echo "DATABASE_URL not set" >&2
+  exit 1
+fi
+
+BATCH_SIZE="${BATCH_SIZE:-10000}"
+SLEEP_BETWEEN_BATCHES="${SLEEP_BETWEEN_BATCHES:-0.1}"
+
+echo "[backfill] BATCH_SIZE=$BATCH_SIZE SLEEP_BETWEEN_BATCHES=${SLEEP_BETWEEN_BATCHES}s"
+
+remaining_count() {
+  psql "$DATABASE_URL" -tAc "SELECT count(*) FROM public.events WHERE has_embedding IS NULL"
+}
+
+total_remaining=$(remaining_count)
+echo "[backfill] $total_remaining rows have has_embedding IS NULL"
+
+if [ "$total_remaining" = "0" ]; then
+  echo "[backfill] nothing to do"
+  exit 0
+fi
+
+batches=0
+while true; do
+  # Each batch is one transaction. Update up to $BATCH_SIZE rows where the
+  # column is still unknown. UPDATE FROM joins to event_embeddings to set
+  # the right value; rows with no matching embedding row get FALSE.
+  rows_updated=$(psql "$DATABASE_URL" -tAc "
+    WITH batch AS (
+      SELECT id FROM public.events
+       WHERE has_embedding IS NULL
+       LIMIT $BATCH_SIZE
+       FOR UPDATE SKIP LOCKED
+    )
+    UPDATE public.events e
+       SET has_embedding = (emb.event_id IS NOT NULL)
+      FROM batch b
+      LEFT JOIN public.event_embeddings emb ON emb.event_id = b.id
+     WHERE e.id = b.id
+    RETURNING 1
+  " | wc -l | tr -d ' ')
+
+  batches=$((batches + 1))
+
+  if [ "$rows_updated" = "0" ]; then
+    echo "[backfill] no rows updated in batch $batches — done"
+    break
+  fi
+
+  if [ $((batches % 10)) -eq 0 ]; then
+    current_remaining=$(remaining_count)
+    echo "[backfill] batch $batches: ~${rows_updated} rows updated this batch, ${current_remaining} remaining"
+  fi
+
+  sleep "$SLEEP_BETWEEN_BATCHES"
+done
+
+final_remaining=$(remaining_count)
+echo "[backfill] complete: $final_remaining rows still have has_embedding IS NULL (expect 0)"


### PR DESCRIPTION
## Why

Postmortem measurement (pg_stat_statements, see [#767](https://github.com/lobu-ai/lobu/pull/767)): the embed-backfill scheduler is the #1 burner — 564s total / 1274ms mean × 443 calls. Each tick does a parallel seq scan over 1.15M \`events\` rows + hash anti-join against 1.08M \`event_embeddings\` rows, just to find the ~25k events without embeddings.

\`\`\`
Parallel Seq Scan on events e (rows=1029034, t=152ms)
  Filter: payload_text IS NOT NULL AND payload_text <> ''
Parallel Hash Anti Join (events e ⋈ event_embeddings emb)
  rows=8355 of 1.03M scanned per worker × 3 workers
\`\`\`

The fix: denormalize "does this event have an embedding?" as a boolean on \`events\`, maintained by trigger. The scheduler then becomes a tiny partial-index range scan over the ~25k pending rows instead of a 1.15M-row table scan.

## What's in this PR (Phase 1 of 3)

* **Migration** \`20260517000000_events_has_embedding.sql\`:
  * \`ADD COLUMN has_embedding boolean\` — nullable, no default, no rewrite (O(1) metadata flip per PG 11+). **Specifically not \`GENERATED STORED\`** — that's the trap that broke [#765](https://github.com/lobu-ai/lobu/pull/765). Follows the pattern documented in [#769](https://github.com/lobu-ai/lobu/pull/769).
  * Triggers on \`event_embeddings\`: AFTER INSERT flips \`events.has_embedding = true\`; AFTER DELETE flips back to \`false\`.
  * **No partial index yet** — column is mostly NULL until backfill runs, so an index would be empty.
* **Backfill script** \`scripts/backfill-events-has-embedding.sh\`:
  * Batched UPDATE (10k rows per txn, configurable). Each batch bounded so VACUUM keeps up.
  * Idempotent: only touches \`has_embedding IS NULL\` rows; safe to resume after Ctrl-C.
  * Runs **outside** the Helm hook (it's a one-time prod op, not an automated migration step).

**No app code changes.** The scheduler still uses the existing seq-scan path until the column is fully backfilled and verified in prod.

## Phases 2 + 3 (follow-up PRs)

* **PR 4:** run the backfill script against prod, then \`CREATE INDEX CONCURRENTLY idx_events_pending_embedding ON events (organization_id, id) WHERE NOT has_embedding AND payload_text IS NOT NULL AND payload_text <> ''\`.
* **PR 5:** rewrite \`triggerEmbedBackfill\` to query the partial index. Drop the seq-scan path. Verify EXPLAIN ANALYZE before/after.

Sequencing matters: the index can't be added until the column has values, the code can't switch over until the index exists, and each step is independently verifiable. Bundling them would mean a single rollout window with three things to revert.

## Validation

Tested the migration in a \`BEGIN; ... ROLLBACK\` against the prod schema:

* Column adds (column_name=has_embedding, data_type=boolean, nullable).
* Both triggers register (\`trg_event_embeddings_after_insert\` AFTER INSERT, \`trg_event_embeddings_after_delete\` AFTER DELETE).
* Insert a fresh embedding for an event with no existing embedding → \`has_embedding\` flips from \`NULL\` to \`TRUE\`.
* Delete that embedding → \`has_embedding\` flips to \`FALSE\`.
* ROLLBACK: prod state unchanged.

\`make build-packages\` + \`make typecheck\` clean.

## Risks + mitigations

* **Trigger overhead on event_embeddings inserts.** event_embeddings INSERT is pg_stat_statements rank #11 (38s / 135k calls / 0.3ms mean). The trigger adds one UPDATE per insert. Estimate: +1-2ms per insert. On steady throughput (~5/sec) that's negligible; on a backfill burst (1k inserts at once) it adds ~1-2s. Acceptable.
* **Backfill script bottlenecking other writes.** Each batch is a single 10k-row UPDATE that takes a SHARE ROW EXCLUSIVE lock per row. \`FOR UPDATE SKIP LOCKED\` in the picker means concurrent triggers/inserts don't block. Worst case: a single batch takes a few seconds and other writes wait briefly.
* **NULL semantic during backfill.** Until backfill completes, old rows have \`has_embedding = NULL\`. No code reads the column yet, so no behavior change. Phase 2's partial index uses \`WHERE NOT has_embedding\` which excludes NULLs, but that matches the pre-fix semantic ("rows we haven't proven have an embedding"); PR 5 just adds a guard that the partial-index path is only used after backfill finished.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced event embedding tracking with automatic status recording. Database-level mechanisms now maintain consistency between events and their associated embeddings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lobu-ai/lobu/pull/770?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->