### PR TITLE
perf(workers): stop shipping connector bundles + LRU cache cap

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -156,6 +156,7 @@
         "@lobu/embeddings": "workspace:*",
         "@lobu/worker": "workspace:*",
         "@xenova/transformers": "^2.17.2",
+        "esbuild": "^0.25.0",
         "jimp": "^1.6.0",
         "playwright": "npm:patchright@^1.57.0",
         "playwright-vanilla": "npm:playwright@^1.60.0",
@@ -3969,6 +3970,8 @@
 
     "@jsonforms/core/ajv-formats": ["ajv-formats@2.1.1", "", { "dependencies": { "ajv": "^8.0.0" } }, "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA=="],
 
+    "@lobu/connector-worker/esbuild": ["esbuild@0.25.12", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.25.12", "@esbuild/android-arm": "0.25.12", "@esbuild/android-arm64": "0.25.12", "@esbuild/android-x64": "0.25.12", "@esbuild/darwin-arm64": "0.25.12", "@esbuild/darwin-x64": "0.25.12", "@esbuild/freebsd-arm64": "0.25.12", "@esbuild/freebsd-x64": "0.25.12", "@esbuild/linux-arm": "0.25.12", "@esbuild/linux-arm64": "0.25.12", "@esbuild/linux-ia32": "0.25.12", "@esbuild/linux-loong64": "0.25.12", "@esbuild/linux-mips64el": "0.25.12", "@esbuild/linux-ppc64": "0.25.12", "@esbuild/linux-riscv64": "0.25.12", "@esbuild/linux-s390x": "0.25.12", "@esbuild/linux-x64": "0.25.12", "@esbuild/netbsd-arm64": "0.25.12", "@esbuild/netbsd-x64": "0.25.12", "@esbuild/openbsd-arm64": "0.25.12", "@esbuild/openbsd-x64": "0.25.12", "@esbuild/openharmony-arm64": "0.25.12", "@esbuild/sunos-x64": "0.25.12", "@esbuild/win32-arm64": "0.25.12", "@esbuild/win32-ia32": "0.25.12", "@esbuild/win32-x64": "0.25.12" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg=="],
+
     "@lobu/core/@sentry/node": ["@sentry/node@10.50.0", "", { "dependencies": { "@fastify/otel": "0.18.0", "@opentelemetry/api": "^1.9.1", "@opentelemetry/core": "^2.6.1", "@opentelemetry/instrumentation": "^0.214.0", "@opentelemetry/instrumentation-amqplib": "0.61.0", "@opentelemetry/instrumentation-connect": "0.57.0", "@opentelemetry/instrumentation-dataloader": "0.31.0", "@opentelemetry/instrumentation-fs": "0.33.0", "@opentelemetry/instrumentation-generic-pool": "0.57.0", "@opentelemetry/instrumentation-graphql": "0.62.0", "@opentelemetry/instrumentation-hapi": "0.60.0", "@opentelemetry/instrumentation-http": "0.214.0", "@opentelemetry/instrumentation-ioredis": "0.62.0", "@opentelemetry/instrumentation-kafkajs": "0.23.0", "@opentelemetry/instrumentation-knex": "0.58.0", "@opentelemetry/instrumentation-koa": "0.62.0", "@opentelemetry/instrumentation-lru-memoizer": "0.58.0", "@opentelemetry/instrumentation-mongodb": "0.67.0", "@opentelemetry/instrumentation-mongoose": "0.60.0", "@opentelemetry/instrumentation-mysql": "0.60.0", "@opentelemetry/instrumentation-mysql2": "0.60.0", "@opentelemetry/instrumentation-pg": "0.66.0", "@opentelemetry/instrumentation-redis": "0.62.0", "@opentelemetry/instrumentation-tedious": "0.33.0", "@opentelemetry/sdk-trace-base": "^2.6.1", "@opentelemetry/semantic-conventions": "^1.40.0", "@prisma/instrumentation": "7.6.0", "@sentry/core": "10.50.0", "@sentry/node-core": "10.50.0", "@sentry/opentelemetry": "10.50.0", "import-in-the-middle": "^3.0.0" } }, "sha512-TvwzFQu8MGKzMQ2/tqxcNzFA8UG2kKTB+GDmA4uOzx3+GT849YZRRSJzEXCmYhk1teVd2fbmgqyYY2nyLF5a+Q=="],
 
     "@lobu/web/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
@@ -4438,6 +4441,58 @@
     "@isaacs/cliui/string-width/emoji-regex": ["emoji-regex@9.2.2", "", {}, "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="],
 
     "@isaacs/cliui/wrap-ansi/ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
+
+    "@lobu/connector-worker/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.25.12", "", { "os": "aix", "cpu": "ppc64" }, "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA=="],
+
+    "@lobu/connector-worker/esbuild/@esbuild/android-arm": ["@esbuild/android-arm@0.25.12", "", { "os": "android", "cpu": "arm" }, "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg=="],
+
+    "@lobu/connector-worker/esbuild/@esbuild/android-arm64": ["@esbuild/android-arm64@0.25.12", "", { "os": "android", "cpu": "arm64" }, "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg=="],
+
+    "@lobu/connector-worker/esbuild/@esbuild/android-x64": ["@esbuild/android-x64@0.25.12", "", { "os": "android", "cpu": "x64" }, "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg=="],
+
+    "@lobu/connector-worker/esbuild/@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.25.12", "", { "os": "darwin", "cpu": "arm64" }, "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg=="],
+
+    "@lobu/connector-worker/esbuild/@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.25.12", "", { "os": "darwin", "cpu": "x64" }, "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA=="],
+
+    "@lobu/connector-worker/esbuild/@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.25.12", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg=="],
+
+    "@lobu/connector-worker/esbuild/@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.25.12", "", { "os": "freebsd", "cpu": "x64" }, "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ=="],
+
+    "@lobu/connector-worker/esbuild/@esbuild/linux-arm": ["@esbuild/linux-arm@0.25.12", "", { "os": "linux", "cpu": "arm" }, "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw=="],
+
+    "@lobu/connector-worker/esbuild/@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.25.12", "", { "os": "linux", "cpu": "arm64" }, "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ=="],
+
+    "@lobu/connector-worker/esbuild/@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.25.12", "", { "os": "linux", "cpu": "ia32" }, "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA=="],
+
+    "@lobu/connector-worker/esbuild/@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.25.12", "", { "os": "linux", "cpu": "none" }, "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng=="],
+
+    "@lobu/connector-worker/esbuild/@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.25.12", "", { "os": "linux", "cpu": "none" }, "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw=="],
+
+    "@lobu/connector-worker/esbuild/@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.25.12", "", { "os": "linux", "cpu": "ppc64" }, "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA=="],
+
+    "@lobu/connector-worker/esbuild/@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.25.12", "", { "os": "linux", "cpu": "none" }, "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w=="],
+
+    "@lobu/connector-worker/esbuild/@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.25.12", "", { "os": "linux", "cpu": "s390x" }, "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg=="],
+
+    "@lobu/connector-worker/esbuild/@esbuild/linux-x64": ["@esbuild/linux-x64@0.25.12", "", { "os": "linux", "cpu": "x64" }, "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw=="],
+
+    "@lobu/connector-worker/esbuild/@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.25.12", "", { "os": "none", "cpu": "arm64" }, "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg=="],
+
+    "@lobu/connector-worker/esbuild/@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.25.12", "", { "os": "none", "cpu": "x64" }, "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ=="],
+
+    "@lobu/connector-worker/esbuild/@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.25.12", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A=="],
+
+    "@lobu/connector-worker/esbuild/@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.25.12", "", { "os": "openbsd", "cpu": "x64" }, "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw=="],
+
+    "@lobu/connector-worker/esbuild/@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.25.12", "", { "os": "none", "cpu": "arm64" }, "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg=="],
+
+    "@lobu/connector-worker/esbuild/@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.25.12", "", { "os": "sunos", "cpu": "x64" }, "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w=="],
+
+    "@lobu/connector-worker/esbuild/@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.25.12", "", { "os": "win32", "cpu": "arm64" }, "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg=="],
+
+    "@lobu/connector-worker/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.25.12", "", { "os": "win32", "cpu": "ia32" }, "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ=="],
+
+    "@lobu/connector-worker/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.25.12", "", { "os": "win32", "cpu": "x64" }, "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA=="],
 
     "@lobu/core/@sentry/node/@opentelemetry/core": ["@opentelemetry/core@2.7.0", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-DT12SXVwV2eoJrGf4nnsvZojxxeQo+LlNAsoYGRRObPWTeN6APiqZ2+nqDCQDvQX40eLi1AePONS0onoASp3yQ=="],
 

--- a/packages/connector-worker/package.json
+++ b/packages/connector-worker/package.json
@@ -42,6 +42,7 @@
     "@lobu/embeddings": "workspace:*",
     "@lobu/worker": "workspace:*",
     "@xenova/transformers": "^2.17.2",
+    "esbuild": "^0.25.0",
     "jimp": "^1.6.0",
     "playwright": "npm:patchright@^1.57.0",
     "playwright-vanilla": "npm:playwright@^1.60.0",

--- a/packages/connector-worker/src/compile-connector.ts
+++ b/packages/connector-worker/src/compile-connector.ts
@@ -1,0 +1,116 @@
+/**
+ * Worker-side connector compiler.
+ *
+ * Until lobu#771's perf brainstorm, the gateway compiled connector bundles
+ * via esbuild and shipped the ~13 MB output inline in every `/api/workers/poll`
+ * response. The gateway pod held all ~29 connector bundles in its
+ * compile cache (~384 MB, dominant heap occupant under the 1 GiB limit;
+ * see lobu#771 for the heap-snapshot trail).
+ *
+ * For fleet workers (and embedded mode where worker + gateway share a host),
+ * the bundled connector .ts source is on disk in both pods — the gateway
+ * doesn't need to compile or ship it. The gateway now sends
+ * `connector_source_path` (the absolute path that `findBundledConnectorFile`
+ * resolved) and this module compiles locally in the worker process.
+ *
+ * Device workers (Lobu Mac Bridge, etc.) keep getting `compiled_code` inline
+ * — they don't have the connectors directory on disk.
+ *
+ * This file mirrors the server's `utils/connector-catalog.ts` compile pipeline.
+ * Kept here (rather than shared) so the connector-worker package doesn't take
+ * a runtime dep on the server package's bundle layout.
+ */
+
+import { readFile } from 'node:fs/promises';
+import { mkdtemp, rm, stat } from 'node:fs/promises';
+import { createRequire } from 'node:module';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { build, type Plugin } from 'esbuild';
+import { EXTERNAL_RUNTIME_DEPS } from './runtime-deps.js';
+
+const require_ = createRequire(import.meta.url);
+const SDK_ENTRY = require_.resolve('@lobu/connector-sdk');
+
+// Connectors declare runtime npm deps via `import x from 'npm:foo@1.2.3'`.
+// Strip the prefix so esbuild resolves the bare name against node_modules;
+// when the package isn't installed here, mark it external so the bundle
+// still emits. The worker image is expected to provide it.
+const npmSpecifierPlugin: Plugin = {
+  name: 'npm-specifier',
+  setup(b) {
+    b.onResolve({ filter: /^npm:/ }, async (args) => {
+      const bare = args.path
+        .slice(4)
+        .replace(/^(@[^/]+\/[^/@]+)@[^/]*/, '$1')
+        .replace(/^([^/@]+)@[^/]*/, '$1');
+      const resolved = await b.resolve(bare, {
+        resolveDir: args.resolveDir,
+        kind: args.kind,
+      });
+      if (resolved.errors.length > 0) {
+        return { path: bare, external: true, errors: [], warnings: [] };
+      }
+      return resolved;
+    });
+  },
+};
+
+// LRU-capped cache. Worker daemon is long-lived; one entry per recently-used
+// connector. See the matching cache in
+// `packages/server/src/utils/connector-catalog.ts` for the cap rationale.
+const COMPILED_FILE_CACHE_MAX = 8;
+const compiledFileCache = new Map<string, { mtimeMs: number; code: string }>();
+
+function touchCacheEntry(filePath: string, entry: { mtimeMs: number; code: string }): void {
+  compiledFileCache.delete(filePath);
+  compiledFileCache.set(filePath, entry);
+  while (compiledFileCache.size > COMPILED_FILE_CACHE_MAX) {
+    const oldest = compiledFileCache.keys().next().value;
+    if (oldest === undefined) break;
+    compiledFileCache.delete(oldest);
+  }
+}
+
+export async function compileConnectorFromFile(filePath: string): Promise<string> {
+  let mtimeMs: number | null = null;
+  try {
+    mtimeMs = (await stat(filePath)).mtimeMs;
+    const cached = compiledFileCache.get(filePath);
+    if (cached && cached.mtimeMs === mtimeMs) {
+      touchCacheEntry(filePath, cached);
+      return cached.code;
+    }
+  } catch {
+    // stat failed — let the build surface the real error.
+  }
+
+  const tmpDir = await mkdtemp(join(tmpdir(), 'lobu-connector-worker-'));
+  const outPath = join(tmpDir, 'out.mjs');
+
+  try {
+    await build({
+      entryPoints: [filePath],
+      outfile: outPath,
+      bundle: true,
+      format: 'esm',
+      platform: 'node',
+      target: 'node20',
+      alias: { lobu: SDK_ENTRY, '@lobu/connector-sdk': SDK_ENTRY },
+      banner: {
+        js: `import { createRequire as __createRequire } from 'module'; const require = __createRequire(import.meta.url);`,
+      },
+      plugins: [npmSpecifierPlugin],
+      external: [...EXTERNAL_RUNTIME_DEPS],
+      write: true,
+      minify: false,
+      sourcemap: false,
+    });
+
+    const code = await readFile(outPath, 'utf-8');
+    if (mtimeMs !== null) touchCacheEntry(filePath, { mtimeMs, code });
+    return code;
+  } finally {
+    await rm(tmpDir, { recursive: true, force: true });
+  }
+}

--- a/packages/connector-worker/src/compile-connector.ts
+++ b/packages/connector-worker/src/compile-connector.ts
@@ -21,13 +21,50 @@
  * a runtime dep on the server package's bundle layout.
  */
 
-import { readFile } from 'node:fs/promises';
-import { mkdtemp, rm, stat } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { mkdtemp, readFile, rm, stat } from 'node:fs/promises';
 import { createRequire } from 'node:module';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { build, type Plugin } from 'esbuild';
 import { EXTERNAL_RUNTIME_DEPS } from './runtime-deps.js';
+
+// Worker-side resolver for the bundled connectors directory. The gateway's
+// `findBundledConnectorFile` resolves to paths that exist in the gateway
+// image (e.g. /app/packages/server/dist/connectors); those paths do not
+// exist in the worker image, which has the sources at
+// /app/packages/connectors. Each side resolves locally instead of trusting
+// gateway-supplied absolute paths.
+const HERE = fileURLToPath(new URL('.', import.meta.url));
+const WORKER_CONNECTOR_DIR_CANDIDATES = [
+  resolve(HERE, '../../../connectors/src'),
+  resolve(HERE, '../../../connectors/dist'),
+  resolve(HERE, '../../connectors/src'),
+  resolve(HERE, '../../connectors/dist'),
+  resolve(HERE, '../connectors/src'),
+  resolve(process.cwd(), 'packages/connectors/src'),
+  resolve(process.cwd(), 'connectors'),
+];
+
+// Strict regex for connector_key: lowercase letters/digits, optional dots
+// for namespacing, underscores for word separators. Defense-in-depth even
+// though keys come from a trusted DB column — we're about to use the value
+// to construct a filesystem path.
+const CONNECTOR_KEY_RE = /^[a-z][a-z0-9]*(?:[._][a-z0-9]+)*$/;
+
+export function findBundledConnectorFile(key: string): string | null {
+  if (!CONNECTOR_KEY_RE.test(key)) return null;
+  const fileName = `${key.replace(/\./g, '_')}.ts`;
+  for (const candidate of WORKER_CONNECTOR_DIR_CANDIDATES) {
+    const filePath = resolve(candidate, fileName);
+    // Belt-and-braces: assert the resolved path stays under the candidate
+    // dir even though CONNECTOR_KEY_RE already forbids the dangerous chars.
+    if (!filePath.startsWith(`${candidate}/`)) continue;
+    if (existsSync(filePath)) return filePath;
+  }
+  return null;
+}
 
 const require_ = createRequire(import.meta.url);
 const SDK_ENTRY = require_.resolve('@lobu/connector-sdk');

--- a/packages/connector-worker/src/daemon/client.ts
+++ b/packages/connector-worker/src/daemon/client.ts
@@ -87,19 +87,15 @@ export interface PollResponse {
   feed_id?: number;
   /**
    * Compiled connector code, shipped inline. Used for device workers and
-   * DB-only user-uploaded connectors. Fleet workers should receive
-   * `connector_source_path` instead and compile locally to keep the
-   * gateway's poll responses small.
+   * DB-only user-uploaded connectors that don't have the connector source
+   * on disk. Fleet workers receive a bare `connector_key` only (no
+   * inline code) and resolve + compile the source from their own
+   * filesystem to keep poll responses small — see worker-api.ts handler
+   * comment + lobu#772 review for why we send the key and not an absolute
+   * path (gateway and worker images have different paths to the same
+   * sources).
    */
   compiled_code?: string;
-  /**
-   * Absolute path to the connector's `.ts` source on the worker's local
-   * filesystem (gateway-resolved via `findBundledConnectorFile`). The
-   * worker compiles from this path on demand and caches the result. Sent
-   * for fleet workers when the connector ships in the image; mutually
-   * exclusive with `compiled_code` for any given poll response.
-   */
-  connector_source_path?: string;
   /** Connection session state (browser cookies, etc.) */
   session_state?: Record<string, unknown>;
   /** Connector version */

--- a/packages/connector-worker/src/daemon/client.ts
+++ b/packages/connector-worker/src/daemon/client.ts
@@ -85,8 +85,21 @@ export interface PollResponse {
   connection_id?: number;
   /** Feed ID (for sync runs) */
   feed_id?: number;
-  /** Compiled connector code */
+  /**
+   * Compiled connector code, shipped inline. Used for device workers and
+   * DB-only user-uploaded connectors. Fleet workers should receive
+   * `connector_source_path` instead and compile locally to keep the
+   * gateway's poll responses small.
+   */
   compiled_code?: string;
+  /**
+   * Absolute path to the connector's `.ts` source on the worker's local
+   * filesystem (gateway-resolved via `findBundledConnectorFile`). The
+   * worker compiles from this path on demand and caches the result. Sent
+   * for fleet workers when the connector ships in the image; mutually
+   * exclusive with `compiled_code` for any given poll response.
+   */
+  connector_source_path?: string;
   /** Connection session state (browser cookies, etc.) */
   session_state?: Record<string, unknown>;
   /** Connector version */

--- a/packages/connector-worker/src/daemon/executor.ts
+++ b/packages/connector-worker/src/daemon/executor.ts
@@ -6,6 +6,7 @@
  */
 
 import type { Checkpoint, Content, Env } from '@lobu/connector-sdk';
+import { compileConnectorFromFile } from '../compile-connector.js';
 import { batchGenerateEmbeddings, generateEmbedding } from '../embeddings.js';
 import {
   executeCompiledConnector,
@@ -14,6 +15,24 @@ import {
 } from '../executor/runtime.js';
 import { SubprocessExecutor } from '../executor/subprocess.js';
 import type { ContentItem, ExecutorClient, PollResponse } from './client.js';
+
+/**
+ * Get the executable compiled code for a job.
+ *
+ * The gateway now prefers shipping `connector_source_path` (a bytes-cheap
+ * filesystem path) for fleet workers instead of an inline ~13 MB
+ * `compiled_code` blob — see worker-api.ts handler comment + lobu#771
+ * postmortem. This helper compiles from the path when present, falling
+ * back to the inline blob for device workers and DB-only user-uploaded
+ * connectors that don't have an on-disk source.
+ */
+async function resolveJobCode(job: PollResponse): Promise<string | null> {
+  if (job.compiled_code) return job.compiled_code;
+  if (job.connector_source_path) {
+    return await compileConnectorFromFile(job.connector_source_path);
+  }
+  return null;
+}
 
 export interface ExecutorConfig {
   batchSize: number;
@@ -86,13 +105,13 @@ async function executeSyncRun(
     config: feedConfig,
     checkpoint,
     credentials,
-    compiled_code,
   } = job;
 
   if (!run_id || !connector_key) {
     throw new Error('Invalid run: missing run_id or connector_key');
   }
 
+  const compiled_code = await resolveJobCode(job);
   if (!compiled_code) {
     throw new Error(
       `Run ${run_id} (${connector_key}): No compiled code available. ` +
@@ -280,12 +299,13 @@ async function executeActionRun(
     timeoutMs: cfg.timeoutMs,
     maxOldSpaceSize: cfg.maxOldSpaceSize,
   });
-  const { run_id, connector_key, action_key, action_input, credentials, compiled_code } = job;
+  const { run_id, connector_key, action_key, action_input, credentials } = job;
 
   if (!run_id || !connector_key || !action_key) {
     throw new Error('Invalid action run: missing run_id, connector_key, or action_key');
   }
 
+  const compiled_code = await resolveJobCode(job);
   if (!compiled_code) {
     throw new Error(`Action run ${run_id}: No compiled code available.`);
   }
@@ -350,11 +370,12 @@ async function executeAuthRun(
     timeoutMs: 0,
     maxOldSpaceSize: cfg.maxOldSpaceSize,
   });
-  const { run_id, connector_key, compiled_code, previous_credentials } = job;
+  const { run_id, connector_key, previous_credentials } = job;
 
   if (!run_id || !connector_key) {
     throw new Error('Invalid auth run: missing run_id or connector_key');
   }
+  const compiled_code = await resolveJobCode(job);
   if (!compiled_code) {
     throw new Error(`Auth run ${run_id}: No compiled code available.`);
   }

--- a/packages/connector-worker/src/daemon/executor.ts
+++ b/packages/connector-worker/src/daemon/executor.ts
@@ -6,7 +6,7 @@
  */
 
 import type { Checkpoint, Content, Env } from '@lobu/connector-sdk';
-import { compileConnectorFromFile } from '../compile-connector.js';
+import { compileConnectorFromFile, findBundledConnectorFile } from '../compile-connector.js';
 import { batchGenerateEmbeddings, generateEmbedding } from '../embeddings.js';
 import {
   executeCompiledConnector,
@@ -17,21 +17,47 @@ import { SubprocessExecutor } from '../executor/subprocess.js';
 import type { ContentItem, ExecutorClient, PollResponse } from './client.js';
 
 /**
- * Get the executable compiled code for a job.
+ * Resolve the executable compiled code for a job.
  *
- * The gateway now prefers shipping `connector_source_path` (a bytes-cheap
- * filesystem path) for fleet workers instead of an inline ~13 MB
- * `compiled_code` blob — see worker-api.ts handler comment + lobu#771
- * postmortem. This helper compiles from the path when present, falling
- * back to the inline blob for device workers and DB-only user-uploaded
- * connectors that don't have an on-disk source.
+ * The gateway prefers omitting `compiled_code` for fleet workers and
+ * relying on this side to find + compile the source locally from
+ * `connector_key`. This saves the ~13 MB inline blob in poll responses
+ * (lobu#771 postmortem trail; lobu#772 perf fix). Device workers and
+ * DB-only user-uploaded connectors still receive `compiled_code`
+ * directly — they don't have the connector source on disk.
+ *
+ * Gateway and worker images have different paths to the bundled source,
+ * so the gateway sends only `connector_key` and each side resolves it
+ * against its own filesystem.
+ *
+ * Returns `{ code }` on success or `{ error }` on failure. Callers must
+ * surface the error to the gateway via `client.complete*` rather than
+ * throwing — the daemon-level catch only logs, leaving runs stuck
+ * `running` until stale-run reaping.
  */
-async function resolveJobCode(job: PollResponse): Promise<string | null> {
-  if (job.compiled_code) return job.compiled_code;
-  if (job.connector_source_path) {
-    return await compileConnectorFromFile(job.connector_source_path);
+type JobCodeResult = { ok: true; code: string } | { ok: false; error: string };
+
+async function resolveJobCode(job: PollResponse): Promise<JobCodeResult> {
+  if (job.compiled_code) return { ok: true, code: job.compiled_code };
+  if (!job.connector_key) {
+    return { ok: false, error: 'No compiled_code and no connector_key — gateway sent neither.' };
   }
-  return null;
+  const localPath = findBundledConnectorFile(job.connector_key);
+  if (!localPath) {
+    return {
+      ok: false,
+      error:
+        `connector_key '${job.connector_key}' did not resolve to a local source file. ` +
+        `Either the connector isn't bundled in this worker image, or the key is malformed.`,
+    };
+  }
+  try {
+    const code = await compileConnectorFromFile(localPath);
+    return { ok: true, code };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return { ok: false, error: `esbuild failed for '${job.connector_key}' (${localPath}): ${msg}` };
+  }
 }
 
 export interface ExecutorConfig {
@@ -111,13 +137,20 @@ async function executeSyncRun(
     throw new Error('Invalid run: missing run_id or connector_key');
   }
 
-  const compiled_code = await resolveJobCode(job);
-  if (!compiled_code) {
-    throw new Error(
-      `Run ${run_id} (${connector_key}): No compiled code available. ` +
-        'Ensure the connector has a compiled version.'
-    );
+  const codeResult = await resolveJobCode(job);
+  if (!codeResult.ok) {
+    const errorMessage = `Run ${run_id} (${connector_key}): ${codeResult.error}`;
+    console.error('[executor]', errorMessage);
+    await client.complete({
+      run_id,
+      worker_id: client.id,
+      status: 'failed',
+      error_message: errorMessage,
+      items_collected: 0,
+    });
+    return { itemsCollected: 0, error: errorMessage };
   }
+  const compiled_code = codeResult.code;
 
   console.error(`[executor] Starting sync run ${run_id} (${connector_key}/${feed_key})`);
 
@@ -305,10 +338,19 @@ async function executeActionRun(
     throw new Error('Invalid action run: missing run_id, connector_key, or action_key');
   }
 
-  const compiled_code = await resolveJobCode(job);
-  if (!compiled_code) {
-    throw new Error(`Action run ${run_id}: No compiled code available.`);
+  const codeResult = await resolveJobCode(job);
+  if (!codeResult.ok) {
+    const errorMessage = `Action run ${run_id} (${connector_key}): ${codeResult.error}`;
+    console.error('[executor]', errorMessage);
+    await client.completeAction({
+      run_id,
+      worker_id: client.id,
+      status: 'failed',
+      error_message: errorMessage,
+    });
+    return { itemsCollected: 0, error: errorMessage };
   }
+  const compiled_code = codeResult.code;
 
   console.error(`[executor] Starting action run ${run_id} (${connector_key}/${action_key})`);
 
@@ -375,10 +417,19 @@ async function executeAuthRun(
   if (!run_id || !connector_key) {
     throw new Error('Invalid auth run: missing run_id or connector_key');
   }
-  const compiled_code = await resolveJobCode(job);
-  if (!compiled_code) {
-    throw new Error(`Auth run ${run_id}: No compiled code available.`);
+  const codeResult = await resolveJobCode(job);
+  if (!codeResult.ok) {
+    const errorMessage = `Auth run ${run_id} (${connector_key}): ${codeResult.error}`;
+    console.error('[executor]', errorMessage);
+    await client.completeAuth({
+      run_id,
+      worker_id: client.id,
+      status: 'failed',
+      error_message: errorMessage,
+    });
+    return { itemsCollected: 0, error: errorMessage };
   }
+  const compiled_code = codeResult.code;
 
   console.error(`[executor] Starting auth run ${run_id} (${connector_key})`);
 

--- a/packages/server/src/utils/connector-catalog.ts
+++ b/packages/server/src/utils/connector-catalog.ts
@@ -202,16 +202,38 @@ export function getConfiguredConnectorCatalogUris(rawUris?: string): string[] {
 // Compiling a connector spawns esbuild; on the hot paths (feed sync, worker
 // poll) the same bundled .ts file is recompiled repeatedly. Cache the output
 // keyed by file mtime so a recompile only happens when the source actually
-// changes. Process restart (= deploy, = SDK rebuild) clears it, same as
-// `metadataCache` above.
+// changes. Process restart (= deploy, = SDK rebuild) clears it.
+//
+// LRU-capped: each entry is the full compiled bundle (~13 MB today, smaller
+// once non-essential transitive deps are externalized — see
+// EXTERNAL_RUNTIME_DEPS). Before the cap, prod was seeing the cache hold
+// every connector's bundle indefinitely (~29 × 13 MB = 384 MB resident, the
+// dominant heap occupant under the 1 GiB pod limit; see lobu#771 postmortem
+// for the heap-snapshot trail). The cap keeps the cache to the working set
+// of recently-used connectors and lets V8 reclaim the rest.
+const COMPILED_FILE_CACHE_MAX = 8;
 const compiledFileCache = new Map<string, { mtimeMs: number; code: string }>();
+
+function touchCacheEntry(filePath: string, entry: { mtimeMs: number; code: string }): void {
+  compiledFileCache.delete(filePath);
+  compiledFileCache.set(filePath, entry);
+  while (compiledFileCache.size > COMPILED_FILE_CACHE_MAX) {
+    const oldest = compiledFileCache.keys().next().value;
+    if (oldest === undefined) break;
+    compiledFileCache.delete(oldest);
+  }
+}
 
 export async function compileConnectorFromFile(filePath: string): Promise<string> {
   let mtimeMs: number | null = null;
   try {
     mtimeMs = (await stat(filePath)).mtimeMs;
     const cached = compiledFileCache.get(filePath);
-    if (cached && cached.mtimeMs === mtimeMs) return cached.code;
+    if (cached && cached.mtimeMs === mtimeMs) {
+      // Move to end of insertion order = mark as most-recently-used.
+      touchCacheEntry(filePath, cached);
+      return cached.code;
+    }
   } catch {
     // stat failed — fall through and let the build surface the real error.
   }
@@ -246,7 +268,7 @@ export async function compileConnectorFromFile(filePath: string): Promise<string
     });
 
     const code = await readFile(outPath, 'utf-8');
-    if (mtimeMs !== null) compiledFileCache.set(filePath, { mtimeMs, code });
+    if (mtimeMs !== null) touchCacheEntry(filePath, { mtimeMs, code });
     return code;
   } finally {
     await rm(tmpDir, { recursive: true, force: true });

--- a/packages/server/src/worker-api.ts
+++ b/packages/server/src/worker-api.ts
@@ -424,38 +424,43 @@ export async function pollWorkerJob(c: Context<{ Bindings: Env }>) {
   };
 
   // Connector code delivery:
-  //   - Fleet workers (server pods, embedded mode) share the host filesystem
-  //     with the gateway. When `findBundledConnectorFile` returns a path, the
-  //     worker can compile from it locally — no need for the gateway to esbuild
-  //     a ~13 MB bundle into every poll response and hold it in cache. Was the
-  //     dominant gateway-heap occupant in lobu#771 (29 cached bundles ~ 384 MB).
-  //   - Device workers (Lobu Mac Bridge, etc.) don't have the bundled
-  //     connectors directory. Same for DB-only user-uploaded connectors that
-  //     never had an on-disk source. Both fall back to shipping `compiled_code`.
+  //   - Fleet workers (server pods, embedded mode) ship the same bundled
+  //     connector .ts sources in their image. The gateway omits
+  //     `compiled_code` from the response — the worker resolves
+  //     `connector_key` against its own filesystem and compiles locally,
+  //     keeping its own LRU-capped cache. Cuts gateway poll responses
+  //     from ~13 MB to ~kB and stops the gateway-side cache from being
+  //     the dominant heap occupant (lobu#771 postmortem trail; 29 cached
+  //     bundles totalled ~384 MB).
+  //   - Device workers (Lobu Mac Bridge) and DB-only user-uploaded
+  //     connectors don't have the source on disk; they still get
+  //     `compiled_code` shipped inline. We check the gateway-local
+  //     `findBundledConnectorFile` (different filesystem layout from the
+  //     worker image — see worker-side resolver in
+  //     connector-worker/src/compile-connector.ts) to decide whether the
+  //     fleet path applies.
   let compiledCode: string | undefined;
-  let connectorSourcePath: string | undefined;
-  if (row.connector_key) {
-    const localPath = !isUserScopedWorker ? findBundledConnectorFile(row.connector_key) : null;
-    if (localPath) {
-      connectorSourcePath = localPath;
-    } else {
-      try {
-        compiledCode = await resolveConnectorCode(row.connector_key, row.compiled_code);
-      } catch (err) {
-        const message = errorMessage(err);
-        await sql`
-          UPDATE runs
-          SET status = 'failed',
-              completed_at = current_timestamp,
-              error_message = ${message}
-          WHERE id = ${row.run_id}
-        `;
-        logger.error(
-          { run_id: row.run_id, connector_key: row.connector_key, err },
-          'Failed to resolve connector code for claimed worker run'
-        );
-        return c.json({ next_poll_seconds: 1, skipped_run_id: row.run_id, error: message });
-      }
+  const gatewayHasLocalSource = row.connector_key
+    ? findBundledConnectorFile(row.connector_key) !== null
+    : false;
+  const workerWillResolveLocally = !isUserScopedWorker && gatewayHasLocalSource;
+  if (row.connector_key && !workerWillResolveLocally) {
+    try {
+      compiledCode = await resolveConnectorCode(row.connector_key, row.compiled_code);
+    } catch (err) {
+      const message = errorMessage(err);
+      await sql`
+        UPDATE runs
+        SET status = 'failed',
+            completed_at = current_timestamp,
+            error_message = ${message}
+        WHERE id = ${row.run_id}
+      `;
+      logger.error(
+        { run_id: row.run_id, connector_key: row.connector_key, err },
+        'Failed to resolve connector code for claimed worker run'
+      );
+      return c.json({ next_poll_seconds: 1, skipped_run_id: row.run_id, error: message });
     }
   }
 
@@ -504,7 +509,6 @@ export async function pollWorkerJob(c: Context<{ Bindings: Env }>) {
     connection_credentials:
       Object.keys(connectionCredentials).length > 0 ? connectionCredentials : undefined,
     compiled_code: compiledCode,
-    connector_source_path: connectorSourcePath,
     session_state: sessionState ?? undefined,
     action_key: row.action_key ?? undefined,
     action_input: (row as any).approved_input ?? row.action_input ?? undefined,

--- a/packages/server/src/worker-api.ts
+++ b/packages/server/src/worker-api.ts
@@ -27,6 +27,7 @@ import { captureServerError } from './sentry';
 import { autoLinkEvent } from './utils/auto-linker';
 import { nextRunAt as nextRunAtFromCron } from './utils/cron';
 import { reconcileDeviceCapabilities } from './worker-api/device-reconcile';
+import { findBundledConnectorFile } from './utils/connector-catalog';
 import { resolveConnectorCode } from './utils/ensure-connector-installed';
 import { applyEntityLinks } from './utils/entity-link-upsert';
 import { errorMessage } from './utils/errors';
@@ -422,24 +423,39 @@ export async function pollWorkerJob(c: Context<{ Bindings: Env }>) {
     auth_profile_auth_data: Record<string, unknown> | null;
   };
 
+  // Connector code delivery:
+  //   - Fleet workers (server pods, embedded mode) share the host filesystem
+  //     with the gateway. When `findBundledConnectorFile` returns a path, the
+  //     worker can compile from it locally — no need for the gateway to esbuild
+  //     a ~13 MB bundle into every poll response and hold it in cache. Was the
+  //     dominant gateway-heap occupant in lobu#771 (29 cached bundles ~ 384 MB).
+  //   - Device workers (Lobu Mac Bridge, etc.) don't have the bundled
+  //     connectors directory. Same for DB-only user-uploaded connectors that
+  //     never had an on-disk source. Both fall back to shipping `compiled_code`.
   let compiledCode: string | undefined;
+  let connectorSourcePath: string | undefined;
   if (row.connector_key) {
-    try {
-      compiledCode = await resolveConnectorCode(row.connector_key, row.compiled_code);
-    } catch (err) {
-      const message = errorMessage(err);
-      await sql`
-        UPDATE runs
-        SET status = 'failed',
-            completed_at = current_timestamp,
-            error_message = ${message}
-        WHERE id = ${row.run_id}
-      `;
-      logger.error(
-        { run_id: row.run_id, connector_key: row.connector_key, err },
-        'Failed to resolve connector code for claimed worker run'
-      );
-      return c.json({ next_poll_seconds: 1, skipped_run_id: row.run_id, error: message });
+    const localPath = !isUserScopedWorker ? findBundledConnectorFile(row.connector_key) : null;
+    if (localPath) {
+      connectorSourcePath = localPath;
+    } else {
+      try {
+        compiledCode = await resolveConnectorCode(row.connector_key, row.compiled_code);
+      } catch (err) {
+        const message = errorMessage(err);
+        await sql`
+          UPDATE runs
+          SET status = 'failed',
+              completed_at = current_timestamp,
+              error_message = ${message}
+          WHERE id = ${row.run_id}
+        `;
+        logger.error(
+          { run_id: row.run_id, connector_key: row.connector_key, err },
+          'Failed to resolve connector code for claimed worker run'
+        );
+        return c.json({ next_poll_seconds: 1, skipped_run_id: row.run_id, error: message });
+      }
     }
   }
 
@@ -488,6 +504,7 @@ export async function pollWorkerJob(c: Context<{ Bindings: Env }>) {
     connection_credentials:
       Object.keys(connectionCredentials).length > 0 ? connectionCredentials : undefined,
     compiled_code: compiledCode,
+    connector_source_path: connectorSourcePath,
     session_state: sessionState ?? undefined,
     action_key: row.action_key ?? undefined,
     action_input: (row as any).approved_input ?? row.action_input ?? undefined,


### PR DESCRIPTION
## Why

[lobu#771 postmortem](https://github.com/lobu-ai/lobu/pull/771) heap-snapshot trail found the gateway pod's `compiledFileCache` holding 29 connector bundles totaling ~384 MB — the dominant heap occupant under the 1 GiB pod limit, the reason the pod kept OOM-killing.

Each bundle is ~13 MB because esbuild inlines OpenTelemetry, pino, postgres-js, etc. inline. The cache itself wasn't leaking; it was *correctly* caching every connector that ever ran on the gateway. But 384 MB resident + V8 overhead + working set is too much for the limit.

The architectural fix: don't compile or cache on the gateway at all when the worker can do it locally.

## What

* **Gateway sends `connector_source_path` for fleet workers.** When the connector ships in the image (`findBundledConnectorFile` resolves), the poll response sends the absolute path (~50 bytes) instead of the inline ~13 MB `compiled_code` blob. The gateway never reads or compiles the source on this path, so the cache stays empty for fleet traffic.
* **Device workers + DB-only user-uploaded connectors keep the existing path** — they don't have the connectors directory on disk, so `compiled_code` ships inline as before. The two response fields are mutually exclusive per poll.
* **Worker daemon compiles locally.** New `packages/connector-worker/src/compile-connector.ts` mirrors the server's esbuild pipeline (npm:* specifier plugin, `@lobu/connector-sdk` alias, `EXTERNAL_RUNTIME_DEPS`). Worker package gets `esbuild` as a runtime dep.
* **LRU cap on both caches (8 entries).** Each worker process holds its own LRU-capped cache replacing the previously-unbounded gateway cache. The gateway's residual cache (device-worker / DB-only path) gets the same cap as defense-in-depth.

## Numbers (estimated, validated against the heap-snapshot data)

| | Before | After |
|---|---|---|
| Gateway pod connector-cache memory | ~384 MB unbounded | **~0 MB** (fleet path) / ≤104 MB capped (device-worker path) |
| Per-poll response size for fleet workers | ~13 MB inline | **~50 bytes (path string)** |
| Worker pod connector-cache memory | n/a | ≤104 MB (8 × ~13 MB LRU) |
| Per-worker spawn overhead | none | first poll per connector → compile (~1–2s once) then cached |

## Deferred

Externalizing more transitive deps from the connector bundle (pino, opentelemetry, postgres). The team's stated rule in `runtime-deps.ts` is to bundle pure-JS deps for safety (avoids "Cannot find package X" failures). Marginal win on the worker pod (~104 MB → ~16 MB) isn't worth violating it without first measuring bundle composition with `esbuild --metafile`. Tracked as a follow-up.

## Test plan

- [x] `make build-packages` clean
- [x] `make typecheck` clean
- [x] Code review: PollResponse type updated, executor consumes either field, gateway only sends one of the two
- [ ] Manual: deploy, observe gateway cache stays at 0 entries via heap snapshot, worker cache populates as connectors are polled

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * On-demand connector compilation in workers for dynamic bundling.
  * Fleet workers can compile from local bundled connector source to reduce gateway payloads.
  * LRU caching for compiled connectors to limit memory use and improve performance.

* **Improvements**
  * More robust handling and clearer reporting when connector code is missing or compilation fails.
  * Poll responses optimized to avoid sending compiled code to eligible fleet workers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lobu-ai/lobu/pull/772?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->