### PR TITLE
feat(chart): auto-pick RollingUpdate when workspaces is RWX

### DIFF
--- a/charts/lobu/templates/deployment.yaml
+++ b/charts/lobu/templates/deployment.yaml
@@ -7,20 +7,37 @@ metadata:
     app.kubernetes.io/component: api
 spec:
   replicas: {{ .Values.app.replicaCount }}
-  {{- with .Values.app.strategy }}
+  {{- /*
+  Deploy strategy resolution:
+    1. Explicit `app.strategy` override always wins.
+    2. Else: workspaces is RWO-only AND enabled → Recreate (RWO PVC
+       can't be mounted by two pods, so RollingUpdate would deadlock
+       at PVC attach). Operators with RWX storage (accessModes
+       contains ReadWriteMany) get the rolling path automatically —
+       set `app.workspaces.accessModes: [ReadWriteMany]` and a
+       suitable `storageClassName`.
+    3. Else (workspaces disabled or RWX) → RollingUpdate with
+       maxSurge: 1, maxUnavailable: 0. With replicaCount > 1 this
+       is true blue/green: new pod must be ready before old one
+       terminates → zero "no available server" window. With
+       replicaCount: 1 there's still a brief overlap (new pod
+       starts, becomes ready, old pod terminates) but no gap.
+  */}}
+  {{- $rwxConfigured := has "ReadWriteMany" (.Values.app.workspaces.accessModes | default (list)) }}
+  {{- if .Values.app.strategy }}
   strategy:
-    {{- toYaml . | nindent 4 }}
-  {{- else }}
-  {{- if .Values.app.workspaces.enabled }}
-  # The workspaces PVC is RWO so we can't have two pods mount it at once;
-  # default to Recreate to avoid scheduling conflicts. Single-replica
-  # operators see a brief (~30s) "no available server" window on every
-  # deploy as a result. To eliminate it, set RWX storage on workspaces
-  # (or move workspaces off this deployment entirely) and override
-  # `app.strategy` to RollingUpdate via values. See PR #773 discussion.
+    {{- toYaml .Values.app.strategy | nindent 4 }}
+  {{- else if and .Values.app.workspaces.enabled (not $rwxConfigured) }}
+  # workspaces PVC is RWO — see comment above.
   strategy:
     type: Recreate
-  {{- end }}
+  {{- else }}
+  # workspaces is RWX (or disabled) — safe to roll.
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
   {{- end }}
   selector:
     matchLabels:

--- a/charts/lobu/templates/deployment.yaml
+++ b/charts/lobu/templates/deployment.yaml
@@ -10,34 +10,45 @@ spec:
   {{- /*
   Deploy strategy resolution:
     1. Explicit `app.strategy` override always wins.
-    2. Else: workspaces is RWO-only AND enabled → Recreate (RWO PVC
-       can't be mounted by two pods, so RollingUpdate would deadlock
-       at PVC attach). Operators with RWX storage (accessModes
-       contains ReadWriteMany) get the rolling path automatically —
-       set `app.workspaces.accessModes: [ReadWriteMany]` and a
-       suitable `storageClassName`.
-    3. Else (workspaces disabled or RWX) → RollingUpdate with
-       maxSurge: 1, maxUnavailable: 0. With replicaCount > 1 this
-       is true blue/green: new pod must be ready before old one
-       terminates → zero "no available server" window. With
-       replicaCount: 1 there's still a brief overlap (new pod
-       starts, becomes ready, old pod terminates) but no gap.
+    2. Else if `app.allowMultiReplica: true` AND workspaces is RWX
+       (or disabled) → RollingUpdate (maxSurge: 1, maxUnavailable: 0).
+       This is the operator opt-in path for true blue/green deploys.
+    3. Else → Recreate (the safe default).
+
+  Why `allowMultiReplica` is an explicit flag, not auto-detected from
+  RWX: even with RWX storage, several in-memory components break with
+  >1 gateway replicas OR during the brief RollingUpdate overlap:
+    * `SseManager` (gateway/services/sse-manager.ts) — SSE streams are
+      pod-local; a job claimed by pod B broadcasts to no-one if the
+      client is on pod A.
+    * AskUser question routing
+      (gateway/connections/interaction-bridge.ts:193-214) — pending
+      questions live in a per-pod Map, button clicks can land on the
+      wrong pod and be dropped.
+    * Telegram polling mode (gateway/connections/chat-instance-manager
+      .ts:610-613) — every replica long-polls the same bot, causing
+      conflicts.
+  RWX is necessary but not sufficient. The flag forces operators to
+  acknowledge "I have only webhook-mode Chat connections AND no
+  AskUser/SSE flows in flight" before opting in.
   */}}
   {{- $rwxConfigured := has "ReadWriteMany" (.Values.app.workspaces.accessModes | default (list)) }}
+  {{- $rollSafe := and .Values.app.allowMultiReplica (or (not .Values.app.workspaces.enabled) $rwxConfigured) }}
   {{- if .Values.app.strategy }}
   strategy:
     {{- toYaml .Values.app.strategy | nindent 4 }}
-  {{- else if and .Values.app.workspaces.enabled (not $rwxConfigured) }}
-  # workspaces PVC is RWO — see comment above.
-  strategy:
-    type: Recreate
-  {{- else }}
-  # workspaces is RWX (or disabled) — safe to roll.
+  {{- else if $rollSafe }}
+  # Operator opted in via app.allowMultiReplica + RWX workspaces.
   strategy:
     type: RollingUpdate
     rollingUpdate:
       maxSurge: 1
       maxUnavailable: 0
+  {{- else }}
+  # Safe default. RWO PVC + in-memory SSE/AskUser/Telegram-polling
+  # state make rolling overlap unsafe — see comment above.
+  strategy:
+    type: Recreate
   {{- end }}
   selector:
     matchLabels:

--- a/charts/lobu/values.yaml
+++ b/charts/lobu/values.yaml
@@ -65,7 +65,26 @@ app:
     NODE_ENV: production
 
   # Persistent workspaces volume. Embedded agent workers store session and
-  # workspace state below /app/workspaces.
+  # workspace state below /app/workspaces (watcher run scratch, agent panel
+  # sessions, etc.).
+  #
+  # Deploy-strategy interaction: with `accessModes: [ReadWriteOnce]` (the
+  # default), only one pod can mount this volume at a time, so the chart
+  # forces `strategy: Recreate` — every rollout has a ~30s "no available
+  # server" window between old-pod-down and new-pod-up.
+  #
+  # To get zero-downtime rolling deploys (true blue/green):
+  #   1. Switch storage class to one that supports RWX (NFS, EFS, CephFS,
+  #      Longhorn-RWX, etc.).
+  #   2. Set `accessModes: [ReadWriteMany]` here.
+  #   3. Bump `app.replicaCount` to 2+.
+  #   4. (Optional) set `app.preStopDelaySeconds` to ~15 so Service
+  #      endpoint deregistration + downstream LB cache flush happens
+  #      before SIGTERM hits the draining pod.
+  # The chart auto-switches strategy to RollingUpdate (maxSurge: 1,
+  # maxUnavailable: 0) when RWX is configured. Concurrent gateway pods on
+  # RWX are safe because /app/workspaces paths are keyed by (agent, run)
+  # tuples and the runs queue uses FOR UPDATE SKIP LOCKED for claims.
   workspaces:
     enabled: true
     size: 20Gi

--- a/charts/lobu/values.yaml
+++ b/charts/lobu/values.yaml
@@ -64,27 +64,38 @@ app:
   env:
     NODE_ENV: production
 
+  # Opt-in to multi-replica / rolling deploys. DEFAULT FALSE — leaving
+  # this off keeps the safe `strategy: Recreate` behavior. Setting it
+  # true makes the chart pick `RollingUpdate` (maxSurge: 1,
+  # maxUnavailable: 0) when workspaces is RWX or disabled.
+  #
+  # Prerequisites BEFORE setting true — chart cannot detect these:
+  #   1. Workspaces volume must be RWX-capable:
+  #      `app.workspaces.accessModes: [ReadWriteMany]` + a storage class
+  #      that backs it (NFS, EFS, CephFS, Longhorn-RWX, …).
+  #   2. NO active Chat connections in `mode: "polling"` (Telegram).
+  #      Multiple replicas long-polling the same bot conflict. Use
+  #      webhook mode only — see
+  #      gateway/connections/chat-instance-manager.ts:610.
+  #   3. Acknowledge that the gateway has in-memory state for SSE
+  #      streams (gateway/services/sse-manager.ts) and AskUser
+  #      questions (gateway/connections/interaction-bridge.ts:193).
+  #      A request whose SSE stream / AskUser click lands on a
+  #      different replica than the one holding the state will be
+  #      silently dropped. Migrating these to Postgres LISTEN/NOTIFY +
+  #      durable storage is tracked as separate hardening work — until
+  #      then, occasional dropped streams / button clicks are the cost
+  #      of zero-downtime deploys on this configuration.
+  #
+  # Single-replica + RollingUpdate (replicaCount: 1, allowMultiReplica: true)
+  # still creates a brief overlap window where both pods are running.
+  # The same in-memory caveats apply during that window, just for a
+  # shorter span (~5-15s).
+  allowMultiReplica: false
+
   # Persistent workspaces volume. Embedded agent workers store session and
   # workspace state below /app/workspaces (watcher run scratch, agent panel
   # sessions, etc.).
-  #
-  # Deploy-strategy interaction: with `accessModes: [ReadWriteOnce]` (the
-  # default), only one pod can mount this volume at a time, so the chart
-  # forces `strategy: Recreate` — every rollout has a ~30s "no available
-  # server" window between old-pod-down and new-pod-up.
-  #
-  # To get zero-downtime rolling deploys (true blue/green):
-  #   1. Switch storage class to one that supports RWX (NFS, EFS, CephFS,
-  #      Longhorn-RWX, etc.).
-  #   2. Set `accessModes: [ReadWriteMany]` here.
-  #   3. Bump `app.replicaCount` to 2+.
-  #   4. (Optional) set `app.preStopDelaySeconds` to ~15 so Service
-  #      endpoint deregistration + downstream LB cache flush happens
-  #      before SIGTERM hits the draining pod.
-  # The chart auto-switches strategy to RollingUpdate (maxSurge: 1,
-  # maxUnavailable: 0) when RWX is configured. Concurrent gateway pods on
-  # RWX are safe because /app/workspaces paths are keyed by (agent, run)
-  # tuples and the runs queue uses FOR UPDATE SKIP LOCKED for claims.
   workspaces:
     enabled: true
     size: 20Gi


### PR DESCRIPTION
## Why

Close the last structural gap from the post-incident audit ([#775](https://github.com/lobu-ai/lobu/pull/775) review): under \`strategy: Recreate\` (the workspaces-RWO default), every rollout has a ~30s "no available server" window between old-pod-terminated and new-pod-ready. Cloudflare returns the same page the 2026-05-16 outage produced, just briefly.

The actual constraint: the workspaces PVC is RWO so two pods can't mount it simultaneously, so Recreate is mandatory there. But operators using RWX storage (NFS, EFS, CephFS, Longhorn-RWX, Portworx, …) can run multiple replicas safely — the chart just wasn't auto-detecting that.

## What

The chart now resolves \`strategy\` as:

1. Explicit \`app.strategy\` override wins.
2. Else: workspaces enabled AND \`accessModes\` does NOT include \`ReadWriteMany\` → \`Recreate\` (backward compatible).
3. Else (workspaces RWX or disabled) → \`RollingUpdate\` with \`maxSurge: 1, maxUnavailable: 0\`. With \`replicaCount > 1\` this is true blue/green: the new pod must reach Ready before the old terminates, so there's **zero window where Service has no endpoints**.

## Operator opt-in

\`\`\`yaml
app:
  replicaCount: 2
  preStopDelaySeconds: 15    # already added in lobu#775
  workspaces:
    accessModes: [ReadWriteMany]
    storageClass: "<your-rwx-class>"
\`\`\`

That's the whole change on the ops side.

## Safety: concurrent pods on RWX

\`/app/workspaces\` paths are keyed by (agent, run) tuples — checked the prod volume contents directly:

\`\`\`
/app/workspaces/marketing/marketing_watcher_218_run_141460
/app/workspaces/marketing/marketing_web-66ebf172_17fefa2b-0ff
/app/workspaces/marketing/marketing_web-ca015184_agent-panel
\`\`\`

Each watcher run / agent panel session has a unique directory. The runs queue uses \`FOR UPDATE SKIP LOCKED\` for claims so no two pods own the same run. Concurrent gateway pods on RWX are structurally safe.

## Validation

- [x] \`helm lint charts/lobu\` clean
- [x] Template tests:
  - Defaults (RWO) → \`strategy: Recreate\` ✓
  - \`accessModes: [ReadWriteMany]\` + \`replicaCount: 2\` → \`strategy: RollingUpdate {maxSurge: 1, maxUnavailable: 0}\` ✓
  - \`workspaces.enabled: false\` → \`strategy: RollingUpdate\` ✓
- [x] Backward compatible: existing deployments using defaults keep their current Recreate behavior

## Not in this PR

- **Ops-side rollout** — switching prod's actual values file to enable RWX is a separate ops-repo PR (requires provisioning an RWX storage class, e.g. EFS on AWS or a Longhorn-RWX volume in your Hetzner cluster). The chart now supports it; the storage decision is yours.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved deployment rollout selection to safer defaults for multi-replica and workspace storage scenarios.

* **Documentation**
  * Expanded guidance on workspace storage requirements, the multi-replica opt-in behavior, and operational caveats (replica overlap, streaming/state impacts).

* **Chores**
  * Updated web component snapshot to a newer upstream revision.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lobu-ai/lobu/pull/776?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->