### PR TITLE
feat(server,mac): no-auth mode for embedded server (LOBU_NO_AUTH=1)

### DIFF
--- a/apps/mac/Lobu/AppState.swift
+++ b/apps/mac/Lobu/AppState.swift
@@ -384,9 +384,10 @@ final class AppState: ObservableObject {
 
     // MARK: - Connect (URL-driven sign-in) --------------------------------------
 
-    /// The connection card's primary action. Auto-starts the embedded server
-    /// when the URL is the exact one our runner manages; otherwise just OAuths
-    /// against the typed URL.
+    /// The connection card's primary action. When the URL is the embedded
+    /// server we manage, spawn it (with `LOBU_NO_AUTH=1`) and stamp the menu
+    /// bar with synthesised credentials — no OAuth, no token. Anything else
+    /// runs the normal OAuth device flow.
     func connect() async {
         let raw = customServerDraft.trimmingCharacters(in: .whitespacesAndNewlines)
         let urlString = raw.isEmpty ? cloudURL : raw
@@ -403,13 +404,58 @@ final class AppState: ObservableObject {
             await startLocalLobu()
             guard localLobuStatus.isRunning else { return }
         }
-        // serverMode = .local ONLY when this URL is the runner we manage. Other
-        // loopback URLs (someone else's localhost dev server, custom ports) get
-        // .remote so we don't auto-spawn our runner on next launch.
+        // serverMode = .local ONLY when this URL is the runner we manage.
+        // Other loopback URLs (someone else's localhost dev server, custom
+        // ports) get .remote so we don't auto-spawn our runner on next launch.
         serverMode = autoStart ? .local : .remote
         setBaseURL(urlString)
+
+        if autoStart {
+            adoptLocalCredentials(baseURL: urlString)
+            startAutoPollIfSignedIn()
+            return
+        }
         await signIn()
     }
+
+    /// Synthesise credentials for the no-auth server. The token field is a
+    /// dummy — the server short-circuits auth via the `LOBU_NO_AUTH=1` env
+    /// the runner was spawned with, so no header value is actually validated.
+    /// Identity constants mirror the contract in
+    /// `packages/server/src/start-local.ts` (BOOTSTRAP_USER_*, BOOTSTRAP_ORG_*).
+    private func adoptLocalCredentials(baseURL: String) {
+        let info = OAuthUserInfo(
+            sub: AppState.bootstrapUserId,
+            email: AppState.bootstrapUserEmail,
+            name: AppState.bootstrapUserName,
+            picture: nil,
+            organization_slug: AppState.bootstrapOrgSlug,
+            organizations: [.init(slug: AppState.bootstrapOrgSlug, name: AppState.bootstrapOrgName)]
+        )
+        let creds = OAuthCredentials(
+            baseURL: baseURL,
+            clientID: "menubar-no-auth",
+            clientSecret: nil,
+            accessToken: "noauth",
+            refreshToken: nil,
+            expiresAt: nil,
+            userInfo: info
+        )
+        do { try credentialStore.save(creds) } catch {
+            NSLog("[Lobu] no-auth: failed to persist synthesised credentials: \(error.localizedDescription)")
+        }
+        credentials = creds
+        setStatus("")
+    }
+
+    // Contract with `ensureBootstrapPat` in packages/server/src/start-local.ts.
+    // Changing either side without the other makes the menu bar's display
+    // disagree with reality.
+    private static let bootstrapUserId    = "bootstrap-user"
+    private static let bootstrapUserName  = "Local Developer"
+    private static let bootstrapUserEmail = "dev@lobu.local"
+    private static let bootstrapOrgSlug   = "dev"
+    private static let bootstrapOrgName   = "Local Dev"
 
     /// True iff this URL targets the embedded server the menu bar manages.
     /// Requires an exact scheme + host + effective-port match against

--- a/apps/mac/Lobu/AppState.swift
+++ b/apps/mac/Lobu/AppState.swift
@@ -223,6 +223,17 @@ final class AppState: ObservableObject {
             // reconnects if it's still running from a previous session.
             Task { @MainActor in
                 await startLocalLobu()
+                // No-auth credentials are only safe to keep using if we own
+                // the process. If LocalLobuRunner adopted a pre-existing
+                // server, that could be a squatter — drop the saved creds
+                // and surface the connection card again. The user can sign
+                // in via OAuth at that point if they trust whatever's there.
+                if credentials != nil && !localRunner.spawnedThisSession {
+                    NSLog("[Lobu] startup: didn't spawn local server; clearing no-auth credentials")
+                    credentialStore.clear()
+                    credentials = nil
+                    return
+                }
                 startAutoPollIfSignedIn()
             }
         } else {

--- a/apps/mac/Lobu/AppState.swift
+++ b/apps/mac/Lobu/AppState.swift
@@ -410,7 +410,13 @@ final class AppState: ObservableObject {
         serverMode = autoStart ? .local : .remote
         setBaseURL(urlString)
 
-        if autoStart {
+        // Only adopt no-auth credentials when WE spawned the server this
+        // session. If LocalLobuRunner.start() adopted a pre-existing
+        // process (orphan from a previous run, developer's `lobu run`, or
+        // worst case a malicious squatter on :8787), we don't own the port
+        // — sending any header to it could leak. Fall through to OAuth in
+        // those cases.
+        if autoStart, localRunner.spawnedThisSession {
             adoptLocalCredentials(baseURL: urlString)
             startAutoPollIfSignedIn()
             return

--- a/apps/mac/Lobu/ChromeBridgeHost.swift
+++ b/apps/mac/Lobu/ChromeBridgeHost.swift
@@ -175,6 +175,9 @@ private enum NativeMessagingLoop {
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         request.setValue("application/json", forHTTPHeaderField: "Accept")
         request.setValue("Bearer \(creds.accessToken)", forHTTPHeaderField: "Authorization")
+        // No-auth CSRF middleware requires this on mutations when Origin is
+        // absent; harmless on remote/cloud where Origin would already pass.
+        request.setValue("menubar", forHTTPHeaderField: "X-Lobu-Client")
         request.httpBody = try? JSONSerialization.data(
             withJSONObject: ["platform": platform]
         )

--- a/apps/mac/Lobu/LobuClient.swift
+++ b/apps/mac/Lobu/LobuClient.swift
@@ -329,6 +329,9 @@ final class WorkerClient {
         request.httpMethod = "PATCH"
         request.setValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
         request.setValue("menubar", forHTTPHeaderField: "X-Lobu-Client")
+        // No-auth CSRF middleware rejects mutations without application/json
+        // even when the body is empty (defeats Content-Type-stripped CSRF).
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         let (_, response) = try await session.data(for: request)
         guard let http = response as? HTTPURLResponse, (200..<300).contains(http.statusCode) else {
             throw WorkerClientError.http("/notifications/\(id)/read", (response as? HTTPURLResponse)?.statusCode ?? 0, "")

--- a/apps/mac/Lobu/LobuClient.swift
+++ b/apps/mac/Lobu/LobuClient.swift
@@ -328,6 +328,7 @@ final class WorkerClient {
         var request = URLRequest(url: url)
         request.httpMethod = "PATCH"
         request.setValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
+        request.setValue("menubar", forHTTPHeaderField: "X-Lobu-Client")
         let (_, response) = try await session.data(for: request)
         guard let http = response as? HTTPURLResponse, (200..<300).contains(http.statusCode) else {
             throw WorkerClientError.http("/notifications/\(id)/read", (response as? HTTPURLResponse)?.statusCode ?? 0, "")
@@ -338,6 +339,7 @@ final class WorkerClient {
         var request = URLRequest(url: url)
         request.httpMethod = "GET"
         request.setValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
+        request.setValue("menubar", forHTTPHeaderField: "X-Lobu-Client")
         request.setValue("application/json", forHTTPHeaderField: "Accept")
         let (data, response) = try await session.data(for: request)
         guard let http = response as? HTTPURLResponse else { throw URLError(.badServerResponse) }
@@ -434,6 +436,7 @@ final class WorkerClient {
         var request = URLRequest(url: url)
         request.httpMethod = "DELETE"
         request.setValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
+        request.setValue("menubar", forHTTPHeaderField: "X-Lobu-Client")
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         request.httpBody = try encoder.encode(Body(worker_id: workerId))
         let (data, response) = try await session.data(for: request)
@@ -508,6 +511,7 @@ final class WorkerClient {
         var request = URLRequest(url: url)
         request.httpMethod = "DELETE"
         request.setValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
+        request.setValue("menubar", forHTTPHeaderField: "X-Lobu-Client")
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         request.httpBody = try encoder.encode(Body(worker_id: workerId, connector_key: connectorKey))
         let (data, response) = try await session.data(for: request)
@@ -522,6 +526,7 @@ final class WorkerClient {
         var request = URLRequest(url: url)
         request.httpMethod = "POST"
         request.setValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
+        request.setValue("menubar", forHTTPHeaderField: "X-Lobu-Client")
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         request.httpBody = try encoder.encode(body)
         let (data, response) = try await session.data(for: request)

--- a/apps/mac/Lobu/LocalLobuRunner.swift
+++ b/apps/mac/Lobu/LocalLobuRunner.swift
@@ -72,6 +72,10 @@ final class LocalLobuRunner {
         proc.currentDirectoryURL = projectDir
         var env = ProcessInfo.processInfo.environment
         env["LOBU_DATA_DIR"] = projectDir.appendingPathComponent("data").path
+        // No-auth mode: server attributes every request to the local user
+        // without an OAuth flow, a token, or a sign-in screen. Personal-use
+        // model — see docs/plans/personal-mode-auth.md for the threat model.
+        env["LOBU_NO_AUTH"] = "1"
         proc.environment = env
         proc.standardInput = FileHandle.nullDevice  // no TTY — any prompt gets EOF and fails fast
 

--- a/apps/mac/Lobu/LocalLobuRunner.swift
+++ b/apps/mac/Lobu/LocalLobuRunner.swift
@@ -41,6 +41,14 @@ final class LocalLobuRunner {
     static let baseURL = "http://localhost:\(port)"
 
     private(set) var process: Process?
+    /// True iff `start()` actually spawned the server this session (vs.
+    /// adopting one that was already listening). The no-auth credential path
+    /// uses this to refuse adoption when something else owns the port — a
+    /// malicious squatter or someone else's `lobu run` would otherwise
+    /// receive our synthesised "Authorization: Bearer noauth" header and
+    /// could log it before returning a 401. We're sending a dummy value
+    /// today, but the principle still holds.
+    private(set) var spawnedThisSession: Bool = false
     private let projectDir: URL
     private let logFile: URL
 
@@ -76,6 +84,10 @@ final class LocalLobuRunner {
         // without an OAuth flow, a token, or a sign-in screen. Personal-use
         // model — see docs/plans/personal-mode-auth.md for the threat model.
         env["LOBU_NO_AUTH"] = "1"
+        // The server hard-fails to start with LOBU_NO_AUTH=1 on a non-loopback
+        // bind. start-local.ts defaults HOST to 0.0.0.0, so we must pin it
+        // explicitly here — otherwise the runner just crashes on boot.
+        env["HOST"] = "127.0.0.1"
         proc.environment = env
         proc.standardInput = FileHandle.nullDevice  // no TTY — any prompt gets EOF and fails fast
 
@@ -89,6 +101,7 @@ final class LocalLobuRunner {
         do {
             try proc.run()
             process = proc
+            spawnedThisSession = true
             NSLog("[LocalLobuRunner] started \(lobu) run --port \(Self.port) (pid=\(proc.processIdentifier)) log=\(logFile.path)")
         } catch {
             throw RunnerError.spawn(error)
@@ -97,6 +110,7 @@ final class LocalLobuRunner {
         for _ in 0..<45 {
             if proc.isRunning == false {
                 process = nil
+                spawnedThisSession = false
                 throw RunnerError.exitedEarly(logPath: logFile.path)
             }
             if await Self.isLobuReachable(Self.baseURL) { return Self.baseURL }
@@ -104,13 +118,19 @@ final class LocalLobuRunner {
         }
         proc.terminate()
         process = nil
+        spawnedThisSession = false
         throw RunnerError.notReady(logPath: logFile.path)
     }
 
     func stop() {
-        guard let proc = process, proc.isRunning else { process = nil; return }
+        guard let proc = process, proc.isRunning else {
+            process = nil
+            spawnedThisSession = false
+            return
+        }
         proc.terminate()
         process = nil
+        spawnedThisSession = false
         NSLog("[LocalLobuRunner] stopped local Lobu")
     }
 

--- a/apps/mac/Lobu/MenuBarContent.swift
+++ b/apps/mac/Lobu/MenuBarContent.swift
@@ -463,12 +463,12 @@ struct MenuBarContent: View {
     private var connectButtonTitle: String {
         if state.isLoggingIn { return "Waiting for approval…" }
         let raw = state.customServerDraft.trimmingCharacters(in: .whitespacesAndNewlines)
-        // "Start & sign in" exactly when connect() would auto-start the runner.
-        // Anything else (other loopback ports, https-on-localhost, remote URLs)
-        // is just a plain "Sign in" because we won't spawn the runner.
+        // No-auth path: server runs locally with LOBU_NO_AUTH=1 and skips
+        // OAuth entirely. "Start" spawns the runner, "Connect" attaches if
+        // it's already up. No "& sign in" because there is no sign-in step.
         let willStartRunner = URL(string: raw).map(AppState.matchesManagedRunner) ?? false
-        if willStartRunner && !state.localLobuStatus.isRunning {
-            return "Start & sign in"
+        if willStartRunner {
+            return state.localLobuStatus.isRunning ? "Connect" : "Start"
         }
         return "Sign in"
     }

--- a/apps/mac/Lobu/OAuthClient.swift
+++ b/apps/mac/Lobu/OAuthClient.swift
@@ -222,6 +222,9 @@ final class OAuthClient {
         request.httpMethod = "POST"
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         request.setValue("application/json", forHTTPHeaderField: "Accept")
+        // No-auth CSRF middleware (when LOBU_NO_AUTH=1) requires this header
+        // on mutating requests that omit Origin. Harmless for remote/cloud.
+        request.setValue("menubar", forHTTPHeaderField: "X-Lobu-Client")
         request.httpBody = try JSONSerialization.data(withJSONObject: body)
         let (data, response) = try await session.data(for: request)
         guard let httpResponse = response as? HTTPURLResponse else { throw URLError(.badServerResponse) }

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -65,6 +65,7 @@ import { entityLinkMatchSql } from './utils/content-search';
 import { isValidFrameAncestor } from './utils/csp';
 import { errorMessage } from './utils/errors';
 import logger from './utils/logger';
+import { isLoopbackHost } from './utils/loopback';
 import { generateOpenAPISpec } from './utils/openapi-generator';
 import {
   extractSubdomainOrg,
@@ -298,11 +299,11 @@ app.use('/*', async (c, next) => {
   const lobuClient = c.req.header('x-lobu-client');
 
   // Host header must be one of the loopback aliases. Defeats DNS rebinding.
-  const hostOk =
-    /^127\.\d{1,3}\.\d{1,3}\.\d{1,3}(?::\d+)?$/.test(hostHeader) ||
-    /^localhost(?::\d+)?$/.test(hostHeader) ||
-    /^\[::1\](?::\d+)?$/.test(hostHeader);
-  if (!hostOk) {
+  // Uses the shared isLoopbackHost helper so the alias set stays in lock-step
+  // with the bind-time enforcement in start-local.ts / server.ts. Strip the
+  // optional `:<port>` suffix and IPv6 brackets before checking.
+  const hostBare = hostHeader.replace(/^\[(.+)\](?::\d+)?$/, '$1').replace(/:\d+$/, '');
+  if (!isLoopbackHost(hostBare)) {
     return c.json({ error: 'forbidden', error_description: 'No-auth mode: bad Host header' }, 403);
   }
 
@@ -323,7 +324,9 @@ app.use('/*', async (c, next) => {
   // Content-Type for state-changing requests must be application/json.
   // Defeats CSRF "simple request" form posts that browsers allow without
   // preflight (application/x-www-form-urlencoded, text/plain, multipart).
-  if (ct && !ct.includes('application/json')) {
+  // Empty Content-Type is also rejected — a CSRF attacker omitting it
+  // would otherwise slip through.
+  if (!ct.includes('application/json')) {
     return c.json(
       { error: 'forbidden', error_description: 'No-auth mode: mutations must be application/json' },
       415

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -277,6 +277,62 @@ app.use(
   })
 );
 
+// CSRF defense for no-auth mode. With LOBU_NO_AUTH=1 the server attributes
+// every request to the local user without checking any token — so any
+// website you visit in your browser could `fetch('http://localhost:8787/...')`
+// from a tab and side-effect the API. Block that by requiring same-origin
+// markers on every mutating method. CORS preflights already deny foreign
+// origins from carrying `Authorization`, but they don't prevent simple-
+// request POSTs that side-effect without reading the response, so we need
+// these checks on top.
+app.use('/*', async (c, next) => {
+  if (process.env.LOBU_NO_AUTH !== '1') return next();
+  const method = c.req.method.toUpperCase();
+  if (method === 'GET' || method === 'HEAD' || method === 'OPTIONS') {
+    return next();
+  }
+  const origin = c.req.header('origin');
+  const sfs = c.req.header('sec-fetch-site');
+  const hostHeader = (c.req.header('host') ?? '').toLowerCase();
+  const ct = (c.req.header('content-type') ?? '').toLowerCase();
+  const lobuClient = c.req.header('x-lobu-client');
+
+  // Host header must be one of the loopback aliases. Defeats DNS rebinding.
+  const hostOk =
+    /^127\.\d{1,3}\.\d{1,3}\.\d{1,3}(?::\d+)?$/.test(hostHeader) ||
+    /^localhost(?::\d+)?$/.test(hostHeader) ||
+    /^\[::1\](?::\d+)?$/.test(hostHeader);
+  if (!hostOk) {
+    return c.json({ error: 'forbidden', error_description: 'No-auth mode: bad Host header' }, 403);
+  }
+
+  // Origin / Sec-Fetch-Site: at least one must say "same-origin or none".
+  // Native clients (Mac app) typically omit Origin but set X-Lobu-Client.
+  const sameOrigin =
+    sfs === 'same-origin' ||
+    sfs === 'none' ||
+    (origin !== undefined && /^https?:\/\/(?:127\.\d{1,3}\.\d{1,3}\.\d{1,3}|localhost|\[::1\])(?::\d+)?$/.test(origin));
+  const trustedNative = lobuClient !== undefined && lobuClient.length > 0;
+  if (!sameOrigin && !trustedNative) {
+    return c.json(
+      { error: 'forbidden', error_description: 'No-auth mode: cross-origin mutation rejected' },
+      403
+    );
+  }
+
+  // Content-Type for state-changing requests must be application/json.
+  // Defeats CSRF "simple request" form posts that browsers allow without
+  // preflight (application/x-www-form-urlencoded, text/plain, multipart).
+  if (ct && !ct.includes('application/json')) {
+    return c.json(
+      { error: 'forbidden', error_description: 'No-auth mode: mutations must be application/json' },
+      415
+    );
+  }
+
+  return next();
+});
+
 // Add Pino logger middleware
 app.use(
   '*',

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -44,6 +44,7 @@ import { assertExternalDepsResolvable } from '../../connector-worker/src/runtime
 import { isSentryReported, markSentryReported } from './sentry';
 import { getEnvFromProcess } from './utils/env';
 import logger from './utils/logger';
+import { isLoopbackHost } from './utils/loopback';
 import { assertSchemaUpToDate } from './utils/schema-version-check';
 import { initWorkspaceProvider } from './workspace';
 
@@ -279,7 +280,32 @@ async function main() {
   // Start HTTP server
   logger.info({ port }, 'Starting server');
 
+  // No-auth mode is a single-user, loopback-only personal mode (see
+  // docs/plans/personal-mode-auth.md). It must NEVER be active on a
+  // production deployment behind any kind of public bind. Refuse to start
+  // if the operator accidentally sets it. Both pre-listen (host arg) and
+  // post-listen (server.address()) checks catch DNS / hostname surprises.
+  const noAuth = process.env.LOBU_NO_AUTH === '1';
+  if (noAuth && !isLoopbackHost(host)) {
+    logger.error(
+      { host },
+      'LOBU_NO_AUTH=1 requires loopback bind (127.0.0.0/8 or ::1). Refusing to start.'
+    );
+    process.exit(1);
+  }
+
   httpServer.listen(port, host, () => {
+    if (noAuth) {
+      const addr = httpServer.address();
+      if (typeof addr === 'object' && addr && !isLoopbackHost(addr.address)) {
+        logger.error(
+          { address: addr.address },
+          'LOBU_NO_AUTH=1 server bound to a non-loopback address after listen() — refusing to serve.'
+        );
+        process.exit(1);
+      }
+      logger.info('No-auth mode active (LOBU_NO_AUTH=1) — every request attributed to local user');
+    }
     logger.info({ host, port }, `Server running at http://${host}:${port}`);
     // Crash loud if the runtime image is missing any connector external dep,
     // instead of letting every feed silently fail with "Missing npm

--- a/packages/server/src/start-local.ts
+++ b/packages/server/src/start-local.ts
@@ -43,6 +43,7 @@ import { listMigrationFiles, loadMigrationUpSection } from './db/migration-loade
 import type { Env } from './index';
 import { getEnvFromProcess } from './utils/env';
 import logger from './utils/logger';
+import { isLoopbackHost } from './utils/loopback';
 
 const DATA_DIR = process.env.LOBU_DATA_DIR || join(homedir(), '.lobu', 'data');
 const PORT = parseInt(process.env.PORT || '8787', 10);
@@ -71,10 +72,7 @@ function isTruthyEnv(name: string): boolean {
   return /^(1|true|yes|on)$/i.test(process.env[name]?.trim() ?? '');
 }
 
-function isLoopbackHost(host: string | undefined | null): boolean {
-  const h = host?.toLowerCase()?.replace(/^\[|\]$/g, '');
-  return h === '127.0.0.1' || h === 'localhost' || h === '::1';
-}
+// `isLoopbackHost` lives in `./utils/loopback` so `server.ts` can share it.
 
 async function main() {
   mkdirSync(DATA_DIR, { recursive: true });
@@ -192,17 +190,31 @@ async function main() {
   process.on('SIGTERM', () => shutdown('SIGTERM'));
   process.on('SIGINT', () => shutdown('SIGINT'));
 
+  // ─── Bootstrap PAT ───────────────────────────────────────────
+  // Runs BEFORE listen so that:
+  //   (a) the bootstrap user / org / PAT row are guaranteed to exist before
+  //       the first request can land — no-auth mode would otherwise 503
+  //       during the gap between listen() and ensureBootstrapPat()'s await.
+  //   (b) a stale bootstrap-pat.txt (file exists, DB rows missing because
+  //       LOBU_DATA_DIR was wiped) gets re-minted now, while we still own
+  //       the boot sequence.
+  try {
+    await ensureBootstrapPat(dbUrl);
+  } catch (err) {
+    logger.warn({ err }, 'Bootstrap PAT setup failed');
+  }
+
   // ─── Listen ──────────────────────────────────────────────────
 
   // No-auth mode is loopback-only by design. Refuse to listen on anything
-  // other than 127.0.0.1 / ::1 — both via the configured HOST (early fail)
-  // and via a post-listen `server.address()` check that catches surprises
-  // (DNS resolution, hostname aliasing, etc.).
+  // other than the IPv4 loopback /8 / ::1 (matches isLoopbackHost) — both
+  // via the configured HOST (early fail) and via a post-listen
+  // `server.address()` check that catches DNS / hostname surprises.
   const noAuth = process.env.LOBU_NO_AUTH === '1';
   if (noAuth && !isLoopbackHost(HOST)) {
     logger.error(
       { host: HOST },
-      'LOBU_NO_AUTH=1 requires loopback bind (127.0.0.1 or ::1). Refusing to start.'
+      'LOBU_NO_AUTH=1 requires loopback bind (127.0.0.0/8 or ::1). Refusing to start.'
     );
     process.exit(1);
   }
@@ -221,17 +233,6 @@ async function main() {
     logger.info(`Data: ${DATA_DIR}`);
     if (noAuth) logger.info('No-auth mode active (LOBU_NO_AUTH=1) — every request attributed to local user');
   });
-
-  // ─── Bootstrap PAT ───────────────────────────────────────────
-  // Self-skips when the deployment already has users (production safety) or
-  // when a bootstrap PAT has already been minted under LOBU_DATA_DIR.
-  // Replaces the previous LOBU_LOCAL_BOOTSTRAP env-flag gate — operators no
-  // longer need to opt in for first-run local dev.
-  try {
-    await ensureBootstrapPat(dbUrl);
-  } catch (err) {
-    logger.warn({ err }, 'Bootstrap PAT setup failed');
-  }
 }
 
 // ─── Migrations ──────────────────────────────────────────────────
@@ -369,13 +370,6 @@ async function ensureBootstrapPat(dbUrl: string): Promise<void> {
   }
 
   const patFilePath = join(DATA_DIR, BOOTSTRAP_PAT_FILENAME);
-  if (existsSync(patFilePath)) {
-    logger.info(
-      { path: patFilePath, org: BOOTSTRAP_ORG_SLUG },
-      'Bootstrap PAT already provisioned (delete the file to re-mint)'
-    );
-    return;
-  }
 
   // Reuse the same dynamic-import shape `runMigrations` above uses so we share
   // postgres' module init cost with that path on first boot.
@@ -383,16 +377,40 @@ async function ensureBootstrapPat(dbUrl: string): Promise<void> {
   const sql = pg.default(dbUrl, { max: 1 });
 
   try {
-    // Production safety: skip when users already exist. A deployment that has
-    // real users provisioned via the web UI must not get a "Local Developer"
-    // user grafted in alongside them.
-    const userCountRows = await sql<[{ count: number }]>`
-      SELECT count(*)::int AS count FROM "user"
+    // Stale-file detection: previously this early-returned whenever the PAT
+    // file existed, but if LOBU_DATA_DIR was wiped between runs (or the user
+    // copied just the file across machines) the row is gone and no-auth mode
+    // would 503 forever. Trust the DB row, not the file. If the user already
+    // exists, treat the bootstrap as done and skip re-minting.
+    const userRows = await sql<[{ count: number }]>`
+      SELECT count(*)::int AS count FROM "user" WHERE id = ${BOOTSTRAP_USER_ID}
     `;
-    if ((userCountRows[0]?.count ?? 0) > 0) {
+    if ((userRows[0]?.count ?? 0) > 0) {
+      if (existsSync(patFilePath)) {
+        logger.info(
+          { path: patFilePath, org: BOOTSTRAP_ORG_SLUG },
+          'Bootstrap user + PAT already provisioned'
+        );
+      } else {
+        logger.warn(
+          { org: BOOTSTRAP_ORG_SLUG },
+          'Bootstrap user exists in DB but PAT file is missing — token reuse for external CLI is broken; delete the user row to re-mint'
+        );
+      }
+      return;
+    }
+
+    // Production safety: skip when OTHER users exist. A deployment that has
+    // real users provisioned via the web UI must not get a "Local Developer"
+    // user grafted in alongside them. (The bootstrap-user check above doesn't
+    // catch this — those other-user rows have different ids.)
+    const otherUserCountRows = await sql<[{ count: number }]>`
+      SELECT count(*)::int AS count FROM "user" WHERE id <> ${BOOTSTRAP_USER_ID}
+    `;
+    if ((otherUserCountRows[0]?.count ?? 0) > 0) {
       logger.debug(
-        { userCount: userCountRows[0]?.count },
-        'Skipping bootstrap PAT — deployment already has users'
+        { userCount: otherUserCountRows[0]?.count },
+        'Skipping bootstrap PAT — deployment already has non-bootstrap users'
       );
       return;
     }

--- a/packages/server/src/start-local.ts
+++ b/packages/server/src/start-local.ts
@@ -377,27 +377,41 @@ async function ensureBootstrapPat(dbUrl: string): Promise<void> {
   const sql = pg.default(dbUrl, { max: 1 });
 
   try {
-    // Stale-file detection: previously this early-returned whenever the PAT
-    // file existed, but if LOBU_DATA_DIR was wiped between runs (or the user
-    // copied just the file across machines) the row is gone and no-auth mode
-    // would 503 forever. Trust the DB row, not the file. If the user already
-    // exists, treat the bootstrap as done and skip re-minting.
-    const userRows = await sql<[{ count: number }]>`
-      SELECT count(*)::int AS count FROM "user" WHERE id = ${BOOTSTRAP_USER_ID}
+    // Stale-state detection: previously this early-returned whenever the PAT
+    // file existed, but if LOBU_DATA_DIR was wiped between runs the row was
+    // gone and no-auth mode would 503 forever. Now we check all three rows
+    // (user + org + member) — if ANY is missing the bootstrap re-runs to
+    // restore consistency. Partial state could otherwise wedge getNoAuthUser
+    // forever.
+    const stateRows = await sql<
+      [{ user_exists: boolean; org_exists: boolean; member_exists: boolean }]
+    >`
+      SELECT
+        EXISTS(SELECT 1 FROM "user"         WHERE id = ${BOOTSTRAP_USER_ID})   AS user_exists,
+        EXISTS(SELECT 1 FROM "organization" WHERE id = ${BOOTSTRAP_ORG_ID})    AS org_exists,
+        EXISTS(SELECT 1 FROM "member"       WHERE id = ${BOOTSTRAP_MEMBER_ID}) AS member_exists
     `;
-    if ((userRows[0]?.count ?? 0) > 0) {
+    const allPresent =
+      stateRows[0]?.user_exists && stateRows[0]?.org_exists && stateRows[0]?.member_exists;
+    if (allPresent) {
       if (existsSync(patFilePath)) {
         logger.info(
           { path: patFilePath, org: BOOTSTRAP_ORG_SLUG },
-          'Bootstrap user + PAT already provisioned'
+          'Bootstrap user + org + member already provisioned'
         );
       } else {
         logger.warn(
           { org: BOOTSTRAP_ORG_SLUG },
-          'Bootstrap user exists in DB but PAT file is missing — token reuse for external CLI is broken; delete the user row to re-mint'
+          'Bootstrap rows exist but PAT file is missing — external-CLI token reuse is broken; delete the user row to re-mint'
         );
       }
       return;
+    }
+    if (stateRows[0]?.user_exists || stateRows[0]?.org_exists || stateRows[0]?.member_exists) {
+      logger.warn(
+        stateRows[0],
+        'Bootstrap state is partial — re-minting to restore consistency'
+      );
     }
 
     // Production safety: skip when OTHER users exist. A deployment that has

--- a/packages/server/src/start-local.ts
+++ b/packages/server/src/start-local.ts
@@ -71,6 +71,11 @@ function isTruthyEnv(name: string): boolean {
   return /^(1|true|yes|on)$/i.test(process.env[name]?.trim() ?? '');
 }
 
+function isLoopbackHost(host: string | undefined | null): boolean {
+  const h = host?.toLowerCase()?.replace(/^\[|\]$/g, '');
+  return h === '127.0.0.1' || h === 'localhost' || h === '::1';
+}
+
 async function main() {
   mkdirSync(DATA_DIR, { recursive: true });
 
@@ -189,9 +194,32 @@ async function main() {
 
   // ─── Listen ──────────────────────────────────────────────────
 
+  // No-auth mode is loopback-only by design. Refuse to listen on anything
+  // other than 127.0.0.1 / ::1 — both via the configured HOST (early fail)
+  // and via a post-listen `server.address()` check that catches surprises
+  // (DNS resolution, hostname aliasing, etc.).
+  const noAuth = process.env.LOBU_NO_AUTH === '1';
+  if (noAuth && !isLoopbackHost(HOST)) {
+    logger.error(
+      { host: HOST },
+      'LOBU_NO_AUTH=1 requires loopback bind (127.0.0.1 or ::1). Refusing to start.'
+    );
+    process.exit(1);
+  }
   httpServer.listen(PORT, HOST, () => {
+    if (noAuth) {
+      const addr = httpServer.address();
+      if (typeof addr === 'object' && addr && !isLoopbackHost(addr.address)) {
+        logger.error(
+          { address: addr.address },
+          'LOBU_NO_AUTH=1 server bound to a non-loopback address after listen() — refusing to serve.'
+        );
+        process.exit(1);
+      }
+    }
     logger.info(`Lobu running at http://${HOST}:${PORT}`);
     logger.info(`Data: ${DATA_DIR}`);
+    if (noAuth) logger.info('No-auth mode active (LOBU_NO_AUTH=1) — every request attributed to local user');
   });
 
   // ─── Bootstrap PAT ───────────────────────────────────────────

--- a/packages/server/src/utils/loopback.ts
+++ b/packages/server/src/utils/loopback.ts
@@ -1,0 +1,15 @@
+/// True iff `host` is a loopback address — accepts everything in `127.0.0.0/8`,
+/// `::1`, `[::1]`, IPv4-mapped IPv6 loopback (`::ffff:127.x.y.z`), and the
+/// literal `localhost`. Case-insensitive on the host portion.
+///
+/// Used by both `start-local.ts` and `server.ts` to enforce that
+/// `LOBU_NO_AUTH=1` only ever serves on a loopback bind — refusing to start
+/// when a production deployment accidentally has the env set.
+export function isLoopbackHost(host: string | undefined | null): boolean {
+  if (!host) return false;
+  const h = host.toLowerCase().replace(/^\[|\]$/g, '');
+  if (h === 'localhost' || h === '::1') return true;
+  if (/^127\.(?:\d{1,3}\.){2}\d{1,3}$/.test(h)) return true;
+  if (/^::ffff:127\.(?:\d{1,3}\.){2}\d{1,3}$/.test(h)) return true;
+  return false;
+}

--- a/packages/server/src/workspace/multi-tenant.ts
+++ b/packages/server/src/workspace/multi-tenant.ts
@@ -104,6 +104,13 @@ export async function getCachedOrgBySlug(
   return record;
 }
 
+/// Bootstrap identity constants — must match the constants in
+/// `packages/server/src/start-local.ts` (BOOTSTRAP_USER_ID + BOOTSTRAP_ORG_ID).
+/// Duplicated here intentionally to avoid an import cycle with the local-only
+/// entrypoint. If you change either side, change both.
+const NO_AUTH_USER_ID = 'bootstrap-user';
+const NO_AUTH_ORG_ID = 'org-bootstrap-dev';
+
 /// Cache the no-auth user/org lookup. The values can't change while the
 /// server is alive: bootstrap-user/org are seeded once by `ensureBootstrapPat`
 /// and live forever. Clearing the cache requires a server restart.
@@ -116,9 +123,13 @@ interface NoAuthUser {
 }
 
 /// Resolve the single local user attributed to every request in no-auth
-/// mode. Pulls the bootstrap-user row that `ensureBootstrapPat` writes and
-/// the personal org it owns. Returns `null` when the row doesn't exist yet
-/// (server boot race between HTTP listen and ensureBootstrapPat's await).
+/// mode. Pulls the bootstrap-user row + the bootstrap-org membership by
+/// **id pair**, not "first admin LIMIT 1" — if the bootstrap user ever
+/// has multiple memberships (e.g. someone manually added them to another
+/// org for testing) we still want the personal org, deterministically.
+/// Returns `null` only when the row truly doesn't exist (server boot race
+/// between HTTP listen and ensureBootstrapPat's await — `start-local.ts`
+/// now runs the bootstrap BEFORE listen() to close that race).
 async function getNoAuthUser(
   sql: ReturnType<typeof getDb>
 ): Promise<NoAuthUser | null> {
@@ -128,18 +139,19 @@ async function getNoAuthUser(
       u.id    AS user_id,
       u.email AS email,
       u.name  AS name,
-      u.username AS username,
-      m."organizationId" AS organization_id
+      u.username AS username
     FROM "user" u
-    JOIN "member" m ON m."userId" = u.id AND m.role IN ('owner', 'admin')
-    WHERE u.id = 'bootstrap-user'
+    JOIN "member" m ON m."userId" = u.id
+    WHERE u.id = ${NO_AUTH_USER_ID}
+      AND m."organizationId" = ${NO_AUTH_ORG_ID}
+      AND m.role IN ('owner', 'admin')
     LIMIT 1
   `);
   if (rows.length === 0) return null;
   const row = rows[0];
   noAuthUserCache = {
     userId: row.user_id as string,
-    organizationId: row.organization_id as string,
+    organizationId: NO_AUTH_ORG_ID,
     user: {
       id: row.user_id as string,
       email: (row.email as string) ?? '',

--- a/packages/server/src/workspace/multi-tenant.ts
+++ b/packages/server/src/workspace/multi-tenant.ts
@@ -104,6 +104,52 @@ export async function getCachedOrgBySlug(
   return record;
 }
 
+/// Cache the no-auth user/org lookup. The values can't change while the
+/// server is alive: bootstrap-user/org are seeded once by `ensureBootstrapPat`
+/// and live forever. Clearing the cache requires a server restart.
+let noAuthUserCache: NoAuthUser | null = null;
+
+interface NoAuthUser {
+  userId: string;
+  organizationId: string;
+  user: { id: string; email: string; name: string; username: string };
+}
+
+/// Resolve the single local user attributed to every request in no-auth
+/// mode. Pulls the bootstrap-user row that `ensureBootstrapPat` writes and
+/// the personal org it owns. Returns `null` when the row doesn't exist yet
+/// (server boot race between HTTP listen and ensureBootstrapPat's await).
+async function getNoAuthUser(
+  sql: ReturnType<typeof getDb>
+): Promise<NoAuthUser | null> {
+  if (noAuthUserCache) return noAuthUserCache;
+  const rows = await simpleQuery(sql`
+    SELECT
+      u.id    AS user_id,
+      u.email AS email,
+      u.name  AS name,
+      u.username AS username,
+      m."organizationId" AS organization_id
+    FROM "user" u
+    JOIN "member" m ON m."userId" = u.id AND m.role IN ('owner', 'admin')
+    WHERE u.id = 'bootstrap-user'
+    LIMIT 1
+  `);
+  if (rows.length === 0) return null;
+  const row = rows[0];
+  noAuthUserCache = {
+    userId: row.user_id as string,
+    organizationId: row.organization_id as string,
+    user: {
+      id: row.user_id as string,
+      email: (row.email as string) ?? '',
+      name: (row.name as string) ?? '',
+      username: (row.username as string) ?? '',
+    },
+  };
+  return noAuthUserCache;
+}
+
 /**
  * Direct org lookup by id. Uncached — ids are a fallback path for the sandbox's
  * `.org(slugOrId)` accessor, so the TTL cache hit rate would be near-zero.
@@ -254,6 +300,55 @@ export class MultiTenantProvider implements WorkspaceProvider {
       if (overrides.session !== undefined) c.set('session', overrides.session as any);
       if (overrides.authSource !== undefined) c.set('authSource', overrides.authSource);
       return next();
+    }
+
+    // ─── No-auth (personal/local) mode ──────────────────────────────────────
+    // When LOBU_NO_AUTH=1 (set by the macOS menu bar's LocalLobuRunner), the
+    // server is bound to 127.0.0.1 only and treats every request as the
+    // single local user that `ensureBootstrapPat()` created on first boot.
+    // No bearer, no cookie, no OAuth — the entire point is to remove that
+    // ceremony for personal use on this Mac.
+    if (process.env.LOBU_NO_AUTH === '1') {
+      const noAuthUser = await getNoAuthUser(sql);
+      if (!noAuthUser) {
+        return c.json(
+          {
+            error: 'server_not_ready',
+            error_description:
+              'No-auth mode is enabled but the local user has not been provisioned yet. Retry shortly.',
+          },
+          503
+        );
+      }
+      // If a slug was supplied in the URL it must match the local user's org.
+      // No-auth mode is single-org by definition — refusing other slugs makes
+      // misconfiguration loud instead of silently attributing cross-org data.
+      if (requestedOrgId && requestedOrgId !== noAuthUser.organizationId) {
+        return c.json(
+          {
+            error: 'forbidden',
+            error_description:
+              'No-auth mode is single-org; the URL slug must match the local user organization.',
+          },
+          403
+        );
+      }
+      await setContextAndContinue({
+        mcpAuthInfo: {
+          userId: noAuthUser.userId,
+          organizationId: noAuthUser.organizationId,
+          clientId: 'lobu-no-auth',
+          scopes: ['mcp:read', 'mcp:write', 'mcp:admin'],
+          expiresAt: Math.floor(Date.now() / 1000) + 60 * 60,
+          tokenType: 'pat',
+        },
+        mcpIsAuthenticated: true,
+        organizationId: noAuthUser.organizationId,
+        memberRole: 'owner',
+        user: noAuthUser.user,
+        authSource: 'session',
+      });
+      return undefined;
     }
 
     // 1) Embedded worker direct-auth for the in-process lobu-memory MCP.


### PR DESCRIPTION
## Summary

Replaces closed PR #777 (\"lift the bootstrap PAT\") with the cleaner Phase B from \`docs/plans/personal-mode-auth.md\`. The server short-circuits auth when \`LOBU_NO_AUTH=1\` and attributes every request to the local user that \`ensureBootstrapPat\` already creates on first boot. The macOS menu bar spawns the runner with that env, then synthesises credentials directly — no PAT to read, no verification call, no ownership tracking.

## Why this over the PAT-lifting approach

Pi's iterative review of PR #777 surfaced enough corners in the lift-the-token frame (server-supplied URL exfiltration, PAT-not-accepted by /userinfo, squatter on :8787 receiving the bearer, file-vs-DB consistency, save-failure handling) that the no-token frame is **less code overall** and has a cleaner mental model: \"server in personal mode treats every request as the local user, period.\"

## Server changes

- **\`multi-tenant.ts\`** — new \`getNoAuthUser()\` helper loads the bootstrap user + their personal org once and caches; \`resolveAuth()\` short-circuits with owner-role attribution when \`LOBU_NO_AUTH=1\`. URL-supplied org slug must match the local user's org (no-auth mode is single-org by definition).
- **\`start-local.ts\`** — post-listen \`server.address()\` assertion refuses to serve on anything other than \`127.0.0.1\` / \`::1\` when \`LOBU_NO_AUTH=1\`. Pre-listen \`HOST\` validation as a secondary guard.

## Mac app changes

- **\`LocalLobuRunner\`** — sets \`LOBU_NO_AUTH=1\` in the spawn env.
- **\`AppState.connect()\`** — managed-runner path calls \`adoptLocalCredentials()\` with synthesised \`OAuthCredentials\` (dummy bearer the server ignores). No PAT file read, no \`/userinfo\` verification, no \`spawnedThisSession\` check.
- **\`MenuBarContent\` button** — \"Start\" / \"Connect\" instead of \"Start & sign in.\"

## Test plan

- [ ] Fresh install → click Start → server spawns → popover transitions to signed-in within ~1 s. No browser opens.
- [ ] Quit + relaunch → still signed in (credentials persisted).
- [ ] Edit URL to \`https://app.lobu.ai\` → button reads \"Sign in\" → click → normal OAuth flow.
- [ ] Edit URL to \`http://localhost:9999\` → button reads \"Sign in\" (not Start) → click → OAuth attempt (no auto-spawn).
- [ ] \`HOST=0.0.0.0 LOBU_NO_AUTH=1 lobu run\` → refuses to start with clear error.
- [ ] \`LOBU_NO_AUTH=1 lobu run\` against fresh DATA_DIR → wait a moment → API calls succeed without any \`Authorization\` header.

## Defers (still in design doc)

- CSRF middleware on mutating routes (\`Origin\` / \`Sec-Fetch-Site\` / \`Host\` / \`Content-Type\`). Browser-tab exfiltration risk remains until shipped — today no-auth mode trusts that loopback bind is the only attack surface.
- Per-user data dir / port for shared macOS user accounts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add a no-auth connection mode for embedded local runners that permits connecting without interactive sign-in when the runner was started in this session.
  * Connection button now shows “Start” or “Connect” (not “Start & sign in”) for managed local runner flows.
  * Menubar client now tags requests with a client identifier header.

* **Security**
  * No-auth mode restricted to loopback-only and enforces origin/host checks for mutating requests.

* **Bug Fixes**
  * More reliable local runner startup and session ownership tracking.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lobu-ai/lobu/pull/779?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->