### PR TITLE
fix(insert-event): guard against empty INSERT RETURNING

### DIFF
--- a/packages/server/src/utils/insert-event.ts
+++ b/packages/server/src/utils/insert-event.ts
@@ -234,9 +234,19 @@ export async function insertEvent(
           WHERE id = ${existing.id}
           LIMIT 1
         `;
-        return existingRows[0] as InsertedEvent;
+        const existingRow = existingRows[0] as InsertedEvent | undefined;
+        if (existingRow) return existingRow;
+        // Race: the existing row was deleted/tombstoned between the
+        // findCurrentEventByOrigin lookup above and the SELECT here. Fall
+        // through into the INSERT path with `supersedesEventId` unset so we
+        // create a fresh row instead of crashing on `undefined.id`.
+        logger.warn(
+          { existingId: existing.id, originId: params.originId },
+          '[insert-event] existing row vanished between find and reread — proceeding with fresh insert'
+        );
+      } else {
+        supersedesEventId = existing.id;
       }
-      supersedesEventId = existing.id;
     }
   }
 
@@ -299,7 +309,33 @@ export async function insertEvent(
     result = await insertWithClientId(null);
   }
 
-  const inserted = result[0] as InsertedEvent;
+  const inserted = result[0] as InsertedEvent | undefined;
+  if (!inserted) {
+    // INSERT ... RETURNING should always yield a row for a successful insert.
+    // An empty result means either (a) a BEFORE INSERT trigger silently
+    // RETURNed NULL (none in our schema today), (b) a PGlite quirk around
+    // GENERATED STORED columns failing without surfacing an error, or
+    // (c) postgres.js dropping the rows for an obscure reason. None of these
+    // should drop events on the floor — convert the cryptic `Cannot read
+    // properties of undefined (reading 'id')` into a real error with
+    // diagnostic context so we can root-cause when it next happens.
+    logger.error(
+      {
+        originId: params.originId,
+        connectionId: params.connectionId,
+        organizationId: params.organizationId,
+        semanticType: params.semanticType,
+        connectorKey: params.connectorKey,
+        feedKey: params.feedKey,
+      },
+      '[insert-event] INSERT ... RETURNING returned no rows — event not persisted'
+    );
+    throw new Error(
+      `insertEvent: INSERT RETURNING came back empty for ` +
+        `origin_id=${params.originId} connection_id=${params.connectionId}. ` +
+        `Row was not persisted; check server logs for diagnostic context.`
+    );
+  }
   await upsertEmbedding(inserted.id, params.embedding, sql);
   return inserted;
 }

--- a/packages/server/src/utils/insert-event.ts
+++ b/packages/server/src/utils/insert-event.ts
@@ -227,7 +227,11 @@ export async function insertEvent(
     const existing = await findCurrentEventByOrigin(sql, params);
     if (existing) {
       if (isSemanticallyEqual(existing, params)) {
-        await upsertEmbedding(existing.id, params.embedding, sql);
+        // Reread before touching the embedding. If the row got
+        // deleted / tombstoned between findCurrentEventByOrigin and
+        // here, upsertEmbedding would FK-fail instead of letting us
+        // fall through cleanly to a fresh insert (CodeRabbit catch
+        // on PR #780).
         const existingRows = await sql`
           SELECT id, entity_ids, origin_id, title, semantic_type, created_at
           FROM events
@@ -235,7 +239,10 @@ export async function insertEvent(
           LIMIT 1
         `;
         const existingRow = existingRows[0] as InsertedEvent | undefined;
-        if (existingRow) return existingRow;
+        if (existingRow) {
+          await upsertEmbedding(existingRow.id, params.embedding, sql);
+          return existingRow;
+        }
         // Race: the existing row was deleted/tombstoned between the
         // findCurrentEventByOrigin lookup above and the SELECT here. Fall
         // through into the INSERT path with `supersedesEventId` unset so we


### PR DESCRIPTION
## Summary

\`insertEvent\` assumed \`INSERT ... RETURNING\` always yields a row, then dereferenced \`result[0].id\`. When the result came back empty (exposed by the menu bar's no-auth sync round-trip completing for the first time in PR #779) the call crashed with the cryptic \`TypeError: Cannot read properties of undefined (reading 'id')\` and the worker stream handler returned 500.

This adds two defensive guards in \`packages/server/src/utils/insert-event.ts\`:

1. **Main INSERT path** — treat \`result[0]\` as possibly undefined, log connector/feed/origin context, throw a real error explaining the row wasn't persisted. Callers (worker \`streamContent\`) catch the throw and surface a useful message instead of the stack-trace blob.

2. **Conflict-update early-return** — \`existingRows[0]\` could also be undefined if the found row was deleted/tombstoned between \`findCurrentEventByOrigin\` and the subsequent reread (race). Fall through to the fresh-insert path instead of crashing.

## Root cause of the empty result

Still under investigation. Most likely culprit: PGlite quirk with the new \`search_tsv tsvector GENERATED ALWAYS AS (...) STORED\` column from PR #765, or a transient state during bootstrap-org/connector wire-up. The right behavior either way is to fail loud with context rather than silently crash on \`undefined.id\`.

## Test plan

- [ ] Fresh \`LOBU_DATA_DIR\` + Mac menu bar Start → worker stream calls return 200 (verified locally in PR #779 follow-up testing).
- [ ] If a row genuinely fails to persist, server logs show the connector/feed/origin context and the stream handler returns a clear error (not \`Cannot read properties of undefined\`).
- [ ] Conflict-update race (delete existing row between find and reread) falls through to fresh insert instead of crashing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# Release Notes

* **Bug Fixes**
  * Improved event persistence validation to ensure data integrity and prevent silent failures when events are not properly saved.
  * Enhanced error diagnostics and logging to provide clearer messages when event insertion fails, making troubleshooting easier.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lobu-ai/lobu/pull/780?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->