### PR TITLE
fix(mac): auto-start runner with the env it actually needs

### DIFF
--- a/apps/mac/Lobu/AppState.swift
+++ b/apps/mac/Lobu/AppState.swift
@@ -236,6 +236,13 @@ final class AppState: ObservableObject {
                 }
                 startAutoPollIfSignedIn()
             }
+        } else if credentials == nil, shouldAutoConnectAtLaunch() {
+            // First launch with no stored creds AND the URL points at the
+            // embedded runner we manage → auto-connect. No need to surface
+            // a "Start" button: spawn the runner, adopt no-auth credentials,
+            // signed in within ~1 s. Failures (CLI missing, port conflict)
+            // leave `credentials` nil and the connection card surfaces.
+            Task { @MainActor in await connect() }
         } else {
             startAutoPollIfSignedIn()
         }
@@ -465,6 +472,16 @@ final class AppState: ObservableObject {
         setStatus("")
     }
 
+    /// True iff init() should auto-trigger connect() at launch instead of
+    /// showing the connection card. We only do this when the URL targets the
+    /// embedded runner we manage — auto-spawning a process for a URL the
+    /// user typed pointing at someone else's server would be surprising.
+    private func shouldAutoConnectAtLaunch() -> Bool {
+        let raw = customServerDraft.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let url = URL(string: raw) else { return false }
+        return AppState.matchesManagedRunner(url)
+    }
+
     // Contract with `ensureBootstrapPat` in packages/server/src/start-local.ts.
     // Changing either side without the other makes the menu bar's display
     // disagree with reality.
@@ -523,10 +540,16 @@ final class AppState: ObservableObject {
             setStatus("Lobu is running on this Mac (~/lobu).")
         } catch LocalLobuRunner.RunnerError.cliNotFound {
             localLobuStatus = .cliMissing
-            setStatus(LocalLobuRunner.RunnerError.cliNotFound.errorDescription ?? "Lobu CLI not installed.")
+            // The connection card surfaces `cliMissing` inline with the
+            // install hint — don't echo it into the header status too.
+            setStatus("")
         } catch {
             localLobuStatus = .failed(message: error.localizedDescription)
-            setStatus(error.localizedDescription)
+            // Same — connectionCard's `connectStatusLine` renders the failure
+            // in orange right under the Start button. Echoing it into
+            // `state.status` would also push it into the header, producing
+            // the duplicate the user saw.
+            setStatus("")
         }
     }
 

--- a/apps/mac/Lobu/LocalLobuRunner.swift
+++ b/apps/mac/Lobu/LocalLobuRunner.swift
@@ -88,6 +88,18 @@ final class LocalLobuRunner {
         // bind. start-local.ts defaults HOST to 0.0.0.0, so we must pin it
         // explicitly here — otherwise the runner just crashes on boot.
         env["HOST"] = "127.0.0.1"
+        // The embedded gateway refuses to boot without an ENCRYPTION_KEY (used
+        // to encrypt at-rest connection secrets). For a personal-use install
+        // the only sensible default is an ephemeral key generated on first
+        // boot and persisted under LOBU_DATA_DIR — opt in here so the user
+        // doesn't have to manage a secret manually.
+        env["LOBU_ALLOW_EPHEMERAL_ENCRYPTION_KEY"] = "1"
+        // The embedded server requires Node 22.x–24.x (isolated-vm constraint).
+        // If the user's PATH leads with a newer Node (Homebrew often does
+        // `node` = latest), inject the keg-only Node 22 location first so
+        // `lobu` picks the right interpreter without forcing the user to
+        // manage PATH manually.
+        env["PATH"] = Self.preferredPath(currentPath: env["PATH"] ?? "")
         proc.environment = env
         proc.standardInput = FileHandle.nullDevice  // no TTY — any prompt gets EOF and fails fast
 
@@ -149,6 +161,29 @@ final class LocalLobuRunner {
             json["device_authorization_endpoint"] != nil
         else { return false }
         return true
+    }
+
+    /// Return a PATH that puts a known Node 22 install first if one exists,
+    /// so the spawned `lobu run` picks an interpreter the embedded server
+    /// supports (22.x–24.x; isolated-vm doesn't build on Node 25+).
+    ///
+    /// Looks in the obvious places: Homebrew keg-only `node@22`, plus the
+    /// version-manager shim paths the user might already have configured.
+    /// Order matters — Homebrew's keg-only formula is the most common case
+    /// on macOS, so it goes first.
+    private static func preferredPath(currentPath: String) -> String {
+        let candidates = [
+            "/opt/homebrew/opt/node@22/bin",
+            "/usr/local/opt/node@22/bin",
+            "/opt/homebrew/opt/node@24/bin",
+            "/usr/local/opt/node@24/bin",
+            "\(NSHomeDirectory())/.local/share/mise/installs/node/22/bin",
+            "\(NSHomeDirectory())/.local/share/fnm/aliases/default/bin",
+        ]
+        let fm = FileManager.default
+        let prefixes = candidates.filter { fm.isExecutableFile(atPath: "\($0)/node") }
+        if prefixes.isEmpty { return currentPath }
+        return (prefixes + [currentPath]).joined(separator: ":")
     }
 
     private static func locateLobuCLI() -> String? {


### PR DESCRIPTION
## Summary

PR #779 introduced no-auth mode but left three rough edges in the Mac app side of the spawn — each of which made the \"Start\" path silently fail end-to-end:

1. **\`HOST=127.0.0.1\` wasn't set** — \`start-local.ts\` defaults \`HOST=0.0.0.0\` and the no-auth bind guard refuses non-loopback. Without this, the runner crashes on boot.
2. **No \`LOBU_ALLOW_EPHEMERAL_ENCRYPTION_KEY=1\`** — the embedded gateway refuses to start without \`ENCRYPTION_KEY\` or this opt-in flag. For a personal install, the ephemeral key is the only sensible default.
3. **PATH didn't prefer Node 22** — Homebrew users with \`node\` = 25+ would crash the runner (isolated-vm only supports Node 22–24). Now \`LocalLobuRunner.preferredPath\` prepends well-known Node 22 install paths (Homebrew keg-only \`node@22\`, mise, fnm) to PATH for the spawn.

Plus two UX cleanups:

- \`AppState.connect()\` now **auto-fires on launch** when credentials are nil and the URL targets the managed runner. No Start button click required for the 99% case. The connection card only surfaces on actual failure.
- \`startLocalLobu()\`'s failure handler **no longer echoes the runner error into \`state.status\`**. The connection card's \`connectStatusLine\` already shows it in orange; echoing into \`state.status\` duplicated the message at the top of the popover (visible in the user's earlier screenshot).

## Test plan

- [ ] Fresh install with \`node@22\` keg-only present → click Lobu icon → popover transitions to signed-in within ~2s. No Start click, no browser, no error.
- [ ] System has only Node 25+ → \`brew install node@22\` → relaunch → succeeds.
- [ ] Move \`/opt/homebrew/opt/node@22\` aside → relaunch → connection card shows \`Unsupported Node.js runtime\` error inline (no duplicate in header).
- [ ] Kill the runner mid-session → menu bar shows the failure inline; no header echo.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Refined auto-connect behavior to activate only with the embedded local runner
  * Improved error message display when local service startup fails

* **Improvements**
  * Enhanced local runner compatibility with better Node.js detection across common installation locations
  * Simplified embedded gateway configuration to reduce manual setup requirements

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lobu-ai/lobu/pull/783?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->