### PR TITLE
fix(no-auth): address CodeRabbit follow-ups from PR #780 review

### DIFF
--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -309,10 +309,17 @@ app.use('/*', async (c, next) => {
 
   // Origin / Sec-Fetch-Site: at least one must say "same-origin or none".
   // Native clients (Mac app) typically omit Origin but set X-Lobu-Client.
+  //
+  // The Origin match is exact-against-this-server, not any-loopback-shape.
+  // Previously we accepted any `http(s)://(127.x.x.x|localhost|[::1])(:port)?`
+  // which let a malicious tab loaded from e.g. `http://localhost:9999` send
+  // CSRF mutations to our `:8787`. Now we derive the canonical origin from
+  // the validated Host header above and require an exact string match.
+  const expectedOrigin = `http://${hostHeader}`;
   const sameOrigin =
     sfs === 'same-origin' ||
     sfs === 'none' ||
-    (origin !== undefined && /^https?:\/\/(?:127\.\d{1,3}\.\d{1,3}\.\d{1,3}|localhost|\[::1\])(?::\d+)?$/.test(origin));
+    origin === expectedOrigin;
   const trustedNative = lobuClient !== undefined && lobuClient.length > 0;
   if (!sameOrigin && !trustedNative) {
     return c.json(

--- a/packages/server/src/start-local.ts
+++ b/packages/server/src/start-local.ts
@@ -422,6 +422,20 @@ async function ensureBootstrapPat(dbUrl: string): Promise<void> {
       SELECT count(*)::int AS count FROM "user" WHERE id <> ${BOOTSTRAP_USER_ID}
     `;
     if ((otherUserCountRows[0]?.count ?? 0) > 0) {
+      // If LOBU_NO_AUTH=1 is set, the auth bypass needs the bootstrap user
+      // to attribute every request to. Skipping bootstrap here while no-auth
+      // is on leaves resolveAuth() returning 503 forever — visible only at
+      // request time, when the user has no clear path to recover. Fail loud
+      // at startup instead so the operator sees the mismatch immediately.
+      if (process.env.LOBU_NO_AUTH === '1') {
+        logger.error(
+          { otherUserCount: otherUserCountRows[0]?.count },
+          'LOBU_NO_AUTH=1 requires the bootstrap user to exist, but this deployment ' +
+            'already has non-bootstrap users — no-auth mode would 503 every request. ' +
+            'Either unset LOBU_NO_AUTH for this deployment or use a clean LOBU_DATA_DIR.'
+        );
+        process.exit(1);
+      }
       logger.debug(
         { userCount: otherUserCountRows[0]?.count },
         'Skipping bootstrap PAT — deployment already has non-bootstrap users'

--- a/packages/server/src/workspace/multi-tenant.ts
+++ b/packages/server/src/workspace/multi-tenant.ts
@@ -28,8 +28,14 @@ import {
 // Re-export the test-only cache clearer so existing imports
 // (`from '../workspace/multi-tenant'`) keep working; the cache instances
 // themselves live in `./multi-tenant-caches` to keep test cleanup off this
-// file's heavy import graph.
-export const clearMultiTenantCachesForTests = clearMultiTenantCachesForTestsShared;
+// file's heavy import graph. We wrap rather than re-export so we can also
+// reset the no-auth user cache that lives in THIS file (see `getNoAuthUser`
+// below) — tests that swap bootstrap rows or LOBU_NO_AUTH between cases
+// would otherwise see stale identity.
+export function clearMultiTenantCachesForTests(): void {
+  clearMultiTenantCachesForTestsShared();
+  noAuthUserCache = null;
+}
 
 /**
  * Path namespaces that don't carry an org context. Authenticated requests to


### PR DESCRIPTION
## Summary

Three deferred items from CodeRabbit's review of PR #780 that were outside that PR's diff but in scope for follow-up.

1. **CSRF Origin check tightened** — \`packages/server/src/index.ts\`. The previous check accepted any \`http(s)://(127.x.x.x|localhost|[::1])(:port)?\` origin, which let a malicious tab loaded from e.g. \`http://localhost:9999\` send CSRF mutations to our \`:8787\`. Now derives the canonical origin from the validated \`Host\` header and requires an exact match.

2. **Fail-fast when no-auth lacks a bootstrap user** — \`packages/server/src/start-local.ts\`. If \`LOBU_NO_AUTH=1\` is set but the deployment already has non-bootstrap users (production DB grafted onto a no-auth process), \`ensureBootstrapPat\` skipped silently. \`resolveAuth()\` would then 503 every request, visible only at request time with no clear recovery path. Now exits at startup with a message naming both the cause and the fix.

3. **Test-cache leak fixed** — \`packages/server/src/workspace/multi-tenant.ts\`. \`noAuthUserCache\` is a module-level variable inside this file (not in \`multi-tenant-caches.ts\` where the shared teardown lives). Wraps the shared \`clearMultiTenantCachesForTests\` with a local version that also resets \`noAuthUserCache\` so tests swapping bootstrap rows / env between cases don't see stale identity.

## Test plan

- [ ] \`curl -X POST -H 'Origin: http://localhost:9999' -H 'Host: localhost:8787' -H 'Content-Type: application/json' http://localhost:8787/api/dev/anything\` → 403 (was previously accepted).
- [ ] \`curl -X POST -H 'Origin: http://localhost:8787' -H 'Host: localhost:8787' -H 'Content-Type: application/json' -H 'X-Lobu-Client: menubar' http://localhost:8787/api/dev/anything\` → passes CSRF (then probably 404 for the route).
- [ ] \`LOBU_NO_AUTH=1 lobu run\` against a DB that already has non-bootstrap users → exits 1 at startup with the new error message.
- [ ] \`LOBU_NO_AUTH=1 lobu run\` against fresh DATA_DIR → boots, attributes requests to bootstrap user, no changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved startup validation for no-auth mode to prevent service errors when misconfigured.
  * Enhanced Origin header validation for stricter same-origin mutation request verification.

* **Chores**
  * Improved test isolation to prevent stale state from affecting subsequent test runs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lobu-ai/lobu/pull/785?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->