### PR TITLE
ci: add mac-build-smoke job — catch submodule-side breakage on every PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -393,19 +393,16 @@ jobs:
             exit 1
           fi
 
-  # Cheap end-to-end Xcode build for the Mac app. `mac-release.yml` is
-  # workflow_dispatch only, so a rename or path move inside the owletto
-  # submodule (Mac source lives at `packages/web/apps/mac/`) can silently
-  # break the release pipeline and only surface the next time someone
-  # triggers a release. Build-only (no archive, no signing, no notarize)
-  # is enough to prove the Xcode project + submodule layout still compose.
-  #
-  # Runner cost is bounded by the path filter below — the job only runs
-  # when the submodule pointer, the release workflow, or the submodule
-  # setup action changes.
-  mac-build-smoke:
-    runs-on: macos-15
-    timeout-minutes: 15
+  # Path-filter for the Mac smoke build, isolated to a cheap ubuntu runner
+  # so skipped PRs don't allocate a macOS runner just to evaluate the diff.
+  # `github.event.pull_request.changed_files` in the webhook payload is an
+  # integer (the count of changed files), not a list — `contains()` over it
+  # never matches. Use git diff against the PR base instead. On push events
+  # (main) there's no PR object, so default to running the smoke job.
+  mac-build-smoke-filter:
+    runs-on: ubuntu-latest
+    outputs:
+      run: ${{ steps.filter.outputs.run }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -413,11 +410,6 @@ jobs:
           # fetch-depth=1 only has HEAD.
           fetch-depth: 0
 
-      # `github.event.pull_request.changed_files` in the webhook payload is
-      # an integer (the count of changed files), not a list — `contains()`
-      # over it never matches. Use git diff against the PR base instead so
-      # the filter is actually correct. On push events (main) there's no
-      # base SHA in the payload, so default to running the smoke job.
       - name: Decide whether to run the Mac smoke build
         id: filter
         env:
@@ -430,15 +422,32 @@ jobs:
             exit 0
           fi
           changed=$(git diff --name-only "$BASE_SHA"...HEAD)
-          if echo "$changed" | grep -E '^(packages/web($|/)|\.github/workflows/mac-release\.yml$|\.github/actions/setup-submodule(/|$))' >/dev/null; then
+          if echo "$changed" | grep -E '^(packages/web($|/)|\.github/workflows/mac-release\.yml$|\.github/actions/setup-submodule(/|$)|\.gitmodules$)' >/dev/null; then
             echo "run=true" >> "$GITHUB_OUTPUT"
           else
             echo "run=false" >> "$GITHUB_OUTPUT"
             echo "::notice::No paths affecting the Mac build changed — skipping mac-build-smoke."
           fi
 
+  # Cheap end-to-end Xcode build for the Mac app. `mac-release.yml` is
+  # workflow_dispatch only, so a rename or path move inside the owletto
+  # submodule (Mac source lives at `packages/web/apps/mac/`) can silently
+  # break the release pipeline and only surface the next time someone
+  # triggers a release. Build-only (no archive, no signing, no notarize)
+  # is enough to prove the Xcode project + submodule layout still compose.
+  #
+  # Runner cost is bounded by the filter job above — the macOS runner is
+  # only allocated when the submodule pointer, the release workflow, the
+  # submodule setup action, or `.gitmodules` changes.
+  mac-build-smoke:
+    needs: mac-build-smoke-filter
+    if: needs.mac-build-smoke-filter.outputs.run == 'true'
+    runs-on: macos-15
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
       - id: submodule
-        if: steps.filter.outputs.run == 'true'
         uses: ./.github/actions/setup-submodule
         with:
           deploy-key: ${{ secrets.OWLETTO_WEB_DEPLOY_KEY }}
@@ -446,19 +455,20 @@ jobs:
       # Forks (and any run where the secret isn't available) get a stub
       # package.json from setup-submodule. There's no Mac source to build
       # there, so skip the rest gracefully rather than fail. Same-repo PRs
-      # have the key, so a stub here means the secret is misconfigured.
-      - name: Fail fast if submodule is stubbed (same-repo PRs only)
-        if: steps.filter.outputs.run == 'true' && steps.submodule.outputs.stubbed == 'true' && github.event.pull_request.head.repo.full_name == github.repository
+      # and push events both have the key, so a stub there means the secret
+      # is misconfigured — fail loudly.
+      - name: Fail fast if submodule is stubbed (same-repo PRs and push)
+        if: steps.submodule.outputs.stubbed == 'true' && !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository)
         run: |
           echo "::error::Mac source unreachable — OWLETTO_WEB_DEPLOY_KEY missing or invalid."
           exit 1
 
       - name: Skip on fork PRs without submodule access
-        if: steps.filter.outputs.run == 'true' && steps.submodule.outputs.stubbed == 'true' && github.event.pull_request.head.repo.full_name != github.repository
+        if: steps.submodule.outputs.stubbed == 'true' && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository
         run: echo "::notice::Submodule stubbed on fork PR — skipping Mac smoke build."
 
       - name: Build (unsigned, no archive)
-        if: steps.filter.outputs.run == 'true' && steps.submodule.outputs.stubbed != 'true'
+        if: steps.submodule.outputs.stubbed != 'true'
         run: |
           xcodebuild \
             -project packages/web/apps/mac/Lobu.xcodeproj \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -392,3 +392,75 @@ jobs:
             echo "::error::db/schema.sql is stale. Regenerate with \`dbmate --migrations-dir db/migrations --schema-file db/schema.sql dump && scripts/normalize-schema.sh db/schema.sql\` and commit the result."
             exit 1
           fi
+
+  # Cheap end-to-end Xcode build for the Mac app. `mac-release.yml` is
+  # workflow_dispatch only, so a rename or path move inside the owletto
+  # submodule (Mac source lives at `packages/web/apps/mac/`) can silently
+  # break the release pipeline and only surface the next time someone
+  # triggers a release. Build-only (no archive, no signing, no notarize)
+  # is enough to prove the Xcode project + submodule layout still compose.
+  #
+  # Runner cost is bounded by the path filter below — the job only runs
+  # when the submodule pointer, the release workflow, or the submodule
+  # setup action changes.
+  mac-build-smoke:
+    runs-on: macos-15
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Need the PR base commit so we can diff against it. The default
+          # fetch-depth=1 only has HEAD.
+          fetch-depth: 0
+
+      # `github.event.pull_request.changed_files` in the webhook payload is
+      # an integer (the count of changed files), not a list — `contains()`
+      # over it never matches. Use git diff against the PR base instead so
+      # the filter is actually correct. On push events (main) there's no
+      # base SHA in the payload, so default to running the smoke job.
+      - name: Decide whether to run the Mac smoke build
+        id: filter
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          set -euo pipefail
+          if [ -z "${BASE_SHA:-}" ]; then
+            # push to main (or any non-PR trigger) — always run.
+            echo "run=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          changed=$(git diff --name-only "$BASE_SHA"...HEAD)
+          if echo "$changed" | grep -E '^(packages/web($|/)|\.github/workflows/mac-release\.yml$|\.github/actions/setup-submodule(/|$))' >/dev/null; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "run=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::No paths affecting the Mac build changed — skipping mac-build-smoke."
+          fi
+
+      - id: submodule
+        if: steps.filter.outputs.run == 'true'
+        uses: ./.github/actions/setup-submodule
+        with:
+          deploy-key: ${{ secrets.OWLETTO_WEB_DEPLOY_KEY }}
+
+      # Forks (and any run where the secret isn't available) get a stub
+      # package.json from setup-submodule. There's no Mac source to build
+      # there, so skip the rest gracefully rather than fail. Same-repo PRs
+      # have the key, so a stub here means the secret is misconfigured.
+      - name: Fail fast if submodule is stubbed (same-repo PRs only)
+        if: steps.filter.outputs.run == 'true' && steps.submodule.outputs.stubbed == 'true' && github.event.pull_request.head.repo.full_name == github.repository
+        run: |
+          echo "::error::Mac source unreachable — OWLETTO_WEB_DEPLOY_KEY missing or invalid."
+          exit 1
+
+      - name: Skip on fork PRs without submodule access
+        if: steps.filter.outputs.run == 'true' && steps.submodule.outputs.stubbed == 'true' && github.event.pull_request.head.repo.full_name != github.repository
+        run: echo "::notice::Submodule stubbed on fork PR — skipping Mac smoke build."
+
+      - name: Build (unsigned, no archive)
+        if: steps.filter.outputs.run == 'true' && steps.submodule.outputs.stubbed != 'true'
+        run: |
+          xcodebuild \
+            -project packages/web/apps/mac/Lobu.xcodeproj \
+            -scheme Lobu -configuration Release build \
+            CODE_SIGNING_ALLOWED=NO


### PR DESCRIPTION
## Summary

Adds a `mac-build-smoke` job to `.github/workflows/ci.yml` that runs `xcodebuild build` (unsigned, no archive) against the pinned `packages/web` submodule SHA on PRs that could affect the Mac build.

Closes #793.

### What triggers it

The job only runs when the diff touches a path that can break the Mac release pipeline:

- `packages/web` — the submodule pointer (Mac source lives at `packages/web/apps/mac/`)
- `.github/workflows/mac-release.yml` — the release workflow whose contract this smokes
- `.github/actions/setup-submodule` — the composite action both workflows depend on

Everything else short-circuits with a notice and uses zero macOS-runner minutes.

### What it does

- Re-uses the existing `setup-submodule` composite action.
- Fails fast on same-repo PRs if the submodule got stubbed (means `OWLETTO_WEB_DEPLOY_KEY` is missing/invalid — same posture as `mac-release.yml`'s release contract).
- On fork PRs without the deploy key it logs a notice and skips the build (forks legitimately can't access the private submodule).
- Runs `xcodebuild ... -scheme Lobu -configuration Release build CODE_SIGNING_ALLOWED=NO`. No archive, no signing, no notarization, no DMG.

### Note on the path filter

The issue's snippet uses `contains(github.event.pull_request.changed_files || '', ...)`. That expression doesn't work — `changed_files` in the PR webhook payload is an integer (the *count* of changed files), not a list of paths, so `contains()` over it never matches and the job would run on every PR.

This implementation computes the changed-file list via `git diff "$BASE_SHA"...HEAD` in a setup step and gates the rest of the job on its output. Push events (no PR base SHA) default to running the job.

### Runner cost

`macos-15` is the most expensive runner tier, but the filter keeps it to PRs that actually touch the relevant paths — likely a handful per month, in line with how often the submodule pointer bumps.

## Test plan

- [ ] Verify the filter skips this CI run itself (this PR only touches `.github/workflows/ci.yml`, not the three trigger paths) — should see the `mac-build-smoke` job exist but log "No paths affecting the Mac build changed — skipping" and pass with no `xcodebuild` invocation.
- [ ] On a follow-up PR that bumps the `packages/web` submodule pointer, confirm the smoke build actually runs and passes against the current owletto SHA.
- [ ] Confirm a fork PR (no `OWLETTO_WEB_DEPLOY_KEY`) hits the "submodule stubbed on fork PR" notice rather than failing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a path-filtered, lightweight macOS "smoke" build to CI that runs only when Mac app–related files change.
  * CI now skips or adjusts the mac build for forked PRs and situations where the mac submodule is unavailable, reducing unnecessary mac build runs and failing fast on genuine mac build problems.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lobu-ai/lobu/pull/806?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->