### PR TITLE
ci(mac-release): release-contract asserts scheme + bundle-id + SUPublicEDKey

### DIFF
--- a/.github/workflows/mac-release.yml
+++ b/.github/workflows/mac-release.yml
@@ -72,6 +72,12 @@ jobs:
       #      assumes must actually exist at the pinned SHA. Otherwise the
       #      `lobster-mark.svg` → `owletto-mark.svg` style of silent rename on
       #      the owletto side would only surface inside `xcodebuild`.
+      #   4-7. The scheme name, app display name, bundle identifier, and
+      #      Sparkle public key must match what the rest of the workflow and
+      #      installed apps depend on. A rename inside owletto (e.g. scheme
+      #      `Lobu` → `Owletto`, bundle id `ai.lobu.mac` → `ai.owletto.mac`)
+      #      would pass the path checks above but break the build or, worse,
+      #      silently break auto-update for installed users.
       - name: Verify release contract (submodule + Mac source layout)
         shell: bash
         run: |
@@ -98,6 +104,52 @@ jobs:
               exit 1
             fi
           done
+
+          # 4. The Xcode scheme must still be named 'Lobu'. The rest of this
+          #    workflow passes `-scheme Lobu` to xcodebuild; if owletto renames
+          #    the scheme (e.g. to 'Owletto') the path checks above still pass
+          #    and we'd only find out late inside xcodebuild.
+          if ! xcodebuild -project packages/web/apps/mac/Lobu.xcodeproj -list 2>/dev/null \
+            | grep -qE '^[[:space:]]+Lobu[[:space:]]*$'; then
+            echo "::error::Expected scheme 'Lobu' missing from Lobu.xcodeproj"
+            exit 1
+          fi
+
+          # 5. CFBundleName + CFBundleDisplayName must stay 'Owletto'. These
+          #    are what users see in Finder / the menu bar / "About"; a silent
+          #    rename here would ship a DMG that installs as a different app
+          #    next to existing installs.
+          EXPECTED_BUNDLE_NAME="Owletto"
+          for key in CFBundleName CFBundleDisplayName; do
+            actual=$(/usr/libexec/PlistBuddy -c "Print :$key" \
+              packages/web/apps/mac/Lobu/Info.plist 2>/dev/null || true)
+            if [ "$actual" != "$EXPECTED_BUNDLE_NAME" ]; then
+              echo "::error::Info.plist:$key is '$actual', expected '$EXPECTED_BUNDLE_NAME'"
+              exit 1
+            fi
+          done
+
+          # 6. PRODUCT_BUNDLE_IDENTIFIER in project.pbxproj must stay
+          #    ai.lobu.mac. CFBundleIdentifier in Info.plist resolves to
+          #    $(PRODUCT_BUNDLE_IDENTIFIER) at build time, so the real value
+          #    lives in the pbxproj build settings. The URL scheme, Keychain
+          #    service name, and Sparkle update path are all keyed off this —
+          #    a change here breaks the upgrade contract for installed apps.
+          EXPECTED_BUNDLE_ID="ai.lobu.mac"
+          if ! grep -q "PRODUCT_BUNDLE_IDENTIFIER = ${EXPECTED_BUNDLE_ID};" \
+            packages/web/apps/mac/Lobu.xcodeproj/project.pbxproj; then
+            echo "::error::PRODUCT_BUNDLE_IDENTIFIER in project.pbxproj is not '${EXPECTED_BUNDLE_ID}'. Bundle id drift breaks installed-app upgrades."
+            exit 1
+          fi
+
+          # 7. Sparkle public key must still be in Info.plist. Installed apps
+          #    verify update signatures against SUPublicEDKey; if the key is
+          #    removed or rotated server-side without matching a key the
+          #    installed app trusts, auto-update breaks silently.
+          if ! grep -q "<key>SUPublicEDKey</key>" packages/web/apps/mac/Lobu/Info.plist; then
+            echo "::error::SUPublicEDKey missing from Info.plist — installed apps cannot verify updates"
+            exit 1
+          fi
 
       - name: Resolve version
         id: v

--- a/.github/workflows/mac-release.yml
+++ b/.github/workflows/mac-release.yml
@@ -109,9 +109,15 @@ jobs:
           #    workflow passes `-scheme Lobu` to xcodebuild; if owletto renames
           #    the scheme (e.g. to 'Owletto') the path checks above still pass
           #    and we'd only find out late inside xcodebuild.
-          if ! xcodebuild -project packages/web/apps/mac/Lobu.xcodeproj -list 2>/dev/null \
-            | grep -qE '^[[:space:]]+Lobu[[:space:]]*$'; then
-            echo "::error::Expected scheme 'Lobu' missing from Lobu.xcodeproj"
+          #
+          #    Scope the check to the schemes list via `-list -json`. The plain
+          #    `-list` text output has both `Targets:` and `Schemes:` sections,
+          #    so a `grep '^  Lobu$'` could match a target named 'Lobu' even
+          #    after the scheme was renamed to 'Owletto'.
+          SCHEMES=$(xcodebuild -project packages/web/apps/mac/Lobu.xcodeproj -list -json 2>/dev/null \
+            | python3 -c "import json,sys; print('\n'.join(json.load(sys.stdin)['project']['schemes']))")
+          if ! echo "$SCHEMES" | grep -qE '^Lobu$'; then
+            echo "::error::Expected scheme 'Lobu' missing from project schemes (got: $SCHEMES)"
             exit 1
           fi
 
@@ -130,15 +136,24 @@ jobs:
           done
 
           # 6. PRODUCT_BUNDLE_IDENTIFIER in project.pbxproj must stay
-          #    ai.lobu.mac. CFBundleIdentifier in Info.plist resolves to
-          #    $(PRODUCT_BUNDLE_IDENTIFIER) at build time, so the real value
-          #    lives in the pbxproj build settings. The URL scheme, Keychain
-          #    service name, and Sparkle update path are all keyed off this —
-          #    a change here breaks the upgrade contract for installed apps.
+          #    ai.lobu.mac across ALL build configurations. CFBundleIdentifier
+          #    in Info.plist resolves to $(PRODUCT_BUNDLE_IDENTIFIER) at build
+          #    time, so the real value lives in the pbxproj build settings.
+          #    The URL scheme, Keychain service name, and Sparkle update path
+          #    are all keyed off this — a change here breaks the upgrade
+          #    contract for installed apps.
+          #
+          #    Assert the set of distinct values is exactly {ai.lobu.mac}, not
+          #    "some occurrence equals ai.lobu.mac". A simple grep would still
+          #    pass if one config drifted while another stale occurrence stayed
+          #    correct.
           EXPECTED_BUNDLE_ID="ai.lobu.mac"
-          if ! grep -q "PRODUCT_BUNDLE_IDENTIFIER = ${EXPECTED_BUNDLE_ID};" \
-            packages/web/apps/mac/Lobu.xcodeproj/project.pbxproj; then
-            echo "::error::PRODUCT_BUNDLE_IDENTIFIER in project.pbxproj is not '${EXPECTED_BUNDLE_ID}'. Bundle id drift breaks installed-app upgrades."
+          distinct_ids=$(grep -E 'PRODUCT_BUNDLE_IDENTIFIER = ' \
+            packages/web/apps/mac/Lobu.xcodeproj/project.pbxproj \
+            | sed -E 's/.*PRODUCT_BUNDLE_IDENTIFIER = ([^;]+);.*/\1/' \
+            | sort -u)
+          if [ "$distinct_ids" != "$EXPECTED_BUNDLE_ID" ]; then
+            echo "::error::PRODUCT_BUNDLE_IDENTIFIER must be exactly '${EXPECTED_BUNDLE_ID}' across all configs (got: $distinct_ids). Bundle id drift breaks installed-app upgrades."
             exit 1
           fi
 
@@ -146,7 +161,11 @@ jobs:
           #    verify update signatures against SUPublicEDKey; if the key is
           #    removed or rotated server-side without matching a key the
           #    installed app trusts, auto-update breaks silently.
-          if ! grep -q "<key>SUPublicEDKey</key>" packages/web/apps/mac/Lobu/Info.plist; then
+          #
+          #    Use PlistBuddy so the check matches an actual plist key, not
+          #    text inside an XML comment.
+          if ! /usr/libexec/PlistBuddy -c "Print :SUPublicEDKey" \
+            packages/web/apps/mac/Lobu/Info.plist >/dev/null 2>&1; then
             echo "::error::SUPublicEDKey missing from Info.plist — installed apps cannot verify updates"
             exit 1
           fi


### PR DESCRIPTION
Closes #794.

## Context

PR #784 added a "Verify release contract" step in `mac-release.yml` that only checked path existence. A rename inside the `lobu-ai/owletto` submodule (Xcode scheme `Lobu` → `Owletto`, bundle id `ai.lobu.mac` → `ai.owletto.mac`, or accidental removal of `SUPublicEDKey`) would pass those checks and fail late in `xcodebuild -scheme Lobu` — or worse, silently break Sparkle auto-update for installed users.

## What's now verified

The same `Verify release contract` shell block (no new step) now also asserts, at the pinned submodule SHA, **before any build runs**:

1. `xcodebuild -project Lobu.xcodeproj -list` exposes a scheme named exactly **`Lobu`** (regex-anchored so e.g. `LobuTests` doesn't match).
2. `Info.plist` `CFBundleName` and `CFBundleDisplayName` are both **`Owletto`** (what users see in Finder, the menu bar, "About").
3. `project.pbxproj` still sets `PRODUCT_BUNDLE_IDENTIFIER = ai.lobu.mac` — `CFBundleIdentifier` in Info.plist resolves to `$(PRODUCT_BUNDLE_IDENTIFIER)` at build time, so the real id lives in the pbxproj build settings. This is the value the URL scheme, Keychain service name, and Sparkle update path all key off.
4. `Info.plist` contains `<key>SUPublicEDKey</key>` so installed apps can still verify Sparkle update signatures.

## Compatibility

Additive only — every existing path-existence check is preserved unchanged. Verified locally against the currently-pinned `packages/web` SHA: all four new assertions pass; flipping any of the four expected values to a renamed variant (`Owletto` scheme, `ai.owletto.mac` bundle id) fails with a clear `::error::` and aborts before `xcodebuild` runs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added validation checks to the macOS release workflow to enforce consistency across build configurations: verifies the expected build scheme is present, app display/name values match, the app bundle identifier is exact, and the update-signing key remains present to ensure signed updates validate correctly.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lobu-ai/lobu/pull/807?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->