### PR TITLE
fix(server): server-side agent must skip device-pinned watcher runs

### DIFF
--- a/packages/server/src/__tests__/integration/watchers/automation-contract.test.ts
+++ b/packages/server/src/__tests__/integration/watchers/automation-contract.test.ts
@@ -200,6 +200,58 @@ describe('watcher automation contract', () => {
     expect(Number(run.window_id)).toBe(completion.window_id);
   });
 
+  it('skips watcher runs pinned to a device worker (#802)', async () => {
+    const { sql, dbClient, workspace, watcherId, agent } = await createAutomatedWatcher();
+
+    const granularity = inferWatcherGranularityFromSchedule('0 9 * * *');
+    const { windowStart, windowEnd } = await computePendingWindow(dbClient, watcherId, granularity);
+    const queued = await createWatcherRun({
+      organizationId: workspace.org.id,
+      watcherId,
+      agentId: agent.agentId,
+      windowStart: windowStart.toISOString(),
+      windowEnd: windowEnd.toISOString(),
+      dispatchSource: 'scheduled',
+    });
+
+    // Pin the run to a device worker — the dispatcher in #798 will set this
+    // when the watcher is bound to a Mac/CLI device. Until that lands the
+    // server-side claim path must already refuse to grab the row.
+    await sql`
+      UPDATE runs
+      SET approved_input = approved_input || ${sql.json({ device_worker_id: 'mac-device-abc' })}
+      WHERE id = ${queued.runId}
+    `;
+
+    const result = await dispatchPendingWatcherRuns({} as Env, { db: dbClient });
+
+    expect(result.claimed).toBe(0);
+    expect(result.dispatched).toBe(0);
+
+    const [run] = await sql`
+      SELECT status, claimed_by, claimed_at
+      FROM runs
+      WHERE id = ${queued.runId}
+    `;
+    expect(String(run.status)).toBe('pending');
+    expect(run.claimed_by).toBeNull();
+    expect(run.claimed_at).toBeNull();
+
+    // Explicit runIds path must also refuse to claim — the dispatcher's
+    // queueAndDispatchWatcherRun helper hits this branch when a watcher run
+    // is manually triggered.
+    const targeted = await dispatchPendingWatcherRuns({} as Env, {
+      db: dbClient,
+      runIds: [queued.runId],
+    });
+    expect(targeted.claimed).toBe(0);
+
+    const [stillPending] = await sql`
+      SELECT status FROM runs WHERE id = ${queued.runId}
+    `;
+    expect(String(stillPending.status)).toBe('pending');
+  });
+
   it('paginates watcher reads by cursor and completes from multiple page tokens', async () => {
     const { sql, workspace, api, entityId, watcherId } = await createAutomatedWatcher();
 

--- a/packages/server/src/watchers/automation.ts
+++ b/packages/server/src/watchers/automation.ts
@@ -576,12 +576,23 @@ async function claimWatcherRun(
 ): Promise<ClaimedWatcherRunRow | null> {
   return sql.begin(async (tx) => {
     const specificRunClause = runId ? tx`AND r.id = ${runId}` : tx``;
+    // Skip runs pinned to a device worker (#802): the user's Mac (or other
+    // device) will claim these via /api/workers/poll. Without this filter the
+    // server-side dispatcher races the device worker for the same row — the
+    // exact failure mode that caused the watcher-run silent-success bug.
+    // The pin currently lives in approved_input JSONB (issue #799 will add a
+    // proper column); both shapes are guarded here so the filter survives
+    // either schema.
     const claimed = await tx`
       WITH next_run AS (
         SELECT r.id
         FROM runs r
         WHERE r.run_type = 'watcher'
           AND r.status = 'pending'
+          AND (
+            r.approved_input->>'device_worker_id' IS NULL
+            OR r.approved_input->>'device_worker_id' = ''
+          )
           ${specificRunClause}
         ORDER BY r.created_at ASC
         FOR UPDATE SKIP LOCKED


### PR DESCRIPTION
## Summary

Closes #802. Prereq for #798.

`claimWatcherRun` in `packages/server/src/watchers/automation.ts` previously grabbed every pending `run_type='watcher'` row, ignoring whether the run was pinned to a specific device worker. Once the dispatcher in #798 starts setting `approved_input.device_worker_id`, the user's Mac (polling `/api/workers/poll`, which already honors device pinning) will race the in-process server-side agent for the same row.

This is the exact failure mode behind the historical *"owletto-worker daemon claims run_type='watcher' and silently marks success"* bug — different surface, same shape (two claimants on one row, one of them eats it without doing the work).

## Change

Add a JSONB-level guard inside the `WITH next_run AS (...)` CTE so the server-side dispatcher's `FOR UPDATE SKIP LOCKED` selection ignores any run whose `approved_input->>'device_worker_id'` is non-null and non-empty. The pin lives in `approved_input` JSONB for now; issue #799 will add a proper column, at which point this guard plus a column predicate is a single-line follow-up.

No schema change. `/api/workers/poll` is untouched (already has device pinning).

## Test plan

- [x] New test in `automation-contract.test.ts`: a watcher run with `approved_input.device_worker_id = 'mac-device-abc'` stays in `pending` (with `claimed_by`/`claimed_at` still NULL) after both the global `dispatchPendingWatcherRuns({} as Env, { db })` scan AND the explicit `runIds: [queued.runId]` branch.
- [x] `make typecheck` — clean for my files; the only failure is the pre-existing `@electric-sql/pglite-postgis` module-not-found in `pglite-backend.ts`, which exists on `origin/main` unchanged.
- [ ] Integration test run gated on Postgres in CI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved watcher run scheduling to prevent race conditions when runs are assigned to device workers, ensuring proper coordination between dispatcher and device worker assignments.

* **Tests**
  * Added test coverage for scheduled watcher runs pinned to device workers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lobu-ai/lobu/pull/808?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->