### PR TITLE
fix(server): scheduled-jobs embedded patch — make idempotent + fix FK ordering

### DIFF
--- a/packages/server/src/__tests__/integration/embedded-schema-patches.test.ts
+++ b/packages/server/src/__tests__/integration/embedded-schema-patches.test.ts
@@ -1,0 +1,75 @@
+/**
+ * Regression test for the `scheduled-jobs` embedded schema patch.
+ *
+ * Issue lobu#787: on a real PGlite restart, the patch tries to re-add the
+ * single-column FK `scheduled_jobs_agent_fkey → agents(id)` even though the
+ * earlier `agents-per-org-pk-phase-c` patch has already swapped `agents` PK
+ * to the composite `(organization_id, id)` and replaced this FK with
+ * `scheduled_jobs_org_agent_fkey`. The second boot crashes with 42830
+ * ("there is no unique constraint matching given keys for referenced table").
+ *
+ * This test mirrors the boot sequence: migrations run (via the global setup),
+ * then EMBEDDED_SCHEMA_PATCHES run twice in a row against the same DB. The
+ * second pass must be a no-op — no crash, no constraint drift.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { EMBEDDED_SCHEMA_PATCHES } from '../../db/embedded-schema-patches';
+import { cleanupTestDatabase, getTestDb } from '../setup/test-db';
+
+describe('embedded schema patches', () => {
+  it('are idempotent across two consecutive boots (regression: lobu#787)', async () => {
+    await cleanupTestDatabase();
+    const sql = getTestDb();
+
+    // Migrations have already run via global-setup. The dbmate runner mirrors
+    // the patch DDL, so the constraint landscape post-migration matches what
+    // a long-lived embedded DB looks like after the first boot.
+
+    // Sanity: after migrations, agents PK is composite (org, id) and
+    // scheduled_jobs has the composite FK, not the single-column one.
+    const constraintsBefore = (await sql.unsafe(`
+      SELECT conname FROM pg_constraint
+      WHERE conname IN ('scheduled_jobs_agent_fkey', 'scheduled_jobs_org_agent_fkey')
+    `)) as Array<{ conname: string }>;
+    const namesBefore = new Set(constraintsBefore.map((r) => r.conname));
+    expect(namesBefore.has('scheduled_jobs_org_agent_fkey')).toBe(true);
+    expect(namesBefore.has('scheduled_jobs_agent_fkey')).toBe(false);
+
+    // First post-migration run of embedded patches. With the fix, the
+    // scheduled-jobs patch detects the composite FK is already installed and
+    // skips re-adding the single-column FK.
+    for (const patch of EMBEDDED_SCHEMA_PATCHES) {
+      await patch.apply(sql as unknown as { unsafe: (...a: unknown[]) => Promise<unknown> });
+    }
+
+    // Second run — simulates a server restart against the same DB. This is
+    // the path that crashes before the fix.
+    for (const patch of EMBEDDED_SCHEMA_PATCHES) {
+      await patch.apply(sql as unknown as { unsafe: (...a: unknown[]) => Promise<unknown> });
+    }
+
+    // Post-condition: composite FK still in place, single-column FK absent,
+    // and agents PK is still the composite.
+    const constraintsAfter = (await sql.unsafe(`
+      SELECT conname FROM pg_constraint
+      WHERE conname IN ('scheduled_jobs_agent_fkey', 'scheduled_jobs_org_agent_fkey')
+    `)) as Array<{ conname: string }>;
+    const namesAfter = new Set(constraintsAfter.map((r) => r.conname));
+    expect(namesAfter.has('scheduled_jobs_org_agent_fkey')).toBe(true);
+    expect(namesAfter.has('scheduled_jobs_agent_fkey')).toBe(false);
+
+    const pkDef = (await sql.unsafe(`
+      SELECT pg_get_constraintdef(c.oid) AS def
+      FROM pg_constraint c
+      JOIN pg_class t ON t.oid = c.conrelid
+      JOIN pg_namespace n ON n.oid = t.relnamespace
+      WHERE n.nspname = 'public'
+        AND t.relname = 'agents'
+        AND c.contype = 'p'
+      LIMIT 1
+    `)) as Array<{ def: string }>;
+    expect(pkDef[0]?.def ?? '').toMatch(/organization_id/);
+    expect(pkDef[0]?.def ?? '').toMatch(/\bid\b/);
+  });
+});

--- a/packages/server/src/db/embedded-schema-patches.ts
+++ b/packages/server/src/db/embedded-schema-patches.ts
@@ -464,15 +464,46 @@ export const EMBEDDED_SCHEMA_PATCHES: EmbeddedSchemaPatch[] = [
           )
         )
       `);
+      // Add the single-column FK only when `agents.id` still has a unique
+      // constraint to reference. The later `agents-per-org-pk-phase-c` patch
+      // swaps the PK to composite `(organization_id, id)` and installs
+      // `scheduled_jobs_org_agent_fkey` in place of this one — after that
+      // swap, re-adding the single-column FK fails with 42830 ("no unique
+      // constraint matching given keys for referenced table"). Skip when the
+      // composite FK is already present *or* when no single-column unique
+      // exists on agents(id). Issue lobu#787.
       await sql.unsafe(`
         DO $$
         BEGIN
-          IF EXISTS (SELECT 1 FROM pg_class WHERE relname = 'agents' AND relkind = 'r')
-             AND NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'scheduled_jobs_agent_fkey') THEN
-            ALTER TABLE public.scheduled_jobs
-              ADD CONSTRAINT scheduled_jobs_agent_fkey
-              FOREIGN KEY (created_by_agent) REFERENCES public.agents(id) ON DELETE CASCADE;
+          IF NOT EXISTS (SELECT 1 FROM pg_class WHERE relname = 'agents' AND relkind = 'r') THEN
+            RETURN;
           END IF;
+          IF EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'scheduled_jobs_agent_fkey') THEN
+            RETURN;
+          END IF;
+          IF EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'scheduled_jobs_org_agent_fkey') THEN
+            -- Composite FK already installed by the later phase-c patch.
+            RETURN;
+          END IF;
+          -- Confirm a single-column unique/PK exists on agents(id) before
+          -- referencing it; otherwise the ADD CONSTRAINT will crash with 42830.
+          IF NOT EXISTS (
+            SELECT 1
+            FROM pg_constraint c
+            JOIN pg_class t ON t.oid = c.conrelid
+            JOIN pg_namespace n ON n.oid = t.relnamespace
+            JOIN pg_attribute a ON a.attrelid = c.conrelid AND a.attnum = ANY (c.conkey)
+            WHERE n.nspname = 'public'
+              AND t.relname = 'agents'
+              AND c.contype IN ('p', 'u')
+              AND array_length(c.conkey, 1) = 1
+              AND a.attname = 'id'
+          ) THEN
+            RETURN;
+          END IF;
+          ALTER TABLE public.scheduled_jobs
+            ADD CONSTRAINT scheduled_jobs_agent_fkey
+            FOREIGN KEY (created_by_agent) REFERENCES public.agents(id) ON DELETE CASCADE;
         END$$;
       `);
       await sql.unsafe(`


### PR DESCRIPTION
Fixes #787.

## Root cause

The `scheduled-jobs` embedded schema patch unconditionally re-adds the single-column FK `scheduled_jobs_agent_fkey → agents(id)` whenever the constraint is missing. That works on the *first* boot, but the later `agents-per-org-pk-phase-c` patch runs in the same boot and:

1. drops `scheduled_jobs_agent_fkey`,
2. swaps `agents` PK from `(id)` to composite `(organization_id, id)`,
3. installs `scheduled_jobs_org_agent_fkey` referencing the composite key.

After step 2, `agents.id` no longer has a single-column unique constraint — so on the **second** boot the `scheduled-jobs` patch finds the named constraint absent, tries to re-add it, and Postgres rejects with `42830`:

```
PostgresError: there is no unique constraint matching given keys for referenced table "agents"
  SQL: ALTER TABLE public.scheduled_jobs
       ADD CONSTRAINT scheduled_jobs_agent_fkey
       FOREIGN KEY (created_by_agent) REFERENCES public.agents(id) ON DELETE CASCADE
  code: 42830
```

…blocking every subsequent restart of any embedded/PGlite install. The workaround so far has been `rm -rf ~/lobu/data` between restarts — destructive.

## Fix

Tighten the patch's idempotency guard inside the existing `DO $$ ... END $$` block. Skip the FK creation when:

- `scheduled_jobs_agent_fkey` already exists (unchanged), **or**
- the composite FK `scheduled_jobs_org_agent_fkey` is already installed (the phase-c output), **or**
- there is no single-column unique/PK on `agents(id)` to reference.

All three checks are read-only `pg_constraint` lookups; the patch stays one statement and a fresh-boot apply (PK on bare `id` still present) is unchanged.

The original Postgres dbmate migration is **not** modified — it runs once at install time and the bug never reproduces there. Only the embedded mirror needed the extra guard, because it replays on every boot.

## Regression test

`packages/server/src/__tests__/integration/embedded-schema-patches.test.ts` runs all `EMBEDDED_SCHEMA_PATCHES` twice in a row against the same PGlite backend (exactly the restart sequence from the bug report) and asserts:

- the composite FK `scheduled_jobs_org_agent_fkey` survives both passes;
- the single-column FK `scheduled_jobs_agent_fkey` does **not** get re-added;
- `agents` keeps its composite PK `(organization_id, id)`.

Verified the test reproduces the bug on `main` (fails with the exact `42830` from the issue) and passes with the fix.

## Local test procedure

```bash
# Reproduce the issue's symptom path:
LOBU_TEST_BACKEND=pglite bunx vitest run \
  --config packages/server/vitest.config.ts \
  src/__tests__/integration/embedded-schema-patches.test.ts

# Validate
make typecheck       # clean
make build-packages  # clean
```

## Test plan

- [x] Regression test in `embedded-schema-patches.test.ts` passes (was failing before the fix with the exact issue error).
- [x] `make typecheck` clean.
- [x] `make build-packages` clean.
- [ ] Reviewer: spot-check that the `pg_constraint` guard correctly tracks both code paths (fresh install → `agents(id)` PK present → FK added; second boot → composite FK present → patch no-ops).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added regression test ensuring database schema updates remain idempotent when applied consecutively.

* **Bug Fixes**
  * Improved robustness of database schema updates through enhanced constraint validation and early-return safeguards.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lobu-ai/lobu/pull/809?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->