### PR TITLE
fix(server): project device_worker_id + goal_id on watcher list endpoint

### DIFF
--- a/packages/server/src/tools/admin/manage_watchers.ts
+++ b/packages/server/src/tools/admin/manage_watchers.ts
@@ -2363,6 +2363,8 @@ async function handleList(
       i.schedule,
       i.next_run_at,
       i.agent_id,
+      i.goal_id,
+      i.device_worker_id,
       i.scheduler_client_id,
       i.model_config,
       i.sources,

--- a/packages/server/src/tools/get_watchers.ts
+++ b/packages/server/src/tools/get_watchers.ts
@@ -203,6 +203,7 @@ interface WatcherQueryRow {
   next_run_at: string | null;
   agent_id: string | null;
   goal_id: number | null;
+  device_worker_id: string | null;
   scheduler_client_id: string | null;
   version: number;
   current_version_id: number | null;
@@ -549,6 +550,7 @@ export async function getWatcher(
         i.next_run_at,
         i.agent_id,
         i.goal_id,
+        i.device_worker_id,
         i.scheduler_client_id,
         i.version,
         i.current_version_id,
@@ -811,6 +813,7 @@ export async function getWatcher(
       next_run_at: watcherRow.next_run_at,
       agent_id: watcherRow.agent_id,
       goal_id: watcherRow.goal_id ?? null,
+      device_worker_id: watcherRow.device_worker_id ?? null,
       scheduler_client_id: watcherRow.scheduler_client_id,
       version: pinnedVersion,
       sources: watcherSources,

--- a/packages/server/src/types/watchers.ts
+++ b/packages/server/src/types/watchers.ts
@@ -133,6 +133,11 @@ export interface WatcherMetadata {
    * "ungrouped" — historical behavior. See manage_goals + #800.
    */
   goal_id?: number | null;
+  /**
+   * Optional FK into `device_workers.id` pinning this watcher (and its run)
+   * to a specific device worker. NULL/undefined means any worker can claim.
+   */
+  device_worker_id?: string | null;
   scheduler_client_id?: string | null;
   version: number;
   sources: WatcherSource[];


### PR DESCRIPTION
## Summary

`list_watchers` (powering `GET /api/:orgSlug/watchers`) didn't include `device_worker_id` or `goal_id` in its projection, so clients filtering on those fields treated every watcher as unpinned / ungrouped. `get_watcher` already projected `goal_id` but missed `device_worker_id`, and the `WatcherMetadata` type was missing both at the type level.

- `handleList` (admin/manage_watchers.ts): add `i.goal_id`, `i.device_worker_id` to the SELECT — these flow through `...rest` into the response untouched.
- `getWatcher` (tools/get_watchers.ts): add `i.device_worker_id` to the SELECT, include it in the returned watcher metadata (`device_worker_id: watcherRow.device_worker_id ?? null`), and add it to the `WatcherQueryRow` row type.
- `WatcherMetadata` (types/watchers.ts): declare `device_worker_id?: string | null`.

No semantic / auth changes. Both columns are already writeable via `manage_watchers` create/update — this just round-trips them on read.

Unblocks Owletto PR #146 (menubar canvas, issue #801) whose strict-UUID filter on `device_worker_id` was hiding every watcher.

## Test plan

- [x] `make build-packages` (server + bundle + cli)
- [x] `cd packages/server && bunx tsc --noEmit` clean (only pre-existing `@electric-sql/pglite-postgis` test-setup error remains, unrelated)
- [ ] Hit `GET /api/<orgSlug>/watchers` against a local instance and confirm `device_worker_id` + `goal_id` appear on every row
- [ ] Hit `GET /api/<orgSlug>/watchers?watcher_id=<id>` and confirm `device_worker_id` appears in the returned `watcher` metadata