### PR TITLE
fix(goals): emit lifecycle event on update (#815)

### DIFF
--- a/packages/server/src/tools/admin/manage_goals.ts
+++ b/packages/server/src/tools/admin/manage_goals.ts
@@ -336,7 +336,18 @@ async function handleUpdate(
     throw new Error(`Goal ${existing.id} not found`);
   }
 
-  return { action: 'update', goal: mapGoalRow(updated[0] as Record<string, unknown>) };
+  const goal = mapGoalRow(updated[0] as Record<string, unknown>);
+
+  recordLifecycleEvent({
+    organizationId: ctx.organizationId!,
+    entityType: 'goal',
+    op: 'updated',
+    entityId: goal.id,
+    summary: `Goal '${goal.name}' updated`,
+    createdBy: ctx.userId,
+  });
+
+  return { action: 'update', goal };
 }
 
 async function handleGet(


### PR DESCRIPTION
Closes #815.

The `update` action in `manage_goals` was the only mutating handler not emitting a lifecycle event — `create`, `archive`, and `delete` all call `recordLifecycleEvent`, but `update` silently committed and returned. This left goal edits invisible to events-sourced dashboard stats and audit trails.

Add a `recordLifecycleEvent({ entityType: 'goal', op: 'updated', ... })` call after the `UPDATE` returns, matching the shape of the existing `create`/`archive`/`delete` calls in the same file.

## Test plan

- [x] `make build-packages` — clean
- [x] Pre-commit `tsc --noEmit` — clean
- [ ] Manual: call `manage_goals` with `action: 'update'`, confirm a `goal:updated` row appears in `events`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Goal updates are now properly logged with complete audit information including organization details, entity identifiers, summaries, and creator attribution.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lobu-ai/lobu/pull/818?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->