### PR TITLE
feat(browser-bridge): SPIKE — playwriter-backed CDP relay for user's real Chrome

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -42,6 +42,23 @@
         "bun": ">=1.0.0",
       },
     },
+    "packages/browser-bridge": {
+      "name": "@lobu/browser-bridge",
+      "version": "0.0.0",
+      "dependencies": {
+        "playwriter": "0.1.0",
+      },
+      "devDependencies": {
+        "@types/node": "20.19.9",
+        "typescript": "^5.7.2",
+      },
+      "peerDependencies": {
+        "playwright": "npm:patchright@^1.57.0",
+      },
+      "optionalPeers": [
+        "playwright",
+      ],
+    },
     "packages/cli": {
       "name": "@lobu/cli",
       "version": "7.0.0",
@@ -782,6 +799,8 @@
 
     "@hono/node-server": ["@hono/node-server@1.19.14", "", { "peerDependencies": { "hono": "^4" } }, "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw=="],
 
+    "@hono/node-ws": ["@hono/node-ws@1.3.1", "", { "dependencies": { "ws": "^8.17.0" }, "peerDependencies": { "@hono/node-server": "^1.19.11", "hono": "^4.6.0" } }, "sha512-vo/MwCnpJAVHBkGzWjCJ28wF45fYHAfbPZcH2rodZODHtch2GHA94KtMfusmVycTUtsLAsaNsHhtY6P8X3RQsA=="],
+
     "@hono/zod-openapi": ["@hono/zod-openapi@1.3.0", "", { "dependencies": { "@asteasolutions/zod-to-openapi": "^8.5.0", "@hono/zod-validator": "^0.7.6", "openapi3-ts": "^4.5.0" }, "peerDependencies": { "hono": ">=4.3.6", "zod": "^4.0.0" } }, "sha512-loDVevfMaaNa0slskhpMcqjSdidVXba2QJwNVmnS5Dp6L8AqSgtjJxWGJfRZtosyzYOb5gx4ZzXNCe+QhwY7xw=="],
 
     "@hono/zod-validator": ["@hono/zod-validator@0.7.6", "", { "peerDependencies": { "hono": ">=3.9.0", "zod": "^3.25.0 || ^4.0.0" } }, "sha512-Io1B6d011Gj1KknV4rXYz4le5+5EubcWEU/speUjuw9XMMIaP3n78yXLhjd2A3PXaXaUwEAluOiAyLqhBEJgsw=="],
@@ -992,6 +1011,8 @@
 
     "@lezer/lr": ["@lezer/lr@1.4.10", "", { "dependencies": { "@lezer/common": "^1.0.0" } }, "sha512-rnCpTIBafOx4mRp43xOxDJbFipJm/c0cia/V5TiGlhmMa+wsSdoGmUN3w5Bqrks/09Q/D4tNAmWaT8p6NRi77A=="],
 
+    "@lobu/browser-bridge": ["@lobu/browser-bridge@workspace:packages/browser-bridge"],
+
     "@lobu/cli": ["@lobu/cli@workspace:packages/cli"],
 
     "@lobu/connector-sdk": ["@lobu/connector-sdk@workspace:packages/connector-sdk"],
@@ -1013,6 +1034,8 @@
     "@lobu/server": ["@lobu/server@workspace:packages/server"],
 
     "@lobu/worker": ["@lobu/worker@workspace:packages/agent-worker"],
+
+    "@lowire/loop": ["@lowire/loop@0.0.25", "", {}, "sha512-tBfQ3+m+BelMSRqmdpOqLQPervF6PoS4IV0JE0ga1fJnOaPRnOfjkGecyaR45Hp7VuhY9oBQdVlDkAXoOkjk1w=="],
 
     "@marijn/find-cluster-break": ["@marijn/find-cluster-break@1.0.2", "", {}, "sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g=="],
 
@@ -1087,6 +1110,8 @@
     "@nodelib/fs.stat": ["@nodelib/fs.stat@2.0.5", "", {}, "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A=="],
 
     "@nodelib/fs.walk": ["@nodelib/fs.walk@1.2.8", "", { "dependencies": { "@nodelib/fs.scandir": "2.1.5", "fastq": "^1.6.0" } }, "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg=="],
+
+    "@one-ini/wasm": ["@one-ini/wasm@0.1.1", "", {}, "sha512-XuySG1E38YScSJoMlqovLru4KTUNSjgVTIjyh7qMX6aNN5HY5Ct5LhRJdxO79JtTzKfzV/bnWpz+zquYrISsvw=="],
 
     "@open-draft/deferred-promise": ["@open-draft/deferred-promise@3.0.0", "", {}, "sha512-XW375UK8/9SqUVNVa6M0yEy8+iTi4QN5VZ7aZuRFQmy76LRwI9wy5F4YIBU6T+eTe2/DNDo8tqu8RHlwLHM6RA=="],
 
@@ -1902,6 +1927,10 @@
 
     "@xenova/transformers": ["@xenova/transformers@2.17.2", "", { "dependencies": { "@huggingface/jinja": "^0.2.2", "onnxruntime-web": "1.14.0", "sharp": "^0.32.0" }, "optionalDependencies": { "onnxruntime-node": "1.14.0" } }, "sha512-lZmHqzrVIkSvZdKZEx7IYY51TK0WDrC8eR0c5IMnBsO8di8are1zzw8BlLhyO2TklZKLN5UffNGs1IJwT6oOqQ=="],
 
+    "@xmorse/playwright-core": ["@xmorse/playwright-core@1.59.10", "", { "dependencies": { "@lowire/loop": "^0.0.25", "@modelcontextprotocol/sdk": "^1.29.0", "colors": "1.4.0", "commander": "^13.0.0", "debug": "^4.3.4", "diff": "^7.0.0", "dotenv": "^16.4.5", "get-stream": "^5.2.0", "graceful-fs": "^4.2.11", "https-proxy-agent": "7.0.6", "jpeg-js": "0.4.4", "mime": "^3.0.0", "minimatch": "^3.1.2", "open": "8.4.0", "pngjs": "6.0.0", "progress": "2.0.3", "proxy-from-env": "1.1.0", "retry": "^0.13.1", "signal-exit": "^4.1.0", "socks-proxy-agent": "8.0.5", "ws": "8.17.1", "yaml": "^2.6.0", "yauzl": "3.2.0", "yazl": "2.5.1", "zod": "^4.3.5", "zod-to-json-schema": "^3.25.1" }, "bin": { "playwright-core": "cli.js" } }, "sha512-3elxXCCodJHm1slVBfiIxrqqFIZsNZhx4kVYIxe53u9+VlqguM4LozWgRfekPumrQEvAInLH0IdFZWSTiYHniQ=="],
+
+    "abbrev": ["abbrev@2.0.0", "", {}, "sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ=="],
+
     "accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
 
     "acorn": ["acorn@8.16.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw=="],
@@ -1963,6 +1992,8 @@
     "async": ["async@3.2.6", "", {}, "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA=="],
 
     "async-mutex": ["async-mutex@0.5.0", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-1A94B18jkJ3DYq284ohPxoXbfTA5HsQ7/Mf4DEhcyLx3Bz27Rh59iScbB6EPiP+B+joue6YCxcMXSbFC1tZKwA=="],
+
+    "async-sema": ["async-sema@3.1.1", "", {}, "sha512-tLRNUXati5MFePdAk8dw7Qt7DpxPB60ofAgn8WRhW6a2rcimZnYBP9oxHiv0OHy+Wz7kPMG+t4LGdt31+4EmGg=="],
 
     "asynckit": ["asynckit@0.4.0", "", {}, "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="],
 
@@ -2045,6 +2076,8 @@
     "browserslist": ["browserslist@4.28.2", "", { "dependencies": { "baseline-browser-mapping": "^2.10.12", "caniuse-lite": "^1.0.30001782", "electron-to-chromium": "^1.5.328", "node-releases": "^2.0.36", "update-browserslist-db": "^1.2.3" }, "bin": { "browserslist": "cli.js" } }, "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg=="],
 
     "buffer": ["buffer@5.7.1", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.1.13" } }, "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ=="],
+
+    "buffer-crc32": ["buffer-crc32@0.2.13", "", {}, "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ=="],
 
     "buffer-equal-constant-time": ["buffer-equal-constant-time@1.0.1", "", {}, "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="],
 
@@ -2139,6 +2172,10 @@
     "commander": ["commander@14.0.3", "", {}, "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw=="],
 
     "common-ancestor-path": ["common-ancestor-path@2.0.0", "", {}, "sha512-dnN3ibLeoRf2HNC+OlCiNc5d2zxbLJXOtiZUudNFSXZrNSydxcCsSpRzXwfu7BBWCIfHPw+xTayeBvJCP/D8Ng=="],
+
+    "concat-map": ["concat-map@0.0.1", "", {}, "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="],
+
+    "config-chain": ["config-chain@1.1.13", "", { "dependencies": { "ini": "^1.3.4", "proto-list": "~1.2.1" } }, "sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ=="],
 
     "constantinople": ["constantinople@4.0.1", "", { "dependencies": { "@babel/parser": "^7.6.0", "@babel/types": "^7.6.1" } }, "sha512-vCrqcSIq4//Gx74TXXCGnHpulY1dskqLTFGDmhrGxzeXL8lF8kvXv6mpNWlJj1uD4DW23D4ljAqbY4RRaaUZIw=="],
 
@@ -2250,7 +2287,7 @@
 
     "doctypes": ["doctypes@1.1.0", "", {}, "sha512-LLBi6pEqS6Do3EKQ3J0NqHWV5hhb78Pi8vvESYwyOy2c31ZEZVdtitdzsQsKb7878PEERhzUk0ftqGhG6Mz+pQ=="],
 
-    "dom-accessibility-api": ["dom-accessibility-api@0.6.3", "", {}, "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w=="],
+    "dom-accessibility-api": ["dom-accessibility-api@0.7.1", "", {}, "sha512-vdnCeZD+3wZ+8h8xXL/ZtBlvvoobOFyPzSiIfO6sGOZDqjFx4aLMAjZhl4rawj5xYz3UwP6Tgvyh0iH4IOCVnQ=="],
 
     "dom-serializer": ["dom-serializer@2.0.0", "", { "dependencies": { "domelementtype": "^2.3.0", "domhandler": "^5.0.2", "entities": "^4.2.0" } }, "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg=="],
 
@@ -2271,6 +2308,8 @@
     "ecdsa-sig-formatter": ["ecdsa-sig-formatter@1.0.11", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ=="],
 
     "echarts": ["echarts@5.6.0", "", { "dependencies": { "tslib": "2.3.0", "zrender": "5.6.1" } }, "sha512-oTbVTsXfKuEhxftHqL5xprgLoc0k7uScAwtryCgWF6hPYFLRwOUHiFmHGCBKP5NPFNkDVopOieyUqYGH8Fa3kA=="],
+
+    "editorconfig": ["editorconfig@1.0.7", "", { "dependencies": { "@one-ini/wasm": "0.1.1", "commander": "^10.0.0", "minimatch": "^9.0.1", "semver": "^7.5.3" }, "bin": { "editorconfig": "bin/editorconfig" } }, "sha512-e0GOtq/aTQhVdNyDU9e02+wz9oDDM+SIOQxWME2QRjzRX5yyLAuHDE+0aE8vHb9XRC8XD37eO2u57+F09JqFhw=="],
 
     "ee-first": ["ee-first@1.1.1", "", {}, "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="],
 
@@ -2470,6 +2509,8 @@
 
     "glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 
+    "goke": ["goke@6.12.1", "", {}, "sha512-wQcxJ/VXcFEgQV/vjGu5YSJrPzzi7UDhW4lzCZ+a79PaGthWU11PFBZCXQ2dJlCJuT3Qh3bV9gnzHs0abf9+bw=="],
+
     "goober": ["goober@2.1.18", "", { "peerDependencies": { "csstype": "^3.0.10" } }, "sha512-2vFqsaDVIT9Gz7N6kAL++pLpp41l3PfDuusHcjnGLfR6+huZkl6ziX+zgVC3ZxpqWhzH6pyDdGrCeDhMIvwaxw=="],
 
     "google-auth-library": ["google-auth-library@10.6.2", "", { "dependencies": { "base64-js": "^1.3.0", "ecdsa-sig-formatter": "^1.0.11", "gaxios": "^7.1.4", "gcp-metadata": "8.1.2", "google-logging-utils": "1.1.3", "jws": "^4.0.0" } }, "sha512-e27Z6EThmVNNvtYASwQxose/G57rkRuaRbQyxM2bvYLLX/GqWZ5chWq2EBoUchJbCc57eC9ArzO5wMsEmWftCw=="],
@@ -2640,6 +2681,8 @@
 
     "is-interactive": ["is-interactive@2.0.0", "", {}, "sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ=="],
 
+    "is-json": ["is-json@2.0.1", "", {}, "sha512-6BEnpVn1rcf3ngfmViLM6vjUjGErbdrL4rwlv+u1NO1XO8kqT4YGL8+19Q+Z/bas8tY90BTWMk2+fW1g6hQjbA=="],
+
     "is-node-process": ["is-node-process@1.2.0", "", {}, "sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw=="],
 
     "is-number": ["is-number@7.0.0", "", {}, "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="],
@@ -2683,6 +2726,10 @@
     "jose": ["jose@6.2.2", "", {}, "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ=="],
 
     "jpeg-js": ["jpeg-js@0.4.4", "", {}, "sha512-WZzeDOEtTOBK4Mdsar0IqEU5sMr3vSV2RqkAIzUEV2BHnUfKGyswWFPFwK5EeDo93K3FohSHbLAjj0s1Wzd+dg=="],
+
+    "js-beautify": ["js-beautify@1.15.4", "", { "dependencies": { "config-chain": "^1.1.13", "editorconfig": "^1.0.4", "glob": "^10.4.2", "js-cookie": "^3.0.5", "nopt": "^7.2.1" }, "bin": { "css-beautify": "js/bin/css-beautify.js", "html-beautify": "js/bin/html-beautify.js", "js-beautify": "js/bin/js-beautify.js" } }, "sha512-9/KXeZUKKJwqCXUdBxFJ3vPh467OCckSBmYDwSK/EtV090K+iMJ7zx2S3HLVDIWFQdqMIsZWbnaGiba18aWhaA=="],
+
+    "js-cookie": ["js-cookie@3.0.7", "", {}, "sha512-z/wZZgDrkNV1eA0ULjM/F9/50Ya8fbzgKneSpoPsXSGd0KnpdtHfOZWK+GcwLk+EZbS4F9RBhU+K2RgzuDaItw=="],
 
     "js-stringify": ["js-stringify@1.0.2", "", {}, "sha512-rtS5ATOo2Q5k1G+DADISilDA6lv79zIiwFd6CcjuIxGKLFm5C+RLImRscVap9k55i+MOZwgliw+NejvkLuGD5g=="],
 
@@ -3042,6 +3089,8 @@
 
     "node-sql-parser": ["node-sql-parser@5.4.0", "", { "dependencies": { "@types/pegjs": "^0.10.0", "big-integer": "^1.6.48" } }, "sha512-jVe6Z61gPcPjCElPZ6j8llB3wnqGcuQzefim1ERsqIakxnEy5JlzV7XKdO1KmacRG5TKwPc4vJTgSRQ0LfkbFw=="],
 
+    "nopt": ["nopt@7.2.1", "", { "dependencies": { "abbrev": "^2.0.0" }, "bin": { "nopt": "bin/nopt.js" } }, "sha512-taM24ViiimT/XntxbPyJQzCG+p4EKOpgD3mxFwW38mGjVUrfERQOeY4EDHjdnptttfHuHQXFx+lTP08Q+mLa/w=="],
+
     "normalize-path": ["normalize-path@3.0.0", "", {}, "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="],
 
     "npm-run-path": ["npm-run-path@4.0.1", "", { "dependencies": { "path-key": "^3.0.0" } }, "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw=="],
@@ -3156,6 +3205,8 @@
 
     "peberminta": ["peberminta@0.9.0", "", {}, "sha512-XIxfHpEuSJbITd1H3EeQwpcZbTLHc+VVr8ANI9t5sit565tsI4/xK3KWTUFE2e6QiangUkh3B0jihzmGnNrRsQ=="],
 
+    "pend": ["pend@1.2.0", "", {}, "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg=="],
+
     "pg": ["pg@8.20.0", "", { "dependencies": { "pg-connection-string": "^2.12.0", "pg-pool": "^3.13.0", "pg-protocol": "^1.13.0", "pg-types": "2.2.0", "pgpass": "1.0.5" }, "optionalDependencies": { "pg-cloudflare": "^1.3.0" }, "peerDependencies": { "pg-native": ">=3.0.1" }, "optionalPeers": ["pg-native"] }, "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA=="],
 
     "pg-cloudflare": ["pg-cloudflare@1.3.0", "", {}, "sha512-6lswVVSztmHiRtD6I8hw4qP/nDm1EJbKMRhf3HCYaqud7frGysPv7FYJ5noZQdhQtN2xJnimfMtvQq21pdbzyQ=="],
@@ -3196,7 +3247,9 @@
 
     "playwright-vanilla": ["playwright@1.60.0", "", { "dependencies": { "playwright-core": "1.60.0" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA=="],
 
-    "pngjs": ["pngjs@7.0.0", "", {}, "sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow=="],
+    "playwriter": ["playwriter@0.1.0", "", { "dependencies": { "@hono/node-server": "^1.19.6", "@hono/node-ws": "^1.2.0", "@modelcontextprotocol/sdk": "^1.29.0", "@xmorse/playwright-core": "^1.59.10", "acorn": "^8.15.0", "async-sema": "^3.1.1", "diff": "^8.0.2", "dom-accessibility-api": "^0.7.1", "goke": "^6.6.0", "hono": "^4.12.12", "picocolors": "^1.1.1", "posthtml": "^0.16.7", "posthtml-beautify": "^0.7.0", "string-dedent": "^3.0.2", "strip-ansi": "^7.1.2", "ws": "^8.18.3", "zod": "^4.3.5", "zustand": "^5.0.8" }, "optionalDependencies": { "sharp": "^0.34.5" }, "bin": { "playwriter": "bin.js" } }, "sha512-+u3hbzuiy09DjZUoUrlbxydWzTqt67QWBefOQzsDgnIaDhHEPUeBZSIz2/jsI/QjqTT5nbcbHRSTB2r1vKDDqQ=="],
+
+    "pngjs": ["pngjs@6.0.0", "", {}, "sha512-TRzzuFRRmEoSW/p1KVAmiOgPco2Irlah+bGFCeNfJXxxYGwSw7YwAOAcd7X28K/m5bjBWKsC29KyoMfHbypayg=="],
 
     "postal-mime": ["postal-mime@2.7.4", "", {}, "sha512-0WdnFQYUrPGGTFu1uOqD2s7omwua8xaeYGdO6rb88oD5yJ/4pPHDA4sdWqfD8wQVfCny563n/HQS7zTFft+f/g=="],
 
@@ -3218,6 +3271,14 @@
 
     "postgres-interval": ["postgres-interval@1.2.0", "", { "dependencies": { "xtend": "^4.0.0" } }, "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ=="],
 
+    "posthtml": ["posthtml@0.16.7", "", { "dependencies": { "posthtml-parser": "^0.11.0", "posthtml-render": "^3.0.0" } }, "sha512-7Hc+IvlQ7hlaIfQFZnxlRl0jnpWq2qwibORBhQYIb0QbNtuicc5ZxvKkVT71HJ4Py1wSZ/3VR1r8LfkCtoCzhw=="],
+
+    "posthtml-beautify": ["posthtml-beautify@0.7.0", "", { "dependencies": { "@babel/runtime": "^7.10.2", "deepmerge": "^4.2.2", "js-beautify": "^1.11.0", "posthtml-parser": "^0.4.2", "posthtml-render": "^1.2.2" } }, "sha512-g9+tYK5Z1WiYHgEOXt3jmVd6ioG5Hk6wVIw8rYVMqzFBeJzELHcxUk0bxTfYYP715Qrrh/xkwHyXrDL+ETKUgQ=="],
+
+    "posthtml-parser": ["posthtml-parser@0.11.0", "", { "dependencies": { "htmlparser2": "^7.1.1" } }, "sha512-QecJtfLekJbWVo/dMAA+OSwY79wpRmbqS5TeXvXSX+f0c6pW4/SE6inzZ2qkU7oAMCPqIDkZDvd/bQsSFUnKyw=="],
+
+    "posthtml-render": ["posthtml-render@3.0.0", "", { "dependencies": { "is-json": "^2.0.1" } }, "sha512-z+16RoxK3fUPgwaIgH9NGnK1HKY9XIDpydky5eQGgAFVXTCSezalv9U2jQuNV+Z9qV1fDWNzldcw4eK0SSbqKA=="],
+
     "preact": ["preact@10.29.1", "", {}, "sha512-gQCLc/vWroE8lIpleXtdJhTFDogTdZG9AjMUpVkDf2iTCNwYNWA+u16dL41TqUDJO4gm2IgrcMv3uTpjd4Pwmg=="],
 
     "preact-render-to-string": ["preact-render-to-string@6.6.7", "", { "peerDependencies": { "preact": ">=10 || >= 11.0.0-0" } }, "sha512-3XdbsX3+vn9dQW+jJI/FsI9rlkgl6dbeUpqLsChak6jp3j3auFqBCkno7VChbMFs5Q8ylBj6DrUkKRwtVN3nvw=="],
@@ -3232,6 +3293,8 @@
 
     "process-warning": ["process-warning@5.0.0", "", {}, "sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA=="],
 
+    "progress": ["progress@2.0.3", "", {}, "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA=="],
+
     "promise": ["promise@7.3.1", "", { "dependencies": { "asap": "~2.0.3" } }, "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg=="],
 
     "prop-types": ["prop-types@15.8.1", "", { "dependencies": { "loose-envify": "^1.4.0", "object-assign": "^4.1.1", "react-is": "^16.13.1" } }, "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg=="],
@@ -3239,6 +3302,8 @@
     "proper-lockfile": ["proper-lockfile@4.1.2", "", { "dependencies": { "graceful-fs": "^4.2.4", "retry": "^0.12.0", "signal-exit": "^3.0.2" } }, "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA=="],
 
     "property-information": ["property-information@7.1.0", "", {}, "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ=="],
+
+    "proto-list": ["proto-list@1.2.4", "", {}, "sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA=="],
 
     "protobufjs": ["protobufjs@7.5.5", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.2", "@protobufjs/base64": "^1.1.2", "@protobufjs/codegen": "^2.0.4", "@protobufjs/eventemitter": "^1.1.0", "@protobufjs/fetch": "^1.1.0", "@protobufjs/float": "^1.0.2", "@protobufjs/inquire": "^1.1.0", "@protobufjs/path": "^1.1.2", "@protobufjs/pool": "^1.1.0", "@protobufjs/utf8": "^1.1.0", "@types/node": ">=13.7.0", "long": "^5.0.0" } }, "sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg=="],
 
@@ -3488,7 +3553,7 @@
 
     "siginfo": ["siginfo@2.0.0", "", {}, "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g=="],
 
-    "signal-exit": ["signal-exit@3.0.7", "", {}, "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="],
+    "signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
 
     "simple-code-frame": ["simple-code-frame@1.3.0", "", { "dependencies": { "kolorist": "^1.6.0" } }, "sha512-MB4pQmETUBlNs62BBeRjIFGeuy/x6gGKh7+eRUemn1rCFhqo7K+4slPqsyizCbcbYLnaYqaoZ2FWsZ/jN06D8w=="],
 
@@ -3555,6 +3620,8 @@
     "streamx": ["streamx@2.25.0", "", { "dependencies": { "events-universal": "^1.0.0", "fast-fifo": "^1.3.2", "text-decoder": "^1.1.0" } }, "sha512-0nQuG6jf1w+wddNEEXCF4nTg3LtufWINB5eFEN+5TNZW7KWJp6x87+JFL43vaAUPyCfH1wID+mNVyW6OHtFamg=="],
 
     "strict-event-emitter": ["strict-event-emitter@0.5.1", "", {}, "sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ=="],
+
+    "string-dedent": ["string-dedent@3.0.2", "", {}, "sha512-M4q+HpHCtGXlbyzYDOcOo7V185dlq6YXvGUPcWZqL4vttCX9gFYoWIOxcPd7v5CAYcTJsGLs3ZJCAH2TXONF/g=="],
 
     "string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
 
@@ -3856,6 +3923,10 @@
 
     "yargs-parser": ["yargs-parser@22.0.0", "", {}, "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw=="],
 
+    "yauzl": ["yauzl@3.2.0", "", { "dependencies": { "buffer-crc32": "~0.2.3", "pend": "~1.2.0" } }, "sha512-Ow9nuGZE+qp1u4JIPvg+uCiUr7xGQWdff7JQSk5VGYTAZMDe2q8lxJ10ygv10qmSj031Ty/6FNJpLO4o1Sgc+w=="],
+
+    "yazl": ["yazl@2.5.1", "", { "dependencies": { "buffer-crc32": "~0.2.3" } }, "sha512-phENi2PLiHnHb6QBVot+dJnaAZ0xosj7p3fWl+znIjBDlnMI2PsZCJZ306BPTFOaHf5qdDEI8x5qFrSOBN5vrw=="],
+
     "yocto-queue": ["yocto-queue@1.2.2", "", {}, "sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ=="],
 
     "yoctocolors": ["yoctocolors@2.1.2", "", {}, "sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug=="],
@@ -3926,8 +3997,6 @@
 
     "@grpc/proto-loader/long": ["long@5.3.2", "", {}, "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA=="],
 
-    "@inquirer/core/signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
-
     "@instantdb/core/uuid": ["uuid@11.1.1", "", { "bin": { "uuid": "dist/esm/bin/uuid" } }, "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ=="],
 
     "@instantdb/react/eventsource": ["eventsource@4.1.0", "", { "dependencies": { "eventsource-parser": "^3.0.1" } }, "sha512-2GuF51iuHX6A9xdTccMTsNb7VO0lHZihApxhvQzJB5A03DvHDd2FQepodbMaztPBmBcE/ox7o2gqaxGhYB9LhQ=="],
@@ -3935,6 +4004,8 @@
     "@isaacs/cliui/string-width": ["string-width@5.1.2", "", { "dependencies": { "eastasianwidth": "^0.2.0", "emoji-regex": "^9.2.2", "strip-ansi": "^7.0.1" } }, "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA=="],
 
     "@isaacs/cliui/wrap-ansi": ["wrap-ansi@8.1.0", "", { "dependencies": { "ansi-styles": "^6.1.0", "string-width": "^5.0.1", "strip-ansi": "^7.0.1" } }, "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ=="],
+
+    "@jimp/js-png/pngjs": ["pngjs@7.0.0", "", {}, "sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow=="],
 
     "@jimp/plugin-blit/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
@@ -4206,6 +4277,8 @@
 
     "@testing-library/dom/dom-accessibility-api": ["dom-accessibility-api@0.5.16", "", {}, "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg=="],
 
+    "@testing-library/jest-dom/dom-accessibility-api": ["dom-accessibility-api@0.6.3", "", {}, "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w=="],
+
     "@triplit/db/nanoid": ["nanoid@5.1.9", "", { "bin": { "nanoid": "bin/nanoid.js" } }, "sha512-ZUvP7KeBLe3OZ1ypw6dI/TzYJuvHP77IM4Ry73waSQTLn8/g8rpdjfyVAh7t1/+FjBtG4lCP42MEbDxOsRpBMw=="],
 
     "@types/pg-pool/@types/pg": ["@types/pg@8.20.0", "", { "dependencies": { "@types/node": "*", "pg-protocol": "*", "pg-types": "^2.2.0" } }, "sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow=="],
@@ -4215,6 +4288,16 @@
     "@vitest/mocker/estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
 
     "@xenova/transformers/sharp": ["sharp@0.32.6", "", { "dependencies": { "color": "^4.2.3", "detect-libc": "^2.0.2", "node-addon-api": "^6.1.0", "prebuild-install": "^7.1.1", "semver": "^7.5.4", "simple-get": "^4.0.1", "tar-fs": "^3.0.4", "tunnel-agent": "^0.6.0" } }, "sha512-KyLTWwgcR9Oe4d9HwCwNM2l7+J0dUQwn/yf7S0EnTtb0eVS4RxO0eUSvxPtzT4F3SY+C4K6fqdv/DO27sJ/v/w=="],
+
+    "@xmorse/playwright-core/commander": ["commander@13.1.0", "", {}, "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw=="],
+
+    "@xmorse/playwright-core/diff": ["diff@7.0.0", "", {}, "sha512-PJWHUb1RFevKCwaFA9RlG5tCd+FO5iRh9A8HEtkmBH2Li03iJriB6m6JIN4rGz3K3JLawI7/veA1xzRKP6ISBw=="],
+
+    "@xmorse/playwright-core/minimatch": ["minimatch@3.1.5", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w=="],
+
+    "@xmorse/playwright-core/open": ["open@8.4.0", "", { "dependencies": { "define-lazy-prop": "^2.0.0", "is-docker": "^2.1.1", "is-wsl": "^2.2.0" } }, "sha512-XgFPPM+B28FtCCgSb9I+s9szOC1vZRSwgWsRUA5ylIxRTgKozqjOCrVOqGsYABPYK5qnfqClxZTFBa8PKt2v6Q=="],
+
+    "@xmorse/playwright-core/ws": ["ws@8.17.1", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ=="],
 
     "accepts/mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
 
@@ -4246,6 +4329,8 @@
 
     "cliui/wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
 
+    "config-chain/ini": ["ini@1.3.8", "", {}, "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="],
+
     "csso/css-tree": ["css-tree@2.2.1", "", { "dependencies": { "mdn-data": "2.0.28", "source-map-js": "^1.0.1" } }, "sha512-OA0mILzGc1kCOCSJerOeqDxDQ4HOh+G8NbOJFOTgOCzpw7fCBubk0fEyxp8AgOL/jvLgYA/uV0cMbe43ElF1JA=="],
 
     "discord.js/discord-api-types": ["discord-api-types@0.38.47", "", {}, "sha512-XgXQodHQBAE6kfD7kMvVo30863iHX1LHSqNq6MGUTDwIFCCvHva13+rwxyxVXDqudyApMNAd32PGjgVETi5rjA=="],
@@ -4256,17 +4341,19 @@
 
     "echarts/tslib": ["tslib@2.3.0", "", {}, "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="],
 
+    "editorconfig/commander": ["commander@10.0.1", "", {}, "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug=="],
+
     "estree-util-build-jsx/estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
 
     "estree-util-to-js/source-map": ["source-map@0.7.6", "", {}, "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ=="],
 
     "execa/onetime": ["onetime@5.1.2", "", { "dependencies": { "mimic-fn": "^2.1.0" } }, "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg=="],
 
+    "execa/signal-exit": ["signal-exit@3.0.7", "", {}, "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="],
+
     "express/cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
 
     "express/mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
-
-    "foreground-child/signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
 
     "glob/minimatch": ["minimatch@10.2.5", "", { "dependencies": { "brace-expansion": "^5.0.5" } }, "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg=="],
 
@@ -4283,6 +4370,8 @@
     "is-expression/acorn": ["acorn@7.4.1", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A=="],
 
     "istanbul-reports/html-escaper": ["html-escaper@2.0.2", "", {}, "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg=="],
+
+    "js-beautify/glob": ["glob@10.5.0", "", { "dependencies": { "foreground-child": "^3.1.0", "jackspeak": "^3.1.2", "minimatch": "^9.0.4", "minipass": "^7.1.2", "package-json-from-dist": "^1.0.0", "path-scurry": "^1.11.1" }, "bin": { "glob": "dist/esm/bin.mjs" } }, "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg=="],
 
     "jscpd/commander": ["commander@5.1.0", "", {}, "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg=="],
 
@@ -4318,7 +4407,11 @@
 
     "parse5-htmlparser2-tree-adapter/parse5": ["parse5@6.0.1", "", {}, "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw=="],
 
-    "pixelmatch/pngjs": ["pngjs@6.0.0", "", {}, "sha512-TRzzuFRRmEoSW/p1KVAmiOgPco2Irlah+bGFCeNfJXxxYGwSw7YwAOAcd7X28K/m5bjBWKsC29KyoMfHbypayg=="],
+    "posthtml-beautify/posthtml-parser": ["posthtml-parser@0.4.2", "", { "dependencies": { "htmlparser2": "^3.9.2" } }, "sha512-BUIorsYJTvS9UhXxPTzupIztOMVNPa/HtAm9KHni9z6qEfiJ1bpOBL5DfUOL9XAc3XkLIEzBzpph+Zbm4AdRAg=="],
+
+    "posthtml-beautify/posthtml-render": ["posthtml-render@1.4.0", "", {}, "sha512-W1779iVHGfq0Fvh2PROhCe2QhB8mEErgqzo1wpIt36tCgChafP+hbXIhLDOM8ePJrZcFs0vkNEtdibEWVqChqw=="],
+
+    "posthtml-parser/htmlparser2": ["htmlparser2@7.2.0", "", { "dependencies": { "domelementtype": "^2.0.1", "domhandler": "^4.2.2", "domutils": "^2.8.0", "entities": "^3.0.1" } }, "sha512-H7MImA4MS6cw7nbyURtLPO1Tms7C5H602LRETv95z1MxO/7CP7rDVROehUYeYBUYEON94NXXDEPmZuq+hX4sog=="],
 
     "prebuild-install/tar-fs": ["tar-fs@2.1.4", "", { "dependencies": { "chownr": "^1.1.1", "mkdirp-classic": "^0.5.2", "pump": "^3.0.0", "tar-stream": "^2.1.4" } }, "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ=="],
 
@@ -4329,6 +4422,8 @@
     "prop-types/react-is": ["react-is@16.13.1", "", {}, "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="],
 
     "proper-lockfile/retry": ["retry@0.12.0", "", {}, "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow=="],
+
+    "proper-lockfile/signal-exit": ["signal-exit@3.0.7", "", {}, "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="],
 
     "protobufjs/long": ["long@5.3.2", "", {}, "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA=="],
 
@@ -4353,8 +4448,6 @@
     "rc/strip-json-comments": ["strip-json-comments@2.0.1", "", {}, "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ=="],
 
     "readdirp/picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
-
-    "restore-cursor/signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
 
     "router/path-to-regexp": ["path-to-regexp@8.4.2", "", {}, "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA=="],
 
@@ -4680,6 +4773,14 @@
 
     "@so-ric/colorspace/color/color-string": ["color-string@2.1.4", "", { "dependencies": { "color-name": "^2.0.0" } }, "sha512-Bb6Cq8oq0IjDOe8wJmi4JeNn763Xs9cfrBcaylK1tPypWzyoy2G3l90v9k64kjphl/ZJjPIShFztenRomi8WTg=="],
 
+    "@xmorse/playwright-core/minimatch/brace-expansion": ["brace-expansion@1.1.14", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g=="],
+
+    "@xmorse/playwright-core/open/define-lazy-prop": ["define-lazy-prop@2.0.0", "", {}, "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og=="],
+
+    "@xmorse/playwright-core/open/is-docker": ["is-docker@2.2.1", "", { "bin": { "is-docker": "cli.js" } }, "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ=="],
+
+    "@xmorse/playwright-core/open/is-wsl": ["is-wsl@2.2.0", "", { "dependencies": { "is-docker": "^2.0.0" } }, "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww=="],
+
     "accepts/mime-types/mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
 
     "astro/vite/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
@@ -4712,6 +4813,8 @@
 
     "hast-util-raw/parse5/entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
 
+    "js-beautify/glob/path-scurry": ["path-scurry@1.11.1", "", { "dependencies": { "lru-cache": "^10.2.0", "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0" } }, "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA=="],
+
     "just-bash/minimatch/brace-expansion": ["brace-expansion@5.0.5", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ=="],
 
     "lru-memoizer/lru-cache/yallist": ["yallist@4.0.0", "", {}, "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="],
@@ -4719,6 +4822,14 @@
     "msw/@inquirer/confirm/@inquirer/core": ["@inquirer/core@11.1.9", "", { "dependencies": { "@inquirer/ansi": "^2.0.5", "@inquirer/figures": "^2.0.5", "@inquirer/type": "^4.0.5", "cli-width": "^4.1.0", "fast-wrap-ansi": "^0.2.0", "mute-stream": "^3.0.0", "signal-exit": "^4.1.0" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-BDE4fG22uYh1bGSifcj7JSx119TVYNViMhMu85usp4Fswrzh6M0DV3yld64jA98uOAa2GSQ4Bg4bZRm2d2cwSg=="],
 
     "msw/@inquirer/confirm/@inquirer/type": ["@inquirer/type@4.0.5", "", { "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-aetVUNeKNc/VriqXlw1NRSW0zhMBB0W4bNbWRJgzRl/3d0QNDQFfk0GO5SDdtjMZVg6o8ZKEiadd7SCCzoOn5Q=="],
+
+    "posthtml-beautify/posthtml-parser/htmlparser2": ["htmlparser2@3.10.1", "", { "dependencies": { "domelementtype": "^1.3.1", "domhandler": "^2.3.0", "domutils": "^1.5.1", "entities": "^1.1.1", "inherits": "^2.0.1", "readable-stream": "^3.1.1" } }, "sha512-IgieNijUMbkDovyoKObU1DUhm1iwNYE/fuifEoEHfd1oZKZDaONBSkal7Y01shxsM49R4XaMdGez3WnF9UfiCQ=="],
+
+    "posthtml-parser/htmlparser2/domhandler": ["domhandler@4.3.1", "", { "dependencies": { "domelementtype": "^2.2.0" } }, "sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ=="],
+
+    "posthtml-parser/htmlparser2/domutils": ["domutils@2.8.0", "", { "dependencies": { "dom-serializer": "^1.0.1", "domelementtype": "^2.2.0", "domhandler": "^4.2.0" } }, "sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A=="],
+
+    "posthtml-parser/htmlparser2/entities": ["entities@3.0.1", "", {}, "sha512-WiyBqoomrwMdFG1e0kqvASYfnlb0lp8M5o5Fw2OFq1hNZxxcNk8Ik0Xm7LxzBhuidnZB/UtBqVCgUz3kBOP51Q=="],
 
     "prebuild-install/tar-fs/tar-stream": ["tar-stream@2.2.0", "", { "dependencies": { "bl": "^4.0.3", "end-of-stream": "^1.4.1", "fs-constants": "^1.0.0", "inherits": "^2.0.3", "readable-stream": "^3.1.1" } }, "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ=="],
 
@@ -4884,6 +4995,8 @@
 
     "glob/minimatch/brace-expansion/balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
 
+    "js-beautify/glob/path-scurry/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
+
     "just-bash/minimatch/brace-expansion/balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
 
     "msw/@inquirer/confirm/@inquirer/core/@inquirer/ansi": ["@inquirer/ansi@2.0.5", "", {}, "sha512-doc2sWgJpbFQ64UflSVd17ibMGDuxO1yKgOgLMwavzESnXjFWJqUeG8saYosqKpHp4kWiM5x1nXvEjbpx90gzw=="],
@@ -4894,7 +5007,15 @@
 
     "msw/@inquirer/confirm/@inquirer/core/mute-stream": ["mute-stream@3.0.0", "", {}, "sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw=="],
 
-    "msw/@inquirer/confirm/@inquirer/core/signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
+    "posthtml-beautify/posthtml-parser/htmlparser2/domelementtype": ["domelementtype@1.3.1", "", {}, "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w=="],
+
+    "posthtml-beautify/posthtml-parser/htmlparser2/domhandler": ["domhandler@2.4.2", "", { "dependencies": { "domelementtype": "1" } }, "sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA=="],
+
+    "posthtml-beautify/posthtml-parser/htmlparser2/domutils": ["domutils@1.7.0", "", { "dependencies": { "dom-serializer": "0", "domelementtype": "1" } }, "sha512-Lgd2XcJ/NjEw+7tFvfKxOzCYKZsdct5lczQ2ZaQY8Djz7pfAD3Gbp8ySJWtreII/vDlMVmxwa6pHmdxIYgttDg=="],
+
+    "posthtml-beautify/posthtml-parser/htmlparser2/entities": ["entities@1.1.2", "", {}, "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w=="],
+
+    "posthtml-parser/htmlparser2/domutils/dom-serializer": ["dom-serializer@1.4.1", "", { "dependencies": { "domelementtype": "^2.0.1", "domhandler": "^4.2.0", "entities": "^2.0.0" } }, "sha512-VHwB3KfrcOOkelEG2ZOfxqLZdfkil8PtJi4P8N2MMXucZq2yLp75ClViUlOVwyoHEDjYU433Aq+5zWP61+RGag=="],
 
     "test-exclude/glob/path-scurry/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
 
@@ -5016,10 +5137,18 @@
 
     "msw/@inquirer/confirm/@inquirer/core/fast-wrap-ansi/fast-string-width": ["fast-string-width@3.0.2", "", { "dependencies": { "fast-string-truncated-width": "^3.0.2" } }, "sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg=="],
 
+    "posthtml-beautify/posthtml-parser/htmlparser2/domutils/dom-serializer": ["dom-serializer@0.2.2", "", { "dependencies": { "domelementtype": "^2.0.1", "entities": "^2.0.0" } }, "sha512-2/xPb3ORsQ42nHYiSunXkDjPLBaEj/xTwUO4B7XCZQTRk7EBtTOPaygh10YAAh2OI1Qrp6NWfpAhzswj0ydt9g=="],
+
+    "posthtml-parser/htmlparser2/domutils/dom-serializer/entities": ["entities@2.2.0", "", {}, "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A=="],
+
     "@lobu/core/@sentry/node/@prisma/instrumentation/@opentelemetry/instrumentation/import-in-the-middle/cjs-module-lexer": ["cjs-module-lexer@2.2.0", "", {}, "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ=="],
 
     "@lobu/worker/@sentry/node/@prisma/instrumentation/@opentelemetry/instrumentation/import-in-the-middle/cjs-module-lexer": ["cjs-module-lexer@2.2.0", "", {}, "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ=="],
 
     "msw/@inquirer/confirm/@inquirer/core/fast-wrap-ansi/fast-string-width/fast-string-truncated-width": ["fast-string-truncated-width@3.0.3", "", {}, "sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g=="],
+
+    "posthtml-beautify/posthtml-parser/htmlparser2/domutils/dom-serializer/domelementtype": ["domelementtype@2.3.0", "", {}, "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw=="],
+
+    "posthtml-beautify/posthtml-parser/htmlparser2/domutils/dom-serializer/entities": ["entities@2.2.0", "", {}, "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A=="],
   }
 }

--- a/bun.lock
+++ b/bun.lock
@@ -52,12 +52,6 @@
         "@types/node": "20.19.9",
         "typescript": "^5.7.2",
       },
-      "peerDependencies": {
-        "playwright": "npm:patchright@^1.57.0",
-      },
-      "optionalPeers": [
-        "playwright",
-      ],
     },
     "packages/cli": {
       "name": "@lobu/cli",

--- a/packages/browser-bridge/README.md
+++ b/packages/browser-bridge/README.md
@@ -49,13 +49,14 @@ const token = randomBytes(32).toString('hex');
 const bridge = await startBridgeServer({ token });
 
 try {
-  const browser = await chromium.connectOverCDP(bridge.url, {
-    headers: { authorization: `Bearer ${token}` },
-  });
+  // bridge.url already contains the /cdp path and ?token=... query.
+  // Do NOT pass an Authorization Bearer header — the underlying relay's
+  // /cdp route only checks the query token.
+  const browser = await chromium.connectOverCDP(bridge.url);
   const page = (await browser.contexts())[0].pages()[0];
   await page.goto('https://app.revolut.com');
   // ... your existing Playwright connector code, unchanged ...
-  await browser.close();
+  await browser.close(); // disconnects CDP only — does NOT close user's Chrome.
 } finally {
   bridge.close();
 }
@@ -68,11 +69,19 @@ import { acquireBrowser } from '@lobu/connector-sdk';
 
 const { browser, page } = await acquireBrowser({
   bridgeUrl: bridge.url,
-  bridgeAuthToken: token,
   cookies: [],
   authDomains: [],
 });
 ```
+
+## Cost of taking this dep
+
+Any consumer of `@lobu/browser-bridge` pays the full `playwriter` install
+cost (~10 MB unpacked, ~100 transitive packages including hono,
+`@xmorse/playwright-core`, the MCP SDK, and a couple of native-binding
+optionals). Worth knowing before importing this into a hot path or a
+client-side bundle. For server-side connector use this is fine; it's the
+same magnitude as Playwright itself.
 
 ## What's in / out of scope for this spike PR
 
@@ -97,6 +106,10 @@ Out of scope (follow-ups):
   Chrome with the extension loaded plus a Playwright snippet).
 - Origin-header rejection on the bridge WS (playwriter's auth model is
   token-based; Origin validation is part of its extension story).
+- Wiring this package into `make build-packages` and the publish scripts.
+  The spike doesn't ship via the normal release flow — it's installable as
+  a workspace dep only — until the extension story lands and we know
+  whether the public surface stays this small.
 
 ## Manual verification
 

--- a/packages/browser-bridge/README.md
+++ b/packages/browser-bridge/README.md
@@ -1,0 +1,117 @@
+# @lobu/browser-bridge — SPIKE
+
+CDP relay that lets Lobu Playwright connectors drive the user's
+already-signed-in Chrome via a Chrome extension using `chrome.debugger`.
+
+Status: **spike**. Wraps [`playwriter`](https://github.com/remorses/playwriter)
+(MIT) which implements the actual relay + extension. This package gives
+connector-sdk a stable Lobu-shaped API so the underlying implementation
+can be swapped later (vendored fork, in-house rewrite) without churning
+callers.
+
+## Why
+
+Connectors that need the user's real signed-in browser (Revolut, banking,
+anything aggressively fingerprinted) can't be driven from a Lobu-launched
+Chromium — the site detects it, or the user's MFA/device trust isn't
+present. The bridge solves this by attaching to the user's real Chrome via
+a `chrome.debugger`-backed extension, while keeping the Lobu Playwright
+connector code unchanged: connectors still call `chromium.connectOverCDP`,
+the URL just happens to point at the bridge.
+
+See `project_openclaw_browser_plugin.md` in agent memory for the full
+landscape (termos prior art, playwright-crx alternative, why the bridge
+shim path was picked).
+
+## Architecture
+
+```
+Lobu worker host (Node)          local relay          Chrome extension      user's Chrome
+─────────────────────           ─────────────         ──────────────       ──────────────
+chromium.connectOverCDP(url) ── WS server :19988 ──   WS client            chrome.debugger
+                                + browser-level                            on user's tabs
+                                CDP shim (Target.*)
+```
+
+The shim is what makes `connectOverCDP` work over `chrome.debugger`: it
+fakes the browser-level CDP commands (`Target.getTargets`,
+`Target.attachToTarget`, etc.) that Playwright expects, translating them
+into per-tab `chrome.debugger.attach` calls inside the extension.
+
+## Usage
+
+```ts
+import { startBridgeServer } from '@lobu/browser-bridge';
+import { chromium } from 'playwright';
+import { randomBytes } from 'node:crypto';
+
+const token = randomBytes(32).toString('hex');
+const bridge = await startBridgeServer({ token });
+
+try {
+  const browser = await chromium.connectOverCDP(bridge.url, {
+    headers: { authorization: `Bearer ${token}` },
+  });
+  const page = (await browser.contexts())[0].pages()[0];
+  await page.goto('https://app.revolut.com');
+  // ... your existing Playwright connector code, unchanged ...
+  await browser.close();
+} finally {
+  bridge.close();
+}
+```
+
+Through `acquireBrowser` (recommended for connectors):
+
+```ts
+import { acquireBrowser } from '@lobu/connector-sdk';
+
+const { browser, page } = await acquireBrowser({
+  bridgeUrl: bridge.url,
+  bridgeAuthToken: token,
+  cookies: [],
+  authDomains: [],
+});
+```
+
+## What's in / out of scope for this spike PR
+
+In scope:
+
+- The `@lobu/browser-bridge` package wrapping `playwriter`.
+- A `bridge` resolution mode in `acquireBrowser` (connector-sdk).
+- A wire-level smoke test that proves the relay boots and exposes the CDP
+  discovery endpoint Playwright's `connectOverCDP` first hits.
+
+Out of scope (follow-ups):
+
+- The extension itself. For now, load `playwriter`'s unpacked extension
+  manually (see `playwriter` docs). A later PR will fold a Lobu-branded
+  extension into `apps/chrome/` in the owletto-web submodule.
+- The Mac menu-bar "Use my Chrome" toggle and per-profile capability gates.
+- Device-pinning UI changes in the connections admin (the existing
+  `device_worker_id` primitive is the routing path).
+- Production-grade auth and audit: token rotation, per-session caps,
+  per-attach consent UI, audit-log emission on session open/close.
+- End-to-end test against a real Chrome (manual for the spike; needs a
+  Chrome with the extension loaded plus a Playwright snippet).
+- Origin-header rejection on the bridge WS (playwriter's auth model is
+  token-based; Origin validation is part of its extension story).
+
+## Manual verification
+
+Until the e2e harness exists, the bridge is verified end-to-end by:
+
+1. `bunx playwriter mcp` (or `playwriter cli`) to launch their bundled
+   relay + auto-install the extension into Chrome.
+2. Run a connector with `cdpUrl` set to `ws://127.0.0.1:19988` (the
+   playwriter default).
+3. Connector should drive the active tab in your real Chrome.
+
+This package replaces step 1 with `startBridgeServer({ token })` — the
+extension half stays manual until the follow-up.
+
+## License
+
+BUSL-1.1 (Lobu wrapper). The underlying `playwriter` package is MIT —
+see its repository for attribution.

--- a/packages/browser-bridge/README.md
+++ b/packages/browser-bridge/README.md
@@ -111,20 +111,54 @@ Out of scope (follow-ups):
   a workspace dep only — until the extension story lands and we know
   whether the public surface stays this small.
 
-## Manual verification
+## Verification — what's proven, what's blocked
 
-Until the e2e harness exists, the bridge is verified end-to-end by:
+Automated (passing in smoke tests):
 
-1. `bunx playwriter mcp` (or `playwriter cli`) to launch their bundled
-   relay + auto-install the extension into Chrome.
-2. Run a connector with `cdpUrl` set to `ws://127.0.0.1:19988` (the
-   playwriter default).
-3. Connector should drive the active tab in your real Chrome.
+- Bridge starts via `startBridgeServer`, listens on the configured loopback port.
+- `bridge.url` is shaped correctly: `ws://host:port/cdp[?token=...]`.
+- `/cdp` route's token query-param auth gate works (401 without, !401 with).
+- playwriter's `/json/version` discovery URL still points at `/cdp`
+  (drift check for future upstream releases).
+- `chromium.connectOverCDP(bridge.url)` reaches the relay end-to-end — the
+  relay accepts the WS upgrade and either pairs the client to an attached
+  extension or cleanly rejects with no-extension (verified with no
+  extension loaded).
 
-This package replaces step 1 with `startBridgeServer({ token })` — the
-extension half stays manual until the follow-up.
+Verified manually via a throwaway Chrome (Playwright `launchPersistentContext`
++ `--load-extension`) + service-worker `evaluate("toggleExtensionForActiveTab()")`:
+
+- Extension connects to `ws://.../extension`, the relay registers it,
+  `globalThis.toggleExtensionForActiveTab()` (exposed by playwriter's bg
+  script) triggers `chrome.debugger.attach` on the active tab, and the
+  relay forwards `Target.attachedToTarget` events to Playwright clients.
+
+Blocked at the moment (NOT a bug in this wrapper):
+
+- After extension attach succeeds, `chromium.connectOverCDP(bridge.url)`
+  hangs at the CDP-shim handshake for 30s and times out. Reproduces
+  identically against playwriter's relay **without** this wrapper, with
+  both `patchright` and `playwright-vanilla`, and `playwriter browser list`
+  also fails to see the connected extension. Issue is in `playwriter@0.1.0`
+  on npm, not in this wrapper or in our acquireBrowser hook.
+
+  Follow-ups: vendor playwriter from the github main branch (currently
+  ~0.1.6, but it's a pnpm workspace with internal deps so `bun add` from
+  github can't resolve it cleanly) OR switch the underlying implementation
+  to Microsoft's [Playwright MCP Bridge](https://github.com/microsoft/playwright-mcp)
+  or [ruifigueira/playwright-crx](https://github.com/ruifigueira/playwright-crx)
+  before depending on this in any real connector.
 
 ## License
 
-BUSL-1.1 (Lobu wrapper). The underlying `playwriter` package is MIT —
-see its repository for attribution.
+BUSL-1.1 (Lobu wrapper).
+
+### Third-party attribution
+
+This package depends on [`playwriter`](https://github.com/remorses/playwriter)
+by Tommaso De Rossi (`xmorse`). Playwriter is distributed under the MIT
+License (LICENSE file in the playwriter repo; the npm `license` field is
+empty but the source LICENSE is MIT). Source review and security audit of
+the playwriter dependency tree is a prerequisite before any production use
+of this bridge — the relay grants control of the user's signed-in browser
+and pulls in ~100 transitive packages including native binding optionals.

--- a/packages/browser-bridge/package.json
+++ b/packages/browser-bridge/package.json
@@ -1,0 +1,53 @@
+{
+  "name": "@lobu/browser-bridge",
+  "version": "0.0.0",
+  "description": "CDP relay that lets Lobu Playwright connectors drive the user's already-signed-in Chrome via a chrome.debugger-backed extension. Spike: thin wrapper around playwriter.",
+  "license": "BUSL-1.1",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      }
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "typecheck": "tsc --noEmit",
+    "test": "bun test src",
+    "clean": "rm -rf dist"
+  },
+  "dependencies": {
+    "playwriter": "0.1.0"
+  },
+  "peerDependencies": {
+    "playwright": "npm:patchright@^1.57.0"
+  },
+  "peerDependenciesMeta": {
+    "playwright": {
+      "optional": true
+    }
+  },
+  "devDependencies": {
+    "@types/node": "20.19.9",
+    "typescript": "^5.7.2"
+  },
+  "engines": {
+    "node": ">=20"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "homepage": "https://github.com/lobu-ai/lobu",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/lobu-ai/lobu.git",
+    "directory": "packages/browser-bridge"
+  }
+}

--- a/packages/browser-bridge/package.json
+++ b/packages/browser-bridge/package.json
@@ -26,14 +26,6 @@
   "dependencies": {
     "playwriter": "0.1.0"
   },
-  "peerDependencies": {
-    "playwright": "npm:patchright@^1.57.0"
-  },
-  "peerDependenciesMeta": {
-    "playwright": {
-      "optional": true
-    }
-  },
   "devDependencies": {
     "@types/node": "20.19.9",
     "typescript": "^5.7.2"

--- a/packages/browser-bridge/src/__tests__/bridge.smoke.test.ts
+++ b/packages/browser-bridge/src/__tests__/bridge.smoke.test.ts
@@ -1,56 +1,92 @@
 /**
  * Spike-level wire test for @lobu/browser-bridge.
  *
- * Proves the relay boots, listens on a loopback port, and accepts the CDP
- * discovery handshake that `chromium.connectOverCDP` performs as its first
- * step (a GET to `/json/version`). Does NOT exercise an actual extension
- * attach — that requires Chrome + the playwriter extension loaded, which
- * is out of scope for an automated smoke test.
+ * Confidence level: medium-low. Asserts that startBridgeServer hands back a
+ * URL of the right shape for the underlying relay (path = /cdp, token in
+ * query string, NOT in headers), that the /cdp route exists and gates on
+ * the token when configured, and that the relay can be cleanly torn down.
  *
- * Confidence level: medium. "Server starts, exposes the well-known CDP
- * discovery endpoint, can be cleanly torn down." Enough to prove the
- * package wires up, not enough to prove the full end-to-end shim works.
- * End-to-end validation needs manual Chrome + extension testing per the
- * spike PR notes.
+ * What this does NOT cover: actual chromium.connectOverCDP roundtrip,
+ * extension attach via chrome.debugger, Target.* shim correctness, default
+ * context delivery, real tab control. Those need a real Chrome with the
+ * playwriter extension loaded — manual operator step documented in the
+ * package README until a desktop-bridge e2e harness exists.
  */
 
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { startBridgeServer, type BridgeServer } from "../index.js";
 
-const TEST_PORT = 19989; // off the playwriter default to avoid collisions
+const TEST_PORT_NOAUTH = 19989;
+const TEST_PORT_AUTH = 19990;
+const TEST_TOKEN = "spike-test-token-not-a-real-secret";
 
-describe("browser-bridge smoke", () => {
+describe("browser-bridge smoke (no token)", () => {
   let bridge: BridgeServer;
 
   beforeAll(async () => {
-    bridge = await startBridgeServer({ port: TEST_PORT, host: "127.0.0.1" });
+    bridge = await startBridgeServer({ port: TEST_PORT_NOAUTH, host: "127.0.0.1" });
   });
 
   afterAll(() => {
     bridge?.close();
   });
 
-  test("exposes a ws:// loopback url", () => {
-    expect(bridge.url).toBe(`ws://127.0.0.1:${TEST_PORT}`);
+  test("url targets the /cdp route, not the server root", () => {
+    expect(bridge.url).toBe(`ws://127.0.0.1:${TEST_PORT_NOAUTH}/cdp`);
   });
 
-  test("answers the CDP discovery probe with a Browser endpoint", async () => {
-    // `chromium.connectOverCDP("ws://host:port")` first hits
-    // `http://host:port/json/version` to learn the browser-level WebSocket
-    // URL. If this 404s, connectOverCDP fails before the shim ever runs.
-    const res = await fetch(`http://127.0.0.1:${TEST_PORT}/json/version`);
+  test("url omits the token query when no token is configured", () => {
+    expect(bridge.url).not.toContain("token=");
+  });
+
+  test("/json/version returns a CDP endpoint pointing at /cdp", async () => {
+    // Sanity check that the relay's discovery endpoint hands out a URL
+    // matching what we expose as bridge.url. If these diverge in a future
+    // playwriter release, callers using bridge.url stay safe but the
+    // divergence is worth surfacing.
+    const res = await fetch(`http://127.0.0.1:${TEST_PORT_NOAUTH}/json/version`);
     expect(res.status).toBe(200);
     const body = (await res.json()) as { webSocketDebuggerUrl?: string };
-    expect(typeof body.webSocketDebuggerUrl).toBe("string");
-    expect(body.webSocketDebuggerUrl).toMatch(/^ws:\/\//);
+    expect(body.webSocketDebuggerUrl).toMatch(/^ws:\/\/.+\/cdp$/);
+  });
+});
+
+describe("browser-bridge smoke (with token)", () => {
+  let bridge: BridgeServer;
+
+  beforeAll(async () => {
+    bridge = await startBridgeServer({
+      port: TEST_PORT_AUTH,
+      host: "127.0.0.1",
+      token: TEST_TOKEN,
+    });
   });
 
-  test("rejects /json/version on a wrong path (no silent allow-all)", async () => {
-    const res = await fetch(
-      `http://127.0.0.1:${TEST_PORT}/definitely-not-a-cdp-route`
+  afterAll(() => {
+    bridge?.close();
+  });
+
+  test("url embeds the token in the query string", () => {
+    expect(bridge.url).toBe(
+      `ws://127.0.0.1:${TEST_PORT_AUTH}/cdp?token=${encodeURIComponent(TEST_TOKEN)}`
     );
-    // Anything other than a 200 with a Browser endpoint is acceptable —
-    // we just don't want the server happily echoing anything back.
-    expect(res.status).not.toBe(200);
+  });
+
+  test("/cdp WS upgrade is rejected without a matching token", async () => {
+    // The /cdp route checks ?token=... on WS upgrade. We trigger the route
+    // via a plain HTTP GET — playwriter's middleware short-circuits on
+    // bad token BEFORE attempting upgrade, so we see a 401. This proves
+    // the auth gate is wired; it does NOT prove the WS itself works.
+    const res = await fetch(`http://127.0.0.1:${TEST_PORT_AUTH}/cdp`);
+    expect(res.status).toBe(401);
+  });
+
+  test("/cdp accepts requests with the correct token", async () => {
+    const res = await fetch(
+      `http://127.0.0.1:${TEST_PORT_AUTH}/cdp?token=${encodeURIComponent(TEST_TOKEN)}`
+    );
+    // Auth passes; the request is then a normal GET (not a WS upgrade) so
+    // Hono / @hono/node-ws responds with something other than 401.
+    expect(res.status).not.toBe(401);
   });
 });

--- a/packages/browser-bridge/src/__tests__/bridge.smoke.test.ts
+++ b/packages/browser-bridge/src/__tests__/bridge.smoke.test.ts
@@ -1,0 +1,54 @@
+/**
+ * Spike-level wire test for @lobu/browser-bridge.
+ *
+ * Proves the relay boots, listens on a loopback port, and accepts the CDP
+ * discovery handshake that `chromium.connectOverCDP` performs as its first
+ * step (a GET to `/json/version`). Does NOT exercise an actual extension
+ * attach — that requires Chrome + the playwriter extension loaded, which
+ * is out of scope for an automated smoke test.
+ *
+ * Confidence level: medium. "Server starts, exposes the well-known CDP
+ * discovery endpoint, can be cleanly torn down." Enough to prove the
+ * package wires up, not enough to prove the full end-to-end shim works.
+ * End-to-end validation needs manual Chrome + extension testing per the
+ * spike PR notes.
+ */
+
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
+import { startBridgeServer, type BridgeServer } from '../index.js';
+
+const TEST_PORT = 19989; // off the playwriter default to avoid collisions
+
+describe('browser-bridge smoke', () => {
+  let bridge: BridgeServer;
+
+  beforeAll(async () => {
+    bridge = await startBridgeServer({ port: TEST_PORT, host: '127.0.0.1' });
+  });
+
+  afterAll(() => {
+    bridge?.close();
+  });
+
+  test('exposes a ws:// loopback url', () => {
+    expect(bridge.url).toBe(`ws://127.0.0.1:${TEST_PORT}`);
+  });
+
+  test('answers the CDP discovery probe with a Browser endpoint', async () => {
+    // `chromium.connectOverCDP("ws://host:port")` first hits
+    // `http://host:port/json/version` to learn the browser-level WebSocket
+    // URL. If this 404s, connectOverCDP fails before the shim ever runs.
+    const res = await fetch(`http://127.0.0.1:${TEST_PORT}/json/version`);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { webSocketDebuggerUrl?: string };
+    expect(typeof body.webSocketDebuggerUrl).toBe('string');
+    expect(body.webSocketDebuggerUrl).toMatch(/^ws:\/\//);
+  });
+
+  test('rejects /json/version on a wrong path (no silent allow-all)', async () => {
+    const res = await fetch(`http://127.0.0.1:${TEST_PORT}/definitely-not-a-cdp-route`);
+    // Anything other than a 200 with a Browser endpoint is acceptable —
+    // we just don't want the server happily echoing anything back.
+    expect(res.status).not.toBe(200);
+  });
+});

--- a/packages/browser-bridge/src/__tests__/bridge.smoke.test.ts
+++ b/packages/browser-bridge/src/__tests__/bridge.smoke.test.ts
@@ -24,7 +24,10 @@ describe("browser-bridge smoke (no token)", () => {
   let bridge: BridgeServer;
 
   beforeAll(async () => {
-    bridge = await startBridgeServer({ port: TEST_PORT_NOAUTH, host: "127.0.0.1" });
+    bridge = await startBridgeServer({
+      port: TEST_PORT_NOAUTH,
+      host: "127.0.0.1",
+    });
   });
 
   afterAll(() => {
@@ -44,7 +47,9 @@ describe("browser-bridge smoke (no token)", () => {
     // matching what we expose as bridge.url. If these diverge in a future
     // playwriter release, callers using bridge.url stay safe but the
     // divergence is worth surfacing.
-    const res = await fetch(`http://127.0.0.1:${TEST_PORT_NOAUTH}/json/version`);
+    const res = await fetch(
+      `http://127.0.0.1:${TEST_PORT_NOAUTH}/json/version`
+    );
     expect(res.status).toBe(200);
     const body = (await res.json()) as { webSocketDebuggerUrl?: string };
     expect(body.webSocketDebuggerUrl).toMatch(/^ws:\/\/.+\/cdp$/);

--- a/packages/browser-bridge/src/__tests__/bridge.smoke.test.ts
+++ b/packages/browser-bridge/src/__tests__/bridge.smoke.test.ts
@@ -14,39 +14,41 @@
  * spike PR notes.
  */
 
-import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
-import { startBridgeServer, type BridgeServer } from '../index.js';
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { startBridgeServer, type BridgeServer } from "../index.js";
 
 const TEST_PORT = 19989; // off the playwriter default to avoid collisions
 
-describe('browser-bridge smoke', () => {
+describe("browser-bridge smoke", () => {
   let bridge: BridgeServer;
 
   beforeAll(async () => {
-    bridge = await startBridgeServer({ port: TEST_PORT, host: '127.0.0.1' });
+    bridge = await startBridgeServer({ port: TEST_PORT, host: "127.0.0.1" });
   });
 
   afterAll(() => {
     bridge?.close();
   });
 
-  test('exposes a ws:// loopback url', () => {
+  test("exposes a ws:// loopback url", () => {
     expect(bridge.url).toBe(`ws://127.0.0.1:${TEST_PORT}`);
   });
 
-  test('answers the CDP discovery probe with a Browser endpoint', async () => {
+  test("answers the CDP discovery probe with a Browser endpoint", async () => {
     // `chromium.connectOverCDP("ws://host:port")` first hits
     // `http://host:port/json/version` to learn the browser-level WebSocket
     // URL. If this 404s, connectOverCDP fails before the shim ever runs.
     const res = await fetch(`http://127.0.0.1:${TEST_PORT}/json/version`);
     expect(res.status).toBe(200);
     const body = (await res.json()) as { webSocketDebuggerUrl?: string };
-    expect(typeof body.webSocketDebuggerUrl).toBe('string');
+    expect(typeof body.webSocketDebuggerUrl).toBe("string");
     expect(body.webSocketDebuggerUrl).toMatch(/^ws:\/\//);
   });
 
-  test('rejects /json/version on a wrong path (no silent allow-all)', async () => {
-    const res = await fetch(`http://127.0.0.1:${TEST_PORT}/definitely-not-a-cdp-route`);
+  test("rejects /json/version on a wrong path (no silent allow-all)", async () => {
+    const res = await fetch(
+      `http://127.0.0.1:${TEST_PORT}/definitely-not-a-cdp-route`
+    );
     // Anything other than a 200 with a Browser endpoint is acceptable —
     // we just don't want the server happily echoing anything back.
     expect(res.status).not.toBe(200);

--- a/packages/browser-bridge/src/index.ts
+++ b/packages/browser-bridge/src/index.ts
@@ -1,0 +1,101 @@
+/**
+ * @lobu/browser-bridge — SPIKE
+ *
+ * CDP relay that lets Lobu Playwright connectors drive the user's
+ * already-signed-in Chrome via a Chrome extension that uses
+ * `chrome.debugger.attach` and forwards CDP frames over WebSocket.
+ *
+ * Architecture:
+ *
+ *     Lobu worker host (Node)          local relay         Chrome extension
+ *     ----------------------          ------------         ----------------
+ *     chromium.connectOverCDP(url) ── WS server on :19988 ─ WS client
+ *                                     + browser-level                      ↓
+ *                                     CDP shim (Target.*)         chrome.debugger
+ *                                                                 .attach on tabs
+ *
+ * Spike status: this package is a thin wrapper around `playwriter`
+ * (https://github.com/remorses/playwriter, MIT) which implements the actual
+ * CDP shim and extension. We do NOT ship the extension here yet — for the
+ * spike, the user loads playwriter's unpacked extension manually. The
+ * follow-up PR folds the extension into apps/chrome/ in the owletto-web
+ * submodule.
+ *
+ * Why a wrapper rather than calling playwriter directly: gives connector-sdk
+ * a stable Lobu-shaped API, lets us swap the underlying implementation
+ * later (vendored fork, in-house rewrite) without churning every caller.
+ */
+
+import { startPlayWriterCDPRelayServer } from 'playwriter';
+
+export interface BridgeServerOptions {
+  /**
+   * TCP port for the loopback CDP relay. Defaults to playwriter's 19988.
+   * Pick a random port + advertise it via the Lobu device-worker poll
+   * payload when running in a multi-tenant environment.
+   */
+  port?: number;
+  /**
+   * Bind host. MUST be loopback in production (`127.0.0.1` or `::1`).
+   * Defaults to `127.0.0.1`. The CDP endpoint is unauthenticated below the
+   * `token` layer, so binding to a non-loopback interface effectively
+   * exposes browser control to the network.
+   */
+  host?: string;
+  /**
+   * Bearer token required on connections. When set, callers must include
+   * `Authorization: Bearer <token>` on the CDP WebSocket. Strongly
+   * recommended; the spike accepts undefined for local dev only.
+   */
+  token?: string;
+  /**
+   * Optional logger sink. Defaults to no-op so the relay doesn't spam stdout
+   * from inside a connector run.
+   */
+  logger?: { log(...args: unknown[]): void; error(...args: unknown[]): void };
+}
+
+export interface BridgeServer {
+  /** CDP endpoint URL — pass directly to `chromium.connectOverCDP(url, ...)`. */
+  readonly url: string;
+  /** Stop the relay and disconnect any attached extensions. */
+  close(): void;
+}
+
+const NOOP_LOGGER = {
+  log: () => undefined,
+  error: () => undefined,
+};
+
+/**
+ * Start the loopback CDP relay. Returns once the server is listening.
+ *
+ * Connector usage:
+ *
+ *     const bridge = await startBridgeServer({ token: randomToken() });
+ *     const browser = await chromium.connectOverCDP(bridge.url, {
+ *       headers: { authorization: `Bearer ${token}` },
+ *     });
+ *     // ... run connector ...
+ *     await browser.close();
+ *     bridge.close();
+ */
+export async function startBridgeServer(
+  opts: BridgeServerOptions = {}
+): Promise<BridgeServer> {
+  const port = opts.port ?? 19988;
+  const host = opts.host ?? '127.0.0.1';
+  const logger = opts.logger ?? NOOP_LOGGER;
+
+  const server = await startPlayWriterCDPRelayServer({
+    port,
+    host,
+    token: opts.token,
+    logger,
+  });
+
+  return {
+    url: `ws://${host}:${port}`,
+    close: () => server.close(),
+  };
+}

--- a/packages/browser-bridge/src/index.ts
+++ b/packages/browser-bridge/src/index.ts
@@ -56,7 +56,18 @@ export interface BridgeServerOptions {
 }
 
 export interface BridgeServer {
-  /** CDP endpoint URL — pass directly to `chromium.connectOverCDP(url, ...)`. */
+  /**
+   * Full CDP WebSocket URL — pass directly to `chromium.connectOverCDP(url)`.
+   *
+   * Already includes the `/cdp` path that playwriter's relay listens on, plus
+   * `?token=...` when a token was configured. Bypasses the http→ws discovery
+   * roundtrip Playwright would otherwise do (and which playwriter's
+   * `/json/version` doesn't propagate the token through, so the discovered
+   * URL would 401 on /cdp).
+   *
+   * Do NOT also pass an `Authorization: Bearer` header — playwriter's /cdp
+   * route only checks the query token; the header is ignored there.
+   */
   readonly url: string;
   /** Stop the relay and disconnect any attached extensions. */
   close(): void;
@@ -73,9 +84,9 @@ const NOOP_LOGGER = {
  * Connector usage:
  *
  *     const bridge = await startBridgeServer({ token: randomToken() });
- *     const browser = await chromium.connectOverCDP(bridge.url, {
- *       headers: { authorization: `Bearer ${token}` },
- *     });
+ *     // bridge.url already contains the /cdp path and ?token=... query.
+ *     // Do NOT also pass headers — playwriter's CDP route ignores them.
+ *     const browser = await chromium.connectOverCDP(bridge.url);
  *     // ... run connector ...
  *     await browser.close();
  *     bridge.close();
@@ -94,8 +105,9 @@ export async function startBridgeServer(
     logger,
   });
 
+  const tokenQuery = opts.token ? `?token=${encodeURIComponent(opts.token)}` : "";
   return {
-    url: `ws://${host}:${port}`,
+    url: `ws://${host}:${port}/cdp${tokenQuery}`,
     close: () => server.close(),
   };
 }

--- a/packages/browser-bridge/src/index.ts
+++ b/packages/browser-bridge/src/index.ts
@@ -43,9 +43,11 @@ export interface BridgeServerOptions {
    */
   host?: string;
   /**
-   * Bearer token required on connections. When set, callers must include
-   * `Authorization: Bearer <token>` on the CDP WebSocket. Strongly
-   * recommended; the spike accepts undefined for local dev only.
+   * Token required on connections. When set, it is embedded as `?token=...`
+   * in the returned `url` — callers just pass `bridge.url` to
+   * `connectOverCDP`; no header plumbing. Strongly recommended for any
+   * non-local-dev environment; the spike accepts undefined for local dev
+   * only.
    */
   token?: string;
   /**
@@ -105,7 +107,9 @@ export async function startBridgeServer(
     logger,
   });
 
-  const tokenQuery = opts.token ? `?token=${encodeURIComponent(opts.token)}` : "";
+  const tokenQuery = opts.token
+    ? `?token=${encodeURIComponent(opts.token)}`
+    : "";
   return {
     url: `ws://${host}:${port}/cdp${tokenQuery}`,
     close: () => server.close(),

--- a/packages/browser-bridge/src/index.ts
+++ b/packages/browser-bridge/src/index.ts
@@ -26,7 +26,7 @@
  * later (vendored fork, in-house rewrite) without churning every caller.
  */
 
-import { startPlayWriterCDPRelayServer } from 'playwriter';
+import { startPlayWriterCDPRelayServer } from "playwriter";
 
 export interface BridgeServerOptions {
   /**
@@ -84,7 +84,7 @@ export async function startBridgeServer(
   opts: BridgeServerOptions = {}
 ): Promise<BridgeServer> {
   const port = opts.port ?? 19988;
-  const host = opts.host ?? '127.0.0.1';
+  const host = opts.host ?? "127.0.0.1";
   const logger = opts.logger ?? NOOP_LOGGER;
 
   const server = await startPlayWriterCDPRelayServer({

--- a/packages/browser-bridge/tsconfig.json
+++ b/packages/browser-bridge/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "module": "ESNext",
+    "target": "ES2022",
+    "moduleResolution": "bundler",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "./dist",
+    "resolveJsonModule": true,
+    "allowSyntheticDefaultImports": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": false
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "**/__tests__/**", "**/*.test.ts"]
+}

--- a/packages/connector-sdk/src/browser/acquire.ts
+++ b/packages/connector-sdk/src/browser/acquire.ts
@@ -35,19 +35,18 @@ export interface AcquireBrowserOptions {
   /**
    * @lobu/browser-bridge endpoint that fronts the user's real signed-in
    * Chrome (via the chrome.debugger-backed extension). When set, takes
-   * precedence over `cdpUrl` and `userDataDir`. Pair with `bridgeAuthToken`.
+   * precedence over `cdpUrl` and `userDataDir`.
+   *
+   * Pass the URL returned by `BridgeServer.url` directly — it already
+   * contains the `/cdp` path and `?token=...` query for auth. Do NOT
+   * pass a Bearer header; the underlying relay only checks the query
+   * token on its CDP route.
    *
    * Used for connectors against sites that need the user's real
    * MFA-trusted session — Revolut, banking, etc. — where a Lobu-launched
    * Chromium would be detected or wouldn't have the session.
    */
   bridgeUrl?: string;
-  /**
-   * Bearer token for the bridge connection. Required whenever `bridgeUrl`
-   * is set in any non-local-dev environment. Passed as
-   * `Authorization: Bearer <token>` on the CDP WebSocket handshake.
-   */
-  bridgeAuthToken?: string;
   /** CDP endpoint URL, 'auto' to auto-discover, or null to skip CDP entirely. */
   cdpUrl?: string | 'auto' | null;
   /** Stored cookies for Playwright fallback. May be empty. */
@@ -174,22 +173,36 @@ async function acquireViaBridge(opts: AcquireBrowserOptions): Promise<AcquiredBr
   const { chromium } = await import(/* @vite-ignore */ playwrightModule);
 
   const url = opts.bridgeUrl!;
-  const headers: Record<string, string> | undefined = opts.bridgeAuthToken
-    ? { authorization: `Bearer ${opts.bridgeAuthToken}` }
-    : undefined;
   const screenshotDir = process.env.BROWSER_SCREENSHOT_DIR ?? '/tmp/feed-screenshots';
 
-  const browser = (await chromium.connectOverCDP(url, { headers })) as Browser;
+  // bridgeUrl is the full ws://host:port/cdp?token=... — auth lives in the
+  // query string, NOT in headers. Don't pass an Authorization Bearer here.
+  const browser = (await chromium.connectOverCDP(url)) as Browser;
   try {
-    // The bridge fronts the user's existing Chrome — there is already a
-    // default context with their open tabs/cookies/storage. Use it rather
-    // than newContext, which on connectOverCDP returns an isolated incognito
-    // context that defeats the whole point.
+    // The bridge fronts the user's existing Chrome — there should already
+    // be a default context with the user's open tabs/cookies/storage. Use
+    // it rather than newContext, which on connectOverCDP returns an
+    // isolated incognito context and defeats the whole point.
+    //
+    // Fail loud if there's no context — silently creating a fresh incognito
+    // would (a) lose the user's session, and (b) the connector would happily
+    // run against the wrong browser state and get blocked. Worse than
+    // throwing.
     const contexts = browser.contexts();
-    const context = (contexts.length > 0 ? contexts[0] : await browser.newContext()) as BrowserContext;
+    if (contexts.length === 0) {
+      throw new Error(
+        '@lobu/browser-bridge: connected to relay but no browser context was advertised. ' +
+          'The extension probably is not attached to any tab. Open Chrome and click ' +
+          "the Lobu extension's toolbar icon on a tab, then retry."
+      );
+    }
+    const context = contexts[0] as BrowserContext;
     if (opts.cookies.length > 0) {
       await context.addCookies(opts.cookies);
     }
+    // pages()[0] picks an arbitrary attached tab. Acceptable for the spike
+    // since the extension attaches one tab at a time today; multi-tab
+    // selection (active tab, named tab, new tab) is a follow-up.
     const pages = context.pages();
     const page = pages.length > 0 ? pages[0] : await context.newPage();
 
@@ -202,12 +215,19 @@ async function acquireViaBridge(opts: AcquireBrowserOptions): Promise<AcquiredBr
       cdpPage: null,
       cdpWsUrl: url,
       backend: 'playwright',
-      ownsBrowser: false, // user's Chrome — caller must NOT close it
+      // user's Chrome — caller must NOT call browser.close() (would close
+      // their browser). Cleanup of the CDP attachment is handled by the
+      // extension on disconnect; the relay closes the WS when bridge.close()
+      // is invoked on the BridgeServer handle (separate concern from
+      // ownsBrowser).
+      ownsBrowser: false,
       screenshotDir,
     };
   } catch (err) {
     // Bridge connect succeeded but downstream setup failed. Drop the WS
     // connection so we don't leak a CDP attachment on the user's Chrome.
+    // browser.close() on a connectOverCDP Browser disconnects the CDP
+    // session — it does NOT close the user's Chrome itself.
     await browser.close().catch(() => {});
     throw err;
   }

--- a/packages/connector-sdk/src/browser/acquire.ts
+++ b/packages/connector-sdk/src/browser/acquire.ts
@@ -1,18 +1,23 @@
 /**
  * Browser Acquisition
  *
- * Single entry point for all browser-based connectors. Implements a two-layer
- * cascade:
+ * Single entry point for all browser-based connectors. Implements a cascade:
  *
- *   1. CDP — connect to user's real Chrome via raw CDP protocol.
+ *   1. Bridge — when `bridgeUrl` is set, the connector drives the user's
+ *      real signed-in Chrome through @lobu/browser-bridge (a CDP relay
+ *      backed by a chrome.debugger extension). Used for sites that need
+ *      the user's actual MFA-trusted session — Revolut, banking, etc.
+ *      Connects via Playwright's connectOverCDP through the bridge URL.
+ *
+ *   2. CDP — connect to user's real Chrome via raw CDP protocol.
  *      Uses CdpPage for DOM scraping (avoids Playwright's connectOverCDP crash
  *      on browsers with many tabs). For network interception, callers use
  *      Playwright's connectOverCDP on the resolved wsUrl directly.
  *
- *   2. Playwright — launch headless browser, inject stored cookies.
+ *   3. Playwright — launch headless browser, inject stored cookies.
  *      Cookies may come from a previous CDP session (freshest) or CLI capture.
  *
- * Both paths share the same caller API. Fresh cookies are always captured
+ * All paths share the same caller API. Fresh cookies are always captured
  * from the resulting context so the caller can persist them for future fallback.
  */
 
@@ -27,6 +32,22 @@ import { launchBrowser } from './launcher.js';
 // ---------------------------------------------------------------------------
 
 export interface AcquireBrowserOptions {
+  /**
+   * @lobu/browser-bridge endpoint that fronts the user's real signed-in
+   * Chrome (via the chrome.debugger-backed extension). When set, takes
+   * precedence over `cdpUrl` and `userDataDir`. Pair with `bridgeAuthToken`.
+   *
+   * Used for connectors against sites that need the user's real
+   * MFA-trusted session — Revolut, banking, etc. — where a Lobu-launched
+   * Chromium would be detected or wouldn't have the session.
+   */
+  bridgeUrl?: string;
+  /**
+   * Bearer token for the bridge connection. Required whenever `bridgeUrl`
+   * is set in any non-local-dev environment. Passed as
+   * `Authorization: Bearer <token>` on the CDP WebSocket handshake.
+   */
+  bridgeAuthToken?: string;
   /** CDP endpoint URL, 'auto' to auto-discover, or null to skip CDP entirely. */
   cdpUrl?: string | 'auto' | null;
   /** Stored cookies for Playwright fallback. May be empty. */
@@ -93,6 +114,19 @@ export class BrowserAuthCascadeError extends Error {
 export async function acquireBrowser(opts: AcquireBrowserOptions): Promise<AcquiredBrowser> {
   const attempts: Array<{ layer: string; error: string }> = [];
 
+  // --- Bridge: drive user's real signed-in Chrome via @lobu/browser-bridge ---
+  // Highest priority — when the caller picked this mode, falling back to a
+  // headless Playwright launch would silently lose the user's session and
+  // (for sites like Revolut) get the connector blocked. Fail loud instead.
+  if (opts.bridgeUrl) {
+    try {
+      return await acquireViaBridge(opts);
+    } catch (err: any) {
+      attempts.push({ layer: 'Bridge', error: err.message });
+      throw new BrowserAuthCascadeError(attempts);
+    }
+  }
+
   // --- Persistent profile path: cookies live in --user-data-dir ---
   // Skip CDP entirely — the profile dir is authoritative for cookies/state.
   if (opts.userDataDir) {
@@ -131,6 +165,53 @@ export async function acquireBrowser(opts: AcquireBrowserOptions): Promise<Acqui
 // ---------------------------------------------------------------------------
 // Layer implementations
 // ---------------------------------------------------------------------------
+
+async function acquireViaBridge(opts: AcquireBrowserOptions): Promise<AcquiredBrowser> {
+  // Dynamic playwright import to match the pattern in acquireViaPersistent —
+  // playwright is an optional peer dep; connector-sdk consumers without it
+  // shouldn't pay the import cost just because the type signature exists.
+  const playwrightModule = 'playwright';
+  const { chromium } = await import(/* @vite-ignore */ playwrightModule);
+
+  const url = opts.bridgeUrl!;
+  const headers: Record<string, string> | undefined = opts.bridgeAuthToken
+    ? { authorization: `Bearer ${opts.bridgeAuthToken}` }
+    : undefined;
+  const screenshotDir = process.env.BROWSER_SCREENSHOT_DIR ?? '/tmp/feed-screenshots';
+
+  const browser = (await chromium.connectOverCDP(url, { headers })) as Browser;
+  try {
+    // The bridge fronts the user's existing Chrome — there is already a
+    // default context with their open tabs/cookies/storage. Use it rather
+    // than newContext, which on connectOverCDP returns an isolated incognito
+    // context that defeats the whole point.
+    const contexts = browser.contexts();
+    const context = (contexts.length > 0 ? contexts[0] : await browser.newContext()) as BrowserContext;
+    if (opts.cookies.length > 0) {
+      await context.addCookies(opts.cookies);
+    }
+    const pages = context.pages();
+    const page = pages.length > 0 ? pages[0] : await context.newPage();
+
+    sdkLogger.info({ url }, '[BrowserAcquire] Connected via @lobu/browser-bridge');
+
+    return {
+      browser,
+      context,
+      page,
+      cdpPage: null,
+      cdpWsUrl: url,
+      backend: 'playwright',
+      ownsBrowser: false, // user's Chrome — caller must NOT close it
+      screenshotDir,
+    };
+  } catch (err) {
+    // Bridge connect succeeded but downstream setup failed. Drop the WS
+    // connection so we don't leak a CDP attachment on the user's Chrome.
+    await browser.close().catch(() => {});
+    throw err;
+  }
+}
 
 async function acquireViaCdp(opts: AcquireBrowserOptions): Promise<AcquiredBrowser> {
   const wsUrl = await resolveCdpUrl(opts.cdpUrl === 'auto' ? 'auto' : opts.cdpUrl, {


### PR DESCRIPTION
## Summary

Spike that lets existing Lobu Playwright connectors drive the user's **already-signed-in Chrome** via a `chrome.debugger`-backed extension, by way of [`playwriter`](https://github.com/remorses/playwriter) (MIT). Required for sites like Revolut / banking that fingerprint Lobu-launched Chromium or need MFA-trusted sessions.

### Why now

Existing browser modes (CDP via `cdp_url`, persistent `user_data_dir`, headless Playwright with cookies) all either launch a fresh Chromium or use a Lobu-managed profile. They lose to anti-bot detection on auth-walled sites where the user is already signed in with device trust established. The bridge sits Playwright on top of `chrome.debugger`-mediated CDP so the connector code is **unchanged** — only the connection URL differs.

Architecture:

```
worker host (Node)             local relay         Chrome extension      user's Chrome
─────────────                  ─────────────       ──────────────       ──────────────
chromium.connectOverCDP(url) ─ WS server :19988 ── WS client            chrome.debugger
                               + browser-level                          on user's tabs
                               CDP shim (Target.*)
```

The shim — making `connectOverCDP` work over `chrome.debugger` — is the load-bearing trick. `playwriter` solves it; we wrap it.

## What's in this PR

- `@lobu/browser-bridge` workspace package. Thin wrapper over `playwriter@0.1.0`, exposes `startBridgeServer({ port?, host?, token? }) → { url, close }`.
- `acquireBrowser` gains `bridgeUrl` + `bridgeAuthToken` options. When set, uses `chromium.connectOverCDP(bridgeUrl, { headers: { authorization: \`Bearer …\` } })` and returns the user's **existing default context** (not a fresh incognito `newContext`, which would silently lose the session). `ownsBrowser=false` so cleanup doesn't close the user's Chrome.
- Wire-level smoke test that boots the relay and verifies it answers Playwright's CDP `/json/version` discovery probe.

## What's deliberately out of scope (follow-ups)

- **The extension itself.** For now, load `playwriter`'s unpacked extension manually. A follow-up PR folds a Lobu-branded extension into `apps/chrome/` in the owletto submodule.
- **Mac menu-bar "Use my Chrome" toggle** and per-profile capability gates in `BrowserProfilesView.swift`.
- **Device-pinning UI** in the connections admin (the existing `device_worker_id` primitive is the routing path).
- **Production auth + audit**: token rotation, per-session caps, per-attach consent UI, structured audit-log emission on session open/close.
- **End-to-end test against real Chrome.** Manual for the spike per the README — needs a Chrome with the playwriter extension loaded plus a Playwright snippet.

## Test plan

- [x] `bun test src` in `packages/browser-bridge` — 3 pass
- [x] `make build-packages`
- [x] `make typecheck` (strict, matches Dockerfile)
- [ ] Manual e2e: load playwriter extension in real Chrome, run a Lobu connector with `bridgeUrl` set, verify it drives the user's signed-in tab. (Operator step — out of scope for CI.)

## Notes for reviewers

- `acquireBrowser` failure cascade for bridge mode is fail-fast (no fallback to headless Playwright). Reasoning: when the caller picked bridge mode, silently falling back to a fresh headless Chromium would lose the user's session and (for Revolut etc.) get the connector blocked. Loud failure is correct.
- Static `playwriter` import in `@lobu/browser-bridge`; **dynamic** `import('playwright')` in `acquireViaBridge` to match the existing pattern in `acquireViaPersistent` (playwright is an optional peer dep).
- See `packages/browser-bridge/README.md` for the full architecture writeup, manual-verification recipe, and follow-up checklist.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New browser bridge package enabling a CDP relay to connect to an already-signed-in Chrome via a relay URL (token-in-query auth); acquisition flow adds a bridge option and returns a non-owning browser session so the user’s Chrome remains left open.

* **Documentation**
  * Added comprehensive usage, auth guidance, scope/next-steps, manual verification steps, and license notes.

* **Tests**
  * Updated smoke tests to validate bridge URL shape and token-based auth behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lobu-ai/lobu/pull/819?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->