### PR TITLE
feat(browser-bridge-mcp): SPIKE — MS @playwright/mcp bridge (supersedes #819)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -42,6 +42,18 @@
         "bun": ">=1.0.0",
       },
     },
+    "packages/browser-bridge-mcp": {
+      "name": "@lobu/browser-bridge-mcp",
+      "version": "0.0.0",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.0.0",
+        "@playwright/mcp": "^0.0.75",
+      },
+      "devDependencies": {
+        "@types/node": "20.19.9",
+        "typescript": "^5.7.2",
+      },
+    },
     "packages/cli": {
       "name": "@lobu/cli",
       "version": "7.0.0",
@@ -992,6 +1004,8 @@
 
     "@lezer/lr": ["@lezer/lr@1.4.10", "", { "dependencies": { "@lezer/common": "^1.0.0" } }, "sha512-rnCpTIBafOx4mRp43xOxDJbFipJm/c0cia/V5TiGlhmMa+wsSdoGmUN3w5Bqrks/09Q/D4tNAmWaT8p6NRi77A=="],
 
+    "@lobu/browser-bridge-mcp": ["@lobu/browser-bridge-mcp@workspace:packages/browser-bridge-mcp"],
+
     "@lobu/cli": ["@lobu/cli@workspace:packages/cli"],
 
     "@lobu/connector-sdk": ["@lobu/connector-sdk@workspace:packages/connector-sdk"],
@@ -1289,6 +1303,8 @@
     "@pinojs/redact": ["@pinojs/redact@0.4.0", "", {}, "sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg=="],
 
     "@pkgjs/parseargs": ["@pkgjs/parseargs@0.11.0", "", {}, "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg=="],
+
+    "@playwright/mcp": ["@playwright/mcp@0.0.75", "", { "dependencies": { "playwright": "1.61.0-alpha-1778188671000", "playwright-core": "1.61.0-alpha-1778188671000" }, "bin": { "playwright-mcp": "cli.js" } }, "sha512-oBjzVXfEGZ9Ev45tKKQULNDVdF83B82lg0uPejEK3xsp/zWmdNdNVnPi032fmd/o20ZZXs+LX7cr77qRNbV4VA=="],
 
     "@polyglot-sql/sdk": ["@polyglot-sql/sdk@0.1.15", "", {}, "sha512-FwzwZvEO6qca4ZWqH3cluAzE91uyJsthokRii8muevugT1uRqFCEgBD6UBOJKHAb1kX1nduNfNYD6SWsciq0ZQ=="],
 
@@ -3192,7 +3208,7 @@
 
     "playwright": ["patchright@1.59.4", "", { "dependencies": { "patchright-core": "v1.59.4" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "patchright": "cli.js" } }, "sha512-RDZ40tBZHZtTAMoUoct/IpMA1wrozPZGU2RFk8NIDEndOEBbLxS0dH2fRLiwsNrgXgjZGA/3krrTlzK+uFGgoQ=="],
 
-    "playwright-core": ["playwright-core@1.60.0", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA=="],
+    "playwright-core": ["playwright-core@1.61.0-alpha-1778188671000", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-nsw2Crz0uZS3IRHiEcOXUt+RaKB/Hna+GAD4oD6cPqCHfJfW77cJdgktC0jzp3Ndyv23EJI3bcWSqFIiqSNE5A=="],
 
     "playwright-vanilla": ["playwright@1.60.0", "", { "dependencies": { "playwright-core": "1.60.0" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA=="],
 
@@ -4012,6 +4028,8 @@
 
     "@opentelemetry/sdk-trace-base/@opentelemetry/semantic-conventions": ["@opentelemetry/semantic-conventions@1.28.0", "", {}, "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA=="],
 
+    "@playwright/mcp/playwright": ["playwright@1.61.0-alpha-1778188671000", "", { "dependencies": { "playwright-core": "1.61.0-alpha-1778188671000" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-A6fFc7ExLRmvm0ZHqCyY2uHXSvEdpb8W+/HyIPK4ecRqNil8Mc1Vig1WFYoqk82x3+U9Qb571fQE95wgKqIQ1g=="],
+
     "@prefresh/vite/@rollup/pluginutils": ["@rollup/pluginutils@4.2.1", "", { "dependencies": { "estree-walker": "^2.0.1", "picomatch": "^2.2.2" } }, "sha512-iKnFXr7NkdZAIHiIWE+BX5ULi/ucVFYWD6TbAV+rZctiRTY2PL6tsIKhoIOaoskiWAkgu+VsbXgUVDNLHf+InQ=="],
 
     "@radix-ui/react-accordion/@radix-ui/react-context": ["@radix-ui/react-context@1.1.2", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA=="],
@@ -4319,6 +4337,8 @@
     "parse5-htmlparser2-tree-adapter/parse5": ["parse5@6.0.1", "", {}, "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw=="],
 
     "pixelmatch/pngjs": ["pngjs@6.0.0", "", {}, "sha512-TRzzuFRRmEoSW/p1KVAmiOgPco2Irlah+bGFCeNfJXxxYGwSw7YwAOAcd7X28K/m5bjBWKsC29KyoMfHbypayg=="],
+
+    "playwright-vanilla/playwright-core": ["playwright-core@1.60.0", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA=="],
 
     "prebuild-install/tar-fs": ["tar-fs@2.1.4", "", { "dependencies": { "chownr": "^1.1.1", "mkdirp-classic": "^0.5.2", "pump": "^3.0.0", "tar-stream": "^2.1.4" } }, "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ=="],
 

--- a/packages/browser-bridge-mcp/README.md
+++ b/packages/browser-bridge-mcp/README.md
@@ -1,0 +1,120 @@
+# @lobu/browser-bridge-mcp — SPIKE
+
+Bridges Lobu connectors to the user's already-signed-in Chrome via
+Microsoft's [`@playwright/mcp`](https://github.com/microsoft/playwright-mcp)
++ the Playwright MCP Bridge Chrome extension
+([`mmlmfjhmonkocbjadbfplnigmagldckm`](https://chromewebstore.google.com/detail/playwright-extension/mmlmfjhmonkocbjadbfplnigmagldckm),
+MS-published).
+
+This package supersedes the playwriter-based `@lobu/browser-bridge` spike
+(PR #819) — see the maintenance writeup there for why. tl;dr: same
+architecture, Microsoft-maintained, clean dep tree, no fork-of-Playwright.
+
+## Architecture
+
+```
+Lobu worker host (Node)        local MCP HTTP server        MS Bridge ext     user's Chrome
+─────────────────────         ────────────────────         ─────────────     ─────────────
+MCP client (browser_navigate, ── playwright-mcp        ──  WebSocket  ──    chrome.debugger
+            browser_click,...)   --extension --port        client            on user's tabs
+                                 (spawned as child)
+```
+
+## What this PR proves
+
+| | |
+|---|---|
+| ✅ MCP bridge server spawn | `startMcpBridgeServer({ port, host })` spawns `playwright-mcp --extension`, waits for HTTP readiness, hands back a clean handle. |
+| ✅ MCP client handshake | An `@modelcontextprotocol/sdk` `Client` connects via `StreamableHTTPClientTransport` to `${url}/mcp` and completes the MCP initialize roundtrip. |
+| ✅ Expected tool surface | Lists tools and verifies `browser_navigate`, `browser_click`, `browser_snapshot` are advertised. Concrete signal we're talking to playwright-mcp, not a random HTTP server. |
+| ✅ Connector-facing API | `acquireBridgeMcp({ bridgeUrl })` wraps the URL composition + handshake into one call for connector authors. |
+
+## What this PR does NOT prove (deferred)
+
+- **Extension install in the user's Chrome.** The MS Playwright Bridge
+  extension is on the Chrome Web Store; until the user installs it, tool
+  calls (`browser_navigate` etc.) will fail with "no browser connected"
+  inside the MCP server. The Mac menu-bar app's "Allow Lobu to use this
+  browser" toggle is what should bundle that install — that's the
+  next-spike scope.
+- **End-to-end with a real attached tab.** Requires the extension above.
+  Manual operator verification recipe is in the PR description.
+- **Connector authoring story.** Connectors that use this bridge talk MCP
+  tools, not the Playwright `Browser`/`Page` API. That's a new authoring
+  model for the small subset of connectors that need user's-real-Chrome
+  (Revolut, banking). Stays out of this PR; the first such connector will
+  flesh the pattern out.
+- **Production auth + audit.** The MCP HTTP server binds to loopback by
+  default; that's the only security posture. Per-tool auth, per-session
+  scoping, audit logging, and the Mac per-profile consent surface are
+  follow-ups.
+
+## Usage
+
+Server side (typically owned by the Mac menu-bar app or the Lobu gateway):
+
+```ts
+import { startMcpBridgeServer } from '@lobu/browser-bridge-mcp';
+
+const bridge = await startMcpBridgeServer({ port: 19998 });
+console.log(bridge.url); // http://localhost:19998
+
+// ... later ...
+await bridge.close();
+```
+
+Connector side:
+
+```ts
+import { acquireBridgeMcp } from '@lobu/browser-bridge-mcp';
+
+const { client, close } = await acquireBridgeMcp({
+  bridgeUrl: 'http://localhost:19998',
+  clientName: 'lobu/revolut-connector',
+});
+try {
+  await client.callTool({
+    name: 'browser_navigate',
+    arguments: { url: 'https://app.revolut.com' },
+  });
+  const snap = await client.callTool({
+    name: 'browser_snapshot',
+    arguments: {},
+  });
+  // ... act on snapshot, click, evaluate, ...
+} finally {
+  await close();
+}
+```
+
+## Why MCP tool surface instead of Playwright Browser
+
+`@playwright/mcp` exposes an MCP server, not a Playwright endpoint. There
+is no JS API to extract a `BrowserContext` connected to the extension —
+the `createConnection(config, contextGetter)` factory expects you to
+*provide* a context, not receive one. So our wrapper is "spawn the bin in
+extension mode and let it own the browser connection."
+
+For Lobu specifically, the connectors that need this bridge are a small
+subset (sites that fingerprint or need MFA-trusted sessions — Revolut,
+banking). Connectors that don't need the user's real Chrome continue to
+use the existing `acquireBrowser` Playwright path in `@lobu/connector-sdk`
+against a managed Chromium. Two surfaces, each in its zone of strength.
+
+## Manual e2e (operator step)
+
+Until the Mac app handles extension install + per-profile consent:
+
+1. `bunx playwright-mcp --extension --port 19998` (or via this package's
+   `startMcpBridgeServer`).
+2. Install [Microsoft's Playwright Bridge extension](https://chromewebstore.google.com/detail/playwright-extension/mmlmfjhmonkocbjadbfplnigmagldckm)
+   in your Chrome.
+3. Click the extension's toolbar icon on a tab to attach.
+4. Run an MCP client snippet (e.g. via the `acquireBridgeMcp` example
+   above) that calls `browser_navigate` + `browser_snapshot` and verifies
+   the snapshot reflects your real browser state.
+
+## License
+
+BUSL-1.1 (Lobu wrapper). Depends on Microsoft's `@playwright/mcp`
+(Apache-2.0).

--- a/packages/browser-bridge-mcp/README.md
+++ b/packages/browser-bridge-mcp/README.md
@@ -45,9 +45,24 @@ MCP client (browser_navigate, ── playwright-mcp        ──  WebSocket  �
   (Revolut, banking). Stays out of this PR; the first such connector will
   flesh the pattern out.
 - **Production auth + audit.** The MCP HTTP server binds to loopback by
-  default; that's the only security posture. Per-tool auth, per-session
-  scoping, audit logging, and the Mac per-profile consent surface are
-  follow-ups.
+  default; that's the only security posture. Loopback is not a hard
+  security boundary — any local process can reach the port. Production
+  needs: random port + capability token in the URL, per-tool consent
+  scoping, audit log per call, and the Mac per-profile consent surface.
+  Follow-up.
+- **Typed connector helpers.** `acquireBridgeMcp` returns a raw MCP
+  `Client` today. Connector authors shouldn't have to memorise tool names
+  or parse raw tool results long-term — a typed helper layer
+  (`navigate(url)`, `snapshot()`, `click(ref)`, `evaluate(...)`) with
+  normalised errors (`"extension missing"`, `"no browser attached"`,
+  `"tool unavailable"`) is the right level. Stays out of this spike;
+  added alongside the first MCP-based connector so the helper shape is
+  driven by real usage.
+- **Wire into `make build-packages` + publish scripts.** Currently this
+  package builds only via its own `bun run build`. Wire it into the
+  monorepo build/publish only once the bridge has a first concrete
+  consumer (the first MCP-based connector) — until then it's a spike
+  artifact, intentionally not on the release path.
 
 ## Usage
 
@@ -95,11 +110,27 @@ the `createConnection(config, contextGetter)` factory expects you to
 *provide* a context, not receive one. So our wrapper is "spawn the bin in
 extension mode and let it own the browser connection."
 
+**Explicit consequence: existing Playwright `Browser`/`Page` connectors
+are NOT portable to this bridge as-is.** A bridge connector must be
+written (or rewritten) against MCP tools: `browser_navigate(url)`,
+`browser_snapshot()`, `browser_click({ ref })`, `browser_evaluate(...)`,
+etc. The snapshot model (refs into an accessibility-tree-like structure)
+is different from Playwright's locator model. Plan a real rewrite, not a
+type-swap.
+
 For Lobu specifically, the connectors that need this bridge are a small
 subset (sites that fingerprint or need MFA-trusted sessions — Revolut,
 banking). Connectors that don't need the user's real Chrome continue to
 use the existing `acquireBrowser` Playwright path in `@lobu/connector-sdk`
 against a managed Chromium. Two surfaces, each in its zone of strength.
+
+## Version coupling
+
+`@playwright/mcp` is `0.0.x` and pulls alpha Playwright. We pin the major
+range; expected tool names live in `EXPECTED_BROWSER_TOOLS` and the smoke
+suite asserts on them. **Treat any `@playwright/mcp` upgrade as
+breaking-by-default** — rerun manual e2e (extension install + tool
+roundtrip) and update `EXPECTED_BROWSER_TOOLS` if anything moved.
 
 ## Manual e2e (operator step)
 

--- a/packages/browser-bridge-mcp/package.json
+++ b/packages/browser-bridge-mcp/package.json
@@ -1,0 +1,46 @@
+{
+  "name": "@lobu/browser-bridge-mcp",
+  "version": "0.0.0",
+  "description": "Bridge that lets Lobu connectors drive the user's already-signed-in Chrome via Microsoft's @playwright/mcp + the Playwright MCP Bridge extension. Replaces the playwriter-based @lobu/browser-bridge spike (#819) — see PR for the why.",
+  "license": "BUSL-1.1",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      }
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "typecheck": "tsc --noEmit",
+    "test": "bun test src",
+    "clean": "rm -rf dist"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.0.0",
+    "@playwright/mcp": "^0.0.75"
+  },
+  "devDependencies": {
+    "@types/node": "20.19.9",
+    "typescript": "^5.7.2"
+  },
+  "engines": {
+    "node": ">=20"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "homepage": "https://github.com/lobu-ai/lobu",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/lobu-ai/lobu.git",
+    "directory": "packages/browser-bridge-mcp"
+  }
+}

--- a/packages/browser-bridge-mcp/src/__tests__/bridge.smoke.test.ts
+++ b/packages/browser-bridge-mcp/src/__tests__/bridge.smoke.test.ts
@@ -48,8 +48,13 @@ describe("browser-bridge-mcp smoke", () => {
   });
 
   test("MCP client can connect and list browser_* tools", async () => {
-    const client = new Client({ name: "lobu-bridge-smoke", version: "0.0.0" }, {});
-    const transport = new StreamableHTTPClientTransport(new URL(`${bridge.url}/mcp`));
+    const client = new Client(
+      { name: "lobu-bridge-smoke", version: "0.0.0" },
+      {}
+    );
+    const transport = new StreamableHTTPClientTransport(
+      new URL(`${bridge.url}/mcp`)
+    );
     try {
       await client.connect(transport);
       const { tools } = await client.listTools();

--- a/packages/browser-bridge-mcp/src/__tests__/bridge.smoke.test.ts
+++ b/packages/browser-bridge-mcp/src/__tests__/bridge.smoke.test.ts
@@ -18,6 +18,7 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 import {
   acquireBridgeMcp,
+  EXPECTED_BROWSER_TOOLS,
   startMcpBridgeServer,
   type McpBridgeServer,
 } from "../index.js";
@@ -61,12 +62,13 @@ describe("browser-bridge-mcp smoke", () => {
       expect(tools.length).toBeGreaterThan(0);
 
       // Microsoft's playwright-mcp ships standard browser_* tools when run
-      // with --extension. Concrete signal that we're talking to the right
-      // server, not just a random HTTP service.
-      const toolNames = tools.map((t) => t.name);
-      expect(toolNames).toContain("browser_navigate");
-      expect(toolNames).toContain("browser_click");
-      expect(toolNames).toContain("browser_snapshot");
+      // with --extension. Pinned-contract assertion: if @playwright/mcp
+      // drops/renames any of these in a future release, this fails loud
+      // (intentional — versions are alpha-ish; upgrades need re-verifying).
+      const toolNames = new Set(tools.map((t) => t.name));
+      for (const expected of EXPECTED_BROWSER_TOOLS) {
+        expect(toolNames.has(expected)).toBe(true);
+      }
     } finally {
       await client.close().catch(() => undefined);
     }

--- a/packages/browser-bridge-mcp/src/__tests__/bridge.smoke.test.ts
+++ b/packages/browser-bridge-mcp/src/__tests__/bridge.smoke.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Spike-level wire test for @lobu/browser-bridge-mcp.
+ *
+ * Boots the MCP bridge server (which spawns `playwright-mcp --extension`),
+ * connects an MCP client to it, and verifies the standard browser tool
+ * surface is advertised. Does NOT require the Chrome extension to be
+ * installed — tool listing works without an attached browser.
+ *
+ * Confidence level: medium. Proves: child-process plumbing works, MCP HTTP
+ * server is reachable, MCP handshake succeeds, expected tool surface is
+ * present. Does NOT prove: actual browser_navigate roundtrip with a real
+ * Chrome + Playwright Bridge extension attached (manual operator step
+ * until the Mac app installs the extension automatically).
+ */
+
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import {
+  acquireBridgeMcp,
+  startMcpBridgeServer,
+  type McpBridgeServer,
+} from "../index.js";
+
+const TEST_PORT = 19997;
+
+describe("browser-bridge-mcp smoke", () => {
+  let bridge: McpBridgeServer;
+
+  beforeAll(async () => {
+    bridge = await startMcpBridgeServer({ port: TEST_PORT, host: "localhost" });
+  });
+
+  afterAll(async () => {
+    await bridge?.close();
+  });
+
+  test("url targets the playwright-mcp server", () => {
+    expect(bridge.url).toBe(`http://localhost:${TEST_PORT}`);
+  });
+
+  test("HTTP root responds (server is up)", async () => {
+    const res = await fetch(bridge.url);
+    // playwright-mcp may respond 200, 400, or 404 on bare `/` — any HTTP
+    // response means the server is listening. We just don't want
+    // ECONNREFUSED here.
+    expect(typeof res.status).toBe("number");
+  });
+
+  test("MCP client can connect and list browser_* tools", async () => {
+    const client = new Client({ name: "lobu-bridge-smoke", version: "0.0.0" }, {});
+    const transport = new StreamableHTTPClientTransport(new URL(`${bridge.url}/mcp`));
+    try {
+      await client.connect(transport);
+      const { tools } = await client.listTools();
+      expect(tools.length).toBeGreaterThan(0);
+
+      // Microsoft's playwright-mcp ships standard browser_* tools when run
+      // with --extension. Concrete signal that we're talking to the right
+      // server, not just a random HTTP service.
+      const toolNames = tools.map((t) => t.name);
+      expect(toolNames).toContain("browser_navigate");
+      expect(toolNames).toContain("browser_click");
+      expect(toolNames).toContain("browser_snapshot");
+    } finally {
+      await client.close().catch(() => undefined);
+    }
+  });
+
+  test("acquireBridgeMcp wraps the SDK client + advertises browser tools", async () => {
+    // Exercise the connector-facing entry point end-to-end against the same
+    // server — proves the URL composition (`${bridgeUrl}/mcp`) and the
+    // handshake work from the wrapper, not just the bare SDK client.
+    const acquired = await acquireBridgeMcp({
+      bridgeUrl: bridge.url,
+      clientName: "lobu-bridge-smoke-acquire",
+    });
+    try {
+      const { tools } = await acquired.client.listTools();
+      expect(tools.map((t) => t.name)).toContain("browser_navigate");
+    } finally {
+      await acquired.close();
+    }
+  });
+});

--- a/packages/browser-bridge-mcp/src/index.ts
+++ b/packages/browser-bridge-mcp/src/index.ts
@@ -1,0 +1,215 @@
+/**
+ * @lobu/browser-bridge-mcp — SPIKE (replaces #819 @lobu/browser-bridge)
+ *
+ * Bridges Lobu connectors to the user's already-signed-in Chrome via
+ * Microsoft's `@playwright/mcp --extension` + the Playwright MCP Bridge
+ * Chrome extension (`mmlmfjhmonkocbjadbfplnigmagldckm`, on the Chrome
+ * Web Store, MS-published).
+ *
+ * Architecture:
+ *
+ *     Lobu worker host (Node)        local MCP HTTP server        Chrome extension     user's Chrome
+ *     ----------------------         --------------------         ----------------     -------------
+ *     MCP client                  ── playwright-mcp           ── WebSocket          chrome.debugger
+ *     (browser_navigate,             --extension --port            client                on user's tabs
+ *      browser_click, ...)           Lobu spawns as a child
+ *
+ * Why this instead of the playwriter wrapper in #819:
+ *   - MS-maintained (Playwright team). Strongest possible bus factor.
+ *   - Clean dep tree: just `playwright` + `playwright-core`. No fork.
+ *   - Extension lives on the Chrome Web Store — we don't ship one.
+ *   - playwriter@0.1.0's CDP shim hangs Playwright's connectOverCDP after
+ *     extension attach (verified against playwriter directly without our
+ *     wrapper). MCP path sidesteps the shim entirely.
+ *
+ * Trade-off: connectors that use this bridge speak the MCP tool surface
+ * (`browser_navigate`, `browser_click`, `browser_evaluate`, ...), not the
+ * Playwright `Browser` / `Page` API. Connector authoring for the
+ * bridge-only case is a new model — see `acquireBridgeMcp` in
+ * `@lobu/connector-sdk` for the Lobu-side wrapping. Connectors that don't
+ * need the user's real Chrome stay on Playwright + managed Chromium.
+ *
+ * Spike status: this package only stands up the local MCP server and
+ * verifies the wire shape. Extension install in the user's Chrome, the
+ * Mac menu-bar toggle, the actual connector authoring model — all
+ * follow-ups. See README.
+ */
+
+import { spawn, type ChildProcess } from "node:child_process";
+import { createRequire } from "node:module";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+
+export interface McpBridgeServerOptions {
+  /** TCP port for the MCP HTTP server. Defaults to 19998 (different from playwriter's 19988). */
+  port?: number;
+  /** Bind host. Loopback by default. */
+  host?: "localhost" | "127.0.0.1" | "::1";
+  /** Extra args to forward to `playwright-mcp`. Use with caution; the spike pins `--extension`. */
+  extraArgs?: readonly string[];
+  /** stdio sink. Defaults to silent so the MCP server doesn't spam the connector log. */
+  stderr?: "inherit" | "ignore" | "pipe";
+}
+
+export interface McpBridgeServer {
+  /** MCP HTTP endpoint — pass directly to an MCP client (`mcpUrl + "/mcp"`). */
+  readonly url: string;
+  /** Stop the MCP server child process. */
+  close(): Promise<void>;
+}
+
+const NOOP = () => undefined;
+
+function resolveMcpBin(): string {
+  // playwright-mcp ships as a bin (`playwright-mcp` → `cli.js`). Resolve
+  // the package.json to find the script path; avoids hard-coding
+  // node_modules/.bin which may not exist under bunx-style usage.
+  const require = createRequire(import.meta.url);
+  const pkgPath = require.resolve("@playwright/mcp/package.json");
+  const pkg = require(pkgPath) as { bin?: string | Record<string, string> };
+  const binEntry =
+    typeof pkg.bin === "string" ? pkg.bin : (pkg.bin?.["playwright-mcp"] ?? "cli.js");
+  const pkgDir = pkgPath.replace(/[/\\]package\.json$/, "");
+  return `${pkgDir}/${binEntry}`;
+}
+
+async function waitForListening(url: string, timeoutMs: number): Promise<void> {
+  const start = Date.now();
+  let lastError: unknown;
+  while (Date.now() - start < timeoutMs) {
+    try {
+      // playwright-mcp answers GET / with the MCP discovery; we just want
+      // to know "something is listening." Any HTTP response counts.
+      const res = await fetch(url, { method: "GET" });
+      if (res.status > 0) return;
+    } catch (err) {
+      lastError = err;
+    }
+    await new Promise((r) => setTimeout(r, 100));
+  }
+  throw new Error(
+    `MCP bridge server did not start within ${timeoutMs}ms (last error: ${
+      lastError instanceof Error ? lastError.message : String(lastError)
+    })`
+  );
+}
+
+/**
+ * Start `playwright-mcp --extension --port <port>` as a child process.
+ *
+ * Caller usage:
+ *
+ *     const bridge = await startMcpBridgeServer({ port: 19998 });
+ *     // Connect an MCP client to `${bridge.url}/mcp` (see @modelcontextprotocol/sdk client).
+ *     // Tools: browser_navigate, browser_click, browser_evaluate, ...
+ *     await bridge.close();
+ *
+ * NOTE: This spike does NOT install the Microsoft Playwright Bridge
+ * Chrome extension. The operator must install it from the Web Store
+ * manually before the bridge can drive any real tab. Until installed,
+ * tool calls will return "no browser connected" errors from the MCP
+ * server. Follow-up: bundle the extension install into the Mac
+ * menu-bar app's "Allow Lobu to use this browser" toggle.
+ */
+export async function startMcpBridgeServer(
+  opts: McpBridgeServerOptions = {}
+): Promise<McpBridgeServer> {
+  const port = opts.port ?? 19998;
+  // Default to `localhost` (not `127.0.0.1`) because playwright-mcp's
+  // Host-header allow-list defaults to the host it's bound to, and MCP
+  // client URLs typically use `localhost` — Host headers must match.
+  const host = opts.host ?? "localhost";
+
+  const bin = resolveMcpBin();
+  const args = [
+    "--extension",
+    "--port",
+    String(port),
+    "--host",
+    host,
+    // Allow both forms in case a connector mints the URL with the IP.
+    "--allowed-hosts",
+    `localhost:${port},127.0.0.1:${port}`,
+    ...(opts.extraArgs ?? []),
+  ];
+
+  const child: ChildProcess = spawn(process.execPath, [bin, ...args], {
+    stdio: ["ignore", "ignore", opts.stderr ?? "ignore"],
+  });
+
+  child.once("error", NOOP); // surface via close() rejection if relevant
+  await waitForListening(`http://${host}:${port}/`, 10_000).catch(async (err) => {
+    child.kill("SIGTERM");
+    throw err;
+  });
+
+  let closed = false;
+  return {
+    url: `http://${host}:${port}`,
+    async close() {
+      if (closed) return;
+      closed = true;
+      if (child.exitCode !== null) return;
+      child.kill("SIGTERM");
+      await new Promise<void>((resolve) => {
+        const t = setTimeout(() => {
+          child.kill("SIGKILL");
+          resolve();
+        }, 2_000);
+        child.once("exit", () => {
+          clearTimeout(t);
+          resolve();
+        });
+      });
+    },
+  };
+}
+
+// ----------------------------------------------------------------------------
+// Connector-facing API: thin MCP client wrapper
+// ----------------------------------------------------------------------------
+
+export interface AcquireBridgeMcpOptions {
+  /** Bridge endpoint (from `BridgeServer.url`). The `/mcp` path is appended automatically. */
+  bridgeUrl: string;
+  /** Client identity sent in the MCP `initialize` handshake. */
+  clientName?: string;
+  clientVersion?: string;
+}
+
+export interface AcquiredBridgeMcp {
+  /** Connected MCP client. Call `callTool({ name, arguments })` to drive the browser. */
+  readonly client: Client;
+  /** Close the MCP transport. Does NOT stop the underlying bridge server. */
+  close(): Promise<void>;
+}
+
+/**
+ * Connector-side handle for the MCP bridge.
+ *
+ * The returned `client` is a connected `@modelcontextprotocol/sdk` Client.
+ * Use `client.callTool({ name: "browser_navigate", arguments: { url } })`
+ * etc. — list the available tools with `client.listTools()`.
+ *
+ * Connectors that need the user's real signed-in Chrome use this; everything
+ * else stays on the Playwright `acquireBrowser` path in connector-sdk.
+ */
+export async function acquireBridgeMcp(
+  opts: AcquireBridgeMcpOptions
+): Promise<AcquiredBridgeMcp> {
+  const client = new Client(
+    {
+      name: opts.clientName ?? "lobu-connector",
+      version: opts.clientVersion ?? "0.0.0",
+    },
+    {}
+  );
+  const transport = new StreamableHTTPClientTransport(new URL(`${opts.bridgeUrl}/mcp`));
+  await client.connect(transport);
+  return {
+    client,
+    async close() {
+      await client.close().catch(() => undefined);
+    },
+  };
+}

--- a/packages/browser-bridge-mcp/src/index.ts
+++ b/packages/browser-bridge-mcp/src/index.ts
@@ -68,7 +68,9 @@ function resolveMcpBin(): string {
   const pkgPath = require.resolve("@playwright/mcp/package.json");
   const pkg = require(pkgPath) as { bin?: string | Record<string, string> };
   const binEntry =
-    typeof pkg.bin === "string" ? pkg.bin : (pkg.bin?.["playwright-mcp"] ?? "cli.js");
+    typeof pkg.bin === "string"
+      ? pkg.bin
+      : (pkg.bin?.["playwright-mcp"] ?? "cli.js");
   const pkgDir = pkgPath.replace(/[/\\]package\.json$/, "");
   return `${pkgDir}/${binEntry}`;
 }
@@ -138,10 +140,12 @@ export async function startMcpBridgeServer(
   });
 
   child.once("error", NOOP); // surface via close() rejection if relevant
-  await waitForListening(`http://${host}:${port}/`, 10_000).catch(async (err) => {
-    child.kill("SIGTERM");
-    throw err;
-  });
+  await waitForListening(`http://${host}:${port}/`, 10_000).catch(
+    async (err) => {
+      child.kill("SIGTERM");
+      throw err;
+    }
+  );
 
   let closed = false;
   return {
@@ -204,7 +208,9 @@ export async function acquireBridgeMcp(
     },
     {}
   );
-  const transport = new StreamableHTTPClientTransport(new URL(`${opts.bridgeUrl}/mcp`));
+  const transport = new StreamableHTTPClientTransport(
+    new URL(`${opts.bridgeUrl}/mcp`)
+  );
   await client.connect(transport);
   return {
     client,

--- a/packages/browser-bridge-mcp/src/index.ts
+++ b/packages/browser-bridge-mcp/src/index.ts
@@ -40,6 +40,22 @@ import { createRequire } from "node:module";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 
+/**
+ * Tool names this wrapper expects to be advertised by `@playwright/mcp` when
+ * run with `--extension`. Centralised so the smoke test, runtime
+ * preflighting, and any future typed helpers can share one source of truth.
+ *
+ * `@playwright/mcp` is `0.0.x` and pulls alpha Playwright; treat these as a
+ * pinned-contract assertion. If an upgrade drops or renames any of these,
+ * the smoke test (and `acquireBridgeMcp` preflight, when added) fail loud
+ * with a clear "unsupported tool surface" message.
+ */
+export const EXPECTED_BROWSER_TOOLS = [
+  "browser_navigate",
+  "browser_click",
+  "browser_snapshot",
+] as const;
+
 export interface McpBridgeServerOptions {
   /** TCP port for the MCP HTTP server. Defaults to 19998 (different from playwriter's 19988). */
   port?: number;
@@ -47,8 +63,12 @@ export interface McpBridgeServerOptions {
   host?: "localhost" | "127.0.0.1" | "::1";
   /** Extra args to forward to `playwright-mcp`. Use with caution; the spike pins `--extension`. */
   extraArgs?: readonly string[];
-  /** stdio sink. Defaults to silent so the MCP server doesn't spam the connector log. */
-  stderr?: "inherit" | "ignore" | "pipe";
+  /**
+   * If true, the child's stderr is forwarded to this process's stderr.
+   * Default false — stderr is captured into a bounded ring buffer that's
+   * surfaced on startup failure so silent crashes are diagnosable.
+   */
+  logStderr?: boolean;
 }
 
 export interface McpBridgeServer {
@@ -75,10 +95,19 @@ function resolveMcpBin(): string {
   return `${pkgDir}/${binEntry}`;
 }
 
-async function waitForListening(url: string, timeoutMs: number): Promise<void> {
+async function waitForListening(
+  url: string,
+  timeoutMs: number,
+  childExited: { reason: string | null }
+): Promise<void> {
   const start = Date.now();
   let lastError: unknown;
   while (Date.now() - start < timeoutMs) {
+    if (childExited.reason) {
+      throw new Error(
+        `MCP bridge server child exited before ready: ${childExited.reason}`
+      );
+    }
     try {
       // playwright-mcp answers GET / with the MCP discovery; we just want
       // to know "something is listening." Any HTTP response counts.
@@ -95,6 +124,13 @@ async function waitForListening(url: string, timeoutMs: number): Promise<void> {
     })`
   );
 }
+
+function formatHostForUrl(host: string): string {
+  // IPv6 literals must be bracketed in URLs (e.g. http://[::1]:port).
+  return host.includes(":") && !host.startsWith("[") ? `[${host}]` : host;
+}
+
+const STDERR_BUFFER_BYTES = 32 * 1024;
 
 /**
  * Start `playwright-mcp --extension --port <port>` as a child process.
@@ -129,35 +165,89 @@ export async function startMcpBridgeServer(
     String(port),
     "--host",
     host,
-    // Allow both forms in case a connector mints the URL with the IP.
+    // Allow both forms so a connector that mints URLs with either name or
+    // IP works. Loopback binding is the actual security boundary.
     "--allowed-hosts",
-    `localhost:${port},127.0.0.1:${port}`,
+    `localhost:${port},127.0.0.1:${port},[::1]:${port}`,
     ...(opts.extraArgs ?? []),
   ];
 
   const child: ChildProcess = spawn(process.execPath, [bin, ...args], {
-    stdio: ["ignore", "ignore", opts.stderr ?? "ignore"],
+    stdio: ["ignore", "ignore", "pipe"],
   });
 
-  child.once("error", NOOP); // surface via close() rejection if relevant
-  await waitForListening(`http://${host}:${port}/`, 10_000).catch(
-    async (err) => {
-      child.kill("SIGTERM");
-      throw err;
+  // Track early exit so the readiness loop can fail fast instead of
+  // polling a port nothing's listening on for the full timeout.
+  const exited: { reason: string | null } = { reason: null };
+  child.once("exit", (code, signal) => {
+    exited.reason = signal ? `signal ${signal}` : `code ${code ?? "?"}`;
+  });
+  child.once("error", (err) => {
+    exited.reason = `spawn error: ${err.message}`;
+  });
+
+  // Bounded stderr ring buffer — surfaced on startup failure for
+  // diagnosability. If `logStderr` is true, also tee to this process.
+  let stderrBuf = "";
+  child.stderr?.on("data", (chunk: Buffer) => {
+    if (opts.logStderr) process.stderr.write(chunk);
+    stderrBuf += chunk.toString("utf8");
+    if (stderrBuf.length > STDERR_BUFFER_BYTES) {
+      stderrBuf = stderrBuf.slice(-STDERR_BUFFER_BYTES);
     }
-  );
+  });
+  child.stderr?.on("error", NOOP);
+
+  const readyUrl = `http://${formatHostForUrl(host)}:${port}/`;
+  try {
+    await waitForListening(readyUrl, 10_000, exited);
+  } catch (err) {
+    if (child.exitCode === null && !child.killed) child.kill("SIGTERM");
+    const tail = stderrBuf.trim().slice(-2_000);
+    const detail = tail ? `\n--- child stderr (tail) ---\n${tail}` : "";
+    throw new Error(`${err instanceof Error ? err.message : String(err)}${detail}`);
+  }
+
+  // Parent-exit cleanup so a crashed/killed parent doesn't orphan the
+  // playwright-mcp child. SIGINT/SIGTERM forward; `exit` is best-effort
+  // (synchronous kill, no wait).
+  const cleanupOnExit = () => {
+    if (child.exitCode === null && !child.killed) {
+      try {
+        child.kill("SIGTERM");
+      } catch {
+        // ignore
+      }
+    }
+  };
+  const forwardAndDie = (sig: NodeJS.Signals) => () => {
+    cleanupOnExit();
+    process.exit(sig === "SIGINT" ? 130 : 143);
+  };
+  const onSigint = forwardAndDie("SIGINT");
+  const onSigterm = forwardAndDie("SIGTERM");
+  process.once("exit", cleanupOnExit);
+  process.once("SIGINT", onSigint);
+  process.once("SIGTERM", onSigterm);
 
   let closed = false;
   return {
-    url: `http://${host}:${port}`,
+    url: `http://${formatHostForUrl(host)}:${port}`,
     async close() {
       if (closed) return;
       closed = true;
-      if (child.exitCode !== null) return;
+      process.removeListener("exit", cleanupOnExit);
+      process.removeListener("SIGINT", onSigint);
+      process.removeListener("SIGTERM", onSigterm);
+      if (child.exitCode !== null || child.killed) return;
       child.kill("SIGTERM");
       await new Promise<void>((resolve) => {
         const t = setTimeout(() => {
-          child.kill("SIGKILL");
+          try {
+            child.kill("SIGKILL");
+          } catch {
+            // ignore
+          }
           resolve();
         }, 2_000);
         child.once("exit", () => {

--- a/packages/browser-bridge-mcp/tsconfig.json
+++ b/packages/browser-bridge-mcp/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "module": "ESNext",
+    "target": "ES2022",
+    "moduleResolution": "bundler",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "./dist",
+    "resolveJsonModule": true,
+    "allowSyntheticDefaultImports": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": false
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "**/__tests__/**", "**/*.test.ts"]
+}


### PR DESCRIPTION
## Summary

Pivot from the playwriter-based `@lobu/browser-bridge` spike in #819. Same architecture (local relay between worker host and user's Chrome via a chrome.debugger-backed extension), but using **Microsoft's [`@playwright/mcp`](https://github.com/microsoft/playwright-mcp)** + the Microsoft-published Playwright MCP Bridge Chrome extension (`mmlmfjhmonkocbjadbfplnigmagldckm`) instead of `playwriter`.

### Why pivot

| | playwriter (#819) | playwright-mcp (this PR) |
|---|---|---|
| Bus factor | Solo (xmorse) | Microsoft Playwright team |
| Dep tree | ~100 packages incl. fork of Playwright (`@xmorse/playwright-core`) | Just `playwright` + `playwright-core` |
| Extension ship/maintain | We'd vendor/fork | On Chrome Web Store, MS-published |
| Wire e2e status | Hangs at CDP-shim handshake (verified in #819 against playwriter directly without the Lobu wrapper) | Works (see test results below) |
| Connector authoring | Playwright `Browser` (no rewrite) | MCP tool surface (rewrite for bridge-only connectors) |

The MCP tool-surface trade-off is real but bounded: only the small subset of connectors that need user's-real-Chrome (Revolut, banking, sites with MFA-trusted sessions) use this bridge. The rest stay on the existing `acquireBrowser` Playwright path against a managed Chromium. Two surfaces, each in its zone of strength.

## What this PR ships

New `@lobu/browser-bridge-mcp` workspace package:

- **`startMcpBridgeServer({ port?, host? })`** — spawns `playwright-mcp --extension --port <port>` as a child process, waits for HTTP readiness, hands back `{ url, close }`. Defaults to `localhost:19998` (off playwriter's 19988 so both can coexist during transition).
- **`acquireBridgeMcp({ bridgeUrl })`** — connector-facing wrapper around `@modelcontextprotocol/sdk`'s `Client` + `StreamableHTTPClientTransport`. Returns `{ client, close }` where `client.callTool({ name: "browser_navigate", ... })` etc. drives the user's Chrome.
- **4-test smoke suite** (passes locally):
  1. URL composition (`http://localhost:19998`).
  2. HTTP root responds (server is up).
  3. MCP client connects + `listTools()` advertises `browser_navigate`, `browser_click`, `browser_snapshot`.
  4. `acquireBridgeMcp` wraps the URL composition + handshake end-to-end.

## What this PR does NOT ship (deferred)

- Extension install in the user's Chrome — the MS Playwright Bridge ext is on the Web Store but the user has to install it manually until the Mac menu-bar app handles it. Until installed, `browser_navigate` etc. return "no browser connected" from the MCP server. This is the next-spike scope (alongside the per-profile consent toggle).
- E2E with a real attached tab — manual recipe in the README.
- First MCP-based connector — that's what'll flesh out the authoring pattern; touching it in this PR would balloon scope.
- Production auth/audit beyond loopback-only binding + Host-header allow-list.

## Relationship to PR #819

Recommend **closing #819** (or keeping open as a research artifact). The playwriter findings — particularly that v0.1.0's CDP shim hangs Playwright's `connectOverCDP` independently of my wrapper — are useful background. This PR carries forward the architecture decisions made there (per-profile pinning via `connections.device_worker_id` is still the routing primitive; the menu-bar toggle is still the consent UX) but swaps the underlying implementation.

## Test plan

- [x] `bun test src` in `packages/browser-bridge-mcp` — 4 pass
- [x] `make build-packages`
- [x] `make typecheck` (strict, matches Dockerfile)
- [ ] Manual e2e: install MS Playwright Bridge from Web Store, click toolbar icon on a tab, run an MCP client snippet that calls `browser_navigate` + `browser_snapshot`, verify snapshot reflects real browser state. (Operator step until Mac app handles extension install.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new browser bridge package enabling MCP integration with Chrome for browser automation and control.

* **Documentation**
  * Added comprehensive README with architecture, usage examples, operator checklist, and licensing notes.

* **Tests**
  * Added smoke tests validating bridge startup, HTTP responsiveness, and MCP client tool discovery.

* **Chores**
  * Added package manifest and TypeScript build/configuration for the new package.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lobu-ai/lobu/pull/821?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->