### PR TITLE
fix(server): ignore packages/owletto in dev watcher

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -9,8 +9,8 @@
     "node": ">=22 <25"
   },
   "scripts": {
-    "dev": "tsx watch --ignore=../web/** --ignore=../../node_modules/** src/server.ts",
-    "dev:local": "tsx watch --ignore=../web/** --ignore=../../node_modules/** src/start-local.ts",
+    "dev": "tsx watch --ignore=../web/** --ignore=../owletto/** --ignore=../../node_modules/** src/server.ts",
+    "dev:local": "tsx watch --ignore=../web/** --ignore=../owletto/** --ignore=../../node_modules/** src/start-local.ts",
     "start": "tsx src/server.ts",
     "build:server": "node ./scripts/build-server-bundle.mjs",
     "test": "vitest",


### PR DESCRIPTION
## Summary
- Follow-up to #789 (renamed submodule mount from \`packages/web\` to \`packages/owletto\`).
- The \`tsx watch\` ignore patterns in \`packages/server/package.json\` still excluded \`../web/**\` only; once Vite's HMR started writing timestamp files into \`packages/owletto/node_modules/.vite-temp/\`, tsx restarted the server every ~20s and \`make dev\` never finished booting.
- Add \`--ignore=../owletto/**\` to both \`dev\` and \`dev:local\` scripts.

## Test plan
- [x] \`make dev\` boots to "Server running" without the restart loop.
- [x] Vite HMR still picks up source edits under \`packages/owletto/src/**\`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development environment file watching configuration to optimize build performance during local development.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lobu-ai/lobu/pull/826?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->