### PR TITLE
feat(connectors): browser.evaluate connector + owletto submodule bump

### DIFF
--- a/packages/cli/src/commands/_lib/apply/__tests__/diff.test.ts
+++ b/packages/cli/src/commands/_lib/apply/__tests__/diff.test.ts
@@ -10,983 +10,983 @@ import { renderPlan, renderSummary } from "../render.js";
 chalk.level = 0;
 
 function buildDesiredAgent(
-	agentId: string,
-	overrides: Partial<DesiredAgent> = {},
+  agentId: string,
+  overrides: Partial<DesiredAgent> = {}
 ): DesiredAgent {
-	return {
-		metadata: { agentId, name: agentId, description: undefined },
-		settings: {},
-		platforms: [],
-		...overrides,
-	};
+  return {
+    metadata: { agentId, name: agentId, description: undefined },
+    settings: {},
+    platforms: [],
+    ...overrides,
+  };
 }
 
 function buildState(
-	agents: DesiredAgent[],
-	overrides: Partial<DesiredState> = {},
+  agents: DesiredAgent[],
+  overrides: Partial<DesiredState> = {}
 ): DesiredState {
-	return {
-		agents,
-		memorySchema: { entityTypes: [], relationshipTypes: [] },
-		watchers: [],
-		connectors: { definitions: [], authProfiles: [], connections: [] },
-		requiredSecrets: [],
-		...overrides,
-	};
+  return {
+    agents,
+    memorySchema: { entityTypes: [], relationshipTypes: [] },
+    watchers: [],
+    connectors: { definitions: [], authProfiles: [], connections: [] },
+    requiredSecrets: [],
+    ...overrides,
+  };
 }
 
 function emptyRemote(): RemoteSnapshot {
-	return {
-		agents: [],
-		agentSettings: new Map(),
-		platformsByAgent: new Map(),
-		entityTypes: [],
-		relationshipTypes: [],
-		watchers: [],
-		connectorDefinitions: [],
-		authProfiles: [],
-		connections: [],
-		feedsByConnectionId: new Map(),
-	};
+  return {
+    agents: [],
+    agentSettings: new Map(),
+    platformsByAgent: new Map(),
+    entityTypes: [],
+    relationshipTypes: [],
+    watchers: [],
+    connectorDefinitions: [],
+    authProfiles: [],
+    connections: [],
+    feedsByConnectionId: new Map(),
+  };
 }
 
 describe("apply diff — agents", () => {
-	test("create from empty remote", () => {
-		const desired = buildState([
-			buildDesiredAgent("triage", {
-				metadata: {
-					agentId: "triage",
-					name: "Triage",
-					description: "Triage bot",
-				},
-			}),
-		]);
-		const plan = computeDiff(desired, emptyRemote());
+  test("create from empty remote", () => {
+    const desired = buildState([
+      buildDesiredAgent("triage", {
+        metadata: {
+          agentId: "triage",
+          name: "Triage",
+          description: "Triage bot",
+        },
+      }),
+    ]);
+    const plan = computeDiff(desired, emptyRemote());
 
-		expect(plan.counts).toEqual({ create: 2, update: 0, noop: 0, drift: 0 });
-		expect(renderPlan(plan)).toMatchSnapshot();
-	});
+    expect(plan.counts).toEqual({ create: 2, update: 0, noop: 0, drift: 0 });
+    expect(renderPlan(plan)).toMatchSnapshot();
+  });
 
-	test("noop when remote matches desired", () => {
-		const desired = buildState([
-			buildDesiredAgent("triage", {
-				metadata: { agentId: "triage", name: "Triage" },
-			}),
-		]);
-		const remote: RemoteSnapshot = {
-			...emptyRemote(),
-			agents: [{ agentId: "triage", name: "Triage" }],
-			agentSettings: new Map([["triage", null]]),
-			platformsByAgent: new Map([["triage", []]]),
-		};
-		const plan = computeDiff(desired, remote);
-		expect(plan.counts.noop).toBeGreaterThan(0);
-		expect(plan.counts.create).toBe(0);
-		expect(plan.counts.update).toBe(0);
-		expect(renderPlan(plan)).toMatchSnapshot();
-	});
+  test("noop when remote matches desired", () => {
+    const desired = buildState([
+      buildDesiredAgent("triage", {
+        metadata: { agentId: "triage", name: "Triage" },
+      }),
+    ]);
+    const remote: RemoteSnapshot = {
+      ...emptyRemote(),
+      agents: [{ agentId: "triage", name: "Triage" }],
+      agentSettings: new Map([["triage", null]]),
+      platformsByAgent: new Map([["triage", []]]),
+    };
+    const plan = computeDiff(desired, remote);
+    expect(plan.counts.noop).toBeGreaterThan(0);
+    expect(plan.counts.create).toBe(0);
+    expect(plan.counts.update).toBe(0);
+    expect(renderPlan(plan)).toMatchSnapshot();
+  });
 
-	test("update when name differs", () => {
-		const desired = buildState([
-			buildDesiredAgent("triage", {
-				metadata: { agentId: "triage", name: "Renamed" },
-			}),
-		]);
-		const remote: RemoteSnapshot = {
-			...emptyRemote(),
-			agents: [{ agentId: "triage", name: "Original" }],
-			agentSettings: new Map([["triage", null]]),
-			platformsByAgent: new Map([["triage", []]]),
-		};
-		const plan = computeDiff(desired, remote);
-		expect(plan.counts.update).toBeGreaterThan(0);
-		expect(renderPlan(plan)).toMatchSnapshot();
-	});
+  test("update when name differs", () => {
+    const desired = buildState([
+      buildDesiredAgent("triage", {
+        metadata: { agentId: "triage", name: "Renamed" },
+      }),
+    ]);
+    const remote: RemoteSnapshot = {
+      ...emptyRemote(),
+      agents: [{ agentId: "triage", name: "Original" }],
+      agentSettings: new Map([["triage", null]]),
+      platformsByAgent: new Map([["triage", []]]),
+    };
+    const plan = computeDiff(desired, remote);
+    expect(plan.counts.update).toBeGreaterThan(0);
+    expect(renderPlan(plan)).toMatchSnapshot();
+  });
 
-	test("drift when remote has agent not in desired", () => {
-		const desired = buildState([]);
-		const remote: RemoteSnapshot = {
-			...emptyRemote(),
-			agents: [{ agentId: "stale", name: "Stale Agent" }],
-		};
-		const plan = computeDiff(desired, remote);
-		expect(plan.counts.drift).toBe(1);
-		expect(renderPlan(plan)).toMatchSnapshot();
-	});
+  test("drift when remote has agent not in desired", () => {
+    const desired = buildState([]);
+    const remote: RemoteSnapshot = {
+      ...emptyRemote(),
+      agents: [{ agentId: "stale", name: "Stale Agent" }],
+    };
+    const plan = computeDiff(desired, remote);
+    expect(plan.counts.drift).toBe(1);
+    expect(renderPlan(plan)).toMatchSnapshot();
+  });
 });
 
 describe("apply diff — settings", () => {
-	test("update on networkConfig change", () => {
-		const desired = buildState([
-			buildDesiredAgent("triage", {
-				metadata: { agentId: "triage", name: "Triage" },
-				settings: {
-					networkConfig: { allowedDomains: ["github.com"] },
-				},
-			}),
-		]);
-		const remote: RemoteSnapshot = {
-			...emptyRemote(),
-			agents: [{ agentId: "triage", name: "Triage" }],
-			agentSettings: new Map<string, AgentSettings | null>([
-				[
-					"triage",
-					{
-						networkConfig: { allowedDomains: ["pypi.org"] },
-						updatedAt: 0,
-					},
-				],
-			]),
-			platformsByAgent: new Map([["triage", []]]),
-		};
-		const plan = computeDiff(desired, remote);
-		const settingsRow = plan.rows.find((r) => r.kind === "settings");
-		expect(settingsRow?.verb).toBe("update");
-		if (settingsRow?.kind === "settings") {
-			expect(settingsRow.changedFields).toContain("networkConfig");
-		}
-		expect(renderPlan(plan)).toMatchSnapshot();
-	});
+  test("update on networkConfig change", () => {
+    const desired = buildState([
+      buildDesiredAgent("triage", {
+        metadata: { agentId: "triage", name: "Triage" },
+        settings: {
+          networkConfig: { allowedDomains: ["github.com"] },
+        },
+      }),
+    ]);
+    const remote: RemoteSnapshot = {
+      ...emptyRemote(),
+      agents: [{ agentId: "triage", name: "Triage" }],
+      agentSettings: new Map<string, AgentSettings | null>([
+        [
+          "triage",
+          {
+            networkConfig: { allowedDomains: ["pypi.org"] },
+            updatedAt: 0,
+          },
+        ],
+      ]),
+      platformsByAgent: new Map([["triage", []]]),
+    };
+    const plan = computeDiff(desired, remote);
+    const settingsRow = plan.rows.find((r) => r.kind === "settings");
+    expect(settingsRow?.verb).toBe("update");
+    if (settingsRow?.kind === "settings") {
+      expect(settingsRow.changedFields).toContain("networkConfig");
+    }
+    expect(renderPlan(plan)).toMatchSnapshot();
+  });
 
-	test("updates when provider declarations change but ignores installedAt churn", () => {
-		const desired = buildState([
-			buildDesiredAgent("triage", {
-				metadata: { agentId: "triage", name: "Triage" },
-				settings: {
-					installedProviders: [
-						{ providerId: "anthropic", installedAt: 200 },
-						{ providerId: "openai", installedAt: 200 },
-					],
-				},
-			}),
-		]);
-		const remote: RemoteSnapshot = {
-			...emptyRemote(),
-			agents: [{ agentId: "triage", name: "Triage" }],
-			agentSettings: new Map<string, AgentSettings | null>([
-				[
-					"triage",
-					{
-						installedProviders: [{ providerId: "anthropic", installedAt: 100 }],
-						updatedAt: 0,
-					},
-				],
-			]),
-			platformsByAgent: new Map([["triage", []]]),
-		};
-		const plan = computeDiff(desired, remote);
-		const settingsRow = plan.rows.find((r) => r.kind === "settings");
-		expect(settingsRow?.verb).toBe("update");
-		if (settingsRow?.kind === "settings") {
-			expect(settingsRow.changedFields).toContain("installedProviders");
-		}
+  test("updates when provider declarations change but ignores installedAt churn", () => {
+    const desired = buildState([
+      buildDesiredAgent("triage", {
+        metadata: { agentId: "triage", name: "Triage" },
+        settings: {
+          installedProviders: [
+            { providerId: "anthropic", installedAt: 200 },
+            { providerId: "openai", installedAt: 200 },
+          ],
+        },
+      }),
+    ]);
+    const remote: RemoteSnapshot = {
+      ...emptyRemote(),
+      agents: [{ agentId: "triage", name: "Triage" }],
+      agentSettings: new Map<string, AgentSettings | null>([
+        [
+          "triage",
+          {
+            installedProviders: [{ providerId: "anthropic", installedAt: 100 }],
+            updatedAt: 0,
+          },
+        ],
+      ]),
+      platformsByAgent: new Map([["triage", []]]),
+    };
+    const plan = computeDiff(desired, remote);
+    const settingsRow = plan.rows.find((r) => r.kind === "settings");
+    expect(settingsRow?.verb).toBe("update");
+    if (settingsRow?.kind === "settings") {
+      expect(settingsRow.changedFields).toContain("installedProviders");
+    }
 
-		const unchanged = computeDiff(desired, {
-			...remote,
-			agentSettings: new Map<string, AgentSettings | null>([
-				[
-					"triage",
-					{
-						installedProviders: [
-							{ providerId: "anthropic", installedAt: 1 },
-							{ providerId: "openai", installedAt: 2 },
-						],
-						updatedAt: 0,
-					},
-				],
-			]),
-		});
-		const unchangedSettingsRow = unchanged.rows.find(
-			(r) => r.kind === "settings",
-		);
-		expect(unchangedSettingsRow?.verb).toBe("noop");
-	});
+    const unchanged = computeDiff(desired, {
+      ...remote,
+      agentSettings: new Map<string, AgentSettings | null>([
+        [
+          "triage",
+          {
+            installedProviders: [
+              { providerId: "anthropic", installedAt: 1 },
+              { providerId: "openai", installedAt: 2 },
+            ],
+            updatedAt: 0,
+          },
+        ],
+      ]),
+    });
+    const unchangedSettingsRow = unchanged.rows.find(
+      (r) => r.kind === "settings"
+    );
+    expect(unchangedSettingsRow?.verb).toBe("noop");
+  });
 });
 
 describe("apply diff — platforms", () => {
-	test("create on empty remote", () => {
-		const desired = buildState([
-			buildDesiredAgent("triage", {
-				metadata: { agentId: "triage", name: "Triage" },
-				platforms: [
-					{
-						stableId: "triage-telegram",
-						type: "telegram",
-						config: { botToken: "abc" },
-					},
-				],
-			}),
-		]);
-		const plan = computeDiff(desired, emptyRemote());
-		const platformRow = plan.rows.find((r) => r.kind === "platform");
-		expect(platformRow?.verb).toBe("create");
-		expect(renderPlan(plan)).toMatchSnapshot();
-	});
+  test("create on empty remote", () => {
+    const desired = buildState([
+      buildDesiredAgent("triage", {
+        metadata: { agentId: "triage", name: "Triage" },
+        platforms: [
+          {
+            stableId: "triage-telegram",
+            type: "telegram",
+            config: { botToken: "abc" },
+          },
+        ],
+      }),
+    ]);
+    const plan = computeDiff(desired, emptyRemote());
+    const platformRow = plan.rows.find((r) => r.kind === "platform");
+    expect(platformRow?.verb).toBe("create");
+    expect(renderPlan(plan)).toMatchSnapshot();
+  });
 
-	test("update with willRestart when config changes", () => {
-		const desired = buildState([
-			buildDesiredAgent("triage", {
-				metadata: { agentId: "triage", name: "Triage" },
-				platforms: [
-					{
-						stableId: "triage-telegram",
-						type: "telegram",
-						config: { botToken: "new" },
-					},
-				],
-			}),
-		]);
-		const remote: RemoteSnapshot = {
-			...emptyRemote(),
-			agents: [{ agentId: "triage", name: "Triage" }],
-			agentSettings: new Map<string, AgentSettings | null>([["triage", null]]),
-			platformsByAgent: new Map([
-				[
-					"triage",
-					[
-						{
-							id: "triage-telegram",
-							platform: "telegram",
-							config: { botToken: "old" },
-						},
-					],
-				],
-			]),
-		};
-		const plan = computeDiff(desired, remote);
-		const platformRow = plan.rows.find((r) => r.kind === "platform");
-		expect(platformRow?.verb).toBe("update");
-		if (platformRow?.kind === "platform") {
-			expect(platformRow.willRestart).toBe(true);
-		}
-		expect(renderPlan(plan)).toMatchSnapshot();
-	});
+  test("update with willRestart when config changes", () => {
+    const desired = buildState([
+      buildDesiredAgent("triage", {
+        metadata: { agentId: "triage", name: "Triage" },
+        platforms: [
+          {
+            stableId: "triage-telegram",
+            type: "telegram",
+            config: { botToken: "new" },
+          },
+        ],
+      }),
+    ]);
+    const remote: RemoteSnapshot = {
+      ...emptyRemote(),
+      agents: [{ agentId: "triage", name: "Triage" }],
+      agentSettings: new Map<string, AgentSettings | null>([["triage", null]]),
+      platformsByAgent: new Map([
+        [
+          "triage",
+          [
+            {
+              id: "triage-telegram",
+              platform: "telegram",
+              config: { botToken: "old" },
+            },
+          ],
+        ],
+      ]),
+    };
+    const plan = computeDiff(desired, remote);
+    const platformRow = plan.rows.find((r) => r.kind === "platform");
+    expect(platformRow?.verb).toBe("update");
+    if (platformRow?.kind === "platform") {
+      expect(platformRow.willRestart).toBe(true);
+    }
+    expect(renderPlan(plan)).toMatchSnapshot();
+  });
 });
 
 describe("apply diff — memory schema", () => {
-	test("creates entity + relationship types", () => {
-		const desired: DesiredState = {
-			agents: [],
-			memorySchema: {
-				entityTypes: [{ slug: "company", name: "Company", required: ["name"] }],
-				relationshipTypes: [
-					{
-						slug: "works_at",
-						name: "Works At",
-						rules: [{ source: "person", target: "company" }],
-					},
-				],
-			},
-			watchers: [],
-			requiredSecrets: [],
-		};
-		const plan = computeDiff(desired, emptyRemote());
-		expect(plan.counts.create).toBe(2);
-		expect(renderPlan(plan)).toMatchSnapshot();
-	});
+  test("creates entity + relationship types", () => {
+    const desired: DesiredState = {
+      agents: [],
+      memorySchema: {
+        entityTypes: [{ slug: "company", name: "Company", required: ["name"] }],
+        relationshipTypes: [
+          {
+            slug: "works_at",
+            name: "Works At",
+            rules: [{ source: "person", target: "company" }],
+          },
+        ],
+      },
+      watchers: [],
+      requiredSecrets: [],
+    };
+    const plan = computeDiff(desired, emptyRemote());
+    expect(plan.counts.create).toBe(2);
+    expect(renderPlan(plan)).toMatchSnapshot();
+  });
 
-	test("noop when remote matches", () => {
-		const desired: DesiredState = {
-			agents: [],
-			memorySchema: {
-				entityTypes: [{ slug: "company", name: "Company" }],
-				relationshipTypes: [],
-			},
-			watchers: [],
-			requiredSecrets: [],
-		};
-		const remote: RemoteSnapshot = {
-			...emptyRemote(),
-			entityTypes: [{ slug: "company", name: "Company" }],
-		};
-		const plan = computeDiff(desired, remote);
-		expect(plan.counts.noop).toBe(1);
-		expect(plan.counts.update).toBe(0);
-	});
+  test("noop when remote matches", () => {
+    const desired: DesiredState = {
+      agents: [],
+      memorySchema: {
+        entityTypes: [{ slug: "company", name: "Company" }],
+        relationshipTypes: [],
+      },
+      watchers: [],
+      requiredSecrets: [],
+    };
+    const remote: RemoteSnapshot = {
+      ...emptyRemote(),
+      entityTypes: [{ slug: "company", name: "Company" }],
+    };
+    const plan = computeDiff(desired, remote);
+    expect(plan.counts.noop).toBe(1);
+    expect(plan.counts.update).toBe(0);
+  });
 });
 
 describe("apply diff — empty container preservation", () => {
-	// Bug fix: previously canonical() collapsed [] and {} to null, which
-	// meant clearing a remote allowlist by setting it to [] silently
-	// round-tripped as a noop instead of an update.
-	test("clearing networkConfig.allowedDomains from non-empty to [] is an update", () => {
-		const desired = buildState([
-			buildDesiredAgent("triage", {
-				metadata: { agentId: "triage", name: "Triage" },
-				settings: {
-					networkConfig: { allowedDomains: [] },
-				},
-			}),
-		]);
-		const remote: RemoteSnapshot = {
-			...emptyRemote(),
-			agents: [{ agentId: "triage", name: "Triage" }],
-			agentSettings: new Map<string, AgentSettings | null>([
-				[
-					"triage",
-					{
-						networkConfig: { allowedDomains: ["foo.com"] },
-						updatedAt: 0,
-					},
-				],
-			]),
-			platformsByAgent: new Map([["triage", []]]),
-		};
-		const plan = computeDiff(desired, remote);
-		const settingsRow = plan.rows.find((r) => r.kind === "settings");
-		expect(settingsRow?.verb).toBe("update");
-		if (settingsRow?.kind === "settings") {
-			expect(settingsRow.changedFields).toContain("networkConfig");
-		}
-	});
+  // Bug fix: previously canonical() collapsed [] and {} to null, which
+  // meant clearing a remote allowlist by setting it to [] silently
+  // round-tripped as a noop instead of an update.
+  test("clearing networkConfig.allowedDomains from non-empty to [] is an update", () => {
+    const desired = buildState([
+      buildDesiredAgent("triage", {
+        metadata: { agentId: "triage", name: "Triage" },
+        settings: {
+          networkConfig: { allowedDomains: [] },
+        },
+      }),
+    ]);
+    const remote: RemoteSnapshot = {
+      ...emptyRemote(),
+      agents: [{ agentId: "triage", name: "Triage" }],
+      agentSettings: new Map<string, AgentSettings | null>([
+        [
+          "triage",
+          {
+            networkConfig: { allowedDomains: ["foo.com"] },
+            updatedAt: 0,
+          },
+        ],
+      ]),
+      platformsByAgent: new Map([["triage", []]]),
+    };
+    const plan = computeDiff(desired, remote);
+    const settingsRow = plan.rows.find((r) => r.kind === "settings");
+    expect(settingsRow?.verb).toBe("update");
+    if (settingsRow?.kind === "settings") {
+      expect(settingsRow.changedFields).toContain("networkConfig");
+    }
+  });
 
-	test("[] is not equal to null (preserved as distinct values)", () => {
-		// When desired sets allowedDomains: [] and remote has the field
-		// missing entirely, the diff should still treat them as equivalent
-		// for the case where remote literally doesn't have the field — but
-		// [] vs the explicit array ["foo"] must differ.
-		const desiredEmpty = buildState([
-			buildDesiredAgent("triage", {
-				metadata: { agentId: "triage", name: "Triage" },
-				settings: {
-					networkConfig: { allowedDomains: [] },
-				},
-			}),
-		]);
-		const remoteWithItems: RemoteSnapshot = {
-			...emptyRemote(),
-			agents: [{ agentId: "triage", name: "Triage" }],
-			agentSettings: new Map<string, AgentSettings | null>([
-				[
-					"triage",
-					{
-						networkConfig: { allowedDomains: ["x.com"] },
-						updatedAt: 0,
-					},
-				],
-			]),
-			platformsByAgent: new Map([["triage", []]]),
-		};
-		const plan = computeDiff(desiredEmpty, remoteWithItems);
-		expect(plan.counts.update).toBeGreaterThan(0);
-	});
+  test("[] is not equal to null (preserved as distinct values)", () => {
+    // When desired sets allowedDomains: [] and remote has the field
+    // missing entirely, the diff should still treat them as equivalent
+    // for the case where remote literally doesn't have the field — but
+    // [] vs the explicit array ["foo"] must differ.
+    const desiredEmpty = buildState([
+      buildDesiredAgent("triage", {
+        metadata: { agentId: "triage", name: "Triage" },
+        settings: {
+          networkConfig: { allowedDomains: [] },
+        },
+      }),
+    ]);
+    const remoteWithItems: RemoteSnapshot = {
+      ...emptyRemote(),
+      agents: [{ agentId: "triage", name: "Triage" }],
+      agentSettings: new Map<string, AgentSettings | null>([
+        [
+          "triage",
+          {
+            networkConfig: { allowedDomains: ["x.com"] },
+            updatedAt: 0,
+          },
+        ],
+      ]),
+      platformsByAgent: new Map([["triage", []]]),
+    };
+    const plan = computeDiff(desiredEmpty, remoteWithItems);
+    expect(plan.counts.update).toBeGreaterThan(0);
+  });
 
-	test("{} is not equal to populated object", () => {
-		// empty config object vs populated config object must show as drift/update
-		const desired = buildState([
-			buildDesiredAgent("triage", {
-				metadata: { agentId: "triage", name: "Triage" },
-				platforms: [
-					{
-						stableId: "triage-telegram",
-						type: "telegram",
-						config: {},
-					},
-				],
-			}),
-		]);
-		const remote: RemoteSnapshot = {
-			...emptyRemote(),
-			agents: [{ agentId: "triage", name: "Triage" }],
-			agentSettings: new Map<string, AgentSettings | null>([["triage", null]]),
-			platformsByAgent: new Map([
-				[
-					"triage",
-					[
-						{
-							id: "triage-telegram",
-							platform: "telegram",
-							config: { botToken: "abc" },
-						},
-					],
-				],
-			]),
-		};
-		const plan = computeDiff(desired, remote);
-		const platformRow = plan.rows.find((r) => r.kind === "platform");
-		expect(platformRow?.verb).toBe("update");
-	});
+  test("{} is not equal to populated object", () => {
+    // empty config object vs populated config object must show as drift/update
+    const desired = buildState([
+      buildDesiredAgent("triage", {
+        metadata: { agentId: "triage", name: "Triage" },
+        platforms: [
+          {
+            stableId: "triage-telegram",
+            type: "telegram",
+            config: {},
+          },
+        ],
+      }),
+    ]);
+    const remote: RemoteSnapshot = {
+      ...emptyRemote(),
+      agents: [{ agentId: "triage", name: "Triage" }],
+      agentSettings: new Map<string, AgentSettings | null>([["triage", null]]),
+      platformsByAgent: new Map([
+        [
+          "triage",
+          [
+            {
+              id: "triage-telegram",
+              platform: "telegram",
+              config: { botToken: "abc" },
+            },
+          ],
+        ],
+      ]),
+    };
+    const plan = computeDiff(desired, remote);
+    const platformRow = plan.rows.find((r) => r.kind === "platform");
+    expect(platformRow?.verb).toBe("update");
+  });
 });
 
 describe("apply diff — watchers", () => {
-	const desiredWatcher = {
-		slug: "weekly-digest",
-		agent: "triage",
-		name: "Weekly digest",
-		prompt: "Produce a digest.",
-		extractionSchema: { type: "object" as const },
-		schedule: "0 9 * * 1",
-	};
+  const desiredWatcher = {
+    slug: "weekly-digest",
+    agent: "triage",
+    name: "Weekly digest",
+    prompt: "Produce a digest.",
+    extractionSchema: { type: "object" as const },
+    schedule: "0 9 * * 1",
+  };
 
-	test("create when watcher missing remotely", () => {
-		const desired = buildState([], { watchers: [desiredWatcher] });
-		const plan = computeDiff(desired, emptyRemote());
-		const row = plan.rows.find((r) => r.kind === "watcher");
-		expect(row?.verb).toBe("create");
-		expect(row?.id).toBe("weekly-digest");
-	});
+  test("create when watcher missing remotely", () => {
+    const desired = buildState([], { watchers: [desiredWatcher] });
+    const plan = computeDiff(desired, emptyRemote());
+    const row = plan.rows.find((r) => r.kind === "watcher");
+    expect(row?.verb).toBe("create");
+    expect(row?.id).toBe("weekly-digest");
+  });
 
-	test("noop when remote matches every field the diff covers", () => {
-		const desired = buildState([], { watchers: [desiredWatcher] });
-		const remote: RemoteSnapshot = {
-			...emptyRemote(),
-			watchers: [
-				{
-					slug: "weekly-digest",
-					name: "Weekly digest",
-					agent_id: "triage",
-					prompt: "Produce a digest.",
-					extraction_schema: { type: "object" },
-					schedule: "0 9 * * 1",
-				},
-			],
-		};
-		const plan = computeDiff(desired, remote);
-		const row = plan.rows.find((r) => r.kind === "watcher");
-		expect(row?.verb).toBe("noop");
-		expect(plan.counts.create).toBe(0);
-	});
+  test("noop when remote matches every field the diff covers", () => {
+    const desired = buildState([], { watchers: [desiredWatcher] });
+    const remote: RemoteSnapshot = {
+      ...emptyRemote(),
+      watchers: [
+        {
+          slug: "weekly-digest",
+          name: "Weekly digest",
+          agent_id: "triage",
+          prompt: "Produce a digest.",
+          extraction_schema: { type: "object" },
+          schedule: "0 9 * * 1",
+        },
+      ],
+    };
+    const plan = computeDiff(desired, remote);
+    const row = plan.rows.find((r) => r.kind === "watcher");
+    expect(row?.verb).toBe("noop");
+    expect(plan.counts.create).toBe(0);
+  });
 
-	test("update with scalar drift when schedule changes remotely", () => {
-		const desired = buildState([], { watchers: [desiredWatcher] });
-		const remote: RemoteSnapshot = {
-			...emptyRemote(),
-			watchers: [
-				{
-					slug: "weekly-digest",
-					name: "Weekly digest",
-					agent_id: "triage",
-					prompt: "Produce a digest.",
-					extraction_schema: { type: "object" },
-					schedule: "0 10 * * 1",
-				},
-			],
-		};
-		const plan = computeDiff(desired, remote);
-		const row = plan.rows.find((r) => r.kind === "watcher");
-		expect(row?.verb).toBe("update");
-		expect(row?.changedFields).toContain("schedule");
-		expect(
-			(row as { versionBoundFields?: string[] }).versionBoundFields,
-		).toBeUndefined();
-	});
+  test("update with scalar drift when schedule changes remotely", () => {
+    const desired = buildState([], { watchers: [desiredWatcher] });
+    const remote: RemoteSnapshot = {
+      ...emptyRemote(),
+      watchers: [
+        {
+          slug: "weekly-digest",
+          name: "Weekly digest",
+          agent_id: "triage",
+          prompt: "Produce a digest.",
+          extraction_schema: { type: "object" },
+          schedule: "0 10 * * 1",
+        },
+      ],
+    };
+    const plan = computeDiff(desired, remote);
+    const row = plan.rows.find((r) => r.kind === "watcher");
+    expect(row?.verb).toBe("update");
+    expect(row?.changedFields).toContain("schedule");
+    expect(
+      (row as { versionBoundFields?: string[] }).versionBoundFields
+    ).toBeUndefined();
+  });
 
-	test("update with version-bound drift when prompt changes remotely", () => {
-		const desired = buildState([], { watchers: [desiredWatcher] });
-		const remote: RemoteSnapshot = {
-			...emptyRemote(),
-			watchers: [
-				{
-					slug: "weekly-digest",
-					name: "Weekly digest",
-					agent_id: "triage",
-					prompt: "Old prompt",
-					extraction_schema: { type: "object" },
-					schedule: "0 9 * * 1",
-				},
-			],
-		};
-		const plan = computeDiff(desired, remote);
-		const row = plan.rows.find((r) => r.kind === "watcher");
-		expect(row?.verb).toBe("update");
-		expect(
-			(row as { versionBoundFields?: string[] }).versionBoundFields,
-		).toEqual(["prompt"]);
-	});
+  test("update with version-bound drift when prompt changes remotely", () => {
+    const desired = buildState([], { watchers: [desiredWatcher] });
+    const remote: RemoteSnapshot = {
+      ...emptyRemote(),
+      watchers: [
+        {
+          slug: "weekly-digest",
+          name: "Weekly digest",
+          agent_id: "triage",
+          prompt: "Old prompt",
+          extraction_schema: { type: "object" },
+          schedule: "0 9 * * 1",
+        },
+      ],
+    };
+    const plan = computeDiff(desired, remote);
+    const row = plan.rows.find((r) => r.kind === "watcher");
+    expect(row?.verb).toBe("update");
+    expect(
+      (row as { versionBoundFields?: string[] }).versionBoundFields
+    ).toEqual(["prompt"]);
+  });
 
-	test("reaction_script declared → always re-pushed (idempotent)", () => {
-		const desired = buildState([], {
-			watchers: [
-				{
-					...desiredWatcher,
-					reactionScript: {
-						sourcePath: "/abs/path/r.ts",
-						sourceCode: "export default async () => {};",
-					},
-				},
-			],
-		});
-		const remote: RemoteSnapshot = {
-			...emptyRemote(),
-			watchers: [
-				{
-					slug: "weekly-digest",
-					name: "Weekly digest",
-					agent_id: "triage",
-					prompt: "Produce a digest.",
-					extraction_schema: { type: "object" },
-					schedule: "0 9 * * 1",
-				},
-			],
-		};
-		const plan = computeDiff(desired, remote);
-		const row = plan.rows.find((r) => r.kind === "watcher");
-		expect(row?.verb).toBe("update");
-		expect(row?.changedFields).toEqual(["reaction_script"]);
-		expect(
-			(row as { reactionScriptDeclared?: boolean }).reactionScriptDeclared,
-		).toBe(true);
-	});
+  test("reaction_script declared → always re-pushed (idempotent)", () => {
+    const desired = buildState([], {
+      watchers: [
+        {
+          ...desiredWatcher,
+          reactionScript: {
+            sourcePath: "/abs/path/r.ts",
+            sourceCode: "export default async () => {};",
+          },
+        },
+      ],
+    });
+    const remote: RemoteSnapshot = {
+      ...emptyRemote(),
+      watchers: [
+        {
+          slug: "weekly-digest",
+          name: "Weekly digest",
+          agent_id: "triage",
+          prompt: "Produce a digest.",
+          extraction_schema: { type: "object" },
+          schedule: "0 9 * * 1",
+        },
+      ],
+    };
+    const plan = computeDiff(desired, remote);
+    const row = plan.rows.find((r) => r.kind === "watcher");
+    expect(row?.verb).toBe("update");
+    expect(row?.changedFields).toEqual(["reaction_script"]);
+    expect(
+      (row as { reactionScriptDeclared?: boolean }).reactionScriptDeclared
+    ).toBe(true);
+  });
 
-	test("drift when remote watcher not declared in models", () => {
-		const desired = buildState([], { watchers: [] });
-		const remote: RemoteSnapshot = {
-			...emptyRemote(),
-			watchers: [{ slug: "orphan-watcher" }],
-		};
-		const plan = computeDiff(desired, remote);
-		const row = plan.rows.find((r) => r.kind === "watcher");
-		expect(row?.verb).toBe("drift");
-		expect(plan.counts.drift).toBe(1);
-	});
+  test("drift when remote watcher not declared in models", () => {
+    const desired = buildState([], { watchers: [] });
+    const remote: RemoteSnapshot = {
+      ...emptyRemote(),
+      watchers: [{ slug: "orphan-watcher" }],
+    };
+    const plan = computeDiff(desired, remote);
+    const row = plan.rows.find((r) => r.kind === "watcher");
+    expect(row?.verb).toBe("drift");
+    expect(plan.counts.drift).toBe(1);
+  });
 });
 
 describe("renderSummary", () => {
-	test("renders zero-row plan", () => {
-		const desired = buildState([]);
-		const plan = computeDiff(desired, emptyRemote());
-		expect(renderSummary(plan)).toMatchSnapshot();
-	});
+  test("renders zero-row plan", () => {
+    const desired = buildState([]);
+    const plan = computeDiff(desired, emptyRemote());
+    expect(renderSummary(plan)).toMatchSnapshot();
+  });
 });
 
 describe("apply diff — connectors", () => {
-	const builtinConnectorDef = {
-		key: "hackernews",
-		name: "Hacker News",
-		installed: false,
-		installable: true,
-	};
+  const builtinConnectorDef = {
+    key: "hackernews",
+    name: "Hacker News",
+    installed: false,
+    installable: true,
+  };
 
-	function connectorState() {
-		return buildState([], {
-			connectors: {
-				definitions: [
-					{
-						key: "acme",
-						sourcePath: "/proj/connectors/acme.connector.ts",
-						sourceCode: "export default class {}",
-						sourceFile: "connectors/acme.connector.ts",
-					},
-				],
-				authProfiles: [
-					{
-						slug: "hn-token",
-						connector: "hackernews",
-						kind: "env" as const,
-						name: "HN token",
-						credentials: { HN_TOKEN: "$HN_TOKEN" },
-						sourceFile: "connectors/hackernews.yaml",
-					},
-					{
-						slug: "x-account",
-						connector: "x",
-						kind: "oauth_account" as const,
-						sourceFile: "connectors/x.yaml",
-					},
-				],
-				connections: [
-					{
-						slug: "hn-frontpage",
-						connector: "hackernews",
-						name: "HN front page",
-						authProfileSlug: "hn-token",
-						feeds: [{ feedKey: "stories", schedule: "0 * * * *" }],
-						sourceFile: "connectors/hackernews.yaml",
-					},
-				],
-			},
-		});
-	}
+  function connectorState() {
+    return buildState([], {
+      connectors: {
+        definitions: [
+          {
+            key: "acme",
+            sourcePath: "/proj/connectors/acme.connector.ts",
+            sourceCode: "export default class {}",
+            sourceFile: "connectors/acme.connector.ts",
+          },
+        ],
+        authProfiles: [
+          {
+            slug: "hn-token",
+            connector: "hackernews",
+            kind: "env" as const,
+            name: "HN token",
+            credentials: { HN_TOKEN: "$HN_TOKEN" },
+            sourceFile: "connectors/hackernews.yaml",
+          },
+          {
+            slug: "x-account",
+            connector: "x",
+            kind: "oauth_account" as const,
+            sourceFile: "connectors/x.yaml",
+          },
+        ],
+        connections: [
+          {
+            slug: "hn-frontpage",
+            connector: "hackernews",
+            name: "HN front page",
+            authProfileSlug: "hn-token",
+            feeds: [{ feedKey: "stories", schedule: "0 * * * *" }],
+            sourceFile: "connectors/hackernews.yaml",
+          },
+        ],
+      },
+    });
+  }
 
-	test("create verbs for new connector def, auth profile, connection, feed", () => {
-		const plan = computeDiff(connectorState(), {
-			...emptyRemote(),
-			connectorDefinitions: [builtinConnectorDef],
-		});
-		const def = plan.rows.find((r) => r.kind === "connector-definition");
-		expect(def?.verb).toBe("create");
-		const authEnv = plan.rows.find(
-			(r) => r.kind === "auth-profile" && r.id === "hn-token",
-		);
-		expect(authEnv?.verb).toBe("create");
-		const authOauth = plan.rows.find(
-			(r) => r.kind === "auth-profile" && r.id === "x-account",
-		);
-		expect(authOauth?.verb).toBe("create");
-		expect(
-			authOauth && "needsAuth" in authOauth ? authOauth.needsAuth : undefined,
-		).toBe(true);
-		const conn = plan.rows.find((r) => r.kind === "connection");
-		expect(conn?.verb).toBe("create");
-		const feed = plan.rows.find((r) => r.kind === "feed");
-		expect(feed?.verb).toBe("create");
-		expect(feed?.id).toBe("hn-frontpage/stories");
-	});
+  test("create verbs for new connector def, auth profile, connection, feed", () => {
+    const plan = computeDiff(connectorState(), {
+      ...emptyRemote(),
+      connectorDefinitions: [builtinConnectorDef],
+    });
+    const def = plan.rows.find((r) => r.kind === "connector-definition");
+    expect(def?.verb).toBe("create");
+    const authEnv = plan.rows.find(
+      (r) => r.kind === "auth-profile" && r.id === "hn-token"
+    );
+    expect(authEnv?.verb).toBe("create");
+    const authOauth = plan.rows.find(
+      (r) => r.kind === "auth-profile" && r.id === "x-account"
+    );
+    expect(authOauth?.verb).toBe("create");
+    expect(
+      authOauth && "needsAuth" in authOauth ? authOauth.needsAuth : undefined
+    ).toBe(true);
+    const conn = plan.rows.find((r) => r.kind === "connection");
+    expect(conn?.verb).toBe("create");
+    const feed = plan.rows.find((r) => r.kind === "feed");
+    expect(feed?.verb).toBe("create");
+    expect(feed?.id).toBe("hn-frontpage/stories");
+  });
 
-	test("noop when connection + feed already match remotely", () => {
-		const remote: RemoteSnapshot = {
-			...emptyRemote(),
-			connectorDefinitions: [builtinConnectorDef],
-			authProfiles: [
-				{
-					slug: "hn-token",
-					display_name: "HN token",
-					connector_key: "hackernews",
-					profile_kind: "env",
-					status: "active",
-				},
-				{
-					slug: "x-account",
-					connector_key: "x",
-					profile_kind: "oauth_account",
-					status: "active",
-				},
-			],
-			connections: [
-				{
-					id: 7,
-					slug: "hn-frontpage",
-					connector_key: "hackernews",
-					display_name: "HN front page",
-					status: "active",
-					auth_profile_slug: "hn-token",
-					app_auth_profile_slug: null,
-					config: {},
-				},
-			],
-			feedsByConnectionId: new Map([
-				[
-					7,
-					[
-						{
-							id: 11,
-							connection_id: 7,
-							feed_key: "stories",
-							status: "active",
-							schedule: "0 * * * *",
-							config: {},
-						},
-					],
-				],
-			]),
-		};
-		const plan = computeDiff(connectorState(), remote);
-		expect(plan.rows.find((r) => r.kind === "connection")?.verb).toBe("noop");
-		expect(plan.rows.find((r) => r.kind === "feed")?.verb).toBe("noop");
-		expect(
-			plan.rows.find((r) => r.kind === "auth-profile" && r.id === "x-account")
-				?.verb,
-		).toBe("noop");
-	});
+  test("noop when connection + feed already match remotely", () => {
+    const remote: RemoteSnapshot = {
+      ...emptyRemote(),
+      connectorDefinitions: [builtinConnectorDef],
+      authProfiles: [
+        {
+          slug: "hn-token",
+          display_name: "HN token",
+          connector_key: "hackernews",
+          profile_kind: "env",
+          status: "active",
+        },
+        {
+          slug: "x-account",
+          connector_key: "x",
+          profile_kind: "oauth_account",
+          status: "active",
+        },
+      ],
+      connections: [
+        {
+          id: 7,
+          slug: "hn-frontpage",
+          connector_key: "hackernews",
+          display_name: "HN front page",
+          status: "active",
+          auth_profile_slug: "hn-token",
+          app_auth_profile_slug: null,
+          config: {},
+        },
+      ],
+      feedsByConnectionId: new Map([
+        [
+          7,
+          [
+            {
+              id: 11,
+              connection_id: 7,
+              feed_key: "stories",
+              status: "active",
+              schedule: "0 * * * *",
+              config: {},
+            },
+          ],
+        ],
+      ]),
+    };
+    const plan = computeDiff(connectorState(), remote);
+    expect(plan.rows.find((r) => r.kind === "connection")?.verb).toBe("noop");
+    expect(plan.rows.find((r) => r.kind === "feed")?.verb).toBe("noop");
+    expect(
+      plan.rows.find((r) => r.kind === "auth-profile" && r.id === "x-account")
+        ?.verb
+    ).toBe("noop");
+  });
 
-	test("update when feed schedule changes; needs-auth when oauth profile inactive", () => {
-		const remote: RemoteSnapshot = {
-			...emptyRemote(),
-			connectorDefinitions: [builtinConnectorDef],
-			authProfiles: [
-				{
-					slug: "hn-token",
-					display_name: "HN token",
-					connector_key: "hackernews",
-					profile_kind: "env",
-					status: "active",
-				},
-				{
-					slug: "x-account",
-					connector_key: "x",
-					profile_kind: "oauth_account",
-					status: "pending_auth",
-				},
-			],
-			connections: [
-				{
-					id: 7,
-					slug: "hn-frontpage",
-					connector_key: "hackernews",
-					display_name: "HN front page",
-					status: "active",
-					auth_profile_slug: "hn-token",
-					app_auth_profile_slug: null,
-					config: {},
-				},
-			],
-			feedsByConnectionId: new Map([
-				[
-					7,
-					[
-						{
-							id: 11,
-							connection_id: 7,
-							feed_key: "stories",
-							status: "active",
-							schedule: "0 0 * * *",
-							config: {},
-						},
-					],
-				],
-			]),
-		};
-		const plan = computeDiff(connectorState(), remote);
-		const feed = plan.rows.find((r) => r.kind === "feed");
-		expect(feed?.verb).toBe("update");
-		expect(feed && "changedFields" in feed ? feed.changedFields : []).toEqual([
-			"schedule",
-		]);
-		const authOauth = plan.rows.find(
-			(r) => r.kind === "auth-profile" && r.id === "x-account",
-		);
-		expect(
-			authOauth && "needsAuth" in authOauth ? authOauth.needsAuth : undefined,
-		).toBe(true);
-	});
+  test("update when feed schedule changes; needs-auth when oauth profile inactive", () => {
+    const remote: RemoteSnapshot = {
+      ...emptyRemote(),
+      connectorDefinitions: [builtinConnectorDef],
+      authProfiles: [
+        {
+          slug: "hn-token",
+          display_name: "HN token",
+          connector_key: "hackernews",
+          profile_kind: "env",
+          status: "active",
+        },
+        {
+          slug: "x-account",
+          connector_key: "x",
+          profile_kind: "oauth_account",
+          status: "pending_auth",
+        },
+      ],
+      connections: [
+        {
+          id: 7,
+          slug: "hn-frontpage",
+          connector_key: "hackernews",
+          display_name: "HN front page",
+          status: "active",
+          auth_profile_slug: "hn-token",
+          app_auth_profile_slug: null,
+          config: {},
+        },
+      ],
+      feedsByConnectionId: new Map([
+        [
+          7,
+          [
+            {
+              id: 11,
+              connection_id: 7,
+              feed_key: "stories",
+              status: "active",
+              schedule: "0 0 * * *",
+              config: {},
+            },
+          ],
+        ],
+      ]),
+    };
+    const plan = computeDiff(connectorState(), remote);
+    const feed = plan.rows.find((r) => r.kind === "feed");
+    expect(feed?.verb).toBe("update");
+    expect(feed && "changedFields" in feed ? feed.changedFields : []).toEqual([
+      "schedule",
+    ]);
+    const authOauth = plan.rows.find(
+      (r) => r.kind === "auth-profile" && r.id === "x-account"
+    );
+    expect(
+      authOauth && "needsAuth" in authOauth ? authOauth.needsAuth : undefined
+    ).toBe(true);
+  });
 
-	test("undeclared remote connector becomes an informational note (no uninstall)", () => {
-		const remote: RemoteSnapshot = {
-			...emptyRemote(),
-			connectorDefinitions: [
-				builtinConnectorDef,
-				{
-					key: "legacy",
-					name: "Legacy",
-					installed: true,
-					installable: false,
-				},
-			],
-		};
-		const plan = computeDiff(connectorState(), remote);
-		expect(plan.notes.some((n) => n.includes('"legacy"'))).toBe(true);
-		expect(
-			plan.rows.some(
-				(r) => r.kind === "connector-definition" && r.id === "legacy",
-			),
-		).toBe(false);
-	});
+  test("undeclared remote connector becomes an informational note (no uninstall)", () => {
+    const remote: RemoteSnapshot = {
+      ...emptyRemote(),
+      connectorDefinitions: [
+        builtinConnectorDef,
+        {
+          key: "legacy",
+          name: "Legacy",
+          installed: true,
+          installable: false,
+        },
+      ],
+    };
+    const plan = computeDiff(connectorState(), remote);
+    expect(plan.notes.some((n) => n.includes('"legacy"'))).toBe(true);
+    expect(
+      plan.rows.some(
+        (r) => r.kind === "connector-definition" && r.id === "legacy"
+      )
+    ).toBe(false);
+  });
 
-	test("connectors are skipped when --only is set", () => {
-		const plan = computeDiff(connectorState(), emptyRemote(), {
-			only: "agents",
-		});
-		expect(plan.rows.some((r) => r.kind === "connection")).toBe(false);
-		expect(plan.rows.some((r) => r.kind === "connector-definition")).toBe(
-			false,
-		);
-	});
+  test("connectors are skipped when --only is set", () => {
+    const plan = computeDiff(connectorState(), emptyRemote(), {
+      only: "agents",
+    });
+    expect(plan.rows.some((r) => r.kind === "connection")).toBe(false);
+    expect(plan.rows.some((r) => r.kind === "connector-definition")).toBe(
+      false
+    );
+  });
 
-	test("render includes the connectors sections", () => {
-		const plan = computeDiff(connectorState(), {
-			...emptyRemote(),
-			connectorDefinitions: [builtinConnectorDef],
-		});
-		expect(renderPlan(plan)).toMatchSnapshot();
-	});
+  test("render includes the connectors sections", () => {
+    const plan = computeDiff(connectorState(), {
+      ...emptyRemote(),
+      connectorDefinitions: [builtinConnectorDef],
+    });
+    expect(renderPlan(plan)).toMatchSnapshot();
+  });
 
-	// ── round-2 ──────────────────────────────────────────────────────────────
+  // ── round-2 ──────────────────────────────────────────────────────────────
 
-	test("connection slug bound to a different connector remotely is a hard error", () => {
-		expect(() =>
-			computeDiff(connectorState(), {
-				...emptyRemote(),
-				connectorDefinitions: [builtinConnectorDef],
-				connections: [
-					{
-						id: 9,
-						slug: "hn-frontpage",
-						connector_key: "rss",
-						status: "active",
-						auth_profile_slug: null,
-						app_auth_profile_slug: null,
-						config: {},
-					},
-				],
-			}),
-		).toThrow(/bound to connector "rss" remotely.*declares "hackernews"/);
-	});
+  test("connection slug bound to a different connector remotely is a hard error", () => {
+    expect(() =>
+      computeDiff(connectorState(), {
+        ...emptyRemote(),
+        connectorDefinitions: [builtinConnectorDef],
+        connections: [
+          {
+            id: 9,
+            slug: "hn-frontpage",
+            connector_key: "rss",
+            status: "active",
+            auth_profile_slug: null,
+            app_auth_profile_slug: null,
+            config: {},
+          },
+        ],
+      })
+    ).toThrow(/bound to connector "rss" remotely.*declares "hackernews"/);
+  });
 
-	test("auth-profile slug bound to a different kind remotely is a hard error", () => {
-		expect(() =>
-			computeDiff(connectorState(), {
-				...emptyRemote(),
-				connectorDefinitions: [builtinConnectorDef],
-				authProfiles: [
-					{
-						slug: "hn-token",
-						connector_key: "hackernews",
-						profile_kind: "oauth_app",
-						status: "active",
-					},
-				],
-			}),
-		).toThrow(/auth_profile "hn-token" is bound to hackernews\/oauth_app/);
-	});
+  test("auth-profile slug bound to a different kind remotely is a hard error", () => {
+    expect(() =>
+      computeDiff(connectorState(), {
+        ...emptyRemote(),
+        connectorDefinitions: [builtinConnectorDef],
+        authProfiles: [
+          {
+            slug: "hn-token",
+            connector_key: "hackernews",
+            profile_kind: "oauth_app",
+            status: "active",
+          },
+        ],
+      })
+    ).toThrow(/auth_profile "hn-token" is bound to hackernews\/oauth_app/);
+  });
 
-	test("credential rotation re-pushes: env profile shows update (credentials)", () => {
-		const plan = computeDiff(connectorState(), {
-			...emptyRemote(),
-			connectorDefinitions: [builtinConnectorDef],
-			authProfiles: [
-				{
-					slug: "hn-token",
-					display_name: "HN token",
-					connector_key: "hackernews",
-					profile_kind: "env",
-					status: "active",
-				},
-			],
-		});
-		const row = plan.rows.find(
-			(r) => r.kind === "auth-profile" && r.id === "hn-token",
-		);
-		expect(row?.verb).toBe("update");
-		expect(row && "changedFields" in row ? row.changedFields : []).toContain(
-			"credentials",
-		);
-	});
+  test("credential rotation re-pushes: env profile shows update (credentials)", () => {
+    const plan = computeDiff(connectorState(), {
+      ...emptyRemote(),
+      connectorDefinitions: [builtinConnectorDef],
+      authProfiles: [
+        {
+          slug: "hn-token",
+          display_name: "HN token",
+          connector_key: "hackernews",
+          profile_kind: "env",
+          status: "active",
+        },
+      ],
+    });
+    const row = plan.rows.find(
+      (r) => r.kind === "auth-profile" && r.id === "hn-token"
+    );
+    expect(row?.verb).toBe("update");
+    expect(row && "changedFields" in row ? row.changedFields : []).toContain(
+      "credentials"
+    );
+  });
 
-	test("a fully-converged remote state produces no connector create/update (except idempotent connector-def re-push)", () => {
-		// Build a remote snapshot that exactly mirrors connectorState(): the env
-		// auth profile has no declared-credential drift suppression, so it would
-		// re-push (update credentials). The acme connector def is installed, so it
-		// shows as a (no-op-on-server) "update". Everything else is noop.
-		const remote: RemoteSnapshot = {
-			...emptyRemote(),
-			connectorDefinitions: [
-				{ key: "hackernews", installed: false, installable: true },
-				{ key: "x", installed: false, installable: true },
-				{ key: "acme", installed: true, installable: false },
-			],
-			authProfiles: [
-				{
-					slug: "hn-token",
-					display_name: "HN token",
-					connector_key: "hackernews",
-					profile_kind: "env",
-					status: "active",
-				},
-				{
-					slug: "x-account",
-					connector_key: "x",
-					profile_kind: "oauth_account",
-					status: "active",
-				},
-			],
-			connections: [
-				{
-					id: 7,
-					slug: "hn-frontpage",
-					connector_key: "hackernews",
-					display_name: "HN front page",
-					status: "active",
-					auth_profile_slug: "hn-token",
-					app_auth_profile_slug: null,
-					config: {},
-				},
-			],
-			feedsByConnectionId: new Map([
-				[
-					7,
-					[
-						{
-							id: 11,
-							connection_id: 7,
-							feed_key: "stories",
-							status: "active",
-							schedule: "0 * * * *",
-							config: {},
-						},
-					],
-				],
-			]),
-		};
-		const plan = computeDiff(connectorState(), remote);
-		// Only "update" rows allowed: the connector-def re-push and the
-		// env-credential re-push — both idempotent on the server.
-		const nonIdempotentChurn = plan.rows.filter(
-			(r) =>
-				(r.verb === "create" || r.verb === "update") &&
-				!(r.kind === "connector-definition") &&
-				!(r.kind === "auth-profile" && r.id === "hn-token"),
-		);
-		expect(nonIdempotentChurn).toEqual([]);
-		expect(plan.notes).toEqual([]);
-	});
+  test("a fully-converged remote state produces no connector create/update (except idempotent connector-def re-push)", () => {
+    // Build a remote snapshot that exactly mirrors connectorState(): the env
+    // auth profile has no declared-credential drift suppression, so it would
+    // re-push (update credentials). The acme connector def is installed, so it
+    // shows as a (no-op-on-server) "update". Everything else is noop.
+    const remote: RemoteSnapshot = {
+      ...emptyRemote(),
+      connectorDefinitions: [
+        { key: "hackernews", installed: false, installable: true },
+        { key: "x", installed: false, installable: true },
+        { key: "acme", installed: true, installable: false },
+      ],
+      authProfiles: [
+        {
+          slug: "hn-token",
+          display_name: "HN token",
+          connector_key: "hackernews",
+          profile_kind: "env",
+          status: "active",
+        },
+        {
+          slug: "x-account",
+          connector_key: "x",
+          profile_kind: "oauth_account",
+          status: "active",
+        },
+      ],
+      connections: [
+        {
+          id: 7,
+          slug: "hn-frontpage",
+          connector_key: "hackernews",
+          display_name: "HN front page",
+          status: "active",
+          auth_profile_slug: "hn-token",
+          app_auth_profile_slug: null,
+          config: {},
+        },
+      ],
+      feedsByConnectionId: new Map([
+        [
+          7,
+          [
+            {
+              id: 11,
+              connection_id: 7,
+              feed_key: "stories",
+              status: "active",
+              schedule: "0 * * * *",
+              config: {},
+            },
+          ],
+        ],
+      ]),
+    };
+    const plan = computeDiff(connectorState(), remote);
+    // Only "update" rows allowed: the connector-def re-push and the
+    // env-credential re-push — both idempotent on the server.
+    const nonIdempotentChurn = plan.rows.filter(
+      (r) =>
+        (r.verb === "create" || r.verb === "update") &&
+        !(r.kind === "connector-definition") &&
+        !(r.kind === "auth-profile" && r.id === "hn-token")
+    );
+    expect(nonIdempotentChurn).toEqual([]);
+    expect(plan.notes).toEqual([]);
+  });
 
-	test("connector-definition with an already-installed key renders as update, not create", () => {
-		const installedAcme = { key: "acme", installed: true, installable: false };
-		const plan = computeDiff(connectorState(), {
-			...emptyRemote(),
-			connectorDefinitions: [builtinConnectorDef, installedAcme],
-		});
-		// connectorState()'s acme def has key:"acme"; it is installed remotely.
-		const row = plan.rows.find(
-			(r) => r.kind === "connector-definition" && r.id?.startsWith("acme"),
-		);
-		expect(row?.verb).toBe("update");
-	});
+  test("connector-definition with an already-installed key renders as update, not create", () => {
+    const installedAcme = { key: "acme", installed: true, installable: false };
+    const plan = computeDiff(connectorState(), {
+      ...emptyRemote(),
+      connectorDefinitions: [builtinConnectorDef, installedAcme],
+    });
+    // connectorState()'s acme def has key:"acme"; it is installed remotely.
+    const row = plan.rows.find(
+      (r) => r.kind === "connector-definition" && r.id?.startsWith("acme")
+    );
+    expect(row?.verb).toBe("update");
+  });
 
-	// ── round-4 ──────────────────────────────────────────────────────────────
+  // ── round-4 ──────────────────────────────────────────────────────────────
 
-	test("referenced-but-not-installed bundled connector becomes a connector-definition create row", () => {
-		const plan = computeDiff(connectorState(), {
-			...emptyRemote(),
-			connectorDefinitions: [
-				// hackernews: installable + has a server-side source_uri, not installed
-				{
-					key: "hackernews",
-					installed: false,
-					installable: true,
-					source_uri: "file:///app/connectors/hackernews.ts",
-				},
-				// x: same
-				{
-					key: "x",
-					installed: false,
-					installable: true,
-					source_uri: "file:///app/connectors/x.ts",
-				},
-			],
-		});
-		const hn = plan.rows.find(
-			(r) => r.kind === "connector-definition" && r.id === "hackernews",
-		);
-		expect(hn?.verb).toBe("create");
-		const x = plan.rows.find(
-			(r) => r.kind === "connector-definition" && r.id === "x",
-		);
-		expect(x?.verb).toBe("create");
-		// acme is locally declared (sourcePath) — it still gets its own row.
-		expect(
-			plan.rows.some(
-				(r) => r.kind === "connector-definition" && r.id?.startsWith("acme"),
-			),
-		).toBe(true);
-	});
+  test("referenced-but-not-installed bundled connector becomes a connector-definition create row", () => {
+    const plan = computeDiff(connectorState(), {
+      ...emptyRemote(),
+      connectorDefinitions: [
+        // hackernews: installable + has a server-side source_uri, not installed
+        {
+          key: "hackernews",
+          installed: false,
+          installable: true,
+          source_uri: "file:///app/connectors/hackernews.ts",
+        },
+        // x: same
+        {
+          key: "x",
+          installed: false,
+          installable: true,
+          source_uri: "file:///app/connectors/x.ts",
+        },
+      ],
+    });
+    const hn = plan.rows.find(
+      (r) => r.kind === "connector-definition" && r.id === "hackernews"
+    );
+    expect(hn?.verb).toBe("create");
+    const x = plan.rows.find(
+      (r) => r.kind === "connector-definition" && r.id === "x"
+    );
+    expect(x?.verb).toBe("create");
+    // acme is locally declared (sourcePath) — it still gets its own row.
+    expect(
+      plan.rows.some(
+        (r) => r.kind === "connector-definition" && r.id?.startsWith("acme")
+      )
+    ).toBe(true);
+  });
 
-	test("a locally-supplied connector key is NOT also a bundled-install row (no double mutation)", () => {
-		// Pretend "acme" is *also* in the bundled catalog with a source_uri; the
-		// local .connector.ts should win — no bundled row for "acme".
-		const state = connectorState();
-		// Make a connection reference "acme" so it's in referencedConnectorKeys.
-		state.connectors.connections.push({
-			slug: "acme-conn",
-			connector: "acme",
-			feeds: [],
-			sourceFile: "connectors/acme.yaml",
-		});
-		const plan = computeDiff(state, {
-			...emptyRemote(),
-			connectorDefinitions: [
-				{
-					key: "acme",
-					installed: false,
-					installable: true,
-					source_uri: "file:///app/connectors/acme.ts",
-				},
-			],
-		});
-		const acmeRows = plan.rows.filter(
-			(r) => r.kind === "connector-definition" && r.id?.startsWith("acme"),
-		);
-		// Exactly one row — the locally-declared def — never a bundled duplicate.
-		expect(acmeRows).toHaveLength(1);
-	});
+  test("a locally-supplied connector key is NOT also a bundled-install row (no double mutation)", () => {
+    // Pretend "acme" is *also* in the bundled catalog with a source_uri; the
+    // local .connector.ts should win — no bundled row for "acme".
+    const state = connectorState();
+    // Make a connection reference "acme" so it's in referencedConnectorKeys.
+    state.connectors.connections.push({
+      slug: "acme-conn",
+      connector: "acme",
+      feeds: [],
+      sourceFile: "connectors/acme.yaml",
+    });
+    const plan = computeDiff(state, {
+      ...emptyRemote(),
+      connectorDefinitions: [
+        {
+          key: "acme",
+          installed: false,
+          installable: true,
+          source_uri: "file:///app/connectors/acme.ts",
+        },
+      ],
+    });
+    const acmeRows = plan.rows.filter(
+      (r) => r.kind === "connector-definition" && r.id?.startsWith("acme")
+    );
+    // Exactly one row — the locally-declared def — never a bundled duplicate.
+    expect(acmeRows).toHaveLength(1);
+  });
 });

--- a/packages/cli/src/commands/_lib/connector-loader.ts
+++ b/packages/cli/src/commands/_lib/connector-loader.ts
@@ -44,13 +44,22 @@ const bundledFileCache = new Map<string, string | null>();
 export function findBundledConnectorFile(key: string): string | null {
   const cached = bundledFileCache.get(key);
   if (cached !== undefined) return cached;
-  const fileName = `${key.replace(/\./g, "_")}.ts`;
+  // Mirror the resolver in @lobu/connector-worker's compile-connector.ts:
+  // subdir layout (`browser.evaluate` → `browser/evaluate.ts`) first, then
+  // the flat underscore convention (`chrome.tabs` → `chrome_tabs.ts`).
+  const candidates = [
+    `${key.replace(/\./g, "/")}.ts`,
+    `${key.replace(/\./g, "_")}.ts`,
+  ];
   let found: string | null = null;
-  for (const candidate of SOURCE_DIR_CANDIDATES) {
-    const filePath = resolve(candidate, fileName);
-    if (existsSync(filePath)) {
-      found = filePath;
-      break;
+  outer: for (const dir of SOURCE_DIR_CANDIDATES) {
+    for (const fileName of candidates) {
+      const filePath = resolve(dir, fileName);
+      if (!filePath.startsWith(`${dir}/`)) continue;
+      if (existsSync(filePath)) {
+        found = filePath;
+        break outer;
+      }
     }
   }
   bundledFileCache.set(key, found);

--- a/packages/connector-worker/src/compile-connector.ts
+++ b/packages/connector-worker/src/compile-connector.ts
@@ -55,13 +55,26 @@ const CONNECTOR_KEY_RE = /^[a-z][a-z0-9]*(?:[._][a-z0-9]+)*$/;
 
 export function findBundledConnectorFile(key: string): string | null {
   if (!CONNECTOR_KEY_RE.test(key)) return null;
-  const fileName = `${key.replace(/\./g, '_')}.ts`;
-  for (const candidate of WORKER_CONNECTOR_DIR_CANDIDATES) {
-    const filePath = resolve(candidate, fileName);
-    // Belt-and-braces: assert the resolved path stays under the candidate
-    // dir even though CONNECTOR_KEY_RE already forbids the dangerous chars.
-    if (!filePath.startsWith(`${candidate}/`)) continue;
-    if (existsSync(filePath)) return filePath;
+  // Two filename conventions:
+  //  - Subdirectory layout (preferred for grouped primitives): the dot in
+  //    `browser.evaluate` maps to `browser/evaluate.ts`. Lets us co-locate
+  //    related connectors without renaming the key.
+  //  - Flat-with-underscores (existing convention): `chrome.tabs` →
+  //    `chrome_tabs.ts`, `apple_health` → `apple_health.ts`.
+  // Try subdirectory first so newer primitives win when both happen to exist.
+  const candidates = [
+    `${key.replace(/\./g, '/')}.ts`,
+    `${key.replace(/\./g, '_')}.ts`,
+  ];
+  for (const dir of WORKER_CONNECTOR_DIR_CANDIDATES) {
+    for (const fileName of candidates) {
+      const filePath = resolve(dir, fileName);
+      // Belt-and-braces: the resolved path must stay under the candidate
+      // dir. CONNECTOR_KEY_RE already forbids `..`, but the regex doesn't
+      // know about our path-joining choices.
+      if (!filePath.startsWith(`${dir}/`)) continue;
+      if (existsSync(filePath)) return filePath;
+    }
   }
   return null;
 }

--- a/packages/connectors/src/browser/evaluate.ts
+++ b/packages/connectors/src/browser/evaluate.ts
@@ -1,0 +1,115 @@
+/**
+ * Browser Evaluate Connector — Owletto for Chrome only.
+ *
+ * Runs on the Owletto Chrome extension, which advertises capability
+ * `browser.debugger`. The extension attaches `chrome.debugger` to a tab,
+ * optionally navigates + waits for a selector, runs the supplied JS via
+ * `Runtime.evaluate`, and emits one event with the JSON-serialised result.
+ *
+ * This is the generic "agent runs JS in a user's signed-in Chrome" primitive
+ * — most bridge connectors (Revolut feed, banking, sites that fingerprint
+ * a managed Chromium) compose on top of `browser.evaluate` rather than
+ * shipping their own connector. The trust boundary is `config.script`: only
+ * the gateway-side connector author should mint it. The extension defaults
+ * to opening a fresh background tab so a compromised gateway / leaked token
+ * can't drive the tab a user is actively using; see executor.js in
+ * owletto-web for the full threat model.
+ *
+ * Cloud-side `sync()` / `execute()` throw — actual work happens in the
+ * extension's service worker (lobu-ai/owletto: apps/chrome/executor.js).
+ */
+
+import {
+  type ActionResult,
+  type ConnectorDefinition,
+  ConnectorRuntime,
+  type SyncContext,
+  type SyncResult,
+} from '@lobu/connector-sdk';
+
+const BRIDGE_ONLY =
+  'browser.evaluate runs only on a worker advertising capability "browser.debugger" (Owletto for Chrome).';
+
+export default class BrowserEvaluateConnector extends ConnectorRuntime {
+  readonly definition: ConnectorDefinition = {
+    key: 'browser.evaluate',
+    name: 'Browser Evaluate',
+    description:
+      'Runs a JS snippet in a page via chrome.debugger and emits the result. The primitive most bridge connectors build on.',
+    version: '0.1.0',
+    faviconDomain: 'google.com',
+    requiredCapability: 'browser.debugger',
+    runtime: { platforms: ['chrome-extension'] },
+    authSchema: { methods: [{ type: 'none' }] },
+    feeds: {
+      evaluate: {
+        key: 'evaluate',
+        name: 'Evaluate JS',
+        description:
+          'Executes a JS expression in the page and emits one event with the JSON-serialised return value.',
+        configSchema: {
+          type: 'object',
+          required: ['script'],
+          properties: {
+            url: {
+              type: 'string',
+              format: 'uri',
+              description: 'If set, navigate the tab here before evaluating.',
+            },
+            script: {
+              type: 'string',
+              description:
+                'JS expression evaluated with Runtime.evaluate(awaitPromise: true). Return value is JSON-serialised — keep it small.',
+            },
+            wait_for_selector: {
+              type: 'string',
+              description:
+                'CSS selector to wait for before evaluating (polled every 200ms via Runtime.evaluate).',
+            },
+            wait_timeout_ms: {
+              type: 'integer',
+              minimum: 100,
+              maximum: 60_000,
+              description: 'Timeout for wait_for_selector. Default 10000.',
+            },
+            open_in_new_tab: {
+              type: 'boolean',
+              description:
+                'Open a fresh background tab instead of driving the active tab. DEFAULT TRUE — opt out only when you specifically need the user-active tab.',
+            },
+            close_tab_after: {
+              type: 'boolean',
+              description:
+                'Close the tab when the run completes. Defaults to true when open_in_new_tab is true.',
+            },
+          },
+        },
+        eventKinds: {
+          browser_evaluate: {
+            description:
+              'One event per run with the JSON-serialised Runtime.evaluate result.',
+            metadataSchema: {
+              type: 'object',
+              required: ['source', 'origin_id'],
+              properties: {
+                source: { type: 'string', const: 'browser_evaluate' },
+                origin_id: { type: 'string' },
+                url: { type: 'string' },
+                title: { type: 'string' },
+                tab_id: { type: 'integer' },
+              },
+            },
+          },
+        },
+      },
+    },
+  };
+
+  async sync(_ctx: SyncContext): Promise<SyncResult> {
+    throw new Error(BRIDGE_ONLY);
+  }
+
+  async execute(): Promise<ActionResult> {
+    throw new Error(BRIDGE_ONLY);
+  }
+}

--- a/packages/connectors/src/browser/evaluate.ts
+++ b/packages/connectors/src/browser/evaluate.ts
@@ -47,6 +47,11 @@ export default class BrowserEvaluateConnector extends ConnectorRuntime {
         name: 'Evaluate JS',
         description:
           'Executes a JS expression in the page and emits one event with the JSON-serialised return value.',
+        // `script` is required and gateway-author-supplied. Auto-wire would
+        // insert a feed row with config=NULL and produce a runs-but-fails
+        // loop. Bridge connectors (Revolut, banking, etc.) compose by
+        // creating explicit feed instances per call site.
+        userManaged: true,
         configSchema: {
           type: 'object',
           required: ['script'],

--- a/packages/connectors/src/browser/fill_form.ts
+++ b/packages/connectors/src/browser/fill_form.ts
@@ -41,6 +41,9 @@ export default class BrowserFillFormConnector extends ConnectorRuntime {
         name: 'Fill form',
         description:
           'Sets values on input/textarea/select elements matched by CSS selector.',
+        // Required url + fields; instances are minted by composing bridge
+        // connectors, not auto-wired by device-reconcile.
+        userManaged: true,
         configSchema: {
           type: 'object',
           required: ['url', 'fields'],

--- a/packages/connectors/src/browser/fill_form.ts
+++ b/packages/connectors/src/browser/fill_form.ts
@@ -1,0 +1,104 @@
+/**
+ * Browser Fill Form Connector — Owletto for Chrome only.
+ *
+ * Thin wrapper around browser.evaluate that bakes in a "fill these inputs
+ * by selector and dispatch the right input/change events" script.
+ *
+ * The extension's executor branch for `browser.fill_form` substitutes the
+ * canonical fill-form script when this connector_key is dispatched. The
+ * server-side definition just exposes the URL + fields config to the
+ * admin UI.
+ *
+ * Cloud-side `sync()` / `execute()` throw — actual work happens in the
+ * extension's service worker (lobu-ai/owletto: apps/chrome/executor.js).
+ */
+
+import {
+  type ActionResult,
+  type ConnectorDefinition,
+  ConnectorRuntime,
+  type SyncContext,
+  type SyncResult,
+} from '@lobu/connector-sdk';
+
+const BRIDGE_ONLY =
+  'browser.fill_form runs only on a worker advertising capability "browser.debugger" (Owletto for Chrome).';
+
+export default class BrowserFillFormConnector extends ConnectorRuntime {
+  readonly definition: ConnectorDefinition = {
+    key: 'browser.fill_form',
+    name: 'Browser Fill Form',
+    description:
+      'Fills inputs on a page by CSS selector and dispatches input/change events. Returns the filled field count.',
+    version: '0.1.0',
+    faviconDomain: 'google.com',
+    requiredCapability: 'browser.debugger',
+    runtime: { platforms: ['chrome-extension'] },
+    authSchema: { methods: [{ type: 'none' }] },
+    feeds: {
+      fill: {
+        key: 'fill',
+        name: 'Fill form',
+        description:
+          'Sets values on input/textarea/select elements matched by CSS selector.',
+        configSchema: {
+          type: 'object',
+          required: ['url', 'fields'],
+          properties: {
+            url: {
+              type: 'string',
+              format: 'uri',
+              description: 'Page to load before filling.',
+            },
+            fields: {
+              type: 'object',
+              description:
+                'Map of CSS selector → value to set. e.g. { "#email": "x@y.com", "#submit": "click" } — the literal string "click" triggers a click instead of a value set.',
+              additionalProperties: { type: 'string' },
+            },
+            wait_for_selector: {
+              type: 'string',
+              description:
+                'CSS selector to wait for before filling (defaults to the first key of fields).',
+            },
+            wait_timeout_ms: {
+              type: 'integer',
+              minimum: 100,
+              maximum: 60_000,
+            },
+            submit_selector: {
+              type: 'string',
+              description:
+                'Optional selector to click after filling all fields (e.g. "button[type=submit]").',
+            },
+          },
+        },
+        eventKinds: {
+          form_filled: {
+            description:
+              'One event per run with the count of fields filled + whether submit was clicked.',
+            metadataSchema: {
+              type: 'object',
+              required: ['source', 'origin_id', 'url', 'filled_count'],
+              properties: {
+                source: { type: 'string', const: 'browser_fill_form' },
+                origin_id: { type: 'string' },
+                url: { type: 'string', format: 'uri' },
+                filled_count: { type: 'integer' },
+                submitted: { type: 'boolean' },
+              },
+            },
+          },
+        },
+      },
+    },
+  };
+
+  async sync(_ctx: SyncContext): Promise<SyncResult> {
+    throw new Error(BRIDGE_ONLY);
+  }
+
+  async execute(): Promise<ActionResult> {
+    throw new Error(BRIDGE_ONLY);
+  }
+}

--- a/packages/connectors/src/browser/page_text.ts
+++ b/packages/connectors/src/browser/page_text.ts
@@ -41,6 +41,9 @@ export default class BrowserPageTextConnector extends ConnectorRuntime {
         key: 'page',
         name: 'Page text',
         description: 'Snapshot of the text content of a single page.',
+        // Required url; instances are minted by composing bridge connectors,
+        // not auto-wired by device-reconcile.
+        userManaged: true,
         configSchema: {
           type: 'object',
           required: ['url'],

--- a/packages/connectors/src/browser/page_text.ts
+++ b/packages/connectors/src/browser/page_text.ts
@@ -1,0 +1,105 @@
+/**
+ * Browser Page Text Connector — Owletto for Chrome only.
+ *
+ * Thin wrapper around browser.evaluate that bakes in a "return cleaned-up
+ * page text" script. Saves the connector author from re-deriving the
+ * text-extraction recipe for every page-scrape feed.
+ *
+ * The extension's executor branch for `browser.page_text` is responsible
+ * for substituting the canonical script when this connector_key is
+ * dispatched — gateway-side this connector definition just exposes the
+ * URL + selector-scope config to the admin UI.
+ *
+ * Cloud-side `sync()` / `execute()` throw — actual work happens in the
+ * extension's service worker (lobu-ai/owletto: apps/chrome/executor.js).
+ */
+
+import {
+  type ActionResult,
+  type ConnectorDefinition,
+  ConnectorRuntime,
+  type SyncContext,
+  type SyncResult,
+} from '@lobu/connector-sdk';
+
+const BRIDGE_ONLY =
+  'browser.page_text runs only on a worker advertising capability "browser.debugger" (Owletto for Chrome).';
+
+export default class BrowserPageTextConnector extends ConnectorRuntime {
+  readonly definition: ConnectorDefinition = {
+    key: 'browser.page_text',
+    name: 'Browser Page Text',
+    description:
+      'Fetches a page in the paired Chrome and returns its readable text content. Wraps browser.evaluate with a canonical text-extraction script.',
+    version: '0.1.0',
+    faviconDomain: 'google.com',
+    requiredCapability: 'browser.debugger',
+    runtime: { platforms: ['chrome-extension'] },
+    authSchema: { methods: [{ type: 'none' }] },
+    feeds: {
+      page: {
+        key: 'page',
+        name: 'Page text',
+        description: 'Snapshot of the text content of a single page.',
+        configSchema: {
+          type: 'object',
+          required: ['url'],
+          properties: {
+            url: {
+              type: 'string',
+              format: 'uri',
+              description: 'Page to load and read text from.',
+            },
+            selector: {
+              type: 'string',
+              description:
+                'CSS selector to scope the extraction to (defaults to body.innerText).',
+            },
+            wait_for_selector: {
+              type: 'string',
+              description:
+                'CSS selector to wait for before reading (defaults to body).',
+            },
+            wait_timeout_ms: {
+              type: 'integer',
+              minimum: 100,
+              maximum: 60_000,
+            },
+            max_chars: {
+              type: 'integer',
+              minimum: 100,
+              maximum: 1_000_000,
+              description: 'Truncate output past this length. Default 200000.',
+            },
+          },
+        },
+        eventKinds: {
+          page_text: {
+            description:
+              'One event per run containing the page text (truncated to max_chars).',
+            metadataSchema: {
+              type: 'object',
+              required: ['source', 'origin_id', 'url'],
+              properties: {
+                source: { type: 'string', const: 'browser_page_text' },
+                origin_id: { type: 'string' },
+                url: { type: 'string', format: 'uri' },
+                title: { type: 'string' },
+                char_count: { type: 'integer' },
+                truncated: { type: 'boolean' },
+              },
+            },
+          },
+        },
+      },
+    },
+  };
+
+  async sync(_ctx: SyncContext): Promise<SyncResult> {
+    throw new Error(BRIDGE_ONLY);
+  }
+
+  async execute(): Promise<ActionResult> {
+    throw new Error(BRIDGE_ONLY);
+  }
+}

--- a/packages/connectors/src/index.ts
+++ b/packages/connectors/src/index.ts
@@ -3,6 +3,13 @@ export * from './apple_photos.ts';
 export * from './apple_screen_time.ts';
 export * from './local_directory.ts';
 export * from './browser-scraper-utils.ts';
+// Browser primitives — connector definitions whose executors live in the
+// Owletto for Chrome extension (apps/chrome/executor.js). Kept under
+// browser/ so they're structurally distinct from third-party service
+// connectors (linkedin, revolut, github, etc.).
+export * from './browser/evaluate.ts';
+export * from './browser/fill_form.ts';
+export * from './browser/page_text.ts';
 export * from './capterra.ts';
 export * from './chrome_tabs.ts';
 export * from './g2.ts';

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -151,9 +151,9 @@ async function resolveWebDistDirectory(): Promise<string | null> {
   const candidates = [
     process.env.WEB_DIST_DIR?.trim(),
     path.resolve(APP_ROOT, 'packages/owletto/dist'),
-    path.resolve(APP_ROOT, '../web/dist'),
+    path.resolve(APP_ROOT, '../owletto/dist'),
     path.resolve(process.cwd(), 'packages/owletto/dist'),
-    path.resolve(process.cwd(), '../packages/owletto/dist'),
+    path.resolve(process.cwd(), '../owletto/dist'),
   ].filter((candidate): candidate is string => Boolean(candidate));
 
   for (const candidate of candidates) {
@@ -187,11 +187,19 @@ async function loadSpaHtmlTemplate(): Promise<string | null> {
 }
 
 async function loadFallbackSpaHtmlTemplate(): Promise<string | null> {
+  // APP_ROOT is the server package dir (packages/server). The sibling
+  // candidate must walk one level up first to land in `packages/`, then
+  // into `owletto/`. The previous `../packages/owletto/...` form here and
+  // in resolveWebDistDirectory was a copy-paste from when this file was
+  // working from a different anchor — it resolves to
+  // `packages/packages/owletto/...` and silently misses every time.
+  // Same story for `../web/...` which was left over from the
+  // packages/web → packages/owletto rename (#817).
   const candidates = [
     path.resolve(APP_ROOT, 'packages/owletto/index.html'),
-    path.resolve(APP_ROOT, '../web/index.html'),
+    path.resolve(APP_ROOT, '../owletto/index.html'),
     path.resolve(process.cwd(), 'packages/owletto/index.html'),
-    path.resolve(process.cwd(), '../packages/owletto/index.html'),
+    path.resolve(process.cwd(), '../owletto/index.html'),
   ];
 
   for (const candidate of candidates) {

--- a/packages/server/src/utils/connector-catalog.ts
+++ b/packages/server/src/utils/connector-catalog.ts
@@ -385,6 +385,11 @@ export async function listCatalogConnectorDefinitions(
         continue;
       }
       if (entry.isDirectory()) {
+        // Skip private / non-connector folders. `__tests__` ships test files
+        // that import `bun:test`, which esbuild can't resolve and which
+        // surface as catalog-cold-scan warnings; any leading-underscore name
+        // is by convention not a connector grouping.
+        if (entry.name === '__tests__' || entry.name.startsWith('_')) continue;
         try {
           const subEntries = await readdir(entryPath, { withFileTypes: true });
           for (const sub of subEntries.sort((a, b) => a.name.localeCompare(b.name))) {

--- a/packages/server/src/utils/connector-catalog.ts
+++ b/packages/server/src/utils/connector-catalog.ts
@@ -134,17 +134,40 @@ const bundledFileCache = new Map<string, string | null>();
 export function findBundledConnectorFile(key: string): string | null {
   const cached = bundledFileCache.get(key);
   if (cached !== undefined) return cached;
-  const fileName = `${key.replace(/\./g, '_')}.ts`;
+  // Mirror the worker-side resolver in compile-connector.ts: try the
+  // subdir layout first (`browser.evaluate` → `browser/evaluate.ts`) and
+  // fall back to the flat underscore convention (`chrome.tabs` →
+  // `chrome_tabs.ts`). Keep these in sync if either side changes.
+  const candidates = [`${key.replace(/\./g, '/')}.ts`, `${key.replace(/\./g, '_')}.ts`];
   let found: string | null = null;
-  for (const candidate of DEFAULT_CONNECTOR_DIR_CANDIDATES) {
-    const filePath = resolve(candidate, fileName);
-    if (existsSync(filePath)) {
-      found = filePath;
-      break;
+  outer: for (const dir of DEFAULT_CONNECTOR_DIR_CANDIDATES) {
+    for (const fileName of candidates) {
+      const filePath = resolve(dir, fileName);
+      if (!filePath.startsWith(`${dir}/`)) continue;
+      if (existsSync(filePath)) {
+        found = filePath;
+        break outer;
+      }
     }
   }
   bundledFileCache.set(key, found);
   return found;
+}
+
+// Derive the persisted source_path (relative to the bundled-connectors
+// catalog dir) for a file resolved by findBundledConnectorFile. Used by
+// auto-install / device-reconcile so subdir-grouped connectors
+// (`browser/evaluate.ts`) round-trip correctly through
+// `connectorSourcePathToUri`. Falls back to basename if the file lives
+// outside every known candidate (shouldn't happen in practice, but keeps
+// the call site simple).
+export function bundledConnectorSourcePath(filePath: string): string {
+  for (const dir of DEFAULT_CONNECTOR_DIR_CANDIDATES) {
+    if (filePath.startsWith(`${dir}/`)) {
+      return relative(dir, filePath);
+    }
+  }
+  return relative(resolve(filePath, '..'), filePath);
 }
 
 export function normalizeFileSourceUri(value: string): string | null {

--- a/packages/server/src/utils/connector-catalog.ts
+++ b/packages/server/src/utils/connector-catalog.ts
@@ -2,7 +2,7 @@ import { existsSync } from 'node:fs';
 import { mkdtemp, readdir, readFile, rm, stat } from 'node:fs/promises';
 import { createRequire } from 'node:module';
 import { tmpdir } from 'node:os';
-import { basename, extname, join, resolve } from 'node:path';
+import { extname, join, relative, resolve } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import { build, type Plugin } from 'esbuild';
 import { EXTERNAL_RUNTIME_DEPS } from '../../../connector-worker/src/runtime-deps';
@@ -349,12 +349,34 @@ export async function listCatalogConnectorDefinitions(
       continue;
     }
 
-    const entries = await readdir(dirPath, { withFileTypes: true });
-    for (const entry of entries.sort((a, b) => a.name.localeCompare(b.name))) {
-      if (!entry.isFile()) continue;
-      if (extname(entry.name) !== '.ts' || entry.name.endsWith('.d.ts')) continue;
+    // Scan one level deep so primitive groupings like `browser/*.ts` are
+    // discovered alongside top-level service connectors. Two-level scan
+    // keeps the loader bounded — connectors don't currently nest deeper.
+    const candidatePaths: string[] = [];
+    const topEntries = await readdir(dirPath, { withFileTypes: true });
+    for (const entry of topEntries.sort((a, b) => a.name.localeCompare(b.name))) {
+      const entryPath = resolve(dirPath, entry.name);
+      if (entry.isFile()) {
+        if (extname(entry.name) !== '.ts' || entry.name.endsWith('.d.ts')) continue;
+        candidatePaths.push(entryPath);
+        continue;
+      }
+      if (entry.isDirectory()) {
+        try {
+          const subEntries = await readdir(entryPath, { withFileTypes: true });
+          for (const sub of subEntries.sort((a, b) => a.name.localeCompare(b.name))) {
+            if (!sub.isFile()) continue;
+            if (extname(sub.name) !== '.ts' || sub.name.endsWith('.d.ts')) continue;
+            candidatePaths.push(resolve(entryPath, sub.name));
+          }
+        } catch {
+          // Subdir unreadable — skip silently. Top-level scan still produced
+          // whatever it could; don't fail the whole catalog over one bad dir.
+        }
+      }
+    }
 
-      const filePath = resolve(dirPath, entry.name);
+    for (const filePath of candidatePaths) {
       const metadata = await extractConnectorCatalogMetadata(filePath);
       if (!metadata || seenKeys.has(metadata.key)) continue;
 
@@ -373,7 +395,9 @@ export async function listCatalogConnectorDefinitions(
         runtime: metadata.runtime,
         status: 'active',
         login_enabled: metadata.login_enabled,
-        source_path: basename(filePath),
+        // Preserve subdirectory in source_path so worker resolvers can
+        // find `browser/evaluate.ts` etc. without colliding on basename.
+        source_path: relative(dirPath, filePath),
         source_uri: pathToFileURL(filePath).toString(),
         installed: false,
         installable: true,

--- a/packages/server/src/utils/ensure-connector-installed.ts
+++ b/packages/server/src/utils/ensure-connector-installed.ts
@@ -9,9 +9,12 @@
  * from source_path, so edits to .ts files take effect without reinstalling.
  */
 
-import { basename } from 'node:path';
 import { getDb } from '../db/client';
-import { compileConnectorFromFile, findBundledConnectorFile } from './connector-catalog';
+import {
+  bundledConnectorSourcePath,
+  compileConnectorFromFile,
+  findBundledConnectorFile,
+} from './connector-catalog';
 import { extractConnectorMetadata } from './connector-compiler';
 import { upsertConnectorDefinitionRecords } from './connector-definition-install';
 import logger from './logger';
@@ -65,7 +68,7 @@ export async function ensureConnectorInstalled(params: {
       throw new Error('Connector must have key, name, and version.');
     }
 
-    const sourcePath = basename(filePath);
+    const sourcePath = bundledConnectorSourcePath(filePath);
     await upsertConnectorDefinitionRecords({
       sql,
       organizationId: params.organizationId,

--- a/packages/server/src/utils/public-origin.ts
+++ b/packages/server/src/utils/public-origin.ts
@@ -57,16 +57,20 @@ export function hasLocalFrontend(): boolean {
 
   const envDist = process.env.WEB_DIST_DIR?.trim();
   const isDevelopment = process.env.NODE_ENV === 'development';
+  // Sibling-walk candidates must go through `../owletto/`, not
+  // `../packages/owletto/` (resolves to `packages/packages/owletto/`).
+  // `../web/...` is a leftover from the packages/web → packages/owletto
+  // rename in #817.
   const candidates = [
     envDist ? path.join(envDist, 'index.html') : undefined,
     path.resolve(APP_ROOT, 'packages/owletto/dist/index.html'),
-    path.resolve(APP_ROOT, '../web/dist/index.html'),
+    path.resolve(APP_ROOT, '../owletto/dist/index.html'),
     path.resolve(process.cwd(), 'packages/owletto/dist/index.html'),
-    path.resolve(process.cwd(), '../packages/owletto/dist/index.html'),
+    path.resolve(process.cwd(), '../owletto/dist/index.html'),
     isDevelopment ? path.resolve(APP_ROOT, 'packages/owletto/index.html') : undefined,
-    isDevelopment ? path.resolve(APP_ROOT, '../web/index.html') : undefined,
+    isDevelopment ? path.resolve(APP_ROOT, '../owletto/index.html') : undefined,
     isDevelopment ? path.resolve(process.cwd(), 'packages/owletto/index.html') : undefined,
-    isDevelopment ? path.resolve(process.cwd(), '../packages/owletto/index.html') : undefined,
+    isDevelopment ? path.resolve(process.cwd(), '../owletto/index.html') : undefined,
   ].filter((candidate): candidate is string => Boolean(candidate));
 
   for (const candidate of candidates) {

--- a/packages/server/src/worker-api/device-reconcile.ts
+++ b/packages/server/src/worker-api/device-reconcile.ts
@@ -9,10 +9,10 @@
  * creating runs nothing can claim.
  */
 
-import { basename } from 'node:path';
 import { getDb, pgTextArray } from '../db/client';
 import {
   type BundledDeviceConnector,
+  bundledConnectorSourcePath,
   compileConnectorFromFile,
   findBundledConnectorFile,
   getBundledDeviceConnectors,
@@ -158,7 +158,7 @@ async function ensureDeviceConnectorWired(
           compiledCode: null,
           compiledCodeHash: null,
           sourceCode: null,
-          sourcePath: basename(filePath),
+          sourcePath: bundledConnectorSourcePath(filePath),
         },
       });
 

--- a/packages/server/src/worker-api/device-reconcile.ts
+++ b/packages/server/src/worker-api/device-reconcile.ts
@@ -55,6 +55,15 @@ async function ensureDeviceConnectorWired(
 ): Promise<void> {
   const sql = getDb();
 
+  // Primitive connectors (every feed marked `userManaged`, e.g. browser/*)
+  // have nothing to auto-wire — feeds are minted by composing bridge
+  // connectors via /api/workers/me/feeds, not by device-reconcile. Skip
+  // before doing any DB or compile work so each Chrome poll doesn't pay
+  // the cost. The connector_definition + version row will be installed
+  // lazily by ensureConnectorInstalled when a composing connector
+  // actually runs one of these primitives.
+  if (declaredFeedKeys.length === 0) return;
+
   // Self-heal the device pin against the user's current fleet. Cheap, idempotent
   // (the WHERE matches nothing when the pin is already a valid fresh device), and
   // runs even on the fast path so a stale pin doesn't silently strand the feeds.

--- a/packages/server/src/worker-api/device-reconcile.ts
+++ b/packages/server/src/worker-api/device-reconcile.ts
@@ -55,15 +55,6 @@ async function ensureDeviceConnectorWired(
 ): Promise<void> {
   const sql = getDb();
 
-  // Primitive connectors (every feed marked `userManaged`, e.g. browser/*)
-  // have nothing to auto-wire — feeds are minted by composing bridge
-  // connectors via /api/workers/me/feeds, not by device-reconcile. Skip
-  // before doing any DB or compile work so each Chrome poll doesn't pay
-  // the cost. The connector_definition + version row will be installed
-  // lazily by ensureConnectorInstalled when a composing connector
-  // actually runs one of these primitives.
-  if (declaredFeedKeys.length === 0) return;
-
   // Self-heal the device pin against the user's current fleet. Cheap, idempotent
   // (the WHERE matches nothing when the pin is already a valid fresh device), and
   // runs even on the fast path so a stale pin doesn't silently strand the feeds.
@@ -124,8 +115,13 @@ async function ensureDeviceConnectorWired(
     if (
       existingReady[0]?.connection_id &&
       existingReady[0]?.version_key &&
-      declaredFeedKeys.length > 0 &&
-      declaredFeedKeys.every((feedKey) => activeFeedKeys.has(feedKey))
+      // userManaged-only connectors (e.g. local.directory, browser/*) report
+      // declaredFeedKeys=[]. Once the connection + definition are installed,
+      // every subsequent poll has nothing to verify — fast-path out.
+      // Composing primitives still hit /api/workers/me/feeds to mint
+      // explicit per-instance rows; that path is unchanged.
+      (declaredFeedKeys.length === 0 ||
+        declaredFeedKeys.every((feedKey) => activeFeedKeys.has(feedKey)))
     ) {
       return;
     }

--- a/packages/server/src/workspace/multi-tenant.ts
+++ b/packages/server/src/workspace/multi-tenant.ts
@@ -574,6 +574,22 @@ export class MultiTenantProvider implements WorkspaceProvider {
       // Session validation failed, continue to anonymous
     }
 
+    // If the client sent `Authorization: Bearer …` and we got here, it
+    // wasn't a valid PAT, OAuth access token, or Better Auth session token —
+    // all three resolution paths above bailed. Return the RFC 6750
+    // `invalid_token` error (not the generic anonymous fall-through), so
+    // standards-compliant clients surface "bad token" rather than mistaking
+    // it for "no auth needed."
+    if (authHeader?.startsWith('Bearer ')) {
+      return c.json(
+        { error: 'invalid_token', error_description: 'Invalid or expired access token' },
+        401,
+        {
+          'WWW-Authenticate': `Bearer realm="${baseUrl}/.well-known/oauth-protected-resource", error="invalid_token"`,
+        }
+      );
+    }
+
     // 3) Anonymous: allow through with null org for discovery (tools/list, initialize)
     //    tools/call will enforce org context at the handler level.
     if (!requestedOrgId) {


### PR DESCRIPTION
## Summary

Pairs with owletto-web PR #153 (chrome.debugger executor inside Owletto for Chrome). Adds the server-side connector definition that makes the new extension executor invocable from the admin UI + watcher dispatch, and bumps the owletto submodule pointer so the matching extension code lands.

## What's in this PR

- **`packages/connectors/src/browser_evaluate.ts` (new)** — generic "run JS in a user's signed-in Chrome via chrome.debugger" connector. `requiredCapability: 'browser.debugger'`, `runtime.platforms: ['chrome-extension']`. configSchema mirrors the executor's payload contract:
  - `url` (optional) — navigate first
  - `script` (required) — JS expression for `Runtime.evaluate(awaitPromise: true)`
  - `wait_for_selector` + `wait_timeout_ms` — polled selector gate before eval
  - `open_in_new_tab` — **defaults true** for the same trust-boundary reason as the extension side: a compromised gateway / leaked worker token shouldn't be able to drive the tab the user is actively using
  - `close_tab_after` — defaults to `open_in_new_tab`
- **`packages/connectors/src/index.ts`** — export the new connector. The catalog auto-discovers `packages/connectors/src/*.ts` so registration is automatic, but the index export is needed for direct imports from the connector worker.
- **`packages/owletto`** — bump submodule pointer to `feat/chrome-debugger-executor` HEAD so the extension's `runBrowserEvaluate` lands with the connector definition.

## Why this is small

The architecture was already there (`device_worker_id` pinning, `approved_input` → `action_input` plumbing, `runtime.platforms: ['chrome-extension']` auto-wiring) — only the missing pieces were the extension-side executor (in PR #153) and this one server-side definition file. No new gateway code, no new dispatch logic, no new run protocol — the existing `chrome.tabs` connector is the same shape.

## End-to-end verification

Done locally with a fake mini-gateway + Playwright-loaded Chrome + the Owletto extension built from the submodule pointer in this PR. The executor opened a background tab, attached chrome.debugger, navigated to example.com, evaluated `({ title: document.title, h1: document.querySelector('h1')?.textContent })`, streamed back `{"title":"Example Domain","h1":"Example Domain"}`, posted complete, closed the tab — all in ~2 seconds with no leftover yellow debugger banner. Full log in PR #153's e2e comment.

## Test plan

- [x] `make build-packages`
- [x] `make typecheck` (strict, matches Dockerfile)
- [x] E2E with real Chrome via fake gateway (see PR #153)
- [ ] **Manual integration**: once both PRs are merged, create a "Browser Evaluate" connection from the admin UI, pin it to a Chrome device, dispatch a run, verify the event lands.

## Follow-ups

- **Typed connector helpers in the SDK** — connector authors today craft raw JS strings. A `navigate(url) + snapshot() + click(ref) + evaluate(fn)` DSL on the gateway side would be the natural ergonomics layer. Out of scope; shaped by the first real bridge connector (Revolut feed is the most likely first consumer).
- **Signed/allowlisted scripts** — the real fix to the trust boundary. The current posture (default new tab, gateway-mints-script, OAuth gates the gateway) is sufficient for v0.2 but worth tightening before opening the bridge to user-tooled scripts.
- **`browser.snapshot` / `browser.page_text` / `browser.fill_form`** — specialized connectors that build on top of `browser.evaluate`. Each is a thin wrapper.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added three new Chrome extension connectors: `browser.evaluate` for executing scripts, `browser.fill_form` for automating form submissions, and `browser.page_text` for extracting page content.

* **Improvements**
  * Enhanced connector discovery to support connectors organized in subdirectories.

* **Tests**
  * Updated test formatting and consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lobu-ai/lobu/pull/828?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->