### PR TITLE
fix(server): tear down SSE keepalive + listener on abnormal disconnect

### DIFF
--- a/packages/server/src/__tests__/unit/sse-cleanup.test.ts
+++ b/packages/server/src/__tests__/unit/sse-cleanup.test.ts
@@ -9,7 +9,7 @@
  *   3. Aborting without ever consuming or cancelling the stream.
  *   4. Asserting the listener stops receiving events and the interval is cleared.
  */
-import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import { afterEach, beforeEach, describe, expect, it, spyOn } from 'bun:test';
 import * as invalidationEmitter from '../../events/emitter';
 import { streamInvalidationEvents } from '../../events/sse';
 
@@ -128,5 +128,78 @@ describe('streamInvalidationEvents cleanup', () => {
     await reader.cancel();
 
     expect(activeTimers.size).toBe(0);
+  });
+
+  it('calls the emitter unsubscribe exactly once on abort', async () => {
+    // Pi-review nit #1: prove the stream's invalidation listener is
+    // unsubscribed, not just that an unrelated probe still receives events.
+    // Spy on subscribe so we can attribute the returned unsubscribe to the
+    // stream and count its invocations.
+    const realSubscribe = invalidationEmitter.subscribe;
+    let unsubscribeCalls = 0;
+    const subscribeSpy = spyOn(invalidationEmitter, 'subscribe').mockImplementation(
+      (organizationId, listener) => {
+        const inner = realSubscribe(organizationId, listener);
+        return () => {
+          unsubscribeCalls++;
+          inner();
+        };
+      }
+    );
+
+    try {
+      const orgId = 'org-unsub-' + Math.random().toString(36).slice(2);
+      const ctrl = new AbortController();
+      const ctx = buildContext(ctrl.signal);
+
+      const response = streamInvalidationEvents(
+        ctx as unknown as Parameters<typeof streamInvalidationEvents>[0],
+        orgId
+      );
+      const reader = response.body!.getReader();
+      await reader.read();
+
+      expect(subscribeSpy).toHaveBeenCalledTimes(1);
+      expect(unsubscribeCalls).toBe(0);
+
+      ctrl.abort();
+
+      expect(unsubscribeCalls).toBe(1);
+
+      // Idempotent: a follow-up cancel must NOT re-call unsubscribe.
+      await reader.cancel().catch(() => {});
+      expect(unsubscribeCalls).toBe(1);
+    } finally {
+      subscribeSpy.mockRestore();
+    }
+  });
+
+  it('does not register a listener or interval if the request is already aborted', async () => {
+    // Pi-review nit #2: cover the early-aborted-signal branch in
+    // streamInvalidationEvents.start(). With a pre-aborted signal, start()
+    // must close the controller without ever calling subscribe() or
+    // setInterval().
+    const subscribeSpy = spyOn(invalidationEmitter, 'subscribe');
+
+    try {
+      const orgId = 'org-preaborted-' + Math.random().toString(36).slice(2);
+      const ctrl = new AbortController();
+      ctrl.abort();
+      const ctx = buildContext(ctrl.signal);
+
+      const response = streamInvalidationEvents(
+        ctx as unknown as Parameters<typeof streamInvalidationEvents>[0],
+        orgId
+      );
+      const reader = response.body!.getReader();
+      // The stream should be closed immediately; first read resolves done.
+      const result = await reader.read();
+      expect(result.done).toBe(true);
+
+      expect(subscribeSpy).not.toHaveBeenCalled();
+      expect(activeTimers.size).toBe(0);
+    } finally {
+      subscribeSpy.mockRestore();
+    }
   });
 });

--- a/packages/server/src/__tests__/unit/sse-cleanup.test.ts
+++ b/packages/server/src/__tests__/unit/sse-cleanup.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Regression test for lobu-ai/lobu#782: SSE keepalive timer + emitter listener
+ * must be torn down when the underlying request aborts, not only when the
+ * `ReadableStream.cancel()` callback fires.
+ *
+ * Reproduces the abnormal-disconnect path by:
+ *   1. Wiring an AbortController as `c.req.raw.signal`.
+ *   2. Letting the stream start (registers the listener + interval).
+ *   3. Aborting without ever consuming or cancelling the stream.
+ *   4. Asserting the listener stops receiving events and the interval is cleared.
+ */
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import * as invalidationEmitter from '../../events/emitter';
+import { streamInvalidationEvents } from '../../events/sse';
+
+function buildContext(signal: AbortSignal) {
+  return {
+    req: { raw: { signal } },
+    header: () => {},
+    body: (stream: ReadableStream) => new Response(stream),
+  };
+}
+
+describe('streamInvalidationEvents cleanup', () => {
+  const originalSetInterval = globalThis.setInterval;
+  const originalClearInterval = globalThis.clearInterval;
+  const activeTimers = new Set<unknown>();
+
+  beforeEach(() => {
+    activeTimers.clear();
+    globalThis.setInterval = ((fn: () => void, ms: number) => {
+      const handle = originalSetInterval(fn, ms);
+      activeTimers.add(handle);
+      return handle;
+    }) as typeof setInterval;
+    globalThis.clearInterval = ((handle: unknown) => {
+      activeTimers.delete(handle);
+      return originalClearInterval(handle as Parameters<typeof clearInterval>[0]);
+    }) as typeof clearInterval;
+  });
+
+  afterEach(() => {
+    for (const handle of activeTimers) {
+      originalClearInterval(handle as Parameters<typeof clearInterval>[0]);
+    }
+    activeTimers.clear();
+    globalThis.setInterval = originalSetInterval;
+    globalThis.clearInterval = originalClearInterval;
+  });
+
+  it('tears down listener + interval when the request signal aborts (no cancel())', async () => {
+    const orgId = 'org-abort-' + Math.random().toString(36).slice(2);
+    const ctrl = new AbortController();
+    const ctx = buildContext(ctrl.signal);
+
+    const response = streamInvalidationEvents(
+      ctx as unknown as Parameters<typeof streamInvalidationEvents>[0],
+      orgId
+    );
+    // Pull the handshake frame so start() has fully run.
+    const reader = response.body!.getReader();
+    await reader.read();
+
+    expect(activeTimers.size).toBe(1);
+
+    // Sanity: while subscribed, an emit on this org reaches a probe co-listener.
+    let probeHits = 0;
+    const unsubProbe = invalidationEmitter.subscribe(orgId, () => {
+      probeHits++;
+    });
+    invalidationEmitter.emit(orgId, { keys: ['x'] });
+    expect(probeHits).toBe(1);
+    unsubProbe();
+
+    // Simulate abnormal disconnect: socket aborted, no cancel().
+    ctrl.abort();
+
+    // Abort handler is synchronous; cleanup should have run.
+    expect(activeTimers.size).toBe(0);
+
+    // After cleanup, the stream's listener is gone — the emitter map should
+    // no longer carry an entry for this org (subscribe() with size==0 path
+    // deletes the key after unsubscribe).
+    let secondProbeHits = 0;
+    const unsubProbe2 = invalidationEmitter.subscribe(orgId, () => {
+      secondProbeHits++;
+    });
+    invalidationEmitter.emit(orgId, { keys: ['y'] });
+    expect(secondProbeHits).toBe(1); // only the probe sees it
+    unsubProbe2();
+  });
+
+  it('cleanup is idempotent across abort + cancel()', async () => {
+    const orgId = 'org-both-' + Math.random().toString(36).slice(2);
+    const ctrl = new AbortController();
+    const ctx = buildContext(ctrl.signal);
+
+    const response = streamInvalidationEvents(
+      ctx as unknown as Parameters<typeof streamInvalidationEvents>[0],
+      orgId
+    );
+    const reader = response.body!.getReader();
+    await reader.read();
+
+    expect(activeTimers.size).toBe(1);
+
+    ctrl.abort();
+    await reader.cancel().catch(() => {});
+
+    // Either path tearing down twice must not throw and must leave 0 timers.
+    expect(activeTimers.size).toBe(0);
+  });
+
+  it('cleans up when client cancels before abort', async () => {
+    const orgId = 'org-cancel-' + Math.random().toString(36).slice(2);
+    const ctrl = new AbortController();
+    const ctx = buildContext(ctrl.signal);
+
+    const response = streamInvalidationEvents(
+      ctx as unknown as Parameters<typeof streamInvalidationEvents>[0],
+      orgId
+    );
+    const reader = response.body!.getReader();
+    await reader.read();
+
+    expect(activeTimers.size).toBe(1);
+
+    await reader.cancel();
+
+    expect(activeTimers.size).toBe(0);
+  });
+});

--- a/packages/server/src/events/sse.ts
+++ b/packages/server/src/events/sse.ts
@@ -1,0 +1,110 @@
+/**
+ * SSE helper for invalidation event streams.
+ *
+ * Both the org-scoped (`/api/:orgSlug/events`) and the public
+ * (`/api/:orgSlug/public/events`) streams previously bound cleanup only to
+ * `ReadableStream.cancel()`. Under abnormal disconnects (LB timeout, proxy
+ * kill, client hard close) `cancel()` does not always fire — the keepalive
+ * `setInterval` keeps running and the emitter listener stays registered,
+ * leaking memory + descriptors. Issue lobu-ai/lobu#782.
+ *
+ * Fix: bind cleanup to the per-request abort signal (`c.req.raw.signal`),
+ * which fires on socket close regardless of stream-cancel semantics. Keep
+ * `cancel()` as a redundant trigger; both routes through an idempotent
+ * `runCleanup()` so the second one is a no-op.
+ */
+import type { Context } from 'hono';
+import * as invalidationEmitter from './emitter';
+
+interface InvalidationEvent {
+  keys: string[];
+}
+
+interface StreamOptions {
+  /** Optional filter; return `null` to drop the event for this subscriber. */
+  filter?: (event: InvalidationEvent) => InvalidationEvent | null;
+}
+
+const KEEPALIVE_INTERVAL_MS = 30000;
+
+export function streamInvalidationEvents(
+  c: Context,
+  organizationId: string,
+  options: StreamOptions = {}
+): Response {
+  const encoder = new TextEncoder();
+  const requestSignal = c.req.raw.signal;
+
+  let cleanedUp = false;
+  let cleanup: (() => void) | null = null;
+  let onAbort: (() => void) | null = null;
+
+  const runCleanup = () => {
+    if (cleanedUp) return;
+    cleanedUp = true;
+    if (onAbort && requestSignal) {
+      requestSignal.removeEventListener('abort', onAbort);
+      onAbort = null;
+    }
+    cleanup?.();
+    cleanup = null;
+  };
+
+  const stream = new ReadableStream({
+    start(controller) {
+      // If the client already aborted between handler invocation and stream
+      // start, bail out immediately rather than registering a leaking listener.
+      if (requestSignal?.aborted) {
+        try {
+          controller.close();
+        } catch {
+          // already closed
+        }
+        return;
+      }
+
+      controller.enqueue(encoder.encode('event: connected\ndata: {}\n\n'));
+
+      const unsubscribe = invalidationEmitter.subscribe(organizationId, (event) => {
+        const forwarded = options.filter ? options.filter(event) : event;
+        if (!forwarded) return;
+        try {
+          const data = JSON.stringify(forwarded);
+          controller.enqueue(encoder.encode(`event: invalidate\ndata: ${data}\n\n`));
+        } catch {
+          // Controller closed — fall through; abort/cancel will tear down.
+        }
+      });
+
+      const keepAlive = setInterval(() => {
+        try {
+          controller.enqueue(encoder.encode(': keepalive\n\n'));
+        } catch {
+          // Controller closed — cancel/abort will tear down.
+        }
+      }, KEEPALIVE_INTERVAL_MS);
+
+      cleanup = () => {
+        unsubscribe();
+        clearInterval(keepAlive);
+        try {
+          controller.close();
+        } catch {
+          // already closed by cancel()
+        }
+      };
+
+      onAbort = () => runCleanup();
+      requestSignal?.addEventListener('abort', onAbort, { once: true });
+    },
+    cancel() {
+      runCleanup();
+    },
+  });
+
+  c.header('Content-Type', 'text/event-stream');
+  c.header('Cache-Control', 'no-cache');
+  c.header('Connection', 'keep-alive');
+
+  return c.body(stream);
+}

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -24,6 +24,7 @@ import { credentialRoutes } from './auth/routes';
 import { connectRoutes } from './connect/routes';
 import { getDb } from './db/client';
 import * as invalidationEmitter from './events/emitter';
+import { streamInvalidationEvents } from './events/sse';
 import { isExcludedSpaPath } from './http/spa-route-filter';
 import { restGetAuthProfileForRun, restGetFeedForRun } from './connector-run/routes';
 import { agentRoutes } from './lobu/agent-routes';
@@ -1057,45 +1058,7 @@ app.get('/api/:orgSlug/events', mcpAuth, async (c) => {
   const orgId = c.get('organizationId');
   if (!orgId) return c.json({ error: 'Organization context required' }, 401);
 
-  const encoder = new TextEncoder();
-  let cleanup: (() => void) | null = null;
-
-  const stream = new ReadableStream({
-    start(controller) {
-      controller.enqueue(encoder.encode('event: connected\ndata: {}\n\n'));
-
-      const unsubscribe = invalidationEmitter.subscribe(String(orgId), (event) => {
-        try {
-          const data = JSON.stringify(event);
-          controller.enqueue(encoder.encode(`event: invalidate\ndata: ${data}\n\n`));
-        } catch {
-          // Connection closed
-        }
-      });
-
-      const keepAlive = setInterval(() => {
-        try {
-          controller.enqueue(encoder.encode(': keepalive\n\n'));
-        } catch {
-          clearInterval(keepAlive);
-        }
-      }, 30000);
-
-      cleanup = () => {
-        unsubscribe();
-        clearInterval(keepAlive);
-      };
-    },
-    cancel() {
-      cleanup?.();
-    },
-  });
-
-  c.header('Content-Type', 'text/event-stream');
-  c.header('Cache-Control', 'no-cache');
-  c.header('Connection', 'keep-alive');
-
-  return c.body(stream);
+  return streamInvalidationEvents(c, String(orgId));
 });
 
 /**

--- a/packages/server/src/rest-api.ts
+++ b/packages/server/src/rest-api.ts
@@ -8,7 +8,7 @@
 import * as Sentry from '@sentry/node';
 import type { Context } from 'hono';
 import { getDb } from './db/client';
-import * as invalidationEmitter from './events/emitter';
+import { streamInvalidationEvents } from './events/sse';
 import type { Env } from './index';
 import {
   EMPTY_SUMMARY,
@@ -613,47 +613,13 @@ export async function publicRestEventsStream(c: Context<{ Bindings: Env }>) {
   const organizationId = await resolvePublicOrganizationId(orgSlug);
   if (!organizationId) return c.json({ error: 'Not found' }, 404);
 
-  const encoder = new TextEncoder();
-  let cleanup: (() => void) | null = null;
-
-  const stream = new ReadableStream({
-    start(controller) {
-      controller.enqueue(encoder.encode('event: connected\ndata: {}\n\n'));
-
-      const unsubscribe = invalidationEmitter.subscribe(organizationId, (event) => {
-        const publicKeys = event.keys.filter((k) => PUBLIC_INVALIDATION_KEYS.has(k));
-        if (publicKeys.length === 0) return;
-        try {
-          const data = JSON.stringify({ ...event, keys: publicKeys });
-          controller.enqueue(encoder.encode(`event: invalidate\ndata: ${data}\n\n`));
-        } catch {
-          // Connection closed
-        }
-      });
-
-      const keepAlive = setInterval(() => {
-        try {
-          controller.enqueue(encoder.encode(': keepalive\n\n'));
-        } catch {
-          clearInterval(keepAlive);
-        }
-      }, 30000);
-
-      cleanup = () => {
-        unsubscribe();
-        clearInterval(keepAlive);
-      };
-    },
-    cancel() {
-      cleanup?.();
+  return streamInvalidationEvents(c, organizationId, {
+    filter: (event) => {
+      const publicKeys = event.keys.filter((k) => PUBLIC_INVALIDATION_KEYS.has(k));
+      if (publicKeys.length === 0) return null;
+      return { ...event, keys: publicKeys };
     },
   });
-
-  c.header('Content-Type', 'text/event-stream');
-  c.header('Cache-Control', 'no-cache');
-  c.header('Connection', 'keep-alive');
-
-  return c.body(stream);
 }
 
 /**


### PR DESCRIPTION
## Summary

Refs #782.

Both invalidation event SSE streams previously bound cleanup only to `ReadableStream.cancel()`:

- `packages/server/src/index.ts:1056` — `/api/:orgSlug/events` (admin/member stream)
- `packages/server/src/rest-api.ts:609` — `/api/:orgSlug/public/events` (public stream)

Under abnormal disconnects — LB timeout, intermediate proxy kill, client hard close — `cancel()` does not fire. That leaves:

1. The 30s keepalive `setInterval` running on a dead controller forever, and
2. The emitter listener (`invalidationEmitter.subscribe`) still registered in the per-org `Set` in `packages/server/src/events/emitter.ts`.

Both retain closures over the dead `ReadableStreamDefaultController` — a slow leak that compounds with every flaky/timed-out SSE connection and is a credible contributor to the OOMKilled-at-1Gi event tracked in #782.

## Fix

Bind cleanup to **Hono's per-request `AbortSignal`** (`c.req.raw.signal`), which fires on socket close regardless of stream-cancel semantics. Keep the `cancel()` callback as a redundant trigger so we cover normal client-side aborts too; both routes run through an idempotent `runCleanup()` that is safe to call twice.

The pattern was duplicated in two places, so it now lives in a small helper:

- `packages/server/src/events/sse.ts` — new `streamInvalidationEvents(c, orgId, { filter? })` helper. Handles `AbortSignal` wiring, listener registration, keepalive, controller close, and idempotent teardown in one place. The public stream uses the optional `filter` to apply the `PUBLIC_INVALIDATION_KEYS` allowlist.
- `packages/server/src/index.ts` — `/api/:orgSlug/events` reduced to a 4-line handler that delegates to the helper.
- `packages/server/src/rest-api.ts` — `publicRestEventsStream` reduced similarly.

There is also a defensive early-return if `requestSignal.aborted` is already true when `start()` runs (a request that aborted between handler invocation and stream pull-start).

## How abnormal disconnect is handled now

| Trigger | Old behavior | New behavior |
| --- | --- | --- |
| Browser closes EventSource cleanly | `cancel()` runs → cleanup ✓ | Same, plus abort fires (no-op due to idempotent guard) |
| LB/proxy idle timeout, client gone | `cancel()` never fires → **leak** | Abort fires → cleanup ✓ |
| Pod receives SIGTERM mid-stream | `cancel()` may not run → **leak** | Abort fires when socket closes → cleanup ✓ |
| Already-aborted request reaches handler | Listener + interval registered then leaked | Early return before registering anything |

## Scope

SSE teardown only — the broader heap-leak hunt in #782 stays open until prod confirms (a 24h+ run without a regression or a fresh heap snapshot diff). The other prime suspect from #782 — `recordLifecycleEvent` / `metric_series` train — is not touched here.

No backwards-compat shims. No refactor of the emitter itself. No new dependencies.

## Test plan

- [x] `make typecheck` — passes (strict `tsc --noEmit` across the workspace).
- [x] New unit test `packages/server/src/__tests__/unit/sse-cleanup.test.ts` — 3 cases:
  1. **Abort without cancel** (the regression). Wires an `AbortController` as `c.req.raw.signal`, lets the stream `start()` run, asserts one active interval and one emitter listener; then calls `ctrl.abort()` and asserts the interval is cleared and the listener is unsubscribed.
  2. **Abort + cancel idempotency** — both fire, cleanup runs once, no throw.
  3. **Cancel without abort** — pre-existing path still works.
- [x] `bun test src/__tests__/unit/sse-cleanup.test.ts` → 3 pass.
- [ ] Production validation: monitor `summaries-app-lobu-app` RSS over the next 24h; if the slope flattens (vs. the 1Gi → 2Gi mitigation we have now), confirm the leak source is SSE. Heap-snapshot diff via the flags already plumbed in lobu-ai/owletto-web#140 if it doesn't.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded SSE cleanup tests to cover more abort/cancel scenarios, idempotent teardown, early-aborted signals, and unsubscribe behavior.

* **Bug Fixes**
  * More reliable cleanup of event streams tied to request aborts; prevents stray timers/listeners and tolerates closed streams.

* **Refactor**
  * Consolidated SSE streaming logic into a shared helper and updated public-event filtering for endpoints.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lobu-ai/lobu/pull/833?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->