### PR TITLE
fix(device-reconcile): replace uuid[] cast with text[] to avoid PG array parse failure

### DIFF
--- a/packages/server/src/worker-api/device-reconcile.ts
+++ b/packages/server/src/worker-api/device-reconcile.ts
@@ -60,12 +60,19 @@ async function ensureDeviceConnectorWired(
   // runs even on the fast path so a stale pin doesn't silently strand the feeds.
   const reconcilePin = async (db: typeof sql, connectionId: number) => {
     const target = matchingDeviceIds.length === 1 ? matchingDeviceIds[0] : null;
+    // Compare via text on both sides — passing a `pgTextArray(...)` literal
+    // through a `::uuid[]` cast trips a postgres "malformed array literal"
+    // failure under the extended-protocol path postgres.js uses (the bound
+    // text parameter never gets re-parsed as an array before the uuid[] cast
+    // runs). `device_worker_id::text = ANY(text[])` sidesteps the cast
+    // entirely; UUIDs are canonical lowercase so text equality matches the
+    // uuid form 1:1.
     await db`
       UPDATE connections
       SET device_worker_id = ${target}::uuid, updated_at = NOW()
       WHERE id = ${connectionId}
         AND device_worker_id IS DISTINCT FROM ${target}::uuid
-        AND (device_worker_id IS NULL OR NOT (device_worker_id = ANY(${pgTextArray(matchingDeviceIds)}::uuid[])))
+        AND (device_worker_id IS NULL OR NOT (device_worker_id::text = ANY(${pgTextArray(matchingDeviceIds)}::text[])))
     `;
   };
 


### PR DESCRIPTION
Fixes #781.

## Smoking gun

Production app pod logs (image \`20260516-235210\`, 2026-05-17 00:10:06 UTC):

\`\`\`
[runs-queue] Run 197444 failed after retries: malformed array literal: \"f7623d32-b589-4085-9504-edbf30925961\"
[runs-queue] Run 197426 failed after retries: malformed array literal: \"f7623d32-b589-4085-9504-edbf30925961\"
\`\`\`

\`rg \"uuid\\[\\]\" packages db\` returns exactly one hit across the entire backend — \`packages/server/src/worker-api/device-reconcile.ts:68\`, in the \`reconcilePin\` self-heal UPDATE. The error matches the shape of a bound text parameter (\`pgTextArray(matchingDeviceIds)\` → \`{\"f7623d...\"}\`) being passed through a \`::uuid[]\` cast that postgres.js's extended-protocol path doesn't re-parse as an array first.

(Note: the issue body pointed at commit 2ffccfbd / #814 as a suspect, but that commit landed at 2026-05-17 05:11 UTC — *after* the crash at 00:10:06 UTC. The bug pre-dates it; \`device-reconcile.ts:68\` was introduced in #714 / 76fc6e98 on May 11.)

## Rationale for the fix shape

Two options the issue suggested:

1. Wrap as \`[uuid]\` before insert — already done via \`pgTextArray\`; the bug isn't a missing wrapper but a postgres.js + \`::uuid[]\` cast interaction.
2. Change to scalar \`uuid\` — wrong: the WHERE clause is genuinely multi-valued (the user's fleet can serve a capability from multiple devices; the pin self-heal needs to check membership against the full fresh-device set).

So the fix instead drops the \`uuid[]\` cast entirely and switches to \`text[]\` with \`device_worker_id::text\` on the left side. UUIDs are canonical lowercase in Postgres, so text equality matches the uuid form 1:1 — no semantic change, zero array-cast surface area.

\`SET device_worker_id = \${target}::uuid\` and the \`IS DISTINCT FROM\` clause on line 67 are left as-is — they bind a single uuid (or NULL), which the simple \`::uuid\` cast handles fine; only the \`uuid[]\` path was broken.

## Test plan

- [x] \`make typecheck\` clean
- [ ] Watch \`summaries-prod\` after deploy: no \`[runs-queue] Run ... failed after retries: malformed array literal: \"<uuid>\"\` entries during a 24h window
- [ ] No regression in device pin reconciliation: existing pinned connections stay pinned, multi-device users still get unpinned, dropped-out pins still get repaired

No regression test added: would require new device_workers + connection + connector_definitions fixtures (none exist for this path) and the vitest suite isn't wired into CI. The fix is single-line and self-contained; pi review is the right gate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a database error that could occur during device reconciliation operations, improving system stability and reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lobu-ai/lobu/pull/835?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->