### PR TITLE
docs(agents): cross-repo dispatch pattern + e2e-before-merge gate

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -162,7 +162,7 @@ webhook/OAuth-callback testing actually needs the public URL.
 2. Apply the fix.
 3. Re-run the reproducer. Capture output.
 4. Paste both in the PR body under a "Reproducer" section.
-5. **If you can't reproduce the original failure, BAIL** — post the dead-end on the issue, do not open a PR. Pi approval validates code shape, not that the fix hits the actual smoking gun.
+5. **If you can't reproduce the original failure, BAIL** — post the dead-end on the issue, do not open a PR. Pi (the project's automated PR-review CLI, run as `pi -p <PR>`) validates code shape, not that the fix hits the actual smoking gun.
 
 Exception: changes that require dev environments the agent can't reach (Mac/Xcode, iOS, hardware). Call it out in the PR body ("Untested — requires Xcode") and leave the PR in draft until a human validates.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -121,6 +121,8 @@ When the user pivots mid-session, the default failure mode is piling unrelated w
 - **Never `git stash`.** Stashes are invisible, easy to lose, and collide across agents. If you need to pivot without finishing, commit WIP to the current branch (`git add -A && git commit -m "wip"`) and squash later. WIP commits are visible, pushable, recoverable.
 - **Per-agent isolation:** when launching a parallel Claude Code session, use `claude --worktree <name>` so each agent gets its own checkout + branch. No shared working dir = no cross-agent collisions.
 - **Subagent isolation (mandatory):** any spawned subagent that may `git switch`, commit, push, or run a destructive command MUST run with `isolation: "worktree"`. Read-only research/exploration agents may share the parent checkout. If unsure, use a worktree — the cost is a temp checkout, the cost of skipping is overwriting the user's working tree.
+- **Cross-repo dispatch:** owletto changes go through a **standalone clone at `~/Code/owletto`**, not `packages/owletto/`. The submodule worktree inherits the parent's `.git` and pushes to the wrong remote; an isolation worktree of lobu that needs to edit owletto code ends up with `origin = lobu-ai/owletto` and can't push to lobu. After an owletto PR merges, bump the submodule pointer in lobu in a separate small PR.
+- **Don't pass `"REPO: /absolute/path"` in dispatch prompts.** Agents take it as a cwd directive and `cd` out of their isolation worktree onto the main checkout. Say "the lobu repo" / "the owletto repo" instead and let `isolation: "worktree"` do its job.
 - **If a branch has already gotten mixed**, recover with `git rebase -i` + `git reset HEAD~N` and re-commit in clean groups before opening PRs.
 
 ## Development
@@ -153,6 +155,16 @@ are reachable on `http://localhost:8788` etc. — fine for UI work; only
 webhook/OAuth-callback testing actually needs the public URL.
 
 ### Validation after code changes
+
+**E2E before merge (hard gate).** For any bug-fix PR, do a red → fix → green cycle before opening:
+
+1. Reproduce the failure first (boot PGlite for SQL bugs, the gateway for SSE/runtime bugs, the actual binary for CLI bugs). Capture output.
+2. Apply the fix.
+3. Re-run the reproducer. Capture output.
+4. Paste both in the PR body under a "Reproducer" section.
+5. **If you can't reproduce the original failure, BAIL** — post the dead-end on the issue, do not open a PR. Pi approval validates code shape, not that the fix hits the actual smoking gun.
+
+Exception: changes that require dev environments the agent can't reach (Mac/Xcode, iOS, hardware). Call it out in the PR body ("Untested — requires Xcode") and leave the PR in draft until a human validates.
 
 Run the validation that matches what you touched:
 


### PR DESCRIPTION
## Summary
- Owletto agents work in a standalone \`~/Code/owletto\` clone, not via the lobu submodule (\`packages/owletto/\`). Submodule worktrees inherit \`origin = lobu-ai/owletto\` and can't push lobu PRs — bit two agents in the 2026-05-17 triage.
- Don't pass \`"REPO: /absolute/path"\` in dispatch prompts. Agents take it as a cwd hint and \`cd\` out of their isolation worktree onto the main checkout.
- New hard gate: e2e red→fix→green reproducer in PR body for every bug fix. Bail if you can't reproduce. Pi approval validates code shape, not that the fix hits the actual smoking gun.

## Why now
Triage of 24h-old issues shipped three PRs (#833, #835, owletto#160) without any reproducer. Pi flagged one of them (#835) as "not reproducible from code alone" — merged anyway. Honest cost: two prod fixes need 24h of log-watching to confirm they hit the actual bug. This PR codifies the rule that would have caught that.

## Test plan
- [x] Diff is 12 lines, AGENTS.md only.
- [x] Existing rules unchanged; new bullets sit alongside them.

🤖 No-op verification — docs only, no code path affected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified workflow guardrails for cross-repo dispatch: use a standalone local clone and avoid absolute-path directives in prompts.
  * Added an "E2E before merge (hard gate)" requirement for bug-fix PRs: reproduce → fix → green validation, required PR-body contents, a bail-out rule if reproduction is impossible, and a draft/exception path when required environments are unreachable.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lobu-ai/lobu/pull/837?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->