### PR TITLE
feat(local-server): persist DATABASE_URL/PORT/HOST/dataDir in user config

### DIFF
--- a/packages/cli/src/commands/dev.ts
+++ b/packages/cli/src/commands/dev.ts
@@ -76,10 +76,13 @@ export async function devCommand(
   // Precedence: shell > project .env > user config > defaults.
   const userServerConfig = await getServerConfig().catch(() => undefined);
   const userServerEnv: Record<string, string> = {};
-  if (userServerConfig?.databaseUrl) userServerEnv.DATABASE_URL = userServerConfig.databaseUrl;
-  if (userServerConfig?.port) userServerEnv.PORT = String(userServerConfig.port);
+  if (userServerConfig?.databaseUrl)
+    userServerEnv.DATABASE_URL = userServerConfig.databaseUrl;
+  if (userServerConfig?.port)
+    userServerEnv.PORT = String(userServerConfig.port);
   if (userServerConfig?.host) userServerEnv.HOST = userServerConfig.host;
-  if (userServerConfig?.dataDir) userServerEnv.LOBU_DATA_DIR = userServerConfig.dataDir;
+  if (userServerConfig?.dataDir)
+    userServerEnv.LOBU_DATA_DIR = userServerConfig.dataDir;
 
   const mergedEnv = {
     ...userServerEnv,

--- a/packages/cli/src/commands/dev.ts
+++ b/packages/cli/src/commands/dev.ts
@@ -9,7 +9,7 @@ import chalk from "chalk";
 import ora from "ora";
 import { isLoadError, loadConfig } from "../config/loader.js";
 import { resolveApiClient } from "../internal/api-client.js";
-import { addContext } from "../internal/context.js";
+import { addContext, getServerConfig } from "../internal/context.js";
 import { type Credentials, saveCredentials } from "../internal/credentials.js";
 import { parseEnvContent } from "../internal/index.js";
 import { loadProjectLink } from "../internal/project-link.js";
@@ -71,16 +71,32 @@ export async function devCommand(
     envVars = {};
   }
 
-  const mergedEnv = { ...envVars, ...(process.env as Record<string, string>) };
+  // User-level server config from ~/.config/lobu/config.json (Mac-app
+  // settings pane writes here; CLI users can also `lobu context server ...`).
+  // Precedence: shell > project .env > user config > defaults.
+  const userServerConfig = await getServerConfig().catch(() => undefined);
+  const userServerEnv: Record<string, string> = {};
+  if (userServerConfig?.databaseUrl) userServerEnv.DATABASE_URL = userServerConfig.databaseUrl;
+  if (userServerConfig?.port) userServerEnv.PORT = String(userServerConfig.port);
+  if (userServerConfig?.host) userServerEnv.HOST = userServerConfig.host;
+  if (userServerConfig?.dataDir) userServerEnv.LOBU_DATA_DIR = userServerConfig.dataDir;
+
+  const mergedEnv = {
+    ...userServerEnv,
+    ...envVars,
+    ...(process.env as Record<string, string>),
+  };
   const hasDatabaseUrl = Boolean(mergedEnv.DATABASE_URL?.trim());
 
   // Refuse to boot against a shared/non-local DATABASE_URL that came from the
-  // parent shell rather than the project's own .env — a common footgun where
-  // "local lobu run" silently writes into prod / a teammate's tailnet DB.
-  // The project pinning its own DATABASE_URL is treated as explicit consent.
+  // parent shell rather than the project's own .env or the user's config.
+  // A common footgun: "local lobu run" silently writes into prod / a
+  // teammate's tailnet DB. The project pinning its own DATABASE_URL, or the
+  // user persisting one in ~/.config/lobu/config.json, is explicit consent.
   if (
     hasDatabaseUrl &&
     !envVars.DATABASE_URL?.trim() &&
+    !userServerEnv.DATABASE_URL?.trim() &&
     isSharedDatabaseUrl(mergedEnv.DATABASE_URL!) &&
     !options.unsafeSharedDb
   ) {

--- a/packages/cli/src/internal/__tests__/context.test.ts
+++ b/packages/cli/src/internal/__tests__/context.test.ts
@@ -13,8 +13,10 @@ import {
   findContextByMemoryUrl,
   findContextByUrl,
   getActiveOrg,
+  getServerConfig,
   loadContextConfig,
   setActiveOrg,
+  setServerConfig,
 } from "../context";
 
 describe("context management", () => {
@@ -103,5 +105,60 @@ describe("context management", () => {
     const matched = await findContextByMemoryUrl("http://localhost:8787/mcp");
 
     expect(matched?.name).toBe("local");
+  });
+
+  test("reads and persists the server block per context", async () => {
+    const configData = {
+      currentContext: "local",
+      contexts: {
+        local: {
+          apiUrl: "http://localhost:8787/api/v1",
+          server: {
+            databaseUrl: "postgres://burakemre@localhost:5432/lobu",
+            port: 9000,
+            host: "0.0.0.0",
+            dataDir: "/tmp/lobu-data",
+          },
+        },
+      },
+    };
+    readFileSpy.mockResolvedValue(JSON.stringify(configData));
+
+    expect(await getServerConfig("local")).toEqual({
+      databaseUrl: "postgres://burakemre@localhost:5432/lobu",
+      port: 9000,
+      host: "0.0.0.0",
+      dataDir: "/tmp/lobu-data",
+    });
+
+    await setServerConfig({ databaseUrl: "postgres://new/db", port: 8788 }, "local");
+    const [, written] = writeFileSpy.mock.calls.at(-1)!;
+    const saved = JSON.parse(written as string) as typeof configData;
+    expect(saved.contexts.local.server).toEqual({
+      databaseUrl: "postgres://new/db",
+      port: 8788,
+    });
+  });
+
+  test("drops invalid server fields during normalization", async () => {
+    const configData = {
+      currentContext: "local",
+      contexts: {
+        local: {
+          apiUrl: "http://localhost:8787/api/v1",
+          server: {
+            databaseUrl: "  ",
+            port: -1,
+            host: "   ",
+            dataDir: "/cfg/data",
+            // unknown field — should be ignored
+            phaserBank: 5,
+          },
+        },
+      },
+    };
+    readFileSpy.mockResolvedValue(JSON.stringify(configData));
+
+    expect(await getServerConfig("local")).toEqual({ dataDir: "/cfg/data" });
   });
 });

--- a/packages/cli/src/internal/__tests__/context.test.ts
+++ b/packages/cli/src/internal/__tests__/context.test.ts
@@ -131,7 +131,10 @@ describe("context management", () => {
       dataDir: "/tmp/lobu-data",
     });
 
-    await setServerConfig({ databaseUrl: "postgres://new/db", port: 8788 }, "local");
+    await setServerConfig(
+      { databaseUrl: "postgres://new/db", port: 8788 },
+      "local"
+    );
     const [, written] = writeFileSpy.mock.calls.at(-1)!;
     const saved = JSON.parse(written as string) as typeof configData;
     expect(saved.contexts.local.server).toEqual({

--- a/packages/cli/src/internal/context.ts
+++ b/packages/cli/src/internal/context.ts
@@ -246,7 +246,11 @@ function normalizeServerConfig(raw: unknown): LobuServerConfig | undefined {
   if (typeof src.databaseUrl === "string" && src.databaseUrl.trim()) {
     out.databaseUrl = src.databaseUrl.trim();
   }
-  if (typeof src.port === "number" && Number.isInteger(src.port) && src.port > 0) {
+  if (
+    typeof src.port === "number" &&
+    Number.isInteger(src.port) &&
+    src.port > 0
+  ) {
     out.port = src.port;
   }
   if (typeof src.host === "string" && src.host.trim()) {

--- a/packages/cli/src/internal/context.ts
+++ b/packages/cli/src/internal/context.ts
@@ -10,10 +10,18 @@ const CONTEXTS_FILE = join(LOBU_CONFIG_DIR, "config.json");
 
 export const DEFAULT_MEMORY_URL = "https://lobu.ai/mcp";
 
+export interface LobuServerConfig {
+  databaseUrl?: string;
+  port?: number;
+  host?: string;
+  dataDir?: string;
+}
+
 interface LobuContextEntry {
   apiUrl: string;
   activeOrg?: string;
   memoryUrl?: string;
+  server?: LobuServerConfig;
 }
 
 interface LobuContextConfig {
@@ -215,6 +223,7 @@ function normalizeContextConfig(raw: StoredContextConfig): LobuContextConfig {
         typeof value.memoryUrl === "string"
           ? value.memoryUrl.trim()
           : undefined,
+      server: normalizeServerConfig(value.server),
     };
   }
 
@@ -227,6 +236,51 @@ function normalizeContextConfig(raw: StoredContextConfig): LobuContextConfig {
     currentContext,
     contexts,
   };
+}
+
+function normalizeServerConfig(raw: unknown): LobuServerConfig | undefined {
+  if (!raw || typeof raw !== "object") return undefined;
+  const src = raw as Record<string, unknown>;
+  const out: LobuServerConfig = {};
+
+  if (typeof src.databaseUrl === "string" && src.databaseUrl.trim()) {
+    out.databaseUrl = src.databaseUrl.trim();
+  }
+  if (typeof src.port === "number" && Number.isInteger(src.port) && src.port > 0) {
+    out.port = src.port;
+  }
+  if (typeof src.host === "string" && src.host.trim()) {
+    out.host = src.host.trim();
+  }
+  if (typeof src.dataDir === "string" && src.dataDir.trim()) {
+    out.dataDir = src.dataDir.trim();
+  }
+
+  return Object.keys(out).length === 0 ? undefined : out;
+}
+
+export async function getServerConfig(
+  contextName?: string
+): Promise<LobuServerConfig | undefined> {
+  const config = await loadContextConfig();
+  const name = contextName || config.currentContext;
+  return config.contexts[name]?.server;
+}
+
+export async function setServerConfig(
+  server: LobuServerConfig | undefined,
+  contextName?: string
+): Promise<LobuContextConfig> {
+  const config = await loadContextConfig();
+  const name = contextName || config.currentContext;
+  const context = config.contexts[name];
+  if (!context) {
+    throw new Error(`Unknown context "${name}".`);
+  }
+
+  context.server = server ? normalizeServerConfig(server) : undefined;
+  await saveContextConfig(config);
+  return config;
 }
 
 function normalizeAndValidateApiUrl(apiUrl: string): string {

--- a/packages/server/src/start-local.ts
+++ b/packages/server/src/start-local.ts
@@ -27,6 +27,13 @@ import dotenv from 'dotenv';
 
 dotenv.config();
 
+import { applyUserServerConfigToEnv } from './utils/user-config';
+
+// After dotenv (project .env) so .env wins; before any env reads below so the
+// module-level DATA_DIR / PORT / HOST constants pick up Mac-app overrides
+// written to ~/.config/lobu/config.json.
+applyUserServerConfigToEnv();
+
 import { ensureDefaultAgent } from './auth/default-provisioning';
 
 import { PGlite } from '@electric-sql/pglite';

--- a/packages/server/src/start-local.ts
+++ b/packages/server/src/start-local.ts
@@ -29,9 +29,15 @@ dotenv.config();
 
 import { applyUserServerConfigToEnv } from './utils/user-config';
 
-// After dotenv (project .env) so .env wins; before any env reads below so the
-// module-level DATA_DIR / PORT / HOST constants pick up Mac-app overrides
-// written to ~/.config/lobu/config.json.
+// After dotenv (project .env) so .env wins; before the module-level DATA_DIR
+// / PORT / HOST reads below so user-config overrides from
+// ~/.config/lobu/config.json land in time.
+//
+// DATABASE_URL is also filled in, but this bundle always boots PGlite and
+// overwrites it (line ~141). External-Postgres routing happens upstream in
+// `lobu run` (packages/cli/src/commands/dev.ts), which switches bundles when
+// the user config or env pins DATABASE_URL. So in practice only LOBU_DATA_DIR
+// / PORT / HOST flow through this call.
 applyUserServerConfigToEnv();
 
 import { ensureDefaultAgent } from './auth/default-provisioning';

--- a/packages/server/src/utils/__tests__/user-config.test.ts
+++ b/packages/server/src/utils/__tests__/user-config.test.ts
@@ -1,0 +1,152 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { applyUserServerConfigToEnv, loadUserServerConfig } from '../user-config';
+
+const tempDirs: string[] = [];
+
+function writeConfig(payload: unknown): string {
+  const root = mkdtempSync(join(tmpdir(), 'lobu-user-config-'));
+  tempDirs.push(root);
+  mkdirSync(join(root, '.config', 'lobu'), { recursive: true });
+  const path = join(root, '.config', 'lobu', 'config.json');
+  writeFileSync(path, JSON.stringify(payload));
+  return path;
+}
+
+const ENV_KEYS = ['DATABASE_URL', 'PORT', 'HOST', 'LOBU_DATA_DIR', 'LOBU_CONTEXT'];
+const saved: Record<string, string | undefined> = {};
+
+beforeEach(() => {
+  for (const k of ENV_KEYS) {
+    saved[k] = process.env[k];
+    delete process.env[k];
+  }
+});
+
+afterEach(() => {
+  for (const k of ENV_KEYS) {
+    if (saved[k] === undefined) delete process.env[k];
+    else process.env[k] = saved[k];
+  }
+  while (tempDirs.length) {
+    const d = tempDirs.pop();
+    if (d) rmSync(d, { recursive: true, force: true });
+  }
+});
+
+describe('loadUserServerConfig', () => {
+  it('returns undefined when the file is missing', () => {
+    expect(loadUserServerConfig(join(tmpdir(), 'does-not-exist.json'))).toBeUndefined();
+  });
+
+  it('returns undefined when the JSON is malformed', () => {
+    const path = writeConfig('not json');
+    writeFileSync(path, '{not json');
+    expect(loadUserServerConfig(path)).toBeUndefined();
+  });
+
+  it('returns the current context server block', () => {
+    const path = writeConfig({
+      currentContext: 'local',
+      contexts: {
+        local: {
+          apiUrl: 'http://localhost:8787/api/v1',
+          server: {
+            databaseUrl: 'postgres://burakemre@localhost:5432/lobu',
+            port: 9000,
+            host: '0.0.0.0',
+            dataDir: '/tmp/lobu-data',
+          },
+        },
+      },
+    });
+    expect(loadUserServerConfig(path)).toEqual({
+      databaseUrl: 'postgres://burakemre@localhost:5432/lobu',
+      port: 9000,
+      host: '0.0.0.0',
+      dataDir: '/tmp/lobu-data',
+    });
+  });
+
+  it('falls back to "lobu" when currentContext is missing', () => {
+    const path = writeConfig({
+      contexts: {
+        lobu: {
+          apiUrl: 'https://app.lobu.ai/api/v1',
+          server: { databaseUrl: 'postgres://x/y' },
+        },
+      },
+    });
+    expect(loadUserServerConfig(path)).toEqual({ databaseUrl: 'postgres://x/y' });
+  });
+
+  it('honors the context override', () => {
+    const path = writeConfig({
+      currentContext: 'prod',
+      contexts: {
+        prod: { apiUrl: 'https://app.lobu.ai/api/v1', server: { port: 8080 } },
+        local: {
+          apiUrl: 'http://localhost:8787/api/v1',
+          server: { databaseUrl: 'postgres://local/db' },
+        },
+      },
+    });
+    expect(loadUserServerConfig(path, 'local')).toEqual({
+      databaseUrl: 'postgres://local/db',
+    });
+  });
+
+  it('returns undefined when the server block is empty / invalid', () => {
+    const path = writeConfig({
+      currentContext: 'local',
+      contexts: {
+        local: { apiUrl: 'http://localhost:8787/api/v1', server: { port: 'nope' } },
+      },
+    });
+    expect(loadUserServerConfig(path)).toBeUndefined();
+  });
+
+  it('returns undefined when the context has no server block', () => {
+    const path = writeConfig({
+      currentContext: 'local',
+      contexts: { local: { apiUrl: 'http://localhost:8787/api/v1' } },
+    });
+    expect(loadUserServerConfig(path)).toBeUndefined();
+  });
+});
+
+describe('applyUserServerConfigToEnv', () => {
+  it('fills missing env vars and leaves existing ones alone', () => {
+    const path = writeConfig({
+      currentContext: 'local',
+      contexts: {
+        local: {
+          apiUrl: 'http://localhost:8787/api/v1',
+          server: {
+            databaseUrl: 'postgres://from-config/db',
+            port: 9000,
+            host: 'cfg-host',
+            dataDir: '/cfg/data',
+          },
+        },
+      },
+    });
+
+    process.env.DATABASE_URL = 'postgres://from-env/db';
+
+    applyUserServerConfigToEnv(path);
+
+    expect(process.env.DATABASE_URL).toBe('postgres://from-env/db');
+    expect(process.env.PORT).toBe('9000');
+    expect(process.env.HOST).toBe('cfg-host');
+    expect(process.env.LOBU_DATA_DIR).toBe('/cfg/data');
+  });
+
+  it('no-ops when no config file is present', () => {
+    applyUserServerConfigToEnv(join(tmpdir(), 'missing.json'));
+    expect(process.env.DATABASE_URL).toBeUndefined();
+    expect(process.env.PORT).toBeUndefined();
+  });
+});

--- a/packages/server/src/utils/user-config.ts
+++ b/packages/server/src/utils/user-config.ts
@@ -1,0 +1,113 @@
+/**
+ * User-level config loader for the embedded server.
+ *
+ * Reads `~/.config/lobu/config.json` (owned by the CLI's
+ * `packages/cli/src/internal/context.ts`) and returns the current context's
+ * `server` block. The Mac app writes this file to point a stable local server
+ * at a brew-managed Postgres without per-project `.env` plumbing.
+ *
+ * Sync on purpose — start-local.ts reads env at module-load time, so this has
+ * to resolve before the first env read. Cost is one ~1KB JSON file per boot.
+ *
+ * Schema is duplicated from the CLI's `LobuServerConfig` rather than imported
+ * to keep `@lobu/server` free of a `@lobu/cli` dependency.
+ */
+
+import { readFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+export interface UserServerConfig {
+  databaseUrl?: string;
+  port?: number;
+  host?: string;
+  dataDir?: string;
+}
+
+interface StoredEntry {
+  apiUrl?: unknown;
+  server?: unknown;
+}
+
+interface StoredConfig {
+  currentContext?: unknown;
+  contexts?: Record<string, StoredEntry>;
+}
+
+const CONFIG_PATH = join(homedir(), '.config', 'lobu', 'config.json');
+
+export function loadUserServerConfig(
+  configPath: string = CONFIG_PATH,
+  contextOverride?: string
+): UserServerConfig | undefined {
+  let raw: string;
+  try {
+    raw = readFileSync(configPath, 'utf-8');
+  } catch {
+    return undefined;
+  }
+
+  let parsed: StoredConfig;
+  try {
+    parsed = JSON.parse(raw) as StoredConfig;
+  } catch {
+    return undefined;
+  }
+
+  const contextName =
+    contextOverride?.trim() ||
+    (typeof parsed.currentContext === 'string' && parsed.currentContext.trim()) ||
+    'lobu';
+  const entry = parsed.contexts?.[contextName];
+  if (!entry) return undefined;
+
+  return normalizeServerConfig(entry.server);
+}
+
+function normalizeServerConfig(raw: unknown): UserServerConfig | undefined {
+  if (!raw || typeof raw !== 'object') return undefined;
+  const src = raw as Record<string, unknown>;
+  const out: UserServerConfig = {};
+
+  if (typeof src.databaseUrl === 'string' && src.databaseUrl.trim()) {
+    out.databaseUrl = src.databaseUrl.trim();
+  }
+  if (typeof src.port === 'number' && Number.isInteger(src.port) && src.port > 0) {
+    out.port = src.port;
+  }
+  if (typeof src.host === 'string' && src.host.trim()) {
+    out.host = src.host.trim();
+  }
+  if (typeof src.dataDir === 'string' && src.dataDir.trim()) {
+    out.dataDir = src.dataDir.trim();
+  }
+
+  return Object.keys(out).length === 0 ? undefined : out;
+}
+
+/**
+ * Fill missing env vars from the user config. Env wins; we never overwrite a
+ * value the operator already set.
+ */
+export function applyUserServerConfigToEnv(
+  configPath?: string,
+  contextOverride?: string
+): UserServerConfig | undefined {
+  const cfg = loadUserServerConfig(configPath, contextOverride ?? process.env.LOBU_CONTEXT);
+  if (!cfg) return undefined;
+
+  if (cfg.databaseUrl && !process.env.DATABASE_URL?.trim()) {
+    process.env.DATABASE_URL = cfg.databaseUrl;
+  }
+  if (cfg.port && !process.env.PORT?.trim()) {
+    process.env.PORT = String(cfg.port);
+  }
+  if (cfg.host && !process.env.HOST?.trim()) {
+    process.env.HOST = cfg.host;
+  }
+  if (cfg.dataDir && !process.env.LOBU_DATA_DIR?.trim()) {
+    process.env.LOBU_DATA_DIR = cfg.dataDir;
+  }
+
+  return cfg;
+}


### PR DESCRIPTION
## Summary

- Adds an optional `server` block to `~/.config/lobu/config.json` so the Mac menubar app (and any "stable local server" workflow) can pin `DATABASE_URL` / `PORT` / `HOST` / `dataDir` without per-project `.env` plumbing.
- Precedence stays: **shell env > project `.env` > user config > defaults**. A `DATABASE_URL` set via the user config counts as explicit consent for the shared-DB safety gate, same as if it lived in project `.env`.
- Both entry points are covered:
  - `lobu run` (`dev.ts`) merges the block before deciding PGlite vs Postgres bundle.
  - `start-local.bundle.mjs` applies it right after `dotenv.config()` so a direct spawn (Mac app skipping the CLI) still picks it up.

## Why

The Mac app needs a stable, persistent local server with knobs that survive launches. The user already has `~/.config/lobu/config.json` for `apiUrl` / `activeOrg` / `memoryUrl`; extending the same entry with a `server` block keeps the config story single-file and lets the Mac app reuse the existing read/write infra.

## Example config

```json
{
  "currentContext": "local",
  "contexts": {
    "local": {
      "apiUrl": "http://localhost:8787/api/v1",
      "server": {
        "databaseUrl": "postgres://burakemre@localhost:5432/lobu",
        "port": 8787
      }
    }
  }
}
```

## Test plan

- [x] `bun test packages/cli/src/internal/__tests__/context.test.ts` — 6 pass (covers normalize, getter, setter, invalid-field drop)
- [x] `bunx vitest run packages/server/src/utils/__tests__/user-config.test.ts` — 9 pass (missing file, malformed JSON, context override, env precedence)
- [x] `bun run typecheck`
- [x] `make build-packages`
- [ ] e2e: `lobu run` from a project with config pinning `databaseUrl` → routes to Postgres bundle, connects to brew Postgres

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added user-level server configuration support. Users can now set database URL, port, host, and data directory via home directory configuration with proper precedence (shell variables > project config > user config > defaults). Configuration is context-aware.

* **Tests**
  * Added comprehensive test coverage for user-level server configuration loading and environment variable application.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lobu-ai/lobu/pull/839?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->