### PR TITLE
fix(agent-worker): guard against null assistantMessageEvent in OpenClawProgressProcessor

### DIFF
--- a/packages/agent-worker/src/__tests__/processor-harden.test.ts
+++ b/packages/agent-worker/src/__tests__/processor-harden.test.ts
@@ -45,29 +45,19 @@ function makeMessageEnd(opts: {
 // ---------------------------------------------------------------------------
 
 describe("OpenClawProgressProcessor — malformed events don't throw", () => {
-  test("message_update with null assistantMessageEvent returns false", () => {
+  test("message_update with null assistantMessageEvent returns false without throwing", () => {
     const p = new OpenClawProgressProcessor();
     const event = {
       type: "message_update",
       message: { role: "assistant" },
       assistantMessageEvent: null,
     };
-    // Should not throw; null.type throws TypeError — this exposes a real gap.
-    // The processor currently does not guard against null assistantMessageEvent.
-    // We wrap in try/catch to record the actual behavior without crashing the suite.
-    let threw = false;
-    try {
-      p.processEvent(event as any);
-    } catch {
-      threw = true;
-    }
-    // Whether it throws or returns false, the processor must leave itself in a clean state
+    let result: boolean | undefined;
+    expect(() => {
+      result = p.processEvent(event as any);
+    }).not.toThrow();
+    expect(result).toBe(false);
     expect(p.getDelta()).toBeNull();
-    // Flag the gap: ideally threw === false (defensive guard)
-    if (threw) {
-      // Known gap: null assistantMessageEvent causes unhandled TypeError
-      expect(threw).toBe(true); // document rather than mask
-    }
   });
 
   test("tool_execution_start with null args does not throw", () => {

--- a/packages/agent-worker/src/openclaw/processor.ts
+++ b/packages/agent-worker/src/openclaw/processor.ts
@@ -33,6 +33,7 @@ export class OpenClawProgressProcessor {
           return false;
         }
         const assistantEvent = event.assistantMessageEvent;
+        if (!assistantEvent) return false;
 
         if (assistantEvent.type === "text_delta") {
           this.hasStreamedText = true;


### PR DESCRIPTION
Fixes #691.

## Summary
`OpenClawProgressProcessor.processEvent` dereferenced `assistantMessageEvent.type` without a null guard. If the gateway emitted a `message_update` event with `assistantMessageEvent === null`, the switch threw `TypeError: null is not an object (evaluating 'assistantEvent.type')`.

One-line fix: `if (!assistantEvent) return false;` immediately after destructuring.

Updates `processor-harden.test.ts` — the existing test pinned the broken behavior (was documenting the gap with `expect(threw).toBe(true)`); it now asserts the processor returns `false` without throwing.

## Reproducer

Direct invocation against the processor (same shape the issue describes):

```ts
const p = new OpenClawProgressProcessor();
p.processEvent({
  type: "message_update",
  message: { role: "assistant" },
  assistantMessageEvent: null,
} as any);
```

**Before fix** (`bun -e` on the unpatched processor):
```
THREW: null is not an object (evaluating 'assistantEvent.type')
```

**After fix:**
```
OK no throw, returned: false
```

## Test output

**Before** (test pinned the throw):
```
bun test v1.3.5
 17 pass
 0 fail
 25 expect() calls
```

**After** (test now asserts clean handling):
```
bun test v1.3.5
 17 pass
 0 fail
 26 expect() calls
```

Extra `expect()` call comes from the new `not.toThrow()` + return-value assertion replacing the conditional `threw === true` documentation block.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of message update events with missing or incomplete assistant message information, preventing potential processing failures and ensuring graceful error management.

* **Tests**
  * Updated test cases to verify proper behavior when processing malformed message update events, confirming safe handling without exceptions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lobu-ai/lobu/pull/841?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->