### PR TITLE
fix(server): serialize startup error so docker logs are debuggable

### DIFF
--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -303,8 +303,60 @@ async function main() {
   });
 }
 
+/**
+ * Defensive error → plain-object serializer for the top-level boot catch.
+ *
+ * pino's logger registers `err` / `error` serializers (see utils/logger.ts),
+ * but `JSON.stringify(new Error('boom'))` returns `{}` because Error's own
+ * properties are non-enumerable. If anything ever drops the pino serializer
+ * config (older image, bundler tree-shake, etc.), Docker users see only
+ * `"error":{}` with zero signal — exactly what issue #766 reported. Walk
+ * the error manually so the log line always carries message + stack
+ * regardless of pino config, ZodError `issues`, AggregateError children,
+ * or wrapped `cause` chains.
+ */
+function serializeBootError(err: unknown): Record<string, unknown> {
+  if (err === null || err === undefined) return { value: String(err) };
+  if (typeof err !== 'object') return { value: String(err), type: typeof err };
+  const e = err as Error & {
+    code?: unknown;
+    cause?: unknown;
+    issues?: unknown;
+    errors?: unknown;
+  };
+  const out: Record<string, unknown> = {
+    type: e?.constructor?.name ?? 'Error',
+    message: typeof e.message === 'string' ? e.message : String(e),
+  };
+  if (typeof e.stack === 'string') out.stack = e.stack;
+  if (e.code !== undefined) out.code = e.code;
+  // ZodError surfaces failing field paths in `issues`; preserve them so the
+  // log shows *which* env var or config field failed validation.
+  if (Array.isArray(e.issues)) out.issues = e.issues;
+  // AggregateError stashes children in `errors`.
+  if (Array.isArray(e.errors)) {
+    out.errors = e.errors.map((child) => serializeBootError(child));
+  }
+  if (e.cause !== undefined && e.cause !== err) {
+    out.cause = serializeBootError(e.cause);
+  }
+  return out;
+}
+
 // Start the server
 main().catch((error) => {
-  logger.error({ error }, 'Failed to start server');
+  const serialized = serializeBootError(error);
+  // Log under both `err` (pino convention) and `error` (legacy key) so the
+  // line is useful whether or not the pino error serializer is wired.
+  logger.error({ err: serialized, error: serialized }, 'Failed to start server');
+  // Also print a plain-text line to stderr as a last-resort fallback for
+  // anyone whose log shipper drops structured fields — `docker logs` users
+  // hit this in #766.
+  process.stderr.write(
+    `Failed to start server: ${serialized.type ?? 'Error'}: ${serialized.message ?? ''}\n`
+  );
+  if (typeof serialized.stack === 'string') {
+    process.stderr.write(`${serialized.stack}\n`);
+  }
   process.exit(1);
 });


### PR DESCRIPTION
## Summary

Top-level `main().catch` in `packages/server/src/server.ts` logged the boot error directly with `logger.error({ error }, 'Failed to start server')`. When the pino `error` serializer isn't picked up (older image, bundler tree-shake, or before #767 landed in a given build), pino falls back to plain object serialization — and `JSON.stringify(new Error('boom'))` returns `{}` because `Error` properties are non-enumerable.

Docker users (issue #766) saw exactly this and had zero signal about which env var or config field was wrong:

```
{"level":"error","msg":"Failed to start server","error":{}}
```

This PR adds a small `serializeBootError(err)` walker right at the catch site that pulls out:

- `type` (constructor name)
- `message`
- `stack`
- `code` (if present, e.g. ECONNREFUSED)
- `issues` (ZodError field-path array)
- `errors` (AggregateError children, recursively)
- `cause` (recursively)

…and logs the result under both `err` (pino convention) and `error` (legacy key) so the line is informative regardless of pino config. As a last-resort fallback it also writes a plain-text `Failed to start server: <Type>: <message>` + stack to stderr, so users whose log shipper only captures stderr or strips structured fields still see the cause.

## Reproducer

Pre-fix behavior (what #766 hits):

```
$ bun -e 'import pino from "pino"; const l = pino(); l.error({error: new Error("ENCRYPTION_KEY is required")}, "Failed to start server")'
{"level":50,"time":...,"error":{},"msg":"Failed to start server"}
```

Post-fix behavior (same scenario after `serializeBootError`):

```
{"level":50,"time":...,
 "err":{"type":"Error","message":"ENCRYPTION_KEY is required","stack":"Error: ENCRYPTION_KEY is required\n    at ..."},
 "error":{...same...},
 "msg":"Failed to start server"}
Failed to start server: Error: ENCRYPTION_KEY is required
Error: ENCRYPTION_KEY is required
    at ...
```

The original `error: {}` line is replaced by a fully-structured object with `type` / `message` / `stack`, plus a stderr fallback for `docker logs` consumers.

## Test plan

- [x] `bunx tsc --noEmit -p packages/server/tsconfig.json` clean
- [x] Pre-commit biome + tsc hook passes
- [x] Manual repro: boot with `dotenv.config()` returning empty + `DATABASE_URL` set + no `ENCRYPTION_KEY`. Pre-fix prints `error:{}`; post-fix prints full message + stack + stderr fallback line.
- [ ] Optional: trigger any other early-boot throw (ZodError, missing DATABASE_URL) and confirm the new fields land.

Fixes #766

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error reporting and logging when the server fails to start, providing clearer and more structured error information for diagnostics.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lobu-ai/lobu/pull/843?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->