### PR TITLE
fix(mcp): fail closed when tool annotations cannot be fetched

### DIFF
--- a/packages/server/src/gateway/__tests__/mcp-proxy-edge-cases.test.ts
+++ b/packages/server/src/gateway/__tests__/mcp-proxy-edge-cases.test.ts
@@ -673,6 +673,56 @@ describe("tool approval — onToolBlocked and wildcard grants", () => {
     expect(r2.status).toBe(200);
   });
 
+  test("fails closed when tool annotations cannot be fetched (issue #688)", async () => {
+    // Regression: when `fetchToolsForMcp` returns `{ tools: [] }` because
+    // discovery failed (upstream error, SSRF block, timeout, ...), the
+    // approval gate must NOT default to allow. A destructive tool on a
+    // protected MCP would otherwise be invocable without approval whenever
+    // discovery failed.
+    const grantStore = new GrantStore();
+
+    const configSource = createConfigSource({
+      "destructive-mcp": {
+        id: "destructive-mcp",
+        upstreamUrl: "http://destructive.example.com/mcp",
+      },
+    });
+
+    let blockedCount = 0;
+    const proxy = new McpProxy(configSource, {
+      secretStore: new InMemoryWritableStore(),
+      // No toolCache — forces fetchToolsForMcp to be called.
+      grantStore,
+    });
+    proxy.onToolBlocked = async () => {
+      blockedCount++;
+    };
+
+    const app = proxy.getApp();
+
+    // Simulate annotation-fetch failure: fetch always throws, so the MCP
+    // initialize/tools-list calls fail and fetchToolsForMcp resolves to
+    // { tools: [] }.
+    globalThis.fetch = async () => {
+      throw new Error("upstream unreachable");
+    };
+
+    const res = await app.request("/destructive-mcp/tools/wipe_database", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${agent1Token}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ confirm: true }),
+    });
+
+    // Must be blocked, not allowed through.
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.content[0].text).toContain("requires approval");
+    expect(blockedCount).toBe(1);
+  });
+
   test("onToolBlocked receives correct agentId and tool metadata", async () => {
     const toolCache = new McpToolCache();
     const grantStore = new GrantStore();

--- a/packages/server/src/gateway/auth/mcp/proxy.ts
+++ b/packages/server/src/gateway/auth/mcp/proxy.ts
@@ -1070,7 +1070,12 @@ export class McpProxy {
       tokenData,
       token
     );
-    if (!found || !requiresToolApproval(annotations)) return "allow";
+    // Fail closed: when tool annotations can't be fetched (upstream error,
+    // SSRF block, timeout, etc.), `found` is false. The previous behaviour
+    // returned "allow" here, which let destructive tools bypass approval
+    // whenever discovery failed. Require approval unless we have annotations
+    // that explicitly say the tool is safe.
+    if (found && !requiresToolApproval(annotations)) return "allow";
 
     const pattern = `/mcp/${mcpId}/tools/${toolName}`;
     if (await this.grantStore.hasGrant(agentId, pattern)) return "allow";


### PR DESCRIPTION
## Summary

`evaluateToolApproval` fails open: when `fetchToolsForMcp` returns `{ tools: [] }` (upstream error, SSRF block, timeout, etc.), `getToolAnnotations` reports `{ found: false }`, and the next line short-circuits to `"allow"`. A destructive tool on a protected MCP gets invoked without the approval card ever firing.

Fix: drop the `!found` early-allow. When annotations are unknown, fall through to the grant check + `onToolBlocked` path — that's the conservative default. `requiresToolApproval(undefined)` already returns `true`, so the secondary branch (tool missing from the discovered list) was already correct.

## Reproducer

Run the new test in `packages/server/src/gateway/__tests__/mcp-proxy-edge-cases.test.ts`:

```
bun test src/gateway/__tests__/mcp-proxy-edge-cases.test.ts -t "fails closed"
```

Pre-fix output (test fails — bypass is real):

```
expect(received).toBe(expected)
Expected: 403
Received: 502
(fail) tool approval — onToolBlocked and wildcard grants > fails closed when tool annotations cannot be fetched (issue #688)
```

The 502 means the call was forwarded to the upstream (which failed); approval was never required. Post-fix the call returns 403 (`requires approval`) and `onToolBlocked` fires once.

Full suite post-fix:

```
34 pass / 0 fail
```

## Test plan

- [x] New regression test added in `mcp-proxy-edge-cases.test.ts`
- [x] All 34 tests in the file pass
- [x] `bunx tsc -p packages/server/tsconfig.json --noEmit` clean
- [x] Biome pre-commit hook clean

Fixes #688