### PR TITLE
fix(server): remove unauthenticated GET /internal/connections

### DIFF
--- a/packages/server/src/gateway/__tests__/rest-api-hardening.test.ts
+++ b/packages/server/src/gateway/__tests__/rest-api-hardening.test.ts
@@ -714,28 +714,17 @@ describe("connection routes: access control", () => {
   });
 
   /**
-   * SUSPECTED BUG: GET /internal/connections has no authentication.
-   *
-   * The createConnectionCrudRoutes function registers:
-   *   app.get("/internal/connections", listAllConnections)
-   * with no auth middleware. Any unauthenticated caller can enumerate all
-   * platform connections and their agentId associations.
-   *
-   * This test documents the current (insecure) behavior.
-   * The endpoint should either be removed, moved behind auth, or restricted
-   * to same-process callers only (e.g., localhost-only binding).
+   * Regression: GET /internal/connections was previously registered with no
+   * auth middleware, enabling unauthenticated tenant enumeration. The route
+   * had no internal callers (the "Internal endpoint" comment was aspirational)
+   * so it was removed outright. This test pins the 404 to prevent re-introduction.
    */
-  test("[KNOWN GAP] GET /internal/connections requires no auth — documents unauthenticated access", async () => {
+  test("GET /internal/connections is not exposed (route removed)", async () => {
     // No session set — completely unauthenticated
     const response = await orgContext.run({ organizationId: ORG_A }, () =>
       buildConnectionApp().request("/internal/connections")
     );
-    // Current behavior: 200 with connection data, no auth required.
-    // This is a security gap — internal routes should not be reachable without auth.
-    expect(response.status).toBe(200);
-    const data = (await response.json()) as any;
-    // Data leaks connection details to unauthenticated callers:
-    expect(Array.isArray(data.connections)).toBe(true);
+    expect(response.status).toBe(404);
   });
 });
 

--- a/packages/server/src/gateway/routes/public/connections.ts
+++ b/packages/server/src/gateway/routes/public/connections.ts
@@ -458,17 +458,6 @@ export function createConnectionCrudRoutes(
   app.get("/internal/connections/platforms", listLocalTestPlatforms);
   app.get("/internal/connections/test-targets", listLocalTestTargets);
 
-  // Internal endpoint for server-to-server connection listing (no auth required)
-  const listAllConnections = async (c: any) => {
-    const { platform, agentId } = c.req.query();
-    const connections = await manager.listConnections({
-      platform: platform || undefined,
-      agentId: agentId || undefined,
-    });
-    return c.json({ connections });
-  };
-  app.get("/internal/connections", listAllConnections);
-
   app.openapi(ListConnectionsRoute, async (c): Promise<any> => {
     const session = await verifySettingsSession(c);
     if (!session) {


### PR DESCRIPTION
## Summary

`GET /internal/connections`, registered by `createConnectionCrudRoutes` in `packages/server/src/gateway/routes/public/connections.ts`, had no auth middleware. Any unauthenticated caller could enumerate every chat connection in the system plus its `agentId` association — a tenant boundary leak.

A repo-wide search turned up **zero internal callers** of the route — the inline `// Internal endpoint for server-to-server connection listing (no auth required)` comment was aspirational. The authenticated `/api/v1/connections` endpoint (registered immediately below it with full session + per-agent access checks) already covers the legitimate listing use case.

Per the three options listed in #687, the smallest safe fix is **option 3 — remove the route outright**. Adding admin/service-token auth or localhost gating would be dead weight for code nothing calls.

The PR #684 regression test in `rest-api-hardening.test.ts` is flipped from documenting the broken 200 to asserting the post-fix 404.

Fixes #687

## Reproducer

Booted `packages/server/dist/start-local.bundle.mjs` locally (Node 22, PGlite, ephemeral keys) on `:9091` against both the pre-fix and post-fix bundles.

**Pre-fix** (build from `main` with the route still registered): `GET http://127.0.0.1:9091/internal/connections` resolves to the `listAllConnections` handler in this start-local boot only when a `chatInstanceManager` is provided (see `gateway.ts` line 682 mounting guard). The vulnerable surface is reachable in any deployment that has at least one chat connection configured — i.e. every real production gateway, since chat platforms are why the gateway exists.

**Post-fix**: `curl -i http://127.0.0.1:9091/internal/connections` returns `HTTP 404 Not Found`. Bundle no longer contains `listAllConnections` (`grep -c listAllConnections packages/server/dist/*.bundle.mjs` → 0).

The unit-level reproducer is the test in `rest-api-hardening.test.ts`, which constructs `createConnectionCrudRoutes` directly and hits `/internal/connections` with no session: pre-fix `200` + JSON `{connections: [...]}`, post-fix `404`.

## Test plan

- [x] `make build-packages` clean
- [x] Bundle no longer contains `listAllConnections`
- [x] Regression test updated to assert 404
- [ ] CI typecheck + tests