### PR TITLE
fix(interactions): require connectionId to prevent cross-platform leakage

### DIFF
--- a/packages/server/src/gateway/__tests__/connections-platform-isolation.test.ts
+++ b/packages/server/src/gateway/__tests__/connections-platform-isolation.test.ts
@@ -146,44 +146,120 @@ describe("InteractionService.postLinkButton — URL scheme guard", () => {
 
   test("accepts https:// URLs", async () => {
     await expect(
-      svc.postLinkButton("u", "conv", "ch", undefined, undefined, "slack",
+      svc.postLinkButton("u", "conv", "ch", undefined, "conn-1", "slack",
         "https://example.com/auth", "Connect", "oauth")
     ).resolves.toBeDefined();
   });
 
   test("accepts http:// URLs", async () => {
     await expect(
-      svc.postLinkButton("u", "conv", "ch", undefined, undefined, "slack",
+      svc.postLinkButton("u", "conv", "ch", undefined, "conn-1", "slack",
         "http://example.com/auth", "Connect", "oauth")
     ).resolves.toBeDefined();
   });
 
   test("rejects javascript: scheme", async () => {
     await expect(
-      svc.postLinkButton("u", "conv", "ch", undefined, undefined, "slack",
+      svc.postLinkButton("u", "conv", "ch", undefined, "conn-1", "slack",
         "javascript:alert(1)", "XSS", "oauth")
     ).rejects.toThrow(/unsafe scheme/i);
   });
 
   test("rejects data: scheme", async () => {
     await expect(
-      svc.postLinkButton("u", "conv", "ch", undefined, undefined, "slack",
+      svc.postLinkButton("u", "conv", "ch", undefined, "conn-1", "slack",
         "data:text/html,<h1>hi</h1>", "Data", "oauth")
     ).rejects.toThrow(/unsafe scheme/i);
   });
 
   test("rejects file: scheme", async () => {
     await expect(
-      svc.postLinkButton("u", "conv", "ch", undefined, undefined, "slack",
+      svc.postLinkButton("u", "conv", "ch", undefined, "conn-1", "slack",
         "file:///etc/passwd", "File", "oauth")
     ).rejects.toThrow(/unsafe scheme/i);
   });
 
   test("rejects completely invalid URL", async () => {
     await expect(
-      svc.postLinkButton("u", "conv", "ch", undefined, undefined, "slack",
+      svc.postLinkButton("u", "conv", "ch", undefined, "conn-1", "slack",
         "not-a-url", "Bad", "oauth")
     ).rejects.toThrow(/invalid link button url/i);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3b. InteractionService — fail-closed when connectionId is missing
+//
+// Cross-tenant / cross-connection event leakage was possible when callers
+// omitted `connectionId`: the interaction-bridge `shouldHandle` filter falls
+// through when `event.connectionId` is falsy, so any bridge on the matching
+// platform would handle the event. The service refuses to post without a
+// non-empty connectionId so the bug surfaces as an error rather than
+// silently routing to the wrong tenant.
+// ---------------------------------------------------------------------------
+
+describe("InteractionService — connectionId is required", () => {
+  test("postQuestion throws when connectionId is undefined", async () => {
+    const svc = new InteractionService();
+    await expect(
+      svc.postQuestion("u", "conv", "ch", undefined, undefined, "slack", "?", ["A"])
+    ).rejects.toThrow(/connectionId is required/);
+  });
+
+  test("postQuestion throws when connectionId is empty string", async () => {
+    const svc = new InteractionService();
+    await expect(
+      svc.postQuestion("u", "conv", "ch", undefined, "", "slack", "?", ["A"])
+    ).rejects.toThrow(/connectionId is required/);
+  });
+
+  test("postLinkButton throws when connectionId is undefined", async () => {
+    const svc = new InteractionService();
+    await expect(
+      svc.postLinkButton("u", "conv", "ch", undefined, undefined, "slack",
+        "https://example.com", "Open", "oauth")
+    ).rejects.toThrow(/connectionId is required/);
+  });
+
+  test("postToolApproval throws when connectionId is undefined", async () => {
+    const svc = new InteractionService();
+    await expect(
+      svc.postToolApproval("req-1", "agent-1", "u", "conv", "ch", undefined,
+        undefined, "slack", "mcp", "t", {}, "/mcp/mcp/tools/t")
+    ).rejects.toThrow(/connectionId is required/);
+  });
+
+  test("postStatusMessage throws when connectionId is undefined", async () => {
+    const svc = new InteractionService();
+    await expect(
+      svc.postStatusMessage("conv", "ch", undefined, undefined, "slack", "hi")
+    ).rejects.toThrow(/connectionId is required/);
+  });
+
+  test("postOauthLink throws when connectionId is undefined", async () => {
+    const svc = new InteractionService();
+    await expect(
+      svc.postOauthLink("u", "conv", "ch", undefined, undefined, "slack",
+        "https://example.com", "Sign in")
+    ).rejects.toThrow(/connectionId is required/);
+  });
+
+  test("no event is emitted when connectionId is missing", async () => {
+    const svc = new InteractionService();
+    const received: unknown[] = [];
+    svc.on("question:created", (e) => received.push(e));
+    svc.on("link-button:created", (e) => received.push(e));
+    svc.on("status-message:created", (e) => received.push(e));
+    svc.on("tool:approval-needed", (e) => received.push(e));
+
+    await svc
+      .postQuestion("u", "conv", "ch", undefined, undefined, "slack", "?", ["A"])
+      .catch(() => undefined);
+    await svc
+      .postStatusMessage("conv", "ch", undefined, undefined, "slack", "hi")
+      .catch(() => undefined);
+
+    expect(received).toHaveLength(0);
   });
 });
 
@@ -197,7 +273,7 @@ describe("InteractionService — platform field on emitted events", () => {
     const received: any[] = [];
     svc.on("question:created", (e) => received.push(e));
 
-    await svc.postQuestion("u", "conv", "ch", undefined, undefined, "telegram",
+    await svc.postQuestion("u", "conv", "ch", undefined, "conn-1", "telegram",
       "Pick one?", ["A", "B"]);
 
     expect(received).toHaveLength(1);
@@ -209,7 +285,7 @@ describe("InteractionService — platform field on emitted events", () => {
     const received: any[] = [];
     svc.on("link-button:created", (e) => received.push(e));
 
-    await svc.postLinkButton("u", "conv", "ch", undefined, undefined, "slack",
+    await svc.postLinkButton("u", "conv", "ch", undefined, "conn-1", "slack",
       "https://example.com", "Open", "oauth");
 
     expect(received).toHaveLength(1);
@@ -222,7 +298,7 @@ describe("InteractionService — platform field on emitted events", () => {
     svc.on("tool:approval-needed", (e) => received.push(e));
 
     await svc.postToolApproval("req-1", "agent-1", "u", "conv", "ch", undefined,
-      undefined, "discord", "mcp-id", "tool_name", {}, "/mcp/mcp-id/tools/tool_name");
+      "conn-1", "discord", "mcp-id", "tool_name", {}, "/mcp/mcp-id/tools/tool_name");
 
     expect(received).toHaveLength(1);
     expect(received[0].platform).toBe("discord");
@@ -233,7 +309,7 @@ describe("InteractionService — platform field on emitted events", () => {
     const received: any[] = [];
     svc.on("status-message:created", (e) => received.push(e));
 
-    await svc.postStatusMessage("conv", "ch", undefined, undefined, "teams", "Working...");
+    await svc.postStatusMessage("conv", "ch", undefined, "conn-1", "teams", "Working...");
 
     expect(received).toHaveLength(1);
     expect(received[0].platform).toBe("teams");
@@ -755,9 +831,9 @@ describe("InteractionService — unique event ids", () => {
     const ids: string[] = [];
     svc.on("status-message:created", (e) => ids.push(e.id));
 
-    await svc.postStatusMessage("conv", "ch", undefined, undefined, "slack", "A");
-    await svc.postStatusMessage("conv", "ch", undefined, undefined, "slack", "B");
-    await svc.postStatusMessage("conv", "ch", undefined, undefined, "slack", "C");
+    await svc.postStatusMessage("conv", "ch", undefined, "conn-1", "slack", "A");
+    await svc.postStatusMessage("conv", "ch", undefined, "conn-1", "slack", "B");
+    await svc.postStatusMessage("conv", "ch", undefined, "conn-1", "slack", "C");
 
     expect(ids).toHaveLength(3);
     expect(new Set(ids).size).toBe(3);
@@ -768,9 +844,9 @@ describe("InteractionService — unique event ids", () => {
     const ids: string[] = [];
     svc.on("link-button:created", (e) => ids.push(e.id));
 
-    await svc.postLinkButton("u", "conv", "ch", undefined, undefined, "slack",
+    await svc.postLinkButton("u", "conv", "ch", undefined, "conn-1", "slack",
       "https://a.com", "A", "oauth");
-    await svc.postLinkButton("u", "conv", "ch", undefined, undefined, "slack",
+    await svc.postLinkButton("u", "conv", "ch", undefined, "conn-1", "slack",
       "https://b.com", "B", "oauth");
 
     expect(ids).toHaveLength(2);
@@ -792,7 +868,7 @@ describe("InteractionService — beforeCreateHook ordering", () => {
     });
     svc.on("question:created", () => log.push("event"));
 
-    await svc.postQuestion("u", "conv", "ch", undefined, undefined, "slack", "?", ["Y", "N"]);
+    await svc.postQuestion("u", "conv", "ch", undefined, "conn-1", "slack", "?", ["Y", "N"]);
 
     expect(log).toEqual(["hook", "event"]);
   });
@@ -837,7 +913,7 @@ describe("InteractionService.postLinkButton — body field", () => {
     const received: PostedLinkButton[] = [];
     svc.on("link-button:created", (e) => received.push(e));
 
-    await svc.postLinkButton("u", "conv", "ch", undefined, undefined, "slack",
+    await svc.postLinkButton("u", "conv", "ch", undefined, "conn-1", "slack",
       "https://example.com", "Connect", "oauth", "Authorize access to GitHub.");
 
     expect(received[0]!.body).toBe("Authorize access to GitHub.");
@@ -848,7 +924,7 @@ describe("InteractionService.postLinkButton — body field", () => {
     const received: PostedLinkButton[] = [];
     svc.on("link-button:created", (e) => received.push(e));
 
-    await svc.postLinkButton("u", "conv", "ch", undefined, undefined, "slack",
+    await svc.postLinkButton("u", "conv", "ch", undefined, "conn-1", "slack",
       "https://example.com", "Connect", "oauth");
 
     expect(received[0]!.body).toBeUndefined();
@@ -859,7 +935,7 @@ describe("InteractionService.postLinkButton — body field", () => {
     const received: PostedLinkButton[] = [];
     svc.on("link-button:created", (e) => received.push(e));
 
-    await svc.postOauthLink("u", "conv", "ch", undefined, undefined, "telegram",
+    await svc.postOauthLink("u", "conv", "ch", undefined, "conn-1", "telegram",
       "https://oauth.example.com/auth", "Sign in", "Please sign in.");
 
     expect(received[0]!.linkType).toBe("oauth");

--- a/packages/server/src/gateway/interactions.ts
+++ b/packages/server/src/gateway/interactions.ts
@@ -32,6 +32,27 @@ function assertSafeLinkButtonUrl(url: string): void {
 }
 
 /**
+ * Refuse to post an interaction event without a non-empty `connectionId`.
+ *
+ * `connectionId` is the *only* routing key that prevents cross-tenant /
+ * cross-connection event leakage: the interaction bridge's `shouldHandle`
+ * filter falls through when `event.connectionId` is falsy, which means any
+ * bridge on the matching platform will pick the event up. Fail closed at
+ * post-time so a missing connection id surfaces as an error rather than
+ * silently routing to the wrong tenant.
+ */
+function assertConnectionId(
+  connectionId: string | undefined,
+  kind: string
+): asserts connectionId is string {
+  if (!connectionId) {
+    throw new Error(
+      `Refusing to post ${kind}: connectionId is required to prevent cross-platform event leakage`
+    );
+  }
+}
+
+/**
  * Payload emitted on "question:created" — platform renderers listen for this.
  */
 export interface PostedQuestion extends BaseMessage {
@@ -114,6 +135,7 @@ export class InteractionService extends EventEmitter {
     question: string,
     options: string[]
   ): Promise<PostedQuestion> {
+    assertConnectionId(connectionId, "question");
     if (this.beforeCreateHook) {
       await this.beforeCreateHook(userId, conversationId);
     }
@@ -160,6 +182,7 @@ export class InteractionService extends EventEmitter {
     args: Record<string, unknown>,
     grantPattern: string
   ): Promise<PostedToolApproval> {
+    assertConnectionId(connectionId, "tool approval");
     if (this.beforeCreateHook) {
       await this.beforeCreateHook(userId, conversationId);
     }
@@ -203,6 +226,7 @@ export class InteractionService extends EventEmitter {
     linkType: "settings" | "install" | "oauth",
     body?: string
   ): Promise<PostedLinkButton> {
+    assertConnectionId(connectionId, "link button");
     assertSafeLinkButtonUrl(url);
     if (this.beforeCreateHook) {
       await this.beforeCreateHook(userId, conversationId);
@@ -270,6 +294,7 @@ export class InteractionService extends EventEmitter {
     platform: string,
     text: string
   ): Promise<PostedStatusMessage> {
+    assertConnectionId(connectionId, "status message");
     if (this.beforeCreateHook) {
       await this.beforeCreateHook("", conversationId);
     }


### PR DESCRIPTION
## Summary

`InteractionService.postQuestion` / `postLinkButton` / `postToolApproval` / `postStatusMessage` previously accepted `undefined` for `connectionId`. The interaction-bridge `shouldHandle` filter falls through when `event.connectionId` is falsy, so **any bridge on the matching platform** would handle the event — cross-tenant / cross-connection event leakage. The existing `instance.connection.platform === bridgePlatform` check is tautological (bridges are registered for a specific connection's platform).

The fix fails closed at post-time: throw if `connectionId` is empty/undefined so the bug surfaces as an error rather than silently routing to the wrong tenant. `postOauthLink` inherits the guard via its delegate to `postLinkButton`.

Scope is intentionally narrow — the 5-minute dedup TTL issue called out in #690 is left for a separate PR.

Fixes #690

## Reproducer

`packages/server/src/gateway/__tests__/connections-platform-isolation.test.ts` (introduced in #684) pinned the prior shape of the routing logic. This PR adds a new describe block "InteractionService — connectionId is required" that asserts each post method throws when `connectionId` is `undefined` or `""`, and that no event is emitted on the failure path. Existing tests that previously passed `undefined` for `connectionId` have been updated to pass a real id so they continue exercising the post path itself.

Steps:

1. `git switch origin/main && bun test packages/server/src/gateway/__tests__/connections-platform-isolation.test.ts` — the new "connectionId is required" tests do not exist; the current behavior (accepting `undefined`) is what the bridge tests pin around.
2. Check out this PR; rerun the same test file.
3. The new tests pass; the post methods now throw on missing `connectionId`.

## Test plan

- [x] `bun test packages/server/src/gateway/__tests__/connections-platform-isolation.test.ts` — 83/83 pass.
- [x] `make typecheck` — clean (matches the prod Dockerfile's `bunx tsc --noEmit`).
- [ ] Manual smoke: a worker token without a `connectionId` calling `POST /internal/interactions/create` returns 500 (was previously 200 with cross-tenant emit).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced URL validation for link buttons to block unsafe schemes (javascript:, data:, file:); only https:// and http:// are now accepted
  * Added connection ID requirement validation to prevent cross-connection interaction event leakage

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lobu-ai/lobu/pull/847?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->