### PR TITLE
feat(chart): expose service.sessionAffinity for multi-replica SSE stickiness

### DIFF
--- a/charts/lobu/templates/NOTES.txt
+++ b/charts/lobu/templates/NOTES.txt
@@ -30,3 +30,12 @@ Database:
 Useful checks:
   kubectl -n {{ .Release.Namespace }} get pods -l app.kubernetes.io/instance={{ .Release.Name }}
   kubectl -n {{ .Release.Namespace }} logs deploy/{{ include "lobu.fullname" . }}-app
+
+{{- if and (gt (int (.Values.app.replicaCount | default 1)) 1) (or (not .Values.service.sessionAffinity) (eq (.Values.service.sessionAffinity | default "None") "None")) }}
+
+WARNING: app.replicaCount = {{ .Values.app.replicaCount }} but service.sessionAffinity
+is "None". The SSE manager and its 100-event backlog live in memory per pod
+(packages/server/src/gateway/services/sse-manager.ts), so a client whose stream
+lands on pod A while the worker run is claimed by pod B will silently miss
+events. Set service.sessionAffinity: ClientIP to pin each client to one pod.
+{{- end }}

--- a/charts/lobu/templates/service.yaml
+++ b/charts/lobu/templates/service.yaml
@@ -7,6 +7,16 @@ metadata:
     app.kubernetes.io/component: api
 spec:
   type: {{ .Values.service.type }}
+  {{- with .Values.service.sessionAffinity }}
+  {{- if ne . "None" }}
+  sessionAffinity: {{ . }}
+  {{- if eq . "ClientIP" }}
+  sessionAffinityConfig:
+    clientIP:
+      timeoutSeconds: {{ $.Values.service.sessionAffinityTimeoutSeconds | default 10800 }}
+  {{- end }}
+  {{- end }}
+  {{- end }}
   ports:
     - port: {{ .Values.service.port }}
       targetPort: http

--- a/charts/lobu/values.yaml
+++ b/charts/lobu/values.yaml
@@ -167,6 +167,20 @@ embeddings:
 service:
   type: ClusterIP
   port: 8787
+  # Pin each client to the same pod for the lifetime of the affinity
+  # window. Required when running >1 app replica: SSE streams
+  # (`/api/v1/agents/<id>/events`) and the per-pod backlog in
+  # `SseManager` are not cross-pod — a client whose first SSE chunk
+  # lands on pod A and whose later run claim lands on pod B would
+  # silently miss events. ClientIP affinity works at kube-proxy
+  # without any ingress controller config. Disabled by default; the
+  # helmrelease in deploy/k8s opts in alongside `replicaCount: 2`.
+  #
+  # `sessionAffinity` accepts "None" (default) or "ClientIP". The
+  # timeout is the affinity window in seconds (default 10800 = 3h);
+  # set lower if NAT churn is a concern.
+  sessionAffinity: None
+  sessionAffinityTimeoutSeconds: 10800
 
 # Optional Ingress for public webhooks and the admin UI. When hosts are set,
 # the app Deployment derives PUBLIC_WEB_URL from the first host unless you set


### PR DESCRIPTION
## Summary

Prod runs `app.replicaCount: 2` ([helmrelease.yaml#L86](https://github.com/lobu-ai/owletto/blob/main/deploy/k8s/apps/lobu/base/helmrelease.yaml)) but the chart never exposed `Service.sessionAffinity`. Kube-proxy round-robins traffic across pods, and the SSE manager keeps connections + a 100-event/2-min backlog **in memory per pod** ([sse-manager.ts:44-45](https://github.com/lobu-ai/lobu/blob/main/packages/server/src/gateway/services/sse-manager.ts#L44-L45)). A client whose stream lands on pod A while the worker run is claimed by pod B silently misses events.

PR #834 fixed the AskUser click path by moving pending interactions to Postgres. SSE chunks still need to flow through the pod that holds the connection.

## What this does

Adds `service.sessionAffinity` (default `"None"`) + `service.sessionAffinityTimeoutSeconds` (default `10800`, 3h) to `values.yaml`. Template emits the `sessionAffinity`/`sessionAffinityConfig` stanza only when set to `ClientIP`. No ingress-controller config required — works at kube-proxy / iptables. Chart stays controller-agnostic.

## Why ClientIP not cookies

- SDK clients (lobu chat, lobu eval, JS SDK) don't preserve cookies; ClientIP works for them.
- Browsers also have stable source IPs for the SSE lifetime.
- Downside: shared-NAT environments (large office on one egress IP) all stick to one pod. For Lobu's traffic profile this is fine.

## Verification

\`\`\`
helm template charts/lobu --show-only templates/service.yaml
  → emits no sessionAffinity (default behavior preserved)

helm template charts/lobu --set service.sessionAffinity=ClientIP --show-only templates/service.yaml
  → emits sessionAffinity: ClientIP + sessionAffinityConfig.clientIP.timeoutSeconds: 10800
\`\`\`

## Rollout

Chart default is unchanged (off). The helmrelease in `lobu-ai/owletto` (`deploy/k8s/apps/lobu/base/helmrelease.yaml`) needs a separate one-line opt-in:

\`\`\`yaml
service:
  sessionAffinity: ClientIP
\`\`\`

That's a separate PR in the owletto repo — flagged in the PR comment thread.

## Test plan
- [x] `helm template` renders correctly default-off
- [x] `helm template` renders correctly with `--set service.sessionAffinity=ClientIP`
- [ ] After merge: opt in via the owletto helmrelease and verify SSE delivery on the 2-replica deploy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Service supports configurable session affinity (sticky sessions) so clients can be routed to the same pod; includes options to set affinity type and timeout (default 10800 seconds).

* **Documentation**
  * Added a deployment note warning when multiple replicas are used without session affinity, explaining SSE/in-memory backlog per pod and recommending enabling affinity for consistent client routing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lobu-ai/lobu/pull/848?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->