### PR TITLE
fix: security + correctness bundle (#687 #688 #690 #691)

### DIFF
--- a/packages/agent-worker/src/__tests__/processor-harden.test.ts
+++ b/packages/agent-worker/src/__tests__/processor-harden.test.ts
@@ -45,29 +45,19 @@ function makeMessageEnd(opts: {
 // ---------------------------------------------------------------------------
 
 describe("OpenClawProgressProcessor — malformed events don't throw", () => {
-  test("message_update with null assistantMessageEvent returns false", () => {
+  test("message_update with null assistantMessageEvent returns false (no throw)", () => {
     const p = new OpenClawProgressProcessor();
     const event = {
       type: "message_update",
       message: { role: "assistant" },
       assistantMessageEvent: null,
     };
-    // Should not throw; null.type throws TypeError — this exposes a real gap.
-    // The processor currently does not guard against null assistantMessageEvent.
-    // We wrap in try/catch to record the actual behavior without crashing the suite.
-    let threw = false;
-    try {
-      p.processEvent(event as any);
-    } catch {
-      threw = true;
-    }
-    // Whether it throws or returns false, the processor must leave itself in a clean state
+    // Regression for #691: the processor used to null-deref on
+    // `assistantEvent.type`. It must now treat the malformed event as a no-op
+    // and stay in a clean state.
+    expect(() => p.processEvent(event as any)).not.toThrow();
+    expect(p.processEvent(event as any)).toBe(false);
     expect(p.getDelta()).toBeNull();
-    // Flag the gap: ideally threw === false (defensive guard)
-    if (threw) {
-      // Known gap: null assistantMessageEvent causes unhandled TypeError
-      expect(threw).toBe(true); // document rather than mask
-    }
   });
 
   test("tool_execution_start with null args does not throw", () => {

--- a/packages/agent-worker/src/openclaw/processor.ts
+++ b/packages/agent-worker/src/openclaw/processor.ts
@@ -33,6 +33,12 @@ export class OpenClawProgressProcessor {
           return false;
         }
         const assistantEvent = event.assistantMessageEvent;
+        // Defensive: malformed events (null/missing assistantMessageEvent) used
+        // to null-deref on `.type`. Treat as a no-op instead of crashing the
+        // streaming pipeline. See #691.
+        if (!assistantEvent) {
+          return false;
+        }
 
         if (assistantEvent.type === "text_delta") {
           this.hasStreamedText = true;

--- a/packages/server/src/gateway/__tests__/connections-platform-isolation.test.ts
+++ b/packages/server/src/gateway/__tests__/connections-platform-isolation.test.ts
@@ -146,14 +146,14 @@ describe("InteractionService.postLinkButton — URL scheme guard", () => {
 
   test("accepts https:// URLs", async () => {
     await expect(
-      svc.postLinkButton("u", "conv", "ch", undefined, undefined, "slack",
+      svc.postLinkButton("u", "conv", "ch", undefined, "conn-1", "slack",
         "https://example.com/auth", "Connect", "oauth")
     ).resolves.toBeDefined();
   });
 
   test("accepts http:// URLs", async () => {
     await expect(
-      svc.postLinkButton("u", "conv", "ch", undefined, undefined, "slack",
+      svc.postLinkButton("u", "conv", "ch", undefined, "conn-1", "slack",
         "http://example.com/auth", "Connect", "oauth")
     ).resolves.toBeDefined();
   });
@@ -197,7 +197,7 @@ describe("InteractionService — platform field on emitted events", () => {
     const received: any[] = [];
     svc.on("question:created", (e) => received.push(e));
 
-    await svc.postQuestion("u", "conv", "ch", undefined, undefined, "telegram",
+    await svc.postQuestion("u", "conv", "ch", undefined, "conn-tg", "telegram",
       "Pick one?", ["A", "B"]);
 
     expect(received).toHaveLength(1);
@@ -209,7 +209,7 @@ describe("InteractionService — platform field on emitted events", () => {
     const received: any[] = [];
     svc.on("link-button:created", (e) => received.push(e));
 
-    await svc.postLinkButton("u", "conv", "ch", undefined, undefined, "slack",
+    await svc.postLinkButton("u", "conv", "ch", undefined, "conn-slack", "slack",
       "https://example.com", "Open", "oauth");
 
     expect(received).toHaveLength(1);
@@ -222,7 +222,7 @@ describe("InteractionService — platform field on emitted events", () => {
     svc.on("tool:approval-needed", (e) => received.push(e));
 
     await svc.postToolApproval("req-1", "agent-1", "u", "conv", "ch", undefined,
-      undefined, "discord", "mcp-id", "tool_name", {}, "/mcp/mcp-id/tools/tool_name");
+      "conn-discord", "discord", "mcp-id", "tool_name", {}, "/mcp/mcp-id/tools/tool_name");
 
     expect(received).toHaveLength(1);
     expect(received[0].platform).toBe("discord");
@@ -233,10 +233,36 @@ describe("InteractionService — platform field on emitted events", () => {
     const received: any[] = [];
     svc.on("status-message:created", (e) => received.push(e));
 
-    await svc.postStatusMessage("conv", "ch", undefined, undefined, "teams", "Working...");
+    await svc.postStatusMessage("conv", "ch", undefined, "conn-teams", "teams", "Working...");
 
     expect(received).toHaveLength(1);
     expect(received[0].platform).toBe("teams");
+  });
+
+  test("post* methods throw when connectionId is missing (cross-platform leak guard)", async () => {
+    const svc = new InteractionService();
+
+    await expect(
+      svc.postQuestion("u", "conv", "ch", undefined, undefined, "telegram", "?", ["A"])
+    ).rejects.toThrow(/connectionId is required/);
+
+    await expect(
+      svc.postQuestion("u", "conv", "ch", undefined, "", "telegram", "?", ["A"])
+    ).rejects.toThrow(/connectionId is required/);
+
+    await expect(
+      svc.postLinkButton("u", "conv", "ch", undefined, undefined, "slack",
+        "https://example.com", "Open", "oauth")
+    ).rejects.toThrow(/connectionId is required/);
+
+    await expect(
+      svc.postToolApproval("req-1", "agent-1", "u", "conv", "ch", undefined,
+        undefined, "discord", "mcp", "t", {}, "/mcp/mcp/tools/t")
+    ).rejects.toThrow(/connectionId is required/);
+
+    await expect(
+      svc.postStatusMessage("conv", "ch", undefined, undefined, "teams", "...")
+    ).rejects.toThrow(/connectionId is required/);
   });
 });
 
@@ -755,9 +781,9 @@ describe("InteractionService — unique event ids", () => {
     const ids: string[] = [];
     svc.on("status-message:created", (e) => ids.push(e.id));
 
-    await svc.postStatusMessage("conv", "ch", undefined, undefined, "slack", "A");
-    await svc.postStatusMessage("conv", "ch", undefined, undefined, "slack", "B");
-    await svc.postStatusMessage("conv", "ch", undefined, undefined, "slack", "C");
+    await svc.postStatusMessage("conv", "ch", undefined, "conn-1", "slack", "A");
+    await svc.postStatusMessage("conv", "ch", undefined, "conn-1", "slack", "B");
+    await svc.postStatusMessage("conv", "ch", undefined, "conn-1", "slack", "C");
 
     expect(ids).toHaveLength(3);
     expect(new Set(ids).size).toBe(3);
@@ -768,9 +794,9 @@ describe("InteractionService — unique event ids", () => {
     const ids: string[] = [];
     svc.on("link-button:created", (e) => ids.push(e.id));
 
-    await svc.postLinkButton("u", "conv", "ch", undefined, undefined, "slack",
+    await svc.postLinkButton("u", "conv", "ch", undefined, "conn-1", "slack",
       "https://a.com", "A", "oauth");
-    await svc.postLinkButton("u", "conv", "ch", undefined, undefined, "slack",
+    await svc.postLinkButton("u", "conv", "ch", undefined, "conn-1", "slack",
       "https://b.com", "B", "oauth");
 
     expect(ids).toHaveLength(2);
@@ -792,7 +818,7 @@ describe("InteractionService — beforeCreateHook ordering", () => {
     });
     svc.on("question:created", () => log.push("event"));
 
-    await svc.postQuestion("u", "conv", "ch", undefined, undefined, "slack", "?", ["Y", "N"]);
+    await svc.postQuestion("u", "conv", "ch", undefined, "conn-1", "slack", "?", ["Y", "N"]);
 
     expect(log).toEqual(["hook", "event"]);
   });
@@ -837,7 +863,7 @@ describe("InteractionService.postLinkButton — body field", () => {
     const received: PostedLinkButton[] = [];
     svc.on("link-button:created", (e) => received.push(e));
 
-    await svc.postLinkButton("u", "conv", "ch", undefined, undefined, "slack",
+    await svc.postLinkButton("u", "conv", "ch", undefined, "conn-1", "slack",
       "https://example.com", "Connect", "oauth", "Authorize access to GitHub.");
 
     expect(received[0]!.body).toBe("Authorize access to GitHub.");
@@ -848,7 +874,7 @@ describe("InteractionService.postLinkButton — body field", () => {
     const received: PostedLinkButton[] = [];
     svc.on("link-button:created", (e) => received.push(e));
 
-    await svc.postLinkButton("u", "conv", "ch", undefined, undefined, "slack",
+    await svc.postLinkButton("u", "conv", "ch", undefined, "conn-1", "slack",
       "https://example.com", "Connect", "oauth");
 
     expect(received[0]!.body).toBeUndefined();
@@ -859,7 +885,7 @@ describe("InteractionService.postLinkButton — body field", () => {
     const received: PostedLinkButton[] = [];
     svc.on("link-button:created", (e) => received.push(e));
 
-    await svc.postOauthLink("u", "conv", "ch", undefined, undefined, "telegram",
+    await svc.postOauthLink("u", "conv", "ch", undefined, "conn-1", "telegram",
       "https://oauth.example.com/auth", "Sign in", "Please sign in.");
 
     expect(received[0]!.linkType).toBe("oauth");

--- a/packages/server/src/gateway/__tests__/mcp-proxy-edge-cases.test.ts
+++ b/packages/server/src/gateway/__tests__/mcp-proxy-edge-cases.test.ts
@@ -611,6 +611,51 @@ describe("tool approval — onToolBlocked and wildcard grants", () => {
     expect(blockedCount).toBe(1);
   });
 
+  test("fails closed when tool annotations cannot be discovered (empty tool list)", async () => {
+    // Regression for #688: previously, if tool discovery returned `{tools: []}`
+    // (because the upstream MCP was unreachable, SSRF-blocked, or timed out),
+    // `evaluateToolApproval` treated `found=false` as "allow" and let every
+    // tool call through without an approval check. Must fail closed instead.
+    const toolCache = new McpToolCache();
+    const grantStore = new GrantStore();
+
+    const configSource = createConfigSource({
+      "unreachable-mcp": {
+        id: "unreachable-mcp",
+        upstreamUrl: "http://unreachable.example.com/mcp",
+      },
+    });
+
+    let blockedCount = 0;
+    const proxy = new McpProxy(configSource, {
+      secretStore: new InMemoryWritableStore(),
+      toolCache,
+      grantStore,
+    });
+    proxy.onToolBlocked = async () => {
+      blockedCount++;
+    };
+
+    // No toolCache entry, and upstream tools/list returns an empty list —
+    // discovery yields `{ tools: [] }` ⇒ `found=false` ⇒ must require approval.
+    successFetch({ jsonrpc: "2.0", id: 1, result: { tools: [] } });
+
+    const app = proxy.getApp();
+    const res = await app.request("/unreachable-mcp/tools/anything", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${agent1Token}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({}),
+    });
+
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.content[0].text).toContain("requires approval");
+    expect(blockedCount).toBe(1);
+  });
+
   test("wildcard grant /mcp/<id>/tools/* covers all tools of that server", async () => {
     const toolCache = new McpToolCache();
     const grantStore = new GrantStore();

--- a/packages/server/src/gateway/__tests__/rest-api-hardening.test.ts
+++ b/packages/server/src/gateway/__tests__/rest-api-hardening.test.ts
@@ -714,28 +714,16 @@ describe("connection routes: access control", () => {
   });
 
   /**
-   * SUSPECTED BUG: GET /internal/connections has no authentication.
-   *
-   * The createConnectionCrudRoutes function registers:
-   *   app.get("/internal/connections", listAllConnections)
-   * with no auth middleware. Any unauthenticated caller can enumerate all
-   * platform connections and their agentId associations.
-   *
-   * This test documents the current (insecure) behavior.
-   * The endpoint should either be removed, moved behind auth, or restricted
-   * to same-process callers only (e.g., localhost-only binding).
+   * Regression: `GET /internal/connections` previously had no auth, leaking
+   * the full connection list (including agentId associations) to any
+   * unauthenticated caller. The route is removed entirely — the only caller
+   * was dead code referencing a non-existent `/api/v1/messaging/send`.
    */
-  test("[KNOWN GAP] GET /internal/connections requires no auth — documents unauthenticated access", async () => {
-    // No session set — completely unauthenticated
+  test("GET /internal/connections is removed — no unauthenticated tenant enumeration", async () => {
     const response = await orgContext.run({ organizationId: ORG_A }, () =>
       buildConnectionApp().request("/internal/connections")
     );
-    // Current behavior: 200 with connection data, no auth required.
-    // This is a security gap — internal routes should not be reachable without auth.
-    expect(response.status).toBe(200);
-    const data = (await response.json()) as any;
-    // Data leaks connection details to unauthenticated callers:
-    expect(Array.isArray(data.connections)).toBe(true);
+    expect(response.status).toBe(404);
   });
 });
 

--- a/packages/server/src/gateway/auth/mcp/proxy.ts
+++ b/packages/server/src/gateway/auth/mcp/proxy.ts
@@ -1070,7 +1070,11 @@ export class McpProxy {
       tokenData,
       token
     );
-    if (!found || !requiresToolApproval(annotations)) return "allow";
+    // Fail closed: if tool annotations couldn't be discovered (upstream MCP
+    // unreachable, SSRF block, fetch timeout, empty tool list, …) we can't
+    // determine whether the call needs approval, so require approval rather
+    // than silently allowing every tool to bypass the gate.
+    if (found && !requiresToolApproval(annotations)) return "allow";
 
     const pattern = `/mcp/${mcpId}/tools/${toolName}`;
     if (await this.grantStore.hasGrant(agentId, pattern)) return "allow";

--- a/packages/server/src/gateway/connections/interaction-bridge.ts
+++ b/packages/server/src/gateway/connections/interaction-bridge.ts
@@ -814,7 +814,19 @@ function shouldHandle(
     );
     return false;
   }
-  if (event.connectionId && event.connectionId !== connectionId) {
+  // Fail closed when the event omits a connectionId: without an explicit
+  // routing key every registered bridge would handle the same event, leaking
+  // it across platforms / tenants. InteractionService.post* now rejects
+  // empty connectionIds at the source; this defends against direct
+  // svc.emit() callers (tests, future code paths). See #690.
+  if (!event.connectionId) {
+    logger.debug(
+      { connectionId, platform },
+      "shouldHandle: event missing connectionId — refusing to route"
+    );
+    return false;
+  }
+  if (event.connectionId !== connectionId) {
     return false;
   }
   const instance = manager.getInstance(connectionId);

--- a/packages/server/src/gateway/interactions.ts
+++ b/packages/server/src/gateway/interactions.ts
@@ -13,6 +13,26 @@ const logger = createLogger("interactions");
 const SAFE_LINK_BUTTON_SCHEMES = new Set(["http:", "https:"]);
 
 /**
+ * Every event emitted by InteractionService MUST carry a non-empty
+ * `connectionId`. Bridges route by connectionId; an event with no
+ * connectionId would be picked up by every registered bridge regardless of
+ * platform, causing cross-platform leakage (e.g. a Slack tool-approval card
+ * also rendered in Telegram for an unrelated tenant). See #690.
+ */
+function assertNonEmptyConnectionId(
+  connectionId: string | undefined,
+  method: string
+): asserts connectionId is string {
+  if (typeof connectionId !== "string" || connectionId.length === 0) {
+    throw new Error(
+      `InteractionService.${method}: connectionId is required (got ${
+        connectionId === undefined ? "undefined" : JSON.stringify(connectionId)
+      }) — events without a connectionId would cross platforms`
+    );
+  }
+}
+
+/**
  * Reject URLs whose scheme could be used to execute code in the user's
  * client (e.g. `javascript:`, `data:`, `vbscript:`, `file:`) when posted
  * as a link button. We only accept normal web URLs.
@@ -114,6 +134,7 @@ export class InteractionService extends EventEmitter {
     question: string,
     options: string[]
   ): Promise<PostedQuestion> {
+    assertNonEmptyConnectionId(connectionId, "postQuestion");
     if (this.beforeCreateHook) {
       await this.beforeCreateHook(userId, conversationId);
     }
@@ -160,6 +181,7 @@ export class InteractionService extends EventEmitter {
     args: Record<string, unknown>,
     grantPattern: string
   ): Promise<PostedToolApproval> {
+    assertNonEmptyConnectionId(connectionId, "postToolApproval");
     if (this.beforeCreateHook) {
       await this.beforeCreateHook(userId, conversationId);
     }
@@ -204,6 +226,7 @@ export class InteractionService extends EventEmitter {
     body?: string
   ): Promise<PostedLinkButton> {
     assertSafeLinkButtonUrl(url);
+    assertNonEmptyConnectionId(connectionId, "postLinkButton");
     if (this.beforeCreateHook) {
       await this.beforeCreateHook(userId, conversationId);
     }
@@ -270,6 +293,7 @@ export class InteractionService extends EventEmitter {
     platform: string,
     text: string
   ): Promise<PostedStatusMessage> {
+    assertNonEmptyConnectionId(connectionId, "postStatusMessage");
     if (this.beforeCreateHook) {
       await this.beforeCreateHook("", conversationId);
     }

--- a/packages/server/src/gateway/routes/public/connections.ts
+++ b/packages/server/src/gateway/routes/public/connections.ts
@@ -458,17 +458,6 @@ export function createConnectionCrudRoutes(
   app.get("/internal/connections/platforms", listLocalTestPlatforms);
   app.get("/internal/connections/test-targets", listLocalTestTargets);
 
-  // Internal endpoint for server-to-server connection listing (no auth required)
-  const listAllConnections = async (c: any) => {
-    const { platform, agentId } = c.req.query();
-    const connections = await manager.listConnections({
-      platform: platform || undefined,
-      agentId: agentId || undefined,
-    });
-    return c.json({ connections });
-  };
-  app.get("/internal/connections", listAllConnections);
-
   app.openapi(ListConnectionsRoute, async (c): Promise<any> => {
     const session = await verifySettingsSession(c);
     if (!session) {

--- a/packages/server/src/notifications/service.ts
+++ b/packages/server/src/notifications/service.ts
@@ -1,7 +1,4 @@
 import { getDb, pgTextArray } from '../db/client';
-import { isLobuGatewayRunning } from '../lobu/gateway';
-import { getLobuServiceToken } from '../lobu/service-token';
-import logger from '../utils/logger';
 
 interface CreateNotificationParams {
   organizationId: string;
@@ -34,88 +31,6 @@ interface NotificationRow {
   resource_url: string | null;
   is_read: boolean;
   created_at: string;
-}
-
-/**
- * Forward a notification to active bot connections via Lobu's messaging API.
- *
- * Fetches active connections and their default targets from Lobu's internal API,
- * then sends via /api/v1/messaging/send with platform-specific routing.
- */
-async function deliverToBotConnections(
-  params: Omit<CreateNotificationParams, 'userId'>
-): Promise<void> {
-  if (!isLobuGatewayRunning()) return;
-
-  const port = process.env.PORT || '8787';
-  const lobuBaseUrl = `http://127.0.0.1:${port}/lobu`;
-
-  const text = params.body ? `${params.title}\n\n${params.body}` : params.title;
-
-  try {
-    // Fetch connections and targets in parallel
-    const [connRes, targetsRes] = await Promise.all([
-      fetch(`${lobuBaseUrl}/api/internal/connections`),
-      fetch(`${lobuBaseUrl}/api/internal/connections/test-targets`),
-    ]);
-    if (!connRes.ok) return;
-
-    const connBody = (await connRes.json()) as {
-      connections: Array<{
-        id: string;
-        platform: string;
-        agentId: string;
-        status: string;
-      }>;
-    };
-    const targets = targetsRes.ok
-      ? ((await targetsRes.json()) as Array<{ platform: string; defaultTarget: string }>)
-      : [];
-
-    const targetMap = new Map(targets.map((t) => [t.platform, t.defaultTarget]));
-
-    let connections = connBody.connections.filter((c) => c.status === 'active');
-    if (params.connectionId) {
-      connections = connections.filter((c) => c.id === params.connectionId);
-    }
-    if (connections.length === 0) return;
-
-    // Mint the service token once per org (it's org-scoped, not per-connection).
-    const token = await getLobuServiceToken(params.organizationId);
-
-    await Promise.allSettled(
-      connections.map((conn) => {
-        const target = targetMap.get(conn.platform);
-        // Platform-specific routing
-        const routing: Record<string, unknown> = {};
-        if (conn.platform === 'telegram' && target) {
-          routing.telegram = { chatId: target };
-        } else if (conn.platform === 'slack' && target) {
-          routing.slack = { channel: target };
-        }
-        return fetch(`${lobuBaseUrl}/api/v1/messaging/send`, {
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-            ...(token ? { Authorization: `Bearer ${token}` } : {}),
-          },
-          body: JSON.stringify({
-            agentId: conn.agentId,
-            message: text,
-            platform: conn.platform,
-            ...routing,
-          }),
-        }).catch((err) =>
-          logger.warn(
-            { err, connectionId: conn.id },
-            '[Notifications] Failed to send via Lobu connection'
-          )
-        );
-      })
-    );
-  } catch (err) {
-    logger.warn({ err }, '[Notifications] Failed to deliver to embedded Lobu');
-  }
 }
 
 /**
@@ -168,13 +83,6 @@ export async function createNotificationForUsers(
       ON CONFLICT DO NOTHING
     `;
   });
-
-  // Deliver to bot connections (fire-and-forget). The bot delivery targets
-  // the org's connection default channels and is identical for every user in
-  // this call, so fan it out once — not once per user.
-  deliverToBotConnections(params).catch((err) =>
-    logger.warn({ err }, '[Notifications] Failed to deliver to bot connections')
-  );
 }
 
 export async function listNotifications(opts: {


### PR DESCRIPTION
## Summary

Bundles four fixes flagged as "Suspected real bugs" in PR #684 / #685 and tracked as issues #687, #688, #690, #691. Each fix lands alongside an assertion flip (or a fresh regression test) so the failure mode is now pinned in CI.

### #687 — `GET /internal/connections` was unauthenticated (tenant enumeration)
- Removed the route entirely from `packages/server/src/gateway/routes/public/connections.ts` (lines 461-470 in the pre-fix file).
- The only consumer was `deliverToBotConnections` in `packages/server/src/notifications/service.ts`, which forwarded to a `/api/v1/messaging/send` endpoint that doesn't exist in the tree. That dead delivery helper is removed too (along with its `isLobuGatewayRunning` / `getLobuServiceToken` imports).
- `rest-api-hardening.test.ts` "[KNOWN GAP]" now asserts 404 instead of 200.

### #688 — MCP tool approval failed open when annotations couldn't be discovered
- `packages/server/src/gateway/auth/mcp/proxy.ts` :: `evaluateToolApproval` previously did `if (!found || !requiresToolApproval(...)) return "allow"`, which let every tool through whenever `fetchToolsForMcp` returned `{tools: []}` (upstream MCP unreachable / SSRF-blocked / timed out / empty cache).
- Flipped to `if (found && !requiresToolApproval(...))` — `!found` now drops through to the approval-required path.
- Added a fresh regression in `mcp-proxy-edge-cases.test.ts` asserting 403 + onToolBlocked when the upstream returns `{tools: []}`.

### #690 — InteractionService events without `connectionId` crossed platforms
- `packages/server/src/gateway/interactions.ts` :: every `post*` method now calls `assertNonEmptyConnectionId(connectionId, "<method>")` and throws on undefined or empty string.
- `packages/server/src/gateway/connections/interaction-bridge.ts` :: `shouldHandle` refuses to route events whose `event.connectionId` is missing (defense-in-depth for direct `svc.emit()` callers).
- `connections-platform-isolation.test.ts`: updated the accept-tests (URL-scheme, platform-field, unique-id, body-field, OAuth-link, beforeCreateHook) to supply real connectionIds, and added a `post* methods throw when connectionId is missing` test that pins the new contract.

### #691 — `OpenClawProgressProcessor.processEvent` null-derefed
- `packages/agent-worker/src/openclaw/processor.ts` :: added `if (!assistantEvent) return false;` after pulling `event.assistantMessageEvent` in the `message_update` arm.
- `processor-harden.test.ts` :: rewrote the "[KNOWN GAP]" test to assert `expect(() => p.processEvent(...)).not.toThrow()` + `processEvent(...) === false` + `getDelta() === null`.

## Touched files
- `packages/agent-worker/src/__tests__/processor-harden.test.ts`
- `packages/agent-worker/src/openclaw/processor.ts`
- `packages/server/src/gateway/__tests__/connections-platform-isolation.test.ts`
- `packages/server/src/gateway/__tests__/mcp-proxy-edge-cases.test.ts`
- `packages/server/src/gateway/__tests__/rest-api-hardening.test.ts`
- `packages/server/src/gateway/auth/mcp/proxy.ts`
- `packages/server/src/gateway/connections/interaction-bridge.ts`
- `packages/server/src/gateway/interactions.ts`
- `packages/server/src/gateway/routes/public/connections.ts`
- `packages/server/src/notifications/service.ts`

## Test plan
- [x] `bun run typecheck` — clean
- [x] `bun test src/gateway/__tests__/rest-api-hardening.test.ts` — 45 pass
- [x] `bun test src/gateway/__tests__/mcp-proxy-edge-cases.test.ts` — 34 pass (new annotations-unavailable test included)
- [x] `bun test src/gateway/__tests__/connections-platform-isolation.test.ts` — 77 pass
- [x] `bun test src/__tests__/processor-harden.test.ts` — 17 pass
- [x] `bun test src/gateway/__tests__/` (full gateway suite) — 793 pass
- [x] `cd packages/agent-worker && bun test` — 480 pass

Closes #687
Closes #688
Closes #690
Closes #691

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced event handling robustness for malformed or missing data
  * Improved cross-platform isolation through stricter connection ID validation
  * Tool approval now fails safely when tool metadata is unavailable

* **Security Improvements**
  * Removed unauthenticated endpoint exposing connection information
  * Added guards to prevent events from routing across platform boundaries

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lobu-ai/lobu/pull/851?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->