### PR TITLE
fix(docker): correct compose example after actual e2e test

### DIFF
--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -16,6 +16,7 @@
 services:
   postgres:
     image: pgvector/pgvector:pg18-trixie
+    # platform: linux/amd64  # uncomment on Apple Silicon if pgvector arm64 build is missing
     container_name: lobu-postgres
     environment:
       POSTGRES_USER: lobu
@@ -24,7 +25,7 @@ services:
     ports:
       - "5433:5432"
     volumes:
-      - lobu_pgdata:/var/lib/postgresql/data
+      - lobu_pgdata:/var/lib/postgresql
     restart: unless-stopped
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U lobu -d lobu"]
@@ -34,6 +35,7 @@ services:
 
   lobu:
     image: ghcr.io/lobu-ai/lobu-app:latest
+    # platform: linux/amd64  # required on Apple Silicon until multi-arch image lands (see GitHub Issues)
     container_name: lobu-app
     ports:
       - "8787:8787"

--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -36,6 +36,10 @@ That's it. Sign up via the admin UI, add provider API keys from the settings pag
 | `OPENAI_API_KEY` / `GROQ_API_KEY` / etc. | No | Same as Anthropic — set only the providers you want available, or add them via the admin UI at runtime. |
 | `WORKER_ALLOWED_DOMAINS` | Optional | Default empty = workers have no internet. Comma-separated allowlist, or `*` for unrestricted (not recommended in prod). See `.env.example` for the full pattern. |
 
+## Apple Silicon (M1/M2/M3) note
+
+The published image is currently amd64-only. Docker on Apple Silicon refuses to pull mismatched-architecture images unless you opt into emulation. Uncomment the `platform: linux/amd64` line in `docker-compose.example.yml` to run it via Rosetta — slightly slower but functional. A multi-arch image is planned; once published, drop the override.
+
 ## Boot errors and how to read them
 
 A failing boot now prints the actual error (type, message, stack, and Zod-validation issues). If you see:


### PR DESCRIPTION
## Summary

Fixes two real bugs in the sample compose shipped in #850 that I should have caught before merging — applying the e2e-before-merge rule that #837 codified hours earlier. My bad.

## Reproducer (the test #850 should have included)

```bash
cp docker-compose.example.yml /tmp/test/docker-compose.yml
cd /tmp/test
# Generate the two secrets per docs/DOCKER.md
sed -i '' "s|REPLACE_ME_openssl_rand_base64_32|$(openssl rand -base64 32)|"  docker-compose.yml  # ENCRYPTION_KEY
sed -i '' "0,/REPLACE_ME_openssl_rand_base64_32/{s/REPLACE_ME_openssl_rand_base64_32/$(openssl rand -base64 32)/}" docker-compose.yml  # BETTER_AUTH_SECRET
docker compose up -d
```

### Before this fix

```
Container lobu-postgres Error dependency postgres failed to start
dependency failed to start: container lobu-postgres is unhealthy
```

Postgres logs (truncated):
```
Counter to that, there appears to be PostgreSQL data in:
  /var/lib/postgresql/data (unused mount/volume)
This is usually the result of upgrading the Docker image without
upgrading the underlying database...
```

And on Apple Silicon, even before postgres tries to start:
```
no matching manifest for linux/arm64/v8 in the manifest list entries
```

### After this fix

```
Container lobu-postgres Healthy
Container lobu-app Started
```

Server logs end with:
```
{"port":8787,"msg":"Starting server"}
{"host":"0.0.0.0","port":8787,"msg":"Server running at http://0.0.0.0:8787"}
```

`GET /healthz` → `{"status":"ok",...}`. `GET /` returns 3211 bytes of SPA HTML. All 16 bundled providers loaded, 22 migrations applied cleanly.

## The two fixes

1. **Volume mount**: `lobu_pgdata:/var/lib/postgresql/data` → `lobu_pgdata:/var/lib/postgresql`. PG18+ uses major-version-specific subdirectories under the parent dir, so mounting `/data` directly conflicts with that layout and PG refuses to start. The user's original #766 compose had this right; I "fixed" it during #850 and broke it.

2. **Apple Silicon `platform: linux/amd64`**: the published image is amd64-only. Added a commented-out `platform:` line users can uncomment, plus a note in `docs/DOCKER.md`. Multi-arch image build is a follow-up.

## Test plan

- [x] `docker compose -f docker-compose.example.yml config` validates after edits.
- [x] Real e2e: compose up → both containers healthy → `GET /healthz` 200 → `GET /` returns SPA → no errors in lobu-app logs.

Refs #766.