### PR TITLE
ci: build images for linux/amd64 + linux/arm64

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -49,6 +49,9 @@ jobs:
         with:
           deploy-key: ${{ secrets.OWLETTO_WEB_DEPLOY_KEY }}
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -72,6 +75,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           file: ./docker/app/Dockerfile
           push: true
           tags: ${{ steps.meta.outputs.tags }}
@@ -104,6 +108,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -127,6 +134,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           file: ./docker/worker/Dockerfile
           push: true
           tags: ${{ steps.meta.outputs.tags }}
@@ -154,6 +162,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -177,6 +188,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           file: ./docker/embeddings-service/Dockerfile
           push: true
           tags: ${{ steps.meta.outputs.tags }}


### PR DESCRIPTION
## Summary

The published \`ghcr.io/lobu-ai/lobu-{app,worker,embeddings}\` images are amd64-only today. Apple Silicon users hit \`no matching manifest for linux/arm64/v8\` on \`docker compose up\` and have to manually opt into Rosetta emulation (see workaround comment in \`docker-compose.example.yml\`). After this lands, the native arm64 image gets pushed alongside amd64 and the override can be dropped (separate PR after the first multi-arch tag publishes).

## Change

Two lines per build job:
- Add \`docker/setup-qemu-action@v3\` before each \`setup-buildx-action@v3\`.
- Add \`platforms: linux/amd64,linux/arm64\` to each \`build-push-action@v6\`.

Standard multi-arch recipe. Buildx farms out the arm64 build to a QEMU-emulated runner inside the same ubuntu-latest job.

## Trade-offs

Build time will increase. \`isolated-vm\` native compile under QEMU is slow (5-10x slower than native arm64). If that becomes a problem in CI we move to a real arm64 runner (GitHub now offers \`ubuntu-22.04-arm\` as a paid runner) or split platforms into parallel jobs.

## Test plan

- [x] YAML syntax valid.
- [ ] First merged build actually produces a multi-arch image (will be visible in the next \`build-images.yml\` run's logs as \`linux/amd64,linux/arm64\` in the buildx output).
- [ ] After the first push, \`docker manifest inspect ghcr.io/lobu-ai/lobu-app:latest\` should show both \`amd64\` and \`arm64\` manifests.
- [ ] Follow-up: drop \`platform: linux/amd64\` override comments from \`docker-compose.example.yml\` once multi-arch is live.

Refs #766.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Docker images now support multi-architecture builds for AMD64 and ARM64 platforms.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lobu-ai/lobu/pull/854?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->