### PR TITLE
fix(auth-profiles): bound agentOwner / agentOrg caches at 1024 entries

### DIFF
--- a/packages/server/src/gateway/auth/settings/__tests__/auth-profiles-manager-cache-cap.test.ts
+++ b/packages/server/src/gateway/auth/settings/__tests__/auth-profiles-manager-cache-cap.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, mock, test } from "bun:test";
+import { AuthProfilesManager } from "../auth-profiles-manager.js";
+
+/** Probes the bounded-cache invariant: even when the gateway sees many
+ *  distinct one-shot agents, the agentOwner/agentOrg caches must not grow
+ *  unbounded. Without the cap they would accumulate one entry per distinct
+ *  agentId for the pod's lifetime (the existing TTL only refreshes values,
+ *  not map size). Cap is 1024 — exercised at 2048 lookups. */
+describe("AuthProfilesManager: bounded auth-resolver caches", () => {
+  test("agentOwner cache stays bounded under many distinct one-shot lookups", async () => {
+    const manager = new AuthProfilesManager({
+      ephemeralProfiles: { get: () => undefined } as never,
+      declaredAgents: { get: () => undefined } as never,
+      userAuthProfiles: { list: mock(async () => []) } as never,
+      secretStore: { get: mock(async () => undefined) } as never,
+      agentOwnerResolver: async (id) => `owner-${id}`,
+      agentOrgResolver: async (id) => `org-${id}`,
+    });
+
+    // 2048 distinct agentIds — twice the cap.
+    for (let i = 0; i < 2048; i++) {
+      // @ts-expect-error — exercising private resolver path via friend access
+      await manager["resolveAgentOwnerUserId"](`agent-${i}`);
+      // @ts-expect-error
+      await manager["resolveAgentOrgId"](`agent-${i}`);
+    }
+    // @ts-expect-error
+    expect(manager["agentOwnerCache"].size).toBeLessThanOrEqual(1024);
+    // @ts-expect-error
+    expect(manager["agentOrgCache"].size).toBeLessThanOrEqual(1024);
+  });
+});

--- a/packages/server/src/gateway/auth/settings/auth-profiles-manager.ts
+++ b/packages/server/src/gateway/auth/settings/auth-profiles-manager.ts
@@ -112,6 +112,17 @@ export class AuthProfilesManager {
   >();
   private static readonly AGENT_OWNER_CACHE_TTL_MS = 60_000;
   private static readonly AGENT_ORG_CACHE_TTL_MS = 60_000;
+  /** Hard cap on either cache to bound retention if many distinct agents are
+   *  looked up but never re-queried. When set() crosses this, the oldest
+   *  insertion is evicted (Maps iterate in insertion order). */
+  private static readonly AGENT_CACHE_MAX_ENTRIES = 1024;
+  private cacheSet<V>(cache: Map<string, V>, key: string, value: V): void {
+    if (cache.size >= AuthProfilesManager.AGENT_CACHE_MAX_ENTRIES && !cache.has(key)) {
+      const oldest = cache.keys().next().value;
+      if (oldest !== undefined) cache.delete(oldest);
+    }
+    cache.set(key, value);
+  }
   private lazyRefreshHooks?: LazyRefreshHooks;
 
   constructor(options: AuthProfilesManagerOptions) {
@@ -230,7 +241,7 @@ export class AuthProfilesManager {
       );
       return undefined;
     }
-    this.agentOwnerCache.set(agentId, {
+    this.cacheSet(this.agentOwnerCache, agentId, {
       ownerUserId,
       expiresAt: Date.now() + AuthProfilesManager.AGENT_OWNER_CACHE_TTL_MS,
     });
@@ -256,7 +267,7 @@ export class AuthProfilesManager {
       );
       return undefined;
     }
-    this.agentOrgCache.set(agentId, {
+    this.cacheSet(this.agentOrgCache, agentId, {
       organizationId,
       expiresAt: Date.now() + AuthProfilesManager.AGENT_ORG_CACHE_TTL_MS,
     });


### PR DESCRIPTION
## Summary

Hardening pass on the auth-profile resolver caches in `AuthProfilesManager`, motivated by #782's leak hunt.

## Root cause

`AuthProfilesManager` has two short-lived caches:

```ts
private readonly agentOwnerCache = new Map<string, { ownerUserId; expiresAt }>();
private readonly agentOrgCache   = new Map<string, { organizationId; expiresAt }>();
```

Both use "lazy refresh on read" — when an entry is looked up and expired, the resolver is called again and `set()` updates the entry. **But for agentIds that are looked up once and never re-queried, the entry stays in the Map forever.** The 60-second TTL only refreshes values, not map size.

In practice this is small (~200 bytes per distinct agentId, hundreds-to-thousands of agents per day). Almost certainly **not** the cause of the 1 Gi OOM in #782 — but a real Map that should clean up after itself.

## Fix

Adds a tiny `cacheSet(map, key, value)` helper that enforces a 1024-entry hard cap. When `set()` would push the size over the cap, evict the oldest insertion first (Maps iterate in insertion order, so `map.keys().next().value` + `map.delete()` is O(1)).

Both call sites updated to use the helper.

## Reproducer (e2e gate per AGENTS.md)

```
$ bun test packages/server/src/gateway/auth/settings/__tests__/auth-profiles-manager-cache-cap.test.ts
```

### Before fix (RED)

```
(fail) AuthProfilesManager: bounded auth-resolver caches > agentOwner cache stays bounded under many distinct one-shot lookups
 0 pass | 1 fail | 1 expect() calls
```

The test inserts 2048 distinct lookups and asserts `cache.size <= 1024`. Without the cap, size hits 2048.

### After fix (GREEN)

```
 1 pass | 0 fail | 2 expect() calls
Ran 1 test across 1 file. [91.00ms]
```

## Refs

- Refs #782 — hardening, not root-cause fix.
- The likely actual OOM fixes were already shipped: #833 (SSE keepalive teardown) and #834 (in-memory pending-interactions moved to Postgres).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test verification for bounded cache sizes.

* **Chores**
  * Implemented fixed maximum entry count for internal caches with automatic eviction of oldest entries when limit exceeded.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lobu-ai/lobu/pull/855?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->