### PR TITLE
fix(reaper): narrow stale-run reaper to lanes that actually heartbeat (sync + auth)

### DIFF
--- a/db/migrations/20260518020000_runs_heartbeat_inflight_narrow.sql
+++ b/db/migrations/20260518020000_runs_heartbeat_inflight_narrow.sql
@@ -1,0 +1,36 @@
+-- migrate:up
+
+-- Narrow the partial index `idx_runs_heartbeat_inflight` to the lanes that
+-- actually emit `client.heartbeat()` from the connector-worker executor.
+-- The previous index (20260518010000) covered all four connector lanes
+-- (sync, action, embed_backfill, auth), but only `sync` and `auth` runs call
+-- heartbeat() in packages/connector-worker/src/daemon/executor.ts. Action
+-- runs (executeActionRun) and embed_backfill runs (executeEmbedBackfillRun)
+-- never heartbeat, so the reaper's heartbeat-based WHERE clause would mark
+-- any action/embed_backfill run lasting longer than the stale threshold
+-- (default 120s) as `timeout` while it is still executing.
+--
+-- Drop and recreate to also align the index with the reaper query in
+-- packages/server/src/scheduled/check-stalled-executions.ts, which is
+-- updated to filter on the narrower lane set in the same change.
+--
+-- Follow-ups (tracked as separate issues):
+--   1. Wire `client.heartbeat()` into executeActionRun + executeEmbedBackfillRun
+--      so those lanes can be safely reaped.
+--   2. Wire heartbeat into the Chrome/Owletto browser-worker run path.
+
+DROP INDEX IF EXISTS public.idx_runs_heartbeat_inflight;
+
+CREATE INDEX IF NOT EXISTS idx_runs_heartbeat_inflight
+    ON public.runs (last_heartbeat_at)
+    WHERE status IN ('claimed', 'running')
+      AND run_type IN ('sync', 'auth');
+
+-- migrate:down
+
+DROP INDEX IF EXISTS public.idx_runs_heartbeat_inflight;
+
+CREATE INDEX IF NOT EXISTS idx_runs_heartbeat_inflight
+    ON public.runs (last_heartbeat_at)
+    WHERE status IN ('claimed', 'running')
+      AND run_type IN ('sync', 'action', 'embed_backfill', 'auth');

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -3704,7 +3704,7 @@ CREATE INDEX idx_runs_feed ON public.runs USING btree (feed_id);
 -- Name: idx_runs_heartbeat_inflight; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX idx_runs_heartbeat_inflight ON public.runs USING btree (last_heartbeat_at) WHERE ((status = ANY (ARRAY['claimed'::text, 'running'::text])) AND (run_type = ANY (ARRAY['sync'::text, 'action'::text, 'embed_backfill'::text, 'auth'::text])));
+CREATE INDEX idx_runs_heartbeat_inflight ON public.runs USING btree (last_heartbeat_at) WHERE ((status = ANY (ARRAY['claimed'::text, 'running'::text])) AND (run_type = ANY (ARRAY['sync'::text, 'auth'::text])));
 
 --
 -- Name: idx_runs_org; Type: INDEX; Schema: public; Owner: -
@@ -5078,4 +5078,5 @@ INSERT INTO public.schema_migrations (version) VALUES
     ('20260517150000'),
     ('20260517160000'),
     ('20260518000000'),
-    ('20260518010000');
+    ('20260518010000'),
+    ('20260518020000');

--- a/packages/server/src/db/embedded-schema-patches.ts
+++ b/packages/server/src/db/embedded-schema-patches.ts
@@ -862,4 +862,22 @@ export const EMBEDDED_SCHEMA_PATCHES: EmbeddedSchemaPatch[] = [
       `);
     },
   },
+  {
+    id: 'runs-heartbeat-inflight-narrow',
+    apply: async (sql) => {
+      // Mirrors db/migrations/20260518020000_runs_heartbeat_inflight_narrow.sql.
+      // Narrows the partial index + reaper WHERE clause to the lanes that
+      // actually heartbeat today (sync + auth). The previous wide set
+      // (sync, action, embed_backfill, auth) caused in-flight action and
+      // embed_backfill runs to be marked `timeout` after 120s because their
+      // executors never call client.heartbeat().
+      await sql.unsafe(`DROP INDEX IF EXISTS public.idx_runs_heartbeat_inflight`);
+      await sql.unsafe(`
+        CREATE INDEX IF NOT EXISTS idx_runs_heartbeat_inflight
+          ON public.runs (last_heartbeat_at)
+          WHERE status IN ('claimed', 'running')
+            AND run_type IN ('sync', 'auth')
+      `);
+    },
+  },
 ];

--- a/packages/server/src/scheduled/__tests__/stale-run-reaper.test.ts
+++ b/packages/server/src/scheduled/__tests__/stale-run-reaper.test.ts
@@ -166,16 +166,9 @@ describe('reapStaleRuns — connector lanes', () => {
     expect(await statusOf(staleId)).toBe('timeout');
   });
 
-  test('action and auth lanes are reaped (parity with sync/embed_backfill)', async () => {
-    // These lanes were missing from the legacy checkStalledExecutions sweep
-    // — only `sync` + `embed_backfill` were covered. The new reaper covers
-    // all four connector lanes uniformly.
-    const actionId = await seedRun({
-      status: 'running',
-      lastHeartbeatAgoSeconds: STALE_THRESHOLD_SECONDS * 3,
-      claimedAtAgoSeconds: STALE_THRESHOLD_SECONDS * 3,
-      runType: 'action',
-    });
+  test('auth lane is reaped (parity with sync)', async () => {
+    // `auth` heartbeats from executeAuthRun in the connector-worker daemon, so
+    // staleness on `last_heartbeat_at` is a real failure signal there too.
     const authId = await seedRun({
       status: 'running',
       lastHeartbeatAgoSeconds: STALE_THRESHOLD_SECONDS * 3,
@@ -184,8 +177,32 @@ describe('reapStaleRuns — connector lanes', () => {
     });
 
     const result = await reapStaleRuns();
-    expect(result.reaped).toBe(2);
-    expect(await statusOf(actionId)).toBe('timeout');
+    expect(result.reaped).toBe(1);
     expect(await statusOf(authId)).toBe('timeout');
+  });
+
+  test('action and embed_backfill lanes are NOT reaped (they do not heartbeat today)', async () => {
+    // executeActionRun and executeEmbedBackfillRun in
+    // packages/connector-worker/src/daemon/executor.ts never call
+    // client.heartbeat(), so reaping them on `last_heartbeat_at` would kill
+    // in-flight runs after the stale threshold elapses. Until those lanes
+    // emit heartbeats, the reaper must leave them alone.
+    const actionId = await seedRun({
+      status: 'running',
+      lastHeartbeatAgoSeconds: STALE_THRESHOLD_SECONDS * 3,
+      claimedAtAgoSeconds: STALE_THRESHOLD_SECONDS * 3,
+      runType: 'action',
+    });
+    const embedId = await seedRun({
+      status: 'running',
+      lastHeartbeatAgoSeconds: STALE_THRESHOLD_SECONDS * 3,
+      claimedAtAgoSeconds: STALE_THRESHOLD_SECONDS * 3,
+      runType: 'embed_backfill',
+    });
+
+    const result = await reapStaleRuns();
+    expect(result.reaped).toBe(0);
+    expect(await statusOf(actionId)).toBe('running');
+    expect(await statusOf(embedId)).toBe('running');
   });
 });

--- a/packages/server/src/scheduled/check-stalled-executions.ts
+++ b/packages/server/src/scheduled/check-stalled-executions.ts
@@ -9,8 +9,15 @@
  * reaper those rows sit "running" forever and the feed never gets a retry.
  *
  * Scope:
- *  - `sync`, `action`, `embed_backfill`, `auth` — driven by the out-of-process
- *    connector-worker daemon. These are reaped here.
+ *  - `sync`, `auth` — driven by the out-of-process connector-worker daemon
+ *    and emit `client.heartbeat()` from their executors. These are the only
+ *    lanes safe to reap on a heartbeat-staleness basis today.
+ *  - `action`, `embed_backfill` — also connector-worker lanes, but their
+ *    executors (`executeActionRun`, `executeEmbedBackfillRun` in
+ *    packages/connector-worker/src/daemon/executor.ts) do NOT heartbeat.
+ *    Reaping them on `last_heartbeat_at` would kill in-flight runs the
+ *    moment they exceed the stale threshold. Tracked as a follow-up — once
+ *    those lanes heartbeat, fold them back into the WHERE clause + index.
  *  - `watcher` — driven in-process by the embedded gateway. Lifecycle is
  *    handled by WatcherRunTracker + the dedicated `sweepStaleWatcherRuns` /
  *    `resetOrphanedWatcherRuns` helpers in watchers/automation.ts.
@@ -99,7 +106,7 @@ export async function reapStaleRuns(): Promise<ReapStaleRunsResult> {
         SET status = 'timeout',
             completed_at = current_timestamp,
             error_message = ${errorMessage}
-        WHERE run_type IN ('sync', 'action', 'embed_backfill', 'auth')
+        WHERE run_type IN ('sync', 'auth')
           AND status IN ('claimed', 'running')
           AND (
             (last_heartbeat_at IS NULL


### PR DESCRIPTION
## Summary

PR #849 added a heartbeat-based stale-run reaper covering four connector
lanes (`sync`, `action`, `embed_backfill`, `auth`). Codex audit (gpt-5.5,
`reasoning_effort=high`) flagged a critical bug: only `sync` and `auth`
runs actually call `client.heartbeat()` from
`packages/connector-worker/src/daemon/executor.ts`. `executeActionRun`
(lines 353-377) and `executeEmbedBackfillRun` (lines 577-622) never
heartbeat.

**Net result on prod:** any in-flight `action` or `embed_backfill` run
lasting longer than `RUNS_REAPER_STALE_AFTER_SECONDS` (default 120s) gets
marked `status='timeout'` with `error_message='worker_heartbeat_lost'`
while it is still executing successfully. This kills active runs the
moment #849 hits prod.

## Scope (narrow + safe)

- New migration `db/migrations/20260518020000_runs_heartbeat_inflight_narrow.sql`
  drops and recreates `idx_runs_heartbeat_inflight` restricted to
  `('sync', 'auth')`.
- Mirrored in `packages/server/src/db/embedded-schema-patches.ts` so already-
  initialised embedded/PGlite databases pick it up at boot.
- `reapStaleRuns()` `WHERE` clause in
  `packages/server/src/scheduled/check-stalled-executions.ts` narrowed to
  the same lane set so the bulk UPDATE matches the partial index.
- `db/schema.sql` regenerated by hand (predicate updated + new migration
  row appended).
- Test in `packages/server/src/scheduled/__tests__/stale-run-reaper.test.ts`
  updated: `action`/`embed_backfill` runs with stale `last_heartbeat_at`
  must NOT be reaped while their executors do not emit heartbeats.

## Out of scope (separate follow-up issues will be filed)

1. **Heartbeat `action` + `embed_backfill` runs** so they can be safely
   reaped on `last_heartbeat_at`. Once that lands, the lane set widens
   back; the index + WHERE clause stay the single source of truth so
   they cannot drift again.
2. **Heartbeat the Chrome/Owletto browser-worker run path**
   (`apps/chrome/background.js`) — same staleness blindspot, different
   lane.
3. **Restore atomicity of the sync timeout + retry insert** (the medium
   audit finding around the SELECT-then-UPDATE-then-INSERT shape; the
   advisory lock helps cross-pod, but the per-row sequence is still not
   atomic within a single tick).

## Reproducer

Test file `packages/server/src/scheduled/__tests__/stale-run-reaper.test.ts`:

- Red (without this fix): the `action` + `embed_backfill` runs are reaped
  by the WHERE clause that still lists all four lanes — the assertion that
  they stay `running` fails.
- Green (with this fix): all 6 tests pass.

```
$ bun test packages/server/src/scheduled/__tests__/stale-run-reaper.test.ts
 6 pass
 0 fail
 22 expect() calls
Ran 6 tests across 1 file. [3.16s]
```

## Test plan

- [x] `bun test packages/server/src/scheduled/__tests__/stale-run-reaper.test.ts` (6/6 pass)
- [x] Pre-commit `biome check` + `tsc --noEmit` pass
- [ ] CI: `make typecheck` already shows pre-existing `WorkerTokenData.organizationId` errors on `origin/main` unrelated to this change; check-drift is a known submodule-pointer concern (owletto behind main), not blocking. Required checks: typecheck / format-lint / build-test / pr-title / migrations / unit / integration / frontend.

## Codex audit reference

Inline finding from the Codex audit of PR #849 — flagged the index +
WHERE clause covering four lanes while only two emit heartbeats today.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected stalled connector run detection to focus on sync and auth run types that actively send heartbeats, excluding action and embed_backfill runs from heartbeat-based staleness monitoring.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lobu-ai/lobu/pull/859?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->