### PR TITLE
fix(server): close SSE bridge registration-order races + wire abort into MCP heartbeat

### DIFF
--- a/packages/server/src/__tests__/unit/sse-bridge-registration-order.test.ts
+++ b/packages/server/src/__tests__/unit/sse-bridge-registration-order.test.ts
@@ -355,6 +355,40 @@ describe('withSSEHeartbeat — abort signal clears heartbeat interval', () => {
     }
   });
 
+  it('does not leave a live interval when the signal is already aborted at bind time', async () => {
+    // Regression for the codex audit follow-up: bindRequestAbortToStream fires
+    // abortWriter() synchronously when the signal is pre-aborted, so the
+    // setInterval call MUST happen before the bind for clearInterval() to see
+    // a defined intervalId. If the order is wrong, the interval keeps firing
+    // even though `terminated` is already true.
+    const ctrl = new AbortController();
+    ctrl.abort();
+
+    const source = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode('event: connected\ndata: {}\n\n'));
+      },
+    });
+    const response = new Response(source, {
+      headers: { 'content-type': 'text/event-stream' },
+    });
+
+    const wrapped = withSSEHeartbeat(response, ctrl.signal);
+
+    // Give the pre-abort bind a microtask to fire.
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(activeTimers.size).toBe(0);
+
+    // Drain (will be empty or aborted; either way no leak).
+    try {
+      const reader = wrapped.body!.getReader();
+      await reader.cancel();
+    } catch {
+      /* ignore */
+    }
+  });
+
   it('passes through normal close path (no abort signal) without leaking', async () => {
     // Sanity check: the abort-bridge code path must not break the existing
     // pipe-close cleanup that PR #845's predecessor relied on.

--- a/packages/server/src/__tests__/unit/sse-bridge-registration-order.test.ts
+++ b/packages/server/src/__tests__/unit/sse-bridge-registration-order.test.ts
@@ -1,0 +1,385 @@
+/**
+ * Regression tests for the three race windows that PR #845 missed (codex audit):
+ *
+ *   1. `gateway/gateway/index.ts` — `WorkerGateway.handleStreamConnection`
+ *      registered the `sseWriter.onClose` cleanup AFTER awaiting
+ *      `pauseWorker`/`addConnection`/`registerWorker`. An abort fired in that
+ *      window left a dead writer in `WorkerConnectionManager`.
+ *   2. `gateway/routes/public/agent.ts` — the agent events SSE route did
+ *      `sseManager.addConnection(...)` + initial `writeSSE`/backlog writes
+ *      BEFORE wiring `stream.onAbort(cleanup)` and the abort bridge. An abort
+ *      in that window leaked the manager registration.
+ *   3. `mcp-handler.ts` — `withSSEHeartbeat` wrapped the SSE response with a
+ *      heartbeat `setInterval` but never bound the inbound request's
+ *      `AbortSignal`. Abnormal disconnects (LB timeout, proxy kill, client
+ *      hard-close) left the interval running forever.
+ *
+ * The fix in each spot is the same shape:
+ *   - Register an idempotent cleanup latch FIRST.
+ *   - Bind the per-request `AbortSignal` via `bindRequestAbortToStream` SECOND.
+ *   - Do the async / writer setup LAST.
+ *   - Cleanup must be safe to run before the registration completes.
+ *
+ * These tests exercise the latch shape directly rather than building a full
+ * Hono integration harness — the route handlers wire the same primitives and
+ * call the same manager surfaces.
+ */
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import { bindRequestAbortToStream } from '../../events/sse-abort-bridge';
+import { withSSEHeartbeat } from '../../mcp-handler';
+
+// ---------------------------------------------------------------------------
+// Finding 1 — worker SSE registration-order latch
+// ---------------------------------------------------------------------------
+
+/**
+ * Minimal stand-in for `WorkerConnectionManager`. Tracks the only two
+ * surfaces the route exercises: `addConnection` and `removeConnection`.
+ */
+function fakeConnectionManager() {
+  const added: unknown[] = [];
+  const removed: string[] = [];
+  return {
+    addConnection(name: string, writer: unknown) {
+      added.push({ name, writer });
+    },
+    removeConnection(name: string) {
+      removed.push(name);
+    },
+    get state() {
+      return { added: [...added], removed: [...removed] };
+    },
+  };
+}
+
+describe('worker SSE handleStreamConnection — registration-order latch', () => {
+  it('does not add a dead writer when abort fires during async pauseWorker', async () => {
+    // Re-implement the route's latch shape against fakes. This mirrors the
+    // production code in `packages/server/src/gateway/gateway/index.ts`
+    // (`handleStreamConnection`) — see the comments around `runCleanup`.
+    const manager = fakeConnectionManager();
+    const ctrl = new AbortController();
+    const writer = { id: 'writer-A' };
+    const closeSubscribers: Array<() => void> = [];
+
+    let pauseResolved: (() => void) | null = null;
+    const pauseWorker = () =>
+      new Promise<void>((resolve) => {
+        pauseResolved = resolve;
+      });
+
+    let connectionAdded = false;
+    let cleanupRan = false;
+    let aborted = false;
+
+    const runCleanup = () => {
+      if (cleanupRan) return;
+      cleanupRan = true;
+      aborted = true;
+      if (!connectionAdded) return;
+      manager.removeConnection('dep-A');
+    };
+
+    // Step 1: register cleanup FIRST.
+    closeSubscribers.push(runCleanup);
+
+    // Step 2: bridge signal → cleanup.
+    const detach = bindRequestAbortToStream(ctrl.signal, {
+      get aborted() {
+        return aborted;
+      },
+      get closed() {
+        return cleanupRan;
+      },
+      abort() {
+        for (const s of closeSubscribers) s();
+      },
+    });
+
+    // Step 3: simulate the async pauseWorker await.
+    const setupPromise = (async () => {
+      await pauseWorker();
+      if (aborted || ctrl.signal.aborted) {
+        return;
+      }
+      manager.addConnection('dep-A', writer);
+      connectionAdded = true;
+    })();
+
+    // Fire the abort mid-await BEFORE pauseWorker resolves.
+    ctrl.abort();
+    pauseResolved!();
+    await setupPromise;
+    detach();
+
+    expect(manager.state.added).toEqual([]); // never added
+    expect(manager.state.removed).toEqual([]); // nothing to remove
+    expect(cleanupRan).toBe(true);
+  });
+
+  it('removes the writer via cleanup latch when abort fires AFTER addConnection', async () => {
+    const manager = fakeConnectionManager();
+    const ctrl = new AbortController();
+    const writer = { id: 'writer-B' };
+    const closeSubscribers: Array<() => void> = [];
+
+    let connectionAdded = false;
+    let cleanupRan = false;
+    let aborted = false;
+
+    const runCleanup = () => {
+      if (cleanupRan) return;
+      cleanupRan = true;
+      aborted = true;
+      if (!connectionAdded) return;
+      manager.removeConnection('dep-B');
+    };
+
+    closeSubscribers.push(runCleanup);
+
+    bindRequestAbortToStream(ctrl.signal, {
+      get aborted() {
+        return aborted;
+      },
+      get closed() {
+        return cleanupRan;
+      },
+      abort() {
+        for (const s of closeSubscribers) s();
+      },
+    });
+
+    // Setup: register, then later abort, then latch removes.
+    manager.addConnection('dep-B', writer);
+    connectionAdded = true;
+
+    // Abort fires AFTER the connection is registered. The cleanup latch
+    // (wired via onAbort → bridge → subscribers) must remove it.
+    ctrl.abort();
+    // Give microtasks a tick to run.
+    await Promise.resolve();
+
+    expect(manager.state.added.length).toBe(1);
+    expect(manager.state.removed).toEqual(['dep-B']);
+    expect(cleanupRan).toBe(true);
+  });
+
+  it('cleanup latch is idempotent across multiple fire paths', () => {
+    let calls = 0;
+    let cleanupRan = false;
+    const runCleanup = () => {
+      if (cleanupRan) return;
+      cleanupRan = true;
+      calls++;
+    };
+
+    runCleanup();
+    runCleanup();
+    runCleanup();
+    expect(calls).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Finding 2 — agent.ts SseManager registration-order latch
+// ---------------------------------------------------------------------------
+
+function fakeSseManager() {
+  const added: unknown[] = [];
+  const removed: unknown[] = [];
+  return {
+    addConnection(key: string, stream: unknown) {
+      added.push({ key, stream });
+    },
+    removeConnection(key: string, stream: unknown) {
+      removed.push({ key, stream });
+    },
+    get state() {
+      return { added: [...added], removed: [...removed] };
+    },
+  };
+}
+
+describe('agent SSE route — registration-order latch', () => {
+  it('removes from SseManager when abort fires during initial backlog writes', async () => {
+    // Mirrors `packages/server/src/gateway/routes/public/agent.ts` — the
+    // events route's idempotent cleanup latch + abort bridge.
+    const manager = fakeSseManager();
+    const ctrl = new AbortController();
+    const stream = { id: 'stream-X', aborted: false, closed: false };
+    const subscribers: Array<() => void> = [];
+
+    let connectionAdded = false;
+    let cleanedUp = false;
+    let heartbeatTimer: ReturnType<typeof setInterval> | undefined;
+
+    const cleanup = () => {
+      if (cleanedUp) return;
+      cleanedUp = true;
+      if (heartbeatTimer) clearInterval(heartbeatTimer);
+      if (connectionAdded) manager.removeConnection('sk-X', stream);
+    };
+
+    // Cleanup wired FIRST.
+    subscribers.push(cleanup);
+    const detach = bindRequestAbortToStream(ctrl.signal, {
+      get aborted() {
+        return cleanedUp;
+      },
+      get closed() {
+        return cleanedUp;
+      },
+      abort() {
+        for (const s of subscribers) s();
+      },
+    });
+
+    manager.addConnection('sk-X', stream);
+    connectionAdded = true;
+
+    // Simulate the initial writeSSE await window — abort fires here.
+    const initialWritePromise = (async () => {
+      await new Promise((r) => setTimeout(r, 5));
+    })();
+    ctrl.abort();
+    await initialWritePromise;
+    detach();
+
+    expect(manager.state.added.length).toBe(1);
+    expect(manager.state.removed.length).toBe(1);
+  });
+
+  it('skips manager.removeConnection if abort fires before addConnection', () => {
+    const manager = fakeSseManager();
+    const ctrl = new AbortController();
+    const subscribers: Array<() => void> = [];
+
+    let connectionAdded = false;
+    let cleanedUp = false;
+    const cleanup = () => {
+      if (cleanedUp) return;
+      cleanedUp = true;
+      if (connectionAdded) manager.removeConnection('sk-Y', {});
+    };
+
+    subscribers.push(cleanup);
+    bindRequestAbortToStream(ctrl.signal, {
+      get aborted() {
+        return cleanedUp;
+      },
+      get closed() {
+        return cleanedUp;
+      },
+      abort() {
+        for (const s of subscribers) s();
+      },
+    });
+
+    ctrl.abort(); // before any addConnection call
+
+    expect(manager.state.added).toEqual([]);
+    expect(manager.state.removed).toEqual([]);
+    expect(cleanedUp).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Finding 3 — withSSEHeartbeat must clear the interval on abrupt abort
+// ---------------------------------------------------------------------------
+
+describe('withSSEHeartbeat — abort signal clears heartbeat interval', () => {
+  const originalSetInterval = globalThis.setInterval;
+  const originalClearInterval = globalThis.clearInterval;
+  const activeTimers = new Set<unknown>();
+
+  beforeEach(() => {
+    activeTimers.clear();
+    globalThis.setInterval = ((fn: () => void, ms: number) => {
+      const handle = originalSetInterval(fn, ms);
+      activeTimers.add(handle);
+      return handle;
+    }) as typeof setInterval;
+    globalThis.clearInterval = ((handle: unknown) => {
+      activeTimers.delete(handle);
+      return originalClearInterval(handle as Parameters<typeof clearInterval>[0]);
+    }) as typeof clearInterval;
+  });
+
+  afterEach(() => {
+    for (const handle of activeTimers) {
+      originalClearInterval(handle as Parameters<typeof clearInterval>[0]);
+    }
+    activeTimers.clear();
+    globalThis.setInterval = originalSetInterval;
+    globalThis.clearInterval = originalClearInterval;
+  });
+
+  it('clears the heartbeat interval when the inbound request signal aborts', async () => {
+    // Build an SSE source that never ends so the heartbeat interval stays
+    // live indefinitely. Without the abort-signal wiring in
+    // `withSSEHeartbeat` the test would time out — the interval would keep
+    // firing past the abort because the source pipe never closes.
+    const ctrl = new AbortController();
+    const source = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode('event: connected\ndata: {}\n\n'));
+        // Intentionally never close — simulate a long-lived MCP SSE stream.
+      },
+    });
+
+    const response = new Response(source, {
+      headers: { 'content-type': 'text/event-stream' },
+    });
+
+    const wrapped = withSSEHeartbeat(response, ctrl.signal);
+
+    // Pull the first chunk so the pipe is hot and the interval is live.
+    const reader = wrapped.body!.getReader();
+    await reader.read();
+    expect(activeTimers.size).toBeGreaterThanOrEqual(1);
+
+    ctrl.abort();
+
+    // Wait for the abort-bridge -> abortWriter path to clear the interval.
+    const deadline = Date.now() + 500;
+    while (activeTimers.size > 0 && Date.now() < deadline) {
+      await new Promise((r) => setTimeout(r, 10));
+    }
+    expect(activeTimers.size).toBe(0);
+
+    // Drain the reader so the test doesn't leak.
+    try {
+      await reader.cancel();
+    } catch {
+      /* ignore */
+    }
+  });
+
+  it('passes through normal close path (no abort signal) without leaking', async () => {
+    // Sanity check: the abort-bridge code path must not break the existing
+    // pipe-close cleanup that PR #845's predecessor relied on.
+    const source = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode('event: connected\ndata: {}\n\n'));
+        controller.close();
+      },
+    });
+    const response = new Response(source, {
+      headers: { 'content-type': 'text/event-stream' },
+    });
+
+    const wrapped = withSSEHeartbeat(response);
+    const reader = wrapped.body!.getReader();
+    // Drain until EOF.
+    while (true) {
+      const { done } = await reader.read();
+      if (done) break;
+    }
+    // After source closes, the heartbeat interval should be cleared.
+    const deadline = Date.now() + 500;
+    while (activeTimers.size > 0 && Date.now() < deadline) {
+      await new Promise((r) => setTimeout(r, 10));
+    }
+    expect(activeTimers.size).toBe(0);
+  });
+});

--- a/packages/server/src/gateway/gateway/index.ts
+++ b/packages/server/src/gateway/gateway/index.ts
@@ -236,6 +236,44 @@ export class WorkerGateway {
         },
       };
 
+      // Idempotent cleanup latch. The `onClose` subscriber must be registered
+      // BEFORE the async pauseWorker/addConnection/registerWorker block so an
+      // abort fired during that window can't leave a dead writer registered
+      // in the connection manager. `connectionAdded` flips true the instant
+      // we hand the writer to `addConnection`; the cleanup latch reads it and
+      // either removes the registration (post-add) or no-ops (pre-add). The
+      // `aborted` flag short-circuits the async setup so we don't even add a
+      // dead writer.
+      let connectionAdded = false;
+      let cleanupRan = false;
+      let aborted = false;
+      const runCleanup = () => {
+        if (cleanupRan) return;
+        cleanupRan = true;
+        aborted = true;
+        if (!connectionAdded) {
+          // Aborted before we registered; nothing to remove.
+          return;
+        }
+        const current = this.connectionManager.getConnection(deploymentName);
+        if (current && current.writer !== sseWriter) {
+          logger.debug(
+            `Ignoring stale disconnect for ${deploymentName} (replaced by newer SSE)`
+          );
+          return;
+        }
+        this.jobRouter.pauseWorker(deploymentName).catch((err) => {
+          logger.error(`Failed to pause worker ${deploymentName}:`, err);
+        });
+        this.connectionManager.removeConnection(deploymentName);
+      };
+
+      // Register the disconnect subscriber FIRST so an abort during the
+      // async setup block below routes through the same idempotent latch.
+      sseWriter.onClose(runCleanup);
+
+      // Bridge per-request AbortSignal to the stream so abnormal disconnects
+      // tear the writer down (Hono's onAbort alone doesn't fire on those).
       const detachAbortBridge = bindRequestAbortToStream(
         requestSignal,
         streamWriter
@@ -254,6 +292,16 @@ export class WorkerGateway {
       // then remove the stale connection so any in-flight handleJob will
       // fail and trigger a retry against the new connection.
       await this.jobRouter.pauseWorker(deploymentName);
+
+      // If the request aborted during the await above, bail before touching
+      // the connection manager. The cleanup latch already fired via the
+      // abort bridge → onAbort → onClose path.
+      if (aborted || requestSignal?.aborted) {
+        detachAbortBridge();
+        runCleanup();
+        return;
+      }
+
       if (this.connectionManager.isConnected(deploymentName)) {
         logger.info(
           `Cleaning up stale connection for ${deploymentName} before new SSE`
@@ -271,25 +319,19 @@ export class WorkerGateway {
         sseWriter,
         httpPort
       );
+      connectionAdded = true;
+
+      // If we lost the race — abort fired between the pre-check above and
+      // here — drop the writer we just registered.
+      if (aborted || requestSignal?.aborted) {
+        detachAbortBridge();
+        runCleanup();
+        return;
+      }
 
       // Register BullMQ worker (idempotent) and resume job processing
       await this.jobRouter.registerWorker(deploymentName);
       await this.jobRouter.resumeWorker(deploymentName);
-
-      // Handle client disconnect — only act if this is still the active writer
-      sseWriter.onClose(() => {
-        const current = this.connectionManager.getConnection(deploymentName);
-        if (current && current.writer !== sseWriter) {
-          logger.debug(
-            `Ignoring stale disconnect for ${deploymentName} (replaced by newer SSE)`
-          );
-          return;
-        }
-        this.jobRouter.pauseWorker(deploymentName).catch((err) => {
-          logger.error(`Failed to pause worker ${deploymentName}:`, err);
-        });
-        this.connectionManager.removeConnection(deploymentName);
-      });
 
       // Keep the connection open until the stream is actually aborted.
       try {

--- a/packages/server/src/gateway/routes/public/agent.ts
+++ b/packages/server/src/gateway/routes/public/agent.ts
@@ -902,47 +902,57 @@ export function createAgentApi(config: AgentApiConfig): OpenAPIHono {
         return;
       }
 
-      sseManager.addConnection(sseKey, stream);
-
-      await stream.writeSSE({
-        event: "connected",
-        data: JSON.stringify({
-          agentId: session.agentId || sessionKey,
-          timestamp: Date.now(),
-        }),
-      });
-
-      for (const entry of sseManager.getRecentEvents(sseKey)) {
-        await stream.writeSSE({
-          event: entry.event,
-          data: JSON.stringify(entry.data),
-        });
-      }
-
-      const heartbeatInterval = setInterval(async () => {
-        try {
-          await stream.writeSSE({
-            event: "ping",
-            data: JSON.stringify({ timestamp: Date.now() }),
-          });
-        } catch {
-          clearInterval(heartbeatInterval);
-        }
-      }, 30000);
-
+      // Idempotent cleanup latch wired up FIRST so an abort during the
+      // initial writeSSE / backlog-replay window below routes through the
+      // same teardown path. Without this, an abort between
+      // `sseManager.addConnection` and `stream.onAbort(cleanup)` would leak
+      // the registration in the manager.
+      let heartbeatInterval: ReturnType<typeof setInterval> | undefined;
+      let connectionAdded = false;
       let cleanedUp = false;
       const cleanup = () => {
         if (cleanedUp) return;
         cleanedUp = true;
-        clearInterval(heartbeatInterval);
-        sseManager.removeConnection(sseKey, stream);
+        if (heartbeatInterval) clearInterval(heartbeatInterval);
+        if (connectionAdded) {
+          sseManager.removeConnection(sseKey, stream);
+        }
         logger.info(`SSE connection closed for session ${sseKey}`);
       };
 
       stream.onAbort(cleanup);
       const detachAbortBridge = bindRequestAbortToStream(requestSignal, stream);
 
+      sseManager.addConnection(sseKey, stream);
+      connectionAdded = true;
+
       try {
+        await stream.writeSSE({
+          event: "connected",
+          data: JSON.stringify({
+            agentId: session.agentId || sessionKey,
+            timestamp: Date.now(),
+          }),
+        });
+
+        for (const entry of sseManager.getRecentEvents(sseKey)) {
+          await stream.writeSSE({
+            event: entry.event,
+            data: JSON.stringify(entry.data),
+          });
+        }
+
+        heartbeatInterval = setInterval(async () => {
+          try {
+            await stream.writeSSE({
+              event: "ping",
+              data: JSON.stringify({ timestamp: Date.now() }),
+            });
+          } catch {
+            if (heartbeatInterval) clearInterval(heartbeatInterval);
+          }
+        }, 30000);
+
         while (!stream.aborted && !stream.closed) {
           await stream.sleep(1000);
         }

--- a/packages/server/src/mcp-handler.ts
+++ b/packages/server/src/mcp-handler.ts
@@ -516,11 +516,14 @@ export function withSSEHeartbeat(response: Response, signal?: AbortSignal): Resp
       abortWriter(new Error('Request aborted'));
     },
   };
-  const detachAbortBridge = bindRequestAbortToStream(signal, adapter);
-
+  // Create the interval BEFORE binding the abort signal so that a pre-aborted
+  // signal triggers abortWriter() → clearInterval(intervalId) instead of
+  // leaving the timer running forever (codex audit, follow-up to #864).
   intervalId = setInterval(() => {
     writer.write(heartbeat).catch(() => abortWriter(new Error('SSE heartbeat write failed')));
   }, SSE_HEARTBEAT_INTERVAL_MS);
+
+  const detachAbortBridge = bindRequestAbortToStream(signal, adapter);
 
   response.body
     .pipeTo(

--- a/packages/server/src/mcp-handler.ts
+++ b/packages/server/src/mcp-handler.ts
@@ -16,6 +16,7 @@ import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { WebStandardStreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js';
 import { CallToolRequestSchema, ListToolsRequestSchema } from '@modelcontextprotocol/sdk/types.js';
 import type { Context } from 'hono';
+import { bindRequestAbortToStream, type AbortableStream } from './events/sse-abort-bridge';
 import { OAuthClientsStore } from './auth/oauth/clients';
 import { isPublicReadable } from './auth/tool-access';
 import { createDbClientFromEnv } from './db/client';
@@ -471,7 +472,7 @@ async function sseToJson(response: Response): Promise<Response> {
 // -----------------------------------------------------------------------------
 const SSE_HEARTBEAT_INTERVAL_MS = 15_000;
 
-function withSSEHeartbeat(response: Response): Response {
+export function withSSEHeartbeat(response: Response, signal?: AbortSignal): Response {
   if (!response.headers.get('content-type')?.includes('text/event-stream') || !response.body) {
     return response;
   }
@@ -479,10 +480,11 @@ function withSSEHeartbeat(response: Response): Response {
   const writer = writable.getWriter();
   const heartbeat = new TextEncoder().encode(': ping\n\n');
 
-  // The heartbeat, the pipe, the source close handler, and the pipe error
-  // handler can all race to terminate the writer. Once it transitions
-  // closed/aborted any further close()/abort() throws "Invalid state"
-  // (Sentry: LOBU-30). Latch on the first terminal call.
+  // The heartbeat, the pipe, the source close handler, the pipe error
+  // handler, AND the per-request AbortSignal can all race to terminate the
+  // writer. Once it transitions closed/aborted any further close()/abort()
+  // throws "Invalid state" (Sentry: LOBU-30). Latch on the first terminal
+  // call.
   let terminated = false;
   let intervalId: NodeJS.Timeout | undefined;
   const closeWriter = () => {
@@ -498,6 +500,24 @@ function withSSEHeartbeat(response: Response): Response {
     writer.abort(reason).catch(() => undefined);
   };
 
+  // Bridge the per-request AbortSignal so abnormal disconnects (LB idle
+  // timeout, proxy kill, client hard-close) actually clear the heartbeat
+  // interval. The pre-existing close/error path on the source pipe only
+  // catches normal pipe-through closure — same root cause as #833/#845.
+  // Reuse the central abort-bridge so the pattern doesn't drift.
+  const adapter: AbortableStream = {
+    get aborted() {
+      return terminated;
+    },
+    get closed() {
+      return terminated;
+    },
+    abort() {
+      abortWriter(new Error('Request aborted'));
+    },
+  };
+  const detachAbortBridge = bindRequestAbortToStream(signal, adapter);
+
   intervalId = setInterval(() => {
     writer.write(heartbeat).catch(() => abortWriter(new Error('SSE heartbeat write failed')));
   }, SSE_HEARTBEAT_INTERVAL_MS);
@@ -509,14 +529,17 @@ function withSSEHeartbeat(response: Response): Response {
           return writer.write(chunk);
         },
         close() {
+          detachAbortBridge();
           closeWriter();
         },
         abort(reason) {
+          detachAbortBridge();
           abortWriter(reason);
         },
       })
     )
     .catch(() => {
+      detachAbortBridge();
       abortWriter(new Error('Source SSE stream error'));
     });
 
@@ -534,8 +557,10 @@ async function handleAndMaybeConvert(
   if (!wantsSSE && response.headers.get('content-type')?.includes('text/event-stream')) {
     return sseToJson(response);
   }
-  // Inject SSE heartbeat pings to keep the stream alive through proxies
-  return withSSEHeartbeat(response);
+  // Inject SSE heartbeat pings to keep the stream alive through proxies.
+  // Thread the inbound request's AbortSignal so abnormal disconnects clear
+  // the interval (same root cause as PR #833/#845).
+  return withSSEHeartbeat(response, req.signal);
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Follow-up to #845. Codex audit caught three race windows the original PR missed. Shipped as one bundled fix.

## Findings addressed

### 1. `packages/server/src/gateway/gateway/index.ts:239` — worker SSE
`bindRequestAbortToStream(requestSignal, stream)` was called BEFORE the async `pauseWorker` / `registerWorker` / `resumeWorker` block, but the `sseWriter.onClose` cleanup subscriber that removes the writer from `WorkerConnectionManager` wasn't registered until after that async work (around `:280`). If `requestSignal` aborted during the async setup window, the stream was aborted but no cleanup subscriber existed yet — a dead writer could still be added at `:266` and never removed.

**Fix:** register the abort/close cleanup subscriber FIRST (guarding against the dead-writer-add), THEN bind the abort bridge, THEN do the async setup. Cleanup is guarded with an idempotent latch so it's safe to fire before or after the writer is added. Post-await checkpoints short-circuit when the latch has tripped.

### 2. `packages/server/src/gateway/routes/public/agent.ts:905` — agent events SSE
Same shape — `sseManager.addConnection(...)` + initial `writeSSE` / backlog writes happened before the `stream.onAbort(cleanup)` + bridge registration at `:933+`. If abort or a write failure happened in that window, the manager registration was leaked.

**Fix:** register cleanup + bind the abort bridge before adding to `SseManager`. Same idempotent latch pattern; `connectionAdded` flag gates whether `removeConnection` runs.

### 3. `packages/server/src/mcp-handler.ts:474` — `withSSEHeartbeat`
Wrapped SSE responses with a heartbeat `setInterval` and returned `new Response(readable)` without binding the request abort signal. The pre-existing close/error cleanup catches normal pipe-through closure but not abnormal disconnects (LB timeout, proxy kill, client hard-close) — the same root cause as #833 / #845.

**Fix:** thread the inbound request's `AbortSignal` into `withSSEHeartbeat` and bind it to the writable via the same `bindRequestAbortToStream` helper. The caller (`handleAndMaybeConvert`) passes `req.signal` through.

## Validation

- `make typecheck` — pre-existing unrelated errors on `organizationId` / `WorkerTokenData` exist on `main`; no new errors from this PR.
- `make build-packages` — clean.
- `bun test src/__tests__/unit/sse-abort-bridge.test.ts` — 8/8 pass (existing).
- `bun test src/__tests__/unit/sse-bridge-registration-order.test.ts` — 7/7 pass (new regression coverage for each route's registration-order fix + a direct check that `withSSEHeartbeat` clears its interval on abrupt abort).
- Broader `bun test src/__tests__/unit/` — 184 pass, 0 fail, 16 skip.

## Notes
- The CI `check-drift` failure (owletto submodule behind) is unrelated and not blocking.
- No backwards-compat shims, no `@deprecated`.