### PR TITLE
fix(agent-worker): propagate runId + runJobToken through JobEventSchema

### DIFF
--- a/packages/agent-worker/src/__tests__/sse-client.test.ts
+++ b/packages/agent-worker/src/__tests__/sse-client.test.ts
@@ -50,6 +50,105 @@ describe("GatewayClient heartbeat ACKs", () => {
     });
   });
 
+  test("propagates runId and runJobToken from job payload to handleThreadMessage", async () => {
+    // Regression test for the bug shipped in PR #871: snapshot mode became
+    // the default, but JobEventSchema was a plain z.object() (default zod
+    // mode strips unknown keys). MessageConsumer stamps runId + runJobToken
+    // onto the MessagePayload before SSE dispatch, but those fields were
+    // silently dropped by safeParse — so every snapshot-mode chat threw
+    // "WorkerConfig.runId is missing" at boot. Pre-fix: this assertion
+    // sees `undefined`. Post-fix: the fields survive parsing.
+    const client = new GatewayClient(
+      "https://gateway.example.com",
+      "worker-token",
+      "user-1",
+      "worker-1"
+    );
+    const handleThreadMessage = mock(async () => undefined);
+    (client as any).handleThreadMessage = handleThreadMessage;
+
+    await (client as any).handleEvent(
+      "job",
+      JSON.stringify({
+        payload: {
+          botId: "lobu-bot",
+          userId: "telegram-user-1",
+          agentId: "default",
+          conversationId: "telegram:6570514069",
+          platform: "telegram",
+          channelId: "6570514069",
+          messageId: "6570514069:29",
+          messageText: "hi",
+          platformMetadata: {},
+          agentOptions: {},
+          runId: 12345,
+          runJobToken: "per-run-jwt-abc",
+        },
+        jobId: "12345",
+      })
+    );
+
+    expect(handleThreadMessage).toHaveBeenCalledTimes(1);
+    const forwarded = handleThreadMessage.mock.calls[0]?.[0];
+    expect(forwarded.runId).toBe(12345);
+    expect(forwarded.runJobToken).toBe("per-run-jwt-abc");
+  });
+
+  test("payloadToWorkerConfig threads runId + runJobToken into WorkerConfig", async () => {
+    // The dispatch-path bug's second half: even if zod kept the fields,
+    // payloadToWorkerConfig has to forward them onto the WorkerConfig the
+    // worker reads at boot (worker.ts:353-360). Lock that mapping in.
+    const client = new GatewayClient(
+      "https://gateway.example.com",
+      "worker-token",
+      "user-1",
+      "worker-1"
+    );
+    const config = (client as any).payloadToWorkerConfig({
+      botId: "lobu-bot",
+      userId: "telegram-user-1",
+      agentId: "default",
+      conversationId: "telegram:6570514069",
+      platform: "telegram",
+      channelId: "6570514069",
+      messageId: "6570514069:29",
+      messageText: "hi",
+      platformMetadata: {},
+      agentOptions: {},
+      runId: 67890,
+      runJobToken: "per-run-jwt-xyz",
+    });
+    expect(config.runId).toBe(67890);
+    expect(config.runJobToken).toBe("per-run-jwt-xyz");
+  });
+
+  test("payloadToWorkerConfig leaves runId/runJobToken undefined when absent (legacy direct-enqueue path)", async () => {
+    // Backwards-compat: legacy direct-enqueue paths don't set runId. The
+    // worker handles this by skipping the snapshot POST when
+    // LOBU_SESSION_STORE=file. The fields must survive end-to-end as
+    // `undefined`, not be coerced into NaN/empty-string.
+    const client = new GatewayClient(
+      "https://gateway.example.com",
+      "worker-token",
+      "user-1",
+      "worker-1"
+    );
+    const config = (client as any).payloadToWorkerConfig({
+      botId: "lobu-bot",
+      userId: "user-1",
+      agentId: "default",
+      conversationId: "conv",
+      platform: "api",
+      channelId: "channel",
+      messageId: "msg-1",
+      messageText: "hi",
+      platformMetadata: {},
+      agentOptions: {},
+    });
+    expect(config.runId).toBeUndefined();
+    expect(config.runJobToken).toBeUndefined();
+  });
+
   test("ACKs heartbeat pings over the worker response endpoint", async () => {
     const fetchMock = mock(
       async (_url: string | URL | Request, _options?: RequestInit) =>

--- a/packages/agent-worker/src/gateway/sse-client.ts
+++ b/packages/agent-worker/src/gateway/sse-client.ts
@@ -81,20 +81,33 @@ const AgentOptionsSchema = z
   .passthrough();
 
 const JobEventSchema = z.object({
-  payload: z.object({
-    botId: z.string(),
-    userId: z.string(),
-    agentId: z.string(),
-    conversationId: z.string(),
-    platform: z.string(),
-    channelId: z.string(),
-    messageId: z.string(),
-    messageText: z.string(),
-    platformMetadata: PlatformMetadataSchema,
-    agentOptions: AgentOptionsSchema,
-    jobId: z.string().optional(),
-    teamId: z.string().optional(), // Optional for WhatsApp (top-level) and Slack (in platformMetadata)
-  }),
+  payload: z
+    .object({
+      botId: z.string(),
+      userId: z.string(),
+      agentId: z.string(),
+      conversationId: z.string(),
+      platform: z.string(),
+      channelId: z.string(),
+      messageId: z.string(),
+      messageText: z.string(),
+      platformMetadata: PlatformMetadataSchema,
+      agentOptions: AgentOptionsSchema,
+      jobId: z.string().optional(),
+      teamId: z.string().optional(), // Optional for WhatsApp (top-level) and Slack (in platformMetadata)
+      // Threaded through from MessageConsumer's runs-queue claim. The worker
+      // asserts these in snapshot mode (LOBU_SESSION_STORE != "file") — see
+      // worker.ts:353-360. The default zod object mode strips unknown keys,
+      // which silently dropped these fields and broke every Telegram chat
+      // when snapshot mode became the default in PR #871. Declare them
+      // explicitly so they survive parsing, and `.passthrough()` keeps any
+      // future MessagePayload field (mcpConfig, nixConfig, egressConfig,
+      // preApprovedTools, exec* fields, organizationId, networkConfig...)
+      // from regressing the same way.
+      runId: z.number().optional(),
+      runJobToken: z.string().optional(),
+    })
+    .passthrough(),
   processedIds: z.array(z.string()).optional(),
 });
 


### PR DESCRIPTION
## Summary

PR #871 flipped `LOBU_SESSION_STORE` default to snapshot mode. PR #865 added a startup assertion that throws if snapshot mode is on but `WorkerConfig.runId` is missing. Together they broke **every Telegram chat in prod**:

```
[error] [sse-client] Agent failed {
  "error":"Snapshot mode (LOBU_SESSION_STORE != 'file') but WorkerConfig.runId is missing
           — runs-queue dispatch did not stamp runId on the job payload"
}
```

The gateway sets `data.runId` (message-consumer.ts:149) and `data.runJobToken` (line 185) correctly. `job-router` writes the whole payload to SSE. The worker reads `payload.runId` / `payload.runJobToken` in `payloadToWorkerConfig` (sse-client.ts:925-935).

The dropped link was **`JobEventSchema`**. Its inner `payload` was a plain `z.object(...)` — default zod mode is strict-strip-unknown, so `runId` and `runJobToken` were silently removed at `safeParse`. `payload.runId` therefore always reached the worker as `undefined`, and the assertion fired on every message.

## Fix

- Declare `runId` + `runJobToken` explicitly on the schema.
- Add `.passthrough()` so future `MessagePayload` fields (`mcpConfig`, `nixConfig`, `egressConfig`, `preApprovedTools`, `exec*`, `organizationId`, `networkConfig`, ...) don't regress the same way.

Diff is 5 lines of real logic; rest is the schema + comments.

## Reproducer

**Pre-fix** — revert the schema change, run the new test:

```
expect(received).toBe(expected)
Expected: 12345
Received: undefined
  at packages/agent-worker/src/__tests__/sse-client.test.ts:93:29
(fail) propagates runId and runJobToken from job payload to handleThreadMessage
 4 pass, 1 fail
```

That `undefined` is exactly the dropped field that fires the prod assertion.

**Post-fix** — same test suite, schema restored:

```
5 pass
0 fail
Ran 5 tests across 1 file. [284.00ms]
```

## Test plan

- [x] New regression test exercises the actual `handleEvent("job", ...)` parse path with `runId` + `runJobToken` and asserts they reach `handleThreadMessage` — fails pre-fix, passes post-fix.
- [x] New test pins `payloadToWorkerConfig` mapping into `WorkerConfig`.
- [x] New test confirms legacy direct-enqueue path (no `runId`) still threads `undefined` cleanly — backwards-compat preserved.
- [x] `make typecheck` clean.
- [x] `make build-packages` clean.
- [ ] Post-merge: send a Telegram message in prod, verify a row appears in `agent_transcript_snapshot` for that run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for job event handling, verifying payload field propagation and worker configuration initialization for both new and legacy job enqueue paths.

* **Bug Fixes**
  * Improved job event payload validation to include optional fields and preserve additional gateway-provided keys during parsing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lobu-ai/lobu/pull/874?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->