### PR TITLE
fix(server): handle action_input JSONB-string shape + write JSONB objects for new runs

### DIFF
--- a/packages/server/src/gateway/__tests__/agent-transcript-snapshot.test.ts
+++ b/packages/server/src/gateway/__tests__/agent-transcript-snapshot.test.ts
@@ -493,6 +493,133 @@ describe("agent_transcript_snapshot — snapshot route", () => {
     const res = await callRoute("GET", "/snapshot", token);
     expect(res.status).toBe(400);
   });
+
+  test("authorises legacy runs whose action_input is a JSONB *string* (double-encoded)", async () => {
+    // Live prod regression: pre-fix dispatch wrote `action_input` as
+    // `'"{\\"agentId\\":...}"'` (jsonb_typeof = 'string') because the
+    // RunsQueue INSERT did `JSON.stringify(data)` bound to a `$1::jsonb`
+    // parameter via `tx.unsafe()`. Postgres then stored it as a JSONB
+    // string, not a JSONB object. The verifier's `action_input ->> 'agentId'`
+    // returned NULL on those rows → 403 every snapshot POST. We hand-roll
+    // both row shapes here and assert the verifier accepts both — the
+    // backward-compat path must keep working until existing in-flight
+    // legacy rows drain.
+    const orgId = await seedAgentRow("agent-jsonb-shape", {
+      organizationId: "org_jsonb_shape",
+    });
+    const agentId = "agent-jsonb-shape";
+    const conversationId = "conv-jsonb-shape";
+    const sql = getDb();
+
+    // Insert ONE legacy row (jsonb string) and ONE current row (jsonb object).
+    // sql.unsafe with JSON.stringify + $1::jsonb reproduces the broken
+    // production shape; sql.json reproduces the post-fix shape.
+    const legacyJsonString = JSON.stringify({ agentId, conversationId });
+    const legacyRows = await sql.unsafe<{ id: number }>(
+      `INSERT INTO public.runs (
+         organization_id, run_type, status, action_input,
+         queue_name, run_at, created_at
+       ) VALUES ($1, 'chat_message', 'running', $2::jsonb, 'chat_message', NOW(), NOW())
+       RETURNING id`,
+      [orgId, legacyJsonString]
+    );
+    const legacyRunId = Number(legacyRows[0]!.id);
+
+    const objectRows = (await sql`
+      INSERT INTO public.runs (
+        organization_id, run_type, status, action_input,
+        queue_name, run_at, created_at
+      ) VALUES (
+        ${orgId}, 'chat_message', 'running', ${sql.json({ agentId, conversationId })},
+        'chat_message', NOW(), NOW()
+      )
+      RETURNING id
+    `) as Array<{ id: number }>;
+    const objectRunId = Number(objectRows[0]!.id);
+
+    // Sanity-check the shapes — without this the test could pass for the
+    // wrong reasons if a future Postgres-client release silently normalises
+    // the string-shape on insert.
+    const shapes = (await sql`
+      SELECT id, jsonb_typeof(action_input) AS t
+      FROM public.runs WHERE id IN (${legacyRunId}, ${objectRunId})
+      ORDER BY id ASC
+    `) as Array<{ id: number; t: string }>;
+    const byId = new Map(shapes.map((r) => [Number(r.id), r.t]));
+    expect(byId.get(legacyRunId)).toBe("string");
+    expect(byId.get(objectRunId)).toBe("object");
+
+    // Verifier accepts the legacy `string`-shape row.
+    let res = await callRoute(
+      "POST",
+      "/snapshot",
+      mintWorkerToken({
+        organizationId: orgId,
+        agentId,
+        conversationId,
+        runId: legacyRunId,
+      }),
+      {
+        terminalStatus: "completed",
+        snapshotJsonl: `{"type":"session","id":"legacy"}\n`,
+        runId: legacyRunId,
+      }
+    );
+    expect(res.status).toBe(200);
+
+    // Verifier accepts the `object`-shape row.
+    res = await callRoute(
+      "POST",
+      "/snapshot",
+      mintWorkerToken({
+        organizationId: orgId,
+        agentId,
+        conversationId,
+        runId: objectRunId,
+      }),
+      {
+        terminalStatus: "completed",
+        snapshotJsonl: `{"type":"session","id":"modern"}\n`,
+        runId: objectRunId,
+      }
+    );
+    expect(res.status).toBe(200);
+
+    // Verifier REJECTS when scope mismatches, regardless of row shape.
+    res = await callRoute(
+      "POST",
+      "/snapshot",
+      mintWorkerToken({
+        organizationId: orgId,
+        agentId: "wrong-agent",
+        conversationId,
+        runId: legacyRunId,
+      }),
+      {
+        terminalStatus: "completed",
+        snapshotJsonl: `{"type":"session","id":"x"}\n`,
+        runId: legacyRunId,
+      }
+    );
+    expect(res.status).toBe(403);
+
+    res = await callRoute(
+      "POST",
+      "/snapshot",
+      mintWorkerToken({
+        organizationId: orgId,
+        agentId,
+        conversationId: "wrong-conv",
+        runId: objectRunId,
+      }),
+      {
+        terminalStatus: "completed",
+        snapshotJsonl: `{"type":"session","id":"x"}\n`,
+        runId: objectRunId,
+      }
+    );
+    expect(res.status).toBe(403);
+  });
 });
 
 describe("agent_transcript_snapshot — /agent-history fallback", () => {

--- a/packages/server/src/gateway/__tests__/runs-queue-integration.test.ts
+++ b/packages/server/src/gateway/__tests__/runs-queue-integration.test.ts
@@ -162,6 +162,45 @@ describe("RunsQueue — caller options", () => {
   });
 });
 
+describe("RunsQueue — action_input JSONB shape", () => {
+  test("send() persists action_input as a JSONB object, not a double-encoded JSONB string", async () => {
+    // Regression: pre-fix, the INSERT bound `JSON.stringify(data)` to a
+    // `$4::jsonb` parameter via `tx.unsafe()`. Postgres stored that as a
+    // JSONB *string* (jsonb_typeof = 'string'), not a JSONB object, which
+    // made every downstream `action_input ->> 'field'` reader silently
+    // return NULL — including the snapshot-route ownership verifier in
+    // gateway/transcript-routes.ts. Assert the new shape end-to-end so a
+    // future refactor can't re-introduce the bug.
+    if (!queue) throw new Error("queue not started");
+    const payload = {
+      agentId: "marketing",
+      conversationId: "telegram:6570514069",
+      userId: "u1",
+    };
+    await queue.send("test-jsonb-shape", payload);
+
+    const sql = getDb();
+    const rows = (await sql`
+      SELECT jsonb_typeof(action_input) AS shape,
+             action_input ->> 'agentId' AS extracted_agent_id,
+             action_input ->> 'conversationId' AS extracted_conv_id
+      FROM runs
+      WHERE queue_name = 'test-jsonb-shape'
+    `) as Array<{
+      shape: string;
+      extracted_agent_id: string | null;
+      extracted_conv_id: string | null;
+    }>;
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.shape).toBe("object");
+    // Direct `->>` extraction works on the object shape — the exact
+    // accessor the snapshot-route verifier relies on.
+    expect(rows[0]!.extracted_agent_id).toBe("marketing");
+    expect(rows[0]!.extracted_conv_id).toBe("telegram:6570514069");
+  });
+});
+
 describe("RunsQueue — graceful shutdown", () => {
   test("stop() releases claimed rows back to pending", async () => {
     if (!queue) throw new Error("queue not started");

--- a/packages/server/src/gateway/gateway/transcript-routes.ts
+++ b/packages/server/src/gateway/gateway/transcript-routes.ts
@@ -71,12 +71,29 @@ async function isRunOwnedByJwtScope(
   conversationId: string
 ): Promise<boolean> {
   const sql = getDb();
+  // `runs.action_input` is `jsonb` typed, but rows written before the
+  // dispatch-path fix below stored a double-encoded JSON *string* (e.g.
+  // `'"{\\"agentId\\":\\"marketing\\",...}"'`) instead of a JSONB object.
+  // `action_input ->> 'agentId'` returns NULL on a JSONB string, which
+  // would 403 every snapshot POST on rows enqueued before the fix rolled.
+  // CASE on `jsonb_typeof` so both shapes authorize identically: object
+  // rows use the direct `->>` accessor; string rows unwrap one layer via
+  // `(action_input #>> '{}')::jsonb ->>` first. New rows (post fix below)
+  // always take the 'object' branch; legacy in-flight rows take 'string'.
   const rows = await sql<{ ok: boolean }>`
     SELECT 1 AS ok FROM public.runs
     WHERE id = ${runId}
       AND organization_id = ${organizationId}
-      AND (action_input ->> 'agentId') = ${agentId}
-      AND (action_input ->> 'conversationId') = ${conversationId}
+      AND CASE jsonb_typeof(action_input)
+            WHEN 'object' THEN action_input ->> 'agentId'
+            WHEN 'string' THEN (action_input #>> '{}')::jsonb ->> 'agentId'
+            ELSE NULL
+          END = ${agentId}
+      AND CASE jsonb_typeof(action_input)
+            WHEN 'object' THEN action_input ->> 'conversationId'
+            WHEN 'string' THEN (action_input #>> '{}')::jsonb ->> 'conversationId'
+            ELSE NULL
+          END = ${conversationId}
     LIMIT 1
   `;
   return rows.length > 0;

--- a/packages/server/src/gateway/infrastructure/queue/runs-queue.ts
+++ b/packages/server/src/gateway/infrastructure/queue/runs-queue.ts
@@ -309,7 +309,14 @@ export class RunsQueue implements IMessageQueue {
       : "NULL";
 
     const sql = getDb();
-    const actionInput = JSON.stringify(data ?? {});
+    // Pass the payload object through postgres-js's `sql.json()` helper so
+    // the driver sends it as a single-encoded JSONB value. The previous
+    // shape — `JSON.stringify(data)` bound to a `$4::jsonb` parameter via
+    // `tx.unsafe()` — round-tripped through Postgres as a JSONB *string*
+    // (jsonb_typeof = 'string'), not a JSONB object. That broke every
+    // downstream reader using `action_input ->> 'field'`, including the
+    // snapshot-route ownership verifier in transcript-routes.ts.
+    const actionInput = sql.json(data ?? {});
 
     // Insert + ON-CONFLICT-fallback inside a single transaction so a race
     // between two enqueues with the same idempotency key resolves cleanly.
@@ -342,7 +349,7 @@ export class RunsQueue implements IMessageQueue {
           expires_at,
           retry_delay_seconds
         ) VALUES (
-          $1, $2, $3, $4::jsonb, $5, $6, 0, 'pending', ${runAtSql}, $7, ${expiresAtSql}, $8
+          $1, $2, $3, $4, $5, $6, 0, 'pending', ${runAtSql}, $7, ${expiresAtSql}, $8
         )
         ON CONFLICT (idempotency_key)
           WHERE idempotency_key IS NOT NULL


### PR DESCRIPTION
## Summary
Third bug in the Phase 5 chain. Workers correctly POST snapshots (post PR #874), but the gateway's verifier 403's every one because `runs.action_input` is stored as a JSONB **string** (double-encoded) — `action_input ->> 'agentId'` returns NULL.

## Root cause
`runs-queue.ts:309`: `JSON.stringify(data)` bound to a `$4::jsonb` parameter → Postgres stored the JSONB as a string scalar, not a JSONB object. Every chat_message run since the dawn of time has been wrong-shape.

## Fix
- **Verifier** (`transcript-routes.ts`): `CASE jsonb_typeof(action_input)` handles both shapes. String rows unwrap via `(action_input #>> '{}')::jsonb` first; object rows use direct `->>`. Crossover-safe.
- **Dispatch** (`runs-queue.ts`): `sql.json(data)` replaces `JSON.stringify` so postgres-js sends a real JSONB object going forward.

## Verification
After merge + image roll, Telegram message via `@embeddedlobu2bot` should produce a row in `agent_transcript_snapshot` (currently 0 rows since Phase 5).

## Test plan
- [x] make typecheck clean
- [ ] CI green
- [ ] Real Telegram message → snapshot row appears

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed snapshot authorization so valid snapshots from legacy-inflight records are accepted.
  * Ensured queued action payloads are persisted as structured JSON to avoid mismatches.

* **Tests**
  * Added regression tests covering snapshot authorization and end-to-end persistence for legacy and current data shapes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lobu-ai/lobu/pull/877?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->