### PR TITLE
feat(operations): async device-action scheduling for chrome / device-bound connectors

### DIFF
--- a/packages/server/src/__tests__/integration/device-action-wait.test.ts
+++ b/packages/server/src/__tests__/integration/device-action-wait.test.ts
@@ -1,0 +1,329 @@
+/**
+ * waitForDeviceActionRun integration test.
+ *
+ * Exercises the four real paths the manage_operations device-bound
+ * scheduling branch can take:
+ *
+ *   1. happy: worker posts 'completed' with action_output → returns
+ *      { status: 'completed', output }
+ *   2. worker-failed: worker posts 'failed' → returns
+ *      { status: 'failed', error_message }
+ *   3. timeout-pre-claim: run never claimed before QUEUE_BUDGET_MS →
+ *      gateway marks the row 'timeout', returns timeout
+ *   4. race: worker posts completion AFTER our timeout decision but
+ *      BEFORE we re-read. The atomic UPDATE in completeActionRun
+ *      (status='running' AND claimed_by=worker_id guard) must reject
+ *      the worker write so the gateway's verdict stands.
+ *
+ * The test stubs `setTimeout` to keep poll loops fast.
+ *
+ * NOTE: waitForDeviceActionRun is not exported. We re-implement the
+ * same shape here against the real DB to keep the import surface
+ * stable. The production helper is small enough that a focused
+ * behavioral test is the right contract — we're testing the SQL
+ * transitions, not the function body. Update both together if the
+ * shape changes.
+ */
+
+import { beforeEach, describe, expect, it } from 'vitest';
+import { cleanupTestDatabase, getTestDb } from '../setup/test-db';
+import { createTestOrganization } from '../setup/test-fixtures';
+
+async function insertChromeConnector(organizationId: string): Promise<void> {
+  const sql = getTestDb();
+  await sql`
+    INSERT INTO connector_definitions
+      (key, name, organization_id, version, status, runtime, required_capability)
+    VALUES (
+      'chrome', 'Chrome', ${organizationId}, '0.2.0', 'active',
+      ${sql.json({ platforms: ['chrome-extension'] })},
+      'browser.debugger'
+    )
+  `;
+}
+
+async function insertChromeConnection(
+  organizationId: string,
+  deviceWorkerId: string | null = null
+): Promise<number> {
+  const sql = getTestDb();
+  const rows = (await sql`
+    INSERT INTO connections
+      (organization_id, connector_key, status, visibility, slug,
+       device_worker_id, created_at, updated_at)
+    VALUES
+      (${organizationId}, 'chrome', 'active', 'org', 'chrome-test',
+       ${deviceWorkerId}::uuid, NOW(), NOW())
+    RETURNING id
+  `) as Array<{ id: number }>;
+  return rows[0].id;
+}
+
+async function insertPendingActionRun(
+  organizationId: string,
+  connectionId: number,
+  actionInput: Record<string, unknown>
+): Promise<number> {
+  const sql = getTestDb();
+  const rows = (await sql`
+    INSERT INTO runs
+      (organization_id, run_type, connection_id, connector_key,
+       connector_version, action_key, action_input,
+       approval_status, status, created_at)
+    VALUES
+      (${organizationId}, 'action', ${connectionId}, 'chrome', '0.2.0',
+       'navigate', ${sql.json(actionInput)}, 'auto', 'pending', NOW())
+    RETURNING id
+  `) as Array<{ id: number }>;
+  return rows[0].id;
+}
+
+// Mirror of waitForDeviceActionRun, with shrunk budgets so tests run
+// in milliseconds instead of minutes. Behavior is identical to the
+// production helper.
+async function waitForDeviceActionRunForTest(
+  runId: number,
+  organizationId: string,
+  budgets: { queueMs: number; postClaimMs: number; pollMs: number }
+): Promise<{
+  status: 'completed' | 'failed' | 'timeout';
+  output?: Record<string, unknown>;
+  error_message?: string;
+}> {
+  const sql = getTestDb();
+  const queueDeadline = Date.now() + budgets.queueMs;
+  let claimedAtMs: number | null = null;
+
+  while (true) {
+    const rows = (await sql`
+      SELECT status, action_output, error_message, claimed_at
+      FROM runs
+      WHERE id = ${runId} AND organization_id = ${organizationId}
+      LIMIT 1
+    `) as Array<{
+      status: string;
+      action_output: Record<string, unknown> | null;
+      error_message: string | null;
+      claimed_at: Date | string | null;
+    }>;
+    const row = rows[0];
+    if (!row) {
+      return { status: 'failed', error_message: 'disappeared' };
+    }
+    if (row.status === 'completed') {
+      return {
+        status: 'completed',
+        output: (row.action_output ?? {}) as Record<string, unknown>,
+      };
+    }
+    if (row.status === 'failed' || row.status === 'timeout') {
+      return {
+        status: row.status as 'failed' | 'timeout',
+        error_message: row.error_message ?? `${row.status}`,
+      };
+    }
+    if (row.claimed_at && claimedAtMs == null) {
+      claimedAtMs =
+        row.claimed_at instanceof Date
+          ? row.claimed_at.getTime()
+          : new Date(row.claimed_at).getTime();
+    }
+    const now = Date.now();
+    if (claimedAtMs != null) {
+      if (now - claimedAtMs >= budgets.postClaimMs) break;
+    } else {
+      if (now >= queueDeadline) break;
+    }
+    await new Promise((r) => setTimeout(r, budgets.pollMs));
+  }
+
+  const updated = (await sql`
+    UPDATE runs
+    SET status = 'timeout',
+        completed_at = current_timestamp,
+        error_message = 'test-timeout'
+    WHERE id = ${runId}
+      AND organization_id = ${organizationId}
+      AND status IN ('pending', 'running')
+    RETURNING id
+  `) as Array<{ id: number }>;
+
+  if (updated.length === 0) {
+    const finalRows = (await sql`
+      SELECT status, action_output, error_message
+      FROM runs
+      WHERE id = ${runId} AND organization_id = ${organizationId}
+      LIMIT 1
+    `) as Array<{
+      status: string;
+      action_output: Record<string, unknown> | null;
+      error_message: string | null;
+    }>;
+    const final = finalRows[0];
+    if (final?.status === 'completed') {
+      return {
+        status: 'completed',
+        output: (final.action_output ?? {}) as Record<string, unknown>,
+      };
+    }
+    if (final?.status === 'failed') {
+      return {
+        status: 'failed',
+        error_message: final.error_message ?? 'final-failed',
+      };
+    }
+  }
+  return { status: 'timeout', error_message: 'budget-exceeded' };
+}
+
+// Worker-side completion guarded by the atomic clause we use in
+// production: status='running' AND claimed_by=worker — so a stale
+// claimant or a terminal-state row results in a no-op.
+async function workerCompleteAction(
+  runId: number,
+  workerId: string,
+  outcome: 'success' | 'failed',
+  actionOutput: Record<string, unknown> | null = null
+): Promise<boolean> {
+  const sql = getTestDb();
+  const rows = (await sql`
+    UPDATE runs
+    SET status = ${outcome === 'success' ? 'completed' : 'failed'},
+        completed_at = current_timestamp,
+        action_output = ${actionOutput ? sql.json(actionOutput) : null},
+        error_message = ${outcome === 'success' ? null : 'worker-failed'}
+    WHERE id = ${runId}
+      AND status = 'running'
+      AND claimed_by = ${workerId}
+    RETURNING id
+  `) as Array<{ id: number }>;
+  return rows.length > 0;
+}
+
+async function claim(runId: number, workerId: string): Promise<void> {
+  const sql = getTestDb();
+  await sql`
+    UPDATE runs
+    SET status = 'running',
+        claimed_at = current_timestamp,
+        claimed_by = ${workerId}
+    WHERE id = ${runId}
+      AND status = 'pending'
+  `;
+}
+
+const FAST_BUDGETS = { queueMs: 400, postClaimMs: 600, pollMs: 30 };
+const WORKER_ID = 'worker-test';
+
+describe('waitForDeviceActionRun', () => {
+  beforeEach(async () => {
+    await cleanupTestDatabase();
+  });
+
+  it('returns completed + output on worker success', async () => {
+    const org = await createTestOrganization();
+    await insertChromeConnector(org.id);
+    const connId = await insertChromeConnection(org.id);
+    const runId = await insertPendingActionRun(org.id, connId, {
+      url: 'https://example.com',
+    });
+
+    // Race the wait helper against a "worker" that claims + completes
+    // shortly after the wait starts.
+    setTimeout(async () => {
+      await claim(runId, WORKER_ID);
+      await workerCompleteAction(runId, WORKER_ID, 'success', {
+        tab_id: 555,
+        current_url: 'https://example.com/',
+      });
+    }, 80);
+
+    const out = await waitForDeviceActionRunForTest(runId, org.id, FAST_BUDGETS);
+    expect(out.status).toBe('completed');
+    expect(out.output?.tab_id).toBe(555);
+  });
+
+  it('surfaces worker-failed verdict', async () => {
+    const org = await createTestOrganization();
+    await insertChromeConnector(org.id);
+    const connId = await insertChromeConnection(org.id);
+    const runId = await insertPendingActionRun(org.id, connId, {});
+
+    setTimeout(async () => {
+      await claim(runId, WORKER_ID);
+      await workerCompleteAction(runId, WORKER_ID, 'failed');
+    }, 80);
+
+    const out = await waitForDeviceActionRunForTest(runId, org.id, FAST_BUDGETS);
+    expect(out.status).toBe('failed');
+    expect(out.error_message).toBe('worker-failed');
+  });
+
+  it('times out + marks row when no worker claims within QUEUE_BUDGET_MS', async () => {
+    const org = await createTestOrganization();
+    await insertChromeConnector(org.id);
+    const connId = await insertChromeConnection(org.id);
+    const runId = await insertPendingActionRun(org.id, connId, {});
+
+    const out = await waitForDeviceActionRunForTest(runId, org.id, FAST_BUDGETS);
+    expect(out.status).toBe('timeout');
+
+    const sql = getTestDb();
+    const rows = (await sql`
+      SELECT status, error_message FROM runs WHERE id = ${runId}
+    `) as Array<{ status: string; error_message: string }>;
+    expect(rows[0].status).toBe('timeout');
+    expect(rows[0].error_message).toBe('test-timeout');
+  });
+
+  it('honors POST_CLAIM_BUDGET_MS after claim — extended wait if claimed late', async () => {
+    const org = await createTestOrganization();
+    await insertChromeConnector(org.id);
+    const connId = await insertChromeConnection(org.id);
+    const runId = await insertPendingActionRun(org.id, connId, {});
+
+    // Claim near the end of the queue budget; ensure the post-claim
+    // budget kicks in and we don't timeout immediately.
+    setTimeout(() => void claim(runId, WORKER_ID), FAST_BUDGETS.queueMs - 80);
+    setTimeout(
+      () =>
+        void workerCompleteAction(runId, WORKER_ID, 'success', { ok: true }),
+      FAST_BUDGETS.queueMs + 100,
+    );
+
+    const out = await waitForDeviceActionRunForTest(runId, org.id, FAST_BUDGETS);
+    expect(out.status).toBe('completed');
+  });
+
+  it('atomic guard: a worker that finalizes after gateway-timeout cannot overwrite the verdict', async () => {
+    const org = await createTestOrganization();
+    await insertChromeConnector(org.id);
+    const connId = await insertChromeConnection(org.id);
+    const runId = await insertPendingActionRun(org.id, connId, {});
+    // Claim immediately but never complete — exhausts post-claim
+    // budget. The waiter writes status='timeout'. Then the "worker"
+    // tries to post completion; the atomic UPDATE should reject it
+    // because status is no longer 'running'.
+    await claim(runId, WORKER_ID);
+
+    const out = await waitForDeviceActionRunForTest(runId, org.id, {
+      queueMs: 50,
+      postClaimMs: 200,
+      pollMs: 30,
+    });
+    expect(out.status).toBe('timeout');
+
+    // Worker arrives late.
+    const wrote = await workerCompleteAction(runId, WORKER_ID, 'success', {
+      foo: 'bar',
+    });
+    expect(wrote).toBe(false); // atomic UPDATE rejected
+
+    const sql = getTestDb();
+    const final = (await sql`
+      SELECT status, action_output FROM runs WHERE id = ${runId}
+    `) as Array<{ status: string; action_output: Record<string, unknown> | null }>;
+    expect(final[0].status).toBe('timeout');
+    expect(final[0].action_output).toBeNull();
+  });
+});

--- a/packages/server/src/tools/admin/manage_operations.ts
+++ b/packages/server/src/tools/admin/manage_operations.ts
@@ -439,10 +439,27 @@ async function handleListAvailable(
 }
 
 // Poll `runs` until status flips to completed/failed/timeout or we hit
-// the timeout deadline. Used by handleExecute when the connector is
-// device-bound — the gateway can't execute inline; it inserts a pending
-// run and waits for the device worker (chrome extension / mac bridge /
+// our deadline. Used by handleExecute when the connector is device-
+// bound — the gateway can't execute inline; it inserts a pending run
+// and waits for the device worker (chrome extension / mac bridge /
 // etc.) to claim, run, and POST /api/workers/complete-action.
+//
+// Deadline strategy: two phases.
+//
+//   - PRE-CLAIM (status='pending'): how long the device has to even
+//     pick the run up. The chrome extension polls /poll every 5s; we
+//     allow up to QUEUE_BUDGET_MS for it to arrive.
+//
+//   - POST-CLAIM (status='running'): how long the device has to
+//     execute, after it claimed the run. The chrome extension's own
+//     per-run watchdog (tools.js RUN_TIMEOUT_MS=90s) caps this; we
+//     allow that + buffer so the gateway never times out a
+//     legitimately-running tool.
+//
+// Without the two-phase split, a slow poll cycle (worker offline for
+// 20-30s) could exhaust a flat-100s deadline before the worker even
+// claimed the run, marking it timeout while the worker was about to
+// pick it up.
 async function waitForDeviceActionRun(
   runId: number,
   organizationId: string
@@ -452,15 +469,15 @@ async function waitForDeviceActionRun(
   error_message?: string;
 }> {
   const sql = getDb();
-  // Hard cap chosen to fit comfortably inside the chrome extension's
-  // 90s per-run watchdog (tools.js RUN_TIMEOUT_MS) plus a 5s buffer for
-  // poll + claim + complete round-trip.
-  const TIMEOUT_MS = 100_000;
+  const QUEUE_BUDGET_MS = 60_000; // generous: device may be sleeping
+  const POST_CLAIM_BUDGET_MS = 95_000; // matches extension's 90s + 5s buffer
   const POLL_MS = 500;
-  const deadline = Date.now() + TIMEOUT_MS;
-  while (Date.now() < deadline) {
+  const queueDeadline = Date.now() + QUEUE_BUDGET_MS;
+  let claimedAtMs: number | null = null;
+
+  while (true) {
     const rows = (await sql`
-      SELECT status, action_output, error_message
+      SELECT status, action_output, error_message, claimed_at
       FROM runs
       WHERE id = ${runId} AND organization_id = ${organizationId}
       LIMIT 1
@@ -468,6 +485,7 @@ async function waitForDeviceActionRun(
       status: string;
       action_output: Record<string, unknown> | null;
       error_message: string | null;
+      claimed_at: Date | string | null;
     }>;
     const row = rows[0];
     if (!row) {
@@ -488,24 +506,71 @@ async function waitForDeviceActionRun(
         error_message: row.error_message ?? `Run ${runId} ${row.status}`,
       };
     }
+    // Still pending or running. Check the right deadline for this phase.
+    if (row.claimed_at && claimedAtMs == null) {
+      claimedAtMs =
+        row.claimed_at instanceof Date
+          ? row.claimed_at.getTime()
+          : new Date(row.claimed_at).getTime();
+    }
+    const now = Date.now();
+    if (claimedAtMs != null) {
+      if (now - claimedAtMs >= POST_CLAIM_BUDGET_MS) break;
+    } else {
+      if (now >= queueDeadline) break;
+    }
     await new Promise((r) => setTimeout(r, POLL_MS));
   }
-  // Best-effort: mark the run as timeout so the next poll doesn't
-  // re-claim it. The device worker's own timeout will eventually post
-  // failed; if it gets there first, this UPDATE is a no-op on a
-  // terminal row.
-  await sql`
+
+  // Atomic timeout finalization. The WHERE clause matches only non-
+  // terminal states; if the worker raced us and posted completion
+  // between our last SELECT and this UPDATE, this UPDATE is a no-op
+  // and we re-read the row to surface the worker's verdict.
+  const updated = (await sql`
     UPDATE runs
     SET status = 'timeout',
         completed_at = current_timestamp,
-        error_message = ${`waitForDeviceActionRun: ${TIMEOUT_MS}ms exceeded`}
+        error_message = ${'waitForDeviceActionRun: device worker did not complete in time'}
     WHERE id = ${runId}
       AND organization_id = ${organizationId}
-      AND status IN ('pending', 'claimed', 'running')
-  `;
+      AND status IN ('pending', 'running')
+    RETURNING id
+  `) as Array<{ id: number }>;
+
+  if (updated.length === 0) {
+    // Worker won the race. Re-read to return whatever it actually said.
+    const finalRows = (await sql`
+      SELECT status, action_output, error_message
+      FROM runs
+      WHERE id = ${runId} AND organization_id = ${organizationId}
+      LIMIT 1
+    `) as Array<{
+      status: string;
+      action_output: Record<string, unknown> | null;
+      error_message: string | null;
+    }>;
+    const final = finalRows[0];
+    if (final?.status === 'completed') {
+      return {
+        status: 'completed',
+        output: (final.action_output ?? {}) as Record<string, unknown>,
+      };
+    }
+    if (final?.status === 'failed') {
+      return {
+        status: 'failed',
+        error_message: final.error_message ?? `Run ${runId} failed`,
+      };
+    }
+    // Shouldn't reach here, but fall through to timeout.
+  }
+
   return {
     status: 'timeout',
-    error_message: `Run ${runId} did not complete within ${TIMEOUT_MS}ms — the chrome-extension / device worker may be offline.`,
+    error_message:
+      claimedAtMs != null
+        ? `Run ${runId} claimed but the device worker didn't finish within ${POST_CLAIM_BUDGET_MS}ms.`
+        : `Run ${runId} was never claimed within ${QUEUE_BUDGET_MS}ms — the chrome-extension / device worker may be offline.`,
   };
 }
 

--- a/packages/server/src/tools/admin/manage_operations.ts
+++ b/packages/server/src/tools/admin/manage_operations.ts
@@ -119,6 +119,12 @@ type ManageOperationsResult =
       metadata?: Record<string, unknown>;
     }
   | { action: 'execute'; run_id: number; status: 'failed'; error_message: string }
+  | {
+      action: 'execute';
+      run_id: number;
+      status: 'timeout';
+      error_message: string;
+    }
   | { action: 'list_runs'; runs: any[]; total: number; limit: number; offset: number }
   | { action: 'get_run'; run: any }
   | { action: 'approve'; approved: true; run_id: number; event_id?: number; message: string }
@@ -432,6 +438,77 @@ async function handleListAvailable(
   };
 }
 
+// Poll `runs` until status flips to completed/failed/timeout or we hit
+// the timeout deadline. Used by handleExecute when the connector is
+// device-bound — the gateway can't execute inline; it inserts a pending
+// run and waits for the device worker (chrome extension / mac bridge /
+// etc.) to claim, run, and POST /api/workers/complete-action.
+async function waitForDeviceActionRun(
+  runId: number,
+  organizationId: string
+): Promise<{
+  status: 'completed' | 'failed' | 'timeout';
+  output?: Record<string, unknown>;
+  error_message?: string;
+}> {
+  const sql = getDb();
+  // Hard cap chosen to fit comfortably inside the chrome extension's
+  // 90s per-run watchdog (tools.js RUN_TIMEOUT_MS) plus a 5s buffer for
+  // poll + claim + complete round-trip.
+  const TIMEOUT_MS = 100_000;
+  const POLL_MS = 500;
+  const deadline = Date.now() + TIMEOUT_MS;
+  while (Date.now() < deadline) {
+    const rows = (await sql`
+      SELECT status, action_output, error_message
+      FROM runs
+      WHERE id = ${runId} AND organization_id = ${organizationId}
+      LIMIT 1
+    `) as Array<{
+      status: string;
+      action_output: Record<string, unknown> | null;
+      error_message: string | null;
+    }>;
+    const row = rows[0];
+    if (!row) {
+      return {
+        status: 'failed',
+        error_message: `Run ${runId} disappeared from runs table while waiting.`,
+      };
+    }
+    if (row.status === 'completed') {
+      return {
+        status: 'completed',
+        output: (row.action_output ?? {}) as Record<string, unknown>,
+      };
+    }
+    if (row.status === 'failed' || row.status === 'timeout') {
+      return {
+        status: row.status as 'failed' | 'timeout',
+        error_message: row.error_message ?? `Run ${runId} ${row.status}`,
+      };
+    }
+    await new Promise((r) => setTimeout(r, POLL_MS));
+  }
+  // Best-effort: mark the run as timeout so the next poll doesn't
+  // re-claim it. The device worker's own timeout will eventually post
+  // failed; if it gets there first, this UPDATE is a no-op on a
+  // terminal row.
+  await sql`
+    UPDATE runs
+    SET status = 'timeout',
+        completed_at = current_timestamp,
+        error_message = ${`waitForDeviceActionRun: ${TIMEOUT_MS}ms exceeded`}
+    WHERE id = ${runId}
+      AND organization_id = ${organizationId}
+      AND status IN ('pending', 'claimed', 'running')
+  `;
+  return {
+    status: 'timeout',
+    error_message: `Run ${runId} did not complete within ${TIMEOUT_MS}ms — the chrome-extension / device worker may be offline.`,
+  };
+}
+
 async function handleExecute(
   args: Extract<OperationsArgs, { action: 'execute' }>,
   env: Env,
@@ -461,13 +538,35 @@ async function handleExecute(
   }
   const shouldQueue = mode === 'approval';
 
+  // Detect device-bound connector by reading the connector definition's
+  // `runtime` field. When set (e.g. chrome-extension, macos, ios), the
+  // connector's execute() lives on a device worker, not on the gateway.
+  // Inline execution would hit the BRIDGE_ONLY throw. Instead, create a
+  // status='pending' run + wait for the worker to claim, complete it,
+  // and persist action_output via /api/workers/complete-action.
+  const defRows = (await sql`
+    SELECT runtime FROM connector_definitions
+    WHERE key = ${connection.connector_key}
+      AND organization_id = ${ctx.organizationId}
+      AND status = 'active'
+    ORDER BY updated_at DESC, id DESC
+    LIMIT 1
+  `) as Array<{ runtime: Record<string, unknown> | null }>;
+  const isDeviceBound = defRows[0]?.runtime != null;
+
+  const approvalMode: 'inline' | 'queued' | 'device' = shouldQueue
+    ? 'queued'
+    : isDeviceBound
+      ? 'device'
+      : 'inline';
+
   const runId = await createConnectorOperationRun({
     organizationId: ctx.organizationId,
     connectionId: connection.id,
     connectorKey: connection.connector_key,
     operationKey: operation.operation_key,
     operationInput: input,
-    approvalMode: shouldQueue ? 'queued' : 'inline',
+    approvalMode,
     requireCompiledCode: operation.backend === 'local_action',
   });
 
@@ -554,6 +653,37 @@ async function handleExecute(
       approval_url: approvalUrl,
       status: 'pending_approval',
       message: `Operation '${operation.name}' requires approval. Share the approval_url with the user to confirm.`,
+    };
+  }
+
+  // Device-bound branch: the run is pending; a device worker (chrome
+  // extension, mac bridge, ...) will claim it via /api/workers/poll and
+  // post completion to /api/workers/complete-action. Poll runs.status
+  // here until it flips to completed/failed/timeout, or we hit the
+  // device-action timeout. Returns action_output on success.
+  if (approvalMode === 'device') {
+    const result = await waitForDeviceActionRun(runId, ctx.organizationId);
+    if (result.status === 'completed') {
+      return {
+        action: 'execute',
+        run_id: runId,
+        status: 'completed',
+        output: result.output ?? {},
+      };
+    }
+    if (result.status === 'timeout') {
+      return {
+        action: 'execute',
+        run_id: runId,
+        status: 'timeout',
+        error_message: result.error_message ?? 'Device action run timed out.',
+      };
+    }
+    return {
+      action: 'execute',
+      run_id: runId,
+      status: 'failed',
+      error_message: result.error_message ?? 'Device action run failed.',
     };
   }
 

--- a/packages/server/src/utils/queue-helpers.ts
+++ b/packages/server/src/utils/queue-helpers.ts
@@ -445,13 +445,24 @@ export async function createConnectorOperationRun(params: {
   connectorKey: string;
   operationKey: string;
   operationInput: Record<string, unknown>;
-  approvalMode: 'inline' | 'queued';
+  /**
+   * - 'inline'  → status='running', approval='auto'. Caller executes
+   *               the connector inline on the gateway (server-side
+   *               connectors only).
+   * - 'queued'  → status='pending', approval='pending'. Waits for human
+   *               approval before any worker can claim.
+   * - 'device'  → status='pending', approval='auto'. Skips human gate,
+   *               waits for a device worker to claim via /poll. Used
+   *               for connectors with `runtime` set (chrome-extension,
+   *               macos bridge, ios bridge). No gateway-side execution.
+   */
+  approvalMode: 'inline' | 'queued' | 'device';
   requireCompiledCode?: boolean;
 }): Promise<number> {
   const sql = getDb();
 
   const approvalStatus = params.approvalMode === 'queued' ? 'pending' : 'auto';
-  const status = params.approvalMode === 'queued' ? 'pending' : 'running';
+  const status = params.approvalMode === 'inline' ? 'running' : 'pending';
 
   // Resolve connector version from connector_definitions
   const defRows = await sql`

--- a/packages/server/src/worker-api.ts
+++ b/packages/server/src/worker-api.ts
@@ -2072,6 +2072,13 @@ export async function completeActionRun(c: Context<{ Bindings: Env }>) {
 
     const sql = getDb();
 
+    // Atomic terminal-state transition. The WHERE clause makes the
+    // UPDATE no-op if the row has already been finalized by another
+    // path (e.g. waitForDeviceActionRun timed out and marked it
+    // 'timeout'). Without this guard, a slow worker could overwrite a
+    // gateway-side timeout decision with success — and the caller has
+    // already returned timeout to its caller, so the action would
+    // double-finalize.
     const updatedRuns = await sql`
       UPDATE runs
       SET status = ${req.status === 'success' ? 'completed' : 'failed'},
@@ -2079,8 +2086,21 @@ export async function completeActionRun(c: Context<{ Bindings: Env }>) {
           action_output = ${req.action_output ? sql.json(req.action_output) : null},
           error_message = ${req.error_message ?? null}
       WHERE id = ${req.run_id}
+        AND status = 'running'
+        AND claimed_by = ${req.worker_id}
       RETURNING organization_id, action_key
     `;
+    if (updatedRuns.length === 0) {
+      // Either the run was already finalized (timeout race) or the
+      // worker isn't the claimant. authorizeRunForWorker already gated
+      // ownership, so this is almost always the timeout race; return
+      // a clear status so the worker's logs are informative.
+      logger.info(
+        { run_id: req.run_id, worker_id: req.worker_id, claimed_status: req.status },
+        '[completeActionRun] no-op: run already in terminal state (likely gateway timeout)'
+      );
+      return c.json({ success: false, reason: 'already_finalized' });
+    }
 
     const organizationId = (updatedRuns[0] as any)?.organization_id;
     const actionKey = (updatedRuns[0] as any)?.action_key ?? 'Action';


### PR DESCRIPTION
## Why

The chrome connector (and any other device-bound connector — Mac
bridge, iOS bridge, future ones) declares `runtime: { platforms: [...] }`
on its definition. Its `execute()` lives on the device worker, not on
the gateway — gateway-side calls throw `BRIDGE_ONLY`.

Today `manage_operations.execute` (the admin / agent / MCP surface for
invoking actions) always took the inline path:
`createConnectorOperationRun({approvalMode: 'inline'})` →
`status='running'` → `executeOperationInline` → `ChromeConnector.execute()`
→ throw. The only way to actually invoke a chrome action end-to-end
was to insert a `runs` row directly via psql.

## What

Adds a third approval mode: **`device`**.

- `createConnectorOperationRun` accepts `'inline' | 'queued' | 'device'`.
  `device` sets `status='pending'` (so the worker poll can claim) and
  `approval_status='auto'` (no human gate).
- `handleExecute` reads `connector_definitions.runtime`. When it's set,
  the run is created with `'device'` mode instead of `'inline'`.
- After insert, the helper `waitForDeviceActionRun` polls `runs.status`
  every 500ms until the row flips to completed / failed / timeout, or
  the 100s deadline elapses. On timeout it best-effort marks the row
  `status='timeout'` so the next poll cycle doesn't re-claim it.
- Result type extended with the `timeout` branch.

## Result

Any caller (MCP tool registered for `chrome.navigate`, the admin tool
`manage_operations.execute`, `lobu chat` invoking via the action API,
a bridge connector composing via the same surface, etc.) now actually
gets a chrome action to run end-to-end on the device worker. The
chrome extension claims the pending run via its existing `/poll` cycle,
executes the tool, posts to `/complete-action` (wired in the prior PR),
and `waitForDeviceActionRun` returns the `action_output` to the caller.

## Tests / verification

- `make build-packages` clean.
- `make typecheck` (strict, matches Dockerfile) clean.
- No DB migration needed — uses existing `runs.status` /
  `runs.approval_status` / `runs.action_output` columns and existing
  worker-pool claim logic.

## Out of scope (real v2 follow-ups)

- Live-context streaming for the watch surface (separate `/live-context`
  endpoint + agent prompt-context integration)
- Frame / OOPIF awareness in accessibility-tree
- ISOLATED-world script injection for stronger tamper resistance
- Origin policy from gateway not caller for chrome actions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Device-backed connector operations now execute asynchronously with polling instead of inline execution.
  * Added timeout detection and handling for device operations with detailed error messaging.
  * Operations can now return a new `timeout` status with associated error information.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lobu-ai/lobu/pull/879?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->