### PR TITLE
chore(chart): align with owletto fork prior to consolidation (Chart.yaml 0.4.0)

### DIFF
--- a/charts/lobu/Chart.yaml
+++ b/charts/lobu/Chart.yaml
@@ -2,7 +2,14 @@ apiVersion: v2
 name: lobu
 description: Lobu self-hosted AI agent platform
 type: application
-version: 7.1.0
+# Chart version is decoupled from the node-package release-please cycle.
+# It continues the numbering established by the previous fork at
+# packages/owletto/deploy/charts/lobu (most recently bumped to 0.3.0 by
+# lobu#878 / owletto#179, the worker-smoke gate). 0.4.0 marks the
+# consolidation: this chart is now the single source of truth and Flux
+# pulls directly from lobu-ai/lobu. See the consolidation PR description
+# for context.
+version: 0.4.0
 appVersion: 7.1.0
 keywords:
   - lobu

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -59,11 +59,6 @@
         {
           "type": "yaml",
           "path": "charts/lobu/Chart.yaml",
-          "jsonpath": "$.version"
-        },
-        {
-          "type": "yaml",
-          "path": "charts/lobu/Chart.yaml",
           "jsonpath": "$.appVersion"
         }
       ]


### PR DESCRIPTION
## Summary

Step 1 of the chart-fork-consolidation plan. Aligns `charts/lobu/` so it can become the single source of truth Flux pulls from, replacing the divergent `packages/owletto/deploy/charts/lobu/` copy.

- **`Chart.yaml` version: 7.1.0 → 0.4.0.** Continues the versioning the owletto fork has been on (lobu#878 / owletto#179 bumped owletto to 0.3.0; 0.4.0 marks the planned Flux repoint). 7.1.0 was an artifact of release-please using the same version as the node packages — that linkage doesn't make sense for a chart consumed by Flux.
- **Decouple chart `version` from release-please** so it can drift independently. `appVersion` stays tracked since it semantically follows the underlying app release.

### Why no template changes

Re-running `helm template` on both charts with prod helmrelease values produces structurally equivalent output. Every diff is either a strict improvement in lobu's chart (named-port `targetPort`, component labels, `terminationGracePeriodSeconds`, more lenient readiness `failureThreshold`, `releaseGates.smokeTest.requiredSchema` schema check, helper-based `lobu.secretName`) or overridden by the prod overlay (resources, `imagePullSecrets` — public `ghcr.io/lobu-ai/lobu-*` images don't need a pull secret — and `PUBLIC_WEB_URL` which the overlay sets explicitly).

### Next steps (separate PRs in owletto)

1. Repoint Flux `lobu-charts` GitRepository at `lobu-ai/lobu` + helmrelease `chart.spec.chart` at `./charts/lobu`.
2. After prod verifies `chartVersion: 0.4.0` from the lobu repo, delete `owletto/deploy/charts/lobu/`.

## Test plan
- [x] `helm lint charts/lobu/` → clean (1 INFO, no errors)
- [x] `helm template summaries-app charts/lobu -f <prod-like-values>` renders without errors
- [x] Render diff vs owletto chart is only cosmetic / strict-improvement / overridden-in-overlay
- [x] `make build-packages` clean
- [x] `make typecheck` clean
- [ ] Confirm intent: re-numbering chart from 7.1.0 down to 0.4.0 and severing release-please's `$.version` tracking is the correct decision

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Helm chart versioning to decouple chart version (0.4.0) from application version (7.1.0).
  * Updated release configuration to align version tracking with application versioning.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lobu-ai/lobu/pull/880?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->