### PR TITLE
fix(server): restore organization_id INSERT in runs-queue (slop revert overshoot)

### DIFF
--- a/packages/server/src/gateway/infrastructure/queue/runs-queue.ts
+++ b/packages/server/src/gateway/infrastructure/queue/runs-queue.ts
@@ -318,6 +318,24 @@ export class RunsQueue implements IMessageQueue {
     // snapshot-route ownership verifier in transcript-routes.ts.
     const actionInput = sql.json(data ?? {});
 
+    // Populate runs.organization_id from the payload. This column is
+    // preexisting (NOT from PR #870's denormalization — that one removed
+    // agent_id+conversation_id only) and is the column the snapshot
+    // verifier checks via `WHERE organization_id = $X` in
+    // isRunOwnedByJwtScope. PR #873's denormalize revert accidentally
+    // dropped organization_id from the INSERT alongside agent_id/
+    // conversation_id, leaving the column NULL on every new chat_message
+    // row. Result: verifier returned false for every snapshot POST,
+    // workers rejected with 403 the moment Phase 5 flipped snapshot
+    // mode to default. Re-add organization_id only.
+    const organizationIdFromPayload =
+      typeof (data as { organizationId?: unknown })?.organizationId ===
+        "string" &&
+      ((data as { organizationId?: string }).organizationId as string).length >
+        0
+        ? (data as { organizationId: string }).organizationId
+        : null;
+
     // Insert + ON-CONFLICT-fallback inside a single transaction so a race
     // between two enqueues with the same idempotency key resolves cleanly.
     // pg_notify happens AFTER commit (otherwise listeners may wake before
@@ -347,9 +365,10 @@ export class RunsQueue implements IMessageQueue {
           run_at,
           priority,
           expires_at,
-          retry_delay_seconds
+          retry_delay_seconds,
+          organization_id
         ) VALUES (
-          $1, $2, $3, $4, $5, $6, 0, 'pending', ${runAtSql}, $7, ${expiresAtSql}, $8
+          $1, $2, $3, $4, $5, $6, 0, 'pending', ${runAtSql}, $7, ${expiresAtSql}, $8, $9
         )
         ON CONFLICT (idempotency_key)
           WHERE idempotency_key IS NOT NULL
@@ -365,6 +384,7 @@ export class RunsQueue implements IMessageQueue {
           maxAttempts,
           priority,
           retryDelaySeconds,
+          organizationIdFromPayload,
         ],
       );
 


### PR DESCRIPTION
## Summary

PR #873's denormalize revert correctly dropped `agent_id` and `conversation_id` from `runs`, but the same change accidentally also removed the preexisting `organization_id` column from the runs INSERT. That left `organization_id` NULL on every newly-enqueued `chat_message` row.

The snapshot-route ownership verifier in `transcript-routes.ts` checks `WHERE organization_id = $X` (see `isRunOwnedByJwtScope`). Against NULL, the verifier returns 0 rows for every new run. Workers hit 403 on snapshot POST as soon as Phase 5 flipped `LOBU_SESSION_STORE` off `"file"` mode, and no `agent_transcript_snapshot` rows landed for new traffic.

## Fix

Re-add `organization_id` only — extracted from the action-input payload. Do not reintroduce `agent_id` / `conversation_id` (those stay JSONB; verifier extracts them on the PK-matched row, which is microseconds).

## Reproducer

Before this fix, running a Telegram message against `@embeddedlobu2bot` in prod:

```
$ tguser send @embeddedlobu2bot "test"
$ psql "$DB" -c "SELECT organization_id, created_at FROM runs WHERE run_type='chat_message' ORDER BY id DESC LIMIT 3;"
 organization_id |          created_at
-----------------+-------------------------------
 NULL            | 2026-05-18 14:32:00+00
 NULL            | 2026-05-18 14:30:00+00
```

Worker logs:
```
[snapshot] verifier returned not-owned for runId=<n> orgId=<o> agentId=<a> → 403
```

After fix (post-rollout, will verify):
```
 organization_id | ...
-----------------+----
 <uuid>          | ...
```

And a fresh row in `agent_transcript_snapshot` for the run.

## Test plan
- [x] `make typecheck` clean
- [x] `make build-packages` clean
- [ ] Codex review
- [ ] Admin-merge
- [ ] New image rollout
- [ ] `tguser send @embeddedlobu2bot` produces snapshot row

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed organization attribution for chat message queue operations to ensure proper data ownership and access control assignment in downstream operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lobu-ai/lobu/pull/883?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->