### PR TITLE
feat(server): broaden CSP frame-ancestors so owletto extension can embed the whole app

### DIFF
--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -325,12 +325,27 @@ app.use('/*', async (c, next) => {
           .filter((entry) => isValidFrameAncestor(entry))
           .join(' ')
       : 'https://lobu.ai https://*.lobu.ai';
-    // /embedded is the Chrome-extension sidepanel target — it must be framable
-    // from any chrome-extension:// origin. Other routes keep the default
-    // 'self' + lobu.ai allowlist so the rest of the app can't be embedded by
-    // arbitrary extensions.
-    const path = new URL(c.req.url).pathname;
-    const extensionAllowed = path === '/embedded' ? ' chrome-extension:' : '';
+    // Owletto for Chrome embeds the whole app in its sidepanel iframe —
+    // not just a stub route, the same UI users get in a regular tab. To
+    // allow that without opening clickjacking risk to every extension on
+    // the user's machine, we narrow the allow to OUR extension ID
+    // (pinned via apps/chrome/manifest.json's `key` field; see
+    // lobu-ai/owletto:apps/chrome/manifest.json).
+    // LOBU_OWLETTO_EXTENSION_IDS takes a comma-separated list so a dev
+    // build with a different manifest key can be allowed alongside the
+    // canonical published one.
+    const extraExtensionIds = (c.env.LOBU_OWLETTO_EXTENSION_IDS ?? '')
+      .split(',')
+      .map((s) => s.trim())
+      .filter((s) => /^[a-p]{32}$/.test(s));
+    const ownedExtensionIds = [
+      // canonical, derived from apps/chrome/manifest.json's `key`
+      'amnnhclgmbldmfcfamonoggjhfidemmm',
+      ...extraExtensionIds,
+    ];
+    const extensionAllowed = ownedExtensionIds
+      .map((id) => ` chrome-extension://${id}`)
+      .join('');
     c.header(
       'Content-Security-Policy',
       `frame-ancestors 'self' ${frameAncestors}${extensionAllowed}`


### PR DESCRIPTION
Companion to [lobu-ai/owletto#TBD](https://github.com/lobu-ai/owletto/pull/178) (`feat/sidepanel-whole-app`).

## Why

The Chrome extension's sidepanel used to iframe `/embedded`, a stub route. The companion PR replaces that with iframing the gateway's root — same UI users get in a regular tab. CSP `frame-ancestors` was scoped to `/embedded` only, so without this change the iframe is refused by Chrome.

## What

- Drop the `path === '/embedded'` check.
- Add the canonical Owletto for Chrome extension ID (`amnnhclgmbldmfcfamonoggjhfidemmm` — derived from the manifest `key` we shipped in PR #172) to `frame-ancestors` for all HTML routes.
- New env var `LOBU_OWLETTO_EXTENSION_IDS` accepts a comma-separated list of additional IDs (validated against Chrome's `^[a-p]{32}$` ID shape) — for dev builds with a different manifest key.

## Still narrow

`frame-ancestors` reads `'self' <https://lobu.ai et al> chrome-extension://amnnhclgmbldmfcfamonoggjhfidemmm`. Arbitrary extensions remain blocked from iframing the app.