### PR TITLE
fix(server): pass organizationId on continuation chat_message enqueues

### DIFF
--- a/packages/server/src/gateway/auth/mcp/resume-after-oauth.ts
+++ b/packages/server/src/gateway/auth/mcp/resume-after-oauth.ts
@@ -67,15 +67,22 @@ export async function postOAuthCompletionPrompt(
 
   // Re-fetch conversation history so the worker session can warm-start with
   // full context even if it got evicted since the 401 was returned.
-  const conversationState = connectionId
-    ? chatInstanceManager?.getInstance(connectionId)?.conversationState
+  const instance = connectionId
+    ? chatInstanceManager?.getInstance(connectionId)
     : undefined;
+  const conversationState = instance?.conversationState;
   const conversationHistory =
     connectionId && conversationState
       ? await conversationState
           .getHistory(connectionId, channelId)
           .catch(() => [])
       : [];
+  // Derive the connection's owning org so the enqueued resume run carries
+  // organization_id — verifier in transcript-routes.ts denies snapshots on
+  // NULL org. Falls through to undefined if the connection isn't currently
+  // tracked (legacy / cross-pod), in which case the resume run lands NULL
+  // and its snapshot is denied; the user can re-send manually.
+  const organizationId = instance?.connection.organizationId ?? undefined;
 
   const scopeSuffix = scope ? ` (granted scopes: ${scope})` : "";
   const messageText =
@@ -92,6 +99,7 @@ export async function postOAuthCompletionPrompt(
     conversationId: conversationId || channelId,
     teamId: teamId ?? platform,
     agentId,
+    organizationId,
     messageId,
     messageText,
     channelId,

--- a/packages/server/src/gateway/connections/chat-instance-manager.ts
+++ b/packages/server/src/gateway/connections/chat-instance-manager.ts
@@ -1549,6 +1549,7 @@ export class ChatInstanceManager {
       channelId: options.channelId,
       teamId: options.teamId,
       agentId: options.agentId,
+      organizationId: connection.organizationId,
       botId: `${name}-platform`,
       platform: name,
       messageText: message,

--- a/packages/server/src/gateway/connections/message-handler-bridge.ts
+++ b/packages/server/src/gateway/connections/message-handler-bridge.ts
@@ -697,6 +697,7 @@ export class MessageHandlerBridge {
         conversationId,
         teamId: teamId || platform,
         agentId,
+        organizationId: this.connection.organizationId,
         messageId,
         messageText: value,
         channelId,


### PR DESCRIPTION
## Summary

PR #883 fixed `runs-queue.ts` to read `organizationId` from the enqueue payload, but **three callers** of `buildMessagePayload` / `enqueueMessage` don't pass it. Result in prod (post-#883): one inbound Telegram message produces 14 `chat_message` rows; only the 2 from the main inbound path get `organization_id`. The other 12 are NULL-org and their snapshots are silently denied by the verifier.

## Reproducer

Before this fix, image `20260518-163118` in prod:
\`\`\`
$ tguser send @embeddedlobu2bot "e2e org_id verify"
$ psql ... "SELECT id, organization_id FROM runs WHERE run_type='chat_message' AND created_at > NOW() - INTERVAL '5 minutes' ORDER BY id;"
 212704 | 8dc12bdd-...  (handleMessage — fixed in #883)
 212705 | 8dc12bdd-...
 212707 | NULL          (continuation — this PR fixes)
 212708 | NULL
 ... 10 more NULLs
\`\`\`

## Three call sites fixed

1. **`message-handler-bridge.ts:693`** (`handleQuestionClick`) — adds `organizationId: this.connection.organizationId` to `buildMessagePayload`. Mirrors the same fix already present at line 529 (`handleMessage`).

2. **`chat-instance-manager.ts:1545`** (`routePlatformChat`, used by `lobu chat` / platform-cli) — adds `organizationId: connection.organizationId` to the direct `enqueueMessage` call. Connection is already in scope.

3. **`resume-after-oauth.ts`** (`postOAuthCompletionPrompt`) — derives `organizationId` from `chatInstanceManager.getInstance(connectionId).connection.organizationId`. No caller change needed; `ManagedInstance` already exposes `connection`. Falls back to `undefined` if connection isn't tracked locally (cross-pod / legacy), preserving existing safe-but-degraded behavior.

## Multi-tenant impact

The verifier in `transcript-routes.ts` runs `WHERE organization_id = $org`, which against NULL returns no rows → snapshot POST 403s. This isn't a cross-tenant leak (NULL never matches a real org), but the affected runs silently lose their transcripts. With this PR, all four message-payload enqueue paths produce rows that pass the verifier.

## Test plan
- [x] `make typecheck` clean
- [x] `make build-packages` clean  
- [ ] After rollout: send 1 Telegram message → check that *all* `chat_message` rows produced (including continuations) carry `organization_id`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced organization context propagation across authentication flows, message routing, and event handling to ensure proper tenant isolation and data consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lobu-ai/lobu/pull/887?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->