### PR TITLE
fix(server): inject organizationId from worker token onto worker-response payloads (4th writer)

### DIFF
--- a/packages/server/src/gateway/auth/mcp/resume-after-oauth.ts
+++ b/packages/server/src/gateway/auth/mcp/resume-after-oauth.ts
@@ -67,15 +67,22 @@ export async function postOAuthCompletionPrompt(
 
   // Re-fetch conversation history so the worker session can warm-start with
   // full context even if it got evicted since the 401 was returned.
-  const conversationState = connectionId
-    ? chatInstanceManager?.getInstance(connectionId)?.conversationState
+  const instance = connectionId
+    ? chatInstanceManager?.getInstance(connectionId)
     : undefined;
+  const conversationState = instance?.conversationState;
   const conversationHistory =
     connectionId && conversationState
       ? await conversationState
           .getHistory(connectionId, channelId)
           .catch(() => [])
       : [];
+  // Derive the connection's owning org so the enqueued resume run carries
+  // organization_id — verifier in transcript-routes.ts denies snapshots on
+  // NULL org. Falls through to undefined if the connection isn't currently
+  // tracked (legacy / cross-pod), in which case the resume run lands NULL
+  // and its snapshot is denied; the user can re-send manually.
+  const organizationId = instance?.connection.organizationId ?? undefined;
 
   const scopeSuffix = scope ? ` (granted scopes: ${scope})` : "";
   const messageText =
@@ -92,6 +99,7 @@ export async function postOAuthCompletionPrompt(
     conversationId: conversationId || channelId,
     teamId: teamId ?? platform,
     agentId,
+    organizationId,
     messageId,
     messageText,
     channelId,

--- a/packages/server/src/gateway/connections/chat-instance-manager.ts
+++ b/packages/server/src/gateway/connections/chat-instance-manager.ts
@@ -1549,6 +1549,7 @@ export class ChatInstanceManager {
       channelId: options.channelId,
       teamId: options.teamId,
       agentId: options.agentId,
+      organizationId: connection.organizationId,
       botId: `${name}-platform`,
       platform: name,
       messageText: message,

--- a/packages/server/src/gateway/connections/message-handler-bridge.ts
+++ b/packages/server/src/gateway/connections/message-handler-bridge.ts
@@ -697,6 +697,7 @@ export class MessageHandlerBridge {
         conversationId,
         teamId: teamId || platform,
         agentId,
+        organizationId: this.connection.organizationId,
         messageId,
         messageText: value,
         channelId,

--- a/packages/server/src/gateway/gateway/index.ts
+++ b/packages/server/src/gateway/gateway/index.ts
@@ -370,18 +370,27 @@ export class WorkerGateway {
     try {
       const body = await c.req.json();
       const { jobId, ...responseData } = body;
+      // Stamp the worker token's owning org onto the response so the row
+      // landed in `thread_response` carries organization_id — the snapshot
+      // ownership verifier in transcript-routes.ts denies POSTs to NULL-org
+      // rows. The worker doesn't know its org (token-scoped, not payload-
+      // scoped) so it relies on the gateway to inject it from the auth.
+      const orgEnriched =
+        auth.tokenData.organizationId && !responseData.organizationId
+          ? { ...responseData, organizationId: auth.tokenData.organizationId }
+          : responseData;
       const enrichedResponse =
         auth.tokenData.connectionId &&
-        (!responseData.platformMetadata ||
-          typeof responseData.platformMetadata === "object")
+        (!orgEnriched.platformMetadata ||
+          typeof orgEnriched.platformMetadata === "object")
           ? {
-              ...responseData,
+              ...orgEnriched,
               platformMetadata: {
-                ...(responseData.platformMetadata || {}),
+                ...(orgEnriched.platformMetadata || {}),
                 connectionId: auth.tokenData.connectionId,
               },
             }
-          : responseData;
+          : orgEnriched;
 
       // Acknowledge job completion if jobId provided
       if (jobId) {


### PR DESCRIPTION
## Summary

PRs #883 + #887 covered three of four `chat_message` enqueue paths:
1. `runs-queue.ts` reads `organizationId` from payload root (#883)
2. `handleQuestionClick` passes it via buildMessagePayload (#887)
3. `routePlatformChat` passes it on direct enqueueMessage (#887)
4. `postOAuthCompletionPrompt` derives it from the chat instance (#887)

**This PR fixes the fourth and dominant path:** `handleWorkerResponse` (gateway route `/worker/response`) forwards the worker's streaming response into the `thread_response` queue. The worker's payload doesn't include `organizationId` (workers don't know their org — that lives on the token). The gateway now injects `auth.tokenData.organizationId` onto the payload before enqueue.

## Reproducer (post-#887, image 20260518-171520)

```
$ tguser send @embeddedlobu2bot "e2e verify"
$ psql -tAc "SELECT id, organization_id IS NOT NULL FROM runs
             WHERE created_at > NOW() - INTERVAL '2 minutes'
               AND run_type='chat_message' ORDER BY id;"
 213003 | t      (inbound — #887)
 213004 | t
 213005 | f      (worker streaming delta — bug)
 213006 | f
 213007 | f
 ... 8 more NULL-org rows
```

After this fix, all 12+ rows from one Telegram message should carry the org.

## Why on the gateway side, not the worker

The worker is by design ignorant of its owning org — the worker JWT carries it and the gateway is the trusted authority. Pushing org into the worker payload would require leaking the token contents to the worker, which is the exact kind of separation we're keeping.

## Test plan
- [x] `make typecheck` clean
- [x] `make build-packages` clean
- [ ] After rollout: 1 Telegram message → all resulting chat_message rows (inbound + 10+ streaming deltas) carry org_id

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured organization context is properly included in message processing across OAuth completion, platform messaging, and click-ingestion workflows to maintain accurate data scoping.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lobu-ai/lobu/pull/888?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->