### PR TITLE
feat(cli,server): LOBU_CONTEXT + lifecycle tag, bump owletto to #185

### DIFF
--- a/packages/cli/src/internal/context.ts
+++ b/packages/cli/src/internal/context.ts
@@ -15,6 +15,11 @@ export interface LobuServerConfig {
   port?: number;
   host?: string;
   dataDir?: string;
+  // "managed" → the Mac menubar (or another lifecycle owner) spawns
+  // `lobu run` for this context. "external" → just connect; never
+  // spawn or kill. Absent → infer from apiUrl: loopback ⇒ managed,
+  // remote ⇒ external. Today only the Mac menubar reads this.
+  lifecycle?: "managed" | "external";
 }
 
 interface LobuContextEntry {
@@ -259,6 +264,9 @@ function normalizeServerConfig(raw: unknown): LobuServerConfig | undefined {
   if (typeof src.dataDir === "string" && src.dataDir.trim()) {
     out.dataDir = src.dataDir.trim();
   }
+  if (src.lifecycle === "managed" || src.lifecycle === "external") {
+    out.lifecycle = src.lifecycle;
+  }
 
   return Object.keys(out).length === 0 ? undefined : out;
 }
@@ -267,7 +275,14 @@ export async function getServerConfig(
   contextName?: string
 ): Promise<LobuServerConfig | undefined> {
   const config = await loadContextConfig();
-  const name = contextName || config.currentContext;
+  // Honor LOBU_CONTEXT the same way resolveContext() does — without this,
+  // a caller that sets the env var to pin a context (e.g. the Mac menubar
+  // spawning `lobu run` with LOBU_CONTEXT=local) gets the server block
+  // from `currentContext` instead, because no contextName was passed.
+  const name =
+    contextName?.trim() ||
+    process.env.LOBU_CONTEXT?.trim() ||
+    config.currentContext;
   return config.contexts[name]?.server;
 }
 

--- a/packages/server/src/utils/user-config.ts
+++ b/packages/server/src/utils/user-config.ts
@@ -22,6 +22,12 @@ export interface UserServerConfig {
   port?: number;
   host?: string;
   dataDir?: string;
+  /// "managed" → the Mac menubar (or another lifecycle owner) spawns
+  /// `lobu run` for this context. "external" → just connect; never
+  /// spawn or kill. Absent → infer from apiUrl: loopback ⇒ managed,
+  /// remote ⇒ external. Today only the Mac menubar reads this; the
+  /// CLI's `lobu run` ignores it.
+  lifecycle?: "managed" | "external";
 }
 
 interface StoredEntry {
@@ -80,6 +86,9 @@ function normalizeServerConfig(raw: unknown): UserServerConfig | undefined {
   }
   if (typeof src.dataDir === 'string' && src.dataDir.trim()) {
     out.dataDir = src.dataDir.trim();
+  }
+  if (src.lifecycle === 'managed' || src.lifecycle === 'external') {
+    out.lifecycle = src.lifecycle;
   }
 
   return Object.keys(out).length === 0 ? undefined : out;


### PR DESCRIPTION
## Summary

Picks up [lobu-ai/owletto#185](https://github.com/lobu-ai/owletto/pull/185) (Mac menubar context picker + per-context Keychain + Start/Stop semantics) and adds the CLI/server hooks the menubar needs.

### CLI / server changes
- **`getServerConfig()` honors `LOBU_CONTEXT`** (in addition to the explicit arg and the config's `currentContext`). Without this, the menubar's spawn of `lobu run` couldn't make the embedded server pick the intended context's `server` block — every run fell back to the operator's CLI default and silently chose PGlite even when a `databaseUrl` was configured for the target context.
- **`LobuServerConfig` + `UserServerConfig` gain `lifecycle?: "managed" | "external"`**. The Mac menubar uses this to decide whether to own the runner's process (Start/Stop) or just connect (Sign in/out). Today only the menubar reads it.

### Submodule
- `packages/owletto`: `fb84cf15` → `970eb500`. Brings in #170 (inline pairing), #172 (manifest key + extension ID), #173 (sidepanel iframe), and #185.

## Test plan
- [x] `make build-packages` clean.
- [x] `make typecheck` clean.
- [x] Owletto.app launches against the new submodule, spawns `server.bundle.mjs` with `LOBU_CONTEXT=local` + `DATABASE_URL=postgresql://…/owletto_local` (verified via `ps eww`).
- [x] Per-context Keychain slots co-exist (`context.local`, `context.lobu`); legacy `oauth-credentials` slot migrated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Server configurations now support an optional lifecycle field to specify server management modes (managed or external), enabling greater flexibility in deployment scenarios.

* **Improvements**
  * Enhanced context selection logic to better prioritize environment variables and improve configuration resolution.

* **Chores**
  * Updated internal dependencies.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lobu-ai/lobu/pull/889?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->