### PR TITLE
chore(chart,docs): fix NOTES.txt ingress key + drop duplicate secrets block

### DIFF
--- a/charts/lobu/templates/NOTES.txt
+++ b/charts/lobu/templates/NOTES.txt
@@ -1,8 +1,8 @@
 Insights Platform has been deployed!
 
 1. Application URL:
-{{- if .Values.ingress.enabled }}
-   https://{{ .Values.ingress.host }}
+{{- if and .Values.ingress.enabled (gt (len .Values.ingress.hosts) 0) }}
+   https://{{ index .Values.ingress.hosts 0 }}
 {{- else }}
    kubectl port-forward svc/{{ include "lobu.fullname" . }}-app {{ .Values.service.port }}:{{ .Values.service.port }}
 {{- end }}

--- a/packages/landing/src/content/docs/deployment/kubernetes.mdx
+++ b/packages/landing/src/content/docs/deployment/kubernetes.mdx
@@ -68,16 +68,7 @@ ingress:
     - lobu.example.com
 ```
 
-Create the referenced secrets before installing:
-
-```bash
-kubectl -n lobu create secret generic lobu-db \
-  --from-literal=uri='postgresql://USER:PASSWORD@HOST:5432/lobu?sslmode=require'
-kubectl -n lobu create secret generic lobu-secrets \
-  --from-literal=JWT_SECRET='replace-with-a-long-random-value' \
-  --from-literal=BETTER_AUTH_SECRET='replace-with-a-long-random-value' \
-  --from-literal=ANTHROPIC_API_KEY='sk-ant-...'
-```
+Make sure the secrets from the [Create secrets](#create-secrets) section above already exist in the target namespace — `values.yaml` references them by name (`lobu-db` and `lobu-secrets`).
 
 Always set `app.env.PUBLIC_WEB_URL` to your public origin (e.g. `https://lobu.example.com`). The server reads this to mint OAuth redirect URIs, webhook callbacks, and invite links; without it those URLs default to `http://localhost:8787` and the install will be broken end-to-end.
 


### PR DESCRIPTION
## Summary

Two CodeRabbit follow-ups from PR #882:

1. `charts/lobu/templates/NOTES.txt` referenced `.Values.ingress.host` (singular), but the chart's values schema uses `.Values.ingress.hosts` (array). Fresh installs rendered the install URL as `https://` with an empty host. Now reads from `index .Values.ingress.hosts 0` when both `ingress.enabled` is true and at least one host is set, falling through to the port-forward hint otherwise.

2. `packages/landing/.../kubernetes.mdx` had the same `kubectl create secret` block twice. The second copy is removed and replaced with a back-reference to the earlier section.

## Verification

\`\`\`
$ helm install --dry-run --debug --generate-name charts/lobu \\
    --set ingress.enabled=true --set 'ingress.hosts={app.example.com}' | grep 'Application URL' -A 1
   Application URL:
   https://app.example.com

$ helm install --dry-run --debug --generate-name charts/lobu \\
    --set ingress.enabled=false | grep 'Application URL' -A 1
   Application URL:
   kubectl port-forward svc/lobu-...-app 8787:8787
\`\`\`

## Test plan
- [x] `make build-packages` clean
- [x] `make typecheck` clean
- [x] Helm renders correctly for both ingress.enabled=true and ingress.enabled=false

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Kubernetes Helm deployment guide with clarified guidance on required Kubernetes Secrets handling during installation.

* **Improvements**
  * Helm chart NOTES template now intelligently displays the application URL only when ingress is enabled and configured with valid hosts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lobu-ai/lobu/pull/890?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->