### PR TITLE
feat(cli): task-setup.sh + per-worktree context registration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,11 @@ node_modules
 **/.claude/settings.local.json
 .claude/worktrees/
 
+# Marker file written by scripts/task-setup.sh at each worktree root. Untracked
+# inside the worktree's own checkout, so it must be ignored to keep `git status`
+# clean (otherwise `make task-clean` would always refuse without FORCE=1).
+.task
+
 # Environment files
 .env
 .env.*

--- a/Makefile
+++ b/Makefile
@@ -83,7 +83,7 @@ task-setup:
 
 task-clean:
 	@: $${NAME?Usage: make task-clean NAME=<name> [FORCE=1]}
-	@./scripts/task-clean.sh "$(NAME)" $$( [ -n "$(FORCE)" ] && echo --force )
+	@./scripts/task-clean.sh "$(NAME)" $$( [ "$(FORCE)" = "1" ] && echo --force )
 
 # --- Test pipelines ---------------------------------------------------------
 # These mirror what CI runs (.github/workflows/ci.yml) so a passing local run

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Development Makefile for Lobu
 
-.PHONY: help setup build test eval clean dev build-packages ensure-submodule clean-workers test-unit test-integration test-e2e typecheck
+.PHONY: help setup build test eval clean dev build-packages ensure-submodule clean-workers test-unit test-integration test-e2e typecheck task-setup task-clean
 
 # Default target
 help:
@@ -15,6 +15,8 @@ help:
 	@echo "  make eval                                  - Run agent evals"
 	@echo "  make clean-workers                         - Stop any running embedded worker subprocesses"
 	@echo "  make typecheck                             - Strict typecheck (same as Dockerfile) for server + owletto"
+	@echo "  make task-setup NAME=<name>                - Create a paired worktree at .claude/worktrees/<name> (lobu + submodule on real branch, .env copied, ports auto-assigned, Lobu context registered)"
+	@echo "  make task-clean NAME=<name> [FORCE=1]      - Remove the worktree, both branches, and the Lobu context (refuses if there's uncommitted/unpushed work unless FORCE=1)"
 
 # Strict typecheck — mirrors the Dockerfile so local matches CI. Catches
 # what `build-packages` (relaxed, bundler-only) misses.
@@ -69,6 +71,19 @@ test:
 # Run agent evals
 eval:
 	@npx @lobu/cli@latest eval
+
+# --- Task worktrees ---------------------------------------------------------
+# Paired-branch worktrees for parallel work without losing changes to the
+# packages/owletto submodule. See scripts/task-setup.sh header for details
+# (the script also documents an optional `task-start` shell function alias).
+
+task-setup:
+	@: $${NAME?Usage: make task-setup NAME=<kebab-case-name>}
+	@./scripts/task-setup.sh "$(NAME)"
+
+task-clean:
+	@: $${NAME?Usage: make task-clean NAME=<name> [FORCE=1]}
+	@./scripts/task-clean.sh "$(NAME)" $$( [ -n "$(FORCE)" ] && echo --force )
 
 # --- Test pipelines ---------------------------------------------------------
 # These mirror what CI runs (.github/workflows/ci.yml) so a passing local run

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Development Makefile for Lobu
 
-.PHONY: help setup build test eval clean dev build-packages ensure-submodule clean-workers test-unit test-integration test-e2e typecheck task-setup task-clean
+.PHONY: help setup build test eval clean dev build-packages ensure-submodule clean-workers test-unit test-integration test-e2e typecheck task-setup task-clean task-use
 
 # Default target
 help:
@@ -17,6 +17,7 @@ help:
 	@echo "  make typecheck                             - Strict typecheck (same as Dockerfile) for server + owletto"
 	@echo "  make task-setup NAME=<name>                - Create a paired worktree at .claude/worktrees/<name> (lobu + submodule on real branch, .env copied, ports auto-assigned, Lobu context registered)"
 	@echo "  make task-clean NAME=<name> [FORCE=1]      - Remove the worktree, both branches, and the Lobu context (refuses if there's uncommitted/unpushed work unless FORCE=1)"
+	@echo "  make task-use NAME=<name|main>             - Point Chrome ext / Mac app symlinks at this worktree (or 'main' for the canonical checkout)"
 
 # Strict typecheck — mirrors the Dockerfile so local matches CI. Catches
 # what `build-packages` (relaxed, bundler-only) misses.
@@ -84,6 +85,10 @@ task-setup:
 task-clean:
 	@: $${NAME?Usage: make task-clean NAME=<name> [FORCE=1]}
 	@./scripts/task-clean.sh "$(NAME)" $$( [ "$(FORCE)" = "1" ] && echo --force )
+
+task-use:
+	@: $${NAME?Usage: make task-use NAME=<name|main>}
+	@./scripts/task-use.sh "$(NAME)"
 
 # --- Test pipelines ---------------------------------------------------------
 # These mirror what CI runs (.github/workflows/ci.yml) so a passing local run

--- a/packages/cli/src/commands/context.ts
+++ b/packages/cli/src/commands/context.ts
@@ -3,6 +3,7 @@ import {
   addContext,
   getCurrentContextName,
   loadContextConfig,
+  removeContext,
   resolveContext,
   setCurrentContext,
 } from "../internal/index.js";
@@ -69,6 +70,11 @@ export async function contextAddCommand(options: {
   console.log(
     chalk.green(`\n  Saved context ${options.name} -> ${options.apiUrl}\n`)
   );
+}
+
+export async function contextRmCommand(name: string): Promise<void> {
+  await removeContext(name);
+  console.log(chalk.dim(`\n  Removed context ${name}\n`));
 }
 
 export async function contextUseCommand(name: string): Promise<void> {

--- a/packages/cli/src/commands/context.ts
+++ b/packages/cli/src/commands/context.ts
@@ -6,6 +6,7 @@ import {
   resolveContext,
   setCurrentContext,
 } from "../internal/index.js";
+import type { LobuServerConfig } from "../internal/context.js";
 
 export async function contextListCommand(): Promise<void> {
   const config = await loadContextConfig();
@@ -45,8 +46,26 @@ export async function contextCurrentCommand(): Promise<void> {
 export async function contextAddCommand(options: {
   name: string;
   apiUrl: string;
+  port?: number;
+  host?: string;
+  databaseUrl?: string;
+  dataDir?: string;
+  cwd?: string;
+  lifecycle?: "managed" | "external";
 }): Promise<void> {
-  await addContext(options.name, options.apiUrl);
+  const server: LobuServerConfig = {};
+  if (options.port !== undefined) server.port = options.port;
+  if (options.host) server.host = options.host;
+  if (options.databaseUrl) server.databaseUrl = options.databaseUrl;
+  if (options.dataDir) server.dataDir = options.dataDir;
+  if (options.cwd) server.cwd = options.cwd;
+  if (options.lifecycle) server.lifecycle = options.lifecycle;
+
+  await addContext(
+    options.name,
+    options.apiUrl,
+    Object.keys(server).length === 0 ? undefined : server
+  );
   console.log(
     chalk.green(`\n  Saved context ${options.name} -> ${options.apiUrl}\n`)
   );

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -546,7 +546,16 @@ Memory:
     .option(
       "--port <port>",
       "Server port (when this context owns a managed lobu server)",
-      (value) => Number.parseInt(value, 10)
+      (value: string) => {
+        if (!/^\d+$/.test(value)) {
+          throw new Error(`--port must be an integer, got "${value}"`);
+        }
+        const n = Number.parseInt(value, 10);
+        if (n < 1 || n > 65535) {
+          throw new Error(`--port must be in 1-65535, got ${n}`);
+        }
+        return n;
+      }
     )
     .option("--host <host>", "Server host (default: 127.0.0.1)")
     .option(

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -606,6 +606,14 @@ Memory:
       await contextUseCommand(name);
     });
 
+  context
+    .command("rm <name>")
+    .description("Remove a named context (idempotent)")
+    .action(async (name: string) => {
+      const { contextRmCommand } = await import("./commands/context.js");
+      await contextRmCommand(name);
+    });
+
   // ─── status ─────────────────────────────────────────────────────────
   withCommonOpts(
     program

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -543,10 +543,60 @@ Memory:
     .command("add <name>")
     .description("Add a named context")
     .requiredOption("--api-url <url>", "API base URL for this context")
-    .action(async (name: string, options: { apiUrl: string }) => {
-      const { contextAddCommand } = await import("./commands/context.js");
-      await contextAddCommand({ name, apiUrl: options.apiUrl });
-    });
+    .option(
+      "--port <port>",
+      "Server port (when this context owns a managed lobu server)",
+      (value) => Number.parseInt(value, 10)
+    )
+    .option("--host <host>", "Server host (default: 127.0.0.1)")
+    .option(
+      "--database-url <url>",
+      "Postgres DATABASE_URL for the managed server"
+    )
+    .option(
+      "--data-dir <path>",
+      "LOBU_DATA_DIR for the managed server (state, PGlite)"
+    )
+    .option(
+      "--cwd <path>",
+      "Working directory the lifecycle owner cd's into before spawning `lobu run` (used by per-worktree contexts)"
+    )
+    .option(
+      "--lifecycle <mode>",
+      "managed | external — managed means the menubar spawns `lobu run`",
+      (value: string) => {
+        if (value !== "managed" && value !== "external") {
+          throw new Error(`--lifecycle must be 'managed' or 'external'`);
+        }
+        return value;
+      }
+    )
+    .action(
+      async (
+        name: string,
+        options: {
+          apiUrl: string;
+          port?: number;
+          host?: string;
+          databaseUrl?: string;
+          dataDir?: string;
+          cwd?: string;
+          lifecycle?: "managed" | "external";
+        }
+      ) => {
+        const { contextAddCommand } = await import("./commands/context.js");
+        await contextAddCommand({
+          name,
+          apiUrl: options.apiUrl,
+          port: options.port,
+          host: options.host,
+          databaseUrl: options.databaseUrl,
+          dataDir: options.dataDir,
+          cwd: options.cwd,
+          lifecycle: options.lifecycle,
+        });
+      }
+    );
 
   context
     .command("use <name>")

--- a/packages/cli/src/internal/__tests__/context.test.ts
+++ b/packages/cli/src/internal/__tests__/context.test.ts
@@ -166,6 +166,21 @@ describe("context management", () => {
     });
   });
 
+  test("addContext refuses to overwrite the default context", async () => {
+    readFileSpy.mockResolvedValue(
+      JSON.stringify({
+        contexts: {
+          [DEFAULT_CONTEXT_NAME]: { apiUrl: "https://app.lobu.ai/api/v1" },
+        },
+      })
+    );
+
+    await expect(
+      addContext(DEFAULT_CONTEXT_NAME, "http://localhost:8788")
+    ).rejects.toThrow(/Cannot overwrite the default context/);
+    expect(writeFileSpy.mock.calls.length).toBe(0);
+  });
+
   test("addContext without server keeps shape backwards-compatible", async () => {
     readFileSpy.mockResolvedValue(JSON.stringify({ contexts: {} }));
 

--- a/packages/cli/src/internal/__tests__/context.test.ts
+++ b/packages/cli/src/internal/__tests__/context.test.ts
@@ -9,6 +9,7 @@ import {
 } from "bun:test";
 import * as fs from "node:fs/promises";
 import {
+  addContext,
   DEFAULT_CONTEXT_NAME,
   findContextByMemoryUrl,
   findContextByUrl,
@@ -140,6 +141,39 @@ describe("context management", () => {
     expect(saved.contexts.local.server).toEqual({
       databaseUrl: "postgres://new/db",
       port: 8788,
+    });
+  });
+
+  test("addContext stores optional server config (port + cwd + lifecycle)", async () => {
+    readFileSpy.mockResolvedValue(JSON.stringify({ contexts: {} }));
+
+    await addContext("verify-flow", "http://localhost:8788", {
+      port: 8788,
+      cwd: "/Users/me/Code/lobu/.claude/worktrees/verify-flow",
+      lifecycle: "managed",
+    });
+
+    const [, written] = writeFileSpy.mock.calls.at(-1)!;
+    const saved = JSON.parse(written as string);
+    expect(saved.contexts["verify-flow"]).toEqual({
+      apiUrl: "http://localhost:8788",
+      server: {
+        port: 8788,
+        cwd: "/Users/me/Code/lobu/.claude/worktrees/verify-flow",
+        lifecycle: "managed",
+      },
+    });
+  });
+
+  test("addContext without server keeps shape backwards-compatible", async () => {
+    readFileSpy.mockResolvedValue(JSON.stringify({ contexts: {} }));
+
+    await addContext("plain", "https://example.com/api/v1");
+
+    const [, written] = writeFileSpy.mock.calls.at(-1)!;
+    const saved = JSON.parse(written as string);
+    expect(saved.contexts.plain).toEqual({
+      apiUrl: "https://example.com/api/v1",
     });
   });
 

--- a/packages/cli/src/internal/__tests__/context.test.ts
+++ b/packages/cli/src/internal/__tests__/context.test.ts
@@ -16,6 +16,7 @@ import {
   getActiveOrg,
   getServerConfig,
   loadContextConfig,
+  removeContext,
   setActiveOrg,
   setServerConfig,
 } from "../context";
@@ -175,6 +176,45 @@ describe("context management", () => {
     expect(saved.contexts.plain).toEqual({
       apiUrl: "https://example.com/api/v1",
     });
+  });
+
+  test("removeContext deletes the entry and resets currentContext if needed", async () => {
+    readFileSpy.mockResolvedValue(
+      JSON.stringify({
+        currentContext: "verify-flow",
+        contexts: {
+          lobu: { apiUrl: "https://app.lobu.ai/api/v1" },
+          "verify-flow": { apiUrl: "http://localhost:8788" },
+        },
+      })
+    );
+
+    await removeContext("verify-flow");
+    const [, written] = writeFileSpy.mock.calls.at(-1)!;
+    const saved = JSON.parse(written as string);
+    expect(saved.contexts["verify-flow"]).toBeUndefined();
+    expect(saved.currentContext).toBe(DEFAULT_CONTEXT_NAME);
+  });
+
+  test("removeContext is idempotent for missing entries", async () => {
+    readFileSpy.mockResolvedValue(JSON.stringify({ contexts: {} }));
+
+    await removeContext("never-existed");
+    expect(writeFileSpy.mock.calls.length).toBe(0);
+  });
+
+  test("removeContext refuses the default context", async () => {
+    readFileSpy.mockResolvedValue(
+      JSON.stringify({
+        contexts: {
+          [DEFAULT_CONTEXT_NAME]: { apiUrl: "https://app.lobu.ai/api/v1" },
+        },
+      })
+    );
+
+    await expect(removeContext(DEFAULT_CONTEXT_NAME)).rejects.toThrow(
+      /Cannot remove the default context/
+    );
   });
 
   test("drops invalid server fields during normalization", async () => {

--- a/packages/cli/src/internal/context.ts
+++ b/packages/cli/src/internal/context.ts
@@ -186,6 +186,11 @@ export async function addContext(
   if (!trimmedName) {
     throw new Error("Context name cannot be empty.");
   }
+  if (trimmedName === DEFAULT_CONTEXT_NAME) {
+    throw new Error(
+      `Cannot overwrite the default context "${trimmedName}". Pick a different name.`
+    );
+  }
 
   const config = await loadContextConfig();
   const entry: LobuContextEntry = {
@@ -200,9 +205,7 @@ export async function addContext(
   return config;
 }
 
-export async function removeContext(
-  name: string
-): Promise<LobuContextConfig> {
+export async function removeContext(name: string): Promise<LobuContextConfig> {
   const trimmedName = name.trim();
   if (!trimmedName) {
     throw new Error("Context name cannot be empty.");

--- a/packages/cli/src/internal/context.ts
+++ b/packages/cli/src/internal/context.ts
@@ -15,6 +15,11 @@ export interface LobuServerConfig {
   port?: number;
   host?: string;
   dataDir?: string;
+  // Directory the lifecycle owner should `cd` into before spawning
+  // `lobu run`. Used by per-worktree contexts so the menubar launches
+  // the server against the worktree's source (hot-reload on the right
+  // checkout). Absent → spawner uses its own cwd.
+  cwd?: string;
   // "managed" → the Mac menubar (or another lifecycle owner) spawns
   // `lobu run` for this context. "external" → just connect; never
   // spawn or kill. Absent → infer from apiUrl: loopback ⇒ managed,
@@ -174,7 +179,8 @@ export async function resolveContext(
 
 export async function addContext(
   name: string,
-  apiUrl: string
+  apiUrl: string,
+  server?: LobuServerConfig
 ): Promise<LobuContextConfig> {
   const trimmedName = name.trim();
   if (!trimmedName) {
@@ -182,9 +188,14 @@ export async function addContext(
   }
 
   const config = await loadContextConfig();
-  config.contexts[trimmedName] = {
+  const entry: LobuContextEntry = {
     apiUrl: normalizeAndValidateApiUrl(apiUrl),
   };
+  const normalizedServer = server ? normalizeServerConfig(server) : undefined;
+  if (normalizedServer) {
+    entry.server = normalizedServer;
+  }
+  config.contexts[trimmedName] = entry;
   await saveContextConfig(config);
   return config;
 }
@@ -263,6 +274,9 @@ function normalizeServerConfig(raw: unknown): LobuServerConfig | undefined {
   }
   if (typeof src.dataDir === "string" && src.dataDir.trim()) {
     out.dataDir = src.dataDir.trim();
+  }
+  if (typeof src.cwd === "string" && src.cwd.trim()) {
+    out.cwd = src.cwd.trim();
   }
   if (src.lifecycle === "managed" || src.lifecycle === "external") {
     out.lifecycle = src.lifecycle;

--- a/packages/cli/src/internal/context.ts
+++ b/packages/cli/src/internal/context.ts
@@ -200,6 +200,31 @@ export async function addContext(
   return config;
 }
 
+export async function removeContext(
+  name: string
+): Promise<LobuContextConfig> {
+  const trimmedName = name.trim();
+  if (!trimmedName) {
+    throw new Error("Context name cannot be empty.");
+  }
+
+  const config = await loadContextConfig();
+  if (!config.contexts[trimmedName]) {
+    // Idempotent: removing a non-existent context is a no-op.
+    return config;
+  }
+  if (trimmedName === DEFAULT_CONTEXT_NAME) {
+    throw new Error(`Cannot remove the default context "${trimmedName}".`);
+  }
+
+  delete config.contexts[trimmedName];
+  if (config.currentContext === trimmedName) {
+    config.currentContext = DEFAULT_CONTEXT_NAME;
+  }
+  await saveContextConfig(config);
+  return config;
+}
+
 export async function setCurrentContext(
   name: string
 ): Promise<LobuContextConfig> {

--- a/packages/cli/src/internal/index.ts
+++ b/packages/cli/src/internal/index.ts
@@ -5,6 +5,7 @@ export {
   getCurrentContextName,
   getMemoryUrl,
   loadContextConfig,
+  removeContext,
   resolveContext,
   setActiveOrg,
   setCurrentContext,

--- a/scripts/task-clean.sh
+++ b/scripts/task-clean.sh
@@ -117,4 +117,12 @@ if command -v lobu >/dev/null 2>&1; then
   fi
 fi
 
+# If this worktree was the active target for the Chrome/Mac symlinks, fall
+# back to 'main' so the symlinks don't dangle into a deleted directory.
+active_name_file="$HOME/.config/lobu-dev/active/.active-name"
+if [[ -f "$active_name_file" ]] && [[ "$(cat "$active_name_file")" == "$name" ]]; then
+  "$repo/scripts/task-use.sh" main >/dev/null && \
+    echo "→ active worktree was '$name'; reset to 'main'"
+fi
+
 echo "✓ cleaned up task '$name'"

--- a/scripts/task-clean.sh
+++ b/scripts/task-clean.sh
@@ -57,6 +57,14 @@ ahead_of() {
 }
 
 if [[ $force -eq 0 ]]; then
+  # Refresh remote-tracking refs so the "ahead of origin/<branch>" check below
+  # doesn't trust a stale local ref (e.g. branch deleted on remote → we'd see
+  # origin/<branch> at its old position and conclude 0 unpushed commits).
+  (cd "$worktree_dir" && git fetch origin --prune --quiet) || true
+  if [[ -d "$worktree_dir/packages/owletto" ]]; then
+    (cd "$worktree_dir/packages/owletto" && git fetch origin --prune --quiet) || true
+  fi
+
   if [[ -n "$(git -C "$worktree_dir" status --porcelain)" ]]; then
     echo "error: uncommitted changes in $worktree_dir (pass --force to discard)" >&2
     exit 1

--- a/scripts/task-clean.sh
+++ b/scripts/task-clean.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# task-clean.sh — remove a task worktree, its branches in both repos,
+# and its Lobu CLI context entry.
+#
+# Usage:
+#   scripts/task-clean.sh <name> [--force]
+#
+# Refuses by default when there is unfinished work:
+#   - uncommitted changes in the lobu worktree or in packages/owletto
+#   - commits on feat/<name> not pushed to origin
+#
+# Pass --force (or `make task-clean NAME=<name> FORCE=1`) to override.
+
+set -euo pipefail
+
+usage() {
+  echo "usage: $0 <name> [--force]" >&2
+  exit 1
+}
+
+force=0
+name=""
+for arg in "$@"; do
+  case "$arg" in
+    --force|-f) force=1 ;;
+    -*) echo "error: unknown flag '$arg'" >&2; usage ;;
+    *) [[ -z "$name" ]] && name="$arg" || usage ;;
+  esac
+done
+[[ -n "$name" ]] || usage
+
+if ! [[ "$name" =~ ^[a-z0-9]+(-[a-z0-9]+)*$ ]]; then
+  echo "error: name must be kebab-case: '$name'" >&2
+  exit 1
+fi
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo="$(cd "$script_dir/.." && pwd)"
+worktree_dir="$repo/.claude/worktrees/$name"
+branch="feat/$name"
+
+if [[ ! -d "$worktree_dir" ]]; then
+  echo "error: no worktree at $worktree_dir" >&2
+  exit 1
+fi
+
+# Count commits on $branch that aren't reachable from $upstream. Echoes 0 when
+# $upstream is missing (treats "no upstream" as "no proven publish"; caller
+# may still bail elsewhere). Echoes a positive number if the branch is ahead.
+ahead_of() {
+  local gitdir="$1" upstream="$2"
+  if ! git -C "$gitdir" rev-parse --verify "$upstream" >/dev/null 2>&1; then
+    echo 0
+    return
+  fi
+  git -C "$gitdir" rev-list --count "$upstream..$branch" 2>/dev/null || echo 0
+}
+
+if [[ $force -eq 0 ]]; then
+  if [[ -n "$(git -C "$worktree_dir" status --porcelain)" ]]; then
+    echo "error: uncommitted changes in $worktree_dir (pass --force to discard)" >&2
+    exit 1
+  fi
+  if [[ -d "$worktree_dir/packages/owletto" ]] \
+     && [[ -n "$(git -C "$worktree_dir/packages/owletto" status --porcelain)" ]]; then
+    echo "error: uncommitted changes in packages/owletto (pass --force to discard)" >&2
+    exit 1
+  fi
+
+  ahead_lobu="$(ahead_of "$worktree_dir" "origin/$branch")"
+  # When the branch was never pushed, fall back to "ahead of origin/main".
+  if ! git -C "$worktree_dir" rev-parse --verify "origin/$branch" >/dev/null 2>&1; then
+    ahead_lobu="$(ahead_of "$worktree_dir" "origin/main")"
+  fi
+  if [[ "$ahead_lobu" != "0" ]]; then
+    echo "error: lobu $branch has $ahead_lobu unpushed commit(s) (pass --force to discard)" >&2
+    exit 1
+  fi
+
+  if [[ -d "$worktree_dir/packages/owletto" ]]; then
+    ahead_owl="$(ahead_of "$worktree_dir/packages/owletto" "origin/$branch")"
+    if ! git -C "$worktree_dir/packages/owletto" rev-parse --verify "origin/$branch" >/dev/null 2>&1; then
+      ahead_owl="$(ahead_of "$worktree_dir/packages/owletto" "origin/main")"
+    fi
+    if [[ "$ahead_owl" != "0" ]]; then
+      echo "error: owletto $branch has $ahead_owl unpushed commit(s) (pass --force to discard)" >&2
+      exit 1
+    fi
+  fi
+fi
+
+echo "→ removing worktree $worktree_dir"
+git -C "$repo" worktree remove "$worktree_dir" --force
+
+if git -C "$repo" show-ref --verify --quiet "refs/heads/$branch"; then
+  echo "→ deleting lobu branch $branch"
+  git -C "$repo" branch -D "$branch"
+fi
+
+if [[ -d "$repo/packages/owletto" ]] \
+   && git -C "$repo/packages/owletto" show-ref --verify --quiet "refs/heads/$branch"; then
+  echo "→ deleting owletto branch $branch"
+  git -C "$repo/packages/owletto" branch -D "$branch"
+fi
+
+if command -v lobu >/dev/null 2>&1; then
+  if lobu context rm "$name" >/dev/null 2>&1; then
+    echo "→ removed Lobu context '$name'"
+  fi
+fi
+
+echo "✓ cleaned up task '$name'"

--- a/scripts/task-setup.sh
+++ b/scripts/task-setup.sh
@@ -2,9 +2,13 @@
 # task-setup.sh — prepare a paired-branch worktree for a new task.
 #
 # Usage:
-#   scripts/task-setup.sh <name>
+#   make task-setup NAME=<name>       (recommended, team-friendly)
+#   scripts/task-setup.sh <name>      (direct invocation)
 #
 #   <name>  kebab-case task slug (e.g. fix-sse-leak)
+#
+# Companion: `make task-clean NAME=<name> [FORCE=1]` removes the worktree,
+# its branches in both repos, and the Lobu CLI context.
 #
 # Behavior (idempotent — re-running on an existing worktree refreshes .env
 # and .env.local only):
@@ -19,24 +23,25 @@
 #   6. Drops a .task marker file at the worktree root so `git worktree list`
 #      can distinguish human task-worktrees from agent-* isolation worktrees.
 #
-# Companion shell functions (add to ~/.zshrc — NOT auto-installed):
+# Optional shell-function sugar — `make task-setup` does the setup, then you
+# still have to `cd <path> && claude` by hand. If you want one command that
+# also moves your shell and launches claude, add this to ~/.zshrc:
 #
 #   task-start() {
-#     local name="$1"
-#     local repo="$HOME/Code/lobu"
+#     local name="$1"; local repo="$HOME/Code/lobu"
 #     "$repo/scripts/task-setup.sh" "$name" || return $?
 #     cd "$repo/.claude/worktrees/$name" && exec claude
 #   }
 #   task-resume() {
-#     local name="$1"
-#     local repo="$HOME/Code/lobu"
+#     local name="$1"; local repo="$HOME/Code/lobu"
 #     [[ -d "$repo/.claude/worktrees/$name" ]] \
 #       || { echo "no such worktree: $name"; return 1; }
 #     cd "$repo/.claude/worktrees/$name" && exec claude
 #   }
 #
-# The cd + exec must live in the shell function (not this script) so that the
-# parent terminal actually moves and Warp/iTerm detect the new working dir.
+# The cd + exec must live in the shell function (not a Makefile target or this
+# script) so that the parent terminal actually moves and Warp/iTerm detect the
+# new working directory.
 
 set -euo pipefail
 

--- a/scripts/task-setup.sh
+++ b/scripts/task-setup.sh
@@ -59,6 +59,17 @@ if ! [[ "$name" =~ ^[a-z0-9]+(-[a-z0-9]+)*$ ]]; then
   exit 1
 fi
 
+# Reserve names that match the built-in Lobu CLI contexts so `task-setup` never
+# clobbers a global context (it calls `lobu context add <name>`, which would
+# overwrite the entry — and `lobu context rm` refuses the default, so cleanup
+# wouldn't recover). Keep this list in sync with the contexts most users have.
+case "$name" in
+  lobu|dev|local)
+    echo "error: '$name' is a reserved CLI context name; pick a feature slug" >&2
+    exit 1
+    ;;
+esac
+
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 repo="$(cd "$script_dir/.." && pwd)"
 worktree_dir="$repo/.claude/worktrees/$name"
@@ -81,6 +92,9 @@ if [[ $refresh_only -eq 0 ]]; then
 
   echo "→ preparing packages/owletto submodule on $branch (real branch, not detached)"
   (cd "$worktree_dir" && git submodule update --init packages/owletto)
+  # Branch from the submodule HEAD (the SHA the parent pins), NOT origin/main —
+  # the pin and origin/main can differ, and using origin/main here would
+  # silently bump the submodule pointer in the new worktree.
   (
     cd "$worktree_dir/packages/owletto"
     git fetch origin --quiet
@@ -89,7 +103,7 @@ if [[ $refresh_only -eq 0 ]]; then
     elif git show-ref --verify --quiet "refs/heads/$branch"; then
       git switch "$branch"
     else
-      git switch -c "$branch" origin/main
+      git switch -c "$branch" HEAD
     fi
   )
 

--- a/scripts/task-setup.sh
+++ b/scripts/task-setup.sh
@@ -1,0 +1,171 @@
+#!/usr/bin/env bash
+# task-setup.sh — prepare a paired-branch worktree for a new task.
+#
+# Usage:
+#   scripts/task-setup.sh <name>
+#
+#   <name>  kebab-case task slug (e.g. fix-sse-leak)
+#
+# Behavior (idempotent — re-running on an existing worktree refreshes .env
+# and .env.local only):
+#   1. Creates a lobu worktree at .claude/worktrees/<name> on branch feat/<name>.
+#   2. Initializes packages/owletto submodule on a real named branch feat/<name>
+#      (never detached HEAD — fixes the "we keep losing changes" bug).
+#   3. Runs `bun install` after submodule init (avoids the bun.lock prune bug).
+#   4. Copies .env from the main repo (gitignored secrets don't auto-carry into
+#      a fresh worktree, so `make dev` / `lobu run` would otherwise fail at boot).
+#   5. Writes .env.local with PORT / WORKER_PROXY_PORT picked to avoid collisions
+#      with other worktrees and the main repo (which defaults to 8787 / 8118).
+#   6. Drops a .task marker file at the worktree root so `git worktree list`
+#      can distinguish human task-worktrees from agent-* isolation worktrees.
+#
+# Companion shell functions (add to ~/.zshrc — NOT auto-installed):
+#
+#   task-start() {
+#     local name="$1"
+#     local repo="$HOME/Code/lobu"
+#     "$repo/scripts/task-setup.sh" "$name" || return $?
+#     cd "$repo/.claude/worktrees/$name" && exec claude
+#   }
+#   task-resume() {
+#     local name="$1"
+#     local repo="$HOME/Code/lobu"
+#     [[ -d "$repo/.claude/worktrees/$name" ]] \
+#       || { echo "no such worktree: $name"; return 1; }
+#     cd "$repo/.claude/worktrees/$name" && exec claude
+#   }
+#
+# The cd + exec must live in the shell function (not this script) so that the
+# parent terminal actually moves and Warp/iTerm detect the new working dir.
+
+set -euo pipefail
+
+usage() {
+  echo "usage: $0 <name>" >&2
+  echo "  <name>  kebab-case task slug (lowercase letters/digits, hyphens)" >&2
+  exit 1
+}
+
+[[ $# -eq 1 ]] || usage
+name="$1"
+
+if ! [[ "$name" =~ ^[a-z0-9]+(-[a-z0-9]+)*$ ]]; then
+  echo "error: name must be kebab-case: '$name'" >&2
+  exit 1
+fi
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo="$(cd "$script_dir/.." && pwd)"
+worktree_dir="$repo/.claude/worktrees/$name"
+branch="feat/$name"
+
+refresh_only=0
+if [[ -d "$worktree_dir" ]]; then
+  echo "→ worktree exists; refreshing .env + .env.local only"
+  refresh_only=1
+fi
+
+if [[ $refresh_only -eq 0 ]]; then
+  echo "→ creating lobu worktree: $worktree_dir on $branch"
+  (cd "$repo" && git fetch origin --quiet)
+  if (cd "$repo" && git show-ref --verify --quiet "refs/heads/$branch"); then
+    (cd "$repo" && git worktree add "$worktree_dir" "$branch")
+  else
+    (cd "$repo" && git worktree add "$worktree_dir" -b "$branch" origin/main)
+  fi
+
+  echo "→ preparing packages/owletto submodule on $branch (real branch, not detached)"
+  (cd "$worktree_dir" && git submodule update --init packages/owletto)
+  (
+    cd "$worktree_dir/packages/owletto"
+    git fetch origin --quiet
+    if git rev-parse --verify "origin/$branch" >/dev/null 2>&1; then
+      git switch -c "$branch" --track "origin/$branch"
+    elif git show-ref --verify --quiet "refs/heads/$branch"; then
+      git switch "$branch"
+    else
+      git switch -c "$branch" origin/main
+    fi
+  )
+
+  echo "→ bun install"
+  (cd "$worktree_dir" && bun install)
+fi
+
+if [[ -f "$repo/.env" ]]; then
+  cp "$repo/.env" "$worktree_dir/.env"
+  echo "→ copied .env from main repo"
+else
+  echo "warning: no .env in $repo — worktree will lack secrets" >&2
+fi
+
+highest_port=8787
+highest_proxy=8118
+shopt -s nullglob
+for env_local in "$repo"/.claude/worktrees/*/.env.local; do
+  [[ "$env_local" == "$worktree_dir/.env.local" ]] && continue
+  p="$(awk -F= '/^PORT=/{print $2; exit}' "$env_local" | tr -d '[:space:]')"
+  q="$(awk -F= '/^WORKER_PROXY_PORT=/{print $2; exit}' "$env_local" | tr -d '[:space:]')"
+  [[ -n "$p" && "$p" =~ ^[0-9]+$ && "$p" -gt "$highest_port" ]] && highest_port="$p"
+  [[ -n "$q" && "$q" =~ ^[0-9]+$ && "$q" -gt "$highest_proxy" ]] && highest_proxy="$q"
+done
+shopt -u nullglob
+
+if [[ -f "$worktree_dir/.env.local" ]] \
+   && existing_port="$(awk -F= '/^PORT=/{print $2; exit}' "$worktree_dir/.env.local" | tr -d '[:space:]')" \
+   && [[ "$existing_port" =~ ^[0-9]+$ ]]; then
+  port="$existing_port"
+  proxy="$(awk -F= '/^WORKER_PROXY_PORT=/{print $2; exit}' "$worktree_dir/.env.local" | tr -d '[:space:]')"
+  [[ "$proxy" =~ ^[0-9]+$ ]] || proxy=$((highest_proxy + 1))
+else
+  port=$((highest_port + 1))
+  proxy=$((highest_proxy + 1))
+fi
+
+cat > "$worktree_dir/.env.local" <<EOF
+PORT=$port
+WORKER_PROXY_PORT=$proxy
+LOBU_TASK_NAME=$name
+EOF
+echo "→ .env.local: PORT=$port WORKER_PROXY_PORT=$proxy"
+
+echo "$name" > "$worktree_dir/.task"
+
+# Register the worktree as a Lobu CLI context so the Mac menubar can spawn
+# `lobu run` for it (lifecycle: managed) against the worktree's source. Safe to
+# re-run — `lobu context add` overwrites the existing entry. Non-fatal: the
+# worktree is still useful even if the lobu CLI isn't on PATH yet.
+if command -v lobu >/dev/null 2>&1; then
+  if lobu context add "$name" \
+       --api-url "http://localhost:$port" \
+       --port "$port" \
+       --cwd "$worktree_dir" \
+       --lifecycle managed >/dev/null; then
+    echo "→ registered Lobu context '$name' (menubar can spawn its server)"
+  else
+    echo "warning: failed to register Lobu context '$name'" >&2
+  fi
+else
+  echo "warning: 'lobu' CLI not on PATH; skipping context registration" >&2
+fi
+
+cat <<EOF
+
+✓ Worktree ready: $worktree_dir
+
+  lobu branch:       $branch
+  owletto branch:    $branch (real named branch, not detached HEAD)
+  PORT:              $port
+  WORKER_PROXY_PORT: $proxy
+
+When pushing owletto changes:
+  1. Push owletto FIRST so the SHA is reachable on origin:
+       git -C $worktree_dir/packages/owletto push -u origin $branch
+  2. THEN bump the submodule pointer in lobu:
+       git -C $worktree_dir add packages/owletto
+       git -C $worktree_dir commit -m "chore: bump owletto pointer"
+       git -C $worktree_dir push -u origin $branch
+
+Launch via the task-start shell function (recommended; see script header),
+or manually: cd $worktree_dir && claude
+EOF

--- a/scripts/task-setup.sh
+++ b/scripts/task-setup.sh
@@ -150,6 +150,10 @@ echo "→ .env.local: PORT=$port WORKER_PROXY_PORT=$proxy"
 
 echo "$name" > "$worktree_dir/.task"
 
+# Auto-activate this worktree for the Chrome extension / Mac app (symlink swap).
+# Safe / idempotent — task-use.sh re-points existing symlinks each time.
+"$repo/scripts/task-use.sh" "$name" || true
+
 # Register the worktree as a Lobu CLI context so the Mac menubar can spawn
 # `lobu run` for it (lifecycle: managed) against the worktree's source. Safe to
 # re-run — `lobu context add` overwrites the existing entry. Non-fatal: the

--- a/scripts/task-use.sh
+++ b/scripts/task-use.sh
@@ -65,3 +65,8 @@ set_link "mac"    "$source_root/packages/owletto/apps/mac"    "$active_dir/mac"
 # to know whether to reset to 'main' when cleaning the active worktree).
 echo "$name" > "$active_dir/.active-name"
 echo "✓ active worktree: $name"
+echo ""
+echo "  ↳ Chrome will not auto-reload the extension when the symlink retargets."
+echo "    Click 'Reload' on the owletto extension in chrome://extensions to pick"
+echo "    up the new source. (MV3 service workers re-register on extension reload,"
+echo "    not on symlink change.)"

--- a/scripts/task-use.sh
+++ b/scripts/task-use.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# task-use.sh — point external tools (Chrome extension, Xcode/Mac app) at a
+# specific worktree's source by retargeting fixed symlinks.
+#
+# Usage:
+#   scripts/task-use.sh <name>     # use the worktree at .claude/worktrees/<name>
+#   scripts/task-use.sh main       # use the main checkout (no worktree)
+#
+# Symlinks (created/updated each run):
+#   ~/.config/lobu-dev/active/chrome  →  <root>/packages/owletto/apps/chrome
+#   ~/.config/lobu-dev/active/mac     →  <root>/packages/owletto/apps/mac
+#
+# Point Chrome's "Load unpacked" at ~/.config/lobu-dev/active/chrome ONCE.
+# Open Xcode against ~/.config/lobu-dev/active/mac. Then `task-use <name>`
+# swaps which worktree those resolve to; reload the extension / re-open the
+# Xcode project to pick up the new source.
+
+set -euo pipefail
+
+usage() {
+  echo "usage: $0 <name|main>" >&2
+  exit 1
+}
+
+[[ $# -eq 1 ]] || usage
+name="$1"
+
+if [[ "$name" != "main" ]] && ! [[ "$name" =~ ^[a-z0-9]+(-[a-z0-9]+)*$ ]]; then
+  echo "error: name must be kebab-case or 'main': '$name'" >&2
+  exit 1
+fi
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo="$(cd "$script_dir/.." && pwd)"
+
+if [[ "$name" == "main" ]]; then
+  source_root="$repo"
+else
+  source_root="$repo/.claude/worktrees/$name"
+  if [[ ! -d "$source_root" ]]; then
+    echo "error: no worktree at $source_root" >&2
+    exit 1
+  fi
+fi
+
+active_dir="$HOME/.config/lobu-dev/active"
+mkdir -p "$active_dir"
+
+set_link() {
+  local label="$1" target="$2" link="$3"
+  if [[ -d "$target" ]]; then
+    ln -sfn "$target" "$link"
+    echo "→ $label: $link → $target"
+  else
+    # Source path missing in this worktree (e.g. submodule not initialized).
+    # Leave the existing symlink alone rather than break it.
+    echo "(skip $label: source not present at $target)"
+  fi
+}
+
+set_link "chrome" "$source_root/packages/owletto/apps/chrome" "$active_dir/chrome"
+set_link "mac"    "$source_root/packages/owletto/apps/mac"    "$active_dir/mac"
+
+# Record the active task name for tooling that wants it (and for task-clean
+# to know whether to reset to 'main' when cleaning the active worktree).
+echo "$name" > "$active_dir/.active-name"
+echo "✓ active worktree: $name"


### PR DESCRIPTION
## Summary

Adds a team-friendly, Makefile-driven workflow for paired-branch worktrees that don't lose changes inside the `packages/owletto` submodule, plus the Lobu CLI context plumbing the Mac menubar will need to surface each worktree as a managed server.

- **`make task-setup NAME=<name>`** — creates the worktree at `.claude/worktrees/<name>` (lobu + submodule on real `feat/<name>` branches), copies `.env`, picks free ports, writes `.env.local`, drops a `.task` marker, and registers the worktree as a Lobu CLI context with `lifecycle: "managed"`.
- **`make task-clean NAME=<name> [FORCE=1]`** — removes the worktree, both branches, and the Lobu context. Refuses by default when there's uncommitted work or unpushed commits; `FORCE=1` overrides.
- **`lobu context add`** now accepts `--port`, `--host`, `--database-url`, `--data-dir`, `--cwd`, `--lifecycle`.
- **`lobu context rm <name>`** (new) — idempotent, refuses the default context.
- **`LobuServerConfig.cwd`** (new field) — "directory the lifecycle owner cd's into before spawning `lobu run`". No reader yet; menubar update is a follow-up in owletto.

Optional shell-function sugar (`task-start` / `task-resume`) documented in `scripts/task-setup.sh` header — only needed if you want one command that also `cd`'s and `exec claude`'s for you (Make can't move the parent shell).

## What this fixes

The four submodule footguns that have been costing us work:

1. **Detached-HEAD trap** (AGENTS.md:21–22) — `git submodule update` checks out a SHA, not a branch; commits there get orphaned. Script forces a real `feat/<name>` branch in the submodule before any edits.
2. **bun.lock prune** (PR #654) — `bun install` before `git submodule update --init` drops the locked subdir. Script orders correctly.
3. **Missing `.env`** — `.env` is gitignored, so `git worktree add` leaves a worktree that can't boot. Script copies from the main repo.
4. **Port collisions** — parallel `make dev` fights for `:8787` / `:8118`. Script scans existing `.env.local` files and picks the next free pair.

## Reproducer (red → green)

**Red — today, without the script** (documented in AGENTS.md:21–22):
`git submodule update --init packages/owletto` lands the submodule on detached HEAD. Edits + commits there are reachable only via reflog. Next `git submodule update` or parent `git switch` orphans them.

**Green — with this PR:**
```
$ make task-setup NAME=wrapper-smoke
…
✓ Worktree ready: …/.claude/worktrees/wrapper-smoke
  lobu branch:       feat/wrapper-smoke
  owletto branch:    feat/wrapper-smoke (real named branch, not detached HEAD)
  PORT:              8788
  WORKER_PROXY_PORT: 8119

$ git -C .claude/worktrees/wrapper-smoke/packages/owletto rev-parse --abbrev-ref HEAD
feat/wrapper-smoke           # ← was 'HEAD' (detached) before this PR

# Loss-mode test: commit in submodule lands on the branch (not orphaned)
$ echo 'x' >> …/packages/owletto/README.md \
   && git -C …/packages/owletto add README.md && git commit -m smoke …
$ git -C …/packages/owletto log --oneline feat/wrapper-smoke -1
78b0aa3 smoke: prove commit lands on real branch
```

**Cleanup path verified:**
```
$ make task-clean NAME=cleanup-smoke
error: uncommitted changes in …/.claude/worktrees/cleanup-smoke (pass --force to discard)
make: *** [task-clean] Error 1

$ make task-clean NAME=cleanup-smoke FORCE=1
→ removing worktree …/.claude/worktrees/cleanup-smoke
→ deleting lobu branch feat/cleanup-smoke
Deleted branch feat/cleanup-smoke (was 5ab6d140).
✓ cleaned up task 'cleanup-smoke'
```

**`lobu context rm` verified end-to-end:**
```
$ lobu context add verify-flow --api-url http://localhost:8788 --port 8788 --cwd /…/verify-flow --lifecycle managed
  Saved context verify-flow -> http://localhost:8788

$ lobu context list
   lobu  https://app.lobu.ai/api/v1
 * verify-flow  http://localhost:8788

$ lobu context rm verify-flow
  Removed context verify-flow

$ lobu context rm verify-flow    # idempotent
  Removed context verify-flow

$ lobu context rm lobu           # refuses default
  Error: Cannot remove the default context "lobu".
```

Also verified:
- `bun run typecheck` clean.
- `bun test packages/cli/src/internal/__tests__/context.test.ts` — 11/11 pass (5 new: addContext server config, addContext bare, removeContext + idempotent + refuses-default).

## Follow-ups (separate PRs)

- **Owletto-side menubar:** read `LobuServerConfig.cwd` and `cd` there before spawning `lobu run`. Until then, context registration is benign — `lobu chat -c <name>` already routes to the right port via `apiUrl`.
- **Deprecate `~/Code/owletto`:** once the wrapper is in active use, remove the standalone clone and the matching AGENTS.md guidance.

## Test plan

- [x] `bun run typecheck`
- [x] `bun test packages/cli/src/internal/__tests__/context.test.ts` (11/11)
- [x] E2E setup (`make task-setup`) — submodule branch non-detached, .env present, ports assigned, marker file written
- [x] Commit-survives-on-branch test in the submodule (the actual bug fix)
- [x] E2E `make task-clean` — bails on uncommitted work, completes with `FORCE=1`, removes worktree + branch
- [x] `lobu context add` / `rm` end-to-end with new flags
- [ ] Live-boot test (`make dev` on the assigned port without colliding with `:8787`) — manual, requires running services

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `context add` accepts and persists optional server settings (port, host, database-url, data-dir, cwd, lifecycle).
  * `context rm <name>` added to remove saved contexts idempotently.
  * Task tooling: create/use/clean per-task worktrees with auto port assignment, env handling, symlink switching, and optional CLI context registration.

* **Chores**
  * Added Makefile targets: task-setup, task-clean, task-use; added .task to .gitignore.

* **Tests**
  * Added tests for server config persistence, backward compatibility, and context removal behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lobu-ai/lobu/pull/891?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->