### PR TITLE
feat(connector-worker,server): heartbeat action+embed_backfill, atomic reaper retries

### DIFF
--- a/db/migrations/20260518070000_runs_heartbeat_inflight_widen.sql
+++ b/db/migrations/20260518070000_runs_heartbeat_inflight_widen.sql
@@ -1,0 +1,33 @@
+-- migrate:up
+
+-- Widen the partial index `idx_runs_heartbeat_inflight` back to all four
+-- connector lanes (sync, action, embed_backfill, auth) now that the
+-- action + embed_backfill executors in
+-- packages/connector-worker/src/daemon/executor.ts actually emit
+-- `client.heartbeat()` (lobu#860). The reaper WHERE clause in
+-- packages/server/src/scheduled/check-stalled-executions.ts mirrors this
+-- set so the bulk UPDATE keeps using this partial index.
+--
+-- History:
+--   20260518010000 — created with the wide four-lane set.
+--   20260518020000 — narrowed to (sync, auth) because action +
+--                    embed_backfill weren't heartbeating; in-flight runs
+--                    were being marked `timeout` mid-flight after 120s.
+--   20260518070000 — this — wide again, paired with the executor change
+--                    that makes those lanes heartbeat.
+
+DROP INDEX IF EXISTS public.idx_runs_heartbeat_inflight;
+
+CREATE INDEX IF NOT EXISTS idx_runs_heartbeat_inflight
+    ON public.runs (last_heartbeat_at)
+    WHERE status IN ('claimed', 'running')
+      AND run_type IN ('sync', 'action', 'embed_backfill', 'auth');
+
+-- migrate:down
+
+DROP INDEX IF EXISTS public.idx_runs_heartbeat_inflight;
+
+CREATE INDEX IF NOT EXISTS idx_runs_heartbeat_inflight
+    ON public.runs (last_heartbeat_at)
+    WHERE status IN ('claimed', 'running')
+      AND run_type IN ('sync', 'auth');

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -3764,7 +3764,7 @@ CREATE INDEX idx_runs_feed ON public.runs USING btree (feed_id);
 -- Name: idx_runs_heartbeat_inflight; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX idx_runs_heartbeat_inflight ON public.runs USING btree (last_heartbeat_at) WHERE ((status = ANY (ARRAY['claimed'::text, 'running'::text])) AND (run_type = ANY (ARRAY['sync'::text, 'auth'::text])));
+CREATE INDEX idx_runs_heartbeat_inflight ON public.runs USING btree (last_heartbeat_at) WHERE ((status = ANY (ARRAY['claimed'::text, 'running'::text])) AND (run_type = ANY (ARRAY['sync'::text, 'action'::text, 'embed_backfill'::text, 'auth'::text])));
 
 --
 -- Name: idx_runs_org; Type: INDEX; Schema: public; Owner: -
@@ -5156,4 +5156,5 @@ INSERT INTO public.schema_migrations (version) VALUES
     ('20260518020000'),
     ('20260518040000'),
     ('20260518050000'),
-    ('20260518060000');
+    ('20260518060000'),
+    ('20260518070000');

--- a/packages/connector-worker/src/__tests__/executor-heartbeat.test.ts
+++ b/packages/connector-worker/src/__tests__/executor-heartbeat.test.ts
@@ -81,6 +81,7 @@ describe('executor heartbeats (lobu#860)', () => {
   // biome-ignore lint/suspicious/noExplicitAny: spy refs
   let setIntervalSpy: any;
   let scheduledIntervals: Array<{ fn: () => Promise<void> | void; ms: number; id: number }>;
+  let intervalsEverScheduledMs: number[];
   let nextId: number;
 
   beforeEach(() => {
@@ -89,11 +90,13 @@ describe('executor heartbeats (lobu#860)', () => {
     executeCompiledConnectorMock.mockClear();
     batchGenerateEmbeddingsMock.mockClear();
 
+    intervalsEverScheduledMs = [];
     setIntervalSpy = spyOn(globalThis, 'setInterval').mockImplementation(
       // biome-ignore lint/suspicious/noExplicitAny: test seam
       ((fn: any, ms: number) => {
         const id = nextId++;
         scheduledIntervals.push({ fn, ms, id });
+        intervalsEverScheduledMs.push(ms);
         return id;
         // biome-ignore lint/suspicious/noExplicitAny: cast for setInterval typing
       }) as any
@@ -148,8 +151,13 @@ describe('executor heartbeats (lobu#860)', () => {
     expect(result.error).toBeUndefined();
     expect(client.__heartbeats).toBeGreaterThanOrEqual(2);
 
-    // 30s cadence: at least one setInterval was registered with ms === 30_000.
-    expect(scheduledIntervals.map((s) => s.ms).concat([30_000])).toContain(30_000);
+    // 30s cadence is the contract with the gateway reaper (default
+    // RUNS_REAPER_STALE_AFTER_SECONDS=120 ÷ 4 ≈ 30s). Assert that
+    // executeActionRun actually used 30_000ms for its setInterval.
+    // `intervalsEverScheduledMs` accumulates across the run, so even
+    // after `finally` clears the interval the registration is still
+    // recorded here.
+    expect(intervalsEverScheduledMs).toContain(30_000);
   });
 
   test('executeEmbedBackfillRun heartbeats at least twice over a 70s simulated run', async () => {

--- a/packages/connector-worker/src/__tests__/executor-heartbeat.test.ts
+++ b/packages/connector-worker/src/__tests__/executor-heartbeat.test.ts
@@ -1,0 +1,222 @@
+/**
+ * Heartbeat coverage for the action + embed_backfill executor lanes.
+ *
+ * lobu#860: PR #859 narrowed the gateway's stale-run reaper to lanes that
+ * actually emit `client.heartbeat()` (sync, auth). This test asserts the
+ * other two connector-worker lanes — `action` (executeActionRun) and
+ * `embed_backfill` (executeEmbedBackfillRun) — now heartbeat on the same
+ * 30s cadence so the reaper can be widened back to all four lanes.
+ *
+ * Strategy: mock the heavy collaborators (`executeCompiledConnector`,
+ * `batchGenerateEmbeddings`) so the executor body resolves quickly, and
+ * drive the registered setInterval manually to simulate the 70s window
+ * (the heartbeat fires at t=30 and t=60, so we should see at least 2
+ * calls to `client.heartbeat`).
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, spyOn, test } from 'bun:test';
+
+// biome-ignore lint/suspicious/noExplicitAny: test seam — module mocks need loose types
+type AnyFn = (...args: any[]) => any;
+
+const executeCompiledConnectorMock = mock<AnyFn>(async () => ({
+  contents: [],
+  checkpoint: null,
+}));
+
+const batchGenerateEmbeddingsMock = mock<AnyFn>(async (texts: string[]) =>
+  texts.map(() => [0.1, 0.2, 0.3])
+);
+
+mock.module('../executor/runtime.js', () => ({
+  executeCompiledConnector: executeCompiledConnectorMock,
+  getActionOutput: () => ({ ok: true }),
+  normalizeEventEnvelope: (e: Record<string, unknown>) => e,
+}));
+
+mock.module('../embeddings.js', () => ({
+  batchGenerateEmbeddings: batchGenerateEmbeddingsMock,
+  generateEmbedding: async () => [0, 0, 0],
+}));
+
+mock.module('../compile-connector.js', () => ({
+  compileConnectorFromFile: async () => 'compiled-code',
+  findBundledConnectorFile: () => '/fake/path',
+}));
+
+mock.module('../executor/subprocess.js', () => ({
+  SubprocessExecutor: class {
+    // biome-ignore lint/suspicious/noExplicitAny: test stub
+    constructor(_opts: any) {}
+  },
+}));
+
+import { executeRun } from '../daemon/executor.js';
+
+function makeStubClient() {
+  const client = {
+    id: 'test-worker',
+    version: 'test',
+    __heartbeats: 0,
+    async heartbeat(_runId: number) {
+      client.__heartbeats += 1;
+    },
+    async stream() {},
+    async complete() {},
+    async completeAction() {},
+    async completeEmbeddings() {},
+    async completeAuth() {},
+    async emitAuthArtifact() {},
+    async pollAuthSignal() {
+      return { signal: null };
+    },
+    async fetchEventsForEmbedding(ids: number[]) {
+      return ids.map((id) => ({ id, title: 't', content: 'c' }));
+    },
+  };
+  return client;
+}
+
+describe('executor heartbeats (lobu#860)', () => {
+  // biome-ignore lint/suspicious/noExplicitAny: spy refs
+  let setIntervalSpy: any;
+  let scheduledIntervals: Array<{ fn: () => Promise<void> | void; ms: number; id: number }>;
+  let nextId: number;
+
+  beforeEach(() => {
+    nextId = 1;
+    scheduledIntervals = [];
+    executeCompiledConnectorMock.mockClear();
+    batchGenerateEmbeddingsMock.mockClear();
+
+    setIntervalSpy = spyOn(globalThis, 'setInterval').mockImplementation(
+      // biome-ignore lint/suspicious/noExplicitAny: test seam
+      ((fn: any, ms: number) => {
+        const id = nextId++;
+        scheduledIntervals.push({ fn, ms, id });
+        return id;
+        // biome-ignore lint/suspicious/noExplicitAny: cast for setInterval typing
+      }) as any
+    );
+    spyOn(globalThis, 'clearInterval').mockImplementation(
+      // biome-ignore lint/suspicious/noExplicitAny: test seam
+      ((id: any) => {
+        scheduledIntervals = scheduledIntervals.filter((s) => s.id !== id);
+      }) as () => void
+    );
+  });
+
+  afterEach(() => {
+    setIntervalSpy?.mockRestore();
+    // biome-ignore lint/suspicious/noExplicitAny: cleanup
+    (globalThis.clearInterval as any).mockRestore?.();
+  });
+
+  // Drive each registered interval `tickCount` times by invoking the
+  // function directly. The executor's setInterval is the only one we
+  // scheduled (via the spy), so this is the heartbeat tick.
+  async function fireIntervalTicks(tickCount: number) {
+    for (let i = 0; i < tickCount; i++) {
+      for (const s of [...scheduledIntervals]) {
+        await s.fn();
+      }
+    }
+  }
+
+  test('executeActionRun heartbeats at least twice over a 70s simulated run', async () => {
+    const client = makeStubClient();
+
+    // Make executeCompiledConnector return only AFTER 2 heartbeat ticks
+    // have fired — simulates the action body taking 60+ seconds.
+    executeCompiledConnectorMock.mockImplementationOnce(async () => {
+      await fireIntervalTicks(2);
+      return { contents: [{ result: { ok: true } }], checkpoint: null };
+    });
+
+    const job = {
+      run_id: 100,
+      run_type: 'action',
+      connector_key: 'fake',
+      action_key: 'do_thing',
+      action_input: {},
+      compiled_code: 'compiled-code',
+      // biome-ignore lint/suspicious/noExplicitAny: minimal job shape
+    } as any;
+
+    // biome-ignore lint/suspicious/noExplicitAny: minimal env
+    const result = await executeRun(client as any, job, {} as any);
+    expect(result.error).toBeUndefined();
+    expect(client.__heartbeats).toBeGreaterThanOrEqual(2);
+
+    // 30s cadence: at least one setInterval was registered with ms === 30_000.
+    expect(scheduledIntervals.map((s) => s.ms).concat([30_000])).toContain(30_000);
+  });
+
+  test('executeEmbedBackfillRun heartbeats at least twice over a 70s simulated run', async () => {
+    const client = makeStubClient();
+
+    batchGenerateEmbeddingsMock.mockImplementationOnce(async (texts: string[]) => {
+      await fireIntervalTicks(2);
+      return texts.map(() => [0.1, 0.2, 0.3]);
+    });
+
+    const job = {
+      run_id: 200,
+      run_type: 'embed_backfill',
+      action_input: { event_ids: [1, 2, 3] },
+      compiled_code: 'compiled-code',
+      // biome-ignore lint/suspicious/noExplicitAny: minimal job
+    } as any;
+
+    // biome-ignore lint/suspicious/noExplicitAny: minimal env
+    const result = await executeRun(client as any, job, {} as any);
+    expect(result.error).toBeUndefined();
+    expect(client.__heartbeats).toBeGreaterThanOrEqual(2);
+  });
+
+  test('heartbeat interval is cleared after a successful action run', async () => {
+    const client = makeStubClient();
+    executeCompiledConnectorMock.mockImplementationOnce(async () => ({
+      contents: [{ result: { ok: true } }],
+      checkpoint: null,
+    }));
+
+    const job = {
+      run_id: 300,
+      run_type: 'action',
+      connector_key: 'fake',
+      action_key: 'do_thing',
+      action_input: {},
+      compiled_code: 'compiled-code',
+      // biome-ignore lint/suspicious/noExplicitAny: minimal job
+    } as any;
+
+    // biome-ignore lint/suspicious/noExplicitAny: minimal env
+    await executeRun(client as any, job, {} as any);
+    // After the run, the heartbeat interval should be cleared on every
+    // path via `finally`.
+    expect(scheduledIntervals.length).toBe(0);
+  });
+
+  test('heartbeat interval is cleared after a failed action run', async () => {
+    const client = makeStubClient();
+    executeCompiledConnectorMock.mockImplementationOnce(async () => {
+      throw new Error('boom');
+    });
+
+    const job = {
+      run_id: 400,
+      run_type: 'action',
+      connector_key: 'fake',
+      action_key: 'do_thing',
+      action_input: {},
+      compiled_code: 'compiled-code',
+      // biome-ignore lint/suspicious/noExplicitAny: minimal job
+    } as any;
+
+    // biome-ignore lint/suspicious/noExplicitAny: minimal env
+    const result = await executeRun(client as any, job, {} as any);
+    expect(result.error).toContain('boom');
+    expect(scheduledIntervals.length).toBe(0);
+  });
+});

--- a/packages/connector-worker/src/daemon/executor.ts
+++ b/packages/connector-worker/src/daemon/executor.ts
@@ -101,7 +101,7 @@ export async function executeRun(
       );
       return { itemsCollected: 0, error: 'watcher run not handled by daemon' };
     case 'embed_backfill':
-      return executeEmbedBackfillRun(client, job, env);
+      return executeEmbedBackfillRun(client, job, env, cfg);
     case 'auth':
       return executeAuthRun(client, job, env, cfg);
     default:
@@ -352,6 +352,21 @@ async function executeActionRun(
 
   console.error(`[executor] Starting action run ${run_id} (${connector_key}/${action_key})`);
 
+  // Heartbeat so the gateway's stale-run reaper doesn't write us off
+  // mid-action. Action runs can legitimately take minutes (LLM calls,
+  // long Playwright sessions, third-party API rate-limit waits); the
+  // reaper's default threshold is 120s, so a 30s heartbeat gives ~3
+  // ticks of grace. Without this the row sits "running" until the worker
+  // process dies, and the lane was previously excluded from the reaper
+  // (lobu#859) because the heartbeat was missing.
+  const heartbeatInterval = setInterval(async () => {
+    try {
+      await client.heartbeat(run_id);
+    } catch (err) {
+      console.error('[executor] Action heartbeat failed:', err);
+    }
+  }, cfg.heartbeatIntervalMs);
+
   try {
     const result = await executeCompiledConnector({
       mode: 'action',
@@ -390,6 +405,8 @@ async function executeActionRun(
     });
 
     return { itemsCollected: 0, error: errorMessage };
+  } finally {
+    clearInterval(heartbeatInterval);
   }
 }
 
@@ -533,7 +550,8 @@ function delay(ms: number): Promise<void> {
 async function executeEmbedBackfillRun(
   client: ExecutorClient,
   job: PollResponse,
-  _env: Env
+  _env: Env,
+  cfg: ExecutorConfig
 ): Promise<{ itemsCollected: number; error?: string }> {
   const { run_id, action_input } = job;
 
@@ -575,6 +593,20 @@ async function executeEmbedBackfillRun(
   }
 
   console.error(`[executor] Starting embed_backfill run ${run_id} for ${eventIds.length} events`);
+
+  // Heartbeat so the gateway's stale-run reaper doesn't time us out.
+  // Embed backfills can run for minutes on large batches (each embedding
+  // call is a network round-trip + GPU/CPU work); the reaper threshold
+  // is 120s, so a 30s heartbeat gives ~3 ticks of grace. This lane was
+  // excluded from the reaper in lobu#859 because the heartbeat was
+  // missing — now folded back in.
+  const heartbeatInterval = setInterval(async () => {
+    try {
+      await client.heartbeat(run_id);
+    } catch (err) {
+      console.error('[executor] Embed backfill heartbeat failed:', err);
+    }
+  }, cfg.heartbeatIntervalMs);
 
   try {
     // Fetch event content from the API
@@ -637,6 +669,8 @@ async function executeEmbedBackfillRun(
     });
 
     return { itemsCollected: 0, error: errorMessage };
+  } finally {
+    clearInterval(heartbeatInterval);
   }
 }
 

--- a/packages/server/src/db/embedded-schema-patches.ts
+++ b/packages/server/src/db/embedded-schema-patches.ts
@@ -880,4 +880,22 @@ export const EMBEDDED_SCHEMA_PATCHES: EmbeddedSchemaPatch[] = [
       `);
     },
   },
+  {
+    id: 'runs-heartbeat-inflight-widen',
+    apply: async (sql) => {
+      // Mirrors db/migrations/20260518070000_runs_heartbeat_inflight_widen.sql.
+      // Widens the partial index + reaper WHERE clause back to all four
+      // connector lanes now that the action + embed_backfill executors
+      // emit client.heartbeat() (lobu#860). Same wide predicate as the
+      // original 20260518010000 patch; the intermediate narrow was a
+      // hotfix for the heartbeat-blind reaping window.
+      await sql.unsafe(`DROP INDEX IF EXISTS public.idx_runs_heartbeat_inflight`);
+      await sql.unsafe(`
+        CREATE INDEX IF NOT EXISTS idx_runs_heartbeat_inflight
+          ON public.runs (last_heartbeat_at)
+          WHERE status IN ('claimed', 'running')
+            AND run_type IN ('sync', 'action', 'embed_backfill', 'auth')
+      `);
+    },
+  },
 ];

--- a/packages/server/src/scheduled/__tests__/stale-run-reaper.test.ts
+++ b/packages/server/src/scheduled/__tests__/stale-run-reaper.test.ts
@@ -69,6 +69,25 @@ async function seedRun(opts: SeedRunOpts): Promise<number> {
   return Number(rows[0].id);
 }
 
+async function seedFeed(feedId: number): Promise<void> {
+  const sql = getDb();
+  // Seed an org-scoped connection + feed at the requested id so the
+  // runs.feed_id FK is satisfied. Each test bumps the id so the
+  // partial-unique-index dedup logic exercises real rows.
+  await sql.unsafe(
+    `INSERT INTO connections (id, organization_id, connector_key, slug, status, created_at)
+     VALUES ($1, $2, 'fake', $3, 'active', current_timestamp)
+     ON CONFLICT (id) DO NOTHING`,
+    [feedId, ORG_ID, `fake-${feedId}`],
+  );
+  await sql.unsafe(
+    `INSERT INTO feeds (id, organization_id, connection_id, feed_key, status, created_at, updated_at)
+     VALUES ($1, $2, $1, 'data', 'active', current_timestamp, current_timestamp)
+     ON CONFLICT (id) DO NOTHING`,
+    [feedId, ORG_ID],
+  );
+}
+
 async function statusOf(runId: number): Promise<string> {
   const sql = getDb();
   const rows = (await sql`SELECT status FROM runs WHERE id = ${runId}`) as unknown as Array<{
@@ -166,27 +185,12 @@ describe('reapStaleRuns — connector lanes', () => {
     expect(await statusOf(staleId)).toBe('timeout');
   });
 
-  test('auth lane is reaped (parity with sync)', async () => {
-    // `auth` heartbeats from executeAuthRun in the connector-worker daemon, so
-    // staleness on `last_heartbeat_at` is a real failure signal there too.
-    const authId = await seedRun({
-      status: 'running',
-      lastHeartbeatAgoSeconds: STALE_THRESHOLD_SECONDS * 3,
-      claimedAtAgoSeconds: STALE_THRESHOLD_SECONDS * 3,
-      runType: 'auth',
-    });
-
-    const result = await reapStaleRuns();
-    expect(result.reaped).toBe(1);
-    expect(await statusOf(authId)).toBe('timeout');
-  });
-
-  test('action and embed_backfill lanes are NOT reaped (they do not heartbeat today)', async () => {
-    // executeActionRun and executeEmbedBackfillRun in
-    // packages/connector-worker/src/daemon/executor.ts never call
-    // client.heartbeat(), so reaping them on `last_heartbeat_at` would kill
-    // in-flight runs after the stale threshold elapses. Until those lanes
-    // emit heartbeats, the reaper must leave them alone.
+  test('action, embed_backfill, auth lanes are reaped (parity with sync)', async () => {
+    // All four connector lanes now emit `client.heartbeat()` from the
+    // out-of-process executor (lobu#860 wired action + embed_backfill;
+    // sync + auth already did). The reaper's WHERE clause covers all
+    // four; staleness on `last_heartbeat_at` is a real failure signal
+    // everywhere.
     const actionId = await seedRun({
       status: 'running',
       lastHeartbeatAgoSeconds: STALE_THRESHOLD_SECONDS * 3,
@@ -199,10 +203,195 @@ describe('reapStaleRuns — connector lanes', () => {
       claimedAtAgoSeconds: STALE_THRESHOLD_SECONDS * 3,
       runType: 'embed_backfill',
     });
+    const authId = await seedRun({
+      status: 'running',
+      lastHeartbeatAgoSeconds: STALE_THRESHOLD_SECONDS * 3,
+      claimedAtAgoSeconds: STALE_THRESHOLD_SECONDS * 3,
+      runType: 'auth',
+    });
 
     const result = await reapStaleRuns();
-    expect(result.reaped).toBe(0);
-    expect(await statusOf(actionId)).toBe('running');
-    expect(await statusOf(embedId)).toBe('running');
+    expect(result.reaped).toBe(3);
+    expect(await statusOf(actionId)).toBe('timeout');
+    expect(await statusOf(embedId)).toBe('timeout');
+    expect(await statusOf(authId)).toBe('timeout');
+  });
+});
+
+describe('reapStaleRuns — atomic timeout + retry (lobu#862)', () => {
+  test('a stale sync run gets timed out AND a retry queued in one statement', async () => {
+    // Seed a stale sync run for a feed. After reapStaleRuns runs, we
+    // should see exactly one timeout + one pending retry for the same
+    // feed — both written in the same CTE so a process crash cannot
+    // leave the row timed out with no retry queued.
+    const feedId = 4242;
+    await seedFeed(feedId);
+    const staleId = await seedRun({
+      status: 'running',
+      lastHeartbeatAgoSeconds: STALE_THRESHOLD_SECONDS * 3,
+      claimedAtAgoSeconds: STALE_THRESHOLD_SECONDS * 3,
+      runType: 'sync',
+      feedId,
+    });
+
+    const result = await reapStaleRuns();
+    expect(result.reaped).toBe(1);
+    expect(result.retriesCreated).toBe(1);
+    expect(await statusOf(staleId)).toBe('timeout');
+
+    const sql = getDb();
+    const retries = (await sql`
+      SELECT id, status FROM runs
+      WHERE feed_id = ${feedId} AND run_type = 'sync' AND status = 'pending'
+    `) as unknown as Array<{ id: number | string; status: string }>;
+    expect(retries.length).toBe(1);
+  });
+
+  test('non-sync stale runs do NOT produce retries (action/embed_backfill/auth)', async () => {
+    // Only sync runs need a re-queue; the other lanes are reaped but
+    // not retried.
+    await seedRun({
+      status: 'running',
+      lastHeartbeatAgoSeconds: STALE_THRESHOLD_SECONDS * 3,
+      claimedAtAgoSeconds: STALE_THRESHOLD_SECONDS * 3,
+      runType: 'action',
+    });
+    await seedRun({
+      status: 'running',
+      lastHeartbeatAgoSeconds: STALE_THRESHOLD_SECONDS * 3,
+      claimedAtAgoSeconds: STALE_THRESHOLD_SECONDS * 3,
+      runType: 'embed_backfill',
+    });
+    await seedRun({
+      status: 'running',
+      lastHeartbeatAgoSeconds: STALE_THRESHOLD_SECONDS * 3,
+      claimedAtAgoSeconds: STALE_THRESHOLD_SECONDS * 3,
+      runType: 'auth',
+    });
+
+    const result = await reapStaleRuns();
+    expect(result.reaped).toBe(3);
+    expect(result.retriesCreated).toBe(0);
+  });
+
+  test('two stale sync runs on the SAME feed produce exactly one retry (dedup via NOT EXISTS)', async () => {
+    // Two stale runs that share a feed_id can only exist if one is in a
+    // terminal status — the partial unique index `idx_runs_active_sync_per_feed`
+    // forbids two simultaneously active syncs per feed. Simulate the
+    // realistic case: a previously-completed sync, plus a stale running
+    // one. The reaper should reap the running one and queue exactly
+    // ONE retry for that feed (not two — the completed one is not
+    // touched).
+    //
+    // This also exercises the dedup-against-itself trap: if the NOT
+    // EXISTS predicate didn't exclude `timed_out.id`, the running row
+    // would dedupe against itself and no retries would be queued.
+    const feedId = 5151;
+    await seedFeed(feedId);
+    // First run already finished — terminal, not in the active set.
+    await seedRun({
+      status: 'completed',
+      lastHeartbeatAgoSeconds: STALE_THRESHOLD_SECONDS * 10,
+      claimedAtAgoSeconds: STALE_THRESHOLD_SECONDS * 10,
+      runType: 'sync',
+      feedId,
+    });
+    const staleId = await seedRun({
+      status: 'running',
+      lastHeartbeatAgoSeconds: STALE_THRESHOLD_SECONDS * 3,
+      claimedAtAgoSeconds: STALE_THRESHOLD_SECONDS * 3,
+      runType: 'sync',
+      feedId,
+    });
+
+    const result = await reapStaleRuns();
+    expect(result.reaped).toBe(1);
+    expect(result.retriesCreated).toBe(1);
+    expect(await statusOf(staleId)).toBe('timeout');
+
+    // Exactly one pending row queued.
+    const sql = getDb();
+    const pending = (await sql`
+      SELECT id FROM runs
+      WHERE feed_id = ${feedId} AND run_type = 'sync' AND status = 'pending'
+    `) as unknown as Array<{ id: number | string }>;
+    expect(pending.length).toBe(1);
+  });
+
+  test('a pending sync that pre-exists prevents a duplicate retry being inserted', async () => {
+    // Edge case: a pending sync exists for the feed, and an unrelated
+    // stale auth run (no feed) is reaped in the same sweep. We should
+    // reap the auth row, and NOT insert any sync retry — the pending
+    // sync already covers the feed.
+    //
+    // (We can't co-exist a stale sync + a pending sync on the same
+    // feed; the partial unique index forbids it. This test uses a
+    // different lane to exercise the negative path.)
+    const feedId = 6262;
+    await seedFeed(feedId);
+    await seedRun({
+      status: 'pending',
+      lastHeartbeatAgoSeconds: null,
+      runType: 'sync',
+      feedId,
+    });
+    const authId = await seedRun({
+      status: 'running',
+      lastHeartbeatAgoSeconds: STALE_THRESHOLD_SECONDS * 3,
+      claimedAtAgoSeconds: STALE_THRESHOLD_SECONDS * 3,
+      runType: 'auth',
+    });
+
+    const result = await reapStaleRuns();
+    expect(result.reaped).toBe(1);
+    // No retry insert: auth lane doesn't queue retries.
+    expect(result.retriesCreated).toBe(0);
+    expect(await statusOf(authId)).toBe('timeout');
+
+    // The pre-existing pending sync stays intact, no duplicates.
+    const sql = getDb();
+    const pending = (await sql`
+      SELECT id FROM runs
+      WHERE feed_id = ${feedId} AND run_type = 'sync' AND status = 'pending'
+    `) as unknown as Array<{ id: number | string }>;
+    expect(pending.length).toBe(1);
+  });
+
+  test('reaper output count and DB state agree (no UPDATE-without-INSERT gap)', async () => {
+    // Reproducer for lobu#862: the previous shape (bulk UPDATE RETURNING
+    // followed by a per-row INSERT loop) could leave a row timed-out
+    // with no retry queued if the process crashed mid-loop. The CTE
+    // version writes both in the same statement, so the SQL engine
+    // guarantees they land together or not at all.
+    //
+    // Seed three stale sync runs for three different feeds. After the
+    // reap there must be exactly three timeouts AND three retries —
+    // observable atomicity from the caller's perspective.
+    const feedIds = [9001, 9002, 9003];
+    for (const feedId of feedIds) {
+      await seedFeed(feedId);
+      await seedRun({
+        status: 'running',
+        lastHeartbeatAgoSeconds: STALE_THRESHOLD_SECONDS * 3,
+        claimedAtAgoSeconds: STALE_THRESHOLD_SECONDS * 3,
+        runType: 'sync',
+        feedId,
+      });
+    }
+
+    const result = await reapStaleRuns();
+    expect(result.reaped).toBe(3);
+    expect(result.retriesCreated).toBe(3);
+
+    const sql = getDb();
+    const counts = (await sql`
+      SELECT status, count(*)::int AS n FROM runs
+      WHERE feed_id IN ${sql(feedIds)} AND run_type = 'sync'
+      GROUP BY status
+      ORDER BY status
+    `) as unknown as Array<{ status: string; n: number }>;
+    const byStatus = Object.fromEntries(counts.map((r) => [r.status, r.n]));
+    expect(byStatus.pending).toBe(3);
+    expect(byStatus.timeout).toBe(3);
   });
 });

--- a/packages/server/src/scheduled/check-stalled-executions.ts
+++ b/packages/server/src/scheduled/check-stalled-executions.ts
@@ -9,15 +9,16 @@
  * reaper those rows sit "running" forever and the feed never gets a retry.
  *
  * Scope:
- *  - `sync`, `auth` — driven by the out-of-process connector-worker daemon
- *    and emit `client.heartbeat()` from their executors. These are the only
- *    lanes safe to reap on a heartbeat-staleness basis today.
- *  - `action`, `embed_backfill` — also connector-worker lanes, but their
- *    executors (`executeActionRun`, `executeEmbedBackfillRun` in
- *    packages/connector-worker/src/daemon/executor.ts) do NOT heartbeat.
- *    Reaping them on `last_heartbeat_at` would kill in-flight runs the
- *    moment they exceed the stale threshold. Tracked as a follow-up — once
- *    those lanes heartbeat, fold them back into the WHERE clause + index.
+ *  - `sync`, `action`, `embed_backfill`, `auth` — all driven by the
+ *    out-of-process connector-worker daemon and all emit
+ *    `client.heartbeat()` from their executors in
+ *    packages/connector-worker/src/daemon/executor.ts. PR lobu#859
+ *    temporarily narrowed this set to `sync` + `auth` because the action
+ *    and embed_backfill executors were silent; lobu#860 wired heartbeats
+ *    into both, so the WHERE clause + partial index widen back to the
+ *    full four-lane set here. The browser-worker (Chrome) lane runs out
+ *    of a service-worker and also heartbeats now (owletto#186) but uses
+ *    its own `chrome.alarms` cadence — it shares this WHERE clause.
  *  - `watcher` — driven in-process by the embedded gateway. Lifecycle is
  *    handled by WatcherRunTracker + the dedicated `sweepStaleWatcherRuns` /
  *    `resetOrphanedWatcherRuns` helpers in watchers/automation.ts.
@@ -40,7 +41,6 @@ import { getDb } from '../db/client';
 import type { Env } from '../index';
 import { expireStaleConnectTokens } from '../utils/connect-tokens';
 import logger from '../utils/logger';
-import { isUniqueViolation } from '../utils/pg-errors';
 import { reconcileWatcherRuns, sweepStaleWatcherRuns } from '../watchers/automation';
 
 /** Advisory-lock key for cross-pod coordination of the stale-run reaper.
@@ -98,77 +98,115 @@ export async function reapStaleRuns(): Promise<ReapStaleRunsResult> {
 
     try {
       const errorMessage = 'worker_heartbeat_lost';
-      // Reap in a single UPDATE so concurrent SELECT-then-UPDATE races inside
-      // the same pod cannot double-fail a row. The advisory lock makes the
-      // cross-pod race impossible too, but belt-and-braces.
+      // Reap + re-queue in a single statement using a CTE: the UPDATE
+      // writes the timeout, and `INSERT ... SELECT ... FROM timed_out`
+      // queues a fresh `pending` sync retry for every reaped `sync` row
+      // that still has a `feed_id`. Doing both in one statement makes
+      // the timeout + retry atomic — if the process crashes after the
+      // statement returns, both writes are durable; if it crashes
+      // before, neither is. The previous shape (bulk UPDATE RETURNING +
+      // per-row INSERT loop) could leave a row in `timeout` with no
+      // retry queued when a crash landed between the two writes (lobu#862).
+      //
+      // The retry INSERT uses `WHERE NOT EXISTS (SELECT 1 FROM runs ...)`
+      // to dedupe against any currently-active sync run on the same
+      // feed. The partial unique index `idx_runs_active_sync_per_feed`
+      // still backs this (it's the same predicate, and the index is
+      // what makes the check cheap); the NOT EXISTS shape avoids
+      // PostgreSQL `ON CONFLICT` inference quirks against partial
+      // unique indexes inside a CTE — which can throw the constraint
+      // violation instead of DO NOTHING. NOT EXISTS evaluates the
+      // dedup predicate against the same snapshot as the surrounding
+      // CTE, so the cross-CTE visibility rule that breaks ON CONFLICT
+      // doesn't apply here.
+      //
+      // The advisory lock still serialises cross-pod sweeps — the CTE
+      // narrows the window to "one transaction tick" but doesn't replace
+      // the lock.
       const reaped = (await reserved`
-        UPDATE public.runs
-        SET status = 'timeout',
-            completed_at = current_timestamp,
-            error_message = ${errorMessage}
-        WHERE run_type IN ('sync', 'auth')
-          AND status IN ('claimed', 'running')
-          AND (
-            (last_heartbeat_at IS NULL
-             AND COALESCE(claimed_at, created_at)
-                 < current_timestamp - (${thresholdSeconds}::int * interval '1 second'))
-            OR
-            (last_heartbeat_at IS NOT NULL
-             AND last_heartbeat_at
-                 < current_timestamp - (${thresholdSeconds}::int * interval '1 second'))
+        WITH timed_out AS (
+          UPDATE public.runs
+          SET status = 'timeout',
+              completed_at = current_timestamp,
+              error_message = ${errorMessage}
+          WHERE run_type IN ('sync', 'action', 'embed_backfill', 'auth')
+            AND status IN ('claimed', 'running')
+            AND (
+              (last_heartbeat_at IS NULL
+               AND COALESCE(claimed_at, created_at)
+                   < current_timestamp - (${thresholdSeconds}::int * interval '1 second'))
+              OR
+              (last_heartbeat_at IS NOT NULL
+               AND last_heartbeat_at
+                   < current_timestamp - (${thresholdSeconds}::int * interval '1 second'))
+            )
+          RETURNING id, run_type, feed_id, connection_id, connector_key, connector_version, organization_id
+        ),
+        retries AS (
+          INSERT INTO public.runs (
+            organization_id, run_type, feed_id, connection_id,
+            connector_key, connector_version, status, approval_status, created_at
           )
-        RETURNING id, run_type, feed_id, connection_id, connector_key, connector_version, organization_id
+          SELECT
+            t.organization_id, 'sync', t.feed_id, t.connection_id,
+            t.connector_key, t.connector_version, 'pending', 'auto', current_timestamp
+          FROM timed_out t
+          WHERE t.run_type = 'sync'
+            AND t.feed_id IS NOT NULL
+            AND NOT EXISTS (
+              -- Look for an unrelated active sync run on the same feed.
+              -- Exclude timed_out.id because in PostgreSQL the sibling
+              -- CTE UPDATE is not visible here (all CTEs see the same
+              -- snapshot), so the row we just reaped still appears as
+              -- running. Without this exclusion, every reap would
+              -- dedupe against itself and no retries would ever land.
+              SELECT 1 FROM public.runs r
+              WHERE r.feed_id = t.feed_id
+                AND r.run_type = 'sync'
+                AND r.status IN ('pending', 'claimed', 'running')
+                AND r.id NOT IN (SELECT id FROM timed_out)
+            )
+          RETURNING id, feed_id
+        )
+        SELECT
+          (SELECT count(*)::int FROM timed_out) AS reaped,
+          (SELECT count(*)::int FROM retries) AS retries_created,
+          (SELECT count(*)::int FROM timed_out
+            WHERE run_type = 'sync' AND feed_id IS NOT NULL) AS sync_eligible
       `) as unknown as Array<{
-        id: number | string;
-        run_type: string;
-        feed_id: number | null;
-        connection_id: number | null;
-        connector_key: string | null;
-        connector_version: string | null;
-        organization_id: string | null;
+        reaped: number;
+        retries_created: number;
+        sync_eligible: number;
       }>;
 
-      if (reaped.length === 0) {
+      const reapedRow = reaped[0];
+      const reapedCount = reapedRow?.reaped ?? 0;
+      const retriesCreated = reapedRow?.retries_created ?? 0;
+      const syncEligible = reapedRow?.sync_eligible ?? 0;
+
+      if (reapedCount === 0) {
         return { acquired: true, reaped: 0, retriesCreated: 0 };
       }
 
       logger.warn(
-        { reaped: reaped.length, thresholdSeconds },
+        { reaped: reapedCount, retriesCreated, thresholdSeconds },
         '[reaper] Marked stale connector runs as timeout (worker_heartbeat_lost)'
       );
 
-      // Re-queue stalled `sync` runs so the feed picks itself back up on the
-      // next worker poll. Same retry semantics as the legacy
-      // checkStalledExecutions path. Unique-violation on the partial
-      // `idx_runs_active_sync_per_feed` index is benign — it means another
-      // active sync row already exists for this feed.
-      let retriesCreated = 0;
-      for (const row of reaped) {
-        if (row.run_type !== 'sync' || !row.feed_id) continue;
-        try {
-          await reserved`
-            INSERT INTO runs (
-              organization_id, run_type, feed_id, connection_id,
-              connector_key, connector_version, status, approval_status, created_at
-            ) VALUES (
-              ${row.organization_id}, 'sync', ${row.feed_id}, ${row.connection_id},
-              ${row.connector_key}, ${row.connector_version}, 'pending', 'auto', current_timestamp
-            )
-          `;
-          retriesCreated += 1;
-        } catch (err) {
-          if (isUniqueViolation(err, 'idx_runs_active_sync_per_feed')) {
-            logger.info(
-              { feedId: row.feed_id },
-              '[reaper] Skipped sync retry — another active sync run exists'
-            );
-          } else {
-            logger.error({ err, runId: row.id }, '[reaper] Failed to insert sync retry');
-          }
-        }
+      // Surface the conflict-dedup count so operators can spot when two
+      // pods are competing for the same stale row across an advisory-
+      // lock release boundary (the only case where `ON CONFLICT DO
+      // NOTHING` should fire on the partial unique index). The delta is
+      // sync-eligible reaped rows that did not produce a retry insert.
+      const skippedRetries = syncEligible - retriesCreated;
+      if (skippedRetries > 0) {
+        logger.info(
+          { count: skippedRetries },
+          '[reaper] Skipped sync retries — another active sync run exists (ON CONFLICT DO NOTHING)'
+        );
       }
 
-      return { acquired: true, reaped: reaped.length, retriesCreated };
+      return { acquired: true, reaped: reapedCount, retriesCreated };
     } finally {
       await reserved`SELECT pg_advisory_unlock(${REAPER_ADVISORY_LOCK_KEY})`;
     }


### PR DESCRIPTION
## Summary

Bundles three coupled fixes around the stale-run reaper:

- **lobu#860** — `executeActionRun` + `executeEmbedBackfillRun` now emit
  `client.heartbeat()` on a 30s interval, mirroring `executeSyncRun` /
  `executeAuthRun`. Both interval lifetimes are cleared in a `finally`
  block.
- **reaper widening** — the `reapStaleRuns` WHERE clause + partial
  index `idx_runs_heartbeat_inflight` widen back to all four connector
  lanes `('sync', 'action', 'embed_backfill', 'auth')`. PR #859 had
  narrowed them as a hotfix because action + embed_backfill weren't
  heartbeating; now they do, so the lane set widens in lockstep.
  New migration `db/migrations/20260518070000_runs_heartbeat_inflight_widen.sql`
  + mirror in `packages/server/src/db/embedded-schema-patches.ts`.
- **lobu#862** — atomic timeout + retry: the previous bulk-UPDATE +
  per-row INSERT loop becomes a single CTE statement. A crash between
  the two writes can no longer leave a row in `timeout` with no retry
  queued.

## Reproducer (lobu#862)

A standalone reproducer simulates the "crash between writes" scenario
by manually running the OLD-shape UPDATE + throwing before the INSERT
loop, then running the NEW-shape `reapStaleRuns`. Output:

```
=== RED: bulk UPDATE + per-row INSERT loop crashing mid-loop ===
  UPDATE reaped 1 row(s)
  Process crashed: SIMULATED CRASH
  DB state after crash: {"timeout":1}
  BUG: timeout=1 but pending=0 — feed is dark

=== GREEN: single-statement CTE via reapStaleRuns ===
  reapStaleRuns returned: reaped=1, retriesCreated=1
  DB state: {"pending":1,"timeout":1}
  FIXED: timeout=1 AND pending=1 — retry queued atomically with the timeout
```

The `reaper output count and DB state agree (no UPDATE-without-INSERT
gap)` test seeds three stale sync runs and asserts exactly 3 timeouts
+ 3 pending retries land — observable atomicity from the caller's view.

## CTE details

The retry INSERT had two PGlite-quirk traps:

1. `ON CONFLICT (feed_id) WHERE ...` is the natural shape against the
   partial unique index `idx_runs_active_sync_per_feed`. PostgreSQL
   does not consistently infer the partial unique index inside a CTE
   and throws the constraint violation instead of DO NOTHING. Switched
   to `WHERE NOT EXISTS (SELECT 1 FROM runs WHERE feed_id = ... AND
   status IN ('pending', 'claimed', 'running'))`.
2. Sibling CTEs see the same snapshot, so the row the sibling CTE is
   timing out still appears as `running` to the NOT EXISTS check. The
   predicate adds `AND r.id NOT IN (SELECT id FROM timed_out)` so a
   reap doesn't dedup against itself.

The advisory lock (`pg_try_advisory_lock(REAPER_ADVISORY_LOCK_KEY)`)
still serialises cross-pod sweeps. A new log line
`[reaper] Skipped sync retries — another active sync run exists` fires
when the dedup branch trips, so operators can spot cross-pod races.

## Test plan

- [x] `bun test packages/connector-worker/src/__tests__/executor-heartbeat.test.ts` — 4/4 pass
- [x] `bun test packages/server/src/scheduled/__tests__/stale-run-reaper.test.ts` — 10/10 pass
- [x] `make typecheck` — clean (strict)
- [x] `make build-packages` — clean
- [x] Reproducer above demonstrates red → green

## Related

- lobu#860 (this fixes)
- lobu#862 (this fixes)
- lobu#861 → owletto#186 (Chrome browser-worker heartbeat, merged
  577f0e06b97a48ec6cdbb7b95ddfe8ece635b703)
- PR #859 (the narrow hotfix this PR widens back from)
- PR #849 (the initial reaper)

## Follow-up

A separate small PR will bump the `packages/owletto` submodule pointer
to pull in owletto#186 once a stable owletto release tag is available.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Heartbeat monitoring enabled for action and embed-backfill runs to improve stalled-execution detection.

* **Bug Fixes**
  * Extended stale-execution detection to cover additional run types.
  * Improved atomicity and deduplication of automatic retry behavior for timed-out runs.

* **Tests**
  * Added tests verifying heartbeat cadence, cleanup, and stale-run reaper behaviors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lobu-ai/lobu/pull/893?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->