### PR TITLE
feat(mac-release): auto-fire on release-please published releases

### DIFF
--- a/.github/workflows/mac-release.yml
+++ b/.github/workflows/mac-release.yml
@@ -203,17 +203,36 @@ jobs:
       # runs carry it on github.event.release.tag_name in the form
       # `lobu-v<X.Y.Z>` (set by release-please). Strip the prefix so the
       # value matches the dispatch input shape.
+      #
+      # Untrusted inputs are passed through `env:` (never interpolated
+      # straight into a `run:` block) and validated against a strict semver
+      # regex before they reach $GITHUB_OUTPUT — a tag like
+      # `lobu-v7.2.0;rm -rf /` would pass the prefix-only job guard but is
+      # rejected here, so downstream steps that interpolate `steps.v.outputs.version`
+      # (notarytool, the release-attach action, the appcast publisher) can't
+      # be tricked into executing shell.
       - name: Resolve version
         id: v
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          DISPATCH_VERSION: ${{ github.event.inputs.version }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            VERSION="${{ github.event.inputs.version }}"
+          set -euo pipefail
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            VERSION="$DISPATCH_VERSION"
           else
-            TAG="${{ github.event.release.tag_name }}"
-            VERSION="${TAG#lobu-v}"
+            VERSION="${RELEASE_TAG#lobu-v}"
           fi
           if [ -z "$VERSION" ]; then
-            echo "::error::Could not resolve a version (event=${{ github.event_name }})"
+            echo "::error::Could not resolve a version (event=$EVENT_NAME)"
+            exit 1
+          fi
+          # Strict semver-ish: digits.digits.digits with an optional `-prerelease`
+          # suffix of alphanum / dot / hyphen. Anything else (shell metachars,
+          # path traversal, whitespace) is rejected.
+          if ! printf '%s' "$VERSION" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$'; then
+            echo "::error::Refusing to use version '$VERSION' — not a valid semver."
             exit 1
           fi
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/mac-release.yml
+++ b/.github/workflows/mac-release.yml
@@ -64,6 +64,13 @@ on:
       version:
         description: 'Release version, e.g. 0.42.0 (must have a lobu-v<version> release)'
         required: true
+  # Auto-fires every time release-please publishes a GitHub Release (which
+  # happens once a `chore(main): release lobu X.Y.Z` PR is merged). The job
+  # guard below filters out anything that isn't a `lobu-v*` tag, so other
+  # release-creating workflows in this repo don't accidentally rebuild the
+  # Mac DMG.
+  release:
+    types: [published]
 
 permissions:
   contents: write
@@ -71,6 +78,9 @@ permissions:
 jobs:
   release:
     runs-on: macos-15
+    if: >-
+      github.event_name == 'workflow_dispatch'
+      || startsWith(github.event.release.tag_name, 'lobu-v')
     steps:
       - uses: actions/checkout@v4
 
@@ -189,9 +199,24 @@ jobs:
             exit 1
           fi
 
+      # workflow_dispatch carries the version as an input; release-triggered
+      # runs carry it on github.event.release.tag_name in the form
+      # `lobu-v<X.Y.Z>` (set by release-please). Strip the prefix so the
+      # value matches the dispatch input shape.
       - name: Resolve version
         id: v
-        run: echo "version=${{ github.event.inputs.version }}" >> "$GITHUB_OUTPUT"
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            VERSION="${{ github.event.inputs.version }}"
+          else
+            TAG="${{ github.event.release.tag_name }}"
+            VERSION="${TAG#lobu-v}"
+          fi
+          if [ -z "$VERSION" ]; then
+            echo "::error::Could not resolve a version (event=${{ github.event_name }})"
+            exit 1
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Detect signing mode
         id: mode

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -48,20 +48,5 @@ jobs:
             --ref main \
             -f bump=skip
 
-  mac:
-    needs: release-please
-    if: ${{ needs.release-please.outputs.release_created == 'true' }}
-    runs-on: ubuntu-latest
-    permissions:
-      # Dispatch mac-release.yml, which builds/signs/notarizes the DMG on macOS
-      # and attaches it to the release-please release.
-      actions: write
-    steps:
-      - name: Trigger mac-release workflow
-        env:
-          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
-        run: |
-          gh workflow run mac-release.yml \
-            --repo ${{ github.repository }} \
-            --ref main \
-            -f version=${{ needs.release-please.outputs.version }}
+  # mac-release.yml now auto-fires on `release: types: [published]` directly,
+  # so this job is no longer needed — see mac-release.yml's `on:` block.


### PR DESCRIPTION
## Summary

Previously \`mac-release.yml\` was \`workflow_dispatch\` only, so every release-please merge needed a follow-up manual \`gh workflow run\` to actually attach the signed Owletto.dmg to the new \`lobu-v<X.Y.Z>\` release.

This PR:

- Adds \`on: release: types: [published]\` alongside the existing dispatch trigger.
- Job guard \`if: github.event_name == 'workflow_dispatch' || startsWith(github.event.release.tag_name, 'lobu-v')\` so unrelated releases (debug tags, future workflows) don't rebuild the Mac DMG.
- \`Resolve version\` step reads from \`github.event.release.tag_name\` (stripping the \`lobu-v\` prefix) when the workflow is triggered by a release event; falls back to the dispatch input otherwise. Fails fast if neither produces a non-empty version.

\`workflow_dispatch\` path is unchanged so manual reruns and ad-hoc versions still work.

## Test plan

- [ ] Merge.
- [ ] Merge release-please PR #863 (\`chore(main): release lobu 7.2.0\`) — that publishes \`lobu-v7.2.0\`.
- [ ] Confirm \`mac-release\` auto-fires on the release event, attaches Owletto.dmg to \`lobu-v7.2.0\`, publishes the Sparkle appcast entry.
- [ ] Manual dispatch with explicit version still works.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * macOS release workflow now auto-triggers for published releases and still supports manual dispatch.
  * Version resolution improved: supports input or release tag, validates and errors on invalid/empty values before continuing.
  * Removed the now-redundant dispatch job from the primary release workflow.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lobu-ai/lobu/pull/895?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->