### PR TITLE
feat(server): local-first identity + single-user mode for bootstrap

### DIFF
--- a/packages/connector-sdk/src/types.ts
+++ b/packages/connector-sdk/src/types.ts
@@ -96,6 +96,11 @@ export interface Env {
   // HTML responses. Defaults to `https://lobu.ai https://*.lobu.ai` when unset.
   FRAME_ANCESTORS?: string;
 
+  // Single-user-mode toggle ("1" enables). When on, blocks /api/auth/sign-up/*
+  // so the bootstrap user can't be forked into a second account. `lobu run`
+  // defaults this on; multi-user deployments leave it unset.
+  LOBU_SINGLE_USER?: string;
+
   // Sync intervals
   DEFAULT_SYNC_INTERVAL_MS?: string;
   DEFAULT_SYNC_INTERVAL_HOURS?: string;

--- a/packages/server/src/auth/index.tsx
+++ b/packages/server/src/auth/index.tsx
@@ -1,5 +1,5 @@
 import { createHash } from "node:crypto";
-import { betterAuth } from "better-auth";
+import { APIError, betterAuth } from "better-auth";
 import { magicLink, organization, phoneNumber } from "better-auth/plugins";
 import { bearer } from "better-auth/plugins/bearer";
 import type { Env } from "../index";
@@ -519,6 +519,33 @@ export async function createAuth(env: Env, request?: Request) {
 			user: {
 				create: {
 					before: async (user) => {
+						// Single-user-mode chokepoint. The /api/auth/* middleware
+						// in index.ts blocks /api/auth/sign-up/*, but Better Auth
+						// also creates users on magic-link verify and on OAuth
+						// callbacks — paths the URL guard never sees. This hook
+						// runs immediately before every user INSERT regardless of
+						// how the request arrived; if LOBU_SINGLE_USER is on and
+						// the deployment already has a user, refuse to create a
+						// second one. Closes the fork-via-magic-link / fork-via-
+						// social-login backdoor codex flagged.
+						if (env.LOBU_SINGLE_USER === "1") {
+							const { getDb } = await import("../db/client");
+							const sql = getDb();
+							const rows = (await sql`
+								SELECT count(*)::int AS count FROM "user"
+							`) as unknown as Array<{ count: number }>;
+							const existing = rows[0]?.count ?? 0;
+							if (existing > 0) {
+								// APIError so Better Auth turns this into a structured
+								// JSON response with the right status code, not an
+								// unhandled 500 with an empty body.
+								throw new APIError("FORBIDDEN", {
+									code: "SIGN_UP_DISABLED_IN_SINGLE_USER_MODE",
+									message:
+										"This install allows exactly one user; sign in to the existing account instead.",
+								});
+							}
+						}
 						if (!user.image && user.email) {
 							return { data: { ...user, image: gravatarUrl(user.email) } };
 						}

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -499,8 +499,38 @@ app.get('/health/scheduler', async (c) => {
 /**
  * Better-Auth routes
  * Handles all authentication requests: OAuth, magic link, phone OTP, sessions
+ *
+ * Single-user-mode guard (`LOBU_SINGLE_USER=1`): blocks new credential/social
+ * sign-ups so the bootstrap user can't be forked into a second account.
+ * Without this guard, a fresh PGlite install where the operator visits
+ * `/sign-up` ends up with `bootstrap-user` (used by the Mac app + CLI) AND
+ * the new real user (used by the web UI) — same machine, two identities,
+ * orphaned worker rows and personal orgs. The Mac app's saved bearer keeps
+ * working as `bootstrap-user` while the web UI shows the new account, and
+ * nothing migrates between them.
+ *
+ * Sign-IN still works (so the operator can log into the bootstrap user with
+ * the printed credentials). Sign-OUT, magic-link, OTP, OAuth-callback, etc.
+ * also pass through — only the sign-up entry points are blocked.
  */
 app.on(['GET', 'POST'], '/api/auth/*', async (c) => {
+  if (c.env.LOBU_SINGLE_USER === '1' && c.req.method === 'POST') {
+    const path = new URL(c.req.url).pathname;
+    if (
+      path === '/api/auth/sign-up/email' ||
+      path === '/api/auth/sign-up' ||
+      path.startsWith('/api/auth/sign-up/')
+    ) {
+      return c.json(
+        {
+          error: 'sign_up_disabled_in_single_user_mode',
+          error_description:
+            'This install is in single-user mode. Sign in with the bootstrap credentials printed by `lobu run`, or unset LOBU_SINGLE_USER to allow additional accounts.',
+        },
+        403
+      );
+    }
+  }
   const auth = await createAuth(c.env, c.req.raw);
   // better-call crashes with "Unexpected end of JSON input" when a POST has
   // Content-Type: application/json but an empty body. Ensure a valid body.

--- a/packages/server/src/start-local.ts
+++ b/packages/server/src/start-local.ts
@@ -14,16 +14,17 @@
 // asserts on load, so this must be the first import; see assert-node-version.ts.
 import './utils/assert-node-version';
 
-import { fork } from 'node:child_process';
+import { fork, spawnSync } from 'node:child_process';
 import { randomBytes } from 'node:crypto';
 import { existsSync, mkdirSync } from 'node:fs';
 import http from 'node:http';
 import { createRequire } from 'node:module';
-import { homedir } from 'node:os';
+import os, { homedir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import dotenv from 'dotenv';
+import { z } from 'zod';
 
 dotenv.config();
 
@@ -108,6 +109,15 @@ async function main() {
   }
   process.env.PGSSLMODE = 'disable';
   process.env.LOBU_DISABLE_PREPARE = '1';
+  // Single-user mode default: the embedded runner spawns its own PGlite,
+  // seeds a single bootstrap user, and is expected to be used by exactly
+  // one operator on one machine. Block additional sign-ups so the
+  // operator can't accidentally fork into a second account (one for the
+  // Mac app + CLI, one for the web UI) by visiting /sign-up. Operators
+  // who actually want multi-user mode set LOBU_SINGLE_USER=0 explicitly.
+  if (process.env.LOBU_SINGLE_USER === undefined) {
+    process.env.LOBU_SINGLE_USER = '1';
+  }
 
   // ─── PGlite ──────────────────────────────────────────────────
 
@@ -356,10 +366,11 @@ async function applyEmbeddedSchemaPatches(sql: MigrationSqlClient) {
 // `session` table on issuance, the `user` row here on seeding.
 
 const BOOTSTRAP_USER_ID = 'bootstrap-user';
-// Needs a dotted domain — better-auth's email validator rejects bare `dev@local`.
-const BOOTSTRAP_USER_EMAIL = 'dev@lobu.local';
-const BOOTSTRAP_USER_NAME = 'Local Developer';
-const BOOTSTRAP_USERNAME = 'dev-local';
+// Fallback identity when no env override / git config is available. Needs a
+// dotted domain — better-auth's email validator rejects bare `dev@local`.
+const BOOTSTRAP_DEFAULT_EMAIL = 'dev@lobu.local';
+const BOOTSTRAP_DEFAULT_NAME = 'Local Developer';
+const BOOTSTRAP_DEFAULT_USERNAME = 'dev-local';
 const BOOTSTRAP_ORG_ID = 'org-bootstrap-dev';
 const BOOTSTRAP_ORG_SLUG = 'dev';
 const BOOTSTRAP_ORG_NAME = 'Local Dev';
@@ -369,6 +380,82 @@ const BOOTSTRAP_MEMBER_ID = 'member-bootstrap-dev';
 // Must be >= 8 chars to satisfy the web login form's minlength validation.
 const BOOTSTRAP_PASSWORD = 'lobudev123';
 const BOOTSTRAP_ACCOUNT_ID = 'account-bootstrap-dev';
+
+interface BootstrapIdentity {
+  email: string;
+  name: string;
+  username: string;
+}
+
+/**
+ * Pick the bootstrap user's identity for a fresh local install.
+ *
+ * Order of preference:
+ *   1. `LOBU_LOCAL_EMAIL` / `LOBU_LOCAL_NAME` env vars (operator-set).
+ *   2. `git config user.email` / `git config user.name` (most likely correct
+ *      for the dev running `lobu run` out of a checkout).
+ *   3. `${USER}@${hostname}.local` fallback (no Apple Push push-mail goes
+ *      anywhere — better-auth just needs a dotted domain).
+ *   4. The original `dev@lobu.local` / "Local Developer" defaults.
+ *
+ * The bootstrap user only exists on a fresh PGlite install and is gated to
+ * loopback, so a wrong-guess email here can't reach a real mailbox. The
+ * point is to show the operator's actual identity in the menubar + web UI
+ * instead of a hardcoded placeholder.
+ */
+function pickBootstrapIdentity(): BootstrapIdentity {
+  const envEmail = process.env.LOBU_LOCAL_EMAIL?.trim();
+  const envName = process.env.LOBU_LOCAL_NAME?.trim();
+
+  const gitEmail = safeRead(() =>
+    spawnSync('git', ['config', '--get', 'user.email']).stdout.toString().trim()
+  );
+  const gitName = safeRead(() =>
+    spawnSync('git', ['config', '--get', 'user.name']).stdout.toString().trim()
+  );
+
+  const osUser = process.env.USER?.trim() || process.env.USERNAME?.trim();
+  const osHost = os.hostname()?.trim();
+  const osFallbackEmail =
+    osUser && osHost ? `${osUser.toLowerCase()}@${osHost.toLowerCase()}.local` : null;
+
+  const email = pickFirstValidEmail([envEmail, gitEmail, osFallbackEmail]) ?? BOOTSTRAP_DEFAULT_EMAIL;
+  const name = envName || gitName || osUser || BOOTSTRAP_DEFAULT_NAME;
+  const username = usernameFromEmail(email) ?? BOOTSTRAP_DEFAULT_USERNAME;
+  return { email, name, username };
+}
+
+function safeRead(fn: () => string): string | null {
+  try {
+    const v = fn();
+    return v ? v : null;
+  } catch {
+    return null;
+  }
+}
+
+// Use zod's email validator — it's what Better Auth's sign-in/sign-up
+// schemas use internally, so anything that passes here is also accepted
+// by `/api/auth/sign-in/email`. A weaker regex (e.g. `^[^@]+@[^@]+\.[^@]+$`)
+// lets values like `a@b.c`, `user@[127.0.0.1]`, `foo@bar..com` through,
+// which fail BA's Zod and leave us with a seeded user whose printed
+// credentials can't actually be used.
+const emailSchema = z.string().email();
+
+function pickFirstValidEmail(candidates: Array<string | null | undefined>): string | null {
+  for (const c of candidates) {
+    if (c && emailSchema.safeParse(c).success) return c;
+  }
+  return null;
+}
+
+function usernameFromEmail(email: string): string | null {
+  const local = email.split('@')[0]?.toLowerCase();
+  if (!local) return null;
+  // Match the slug shape personal-org-provisioning uses for collision safety.
+  const slug = local.replace(/[^a-z0-9-]+/g, '-').replace(/^-+|-+$/g, '');
+  return slug || null;
+}
 
 function isLoopbackPgUrl(dbUrl: string): boolean {
   try {
@@ -442,15 +529,22 @@ async function ensureBootstrapUser(dbUrl: string): Promise<void> {
       return;
     }
 
+    // Pick the operator's actual identity from env / git config / OS user
+    // before seeding. The bootstrap user only exists on fresh PGlite installs
+    // (guarded above), and is loopback-only — wrong-guess emails can't reach
+    // a real mailbox. The point is to show a real identity in the menubar +
+    // web UI instead of a hardcoded `dev@lobu.local` placeholder.
+    const identity = pickBootstrapIdentity();
+
     // Idempotent user/org/member upsert. Re-runs of the embedded schema (e.g.
     // LOBU_DATA_DIR pre-existing without the PAT file) skip ON CONFLICT.
     await sql`
       INSERT INTO "user" (id, name, email, username, "emailVerified", "createdAt", "updatedAt")
       VALUES (
         ${BOOTSTRAP_USER_ID},
-        ${BOOTSTRAP_USER_NAME},
-        ${BOOTSTRAP_USER_EMAIL},
-        ${BOOTSTRAP_USERNAME},
+        ${identity.name},
+        ${identity.email},
+        ${identity.username},
         true,
         NOW(),
         NOW()
@@ -505,7 +599,7 @@ async function ensureBootstrapUser(dbUrl: string): Promise<void> {
 
     const url = `http://localhost:${PORT}`;
     process.stdout.write(
-      `[bootstrap login] ${BOOTSTRAP_USER_EMAIL} / ${BOOTSTRAP_PASSWORD}  →  ${url}\n`
+      `[bootstrap login] ${identity.email} / ${BOOTSTRAP_PASSWORD}  →  ${url}\n`
     );
     logger.info(
       { org: BOOTSTRAP_ORG_SLUG, url },


### PR DESCRIPTION
## Summary

Closes the two friction points in local-first onboarding (codex review in [#896](https://github.com/lobu-ai/lobu/pull/896) called this out as a real but separate problem):

1. **Bootstrap identity uses the operator's actual email**, not a hardcoded `dev@lobu.local`. Order: `LOBU_LOCAL_EMAIL` env → `git config user.email` → `${USER}@${hostname}.local` → original default.
2. **Single-user mode** (`LOBU_SINGLE_USER=1`, default-on inside `lobu run`) **blocks all user-creation paths** when the DB already has a user. Closes the fork-via-/sign-up + fork-via-magic-link + fork-via-OAuth-callback hole — the chokepoint is `databaseHooks.user.create.before`, which runs regardless of how the request arrived. Friendly 403 via `APIError(FORBIDDEN)`.

## Validation

- ✅ `make typecheck` clean.
- ✅ `bun test packages/server/src/__tests__/unit` — 185 pass, 0 fail.
- ✅ Codex reviewed twice: caught the path-only guard bypass + weak regex on the first pass; the second pass caught the plain-`Error` → 500 issue. All three fixed in this commit.

## Not in this PR (deferred)

- No web UI changes — `/sign-up` form still renders, just the API call 403s. Acceptable cost; SPA single-user mode is a separate piece of work.
- No new endpoints (no `/api/local-bootstrap`). `/api/local-init` keeps existing behavior.
- No migration for existing forked installs.

## Reproducer

**Before:** fresh PGlite → `lobu run` seeds `bootstrap-user@dev@lobu.local`. Operator visits `localhost:8787/sign-up`, signs up with their real email → DB now has two users. Mac app/CLI auth as `bootstrap-user`; web UI shows the new user. Worker rows and personal orgs split.

**After:** `lobu run` defaults `LOBU_SINGLE_USER=1`. Bootstrap user is seeded with the operator's git/OS identity. Visiting `/sign-up` returns:
```
403 {"code":"SIGN_UP_DISABLED_IN_SINGLE_USER_MODE","message":"This install allows exactly one user; sign in to the existing account instead."}
```
Magic-link and OAuth-callback sign-ups hit the same hook with the same response. Operator signs in with the printed bootstrap credentials; no fork.

## Test plan
- [x] `make typecheck`
- [x] `bun test packages/server/src/__tests__/unit`
- [ ] End-to-end smoke: boot `lobu run` from a fresh PGlite, observe the bootstrap login line shows real email; `curl POST /api/auth/sign-up/email` returns 403.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced single-user mode that prevents creation of secondary accounts
  * Local development server now defaults to single-user mode for streamlined onboarding
  * Bootstrap user identity is now dynamically derived from system configuration

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lobu-ai/lobu/pull/898?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->