### PR TITLE
fix(cli): task-setup resolves repo via git-common-dir, not script cwd

### DIFF
--- a/scripts/task-setup.sh
+++ b/scripts/task-setup.sh
@@ -71,7 +71,19 @@ case "$name" in
 esac
 
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-repo="$(cd "$script_dir/.." && pwd)"
+# Always resolve `repo` to the main checkout, not the cwd we were invoked
+# from. Worktrees share the full working tree (scripts/ included), so a naive
+# `$script_dir/..` resolves to whatever worktree the user happened to be
+# inside when they ran `make task-setup`. That landed new worktrees at
+# <calling-worktree>/.claude/worktrees/<name>/ — nested instead of flat,
+# and `make task-clean` of the outer one would then refuse on (or rm -rf
+# through) the inner ones.
+#
+# `git rev-parse --git-common-dir` returns the SHARED .git directory (the
+# main repo's .git path) regardless of which worktree the call is made from.
+# Its parent is the main checkout — exactly what we want for both the
+# `git worktree add` target and the `.env` source.
+repo="$(cd "$(dirname "$(git -C "$script_dir" rev-parse --git-common-dir)")" && pwd)"
 worktree_dir="$repo/.claude/worktrees/$name"
 branch="feat/$name"
 


### PR DESCRIPTION
## Summary

`task-setup.sh` resolved the target repo as `$script_dir/..`, which only works when invoked from the main checkout. Worktrees share the full working tree including `scripts/`, so running `make task-setup NAME=foo` from inside an existing worktree landed the new worktree at `<calling-worktree>/.claude/worktrees/foo/` — nested — instead of `~/Code/lobu/.claude/worktrees/foo/`.

Fix: resolve `repo` via `git rev-parse --git-common-dir`, which returns the shared `.git` directory regardless of which worktree the call originates from. Its parent is always the main checkout.

## Reproducer

**Before:**
```bash
cd ~/Code/lobu/.claude/worktrees/some-existing-task
make task-setup NAME=foo
# worktree created at ~/Code/lobu/.claude/worktrees/some-existing-task/.claude/worktrees/foo  ← nested
```

**After:**
```bash
cd ~/Code/lobu/.claude/worktrees/some-existing-task
make task-setup NAME=foo
# worktree created at ~/Code/lobu/.claude/worktrees/foo  ← flat
```

## Real-world fallout (from the session that uncovered it)

Two nested worktrees (`feat/frontend` and `feat/landing-page`) had been created via this bug from inside `feat/chrome-extension-e2e`. When `make task-clean NAME=chrome-extension-e2e FORCE=1` ran, `rm -rf` of the outer worktree clipped tracked files inside the inner worktrees before bailing on "Directory not empty". Tracked files were recoverable via `git checkout -- .`; any untracked WIP would have been lost. This fix prevents the nesting from happening at all.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed setup script to correctly resolve repository paths when invoked from within an existing worktree, ensuring proper configuration sources and preventing incorrect path assignments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lobu-ai/lobu/pull/899?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->