### PR TITLE
fix(cli): task-setup uses --path-format=absolute for git-common-dir

### DIFF
--- a/scripts/task-setup.sh
+++ b/scripts/task-setup.sh
@@ -83,7 +83,14 @@ script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # main repo's .git path) regardless of which worktree the call is made from.
 # Its parent is the main checkout — exactly what we want for both the
 # `git worktree add` target and the `.env` source.
-repo="$(cd "$(dirname "$(git -C "$script_dir" rev-parse --git-common-dir)")" && pwd)"
+#
+# `--path-format=absolute` is load-bearing. Without it, `--git-common-dir`
+# returns a path relative to git's cwd ("../.git"), and `dirname` of that
+# resolves against whatever directory the caller happens to be in — landing
+# the worktree at the wrong path (e.g. /Users/burakemre/Code instead of
+# /Users/burakemre/Code/lobu when run from the main checkout). The absolute
+# form makes the resolution invariant.
+repo="$(dirname "$(git -C "$script_dir" rev-parse --path-format=absolute --git-common-dir)")"
 worktree_dir="$repo/.claude/worktrees/$name"
 branch="feat/$name"
 


### PR DESCRIPTION
## Summary

Follow-up to #899. The previous fix called `git rev-parse --git-common-dir` without forcing absolute output. From inside a checkout, git returns a path **relative to its cwd** (`../.git`), and `dirname` of that resolves against whatever directory the caller happens to be in. Net result:

```bash
cd ~/Code/lobu                    # main repo
make task-setup NAME=foo
# resolves repo to /Users/burakemre/Code   ← parent of lobu, wrong!
# worktree created at /Users/burakemre/Code/.claude/worktrees/foo
```

## Fix

Pass `--path-format=absolute` so git always returns the full path (e.g. `/Users/burakemre/Code/lobu/.git`). `dirname` of an absolute path is invariant to cwd.

```diff
-repo="$(cd "$(dirname "$(git -C "$script_dir" rev-parse --git-common-dir)")" && pwd)"
+repo="$(dirname "$(git -C "$script_dir" rev-parse --path-format=absolute --git-common-dir)")"
```

## Verification

```
from main:      /Users/burakemre/Code/lobu  ✓
from worktree:  /Users/burakemre/Code/lobu  ✓
```

Caught while validating #899 — same logic but two cwds wrong.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed incorrect worktree placement when the setup script is invoked from within an existing worktree.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lobu-ai/lobu/pull/900?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->