### PR TITLE
chore(db): auto-patch schema_migrations.version length in normalize

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -384,12 +384,12 @@ jobs:
         # immutability check above looks at the migration file set; this looks
         # at the end-state schema. They catch the same class of bug from
         # opposite sides — a buggy edit could in principle pass one and trip
-        # the other (e.g. rename + edit). Failure mode is concrete: regenerate
-        # `db/schema.sql` locally (`dbmate --schema-file db/schema.sql dump`),
-        # run `scripts/normalize-schema.sh db/schema.sql`, and commit.
+        # the other (e.g. rename + edit). Failure mode is concrete:
+        # `make db-schema` locally (requires DATABASE_URL with pgvector) and
+        # commit the regenerated db/schema.sql.
         run: |
           if ! git diff --exit-code -- db/schema.sql; then
-            echo "::error::db/schema.sql is stale. Regenerate with \`dbmate --migrations-dir db/migrations --schema-file db/schema.sql dump && scripts/normalize-schema.sh db/schema.sql\` and commit the result."
+            echo "::error::db/schema.sql is stale. Regenerate locally with \`make db-schema\` (requires DATABASE_URL with pgvector) and commit the result."
             exit 1
           fi
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Development Makefile for Lobu
 
-.PHONY: help setup build test eval clean dev build-packages ensure-submodule clean-workers test-unit test-integration test-e2e typecheck task-setup task-clean task-use
+.PHONY: help setup build test eval clean dev build-packages ensure-submodule clean-workers test-unit test-integration test-e2e typecheck task-setup task-clean task-use db-schema
 
 # Default target
 help:
@@ -18,6 +18,7 @@ help:
 	@echo "  make task-setup NAME=<name>                - Create a paired worktree at .claude/worktrees/<name> (lobu + submodule on real branch, .env copied, ports auto-assigned, Lobu context registered)"
 	@echo "  make task-clean NAME=<name> [FORCE=1]      - Remove the worktree, both branches, and the Lobu context (refuses if there's uncommitted/unpushed work unless FORCE=1)"
 	@echo "  make task-use NAME=<name|main>             - Point Chrome ext / Mac app symlinks at this worktree (or 'main' for the canonical checkout)"
+	@echo "  make db-schema                             - Run dbmate up + normalize db/schema.sql (after adding a migration; auto-patches the varchar(128) gotcha)"
 
 # Strict typecheck — mirrors the Dockerfile so local matches CI. Catches
 # what `build-packages` (relaxed, bundler-only) misses.
@@ -89,6 +90,20 @@ task-clean:
 task-use:
 	@: $${NAME?Usage: make task-use NAME=<name|main>}
 	@./scripts/task-use.sh "$(NAME)"
+
+# --- DB schema regen ---------------------------------------------------------
+# After adding a file under db/migrations/, regenerate the end-state snapshot
+# at db/schema.sql so CI's drift check passes. Mirrors exactly what CI runs,
+# then normalizes the output (strips pg18 noise + restores the varchar(128)
+# length pg18 silently drops from schema_migrations.version).
+
+db-schema:
+	@: $${DATABASE_URL?Set DATABASE_URL=postgres://... (with pgvector) before running}
+	@echo "→ dbmate up (migrations → db/schema.sql)..."
+	@dbmate --migrations-dir db/migrations --schema-file db/schema.sql up
+	@echo "→ normalizing db/schema.sql..."
+	@./scripts/normalize-schema.sh db/schema.sql
+	@echo "✓ db/schema.sql regenerated and normalized (varchar(128) auto-patched)"
 
 # --- Test pipelines ---------------------------------------------------------
 # These mirror what CI runs (.github/workflows/ci.yml) so a passing local run

--- a/scripts/normalize-schema.sh
+++ b/scripts/normalize-schema.sh
@@ -44,9 +44,15 @@ awk '
     next
   }
   # Restore schema_migrations.version length stripped by pg18 pg_dump.
-  /^    version character varying NOT NULL$/ {
+  # Table-scoped: only inside `CREATE TABLE public.schema_migrations (...)`.
+  # Without the scope guard, any future app table whose column happens to be
+  # exactly `    version character varying NOT NULL` would also get silently
+  # patched to (128) — which would be wrong.
+  /^CREATE TABLE public\.schema_migrations \(/ { in_schema_migrations = 1 }
+  in_schema_migrations && /^    version character varying NOT NULL$/ {
     sub(/character varying/, "character varying(128)")
   }
+  in_schema_migrations && /^\);/ { in_schema_migrations = 0 }
   {
     if (pending_blank) { print ""; pending_blank = 0 }
     print

--- a/scripts/normalize-schema.sh
+++ b/scripts/normalize-schema.sh
@@ -10,6 +10,17 @@
 #   -- Dumped by pg_dump version <...>
 #   SET transaction_timeout = 0;   — emitted only by pg17+
 #
+# Lines patched:
+#   schema_migrations.version  — pg18's pg_dump emits this column as bare
+#                                `character varying`, dropping the explicit
+#                                length dbmate declared. The committed form
+#                                (and what CI keeps) is `character varying(128)`.
+#                                Restoring the (128) here lets local regen
+#                                under pg18 produce a byte-identical file.
+#                                Other columns are unaffected — they have
+#                                explicit lengths in migrations and pg18
+#                                preserves them.
+#
 # Adjacent blank lines that result from deletions are collapsed and any
 # leading blanks at the top of the file are dropped, so the output is the
 # same regardless of which lines were originally present.
@@ -31,6 +42,10 @@ awk '
     if (!seen) next
     pending_blank = 1
     next
+  }
+  # Restore schema_migrations.version length stripped by pg18 pg_dump.
+  /^    version character varying NOT NULL$/ {
+    sub(/character varying/, "character varying(128)")
   }
   {
     if (pending_blank) { print ""; pending_blank = 0 }


### PR DESCRIPTION
## Summary

After adding a migration, devs run \`dbmate up\` and then \`scripts/normalize-schema.sh\`. The normalizer stripped pg18 noise but missed one gotcha: **pg18 silently drops the explicit \`(128)\` from \`schema_migrations.version\`**, so the freshly-regen'd file would always drift the CI check unless the dev remembered to manually patch \`character varying NOT NULL\` → \`character varying(128) NOT NULL\` before commit.

Captured as a sharp-edge in this repo's agent memory (\`feedback_schema_migrations_varchar_length.md\`). Fixing it instead of documenting it.

Changes:

1. **\`scripts/normalize-schema.sh\`** now auto-patches the one specific line shape pg18 emits (\`    version character varying NOT NULL\`). Narrow match — only the schema_migrations.version column matches this pattern; everywhere else, columns declare explicit lengths in migrations and pg18 preserves them.

2. **New \`make db-schema\` target** wraps the canonical CI command + the normalizer:

   ```bash
   make db-schema    # → dbmate up + normalize, single command after adding a migration
   ```

   Mirrors what CI runs exactly (\`dbmate --migrations-dir db/migrations --schema-file db/schema.sql up\`), so passing locally = passing CI.

## Reproducer

Synthetic dirty dump fed through \`scripts/normalize-schema.sh\`:

\`\`\`
input:                              after normalize:
\restrict abcdef123XYZ              SET statement_timeout = 0;
                                    SET client_encoding = 'UTF8';
-- Dumped from database version …
-- Dumped by pg_dump version 18.1   CREATE TABLE public.schema_migrations (
                                        version character varying(128) NOT NULL
SET statement_timeout = 0;          );
SET transaction_timeout = 0;
SET client_encoding = 'UTF8';       CREATE TABLE public.personal_access_tokens (
                                        token_prefix character varying(16) NOT NULL,
CREATE TABLE public.schema_migrations (   name text
    version character varying NOT NULL    );
);
\unrestrict abcdef123XYZ
\`\`\`

Assertions all pass:
- ✓ \`schema_migrations.version\` patched to \`(128)\`
- ✓ \`\restrict\` / \`\unrestrict\` stripped
- ✓ pg version comment lines stripped
- ✓ \`SET transaction_timeout\` stripped
- ✓ unrelated varchar lengths (e.g. \`token_prefix character varying(16)\`) untouched — no over-patching

## Test plan

- [x] Synthetic e2e test (5/5 assertions pass)
- [x] \`bash -n scripts/normalize-schema.sh\` syntax check
- [x] \`bun run typecheck\` clean (unrelated but verified)
- [ ] Next time someone regenerates db/schema.sql, \`make db-schema\` does the right thing in one shot

## Notes

This commit does **not** modify \`db/schema.sql\` itself. There's a pre-existing local diff there from someone's in-flight regen; that's not part of this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new make command to regenerate and normalize the project database schema from migrations; documented in help output.

* **Bug Fixes**
  * Restored stable schema output across PostgreSQL versions by normalizing dumped schema to avoid CI drift.
  * Updated CI messaging to instruct using the new make command when the schema snapshot differs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lobu-ai/lobu/pull/901?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->