### PR TITLE
feat(landing): add 'Add to Slack' install button to hero

### DIFF
--- a/packages/landing/src/components/HeroSection.tsx
+++ b/packages/landing/src/components/HeroSection.tsx
@@ -2,8 +2,24 @@ import { useEffect, useState } from "preact/hooks";
 import type { LandingUseCaseId } from "../use-case-definitions";
 import {
   getLandingUseCaseShowcase,
+  getLobuBaseUrl,
   type SurfaceHeroCopy,
 } from "../use-case-showcases";
+
+// Inline Slack mark — matches the existing iconography in platforms.tsx.
+// Kept here to avoid pulling platforms.tsx (and its other platform icons)
+// into the hero bundle just for this single SVG.
+const SlackIcon = ({ size = 14 }: { size?: number }) => (
+  <svg
+    width={size}
+    height={size}
+    viewBox="0 0 24 24"
+    fill="currentColor"
+    aria-hidden="true"
+  >
+    <path d="M5.042 15.165a2.528 2.528 0 0 1-2.52 2.523A2.528 2.528 0 0 1 0 15.165a2.527 2.527 0 0 1 2.522-2.52h2.52v2.52zM6.313 15.165a2.527 2.527 0 0 1 2.521-2.52 2.527 2.527 0 0 1 2.521 2.52v6.313A2.528 2.528 0 0 1 8.834 24a2.528 2.528 0 0 1-2.521-2.522v-6.313zM8.834 5.042a2.528 2.528 0 0 1-2.521-2.52A2.528 2.528 0 0 1 8.834 0a2.528 2.528 0 0 1 2.521 2.522v2.52H8.834zM8.834 6.313a2.528 2.528 0 0 1 2.521 2.521 2.528 2.528 0 0 1-2.521 2.521H2.522A2.528 2.528 0 0 1 0 8.834a2.528 2.528 0 0 1 2.522-2.521h6.312zM18.956 8.834a2.528 2.528 0 0 1 2.522-2.521A2.528 2.528 0 0 1 24 8.834a2.528 2.528 0 0 1-2.522 2.521h-2.522V8.834zM17.688 8.834a2.528 2.528 0 0 1-2.523 2.521 2.527 2.527 0 0 1-2.52-2.521V2.522A2.527 2.527 0 0 1 15.165 0a2.528 2.528 0 0 1 2.523 2.522v6.312zM15.165 18.956a2.528 2.528 0 0 1 2.523 2.522A2.528 2.528 0 0 1 15.165 24a2.527 2.527 0 0 1-2.52-2.522v-2.522h2.52zM15.165 17.688a2.527 2.527 0 0 1-2.52-2.523 2.526 2.526 0 0 1 2.52-2.52h6.313A2.527 2.527 0 0 1 24 15.165a2.528 2.528 0 0 1-2.522 2.523h-6.313z" />
+  </svg>
+);
 
 const ArrowRightIcon = () => (
   <svg
@@ -215,6 +231,18 @@ export function HeroSection(props: {
             }}
           >
             Start building
+          </a>
+          <a
+            href={`${getLobuBaseUrl()}/slack/install`}
+            class="inline-flex items-center gap-2 text-[14px] font-medium px-5 h-10 rounded-lg transition-opacity hover:opacity-90"
+            style={{
+              background: "transparent",
+              color: "var(--color-page-text)",
+              border: "1px solid var(--color-page-border)",
+            }}
+          >
+            <SlackIcon size={14} />
+            Add to Slack
           </a>
           <CopyPromptButton />
         </div>


### PR DESCRIPTION
## Summary

The `/slack/install` OAuth endpoint already exists in `packages/server/src/gateway/routes/public/slack.ts:154` but the landing page has no visible install entry — visitors who want to add Lobu to their Slack have to discover the path themselves. This adds a secondary CTA button next to **Start building** in the hero that links to `${getLobuBaseUrl()}/slack/install`.

Flow:
- **Returning user (signed in):** lands in the install OAuth dance directly.
- **First-time visitor:** existing \`/slack/install\` logic routes them through signup → org creation → back to the install flow. No extra wiring needed on the landing side.

## Changes

`packages/landing/src/components/HeroSection.tsx`:
- Adds an inline \`SlackIcon\` SVG (same shape as the one in \`platforms.tsx\` — not imported to avoid pulling all platform icons into the hero bundle).
- Adds the button as a **secondary CTA** (outlined / transparent background) next to the primary **Start building** primary CTA. The \`CopyPromptButton\` stays third.
- Uses \`getLobuBaseUrl()\` from \`use-case-showcases\` — same source as every other external lobu link on the landing.

## Mockup

```
[ Start building ]  [ 〈slack-icon〉 Add to Slack ]  [ Copy prompt ]
```

## Test plan

- [x] \`bun run build\` (Astro) — 81 pages built in 6.30s, no errors
- [x] \`bun run typecheck\` clean
- [ ] Visual check in a browser after merge (couldn't boot from this session)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Add to Slack" button to the hero section, allowing users to integrate Slack directly from the landing page alongside the existing "Start building" option.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lobu-ai/lobu/pull/903?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->