### PR TITLE
feat: local-first polish — magic-link gating, task-use bug, no_user_yet route + SPA copy

### DIFF
--- a/packages/server/src/auth/config.ts
+++ b/packages/server/src/auth/config.ts
@@ -403,7 +403,14 @@ export async function getAuthConfig(
     }
   }
 
-  const magicLink = hasValue(env.RESEND_API_KEY) || !isProduction;
+  // Magic-link requires actual email delivery. Without RESEND_API_KEY,
+  // Better Auth's plugin logs the magic URL to server stdout instead of
+  // emailing it — useful for debugging, useless to a real operator who's
+  // staring at their inbox. Hide the "Send me a magic link" affordance
+  // when delivery isn't configured. (Previously this also returned true
+  // in non-production, which made local dev render a dead button that
+  // appears to work then silently does nothing.)
+  const magicLink = hasValue(env.RESEND_API_KEY);
   const phone =
     hasValue(env.TWILIO_SID) && hasValue(env.TWILIO_TOKEN) && hasValue(env.TWILIO_WHATSAPP_NUMBER);
   const hasProviderAuthEnabled = Object.values(social).some(Boolean) || phone;

--- a/packages/server/src/auth/routes.ts
+++ b/packages/server/src/auth/routes.ts
@@ -434,7 +434,11 @@ credentialRoutes.post('/local-init', async (c) => {
         error: 'no_user_yet',
         error_description:
           'No user exists yet on this install. Open the web UI and sign up first; the menubar / CLI will pick up the new user on the next /api/local-init call.',
-        signup_url: '/sign-up',
+        // Owletto's SPA routes signup via /auth/sign-up (mapped by
+        // auth/$pathname.tsx → /auth/login?intent=sign-up). A bare /sign-up
+        // would fall into the $owner catch-all and loop through the login
+        // redirect — pre-PR-908 codex review caught this.
+        signup_url: '/auth/sign-up',
       },
       404
     );

--- a/scripts/task-use.sh
+++ b/scripts/task-use.sh
@@ -31,7 +31,15 @@ if [[ "$name" != "main" ]] && ! [[ "$name" =~ ^[a-z0-9]+(-[a-z0-9]+)*$ ]]; then
 fi
 
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-repo="$(cd "$script_dir/.." && pwd)"
+# Resolve `repo` to the main checkout, not whatever worktree the script
+# happens to live inside. Worktrees share the working tree (scripts/
+# included), so a naive `$script_dir/..` returns the calling worktree's
+# root — and task-use would retarget the active/chrome + active/mac
+# symlinks at `<calling-worktree>/.claude/worktrees/<name>/packages/...`,
+# nested inside whatever worktree the operator happened to be in. Same
+# fix as task-setup.sh (#899/#900): use git's shared .git path with
+# --path-format=absolute so the resolution is invariant to cwd.
+repo="$(dirname "$(git -C "$script_dir" rev-parse --path-format=absolute --git-common-dir)")"
 
 if [[ "$name" == "main" ]]; then
   source_root="$repo"


### PR DESCRIPTION
## Summary

Five real gaps from the post-passkey audit, bundled.

### Server
- **`auth/config.ts`**: hide magic-link button when `RESEND_API_KEY` is unset. Previously rendered a dead button in dev that logged the URL to stdout instead of emailing.
- **`auth/routes.ts /api/local-init`**: `no_user_yet` response's `signup_url` now points at `/auth/sign-up` (Owletto's actual SPA route, mapped via `/auth/$pathname.tsx`). The previous `/sign-up` fell into the `$owner` catch-all and looped.

### Scripts
- **`task-use.sh`**: same `$script_dir/..` → `git rev-parse --path-format=absolute --git-common-dir` fix as task-setup.sh in #900. Without it, running from inside a worktree retargets symlinks at nested paths.

### Owletto submodule (lobu-ai/owletto#191, `19221e9`)
- `login.tsx`: single-user-mode copy ("Set up your local install", "stays on this machine", etc.). Post-signup `addPasskey()` auto-enrolls Touch ID from the same form-submit click context.
- `AppState.swift`: handles `no_user_yet` from `/api/local-init` by opening the signup URL in the browser. Resolves the URL via URL APIs so absolute signup_url and base URLs with path prefixes both work.

## Codex review

Caught two bugs in the polish PR's first draft:
1. `/sign-up` route → `/auth/sign-up` (would otherwise loop into `$owner` catch-all).
2. Mac side concatenated strings to build URL; now uses URL APIs to handle absolute paths and prefixes.

Both fixed before push.

## Test plan
- [x] `make typecheck` clean.
- [x] `bun test packages/server/src/__tests__/unit` — 201 pass.
- [x] `xcodebuild Owletto Debug` — BUILD SUCCEEDED.
- [ ] E2E on fresh PGlite: Mac app opens browser at `/auth/sign-up`, operator types name+password+email, post-submit OS prompts for Touch ID, Mac app picks up the session via `/api/local-init`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Magic link authentication option now displays only when email delivery is configured.
  * Corrected signup URL routing in the authentication initialization flow.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lobu-ai/lobu/pull/909?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->