### PR TITLE
chore: task-setup task-start doc + bump owletto for per-context runner

### DIFF
--- a/scripts/task-setup.sh
+++ b/scripts/task-setup.sh
@@ -25,19 +25,24 @@
 #
 # Optional shell-function sugar — `make task-setup` does the setup, then you
 # still have to `cd <path> && claude` by hand. If you want one command that
-# also moves your shell and launches claude, add this to ~/.zshrc:
+# also moves your shell and launches a tool, add this to ~/.zshrc:
 #
 #   task-start() {
-#     local name="$1"; local repo="$HOME/Code/lobu"
+#     local name="$1"; shift
+#     local repo="$HOME/Code/lobu"
 #     "$repo/scripts/task-setup.sh" "$name" || return $?
-#     cd "$repo/.claude/worktrees/$name" && exec claude
+#     cd "$repo/.claude/worktrees/$name" && exec "${@:-claude}"
 #   }
 #   task-resume() {
-#     local name="$1"; local repo="$HOME/Code/lobu"
+#     local name="$1"; shift
+#     local repo="$HOME/Code/lobu"
 #     [[ -d "$repo/.claude/worktrees/$name" ]] \
 #       || { echo "no such worktree: $name"; return 1; }
-#     cd "$repo/.claude/worktrees/$name" && exec claude
+#     cd "$repo/.claude/worktrees/$name" && exec "${@:-claude}"
 #   }
+#
+# Usage: `task-start fix-sse-leak` (defaults to claude), or
+#        `task-start fix-sse-leak codex` / `task-start fix-sse-leak zsh`.
 #
 # The cd + exec must live in the shell function (not a Makefile target or this
 # script) so that the parent terminal actually moves and Warp/iTerm detect the


### PR DESCRIPTION
## Summary
- Bump `packages/owletto` to pick up [lobu-ai/owletto#192](https://github.com/lobu-ai/owletto/pull/192) — the menubar's Start button now spawns the right server for `lobu context add ... --port N --cwd <path> --lifecycle managed` entries (i.e. task-setup-registered worktrees), instead of always trying port 8787 + `~/lobu`.
- Refresh the `task-start` / `task-resume` shell-function template in `scripts/task-setup.sh` header: command is now a parameter (defaults to `claude`), so `task-start fix-sse-leak codex` or `task-start fix-sse-leak zsh` work without editing the function. Function itself lives in the operator's `~/.zshrc`; this is just the in-tree reference.

## Why
After `task-setup` writes a managed context for the worktree (port = e.g. 8789, cwd = the worktree root), the menubar already surfaced the row with a Start verb — but pressing Start spawned on 8787 in `~/lobu`, not the worktree's port/cwd. The Swift fix in owletto closes that loop; this PR is just the pointer bump + doc tweak.

## Test plan
- [ ] After merge, `make task-setup NAME=foo` → `lobu context use foo` → menubar Start → server boots on the worktree's PORT against the worktree as cwd.
- [ ] Owletto PR merges first (or in parallel); this PR's submodule pin (`packages/owletto`) must resolve to a SHA on `main`. Confirmed pushed: `feat/menubar-runner-context` on lobu-ai/owletto.

## Companion
[lobu-ai/owletto#192](https://github.com/lobu-ai/owletto/pull/192) — the Swift change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated a subproject reference to a newer revision to ensure the app builds and runs with the latest included changes.

* **Documentation**
  * Improved shell helper setup instructions and examples so task-launching helpers accept and forward extra command arguments, making local workflow commands more flexible and predictable.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lobu-ai/lobu/pull/910?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->