### PR TITLE
chore(scripts): task-clean repo resolution, drop mac symlink, surface PORT

### DIFF
--- a/scripts/task-clean.sh
+++ b/scripts/task-clean.sh
@@ -35,7 +35,12 @@ if ! [[ "$name" =~ ^[a-z0-9]+(-[a-z0-9]+)*$ ]]; then
 fi
 
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-repo="$(cd "$script_dir/.." && pwd)"
+# Resolve `repo` to the main checkout, not whatever worktree the script
+# happens to live inside. Same fix as task-setup.sh (#900) / task-use.sh —
+# `--git-common-dir --path-format=absolute` returns the shared .git path
+# regardless of which worktree the call is made from, so invoking
+# `make task-clean` from inside a worktree targets the right paths.
+repo="$(dirname "$(git -C "$script_dir" rev-parse --path-format=absolute --git-common-dir)")"
 worktree_dir="$repo/.claude/worktrees/$name"
 branch="feat/$name"
 
@@ -114,11 +119,15 @@ fi
 if command -v lobu >/dev/null 2>&1; then
   if lobu context rm "$name" >/dev/null 2>&1; then
     echo "→ removed Lobu context '$name'"
+  else
+    echo "warning: failed to remove Lobu context '$name' (already gone or CLI error)" >&2
   fi
+else
+  echo "warning: 'lobu' CLI not on PATH; skipping context removal" >&2
 fi
 
-# If this worktree was the active target for the Chrome/Mac symlinks, fall
-# back to 'main' so the symlinks don't dangle into a deleted directory.
+# If this worktree was the active target for the Chrome symlink, fall back
+# to 'main' so the active/chrome symlink doesn't dangle into a deleted dir.
 active_name_file="$HOME/.config/lobu-dev/active/.active-name"
 if [[ -f "$active_name_file" ]] && [[ "$(cat "$active_name_file")" == "$name" ]]; then
   "$repo/scripts/task-use.sh" main >/dev/null && \

--- a/scripts/task-use.sh
+++ b/scripts/task-use.sh
@@ -1,19 +1,29 @@
 #!/usr/bin/env bash
-# task-use.sh — point external tools (Chrome extension, Xcode/Mac app) at a
-# specific worktree's source by retargeting fixed symlinks.
+# task-use.sh — point the Chrome extension at a specific worktree's source by
+# retargeting a fixed symlink.
 #
 # Usage:
 #   scripts/task-use.sh <name>     # use the worktree at .claude/worktrees/<name>
 #   scripts/task-use.sh main       # use the main checkout (no worktree)
 #
-# Symlinks (created/updated each run):
+# Symlink (created/updated each run):
 #   ~/.config/lobu-dev/active/chrome  →  <root>/packages/owletto/apps/chrome
-#   ~/.config/lobu-dev/active/mac     →  <root>/packages/owletto/apps/mac
 #
 # Point Chrome's "Load unpacked" at ~/.config/lobu-dev/active/chrome ONCE.
-# Open Xcode against ~/.config/lobu-dev/active/mac. Then `task-use <name>`
-# swaps which worktree those resolve to; reload the extension / re-open the
-# Xcode project to pick up the new source.
+# Then `task-use <name>` swaps which worktree it resolves to; reload the
+# extension at chrome://extensions to pick up the new source.
+#
+# The Chrome extension's gateway URL is configured separately in the
+# sidepanel ("Server URL"). Because each worktree's `make dev` runs on its
+# own PORT (assigned in .env.local), the symlink retarget alone does NOT
+# repoint the extension at the new server — re-open the sidepanel and update
+# the URL to http://localhost:<PORT> for the active worktree.
+#
+# Xcode/Mac is intentionally NOT symlinked. Open the .xcodeproj at the
+# worktree path directly (`packages/owletto/apps/mac` inside the worktree).
+# The Mac menubar reads ~/.config/lobu/config.json on every popover, so
+# per-worktree Lobu contexts (registered by task-setup) appear in its picker
+# automatically — no separate "active mac" indirection is required.
 
 set -euo pipefail
 
@@ -34,10 +44,10 @@ script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # Resolve `repo` to the main checkout, not whatever worktree the script
 # happens to live inside. Worktrees share the working tree (scripts/
 # included), so a naive `$script_dir/..` returns the calling worktree's
-# root — and task-use would retarget the active/chrome + active/mac
-# symlinks at `<calling-worktree>/.claude/worktrees/<name>/packages/...`,
-# nested inside whatever worktree the operator happened to be in. Same
-# fix as task-setup.sh (#899/#900): use git's shared .git path with
+# root — and task-use would retarget the active/chrome symlink at
+# `<calling-worktree>/.claude/worktrees/<name>/packages/...`, nested inside
+# whatever worktree the operator happened to be in. Same fix as
+# task-setup.sh (#899/#900): use git's shared .git path with
 # --path-format=absolute so the resolution is invariant to cwd.
 repo="$(dirname "$(git -C "$script_dir" rev-parse --path-format=absolute --git-common-dir)")"
 
@@ -67,14 +77,28 @@ set_link() {
 }
 
 set_link "chrome" "$source_root/packages/owletto/apps/chrome" "$active_dir/chrome"
-set_link "mac"    "$source_root/packages/owletto/apps/mac"    "$active_dir/mac"
 
 # Record the active task name for tooling that wants it (and for task-clean
 # to know whether to reset to 'main' when cleaning the active worktree).
 echo "$name" > "$active_dir/.active-name"
+
+# Surface the worktree's PORT so the operator is reminded to update the
+# Chrome extension's "Server URL" sidepanel setting — the source symlink
+# and the gateway URL are independent switches, and stale URLs are the
+# single most common footgun across worktree switches.
+active_port=""
+if [[ "$name" != "main" ]]; then
+  env_local="$source_root/.env.local"
+  if [[ -f "$env_local" ]]; then
+    active_port="$(awk -F= '/^PORT=/{print $2; exit}' "$env_local" | tr -d '[:space:]')"
+  fi
+fi
+
 echo "✓ active worktree: $name"
-echo ""
-echo "  ↳ Chrome will not auto-reload the extension when the symlink retargets."
-echo "    Click 'Reload' on the owletto extension in chrome://extensions to pick"
-echo "    up the new source. (MV3 service workers re-register on extension reload,"
-echo "    not on symlink change.)"
+if [[ -n "$active_port" ]]; then
+  echo "  ↳ Chrome ext: set Server URL to http://localhost:$active_port"
+  echo "    (open the owletto sidepanel; or reset via chrome://extensions → Reload)"
+else
+  echo "  ↳ Chrome ext: confirm Server URL points at this worktree's gateway"
+fi
+echo "    MV3 service workers re-register on extension reload, not on symlink change."


### PR DESCRIPTION
## Summary

Three small dev-script fixes for the per-task worktree workflow, scoped by a codex review of the multi-port story.

- **`task-clean.sh` repo resolution.** Running from inside a worktree resolved `repo` to that worktree, so the worktree-dir + branch deletions targeted the wrong place. Switch to `git rev-parse --git-common-dir --path-format=absolute`, matching the fix `task-setup.sh` (#900) and `task-use.sh` already use.
- **`task-clean.sh` warn on `lobu context rm` failure.** Mirrors `task-setup.sh:188`. Silent failures left stale context entries after a clean.
- **`task-use.sh` drops the Mac symlink.** The Mac menubar reads `~/.config/lobu/config.json` on every popover expand (`AppState.swift:456 refreshContexts`) and shows each context's `apiUrl` independently — per-worktree contexts already appear in its picker, no "active mac" indirection needed. Devs open Xcode at the worktree's `packages/owletto/apps/mac` directly. The Chrome symlink stays.
- **`task-use.sh` surfaces PORT.** Reads PORT from `.env.local` and prints it in the success message. The Chrome extension's gateway URL (sidepanel "Server URL" → `chrome.storage.local`) and the source symlink are independent switches; surfacing PORT each invocation makes the "still pointed at the previous worktree" footgun visible.

## Reproducer

```
$ cd /Users/burakemre/Code/lobu/.claude/worktrees/task-script-fixes
$ bash scripts/task-use.sh task-script-fixes
→ chrome: /Users/burakemre/.config/lobu-dev/active/chrome → …/task-script-fixes/packages/owletto/apps/chrome
✓ active worktree: task-script-fixes
  ↳ Chrome ext: set Server URL to http://localhost:8789
    (open the owletto sidepanel; or reset via chrome://extensions → Reload)
    MV3 service workers re-register on extension reload, not on symlink change.
```

`task-clean.sh` repo-resolution path was syntax-checked (`bash -n`); not run end-to-end because doing so would remove this worktree mid-PR. The change is mechanical (one variable, identical to existing `task-setup.sh` / `task-use.sh` pattern).

## Notes

- **Per-port auth cookies.** Each `localhost:$PORT` has its own better-auth session — expected, but worth knowing when switching worktrees. Not changing.
- **Menubar refresh cadence.** `refreshContexts()` is on-popover, not a filesystem watcher; new contexts appear on the next menu open. Acceptable.

## Test plan
- [x] `bash -n scripts/task-{clean,use}.sh`
- [x] `bash scripts/task-use.sh <worktree>` retargets chrome symlink + prints PORT
- [ ] Verify next `task-setup` + `task-clean` round-trip after merge (uses the new repo resolution from inside a worktree)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced error handling in cleanup operations with explicit warnings for missing dependencies.
  * Streamlined extension development setup process.
  * Improved setup guidance for configuring extension server connection and MV3 reload behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lobu-ai/lobu/pull/912?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->