### PR TITLE
chore(build): bun lockfile docs, login polling cleanup, migration idempotency

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -156,6 +156,29 @@ worktree owns `:8787` is what `https://...ts.net:8443` serves. Other worktrees
 are reachable on `http://localhost:8788` etc. — fine for UI work; only
 webhook/OAuth-callback testing actually needs the public URL.
 
+### bun lockfile + owletto submodule
+
+CI initialises `packages/owletto` via the deploy key before `bun install --frozen-lockfile`, so the lockfile that lands on `main` always reflects an *initialised* submodule. Locally, `bun install --frozen-lockfile` only matches that state if your checkout also has the submodule initialised — an uninitialised submodule prunes the owletto half of the dependency graph and Bun rewrites the lockfile, which then fails CI's frozen check on the next push.
+
+Before pushing changes that touch `bun.lock` or any `package.json`, run:
+
+```bash
+git submodule update --init packages/owletto
+bun install --frozen-lockfile
+```
+
+If the second command rewrites `bun.lock`, that's the drift CI would have caught — commit the regenerated lockfile in the same change.
+
+### Biome / IDE setup
+
+Husky's pre-commit hook runs `biome check --write`, so the canonical formatter is biome and not whatever your editor ships by default. To keep your editor and the hook from fighting:
+
+- **VS Code:** install the official [Biome extension](https://marketplace.visualstudio.com/items?itemName=biomejs.biome) and set it as the default formatter for TS/JS/JSON in workspace settings.
+- **JetBrains (WebStorm/IDEA):** install the Biome plugin, *or* wire a File Watcher that runs `bunx biome check --write $FilePath$` on save.
+- **Other editors:** point your save-time formatter at `bunx biome check --write` so the pre-commit hook's auto-fixes match what's already on disk.
+
+Without an editor integration, biome's `--write` still rewrites files at commit time — you just don't see the diff until `git status` surprises you.
+
 ### Validation after code changes
 
 **E2E before merge (hard gate).** For any bug-fix PR, do a red → fix → green cycle before opening:

--- a/packages/cli/src/commands/login.ts
+++ b/packages/cli/src/commands/login.ts
@@ -29,7 +29,18 @@ interface LoginOptions {
   force?: boolean;
   /** Forwarded to RFC 7591 dynamic client registration as `software_version`. */
   cliVersion?: string;
+  /** Suppress spinner output; bail out non-interactively if the server rejects polling. */
+  quiet?: boolean;
 }
+
+/**
+ * Hard ceiling on the polling loop. RFC 8628 servers typically return
+ * `expires_in: 600` (10 min), but if the server hands us a much longer
+ * deadline we still don't want to hammer `/oauth/token` for an hour from
+ * a backgrounded shell. 5 minutes matches the documented device-code
+ * expiry and is generous for a human to scan a QR + approve.
+ */
+const POLL_HARD_TIMEOUT_MS = 5 * 60 * 1000;
 
 /**
  * `lobu login` runs the OAuth 2.0 device-code grant against the issuer
@@ -143,73 +154,129 @@ export async function loginCommand(options: LoginOptions): Promise<void> {
     }
   }
 
-  const spinner = ora("Waiting for authorization...").start();
-  const deadline = Date.now() + authorization.expiresIn * 1000;
+  const isInteractive = process.stdout.isTTY === true && !options.quiet;
+  const spinner = isInteractive
+    ? ora("Waiting for authorization...").start()
+    : null;
+
+  // Cap the wait at the server-advertised lifetime AND our local ceiling.
+  // The local ceiling guards against a misconfigured issuer handing us an
+  // hour-long deadline that a backgrounded shell would otherwise honour.
+  const serverDeadline = Date.now() + authorization.expiresIn * 1000;
+  const localDeadline = Date.now() + POLL_HARD_TIMEOUT_MS;
+  const deadline = Math.min(serverDeadline, localDeadline);
+
+  // If the user kills the spawning shell (SIGHUP) or any supervisor sends
+  // SIGTERM, exit promptly instead of inheriting the orphaned poll loop.
+  // Without these handlers a backgrounded `lobu login &` keeps hitting
+  // `/oauth/token` every interval until the device code expires.
+  const abortBox: { signal: NodeJS.Signals | null } = { signal: null };
+  const abort = (signal: NodeJS.Signals): void => {
+    if (abortBox.signal === null) abortBox.signal = signal;
+  };
+  const onSIGHUP = () => abort("SIGHUP");
+  const onSIGTERM = () => abort("SIGTERM");
+  const onSIGINT = () => abort("SIGINT");
+  process.on("SIGHUP", onSIGHUP);
+  process.on("SIGTERM", onSIGTERM);
+  process.on("SIGINT", onSIGINT);
+  const detach = () => {
+    process.off("SIGHUP", onSIGHUP);
+    process.off("SIGTERM", onSIGTERM);
+    process.off("SIGINT", onSIGINT);
+  };
+
   let intervalSeconds = authorization.interval;
 
-  while (Date.now() < deadline) {
-    await delay(intervalSeconds * 1000);
+  try {
+    while (Date.now() < deadline) {
+      await delay(intervalSeconds * 1000);
 
-    const result = await pollDeviceToken(
-      discovery.tokenEndpoint,
-      client,
-      authorization.deviceCode
-    );
+      if (abortBox.signal) {
+        spinner?.fail(`Login cancelled (${abortBox.signal}).`);
+        process.exitCode = 1;
+        return;
+      }
 
-    if (result.status === "pending") {
-      intervalSeconds = bumpInterval(intervalSeconds, result.bumpInterval);
-      continue;
-    }
+      const result = await pollDeviceToken(
+        discovery.tokenEndpoint,
+        client,
+        authorization.deviceCode
+      );
 
-    if (result.status === "error") {
-      spinner.fail(result.message);
+      if (result.status === "pending") {
+        // Non-interactive callers (CI, backgrounded shells) can't approve
+        // the device code, so a `pending` poll is the terminal answer —
+        // bail out instead of looping until expiry.
+        if (!isInteractive) {
+          console.log(
+            chalk.red("  Device-code login requires an interactive terminal.")
+          );
+          console.log(
+            chalk.dim("  Use `--token <pat>` for non-interactive auth.\n")
+          );
+          process.exitCode = 1;
+          return;
+        }
+        intervalSeconds = bumpInterval(intervalSeconds, result.bumpInterval);
+        continue;
+      }
+
+      if (result.status === "error") {
+        spinner?.fail(result.message);
+        if (!spinner) console.log(chalk.red(`  ${result.message}`));
+        console.log();
+        process.exitCode = 1;
+        return;
+      }
+
+      const tokens = result.tokens;
+      let identity: { email?: string; name?: string; userId?: string } = {};
+      if (discovery.userinfoEndpoint) {
+        const info = await fetchUserInfo(
+          discovery.userinfoEndpoint,
+          tokens.accessToken
+        );
+        if (info) {
+          identity = { email: info.email, name: info.name, userId: info.sub };
+        }
+      }
+
+      const oauth: OAuthClientInfo = {
+        clientId: client.clientId,
+        clientSecret: client.clientSecret,
+        tokenEndpoint: discovery.tokenEndpoint,
+        revocationEndpoint: discovery.revocationEndpoint,
+        userinfoEndpoint: discovery.userinfoEndpoint,
+      };
+
+      await saveCredentials(
+        {
+          accessToken: tokens.accessToken,
+          refreshToken: tokens.refreshToken,
+          expiresAt:
+            typeof tokens.expiresIn === "number"
+              ? Date.now() + tokens.expiresIn * 1000
+              : undefined,
+          ...identity,
+          oauth,
+        },
+        target.name
+      );
+
+      spinner?.succeed(`Logged in to ${target.name}.`);
+      if (!spinner) console.log(chalk.green(`  Logged in to ${target.name}.`));
       console.log();
-      process.exitCode = 1;
       return;
     }
 
-    const tokens = result.tokens;
-    let identity: { email?: string; name?: string; userId?: string } = {};
-    if (discovery.userinfoEndpoint) {
-      const info = await fetchUserInfo(
-        discovery.userinfoEndpoint,
-        tokens.accessToken
-      );
-      if (info) {
-        identity = { email: info.email, name: info.name, userId: info.sub };
-      }
-    }
-
-    const oauth: OAuthClientInfo = {
-      clientId: client.clientId,
-      clientSecret: client.clientSecret,
-      tokenEndpoint: discovery.tokenEndpoint,
-      revocationEndpoint: discovery.revocationEndpoint,
-      userinfoEndpoint: discovery.userinfoEndpoint,
-    };
-
-    await saveCredentials(
-      {
-        accessToken: tokens.accessToken,
-        refreshToken: tokens.refreshToken,
-        expiresAt:
-          typeof tokens.expiresIn === "number"
-            ? Date.now() + tokens.expiresIn * 1000
-            : undefined,
-        ...identity,
-        oauth,
-      },
-      target.name
-    );
-
-    spinner.succeed(`Logged in to ${target.name}.`);
+    spinner?.fail("Login request expired. Run `lobu login` again.");
+    if (!spinner) console.log(chalk.red("  Login request expired."));
     console.log();
-    return;
+    process.exitCode = 1;
+  } finally {
+    detach();
   }
-
-  spinner.fail("Login request expired. Run `lobu login` again.");
-  console.log();
-  process.exitCode = 1;
 }
 
 async function loginWithToken(

--- a/packages/cli/src/commands/login.ts
+++ b/packages/cli/src/commands/login.ts
@@ -154,7 +154,14 @@ export async function loginCommand(options: LoginOptions): Promise<void> {
     }
   }
 
-  const isInteractive = process.stdout.isTTY === true && !options.quiet;
+  // Both ends of the stdio pair must be a TTY for the device-code prompt to
+  // make sense — a backgrounded shell or CI runner has neither stdin to
+  // approve from nor stdout to spin on. Require both, plus the absence of
+  // `--quiet`, before treating the call as interactive.
+  const isInteractive =
+    process.stdout.isTTY === true &&
+    process.stdin.isTTY === true &&
+    !options.quiet;
   const spinner = isInteractive
     ? ora("Waiting for authorization...").start()
     : null;
@@ -168,11 +175,15 @@ export async function loginCommand(options: LoginOptions): Promise<void> {
 
   // If the user kills the spawning shell (SIGHUP) or any supervisor sends
   // SIGTERM, exit promptly instead of inheriting the orphaned poll loop.
-  // Without these handlers a backgrounded `lobu login &` keeps hitting
-  // `/oauth/token` every interval until the device code expires.
-  const abortBox: { signal: NodeJS.Signals | null } = { signal: null };
+  // The abortable sleep below wakes immediately when `signal` is set, so we
+  // don't have to wait out the polling interval first.
+  const abortBox: { signal: NodeJS.Signals | null; wake: (() => void) | null } =
+    { signal: null, wake: null };
   const abort = (signal: NodeJS.Signals): void => {
-    if (abortBox.signal === null) abortBox.signal = signal;
+    if (abortBox.signal === null) {
+      abortBox.signal = signal;
+      abortBox.wake?.();
+    }
   };
   const onSIGHUP = () => abort("SIGHUP");
   const onSIGTERM = () => abort("SIGTERM");
@@ -190,13 +201,22 @@ export async function loginCommand(options: LoginOptions): Promise<void> {
 
   try {
     while (Date.now() < deadline) {
-      await delay(intervalSeconds * 1000);
+      // Sleep at most until the deadline, and let signal handlers wake us
+      // up so cancellation doesn't have to wait out the full polling
+      // interval (which `slow_down` can balloon to >30s).
+      const remainingMs = deadline - Date.now();
+      const sleepMs = Math.min(
+        intervalSeconds * 1000,
+        Math.max(remainingMs, 0)
+      );
+      await abortableDelay(sleepMs, abortBox);
 
       if (abortBox.signal) {
         spinner?.fail(`Login cancelled (${abortBox.signal}).`);
         process.exitCode = 1;
         return;
       }
+      if (Date.now() >= deadline) break;
 
       const result = await pollDeviceToken(
         discovery.tokenEndpoint,
@@ -319,8 +339,23 @@ async function revokeExisting(existing: Credentials): Promise<void> {
   );
 }
 
-function delay(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
+function abortableDelay(
+  ms: number,
+  abortBox: { signal: NodeJS.Signals | null; wake: (() => void) | null }
+): Promise<void> {
+  if (ms <= 0) return Promise.resolve();
+  if (abortBox.signal) return Promise.resolve();
+  return new Promise((resolve) => {
+    const timer = setTimeout(() => {
+      abortBox.wake = null;
+      resolve();
+    }, ms);
+    abortBox.wake = () => {
+      clearTimeout(timer);
+      abortBox.wake = null;
+      resolve();
+    };
+  });
 }
 
 async function tryOAuthStep<T>(fn: () => Promise<T>): Promise<T | undefined> {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -374,11 +374,16 @@ Memory:
       .option("--token <token>", "Use API token directly (CI/CD)")
   )
     .option("-f, --force", "Re-authenticate (revokes existing session)")
+    .option(
+      "-q, --quiet",
+      "Suppress spinner; bail immediately if non-interactive (CI / backgrounded shells)"
+    )
     .action(
       async (options: {
         token?: string;
         context?: string;
         force?: boolean;
+        quiet?: boolean;
       }) => {
         const { loginCommand } = await import("./commands/login.js");
         await loginCommand({ ...options, cliVersion: version });

--- a/packages/server/src/start-local.ts
+++ b/packages/server/src/start-local.ts
@@ -307,6 +307,15 @@ async function runMigrations(dbUrl: string) {
     )) as Array<{ version: string }>;
     const applied = new Set(appliedRows.map((r) => r.version));
 
+    // Versions whose contents are known to be fully covered by an existing
+    // schema (i.e. the squashed baseline). When one of these errors with a
+    // duplicate-object SQLSTATE the DB is already at the target state and we
+    // can safely record the version as applied. This is intentionally narrow:
+    // any future delta migration must use `IF NOT EXISTS` discipline rather
+    // than relying on this fallback, or its mid-file failures could mask
+    // schema drift.
+    const IDEMPOTENT_BASELINE_VERSIONS = new Set(['00000000000000']);
+
     logger.info('Running migrations...');
     for (const file of listMigrationFiles(migrationsDir)) {
       // Filename convention is `<version>_<slug>.sql`; the version is the
@@ -322,22 +331,24 @@ async function runMigrations(dbUrl: string) {
       try {
         await sql.unsafe(migrationSql);
       } catch (err) {
-        // Migrations are written to be replayable (`CREATE TABLE IF NOT
-        // EXISTS`, `ADD COLUMN IF NOT EXISTS`, …), but the squashed baseline
-        // uses plain `CREATE FUNCTION` / `CREATE TYPE` for cleanliness, so
-        // replaying it against a DB that already has the schema raises
-        // `42723` (duplicate function) or `42P07` (duplicate table/type).
-        // When every statement in the file would fail this way the DB is
-        // already at the target state — mark the version applied and move on.
+        // The squashed baseline uses plain `CREATE FUNCTION` / `CREATE TABLE`
+        // for cleanliness, so replaying it against a DB that already has the
+        // schema raises `42723` (duplicate function) / `42P07` (duplicate
+        // table) / `42710` (duplicate object). When the failing file is the
+        // baseline, that's exactly the no-op case `lobu run` should treat as
+        // success. For any other migration the duplicate error is surfaced
+        // unchanged so partial failures cannot silently advance the ledger
+        // (see `IDEMPOTENT_BASELINE_VERSIONS` above).
         const code = (err as { code?: string } | null)?.code;
-        if (code === '42723' || code === '42P07' || code === '42710') {
-          logger.info(
-            { migration: file, version, pgErrorCode: code },
-            'Migration already applied (idempotent skip)'
-          );
-        } else {
+        const isDuplicateObject =
+          code === '42723' || code === '42P07' || code === '42710';
+        if (!isDuplicateObject || !IDEMPOTENT_BASELINE_VERSIONS.has(version)) {
           throw err;
         }
+        logger.info(
+          { migration: file, version, pgErrorCode: code },
+          'Migration already applied (idempotent skip)'
+        );
       }
       await sql`
         INSERT INTO public.schema_migrations (version) VALUES (${version})

--- a/packages/server/src/start-local.ts
+++ b/packages/server/src/start-local.ts
@@ -319,7 +319,26 @@ async function runMigrations(dbUrl: string) {
       if (!migrationSql) continue;
 
       await sql.unsafe('SET search_path TO public');
-      await sql.unsafe(migrationSql);
+      try {
+        await sql.unsafe(migrationSql);
+      } catch (err) {
+        // Migrations are written to be replayable (`CREATE TABLE IF NOT
+        // EXISTS`, `ADD COLUMN IF NOT EXISTS`, …), but the squashed baseline
+        // uses plain `CREATE FUNCTION` / `CREATE TYPE` for cleanliness, so
+        // replaying it against a DB that already has the schema raises
+        // `42723` (duplicate function) or `42P07` (duplicate table/type).
+        // When every statement in the file would fail this way the DB is
+        // already at the target state — mark the version applied and move on.
+        const code = (err as { code?: string } | null)?.code;
+        if (code === '42723' || code === '42P07' || code === '42710') {
+          logger.info(
+            { migration: file, version, pgErrorCode: code },
+            'Migration already applied (idempotent skip)'
+          );
+        } else {
+          throw err;
+        }
+      }
       await sql`
         INSERT INTO public.schema_migrations (version) VALUES (${version})
         ON CONFLICT DO NOTHING


### PR DESCRIPTION
## Summary

Four hygiene gaps that surfaced during the PR #911 (drop YAML eval runner) end-to-end test:

1. **`bun.lock` + owletto submodule drift** — CI initialises the submodule before `bun install --frozen-lockfile`; an uninitialised local checkout silently regenerates the lockfile and trips the next CI run. Adds an AGENTS.md section with a pre-push check.
2. **Biome / IDE setup** — Husky pre-commit runs `biome check --write`. Without an editor integration, the hook rewrites files behind the editor's back. Adds AGENTS.md pointers for VS Code (extension) and JetBrains (plugin or File Watcher).
3. **`lobu login` device-flow polling cleanup** (`packages/cli/src/commands/login.ts`):
   - SIGHUP / SIGTERM / SIGINT handlers that exit the poll loop cleanly (fixes backgrounded `lobu login &` hammering `/oauth/token` after the parent shell exits).
   - Hard 5-minute ceiling on the loop in addition to the server-advertised `expires_in` deadline.
   - Non-interactive bail (`--quiet` or `!isTTY`): a `pending` poll is terminal — print "use `--token <pat>`" and exit instead of looping until expiry.
4. **Migration runner idempotency** (`packages/server/src/start-local.ts`) — squashed baseline uses plain `CREATE FUNCTION` / `CREATE TABLE`, so replaying against a DB that already has the schema raises `42723` / `42P07` / `42710`. Catch those specific codes, log `Migration already applied (idempotent skip)`, record the version as applied. Non-idempotent errors still propagate. **No new migrations, no schema changes** (coordinated with the install-identity worktree).

## Test plan

- [x] `make typecheck` (strict, mirrors Dockerfile) — clean.
- [x] `bun test packages/server/src/__tests__/unit` — pre-existing failures only (`@lobu/connector-sdk` not built in the runner; unrelated). No new failures introduced.
- [x] Pre-commit Biome / TS hook passes.
- [ ] Manual: re-run `lobu run` against an already-initialised `~/.lobu/data` and confirm the duplicate-function migration step logs "idempotent skip" instead of crashing.
- [ ] Manual: `lobu login --quiet` or `lobu login </dev/null` exits with code 1 on the first poll instead of looping.
- [ ] Manual: backgrounded `lobu login &` exits cleanly on `kill -HUP <pid>`.

## Reproducer notes

The original migration crash (`function "prevent_entity_cycles" already exists with same argument types`) is reproducible by pointing `LOBU_DATA_DIR` at a previously-initialised PGlite dir and re-running `lobu run`. The new error-code handler is gated on Postgres SQLSTATEs `42723` / `42P07` / `42710`, so any non-already-exists error still bubbles up unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--quiet` flag to the login command for non-interactive use, suppressing the authorization spinner.

* **Bug Fixes**
  * Login now respects interrupt signals and enforces a polling timeout to avoid hanging.
  * Database migrations now gracefully skip already-applied baseline changes when safe.

* **Documentation**
  * Updated developer guidance: CI submodule initialization and Biome/IDE + pre-commit formatting setup.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lobu-ai/lobu/pull/914?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->