### PR TITLE
feat: wire guardrails runtime end-to-end + secret-scan and forbidden-tools built-ins

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,7 +49,11 @@ All chat platforms (Telegram, Slack, Discord, WhatsApp, Teams) run through Chat 
 #### Guardrails
 - Primitive lives in `packages/core/src/guardrails/`: `Guardrail<stage>`, `GuardrailRegistry`, `runGuardrails()`. Stages: `input` (user message → worker), `output` (worker text → user), `pre-tool` (tool call authorization).
 - Each guardrail's `run(ctx)` returns `{ tripped, reason?, metadata? }`. The runner races all enabled guardrails at a stage; the first trip short-circuits (later results are discarded) and a thrown guardrail is logged and treated as a pass.
-- Built-in: `createNoopGuardrail(stage, name?)` for tests and as a template. Real built-ins ship from `packages/server/src/gateway/guardrails/builtins.ts` — currently `pii-scan` (regex sweep for emails / US phones / 13–19 digit card-shaped runs across input, output, and serialized pre-tool args). Plugin-provided guardrails (prompt-injection classifier, secret scanner, …) live in downstream packages that call `registry.register(...)` during gateway boot.
+- Built-ins ship from `packages/server/src/gateway/guardrails/builtins.ts` and are wired during `CoreServices.initialize`:
+  - `secret-scan` (output) — regex scan for OpenAI keys (`sk-…`), GitHub PATs (`ghp_…`), AWS access keys (`AKIA…`), JWT-shaped tokens. Cheap enough to run per streaming delta.
+  - `pii-scan` (input / output / pre-tool) — regex sweep for emails, US-shaped phones, and Luhn-valid 13–19 digit card-shaped runs across the user message, worker output, or serialized pre-tool args.
+  - `forbidden-tools` (pre-tool) — hardcoded deny-list (`delete_repo`, `delete_branch`, `drop_table`).
+- `createNoopGuardrail(stage, name?)` remains a template for downstream packages (prompt-injection classifier, custom PII scrubbers, etc.) that call `registry.register(...)` after `getCoreServices().getGuardrailRegistry()`.
 
 ##### Configuration
 
@@ -95,6 +99,15 @@ Names match the resolved `Guardrail.name` — including the synthesized inline n
 ##### LLM judge engine
 
 `createJudgeGuardrail(stage, policy, options?)` from `packages/server/src/gateway/guardrails/judge-factory.ts` wraps `TextJudge` (extracted from the egress judge — same Haiku client, 5-min verdict cache keyed by `(policyHash, textHash)`, circuit breaker 5 failures → 30s cooldown, fail closed). Requires `ANTHROPIC_API_KEY` at the gateway. Reuses the egress judge's primitives so behavior is identical: cache, breaker, timeout, fail-closed posture.
+
+##### Runtime wiring
+
+- Wired call sites: `MessageConsumer.handleMessage` (input), `ChatResponseBridge.handleDelta` (output, runs per streaming delta), and `McpProxy.handleProxyRequest` (pre-tool, before the approval check). All three fail open on infrastructure errors — guardrails are a safety net, not a hard dependency.
+- Trip handling per stage:
+  - **Input** → dispatch is skipped and `Message rejected: <reason>` is pushed to the `thread_response` queue so the user sees a rejection in-thread.
+  - **Output** → the in-flight platform stream is disposed, `Message blocked by guardrail: <reason>` is posted, and the rest of the worker's stream for that conversation is suppressed. The partial buffer is NOT written to history.
+  - **Pre-tool** → the worker receives a JSON-RPC `isError: true` reply with the literal text `Tool call blocked by policy.`. The specific reason is intentionally NOT surfaced to the worker — leaking it is an evasion surface.
+- Every trip writes one `events` row with `semantic_type='guardrail-trip'`, `origin_type='guardrail-<stage>'`, and metadata `{guardrail, stage, reason, agent_id, user_id, conversation_id, guardrail_metadata?}`. Append-only — operators can dashboard these in the same place lifecycle events live.
 
 #### Network
 - Gateway runs a Node HTTP proxy on `127.0.0.1:8118`; worker subprocesses get `HTTP_PROXY=http://localhost:8118` for all outbound (curl/wget/npm/git). The proxy enforces domain allowlist/blocklist + LLM egress judge.

--- a/packages/server/src/__tests__/guardrails-runtime.test.ts
+++ b/packages/server/src/__tests__/guardrails-runtime.test.ts
@@ -240,6 +240,71 @@ describe('ChatResponseBridge — wired output guardrail', () => {
     expect(rows.length).toBe(1);
   });
 
+  it('isFullReplacement clears the rolling tail before scanning (no false positive across replacement)', async () => {
+    // Regression: scanning ran BEFORE the fullReplacement dispose, so the
+    // tail still contained the prior delta and the next scan operated on
+    // (prior-delta + replacement-text), synthesizing matches that exist
+    // in neither piece alone. The fix moves the replacement handling
+    // ahead of the scan + tail-update.
+    const { target, posted } = createCapturingTarget();
+    const manager = createManager(target, agentId, orgId);
+    const bridge = new ChatResponseBridge(manager as any);
+
+    const registry = new GuardrailRegistry();
+    registerBuiltinGuardrails(registry);
+    const settingsStore = new AgentSettingsStore(
+      createPostgresAgentConfigStore()
+    );
+    bridge.setGuardrails(registry, settingsStore);
+
+    const payload = {
+      messageId: 'm1',
+      channelId: '123',
+      conversationId: '123',
+      userId: 'u1',
+      teamId: 't1',
+      timestamp: 0,
+      platform: 'telegram',
+      platformMetadata: { connectionId: 'conn-1', chatId: '123' },
+    };
+
+    // Choose two chunks that are individually safe but whose
+    // concatenation matches the openai-key regex (`sk-` + 20+ alnum).
+    //   prior:        "...ends with sk-a"
+    //   replacement:  "bcdefghij0123456789AB starts fresh"
+    // Pre-fix: tail = "...sk-a", scanText = tail + replacement → match.
+    // Post-fix: replacement clears the tail first → scanText is just the
+    // replacement, which does NOT match.
+    await orgContext.run({ organizationId: orgId }, async () => {
+      await bridge.handleDelta(
+        { ...payload, delta: 'first reply ending with sk-a' },
+        's-1'
+      );
+      // Second message arrives as a full replacement. Despite the prior
+      // delta still being in the tail, the scan must run only against the
+      // replacement text.
+      await bridge.handleDelta(
+        {
+          ...payload,
+          delta: 'bcdefghij0123456789AB starts fresh',
+          isFullReplacement: true,
+        },
+        's-2'
+      );
+    });
+
+    // No block message should have been posted — neither delta on its own
+    // contains a secret, and the replacement properly resets the tail.
+    const blockPost = posted.find((p) =>
+      p.text?.startsWith('Message blocked by guardrail')
+    );
+    expect(blockPost).toBeUndefined();
+
+    await flushPendingGuardrailAudits();
+    const rows = await fetchGuardrailEvents(orgId, 'output');
+    expect(rows.length).toBe(0);
+  });
+
   it('audits the trip even when platformMetadata.organizationId is missing (connection fallback)', async () => {
     const { target } = createCapturingTarget();
     // Build a manager whose connection carries the org id — this is the

--- a/packages/server/src/__tests__/guardrails-runtime.test.ts
+++ b/packages/server/src/__tests__/guardrails-runtime.test.ts
@@ -1,46 +1,143 @@
 /**
- * End-to-end guardrails-runtime smoke test.
+ * End-to-end guardrails-runtime test against the actual wired call sites.
  *
- * Boots the bare minimum to exercise the wired call sites against a real DB:
- *   - createPostgresAgentConfigStore + AgentSettingsStore (real settings lookup)
- *   - GuardrailRegistry populated via the same `registerBuiltinGuardrails`
- *     the gateway uses at boot
- *   - The same `runGuardrails(...)` path the wired code invokes
- *   - A real `events` row produced by `recordGuardrailTrip` (the audit-trail
- *     side of every trip) — proving the join-up writes land.
+ * Each block constructs the real service (ChatResponseBridge / MessageConsumer
+ * / McpProxy), wires the same registry + AgentSettingsStore the production
+ * gateway uses, and drives the public method that handles the corresponding
+ * stage. Assertions cover:
  *
- * Doesn't boot the HTTP server or workers (would require provider keys + the
- * full Lobu stack). The three wired call sites all share the same shape:
- * load settings, run guardrails, on trip → emit audit row + branch. This test
- * pins that shape against a live DB.
+ *   - the block message is delivered (chat target / queue / JSON-RPC reply)
+ *   - the `events` row lands with `semantic_type='guardrail-trip'`
+ *   - the rolling output buffer catches secrets split across stream chunks
+ *   - the audit org id falls back to the connection / agent metadata when the
+ *     payload doesn't carry it
+ *
+ * Tests use `flushPendingGuardrailAudits()` (the production hook) instead of
+ * a sleep — fire-and-forget audit writes are explicitly awaitable.
  */
 
-import { afterAll, beforeEach, describe, expect, it } from 'vitest';
+import { afterAll, afterEach, beforeEach, describe, expect, it } from 'vitest';
+import type { Guardrail } from '@lobu/core';
+import { generateWorkerToken, GuardrailRegistry } from '@lobu/core';
 import { AgentSettingsStore } from '../gateway/auth/settings/agent-settings-store';
-import { recordGuardrailTrip } from '../gateway/guardrails/audit';
+import { McpProxy } from '../gateway/auth/mcp/proxy';
+import { ChatResponseBridge } from '../gateway/connections/chat-response-bridge';
 import {
-  registerBuiltinGuardrails,
-  secretScanGuardrail,
-} from '../gateway/guardrails/builtins';
-import { GuardrailRegistry, runGuardrails } from '@lobu/core';
+  flushPendingGuardrailAudits,
+} from '../gateway/guardrails/audit';
+import { registerBuiltinGuardrails } from '../gateway/guardrails/builtins';
+import { MessageConsumer } from '../gateway/orchestration/message-consumer';
+import type { OrchestratorConfig } from '../gateway/orchestration/base-deployment-manager';
+import type { BaseDeploymentManager } from '../gateway/orchestration/base-deployment-manager';
+import { GrantStore } from '../gateway/permissions/grant-store';
+import {
+  PostgresSecretStore,
+} from '../lobu/stores/postgres-secret-store';
 import { orgContext } from '../lobu/stores/org-context';
 import { createPostgresAgentConfigStore } from '../lobu/stores/postgres-stores';
+import { SecretStoreRegistry } from '../gateway/secrets/index';
 import { cleanupTestDatabase, getTestDb } from './setup/test-db';
 import {
   createTestAgent,
   createTestOrganization,
 } from './setup/test-fixtures';
 
-describe('guardrails runtime — wired-path E2E', () => {
+// ─────────────────────────────────────────────────────────────────────────
+// Shared fixtures
+// ─────────────────────────────────────────────────────────────────────────
+
+interface PostedMessage {
+  text?: string;
+  iterableChunks?: string[];
+}
+
+/**
+ * Mock chat target that captures `post(string)` and `post(asyncIterable)`
+ * separately so the test can distinguish a streaming chunk from the
+ * out-of-band block message.
+ */
+function createCapturingTarget() {
+  const posted: PostedMessage[] = [];
+  const target = {
+    post: async (arg: unknown) => {
+      if (typeof arg === 'string') {
+        posted.push({ text: arg });
+        return { id: 'msg' };
+      }
+      if (arg && typeof (arg as any)[Symbol.asyncIterator] === 'function') {
+        const chunks: string[] = [];
+        for await (const chunk of arg as AsyncIterable<string>) {
+          chunks.push(chunk);
+        }
+        posted.push({ iterableChunks: chunks });
+        return { id: 'msg-stream' };
+      }
+      posted.push({});
+      return { id: 'msg-other' };
+    },
+    startTyping: async () => {},
+  };
+  return { target, posted };
+}
+
+function createManager(target: unknown, agentId: string, orgId: string) {
+  return {
+    getInstance: () => ({
+      connection: {
+        agentId,
+        organizationId: orgId,
+        platform: 'telegram',
+      },
+      chat: {
+        channel: () => target,
+        getAdapter: () => undefined,
+      },
+      conversationState: undefined,
+    }),
+    has: () => true,
+  };
+}
+
+async function fetchGuardrailEvents(orgId: string, stage: string) {
+  const db = getTestDb();
+  return db<{
+    id: number;
+    semantic_type: string;
+    origin_type: string | null;
+    title: string;
+    metadata: any;
+  }[]>`
+    SELECT id, semantic_type, origin_type, title, metadata
+    FROM events
+    WHERE organization_id = ${orgId}
+      AND semantic_type = 'guardrail-trip'
+      AND origin_type = ${`guardrail-${stage}`}
+    ORDER BY id DESC
+  `;
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// ChatResponseBridge (output stage)
+// ─────────────────────────────────────────────────────────────────────────
+
+describe('ChatResponseBridge — wired output guardrail', () => {
   let orgId: string;
   let agentId: string;
 
   beforeEach(async () => {
     await cleanupTestDatabase();
-    const org = await createTestOrganization({ name: 'Guardrails Org' });
+    const org = await createTestOrganization({ name: 'Guardrails Output Org' });
     orgId = org.id;
     const agent = await createTestAgent({ organizationId: orgId });
     agentId = agent.agentId;
+
+    const configStore = createPostgresAgentConfigStore();
+    await orgContext.run({ organizationId: orgId }, async () => {
+      await configStore.saveSettings(agentId, {
+        guardrails: ['secret-scan'],
+        updatedAt: Date.now(),
+      });
+    });
   });
 
   afterAll(async () => {
@@ -48,175 +145,491 @@ describe('guardrails runtime — wired-path E2E', () => {
     await db`TRUNCATE agents CASCADE`;
   });
 
-  it('secret-scan trips on the output stage when enabled in settings, audited as a guardrail-trip event', async () => {
-    // 1. Persist `guardrails = ["secret-scan"]` on the agent — exact write path
-    //    the wired runtime reads from on every message.
+  it('blocks a delta containing a full secret, posts the block message, audits the trip', async () => {
+    const { target, posted } = createCapturingTarget();
+    const manager = createManager(target, agentId, orgId);
+    const bridge = new ChatResponseBridge(manager as any);
+
+    const registry = new GuardrailRegistry();
+    registerBuiltinGuardrails(registry);
+    const settingsStore = new AgentSettingsStore(createPostgresAgentConfigStore());
+    bridge.setGuardrails(registry, settingsStore);
+
+    const payload = {
+      messageId: 'm1',
+      channelId: '123',
+      conversationId: '123',
+      userId: 'u1',
+      teamId: 't1',
+      timestamp: 0,
+      platform: 'telegram',
+      platformMetadata: {
+        connectionId: 'conn-1',
+        chatId: '123',
+        // agentId omitted on purpose — fallback to connection.agentId
+        // organizationId omitted on purpose — fallback to connection.organizationId
+      },
+    };
+
+    await orgContext.run({ organizationId: orgId }, async () => {
+      await bridge.handleDelta(
+        { ...payload, delta: 'here is sk-abcdefghij0123456789AB please' },
+        'session-1'
+      );
+    });
+
+    // The capturing target should have received exactly the block message,
+    // not the leaked delta.
+    expect(posted).toEqual([
+      expect.objectContaining({
+        text: expect.stringContaining('Message blocked by guardrail'),
+      }),
+    ]);
+    expect(posted[0]?.text).toMatch(/openai-key/);
+
+    await flushPendingGuardrailAudits();
+
+    const rows = await fetchGuardrailEvents(orgId, 'output');
+    expect(rows.length).toBe(1);
+    expect(rows[0]!.metadata.guardrail).toBe('secret-scan');
+    expect(rows[0]!.metadata.stage).toBe('output');
+    expect(rows[0]!.metadata.agent_id).toBe(agentId);
+    expect(rows[0]!.metadata.conversation_id).toBe('123');
+  });
+
+  it('catches a secret split across two stream chunks via rolling buffer', async () => {
+    const { target, posted } = createCapturingTarget();
+    const manager = createManager(target, agentId, orgId);
+    const bridge = new ChatResponseBridge(manager as any);
+
+    const registry = new GuardrailRegistry();
+    registerBuiltinGuardrails(registry);
+    const settingsStore = new AgentSettingsStore(createPostgresAgentConfigStore());
+    bridge.setGuardrails(registry, settingsStore);
+
+    const payload = {
+      messageId: 'm1',
+      channelId: '123',
+      conversationId: '123',
+      userId: 'u1',
+      teamId: 't1',
+      timestamp: 0,
+      platform: 'telegram',
+      platformMetadata: { connectionId: 'conn-1', chatId: '123' },
+    };
+
+    // First chunk doesn't contain the full pattern.
+    await orgContext.run({ organizationId: orgId }, async () => {
+      await bridge.handleDelta({ ...payload, delta: 'leaking sk-a' }, 's');
+      // Second chunk, in isolation, doesn't match either. Only the
+      // concatenation of (rolling tail + this delta) trips the regex.
+      await bridge.handleDelta(
+        { ...payload, delta: 'bcdefghij0123456789ABCD done' },
+        's'
+      );
+    });
+
+    const blockPost = posted.find((p) =>
+      p.text?.startsWith('Message blocked by guardrail')
+    );
+    expect(blockPost).toBeDefined();
+    expect(blockPost!.text).toMatch(/openai-key/);
+
+    await flushPendingGuardrailAudits();
+    const rows = await fetchGuardrailEvents(orgId, 'output');
+    expect(rows.length).toBe(1);
+  });
+
+  it('audits the trip even when platformMetadata.organizationId is missing (connection fallback)', async () => {
+    const { target } = createCapturingTarget();
+    // Build a manager whose connection carries the org id — this is the
+    // canonical fallback for response-bridge audits.
+    const manager = {
+      getInstance: () => ({
+        connection: {
+          agentId,
+          organizationId: orgId,
+          platform: 'telegram',
+        },
+        chat: {
+          channel: () => target,
+          getAdapter: () => undefined,
+        },
+      }),
+      has: () => true,
+    };
+    const bridge = new ChatResponseBridge(manager as any);
+
+    const registry = new GuardrailRegistry();
+    registerBuiltinGuardrails(registry);
+    const settingsStore = new AgentSettingsStore(createPostgresAgentConfigStore());
+    bridge.setGuardrails(registry, settingsStore);
+
+    const payload = {
+      messageId: 'm1',
+      channelId: '123',
+      conversationId: '123',
+      userId: 'u1',
+      teamId: 't1',
+      timestamp: 0,
+      platform: 'telegram',
+      // No organizationId in metadata — bridge must resolve via the connection.
+      platformMetadata: { connectionId: 'conn-1', chatId: '123' },
+    };
+
+    await orgContext.run({ organizationId: orgId }, async () => {
+      await bridge.handleDelta(
+        { ...payload, delta: 'token AKIAIOSFODNN7EXAMPLE leaked' },
+        's'
+      );
+    });
+
+    await flushPendingGuardrailAudits();
+    const rows = await fetchGuardrailEvents(orgId, 'output');
+    expect(rows.length).toBe(1);
+    expect(rows[0]!.metadata.guardrail).toBe('secret-scan');
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// MessageConsumer (input stage)
+// ─────────────────────────────────────────────────────────────────────────
+
+/**
+ * Sub-class that exposes `handleMessage` for direct invocation. Production
+ * paths reach it via the queue subscribe callback in `start()`; for tests
+ * we don't need the actual queue/worker startup machinery, just the wired
+ * call site.
+ */
+class TestableMessageConsumer extends MessageConsumer {
+  async invokeHandleMessage(job: { id?: string; data: any }): Promise<void> {
+    return (this as any).handleMessage(job);
+  }
+}
+
+/**
+ * The shipped built-ins are stage-specific: `secret-scan` is output-stage,
+ * `forbidden-tools` is pre-tool. To exercise the wired MessageConsumer
+ * input path without falsifying its shape, we register a minimal test-only
+ * input guardrail that trips on any message containing "SECRET".
+ */
+const testInputGuardrail: Guardrail<'input'> = {
+  name: 'test-input-tripper',
+  stage: 'input',
+  async run(ctx) {
+    if (ctx.message.includes('SECRET')) {
+      return {
+        tripped: true,
+        reason: 'test-input-tripper saw "SECRET"',
+        metadata: { stage: 'input' },
+      };
+    }
+    return { tripped: false };
+  },
+};
+
+describe('MessageConsumer — wired input guardrail', () => {
+  let orgId: string;
+  let agentId: string;
+
+  beforeEach(async () => {
+    await cleanupTestDatabase();
+    const org = await createTestOrganization({ name: 'Guardrails Input Org' });
+    orgId = org.id;
+    const agent = await createTestAgent({ organizationId: orgId });
+    agentId = agent.agentId;
+
     const configStore = createPostgresAgentConfigStore();
-    const settingsStore = new AgentSettingsStore(configStore);
     await orgContext.run({ organizationId: orgId }, async () => {
       await configStore.saveSettings(agentId, {
-        guardrails: ['secret-scan'],
+        guardrails: ['test-input-tripper'],
         updatedAt: Date.now(),
       });
     });
-
-    // 2. Build the registry the same way the gateway does at boot.
-    const registry = new GuardrailRegistry();
-    registerBuiltinGuardrails(registry);
-
-    // 3. Exercise the same `runGuardrails` shape `ChatResponseBridge` uses on
-    //    a streaming delta. The text contains an OpenAI-key-shaped string.
-    const enabled = (
-      await orgContext.run({ organizationId: orgId }, async () => {
-        return settingsStore.getSettings(agentId);
-      })
-    )?.guardrails ?? [];
-    expect(enabled).toEqual(['secret-scan']);
-
-    const outcome = await runGuardrails(registry, 'output', enabled, {
-      agentId,
-      userId: 'user-1',
-      text: 'here is your secret sk-abcdefghij0123456789AB please',
-      platform: 'api',
-      conversationId: 'conv-1',
-    });
-
-    expect(outcome.tripped).not.toBeNull();
-    expect(outcome.tripped?.guardrail).toBe('secret-scan');
-    expect(outcome.tripped?.reason).toMatch(/openai-key/);
-
-    // 4. Record the trip via the same audit helper the wired code invokes.
-    recordGuardrailTrip({
-      organizationId: orgId,
-      agentId,
-      userId: 'user-1',
-      conversationId: 'conv-1',
-      stage: 'output',
-      guardrail: outcome.tripped!.guardrail,
-      reason: outcome.tripped!.reason,
-      metadata: outcome.tripped!.metadata,
-    });
-
-    // 5. Verify the event row landed with the contract shape. `recordGuardrailTrip`
-    //    is fire-and-forget — give the insert a tick to land.
-    await new Promise((r) => setTimeout(r, 50));
-
-    const db = getTestDb();
-    const rows = await db<{
-      id: number;
-      semantic_type: string;
-      origin_type: string | null;
-      title: string;
-      metadata: any;
-    }[]>`
-      SELECT id, semantic_type, origin_type, title, metadata
-      FROM events
-      WHERE organization_id = ${orgId}
-        AND semantic_type = 'guardrail-trip'
-      ORDER BY id DESC
-      LIMIT 1
-    `;
-
-    expect(rows.length).toBe(1);
-    const row = rows[0]!;
-    expect(row.semantic_type).toBe('guardrail-trip');
-    expect(row.origin_type).toBe('guardrail-output');
-    expect(row.title).toMatch(/secret-scan/);
-    expect(row.metadata.guardrail).toBe('secret-scan');
-    expect(row.metadata.stage).toBe('output');
-    expect(row.metadata.agent_id).toBe(agentId);
-    expect(row.metadata.conversation_id).toBe('conv-1');
   });
 
-  it('passes when settings.guardrails is empty (no enforcement)', async () => {
+  afterAll(async () => {
+    const db = getTestDb();
+    await db`TRUNCATE agents CASCADE`;
+  });
+
+  it('rejects a tripping input, pushes block message to the response queue, audits the trip', async () => {
+    const sentToQueue: Array<{ queue: string; data: any }> = [];
+    const fakeQueue = {
+      start: async () => {},
+      stop: async () => {},
+      createQueue: async () => {},
+      send: async (queue: string, data: any) => {
+        sentToQueue.push({ queue, data });
+        return 'job-id';
+      },
+      work: async () => {},
+      pauseWorker: async () => {},
+      resumeWorker: async () => {},
+      getQueueStats: async () => ({
+        waiting: 0,
+        active: 0,
+        completed: 0,
+        failed: 0,
+      }),
+      isHealthy: () => true,
+    };
+
+    // Stub deployment manager — happy-path branches need it for
+    // listDeployments / scaleDeployment / etc, but the trip path
+    // short-circuits before any of those are called.
+    const fakeDeployments: BaseDeploymentManager = {
+      listDeployments: async () => [],
+      scaleDeployment: async () => {},
+      updateDeploymentActivity: async () => {},
+      createWorkerDeployment: async () => {},
+      syncNetworkConfigGrants: async () => {},
+      deleteDeployment: async () => {},
+      validateWorkerImage: async () => {},
+      setSecretStore: () => {},
+      setGrantStore: () => {},
+      setPolicyStore: () => {},
+      setProviderCatalogService: () => {},
+      setProviderModules: () => {},
+      reconcileDeployments: async () => {},
+      invalidateGrantSyncCache: () => {},
+      clearAllGrantSyncCaches: () => {},
+    } as unknown as BaseDeploymentManager;
+
+    const config: OrchestratorConfig = {
+      queues: { retryLimit: 1, expireInSeconds: 60 },
+      cleanup: { initialDelayMs: 1_000_000, intervalMs: 1_000_000 },
+    } as OrchestratorConfig;
+
+    const consumer = new TestableMessageConsumer(config, fakeDeployments);
+    // Swap in the fake queue — `MessageConsumer` constructs a RunsQueue
+    // by default which would try to connect.
+    (consumer as any).queue = fakeQueue;
+
+    const registry = new GuardrailRegistry();
+    registerBuiltinGuardrails(registry);
+    registry.register(testInputGuardrail);
+    const settingsStore = new AgentSettingsStore(createPostgresAgentConfigStore());
+    consumer.setGuardrails(registry, settingsStore);
+
+    await orgContext.run({ organizationId: orgId }, async () => {
+      await consumer.invokeHandleMessage({
+        id: '1',
+        data: {
+          userId: 'u1',
+          conversationId: 'conv-1',
+          messageId: 'm1',
+          channelId: 'c1',
+          teamId: 't1',
+          agentId,
+          organizationId: orgId,
+          botId: 'bot',
+          platform: 'telegram',
+          messageText: 'hello SECRET world',
+          platformMetadata: {},
+          agentOptions: {},
+        },
+      });
+    });
+
+    // The trip path must NOT enqueue to the worker thread queue and MUST
+    // enqueue a single thread_response with the rejection content.
+    const threadResponses = sentToQueue.filter(
+      (q) => q.queue === 'thread_response'
+    );
+    const workerEnqueues = sentToQueue.filter((q) =>
+      q.queue.startsWith('thread_message_')
+    );
+    expect(workerEnqueues.length).toBe(0);
+    expect(threadResponses.length).toBe(1);
+    expect(threadResponses[0]!.data.content).toMatch(/Message rejected:/);
+    expect(threadResponses[0]!.data.content).toMatch(/SECRET/);
+
+    await flushPendingGuardrailAudits();
+    const rows = await fetchGuardrailEvents(orgId, 'input');
+    expect(rows.length).toBe(1);
+    expect(rows[0]!.metadata.guardrail).toBe('test-input-tripper');
+  });
+
+  it('falls back to agent-metadata orgId when payload omits organizationId', async () => {
+    const sentToQueue: Array<{ queue: string; data: any }> = [];
+    const fakeQueue = {
+      start: async () => {},
+      stop: async () => {},
+      createQueue: async () => {},
+      send: async (queue: string, data: any) => {
+        sentToQueue.push({ queue, data });
+        return 'job-id';
+      },
+      work: async () => {},
+      pauseWorker: async () => {},
+      resumeWorker: async () => {},
+      getQueueStats: async () => ({
+        waiting: 0,
+        active: 0,
+        completed: 0,
+        failed: 0,
+      }),
+      isHealthy: () => true,
+    };
+    const fakeDeployments = {
+      listDeployments: async () => [],
+    } as unknown as BaseDeploymentManager;
+
+    const consumer = new TestableMessageConsumer(
+      { queues: { retryLimit: 1, expireInSeconds: 60 } } as OrchestratorConfig,
+      fakeDeployments
+    );
+    (consumer as any).queue = fakeQueue;
+
+    const registry = new GuardrailRegistry();
+    registerBuiltinGuardrails(registry);
+    registry.register(testInputGuardrail);
+    const settingsStore = new AgentSettingsStore(createPostgresAgentConfigStore());
+    consumer.setGuardrails(registry, settingsStore);
+
+    await orgContext.run({ organizationId: orgId }, async () => {
+      await consumer.invokeHandleMessage({
+        id: '1',
+        data: {
+          userId: 'u1',
+          conversationId: 'conv-1',
+          messageId: 'm1',
+          channelId: 'c1',
+          teamId: 't1',
+          agentId,
+          // organizationId intentionally absent — exercises metadata fallback
+          botId: 'bot',
+          platform: 'telegram',
+          messageText: 'leaking SECRET data',
+          platformMetadata: {},
+          agentOptions: {},
+        },
+      });
+    });
+
+    await flushPendingGuardrailAudits();
+    const rows = await fetchGuardrailEvents(orgId, 'input');
+    expect(rows.length).toBe(1);
+    expect(rows[0]!.metadata.guardrail).toBe('test-input-tripper');
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// McpProxy (pre-tool stage)
+// ─────────────────────────────────────────────────────────────────────────
+
+describe('McpProxy — wired pre-tool guardrail', () => {
+  let orgId: string;
+  let agentId: string;
+
+  beforeEach(async () => {
+    await cleanupTestDatabase();
+    const org = await createTestOrganization({
+      name: 'Guardrails Pre-Tool Org',
+    });
+    orgId = org.id;
+    const agent = await createTestAgent({ organizationId: orgId });
+    agentId = agent.agentId;
+
     const configStore = createPostgresAgentConfigStore();
     await orgContext.run({ organizationId: orgId }, async () => {
-      await configStore.saveSettings(agentId, { updatedAt: Date.now() });
+      await configStore.saveSettings(agentId, {
+        guardrails: ['forbidden-tools'],
+        updatedAt: Date.now(),
+      });
     });
+  });
+
+  afterAll(async () => {
+    const db = getTestDb();
+    await db`TRUNCATE agents CASCADE`;
+  });
+
+  it('blocks a forbidden tool with generic policy text and audits the trip', async () => {
+    // Minimal McpConfigSource that always returns an HTTP server config —
+    // we don't need real upstream behavior, only the gate before forwardRequest.
+    const fakeConfigService = {
+      getHttpServer: async () => ({
+        url: 'http://upstream.invalid/mcp',
+        type: 'http' as const,
+      }),
+      getAllHttpServers: async () => new Map(),
+    };
+
+    const defaultSecretStore = new PostgresSecretStore();
+    const secretStore = new SecretStoreRegistry(defaultSecretStore, {
+      secret: defaultSecretStore,
+    });
+    const grantStore = new GrantStore();
+    const settingsStore = new AgentSettingsStore(createPostgresAgentConfigStore());
 
     const registry = new GuardrailRegistry();
     registerBuiltinGuardrails(registry);
 
-    const outcome = await runGuardrails(registry, 'output', [], {
-      agentId,
-      userId: 'user-1',
-      text: 'sk-abcdefghij0123456789AB',
-      platform: 'api',
-      conversationId: 'conv-1',
+    const proxy = new McpProxy(fakeConfigService as any, {
+      secretStore,
+      grantStore,
+      agentSettingsStore: settingsStore,
+      guardrailRegistry: registry,
     });
 
-    expect(outcome.tripped).toBeNull();
-    expect(outcome.ran).toEqual([]);
-  });
-
-  it('secret-scan passes safe output', async () => {
-    const outcome = await secretScanGuardrail.run({
+    // Mint a real worker token (uses ENCRYPTION_KEY set by global setup).
+    const token = generateWorkerToken('u1', 'conv-1', 'deployment-1', {
+      channelId: 'c1',
+      teamId: 't1',
       agentId,
-      userId: 'u',
-      text: 'hello world, no secrets here',
-      platform: 'api',
+      organizationId: orgId,
+      platform: 'telegram',
     });
-    expect(outcome.tripped).toBe(false);
-  });
 
-  it('secret-scan matches GitHub PAT shape', async () => {
-    const outcome = await secretScanGuardrail.run({
-      agentId,
-      userId: 'u',
-      text: 'token: ghp_abcdefghij0123456789ABCDEFGH01234567',
-      platform: 'api',
+    const body = JSON.stringify({
+      jsonrpc: '2.0',
+      id: 42,
+      method: 'tools/call',
+      params: { name: 'delete_repo', arguments: { repo: 'org/x' } },
     });
-    expect(outcome.tripped).toBe(true);
-    expect(outcome.metadata).toMatchObject({ pattern: 'github-pat' });
-  });
 
-  it('secret-scan matches AWS access key shape', async () => {
-    const outcome = await secretScanGuardrail.run({
-      agentId,
-      userId: 'u',
-      text: 'AWS_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMPLE',
-      platform: 'api',
-    });
-    expect(outcome.tripped).toBe(true);
-    expect(outcome.metadata).toMatchObject({ pattern: 'aws-access-key' });
-  });
-
-  it('forbidden-tools registers and trips on delete_repo', async () => {
-    const registry = new GuardrailRegistry();
-    registerBuiltinGuardrails(registry);
-
-    const outcome = await runGuardrails(
-      registry,
-      'pre-tool',
-      ['forbidden-tools'],
-      {
-        agentId,
-        userId: 'u',
-        toolName: 'delete_repo',
-        arguments: { repo: 'org/x' },
+    const response = await orgContext.run(
+      { organizationId: orgId },
+      async () => {
+        return proxy.getApp().fetch(
+          new Request('http://localhost/test-mcp', {
+            method: 'POST',
+            headers: {
+              authorization: `Bearer ${token}`,
+              'content-type': 'application/json',
+            },
+            body,
+          })
+        );
       }
     );
 
-    expect(outcome.tripped).not.toBeNull();
-    expect(outcome.tripped?.guardrail).toBe('forbidden-tools');
+    expect(response.status).toBe(200);
+    const json = (await response.json()) as any;
+    expect(json.jsonrpc).toBe('2.0');
+    expect(json.id).toBe(42);
+    expect(json.result.isError).toBe(true);
+    // Generic text — no reason leak.
+    expect(json.result.content[0].text).toBe('Tool call blocked by policy.');
+    expect(json.result.content[0].text).not.toMatch(/delete_repo/);
+
+    await flushPendingGuardrailAudits();
+    const rows = await fetchGuardrailEvents(orgId, 'pre-tool');
+    expect(rows.length).toBe(1);
+    expect(rows[0]!.metadata.guardrail).toBe('forbidden-tools');
+    // Reason is recorded in the audit row even though it's not surfaced
+    // to the worker — operators need it.
+    expect(rows[0]!.metadata.reason).toMatch(/delete_repo/);
   });
+});
 
-  it('forbidden-tools passes safe tools', async () => {
-    const registry = new GuardrailRegistry();
-    registerBuiltinGuardrails(registry);
+// ─────────────────────────────────────────────────────────────────────────
+// Reset for global test isolation
+// ─────────────────────────────────────────────────────────────────────────
 
-    const outcome = await runGuardrails(
-      registry,
-      'pre-tool',
-      ['forbidden-tools'],
-      {
-        agentId,
-        userId: 'u',
-        toolName: 'read_file',
-        arguments: {},
-      }
-    );
-
-    expect(outcome.tripped).toBeNull();
-  });
+afterEach(async () => {
+  // Drain anything still in flight so it doesn't leak into the next test.
+  await flushPendingGuardrailAudits();
 });

--- a/packages/server/src/__tests__/guardrails-runtime.test.ts
+++ b/packages/server/src/__tests__/guardrails-runtime.test.ts
@@ -1,0 +1,222 @@
+/**
+ * End-to-end guardrails-runtime smoke test.
+ *
+ * Boots the bare minimum to exercise the wired call sites against a real DB:
+ *   - createPostgresAgentConfigStore + AgentSettingsStore (real settings lookup)
+ *   - GuardrailRegistry populated via the same `registerBuiltinGuardrails`
+ *     the gateway uses at boot
+ *   - The same `runGuardrails(...)` path the wired code invokes
+ *   - A real `events` row produced by `recordGuardrailTrip` (the audit-trail
+ *     side of every trip) — proving the join-up writes land.
+ *
+ * Doesn't boot the HTTP server or workers (would require provider keys + the
+ * full Lobu stack). The three wired call sites all share the same shape:
+ * load settings, run guardrails, on trip → emit audit row + branch. This test
+ * pins that shape against a live DB.
+ */
+
+import { afterAll, beforeEach, describe, expect, it } from 'vitest';
+import { AgentSettingsStore } from '../gateway/auth/settings/agent-settings-store';
+import { recordGuardrailTrip } from '../gateway/guardrails/audit';
+import {
+  registerBuiltinGuardrails,
+  secretScanGuardrail,
+} from '../gateway/guardrails/builtins';
+import { GuardrailRegistry, runGuardrails } from '@lobu/core';
+import { orgContext } from '../lobu/stores/org-context';
+import { createPostgresAgentConfigStore } from '../lobu/stores/postgres-stores';
+import { cleanupTestDatabase, getTestDb } from './setup/test-db';
+import {
+  createTestAgent,
+  createTestOrganization,
+} from './setup/test-fixtures';
+
+describe('guardrails runtime — wired-path E2E', () => {
+  let orgId: string;
+  let agentId: string;
+
+  beforeEach(async () => {
+    await cleanupTestDatabase();
+    const org = await createTestOrganization({ name: 'Guardrails Org' });
+    orgId = org.id;
+    const agent = await createTestAgent({ organizationId: orgId });
+    agentId = agent.agentId;
+  });
+
+  afterAll(async () => {
+    const db = getTestDb();
+    await db`TRUNCATE agents CASCADE`;
+  });
+
+  it('secret-scan trips on the output stage when enabled in settings, audited as a guardrail-trip event', async () => {
+    // 1. Persist `guardrails = ["secret-scan"]` on the agent — exact write path
+    //    the wired runtime reads from on every message.
+    const configStore = createPostgresAgentConfigStore();
+    const settingsStore = new AgentSettingsStore(configStore);
+    await orgContext.run({ organizationId: orgId }, async () => {
+      await configStore.saveSettings(agentId, {
+        guardrails: ['secret-scan'],
+        updatedAt: Date.now(),
+      });
+    });
+
+    // 2. Build the registry the same way the gateway does at boot.
+    const registry = new GuardrailRegistry();
+    registerBuiltinGuardrails(registry);
+
+    // 3. Exercise the same `runGuardrails` shape `ChatResponseBridge` uses on
+    //    a streaming delta. The text contains an OpenAI-key-shaped string.
+    const enabled = (
+      await orgContext.run({ organizationId: orgId }, async () => {
+        return settingsStore.getSettings(agentId);
+      })
+    )?.guardrails ?? [];
+    expect(enabled).toEqual(['secret-scan']);
+
+    const outcome = await runGuardrails(registry, 'output', enabled, {
+      agentId,
+      userId: 'user-1',
+      text: 'here is your secret sk-abcdefghij0123456789AB please',
+      platform: 'api',
+      conversationId: 'conv-1',
+    });
+
+    expect(outcome.tripped).not.toBeNull();
+    expect(outcome.tripped?.guardrail).toBe('secret-scan');
+    expect(outcome.tripped?.reason).toMatch(/openai-key/);
+
+    // 4. Record the trip via the same audit helper the wired code invokes.
+    recordGuardrailTrip({
+      organizationId: orgId,
+      agentId,
+      userId: 'user-1',
+      conversationId: 'conv-1',
+      stage: 'output',
+      guardrail: outcome.tripped!.guardrail,
+      reason: outcome.tripped!.reason,
+      metadata: outcome.tripped!.metadata,
+    });
+
+    // 5. Verify the event row landed with the contract shape. `recordGuardrailTrip`
+    //    is fire-and-forget — give the insert a tick to land.
+    await new Promise((r) => setTimeout(r, 50));
+
+    const db = getTestDb();
+    const rows = await db<{
+      id: number;
+      semantic_type: string;
+      origin_type: string | null;
+      title: string;
+      metadata: any;
+    }[]>`
+      SELECT id, semantic_type, origin_type, title, metadata
+      FROM events
+      WHERE organization_id = ${orgId}
+        AND semantic_type = 'guardrail-trip'
+      ORDER BY id DESC
+      LIMIT 1
+    `;
+
+    expect(rows.length).toBe(1);
+    const row = rows[0]!;
+    expect(row.semantic_type).toBe('guardrail-trip');
+    expect(row.origin_type).toBe('guardrail-output');
+    expect(row.title).toMatch(/secret-scan/);
+    expect(row.metadata.guardrail).toBe('secret-scan');
+    expect(row.metadata.stage).toBe('output');
+    expect(row.metadata.agent_id).toBe(agentId);
+    expect(row.metadata.conversation_id).toBe('conv-1');
+  });
+
+  it('passes when settings.guardrails is empty (no enforcement)', async () => {
+    const configStore = createPostgresAgentConfigStore();
+    await orgContext.run({ organizationId: orgId }, async () => {
+      await configStore.saveSettings(agentId, { updatedAt: Date.now() });
+    });
+
+    const registry = new GuardrailRegistry();
+    registerBuiltinGuardrails(registry);
+
+    const outcome = await runGuardrails(registry, 'output', [], {
+      agentId,
+      userId: 'user-1',
+      text: 'sk-abcdefghij0123456789AB',
+      platform: 'api',
+      conversationId: 'conv-1',
+    });
+
+    expect(outcome.tripped).toBeNull();
+    expect(outcome.ran).toEqual([]);
+  });
+
+  it('secret-scan passes safe output', async () => {
+    const outcome = await secretScanGuardrail.run({
+      agentId,
+      userId: 'u',
+      text: 'hello world, no secrets here',
+      platform: 'api',
+    });
+    expect(outcome.tripped).toBe(false);
+  });
+
+  it('secret-scan matches GitHub PAT shape', async () => {
+    const outcome = await secretScanGuardrail.run({
+      agentId,
+      userId: 'u',
+      text: 'token: ghp_abcdefghij0123456789ABCDEFGH01234567',
+      platform: 'api',
+    });
+    expect(outcome.tripped).toBe(true);
+    expect(outcome.metadata).toMatchObject({ pattern: 'github-pat' });
+  });
+
+  it('secret-scan matches AWS access key shape', async () => {
+    const outcome = await secretScanGuardrail.run({
+      agentId,
+      userId: 'u',
+      text: 'AWS_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMPLE',
+      platform: 'api',
+    });
+    expect(outcome.tripped).toBe(true);
+    expect(outcome.metadata).toMatchObject({ pattern: 'aws-access-key' });
+  });
+
+  it('forbidden-tools registers and trips on delete_repo', async () => {
+    const registry = new GuardrailRegistry();
+    registerBuiltinGuardrails(registry);
+
+    const outcome = await runGuardrails(
+      registry,
+      'pre-tool',
+      ['forbidden-tools'],
+      {
+        agentId,
+        userId: 'u',
+        toolName: 'delete_repo',
+        arguments: { repo: 'org/x' },
+      }
+    );
+
+    expect(outcome.tripped).not.toBeNull();
+    expect(outcome.tripped?.guardrail).toBe('forbidden-tools');
+  });
+
+  it('forbidden-tools passes safe tools', async () => {
+    const registry = new GuardrailRegistry();
+    registerBuiltinGuardrails(registry);
+
+    const outcome = await runGuardrails(
+      registry,
+      'pre-tool',
+      ['forbidden-tools'],
+      {
+        agentId,
+        userId: 'u',
+        toolName: 'read_file',
+        arguments: {},
+      }
+    );
+
+    expect(outcome.tripped).toBeNull();
+  });
+});

--- a/packages/server/src/gateway/auth/mcp/proxy.ts
+++ b/packages/server/src/gateway/auth/mcp/proxy.ts
@@ -1,12 +1,19 @@
 import { randomUUID } from "node:crypto";
 import dns from "node:dns/promises";
-import { createLogger, verifyWorkerToken } from "@lobu/core";
+import {
+  createLogger,
+  type GuardrailRegistry,
+  runGuardrails,
+  verifyWorkerToken,
+} from "@lobu/core";
 import type { Context } from "hono";
 import { Hono } from "hono";
 import { storePendingTool } from "./pending-tool-store.js";
 import { getRevokedTokenStore } from "../revoked-token-store.js";
 import { requiresToolApproval } from "../../permissions/approval-policy.js";
 import type { GrantStore } from "../../permissions/grant-store.js";
+import type { AgentSettingsStore } from "../settings/agent-settings-store.js";
+import { recordGuardrailTrip } from "../../guardrails/audit.js";
 import {
   getStoredCredential,
   refreshCredential,
@@ -211,6 +218,8 @@ export class McpProxy {
   private readonly secretStore: WritableSecretStore;
   private readonly grantStore?: GrantStore;
   private readonly publicGatewayUrl?: string;
+  private readonly agentSettingsStore?: AgentSettingsStore;
+  private readonly guardrailRegistry?: GuardrailRegistry;
 
   /** Callback invoked when a tool call is blocked for approval. */
   public onToolBlocked?: (
@@ -254,12 +263,18 @@ export class McpProxy {
       grantStore?: GrantStore;
       /** Absolute gateway URL for OAuth redirect_uri construction. */
       publicGatewayUrl?: string;
+      /** Source of per-agent guardrail enable lists for the pre-tool stage. */
+      agentSettingsStore?: AgentSettingsStore;
+      /** Shared registry of guardrails; pre-tool stage entries are queried. */
+      guardrailRegistry?: GuardrailRegistry;
     }
   ) {
     this.secretStore = options.secretStore;
     this.toolCache = options.toolCache;
     this.grantStore = options.grantStore;
     this.publicGatewayUrl = options.publicGatewayUrl;
+    this.agentSettingsStore = options.agentSettingsStore;
+    this.guardrailRegistry = options.guardrailRegistry;
     this.app = new Hono();
     this.setupRoutes();
     logger.debug("MCP proxy initialized");
@@ -984,12 +999,79 @@ export class McpProxy {
           if (jsonRpc.method === "tools/call" && jsonRpc.params?.name) {
             const toolName = jsonRpc.params.name;
             const toolArgs = jsonRpc.params.arguments || {};
-            // TODO(#254): pre-tool-stage guardrail hook. Before the existing
-            // approval check below, call runGuardrails("pre-tool", registry,
-            // settings.guardrails, { toolName, arguments: toolArgs, agentId, ...}).
-            // On trip: reuse the onToolBlocked path to return a JSON-RPC error
-            // with trip.reason. Wiring deferred to the PR that registers the
-            // first real pre-tool guardrail.
+
+            // Pre-tool guardrails: run before the existing approval check so
+            // a blocked tool never enters the approval funnel. The worker
+            // sees a generic policy message — the specific reason is
+            // intentionally NOT surfaced (evasion surface).
+            if (this.guardrailRegistry && this.agentSettingsStore) {
+              try {
+                const settings =
+                  await this.agentSettingsStore.getSettings(agentId);
+                const enabled = settings?.guardrails ?? [];
+                if (enabled.length > 0) {
+                  const outcome = await runGuardrails(
+                    this.guardrailRegistry,
+                    "pre-tool",
+                    enabled,
+                    {
+                      agentId,
+                      userId: tokenData.userId,
+                      toolName,
+                      arguments: toolArgs,
+                      conversationId: tokenData.conversationId,
+                    }
+                  );
+                  if (outcome.tripped) {
+                    recordGuardrailTrip({
+                      organizationId: tokenData.organizationId,
+                      agentId,
+                      userId: tokenData.userId,
+                      conversationId: tokenData.conversationId,
+                      stage: "pre-tool",
+                      guardrail: outcome.tripped.guardrail,
+                      reason: outcome.tripped.reason,
+                      metadata: outcome.tripped.metadata,
+                    });
+                    logger.info(
+                      {
+                        agentId,
+                        toolName,
+                        guardrail: outcome.tripped.guardrail,
+                      },
+                      "Pre-tool guardrail tripped — returning generic policy block to worker"
+                    );
+                    return c.json({
+                      jsonrpc: "2.0",
+                      id: jsonRpc.id,
+                      result: {
+                        content: [
+                          {
+                            type: "text",
+                            text: "Tool call blocked by policy.",
+                          },
+                        ],
+                        isError: true,
+                      },
+                    });
+                  }
+                }
+              } catch (err) {
+                // Treat lookup/runner failures as a pass — guardrails are a
+                // safety net, not a hard dependency. The runner itself
+                // already fail-opens on individual guardrail throws; this
+                // catch covers settings-store outages.
+                logger.warn(
+                  {
+                    agentId,
+                    toolName,
+                    err: err instanceof Error ? err.message : String(err),
+                  },
+                  "Pre-tool guardrail check failed — proceeding without guardrails"
+                );
+              }
+            }
+
             const approval = await this.evaluateToolApproval(
               mcpId,
               toolName,

--- a/packages/server/src/gateway/auth/mcp/proxy.ts
+++ b/packages/server/src/gateway/auth/mcp/proxy.ts
@@ -1023,11 +1023,10 @@ export class McpProxy {
                     }
                   );
                   if (outcome.tripped) {
-                    // Resolve org id with a metadata fallback: per-job
-                    // tokens minted by the runs-queue dispatcher carry it,
-                    // but legacy deployment-lifetime tokens may not. A
-                    // trip that fails to audit is a security log gap, so
-                    // hit the agent row before giving up.
+                    // Resolve org id with a metadata fallback — per-job
+                    // tokens carry it, but legacy deployment-lifetime
+                    // tokens may not, and an unaudited trip is a security
+                    // log gap.
                     let resolvedOrgId = tokenData.organizationId;
                     if (!resolvedOrgId) {
                       try {
@@ -1047,8 +1046,6 @@ export class McpProxy {
                         );
                       }
                     }
-                    // Fire-and-forget — never blocks the JSON-RPC reply.
-                    // Tests use `flushPendingGuardrailAudits` to drain.
                     void recordGuardrailTrip({
                       organizationId: resolvedOrgId,
                       agentId,
@@ -1083,10 +1080,8 @@ export class McpProxy {
                   }
                 }
               } catch (err) {
-                // Treat lookup/runner failures as a pass — guardrails are a
-                // safety net, not a hard dependency. The runner itself
-                // already fail-opens on individual guardrail throws; this
-                // catch covers settings-store outages.
+                // Fail open on store/registry-level errors — the runner
+                // already fail-opens on per-guardrail throws.
                 logger.warn(
                   {
                     agentId,

--- a/packages/server/src/gateway/auth/mcp/proxy.ts
+++ b/packages/server/src/gateway/auth/mcp/proxy.ts
@@ -1023,8 +1023,34 @@ export class McpProxy {
                     }
                   );
                   if (outcome.tripped) {
-                    recordGuardrailTrip({
-                      organizationId: tokenData.organizationId,
+                    // Resolve org id with a metadata fallback: per-job
+                    // tokens minted by the runs-queue dispatcher carry it,
+                    // but legacy deployment-lifetime tokens may not. A
+                    // trip that fails to audit is a security log gap, so
+                    // hit the agent row before giving up.
+                    let resolvedOrgId = tokenData.organizationId;
+                    if (!resolvedOrgId) {
+                      try {
+                        const md =
+                          await this.agentSettingsStore.getMetadata(agentId);
+                        resolvedOrgId = md?.organizationId;
+                      } catch (lookupErr) {
+                        logger.warn(
+                          {
+                            agentId,
+                            err:
+                              lookupErr instanceof Error
+                                ? lookupErr.message
+                                : String(lookupErr),
+                          },
+                          "Pre-tool guardrail trip: orgId metadata lookup failed (audit may be skipped)"
+                        );
+                      }
+                    }
+                    // Fire-and-forget — never blocks the JSON-RPC reply.
+                    // Tests use `flushPendingGuardrailAudits` to drain.
+                    void recordGuardrailTrip({
+                      organizationId: resolvedOrgId,
                       agentId,
                       userId: tokenData.userId,
                       conversationId: tokenData.conversationId,

--- a/packages/server/src/gateway/connections/chat-response-bridge.ts
+++ b/packages/server/src/gateway/connections/chat-response-bridge.ts
@@ -26,6 +26,10 @@ import { extractSettingsLinkButtons } from "../platform/link-buttons.js";
 import type { ResponseRenderer } from "../platform/response-renderer.js";
 import type { ChatInstanceManager } from "./chat-instance-manager.js";
 import {
+  platformMetadataString,
+  readPlatformMetadata,
+} from "./platform-metadata.js";
+import {
   getResponseStrategy,
   type PlatformResponseStrategy,
   type StreamState,
@@ -45,13 +49,12 @@ function buildCurrentMessageFromMetadata(
   threadId: string,
   platformMetadata: Record<string, unknown> | undefined
 ): Record<string, unknown> | undefined {
-  const senderId = platformMetadata?.senderId as string | undefined;
+  const md = readPlatformMetadata(platformMetadata);
+  const senderId = md.senderId;
   if (!senderId) return undefined;
-  const senderUsername = platformMetadata?.senderUsername as string | undefined;
-  const senderDisplayName = platformMetadata?.senderDisplayName as
-    | string
-    | undefined;
-  const teamId = platformMetadata?.teamId as string | undefined;
+  const senderUsername = md.senderUsername;
+  const senderDisplayName = md.senderDisplayName;
+  const teamId = md.teamId;
   return {
     threadId,
     text: "",
@@ -73,6 +76,22 @@ interface ResponseContext {
 }
 
 /**
+ * Streaming chunks split arbitrarily across token boundaries. A secret like
+ * `sk-abc...` can arrive as `"sk-an"` then `"t-..."` and bypass every
+ * per-delta regex. The bridge keeps a rolling tail of recent emitted text
+ * per stream key (capped at OUTPUT_GUARDRAIL_TAIL_CHARS) and prepends it
+ * to the next delta before scanning, so a pattern straddling a chunk
+ * boundary still matches. Cleared on stream completion / dispose.
+ *
+ * 256 chars is generous against the regexes the built-ins ship — the
+ * longest pattern (JWT) is bounded only on its first segment but the
+ * second `.eyJ…` re-anchors, so a tail well above the first-segment
+ * minimum suffices. Keep it tight to avoid quadratic scan cost on long
+ * streams.
+ */
+const OUTPUT_GUARDRAIL_TAIL_CHARS = 256;
+
+/**
  * ChatResponseBridge implements ResponseRenderer so it can be plugged into
  * the unified thread consumer alongside legacy platform renderers.
  */
@@ -84,6 +103,12 @@ export class ChatResponseBridge implements ResponseRenderer {
    * completion buffer) reach the platform.
    */
   private blockedStreams = new Set<string>();
+  /**
+   * Per-stream rolling tail of emitted output text, used as a prefix when
+   * scanning the next delta so secrets split across chunk boundaries still
+   * match. Keyed by the same `key` as `streams`.
+   */
+  private guardrailTails = new Map<string, string>();
   private guardrailRegistry?: GuardrailRegistry;
   private agentSettingsStore?: AgentSettingsStore;
 
@@ -111,8 +136,8 @@ export class ChatResponseBridge implements ResponseRenderer {
     payload: ThreadResponsePayload,
     ctx: ResponseContext
   ): string | null {
-    const fromMetadata = (payload.platformMetadata as any)?.agentId;
-    if (typeof fromMetadata === "string" && fromMetadata) return fromMetadata;
+    const md = readPlatformMetadata(payload.platformMetadata);
+    if (md.agentId) return md.agentId;
     const fromConnection = ctx.instance?.connection?.agentId;
     if (typeof fromConnection === "string" && fromConnection)
       return fromConnection;
@@ -120,17 +145,71 @@ export class ChatResponseBridge implements ResponseRenderer {
   }
 
   /**
+   * Resolve the organization id for audit attribution. Workers attach it
+   * on `platformMetadata.organizationId`; the canonical fallback is the
+   * connection record (`instance.connection.organizationId`), which is
+   * set when the connection was created via the connections CRUD API and
+   * is durable across requests. Returns `undefined` only when neither is
+   * available — in that case the audit module logs the gap loudly.
+   */
+  private resolveOrganizationId(
+    payload: ThreadResponsePayload,
+    ctx: ResponseContext
+  ): string | undefined {
+    const md = readPlatformMetadata(payload.platformMetadata);
+    if (md.organizationId) return md.organizationId;
+    const fromConnection = ctx.instance?.connection?.organizationId;
+    if (typeof fromConnection === "string" && fromConnection)
+      return fromConnection;
+    return undefined;
+  }
+
+  /**
+   * Append `delta` to the per-stream tail and return the rolling window
+   * (tail-prefix + delta, capped at `OUTPUT_GUARDRAIL_TAIL_CHARS * 2`)
+   * that should be scanned. The cap keeps the scanned slice bounded —
+   * the slice length is at most ~2× the tail, so regex cost stays
+   * proportional to the chunk being processed, not the entire stream.
+   */
+  private updateGuardrailTail(key: string, delta: string): string {
+    const previous = this.guardrailTails.get(key) ?? "";
+    const combined = previous + delta;
+    // Keep the last 2 × tail chars so the next call can still build a
+    // tail-prefix from this combined window if needed.
+    const nextTail = combined.slice(-OUTPUT_GUARDRAIL_TAIL_CHARS * 2);
+    this.guardrailTails.set(key, nextTail);
+    // Return the scan slice: previous tail + current delta. Bound at
+    // 2× tail to stay cheap.
+    const scanSlice =
+      previous.length > 0 ? previous + delta : delta;
+    return scanSlice.length > OUTPUT_GUARDRAIL_TAIL_CHARS * 2
+      ? scanSlice.slice(-OUTPUT_GUARDRAIL_TAIL_CHARS * 2)
+      : scanSlice;
+  }
+
+  /** Drop the rolling tail when a stream finishes or is disposed. */
+  private clearGuardrailTail(key: string): void {
+    this.guardrailTails.delete(key);
+  }
+
+  /**
    * Run output-stage guardrails for a single delta. Returns the trip outcome
    * (already audited) when blocked, `null` when the delta is safe to send.
    * Failures inside the runner are logged and treated as a pass.
+   *
+   * The scan operates on `tailPrefix + delta`, not just `delta`, so a
+   * secret split across two streaming chunks still trips on the second
+   * chunk. The tail is updated in `handleDelta` only after a passing
+   * scan — a tripped stream is disposed and its tail dropped, so we
+   * never carry blocked-stream state forward.
    */
   private async runOutputGuardrails(
-    text: string,
+    scanText: string,
     payload: ThreadResponsePayload,
     ctx: ResponseContext
   ): Promise<{ guardrail: string; reason?: string } | null> {
     if (!this.guardrailRegistry || !this.agentSettingsStore) return null;
-    if (!text) return null;
+    if (!scanText) return null;
     const agentId = this.resolveAgentId(payload, ctx);
     if (!agentId) return null;
 
@@ -145,17 +224,16 @@ export class ChatResponseBridge implements ResponseRenderer {
         {
           agentId,
           userId: payload.userId,
-          text,
+          text: scanText,
           platform: ctx.platform,
           conversationId: payload.conversationId,
         }
       );
       if (!outcome.tripped) return null;
-      const orgIdFromMetadata = (payload.platformMetadata as any)
-        ?.organizationId;
-      recordGuardrailTrip({
-        organizationId:
-          typeof orgIdFromMetadata === "string" ? orgIdFromMetadata : undefined,
+      // Fire-and-forget: the audit module returns a promise that never
+      // rejects. Don't block delivery of the block message on the write.
+      void recordGuardrailTrip({
+        organizationId: this.resolveOrganizationId(payload, ctx),
         agentId,
         userId: payload.userId,
         conversationId: payload.conversationId,
@@ -182,16 +260,14 @@ export class ChatResponseBridge implements ResponseRenderer {
   private extractResponseContext(
     payload: ThreadResponsePayload
   ): ResponseContext | null {
-    const connectionId = (payload.platformMetadata as any)?.connectionId;
+    const md = readPlatformMetadata(payload.platformMetadata);
+    const connectionId = md.connectionId;
     if (!connectionId) return null;
 
     const instance = this.manager.getInstance(connectionId);
     if (!instance) return null;
 
-    const channelId =
-      (payload.platformMetadata as any)?.chatId ??
-      (payload.platformMetadata as any)?.responseChannel ??
-      payload.channelId;
+    const channelId = md.chatId ?? md.responseChannel ?? payload.channelId;
 
     const platform = instance.connection.platform;
 
@@ -209,7 +285,10 @@ export class ChatResponseBridge implements ResponseRenderer {
    * Returns false if the connection is not managed — the caller should fall through to legacy.
    */
   canHandle(data: ThreadResponsePayload): boolean {
-    const connectionId = (data.platformMetadata as any)?.connectionId;
+    const connectionId = platformMetadataString(
+      data.platformMetadata,
+      "connectionId"
+    );
     return !!connectionId && this.manager.has(connectionId);
   }
 
@@ -232,13 +311,18 @@ export class ChatResponseBridge implements ResponseRenderer {
     // async to the worker — silently swallowing the tail is correct.
     if (this.blockedStreams.has(key)) return null;
 
-    // Per-delta output guardrails. Regex-shaped checks are cheap enough to
-    // run on every chunk; LLM-judge guardrails should batch upstream
-    // (PR B). On trip, emit a generic block message in-place instead of
-    // the model output and mark the stream blocked.
-    const trip = await this.runOutputGuardrails(payload.delta, payload, ctx);
+    // Per-delta output guardrails. We scan `(rolling tail) + delta` so a
+    // secret split across two streaming chunks ("sk-ab" then "cd…") still
+    // trips on the second chunk. The tail is only updated after a passing
+    // scan — tripping disposes the stream and drops its tail.
+    const scanText = this.updateGuardrailTail(key, payload.delta);
+    const trip = await this.runOutputGuardrails(scanText, payload, ctx);
     if (trip) {
       this.blockedStreams.add(key);
+      // Drop the rolling tail — the stream is dead, no further deltas
+      // will be scanned for this key, and we don't want a future stream
+      // re-using the key to inherit the blocked stream's bytes.
+      this.clearGuardrailTail(key);
       // Close any in-flight strategy stream so the partial output that
       // already shipped to the platform terminates cleanly. We can't
       // unsend bytes already delivered, but for the default strategy
@@ -264,7 +348,7 @@ export class ChatResponseBridge implements ResponseRenderer {
           instance,
           channelId,
           payload.conversationId,
-          (payload.platformMetadata as any)?.responseThreadId,
+          platformMetadataString(payload.platformMetadata, "responseThreadId"),
           payload.platformMetadata as Record<string, unknown> | undefined
         );
         if (target) {
@@ -290,6 +374,10 @@ export class ChatResponseBridge implements ResponseRenderer {
       await strategy.disposeOnFullReplacement(existing);
       this.streams.delete(key);
       current = undefined;
+      // Full-replacement also throws away the prior emitted text, so the
+      // rolling tail must reset to avoid a false positive joining the
+      // replaced text with the new stream's first delta.
+      this.clearGuardrailTail(key);
     }
 
     const next = await strategy.handleDelta({
@@ -301,7 +389,7 @@ export class ChatResponseBridge implements ResponseRenderer {
           instance,
           channelId,
           payload.conversationId,
-          (payload.platformMetadata as any)?.responseThreadId,
+          platformMetadataString(payload.platformMetadata, "responseThreadId"),
           payload.platformMetadata as Record<string, unknown> | undefined
         ),
     });
@@ -330,6 +418,7 @@ export class ChatResponseBridge implements ResponseRenderer {
     if (this.blockedStreams.has(key)) {
       this.blockedStreams.delete(key);
       this.streams.delete(key);
+      this.clearGuardrailTail(key);
       logger.info(
         { connectionId, channelId, conversationId: payload.conversationId },
         "Completion suppressed — stream was blocked by guardrail"
@@ -355,6 +444,9 @@ export class ChatResponseBridge implements ResponseRenderer {
       await strategy.handleCompletion({ ctx, payload, stream });
       this.streams.delete(key);
     }
+    // Drop the rolling guardrail tail on any non-blocked completion path —
+    // next stream on the same key starts with a fresh tail.
+    this.clearGuardrailTail(key);
 
     const conversationState =
       this.manager.getInstance(connectionId)?.conversationState;
@@ -379,8 +471,9 @@ export class ChatResponseBridge implements ResponseRenderer {
     }
 
     // Session reset: clear history and delete session file
-    if ((payload.platformMetadata as any)?.sessionReset) {
-      const agentId = (payload.platformMetadata as any)?.agentId;
+    const completionMd = readPlatformMetadata(payload.platformMetadata);
+    if (completionMd.sessionReset) {
+      const agentId = completionMd.agentId;
       try {
         await conversationState?.clearHistory(connectionId, channelId);
         logger.info(
@@ -513,7 +606,7 @@ export class ChatResponseBridge implements ResponseRenderer {
         instance,
         channelId,
         payload.conversationId,
-        (payload.platformMetadata as any)?.responseThreadId,
+        platformMetadataString(payload.platformMetadata, "responseThreadId"),
         payload.platformMetadata as Record<string, unknown> | undefined
       );
       if (target) {
@@ -539,7 +632,7 @@ export class ChatResponseBridge implements ResponseRenderer {
         instance,
         channelId,
         payload.conversationId,
-        (payload.platformMetadata as any)?.responseThreadId,
+        platformMetadataString(payload.platformMetadata, "responseThreadId"),
         payload.platformMetadata as Record<string, unknown> | undefined
       );
       if (target) {
@@ -563,7 +656,7 @@ export class ChatResponseBridge implements ResponseRenderer {
         instance,
         channelId,
         payload.conversationId,
-        (payload.platformMetadata as any)?.responseThreadId,
+        platformMetadataString(payload.platformMetadata, "responseThreadId"),
         payload.platformMetadata as Record<string, unknown> | undefined
       );
       if (target) {

--- a/packages/server/src/gateway/connections/chat-response-bridge.ts
+++ b/packages/server/src/gateway/connections/chat-response-bridge.ts
@@ -13,8 +13,14 @@
 
 import { unlink } from "node:fs/promises";
 import { resolve } from "node:path";
-import { createLogger } from "@lobu/core";
+import {
+  createLogger,
+  type GuardrailRegistry,
+  runGuardrails,
+} from "@lobu/core";
 import { getDb } from "../../db/client.js";
+import type { AgentSettingsStore } from "../auth/settings/agent-settings-store.js";
+import { recordGuardrailTrip } from "../guardrails/audit.js";
 import type { ThreadResponsePayload } from "../infrastructure/queue/index.js";
 import { extractSettingsLinkButtons } from "../platform/link-buttons.js";
 import type { ResponseRenderer } from "../platform/response-renderer.js";
@@ -72,14 +78,107 @@ interface ResponseContext {
  */
 export class ChatResponseBridge implements ResponseRenderer {
   private streams = new Map<string, StreamState>();
+  /**
+   * Tracks streams that an output guardrail already blocked. A stream that
+   * trips mid-flight must not have any further deltas (or the final
+   * completion buffer) reach the platform.
+   */
+  private blockedStreams = new Set<string>();
+  private guardrailRegistry?: GuardrailRegistry;
+  private agentSettingsStore?: AgentSettingsStore;
 
   constructor(private manager: ChatInstanceManager) {}
 
-  // TODO(#254): output-stage guardrail hook. Before emitting a delta to the
-  // platform strategy, call runGuardrails("output", registry, settings.guardrails,
-  // { text: payload.delta, ... }). On trip: redact or replace the delta per
-  // guardrail policy. Wiring deferred to the PR that registers the first
-  // real output guardrail (#253 secret/PII scan).
+  /**
+   * Wire output-stage guardrails. Both must be set for guardrails to run;
+   * with neither, the bridge behaves as before.
+   */
+  setGuardrails(
+    registry?: GuardrailRegistry,
+    settingsStore?: AgentSettingsStore
+  ): void {
+    this.guardrailRegistry = registry;
+    this.agentSettingsStore = settingsStore;
+  }
+
+  /**
+   * Resolve the agentId for a given response payload. Workers attach it on
+   * `platformMetadata.agentId`; for cases where it's missing we fall back
+   * to the bound connection's agent. Returns `null` when neither is known —
+   * the caller should treat that as "skip guardrails" rather than block.
+   */
+  private resolveAgentId(
+    payload: ThreadResponsePayload,
+    ctx: ResponseContext
+  ): string | null {
+    const fromMetadata = (payload.platformMetadata as any)?.agentId;
+    if (typeof fromMetadata === "string" && fromMetadata) return fromMetadata;
+    const fromConnection = ctx.instance?.connection?.agentId;
+    if (typeof fromConnection === "string" && fromConnection)
+      return fromConnection;
+    return null;
+  }
+
+  /**
+   * Run output-stage guardrails for a single delta. Returns the trip outcome
+   * (already audited) when blocked, `null` when the delta is safe to send.
+   * Failures inside the runner are logged and treated as a pass.
+   */
+  private async runOutputGuardrails(
+    text: string,
+    payload: ThreadResponsePayload,
+    ctx: ResponseContext
+  ): Promise<{ guardrail: string; reason?: string } | null> {
+    if (!this.guardrailRegistry || !this.agentSettingsStore) return null;
+    if (!text) return null;
+    const agentId = this.resolveAgentId(payload, ctx);
+    if (!agentId) return null;
+
+    try {
+      const settings = await this.agentSettingsStore.getSettings(agentId);
+      const enabled = settings?.guardrails ?? [];
+      if (enabled.length === 0) return null;
+      const outcome = await runGuardrails(
+        this.guardrailRegistry,
+        "output",
+        enabled,
+        {
+          agentId,
+          userId: payload.userId,
+          text,
+          platform: ctx.platform,
+          conversationId: payload.conversationId,
+        }
+      );
+      if (!outcome.tripped) return null;
+      const orgIdFromMetadata = (payload.platformMetadata as any)
+        ?.organizationId;
+      recordGuardrailTrip({
+        organizationId:
+          typeof orgIdFromMetadata === "string" ? orgIdFromMetadata : undefined,
+        agentId,
+        userId: payload.userId,
+        conversationId: payload.conversationId,
+        stage: "output",
+        guardrail: outcome.tripped.guardrail,
+        reason: outcome.tripped.reason,
+        metadata: outcome.tripped.metadata,
+      });
+      return {
+        guardrail: outcome.tripped.guardrail,
+        reason: outcome.tripped.reason,
+      };
+    } catch (err) {
+      logger.warn(
+        {
+          err: err instanceof Error ? err.message : String(err),
+        },
+        "Output guardrail check failed — proceeding without guardrails"
+      );
+      return null;
+    }
+  }
+
   private extractResponseContext(
     payload: ThreadResponsePayload
   ): ResponseContext | null {
@@ -126,6 +225,60 @@ export class ChatResponseBridge implements ResponseRenderer {
 
     const { strategy, instance, channelId } = ctx;
     const key = `${channelId}:${payload.conversationId}`;
+
+    // If a prior delta in this stream tripped a guardrail, drop everything
+    // else for the rest of the message. We've already posted the block
+    // notice; the worker may keep streaming because trip handling here is
+    // async to the worker — silently swallowing the tail is correct.
+    if (this.blockedStreams.has(key)) return null;
+
+    // Per-delta output guardrails. Regex-shaped checks are cheap enough to
+    // run on every chunk; LLM-judge guardrails should batch upstream
+    // (PR B). On trip, emit a generic block message in-place instead of
+    // the model output and mark the stream blocked.
+    const trip = await this.runOutputGuardrails(payload.delta, payload, ctx);
+    if (trip) {
+      this.blockedStreams.add(key);
+      // Close any in-flight strategy stream so the partial output that
+      // already shipped to the platform terminates cleanly. We can't
+      // unsend bytes already delivered, but for the default strategy
+      // (Telegram buffers a single edit) the block message will replace
+      // the partial; for Slack, the user sees the partial followed by
+      // the block notice. Closing here also prevents further deltas from
+      // being appended.
+      const existingStream = this.streams.get(key);
+      if (existingStream) {
+        try {
+          await strategy.disposeOnFullReplacement(existingStream);
+        } catch (err) {
+          logger.debug(
+            { err: String(err) },
+            "Failed to dispose stream on guardrail block (continuing)"
+          );
+        }
+        this.streams.delete(key);
+      }
+      const blockText = `Message blocked by guardrail: ${trip.reason ?? trip.guardrail}`;
+      try {
+        const target = await this.resolveTarget(
+          instance,
+          channelId,
+          payload.conversationId,
+          (payload.platformMetadata as any)?.responseThreadId,
+          payload.platformMetadata as Record<string, unknown> | undefined
+        );
+        if (target) {
+          await target.post(blockText);
+        }
+      } catch (err) {
+        logger.error(
+          { err: String(err) },
+          "Failed to post guardrail block message"
+        );
+      }
+      return null;
+    }
+
     const existing = this.streams.get(key);
 
     // Full replacement: ask the strategy to dispose the prior stream (the
@@ -170,6 +323,19 @@ export class ChatResponseBridge implements ResponseRenderer {
 
     const { connectionId, strategy, channelId } = ctx;
     const key = `${channelId}:${payload.conversationId}`;
+
+    // If a guardrail blocked this stream mid-flight, skip completion
+    // entirely: stream was disposed at trip time, the block message was
+    // posted, and we don't want the partial buffer landing in history.
+    if (this.blockedStreams.has(key)) {
+      this.blockedStreams.delete(key);
+      this.streams.delete(key);
+      logger.info(
+        { connectionId, channelId, conversationId: payload.conversationId },
+        "Completion suppressed — stream was blocked by guardrail"
+      );
+      return;
+    }
 
     const stream = this.streams.get(key);
     if (stream) {

--- a/packages/server/src/gateway/connections/chat-response-bridge.ts
+++ b/packages/server/src/gateway/connections/chat-response-bridge.ts
@@ -76,20 +76,15 @@ interface ResponseContext {
 }
 
 /**
- * Streaming chunks split arbitrarily across token boundaries. A secret like
- * `sk-abc...` can arrive as `"sk-an"` then `"t-..."` and bypass every
- * per-delta regex. The bridge keeps a rolling tail of recent emitted text
- * per stream key (capped at OUTPUT_GUARDRAIL_TAIL_CHARS) and prepends it
- * to the next delta before scanning, so a pattern straddling a chunk
- * boundary still matches. Cleared on stream completion / dispose.
- *
- * 256 chars is generous against the regexes the built-ins ship — the
- * longest pattern (JWT) is bounded only on its first segment but the
- * second `.eyJ…` re-anchors, so a tail well above the first-segment
- * minimum suffices. Keep it tight to avoid quadratic scan cost on long
- * streams.
+ * Streaming chunks split arbitrarily across token boundaries; a secret like
+ * `sk-abc...` can arrive as `"sk-an"` then `"t-..."` and bypass any per-delta
+ * regex. We keep a rolling tail of recent emitted text per stream and scan
+ * `tail + delta` so patterns straddling a chunk boundary still match. The
+ * scan window is bounded at 2× this value to keep regex cost proportional
+ * to the chunk being processed, not the entire stream.
  */
 const OUTPUT_GUARDRAIL_TAIL_CHARS = 256;
+const GUARDRAIL_SCAN_WINDOW = OUTPUT_GUARDRAIL_TAIL_CHARS * 2;
 
 /**
  * ChatResponseBridge implements ResponseRenderer so it can be plugged into
@@ -98,16 +93,12 @@ const OUTPUT_GUARDRAIL_TAIL_CHARS = 256;
 export class ChatResponseBridge implements ResponseRenderer {
   private streams = new Map<string, StreamState>();
   /**
-   * Tracks streams that an output guardrail already blocked. A stream that
-   * trips mid-flight must not have any further deltas (or the final
-   * completion buffer) reach the platform.
+   * Streams whose output guardrail has tripped — every subsequent delta
+   * and the final completion buffer must be dropped before reaching the
+   * platform.
    */
   private blockedStreams = new Set<string>();
-  /**
-   * Per-stream rolling tail of emitted output text, used as a prefix when
-   * scanning the next delta so secrets split across chunk boundaries still
-   * match. Keyed by the same `key` as `streams`.
-   */
+  /** Per-stream rolling tail of recently emitted output text. */
   private guardrailTails = new Map<string, string>();
   private guardrailRegistry?: GuardrailRegistry;
   private agentSettingsStore?: AgentSettingsStore;
@@ -127,10 +118,9 @@ export class ChatResponseBridge implements ResponseRenderer {
   }
 
   /**
-   * Resolve the agentId for a given response payload. Workers attach it on
-   * `platformMetadata.agentId`; for cases where it's missing we fall back
-   * to the bound connection's agent. Returns `null` when neither is known —
-   * the caller should treat that as "skip guardrails" rather than block.
+   * Resolve the agentId for a payload: payload metadata first, then the
+   * bound connection's agent. Returns `null` when neither is known so
+   * the caller can skip guardrails rather than block.
    */
   private resolveAgentId(
     payload: ThreadResponsePayload,
@@ -139,18 +129,15 @@ export class ChatResponseBridge implements ResponseRenderer {
     const md = readPlatformMetadata(payload.platformMetadata);
     if (md.agentId) return md.agentId;
     const fromConnection = ctx.instance?.connection?.agentId;
-    if (typeof fromConnection === "string" && fromConnection)
-      return fromConnection;
-    return null;
+    return typeof fromConnection === "string" && fromConnection
+      ? fromConnection
+      : null;
   }
 
   /**
-   * Resolve the organization id for audit attribution. Workers attach it
-   * on `platformMetadata.organizationId`; the canonical fallback is the
-   * connection record (`instance.connection.organizationId`), which is
-   * set when the connection was created via the connections CRUD API and
-   * is durable across requests. Returns `undefined` only when neither is
-   * available — in that case the audit module logs the gap loudly.
+   * Resolve the organization id for audit attribution: payload metadata
+   * first, then the connection record. Undefined only when neither is
+   * available — the audit module logs that gap loudly.
    */
   private resolveOrganizationId(
     payload: ThreadResponsePayload,
@@ -159,49 +146,31 @@ export class ChatResponseBridge implements ResponseRenderer {
     const md = readPlatformMetadata(payload.platformMetadata);
     if (md.organizationId) return md.organizationId;
     const fromConnection = ctx.instance?.connection?.organizationId;
-    if (typeof fromConnection === "string" && fromConnection)
-      return fromConnection;
-    return undefined;
+    return typeof fromConnection === "string" && fromConnection
+      ? fromConnection
+      : undefined;
   }
 
   /**
-   * Append `delta` to the per-stream tail and return the rolling window
-   * (tail-prefix + delta, capped at `OUTPUT_GUARDRAIL_TAIL_CHARS * 2`)
-   * that should be scanned. The cap keeps the scanned slice bounded —
-   * the slice length is at most ~2× the tail, so regex cost stays
-   * proportional to the chunk being processed, not the entire stream.
+   * Append `delta` to the per-stream tail and return the scan window
+   * (`tail + delta`, capped at `GUARDRAIL_SCAN_WINDOW` chars). The stored
+   * tail is the same window — next call sees the most recent emitted text
+   * even when individual deltas exceed the cap.
    */
-  private updateGuardrailTail(key: string, delta: string): string {
-    const previous = this.guardrailTails.get(key) ?? "";
-    const combined = previous + delta;
-    // Keep the last 2 × tail chars so the next call can still build a
-    // tail-prefix from this combined window if needed.
-    const nextTail = combined.slice(-OUTPUT_GUARDRAIL_TAIL_CHARS * 2);
-    this.guardrailTails.set(key, nextTail);
-    // Return the scan slice: previous tail + current delta. Bound at
-    // 2× tail to stay cheap.
-    const scanSlice =
-      previous.length > 0 ? previous + delta : delta;
-    return scanSlice.length > OUTPUT_GUARDRAIL_TAIL_CHARS * 2
-      ? scanSlice.slice(-OUTPUT_GUARDRAIL_TAIL_CHARS * 2)
-      : scanSlice;
-  }
-
-  /** Drop the rolling tail when a stream finishes or is disposed. */
-  private clearGuardrailTail(key: string): void {
-    this.guardrailTails.delete(key);
+  private scanWindowWithTail(key: string, delta: string): string {
+    const combined = (this.guardrailTails.get(key) ?? "") + delta;
+    const window =
+      combined.length > GUARDRAIL_SCAN_WINDOW
+        ? combined.slice(-GUARDRAIL_SCAN_WINDOW)
+        : combined;
+    this.guardrailTails.set(key, window);
+    return window;
   }
 
   /**
-   * Run output-stage guardrails for a single delta. Returns the trip outcome
-   * (already audited) when blocked, `null` when the delta is safe to send.
-   * Failures inside the runner are logged and treated as a pass.
-   *
-   * The scan operates on `tailPrefix + delta`, not just `delta`, so a
-   * secret split across two streaming chunks still trips on the second
-   * chunk. The tail is updated in `handleDelta` only after a passing
-   * scan — a tripped stream is disposed and its tail dropped, so we
-   * never carry blocked-stream state forward.
+   * Run output-stage guardrails for `scanText` (already includes any
+   * rolling tail). Returns the trip outcome (already audited) on block,
+   * `null` when safe to send. Runner failures are logged and pass.
    */
   private async runOutputGuardrails(
     scanText: string,
@@ -230,8 +199,7 @@ export class ChatResponseBridge implements ResponseRenderer {
         }
       );
       if (!outcome.tripped) return null;
-      // Fire-and-forget: the audit module returns a promise that never
-      // rejects. Don't block delivery of the block message on the write.
+      // Fire-and-forget — the block message must not wait on the audit write.
       void recordGuardrailTrip({
         organizationId: this.resolveOrganizationId(payload, ctx),
         agentId,
@@ -305,46 +273,31 @@ export class ChatResponseBridge implements ResponseRenderer {
     const { strategy, instance, channelId } = ctx;
     const key = `${channelId}:${payload.conversationId}`;
 
-    // If a prior delta in this stream tripped a guardrail, drop everything
-    // else for the rest of the message. We've already posted the block
-    // notice; the worker may keep streaming because trip handling here is
-    // async to the worker — silently swallowing the tail is correct.
+    // A prior delta tripped — drop everything else for this stream. The
+    // worker may keep streaming because trip handling here is async to it.
     if (this.blockedStreams.has(key)) return null;
 
-    // Full-replacement: dispose the prior stream + drop the rolling tail
-    // BEFORE scanning. Order matters: a replacement throws away the previous
-    // emitted text, so the next scan must operate on the new delta alone.
-    // Without clearing first, the tail would still hold the previous
-    // delta's last 256 chars and the scan would run against
-    // (previous-stream-bytes + new-replacement-text), which can synthesize
-    // a regex match that exists in neither piece on its own — a false
-    // positive trip on the very first delta of an unrelated reply.
+    // Full-replacement must dispose the prior stream and clear the tail
+    // BEFORE scanning. Otherwise the tail still holds the previous delta's
+    // last bytes and the scan runs against (prior + replacement), which
+    // can synthesize a regex match present in neither piece alone.
     const existingForReplacement = this.streams.get(key);
     if (payload.isFullReplacement && existingForReplacement) {
       await strategy.disposeOnFullReplacement(existingForReplacement);
       this.streams.delete(key);
-      this.clearGuardrailTail(key);
+      this.guardrailTails.delete(key);
     }
 
-    // Per-delta output guardrails. We scan `(rolling tail) + delta` so a
-    // secret split across two streaming chunks ("sk-ab" then "cd…") still
-    // trips on the second chunk. The tail is only updated after a passing
-    // scan — tripping disposes the stream and drops its tail.
-    const scanText = this.updateGuardrailTail(key, payload.delta);
+    // Per-delta output guardrails scan `tail + delta` so a secret split
+    // across chunks ("sk-ab" then "cd…") still trips on the second chunk.
+    const scanText = this.scanWindowWithTail(key, payload.delta);
     const trip = await this.runOutputGuardrails(scanText, payload, ctx);
     if (trip) {
       this.blockedStreams.add(key);
-      // Drop the rolling tail — the stream is dead, no further deltas
-      // will be scanned for this key, and we don't want a future stream
-      // re-using the key to inherit the blocked stream's bytes.
-      this.clearGuardrailTail(key);
-      // Close any in-flight strategy stream so the partial output that
-      // already shipped to the platform terminates cleanly. We can't
-      // unsend bytes already delivered, but for the default strategy
-      // (Telegram buffers a single edit) the block message will replace
-      // the partial; for Slack, the user sees the partial followed by
-      // the block notice. Closing here also prevents further deltas from
-      // being appended.
+      this.guardrailTails.delete(key);
+      // Close any in-flight strategy stream so the partial output already
+      // delivered terminates cleanly. We can't unsend delivered bytes, but
+      // closing prevents further deltas from being appended.
       const existingStream = this.streams.get(key);
       if (existingStream) {
         try {
@@ -378,9 +331,8 @@ export class ChatResponseBridge implements ResponseRenderer {
       return null;
     }
 
-    // Pick up the current stream after the (possible) full-replacement
-    // dispose above. If we disposed, `current` stays undefined so the
-    // strategy starts a fresh stream.
+    // After the (possible) full-replacement dispose, `current` is
+    // undefined and the strategy starts a fresh stream.
     const current = this.streams.get(key);
 
     const next = await strategy.handleDelta({
@@ -421,7 +373,7 @@ export class ChatResponseBridge implements ResponseRenderer {
     if (this.blockedStreams.has(key)) {
       this.blockedStreams.delete(key);
       this.streams.delete(key);
-      this.clearGuardrailTail(key);
+      this.guardrailTails.delete(key);
       logger.info(
         { connectionId, channelId, conversationId: payload.conversationId },
         "Completion suppressed — stream was blocked by guardrail"
@@ -447,9 +399,8 @@ export class ChatResponseBridge implements ResponseRenderer {
       await strategy.handleCompletion({ ctx, payload, stream });
       this.streams.delete(key);
     }
-    // Drop the rolling guardrail tail on any non-blocked completion path —
-    // next stream on the same key starts with a fresh tail.
-    this.clearGuardrailTail(key);
+    // Next stream on the same key starts with a fresh tail.
+    this.guardrailTails.delete(key);
 
     const conversationState =
       this.manager.getInstance(connectionId)?.conversationState;

--- a/packages/server/src/gateway/connections/chat-response-bridge.ts
+++ b/packages/server/src/gateway/connections/chat-response-bridge.ts
@@ -26,6 +26,7 @@ import { extractSettingsLinkButtons } from "../platform/link-buttons.js";
 import type { ResponseRenderer } from "../platform/response-renderer.js";
 import type { ChatInstanceManager } from "./chat-instance-manager.js";
 import {
+  type PlatformMetadata,
   platformMetadataString,
   readPlatformMetadata,
 } from "./platform-metadata.js";
@@ -47,14 +48,13 @@ const logger = createLogger("chat-response-bridge");
  */
 function buildCurrentMessageFromMetadata(
   threadId: string,
-  platformMetadata: Record<string, unknown> | undefined
+  platformMetadata: PlatformMetadata
 ): Record<string, unknown> | undefined {
-  const md = readPlatformMetadata(platformMetadata);
-  const senderId = md.senderId;
+  const senderId = platformMetadata.senderId;
   if (!senderId) return undefined;
-  const senderUsername = md.senderUsername;
-  const senderDisplayName = md.senderDisplayName;
-  const teamId = md.teamId;
+  const senderUsername = platformMetadata.senderUsername;
+  const senderDisplayName = platformMetadata.senderDisplayName;
+  const teamId = platformMetadata.teamId;
   return {
     threadId,
     text: "",
@@ -311,6 +311,21 @@ export class ChatResponseBridge implements ResponseRenderer {
     // async to the worker — silently swallowing the tail is correct.
     if (this.blockedStreams.has(key)) return null;
 
+    // Full-replacement: dispose the prior stream + drop the rolling tail
+    // BEFORE scanning. Order matters: a replacement throws away the previous
+    // emitted text, so the next scan must operate on the new delta alone.
+    // Without clearing first, the tail would still hold the previous
+    // delta's last 256 chars and the scan would run against
+    // (previous-stream-bytes + new-replacement-text), which can synthesize
+    // a regex match that exists in neither piece on its own — a false
+    // positive trip on the very first delta of an unrelated reply.
+    const existingForReplacement = this.streams.get(key);
+    if (payload.isFullReplacement && existingForReplacement) {
+      await strategy.disposeOnFullReplacement(existingForReplacement);
+      this.streams.delete(key);
+      this.clearGuardrailTail(key);
+    }
+
     // Per-delta output guardrails. We scan `(rolling tail) + delta` so a
     // secret split across two streaming chunks ("sk-ab" then "cd…") still
     // trips on the second chunk. The tail is only updated after a passing
@@ -349,7 +364,7 @@ export class ChatResponseBridge implements ResponseRenderer {
           channelId,
           payload.conversationId,
           platformMetadataString(payload.platformMetadata, "responseThreadId"),
-          payload.platformMetadata as Record<string, unknown> | undefined
+          readPlatformMetadata(payload.platformMetadata)
         );
         if (target) {
           await target.post(blockText);
@@ -363,22 +378,10 @@ export class ChatResponseBridge implements ResponseRenderer {
       return null;
     }
 
-    const existing = this.streams.get(key);
-
-    // Full replacement: ask the strategy to dispose the prior stream (the
-    // default strategy closes the live iterator and awaits its delivery;
-    // Slack is a no-op since no real stream was opened). Treat the delta
-    // as the start of a fresh stream below.
-    let current = existing;
-    if (payload.isFullReplacement && existing) {
-      await strategy.disposeOnFullReplacement(existing);
-      this.streams.delete(key);
-      current = undefined;
-      // Full-replacement also throws away the prior emitted text, so the
-      // rolling tail must reset to avoid a false positive joining the
-      // replaced text with the new stream's first delta.
-      this.clearGuardrailTail(key);
-    }
+    // Pick up the current stream after the (possible) full-replacement
+    // dispose above. If we disposed, `current` stays undefined so the
+    // strategy starts a fresh stream.
+    const current = this.streams.get(key);
 
     const next = await strategy.handleDelta({
       ctx,
@@ -390,7 +393,7 @@ export class ChatResponseBridge implements ResponseRenderer {
           channelId,
           payload.conversationId,
           platformMetadataString(payload.platformMetadata, "responseThreadId"),
-          payload.platformMetadata as Record<string, unknown> | undefined
+          readPlatformMetadata(payload.platformMetadata)
         ),
     });
 
@@ -607,7 +610,7 @@ export class ChatResponseBridge implements ResponseRenderer {
         channelId,
         payload.conversationId,
         platformMetadataString(payload.platformMetadata, "responseThreadId"),
-        payload.platformMetadata as Record<string, unknown> | undefined
+        readPlatformMetadata(payload.platformMetadata)
       );
       if (target) {
         await target.post(`Error: ${payload.error}`);
@@ -633,7 +636,7 @@ export class ChatResponseBridge implements ResponseRenderer {
         channelId,
         payload.conversationId,
         platformMetadataString(payload.platformMetadata, "responseThreadId"),
-        payload.platformMetadata as Record<string, unknown> | undefined
+        readPlatformMetadata(payload.platformMetadata)
       );
       if (target) {
         await target.startTyping?.("Processing...");
@@ -657,7 +660,7 @@ export class ChatResponseBridge implements ResponseRenderer {
         channelId,
         payload.conversationId,
         platformMetadataString(payload.platformMetadata, "responseThreadId"),
-        payload.platformMetadata as Record<string, unknown> | undefined
+        readPlatformMetadata(payload.platformMetadata)
       );
       if (target) {
         const { processedContent, linkButtons } = extractSettingsLinkButtons(
@@ -712,7 +715,7 @@ export class ChatResponseBridge implements ResponseRenderer {
     channelId: string,
     conversationId?: string,
     responseThreadId?: string,
-    platformMetadata?: Record<string, unknown>
+    platformMetadata: PlatformMetadata = {}
   ): Promise<any | null> {
     const platform = instance.connection.platform;
     const chat = instance.chat;

--- a/packages/server/src/gateway/connections/platform-metadata.ts
+++ b/packages/server/src/gateway/connections/platform-metadata.ts
@@ -1,0 +1,65 @@
+/**
+ * Typed view over the loose `platformMetadata: Record<string, unknown>`
+ * bag that rides on `ThreadResponsePayload` / `MessagePayload`. Workers
+ * and producers stuff various fields onto this object — historically read
+ * with `(metadata as any).fooBar` at every call site. That hid two real
+ * bugs in the guardrails wiring: the agentId fallback typed itself wrong,
+ * and the organizationId read assumed a string without a runtime guard.
+ *
+ * This module declares the contract and gives a single narrowing helper
+ * so call sites can read fields without `any` and still tolerate the
+ * absence of the field.
+ */
+
+export interface PlatformMetadata {
+  /** Outbound: the Chat SDK connection the response originated from. */
+  connectionId?: string;
+  /** Outbound: optional override for the chat-level recipient. */
+  chatId?: string;
+  /** Outbound: alternative override (Slack legacy ephemerals). */
+  responseChannel?: string;
+  /** Outbound: full thread id (e.g. `telegram:{chat}:{topic}`). */
+  responseThreadId?: string;
+  /** Both directions: the agent that produced/should produce the message. */
+  agentId?: string;
+  /** Both directions: the agent's owning organization id. */
+  organizationId?: string;
+  /** Inbound: chat sender's platform user id. */
+  senderId?: string;
+  senderUsername?: string;
+  senderDisplayName?: string;
+  /** Inbound: Slack workspace id (also used as `raw.team_id` shim). */
+  teamId?: string;
+  /** Outbound: marker for the session-reset signal from the worker. */
+  sessionReset?: boolean;
+  /** Outbound: distributed tracing context propagation. */
+  traceparent?: string;
+  /** Outbound: client-side message id correlation. */
+  clientMessageId?: string;
+}
+
+/**
+ * Read `platformMetadata` as a typed object. Always returns an object
+ * (empty when missing) so callers can safely chain optional reads without
+ * a null check at each site.
+ */
+export function readPlatformMetadata(
+  metadata: Record<string, unknown> | null | undefined
+): PlatformMetadata {
+  if (!metadata || typeof metadata !== "object") return {};
+  return metadata as PlatformMetadata;
+}
+
+/**
+ * Narrow a single string field on platformMetadata. Returns undefined when
+ * the field is missing, empty, or the wrong type — never throws.
+ */
+export function platformMetadataString(
+  metadata: Record<string, unknown> | null | undefined,
+  key: keyof PlatformMetadata
+): string | undefined {
+  if (!metadata || typeof metadata !== "object") return undefined;
+  const value = (metadata as Record<string, unknown>)[key];
+  if (typeof value !== "string" || value.length === 0) return undefined;
+  return value;
+}

--- a/packages/server/src/gateway/guardrails/audit.ts
+++ b/packages/server/src/gateway/guardrails/audit.ts
@@ -1,13 +1,42 @@
 /**
- * Audit trail for guardrail trips. Every short-circuited stage logs one
+ * Audit trail for guardrail trips. Every short-circuited stage writes one
  * `semantic_type='guardrail-trip'` row to `events` so operators can review
- * what was blocked, when, and why. Fire-and-forget — guardrail enforcement
- * must not depend on the audit write succeeding.
+ * what was blocked, when, and why.
+ *
+ * `recordGuardrailTrip` returns a Promise that resolves once the insert
+ * lands (or has been logged-and-swallowed on failure). Wired call sites
+ * fire-and-forget by ignoring the return value; tests can `await` it. A
+ * trip that we couldn't audit (e.g. missing organizationId after fallback)
+ * is logged at warn so it shows up in the security log audit even when the
+ * `events` row didn't make it.
  */
 
 import { insertEvent } from "../../utils/insert-event";
 import logger from "../../utils/logger";
 import type { GuardrailStage } from "@lobu/core";
+
+/**
+ * Tracks in-flight `recordGuardrailTrip` calls so tests can flush all
+ * pending audit writes without sleep-and-pray. Wired call sites use
+ * `void recordGuardrailTrip(...)` and don't care about completion, but
+ * the tracker still resolves on each insert so a single
+ * `flushPendingGuardrailAudits()` await drains everything.
+ */
+const pendingAudits = new Set<Promise<void>>();
+
+/**
+ * Await all in-flight guardrail-audit inserts. For test code only — the
+ * production call sites fire-and-forget so they don't block the user-facing
+ * block message on a DB write. Resolves after the current set drains; new
+ * trips that fire while we're awaiting are NOT included (call again).
+ */
+export async function flushPendingGuardrailAudits(): Promise<void> {
+  // Snapshot the current set — Promise.allSettled handles concurrent
+  // additions by simply not waiting on them.
+  const snapshot = Array.from(pendingAudits);
+  if (snapshot.length === 0) return;
+  await Promise.allSettled(snapshot);
+}
 
 interface RecordGuardrailTripParams {
   organizationId: string | undefined;
@@ -16,49 +45,74 @@ interface RecordGuardrailTripParams {
   conversationId?: string;
   stage: GuardrailStage;
   guardrail: string;
-  /** Internal reason — written to the event row but never surfaced to the
-   *  blocked party for the pre-tool stage. */
+  /**
+   * Internal reason — written to the event row but never surfaced to the
+   * blocked party for the pre-tool stage.
+   */
   reason?: string;
   metadata?: unknown;
 }
 
-export function recordGuardrailTrip(params: RecordGuardrailTripParams): void {
-  // We require an organizationId to write to the events table — the schema
-  // is org-scoped. If we don't have one (e.g. an unbound auth path), log
-  // and skip; the enforcement decision has already taken effect.
+/**
+ * Insert a `guardrail-trip` row. Returns a promise that resolves whether
+ * the insert succeeds, throws, or is skipped (missing org id). Never
+ * rejects — guardrail enforcement is the source of truth for the block,
+ * the audit is best-effort but tests/operators can still observe failures
+ * through the structured log emitted on the failure paths.
+ */
+export function recordGuardrailTrip(
+  params: RecordGuardrailTripParams
+): Promise<void> {
+  const work = doRecordGuardrailTrip(params);
+  pendingAudits.add(work);
+  // Remove from the tracker regardless of success/failure so the set
+  // doesn't grow unbounded.
+  work.finally(() => pendingAudits.delete(work));
+  return work;
+}
+
+async function doRecordGuardrailTrip(
+  params: RecordGuardrailTripParams
+): Promise<void> {
+  // Without an organization id we can't write to `events` (org-scoped
+  // schema). Log loudly — a trip that doesn't audit is a security log gap
+  // and downstream callers must surface this on their own resolver paths.
   if (!params.organizationId) {
-    logger.warn(
+    logger.error(
       {
         agentId: params.agentId,
         guardrail: params.guardrail,
         stage: params.stage,
+        reason: params.reason,
       },
-      "[guardrail] trip not audited — no organizationId in context"
+      "[guardrail] trip not audited — no organizationId resolved (security log gap)"
     );
     return;
   }
 
   const originId = `guardrail_trip_${params.stage}_${params.guardrail}_${params.agentId}_${Date.now()}`;
 
-  insertEvent({
-    entityIds: [],
-    organizationId: params.organizationId,
-    originId,
-    title: `Guardrail "${params.guardrail}" tripped at ${params.stage}`,
-    semanticType: "guardrail-trip",
-    originType: `guardrail-${params.stage}`,
-    metadata: {
-      guardrail: params.guardrail,
-      stage: params.stage,
-      reason: params.reason ?? null,
-      agent_id: params.agentId,
-      user_id: params.userId ?? null,
-      conversation_id: params.conversationId ?? null,
-      ...(params.metadata !== undefined
-        ? { guardrail_metadata: params.metadata }
-        : {}),
-    },
-  }).catch((err) => {
+  try {
+    await insertEvent({
+      entityIds: [],
+      organizationId: params.organizationId,
+      originId,
+      title: `Guardrail "${params.guardrail}" tripped at ${params.stage}`,
+      semanticType: "guardrail-trip",
+      originType: `guardrail-${params.stage}`,
+      metadata: {
+        guardrail: params.guardrail,
+        stage: params.stage,
+        reason: params.reason ?? null,
+        agent_id: params.agentId,
+        user_id: params.userId ?? null,
+        conversation_id: params.conversationId ?? null,
+        ...(params.metadata !== undefined
+          ? { guardrail_metadata: params.metadata }
+          : {}),
+      },
+    });
+  } catch (err) {
     logger.warn(
       {
         err: err instanceof Error ? err.message : String(err),
@@ -67,5 +121,5 @@ export function recordGuardrailTrip(params: RecordGuardrailTripParams): void {
       },
       "[guardrail] failed to record trip event"
     );
-  });
+  }
 }

--- a/packages/server/src/gateway/guardrails/audit.ts
+++ b/packages/server/src/gateway/guardrails/audit.ts
@@ -1,0 +1,71 @@
+/**
+ * Audit trail for guardrail trips. Every short-circuited stage logs one
+ * `semantic_type='guardrail-trip'` row to `events` so operators can review
+ * what was blocked, when, and why. Fire-and-forget — guardrail enforcement
+ * must not depend on the audit write succeeding.
+ */
+
+import { insertEvent } from "../../utils/insert-event";
+import logger from "../../utils/logger";
+import type { GuardrailStage } from "@lobu/core";
+
+interface RecordGuardrailTripParams {
+  organizationId: string | undefined;
+  agentId: string;
+  userId?: string;
+  conversationId?: string;
+  stage: GuardrailStage;
+  guardrail: string;
+  /** Internal reason — written to the event row but never surfaced to the
+   *  blocked party for the pre-tool stage. */
+  reason?: string;
+  metadata?: unknown;
+}
+
+export function recordGuardrailTrip(params: RecordGuardrailTripParams): void {
+  // We require an organizationId to write to the events table — the schema
+  // is org-scoped. If we don't have one (e.g. an unbound auth path), log
+  // and skip; the enforcement decision has already taken effect.
+  if (!params.organizationId) {
+    logger.warn(
+      {
+        agentId: params.agentId,
+        guardrail: params.guardrail,
+        stage: params.stage,
+      },
+      "[guardrail] trip not audited — no organizationId in context"
+    );
+    return;
+  }
+
+  const originId = `guardrail_trip_${params.stage}_${params.guardrail}_${params.agentId}_${Date.now()}`;
+
+  insertEvent({
+    entityIds: [],
+    organizationId: params.organizationId,
+    originId,
+    title: `Guardrail "${params.guardrail}" tripped at ${params.stage}`,
+    semanticType: "guardrail-trip",
+    originType: `guardrail-${params.stage}`,
+    metadata: {
+      guardrail: params.guardrail,
+      stage: params.stage,
+      reason: params.reason ?? null,
+      agent_id: params.agentId,
+      user_id: params.userId ?? null,
+      conversation_id: params.conversationId ?? null,
+      ...(params.metadata !== undefined
+        ? { guardrail_metadata: params.metadata }
+        : {}),
+    },
+  }).catch((err) => {
+    logger.warn(
+      {
+        err: err instanceof Error ? err.message : String(err),
+        guardrail: params.guardrail,
+        stage: params.stage,
+      },
+      "[guardrail] failed to record trip event"
+    );
+  });
+}

--- a/packages/server/src/gateway/guardrails/audit.ts
+++ b/packages/server/src/gateway/guardrails/audit.ts
@@ -1,14 +1,9 @@
 /**
  * Audit trail for guardrail trips. Every short-circuited stage writes one
  * `semantic_type='guardrail-trip'` row to `events` so operators can review
- * what was blocked, when, and why.
- *
- * `recordGuardrailTrip` returns a Promise that resolves once the insert
- * lands (or has been logged-and-swallowed on failure). Wired call sites
- * fire-and-forget by ignoring the return value; tests can `await` it. A
- * trip that we couldn't audit (e.g. missing organizationId after fallback)
- * is logged at warn so it shows up in the security log audit even when the
- * `events` row didn't make it.
+ * what was blocked, when, and why. `recordGuardrailTrip` never rejects —
+ * failures (insert error or missing org id) are logged at warn/error so the
+ * gap still shows up in the security log even when the row didn't make it.
  */
 
 import { insertEvent } from "../../utils/insert-event";
@@ -16,23 +11,16 @@ import logger from "../../utils/logger";
 import type { GuardrailStage } from "@lobu/core";
 
 /**
- * Tracks in-flight `recordGuardrailTrip` calls so tests can flush all
- * pending audit writes without sleep-and-pray. Wired call sites use
- * `void recordGuardrailTrip(...)` and don't care about completion, but
- * the tracker still resolves on each insert so a single
- * `flushPendingGuardrailAudits()` await drains everything.
+ * Tracks in-flight `recordGuardrailTrip` calls. Production fires-and-forgets
+ * the returned promise; tests await `flushPendingGuardrailAudits()` to drain.
  */
 const pendingAudits = new Set<Promise<void>>();
 
 /**
- * Await all in-flight guardrail-audit inserts. For test code only — the
- * production call sites fire-and-forget so they don't block the user-facing
- * block message on a DB write. Resolves after the current set drains; new
- * trips that fire while we're awaiting are NOT included (call again).
+ * Await all currently in-flight guardrail-audit inserts. Test-only — trips
+ * that fire after the snapshot is taken are not included (call again).
  */
 export async function flushPendingGuardrailAudits(): Promise<void> {
-  // Snapshot the current set — Promise.allSettled handles concurrent
-  // additions by simply not waiting on them.
   const snapshot = Array.from(pendingAudits);
   if (snapshot.length === 0) return;
   await Promise.allSettled(snapshot);
@@ -65,8 +53,6 @@ export function recordGuardrailTrip(
 ): Promise<void> {
   const work = doRecordGuardrailTrip(params);
   pendingAudits.add(work);
-  // Remove from the tracker regardless of success/failure so the set
-  // doesn't grow unbounded.
   work.finally(() => pendingAudits.delete(work));
   return work;
 }

--- a/packages/server/src/gateway/guardrails/builtins.ts
+++ b/packages/server/src/gateway/guardrails/builtins.ts
@@ -1,6 +1,7 @@
 import type {
   Guardrail,
   GuardrailContext,
+  GuardrailRegistry,
   GuardrailStage,
   InputGuardrailContext,
   OutputGuardrailContext,
@@ -9,7 +10,10 @@ import type {
 import { safeStringify } from "./safe-stringify.js";
 
 /**
- * Built-in guardrails registered by the gateway at startup.
+ * Built-in guardrails registered by the gateway at startup. Three primitives:
+ *  - `secret-scan`     (output, stage-locked)  — credential-shape regex scan
+ *  - `pii-scan`        (any stage)             — emails / phones / Luhn PANs
+ *  - `forbidden-tools` (pre-tool, stage-locked) — destructive-tool deny list
  */
 
 // -- pii-scan ---------------------------------------------------------------
@@ -47,14 +51,10 @@ function scanCreditCard(text: string): { kind: string; match: string } | null {
 }
 
 /**
- * Standard Luhn (mod-10) check. Strips spaces/hyphens, requires 13-19
- * digits, then walks right-to-left doubling every second digit. Real PANs
- * satisfy this; random 13-19 digit runs (invoice/tracking numbers) almost
- * never do.
+ * Standard Luhn check on a 13-19 digit string, separators stripped.
  */
-export function luhnValid(raw: string): boolean {
-  const digits = raw.replace(/[ -]/g, "");
-  if (!/^\d+$/.test(digits)) return false;
+export function luhnValid(candidate: string): boolean {
+  const digits = candidate.replace(/[^\d]/g, "");
   if (digits.length < 13 || digits.length > 19) return false;
   let sum = 0;
   let alt = false;
@@ -98,12 +98,6 @@ function extractTextForPii<S extends GuardrailStage>(
   }
 }
 
-/**
- * Regex-backed PII scanner: emails, US-shaped phones, Luhn-valid 13-19
- * digit credit-card numbers. Trips on first pattern match. `metadata.kind`
- * identifies the family; the raw match is intentionally not surfaced in the
- * trip reason since it may end up in user-facing audit copy.
- */
 export function createPiiScanGuardrail<S extends GuardrailStage>(
   stage: S,
   name = "pii-scan"
@@ -124,13 +118,89 @@ export function createPiiScanGuardrail<S extends GuardrailStage>(
   };
 }
 
+// -- secret-scan (output, stage-locked) -------------------------------------
+
+const SECRET_PATTERNS: Array<{ name: string; re: RegExp }> = [
+  { name: "openai-key", re: /sk-[a-zA-Z0-9]{20,}/ },
+  { name: "github-pat", re: /ghp_[a-zA-Z0-9]{36}/ },
+  { name: "aws-access-key", re: /AKIA[0-9A-Z]{16}/ },
+  {
+    name: "jwt",
+    re: /eyJ[A-Za-z0-9_-]{40,}\.eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+/,
+  },
+];
+
+export const secretScanGuardrail: Guardrail<"output"> = {
+  name: "secret-scan",
+  stage: "output",
+  async run(ctx: OutputGuardrailContext) {
+    const text = ctx.text;
+    if (!text) return { tripped: false };
+    for (const { name, re } of SECRET_PATTERNS) {
+      if (re.test(text)) {
+        return {
+          tripped: true,
+          reason: `Output contains a value that looks like a ${name}`,
+          metadata: { pattern: name },
+        };
+      }
+    }
+    return { tripped: false };
+  },
+};
+
+// -- forbidden-tools (pre-tool, stage-locked) -------------------------------
+
+const FORBIDDEN_TOOLS = new Set<string>([
+  "delete_repo",
+  "delete_branch",
+  "drop_table",
+]);
+
+export const forbiddenToolsGuardrail: Guardrail<"pre-tool"> = {
+  name: "forbidden-tools",
+  stage: "pre-tool",
+  async run(ctx: PreToolGuardrailContext) {
+    if (FORBIDDEN_TOOLS.has(ctx.toolName)) {
+      return {
+        tripped: true,
+        // Internal-only reason; proxy MUST surface a generic block message
+        // to the worker (leaking specifics is an evasion surface).
+        reason: `Tool "${ctx.toolName}" is on the built-in deny list`,
+        metadata: { toolName: ctx.toolName },
+      };
+    }
+    return { tripped: false };
+  },
+};
+
+// -- lookup tables ----------------------------------------------------------
+
 /**
- * Names of all built-in guardrail factories exported here. Lookup table for
- * the aggregator when a skill or agent references a builtin by name.
+ * Factory map used by the aggregator to instantiate built-ins by name.
+ * Stage-locked builtins (secret-scan, forbidden-tools) ignore the stage
+ * parameter and return their canonical stage instance cast to the caller's
+ * generic; the aggregator only requests them at their natural stage.
  */
 export const BUILTIN_GUARDRAIL_FACTORIES: Record<
   string,
   <S extends GuardrailStage>(stage: S, name?: string) => Guardrail<S>
 > = {
   "pii-scan": createPiiScanGuardrail,
+  "secret-scan": <S extends GuardrailStage>(_stage: S, _name?: string) =>
+    secretScanGuardrail as unknown as Guardrail<S>,
+  "forbidden-tools": <S extends GuardrailStage>(_stage: S, _name?: string) =>
+    forbiddenToolsGuardrail as unknown as Guardrail<S>,
 };
+
+/**
+ * Register all gateway built-ins on the shared registry exactly once at boot.
+ * Duplicate registration is a programmer error (the registry throws).
+ */
+export function registerBuiltinGuardrails(registry: GuardrailRegistry): void {
+  registry.register(secretScanGuardrail);
+  registry.register(forbiddenToolsGuardrail);
+  registry.register(createPiiScanGuardrail("input"));
+  registry.register(createPiiScanGuardrail("output"));
+  registry.register(createPiiScanGuardrail("pre-tool"));
+}

--- a/packages/server/src/gateway/orchestration/index.ts
+++ b/packages/server/src/gateway/orchestration/index.ts
@@ -2,7 +2,12 @@ export * from "./base-deployment-manager.js";
 export * from "./deployment-utils.js";
 export * from "./impl/embedded-deployment.js";
 
-import { createLogger, moduleRegistry } from "@lobu/core";
+import {
+  createLogger,
+  type GuardrailRegistry,
+  moduleRegistry,
+} from "@lobu/core";
+import type { AgentSettingsStore } from "../auth/settings/agent-settings-store.js";
 import type { ProviderCatalogService } from "../auth/provider-catalog.js";
 import {
   getModelProviderModules,
@@ -53,7 +58,9 @@ export class Orchestrator {
     secretStore: WritableSecretStore,
     providerCatalogService?: ProviderCatalogService,
     grantStore?: GrantStore,
-    policyStore?: PolicyStore
+    policyStore?: PolicyStore,
+    guardrailRegistry?: GuardrailRegistry,
+    agentSettingsStore?: AgentSettingsStore
   ): Promise<void> {
     this.deploymentManager.setSecretStore(secretStore);
 
@@ -67,6 +74,14 @@ export class Orchestrator {
 
     if (providerCatalogService) {
       this.deploymentManager.setProviderCatalogService(providerCatalogService);
+    }
+
+    // Wire input-stage guardrails into the queue consumer. Both must be
+    // present for the consumer to run anything — the setter is a no-op
+    // otherwise.
+    if (guardrailRegistry && agentSettingsStore) {
+      this.queueConsumer.setGuardrails(guardrailRegistry, agentSettingsStore);
+      logger.debug("Input-stage guardrails wired into MessageConsumer");
     }
 
     const providerModules = getModelProviderModules();

--- a/packages/server/src/gateway/orchestration/message-consumer.ts
+++ b/packages/server/src/gateway/orchestration/message-consumer.ts
@@ -14,6 +14,7 @@ import {
 } from "@lobu/core";
 import * as Sentry from "@sentry/node";
 import type { AgentSettingsStore } from "../auth/settings/agent-settings-store.js";
+import { platformMetadataString } from "../connections/platform-metadata.js";
 import { recordGuardrailTrip } from "../guardrails/audit.js";
 import type {
   IMessageQueue,
@@ -123,9 +124,10 @@ export class MessageConsumer {
     const jobId = job?.id || "unknown";
 
     // Extract traceparent for distributed tracing (from message ingestion)
-    const traceparent = data?.platformMetadata?.traceparent as
-      | string
-      | undefined;
+    const traceparent = platformMetadataString(
+      data?.platformMetadata,
+      "traceparent"
+    );
 
     // Extract or generate trace ID for logging (backwards compatible)
     const traceId =

--- a/packages/server/src/gateway/orchestration/message-consumer.ts
+++ b/packages/server/src/gateway/orchestration/message-consumer.ts
@@ -251,8 +251,34 @@ export class MessageConsumer {
               }
             );
             if (outcome.tripped) {
-              recordGuardrailTrip({
-                organizationId: data.organizationId,
+              // Resolve org id with a metadata fallback so a trip never
+              // silently drops the audit. `data.organizationId` is
+              // populated for all production paths but legacy/test
+              // enqueues can omit it.
+              let resolvedOrgId = data.organizationId;
+              if (!resolvedOrgId && this.agentSettingsStore) {
+                try {
+                  const md = await this.agentSettingsStore.getMetadata(
+                    data.agentId
+                  );
+                  resolvedOrgId = md?.organizationId;
+                } catch (lookupErr) {
+                  logger.warn(
+                    {
+                      agentId: data.agentId,
+                      err:
+                        lookupErr instanceof Error
+                          ? lookupErr.message
+                          : String(lookupErr),
+                    },
+                    "Input guardrail trip: orgId metadata lookup failed (audit may be skipped)"
+                  );
+                }
+              }
+              // Fire-and-forget — never blocks the response queue send.
+              // Tests use `flushPendingGuardrailAudits` to drain.
+              void recordGuardrailTrip({
+                organizationId: resolvedOrgId,
                 agentId: data.agentId,
                 userId: data.userId,
                 conversationId: effectiveConversationId,

--- a/packages/server/src/gateway/orchestration/message-consumer.ts
+++ b/packages/server/src/gateway/orchestration/message-consumer.ts
@@ -6,11 +6,15 @@ import {
   generateTraceId,
   generateWorkerToken,
   getTraceparent,
+  type GuardrailRegistry,
   OrchestratorError,
   retryWithBackoff,
+  runGuardrails,
   SpanStatusCode,
 } from "@lobu/core";
 import * as Sentry from "@sentry/node";
+import type { AgentSettingsStore } from "../auth/settings/agent-settings-store.js";
+import { recordGuardrailTrip } from "../guardrails/audit.js";
 import type {
   IMessageQueue,
   QueueJob as SharedQueueJob,
@@ -39,6 +43,8 @@ export class MessageConsumer {
    * has cross-process workers.
    */
   private deploymentLocks = new Map<string, Promise<unknown>>();
+  private agentSettingsStore?: AgentSettingsStore;
+  private guardrailRegistry?: GuardrailRegistry;
   constructor(
     config: OrchestratorConfig,
     deploymentManager: BaseDeploymentManager,
@@ -46,6 +52,21 @@ export class MessageConsumer {
     this.config = config;
     this.deploymentManager = deploymentManager;
     this.queue = new RunsQueue();
+  }
+
+  /**
+   * Inject guardrail infrastructure post-construction. Called by the
+   * Orchestrator after CoreServices has built the registry — the consumer
+   * is constructed earlier than CoreServices is wired up, so a setter
+   * matches the existing `injectCoreServices` pattern on the orchestrator.
+   * Calling with no args is a no-op (guardrails simply don't run).
+   */
+  setGuardrails(
+    registry?: GuardrailRegistry,
+    settingsStore?: AgentSettingsStore
+  ): void {
+    this.guardrailRegistry = registry;
+    this.agentSettingsStore = settingsStore;
   }
 
   async start(): Promise<void> {
@@ -201,12 +222,94 @@ export class MessageConsumer {
         `Conversation routing - effectiveConversationId: ${effectiveConversationId}, canonicalKey: ${canonicalConversationKey}, deploymentName: ${deploymentName}`
       );
 
-      // TODO(#254): input-stage guardrail hook. When a GuardrailRegistry is
-      // injected here, call runGuardrails("input", registry, settings.guardrails, ctx)
-      // before sendToWorkerQueue. On trip: skip dispatch, surface trip.reason
-      // to the user via the response bridge. Lookup of settings.guardrails
-      // requires threading an AgentConfigStore into MessageConsumer; deferred
-      // to the PR that registers the first real input guardrail (#251).
+      // Input-stage guardrails: short-circuit dispatch when an enabled
+      // guardrail trips. We surface the trip reason to the user via the
+      // `thread_response` queue (same path `trackFailedDeployment` uses)
+      // and skip both the worker queue enqueue and the deployment ensure.
+      if (
+        this.guardrailRegistry &&
+        this.agentSettingsStore &&
+        data.agentId &&
+        data.messageText
+      ) {
+        try {
+          const settings = await this.agentSettingsStore.getSettings(
+            data.agentId
+          );
+          const enabled = settings?.guardrails ?? [];
+          if (enabled.length > 0) {
+            const outcome = await runGuardrails(
+              this.guardrailRegistry,
+              "input",
+              enabled,
+              {
+                agentId: data.agentId,
+                userId: data.userId,
+                message: data.messageText,
+                platform: data.platform,
+                conversationId: effectiveConversationId,
+              }
+            );
+            if (outcome.tripped) {
+              recordGuardrailTrip({
+                organizationId: data.organizationId,
+                agentId: data.agentId,
+                userId: data.userId,
+                conversationId: effectiveConversationId,
+                stage: "input",
+                guardrail: outcome.tripped.guardrail,
+                reason: outcome.tripped.reason,
+                metadata: outcome.tripped.metadata,
+              });
+              const reasonText =
+                outcome.tripped.reason ?? "blocked by policy";
+              const blockMessage = `Message rejected: ${reasonText}`;
+              try {
+                const responseQueue = "thread_response";
+                await this.queue.createQueue(responseQueue);
+                await this.queue.send(responseQueue, {
+                  messageId: data.messageId,
+                  userId: data.userId,
+                  channelId: data.channelId,
+                  conversationId: data.conversationId,
+                  platform: data.platform,
+                  platformMetadata: data.platformMetadata,
+                  content: blockMessage,
+                  processedMessageIds: [data.messageId],
+                });
+              } catch (notifyError) {
+                logger.error(
+                  { notifyError: String(notifyError) },
+                  "Failed to send guardrail block message to user"
+                );
+              }
+              logger.info(
+                {
+                  agentId: data.agentId,
+                  guardrail: outcome.tripped.guardrail,
+                  conversationId: effectiveConversationId,
+                },
+                "Input guardrail tripped — message dropped"
+              );
+              queueSpan?.setStatus({ code: SpanStatusCode.OK });
+              queueSpan?.end();
+              return;
+            }
+          }
+        } catch (err) {
+          // Fail open on guardrail infra errors — same rationale as the
+          // pre-tool path in McpProxy. The runner already fail-opens on
+          // per-guardrail throws; this catches store/registry-level issues.
+          logger.warn(
+            {
+              agentId: data.agentId,
+              err: err instanceof Error ? err.message : String(err),
+            },
+            "Input guardrail check failed — proceeding without guardrails"
+          );
+        }
+      }
+
       // 1) Send to thread queue immediately (queue persists; worker will drain on attach)
       await Sentry.startSpan(
         {

--- a/packages/server/src/gateway/orchestration/message-consumer.ts
+++ b/packages/server/src/gateway/orchestration/message-consumer.ts
@@ -254,9 +254,7 @@ export class MessageConsumer {
             );
             if (outcome.tripped) {
               // Resolve org id with a metadata fallback so a trip never
-              // silently drops the audit. `data.organizationId` is
-              // populated for all production paths but legacy/test
-              // enqueues can omit it.
+              // silently drops the audit — legacy/test enqueues can omit it.
               let resolvedOrgId = data.organizationId;
               if (!resolvedOrgId && this.agentSettingsStore) {
                 try {
@@ -277,8 +275,6 @@ export class MessageConsumer {
                   );
                 }
               }
-              // Fire-and-forget — never blocks the response queue send.
-              // Tests use `flushPendingGuardrailAudits` to drain.
               void recordGuardrailTrip({
                 organizationId: resolvedOrgId,
                 agentId: data.agentId,
@@ -325,9 +321,8 @@ export class MessageConsumer {
             }
           }
         } catch (err) {
-          // Fail open on guardrail infra errors — same rationale as the
-          // pre-tool path in McpProxy. The runner already fail-opens on
-          // per-guardrail throws; this catches store/registry-level issues.
+          // Fail open on store/registry-level errors — the runner already
+          // fail-opens on per-guardrail throws.
           logger.warn(
             {
               agentId: data.agentId,

--- a/packages/server/src/gateway/services/core-services.ts
+++ b/packages/server/src/gateway/services/core-services.ts
@@ -6,9 +6,11 @@ import {
   type AgentConnectionStore,
   CommandRegistry,
   createLogger,
+  GuardrailRegistry,
   moduleRegistry,
   type ProviderRegistryEntry,
 } from "@lobu/core";
+import { registerBuiltinGuardrails } from "../guardrails/builtins.js";
 import { AgentMetadataStore } from "../auth/agent-metadata-store.js";
 import { ApiKeyProviderModule } from "../auth/api-key-provider-module.js";
 import { BedrockProviderModule } from "../auth/bedrock/provider-module.js";
@@ -165,6 +167,13 @@ export class CoreServices {
   private commandRegistry?: CommandRegistry;
 
   // ============================================================================
+  // Guardrails — runtime registry of input/output/pre-tool checks. Populated
+  // with built-ins at boot; downstream packages can register more by calling
+  // `getGuardrailRegistry().register(...)` after `initialize()` returns.
+  // ============================================================================
+  private guardrailRegistry?: GuardrailRegistry;
+
+  // ============================================================================
   // Ephemeral-table sweeper — now scheduler-driven, no per-instance state.
   // See `sweepEphemeralTables` (public method) registered as a periodic task.
   // ============================================================================
@@ -228,6 +237,12 @@ export class CoreServices {
    */
   async initialize(): Promise<void> {
     logger.debug("Initializing core services...");
+
+    // 0. Guardrail registry — populated before any service that may invoke
+    // `runGuardrails()` is constructed (McpProxy, MessageConsumer, etc.).
+    this.guardrailRegistry = new GuardrailRegistry();
+    registerBuiltinGuardrails(this.guardrailRegistry);
+    logger.debug("Guardrail registry initialized with built-ins");
 
     // 1. Queue (foundation for everything else)
     await this.initializeQueue();
@@ -743,6 +758,8 @@ export class CoreServices {
       toolCache: mcpToolCache,
       grantStore: this.grantStore,
       publicGatewayUrl: this.config.mcp.publicGatewayUrl,
+      agentSettingsStore: this.agentSettingsStore,
+      guardrailRegistry: this.guardrailRegistry,
     });
     this.mcpProxy.onToolBlocked = async (
       requestId,
@@ -1037,6 +1054,10 @@ export class CoreServices {
     if (!this.agentMetadataStore)
       throw new Error("Agent metadata store not initialized");
     return this.agentMetadataStore;
+  }
+
+  getGuardrailRegistry(): GuardrailRegistry | undefined {
+    return this.guardrailRegistry;
   }
 
   getCommandRegistry(): CommandRegistry {

--- a/packages/server/src/lobu/gateway.ts
+++ b/packages/server/src/lobu/gateway.ts
@@ -176,7 +176,9 @@ export async function initLobuGateway(): Promise<Hono | null> {
       coreServices.getSecretStore(),
       coreServices.getProviderCatalogService(),
       coreServices.getGrantStore() ?? undefined,
-      coreServices.getPolicyStore() ?? undefined
+      coreServices.getPolicyStore() ?? undefined,
+      coreServices.getGuardrailRegistry() ?? undefined,
+      coreServices.getAgentSettingsStore() ?? undefined
     );
     logger.info('[Lobu] Embedded orchestrator injected core services');
 
@@ -193,6 +195,10 @@ export async function initLobuGateway(): Promise<Hono | null> {
       const unifiedConsumer = gateway.getUnifiedConsumer();
       if (unifiedConsumer) {
         const bridge = new ChatResponseBridge(chatInstanceManager);
+        bridge.setGuardrails(
+          coreServices.getGuardrailRegistry(),
+          coreServices.getAgentSettingsStore()
+        );
         unifiedConsumer.setChatResponseBridge(bridge);
       }
     } catch (error) {


### PR DESCRIPTION
## Summary

PR A of the 3-PR guardrails rollout — wires the runtime end-to-end and ships the first two real guardrails. The guardrail primitive (`@lobu/core` `Guardrail<stage>` / `GuardrailRegistry` / `runGuardrails`) and the config/storage plumbing (`agents.guardrails jsonb`, `AgentSettings.guardrails`, `lobu apply`) were already in place. This PR replaces the three TODO call sites with real `runGuardrails()` invocations and ships the first built-ins. Sibling PRs cover schema extensions (PR B) and owletto UI (PR C).

- **Wired call sites:**
  - `MessageConsumer.handleMessage` (input) — dispatch is short-circuited on trip, `Message rejected: <reason>` pushed to `thread_response`.
  - `ChatResponseBridge.handleDelta` (output, per delta) — in-flight stream disposed on trip, `Message blocked by guardrail: <reason>` posted, partial buffer not written to history.
  - `McpProxy.handleProxyRequest` (pre-tool) — JSON-RPC `isError` with generic `Tool call blocked by policy.`; specific reason intentionally not leaked.
- **Built-ins** (`packages/server/src/gateway/guardrails/builtins.ts`):
  - `secret-scan` (output) — OpenAI/GitHub PAT/AWS/JWT regex.
  - `forbidden-tools` (pre-tool) — deny-list `[delete_repo, delete_branch, drop_table]`.
- Registered at boot in `CoreServices.initialize()` via `registerBuiltinGuardrails(...)`; exposed via `getGuardrailRegistry()`.
- Every trip writes one `semantic_type='guardrail-trip'` event with `{guardrail, stage, reason, agent_id, user_id, conversation_id}` metadata.
- `AGENTS.md` `#### Guardrails` updated to reflect what ships.

## Codex review rounds

### Round 1 (commit `b90dbdc0`)

Five concerns from the high-effort codex review, all fixed:

1. **Split-chunk regression in `chat-response-bridge.ts`** — per-delta regex scan missed secrets straddling chunk boundaries (`"sk-an"` then `"t-..."`). Fixed via a per-stream rolling tail (`OUTPUT_GUARDRAIL_TAIL_CHARS = 256`); the scan operates on `(previous tail + current delta)` so the regex still matches on the second chunk. Tail is dropped on completion, full-replacement, and trip so a blocked stream's bytes never leak into the next stream on the same key.
2. **Audit silently dropped trips on missing `organizationId`** — security log gap. Bridge falls back to `instance.connection.organizationId`; MessageConsumer and McpProxy fall back to `agentSettingsStore.getMetadata(agentId)`. Audit logs at **error** when both fail.
3. **Fake e2e in `guardrails-runtime.test.ts`** — prior test only called `runGuardrails(...)` directly. Rewritten to instantiate real `ChatResponseBridge`, `MessageConsumer` (subclassed `TestableMessageConsumer`), `McpProxy` and drive their public methods.
4. **Flaky `setTimeout(50)`** — replaced with `flushPendingGuardrailAudits()`, a production helper that drains in-flight audit writes. Wired call sites still use `void recordGuardrailTrip(...)`.
5. **`(platformMetadata as any).field`** — new `connections/platform-metadata.ts` declares `PlatformMetadata` + `readPlatformMetadata` + `platformMetadataString`.

### Round 2 (commit `2eb575f7`)

Two remaining items, both fixed:

1. **`handleDelta` ordering with `fullReplacement`** — the rolling tail was updated/scanned BEFORE the replacement was handled, so the scan ran on `(previous-delta-tail + new-replacement-text)`. Joining two unrelated text bodies can synthesize a regex match that exists in neither piece on its own — a false-positive trip on the first delta of an unrelated reply. Fixed by reordering: detect `isFullReplacement` first, dispose the prior stream + clear the tail, **then** scan. A regression test asserts the scenario: prior delta ending `"...sk-a"` followed by a fullReplacement delta starting `"bcdefghij..."` (each safe alone, naive concat would match `openai-key`) must NOT trip. **Verified to fail against the pre-fix code** before the reorder.

2. **Residual `payload.platformMetadata as Record<...>` casts** — three call sites in `chat-response-bridge.ts` (`handleError`, `handleStatusUpdate`, `handleEphemeral`) plus one `data?.platformMetadata?.traceparent as string | undefined` in `message-consumer.ts`. Replaced with `readPlatformMetadata(...)` / `platformMetadataString(...)`. `resolveTarget` and `buildCurrentMessageFromMetadata` signatures now take `PlatformMetadata` directly. No production-code `platformMetadata as Record` / `platformMetadata as any` casts remain.

### Round 3 simplification pass (commit `8e9508ca`)

Post-review cleanup — no behavior change, 7/7 + 887/887 tests still green.

1. **Collapsed the rolling-tail helpers in `chat-response-bridge.ts`.** `updateGuardrailTail(key, delta)` and `clearGuardrailTail(key)` became one `scanWindowWithTail(key, delta)` plus inlined `this.guardrailTails.delete(key)` at the three call sites. The previous `updateGuardrailTail` computed `nextTail = combined.slice(-512)` AND separately computed `scanSlice = (previous + delta).slice(-512)` — the same window twice with slightly different conditionals. One slice now serves both roles. `clearGuardrailTail` added no meaning over the Map call it wrapped.
2. **Stripped review-justifying comments.** Per-method docs on `resolveAgentId`/`resolveOrganizationId`, the file-level audit.ts block, the `Fire-and-forget — Tests use flushPendingGuardrailAudits to drain` repeats in bridge/proxy/message-consumer, the `Fail open — same rationale as the pre-tool path in McpProxy` comments. Kept the terse invariant on the `isFullReplacement` ordering (the regression test exercises exactly that order).
3. **Left intentionally as-is:** `audit.ts` 3-concept shape (`recordGuardrailTrip` + `pendingAudits` Set + `flushPendingGuardrailAudits`). The user prompt's suggestion (return promise from `recordGuardrailTrip`, callers `void`) is already what it does. Removing the tracking would force the test to either change the production call sites to expose the promise or accept a `sleep(50)` — both are worse than the current private-tracker shape.

## Reproducer

```
$ cd packages/server && LOBU_TEST_BACKEND=pglite bunx vitest run src/__tests__/guardrails-runtime.test.ts

✅ PGlite ready
🗄️  Running migrations...
✅ Test database ready.

[guardrail-runner] Guardrail tripped {"guardrail":"secret-scan","stage":"output","reason":"... openai-key"}
[guardrail-runner] Guardrail tripped {"guardrail":"secret-scan","stage":"output","reason":"... openai-key"}    ← split-chunk
[guardrail-runner] Guardrail tripped {"guardrail":"secret-scan","stage":"output","reason":"... aws-access-key"} ← connection org-id fallback
[orchestrator] Input guardrail tripped — message dropped {"guardrail":"test-input-tripper"}
[orchestrator] Input guardrail tripped — message dropped {"guardrail":"test-input-tripper"} ← metadata orgId fallback
[mcp-proxy] Pre-tool guardrail tripped — returning generic policy block to worker {"guardrail":"forbidden-tools"}

 ✓ src/__tests__/guardrails-runtime.test.ts (7 tests) 601ms
 Test Files  1 passed (1)      Tests  7 passed (7)
```

Tests:
- `ChatResponseBridge` — full-secret-in-one-delta, split-chunk-across-two-deltas, **fullReplacement-clears-tail (no false positive)**, connection.organizationId fallback
- `MessageConsumer` — trip blocks worker enqueue + emits thread_response, metadata-orgId fallback
- `McpProxy` — `delete_repo` returns `Tool call blocked by policy.` (no reason leak), audit row records reason for operators

## Test plan

- [x] `make build-packages` clean
- [x] `bun run typecheck` clean
- [x] `bun test src/gateway/__tests__/` — 887/887 tests pass (no regressions)
- [x] `LOBU_TEST_BACKEND=pglite bunx vitest run src/__tests__/guardrails-runtime.test.ts` — 7/7 pass
- [x] Regression test (`isFullReplacement clears the rolling tail before scanning`) verified to FAIL against pre-fix `chat-response-bridge.ts` before the reorder
- [x] Core guardrail tests — 28/28 pass
- [x] AGENTS.md `#### Guardrails` describes the shipped behavior

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Runtime guardrails enabled: secret-scanning for outputs, forbidden-tool blocking for tool calls, and input-stage checks. Blocked outputs post a user-facing notice; blocked tool calls return a generic "Tool call blocked by policy" response; rejected inputs enqueue a thread rejection.

* **Documentation**
  * Updated guardrail configuration and per-stage semantics documented.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Runtime guardrails enabled: secret-scanning for outputs, forbidden-tool blocking for tool calls, and input-stage checks; blocked outputs post a user notice, blocked tool calls return a generic "Tool call blocked by policy", and rejected inputs enqueue a thread rejection.

* **Documentation**
  * Guardrail configuration and per-stage semantics updated and clarified.

* **Tests**
  * End-to-end guardrails test suite added with database-backed audit verification.

* **Other**
  * Guardrail trips are recorded as append-only audit events; infra errors fail open.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lobu-ai/lobu/pull/919?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->