### PR TITLE
chore: bump owletto submodule (#196) + correct AGENTS.md guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -180,7 +180,7 @@ When the user pivots mid-session, the default failure mode is piling unrelated w
 - **Never `git stash`.** Stashes are invisible, easy to lose, and collide across agents. If you need to pivot without finishing, commit WIP to the current branch (`git add -A && git commit -m "wip"`) and squash later. WIP commits are visible, pushable, recoverable.
 - **Per-agent isolation:** when launching a parallel Claude Code session, use `claude --worktree <name>` so each agent gets its own checkout + branch. No shared working dir = no cross-agent collisions.
 - **Subagent isolation (mandatory):** any spawned subagent that may `git switch`, commit, push, or run a destructive command MUST run with `isolation: "worktree"`. Read-only research/exploration agents may share the parent checkout. If unsure, use a worktree — the cost is a temp checkout, the cost of skipping is overwriting the user's working tree.
-- **Cross-repo dispatch:** owletto changes go through a **standalone clone at `~/Code/owletto`**, not `packages/owletto/`. The submodule worktree inherits the parent's `.git` and pushes to the wrong remote; an isolation worktree of lobu that needs to edit owletto code ends up with `origin = lobu-ai/owletto` and can't push to lobu. After an owletto PR merges, bump the submodule pointer in lobu in a separate small PR.
+- **Cross-repo dispatch:** owletto changes go through a `make task-setup NAME=<slug>` worktree, which fetches a fresh owletto checkout under `.claude/worktrees/<slug>/packages/owletto` on a real branch (not a detached submodule SHA). The submodule worktree inherits the parent's `.git` and pushes to the wrong remote; an isolation worktree of lobu that needs to edit owletto code ends up with `origin = lobu-ai/owletto` and can't push to lobu. After an owletto PR merges, bump the submodule pointer in lobu in a separate small PR.
 - **Don't pass `"REPO: /absolute/path"` in dispatch prompts.** Agents take it as a cwd directive and `cd` out of their isolation worktree onto the main checkout. Say "the lobu repo" / "the owletto repo" instead and let `isolation: "worktree"` do its job.
 - **If a branch has already gotten mixed**, recover with `git rebase -i` + `git reset HEAD~N` and re-commit in clean groups before opening PRs.
 
@@ -246,7 +246,7 @@ Without an editor integration, biome's `--write` still rewrites files at commit 
 4. Paste both in the PR body under a "Reproducer" section.
 5. **If you can't reproduce the original failure, BAIL** — post the dead-end on the issue, do not open a PR. Pi (the project's automated PR-review CLI, run as `pi -p <PR>`) validates code shape, not that the fix hits the actual smoking gun.
 
-Exception: changes that require dev environments the agent can't reach (Mac/Xcode, iOS, hardware). Call it out in the PR body ("Untested — requires Xcode") and leave the PR in draft until a human validates.
+Exception: runtime/UI validation on native apps (Mac/iOS) or hardware that needs a human-driven click. Compile-checks aren't exempt — `xcodebuild` runs headlessly. If you can't drive the UI, say so explicitly in the PR body ("Compiled clean; UI flow needs human validation") and leave the PR in draft.
 
 Run the validation that matches what you touched:
 
@@ -254,6 +254,7 @@ Run the validation that matches what you touched:
 | --- | --- |
 | `packages/landing/*` | `cd packages/landing && bun run build` |
 | `packages/{core,server,agent-worker,cli}/*` | `make build-packages` |
+| `packages/owletto/apps/mac/*` | `cd packages/owletto/apps/mac && xcodebuild -project Owletto.xcodeproj -scheme Owletto -configuration Debug -destination "platform=macOS" build CODE_SIGNING_ALLOWED=NO` |
 | Broad TS check | `bun run typecheck` |
 
 For MCP work, verify tool calls against the gateway proxy or Lobu directly (e.g. via `bun -e`) before exercising the full agent loop.


### PR DESCRIPTION
Two related cleanups discovered while shipping owletto#196.

## 1. Bump owletto submodule pointer
Picks up [owletto#196](https://github.com/lobu-ai/owletto/pull/196): **feat(mac): Cancel button for the OAuth sign-in flow** — three codex rounds of cancellation-race fixes; xcodebuild green on every commit.

Submodule SHA: `4f7c757` → `05e966b`.

## 2. AGENTS.md: correct the Mac/Xcode validation exception
- The "E2E before merge" exception claimed agents can't reach Mac/Xcode. `xcodebuild` actually runs headlessly from Bash — verified during owletto#196's iteration. Reworded the exception so only UI/runtime validation is exempt; added the xcodebuild command to the validation table.
- Updated "Cross-repo dispatch" to reference `make task-setup` workflow (which is how #196 was shipped) instead of the retired standalone `~/Code/owletto` clone.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

This release contains internal updates and documentation improvements with no end-user visible changes.

* **Chores**
  * Updated internal project references and developer documentation

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lobu-ai/lobu/pull/926?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->