### PR TITLE
ci(publish): authenticate clawhub via CLAWHUB_TOKEN secret

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -50,6 +50,16 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
+      - name: ClawHub login
+        # clawhub CLI v0.16 doesn't expose an explicit OIDC flag; use a
+        # long-lived org token stored as a repo + production-environment
+        # secret. Skipped if CLAWHUB_TOKEN is unset (e.g. forks).
+        if: ${{ env.CLAWHUB_TOKEN_SET == 'true' }}
+        env:
+          CLAWHUB_TOKEN: ${{ secrets.CLAWHUB_TOKEN }}
+          CLAWHUB_TOKEN_SET: ${{ secrets.CLAWHUB_TOKEN != '' }}
+        run: npx --yes clawhub@latest login --token "$CLAWHUB_TOKEN" --no-browser
+
       - name: Publish packages
         env:
           # Auth precedence (npm 11+):


### PR DESCRIPTION
## Summary

- ClawHub CLI v0.16 has no OIDC flag, so the openclaw-plugin clawhub publish step has been failing with \`Not logged in\` since 05-14 (last 4 release attempts).
- Add a pre-publish step that does \`clawhub login --token \$CLAWHUB_TOKEN --no-browser\` using a long-lived org token stored as a repo + production-environment secret (\`CLAWHUB_TOKEN\`).
- Step is gated on \`env.CLAWHUB_TOKEN_SET == 'true'\` so forks and non-publishing PR runs are unaffected.
- openclaw-plugin@8.0.0 was already published to ClawHub manually with \`--manual-override-reason\` before opening this PR, so 8.0.0 is consistent across both registries.

## Test plan

- [x] Verified \`CLAWHUB_TOKEN\` secret is set at repo + production environment scope (\`gh secret list\`)
- [x] Locally validated \`npx clawhub@latest login --token \$TOKEN --no-browser\` succeeds and \`clawhub whoami\` returns \`buremba\`
- [ ] Next release: CI will exercise the new step end-to-end

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package publishing workflow with enhanced authentication for improved deployment reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lobu-ai/lobu/pull/936?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->