### PR TITLE
refactor(memory): clarify namespace vocabulary + add agent_id filter on search_memory

### DIFF
--- a/packages/agent-worker/src/openclaw/worker.ts
+++ b/packages/agent-worker/src/openclaw/worker.ts
@@ -81,6 +81,32 @@ const logger = createLogger("worker");
 const MEMORY_FLUSH_STATE_CUSTOM_TYPE = "lobu.memory_flush_state";
 const APPROX_IMAGE_TOKENS = 1200;
 
+const LOBU_MEMORY_PLUGIN_SOURCE = "@lobu/openclaw-plugin";
+
+/**
+ * Inject the bound agentId into the Lobu memory plugin's config so its
+ * autoCapture path stamps `metadata.agent_id` on save_memory calls. Other
+ * plugins are passed through unchanged. Returns a new PluginsConfig — does
+ * not mutate input.
+ */
+function injectAgentIdIntoLobuPlugin(
+  pluginsConfig: PluginsConfig | undefined,
+  agentId: string | undefined
+): PluginsConfig | undefined {
+  if (!pluginsConfig?.plugins?.length || !agentId) return pluginsConfig;
+  const plugins = pluginsConfig.plugins.map((plugin) => {
+    if (plugin.source !== LOBU_MEMORY_PLUGIN_SOURCE) return plugin;
+    return {
+      ...plugin,
+      config: {
+        ...plugin.config,
+        agentId,
+      },
+    };
+  });
+  return { ...pluginsConfig, plugins };
+}
+
 interface ResolvedMemoryFlushConfig {
   enabled: boolean;
   softThresholdTokens: number;
@@ -1239,8 +1265,14 @@ Use it when the user references past discussions or you need context.`);
       }
     }
 
-    // Load OpenClaw plugins
-    const pluginsConfig = rawOptions.pluginsConfig as PluginsConfig | undefined;
+    // Load OpenClaw plugins. Inject the worker's bound agentId into the Lobu
+    // memory plugin's config so its autoCapture path can stamp
+    // `metadata.agent_id` on every save_memory call — that's the
+    // memory-scope axis search_memory's `agent_id` filter reads.
+    const pluginsConfig = injectAgentIdIntoLobuPlugin(
+      rawOptions.pluginsConfig as PluginsConfig | undefined,
+      this.config.agentId
+    );
     const loadedPlugins = await loadPlugins(pluginsConfig, workspaceDir);
     const pluginTools = loadedPlugins.flatMap((p) => p.tools);
 

--- a/packages/connector-sdk/src/identity-normalize.ts
+++ b/packages/connector-sdk/src/identity-normalize.ts
@@ -4,6 +4,18 @@
  * Connectors call these before emitting identifiers on events. The ingestion
  * pipeline also re-runs normalization as a defensive pass, so mismatched
  * connector behavior can't poison cross-channel matching.
+ *
+ * Glossary — "namespace" in this file:
+ *   The string `namespace` here means an *identity scope* — the type of an
+ *   external identifier (`email`, `phone`, `wa_jid`, `slack_user_id`, etc.).
+ *   It backs the `entity_identities.namespace` column and is the unit of
+ *   uniqueness for cross-connector identity matching.
+ *
+ *   It is NOT the memory-scope axis. Per-agent memory scoping lives on
+ *   `events.metadata.agent_id` (filtered via `search_memory`'s `agent_id`
+ *   arg, populated by `@lobu/openclaw-plugin` autoCapture). Identity
+ *   namespaces and memory scopes are unrelated subsystems that happen to
+ *   share an English word — don't conflate them when reading this file.
  */
 
 const PHONE_MIN_DIGITS = 7;

--- a/packages/openclaw-plugin/README.md
+++ b/packages/openclaw-plugin/README.md
@@ -32,6 +32,7 @@ Replace `<mcp-url>` with your workspace MCP URL (for example `https://lobu.ai/mc
 | `autoRecall` | Search Lobu memory for relevant memories before each prompt. Default `true`. |
 | `recallLimit` | Maximum recalled memory records per request. Default `6`. |
 | `autoCapture` | Capture conversation observations as long-term memories after each session. Default `true`. |
+| `agentId` | Agent ID this plugin instance is bound to. When set, `autoCapture` stamps `metadata.agent_id` on every save so `search_memory`'s `agent_id` filter can scope recall to this agent's own writes. Falls back to `LOBU_AGENT_ID` env. |
 
 See [`openclaw.plugin.json`](./openclaw.plugin.json) for the full schema.
 

--- a/packages/openclaw-plugin/openclaw.plugin.json
+++ b/packages/openclaw-plugin/openclaw.plugin.json
@@ -60,6 +60,10 @@
         "type": "boolean",
         "default": true,
         "description": "When true, captures conversation observations as long-term memories after each agent session."
+      },
+      "agentId": {
+        "type": "string",
+        "description": "Agent ID this plugin instance is bound to. autoCapture saves stamp `metadata.agent_id` with this value so `search_memory` can scope recall to the agent's own writes. Falls back to LOBU_AGENT_ID env when unset."
       }
     }
   },

--- a/packages/openclaw-plugin/src/index.ts
+++ b/packages/openclaw-plugin/src/index.ts
@@ -345,6 +345,7 @@ function resolvePluginConfig(api: Record<string, unknown>, pluginId: string): Re
   const tokenCommand =
     asString(cfg.tokenCommand) ?? asString(process.env.LOBU_MCP_TOKEN_COMMAND);
   const gatewayAuthUrl = asString(cfg.gatewayAuthUrl) ?? asString(process.env.GATEWAY_AUTH_URL);
+  const agentId = asString(cfg.agentId) ?? asString(process.env.LOBU_AGENT_ID);
 
   const headers: Record<string, string> = {};
   if (isRecord(cfg.headers)) {
@@ -365,6 +366,7 @@ function resolvePluginConfig(api: Record<string, unknown>, pluginId: string): Re
     autoRecall: asBoolean(cfg.autoRecall, true),
     autoCapture: asBoolean(cfg.autoCapture, true),
     recallLimit: asPositiveInt(cfg.recallLimit, DEFAULT_RECALL_LIMIT),
+    agentId,
   };
 }
 
@@ -1481,10 +1483,18 @@ const plugin = {
         const content = combined.length > 2000 ? combined.slice(0, 2000) : combined;
 
         // Fire-and-forget — don't block the agent_end path.
+        // Stamp `agent_id` so `search_memory` can scope recall to this
+        // agent's own observations. `metadata.agent_id` is the memory-scope
+        // axis (see `identity-normalize.ts` glossary); it does NOT relate
+        // to `entity_identities.namespace`.
+        const captureMetadata: Record<string, unknown> = {};
+        if (config.agentId) {
+          captureMetadata.agent_id = config.agentId;
+        }
         callMcpTool(config, 'save_memory', {
           content,
           semantic_type: 'observation',
-          metadata: {},
+          metadata: captureMetadata,
         })
           .then(() => log.info('lobu: captured conversation observation'))
           .catch((err) =>

--- a/packages/openclaw-plugin/src/types.ts
+++ b/packages/openclaw-plugin/src/types.ts
@@ -12,6 +12,13 @@ export interface PluginConfig {
   autoRecall?: boolean;
   autoCapture?: boolean;
   recallLimit?: number;
+  /**
+   * Agent ID the plugin instance is bound to. When set, autoCapture saves
+   * stamp `metadata.agent_id` on every event so `search_memory` can scope
+   * recall to this agent's own writes. Injected by the Lobu worker from
+   * the agent's runtime config; falls back to `process.env.LOBU_AGENT_ID`.
+   */
+  agentId?: string;
 }
 
 export interface ResolvedPluginConfig {
@@ -24,6 +31,7 @@ export interface ResolvedPluginConfig {
   autoRecall: boolean;
   autoCapture: boolean;
   recallLimit: number;
+  agentId: string | null;
 }
 
 export interface McpToolDefinition {

--- a/packages/server/src/tools/registry.ts
+++ b/packages/server/src/tools/registry.ts
@@ -3,6 +3,18 @@
  *
  * This file defines all MCP tools and imports their Typebox schemas from tool files.
  * Typebox provides compile-time type safety and runtime JSON schema generation.
+ *
+ * Glossary — "namespace" in tool descriptions below means three different things,
+ * none of which is a memory-scope axis:
+ *   1. `search_sdk`'s `namespace` param — a ClientSDK module name
+ *      (`watchers`, `entities`, `knowledge`, ...).
+ *   2. `resolve_path`'s "namespace-based URL path" — the first URL segment
+ *      (org slug or entity-type slug).
+ *   3. `entity_identities.namespace` (deep in SQL) — the identifier type
+ *      (`email`, `phone`, `wa_jid`); see `identity-normalize.ts`.
+ *
+ * Memory scoping uses `events.metadata.agent_id` (filtered via
+ * `search_memory`'s top-level `agent_id` arg) — not any of the above.
  */
 
 import { getPublicReadableActions, getRequiredAccessLevel } from '../auth/tool-access';

--- a/packages/server/src/tools/search.ts
+++ b/packages/server/src/tools/search.ts
@@ -98,7 +98,13 @@ export const SearchSchema = Type.Object({
   metadata_filter: Type.Optional(
     Type.Record(Type.String(), Type.String(), {
       description:
-        'Filter entities by metadata key-value pairs (e.g. {"namespace": "agent:prefs"})',
+        'Filter entities by metadata key-value pairs (e.g. {"category": "preference"})',
+    })
+  ),
+  agent_id: Type.Optional(
+    Type.String({
+      description:
+        "Limit results to memory written by this agent. Filters events where `metadata.agent_id` matches the given id. Agents that opt in (via the `@lobu/openclaw-plugin` autoCapture path) get their saves stamped with their own id automatically; pass the same id here to scope recall to that agent's own writes.",
     })
   ),
   limit: Type.Optional(
@@ -252,7 +258,8 @@ async function fetchContentSnippets(
   organizationId: string,
   contentLimit: number,
   env: Env,
-  queryEmbedding?: number[]
+  queryEmbedding?: number[],
+  agentId?: string
 ): Promise<ContentSnippet[]> {
   const result = await searchContentByText(
     query,
@@ -261,6 +268,7 @@ async function fetchContentSnippets(
       limit: contentLimit,
       min_similarity: 0.4,
       query_embedding: queryEmbedding,
+      agent_id: agentId,
       // Recall wants the most *relevant* matching content, not the most recent.
       // This also opts into the bounded recall-only candidate path (the implicit
       // default is a chronological date feed).
@@ -305,6 +313,8 @@ export async function search(
   // query or a pre-computed embedding — forwarding the embedding lets the
   // content layer skip regenerating it from text.
   const hasContentSignal = Boolean(args.query || args.query_embedding?.length);
+  const agentIdScope =
+    args.agent_id ?? (args.metadata_filter?.agent_id as string | undefined);
   const contentSearchPromise =
     includeContent && hasContentSignal
       ? fetchContentSnippets(
@@ -312,7 +322,8 @@ export async function search(
           ctx.organizationId,
           contentLimit,
           env,
-          args.query_embedding
+          args.query_embedding,
+          agentIdScope
         ).catch((err) => {
           logger.warn(
             `[search] content search failed: ${err instanceof Error ? err.message : String(err)}`
@@ -579,6 +590,14 @@ async function queryEntities(
     for (const [key, value] of Object.entries(args.metadata_filter)) {
       conditions.push(`e.metadata->>'${key.replace(/'/g, "''")}' = $${addParam(value)}`);
     }
+  }
+
+  // Structured agent_id filter (also accepted under metadata_filter; the
+  // top-level form is the documented contract so agents can't typo the key).
+  const agentIdFilter =
+    args.agent_id ?? (args.metadata_filter?.agent_id as string | undefined);
+  if (agentIdFilter) {
+    conditions.push(`e.metadata->>'agent_id' = $${addParam(agentIdFilter)}`);
   }
 
   const whereClause = conditions.join(' AND ');

--- a/packages/server/src/utils/content-search.ts
+++ b/packages/server/src/utils/content-search.ts
@@ -159,6 +159,9 @@ function buildStandardParams(
         )
       : null,
     options.interaction_status ?? null,
+    // Slot $11 — per-agent memory scope. WHERE template uses
+    // `($11::text IS NULL OR f.metadata->>'agent_id' = $11::text)`.
+    options.agent_id ?? null,
   ];
 }
 
@@ -335,7 +338,8 @@ function buildStandardWhereSql(entityLinkSql: string): string {
               AND lc_source.source = $8::text
           ))
           AND ($9::text[] IS NULL OR f.semantic_type = ANY($9::text[]))
-          AND ($10::text IS NULL OR f.interaction_status = $10::text)`;
+          AND ($10::text IS NULL OR f.interaction_status = $10::text)
+          AND ($11::text IS NULL OR f.metadata->>'agent_id' = $11::text)`;
 }
 
 const WINDOW_JOIN_SQL = `LEFT JOIN watcher_window_events iwf
@@ -473,6 +477,14 @@ interface ContentSearchOptions {
   content_ids?: number[]; // Filter to specific content IDs
   semantic_type?: string | string[]; // Filter by semantic type — single value or array (matches any)
   interaction_status?: 'pending' | 'approved' | 'rejected' | 'completed' | 'failed';
+
+  // Per-agent memory scope. Filters events whose `metadata->>'agent_id'`
+  // matches this string. Threaded through search_memory's top-level
+  // `agent_id` arg; populated automatically on saves by the
+  // `@lobu/openclaw-plugin` autoCapture path. Note: `metadata.agent_id`
+  // is the memory-scope axis, NOT the identity-namespace column
+  // (`entity_identities.namespace`) — see identity-normalize.ts.
+  agent_id?: string;
 
   // Classification options (only JOINs when needed)
   include_classifications?: boolean; // Include classifications in results
@@ -1239,6 +1251,10 @@ async function listContentInternal(
       baseParams.push(options.interaction_status);
       baseConditions.push(`f.interaction_status = $${baseParams.length}`);
     }
+    if (options.agent_id) {
+      baseParams.push(options.agent_id);
+      baseConditions.push(`f.metadata->>'agent_id' = $${baseParams.length}`);
+    }
 
     const classificationExists = buildClassificationExistsClauses(
       filtersBySlug,
@@ -1515,14 +1531,15 @@ async function searchContentBySingleQuery(
   const searchEntityScopes: EntityIdentityScope[] =
     entityId != null ? await fetchEntityIdentityScopes(sql, entityId) : [];
 
+  // Slot $11 is the agent_id memory-scope filter — bumps orgScope to $12.
   const orgScope = buildOrgScopeWhere({
     entity_id: entityId,
     organization_id: options.organization_id,
-    baseParamIndex: 11,
+    baseParamIndex: 12,
   });
   // Exclude-watcher param slot sits immediately after orgScope so its $N index
   // is stable regardless of whether an embedding param follows.
-  const excludeParamIdx = 11 + orgScope.params.length;
+  const excludeParamIdx = 12 + orgScope.params.length;
   const excludeClause = buildExcludeWatcherClause(
     options.exclude_watcher_id,
     excludeParamIdx
@@ -1582,6 +1599,7 @@ async function searchContentBySingleQuery(
           AND ($8::numeric IS NULL OR f.score <= $8::numeric)
           AND ($9::text[] IS NULL OR f.semantic_type = ANY($9::text[]))
           AND ($10::text IS NULL OR f.interaction_status = $10::text)
+          AND ($11::text IS NULL OR f.metadata->>'agent_id' = $11::text)
           ${excludeClause.sql}
           ${visibilityClause.sql}
           ${orgScope.sql}`;
@@ -1832,6 +1850,9 @@ async function searchContentBySingleQuery(
         )
       : null,
     options.interaction_status ?? null,
+    // Slot $11 — per-agent memory scope. See buildStandardParams for the
+    // mirror call site. Bumps orgScope to $12 (set above).
+    options.agent_id ?? null,
     ...orgScope.params,
     ...excludeClause.params,
     ...visibilityClause.params,


### PR DESCRIPTION
## Summary

The word "namespace" carries **four unrelated meanings** in this codebase, and only one of them sits on the memory write/read surface — as an example string in `search_memory.metadata_filter`'s description (`{"namespace": "agent:prefs"}`) with no validator, no populator, no reader. The full audit is in `memory-namespace-cleanup.md`.

This PR removes that phantom convention and replaces it with a **real, structured per-agent memory scope** (`metadata.agent_id`), then adds glossary comments so the remaining three "namespace" call sites can't be confused with memory scoping.

## The four "namespace" meanings (file:line)

1. **Identifier scope** — `packages/connector-sdk/src/identity-normalize.ts` (`namespace: 'email' | 'phone' | 'wa_jid' | ...`) backing the `entity_identities.namespace` column.
2. **ClientSDK module name** — `packages/server/src/sandbox/namespaces/*` (`client.entities.list()`, etc.), surfaced to agents via `search_sdk`'s `namespace` arg (`packages/server/src/tools/registry.ts:124-126`).
3. **URL path segment** — `packages/server/src/tools/resolve_path.ts:348` + `packages/server/src/tools/registry.ts:171` ("Resolve a namespace-based URL path"). Internal frontend tool.
4. **Phantom `metadata.namespace`** — `packages/server/src/tools/search.ts:101` example string only. Nothing reads or writes it.

The actual memory-scope gap the codebase had: no structured way to filter `search_memory` by "this agent's own writes". Two agents in the same org bled memories into each other's recall pool.

## Changes

- `packages/server/src/tools/search.ts` — phantom example replaced; `search_memory` gains a top-level `agent_id?: string` filter (also honors `metadata_filter.agent_id` so neither shape typos silently). Applied to entity rows and forwarded to content snippet search.
- `packages/server/src/utils/content-search.ts` — `ContentSearchOptions` gains `agent_id`; slot `$11` added to the standard `$1–$10` filter shape (mirrored in `buildStandardParams`, `buildStandardWhereSql`, the classifications-dynamic path, and the search query-params builder). NULL-safe — existing callers passing `undefined` hit the same query plan as before.
- `packages/openclaw-plugin/{src/index.ts,src/types.ts,openclaw.plugin.json,README.md}` — `PluginConfig`/JSON schema gain `agentId` (resolver also reads `LOBU_AGENT_ID` env). `autoCapture` stamps `metadata.agent_id` on every save so `search_memory`'s new filter has something to match. No semver bump beyond what release-please will pick up from the conventional commit (`refactor(memory): …` → patch).
- `packages/agent-worker/src/openclaw/worker.ts` — injects `this.config.agentId` into the Lobu memory plugin's config (only the Lobu plugin; other plugins passed through unchanged) before `loadPlugins`. The worker already had `agentId`; the plugin didn't have a way to read it.
- `packages/connector-sdk/src/identity-normalize.ts` + `packages/server/src/tools/registry.ts` — glossary comments at the top calling out which "namespace" is which and that memory scoping uses `metadata.agent_id`, not any of the above.

## Intentionally NOT touched

- **DB schema.** No `events.agent_id` column. No migrations. JSONB filter on `metadata->>'agent_id'` is fine for v1 — promote to a real column only after `pg_stat_statements` shows the extraction matters (the plan's Option 2, explicitly off-the-table here).
- **`lobu memory *` CLI.** No flags added, no commands removed.
- **`entity_identities.namespace`, `sandbox/namespaces/`, `resolve_path` terminology.** These are independent subsystems with valid uses of the word; glossary comments are the fix, not renames.
- **Published plugin config keys.** `agentId` is additive and optional; existing keys unchanged. No on-disk config schema break.

## Validation

- `make typecheck` — clean (mirrors prod Dockerfile's strict `tsc --noEmit`).
- `make build-packages` — clean.
- `bun test packages/openclaw-plugin packages/core packages/connector-sdk packages/agent-worker` — 802 + 505 unit tests pass; 4 failing tests are e2e suites that need a live server / DB at `http://localhost:8787` (pre-existing, unrelated to this PR).
- The two integration tests in `packages/server/src/__tests__/integration/events/search-content-*.test.ts` need `DATABASE_URL` and run in CI; my changes are additive and NULL-safe (every existing caller passes `agent_id: undefined` → `f.metadata->>'agent_id' = $11::text` short-circuits via the `$11::text IS NULL OR …` guard), so the existing query plan is preserved.

## Test plan

- [ ] CI green on `make typecheck` + integration tests.
- [ ] Manual smoke (post-merge or local boot at `PORT=8805`): `save_memory` from an agent → assert `metadata.agent_id` is stamped on the resulting event row. Then `search_memory` with `agent_id` filter → assert it returns only that agent's events.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added agent ID configuration to scope automatic memory capture and recall.
  * Enhanced search with agent-scoped content filtering.

* **Documentation**
  * Updated OpenClaw plugin configuration documentation.
  * Improved search schema documentation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lobu-ai/lobu/pull/937?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->