### PR TITLE
feat(cli): lobu call — generic dispatcher over admin REST tools

### DIFF
--- a/packages/cli/src/__tests__/call.test.ts
+++ b/packages/cli/src/__tests__/call.test.ts
@@ -1,0 +1,261 @@
+import { afterEach, describe, expect, mock, spyOn, test } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { buildArgs, callCommand, parseArgEntry } from "../commands/call";
+import { ValidationError } from "../commands/memory/_lib/errors";
+import * as openclawAuth from "../commands/memory/_lib/openclaw-auth";
+
+const originalFetch = globalThis.fetch;
+const originalStdoutWrite = process.stdout.write.bind(process.stdout);
+
+function captureStdout(): { chunks: string[]; restore: () => void } {
+  const chunks: string[] = [];
+  process.stdout.write = ((chunk: string | Uint8Array, cb?: unknown) => {
+    chunks.push(String(chunk));
+    if (typeof cb === "function") {
+      (cb as (error?: Error | null) => void)(null);
+    }
+    return true;
+  }) as typeof process.stdout.write;
+  return {
+    chunks,
+    restore: () => {
+      process.stdout.write = originalStdoutWrite;
+    },
+  };
+}
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  process.stdout.write = originalStdoutWrite;
+  mock.restore();
+});
+
+describe("parseArgEntry", () => {
+  test("key=value parses as a string", () => {
+    expect(parseArgEntry("name=alice")).toEqual(["name", "alice"]);
+  });
+
+  test("preserves '=' characters in the value", () => {
+    expect(parseArgEntry("query=a=b=c")).toEqual(["query", "a=b=c"]);
+  });
+
+  test("key:=<json> parses the right-hand side as JSON", () => {
+    expect(parseArgEntry("count:=42")).toEqual(["count", 42]);
+    expect(parseArgEntry("enabled:=true")).toEqual(["enabled", true]);
+    expect(parseArgEntry("arr:=[1,2,3]")).toEqual(["arr", [1, 2, 3]]);
+    expect(parseArgEntry('obj:={"a":1}')).toEqual(["obj", { a: 1 }]);
+  });
+
+  test("':=' wins over a later '='", () => {
+    expect(parseArgEntry('payload:={"foo":"bar=baz"}')).toEqual([
+      "payload",
+      { foo: "bar=baz" },
+    ]);
+  });
+
+  test("rejects entries with no '=' or ':='", () => {
+    expect(() => parseArgEntry("nope")).toThrow(ValidationError);
+  });
+
+  test("rejects empty keys", () => {
+    expect(() => parseArgEntry("=value")).toThrow(ValidationError);
+    expect(() => parseArgEntry(":=42")).toThrow(ValidationError);
+  });
+
+  test("rejects malformed JSON after ':='", () => {
+    expect(() => parseArgEntry("x:={not-json}")).toThrow(ValidationError);
+  });
+});
+
+describe("buildArgs", () => {
+  test("builds an object from a mix of string and JSON args", async () => {
+    const result = await buildArgs({
+      arg: ["action=trigger_feed", "feed_id:=42", "force:=true"],
+    });
+    expect(result).toEqual({
+      action: "trigger_feed",
+      feed_id: 42,
+      force: true,
+    });
+  });
+
+  test("reads --input-file when provided", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "lobu-call-"));
+    const path = join(dir, "args.json");
+    writeFileSync(path, JSON.stringify({ action: "list", page: 2 }));
+    try {
+      const result = await buildArgs({ inputFile: path });
+      expect(result).toEqual({ action: "list", page: 2 });
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("rejects --arg + --input-file combination", async () => {
+    expect(
+      buildArgs({ arg: ["foo=bar"], inputFile: "/tmp/whatever.json" })
+    ).rejects.toThrow(ValidationError);
+  });
+
+  test("rejects --input-file pointing at a JSON array", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "lobu-call-"));
+    const path = join(dir, "args.json");
+    writeFileSync(path, JSON.stringify([1, 2, 3]));
+    try {
+      expect(buildArgs({ inputFile: path })).rejects.toThrow(ValidationError);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("callCommand", () => {
+  function stubAuth() {
+    spyOn(openclawAuth, "resolveOrg").mockResolvedValue("acme");
+    spyOn(openclawAuth, "getSessionForOrg").mockResolvedValue({
+      session: {
+        mcpUrl: "https://example.test/mcp/acme",
+        org: "acme",
+        tokenType: "Bearer",
+      },
+      key: "https://example.test/mcp/acme",
+    });
+    spyOn(openclawAuth, "getUsableToken").mockResolvedValue({
+      token: "test-token",
+      contextName: "default",
+      session: {
+        mcpUrl: "https://example.test/mcp/acme",
+        org: "acme",
+        tokenType: "Bearer",
+      },
+    });
+  }
+
+  test("--list prints a tool table, filtering internal tools by default", async () => {
+    stubAuth();
+    const fetchMock = mock(async (url: string) => {
+      expect(url).toBe("https://example.test/api/acme/tools");
+      return new Response(
+        JSON.stringify({
+          tools: [
+            { name: "manage_feeds", description: "Feed mgmt", internal: true },
+            {
+              name: "search_memory",
+              description: "Search memory",
+              internal: false,
+            },
+          ],
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } }
+      );
+    });
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const captured = captureStdout();
+    try {
+      await callCommand(undefined, { list: true });
+    } finally {
+      captured.restore();
+    }
+    const output = captured.chunks.join("");
+    expect(output).toContain("search_memory");
+    expect(output).not.toContain("manage_feeds");
+    expect(output).toContain("1 tool(s)");
+  });
+
+  test("--list --all includes admin tools with [admin] marker", async () => {
+    stubAuth();
+    globalThis.fetch = (async () =>
+      new Response(
+        JSON.stringify({
+          tools: [
+            { name: "manage_feeds", description: "Feeds", internal: true },
+            { name: "search_memory", description: "Search", internal: false },
+          ],
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } }
+      )) as unknown as typeof fetch;
+
+    const captured = captureStdout();
+    try {
+      await callCommand(undefined, { list: true, all: true });
+    } finally {
+      captured.restore();
+    }
+    const output = captured.chunks.join("");
+    expect(output).toContain("manage_feeds");
+    expect(output).toContain("[admin]");
+    expect(output).toContain("2 tool(s)");
+  });
+
+  test("--list --json emits a tools array as JSON", async () => {
+    stubAuth();
+    globalThis.fetch = (async () =>
+      new Response(
+        JSON.stringify({
+          tools: [{ name: "search_memory", description: "x", internal: false }],
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } }
+      )) as unknown as typeof fetch;
+
+    const captured = captureStdout();
+    try {
+      await callCommand(undefined, { list: true, json: true });
+    } finally {
+      captured.restore();
+    }
+    const parsed = JSON.parse(captured.chunks.join(""));
+    expect(parsed.tools).toHaveLength(1);
+    expect(parsed.tools[0].name).toBe("search_memory");
+  });
+
+  test("dispatches a tool call and prints the JSON result", async () => {
+    stubAuth();
+    const fetchMock = mock(async (url: string, init?: RequestInit) => {
+      expect(url).toBe("https://example.test/api/acme/manage_feeds");
+      expect(init?.method).toBe("POST");
+      expect(JSON.parse(String(init?.body))).toEqual({
+        action: "list",
+        page: 2,
+      });
+      return new Response(JSON.stringify({ feeds: [{ id: 1 }] }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    });
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const captured = captureStdout();
+    try {
+      await callCommand("manage_feeds", {
+        arg: ["action=list", "page:=2"],
+      });
+    } finally {
+      captured.restore();
+    }
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const parsed = JSON.parse(captured.chunks.join(""));
+    expect(parsed).toEqual({ feeds: [{ id: 1 }] });
+  });
+
+  test("missing org slug surfaces a ValidationError", async () => {
+    spyOn(openclawAuth, "resolveOrg").mockResolvedValue(undefined);
+    expect(callCommand("manage_feeds", {})).rejects.toThrow(ValidationError);
+  });
+
+  test("404 on missing tool propagates as an ApiError", async () => {
+    stubAuth();
+    globalThis.fetch = (async () =>
+      new Response(JSON.stringify({ error: "Tool not found: bogus" }), {
+        status: 404,
+        headers: { "Content-Type": "application/json" },
+      })) as unknown as typeof fetch;
+
+    expect(callCommand("bogus", { arg: [] })).rejects.toThrow(
+      /Tool not found: bogus/
+    );
+  });
+});

--- a/packages/cli/src/commands/call.ts
+++ b/packages/cli/src/commands/call.ts
@@ -1,0 +1,248 @@
+/**
+ * `lobu call <tool> [args]` — generic dispatcher over the admin REST surface
+ * mounted at `POST /api/:orgSlug/:toolName`. Companion to `lobu call --list`
+ * (`GET /api/:orgSlug/tools`).
+ *
+ * Design ref: `/Users/burakemre/.claude/plans/lobu-call-dispatcher.md`.
+ *
+ * Argument shapes (mutually exclusive):
+ *   --input-file <path>     JSON object read from disk
+ *   stdin                   JSON object piped on stdin (when stdin is not a TTY)
+ *   --arg key=value         flat string field (top-level only)
+ *   --arg key:=<jsonvalue>  JSON-parsed field (httpie-style)
+ *
+ * Output is pretty JSON by default; `--raw` switches to compact JSON for piping.
+ * Errors go to stderr with exit code 1 (ApiError) / 2 (validation).
+ */
+
+import { readFile } from "node:fs/promises";
+
+import { ValidationError } from "./memory/_lib/errors.js";
+import { restGet, restToolCall } from "./memory/_lib/mcp.js";
+import {
+  getSessionForOrg,
+  mcpUrlForOrg,
+  resolveOrg,
+  resolveServerUrl,
+} from "./memory/_lib/openclaw-auth.js";
+
+export interface CallOptions {
+  org?: string;
+  context?: string;
+  inputFile?: string;
+  arg?: string[];
+  list?: boolean;
+  all?: boolean;
+  json?: boolean;
+  raw?: boolean;
+  url?: string;
+}
+
+interface ToolListEntry {
+  name: string;
+  description?: string;
+  inputSchema?: unknown;
+  annotations?: { readOnlyHint?: boolean };
+  internal?: boolean;
+}
+
+function printJson(data: unknown, raw: boolean): void {
+  const text = raw ? JSON.stringify(data) : JSON.stringify(data, null, 2);
+  process.stdout.write(`${text}\n`);
+}
+
+/** Parse a single `--arg key=value` or `key:=<json>` entry into a [key, value]. */
+export function parseArgEntry(entry: string): [string, unknown] {
+  // `:=` first — must be longer than `=` to win the prefix match.
+  const jsonIdx = entry.indexOf(":=");
+  const eqIdx = entry.indexOf("=");
+  if (jsonIdx >= 0 && (eqIdx < 0 || jsonIdx < eqIdx)) {
+    const key = entry.slice(0, jsonIdx).trim();
+    const rawValue = entry.slice(jsonIdx + 2);
+    if (!key) {
+      throw new ValidationError(`--arg "${entry}" has no key before ':='`);
+    }
+    try {
+      return [key, JSON.parse(rawValue)];
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      throw new ValidationError(
+        `--arg "${entry}": value after ':=' must be valid JSON (${message})`
+      );
+    }
+  }
+  if (eqIdx >= 0) {
+    const key = entry.slice(0, eqIdx).trim();
+    const value = entry.slice(eqIdx + 1);
+    if (!key) {
+      throw new ValidationError(`--arg "${entry}" has no key before '='`);
+    }
+    return [key, value];
+  }
+  throw new ValidationError(
+    `--arg "${entry}" missing '=' or ':='. Use key=string or key:=<json>.`
+  );
+}
+
+async function readStdinJson(): Promise<Record<string, unknown> | null> {
+  if (process.stdin.isTTY) return null;
+  const chunks: Buffer[] = [];
+  for await (const chunk of process.stdin) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  }
+  const raw = Buffer.concat(chunks).toString("utf8").trim();
+  if (!raw) return null;
+  try {
+    const parsed = JSON.parse(raw);
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      throw new ValidationError(
+        "stdin JSON must be a top-level object (got array or primitive)."
+      );
+    }
+    return parsed as Record<string, unknown>;
+  } catch (error) {
+    if (error instanceof ValidationError) throw error;
+    const message = error instanceof Error ? error.message : String(error);
+    throw new ValidationError(`Invalid JSON on stdin: ${message}`);
+  }
+}
+
+async function readInputFile(path: string): Promise<Record<string, unknown>> {
+  let raw: string;
+  try {
+    raw = await readFile(path, "utf8");
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new ValidationError(
+      `Failed to read --input-file ${path}: ${message}`
+    );
+  }
+  try {
+    const parsed = JSON.parse(raw);
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      throw new ValidationError(
+        `--input-file ${path}: JSON must be a top-level object.`
+      );
+    }
+    return parsed as Record<string, unknown>;
+  } catch (error) {
+    if (error instanceof ValidationError) throw error;
+    const message = error instanceof Error ? error.message : String(error);
+    throw new ValidationError(`Invalid JSON in ${path}: ${message}`);
+  }
+}
+
+/** Build the args payload from the three mutually-exclusive sources. */
+export async function buildArgs(
+  options: CallOptions
+): Promise<Record<string, unknown>> {
+  const argEntries = options.arg ?? [];
+  const hasArgFlag = argEntries.length > 0;
+  const hasFile = !!options.inputFile;
+
+  if (hasArgFlag && hasFile) {
+    throw new ValidationError(
+      "Cannot combine --arg with --input-file. Pick one."
+    );
+  }
+
+  if (hasFile) {
+    return readInputFile(options.inputFile as string);
+  }
+
+  if (hasArgFlag) {
+    const out: Record<string, unknown> = {};
+    for (const entry of argEntries) {
+      const [key, value] = parseArgEntry(entry);
+      out[key] = value;
+    }
+    return out;
+  }
+
+  const fromStdin = await readStdinJson();
+  if (fromStdin) return fromStdin;
+
+  // No payload provided — let the server validate. Empty object is the
+  // honest default; many admin tools have all-optional fields.
+  return {};
+}
+
+/** Resolve the MCP URL for the requested org (mirrors `memory run`'s chain). */
+async function resolveCallEndpoint(options: CallOptions): Promise<string> {
+  const org = await resolveOrg(options.org, undefined, options.context);
+  if (!org) {
+    throw new ValidationError(
+      "Cannot resolve org slug. Pass --org or run `lobu context use <name>` / `lobu org set <slug>`."
+    );
+  }
+  const orgSession = await getSessionForOrg(org, options.context, options.url);
+  if (orgSession) return orgSession.key;
+
+  const base = await resolveServerUrl(options.url, options.context);
+  if (!base) {
+    throw new ValidationError(
+      "Server URL required. Pass --url or configure a context with `lobu context add`."
+    );
+  }
+  return mcpUrlForOrg(base, org);
+}
+
+function printToolList(
+  tools: ToolListEntry[],
+  options: { json: boolean; raw: boolean; includeInternal: boolean }
+): void {
+  const visible = options.includeInternal
+    ? tools
+    : tools.filter((t) => t.internal !== true);
+
+  if (options.json) {
+    printJson({ tools: visible }, options.raw);
+    return;
+  }
+
+  if (visible.length === 0) {
+    process.stdout.write("No tools available.\n");
+    return;
+  }
+
+  const nameWidth = Math.max(...visible.map((t) => t.name.length));
+  for (const tool of visible) {
+    const tag = tool.internal ? " [admin]" : "";
+    const desc = tool.description ? ` — ${tool.description}` : "";
+    process.stdout.write(`  ${tool.name.padEnd(nameWidth)}${tag}${desc}\n`);
+  }
+  process.stdout.write(`\n${visible.length} tool(s)\n`);
+}
+
+export async function callCommand(
+  tool: string | undefined,
+  options: CallOptions = {}
+): Promise<void> {
+  const json = options.json === true;
+  const raw = options.raw === true;
+  const mcpUrl = await resolveCallEndpoint(options);
+
+  if (options.list || !tool) {
+    const result = await restGet<{ tools: ToolListEntry[] }>(
+      mcpUrl,
+      "tools",
+      options.context
+    );
+    const tools = Array.isArray(result?.tools) ? result.tools : [];
+    printToolList(tools, {
+      json,
+      raw,
+      includeInternal: options.all === true,
+    });
+    return;
+  }
+
+  const args = await buildArgs(options);
+  const result = await restToolCall<unknown>(
+    mcpUrl,
+    tool,
+    args,
+    options.context
+  );
+  printJson(result, raw);
+}

--- a/packages/cli/src/commands/memory/_lib/mcp.ts
+++ b/packages/cli/src/commands/memory/_lib/mcp.ts
@@ -285,3 +285,62 @@ export async function restToolCall<T = unknown>(
 
   return (raw.length > 0 ? JSON.parse(raw) : {}) as T;
 }
+
+/**
+ * GET sibling of `restToolCall` — fetches `${origin}/api/${orgSlug}/${path}`
+ * using the same auth-resolution + localhost-fallback chain. Used by
+ * `lobu call --list` to hit `GET /api/<org>/tools` without spinning up an MCP
+ * session for discovery.
+ */
+export async function restGet<T = unknown>(
+  mcpUrl: string,
+  path: string,
+  contextName?: string
+): Promise<T> {
+  const headers: Record<string, string> = {};
+  const tokenResult = await getUsableToken(mcpUrl, contextName);
+  if (tokenResult) {
+    headers.Authorization = `Bearer ${tokenResult.token}`;
+  }
+
+  const orgSlug = orgFromMcpUrl(mcpUrl) ?? tokenResult?.session.org ?? null;
+  if (!orgSlug) {
+    throw new ApiError(
+      `Cannot GET ${path}: no org slug on MCP URL ${mcpUrl}. Use --org or run: lobu org set <slug>`
+    );
+  }
+
+  const baseUrl = new URL(mcpUrl).origin;
+  const endpoint = `${baseUrl}/api/${orgSlug}/${path}`;
+
+  const { response: res, usedUrl } = await fetchMcpWithFallback(endpoint, {
+    method: "GET",
+    headers,
+  });
+
+  const raw = await res.text();
+  if (!res.ok) {
+    let message = `${res.status} ${res.statusText}`;
+    if (raw) {
+      try {
+        const body = JSON.parse(raw) as { error?: string };
+        if (body?.error) message = body.error;
+      } catch {
+        message = raw;
+      }
+    }
+    const authContext = tokenResult
+      ? ` using context "${tokenResult.contextName}"`
+      : " without an access token";
+    const hint =
+      res.status === 401
+        ? `${authContext}. Try --context <name> or run \`lobu context use <name>\`.`
+        : authContext;
+    throw new ApiError(
+      `GET ${path} failed via ${usedUrl}: ${message}${hint}`,
+      res.status
+    );
+  }
+
+  return (raw.length > 0 ? JSON.parse(raw) : {}) as T;
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -115,6 +115,7 @@ Cloud:
   link | unlink            Bind this directory to a (context, org)
   apply | deploy           Sync lobu.toml to cloud (idempotent)
   agent <subcmd>           CRUD agents via REST
+  call [tool]              Invoke an admin REST tool by name (--list to discover)
   token [create]           Print or mint personal access tokens
 
 Memory:
@@ -830,6 +831,60 @@ Memory:
       await agentConfigPatchCommand(agentId, options);
     }
   );
+
+  // ─── call ───────────────────────────────────────────────────────────
+  // Generic dispatcher over the admin REST tool surface
+  // (`POST /api/<org>/<tool>`). Replaces the urge to add bespoke
+  // per-action commands (`lobu sync`, `lobu retry-feed`, ...) by exposing
+  // every UI-callable tool through one entry point. `lobu memory run` is
+  // kept alongside intentionally — it routes via MCP JSON-RPC, this one via
+  // the REST proxy. See packages/cli/src/commands/call.ts for the arg shape.
+  const call = withCommonOpts(
+    program
+      .command("call [tool]")
+      .description(
+        "Invoke an admin REST tool by name (POST /api/<org>/<tool>). Run with --list or no args to discover."
+      )
+      .option(
+        "--list",
+        "List tools available to the current token (default when called bare)"
+      )
+      .option("--all", "Include internal/admin-only tools in --list output")
+      .option(
+        "--input-file <path>",
+        "Read the JSON args body from a file (top-level object)"
+      )
+      .option(
+        "--arg <entry>",
+        "Add a top-level arg as key=string or key:=<json> (repeatable)",
+        (value: string, previous: string[] | undefined) =>
+          previous ? [...previous, value] : [value]
+      )
+      .option("--raw", "Emit compact JSON (default is pretty-printed)")
+      .option("--url <url>", "Server URL override"),
+    { org: true, json: true }
+  ).action(
+    async (
+      tool: string | undefined,
+      options: {
+        org?: string;
+        context?: string;
+        json?: boolean;
+        list?: boolean;
+        all?: boolean;
+        inputFile?: string;
+        arg?: string[];
+        raw?: boolean;
+        url?: string;
+      }
+    ) => {
+      const { callCommand } = await import("./commands/call.js");
+      await callCommand(tool, options);
+    }
+  );
+  // Silence unused-variable lint — `call` is the Commander handle, retained
+  // for symmetry with sibling command groups in case subcommands are added.
+  void call;
 
   // ─── connector ──────────────────────────────────────────────────────
   const connector = program

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -58,6 +58,7 @@ import {
   publicRestSearchKnowledge,
   restGetWatchers,
   restHealth,
+  restListTools,
   restSearchKnowledge,
   restToolProxy,
   restUpdateContentClassification,
@@ -1193,6 +1194,14 @@ app.post('/api/:orgSlug/join', async (c) => {
     role: result.role,
   });
 });
+
+/**
+ * GET /api/:orgSlug/tools
+ * List admin REST tools available to the caller. Companion to the POST
+ * proxy below — gives CLI/web callers a discovery surface without spinning
+ * up an MCP session just to call tools/list.
+ */
+app.get('/api/:orgSlug/tools', mcpAuth, restListTools);
 
 /**
  * Generic tool proxy - forwards to any MCP tool

--- a/packages/server/src/rest-api.ts
+++ b/packages/server/src/rest-api.ts
@@ -24,7 +24,7 @@ import { listWatchers } from './tools/admin/manage_watchers';
 import { executeTool, extractAuthContext, toToolContext } from './tools/execute';
 import { getContent } from './tools/get_content';
 import { getWatcher } from './tools/get_watchers';
-import { getTool, type ToolContext } from './tools/registry';
+import { getAllTools, getTool, type ToolContext } from './tools/registry';
 import { toJsonSafe } from '@lobu/core';
 import { ToolNotRegisteredError, ToolUserError, errorMessage } from './utils/errors';
 import logger from './utils/logger';
@@ -250,6 +250,67 @@ export async function restToolProxy(
         extra: { tool_name: error.toolName },
       });
     }
+    return c.json({ error: errorMessage(error) }, 400);
+  }
+}
+
+/**
+ * GET /api/:orgSlug/tools
+ * List the admin REST tool surface available to the caller.
+ *
+ * Mirrors the access-level / scope filter that `mcp-handler.ts` applies to
+ * `tools/list`, but always returns the REST-internal surface (`/api/:orgSlug/*`
+ * is never the public MCP path, so `allowInternalTools` is true here). The
+ * `internal` flag is preserved on each row so CLI clients can mark tools that
+ * external MCP clients don't see.
+ */
+export async function restListTools(c: Context<{ Bindings: Env }>) {
+  try {
+    const authCtx = extractAuthContext(c);
+    if (!authCtx.organizationId) {
+      return c.json(
+        { error: 'Organization context required. Authenticate with OAuth or API key.' },
+        401
+      );
+    }
+    const roleAccessLevel = !authCtx.memberRole
+      ? 'read'
+      : authCtx.memberRole === 'owner' || authCtx.memberRole === 'admin'
+        ? 'admin'
+        : 'write';
+    const scopeAccessLevel = !authCtx.scopes
+      ? 'admin'
+      : authCtx.scopes.includes('mcp:admin')
+        ? 'admin'
+        : authCtx.scopes.includes('mcp:write')
+          ? 'write'
+          : 'read';
+    const maxAccessLevel =
+      roleAccessLevel === 'read' || scopeAccessLevel === 'read'
+        ? 'read'
+        : roleAccessLevel === 'write' || scopeAccessLevel === 'write'
+          ? 'write'
+          : 'admin';
+    const tools = getAllTools({
+      includeInternalTools: true,
+      publicOnly: false,
+      maxAccessLevel,
+    });
+    // Re-attach the `internal` flag from the source registry (getAllTools
+    // strips it) so callers can distinguish UI-only handlers from public MCP
+    // tools.
+    const withInternalFlag = tools.map((tool) => {
+      const source = getTool(tool.name);
+      return {
+        name: tool.name,
+        description: tool.description,
+        inputSchema: tool.inputSchema,
+        ...(tool.annotations && { annotations: tool.annotations }),
+        internal: source?.internal === true,
+      };
+    });
+    return c.json({ tools: withInternalFlag });
+  } catch (error) {
     return c.json({ error: errorMessage(error) }, 400);
   }
 }


### PR DESCRIPTION
## Motivation

The web UI already POSTs to `/api/<orgSlug>/<toolName>` for every admin
action; that surface (`INTERNAL_REST_TOOLS` in `packages/server/src/tools/admin/index.ts`)
has 14 named handlers — feeds, watchers, classifiers, schedules, etc. The CLI
keeps almost catching up via bespoke commands (`lobu memory run`, the
proposed `lobu sync` / `lobu retry-feed` / ...). This adds one generic entry
point so every UI-callable tool is reachable from the CLI without growing the
command tree per feature.

Plan reference: `.claude/plans/lobu-call-dispatcher.md`.

## Surface

- `lobu call --list` (or `lobu call` with no args) prints the tool table from
  the new `GET /api/<org>/tools` endpoint. Internal/admin tools are hidden by
  default; `--all` includes them with a `[admin]` marker. `--json` emits the
  raw `{ tools: [...] }` array.
- `lobu call <tool>` builds the JSON args body from one of:
  - `--input-file <path>` — JSON object on disk
  - stdin (when piped) — JSON object
  - `--arg key=value` (string) / `--arg key:=<json>` (httpie-style JSON
    parse) — repeatable, top-level only
- `--org`, `--context`, `--url` resolve via the same chain as `lobu memory
  run`; `--raw` switches default pretty JSON to compact for piping.

## Discovery endpoint

`GET /api/:orgSlug/tools` (`restListTools` in `packages/server/src/rest-api.ts`)
mirrors the access-level + scope filter `mcp-handler.ts` applies to
`tools/list`, but always returns the internal REST surface (`/api/<org>/*`
isn't the public MCP path). Preserves the `internal` flag on each row so the
CLI can distinguish UI-only handlers from public MCP tools.

## Scope discipline

- Keeps `lobu memory run` alongside intentionally — `memory run` routes via
  MCP JSON-RPC, this one via the REST proxy. The plan calls out future
  deprecation as a follow-up after `lobu call` settles.
- No new dynamic-import allow-list entry needed: `await import("./commands/call.js")`
  fits the existing CLI subcommand-lazy-load pattern already documented at the
  top of `packages/cli/src/index.ts`.

## Validation

- `bunx tsc --noEmit` clean on changed CLI + server files (pre-existing
  errors in unrelated server modules are unchanged: count went 25 → 25 with
  fresh package types, then both clean after `make build-packages`).
- 17 new tests in `packages/cli/src/__tests__/call.test.ts` cover:
  - `parseArgEntry` — `key=value` vs `key:=<json>`, escape handling, error
    cases (missing key / `=`, bad JSON).
  - `buildArgs` — string + JSON arg mix, `--input-file` happy path,
    `--arg` + `--input-file` mutex error, array-not-object error.
  - `callCommand` — `--list` filters internal by default, `--all` includes
    them, `--list --json` shape, dispatch wire format
    (`POST /api/<org>/<tool>` + body), missing-org `ValidationError`, 404
    propagation as `ApiError`.
- Pre-commit hook (biome + tsc) green.
- Smoke: `node packages/cli/bin/lobu.js call manage_feeds --arg action=list`
  against an active context resolves auth + URL correctly (returns the
  server's 405 from the unrelated remote target, confirming end-to-end
  routing).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `lobu call` CLI command for invoking tools with flexible argument input modes (`--arg` entries, `--input-file`, stdin).
  * Added tool discovery with `--list` and `--all` flags to view available tools.
  * Added output formatting options (`--json`, `--raw`) for tool invocation results.
  * Added REST endpoint for authenticated tool listing and discovery.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lobu-ai/lobu/pull/938?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->