### PR TITLE
fix(cli/server): zero-to-chat local-dev flow works without --org or browser sign-in

### DIFF
--- a/packages/cli/src/commands/dev.ts
+++ b/packages/cli/src/commands/dev.ts
@@ -9,7 +9,11 @@ import chalk from "chalk";
 import ora from "ora";
 import { isLoadError, loadConfig } from "../config/loader.js";
 import { resolveApiClient } from "../internal/api-client.js";
-import { addContext, getServerConfig } from "../internal/context.js";
+import {
+  addContext,
+  getServerConfig,
+  setActiveOrg,
+} from "../internal/context.js";
 import { type Credentials, saveCredentials } from "../internal/credentials.js";
 import { parseEnvContent } from "../internal/index.js";
 import { loadProjectLink } from "../internal/project-link.js";
@@ -412,6 +416,7 @@ async function announceLocalSignIn(
       device_token?: string;
       session_token?: string;
       user?: { id?: string; email?: string; name?: string };
+      organization?: { id?: string; slug?: string; name?: string };
     };
     // CLI gets the worker-scoped PAT — works against /api/workers/* (used
     // by lobu apply and everything else). The session_token is
@@ -431,6 +436,15 @@ async function announceLocalSignIn(
       ...(body.user?.id ? { userId: body.user.id } : {}),
     };
     await saveCredentials(creds, contextName);
+    // Bind the bootstrap org slug returned by /api/local-init to the
+    // context. Without this, `lobu apply -c local` errors with
+    // "No organization selected" until the user manually runs
+    // `lobu org set <slug>`. The server is the source of truth — it
+    // auto-provisioned this org for the install operator.
+    const orgSlug = body.organization?.slug?.trim();
+    if (orgSlug) {
+      await setActiveOrg(orgSlug, contextName).catch(() => undefined);
+    }
 
     const url = new URL(gatewayUrl);
     url.searchParams.set("lobu_token", body.session_token ?? cliToken);

--- a/packages/cli/src/commands/dev.ts
+++ b/packages/cli/src/commands/dev.ts
@@ -11,8 +11,10 @@ import { isLoadError, loadConfig } from "../config/loader.js";
 import { resolveApiClient } from "../internal/api-client.js";
 import {
   addContext,
+  getCurrentContextName,
   getServerConfig,
   setActiveOrg,
+  setCurrentContext,
 } from "../internal/context.js";
 import { type Credentials, saveCredentials } from "../internal/credentials.js";
 import { parseEnvContent } from "../internal/index.js";
@@ -444,6 +446,23 @@ async function announceLocalSignIn(
     const orgSlug = body.organization?.slug?.trim();
     if (orgSlug) {
       await setActiveOrg(orgSlug, contextName).catch(() => undefined);
+    }
+    // Auto-switch the active context so plain `lobu apply` / `lobu chat`
+    // from any shell hit this loopback server instead of whatever cloud
+    // context was active. Announce on stderr when we actually flip so the
+    // user isn't surprised — `lobu run` on a fresh box silently lands on
+    // `local`; `lobu run` from a shell previously on `lobu` cloud prints
+    // the switch.
+    try {
+      const current = await getCurrentContextName();
+      if (current !== contextName) {
+        await setCurrentContext(contextName);
+        process.stderr.write(
+          `Switched active context to "${contextName}" (lobu run)\n`
+        );
+      }
+    } catch {
+      // Best-effort — failing to switch shouldn't kill the run banner.
     }
 
     const url = new URL(gatewayUrl);

--- a/packages/cli/src/internal/credentials.ts
+++ b/packages/cli/src/internal/credentials.ts
@@ -4,6 +4,7 @@ import {
   DEFAULT_CONTEXT_NAME,
   LOBU_CONFIG_DIR,
   resolveContext,
+  setActiveOrg,
 } from "./context.js";
 import { refreshTokens } from "./oauth.js";
 
@@ -171,6 +172,7 @@ async function tryLocalInit(contextName?: string): Promise<Credentials | null> {
       device_token?: string;
       session_token?: string;
       user?: { id?: string; email?: string; name?: string };
+      organization?: { id?: string; slug?: string; name?: string };
     };
     // Prefer device_token (PAT scoped with device_worker:run + mcp:*) so
     // `lobu chat` / `lobu apply` / worker poll all pass the scope gate on
@@ -185,6 +187,15 @@ async function tryLocalInit(contextName?: string): Promise<Credentials | null> {
       ...(body.user?.id ? { userId: body.user.id } : {}),
     };
     await saveCredentials(creds, target.name);
+    // Bind the local-init org slug to the context so `lobu apply` /
+    // `lobu chat` / `lobu org current` find it without a manual
+    // `lobu org set <slug>`. The server's bootstrap auto-provisions the
+    // single user's personal org and returns it in the response — that
+    // slug is the source of truth for this loopback install.
+    const orgSlug = body.organization?.slug?.trim();
+    if (orgSlug) {
+      await setActiveOrg(orgSlug, target.name).catch(() => undefined);
+    }
     return creds;
   } catch {
     return null;

--- a/packages/cli/src/internal/credentials.ts
+++ b/packages/cli/src/internal/credentials.ts
@@ -2,9 +2,11 @@ import { chmod, mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import {
   DEFAULT_CONTEXT_NAME,
+  getCurrentContextName,
   LOBU_CONFIG_DIR,
   resolveContext,
   setActiveOrg,
+  setCurrentContext,
 } from "./context.js";
 import { refreshTokens } from "./oauth.js";
 
@@ -195,6 +197,23 @@ async function tryLocalInit(contextName?: string): Promise<Credentials | null> {
     const orgSlug = body.organization?.slug?.trim();
     if (orgSlug) {
       await setActiveOrg(orgSlug, target.name).catch(() => undefined);
+    }
+    // Auto-switch the active context so subsequent `lobu apply` / `lobu chat`
+    // invocations (without `-c <name>`) hit the same loopback server. Without
+    // this, a user previously on the `lobu` cloud context who runs `lobu run`
+    // locally still sees cloud for every other command — and the fact that a
+    // local context exists is invisible. Announce on stderr so the change is
+    // visible but doesn't pollute stdout pipelines.
+    try {
+      const current = await getCurrentContextName();
+      if (current !== target.name) {
+        await setCurrentContext(target.name);
+        process.stderr.write(
+          `Switched active context to "${target.name}" (lobu run)\n`
+        );
+      }
+    } catch {
+      // Best-effort — a write failure here shouldn't break the auth flow.
     }
     return creds;
   } catch {

--- a/packages/server/src/auth/oauth/provider.ts
+++ b/packages/server/src/auth/oauth/provider.ts
@@ -6,6 +6,7 @@
  */
 
 import type { DbClient } from '../../db/client';
+import { PersonalAccessTokenService } from '../tokens';
 import { OAuthClientsStore } from './clients';
 import { AVAILABLE_SCOPES } from './scopes';
 import type {
@@ -352,9 +353,22 @@ export class OAuthProvider {
   // ============================================
 
   /**
-   * Verify an access token and return auth info
+   * Verify an access token and return auth info.
+   *
+   * Accepts both OAuth 2.1 access tokens (`oauth_tokens` rows) and Personal
+   * Access Tokens (`personal_access_tokens` rows, prefix `owl_pat_`). The
+   * `/oauth/userinfo` route delegates here, so making PATs work for OAuth
+   * introspection lets a single bearer token authenticate against
+   * `/oauth/userinfo`, `/api/<orgSlug>/*`, the gateway's `/lobu/api/v1/*`
+   * via `createApiAuthMiddleware`, and the CLI's `lobu apply`
+   * org-resolution call. Without this, `lobu chat -c local` against the
+   * embedded server fails with a 404/401 even after a successful
+   * `/api/local-init` because the gateway can't introspect the PAT.
    */
   async verifyAccessToken(token: string): Promise<AuthInfo | null> {
+    if (token.startsWith('owl_pat_')) {
+      return new PersonalAccessTokenService(this.sql).verify(token);
+    }
     const tokenHash = hashToken(token);
 
     const result = await this.sql`

--- a/packages/server/src/auth/routes.ts
+++ b/packages/server/src/auth/routes.ts
@@ -526,7 +526,12 @@ credentialRoutes.post('/local-init', async (c) => {
     'local-init',
     {
       description: 'Auto-minted by POST /api/local-init for local-runner clients.',
-      scope: 'device_worker:run mcp:read mcp:write mcp:admin',
+      // `profile:read` lets the same PAT hit `/oauth/userinfo`, which the
+      // gateway's `createApiAuthMiddleware` (used by `/lobu/api/v1/agents/*`)
+      // and the CLI's `lobu apply` org-resolution path both call. Without it
+      // the PAT works for `/api/<orgSlug>/*` and worker poll but is rejected
+      // by the agent-session and userinfo endpoints with a confusing 403/404.
+      scope: 'device_worker:run mcp:read mcp:write mcp:admin profile:read',
     }
   );
 

--- a/packages/server/src/gateway/routes/public/agent.ts
+++ b/packages/server/src/gateway/routes/public/agent.ts
@@ -754,6 +754,7 @@ export function createAgentApi(config: AgentApiConfig): OpenAPIHono {
         : undefined,
       nixConfig,
       agentId,
+      ...(tokenOrganizationId ? { organizationId: tokenOrganizationId } : {}),
       dryRun: effectiveDryRun,
       intent: watcherIntent ?? undefined,
       isEphemeral,
@@ -1210,6 +1211,9 @@ export function createAgentApi(config: AgentApiConfig): OpenAPIHono {
         channelId,
         teamId: "api",
         agentId: realAgentId,
+        ...(session.organizationId
+          ? { organizationId: session.organizationId }
+          : {}),
         botId: "lobu-api",
         platform: "api",
         messageText: messageContent,

--- a/packages/server/src/gateway/session.ts
+++ b/packages/server/src/gateway/session.ts
@@ -37,6 +37,15 @@ export interface ThreadSession {
   nixConfig?: NixConfig;
   /** Original agent ID (before composite session key generation) */
   agentId?: string;
+  /**
+   * Owning organization of the agent. Cached at session-create time so the
+   * message-send path can stamp it on the queue payload without re-reading
+   * `agent_metadata` for every message. EmbeddedDeploymentManager refuses
+   * `grantStore.grant()` calls without an org id, so without this the very
+   * first message after `lobu chat` would fail at worker spawn even though
+   * the session itself was created cleanly.
+   */
+  organizationId?: string;
   /** Process without persisting history */
   dryRun?: boolean;
   /** Internal automation intent for one-shot system sessions. */

--- a/packages/server/src/start-local.ts
+++ b/packages/server/src/start-local.ts
@@ -168,7 +168,7 @@ async function main() {
   const { bootTaskScheduler } = await import('./scheduled/jobs');
 
   await initWorkspaceProvider();
-  await initLobuGateway();
+  const lobuApp = await initLobuGateway();
 
   const env = getEnvFromProcess();
   const taskScheduler = await bootTaskScheduler(getLobuCoreServices(), env);
@@ -202,6 +202,16 @@ async function main() {
     Object.assign(c.env, env);
     return next();
   });
+  // Mount the embedded Lobu gateway (Agent API + worker proxy + MCP) at
+  // /lobu BEFORE the main app's catch-all. Mirrors server.ts so that
+  // `lobu chat` / `lobu run` / SDK clients targeting `<origin>/lobu/api/v1/*`
+  // resolve identically in local-mode and production. Without this the
+  // bundle exposes /api/<orgSlug>/* (admin REST) but nothing under /lobu —
+  // so the public Agent API 404s and `lobu chat` fails before the worker
+  // even starts.
+  if (lobuApp) {
+    wrapper.route('/lobu', lobuApp);
+  }
   wrapper.route('/', mainApp);
 
   const honoListener = getRequestListener(wrapper.fetch);


### PR DESCRIPTION
## Summary

After \`lobu init my-agent && cd my-agent && lobu run\` on a fresh \`LOBU_DATA_DIR\`, a developer should be able to immediately run \`lobu apply && lobu chat -a <agent> \"…\"\` and get a real response — no \`--org\` flag, no manual \`lobu org set\`, no browser sign-in.

Today this doesn't work because of three compounding bugs. This PR fixes all three.

## Bugs fixed

### Bug 1 — Org slug not persisted from local-init
\`/api/local-init\` auto-provisions a personal org for the bootstrap user (slug \`dev\`) and returns it. But the CLI was ignoring \`body.organization\` — so the context had no active org, and \`lobu apply\` defaulted to \`local-install\` (which doesn't exist).

**Fix:** \`tryLocalInit\` and \`announceLocalSignIn\` now call \`setActiveOrg(body.organization.slug, contextName)\` after a successful bootstrap. \`lobu apply\` resolves the org from \`context.activeOrg\` and just works.

Bug 2 from the original triage (apply ignores \`lobu org set\`) turned out to be the same bug — \`resolveOrgSlug\` already reads per-context \`activeOrg\`; it was just empty. Closed by this fix.

### Bug 3 — \`lobu chat\` 404 / 403 / crash
Three sub-bugs stacked.

**3a.** \`packages/server/src/start-local.ts\` called \`initLobuGateway()\` but discarded the returned sub-app, so \`/lobu/api/v1/agents\` 404'd in local mode (prod's \`server.ts\` mounts it). Fixed by mirroring the \`wrapper.route('/lobu', lobuApp)\` mount before the main app catch-all.

**3b.** The gateway's \`createApiAuthMiddleware\` validates bearer tokens via the issuer's \`/oauth/userinfo\`, which only checked \`oauth_tokens\` rows — PATs returned 403. Fixed by \`OAuthProvider.verifyAccessToken\` delegating to \`PersonalAccessTokenService.verify\` for \`owl_pat_*\` bearers, plus adding \`profile:read\` to the local-init PAT scope.

**3c.** Once the worker spawned it crashed at \`GrantStore.grant requires organizationId\` — the agent route's \`enqueueMessage\` payload was missing \`organizationId\` because \`ThreadSession\` had no such field. Added \`organizationId\` to \`ThreadSession\`, cached it from the agent-metadata lookup at session-create time, and stamped it on the queue payload.

## Reproducer

\`\`\`bash
unset DATABASE_URL
export LOBU_DATA_DIR=/tmp/lobu-fresh-\$(date +%s)
export PATH=/opt/homebrew/opt/node@22/bin:\$PATH
export Z_AI_API_KEY=\$YOUR_KEY

lobu init bot -y --no-sentry --no-slack-preview --provider z-ai
cd bot
lobu run --port 9788 &
sleep 5
lobu apply --yes --force         # works without --org
lobu chat -a bot "Reply hello"   # returns real LLM response
\`\`\`

Verified ending with \`hello there friend\` from the agent.

## Test plan

- [x] Repro the three failure modes on fresh \`LOBU_DATA_DIR\`
- [x] Apply each fix, re-run reproducer at each step
- [x] \`make typecheck\` clean
- [x] \`make build-packages\` clean
- [ ] Pi review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Personal Access Tokens (PATs) can be used for OAuth/API gateway authentication.
  * Local CLI now auto-resolves, persists and (best-effort) auto-switches to the resolved organization context.
  * Local init now issues a worker PAT with expanded scopes so it can access userinfo/org resolution paths.

* **Bug Fixes**
  * Organization metadata is propagated for agent sessions and queued messages to ensure correct routing.
  * Restored gateway routing for local development.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lobu-ai/lobu/pull/944?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->