### PR TITLE
fix(ci): expose ClawHub token flag to login step

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -27,6 +27,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     environment: production
+    env:
+      # Step-level env is not visible to the same step's `if:` evaluator.
+      CLAWHUB_TOKEN_SET: ${{ secrets.CLAWHUB_TOKEN != '' }}
     steps:
       - uses: actions/checkout@v4
 
@@ -57,7 +60,6 @@ jobs:
         if: ${{ env.CLAWHUB_TOKEN_SET == 'true' }}
         env:
           CLAWHUB_TOKEN: ${{ secrets.CLAWHUB_TOKEN }}
-          CLAWHUB_TOKEN_SET: ${{ secrets.CLAWHUB_TOKEN != '' }}
         run: npx --yes clawhub@latest login --token "$CLAWHUB_TOKEN" --no-browser
 
       - name: Publish packages


### PR DESCRIPTION
## Summary
- Hoist `CLAWHUB_TOKEN_SET` to job-level env so the `ClawHub login` step's `if:` evaluator can see it.
- Remove the ineffective same-step `CLAWHUB_TOKEN_SET` env assignment.

Fixes #953.

## Validation
- `actionlint .github/workflows/publish-packages.yml`
- Triggered `publish-packages.yml` on this branch with `bump=skip`, `provenance=false`: https://github.com/lobu-ai/lobu/actions/runs/26137358970
  - `ClawHub login` ran and succeeded: `OK. Logged in as @buremba.`
  - `Publish packages` completed successfully; npm packages and `lobu@8.0.0` on ClawHub were detected as already published/skipped.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal CI/CD workflow configuration to improve build process efficiency and reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lobu-ai/lobu/pull/954?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->