### PR TITLE
fix: remove redundant getDb dynamic imports and fix $member entity FK violation

### DIFF
--- a/packages/server/src/auth/index.tsx
+++ b/packages/server/src/auth/index.tsx
@@ -201,7 +201,6 @@ export async function createAuth(env: Env, request?: Request) {
 				// install@<hostname> email that doesn't deliver. Refuse password
 				// reset for it so an accidental "forgot password" can't replace
 				// the operator's credential. See docs/install-operator-bootstrap.md.
-				const { getDb } = await import("../db/client");
 				const sql = getDb();
 				const rows = (await sql`
 					SELECT principal_kind FROM "user"
@@ -510,7 +509,6 @@ export async function createAuth(env: Env, request?: Request) {
 					// the hostname mint an operator session via the email channel,
 					// bypassing the ENCRYPTION_KEY guard. See
 					// docs/install-operator-bootstrap.md.
-					const { getDb } = await import("../db/client");
 					const sql = getDb();
 					const rows = (await sql`
 						SELECT principal_kind FROM "user"

--- a/packages/server/src/utils/entity-management.ts
+++ b/packages/server/src/utils/entity-management.ts
@@ -320,7 +320,10 @@ export async function createEntity(
       throw new Error('Entity already exists with this name/domain');
     }
     if (msg.includes('foreign key')) {
-      throw new Error(`Parent entity ${data.parent_id} does not exist`);
+      if (data.parent_id) {
+        throw new Error(`Parent entity ${data.parent_id} does not exist`);
+      }
+      throw new Error(`Foreign key violation: ${msg}`);
     }
     if (msg.includes('check constraint')) {
       throw new Error(`Invalid entity data: ${msg}`);

--- a/packages/server/src/utils/member-entity.ts
+++ b/packages/server/src/utils/member-entity.ts
@@ -71,13 +71,17 @@ export async function ensureMemberEntity(params: EnsureMemberEntityParams): Prom
   if (params.image && imageField) metadata[imageField] = params.image;
   if (params.role) metadata.role = params.role;
 
-  await createEntity(
-    {
+  const entityData: Record<string, unknown> = {
       entity_type: '$member',
       name: params.name.trim(),
       organization_id: params.organizationId,
       metadata,
-    },
+  };
+  if (params.userId) {
+    (entityData as any).created_by = params.userId;
+  }
+  await createEntity(
+    entityData as any,
     { skipHooks: true }
   );
 }


### PR DESCRIPTION
## Summary

Two fixes in one PR — both discovered during the #947 investigation:

### 1. Remove redundant `getDb` dynamic imports (#957)

`auth/index.tsx` had two `await import("../db/client")` calls in `sendResetPassword` (line 204) and `sendMagicLink` (line 513), but `getDb` was already statically imported at line 7. The dynamic imports were:
- Redundant (shadow the static binding)
- An AGENTS.md rule violation (dynamic imports outside the allow-list)
- A latent deadlock risk (same shape as #947 — if BA ever wraps these in a transaction, PGlite deadlocks)

Fix: delete both lines, use the module-level `getDb()`.

### 2. Fix $member entity provisioning FK violation (#956)

Every signup logged `Parent entity undefined does not exist` and silently failed to create the $member entity + core identity rows. Two bugs:

**a) Root cause:** `ensureMemberEntity` called `createEntity` without `created_by`, which defaulted to `'system'`. The `entities.created_by` column has `FK → user(id) ON DELETE RESTRICT` — no `system` user exists in a fresh DB → FK violation. (The `events` table got the same fix via migration `20260427133000` which added a normalize trigger, but `entities` never did.)

Fix: pass `userId` through to `createEntity` as `created_by`.

**b) Error masking:** `createEntity`'s catch block mapped *any* FK violation to `Parent entity ${data.parent_id} does not exist`. When `parent_id` is undefined (as it is for $member entities), the error message was misleading.

Fix: only attribute FK failures to parent when `data.parent_id` is set; surface the real constraint message otherwise.

## Test plan
- [x] `make build-packages` — clean build, no errors
- [x] Pre-commit hooks pass (biome + tsc)
- [ ] Signup flow produces $member entity without error log
- [ ] Password reset + magic link still correctly block install_operator

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Entity creation now provides clearer error messages, distinguishing between invalid parent entity references and other database constraint violations
  * Authentication flows have been reinforced to restrict certain account types from initiating password resets or using magic link authentication

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lobu-ai/lobu/pull/959?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Reproducer

### Before fix (#956)
Signup logged `[Auth] Failed to provision $member entity ... Parent entity undefined does not exist` and silently dropped the $member + core identity rows.

### After fix — verified
1. Signed up a new user via `POST /api/auth/sign-up/email` → 200 OK
2. Server logs: **zero** `Failed to provision` / `Parent entity` / FK violation errors
3. DB query confirmed $member entity created with `created_by = <actual userId>` (not `'system'`)
4. `sendResetPassword` callback still correctly blocks `install_operator` users (static `getDb()` works)
5. Clean build, pre-commit hooks pass (biome + tsc)