### PR TITLE
chore: gate local pi review status

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ help:
 	@echo "  make task-clean NAME=<name> [FORCE=1]      - Remove the worktree, both branches, and the Lobu context (refuses if there's uncommitted/unpushed work unless FORCE=1)"
 	@echo "  make task-use NAME=<name|main>             - Point Chrome ext / Mac app symlinks at this worktree (or 'main' for the canonical checkout)"
 	@echo "  make bump SUBMODULE=<path> [TARGET=<ref>]  - Lightweight worktree + commit + PR for a trivial submodule pointer bump (skips bun install, .env, ports)"
-	@echo "  make review [BASE=<branch>]                - Run the local review (typecheck+unit+integration + pi) in cwd; posts pi-review check-run if a PR exists for the current branch"
+	@echo "  make review [BASE=<branch>]                - Run local review (typecheck+unit+integration + pi); posts pi-review status and PR comment"
 
 # Strict typecheck — mirrors the Dockerfile so local matches CI. Catches
 # what `build-packages` (relaxed, bundler-only) misses.
@@ -146,8 +146,8 @@ clean-workers:
 # Local-only: runs the deterministic suites in cwd, then invokes pi against
 # `git diff <BASE>...HEAD` (BASE defaults to main; override with BASE=<branch>
 # env or `--base <branch>` arg). Prints a JSON verdict on the last line. If
-# the current branch has an open PR, also posts a pi-review check-run + PR
-# comment. See docs/REVIEW_SCHEMA.md.
+# GitHub auth is available, posts a pi-review commit status; if the current
+# branch has an open PR, also posts/updates a PR comment. See docs/REVIEW_SCHEMA.md.
 
 review:
 	@./scripts/review.sh $(if $(BASE),--base $(BASE),)

--- a/Makefile
+++ b/Makefile
@@ -142,7 +142,7 @@ clean-workers:
 	@pkill -f '@lobu/worker' 2>/dev/null || true
 	@echo "✅ Worker subprocesses stopped"
 
-# --- Shadow-mode AI reviewer -----------------------------------------------
+# --- Local AI review gate ---------------------------------------------------
 # Local-only: runs the deterministic suites in cwd, then invokes pi against
 # `git diff <BASE>...HEAD` (BASE defaults to main; override with BASE=<branch>
 # env or `--base <branch>` arg). Prints a JSON verdict on the last line. If

--- a/docs/REVIEW_SCHEMA.md
+++ b/docs/REVIEW_SCHEMA.md
@@ -68,8 +68,8 @@ How sure the reviewer is that the change works correctly and won't break prod.
 **Calibration rule:** do not go above 90 unless the reviewer would genuinely
 stake the team on this.
 
-**Future gate:** auto-merge will require `bug_free_confidence >= 80` (and
-equivalent thresholds from any additional reviewer that gets wired in).
+**Gate:** `make review` passes only when `bug_free_confidence >= 80` by
+default. Override for one run with `PI_REVIEW_MIN_BUG_FREE=<n>`.
 
 ### `bugs` (integer, ≥0)
 
@@ -89,7 +89,7 @@ didn't verify, you don't get to count.
 
 Style nits and naming preferences do not count.
 
-**Future gate:** auto-merge will require `bugs == 0`.
+**Gate:** `make review` passes only when `bugs == 0`.
 
 ### `slop` (integer, 0–100)
 
@@ -144,7 +144,7 @@ Override for one run with `PI_REVIEW_MIN_SIMPLICITY=<n>`.
 > **Independent axes.** `bug_free_confidence`, `slop`, and `simplicity` are
 > independent. A change can score high `bug_free_confidence` (works), high
 > `slop` (lots of unused code added), and low `simplicity` (overengineered).
-> All three must clear their thresholds for auto-merge.
+> All three must clear their thresholds for the `pi-review` status to pass.
 
 ### `blockers` (array of strings)
 
@@ -161,7 +161,7 @@ test setup) are NOT blockers — they belong in `notes` with an `[env]`
 prefix. A failing test only blocks when the failing test, or the source
 code it exercises, appears in `git diff --name-only "$BASE_BRANCH...HEAD"`.
 
-**Future gate:** auto-merge will require `blockers.length == 0`.
+**Gate:** `make review` passes only when `blockers.length == 0`.
 
 ### `change_type` (enum)
 
@@ -172,8 +172,9 @@ Maps to conventional-commit prefix. Use the prefix that best describes the
 measure (e.g. `feat` + `test`), prefer `feat`. If you would split this PR,
 say so in `notes`.
 
-**Future use:** `docs` / `chore` / `test` PRs will get a more permissive gate
-than `feat` / `fix` / `refactor`.
+**Note:** the current `pi-review` status applies one gate policy to all change
+types. If a docs/chore/test PR needs an exception, use an explicit env override
+or admin merge.
 
 ### `behavior_change_risk` (enum)
 
@@ -189,8 +190,8 @@ One of: `none`, `low`, `medium`, `high`.
   data integrity, or anything with cross-system consequences (queue,
   scheduler, retry).
 
-**Future gate:** `high` will require human approval even if scores otherwise
-pass.
+**Gate:** `make review` fails when risk is `high`; that path requires human
+approval / admin merge even if scores otherwise pass.
 
 ### `tests_adequate` (boolean)
 
@@ -198,8 +199,8 @@ pass.
 are warranted because behavior_change_risk is `none`). `false` if a
 behavior change ships without test coverage.
 
-**Future gate:** `false` blocks auto-merge unless `change_type` is `docs` /
-`chore`.
+**Gate:** `make review` fails when `tests_adequate` is `false`. For docs/chore
+exceptions, use an explicit env override or admin merge.
 
 ### `suggested_fixes` (array of objects)
 
@@ -238,17 +239,14 @@ Path → category mapping:
 When a path matches multiple patterns, the more specific one wins
 (`__tests__/**` beats `packages/*/src/**`).
 
-**Future use:** the merge bot uses these to apply per-category gates (e.g.
-`docs`-only PRs skip the bugs/slop gates).
+**Note:** categories are currently informational and may be used for more
+nuanced gates later.
 
-## Shadow-mode reminder
+## Local gate flow
 
-Merges are not gated by this verdict yet. The point of shadow mode is to
-observe how the verdicts track real-world PR outcomes so the gate
-thresholds above can be calibrated before they are wired up.
-
-Today's flow: agent finishes a change → runs `make review` from the
-branch's worktree → pi reviews and prints the JSON verdict (and posts a
-PR comment if a PR exists) → human reads the verdict and decides whether
-to merge. A future merge bot will read the verdict and apply the gate
-thresholds above; that bot doesn't exist yet.
+Today's flow: agent finishes a change → opens a PR → runs `make review` from
+the branch's worktree → pi reviews and prints the JSON verdict → the script
+posts/updates the `pi-review` commit status and PR comment. Branch protection
+can require `pi-review`, so a new commit remains unmergeable until the local
+review runs and passes for that exact SHA. Human/admin merge remains the
+explicit escape hatch for intentional exceptions.

--- a/docs/REVIEW_SCHEMA.md
+++ b/docs/REVIEW_SCHEMA.md
@@ -144,7 +144,9 @@ Override for one run with `PI_REVIEW_MIN_SIMPLICITY=<n>`.
 > **Independent axes.** `bug_free_confidence`, `slop`, and `simplicity` are
 > independent. A change can score high `bug_free_confidence` (works), high
 > `slop` (lots of unused code added), and low `simplicity` (overengineered).
-> All three must clear their thresholds for the `pi-review` status to pass.
+> The `pi-review` status requires all seven gates to pass: these three metrics,
+> `bugs == 0`, `blockers.length == 0`, `behavior_change_risk != "high"`, and
+> `tests_adequate == true`.
 
 ### `blockers` (array of strings)
 

--- a/docs/REVIEW_SCHEMA.md
+++ b/docs/REVIEW_SCHEMA.md
@@ -4,14 +4,18 @@ After making changes on a feature branch, the agent runs `make review`
 locally. `scripts/review.sh` drives the deterministic test suites in cwd,
 invokes `pi` against `git diff <base>...HEAD` (base defaults to `main`,
 override with `BASE=<branch>` or `--base <branch>`), and prints a JSON
-verdict matching this schema. If a PR exists for the current branch, the
-script also posts an idempotent PR comment (marker-keyed upsert) with the
-verdict — that posting is a bonus, not a requirement. **GitHub Actions
-does not run review** — it's a local-driven shadow mode owned by the
-agent doing the work.
+verdict matching this schema. The script posts a `pi-review` commit status
+whenever GitHub auth is available; if a PR exists for the current branch, it
+also posts an idempotent PR comment (marker-keyed upsert) with the verdict.
+**GitHub Actions does not run review** — it's a local-driven gate owned by
+the agent doing the work.
 
-A future merge bot will read this verdict and decide whether to auto-merge.
-For now the verdict is informational and **no gate logic exists yet**.
+Branch protection can require the `pi-review` status. The status fails when
+any merge gate below fails: `bug_free_confidence < 80`, `bugs > 0`,
+`slop > 15`, `simplicity < 70`, `blockers` is non-empty,
+`tests_adequate == false`, or `behavior_change_risk == "high"`. Thresholds
+are tunable for one-off runs with `PI_REVIEW_MIN_BUG_FREE`,
+`PI_REVIEW_MAX_SLOP`, and `PI_REVIEW_MIN_SIMPLICITY`.
 
 The schema is reviewer-agnostic — a second independent reviewer can be
 added later without touching the shape below.
@@ -115,7 +119,8 @@ ratio of slop lines to total changed lines:
 diff; 50 = significant fraction of the diff is waste; 80+ = the diff is
 mostly waste.
 
-**Future gate:** auto-merge will require `slop <= 30`.
+**Gate:** `make review` passes only when `slop <= 15` by default. Override for
+one run with `PI_REVIEW_MAX_SLOP=<n>`.
 
 ### `simplicity` (integer, 0–100)
 
@@ -133,7 +138,8 @@ How elegant the change is for the goal it's pursuing. Higher = simpler.
 clever side effect is low simplicity. A 200-line change that reads
 top-to-bottom is high simplicity.
 
-**Future gate:** auto-merge will require `simplicity >= 60`.
+**Gate:** `make review` passes only when `simplicity >= 70` by default.
+Override for one run with `PI_REVIEW_MIN_SIMPLICITY=<n>`.
 
 > **Independent axes.** `bug_free_confidence`, `slop`, and `simplicity` are
 > independent. A change can score high `bug_free_confidence` (works), high

--- a/prompts/review-prompt.md
+++ b/prompts/review-prompt.md
@@ -125,6 +125,11 @@ Do not go above 90 unless you would genuinely stake the team on this.
 
 ### Slop rubric
 
+Slop avoidance is a primary goal of this review. Actively hunt for unnecessary
+AI-generated waste; don't bury it as a soft style note. If `slop > 0`, include
+specific removals/simplifications in `suggested_fixes` when you can name an
+exact file and line.
+
 0–100 score for "AI-generated waste in the diff." Count instances and let
 the score reflect ratio of slop to total changed lines:
 

--- a/scripts/review.sh
+++ b/scripts/review.sh
@@ -11,13 +11,18 @@
 # reachable. Does NOT create a worktree, install deps, or manage the test DB.
 #
 # If a PR exists for the current branch, also posts an idempotent PR comment
-# with the verdict (marker-keyed upsert). If there's no PR, posting is
-# skipped — the verdict still prints locally.
+# with the verdict (marker-keyed upsert). It posts a commit status named by
+# PI_REVIEW_STATUS_CONTEXT (default: pi-review) whenever GitHub auth is
+# available, so branch protection can require the local agent review.
+# If there's no PR, the verdict still prints locally.
 #
 # Auth: uses the operator's ~/.pi/agent state for pi, `gh auth token` for
-# GitHub (optional — missing auth just skips posting). Posting a check-run
-# is not attempted: `gh api check-runs` requires GitHub App auth, and a
-# user PAT cannot satisfy it.
+# GitHub (optional — missing auth just skips posting). Pi is pinned to the
+# ChatGPT/Codex GPT-5.5 high-reasoning model family via PI_REVIEW_MODELS;
+# the default model scope includes all three local ChatGPT account providers so
+# the multi-account extension can pick/switch among linked account slots.
+# Commit statuses use the legacy Statuses API because `gh api check-runs`
+# requires GitHub App auth, and a user PAT cannot create check-runs.
 
 set -euo pipefail
 
@@ -37,6 +42,11 @@ fi
 # --- args -------------------------------------------------------------------
 
 BASE_BRANCH="${BASE:-main}"
+PI_REVIEW_MODELS="${PI_REVIEW_MODELS:-openai-codex/gpt-5.5:high,openai-codex-2/gpt-5.5:high,openai-codex-3/gpt-5.5:high}"
+PI_REVIEW_STATUS_CONTEXT="${PI_REVIEW_STATUS_CONTEXT:-pi-review}"
+PI_REVIEW_MIN_BUG_FREE="${PI_REVIEW_MIN_BUG_FREE:-80}"
+PI_REVIEW_MAX_SLOP="${PI_REVIEW_MAX_SLOP:-15}"
+PI_REVIEW_MIN_SIMPLICITY="${PI_REVIEW_MIN_SIMPLICITY:-70}"
 while [ $# -gt 0 ]; do
   case "$1" in
     --base) BASE_BRANCH="$2"; shift 2 ;;
@@ -54,6 +64,35 @@ fi
 echo ">> cwd:  $(pwd)"
 echo ">> base: $BASE_BRANCH (merge-base $MERGE_BASE)"
 echo ">> head: $HEAD_SHA"
+
+post_review_status() {
+  [ "$GH_AVAILABLE" = "1" ] || return 0
+  local state="$1"
+  local description="$2"
+  local target_url="${3:-}"
+  local repo
+  repo="$(gh repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null || true)"
+  [ -n "$repo" ] || return 0
+
+  # GitHub commit status descriptions are capped at 140 chars.
+  description="${description:0:140}"
+  local args=(-f "state=$state" -f "context=$PI_REVIEW_STATUS_CONTEXT" -f "description=$description")
+  if [ -n "$target_url" ]; then
+    args+=(-f "target_url=$target_url")
+  fi
+  gh api -X POST "repos/$repo/statuses/$HEAD_SHA" "${args[@]}" >/dev/null 2>&1 \
+    || echo ">> warning: failed to post GitHub commit status '$PI_REVIEW_STATUS_CONTEXT'" >&2
+}
+
+REVIEW_STATUS_FINALIZED=0
+finalize_review_status() {
+  post_review_status "$1" "$2" "${3:-}"
+  REVIEW_STATUS_FINALIZED=1
+}
+
+trap 'ec=$?; if [ $ec -ne 0 ] && [ "${REVIEW_STATUS_FINALIZED:-0}" != "1" ]; then post_review_status error "pi review failed before verdict (exit $ec)"; fi' EXIT
+
+post_review_status pending "pi review running"
 
 # --- env --------------------------------------------------------------------
 
@@ -131,7 +170,7 @@ echo ">> suite exit codes: typecheck=$TYPECHECK_EXIT unit=$UNIT_EXIT integration
 PROMPT_FILE="$(pwd)/prompts/review-prompt.md"
 [ -f "$PROMPT_FILE" ] || { echo "prompt not found: $PROMPT_FILE" >&2; exit 2; }
 
-echo ">> invoking pi"
+echo ">> invoking pi (models: $PI_REVIEW_MODELS)"
 GH_TOKEN_VAL=""
 [ "$GH_AVAILABLE" = "1" ] && GH_TOKEN_VAL="$(gh auth token)"
 
@@ -144,7 +183,7 @@ RAW="$(
   INTEGRATION_LOG="$INTEGRATION_LOG" INTEGRATION_EXIT="$INTEGRATION_EXIT" \
   GH_TOKEN="$GH_TOKEN_VAL" \
   DATABASE_URL="$DATABASE_URL" \
-  pi --mode json --no-session -p "@${PROMPT_FILE}" "Review the diff. Emit only the JSON verdict." < /dev/null
+  pi --mode json --no-session --models "$PI_REVIEW_MODELS" -p "@${PROMPT_FILE}" "Review the diff. Emit only the JSON verdict." < /dev/null
 )"
 PI_EXIT=$?
 set -e
@@ -164,7 +203,20 @@ VERDICT="$(printf '%s\n' "$RAW" | jq -rs '
 [ -n "$VERDICT" ] || VERDICT="$RAW"
 VERDICT="$(printf '%s\n' "$VERDICT" | sed -e 's/^```json//' -e 's/^```//' -e 's/```$//')"
 
-if ! echo "$VERDICT" | jq -e '.bug_free_confidence != null and .bugs != null and .slop != null and .simplicity != null and (.blockers|type=="array")' >/dev/null 2>&1; then
+if ! echo "$VERDICT" | jq -e '
+  (.bug_free_confidence | type == "number" and floor == . and . >= 0 and . <= 100) and
+  (.bugs | type == "number" and floor == . and . >= 0) and
+  (.slop | type == "number" and floor == . and . >= 0 and . <= 100) and
+  (.simplicity | type == "number" and floor == . and . >= 0 and . <= 100) and
+  (.blockers | type == "array") and
+  (.change_type | IN("feat", "fix", "refactor", "docs", "chore", "test", "deps")) and
+  (.behavior_change_risk | IN("none", "low", "medium", "high")) and
+  (.tests_adequate | type == "boolean") and
+  (.suggested_fixes | type == "array") and
+  (.notes | type == "string") and
+  (.categories | type == "object")
+' >/dev/null 2>&1; then
+  finalize_review_status error "pi review did not produce a valid JSON verdict"
   echo "pi did not produce a valid JSON verdict. pi exit=$PI_EXIT" >&2
   echo "logs: $TYPECHECK_LOG $UNIT_LOG $INTEGRATION_LOG" >&2
   echo "raw output:" >&2
@@ -176,8 +228,25 @@ BUG_FREE="$(echo "$VERDICT" | jq -r .bug_free_confidence)"
 BUGS="$(echo "$VERDICT" | jq -r .bugs)"
 SLOP="$(echo "$VERDICT" | jq -r .slop)"
 SIMPLICITY="$(echo "$VERDICT" | jq -r .simplicity)"
+TESTS_ADEQUATE="$(echo "$VERDICT" | jq -r .tests_adequate)"
+RISK="$(echo "$VERDICT" | jq -r .behavior_change_risk)"
 BLOCKER_COUNT="$(echo "$VERDICT" | jq -r '.blockers|length')"
 HEADLINE="bug_free $BUG_FREE, simplicity $SIMPLICITY, slop $SLOP, bugs $BUGS, $BLOCKER_COUNT blockers"
+STATUS_STATE="success"
+STATUS_REASONS=()
+[ "$BUG_FREE" -ge "$PI_REVIEW_MIN_BUG_FREE" ] || STATUS_REASONS+=("bug_free<$PI_REVIEW_MIN_BUG_FREE")
+[ "$BUGS" -eq 0 ] || STATUS_REASONS+=("bugs>0")
+[ "$SLOP" -le "$PI_REVIEW_MAX_SLOP" ] || STATUS_REASONS+=("slop>$PI_REVIEW_MAX_SLOP")
+[ "$SIMPLICITY" -ge "$PI_REVIEW_MIN_SIMPLICITY" ] || STATUS_REASONS+=("simplicity<$PI_REVIEW_MIN_SIMPLICITY")
+[ "$BLOCKER_COUNT" -eq 0 ] || STATUS_REASONS+=("blockers>0")
+[ "$TESTS_ADEQUATE" = "true" ] || STATUS_REASONS+=("tests inadequate")
+[ "$RISK" != "high" ] || STATUS_REASONS+=("high risk needs human approval")
+if [ "${#STATUS_REASONS[@]}" -gt 0 ]; then
+  STATUS_STATE="failure"
+  STATUS_DESCRIPTION="$HEADLINE; $(IFS=', '; echo "${STATUS_REASONS[*]}")"
+else
+  STATUS_DESCRIPTION="$HEADLINE"
+fi
 
 echo ""
 echo "=========================================="
@@ -188,12 +257,17 @@ echo "=========================================="
 # --- optional GitHub post --------------------------------------------------
 
 PR_NUMBER=""
+PR_URL=""
 if [ "$GH_AVAILABLE" = "1" ]; then
-  PR_NUMBER="$(gh pr view --json number -q .number 2>/dev/null || true)"
+  PR_JSON="$(gh pr view --json number,url 2>/dev/null || true)"
+  PR_NUMBER="$(echo "$PR_JSON" | jq -r '.number // empty' 2>/dev/null || true)"
+  PR_URL="$(echo "$PR_JSON" | jq -r '.url // empty' 2>/dev/null || true)"
 fi
 
+finalize_review_status "$STATUS_STATE" "$STATUS_DESCRIPTION" "$PR_URL"
+
 if [ -z "$PR_NUMBER" ]; then
-  echo ">> no PR for current branch; skipping GitHub post"
+  echo ">> no PR for current branch; skipping GitHub comment"
 else
   NOTES="$(echo "$VERDICT" | jq -r '.notes // ""')"
   PRETTY="$(echo "$VERDICT" | jq .)"
@@ -207,7 +281,7 @@ else
     else "\n\n### Blockers\n\n" + ((.blockers // []) | map("- " + .) | join("\n"))
     end')"
   # shellcheck disable=SC2016
-  SUMMARY="$(printf '**%s**\n\n%s%s%s\n\n<details><summary>Full verdict JSON</summary>\n\n```json\n%s\n```\n\n</details>\n\n_Shadow mode — verdict does not gate merges. See `docs/REVIEW_SCHEMA.md`._' \
+  SUMMARY="$(printf '**%s**\n\n%s%s%s\n\n<details><summary>Full verdict JSON</summary>\n\n```json\n%s\n```\n\n</details>\n\n_Local review gate — branch protection can require the `pi-review` commit status. See `docs/REVIEW_SCHEMA.md`._' \
     "$HEADLINE" "$NOTES" "$BLOCKERS_LIST" "$SUGGESTIONS_TABLE" "$PRETTY")"
 
   MARKER="<!-- pi-review-marker -->"


### PR DESCRIPTION
## Summary
- Pin `make review` to GPT-5.5 high across all three ChatGPT/Codex account slots via `--models`
- Post an enforceable `pi-review` commit status in addition to the PR comment
- Tighten the local review gate to fail on slop, low simplicity, inadequate tests, high risk, invalid verdicts, bugs, or blockers

## Validation
- `bash -n scripts/review.sh`
- `jq` smoke check for the verdict schema expression
- `git diff --check`
- pre-commit hook: Biome + TypeScript type check


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Review docs revised to describe a real local review gate with explicit pass/fail rules, default thresholds, and env var overrides; clarifies gate behavior across change types and SHA-specific unmergeability until the gate passes.

* **New Features**
  * Review command now posts a pi-review commit status and a PR comment summarizing local gate results.

* **Chores**
  * Local review pipeline improved with configurable model selection, stricter verdict validation, and more robust commit-status/PR reporting (includes PR URL).

* **Style**
  * Added a "slop avoidance" rubric directing reviewers to remove unnecessary AI-generated waste.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lobu-ai/lobu/pull/964?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->