### PR TITLE
test: harden flaky port allocation + connector-sdk re-export barrel (#976)

### DIFF
--- a/packages/connector-sdk/src/index.ts
+++ b/packages/connector-sdk/src/index.ts
@@ -49,7 +49,13 @@ export type {
 export { IDENTITY } from './connector-types.js';
 // Identity-engine SDK contracts. Each schema export is both a TypeBox
 // runtime validator (value) AND a TypeScript type via declaration merging.
-export {
+// We import then re-export locally instead of `export { … } from
+// './identity-types.js'`: bun's ESM linker (macOS + node26 + bun 1.3.5)
+// intermittently fails to resolve a name through a large transitive
+// re-export barrel, surfacing as a flaky `Export named 'X' not found in
+// dist/index.js` under concurrent test load (issue #976). A local export
+// list links against the already-bound import.
+import {
   AssuranceLevel,
   assuranceMeets,
   AutoCreateWhenRule,
@@ -63,6 +69,20 @@ export {
   IDENTITY_FACT_SEMANTIC_TYPE,
   RelationshipTypeIdentityMetadata,
 } from './identity-types.js';
+export {
+  AssuranceLevel,
+  assuranceMeets,
+  AutoCreateWhenRule,
+  CLAIM_COLLISION_SEMANTIC_TYPE,
+  ClaimCollisionPayload,
+  ConnectorFact,
+  ConnectorIdentityCapability,
+  DerivedFromProvenance,
+  DerivedRelationshipMetadata,
+  FactEventMetadata,
+  IDENTITY_FACT_SEMANTIC_TYPE,
+  RelationshipTypeIdentityMetadata,
+};
 export {
   normalizeAuthUserId,
   normalizeEmail,

--- a/packages/server/src/__tests__/setup/embedded-postgres-backend.ts
+++ b/packages/server/src/__tests__/setup/embedded-postgres-backend.ts
@@ -38,19 +38,34 @@ export async function startEmbeddedBackend(): Promise<EmbeddedBackend> {
   // Each attempt gets a fresh datadir because initdb refuses a reused one.
   const { pg, port, dataDir } = await withFreePortRetry(async (candidate) => {
     const dir = mkdtempSync(join(tmpdir(), 'lobu-test-pg-'));
+    // embedded-postgres rejects start() with `undefined` on ANY early exit —
+    // a port collision included — so the OS-level EADDRINUSE never reaches the
+    // catch. Capture stderr and re-tag a bind failure as EADDRINUSE so the
+    // retry wrapper actually retries; surface anything else as a real error.
+    let log = '';
     const instance = new EmbeddedPostgres({
       databaseDir: dir,
       user: 'postgres',
       password: 'postgres',
       port: candidate,
       persistent: false,
+      onLog: (message) => {
+        log += message;
+      },
     });
     try {
       await instance.initialise();
       await instance.start();
     } catch (err) {
       rmSync(dir, { recursive: true, force: true });
-      throw err;
+      if (/address already in use|could not bind/i.test(log)) {
+        throw Object.assign(new Error(`embedded-postgres: port ${candidate} in use`), {
+          code: 'EADDRINUSE',
+        });
+      }
+      throw err instanceof Error
+        ? err
+        : new Error(`embedded-postgres failed to start: ${log.slice(-500) || 'no output'}`);
     }
     return { pg: instance, port: candidate, dataDir: dir };
   });

--- a/packages/server/src/__tests__/setup/embedded-postgres-backend.ts
+++ b/packages/server/src/__tests__/setup/embedded-postgres-backend.ts
@@ -14,6 +14,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { injectPgvector, resolveEmbeddedNativeDir } from '@lobu/pgvector-embedded';
 import EmbeddedPostgres from 'embedded-postgres';
+import { withFreePortRetry } from './free-port';
 
 export interface EmbeddedBackend {
   url: string;
@@ -31,20 +32,28 @@ export async function startEmbeddedBackend(): Promise<EmbeddedBackend> {
 
   injectPgvector(resolveEmbeddedNativeDir());
 
-  const dataDir = mkdtempSync(join(tmpdir(), 'lobu-test-pg-'));
-  // 0 lets the OS assign; embedded-postgres needs a concrete port, so pick a
-  // high random one and let a collision fail loudly rather than silently share.
-  const port = 50000 + Math.floor(Math.random() * 10000);
-  const pg = new EmbeddedPostgres({
-    databaseDir: dataDir,
-    user: 'postgres',
-    password: 'postgres',
-    port,
-    persistent: false,
+  // embedded-postgres needs a concrete port at construction. Ask the OS for a
+  // free one and retry on collision rather than picking a random high port and
+  // failing loud — under concurrent test load that races to EADDRINUSE (#976).
+  // Each attempt gets a fresh datadir because initdb refuses a reused one.
+  const { pg, port, dataDir } = await withFreePortRetry(async (candidate) => {
+    const dir = mkdtempSync(join(tmpdir(), 'lobu-test-pg-'));
+    const instance = new EmbeddedPostgres({
+      databaseDir: dir,
+      user: 'postgres',
+      password: 'postgres',
+      port: candidate,
+      persistent: false,
+    });
+    try {
+      await instance.initialise();
+      await instance.start();
+    } catch (err) {
+      rmSync(dir, { recursive: true, force: true });
+      throw err;
+    }
+    return { pg: instance, port: candidate, dataDir: dir };
   });
-
-  await pg.initialise();
-  await pg.start();
 
   const url = `postgresql://postgres:postgres@127.0.0.1:${port}/postgres?sslmode=disable`;
   active = {

--- a/packages/server/src/__tests__/setup/free-port.ts
+++ b/packages/server/src/__tests__/setup/free-port.ts
@@ -1,0 +1,54 @@
+/**
+ * Free-port allocation for tests.
+ *
+ * Test harnesses used to pick a random high port and "fail loud on collision"
+ * (embedded-postgres-backend.ts, proxy-hardening.test.ts). Under concurrent
+ * `bun test` / vitest load that surfaces as intermittent `EADDRINUSE` — a pure
+ * flake, not a real failure (issue #976). Asking the OS for a port (bind :0)
+ * and retrying on collision shrinks the window to near-zero.
+ */
+
+import net from 'node:net';
+
+/**
+ * Bind `:0` on `host`, read the OS-assigned port, close, and return it. There
+ * is an unavoidable TOCTOU gap between this close and the caller's own bind —
+ * pair with `withFreePortRetry` when the caller needs a concrete port up front.
+ */
+export function getFreePort(host = '127.0.0.1'): Promise<number> {
+  return new Promise<number>((resolve, reject) => {
+    const srv = net.createServer();
+    srv.once('error', reject);
+    srv.listen(0, host, () => {
+      const addr = srv.address();
+      const port = addr && typeof addr === 'object' ? addr.port : 0;
+      srv.close((err) => (err ? reject(err) : resolve(port)));
+    });
+  });
+}
+
+/**
+ * Run `fn` with an OS-assigned free port, retrying on `EADDRINUSE` with a fresh
+ * port to cover the TOCTOU gap between selection and bind. Any other error
+ * propagates immediately.
+ */
+export async function withFreePortRetry<T>(
+  fn: (port: number) => Promise<T>,
+  attempts = 5,
+  host = '127.0.0.1',
+): Promise<T> {
+  let lastErr: unknown;
+  for (let i = 0; i < attempts; i++) {
+    const port = await getFreePort(host);
+    try {
+      return await fn(port);
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException)?.code === 'EADDRINUSE') {
+        lastErr = err;
+        continue;
+      }
+      throw err;
+    }
+  }
+  throw lastErr ?? new Error('withFreePortRetry: exhausted attempts without binding');
+}

--- a/packages/server/src/gateway/__tests__/proxy-hardening.test.ts
+++ b/packages/server/src/gateway/__tests__/proxy-hardening.test.ts
@@ -33,6 +33,7 @@ import { EgressJudge } from "../proxy/egress-judge/judge.js";
 import type { ResolvedJudgeRule } from "../permissions/policy-store.js";
 import type { JudgeClient, JudgeVerdict } from "../proxy/egress-judge/types.js";
 import { VerdictCache } from "../proxy/egress-judge/cache.js";
+import { withFreePortRetry } from "../../__tests__/setup/free-port.js";
 import {
   __testOnly,
   setProxyEgressJudge,
@@ -307,8 +308,13 @@ describe("HTTP Proxy — domain blocking edge cases", () => {
   });
 
   async function startProxy(): Promise<void> {
-    proxyPort = 10000 + Math.floor(Math.random() * 50000);
-    proxyServer = await startHttpProxy(proxyPort, "127.0.0.1");
+    // Ask the OS for a free port and retry on collision instead of gambling on a
+    // random high port — concurrent test load otherwise races to EADDRINUSE (#976).
+    proxyServer = await withFreePortRetry(async (port) => {
+      const server = await startHttpProxy(port, "127.0.0.1");
+      proxyPort = port;
+      return server;
+    });
   }
 
   function auth(): string {


### PR DESCRIPTION
Fixes the two pre-existing test flakes tracked in #976. Both are intermittent (CI's `integration` job is green); this is flake-reduction, not broken tests.

## 1. Port collisions (deterministic — fixed + validated)

`embedded-postgres-backend.ts` picked `50000 + random(10000)` and `proxy-hardening.test.ts` picked `10000 + random(50000)` — **overlapping ranges**, no collision handling, "fail loud on collision." Under concurrent `bun test` / vitest load they race to `EADDRINUSE` (CI run 26180947161, passed on re-run).

Added `packages/server/src/__tests__/setup/free-port.ts`:
- `getFreePort()` — bind `:0`, read the OS-assigned port, close, return it.
- `withFreePortRetry(fn)` — run `fn(port)` with a free port, retry on `EADDRINUSE` with a fresh port to cover the TOCTOU gap.

Both sites now route through it. embedded-postgres gets a fresh datadir per attempt (initdb refuses a reused one).

## 2. connector-sdk `AutoCreateWhenRule` (preventive — NOT repro-validated)

**Honest disclosure per the repo's E2E gate:** I could **not reproduce** this flake on current `main` — 27 runs (15 sequential + 12 across 4 parallel processes, max dist contention) on the exact reported environment (macOS + node26 + bun 1.3.5), all clean (285 pass). The #973 PR note observed it "on the base commit" of #973; #973 then **externalized `@lobu/connector-sdk`** and reworked the compile pipeline, which likely already mitigated it. #976 was filed before #973 landed.

Applying anyway as **structural hardening** against the documented failure mode: the schemas were re-exported through a large transitive `export { … } from './identity-types.js'` barrel; bun's ESM linker intermittently fails to resolve a name through such a barrel under concurrent load (`Export named 'X' not found in dist/index.js`). Switched to `import { … }` + a local `export { … }` list, so the dist links the export names against an already-bound import (a different bun linker path) instead of a re-export-from. **Zero semantic change** — same exports.

> Note: line-splitting the re-exports into individual `export { X } from …` lines is *not* viable — biome's organizer merges them straight back. The import + local-export form survives biome and is the cleanest version that does.

## Validation

| Check | Result |
|---|---|
| `proxy-hardening.test.ts` | 72 pass × 3 runs, zero `EADDRINUSE` |
| embedded-PG backend smoke | boots → `SELECT 1` ok → stops clean via free-port path |
| `bun test packages/cli` (B2 consumer) | 285 pass × 5+ runs, 0 `AutoCreateWhenRule` errors |
| `bun test packages/connector-worker` | 52 pass / 0 fail |
| server `tsc --noEmit` + repo `tsc --noEmit` (husky) | clean |
| `biome check` (repo config) | clean (connector-sdk is biome-excluded; edit hand-formatted to match) |

Closes #976.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved module export wiring in the connector SDK for more reliable ESM behavior across environments.

* **Tests**
  * Added a test utility for OS-assigned free TCP ports and retry handling.
  * Updated test helpers to use OS-chosen ports with retry-on-collision, reducing flakiness under concurrent runs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lobu-ai/lobu/pull/984?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->