### PR TITLE
feat(cli): ship the owletto web UI bundle in lobu run

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,12 @@ build-packages:
 	done
 	@echo "   📦 Building packages/server bundle..."
 	@( cd packages/server && bun run build:server ) || exit $$?
+	@if [ -f packages/owletto/package.json ]; then \
+		echo "   📦 Building packages/owletto (web UI)..."; \
+		( cd packages/owletto && bun run build ) || exit $$?; \
+	else \
+		echo "   ⚠️  packages/owletto absent — CLI will ship headless (API only)"; \
+	fi
 	@echo "   📦 Building packages/cli..."
 	@( cd packages/cli && bun run build ) || exit $$?
 	@echo "✅ All packages built successfully!"

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "test:coverage": "bun test packages/core/src packages/agent-worker/src packages/landing/src --coverage",
     "typecheck": "tsc --noEmit",
     "dev": "./scripts/dev-native.sh",
-    "build:packages": "cd packages/core && bun run build && cd ../connector-sdk && bun run build && cd ../agent-worker && bun run build && cd ../openclaw-plugin && bun run build && cd ../embeddings && bun run build && cd ../connector-worker && bun run build && cd ../promptfoo-provider && bun run build && cd ../server && bun run build:server && cd ../cli && bun run build",
+    "build:packages": "cd packages/core && bun run build && cd ../connector-sdk && bun run build && cd ../agent-worker && bun run build && cd ../openclaw-plugin && bun run build && cd ../embeddings && bun run build && cd ../connector-worker && bun run build && cd ../promptfoo-provider && bun run build && cd ../server && bun run build:server && cd .. && if [ -f owletto/package.json ]; then (cd owletto && bun run build); else echo '[build:packages] owletto submodule absent — CLI ships headless (API only)'; fi && cd cli && bun run build",
     "build:lobu": "cd packages/embeddings && bun run build && cd ../..",
     "watch:packages": "tsc -b --watch packages/core packages/agent-worker",
     "test:packages": "cd packages/core && bun run test && cd ../agent-worker && bun run test",

--- a/packages/cli/scripts/build.cjs
+++ b/packages/cli/scripts/build.cjs
@@ -38,6 +38,16 @@ copyDirIfExists("../connectors/src", "dist/connectors");
 // Copy database migrations for the bundled PGlite local server.
 copyDirIfExists("../../db/migrations", "dist/db/migrations");
 
+// Copy the built owletto web UI (admin/console SPA) next to the server bundle
+// so `lobu run` serves it — OAuth, MCP-client setup, and connection CRUD have
+// no surface without it. owletto is a private submodule (`private: true`);
+// only its compiled `dist/` ships in the CLI tarball, never the source. CI's
+// publish flow builds it (`bun run build` in packages/owletto, gated on the
+// submodule being present) before this script runs. Missing locally (fork or
+// uninitialised submodule) → the copy is skipped and `lobu run` boots headless
+// (API only), matching prior behaviour. `dev.ts` points WEB_DIST_DIR here.
+copyDirIfExists("../owletto/dist", "dist/owletto/dist");
+
 // Copy server bundles so `lobu run` is self-contained.
 // @lobu/server is private (`private: true` in its package.json),
 // so `npx @lobu/cli` users can never resolve it via npm — they only get

--- a/packages/cli/src/commands/dev.ts
+++ b/packages/cli/src/commands/dev.ts
@@ -323,12 +323,24 @@ export async function devCommand(
     envVars.LOBU_PROVIDER_REGISTRY_PATH ||
     (existsSync(bundledProvidersPath) ? bundledProvidersPath : undefined);
 
+  // Bundled CLIs ship the built owletto web UI next to the server bundle (see
+  // packages/cli/scripts/build.cjs). Point the server at it unless the user or
+  // .env already set WEB_DIST_DIR. In a monorepo checkout the bundle's sibling
+  // dir has no owletto/dist, so this stays undefined and the server's own
+  // monorepo-relative lookup / Vite dev path takes over.
+  const bundledWebDistPath = join(dirname(bundlePath), "owletto", "dist");
+  const webDistDir =
+    process.env.WEB_DIST_DIR ||
+    envVars.WEB_DIST_DIR ||
+    (existsSync(bundledWebDistPath) ? bundledWebDistPath : undefined);
+
   const childEnv: Record<string, string> = {
     ...mergedEnv,
     LOBU_DEV_PROJECT_PATH: projectPath,
     ...(providerRegistryPath
       ? { LOBU_PROVIDER_REGISTRY_PATH: providerRegistryPath }
       : {}),
+    ...(webDistDir ? { WEB_DIST_DIR: webDistDir } : {}),
     PORT: String(portNum),
     GATEWAY_PORT: String(portNum),
     ...(logLevel ? { LOG_LEVEL: logLevel } : {}),


### PR DESCRIPTION
## Problem

A clean `npm i -g @lobu/cli && lobu run` boots **headless** today — the server's SPA lookup (`resolveWebDistDirectory`) finds no `owletto/dist`, so OAuth callbacks, MCP-client setup, and connection CRUD have no surface. The UI only ever served in two channels that happen to have the **private** `packages/owletto` submodule present at build time:

- **prod Docker** (`docker/app/Dockerfile` builds owletto, copies dist into runtime), and
- **monorepo dev** (`make dev` → Vite dev server against the source).

The published CLI tarball never carried it: `build.cjs` copies the server bundle / providers / connectors / migrations, but not `owletto/dist`, and nothing in the build chain builds owletto. It's not a policy choice — it's a gap.

## Approach

Ship the **compiled** `owletto/dist` (never the source) inside the CLI tarball. A client SPA bundle is already served to every browser hitting the hosted app, so this exposes nothing the moat relied on — the private submodule **source** stays private. Three mechanical pieces:

1. **`build:packages` + `Makefile build-packages`** build owletto before the CLI, guarded on the submodule being present (forks without it stay headless, no error).
2. **`build.cjs`** copies `owletto/dist` → `dist/owletto/dist`, next to the server bundle.
3. **`dev.ts`** points `WEB_DIST_DIR` at the shipped dist, mirroring the existing `providers.json` wiring. Respects user/`.env` override; stays undefined in a monorepo checkout so Vite dev still wins.

**No CI/workflow change needed** — `publish-packages.yml` already checks out the private submodule via `setup-submodule` + `OWLETTO_WEB_DEPLOY_KEY`, so the publish job will build & ship the UI automatically.

## Reproducer (E2E, faithful npm-install simulation)

Hid the monorepo's `packages/owletto/dist` and ran with `NODE_ENV=production` (Vite dev off), so the SPA could **only** resolve via the new `WEB_DIST_DIR` → shipped `cli/dist/owletto/dist`:

| Request | Result |
| --- | --- |
| `GET /` | 200, 3211 B, `<title>Lobu</title>` + `<div id="root">` + asset refs |
| `GET /assets/index-DkudoADq.js` | 200, 2,631,874 B (exact match to built bundle) |
| `GET /assets/…css` | 200 `text/css` |
| `GET /some-org/agents` (browser `Accept: text/html`) | 200, SPA shell — deep-link refresh works |

Tarball confirmed via `bun pm pack --dry-run` to carry `dist/owletto/dist/index.html` + assets. `tsc --noEmit` green (pre-commit).

## Tradeoff

CLI tarball grows by the owletto bundle (~3 MB gzipped, ~5 MB unpacked). Acceptable for an npm package; flagging it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Build system now conditionally builds and integrates the optional web UI component; build process continues successfully regardless of availability.
  * CLI gracefully handles the missing web UI and can run in headless/API-only mode when the component is unavailable.
  * Dev command automatically configures and serves the bundled web UI when it is present in the distribution.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lobu-ai/lobu/pull/985?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->