### PR TITLE
ci: build pgvector-embedded before vitest security tests

### DIFF
--- a/.github/workflows/security-tests.yml
+++ b/.github/workflows/security-tests.yml
@@ -161,10 +161,16 @@ jobs:
       - name: Install dependencies
         run: bun install
 
-      - name: Build core + connector-sdk
+      - name: Build core + connector-sdk + pgvector-embedded
         run: |
           cd packages/core && bun run build && cd ../..
           cd packages/connector-sdk && bun run build && cd ../..
+          # vitest resolves @lobu/pgvector-embedded via its "import"/"require"
+          # export condition (dist/index.js), unlike bun:test which uses the
+          # "bun" condition (src). The embedded-Postgres test backend imports
+          # it, so without this build vitest fails collection with
+          # ERR_RESOLVE_PACKAGE_ENTRY_FAIL.
+          cd packages/pgvector-embedded && bun run build && cd ../..
 
       - name: Verify Postgres + pgvector
         run: |


### PR DESCRIPTION
## Problem

`Security tests (vitest)` has been **red on `main` since the embedded-Postgres migration (#965)** — every commit since (#978, #973, #983) failed it; last green was #971.

Root cause: the job's build step builds only `core` + `connector-sdk`, **not `@lobu/pgvector-embedded`**. The two security-test jobs resolve that package differently:

| Job | Runner | `@lobu/pgvector-embedded` resolves via | Needs build? |
| --- | --- | --- | --- |
| `Security tests (bun:test)` | `bun test` | `"bun"` export → `src/index.ts` | no → ✅ green |
| `Security tests (vitest)` | `node …/vitest` | `"import"` export → `dist/index.js` | **yes** → ❌ red |

`dist/` is a `tsc` artifact (not in git). The embedded-Postgres test backend (`src/__tests__/setup/embedded-postgres-backend.ts`) does `import … from "@lobu/pgvector-embedded"`, so vitest dies at collection with `ERR_RESOLVE_PACKAGE_ENTRY_FAIL` → "no tests" → exit 1.

(CI's main `integration` job passes because it builds via the Makefile loop, which already includes `pgvector-embedded`; only this workflow's hand-rolled build step omitted it.)

## Fix

One build line added to the `vitest-security-tests` job.

## Reproducer (exact CI command, `packages/server`)

```
node ../../node_modules/.bin/vitest run src/__tests__/webhook-signatures.test.ts --reporter=default
```

- **RED** — without `pgvector-embedded` dist: `Failed to resolve entry for package "@lobu/pgvector-embedded"` / `ERR_RESOLVE_PACKAGE_ENTRY_FAIL`, `Test Files no tests`.
- **GREEN** — with `core` + `connector-sdk` + `pgvector-embedded` built (the fixed step's set): `✓ webhook-signatures.test.ts (7 tests)`, `Test Files 1 passed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved security testing workflow to ensure proper dependency resolution during test collection, preventing failures and guaranteeing consistent security test execution.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lobu-ai/lobu/pull/986?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->