### PR TITLE
fix: getting-started reliability (openrouter model routing + run auto-apply)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -112,6 +112,7 @@ Rules for agents:
   - `packages/cli/src/commands/_lib/connector-run-cmd.ts` — `browser-mirror`, `devtools-active-port`, `executeCompiledConnector`.
   - `packages/cli/src/commands/_lib/apply/apply-cmd.ts` — `connector-loader` + `ensure-deps-installed` (the connector-compile graph: esbuild + connector-worker + SDK). Loaded only when an apply has local `*.connector.ts` to compile; keeps that graph out of apply-cmd's module-load path (and out of every CLI test that imports it).
   - `packages/cli/src/commands/_lib/apply/desired-state.ts` — `yaml` (loaded only on YAML inputs).
+  - `packages/cli/src/commands/dev.ts` — `apply-cmd` (auto-apply the project after an embedded `lobu run`). Loaded lazily, after the server boots, so the connector-compile graph stays out of `lobu run`'s module-load path.
   - `packages/cli/src/commands/memory/_lib/browser-auth-cmd.ts` — `decryptChromeCookiesMacOS`, `playwright/chromium`.
   - `packages/server/src/server.ts` — `./embedded-runtime` is statically imported, but `./server-lifecycle` is lazy: its transitive imports read env at module-eval, and the embedded branch only finalises DATABASE_URL during `main()`. Loading the lifecycle eagerly would snapshot a stale env.
   - `packages/server/src/embedded-runtime.ts` — `embedded-postgres` + `@lobu/pgvector-embedded` (and `postgres`) are lazy so the external/prod path (postgres:// URL) never resolves or loads the ~145MB embedded-Postgres binary even though it sits in node_modules. Only reached when DATABASE_URL is a path/file://.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,3 @@
-<!-- Per-repo agent rules loaded into every Claude Code session in this repo. Inlines AGENTS.md (shared project rules) first, then layers local-only notes below. User memory entries live under ~/.claude/projects/.../memory/. -->
+<!-- Per-repo agent rules loaded into every Claude Code session in this repo. Inlines AGENTS.md (shared project rules) first, then layers local-only notes below. User memory entries live under ~/.claude/projects/.../memory/. Don't add anything here unless it's only relevant to Claude agent specific. If other harnesses like pi or codex need it, modify AGENTS.md -->
 
 @AGENTS.md
-
-## Lobu
-
-The live Lobu MCP server, ClientSDK, sandbox, and tool registry are in `packages/server/` of this repo. Prod runs the bundled Node entry (`packages/server/dist/server.bundle.mjs`, built via `bun run build:server`) — same artifact that `lobu run` invokes. Any question about Lobu behavior — MCP tools, instructions, sandbox, SDK, auth — is answered from that path.

--- a/README.md
+++ b/README.md
@@ -21,14 +21,16 @@ https://github.com/user-attachments/assets/d72a9286-0325-4b8b-afc0-c1efe9c96f4e
 
 ## Quick Start
 
-Scaffold and run via the CLI. Lobu boots as a single Node process; you bring your own Postgres (pgvector required — managed instance or local via `brew services start postgresql`).
+Scaffold and run via the CLI. Lobu boots as a single Node process with a zero-config embedded Postgres by default (or bring your own — pgvector required — via `DATABASE_URL`).
 
 ```bash
 npx @lobu/cli@latest init my-bot
 cd my-bot
-# edit .env to set DATABASE_URL
-npx @lobu/cli@latest run
+npx @lobu/cli@latest run                      # boots the stack and applies your agent
+npx @lobu/cli@latest chat -c local "hello"    # talk to it
 ```
+
+`lobu run` (embedded) auto-applies your `lobu.toml`, so the scaffolded agent is usable immediately. To use an external Postgres, set `DATABASE_URL` in `.env`; to push later config changes, run `lobu apply`.
 
 ## Agent configuration
 

--- a/packages/agent-worker/src/__tests__/model-resolver-harden.test.ts
+++ b/packages/agent-worker/src/__tests__/model-resolver-harden.test.ts
@@ -114,6 +114,70 @@ describe("resolveModelRef — edge cases", () => {
   });
 });
 
+describe("resolveModelRef — configured provider wins over slug split", () => {
+  let origDefaultModel: string | undefined;
+  let origDefaultProvider: string | undefined;
+
+  beforeEach(() => {
+    origDefaultModel = process.env.AGENT_DEFAULT_MODEL;
+    origDefaultProvider = process.env.AGENT_DEFAULT_PROVIDER;
+    delete process.env.AGENT_DEFAULT_MODEL;
+    delete process.env.AGENT_DEFAULT_PROVIDER;
+  });
+
+  afterEach(() => {
+    if (origDefaultModel !== undefined)
+      process.env.AGENT_DEFAULT_MODEL = origDefaultModel;
+    else delete process.env.AGENT_DEFAULT_MODEL;
+
+    if (origDefaultProvider !== undefined)
+      process.env.AGENT_DEFAULT_PROVIDER = origDefaultProvider;
+    else delete process.env.AGENT_DEFAULT_PROVIDER;
+  });
+
+  test("openrouter + anthropic/claude-sonnet-4 → openrouter, slug intact", () => {
+    const result = resolveModelRef("anthropic/claude-sonnet-4", {
+      defaultProvider: "openrouter",
+    });
+    expect(result.provider).toBe("openrouter");
+    expect(result.modelId).toBe("anthropic/claude-sonnet-4");
+  });
+
+  test("openrouter + openai/gpt-4o → openrouter, NOT openai", () => {
+    const result = resolveModelRef("openai/gpt-4o", {
+      defaultProvider: "openrouter",
+    });
+    expect(result.provider).toBe("openrouter");
+    expect(result.modelId).toBe("openai/gpt-4o");
+  });
+
+  test("AGENT_DEFAULT_PROVIDER env also wins over slug split", () => {
+    process.env.AGENT_DEFAULT_PROVIDER = "openrouter";
+    const result = resolveModelRef("google/gemini-2.0-flash");
+    expect(result.provider).toBe("openrouter");
+    expect(result.modelId).toBe("google/gemini-2.0-flash");
+  });
+
+  test("configured provider + 'auto' resolves to that provider's default", () => {
+    const result = resolveModelRef("auto", { defaultProvider: "openrouter" });
+    expect(result.provider).toBe("openrouter");
+    // openrouter has no DEFAULT_PROVIDER_MODELS entry, so "auto" stays as-is.
+    expect(result.modelId).toBe("auto");
+  });
+
+  test("configured provider + 'auto' for a known provider resolves the default", () => {
+    const result = resolveModelRef("auto", { defaultProvider: "anthropic" });
+    expect(result.provider).toBe("anthropic");
+    expect(result.modelId).toBe(DEFAULT_PROVIDER_MODELS.anthropic);
+  });
+
+  test("auto-mode (no provider) still derives provider from slug", () => {
+    const result = resolveModelRef("groq/llama-x");
+    expect(result.provider).toBe("groq");
+    expect(result.modelId).toBe("llama-x");
+  });
+});
+
 describe("resolveModelRef — does not leak secrets", () => {
   test("model ID containing lobu_secret placeholder is passed through unchanged", () => {
     // Unlikely in practice but the resolver must not strip or transform it

--- a/packages/agent-worker/src/__tests__/model-resolver.test.ts
+++ b/packages/agent-worker/src/__tests__/model-resolver.test.ts
@@ -80,6 +80,37 @@ describe("resolveModelRef", () => {
     const result = resolveModelRef("  anthropic/claude-sonnet-4-20250514  ");
     expect(result.provider).toBe("anthropic");
   });
+
+  test("configured provider wins: OpenRouter vendor/model slug is passed through verbatim", () => {
+    // OpenRouter expresses models as "vendor/model" in its OWN namespace.
+    // With provider configured, do NOT split — route to the configured
+    // provider and keep the model string intact.
+    const result = resolveModelRef("anthropic/claude-sonnet-4", {
+      defaultProvider: "openrouter",
+    });
+    expect(result.provider).toBe("openrouter");
+    expect(result.modelId).toBe("anthropic/claude-sonnet-4");
+  });
+
+  test("configured provider wins: openai/gpt-4o slug is not mis-routed to openai", () => {
+    const result = resolveModelRef("openai/gpt-4o", {
+      defaultProvider: "openrouter",
+    });
+    expect(result.provider).toBe("openrouter");
+    expect(result.modelId).toBe("openai/gpt-4o");
+  });
+
+  test("configured provider + 'auto' resolves to that provider's default model", () => {
+    const result = resolveModelRef("auto", { defaultProvider: "anthropic" });
+    expect(result.provider).toBe("anthropic");
+    expect(result.modelId).toBe(DEFAULT_PROVIDER_MODELS.anthropic);
+  });
+
+  test("auto-mode (no configured provider) still derives provider from slug", () => {
+    const result = resolveModelRef("groq/llama-x");
+    expect(result.provider).toBe("groq");
+    expect(result.modelId).toBe("llama-x");
+  });
 });
 
 describe("registerDynamicProvider", () => {

--- a/packages/agent-worker/src/__tests__/model-resolver.test.ts
+++ b/packages/agent-worker/src/__tests__/model-resolver.test.ts
@@ -82,22 +82,15 @@ describe("resolveModelRef", () => {
   });
 
   test("configured provider wins: OpenRouter vendor/model slug is passed through verbatim", () => {
-    // OpenRouter expresses models as "vendor/model" in its OWN namespace.
-    // With provider configured, do NOT split — route to the configured
-    // provider and keep the model string intact.
+    // Smoke case — the full matrix of configured-provider slug routing lives in
+    // model-resolver-harden.test.ts. OpenRouter expresses models as
+    // "vendor/model" in its OWN namespace; with a provider configured, do NOT
+    // split — route to the configured provider and keep the model intact.
     const result = resolveModelRef("anthropic/claude-sonnet-4", {
       defaultProvider: "openrouter",
     });
     expect(result.provider).toBe("openrouter");
     expect(result.modelId).toBe("anthropic/claude-sonnet-4");
-  });
-
-  test("configured provider wins: openai/gpt-4o slug is not mis-routed to openai", () => {
-    const result = resolveModelRef("openai/gpt-4o", {
-      defaultProvider: "openrouter",
-    });
-    expect(result.provider).toBe("openrouter");
-    expect(result.modelId).toBe("openai/gpt-4o");
   });
 
   test("configured provider + 'auto' resolves to that provider's default model", () => {

--- a/packages/agent-worker/src/openclaw/model-resolver.ts
+++ b/packages/agent-worker/src/openclaw/model-resolver.ts
@@ -108,6 +108,26 @@ export function resolveModelRef(
     );
   }
 
+  // When the agent has an explicitly configured provider, route to it and pass
+  // the model string AS-IS. The model is expressed in that provider's own
+  // namespace — e.g. OpenRouter slugs like "anthropic/claude-sonnet-4" or
+  // "openai/gpt-4o" mean "OpenRouter's anthropic/openai model", not "switch to
+  // the anthropic/openai provider". Splitting on "/" here would mis-route them.
+  if (defaultProvider) {
+    let modelId = modelRef;
+    // Resolve "auto" to the configured provider's default model.
+    if (modelId === "auto") {
+      const fallback = DEFAULT_PROVIDER_MODELS[defaultProvider];
+      if (fallback) {
+        logger.info(`Resolved auto model for ${defaultProvider}: ${fallback}`);
+        modelId = fallback;
+      }
+    }
+    return { provider: defaultProvider, modelId };
+  }
+
+  // Auto / no-configured-provider mode: derive the provider from the model
+  // string's first segment ("provider/model").
   const parts = modelRef.split("/").filter(Boolean);
   if (parts.length >= 2) {
     const provider = parts[0]!;
@@ -123,13 +143,9 @@ export function resolveModelRef(
     return { provider, modelId };
   }
 
-  if (!defaultProvider) {
-    throw new Error(
-      `No provider specified for model "${modelRef}". Use "provider/model" format or set AGENT_DEFAULT_PROVIDER.`
-    );
-  }
-
-  return { provider: defaultProvider, modelId: modelRef };
+  throw new Error(
+    `No provider specified for model "${modelRef}". Use "provider/model" format or set AGENT_DEFAULT_PROVIDER.`
+  );
 }
 
 export async function openOrCreateSessionManager(

--- a/packages/cli/src/__tests__/dev.test.ts
+++ b/packages/cli/src/__tests__/dev.test.ts
@@ -14,6 +14,7 @@ import {
   findEnclosingMonorepoRoot,
   isSharedDatabaseUrl,
   resolveBackendBundle,
+  shouldAutoApplyLocalProject,
   shouldRefuseSharedDatabaseUrl,
 } from "../commands/dev";
 
@@ -249,5 +250,49 @@ describe("lobu run backend bundle resolution", () => {
     );
     expect(buildScript).toContain('copyDirIfExists("../../db/migrations"');
     expect(buildScript).toContain('"server.bundle.mjs"');
+  });
+});
+
+describe("shouldAutoApplyLocalProject", () => {
+  test("applies for an embedded run once the local context is ready", () => {
+    expect(
+      shouldAutoApplyLocalProject({
+        mode: "embedded",
+        localContextReady: true,
+        hasLobuToml: true,
+      })
+    ).toBe(true);
+  });
+
+  test("skips when sign-in did not establish the local context", () => {
+    // The guard that stops `lobu run` applying a local project to whatever
+    // cloud/prod context happened to be active.
+    expect(
+      shouldAutoApplyLocalProject({
+        mode: "embedded",
+        localContextReady: false,
+        hasLobuToml: true,
+      })
+    ).toBe(false);
+  });
+
+  test("never auto-applies against an external backend", () => {
+    expect(
+      shouldAutoApplyLocalProject({
+        mode: "external",
+        localContextReady: true,
+        hasLobuToml: true,
+      })
+    ).toBe(false);
+  });
+
+  test("skips when the project has no lobu.toml to apply", () => {
+    expect(
+      shouldAutoApplyLocalProject({
+        mode: "embedded",
+        localContextReady: true,
+        hasLobuToml: false,
+      })
+    ).toBe(false);
   });
 });

--- a/packages/cli/src/__tests__/dev.test.ts
+++ b/packages/cli/src/__tests__/dev.test.ts
@@ -167,6 +167,13 @@ describe("lobu run backend bundle resolution", () => {
 
     // Garbage URL → not "shared" (the boot path will fail elsewhere).
     expect(isSharedDatabaseUrl("not-a-url")).toBe(false);
+
+    // file:// embedded paths are LOCAL, never shared — even though their URL
+    // hostname parses as empty. The menubar app passes file://<abs path>, so a
+    // regression here refuses to boot the local embedded server.
+    expect(isSharedDatabaseUrl("file:///Users/me/lobu/data")).toBe(false);
+    expect(isSharedDatabaseUrl("file://.")).toBe(false);
+    expect(isSharedDatabaseUrl("file:/Users/me/lobu/data")).toBe(false);
   });
 
   describe("shouldRefuseSharedDatabaseUrl", () => {

--- a/packages/cli/src/commands/chat.ts
+++ b/packages/cli/src/commands/chat.ts
@@ -272,6 +272,18 @@ async function createSession(
       );
       process.exit(1);
     }
+    if (createRes.status === 404) {
+      // The server returns an actionable message (e.g. the agent hasn't been
+      // deployed yet — "Run `lobu apply`"). Surface it directly.
+      let message = body;
+      try {
+        message = (JSON.parse(body) as { error?: string }).error ?? body;
+      } catch {
+        // body wasn't JSON — fall back to the raw text
+      }
+      console.error(chalk.red(`\n  ${message}\n`));
+      process.exit(1);
+    }
     console.error(
       chalk.red(`\n  Failed to create session (${createRes.status}): ${body}\n`)
     );

--- a/packages/cli/src/commands/chat.ts
+++ b/packages/cli/src/commands/chat.ts
@@ -272,18 +272,6 @@ async function createSession(
       );
       process.exit(1);
     }
-    if (createRes.status === 404) {
-      // The server returns an actionable message (e.g. the agent hasn't been
-      // deployed yet — "Run `lobu apply`"). Surface it directly.
-      let message = body;
-      try {
-        message = (JSON.parse(body) as { error?: string }).error ?? body;
-      } catch {
-        // body wasn't JSON — fall back to the raw text
-      }
-      console.error(chalk.red(`\n  ${message}\n`));
-      process.exit(1);
-    }
     console.error(
       chalk.red(`\n  Failed to create session (${createRes.status}): ${body}\n`)
     );

--- a/packages/cli/src/commands/dev.ts
+++ b/packages/cli/src/commands/dev.ts
@@ -419,9 +419,7 @@ export function shouldAutoApplyLocalProject(opts: {
   localContextReady: boolean;
   hasLobuToml: boolean;
 }): boolean {
-  return (
-    opts.mode === "embedded" && opts.localContextReady && opts.hasLobuToml
-  );
+  return opts.mode === "embedded" && opts.localContextReady && opts.hasLobuToml;
 }
 
 /**

--- a/packages/cli/src/commands/dev.ts
+++ b/packages/cli/src/commands/dev.ts
@@ -43,6 +43,12 @@ export interface DevOptions {
  * Exported for unit tests; the safety gate in `devCommand` is the consumer.
  */
 export function isSharedDatabaseUrl(databaseUrl: string): boolean {
+  // Only network (postgres://) URLs can point at a shared/remote DB. Embedded
+  // backends are local filesystem paths — frequently a `file://<abs path>` URL
+  // (e.g. the menubar app passes `file:///Users/me/lobu/data`), whose URL
+  // hostname parses as empty. Treating that empty host as "non-loopback" would
+  // wrongly flag every local embedded run as shared and refuse to boot.
+  if (!isExternalDatabaseUrl(databaseUrl)) return false;
   try {
     const url = new URL(databaseUrl);
     // `new URL("postgres://[::1]:5432/x").hostname` returns `[::1]` with the

--- a/packages/cli/src/commands/dev.ts
+++ b/packages/cli/src/commands/dev.ts
@@ -368,10 +368,16 @@ export async function devCommand(
       // Once the `local` context is confirmed registered + active, push the
       // project's lobu.toml into the embedded DB so the scaffolded agent is
       // usable via `lobu chat -c local …` with no separate `lobu apply`.
-      // Gated on localContextReady AND pinned to the local URL (below) so a
-      // failed sign-in can never apply this local project to whatever
+      // Gated (see shouldAutoApplyLocalProject) AND pinned to the local URL so
+      // a failed sign-in can never apply this local project to whatever
       // cloud/prod context happened to be active.
-      if (mode === "embedded" && localContextReady) {
+      if (
+        shouldAutoApplyLocalProject({
+          mode,
+          localContextReady,
+          hasLobuToml: existsSync(join(cwd, "lobu.toml")),
+        })
+      ) {
         return autoApplyLocalProject(cwd, gatewayUrl);
       }
     }
@@ -402,6 +408,23 @@ export async function devCommand(
 }
 
 /**
+ * Whether `lobu run` should auto-apply the project. True only when:
+ *  - the backend is embedded (never auto-mutate an external/prod DB), AND
+ *  - the `local` context was registered + made active (so the apply targets the
+ *    embedded server, not whatever cloud context was active before), AND
+ *  - the project actually has a `lobu.toml` to apply.
+ */
+export function shouldAutoApplyLocalProject(opts: {
+  mode: "external" | "embedded";
+  localContextReady: boolean;
+  hasLobuToml: boolean;
+}): boolean {
+  return (
+    opts.mode === "embedded" && opts.localContextReady && opts.hasLobuToml
+  );
+}
+
+/**
  * After `lobu run` boots an embedded backend, push the project's `lobu.toml`
  * into the local DB so the agent the user just scaffolded is immediately usable
  * (`lobu chat -c local …`) without a separate `lobu apply`. Uses the `local`
@@ -417,7 +440,6 @@ async function autoApplyLocalProject(
   cwd: string,
   gatewayUrl: string
 ): Promise<void> {
-  if (!existsSync(join(cwd, "lobu.toml"))) return;
   try {
     const { applyCommand } = await import("./_lib/apply/apply-cmd.js");
     // Pin the apply to the embedded server's URL. `resolveApiTarget` matches

--- a/packages/cli/src/commands/dev.ts
+++ b/packages/cli/src/commands/dev.ts
@@ -363,7 +363,13 @@ export async function devCommand(
   // click the URL straight from their terminal and land logged in. Also
   // persists the session as the `local` CLI context so `lobu chat -c local`
   // works without a separate `lobu login`.
-  void announceLocalSignIn(gatewayUrl, mode === "embedded");
+  void announceLocalSignIn(gatewayUrl, mode === "embedded").then(() => {
+    // After the `local` context is registered, push the project's lobu.toml
+    // into the embedded DB so the agent the user just scaffolded is usable via
+    // `lobu chat -c local …` with no separate `lobu apply`. Embedded/local
+    // only — never auto-mutate an external (prod) DB from a local file.
+    if (mode === "embedded") return autoApplyLocalProject(cwd);
+  });
 
   // Forward Ctrl+C to the child so it can clean up its own subprocess workers
   // before the parent exits. SIGKILL after a timeout in case it wedges.
@@ -387,6 +393,32 @@ export async function devCommand(
     }
     process.exit(code ?? 0);
   });
+}
+
+/**
+ * After `lobu run` boots an embedded backend, push the project's `lobu.toml`
+ * into the local DB so the agent the user just scaffolded is immediately usable
+ * (`lobu chat -c local …`) without a separate `lobu apply`. Uses the `local`
+ * context that `announceLocalSignIn` just registered.
+ *
+ * Best-effort: a project with nothing to apply, or a transient failure, must
+ * never crash the running server. The apply graph (esbuild + connector-worker
+ * + SDK, pulled in by apply-cmd) is imported lazily so it stays out of
+ * `lobu run`'s module-load path — see the dynamic-import allow-list in
+ * AGENTS.md.
+ */
+async function autoApplyLocalProject(cwd: string): Promise<void> {
+  if (!existsSync(join(cwd, "lobu.toml"))) return;
+  try {
+    const { applyCommand } = await import("./_lib/apply/apply-cmd.js");
+    await applyCommand({ cwd, yes: true });
+  } catch (err) {
+    console.warn(
+      chalk.dim(
+        `  (auto-apply skipped: ${err instanceof Error ? err.message : String(err)})`
+      )
+    );
+  }
 }
 
 /**

--- a/packages/cli/src/commands/dev.ts
+++ b/packages/cli/src/commands/dev.ts
@@ -363,13 +363,19 @@ export async function devCommand(
   // click the URL straight from their terminal and land logged in. Also
   // persists the session as the `local` CLI context so `lobu chat -c local`
   // works without a separate `lobu login`.
-  void announceLocalSignIn(gatewayUrl, mode === "embedded").then(() => {
-    // After the `local` context is registered, push the project's lobu.toml
-    // into the embedded DB so the agent the user just scaffolded is usable via
-    // `lobu chat -c local …` with no separate `lobu apply`. Embedded/local
-    // only — never auto-mutate an external (prod) DB from a local file.
-    if (mode === "embedded") return autoApplyLocalProject(cwd);
-  });
+  void announceLocalSignIn(gatewayUrl, mode === "embedded").then(
+    (localContextReady) => {
+      // Once the `local` context is confirmed registered + active, push the
+      // project's lobu.toml into the embedded DB so the scaffolded agent is
+      // usable via `lobu chat -c local …` with no separate `lobu apply`.
+      // Gated on localContextReady AND pinned to the local URL (below) so a
+      // failed sign-in can never apply this local project to whatever
+      // cloud/prod context happened to be active.
+      if (mode === "embedded" && localContextReady) {
+        return autoApplyLocalProject(cwd, gatewayUrl);
+      }
+    }
+  );
 
   // Forward Ctrl+C to the child so it can clean up its own subprocess workers
   // before the parent exits. SIGKILL after a timeout in case it wedges.
@@ -407,11 +413,18 @@ export async function devCommand(
  * `lobu run`'s module-load path — see the dynamic-import allow-list in
  * AGENTS.md.
  */
-async function autoApplyLocalProject(cwd: string): Promise<void> {
+async function autoApplyLocalProject(
+  cwd: string,
+  gatewayUrl: string
+): Promise<void> {
   if (!existsSync(join(cwd, "lobu.toml"))) return;
   try {
     const { applyCommand } = await import("./_lib/apply/apply-cmd.js");
-    await applyCommand({ cwd, yes: true });
+    // Pin the apply to the embedded server's URL. `resolveApiTarget` matches
+    // the `local` context by URL — and refuses to send any other context's
+    // credentials to a different URL — so this can only ever target the local
+    // server, never a cloud/prod org.
+    await applyCommand({ cwd, yes: true, url: gatewayUrl });
   } catch (err) {
     console.warn(
       chalk.dim(
@@ -505,23 +518,23 @@ export function resolveBackendBundle(
 async function announceLocalSignIn(
   gatewayUrl: string,
   embedded: boolean
-): Promise<void> {
+): Promise<boolean> {
   // Poll briefly so the announce lands AFTER the server's own startup
   // banner without racing it.
   const reachable = await waitForServerReachable(gatewayUrl);
-  if (!reachable) return;
+  if (!reachable) return false;
 
   // Only the embedded path seeds the bootstrap user → /local-init will refuse
   // on an external-Postgres deployment with real signups. Skip the network
   // call entirely in that case to keep the banner quiet.
-  if (!embedded) return;
+  if (!embedded) return false;
 
   try {
     const res = await fetch(`${gatewayUrl}/api/local-init`, {
       method: "POST",
       headers: { "X-Lobu-Client": "lobu-run" },
     });
-    if (!res.ok) return;
+    if (!res.ok) return false;
     const body = (await res.json()) as {
       device_token?: string;
       session_token?: string;
@@ -535,7 +548,7 @@ async function announceLocalSignIn(
     // so the SPA hook reaches /api/exchange-token → Better Auth session
     // cookie).
     const cliToken = body.device_token ?? body.session_token;
-    if (!cliToken) return;
+    if (!cliToken) return false;
 
     const contextName = "local";
     await addContext(contextName, gatewayUrl);
@@ -585,8 +598,12 @@ async function announceLocalSignIn(
         chalk.cyan(`lobu chat -c ${contextName} "hello"`)
     );
     console.log();
+    // The `local` context is registered, credentialed, and active — safe to
+    // auto-apply the project against it.
+    return true;
   } catch {
     // Swallow — the banner is best-effort.
+    return false;
   }
 }
 

--- a/packages/server/src/gateway/__tests__/agent-session-create.test.ts
+++ b/packages/server/src/gateway/__tests__/agent-session-create.test.ts
@@ -1,0 +1,94 @@
+/**
+ * POST /api/v1/agents (session create) — ownership-denial is enumeration-safe.
+ *
+ * A denied session-create must return the SAME response whether the requested
+ * agent is missing or merely belongs to another tenant. Distinguishing the two
+ * (e.g. 404-for-missing vs 403-for-unauthorized) would let a caller probe
+ * arbitrary ids to discover other tenants' agents.
+ *
+ * Mounts the real `createAgentApi` and authenticates with a real worker token
+ * (encrypted with a test ENCRYPTION_KEY) scoped to a different agent, so
+ * ownership is always denied. No DB: `RevokedTokenStore.isRevoked` fails open
+ * to `false` when no pool is configured.
+ */
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { generateWorkerToken } from "@lobu/core";
+import { createAgentApi } from "../routes/public/agent.js";
+import { setAuthProvider } from "../routes/public/settings-auth.js";
+
+const TEST_KEY =
+  "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+
+/** Agent that "exists" in the metadata store; everything else is unknown. */
+const EXISTING_AGENT = "agent-existing";
+
+let savedKey: string | undefined;
+beforeEach(() => {
+  savedKey = process.env.ENCRYPTION_KEY;
+  process.env.ENCRYPTION_KEY = TEST_KEY;
+  // No settings-session provider — force the worker-token auth path.
+  setAuthProvider(null);
+});
+afterEach(() => {
+  if (savedKey === undefined) delete process.env.ENCRYPTION_KEY;
+  else process.env.ENCRYPTION_KEY = savedKey;
+  setAuthProvider(null);
+});
+
+function makeApp() {
+  return createAgentApi({
+    // Unused before the ownership check returns — minimal stubs.
+    queueProducer: {} as never,
+    sessionManager: {} as never,
+    sseManager: {} as never,
+    publicGatewayUrl: "http://localhost:8787",
+    agentMetadataStore: {
+      async getMetadata(agentId: string) {
+        return agentId === EXISTING_AGENT
+          ? { owner: { platform: "api", userId: "owner-1" } }
+          : null;
+      },
+    } as never,
+  });
+}
+
+/** Worker token scoped to a *different* agent, so ownership is always denied. */
+function tokenForOtherAgent(): string {
+  return generateWorkerToken("agent-other", "conv-1", "deploy-1", {
+    channelId: "api_test",
+    agentId: "agent-other",
+  });
+}
+
+async function createSession(agentId: string): Promise<Response> {
+  return makeApp().request("/api/v1/agents", {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${tokenForOtherAgent()}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ agentId }),
+  });
+}
+
+describe("POST /api/v1/agents — enumeration-safe ownership denial", () => {
+  test("an unauthorized request for an EXISTING agent is denied with 403", async () => {
+    const res = await createSession(EXISTING_AGENT);
+    expect(res.status).toBe(403);
+    expect((await res.json()) as { error?: string }).toEqual({
+      success: false,
+      error: "Forbidden",
+    });
+  });
+
+  test("a request for a MISSING agent returns the identical denial (no leak)", async () => {
+    const res = await createSession("agent-not-deployed");
+    // Same status + body as the existing-but-unauthorized case — the response
+    // reveals nothing about whether the agent exists.
+    expect(res.status).toBe(403);
+    expect((await res.json()) as { error?: string }).toEqual({
+      success: false,
+      error: "Forbidden",
+    });
+  });
+});

--- a/packages/server/src/gateway/routes/public/agent.ts
+++ b/packages/server/src/gateway/routes/public/agent.ts
@@ -628,28 +628,14 @@ export function createAgentApi(config: AgentApiConfig): OpenAPIHono {
     const agentId = requestedAgentId?.trim() || randomUUID();
 
     // If the caller pinned a specific agentId, require ownership so a signed-in
-    // user cannot open a session against another tenant's agent.
+    // user cannot open a session against another tenant's agent. The denial is
+    // uniform on purpose: never reveal whether `agentId` exists (distinguishing
+    // "missing" from "exists-but-unauthorized" would be a cross-tenant
+    // enumeration oracle). The getting-started UX is carried by `lobu run`
+    // auto-applying the project, so a fresh local agent exists by chat time.
     if (!isEphemeral) {
       const denial = await requireAgentOwnership(c, agentId);
-      if (denial) {
-        // A denial conflates two cases: the agent exists but the caller can't
-        // access it (a genuine 403), or the agent simply hasn't been deployed
-        // yet. A fresh local project hits the latter before its first
-        // `lobu apply` — surface that as an actionable 404 instead of a bare
-        // "Forbidden". Existing-but-unauthorized agents still return 403, so
-        // this leaks nothing about another tenant's agents.
-        const metadata = await ownershipMetadataStore?.getMetadata(agentId);
-        if (!metadata) {
-          return c.json(
-            {
-              success: false,
-              error: `Agent "${agentId}" not found. Run \`lobu apply\` to deploy it.`,
-            },
-            404
-          );
-        }
-        return denial;
-      }
+      if (denial) return denial;
     }
 
     // Stamp the worker token with the agent's owning org so the egress

--- a/packages/server/src/gateway/routes/public/agent.ts
+++ b/packages/server/src/gateway/routes/public/agent.ts
@@ -631,7 +631,25 @@ export function createAgentApi(config: AgentApiConfig): OpenAPIHono {
     // user cannot open a session against another tenant's agent.
     if (!isEphemeral) {
       const denial = await requireAgentOwnership(c, agentId);
-      if (denial) return denial;
+      if (denial) {
+        // A denial conflates two cases: the agent exists but the caller can't
+        // access it (a genuine 403), or the agent simply hasn't been deployed
+        // yet. A fresh local project hits the latter before its first
+        // `lobu apply` — surface that as an actionable 404 instead of a bare
+        // "Forbidden". Existing-but-unauthorized agents still return 403, so
+        // this leaks nothing about another tenant's agents.
+        const metadata = await ownershipMetadataStore?.getMetadata(agentId);
+        if (!metadata) {
+          return c.json(
+            {
+              success: false,
+              error: `Agent "${agentId}" not found. Run \`lobu apply\` to deploy it.`,
+            },
+            404
+          );
+        }
+        return denial;
+      }
     }
 
     // Stamp the worker token with the agent's owning org so the egress


### PR DESCRIPTION
## Why

End-to-end testing the `npx @lobu/cli init` → `lobu run` → chat getting-started flow surfaced two blockers that stop a brand-new user's first chat from working out of the box.

## Changes

**1. `fix(agent-worker)` — configured provider wins in model resolution**
`resolveModelRef` always split the model on `/` and let the prefix override the configured provider. So an agent on provider `openrouter` with model `anthropic/claude-sonnet-4` (OpenRouter's native slug) was routed to provider `anthropic` and crashed the worker (`Model "claude-sonnet-4" not found for provider "anthropic"`). `openai/gpt-4o` broke too. Now: when a provider is explicitly configured, the model string is passed to it as-is; the `provider/model` split only applies in auto/no-provider mode.

**2. `fix(cli,server)` — getting-started chat works without a manual `lobu apply`**
- `lobu run` (embedded/local only) auto-applies the project's `lobu.toml` after boot, so the scaffolded agent is immediately usable. Best-effort; never mutates an external DB from a local file.
- The Agent API now returns `404 Agent "<id>" not found. Run \`lobu apply\` to deploy it.` when a session targets an undeployed agent, instead of a bare `403 Forbidden`. Existing-but-unauthorized agents still return 403 (no info leak).
- `lobu chat` surfaces that 404 message; README quick-start updated.
- `dev.ts` added to the dynamic-import allow-list (apply graph stays out of `lobu run`'s module-load path).

## Reproducer (red → green)

Built under Node 22; fresh `/tmp` project via the locally-built CLI.

**Blocker 1 — model routing**
- RED (before): `lobu chat` → `💥 Worker crashed: Model "claude-sonnet-4" not found for provider "anthropic"`
- GREEN (after): `"not found for provider"` count in the stream: **0**. The model now reaches `openrouter.ai` — the only error is `402 This request requires more credits` from OpenRouter (the test account is out of credits), which positively confirms correct provider routing.
- Unit tests authoritative for the slug parsing: `model-resolver.test.ts` + `model-resolver-harden.test.ts` → **55 pass, 0 fail** (added cases: `openrouter` + `anthropic/claude-sonnet-4`, `openrouter` + `openai/gpt-4o`, auto-mode `groq/llama`, `openrouter` + `auto`).

**Blocker 2 — chat works without manual apply + actionable error**
- `lobu run` log: `Plan: + agent bot → Applying → ↻ provider-key bot/openrouter → Apply complete` (auto-applied)
- session-create `{agentId:"bot"}` → `OK` (auto-applied agent reachable)
- bogus agent → `404 {"success":false,"error":"Agent \"does-not-exist-xyz\" not found. Run \`lobu apply\` to deploy it."}`

## Notes
- Default Node kept at **22** (a bump to 24 was considered then dropped). Node 25+ remains impossible — `isolated-vm@6.1.2` won't compile on the Node 25/26 V8 line.
- `lobu chat -c local` is the intended UX and registers the `local` context on `lobu run`; I verified the underlying Agent API path directly via curl to avoid a transient shared-config race on this multi-agent dev box.
- Full integration suite runs in CI (Node 22 + real pgvector).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Embedded mode now defaults to single-process with zero-config embedded Postgres and can auto-apply the local project after sign-in.

* **Bug Fixes**
  * Agent session errors surface server-provided 404 details.
  * Agent creation returns clearer 404 with actionable apply guidance when appropriate.
  * Model resolution now honors configured provider/defaults and enforces provider requirements.

* **Documentation**
  * Quick Start updated for embedded defaults and configuration guidance.
  * Dynamic-import allow-list updated.

* **Tests**
  * Added model-resolution and CLI dev behavior tests covering provider precedence and auto-apply logic.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lobu-ai/lobu/pull/987?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->