### PR TITLE
fix: prevent prod data wipe — non-destructive baseline down + test-DB guard

### DIFF
--- a/db/migrations/00000000000000_baseline.sql
+++ b/db/migrations/00000000000000_baseline.sql
@@ -5461,8 +5461,16 @@ ALTER TABLE ONLY public.watchers
 
 -- migrate:down
 
--- Reverting the baseline drops everything in public. Safe for fresh dev
--- DBs; never run against prod (use CNPG PITR — see header).
-DROP SCHEMA IF EXISTS public CASCADE;
-CREATE SCHEMA public;
-COMMENT ON SCHEMA public IS 'standard public schema';
+-- The squashed baseline is the ORIGIN of the schema; it is intentionally
+-- irreversible. The previous down here was `DROP SCHEMA public CASCADE`,
+-- which on 2026-05-20 wiped production when a `dbmate down`/rollback was run
+-- against $PROD_DATABASE_URL. A baseline down must never be destructive — any
+-- environment a rollback can reach (incl. prod) would lose everything.
+--
+-- To reset a *dev* database, drop the database itself (an explicit, dev-only
+-- action), not the schema:  `dbmate drop`  (or `dropdb && createdb`).
+DO $$
+BEGIN
+  RAISE EXCEPTION 'baseline 00000000000000 is irreversible: refusing to roll back the schema origin. To reset a dev database use `dbmate drop` (drops the whole database), never `dbmate down`.';
+END
+$$;

--- a/packages/server/src/__tests__/setup/test-db.ts
+++ b/packages/server/src/__tests__/setup/test-db.ts
@@ -36,6 +36,41 @@ const SKIP_ON_FRESH_SETUP = new Set<string>();
 
 let sql: postgres.Sql | null = null;
 
+/**
+ * Refuse to run the (destructive) test harness against anything that isn't an
+ * obvious throwaway test database.
+ *
+ * `setupTestDatabase()` runs `DROP SCHEMA public CASCADE`. On 2026-05-20 a
+ * developer ran the integration suite with `DATABASE_URL` pointed at the
+ * production `owletto` database; the test role owns that DB, so the drop
+ * succeeded and wiped 49 orgs / 1.15M events. There was no guard.
+ *
+ * Allow only databases whose name marks them as test/CI (anything containing
+ * `test`, or ending `_ci`) — CI uses `lobu_test` / `lobu_ci`. Anything else
+ * (e.g. `owletto`) is refused unless `LOBU_ALLOW_DESTRUCTIVE_TEST_DB=1` is set
+ * as a deliberate, explicit override.
+ */
+export function assertSafeTestDatabaseUrl(url: string): void {
+  if (process.env.LOBU_ALLOW_DESTRUCTIVE_TEST_DB === '1') return;
+  let dbName: string;
+  try {
+    dbName = new URL(url).pathname.replace(/^\//, '').split('?')[0];
+  } catch {
+    // Unparseable URL — let the postgres client surface the connection error.
+    return;
+  }
+  const looksLikeTestDb = /test/i.test(dbName) || /_ci$/i.test(dbName);
+  if (!looksLikeTestDb) {
+    throw new Error(
+      `Refusing to run the integration test harness against database "${dbName}": ` +
+        `setup runs DROP SCHEMA public CASCADE and would destroy its data. ` +
+        `Point DATABASE_URL at a throwaway test database (name must contain "test", ` +
+        `e.g. postgresql://localhost:5432/lobu_test). If this really is a disposable ` +
+        `database, set LOBU_ALLOW_DESTRUCTIVE_TEST_DB=1 to override.`
+    );
+  }
+}
+
 function pgBool(value: unknown): boolean {
   if (typeof value === 'boolean') return value;
   if (typeof value === 'string') {
@@ -59,6 +94,7 @@ export function getTestDb(): postgres.Sql {
           'Example: DATABASE_URL=postgresql://localhost:5432/lobu_test'
       );
     }
+    assertSafeTestDatabaseUrl(url);
     sql = postgres(url, {
       max: 5,
       idle_timeout: 20,


### PR DESCRIPTION
## Incident (2026-05-20)

A developer ran the **integration test suite locally with `DATABASE_URL` pointed at the production `owletto` database**. The suite's setup resets the schema with `DROP SCHEMA public CASCADE`; the test role owns that DB, so it succeeded — wiping **49 orgs / 36 users / 1.15M events (~12 GB)**. It ran several times (16:59–17:27 UTC). Recovery was done via CNPG PITR to the pre-wipe state.

Two independent safety holes let this happen. This PR closes both.

### 1. `getTestDb()` had no prod-safety guard (the actual trigger)
`packages/server/src/__tests__/setup/test-db.ts` connected to whatever `DATABASE_URL` said and `DROP SCHEMA`'d it. Added `assertSafeTestDatabaseUrl()`: refuses any DB whose name isn't test-shaped (`*test*` or `*_ci`). CI's `lobu_test`/`lobu_ci` pass; `owletto` is rejected. `LOBU_ALLOW_DESTRUCTIVE_TEST_DB=1` overrides.

### 2. Baseline `migrate:down` was `DROP SCHEMA public CASCADE` (loaded gun)
`db/migrations/00000000000000_baseline.sql` shipped a destructive rollback. The server runner only runs `up`, but any `dbmate down`/rollback or direct execution against any DB wipes it. Replaced with a hard refusal (`RAISE EXCEPTION`); dev resets use `dbmate drop`.

## Verification (red→green)

**Baseline down** (throwaway PG):
| Scenario | Result |
|---|---|
| OLD down SQL run directly | data dropped (wipe reproduced) |
| NEW down SQL run directly / via `dbmate down` | ERROR, rows intact |

**Test-DB guard:**
| DATABASE_URL | Result |
|---|---|
| `…/owletto` (prod) | **blocked** |
| `…/lobu_test`, `…/lobu_ci`, any `*test*` | allowed |
| prod + `LOBU_ALLOW_DESTRUCTIVE_TEST_DB=1` | allowed (override) |

## Notes
- Touches the excluded baseline file; `[squash-baseline]` marker present for the immutability gate.
- Production data recovered separately via PITR (CNPG) to 16:00 UTC (latest verified-complete snapshot).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Baseline migration rollback is now non-destructive: attempting to roll back the baseline raises an error and directs users to perform a full DB reset instead of using the rollback command to avoid data loss.

* **Tests**
  * Test setup now blocks destructive operations against non-test databases, allowing destructive setup only with explicit opt-in or when the DB name clearly indicates a test/CI environment.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lobu-ai/lobu/pull/989?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->