### PR TITLE
docs(landing): guardrails guide, multi-replica k8s ops, egress + secret-proxy pages, connector native deps

### DIFF
--- a/packages/landing/src/content/docs/deployment/kubernetes.mdx
+++ b/packages/landing/src/content/docs/deployment/kubernetes.mdx
@@ -105,6 +105,32 @@ curl https://lobu.example.com/health
 curl http://localhost:8787/health
 ```
 
+## Scaling and multi-replica operation
+
+In production the app runs as a multi-replica Deployment. Two chart values must move together when you scale past one app pod:
+
+```yaml
+app:
+  replicaCount: 3
+
+service:
+  # Required when replicaCount > 1. Pins each client to one pod for the
+  # affinity window (default 3h). The chart's NOTES.txt prints a warning
+  # if you scale up without it.
+  sessionAffinity: ClientIP
+  sessionAffinityTimeoutSeconds: 10800
+```
+
+Affinity is mandatory because some per-pod state is in-memory and pod-local, with no cross-pod fan-out. Each pod owns its own SSE connections and their event backlog (`SseManager`), its own map of spawned worker subprocesses, and its deployment-creation lock cache. A client whose SSE stream (`/api/v1/agents/<id>/events`) lands on pod A but whose `POST /messages` lands on pod B would silently miss events. `ClientIP` affinity co-locates a client's SSE stream, its message posts, and its conversation's worker on one pod.
+
+Cross-replica delivery rides Postgres, not memory. A worker reply reaches the client's SSE pod through the `thread_response` queue: any pod's consumer may claim a row and broadcast it to its own local `SseManager`. Platform responses (Slack, Telegram, and so on) are owner-routed, re-queued until the pod that owns the connection claims them.
+
+The conversation workers the gateway spawns are child processes of their pod, not pods themselves. Scaling `app.replicaCount` scales the gateway and its local worker capacity together.
+
+### Migrations stay single-writer
+
+Schema migrations run once, from the Helm pre-install/pre-upgrade Job, never from app pods. That is why the [example values](#prepare-values) set `SKIP_MIGRATIONS: "1"` on `app.env`. With N app pods, letting each pod run migrations on boot would race the schema. The Job is the single writer and the pods skip it.
+
 ## Upgrade
 
 Pin image tags for production upgrades, then run:

--- a/packages/landing/src/content/docs/getting-started/connector-sdk.md
+++ b/packages/landing/src/content/docs/getting-started/connector-sdk.md
@@ -318,6 +318,40 @@ my-agent/
 
 `lobu apply` discovers, type-checks, and ships them. Update the `version` field whenever the event shape changes so the gateway forces a fresh checkpoint.
 
+## Dependencies
+
+A connector can pull in two kinds of dependency, and they are provisioned differently.
+
+**npm packages are bundled at compile time.** Add them to the `package.json` next to your `lobu.toml` and import them normally:
+
+```ts
+import { parse } from "csv-parse/sync";
+```
+
+`lobu apply` runs `bun install --ignore-scripts` in the project, then esbuild bundles each connector with the project's `node_modules` and uploads the artifact. The server only ever receives the bundle, so npm deps ship inside it. `--ignore-scripts` keeps install-time supply-chain surface off your machine, which is also why packages that need native build steps do not belong here.
+
+**Native tools are provisioned at run time via nix.** Declare them as nixpkgs attribute refs in `runtime.nix.packages` on the connector definition:
+
+```ts
+export default class VideoConnector extends ConnectorRuntime {
+  definition: ConnectorDefinition = {
+    key: "media.video",
+    name: "Video",
+    version: "1.0.0",
+    runtime: {
+      platforms: ["linux", "macos"],
+      nix: { packages: ["ffmpeg", "imagemagick"] },
+    },
+    // ...feeds, actions
+  };
+  // ...sync / execute can now shell out to ffmpeg
+}
+```
+
+At execution the runtime wraps the connector's subprocess in `nix-shell -p <packages>` so the declared tools are on `PATH`. Backends that cannot run native deps reject a connector that declares them, and a host without `nix-shell` errors with a clear message rather than failing mid-run.
+
+The rule of thumb: **npm is bundled (compile-time), native is nix (run-time).** Never put a native tool in `package.json` expecting it to ship, and never list an npm package in `runtime.nix.packages`. See the [`ConnectorRuntimeInfo` reference](/reference/connector-sdk/#connectorruntimeinfo) for the field shape.
+
 ## See it in production
 
 - [`examples/ecommerce/connectors/stripe-charges.connector.ts`](https://github.com/lobu-ai/lobu/blob/main/examples/ecommerce/connectors/stripe-charges.connector.ts) — REST API, `env_keys` auth, timestamp checkpoint.

--- a/packages/landing/src/content/docs/guides/egress-judge.md
+++ b/packages/landing/src/content/docs/guides/egress-judge.md
@@ -1,0 +1,54 @@
+---
+title: Egress judge
+description: Per-request LLM judging of worker outbound network access, for domains where a flat allow/deny is too coarse.
+---
+
+Workers route all outbound HTTP through the gateway proxy, which enforces a domain allowlist/blocklist (see [Security](/guides/security/#network-isolation)). For most domains a flat allow or deny is the right call. For a few, like Slack, GitHub user-content, and Notion, the domain is *sometimes* fine and *sometimes* exfiltration, and the difference is in the request, not the hostname. The egress judge decides those per request with an LLM.
+
+Only domains that match a `judge` rule invoke the judge. Everything else stays on the fast allow/deny path, so the cost and latency stay bounded.
+
+## Declaring judged domains
+
+Skills declare judged domains and named policies in their `SKILL.md` frontmatter:
+
+```yaml
+network:
+  allow: [api.readonly.example.com]      # flat allow, fast path
+  judge:
+    - .slack.com                          # uses the "default" policy
+    - domain: user-content.x.com
+      judge: strict                       # uses the named "strict" policy
+judges:
+  default: "Allow only reads to channels in the agent's context."
+  strict:  "Only GET for file IDs from the current session."
+```
+
+The same shape is available to operators in [`lobu.toml`](/reference/lobu-toml/) under `[agents.<id>.network]`, where the `judge` array takes either a bare domain string (which uses the `default` policy) or `{ domain, judge }` naming a policy.
+
+## Operator overrides
+
+Operators layer a project-wide policy on top of whatever the skill author declared:
+
+```toml
+[agents.assistant.egress]
+extra_policy = "Never exfiltrate PATs or bearer tokens."
+judge_model  = "claude-haiku-4-5-20251001"   # default
+```
+
+`extra_policy` is **appended** to the matched skill policy rather than replacing it, so operator constraints compose with skill-author intent. The judge runs only when a `judge` rule under `[agents.<id>.network]` matches a request, so most traffic never reaches it.
+
+## Behavior
+
+- **Defaults:** Haiku judge, a 5-minute verdict cache keyed by `(policyHash, request signature)`, and a circuit breaker that opens after 5 consecutive judge failures (30s cooldown) and **fails closed**.
+- **What the judge sees:** for HTTPS the TLS tunnel is opaque, so the judge gets the **hostname only** (via the `CONNECT` request). For plain HTTP it also sees the method and path. Request bodies and headers are never inspected.
+- **Audit:** every decision emits a structured `egress-decision` log with the verdict, source (`global | grant | judge`), latency, and policy hash. No request bodies or headers are logged.
+- **Required env:** `ANTHROPIC_API_KEY` in the gateway environment. A gateway with no judged-domain rules never constructs the judge client.
+
+The judge shares its cache and circuit-breaker machinery with [inline guardrail judges](/guides/guardrails/#inline-llm-judges). Hooks live in `packages/server/src/gateway/proxy/http-proxy.ts`.
+
+## See also
+
+- [Security](/guides/security/), the worker isolation and network model the judge sits inside.
+- [Secret proxy](/guides/secret-proxy/), how credentials stay off the worker, the other half of egress safety.
+- [Guardrails](/guides/guardrails/), input/output/pre-tool policy checks, including inline LLM judges.
+- [`lobu.toml` reference](/reference/lobu-toml/), `[agents.<id>.network]` and `[agents.<id>.egress]`.

--- a/packages/landing/src/content/docs/guides/guardrails.md
+++ b/packages/landing/src/content/docs/guides/guardrails.md
@@ -1,0 +1,105 @@
+---
+title: Guardrails
+description: Policy checks that gate user input, worker output, and tool calls. Built-ins, inline LLM judges, and operator overrides.
+---
+
+Guardrails are policy checks that run at three points in an agent turn: before a user message reaches the worker, before the worker's text reaches the user, and before a tool call is authorized. They are how you stop a worker from leaking a secret, echoing PII, or invoking a destructive tool, independent of the prompt, so a jailbroken or buggy worker still hits the same wall.
+
+Each guardrail targets exactly one **stage** and returns a verdict. The gateway runs every enabled guardrail for a stage in parallel and acts on the first one that trips.
+
+## Stages
+
+| Stage | When it runs | What it inspects | On trip |
+|---|---|---|---|
+| `input` | User message to worker, before dispatch | The raw user message | Dispatch is skipped; the user gets `Message rejected: <reason>` |
+| `output` | Worker text to user, per streaming delta | The worker's output text | The stream is disposed, the partial buffer dropped, and `Message blocked by guardrail: <reason>` is posted |
+| `pre-tool` | Tool call, before authorization | The tool name plus serialized arguments | The worker receives `isError: true` with `Tool call blocked by policy.` |
+
+The `pre-tool` block message is intentionally generic. The real reason is hidden from the worker because leaking *why* a tool was blocked is an evasion surface. The `input` and `output` reasons are surfaced to the user, who is trusted.
+
+## How the runner behaves
+
+`runGuardrails(registry, stage, enabled, ctx)` races all enabled guardrails for the stage:
+
+- **First trip wins.** The runner short-circuits on the first guardrail that trips; the others keep running but their results are discarded.
+- **Fail open.** A guardrail that *throws* is logged and treated as a pass. Guardrails that need halt-on-error semantics must catch their own errors and return `{ tripped: true }`. So an infrastructure failure (a judge API timeout, say) never wedges the turn; it weakens enforcement instead of blocking traffic.
+- **No-op when empty.** If no guardrails are enabled for a stage, the runner returns immediately.
+
+## Built-in guardrails
+
+Three primitives ship from the gateway and are registered at boot. Reference them by name in `lobu.toml`.
+
+| Name | Stage(s) | Catches |
+|---|---|---|
+| `secret-scan` | `output` | Credential-shaped strings in worker output: OpenAI keys (`sk-…`), GitHub PATs (`ghp_…`), AWS access keys (`AKIA…`), and JWT-shaped tokens. Cheap enough to run per streaming delta. |
+| `pii-scan` | `input`, `output`, `pre-tool` | Emails, US-shaped phone numbers, and Luhn-valid 13-19 digit card-shaped runs. On `pre-tool` it scans the serialized tool arguments. |
+| `forbidden-tools` | `pre-tool` | A hardcoded deny list: `delete_repo`, `delete_branch`, `drop_table`. |
+
+`secret-scan` and `forbidden-tools` are stage-locked, so they only ever run at their natural stage. `pii-scan` is registered once per stage, so enabling `pii-scan` covers input, output, and pre-tool.
+
+## Enabling guardrails
+
+List built-in (or globally-registered) guardrail names on the agent in [`lobu.toml`](/reference/lobu-toml/):
+
+```toml
+[agents.assistant]
+name = "assistant"
+dir = "./agents/assistant"
+guardrails = ["secret-scan", "pii-scan", "forbidden-tools"]
+```
+
+Names that don't resolve to a guardrail registered in the gateway's `GuardrailRegistry` at startup are logged and skipped. A typo silently disables protection rather than failing the boot, so check the startup logs after changing this list.
+
+## Inline LLM judges
+
+When a regex won't express the policy, attach an ad-hoc LLM-judge guardrail with `[[agents.<id>.guardrails_inline]]`. Each entry names a stage and a judge prompt; the gateway materializes it into a guardrail at resolve time.
+
+```toml
+[[agents.assistant.guardrails_inline]]
+stage = "output"
+judge = "Never mention competitor product names."
+
+[[agents.assistant.guardrails_inline]]
+stage = "pre-tool"
+tools = ["github.delete_repo"]
+judge = "Only allow when the issue reference matches the active sprint."
+```
+
+- `stage` is one of `input`, `output`, `pre-tool`.
+- `tools` narrows a `pre-tool` judge to specific tool names; it is ignored for other stages.
+- `judge` is the policy text the LLM evaluates the stage context against.
+
+Inline judges run through a shared judge client with a verdict cache and a circuit breaker that fails closed after repeated failures (the same machinery as the [egress judge](/guides/egress-judge/)). Each inline entry materializes into a guardrail named `inline:<stage>:<hash8>`, so operators can target it for disabling.
+
+## Skill-provided guardrails
+
+A skill can declare its own `pre-tool` guardrails in its `SKILL.md`, either a built-in by name or an inline judge. These are added when the skill is enabled, so a skill that ships a destructive tool can also ship the policy that gates it. Skill-declared inline judges are named `skill:<name>:inline:pre-tool:<hash8>`.
+
+Skills can only add `pre-tool` guardrails. They cannot weaken input/output policy.
+
+## Operator overrides
+
+The full set for an agent is the union of enabled built-ins, skill-provided guardrails, and inline judges, deduplicated by name within each stage. The operator's exclude list is applied **last** and wins:
+
+```toml
+[agents.assistant]
+guardrails_disabled = [
+  "pii-scan",                              # turn off a built-in
+  "skill:github:inline:pre-tool:1a2b3c4d", # turn off a skill's judge
+]
+```
+
+`guardrails_disabled` matches against each guardrail's resolved `.name`, including the synthesized `inline:<stage>:<hash8>` and `skill:<name>:inline:pre-tool:<hash8>` names. Because it is operator-only and applied last, it is the single override point: a skill cannot re-enable something an operator disabled.
+
+The merge happens in `resolveAgentGuardrails()`; see `packages/server/src/gateway/guardrails/aggregator.ts` and `judge-factory.ts` for the resolution order, judge cache, and circuit breaker.
+
+## Auditing
+
+Every trip, at any stage, built-in or judge, writes an event with `semantic_type='guardrail-trip'`, so operators can review what fired and why without the worker or user seeing the internal reason. The trip is recorded even though the `pre-tool` reason is hidden from the worker.
+
+## See also
+
+- [Egress judge](/guides/egress-judge/), the per-request LLM judge for outbound network access. Shares the judge cache and circuit-breaker machinery.
+- [Tool Policy](/guides/tool-policy/), MCP tool approval and `pre_approved` overrides, the layer that sits alongside `pre-tool` guardrails.
+- [Secret proxy](/guides/secret-proxy/), how `secret-scan` complements credential isolation at egress.
+- [`lobu.toml` reference](/reference/lobu-toml/), the `guardrails`, `guardrails_inline`, and `guardrails_disabled` keys.

--- a/packages/landing/src/content/docs/guides/secret-proxy.md
+++ b/packages/landing/src/content/docs/guides/secret-proxy.md
@@ -1,0 +1,48 @@
+---
+title: Secret proxy
+description: How the gateway keeps real credentials out of workers by swapping placeholder tokens for secrets at egress.
+---
+
+Workers run untrusted code: agent reasoning, connector logic, tool calls. A worker that is jailbroken, buggy, or shipping a malicious skill must never be able to read a raw provider key or OAuth token. The secret proxy is how Lobu guarantees that. The worker only ever holds an opaque placeholder, and the real value is substituted on the gateway as the outbound request leaves the host.
+
+## The placeholder model
+
+When the gateway hands a credential to a worker, it hands over a placeholder of the form `lobu_secret_<uuid>`, never the real value. From the worker's code the placeholder behaves like a normal string:
+
+- For `env_keys` auth, the value you read from `ctx.config.<field>` is a placeholder.
+- For `oauth` auth, `ctx.credentials.accessToken` is a placeholder.
+
+Your connector or tool code uses it exactly as if it were the token (sets it as a header, puts it in a query string) and never has to know it isn't the real thing.
+
+## Swap at egress
+
+All worker outbound HTTP goes through the gateway's in-process proxy on `127.0.0.1:8118`. When a request leaves the proxy, the `secret-proxy` component scans it for `lobu_secret_<uuid>` placeholders and swaps each one for the real secret **just before** the bytes go upstream. The real value:
+
+- never exists in the worker process's memory,
+- never appears in worker logs, run records, or checkpoints,
+- only lives, decrypted, in the gateway for the duration of the outbound request.
+
+This composes with [network isolation](/guides/security/#network-isolation): on Linux production hosts the worker is wrapped in `systemd-run --user --scope` with `IPAddressDeny=any` plus `IPAddressAllow=127.0.0.1`, so a worker cannot open a socket that bypasses the proxy. That means it cannot reach a destination where its placeholders would be resolved to anything.
+
+## Where secret material lives
+
+The proxy resolves placeholders from the gateway's credential stores. Workers never touch these directly.
+
+| Category | Resolved from |
+|---|---|
+| Provider secrets | The built-in Postgres-backed encrypted secret store, external refs (`secret://…`, `aws-sm://…`), or a host-provided embedded secret store. |
+| Per-user MCP / OAuth tokens | Collected via device-auth and injected by the gateway MCP proxy per call. Integration auth (GitHub, Google, Linear, and similar) is handled by Lobu MCP servers. |
+
+`aws-sm://…` refs are **read-only**, which is good for durable provider secrets, but refreshed user tokens still need a writable store (the built-in Postgres store or a writable host store).
+
+## Defense in depth
+
+The secret proxy keeps credentials *out* of the worker. The [`secret-scan` guardrail](/guides/guardrails/#built-in-guardrails) is the backstop for the other direction: if a worker ever does emit a credential-shaped string in its output (a key the user pasted into chat, a token printed by a tool), `secret-scan` trips on the output stream before it reaches the user.
+
+## See also
+
+- [Security](/guides/security/), the full isolation model.
+- [Egress judge](/guides/egress-judge/), per-request judging of where workers can connect.
+- [Guardrails](/guides/guardrails/), `secret-scan` and the rest of the policy layer.
+- [MCP Proxy](/guides/mcp-proxy/), how per-user tokens are injected into MCP calls.
+- [Connector SDK](/getting-started/connector-sdk/), how connector code receives placeholders for `env_keys` and `oauth` auth.

--- a/packages/landing/src/content/docs/guides/security.md
+++ b/packages/landing/src/content/docs/guides/security.md
@@ -26,42 +26,13 @@ Domain format: exact (`api.example.com`) or wildcard (`.example.com` matches all
 
 ### LLM-judged egress
 
-For domains where flat allow/deny is too coarse — Slack, GitHub user-content, Notion — skills can route requests through an LLM judge that decides per request. Most traffic still bypasses the judge: only domains that match a `judge` rule invoke it, so the cost stays bounded.
+For domains where flat allow/deny is too coarse, like Slack, GitHub user-content, or Notion, skills can route requests through an LLM judge that decides per request. Only domains that match a `judge` rule invoke it, so the cost stays bounded. Skills declare judged domains and named policies in `SKILL.md`; operators layer an `extra_policy` on top in `lobu.toml`.
 
-Skills declare judged domains and named policies in `SKILL.md` frontmatter:
-
-```yaml
-network:
-  allow: [api.readonly.example.com]      # flat allow, fast path
-  judge:
-    - .slack.com                          # uses the "default" policy
-    - domain: user-content.x.com
-      judge: strict                       # uses the named "strict" policy
-judges:
-  default: "Allow only reads to channels in the agent's context."
-  strict:  "Only GET for file IDs from the current session."
-```
-
-Operators append a project-wide policy in `lobu.toml`:
-
-```toml
-[agents.<id>.egress]
-extra_policy = "Never exfiltrate PATs or bearer tokens."
-judge_model  = "claude-haiku-4-5-20251001"   # default
-```
-
-`extra_policy` is appended to the matched skill policy, so operator constraints compose with skill author intent rather than replacing it.
-
-Behavior:
-
-- **Defaults**: Haiku judge, 5-minute verdict cache keyed by `(policyHash, request signature)`, circuit breaker opens after 5 consecutive judge failures (30s cooldown) and fails closed.
-- **Hostname-only for HTTPS CONNECT** (TLS tunnel is opaque); method + path inspected for plain HTTP.
-- **Audit**: every decision emits a structured `egress-decision` log with verdict, source (`global | grant | judge`), latency, and policy hash. No request bodies/headers are logged.
-- **Required**: `ANTHROPIC_API_KEY` in the gateway env. Gateways with no judged-domain rules never construct the judge client.
+See [Egress judge](/guides/egress-judge/) for the policy schema, judge defaults (Haiku, verdict cache, fail-closed circuit breaker), and the `egress-decision` audit record.
 
 ## Credentials
 
-Workers never receive raw provider credentials or OAuth tokens. The gateway resolves credentials, injects them only at proxy time, and keeps workers on opaque placeholders or agent-scoped proxy URLs.
+Workers never receive raw provider credentials or OAuth tokens. The gateway resolves credentials, injects them only at proxy time, and keeps workers on opaque placeholders or agent-scoped proxy URLs. See [Secret proxy](/guides/secret-proxy/) for how the `lobu_secret_<uuid>` placeholder swap works at egress.
 
 | Category | How it works | Where secret material can live |
 |---|---|---|

--- a/packages/landing/src/content/docs/reference/connector-sdk.md
+++ b/packages/landing/src/content/docs/reference/connector-sdk.md
@@ -76,11 +76,14 @@ interface ConnectorDefinition {
 ```ts
 interface ConnectorRuntimeInfo {
   platforms: Array<"ios" | "android" | "macos" | "windows" | "linux">;
-  scopes?: string[]; // forwarded to the native platform adapter
+  scopes?: string[];            // forwarded to the native platform adapter
+  nix?: { packages: string[] }; // native deps provisioned at run time
 }
 ```
 
-Present only on device-bound connectors. Omit for cloud-fleet connectors.
+`platforms` and `scopes` describe device-bound connectors; omit the `runtime` block for cloud-fleet connectors that do not pin to a device.
+
+`nix.packages` lists native system dependencies as nixpkgs attribute refs (for example `["ffmpeg", "imagemagick"]`) the connector needs on PATH at execution time. npm dependencies are bundled into the connector at compile time and do **not** go here. Backends that can run native deps (embedded, container, machine) provision them via `nix-shell`; backends that cannot (for example edge workers) reject a connector that declares them. See [Dependencies](/getting-started/connector-sdk/#dependencies) in the guide for the npm-vs-native split.
 
 ---
 


### PR DESCRIPTION
Focused docs PR closing the gaps a docs-coverage review surfaced. All content verified against the actual code, not paraphrased from AGENTS.md.

## What changed

**New pages**
- `guides/guardrails.md` — the strongest gap. Stages (input/output/pre-tool), runner semantics (race, first-trip short-circuit, fail-open), built-ins (`secret-scan`/`pii-scan`/`forbidden-tools`), inline LLM judges, skill-provided guardrails, operator overrides (`guardrails_disabled` + synthesized names), trip behavior, and `guardrail-trip` auditing.
- `guides/egress-judge.md` — dedicated deep-dive on per-request LLM egress judging (policy schema, Haiku default, verdict cache, fail-closed circuit breaker, `egress-decision` audit).
- `guides/secret-proxy.md` — the `lobu_secret_<uuid>` placeholder-swap-at-egress model, where secret material lives, and how `secret-scan` backstops the other direction.

**Edits**
- `guides/security.md` — egress + secret-proxy detail moved into the dedicated pages above; the section now summarizes and links out (no duplication).
- `deployment/kubernetes.mdx` — new **Scaling and multi-replica operation** section: `app.replicaCount` > 1, mandatory `service.sessionAffinity: ClientIP` (with the real chart keys), pod-local in-memory state, Postgres-mediated cross-replica delivery via `thread_response`, owner-routed platform responses, and single-writer migrations.
- `reference/connector-sdk.md` + `getting-started/connector-sdk.md` — document `runtime.nix.packages`: **npm = bundled at compile time, native = nix at run time**, with the verified `ConnectorRuntimeInfo` shape.

## Validation
- `cd packages/landing && bun run build` — green, 86 pages, all new pages render, internal anchors resolve.
- Pre-commit `tsc --noEmit` passed.
- No em dashes in any new/edited landing copy (per AGENTS.md landing-copy rule).

## Notes
- The original review note also flagged egress + secret-proxy as "missing." They were already covered inside `security.md`; per the requested scope this PR promotes them to dedicated pages and de-duplicates `security.md` rather than leaving parallel copies.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added Kubernetes deployment guide covering multi-replica scaling and migration single-writer behavior
  * Expanded connector SDK getting-started and reference with dependency guidance (npm vs native tools via nix)
  * Added guides for egress judge, policy guardrails, and secret-proxy workflows
  * Streamlined security guide to reference the new egress judge and secret-proxy docs

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lobu-ai/lobu/pull/990?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->