### PR TITLE
fix(providers): reliable routing for all config-driven LLM providers

### DIFF
--- a/config/providers.json
+++ b/config/providers.json
@@ -37,7 +37,7 @@
           "apiKeyInstructions": "Get your API key from <a href=\"https://aistudio.google.com/apikey\" target=\"_blank\" class=\"text-blue-600 hover:underline\">Google AI Studio</a>",
           "apiKeyPlaceholder": "AIza...",
           "sdkCompat": "openai",
-          "defaultModel": "gemini-2.0-flash",
+          "defaultModel": "gemini-2.5-flash",
           "modelsEndpoint": "/v1/models"
         }
       ]

--- a/packages/agent-worker/src/__tests__/model-resolver-harden.test.ts
+++ b/packages/agent-worker/src/__tests__/model-resolver-harden.test.ts
@@ -244,7 +244,9 @@ describe("DEFAULT_PROVIDER_MODELS completeness", () => {
     "anthropic",
     "openai",
     "openai-codex",
-    "google",
+    // Keyed by the gateway provider slug "gemini" (the providers.json id),
+    // NOT "google" — the gateway never emits "google" as a defaultProvider.
+    "gemini",
     "nvidia",
     "z-ai",
   ];

--- a/packages/agent-worker/src/__tests__/model-resolver.test.ts
+++ b/packages/agent-worker/src/__tests__/model-resolver.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import {
+  buildDynamicOpenAIModel,
   DEFAULT_PROVIDER_BASE_URL_ENV,
   DEFAULT_PROVIDER_MODELS,
   PROVIDER_REGISTRY_ALIASES,
@@ -60,10 +61,10 @@ describe("resolveModelRef", () => {
   });
 
   test("falls back to provider default when no model or AGENT_DEFAULT_MODEL", () => {
-    process.env.AGENT_DEFAULT_PROVIDER = "google";
+    process.env.AGENT_DEFAULT_PROVIDER = "gemini";
     const result = resolveModelRef("");
-    expect(result.provider).toBe("google");
-    expect(result.modelId).toBe(DEFAULT_PROVIDER_MODELS.google);
+    expect(result.provider).toBe("gemini");
+    expect(result.modelId).toBe(DEFAULT_PROVIDER_MODELS.gemini);
   });
 
   test("throws when no model can be determined", () => {
@@ -169,7 +170,74 @@ describe("DEFAULT_PROVIDER_MODELS", () => {
   test("contains expected providers", () => {
     expect(DEFAULT_PROVIDER_MODELS.anthropic).toBeDefined();
     expect(DEFAULT_PROVIDER_MODELS.openai).toBeDefined();
-    expect(DEFAULT_PROVIDER_MODELS.google).toBeDefined();
+    // Keyed by gateway slug "gemini" (the config provider id), not "google".
+    expect(DEFAULT_PROVIDER_MODELS.gemini).toBeDefined();
+  });
+});
+
+describe("buildDynamicOpenAIModel — never silently route to OpenAI", () => {
+  test("third-party provider with a resolved base URL builds an entry", () => {
+    const model = buildDynamicOpenAIModel({
+      rawProvider: "gemini",
+      registryProvider: "openai",
+      modelId: "gemini-2.5-flash",
+      providerBaseUrl: "http://localhost:8118/api/proxy/gemini/a/agent-1",
+    });
+    expect(model.api).toBe("openai-completions");
+    expect(model.id).toBe("gemini-2.5-flash");
+    expect(model.provider).toBe("openai");
+    expect(model.baseUrl).toBe(
+      "http://localhost:8118/api/proxy/gemini/a/agent-1"
+    );
+  });
+
+  test("THROWS for a third-party provider with no resolved base URL", () => {
+    // Regression for the silent-misroute bug: an unresolved proxy base URL
+    // previously fell back to api.openai.com, shipping the request to OpenAI
+    // with an unknown model ID ("400 <model> is not a valid model ID").
+    expect(() =>
+      buildDynamicOpenAIModel({
+        rawProvider: "gemini",
+        registryProvider: "openai",
+        modelId: "gemini-2.5-flash",
+        providerBaseUrl: undefined,
+      })
+    ).toThrow(/Could not resolve a base URL for provider "gemini"/);
+  });
+
+  test("THROWS for nvidia/together/etc with no base URL (generic, all providers)", () => {
+    for (const rawProvider of ["nvidia", "together-ai", "z-ai", "groq"]) {
+      expect(() =>
+        buildDynamicOpenAIModel({
+          rawProvider,
+          registryProvider: "openai",
+          modelId: "some-model",
+          providerBaseUrl: undefined,
+        })
+      ).toThrow(/Refusing to route .* to OpenAI's public endpoint/);
+    }
+  });
+
+  test("real OpenAI MAY default to api.openai.com when base URL is absent", () => {
+    const model = buildDynamicOpenAIModel({
+      rawProvider: "openai",
+      registryProvider: "openai",
+      modelId: "gpt-4.1",
+      providerBaseUrl: undefined,
+    });
+    expect(model.baseUrl).toBe("https://api.openai.com/v1");
+  });
+});
+
+describe("DEFAULT_PROVIDER_BASE_URL_ENV — gateway-slug keying", () => {
+  test("gemini base-URL env is keyed by the 'gemini' slug, not 'google'", () => {
+    // The gateway emits the provider slug "gemini" (config id) as
+    // defaultProvider and keys its proxy mapping on GEMINI_API_BASE_URL.
+    // The worker's fallback map MUST use the same "gemini" key, or
+    // providerBaseUrl resolution misses and the request silently routes to
+    // OpenAI. A dead "google" key would never match.
+    expect(DEFAULT_PROVIDER_BASE_URL_ENV.gemini).toBe("GEMINI_API_BASE_URL");
+    expect(DEFAULT_PROVIDER_BASE_URL_ENV.google).toBeUndefined();
   });
 });
 

--- a/packages/agent-worker/src/openclaw/model-resolver.ts
+++ b/packages/agent-worker/src/openclaw/model-resolver.ts
@@ -15,7 +15,10 @@ export const DEFAULT_PROVIDER_BASE_URL_ENV: Record<string, string> = {
   anthropic: "ANTHROPIC_BASE_URL",
   openai: "OPENAI_BASE_URL",
   "openai-codex": "OPENAI_BASE_URL",
-  google: "GEMINI_API_BASE_URL",
+  // Keyed by the gateway provider slug (config id), e.g. "gemini" — NOT
+  // "google". registerDynamicProvider() overlays the live config values at
+  // runtime; these stay as fallbacks for providers not in providers.json.
+  gemini: "GEMINI_API_BASE_URL",
   nvidia: "NVIDIA_API_BASE_URL",
   "z-ai": "Z_AI_API_BASE_URL",
 };
@@ -25,7 +28,9 @@ export const DEFAULT_PROVIDER_MODELS: Record<string, string> = {
   anthropic: "claude-sonnet-4-20250514",
   openai: "gpt-4.1",
   "openai-codex": "gpt-5.1-codex-max",
-  google: "gemini-2.5-pro",
+  // Keyed by gateway slug ("gemini", not "google"). Overridden at runtime by
+  // the config-driven defaultModel via registerDynamicProvider().
+  gemini: "gemini-2.5-flash",
   nvidia: "nvidia/moonshotai/kimi-k2.5",
   "z-ai": "glm-4.7",
 };
@@ -73,6 +78,70 @@ export function registerDynamicProvider(
   logger.info(
     `Registered dynamic provider: ${id} (baseUrlEnv=${config.baseUrlEnvVar}, sdkCompat=${config.sdkCompat || "none"})`
   );
+}
+
+/** Shape of a dynamically-built openai-completions model entry. */
+export interface DynamicOpenAIModel {
+  id: string;
+  name: string;
+  api: "openai-completions";
+  provider: string;
+  baseUrl: string;
+  reasoning: boolean;
+  input: string[];
+  cost: {
+    input: number;
+    output: number;
+    cacheRead: number;
+    cacheWrite: number;
+  };
+  contextWindow: number;
+  maxTokens: number;
+}
+
+/**
+ * Build a dynamic openai-completions model entry for a config-driven provider
+ * whose model isn't in pi-ai's static registry (gemini, nvidia, together-ai,
+ * z.ai, …).
+ *
+ * `rawProvider` is the gateway provider slug; `registryProvider` is the
+ * model-registry name it maps to (usually "openai" for sdkCompat providers).
+ *
+ * Reliability invariant: only REAL OpenAI may default to OpenAI's public
+ * endpoint. For every other provider an unresolved `providerBaseUrl` means the
+ * gateway failed to supply a proxy mapping — routing such a request to
+ * api.openai.com would silently mis-deliver it to OpenAI with a model ID it
+ * doesn't know, surfacing as a confusing "400 <model> is not a valid model
+ * ID". We throw instead so the real cause (no proxy base URL) is visible.
+ */
+export function buildDynamicOpenAIModel(args: {
+  rawProvider: string;
+  registryProvider: string;
+  modelId: string;
+  providerBaseUrl: string | undefined;
+}): DynamicOpenAIModel {
+  const { rawProvider, registryProvider, modelId, providerBaseUrl } = args;
+  const isRealOpenAI = rawProvider === "openai";
+  if (!isRealOpenAI && !providerBaseUrl) {
+    throw new Error(
+      `Could not resolve a base URL for provider "${rawProvider}". ` +
+        `The gateway did not supply a proxy mapping for its base-URL env ` +
+        `var (${DEFAULT_PROVIDER_BASE_URL_ENV[rawProvider] ?? "unknown"}). ` +
+        `Refusing to route "${modelId}" to OpenAI's public endpoint.`
+    );
+  }
+  return {
+    id: modelId,
+    name: modelId,
+    api: "openai-completions",
+    provider: registryProvider,
+    baseUrl: providerBaseUrl || "https://api.openai.com/v1",
+    reasoning: false,
+    input: ["text", "image"],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: 128000,
+    maxTokens: 16384,
+  };
 }
 
 export function resolveModelRef(

--- a/packages/agent-worker/src/openclaw/worker.ts
+++ b/packages/agent-worker/src/openclaw/worker.ts
@@ -47,19 +47,13 @@ import {
   OpenClawPromptIntentInstructionProvider,
 } from "./instructions";
 import {
+  buildDynamicOpenAIModel,
   DEFAULT_PROVIDER_BASE_URL_ENV,
   openOrCreateSessionManager,
   PROVIDER_REGISTRY_ALIASES,
   registerDynamicProvider,
   resolveModelRef,
 } from "./model-resolver";
-import { checkSandboxLeak } from "./sandbox-leak";
-import {
-  clearSnapshots,
-  hydrateFromSnapshot,
-  type TerminalStatus,
-  writeSnapshot,
-} from "./transcript-snapshot";
 import {
   loadPlugins,
   runPluginHooks,
@@ -67,14 +61,21 @@ import {
   stopPluginServices,
 } from "./plugin-loader";
 import { OpenClawProgressProcessor } from "./processor";
+import { checkSandboxLeak } from "./sandbox-leak";
 import { getOpenClawSessionContext } from "./session-context";
-import { buildToolUseEventPayload } from "./tool-use-events";
 import {
   buildToolPolicy,
   enforceBashCommandPolicy,
   isToolAllowedByPolicy,
 } from "./tool-policy";
+import { buildToolUseEventPayload } from "./tool-use-events";
 import { createOpenClawTools } from "./tools";
+import {
+  clearSnapshots,
+  hydrateFromSnapshot,
+  type TerminalStatus,
+  writeSnapshot,
+} from "./transcript-snapshot";
 
 const logger = createLogger("worker");
 
@@ -907,18 +908,14 @@ export class OpenClawWorker implements WorkerExecutor {
         logger.info(
           `Creating dynamic model entry for ${rawProvider}/${modelId} (openai-compatible)`
         );
-        baseModel = {
-          id: modelId,
-          name: modelId,
-          api: "openai-completions",
-          provider: registryProvider,
-          baseUrl: providerBaseUrl || "https://api.openai.com/v1",
-          reasoning: false,
-          input: ["text", "image"],
-          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-          contextWindow: 128000,
-          maxTokens: 16384,
-        };
+        // Throws if a non-OpenAI provider's base URL is unresolved, rather
+        // than silently routing to OpenAI's public endpoint.
+        baseModel = buildDynamicOpenAIModel({
+          rawProvider,
+          registryProvider,
+          modelId,
+          providerBaseUrl,
+        });
       } else {
         throw new Error(
           `Model "${modelId}" not found for provider "${provider}". Check that the model ID is valid and registered in the model registry.`


### PR DESCRIPTION
## Problem

Config-driven LLM providers (gemini, etc.) failed for `lobu chat` against a local embedded server. Two distinct root causes, both at the shared model-resolution / routing layer — no per-provider workaround.

### Root cause 1 — stale Gemini default model
`config/providers.json` shipped `gemini-2.0-flash` as the Gemini default. Google now **404s** that model for new API users:

```
{"error":{"code":404,"message":"This model models/gemini-2.0-flash is no longer available to new users...","status":"NOT_FOUND"}}
```

The outbound request body/headers were never the problem — replaying the exact captured worker body verbatim against `https://generativelanguage.googleapis.com/v1beta/openai/chat/completions` 404s on `gemini-2.0-flash` but **200s** on `gemini-2.5-flash` / `gemini-2.5-pro` / `gemini-flash-latest`. Bumped the default to `gemini-2.5-flash`.

### Root cause 2 — silent OpenAI misroute (latent, all providers)
When a config provider's proxy base URL fails to resolve, the worker built a dynamic `openai-completions` model with `baseUrl = providerBaseUrl || "https://api.openai.com/v1"` — shipping the request to **real OpenAI** with a model id it doesn't know, surfacing as the confusing, run-to-run-inconsistent `400 <model> is not a valid model ID`. Extracted `buildDynamicOpenAIModel()`, which now **throws** for any non-OpenAI provider whose base URL is unresolved instead of falling back to OpenAI.

### Keying inconsistency the bug rode on
The worker fallback maps (`DEFAULT_PROVIDER_BASE_URL_ENV`, `DEFAULT_PROVIDER_MODELS`) were keyed `"google"`, but the gateway emits the provider **slug** `"gemini"` (the `providers.json` id) as `defaultProvider` — a dead key that never matched. Re-keyed to `"gemini"`.

## Why this covers every provider
The fix is in the shared path (`model-resolver.ts` + the dynamic-model builder used by the worker for all sdkCompat=openai providers). Every config-driven provider — groq, z-ai, together-ai, nvidia, deepseek, mistral, fireworks, cerebras, xai, perplexity, cohere, openrouter, openai — routes through the same `buildDynamicOpenAIModel()` + proxy-base-URL mapping. No gemini special-case.

## Reproducer (red → green)

Embedded server (`lobu run`, embedded Postgres), Gemini agent, `gemini-2.0-flash` (old default):

**RED** (before fix):
```
$ lobu chat -c local -a prov-test "Say the single word: pong"
❌ Session failed: 404 status code (no body)
  Agent error: 404 status code (no body)
```

Captured outbound proxy body replayed with curl confirmed the cause was the model id, not the body:
```
model=gemini-2.0-flash -> HTTP 404   (no longer available to new users)
model=gemini-2.5-flash -> HTTP 200
```

**GREEN** (after fix — fresh scaffold picks up `gemini-2.5-flash`):
```
$ lobu chat -c local -a prov-test "Reply with the single word: pong"
pong
```
Proxy log: `Forwarding to upstream: POST https://generativelanguage.googleapis.com/v1beta/openai/chat/completions` (200, no upstream-error warning).

**Regression check — z-ai still works:**
```
[worker] Starting OpenClaw session: provider=zai, model=glm-4.6
[secret-proxy] Forwarding to upstream: POST https://api.z.ai/api/coding/paas/v4/chat/completions
[worker] Session completed successfully - all content already streamed
```
z-ai routes to the correct upstream and completes (200) — unchanged by this PR.

## Tests
- New `buildDynamicOpenAIModel` unit tests: third-party provider with resolved base URL builds an entry; **throws** for gemini/nvidia/together-ai/z-ai/groq with no base URL (regression for the silent-misroute); real OpenAI may still default to `api.openai.com`.
- New gateway-slug-keying test: `DEFAULT_PROVIDER_BASE_URL_ENV.gemini === "GEMINI_API_BASE_URL"`, `.google` undefined.
- Updated existing `"google"`-keyed assertions to the corrected `"gemini"` slug.
- `bun test` model-resolver suites: 59 pass. `tsc --noEmit` clean for core / agent-worker / server.

## Verified vs code-reviewed
- **E2E verified with real keys:** gemini (`gemini-2.5-flash`, was 404), z-ai (`glm-4.6`, regression).
- **Code-reviewed (same shared path):** groq, together-ai, nvidia, deepseek, mistral, fireworks, cerebras, xai, perplexity, cohere, openrouter, openai.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added dynamic model configuration support for additional providers (NVIDIA, Z-AI, Gemini).

* **Updates**
  * Updated default Gemini model to gemini-2.5-flash.
  * Standardized provider slug mappings so Gemini is used consistently.

* **Bug Fixes**
  * Safer provider routing: prevents accidental fallback to OpenAI by requiring resolved proxy base URLs for non-OpenAI providers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lobu-ai/lobu/pull/992?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->