### PR TITLE
fix(cli,server): apply takes effect without lobu run restart

### DIFF
--- a/packages/server/src/gateway/auth/__tests__/base-provider-module-credentials.test.ts
+++ b/packages/server/src/gateway/auth/__tests__/base-provider-module-credentials.test.ts
@@ -1,0 +1,101 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { encrypt } from "@lobu/core";
+
+const TEST_ENCRYPTION_KEY = Buffer.from(
+  "12345678901234567890123456789012"
+).toString("base64");
+
+// Controls what the mocked org context and db return per-test.
+let mockOrgId: string | null = null;
+let orgSharedSecretRows: Array<{ ciphertext: string }> = [];
+
+// Mock the org-context AsyncLocalStorage lookup so we can simulate a worker
+// request that does (or doesn't) carry an org.
+mock.module("../../../lobu/stores/org-context.js", () => ({
+  tryGetOrgId: () => mockOrgId,
+  getOrgId: () => {
+    if (!mockOrgId) throw new Error("no org");
+    return mockOrgId;
+  },
+}));
+
+// Mock the db client. `readOrgSharedProviderKey` uses the postgres tagged
+// template (`sql\`SELECT ...\``); a tagged-template call invokes the function
+// with (strings, ...values), so returning the rows array satisfies it.
+mock.module("../../../db/client.js", () => ({
+  getDb: () => () => Promise.resolve(orgSharedSecretRows),
+}));
+
+// Import AFTER mocks so the module graph picks them up.
+const { ApiKeyProviderModule } = await import("../api-key-provider-module.js");
+
+function makeModule(hasProfile: boolean) {
+  return new ApiKeyProviderModule({
+    providerId: "z-ai",
+    providerDisplayName: "z.ai",
+    providerIconUrl: "https://example.com/z.png",
+    envVarName: "Z_AI_API_KEY",
+    apiKeyInstructions: "Get a key",
+    apiKeyPlaceholder: "zai-...",
+    sdkCompat: "openai",
+    authProfilesManager: {
+      hasProviderProfiles: async () => hasProfile,
+    } as any,
+  });
+}
+
+describe("BaseProviderModule.hasCredentials org-shared key fallback", () => {
+  const previousEncryptionKey = process.env.ENCRYPTION_KEY;
+  const previousZKey = process.env.Z_AI_API_KEY;
+
+  beforeEach(() => {
+    process.env.ENCRYPTION_KEY = TEST_ENCRYPTION_KEY;
+    // Ensure no system key influences the result — we test the org-shared path.
+    delete process.env.Z_AI_API_KEY;
+    mockOrgId = null;
+    orgSharedSecretRows = [];
+  });
+
+  afterEach(() => {
+    if (previousEncryptionKey === undefined) delete process.env.ENCRYPTION_KEY;
+    else process.env.ENCRYPTION_KEY = previousEncryptionKey;
+    if (previousZKey === undefined) delete process.env.Z_AI_API_KEY;
+    else process.env.Z_AI_API_KEY = previousZKey;
+  });
+
+  test("returns true when a per-user auth profile exists", async () => {
+    const mod = makeModule(true);
+    expect(await mod.hasCredentials("agent-1")).toBe(true);
+  });
+
+  test("returns true when only an org-shared API key exists (lobu apply path)", async () => {
+    // No auth profile, but `lobu apply` wrote provider:z-ai:apiKey for the org.
+    mockOrgId = "org-1";
+    orgSharedSecretRows = [{ ciphertext: encrypt("zai-secret-value") }];
+
+    const mod = makeModule(false);
+    // Pass org explicitly (as the worker session-context path now does) and
+    // also via the ALS fallback — both must resolve the org-shared key.
+    expect(
+      await mod.hasCredentials("agent-1", { organizationId: "org-1" })
+    ).toBe(true);
+    expect(await mod.hasCredentials("agent-1")).toBe(true);
+  });
+
+  test("returns false when neither profile nor org-shared key exists", async () => {
+    mockOrgId = "org-1";
+    orgSharedSecretRows = [];
+    const mod = makeModule(false);
+    expect(
+      await mod.hasCredentials("agent-1", { organizationId: "org-1" })
+    ).toBe(false);
+  });
+
+  test("returns false when there is no org context and no profile", async () => {
+    // No org id anywhere → org-shared lookup short-circuits, no db hit.
+    mockOrgId = null;
+    orgSharedSecretRows = [{ ciphertext: encrypt("should-not-be-read") }];
+    const mod = makeModule(false);
+    expect(await mod.hasCredentials("agent-1")).toBe(false);
+  });
+});

--- a/packages/server/src/gateway/auth/base-provider-module.ts
+++ b/packages/server/src/gateway/auth/base-provider-module.ts
@@ -163,11 +163,19 @@ export abstract class BaseProviderModule
     agentId: string,
     context?: ProviderCredentialContext
   ): Promise<boolean> {
-    return this.authProfilesManager.hasProviderProfiles(
+    const hasProfile = await this.authProfilesManager.hasProviderProfiles(
       agentId,
       this.providerId,
       context
     );
+    if (hasProfile) return true;
+    // Mirror the resolution chain in `buildEnvVars`: when no per-user auth
+    // profile exists, an org-shared API key written by `lobu apply`
+    // (`provider:<id>:apiKey` in agent_secrets) is a valid credential too.
+    // Without this, `lobu apply`-provisioned providers report no credentials,
+    // so primary-provider detection (and thus the worker's defaultProvider /
+    // model resolution) silently fails until the gateway is restarted.
+    return (await readOrgSharedProviderKey(this.providerId, context)) !== null;
   }
 
   hasSystemKey(): boolean {

--- a/packages/server/src/gateway/gateway/index.ts
+++ b/packages/server/src/gateway/gateway/index.ts
@@ -589,7 +589,8 @@ export class WorkerGateway {
         agentId || "",
         resolveEffectiveModelRef(agentSettings),
         baseUrl,
-        auth.token
+        auth.token,
+        auth.tokenData.organizationId
       );
 
       // Fetch enabled skills with content for worker filesystem sync
@@ -712,7 +713,8 @@ export class WorkerGateway {
     agentId: string,
     agentModel?: string,
     requestBaseUrl?: string,
-    workerToken?: string
+    workerToken?: string,
+    organizationId?: string
   ): Promise<{
     credentialEnvVarName?: string;
     defaultProvider?: string;
@@ -751,7 +753,7 @@ export class WorkerGateway {
       for (const candidate of effectiveProviders) {
         if (
           candidate.hasSystemKey() ||
-          (await candidate.hasCredentials(agentId))
+          (await candidate.hasCredentials(agentId, { organizationId }))
         ) {
           primaryProvider = candidate;
           break;
@@ -802,7 +804,10 @@ export class WorkerGateway {
     // the worker token so their placeholder *is* a verifiable credential.
     const credentialPlaceholders: Record<string, string> = {};
     for (const provider of effectiveProviders) {
-      if (provider.hasSystemKey() || (await provider.hasCredentials(agentId))) {
+      if (
+        provider.hasSystemKey() ||
+        (await provider.hasCredentials(agentId, { organizationId }))
+      ) {
         const credVar = provider.getCredentialEnvVarName();
         const placeholder = provider.buildCredentialPlaceholder
           ? await provider.buildCredentialPlaceholder(agentId, { workerToken })


### PR DESCRIPTION
## Problem

After `lobu apply` against a **running** embedded `lobu run` server, a new `lobu chat` session kept using the previously-selected provider/model until `lobu run` was restarted. In fact, an `lobu apply`-provisioned provider often never resolved at all — the worker errored with `No provider specified for model "glm-4.6"`.

## Root cause

`BaseProviderModule.hasCredentials` only checked per-user `auth_profiles`. It ignored the **org-shared API key** that `lobu apply` writes to `agent_secrets` (`provider:<id>:apiKey`). `buildEnvVars` already falls back to that org-shared key when injecting credentials, but `hasCredentials` did not.

As a result, the session-context primary-provider detection in `resolveProviderConfig` (`gateway/index.ts`) found no credentialed provider and returned `defaultProvider: none`. The CLI and the web UI both store model preferences as a **bare** model ref (e.g. `glm-4.6`, no `provider/` prefix), so the worker's `resolveModelRef("glm-4.6", { defaultProvider: "" })` threw `No provider specified for model "glm-4.6"`. The model was effectively pinned to whatever the first successful resolution produced until the gateway restarted.

Agent settings are read fresh from Postgres per message (`resolveAgentOptions` → `getSettings`, no caching), so once the provider resolves correctly, both the first session and any re-applied model take effect on the next session with no restart.

## Fix

- `hasCredentials` now also recognizes an org-shared provider key (the same source `buildEnvVars` already uses), so `lobu apply`-provisioned providers report credentials.
- Thread the worker token's `organizationId` into `resolveProviderConfig` and its `hasCredentials` calls. The worker session-context endpoint runs outside the org-scoped HTTP middleware's AsyncLocalStorage, so passing the org explicitly makes the `agent_secrets` lookup reliable.

## Reproducer (red → green)

Embedded `lobu run` on a clean DB, agent `hotreload-test` with one z-ai provider, `model = "glm-4.6"`. Single server process throughout (worker `lobu-worker-api-4c5447d606e`), no restart.

**RED (before fix)** — first chat after apply:
```
[platform-helpers] Applying agent settings {"agentId":"hotreload-test","effectiveModel":"glm-4.6"}
[worker-gateway] Session context for hotreload-test: ... provider: none
[api-response-renderer] Broadcast error: No provider specified for model "glm-4.6". Use "provider/model" format or set AGENT_DEFAULT_PROVIDER.
```

**GREEN (after fix)** — chat 1 (`glm-4.6`), then edit `lobu.toml` → `glm-4.5`, `lobu apply` against the **running** server (incremental `~ settings hotreload-test (providerModelPreferences)`), then a new chat — no `lobu run` restart:
```
# chat 1
[platform-helpers] Applying agent settings {"agentId":"hotreload-test","effectiveModel":"glm-4.6"}
[orchestrator] Selected primary provider {"agentId":"hotreload-test","primaryProviderId":"z-ai","slug":"z-ai"}
[worker] Starting OpenClaw session: provider=zai, model=glm-4.6, tools=7, customTools=28

# lobu apply  →  ~ settings hotreload-test (providerModelPreferences)   (running server, no restart)

# chat 2 (same server pid, same worker)
[platform-helpers] Applying agent settings {"agentId":"hotreload-test","effectiveModel":"glm-4.5"}
[worker] Starting OpenClaw session: provider=zai, model=glm-4.5, tools=7, customTools=28
```

Model switched `glm-4.6` → `glm-4.5` for the next session with no restart.

## Validation

- `bunx tsc --noEmit` (packages/server) — clean.
- `make build-packages` + `packages/cli` build — green.
- New unit test `base-provider-module-credentials.test.ts` (4 pass) covers: profile present, org-shared key only (the apply path, via explicit org + ALS fallback), neither present, and no-org short-circuit.
- E2E above run end-to-end against an embedded `lobu run` (Node 22, z-ai / glm-4.6 → glm-4.5).

Note: the 2 pre-existing failures in `api-auth-middleware.test.ts` (ENCRYPTION_KEY rotation / agent-scoped token isolation) fail identically at HEAD and don't reference any code in this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Organization-shared provider API keys now serve as a fallback credential option when individual user credentials are unavailable, enabling more flexible credential management.
  * Provider configuration selection and credential eligibility are now organization-aware, allowing better context-specific handling across shared environments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lobu-ai/lobu/pull/993?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->