### PR TITLE
fix(watchers): malformed array literal swallows chat replies

### DIFF
--- a/packages/server/src/watchers/run-completion.ts
+++ b/packages/server/src/watchers/run-completion.ts
@@ -1,5 +1,5 @@
 import type { DbClient } from '../db/client';
-import { getDb } from '../db/client';
+import { getDb, pgTextArray } from '../db/client';
 import { ACTIVE_RUN_STATUSES, runStatusLiteral } from '../utils/run-statuses';
 
 export type WatcherTerminalResult = { ok: true } | { ok: false; error: string };
@@ -60,7 +60,7 @@ export async function resolveWatcherRunsByMessageIds(
     SELECT id
     FROM runs
     WHERE run_type = 'watcher'
-      AND dispatched_message_id = ANY(${ids}::text[])
+      AND dispatched_message_id = ANY(${pgTextArray(ids)}::text[])
       AND status = ANY(${runStatusLiteral(ACTIVE_RUN_STATUSES)}::text[])
   `;
 


### PR DESCRIPTION
## Problem
`resolveWatcherRunsByMessageIds` (run on **every** terminal chat payload by `api-response-renderer`) built `dispatched_message_id = ANY(${ids}::text[])` from a raw JS array. The bundled `postgres.js` serializes that parameter as a bare scalar (the message UUID), so Postgres rejects it:

```
ERROR: malformed array literal: "3b50ef02-64f5-47c1-bcdc-d93b04e8a69f"
  detail: Array value must start with "{"   where: $1 = '<uuid>'
[api-response-renderer] Failed to resolve watcher runs from terminal API payload
```

Because it throws in the response-render path, it **intermittently swallows the final CLI render** of an otherwise-successful chat. Every other call site in the codebase uses the canonical `ANY(${pg*Array(...)}::type[])` (string-literal helper + cast); this was the lone raw-array usage.

## Fix
Wrap `ids` with `pgTextArray(ids)` (already exported from `db/client.ts`), matching `runStatusLiteral`/`pgBigintArray` usage everywhere else. 2-line change.

## Reproducer (red → green, real bundled server, embedded Postgres)
- **RED** (unfixed `main` build): a `lobu chat` turn logs `malformed array literal: "<uuid>"` + `Failed to resolve watcher runs from terminal API payload` (Postgres `22P02`).
- **GREEN** (this branch): same chat → **0** such errors; `Session completed successfully - all content already streamed`.

Note: a standalone `postgres.js` repro did **not** reproduce it (it serialized the JS array correctly) — the bug only manifests through the esbuild-bundled server, which is why the E2E was run against the actual `lobu run` build.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced database query parameterization for watcher run operations to improve consistency and reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lobu-ai/lobu/pull/994?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->