### PR TITLE
docs(agents): stop inlining DESIGN_GUIDELINES into every context

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,7 +28,7 @@ bun install --frozen-lockfile
 If that rewrites `bun.lock`, commit the regenerated lockfile in the same change.
 
 ### Frontend (owletto)
-When editing UI under `packages/owletto`, follow the design rules in @packages/owletto/DESIGN_GUIDELINES.md — confirmations, surfaces, empty states, selection, forms, page copy, radius, Sheet vs Dialog. Match the existing components and exemplar files referenced there; do not introduce new primitives without updating the guideline in the same PR.
+When editing UI under `packages/owletto`, first read `packages/owletto/DESIGN_GUIDELINES.md` (NOT auto-loaded — read it before UI changes) and follow its rules: confirmations, surfaces, empty states, selection, forms, page copy, radius, Sheet vs Dialog. Match the existing components and exemplar files referenced there; do not introduce new primitives without updating the guideline in the same PR.
 
 ### Architecture
 


### PR DESCRIPTION
`CLAUDE.md` → `@AGENTS.md` (196 lines) → `@packages/owletto/DESIGN_GUIDELINES.md` (150 lines) loads into **every** session and re-injects per worktree. The web-UI design doc is dead weight for all backend/infra/DB/CLI work.

Drops the `@` on the DESIGN_GUIDELINES reference so it's read on-demand for owletto UI work only. Always-on chain is now just CLAUDE.md → AGENTS.md (−150 lines/load).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated agent guidelines for UI editing to streamline the design guidelines reference process.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lobu-ai/lobu/pull/995?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->