### PR TITLE
fix(cli): vendor private @lobu/pgvector-embedded into the CLI tarball (unblocks publish)

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -43,7 +43,6 @@
     "@lobu/connector-worker": "workspace:*",
     "@lobu/core": "workspace:*",
     "@lobu/embeddings": "workspace:*",
-    "@lobu/pgvector-embedded": "workspace:*",
     "@lobu/worker": "workspace:*",
     "@mariozechner/pi-ai": "^0.51.6",
     "@modelcontextprotocol/sdk": "^1.27.1",
@@ -98,6 +97,7 @@
   },
   "devDependencies": {
     "@types/node": "^20.0.0",
+    "@lobu/pgvector-embedded": "workspace:*",
     "typescript": "^5.8.3"
   },
   "files": [

--- a/packages/cli/scripts/build.cjs
+++ b/packages/cli/scripts/build.cjs
@@ -67,3 +67,33 @@ for (const bundleName of ["server.bundle.mjs"]) {
     );
   }
 }
+
+// Vendor @lobu/pgvector-embedded into the CLI tarball. It's `private` (never
+// published) but the bundled server needs it at runtime for embedded Postgres
+// + pgvector. esbuild can't inline its prebuilt native binaries, so we ship
+// the package's dist + prebuilt under dist/vendor/ (NOT node_modules, which
+// npm strips from tarballs). embedded-runtime.ts loads this copy by path when
+// the bare specifier isn't resolvable (i.e. in the published CLI). The `bun`
+// export condition is stripped so a bun runtime resolves dist/index.js rather
+// than the src/ that doesn't ship.
+const pgvSrc = "../pgvector-embedded";
+const pgvDest = "dist/vendor/pgvector-embedded";
+if (fs.existsSync(`${pgvSrc}/dist`) && fs.existsSync(`${pgvSrc}/prebuilt`)) {
+  copyDirIfExists(`${pgvSrc}/dist`, `${pgvDest}/dist`);
+  copyDirIfExists(`${pgvSrc}/prebuilt`, `${pgvDest}/prebuilt`);
+  const pgvPkg = JSON.parse(fs.readFileSync(`${pgvSrc}/package.json`, "utf8"));
+  if (pgvPkg.exports?.["."]?.bun) {
+    delete pgvPkg.exports["."].bun;
+  }
+  fs.mkdirSync(pgvDest, { recursive: true });
+  fs.writeFileSync(
+    `${pgvDest}/package.json`,
+    `${JSON.stringify(pgvPkg, null, 2)}\n`
+  );
+} else {
+  console.warn(
+    `[cli build] @lobu/pgvector-embedded dist/prebuilt missing at ${pgvSrc}; ` +
+      "embedded-Postgres pgvector will be unavailable in `lobu run`. Run " +
+      "`bun run --filter '@lobu/pgvector-embedded' build` (binaries are committed)."
+  );
+}

--- a/packages/cli/src/__tests__/dev.test.ts
+++ b/packages/cli/src/__tests__/dev.test.ts
@@ -99,10 +99,18 @@ describe("lobu run backend bundle resolution", () => {
       expect(cliRuntimeDeps[name]).toBeDefined();
     }
 
-    // @lobu/pgvector-embedded is the one @lobu/* dep the bundle keeps EXTERNAL
-    // (it ships prebuilt binary assets esbuild can't inline), so the published
-    // CLI must declare it explicitly.
-    expect(cliRuntimeDeps["@lobu/pgvector-embedded"]).toBeDefined();
+    // @lobu/pgvector-embedded ships prebuilt native binaries esbuild can't
+    // inline, and it's `private` (never published). It must therefore NOT be a
+    // runtime/registry dependency of the published CLI — otherwise
+    // `npm i @lobu/cli` would 404 on it. Instead build.cjs vendors it into
+    // dist/vendor/pgvector-embedded, and embedded-runtime.ts loads it from
+    // there when the bare specifier isn't resolvable.
+    expect(cliRuntimeDeps["@lobu/pgvector-embedded"]).toBeUndefined();
+    const cliBuildScript = readFileSync(
+      join(repoRoot, "packages", "cli", "scripts", "build.cjs"),
+      "utf8"
+    );
+    expect(cliBuildScript).toContain("dist/vendor/pgvector-embedded");
 
     // Compiled connector code deliberately leaves these native/browser deps
     // external, so npx-installed CLIs must provide them too.

--- a/packages/pgvector-embedded/package.json
+++ b/packages/pgvector-embedded/package.json
@@ -22,9 +22,7 @@
   "engines": {
     "node": ">=20"
   },
-  "publishConfig": {
-    "access": "public"
-  },
+  "private": true,
   "repository": {
     "type": "git",
     "url": "git+https://github.com/lobu-ai/lobu.git",

--- a/packages/server/src/embedded-runtime.ts
+++ b/packages/server/src/embedded-runtime.ts
@@ -27,6 +27,36 @@ import logger from "./utils/logger";
 const APP_ROOT = join(fileURLToPath(new URL(".", import.meta.url)), "..");
 const require = createRequire(import.meta.url);
 
+/**
+ * Load `@lobu/pgvector-embedded`. It is a `private` package that is never
+ * published to npm. In the monorepo / dev it resolves from `node_modules`
+ * (workspace dev-dependency), but the published `@lobu/cli` ships it vendored
+ * under the server bundle's `dist/vendor/` (copied by the CLI `build.cjs`)
+ * because esbuild can't inline its prebuilt native binaries. Try the bare
+ * specifier first; on failure (the published CLI, where it isn't in
+ * node_modules) load the vendored copy by path relative to this bundle.
+ *
+ * AGENTS.md dynamic-import allow-list: `embedded-runtime.ts` already lazy-loads
+ * `@lobu/pgvector-embedded`; the vendored-path fallback below loads the SAME
+ * dependency from the CLI tarball instead of node_modules — no new dependency,
+ * same lazy-on-embedded-path cost profile.
+ */
+async function importPgvectorEmbedded(): Promise<
+	typeof import("@lobu/pgvector-embedded")
+> {
+	try {
+		return await import("@lobu/pgvector-embedded");
+	} catch {
+		const vendored = new URL(
+			"./vendor/pgvector-embedded/dist/index.js",
+			import.meta.url
+		).href;
+		return (await import(
+			vendored
+		)) as typeof import("@lobu/pgvector-embedded");
+	}
+}
+
 export interface EmbeddedRuntime {
 	/** TCP URL of the spawned cluster; already written to process.env.DATABASE_URL. */
 	databaseUrl: string;
@@ -96,9 +126,8 @@ export async function startEmbeddedRuntime(): Promise<EmbeddedRuntime> {
 	// Heavy deps stay behind dynamic import so the external/prod path never
 	// loads the embedded-postgres binary resolution or the pgvector injector.
 	const { default: EmbeddedPostgres } = await import("embedded-postgres");
-	const { injectPgvector, resolveEmbeddedNativeDir } = await import(
-		"@lobu/pgvector-embedded"
-	);
+	const { injectPgvector, resolveEmbeddedNativeDir } =
+		await importPgvectorEmbedded();
 
 	// embedded-postgres bundles pg_trgm but not pgvector — inject the host
 	// platform's prebuilt vector library into the binary tree before boot

--- a/scripts/publish-packages.mjs
+++ b/scripts/publish-packages.mjs
@@ -24,8 +24,12 @@ const PACKAGES = [
   { dir: "packages/connector-sdk", transform: rewriteWorkspaceRefs },
   { dir: "packages/agent-worker", transform: rewriteWorkspaceRefs },
   { dir: "packages/embeddings", transform: rewriteWorkspaceRefs },
-  // Before cli — cli depends on @lobu/pgvector-embedded (workspace:*).
-  { dir: "packages/pgvector-embedded", transform: rewriteWorkspaceRefs },
+  // @lobu/pgvector-embedded is NOT published: it's `private` and ships its
+  // prebuilt native binaries inside the @lobu/cli tarball (build.cjs copies it
+  // to dist/vendor/pgvector-embedded), so the bundled server resolves it at
+  // runtime without a registry fetch. esbuild can't inline the native
+  // binaries, hence it stays a runtime sidecar rather than part of
+  // server.bundle.mjs.
   { dir: "packages/cli", transform: rewriteWorkspaceRefs },
   {
     dir: "packages/openclaw-plugin",


### PR DESCRIPTION
## Why
`@lobu/pgvector-embedded` ships prebuilt native pgvector binaries that esbuild can't inline, so it's kept external and (added after 8.0.0) became a CLI runtime dependency for `lobu run`'s embedded-Postgres path. It was **never published to npm**, so the **9.0.0 publish 404'd** on it and `@lobu/cli` never shipped 9.0.0 (npm `latest` stayed 8.0.0; 8.0.0 predates the dep, so it's unaffected/installable).

Publishing it publicly doesn't make sense — it's an internal vendored-pgvector package.

## What
- `@lobu/pgvector-embedded` → `private: true`; removed from the publish `PACKAGES` list.
- `build.cjs` vendors its `dist`+`prebuilt` into the CLI tarball under **`dist/vendor/pgvector-embedded`** (npm strips `node_modules` from tarballs, so `bundledDependencies` isn't viable with Bun's workspace hoisting — verified). The `bun` export condition is stripped so a bun runtime resolves `dist/index.js`.
- `embedded-runtime.ts` imports the bare specifier in dev (workspace `node_modules`) and **falls back to the vendored path** in the published CLI.
- It stays a CLI **devDependency** (linked in dev, stripped from consumer installs).

## Verified (E2E, separate directory)
- CLI tarball (`bun pm pack`) ships `dist/vendor/pgvector-embedded` with all 4 platform binaries + SQL + control; **0** `node_modules` entries leaked.
- From `/tmp` with **no ancestor `node_modules`**, the bare specifier fails and the **vendored copy loads via the fallback** (`injectPgvector`/`resolveEmbeddedNativeDir` resolved; `hasPrebuilt(darwin-arm64)=true`).
- `lobu run` boots embedded Postgres and **completes migrations** (pgvector injected from the vendored copy).

After merge, the next release (cut as **9.1.0** via `Release-As:`) will publish `@lobu/cli@9.1.0` successfully (pgvector no longer in the publish set).

Note: `embedded-runtime.ts` is already on the dynamic-import allow-list for lazy-loading `@lobu/pgvector-embedded`; the vendored-path fallback loads the same dependency from the CLI tarball — rationale documented at the call site.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * pgvector-embedded is now private and bundled with the CLI tarball instead of published separately.
  * CLI build was updated to vendor the pgvector runtime into the distributed package and warn if vendored assets are missing.
  * Publish tooling now omits the pgvector-embedded package from npm publish.

* **Tests**
  * CLI tests updated to verify vendoring behavior and that pgvector-embedded is not a runtime dependency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lobu-ai/lobu/pull/1000?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->