### PR TITLE
fix(cli): build pgvector-embedded in publish chain so it vendors (fixes broken 9.1.0)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -17,7 +17,7 @@
     },
     "packages/agent-worker": {
       "name": "@lobu/worker",
-      "version": "8.0.0",
+      "version": "9.1.0",
       "bin": {
         "lobu-worker": "./dist/index.js",
       },
@@ -44,7 +44,7 @@
     },
     "packages/cli": {
       "name": "@lobu/cli",
-      "version": "8.0.0",
+      "version": "9.1.0",
       "bin": {
         "lobu": "bin/lobu.js",
       },
@@ -67,7 +67,6 @@
         "@lobu/connector-worker": "workspace:*",
         "@lobu/core": "workspace:*",
         "@lobu/embeddings": "workspace:*",
-        "@lobu/pgvector-embedded": "workspace:*",
         "@lobu/worker": "workspace:*",
         "@mariozechner/pi-ai": "^0.51.6",
         "@modelcontextprotocol/sdk": "^1.27.1",
@@ -120,6 +119,7 @@
         "zod": "^4.1.12",
       },
       "devDependencies": {
+        "@lobu/pgvector-embedded": "workspace:*",
         "@types/node": "^20.0.0",
         "typescript": "^5.8.3",
       },
@@ -129,7 +129,7 @@
     },
     "packages/connector-sdk": {
       "name": "@lobu/connector-sdk",
-      "version": "8.0.0",
+      "version": "9.1.0",
       "dependencies": {
         "@lobu/core": "workspace:*",
         "@sinclair/typebox": "^0.34.41",
@@ -153,7 +153,7 @@
     },
     "packages/connector-worker": {
       "name": "@lobu/connector-worker",
-      "version": "8.0.0",
+      "version": "9.1.0",
       "bin": {
         "connector-worker": "./dist/bin.js",
       },
@@ -176,7 +176,7 @@
     },
     "packages/connectors": {
       "name": "@lobu/connectors",
-      "version": "8.0.0",
+      "version": "9.1.0",
       "dependencies": {
         "@lobu/connector-sdk": "workspace:*",
         "baileys": "7.0.0-rc.9",
@@ -190,7 +190,7 @@
     },
     "packages/core": {
       "name": "@lobu/core",
-      "version": "8.0.0",
+      "version": "9.1.0",
       "dependencies": {
         "@opentelemetry/api": "^1.9.0",
         "@opentelemetry/exporter-trace-otlp-grpc": "^0.57.0",
@@ -209,7 +209,7 @@
     },
     "packages/embeddings": {
       "name": "@lobu/embeddings",
-      "version": "8.0.0",
+      "version": "9.1.0",
       "dependencies": {
         "@hono/node-server": "^1.13.7",
         "@xenova/transformers": "^2.17.2",
@@ -241,7 +241,7 @@
     },
     "packages/openclaw-plugin": {
       "name": "@lobu/openclaw-plugin",
-      "version": "8.0.0",
+      "version": "9.1.0",
       "dependencies": {
         "@lobu/core": "workspace:*",
       },
@@ -326,7 +326,7 @@
     },
     "packages/pgvector-embedded": {
       "name": "@lobu/pgvector-embedded",
-      "version": "8.0.0",
+      "version": "9.1.0",
       "devDependencies": {
         "@types/node": "20.19.9",
         "typescript": "^5.7.2",
@@ -334,7 +334,7 @@
     },
     "packages/promptfoo-provider": {
       "name": "@lobu/promptfoo-provider",
-      "version": "8.0.0",
+      "version": "9.1.0",
       "devDependencies": {
         "@types/node": "^20.10.0",
         "typescript": "^5.3.3",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "test:coverage": "bun test packages/core/src packages/agent-worker/src packages/landing/src --coverage",
     "typecheck": "tsc --noEmit",
     "dev": "./scripts/dev-native.sh",
-    "build:packages": "cd packages/core && bun run build && cd ../connector-sdk && bun run build && cd ../agent-worker && bun run build && cd ../openclaw-plugin && bun run build && cd ../embeddings && bun run build && cd ../connector-worker && bun run build && cd ../promptfoo-provider && bun run build && cd ../server && bun run build:server && cd .. && if [ -f owletto/package.json ]; then (cd owletto && bun run build); else echo '[build:packages] owletto submodule absent — CLI ships headless (API only)'; fi && cd cli && bun run build",
+    "build:packages": "cd packages/core && bun run build && cd ../pgvector-embedded && bun run build && cd ../connector-sdk && bun run build && cd ../agent-worker && bun run build && cd ../openclaw-plugin && bun run build && cd ../embeddings && bun run build && cd ../connector-worker && bun run build && cd ../promptfoo-provider && bun run build && cd ../server && bun run build:server && cd .. && if [ -f owletto/package.json ]; then (cd owletto && bun run build); else echo '[build:packages] owletto submodule absent — CLI ships headless (API only)'; fi && cd cli && bun run build",
     "build:lobu": "cd packages/embeddings && bun run build && cd ../..",
     "watch:packages": "tsc -b --watch packages/core packages/agent-worker",
     "test:packages": "cd packages/core && bun run test && cd ../agent-worker && bun run test",

--- a/packages/cli/scripts/build.cjs
+++ b/packages/cli/scripts/build.cjs
@@ -78,7 +78,13 @@ for (const bundleName of ["server.bundle.mjs"]) {
 // than the src/ that doesn't ship.
 const pgvSrc = "../pgvector-embedded";
 const pgvDest = "dist/vendor/pgvector-embedded";
-if (fs.existsSync(`${pgvSrc}/dist`) && fs.existsSync(`${pgvSrc}/prebuilt`)) {
+function vendorPgvector() {
+  if (
+    !fs.existsSync(`${pgvSrc}/dist`) ||
+    !fs.existsSync(`${pgvSrc}/prebuilt`)
+  ) {
+    return false;
+  }
   copyDirIfExists(`${pgvSrc}/dist`, `${pgvDest}/dist`);
   copyDirIfExists(`${pgvSrc}/prebuilt`, `${pgvDest}/prebuilt`);
   const pgvPkg = JSON.parse(fs.readFileSync(`${pgvSrc}/package.json`, "utf8"));
@@ -90,10 +96,17 @@ if (fs.existsSync(`${pgvSrc}/dist`) && fs.existsSync(`${pgvSrc}/prebuilt`)) {
     `${pgvDest}/package.json`,
     `${JSON.stringify(pgvPkg, null, 2)}\n`
   );
-} else {
-  console.warn(
-    `[cli build] @lobu/pgvector-embedded dist/prebuilt missing at ${pgvSrc}; ` +
-      "embedded-Postgres pgvector will be unavailable in `lobu run`. Run " +
-      "`bun run --filter '@lobu/pgvector-embedded' build` (binaries are committed)."
+  return true;
+}
+if (!vendorPgvector()) {
+  // Fail HARD (don't warn-and-skip): the package is `private` (never
+  // published), so a CLI shipped without the vendored copy silently breaks
+  // `lobu run` embedded Postgres — exactly the 9.1.0 regression this guards.
+  // pgvector-embedded is built by `bun run build:packages` (and
+  // `make build-packages`) before the CLI; build it first if you hit this.
+  throw new Error(
+    `[cli build] could not vendor @lobu/pgvector-embedded: dist/prebuilt missing at ${pgvSrc}. ` +
+      "Run `bun run build:packages` (it builds pgvector-embedded before the CLI). " +
+      "The published CLI needs it for `lobu run` embedded Postgres and it is not on npm."
   );
 }


### PR DESCRIPTION
## Problem
`@lobu/cli@9.1.0` shipped with **0** pgvector files → its zero-config `lobu run` (embedded Postgres) is broken. (External-`DATABASE_URL` `lobu run` is unaffected; `8.0.0` is fully fine.)

## Root cause
`@lobu/pgvector-embedded` is `private` (never published) and ships **inside** the `@lobu/cli` tarball — `build.cjs` copies its `dist`+`prebuilt` into `dist/vendor/`, exactly like it already vendors `server.bundle.mjs` (private `@lobu/server`), the owletto SPA, and migrations. But the publish build chain (`build:packages`) **never built `pgvector-embedded`**, so in CI its `dist` was missing and the copy silently produced nothing (it only `console.warn`'d).

## Fix
1. Add `pgvector-embedded` to `build:packages` so it's built before the CLI — consistent with `@lobu/server`'s `build:server`.
2. `build.cjs` now **throws** (fails the build) instead of warn-and-skip when pgvector isn't built — so a CLI can never silently ship without it again.
3. Re-lock `bun.lock` to the current `9.1.0` workspace versions (origin/main's was stale from the release bump + the pgvector devDep move in #1000).

## Verified
From a clean state (pgvector `dist` wiped to mimic CI): `bun run build:packages` builds it and the CLI ends up with `dist/vendor/pgvector-embedded` (all 4 platform binaries). Earlier (#1000) I also verified the vendored copy loads via the runtime fallback with no ancestor `node_modules`.

Ships as **9.1.1** (`fix:`), which becomes npm `latest` and supersedes the broken 9.1.0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Build workflow now includes the embedded pgvector package so it is produced as part of standard builds.
  * Build reliability improved: vendoring of the embedded package is strictly enforced so builds fail fast if the embedded package cannot be prepared, preventing incomplete artifacts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lobu-ai/lobu/pull/1003?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->