### PR TITLE
fix(cli): warn when apply ignores connectors

### DIFF
--- a/packages/cli/src/commands/_lib/apply/__tests__/desired-state-extra.test.ts
+++ b/packages/cli/src/commands/_lib/apply/__tests__/desired-state-extra.test.ts
@@ -144,6 +144,41 @@ entities:
     expect(state.memorySchema.entityTypes).toHaveLength(0);
     expect(state.watchers).toHaveLength(0);
   });
+
+  test("warns when connector files are present but memory is disabled", async () => {
+    const toml = `[agents.triage]
+name = "Triage"
+dir = "./agents/triage"
+
+[memory]
+enabled = false
+org = "dev"
+connectors = "./connectors"
+`;
+    const dir = mkProject(toml);
+    mkdirSync(join(dir, "connectors"), { recursive: true });
+    writeFileSync(join(dir, "connectors", ".gitkeep"), "");
+    writeFileSync(join(dir, "connectors", "acme.connector.ts"), "export {};");
+
+    const { state, warnings } = await loadDesiredState({ cwd: dir });
+    expect(state.connectors.definitions).toHaveLength(0);
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain("acme.connector.ts");
+    expect(warnings[0]).toContain("[memory] is disabled or missing");
+  });
+
+  test("does not warn for the scaffolded empty connectors directory", async () => {
+    const toml = `[agents.triage]
+name = "Triage"
+dir = "./agents/triage"
+`;
+    const dir = mkProject(toml);
+    mkdirSync(join(dir, "connectors"), { recursive: true });
+    writeFileSync(join(dir, "connectors", ".gitkeep"), "");
+
+    const { warnings } = await loadDesiredState({ cwd: dir });
+    expect(warnings).toEqual([]);
+  });
 });
 
 // ── No memory block ───────────────────────────────────────────────────────────

--- a/packages/cli/src/commands/_lib/apply/apply-cmd.ts
+++ b/packages/cli/src/commands/_lib/apply/apply-cmd.ts
@@ -1007,12 +1007,15 @@ export async function applyCommand(opts: ApplyOptions = {}): Promise<void> {
   // `lobu dev` does. Existing process.env values win (don't clobber the shell).
   await loadProjectEnvFile(cwd);
 
-  const { state, configPath } = await loadDesiredState({
+  const { state, configPath, warnings } = await loadDesiredState({
     cwd,
     ...(opts.only ? { only: opts.only } : {}),
   });
 
   printText(chalk.dim(`Config: ${configPath}`));
+  for (const warning of warnings) {
+    printText(chalk.yellow(`Warning: ${warning}`));
+  }
 
   // Required secrets gate: fail before any network mutation.
   const { missing } = checkRequiredSecrets(state);

--- a/packages/cli/src/commands/_lib/apply/desired-state.ts
+++ b/packages/cli/src/commands/_lib/apply/desired-state.ts
@@ -1,6 +1,6 @@
-import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { existsSync, readdirSync, readFileSync, type Dirent } from "node:fs";
 import { readdir, readFile, stat } from "node:fs/promises";
-import { join, resolve } from "node:path";
+import { join, relative, resolve } from "node:path";
 import type {
   ConnectorAuthSchema,
   ConnectorDefinition,
@@ -1442,6 +1442,38 @@ const EMPTY_CONNECTORS: LoadedConnectors = {
   connections: [],
 };
 
+function isConnectorDeclarationFile(name: string): boolean {
+  return (
+    name.endsWith(".connector.ts") ||
+    name.endsWith(".yaml") ||
+    name.endsWith(".yml")
+  );
+}
+
+async function findIgnoredConnectorFiles(
+  config: LobuTomlConfig,
+  projectRoot: string
+): Promise<string[]> {
+  const mem = config.memory;
+  if (mem && mem.enabled !== false) return [];
+
+  const dirRel = mem?.connectors?.trim() || "./connectors";
+  const dirPath = resolve(projectRoot, dirRel);
+  let entries: Dirent[];
+  try {
+    entries = await readdir(dirPath, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+
+  return entries
+    .filter((entry) => entry.isFile() && isConnectorDeclarationFile(entry.name))
+    .map(
+      (entry) => relative(projectRoot, join(dirPath, entry.name)) || entry.name
+    )
+    .sort();
+}
+
 /**
  * Load the `[memory].connectors` directory:
  *  - every `*.connector.ts` is auto-discovered as a connector definition
@@ -1918,7 +1950,7 @@ export interface LoadDesiredStateOptions {
 
 export async function loadDesiredState(
   opts: LoadDesiredStateOptions
-): Promise<{ state: DesiredState; configPath: string }> {
+): Promise<{ state: DesiredState; configPath: string; warnings: string[] }> {
   const result = await loadConfig(opts.cwd);
   if (isLoadError(result)) {
     const detail = result.details?.length
@@ -1929,6 +1961,15 @@ export async function loadDesiredState(
 
   const { config, path: configPath } = result;
   await rejectUnsupportedAgentShapes(opts.cwd);
+
+  const ignoredConnectorFiles = opts.only
+    ? []
+    : await findIgnoredConnectorFiles(config, opts.cwd);
+  const warnings = ignoredConnectorFiles.length
+    ? [
+        `Ignored ${ignoredConnectorFiles.length} connector ${ignoredConnectorFiles.length === 1 ? "file" : "files"} because [memory] is disabled or missing: ${ignoredConnectorFiles.join(", ")}. Enable [memory] (enabled = true) for lobu apply to load connectors/.`,
+      ]
+    : [];
 
   const env = opts.env ?? process.env;
   const requiredSecrets = new Set<string>();
@@ -2005,5 +2046,6 @@ export async function loadDesiredState(
       requiredSecrets: [...requiredSecrets].sort(),
     },
     configPath,
+    warnings,
   };
 }


### PR DESCRIPTION
## Summary
- warn during `lobu apply` when connector declaration files exist but `[memory]` is disabled or missing
- keep fresh scaffolded `connectors/.gitkeep` quiet
- add regression coverage for disabled-memory connector warnings

Fixes #1009

## Tests
- `bun test packages/cli/src/commands/_lib/apply/__tests__/desired-state-extra.test.ts`
- `bunx biome check --config-path config/biome.config.json packages/cli/src/commands/_lib/apply/desired-state.ts packages/cli/src/commands/_lib/apply/apply-cmd.ts packages/cli/src/commands/_lib/apply/__tests__/desired-state-extra.test.ts`
- pre-commit: `tsc --noEmit`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * CLI now displays warnings when connector files are present but memory functionality is disabled, clarifying which files are ignored.

* **Tests**
  * Added test coverage for warning behavior when memory is disabled.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lobu-ai/lobu/pull/1010?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->