### PR TITLE
fix(server): register local device-worker capabilities even when poll is anonymous

### DIFF
--- a/packages/server/src/__tests__/integration/auth/anonymous-device-registration.test.ts
+++ b/packages/server/src/__tests__/integration/auth/anonymous-device-registration.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Local/personal-install device-worker registration on an *anonymous* poll.
+ *
+ * When WORKER_API_TOKEN is unset, a device-worker poll whose token fails auth
+ * doesn't 401 — the /api/workers/* middleware degrades it to `anonymous`. The
+ * fix (worker-api.ts) re-anchors such a poll to the user that already owns the
+ * posted worker_id in a non-cloud install, so the device_workers capability
+ * registration (which drives connector wiring) still happens. Cloud
+ * (LOBU_CLOUD_MODE) must stay strict.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { generateSecureToken } from '../../../auth/oauth/utils';
+import { cleanupTestDatabase, getTestDb } from '../../setup/test-db';
+import { post } from '../../setup/test-helpers';
+
+async function seedDeviceOwner(opts: { caps?: Record<string, boolean>; appVersion?: string }) {
+  const sql = getTestDb();
+  const orgId = `org-anon-${generateSecureToken(4)}`;
+  const slug = orgId.toLowerCase();
+  const userId = `user_${generateSecureToken(4)}`;
+  const workerId = `wk-${generateSecureToken(6)}`;
+  await sql`
+    INSERT INTO "organization" (id, name, slug, visibility, "createdAt")
+    VALUES (${orgId}, ${orgId}, ${slug}, 'private', NOW())
+    ON CONFLICT (id) DO NOTHING
+  `;
+  await sql`
+    INSERT INTO "user" (id, name, email, "emailVerified", "createdAt", "updatedAt")
+    VALUES (${userId}, 'Anon Owner', ${`${userId}@test.local`}, true, NOW(), NOW())
+    ON CONFLICT (id) DO NOTHING
+  `;
+  await sql`
+    INSERT INTO device_workers (user_id, worker_id, platform, app_version, capabilities, label, organization_id)
+    VALUES (${userId}, ${workerId}, 'macos', ${opts.appVersion ?? '1.0.0'}, ${sql.json(Object.keys(opts.caps ?? {}))}, 'Mac', ${orgId})
+  `;
+  return { orgId, userId, workerId };
+}
+
+async function readDevice(workerId: string) {
+  const sql = getTestDb();
+  const rows = (await sql`
+    SELECT app_version, capabilities FROM device_workers WHERE worker_id = ${workerId} LIMIT 1
+  `) as unknown as Array<{ app_version: string | null; capabilities: unknown }>;
+  if (rows.length === 0) return null;
+  const caps = Array.isArray(rows[0].capabilities) ? (rows[0].capabilities as string[]) : [];
+  return { appVersion: rows[0].app_version, caps };
+}
+
+const pollBody = (workerId: string) => ({
+  worker_id: workerId,
+  capabilities: { screentime: true },
+  platform: 'macos',
+  app_version: '9.9.0',
+  label: 'Mac',
+});
+
+describe('anonymous device-worker registration (local/non-cloud)', () => {
+  beforeEach(async () => {
+    await cleanupTestDatabase();
+    delete process.env.LOBU_CLOUD_MODE;
+    delete process.env.WORKER_API_TOKEN;
+  });
+  afterEach(() => {
+    delete process.env.LOBU_CLOUD_MODE;
+  });
+
+  it('re-registers an existing device’s capabilities on an anonymous poll', async () => {
+    const { workerId } = await seedDeviceOwner({ caps: {}, appVersion: '8.0.0' });
+
+    const res = await post('/api/workers/poll', { body: pollBody(workerId) });
+    expect(res.status).toBe(200);
+
+    const dev = await readDevice(workerId);
+    expect(dev).not.toBeNull();
+    expect(dev?.caps).toContain('screentime');
+    expect(dev?.appVersion).toBe('9.9.0');
+  });
+
+  it('does NOT register in cloud mode — strict, no worker_id spoofing', async () => {
+    const { workerId } = await seedDeviceOwner({ caps: {}, appVersion: '8.0.0' });
+    process.env.LOBU_CLOUD_MODE = '1';
+
+    const res = await post('/api/workers/poll', { body: pollBody(workerId) });
+    expect(res.status).toBe(200);
+
+    const dev = await readDevice(workerId);
+    expect(dev?.caps).not.toContain('screentime');
+    expect(dev?.appVersion).toBe('8.0.0');
+  });
+
+  it('does not fabricate a registration for an unknown worker_id', async () => {
+    const unknown = `wk-${generateSecureToken(6)}`;
+
+    const res = await post('/api/workers/poll', { body: pollBody(unknown) });
+    expect(res.status).toBe(200);
+
+    expect(await readDevice(unknown)).toBeNull();
+  });
+});

--- a/packages/server/src/worker-api.ts
+++ b/packages/server/src/worker-api.ts
@@ -186,7 +186,42 @@ export async function pollWorkerJob(c: Context<{ Bindings: Env }>) {
   // they advertise, never the embedded-server connectors. So '' is excluded for them,
   // which means a bridge with no granted capabilities claims *nothing* instead
   // of hijacking-and-failing arbitrary embedded-server connector runs (e.g. hackernews).
-  const isUserScopedWorker = c.var.workerAuthMode === 'user';
+  // Local/personal-install fallback. When WORKER_API_TOKEN is unset, a device
+  // worker whose token fails auth doesn't 401 — the /api/workers/* middleware
+  // degrades it to `anonymous` (workerUserId = null), which previously skipped
+  // the device_workers upsert + reconcileDeviceCapabilities below, so device
+  // connectors (Screen Time, Photos, …) silently never wired up. In a non-cloud
+  // install, re-anchor an anonymous poll to the user that already owns this
+  // worker_id and treat it as a device worker END-TO-END (platform binding,
+  // capability allowlist, org-scoped claims, registration) — not as a
+  // trusted/anonymous fleet worker. Cloud (LOBU_CLOUD_MODE) stays strict: a poll
+  // must carry a user-scoped token, so a known worker_id can't be spoofed across
+  // tenants.
+  let anonLocalUserId: string | null = null;
+  let anonLocalOrgId: string | null = null;
+  if (c.var.workerAuthMode === 'anonymous' && worker_id && !isCloudMode()) {
+    const owner = (await sql`
+      SELECT user_id, organization_id FROM device_workers
+      WHERE worker_id = ${worker_id} LIMIT 1
+    `) as unknown as Array<{ user_id: string; organization_id: string | null }>;
+    if (owner.length > 0) {
+      anonLocalUserId = owner[0].user_id;
+      anonLocalOrgId = owner[0].organization_id;
+      logger.info(
+        { worker_id, user_id: anonLocalUserId },
+        '[pollWorkerJob] local (non-cloud) anonymous device poll → treating as device worker for existing owner'
+      );
+    }
+  }
+  // A re-anchored local poll is a device (user-scoped) worker for every check
+  // below, so platform binding / capability authorization / org-scoped claiming
+  // all apply exactly as for a signed-in device.
+  const isUserScopedWorker = c.var.workerAuthMode === 'user' || anonLocalUserId != null;
+  // Effective device identity: the token's user/org when user-scoped, else the
+  // re-anchored local owner.
+  const effectiveWorkerUserId = c.var.workerUserId ?? anonLocalUserId;
+  const effectiveWorkerOrgIds = c.var.workerOrgIds ?? (anonLocalOrgId ? [anonLocalOrgId] : null);
+  const effectiveTokenOrgId = c.var.organizationId ?? anonLocalOrgId;
   // User-scoped (device) callers must post a non-empty worker_id. An empty
   // or missing id would otherwise let a bound PAT (see below) sidestep the
   // binding check by claiming all worker rows under `(user_id, "")`.
@@ -217,10 +252,10 @@ export async function pollWorkerJob(c: Context<{ Bindings: Env }>) {
   // self-reported platform. We read the stored platform first, reject
   // mismatches, and use the stored value for authorization.
   let effectivePlatform: string | null = platform;
-  if (isUserScopedWorker && c.var.workerUserId && worker_id) {
+  if (isUserScopedWorker && effectiveWorkerUserId && worker_id) {
     const existing = (await sql`
       SELECT platform FROM device_workers
-      WHERE user_id = ${c.var.workerUserId} AND worker_id = ${worker_id}
+      WHERE user_id = ${effectiveWorkerUserId} AND worker_id = ${worker_id}
       LIMIT 1
     `) as unknown as Array<{ platform: string | null }>;
     if (existing.length > 0 && existing[0].platform) {
@@ -264,39 +299,12 @@ export async function pollWorkerJob(c: Context<{ Bindings: Env }>) {
   // connection is pinned to it (connections.device_worker_id) is claimable
   // regardless of the connector's required_capability — that's how an
   // otherwise-embedded connector (Reddit, …) ends up running on a chosen device.
-  const workerUserId = c.var.workerUserId;
-  // The org the device's token was issued for — the workspace the user picked on
-  // the OAuth device-authorization page. Falls back to the owner's personal
-  // workspace for tokens not bound to any org. Sets the device's home only on
-  // first registration; moving an existing device is the Devices-page action.
-  const workerTokenOrgId = c.var.organizationId ?? null;
-
-  // Local/personal-install fallback. When WORKER_API_TOKEN is unset, a device
-  // worker whose token fails auth doesn't 401 — the /api/workers/* middleware
-  // degrades it to `anonymous` (workerUserId = null). That silently skipped the
-  // registration below, so device connectors (Screen Time, Photos, …) never
-  // wired up even though the app showed "connected". In a non-cloud install,
-  // re-anchor an anonymous poll to the user that already owns this worker_id so
-  // an established local device keeps refreshing its capabilities (which drives
-  // reconcileDeviceCapabilities → connector wiring). Cloud stays strict: a poll
-  // must carry a user-scoped token to register, so a known worker_id can't be
-  // spoofed across tenants.
-  let registrationUserId = workerUserId;
-  let registrationOrgId = workerTokenOrgId;
-  if (!registrationUserId && worker_id && !isCloudMode()) {
-    const owner = (await sql`
-      SELECT user_id, organization_id FROM device_workers
-      WHERE worker_id = ${worker_id} LIMIT 1
-    `) as unknown as Array<{ user_id: string; organization_id: string | null }>;
-    if (owner.length > 0) {
-      registrationUserId = owner[0].user_id;
-      registrationOrgId = registrationOrgId ?? owner[0].organization_id;
-      logger.info(
-        { worker_id, user_id: registrationUserId },
-        '[pollWorkerJob] local (non-cloud) anonymous device poll → registering under existing owner'
-      );
-    }
-  }
+  // Device home org: the workspace the device's token was issued for (or, for a
+  // re-anchored local device, the org it already lives in). The upsert COALESCEs
+  // to the owner's personal org when null, and sets the home only on first
+  // registration; moving an existing device is the Devices-page action.
+  const registrationUserId = effectiveWorkerUserId;
+  const registrationOrgId = effectiveTokenOrgId;
 
   let deviceWorkerId: string | null = null;
   if (registrationUserId) {
@@ -393,16 +401,18 @@ export async function pollWorkerJob(c: Context<{ Bindings: Env }>) {
   // middleware. Trusted workers (matched WORKER_API_TOKEN) and anonymous
   // local-dev requests see all pending runs — preserving the existing
   // server-side worker fleet behavior.
-  const workerAuthMode = c.var.workerAuthMode;
-  const workerOrgIds = c.var.workerOrgIds;
-  if (workerAuthMode === 'user' && (!workerOrgIds || workerOrgIds.length === 0)) {
+  // Org scope applies to every device (user-scoped) worker — including a
+  // re-anchored local device, whose org is effectiveWorkerOrgIds. A signed-in
+  // worker with no org in scope can claim nothing; a re-anchored device with no
+  // org falls through to the empty-array gate (claims only by capability).
+  if (c.var.workerAuthMode === 'user' && (!effectiveWorkerOrgIds || effectiveWorkerOrgIds.length === 0)) {
     // No org in scope — nothing this worker can ever claim.
     return c.json({ next_poll_seconds: 30 });
   }
-  const orgScopeActive = workerAuthMode === 'user';
+  const orgScopeActive = isUserScopedWorker;
   // Always pass a non-empty array to ANY() to keep the SQL valid; the gate
   // below only activates when orgScopeActive is true.
-  const orgScopeIds = orgScopeActive && workerOrgIds ? workerOrgIds : [''];
+  const orgScopeIds = orgScopeActive && effectiveWorkerOrgIds ? effectiveWorkerOrgIds : [''];
 
   const claimNextPendingRun = async () =>
     sql.begin(async (tx) => {
@@ -659,7 +669,7 @@ export async function pollWorkerJob(c: Context<{ Bindings: Env }>) {
             worker_id: deviceWorkerId,
           },
           user: {
-            user_id: workerUserId ?? null,
+            user_id: effectiveWorkerUserId ?? null,
           },
         },
       },

--- a/packages/server/src/worker-api.ts
+++ b/packages/server/src/worker-api.ts
@@ -132,6 +132,19 @@ async function authorizeRunForWorker(
 }
 
 /**
+ * Truthy `LOBU_CLOUD_MODE` (`1`/`true`/`yes`, case-insensitive) marks a
+ * multi-tenant cloud deployment. Self-hosted / embedded single-tenant installs
+ * leave it unset. Mirrors the canonical reader in chat-instance-manager.ts;
+ * kept local to avoid coupling worker-api to the connections module.
+ */
+function isCloudMode(): boolean {
+  const raw = process.env.LOBU_CLOUD_MODE;
+  if (!raw) return false;
+  const v = raw.trim().toLowerCase();
+  return v === '1' || v === 'true' || v === 'yes';
+}
+
+/**
  * POST /api/workers/poll
  *
  * Worker polls for next available sync run.
@@ -257,8 +270,36 @@ export async function pollWorkerJob(c: Context<{ Bindings: Env }>) {
   // workspace for tokens not bound to any org. Sets the device's home only on
   // first registration; moving an existing device is the Devices-page action.
   const workerTokenOrgId = c.var.organizationId ?? null;
+
+  // Local/personal-install fallback. When WORKER_API_TOKEN is unset, a device
+  // worker whose token fails auth doesn't 401 — the /api/workers/* middleware
+  // degrades it to `anonymous` (workerUserId = null). That silently skipped the
+  // registration below, so device connectors (Screen Time, Photos, …) never
+  // wired up even though the app showed "connected". In a non-cloud install,
+  // re-anchor an anonymous poll to the user that already owns this worker_id so
+  // an established local device keeps refreshing its capabilities (which drives
+  // reconcileDeviceCapabilities → connector wiring). Cloud stays strict: a poll
+  // must carry a user-scoped token to register, so a known worker_id can't be
+  // spoofed across tenants.
+  let registrationUserId = workerUserId;
+  let registrationOrgId = workerTokenOrgId;
+  if (!registrationUserId && worker_id && !isCloudMode()) {
+    const owner = (await sql`
+      SELECT user_id, organization_id FROM device_workers
+      WHERE worker_id = ${worker_id} LIMIT 1
+    `) as unknown as Array<{ user_id: string; organization_id: string | null }>;
+    if (owner.length > 0) {
+      registrationUserId = owner[0].user_id;
+      registrationOrgId = registrationOrgId ?? owner[0].organization_id;
+      logger.info(
+        { worker_id, user_id: registrationUserId },
+        '[pollWorkerJob] local (non-cloud) anonymous device poll → registering under existing owner'
+      );
+    }
+  }
+
   let deviceWorkerId: string | null = null;
-  if (workerUserId) {
+  if (registrationUserId) {
     try {
       const incomingCaps = authorizedCapabilities;
 
@@ -268,11 +309,11 @@ export async function pollWorkerJob(c: Context<{ Bindings: Env }>) {
       const upserted = (await sql`
         INSERT INTO device_workers (user_id, worker_id, platform, app_version, capabilities, label, organization_id)
         VALUES (
-          ${workerUserId}, ${worker_id}, ${platform}, ${app_version},
+          ${registrationUserId}, ${worker_id}, ${platform}, ${app_version},
           ${sql.json(incomingCaps)}, ${label},
           COALESCE(
-            ${workerTokenOrgId}::text,
-            (SELECT id FROM organization WHERE (metadata::jsonb)->>'personal_org_for_user_id' = ${workerUserId} LIMIT 1)
+            ${registrationOrgId}::text,
+            (SELECT id FROM organization WHERE (metadata::jsonb)->>'personal_org_for_user_id' = ${registrationUserId} LIMIT 1)
           )
         )
         ON CONFLICT (user_id, worker_id) DO UPDATE SET
@@ -337,7 +378,7 @@ export async function pollWorkerJob(c: Context<{ Bindings: Env }>) {
       // are present (cheap fast path, also heals partially-wired state), pause
       // the ones that have gone away. The just-upserted row above is already
       // visible to this query, so the polling device's capabilities count.
-      await reconcileDeviceCapabilities(workerUserId);
+      await reconcileDeviceCapabilities(registrationUserId);
     } catch (err) {
       logger.error(
         { worker_id, err: errorMessage(err) },


### PR DESCRIPTION
## What
In a local/personal install (`WORKER_API_TOKEN` unset), a device-worker poll whose token fails `mcpAuth` does not 401 — the `/api/workers/*` middleware degrades it to `anonymous` (`workerUserId = null`). `pollWorkerJob` gated the `device_workers` upsert + `reconcileDeviceCapabilities` on `if (workerUserId)`, so an anonymous poll **silently skipped capability registration**. Device connectors (Screen Time, Photos, …) never wired up even though the app showed "connected" and the poll returned 200 — no error surfaced anywhere.

Fix: in a non-cloud install, re-anchor an anonymous poll to the user that already owns the posted `worker_id`, so an established local device keeps refreshing its capabilities (driving connector wiring). Cloud (`LOBU_CLOUD_MODE`) stays strict — a poll must carry a user-scoped token to register, so a known `worker_id` can't be spoofed across tenants. Claim semantics unchanged.

## Test
- `tsc --noEmit` (server) clean.
- Replayed an anonymous `/api/workers/poll` (no auth, real `worker_id`, advertising `screentime`) against the built gateway → `device_workers` registered `app_version` + `["screentime","photos"]`; before the fix nothing registered. Fix log line fires.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added integration test suite for anonymous device-worker registration behavior across cloud and non-cloud deployments.

* **Bug Fixes**
  * Fixed device-worker registration to properly re-anchor anonymous worker polls to existing device owners in non-cloud mode.
  * Updated capability reconciliation and organization scoping logic to respect cloud mode configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lobu-ai/lobu/pull/1017?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->