### PR TITLE
test(sdk-e2e): cover @lobu/client consumption SDK against a live lobu run

### DIFF
--- a/scripts/sdk-e2e.sh
+++ b/scripts/sdk-e2e.sh
@@ -252,6 +252,38 @@ api() {
 # Extract a JSON field from stdin with node (no jq dependency).
 jget() { node -e 'let s="";process.stdin.on("data",d=>s+=d).on("end",()=>{let v;try{v=JSON.parse(s)}catch{process.exit(2)};for(const k of process.argv[1].split("."))v=v?.[k];process.stdout.write(v==null?"":String(v))})' "$1"; }
 
+# 4b) Client SDK consumption — drive @lobu/client (the CONSUMPTION SDK) against
+#     the live gateway: create a session, send a message, stream the reply back.
+#     This is the path an external JS app takes; the rest of the gate chats via
+#     the `lobu chat` CLI, so without this the consumption SDK has no live-server
+#     coverage (only unit tests vs mocked fetch). The consumer installs the
+#     PACKED tarball into a throwaway project, proving the published artifact is
+#     self-contained (zero deps). The Agent API requires a `device_worker:run`
+#     token — an mcp PAT is rejected — so fetch the device_token from
+#     /api/local-init (the same worker PAT `lobu chat` uses via getAgentApiToken).
+CLIENT_DIR="$RUN_DIR/client-consumer"; mkdir -p "$CLIENT_DIR"
+( cd "$WT/packages/client" && bun pm pack --destination "$CLIENT_DIR" >/dev/null 2>&1 ) \
+  || fail "could not pack @lobu/client (was dist built by make build-packages?)"
+CLIENT_TGZ="$(ls "$CLIENT_DIR"/lobu-client-*.tgz 2>/dev/null | head -1)"
+[ -n "$CLIENT_TGZ" ] || fail "no @lobu/client tarball produced"
+cat > "$CLIENT_DIR/package.json" <<JSON
+{ "name": "sdk-e2e-consumer", "private": true, "type": "module", "dependencies": { "@lobu/client": "file:$CLIENT_TGZ" } }
+JSON
+cp "$HARNESS/client-consumer.mjs" "$CLIENT_DIR/consumer.mjs"
+( cd "$CLIENT_DIR" && bun install >/dev/null 2>&1 ) \
+  || fail "could not install the @lobu/client tarball into the consumer project"
+
+DEVTOKEN="$(curl -fsS -X POST "$GW/api/local-init" -H 'X-Lobu-Client: cli' | jget device_token)"
+[ -n "$DEVTOKEN" ] || fail "could not obtain an Agent-API token (device_token) from /api/local-init"
+
+CLIENT_OUT="$RUN_DIR/client-consumer.out"
+( cd "$CLIENT_DIR" && LOBU_BASE_URL="$GW/lobu" LOBU_TOKEN="$DEVTOKEN" LOBU_AGENT_ID="echo" \
+    timeout 90 node consumer.mjs > "$CLIENT_OUT" 2>&1 ) \
+  || { cat "$CLIENT_OUT" >&2; fail "@lobu/client consumer exited non-zero"; }
+grep -qF "$MOCK_REPLY" "$CLIENT_OUT" \
+  || { cat "$CLIENT_OUT" >&2; fail "@lobu/client stream did not return the agent reply '$MOCK_REPLY'"; }
+echo "✓ @lobu/client created a session, sent a message, and streamed the agent reply ($MOCK_REPLY)"
+
 # 6) Connector sync — prove the COMPILED connector actually RUNS and emits events.
 #    Find the feed manage_feeds created from the `pulse` connection, trigger an
 #    immediate sync, wait for the run to complete, then assert ≥1 event landed.

--- a/scripts/sdk-e2e/client-consumer.mjs
+++ b/scripts/sdk-e2e/client-consumer.mjs
@@ -1,0 +1,97 @@
+// Standalone @lobu/client consumer used by scripts/sdk-e2e.sh.
+//
+// Proves the CONSUMPTION SDK round-trip against a live `lobu run`: create a
+// session, send a message, and stream the agent's reply back over SSE — the
+// path an external JS app takes, distinct from the `lobu chat` CLI the rest of
+// the gate exercises. Runs from a throwaway project that installed the PACKED
+// @lobu/client tarball, so it also proves the published artifact is
+// self-contained (zero deps).
+//
+// Env: LOBU_BASE_URL (origin + /lobu), LOBU_TOKEN (Agent-API token), LOBU_AGENT_ID.
+// Prints the streamed answer to stdout; exits non-zero on an empty answer so
+// the caller can grep for the expected reply and fail the gate on a miss.
+
+import { Lobu } from "@lobu/client";
+
+const baseUrl = process.env.LOBU_BASE_URL;
+const token = process.env.LOBU_TOKEN;
+const agentId = process.env.LOBU_AGENT_ID;
+const question = process.env.LOBU_QUESTION || "say the safe word";
+
+if (!baseUrl || !token || !agentId) {
+  console.error("missing env: LOBU_BASE_URL / LOBU_TOKEN / LOBU_AGENT_ID");
+  process.exit(2);
+}
+
+const lobu = new Lobu({ baseUrl, token });
+
+const session = await lobu.sessions.create({
+  agentId,
+  userId: "sdk-e2e-consumer",
+});
+console.log(`[client] session=${session.agentId} sse=${session.sseUrl}`);
+
+const sent = await session.send(question);
+console.log(`[client] sent messageId=${sent.messageId} queued=${sent.queued}`);
+
+const ac = new AbortController();
+const timeout = setTimeout(() => ac.abort(), 90_000);
+
+let answer = "";
+let complete = false;
+try {
+  for await (const ev of session.events({
+    signal: ac.signal,
+    maxRetryAttempts: 2,
+  })) {
+    let data = ev.data;
+    if (typeof data === "string") {
+      try {
+        data = JSON.parse(data);
+      } catch {
+        // non-JSON payload — treat the raw string as content below
+      }
+    }
+    // Correlate to our message when the server tags events with a messageId.
+    if (
+      data?.messageId &&
+      sent.messageId &&
+      data.messageId !== sent.messageId
+    ) {
+      continue;
+    }
+    // Assistant text arrives as `event: output` with `data.content`. Accept a
+    // couple of fallback shapes so a benign server-side rename can't silently
+    // turn a real answer into an empty one.
+    const chunk =
+      ev.event === "output" || ev.event === "text" || ev.event === "message"
+        ? typeof data === "string"
+          ? data
+          : typeof data?.content === "string"
+            ? data.content
+            : typeof data?.text === "string"
+              ? data.text
+              : ""
+        : "";
+    if (chunk) {
+      answer += chunk;
+      process.stdout.write(chunk);
+    } else if (ev.event === "complete") {
+      complete = true;
+      break;
+    } else if (ev.event === "error") {
+      console.error(`\n[client] stream error: ${JSON.stringify(data)}`);
+      break;
+    }
+  }
+} finally {
+  clearTimeout(timeout);
+  ac.abort();
+}
+
+console.log(`\n[client] complete=${complete} answer_len=${answer.length}`);
+console.log(`[client] ANSWER: ${answer.trim()}`);
+if (!answer.trim()) {
+  console.error("[client] FAIL: empty answer via @lobu/client");
+  process.exit(1);
+}


### PR DESCRIPTION
## What

Adds a **client-SDK consumption leg** to `scripts/sdk-e2e.sh`: drive `@lobu/client` against the already-booted `lobu run` to create a session, send a message, and stream the agent's reply back over SSE.

## Why

The gate already boots a `lobu init` project + `lobu run` + a real worker turn — but it chats through the **`lobu chat` CLI**. The **consumption SDK (`@lobu/client`)** had **no live-server coverage** (only unit tests vs mocked `fetch`). So the path an external JS app actually takes — `new Lobu({...}).sessions.create() → send() → events()` against a running gateway — could regress silently. This closes that gap.

## How it works

- Packs `@lobu/client` (`bun pm pack`) and installs the tarball into a throwaway project — proving the published artifact is **self-contained** (zero deps), exactly as a real external consumer gets it.
- A small consumer (`scripts/sdk-e2e/client-consumer.mjs`) runs `createSession → send → stream` and asserts the agent reply (`SDK_E2E_OK` from the deterministic mock provider) comes back through the SDK.
- Uses the `device_token` from `POST /api/local-init` for Agent-API auth — the Agent API requires a `device_worker:run`-scoped token, which `lobu token create`'s mcp scopes are **not** (scope-allowlist drift between `AVAILABLE_SCOPES` and `AVAILABLE_PAT_SCOPES` — noted as a separate follow-up).

## Validation

Full `sdk-e2e.sh` passes locally including the new leg:
```
✓ agent completed a real turn through the worker (reply: SDK_E2E_OK)
✓ @lobu/client created a session, sent a message, and streamed the agent reply (SDK_E2E_OK)
…
✅ SDK lifecycle e2e PASSED
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Extended end-to-end testing to validate the published client SDK artifact against the running gateway.
  * Added new SDK consumer test that validates SDK round-trip functionality and streamed response handling.
  * Client SDK validation phase now executes before existing connector and watcher checks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lobu-ai/lobu/pull/1024?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->