### PR TITLE
refactor(connectors): make @lobu/connectors private

### DIFF
--- a/packages/connectors/package.json
+++ b/packages/connectors/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@lobu/connectors",
   "version": "9.2.0",
+  "private": true,
   "license": "BUSL-1.1",
   "type": "module",
   "description": "Lobu memory connectors — third-party integration implementations built on @lobu/connector-sdk",

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -48,11 +48,6 @@
         },
         {
           "type": "json",
-          "path": "packages/connectors/package.json",
-          "jsonpath": "$.version"
-        },
-        {
-          "type": "json",
           "path": "packages/connector-worker/package.json",
           "jsonpath": "$.version"
         },

--- a/scripts/bump-version.mjs
+++ b/scripts/bump-version.mjs
@@ -10,7 +10,6 @@ const PACKAGES = [
   "packages/connector-sdk",
   "packages/client",
   "packages/openclaw-plugin",
-  "packages/connectors",
   "packages/connector-worker",
   "packages/embeddings",
 ];

--- a/scripts/publish-packages.mjs
+++ b/scripts/publish-packages.mjs
@@ -37,7 +37,6 @@ const PACKAGES = [
     transform: rewriteWorkspaceRefs,
     clawhub: { slug: "lobu", displayName: "Lobu", family: "code-plugin" },
   },
-  { dir: "packages/connectors", transform: rewriteWorkspaceRefs },
   { dir: "packages/connector-worker", transform: rewriteWorkspaceRefs },
   { dir: "packages/promptfoo-provider", transform: rewriteWorkspaceRefs },
 ];


### PR DESCRIPTION
## What

Marks **`@lobu/connectors`** private and stops publishing it. Part 2 (final) of the 9.3.0 package re-tiering.

`@lobu/connectors` (BUSL-1.1 connector implementations) was published to npm but **never installed or resolved as a package**: nothing `depends` on it, and it's never `require.resolve`/`import.meta.resolve`'d at runtime. The CLI ships its *source* via `build.cjs` (`../connectors/src` → `dist/connectors`, plus the build-time catalog manifest), entirely from the monorepo — not via npm. So publishing it added a registry entry + trusted-publisher surface for nothing.

Same pattern as the already-private `@lobu/pgvector-embedded`.

## Changes
- `private: true` on `packages/connectors/package.json`
- removed from `publish-packages.mjs`, `release-please-config.json` extra-files, `bump-version.mjs`

## Why worker + embeddings stay public (revised from the original plan)
Investigation showed both are **npm-delivered runtime closures**, not bundleable like the pure-TS `@lobu/server`:
- `@lobu/embeddings` carries `@xenova/transformers` (ML runtime); statically imported by `connector-worker` AND resolved at runtime via `import.meta.resolve("@lobu/embeddings/server")` (spawned local service).
- `@lobu/worker` carries `pi-coding-agent` (+ `bun` peerDep); spawned via `require.resolve("@lobu/worker")`, not vendored.

Privatizing either would break `npx @lobu/cli` in ways CI (running in-monorepo) wouldn't catch. Keeping them public is the correct call.

## Validation
- Full `make build-packages` green (incl. server catalog-manifest + CLI `build.cjs`) with connectors private.
- Root `tsc --noEmit` + biome clean (pre-commit).
- CI `sdk-e2e` exercises a local connector end-to-end.

## Net for 9.3.0
11 published → **9**: `@lobu/sdk` folded into `@lobu/cli/config` (#1026) + `@lobu/connectors` privatized.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Marked the connectors package as private and removed it from release and version management processes.
  * Transitioned release configuration to use openclaw-plugin package for versioning and publication management.
  * Added ClawHub distribution configuration for openclaw-plugin package publishing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lobu-ai/lobu/pull/1028?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->