### PR TITLE
fix(release): pass --manual-override-reason to ClawHub publish

### DIFF
--- a/scripts/publish-packages.mjs
+++ b/scripts/publish-packages.mjs
@@ -237,6 +237,13 @@ async function publishToClawhub({ dir, clawhub }) {
       version,
       "--tags",
       "latest",
+      // The `lobu` ClawHub slug has a trusted-publisher config, so ClawHub
+      // treats this scripted CLI publish as a "manual" publish and requires an
+      // explicit override reason. The synchronized npm + ClawHub release is
+      // driven by this script (publish-packages.mjs) from the OIDC release
+      // workflow, so document that as the override reason.
+      "--manual-override-reason",
+      "synchronized npm + ClawHub release via scripts/publish-packages.mjs (publish-packages.yml)",
       "--source-repo",
       CLAWHUB_SOURCE_REPO,
       "--source-commit",


### PR DESCRIPTION
## What
The 9.3.0 publish run's final `[4/4] Publishing to ClawHub` step failed:
> `Manual publishes for packages with trusted publisher config require manualOverrideReason`

The `lobu` ClawHub slug has a trusted-publisher config, so ClawHub treats the scripted `clawhub package publish` of `@lobu/openclaw-plugin` as a *manual* publish and requires an explicit override reason. npm published `@lobu/openclaw-plugin@9.3.0` fine; only the ClawHub marketplace mirror was left behind.

## Fix
Pass `--manual-override-reason "synchronized npm + ClawHub release via scripts/publish-packages.mjs (publish-packages.yml)"` to the `publishToClawhub` invocation in `scripts/publish-packages.mjs`.

## Validation
- `node --check` clean.
- `clawhub package publish <staged> … --manual-override-reason … --dry-run` → **no error**, renders the full publish preview (12 files, 104.8 KB). The flag clears the rejection.

After merge, re-dispatching `publish-packages.yml` republishes (npm idempotently skips the already-published 9.3.0 packages) and the ClawHub step publishes `lobu@9.3.0`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced the package publishing process to include documented reasoning for publishes synchronized with release cycles, improving transparency and traceability of deployment operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lobu-ai/lobu/pull/1030?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->