### PR TITLE
chore(examples): add package.json + tsconfig so examples are self-contained

### DIFF
--- a/examples/agent-community/connectors/discourse-posts.connector.ts
+++ b/examples/agent-community/connectors/discourse-posts.connector.ts
@@ -6,7 +6,7 @@ export default class DiscoursePostsConnector extends ConnectorRuntime {
     key: "discourse-posts",
     name: "Discourse posts",
     version: "1.0.0",
-    authSchema: { methods: [{ type: "env" as const, fields: [{ name: "api_key" }] }] },
+    authSchema: { methods: [{ type: "env_keys" as const, fields: [{ key: "api_key", secret: true }] }] },
     feeds: { posts: { key: "posts", name: "Forum posts" } },
   };
 
@@ -19,6 +19,7 @@ export default class DiscoursePostsConnector extends ConnectorRuntime {
         origin_id: String(p.id),
         origin_type: "post_created",
         title: p.topic_title ?? `Post by ${p.username}`,
+        payload_text: p.raw ?? p.cooked ?? `Post by ${p.username}`,
         author_name: p.username,
         source_url: `${ctx.config.base_url}/t/${p.topic_slug}/${p.topic_id}/${p.id}`,
         occurred_at: new Date(p.created_at),

--- a/examples/agent-community/package.json
+++ b/examples/agent-community/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@lobu/example-agent-community",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "devDependencies": {
+    "@lobu/cli": "^9.2.0",
+    "@lobu/connector-sdk": "^9.2.0"
+  }
+}

--- a/examples/agent-community/package.json
+++ b/examples/agent-community/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "devDependencies": {
-    "@lobu/cli": "^9.2.0",
-    "@lobu/connector-sdk": "^9.2.0"
+    "@lobu/cli": "^9.3.0",
+    "@lobu/connector-sdk": "^9.3.0"
   }
 }

--- a/examples/agent-community/tsconfig.json
+++ b/examples/agent-community/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "Preserve",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true
+  },
+  "include": [
+    "lobu.config.ts",
+    "agents/**/*.ts",
+    "connectors/**/*.ts",
+    "reactions/**/*.ts",
+    "models/**/*.ts"
+  ]
+}

--- a/examples/atlas/package.json
+++ b/examples/atlas/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "devDependencies": {
-    "@lobu/cli": "^9.2.0",
-    "@lobu/connector-sdk": "^9.2.0"
+    "@lobu/cli": "^9.3.0",
+    "@lobu/connector-sdk": "^9.3.0"
   }
 }

--- a/examples/atlas/package.json
+++ b/examples/atlas/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@lobu/example-atlas",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "devDependencies": {
+    "@lobu/cli": "^9.2.0",
+    "@lobu/connector-sdk": "^9.2.0"
+  }
+}

--- a/examples/atlas/tsconfig.json
+++ b/examples/atlas/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "Preserve",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true
+  },
+  "include": [
+    "lobu.config.ts",
+    "agents/**/*.ts",
+    "connectors/**/*.ts",
+    "reactions/**/*.ts",
+    "models/**/*.ts"
+  ]
+}

--- a/examples/delivery/connectors/shopify-orders.connector.ts
+++ b/examples/delivery/connectors/shopify-orders.connector.ts
@@ -6,7 +6,7 @@ export default class ShopifyOrdersConnector extends ConnectorRuntime {
     key: "shopify-orders",
     name: "Shopify orders",
     version: "1.0.0",
-    authSchema: { methods: [{ type: "env" as const, fields: [{ name: "access_token" }] }] },
+    authSchema: { methods: [{ type: "env_keys" as const, fields: [{ key: "access_token", secret: true }] }] },
     feeds: { orders: { key: "orders", name: "Order updates" } },
   };
 
@@ -19,6 +19,7 @@ export default class ShopifyOrdersConnector extends ConnectorRuntime {
         origin_id: `${o.id}:${o.updated_at}`,
         origin_type: "order_updated",
         title: `Order ${o.name} — ${o.fulfillment_status ?? "unfulfilled"}`,
+        payload_text: `Order ${o.name} is ${o.fulfillment_status ?? "unfulfilled"}`,
         source_url: `https://${ctx.config.shop}/admin/orders/${o.id}`,
         occurred_at: new Date(o.updated_at),
       })),

--- a/examples/delivery/package.json
+++ b/examples/delivery/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "devDependencies": {
-    "@lobu/cli": "^9.2.0",
-    "@lobu/connector-sdk": "^9.2.0"
+    "@lobu/cli": "^9.3.0",
+    "@lobu/connector-sdk": "^9.3.0"
   }
 }

--- a/examples/delivery/package.json
+++ b/examples/delivery/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@lobu/example-delivery",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "devDependencies": {
+    "@lobu/cli": "^9.2.0",
+    "@lobu/connector-sdk": "^9.2.0"
+  }
+}

--- a/examples/delivery/tsconfig.json
+++ b/examples/delivery/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "Preserve",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true
+  },
+  "include": [
+    "lobu.config.ts",
+    "agents/**/*.ts",
+    "connectors/**/*.ts",
+    "reactions/**/*.ts",
+    "models/**/*.ts"
+  ]
+}

--- a/examples/ecommerce/package.json
+++ b/examples/ecommerce/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "devDependencies": {
-    "@lobu/cli": "^9.2.0",
-    "@lobu/connector-sdk": "^9.2.0"
+    "@lobu/cli": "^9.3.0",
+    "@lobu/connector-sdk": "^9.3.0"
   }
 }

--- a/examples/ecommerce/package.json
+++ b/examples/ecommerce/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@lobu/example-ecommerce",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "devDependencies": {
+    "@lobu/cli": "^9.2.0",
+    "@lobu/connector-sdk": "^9.2.0"
+  }
+}

--- a/examples/ecommerce/tsconfig.json
+++ b/examples/ecommerce/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "Preserve",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true
+  },
+  "include": [
+    "lobu.config.ts",
+    "agents/**/*.ts",
+    "connectors/**/*.ts",
+    "reactions/**/*.ts",
+    "models/**/*.ts"
+  ]
+}

--- a/examples/finance/connectors/quickbooks-transactions.connector.ts
+++ b/examples/finance/connectors/quickbooks-transactions.connector.ts
@@ -6,7 +6,7 @@ export default class QuickBooksTransactionsConnector extends ConnectorRuntime {
     key: "quickbooks-transactions",
     name: "QuickBooks transactions",
     version: "1.0.0",
-    authSchema: { methods: [{ type: "oauth" as const, provider: "intuit" }] },
+    authSchema: { methods: [{ type: "oauth" as const, provider: "intuit", requiredScopes: ["com.intuit.quickbooks.accounting"] }] },
     feeds: { transactions: { key: "transactions", name: "Posted transactions" } },
   };
 
@@ -20,6 +20,7 @@ export default class QuickBooksTransactionsConnector extends ConnectorRuntime {
         origin_id: t.Id,
         origin_type: "transaction_posted",
         title: `${t.AccountRef?.name ?? "Bank"} — $${t.Amount.toFixed(2)}`,
+        payload_text: `${t.AccountRef?.name ?? "Bank"} transaction for $${t.Amount.toFixed(2)} on ${t.TxnDate}`,
         occurred_at: new Date(`${t.TxnDate}T00:00:00Z`),
       })),
       checkpoint: { last_txn_date: txns.at(-1)?.TxnDate ?? since },

--- a/examples/finance/models/reactions/reconciliation-monitor.reaction.ts
+++ b/examples/finance/models/reactions/reconciliation-monitor.reaction.ts
@@ -17,7 +17,7 @@ export default async (
   ctx: ReactionContext,
   client: ReactionClient
 ): Promise<void> => {
-  const data = ctx.extracted_data as ReconciliationData;
+  const data = ctx.extracted_data as unknown as ReconciliationData;
 
   const hasIssues =
     data.unreconciled_count > 0 ||

--- a/examples/finance/package.json
+++ b/examples/finance/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@lobu/example-finance",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "devDependencies": {
+    "@lobu/cli": "^9.2.0",
+    "@lobu/connector-sdk": "^9.2.0"
+  }
+}

--- a/examples/finance/package.json
+++ b/examples/finance/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "devDependencies": {
-    "@lobu/cli": "^9.2.0",
-    "@lobu/connector-sdk": "^9.2.0"
+    "@lobu/cli": "^9.3.0",
+    "@lobu/connector-sdk": "^9.3.0"
   }
 }

--- a/examples/finance/tsconfig.json
+++ b/examples/finance/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "Preserve",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true
+  },
+  "include": [
+    "lobu.config.ts",
+    "agents/**/*.ts",
+    "connectors/**/*.ts",
+    "reactions/**/*.ts",
+    "models/**/*.ts"
+  ]
+}

--- a/examples/leadership/connectors/linear-cycles.connector.ts
+++ b/examples/leadership/connectors/linear-cycles.connector.ts
@@ -8,7 +8,7 @@ export default class LinearCyclesConnector extends ConnectorRuntime {
     key: "linear-cycles",
     name: "Linear cycles",
     version: "1.0.0",
-    authSchema: { methods: [{ type: "oauth" as const, provider: "linear" }] },
+    authSchema: { methods: [{ type: "oauth" as const, provider: "linear", requiredScopes: ["read"] }] },
     feeds: { cycle_issues: { key: "cycle_issues", name: "Cycle issues" } },
   };
 
@@ -21,6 +21,7 @@ export default class LinearCyclesConnector extends ConnectorRuntime {
         origin_id: `${i.id}:${i.state.name}`,
         origin_type: "issue_state_changed",
         title: `${i.identifier} ${i.title} → ${i.state.name}`,
+        payload_text: `${i.identifier} ${i.title} is now ${i.state.name}`,
         source_url: i.url,
         occurred_at: new Date(i.updatedAt),
       })),

--- a/examples/leadership/package.json
+++ b/examples/leadership/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "devDependencies": {
-    "@lobu/cli": "^9.2.0",
-    "@lobu/connector-sdk": "^9.2.0"
+    "@lobu/cli": "^9.3.0",
+    "@lobu/connector-sdk": "^9.3.0"
   }
 }

--- a/examples/leadership/package.json
+++ b/examples/leadership/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@lobu/example-leadership",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "devDependencies": {
+    "@lobu/cli": "^9.2.0",
+    "@lobu/connector-sdk": "^9.2.0"
+  }
+}

--- a/examples/leadership/tsconfig.json
+++ b/examples/leadership/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "Preserve",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true
+  },
+  "include": [
+    "lobu.config.ts",
+    "agents/**/*.ts",
+    "connectors/**/*.ts",
+    "reactions/**/*.ts",
+    "models/**/*.ts"
+  ]
+}

--- a/examples/legal/connectors/docusign-envelopes.connector.ts
+++ b/examples/legal/connectors/docusign-envelopes.connector.ts
@@ -6,7 +6,7 @@ export default class DocuSignEnvelopesConnector extends ConnectorRuntime {
     key: "docusign-envelopes",
     name: "DocuSign envelopes",
     version: "1.0.0",
-    authSchema: { methods: [{ type: "oauth" as const, provider: "docusign" }] },
+    authSchema: { methods: [{ type: "oauth" as const, provider: "docusign", requiredScopes: ["signature"] }] },
     feeds: { envelopes: { key: "envelopes", name: "Envelope status changes" } },
   };
 
@@ -20,6 +20,7 @@ export default class DocuSignEnvelopesConnector extends ConnectorRuntime {
         origin_id: `${e.envelopeId}:${e.status}`,
         origin_type: "envelope_status_changed",
         title: `${e.emailSubject ?? e.envelopeId} → ${e.status}`,
+        payload_text: `Envelope ${e.emailSubject ?? e.envelopeId} is now ${e.status}`,
         occurred_at: new Date(e.statusChangedDateTime),
       })),
       checkpoint: { last_status_changed: envelopes.at(-1)?.statusChangedDateTime ?? since },

--- a/examples/legal/package.json
+++ b/examples/legal/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "devDependencies": {
-    "@lobu/cli": "^9.2.0",
-    "@lobu/connector-sdk": "^9.2.0"
+    "@lobu/cli": "^9.3.0",
+    "@lobu/connector-sdk": "^9.3.0"
   }
 }

--- a/examples/legal/package.json
+++ b/examples/legal/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@lobu/example-legal",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "devDependencies": {
+    "@lobu/cli": "^9.2.0",
+    "@lobu/connector-sdk": "^9.2.0"
+  }
+}

--- a/examples/legal/tsconfig.json
+++ b/examples/legal/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "Preserve",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true
+  },
+  "include": [
+    "lobu.config.ts",
+    "agents/**/*.ts",
+    "connectors/**/*.ts",
+    "reactions/**/*.ts",
+    "models/**/*.ts"
+  ]
+}

--- a/examples/lobu-crm/package.json
+++ b/examples/lobu-crm/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "devDependencies": {
-    "@lobu/cli": "^9.2.0",
-    "@lobu/connector-sdk": "^9.2.0"
+    "@lobu/cli": "^9.3.0",
+    "@lobu/connector-sdk": "^9.3.0"
   }
 }

--- a/examples/lobu-crm/package.json
+++ b/examples/lobu-crm/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@lobu/example-lobu-crm",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "devDependencies": {
+    "@lobu/cli": "^9.2.0",
+    "@lobu/connector-sdk": "^9.2.0"
+  }
+}

--- a/examples/lobu-crm/tsconfig.json
+++ b/examples/lobu-crm/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "Preserve",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true
+  },
+  "include": [
+    "lobu.config.ts",
+    "agents/**/*.ts",
+    "connectors/**/*.ts",
+    "reactions/**/*.ts",
+    "models/**/*.ts"
+  ]
+}

--- a/examples/market/connectors/exa-news-feed.connector.ts
+++ b/examples/market/connectors/exa-news-feed.connector.ts
@@ -6,7 +6,7 @@ export default class ExaNewsFeedConnector extends ConnectorRuntime {
     key: "exa-news-feed",
     name: "Exa news feed",
     version: "1.0.0",
-    authSchema: { methods: [{ type: "env" as const, fields: [{ name: "api_key" }] }] },
+    authSchema: { methods: [{ type: "env_keys" as const, fields: [{ key: "api_key", secret: true }] }] },
     feeds: { articles: { key: "articles", name: "Articles" } },
   };
 
@@ -19,6 +19,7 @@ export default class ExaNewsFeedConnector extends ConnectorRuntime {
         origin_id: x.id,
         origin_type: "article_published",
         title: x.title ?? x.url,
+        payload_text: x.text ?? x.title ?? x.url,
         author_name: x.author,
         source_url: x.url,
         occurred_at: x.publishedDate ? new Date(x.publishedDate) : new Date(),

--- a/examples/market/package.json
+++ b/examples/market/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "devDependencies": {
-    "@lobu/cli": "^9.2.0",
-    "@lobu/connector-sdk": "^9.2.0"
+    "@lobu/cli": "^9.3.0",
+    "@lobu/connector-sdk": "^9.3.0"
   }
 }

--- a/examples/market/package.json
+++ b/examples/market/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@lobu/example-market",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "devDependencies": {
+    "@lobu/cli": "^9.2.0",
+    "@lobu/connector-sdk": "^9.2.0"
+  }
+}

--- a/examples/market/tsconfig.json
+++ b/examples/market/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "Preserve",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true
+  },
+  "include": [
+    "lobu.config.ts",
+    "agents/**/*.ts",
+    "connectors/**/*.ts",
+    "reactions/**/*.ts",
+    "models/**/*.ts"
+  ]
+}

--- a/examples/office-bot/agents/food-ordering/skills/deliveroo-order/deliveroo.ts
+++ b/examples/office-bot/agents/food-ordering/skills/deliveroo-order/deliveroo.ts
@@ -66,7 +66,7 @@ async function withPage<T>(fn: (page: import("playwright").Page) => Promise<T>):
   const browser = await chromium.launch({ headless: true });
   try {
     const context = await browser.newContext();
-    await context.addCookies(loadCookies() as Parameters<typeof context.addCookies>[0]);
+    await context.addCookies(loadCookies() as unknown as Parameters<typeof context.addCookies>[0]);
     const page = await context.newPage();
     return await fn(page);
   } finally {

--- a/examples/office-bot/package.json
+++ b/examples/office-bot/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@lobu/example-office-bot",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "devDependencies": {
+    "@lobu/cli": "^9.2.0",
+    "@lobu/connector-sdk": "^9.2.0"
+  }
+}

--- a/examples/office-bot/package.json
+++ b/examples/office-bot/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "devDependencies": {
-    "@lobu/cli": "^9.2.0",
-    "@lobu/connector-sdk": "^9.2.0"
+    "@lobu/cli": "^9.3.0",
+    "@lobu/connector-sdk": "^9.3.0"
   }
 }

--- a/examples/office-bot/tsconfig.json
+++ b/examples/office-bot/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "Preserve",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true
+  },
+  "include": [
+    "lobu.config.ts",
+    "agents/**/*.ts",
+    "connectors/**/*.ts",
+    "reactions/**/*.ts",
+    "models/**/*.ts"
+  ]
+}

--- a/examples/personal-finance/package.json
+++ b/examples/personal-finance/package.json
@@ -13,7 +13,7 @@
   },
   "devDependencies": {
     "promptfoo": "^0.121.0",
-    "@lobu/cli": "^9.2.0",
-    "@lobu/connector-sdk": "^9.2.0"
+    "@lobu/cli": "^9.3.0",
+    "@lobu/connector-sdk": "^9.3.0"
   }
 }

--- a/examples/personal-finance/package.json
+++ b/examples/personal-finance/package.json
@@ -12,6 +12,8 @@
     "@lobu/promptfoo-provider": "file:../../packages/promptfoo-provider"
   },
   "devDependencies": {
-    "promptfoo": "^0.121.0"
+    "promptfoo": "^0.121.0",
+    "@lobu/cli": "^9.2.0",
+    "@lobu/connector-sdk": "^9.2.0"
   }
 }

--- a/examples/personal-finance/tsconfig.json
+++ b/examples/personal-finance/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "Preserve",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true
+  },
+  "include": [
+    "lobu.config.ts",
+    "agents/**/*.ts",
+    "connectors/**/*.ts",
+    "reactions/**/*.ts",
+    "models/**/*.ts"
+  ]
+}

--- a/examples/sales/connectors/salesforce-pipeline.connector.ts
+++ b/examples/sales/connectors/salesforce-pipeline.connector.ts
@@ -6,7 +6,7 @@ export default class SalesforcePipelineConnector extends ConnectorRuntime {
     key: "salesforce-pipeline",
     name: "Salesforce pipeline",
     version: "1.0.0",
-    authSchema: { methods: [{ type: "oauth" as const, provider: "salesforce" }] },
+    authSchema: { methods: [{ type: "oauth" as const, provider: "salesforce", requiredScopes: ["api", "refresh_token"] }] },
     feeds: { opportunities: { key: "opportunities", name: "Opportunities" } },
   };
 
@@ -20,6 +20,7 @@ export default class SalesforcePipelineConnector extends ConnectorRuntime {
         origin_id: o.Id,
         origin_type: "opportunity_updated",
         title: `${o.Name} → ${o.StageName}`,
+        payload_text: `${o.Name} moved to ${o.StageName}`,
         occurred_at: new Date(o.LastModifiedDate),
       })),
       checkpoint: { last_modified: records.at(-1)?.LastModifiedDate ?? since },

--- a/examples/sales/package.json
+++ b/examples/sales/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "devDependencies": {
-    "@lobu/cli": "^9.2.0",
-    "@lobu/connector-sdk": "^9.2.0"
+    "@lobu/cli": "^9.3.0",
+    "@lobu/connector-sdk": "^9.3.0"
   }
 }

--- a/examples/sales/package.json
+++ b/examples/sales/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@lobu/example-sales",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "devDependencies": {
+    "@lobu/cli": "^9.2.0",
+    "@lobu/connector-sdk": "^9.2.0"
+  }
+}

--- a/examples/sales/tsconfig.json
+++ b/examples/sales/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "Preserve",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true
+  },
+  "include": [
+    "lobu.config.ts",
+    "agents/**/*.ts",
+    "connectors/**/*.ts",
+    "reactions/**/*.ts",
+    "models/**/*.ts"
+  ]
+}


### PR DESCRIPTION
## What

Every example carried only `lobu.config.ts` and relied on the monorepo workspace to resolve `@lobu/cli/config` and `@lobu/connector-sdk`. So they:

- **didn't match what `lobu init` scaffolds** — `scaffoldProjectPackaging` (`packages/cli/src/commands/init.ts:167`) writes a `package.json` (with `@lobu/cli` + `@lobu/connector-sdk` devDeps) and a `tsconfig.json` for exactly this reason: *"so `lobu apply` (jiti) and the editor can resolve the SDK imports outside this monorepo."*
- **couldn't be copied out and typechecked standalone** — the imports only resolved because the examples sit inside the workspace.
- were **inconsistent**: only `personal-finance` had a `package.json`, and even it lacked the SDK devDeps + had no tsconfig.

## The gap, fixed

Give every example the init-style `package.json` (`@lobu/cli` + `@lobu/connector-sdk` at `^9.2.0`, matching `scaffoldProjectPackaging`) and a `tsconfig.json` whose `include` covers the dirs actually present (`agents`/`connectors`/`reactions`/`models` — the examples put reactions under `models/`, which the stock init globs wouldn't catch).

Adding the tsconfigs surfaced **pre-existing type errors** in example code that nothing had ever typechecked (8 of 12 examples failed). Fixed against the shipped SDK contract:

- **4 OAuth connectors** missing `requiredScopes` — salesforce, quickbooks, linear, docusign (`ConnectorAuthOAuth.requiredScopes` is required).
- **3 connectors** using a stale env auth shape — `type: "env"` + `{ name }` fields → `type: "env_keys"` + `{ key }` (discourse, shopify, exa).
- **all 7 connectors** missing the required `EventEnvelope.payload_text`.
- **2 invalid direct casts** — finance reaction (`Record<string,unknown>` → `ReconciliationData`) and office-bot deliveroo skill (cookie array); both now `as unknown as`.

## Validation

`bunx tsc -p examples/<name>/tsconfig.json --noEmit` is green for **all 12 examples**. `biome check` clean. No example `*.config.ts` semantics changed — only packaging added + type errors fixed.

Examples stay standalone (not added to the root workspace), matching the existing `personal-finance` convention.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Emitted events now include human-readable payload text across several integrations (orders, transactions, issues, envelopes, cycles, opportunities, news, and posts)

* **Bug Fixes**
  * Sensitive API keys and tokens are now treated as secrets for improved security
  * OAuth integrations now declare required scopes for several providers

* **Chores**
  * Added example project manifests and TypeScript configs for multiple templates

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lobu-ai/lobu/pull/1034?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->