### PR TITLE
fix(worker): copy packages/core into worker runtime image

### DIFF
--- a/docker/worker/Dockerfile
+++ b/docker/worker/Dockerfile
@@ -82,6 +82,11 @@ RUN useradd -m -s /bin/bash worker && \
 COPY --from=builder --chown=worker:worker /app/node_modules ./node_modules
 COPY --from=builder --chown=worker:worker /app/package.json ./
 COPY --from=builder --chown=worker:worker /app/tsconfig.json ./
+# connector-sdk imports @lobu/core (logger/retry); the bun workspace symlink
+# points at packages/core, so the runtime stage must include it or the symlink
+# dangles -> "ENOENT reading .../connector-sdk/node_modules/@lobu/core" at feed
+# sync. Mirrors docker/app/Dockerfile, which already copies core.
+COPY --from=builder --chown=worker:worker /app/packages/core ./packages/core
 COPY --from=builder --chown=worker:worker /app/packages/connector-sdk ./packages/connector-sdk
 COPY --from=builder --chown=worker:worker /app/packages/connectors ./packages/connectors
 COPY --from=builder --chown=worker:worker /app/packages/embeddings ./packages/embeddings


### PR DESCRIPTION
## Problem

Every connector **feed sync** on the worker deployment (`summaries-app-lobu-worker`) crashes at runtime with:

```
ENOENT reading "/app/packages/connector-sdk/node_modules/@lobu/core"
```

Nothing gets ingested. Discovered while wiring the Spotify connector (valid OAuth, all scopes) — the sync runs fail before emitting any events.

## Root cause

`docker/worker/Dockerfile` **builds** `@lobu/core` in the builder stage (`cd packages/core && bunx tsc`, line 54) but the runtime stage COPY block (lines 82-88) copies `node_modules`, `connector-sdk`, `connectors`, `embeddings`, `connector-worker` — **never `packages/core`**.

At feed-sync time the compiled connector emits a bare `import '@lobu/connector-sdk'` (the SDK is externalized by the compile pipeline). `@lobu/connector-sdk/dist/index.js` re-exports `logger.js` + `retry.js`, which `import { createLogger, retryWithBackoff } from '@lobu/core'`. `bun install`'s workspace symlink `connector-sdk/node_modules/@lobu/core → ../../../core` then **dangles** because its target (`packages/core`) was never copied → `ENOENT`.

`docker/app/Dockerfile` already copies core (line 139), which is why the app deployment isn't affected.

**Not a regression** — long-standing latent gap: the worker runtime stage has never copied `packages/core`. It only surfaces now that the worker deployment is being exercised for connector sync.

## Fix

One line in the runtime COPY block (mirrors the app image):

```dockerfile
COPY --from=builder --chown=worker:worker /app/packages/core ./packages/core
```

## Validation (red → green)

No Docker on the dev host, so reproduced the exact failure mode at the module-resolution level with the real built artifacts (Node 22), replicating the runtime image's COPY layout:

- **RED** (no `packages/core`, current behavior): `fs.realpathSync` on `connector-sdk/node_modules/@lobu/core` throws `ENOENT` — the exact prod error.
- **GREEN** (with `packages/core` + root `node_modules`, as the image has after the fix): the symlink resolves, Node resolves `@lobu/core` from connector-sdk's dist, and the module loads exposing `createLogger` + `retryWithBackoff` (the functions connector-sdk imports).

Full image build verification happens in CI (the worker image build). After this deploys, re-triggering the Spotify feeds in `buremba` should ingest cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed runtime errors occurring during feed and synchronization operations caused by missing dependencies, ensuring stable and reliable performance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lobu-ai/lobu/pull/1035?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->