### PR TITLE
feat(agent-worker): support before_tool_call/after_tool_call plugin hooks

### DIFF
--- a/packages/agent-worker/src/__tests__/plugin-tool-hooks.test.ts
+++ b/packages/agent-worker/src/__tests__/plugin-tool-hooks.test.ts
@@ -1,0 +1,296 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  loadPlugins,
+  wrapToolsWithPluginToolHooks,
+} from "../openclaw/plugin-loader";
+
+type ToolArg = Parameters<typeof wrapToolsWithPluginToolHooks>[0][number];
+type PluginArg = Parameters<typeof wrapToolsWithPluginToolHooks>[1][number];
+type Handler = (
+  event: Record<string, unknown>,
+  ctx: Record<string, unknown>
+) => unknown;
+
+function fakePlugin(hooks: {
+  before_tool_call?: Handler[];
+  after_tool_call?: Handler[];
+}): PluginArg {
+  return {
+    hooks: {
+      before_agent_start: [],
+      agent_end: [],
+      before_tool_call: hooks.before_tool_call ?? [],
+      after_tool_call: hooks.after_tool_call ?? [],
+    },
+  } as unknown as PluginArg;
+}
+
+/** Echoes the params it was executed with back into the result content. */
+function echoTool(name: string, onExecute?: () => void): ToolArg {
+  return {
+    name,
+    label: name,
+    description: "fake echo tool",
+    parameters: { type: "object", properties: {} },
+    execute: async (_toolCallId: string, params: Record<string, unknown>) => {
+      onExecute?.();
+      return {
+        content: [{ type: "text", text: JSON.stringify(params) }],
+        details: undefined,
+      };
+    },
+  } as unknown as ToolArg;
+}
+
+async function runTool(
+  tool: ToolArg,
+  params: Record<string, unknown>
+): Promise<{ content: Array<{ text?: string }>; details: unknown }> {
+  const exec = tool.execute as unknown as (
+    id: string,
+    p: Record<string, unknown>,
+    signal: undefined,
+    onUpdate: undefined,
+    ctx: undefined
+  ) => Promise<{ content: Array<{ text?: string }>; details: unknown }>;
+  return exec("call-1", params, undefined, undefined, undefined);
+}
+
+describe("wrapToolsWithPluginToolHooks", () => {
+  test("returns the original array unchanged when no tool hooks registered", () => {
+    const tools = [echoTool("echo")];
+    const wrapped = wrapToolsWithPluginToolHooks(tools, [fakePlugin({})], {});
+    expect(wrapped).toBe(tools);
+  });
+
+  test("block prevents execution and returns the block reason to the agent", async () => {
+    let executed = false;
+    const [wrapped] = wrapToolsWithPluginToolHooks(
+      [echoTool("echo", () => (executed = true))],
+      [
+        fakePlugin({
+          before_tool_call: [() => ({ block: true, blockReason: "nope" })],
+        }),
+      ],
+      {}
+    );
+
+    const result = await runTool(wrapped, { a: 1 });
+    expect(executed).toBe(false);
+    expect(result.content[0].text).toContain("nope");
+  });
+
+  test("params returned by a hook are merged into the tool args", async () => {
+    const [wrapped] = wrapToolsWithPluginToolHooks(
+      [echoTool("echo")],
+      [fakePlugin({ before_tool_call: [() => ({ params: { b: 2 } })] })],
+      {}
+    );
+
+    const result = await runTool(wrapped, { a: 1 });
+    expect(JSON.parse(result.content[0].text ?? "{}")).toEqual({ a: 1, b: 2 });
+  });
+
+  test("passes through when a hook returns no decision", async () => {
+    let executed = false;
+    const [wrapped] = wrapToolsWithPluginToolHooks(
+      [echoTool("echo", () => (executed = true))],
+      [fakePlugin({ before_tool_call: [() => undefined] })],
+      {}
+    );
+
+    const result = await runTool(wrapped, { a: 1 });
+    expect(executed).toBe(true);
+    expect(JSON.parse(result.content[0].text ?? "{}")).toEqual({ a: 1 });
+  });
+
+  test("fails closed: a throwing hook blocks the call", async () => {
+    let executed = false;
+    const [wrapped] = wrapToolsWithPluginToolHooks(
+      [echoTool("echo", () => (executed = true))],
+      [
+        fakePlugin({
+          before_tool_call: [
+            () => {
+              throw new Error("boom");
+            },
+          ],
+        }),
+      ],
+      {}
+    );
+
+    const result = await runTool(wrapped, {});
+    expect(executed).toBe(false);
+    expect(result.content[0].text).toContain("boom");
+  });
+
+  test("requireApproval maps to a soft block using the description", async () => {
+    let executed = false;
+    const [wrapped] = wrapToolsWithPluginToolHooks(
+      [echoTool("echo", () => (executed = true))],
+      [
+        fakePlugin({
+          before_tool_call: [
+            () => ({
+              requireApproval: { title: "T", description: "needs ok" },
+            }),
+          ],
+        }),
+      ],
+      {}
+    );
+
+    const result = await runTool(wrapped, {});
+    expect(executed).toBe(false);
+    expect(result.content[0].text).toContain("needs ok");
+  });
+
+  test("block takes precedence over a prior requireApproval", async () => {
+    const [wrapped] = wrapToolsWithPluginToolHooks(
+      [echoTool("echo")],
+      [
+        fakePlugin({
+          before_tool_call: [
+            () => ({ requireApproval: { description: "approve me" } }),
+            () => ({ block: true, blockReason: "hard block" }),
+          ],
+        }),
+      ],
+      {}
+    );
+
+    const result = await runTool(wrapped, {});
+    expect(result.content[0].text).toContain("hard block");
+    expect(result.content[0].text).not.toContain("approve me");
+  });
+
+  test("wraps a tool whose execute takes only 4 args (no trailing ctx)", async () => {
+    // AgentTool-shaped tools have a 4-arg execute; the wrapper must still block
+    // them correctly (it passes a 5th arg, which is harmless).
+    let executed = false;
+    const fourArgTool = {
+      name: "echo",
+      label: "echo",
+      description: "4-arg execute tool",
+      parameters: { type: "object", properties: {} },
+      execute: async (_id: string, params: Record<string, unknown>) => {
+        executed = true;
+        return {
+          content: [{ type: "text", text: JSON.stringify(params) }],
+          details: undefined,
+        };
+      },
+    } as unknown as ToolArg;
+
+    const [wrapped] = wrapToolsWithPluginToolHooks(
+      [fourArgTool],
+      [
+        fakePlugin({
+          before_tool_call: [() => ({ block: true, blockReason: "blocked" })],
+        }),
+      ],
+      {}
+    );
+
+    const result = await runTool(wrapped, { command: "x" });
+    expect(executed).toBe(false);
+    expect(result.content[0].text).toContain("blocked");
+  });
+
+  test("after_tool_call fires (detached) with the execution result", async () => {
+    let resolveSeen!: (value: unknown) => void;
+    const seen = new Promise<unknown>((resolve) => {
+      resolveSeen = resolve;
+    });
+    const [wrapped] = wrapToolsWithPluginToolHooks(
+      [echoTool("echo")],
+      [
+        fakePlugin({
+          after_tool_call: [(event) => resolveSeen(event.result)],
+        }),
+      ],
+      {}
+    );
+
+    await runTool(wrapped, { a: 1 });
+    const seenResult = await seen; // detached handler runs after the tool returns
+    expect(
+      (seenResult as { content: Array<{ text?: string }> }).content[0].text
+    ).toContain('"a":1');
+  });
+
+  test("a synchronously throwing after_tool_call does not fail the tool", async () => {
+    // after_tool_call is fire-and-forget: a throwing handler must not reject a
+    // tool that already executed successfully.
+    const [wrapped] = wrapToolsWithPluginToolHooks(
+      [echoTool("echo")],
+      [
+        fakePlugin({
+          after_tool_call: [
+            () => {
+              throw new Error("after boom");
+            },
+          ],
+        }),
+      ],
+      {}
+    );
+
+    const result = await runTool(wrapped, { a: 1 });
+    expect(JSON.parse(result.content[0].text ?? "{}")).toEqual({ a: 1 });
+  });
+});
+
+describe("loadPlugins captures before_tool_call via the shim on()", () => {
+  test("an object-style plugin registering a before_tool_call hook loads and gates its tool", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "lobu-plugin-"));
+    const modPath = join(dir, "gate-plugin.mjs");
+    writeFileSync(
+      modPath,
+      `export default {
+        name: "gate-plugin",
+        register(api) {
+          api.registerTool({
+            name: "echo",
+            label: "echo",
+            description: "echo tool",
+            parameters: { type: "object", properties: {} },
+            execute: async (_id, params) => ({
+              content: [{ type: "text", text: JSON.stringify(params) }],
+              details: undefined,
+            }),
+          });
+          api.on("before_tool_call", (event) =>
+            event.params && event.params.deny ? { block: true, blockReason: "denied" } : undefined
+          );
+        },
+      };`
+    );
+
+    const loaded = await loadPlugins({
+      plugins: [{ source: modPath, slot: "tool" }],
+    });
+
+    expect(loaded).toHaveLength(1);
+    expect(loaded[0].tools).toHaveLength(1);
+    expect(loaded[0].hooks.before_tool_call).toHaveLength(1);
+
+    const [wrapped] = wrapToolsWithPluginToolHooks(
+      loaded[0].tools as unknown as ToolArg[],
+      loaded as unknown as PluginArg[],
+      {}
+    );
+
+    const blocked = await runTool(wrapped, { deny: true });
+    expect(blocked.content[0].text).toContain("denied");
+
+    const allowed = await runTool(wrapped, { deny: false });
+    expect(JSON.parse(allowed.content[0].text ?? "{}")).toEqual({
+      deny: false,
+    });
+  });
+});

--- a/packages/agent-worker/src/openclaw/plugin-loader.ts
+++ b/packages/agent-worker/src/openclaw/plugin-loader.ts
@@ -17,12 +17,52 @@ import type { ToolDefinition } from "@mariozechner/pi-coding-agent";
 
 const logger = createLogger("openclaw-plugin-loader");
 
-type PluginHookName = "before_agent_start" | "agent_end";
+type PluginHookName =
+  | "before_agent_start"
+  | "agent_end"
+  | "before_tool_call"
+  | "after_tool_call";
+
+const PLUGIN_HOOK_NAMES: readonly PluginHookName[] = [
+  "before_agent_start",
+  "agent_end",
+  "before_tool_call",
+  "after_tool_call",
+];
+
+function isPluginHookName(value: unknown): value is PluginHookName {
+  return (
+    typeof value === "string" &&
+    (PLUGIN_HOOK_NAMES as readonly string[]).includes(value)
+  );
+}
 
 type PluginHookHandler = (
   event: Record<string, unknown>,
   ctx: Record<string, unknown>
 ) => unknown | Promise<unknown>;
+
+/**
+ * Subset of OpenClaw's `PluginHookBeforeToolCallResult` that this shim honors.
+ * `requireApproval` is captured but mapped to a soft block (see
+ * {@link wrapToolsWithPluginToolHooks}) — OpenClaw's documented fallback when
+ * the host cannot drive native platform approval.
+ */
+interface BeforeToolCallResult {
+  params?: Record<string, unknown>;
+  block?: boolean;
+  blockReason?: string;
+  requireApproval?: { title?: string; description?: string };
+}
+
+function emptyHooks(): Record<PluginHookName, PluginHookHandler[]> {
+  return {
+    before_agent_start: [],
+    agent_end: [],
+    before_tool_call: [],
+    after_tool_call: [],
+  };
+}
 
 interface PluginService {
   id: string;
@@ -70,9 +110,10 @@ export async function loadPlugins(
           parts.push(`${loaded.tools.length} tool(s)`);
         if (loaded.providers.length > 0)
           parts.push(`${loaded.providers.length} provider(s)`);
-        const hookCount =
-          loaded.hooks.before_agent_start.length +
-          loaded.hooks.agent_end.length;
+        const hookCount = Object.values(loaded.hooks).reduce(
+          (n, handlers) => n + handlers.length,
+          0
+        );
         if (hookCount > 0) parts.push(`${hookCount} hook(s)`);
         if (loaded.services.length > 0)
           parts.push(`${loaded.services.length} service(s)`);
@@ -115,10 +156,8 @@ async function loadSinglePlugin(
 
   const capturedTools: ToolDefinition[] = [];
   const capturedProviders: ProviderRegistration[] = [];
-  const capturedHooks: Record<PluginHookName, PluginHookHandler[]> = {
-    before_agent_start: [],
-    agent_end: [],
-  };
+  const capturedHooks: Record<PluginHookName, PluginHookHandler[]> =
+    emptyHooks();
   const capturedServices: PluginService[] = [];
   const shimApi = createShimApi({
     source,
@@ -243,10 +282,7 @@ function createShimApi(params: {
     logger: shimLogger,
 
     on(eventName: unknown, handler: unknown) {
-      if (
-        (eventName === "before_agent_start" || eventName === "agent_end") &&
-        typeof handler === "function"
-      ) {
+      if (isPluginHookName(eventName) && typeof handler === "function") {
         capturedHooks[eventName].push(handler as PluginHookHandler);
         return;
       }
@@ -371,6 +407,155 @@ export async function runPluginHooks(params: {
     }
   }
   return results;
+}
+
+type LooseToolResult = { content: unknown[]; details: unknown };
+type LooseToolExecute = (
+  toolCallId: string,
+  params: Record<string, unknown>,
+  signal: AbortSignal | undefined,
+  onUpdate: unknown,
+  ctx: unknown
+) => Promise<LooseToolResult>;
+
+/** Minimal structural shape this wrapper needs from a tool. */
+interface WrappableTool {
+  name: string;
+  execute: (...args: never[]) => Promise<unknown>;
+}
+
+/**
+ * Wrap each tool so plugin `before_tool_call` / `after_tool_call` hooks run
+ * around its execution. Tools execute in-process and never traverse the gateway
+ * MCP proxy, so this wrapper is the only place those OpenClaw hooks can fire.
+ *
+ * Generic over the tool type so it wraps both built-in tools (`AgentTool`) and
+ * plugin/MCP custom tools (`ToolDefinition`) — OpenClaw fires `before_tool_call`
+ * for every tool, including bash/read/edit/write, so a plugin policy hook must
+ * see them all.
+ *
+ * `before_tool_call` runs sequentially and honors:
+ *  - `params` — shallow-merged into the tool args before execution
+ *  - `block` + `blockReason` — the tool is NOT executed; the reason is returned
+ *    to the agent. `block: true` is terminal (skips lower-priority handlers).
+ *  - `requireApproval` — mapped to a soft block using the description/title.
+ *    This is OpenClaw's documented fallback when the host cannot drive native
+ *    platform approval; `block` takes precedence over it. (Live platform
+ *    approval is intentionally out of scope here.)
+ * A handler that throws fails closed (blocks the call).
+ *
+ * `after_tool_call` is a fire-and-forget notification (returns void upstream).
+ *
+ * Tools are returned unchanged when no plugin registered tool hooks.
+ */
+export function wrapToolsWithPluginToolHooks<T extends WrappableTool>(
+  tools: T[],
+  plugins: LoadedPlugin[],
+  ctx: Record<string, unknown>
+): T[] {
+  const beforeHandlers = plugins.flatMap((p) => p.hooks.before_tool_call);
+  const afterHandlers = plugins.flatMap((p) => p.hooks.after_tool_call);
+  if (beforeHandlers.length === 0 && afterHandlers.length === 0) {
+    return tools;
+  }
+
+  return tools.map((tool) => {
+    const toolName = tool.name;
+    const originalExecute = tool.execute.bind(tool) as LooseToolExecute;
+
+    const wrappedExecute: LooseToolExecute = async (
+      toolCallId,
+      params,
+      signal,
+      onUpdate,
+      execCtx
+    ) => {
+      let mergedParams: Record<string, unknown> = { ...(params ?? {}) };
+      let blockReason: string | undefined;
+      let approvalReason: string | undefined;
+
+      for (const handler of beforeHandlers) {
+        let result: unknown;
+        try {
+          result = await Promise.resolve(
+            handler({ toolName, params: mergedParams, toolCallId }, ctx)
+          );
+        } catch (err) {
+          // Fail closed: a throwing pre-tool hook blocks the call.
+          blockReason = `before_tool_call hook threw: ${err instanceof Error ? err.message : String(err)}`;
+          break;
+        }
+        if (!result || typeof result !== "object") continue;
+        const r = result as BeforeToolCallResult;
+        if (r.params && typeof r.params === "object") {
+          mergedParams = { ...mergedParams, ...r.params };
+        }
+        if (r.block === true) {
+          blockReason = r.blockReason?.trim() || "Blocked by plugin policy.";
+          break; // block is terminal — skip lower-priority handlers
+        }
+        if (r.requireApproval && approvalReason === undefined) {
+          const ra = r.requireApproval;
+          approvalReason =
+            ra.description?.trim() ||
+            ra.title?.trim() ||
+            "This tool call requires human approval.";
+          // not terminal: a later handler may still hard-block
+        }
+      }
+
+      // `block` takes precedence over `requireApproval`.
+      const denyReason = blockReason ?? approvalReason;
+      if (denyReason !== undefined) {
+        logger.info(
+          `Plugin before_tool_call blocked "${toolName}": ${denyReason}`
+        );
+        return {
+          content: [{ type: "text" as const, text: `⛔ ${denyReason}` }],
+          details: undefined,
+        };
+      }
+
+      const execResult = await originalExecute(
+        toolCallId,
+        mergedParams,
+        signal,
+        onUpdate,
+        execCtx
+      );
+
+      // after_tool_call is a fire-and-forget notification: it must not delay
+      // the tool result, and a handler that throws (sync or async) must never
+      // fail a tool that already ran. Dispatch detached in a microtask (so
+      // synchronous throws become catchable rejections) and don't await.
+      for (const handler of afterHandlers) {
+        Promise.resolve()
+          .then(() =>
+            handler(
+              {
+                toolName,
+                params: mergedParams,
+                toolCallId,
+                result: execResult,
+              },
+              ctx
+            )
+          )
+          .catch((err) =>
+            logger.error(
+              `after_tool_call hook failed for "${toolName}": ${err instanceof Error ? err.message : String(err)}`
+            )
+          );
+      }
+
+      return execResult;
+    };
+
+    return {
+      ...tool,
+      execute: wrappedExecute,
+    } as unknown as T;
+  });
 }
 
 export async function startPluginServices(

--- a/packages/agent-worker/src/openclaw/worker.ts
+++ b/packages/agent-worker/src/openclaw/worker.ts
@@ -59,6 +59,7 @@ import {
   runPluginHooks,
   startPluginServices,
   stopPluginServices,
+  wrapToolsWithPluginToolHooks,
 } from "./plugin-loader";
 import { OpenClawProgressProcessor } from "./processor";
 import { checkSandboxLeak } from "./sandbox-leak";
@@ -1336,7 +1337,20 @@ Use it when the user references past discussions or you need context.`);
         cwd: workspaceDir,
         model,
         tools,
-        customTools,
+        // Wrap custom tools (plugin + MCP) so plugin before_tool_call/
+        // after_tool_call hooks fire around in-process execution — these never
+        // hit the gateway proxy, so this is the only place the hooks can run.
+        // Built-in tools (bash/read/edit/write) are intentionally NOT gated
+        // here: createAgentSession() uses the `tools` option only to derive
+        // active tool names and rebuilds the base tools internally, so wrapped
+        // built-ins would be ignored. Gating them would require constructing
+        // AgentSession with baseToolsOverride directly. Built-ins remain
+        // governed by Lobu's own tool policy.
+        customTools: wrapToolsWithPluginToolHooks(
+          customTools,
+          loadedPlugins,
+          pluginHookContext
+        ),
         sessionManager,
         settingsManager,
         authStorage,


### PR DESCRIPTION
## Summary

Closes #1022. OpenClaw's `before_tool_call` is a real, documented plugin hook, but our shim only forwarded `before_agent_start`/`agent_end` via `api.on(...)` — any other hook loaded silently and never fired. Because in-process plugin tools never traverse the gateway MCP proxy, neither the plugin's own gate nor Lobu's native tool approval applied to them, so a plugin's "approve before this tool" logic was a no-op.

## What changed

- **`plugin-loader.ts`**: capture `before_tool_call` + `after_tool_call` in the shim `on()` (via an `isPluginHookName` guard) instead of dropping them.
- **`wrapToolsWithPluginToolHooks(tools, plugins, ctx)`** wraps in-process plugin custom tools to honor OpenClaw's contract:
  - `params` → shallow-merged into the tool args before execute
  - `block` + `blockReason` → tool not executed, reason returned to the agent; `block: true` is terminal
  - a throwing hook **fails closed** (blocks)
  - `requireApproval` → **soft block** using description/title (OpenClaw's own documented fallback when the host can't drive native platform approval); `block` takes precedence
  - `after_tool_call` → fire-and-forget notification with the result
  - returns the array unchanged when no tool hooks are registered (zero overhead)
- **`worker.ts`**: wrap `customTools` before `createAgentSession`.

## Out of scope (deferred)

Live `requireApproval` (native Telegram/Discord/`/approve` buttons that resume the exact paused call). Lobu's existing multi-replica-safe approval pipeline could be bridged into for this, but it's a larger piece; gated on whether a real plugin needs live buttons vs. agent-cooperative block+reason.

## Test plan

New `plugin-tool-hooks.test.ts` (9 tests): block, params-merge, pass-through, fail-closed-on-throw, `requireApproval`→soft-block, block-precedence, `after_tool_call` fires, no-op identity, plus an integration test that loads a real plugin module through the actual shim `on()` and proves capture→wrap→block end to end.

- 9/9 pass · `tsc --noEmit` clean · biome clean
- Not yet exercised: a live agent turn (LLM calls a plugin tool, block surfaces in chat). Integration test covers the shim→capture→wrap→block path including a real dynamic import.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Plugin hooks extended to support before-tool and after-tool handlers; custom tools are automatically wrapped so before-tool hooks can block, request approval (soft-block), or merge params, and after-tool hooks run post-execution (errors logged).

* **Tests**
  * New tests validate hook sequencing, blocking/approval semantics, param merging, built-in vs custom tool wrapping, and after-tool handler behavior (including fail-closed cases).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lobu-ai/lobu/pull/1036?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->