### PR TITLE
refactor(connectors): remove the dead browser/api_type worker-claim axis

### DIFF
--- a/packages/connector-worker/src/bin.ts
+++ b/packages/connector-worker/src/bin.ts
@@ -109,9 +109,7 @@ async function main(): Promise<void> {
           workerId,
           version,
           workerApiToken: process.env.WORKER_API_TOKEN,
-          capabilities: {
-            browser: true,
-          },
+          capabilities: {},
           ...(Number.isFinite(maxConcurrentJobs) ? { maxConcurrentJobs } : {}),
         },
         env

--- a/packages/connector-worker/src/daemon/client.ts
+++ b/packages/connector-worker/src/daemon/client.ts
@@ -45,9 +45,8 @@ export interface ExecutorClient {
 // Types
 // ============================================
 
-export interface WorkerCapabilities {
-  browser: boolean;
-}
+/** Capability strings the worker advertises, keyed by name (e.g. `browser.debugger`). */
+export type WorkerCapabilities = Record<string, boolean>;
 
 export interface OAuthCredentials {
   accessToken: string;

--- a/packages/connector-worker/src/daemon/worker.ts
+++ b/packages/connector-worker/src/daemon/worker.ts
@@ -19,7 +19,7 @@ export interface DaemonConfig {
   version?: string;
 }
 
-const DEFAULT_CAPABILITIES: WorkerCapabilities = { browser: false };
+const DEFAULT_CAPABILITIES: WorkerCapabilities = {};
 const DEFAULT_EXECUTOR_TIMEOUT_MS = 600000;
 
 /**

--- a/packages/server/src/__tests__/integration/events/scheduling-contract.test.ts
+++ b/packages/server/src/__tests__/integration/events/scheduling-contract.test.ts
@@ -151,8 +151,8 @@ describe('scheduler and worker ingestion contracts', () => {
     `;
 
     const [responseA, responseB] = await Promise.all([
-      post('/api/workers/poll', { body: { worker_id: 'worker-a', capabilities: { browser: false } } }),
-      post('/api/workers/poll', { body: { worker_id: 'worker-b', capabilities: { browser: false } } }),
+      post('/api/workers/poll', { body: { worker_id: 'worker-a', capabilities: {} } }),
+      post('/api/workers/poll', { body: { worker_id: 'worker-b', capabilities: {} } }),
     ]);
     const bodies = [await responseA.json(), await responseB.json()];
     const running = bodies.filter((body) => typeof body.run_id === 'number');

--- a/packages/server/src/gateway/connections/chat-instance-manager.ts
+++ b/packages/server/src/gateway/connections/chat-instance-manager.ts
@@ -30,6 +30,7 @@ import {
 } from "../secrets/index.js";
 import { resolveAgentOptions } from "../services/platform-helpers.js";
 import { orgContext, tryGetOrgId } from "../../lobu/stores/org-context.js";
+import { isCloudMode } from "../../utils/cloud-mode.js";
 import {
   ConversationStateStore,
   type HistoryEntry,
@@ -93,21 +94,6 @@ function configsEqual(
 
 const logger = createLogger("chat-instance-manager");
 
-/**
- * Read `LOBU_CLOUD_MODE` from the env. Truthy values (`1`, `true`, `yes`,
- * case-insensitive) enable cloud-mode guardrails that don't apply to
- * self-hosters running the same gateway in a single-tenant install.
- *
- * Re-read on every call so a process running in a test harness can flip
- * the flag without restart. Embedded gateways check it on every
- * connection-create, which is cold-path enough to skip caching.
- */
-function isCloudMode(): boolean {
-  const raw = process.env.LOBU_CLOUD_MODE;
-  if (!raw) return false;
-  const v = raw.trim().toLowerCase();
-  return v === "1" || v === "true" || v === "yes";
-}
 
 /**
  * `mode: "polling"` is the only config that forces long-polling regardless

--- a/packages/server/src/lib/feed-sync.ts
+++ b/packages/server/src/lib/feed-sync.ts
@@ -22,7 +22,6 @@ export interface FeedRecord {
   connection_config: Record<string, unknown>;
   checkpoint: Record<string, unknown> | null;
   compiled_code: string | null;
-  api_type: string | null;
   auth_profile_id: number | null;
   app_auth_profile_id: number | null;
 }
@@ -48,13 +47,12 @@ export async function fetchFeeds(filter?: FeedFilter): Promise<FeedRecord[]> {
       COALESCE(c.config, '{}'::jsonb) AS connection_config,
       f.checkpoint,
       cv.compiled_code,
-      resolved_def.api_type,
       c.auth_profile_id,
       c.app_auth_profile_id
     FROM feeds f
     JOIN connections c ON c.id = f.connection_id
     LEFT JOIN LATERAL (
-      SELECT d.version, d.api_type
+      SELECT d.version
       FROM connector_definitions d
       WHERE d.key = c.connector_key
         AND d.status = 'active'

--- a/packages/server/src/scheduled/embedded-connector-worker.ts
+++ b/packages/server/src/scheduled/embedded-connector-worker.ts
@@ -63,7 +63,7 @@ export function startEmbeddedConnectorWorker(
       apiUrl,
       workerId,
       workerApiToken: serverEnv.WORKER_API_TOKEN,
-      capabilities: { browser: false },
+      capabilities: {},
       pollIntervalMs: DEFAULT_POLL_INTERVAL_MS,
       maxConcurrentJobs: 1,
     },

--- a/packages/server/src/utils/cloud-mode.ts
+++ b/packages/server/src/utils/cloud-mode.ts
@@ -1,0 +1,16 @@
+/**
+ * Read `LOBU_CLOUD_MODE` from the env. Truthy values (`1`, `true`, `yes`,
+ * case-insensitive) enable cloud-mode guardrails that don't apply to
+ * self-hosters running the same gateway in a single-tenant install — e.g.
+ * rejecting Telegram polling mode, and refusing to re-anchor an anonymous
+ * worker poll to an existing device owner.
+ *
+ * Re-read on every call so a process (or test harness) can flip the flag
+ * without a restart. All call sites are cold-path, so caching isn't worth it.
+ */
+export function isCloudMode(): boolean {
+  const raw = process.env.LOBU_CLOUD_MODE;
+  if (!raw) return false;
+  const v = raw.trim().toLowerCase();
+  return v === '1' || v === 'true' || v === 'yes';
+}

--- a/packages/server/src/utils/table-schema.ts
+++ b/packages/server/src/utils/table-schema.ts
@@ -331,7 +331,6 @@ export const QUERYABLE_SCHEMA = {
         'created_at',
         'updated_at',
         'login_enabled',
-        'api_type',
         'favicon_domain',
         'default_repair_agent_id',
         'required_capability',

--- a/packages/server/src/worker-api.ts
+++ b/packages/server/src/worker-api.ts
@@ -27,6 +27,7 @@ import {
 } from './connectors/repair-agent';
 import { captureServerError } from './sentry';
 import { autoLinkEvent } from './utils/auto-linker';
+import { isCloudMode } from './utils/cloud-mode';
 import { nextRunAt as nextRunAtFromCron } from './utils/cron';
 import { advanceWatcherSchedule, enqueueWatcherRunForWatcher } from './watchers/automation';
 import {
@@ -62,10 +63,7 @@ function normalizeAdvertisedCapabilities(capabilities: Record<string, boolean>):
     new Set(
       Object.entries(capabilities)
         .map(([key, value]) => [key.trim(), value] as const)
-        .filter(
-          ([key, value]) =>
-            value === true && key !== 'browser' && WORKER_CAPABILITY_NAME_RE.test(key)
-        )
+        .filter(([key, value]) => value === true && WORKER_CAPABILITY_NAME_RE.test(key))
         .map(([key]) => key)
     )
   );
@@ -132,19 +130,6 @@ async function authorizeRunForWorker(
 }
 
 /**
- * Truthy `LOBU_CLOUD_MODE` (`1`/`true`/`yes`, case-insensitive) marks a
- * multi-tenant cloud deployment. Self-hosted / embedded single-tenant installs
- * leave it unset. Mirrors the canonical reader in chat-instance-manager.ts;
- * kept local to avoid coupling worker-api to the connections module.
- */
-function isCloudMode(): boolean {
-  const raw = process.env.LOBU_CLOUD_MODE;
-  if (!raw) return false;
-  const v = raw.trim().toLowerCase();
-  return v === '1' || v === 'true' || v === 'yes';
-}
-
-/**
  * POST /api/workers/poll
  *
  * Worker polls for next available sync run.
@@ -173,9 +158,7 @@ export async function pollWorkerJob(c: Context<{ Bindings: Env }>) {
     return c.json({ error: 'Invalid or missing JSON body' }, 400);
   }
   const sql = getDb();
-  const hasBrowser = capabilities.browser ?? false;
-  // Capability set the worker advertised (excluding browser, which has its
-  // own legacy gate via connector_definitions.api_type). Used to filter on
+  // Capability set the worker advertised, used to filter on
   // connector_definitions.required_capability.
   const advertisedCapabilities = normalizeAdvertisedCapabilities(capabilities);
   // Trusted fleet workers (WORKER_API_TOKEN) run the no-capability cloud
@@ -422,7 +405,7 @@ export async function pollWorkerJob(c: Context<{ Bindings: Env }>) {
         FROM runs r
         LEFT JOIN connections con ON con.id = r.connection_id
         LEFT JOIN LATERAL (
-          SELECT cd.api_type, cd.required_capability
+          SELECT cd.required_capability
           FROM connector_definitions cd
           WHERE cd.key = r.connector_key
             AND cd.organization_id = r.organization_id
@@ -434,10 +417,8 @@ export async function pollWorkerJob(c: Context<{ Bindings: Env }>) {
           AND (r.approval_status = 'auto' OR r.approval_status = 'approved')
           AND (
             -- (1) Connector-worker lanes: sync / action / embed_backfill / auth.
-            --     Browser-only connectors require the browser capability.
             (
               r.run_type IN ('sync', 'action', 'embed_backfill', 'auth')
-              AND (${hasBrowser} OR COALESCE(cd.api_type, 'api') = 'api')
               AND (
                 -- (1A) trusted/anonymous fleet worker: the no-capability cloud
                 --      connectors plus any capability it happens to advertise,


### PR DESCRIPTION
## What

Removes a dead code path in worker-claim routing and consolidates a duplicated helper. **No behavior change** (pure `refactor`).

The worker-claim gate `(hasBrowser OR COALESCE(api_type,'api')='api')` was always true:
- `connector_definitions.api_type` is never written to a non-default value by the install path, so it stayed `'api'` for every row.
- the `browser` capability boolean was stripped out *before* the capability match set (`normalizeAdvertisedCapabilities` excluded it).

So the whole `browser`/`api_type` axis did nothing.

## Changes

- Drop the dead `api_type` reads: the claim-query `SELECT` (`worker-api`), `feed-sync`, and the queryable column entry (`table-schema`).
- Remove the `hasBrowser` var + the `'browser'` exclusion in `normalizeAdvertisedCapabilities`.
- `WorkerCapabilities` `{ browser: boolean }` → `Record<string, boolean>` (matches the wire format); drop the legacy `{ browser: true/false }` advertisements in the embedded worker + connector-worker CLI + Mac bridge.
- Consolidate the thrice-duplicated `isCloudMode()` into `utils/cloud-mode.ts`.

## Deliberately deferred
- **The `api_type` column itself is NOT dropped here.** Migrations run as a Helm `pre-upgrade` hook, so dropping it would break old replicas (still reading it) mid-rollout. A follow-up release drops the column once no deployed code references it (expand/contract).
- A separate effort would make "needs a real browser" (`capture:'cdp'` connectors like revolut) declarative — that's blocked on a deeper question (no worker currently executes CDP connectors via poll-claim), so it's parked, not in this PR.

## Validation
- `make review`: **0 blockers, 0 bugs, bug_free 82, simplicity 88**, all suites green (typecheck/unit/integration = 0).
- connector-worker unit 52/0; scheduling-contract integration 3/3.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactoring**
  * Worker capability system now accepts flexible, custom capability flags.
  * Unified cloud-mode feature-flag detection across the platform.
  * Removed per-feed connector api_type from feed records and query outputs.

* **Bug Fixes**
  * Connector/run selection now uses generalized capability matching instead of prior browser/api_type gating.

* **Tests**
  * Updated tests and embedded worker startup to use the new empty-capabilities shape.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lobu-ai/lobu/pull/1042?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->