### PR TITLE
fix(server): unwedge watchers (array-binding bug) + hardening

### DIFF
--- a/packages/server/src/__tests__/integration/watchers/automation-contract.test.ts
+++ b/packages/server/src/__tests__/integration/watchers/automation-contract.test.ts
@@ -19,6 +19,7 @@ import {
   dispatchPendingWatcherRuns,
   materializeDueWatcherRuns,
   reconcileWatcherRuns,
+  runWatcherAutomationTick,
   sweepStaleWatcherRuns,
 } from '../../../watchers/automation';
 import { generateSecureToken, hashToken } from '../../../auth/oauth/utils';
@@ -1091,6 +1092,95 @@ describe('watcher automation contract', () => {
     // Pre-fix this rejects with `malformed array literal`; post-fix it resolves.
     const result = await reconcileWatcherRuns(getDb());
     expect(result.reconciled).toBe(0);
+  });
+
+  describe('watcher-automation tick orchestration', () => {
+    // End-to-end regression for the 12-day outage: a stuck active run carrying a
+    // dispatched_message_id used to make reconcile throw `malformed array literal`,
+    // which (pre phase-isolation) aborted materialize + dispatch every tick. The
+    // tick must now (a) not surface a reconcile error and (b) still materialize a
+    // separate due watcher.
+    it('survives a wedging in-flight run and still materializes other due watchers', async () => {
+      const { sql, dbClient, workspace, watcherId, agent } = await createAutomatedWatcher();
+
+      // Watcher A: a stuck active run with a dispatched_message_id and no window —
+      // the exact shape of prod run 146501 that wedged reconcile.
+      const granularity = inferWatcherGranularityFromSchedule('0 9 * * *');
+      const { windowStart, windowEnd } = await computePendingWindow(dbClient, watcherId, granularity);
+      const stuck = await createWatcherRun({
+        organizationId: workspace.org.id,
+        watcherId,
+        agentId: agent.agentId,
+        windowStart: windowStart.toISOString(),
+        windowEnd: windowEnd.toISOString(),
+        dispatchSource: 'scheduled',
+      });
+      await sql`
+        UPDATE runs
+        SET status = 'running', claimed_at = NOW(), claimed_by = ${`lobu:${agent.agentId}`},
+            dispatched_message_id = 'f7623d32-b589-4085-9504-edbf30925961'
+        WHERE id = ${stuck.runId}
+      `;
+
+      // Watcher B: due, no active run, valid agent → must materialize this tick.
+      const entityB = await createTestEntity({
+        name: 'Tick Entity B',
+        organization_id: workspace.org.id,
+        created_by: workspace.users.owner.id,
+      });
+      const watcherB = (await workspace.owner.watchers.create({
+        entity_id: entityB.id,
+        slug: 'tick-watcher-b',
+        name: 'Tick Watcher B',
+        prompt: 'Summarize content for {{entities}}.',
+        extraction_schema: {
+          type: 'object',
+          properties: { summary: { type: 'string' } },
+          required: ['summary'],
+        },
+        schedule: '0 9 * * *',
+        agent_id: agent.agentId,
+      })) as { watcher_id: string };
+      const watcherBId = Number(watcherB.watcher_id);
+      await sql`UPDATE watchers SET next_run_at = NOW() - INTERVAL '10 minutes' WHERE id = ${watcherBId}`;
+
+      const result = await runWatcherAutomationTick({} as Env);
+
+      // No phase threw — the bind fix means reconcile handles the dispatched-id
+      // array, and isolation means a phase failure wouldn't starve the rest.
+      expect(result.errors).toEqual([]);
+      // Watcher B materialized despite watcher A's stuck run.
+      expect(result.runsCreated).toBeGreaterThanOrEqual(1);
+      const [runB] = await sql`
+        SELECT status FROM runs
+        WHERE watcher_id = ${watcherBId} AND run_type = 'watcher'
+      `;
+      expect(runB).toBeDefined();
+    });
+
+    // Item 1: a watcher whose assigned agent no longer exists (and isn't device
+    // pinned) must NOT be scheduled — no doomed run per tick — and be counted as
+    // unrunnable for visibility. Mirrors prod orgs lobu-crm / lobu-team.
+    it('does not schedule a watcher whose agent does not exist; counts it unrunnable', async () => {
+      const { sql, watcherId } = await createAutomatedWatcher();
+
+      // Point the watcher at a non-existent agent, no device pin, due now.
+      await sql`
+        UPDATE watchers
+        SET agent_id = 'ghost-agent-deleted', device_worker_id = NULL,
+            next_run_at = NOW() - INTERVAL '10 minutes'
+        WHERE id = ${watcherId}
+      `;
+
+      const result = await materializeDueWatcherRuns({} as Env);
+
+      expect(result.runsCreated).toBe(0);
+      expect(result.unrunnable).toBeGreaterThanOrEqual(1);
+      const runs = await sql`
+        SELECT id FROM runs WHERE watcher_id = ${watcherId} AND run_type = 'watcher'
+      `;
+      expect(runs).toHaveLength(0);
+    });
   });
 
   describe('sweepStaleWatcherRuns liveness reaping', () => {

--- a/packages/server/src/__tests__/integration/watchers/automation-contract.test.ts
+++ b/packages/server/src/__tests__/integration/watchers/automation-contract.test.ts
@@ -10,6 +10,7 @@
 import { inferWatcherGranularityFromSchedule } from '@lobu/connector-sdk';
 import { beforeEach, describe, expect, it } from 'vitest';
 import type { DbClient } from '../../../db/client';
+import { getDb } from '../../../db/client';
 import type { Env } from '../../../index';
 import { generateWindowToken } from '../../../utils/jwt';
 import { createWatcherRun } from '../../../utils/queue-helpers';
@@ -17,6 +18,7 @@ import { computePendingWindow } from '../../../utils/window-utils';
 import {
   dispatchPendingWatcherRuns,
   materializeDueWatcherRuns,
+  reconcileWatcherRuns,
   sweepStaleWatcherRuns,
 } from '../../../watchers/automation';
 import { generateSecureToken, hashToken } from '../../../auth/oauth/utils';
@@ -1043,6 +1045,52 @@ describe('watcher automation contract', () => {
 
       expect(secondNextRunMs).toBe(firstNextRunMs);
     });
+  });
+
+  // Regression: an active watcher run carrying a `dispatched_message_id` must
+  // not crash reconciliation. The dispatched-id containment query bound the JS
+  // array straight into `= ANY(${ids})`. The production pool (db/client.ts) runs
+  // with `fetch_types: false`, so postgres.js can't infer the array element type
+  // and ships the lone element as a scalar — PG then throws
+  // `malformed array literal: "<uuid>"`. Because `watcher-automation` (every
+  // tick) AND `check-stalled-executions` both call reconcileWatcherRuns, a single
+  // such run wedged BOTH jobs — watchers stopped firing in prod for 12 days (run
+  // 146501 stuck `running` since 2026-05-13, which also blocked the reaper that
+  // would have cleared it). Fix: bind via pgTextArray(...)::text[], the same
+  // explicit-literal idiom every other ANY() in this file already uses.
+  //
+  // NOTE: this MUST exercise getDb() (the prod pool with fetch_types:false), not
+  // the test-harness client — the latter fetches types and silently masks the
+  // bug. Both clients point at the same DATABASE_URL test database here.
+  it('reconciles without crashing when an active run carries a dispatched_message_id', async () => {
+    const { sql, dbClient, workspace, watcherId, agent } = await createAutomatedWatcher();
+    const granularity = inferWatcherGranularityFromSchedule('0 9 * * *');
+    const { windowStart, windowEnd } = await computePendingWindow(dbClient, watcherId, granularity);
+    const queued = await createWatcherRun({
+      organizationId: workspace.org.id,
+      watcherId,
+      agentId: agent.agentId,
+      windowStart: windowStart.toISOString(),
+      windowEnd: windowEnd.toISOString(),
+      dispatchSource: 'scheduled',
+    });
+
+    // Move the run to an active state with a dispatched_message_id and NO
+    // watcher_windows row — mirrors prod's stuck run 146501 exactly, so the
+    // first reconcile query is a no-op and execution reaches the buggy
+    // dispatched-id containment query.
+    await sql`
+      UPDATE runs
+      SET status = 'running',
+          claimed_at = NOW(),
+          claimed_by = ${`lobu:${agent.agentId}`},
+          dispatched_message_id = 'f7623d32-b589-4085-9504-edbf30925961'
+      WHERE id = ${queued.runId}
+    `;
+
+    // Pre-fix this rejects with `malformed array literal`; post-fix it resolves.
+    const result = await reconcileWatcherRuns(getDb());
+    expect(result.reconciled).toBe(0);
   });
 
   describe('sweepStaleWatcherRuns liveness reaping', () => {

--- a/packages/server/src/__tests__/setup/test-db.ts
+++ b/packages/server/src/__tests__/setup/test-db.ts
@@ -8,6 +8,7 @@
 import { existsSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import postgres from 'postgres';
+import { PROD_PG_VALUE_OPTIONS } from '../../db/client';
 import { listMigrationFiles, loadMigrationUpSection } from '../../db/migration-loader';
 import { clearInMemoryMcpSessionsForTests } from '../../mcp-session-state';
 import { clearMultiTenantCachesForTests } from '../../workspace/multi-tenant-caches';
@@ -101,6 +102,11 @@ export function getTestDb(): postgres.Sql {
       // Integration tests trigger many CASCADE/TRUNCATE notices; suppress them to
       // reduce noisy output and hook slowdowns.
       onnotice: () => {},
+      // Share prod's value-serialization config (fetch_types:false + JSON/bigint
+      // handling) so tests exercise the SAME client behavior as production. A
+      // forgiving test client masked the `= ANY(${jsArray})` bug that wedged
+      // watchers for 12 days (it only throws under fetch_types:false).
+      ...PROD_PG_VALUE_OPTIONS,
     });
   }
   return sql;

--- a/packages/server/src/db/client.ts
+++ b/packages/server/src/db/client.ts
@@ -103,6 +103,55 @@ interface CreatedDbClient {
   raw: Sql;
 }
 
+/**
+ * postgres.js options that control how VALUES are (de)serialized — as opposed
+ * to pool/connection knobs. These MUST be shared verbatim by every client that
+ * stands in for prod (notably the integration-test client, `getTestDb()`):
+ * `fetch_types: false` changes type inference, and a query whose correctness
+ * depends on it (e.g. `= ANY(${jsArray})`, which needs `pgTextArray(...)::text[]`)
+ * behaves differently between a fetch-types client and this one. Tests that run
+ * against a different value-serialization config silently mask that class of bug.
+ */
+export const PROD_PG_VALUE_OPTIONS = {
+  fetch_types: false,
+  transform: {
+    value: {
+      // IMPORTANT: fetch_types: false means postgres.js doesn't auto-parse
+      // JSON/JSONB columns. This transform runs on every value in every row
+      // (both tagged-template and sql.unsafe() queries) and parses any
+      // JSON/JSONB column based on its PostgreSQL OID. This is the single
+      // source of truth for JSONB parsing — no per-field workarounds needed.
+      from: (value: unknown, column: { type: number }) => {
+        if (
+          (column.type === PG_OID_JSON || column.type === PG_OID_JSONB) &&
+          typeof value === 'string'
+        ) {
+          try {
+            return JSON.parse(value);
+          } catch {
+            return value;
+          }
+        }
+        return value;
+      },
+    },
+  },
+  types: {
+    bigint: {
+      to: 20,
+      from: [20],
+      parse: (value: string) => {
+        const num = Number(value);
+        if (process.env.NODE_ENV === 'development' && !Number.isSafeInteger(num)) {
+          logger.warn({ value, parsed: num }, 'BIGINT value exceeds safe integer range');
+        }
+        return num;
+      },
+      serialize: (value: number) => String(value),
+    },
+  },
+};
+
 function createDbClient(connectionString: string, maxConnections?: number): CreatedDbClient {
   const poolMax = maxConnections ?? parseInt(process.env.DB_POOL_MAX || '20', 10);
 
@@ -118,43 +167,7 @@ function createDbClient(connectionString: string, maxConnections?: number): Crea
     connection: {
       application_name: 'server',
     },
-    fetch_types: false,
-    transform: {
-      value: {
-        // IMPORTANT: fetch_types: false means postgres.js doesn't auto-parse
-        // JSON/JSONB columns. This transform runs on every value in every row
-        // (both tagged-template and sql.unsafe() queries) and parses any
-        // JSON/JSONB column based on its PostgreSQL OID. This is the single
-        // source of truth for JSONB parsing — no per-field workarounds needed.
-        from: (value: unknown, column: { type: number }) => {
-          if (
-            (column.type === PG_OID_JSON || column.type === PG_OID_JSONB) &&
-            typeof value === 'string'
-          ) {
-            try {
-              return JSON.parse(value);
-            } catch {
-              return value;
-            }
-          }
-          return value;
-        },
-      },
-    },
-    types: {
-      bigint: {
-        to: 20,
-        from: [20],
-        parse: (value: string) => {
-          const num = Number(value);
-          if (process.env.NODE_ENV === 'development' && !Number.isSafeInteger(num)) {
-            logger.warn({ value, parsed: num }, 'BIGINT value exceeds safe integer range');
-          }
-          return num;
-        },
-        serialize: (value: number) => String(value),
-      },
-    },
+    ...PROD_PG_VALUE_OPTIONS,
   });
 
   // Hand back the raw postgres.js client directly. An earlier serialization

--- a/packages/server/src/scheduled/check-stalled-executions.ts
+++ b/packages/server/src/scheduled/check-stalled-executions.ts
@@ -267,10 +267,26 @@ export function stopStaleRunReaper(): void {
 export async function checkStalledExecutions(_env: Env): Promise<void> {
   const sql = getDb();
 
-  await reconcileWatcherRuns(sql);
-  await sweepStaleWatcherRuns(sql);
-
-  await reapStaleRuns();
+  // Isolate each phase: this cron is the safety net that reaps stuck runs, so a
+  // throw in watcher reconcile/sweep (e.g. the `malformed array literal` bug,
+  // lobu#1046) must NOT prevent reapStaleRuns from running — otherwise the reaper
+  // that would clear the very run triggering the throw is itself disabled
+  // (self-deadlock).
+  try {
+    await reconcileWatcherRuns(sql);
+  } catch (error) {
+    logger.error({ error }, '[StalledRuns] reconcileWatcherRuns failed');
+  }
+  try {
+    await sweepStaleWatcherRuns(sql);
+  } catch (error) {
+    logger.error({ error }, '[StalledRuns] sweepStaleWatcherRuns failed');
+  }
+  try {
+    await reapStaleRuns();
+  } catch (error) {
+    logger.error({ error }, '[StalledRuns] reapStaleRuns failed');
+  }
 
   try {
     const expiredCount = await expireStaleConnectTokens();

--- a/packages/server/src/scheduled/jobs.ts
+++ b/packages/server/src/scheduled/jobs.ts
@@ -10,12 +10,7 @@ import type { Env } from '@lobu/connector-sdk';
 import type { CoreServices } from '../gateway/services/core-services';
 import { cleanupExpiredMcpSessions } from '../mcp-handler';
 import logger from '../utils/logger';
-import {
-  dispatchPendingWatcherRuns,
-  materializeDueWatcherRuns,
-  reconcileWatcherRuns,
-  resetOrphanedWatcherRuns,
-} from '../watchers/automation';
+import { runWatcherAutomationTick } from '../watchers/automation';
 import { checkStalledExecutions } from './check-stalled-executions';
 import { runClassificationReconciliation } from './classification-reconciliation';
 import { registerScheduledJobsTicker } from './scheduled-jobs-service';
@@ -145,28 +140,16 @@ function registerMaintenanceTasks(
   // Watcher automation: reconcile in-flight runs, materialize newly-due runs,
   // dispatch pending runs. The orphaned-runs reset is bounded and idempotent
   // so it runs every tick — no per-pod first-tick latch needed.
+  //
+  // Each phase is isolated: a throw in one (e.g. the `malformed array literal`
+  // bug that wedged reconcile, lobu#1046) must NOT abort the later phases —
+  // otherwise a single fault stops materialize+dispatch and no watcher fires.
   scheduler.register(
     'watcher-automation',
     async () => {
-      const { reset } = await resetOrphanedWatcherRuns();
-      if (reset > 0) {
-        logger.info({ reset }, '[task] watcher-automation: reset orphaned runs');
-      }
-      const reconciliation = await reconcileWatcherRuns();
-      const materialize = await materializeDueWatcherRuns(env);
-      const dispatch = await dispatchPendingWatcherRuns(env);
-
+      const { errors, ...summary } = await runWatcherAutomationTick(env);
       logger.info(
-        {
-          reconciled: reconciliation.reconciled,
-          dueWatchers: materialize.dueWatchers,
-          runsCreated: materialize.runsCreated,
-          skipped: materialize.skipped,
-          claimed: dispatch.claimed,
-          dispatched: dispatch.dispatched,
-          dispatchReconciled: dispatch.reconciled,
-          failed: dispatch.failed,
-        },
+        { ...summary, ...(errors.length > 0 ? { errors } : {}) },
         '[task] watcher-automation completed',
       );
     },

--- a/packages/server/src/watchers/automation.ts
+++ b/packages/server/src/watchers/automation.ts
@@ -577,8 +577,10 @@ export async function materializeDueWatcherRuns(
     LIMIT 100
   `;
 
-  // Count (cheap, tiny table) due active watchers that were filtered out for
-  // lacking a runnable executor — for visibility in the tick summary.
+  // Count (cheap, tiny table) due active watchers that this tick filtered out
+  // SOLELY for lacking a runnable executor — for visibility in the tick summary.
+  // Mirrors the dueWatchers predicate (incl. the no-active-run clause) so a ghost
+  // watcher that already has an in-flight run isn't double-counted here.
   const [unrunnableRow] = await sql<{ count: number }>`
     SELECT count(*)::int AS count
     FROM watchers w
@@ -591,6 +593,12 @@ export async function materializeDueWatcherRuns(
         SELECT 1 FROM agents a
         WHERE a.id = w.agent_id
           AND a.organization_id = w.organization_id
+      )
+      AND NOT EXISTS (
+        SELECT 1 FROM runs r
+        WHERE r.watcher_id = w.id
+          AND r.run_type = 'watcher'
+          AND r.status = ANY(${runStatusLiteral(ACTIVE_RUN_STATUSES)}::text[])
       )
   `;
   const unrunnable = unrunnableRow?.count ?? 0;

--- a/packages/server/src/watchers/automation.ts
+++ b/packages/server/src/watchers/automation.ts
@@ -55,6 +55,11 @@ interface MaterializeDueWatcherRunsResult {
   dueWatchers: number;
   runsCreated: number;
   skipped: number;
+  /** Due active watchers NOT scheduled because they have no runnable executor
+   *  (no device pin AND no matching agents row). Surfaced so a misconfigured
+   *  watcher whose agent was deleted is visible in the tick summary instead of
+   *  silently never running. */
+  unrunnable: number;
 }
 
 interface DispatchWatcherRunsResult {
@@ -535,15 +540,33 @@ export async function materializeDueWatcherRuns(
 ): Promise<MaterializeDueWatcherRunsResult> {
   const sql = db ?? getDb();
 
+  // Only schedule watchers we can actually execute: either device-pinned (an
+  // external/device worker claims it via the poll lane — no cloud agent row
+  // needed) OR the assigned agent still exists in the org. A watcher whose
+  // `agents` row was deleted is otherwise materialized every cron tick and fails
+  // at dispatch ("Assigned agent ... does not exist"). Skipping at the source is
+  // self-healing: it resumes automatically if the agent is recreated. The
+  // dispatch-time `ensureWatcherAgentExists` check stays as a delete-after-select
+  // backstop.
   const dueWatchers = await sql<DueWatcherRow>`
     SELECT w.id, w.organization_id, w.agent_id, w.schedule,
            w.device_worker_id::text AS device_worker_id, w.agent_kind
     FROM watchers w
     WHERE w.status = 'active'
-      AND w.agent_id IS NOT NULL
       AND w.schedule IS NOT NULL
       AND w.next_run_at IS NOT NULL
       AND w.next_run_at <= current_timestamp
+      AND (
+        w.device_worker_id IS NOT NULL
+        OR (
+          w.agent_id IS NOT NULL
+          AND EXISTS (
+            SELECT 1 FROM agents a
+            WHERE a.id = w.agent_id
+              AND a.organization_id = w.organization_id
+          )
+        )
+      )
       AND NOT EXISTS (
         SELECT 1 FROM runs r
         WHERE r.watcher_id = w.id
@@ -554,8 +577,26 @@ export async function materializeDueWatcherRuns(
     LIMIT 100
   `;
 
+  // Count (cheap, tiny table) due active watchers that were filtered out for
+  // lacking a runnable executor — for visibility in the tick summary.
+  const [unrunnableRow] = await sql<{ count: number }>`
+    SELECT count(*)::int AS count
+    FROM watchers w
+    WHERE w.status = 'active'
+      AND w.schedule IS NOT NULL
+      AND w.next_run_at IS NOT NULL
+      AND w.next_run_at <= current_timestamp
+      AND w.device_worker_id IS NULL
+      AND NOT EXISTS (
+        SELECT 1 FROM agents a
+        WHERE a.id = w.agent_id
+          AND a.organization_id = w.organization_id
+      )
+  `;
+  const unrunnable = unrunnableRow?.count ?? 0;
+
   if (dueWatchers.length === 0) {
-    return { dueWatchers: 0, runsCreated: 0, skipped: 0 };
+    return { dueWatchers: 0, runsCreated: 0, skipped: 0, unrunnable };
   }
 
   let runsCreated = 0;
@@ -582,6 +623,64 @@ export async function materializeDueWatcherRuns(
     dueWatchers: dueWatchers.length,
     runsCreated,
     skipped,
+    unrunnable,
+  };
+}
+
+export interface WatcherAutomationTickResult {
+  reset: number | null;
+  reconciled: number | null;
+  dueWatchers: number | null;
+  runsCreated: number | null;
+  skipped: number | null;
+  unrunnable: number | null;
+  claimed: number | null;
+  dispatched: number | null;
+  dispatchReconciled: number | null;
+  failed: number | null;
+  /** Phases that threw this tick (empty on a clean tick). */
+  errors: string[];
+}
+
+/**
+ * One watcher-automation tick: reset orphaned runs → reconcile in-flight →
+ * materialize newly-due → dispatch pending. Each phase is isolated so a throw in
+ * one cannot abort the others — the regression that wedged prod (lobu#1046) was a
+ * throw in `reconcile` taking down `materialize`+`dispatch` for 12 days. Returns
+ * a summary (nulls for phases that threw) plus the names of any failed phases.
+ *
+ * Extracted from the scheduler registration so the orchestration is unit/integration
+ * testable without standing up the full TaskScheduler.
+ */
+export async function runWatcherAutomationTick(env: Env): Promise<WatcherAutomationTickResult> {
+  const errors: string[] = [];
+  const phase = async <T>(name: string, fn: () => Promise<T>): Promise<T | null> => {
+    try {
+      return await fn();
+    } catch (err) {
+      errors.push(name);
+      logger.error({ err, phase: name }, '[watcher-automation] phase failed');
+      return null;
+    }
+  };
+
+  const reset = await phase('reset', () => resetOrphanedWatcherRuns());
+  const reconciliation = await phase('reconcile', () => reconcileWatcherRuns());
+  const materialize = await phase('materialize', () => materializeDueWatcherRuns(env));
+  const dispatch = await phase('dispatch', () => dispatchPendingWatcherRuns(env));
+
+  return {
+    reset: reset?.reset ?? null,
+    reconciled: reconciliation?.reconciled ?? null,
+    dueWatchers: materialize?.dueWatchers ?? null,
+    runsCreated: materialize?.runsCreated ?? null,
+    skipped: materialize?.skipped ?? null,
+    unrunnable: materialize?.unrunnable ?? null,
+    claimed: dispatch?.claimed ?? null,
+    dispatched: dispatch?.dispatched ?? null,
+    dispatchReconciled: dispatch?.reconciled ?? null,
+    failed: dispatch?.failed ?? null,
+    errors,
   };
 }
 

--- a/packages/server/src/watchers/automation.ts
+++ b/packages/server/src/watchers/automation.ts
@@ -2,7 +2,7 @@ import { randomUUID } from 'node:crypto';
 import { generateWorkerToken } from '@lobu/core';
 import { inferWatcherGranularityFromSchedule } from '@lobu/connector-sdk';
 import type { DbClient } from '../db/client';
-import { getDb } from '../db/client';
+import { getDb, pgTextArray } from '../db/client';
 import type { Env } from '../index';
 import {
   getLobuCoreServices,
@@ -388,7 +388,7 @@ export async function reconcileWatcherRuns(db?: DbClient): Promise<ReconcileWatc
      AND rp.payload->'processedMessageIds' ? r.dispatched_message_id
     WHERE r.run_type = 'watcher'
       AND r.status = ANY(${runStatusLiteral(ACTIVE_RUN_STATUSES)}::text[])
-      AND r.dispatched_message_id = ANY(${pendingDispatchIds})
+      AND r.dispatched_message_id = ANY(${pgTextArray(pendingDispatchIds)}::text[])
     ORDER BY r.dispatched_message_id ASC
     LIMIT 100
   `;


### PR DESCRIPTION
## Summary

Every watcher in prod stopped firing on **2026-05-13 ~08:00 UTC** for 12 days. Root cause: one SQL array-binding line. This PR fixes it and hardens the subsystem so the same class can't recur or self-deadlock. Plan reviewed by `pi` before implementation; diff reviewed by `pi` after (no blocking issues).

## The bug

`reconcileWatcherRuns` bound a raw JS array into `= ANY(${pendingDispatchIds})`. The prod pool (`db/client.ts`) runs with **`fetch_types: false`**, so postgres.js can't infer the array element type and ships the lone element as a scalar → `malformed array literal: "<uuid>"`. Every other `ANY()` in the file uses the `pgTextArray(...)::text[]` idiom for exactly this reason; line 391 was the lone exception.

It only fires when ≥1 **active** watcher run carries a `dispatched_message_id`. Run 146501 (stuck `running` since 05-13) tripped it on every `watcher-automation` tick (every minute) **and** every `check-stalled-executions` tick — both call `reconcileWatcherRuns`. So the scheduler **and** the reaper that would have cleared the triggering run both died: **self-deadlock**. 27,141 + 3,601 failed task runs traced to it.

## Changes

**Fix**
- `reconcileWatcherRuns`: bind via `pgTextArray(pendingDispatchIds)::text[]`.

**Hardening (root cause + blast radius)**
- **Tests now use the production DB client config.** Extracted prod's value-serialization options (`fetch_types:false` + JSON/bigint handling) to a shared `PROD_PG_VALUE_OPTIONS`; `getTestDb()` reuses them. The original bug was invisible to the suite because the test client fetched types and silently made `= ANY(${jsArray})` work. **This is what would have caught it.**
- **Per-phase isolation.** `watcher-automation` extracted to `runWatcherAutomationTick`; each phase (reset/reconcile/materialize/dispatch) is isolated so one throw can't starve the rest. `checkStalledExecutions` isolates all three phases so `reapStaleRuns` always runs (kills the self-deadlock).
- **Don't schedule unrunnable watchers.** `materializeDueWatcherRuns` only schedules watchers with a runnable executor — device-pinned **or** a matching `agents` row. A watcher whose agent was deleted is skipped at the source (self-healing) and surfaced as `unrunnable` in the tick summary instead of minting a doomed run every tick. (`ensureWatcherAgentExists` stays as a dispatch-time backstop.) Fixes the prod `lobu-crm`/`lobu-team` watchers that point at deleted agents.

## Tests (red → green)

- Reproducer: an active watcher run with a `dispatched_message_id` reconciles cleanly — calls `getDb()` (the prod pool) on purpose; red emits the exact `malformed array literal` error, green passes.
- Tick survives a wedging in-flight run and still materializes other due watchers.
- A dangling-agent watcher is not scheduled and is counted `unrunnable`.

Local: tsc clean; watcher suite 25/25; full server integration suite 757 passing (4 failures are pre-existing local-env: `getPublicWebUrl` fallback needs `PUBLIC_WEB_URL`, and a `connector_definitions.api_type` schema drift predating this change — none touch files in this PR).

## Prod remediation already applied
Stuck run 146501 was manually marked `timeout` to unblock immediately, but that's not durable (any in-flight watcher re-wedges the buggy code). This PR is the durable fix; merging auto-builds an image that Flux deploys to `summaries-prod`.

> Out of scope (follow-ups): alerting/SLO on scheduler-tick + watcher-run failure rate; the `api_type` schema drift; recreating agents for the `lobu-crm`/`lobu-team` watchers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a multi-phase watcher automation tick that runs reconcile/materialize/dispatch resiliently and reports per-tick errors and an “unrunnable” count.

* **Bug Fixes**
  * Prevented crashes when reconciling watcher runs that reference orphaned dispatch records.

* **Stability / Jobs**
  * Scheduled watcher job and stalled-execution cron now continue later phases even if earlier phases fail.

* **Tests**
  * Added regression and end-to-end tests for stuck in-flight runs, materialization, unrunnable-worker handling, and test DB behavior aligned with production.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lobu-ai/lobu/pull/1046?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->