### PR TITLE
feat(server): watcher/scheduler health metrics + ServiceMonitor/PrometheusRule

### DIFF
--- a/charts/lobu/templates/prometheusrule.yaml
+++ b/charts/lobu/templates/prometheusrule.yaml
@@ -1,0 +1,57 @@
+{{- if .Values.metrics.prometheusRule.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: {{ include "lobu.fullname" . }}-watchers
+  {{- with .Values.metrics.prometheusRule.namespace }}
+  namespace: {{ . }}
+  {{- end }}
+  labels:
+    {{- include "lobu.labels" . | nindent 4 }}
+    {{- /* kube-prometheus-stack selects rules by ruleSelector: release=kube-prometheus-stack */}}
+    {{- with .Values.metrics.prometheusRule.additionalLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  groups:
+    - name: lobu-watchers
+      rules:
+        # Heartbeat / dead-man's-switch. The 12-day outage (lobu#1046) was a
+        # SILENT one: the app was healthy but watcher-automation produced zero
+        # successful ticks. Alert on the ABSENCE of success, not just on errors.
+        # `or on() vector(0)` makes it fire even if the series disappears (all
+        # replicas down / never scraped).
+        - alert: WatcherAutomationSilent
+          expr: |
+            (sum(increase(lobu_scheduled_job_runs_total{job="watcher-automation",outcome="success"}[15m])) or on() vector(0)) == 0
+          for: 15m
+          labels:
+            severity: critical
+            service: lobu
+          annotations:
+            summary: "Lobu watcher-automation has produced no successful tick in 15m"
+            description: "The watcher scheduler is silent or failing on every tick across all replicas. Watchers are not firing. See runs table (run_type='watcher') and app logs for `[task] watcher-automation`."
+        # Internal phase failures. Post-hardening the tick swallows phase errors
+        # (so the scheduler-level counter shows success); this surfaces them.
+        - alert: WatcherAutomationPhaseFailing
+          expr: |
+            sum(increase(lobu_watcher_automation_phase_failures_total[15m])) by (phase) > 0
+          for: 15m
+          labels:
+            severity: warning
+            service: lobu
+          annotations:
+            summary: "Lobu watcher-automation phase {{`{{ $labels.phase }}`}} is failing"
+            description: "The {{`{{ $labels.phase }}`}} phase of watcher-automation threw repeatedly over 15m. Check app logs for `[watcher-automation] phase failed`."
+        # A critical scheduled job erroring repeatedly (e.g. the stale-run reaper).
+        - alert: LobuScheduledJobFailing
+          expr: |
+            sum(increase(lobu_scheduled_job_runs_total{job=~"watcher-automation|check-stalled-executions",outcome="error"}[15m])) by (job) > 0
+          for: 15m
+          labels:
+            severity: warning
+            service: lobu
+          annotations:
+            summary: "Lobu scheduled job {{`{{ $labels.job }}`}} is failing"
+            description: "The {{`{{ $labels.job }}`}} cron task threw on every run over 15m."
+{{- end }}

--- a/charts/lobu/templates/service.yaml
+++ b/charts/lobu/templates/service.yaml
@@ -4,6 +4,7 @@ metadata:
   name: {{ include "lobu.fullname" . }}-app
   labels:
     {{- include "lobu.labels" . | nindent 4 }}
+    app.kubernetes.io/component: api
 spec:
   type: {{ .Values.service.type }}
   {{- with .Values.service.sessionAffinity }}

--- a/charts/lobu/templates/servicemonitor.yaml
+++ b/charts/lobu/templates/servicemonitor.yaml
@@ -1,0 +1,30 @@
+{{- if .Values.metrics.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "lobu.fullname" . }}-app
+  {{- with .Values.metrics.serviceMonitor.namespace }}
+  namespace: {{ . }}
+  {{- end }}
+  labels:
+    {{- include "lobu.labels" . | nindent 4 }}
+    app.kubernetes.io/component: api
+    {{- /* The kube-prometheus-stack Prometheus selects ServiceMonitors by this
+           label (serviceMonitorSelector: release=kube-prometheus-stack). Without
+           it the monitor is silently ignored. */}}
+    {{- with .Values.metrics.serviceMonitor.additionalLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  selector:
+    matchLabels:
+      {{- include "lobu.appSelectorLabels" . | nindent 6 }}
+  endpoints:
+    - port: http
+      path: /metrics
+      interval: {{ .Values.metrics.serviceMonitor.interval }}
+      scrapeTimeout: {{ .Values.metrics.serviceMonitor.scrapeTimeout }}
+{{- end }}

--- a/charts/lobu/values.yaml
+++ b/charts/lobu/values.yaml
@@ -219,3 +219,20 @@ releaseGates:
       conversationIdPrefix: "smoke-"
       timeoutSeconds: 90
       intervalSeconds: 3
+
+# Prometheus metrics scraping + alerting. Requires the prometheus-operator CRDs
+# (kube-prometheus-stack). Both default OFF so the chart installs without the
+# operator; the prod overlay (owletto-deploy) turns them on. The Prometheus in
+# this cluster selects by `release: kube-prometheus-stack`, so set that under
+# additionalLabels when enabling.
+metrics:
+  serviceMonitor:
+    enabled: false
+    # namespace: ""        # defaults to the release namespace
+    interval: 30s
+    scrapeTimeout: 10s
+    additionalLabels: {}   # e.g. { release: kube-prometheus-stack }
+  prometheusRule:
+    enabled: false
+    # namespace: ""
+    additionalLabels: {}   # e.g. { release: kube-prometheus-stack }

--- a/packages/server/src/gateway/metrics/prometheus.ts
+++ b/packages/server/src/gateway/metrics/prometheus.ts
@@ -64,7 +64,34 @@ function initializeMetrics() {
     "gauge"
   );
 
-  setGauge("lobu_process_start_time_seconds", Math.floor(Date.now() / 1000));
+  // Scheduler + watcher-automation health. These back the prod alerting rules
+  // (charts/lobu PrometheusRule): a silent scheduler / failing watcher tick is
+  // exactly the failure mode that went undetected for 12 days (lobu#1046).
+  // Per-pod in-memory counters are the correct Prometheus model — each pod's
+  // /metrics is scraped and summed across pods; counter resets on restart are
+  // handled by rate()/increase().
+  registerMetric(
+    "lobu_scheduled_job_runs_total",
+    "Scheduled (cron) task ticks by job name and outcome (success|error)",
+    "counter"
+  );
+  registerMetric(
+    "lobu_watcher_automation_phase_failures_total",
+    "watcher-automation phases that threw, by phase (reset|reconcile|materialize|dispatch)",
+    "counter"
+  );
+  registerMetric(
+    "lobu_watcher_runs_created_total",
+    "Watcher runs materialized (enqueued) by the scheduler",
+    "counter"
+  );
+  registerMetric(
+    "lobu_watchers_unrunnable",
+    "Due active watchers skipped this tick for lacking a runnable executor (no device pin, no agent row)",
+    "gauge"
+  );
+
+  setGaugeInternal("lobu_process_start_time_seconds", Math.floor(Date.now() / 1000));
   logger.info("Prometheus metrics initialized");
 }
 
@@ -76,7 +103,7 @@ function registerMetric(
   metrics.set(name, { name, help, type, values: [] });
 }
 
-function setGauge(
+function setGaugeInternal(
   name: string,
   value: number,
   labels: Record<string, string> = {}
@@ -95,6 +122,35 @@ function setGauge(
     existing.value = value;
   } else {
     metric.values.push({ value, labels });
+  }
+}
+
+export function setGauge(
+  name: string,
+  value: number,
+  labels: Record<string, string> = {}
+): void {
+  setGaugeInternal(name, value, labels);
+}
+
+export function incrementCounter(
+  name: string,
+  labels: Record<string, string> = {},
+  by = 1
+): void {
+  const metric = metrics.get(name);
+  if (!metric || metric.type !== "counter") {
+    logger.warn(`Counter metric ${name} not found`);
+    return;
+  }
+  const labelKey = JSON.stringify(labels);
+  const existing = metric.values.find(
+    (entry) => JSON.stringify(entry.labels) === labelKey
+  );
+  if (existing) {
+    existing.value += by;
+  } else {
+    metric.values.push({ value: by, labels });
   }
 }
 

--- a/packages/server/src/scheduled/task-scheduler.ts
+++ b/packages/server/src/scheduled/task-scheduler.ts
@@ -42,6 +42,7 @@
 
 import { createLogger } from '@lobu/core';
 import * as Sentry from '@sentry/node';
+import { incrementCounter } from '../gateway/metrics/prometheus';
 import type { IMessageQueue, QueueJob } from '../gateway/infrastructure/queue/types';
 import { nextRunAt } from '../utils/cron';
 
@@ -246,10 +247,26 @@ export class TaskScheduler {
       await this.seedNextCronTick(reg, new Date(fromTick.getTime() + 1));
     }
 
-    await reg.handler({
-      payload: data.payload,
-      taskRunId: Number(job.id),
-    });
+    // Per-tick outcome counter — the scheduler heartbeat that backs the
+    // "watcher-automation silent / failing" alerts. Counts every dispatched
+    // task; alerts filter by job name. Re-throw is preserved so the runs-queue
+    // retry path is unchanged.
+    try {
+      await reg.handler({
+        payload: data.payload,
+        taskRunId: Number(job.id),
+      });
+      incrementCounter('lobu_scheduled_job_runs_total', {
+        job: data.name,
+        outcome: 'success',
+      });
+    } catch (err) {
+      incrementCounter('lobu_scheduled_job_runs_total', {
+        job: data.name,
+        outcome: 'error',
+      });
+      throw err;
+    }
   }
 
   /** Insert (or no-op if already present) a row for this task's next cron

--- a/packages/server/src/watchers/automation.ts
+++ b/packages/server/src/watchers/automation.ts
@@ -3,6 +3,7 @@ import { generateWorkerToken } from '@lobu/core';
 import { inferWatcherGranularityFromSchedule } from '@lobu/connector-sdk';
 import type { DbClient } from '../db/client';
 import { getDb, pgTextArray } from '../db/client';
+import { incrementCounter, setGauge } from '../gateway/metrics/prometheus';
 import type { Env } from '../index';
 import {
   getLobuCoreServices,
@@ -676,6 +677,19 @@ export async function runWatcherAutomationTick(env: Env): Promise<WatcherAutomat
   const reconciliation = await phase('reconcile', () => reconcileWatcherRuns());
   const materialize = await phase('materialize', () => materializeDueWatcherRuns(env));
   const dispatch = await phase('dispatch', () => dispatchPendingWatcherRuns(env));
+
+  // Emit health metrics. The scheduler-level success/error counter can't see
+  // these because this tick swallows phase errors (returns them in `errors`),
+  // so surface phase failures + materialization health explicitly for alerting.
+  for (const failedPhase of errors) {
+    incrementCounter('lobu_watcher_automation_phase_failures_total', { phase: failedPhase });
+  }
+  if (materialize?.runsCreated) {
+    incrementCounter('lobu_watcher_runs_created_total', {}, materialize.runsCreated);
+  }
+  if (materialize) {
+    setGauge('lobu_watchers_unrunnable', materialize.unrunnable);
+  }
 
   return {
     reset: reset?.reset ?? null,


### PR DESCRIPTION
## Why
Follow-up to #1046. That bug was a **silent** 12-day outage — the app was healthy but `watcher-automation` produced zero successful ticks and nothing alerted. This adds the metrics + alert rules so it can't happen silently again. Stacked on #1046 (the phase-failure metric hooks `runWatcherAutomationTick`).

## What
**Metrics** (`gateway/metrics/prometheus.ts` — note: the module was *vestigial*, registering metrics that were never incremented):
- `lobu_scheduled_job_runs_total{job,outcome}` — per cron tick in `TaskScheduler.dispatch` (the scheduler heartbeat).
- `lobu_watcher_automation_phase_failures_total{phase}` — per failed phase in `runWatcherAutomationTick`. Needed because the hardened tick *swallows* phase errors, so the scheduler-level counter shows success even when reconcile/etc. fail internally.
- `lobu_watcher_runs_created_total`, `lobu_watchers_unrunnable` (gauge).

Per-pod in-memory counters are the correct Prometheus model — each pod's `/metrics` is scraped and summed; `rate()`/`increase()` handle restart resets. No cross-replica shared state.

**Chart** (`charts/lobu`, both default OFF; the prod overlay enables them):
- `ServiceMonitor` scraping the app `/metrics`. Adds `app.kubernetes.io/component=api` to the app Service so the monitor targets it, not the embeddings Service (both share name+instance labels).
- `PrometheusRule`:
  - `WatcherAutomationSilent` (**critical**) — dead-man's-switch: fires on the *absence* of successful ticks (`... or on() vector(0)) == 0`), the actual failure mode.
  - `WatcherAutomationPhaseFailing`, `LobuScheduledJobFailing` (**warning**).

`severity` labels route to **#devops** via the **already-live** `slack-devops` AlertmanagerConfig (verified loaded in the running Alertmanager) — **no Alertmanager/webhook change needed.** Both resources carry `release: kube-prometheus-stack` (Prometheus's selector) via `additionalLabels`.

## Validation
- tsc clean; watcher suite 25/25 (exercises the metric calls in `runWatcherAutomationTick`).
- `helm lint` + `helm template` (with metrics enabled) render correctly; ServiceMonitor selector is unique to the app, both resources labeled for the cluster's Prometheus.

## Sequencing / not in this PR
- `Chart.yaml` version intentionally **not** hand-bumped (release-please owns it; `reconcileStrategy: ChartVersion` means the templates deploy on the next release).
- Enabling `metrics.serviceMonitor`/`prometheusRule` in the `summaries-prod` values is a separate **owletto-deploy** PR, to merge *after* the release that ships these templates.

> Base is #1046's branch; retarget to `main` once #1046 merges.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Prometheus monitoring integration with configurable ServiceMonitor and PrometheusRule resources (requires Prometheus Operator).
  * New metrics for tracking watcher automation health, scheduled job execution outcomes, and system failures.
  * New alerting rules for monitoring critical system events and performance degradation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lobu-ai/lobu/pull/1047?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->