### PR TITLE
fix(ci): migrate sdk-e2e fixture to connectorFromFile (unbreak main)

### DIFF
--- a/scripts/sdk-e2e.sh
+++ b/scripts/sdk-e2e.sh
@@ -80,7 +80,7 @@ PROJ="$RUN_DIR/proj"; mkdir -p "$PROJ"
 ( cd "$PROJ" && $LOBU init . -y --here --provider gemini >/dev/null 2>&1 )
 rm -f "$PROJ/package.json"
 cat > "$PROJ/lobu.config.ts" <<'TS'
-import { defineAgent, defineConfig, defineConnection, defineEntityType, defineRelationshipType, defineWatcher, secret } from "@lobu/cli/config";
+import { connectorFromFile, defineAgent, defineConfig, defineConnection, defineEntityType, defineRelationshipType, defineWatcher, secret } from "@lobu/cli/config";
 
 const agent = defineAgent({
   id: "echo", name: "Echo", dir: "./agents/echo",
@@ -90,10 +90,12 @@ const company = defineEntityType({ key: "company", name: "Company" });
 const contact = defineEntityType({ key: "contact", name: "Contact" });
 const worksAt = defineRelationshipType({ key: "works-at", name: "Works at", rules: [{ source: contact, target: company }] });
 
-// A local connector (./connectors/pulse.connector.ts) + a connection that wires
-// its single feed. The gate triggers a sync via the API and asserts the
-// connector's compiled code actually RAN and emitted ≥1 event — proving the
-// whole compile→install→spawn→sync→persist path, not just that apply mapped it.
+// A local connector (./connectors/pulse.connector.ts) declared explicitly via
+// connectorFromFile (the ./connectors auto-scan was dropped in #1043) + a
+// connection that wires its single feed. The gate triggers a sync via the API
+// and asserts the connector's compiled code actually RAN and emitted ≥1 event —
+// proving the whole compile→install→spawn→sync→persist path, not just that
+// apply mapped it.
 const pulseConn = defineConnection({
   slug: "pulse", connector: "sdke2e-pulse", name: "SDK e2e pulse",
   feeds: [{ feed: "pulse", name: "Pulse" }],
@@ -118,7 +120,7 @@ const digest = defineWatcher({
 
 // prune:true so the gate exercises the destructive path on every run (this is
 // what catches the system-type $member halt class of bug).
-export default defineConfig({ prune: true, agents: [agent], entities: [company, contact], relationships: [worksAt], connections: [pulseConn], watchers: [digest] });
+export default defineConfig({ prune: true, agents: [agent], entities: [company, contact], relationships: [worksAt], connectors: [connectorFromFile("./connectors/pulse.connector.ts")], connections: [pulseConn], watchers: [digest] });
 TS
 
 # Local connector: deterministic, zero-dep, no network. `sync()` returns one


### PR DESCRIPTION
## Why main is red

`main` has been red since #1043 (`refactor(cli): explicit connectorFromFile, drop ./connectors scan`). That PR removed the `./connectors` auto-discovery and migrated every `examples/*/lobu.config.ts` to declare connectors explicitly via `connectorFromFile(...)`.

But the `sdk-e2e` gate doesn't use `examples/` — it scaffolds its **own hermetic fixture inline** in a `scripts/sdk-e2e.sh` heredoc (deliberately: a zero-dep, no-network local connector so the gate can assert the full compile→install→spawn→sync→persist path deterministically). Because that fixture lives in a shell script and not the examples tree, the #1043 migration sweep missed it.

Result: the fixture's `./connectors/pulse.connector.ts` was no longer discovered → connection `pulse` referenced an uninstalled connector `sdke2e-pulse` → **apply halted on first failure** → the `sdk-e2e` job failed on `main` and every branch cut from it.

```
error: connector "sdke2e-pulse" referenced by connection "pulse" is not installed in the org
error: Apply halted on first failure.
```

## Fix

Declare the connector explicitly in the fixture's `defineConfig`, mirroring exactly what #1043 did to the examples:

```diff
-import { defineAgent, defineConfig, ... } from "@lobu/cli/config";
+import { connectorFromFile, defineAgent, defineConfig, ... } from "@lobu/cli/config";
...
-export default defineConfig({ ..., connections: [pulseConn], watchers: [digest] });
+export default defineConfig({ ..., connectors: [connectorFromFile("./connectors/pulse.connector.ts")], connections: [pulseConn], watchers: [digest] });
```

## E2E (red → green)

**Red** (pre-fix, on `main`): `❌ SDK e2e FAILED: auto-apply did not complete (skipped/halted?)` — connector `sdke2e-pulse` not installed.

**Green** (this branch, `bash scripts/sdk-e2e.sh`, Node 22):
```
✓ lobu run auto-applied the project (Apply complete)
✓ connector sync ran the compiled connector and emitted events (items=1, event_count=1)
✓ watcher reaction ran and saved its assertable side effect (SDKE2E_REACTION_OK)
✓ re-apply is idempotent (no deletes on a stable config)
✅ SDK lifecycle e2e PASSED
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced configuration examples to explicitly demonstrate connector registration patterns with clearer inline guidance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lobu-ai/lobu/pull/1048?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->