### PR TITLE
fix(test): ephemeral embedded backend uses a lobu_test database (unblocks make review)

### DIFF
--- a/packages/server/src/__tests__/setup/embedded-postgres-backend.ts
+++ b/packages/server/src/__tests__/setup/embedded-postgres-backend.ts
@@ -56,6 +56,15 @@ export async function startEmbeddedBackend(): Promise<EmbeddedBackend> {
     try {
       await instance.initialise();
       await instance.start();
+      // Create a dedicated, test-named database. The harness runs
+      // `DROP SCHEMA public CASCADE`, guarded by assertSafeTestDatabaseUrl which
+      // only accepts databases whose name marks them as test/CI. The embedded
+      // cluster's default db is `postgres`, which the guard (rightly) rejects —
+      // so without this, `make test`/`make review` against the ephemeral backend
+      // fail before a single test runs. A `*_test` name satisfies the guard
+      // naturally, keeping the prod-wipe protection intact (no destructive
+      // override needed).
+      await instance.createDatabase('lobu_test');
     } catch (err) {
       rmSync(dir, { recursive: true, force: true });
       if (/address already in use|could not bind/i.test(log)) {
@@ -70,7 +79,7 @@ export async function startEmbeddedBackend(): Promise<EmbeddedBackend> {
     return { pg: instance, port: candidate, dataDir: dir };
   });
 
-  const url = `postgresql://postgres:postgres@127.0.0.1:${port}/postgres?sslmode=disable`;
+  const url = `postgresql://postgres:postgres@127.0.0.1:${port}/lobu_test?sslmode=disable`;
   active = {
     url,
     stop: async () => {


### PR DESCRIPTION
## Problem
`make review` (and `make test`) `unset DATABASE_URL` and spin the ephemeral embedded Postgres backend. That backend connected to the cluster's default `postgres` database — and `assertSafeTestDatabaseUrl` (the guard added after the 2026-05-20 prod-wipe) **rejects any db name not containing `test` / ending `_ci`**. So the integration suite died before a single test ran:

```
Refusing to run the integration test harness against database "postgres": setup runs DROP SCHEMA public CASCADE …
```

This bit every local `make review` integration run (you'd see `integration=1` with zero tests executed) unless you knew to set `LOBU_ALLOW_DESTRUCTIVE_TEST_DB=1` — which blanket-disables the safety guard.

## Fix
Create + connect to a **`lobu_test`** database on the ephemeral instance (`embedded-postgres` exposes `createDatabase`). It satisfies the guard naturally and keeps the prod-wipe protection fully intact — no destructive override. Only touches the embedded path (local `make test`/`make review`); CI sets `DATABASE_URL` explicitly so it's unaffected.

## Validation
`make review` (no override) → `suite exit codes: typecheck=0 unit=0 integration=0` (integration now actually runs). Previously integration=1 (guard reject, 0 tests).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test database configuration for better test isolation and consistency during test execution.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lobu-ai/lobu/pull/1050?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->