### PR TITLE
fix(ci): stop pgvector-embedded rebuild firing on every release tag

### DIFF
--- a/.github/workflows/build-pgvector-embedded.yml
+++ b/.github/workflows/build-pgvector-embedded.yml
@@ -3,7 +3,7 @@ name: Build pgvector-embedded artifacts
 # Rebuilds the prebuilt pgvector artifacts vendored in
 # packages/pgvector-embedded/prebuilt/<platform>/ for every platform
 # embedded-postgres supports. Run on demand (bump pgvector / PG major) or when
-# the build script changes. embedded-postgres ships vanilla PG 18 with no
+# build.sh changes on main. embedded-postgres ships vanilla PG 18 with no
 # pgvector, so each cell compiles pgvector against a same-major PostgreSQL (the
 # extension ABI is stable within a major) and uploads the result; a final job
 # opens a PR with the regenerated artifacts.
@@ -18,9 +18,15 @@ on:
         description: pgvector git tag to build
         default: v0.8.1
   push:
+    # Branch-scoped on purpose: a bare `paths` filter also matches tag pushes,
+    # and GitHub can't diff a freshly-created ref so it ignores the filter and
+    # runs anyway — which meant every release-please tag (`lobu-vX.Y.Z`) kicked
+    # off a rebuild and opened a churn PR (the builds aren't byte-reproducible).
+    # Restricting to `main` excludes tag refs. Only build.sh affects the
+    # artifacts, so the workflow file itself is intentionally not a path here.
+    branches: [main]
     paths:
       - packages/pgvector-embedded/scripts/build.sh
-      - .github/workflows/build-pgvector-embedded.yml
 
 permissions:
   contents: write


### PR DESCRIPTION
## Problem

The `build-pgvector-embedded` workflow opened a "rebuild prebuilt artifacts" PR on **every release** — #972, #974, #975, #977, #979, #980, #981, #996, #1002, #1005, #1025, #1029.

Two compounding causes:

1. **The `push` trigger fired on release tags.** It used a bare `paths` filter (no `branches`). GitHub can't compute a file diff for a freshly-created ref, so it ignores `paths` and runs the workflow anyway. Every release-please tag (`lobu-vX.Y.Z`) therefore kicked off a full rebuild. Verified: the commit behind #1029 (`d75d07ab`, the 9.3.0 release) touches neither `build.sh` nor the workflow file, yet the run fired.
2. **The builds aren't byte-reproducible.** The `open-pr` job only opens a PR when the rebuilt artifacts differ (`git diff --cached --quiet`). They differ every time — embedded timestamps/paths in the compiled `.so`/`.dylib` — so each tag-triggered rebuild produced a real (but meaningless) diff and a PR.

## Fix

- Scope the `push` trigger to `branches: [main]` so tag refs no longer match.
- Drop the workflow file itself from `paths` — only `build.sh` affects the artifacts, and this also stops the workflow self-triggering when its own YAML is edited (e.g. this PR).

`workflow_dispatch` still covers the only times a rebuild is actually wanted: a deliberate pgvector version or PG major bump.

The vendored binaries stay committed and shipped — they're the pgvector extension that vanilla `embedded-postgres` lacks, required for vector search in `lobu run`. This only stops the *automatic rebuild on release*.

## Follow-up (not in this PR)

Making the pgvector build reproducible (`SOURCE_DATE_EPOCH`, `-ffile-prefix-map`, deterministic strip) would let even a deliberate `build.sh`-change rerun no-op when nothing meaningful changed. Optional hardening.

## Test

YAML validates (`yaml.safe_load`). Behavior change is in event filtering only — no build-step changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized build workflow to trigger only when relevant changes occur on the main branch, reducing unnecessary rebuilds and improving resource efficiency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lobu-ai/lobu/pull/1051?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->