### PR TITLE
fix(cli): token create honors --context/-c flag (#1023)

### DIFF
--- a/packages/cli/src/__tests__/token.test.ts
+++ b/packages/cli/src/__tests__/token.test.ts
@@ -57,4 +57,69 @@ describe("token create", () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(writeSpy).toHaveBeenCalledWith("owl_pat_test\n");
   });
+
+  // Regression for #1023: `-c/--context` is declared on both `token` and its
+  // `create` subcommand, so commander binds the flag to the parent and the
+  // child's local `.opts()` drops it — the request then targets the *active*
+  // context instead of the requested one. Exercised through `runCli` parsing
+  // (not a direct `tokenCreateCommand` call) so the wiring itself is covered.
+  test("token create honors -c/--context through CLI parsing (#1023)", async () => {
+    const resolveSpy = spyOn(context, "resolveContext").mockResolvedValue({
+      name: "lobu",
+      url: "https://app.lobu.ai/api/v1",
+      source: "config",
+    });
+    spyOn(credentials, "getToken").mockResolvedValue("oauth-access-token");
+
+    const fetchMock = mock(
+      async () =>
+        new Response(
+          JSON.stringify({
+            token: {
+              id: 2,
+              token: "owl_pat_ctx",
+              token_prefix: "owl_pat_ctx",
+              name: "ci",
+              scope: "mcp:read",
+              expires_at: null,
+              created_at: "2026-01-01T00:00:00.000Z",
+            },
+          }),
+          { status: 201, headers: { "Content-Type": "application/json" } }
+        )
+    );
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+    spyOn(process.stdout, "write").mockImplementation(() => true);
+
+    const { runCli } = await import("../index");
+    try {
+      await runCli([
+        "node",
+        "lobu",
+        "token",
+        "create",
+        "-c",
+        "lobu",
+        "--org",
+        "atlas",
+        "--scope",
+        "mcp:read",
+        "--name",
+        "ci",
+        "--raw",
+      ]);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+
+    // The requested context must reach resolveContext — not undefined (which
+    // would silently fall back to the active context).
+    expect(resolveSpy).toHaveBeenCalledWith("lobu");
+    // ...and the POST must land on the requested context's host.
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://app.lobu.ai/api/atlas/tokens",
+      expect.objectContaining({ method: "POST" })
+    );
+  });
 });

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -427,7 +427,7 @@ Memory:
       await tokenCommand(options);
     });
 
-  withCommonOpts(
+  const tokenCreate = withCommonOpts(
     token
       .command("create")
       .description("Create an org-scoped personal access token for servers/CI"),
@@ -451,22 +451,15 @@ Memory:
       }
     )
     .option("--raw", "Print token only")
-    .option("--json", "Print JSON response")
-    .action(
-      async (options: {
-        context?: string;
-        org?: string;
-        name?: string;
-        description?: string;
-        scope?: string;
-        expiresInDays?: number;
-        raw?: boolean;
-        json?: boolean;
-      }) => {
-        const { tokenCreateCommand } = await import("./commands/token.js");
-        await tokenCreateCommand(options);
-      }
-    );
+    .option("--json", "Print JSON response");
+  // `-c/--context` is declared on both `token` and `token create`. Commander
+  // binds a flag shared by parent and child to the *parent*, so the child's
+  // local `.opts()` never sees `context` — read `optsWithGlobals()` to merge
+  // the ancestor's value back in (otherwise `-c` is silently ignored, #1023).
+  tokenCreate.action(async () => {
+    const { tokenCreateCommand } = await import("./commands/token.js");
+    await tokenCreateCommand(tokenCreate.optsWithGlobals());
+  });
 
   token
     .command("revoke <jti>")


### PR DESCRIPTION
## Summary

`lobu token create -c <name>` ignored the `--context`/`-c` flag and resolved the API base from the **active** context instead. With an active context pointing at a dead local gateway, this surfaced as a bare `Error: fetch failed`. `lobu org ... -c <name>` honored `-c`, so behavior was inconsistent. Fixes #1023.

## Root cause

`-c/--context` is declared on **both** the `token` parent command (so bare `lobu token -c <name>` works) and its `create` subcommand (via `withCommonOpts`). Commander binds a flag shared by parent and child to the **parent**, so `create`'s action received local `.opts()` *without* `context` — `tokenCreateCommand` then saw `context: undefined` and `resolveApiClient` fell back to the active context.

`org` subcommands are unaffected because the `org` parent doesn't declare `-c` (only its children do), so the flag binds to the child directly.

## Fix

Read the merged value via `tokenCreate.optsWithGlobals()` in the action, so the requested context flows through regardless of where `-c` appears on the command line (`token create -c x`, `token create ... -c x`, or `token -c x create`). Option declarations are otherwise unchanged, so `--help` output and every other command stay identical.

## E2E reproducer (red → green)

Added a regression test that drives the fix through `runCli` argv parsing — the actual layer where the bug lives — rather than calling `tokenCreateCommand` directly.

**Red** (buggy `action(async (options) => tokenCreateCommand(options))`):
```
expect(received).toHaveBeenCalledWith(...expected)
  [
-   "lobu",
+   undefined,
  ]
(fail) token create honors -c/--context through CLI parsing (#1023)
```
`resolveContext` was invoked with `undefined` → silent fallback to the active context.

**Green** (with `optsWithGlobals()`):
```
 332 pass
 1 skip
 0 fail
Ran 333 tests across 23 files.
```
The test asserts `resolveContext` is called with `"lobu"` and the POST lands on `https://app.lobu.ai/api/atlas/tokens`.

## Validation

- `bun test` (packages/cli): 332 pass / 0 fail after `make build-packages`
- `tsc --noEmit` (cli): clean
- Verified the flag-placement matrix against the repo's commander version: `-c` before/after the subcommand and on the parent all resolve correctly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `token create` command to properly honor the `-c/--context` flag when invoked through the CLI, ensuring tokens are created in the specified context.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lobu-ai/lobu/pull/1054?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->