### PR TITLE
feat(client)!: v1.1 polish — refresh(), ask(), typed SSE events, conversationId

### DIFF
--- a/packages/client/src/__tests__/client.test.ts
+++ b/packages/client/src/__tests__/client.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { Lobu } from "../client.js";
+import { LobuAgentError } from "../errors.js";
 
 describe("Lobu", () => {
   test("creates a session and sends with the session token", async () => {
@@ -47,7 +48,7 @@ describe("Lobu", () => {
     });
     const result = await session.send("hello", { messageId: "msg_1" });
 
-    expect(session.agentId).toBe("support_user_1");
+    expect(session.conversationId).toBe("support_user_1");
     expect(result.queued).toBe(true);
     expect(calls[0]).toMatchObject({
       url: "https://lobu.test/lobu/api/v1/agents",
@@ -206,6 +207,197 @@ describe("Lobu", () => {
 
     // The loop must EXIT (not hang) after the abort; the first event arrived.
     expect(collected).toEqual([{ event: "text", data: "first", retry: 3000 }]);
+  });
+
+  test("refresh() re-mints the token via the resume path and updates it in place", async () => {
+    const agentsBodies: unknown[] = [];
+    let mint = 0;
+    const fetchImpl = (async (input, init) => {
+      const request =
+        input instanceof Request ? input : new Request(input, init);
+      if (request.url.endsWith("/api/v1/agents")) {
+        agentsBodies.push(JSON.parse(await request.clone().text()));
+        mint += 1;
+        return json(
+          {
+            success: true,
+            agentId: "support_user_1",
+            token: `session-token-${mint}`,
+            expiresAt: 1000 * mint,
+            sseUrl:
+              "https://lobu.test/lobu/api/v1/agents/support_user_1/events",
+            messagesUrl:
+              "https://lobu.test/lobu/api/v1/agents/support_user_1/messages",
+          },
+          201
+        );
+      }
+      return json({ success: true, messageId: "m", queued: true });
+    }) as typeof fetch;
+
+    const lobu = new Lobu({
+      baseUrl: "https://lobu.test/lobu",
+      token: "api-token",
+      fetch: fetchImpl,
+    });
+
+    const input = { agentId: "support", userId: "user_1", forceNew: true };
+    const session = await lobu.sessions.create(input);
+    expect(session.token).toBe("session-token-1");
+    expect(session.expiresAt).toBe(1000);
+
+    // Mutating the caller's object must not change what refresh replays.
+    input.agentId = "evil";
+
+    const returned = await session.refresh();
+    expect(returned).toBe(session);
+    expect(session.token).toBe("session-token-2");
+    expect(session.expiresAt).toBe(2000);
+
+    // refresh normalizes to the resume path with the ORIGINAL agentId.
+    expect(agentsBodies[1]).toMatchObject({
+      agentId: "support",
+      userId: "user_1",
+      forceNew: false,
+    });
+  });
+
+  test("ask() sends after `connected`, concatenates output, resolves on complete", async () => {
+    const messagesBodies: unknown[] = [];
+    const fetchImpl = (async (input, init) => {
+      const request =
+        input instanceof Request ? input : new Request(input, init);
+      if (request.url.endsWith("/api/v1/agents")) {
+        return json(
+          {
+            success: true,
+            agentId: "support_user_1",
+            token: "session-token",
+            expiresAt: Date.now() + 60_000,
+            sseUrl:
+              "https://lobu.test/lobu/api/v1/agents/support_user_1/events",
+            messagesUrl:
+              "https://lobu.test/lobu/api/v1/agents/support_user_1/messages",
+          },
+          201
+        );
+      }
+      if (request.url.endsWith("/messages")) {
+        messagesBodies.push(JSON.parse(await request.clone().text()));
+        return json({ success: true, messageId: "ask_1", queued: true });
+      }
+      // SSE: connected, a stale delta for another id (must be ignored), our
+      // deltas, then complete for ask_1.
+      return new Response(
+        new ReadableStream({
+          start(controller) {
+            const enc = new TextEncoder();
+            controller.enqueue(
+              enc.encode(
+                'event: connected\ndata: {"agentId":"support","timestamp":1}\n\n'
+              )
+            );
+            controller.enqueue(
+              enc.encode(
+                'event: output\ndata: {"type":"delta","content":"stale","messageId":"other","timestamp":2}\n\n'
+              )
+            );
+            controller.enqueue(
+              enc.encode(
+                'event: output\ndata: {"type":"delta","content":"Hello ","messageId":"ask_1","timestamp":3}\n\n'
+              )
+            );
+            controller.enqueue(
+              enc.encode(
+                'event: output\ndata: {"type":"delta","content":"world","messageId":"ask_1","timestamp":4}\n\n'
+              )
+            );
+            controller.enqueue(
+              enc.encode(
+                'event: complete\ndata: {"type":"complete","messageId":"ask_1","timestamp":5}\n\n'
+              )
+            );
+            controller.close();
+          },
+        }),
+        { status: 200, headers: { "content-type": "text/event-stream" } }
+      );
+    }) as typeof fetch;
+
+    const lobu = new Lobu({
+      baseUrl: "https://lobu.test/lobu",
+      token: "api-token",
+      fetch: fetchImpl,
+    });
+    const session = await lobu.sessions.create({});
+
+    const result = await session.ask("hi", { messageId: "ask_1" });
+
+    expect(result).toEqual({ text: "Hello world", messageId: "ask_1" });
+    // The message was actually sent, tagged with our correlation id.
+    expect(messagesBodies).toEqual([{ content: "hi", messageId: "ask_1" }]);
+  });
+
+  test("ask() rejects with LobuAgentError on agent-error for the message", async () => {
+    const fetchImpl = (async (input, init) => {
+      const request =
+        input instanceof Request ? input : new Request(input, init);
+      if (request.url.endsWith("/api/v1/agents")) {
+        return json(
+          {
+            success: true,
+            agentId: "support_user_1",
+            token: "session-token",
+            expiresAt: Date.now() + 60_000,
+            sseUrl:
+              "https://lobu.test/lobu/api/v1/agents/support_user_1/events",
+            messagesUrl:
+              "https://lobu.test/lobu/api/v1/agents/support_user_1/messages",
+          },
+          201
+        );
+      }
+      if (request.url.endsWith("/messages")) {
+        return json({ success: true, messageId: "ask_1", queued: true });
+      }
+      return new Response(
+        new ReadableStream({
+          start(controller) {
+            const enc = new TextEncoder();
+            controller.enqueue(
+              enc.encode(
+                'event: connected\ndata: {"agentId":"support","timestamp":1}\n\n'
+              )
+            );
+            controller.enqueue(
+              enc.encode(
+                'event: agent-error\ndata: {"type":"error","error":"boom","messageId":"ask_1","timestamp":2}\n\n'
+              )
+            );
+            controller.close();
+          },
+        }),
+        { status: 200, headers: { "content-type": "text/event-stream" } }
+      );
+    }) as typeof fetch;
+
+    const lobu = new Lobu({
+      baseUrl: "https://lobu.test/lobu",
+      token: "api-token",
+      fetch: fetchImpl,
+    });
+    const session = await lobu.sessions.create({});
+
+    let threw: unknown;
+    try {
+      await session.ask("hi", { messageId: "ask_1" });
+    } catch (error) {
+      threw = error;
+    }
+
+    expect(threw).toBeInstanceOf(LobuAgentError);
+    expect((threw as LobuAgentError).message).toBe("boom");
+    expect((threw as LobuAgentError).messageId).toBe("ask_1");
   });
 });
 

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -23,6 +23,6 @@ export class Lobu {
   createSession(input: CreateSessionRequest): Promise<AgentSession> {
     return this.rest
       .createSession(input)
-      .then((response) => new AgentSession(this.rest, response));
+      .then((response) => new AgentSession(this.rest, response, input));
   }
 }

--- a/packages/client/src/errors.ts
+++ b/packages/client/src/errors.ts
@@ -18,3 +18,18 @@ export class LobuApiError extends Error {
     this.response = response;
   }
 }
+
+/**
+ * Thrown by {@link AgentSession.ask} when the agent reports an error for the
+ * message being awaited (an `error`/`agent-error` SSE event). Distinct from
+ * {@link LobuApiError}, which signals an HTTP-transport failure.
+ */
+export class LobuAgentError extends Error {
+  readonly messageId: string | undefined;
+
+  constructor(message: string, messageId?: string) {
+    super(message);
+    this.name = "LobuAgentError";
+    this.messageId = messageId;
+  }
+}

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -1,13 +1,21 @@
 export * as generated from "./generated/index.js";
 export { Lobu } from "./client.js";
-export { LobuApiError } from "./errors.js";
+export { LobuAgentError, LobuApiError } from "./errors.js";
 export { AgentSession } from "./session.js";
 export type {
+  AskOptions,
+  AskResult,
   CreateSessionRequest,
   CreateSessionResponse,
+  LobuAgentEvent,
   LobuClientOptions,
+  LobuCompleteData,
+  LobuConnectedData,
+  LobuErrorData,
   LobuFetch,
   LobuHeaders,
+  LobuOutputData,
+  LobuPingData,
   LobuSseEvent,
   SendMessageOptions,
   SendMessageResponse,

--- a/packages/client/src/session.ts
+++ b/packages/client/src/session.ts
@@ -1,49 +1,173 @@
+import { LobuAgentError } from "./errors.js";
 import type { LobuRestClient } from "./rest.js";
 import type {
+  AskOptions,
+  AskResult,
+  CreateSessionRequest,
   CreateSessionResponse,
+  LobuAgentEvent,
   LobuSseEvent,
   SendMessageOptions,
   SendMessageResponse,
   StreamEventsOptions,
 } from "./types.js";
 
+function newMessageId(): string {
+  return (
+    globalThis.crypto?.randomUUID?.() ??
+    `msg_${Date.now()}_${Math.random().toString(36).slice(2)}`
+  );
+}
+
 export class AgentSession {
-  readonly agentId: string;
-  readonly token: string;
-  readonly expiresAt: number;
   /**
-   * The send/stream endpoints the server advertised for this session. `send`
-   * and `events` below route through the configured `baseUrl` + this session's
-   * `agentId` (the generated REST client is path-templated), which matches the
-   * server's same-origin URLs. These fields are surfaced for callers that need
-   * the exact server-advertised endpoints (e.g. a different public origin); a
-   * future server that advertised a divergent origin/path would require routing
-   * through them directly — tracked as a follow-up.
+   * Server-side conversation/routing id (`${agentId}_${userId}_${thread}`).
+   * `send`/`events`/`ask` route on this. It is **not** the logical agent id you
+   * passed to `createSession` — that one is echoed back in the `connected`
+   * event's `data.agentId`.
+   */
+  readonly conversationId: string;
+  /**
+   * SSE/messages endpoints the server advertised for this session (stable
+   * across refresh). `send`/`events`/`ask` route through `baseUrl` +
+   * `conversationId` (the generated client is path-templated), which matches
+   * the server's same-origin URLs. These are surfaced for callers that need the
+   * exact advertised endpoints (e.g. a server on a different public origin);
+   * routing through a divergent origin directly is a follow-up.
    */
   readonly sseUrl: string;
   readonly messagesUrl: string;
 
+  private _token: string;
+  private _expiresAt: number;
+  private readonly request: CreateSessionRequest;
+
   constructor(
     private readonly rest: LobuRestClient,
-    response: CreateSessionResponse
+    response: CreateSessionResponse,
+    request: CreateSessionRequest
   ) {
-    this.agentId = response.agentId;
-    this.token = response.token;
-    this.expiresAt = response.expiresAt;
+    this.conversationId = response.agentId;
+    this._token = response.token;
+    this._expiresAt = response.expiresAt;
     this.sseUrl = response.sseUrl;
     this.messagesUrl = response.messagesUrl;
+    // Defensive deep copy: refresh replays this request, so the caller mutating
+    // their object afterwards must not change what we re-send.
+    this.request = structuredClone(request);
+  }
+
+  /** Current session (worker) token. Updated in place by {@link refresh}. */
+  get token(): string {
+    return this._token;
+  }
+
+  /** Unix epoch ms when {@link token} expires (24h TTL). */
+  get expiresAt(): number {
+    return this._expiresAt;
   }
 
   send(
     content: string,
     options?: SendMessageOptions
   ): Promise<SendMessageResponse> {
-    return this.rest.sendMessage(this.agentId, this.token, content, options);
+    return this.rest.sendMessage(
+      this.conversationId,
+      this._token,
+      content,
+      options
+    );
   }
 
-  events<TData = unknown>(
+  events(options?: StreamEventsOptions): AsyncIterable<LobuAgentEvent>;
+  events<TData>(
+    options?: StreamEventsOptions
+  ): AsyncIterable<LobuSseEvent<TData>>;
+  events(
     options: StreamEventsOptions = {}
-  ): AsyncIterable<LobuSseEvent<TData>> {
-    return this.rest.streamEvents<TData>(this.agentId, this.token, options);
+  ): AsyncIterable<LobuSseEvent<unknown>> {
+    return this.rest.streamEvents(this.conversationId, this._token, options);
+  }
+
+  /**
+   * Re-mint this session's token without losing the conversation. Re-runs the
+   * original create-session request against the resume path (`forceNew: false`)
+   * and updates {@link token}/{@link expiresAt} in place. Tokens have a 24h TTL;
+   * call this before {@link expiresAt} for a long-lived chat. Manual by
+   * design — there is no background auto-renew.
+   */
+  async refresh(): Promise<this> {
+    const response = await this.rest.createSession({
+      ...this.request,
+      forceNew: false,
+    });
+    this._token = response.token;
+    this._expiresAt = response.expiresAt;
+    return this;
+  }
+
+  /**
+   * Send a message and await the agent's reply. Resolves with the concatenated
+   * text on the `complete` event for this message; rejects with
+   * {@link LobuAgentError} on `error`/`agent-error`. Convenience over
+   * `send` + `events` for request/response use.
+   *
+   * Delivery rides the SSE stream. Under a multi-replica deployment where
+   * API/SSE events are not owner-routed, `ask` can time out even though the
+   * agent finished — single-replica and local runs are reliable. Use
+   * `send` + your own `events` consumer if you need finer control.
+   */
+  async ask(content: string, options: AskOptions = {}): Promise<AskResult> {
+    const messageId = options.messageId ?? newMessageId();
+    const controller = new AbortController();
+    const onAbort = () => controller.abort();
+    options.signal?.addEventListener("abort", onAbort, { once: true });
+    if (options.signal?.aborted) controller.abort();
+
+    const timeoutMs = options.timeoutMs ?? 120_000;
+    let timedOut = false;
+    const timer = setTimeout(() => {
+      timedOut = true;
+      controller.abort();
+    }, timeoutMs);
+
+    let text = "";
+    let sent = false;
+
+    try {
+      for await (const event of this.events({ signal: controller.signal })) {
+        // Send only after the `connected` handshake so the SSE request is open
+        // before the message is enqueued — otherwise the reply can outrun our
+        // subscription. Backlog replay only covers the same pod (see JSDoc).
+        if (event.event === "connected") {
+          if (!sent) {
+            sent = true;
+            await this.send(content, { messageId });
+          }
+          continue;
+        }
+        if (event.event === "output" && event.data.messageId === messageId) {
+          text += event.data.content;
+        } else if (
+          event.event === "complete" &&
+          (event.data.messageId === messageId ||
+            event.data.processedMessageIds?.includes(messageId))
+        ) {
+          return { text, messageId };
+        } else if (
+          (event.event === "error" || event.event === "agent-error") &&
+          event.data.messageId === messageId
+        ) {
+          throw new LobuAgentError(event.data.error, messageId);
+        }
+      }
+      if (options.signal?.aborted) throw new Error("ask() aborted");
+      if (timedOut) throw new Error(`ask() timed out after ${timeoutMs}ms`);
+      throw new Error("ask() stream ended before completion");
+    } finally {
+      clearTimeout(timer);
+      controller.abort();
+      options.signal?.removeEventListener("abort", onAbort);
+    }
   }
 }

--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -21,10 +21,19 @@ export interface CreateSessionRequest {
   model?: string;
   forceNew?: boolean;
   dryRun?: boolean;
+  /**
+   * Server-trusted: the worker's egress allowlist/blocklist. Mint sessions
+   * **server-side** — do not let an untrusted browser pick its own network
+   * policy.
+   */
   networkConfig?: {
     allowedDomains?: string[];
     deniedDomains?: string[];
   };
+  /**
+   * Server-trusted: MCP servers the worker may reach. Mint sessions
+   * **server-side** — do not let an untrusted browser inject MCP servers.
+   */
   mcpServers?: Record<
     string,
     {
@@ -37,6 +46,10 @@ export interface CreateSessionRequest {
       description?: string;
     }
   >;
+  /**
+   * Server-trusted: nix packages provisioned into the worker runtime. Mint
+   * sessions **server-side** — do not let an untrusted browser pick packages.
+   */
   nix?: {
     flakeUrl?: string;
     packages?: string[];
@@ -71,6 +84,95 @@ export interface LobuSseEvent<TData = unknown> {
   data: TData;
   id?: string;
   retry?: number;
+}
+
+/** `connected` payload. `agentId` is the *logical* agent id, not the session's conversation id. */
+export interface LobuConnectedData {
+  agentId: string;
+  timestamp: number;
+}
+
+/** `output` payload: an incremental text delta from the agent. */
+export interface LobuOutputData {
+  type: "delta";
+  content: string;
+  timestamp: number;
+  messageId?: string;
+}
+
+/** `complete` payload: the agent finished a turn. May settle several messages at once. */
+export interface LobuCompleteData {
+  type: "complete";
+  messageId?: string;
+  processedMessageIds?: string[];
+  timestamp: number;
+}
+
+/** `error`/`agent-error` payload. */
+export interface LobuErrorData {
+  type: "error";
+  error: string;
+  messageId?: string;
+  timestamp: number;
+}
+
+/** `ping` heartbeat payload. */
+export interface LobuPingData {
+  timestamp: number;
+}
+
+interface LobuSseEnvelope {
+  id?: string;
+  retry?: number;
+}
+
+/**
+ * Discriminated union of the agent SSE stream. The union is **closed** so that
+ * matching on `event` narrows `data`. The richer interactive events
+ * (`question`, `tool-approval`, …) are present by name with `unknown` data; to
+ * type one yourself, pass an explicit payload type to `events<TData>()`.
+ */
+export type LobuAgentEvent =
+  | (LobuSseEnvelope & { event: "connected"; data: LobuConnectedData })
+  | (LobuSseEnvelope & { event: "output"; data: LobuOutputData })
+  | (LobuSseEnvelope & { event: "complete"; data: LobuCompleteData })
+  | (LobuSseEnvelope & { event: "error"; data: LobuErrorData })
+  | (LobuSseEnvelope & { event: "agent-error"; data: LobuErrorData })
+  | (LobuSseEnvelope & { event: "ping"; data: LobuPingData })
+  | (LobuSseEnvelope & {
+      event:
+        | "status"
+        | "ephemeral"
+        | "question"
+        | "link-button"
+        | "tool-approval"
+        | "suggestion"
+        | "closed"
+        | "stale";
+      data: unknown;
+    });
+
+export interface AskOptions {
+  /**
+   * Correlation id for this turn. Defaults to a fresh random id. Must be unique
+   * per call — `ask` resolves/rejects only on the terminal event carrying this
+   * id, so reusing an id can resolve from a prior turn replayed via backlog.
+   */
+  messageId?: string;
+  /** Abort the wait (and the underlying message send) early. */
+  signal?: AbortSignal;
+  /**
+   * Reject if no terminal `complete` for this message arrives within this many
+   * milliseconds. Defaults to 120000 (2 minutes).
+   */
+  timeoutMs?: number;
+}
+
+export interface AskResult {
+  /** Concatenated `output` deltas for this message. */
+  text: string;
+  /** The correlation id used (echo of `AskOptions.messageId` or the generated one). */
+  messageId: string;
 }
 
 export interface StreamEventsOptions {


### PR DESCRIPTION
Addresses the v1 follow-ups tracked in #1032 as one lean, **client-only** pass over `@lobu/client`. All five items, each in its smallest correct form. Plan was reviewed with `pi` before implementation; its findings (closed union, messageId-filtered `ask`, getter-backed token, breaking rename) are folded in.

## What changed (`packages/client/src/`)

**1. `session.refresh()`** — re-mints the worker token without losing the conversation. Re-runs the original create request against the server resume path (`forceNew: false` → fresh token for the same `conversationId`), updating `token`/`expiresAt` in place (now getter-backed). Manual by design — no background auto-renew. The original request is `structuredClone`d so later caller mutation can't change what we replay.

**2. `session.ask(content, options?)`** — send + await the reply. Convenience over `send` + `events`:
- generates a correlation `messageId` (or takes one), waits for the `connected` handshake **before** sending so the reply can't outrun the subscription,
- accumulates `output` deltas for that `messageId`, resolves on the matching `complete` (checks `processedMessageIds` too), rejects with `LobuAgentError` on a matching `error`/`agent-error`,
- 2-minute default timeout + `signal` support, full cleanup on every exit path.
- JSDoc calls out the known multi-replica caveat: API/SSE events aren't owner-routed across pods, so `ask` can time out even if the agent finished — reliable single-replica/local.

**3. Typed SSE events** — `LobuAgentEvent`, a **closed** discriminated union over the real broadcast names (`connected`/`output`/`complete`/`error`/`agent-error`/`ping`, plus the interactive events with `unknown` data). `events()` now defaults to it; `events<TData>()` keeps the data-type override via overloads. (Closed union, not a `string & {}` catch-all, so `event` actually narrows `data`.)

**4. `agentId` → `conversationId`** — `AgentSession.agentId` was the server conversation/routing id, not the logical agent. Renamed to the honest name (no alias, per repo convention). The logical agent id is echoed in the `connected` event's `data.agentId`. **Breaking** — see below.

**5. Infra-knob docs** — `networkConfig`/`mcpServers`/`nix` on `CreateSessionRequest` are documented as server-trusted ("mint sessions server-side"). No token-scope gating (that's server-side, out of scope here).

## Breaking change
`AgentSession.agentId` → `AgentSession.conversationId`. The SDK is one release old (9.2.0) and nothing in the monorepo consumes it; flagged as `feat(client)!` so release-please bumps accordingly.

## Validation
- `tsc --noEmit` clean (overloads + closed-union narrowing verified).
- 7 unit tests pass, including new coverage: `refresh()` re-mint + resume-path normalization + defensive-copy, `ask()` send-after-`connected` + messageId filtering (stale delta ignored) + resolve-on-complete, `ask()` `LobuAgentError` on agent-error.
- `biome check` clean (correct repo config).

E2E note: the server-side behavior these rely on (resume-path re-mint, messageId round-trip into `output`/`complete`/`error` payloads, `connected`-then-backlog ordering) was verified by reading the gateway routes / response-renderer; the client logic is covered by fetch-mocked unit tests against the real SSE wire format.

Closes #1032

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `ask()` method for sending messages and receiving streaming responses from the agent.
  * Added `refresh()` method to renew session tokens.
  * Improved session state management with conversation tracking.

* **Breaking Changes**
  * Session's `agentId` property renamed to `conversationId`.
  * `token` and `expiresAt` are now accessed via getters instead of direct properties.

* **Bug Fixes**
  * Added `LobuAgentError` for proper handling of agent-side errors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lobu-ai/lobu/pull/1055?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->