### PR TITLE
fix(server): watcher device-pin authz + table-schema drift test runs in CI

### DIFF
--- a/packages/server/src/__tests__/integration/watchers/watchers-crud.test.ts
+++ b/packages/server/src/__tests__/integration/watchers/watchers-crud.test.ts
@@ -14,19 +14,25 @@ import {
   createTestUser,
 } from '../../setup/test-fixtures';
 import { TestApiClient } from '../../setup/test-mcp-client';
-import { cleanupTestDatabase } from '../../setup/test-db';
+import { cleanupTestDatabase, getTestDb } from '../../setup/test-db';
 
 describe('watcher CRUD', () => {
   let owner: TestApiClient;
   let intruder: TestApiClient;
   let entityId: number;
   let agentId: string;
+  let ownerOrgId: string;
+  let ownerUserId: string;
+  let otherOrgId: string;
+  let otherUserId: string;
 
   beforeAll(async () => {
     await cleanupTestDatabase();
     const org = await createTestOrganization({ name: 'Watcher Test Org' });
     const user = await createTestUser({ email: 'watcher-owner@test.com' });
     await addUserToOrganization(user.id, org.id, 'owner');
+    ownerOrgId = org.id;
+    ownerUserId = user.id;
     owner = await TestApiClient.for({
       organizationId: org.id,
       userId: user.id,
@@ -38,6 +44,8 @@ describe('watcher CRUD', () => {
     const otherOrg = await createTestOrganization({ name: 'Watcher Other Org' });
     const otherUser = await createTestUser({ email: 'watcher-other@test.com' });
     await addUserToOrganization(otherUser.id, otherOrg.id, 'owner');
+    otherOrgId = otherOrg.id;
+    otherUserId = otherUser.id;
     intruder = await TestApiClient.for({
       organizationId: otherOrg.id,
       userId: otherUser.id,
@@ -287,5 +295,117 @@ describe('watcher CRUD', () => {
     await expect(member.watchers.delete([created.watcher_id])).rejects.toThrow(
       /admin|owner|access/i
     );
+  });
+
+  // Issue #1060: a device pin (watchers.device_worker_id) runs the watcher's
+  // agent CLI on the device owner's machine, so create/update must verify the
+  // caller may target that device. The exhaustive role × ownership matrix is in
+  // src/__tests__/unit/watcher-device-access.test.ts; this proves the gate is
+  // wired into the handlers end-to-end (device_worker_id only reaches the
+  // handler via the raw `manage()` escape hatch — the typed input omits it).
+  describe('device_worker_id ownership gate', () => {
+    async function seedDevice(opts: {
+      userId: string;
+      organizationId: string | null;
+      worker: string;
+    }): Promise<string> {
+      const sql = getTestDb();
+      const rows = (await sql`
+        INSERT INTO device_workers (user_id, worker_id, platform, capabilities, label, organization_id)
+        VALUES (${opts.userId}, ${opts.worker}, 'macos', ${sql.json([])}, 'Seed Device', ${opts.organizationId})
+        RETURNING id
+      `) as unknown as Array<{ id: string }>;
+      return String(rows[0].id);
+    }
+
+    it('lets an org owner pin a foreign device attached to their org', async () => {
+      // A different user's device, but it lives in the owner's org → allowed
+      // for an owner/admin role.
+      const deviceId = await seedDevice({
+        userId: otherUserId,
+        organizationId: ownerOrgId,
+        worker: 'dev-in-org',
+      });
+      const created = (await owner.watchers.manage({
+        action: 'create',
+        entity_id: entityId,
+        slug: 'device-pin-allowed',
+        name: 'Device Pin Allowed',
+        prompt: 'x',
+        extraction_schema: { type: 'object', properties: {} },
+        agent_id: agentId,
+        device_worker_id: deviceId,
+      })) as { watcher_id: string };
+      expect(created.watcher_id).toBeDefined();
+
+      const got = (await owner.watchers.get(created.watcher_id)) as {
+        watcher?: { device_worker_id?: string | null };
+      };
+      expect(got.watcher?.device_worker_id).toBe(deviceId);
+      await owner.watchers.delete([created.watcher_id]);
+    });
+
+    it("rejects pinning to a device in another org (create)", async () => {
+      // Device owned by another user AND attached to another org — even an owner
+      // cannot pin it; this is the privilege-escalation case.
+      const foreignDeviceId = await seedDevice({
+        userId: otherUserId,
+        organizationId: otherOrgId,
+        worker: 'dev-foreign-org',
+      });
+      await expect(
+        owner.watchers.manage({
+          action: 'create',
+          entity_id: entityId,
+          slug: 'device-pin-foreign',
+          name: 'Device Pin Foreign',
+          prompt: 'x',
+          extraction_schema: { type: 'object', properties: {} },
+          agent_id: agentId,
+          device_worker_id: foreignDeviceId,
+        })
+      ).rejects.toThrow(/device you own|not found or not accessible/i);
+    });
+
+    it('rejects pinning to a nonexistent device (create)', async () => {
+      await expect(
+        owner.watchers.manage({
+          action: 'create',
+          entity_id: entityId,
+          slug: 'device-pin-missing',
+          name: 'Device Pin Missing',
+          prompt: 'x',
+          extraction_schema: { type: 'object', properties: {} },
+          agent_id: agentId,
+          device_worker_id: '00000000-0000-0000-0000-000000000000',
+        })
+      ).rejects.toThrow(/not found or not accessible/i);
+    });
+
+    it('rejects re-pinning an existing watcher to a foreign-org device (update)', async () => {
+      const created = (await owner.watchers.create({
+        entity_id: entityId,
+        slug: 'device-pin-update',
+        name: 'Device Pin Update',
+        prompt: 'x',
+        extraction_schema: { type: 'object', properties: {} },
+        agent_id: agentId,
+      })) as { watcher_id: string };
+
+      const foreignDeviceId = await seedDevice({
+        userId: otherUserId,
+        organizationId: otherOrgId,
+        worker: 'dev-foreign-update',
+      });
+      await expect(
+        owner.watchers.manage({
+          action: 'update',
+          watcher_id: created.watcher_id,
+          device_worker_id: foreignDeviceId,
+        })
+      ).rejects.toThrow(/device you own|not found or not accessible/i);
+
+      await owner.watchers.delete([created.watcher_id]);
+    });
   });
 });

--- a/packages/server/src/__tests__/setup/global-setup.ts
+++ b/packages/server/src/__tests__/setup/global-setup.ts
@@ -10,15 +10,29 @@
  * migrations, fixtures, and assertions are identical either way.
  */
 
+import type { GlobalSetupContext } from 'vitest/node';
 import { closeDbSingleton } from '../../db/client';
 import { type EmbeddedBackend, startEmbeddedBackend } from './embedded-postgres-backend';
 import { closeTestDb, setupTestDatabase } from './test-db';
 
+// Make the resolved test DATABASE_URL available to forked test workers via
+// vitest's `inject()`. Env-var propagation from this setup process to forks
+// is timing-dependent (and was the reason the table-schema drift test could
+// silently self-skip in CI); `provide`/`inject` is the vitest-blessed,
+// transport-level channel that always reaches the workers.
+declare module 'vitest' {
+  interface ProvidedContext {
+    /** Connectable Postgres URL for the suite, or null when DB setup was skipped. */
+    databaseUrl: string | null;
+  }
+}
+
 let embedded: EmbeddedBackend | null = null;
 
-export async function setup(): Promise<void> {
+export async function setup({ provide }: GlobalSetupContext): Promise<void> {
   if (process.env.SKIP_TEST_DB_SETUP === '1') {
     console.log('\n⚠️  Skipping test database setup (SKIP_TEST_DB_SETUP=1).\n');
+    provide('databaseUrl', null);
     return;
   }
 
@@ -33,6 +47,9 @@ export async function setup(): Promise<void> {
     process.env.PGSSLMODE = 'disable';
     console.log(`✅ Embedded Postgres ready at ${embedded.url}`);
   }
+
+  // Authoritative signal for forks (see ProvidedContext augmentation above).
+  provide('databaseUrl', process.env.DATABASE_URL ?? null);
 
   // Deterministic 32-byte hex key for AES-256-GCM in tests. Same value the
   // gateway's secret-store test harness uses so behavior is aligned.

--- a/packages/server/src/__tests__/unit/watcher-device-access.test.ts
+++ b/packages/server/src/__tests__/unit/watcher-device-access.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Unit coverage for the device-worker ownership gate on watcher pins
+ * (watchers.device_worker_id). A device pin runs the watcher's agent CLI on the
+ * device owner's machine, so a member-write actor must not be able to pin a
+ * watcher to another user's device. This pins the pure decision matrix
+ * (owner/admin/member/system × owned/foreign/missing device); the DB-backed
+ * wrapper + persistence is exercised in the integration suite.
+ */
+
+import { describe, expect, it } from 'bun:test';
+import {
+  type DeviceWorkerAccessCaller,
+  type DeviceWorkerOwnershipRow,
+  evaluateDeviceWorkerAccess,
+} from '../../tools/admin/watcher-device-access';
+
+const ORG = 'org-1';
+const OTHER_ORG = 'org-2';
+
+const owner: DeviceWorkerAccessCaller = {
+  memberRole: 'owner',
+  userId: 'u-owner',
+  organizationId: ORG,
+  isAuthenticated: true,
+};
+const admin: DeviceWorkerAccessCaller = {
+  memberRole: 'admin',
+  userId: 'u-admin',
+  organizationId: ORG,
+  isAuthenticated: true,
+};
+const member: DeviceWorkerAccessCaller = {
+  memberRole: 'member',
+  userId: 'u-member',
+  organizationId: ORG,
+  isAuthenticated: true,
+};
+// apply / automation / default-provisioning: authenticated, no user/role.
+const system: DeviceWorkerAccessCaller = {
+  memberRole: null,
+  userId: null,
+  organizationId: ORG,
+  isAuthenticated: true,
+};
+
+function device(
+  overrides: Partial<DeviceWorkerOwnershipRow> = {}
+): DeviceWorkerOwnershipRow {
+  return { id: 'dev-1', user_id: 'u-member', organization_id: ORG, ...overrides };
+}
+
+describe('evaluateDeviceWorkerAccess — own device', () => {
+  it('allows any caller to pin a device they own', () => {
+    expect(evaluateDeviceWorkerAccess(device({ user_id: 'u-member' }), member)).toBeNull();
+    expect(evaluateDeviceWorkerAccess(device({ user_id: 'u-owner' }), owner)).toBeNull();
+    // Even when the owned device is attached to a different org.
+    expect(
+      evaluateDeviceWorkerAccess(
+        device({ user_id: 'u-member', organization_id: OTHER_ORG }),
+        member
+      )
+    ).toBeNull();
+  });
+});
+
+describe('evaluateDeviceWorkerAccess — foreign device', () => {
+  it("blocks a member from pinning another user's device", () => {
+    const reason = evaluateDeviceWorkerAccess(
+      device({ user_id: 'someone-else', organization_id: ORG }),
+      member
+    );
+    expect(reason).toMatch(/device you own/i);
+  });
+
+  it('allows an org owner to pin a foreign device attached to their org', () => {
+    expect(
+      evaluateDeviceWorkerAccess(device({ user_id: 'someone-else', organization_id: ORG }), owner)
+    ).toBeNull();
+  });
+
+  it('allows an org admin to pin a foreign device attached to their org', () => {
+    expect(
+      evaluateDeviceWorkerAccess(device({ user_id: 'someone-else', organization_id: ORG }), admin)
+    ).toBeNull();
+  });
+
+  it('blocks an owner from pinning a device in another org', () => {
+    const reason = evaluateDeviceWorkerAccess(
+      device({ user_id: 'someone-else', organization_id: OTHER_ORG }),
+      owner
+    );
+    expect(reason).toMatch(/device you own/i);
+  });
+
+  it('blocks an admin from pinning a device with no org attachment they do not own', () => {
+    const reason = evaluateDeviceWorkerAccess(
+      device({ user_id: 'someone-else', organization_id: null }),
+      admin
+    );
+    expect(reason).toMatch(/device you own/i);
+  });
+});
+
+describe('evaluateDeviceWorkerAccess — missing device', () => {
+  it('rejects a non-member caller when the device row is absent', () => {
+    expect(evaluateDeviceWorkerAccess(null, member)).toMatch(/not found or not accessible/i);
+    expect(evaluateDeviceWorkerAccess(null, owner)).toMatch(/not found or not accessible/i);
+  });
+});
+
+describe('evaluateDeviceWorkerAccess — system/internal caller', () => {
+  it('allows system callers regardless of ownership', () => {
+    expect(
+      evaluateDeviceWorkerAccess(device({ user_id: 'whoever', organization_id: OTHER_ORG }), system)
+    ).toBeNull();
+  });
+
+  it('allows system callers even when the device is missing', () => {
+    expect(evaluateDeviceWorkerAccess(null, system)).toBeNull();
+  });
+});

--- a/packages/server/src/tools/admin/manage_watchers.ts
+++ b/packages/server/src/tools/admin/manage_watchers.ts
@@ -61,6 +61,7 @@ import { validateTemplate } from '../../watchers/renderer';
 import { validateClassifierSourcePaths, validateExtractionSchema } from '../../watchers/validator';
 import type { ToolContext } from '../registry';
 import { routeAction } from './action-router';
+import { assertDeviceWorkerAccess } from './watcher-device-access';
 import {
   assertValidExecutionConfig,
   WatcherExecutionConfigSchema,
@@ -953,6 +954,10 @@ async function handleCreate(
     throw new ToolUserError('extraction_schema is required for create action');
   }
   assertValidExecutionConfig(args.execution_config, ctx);
+  // A device pin runs the watcher's agent CLI on the device owner's machine —
+  // validate the caller may target this device (own it, or org owner/admin
+  // over a device attached to the org) before storing it.
+  await assertDeviceWorkerAccess(sql, args.device_worker_id, ctx);
 
   // entity_id is optional: omit it for an org-scoped/global watcher.
   const entityId = args.entity_id;
@@ -1286,6 +1291,10 @@ async function handleUpdate(
     throw new Error('watcher_id is required for update action');
   }
   assertValidExecutionConfig(args.execution_config, ctx);
+  // Re-pinning to a device targets that device owner's machine — validate the
+  // caller may pin it (own it, or org owner/admin over an org-attached device).
+  // undefined = unchanged and null = clear the pin both pass without a lookup.
+  await assertDeviceWorkerAccess(sql, args.device_worker_id, ctx);
 
   await requireExists(sql, 'watchers', args.watcher_id, 'Watcher');
 

--- a/packages/server/src/tools/admin/watcher-device-access.ts
+++ b/packages/server/src/tools/admin/watcher-device-access.ts
@@ -1,0 +1,97 @@
+import type { DbClient } from '../../db/client';
+import { ToolUserError } from '../../utils/errors';
+
+/**
+ * Ownership/access enforcement for pinning a watcher to a device worker
+ * (`watchers.device_worker_id`). A device-worker watcher run spawns an agent
+ * CLI on the *device owner's* machine, so an unvalidated pin lets a member-write
+ * actor target another user's device — privilege escalation. This mirrors the
+ * shape of watcher-execution-config.ts: a pure decision function (unit-tested)
+ * plus a thin DB-backed assertion wrapper, both raising ToolUserError on reject.
+ */
+
+/** Minimal caller identity needed to authorize a device-worker pin. */
+export interface DeviceWorkerAccessCaller {
+  memberRole: string | null;
+  userId: string | null;
+  organizationId: string;
+  isAuthenticated: boolean;
+}
+
+/** The device_workers fields that drive the access decision. */
+export interface DeviceWorkerOwnershipRow {
+  id: string;
+  user_id: string | null;
+  organization_id: string | null;
+}
+
+/**
+ * Pure access decision (no DB). Returns null when the caller may pin `device`,
+ * or a human-readable rejection reason otherwise. `device` is null when no
+ * matching device_workers row exists.
+ *
+ * Rules:
+ *  - System/internal callers (apply, automation, default-provisioning) carry no
+ *    memberRole/userId yet are authenticated; they bypass action-access
+ *    enforcement elsewhere, so don't block them here either.
+ *  - The caller owns the device (`device.user_id === caller.userId`), OR
+ *  - The caller is org owner/admin and the device is attached to the caller's
+ *    org (`device.organization_id === caller.organizationId`).
+ */
+export function evaluateDeviceWorkerAccess(
+  device: DeviceWorkerOwnershipRow | null,
+  caller: DeviceWorkerAccessCaller
+): string | null {
+  const isSystem =
+    caller.isAuthenticated && caller.userId === null && caller.memberRole === null;
+  if (isSystem) return null;
+
+  if (!device) {
+    return `Device worker not found or not accessible.`;
+  }
+
+  // Owner of the device may always pin it.
+  if (caller.userId !== null && device.user_id === caller.userId) {
+    return null;
+  }
+
+  // Org owner/admin may pin any device attached to their org.
+  const isOwnerOrAdmin = caller.memberRole === 'owner' || caller.memberRole === 'admin';
+  if (
+    isOwnerOrAdmin &&
+    device.organization_id !== null &&
+    device.organization_id === caller.organizationId
+  ) {
+    return null;
+  }
+
+  return `You can only pin a watcher to a device you own (or, as an org owner/admin, a device attached to your workspace).`;
+}
+
+/**
+ * DB-backed assertion. `undefined`/`null` device_worker_id = no pin / clearing
+ * the pin — both pass without a lookup. Otherwise the device_workers row is
+ * resolved and run through evaluateDeviceWorkerAccess; a rejection throws
+ * ToolUserError (403).
+ */
+export async function assertDeviceWorkerAccess(
+  sql: DbClient,
+  deviceWorkerId: string | null | undefined,
+  caller: DeviceWorkerAccessCaller
+): Promise<void> {
+  if (deviceWorkerId === undefined || deviceWorkerId === null) return;
+  const trimmed = deviceWorkerId.trim();
+  if (!trimmed) return;
+
+  const rows = (await sql`
+    SELECT id, user_id, organization_id
+    FROM device_workers
+    WHERE id = ${trimmed}::uuid
+    LIMIT 1
+  `) as unknown as DeviceWorkerOwnershipRow[];
+
+  const reason = evaluateDeviceWorkerAccess(rows[0] ?? null, caller);
+  if (reason) {
+    throw new ToolUserError(reason, 403);
+  }
+}

--- a/packages/server/src/utils/__tests__/table-schema.test.ts
+++ b/packages/server/src/utils/__tests__/table-schema.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, inject, it } from 'vitest';
 import {
   buildColumnList,
   QUERYABLE_SCHEMA,
@@ -102,12 +102,20 @@ describe('validateTableQuery', () => {
 });
 
 /**
- * Schema drift detection — runs when DATABASE_URL is available.
+ * Schema drift detection — runs whenever the suite has a Postgres backend.
  * Ensures every real column in queryable tables is listed in QUERYABLE_SCHEMA
  * so the polyglot-sql validator doesn't reject valid JOINs.
+ *
+ * Gating note: the previous `describe.skipIf(!process.env.DATABASE_URL)` was
+ * evaluated at module load. In the embedded-PG path the URL is set by
+ * global-setup in the SETUP process; whether a forked vitest worker observes it
+ * at module-load time is timing-dependent, so the block could silently
+ * self-skip and the gate was toothless. We now gate on the URL `provide()`d by
+ * global-setup and read via `inject()` at runtime — vitest's transport-level
+ * channel always reaches forks — and skip from inside the test so the decision
+ * is made against the authoritative value.
  */
-const hasDb = !!process.env.DATABASE_URL;
-describe.skipIf(!hasDb)('QUERYABLE_SCHEMA vs database (drift detection)', () => {
+describe('QUERYABLE_SCHEMA vs database (drift detection)', () => {
   const INTENTIONALLY_OMITTED: Record<string, Set<string>> = {
     entities: new Set(['embedding', 'content_tsv', 'content_hash']),
     events: new Set([]),
@@ -127,7 +135,17 @@ describe.skipIf(!hasDb)('QUERYABLE_SCHEMA vs database (drift detection)', () => 
     user: new Set(['email', 'phoneNumber', 'phoneNumberVerified']),
   };
 
-  it('should have every DB column listed in the schema (or intentionally omitted)', async () => {
+  it('should have every DB column listed in the schema (or intentionally omitted)', async (ctx) => {
+    const databaseUrl = inject('databaseUrl');
+    if (!databaseUrl) {
+      // Only reachable when SKIP_TEST_DB_SETUP=1 — no backend to diff against.
+      ctx.skip();
+      return;
+    }
+    // Defensive: pin the env the db client reads to the authoritative URL from
+    // global-setup, independent of env-propagation timing into this fork.
+    process.env.DATABASE_URL = databaseUrl;
+
     const { getDb, pgTextArray } = await import('../../db/client');
     const sql = getDb();
 

--- a/packages/server/src/utils/table-schema.ts
+++ b/packages/server/src/utils/table-schema.ts
@@ -324,6 +324,11 @@ export const QUERYABLE_SCHEMA = {
         'name',
         'description',
         'version',
+        // Non-secret discriminator ('api' | 'mcp' | 'openapi') selecting which
+        // *_config blob a definition uses; parity with the other scalar
+        // connector_definitions metadata columns. The blobs themselves stay in
+        // INTENTIONALLY_OMITTED (drift test).
+        'api_type',
         'auth_schema',
         'feeds_schema',
         'actions_schema',


### PR DESCRIPTION
Two follow-ups from the PR #1058 multi-aspect review (issues #1060, #1061). Both are server-only; no owletto/submodule changes.

## #1060 — Validate `device_worker_id` ownership in `manage_watchers`
A watcher pinned to a device worker runs its agent CLI on the **device owner's machine**. `manage_watchers` create/update stored `device_worker_id` without verifying the caller could target that device, so a member-write actor could pin a watcher to another user's device — privilege escalation (unattended agent execution on someone else's machine).

**Fix:** new `watcher-device-access.ts` mirroring the shape of `watcher-execution-config.ts`:
- `evaluateDeviceWorkerAccess(device, caller)` — pure decision function (no DB). Allows the device owner (`device.user_id === caller.userId`), or an org owner/admin over a device attached to their org (`device.organization_id === caller.organizationId`). System/internal callers (`isAuthenticated && userId===null && memberRole===null`) are exempt, matching `assertValidExecutionConfig`.
- `assertDeviceWorkerAccess(sql, deviceWorkerId, caller)` — DB-backed wrapper; `undefined` (unchanged) / `null`/empty (clear) pass without a lookup; rejection throws `ToolUserError` (403).

Wired into `handleCreate` and `handleUpdate` right after `assertValidExecutionConfig`. `handleCreateFromVersion` does not set `device_worker_id`, so it needs no gate.

## #1061 — Drift test dormant in CI + `connector_definitions.api_type` missing
**(a)** The drift `describe` was gated on `describe.skipIf(!process.env.DATABASE_URL)` evaluated at module load — timing-dependent under forked vitest workers, so it could silently self-skip and the gate was toothless. Fixed by having `global-setup` `provide('databaseUrl', …)` (vitest's transport-level cross-process channel) and gating the test on `inject('databaseUrl')` read inside the test body, skipping only when there is genuinely no backend (`SKIP_TEST_DB_SETUP=1`).

**(b)** `connector_definitions.api_type` is a real DB column (`text DEFAULT 'api'`, a non-secret `'api'|'mcp'|'openapi'` discriminator) missing from both `QUERYABLE_SCHEMA` and `INTENTIONALLY_OMITTED`, so the drift test fails against a real DB. Added it to the cols list (parity with the other scalar `connector_definitions` metadata columns); the large `*_config` JSONB blobs stay intentionally omitted.

## Validation (Node 22)
- `make build-packages` + `cd packages/server && bunx tsc --noEmit` — clean (exit 0).
- **#1060** unit (`bun test watcher-device-access.test.ts`): 9 pass (owner/admin/member/system × owned/foreign/missing). Integration (`watchers-crud.test.ts`, embedded PG18): 12 pass incl. 4 new device-gate cases. **Teeth proven:** removing `assertDeviceWorkerAccess` makes the 3 rejection cases fail (a foreign-org pin silently succeeds) → restored → green.
- **#1061** drift test proven to RUN (not skip) and PASS against real Homebrew **PG17 + pgvector 0.8.1** (`createdb wf_test` → `dbmate up` → vitest with that `DATABASE_URL`: 14 pass, drift case shows `✓` not `↓`); and under the embedded PG18 backend (14 pass). **Teeth proven:** removing `api_type` makes it fail against the real DB → restored → green. `dropdb wf_test` after.
- `make review BASE=origin/main`: typecheck=0, unit=0, integration=0; pi verdict bug_free 88, 0 bugs, 0 blockers, tests_adequate=true.

Closes #1060
Closes #1061

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Device access control for watchers: enforce ownership and authorization checks when pinning watchers to devices. Only authorized users can pin watchers to devices in their organization.

* **Tests**
  * Extended watcher integration tests with device access control scenarios.
  * Added unit tests for device-worker access validation.
  * Improved test infrastructure for database configuration across forked workers.

* **Chores**
  * Updated connector definitions schema allowlist.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lobu-ai/lobu/pull/1062?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->