### PR TITLE
fix(server): resolve Slack OAuth/preview config from env, not pod-local instance

### DIFF
--- a/packages/server/src/gateway/__tests__/slack-connection-coordinator.test.ts
+++ b/packages/server/src/gateway/__tests__/slack-connection-coordinator.test.ts
@@ -1,6 +1,9 @@
-import { describe, expect, mock, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { SlackConnectionCoordinator } from "../connections/slack-connection-coordinator.js";
-import type { PlatformConnection } from "../connections/types.js";
+import type {
+  PlatformAdapterConfig,
+  PlatformConnection,
+} from "../connections/types.js";
 
 function createSlackConnection(
   id: string,
@@ -26,7 +29,53 @@ function createSlackConnection(
   };
 }
 
+/** Deps stub with sensible no-op defaults; override per test. */
+function makeDeps(
+  overrides: Partial<
+    ConstructorParameters<typeof SlackConnectionCoordinator>[0]
+  > = {}
+): ConstructorParameters<typeof SlackConnectionCoordinator>[0] {
+  return {
+    addConnection: mock(async () => createSlackConnection("unused")),
+    createStateAdapter: mock(async () => ({})),
+    ensureConnectionRunning: mock(async () => true),
+    forwardWebhook: mock(async () => new Response("ok")),
+    getRunningChat: () => undefined,
+    hasConnection: () => true,
+    listSlackConnections: async () => [],
+    restartConnection: mock(async () => undefined),
+    updateConnection: mock(async () => createSlackConnection("unused")),
+    ...overrides,
+  };
+}
+
+const SLACK_ENV_KEYS = [
+  "SLACK_SIGNING_SECRET",
+  "SLACK_CLIENT_ID",
+  "SLACK_CLIENT_SECRET",
+  "SLACK_BOT_TOKEN",
+  "SLACK_ENCRYPTION_KEY",
+  "SLACK_INSTALLATION_KEY_PREFIX",
+  "SLACK_USER_NAME",
+] as const;
+
 describe("SlackConnectionCoordinator", () => {
+  const savedEnv: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    for (const key of SLACK_ENV_KEYS) {
+      savedEnv[key] = process.env[key];
+      delete process.env[key];
+    }
+  });
+
+  afterEach(() => {
+    for (const key of SLACK_ENV_KEYS) {
+      if (savedEnv[key] === undefined) delete process.env[key];
+      else process.env[key] = savedEnv[key];
+    }
+  });
+
   test("ensureWorkspaceConnection is idempotent per team", async () => {
     const connections: PlatformConnection[] = [];
     const addConnection = mock(
@@ -55,22 +104,15 @@ describe("SlackConnectionCoordinator", () => {
     );
     const restartConnection = mock(async () => undefined);
 
-    const coordinator = new SlackConnectionCoordinator({
-      addConnection,
-      createStateAdapter: mock(async () => ({})),
-      ensureConnectionRunning: mock(async () => true),
-      forwardWebhook: mock(async () => new Response("ok")),
-      getCurrentSlackConfig: () => ({
-        signingSecret: "signing-secret",
-        clientId: "client-id",
-        clientSecret: "client-secret",
-      }),
-      getRunningChat: () => undefined,
-      hasConnection: () => false,
-      listSlackConnections: async () => connections,
-      restartConnection,
-      updateConnection,
-    });
+    const coordinator = new SlackConnectionCoordinator(
+      makeDeps({
+        addConnection,
+        hasConnection: () => false,
+        listSlackConnections: async () => connections,
+        restartConnection,
+        updateConnection,
+      })
+    );
 
     const first = await coordinator.ensureWorkspaceConnection("T123", {
       botToken: "xoxb-first-token",
@@ -97,29 +139,76 @@ describe("SlackConnectionCoordinator", () => {
     expect((connections[0]?.config as any).botToken).toBe("xoxb-second-token");
   });
 
+  test("ensureWorkspaceConnection persists only tenant data, not app secrets", async () => {
+    // The Slack adapter reads signingSecret/clientId/clientSecret from env at
+    // runtime, so a per-workspace connection must NOT bake them into its stored
+    // config (that would duplicate the secret per tenant and block rotation).
+    let storedConfig: PlatformAdapterConfig | undefined;
+    const coordinator = new SlackConnectionCoordinator(
+      makeDeps({
+        addConnection: mock(async (_platform, _agentId, config) => {
+          storedConfig = config;
+          return createSlackConnection("conn-new", {}, {});
+        }),
+        hasConnection: () => false,
+        listSlackConnections: async () => [],
+      })
+    );
+
+    await coordinator.ensureWorkspaceConnection("T999", {
+      botToken: "xoxb-tenant-token",
+      botUserId: "U999",
+      teamName: "Tenant",
+    });
+
+    const cfg = storedConfig as any;
+    expect(cfg.platform).toBe("slack");
+    expect(cfg.botToken).toBe("xoxb-tenant-token");
+    expect(cfg.botUserId).toBe("U999");
+    expect(cfg.signingSecret).toBeUndefined();
+    expect(cfg.clientId).toBeUndefined();
+    expect(cfg.clientSecret).toBeUndefined();
+  });
+
+  test("resolveAdapterConfig sources app creds from env (requireOAuth)", async () => {
+    process.env.SLACK_SIGNING_SECRET = "env-signing";
+    process.env.SLACK_CLIENT_ID = "env-client-id";
+    process.env.SLACK_CLIENT_SECRET = "env-client-secret";
+
+    const coordinator = new SlackConnectionCoordinator(makeDeps());
+    const config = coordinator.resolveAdapterConfig({ requireOAuth: true });
+
+    expect(config).toMatchObject({
+      platform: "slack",
+      signingSecret: "env-signing",
+      clientId: "env-client-id",
+      clientSecret: "env-client-secret",
+    });
+  });
+
+  test("resolveAdapterConfig throws when Slack env is absent", () => {
+    const coordinator = new SlackConnectionCoordinator(makeDeps());
+    expect(() => coordinator.resolveAdapterConfig()).toThrow(
+      /SLACK_SIGNING_SECRET/
+    );
+    expect(() => coordinator.resolveAdapterConfig({ requireOAuth: true })).toThrow(
+      /SLACK_SIGNING_SECRET/
+    );
+  });
+
   test("handleAppWebhook prefers an exact team match", async () => {
     const body = JSON.stringify({ team_id: "T123", type: "event_callback" });
-    const coordinator = new SlackConnectionCoordinator({
-      addConnection: mock(async () => createSlackConnection("unused")),
-      createStateAdapter: mock(async () => ({})),
-      ensureConnectionRunning: mock(async () => true),
-      forwardWebhook: mock(async (connectionId: string, request: Request) => {
-        return new Response(`${connectionId}:${await request.text()}`);
-      }),
-      getCurrentSlackConfig: () => ({
-        signingSecret: "signing-secret",
-        clientId: "client-id",
-        clientSecret: "client-secret",
-      }),
-      getRunningChat: () => undefined,
-      hasConnection: () => true,
-      listSlackConnections: async () => [
-        createSlackConnection("conn-team", { teamId: "T123" }),
-        createSlackConnection("conn-default"),
-      ],
-      restartConnection: mock(async () => undefined),
-      updateConnection: mock(async () => createSlackConnection("unused")),
-    });
+    const coordinator = new SlackConnectionCoordinator(
+      makeDeps({
+        forwardWebhook: mock(async (connectionId: string, request: Request) => {
+          return new Response(`${connectionId}:${await request.text()}`);
+        }),
+        listSlackConnections: async () => [
+          createSlackConnection("conn-team", { teamId: "T123" }),
+          createSlackConnection("conn-default"),
+        ],
+      })
+    );
 
     const response = await coordinator.handleAppWebhook(
       new Request("https://gateway.example.com/slack/events", {
@@ -133,26 +222,47 @@ describe("SlackConnectionCoordinator", () => {
     expect(await response.text()).toBe(`conn-team:${body}`);
   });
 
+  test("handleAppWebhook routes a matched team without any Slack env (BYO)", async () => {
+    // Sanity: env-sourcing in resolveAdapterConfig must not affect routing of a
+    // webhook that resolves to a concrete connection — that path uses the
+    // connection's own adapter, never resolveAdapterConfig. Env is unset here
+    // (beforeEach cleared it) and routing must still succeed.
+    const body = JSON.stringify({ team_id: "T777", type: "event_callback" });
+    const coordinator = new SlackConnectionCoordinator(
+      makeDeps({
+        forwardWebhook: mock(async (connectionId: string) => {
+          return new Response(connectionId);
+        }),
+        listSlackConnections: async () => [
+          createSlackConnection("conn-byo", { teamId: "T777" }),
+        ],
+      })
+    );
+
+    const response = await coordinator.handleAppWebhook(
+      new Request("https://gateway.example.com/slack/events", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body,
+      })
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.text()).toBe("conn-byo");
+  });
+
   test("handleAppWebhook falls back to the default Slack connection", async () => {
     const body = JSON.stringify({ type: "url_verification" });
-    const coordinator = new SlackConnectionCoordinator({
-      addConnection: mock(async () => createSlackConnection("unused")),
-      createStateAdapter: mock(async () => ({})),
-      ensureConnectionRunning: mock(async () => true),
-      forwardWebhook: mock(async (connectionId: string, request: Request) => {
-        return new Response(`${connectionId}:${await request.text()}`);
-      }),
-      getCurrentSlackConfig: () => ({
-        signingSecret: "signing-secret",
-        clientId: "client-id",
-        clientSecret: "client-secret",
-      }),
-      getRunningChat: () => undefined,
-      hasConnection: () => true,
-      listSlackConnections: async () => [createSlackConnection("conn-default")],
-      restartConnection: mock(async () => undefined),
-      updateConnection: mock(async () => createSlackConnection("unused")),
-    });
+    const coordinator = new SlackConnectionCoordinator(
+      makeDeps({
+        forwardWebhook: mock(async (connectionId: string, request: Request) => {
+          return new Response(`${connectionId}:${await request.text()}`);
+        }),
+        listSlackConnections: async () => [
+          createSlackConnection("conn-default"),
+        ],
+      })
+    );
 
     const response = await coordinator.handleAppWebhook(
       new Request("https://gateway.example.com/slack/events", {
@@ -169,24 +279,14 @@ describe("SlackConnectionCoordinator", () => {
   test("handleAppWebhook sends a welcome DM for team_join events", async () => {
     const post = mock(async () => undefined);
     const openDM = mock(async () => ({ post }));
-    const coordinator = new SlackConnectionCoordinator({
-      addConnection: mock(async () => createSlackConnection("unused")),
-      createStateAdapter: mock(async () => ({})),
-      ensureConnectionRunning: mock(async () => true),
-      forwardWebhook: mock(async () => new Response("ok")),
-      getCurrentSlackConfig: () => ({
-        signingSecret: "signing-secret",
-        clientId: "client-id",
-        clientSecret: "client-secret",
-      }),
-      getRunningChat: () => ({ openDM }),
-      hasConnection: () => true,
-      listSlackConnections: async () => [
-        createSlackConnection("conn-team", { teamId: "T123" }),
-      ],
-      restartConnection: mock(async () => undefined),
-      updateConnection: mock(async () => createSlackConnection("unused")),
-    });
+    const coordinator = new SlackConnectionCoordinator(
+      makeDeps({
+        getRunningChat: () => ({ openDM }),
+        listSlackConnections: async () => [
+          createSlackConnection("conn-team", { teamId: "T123" }),
+        ],
+      })
+    );
 
     const response = await coordinator.handleAppWebhook(
       new Request("https://gateway.example.com/slack/events", {

--- a/packages/server/src/gateway/connections/chat-instance-manager.ts
+++ b/packages/server/src/gateway/connections/chat-instance-manager.ts
@@ -915,38 +915,12 @@ export class ChatInstanceManager {
     }
   }
 
-  private findRunningInstanceByPlatform(
-    platform: string
-  ): ManagedInstance | undefined {
-    return Array.from(this.instances.values()).find(
-      (instance) => instance.connection.platform === platform
-    );
-  }
-
   private buildSlackCoordinator(): SlackConnectionCoordinator {
     return new SlackConnectionCoordinator({
       addConnection: this.addConnection.bind(this),
       createStateAdapter: this.createStateAdapter.bind(this),
       ensureConnectionRunning: this.ensureConnectionRunning.bind(this),
       forwardWebhook: this.handleWebhook.bind(this),
-      getCurrentSlackConfig: () => {
-        const slackInstance = this.findRunningInstanceByPlatform("slack");
-        const currentConfig = (slackInstance?.connection.config || {}) as
-          | Record<string, any>
-          | undefined;
-
-        return {
-          signingSecret: currentConfig?.signingSecret,
-          clientId: currentConfig?.clientId,
-          clientSecret: currentConfig?.clientSecret,
-          encryptionKey: currentConfig?.encryptionKey,
-          installationKeyPrefix: currentConfig?.installationKeyPrefix,
-          userName:
-            currentConfig?.userName ||
-            slackInstance?.connection.metadata?.botUsername,
-          botToken: currentConfig?.botToken,
-        };
-      },
       getRunningChat: (connectionId) => this.getInstance(connectionId)?.chat,
       hasConnection: this.has.bind(this),
       listSlackConnections: () => this.listConnections({ platform: "slack" }),

--- a/packages/server/src/gateway/connections/slack-connection-coordinator.ts
+++ b/packages/server/src/gateway/connections/slack-connection-coordinator.ts
@@ -34,6 +34,31 @@ type SlackRuntimeConfig = {
   botToken?: string;
 };
 
+/**
+ * App-level Slack credentials for the shared (hosted) Lobu Slack app, read from
+ * the environment. These power the OAuth install handshake and the hosted
+ * preview/linking bot. Reading them from env (not from whatever connection
+ * happens to be warm on the current pod) makes config resolution deterministic
+ * across replicas — every pod sees the same values regardless of which Slack
+ * connections it has warmed. Per-workspace connections persist only tenant data
+ * (bot token); the Slack adapter falls back to these env vars at runtime, so
+ * rotating them does not require reinstalling each workspace.
+ *
+ * When the env is unset, OAuth/preview is simply unavailable and operators must
+ * bring their own Slack credentials on a per-connection basis.
+ */
+function readSlackAppEnvConfig(): SlackRuntimeConfig {
+  return {
+    signingSecret: process.env.SLACK_SIGNING_SECRET,
+    clientId: process.env.SLACK_CLIENT_ID,
+    clientSecret: process.env.SLACK_CLIENT_SECRET,
+    encryptionKey: process.env.SLACK_ENCRYPTION_KEY,
+    installationKeyPrefix: process.env.SLACK_INSTALLATION_KEY_PREFIX,
+    userName: process.env.SLACK_USER_NAME,
+    botToken: process.env.SLACK_BOT_TOKEN,
+  };
+}
+
 interface SlackConnectionCoordinatorDeps {
   addConnection(
     platform: string,
@@ -45,7 +70,6 @@ interface SlackConnectionCoordinatorDeps {
   createStateAdapter(): Promise<any>;
   ensureConnectionRunning(connectionId: string): Promise<boolean>;
   forwardWebhook(connectionId: string, request: Request): Promise<Response>;
-  getCurrentSlackConfig(): SlackRuntimeConfig;
   getRunningChat(connectionId: string): any | undefined;
   hasConnection(connectionId: string): boolean;
   listSlackConnections(): Promise<PlatformConnection[]>;
@@ -85,11 +109,15 @@ export class SlackConnectionCoordinator {
     teamId: string,
     installation: SlackInstallation
   ): Promise<PlatformConnection> {
-    const baseConfig = this.resolveAdapterConfig({
-      requireOAuth: true,
-    }) as Extract<PlatformAdapterConfig, { platform: "slack" }>;
+    // Persist only per-workspace (tenant) data. App-level secrets
+    // (signingSecret/clientId/clientSecret) are read from env by the Slack
+    // adapter at runtime, so they never get duplicated into per-tenant rows and
+    // rotating them does not require reinstalling each workspace. The OAuth
+    // handshake that produced `installation` already validated the env config
+    // (via createOAuthChat → resolveAdapterConfig), so there's nothing to
+    // re-check here.
     const config: PlatformAdapterConfig = {
-      ...baseConfig,
+      platform: "slack",
       botToken: installation.botToken,
       ...(installation.botUserId ? { botUserId: installation.botUserId } : {}),
     };
@@ -236,7 +264,7 @@ export class SlackConnectionCoordinator {
   resolveAdapterConfig(options?: {
     requireOAuth?: boolean;
   }): PlatformAdapterConfig {
-    const currentConfig = this.deps.getCurrentSlackConfig();
+    const currentConfig = readSlackAppEnvConfig();
     const {
       signingSecret,
       clientId,
@@ -247,13 +275,13 @@ export class SlackConnectionCoordinator {
     } = currentConfig;
 
     if (!signingSecret) {
-      throw new Error("Slack signing secret is not configured");
+      throw new Error("Slack signing secret is not configured. Set SLACK_SIGNING_SECRET.");
     }
 
     if (options?.requireOAuth) {
       if (!clientId || !clientSecret) {
         throw new Error(
-          "Slack OAuth is not configured. Set client ID and secret on the connection."
+          "Slack OAuth is not configured. Set SLACK_CLIENT_ID and SLACK_CLIENT_SECRET."
         );
       }
 
@@ -271,7 +299,7 @@ export class SlackConnectionCoordinator {
     const botToken = currentConfig.botToken;
     if (!botToken && (!clientId || !clientSecret)) {
       throw new Error(
-        "Slack adapter is not configured. Provide a bot token or OAuth credentials on the connection."
+        "Slack adapter is not configured. Set SLACK_BOT_TOKEN, or SLACK_CLIENT_ID and SLACK_CLIENT_SECRET."
       );
     }
 


### PR DESCRIPTION
## Problem
`SlackConnectionCoordinator.resolveAdapterConfig()` sourced the shared Slack app credentials via `getCurrentSlackConfig`, which read them from the **first warm Slack connection on the current pod** (an in-memory `instances` Map). Under prod multi-replica (k8s, `replicaCount>1`, `sessionAffinity: ClientIP`), a cold or freshly-scaled pod with no warm Slack connection returns all-`undefined` → OAuth install completion and the no-team-match webhook fallback throw `"Slack signing secret is not configured"`, intermittently. It also baked in a "single global warm Slack identity" assumption that blocked per-connection / per-platform consolidation.

## Fix (a simplifying deletion)
- `resolveAdapterConfig` reads app-level creds (`SLACK_CLIENT_ID` / `SLACK_CLIENT_SECRET` / `SLACK_SIGNING_SECRET`, etc.) from **env** via `readSlackAppEnvConfig()` — every replica resolves identically, no pod-local state.
- `ensureWorkspaceConnection` persists **tenant-only** config (`botToken`, `botUserId`). The Slack adapter falls back to `process.env.SLACK_SIGNING_SECRET` at runtime (`@chat-adapter/slack` `dist/index.js:767`), so rotating the shared app's secret no longer requires reinstalling each workspace, and app secrets are never duplicated into per-tenant rows.
- Removes the now-unused `getCurrentSlackConfig` dep and `findRunningInstanceByPlatform` (net −26 lines in `chat-instance-manager`).

## Behavior policy
- **Env set** → hosted preview + shared-app OAuth available on every replica.
- **Env unset** → Slack requires per-connection BYO credentials (created via the connections CRUD/UI; runtime adapter path, unchanged).

## Reproducer (red → green)
New unit tests in `slack-connection-coordinator.test.ts`, run with **no deps supplying Slack config** (the cold-pod condition):
- `resolveAdapterConfig sources app creds from env (requireOAuth)` — **before:** depended on a warm instance via `getCurrentSlackConfig` (none present → throws); **after:** resolves from env. ✅
- `resolveAdapterConfig throws when Slack env is absent` — env-absent policy gate. ✅
- `ensureWorkspaceConnection persists only tenant data, not app secrets` — asserts stored config has `botToken`/`botUserId` but no `signingSecret`/`clientId`/`clientSecret`. ✅
- `handleAppWebhook routes a matched team without any Slack env (BYO)` — proves env-sourcing does not affect routing of webhooks that resolve to a concrete connection. ✅

## Validation
- build / typecheck / unit (52) / integration (30): all green.
- pi (GPT-5.5 high): **bug_free 88, simplicity 86, slop 0, 0 bugs, 0 blockers, tests_adequate**. pi independently instantiated the adapter with `{botToken}` + `SLACK_SIGNING_SECRET` and confirmed the env signing fallback.

## Scope / not done (intentional)
- No generic multi-tenant-OAuth framework (premature; one consumer today). Trigger to generalize is a real second multi-workspace platform (Discord guild-install).
- No blanket DB migration stripping stored secrets from existing rows — that would break legitimate BYO connections that rely on their own stored `signingSecret`. Existing shared-app rows pick up secret rotation on next reinstall/update.

## Known pre-existing gap (out of scope)
Concurrent OAuth installs for the same workspace can race-create duplicate connections (no DB uniqueness on `team_id`; read-before-write + random id). Not introduced here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Expanded test coverage for Slack workspace connection setup and credential handling, including multi-tenant scenarios.

* **Refactor**
  * Improved separation of workspace-level and app-level credential management for enhanced multi-tenant Slack integration architecture.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lobu-ai/lobu/pull/1065?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->