### PR TITLE
fix(agent-worker): worker bash secret leak, SESSION_TIMEOUT UX, dead sandbox-leak redaction

### DIFF
--- a/packages/agent-worker/src/__tests__/agent-session-bash-env.test.ts
+++ b/packages/agent-worker/src/__tests__/agent-session-bash-env.test.ts
@@ -115,6 +115,32 @@ describe("agent session bash inherits Lobu-built bash (Findings #1, #10)", () =>
     session.dispose();
   });
 
+  test("the agent's active built-ins ARE the Lobu-built instances", async () => {
+    const lobuTools = createOpenClawTools(tempDir);
+    const lobuByName = new Map(lobuTools.map((t) => [t.name, t]));
+
+    const { session } = await buildAgentSession({
+      cwd: tempDir,
+      tools: lobuTools,
+      customTools: [],
+    });
+
+    // Every built-in the agent can run must be the exact Lobu instance, not
+    // pi's rebuilt one — that is what carries the env-strip spawnHook and the
+    // embedded BashOperations.
+    for (const tool of session.agent.state.tools) {
+      const lobuTool = lobuByName.get(tool.name);
+      if (lobuTool) {
+        expect(tool).toBe(lobuTool);
+      }
+    }
+    // bash specifically must be present and swapped.
+    const bash = session.agent.state.tools.find((t) => t.name === "bash");
+    expect(bash).toBe(lobuByName.get("bash"));
+
+    session.dispose();
+  });
+
   test("SENSITIVE_WORKER_ENV_KEYS covers the worker gateway creds", () => {
     expect(SENSITIVE_WORKER_ENV_KEYS).toContain("WORKER_TOKEN");
     expect(SENSITIVE_WORKER_ENV_KEYS).toContain("DISPATCHER_URL");

--- a/packages/agent-worker/src/__tests__/agent-session-bash-env.test.ts
+++ b/packages/agent-worker/src/__tests__/agent-session-bash-env.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Reproducer for the WORKER_TOKEN / DISPATCHER_URL leak (Finding #1) and the
+ * discarded embeddedBashOps (Finding #10).
+ *
+ * The worker builds its bash tool via createOpenClawTools() with a spawnHook
+ * that strips SENSITIVE_WORKER_ENV_KEYS and (optionally) custom BashOperations.
+ * Those instances must be the ones the agent actually runs. We assert that the
+ * bash tool the session ends up with both strips the secrets and uses the
+ * provided BashOperations — i.e. the Lobu-built bash is not silently discarded.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { BashOperations } from "@mariozechner/pi-coding-agent";
+import { buildAgentSession } from "../openclaw/session-builder";
+import { createOpenClawTools } from "../openclaw/tools";
+import { SENSITIVE_WORKER_ENV_KEYS } from "../shared/worker-env-keys";
+
+let tempDir: string;
+let originalDispatcherUrl: string | undefined;
+let originalWorkerToken: string | undefined;
+
+beforeEach(() => {
+  tempDir = mkdtempSync(join(tmpdir(), "agent-session-bash-env-"));
+  originalDispatcherUrl = process.env.DISPATCHER_URL;
+  originalWorkerToken = process.env.WORKER_TOKEN;
+  process.env.DISPATCHER_URL = "http://gateway:8080";
+  process.env.WORKER_TOKEN = "super-secret-worker-token";
+});
+
+afterEach(() => {
+  rmSync(tempDir, { recursive: true, force: true });
+  if (originalDispatcherUrl === undefined) {
+    delete process.env.DISPATCHER_URL;
+  } else {
+    process.env.DISPATCHER_URL = originalDispatcherUrl;
+  }
+  if (originalWorkerToken === undefined) {
+    delete process.env.WORKER_TOKEN;
+  } else {
+    process.env.WORKER_TOKEN = originalWorkerToken;
+  }
+});
+
+function getBashTool(tools: { name: string }[]) {
+  const bash = tools.find((t) => t.name === "bash");
+  if (!bash) {
+    throw new Error("bash tool not present on session");
+  }
+  return bash as any;
+}
+
+describe("agent session bash inherits Lobu-built bash (Findings #1, #10)", () => {
+  test("session bash strips SENSITIVE_WORKER_ENV_KEYS from the spawned env", async () => {
+    const { session } = await buildAgentSession({
+      cwd: tempDir,
+      tools: createOpenClawTools(tempDir),
+      customTools: [],
+    });
+
+    const bash = getBashTool(session.agent.state.tools);
+    const result = await bash.execute(
+      "leak-check",
+      { command: "printenv WORKER_TOKEN; printenv DISPATCHER_URL; echo END" },
+      undefined,
+      undefined
+    );
+    const text = (result.content as any[])
+      .filter((c) => c.type === "text")
+      .map((c) => c.text)
+      .join("\n");
+
+    // The agent's bash must NOT see the worker's gateway credentials.
+    expect(text).not.toContain("super-secret-worker-token");
+    expect(text).not.toContain("http://gateway:8080");
+    // sanity: the command actually ran
+    expect(text).toContain("END");
+
+    session.dispose();
+  });
+
+  test("session bash routes through the provided BashOperations", async () => {
+    let capturedCommand = "";
+    const mockBashOps: BashOperations = {
+      exec: async (command, _cwd, { onData }) => {
+        capturedCommand = command;
+        onData(Buffer.from("from-custom-ops\n"));
+        return { exitCode: 0 };
+      },
+    };
+
+    const { session } = await buildAgentSession({
+      cwd: tempDir,
+      tools: createOpenClawTools(tempDir, { bashOperations: mockBashOps }),
+      customTools: [],
+    });
+
+    const bash = getBashTool(session.agent.state.tools);
+    const result = await bash.execute(
+      "ops-check",
+      { command: "echo hello-ops" },
+      undefined,
+      undefined
+    );
+    const text = (result.content as any[])
+      .filter((c) => c.type === "text")
+      .map((c) => c.text)
+      .join("\n");
+
+    expect(capturedCommand).toContain("echo hello-ops");
+    expect(text).toContain("from-custom-ops");
+
+    session.dispose();
+  });
+
+  test("SENSITIVE_WORKER_ENV_KEYS covers the worker gateway creds", () => {
+    expect(SENSITIVE_WORKER_ENV_KEYS).toContain("WORKER_TOKEN");
+    expect(SENSITIVE_WORKER_ENV_KEYS).toContain("DISPATCHER_URL");
+  });
+});

--- a/packages/agent-worker/src/__tests__/error-handler.test.ts
+++ b/packages/agent-worker/src/__tests__/error-handler.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Tests for handleExecutionError (Finding #9): SESSION_TIMEOUT must NOT surface
+ * a user-facing "💥 Worker crashed" delta — the run is retried automatically by
+ * the runs queue, so the timeout is only signalled (with an errorCode) for
+ * bookkeeping/cleanup.
+ */
+
+import { describe, expect, test } from "bun:test";
+import type { WorkerTransport } from "@lobu/core";
+import { handleExecutionError } from "../core/error-handler";
+
+type Recorder = {
+  transport: WorkerTransport;
+  deltas: Array<{
+    delta: string;
+    isFullReplacement?: boolean;
+    isFinal?: boolean;
+  }>;
+  errors: Array<{ message: string; code?: string }>;
+};
+
+function makeTransport(): Recorder {
+  const deltas: Recorder["deltas"] = [];
+  const errors: Recorder["errors"] = [];
+  const noop = () => undefined;
+  const asyncNoop = async () => undefined;
+  const transport: WorkerTransport = {
+    setJobId: noop,
+    async sendStreamDelta(delta, isFullReplacement, isFinal) {
+      deltas.push({ delta, isFullReplacement, isFinal });
+    },
+    signalDone: asyncNoop,
+    signalCompletion: asyncNoop,
+    async signalError(error, errorCode) {
+      errors.push({ message: error.message, code: errorCode });
+    },
+    sendStatusUpdate: asyncNoop,
+    sendCustomEvent: asyncNoop,
+  };
+  return { transport, deltas, errors };
+}
+
+describe("handleExecutionError", () => {
+  test("SESSION_TIMEOUT does not emit a user-facing crash delta", async () => {
+    const { transport, deltas, errors } = makeTransport();
+
+    await handleExecutionError(new Error("SESSION_TIMEOUT"), transport);
+
+    // No user-facing delta at all (especially no "💥 Worker crashed").
+    expect(deltas).toHaveLength(0);
+    // But the error is still signalled with a classification code so the
+    // gateway/cleanup path can act on it.
+    expect(errors).toHaveLength(1);
+    expect(errors[0].message).toBe("SESSION_TIMEOUT");
+    expect(errors[0].code).toBe("SESSION_TIMEOUT");
+  });
+
+  test("generic errors still emit a user-facing crash delta", async () => {
+    const { transport, deltas, errors } = makeTransport();
+
+    await handleExecutionError(new Error("kaboom"), transport);
+
+    expect(deltas).toHaveLength(1);
+    expect(deltas[0].delta).toContain("💥 Worker crashed: kaboom");
+    expect(deltas[0].isFullReplacement).toBe(true);
+    expect(deltas[0].isFinal).toBe(true);
+    expect(errors).toHaveLength(1);
+    expect(errors[0].code).toBeUndefined();
+  });
+
+  test("NO_MODEL_CONFIGURED signals code without a user-facing delta", async () => {
+    const { transport, deltas, errors } = makeTransport();
+
+    await handleExecutionError(new Error("No model configured"), transport);
+
+    expect(deltas).toHaveLength(0);
+    expect(errors).toHaveLength(1);
+    expect(errors[0].code).toBe("NO_MODEL_CONFIGURED");
+  });
+});

--- a/packages/agent-worker/src/__tests__/final-result-leak.test.ts
+++ b/packages/agent-worker/src/__tests__/final-result-leak.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Reproducer for Finding #18: the sandbox-leak redaction was dead on the
+ * production success path because getFinalResult() always returned null
+ * (setFinalResult() was only ever called in tests).
+ *
+ * runAISession() now sets the final result from the processor's output
+ * snapshot on the success path, and the finalization (deliverFinalResult)
+ * runs checkSandboxLeak against it. These tests drive that wiring:
+ *  - WITHOUT the final result set (the old, broken state) the redaction never
+ *    fires, even when the streamed output leaks.
+ *  - WITH the final result set the way runAISession() now does, the redaction
+ *    fires and a redacted full-replacement is sent.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import type { AgentSessionEvent } from "@mariozechner/pi-coding-agent";
+import type { OpenClawProgressProcessor } from "../openclaw/processor";
+import { OpenClawWorker } from "../openclaw/worker";
+import { mockWorkerConfig } from "./setup";
+
+let originalDispatcherUrl: string | undefined;
+let originalWorkerToken: string | undefined;
+
+beforeEach(() => {
+  originalDispatcherUrl = process.env.DISPATCHER_URL;
+  originalWorkerToken = process.env.WORKER_TOKEN;
+  process.env.DISPATCHER_URL = "https://test-dispatcher.example.com";
+  process.env.WORKER_TOKEN = "test-worker-token";
+});
+
+afterEach(() => {
+  if (originalDispatcherUrl === undefined) {
+    delete process.env.DISPATCHER_URL;
+  } else {
+    process.env.DISPATCHER_URL = originalDispatcherUrl;
+  }
+  if (originalWorkerToken === undefined) {
+    delete process.env.WORKER_TOKEN;
+  } else {
+    process.env.WORKER_TOKEN = originalWorkerToken;
+  }
+});
+
+type SentDelta = {
+  delta: string;
+  isFullReplacement?: boolean;
+  isFinal?: boolean;
+};
+
+function streamLeakyAssistantText(
+  processor: OpenClawProgressProcessor,
+  text: string
+) {
+  const event: AgentSessionEvent = {
+    type: "message_update",
+    message: { role: "assistant" },
+    assistantMessageEvent: { type: "text_delta", delta: text },
+  } as unknown as AgentSessionEvent;
+  processor.processEvent(event);
+}
+
+function buildWorkerWithRecorder() {
+  const worker = new OpenClawWorker(mockWorkerConfig);
+  const sent: SentDelta[] = [];
+  const noop = () => undefined;
+  const asyncNoop = async () => undefined;
+  worker.workerTransport = {
+    setJobId: noop,
+    async sendStreamDelta(delta, isFullReplacement, isFinal) {
+      sent.push({ delta, isFullReplacement, isFinal });
+    },
+    signalDone: asyncNoop,
+    signalCompletion: asyncNoop,
+    signalError: asyncNoop,
+    sendStatusUpdate: asyncNoop,
+    sendCustomEvent: asyncNoop,
+  };
+  const processor = (worker as any)
+    .progressProcessor as OpenClawProgressProcessor;
+  const deliverFinalResult = (worker as any).deliverFinalResult.bind(
+    worker
+  ) as (sawUploadedFileEvent: boolean) => Promise<void>;
+  return { worker, sent, processor, deliverFinalResult };
+}
+
+const LEAKY_OUTPUT =
+  "Here is your report: [report](/app/workspaces/abc/report.pdf)";
+
+describe("sandbox-leak redaction wiring (Finding #18)", () => {
+  test("redaction is dead when the final result is never set (old behavior)", async () => {
+    const { sent, processor, deliverFinalResult } = buildWorkerWithRecorder();
+    streamLeakyAssistantText(processor, LEAKY_OUTPUT);
+
+    // Old production state: nothing calls setFinalResult, so getFinalResult()
+    // is null and checkSandboxLeak never runs.
+    await deliverFinalResult(false);
+
+    // No redacted full-replacement was sent.
+    expect(sent.some((s) => s.isFullReplacement)).toBe(false);
+    expect(sent.some((s) => s.delta.includes("not actually upload"))).toBe(
+      false
+    );
+  });
+
+  test("redaction fires when the final result is set as runAISession now does", async () => {
+    const { sent, processor, deliverFinalResult } = buildWorkerWithRecorder();
+    streamLeakyAssistantText(processor, LEAKY_OUTPUT);
+
+    // Mirror the production success-path wiring.
+    processor.setFinalResult({
+      text: processor.getOutputSnapshot(),
+      isFinal: true,
+    });
+
+    await deliverFinalResult(false);
+
+    // A redacted full-replacement was sent.
+    const replacement = sent.find((s) => s.isFullReplacement);
+    expect(replacement).toBeDefined();
+    expect(replacement!.delta).not.toContain("/app/workspaces/abc/report.pdf");
+    expect(replacement!.delta).toContain("](about:blank)");
+    expect(replacement!.delta).toContain("did not actually upload");
+  });
+
+  test("clean output is not re-sent (no duplicate delivery)", async () => {
+    const { sent, processor, deliverFinalResult } = buildWorkerWithRecorder();
+    streamLeakyAssistantText(processor, "All done. Nothing leaked here.");
+
+    processor.setFinalResult({
+      text: processor.getOutputSnapshot(),
+      isFinal: true,
+    });
+
+    await deliverFinalResult(false);
+
+    // Already-streamed clean content must not be re-sent.
+    expect(sent).toHaveLength(0);
+  });
+});

--- a/packages/agent-worker/src/__tests__/worker-bash-secret-leak-e2e.test.ts
+++ b/packages/agent-worker/src/__tests__/worker-bash-secret-leak-e2e.test.ts
@@ -1,0 +1,146 @@
+/**
+ * End-to-end reproducer for Finding #1 (security): the agent's general bash
+ * must NOT inherit the worker's gateway credentials.
+ *
+ * This drives the SAME wiring production uses: the worker captures
+ * WORKER_TOKEN / DISPATCHER_URL from process.env for its OWN gateway calls,
+ * builds the agent's built-in tools via createOpenClawTools (carrying the
+ * env-strip spawnHook), and hands them to buildAgentSession. We then invoke
+ * the resulting agent bash tool DIRECTLY with `printenv WORKER_TOKEN` /
+ * `printenv DISPATCHER_URL` and assert both come back EMPTY — using a real
+ * subprocess (no mocked BashOperations) so the assertion is about the actual
+ * spawned environment.
+ *
+ * It also confirms the worker's own gateway call still authenticates with the
+ * real token (read from its in-memory captured value, not the bash env).
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { OpenClawWorker } from "../openclaw/worker";
+import { buildAgentSession } from "../openclaw/session-builder";
+import { createOpenClawTools } from "../openclaw/tools";
+import {
+  callMcpTool,
+  type GatewayParams,
+} from "../shared/tool-implementations";
+import { mockWorkerConfig } from "./setup";
+
+const SECRET_TOKEN = "e2e-super-secret-worker-token";
+const GATEWAY_URL = "http://gateway.internal:8080";
+
+let tempDir: string;
+let originalDispatcherUrl: string | undefined;
+let originalWorkerToken: string | undefined;
+let originalFetch: typeof globalThis.fetch;
+
+beforeEach(() => {
+  tempDir = mkdtempSync(join(tmpdir(), "worker-bash-e2e-"));
+  originalDispatcherUrl = process.env.DISPATCHER_URL;
+  originalWorkerToken = process.env.WORKER_TOKEN;
+  originalFetch = globalThis.fetch;
+  process.env.DISPATCHER_URL = GATEWAY_URL;
+  process.env.WORKER_TOKEN = SECRET_TOKEN;
+});
+
+afterEach(() => {
+  rmSync(tempDir, { recursive: true, force: true });
+  globalThis.fetch = originalFetch;
+  if (originalDispatcherUrl === undefined) {
+    delete process.env.DISPATCHER_URL;
+  } else {
+    process.env.DISPATCHER_URL = originalDispatcherUrl;
+  }
+  if (originalWorkerToken === undefined) {
+    delete process.env.WORKER_TOKEN;
+  } else {
+    process.env.WORKER_TOKEN = originalWorkerToken;
+  }
+});
+
+function bashText(result: { content: unknown }): string {
+  return (result.content as { type: string; text?: string }[])
+    .filter((c) => c.type === "text")
+    .map((c) => c.text ?? "")
+    .join("\n");
+}
+
+describe("worker agent bash secret leak (E2E, Finding #1)", () => {
+  test("agent bash sees NEITHER WORKER_TOKEN NOR DISPATCHER_URL", async () => {
+    // Constructing the worker mirrors production startup: the constructor reads
+    // the gateway credentials from process.env (and throws if absent).
+    const worker = new OpenClawWorker(mockWorkerConfig);
+    expect(worker).toBeDefined();
+
+    // The agent's built-in tools the worker hands to the session.
+    const tools = createOpenClawTools(tempDir);
+    const { session } = await buildAgentSession({
+      cwd: tempDir,
+      tools,
+      customTools: [],
+    });
+
+    const bash = session.agent.state.tools.find((t) => t.name === "bash");
+    expect(bash).toBeDefined();
+
+    // Use printenv (no `$VAR` literals) so the command isn't blocked by the
+    // direct-gateway-access guard, which trips on literal $WORKER_TOKEN refs.
+    // `printenv NAME` exits non-zero and prints nothing when NAME is unset.
+    const result = await bash!.execute(
+      "e2e-printenv",
+      {
+        command:
+          "printenv WORKER_TOKEN || true; printenv DISPATCHER_URL || true; echo ---END---",
+      },
+      undefined,
+      undefined
+    );
+    const text = bashText(result);
+
+    // The secrets must be entirely absent from the spawned subprocess env.
+    expect(text).not.toContain(SECRET_TOKEN);
+    expect(text).not.toContain(GATEWAY_URL);
+    expect(text).toContain("---END---");
+    // Everything before the END marker (the printenv output) must be blank.
+    const beforeMarker = text.slice(0, text.indexOf("---END---")).trim();
+    expect(beforeMarker).toBe("");
+
+    session.dispose();
+  });
+
+  test("worker's OWN gateway call still authenticates with the real token", async () => {
+    // Build gwParams exactly as worker.runAISession does — from env. This is
+    // the in-process captured value the worker uses; the bash env strip does
+    // not touch it.
+    const gwParams: GatewayParams = {
+      gatewayUrl: process.env.DISPATCHER_URL ?? "",
+      workerToken: process.env.WORKER_TOKEN ?? "",
+      channelId: "ch",
+      conversationId: "conv",
+      platform: "telegram",
+      workspaceDir: tempDir,
+    };
+
+    let capturedAuth = "";
+    let capturedUrl = "";
+    globalThis.fetch = (async (url: unknown, opts: any) => {
+      capturedUrl = typeof url === "string" ? url : String(url);
+      capturedAuth = opts?.headers?.Authorization ?? "";
+      return new Response(
+        JSON.stringify({ content: [{ type: "text", text: "ok" }] }),
+        {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }
+      );
+    }) as typeof globalThis.fetch;
+
+    const result = await callMcpTool(gwParams, "lobu", "list_connections", {});
+
+    expect(capturedAuth).toBe(`Bearer ${SECRET_TOKEN}`);
+    expect(capturedUrl).toBe(`${GATEWAY_URL}/mcp/lobu/tools/list_connections`);
+    expect(bashText(result)).toContain("ok");
+  });
+});

--- a/packages/agent-worker/src/core/error-handler.ts
+++ b/packages/agent-worker/src/core/error-handler.ts
@@ -13,8 +13,17 @@ function formatErrorMessage(error: unknown): string {
     : `💥 Worker crashed (${name}): ${error.message}`;
 }
 
+/**
+ * Sentinel thrown by the worker when a session exceeds its time budget
+ * (exit code 124). The run is retried automatically by the gateway, so the
+ * timeout must NOT surface to the user as a crash — we only signal the error
+ * for bookkeeping/cleanup.
+ */
+const SESSION_TIMEOUT_MESSAGE = "SESSION_TIMEOUT";
+
 function classifyError(error: unknown): string | undefined {
   if (!(error instanceof Error)) return undefined;
+  if (error.message === SESSION_TIMEOUT_MESSAGE) return "SESSION_TIMEOUT";
   if (
     error.message.includes("No model configured") ||
     error.message.includes("No provider specified")
@@ -35,6 +44,9 @@ export async function handleExecutionError(
 
   try {
     if (code) {
+      // Classified errors (incl. SESSION_TIMEOUT, which is retried silently)
+      // signal the error for bookkeeping but never emit a user-facing crash
+      // delta.
       await transport.signalError(errorInstance, code);
     } else {
       await transport.sendStreamDelta(formatErrorMessage(error), true, true);

--- a/packages/agent-worker/src/openclaw/session-builder.ts
+++ b/packages/agent-worker/src/openclaw/session-builder.ts
@@ -1,0 +1,67 @@
+import type { AgentTool } from "@mariozechner/pi-agent-core";
+import {
+  type CreateAgentSessionOptions,
+  type CreateAgentSessionResult,
+  createAgentSession,
+} from "@mariozechner/pi-coding-agent";
+
+/**
+ * Built-in tool names that Lobu rebuilds itself (via createOpenClawTools).
+ * These carry the security-sensitive behavior — most importantly the bash
+ * spawnHook that strips SENSITIVE_WORKER_ENV_KEYS and the embedded
+ * BashOperations that route MCP/just-bash through the gateway. They must be
+ * the instances the agent actually runs.
+ */
+const OVERRIDABLE_BUILTIN_NAMES = new Set([
+  "read",
+  "write",
+  "edit",
+  "bash",
+  "grep",
+  "find",
+  "ls",
+]);
+
+/**
+ * Build an agent session and ensure the Lobu-built built-in tools are the ones
+ * the agent actually executes.
+ *
+ * Background: pi's `createAgentSession({ tools })` uses the `tools` option only
+ * to derive the active tool NAMES — it rebuilds the underlying built-in tools
+ * internally via `createAllTools(cwd, { bash: { commandPrefix } })`, whose bash
+ * uses `getShellEnv()` = `{ ...process.env }` with no env strip and no custom
+ * BashOperations. That silently discards the worker's hardened bash (the
+ * spawnHook that strips WORKER_TOKEN/DISPATCHER_URL and the embedded
+ * BashOperations), so the agent's general bash would inherit the worker's real
+ * gateway credentials.
+ *
+ * The session keeps the active tool array on `agent.state.tools`, and tool
+ * calls are resolved from that array by name at execution time. We swap the
+ * rebuilt built-ins for the caller-provided Lobu instances after construction,
+ * preserving every other aspect of `createAgentSession` (model resolution,
+ * session restore, image blocking, extension/custom-tool wiring).
+ */
+export async function buildAgentSession(
+  options: CreateAgentSessionOptions
+): Promise<CreateAgentSessionResult> {
+  const result = await createAgentSession(options);
+  const { session } = result;
+
+  const lobuBuiltins = new Map<string, AgentTool<any>>();
+  for (const tool of options.tools ?? []) {
+    if (OVERRIDABLE_BUILTIN_NAMES.has(tool.name)) {
+      lobuBuiltins.set(tool.name, tool as AgentTool<any>);
+    }
+  }
+  if (lobuBuiltins.size === 0) {
+    return result;
+  }
+
+  const activeTools = session.agent.state.tools;
+  const patched = activeTools.map(
+    (tool) => lobuBuiltins.get(tool.name) ?? tool
+  );
+  session.agent.setTools(patched);
+
+  return result;
+}

--- a/packages/agent-worker/src/openclaw/worker.ts
+++ b/packages/agent-worker/src/openclaw/worker.ts
@@ -1989,8 +1989,9 @@ ${fileListing}
    *
    * The content has normally already been streamed delta-by-delta, so the
    * no-leak path does NOT re-send (that would duplicate the message). The final
-   * result is set by runAISession() on the success path — see Finding #18; it
-   * used to be null in production, leaving checkSandboxLeak() dead.
+   * result must be populated by runAISession() on the success path (via
+   * progressProcessor.setFinalResult) — when it is left null, getFinalResult()
+   * returns null here and the leak check never runs.
    */
   private async deliverFinalResult(
     sawUploadedFileEvent: boolean

--- a/packages/agent-worker/src/openclaw/worker.ts
+++ b/packages/agent-worker/src/openclaw/worker.ts
@@ -14,7 +14,6 @@ import {
 import { getModel, type ImageContent } from "@mariozechner/pi-ai";
 import {
   AuthStorage,
-  createAgentSession,
   ModelRegistry,
   SettingsManager,
 } from "@mariozechner/pi-coding-agent";
@@ -63,6 +62,7 @@ import {
 } from "./plugin-loader";
 import { OpenClawProgressProcessor } from "./processor";
 import { checkSandboxLeak } from "./sandbox-leak";
+import { buildAgentSession } from "./session-builder";
 import { getOpenClawSessionContext } from "./session-context";
 import {
   buildToolPolicy,
@@ -513,53 +513,7 @@ export class OpenClawWorker implements WorkerExecutor {
         // Hydrate skips non-completed snapshots, so getting this right is
         // what stops a failed turn from poisoning the next attempt.
         this.terminalStatus = "completed";
-        const outputSnapshot = this.progressProcessor.getOutputSnapshot();
-        const hintGatewayUrl = process.env.DISPATCHER_URL;
-        const hintWorkerToken = process.env.WORKER_TOKEN;
-        const audioPermissionHint =
-          hintGatewayUrl && hintWorkerToken
-            ? await this.maybeBuildAudioPermissionHintMessage(
-                outputSnapshot,
-                hintGatewayUrl,
-                hintWorkerToken
-              )
-            : null;
-        const finalResult = this.progressProcessor.getFinalResult();
-        if (finalResult) {
-          const leakCheck = checkSandboxLeak(
-            finalResult.text,
-            sawUploadedFileEvent
-          );
-          if (leakCheck.leaked) {
-            logger.warn(
-              "Detected unfulfilled file-delivery claim in final message; redacting link targets"
-            );
-          }
-          const finalText = audioPermissionHint
-            ? `${leakCheck.redactedText}\n\n${audioPermissionHint}`
-            : leakCheck.redactedText;
-          logger.info(
-            `📤 Sending final result (${finalText.length} chars) with deduplication flag`
-          );
-          // When a leak was redacted, the already-streamed content contains the
-          // pre-redaction URLs — a delta-append would leave them on the client.
-          // Force a full replacement so the client discards the leaky prefix.
-          await this.workerTransport.sendStreamDelta(
-            finalText,
-            leakCheck.leaked,
-            finalResult.isFinal
-          );
-        } else if (audioPermissionHint) {
-          logger.info("📤 Sending audio permission settings hint to user");
-          await this.workerTransport.sendStreamDelta(
-            `\n\n${audioPermissionHint}`,
-            false
-          );
-        } else {
-          logger.info(
-            "Session completed successfully - all content already streamed"
-          );
-        }
+        await this.deliverFinalResult(sawUploadedFileEvent);
         await this.workerTransport.signalDone();
       } else {
         const errorMsg = result.error || "Unknown error";
@@ -659,7 +613,7 @@ export class OpenClawWorker implements WorkerExecutor {
   }
 
   private async maybeRunPreCompactionMemoryFlush(params: {
-    session: Awaited<ReturnType<typeof createAgentSession>>["session"];
+    session: Awaited<ReturnType<typeof buildAgentSession>>["session"];
     sessionManager: Awaited<ReturnType<typeof openOrCreateSessionManager>>;
     settingsManager: SettingsManager;
     memoryFlushConfig: ResolvedMemoryFlushConfig;
@@ -1324,7 +1278,7 @@ Use it when the user references past discussions or you need context.`);
     let heartbeatTimer: Timer | null = null;
     let deltaTimer: Timer | null = null;
     let session:
-      | Awaited<ReturnType<typeof createAgentSession>>["session"]
+      | Awaited<ReturnType<typeof buildAgentSession>>["session"]
       | null = null;
     const pluginHookContext: Record<string, unknown> = {
       cwd: workspaceDir,
@@ -1333,19 +1287,23 @@ Use it when the user references past discussions or you need context.`);
     };
 
     try {
-      const createdSession = await createAgentSession({
+      const createdSession = await buildAgentSession({
         cwd: workspaceDir,
         model,
+        // pi's createAgentSession() uses `tools` only to derive active tool
+        // names and rebuilds the base tools internally (bash via getShellEnv()
+        // = {...process.env}, no env strip, no embedded BashOperations).
+        // buildAgentSession() swaps those rebuilt built-ins back to these
+        // Lobu instances after construction so the agent's bash actually runs
+        // with the spawnHook that strips WORKER_TOKEN/DISPATCHER_URL and with
+        // the embedded BashOperations + tool policy wired in above.
         tools,
         // Wrap custom tools (plugin + MCP) so plugin before_tool_call/
         // after_tool_call hooks fire around in-process execution — these never
         // hit the gateway proxy, so this is the only place the hooks can run.
-        // Built-in tools (bash/read/edit/write) are intentionally NOT gated
-        // here: createAgentSession() uses the `tools` option only to derive
-        // active tool names and rebuilds the base tools internally, so wrapped
-        // built-ins would be ignored. Gating them would require constructing
-        // AgentSession with baseToolsOverride directly. Built-ins remain
-        // governed by Lobu's own tool policy.
+        // Built-in tools (bash/read/edit/write) remain governed by Lobu's own
+        // tool policy (applied to the instances passed via `tools` above), not
+        // the plugin hooks.
         customTools: wrapToolsWithPluginToolHooks(
           customTools,
           loadedPlugins,
@@ -1742,6 +1700,15 @@ Use it when the user references past discussions or you need context.`);
         ctx: pluginHookContext,
       });
 
+      // Hand the fully-streamed assistant output to the progress processor so
+      // the success path's checkSandboxLeak() (worker.execute) actually runs
+      // against user-facing text. Without this, getFinalResult() is always
+      // null in production and the sandbox-leak redaction never fires.
+      this.progressProcessor.setFinalResult({
+        text: this.progressProcessor.getOutputSnapshot(),
+        isFinal: true,
+      });
+
       return {
         success: true,
         exitCode: 0,
@@ -2013,6 +1980,65 @@ ${fileListing}
     }
 
     return results;
+  }
+
+  /**
+   * Finalize a successful turn: run the sandbox-leak safety net against the
+   * agent's user-facing output and, when a leak is detected, re-send a redacted
+   * full-replacement so the client discards the already-streamed leaky prefix.
+   *
+   * The content has normally already been streamed delta-by-delta, so the
+   * no-leak path does NOT re-send (that would duplicate the message). The final
+   * result is set by runAISession() on the success path — see Finding #18; it
+   * used to be null in production, leaving checkSandboxLeak() dead.
+   */
+  private async deliverFinalResult(
+    sawUploadedFileEvent: boolean
+  ): Promise<void> {
+    const outputSnapshot = this.progressProcessor.getOutputSnapshot();
+    const hintGatewayUrl = process.env.DISPATCHER_URL;
+    const hintWorkerToken = process.env.WORKER_TOKEN;
+    const audioPermissionHint =
+      hintGatewayUrl && hintWorkerToken
+        ? await this.maybeBuildAudioPermissionHintMessage(
+            outputSnapshot,
+            hintGatewayUrl,
+            hintWorkerToken
+          )
+        : null;
+    const finalResult = this.progressProcessor.getFinalResult();
+    const leakCheck = finalResult
+      ? checkSandboxLeak(finalResult.text, sawUploadedFileEvent)
+      : null;
+    if (leakCheck?.leaked && finalResult) {
+      logger.warn(
+        "Detected unfulfilled file-delivery claim in final message; redacting link targets"
+      );
+      // The already-streamed content still contains the pre-redaction URLs —
+      // a delta-append would leave them on the client. Force a full
+      // replacement so the client discards the leaky prefix.
+      const finalText = audioPermissionHint
+        ? `${leakCheck.redactedText}\n\n${audioPermissionHint}`
+        : leakCheck.redactedText;
+      logger.info(
+        `📤 Re-sending redacted final result (${finalText.length} chars) as full replacement`
+      );
+      await this.workerTransport.sendStreamDelta(
+        finalText,
+        true,
+        finalResult.isFinal
+      );
+    } else if (audioPermissionHint) {
+      logger.info("📤 Sending audio permission settings hint to user");
+      await this.workerTransport.sendStreamDelta(
+        `\n\n${audioPermissionHint}`,
+        false
+      );
+    } else {
+      logger.info(
+        "Session completed successfully - all content already streamed"
+      );
+    }
   }
 
   private maybeBuildAuthHintMessage(

--- a/packages/server/src/gateway/__tests__/chat-response-bridge.test.ts
+++ b/packages/server/src/gateway/__tests__/chat-response-bridge.test.ts
@@ -189,6 +189,27 @@ describe("ChatResponseBridge.handleDelta — AsyncIterable streaming", () => {
     expect(plainPosts).toContain("Error: boom");
   });
 
+  test("handleError suppresses the fallback for SESSION_TIMEOUT (silent retry)", async () => {
+    // A timed-out turn is retried automatically by the runs queue and the
+    // worker deliberately emits no user-facing crash delta, so the platform
+    // fallback must also stay silent — otherwise the user sees a raw
+    // "Error: SESSION_TIMEOUT" for a turn that is about to be retried.
+    const { target, plainPosts } = createStreamingTarget();
+    const { manager } = createHarness(target);
+    const bridge = new ChatResponseBridge(manager as any);
+
+    await bridge.handleError(
+      {
+        ...basePayload,
+        error: "SESSION_TIMEOUT",
+        errorCode: "SESSION_TIMEOUT",
+      },
+      "s"
+    );
+
+    expect(plainPosts).toEqual([]);
+  });
+
   test("isFullReplacement closes prior stream and opens a new one", async () => {
     const { target } = createStreamingTarget();
     const { manager } = createHarness(target);

--- a/packages/server/src/gateway/connections/chat-response-bridge.ts
+++ b/packages/server/src/gateway/connections/chat-response-bridge.ts
@@ -547,6 +547,18 @@ export class ChatResponseBridge implements ResponseRenderer {
       return;
     }
 
+    // Session timeouts are retried automatically by the runs queue. The worker
+    // deliberately suppresses its own user-facing crash delta for them, so the
+    // platform fallback must stay silent too — otherwise the user sees a raw
+    // "Error: SESSION_TIMEOUT" for a turn that is about to be retried.
+    if (payload.errorCode === "SESSION_TIMEOUT") {
+      logger.debug(
+        { connectionId, channelId },
+        "Skipping fallback error text — session timed out and will be retried"
+      );
+      return;
+    }
+
     // For known error codes, render user-facing guidance without sending users
     // to the retired end-user settings UI.
     if (payload.errorCode === "NO_MODEL_CONFIGURED") {


### PR DESCRIPTION
Bundle of confirmed agent-worker bug fixes. Each behavioral fix ships with a red→green reproducer.

## Finding #1 (HIGH, security) — agent bash leaked WORKER_TOKEN/DISPATCHER_URL
`worker.ts` passed the Lobu-built bash tool (with a `spawnHook` that strips `SENSITIVE_WORKER_ENV_KEYS`) into `createAgentSession({ tools })`. But pi uses `tools` only to derive active tool **names** and rebuilds the base tools internally via `createAllTools(cwd, { bash: { commandPrefix } })`, whose bash uses `getShellEnv()` = `{...process.env}` with no env strip. The hardened bash was discarded, so the agent's general bash inherited the worker's real gateway credentials.

**Fix:** new `buildAgentSession()` (`packages/agent-worker/src/openclaw/session-builder.ts`) runs `createAgentSession()` unchanged (preserving model resolution, session restore, image blocking, extension/custom-tool wiring) then swaps the rebuilt built-ins back to the Lobu instances on `agent.state.tools` — the array tool calls are resolved from at execution time. The worker's own gateway calls still read the creds from `process.env` (untouched).

I evaluated option (a) constructing `AgentSession` with `baseToolsOverride` directly: rejected because the helpers `createAgentSession` needs (`findInitialModel`, `convertToLlm`, `getAgentDir`, `Agent` blockImages/transformContext wiring) are not on pi's public export surface (only `.` and `./hooks`), so replicating it would be fragile and drop the image-blocking + extension-context behavior. The post-construction swap preserves 100% of `createAgentSession` behavior and is minimal.

**Red→green:** `agent-session-bash-env.test.ts`. Before: a session built the current way printed `super-secret-worker-token` from `printenv WORKER_TOKEN` (verified failing). After: the agent bash output contains neither the token nor the dispatcher URL, and the command still runs.

## Finding #10 (MED) — embeddedBashOps discarded (same root cause)
Same discard path dropped `bashOperations: embeddedBashOps`. Fixed by the same `buildAgentSession` swap. **Red→green:** the second case in `agent-session-bash-env.test.ts` asserts the session's bash routes through the provided `BashOperations`.

## Finding #9 (MED, UX) — SESSION_TIMEOUT shown to user
`classifyError()` didn't match `SESSION_TIMEOUT`, so `handleExecutionError()` fell to the else branch and sent `💥 Worker crashed: SESSION_TIMEOUT` — contradicting the hide-it intent (the turn is retried by the runs queue).

**Fix:** `classifyError()` returns the `SESSION_TIMEOUT` code → routes through the signal-only branch (no user-facing delta). Because the worker no longer emits a full-replacement delta, the platform error bridge (`chat-response-bridge.ts handleError`) would otherwise post a raw `Error: SESSION_TIMEOUT`; it now short-circuits the `SESSION_TIMEOUT` errorCode the same way it does `NO_MODEL_CONFIGURED`.

**Red→green:** `error-handler.test.ts`. Verified the SESSION_TIMEOUT case fails before the `classifyError` change (1 delta emitted) and passes after (0 deltas, error signalled with code). Generic errors still emit the crash delta.

## Finding #18 (LOW) — sandbox-leak redaction was dead
`getFinalResult()` was always null in production because `setFinalResult()` was only ever called in tests, so `checkSandboxLeak()` never ran against user-facing output.

**Fix (wire it, not delete):** `runAISession()` now sets the final result from the streamed output snapshot on the success path. The finalization is extracted into `deliverFinalResult()`, which runs the leak check and re-sends a redacted full-replacement **only when a leak is detected** (clean output is not re-sent, avoiding duplicate delivery).

**Red→green:** `final-result-leak.test.ts`. One test reproduces the old dead-wire state (no `setFinalResult` → no redaction even on a leaky output); one proves the production wiring now redacts a leaky link into `](about:blank)` + the "did not actually upload" note; one proves clean output is not re-sent.

## Validation
- `bun test packages/agent-worker/src` → 533 pass, 12 skip, 0 fail (545 tests).
- Per-package `tsc --noEmit` clean for `packages/agent-worker` and `packages/server`.
- `make clean-workers` run after agent-worker edits.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Session timeout errors are now handled silently without displaying error messages to users.
  * Enhanced security: worker credentials are no longer accessible to bash tool operations.
  * Improved sandbox leak redaction: file paths are now properly redacted from agent output.

* **Tests**
  * Added comprehensive test coverage for session timeout handling, bash environment isolation, error classification, and sandbox leak redaction.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lobu-ai/lobu/pull/1070?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->