### PR TITLE
feat(server): agent account-claim via emailed device authorization

### DIFF
--- a/packages/server/src/__tests__/integration/oauth/device-email-claim.test.ts
+++ b/packages/server/src/__tests__/integration/oauth/device-email-claim.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Agent device-claim email tests (POST /oauth/device/email)
+ *
+ * The agent starts a standard device_authorization, then delivers it to a user
+ * by email instead of having them type a user_code. We assert the endpoint
+ * triggers a Better Auth magic link (a `verification` row is created before
+ * delivery), stays opaque about whether the email has an account, and rejects
+ * the agent's own bad input.
+ *
+ * Email delivery is best-effort and offline here: testEnv sets no
+ * RESEND_API_KEY, so the magic-link send callback throws *after* the
+ * verification value is persisted — the handler swallows that and still
+ * returns the opaque 202.
+ */
+
+import { beforeAll, describe, expect, it } from 'vitest';
+import { cleanupTestDatabase, getTestDb } from '../../setup/test-db';
+import { createTestDeviceCode, createTestOAuthClient, createTestUser } from '../../setup/test-fixtures';
+import { post } from '../../setup/test-helpers';
+
+const DEVICE_GRANT = 'urn:ietf:params:oauth:grant-type:device_code';
+
+async function pendingUserCode(): Promise<string> {
+  const client = await createTestOAuthClient({
+    grant_types: [DEVICE_GRANT, 'refresh_token'],
+  });
+  const device = await createTestDeviceCode(client.client_id, {
+    scope: 'mcp:read mcp:write',
+  });
+  return device.userCode;
+}
+
+async function verificationExistsFor(email: string): Promise<boolean> {
+  const sql = getTestDb();
+  const rows = (await sql`
+    SELECT 1 FROM verification WHERE value LIKE ${`%${email}%`} LIMIT 1
+  `) as unknown as Array<unknown>;
+  return rows.length === 1;
+}
+
+describe('POST /oauth/device/email — agent account claim', () => {
+  beforeAll(async () => {
+    await cleanupTestDatabase();
+  });
+
+  it('triggers a magic link for a pending user_code and returns an opaque 202', async () => {
+    const userCode = await pendingUserCode();
+    const email = `claim-${Date.now()}@example.com`;
+
+    const res = await post('/oauth/device/email', {
+      body: { user_code: userCode, email },
+    });
+
+    expect(res.status).toBe(202);
+    expect((await res.json()).status).toBe('pending');
+
+    // signInMagicLink persists the verification value before invoking the send
+    // callback, so a row proves the magic link was triggered for this address.
+    expect(await verificationExistsFor(email)).toBe(true);
+  });
+
+  it('returns the same opaque 202 whether or not the email already has an account', async () => {
+    const existing = await createTestUser({ email: `existing-${Date.now()}@example.com` });
+    const fresh = `new-${Date.now()}@example.com`;
+
+    const resExisting = await post('/oauth/device/email', {
+      body: { user_code: await pendingUserCode(), email: existing.email },
+    });
+    const resNew = await post('/oauth/device/email', {
+      body: { user_code: await pendingUserCode(), email: fresh },
+    });
+
+    expect(resExisting.status).toBe(202);
+    expect(resNew.status).toBe(202);
+    expect((await resExisting.json()).status).toBe('pending');
+    expect((await resNew.json()).status).toBe('pending');
+  });
+
+  it('rejects an unknown or expired user_code with 400 (the agent\'s own error)', async () => {
+    const res = await post('/oauth/device/email', {
+      body: { user_code: 'NOPE-NOPE', email: 'x@example.com' },
+    });
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toBe('invalid_grant');
+  });
+
+  it('requires user_code, email, and a plausible address', async () => {
+    const userCode = await pendingUserCode();
+
+    const noEmail = await post('/oauth/device/email', { body: { user_code: userCode } });
+    expect(noEmail.status).toBe(400);
+
+    const noCode = await post('/oauth/device/email', { body: { email: 'x@example.com' } });
+    expect(noCode.status).toBe(400);
+
+    const badEmail = await post('/oauth/device/email', {
+      body: { user_code: userCode, email: 'not-an-email' },
+    });
+    expect(badEmail.status).toBe(400);
+  });
+
+  it('rejects malformed non-string inputs with 400 (not an uncaught 500)', async () => {
+    const res = await post('/oauth/device/email', {
+      body: { user_code: 123, email: { nested: true } },
+    });
+    expect(res.status).toBe(400);
+  });
+});

--- a/packages/server/src/auth/oauth/routes.ts
+++ b/packages/server/src/auth/oauth/routes.ts
@@ -685,6 +685,118 @@ oauthRoutes.post('/oauth/device_authorization', async (c) => {
   return c.json(result);
 });
 
+/**
+ * POST /oauth/device/email
+ * Agent-initiated account claim (delivers a device authorization by email).
+ *
+ * The agent starts a normal device_authorization (RFC 8628), then calls this
+ * with the resulting `user_code` and the `email` it wants to act on behalf of.
+ * We trigger a Better Auth magic link whose callbackURL is the device consent
+ * page for that user_code — one click both authenticates the user (creating
+ * the account + personal org on first sign-in, via databaseHooks.user.create)
+ * and lands them on the existing consent screen, where Approve runs the
+ * standard POST /oauth/device/approve path. The agent meanwhile polls
+ * /oauth/token and collects the credential once approved.
+ *
+ * This is intentionally a thin delivery shim over the existing device-code
+ * engine — no new credential type, no new pending-state table.
+ *
+ * Security:
+ *   - The magic link signs the recipient in AS the claimed email, so only the
+ *     inbox owner can land on the consent page — no separate identity check.
+ *   - Approval still requires an explicit authenticated POST, so a prefetched
+ *     link cannot silently approve.
+ *   - The response is opaque: it never reveals whether the email has an
+ *     account (no enumeration). A bad/expired user_code is the agent's own
+ *     error, so 400 there leaks nothing about any user.
+ *   - Rate limited per IP because it sends mail to a caller-supplied address.
+ */
+oauthRoutes.post('/oauth/device/email', async (c) => {
+  // Same abuse posture as /oauth/register: an unauthenticated endpoint that
+  // sends email to an arbitrary address. ON by default; fail CLOSED.
+  if (c.env.RATE_LIMIT_ENABLED !== 'false') {
+    try {
+      const rateLimiter = getRateLimiter();
+      const clientIP = getClientIP(c.req.raw);
+      const rateLimit = await rateLimiter.checkLimit(
+        `rate:oauth:device-email:${clientIP}`,
+        RateLimitPresets.DEVICE_EMAIL_PER_IP_HOUR
+      );
+      if (!rateLimit.allowed) {
+        return c.json(createOAuthError('invalid_request', rateLimit.errorMessage), 429);
+      }
+    } catch (err) {
+      console.warn('[OAuth] Device-email rate limit check failed:', err);
+      return c.json(createOAuthError('server_error', 'Temporarily unavailable'), 503);
+    }
+  }
+
+  const parsed = await parseRequestBody(c);
+  if (parsed instanceof Response) return parsed;
+  const body = parsed as { user_code?: unknown; email?: unknown };
+
+  // Guard on `typeof string` rather than `?.trim()`: a malformed non-string
+  // value (e.g. `{"user_code": 123}`) would otherwise throw an uncaught 500.
+  const userCode = typeof body.user_code === 'string' ? body.user_code.trim() : undefined;
+  const email = typeof body.email === 'string' ? body.email.trim() : undefined;
+  if (!userCode || !email) {
+    return c.json(
+      createOAuthError('invalid_request', 'user_code and email are required'),
+      400
+    );
+  }
+  // Minimal shape check; Better Auth validates the address downstream.
+  if (!email.includes('@')) {
+    return c.json(createOAuthError('invalid_request', 'email is invalid'), 400);
+  }
+
+  // The user_code is the agent's own pending authorization — a bad one is the
+  // agent's error, not account-existence info, so it is safe to 400 here.
+  const provider = getProvider(c);
+  const deviceCode = await provider.getDeviceCodeByUserCode(userCode);
+  if (!deviceCode) {
+    return c.json(createOAuthError('invalid_grant', 'Invalid or expired user code'), 400);
+  }
+
+  // Land the magic link on the existing device consent page for this code.
+  // Relative + same-origin, so Better Auth resolves it against our base URL.
+  const consentPath = `/oauth/device?user_code=${encodeURIComponent(userCode)}`;
+  try {
+    const auth = await createAuth(c.env, c.req.raw);
+    // createAuth() returns a cache-widened betterAuth type (see authCache:
+    // TtlCache<ReturnType<typeof betterAuth>>) that erases plugin endpoint
+    // signatures, so the magic-link endpoint is present at runtime but not in
+    // the static type. Narrowly type just the call we make.
+    const magicLinkApi = auth.api as unknown as {
+      signInMagicLink: (args: {
+        body: { email: string; callbackURL?: string; newUserCallbackURL?: string };
+        headers: Headers;
+      }) => Promise<unknown>;
+    };
+    await magicLinkApi.signInMagicLink({
+      body: {
+        email,
+        callbackURL: consentPath,
+        newUserCallbackURL: consentPath,
+      },
+      headers: c.req.raw.headers,
+    });
+  } catch (err) {
+    // Swallow: delivery failures and the install-operator carve-out must not
+    // reveal whether the address is deliverable/registered. Logged, opaque 202.
+    console.warn('[OAuth] Device-email magic link send failed (opaque):', err);
+  }
+
+  return c.json(
+    {
+      status: 'pending',
+      message:
+        'If the address is valid, a confirmation email has been sent. Poll the token endpoint to collect the credential once approved.',
+    },
+    202
+  );
+});
+
 // GET /oauth/device is served by the SPA fallback (packages/owletto/src/app/oauth/device.tsx).
 // No API route needed — the web app and API share the same origin.
 

--- a/packages/server/src/utils/rate-limiter.ts
+++ b/packages/server/src/utils/rate-limiter.ts
@@ -166,6 +166,14 @@ export const RateLimitPresets = {
       'OAuth client registration rate limit exceeded. Maximum 10 registrations per hour.',
   } as RateLimitConfig,
 
+  /** Agent device-claim email: 10/hour per IP (sends a login email to a caller-supplied address) */
+  DEVICE_EMAIL_PER_IP_HOUR: {
+    limit: 10,
+    windowSeconds: 3600,
+    errorMessage:
+      'Device email rate limit exceeded. Maximum 10 confirmation emails per hour.',
+  } as RateLimitConfig,
+
   /** Invitation preview lookup: 5/minute per IP (unauthenticated) */
   INVITATION_PREVIEW_PER_IP_MINUTE: {
     limit: 5,


### PR DESCRIPTION
## What

Adds `POST /oauth/device/email` so an agent can register a user on hosted lobu.ai by email, with no pre-existing human login. This is the "User Claimed" flow from WorkOS's auth.md, built as a thin shim over our existing device-code engine.

The agent runs a standard RFC 8628 `device_authorization`, then POSTs `{ user_code, email }`. We trigger a Better Auth magic link whose `callbackURL` is the existing device consent page for that `user_code`. One click both authenticates the user (creating the account + personal org on first sign-in via `databaseHooks.user.create.after`) and lands them on the existing Approve flow. The agent polls `/oauth/token` and collects the scoped, role-narrowed credential once approved.

## Why this shape

No new credential type, no new pending-state table, no schema change. Everything load-bearing already exists: `oauth_device_codes` (pending state), `/oauth/device/approve` + `resolveOrganizationForGrant` + `filterScopeByRole` (consent, org mapping, scope narrowing), the magic-link plugin (email verification + user/org creation), and the token mint. The magic link does double duty — it's both the auth and the delivery of the consent URL.

Security:
- The magic link signs the recipient in as the claimed email, so only the inbox owner can reach the consent page. No separate identity check needed.
- Approval still requires an explicit authenticated POST, so a prefetched link can't silently approve.
- Response is opaque (always 202 once the user_code is valid) and never reveals whether the email has an account — no enumeration.
- Per-IP rate limit (`DEVICE_EMAIL_PER_IP_HOUR`), mirroring `/oauth/register`, because it sends mail to a caller-supplied address.

## Test evidence

New integration test `device-email-claim.test.ts`, 5/5 green against real Postgres 17 + pgvector under Node 22. It proves the wire end to end: the generated link is `…/magic-link/verify?token=…&callbackURL=%2Foauth%2Fdevice%3Fuser_code%3D…`, i.e. the `user_code` rides through to the consent page; the send fails closed without RESEND and is swallowed, so the response stays an opaque 202 with the verification row created. Cases cover: trigger + opaque 202, identical response for existing vs new email (no enumeration), bad user_code → 400, missing fields → 400, malformed non-string input → 400 (not an uncaught 500).

## Still deferred

The ID-JAG verified (zero-touch) flow and the auth.md discovery surface (PRM `agent_auth` block + the `auth.md` file). Owletto consent-page copy for the agent-initiated context is a follow-up. `LOBU_API_TOKEN` remains the answer for pure CI.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * **Device email authorization** - agents can now authorize pending device codes by submitting an email address. A secure sign-in link is automatically sent to complete the authentication flow.
  * **Rate-limiting safeguards** - email authorization requests are rate-limited per IP to prevent abuse and protect system stability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lobu-ai/lobu/pull/1071?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->