### PR TITLE
fix(examples): use valid event kinds in lobu-crm reactions

### DIFF
--- a/examples/lobu-crm/funnel-digest.reaction.ts
+++ b/examples/lobu-crm/funnel-digest.reaction.ts
@@ -4,9 +4,10 @@
  * Runs after the weekly Monday-9am window completes. `ctx.extracted_data` is
  * whatever the watcher's `extraction_schema` produced — funnel snapshot, top
  * action, stale leads, etc. We:
- *   1. persist the digest as a `funnel_digest` event linked to every lead the
- *      watcher knows about, so the next digest can compare stage_counts
- *      week-over-week without re-running classification; and
+ *   1. persist the digest as a `summary` event (tagged `metadata.kind:
+ *      "funnel_digest"`) linked to every lead the watcher knows about, so the
+ *      next digest can compare stage_counts week-over-week without re-running
+ *      classification; and
  *   2. push it to the team via `client.notifications.send` — which fans out to
  *      the org's active bot connections (the #leads Slack connection) and the
  *      in-app inbox. `watcher_source` attributes it to this window.
@@ -43,8 +44,11 @@ export default async (
     // CRM data and discoverable from any lead the watcher already touches.
     entity_ids: ctx.entities.map((e) => e.id),
     content,
-    semantic_type: "funnel_digest",
+    // `semantic_type` must be a registered event kind; "summary" fits a digest.
+    // The domain label lives in metadata so it stays queryable.
+    semantic_type: "summary",
     metadata: {
+      kind: "funnel_digest",
       window_id: ctx.window.id,
       watcher_slug: ctx.watcher.slug,
       stage_counts: data.stage_counts ?? {},

--- a/examples/lobu-crm/inbound-triage.reaction.ts
+++ b/examples/lobu-crm/inbound-triage.reaction.ts
@@ -2,8 +2,9 @@
  * Reaction for the `inbound-triage` watcher.
  *
  * Fires every 2h after the watcher LLM extracts new and enriched leads from
- * GitHub/X/HN signals. Persists a `lead_interaction` event per run so the next
- * digest can count them, and — when the run is notable — pushes the recommended
+ * GitHub/X/HN signals. Persists an `observation` event (tagged `metadata.kind:
+ * "lead_interaction"`) per run so the next digest can count them, and — when
+ * the run is notable — pushes the recommended
  * actions to the team via `client.notifications.send` (fans out to the #leads
  * Slack connection + the in-app inbox).
  */
@@ -38,8 +39,11 @@ export default async (
   await client.knowledge.save({
     entity_ids: ctx.entities.map((e) => e.id),
     content: summary,
-    semantic_type: "lead_interaction",
+    // `semantic_type` must be a registered event kind; "observation" fits a
+    // triage note. The domain label lives in metadata so it stays queryable.
+    semantic_type: "observation",
     metadata: {
+      kind: "lead_interaction",
       window_id: ctx.window.id,
       new_lead_count: data.new_leads?.length ?? 0,
       action_count: actions.length,


### PR DESCRIPTION
The lobu-crm `funnel-digest` and `inbound-triage` reactions (shipped in #1064) call `client.knowledge.save` with `semantic_type: "funnel_digest"` / `"lead_interaction"`. Those aren't registered event kinds — `knowledge.save` validates `semantic_type` against the agent's `event_kinds` (built-ins: fact, note, todo, event, change, content, summary, decision, identity, preference, observation) and throws `ScriptError: Invalid kind`. Because `knowledge.save` runs **before** `client.notifications.send`, the reaction aborts and the digest never reaches #leads — the notify half of #1064 was never actually exercised end to end.

## Fix
- `funnel-digest`: `semantic_type` `"funnel_digest"` → `"summary"`
- `inbound-triage`: `semantic_type` `"lead_interaction"` → `"observation"`
- Keep the domain label in `metadata.kind` so week-over-week queries still discriminate digest vs. triage events.

## E2E reproducer (prod, org_lobucrm)
Driven via `manage_watchers.complete_window` (which runs the reaction in-process), against the deployed #1064 image:

- **Red:** with the old scripts → `reaction_status: "failed"`, `reaction_error: ScriptError: Invalid kind 'funnel_digest'. Valid kinds: fact, note, todo, ...` (retried 3×, logged in `watcher_reactions`).
- **Green:** after pushing the fixed `semantic_type` via `set_reaction_script` → `reaction_status: "success"`, a `notification_sent` reaction row (tool `notify`), notification event "Weekly funnel digest — 2026-06-01" created, and zero bot-delivery failures on either app pod.

The prod DB scripts for watchers 219/220 were already hot-fixed the same way; this PR makes the repo source match so the next `lobu apply` doesn't revert it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal data model structures for digest and knowledge event persistence to improve consistency and queryability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lobu-ai/lobu/pull/1072?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->