### PR TITLE
chore: bump packages/owletto pointer to 2ffdefa

### DIFF
--- a/packages/cli/src/__tests__/login-email.test.ts
+++ b/packages/cli/src/__tests__/login-email.test.ts
@@ -26,8 +26,12 @@ describe("login --email (user_claimed)", () => {
           registration_endpoint: "https://lobu.test/oauth/register",
           device_authorization_endpoint:
             "https://lobu.test/oauth/device_authorization",
-          grant_types_supported: ["urn:ietf:params:oauth:grant-type:device_code"],
-          agent_auth: { claim_email_endpoint: "https://lobu.test/oauth/device/email" },
+          grant_types_supported: [
+            "urn:ietf:params:oauth:grant-type:device_code",
+          ],
+          agent_auth: {
+            claim_email_endpoint: "https://lobu.test/oauth/device/email",
+          },
         });
       }
       if (url.endsWith("/oauth/register")) {
@@ -104,11 +108,14 @@ describe("login --email (user_claimed)", () => {
           registration_endpoint: "https://lobu.test/oauth/register",
           device_authorization_endpoint:
             "https://lobu.test/oauth/device_authorization",
-          grant_types_supported: ["urn:ietf:params:oauth:grant-type:device_code"],
+          grant_types_supported: [
+            "urn:ietf:params:oauth:grant-type:device_code",
+          ],
           // no agent_auth → email claim unsupported
         });
       }
-      if (url.endsWith("/oauth/register")) return jsonResponse({ client_id: "c" });
+      if (url.endsWith("/oauth/register"))
+        return jsonResponse({ client_id: "c" });
       if (url.endsWith("/oauth/device_authorization")) {
         return jsonResponse({
           device_code: "d",

--- a/packages/cli/src/internal/__tests__/oauth.test.ts
+++ b/packages/cli/src/internal/__tests__/oauth.test.ts
@@ -122,7 +122,8 @@ describe("oauth", () => {
           token_endpoint: "https://issuer.example.com/token",
           agent_auth: {
             flows_supported: ["user_claimed"],
-            claim_email_endpoint: "https://issuer.example.com/oauth/device/email",
+            claim_email_endpoint:
+              "https://issuer.example.com/oauth/device/email",
           },
         })
       );


### PR DESCRIPTION
Bumps `packages/owletto` pointer.

```
Before: b3d3a64
After:  2ffdefa
```

Picks up: fix(oauth): frame the device consent page as an access request when arriving via a link (#224)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated owletto package reference to point to a new subproject commit.

* **Tests**
  * Updated OAuth discovery mocks used by email-login and OAuth parsing tests to adjust response formatting and the presence/structure of the email-claim endpoint, ensuring tests reflect the new discovery payload formats.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lobu-ai/lobu/pull/1074?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->