### PR TITLE
fix(agent-worker): log the failure reason when a worker run fails

### DIFF
--- a/packages/agent-worker/src/openclaw/worker.ts
+++ b/packages/agent-worker/src/openclaw/worker.ts
@@ -547,9 +547,18 @@ export class OpenClawWorker implements WorkerExecutor {
         }
       }
 
-      logger.info(
-        `Worker completed with ${result.success ? "success" : "failure"}`
-      );
+      if (result.success) {
+        logger.info("Worker completed with success");
+      } else {
+        // Log the actual failure reason. Without this the run is marked
+        // failed (and the reply silently dropped) with no clue why — the
+        // `error`/`exitCode` came back from runAISession but were never
+        // surfaced, making prod failures undiagnosable from logs alone.
+        logger.error(
+          { err: result.error, exitCode: result.exitCode },
+          "Worker completed with failure"
+        );
+      }
     } catch (error) {
       await handleExecutionError(error, this.workerTransport);
     }


### PR DESCRIPTION
## Problem
`OpenClawWorker.execute()` logged `Worker completed with failure` but discarded the `error`/`exitCode` that `runAISession()` returned. A failed worker run **silently drops the user-facing reply** (the chat placeholder is cleaned up with no message), and prod logs gave no clue why.

This is the observability gap behind a live, deployment-wide symptom: chat-agent replies and watcher LLM runs (across multiple orgs, on image `20260526-134658`) return `success: false` and the reply never posts. The agent streams partial output, then `consumeFatalErrorMessage()` returns a fatal error → `success:false` — but that error string is **never logged**, so the root cause is undiagnosable from prod logs alone (and not reproducible in isolation: the configured z-ai endpoint works fine for a trivial prompt).

## Fix
On the failure path, log `result.error` + `result.exitCode` at `error` level instead of a bare "failure" string. Tiny, safe, no behavior change to the run itself.

## Why this first
The actual reply-bug root cause is the fatal turn error this surfaces. With this deployed, the next failed run names the cause in the logs, enabling a targeted follow-up fix — far more reliable than a local repro, since the failure is turn-specific (prompt + 23 MCP tools + conversation), not reproducible by a minimal local agent.

## Validation
- `tsc --noEmit` clean (agent-worker + repo pre-commit).
- Pure logging change on the existing failure branch; no control-flow change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error reporting with more detailed failure information, including error details and exit codes when operations fail.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lobu-ai/lobu/pull/1078?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->