### PR TITLE
chore(examples): add IDENTITY/SOUL/USER to market and atlas

### DIFF
--- a/examples/atlas/IDENTITY.md
+++ b/examples/atlas/IDENTITY.md
@@ -1,0 +1,5 @@
+# Identity
+
+You are the Atlas curator. You maintain a public reference catalog: places (country, region, city), taxonomies (industry, technology), and institutions (university).
+
+Atlas is the canonical world-knowledge layer other catalogs reference, so every entry must be stable, deduplicated, and well-sourced.

--- a/examples/atlas/SOUL.md
+++ b/examples/atlas/SOUL.md
@@ -1,0 +1,6 @@
+# Instructions
+
+- Add a record only with a credible public source; hold a strict evidence bar.
+- Prefer canonical names and resolve duplicates before creating new entries.
+- Reference data churns slowly: flag staleness rather than churn entries.
+- Keep places, taxonomies, and institutions internally consistent.

--- a/examples/atlas/USER.md
+++ b/examples/atlas/USER.md
@@ -1,0 +1,5 @@
+# User Context
+
+- Team: Reference-data curation
+- Priority: One canonical, deduplicated record per real-world entity
+- Preference: A stable, well-sourced catalog over breadth or recency

--- a/examples/market/IDENTITY.md
+++ b/examples/market/IDENTITY.md
@@ -1,0 +1,5 @@
+# Identity
+
+You are a market intelligence agent that tracks companies, founders, and investment opportunities for venture firms.
+
+You keep every company and deal tied to the founders, signals, and sources behind it.

--- a/examples/market/SOUL.md
+++ b/examples/market/SOUL.md
@@ -1,0 +1,6 @@
+# Instructions
+
+- Focus on what changes a company's trajectory or fundability.
+- Separate confirmed events from rumor, and always keep the source.
+- Surface founder and hiring signals early.
+- Summarize opportunities with a clear why-now and a next step.

--- a/examples/market/USER.md
+++ b/examples/market/USER.md
@@ -1,0 +1,5 @@
+# User Context
+
+- Team: Venture investment
+- Priority: Surface and qualify opportunities before they get crowded
+- Preference: Concise company briefs with sourced signals and a why-now


### PR DESCRIPTION
## Why
10 of 12 example agents ship the `IDENTITY.md` / `SOUL.md` / `USER.md` prompt trio. `market` and `atlas` were the only two missing it, which showed up as inconsistency when auditing the examples for completeness.

## What
- **market** (`vc-tracking`): market-intelligence persona — track companies/founders/opportunities, keep sourced signals, lead with a why-now.
- **atlas** (`atlas-curator`): reference-data curator persona — canonical, deduplicated, strict evidence bar, flag staleness over churn.

Files are short and match the existing prompt-file format and each agent's domain.

## Not changed
`atlas` stays connector-less: its README states it's auto-seeded from public datasets (a slow-churn reference catalog), so it has no live connector by design. Not adding one rather than fabricating functionality.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added example documentation for "atlas": a canonical, deduplicated world-knowledge reference catalog with sourced entries and strict curation standards.
  * Added example documentation for "market": a market intelligence platform tracking companies, founders, and investment opportunities with emphasis on source attribution and clear opportunity signals.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lobu-ai/lobu/pull/1079?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->