### PR TITLE
fix(embeddings): stamp legacy embedding_model + stop liveness probe killing the embeddings service

### DIFF
--- a/charts/lobu/Chart.yaml
+++ b/charts/lobu/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: lobu
 description: Lobu Platform - Never forget anything. User content analysis with AI.
 type: application
-version: 9.4.1
+version: 9.4.2
 appVersion: 9.4.1
 keywords:
   - lobu

--- a/charts/lobu/templates/embeddings-deployment.yaml
+++ b/charts/lobu/templates/embeddings-deployment.yaml
@@ -61,18 +61,18 @@ spec:
             httpGet:
               path: /health
               port: {{ .Values.embeddings.service.port }}
-            initialDelaySeconds: {{ .Values.healthCheck.readinessProbe.initialDelaySeconds }}
-            periodSeconds: {{ .Values.healthCheck.readinessProbe.periodSeconds }}
-            timeoutSeconds: {{ .Values.healthCheck.readinessProbe.timeoutSeconds }}
-            failureThreshold: {{ .Values.healthCheck.readinessProbe.failureThreshold }}
+            initialDelaySeconds: {{ .Values.embeddings.healthCheck.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.embeddings.healthCheck.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.embeddings.healthCheck.readinessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.embeddings.healthCheck.readinessProbe.failureThreshold }}
           livenessProbe:
             httpGet:
               path: /health
               port: {{ .Values.embeddings.service.port }}
-            initialDelaySeconds: {{ .Values.healthCheck.livenessProbe.initialDelaySeconds }}
-            periodSeconds: {{ .Values.healthCheck.livenessProbe.periodSeconds }}
-            timeoutSeconds: {{ .Values.healthCheck.livenessProbe.timeoutSeconds }}
-            failureThreshold: {{ .Values.healthCheck.livenessProbe.failureThreshold }}
+            initialDelaySeconds: {{ .Values.embeddings.healthCheck.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.embeddings.healthCheck.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.embeddings.healthCheck.livenessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.embeddings.healthCheck.livenessProbe.failureThreshold }}
           {{- if .Values.embeddings.cache.enabled }}
           volumeMounts:
             - name: embeddings-cache

--- a/charts/lobu/values.yaml
+++ b/charts/lobu/values.yaml
@@ -97,10 +97,29 @@ embeddings:
 
   resources:
     requests:
-      cpu: 500m
+      # Bumped from 500m: the local embedding model runs CPU-bound and inline, so
+      # 500m starved it — batches blocked the event loop long enough to trip the
+      # liveness probe (prod backfill -> SIGKILL -> failed embeddings + restart loop).
+      cpu: 1000m
       memory: 1Gi
     limits:
       memory: 3Gi
+
+  # The embeddings service runs the model INLINE on a single-threaded event loop, so
+  # a heavy batch blocks /health. The app's shared probe (3s timeout x3) killed a
+  # busy-but-healthy service mid-request in prod. Liveness must detect a DEAD process,
+  # not a BUSY one, so the embeddings service gets its own tolerant probe.
+  healthCheck:
+    readinessProbe:
+      initialDelaySeconds: 10
+      periodSeconds: 15
+      timeoutSeconds: 10
+      failureThreshold: 6
+    livenessProbe:
+      initialDelaySeconds: 45
+      periodSeconds: 30
+      timeoutSeconds: 15
+      failureThreshold: 8
 
   env: {}
 

--- a/db/migrations/20260526170000_backfill_legacy_embedding_model_stamp.sql
+++ b/db/migrations/20260526170000_backfill_legacy_embedding_model_stamp.sql
@@ -1,0 +1,22 @@
+-- migrate:up
+
+-- 20260526120000 added event_embeddings.embedding_model but left existing rows
+-- NULL. The model-scoped vector search (content-search.ts) excludes NULL stamps,
+-- so every legacy embedding silently dropped out of vector search until
+-- re-embedded — a full-corpus semantic-recall regression on deploy. Legacy rows
+-- were all produced by the default model (the only model used before stamping
+-- existed), so stamp them with it directly: the label is accurate, no
+-- re-embedding needed. The literal MUST match DEFAULT_EMBEDDING_MODEL in
+-- packages/server/src/utils/embeddings.ts. (Assumes the default model for legacy
+-- rows; an env that ran a non-default EMBEDDINGS_MODEL before this column existed
+-- should stamp accordingly.) Idempotent + a no-op once stamped (only touches NULL
+-- rows, e.g. on a PITR restore from before the manual prod backfill).
+UPDATE public.event_embeddings
+SET embedding_model = 'Xenova/bge-base-en-v1.5'
+WHERE embedding_model IS NULL;
+
+-- migrate:down
+
+-- Intentionally a no-op: re-NULLing would reintroduce the recall regression, and
+-- the stamp records the embedding's true model, so there is nothing to revert.
+SELECT 1;


### PR DESCRIPTION
Two fixes for the embeddings-backfill incident found during the #1066-#1070 prod rollout verification.

## 1. Migration: stamp legacy NULL `embedding_model` rows (recall regression)
`20260526120000` (#1069) added `event_embeddings.embedding_model` but left existing rows NULL. The model-scoped vector search excludes NULL stamps, so on deploy the **entire legacy corpus (prod: 1,231,945 rows) dropped out of vector search** — full semantic-recall regression (text search unaffected). **Hotfixed in prod** with the same UPDATE; this migration makes it reproducible (fresh env / PITR restore). The stamp is accurate (legacy rows were all the default model) — no re-embedding. Idempotent; no-op once stamped.

## 2. Chart: tolerant liveness probe + CPU for the embeddings service (backfill 0/100)
Root-caused the failing backfill (`0/100`, restart loop): the embeddings service runs the model **inline on a single-threaded event loop**, so a heavy batch blocks `/health`. It shared the stateless app's probe (`timeout 3s x3`), so k8s **killed a busy-but-healthy service mid-request** (exit 137, *"failed liveness probe"*, `/health context deadline exceeded`) → in-flight embedding requests died with `fetch failed` → restart loop. **Not OOM, not data, not a code bug — an infra misconfig.**

Fix (no code workaround): the embeddings service gets its **own tolerant probe** (liveness must detect a *dead* process, not a *busy* one: `timeout 15s x8`) and `cpu 500m→1000m` so batches finish faster. `Chart.yaml 9.4.1→9.4.2` so Flux ChartVersion reconcile ships it (release-please doesn't manage the chart).

## Validation
- Migration: idempotent data UPDATE; CI `migrations` job validates apply. No committed `schema.sql`.
- Chart: `helm lint` clean; `helm template` renders the new probe (`liveness timeout 15 / failureThreshold 8`) + `cpu 1000m`.

## Notes
- Prod recall is already restored (manual stamp). This PR makes that reproducible AND permanently fixes the embeddings restart loop.
- Until the chart ships, the backfill still intermittently restarts the embeddings pod (~0.3% of events lack embeddings); merging + shipping the chart stops the churn.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced embeddings service stability with refined health check configuration, improving reliability during high-load operations
  * Increased CPU resource allocation for embeddings service to optimize performance during batch processing
  * Applied database migration to ensure consistent embedding model version tracking

* **Chores**
  * Updated Helm chart version to 9.4.2

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lobu-ai/lobu/pull/1080?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->