### PR TITLE
feat(server): informed consent for agent user_claimed flow

### DIFF
--- a/packages/server/src/__tests__/integration/oauth/agent-claim-discovery.test.ts
+++ b/packages/server/src/__tests__/integration/oauth/agent-claim-discovery.test.ts
@@ -21,6 +21,8 @@ import { initWorkspaceProvider } from '../../../workspace';
 import { cleanupTestDatabase } from '../../setup/test-db';
 import {
   addUserToOrganization,
+  createTestDeviceCode,
+  createTestOAuthClient,
   createTestOrganization,
   createTestSession,
   createTestUser,
@@ -161,5 +163,47 @@ describe('user_claimed flow — full loop', () => {
     const tokens = (await tokenRes.json()) as { access_token: string; scope?: string };
     expect(tokens.access_token).toBeTruthy();
     expect((tokens.scope ?? '').split(' ')).toContain('mcp:read');
+  });
+});
+
+describe('GET /oauth/device/info — informed consent (who + scopes)', () => {
+  it('returns the requesting client name + scopes for a pending code (authed)', async () => {
+    const app = buildApp();
+    const user = await createTestUser({ name: 'Info User' });
+    const session = await createTestSession(user.id);
+    const client = await createTestOAuthClient({
+      client_name: 'Acme Agent',
+      grant_types: [DEVICE_GRANT, 'refresh_token'],
+    });
+    const device = await createTestDeviceCode(client.client_id, {
+      scope: 'mcp:read mcp:write',
+    });
+
+    const res = await call(app, 'GET', `/oauth/device/info?user_code=${device.userCode}`, {
+      headers: { Cookie: session.cookieHeader },
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { client_name: string; scopes: string[] };
+    expect(body.client_name).toBe('Acme Agent');
+    expect(body.scopes).toContain('mcp:read');
+    expect(body.scopes).toContain('mcp:write');
+  });
+
+  it('requires authentication', async () => {
+    const app = buildApp();
+    const client = await createTestOAuthClient({ grant_types: [DEVICE_GRANT, 'refresh_token'] });
+    const device = await createTestDeviceCode(client.client_id);
+    const res = await call(app, 'GET', `/oauth/device/info?user_code=${device.userCode}`);
+    expect(res.status).toBe(401);
+  });
+
+  it('400s for an unknown user_code', async () => {
+    const app = buildApp();
+    const user = await createTestUser({ name: 'Info User 2' });
+    const session = await createTestSession(user.id);
+    const res = await call(app, 'GET', '/oauth/device/info?user_code=NOPE-NOPE', {
+      headers: { Cookie: session.cookieHeader },
+    });
+    expect(res.status).toBe(400);
   });
 });

--- a/packages/server/src/auth/index.tsx
+++ b/packages/server/src/auth/index.tsx
@@ -11,6 +11,7 @@ import {
 	invitationSubject,
 } from "../email/templates/invitation";
 import {
+	authorizeAppSubject,
 	MagicLinkEmail,
 	magicLinkSubject,
 } from "../email/templates/magic-link";
@@ -531,12 +532,28 @@ export async function createAuth(env: Env, request?: Request) {
 							"Magic-link email delivery is not configured (RESEND_API_KEY missing). Check server logs for the generated link.",
 						);
 					}
+					// A magic link whose callbackURL targets the device consent page
+					// is an agent/app authorization request (POST /oauth/device/email),
+					// not a routine login — frame the email accordingly so the user
+					// doesn't grant third-party access thinking they're just signing in.
+					let isAuthorizeRequest = false;
+					try {
+						const callbackUrl = new URL(url).searchParams.get("callbackURL") ?? "";
+						isAuthorizeRequest = decodeURIComponent(callbackUrl).includes("/oauth/device");
+					} catch {
+						isAuthorizeRequest = false;
+					}
 					await sendTransactionalEmail({
 						env,
 						to: email,
 						category: "auth",
-						subject: magicLinkSubject,
-						react: <MagicLinkEmail url={url} />,
+						subject: isAuthorizeRequest ? authorizeAppSubject : magicLinkSubject,
+						react: (
+							<MagicLinkEmail
+								url={url}
+								mode={isAuthorizeRequest ? "authorize" : "sign-in"}
+							/>
+						),
 					});
 				},
 				expiresIn: 60 * 15, // 15 minutes

--- a/packages/server/src/auth/oauth/routes.ts
+++ b/packages/server/src/auth/oauth/routes.ts
@@ -815,6 +815,32 @@ oauthRoutes.post('/oauth/device/email', async (c) => {
 // No API route needed — the web app and API share the same origin.
 
 /**
+ * GET /oauth/device/info?user_code=...
+ * Returns the requesting client + scopes for a pending device code so the
+ * consent page can show the user WHO is asking and WHAT they will get — rather
+ * than approving a blind code. Auth-gated: only the (authenticated) user on the
+ * consent page needs this, and it avoids leaking client/scope by user_code.
+ */
+oauthRoutes.get('/oauth/device/info', requireAuth, async (c) => {
+  const userCode = c.req.query('user_code')?.trim();
+  if (!userCode) {
+    return c.json(createOAuthError('invalid_request', 'user_code is required'), 400);
+  }
+  const provider = getProvider(c);
+  const deviceCode = await provider.getDeviceCodeByUserCode(userCode);
+  if (!deviceCode) {
+    return c.json(createOAuthError('invalid_grant', 'Invalid or expired user code'), 400);
+  }
+  const client = await provider.clientsStore.getClient(deviceCode.client_id);
+  return c.json({
+    client_name: client?.client_name ?? null,
+    client_id: deviceCode.client_id,
+    scopes: (deviceCode.scope ?? '').split(' ').filter(Boolean),
+    resource: deviceCode.resource,
+  });
+});
+
+/**
  * POST /oauth/device/approve
  * Device Code Approval Endpoint
  *

--- a/packages/server/src/email/templates/magic-link.tsx
+++ b/packages/server/src/email/templates/magic-link.tsx
@@ -2,9 +2,27 @@ import { BrandedEmail } from './BrandedEmail';
 
 export interface MagicLinkProps {
   url: string;
+  /**
+   * 'sign-in' (default) is a normal login link. 'authorize' is used when an
+   * application/agent is requesting access on the user's behalf — the copy must
+   * make clear this is an authorization request, not a routine sign-in, so the
+   * user doesn't grant third-party access thinking they're just logging in.
+   */
+  mode?: 'sign-in' | 'authorize';
 }
 
-export function MagicLinkEmail({ url }: MagicLinkProps) {
+export function MagicLinkEmail({ url, mode = 'sign-in' }: MagicLinkProps) {
+  if (mode === 'authorize') {
+    return (
+      <BrandedEmail
+        preview="An application is requesting access to your Lobu account"
+        heading="Authorize access to Lobu"
+        intro="An application is requesting access to your Lobu account. Click below to review the request — you'll see what it can access before you approve. This link expires in 15 minutes."
+        cta={{ href: url, label: 'Review request' }}
+        footerNote="If you didn't request this, you can safely ignore this email — no access is granted unless you approve."
+      />
+    );
+  }
   return (
     <BrandedEmail
       preview="Your sign-in link for Lobu"
@@ -17,3 +35,4 @@ export function MagicLinkEmail({ url }: MagicLinkProps) {
 }
 
 export const magicLinkSubject = 'Your Lobu sign-in link';
+export const authorizeAppSubject = 'Authorize access to your Lobu account';


### PR DESCRIPTION
## What

Closes the informed-consent gaps on the agent `user_claimed` flow (the severe auto-approve was already fixed by the deployed consent-copy build; confirmed e2e on prod — magic-link arrival leaves the token `authorization_pending` until an explicit Approve).

- `GET /oauth/device/info?user_code=…` (auth-gated): resolves a pending device code to its requesting client name + scopes, so the consent page can show **who** is asking and **what** they get.
- The magic-link email reframes as an **authorization request** (subject + heading + CTA) when its `callbackURL` targets the device consent page — so a user doesn't grant third-party access thinking they're completing a routine sign-in. Normal login emails are unchanged (default `mode: 'sign-in'`).

Paired owletto change (lobu-ai/owletto#230): the consent page fetches `/oauth/device/info` and renders "Acme Agent is requesting access — Access: mcp:read, mcp:write."

## Why

pi flagged that approving a blind code, with a "Sign in to Lobu" email, is a phishing-shaped consent for a flow whose real intent is "authorize an agent to act as you." This makes the email and the consent screen say what's actually happening, so approval is informed.

## Test evidence

`agent-claim-discovery.test.ts` now 7/7 green vs real PG17+pgvector under Node 22 — adds: info endpoint returns client_name + scopes (authed), 401 unauthenticated, 400 unknown user_code — alongside the existing discovery + full user_claimed loop.

## Notes

No scope clamp — once consent is explicit and informed, the user grants the full requested scope (read+write), which is correct. Deferred: per-email rate limit + token provenance (hardening), and the auto-approve root-cause was the old SPA's conditional auto-submit, removed in the deployed build.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * OAuth device info endpoint: returns requesting app name and requested permissions during device authorization.
  * Magic-link emails: show distinct authorization messaging when a sign-in is requesting app permissions.

* **Tests**
  * Added integration tests covering authenticated and unauthenticated device info requests.

* **Chores**
  * Updated an internal subproject reference.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lobu-ai/lobu/pull/1081?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->