### PR TITLE
fix(agent-worker): strip redundant provider self-prefix from model code

### DIFF
--- a/packages/agent-worker/src/__tests__/model-resolver.test.ts
+++ b/packages/agent-worker/src/__tests__/model-resolver.test.ts
@@ -94,6 +94,21 @@ describe("resolveModelRef", () => {
     expect(result.modelId).toBe("anthropic/claude-sonnet-4");
   });
 
+  test("configured provider: a redundant self-prefix is stripped (z-ai/glm-4.7 → glm-4.7)", () => {
+    // Lobu names models "provider/model", but the upstream namespace is the
+    // bare code. Sending "z-ai/glm-4.7" to z.ai 400s "Unknown Model" — strip
+    // the configured provider's OWN id so the API receives "glm-4.7".
+    const result = resolveModelRef("z-ai/glm-4.7", { defaultProvider: "z-ai" });
+    expect(result.provider).toBe("z-ai");
+    expect(result.modelId).toBe("glm-4.7");
+  });
+
+  test("configured provider: a bare model code is left untouched", () => {
+    const result = resolveModelRef("glm-4.7", { defaultProvider: "z-ai" });
+    expect(result.provider).toBe("z-ai");
+    expect(result.modelId).toBe("glm-4.7");
+  });
+
   test("configured provider + 'auto' resolves to that provider's default model", () => {
     const result = resolveModelRef("auto", { defaultProvider: "anthropic" });
     expect(result.provider).toBe("anthropic");

--- a/packages/agent-worker/src/openclaw/model-resolver.ts
+++ b/packages/agent-worker/src/openclaw/model-resolver.ts
@@ -184,6 +184,16 @@ export function resolveModelRef(
   // the anthropic/openai provider". Splitting on "/" here would mis-route them.
   if (defaultProvider) {
     let modelId = modelRef;
+    // Strip a redundant leading "<configured-provider>/" prefix. Lobu refers to
+    // models as "provider/model" (e.g. "z-ai/glm-4.7"), but the upstream
+    // provider's own namespace is just the bare code ("glm-4.7") — sending the
+    // Lobu prefix makes z.ai (and other sdkCompat:openai providers) 400 with
+    // "Unknown Model". Only strip the configured provider's OWN id, so a
+    // foreign namespace slug (OpenRouter's "anthropic/claude-sonnet-4") is left
+    // intact and still routes correctly.
+    if (modelId.startsWith(`${defaultProvider}/`)) {
+      modelId = modelId.slice(defaultProvider.length + 1);
+    }
     // Resolve "auto" to the configured provider's default model.
     if (modelId === "auto") {
       const fallback = DEFAULT_PROVIDER_MODELS[defaultProvider];


### PR DESCRIPTION
## Root cause (the deployment-wide chat/watcher "Worker completed with failure")
`resolveModelRef` passes the model string **as-is** when a provider is configured — intentional for OpenRouter-style foreign slugs (`anthropic/claude-sonnet-4` = OpenRouter's namespace). But it didn't strip a **redundant self-prefix**: with the `z-ai` provider configured and model `z-ai/glm-4.7`, it sent `z-ai/glm-4.7` to z.ai's OpenAI-compat API, which **400s `Unknown Model, please check the model code`** (z.ai's namespace is the bare `glm-4.7`).

That fatal turn error (surfaced by #1078's new logging: `{"err":"400 Unknown Model...","exitCode":1}`) marked every worker-spawned z-ai run failed → the user-facing reply was dropped. Hit chat replies (`crm`) **and** watcher LLM turns (`atlas-curator`) across orgs — anything on a `z-ai/<model>` config.

## Fix
Strip only a leading `<configured-provider>/` prefix in the configured-provider branch. Foreign-namespace slugs (OpenRouter) are left intact.

## Verified
- **Live z.ai API:** `z-ai/glm-4.7` → `400 Unknown Model`; `glm-4.7` → `200`.
- **red→green unit test:** without the fix, `resolveModelRef("z-ai/glm-4.7",{defaultProvider:"z-ai"})` returns modelId `z-ai/glm-4.7` (fail); with it, `glm-4.7` (pass). Added a bare-code case too; the existing OpenRouter passthrough test still passes.
- `tsc` + biome clean.

Builds on the diagnosis enabled by #1078 (worker now logs `result.error`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test cases to validate model reference resolution behavior when a default provider is configured, including handling of redundant prefixes.

* **Bug Fixes**
  * Enhanced model reference resolution to correctly strip redundant provider prefixes from model identifiers, ensuring accurate resolution.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lobu-ai/lobu/pull/1083?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->