### PR TITLE
fix(agent-worker): strip provider self-prefix after auto-resolution (generic, gap-free)

### DIFF
--- a/packages/agent-worker/src/__tests__/model-resolver.test.ts
+++ b/packages/agent-worker/src/__tests__/model-resolver.test.ts
@@ -103,6 +103,18 @@ describe("resolveModelRef", () => {
     expect(result.modelId).toBe("glm-4.7");
   });
 
+  test("configured provider: 'auto' resolving to a PREFIXED default is also stripped (nvidia)", () => {
+    // The gap behind the first prefix fix: DEFAULT_PROVIDER_MODELS.nvidia is
+    // itself prefixed ("nvidia/moonshotai/kimi-k2.5"). Stripping must run AFTER
+    // auto-resolution, or an auto agent on nvidia ships the redundant prefix.
+    const result = resolveModelRef("auto", { defaultProvider: "nvidia" });
+    expect(result.provider).toBe("nvidia");
+    expect(result.modelId).toBe(
+      DEFAULT_PROVIDER_MODELS.nvidia.replace(/^nvidia\//, "")
+    );
+    expect(result.modelId.startsWith("nvidia/")).toBe(false);
+  });
+
   test("configured provider: a bare model code is left untouched", () => {
     const result = resolveModelRef("glm-4.7", { defaultProvider: "z-ai" });
     expect(result.provider).toBe("z-ai");

--- a/packages/agent-worker/src/openclaw/model-resolver.ts
+++ b/packages/agent-worker/src/openclaw/model-resolver.ts
@@ -184,23 +184,25 @@ export function resolveModelRef(
   // the anthropic/openai provider". Splitting on "/" here would mis-route them.
   if (defaultProvider) {
     let modelId = modelRef;
-    // Strip a redundant leading "<configured-provider>/" prefix. Lobu refers to
-    // models as "provider/model" (e.g. "z-ai/glm-4.7"), but the upstream
-    // provider's own namespace is just the bare code ("glm-4.7") — sending the
-    // Lobu prefix makes z.ai (and other sdkCompat:openai providers) 400 with
-    // "Unknown Model". Only strip the configured provider's OWN id, so a
-    // foreign namespace slug (OpenRouter's "anthropic/claude-sonnet-4") is left
-    // intact and still routes correctly.
-    if (modelId.startsWith(`${defaultProvider}/`)) {
-      modelId = modelId.slice(defaultProvider.length + 1);
-    }
-    // Resolve "auto" to the configured provider's default model.
+    // Resolve "auto" to the configured provider's default model FIRST — the
+    // default itself may carry a redundant prefix (e.g. nvidia →
+    // "nvidia/moonshotai/kimi-k2.5"), so stripping has to run after this.
     if (modelId === "auto") {
       const fallback = DEFAULT_PROVIDER_MODELS[defaultProvider];
       if (fallback) {
         logger.info(`Resolved auto model for ${defaultProvider}: ${fallback}`);
         modelId = fallback;
       }
+    }
+    // Then strip a redundant leading "<configured-provider>/" self-prefix. Lobu
+    // names models "provider/model" ("z-ai/glm-4.7"), but the upstream
+    // provider's own namespace is the bare code ("glm-4.7") — shipping the Lobu
+    // prefix makes z.ai (and other sdkCompat:openai providers) 400 "Unknown
+    // Model". Only the configured provider's OWN id is stripped, so a foreign
+    // namespace slug (OpenRouter's "anthropic/claude-sonnet-4") stays intact.
+    // Runs after the auto-resolution above so a prefixed default is covered too.
+    if (modelId.startsWith(`${defaultProvider}/`)) {
+      modelId = modelId.slice(defaultProvider.length + 1);
     }
     return { provider: defaultProvider, modelId };
   }


### PR DESCRIPTION
Follow-up to #1083 — closes the ordering gap and makes the rule fully generic.

## The rule (provider-agnostic)
The upstream model code must never carry the configured provider's own Lobu id as a leading segment. `resolveModelRef` (the single Lobu-ref → upstream-code conversion point) now enforces this for **any** provider by stripping a leading `${defaultProvider}/` — no per-provider special-casing.

## The gap #1083 left
#1083 stripped the prefix *before* resolving `auto`. But a provider's auto default can itself be prefixed — `DEFAULT_PROVIDER_MODELS.nvidia = "nvidia/moonshotai/kimi-k2.5"` — so auto-mode re-introduced the prefix after the strip and would still 400. Reordered to: resolve `auto` first, **then** strip the self-prefix. Now correct whether the model arrives explicit (`z-ai/glm-4.7`), bare (`glm-4.7`), or from a prefixed auto default.

Foreign-namespace slugs (OpenRouter's `anthropic/claude-...`, where the prefix is NOT the configured provider's id) are untouched — existing passthrough test still green.

## Verified
- red→green: with the pre-auto order, the new nvidia auto-mode test fails; reordered → all 28 resolver tests pass.
- Live z.ai earlier: `z-ai/glm-4.7` → 400 Unknown Model; `glm-4.7` → 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected model reference resolution when a default provider is set so model identifiers are normalized and redundant provider prefixes are removed reliably.

* **Tests**
  * Added a test verifying default-provider model resolution produces the expected normalized model identifier and preserves the configured provider.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lobu-ai/lobu/pull/1085?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->