### PR TITLE
fix(gateway): deliver Slack reply from worker finalText under multi-replica

### DIFF
--- a/packages/agent-worker/src/gateway/gateway-integration.ts
+++ b/packages/agent-worker/src/gateway/gateway-integration.ts
@@ -138,9 +138,16 @@ export class HttpWorkerTransport implements WorkerTransport {
   }
 
   async signalCompletion(): Promise<void> {
+    // Carry the full assistant text on the terminal row. The reply text is
+    // otherwise only in the gateway's per-pod streaming buffer (built from the
+    // delta rows on whichever replica drained them); a post-once renderer
+    // (Slack) that completes on a different replica has no buffer and would
+    // drop the reply. `finalText` makes the completion self-contained so any
+    // replica can deliver it. (Empty string when nothing was streamed.)
     await this.sendResponse(
       this.buildBaseResponse({
         processedMessageIds: this.processedMessageIds,
+        finalText: this.accumulatedStreamContent.join(""),
       })
     );
   }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -491,6 +491,14 @@ export interface ThreadResponsePayload {
   delta?: string;
   isFullReplacement?: boolean;
   processedMessageIds?: string[];
+  /**
+   * Full final assistant text, set on the TERMINAL completion row by the
+   * worker. Lets a renderer deliver the reply without the per-pod streaming
+   * buffer (which only exists on the pod that consumed the delta rows) — so a
+   * post-once platform (Slack) renders correctly even when the completion is
+   * drained by a different replica than the one that buffered the deltas.
+   */
+  finalText?: string;
   error?: string;
   errorCode?: string;
   timestamp: number;

--- a/packages/server/src/__tests__/guardrails-runtime.test.ts
+++ b/packages/server/src/__tests__/guardrails-runtime.test.ts
@@ -16,7 +16,7 @@
  * a sleep — fire-and-forget audit writes are explicitly awaitable.
  */
 
-import { afterAll, afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { Guardrail } from '@lobu/core';
 import { generateWorkerToken, GuardrailRegistry } from '@lobu/core';
 import { AgentSettingsStore } from '../gateway/auth/settings/agent-settings-store';
@@ -348,6 +348,67 @@ describe('ChatResponseBridge — wired output guardrail', () => {
         's'
       );
     });
+
+    await flushPendingGuardrailAudits();
+    const rows = await fetchGuardrailEvents(orgId, 'output');
+    expect(rows.length).toBe(1);
+    expect(rows[0]!.metadata.guardrail).toBe('secret-scan');
+  });
+
+  it('scans payload.finalText at completion for a post-once (Slack) reply with no local stream (cross-replica)', async () => {
+    // Under N>1 replicas the terminal row can be claimed by a pod that never
+    // saw the delta rows, so the per-delta scan never ran here. The Slack
+    // completion path delivers payload.finalText, so it must be scanned at
+    // completion or a secret would post unguarded. No handleDelta is called —
+    // this mirrors the cross-pod terminal-only delivery.
+    const { target, posted } = createCapturingTarget();
+    const slackPostMessage = vi.fn(async () => ({ ok: true, ts: '1.1' }));
+    const manager = {
+      getInstance: () => ({
+        connection: { agentId, organizationId: orgId, platform: 'slack' },
+        chat: {
+          channel: () => target,
+          getAdapter: (name: string) =>
+            name === 'slack'
+              ? { client: { chat: { postMessage: slackPostMessage } } }
+              : undefined,
+        },
+        conversationState: undefined,
+      }),
+      has: () => true,
+    };
+    const bridge = new ChatResponseBridge(manager as any);
+
+    const registry = new GuardrailRegistry();
+    registerBuiltinGuardrails(registry);
+    const settingsStore = new AgentSettingsStore(createPostgresAgentConfigStore());
+    bridge.setGuardrails(registry, settingsStore);
+
+    const payload = {
+      messageId: 'm1',
+      channelId: 'slack:C123',
+      conversationId: 'slack:C123',
+      userId: 'u1',
+      teamId: 't1',
+      timestamp: 0,
+      platform: 'slack',
+      platformMetadata: { connectionId: 'conn-1', chatId: 'slack:C123' },
+      finalText: 'here is sk-abcdefghij0123456789AB please',
+      processedMessageIds: ['m1'],
+    };
+
+    await orgContext.run({ organizationId: orgId }, async () => {
+      await bridge.handleCompletion(payload, 's');
+    });
+
+    // The secret must NOT reach Slack; only the block message is posted.
+    expect(slackPostMessage).not.toHaveBeenCalled();
+    expect(posted).toEqual([
+      expect.objectContaining({
+        text: expect.stringContaining('Message blocked by guardrail'),
+      }),
+    ]);
+    expect(posted[0]?.text).toMatch(/openai-key/);
 
     await flushPendingGuardrailAudits();
     const rows = await fetchGuardrailEvents(orgId, 'output');

--- a/packages/server/src/gateway/__tests__/chat-response-bridge.test.ts
+++ b/packages/server/src/gateway/__tests__/chat-response-bridge.test.ts
@@ -431,6 +431,122 @@ describe("ChatResponseBridge.handleDelta — Slack markdown_text path", () => {
   });
 });
 
+describe("ChatResponseBridge.handleCompletion — multi-replica finalText", () => {
+  // Under N>1 replicas the `thread_response` queue is drained competitively
+  // (FOR UPDATE SKIP LOCKED, no per-conversation affinity), so a run's delta
+  // rows and its terminal row can land on different pods. A post-once renderer
+  // (Slack) that completes on a pod which buffered no/partial deltas must
+  // render from the worker's authoritative `finalText`, not the local buffer.
+  const slackPayload = {
+    ...basePayload,
+    platform: "slack",
+    channelId: "slack:C123",
+    conversationId: "slack:C123:1700000000.123456",
+    platformMetadata: {
+      connectionId: "conn-1",
+      chatId: "slack:C123",
+    },
+  };
+
+  test("Slack completion with NO local stream posts payload.finalText", async () => {
+    // Simulates the terminal row arriving on a replica that never claimed any
+    // delta rows — `this.streams` has no entry for this key.
+    const { target } = createStreamingTarget();
+    const slackPost = mock(async () => ({ ok: true, ts: "1.1" }));
+    const { manager } = createHarness(target, "slack", slackPost);
+    const bridge = new ChatResponseBridge(manager as any);
+
+    await bridge.handleCompletion(
+      {
+        ...slackPayload,
+        finalText: "full reply from the worker",
+        processedMessageIds: ["m1"],
+      },
+      "s"
+    );
+
+    expect(target.post).not.toHaveBeenCalled();
+    expect(slackPost).toHaveBeenCalledTimes(1);
+    expect(slackPost.mock.calls[0]?.[0]).toMatchObject({
+      channel: "C123",
+      thread_ts: "1700000000.123456",
+      markdown_text: "full reply from the worker",
+    });
+  });
+
+  test("Slack completion prefers finalText over a partial local buffer", async () => {
+    // This replica claimed only a subset of the deltas, so its buffer is
+    // incomplete. finalText is authoritative and must win.
+    const { target } = createStreamingTarget();
+    const slackPost = mock(async () => ({ ok: true, ts: "1.1" }));
+    const { manager } = createHarness(target, "slack", slackPost);
+    const bridge = new ChatResponseBridge(manager as any);
+
+    await bridge.handleDelta(
+      { ...slackPayload, delta: "partial " },
+      "s"
+    );
+    await bridge.handleCompletion(
+      {
+        ...slackPayload,
+        finalText: "partial reply complete and whole",
+        processedMessageIds: ["m1"],
+      },
+      "s"
+    );
+
+    expect(slackPost).toHaveBeenCalledTimes(1);
+    expect(slackPost.mock.calls[0]?.[0]).toMatchObject({
+      markdown_text: "partial reply complete and whole",
+    });
+  });
+
+  test("Slack completion persists finalText to history with no local stream", async () => {
+    const { target } = createStreamingTarget();
+    const slackPost = mock(async () => ({ ok: true, ts: "1.1" }));
+    const { conversationState, manager } = createHarness(
+      target,
+      "slack",
+      slackPost
+    );
+    const bridge = new ChatResponseBridge(manager as any);
+
+    await bridge.handleCompletion(
+      {
+        ...slackPayload,
+        finalText: "persisted full reply",
+        processedMessageIds: ["m1"],
+      },
+      "s"
+    );
+
+    const history = await conversationState.getHistory("conn-1", "slack:C123");
+    expect(history).toEqual([
+      { role: "assistant", content: "persisted full reply", name: undefined },
+    ]);
+  });
+
+  test("live-streaming (Telegram) completion with NO local stream does NOT re-post finalText", async () => {
+    // Default strategy streamed its deltas on whichever replica claimed them.
+    // Re-posting finalText here would duplicate the reply, so a stream-less
+    // completion is a no-op for live-streaming platforms.
+    const { target } = createStreamingTarget();
+    const { manager } = createHarness(target, "telegram");
+    const bridge = new ChatResponseBridge(manager as any);
+
+    await bridge.handleCompletion(
+      {
+        ...basePayload,
+        finalText: "should not be posted again",
+        processedMessageIds: ["m1"],
+      },
+      "s"
+    );
+
+    expect(target.post).not.toHaveBeenCalled();
+  });
+});
+
 describe("ChatResponseBridge.handleEphemeral", () => {
   test("renders settings links as native buttons for Chat SDK targets", async () => {
     const posts: unknown[] = [];

--- a/packages/server/src/gateway/__tests__/chat-response-bridge.test.ts
+++ b/packages/server/src/gateway/__tests__/chat-response-bridge.test.ts
@@ -526,6 +526,46 @@ describe("ChatResponseBridge.handleCompletion — multi-replica finalText", () =
     ]);
   });
 
+  test("two pods: pod A buffers deltas, pod B completes — reply delivered exactly once", async () => {
+    // Faithful two-replica reproducer. Each ChatResponseBridge has its own
+    // pod-local `streams` Map, so two instances model two pods. The competitive
+    // SKIP-LOCKED queue can route a run's deltas to pod A and its terminal row
+    // to pod B. On origin/main pod B has no local stream and drops the Slack
+    // reply (the bug); with finalText, pod B delivers and pod A — which never
+    // receives the terminal row — never posts, so the reply lands exactly once.
+    const slackPostA = mock(async () => ({ ok: true, ts: "a.1" }));
+    const slackPostB = mock(async () => ({ ok: true, ts: "b.1" }));
+    const { target: targetA } = createStreamingTarget();
+    const { target: targetB } = createStreamingTarget();
+    const podA = new ChatResponseBridge(
+      createHarness(targetA, "slack", slackPostA).manager as any
+    );
+    const podB = new ChatResponseBridge(
+      createHarness(targetB, "slack", slackPostB).manager as any
+    );
+
+    // Pod A claims the delta rows and buffers them locally.
+    await podA.handleDelta({ ...slackPayload, delta: "hello " }, "s");
+    await podA.handleDelta({ ...slackPayload, delta: "world" }, "s");
+
+    // Pod B claims the terminal row (it never saw the deltas).
+    await podB.handleCompletion(
+      {
+        ...slackPayload,
+        finalText: "hello world",
+        processedMessageIds: ["m1"],
+      },
+      "s"
+    );
+
+    // Exactly-once: pod B posted the full reply; pod A never did.
+    expect(slackPostB).toHaveBeenCalledTimes(1);
+    expect(slackPostB.mock.calls[0]?.[0]).toMatchObject({
+      markdown_text: "hello world",
+    });
+    expect(slackPostA).not.toHaveBeenCalled();
+  });
+
   test("live-streaming (Telegram) completion with NO local stream does NOT re-post finalText", async () => {
     // Default strategy streamed its deltas on whichever replica claimed them.
     // Re-posting finalText here would duplicate the reply, so a stream-less

--- a/packages/server/src/gateway/connections/chat-response-bridge.ts
+++ b/packages/server/src/gateway/connections/chat-response-bridge.ts
@@ -395,10 +395,22 @@ export class ChatResponseBridge implements ResponseRenderer {
           "Adapter stream errored during completion"
         );
       }
-
-      await strategy.handleCompletion({ ctx, payload, stream });
-      this.streams.delete(key);
     }
+
+    // Deliver when this replica has a local stream OR when this is a post-once
+    // strategy (Slack) carrying the worker's full text. Under N>1 replicas the
+    // delta rows and the terminal row are claimed competitively from the shared
+    // `thread_response` queue with no per-conversation affinity, so the
+    // completion can land on a pod that buffered no (or only some) deltas — only
+    // `payload.finalText` is authoritative there. A live-streaming strategy with
+    // no local stream already posted its deltas on the claiming replica, so it
+    // is intentionally skipped (re-posting would duplicate).
+    const canDeliverFromFinalText =
+      strategy.deliversAtCompletion && !!payload.finalText?.trim();
+    if (stream || canDeliverFromFinalText) {
+      await strategy.handleCompletion({ ctx, payload, stream: stream ?? null });
+    }
+    if (stream) this.streams.delete(key);
     // Next stream on the same key starts with a fresh tail.
     this.guardrailTails.delete(key);
 
@@ -408,12 +420,15 @@ export class ChatResponseBridge implements ResponseRenderer {
     // Gap 1: Store outgoing response in history. Wrap so that a state-store
     // outage doesn't fail the whole response delivery — the user has
     // already seen the message; missing history is recoverable, a 500
-    // here is not.
-    if (stream?.buffer.trim() && conversationState) {
+    // here is not. Prefer the worker's authoritative finalText: under N>1
+    // replicas `stream?.buffer` is null (cross-pod) or only the subset of
+    // deltas this pod claimed, so persisting it would store a truncated reply.
+    const historyText = payload.finalText ?? stream?.buffer;
+    if (historyText?.trim() && conversationState) {
       try {
         await conversationState.appendHistory(connectionId, channelId, {
           role: "assistant",
-          content: stream.buffer,
+          content: historyText,
           timestamp: Date.now(),
         });
       } catch (error) {

--- a/packages/server/src/gateway/connections/chat-response-bridge.ts
+++ b/packages/server/src/gateway/connections/chat-response-bridge.ts
@@ -364,7 +364,7 @@ export class ChatResponseBridge implements ResponseRenderer {
     const ctx = this.extractResponseContext(payload);
     if (!ctx) return;
 
-    const { connectionId, strategy, channelId } = ctx;
+    const { connectionId, strategy, channelId, instance } = ctx;
     const key = `${channelId}:${payload.conversationId}`;
 
     // If a guardrail blocked this stream mid-flight, skip completion
@@ -407,7 +407,48 @@ export class ChatResponseBridge implements ResponseRenderer {
     // is intentionally skipped (re-posting would duplicate).
     const canDeliverFromFinalText =
       strategy.deliversAtCompletion && !!payload.finalText?.trim();
-    if (stream || canDeliverFromFinalText) {
+
+    // Output guardrail for the post-once path. A post-once strategy delivers
+    // here from the full text, so the per-delta scan in handleDelta is NOT a
+    // sufficient guard under N>1 replicas: this completing pod may have scanned
+    // no deltas (cross-pod) or only the subset it claimed, and a secret split
+    // across deltas that scattered to different pods trips no per-delta scan.
+    // `blockedStreams` is pod-local and cannot protect a cross-replica
+    // completion. So scan the full delivered text once here; on a trip, post
+    // the block message and suppress both delivery and history. (Live-streaming
+    // strategies can't defer — they already streamed per-delta — so this only
+    // runs for deliversAtCompletion strategies.)
+    let blockedAtCompletion = false;
+    if (strategy.deliversAtCompletion) {
+      const completionText = payload.finalText ?? stream?.buffer ?? "";
+      if (completionText.trim()) {
+        const trip = await this.runOutputGuardrails(completionText, payload, ctx);
+        if (trip) {
+          blockedAtCompletion = true;
+          const blockText = `Message blocked by guardrail: ${trip.reason ?? trip.guardrail}`;
+          try {
+            const target = await this.resolveTarget(
+              instance,
+              channelId,
+              payload.conversationId,
+              platformMetadataString(
+                payload.platformMetadata,
+                "responseThreadId"
+              ),
+              readPlatformMetadata(payload.platformMetadata)
+            );
+            if (target) await target.post(blockText);
+          } catch (err) {
+            logger.error(
+              { err: String(err) },
+              "Failed to post guardrail block message at completion"
+            );
+          }
+        }
+      }
+    }
+
+    if (!blockedAtCompletion && (stream || canDeliverFromFinalText)) {
       await strategy.handleCompletion({ ctx, payload, stream: stream ?? null });
     }
     if (stream) this.streams.delete(key);
@@ -424,7 +465,7 @@ export class ChatResponseBridge implements ResponseRenderer {
     // replicas `stream?.buffer` is null (cross-pod) or only the subset of
     // deltas this pod claimed, so persisting it would store a truncated reply.
     const historyText = payload.finalText ?? stream?.buffer;
-    if (historyText?.trim() && conversationState) {
+    if (!blockedAtCompletion && historyText?.trim() && conversationState) {
       try {
         await conversationState.appendHistory(connectionId, channelId, {
           role: "assistant",

--- a/packages/server/src/gateway/connections/platform-strategies/index.ts
+++ b/packages/server/src/gateway/connections/platform-strategies/index.ts
@@ -83,15 +83,34 @@ export interface PlatformResponseStrategy {
   }): Promise<StreamState | null>;
 
   /**
-   * Handle completion for a stream. Called after the bridge has closed the
-   * stream's iterator and awaited the adapter's streamPromise. Responsible
-   * for any platform-specific final post (e.g. Slack's `markdown_text`).
+   * Handle completion. For a live-streaming strategy this runs after the
+   * bridge has closed the stream's iterator and awaited the adapter's
+   * streamPromise. `stream` is `null` when no local streaming state exists on
+   * this replica — under N>1 replicas the delta rows can be claimed by a
+   * different pod than the terminal row (the `thread_response` queue is drained
+   * competitively with no per-conversation affinity), so a post-once strategy
+   * must render from `payload.finalText` instead. Post-once strategies should
+   * therefore prefer `payload.finalText` over `stream.buffer` even when a local
+   * stream exists, because that buffer may hold only the subset of deltas this
+   * pod happened to claim.
    */
   handleCompletion(args: {
     ctx: StrategyContext;
     payload: ThreadResponsePayload;
-    stream: StreamState;
+    stream: StreamState | null;
   }): Promise<void>;
+
+  /**
+   * True when the strategy delivers the reply only at completion from the full
+   * text (no live streaming to the platform during deltas) — i.e. Slack, which
+   * buffers deltas and posts once via `chat.postMessage`. Such strategies can
+   * render from `payload.finalText` with no local stream (a different replica
+   * claimed the deltas), since nothing was posted on any other replica. Live-
+   * streaming strategies set this false: their deltas already posted on the
+   * streaming replica, so re-posting the final text from another replica would
+   * duplicate — and a row with no local stream is simply nothing left to do.
+   */
+  readonly deliversAtCompletion: boolean;
 }
 
 /**
@@ -100,6 +119,10 @@ export interface PlatformResponseStrategy {
  * platform-specific buffering requirements.
  */
 class DefaultResponseStrategy implements PlatformResponseStrategy {
+  // Streams live to the platform during deltas — the reply is already posted
+  // on the replica that streamed it, so no cross-replica completion fallback.
+  readonly deliversAtCompletion = false;
+
   async disposeOnFullReplacement(existing: StreamState): Promise<void> {
     // Close current stream and await delivery so a new one can open cleanly.
     existing.iterator.close();
@@ -180,9 +203,15 @@ class DefaultResponseStrategy implements PlatformResponseStrategy {
   }: {
     ctx: StrategyContext;
     payload: ThreadResponsePayload;
-    stream: StreamState;
+    stream: StreamState | null;
   }): Promise<void> {
     const { connectionId, channelId } = ctx;
+    // No local stream means this replica never claimed any delta rows for the
+    // run. A live-streaming strategy has nothing buffered to flush and must not
+    // re-post from finalText (deltas already streamed on the claiming replica),
+    // so there is nothing to do here. The bridge gates on deliversAtCompletion
+    // and won't normally call us stream-less; guard defensively regardless.
+    if (!stream) return;
     if (stream.streamFailed && stream.buffer.trim() && stream.target) {
       // Fallback: when native streaming rejected (e.g. Slack's chatStream
       // requires a recipient user/team id that the public-API send path
@@ -361,6 +390,12 @@ async function postSlackMarkdown(
  * markdown-native rendering.
  */
 class SlackResponseStrategy implements PlatformResponseStrategy {
+  // Slack never streams live — it buffers deltas and posts once at completion.
+  // So it renders from the worker's authoritative `payload.finalText`, which
+  // makes the terminal row self-contained and correct under N>1 replicas (where
+  // delta rows scatter across pods and no single replica holds the full buffer).
+  readonly deliversAtCompletion = true;
+
   async disposeOnFullReplacement(_existing: StreamState): Promise<void> {
     // Slack never opens a real streaming target — no async teardown needed.
     // The bridge simply drops the prior state so the next delta opens a
@@ -409,12 +444,17 @@ class SlackResponseStrategy implements PlatformResponseStrategy {
   }: {
     ctx: StrategyContext;
     payload: ThreadResponsePayload;
-    stream: StreamState;
+    stream: StreamState | null;
   }): Promise<void> {
     const { connectionId, instance, channelId } = ctx;
-    if (!stream.buffer.trim()) return;
+    // Prefer the worker's authoritative full text. `stream?.buffer` is only the
+    // subset of deltas THIS replica claimed (or absent entirely cross-pod), so
+    // it's not trustworthy under N>1 — finalText is. Fall back to the buffer
+    // only when finalText is absent (e.g. a pre-finalText worker).
+    const text = payload.finalText ?? stream?.buffer ?? "";
+    if (!text.trim()) return;
 
-    const cleaned = stripEmptyLinks(decodeHtmlEntities(stream.buffer));
+    const cleaned = stripEmptyLinks(decodeHtmlEntities(text));
     try {
       const handled = await postSlackMarkdown(
         instance,
@@ -427,7 +467,7 @@ class SlackResponseStrategy implements PlatformResponseStrategy {
           { connectionId, channelId, length: cleaned.length },
           "Posted Slack response via markdown_text with paragraph chunking"
         );
-      } else if (stream.target) {
+      } else if (stream?.target) {
         // Adapter unavailable — fall back to the SDK so we still deliver.
         await stream.target.post(cleaned);
       }
@@ -436,7 +476,7 @@ class SlackResponseStrategy implements PlatformResponseStrategy {
         { connectionId, error: String(error) },
         "Slack markdown_text post failed; falling back to SDK"
       );
-      if (stream.target) {
+      if (stream?.target) {
         try {
           await stream.target.post(cleaned);
         } catch (fallbackError) {


### PR DESCRIPTION
## Problem

Under N>1 app replicas (prod runs 2, ClientIP affinity), Slack replies are silently dropped or truncated.

The `thread_response` queue is drained competitively across pods (`runs-queue.ts` `claimOne`: `FOR UPDATE SKIP LOCKED ... ORDER BY priority, run_at, id`) with **no per-conversation affinity**. So a single run's delta rows and its terminal completion row can be claimed by different pods. The gateway's streaming buffer (`ChatResponseBridge.streams`, a per-pod `Map`) is pod-local.

Slack is a **post-once** renderer: `handleDelta` only buffers, `handleCompletion` posts once via `chat.postMessage`. So if the terminal row lands on a pod that buffered:
- **zero deltas** → `if (stream)` is false → reply dropped entirely (the reported bug);
- **some deltas** → `stream.buffer` is only the subset that pod claimed → garbled/truncated post (latent).

`canHandle` is just `manager.has(connectionId)` (true on every pod), so the "Chat SDK rows already owner-route" claim is false — and owner-routing can't fix this anyway: with deltas scattered, no single pod holds the complete buffer.

## Fix

Carry the worker's authoritative full reply text on the terminal row (`finalText`) so completion is self-contained — any replica can render it:

- `ThreadResponsePayload.finalText` (core), set by the worker's `signalCompletion`.
- `SlackResponseStrategy` prefers `payload.finalText` over its local buffer (correct whether this pod saw all/some/no deltas); marked `deliversAtCompletion = true`.
- The bridge invokes the strategy even with **no local stream** for post-once strategies; `handleCompletion`'s `stream` is honestly `StreamState | null`.
- History persistence prefers `finalText` (no truncated history cross-pod).
- Live-streaming strategies (Telegram, `deliversAtCompletion = false`) are skipped stream-less — their deltas already posted on the claiming replica, so re-posting would duplicate.

**Output guardrails on the post-once path:** the per-delta scan (`handleDelta` → pod-local `blockedStreams`) is not authoritative for the `finalText` delivery under N>1 (completing pod may have scanned no/partial deltas; a secret split across scattered deltas trips no per-delta scan). So `finalText` is scanned once at completion for `deliversAtCompletion` strategies; on a trip the block message is posted and both delivery and history are suppressed. This is strictly stronger than the per-delta scan.

No fabricated `StreamState` objects, no new infra. This is also Slack's recommended ack-then-post-stateless pattern.

## Verification (red → green)

**Deterministic two-pod reproducer** (`chat-response-bridge.test.ts` → "two pods: pod A buffers deltas, pod B completes"). Two `ChatResponseBridge` instances model two pods (each has its own pod-local `streams` Map). Pod A buffers the deltas; pod B claims the terminal row with no local stream.
- **RED on `origin/main`**: pod B drops the reply — Slack post count 0 (`Expected: 1`). Confirmed by reverting the two source files to `origin/main` and running the test.
- **GREEN with fix**: pod B delivers from `finalText` exactly once; pod A (no terminal row) never double-posts.

Plus: 4 multi-replica unit tests (no-stream delivery, prefer-finalText-over-partial-buffer, finalText history, Telegram no-double-post) and 1 wired secret-scan test for the Slack completion path. 22/22 bridge tests + 8/8 wired guardrail tests pass; server + agent-worker typecheck clean.

`make review`: **bug_free 86, simplicity 86, slop 0, bugs 0, 0 blockers, tests_adequate: true.** (Integration suite hit a macOS embedded-PG shared-memory exhaustion in an untouched file — `agent-routes-apply.test.ts` — diagnosed `[env]` by pi, which ran the targeted tests directly: pass.)

## Still owed

Post-deploy prod E2E: cross-pod Slack mentions against the live 2-replica deployment, confirm 100% render with no drops/dupes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Completions now deliver the full assistant text so multi-replica sessions no longer produce missing or partial replies; platform posting prefers the authoritative completion text and avoids redundant re-posts for streaming platforms.

* **Tests**
  * Added end-to-end and unit tests covering multi-replica completion handling, delivery-at-completion behavior, and guardrail scanning on final completions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lobu-ai/lobu/pull/1087?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->