### PR TITLE
feat(server): ship watcher prompt in device poll payload (+ owletto pointer)

### DIFF
--- a/packages/server/src/__tests__/integration/watchers/manual-trigger.test.ts
+++ b/packages/server/src/__tests__/integration/watchers/manual-trigger.test.ts
@@ -13,11 +13,29 @@
 
 import { beforeEach, describe, expect, it } from 'vitest';
 import type { DbClient } from '../../../db/client';
+import type { Env } from '../../../index';
 import { generateSecureToken, hashToken } from '../../../auth/oauth/utils';
+import { manageWatchers } from '../../../tools/admin/manage_watchers';
+import type { ToolContext } from '../../../tools/registry';
 import { cleanupTestDatabase, getTestDb } from '../../setup/test-db';
 import { createTestAgent, createTestEntity } from '../../setup/test-fixtures';
 import { post } from '../../setup/test-helpers';
 import { TestWorkspace } from '../../setup/test-mcp-client';
+
+function ownerCtx(workspace: TestWorkspace): ToolContext {
+  return {
+    organizationId: workspace.org.id,
+    userId: workspace.users.owner.id,
+    memberRole: 'owner',
+    agentId: null,
+    isAuthenticated: true,
+    clientId: null,
+    scopes: ['mcp:read', 'mcp:write', 'mcp:admin'],
+    tokenType: 'oauth',
+    scopedToOrg: true,
+    allowCrossOrg: false,
+  };
+}
 
 /**
  * Mint a PAT bound to a specific device worker_id with `device_worker:run`
@@ -337,5 +355,47 @@ describe('POST /api/workers/me/watchers/:watcher_id/trigger', () => {
     };
     expect(job.run_type).toBe('watcher');
     expect(job.payload?.watcher?.execution_config).toEqual(execCfg);
+  });
+
+  it('poll payload carries the run-pinned version prompt, not a later edit', async () => {
+    const ctx = await setupDevicePinnedWatcher({ workerId: 'mac-poll-prompt' });
+    const { token } = await createWorkerBoundPat(
+      ctx.workspace.users.owner.id,
+      ctx.workspace.org.id,
+      'mac-poll-prompt'
+    );
+
+    // Queue a run: createWatcherRun snapshots the current version (prompt v1)
+    // into approved_input.version_id.
+    const trig = await post(`/api/workers/me/watchers/${ctx.watcherId}/trigger`, { token });
+    expect(trig.status).toBe(200);
+
+    // Edit the watcher AFTER the run is queued: a new current version with a
+    // different prompt. The already-queued run must NOT pick this up.
+    const v2 = (await manageWatchers(
+      {
+        action: 'create_version',
+        watcher_id: String(ctx.watcherId),
+        prompt: 'EDITED-AFTER-QUEUE prompt v2.',
+        change_notes: 'edit after queue',
+      } as never,
+      {} as Env,
+      ownerCtx(ctx.workspace)
+    )) as { version: number };
+    expect(v2.version).toBe(2);
+
+    // The poll must deliver the prompt of the version snapshotted at queue time
+    // (v1) — the same version complete_window validates against — not the edit.
+    const pollRes = await post('/api/workers/poll', {
+      token,
+      body: { worker_id: 'mac-poll-prompt', capabilities: {} },
+    });
+    expect(pollRes.status).toBe(200);
+    const job = (await pollRes.json()) as {
+      run_type?: string;
+      payload?: { watcher?: { prompt?: string } };
+    };
+    expect(job.run_type).toBe('watcher');
+    expect(job.payload?.watcher?.prompt).toBe('Summarize {{entities}}.');
   });
 });

--- a/packages/server/src/worker-api.ts
+++ b/packages/server/src/worker-api.ts
@@ -529,7 +529,8 @@ export async function pollWorkerJob(c: Context<{ Bindings: Env }>) {
         w.agent_kind AS watcher_agent_kind,
         w.notification_channel AS watcher_notification_channel,
         w.notification_priority AS watcher_notification_priority,
-        w.execution_config AS watcher_execution_config
+        w.execution_config AS watcher_execution_config,
+        wv.prompt AS watcher_prompt
       FROM runs r
       LEFT JOIN feeds f ON f.id = r.feed_id
       LEFT JOIN connections conn ON conn.id = r.connection_id
@@ -540,6 +541,9 @@ export async function pollWorkerJob(c: Context<{ Bindings: Env }>) {
         AND cd.status = 'active'
       LEFT JOIN auth_profiles ap ON ap.id = r.auth_profile_id
       LEFT JOIN watchers w ON w.id = r.watcher_id
+      LEFT JOIN watcher_versions wv
+        ON wv.id = COALESCE((r.approved_input->>'version_id')::bigint, w.current_version_id)
+        AND wv.watcher_id = w.watcher_group_id
       WHERE r.id = ${runId}
       LIMIT 1
     `;
@@ -605,6 +609,7 @@ export async function pollWorkerJob(c: Context<{ Bindings: Env }>) {
     watcher_notification_channel: string | null;
     watcher_notification_priority: string | null;
     watcher_execution_config: Record<string, unknown> | null;
+    watcher_prompt: string | null;
     // Auth run fields
     run_auth_profile_id: number | null;
     auth_profile_auth_data: Record<string, unknown> | null;
@@ -643,6 +648,16 @@ export async function pollWorkerJob(c: Context<{ Bindings: Env }>) {
           notification_channel: row.watcher_notification_channel ?? 'canvas',
           notification_priority: row.watcher_notification_priority ?? 'normal',
           execution_config: row.watcher_execution_config ?? null,
+          // The prompt of the version this run was pinned to at creation
+          // (run's snapshotted approved_input.version_id, else the watcher's
+          // current_version_id) — same source complete_window validates
+          // against, so a watcher edited after the run was queued doesn't swap
+          // the prompt mid-flight. Device-local executors had no other channel
+          // for the watcher's instructions (the payload shipped only
+          // id/name/slug), so a scheduled watcher's local CLI got a bare
+          // "process this" and improvised; shipping it lets the device run the
+          // real prompt. Null only if the watcher has no version row.
+          prompt: row.watcher_prompt ?? null,
         },
         event: {
           trigger_event_id: null,


### PR DESCRIPTION
## What
Device-local watchers got no instructions: the device poll envelope (`worker-api.ts`, the `run_type==='watcher'` branch) shipped only watcher id/name/slug, so the Mac app's local CLI received a bare "process this" and improvised toward the wrong data source. This joins the run's pinned watcher version and ships its prompt as `payload.watcher.prompt`, so the device runs the watcher's real instructions.

## How
- Poll SQL joins `watcher_versions` on `COALESCE((approved_input->>'version_id')::bigint, current_version_id)` — the same run-pinned resolution `complete_window` uses (manage_watchers.ts:1614), with the same `AND wv.watcher_id = w.watcher_group_id` guard so a forged version_id can't resolve another watcher's prompt.
- Adds `prompt` to the payload + row type.
- Bumps the owletto submodule pointer to the matching Mac-app change (lobu-ai/owletto#231), which decodes and runs the prompt.

## Tests
- New integration test (`manual-trigger.test.ts`): queue a run (pins prompt v1) → create_version v2 → assert the poll payload returns v1 (the snapshot), not the edit.
- `make review`: typecheck/unit/integration all green; pi endorsed the approach (right layer, multi-replica safe) and flagged the scope-guard, now applied. 8/8 in the touched test file pass with the guard.

## Not done (follow-ups noted by pi, out of scope)
Prompt rides in `claude -p` argv (future: stdin/temp-file if prompts carry secrets); no max prompt-length cap yet; version-pin-in-JSONB → dedicated column tracked in #799.

## Deploy note
Live e2e needs this server deployed (prod) + the Mac app rebuilt with owletto#231; validated in isolation (server ships it [tested], app runs it [compiles], the prompt produces a real plan [local claude -p test]) but the assembled prod path is unobserved until shipped.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Poll endpoint now returns the prompt snapshot that was pinned when a run was queued, preserving consistency even if the watcher is edited later.

* **Tests**
  * Added an integration test covering poll endpoint behavior and a test helper to support watcher administration scenarios.

* **Chores**
  * Updated a linked subproject reference.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lobu-ai/lobu/pull/1088?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->