### PR TITLE
fix(gateway): hydrate connection on per-connection webhook under multi-replica

### DIFF
--- a/packages/server/src/gateway/__tests__/chat-instance-manager-slack.test.ts
+++ b/packages/server/src/gateway/__tests__/chat-instance-manager-slack.test.ts
@@ -262,3 +262,58 @@ describe("ChatInstanceManager.postMessageToChannel", () => {
     ).rejects.toThrow(/No active chat instance/);
   });
 });
+
+describe("ChatInstanceManager.handleWebhook (multi-replica)", () => {
+  test("lazily starts the connection on this pod before handling the webhook", async () => {
+    // Regression: the per-connection webhook route (`/api/v1/webhooks/:id`)
+    // calls handleWebhook directly, unlike the Slack coordinator which
+    // pre-warms via ensureConnectionRunning. Under `app.replicaCount > 1` a
+    // webhook (a platform event OR a one-shot `/lobu link` slash command) can
+    // land on a pod that hasn't warmed this connection. It must hydrate from
+    // the store, not 404. Mirrors postMessageToChannel's lazy-start.
+    const ChatInstanceManager = await loadChatInstanceManager();
+    const manager = new ChatInstanceManager() as any;
+    const webhookHandler = mock(
+      async () => new Response("handled", { status: 200 })
+    );
+    manager.connectionStore = {
+      getConnection: async () => ({ id: "conn-cold", status: "active" }),
+    };
+    manager.restartConnection = mock(async (id: string) => {
+      manager.instances.set(id, {
+        connection: { platform: "slack" },
+        chat: { webhooks: { slack: webhookHandler } },
+      });
+    });
+
+    const request = new Request(
+      "https://gw.example.com/api/v1/webhooks/conn-cold",
+      {
+        method: "POST",
+        headers: { "content-type": "application/x-www-form-urlencoded" },
+        body: "command=%2Flobu&text=link+crm-ABC123",
+      }
+    );
+    const response = await manager.handleWebhook("conn-cold", request);
+
+    expect(manager.restartConnection).toHaveBeenCalledWith("conn-cold");
+    expect(webhookHandler).toHaveBeenCalled();
+    expect(response.status).toBe(200);
+    expect(await response.text()).toBe("handled");
+  });
+
+  test("404s when the connection is stopped and cannot be started", async () => {
+    const ChatInstanceManager = await loadChatInstanceManager();
+    const manager = new ChatInstanceManager() as any;
+    manager.connectionStore = {
+      getConnection: async () => ({ id: "stopped-conn", status: "stopped" }),
+    };
+    const response = await manager.handleWebhook(
+      "stopped-conn",
+      new Request("https://gw.example.com/api/v1/webhooks/stopped-conn", {
+        method: "POST",
+      })
+    );
+    expect(response.status).toBe(404);
+  });
+});

--- a/packages/server/src/gateway/connections/chat-instance-manager.ts
+++ b/packages/server/src/gateway/connections/chat-instance-manager.ts
@@ -647,7 +647,22 @@ export class ChatInstanceManager {
     connectionId: string,
     request: Request
   ): Promise<Response> {
-    const instance = this.instances.get(connectionId);
+    // Multi-replica: the per-connection webhook route (`/api/v1/webhooks/:id`)
+    // calls us directly — unlike the Slack `/slack/events` coordinator path,
+    // which pre-warms the connection via `ensureConnectionRunning` before
+    // forwarding here. A connection created or restarted on another replica has
+    // no live instance on this pod, so lazily start it from the store first;
+    // otherwise an inbound webhook (a platform event OR a slash command) that
+    // lands on a pod which hasn't warmed this connection 404s. Slack events
+    // mostly survive that via Slack's retries, but a one-shot slash command
+    // (e.g. `/lobu link <code>`) does not. `ensureConnectionRunning` is a no-op
+    // when the instance is already running, so the coordinator's existing
+    // pre-call stays harmless. Mirrors `postMessageToChannel`.
+    let instance = this.instances.get(connectionId);
+    if (!instance) {
+      const running = await this.ensureConnectionRunning(connectionId);
+      instance = running ? this.instances.get(connectionId) : undefined;
+    }
     if (!instance) {
       return new Response("Connection not found", { status: 404 });
     }


### PR DESCRIPTION
## What was broken

The Slack Preview flow (`/lobu link <code>` to bind a chat to an agent) dead-ends in prod. Tested live against the working lobu-crm `@Lobster` bot:

- In a channel: Slackbot returns "/lobu failed because the app did not respond", and the preview claim stays unconsumed in `oauth_states` (no binding created).
- The lobu-crm bot replies to mentions fine, so it's not a dead connection.

## Root cause

The slash command (and the per-connection Event URL) hits `/api/v1/webhooks/:connectionId` → `ChatInstanceManager.handleWebhook()`, which looks up the Chat instance in the **pod-local** `this.instances` map and 404s if it isn't warm on the receiving pod. It's the only inbound path that doesn't hydrate the connection from the store first.

Prod runs `app.replicaCount: 2`. With ClientIP affinity, a webhook can land on the replica that never warmed this connection → instant 404. Slack events mostly survive because Slack retries 3x and eventually hits the warm pod, but a one-shot slash command doesn't tolerate that, so it surfaced as "app did not respond" + an unconsumed claim. It worked end-to-end when the app ran a single replica.

The `/slack/events` coordinator (`handleAppWebhook`) and `postMessageToChannel` already do the right thing — `ensureConnectionRunning()` before forwarding. `handleWebhook` just never adopted it.

## Fix

`handleWebhook` now calls `ensureConnectionRunning(connectionId)` before giving up — the same store-backed lazy-start the coordinator and `postMessageToChannel` use. It's a no-op when the instance is already running, so the coordinator's existing pre-call stays harmless. Any replica can now serve any connection's inbound webhook.

## Reproducer (red → green)

`packages/server/src/gateway/__tests__/chat-instance-manager-slack.test.ts` — "ChatInstanceManager.handleWebhook (multi-replica)":

- **Red** (without the fix): a cold-pod webhook returns 404, `restartConnection` never called.
- **Green** (with the fix): the cold-pod webhook hydrates from the store and is handled (200). A stopped connection still 404s (no auto-revive).

```
 2 pass / 0 fail   (handleWebhook multi-replica)
```

## Remaining (separate follow-ups, not in this PR)
- Preview claim hardening: platform-scope the claim; check `allowedSurfaces` before deleting the code.
- `previewMode` provisioning seam (declare via `lobu apply` instead of a manual DB edit).
- The bot's AI-app DM is a threaded surface; Slack blocks slash commands there, so DM-based linking needs a message-based path. Channel linking works with this fix.

## Live verification still owed
Prod runs the old code; the live `/lobu link` retest happens after this merges and Flux rolls out the new image.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced webhook delivery reliability in multi-instance deployments. Chat connections are now automatically loaded on-demand when processing incoming webhooks, improving availability and responsiveness.

* **Tests**
  * Added test coverage for webhook handling in multi-replica scenarios, including connection startup and error handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lobu-ai/lobu/pull/1098?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->