### PR TITLE
fix: garbled finalText under divergent-final

### DIFF
--- a/packages/agent-worker/src/__tests__/final-text-authoritative.test.ts
+++ b/packages/agent-worker/src/__tests__/final-text-authoritative.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Reproducer: `signalCompletion()` must send an AUTHORITATIVE `finalText`.
+ *
+ * `finalText` is the multi-replica delivery mechanism (PR #1087): a possibly-
+ * different replica than the one that streamed delivers it to Slack and
+ * persists it to chat history (gateway `chat-response-bridge.ts` /
+ * `platform-strategies/index.ts`).
+ *
+ * Bug (CodeRabbit, merged #1087): in `sendStreamDelta(...)`'s `isFinal`
+ * "content differs" branch, the FULL final `delta` was pushed onto
+ * `accumulatedStreamContent` — which already held the *partial streamed*
+ * content. So `accumulatedStreamContent.join("")` (the old `finalText` source)
+ * became `partial_stream + full_final` → a garbled `finalText` delivered
+ * cross-pod and written to history.
+ *
+ * These tests drive the divergent-final branch and assert `finalText` equals
+ * the authoritative full final, not partial+full. The happy paths (final
+ * identical to / a prefix-extension of the stream) are also covered to guard
+ * the dedupe optimizations.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import type { WorkerTransportConfig } from "@lobu/core";
+import { HttpWorkerTransport } from "../gateway/gateway-integration";
+import type { ResponseData } from "../gateway/types";
+
+const baseConfig: WorkerTransportConfig = {
+  gatewayUrl: "https://test-gateway.example.com",
+  workerToken: "test-worker-token",
+  userId: "U123",
+  channelId: "C123",
+  conversationId: "CONV123",
+  originalMessageTs: "1700000000.000100",
+  teamId: "T123",
+  platform: "slack",
+};
+
+let originalFetch: typeof globalThis.fetch;
+let sentPayloads: ResponseData[];
+
+beforeEach(() => {
+  originalFetch = globalThis.fetch;
+  sentPayloads = [];
+  // Capture every payload POSTed to the gateway's /worker/response endpoint.
+  globalThis.fetch = (async (
+    _url: string | URL | Request,
+    init?: RequestInit
+  ) => {
+    if (init?.body) {
+      sentPayloads.push(JSON.parse(init.body as string));
+    }
+    return new Response(null, { status: 200 });
+  }) as typeof globalThis.fetch;
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+/** The `finalText` carried on the terminal completion row. */
+function completionFinalText(): string | undefined {
+  const completion = sentPayloads.find((p) => "finalText" in p);
+  return completion?.finalText;
+}
+
+describe("HttpWorkerTransport finalText is authoritative", () => {
+  test("divergent final: finalText is the full final, NOT partial+full", async () => {
+    const transport = new HttpWorkerTransport(baseConfig);
+
+    // Stream a couple of partial deltas.
+    await transport.sendStreamDelta("Hello ");
+    await transport.sendStreamDelta("wor");
+
+    // Final result that is neither identical to nor a prefix-extension of the
+    // accumulated stream ("Hello wor") → the "content differs" branch.
+    const finalAnswer = "Completely different answer.";
+    await transport.sendStreamDelta(finalAnswer, false, true);
+
+    await transport.signalCompletion();
+
+    // The OLD logic produced "Hello wor" + "Completely different answer."
+    // (accumulatedStreamContent.join("")). The fix sends the authoritative
+    // full final only.
+    expect(completionFinalText()).toBe(finalAnswer);
+    expect(completionFinalText()).not.toBe(
+      "Hello worCompletely different answer."
+    );
+    expect(completionFinalText()).not.toContain("Hello wor");
+  });
+
+  test("prefix-extension final: finalText is the full final text", async () => {
+    const transport = new HttpWorkerTransport(baseConfig);
+
+    await transport.sendStreamDelta("Hello ");
+    await transport.sendStreamDelta("wor");
+    // Final extends the stream (accumulated is a prefix of the final).
+    await transport.sendStreamDelta("Hello world!", false, true);
+
+    await transport.signalCompletion();
+
+    expect(completionFinalText()).toBe("Hello world!");
+  });
+
+  test("identical final: finalText is the full final text", async () => {
+    const transport = new HttpWorkerTransport(baseConfig);
+
+    await transport.sendStreamDelta("Hello ");
+    await transport.sendStreamDelta("world");
+    // Final identical to accumulated → dedupe skips the duplicate delta send,
+    // but finalText must still be authoritative.
+    await transport.sendStreamDelta("Hello world", false, true);
+
+    await transport.signalCompletion();
+
+    expect(completionFinalText()).toBe("Hello world");
+  });
+
+  test("pure streaming (no explicit final): finalText falls back to the stream", async () => {
+    const transport = new HttpWorkerTransport(baseConfig);
+
+    await transport.sendStreamDelta("Hello ");
+    await transport.sendStreamDelta("world");
+
+    // No isFinal delta was sent — the accumulation IS the final text.
+    await transport.signalCompletion();
+
+    expect(completionFinalText()).toBe("Hello world");
+  });
+
+  test("signalDone with a divergent final delta yields the authoritative finalText", async () => {
+    const transport = new HttpWorkerTransport(baseConfig);
+
+    await transport.sendStreamDelta("Hello ");
+    await transport.sendStreamDelta("wor");
+
+    // signalDone(finalDelta) sends the final delta (isFinal) then completes.
+    await transport.signalDone("Completely different answer.");
+
+    expect(completionFinalText()).toBe("Completely different answer.");
+  });
+});

--- a/packages/agent-worker/src/__tests__/final-text-authoritative.test.ts
+++ b/packages/agent-worker/src/__tests__/final-text-authoritative.test.ts
@@ -42,10 +42,11 @@ beforeEach(() => {
   originalFetch = globalThis.fetch;
   sentPayloads = [];
   // Capture every payload POSTed to the gateway's /worker/response endpoint.
-  globalThis.fetch = (async (
-    _url: string | URL | Request,
-    init?: RequestInit
-  ) => {
+  // `fetch(url, init)` — we only need `init` (the second positional arg), so
+  // bind the args via rest and read index 1 rather than naming an unused URL
+  // parameter.
+  globalThis.fetch = (async (...args: Parameters<typeof globalThis.fetch>) => {
+    const init = args[1];
     if (init?.body) {
       sentPayloads.push(JSON.parse(init.body as string));
     }

--- a/packages/agent-worker/src/gateway/gateway-integration.ts
+++ b/packages/agent-worker/src/gateway/gateway-integration.ts
@@ -32,6 +32,16 @@ export class HttpWorkerTransport implements WorkerTransport {
   private platformMetadata?: Record<string, unknown>;
   private accumulatedStreamContent: string[] = [];
   private lastStreamDelta: string = "";
+  // The authoritative full assistant text, recorded whenever the worker sees
+  // an explicit final result (the `isFinal` delta). `signalCompletion()` sends
+  // THIS as `finalText` rather than re-deriving it from the append-only
+  // `accumulatedStreamContent` dedupe buffer. The buffer can hold
+  // partial_stream + full_final in the divergent-final case (when the final
+  // result is neither identical to nor a prefix-extension of what was
+  // streamed), which would garble the cross-pod/history `finalText`.
+  // `undefined` until an explicit final is seen — pure-streaming turns fall
+  // back to the accumulation (which IS the final text there).
+  private finalText?: string;
 
   constructor(config: WorkerTransportConfig) {
     this.gatewayUrl = config.gatewayUrl;
@@ -68,6 +78,12 @@ export class HttpWorkerTransport implements WorkerTransport {
 
     // Handle final result with deduplication
     if (isFinal) {
+      // `delta` is the complete final assistant text. Record it as the
+      // authoritative `finalText` regardless of which dedupe branch we take
+      // below — the dedupe only controls what (if anything) is *streamed* to
+      // the client, never what the terminal completion row carries cross-pod.
+      this.finalText = delta;
+
       logger.info(`🔍 Processing final result with deduplication`);
       logger.info(`Final text length: ${delta.length} chars`);
       const accumulatedStr = this.accumulatedStreamContent.join("");
@@ -144,10 +160,16 @@ export class HttpWorkerTransport implements WorkerTransport {
     // (Slack) that completes on a different replica has no buffer and would
     // drop the reply. `finalText` makes the completion self-contained so any
     // replica can deliver it. (Empty string when nothing was streamed.)
+    //
+    // Prefer the authoritative final recorded from the `isFinal` delta. Only
+    // fall back to the accumulated stream buffer when no explicit final was
+    // seen (a pure-streaming turn, where the accumulation IS the final text).
+    // Re-deriving from the buffer unconditionally would garble the divergent-
+    // final case, where it holds partial_stream + full_final.
     await this.sendResponse(
       this.buildBaseResponse({
         processedMessageIds: this.processedMessageIds,
-        finalText: this.accumulatedStreamContent.join(""),
+        finalText: this.finalText ?? this.accumulatedStreamContent.join(""),
       })
     );
   }


### PR DESCRIPTION
## The bug

`HttpWorkerTransport.signalCompletion()` (`packages/agent-worker/src/gateway/gateway-integration.ts`) derived `finalText` from `accumulatedStreamContent.join("")` — the append-only dedupe buffer.

In `sendStreamDelta()`'s `isFinal` "content differs" branch (the case the code itself warns about with `⚠️ Final result differs from accumulated content!`), `actualDelta` stays equal to the FULL final `delta`, and that full final is then pushed onto `accumulatedStreamContent`, which already holds the *partial streamed* content. So `accumulatedStreamContent.join("")` = `partial_stream + full_final` → a garbled string.

The happy paths (final identical to, or a prefix-extension of, the stream) are fine; only the divergent-final case garbles.

## Cross-pod / history impact

`finalText` is the PR #1087 multi-replica delivery mechanism. Under N>1 replicas (prod reality, `sessionAffinity: ClientIP`), a possibly-different replica than the one that streamed the deltas delivers the reply to Slack and persists it to chat history:
- gateway `platform-strategies/index.ts` `SlackResponseStrategy` → `payload.finalText ?? stream?.buffer ?? ""`
- gateway `chat-response-bridge.ts` `handleCompletion` history persistence → `payload.finalText ?? stream?.buffer`

So when the final diverged, the garbled `partial_stream + full_final` was delivered to Slack and written to chat history.

## Fix (finalText authoritative; minimal, model-independent)

Track the authoritative full final assistant text in a new `private finalText?: string`, recorded from the `isFinal` delta in `sendStreamDelta()` regardless of which dedupe branch is taken (the dedupe only governs what is *streamed* to the client, never what the terminal completion row carries). `signalCompletion()` sends that field, falling back to `accumulatedStreamContent.join("")` only when no explicit final was recorded (pure-streaming turns, where the accumulation IS the final). The streaming dedupe (identical/prefix/normalized) is unchanged; only the `finalText` SOURCE changes. The gateway contract (`payload.finalText`) is unchanged — finalText is just correct now.

## Reproducer (red → green, deterministic, no live model)

New unit test `packages/agent-worker/src/__tests__/final-text-authoritative.test.ts` mocks `globalThis.fetch` to capture the payloads POSTed to `/worker/response`:

1. Streams partial deltas `"Hello "`, `"wor"`.
2. Drives the `isFinal` "content differs" branch with `"Completely different answer."` (not identical to, not a prefix-extension of `"Hello wor"`).
3. Asserts `finalText === "Completely different answer."`, NOT `"Hello worCompletely different answer."`.

Also covers prefix-extension, identical, pure-streaming-fallback, and the `signalDone(finalDelta)` path.

**Red on old logic** (verified by temporarily reverting `signalCompletion()` to `accumulatedStreamContent.join("")`):
```
Expected: "Completely different answer."
Received: "Hello worCompletely different answer."
(fail) divergent final: finalText is the full final, NOT partial+full
(fail) signalDone with a divergent final delta yields the authoritative finalText
 3 pass, 2 fail
```
**Green with the fix:** `5 pass, 0 fail`.

## Validation

- `bunx tsc --noEmit` clean (agent-worker), `bun test` green (560 pass / 0 fail), `make build-packages` succeeds.

## CodeRabbit

This is the Major finding CodeRabbit flagged on the merged PR #1087: https://github.com/lobu-ai/lobu/pull/1087#discussion_r3305961183 ("Don't build `finalText` from the append-only dedupe buffer.").

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensures the terminal completion reliably shows the authoritative final text in streaming scenarios, preventing garbled or duplicated final content and making deduplication consistent with streamed output.

* **Tests**
  * Added end-to-end tests covering multiple streaming completion scenarios (divergent finals, prefix-extension, identical/deduped finals, pure streaming, and explicit final signals) to validate final-text delivery.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lobu-ai/lobu/pull/1099?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->