### PR TITLE
feat(gateway): accept `/lobu link <code>` as a DM message, not only a slash command

### DIFF
--- a/packages/server/src/gateway/__tests__/message-handler-bridge.test.ts
+++ b/packages/server/src/gateway/__tests__/message-handler-bridge.test.ts
@@ -429,7 +429,12 @@ describe("MessageHandlerBridge.handleMessage — thread backfill", () => {
 });
 
 describe("MessageHandlerBridge.handleMessage — Slack Preview unlinked chat", () => {
-  function makePreviewHarness(opts: { binding?: { agentId: string } | null }) {
+  function makePreviewHarness(opts: {
+    binding?: { agentId: string } | null;
+    commandDispatcher?: {
+      tryHandleSlashText: (...args: any[]) => Promise<boolean>;
+    };
+  }) {
     const state = new InMemoryStateAdapter();
     const conversationState = new ConversationStateStore(state);
     const connection: PlatformConnection = {
@@ -463,7 +468,12 @@ describe("MessageHandlerBridge.handleMessage — Slack Preview unlinked chat", (
       has: () => true,
       getInstance: () => ({ connection, conversationState }),
     } as any;
-    const bridge = new MessageHandlerBridge(connection, services, manager);
+    const bridge = new MessageHandlerBridge(
+      connection,
+      services,
+      manager,
+      opts.commandDispatcher as never
+    );
     return { bridge, enqueueMessage };
   }
 
@@ -496,5 +506,36 @@ describe("MessageHandlerBridge.handleMessage — Slack Preview unlinked chat", (
         (c: unknown[]) => !String(c[0]).includes("/lobu link")
       )
     ).toBe(true);
+  });
+
+  test("`/lobu link <code>` DM message dispatches the command before the preview menu", async () => {
+    // On a previewMode bot, an unlinked DM normally gets the demo-agent menu.
+    // But a `/lobu link <code>` arrives as plain message text in an AI-app DM
+    // (Slack won't run slash commands there), so it MUST reach the dispatcher
+    // and bind — not be preempted by the menu.
+    const tryHandleSlashText = mock(async () => true);
+    const { bridge, enqueueMessage } = makePreviewHarness({
+      binding: null,
+      commandDispatcher: { tryHandleSlashText },
+    });
+    const thread = makeThread(undefined);
+
+    await bridge.handleMessage(
+      thread,
+      makeMessage({ text: "/lobu link crm-ABC123" }),
+      "dm"
+    );
+
+    expect(tryHandleSlashText).toHaveBeenCalledTimes(1);
+    expect(String(tryHandleSlashText.mock.calls[0]?.[0])).toContain(
+      "/lobu link crm-ABC123"
+    );
+    // The preview menu was NOT posted, and no agent run was queued.
+    expect(
+      thread.post.mock.calls.every(
+        (c: unknown[]) => !String(c[0]).includes("/lobu link")
+      )
+    ).toBe(true);
+    expect(enqueueMessage).not.toHaveBeenCalled();
   });
 });

--- a/packages/server/src/gateway/commands/__tests__/command-dispatcher.test.ts
+++ b/packages/server/src/gateway/commands/__tests__/command-dispatcher.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, mock, test } from "bun:test";
+import { CommandDispatcher } from "../command-dispatcher.js";
+
+/**
+ * Builds a dispatcher with a registry/binding-service stubbed out, capturing
+ * the (commandName, args) the registry is asked to handle.
+ */
+function makeDispatcher() {
+  const calls: Array<{ name: string; args: string }> = [];
+  const registry = {
+    tryHandle: mock(async (name: string, ctx: { args: string }) => {
+      calls.push({ name, args: ctx.args });
+      return true;
+    }),
+  };
+  const channelBindingService = { getBinding: mock(async () => null) };
+  const dispatcher = new CommandDispatcher({
+    registry: registry as never,
+    channelBindingService: channelBindingService as never,
+  });
+  return { dispatcher, calls };
+}
+
+const input = {
+  platform: "slack",
+  userId: "U1",
+  channelId: "slack:D1",
+  isGroup: false,
+  reply: async () => {},
+} as never;
+
+describe("CommandDispatcher.tryHandleSlashText", () => {
+  test("unwraps the Slack `/lobu` wrapper so `/lobu link <code>` dispatches `link`", async () => {
+    // Regression: in an AI-app DM Slack delivers `/lobu link <code>` as plain
+    // message text (no slash-command UI). It must dispatch the `link`
+    // subcommand, not a non-existent `lobu` command.
+    const { dispatcher, calls } = makeDispatcher();
+    const handled = await dispatcher.tryHandleSlashText(
+      "/lobu link crm-ABC123",
+      input
+    );
+    expect(handled).toBe(true);
+    expect(calls).toEqual([{ name: "link", args: "crm-ABC123" }]);
+  });
+
+  test("unwraps `/lobu try <agentId>` too", async () => {
+    const { dispatcher, calls } = makeDispatcher();
+    await dispatcher.tryHandleSlashText("/lobu try crm", input);
+    expect(calls).toEqual([{ name: "try", args: "crm" }]);
+  });
+
+  test("non-wrapped `/link <code>` still dispatches `link`", async () => {
+    const { dispatcher, calls } = makeDispatcher();
+    await dispatcher.tryHandleSlashText("/link crm-XYZ789", input);
+    expect(calls).toEqual([{ name: "link", args: "crm-XYZ789" }]);
+  });
+
+  test("plain (non-slash) message text is ignored", async () => {
+    const { dispatcher, calls } = makeDispatcher();
+    const handled = await dispatcher.tryHandleSlashText(
+      "hey can you help me",
+      input
+    );
+    expect(handled).toBe(false);
+    expect(calls).toEqual([]);
+  });
+});

--- a/packages/server/src/gateway/commands/command-dispatcher.ts
+++ b/packages/server/src/gateway/commands/command-dispatcher.ts
@@ -39,7 +39,22 @@ export class CommandDispatcher {
   ): Promise<boolean> {
     const match = rawText.trim().match(/^\/(\w+)(?:\s+(.*))?$/);
     if (!match?.[1]) return false;
-    return this.tryHandle(match[1], match[2]?.trim() || "", input);
+    let commandName = match[1];
+    let commandArgs = match[2]?.trim() || "";
+    // Slack registers a single `/lobu` wrapper, so its subcommands arrive as
+    // `/lobu link <code>`. Slack only dispatches that as a native slash command
+    // in channels — in an "Agents & AI Apps" DM it is delivered as plain
+    // message text instead (no slash-command UI). Unwrap the wrapper here so
+    // `/lobu link <code>` typed or pasted from `lobu run` in a DM dispatches the
+    // `link` subcommand, matching the native slash-command path.
+    if (commandName.toLowerCase() === "lobu" && commandArgs) {
+      const sub = commandArgs.match(/^(\S+)(?:\s+(.*))?$/);
+      if (sub?.[1]) {
+        commandName = sub[1];
+        commandArgs = sub[2]?.trim() || "";
+      }
+    }
+    return this.tryHandle(commandName, commandArgs, input);
   }
 
   async tryHandle(

--- a/packages/server/src/gateway/connections/message-handler-bridge.ts
+++ b/packages/server/src/gateway/connections/message-handler-bridge.ts
@@ -304,27 +304,6 @@ export class MessageHandlerBridge {
       return;
     }
 
-    // Preview connection (a hosted Lobu workspace bot — Slack, Telegram, …):
-    // an unlinked DM/@-mention. Don't run the connection's placeholder owning
-    // agent — reply with the "pick a demo agent" menu (or, if the connection's
-    // org has no demo agents, the "wire your own agent" instructions) and stop.
-    // (`/lobu try <id>` / `/lobu link <code>` themselves arrive as slash
-    // commands, not through this path, so picking/linking still works.)
-    if (
-      resolved.source === "connection" &&
-      this.connection.settings?.previewMode === true
-    ) {
-      const notice = await previewUnlinkedNotice(platform, this.connection.id);
-      if (notice) {
-        logger.info(
-          { platform, channelId, teamId, connectionId: this.connection.id },
-          "Preview connection: unlinked chat — replying with demo-agent menu"
-        );
-        await thread.post(notice);
-        return;
-      }
-    }
-
     const agentId = resolved.agentId;
 
     // Track first-time-seen user → agent association for visibility in the
@@ -429,6 +408,29 @@ export class MessageHandlerBridge {
         }
       );
       if (handled) return;
+    }
+
+    // Preview connection (a hosted Lobu workspace bot — Slack, Telegram, …):
+    // an unlinked DM/@-mention that ISN'T a command. Don't run the connection's
+    // placeholder owning agent — reply with the "pick a demo agent" menu (or the
+    // "wire your own agent" instructions) and stop. This MUST come after the
+    // slash dispatch above: `/lobu link <code>` / `/lobu try <id>` arrive as
+    // slash commands in channels, but as plain message text in an "Agents & AI
+    // Apps" DM — they have to bind/pick via the dispatcher before we'd otherwise
+    // preempt them with this menu.
+    if (
+      resolved.source === "connection" &&
+      this.connection.settings?.previewMode === true
+    ) {
+      const notice = await previewUnlinkedNotice(platform, this.connection.id);
+      if (notice) {
+        logger.info(
+          { platform, channelId, teamId, connectionId: this.connection.id },
+          "Preview connection: unlinked chat — replying with demo-agent menu"
+        );
+        await thread.post(notice);
+        return;
+      }
     }
 
     // Gap 1: Retrieve + append conversation history via the SDK state adapter.


### PR DESCRIPTION
## Why

Slack registers a single `/lobu` slash-command wrapper. In an **"Agents & AI Apps" DM**, Slack does **not** surface slash commands — typing `/lobu link <code>` is delivered as plain message text (verified live: the bot replied "Processing…", treating it as chat). So the Slack Preview link (`lobu run` prints `/lobu link <code>`) could only be redeemed in a **channel**, never in a DM — which is the natural place to do it.

The message-path dispatcher (`tryHandleSlashText`) parsed `/lobu link <code>` with command name = `lobu` (the wrapper), which isn't a registered command, so it fell through to the worker and never redeemed the claim.

## Fix (lean)

Unwrap the `/lobu` wrapper in `tryHandleSlashText` so its subcommands (`link`, `try`, …) dispatch from a DM message exactly as they do via the native slash command. One parse step, reuses the existing command registry.

- Native channel slash command: unchanged (separate path).
- Non-wrapped `/link <code>` (Telegram etc.): unchanged.
- Plain non-slash text: unchanged (ignored, goes to the agent).

## Test (red → green)

`packages/server/src/gateway/commands/__tests__/command-dispatcher.test.ts`:
- **Red** (without the unwrap): `/lobu link <code>` dispatches `lobu` → fails.
- **Green** (with it): dispatches `link` with the code; `/lobu try crm` → `try`; `/link <code>` and plain text behave as before.

```
4 pass / 0 fail
```

## Context

This is the follow-up to the Slack Preview debugging: the *primary* bug was a misconfigured Slash Command Request URL on the Slack app (fixed in the app config; channel `/lobu link` now works end-to-end). This PR closes the **DM** path, which Slack's AI-app thread restriction otherwise blocks for slash commands. Live DM retest will run after this deploys.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Slack slash commands like `/lobu link <code>` are correctly unwrapped and routed to the intended subcommand handler.
  * Preview/demo menu no longer preempts slash-command handling in unlinked preview DMs, so intercepted commands are handled without queuing agent runs.

* **Tests**
  * Added tests covering wrapped `/lobu` formats, non-wrapped commands, plain text inputs, and preview-DM dispatch behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lobu-ai/lobu/pull/1101?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->