### PR TITLE
test(gateway): real-DB e2e for DM /lobu link consume→bind chain

### DIFF
--- a/packages/server/src/gateway/__tests__/dm-link-e2e.test.ts
+++ b/packages/server/src/gateway/__tests__/dm-link-e2e.test.ts
@@ -1,0 +1,119 @@
+/**
+ * Local end-to-end of the DM `/lobu link <code>` chain against a real Postgres:
+ * a plain message `/lobu link <code>` (how it arrives in an AI-app DM) →
+ * CommandDispatcher.tryHandleSlashText unwraps the `/lobu` wrapper → the real
+ * built-in `link` command → consumePreviewClaim → the binding row is written and
+ * the claim is consumed. No mocks for the consume/bind path — only the registry
+ * deps the `link` handler doesn't touch are stubbed.
+ */
+import { beforeAll, describe, expect, mock, test } from "bun:test";
+import { createHash } from "node:crypto";
+import { CommandRegistry } from "@lobu/core";
+import { getDb } from "../../db/client.js";
+import { registerBuiltInCommands } from "../commands/built-in-commands.js";
+import { CommandDispatcher } from "../commands/command-dispatcher.js";
+import { ensureDbForGatewayTests, seedAgentRow } from "./helpers/db-setup.js";
+
+beforeAll(async () => {
+  await ensureDbForGatewayTests();
+});
+
+// Mirrors codeHash() in preview/slack.ts (sha256 of the trimmed, lowercased code).
+function codeHash(code: string): string {
+  return createHash("sha256")
+    .update(code.trim().toLowerCase())
+    .digest("hex");
+}
+
+describe("DM /lobu link <code> — real consume→bind chain", () => {
+  test("a plain-message `/lobu link <code>` redeems the claim and writes the binding", async () => {
+    const sql = getDb();
+    const code = `crm-${Date.now().toString(36).toUpperCase()}`;
+    const agentId = `agent-e2e-${Date.now()}`;
+    const organizationId = `org-e2e-${Date.now()}`;
+    const channelId = `D${Date.now().toString(36)}`;
+    const canonical = `slack:${channelId}`;
+
+    // The binding has an FK on (organization_id, agent_id), so the agent must
+    // exist (seedAgentRow also creates the organization row).
+    await seedAgentRow(agentId, { organizationId });
+
+    // Seed the preview claim exactly as createPreviewClaim would.
+    await sql`
+      INSERT INTO oauth_states (id, scope, payload, expires_at)
+      VALUES (
+        ${codeHash(code)},
+        'slack-preview-claim',
+        ${sql.json({
+          organizationId,
+          agentId,
+          createdBy: null,
+          allowedSurfaces: ["dm", "channel"],
+          createdAt: Date.now(),
+        })},
+        now() + interval '1 hour'
+      )
+    `;
+
+    try {
+      // Real registry + real built-in commands. agentSettingsStore is unused by
+      // the `link` handler, so a stub is fine.
+      const registry = new CommandRegistry();
+      registerBuiltInCommands(registry, {
+        agentSettingsStore: {} as never,
+      });
+      const dispatcher = new CommandDispatcher({
+        registry,
+        channelBindingService: { getBinding: mock(async () => null) } as never,
+      });
+
+      const replies: string[] = [];
+      const handled = await dispatcher.tryHandleSlashText(
+        `/lobu link ${code}`,
+        {
+          platform: "slack",
+          userId: "U_E2E",
+          channelId,
+          teamId: "T_E2E",
+          isGroup: false,
+          reply: async (content: unknown) => {
+            replies.push(
+              typeof content === "string" ? content : JSON.stringify(content)
+            );
+          },
+        }
+      );
+
+      expect(handled).toBe(true);
+      expect(replies.join("\n")).toContain("Linked this chat to agent");
+      expect(replies.join("\n")).toContain(agentId);
+
+      // Claim consumed (one-time use).
+      const remaining = await sql`
+        SELECT 1 FROM oauth_states WHERE id = ${codeHash(code)}
+      `;
+      expect(remaining.length).toBe(0);
+
+      // Binding written under the canonical slack:<id> key, scoped to team+agent.
+      const binding = (await sql`
+        SELECT agent_id, organization_id, team_id
+        FROM agent_channel_bindings
+        WHERE platform = 'slack'
+          AND channel_id = ${canonical}
+          AND team_id = 'T_E2E'
+      `) as Array<{
+        agent_id: string;
+        organization_id: string;
+        team_id: string;
+      }>;
+      expect(binding.length).toBe(1);
+      expect(binding[0]?.agent_id).toBe(agentId);
+      expect(binding[0]?.organization_id).toBe(organizationId);
+    } finally {
+      await sql`DELETE FROM agent_channel_bindings WHERE channel_id = ${canonical}`;
+      await sql`DELETE FROM oauth_states WHERE id = ${codeHash(code)}`;
+      await sql`DELETE FROM agents WHERE id = ${agentId} AND organization_id = ${organizationId}`;
+      await sql`DELETE FROM organization WHERE id = ${organizationId}`;
+    }
+  });
+});


### PR DESCRIPTION
Integration test (real Postgres, not mocks) for the DM `/lobu link <code>` path landed in #1101.

It drives the actual chain: a plain-message `/lobu link <code>` → `CommandDispatcher.tryHandleSlashText` unwraps the `/lobu` wrapper → the real built-in `link` command → `consumePreviewClaim`, then asserts:
- the claim is consumed (one-time use), and
- an `agent_channel_bindings` row is written under the canonical `slack:<id>` key, scoped to the team + agent.

Seeds a real agent/org (FK on `(organization_id, agent_id)`) and cleans up after itself.

Verified locally green against a Postgres+pgvector instance.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive end-to-end testing for the DM link code flow, validating the complete workflow against a live database environment to ensure reliability and correctness of the linking functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lobu-ai/lobu/pull/1103?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->