### PR TITLE
feat(gateway): redeem preview link from plain DM message text

### DIFF
--- a/packages/server/src/gateway/__tests__/message-handler-bridge.test.ts
+++ b/packages/server/src/gateway/__tests__/message-handler-bridge.test.ts
@@ -5,6 +5,7 @@ import {
   ingestInboundAttachments,
   isSenderAllowed,
   MessageHandlerBridge,
+  parsePreviewLinkCode,
 } from "../connections/message-handler-bridge.js";
 import type { PlatformConnection } from "../connections/types.js";
 import { InMemoryStateAdapter } from "./fixtures/in-memory-state-adapter.js";
@@ -13,6 +14,39 @@ import {
   createArtifactTestEnv,
   TEST_GATEWAY_URL,
 } from "./setup.js";
+
+describe("parsePreviewLinkCode", () => {
+  test("bare code paste in a DM", () => {
+    expect(parsePreviewLinkCode("crm-TGHE0Z", false)).toBe("crm-TGHE0Z");
+  });
+  test("multi-segment slug bare code", () => {
+    expect(parsePreviewLinkCode("food-ordering-ABC123", false)).toBe(
+      "food-ordering-ABC123"
+    );
+  });
+  test("`link <code>`", () => {
+    expect(parsePreviewLinkCode("link crm-TGHE0Z", false)).toBe("crm-TGHE0Z");
+  });
+  test("`/lobu link <code>` delivered as text", () => {
+    expect(parsePreviewLinkCode("/lobu link crm-TGHE0Z", false)).toBe(
+      "crm-TGHE0Z"
+    );
+  });
+  test("`/link <code>`", () => {
+    expect(parsePreviewLinkCode("/link crm-TGHE0Z", false)).toBe("crm-TGHE0Z");
+  });
+  test("bare code is ignored in a channel (false-positive guard)", () => {
+    expect(parsePreviewLinkCode("crm-TGHE0Z", true)).toBeNull();
+  });
+  test("`link me` (no hyphenated code) is not a link", () => {
+    expect(parsePreviewLinkCode("link me", false)).toBeNull();
+  });
+  test("normal chatter is ignored", () => {
+    expect(
+      parsePreviewLinkCode("can you help me link the accounts", false)
+    ).toBeNull();
+  });
+});
 
 describe("isSenderAllowed", () => {
   test.each([
@@ -432,7 +466,8 @@ describe("MessageHandlerBridge.handleMessage — Slack Preview unlinked chat", (
   function makePreviewHarness(opts: {
     binding?: { agentId: string } | null;
     commandDispatcher?: {
-      tryHandleSlashText: (...args: any[]) => Promise<boolean>;
+      tryHandleSlashText?: (...args: any[]) => Promise<boolean>;
+      tryHandle?: (...args: any[]) => Promise<boolean>;
     };
   }) {
     const state = new InMemoryStateAdapter();
@@ -508,15 +543,16 @@ describe("MessageHandlerBridge.handleMessage — Slack Preview unlinked chat", (
     ).toBe(true);
   });
 
-  test("`/lobu link <code>` DM message dispatches the command before the preview menu", async () => {
+  test("`/lobu link <code>` DM message dispatches link before the preview menu", async () => {
     // On a previewMode bot, an unlinked DM normally gets the demo-agent menu.
-    // But a `/lobu link <code>` arrives as plain message text in an AI-app DM
-    // (Slack won't run slash commands there), so it MUST reach the dispatcher
-    // and bind — not be preempted by the menu.
-    const tryHandleSlashText = mock(async () => true);
+    // A `/lobu link <code>` arrives as plain message text in an AI-app DM (Slack
+    // won't run slash commands there), so it MUST reach the dispatcher and bind
+    // — not be preempted by the menu. parsePreviewLinkCode routes it to `link`.
+    const tryHandle = mock(async () => true);
+    const tryHandleSlashText = mock(async () => false);
     const { bridge, enqueueMessage } = makePreviewHarness({
       binding: null,
-      commandDispatcher: { tryHandleSlashText },
+      commandDispatcher: { tryHandle, tryHandleSlashText },
     });
     const thread = makeThread(undefined);
 
@@ -526,16 +562,38 @@ describe("MessageHandlerBridge.handleMessage — Slack Preview unlinked chat", (
       "dm"
     );
 
-    expect(tryHandleSlashText).toHaveBeenCalledTimes(1);
-    expect(String(tryHandleSlashText.mock.calls[0]?.[0])).toContain(
-      "/lobu link crm-ABC123"
-    );
+    expect(tryHandle).toHaveBeenCalledTimes(1);
+    expect(tryHandle.mock.calls[0]?.[0]).toBe("link");
+    expect(tryHandle.mock.calls[0]?.[1]).toBe("crm-ABC123");
     // The preview menu was NOT posted, and no agent run was queued.
     expect(
       thread.post.mock.calls.every(
         (c: unknown[]) => !String(c[0]).includes("/lobu link")
       )
     ).toBe(true);
+    expect(enqueueMessage).not.toHaveBeenCalled();
+  });
+
+  test("a bare preview-code paste in a DM dispatches link, not the menu", async () => {
+    const tryHandle = mock(async () => true);
+    const { bridge, enqueueMessage } = makePreviewHarness({
+      binding: null,
+      commandDispatcher: {
+        tryHandle,
+        tryHandleSlashText: mock(async () => false),
+      },
+    });
+    const thread = makeThread(undefined);
+
+    await bridge.handleMessage(
+      thread,
+      makeMessage({ text: "crm-ABC123" }),
+      "dm"
+    );
+
+    expect(tryHandle).toHaveBeenCalledTimes(1);
+    expect(tryHandle.mock.calls[0]?.[0]).toBe("link");
+    expect(tryHandle.mock.calls[0]?.[1]).toBe("crm-ABC123");
     expect(enqueueMessage).not.toHaveBeenCalled();
   });
 });

--- a/packages/server/src/gateway/__tests__/message-handler-bridge.test.ts
+++ b/packages/server/src/gateway/__tests__/message-handler-bridge.test.ts
@@ -465,6 +465,7 @@ describe("MessageHandlerBridge.handleMessage — thread backfill", () => {
 describe("MessageHandlerBridge.handleMessage — Slack Preview unlinked chat", () => {
   function makePreviewHarness(opts: {
     binding?: { agentId: string } | null;
+    previewMode?: boolean;
     commandDispatcher?: {
       tryHandleSlashText?: (...args: any[]) => Promise<boolean>;
       tryHandle?: (...args: any[]) => Promise<boolean>;
@@ -477,7 +478,7 @@ describe("MessageHandlerBridge.handleMessage — Slack Preview unlinked chat", (
       platform: "slack",
       agentId: TEMPLATE_AGENT_ID,
       config: { platform: "slack" } as any,
-      settings: { allowGroups: true, previewMode: true },
+      settings: { allowGroups: true, previewMode: opts.previewMode ?? true },
       metadata: { botUsername: "testbot", botUserId: "U_BOT" },
       status: "active",
       createdAt: 1,
@@ -595,5 +596,30 @@ describe("MessageHandlerBridge.handleMessage — Slack Preview unlinked chat", (
     expect(tryHandle.mock.calls[0]?.[0]).toBe("link");
     expect(tryHandle.mock.calls[0]?.[1]).toBe("crm-ABC123");
     expect(enqueueMessage).not.toHaveBeenCalled();
+  });
+
+  test("non-preview connection: a code-looking DM goes to the agent, not link", async () => {
+    // The plain-text link parsing is gated to previewMode bots. On a normal
+    // agent bot, `crm-ABC123` is just a message for the agent — it must NOT be
+    // swallowed by the link command.
+    const tryHandle = mock(async () => true);
+    const { bridge, enqueueMessage } = makePreviewHarness({
+      binding: null,
+      previewMode: false,
+      commandDispatcher: {
+        tryHandle,
+        tryHandleSlashText: mock(async () => false),
+      },
+    });
+    const thread = makeThread(undefined);
+
+    await bridge.handleMessage(
+      thread,
+      makeMessage({ text: "crm-ABC123" }),
+      "dm"
+    );
+
+    expect(tryHandle).not.toHaveBeenCalled();
+    expect(enqueueMessage).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/server/src/gateway/connections/message-handler-bridge.ts
+++ b/packages/server/src/gateway/connections/message-handler-bridge.ts
@@ -54,6 +54,30 @@ function deriveFilename(
 }
 
 /**
+ * Detect a preview-link redemption in plain message text. Slack blocks slash
+ * commands in an "Agents & AI Apps" DM, so `lobu run`'s `/lobu link <code>`
+ * can't be sent as a slash command there — Slack either rejects it ("not
+ * supported in threads") or, for a bot that registers `/lobu`, never delivers
+ * it as a message. So accept the code as plain text: `link <code>`, the
+ * `/lobu link <code>` / `/link <code>` forms when they do arrive as text, and a
+ * bare `<slug>-<CODE>` paste. Codes always contain a hyphen (`slug-SUFFIX`), so
+ * we require one to avoid matching chatter like "link me". The bare form is
+ * gated to DMs to avoid matching stray channel messages. Returns the code, or
+ * null. The native channel slash command and `tryHandleSlashText` still handle
+ * the `/`-prefixed forms.
+ */
+export function parsePreviewLinkCode(
+  text: string,
+  isGroup: boolean
+): string | null {
+  const t = text.trim();
+  const explicit = t.match(/^(?:\/?lobu\s+)?\/?link\s+(\S+)$/i);
+  if (explicit?.[1] && explicit[1].includes("-")) return explicit[1];
+  if (!isGroup && /^[a-z][a-z0-9-]*-[A-Z0-9]{6}$/.test(t)) return t;
+  return null;
+}
+
+/**
  * Inbound chat SDK attachment shape (loose subset of `chat.Attachment`).
  * Defined here so that this module — and its tests — don't have to take a
  * runtime dependency on the chat SDK.
@@ -390,6 +414,33 @@ export class MessageHandlerBridge {
       );
       await thread.post({ text: "Chat history cleared." });
       return;
+    }
+
+    // Preview-link redemption as plain message text. In an AI-app DM Slack
+    // won't deliver `/lobu link <code>` as a slash command, so accept the code
+    // as a message — `link <code>` or a bare `<slug>-<CODE>` paste — and redeem
+    // via the same `link` command. Runs before the worker enqueue (and before
+    // the previewMode menu below) so a pasted code binds instead of being
+    // treated as chat.
+    if (!sessionReset && this.commandDispatcher) {
+      const linkCode = parsePreviewLinkCode(messageText, isGroup);
+      if (linkCode) {
+        const handled = await this.commandDispatcher.tryHandle(
+          "link",
+          linkCode,
+          {
+            platform,
+            userId,
+            channelId,
+            teamId,
+            isGroup,
+            conversationId,
+            connectionId: this.connection.id,
+            reply: createChatReply((content) => thread.post(content)),
+          }
+        );
+        if (handled) return;
+      }
     }
 
     // Slash command dispatch — intercept before queueing to worker

--- a/packages/server/src/gateway/connections/message-handler-bridge.ts
+++ b/packages/server/src/gateway/connections/message-handler-bridge.ts
@@ -416,13 +416,18 @@ export class MessageHandlerBridge {
       return;
     }
 
-    // Preview-link redemption as plain message text. In an AI-app DM Slack
-    // won't deliver `/lobu link <code>` as a slash command, so accept the code
-    // as a message — `link <code>` or a bare `<slug>-<CODE>` paste — and redeem
-    // via the same `link` command. Runs before the worker enqueue (and before
-    // the previewMode menu below) so a pasted code binds instead of being
-    // treated as chat.
-    if (!sessionReset && this.commandDispatcher) {
+    // Preview-link redemption as plain message text — preview connections only.
+    // In an AI-app DM Slack won't deliver `/lobu link <code>` as a slash command,
+    // so a hosted preview bot accepts the code as a message — `link <code>` or a
+    // bare `<slug>-<CODE>` paste — and redeems via the same `link` command. Gated
+    // to previewMode so a normal agent bot's DMs (where a code-looking message is
+    // just chat for the agent) are never swallowed. Runs before the worker
+    // enqueue and the previewMode menu so a pasted code binds.
+    if (
+      !sessionReset &&
+      this.commandDispatcher &&
+      this.connection.settings?.previewMode === true
+    ) {
       const linkCode = parsePreviewLinkCode(messageText, isGroup);
       if (linkCode) {
         const handled = await this.commandDispatcher.tryHandle(


### PR DESCRIPTION
## Why
Slack blocks slash commands inside an "Agents & AI Apps" DM. Worse, a bot that registers `/lobu` (like the lobu-crm bot) has `/lobu link <code>` **eaten** as a blocked slash command there — verified live: Slackbot replies *"`/lobu` is not supported in threads"* and the gateway never sees it. So the Slack Preview link could only be redeemed in a channel, never in the DM where users naturally try it.

## Fix
`parsePreviewLinkCode` recognizes the link code in **plain message text** and routes it to the existing `link` command (→ `consumePreviewClaim`):
- `link <code>`
- `/lobu link <code>` / `/link <code>` when delivered as text (bots without `/lobu` registered)
- a bare `<slug>-<CODE>` paste (DM-only; hyphen required, so "link me" / chatter doesn't match)

Runs before the worker enqueue and before the previewMode menu, so a pasted code binds instead of being treated as chat.

This is the piece that makes DM linking actually work — the earlier `/lobu` unwrap (#1101) only helped bots that don't register the slash command.

## Tests
- `parsePreviewLinkCode` unit cases incl. false-positive guards (bare code ignored in channels; "link me" / chatter not matched).
- Handler tests: `/lobu link <code>` and a bare code in a DM dispatch `link` (menu not posted, no agent run).
- Existing real-DB consume→bind e2e (#1103) covers the chain.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced Slack preview link redemption with support for multiple input formats, including bare codes, text commands, and slash commands.
  * Improved routing for preview link handling in both direct messages and channels.

* **Tests**
  * Expanded test coverage for preview-mode link parsing and routing scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lobu-ai/lobu/pull/1104?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->