### PR TITLE
test(gateway): full-chain DM bare-code → real consume→bind e2e

### DIFF
--- a/packages/server/src/gateway/__tests__/dm-link-message-e2e.test.ts
+++ b/packages/server/src/gateway/__tests__/dm-link-message-e2e.test.ts
@@ -1,0 +1,148 @@
+/**
+ * Full-chain local e2e against a real Postgres: a bare preview-code **message**
+ * in a previewMode DM goes through MessageHandlerBridge.handleMessage →
+ * parsePreviewLinkCode → the real built-in `link` command → consumePreviewClaim,
+ * and the binding row is actually written + the claim consumed. No mocks on the
+ * consume/bind path. This is the exact flow the live Slack DM exercises.
+ */
+import { beforeAll, describe, expect, mock, test } from "bun:test";
+import { createHash } from "node:crypto";
+import { CommandRegistry } from "@lobu/core";
+import { getDb } from "../../db/client.js";
+import { registerBuiltInCommands } from "../commands/built-in-commands.js";
+import { CommandDispatcher } from "../commands/command-dispatcher.js";
+import { ConversationStateStore } from "../connections/conversation-state-store.js";
+import { MessageHandlerBridge } from "../connections/message-handler-bridge.js";
+import type { PlatformConnection } from "../connections/types.js";
+import { InMemoryStateAdapter } from "./fixtures/in-memory-state-adapter.js";
+import { ensureDbForGatewayTests, seedAgentRow } from "./helpers/db-setup.js";
+
+beforeAll(async () => {
+  await ensureDbForGatewayTests();
+});
+
+function codeHash(code: string): string {
+  return createHash("sha256")
+    .update(code.trim().toLowerCase())
+    .digest("hex");
+}
+
+describe("DM bare-code message → real consume→bind (previewMode)", () => {
+  test("a bare preview code DM binds the chat to the claim's agent", async () => {
+    const sql = getDb();
+    const suffix = Date.now().toString(36).toUpperCase().slice(-6).padStart(6, "0");
+    const code = `crm-${suffix}`;
+    const agentId = `agent-msg-e2e-${Date.now()}`;
+    const organizationId = `org-msg-e2e-${Date.now()}`;
+    const channelId = `D${Date.now().toString(36)}`;
+    const canonical = `slack:${channelId}`;
+
+    await seedAgentRow(agentId, { organizationId });
+    await sql`
+      INSERT INTO oauth_states (id, scope, payload, expires_at)
+      VALUES (
+        ${codeHash(code)}, 'slack-preview-claim',
+        ${sql.json({
+          organizationId,
+          agentId,
+          createdBy: null,
+          allowedSurfaces: ["dm", "channel"],
+          createdAt: Date.now(),
+        })},
+        now() + interval '1 hour'
+      )
+    `;
+
+    try {
+      // Real registry + real built-in `link` command + real dispatcher.
+      const registry = new CommandRegistry();
+      registerBuiltInCommands(registry, { agentSettingsStore: {} as never });
+      const dispatcher = new CommandDispatcher({
+        registry,
+        channelBindingService: { getBinding: mock(async () => null) } as never,
+      });
+
+      const conversationState = new ConversationStateStore(
+        new InMemoryStateAdapter()
+      );
+      const connection: PlatformConnection = {
+        id: "conn-msg-e2e",
+        platform: "slack",
+        agentId: "owner-agent",
+        config: { platform: "slack" } as never,
+        settings: { allowGroups: true, previewMode: true },
+        metadata: { botUsername: "bot", botUserId: "U_BOT" },
+        status: "active",
+        createdAt: 1,
+        updatedAt: 1,
+      };
+      const enqueueMessage = mock(async () => undefined);
+      const services = {
+        getArtifactStore: () => null,
+        getPublicGatewayUrl: () => "https://gateway.example.com",
+        getChannelBindingService: () => ({ getBinding: mock(async () => null) }),
+        getAgentMetadataStore: () => undefined,
+        getUserAgentsStore: () => undefined,
+        getTranscriptionService: () => undefined,
+        getAgentSettingsStore: () => undefined,
+        getDeclaredAgentRegistry: () => undefined,
+        getQueueProducer: () => ({ enqueueMessage }),
+      } as never;
+      const manager = {
+        has: () => true,
+        getInstance: () => ({ connection, conversationState }),
+      } as never;
+      const bridge = new MessageHandlerBridge(
+        connection,
+        services,
+        manager,
+        dispatcher
+      );
+
+      const posts: string[] = [];
+      const thread = {
+        id: channelId,
+        channelId,
+        adapter: undefined,
+        subscribe: mock(async () => undefined),
+        startTyping: mock(async () => undefined),
+        post: mock(async (c: unknown) =>
+          posts.push(typeof c === "string" ? c : JSON.stringify(c))
+        ),
+      };
+      const message = {
+        id: "M_E2E",
+        text: code,
+        author: { userId: "U_E2E", userName: "alice", isBot: false, isMe: false },
+        raw: { team_id: "T_E2E" },
+        attachments: [],
+        metadata: { dateSent: new Date(), edited: false },
+      };
+
+      await bridge.handleMessage(thread as never, message as never, "dm");
+
+      // The link reply was posted, the worker was NOT invoked.
+      expect(posts.join("\n")).toContain("Linked this chat to agent");
+      expect(posts.join("\n")).toContain(agentId);
+      expect(enqueueMessage).not.toHaveBeenCalled();
+
+      // Claim consumed + binding written under the canonical slack:<id> key.
+      const remaining = await sql`
+        SELECT 1 FROM oauth_states WHERE id = ${codeHash(code)}
+      `;
+      expect(remaining.length).toBe(0);
+      const binding = (await sql`
+        SELECT agent_id, organization_id FROM agent_channel_bindings
+        WHERE platform = 'slack' AND channel_id = ${canonical} AND team_id = 'T_E2E'
+      `) as Array<{ agent_id: string; organization_id: string }>;
+      expect(binding.length).toBe(1);
+      expect(binding[0]?.agent_id).toBe(agentId);
+      expect(binding[0]?.organization_id).toBe(organizationId);
+    } finally {
+      await sql`DELETE FROM agent_channel_bindings WHERE channel_id = ${canonical}`;
+      await sql`DELETE FROM oauth_states WHERE id = ${codeHash(code)}`;
+      await sql`DELETE FROM agents WHERE id = ${agentId} AND organization_id = ${organizationId}`;
+      await sql`DELETE FROM organization WHERE id = ${organizationId}`;
+    }
+  });
+});


### PR DESCRIPTION
Real-Postgres e2e of the exact flow the live Slack DM exercises: a bare preview-code message in a previewMode DM → `MessageHandlerBridge.handleMessage` → `parsePreviewLinkCode` → the real built-in `link` command → `consumePreviewClaim`. Asserts the claim is consumed and the `agent_channel_bindings` row is written under the canonical `slack:<id>` key. No mocks on the consume/bind path. Complements the unit tests in #1104 and the dispatcher-level e2e in #1103. Verified green locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **Tests**
  * Added comprehensive end-to-end test coverage for DM message linking and agent binding functionality to ensure proper handling of preview code messages and database state management.

---

**Note:** This release contains internal test improvements with no user-facing changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lobu-ai/lobu/pull/1105?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->