### PR TITLE
feat(examples): working npm-downloads custom connector for lobu-crm

### DIFF
--- a/examples/lobu-crm/README.md
+++ b/examples/lobu-crm/README.md
@@ -1,6 +1,6 @@
 # lobu-crm — Reference example
 
-A funnel CRM agent that tracks GitHub stars, X mentions, and HN posts.
+A funnel CRM agent that tracks GitHub stars, X mentions, HN posts, and npm pulls.
 Use this as a starting point for new projects. It shows every Lobu concept in one place.
 
 ## Structure
@@ -11,6 +11,7 @@ lobu-crm/                                  # single agent → dir: "." keeps it 
 ├── SOUL.md                                # Agent personality
 ├── IDENTITY.md                            # Agent identity
 ├── USER.md                                # User context
+├── npm-downloads.connector.ts             # Custom connector (connectorFromFile)
 ├── inbound-triage.reaction.ts             # Runs after watcher extraction
 ├── funnel-digest.reaction.ts              # Runs after watcher extraction
 └── skills/crm-ops/SKILL.md                # Agent skill (skillFromFile)
@@ -24,4 +25,5 @@ The built-in GitHub, X, Hacker News, and website connections are declared inline
 | File | What it shows |
 |------|--------------|
 | `lobu.config.ts` | Agent config, providers, network allowlist, entity + relationship + watcher definitions, connections, auth profiles |
+| `npm-downloads.connector.ts` | Custom connector with typed checkpoint + config against a live no-auth API (listed via `connectorFromFile`) |
 | `inbound-triage.reaction.ts` | Reaction script with typed `ReactionClient` |

--- a/examples/lobu-crm/lobu.config.ts
+++ b/examples/lobu-crm/lobu.config.ts
@@ -1,4 +1,5 @@
 import {
+  connectorFromFile,
   defineAgent,
   defineAuthProfile,
   defineConfig,
@@ -10,6 +11,7 @@ import {
   secret,
   skillFromFile,
 } from "@lobu/cli/config";
+import type NpmDownloadsConnector from "./npm-downloads.connector.ts";
 import type funnelDigestReaction from "./funnel-digest.reaction.ts";
 import type inboundTriageReaction from "./inbound-triage.reaction.ts";
 
@@ -370,7 +372,27 @@ const x_mentionsConn = defineConnection({
   ],
 });
 
+const npm_downloadsConn = defineConnection({
+  slug: "npm-downloads-lobu-cli",
+  connector: "npm-downloads",
+  name: "npm downloads — @lobu/cli",
+  config: { package: "@lobu/cli" },
+  feeds: [
+    {
+      feed: "weekly",
+      name: "Weekly downloads — @lobu/cli",
+      schedule: "0 8 * * 1",
+      config: { package: "@lobu/cli" },
+    },
+  ],
+});
+
 export default defineConfig({
+  connectors: [
+    connectorFromFile<typeof NpmDownloadsConnector>(
+      "./npm-downloads.connector.ts"
+    ),
+  ],
   org: "lobu-crm",
   orgName: "Lobu CRM",
   orgDescription:
@@ -382,6 +404,7 @@ export default defineConfig({
     competitor_changelogsConn,
     github_lobuConn,
     hn_lobuConn,
+    npm_downloadsConn,
     x_mentionsConn,
   ],
   authProfiles: [github_accountAuth, github_appAuth, x_accountAuth],

--- a/examples/lobu-crm/npm-downloads.connector.ts
+++ b/examples/lobu-crm/npm-downloads.connector.ts
@@ -1,0 +1,80 @@
+import {
+  ConnectorRuntime,
+  type SyncContext,
+  type SyncResult,
+} from "@lobu/connector-sdk";
+
+interface NpmDownloadsCheckpoint {
+  /** Period-end dates already emitted, so a re-poll of the same week is a no-op. */
+  seen_periods: string[];
+}
+
+interface NpmDownloadsConfig {
+  /** npm package name, e.g. "@lobu/cli". */
+  package: string;
+}
+
+/**
+ * npm-downloads connector — polls the public npm download-counts API
+ * (`api.npmjs.org`, no auth) for `config.package` and emits one event per
+ * new weekly period. Dedup via a rolling checkpoint of seen period-end dates.
+ * Auto-discovered by `lobu apply` via `connectorFromFile`.
+ *
+ * A real, working `connectorFromFile` showcase: ConnectorRuntime<C, F> with a
+ * typed checkpoint + config against a live public endpoint. Weekly npm pulls
+ * are a top-of-funnel adoption signal — they belong in the CRM next to stars
+ * and mentions.
+ */
+export default class NpmDownloadsConnector extends ConnectorRuntime<
+  NpmDownloadsCheckpoint,
+  NpmDownloadsConfig
+> {
+  readonly definition = {
+    key: "npm-downloads",
+    name: "npm downloads",
+    version: "1.0.0",
+    authSchema: { methods: [{ type: "none" as const }] },
+    feeds: { weekly: { key: "weekly", name: "Weekly downloads" } },
+  };
+
+  async sync(
+    ctx: SyncContext<NpmDownloadsCheckpoint, NpmDownloadsConfig>
+  ): Promise<SyncResult<NpmDownloadsCheckpoint>> {
+    const seen = new Set<string>(ctx.checkpoint?.seen_periods ?? []);
+    const pkg = ctx.config.package;
+    const res = await fetch(
+      `https://api.npmjs.org/downloads/point/last-week/${encodeURIComponent(pkg)}`
+    );
+    const point = (await res.json()) as {
+      downloads?: number;
+      start?: string;
+      end?: string;
+    };
+    // One event per never-seen weekly period, keyed by the period end date.
+    if (!point.end || seen.has(point.end)) {
+      return { events: [], checkpoint: { seen_periods: [...seen] } };
+    }
+    return {
+      events: [
+        {
+          origin_id: `${pkg}@${point.end}`,
+          origin_type: "npm_downloads_week",
+          title: `${pkg}: ${point.downloads ?? 0} downloads (${point.start} → ${point.end})`,
+          payload_text: `${point.downloads ?? 0} weekly npm downloads for ${pkg}.`,
+          occurred_at: new Date(point.end),
+          metadata: {
+            package: pkg,
+            downloads: point.downloads ?? 0,
+            period_start: point.start,
+            period_end: point.end,
+          },
+        },
+      ],
+      checkpoint: { seen_periods: [...seen, point.end].slice(-52) },
+    };
+  }
+
+  async execute() {
+    return { success: false, error: "no actions" };
+  }
+}


### PR DESCRIPTION
## What

Adds `examples/lobu-crm/npm-downloads.connector.ts` — a minimal but **working** custom connector — and wires it into the example via `connectorFromFile` + a `npm-downloads-lobu-cli` connection.

## Why

#1107 removed the `funnel-form` connector because its endpoint was dead (404, zero events). That was the example's only `connectorFromFile` demonstration. This restores the showcase with a connector that actually works:

- Polls the public npm download-counts API (`api.npmjs.org`, no auth) for `@lobu/cli`.
- Emits one event per new weekly period; dedups via a typed rolling checkpoint of seen period-end dates.
- Weekly npm pulls are a genuine top-of-funnel adoption signal, so it belongs next to the GitHub-stars / X-mentions / HN connections.

## Verification (ran against the live endpoint)
```
RUN 1 — events: 1
  @lobu/cli: 954 downloads (2026-05-20 → 2026-05-26)
  checkpoint: {"seen_periods":["2026-05-26"]}
RUN 2 (same week, with checkpoint) — events: 0   ✓ dedup
```
- `bunx tsc --noEmit` (workspace resolution): no errors in `lobu.config.ts` or `npm-downloads.connector.ts`.
- Pre-commit `tsc` + `biome` pass.

## Note
This is example/repo content; it isn't auto-applied to the live lobu-crm org (which is now UI-managed and has drifted from this config).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The CRM agent now supports npm package download metrics as an additional data source, automatically retrieving the latest metrics from the public npm registry on a weekly schedule

* **Documentation**
  * Updated README documentation to provide comprehensive information about the npm metrics integration feature, including detailed configuration steps and setup instructions

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lobu-ai/lobu/pull/1108?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->