### PR TITLE
fix(cli): init --from-org declares only org-owned types, not public/system

### DIFF
--- a/packages/cli/src/commands/_lib/init-from-org/__tests__/init-from-org.test.ts
+++ b/packages/cli/src/commands/_lib/init-from-org/__tests__/init-from-org.test.ts
@@ -797,4 +797,104 @@ describe("lobu init --from-org", () => {
     );
     expect(rel?.rules).toEqual([{ source: "contact", target: "company" }]);
   });
+
+  test("public/cross-org + system types are NOT declared (only owned ones)", async () => {
+    // The list endpoint returns the org's own types PLUS public types from
+    // OTHER orgs (and the system `$member`). Only the org's own, non-system
+    // types belong in a generated config — foreign ones would emit colliding
+    // `defineEntityType` keys that don't apply.
+    const dir = mkFixtureDir();
+    await initFromOrg({
+      targetDir: dir,
+      fetchImpl: buildFetch({
+        "/oauth/userinfo": () => ({
+          organizations: [{ id: "org-1", slug: "acme", name: "Acme Inc" }],
+        }),
+        "/agents/lone/config": () => ({ updatedAt: 0 }),
+        "/agents": () => ({ agents: [{ agentId: "lone", name: "Lone" }] }),
+        "watchers?include_details": () => ({ watchers: [] }),
+        manage_entity_schema: (body) => {
+          if (body.action === "list_rules") {
+            // The owned cross-org rel type binds an owned type to a NON-owned
+            // (public) one — that target must survive as a string ref.
+            if (body.slug === "tracked-via") {
+              return {
+                rules: [
+                  {
+                    id: 1,
+                    source_entity_type_slug: "lead",
+                    target_entity_type_slug: "investor",
+                  },
+                ],
+              };
+            }
+            return { rules: [] };
+          }
+          return {
+            entity_types: [
+              { slug: "lead", name: "Lead", organization_id: "org-1" },
+              { slug: "pilot", name: "Pilot", organization_id: "org-1" },
+              // System type owned by this org — server-provisioned, rejects create.
+              { slug: "$member", name: "Member", organization_id: "org-1" },
+              // Public type from another org.
+              {
+                slug: "investor",
+                name: "Investor",
+                organization_id: "org-pub",
+              },
+              // Same key as an owned type, but from a public org (a collision
+              // source if both were declared).
+              {
+                slug: "lead",
+                name: "Lead (foreign)",
+                organization_id: "org-pub",
+              },
+            ],
+            relationship_types: [
+              {
+                slug: "converted-to",
+                name: "Converted To",
+                organization_id: "org-1",
+              },
+              {
+                slug: "tracked-via",
+                name: "Tracked Via",
+                organization_id: "org-1",
+              },
+              {
+                slug: "invested-in",
+                name: "Invested In",
+                organization_id: "org-pub",
+              },
+            ],
+          };
+        },
+        manage_auth_profiles: () => ({ auth_profiles: [] }),
+        manage_connections: () => ({ connections: [] }),
+      }),
+    });
+
+    const source = readFileSync(join(dir, "lobu.config.ts"), "utf-8");
+    // Owned, non-system types are declared.
+    expect(source).toContain('key: "lead"');
+    expect(source).toContain('key: "pilot"');
+    expect(source).toContain('key: "converted-to"');
+    expect(source).toContain('key: "tracked-via"');
+    // Foreign (public-org) and system types are NOT declared.
+    expect(source).not.toContain('key: "investor"');
+    expect(source).not.toContain('key: "$member"');
+    expect(source).not.toContain('key: "invested-in"');
+    // The cross-org rule target survives as a string ref (the type isn't declared).
+    expect(source).toContain('target: "investor"');
+
+    // Round-trip: only the owned types land in DesiredState, exactly once each.
+    const { state } = await loadDesiredStateFromConfig({ cwd: dir });
+    expect(state.memorySchema.entityTypes.map((e) => e.slug).sort()).toEqual([
+      "lead",
+      "pilot",
+    ]);
+    expect(
+      state.memorySchema.relationshipTypes.map((r) => r.slug).sort()
+    ).toEqual(["converted-to", "tracked-via"]);
+  });
 });

--- a/packages/cli/src/commands/_lib/init-from-org/bootstrap.ts
+++ b/packages/cli/src/commands/_lib/init-from-org/bootstrap.ts
@@ -844,7 +844,10 @@ interface FetchedState {
   connectorDefinitions: RemoteConnectorDefinition[];
 }
 
-async function fetchOrgState(client: ApplyClient): Promise<FetchedState> {
+async function fetchOrgState(
+  client: ApplyClient,
+  orgId: string | undefined
+): Promise<FetchedState> {
   const [
     agentList,
     entityTypes,
@@ -920,13 +923,31 @@ async function fetchOrgState(client: ApplyClient): Promise<FetchedState> {
       }))
   );
 
+  // The entity/relationship-type `list` endpoints also return *public* types
+  // from OTHER orgs (`o.visibility = 'public'`) so the UI can reference them —
+  // but a generated config must only DECLARE the types this org owns, or it
+  // emits dozens of foreign `defineEntityType()` blocks with colliding keys
+  // (e.g. `product` from several public orgs) that won't apply. Mirror apply's
+  // `ownsDefinition` guard. `$`-prefixed types (e.g. `$member`) are server-
+  // provisioned system types that reject create — never declare them either.
+  // Rules that reference a non-owned type still render as a string ref
+  // (see `emitRelationshipType`), so cross-org bindings survive.
+  const ownsDefinition = (definitionOrgId: string | undefined): boolean =>
+    orgId === undefined ||
+    definitionOrgId === undefined ||
+    definitionOrgId === orgId;
+  const isOwnDeclarable = (d: {
+    slug: string;
+    organization_id?: string;
+  }): boolean => ownsDefinition(d.organization_id) && !d.slug.startsWith("$");
+
   return {
     agents,
     entityTypes: entityTypes
-      .slice()
+      .filter(isOwnDeclarable)
       .sort((a, b) => a.slug.localeCompare(b.slug)),
     relationshipTypes: relationshipTypes
-      .slice()
+      .filter(isOwnDeclarable)
       .sort((a, b) => a.slug.localeCompare(b.slug)),
     watchers,
     authProfiles: authProfiles
@@ -1131,11 +1152,13 @@ export async function initFromOrg(opts: InitFromOrgOptions): Promise<void> {
   printText(chalk.dim(`Bootstrapping from org: ${orgSlug}`));
   printText(chalk.dim(`Destination: ${targetDir}`));
 
-  // Org display name from the userinfo orgs list (no description endpoint).
+  // Org id + display name from the userinfo orgs list (no description endpoint).
+  // The id scopes type declarations to what this org owns (see fetchOrgState).
   const orgs = await client.listOrgs().catch(() => []);
-  const orgName = orgs.find((o) => o.slug === orgSlug)?.name;
+  const targetOrg = orgs.find((o) => o.slug === orgSlug);
+  const orgName = targetOrg?.name;
 
-  const state = await fetchOrgState(client);
+  const state = await fetchOrgState(client, targetOrg?.id);
   const project = generateProject(orgSlug, orgName, state);
 
   // Write lobu.config.ts.


### PR DESCRIPTION
## Bug

`lobu init --from-org <org>` generated a config polluted with entity/relationship types the org doesn't own. Against the live `lobu-crm` org it produced a **2688-line** config with ~50 foreign types (`investor`, `city`, `contract`, `account`…), **duplicate `defineEntityType` keys** (`product` ×4, `$member` ×6, `region` ×3), and the system `$member` type — none of which apply.

## Root cause

The server's entity/relationship-type `list` endpoints intentionally return the org's own types **plus** any `public` org's types (`o.visibility = 'public'`) so the UI can make cross-org references (e.g. `headquartered_in → atlas.city`). That's by design, and `apply` already guards it with `ownsDefinition` (diff.ts). But `init --from-org` (`bootstrap.ts`) applied **no** such guard — it serialized every returned row into a declaration. So in any deployment with public catalog orgs (atlas, market, …), every `from-org` run emitted foreign + colliding + system types.

## Fix

Mirror `apply`'s guard in `fetchOrgState`: keep only types whose `organization_id` matches the target org (resolved from the `listOrgs()` call bootstrap already makes) and whose slug isn't `$`-prefixed. Rules referencing a non-owned type still render as a **string ref** (`emitRelationshipType` already falls back), so cross-org bindings survive. `orgId` undefined → no filtering (safe fallback; existing fixtures without `organization_id` are unaffected).

## Verification (red → green)

New test `public/cross-org + system types are NOT declared`. With the filter disabled (**RED**) the generated config contains:
```
const MemberEntity = defineEntityType({ key: "$member", ... });
const investorEntity = defineEntityType({ key: "investor", ... });
const leadEntity   = defineEntityType({ key: "lead", ... });
const leadEntity2  = defineEntityType({ key: "lead", name: "Lead (foreign)" });  // ← collision
const trackedViaRel = defineRelationshipType({ rules: [{ source: leadEntity2, target: investorEntity }] }); // ← bound to the FOREIGN lead
```
→ test fails on `not.toContain('key: "investor"')`.

With the fix (**GREEN**): only `lead`, `pilot` (entities) and `converted-to`, `tracked-via` (relationships) are declared; the cross-org rule target survives as `target: "investor"` (string). Full `init-from-org` suite: **10 pass / 0 fail**. Pre-commit `tsc` + biome clean.

## Scope
CLI generator only — no server/runtime change. The server behavior (public-type sharing) is correct and untouched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `lobu init --from-org` to properly filter and exclude system types and foreign organization types from generated configuration files, ensuring only owned entity and relationship types are included.
  * Improved handling of cross-org relationship references, preserving them as string references even when target types are not locally declared.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lobu-ai/lobu/pull/1111?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->