### PR TITLE
refactor(cli)!: drop profile-cookie capture from browser-auth

### DIFF
--- a/packages/cli/src/__tests__/cli-ux.test.ts
+++ b/packages/cli/src/__tests__/cli-ux.test.ts
@@ -210,3 +210,28 @@ describe("agent scaffold", () => {
     expect(logs.join("\n")).toContain('name: "Sales \\"Bot\\" v2"');
   });
 });
+
+describe("memory browser-auth --help", () => {
+  test("advertises the CDP flags and not the removed cookie-copy flags", async () => {
+    const cliEntry = join(import.meta.dir, "..", "..", "bin", "lobu.js");
+    const proc = Bun.spawnSync({
+      cmd: [process.execPath, cliEntry, "memory", "browser-auth", "--help"],
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const out =
+      new TextDecoder().decode(proc.stdout) +
+      new TextDecoder().decode(proc.stderr);
+
+    // Present: the CDP-only surface.
+    expect(out).toContain("--connector");
+    expect(out).toContain("--auth-profile-slug");
+    expect(out).toContain("--remote-debug-port");
+    expect(out).toContain("--dedicated-profile");
+    expect(out).toContain("--check");
+
+    // Removed: the old cookie-copy capture flags.
+    expect(out).not.toContain("--launch-cdp");
+    expect(out).not.toContain("--chrome-profile");
+  });
+});

--- a/packages/cli/src/__tests__/cli-ux.test.ts
+++ b/packages/cli/src/__tests__/cli-ux.test.ts
@@ -13,6 +13,7 @@ import { loadDesiredStateFromConfig } from "../commands/_lib/apply/desired-state
 import { agentScaffoldCommand } from "../commands/agent";
 import { isPortFree } from "../commands/dev";
 import { initCommand } from "../commands/init";
+import { buildBrowserAuthData } from "../commands/memory/_lib/browser-auth-cmd";
 import { loadProjectLink, saveProjectLink } from "../internal/project-link";
 
 describe("isPortFree", () => {
@@ -208,6 +209,31 @@ describe("agent scaffold", () => {
       console.log = original;
     }
     expect(logs.join("\n")).toContain('name: "Sales \\"Bot\\" v2"');
+  });
+});
+
+describe("buildBrowserAuthData", () => {
+  // Regression guard: the connector-side cascade in
+  // @lobu/connector-sdk (acquire.ts, browser-network.ts,
+  // browser-scraper-utils.ts) short-circuits on `userDataDir` and tries
+  // Playwright launchPersistentContext, which can't reopen the profile
+  // dir the dedicated Chrome we just launched is holding. The auth_data
+  // payload we write to the auth profile must therefore expose `cdp_url`
+  // and MUST NOT expose `user_data_dir` — otherwise sync silently
+  // diverges from the CDP-attach contract.
+  test("payload contains cdp_url + captured_via + browser_profile and never user_data_dir", () => {
+    const payload = buildBrowserAuthData({
+      cdpUrl: "http://127.0.0.1:9222",
+      profileName: "linkedin",
+      capturedAt: "2026-05-28T00:00:00.000Z",
+    });
+    expect(payload).toEqual({
+      cdp_url: "http://127.0.0.1:9222",
+      captured_at: "2026-05-28T00:00:00.000Z",
+      captured_via: "cli",
+      browser_profile: "linkedin",
+    });
+    expect(payload).not.toHaveProperty("user_data_dir");
   });
 });
 

--- a/packages/cli/src/commands/memory/_lib/browser-auth-cmd.ts
+++ b/packages/cli/src/commands/memory/_lib/browser-auth-cmd.ts
@@ -1,25 +1,18 @@
 /**
  * Browser Auth Command
  *
- * Captures authentication cookies from the user's local Chrome browser
- * for browser-based connectors. On macOS, decrypts the Chrome cookie store
- * directly using the Keychain encryption key. On Linux, uses headless Chrome via CDP.
+ * Sets up browser auth for browser-based connectors by launching a dedicated
+ * Chrome with remote debugging and storing its CDP endpoint on the auth
+ * profile. The connector attaches over CDP at sync time (and harvests fresh
+ * cookies from that live session for the headless fallback). There is no
+ * profile-cookie copying — attaching to a real, logged-in Chrome is the only
+ * capture path.
  */
 
 import { spawn } from "node:child_process";
-import {
-  copyFileSync,
-  existsSync,
-  mkdirSync,
-  mkdtempSync,
-  readFileSync,
-  rmSync,
-} from "node:fs";
-import { get as httpGet } from "node:http";
-import { createServer } from "node:net";
-import { homedir, tmpdir } from "node:os";
+import { existsSync, mkdirSync } from "node:fs";
+import { homedir } from "node:os";
 import { join } from "node:path";
-import { createInterface } from "node:readline";
 import {
   type CdpVersionInfo,
   fetchCdpVersionInfo,
@@ -33,54 +26,14 @@ import { printText } from "./output.js";
 type ProfileShim = { config: Record<string, unknown> };
 const emptyProfile: ProfileShim = { config: {} };
 
-function getChromePaths(): { binary: string; profileDir: string } {
-  const home = homedir();
+function getChromeBinary(): string {
   if (process.platform === "darwin") {
-    return {
-      binary: "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
-      profileDir: join(home, "Library/Application Support/Google/Chrome"),
-    };
+    return "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome";
   }
   if (process.platform === "linux") {
-    return {
-      binary: "/usr/bin/google-chrome",
-      profileDir: join(home, ".config/google-chrome"),
-    };
+    return "/usr/bin/google-chrome";
   }
   throw new Error(`Unsupported platform: ${process.platform}`);
-}
-
-interface ChromeProfile {
-  dir: string;
-  name: string;
-  email: string;
-  isLastUsed: boolean;
-}
-
-interface BrowserCookie {
-  name?: string;
-  value?: string;
-  expires?: number;
-  httpOnly?: boolean;
-  secure?: boolean;
-}
-
-function listProfiles(profileDir: string): ChromeProfile[] {
-  const localStatePath = join(profileDir, "Local State");
-  if (!existsSync(localStatePath)) {
-    throw new Error(`Chrome Local State not found at ${localStatePath}`);
-  }
-
-  const localState = JSON.parse(readFileSync(localStatePath, "utf8"));
-  const infoCache = localState.profile?.info_cache ?? {};
-  const lastUsed = localState.profile?.last_used ?? "";
-
-  return Object.entries(infoCache).map(([dir, info]: [string, any]) => ({
-    dir,
-    name: info.name ?? dir,
-    email: info.user_name ?? "",
-    isLastUsed: dir === lastUsed,
-  }));
 }
 
 function sanitizeDirSegment(value: string): string {
@@ -137,167 +90,6 @@ function launchDedicatedChrome(params: {
   chrome.unref();
 }
 
-async function extractCookies(
-  chromeBinary: string,
-  profileDir: string,
-  chromeProfileDir: string,
-  domains: string[]
-): Promise<any[]> {
-  if (process.platform === "darwin") {
-    // Single source of truth lives in the connector SDK so the connector
-    // subprocess (mirror mode) and this CLI capture flow share one
-    // decryption codepath. The SDK helper takes an `allowDomains` list
-    // and returns Playwright-ready Cookie[]; we just pass through.
-    const { decryptChromeCookiesMacOS } = await import(
-      "@lobu/connector-sdk/browser-mirror"
-    );
-    printText(
-      "macOS will ask to access your browser's cookie encryption key.\n" +
-        'A system dialog from "security" will appear — click "Always Allow" to avoid future prompts.'
-    );
-    const result = await decryptChromeCookiesMacOS({
-      userDataRoot: profileDir,
-      sourceProfileDir: chromeProfileDir,
-      allowDomains: domains,
-    });
-    return result.cookies;
-  }
-  return extractCookiesCDP(chromeBinary, profileDir, chromeProfileDir, domains);
-}
-
-/**
- * Linux fallback: Launch headless Chrome with a copied cookie store
- * and extract via CDP. Works on Linux where cookies aren't encrypted
- * with a per-profile key.
- */
-async function extractCookiesCDP(
-  chromeBinary: string,
-  profileDir: string,
-  chromeProfileDir: string,
-  domains: string[]
-): Promise<any[]> {
-  const { chromium } = await import("playwright");
-
-  const port: number = await new Promise((resolve) => {
-    const srv = createServer();
-    srv.listen(0, () => {
-      const p = (srv.address() as any).port;
-      srv.close(() => resolve(p));
-    });
-  });
-
-  const tmpDir = mkdtempSync(join(tmpdir(), "lobu-auth-"));
-  mkdirSync(join(tmpDir, "Default"), { recursive: true });
-
-  const cookieSrc = join(profileDir, chromeProfileDir, "Cookies");
-  const journalSrc = join(profileDir, chromeProfileDir, "Cookies-journal");
-
-  if (!existsSync(cookieSrc)) {
-    rmSync(tmpDir, { recursive: true, force: true });
-    throw new Error(
-      `No Cookies file found in Chrome profile: ${chromeProfileDir}`
-    );
-  }
-
-  copyFileSync(cookieSrc, join(tmpDir, "Default/Cookies"));
-  if (existsSync(journalSrc)) {
-    copyFileSync(journalSrc, join(tmpDir, "Default/Cookies-journal"));
-  }
-
-  const chrome = spawn(
-    chromeBinary,
-    [
-      "--headless=new",
-      `--remote-debugging-port=${port}`,
-      "--remote-allow-origins=*",
-      `--user-data-dir=${tmpDir}`,
-      "--no-first-run",
-      "--no-default-browser-check",
-      "--disable-background-networking",
-      "--disable-sync",
-      "--profile-directory=Default",
-    ],
-    { detached: true, stdio: "ignore" }
-  );
-  chrome.unref();
-
-  try {
-    for (let i = 0; i < 15; i++) {
-      try {
-        await new Promise<void>((resolve, reject) => {
-          httpGet(`http://localhost:${port}/json/version`, (res) => {
-            res.on("data", () => {
-              /* drain */
-            });
-            res.on("end", () => resolve());
-          }).on("error", reject);
-        });
-        break;
-      } catch {
-        await new Promise((r) => setTimeout(r, 1000));
-      }
-    }
-
-    const browser = await chromium.connectOverCDP(`http://localhost:${port}`);
-    const context = browser.contexts()[0]!;
-    const page = context.pages()[0] || (await context.newPage());
-
-    const primaryDomain = domains[0]!;
-    const url = primaryDomain.startsWith("http")
-      ? primaryDomain
-      : `https://${primaryDomain}`;
-    await page.goto(url, { waitUntil: "domcontentloaded", timeout: 15000 });
-    await page.waitForTimeout(2000);
-
-    const cookieUrls = domains.map((d) =>
-      d.startsWith("http") ? d : `https://${d}`
-    );
-    const cookies = await context.cookies(cookieUrls);
-
-    await browser.close();
-    return cookies;
-  } finally {
-    try {
-      process.kill(chrome.pid!);
-    } catch {
-      /* ignore */
-    }
-    await new Promise((r) => setTimeout(r, 500));
-    try {
-      rmSync(tmpDir, { recursive: true, force: true });
-    } catch {
-      /* ignore */
-    }
-  }
-}
-
-function scoreAuthCookie(cookie: BrowserCookie): number {
-  const name = cookie.name?.toLowerCase() ?? "";
-  if (!name) return Number.NEGATIVE_INFINITY;
-  if (
-    /^(lang|li_theme|timezone|theme|locale|tz|visitor_id|guest_id)$/.test(name)
-  ) {
-    return Number.NEGATIVE_INFINITY;
-  }
-
-  let score = 0;
-  if (/(auth|token|session|sess|sid|jwt)/.test(name)) score += 100;
-  if (/_at$/.test(name)) score += 80;
-  if (cookie.httpOnly) score += 20;
-  if (cookie.secure) score += 10;
-  if ((cookie.value?.length ?? 0) >= 20) score += 5;
-  if ((cookie.expires ?? 0) > 0) score += 5;
-  return score;
-}
-
-function findLikelyAuthCookie(cookies: BrowserCookie[]): BrowserCookie | null {
-  const sorted = [...cookies].sort(
-    (a, b) => scoreAuthCookie(b) - scoreAuthCookie(a)
-  );
-  const best = sorted[0];
-  return best && scoreAuthCookie(best) > 0 ? best : null;
-}
-
 async function resolveConnectorDomains(
   connectorKey: string,
   domainsOverride: string | undefined,
@@ -343,9 +135,7 @@ async function resolveConnectorDomains(
 export interface BrowserAuthOptions {
   connector: string;
   domains?: string;
-  chromeProfile?: string;
   authProfileSlug?: string;
-  launchCdp?: boolean;
   remoteDebugPort?: string;
   dedicatedProfile?: string;
   check?: boolean;
@@ -358,7 +148,7 @@ export async function captureBrowserAuth(
   const cliProfile = emptyProfile;
   const connectorKey = args.connector;
 
-  // --check: verify stored cookies on an auth profile
+  // --check: verify the CDP endpoint stored on an auth profile is reachable.
   if (args.check) {
     if (!args.authProfileSlug) {
       printText("--check requires --auth-profile-slug");
@@ -437,236 +227,96 @@ export async function captureBrowserAuth(
     return;
   }
 
-  const { binary, profileDir } = getChromePaths();
+  const binary = getChromeBinary();
   if (!existsSync(binary)) {
     printText(`Chrome not found at ${binary}`);
     process.exitCode = 1;
     return;
   }
 
-  if (args.launchCdp) {
-    const profileName = args.dedicatedProfile || connectorKey;
-    const userDataDir = getDedicatedChromeProfileDir(profileName);
-    const port = parseInt(args.remoteDebugPort || "9222", 10);
-    if (!Number.isFinite(port) || port <= 0) {
-      printText(`Invalid --remoteDebugPort: ${args.remoteDebugPort}`);
-      process.exitCode = 1;
-      return;
-    }
-
-    const domains = await resolveConnectorDomains(
-      connectorKey,
-      args.domains,
-      cliProfile
-    );
-    const startUrl = domains?.[0]
-      ? domains[0].startsWith("http")
-        ? domains[0]
-        : `https://${domains[0].replace(/^\./, "")}`
-      : undefined;
-    const cdpUrl = `http://127.0.0.1:${port}`;
-
-    printText(`Launching dedicated Chrome profile at ${userDataDir}`);
-    printText(`CDP URL: ${cdpUrl}`);
-    launchDedicatedChrome({
-      chromeBinary: binary,
-      userDataDir,
-      port,
-      startUrl,
-    });
-
-    const info = await waitForCdpEndpoint(cdpUrl);
-    if (!info) {
-      printText(
-        `Chrome launched, but ${cdpUrl}/json/version did not become ready.`
-      );
-      process.exitCode = 1;
-      return;
-    }
-
-    printText(`CDP endpoint ready at ${cdpUrl}`);
-    if (info.Browser) {
-      printText(`Browser: ${info.Browser}`);
-    }
-
-    if (args.authProfileSlug) {
-      const mcpUrl = await resolveMcpEndpoint(cliProfile.config);
-
-      if (!mcpUrl) {
-        printText(
-          "No MCP URL configured. Store the CDP URL on the auth profile manually."
-        );
-      } else {
-        try {
-          const parsed = await restToolCall<any>(
-            mcpUrl,
-            "manage_auth_profiles",
-            {
-              action: "update_auth_profile",
-              auth_profile_slug: args.authProfileSlug,
-              auth_data: {
-                cdp_url: cdpUrl,
-                captured_at: new Date().toISOString(),
-                captured_via: "cli",
-                browser_profile: profileName,
-                user_data_dir: userDataDir,
-              },
-            }
-          );
-          if (parsed?.error) {
-            printText(`Error: ${parsed.error}`);
-            process.exitCode = 1;
-            return;
-          }
-          printText(`CDP URL stored on auth profile ${args.authProfileSlug}.`);
-        } catch (err) {
-          printText(
-            `Error: ${err instanceof Error ? err.message : String(err)}`
-          );
-          process.exitCode = 1;
-          return;
-        }
-      }
-    }
-
-    printText("\nNext steps:");
-    printText(
-      "  1. Sign into the site in the dedicated Chrome window if needed."
-    );
-    printText(
-      `  2. Run: lobu memory browser-auth --connector ${connectorKey}${args.authProfileSlug ? ` --auth-profile-slug ${args.authProfileSlug}` : ""} --check`
-    );
-    return;
-  }
-
-  const profiles = listProfiles(profileDir);
-  if (profiles.length === 0) {
-    printText("No Chrome profiles found");
+  const profileName = args.dedicatedProfile || connectorKey;
+  const userDataDir = getDedicatedChromeProfileDir(profileName);
+  const port = parseInt(args.remoteDebugPort || "9222", 10);
+  if (!Number.isFinite(port) || port <= 0) {
+    printText(`Invalid --remoteDebugPort: ${args.remoteDebugPort}`);
     process.exitCode = 1;
     return;
   }
-
-  let selectedProfile: ChromeProfile;
-
-  if (args.chromeProfile) {
-    const match = profiles.find(
-      (p) =>
-        p.name.toLowerCase() === args.chromeProfile!.toLowerCase() ||
-        p.dir.toLowerCase() === args.chromeProfile!.toLowerCase()
-    );
-    if (!match) {
-      printText(`Profile "${args.chromeProfile}" not found. Available:`);
-      for (const p of profiles) {
-        printText(
-          `  [${p.dir}] ${p.name} (${p.email})${p.isLastUsed ? " <- last used" : ""}`
-        );
-      }
-      process.exitCode = 1;
-      return;
-    }
-    selectedProfile = match;
-  } else {
-    printText("Chrome Profiles:");
-    for (let i = 0; i < profiles.length; i++) {
-      const p = profiles[i];
-      if (!p) continue;
-      printText(
-        `  [${i + 1}] ${p.name} (${p.email})${p.isLastUsed ? " <- last used" : ""}`
-      );
-    }
-
-    const rl = createInterface({
-      input: process.stdin,
-      output: process.stdout,
-    });
-    const answer = await new Promise<string>((resolve) => {
-      rl.question("\nPick a profile: ", resolve);
-    });
-    rl.close();
-
-    const idx = parseInt(answer, 10) - 1;
-    if (Number.isNaN(idx) || idx < 0 || idx >= profiles.length) {
-      printText("Invalid selection");
-      process.exitCode = 1;
-      return;
-    }
-    selectedProfile = profiles[idx]!;
-  }
-
-  printText(
-    `\nUsing profile: ${selectedProfile.name} (${selectedProfile.email})`
-  );
-  printText("Resolving connector domains...");
 
   const domains = await resolveConnectorDomains(
     connectorKey,
     args.domains,
     cliProfile
   );
-  if (!domains) {
-    process.exitCode = 1;
-    return;
-  }
+  const startUrl = domains?.[0]
+    ? domains[0].startsWith("http")
+      ? domains[0]
+      : `https://${domains[0].replace(/^\./, "")}`
+    : undefined;
+  const cdpUrl = `http://127.0.0.1:${port}`;
 
-  printText(`Cookie domains: ${domains.join(", ")}`);
-  printText("Extracting cookies...");
+  printText(`Launching dedicated Chrome profile at ${userDataDir}`);
+  printText(`CDP URL: ${cdpUrl}`);
+  launchDedicatedChrome({
+    chromeBinary: binary,
+    userDataDir,
+    port,
+    startUrl,
+  });
 
-  const cookies = await extractCookies(
-    binary,
-    profileDir,
-    selectedProfile.dir,
-    domains
-  );
-
-  if (cookies.length === 0) {
+  const info = await waitForCdpEndpoint(cdpUrl);
+  if (!info) {
     printText(
-      "No cookies found. Are you logged into the site in this Chrome profile?"
+      `Chrome launched, but ${cdpUrl}/json/version did not become ready.`
     );
     process.exitCode = 1;
     return;
   }
 
-  const authCookie = findLikelyAuthCookie(cookies as BrowserCookie[]);
-  if (!authCookie) {
-    printText(
-      "Warning: No likely auth cookie found. You may not be logged in."
-    );
+  printText(`CDP endpoint ready at ${cdpUrl}`);
+  if (info.Browser) {
+    printText(`Browser: ${info.Browser}`);
   }
-
-  printText(`Captured ${cookies.length} cookies`);
 
   if (args.authProfileSlug) {
-    printText("Saving cookies to auth profile...");
-
     const mcpUrl = await resolveMcpEndpoint(cliProfile.config);
 
     if (!mcpUrl) {
-      printText("No MCP URL configured. Store cookies manually.");
+      printText(
+        "No MCP URL configured. Store the CDP URL on the auth profile manually."
+      );
     } else {
       try {
         const parsed = await restToolCall<any>(mcpUrl, "manage_auth_profiles", {
           action: "update_auth_profile",
           auth_profile_slug: args.authProfileSlug,
           auth_data: {
-            cookies,
+            cdp_url: cdpUrl,
             captured_at: new Date().toISOString(),
             captured_via: "cli",
-            browser_profile: selectedProfile.name,
+            browser_profile: profileName,
+            user_data_dir: userDataDir,
           },
         });
         if (parsed?.error) {
           printText(`Error: ${parsed.error}`);
-        } else {
-          printText(`Cookies stored on auth profile ${args.authProfileSlug}.`);
+          process.exitCode = 1;
+          return;
         }
+        printText(`CDP URL stored on auth profile ${args.authProfileSlug}.`);
       } catch (err) {
         printText(`Error: ${err instanceof Error ? err.message : String(err)}`);
+        process.exitCode = 1;
+        return;
       }
     }
-  } else {
-    printText("\nCookies ready. To store on a browser auth profile:");
-    printText(
-      `  lobu memory browser-auth --connector ${connectorKey} --auth-profile-slug <SLUG> --chrome-profile "${selectedProfile.name}"`
-    );
   }
+
+  printText("\nNext steps:");
+  printText(
+    "  1. Sign into the site in the dedicated Chrome window if needed."
+  );
+  printText(
+    `  2. Run: lobu memory browser-auth --connector ${connectorKey}${args.authProfileSlug ? ` --auth-profile-slug ${args.authProfileSlug}` : ""} --check`
+  );
 }

--- a/packages/cli/src/commands/memory/_lib/browser-auth-cmd.ts
+++ b/packages/cli/src/commands/memory/_lib/browser-auth-cmd.ts
@@ -61,6 +61,29 @@ async function waitForCdpEndpoint(
   return null;
 }
 
+/**
+ * The auth_data payload we write to the auth profile after a successful
+ * CDP launch. Extracted so the unit test can pin its shape without
+ * spawning Chrome — see cli-ux.test.ts. The crucial invariant is that
+ * `user_data_dir` is NOT present: the connector-side cascade
+ * (acquire.ts / browser-network.ts / browser-scraper-utils.ts) prefers
+ * userDataDir over cdp_url and tries Playwright launchPersistentContext,
+ * which can't open a profile dir held by the dedicated Chrome we just
+ * launched. cdp_url alone keeps sync attaching live.
+ */
+export function buildBrowserAuthData(opts: {
+  cdpUrl: string;
+  profileName: string;
+  capturedAt: string;
+}) {
+  return {
+    cdp_url: opts.cdpUrl,
+    captured_at: opts.capturedAt,
+    captured_via: "cli" as const,
+    browser_profile: opts.profileName,
+  };
+}
+
 function launchDedicatedChrome(params: {
   chromeBinary: string;
   userDataDir: string;
@@ -290,19 +313,11 @@ export async function captureBrowserAuth(
         const parsed = await restToolCall<any>(mcpUrl, "manage_auth_profiles", {
           action: "update_auth_profile",
           auth_profile_slug: args.authProfileSlug,
-          // NB: don't persist user_data_dir alongside cdp_url. The
-          // connector-side cascade (acquire.ts / browser-network.ts /
-          // browser-scraper-utils.ts) all short-circuit on userDataDir and
-          // try Playwright launchPersistentContext — which can't open a
-          // profile dir already held by the dedicated Chrome we just
-          // launched (Single Lock). cdp_url alone gives the connector the
-          // attach path it needs.
-          auth_data: {
-            cdp_url: cdpUrl,
-            captured_at: new Date().toISOString(),
-            captured_via: "cli",
-            browser_profile: profileName,
-          },
+          auth_data: buildBrowserAuthData({
+            cdpUrl,
+            profileName,
+            capturedAt: new Date().toISOString(),
+          }),
         });
         if (parsed?.error) {
           printText(`Error: ${parsed.error}`);

--- a/packages/cli/src/commands/memory/_lib/browser-auth-cmd.ts
+++ b/packages/cli/src/commands/memory/_lib/browser-auth-cmd.ts
@@ -290,12 +290,18 @@ export async function captureBrowserAuth(
         const parsed = await restToolCall<any>(mcpUrl, "manage_auth_profiles", {
           action: "update_auth_profile",
           auth_profile_slug: args.authProfileSlug,
+          // NB: don't persist user_data_dir alongside cdp_url. The
+          // connector-side cascade (acquire.ts / browser-network.ts /
+          // browser-scraper-utils.ts) all short-circuit on userDataDir and
+          // try Playwright launchPersistentContext — which can't open a
+          // profile dir already held by the dedicated Chrome we just
+          // launched (Single Lock). cdp_url alone gives the connector the
+          // attach path it needs.
           auth_data: {
             cdp_url: cdpUrl,
             captured_at: new Date().toISOString(),
             captured_via: "cli",
             browser_profile: profileName,
-            user_data_dir: userDataDir,
           },
         });
         if (parsed?.error) {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1062,42 +1062,29 @@ Memory:
   memory
     .command("browser-auth")
     .description(
-      "Capture cookies from your local Chrome browser for a connector"
+      "Set up browser auth for a connector: launch a dedicated Chrome with remote debugging and store its CDP endpoint on the auth profile"
     )
     .requiredOption("--connector <key>", 'Connector key (e.g. "x")')
     .option("--domains <list>", "Comma-separated cookie domains override")
     .option(
-      "--chrome-profile <name>",
-      "Chrome profile name (interactive prompt if not specified)"
-    )
-    .option(
       "--auth-profile-slug <slug>",
-      "Browser auth profile slug to store cookies on"
-    )
-    .option(
-      "--launch-cdp",
-      "Launch a dedicated Chrome user-data-dir with remote debugging enabled"
+      "Browser auth profile slug to store the CDP endpoint on"
     )
     .option(
       "--remote-debug-port <port>",
-      "Remote debugging port for --launch-cdp",
+      "Remote debugging port for the dedicated Chrome",
       "9222"
     )
-    .option(
-      "--dedicated-profile <name>",
-      "Dedicated Chrome profile dir name for --launch-cdp"
-    )
+    .option("--dedicated-profile <name>", "Dedicated Chrome profile dir name")
     .option(
       "--check",
-      "Check if stored cookies for a browser auth profile are still valid"
+      "Check if the CDP endpoint stored on a browser auth profile is reachable"
     )
     .action(
       async (options: {
         connector: string;
         domains?: string;
-        chromeProfile?: string;
         authProfileSlug?: string;
-        launchCdp?: boolean;
         remoteDebugPort?: string;
         dedicatedProfile?: string;
         check?: boolean;

--- a/packages/connectors/src/README.md
+++ b/packages/connectors/src/README.md
@@ -175,10 +175,14 @@ authSchema: {
   methods: [{
     type: 'browser',
     capture: 'cli',             // How auth is captured:
-                                //   'cli'  - Extract cookies from Chrome via `lobu memory browser-auth`
-                                //   'cdp'  - Connect to Chrome via DevTools Protocol (port 9222)
-    requiredDomains: [           // Cookie domains to extract (for 'cli' capture)
-      'x.com',
+                                //   'cli'  - `lobu memory browser-auth` launches a dedicated Chrome
+                                //           with CDP enabled; user signs in once; the connector
+                                //           attaches over CDP at sync time (cdp_url stored on the
+                                //           auth profile).
+                                //   'cdp'  - Connect to a Chrome the user is already running with
+                                //           --remote-debugging-port=9222 (no dedicated profile).
+    requiredDomains: [           // Domains the connector needs an authenticated session on. Used
+      'x.com',                   // to verify the live Chrome session via the `--check` flow.
       '.x.com',
     ],
     defaultCdpUrl: 'auto',       // CDP URL (for 'cdp' capture). 'auto' detects local Chrome.
@@ -187,7 +191,7 @@ authSchema: {
 }
 ```
 
-Use `'cdp'` for services like Google that block headless browsers — it connects to the user's real Chrome session. Use `'cli'` for sites where extracted cookies are sufficient.
+Use `'cdp'` for services like Google that block headless browsers — it connects to the user's already-running Chrome session. Use `'cli'` for sites where attaching to a dedicated, user-signed-in Chrome (per auth profile) is acceptable.
 
 ## Feeds
 

--- a/packages/connectors/src/linkedin.ts
+++ b/packages/connectors/src/linkedin.ts
@@ -244,7 +244,7 @@ export default class LinkedInConnector extends ConnectorRuntime {
           capture: 'cli',
           requiredDomains: ['linkedin.com', '.linkedin.com'],
           description:
-            'Preferred auth mode for LinkedIn scraping. Captures your existing browser session cookies.',
+            'Preferred auth mode for LinkedIn scraping. The CLI launches a dedicated Chrome with remote debugging; you log into LinkedIn once and the connector attaches over CDP, harvesting cookies live from that session.',
         },
         {
           type: 'oauth',

--- a/packages/connectors/src/linkedin.ts
+++ b/packages/connectors/src/linkedin.ts
@@ -3,7 +3,9 @@
  *
  * Scrapes LinkedIn company pages via browser network interception.
  * Uses Playwright to navigate company pages and intercept Voyager API responses.
- * Auth via persisted browser cookies captured into a reusable browser auth profile.
+ * Auth via Chrome attach over CDP — the user signs in once to a dedicated
+ * Chrome window started by `lobu memory browser-auth`, and the connector
+ * connects to that live profile at sync time.
  *
  * Follows the same pattern as the X (Twitter) connector.
  */

--- a/packages/connectors/src/revolut.ts
+++ b/packages/connectors/src/revolut.ts
@@ -451,7 +451,7 @@ export default class RevolutConnector extends ConnectorRuntime {
 					defaultCdpUrl: "http://127.0.0.1:9222",
 					requiredDomains: REVOLUT_AUTH_DOMAINS,
 					description:
-						"Connect over CDP to a Chrome logged in to app.revolut.com: lobu memory browser-auth --connector revolut --launch-cdp (log in there, re-enter the passcode whenever Revolut expires the session).",
+						"Connect over CDP to a Chrome logged in to app.revolut.com: lobu memory browser-auth --connector revolut --auth-profile-slug <slug> (log in to the dedicated Chrome that opens, re-enter the passcode whenever Revolut expires the session).",
 				},
 			],
 		},

--- a/packages/landing/src/content/docs/reference/lobu-memory.md
+++ b/packages/landing/src/content/docs/reference/lobu-memory.md
@@ -176,24 +176,25 @@ lobu memory seed --org my-org --url https://lobu.ai/mcp
 
 ### `lobu memory browser-auth`
 
-Captures cookie state from your local Chrome for connectors that rely on a real browser session. `--connector` is required.
+Sets up browser auth for connectors that rely on a real browser session. The CLI launches a dedicated Chrome with remote debugging enabled and stores its CDP endpoint on the auth profile; the connector attaches over CDP at sync time and harvests fresh cookies live from that session. `--connector` is required.
 
 ```bash
+# Launch a debug Chrome and store the CDP endpoint on the auth profile.
+# A new Chrome window opens; sign into the site once and leave it open.
 lobu memory browser-auth --connector x --auth-profile-slug my-profile
+
+# Verify the CDP endpoint on a profile is still reachable.
 lobu memory browser-auth --connector x --auth-profile-slug my-profile --check
-lobu memory browser-auth --connector x --launch-cdp --remote-debug-port 9222
 ```
 
 | Flag | Description |
 |------|-------------|
 | `--connector <key>` | **Required.** Connector key (e.g. `x`) |
 | `--domains <list>` | Comma-separated cookie-domain override |
-| `--chrome-profile <name>` | Chrome profile name (prompts interactively if omitted) |
-| `--auth-profile-slug <slug>` | Browser auth profile slug to store cookies on |
-| `--launch-cdp` | Launch a dedicated Chrome user-data-dir with remote debugging enabled |
-| `--remote-debug-port <port>` | Remote debugging port for `--launch-cdp` (default `9222`) |
-| `--dedicated-profile <name>` | Dedicated Chrome profile dir name for `--launch-cdp` |
-| `--check` | Check whether stored cookies for a browser auth profile are still valid |
+| `--auth-profile-slug <slug>` | Browser auth profile slug to store the CDP endpoint on |
+| `--remote-debug-port <port>` | Remote debugging port for the dedicated Chrome (default `9222`) |
+| `--dedicated-profile <name>` | Dedicated Chrome profile dir name |
+| `--check` | Check whether the CDP endpoint stored on a browser auth profile is reachable |
 
 ## Skills
 

--- a/skills/lobu/SKILL.md
+++ b/skills/lobu/SKILL.md
@@ -131,14 +131,14 @@ lobu memory health --url <mcp-url> --org <org-slug>
 
 ## Browser-Authenticated Connectors
 
-For connectors that need cookies from a local browser session:
+For connectors that need a real browser session, `browser-auth` launches a dedicated Chrome with remote debugging, stores its CDP endpoint on the auth profile, and the connector attaches over CDP at sync time (harvesting cookies live):
 
 ```bash
 lobu memory browser-auth --connector <key> --auth-profile-slug <slug>
 lobu memory browser-auth --connector <key> --auth-profile-slug <slug> --check
 ```
 
-Use `--chrome-profile`, `--launch-cdp`, and `--dedicated-profile` only when the user needs a specific browser profile or dedicated remote-debugging profile.
+Use `--dedicated-profile` only when you want a non-default dedicated Chrome profile directory; use `--remote-debug-port` to customize the CDP port (default `9222`).
 
 ## Tool Discipline
 


### PR DESCRIPTION
## Why

Profile-copying is the unreliable capture path:

- macOS Safe Storage decryption breaks across Chrome updates and is **fully blocked by recent app-bound cookie encryption**.
- The on-disk `Cookies` SQLite is **locked while Chrome runs** — users must close their browser to capture.
- Captured cookies are a **stale one-time snapshot** with no refresh.

CDP-attach (`--launch-cdp` Chrome with remote debugging) is the supported clean capture path: the connector attaches over CDP and harvests fresh cookies live; `acquire.ts`'s headless fallback reuses those. Removing the profile-copy capture from the CLI loses nothing the CDP path doesn't already cover.

## What changed

- Remove the non-`--launch-cdp` branch from `browser-auth-cmd.ts`: `listProfiles`, `extractCookies` (macOS Keychain decrypt), `extractCookiesCDP` (copy `Cookies` SQLite + headless extract), the cookie-scoring helpers, and the `ChromeProfile`/`BrowserCookie` types.
- Drop both dynamic imports (`@lobu/connector-sdk/browser-mirror`, `playwright`).
- Make the CDP-launch path the default; remove `--launch-cdp` and `--chrome-profile` flags.
- Kept: `--check`, `--domains`, `--auth-profile-slug`, `--remote-debug-port`, `--dedicated-profile`. `acquire.ts` (CDP + headless+stored-cookies + managed `userDataDir`) unchanged.

Diff: **2 files, +63 / −426**.

## Breaking change

`lobu memory browser-auth --connector <key>` now launches a dedicated debug Chrome instead of copying cookies from your real Chrome profile. The `--chrome-profile` and `--launch-cdp` flags are removed (`--launch-cdp` was the path now always taken).

## Validation

- `tsc --noEmit`: clean.
- `packages/server/.../tool-access.test.ts` drift detector: still satisfied — both `manage_connections` and `manage_auth_profiles` are called via `restToolCall`, no `'tools/call'`.
- Full `bun run build` blocked locally only by environment (Node v26 + unbuilt `@lobu/pgvector-embedded` in this worktree). CI runs under Node 22.

## Not in this PR (follow-ups)

- **Runtime mirror mode** — `connector-sdk/browser/mirror-cookies.ts` + `connector-run-cmd.ts` + `worker-api.ts` (`source_profile_dir`/`source_browser_root`) is the same profile-copying at sync time and should go next.
- **LinkedIn/X/Revolut migration** to a `browser.capture_network` batch op on the Lobu Chrome extension, so scrapers run through the existing logged-in Chrome via the extension's `chrome.debugger` Network domain — no CDP relay, no profile-copy, no separate Chrome. The architectural feasibility was verified live by driving Chrome through the Anthropic Chrome MCP (`navigate → scroll → read_network_requests`) against `linkedin.com/company/openai/posts/`.
- **LinkedIn intercept patterns are stale** — the connector still expects `/voyager/api/graphql`, but LinkedIn moved to obfuscated paths (live capture showed POSTs to `/7y6FLH5G-ARvFfccV`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Browser authentication now launches a dedicated Chrome with remote debugging and stores its CDP endpoint for live cookie capture during sync.
  * CLI flags updated: --auth-profile-slug, --remote-debug-port, --dedicated-profile, --check.

* **Documentation**
  * CLI reference, connector guides, and skill docs updated to describe the CDP-based workflow and updated flags.

* **Tests**
  * Added regression tests validating the auth payload shape and CLI help text (including new CDP flags and exclusion of legacy cookie-copy flags).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lobu-ai/lobu/pull/1114?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->