### PR TITLE
fix(gateway): allow Owletto extension origins through CORS

### DIFF
--- a/packages/server/src/__tests__/unit/cors-origin.test.ts
+++ b/packages/server/src/__tests__/unit/cors-origin.test.ts
@@ -1,0 +1,114 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { getOwnedOwlettoExtensionIds, isAllowedCorsOrigin } from '../../index';
+import { __resetPublicOriginCachesForTests } from '../../utils/public-origin';
+
+// The CORS callback at index.ts:285 must accept `chrome-extension://<our id>`
+// or the Owletto service worker's `/api/workers/poll` fetch fails the
+// preflight with "No 'Access-Control-Allow-Origin' header is present on the
+// requested resource" — exactly the regression we're closing.
+//
+// Behind a TLS-terminating proxy `c.req.url` is http://; we use the same
+// shape here so the canonical-origin check exercises the configured public
+// origin path.
+
+const REQUEST_URL = 'http://10.0.0.1/api/workers/poll';
+
+const ORIGINAL_PUBLIC_WEB_URL = process.env.PUBLIC_WEB_URL;
+
+function makeEnv(overrides: Record<string, string | undefined> = {}) {
+  return {
+    ENVIRONMENT: 'test',
+    ...overrides,
+  } as unknown as Parameters<typeof isAllowedCorsOrigin>[1];
+}
+
+beforeEach(() => {
+  process.env.PUBLIC_WEB_URL = 'https://app.lobu.ai';
+  __resetPublicOriginCachesForTests();
+});
+
+afterEach(() => {
+  if (ORIGINAL_PUBLIC_WEB_URL === undefined) {
+    delete process.env.PUBLIC_WEB_URL;
+  } else {
+    process.env.PUBLIC_WEB_URL = ORIGINAL_PUBLIC_WEB_URL;
+  }
+  __resetPublicOriginCachesForTests();
+});
+
+describe('getOwnedOwlettoExtensionIds', () => {
+  test('always includes the canonical published extension id', () => {
+    const ids = getOwnedOwlettoExtensionIds(makeEnv());
+    expect(ids).toContain('amnnhclgmbldmfcfamonoggjhfidemmm');
+  });
+
+  test('merges in well-formed ids from LOBU_OWLETTO_EXTENSION_IDS', () => {
+    const fakeDevId = 'abcdefghijklmnopabcdefghijklmnop'; // 32 chars, [a-p]
+    const ids = getOwnedOwlettoExtensionIds(
+      makeEnv({ LOBU_OWLETTO_EXTENSION_IDS: `  ${fakeDevId} , bogus-id, ` })
+    );
+    expect(ids).toContain('amnnhclgmbldmfcfamonoggjhfidemmm');
+    expect(ids).toContain(fakeDevId);
+    expect(ids).not.toContain('bogus-id');
+  });
+});
+
+describe('isAllowedCorsOrigin — chrome-extension://', () => {
+  test('accepts the canonical Owletto extension origin', () => {
+    expect(
+      isAllowedCorsOrigin(
+        'chrome-extension://amnnhclgmbldmfcfamonoggjhfidemmm',
+        makeEnv(),
+        REQUEST_URL
+      )
+    ).toBe(true);
+  });
+
+  test('accepts an extra id configured via LOBU_OWLETTO_EXTENSION_IDS', () => {
+    const fakeDevId = 'abcdefghijklmnopabcdefghijklmnop';
+    expect(
+      isAllowedCorsOrigin(
+        `chrome-extension://${fakeDevId}`,
+        makeEnv({ LOBU_OWLETTO_EXTENSION_IDS: fakeDevId }),
+        REQUEST_URL
+      )
+    ).toBe(true);
+  });
+
+  test('rejects an unknown chrome-extension origin', () => {
+    expect(
+      isAllowedCorsOrigin(
+        'chrome-extension://aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+        makeEnv(),
+        REQUEST_URL
+      )
+    ).toBe(false);
+  });
+
+  test('rejects http:// pretending to be the extension id (no protocol mismatch)', () => {
+    expect(
+      isAllowedCorsOrigin(
+        'http://amnnhclgmbldmfcfamonoggjhfidemmm',
+        makeEnv(),
+        REQUEST_URL
+      )
+    ).toBe(false);
+  });
+});
+
+describe('isAllowedCorsOrigin — regression coverage for pre-existing branches', () => {
+  test('still accepts the canonical https origin', () => {
+    expect(isAllowedCorsOrigin('https://app.lobu.ai', makeEnv(), REQUEST_URL)).toBe(true);
+  });
+
+  test('still accepts wildcard subdomains of the public origin', () => {
+    // PUBLIC_WEB_URL is app.lobu.ai → only `.app.lobu.ai` subdomains match
+    // without AUTH_COOKIE_DOMAIN. The sibling-zone case is exercised
+    // separately in the existing subdomain-zone tests.
+    expect(isAllowedCorsOrigin('https://acme.app.lobu.ai', makeEnv(), REQUEST_URL)).toBe(true);
+  });
+
+  test('still rejects an arbitrary third-party origin', () => {
+    expect(isAllowedCorsOrigin('https://evil.com', makeEnv(), REQUEST_URL)).toBe(false);
+  });
+});

--- a/packages/server/src/__tests__/unit/cors-origin.test.ts
+++ b/packages/server/src/__tests__/unit/cors-origin.test.ts
@@ -2,7 +2,8 @@ import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
 import { getOwnedOwlettoExtensionIds, isAllowedCorsOrigin } from '../../index';
 import { __resetPublicOriginCachesForTests } from '../../utils/public-origin';
 
-// The CORS callback at index.ts:285 must accept `chrome-extension://<our id>`
+// The Hono CORS middleware in packages/server/src/index.ts must accept
+// `chrome-extension://<our id>`
 // or the Owletto service worker's `/api/workers/poll` fetch fails the
 // preflight with "No 'Access-Control-Allow-Origin' header is present on the
 // requested resource" — exactly the regression we're closing.

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -91,12 +91,43 @@ export type { Env };
 
 const LOCALHOST_HOSTNAMES = new Set(['localhost', '127.0.0.1', '::1', '[::1]']);
 
-function isAllowedCorsOrigin(origin: string, _env: Env, requestUrl: string): boolean {
+// The published Owletto for Chrome extension ID, pinned via the manifest's
+// `key` field (see lobu-ai/owletto:apps/chrome/manifest.json). Identity for
+// CSP frame-ancestors AND CORS — both have to agree that this extension is
+// "us", otherwise either iframe embedding or fetch-from-SW breaks.
+const CANONICAL_OWLETTO_EXTENSION_ID = 'amnnhclgmbldmfcfamonoggjhfidemmm';
+
+const CHROME_EXTENSION_ID_RE = /^[a-p]{32}$/;
+
+/**
+ * Owned Owletto extension IDs (canonical + anything pinned via the
+ * LOBU_OWLETTO_EXTENSION_IDS env so a dev build with a different manifest
+ * key can be allowed alongside the published one). Same source for both
+ * the CSP frame-ancestors directive on HTML responses and the CORS
+ * allowlist that lets the service worker fetch /api/workers/poll.
+ */
+export function getOwnedOwlettoExtensionIds(env: Env): string[] {
+  const extra = (env.LOBU_OWLETTO_EXTENSION_IDS ?? '')
+    .split(',')
+    .map((s) => s.trim())
+    .filter((s) => CHROME_EXTENSION_ID_RE.test(s));
+  return [CANONICAL_OWLETTO_EXTENSION_ID, ...extra];
+}
+
+export function isAllowedCorsOrigin(origin: string, env: Env, requestUrl: string): boolean {
   let parsed: URL;
   try {
     parsed = new URL(origin);
   } catch {
     return false;
+  }
+
+  // The Owletto extension's service worker fetches /api/workers/poll as
+  // origin chrome-extension://<id>. Match against the same owned-IDs list
+  // the CSP block uses so the two trust boundaries can't drift.
+  if (parsed.protocol === 'chrome-extension:') {
+    const owned = new Set(getOwnedOwlettoExtensionIds(env));
+    return owned.has(parsed.hostname);
   }
 
   if (LOCALHOST_HOSTNAMES.has(parsed.hostname.toLowerCase())) {
@@ -334,22 +365,9 @@ app.use('/*', async (c, next) => {
     // Owletto for Chrome embeds the whole app in its sidepanel iframe —
     // not just a stub route, the same UI users get in a regular tab. To
     // allow that without opening clickjacking risk to every extension on
-    // the user's machine, we narrow the allow to OUR extension ID
-    // (pinned via apps/chrome/manifest.json's `key` field; see
-    // lobu-ai/owletto:apps/chrome/manifest.json).
-    // LOBU_OWLETTO_EXTENSION_IDS takes a comma-separated list so a dev
-    // build with a different manifest key can be allowed alongside the
-    // canonical published one.
-    const extraExtensionIds = (c.env.LOBU_OWLETTO_EXTENSION_IDS ?? '')
-      .split(',')
-      .map((s) => s.trim())
-      .filter((s) => /^[a-p]{32}$/.test(s));
-    const ownedExtensionIds = [
-      // canonical, derived from apps/chrome/manifest.json's `key`
-      'amnnhclgmbldmfcfamonoggjhfidemmm',
-      ...extraExtensionIds,
-    ];
-    const extensionAllowed = ownedExtensionIds
+    // the user's machine, we narrow the allow to OUR extension IDs (see
+    // getOwnedOwlettoExtensionIds — same list the CORS allowlist uses).
+    const extensionAllowed = getOwnedOwlettoExtensionIds(c.env)
       .map((id) => ` chrome-extension://${id}`)
       .join('');
     c.header(


### PR DESCRIPTION
## Symptom

After the http→https URL-normalization fix in owletto#238 (PR #1114), the Owletto Chrome extension's service worker still fails to poll the gateway:

\`\`\`
Access to fetch at 'https://app.lobu.ai/api/workers/poll' from origin
'chrome-extension://amnnhclgmbldmfcfamonoggjhfidemmm' has been blocked by
CORS policy: Response to preflight request doesn't pass access control
check: No 'Access-Control-Allow-Origin' header is present on the
requested resource.
\`\`\`

## Root cause

\`isAllowedCorsOrigin\` at \`packages/server/src/index.ts\` only allowed:
- localhost
- the canonical \`PUBLIC_WEB_URL\` origin
- wildcard subdomains of that origin
- subdomains of the auth-cookie zone

Chrome-extension URLs have an empty hostname, so they failed every branch and the Hono \`cors()\` middleware returned no \`Access-Control-Allow-Origin\` header. Preflight failed.

The CSP \`frame-ancestors\` block 50 lines below already had the right idea — it derived an \`ownedExtensionIds\` list from the canonical published ID + \`LOBU_OWLETTO_EXTENSION_IDS\`. The CORS check just never reused it.

## Fix

- Extracted \`getOwnedOwlettoExtensionIds(env)\` so the CSP frame-ancestors and CORS allowlist share one source of truth — the two trust boundaries can't drift.
- \`isAllowedCorsOrigin\` now accepts any \`chrome-extension://<id>\` where \`<id>\` matches that list.
- Unit tests pin accept (canonical / env-configured dev id) and reject (unknown id, http:// pretending to be the id) branches, plus regression for the pre-existing https / subdomain / third-party origin paths.

## E2E reproducer

Pre-fix: extension SW DevTools console shows the CORS error above; \`app.lobu.ai/<org>/devices/<id>\` reports the Chrome device Offline indefinitely.

Post-fix (after this deploys): same SW heartbeat succeeds → device flips Online within ~30s; \`/api/workers/poll\` returns 200.

## Why now

The CORS rejection was latent — the SW never reached the fetch before owletto#238 fixed the http→https URL upgrade. The new error surfaced as soon as the extension actually tried to talk to the cloud gateway.

## Tests

- \`bun test packages/server/src/__tests__/unit/cors-origin.test.ts\` → 9/0
- \`bunx tsc --noEmit\` (server package) → clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Chrome extension origin allowlisting and updated security headers to permit trusted extension embeddings.

* **Tests**
  * Added comprehensive unit tests covering extension CORS origin handling, configured ID validation, and related security regressions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lobu-ai/lobu/pull/1116?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->