### PR TITLE
chore: bump owletto pointer + fix unit job CLI dist build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,17 +54,20 @@ jobs:
         # install it in the worker runtime image" before it ships.
         run: node scripts/check-connector-runtime-deps.mjs
 
-      - name: Build core + sdk + embeddings + connector-worker for downstream type-resolution
+      - name: Build core + sdk + embeddings + connector-worker + cli for downstream type-resolution
         # connector-worker integration tests import from its compiled `dist/`
         # (subprocess-mode tests spawn the built executor); build it here
         # so those run. embeddings must build before connector-worker —
         # connector-worker's src/embeddings.ts imports from @lobu/embeddings
         # and resolves it via the workspace symlink → dist.
+        # cli must build too: the cli-ux unit test spawns `packages/cli/bin/lobu.js`,
+        # whose shim resolves `../dist/index.js` at runtime.
         run: |
           cd packages/core && bun run build && cd ../..
           cd packages/connector-sdk && bun run build && cd ../..
           cd packages/embeddings && bun run build && cd ../..
           cd packages/connector-worker && bun run build && cd ../..
+          cd packages/cli && bun run build && cd ../..
 
       - name: core / cli (bun:test)
         run: bun test packages/core packages/cli --coverage

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,19 +54,22 @@ jobs:
         # install it in the worker runtime image" before it ships.
         run: node scripts/check-connector-runtime-deps.mjs
 
-      - name: Build core + sdk + embeddings + connector-worker + cli for downstream type-resolution
+      - name: Build core + sdk + embeddings + connector-worker + pgvector-embedded + cli for downstream type-resolution
         # connector-worker integration tests import from its compiled `dist/`
         # (subprocess-mode tests spawn the built executor); build it here
         # so those run. embeddings must build before connector-worker —
         # connector-worker's src/embeddings.ts imports from @lobu/embeddings
         # and resolves it via the workspace symlink → dist.
         # cli must build too: the cli-ux unit test spawns `packages/cli/bin/lobu.js`,
-        # whose shim resolves `../dist/index.js` at runtime.
+        # whose shim resolves `../dist/index.js` at runtime. The cli's build
+        # script vendors @lobu/pgvector-embedded's dist+prebuilt into its
+        # tarball, so pgvector-embedded must build first.
         run: |
           cd packages/core && bun run build && cd ../..
           cd packages/connector-sdk && bun run build && cd ../..
           cd packages/embeddings && bun run build && cd ../..
           cd packages/connector-worker && bun run build && cd ../..
+          cd packages/pgvector-embedded && bun run build && cd ../..
           cd packages/cli && bun run build && cd ../..
 
       - name: core / cli (bun:test)


### PR DESCRIPTION
Two tiny pre-existing CI fixes surfaced while triaging #1121's red checks (both are red on \`main\` too, so this is hygiene, not regression).

## 1. \`chore(submodule)\`: bump owletto pointer to current main
\`check-drift\` flags that the lobu parent pins \`a317d4e\` but \`owletto/main\` has moved on to \`6bcdb9c\` (one extension fix + two image bumps already merged on owletto's side). Per CLAUDE.md "bump the lobu submodule pointer as a separate PR" — this is that PR.

## 2. \`ci(unit)\`: build cli dist before running bin/lobu unit tests
The cli-ux unit test spawns \`packages/cli/bin/lobu.js memory browser-auth --help\`. The bin shim resolves \`../dist/index.js\` at runtime; without a prior build the resolver fails with:

\`\`\`
error: Cannot find module '../dist/index.js' from '/home/runner/work/lobu/lobu/packages/cli/bin/lobu.js'
\`\`\`
…and the test fails the \`expect(out).toContain("--connector")\` assertion because the spawned subprocess never started. CI's unit job builds core / connector-sdk / embeddings / connector-worker but not cli; add cli to that list.

## Test plan
- [x] Local: \`bun test packages/cli/src/__tests__/cli-ux.test.ts\` → 15 pass / 0 fail (was the failing surface).
- [x] Local: \`PATH="/opt/homebrew/opt/node@22/bin:$PATH" node packages/cli/bin/lobu.js memory browser-auth --help\` after \`make build-packages\` prints the expected \`--connector\` flag.
- [ ] CI verifies the rest: \`unit\` and \`check-drift\` go green on this PR.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1126"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782575954&installation_id=136316292&pr_number=1126&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1126&signature=03d2f9ec162f368b8a331ab9972c33150cc73458522e5e3717c49310bb5476f2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->