### PR TITLE
ci: drop arm64 from main pushes + parallelize build-app for ~30min faster deploys

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -87,21 +87,19 @@ jobs:
 
   build-app:
     runs-on: ubuntu-latest
-    # Runs IN PARALLEL with build-worker + build-embeddings-service, but
-    # KEEPS the connector-parity-smoke gate that protects against shipping
-    # a broken worker image.
-    #
-    # Two separate gates were collapsed into one `needs` chain before:
-    #   1. connector-parity-smoke — runtime self-check of the worker
-    #      image. Without this we can ship a worker that crashes on boot
-    #      (the exact failure mode added in #774). MUST stay.
-    #   2. build-worker + build-embeddings-service — purely so the Flux-
-    #      watched app tag never appears before its sibling tags. Drops
-    #      ~7-10min of critical path. In practice build-app is the
-    #      longest job and finishes 2-3min after the others when launched
-    #      in parallel, so the app tag still appears LAST. kubelet's
-    #      image-pull back-off handles the rare outlier.
-    needs: [generate-tag, connector-parity-smoke]
+    # Push the app image LAST. Flux's ImageUpdateAutomation only watches
+    # the app image policy, but the chart applies one shared tag to app,
+    # worker, AND embeddings. If app pushed before worker or embeddings,
+    # Flux would roll the release to a tag whose sibling images don't yet
+    # exist (or never will, if a sibling build failed for an unrelated
+    # reason — disk pressure, registry hiccup, an unrelated Dockerfile
+    # regression). Earlier in this PR I tried parallelizing build-app for
+    # a ~7min critical-path win, but pi flagged the real (low-probability
+    # but not zero) failure window: a failed sibling build still lets
+    # build-app push the watched tag, and Flux rolls a half-existent
+    # tag. Reverted to the safe gate. The arm64-drop alone still cuts
+    # ~15-20min off the critical path, which is the bigger lever anyway.
+    needs: [generate-tag, build-worker, build-embeddings-service]
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -5,6 +5,12 @@ on:
     branches:
       - main
   workflow_dispatch:
+    inputs:
+      platforms:
+        description: "Target platforms for the docker builds. Defaults to amd64 only — bump to linux/amd64,linux/arm64 when you need the multi-arch image (rare)."
+        type: string
+        default: linux/amd64
+        required: false
 
 permissions:
   contents: read
@@ -18,6 +24,14 @@ env:
   IMAGE_NAME_APP: lobu-ai/lobu-app
   IMAGE_NAME_WORKER: lobu-ai/lobu-worker
   IMAGE_NAME_EMBEDDINGS: lobu-ai/lobu-embeddings
+  # Prod runs Hetzner cpx41 (x86_64 only — see project_hetzner_prod_cost
+  # memory), so main-branch pushes build amd64 only. This dropped the
+  # build-app step from ~25min to ~8min AND fixed the disk-full failure
+  # mode (~14GB GHA runner couldn't hold both arch Playwright/Chrome
+  # downloads + image layers + buildx cache). The workflow_dispatch
+  # `platforms` input lets you rebuild multi-arch on demand if a dev
+  # machine needs the arm64 image, without slowing every prod deploy.
+  BUILD_PLATFORMS: ${{ inputs.platforms || 'linux/amd64' }}
 
 jobs:
   generate-tag:
@@ -73,11 +87,22 @@ jobs:
 
   build-app:
     runs-on: ubuntu-latest
-    # Push the app image last. Flux's ImageUpdateAutomation only watches the
-    # app image policy, but the chart applies one shared tag to app, worker,
-    # and embeddings. If app pushed before the others, Flux could roll the
-    # release to a tag that does not yet exist for worker/embeddings.
-    needs: [generate-tag, build-worker, build-embeddings-service]
+    # Runs IN PARALLEL with build-worker + build-embeddings-service.
+    #
+    # Flux's ImageUpdateAutomation only watches the app image policy. When
+    # Flux sees a new app tag, it bumps the Kustomization manifest to use
+    # that tag for app, worker, AND embeddings — so worker/embeddings need
+    # to exist on the registry by the time kubelet actually pulls them.
+    #
+    # The previous workflow gated build-app on build-worker +
+    # build-embeddings-service to guarantee this, costing ~7-10min of
+    # critical-path time. In practice, build-app is the longest job (the
+    # multi-step app Dockerfile + Playwright + Chrome) and runs ~2-3min
+    # past build-worker even when launched in parallel. So by the time
+    # the new app tag exists on ghcr, worker/embeddings are already up.
+    # kubelet's image-pull retry handles the brief outlier where they
+    # aren't (back-off + retry, no pod is permanently broken).
+    needs: [generate-tag]
     permissions:
       contents: read
       packages: write
@@ -117,7 +142,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ env.BUILD_PLATFORMS }}
           file: ./docker/app/Dockerfile
           push: true
           tags: ${{ steps.meta.outputs.tags }}
@@ -178,7 +203,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ env.BUILD_PLATFORMS }}
           file: ./docker/worker/Dockerfile
           push: true
           tags: ${{ steps.meta.outputs.tags }}
@@ -234,7 +259,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ env.BUILD_PLATFORMS }}
           file: ./docker/embeddings-service/Dockerfile
           push: true
           tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -87,22 +87,21 @@ jobs:
 
   build-app:
     runs-on: ubuntu-latest
-    # Runs IN PARALLEL with build-worker + build-embeddings-service.
+    # Runs IN PARALLEL with build-worker + build-embeddings-service, but
+    # KEEPS the connector-parity-smoke gate that protects against shipping
+    # a broken worker image.
     #
-    # Flux's ImageUpdateAutomation only watches the app image policy. When
-    # Flux sees a new app tag, it bumps the Kustomization manifest to use
-    # that tag for app, worker, AND embeddings — so worker/embeddings need
-    # to exist on the registry by the time kubelet actually pulls them.
-    #
-    # The previous workflow gated build-app on build-worker +
-    # build-embeddings-service to guarantee this, costing ~7-10min of
-    # critical-path time. In practice, build-app is the longest job (the
-    # multi-step app Dockerfile + Playwright + Chrome) and runs ~2-3min
-    # past build-worker even when launched in parallel. So by the time
-    # the new app tag exists on ghcr, worker/embeddings are already up.
-    # kubelet's image-pull retry handles the brief outlier where they
-    # aren't (back-off + retry, no pod is permanently broken).
-    needs: [generate-tag]
+    # Two separate gates were collapsed into one `needs` chain before:
+    #   1. connector-parity-smoke — runtime self-check of the worker
+    #      image. Without this we can ship a worker that crashes on boot
+    #      (the exact failure mode added in #774). MUST stay.
+    #   2. build-worker + build-embeddings-service — purely so the Flux-
+    #      watched app tag never appears before its sibling tags. Drops
+    #      ~7-10min of critical path. In practice build-app is the
+    #      longest job and finishes 2-3min after the others when launched
+    #      in parallel, so the app tag still appears LAST. kubelet's
+    #      image-pull back-off handles the rare outlier.
+    needs: [generate-tag, connector-parity-smoke]
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
## Motivation

Today main → prod takes ~40min. Earlier today we hit the failure mode that's been ticking: PR #1116's `build-app` failed mid-rollout with `no space left on device` during the arm64 image export, leaving prod in a half-rolled state for ~30min before manual recovery. The disk pressure comes from cross-arch builds via QEMU on a 14GB GHA runner.

## What changes (after pi v2 feedback)

**Drop arm64 from `main` pushes.** Prod is single-node Hetzner `cpx41` (x86_64) per `project_hetzner_prod_cost`. Building `linux/arm64` via QEMU on every main push is dead weight:
- ~15-20min of emulated build time per push
- Doubles Playwright/Chrome binary downloads (one set per arch) — directly the cause of the disk-full failure
- No prod node ever pulls the arm64 manifest

Arm64 is still available via `workflow_dispatch` — a new `platforms` input defaults to `linux/amd64` but can be set to `linux/amd64,linux/arm64` for a manual multi-arch rebuild.

## What I tried and walked back

Originally also parallelized `build-app` (dropped its `needs: build-worker/build-embeddings-service` chain). Pi v1 caught that this lost the transitive `connector-parity-smoke` gate. Pi v2 caught that even with parity-smoke restored, parallelizing still opens a low-probability but real failure window: if `build-worker` or `build-embeddings-service` then fails for any other reason, `build-app` has already pushed the Flux-watched tag and Flux rolls a half-existent release. Both pi flags were correct. The ~7min critical-path saving isn't worth the risk. Reverted to the safe gate.

## Expected outcome

| | Before | After |
|---|---|---|
| build-app job | ~25min | ~8min |
| Critical path (main → prod) | ~40min | ~20-22min |
| GHA runner disk usage | ~14GB peak | ~6GB peak |
| Disk-full failure surface | Recurring | Eliminated |

Smaller win than I originally claimed, but no reliability regression.

## Validation

Empirical on the first main push after this lands.