### PR TITLE
fix(gateway): stamp ephemeral agent worker tokens with caller org

### DIFF
--- a/packages/server/src/gateway/auth/api-auth-middleware.ts
+++ b/packages/server/src/gateway/auth/api-auth-middleware.ts
@@ -7,6 +7,25 @@ import { getRevokedTokenStore } from "./revoked-token-store.js";
 export const TOKEN_EXPIRATION_MS = 24 * 60 * 60 * 1000;
 
 /**
+ * Caller identity surfaced to handlers via `c.get("authContext")` after a
+ * successful auth check. `organizationId` is the token-bound or personal-org
+ * id when the auth path can resolve one (worker token payload, or
+ * `/oauth/userinfo` org slug); otherwise undefined. `createAgent` uses it to
+ * stamp the worker token for ephemeral agents so the cross-pod conversation
+ * lock can be acquired (#1068).
+ */
+export interface ApiAuthContext {
+  userId?: string;
+  organizationId?: string;
+}
+
+declare module "hono" {
+  interface ContextVariableMap {
+    authContext?: ApiAuthContext;
+  }
+}
+
+/**
  * Creates a Hono middleware that enforces the standard auth check:
  *   1. Settings session cookie  2. Worker token (local)  3. External OAuth
  *
@@ -27,6 +46,7 @@ export function createApiAuthMiddleware(opts: {
     if (opts.allowSettingsSession) {
       const session = await verifySettingsSession(c);
       if (session) {
+        c.set("authContext", { userId: session.userId } satisfies ApiAuthContext);
         return next();
       }
     }
@@ -46,6 +66,10 @@ export function createApiAuthMiddleware(opts: {
           if (workerData.jti && (await revokedTokens.isRevoked(workerData.jti))) {
             return c.json({ success: false, error: "Unauthorized" }, 401);
           }
+          c.set("authContext", {
+            userId: workerData.userId,
+            organizationId: workerData.organizationId,
+          } satisfies ApiAuthContext);
           return next();
         }
       }
@@ -55,7 +79,13 @@ export function createApiAuthMiddleware(opts: {
     if (opts.externalAuthClient) {
       try {
         const userInfo = await opts.externalAuthClient.fetchUserInfo(token);
-        if (userInfo?.sub) return next();
+        if (userInfo?.sub) {
+          c.set("authContext", {
+            userId: userInfo.sub,
+            organizationId: userInfo.organizationId,
+          } satisfies ApiAuthContext);
+          return next();
+        }
       } catch {
         // Token not valid for external auth, continue to next method
       }

--- a/packages/server/src/gateway/auth/external/client.ts
+++ b/packages/server/src/gateway/auth/external/client.ts
@@ -43,10 +43,28 @@ interface WellKnownMetadata {
   grant_types_supported?: string[];
 }
 
-interface UserInfoResponse {
+export interface UserInfoResponse {
   sub: string;
   email: string;
   name?: string;
+  /**
+   * Token-bound org id, or — when the token has no org binding (e.g. a
+   * device-flow PAT) — the user's personal-org id. Resolved by mapping
+   * `organization_slug` to its entry in `organizations[]` (both already
+   * returned by `/oauth/userinfo`). Surfaced so the gateway middleware can
+   * attach an auth-context org to handlers like `createAgent`, which
+   * otherwise has no way to find the org for an ephemeral agent and
+   * downstream cross-pod conversation-lock acquisition fails (#1068).
+   */
+  organizationId?: string;
+}
+
+interface UserInfoApiResponse {
+  sub: string;
+  email: string;
+  name?: string;
+  organization_slug?: string | null;
+  organizations?: { id: string; slug: string; name: string }[];
 }
 
 interface DynamicClientCredentials {
@@ -167,12 +185,23 @@ export class ExternalAuthClient {
       );
     }
 
-    const data = (await response.json()) as UserInfoResponse;
+    const data = (await response.json()) as UserInfoApiResponse;
+    const orgId =
+      data.organization_slug && data.organizations
+        ? (data.organizations.find((o) => o.slug === data.organization_slug)
+            ?.id ?? undefined)
+        : undefined;
     logger.info("Fetched external auth user info", {
       sub: data.sub,
       email: data.email,
+      orgId,
     });
-    return data;
+    return {
+      sub: data.sub,
+      email: data.email,
+      name: data.name,
+      organizationId: orgId,
+    };
   }
 
   async getCapabilities(): Promise<ExternalAuthCapabilities> {

--- a/packages/server/src/gateway/routes/public/agent.ts
+++ b/packages/server/src/gateway/routes/public/agent.ts
@@ -638,16 +638,22 @@ export function createAgentApi(config: AgentApiConfig): OpenAPIHono {
       if (denial) return denial;
     }
 
-    // Stamp the worker token with the agent's owning org so the egress
-    // proxy's per-tenant gates (grant/deny, judge cache, judge policy)
-    // can scope decisions by org. Ephemeral agents have no preexisting
-    // metadata; their token mints without orgId and the proxy falls
-    // through to unscoped checks for that worker — flagged for a
-    // future fix that derives org from the auth session.
-    const tokenOrganizationId =
+    // Stamp the worker token with the owning org so the egress proxy's
+    // per-tenant gates (grant/deny, judge cache, judge policy) can scope
+    // decisions by org. Prefer the agent's own metadata; fall back to the
+    // caller's organizationId (already resolved by `createLobuAuthBridge`
+    // from the PAT or Better Auth session). Without the fallback,
+    // ephemeral agents under `lobu chat -c local` mint a tokenless org and
+    // the downstream cross-pod conversation-lock guard refuses to spawn
+    // the worker (#1068).
+    const callerOrgId =
+      (c.get("organizationId") as string | undefined) ??
+      c.get("authContext")?.organizationId;
+    const metadataOrgId =
       !isEphemeral && ownershipMetadataStore
         ? (await ownershipMetadataStore.getMetadata(agentId))?.organizationId
         : undefined;
+    const tokenOrganizationId = metadataOrgId ?? callerOrgId;
 
     // For ephemeral agents, auto-provision settings from system-key
     // providers (env-var-based API keys). No more template-agent fallback —


### PR DESCRIPTION
## Summary
The cross-pod conversation-lock guard introduced in #1068 refuses to spawn a worker when an org-less turn is enqueued. Ephemeral agents under `lobu chat -c local` (no project / no metadata row) fell into that path — `createAgent` only stamped `tokenOrganizationId` from the agent's own metadata, which is `undefined` for ephemerals. The session then shipped without an `organizationId`, `enqueueMessage` omitted it from the payload, and `EmbeddedDeploymentManager.createWorkerDeployment` threw `Cannot acquire per-conversation lock: turn is missing organizationId or conversationId` on every retry.

## Fix
- `createAgent` falls back to the caller's `organizationId` already resolved by `createLobuAuthBridge` (from the PAT or Better Auth session) when the agent's metadata has none.
- Belt-and-suspenders: `createApiAuthMiddleware` now sets an `ApiAuthContext` (`userId`, `organizationId`) on the Hono context after each successful auth path (worker token payload / `/oauth/userinfo` slug → id resolution / settings session), so any handler outside the lobu bridge can also read it.
- `ExternalAuthClient.fetchUserInfo` forwards the `organizationId` resolved from `/oauth/userinfo`'s `organization_slug` + `organizations[]` list (previously typed away).

## Test plan
**Reproducer on `origin/main` (pre-fix):**
```
$ lobu run --port 8814
$ lobu chat -c local "ping"
Agent error: Worker startup failed and your request could not be processed. Please retry in a moment.

# gateway log:
[error] [orchestrator] Refusing to spawn snapshot-mode worker ...:
  cross-pod conversation lock requires both organizationId and conversationId
  (org=<missing>, conv=<userId>_<userId>)
```

**With this fix:**
```
$ lobu chat -c local "ping"
Agent error: No model configured. Ask an admin to connect a provider for the base agent.

# gateway log:
[info] [orchestrator] Generated 1976 characters from 3 local providers
[info] [worker-gateway] Session context for <agent>: provider: none, ...
```

The cross-pod throw is gone; the worker spawned and reached the model-resolution step. The remaining `No model configured` is a separate gap (ephemeral agent provider-binding isn't picked up despite system providers being provisioned at org level) — tracked separately.

- [x] `bun run typecheck` clean
- [x] `cd packages/server && bunx tsc --noEmit` clean
- [x] `make build-packages` green
- [x] E2E: `lobu run` boot → `lobu chat -c local "ping"` no longer blocked on cross-pod lock

## Confidence
~85. Reproduced the bug on `origin/main`, applied the fix, re-ran the same flow, confirmed the throw is gone. Did not run the full `make review` (typecheck + unit pass; integration covered by the e2e repro).

## Follow-ups
1. Fix the "No model configured" path so ephemeral agents pick up the org's provisioned providers automatically (system providers ARE provisioned at agent-create time, but session-context delivery shows `provider: none`).
2. Add a regression integration test that exercises ephemeral-agent + install_operator + chat-message end to end.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1129"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782576901&installation_id=136316292&pr_number=1129&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1129&signature=8b57d89cd7184cb9f753486d55bc2d2f4ee287c28fc15155729df2c486ee9509"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->