### PR TITLE
feat(infra): alert on prod deploy failures (Flux + CI)

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -272,3 +272,42 @@ jobs:
             -H "X-GitHub-Api-Version: 2022-11-28" \
             https://api.github.com/user/packages/container/lobu-embeddings/visibility \
             -d '{"visibility":"public"}' || true
+
+  # Failure notification. The chart applies one shared tag to app + worker +
+  # embeddings, so if any of the three build/push jobs fails on main, the next
+  # ImageUpdateAutomation cycle either rolls a tag that does not exist for one
+  # service (half-rolled prod) or — when app fails after worker/embeddings
+  # already pushed — silently leaves prod on the previous app tag while the
+  # other two move forward. Both modes were caught only by manual inspection
+  # before this notifier existed (PR #1116 build-app disk-full incident).
+  #
+  # Posts to the same Slack webhook the Flux notification-controller's
+  # `slack-devops` Provider uses (devops channel) so cluster-side and CI-side
+  # deploy failures land in one place. Webhook lives in the SLACK_DEPLOY_WEBHOOK_URL
+  # repo secret; if unset the curl is skipped, never failing the job.
+  notify-failure:
+    runs-on: ubuntu-latest
+    needs: [generate-tag, connector-parity-smoke, build-worker, build-embeddings-service, build-app]
+    if: failure() && github.ref == 'refs/heads/main'
+    permissions:
+      contents: read
+    steps:
+      - name: Post failure to Slack devops
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_DEPLOY_WEBHOOK_URL }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          COMMIT_URL: ${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}
+          COMMIT_MSG: ${{ github.event.head_commit.message }}
+          ACTOR: ${{ github.actor }}
+          SHA_SHORT: ${{ github.sha }}
+        run: |
+          if [ -z "$SLACK_WEBHOOK_URL" ]; then
+            echo "SLACK_DEPLOY_WEBHOOK_URL not set; skipping notification."
+            exit 0
+          fi
+          # First line of commit message only, JSON-escaped via jq.
+          first_line=$(printf '%s' "$COMMIT_MSG" | head -n1)
+          payload=$(jq -nc \
+            --arg text "<@U09513HH1N1> :rotating_light: build-images failed on \`main\` — prod will roll half (or not at all). <${RUN_URL}|run> · <${COMMIT_URL}|${SHA_SHORT:0:7}> by ${ACTOR}\n> ${first_line}" \
+            '{text: $text}')
+          curl -sS -X POST -H 'Content-type: application/json' --data "$payload" "$SLACK_WEBHOOK_URL"


### PR DESCRIPTION
## What was broken

When CI's build-images.yml or Flux's prod reconcile fails, nobody was notified. PR #1116's build-app job went disk-full and silently left prod half-rolled (app on old tag, worker/embeddings on new tag) until manual discovery 30+ minutes later.

## What was already working (verified)

The Flux cluster-side alert pipeline is fully wired and firing:

- `flux-system/slack-devops` Provider exists (type: slack, secretRef: `slack-webhook`).
- `flux-system/slack-webhook` SealedSecret unseals to a working `hooks.slack.com` URL (smoke-tested with `curl` → `ok`).
- Two Alerts cover the full prod chain:
  - `slack-deploy-info` (severity: info, ImageUpdateAutomation only, excludes "no changes") — image bumps that actually rolled.
  - `slack-deploy-error` (severity: error, **Kustomization + HelmRelease + ImageUpdateAutomation + GitRepository + ImageRepository**) — anything in the prod chain stalling.

`notification-controller` logs over the past 48h show `slack-deploy-error` was dispatched ~10x against real failures (transient git clone timeouts, infrastructure Kustomization health-check timeouts) with **no notifier errors**. The only error in the logs is for an unrelated `github-status` Provider that has an empty token — out of scope here.

The two real gaps:
1. **No CI-side failure notification** in build-images.yml.
2. Both Alerts use the deprecated `.spec.summary` field, generating a warning every fire that will become an error on the next notification-controller upgrade.

## What this PR changes

### 1. `build-images.yml` notify-failure job

Runs only on `failure() && github.ref == 'refs/heads/main'`, depends on every build job (`connector-parity-smoke`, `build-worker`, `build-embeddings-service`, `build-app`), posts to the same Slack webhook the Flux Provider uses (new `SLACK_DEPLOY_WEBHOOK_URL` repo secret, already set). Tags `<@U09513HH1N1>` so it can't be missed.

If the secret is unset, the curl is skipped — the job never fails on configuration drift.

### 2. Owletto submodule bump (lobu-ai/owletto#241)

Moves `.spec.summary` into `.spec.eventMetadata.summary` on both Alerts. Cosmetic, but the next Flux upgrade will drop the warning to error.

## Smoke-test evidence (this PR's path actually fires)

1. **Direct webhook test** — `curl -X POST -H Content-type:application/json -d '{"text":"..."}' "$WEBHOOK_URL"` returned `ok`. Confirms the webhook is live in the `devops` Slack channel.

2. **Flux Alert smoke** — Created a temporary `flux-system/alert-smoke-test` Kustomization pointing at `./this-path-does-not-exist-on-purpose`. Within ~45s:
   - Kustomization Ready=False with `kustomization path not found`
   - notification-controller log:
     ```
     dispatching event ... Kustomization/alert-smoke-test
     message: "kustomization path not found: stat /tmp/kustomization-XXX/this-path-does-not-exist-on-purpose: no such file or directory"
     Alert: slack-deploy-error
     ```
   - No "failed to dispatch notification" error for the slack-devops provider on this event.
   - Smoke-test Kustomization was deleted immediately after verification.

3. **GHA notify-failure** — Not smoke-tested live (would require deliberately breaking a main-branch build and rolling prod). The path is mechanically simple: `jq` builds a JSON payload, `curl` POSTs to the same webhook the Flux side already proved works. `SLACK_DEPLOY_WEBHOOK_URL` was set via `gh secret set` to the same URL extracted from the in-cluster SealedSecret.

## Multi-replica safety

- notification-controller is a single leader-elected Deployment in flux-system — no per-pod state to coordinate.
- GHA notify-failure runs on one runner per CI run.
- No shared in-memory state is introduced.

## Files

- `.github/workflows/build-images.yml` — +39 lines (one new job)
- `packages/owletto` pointer bump (6bcdb9c7 → 4a1b9d55)

## Depends on

lobu-ai/owletto#241 (merge before this; pointer bump references its head commit)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1130"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782576906&installation_id=136316292&pr_number=1130&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1130&signature=974cf2bdec44ed21e5109bf903db00eb00496c5543965d6ef6b96511460bcfe7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->