### PR TITLE
fix(gateway): create ephemeral agent row before saveSettings + loud-fail saveSettings on no-op

### DIFF
--- a/packages/server/src/gateway/auth/api-auth-middleware.ts
+++ b/packages/server/src/gateway/auth/api-auth-middleware.ts
@@ -7,6 +7,25 @@ import { getRevokedTokenStore } from "./revoked-token-store.js";
 export const TOKEN_EXPIRATION_MS = 24 * 60 * 60 * 1000;
 
 /**
+ * Caller identity surfaced to handlers via `c.get("authContext")` after a
+ * successful auth check. `organizationId` is the token-bound or personal-org
+ * id when the auth path can resolve one (worker token payload, or
+ * `/oauth/userinfo` org slug); otherwise undefined. `createAgent` uses it to
+ * stamp the worker token for ephemeral agents so the cross-pod conversation
+ * lock can be acquired (#1068).
+ */
+export interface ApiAuthContext {
+  userId?: string;
+  organizationId?: string;
+}
+
+declare module "hono" {
+  interface ContextVariableMap {
+    authContext?: ApiAuthContext;
+  }
+}
+
+/**
  * Creates a Hono middleware that enforces the standard auth check:
  *   1. Settings session cookie  2. Worker token (local)  3. External OAuth
  *
@@ -27,6 +46,7 @@ export function createApiAuthMiddleware(opts: {
     if (opts.allowSettingsSession) {
       const session = await verifySettingsSession(c);
       if (session) {
+        c.set("authContext", { userId: session.userId } satisfies ApiAuthContext);
         return next();
       }
     }
@@ -46,6 +66,10 @@ export function createApiAuthMiddleware(opts: {
           if (workerData.jti && (await revokedTokens.isRevoked(workerData.jti))) {
             return c.json({ success: false, error: "Unauthorized" }, 401);
           }
+          c.set("authContext", {
+            userId: workerData.userId,
+            organizationId: workerData.organizationId,
+          } satisfies ApiAuthContext);
           return next();
         }
       }
@@ -55,7 +79,13 @@ export function createApiAuthMiddleware(opts: {
     if (opts.externalAuthClient) {
       try {
         const userInfo = await opts.externalAuthClient.fetchUserInfo(token);
-        if (userInfo?.sub) return next();
+        if (userInfo?.sub) {
+          c.set("authContext", {
+            userId: userInfo.sub,
+            organizationId: userInfo.organizationId,
+          } satisfies ApiAuthContext);
+          return next();
+        }
       } catch {
         // Token not valid for external auth, continue to next method
       }

--- a/packages/server/src/gateway/auth/external/client.ts
+++ b/packages/server/src/gateway/auth/external/client.ts
@@ -43,10 +43,28 @@ interface WellKnownMetadata {
   grant_types_supported?: string[];
 }
 
-interface UserInfoResponse {
+export interface UserInfoResponse {
   sub: string;
   email: string;
   name?: string;
+  /**
+   * Token-bound org id, or — when the token has no org binding (e.g. a
+   * device-flow PAT) — the user's personal-org id. Resolved by mapping
+   * `organization_slug` to its entry in `organizations[]` (both already
+   * returned by `/oauth/userinfo`). Surfaced so the gateway middleware can
+   * attach an auth-context org to handlers like `createAgent`, which
+   * otherwise has no way to find the org for an ephemeral agent and
+   * downstream cross-pod conversation-lock acquisition fails (#1068).
+   */
+  organizationId?: string;
+}
+
+interface UserInfoApiResponse {
+  sub: string;
+  email: string;
+  name?: string;
+  organization_slug?: string | null;
+  organizations?: { id: string; slug: string; name: string }[];
 }
 
 interface DynamicClientCredentials {
@@ -167,12 +185,23 @@ export class ExternalAuthClient {
       );
     }
 
-    const data = (await response.json()) as UserInfoResponse;
+    const data = (await response.json()) as UserInfoApiResponse;
+    const orgId =
+      data.organization_slug && data.organizations
+        ? (data.organizations.find((o) => o.slug === data.organization_slug)
+            ?.id ?? undefined)
+        : undefined;
     logger.info("Fetched external auth user info", {
       sub: data.sub,
       email: data.email,
+      orgId,
     });
-    return data;
+    return {
+      sub: data.sub,
+      email: data.email,
+      name: data.name,
+      organizationId: orgId,
+    };
   }
 
   async getCapabilities(): Promise<ExternalAuthCapabilities> {

--- a/packages/server/src/gateway/routes/public/agent.ts
+++ b/packages/server/src/gateway/routes/public/agent.ts
@@ -638,16 +638,22 @@ export function createAgentApi(config: AgentApiConfig): OpenAPIHono {
       if (denial) return denial;
     }
 
-    // Stamp the worker token with the agent's owning org so the egress
-    // proxy's per-tenant gates (grant/deny, judge cache, judge policy)
-    // can scope decisions by org. Ephemeral agents have no preexisting
-    // metadata; their token mints without orgId and the proxy falls
-    // through to unscoped checks for that worker — flagged for a
-    // future fix that derives org from the auth session.
-    const tokenOrganizationId =
+    // Stamp the worker token with the owning org so the egress proxy's
+    // per-tenant gates (grant/deny, judge cache, judge policy) can scope
+    // decisions by org. Prefer the agent's own metadata; fall back to the
+    // caller's organizationId (already resolved by `createLobuAuthBridge`
+    // from the PAT or Better Auth session). Without the fallback,
+    // ephemeral agents under `lobu chat -c local` mint a tokenless org and
+    // the downstream cross-pod conversation-lock guard refuses to spawn
+    // the worker (#1068).
+    const callerOrgId =
+      (c.get("organizationId") as string | undefined) ??
+      c.get("authContext")?.organizationId;
+    const metadataOrgId =
       !isEphemeral && ownershipMetadataStore
         ? (await ownershipMetadataStore.getMetadata(agentId))?.organizationId
         : undefined;
+    const tokenOrganizationId = metadataOrgId ?? callerOrgId;
 
     // For ephemeral agents, auto-provision settings from system-key
     // providers (env-var-based API keys). No more template-agent fallback —

--- a/packages/server/src/gateway/routes/public/agent.ts
+++ b/packages/server/src/gateway/routes/public/agent.ts
@@ -422,7 +422,7 @@ export interface AgentApiConfig {
     "getSettings" | "listAgents" | "getMetadata"
   >;
   userAgentsStore?: UserAgentsStore;
-  agentMetadataStore?: Pick<AgentMetadataStore, "getMetadata">;
+  agentMetadataStore?: Pick<AgentMetadataStore, "getMetadata" | "createAgent">;
   platformRegistry?: PlatformRegistry;
   approveToolCall?: (
     requestId: string,
@@ -649,10 +649,34 @@ export function createAgentApi(config: AgentApiConfig): OpenAPIHono {
         ? (await ownershipMetadataStore.getMetadata(agentId))?.organizationId
         : undefined;
 
-    // For ephemeral agents, auto-provision settings from system-key
-    // providers (env-var-based API keys). No more template-agent fallback —
-    // there are no template/sandbox agents anymore.
+    // For ephemeral agents, create the `agents` row first so subsequent
+    // `saveSettings` (an UPDATE-only path) actually persists. Without this,
+    // the row never exists, the UPDATE matches 0 rows silently, and the
+    // worker's session-context resolves `installedProviders = []` → no
+    // provider → "No model configured". Followed by provisioning system-
+    // key providers (env-var-based API keys) so the worker has something
+    // to talk to. No more template-agent fallback — there are no
+    // template/sandbox agents anymore.
     if (isEphemeral && agentSettingsStore) {
+      if (agentMetadataStore?.createAgent) {
+        try {
+          await agentMetadataStore.createAgent(
+            agentId,
+            agentId,
+            "api",
+            agentId,
+          );
+        } catch (err) {
+          // saveMetadata is INSERT ... ON CONFLICT DO UPDATE under the hood,
+          // so a re-create of the same id within the same org is benign.
+          // Genuine errors (FK / org mismatch) bubble below and surface as
+          // failed-create.
+          logger.debug(
+            `Ephemeral agent ${agentId}: createAgent threw (likely re-create): ${err}`,
+          );
+        }
+      }
+
       const providerModules = getModelProviderModules();
       const systemProviders: InstalledProvider[] = providerModules
         .filter((m) => m.hasSystemKey())

--- a/packages/server/src/lobu/stores/postgres-stores.ts
+++ b/packages/server/src/lobu/stores/postgres-stores.ts
@@ -215,7 +215,7 @@ export function createPostgresAgentConfigStore(): AgentConfigStore {
       const sql = getDb();
       const orgId = getOrgId();
       const now = new Date();
-      await sql`
+      const result = await sql`
         UPDATE agents SET
           model = ${settings.model ?? null},
           model_selection = ${sql.json(settings.modelSelection ?? {})},
@@ -237,6 +237,16 @@ export function createPostgresAgentConfigStore(): AgentConfigStore {
           updated_at = ${now}
         WHERE id = ${agentId} AND organization_id = ${orgId}
       `;
+      // UPDATE-only by design (agents row identity belongs to saveMetadata).
+      // Fail loud when no row matches so a save can't silently no-op — the
+      // ephemeral-chat path hit exactly this footgun (#1068 follow-up: agent
+      // row never existed → 0 rows updated → empty installedProviders → "No
+      // model configured"). Callers must call saveMetadata first.
+      if (result.count === 0) {
+        throw new Error(
+          `saveSettings: no agents row matches id=${agentId} org=${orgId}; call saveMetadata first`
+        );
+      }
     },
     async updateSettings(agentId, updates) {
       const existing = await store.getSettings(agentId);


### PR DESCRIPTION
## Summary
Two-part fix for the latent "ephemeral agent ends up with no provider" bug uncovered while validating the chat-org propagation fix (#1129).

**Root defect:** `PostgresAgentConfigStore.saveSettings` is UPDATE-only — no agents row, no update, no error. The "auto-provision system providers" call in `createAgent` for ephemeral agents hit exactly this: it logged "provisioned [claude, gemini, …]" but actually persisted nothing because the agents row didn't exist yet. Downstream, the worker's session-context resolved `installedProviders = []` → no provider → `"No model configured. Ask an admin to connect a provider for the base agent"`.

**Fix 1 (the legitimate caller):** `createAgent` now calls `AgentMetadataStore.createAgent` before `saveSettings` for ephemeral agents. `saveMetadata` is `INSERT … ON CONFLICT DO UPDATE` so the call is idempotent; re-creating the same id is benign.

**Fix 2 (the footgun):** `saveSettings` now throws when `result.count === 0`. Previous behavior was a silent success. Any future caller that saves settings before the agents row exists fails loud at the write site instead of as a confusing downstream "No model configured".

## Test plan
**Reproducer (origin/main + #1129 merged, pre-fix):**
```
$ lobu run --port 8816
$ lobu chat -c local "ping"
Agent error: No model configured. Ask an admin to connect a provider for the base agent.

# gateway log:
[info] [agent-settings-store] Saved settings for agent da2299dc-…
[info] [agent-api] Ephemeral agent da2299dc-…: provisioned system providers [claude, gemini, z-ai, openrouter]
[info] [worker-gateway] Session context for da2299dc-…: provider: none, cliBackends: none
```

**With this fix:**
```
$ lobu chat -c local "ping"
❌ Session failed: 403 OAuth authentication is currently not allowed for this organization.
```

The "No model configured" is gone — the worker resolves the provider (claude is picked first), contacts Anthropic, and the request reaches the API. The remaining 403 is a separate, unrelated bug (`claude.hasSystemKey()` always returns true because it does OAuth, but no real OAuth/key is set in this install — different ticket).

- [x] `bun run typecheck` clean
- [x] `cd packages/server && bunx tsc --noEmit` clean
- [x] `make build-packages` green
- [x] E2E: `lobu run` boot → `lobu chat -c local "ping"` now reaches the provider call layer (previously stuck at "No model configured")

Stacks on top of #1129 — without that fix, the cross-pod lock blocks the chat before this path even runs.

## Confidence
~85. Reproduced both bugs (`Refusing to spawn worker` then `No model configured`), applied both fixes, re-ran the same flow, confirmed both errors are gone. The behavior change of `saveSettings` throwing on no-op is small and targeted — full integration suite is being re-run as part of the review.

## Follow-ups
1. `claude.hasSystemKey()` heuristic — should return false when no ANTHROPIC_API_KEY *and* no OAuth state is present, so the provider-priority loop picks a usable provider (gemini / z-ai / openrouter) when only those have credentials. The current OAuth-assumed-true heuristic preempts that.
2. Add an integration test for the full `lobu chat -c local` flow (install_operator → ephemeral agent → worker → provider call). The bug existed for weeks because no test exercised this path end-to-end.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1133"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782578088&installation_id=136316292&pr_number=1133&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1133&signature=1c430ba08c6f9fae26a62505d9eb4e5787447669fe5f2ca0e85d5f934a2240ce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->