### PR TITLE
fix(gateway): route lobu chat to org's default agent end-to-end

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -251,7 +251,10 @@ Memory:
       "-g, --gateway <url>",
       `Gateway URL (default: ${GATEWAY_DEFAULT_URL})`
     )
-    .option("--dry-run", "Process without persisting history")
+    .option(
+      "--dry-run",
+      "Skip side-effecting tool calls (sandbox writes, sdk_run mutations). The turn still runs and history is still persisted."
+    )
     .option("--new", "Force new session (ignore existing)")
     .option(
       "-C, --continue",

--- a/packages/server/src/__tests__/integration/auth/default-provisioning.test.ts
+++ b/packages/server/src/__tests__/integration/auth/default-provisioning.test.ts
@@ -98,6 +98,107 @@ describe('ensureDefaultAgent', () => {
     expect(agents).toHaveLength(0);
   });
 
+  it('stamps owner_user_id + installed_providers + agent_users on insert', async () => {
+    const orgId = `org-owner-${generateSecureToken(4)}`;
+    await seedOrg(orgId);
+
+    // Mark the org as personal_org_for_user_id = <ownerUserId> — this is the
+    // marker ensureDefaultAgent reads to figure out who the agent belongs to.
+    const ownerUserId = `user_${generateSecureToken(4)}`;
+    const sql = getTestDb();
+    await sql`
+      INSERT INTO "user" (id, name, email, "emailVerified", "createdAt", "updatedAt")
+      VALUES (${ownerUserId}, 'Owner', ${`${ownerUserId}@test.local`}, true, NOW(), NOW())
+      ON CONFLICT (id) DO NOTHING
+    `;
+    await sql`
+      UPDATE "organization"
+         SET metadata = ${JSON.stringify({ personal_org_for_user_id: ownerUserId })}
+       WHERE id = ${orgId}
+    `;
+
+    await ensureDefaultAgent(orgId);
+
+    const rows = await sql`
+      SELECT owner_platform, owner_user_id, installed_providers
+        FROM agents
+       WHERE organization_id = ${orgId} AND id = ${DEFAULT_AGENT_ID}
+    `;
+    expect(rows).toHaveLength(1);
+    expect(String(rows[0].owner_platform)).toBe('external');
+    expect(String(rows[0].owner_user_id)).toBe(ownerUserId);
+    // installed_providers shape: array of { providerId, installedAt }.
+    // We don't pin a count because system keys depend on test env vars;
+    // we just assert the column is now a JSON array (object/array, never
+    // null/empty-string).
+    expect(Array.isArray(rows[0].installed_providers)).toBe(true);
+
+    const userAgents = await sql`
+      SELECT platform, user_id
+        FROM agent_users
+       WHERE organization_id = ${orgId} AND agent_id = ${DEFAULT_AGENT_ID}
+    `;
+    expect(userAgents).toHaveLength(1);
+    expect(String(userAgents[0].platform)).toBe('external');
+    expect(String(userAgents[0].user_id)).toBe(ownerUserId);
+  });
+
+  it('backfills owner + agent_users on a legacy row past the sentinel', async () => {
+    // Simulate a legacy install: the row exists with the old
+    // owner_platform='lobu', owner_user_id=NULL, installed_providers='[]'
+    // shape, and the sentinel is already set so the fast-path would skip.
+    const orgId = `org-backfill-${generateSecureToken(4)}`;
+    await seedOrg(orgId);
+
+    const ownerUserId = `user_${generateSecureToken(4)}`;
+    const sql = getTestDb();
+    await sql`
+      INSERT INTO "user" (id, name, email, "emailVerified", "createdAt", "updatedAt")
+      VALUES (${ownerUserId}, 'Legacy Owner', ${`${ownerUserId}@test.local`}, true, NOW(), NOW())
+      ON CONFLICT (id) DO NOTHING
+    `;
+    await sql`
+      UPDATE "organization"
+         SET metadata = ${JSON.stringify({
+           personal_org_for_user_id: ownerUserId,
+           [DEFAULT_AGENT_SENTINEL]: new Date().toISOString(),
+         })}
+       WHERE id = ${orgId}
+    `;
+    await sql`
+      INSERT INTO agents (
+        id, organization_id, name, owner_platform, owner_user_id,
+        installed_providers, created_at, updated_at
+      ) VALUES (
+        ${DEFAULT_AGENT_ID}, ${orgId}, 'Owletto Personal',
+        'lobu', NULL,
+        '[]'::jsonb,
+        NOW(), NOW()
+      )
+    `;
+
+    // Sentinel is set, so the create path is short-circuited, but backfill
+    // still runs.
+    const result = await ensureDefaultAgent(orgId);
+    expect(result.created).toBe(false);
+    expect(result.reason).toBe('sentinel');
+
+    const rows = await sql`
+      SELECT owner_platform, owner_user_id
+        FROM agents
+       WHERE organization_id = ${orgId} AND id = ${DEFAULT_AGENT_ID}
+    `;
+    expect(String(rows[0].owner_platform)).toBe('external');
+    expect(String(rows[0].owner_user_id)).toBe(ownerUserId);
+
+    const userAgents = await sql`
+      SELECT user_id FROM agent_users
+       WHERE organization_id = ${orgId} AND agent_id = ${DEFAULT_AGENT_ID}
+    `;
+    expect(userAgents).toHaveLength(1);
+    expect(String(userAgents[0].user_id)).toBe(ownerUserId);
+  });
+
   it('skips creation (but stamps sentinel) when other agents already exist', async () => {
     const orgId = `org-provision-${generateSecureToken(4)}`;
     await seedOrg(orgId);

--- a/packages/server/src/auth/default-provisioning.ts
+++ b/packages/server/src/auth/default-provisioning.ts
@@ -23,6 +23,7 @@
 
 import { getDb } from '../db/client';
 import type { DbClient } from '../db/client';
+import { getModelProviderModules } from '../gateway/modules/module-system';
 import { getNextNumericId } from '../tools/admin/helpers/db-helpers';
 import { nextRunAt } from '../utils/cron';
 import logger from '../utils/logger';
@@ -152,20 +153,59 @@ export async function ensureDefaultAgent(
       return { created: false, reason: 'has_agents' };
     }
 
+    // Resolve the set of model providers that have a system-level credential
+    // available at this boot (env-var API keys, claude OAuth-discovery, etc.)
+    // and install them onto the default agent up front. Without this, the row
+    // exists but `installed_providers = '[]'` and `lobu chat -c local` would
+    // immediately hit "No model configured" — even though the env keys are
+    // sitting right there in the same process.
+    const systemProviders = getModelProviderModules()
+      .filter((m) => m.hasSystemKey())
+      .map((m) => ({
+        providerId: m.providerId,
+        installedAt: Date.now(),
+      }));
+
+    // Resolve the owning user — the personal_org metadata is the canonical
+    // marker. The default agent is shown as user-owned (rather than the
+    // legacy `'lobu', NULL` org-level marker) so the per-user ownership
+    // check in `verifyOwnedAgentAccess` recognizes this user as the agent's
+    // owner: without it, a PAT session for the user can't open a session
+    // against their own org's default agent.
+    const ownerRows = (await client`
+      SELECT (metadata::jsonb)->>'personal_org_for_user_id' AS owner_user_id
+        FROM "organization"
+       WHERE id = ${organizationId}
+       LIMIT 1
+    `) as unknown as Array<{ owner_user_id: string | null }>;
+    const ownerUserId = ownerRows[0]?.owner_user_id ?? null;
+
     // Insert the default agent. The PK is (organization_id, id) so we can
     // ON CONFLICT DO NOTHING to guard against a parallel boot.
     await client`
       INSERT INTO agents (
         id, organization_id, name, identity_md,
         owner_platform, owner_user_id, is_workspace_agent,
+        installed_providers,
         created_at, updated_at
       ) VALUES (
         ${DEFAULT_AGENT_ID}, ${organizationId}, ${DEFAULT_AGENT_NAME}, ${DEFAULT_AGENT_IDENTITY},
-        'lobu', NULL, false,
+        'external', ${ownerUserId}, false,
+        ${client.json(systemProviders)},
         NOW(), NOW()
       )
       ON CONFLICT (organization_id, id) DO NOTHING
     `;
+
+    // Mirror the ownership into agent_users so `userAgentsStore.ownsAgent`
+    // returns true on the PAT-session path used by `lobu chat -c local`.
+    if (ownerUserId) {
+      await client`
+        INSERT INTO agent_users (organization_id, agent_id, platform, user_id, created_at)
+        VALUES (${organizationId}, ${DEFAULT_AGENT_ID}, 'external', ${ownerUserId}, now())
+        ON CONFLICT (organization_id, agent_id, platform, user_id) DO NOTHING
+      `;
+    }
 
     await writeOrgSentinel(
       client,
@@ -175,7 +215,7 @@ export async function ensureDefaultAgent(
     );
 
     logger.info(
-      { organizationId, agentId: DEFAULT_AGENT_ID },
+      { organizationId, agentId: DEFAULT_AGENT_ID, ownerUserId },
       '[default-provisioning] Provisioned default agent'
     );
     return { created: true, reason: 'inserted' };

--- a/packages/server/src/auth/default-provisioning.ts
+++ b/packages/server/src/auth/default-provisioning.ts
@@ -161,13 +161,12 @@ async function backfillDefaultAgent(
   const row = rows[0];
   if (!row) return;
 
-  const ownerLookup = (await client`
-    SELECT (metadata::jsonb)->>'personal_org_for_user_id' AS owner_user_id
-      FROM "organization"
-     WHERE id = ${organizationId}
-     LIMIT 1
-  `) as unknown as Array<{ owner_user_id: string | null }>;
-  const ownerUserId = ownerLookup[0]?.owner_user_id ?? null;
+  const orgMetadata = await readOrgMetadata(client, organizationId);
+  const ownerUserIdRaw = orgMetadata['personal_org_for_user_id'];
+  const ownerUserId =
+    typeof ownerUserIdRaw === 'string' && ownerUserIdRaw.length > 0
+      ? ownerUserIdRaw
+      : null;
 
   const installedNow = Array.isArray(row.installed_providers)
     ? (row.installed_providers as Array<{ providerId: string }>)
@@ -270,13 +269,12 @@ export async function ensureDefaultAgent(
     // check in `verifyOwnedAgentAccess` recognizes this user as the agent's
     // owner: without it, a PAT session for the user can't open a session
     // against their own org's default agent.
-    const ownerRows = (await client`
-      SELECT (metadata::jsonb)->>'personal_org_for_user_id' AS owner_user_id
-        FROM "organization"
-       WHERE id = ${organizationId}
-       LIMIT 1
-    `) as unknown as Array<{ owner_user_id: string | null }>;
-    const ownerUserId = ownerRows[0]?.owner_user_id ?? null;
+    const orgMetadataForInsert = await readOrgMetadata(client, organizationId);
+    const ownerForInsertRaw = orgMetadataForInsert['personal_org_for_user_id'];
+    const ownerUserId =
+      typeof ownerForInsertRaw === 'string' && ownerForInsertRaw.length > 0
+        ? ownerForInsertRaw
+        : null;
 
     // Insert the default agent. The PK is (organization_id, id) so we can
     // ON CONFLICT DO NOTHING to guard against a parallel boot.

--- a/packages/server/src/auth/default-provisioning.ts
+++ b/packages/server/src/auth/default-provisioning.ts
@@ -128,12 +128,110 @@ export async function hasOrgSentinel(
  * Best-effort: a thrown error is logged and swallowed. A failure here must
  * not break the boot path that called us.
  */
+/**
+ * Backfill an existing default-agent row to the shape this code expects:
+ *   - owner_platform / owner_user_id populated to the personal-org owner
+ *     (legacy installs wrote `'lobu', NULL` which fails the per-user
+ *     ownership check in `verifyOwnedAgentAccess`).
+ *   - agent_users mapping for that (platform, user_id) so `ownsAgent`
+ *     returns true on the PAT-session path.
+ *   - installed_providers populated with all currently-available
+ *     system-key providers when empty. Never removes existing entries
+ *     and never overwrites a non-empty list — admins may have curated
+ *     the list intentionally.
+ *
+ * Idempotent and only writes when there's something to fix. Returns
+ * silently when the row is absent (caller decides whether to INSERT).
+ */
+async function backfillDefaultAgent(
+  organizationId: string,
+  client: DbClient
+): Promise<void> {
+  const rows = (await client`
+    SELECT owner_platform, owner_user_id, installed_providers
+      FROM agents
+     WHERE organization_id = ${organizationId}
+       AND id = ${DEFAULT_AGENT_ID}
+     LIMIT 1
+  `) as unknown as Array<{
+    owner_platform: string | null;
+    owner_user_id: string | null;
+    installed_providers: unknown;
+  }>;
+  const row = rows[0];
+  if (!row) return;
+
+  const ownerLookup = (await client`
+    SELECT (metadata::jsonb)->>'personal_org_for_user_id' AS owner_user_id
+      FROM "organization"
+     WHERE id = ${organizationId}
+     LIMIT 1
+  `) as unknown as Array<{ owner_user_id: string | null }>;
+  const ownerUserId = ownerLookup[0]?.owner_user_id ?? null;
+
+  const installedNow = Array.isArray(row.installed_providers)
+    ? (row.installed_providers as Array<{ providerId: string }>)
+    : [];
+  const installedIds = new Set(installedNow.map((p) => p.providerId));
+  const missingSystemProviders = getModelProviderModules()
+    .filter((m) => m.hasSystemKey() && !installedIds.has(m.providerId))
+    .map((m) => ({ providerId: m.providerId, installedAt: Date.now() }));
+
+  const needsOwnerFix =
+    ownerUserId &&
+    (row.owner_user_id !== ownerUserId || row.owner_platform !== 'external');
+  const needsProvidersFix =
+    installedNow.length === 0 && missingSystemProviders.length > 0;
+
+  if (needsOwnerFix || needsProvidersFix) {
+    const nextProviders = needsProvidersFix
+      ? missingSystemProviders
+      : installedNow;
+    await client`
+      UPDATE agents SET
+        owner_platform = ${needsOwnerFix ? 'external' : row.owner_platform},
+        owner_user_id = ${needsOwnerFix ? ownerUserId : row.owner_user_id},
+        installed_providers = ${client.json(nextProviders)},
+        updated_at = NOW()
+      WHERE organization_id = ${organizationId}
+        AND id = ${DEFAULT_AGENT_ID}
+    `;
+    logger.info(
+      {
+        organizationId,
+        agentId: DEFAULT_AGENT_ID,
+        ownerFixed: !!needsOwnerFix,
+        providersAdded: needsProvidersFix
+          ? missingSystemProviders.map((p) => p.providerId)
+          : [],
+      },
+      '[default-provisioning] Backfilled default agent'
+    );
+  }
+
+  if (ownerUserId) {
+    await client`
+      INSERT INTO agent_users (organization_id, agent_id, platform, user_id, created_at)
+      VALUES (${organizationId}, ${DEFAULT_AGENT_ID}, 'external', ${ownerUserId}, now())
+      ON CONFLICT (organization_id, agent_id, platform, user_id) DO NOTHING
+    `;
+  }
+}
+
 export async function ensureDefaultAgent(
   organizationId: string,
   sql?: DbClient
 ): Promise<{ created: boolean; reason: 'sentinel' | 'has_agents' | 'inserted' }> {
   const client = sql ?? getDb();
   try {
+    // Always run the backfill — it's idempotent and only writes when there's
+    // a divergence to fix. Legacy installs that ran ensureDefaultAgent before
+    // this PR have the row but with `owner_user_id = NULL` and
+    // `installed_providers = []`; the sentinel-fast-path would have skipped
+    // them otherwise, and `lobu chat -c local` would still hit 403 / "No
+    // model configured" on those installs.
+    await backfillDefaultAgent(organizationId, client);
+
     const provisioned = await hasOrgSentinel(organizationId, DEFAULT_AGENT_SENTINEL, client);
     if (provisioned) {
       return { created: false, reason: 'sentinel' };

--- a/packages/server/src/auth/default-provisioning.ts
+++ b/packages/server/src/auth/default-provisioning.ts
@@ -117,18 +117,6 @@ export async function hasOrgSentinel(
 }
 
 /**
- * Provision the default Owletto agent for the given org, exactly once.
- *
- * Three guards stack:
- *   1. Sentinel in `organization.metadata` (deletion stickiness).
- *   2. No existing agents in the org (don't graft Owletto's defaults onto an
- *      org that's already curated agents by hand).
- *   3. ON CONFLICT (organization_id, id) DO NOTHING on the agents PK.
- *
- * Best-effort: a thrown error is logged and swallowed. A failure here must
- * not break the boot path that called us.
- */
-/**
  * Backfill an existing default-agent row to the shape this code expects:
  *   - owner_platform / owner_user_id populated to the personal-org owner
  *     (legacy installs wrote `'lobu', NULL` which fails the per-user
@@ -217,6 +205,22 @@ async function backfillDefaultAgent(
   }
 }
 
+/**
+ * Provision the default Owletto agent for the given org, exactly once. Also
+ * runs `backfillDefaultAgent` on every call so legacy installs (where the
+ * row was inserted before this code populated owner/providers) heal in
+ * place — that part is idempotent and only writes on divergence.
+ *
+ * Three guards stack on the create path:
+ *   1. Sentinel in `organization.metadata` (deletion stickiness — a deleted
+ *      default agent is NOT auto-recreated).
+ *   2. No existing agents in the org (don't graft Owletto's defaults onto an
+ *      org that's already curated agents by hand).
+ *   3. ON CONFLICT (organization_id, id) DO NOTHING on the agents PK.
+ *
+ * Best-effort: a thrown error is logged and swallowed. A failure here must
+ * not break the boot path that called us.
+ */
 export async function ensureDefaultAgent(
   organizationId: string,
   sql?: DbClient

--- a/packages/server/src/gateway/__tests__/agent-session-create.test.ts
+++ b/packages/server/src/gateway/__tests__/agent-session-create.test.ts
@@ -92,3 +92,144 @@ describe("POST /api/v1/agents — enumeration-safe ownership denial", () => {
     });
   });
 });
+
+/**
+ * No-`agentId` (default-agent) resolution path.
+ *
+ * POST /api/v1/agents with an empty body must resolve to
+ * `DEFAULT_AGENT_ID` for the caller's org, scope the session id with that
+ * org so two tenants can't collide, and return 404 when the org has no
+ * default agent provisioned yet (rather than silently minting a new UUID
+ * or serving another tenant's row).
+ */
+describe("POST /api/v1/agents — default-agent resolution", () => {
+  const ORG_ID = "org-test";
+  const USER_ID = "user-test";
+
+  // A worker token bound to the caller's org. The auth middleware reads
+  // `organizationId` off the decrypted token and stamps `authContext` so
+  // the handler can resolve the org without a body field.
+  function orgBoundToken(): string {
+    return generateWorkerToken("owletto-default", "conv-bootstrap", "deploy-1", {
+      channelId: "api_test",
+      agentId: "owletto-default",
+      organizationId: ORG_ID,
+    });
+  }
+
+  // In-memory session store that records the last setSession call so the
+  // test can assert the tenant-scoped conversationId.
+  function makeSessionRecorder() {
+    const sessions = new Map<string, unknown>();
+    return {
+      store: {
+        async getSession(id: string) {
+          return sessions.get(id) ?? null;
+        },
+        async setSession(s: { conversationId: string }) {
+          sessions.set(s.conversationId, s);
+        },
+        async touchSession() {},
+        async deleteSession(id: string) {
+          sessions.delete(id);
+        },
+      },
+      sessions,
+    };
+  }
+
+  function makeAppWithDefault(opts: {
+    defaultAgentOrg: string | null;
+  }) {
+    const recorder = makeSessionRecorder();
+    const app = createAgentApi({
+      queueProducer: {} as never,
+      sessionManager: recorder.store as never,
+      sseManager: {} as never,
+      publicGatewayUrl: "http://localhost:8787",
+      agentSettingsStore: {
+        async saveSettings() {},
+      } as never,
+      agentMetadataStore: {
+        async getMetadata(id: string) {
+          if (id !== "owletto-default" || opts.defaultAgentOrg === null)
+            return null;
+          // Same owner the worker token authenticates as so the per-user
+          // ownership check passes.
+          return {
+            owner: { platform: "api", userId: "owletto-default" },
+            organizationId: opts.defaultAgentOrg,
+          };
+        },
+      } as never,
+      userAgentsStore: {
+        async ownsAgent() {
+          return true;
+        },
+      } as never,
+    });
+    return { app, recorder };
+  }
+
+  test("no-agentId body resolves to owletto-default for caller's org", async () => {
+    const { app, recorder } = makeAppWithDefault({ defaultAgentOrg: ORG_ID });
+    const res = await app.request("/api/v1/agents", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${orgBoundToken()}`,
+        "Content-Type": "application/json",
+      },
+      body: "{}",
+    });
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as { agentId?: string };
+    // conversationId = `${agentId}_${userId}_${orgId}` — the tenant suffix
+    // is what prevents cross-org session collisions when DEFAULT_AGENT_ID
+    // is a global constant.
+    expect(body.agentId).toContain("owletto-default");
+    expect(body.agentId).toContain(ORG_ID);
+    // Session actually persisted under that exact key.
+    expect(recorder.sessions.has(body.agentId!)).toBe(true);
+  });
+
+  test("returns 404 when the org has no default agent provisioned", async () => {
+    // `getMetadata("owletto-default")` returns null for this org → handler
+    // refuses rather than minting a phantom UUID (the old broken behavior)
+    // or serving another tenant's default row.
+    const { app } = makeAppWithDefault({ defaultAgentOrg: null });
+    const res = await app.request("/api/v1/agents", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${orgBoundToken()}`,
+        "Content-Type": "application/json",
+      },
+      body: "{}",
+    });
+    expect(res.status).toBe(404);
+    const body = (await res.json()) as { error?: string };
+    expect(body.error).toContain("Default agent");
+  });
+
+  test("returns 404 when the default agent belongs to a different org", async () => {
+    // Default agent exists, but its org doesn't match the caller's token
+    // org — must NOT leak. The same 404 as 'not provisioned' is fine; the
+    // critical property is that it refuses to mint a session against
+    // another tenant's row.
+    const { app } = makeAppWithDefault({ defaultAgentOrg: "org-other" });
+    const res = await app.request("/api/v1/agents", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${orgBoundToken()}`,
+        "Content-Type": "application/json",
+      },
+      body: "{}",
+    });
+    expect(res.status).toBe(404);
+  });
+
+  // Silence the unused-symbol warning for USER_ID — it's part of the
+  // documented session-id shape (`<agentId>_<userId>_<orgId>`) the test
+  // asserts on but we don't pin the exact userId since it's derived from
+  // authContext under the hood.
+  void USER_ID;
+});

--- a/packages/server/src/gateway/__tests__/agent-session-create.test.ts
+++ b/packages/server/src/gateway/__tests__/agent-session-create.test.ts
@@ -210,6 +210,97 @@ describe("POST /api/v1/agents — default-agent resolution", () => {
     expect(body.error).toContain("Default agent");
   });
 
+  test("cross-tenant GET on a session URL is denied with 403", async () => {
+    // Set up: orgA creates a session via POST /api/v1/agents, then orgB
+    // tries to GET that exact session URL. Both orgs nominally "own"
+    // agentId `owletto-default` (the global constant) — without the
+    // tenant guard in requireAgentOwnership, orgB would pass the
+    // (platform, userId, agentId) check and read orgA's session row.
+    const orgA = "org-A";
+    const orgB = "org-B";
+    const tokenA = generateWorkerToken("owletto-default", "conv-A", "deploy-A", {
+      channelId: "api_test",
+      agentId: "owletto-default",
+      organizationId: orgA,
+    });
+    const tokenB = generateWorkerToken("owletto-default", "conv-B", "deploy-B", {
+      channelId: "api_test",
+      agentId: "owletto-default",
+      organizationId: orgB,
+    });
+
+    // Shared metadata store: BOTH orgs have an `owletto-default` agent that
+    // their respective workers own (the cross-tenant collision setup pi
+    // exploited).
+    const sharedSessions = new Map<string, any>();
+    sharedSessions.set("owletto-default_owletto-default_org-A", {
+      conversationId: "owletto-default_owletto-default_org-A",
+      userId: "owletto-default",
+      agentId: "owletto-default",
+      organizationId: orgA,
+      status: "created",
+      createdAt: Date.now(),
+      lastActivity: Date.now(),
+    });
+
+    const app = createAgentApi({
+      queueProducer: {} as never,
+      sessionManager: {
+        async getSession(id: string) {
+          return sharedSessions.get(id) ?? null;
+        },
+        async setSession(s: any) {
+          sharedSessions.set(s.conversationId, s);
+        },
+        async touchSession() {},
+        async deleteSession(id: string) {
+          sharedSessions.delete(id);
+        },
+      } as never,
+      sseManager: {
+        hasActiveConnection() {
+          return false;
+        },
+      } as never,
+      publicGatewayUrl: "http://localhost:8787",
+      agentMetadataStore: {
+        async getMetadata(id: string) {
+          if (id !== "owletto-default") return null;
+          return {
+            owner: { platform: "api", userId: "owletto-default" },
+          };
+        },
+      } as never,
+      userAgentsStore: {
+        async ownsAgent() {
+          return true;
+        },
+      } as never,
+    });
+
+    // Sanity: orgA can GET its own session (token A authenticates as the
+    // owner, session.organizationId matches authContext).
+    const okSelf = await app.request(
+      "/api/v1/agents/owletto-default_owletto-default_org-A",
+      { headers: { Authorization: `Bearer ${tokenA}` } }
+    );
+    expect(okSelf.status).toBe(200);
+
+    // Real test: orgB tries the same URL. Ownership check would otherwise
+    // pass (orgB also owns agent `owletto-default`) — the tenant guard
+    // inside requireAgentOwnership refuses based on session.organizationId
+    // (orgA) ≠ caller orgId (orgB).
+    const denied = await app.request(
+      "/api/v1/agents/owletto-default_owletto-default_org-A",
+      { headers: { Authorization: `Bearer ${tokenB}` } }
+    );
+    expect(denied.status).toBe(403);
+    expect((await denied.json()) as { error?: string }).toEqual({
+      success: false,
+      error: "Forbidden",
+    });
+  });
+
   test("returns 404 when the default agent belongs to a different org", async () => {
     // Default agent exists, but its org doesn't match the caller's token
     // org — must NOT leak. The same 404 as 'not provisioned' is fine; the

--- a/packages/server/src/gateway/__tests__/agent-session-create.test.ts
+++ b/packages/server/src/gateway/__tests__/agent-session-create.test.ts
@@ -301,6 +301,94 @@ describe("POST /api/v1/agents — default-agent resolution", () => {
     });
   });
 
+  test("cross-tenant GET via a settings-session COOKIE is denied with 403", async () => {
+    // The worker/PAT/OAuth auth paths populate an org on the auth context, so
+    // the up-front tenant guard catches their cross-tenant attempts (the test
+    // above). The settings-session COOKIE path populates only a userId —
+    // callerOrgId stays undefined and that guard is a no-op. This exercises the
+    // resolved-org fallback inside requireAgentOwnership: verifyOwnedAgentAccess
+    // authorizes orgB's cookie user (they own their own `owletto-default`) but
+    // resolves their org to orgB, which must NOT match orgA's session. Without
+    // the fallback this GET would return 200 and leak orgA's session.
+    const orgA = "org-A";
+    const orgB = "org-B";
+
+    const sharedSessions = new Map<string, any>();
+    const seed = (org: string) => {
+      const id = `owletto-default_user-cookie_${org}`;
+      sharedSessions.set(id, {
+        conversationId: id,
+        userId: "user-cookie",
+        agentId: "owletto-default",
+        organizationId: org,
+        status: "created",
+        createdAt: Date.now(),
+        lastActivity: Date.now(),
+      });
+      return id;
+    };
+    const orgASession = seed(orgA);
+    const orgBSession = seed(orgB);
+
+    const app = createAgentApi({
+      queueProducer: {} as never,
+      sessionManager: {
+        async getSession(id: string) {
+          return sharedSessions.get(id) ?? null;
+        },
+        async setSession() {},
+        async touchSession() {},
+        async deleteSession() {},
+      } as never,
+      sseManager: {
+        hasActiveConnection() {
+          return false;
+        },
+      } as never,
+      publicGatewayUrl: "http://localhost:8787",
+      agentMetadataStore: {
+        async getMetadata(id: string) {
+          if (id !== "owletto-default") return null;
+          return { owner: { platform: "api", userId: "user-cookie" } };
+        },
+      } as never,
+      userAgentsStore: {
+        async ownsAgent() {
+          return true;
+        },
+        // The cookie user belongs to orgB only — this is the org
+        // verifyOwnedAgentAccess resolves and compares against the session's.
+        async findAgentOrganizations() {
+          return [orgB];
+        },
+      } as never,
+    });
+
+    // A settings-session cookie carries a userId, NOT an org —
+    // createApiAuthMiddleware stamps authContext = { userId } with no
+    // organizationId, so callerOrgId is undefined and the up-front guard
+    // can't fire.
+    setAuthProvider(() => ({
+      userId: "user-cookie",
+      platform: "api",
+      exp: Date.now() + 60_000,
+    }));
+
+    // Sanity: the cookie user reaches their OWN org's session (resolved org
+    // orgB === session org orgB → allowed; never a false-deny).
+    const okSelf = await app.request(`/api/v1/agents/${orgBSession}`);
+    expect(okSelf.status).toBe(200);
+
+    // The fix: the same cookie user is denied orgA's session (resolved org
+    // orgB ≠ session org orgA) even though ownsAgent() returns true.
+    const denied = await app.request(`/api/v1/agents/${orgASession}`);
+    expect(denied.status).toBe(403);
+    expect((await denied.json()) as { error?: string }).toEqual({
+      success: false,
+      error: "Forbidden",
+    });
+  });
+
   test("returns 404 when the default agent belongs to a different org", async () => {
     // Default agent exists, but its org doesn't match the caller's token
     // org — must NOT leak. The same 404 as 'not provisioned' is fine; the
@@ -323,4 +411,81 @@ describe("POST /api/v1/agents — default-agent resolution", () => {
   // asserts on but we don't pin the exact userId since it's derived from
   // authContext under the hood.
   void USER_ID;
+});
+
+/**
+ * Watcher session-id shape.
+ *
+ * Watcher dispatch correlation — the worker session key AND the API/SSE
+ * owner-routing key (unified-thread-consumer) — both derive from the
+ * conversationId and rely on the exact `..._watcher_<watcherId>_run_<runId>`
+ * shape. The org-scope suffix added for the default-agent / pinned-API paths
+ * must NOT be spliced into watcher conversationIds: `_<org>_` between
+ * `watcher_<id>` and `run_<id>` breaks watcher→worker dispatch (the sdk-e2e
+ * watcher gate went red on exactly this). Tenant isolation for watchers rides
+ * `session.organizationId` (still set) + the route guard, not the id string.
+ */
+describe("POST /api/v1/agents — watcher session id shape", () => {
+  const ORG_ID = "org-watcher";
+
+  test("watcher conversationId keeps watcher_<id>_run_<id> and omits the org suffix", async () => {
+    const sessions = new Map<string, { conversationId: string }>();
+    const app = createAgentApi({
+      queueProducer: {} as never,
+      sessionManager: {
+        async getSession(id: string) {
+          return sessions.get(id) ?? null;
+        },
+        async setSession(s: { conversationId: string }) {
+          sessions.set(s.conversationId, s);
+        },
+        async touchSession() {},
+        async deleteSession() {},
+      } as never,
+      sseManager: {} as never,
+      publicGatewayUrl: "http://localhost:8787",
+      agentMetadataStore: {
+        async getMetadata(id: string) {
+          // Non-empty org metadata → tokenOrganizationId resolves, so the
+          // suffix WOULD be added on a non-watcher path. The watcher exemption
+          // is what keeps it out.
+          return id === "watcher-agent"
+            ? {
+                owner: { platform: "api", userId: "watcher-agent" },
+                organizationId: ORG_ID,
+              }
+            : null;
+        },
+      } as never,
+    });
+
+    // Worker token scoped to the watcher's agent + org (mirrors the internal
+    // service token the watcher dispatcher mints).
+    const token = generateWorkerToken("watcher-agent", "conv-w", "deploy-w", {
+      channelId: "api_test",
+      agentId: "watcher-agent",
+      organizationId: ORG_ID,
+    });
+
+    const res = await app.request("/api/v1/agents", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        agentId: "watcher-agent",
+        userId: "watcher-5",
+        thread: "watcher-5",
+        forceNew: true,
+        intent: { kind: "watcher_run", runId: 27, watcherId: 5 },
+      }),
+    });
+
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as { agentId?: string };
+    // Exact prod-proven shape: `<agentId>_watcher_<watcherId>_run_<runId>`.
+    expect(body.agentId).toBe("watcher-agent_watcher_5_run_27");
+    expect(body.agentId).not.toContain(ORG_ID);
+  });
 });

--- a/packages/server/src/gateway/auth/api-auth-middleware.ts
+++ b/packages/server/src/gateway/auth/api-auth-middleware.ts
@@ -1,10 +1,30 @@
 import { verifyWorkerToken } from "@lobu/core";
 import type { Context, Next } from "hono";
+import { orgContext } from "../../lobu/stores/org-context.js";
 import { verifySettingsSession } from "../routes/public/settings-auth.js";
 import type { ExternalAuthClient } from "./external/client.js";
 import { getRevokedTokenStore } from "./revoked-token-store.js";
 
 export const TOKEN_EXPIRATION_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * Caller identity surfaced to handlers via `c.get("authContext")` after a
+ * successful auth check. `organizationId` is the token-bound or personal-org
+ * id when the auth path can resolve one (worker token payload, or
+ * `/oauth/userinfo` org slug); otherwise undefined. `createAgent` uses it to
+ * route no-agentId requests to the org's default agent so the cross-pod
+ * conversation lock can be acquired (#1068 follow-up).
+ */
+export interface ApiAuthContext {
+  userId?: string;
+  organizationId?: string;
+}
+
+declare module "hono" {
+  interface ContextVariableMap {
+    authContext?: ApiAuthContext;
+  }
+}
 
 /**
  * Creates a Hono middleware that enforces the standard auth check:
@@ -13,6 +33,14 @@ export const TOKEN_EXPIRATION_MS = 24 * 60 * 60 * 1000;
  * The worker-token check is local + cheap, so it runs before the remote OIDC
  * userinfo fetch — a valid worker token never needs to round-trip to the
  * identity provider.
+ *
+ * On a successful check, the caller's identity is attached to the Hono context
+ * as `authContext`. When that includes an `organizationId`, the rest of the
+ * request runs inside `orgContext.run()` so Postgres-backed stores (which read
+ * the org id from AsyncLocalStorage via `getOrgId()`) see the same tenant.
+ * `createLobuAuthBridge` already wraps PAT-authenticated requests this way;
+ * this is the equivalent for the worker-token and external-OAuth paths, which
+ * `createLobuAuthBridge` doesn't cover.
  */
 export function createApiAuthMiddleware(opts: {
   externalAuthClient?: ExternalAuthClient;
@@ -21,13 +49,27 @@ export function createApiAuthMiddleware(opts: {
 }) {
   const revokedTokens = getRevokedTokenStore();
 
+  const runWithContext = (
+    ctx: ApiAuthContext,
+    c: Context,
+    next: Next
+  ): Promise<void> | void => {
+    c.set("authContext", ctx);
+    if (ctx.organizationId) {
+      return orgContext.run({ organizationId: ctx.organizationId }, () =>
+        next()
+      );
+    }
+    return next();
+  };
+
   return async (c: Context, next: Next) => {
     // 1. Try settings session cookie when explicitly allowed.
     // verifySettingsSession now enforces jti revocation internally.
     if (opts.allowSettingsSession) {
       const session = await verifySettingsSession(c);
       if (session) {
-        return next();
+        return runWithContext({ userId: session.userId }, c, next);
       }
     }
 
@@ -46,7 +88,14 @@ export function createApiAuthMiddleware(opts: {
           if (workerData.jti && (await revokedTokens.isRevoked(workerData.jti))) {
             return c.json({ success: false, error: "Unauthorized" }, 401);
           }
-          return next();
+          return runWithContext(
+            {
+              userId: workerData.userId,
+              organizationId: workerData.organizationId,
+            },
+            c,
+            next
+          );
         }
       }
     }
@@ -55,7 +104,16 @@ export function createApiAuthMiddleware(opts: {
     if (opts.externalAuthClient) {
       try {
         const userInfo = await opts.externalAuthClient.fetchUserInfo(token);
-        if (userInfo?.sub) return next();
+        if (userInfo?.sub) {
+          return runWithContext(
+            {
+              userId: userInfo.sub,
+              organizationId: userInfo.organizationId,
+            },
+            c,
+            next
+          );
+        }
       } catch {
         // Token not valid for external auth, continue to next method
       }

--- a/packages/server/src/gateway/auth/external/client.ts
+++ b/packages/server/src/gateway/auth/external/client.ts
@@ -43,10 +43,27 @@ interface WellKnownMetadata {
   grant_types_supported?: string[];
 }
 
-interface UserInfoResponse {
+export interface UserInfoResponse {
   sub: string;
   email: string;
   name?: string;
+  /**
+   * Token-bound org id, or — when the token has no org binding (e.g. a
+   * device-flow PAT) — the user's personal-org id. Resolved by mapping
+   * `organization_slug` to its entry in `organizations[]` (both already
+   * returned by `/oauth/userinfo`). Surfaced so `createApiAuthMiddleware`
+   * can attach an org context to handlers like `createAgent`, which
+   * otherwise has no way to find the org for an ephemeral request.
+   */
+  organizationId?: string;
+}
+
+interface UserInfoApiResponse {
+  sub: string;
+  email: string;
+  name?: string;
+  organization_slug?: string | null;
+  organizations?: { id: string; slug: string; name: string }[];
 }
 
 interface DynamicClientCredentials {
@@ -167,12 +184,23 @@ export class ExternalAuthClient {
       );
     }
 
-    const data = (await response.json()) as UserInfoResponse;
+    const data = (await response.json()) as UserInfoApiResponse;
+    const orgId =
+      data.organization_slug && data.organizations
+        ? (data.organizations.find((o) => o.slug === data.organization_slug)
+            ?.id ?? undefined)
+        : undefined;
     logger.info("Fetched external auth user info", {
       sub: data.sub,
       email: data.email,
+      orgId,
     });
-    return data;
+    return {
+      sub: data.sub,
+      email: data.email,
+      name: data.name,
+      organizationId: orgId,
+    };
   }
 
   async getCapabilities(): Promise<ExternalAuthCapabilities> {

--- a/packages/server/src/gateway/connections/chat-instance-manager.ts
+++ b/packages/server/src/gateway/connections/chat-instance-manager.ts
@@ -173,6 +173,15 @@ export class ChatInstanceManager {
   private slackCoordinator!: SlackConnectionCoordinator;
   private connectionStore!: AgentConnectionStore;
 
+  /**
+   * Public gateway base URL (`PUBLIC_WEB_URL` or derived) — exposed so the
+   * response bridge can build links into the admin UI (e.g. the
+   * provider-settings page) for user-facing error messages.
+   */
+  getPublicGatewayUrl(): string {
+    return this.publicGatewayUrl;
+  }
+
   async initialize(services: CoreServices): Promise<void> {
     this.services = services;
     this.publicGatewayUrl = services.getPublicGatewayUrl();

--- a/packages/server/src/gateway/connections/chat-response-bridge.ts
+++ b/packages/server/src/gateway/connections/chat-response-bridge.ts
@@ -19,6 +19,7 @@ import {
   runGuardrails,
 } from "@lobu/core";
 import { getDb } from "../../db/client.js";
+import { getOrganizationSlug } from "../../utils/url-builder.js";
 import type { AgentSettingsStore } from "../auth/settings/agent-settings-store.js";
 import { recordGuardrailTrip } from "../guardrails/audit.js";
 import type { ThreadResponsePayload } from "../infrastructure/queue/index.js";
@@ -37,6 +38,23 @@ import {
 } from "./platform-strategies/index.js";
 
 const logger = createLogger("chat-response-bridge");
+
+/**
+ * Build the agent's admin-settings URL — `<publicWebUrl>/<orgSlug>/agents/<agentId>`
+ * — for surfacing in user-facing error messages (e.g. NO_MODEL_CONFIGURED tells
+ * the user where to connect a provider). Returns null when any required piece
+ * is missing; callers fall back to non-linked guidance.
+ */
+async function buildAgentSettingsUrl(
+  publicGatewayUrl: string | undefined,
+  organizationId: string | undefined,
+  agentId: string | undefined
+): Promise<string | null> {
+  if (!publicGatewayUrl || !organizationId || !agentId) return null;
+  const slug = await getOrganizationSlug(organizationId).catch(() => null);
+  if (!slug) return null;
+  return `${publicGatewayUrl.replace(/\/+$/, "")}/${slug}/agents/${encodeURIComponent(agentId)}`;
+}
 
 /**
  * Construct a minimal Chat SDK `Message`-shaped object from the inbound
@@ -615,11 +633,21 @@ export class ChatResponseBridge implements ResponseRenderer {
       return;
     }
 
-    // For known error codes, render user-facing guidance without sending users
-    // to the retired end-user settings UI.
+    // For known error codes, render user-facing guidance with a real link
+    // into the admin UI when we can resolve one. The settings page for an
+    // agent is `<publicWebUrl>/<orgSlug>/agents/<agentId>`.
     if (payload.errorCode === "NO_MODEL_CONFIGURED") {
-      payload.error =
-        "No model configured. Provider setup is not available in the end-user chat flow yet. Ask an admin to connect a provider for the base agent.";
+      const errCtx = this.extractResponseContext(payload);
+      const settingsUrl = errCtx
+        ? await buildAgentSettingsUrl(
+            this.manager.getPublicGatewayUrl(),
+            this.resolveOrganizationId(payload, errCtx) ?? undefined,
+            this.resolveAgentId(payload, errCtx) ?? undefined
+          )
+        : null;
+      payload.error = settingsUrl
+        ? `No model configured. Connect a provider at ${settingsUrl}`
+        : "No model configured. Ask an admin to connect a provider for the base agent.";
     }
 
     // Fallback: plain text error via Chat SDK

--- a/packages/server/src/gateway/connections/chat-response-bridge.ts
+++ b/packages/server/src/gateway/connections/chat-response-bridge.ts
@@ -44,6 +44,11 @@ const logger = createLogger("chat-response-bridge");
  * — for surfacing in user-facing error messages (e.g. NO_MODEL_CONFIGURED tells
  * the user where to connect a provider). Returns null when any required piece
  * is missing; callers fall back to non-linked guidance.
+ *
+ * `manager.publicGatewayUrl` is the gateway base, which in embedded mode
+ * includes the `/lobu` path suffix (the gateway is mounted at `/lobu` under
+ * the web app). Admin UI routes live at the web origin (`/<slug>/agents/...`)
+ * NOT under `/lobu`, so strip a trailing `/lobu` before composing the link.
  */
 async function buildAgentSettingsUrl(
   publicGatewayUrl: string | undefined,
@@ -53,7 +58,10 @@ async function buildAgentSettingsUrl(
   if (!publicGatewayUrl || !organizationId || !agentId) return null;
   const slug = await getOrganizationSlug(organizationId).catch(() => null);
   if (!slug) return null;
-  return `${publicGatewayUrl.replace(/\/+$/, "")}/${slug}/agents/${encodeURIComponent(agentId)}`;
+  const webOrigin = publicGatewayUrl
+    .replace(/\/+$/, "")
+    .replace(/\/lobu$/, "");
+  return `${webOrigin}/${slug}/agents/${encodeURIComponent(agentId)}`;
 }
 
 /**

--- a/packages/server/src/gateway/routes/public/agent.ts
+++ b/packages/server/src/gateway/routes/public/agent.ts
@@ -5,7 +5,6 @@ import {
   createLogger,
   createRootSpan,
   generateWorkerToken,
-  type InstalledProvider,
   type McpServerConfig,
   type NetworkConfig,
   normalizeDomainPatterns,
@@ -15,6 +14,7 @@ import type { Context } from "hono";
 import { streamSSE } from "hono/streaming";
 import { bindRequestAbortToStream } from "../../../events/sse-abort-bridge.js";
 import { z } from "zod";
+import { DEFAULT_AGENT_ID } from "../../../auth/default-provisioning.js";
 import type { AgentMetadataStore } from "../../auth/agent-metadata-store.js";
 import { getRevokedTokenStore } from "../../auth/revoked-token-store.js";
 import {
@@ -26,7 +26,6 @@ import type { AgentSettingsStore } from "../../auth/settings/agent-settings-stor
 import type { SettingsTokenPayload } from "../../auth/settings/token-service.js";
 import type { UserAgentsStore } from "../../auth/user-agents-store.js";
 import type { QueueProducer } from "../../infrastructure/queue/queue-producer.js";
-import { getModelProviderModules } from "../../modules/module-system.js";
 import type { PlatformRegistry } from "../../platform.js";
 import { resolveAgentOptions } from "../../services/platform-helpers.js";
 import type { SseManager } from "../../services/sse-manager.js";
@@ -624,52 +623,64 @@ export function createAgentApi(config: AgentApiConfig): OpenAPIHono {
       }
     }
 
-    const isEphemeral = !requestedAgentId?.trim();
-    const agentId = requestedAgentId?.trim() || randomUUID();
-
-    // If the caller pinned a specific agentId, require ownership so a signed-in
-    // user cannot open a session against another tenant's agent. The denial is
-    // uniform on purpose: never reveal whether `agentId` exists (distinguishing
-    // "missing" from "exists-but-unauthorized" would be a cross-tenant
-    // enumeration oracle). The getting-started UX is carried by `lobu run`
-    // auto-applying the project, so a fresh local agent exists by chat time.
-    if (!isEphemeral) {
-      const denial = await requireAgentOwnership(c, agentId);
-      if (denial) return denial;
+    // Resolve the target agent. Two flows, no third:
+    //   - caller pinned agentId → use it (with ownership check)
+    //   - no agentId → route to the org's default agent (`owletto-default`)
+    // The third flow that used to live here ("ephemeral": generate a UUID
+    // and auto-install providers on it) is gone — it created a phantom
+    // agent per chat, never used the user's actual default agent, and the
+    // saveSettings UPDATE silently no-op'd on a row that didn't exist yet.
+    // Default-agent provisioning runs at signup (`ensureDefaultAgent`) and
+    // already populates `installed_providers` from system-key providers,
+    // so the row exists with credentials by the time chat reaches here.
+    //
+    // Org resolution: `createLobuAuthBridge` (outer middleware on `/lobu/*`)
+    // sets `c.get("organizationId")` from the PAT — that's the common path
+    // for `lobu chat -c local`. `createApiAuthMiddleware` (this app's inner
+    // middleware) sets `authContext` for the worker-token and external-OAuth
+    // paths. Check both.
+    const callerOrgId =
+      (c.get("organizationId") as string | undefined) ??
+      c.get("authContext")?.organizationId;
+    let agentId = requestedAgentId?.trim();
+    if (!agentId) {
+      if (!callerOrgId) {
+        return c.json(
+          {
+            success: false,
+            error:
+              "Cannot resolve default agent: caller has no organization context",
+          },
+          400
+        );
+      }
+      const defaultMeta = await ownershipMetadataStore?.getMetadata(
+        DEFAULT_AGENT_ID
+      );
+      if (!defaultMeta || defaultMeta.organizationId !== callerOrgId) {
+        return c.json(
+          {
+            success: false,
+            error: `Default agent "${DEFAULT_AGENT_ID}" not provisioned for this organization. Run lobu apply or create an agent first.`,
+          },
+          404
+        );
+      }
+      agentId = DEFAULT_AGENT_ID;
     }
+
+    const ownershipDenial = await requireAgentOwnership(c, agentId);
+    if (ownershipDenial) return ownershipDenial;
 
     // Stamp the worker token with the agent's owning org so the egress
     // proxy's per-tenant gates (grant/deny, judge cache, judge policy)
-    // can scope decisions by org. Ephemeral agents have no preexisting
-    // metadata; their token mints without orgId and the proxy falls
-    // through to unscoped checks for that worker — flagged for a
-    // future fix that derives org from the auth session.
-    const tokenOrganizationId =
-      !isEphemeral && ownershipMetadataStore
-        ? (await ownershipMetadataStore.getMetadata(agentId))?.organizationId
-        : undefined;
-
-    // For ephemeral agents, auto-provision settings from system-key
-    // providers (env-var-based API keys). No more template-agent fallback —
-    // there are no template/sandbox agents anymore.
-    if (isEphemeral && agentSettingsStore) {
-      const providerModules = getModelProviderModules();
-      const systemProviders: InstalledProvider[] = providerModules
-        .filter((m) => m.hasSystemKey())
-        .map((m) => ({
-          providerId: m.providerId,
-          installedAt: Date.now(),
-        }));
-
-      if (systemProviders.length > 0) {
-        await agentSettingsStore.saveSettings(agentId, {
-          installedProviders: systemProviders,
-        });
-        logger.info(
-          `Ephemeral agent ${agentId}: provisioned system providers [${systemProviders.map((p) => p.providerId).join(", ")}]`
-        );
-      }
-    }
+    // can scope decisions by org. Prefer the agent's metadata; fall back
+    // to the caller's auth-context org for the default-agent route where
+    // the lookup above already proved ownership.
+    const metadataOrgId = ownershipMetadataStore
+      ? (await ownershipMetadataStore.getMetadata(agentId))?.organizationId
+      : undefined;
+    const tokenOrganizationId = metadataOrgId ?? callerOrgId;
 
     const watcherIntent = intent?.kind === "watcher_run" ? intent : null;
     const userId = watcherIntent
@@ -761,7 +772,6 @@ export function createAgentApi(config: AgentApiConfig): OpenAPIHono {
       ...(tokenOrganizationId ? { organizationId: tokenOrganizationId } : {}),
       dryRun: effectiveDryRun,
       intent: watcherIntent ?? undefined,
-      isEphemeral,
     };
     await sessMgr.setSession(session);
 
@@ -829,20 +839,12 @@ export function createAgentApi(config: AgentApiConfig): OpenAPIHono {
     // replay stale completion events from this deleted session.
     sseManager.closeAgent(sessionKey, "agent_deleted");
 
-    // Reuse the session we loaded for ownership verification above.
-    const realAgentId = existingSession?.agentId || sessionKey;
-    const wasEphemeral = existingSession?.isEphemeral === true;
-
+    // Delete the session only. Agent rows persist — they're owned by the
+    // org (declared agents) or the user's personal org (the default agent).
+    // The phantom-ephemeral-agent cleanup that used to run here is gone:
+    // there are no phantom rows to clean up under the default-agent flow.
     await sessMgr.deleteSession(sessionKey);
-    // Only tear down agent settings if we auto-provisioned them for an
-    // ephemeral session. Named/shared agents (like ones loaded from
-    // filesystem config) must keep their settings across session lifecycles.
-    if (wasEphemeral && agentSettingsStore) {
-      await agentSettingsStore.deleteSettings(realAgentId).catch(() => {
-        /* best-effort cleanup */
-      });
-    }
-    logger.info(`Deleted agent ${sessionKey}`);
+    logger.info(`Deleted agent session ${sessionKey}`);
 
     return c.json({
       success: true,

--- a/packages/server/src/gateway/routes/public/agent.ts
+++ b/packages/server/src/gateway/routes/public/agent.ts
@@ -683,9 +683,18 @@ export function createAgentApi(config: AgentApiConfig): OpenAPIHono {
     const tokenOrganizationId = metadataOrgId ?? callerOrgId;
 
     const watcherIntent = intent?.kind === "watcher_run" ? intent : null;
+    // userId backs `conversationId = ${agentId}_${userId}[_${thread}]`, which
+    // is the session-store key. For pinned agents the agentId is per-org so
+    // collisions are bounded to a single tenant. For the default-agent path
+    // agentId is a GLOBAL constant (DEFAULT_AGENT_ID) — so the userId must
+    // be unique-per-caller to keep conversationIds globally unique and
+    // prevent cross-tenant session resume. Prefer the request body, then the
+    // authenticated caller's userId (per-org-unique via the auth bridge),
+    // then fall back to agentId (only for pinned agents where that's safe).
+    const authUserId = c.get("authContext")?.userId;
     const userId = watcherIntent
       ? `watcher_${watcherIntent.watcherId}`
-      : requestedUserId || agentId;
+      : requestedUserId || authUserId || agentId;
     const effectiveThread = watcherIntent
       ? `run_${watcherIntent.runId}`
       : thread;
@@ -702,9 +711,24 @@ export function createAgentApi(config: AgentApiConfig): OpenAPIHono {
     const channelId = `api_${userId}`;
     const deploymentName = `api-${agentId.slice(0, 8)}`;
 
-    // Try to resume existing session (unless forceNew is requested)
+    // Try to resume existing session (unless forceNew is requested).
+    // Refuse cross-tenant resume defensively: even though the userId fallback
+    // above is per-org-unique for the default-agent path, a future caller that
+    // bypasses the auth bridge or passes a colliding requestedUserId would
+    // otherwise resume another tenant's session and leak its worker token.
     if (!effectiveForceNew) {
       const existing = await sessMgr.getSession(conversationId);
+      if (
+        existing &&
+        existing.organizationId &&
+        tokenOrganizationId &&
+        existing.organizationId !== tokenOrganizationId
+      ) {
+        logger.warn(
+          `Refusing to resume session ${conversationId} for org ${tokenOrganizationId}: belongs to org ${existing.organizationId}`
+        );
+        return c.json({ success: false, error: "Forbidden" }, 403);
+      }
       if (existing) {
         // Reuse existing session — touch lastActivity and return existing token
         await sessMgr.touchSession(conversationId);

--- a/packages/server/src/gateway/routes/public/agent.ts
+++ b/packages/server/src/gateway/routes/public/agent.ts
@@ -705,9 +705,18 @@ export function createAgentApi(config: AgentApiConfig): OpenAPIHono {
     // Uses _ separator (colons not allowed in BullMQ custom IDs). Watcher
     // automation gets one deterministic one-shot session per run and never
     // resumes human/API sessions such as marketing_marketing.
+    //
+    // Tenant-scope: include tokenOrganizationId so default-agent sessions
+    // (DEFAULT_AGENT_ID is a global constant) AND pinned-agent sessions
+    // (agentId is a per-org-unique row id, but two orgs can share the same
+    // id string) never collide across tenants in the in-memory session
+    // store. The resume guard below catches in-flight collisions; the org
+    // suffix prevents `forceNew` from silently overwriting another tenant's
+    // session at setSession time.
+    const orgScope = tokenOrganizationId ? `_${tokenOrganizationId}` : "";
     const conversationId = effectiveThread
-      ? `${agentId}_${userId}_${effectiveThread}`
-      : `${agentId}_${userId}`;
+      ? `${agentId}_${userId}${orgScope}_${effectiveThread}`
+      : `${agentId}_${userId}${orgScope}`;
     const channelId = `api_${userId}`;
     const deploymentName = `api-${agentId.slice(0, 8)}`;
 

--- a/packages/server/src/gateway/routes/public/agent.ts
+++ b/packages/server/src/gateway/routes/public/agent.ts
@@ -505,10 +505,33 @@ export function createAgentApi(config: AgentApiConfig): OpenAPIHono {
    */
   async function requireAgentOwnership(
     c: Context,
-    resolvedAgentId: string
+    resolvedAgentId: string,
+    sessionForTenantCheck?: { organizationId?: string } | null
   ): Promise<Response | null> {
     const deny = () =>
       c.json({ success: false, error: "Forbidden" }, 403) as Response;
+
+    // Tenant guard: agent-id-string ownership is per (platform, userId,
+    // agentId) — but the agentId string can repeat across tenants (the
+    // global `DEFAULT_AGENT_ID` constant, or two orgs that happen to share
+    // an id). If a session belongs to org A and the caller's auth context
+    // says org B, deny BEFORE any ownership check — otherwise org B would
+    // pass ownership against its own agent-X and reach org A's session
+    // routed by the same agent-X. Returning the same `Forbidden` shape as
+    // ownership keeps the response uniform (no enumeration oracle on which
+    // check failed). Routes that load a session before calling this MUST
+    // pass it in; createAgent has no pre-existing session and passes null.
+    if (sessionForTenantCheck?.organizationId) {
+      const callerOrgId =
+        (c.get("organizationId") as string | undefined) ??
+        c.get("authContext")?.organizationId;
+      if (
+        callerOrgId &&
+        sessionForTenantCheck.organizationId !== callerOrgId
+      ) {
+        return deny();
+      }
+    }
 
     const bearer = tokenFromHeader(c);
 
@@ -835,7 +858,8 @@ export function createAgentApi(config: AgentApiConfig): OpenAPIHono {
 
     const denial = await requireAgentOwnership(
       c,
-      session.agentId || sessionKey
+      session.agentId || sessionKey,
+      session
     );
     if (denial) return denial;
 
@@ -863,7 +887,8 @@ export function createAgentApi(config: AgentApiConfig): OpenAPIHono {
     const existingSession = await sessMgr.getSession(sessionKey);
     const denial = await requireAgentOwnership(
       c,
-      existingSession?.agentId || sessionKey
+      existingSession?.agentId || sessionKey,
+      existingSession
     );
     if (denial) return denial;
 
@@ -899,7 +924,8 @@ export function createAgentApi(config: AgentApiConfig): OpenAPIHono {
     // cross-tenant caller would receive another agent's buffered events.
     const denial = await requireAgentOwnership(
       c,
-      session.agentId || sessionKey
+      session.agentId || sessionKey,
+      session
     );
     if (denial) return denial;
 
@@ -1016,7 +1042,8 @@ export function createAgentApi(config: AgentApiConfig): OpenAPIHono {
     const preSession = await sessMgr.getSession(agentId);
     const ownershipDenial = await requireAgentOwnership(
       c,
-      preSession?.agentId || agentId
+      preSession?.agentId || agentId,
+      preSession
     );
     if (ownershipDenial) return ownershipDenial;
 

--- a/packages/server/src/gateway/routes/public/agent.ts
+++ b/packages/server/src/gateway/routes/public/agent.ts
@@ -533,6 +533,33 @@ export function createAgentApi(config: AgentApiConfig): OpenAPIHono {
       }
     }
 
+    // Defense-in-depth for the tenant guard above. That guard only fires when
+    // the auth method populated an org (PAT bridge / worker token / external
+    // OAuth all set one). The settings-session COOKIE path authenticates a
+    // userId but carries NO org, so the guard above is a no-op for it — yet
+    // `verifyOwnedAgentAccess` authorizes on (platform, userId, agentId) and
+    // returns the CALLER's org, never the session's. Without this, a cookie
+    // session for org B could read org A's session via a shared agentId (the
+    // global DEFAULT_AGENT_ID). So compare the org ownership actually resolved
+    // to against the session's, and deny on a definite mismatch. An undefined
+    // on either side falls through unchanged — this never denies a legitimate
+    // same-org caller, it only closes the cross-org case the guard above misses.
+    const authorizeOwnership = (access: {
+      authorized: boolean;
+      organizationId?: string;
+    }): Response | null => {
+      if (!access.authorized) return deny();
+      const tenantOrg = sessionForTenantCheck?.organizationId;
+      if (
+        tenantOrg &&
+        access.organizationId &&
+        access.organizationId !== tenantOrg
+      ) {
+        return deny();
+      }
+      return null;
+    };
+
     const bearer = tokenFromHeader(c);
 
     // 1. Settings session cookie (or injected auth provider for embedded mode).
@@ -543,7 +570,7 @@ export function createAgentApi(config: AgentApiConfig): OpenAPIHono {
         resolvedAgentId,
         ownershipAccessConfig
       );
-      return access.authorized ? null : deny();
+      return authorizeOwnership(access);
     }
 
     if (!bearer) return deny();
@@ -585,7 +612,7 @@ export function createAgentApi(config: AgentApiConfig): OpenAPIHono {
             resolvedAgentId,
             ownershipAccessConfig
           );
-          return access.authorized ? null : deny();
+          return authorizeOwnership(access);
         }
       } catch {
         // fall through to deny
@@ -736,7 +763,16 @@ export function createAgentApi(config: AgentApiConfig): OpenAPIHono {
     // store. The resume guard below catches in-flight collisions; the org
     // suffix prevents `forceNew` from silently overwriting another tenant's
     // session at setSession time.
-    const orgScope = tokenOrganizationId ? `_${tokenOrganizationId}` : "";
+    //
+    // Watcher sessions are EXEMPT: their conversationId is already globally
+    // unique via the DB-serial watcherId + runId, and downstream correlation
+    // relies on the exact `..._watcher_<id>_run_<id>` shape — the worker
+    // session key AND the API/SSE owner-routing key (unified-thread-consumer)
+    // both derive from this conversationId. Injecting `_<org>_` mid-id splits
+    // `watcher_<id>` from `run_<id>`, breaking watcher→worker dispatch (caught
+    // by the sdk-e2e gate). Keep the prod-proven shape for the watcher path.
+    const orgScope =
+      tokenOrganizationId && !watcherIntent ? `_${tokenOrganizationId}` : "";
     const conversationId = effectiveThread
       ? `${agentId}_${userId}${orgScope}_${effectiveThread}`
       : `${agentId}_${userId}${orgScope}`;

--- a/packages/server/src/gateway/services/agent-threads.ts
+++ b/packages/server/src/gateway/services/agent-threads.ts
@@ -97,7 +97,6 @@ export async function createThreadForAgent(
     provider: "claude",
     agentId,
     dryRun: false,
-    isEphemeral: false,
   };
   await sessionManager.setSession(session);
 

--- a/packages/server/src/gateway/session.ts
+++ b/packages/server/src/gateway/session.ts
@@ -50,14 +50,6 @@ export interface ThreadSession {
   dryRun?: boolean;
   /** Internal automation intent for one-shot system sessions. */
   intent?: { kind: "watcher_run"; runId: number; watcherId: number };
-  /**
-   * True when the session was created without a caller-supplied agentId and
-   * the gateway auto-provisioned both the agent and its settings. Only
-   * ephemeral sessions should have their settings torn down on DELETE —
-   * tearing down a shared/named agent's settings corrupts every other
-   * session that reuses it.
-   */
-  isEphemeral?: boolean;
 }
 
 /**


### PR DESCRIPTION
Replaces #1129 and #1133.

## Summary

`lobu chat -c local "ping"` in a non-project directory has been broken since the cross-pod conversation-lock guard landed in #1068. Several attempts patched the symptom — this PR removes the broken shape and uses what was already there: every signup auto-provisions a default agent (`owletto-default`); chat should resolve to it. It just never did.

## What was wrong

`createAgent` POST `/api/v1/agents` had an "ephemeral" branch that ran whenever the caller omitted `agentId`. It did:
1. `randomUUID()` → a fresh agent identity per chat call
2. tried to save system-key providers under that UUID via `saveSettings` — but `saveSettings` is UPDATE-only, the row had never been INSERTed, the save silently no-op'd
3. minted a session token for the phantom UUID

The result: every `lobu chat` call generated a new throwaway UUID, never used the user's actual default agent, and the worker eventually hit "No model configured" because `installed_providers = '[]'` for an agent row that didn't exist.

## Fix

**Two paths, no third.** `createAgent` now either uses a caller-pinned `agentId` or resolves to the org's `owletto-default`. The `isEphemeral` field on `ThreadSession` and the matching delete-time cleanup branch are gone.

**`ensureDefaultAgent` does the right thing at provisioning time:**
- Writes `installed_providers` from the set of providers with system keys (env-var API keys, Claude OAuth-discovery) so the default agent is chat-ready out of the box.
- Resolves the personal-org owner from `organization.metadata.personal_org_for_user_id` and writes the agent as user-owned with that user (`owner_platform = 'external'`, matching the EmbeddedSettingsSession the PAT path produces).
- Mirrors the ownership into `agent_users` so `verifyOwnedAgentAccess` (PAT-session path) recognizes the user as the agent's owner without a manual UI step.

**Auth-context plumbing** (this is the #1068 follow-up pi flagged on #1133):
- `createApiAuthMiddleware` now sets a typed `authContext` on the Hono context AND wraps the request in `orgContext.run()` for the worker-token and OAuth paths. `createLobuAuthBridge` already does this for PATs; this closes the gap for the other two methods so any handler that needs the AsyncLocalStorage org id works regardless of auth method.
- `ExternalAuthClient.fetchUserInfo` now surfaces the org id resolved from `/oauth/userinfo`'s `organization_slug` + `organizations[]` list (previously typed away).

**User-facing error link.** `NO_MODEL_CONFIGURED` now renders as `Connect a provider at <publicWebUrl>/<orgSlug>/agents/<agentId>` when the org slug can be resolved, instead of vague "ask an admin" text.

**CLI dry-run help text fix.** Was "Process without persisting history" (misleading — history IS persisted). Now "Skip side-effecting tool calls (sandbox writes, sdk_run mutations). The turn still runs and history is still persisted."

## Test plan

Reproducer on `origin/main`:
```
$ lobu run --port 8821 &
$ lobu chat -c local "ping"
Agent error: Worker startup failed and your request could not be processed. Please retry in a moment.
```

With this PR:
```
$ lobu run --port 8821 &
[default-provisioning] Provisioned default agent
  { organizationId: 'org_…', agentId: 'owletto-default', ownerUserId: 'user_install_…' }
$ lobu chat -c local --dry-run "ping"
❌ Session failed: 403 OAuth authentication is currently not allowed for this organization.
```

(The 403 is the unrelated `claude.hasSystemKey()` heuristic — Claude returns true for hasSystemKey via OAuth-discovery, so it gets picked first even when `ANTHROPIC_API_KEY` isn't set. Separate ticket below.)

Gateway log confirms the worker actually spawned and picked a provider:
```
[worker-gateway] Session context for owletto-default: provider: anthropic, cliBackends: claude-code
[openclaw-session-context] Received session context: provider: anthropic
```

- [x] `bun run typecheck` clean (root + per-package)
- [x] `make build-packages` clean
- [x] E2E: `lobu run` boot → `lobu chat -c local --dry-run "ping"` reaches the provider call (provider resolution end-to-end)
- [ ] `make review BASE=origin/main` — running

## Confidence

~90 on this surface. Reproduced both bugs (cross-pod lock throw, then no-providers) on `origin/main`, applied the fix, confirmed both errors are gone and the chat path reaches a real model API call. The remaining 403 is documented and out of scope.

## Follow-ups

1. **`claude.hasSystemKey()` heuristic**: should return false when no `ANTHROPIC_API_KEY` *and* no OAuth state is present, so the provider-priority loop picks a provider with credentials (Gemini / Z.ai / OpenRouter) when Anthropic isn't usable. Currently the OAuth-discovery-always-true heuristic short-circuits that.
2. **Integration test** covering `lobu chat -c local` end-to-end (install_operator → default agent → worker → provider call). This bug existed for ~weeks because no test exercises this path.
3. **Existing-install backfill**: on installs where `ensureDefaultAgent` already ran before this change, the row exists but `installed_providers` is `'[]'`. A small one-shot refresh that adds missing system-key providers (never removes existing ones) would close the gap for those installs — separate PR.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1136"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782581268&installation_id=136316292&pr_number=1136&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1136&signature=89aa4ba649bb20ad5dbfe98b63b036930a841e9591533d0da00d6b9d0db457ea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented organization-scoped default agent resolution for improved multi-tenant support.
  * Added direct admin settings links to configuration error messages.

* **Bug Fixes**
  * Strengthened cross-organization access controls for agent sessions.

* **Documentation**
  * Updated `--dry-run` flag help text to clarify that history is persisted.

* **Refactor**
  * Removed ephemeral agent creation; agents must now be explicitly specified or use the organization's default agent.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lobu-ai/lobu/pull/1136?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->