### PR TITLE
test(server): pin migration invariants + embedding-model literal drift guard

### DIFF
--- a/packages/server/src/__tests__/integration/db/migration-invariants.test.ts
+++ b/packages/server/src/__tests__/integration/db/migration-invariants.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Migration-invariant guard.
+ *
+ * The test harness applies the real baseline -> latest migration chain before
+ * any test runs (setup/test-db.ts). This suite asserts the load-bearing schema
+ * invariants that recent migrations established, so a future migration that
+ * silently drops or reshapes one fails CI here rather than in production.
+ *
+ * Motivated by the 2-week stability audit:
+ *  - #1121 reshaped pending-auth uniqueness from org-wide to per-user, scoped to
+ *    oauth_account. The functional contract (same user collides, distinct users
+ *    run parallel OAuth flows) is the real invariant — pin it, not just the DDL.
+ *  - #1069/#1080 added event_embeddings.embedding_model; its absence reopens the
+ *    full-corpus recall regression.
+ */
+
+import { beforeAll, describe, expect, it } from 'vitest';
+import { createAuthProfile, PendingAuthConflictError } from '../../../utils/auth-profiles';
+import { cleanupTestDatabase, getTestDb } from '../../setup/test-db';
+import {
+  addUserToOrganization,
+  createTestConnectorDefinition,
+  createTestOrganization,
+  createTestUser,
+} from '../../setup/test-fixtures';
+
+describe('migration invariants', () => {
+  beforeAll(async () => {
+    await cleanupTestDatabase();
+  });
+
+  describe('schema (DDL applied by the migration chain)', () => {
+    it('auth_profiles has the per-user pending oauth_account unique index (#1121)', async () => {
+      const sql = getTestDb();
+      const rows = await sql<{ indexdef: string }[]>`
+        SELECT indexdef FROM pg_indexes
+        WHERE schemaname = 'public'
+          AND tablename = 'auth_profiles'
+          AND indexname = 'auth_profiles_pending_oauth_account_unique'
+      `;
+      expect(rows).toHaveLength(1);
+      const def = rows[0].indexdef;
+      expect(def).toContain('UNIQUE');
+      // per-user, per-connector, per-provider scope
+      for (const col of ['organization_id', 'connector_key', 'provider', 'created_by']) {
+        expect(def).toContain(col);
+      }
+      // partial predicate: only in-flight oauth_account rows
+      expect(def).toContain("'pending_auth'");
+      expect(def).toContain("'oauth_account'");
+    });
+
+    it('the old org-wide auth_profiles_pending_unique index is gone (#1121)', async () => {
+      const sql = getTestDb();
+      const rows = await sql`
+        SELECT 1 FROM pg_indexes
+        WHERE schemaname = 'public'
+          AND tablename = 'auth_profiles'
+          AND indexname = 'auth_profiles_pending_unique'
+      `;
+      expect(rows).toHaveLength(0);
+    });
+
+    it('event_embeddings carries the embedding_model stamp column (#1069/#1080)', async () => {
+      const sql = getTestDb();
+      const rows = await sql`
+        SELECT 1 FROM information_schema.columns
+        WHERE table_schema = 'public'
+          AND table_name = 'event_embeddings'
+          AND column_name = 'embedding_model'
+      `;
+      expect(rows).toHaveLength(1);
+    });
+  });
+
+  describe('functional contract: pending oauth_account uniqueness is per-user (#1121)', () => {
+    let orgId: string;
+    let userA: string;
+    let userB: string;
+    const connectorKey = 'invariant-oauth-connector';
+    const provider = 'google';
+
+    beforeAll(async () => {
+      const org = await createTestOrganization({ name: 'Migration Invariant Org' });
+      orgId = org.id;
+      const a = await createTestUser({ email: 'invariant-user-a@example.com' });
+      const b = await createTestUser({ email: 'invariant-user-b@example.com' });
+      userA = a.id;
+      userB = b.id;
+      await addUserToOrganization(userA, orgId, 'member');
+      await addUserToOrganization(userB, orgId, 'member');
+      await createTestConnectorDefinition({
+        key: connectorKey,
+        name: 'Invariant OAuth',
+        organization_id: orgId,
+      });
+    });
+
+    async function createPending(createdBy: string) {
+      return createAuthProfile({
+        organizationId: orgId,
+        connectorKey,
+        displayName: 'Invariant pending',
+        profileKind: 'oauth_account',
+        provider,
+        status: 'pending_auth',
+        createdBy,
+      });
+    }
+
+    it('a user cannot open two parallel pending flows for the same connector', async () => {
+      await createPending(userA);
+      await expect(createPending(userA)).rejects.toBeInstanceOf(PendingAuthConflictError);
+    });
+
+    it('distinct users CAN run pending flows for the same connector in parallel', async () => {
+      const profile = await createPending(userB);
+      expect(profile.status).toBe('pending_auth');
+      expect(profile.created_by).toBe(userB);
+    });
+  });
+});

--- a/packages/server/src/utils/__tests__/embedding-model-literal.test.ts
+++ b/packages/server/src/utils/__tests__/embedding-model-literal.test.ts
@@ -1,0 +1,23 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { DEFAULT_EMBEDDING_MODEL } from '../embeddings';
+
+/**
+ * The legacy-stamp backfill migration hard-codes the embedding model literal
+ * (it cannot import TS). If DEFAULT_EMBEDDING_MODEL ever changes without the
+ * migration's literal tracking it, legacy rows get stamped with the wrong model
+ * and silently drop out of the model-scoped vector search — the exact
+ * full-corpus recall regression #1069/#1080 fixed. Pin the two together.
+ */
+const MIGRATIONS_DIR = path.resolve(__dirname, '../../../../../db/migrations');
+const BACKFILL_MIGRATION = '20260526170000_backfill_legacy_embedding_model_stamp.sql';
+
+describe('embedding model literal drift guard', () => {
+  it('backfill migration stamps NULL rows with DEFAULT_EMBEDDING_MODEL', () => {
+    const sql = fs.readFileSync(path.join(MIGRATIONS_DIR, BACKFILL_MIGRATION), 'utf-8');
+    const match = sql.match(/SET embedding_model = '([^']+)'/);
+    expect(match, 'backfill UPDATE literal not found in migration').not.toBeNull();
+    expect(match?.[1]).toBe(DEFAULT_EMBEDDING_MODEL);
+  });
+});

--- a/packages/server/src/utils/embeddings.ts
+++ b/packages/server/src/utils/embeddings.ts
@@ -14,7 +14,7 @@ import logger from '../utils/logger';
 const EMBEDDING_DIMENSIONS = 768;
 // Must match @lobu/embeddings DEFAULT_MODEL_NAME (the local pipeline + service
 // fall back to this when EMBEDDINGS_MODEL is unset).
-const DEFAULT_EMBEDDING_MODEL = 'Xenova/bge-base-en-v1.5';
+export const DEFAULT_EMBEDDING_MODEL = 'Xenova/bge-base-en-v1.5';
 // Allowlist mirroring the embeddings service's MODEL_NAME_PATTERN. Used to
 // reject anything unsafe before inlining the configured model into SQL.
 const MODEL_NAME_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._/:-]{0,127}$/;


### PR DESCRIPTION
## Summary

Follow-up to the 2-week stability audit. Adds two additive CI guards (no prod-code behavior change) so recently-changed, load-bearing invariants can't silently regress in a future migration — directly serving the "reliable and consistent tests" goal.

- **`migration-invariants.test.ts`** (integration, runs the real baseline→latest chain the harness already applies):
  - asserts the per-user pending `oauth_account` unique index from #1121 exists and the old org-wide `auth_profiles_pending_unique` is gone
  - **functional contract**: a user's second parallel pending OAuth flow collides (`PendingAuthConflictError`) while a *distinct* user's is allowed — the actual #1121 guarantee, not just the DDL
  - asserts `event_embeddings.embedding_model` stamp column exists (#1069/#1080)
- **`embedding-model-literal.test.ts`** (unit): the legacy-stamp backfill migration hard-codes the model literal (SQL can't import TS). This fails if it ever drifts from `DEFAULT_EMBEDDING_MODEL`, which would silently re-open the full-corpus recall regression. Exports `DEFAULT_EMBEDDING_MODEL` for the assertion.

## Audit context

The #1121 "dropped pending-uniqueness for browser_session" concern turned out to be a **false positive** on closer reading: `browser_session` rows are created with `connector_key = NULL` (`manage_auth_profiles.ts:696`), and the old dropped index was a standard unique index — Postgres treats NULLs as distinct, so it never enforced uniqueness for that kind. `oauth_account` (the only reachably-pending kind with non-null keys) *is* correctly covered. So no code guard was added; the real contract is pinned by the functional test instead.

## Test plan

- [x] `vitest run` both files green (5 integration + 1 unit) against embedded Postgres
- [x] red→green proof: drifting `DEFAULT_EMBEDDING_MODEL` makes the literal guard fail; reverting restores green
- [x] `tsc --noEmit` clean (server); pre-commit biome + typecheck pass

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1138"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782585307&installation_id=136316292&pr_number=1138&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1138&signature=92e488997e10957bb3a493fb114afce9241ce8efb26e4a6155075a9c1c3719cf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->