### PR TITLE
test(gateway): assembled-path guard for cross-replica Slack finalText delivery

### DIFF
--- a/packages/server/src/gateway/__tests__/slack-completion-delivery.test.ts
+++ b/packages/server/src/gateway/__tests__/slack-completion-delivery.test.ts
@@ -13,8 +13,11 @@
 
 import { describe, expect, mock, test } from "bun:test";
 import type { ThreadResponsePayload } from "@lobu/core";
-import { getResponseStrategy } from "../index.js";
-import type { StrategyContext, StreamState } from "../index.js";
+import { getResponseStrategy } from "../connections/platform-strategies/index.js";
+import type {
+  StrategyContext,
+  StreamState,
+} from "../connections/platform-strategies/index.js";
 
 function fakeInstanceWithSlackSpy() {
   const postMessage = mock(async () => ({ ok: true }));

--- a/packages/server/src/gateway/connections/platform-strategies/__tests__/slack-completion-delivery.test.ts
+++ b/packages/server/src/gateway/connections/platform-strategies/__tests__/slack-completion-delivery.test.ts
@@ -1,0 +1,125 @@
+/**
+ * Assembled-path guard for cross-replica Slack reply delivery (#1087/#1099).
+ *
+ * Under N>1 app replicas the pod that drains a terminal `thread_response` row
+ * is usually NOT the pod that ran the worker, so it holds no local stream
+ * buffer. PR #1087 made the worker's authoritative full text ride the row as
+ * `finalText`; #1099 fixed an earlier version that delivered a garbled/stale
+ * buffer instead. These tests drive the REAL SlackResponseStrategy completion
+ * path and fake only the outbound Slack HTTP boundary
+ * (slackClient.chat.postMessage), so a regression that reintroduces
+ * buffer-over-finalText (or drops the cross-pod case) fails here.
+ */
+
+import { describe, expect, mock, test } from "bun:test";
+import type { ThreadResponsePayload } from "@lobu/core";
+import { getResponseStrategy } from "../index.js";
+import type { StrategyContext, StreamState } from "../index.js";
+
+function fakeInstanceWithSlackSpy() {
+  const postMessage = mock(async () => ({ ok: true }));
+  const instance = {
+    chat: {
+      getAdapter: (platform: string) =>
+        platform === "slack" ? { client: { chat: { postMessage } } } : undefined,
+    },
+  };
+  return { instance, postMessage };
+}
+
+function ctx(instance: unknown, channelId = "slack:C0123ABCD"): StrategyContext {
+  return { connectionId: "conn-1", instance, channelId, platform: "slack" };
+}
+
+function payload(extra: Partial<ThreadResponsePayload>): ThreadResponsePayload {
+  return {
+    messageId: "m1",
+    channelId: "slack:C0123ABCD",
+    conversationId: "slack:C0123ABCD",
+    userId: "U1",
+    teamId: "T1",
+    platform: "slack",
+    timestamp: 1,
+    ...extra,
+  };
+}
+
+describe("Slack completion delivery (cross-replica #1087/#1099)", () => {
+  const strategy = getResponseStrategy("slack");
+
+  test("delivers finalText when this replica has no stream buffer (cross-pod drain)", async () => {
+    const { instance, postMessage } = fakeInstanceWithSlackSpy();
+    await strategy.handleCompletion({
+      ctx: ctx(instance),
+      payload: payload({ finalText: "Hello **world**" }),
+      stream: null, // delivering pod never ran the worker — no local buffer
+    });
+    expect(postMessage).toHaveBeenCalledTimes(1);
+    expect(postMessage.mock.calls[0][0]).toMatchObject({
+      channel: "C0123ABCD",
+      markdown_text: "Hello **world**",
+    });
+  });
+
+  test("prefers finalText over a stale local buffer (#1099 regression guard)", async () => {
+    const { instance, postMessage } = fakeInstanceWithSlackSpy();
+    const staleStream = {
+      buffer: "partial garbled delta fragment",
+      streamFailed: true,
+      wasFullyReplaced: false,
+      target: { post: mock(async () => undefined) },
+    } as unknown as StreamState;
+    await strategy.handleCompletion({
+      ctx: ctx(instance),
+      payload: payload({ finalText: "the authoritative final answer" }),
+      stream: staleStream,
+    });
+    expect(postMessage).toHaveBeenCalledTimes(1);
+    expect(postMessage.mock.calls[0][0].markdown_text).toBe("the authoritative final answer");
+  });
+
+  test("falls back to the local buffer only when finalText is absent (pre-finalText worker)", async () => {
+    const { instance, postMessage } = fakeInstanceWithSlackSpy();
+    const stream = {
+      buffer: "legacy buffered text",
+      streamFailed: true,
+      wasFullyReplaced: false,
+      target: { post: mock(async () => undefined) },
+    } as unknown as StreamState;
+    await strategy.handleCompletion({
+      ctx: ctx(instance),
+      payload: payload({}),
+      stream,
+    });
+    expect(postMessage).toHaveBeenCalledTimes(1);
+    expect(postMessage.mock.calls[0][0].markdown_text).toBe("legacy buffered text");
+  });
+
+  test("does not post when there is neither finalText nor buffer", async () => {
+    const { instance, postMessage } = fakeInstanceWithSlackSpy();
+    await strategy.handleCompletion({
+      ctx: ctx(instance),
+      payload: payload({ finalText: "   " }),
+      stream: null,
+    });
+    expect(postMessage).not.toHaveBeenCalled();
+  });
+
+  test("routes a threaded reply to thread_ts parsed from conversationId", async () => {
+    const { instance, postMessage } = fakeInstanceWithSlackSpy();
+    await strategy.handleCompletion({
+      ctx: ctx(instance),
+      payload: payload({
+        finalText: "threaded reply",
+        conversationId: "slack:C0123ABCD:1700000000.123456",
+      }),
+      stream: null,
+    });
+    expect(postMessage).toHaveBeenCalledTimes(1);
+    expect(postMessage.mock.calls[0][0]).toMatchObject({
+      channel: "C0123ABCD",
+      thread_ts: "1700000000.123456",
+      markdown_text: "threaded reply",
+    });
+  });
+});


### PR DESCRIPTION
## Summary

First concrete slice of the assembled-path test work (#1142). The stability audit found that several delivery/multi-replica fixes shipped dead-on-arrival because the merge gate accepted in-process simulations and mocked transports. This adds a test that drives the **real** `SlackResponseStrategy.handleCompletion` and fakes only the outbound Slack HTTP boundary (`slackClient.chat.postMessage`), pinning the cross-pod delivery contract from #1087/#1099.

Cases:
- delivers `payload.finalText` when `stream` is `null` — the cross-pod case, where the replica draining the terminal `thread_response` row never ran the worker and holds no local buffer
- `finalText` wins over a stale local buffer — the exact #1099 regression
- falls back to the buffer only when `finalText` is absent (pre-finalText worker)
- no post when neither is present; `thread_ts` parsed from `conversationId`

Test-only, no source change. Lives under `src/gateway/**/__tests__` so it runs in the bun:test gateway harness.

## Test plan

- [x] `bun test` green (5 pass)
- [x] red→green: reverting `handleCompletion`'s delivery line to the pre-#1099 buffer-first order (`stream?.buffer ?? payload.finalText`) fails the regression test; restoring `payload.finalText ?? stream?.buffer` makes it green
- [x] `tsc --noEmit` clean; pre-commit biome + typecheck pass

Follow-ups tracked in #1142 (full two-process assembled-path suite + merge-gate tiers), #1139 (connection-owner lease), #1140 (withRunningConnection), #1141 (plugin hooks on built-ins).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1144"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782586925&installation_id=136316292&pr_number=1144&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1144&signature=4e7b8555f7169f49a18335fa99a62a71b99ad24b60f7b97a1091a1264889c0b0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->