### PR TITLE
fix(auth): login requests only identity scopes, not sensitive connector scopes

### DIFF
--- a/packages/server/src/auth/__tests__/config.test.ts
+++ b/packages/server/src/auth/__tests__/config.test.ts
@@ -34,7 +34,8 @@ describe('login provider helpers', () => {
 
     const configs = collectEnabledLoginProviderConfigs([
       {
-        // No loginScopes declared and no provisioning union available → filtered out.
+        // Sensitive connector scopes never leak into login: a connector that declares
+        // only requiredScopes (no loginScopes) is filtered out of the login flow.
         key: 'google.calendar',
         auth_schema: {
           methods: [
@@ -47,9 +48,12 @@ describe('login provider helpers', () => {
         },
       },
       {
+        // Sensitive requiredScopes + auto-provisioning must NOT leak into login:
+        // login stays identity-only (openid/email/profile); gmail.readonly is granted
+        // later via the connector's own incremental-auth flow.
         key: 'google.gmail',
         auth_schema:
-          '{"methods":[{"type":"oauth","provider":"google","loginScopes":["openid","email","profile"]}]}',
+          '{"methods":[{"type":"oauth","provider":"google","loginScopes":["openid","email","profile"],"requiredScopes":["https://www.googleapis.com/auth/gmail.readonly"],"loginProvisioning":{"autoCreateConnection":true}}]}',
       },
       {
         key: 'github.issues',

--- a/packages/server/src/auth/config.ts
+++ b/packages/server/src/auth/config.ts
@@ -91,42 +91,8 @@ function getOAuthMethodsFromSchema(
   return parsedAuthSchema?.methods ?? [];
 }
 
-function unionScopes(...scopeLists: Array<readonly string[] | null | undefined>): string[] {
-  return Array.from(
-    new Set(
-      scopeLists
-        .flatMap((scopes) => scopes ?? [])
-        .map((scope) => scope.trim())
-        .filter((scope) => scope.length > 0)
-    )
-  );
-}
-
-function collectProvisioningScopesByProvider(
-  rows: LoginProviderConfigRow[]
-): Map<string, string[]> {
-  const scopesByProvider = new Map<string, string[]>();
-
-  for (const row of rows) {
-    const methods = getOAuthMethodsFromSchema(row.auth_schema);
-    for (const method of methods) {
-      if (method.type !== 'oauth' || typeof method.provider !== 'string') continue;
-      if (!method.loginProvisioning?.autoCreateConnection) continue;
-      const provider = method.provider.trim().toLowerCase();
-      if (!provider) continue;
-      scopesByProvider.set(
-        provider,
-        unionScopes(scopesByProvider.get(provider), method.requiredScopes ?? [])
-      );
-    }
-  }
-
-  return scopesByProvider;
-}
-
 export function collectEnabledLoginProviderConfigs(
-  rows: LoginProviderConfigRow[],
-  provisioningScopesByProvider?: Map<string, string[]>
+  rows: LoginProviderConfigRow[]
 ): EnabledLoginProviderConfig[] {
   const configs: EnabledLoginProviderConfig[] = [];
   const seenProviders = new Map<string, string>();
@@ -141,11 +107,8 @@ export function collectEnabledLoginProviderConfigs(
       const provider = method.provider.trim().toLowerCase();
       if (!provider) continue;
 
-      const loginScopes = unionScopes(
-        getLoginProviderScopes(provider, method.loginScopes),
-        provisioningScopesByProvider?.get(provider)
-      );
-      if (loginScopes.length === 0) {
+      const loginScopes = getLoginProviderScopes(provider, method.loginScopes);
+      if (!loginScopes || loginScopes.length === 0) {
         console.warn(
           `[Auth] Ignoring login-enabled connector '${connectorKey}' for unsupported provider '${provider}'.`
         );
@@ -352,18 +315,7 @@ export async function getEnabledLoginProviderConfigs(
       AND organization_id = ${effectiveOrgId}
     ORDER BY key ASC
   `;
-  const allActiveRows = await db`
-    SELECT key, auth_schema
-    FROM connector_definitions
-    WHERE status = 'active'
-      AND organization_id = ${effectiveOrgId}
-    ORDER BY key ASC
-  `;
-
-  const configs = collectEnabledLoginProviderConfigs(
-    rows as LoginProviderConfigRow[],
-    collectProvisioningScopesByProvider(allActiveRows as LoginProviderConfigRow[])
-  );
+  const configs = collectEnabledLoginProviderConfigs(rows as LoginProviderConfigRow[]);
 
   loginProviderCache.set(cacheKey, configs);
   return configs;


### PR DESCRIPTION
## Problem
Signing in with Google showed the **"unverified app"** warning. Root cause: the login consent folded auto-provisioning connectors' sensitive `requiredScopes` (`gmail.readonly`, `calendar.readonly`, …) into the Google sign-in request. A single sensitive scope on the consent screen requires Google verification — so plain login tripped the warning even for users who only wanted to sign in.

## Fix
Login now derives scopes **only** from each connector's declared `loginScopes` (identity-only: `openid email profile`). The sensitive connector scopes are no longer unioned into login.

This leans on the declarative split connectors already have:
- `loginScopes` → what login asks for (identity)
- `requiredScopes` / `optionalScopes` → what the connector asks for, granted via its **own incremental-auth flow**

Auto-provisioning is unchanged: signing in still auto-creates Gmail/Calendar connections, they just land in `pending_auth`, and the existing **Authorize** button (connection-form.tsx) grants the sensitive scopes and flips them to `active`. Verified the incremental path end-to-end (separate `account` row with sensitive-scoped token; `syncOAuthConnectionsForAuthProfile` flips status).

## Not broken
Every connector with `loginProvisioning.autoCreateConnection` (gmail, calendar, youtube, github, x, spotify, microsoft_outlook) also declares its own `loginScopes`, so none are dropped from login — the union was purely *additive* of sensitive scopes.

## Cleanup
Removed now-dead plumbing: `unionScopes`, `collectProvisioningScopesByProvider`, the second arg of `collectEnabledLoginProviderConfigs`, and the `allActiveRows` query.

## Tests
`packages/server/src/auth/__tests__/config.test.ts` strengthened: the gmail fixture now carries both `loginScopes` AND sensitive `requiredScopes` + `autoCreateConnection`, and asserts the login config stays `['openid','email','profile']` — a direct regression guard. All 5 pass.

## Note on app verification
This removes the warning from **plain login**. Users who actually connect Gmail/Calendar still hit the warning at the connector authorize step until the Google Cloud OAuth app is submitted for verification (sensitive-tier review; `/privacy` + `/terms` + verified domain already exist). That submission is a console operation, tracked separately.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1145"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782596951&installation_id=136316292&pr_number=1145&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1145&signature=b6baa977b9878dc84ca47046cecd15f5247ef66395b62e4ab3dd179819e46a1e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined OAuth login scope configuration logic to reduce complexity and improve maintainability while preserving correct scope handling behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lobu-ai/lobu/pull/1145?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->