### PR TITLE
feat(connectors): add Hacker News front-page feed

### DIFF
--- a/packages/connectors/src/hackernews.ts
+++ b/packages/connectors/src/hackernews.ts
@@ -149,6 +149,38 @@ export default class HackerNewsConnector extends ConnectorRuntime {
           },
         },
       },
+      front_page: {
+        key: 'front_page',
+        name: 'Front Page',
+        description:
+          'The current Hacker News front page — the live homepage, not a keyword search. No search query.',
+        configSchema: {
+          type: 'object',
+          properties: {
+            min_score: {
+              type: 'integer',
+              minimum: 0,
+              default: 0,
+              description: 'Only include front-page stories with at least this many points.',
+            },
+          },
+        },
+        eventKinds: {
+          story: {
+            description: 'A Hacker News front-page story',
+            metadataSchema: {
+              type: 'object',
+              properties: {
+                story_type: { type: 'string', description: 'story, ask_hn, or show_hn' },
+                tags: { type: 'array', items: { type: 'string' } },
+                external_url: { type: 'string', format: 'uri' },
+                score: { type: 'number', description: 'HN points' },
+                reply_count: { type: 'number' },
+              },
+            },
+          },
+        },
+      },
       comments: {
         key: 'comments',
         name: 'Comments',
@@ -236,28 +268,35 @@ export default class HackerNewsConnector extends ConnectorRuntime {
   // -------------------------------------------------------------------------
 
   async sync(ctx: SyncContext): Promise<SyncResult> {
+    // Front page is the live HN homepage (Algolia `tags=front_page`): no search
+    // query, no lookback — it returns the stories currently ranked on the front
+    // page. Everything else is a keyword search over the Algolia archive.
+    const isFrontPage = ctx.feedKey === 'front_page';
     const searchQuery = ctx.config.search_query as string;
     const contentType =
       ctx.feedKey === 'comments' ? 'comment' : ((ctx.config.story_type as string) ?? 'story');
     const lookbackDays = (ctx.config.lookback_days as number) ?? 365;
+    const minScore = (ctx.config.min_score as number) ?? 0;
     const searchFields =
       (ctx.config.search_fields as string[] | undefined) ??
       (contentType === 'comment' ? ['comment_text'] : ['title']);
 
     const lookbackTimestamp = Math.floor((Date.now() - lookbackDays * 86400000) / 1000);
-    const tag = CONTENT_TYPE_TAG[contentType] ?? 'story';
+    const tag = isFrontPage ? 'front_page' : (CONTENT_TYPE_TAG[contentType] ?? 'story');
 
     const events: EventEnvelope[] = [];
     let page = 0;
     let hasMore = true;
 
     while (hasMore && page < this.MAX_PAGES) {
-      const url =
-        `${this.BASE_URL}/search?query=${encodeURIComponent(searchQuery)}` +
-        `&tags=${tag}&hitsPerPage=100&page=${page}` +
-        '&typoTolerance=false' +
-        `&restrictSearchableAttributes=${encodeURIComponent(searchFields.join(','))}` +
-        `&numericFilters=${encodeURIComponent(`created_at_i>${lookbackTimestamp}`)}`;
+      const url = isFrontPage
+        ? `${this.BASE_URL}/search?tags=front_page&hitsPerPage=100&page=${page}` +
+          (minScore > 0 ? `&numericFilters=${encodeURIComponent(`points>=${minScore}`)}` : '')
+        : `${this.BASE_URL}/search?query=${encodeURIComponent(searchQuery)}` +
+          `&tags=${tag}&hitsPerPage=100&page=${page}` +
+          '&typoTolerance=false' +
+          `&restrictSearchableAttributes=${encodeURIComponent(searchFields.join(','))}` +
+          `&numericFilters=${encodeURIComponent(`created_at_i>${lookbackTimestamp}`)}`;
 
       const response = await fetch(url);
 


### PR DESCRIPTION
Adds a `front_page` feed to the Hacker News connector that pulls the **live HN homepage** (Algolia `tags=front_page`) instead of keyword-searching the all-time archive. No `search_query`; optional `min_score` filter; reuses the proven story transform + enrichment.

Why: the existing `stories`/`comments` feeds search the Algolia archive (lookback up to a year), surfacing old/random matches rather than what's currently on HN. A front-page feed lets a watcher triage what's actually being discussed now.

Verified: the exact URL the connector builds (`search?tags=front_page&hitsPerPage=100&numericFilters=points>=N`) returns current front-page stories with objectID/title/points, all tagged `story`+`front_page`. Typecheck clean; `gen-connectors` produces no manifest diff (connector-level metadata only). No connector test harness exists; validated against the live API.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1147"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782599859&installation_id=136316292&pr_number=1147&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1147&signature=d36751707b08acf925db46088e3a4b56f3a2027b7bb7ec622afab8bf74b71b04"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->