### PR TITLE
feat(revolut): DOM-scrape transactions via Owletto extension (drop network-intercept)

### DIFF
--- a/packages/connectors/src/__tests__/revolut-parse.test.ts
+++ b/packages/connectors/src/__tests__/revolut-parse.test.ts
@@ -152,6 +152,20 @@ describe("buildTransactionsFromDom", () => {
 		expect(txns[0]?.id).not.toBe(txns[1]?.id ?? "");
 	});
 
+	test("same minute, same amount, different reference → distinct ids", () => {
+		// The full time line carries Revolut's per-transaction reference, so two
+		// identical-looking payments in the same minute don't collide.
+		const txns = buildTransactionsFromDom(
+			[
+				{ day: "24 May", desc: "Co-op", amounts: ["-£4.50"], timeRef: "18:33 · D1111111" },
+				{ day: "24 May", desc: "Co-op", amounts: ["-£4.50"], timeRef: "18:33 · D2222222" },
+			],
+			now,
+		);
+		expect(txns).toHaveLength(2);
+		expect(txns[0]?.id).not.toBe(txns[1]?.id ?? "");
+	});
+
 	test("drops rows missing desc, amount, or date", () => {
 		const txns = buildTransactionsFromDom(
 			[

--- a/packages/connectors/src/__tests__/revolut-parse.test.ts
+++ b/packages/connectors/src/__tests__/revolut-parse.test.ts
@@ -9,11 +9,13 @@ mock.module("@lobu/connector-sdk", () => ({
 
 import {
 	buildTransactionsFromDom,
+	decideScrollStop,
 	filterTransactionsSinceCheckpoint,
 	isAuthWall,
 	parseAmountString,
 	parseRevolutDate,
 	type RevolutTransaction,
+	STALL_CYCLES,
 	transactionToEvent,
 } from "../revolut";
 
@@ -228,6 +230,53 @@ describe("isAuthWall", () => {
 
 	test("same host, zero rows, no form is NOT an auth wall (just empty)", () => {
 		expect(isAuthWall(req, req, 0, false)).toBe(false);
+	});
+});
+
+describe("decideScrollStop (backfill exhaustion + incremental early-stop)", () => {
+	test("keeps scrolling while still making progress (no stop)", () => {
+		expect(
+			decideScrollStop({ stall: 0, oldestDate: "2024-01-01", stopBeforeMs: null, timeUp: false }),
+		).toBeNull();
+		// One or two stall cycles is not yet the bottom.
+		expect(
+			decideScrollStop({ stall: STALL_CYCLES - 1, oldestDate: "2024-01-01", stopBeforeMs: null, timeUp: false }),
+		).toBeNull();
+	});
+
+	test("backfill stops as exhausted after STALL_CYCLES zero-progress cycles", () => {
+		expect(
+			decideScrollStop({ stall: STALL_CYCLES, oldestDate: "2021-12-01", stopBeforeMs: null, timeUp: false }),
+		).toBe("exhausted");
+	});
+
+	test("incremental stops once oldest rendered day reaches the checkpoint date", () => {
+		const checkpoint = Date.UTC(2026, 4, 20, 10, 0, 0); // 20 May 2026
+		// Still newer than the checkpoint → keep going.
+		expect(
+			decideScrollStop({ stall: 0, oldestDate: "2026-05-25", stopBeforeMs: checkpoint, timeUp: false }),
+		).toBeNull();
+		// Oldest rendered day is the checkpoint day (end-of-day >= cutoff) → stop.
+		expect(
+			decideScrollStop({ stall: 0, oldestDate: "2026-05-20", stopBeforeMs: checkpoint, timeUp: false }),
+		).toBe("reached_checkpoint");
+		// Scrolled a day past it → stop.
+		expect(
+			decideScrollStop({ stall: 0, oldestDate: "2026-05-19", stopBeforeMs: checkpoint, timeUp: false }),
+		).toBe("reached_checkpoint");
+	});
+
+	test("time cap fires (capped_time) when the budget is exhausted", () => {
+		expect(
+			decideScrollStop({ stall: 0, oldestDate: "2024-01-01", stopBeforeMs: null, timeUp: true }),
+		).toBe("capped_time");
+	});
+
+	test("checkpoint precedence: reached_checkpoint wins over stall + time cap", () => {
+		const checkpoint = Date.UTC(2026, 4, 20, 10, 0, 0);
+		expect(
+			decideScrollStop({ stall: STALL_CYCLES, oldestDate: "2026-05-20", stopBeforeMs: checkpoint, timeUp: true }),
+		).toBe("reached_checkpoint");
 	});
 });
 

--- a/packages/connectors/src/__tests__/revolut-parse.test.ts
+++ b/packages/connectors/src/__tests__/revolut-parse.test.ts
@@ -140,6 +140,18 @@ describe("buildTransactionsFromDom", () => {
 		expect(a[0]?.id).not.toBe(c[0]?.id ?? "");
 	});
 
+	test("same day + desc + amount but different time → distinct ids", () => {
+		const txns = buildTransactionsFromDom(
+			[
+				{ day: "24 May", desc: "Co-op", amounts: ["-£4.50"], timeRef: "09:00" },
+				{ day: "24 May", desc: "Co-op", amounts: ["-£4.50"], timeRef: "18:33" },
+			],
+			now,
+		);
+		expect(txns).toHaveLength(2);
+		expect(txns[0]?.id).not.toBe(txns[1]?.id ?? "");
+	});
+
 	test("drops rows missing desc, amount, or date", () => {
 		const txns = buildTransactionsFromDom(
 			[

--- a/packages/connectors/src/__tests__/revolut-parse.test.ts
+++ b/packages/connectors/src/__tests__/revolut-parse.test.ts
@@ -1,0 +1,230 @@
+import { describe, expect, mock, test } from "bun:test";
+
+// revolut.ts imports @lobu/connector-sdk (ConnectorRuntime, ...) which pulls in
+// the browser stack. Stub it so the pure DOM-parse helpers can be imported
+// without spinning up the runtime.
+mock.module("@lobu/connector-sdk", () => ({
+	ConnectorRuntime: class {},
+}));
+
+import {
+	buildTransactionsFromDom,
+	filterTransactionsSinceCheckpoint,
+	isAuthWall,
+	parseAmountString,
+	parseRevolutDate,
+	type RevolutTransaction,
+	transactionToEvent,
+} from "../revolut";
+
+describe("parseAmountString", () => {
+	test("parses signed GBP/USD/EUR symbols", () => {
+		expect(parseAmountString("-£34.13")).toEqual({ amount: -34.13, currency: "GBP" });
+		expect(parseAmountString("+£34.13")).toEqual({ amount: 34.13, currency: "GBP" });
+		expect(parseAmountString("-$46.15")).toEqual({ amount: -46.15, currency: "USD" });
+		expect(parseAmountString("-€1.80")).toEqual({ amount: -1.8, currency: "EUR" });
+	});
+
+	test("handles thousands separators (en-GB dot-decimal)", () => {
+		expect(parseAmountString("-$1,234.56")).toEqual({
+			amount: -1234.56,
+			currency: "USD",
+		});
+	});
+
+	test("handles continental comma-decimal", () => {
+		// "1.234,56 zł" → 1234.56 PLN; "1,80 zł" → 1.80 PLN
+		expect(parseAmountString("-1.234,56 zł")).toEqual({
+			amount: -1234.56,
+			currency: "PLN",
+		});
+		expect(parseAmountString("1,80 zł")).toEqual({ amount: 1.8, currency: "PLN" });
+	});
+
+	test("prefers explicit ISO code", () => {
+		expect(parseAmountString("-12.00 SEK")).toEqual({ amount: -12, currency: "SEK" });
+	});
+
+	test("returns null on unparseable / no-currency input", () => {
+		expect(parseAmountString("")).toBeNull();
+		expect(parseAmountString("just text")).toBeNull();
+		expect(parseAmountString("£")).toBeNull();
+	});
+});
+
+describe("parseRevolutDate", () => {
+	// "now" = 28 May 2026 noon UTC.
+	const now = Date.UTC(2026, 4, 28, 12, 0, 0);
+
+	test("bare day heading assumes current year, applies time", () => {
+		const d = parseRevolutDate("26 May", "07:18", now);
+		expect(d?.toISOString()).toBe("2026-05-26T07:18:00.000Z");
+	});
+
+	test("no time → noon UTC anchor", () => {
+		const d = parseRevolutDate("3 Jan", "", now);
+		expect(d?.toISOString()).toBe("2026-01-03T12:00:00.000Z");
+	});
+
+	test("future bare date rolls back to prior year (Dec→Jan boundary)", () => {
+		// On 5 Jan, a "20 Dec" heading is last year's December, not this year's.
+		const jan = Date.UTC(2026, 0, 5, 12, 0, 0);
+		const d = parseRevolutDate("20 Dec", "09:00", jan);
+		expect(d?.getUTCFullYear()).toBe(2025);
+		expect(d?.getUTCMonth()).toBe(11);
+	});
+
+	test("explicit 4-digit year wins", () => {
+		const d = parseRevolutDate("15 Feb 2022", "10:57", now);
+		expect(d?.toISOString()).toBe("2022-02-15T10:57:00.000Z");
+	});
+
+	test("returns null on garbage", () => {
+		expect(parseRevolutDate("not a date", "", now)).toBeNull();
+	});
+});
+
+describe("buildTransactionsFromDom", () => {
+	const now = Date.UTC(2026, 4, 28, 12, 0, 0);
+
+	test("maps a card payment row (outgoing)", () => {
+		const txns = buildTransactionsFromDom(
+			[{ day: "26 May", desc: "O2", amounts: ["-£34.13"], timeRef: "07:18 · D4468637" }],
+			now,
+		);
+		expect(txns).toHaveLength(1);
+		expect(txns[0]).toMatchObject({
+			description: "O2",
+			amount: 34.13,
+			direction: "out",
+			currency: "GBP",
+			date: "2026-05-26",
+		});
+		expect(txns[0]?.id).toMatch(/^[0-9a-f]{8}$/);
+	});
+
+	test("maps an incoming FX row using the primary amount only", () => {
+		const txns = buildTransactionsFromDom(
+			[
+				{
+					day: "26 May",
+					desc: "Bought GBP with USD",
+					amounts: ["+£34.13", "-$46.15"],
+					timeRef: "07:18",
+				},
+			],
+			now,
+		);
+		expect(txns).toHaveLength(1);
+		expect(txns[0]).toMatchObject({
+			amount: 34.13,
+			direction: "in",
+			currency: "GBP",
+		});
+	});
+
+	test("synthesised id is stable for identical rows and differs across rows", () => {
+		const a = buildTransactionsFromDom(
+			[{ day: "24 May", desc: "Co-op", amounts: ["-£4.50"], timeRef: "18:33" }],
+			now,
+		);
+		const b = buildTransactionsFromDom(
+			[{ day: "24 May", desc: "Co-op", amounts: ["-£4.50"], timeRef: "18:33" }],
+			now,
+		);
+		const c = buildTransactionsFromDom(
+			[{ day: "24 May", desc: "Co-op", amounts: ["-£5.50"], timeRef: "18:33" }],
+			now,
+		);
+		expect(a[0]?.id).toBe(b[0]?.id ?? "");
+		expect(a[0]?.id).not.toBe(c[0]?.id ?? "");
+	});
+
+	test("drops rows missing desc, amount, or date", () => {
+		const txns = buildTransactionsFromDom(
+			[
+				{ day: "24 May", desc: "", amounts: ["-£4.50"], timeRef: "18:33" }, // no desc
+				{ day: "24 May", desc: "X", amounts: [], timeRef: "18:33" }, // no amount
+				{ day: "garbage", desc: "Y", amounts: ["-£1"], timeRef: "" }, // bad date
+				{ day: "24 May", desc: "Z", amounts: ["-£1.00"], timeRef: "01:00" }, // valid
+			],
+			now,
+		);
+		expect(txns).toHaveLength(1);
+		expect(txns[0]?.description).toBe("Z");
+	});
+});
+
+describe("filterTransactionsSinceCheckpoint", () => {
+	const mk = (id: string, iso: string): RevolutTransaction => ({
+		id,
+		description: "x",
+		amount: 1,
+		direction: "out",
+		currency: "GBP",
+		date: iso.slice(0, 10),
+		occurredAt: new Date(iso),
+	});
+
+	test("drops at-or-before the checkpoint timestamp and the checkpoint id", () => {
+		const txns = [
+			mk("c", "2026-05-26T10:00:00Z"),
+			mk("b", "2026-05-25T10:00:00Z"),
+			mk("a", "2026-05-24T10:00:00Z"),
+		];
+		const out = filterTransactionsSinceCheckpoint(txns, {
+			last_transaction_id: "b",
+			last_timestamp: "2026-05-25T10:00:00Z",
+		});
+		expect(out.map((t) => t.id)).toEqual(["c"]);
+	});
+
+	test("dedups by id within a single scrape", () => {
+		const txns = [mk("a", "2026-05-26T10:00:00Z"), mk("a", "2026-05-26T10:00:00Z")];
+		expect(filterTransactionsSinceCheckpoint(txns, null)).toHaveLength(1);
+	});
+});
+
+describe("isAuthWall", () => {
+	const req = "https://app.revolut.com/transactions";
+
+	test("landed host != requested host (app→sso) is an auth wall", () => {
+		expect(isAuthWall(req, "https://sso.revolut.com/passcode?x=1", 0, false)).toBe(true);
+	});
+
+	test("zero rows + login form is an auth wall", () => {
+		expect(isAuthWall(req, req, 0, true)).toBe(true);
+	});
+
+	test("same host with rows is NOT an auth wall", () => {
+		expect(isAuthWall(req, req, 12, false)).toBe(false);
+	});
+
+	test("same host, zero rows, no form is NOT an auth wall (just empty)", () => {
+		expect(isAuthWall(req, req, 0, false)).toBe(false);
+	});
+});
+
+describe("transactionToEvent", () => {
+	test("preserves the legacy file-import event shape", () => {
+		const evt = transactionToEvent({
+			id: "deadbeef",
+			description: "O2",
+			amount: 34.13,
+			direction: "out",
+			currency: "GBP",
+			date: "2026-05-26",
+			occurredAt: new Date("2026-05-26T07:18:00Z"),
+		});
+		expect(evt.origin_id).toBe("revolut-deadbeef");
+		expect(evt.semantic_type).toBe("transaction");
+		expect(evt.payload_text).toBe("O2 -£34.13 on 2026-05-26");
+		expect(evt.metadata).toMatchObject({
+			date: "2026-05-26",
+			description: "O2",
+			amount: 34.13,
+			direction: "out",
+			currency: "GBP",
+		});
+	});
+});

--- a/packages/connectors/src/revolut.ts
+++ b/packages/connectors/src/revolut.ts
@@ -1,17 +1,34 @@
 /**
- * Revolut Connector (V1 runtime)
+ * Revolut Connector
  *
- * Revolut has no public personal-banking API, so this connector drives the
- * Revolut web app and captures the JSON it fetches from
- * `app.revolut.com/api/retail/user/current/transactions/last?...` while
- * paginating the transaction list (the `to=<ms>` param walks back in time).
+ * Revolut has no public personal-banking API, so this connector reads the
+ * RENDERED transaction list from the Revolut web app (`app.revolut.com`) via
+ * the paired Owletto Chrome extension — not Revolut's internal
+ * `/api/retail/...` JSON. The extension drives the user's real signed-in Chrome
+ * session: navigate to the transactions view in a non-disruptive background
+ * scrape window, scroll to lazy-load older rows, then extract each transaction
+ * straight from the DOM.
  *
- * Auth: CDP only. Revolut's `app.revolut.com` access token (`credentials`
- * cookie) is bound to the browser that minted it (a per-request `x-device-id`
- * header + Cloudflare/TLS fingerprint), so exported cookies replayed in a fresh
- * headless browser get a 401 on `/api/retail/...` and bounce to
- * `sso.revolut.com/passcode`. The connector therefore connects over CDP to a
- * Chrome that already holds the live session — see the auth-schema notes.
+ * Why DOM, not network-intercept: Revolut's `app.revolut.com` access token is
+ * bound to the browser that minted it (per-request `x-device-id` header +
+ * Cloudflare/TLS fingerprint), so replaying its internal API in any other
+ * context 401s and bounces to `sso.revolut.com`. Reading what the real session
+ * already rendered sidesteps that entirely, and is robust against Revolut
+ * rotating/obfuscating those internal endpoints.
+ *
+ * Visibility: the transaction list is a virtualized DOM (rows recycle out as
+ * you scroll) and only paints in a rendered tab — a hidden/background tab never
+ * loads it. We navigate with `focus_mode:"window"` (a small, non-focused scrape
+ * window that renders without switching the user's tab); if that returns
+ * nothing (e.g. fully occluded) we retry once with `bring_to_front`. Because
+ * the list virtualizes, we HARVEST rows after every scroll step and accumulate
+ * them (deduped) rather than extracting once at the end.
+ *
+ * Auth is implicit: the user is already signed into app.revolut.com in the
+ * paired Chrome. Revolut's session expires often (passcode / SSO re-auth), so
+ * if the navigate lands on `sso.revolut.com` (host differs from requested) or a
+ * login form with zero rows, we `focus_tab` to surface the tab to the user and
+ * throw `RevolutAuthWallError` instead of silently scraping a logged-out page.
  *
  * The emitted event shape matches the original file-import Revolut connector
  * (`semantic_type: "transaction"`, metadata `{ date, description, amount,
@@ -19,19 +36,13 @@
  */
 
 import {
-	browserNetworkSync,
+	type ChromeActionDispatcher,
 	type ConnectorDefinition,
 	ConnectorRuntime,
 	type EventEnvelope,
 	type SyncContext,
 	type SyncResult,
 } from "@lobu/connector-sdk";
-import {
-	getBrowserCdpUrl,
-	getBrowserCookies,
-	getBrowserUserDataDir,
-	validateCookieNotExpired,
-} from "./browser-scraper-utils";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -61,234 +72,200 @@ export interface RevolutTransaction {
 	state?: string;
 }
 
-// Currencies with zero minor units — Revolut returns these amounts unscaled.
-const ZERO_DECIMAL_CURRENCIES = new Set([
-	"JPY",
-	"KRW",
-	"VND",
-	"CLP",
-	"ISK",
-	"XAF",
-	"XOF",
-	"BIF",
-	"DJF",
-	"GNF",
-	"KMF",
-	"MGA",
-	"PYG",
-	"RWF",
-	"UGX",
-	"VUV",
-	"XPF",
-]);
-
-// Transaction states worth keeping. DECLINED/FAILED/REVERTED never settled.
-const KEPT_STATES = new Set(["COMPLETED", "PENDING", "CONFIRMED", "SETTLED"]);
-
-// Fields the web app uses for the transaction timestamp, best first.
-const TIMESTAMP_FIELDS = [
-	"completedDate",
-	"completed_date",
-	"completedAt",
-	"bookingDate",
-	"booking_date",
-	"valueDate",
-	"value_date",
-	"startedDate",
-	"started_date",
-	"createdDate",
-	"created_date",
-	"createdAt",
-	"date",
-];
+/** A single transaction row scraped from the DOM (before parsing). */
+export interface RevolutDomRow {
+	/** Day-group heading, e.g. "26 May" or "3 Jan" (no year in the web app). */
+	day?: string;
+	/** Merchant / description, e.g. "O2", "Bought GBP with USD". */
+	desc?: string;
+	/** Amount strings as rendered, primary first: e.g. ["-£34.13", "-$46.15"]. */
+	amounts?: string[];
+	/** Time line, e.g. "07:18" or "07:18 · D4468637". */
+	timeRef?: string;
+}
 
 // ---------------------------------------------------------------------------
 // Parsing
 // ---------------------------------------------------------------------------
 
-function minorUnitsToMajor(raw: number, currency: string): number {
-	const exponent = ZERO_DECIMAL_CURRENCIES.has(currency.toUpperCase()) ? 0 : 2;
-	return raw / 10 ** exponent;
-}
+// Symbol → ISO 4217. Revolut renders amounts with a leading symbol; we map the
+// common ones and fall back to any 3-letter code present in the string.
+const SYMBOL_TO_CURRENCY: Record<string, string> = {
+	"£": "GBP",
+	$: "USD",
+	"€": "EUR",
+	"¥": "JPY",
+	"₹": "INR",
+	"₽": "RUB",
+	"₺": "TRY",
+	"₩": "KRW",
+	"₪": "ILS",
+	"₴": "UAH",
+	"₫": "VND",
+	"₱": "PHP",
+	"฿": "THB",
+	"₦": "NGN",
+	R$: "BRL",
+	zł: "PLN",
+	Fr: "CHF",
+};
 
-function coerceTimestamp(value: unknown): Date | null {
-	if (typeof value === "number" && Number.isFinite(value)) {
-		// Revolut uses ms-epoch; treat 10-digit values as seconds defensively.
-		const ms = value < 1e12 ? value * 1000 : value;
-		const d = new Date(ms);
-		return Number.isNaN(d.getTime()) ? null : d;
-	}
-	if (typeof value === "string" && value.trim()) {
-		const d = new Date(value);
-		return Number.isNaN(d.getTime()) ? null : d;
-	}
-	return null;
-}
+const MONTHS: Record<string, number> = {
+	jan: 0,
+	feb: 1,
+	mar: 2,
+	apr: 3,
+	may: 4,
+	jun: 5,
+	jul: 6,
+	aug: 7,
+	sep: 8,
+	sept: 8,
+	oct: 9,
+	nov: 10,
+	dec: 11,
+};
 
-function extractAmountAndCurrency(
-	record: Record<string, unknown>,
+/**
+ * Parse a rendered amount string like "-£34.13", "+£34.13", "-$1,234.56",
+ * "1.234,56 zł" into { amount (signed, major units), currency }.
+ *
+ * Returns the SIGNED value so callers can derive direction. Handles both
+ * thousands/decimal conventions: a comma is a decimal separator only when 1-2
+ * digits trail it (e.g. "1,80" vs "1,234").
+ */
+export function parseAmountString(
+	raw: string,
 ): { amount: number; currency: string } | null {
-	// Flat shape: { amount: -2000, currency: "GBP" }
-	if (
-		typeof record.amount === "number" &&
-		typeof record.currency === "string"
-	) {
-		return { amount: record.amount, currency: record.currency };
+	const s = (raw ?? "").trim();
+	if (!s) return null;
+
+	// Currency: prefer an explicit 3-letter ISO code, else a known symbol.
+	let currency: string | null = null;
+	const isoMatch = s.match(/\b([A-Z]{3})\b/);
+	if (isoMatch) currency = isoMatch[1];
+	if (!currency) {
+		// Longest symbols first so "R$" beats "$".
+		for (const sym of Object.keys(SYMBOL_TO_CURRENCY).sort(
+			(a, b) => b.length - a.length,
+		)) {
+			if (s.includes(sym)) {
+				currency = SYMBOL_TO_CURRENCY[sym];
+				break;
+			}
+		}
 	}
-	// Nested money shape: { amount: { value: -2000, currency: "GBP" } } or
-	// { amount: { amount: -20.0, currency: "GBP" } }.
-	const amt = record.amount;
-	if (amt && typeof amt === "object") {
-		const obj = amt as Record<string, unknown>;
-		let value: number | null = null;
-		if (typeof obj.value === "number") value = obj.value;
-		else if (typeof obj.amount === "number") value = obj.amount;
-		const currency = typeof obj.currency === "string" ? obj.currency : null;
-		if (value !== null && currency) return { amount: value, currency };
+	if (!currency) return null;
+
+	// Sign: an explicit minus, or a parenthesised negative. Default positive.
+	const negative = /-/.test(s) || /^\(.*\)$/.test(s.replace(/\s/g, ""));
+
+	// Strip everything but digits and separators, then normalise to a JS number.
+	const numPart = s.replace(/[^\d.,]/g, "");
+	if (!numPart) return null;
+	let normalised: string;
+	const lastComma = numPart.lastIndexOf(",");
+	const lastDot = numPart.lastIndexOf(".");
+	if (lastComma !== -1 && lastDot !== -1) {
+		// Both present: the later one is the decimal separator.
+		normalised =
+			lastComma > lastDot
+				? numPart.replace(/\./g, "").replace(",", ".")
+				: numPart.replace(/,/g, "");
+	} else if (lastComma !== -1) {
+		// Only comma: decimal if 1-2 trailing digits, else thousands.
+		const decimals = numPart.length - lastComma - 1;
+		normalised =
+			decimals === 1 || decimals === 2
+				? numPart.replace(",", ".")
+				: numPart.replace(/,/g, "");
+	} else {
+		normalised = numPart;
 	}
-	return null;
-}
 
-function nameOf(node: unknown): string | null {
-	if (!node || typeof node !== "object") return null;
-	const obj = node as Record<string, unknown>;
-	for (const key of ["name", "legalName", "username", "displayName"]) {
-		const v = obj[key];
-		if (typeof v === "string" && v.trim()) return v.trim();
-	}
-	return null;
-}
-
-function describeTransaction(record: Record<string, unknown>): string {
-	// Card payments carry a clean `merchant.name` ("OpenAI") alongside a noisy
-	// raw descriptor ("Openai *chatgpt Subscr") — prefer the merchant name, which
-	// is also what the Revolut UI shows and what the legacy import used. Transfers
-	// and top-ups have no merchant, so fall back to the human description.
-	const merchant = nameOf(record.merchant);
-	if (merchant) return merchant;
-	for (const key of [
-		"description",
-		"localisedDescription",
-		"reference",
-		"comment",
-	]) {
-		const v = record[key];
-		if (typeof v === "string" && v.trim()) return v.trim();
-	}
-	for (const key of [
-		"counterpart",
-		"counterparty",
-		"recipient",
-		"sender",
-		"beneficiary",
-	]) {
-		const v = nameOf(record[key]);
-		if (v) return v;
-	}
-	const type = record.type;
-	return typeof type === "string" && type.trim()
-		? type.replace(/_/g, " ")
-		: "Transaction";
-}
-
-function extractBalance(
-	record: Record<string, unknown>,
-	currency: string,
-): number | undefined {
-	let raw: unknown;
-	if (typeof record.balance === "number") {
-		raw = record.balance;
-	} else if (record.balance && typeof record.balance === "object") {
-		const obj = record.balance as Record<string, unknown>;
-		raw = obj.value ?? obj.amount;
-	}
-	if (typeof raw !== "number" || !Number.isFinite(raw)) return undefined;
-	return Number.isInteger(raw) ? minorUnitsToMajor(raw, currency) : raw;
-}
-
-function parseTransactionRecord(
-	record: Record<string, unknown>,
-): RevolutTransaction | null {
-	const money = extractAmountAndCurrency(record);
-	if (!money) return null;
-
-	const id = record.id ?? record.legId ?? record.transactionId ?? record.code;
-	if (typeof id !== "string" && typeof id !== "number") return null;
-
-	let occurredAt: Date | null = null;
-	for (const field of TIMESTAMP_FIELDS) {
-		occurredAt = coerceTimestamp(record[field]);
-		if (occurredAt) break;
-	}
-	if (!occurredAt) return null;
-
-	const state =
-		typeof record.state === "string" ? record.state.toUpperCase() : undefined;
-	if (state && !KEPT_STATES.has(state)) return null;
-
-	const currency = money.currency.toUpperCase();
-	// Revolut's retail API returns integer minor units; some endpoints return a
-	// decimal already in major units — fractional values mean "already major".
-	const value = Number.isInteger(money.amount)
-		? minorUnitsToMajor(money.amount, currency)
-		: money.amount;
-
+	const value = Number.parseFloat(normalised);
+	if (!Number.isFinite(value)) return null;
 	return {
-		id: String(id),
-		description: describeTransaction(record),
-		amount: Math.abs(value),
-		direction: value < 0 ? "out" : "in",
-		balance: extractBalance(record, currency),
-		currency,
-		date: occurredAt.toISOString().slice(0, 10),
-		occurredAt,
-		type: typeof record.type === "string" ? record.type : undefined,
-		state,
+		amount: negative ? -Math.abs(value) : Math.abs(value),
+		currency: currency.toUpperCase(),
 	};
 }
 
 /**
- * Walk an arbitrary JSON value and pull out anything that looks like a Revolut
- * transaction. The web app's responses vary (bare arrays, `{ items: [...] }`,
- * paginated envelopes, single-transaction detail endpoints), so we recurse
- * rather than assume one shape. A record only counts as a transaction if it
- * carries both an amount/currency and a timestamp, which keeps merchant/budget
- * objects out.
+ * Resolve a bare "26 May" / "3 Jan" day heading to a full Date. The web app
+ * omits the year on day headings, so we assume the day belongs to the current
+ * year; if that lands in the future relative to `now`, it's the prior year
+ * (handles the Dec→Jan boundary). An explicit 4-digit year in the heading wins.
+ * The time, if present, is applied; otherwise noon UTC (a stable anchor).
  */
-export function extractTransactionsFromResponse(
-	json: unknown,
+export function parseRevolutDate(
+	day: string,
+	timeRef: string,
+	now: number = Date.now(),
+): Date | null {
+	const dm = (day ?? "").match(/(\d{1,2})\s*([A-Za-z]{3,4})\.?\s*(\d{4})?/);
+	if (!dm) return null;
+	const dayNum = Number.parseInt(dm[1], 10);
+	const month = MONTHS[dm[2].toLowerCase()];
+	if (month === undefined || !Number.isFinite(dayNum)) return null;
+
+	const explicitYear = dm[3] ? Number.parseInt(dm[3], 10) : null;
+	const tm = (timeRef ?? "").match(/(\d{1,2}):(\d{2})/);
+	const hours = tm ? Number.parseInt(tm[1], 10) : 12;
+	const minutes = tm ? Number.parseInt(tm[2], 10) : 0;
+
+	let year = explicitYear ?? new Date(now).getUTCFullYear();
+	let d = new Date(Date.UTC(year, month, dayNum, hours, minutes, 0));
+	if (!explicitYear && d.getTime() > now + 86_400_000) {
+		// A future date with no explicit year → it belongs to the prior year.
+		year -= 1;
+		d = new Date(Date.UTC(year, month, dayNum, hours, minutes, 0));
+	}
+	return Number.isNaN(d.getTime()) ? null : d;
+}
+
+/** Deterministic id for a row that carries no DOM id: hash its stable fields. */
+function synthesizeId(date: string, desc: string, signedAmount: string): string {
+	const basis = `${date}|${desc}|${signedAmount}`;
+	let h = 2166136261;
+	for (let i = 0; i < basis.length; i++) {
+		h ^= basis.charCodeAt(i);
+		h = Math.imul(h, 16777619);
+	}
+	return (h >>> 0).toString(16).padStart(8, "0");
+}
+
+/** Map scraped DOM rows to RevolutTransactions (drops unparseable rows). */
+export function buildTransactionsFromDom(
+	rows: RevolutDomRow[],
+	now: number = Date.now(),
 ): RevolutTransaction[] {
-	const found: RevolutTransaction[] = [];
-	const seen = new Set<object>();
+	const out: RevolutTransaction[] = [];
+	for (const r of rows) {
+		const desc = (r?.desc ?? "").trim();
+		const amounts = Array.isArray(r?.amounts) ? r.amounts : [];
+		if (!desc || amounts.length === 0) continue;
 
-	const visit = (node: unknown): void => {
-		if (!node || typeof node !== "object") return;
-		if (seen.has(node as object)) return;
-		seen.add(node as object);
+		const money = parseAmountString(amounts[0]);
+		if (!money) continue;
 
-		if (Array.isArray(node)) {
-			for (const item of node) {
-				const parsed =
-					item && typeof item === "object" && !Array.isArray(item)
-						? parseTransactionRecord(item as Record<string, unknown>)
-						: null;
-				if (parsed) found.push(parsed);
-				else visit(item);
-			}
-			return;
-		}
+		const occurredAt = parseRevolutDate(r?.day ?? "", r?.timeRef ?? "", now);
+		if (!occurredAt) continue;
 
-		const record = node as Record<string, unknown>;
-		const asTxn = parseTransactionRecord(record);
-		if (asTxn) {
-			found.push(asTxn);
-			return;
-		}
-		for (const value of Object.values(record)) visit(value);
-	};
-
-	visit(json);
-	return found;
+		const signedStr =
+			money.amount < 0 ? `-${Math.abs(money.amount)}` : `${money.amount}`;
+		const date = occurredAt.toISOString().slice(0, 10);
+		out.push({
+			id: synthesizeId(date, desc, signedStr),
+			description: desc,
+			amount: Math.abs(money.amount),
+			direction: money.amount < 0 ? "out" : "in",
+			currency: money.currency,
+			date,
+			occurredAt,
+		});
+	}
+	return out;
 }
 
 // ---------------------------------------------------------------------------
@@ -357,37 +334,247 @@ export function transactionToEvent(t: RevolutTransaction): EventEnvelope {
 }
 
 // ---------------------------------------------------------------------------
-// Sync
+// Extension dispatch + auth-wall handling
 // ---------------------------------------------------------------------------
 
-// The Revolut web app fetches account history from
-// `app.revolut.com/api/retail/user/current/transactions/last?count=N&to=<ms>&internalPocketId=<uuid>`
-// (the `to` param walks back in time as you scroll). These patterns also cover
-// plausible alternates without catching unrelated `/api/retail/...` calls.
-const TRANSACTION_API_PATTERNS: RegExp[] = [
-	/\/api\/retail\/.*transactions?(?:\/|\b)/i,
-	/\/api\/.*\/transactions(?:\b|\?|\/|$)/i,
-	/transactions?[./](?:last|recent|history|search)/i,
-];
+/**
+ * Pull the chrome action dispatcher from sessionState. The connector-worker
+ * subprocess splices a live `chrome_dispatcher` onto every sync's sessionState;
+ * its `dispatch()` rides IPC → daemon → the gateway chrome-action bridge → the
+ * paired Owletto extension. With no online extension in the connection's org,
+ * the bridge returns `failed` and the dispatcher throws — surfaced verbatim.
+ */
+function requireExtensionDispatcher(ctx: SyncContext): ChromeActionDispatcher {
+	const handle = (ctx.sessionState as Record<string, unknown> | null | undefined)
+		?.chrome_dispatcher as ChromeActionDispatcher | undefined;
+	if (!handle || typeof handle.dispatch !== "function") {
+		throw new Error(
+			"Revolut connector requires a paired Owletto Chrome extension. No chrome_dispatcher was injected into sessionState — re-run on a connector-worker that has the dispatcher bridge.",
+		);
+	}
+	return handle;
+}
 
-const REVOLUT_AUTH_DOMAINS = ["app.revolut.com", ".revolut.com"];
-// `/transactions` shows the full, infinitely-scrollable history for the default
-// account; `/home` only shows the latest ~10. Per-pocket history lives at
+/** Raised when the scrape lands on Revolut's passcode / SSO sign-in wall. */
+export class RevolutAuthWallError extends Error {
+	constructor(landedUrl: string) {
+		super(
+			`Revolut session needs sign-in (redirected to ${landedUrl}). The scrape tab was focused so you can re-enter your passcode; the next sync will use the authenticated session.`,
+		);
+		this.name = "RevolutAuthWallError";
+	}
+}
+
+function hostOf(url: string): string | null {
+	try {
+		return new URL(url).hostname.toLowerCase();
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * Deterministic auth-wall detection. Revolut bounces an expired session from
+ * `app.revolut.com` to `sso.revolut.com/passcode` (or `/signin`), so the
+ * primary signal is the LANDED host differing from the REQUESTED host. As a
+ * backstop, a page that rendered zero transaction rows AND shows a login form
+ * (password / passcode input) is also an auth wall. We do NOT rely on URL
+ * keywords alone — the host comparison catches the app→sso redirect cleanly.
+ */
+export function isAuthWall(
+	requestedUrl: string,
+	landedUrl: string,
+	rowCount: number,
+	hasLoginForm: boolean,
+): boolean {
+	const reqHost = hostOf(requestedUrl);
+	const landedHost = hostOf(landedUrl);
+	if (reqHost && landedHost && landedHost !== reqHost) return true;
+	if (rowCount === 0 && hasLoginForm) return true;
+	return false;
+}
+
+// ---------------------------------------------------------------------------
+// DOM scrape (runs in-page via the extension's `evaluate` op)
+// ---------------------------------------------------------------------------
+
+// The Revolut transaction list is virtualized: rows recycle out of the DOM as
+// you scroll, so we accumulate on `window.__lobuRevTxns` across calls and dedup
+// by a content key. Each transaction is a <button> inside a
+// `div[role="transactions-group"]` (one group per day; the group's first text
+// line is the day heading). A button's lines are
+//   [merchant/description, "HH:MM[ · ref]", "<sign><sym><amount>", ...fx].
+// `[class*=ItemTitle]` carries the clean merchant name.
+const HARVEST_EXPRESSION = `
+(() => {
+  const W = window;
+  W.__lobuRevTxns = W.__lobuRevTxns || {};
+  const acc = W.__lobuRevTxns;
+  const groups = [...document.querySelectorAll('[role="transactions-group"]')];
+  for (const g of groups) {
+    const day = (g.innerText || '').split('\\n')[0].trim();
+    let ord = 0;
+    for (const b of g.querySelectorAll('button')) {
+      const lines = b.innerText.split('\\n').map(s => s.trim()).filter(Boolean);
+      if (lines.length < 2) continue;
+      const amounts = lines.filter(l => /[£$€¥₹₽₺₩₪₴₫₱฿₦]|\\b[A-Z]{3}\\b/.test(l) && /\\d/.test(l));
+      if (!amounts.length) continue;
+      const titleEl = b.querySelector('[class*="ItemTitle"]');
+      const desc = titleEl ? titleEl.innerText.trim() : lines[0];
+      const timeRef = lines.find(l => /^\\d{1,2}:\\d{2}/.test(l)) || '';
+      const key = day + '|' + desc + '|' + amounts.join('/') + '|' + timeRef + '|' + (ord++);
+      if (!acc[key]) acc[key] = { day: day, desc: desc, amounts: amounts, timeRef: timeRef };
+    }
+  }
+  return Object.keys(acc).length;
+})()
+`;
+
+/** Scroll the transaction list to lazy-load older rows. */
+const SCROLL_EXPRESSION = `(async()=>{window.scrollTo(0,document.body.scrollHeight);if(document.scrollingElement)document.scrollingElement.scrollTop=document.scrollingElement.scrollHeight;await new Promise(r=>setTimeout(r,1500));return document.querySelectorAll('[role="transactions-group"] button').length})()`;
+
+/** Read the accumulated rows out of the page and clear the accumulator. */
+const COLLECT_EXPRESSION = `
+(() => {
+  const acc = window.__lobuRevTxns || {};
+  const rows = Object.values(acc);
+  window.__lobuRevTxns = {};
+  return rows;
+})()
+`;
+
+/** Probe whether the landed page is a login wall (URL + login-form presence). */
+const PROBE_EXPRESSION = `
+JSON.stringify({
+  url: location.href,
+  rowCount: document.querySelectorAll('[role="transactions-group"] button').length,
+  hasLoginForm: !!document.querySelector('input[type="password"], input[autocomplete="one-time-code"], input[inputmode="numeric"]')
+})
+`;
+
+interface ProbeResult {
+	url: string;
+	rowCount: number;
+	hasLoginForm: boolean;
+}
+
+/**
+ * Render the Revolut transactions page in the paired Chrome and harvest rows.
+ *
+ * Tries `focus_mode:"window"` first (a background scrape window that renders
+ * without switching the user's tab); if it yields nothing — the signature of a
+ * fully-occluded background window Chrome throttled — retries once with
+ * `bring_to_front`. The list is virtualized, so we harvest after each of
+ * `maxScrolls` scroll steps and accumulate (dedup) in-page, then collect.
+ *
+ * On an auth wall (landed host != requested, or zero rows + a login form) we
+ * `focus_tab` to surface the tab so the user can re-enter their passcode, then
+ * throw `RevolutAuthWallError` — never silently scraping a logged-out page.
+ */
+async function scrapeTransactionRows(
+	dispatcher: ChromeActionDispatcher,
+	url: string,
+	maxScrolls: number,
+): Promise<RevolutDomRow[]> {
+	const modes: Array<Record<string, unknown>> = [
+		{ focus_mode: "window" },
+		{ bring_to_front: true },
+	];
+	for (const mode of modes) {
+		const nav = await dispatcher.dispatch<{ tab_id: number; current_url?: string }>(
+			"navigate",
+			{
+				url,
+				open_in_new_tab: true,
+				wait_for_load: true,
+				allowed_origins: ["revolut.com", "*.revolut.com", "app.revolut.com"],
+				...mode,
+			},
+		);
+		const tabId = nav.tab_id;
+
+		// Probe the landed page for an auth wall before scraping.
+		let probe: ProbeResult = {
+			url: String(nav.current_url ?? url),
+			rowCount: 0,
+			hasLoginForm: false,
+		};
+		try {
+			const res = await dispatcher.dispatch<{ value?: unknown }>("evaluate", {
+				tab_id: tabId,
+				expression: PROBE_EXPRESSION,
+			});
+			if (typeof res?.value === "string") {
+				probe = JSON.parse(res.value) as ProbeResult;
+			}
+		} catch {
+			// Probe failure: fall back to the navigate-reported URL.
+		}
+
+		if (isAuthWall(url, probe.url, probe.rowCount, probe.hasLoginForm)) {
+			try {
+				await dispatcher.dispatch("focus_tab", { tab_id: tabId });
+			} catch {
+				// focus_tab may be unavailable on older extensions; best-effort
+				// foreground so the tab is at least visible for re-auth.
+				try {
+					await dispatcher.dispatch("navigate", {
+						tab_id: tabId,
+						url: probe.url,
+						open_in_new_tab: false,
+						bring_to_front: true,
+						wait_for_load: false,
+					});
+				} catch {}
+			}
+			throw new RevolutAuthWallError(probe.url);
+		}
+
+		try {
+			// Harvest the initial view, then scroll + harvest repeatedly.
+			await dispatcher.dispatch("evaluate", {
+				tab_id: tabId,
+				expression: HARVEST_EXPRESSION,
+			});
+			for (let i = 0; i < maxScrolls; i++) {
+				await dispatcher.dispatch("evaluate", {
+					tab_id: tabId,
+					expression: SCROLL_EXPRESSION,
+				});
+				await dispatcher.dispatch("evaluate", {
+					tab_id: tabId,
+					expression: HARVEST_EXPRESSION,
+				});
+			}
+			const collected = await dispatcher.dispatch<{ value?: unknown }>("evaluate", {
+				tab_id: tabId,
+				expression: COLLECT_EXPRESSION,
+			});
+			const rows = Array.isArray(collected?.value)
+				? (collected.value as RevolutDomRow[])
+				: [];
+			if (rows.length > 0) return rows;
+			// Empty: likely the background window was occluded → try the next mode.
+		} finally {
+			try {
+				await dispatcher.dispatch("close_tab", { tab_id: tabId });
+			} catch {
+				// best-effort; the stale-tab reaper backstops a missed close.
+			}
+		}
+	}
+	return [];
+}
+
+// ---------------------------------------------------------------------------
+// Config + connector definition
+// ---------------------------------------------------------------------------
+
+// `/transactions` shows the full, scrollable history for the default account;
+// `/home` only shows the latest ~10. Per-pocket history lives at
 // `/transactions?accountType=pocket&walletId=<uuid>&pocketId=<uuid>` — point a
 // second feed's `start_url` there to sync a non-default currency pocket.
 const DEFAULT_START_URL = "https://app.revolut.com/transactions";
-
-function isLoggedIn(url: string): boolean {
-	let host: string;
-	try {
-		host = new URL(url).hostname;
-	} catch {
-		return false;
-	}
-	// An unauthenticated session is bounced to sso.revolut.com/passcode.
-	if (host !== "app.revolut.com") return false;
-	return !/\/(?:start|signin|login|verify|onboarding)\b/i.test(url);
-}
 
 const configSchema = {
 	type: "object",
@@ -409,7 +596,7 @@ const configSchema = {
 			maximum: 100,
 			default: 20,
 			description:
-				"Maximum scroll iterations to paginate older transactions (default: 20).",
+				"Maximum scroll iterations to lazy-load older transactions (default: 20).",
 		},
 	},
 };
@@ -433,33 +620,21 @@ export default class RevolutConnector extends ConnectorRuntime {
 		key: "revolut",
 		name: "Revolut",
 		description:
-			"Syncs Revolut account transactions from the Revolut web app (no public API). Requires a Chrome instance, with remote debugging enabled, that stays logged in to app.revolut.com.",
-		version: "2.0.0",
+			"Syncs Revolut account transactions by reading the rendered Revolut web app (no public API) through your paired Owletto Chrome session — no separate login, robust against Revolut's rotating internal API.",
+		version: "3.0.0",
 		faviconDomain: "app.revolut.com",
 		authSchema: {
-			methods: [
-				// CDP only — *not* `cli` cookie capture. Revolut's `app.revolut.com`
-				// access token (the `credentials` cookie) is bound to the browser that
-				// minted it (device-id header + Cloudflare/TLS fingerprint), so cookies
-				// exported from Chrome and replayed in a fresh headless browser get a 401
-				// on /api/retail/... and bounce to sso.revolut.com/passcode. The only
-				// path that authenticates is connecting over CDP to the *same* Chrome
-				// that holds the live session — keep one logged in and reachable.
-				{
-					type: "browser",
-					capture: "cdp",
-					defaultCdpUrl: "http://127.0.0.1:9222",
-					requiredDomains: REVOLUT_AUTH_DOMAINS,
-					description:
-						"Connect over CDP to a Chrome logged in to app.revolut.com: lobu memory browser-auth --connector revolut --auth-profile-slug <slug> (log in to the dedicated Chrome that opens, re-enter the passcode whenever Revolut expires the session).",
-				},
-			],
+			// Auth is implicit via the paired Owletto extension's signed-in Chrome —
+			// no CDP, no cookie capture. Revolut's session expires periodically; when
+			// it does the sync surfaces the scrape tab (focus_tab) and fails with a
+			// "needs sign-in" message so the user can re-enter their passcode.
+			methods: [{ type: "none" }],
 		},
 		feeds: {
 			transactions: {
 				key: "transactions",
 				name: "Transactions",
-				description: "Account transactions pulled from the Revolut web app.",
+				description: "Account transactions read from the Revolut web app DOM.",
 				configSchema,
 				eventKinds: {
 					transaction: {
@@ -475,14 +650,14 @@ export default class RevolutConnector extends ConnectorRuntime {
 	async sync(ctx: SyncContext): Promise<SyncResult> {
 		const config = (ctx.config ?? {}) as Record<string, unknown>;
 		const checkpoint = (ctx.checkpoint ?? {}) as RevolutCheckpoint;
+		const dispatcher = requireExtensionDispatcher(ctx);
 
 		const startUrl =
 			typeof config.start_url === "string" && config.start_url.trim()
 				? config.start_url.trim()
 				: DEFAULT_START_URL;
 		const currencyFilter =
-			typeof config.currency_filter === "string" &&
-			config.currency_filter.trim()
+			typeof config.currency_filter === "string" && config.currency_filter.trim()
 				? config.currency_filter.trim().toUpperCase()
 				: null;
 		const maxScrolls = Math.max(
@@ -490,54 +665,14 @@ export default class RevolutConnector extends ConnectorRuntime {
 			Math.min(100, Number(config.max_scrolls ?? 20) || 20),
 		);
 
-		// Primary auth is CDP (connect to the Chrome that holds the live Revolut
-		// session). Stored cookies are only a best-effort fallback for the
-		// Playwright path — see the auth-schema comment on why they rarely suffice
-		// for Revolut. Don't fail the sync just because there are none.
-		const userDataDir = getBrowserUserDataDir(ctx.sessionState);
-		const cdpUrl = getBrowserCdpUrl(ctx.sessionState) ?? "auto";
-		let cookies: ReturnType<typeof getBrowserCookies> = [];
-		if (!userDataDir) {
-			try {
-				cookies = getBrowserCookies(
-					ctx.checkpoint as Record<string, unknown> | null,
-					ctx.sessionState,
-					"revolut",
-				);
-				validateCookieNotExpired(cookies, "credentials", "revolut");
-			} catch {
-				cookies = [];
-			}
-		}
+		const rows = await scrapeTransactionRows(dispatcher, startUrl, maxScrolls);
+		const all = buildTransactionsFromDom(rows);
 
-		const result = await browserNetworkSync<RevolutTransaction>({
-			config: {
-				interceptPatterns: TRANSACTION_API_PATTERNS,
-				authDomains: REVOLUT_AUTH_DOMAINS,
-				maxScrolls,
-				scrollDelayMs: 2500,
-				responseTimeoutMs: 8000,
-				navigationTimeoutMs: 20000,
-				stealth: true,
-			},
-			url: startUrl,
-			cdpUrl,
-			cookies,
-			userDataDir,
-			parseResponse: (_url, json) => extractTransactionsFromResponse(json),
-			checkAuth: async (page) => isLoggedIn(page.url()),
-		});
-
-		let transactions = filterTransactionsSinceCheckpoint(
-			result.items,
-			checkpoint,
-		);
+		let transactions = filterTransactionsSinceCheckpoint(all, checkpoint);
 		if (currencyFilter) {
 			transactions = transactions.filter((t) => t.currency === currencyFilter);
 		}
-		transactions.sort(
-			(a, b) => b.occurredAt.getTime() - a.occurredAt.getTime(),
-		);
+		transactions.sort((a, b) => b.occurredAt.getTime() - a.occurredAt.getTime());
 
 		const events: EventEnvelope[] = transactions.map(transactionToEvent);
 		const newest = transactions[0];
@@ -551,11 +686,10 @@ export default class RevolutConnector extends ConnectorRuntime {
 		return {
 			events,
 			checkpoint: newCheckpoint as unknown as Record<string, unknown>,
-			auth_update: { cookies: result.cookies },
 			metadata: {
 				items_found: events.length,
-				api_calls: result.apiCallCount,
-				backend: result.backend,
+				items_scraped: rows.length,
+				backend: "extension-dom",
 				...(currencyFilter ? { currency_filter: currencyFilter } : {}),
 			},
 		};

--- a/packages/connectors/src/revolut.ts
+++ b/packages/connectors/src/revolut.ts
@@ -226,16 +226,20 @@ export function parseRevolutDate(
 
 /**
  * Deterministic id for a row that carries no DOM id: hash its stable fields.
- * The full occurredAt timestamp (not just the date) is part of the basis so
- * two same-merchant/same-amount payments on the same day at different times
- * (e.g. two £4.50 coffees) get distinct ids and aren't collapsed by dedup.
+ * The basis includes the date, the FULL time line as rendered (which carries
+ * Revolut's per-transaction reference, e.g. "07:18 · D4468637", so even two
+ * same-merchant/same-amount payments in the same minute get distinct ids), the
+ * description, and ALL rendered amounts (the FX source leg disambiguates rows
+ * with no reference). This is stable across syncs — the same row always hashes
+ * the same — without colliding distinct rows.
  */
 function synthesizeId(
-	isoTimestamp: string,
+	date: string,
+	timeRef: string,
 	desc: string,
-	signedAmount: string,
+	amounts: string[],
 ): string {
-	const basis = `${isoTimestamp}|${desc}|${signedAmount}`;
+	const basis = `${date}|${timeRef}|${desc}|${amounts.join("/")}`;
 	let h = 2166136261;
 	for (let i = 0; i < basis.length; i++) {
 		h ^= basis.charCodeAt(i);
@@ -258,15 +262,13 @@ export function buildTransactionsFromDom(
 		const money = parseAmountString(amounts[0]);
 		if (!money) continue;
 
-		const occurredAt = parseRevolutDate(r?.day ?? "", r?.timeRef ?? "", now);
+		const timeRef = (r?.timeRef ?? "").trim();
+		const occurredAt = parseRevolutDate(r?.day ?? "", timeRef, now);
 		if (!occurredAt) continue;
 
-		const signedStr =
-			money.amount < 0 ? `-${Math.abs(money.amount)}` : `${money.amount}`;
-		const iso = occurredAt.toISOString();
-		const date = iso.slice(0, 10);
+		const date = occurredAt.toISOString().slice(0, 10);
 		out.push({
-			id: synthesizeId(iso, desc, signedStr),
+			id: synthesizeId(date, timeRef, desc, amounts),
 			description: desc,
 			amount: Math.abs(money.amount),
 			direction: money.amount < 0 ? "out" : "in",

--- a/packages/connectors/src/revolut.ts
+++ b/packages/connectors/src/revolut.ts
@@ -224,9 +224,18 @@ export function parseRevolutDate(
 	return Number.isNaN(d.getTime()) ? null : d;
 }
 
-/** Deterministic id for a row that carries no DOM id: hash its stable fields. */
-function synthesizeId(date: string, desc: string, signedAmount: string): string {
-	const basis = `${date}|${desc}|${signedAmount}`;
+/**
+ * Deterministic id for a row that carries no DOM id: hash its stable fields.
+ * The full occurredAt timestamp (not just the date) is part of the basis so
+ * two same-merchant/same-amount payments on the same day at different times
+ * (e.g. two £4.50 coffees) get distinct ids and aren't collapsed by dedup.
+ */
+function synthesizeId(
+	isoTimestamp: string,
+	desc: string,
+	signedAmount: string,
+): string {
+	const basis = `${isoTimestamp}|${desc}|${signedAmount}`;
 	let h = 2166136261;
 	for (let i = 0; i < basis.length; i++) {
 		h ^= basis.charCodeAt(i);
@@ -254,9 +263,10 @@ export function buildTransactionsFromDom(
 
 		const signedStr =
 			money.amount < 0 ? `-${Math.abs(money.amount)}` : `${money.amount}`;
-		const date = occurredAt.toISOString().slice(0, 10);
+		const iso = occurredAt.toISOString();
+		const date = iso.slice(0, 10);
 		out.push({
-			id: synthesizeId(date, desc, signedStr),
+			id: synthesizeId(iso, desc, signedStr),
 			description: desc,
 			amount: Math.abs(money.amount),
 			direction: money.amount < 0 ? "out" : "in",

--- a/packages/connectors/src/revolut.ts
+++ b/packages/connectors/src/revolut.ts
@@ -442,8 +442,61 @@ const HARVEST_EXPRESSION = `
 })()
 `;
 
-/** Scroll the transaction list to lazy-load older rows. */
-const SCROLL_EXPRESSION = `(async()=>{window.scrollTo(0,document.body.scrollHeight);if(document.scrollingElement)document.scrollingElement.scrollTop=document.scrollingElement.scrollHeight;await new Promise(r=>setTimeout(r,1500));return document.querySelectorAll('[role="transactions-group"] button').length})()`;
+/**
+ * One scroll cycle: scroll to the bottom to lazy-load older rows, HARVEST the
+ * newly-rendered rows into the in-page accumulator (dedup), then return the
+ * running accumulated-row count and the OLDEST day heading now rendered
+ * (`YYYY-MM-DD`, resolved with the same year inference as the parser). Folding
+ * the harvest in keeps the loop to one `evaluate` per cycle. The oldest-day
+ * signal lets an incremental sync stop once it has scrolled back past the
+ * checkpoint date.
+ */
+const SCROLL_CYCLE_EXPRESSION = `
+(async () => {
+  window.scrollTo(0, document.body.scrollHeight);
+  if (document.scrollingElement) document.scrollingElement.scrollTop = document.scrollingElement.scrollHeight;
+  await new Promise(r => setTimeout(r, 1500));
+
+  // Harvest (same logic as HARVEST_EXPRESSION) into the shared accumulator.
+  const W = window;
+  W.__lobuRevTxns = W.__lobuRevTxns || {};
+  const acc = W.__lobuRevTxns;
+  const groups = [...document.querySelectorAll('[role="transactions-group"]')];
+  for (const g of groups) {
+    const day = (g.innerText || '').split('\\n')[0].trim();
+    let ord = 0;
+    for (const b of g.querySelectorAll('button')) {
+      const lines = b.innerText.split('\\n').map(s => s.trim()).filter(Boolean);
+      if (lines.length < 2) continue;
+      const amounts = lines.filter(l => /[£$€¥₹₽₺₩₪₴₫₱฿₦]|\\b[A-Z]{3}\\b/.test(l) && /\\d/.test(l));
+      if (!amounts.length) continue;
+      const titleEl = b.querySelector('[class*="ItemTitle"]');
+      const desc = titleEl ? titleEl.innerText.trim() : lines[0];
+      const timeRef = lines.find(l => /^\\d{1,2}:\\d{2}/.test(l)) || '';
+      const key = day + '|' + desc + '|' + amounts.join('/') + '|' + timeRef + '|' + (ord++);
+      if (!acc[key]) acc[key] = { day: day, desc: desc, amounts: amounts, timeRef: timeRef };
+    }
+  }
+
+  // Oldest rendered day = last group's heading. Resolve its year the same way
+  // the connector's parser does (current year, rolling back if future).
+  const MONTHS = { jan:0,feb:1,mar:2,apr:3,may:4,jun:5,jul:6,aug:7,sep:8,sept:8,oct:9,nov:10,dec:11 };
+  const resolveDay = (heading) => {
+    const m = (heading || '').match(/(\\d{1,2})\\s*([A-Za-z]{3,4})\\.?\\s*(\\d{4})?/);
+    if (!m) return null;
+    const month = MONTHS[m[2].toLowerCase()];
+    if (month === undefined) return null;
+    const day = parseInt(m[1], 10);
+    const now = Date.now();
+    let year = m[3] ? parseInt(m[3], 10) : new Date(now).getUTCFullYear();
+    let d = Date.UTC(year, month, day, 12, 0, 0);
+    if (!m[3] && d > now + 86400000) d = Date.UTC(year - 1, month, day, 12, 0, 0);
+    return new Date(d).toISOString().slice(0, 10);
+  };
+  const oldestHead = groups.length ? (groups[groups.length - 1].innerText || '').split('\\n')[0].trim() : '';
+  return JSON.stringify({ accCount: Object.keys(acc).length, renderedButtons: document.querySelectorAll('[role="transactions-group"] button').length, oldestDate: resolveDay(oldestHead) });
+})()
+`;
 
 /** Read the accumulated rows out of the page and clear the accumulator. */
 const COLLECT_EXPRESSION = `
@@ -470,14 +523,157 @@ interface ProbeResult {
 	hasLoginForm: boolean;
 }
 
+interface ScrollProgress {
+	accCount: number;
+	renderedButtons: number;
+	oldestDate: string | null;
+}
+
+/** How the scroll loop terminated, surfaced in sync metadata + logs. */
+export type ScrapeStopReason =
+	| "exhausted" // hit the bottom of history (stall)
+	| "reached_checkpoint" // scrolled back past the last-seen txn (incremental)
+	| "capped_cycles" // safety cap on scroll iterations
+	| "capped_time"; // wall-clock budget exhausted
+
+export interface ScrapeResult {
+	rows: RevolutDomRow[];
+	stopReason: ScrapeStopReason;
+	cycles: number;
+	/** Oldest day heading reached (`YYYY-MM-DD`), or null if nothing rendered. */
+	oldestDate: string | null;
+}
+
+// Backfill safety rails: a first full-history sync can be multi-minute, but it
+// must never loop forever. STALL_CYCLES consecutive zero-new-row scrolls means
+// the bottom; MAX_SCROLL_CYCLES / TIME_BUDGET_MS are hard ceilings.
+export const STALL_CYCLES = 3;
+const MAX_SCROLL_CYCLES = 300;
+const TIME_BUDGET_MS = 4 * 60_000;
+
+/** Per-cycle inputs the stop decision is made from. */
+export interface ScrollCycleState {
+	/** Consecutive zero-progress cycles, INCLUDING this one if it added nothing. */
+	stall: number;
+	/** Oldest day reached so far (`YYYY-MM-DD`), or null. */
+	oldestDate: string | null;
+	/** Incremental checkpoint cutoff (ms epoch), or null for a full backfill. */
+	stopBeforeMs: number | null;
+	/** True once the wall-clock budget is exhausted. */
+	timeUp: boolean;
+}
+
 /**
- * Render the Revolut transactions page in the paired Chrome and harvest rows.
+ * Pure stop decision for one scroll cycle (unit-tested). Returns the stop
+ * reason if the loop should halt, or null to keep scrolling.
+ *
+ * Precedence: reached the checkpoint date (incremental) → time cap → stall
+ * (exhausted bottom). The cycle cap is handled by the loop bound itself.
+ */
+export function decideScrollStop(
+	state: ScrollCycleState,
+): ScrapeStopReason | null {
+	if (
+		state.stopBeforeMs !== null &&
+		state.oldestDate &&
+		// The oldest rendered DAY is at/before the checkpoint's day. Compare at
+		// start-of-day so reaching the checkpoint's own day (regardless of the
+		// checkpoint's intra-day time) counts as "scrolled back far enough" —
+		// filterTransactionsSinceCheckpoint then drops anything actually older.
+		new Date(`${state.oldestDate}T00:00:00Z`).getTime() <=
+			new Date(new Date(state.stopBeforeMs).toISOString().slice(0, 10)).getTime()
+	) {
+		return "reached_checkpoint";
+	}
+	if (state.timeUp) return "capped_time";
+	if (state.stall >= STALL_CYCLES) return "exhausted";
+	return null;
+}
+
+/**
+ * The scroll-until-stop core. Harvests the initial view, then repeatedly
+ * scrolls + harvests + accumulates (dedup) in-page until one of:
+ *  - `STALL_CYCLES` consecutive cycles add ZERO new rows → "exhausted" (bottom).
+ *  - (incremental) the oldest rendered day is at/before `stopBeforeMs` → we've
+ *    scrolled back past the checkpoint, so stop → "reached_checkpoint".
+ *  - the scroll-cycle cap is hit → "capped_cycles".
+ *  - the wall-clock budget is exhausted → "capped_time".
+ *
+ * Returns the collected rows plus how it stopped + how far back it reached.
+ */
+async function scrollUntilStop(
+	dispatcher: ChromeActionDispatcher,
+	tabId: number,
+	maxCycles: number,
+	stopBeforeMs: number | null,
+	now: number = Date.now(),
+): Promise<ScrapeResult> {
+	// Harvest the initial view before scrolling so day-zero rows aren't missed.
+	await dispatcher.dispatch("evaluate", { tab_id: tabId, expression: HARVEST_EXPRESSION });
+
+	const deadline = now + TIME_BUDGET_MS;
+	let prevCount = 0;
+	let stall = 0;
+	let cycles = 0;
+	let oldestDate: string | null = null;
+	let stopReason: ScrapeStopReason = "capped_cycles";
+
+	while (cycles < maxCycles) {
+		cycles++;
+		// One round-trip: scroll → harvest → report (count + oldest day).
+		const res = await dispatcher.dispatch<{ value?: unknown }>("evaluate", {
+			tab_id: tabId,
+			expression: SCROLL_CYCLE_EXPRESSION,
+		});
+		let progress: ScrollProgress = { accCount: prevCount, renderedButtons: 0, oldestDate };
+		try {
+			if (typeof res?.value === "string") progress = JSON.parse(res.value) as ScrollProgress;
+		} catch {
+			// Keep prior progress on a parse failure.
+		}
+		if (progress.oldestDate) oldestDate = progress.oldestDate;
+		const count = progress.accCount;
+
+		stall = count > prevCount ? 0 : stall + 1;
+		prevCount = count;
+
+		const decision = decideScrollStop({
+			stall,
+			oldestDate,
+			stopBeforeMs,
+			timeUp: Date.now() >= deadline,
+		});
+		if (decision) {
+			stopReason = decision;
+			break;
+		}
+		// Reached the cycle cap without stopping → capped_cycles (loop default).
+	}
+
+	const collected = await dispatcher.dispatch<{ value?: unknown }>("evaluate", {
+		tab_id: tabId,
+		expression: COLLECT_EXPRESSION,
+	});
+	const rows = Array.isArray(collected?.value)
+		? (collected.value as RevolutDomRow[])
+		: [];
+	return { rows, stopReason, cycles, oldestDate };
+}
+
+/**
+ * Render the Revolut transactions page in the paired Chrome and scrape rows.
  *
  * Tries `focus_mode:"window"` first (a background scrape window that renders
  * without switching the user's tab); if it yields nothing — the signature of a
  * fully-occluded background window Chrome throttled — retries once with
- * `bring_to_front`. The list is virtualized, so we harvest after each of
- * `maxScrolls` scroll steps and accumulate (dedup) in-page, then collect.
+ * `bring_to_front`. The window stays open for the whole scroll loop (a
+ * first-time full backfill can take minutes; that's a one-time cost).
+ *
+ * `stopBeforeMs` drives backfill vs incremental:
+ *  - null (no checkpoint) → full backfill: scroll until the history bottom
+ *    (stall) or a safety cap.
+ *  - a timestamp (checkpoint set) → incremental: scroll only until the oldest
+ *    rendered day reaches that date, then stop.
  *
  * On an auth wall (landed host != requested, or zero rows + a login form) we
  * `focus_tab` to surface the tab so the user can re-enter their passcode, then
@@ -486,12 +682,14 @@ interface ProbeResult {
 async function scrapeTransactionRows(
 	dispatcher: ChromeActionDispatcher,
 	url: string,
-	maxScrolls: number,
-): Promise<RevolutDomRow[]> {
+	maxCycles: number,
+	stopBeforeMs: number | null,
+): Promise<ScrapeResult> {
 	const modes: Array<Record<string, unknown>> = [
 		{ focus_mode: "window" },
 		{ bring_to_front: true },
 	];
+	let last: ScrapeResult = { rows: [], stopReason: "exhausted", cycles: 0, oldestDate: null };
 	for (const mode of modes) {
 		const nav = await dispatcher.dispatch<{ tab_id: number; current_url?: string }>(
 			"navigate",
@@ -543,29 +741,8 @@ async function scrapeTransactionRows(
 		}
 
 		try {
-			// Harvest the initial view, then scroll + harvest repeatedly.
-			await dispatcher.dispatch("evaluate", {
-				tab_id: tabId,
-				expression: HARVEST_EXPRESSION,
-			});
-			for (let i = 0; i < maxScrolls; i++) {
-				await dispatcher.dispatch("evaluate", {
-					tab_id: tabId,
-					expression: SCROLL_EXPRESSION,
-				});
-				await dispatcher.dispatch("evaluate", {
-					tab_id: tabId,
-					expression: HARVEST_EXPRESSION,
-				});
-			}
-			const collected = await dispatcher.dispatch<{ value?: unknown }>("evaluate", {
-				tab_id: tabId,
-				expression: COLLECT_EXPRESSION,
-			});
-			const rows = Array.isArray(collected?.value)
-				? (collected.value as RevolutDomRow[])
-				: [];
-			if (rows.length > 0) return rows;
+			last = await scrollUntilStop(dispatcher, tabId, maxCycles, stopBeforeMs);
+			if (last.rows.length > 0) return last;
 			// Empty: likely the background window was occluded → try the next mode.
 		} finally {
 			try {
@@ -575,7 +752,7 @@ async function scrapeTransactionRows(
 			}
 		}
 	}
-	return [];
+	return last;
 }
 
 // ---------------------------------------------------------------------------
@@ -605,10 +782,10 @@ const configSchema = {
 		max_scrolls: {
 			type: "integer",
 			minimum: 1,
-			maximum: 100,
-			default: 20,
+			maximum: 300,
+			default: 300,
 			description:
-				"Maximum scroll iterations to lazy-load older transactions (default: 20).",
+				"Safety cap on scroll iterations. The first sync (no checkpoint) backfills ALL history — scrolling until the bottom (3 consecutive empty cycles) or this cap / a ~4-minute budget. Later syncs stop at the last-seen transaction. Lower it only to bound a one-off run.",
 		},
 	},
 };
@@ -674,17 +851,42 @@ export default class RevolutConnector extends ConnectorRuntime {
 				: null;
 		const maxScrolls = Math.max(
 			1,
-			Math.min(100, Number(config.max_scrolls ?? 20) || 20),
+			Math.min(MAX_SCROLL_CYCLES, Number(config.max_scrolls ?? MAX_SCROLL_CYCLES) || MAX_SCROLL_CYCLES),
 		);
 
-		const rows = await scrapeTransactionRows(dispatcher, startUrl, maxScrolls);
-		const all = buildTransactionsFromDom(rows);
+		// First sync (no checkpoint) → full backfill: scroll until the history
+		// bottom. Subsequent syncs → incremental: stop once we've scrolled back
+		// past the last-seen transaction's date.
+		const stopBeforeMs = checkpoint.last_timestamp
+			? new Date(checkpoint.last_timestamp).getTime()
+			: null;
+		const isBackfill = stopBeforeMs === null;
+
+		const scrape = await scrapeTransactionRows(
+			dispatcher,
+			startUrl,
+			maxScrolls,
+			Number.isFinite(stopBeforeMs as number) ? (stopBeforeMs as number) : null,
+		);
+		const all = buildTransactionsFromDom(scrape.rows);
 
 		let transactions = filterTransactionsSinceCheckpoint(all, checkpoint);
 		if (currencyFilter) {
 			transactions = transactions.filter((t) => t.currency === currencyFilter);
 		}
 		transactions.sort((a, b) => b.occurredAt.getTime() - a.occurredAt.getTime());
+
+		// Loudly note a capped backfill — we did NOT reach the bottom, so the
+		// oldest history is missing and a follow-up run is needed. Surfaced both
+		// here (worker run log) and in metadata.history_complete below; never a
+		// silent truncation.
+		const capped =
+			scrape.stopReason === "capped_cycles" || scrape.stopReason === "capped_time";
+		if (capped) {
+			console.warn(
+				`[revolut] backfill hit the ${scrape.stopReason === "capped_time" ? "time" : "scroll"} cap after ${scrape.cycles} cycles; reached back to ${scrape.oldestDate ?? "unknown"} but did NOT exhaust history. Re-run to continue from this point.`,
+			);
+		}
 
 		const events: EventEnvelope[] = transactions.map(transactionToEvent);
 		const newest = transactions[0];
@@ -700,8 +902,13 @@ export default class RevolutConnector extends ConnectorRuntime {
 			checkpoint: newCheckpoint as unknown as Record<string, unknown>,
 			metadata: {
 				items_found: events.length,
-				items_scraped: rows.length,
+				items_scraped: scrape.rows.length,
 				backend: "extension-dom",
+				mode: isBackfill ? "backfill" : "incremental",
+				stop_reason: scrape.stopReason,
+				scroll_cycles: scrape.cycles,
+				oldest_date_reached: scrape.oldestDate,
+				history_complete: scrape.stopReason !== "capped_cycles" && scrape.stopReason !== "capped_time",
 				...(currencyFilter ? { currency_filter: currencyFilter } : {}),
 			},
 		};

--- a/packages/server/src/__tests__/unit/connectors/revolut.test.ts
+++ b/packages/server/src/__tests__/unit/connectors/revolut.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it } from "vitest";
 import {
 	buildTransactionsFromDom,
+	decideScrollStop,
 	filterTransactionsSinceCheckpoint,
 	type RevolutTransaction,
+	STALL_CYCLES,
 	transactionToEvent,
 } from "../../../../../connectors/src/revolut";
 
@@ -83,6 +85,33 @@ describe("Revolut DOM-row parsing", () => {
 		);
 		expect(txns).toHaveLength(1);
 		expect(txns[0]?.description).toBe("Z");
+	});
+});
+
+describe("Revolut scroll-loop stop logic", () => {
+	it("backfill: keeps scrolling until STALL_CYCLES zero-progress cycles (exhausted)", () => {
+		expect(
+			decideScrollStop({ stall: 1, oldestDate: "2022-01-01", stopBeforeMs: null, timeUp: false }),
+		).toBeNull();
+		expect(
+			decideScrollStop({ stall: STALL_CYCLES, oldestDate: "2021-12-01", stopBeforeMs: null, timeUp: false }),
+		).toBe("exhausted");
+	});
+
+	it("incremental: stops once the oldest rendered day reaches the checkpoint", () => {
+		const cp = Date.UTC(2026, 4, 20, 10, 0, 0);
+		expect(
+			decideScrollStop({ stall: 0, oldestDate: "2026-05-25", stopBeforeMs: cp, timeUp: false }),
+		).toBeNull();
+		expect(
+			decideScrollStop({ stall: 0, oldestDate: "2026-05-20", stopBeforeMs: cp, timeUp: false }),
+		).toBe("reached_checkpoint");
+	});
+
+	it("safety: time cap fires when the wall-clock budget is exhausted", () => {
+		expect(
+			decideScrollStop({ stall: 0, oldestDate: "2024-01-01", stopBeforeMs: null, timeUp: true }),
+		).toBe("capped_time");
 	});
 });
 

--- a/packages/server/src/__tests__/unit/connectors/revolut.test.ts
+++ b/packages/server/src/__tests__/unit/connectors/revolut.test.ts
@@ -1,116 +1,88 @@
 import { describe, expect, it } from "vitest";
 import {
-	extractTransactionsFromResponse,
+	buildTransactionsFromDom,
 	filterTransactionsSinceCheckpoint,
 	type RevolutTransaction,
 	transactionToEvent,
 } from "../../../../../connectors/src/revolut";
 
-describe("Revolut transaction parsing", () => {
-	it("parses the legacy retail transaction shape (minor units, ms epoch)", () => {
-		const response = {
-			transactions: [
+// The Revolut connector reads the rendered transaction list from the
+// app.revolut.com DOM via the Owletto extension (no network-intercept). These
+// tests exercise the DOM-row parser end-to-end through buildTransactionsFromDom.
+
+describe("Revolut DOM-row parsing", () => {
+	// "now" = 28 May 2026 noon UTC, so bare day headings resolve to 2026.
+	const now = Date.UTC(2026, 4, 28, 12, 0, 0);
+
+	it("parses a card payment (outgoing) and a top-up (incoming)", () => {
+		const txns = buildTransactionsFromDom(
+			[
 				{
-					id: "tx_1",
-					type: "CARD_PAYMENT",
-					state: "COMPLETED",
-					startedDate: 1719705600000,
-					completedDate: 1719705660000, // 2024-06-30
-					amount: -2000,
-					currency: "GBP",
-					balance: 1740589,
-					description: "The Chancellors",
+					day: "26 May",
+					desc: "The Chancellors",
+					amounts: ["-£20.00"],
+					timeRef: "12:01 · D4468637",
 				},
-				{
-					id: "tx_2",
-					type: "TOPUP",
-					state: "COMPLETED",
-					completedDate: 1721318400000, // 2024-07-18
-					amount: 5000,
-					currency: "GBP",
-					balance: 1745589,
-					merchant: { name: "Apple Pay top-up" },
-				},
+				{ day: "26 May", desc: "Apple Pay top-up", amounts: ["+£50.00"], timeRef: "12:05" },
 			],
-		};
-
-		const txns = extractTransactionsFromResponse(response);
+			now,
+		);
 		expect(txns).toHaveLength(2);
-
-		const [a, b] = txns;
-		expect(a).toMatchObject({
-			id: "tx_1",
+		expect(txns[0]).toMatchObject({
 			description: "The Chancellors",
 			amount: 20,
 			direction: "out",
-			balance: 17405.89,
 			currency: "GBP",
-			date: "2024-06-30",
-			type: "CARD_PAYMENT",
-			state: "COMPLETED",
+			date: "2026-05-26",
 		});
-		expect(b).toMatchObject({
-			id: "tx_2",
+		expect(txns[1]).toMatchObject({
 			description: "Apple Pay top-up",
 			amount: 50,
 			direction: "in",
-			balance: 17455.89,
 			currency: "GBP",
 		});
 	});
 
-	it("handles nested money objects and ISO timestamps", () => {
-		const txns = extractTransactionsFromResponse([
-			{
-				id: "tx_3",
-				state: "PENDING",
-				valueDate: "2025-01-15T09:30:00.000Z",
-				amount: { value: -799, currency: "EUR" },
-				description: "Spotify",
-			},
-		]);
-		expect(txns).toEqual([
-			expect.objectContaining({
-				id: "tx_3",
-				amount: 7.99,
-				direction: "out",
-				currency: "EUR",
-				date: "2025-01-15",
-				state: "PENDING",
-			}),
-		]);
-	});
-
-	it("keeps zero-decimal currencies unscaled", () => {
-		const [txn] = extractTransactionsFromResponse([
-			{
-				id: "tx_vnd",
-				state: "COMPLETED",
-				completedDate: "2024-07-19",
-				amount: -120000,
-				currency: "VND",
-				description: "Song Que Cafe",
-			},
-		]);
-		expect(txn.amount).toBe(120000);
-		expect(txn.currency).toBe("VND");
-	});
-
-	it("skips records without a timestamp or without money, and declined states", () => {
-		const txns = extractTransactionsFromResponse({
-			budgets: [{ amount: 50000, currency: "GBP", name: "Groceries" }], // no date
-			pending: [
+	it("uses the primary amount for FX rows (ignores the source-currency leg)", () => {
+		const txns = buildTransactionsFromDom(
+			[
 				{
-					id: "x",
-					state: "DECLINED",
-					completedDate: 1719705600000,
-					amount: -1,
-					currency: "GBP",
+					day: "26 May",
+					desc: "Bought GBP with USD",
+					amounts: ["+£34.13", "-$46.15"],
+					timeRef: "07:18",
 				},
 			],
-			misc: { hello: "world" },
-		});
-		expect(txns).toEqual([]);
+			now,
+		);
+		expect(txns).toHaveLength(1);
+		expect(txns[0]).toMatchObject({ amount: 34.13, direction: "in", currency: "GBP" });
+	});
+
+	it("synthesised id distinguishes same-day/same-amount rows by time", () => {
+		const txns = buildTransactionsFromDom(
+			[
+				{ day: "24 May", desc: "Co-op", amounts: ["-£4.50"], timeRef: "09:00" },
+				{ day: "24 May", desc: "Co-op", amounts: ["-£4.50"], timeRef: "18:33" },
+			],
+			now,
+		);
+		expect(txns).toHaveLength(2);
+		expect(txns[0]?.id).not.toBe(txns[1]?.id ?? "");
+	});
+
+	it("skips rows missing description, amount, or a parseable date", () => {
+		const txns = buildTransactionsFromDom(
+			[
+				{ day: "24 May", desc: "", amounts: ["-£4.50"], timeRef: "18:33" },
+				{ day: "24 May", desc: "X", amounts: [], timeRef: "18:33" },
+				{ day: "garbage", desc: "Y", amounts: ["-£1.00"], timeRef: "" },
+				{ day: "24 May", desc: "Z", amounts: ["-£1.00"], timeRef: "01:00" },
+			],
+			now,
+		);
+		expect(txns).toHaveLength(1);
+		expect(txns[0]?.description).toBe("Z");
 	});
 });
 


### PR DESCRIPTION
## Summary
- Rewrites the Revolut connector to read the **rendered transaction list** from `app.revolut.com` via the paired Owletto Chrome extension, replacing the `browserNetworkSync` network-intercept approach. The old path was fragile (Revolut rotates/obfuscates its internal `/api/retail/...` endpoints, and the access token is device-id + Cloudflare/TLS-fingerprint bound so it can't be replayed) and the list only paints in a rendered tab.
- Mirrors the LinkedIn DOM-scrape connector: `navigate` with `focus_mode:"window"` (non-disruptive background scrape window) + `bring_to_front` occlusion fallback; deterministic auth-wall handling with `focus_tab` + a thrown `RevolutAuthWallError`.
- Revolut's transaction list is **virtualized** (rows recycle out of the DOM as you scroll), so we harvest after every scroll step and accumulate deduped in-page, then collect — rather than extracting once at the end.

## Full-history backfill + incremental sync
- **First sync (no checkpoint) backfills ALL history.** The scroll loop keeps scrolling + harvesting + deduping until **3 consecutive cycles add zero new rows** (the bottom of history) — not a fixed scroll count.
- **Subsequent syncs are incremental.** Once the oldest rendered day scrolls back past the last-seen transaction's date, the loop stops early instead of re-walking the whole history every run.
- **Safety rails so it can't loop forever:** a 300-scroll-cycle cap and a ~4-minute wall-clock budget. A capped run is surfaced loudly — a worker-log `console.warn` plus `metadata.history_complete:false` + `metadata.oldest_date_reached` + `metadata.stop_reason` — so a truncated backfill is never silent; re-running continues from where it left off.
- The scrape window (`focus_mode:"window"`) stays open for the whole backfill; a multi-minute first sync is an accepted one-time cost.
- The pure stop decision (`exhausted` / `reached_checkpoint` / `capped_time`, checkpoint taking precedence) is factored into `decideScrollStop` and unit-tested in both suites.

## How it works
- Each transaction is a `<button>` inside `div[role="transactions-group"]` (one group per day; the group's first text line is the day heading). We parse: merchant/description (`[class*=ItemTitle]`), amount + currency (sign → direction), time, and the day heading (year inferred — bare `26 May` → current year, rolling back across the Dec→Jan boundary if the date would be in the future).
- Rows carry no stable DOM id, so `origin_id` is a deterministic FNV hash of `date | full-time-line | desc | all-amounts` (the time line carries Revolut's per-transaction reference, e.g. `07:18 · D4468637`, so same-minute/same-amount rows don't collide).
- Auth wall (Revolut's passcode/SSO session expires often): detected when the landed host differs from the requested host (`app.revolut.com` → `sso.revolut.com`) **or** zero rows + a login/passcode form. On a wall we `focus_tab` to surface the tab for re-auth and throw, never silently scraping a logged-out page.
- Kept: `RevolutTransaction`, `transactionToEvent`, checkpoint/dedup, config schema (`start_url`/`currency_filter`/`max_scrolls`), legacy event shape. `max_scrolls` is now a **safety cap** (default/max 300), not the target depth. Bumped `2.0.0` → `3.0.0` (auth method changed to `none` — implicit via the extension's signed-in Chrome).

## Dependency
- Depends on the `navigate` primitives from **owletto #246** (`feat/linkedin-make-it-work`): `focus_mode:"window"` + `bring_to_front` are already deployed to the user's live extension; `focus_tab` (used on the auth-wall path) lands with the extension reload/deploy. Not yet merged to owletto main, so a review against the committed submodule pointer will flag these actions as missing — that's the standing cross-repo dependency, not a defect in this PR.

## Test plan
- [x] **Parser + scroll-loop unit tests** (`revolut-parse.test.ts`, 28 tests; mirrored in the server unit suite): `parseAmountString` (symbols, thousands/continental separators, ISO codes), `parseRevolutDate` (year inference + Dec→Jan rollback + explicit year), `buildTransactionsFromDom` (card/FX rows, stable id incl. same-minute/different-ref, drops bad rows), `filterTransactionsSinceCheckpoint`, `isAuthWall`, `transactionToEvent` legacy shape, and **`decideScrollStop`** (exhaustion after 3 stall cycles, incremental stop at the checkpoint day, time cap, checkpoint precedence).
- [x] **E2E — recent-page scrape (prior commit, hard gate met):** drove a live scrape against the logged-in `app.revolut.com/transactions` via the paired extension (connection 369). Harvest + 5 scroll cycles accumulated 6 → **79 transaction rows**; all 79 populated day/desc/amount and parsed to a valid currency + direction. (Redacted — counts/field-presence only.)
- [ ] **E2E — full-history backfill: NOT yet run.** The Revolut session lapsed back to `sso.revolut.com/passcode` before the backfill verification could run (Revolut sessions are short-lived). The backfill logic is unit-covered and the scroll-cycle mechanics were verified live on the recent-page scrape, but the full scroll-until-exhausted path against real history has not been driven end-to-end. Re-run once the user re-authenticates app.revolut.com.
- [x] `revolut.ts` is type-clean (`tsc --noEmit` 0 errors in changed files); `make review` typecheck=0 unit=0. Integration suite is blocked by a local macOS shared-memory (SHMMNI) limit in **untouched** server tests, not by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)