### PR TITLE
docs(landing): Shopify Aquifer comparison post (draft) + blog voice guide

### DIFF
--- a/packages/landing/BLOG_VOICE.md
+++ b/packages/landing/BLOG_VOICE.md
@@ -1,0 +1,35 @@
+# Blog voice
+
+How posts under `src/content/blog/` should read. Reference example: `shopifys-aquifer-in-the-open.mdx`.
+
+The target is the voice of Shopify's "Under the River" engineering post, written in first person. Confident, plain, technical without posturing. Sounds like an engineer explaining a real opinion to peers, not a marketing page and not an essay.
+
+## Do
+
+- **Open with an opinion, not a summary.** Take a position in the first two paragraphs. Disagree with something. If the post only restates a source, it has no reason to exist.
+- **Short declarative sentences, varied with longer ones.** Let a fragment land for emphasis: "That is the easy version." "A product does."
+- **Repeat the key noun** instead of reaching for synonyms. "The corpus", "the memory", "the session". Repetition builds the through-line.
+- **Open each section with a constraint or fact, then pivot to the insight.**
+- **First person.** "We made the same bet." "I wrote about that split in..." Own the claim.
+- **Argue with specifics.** Name the table, the mechanism, the real difference. Vague beats nothing, specific beats vague.
+- **Plain, slightly declarative headers.** Statements or mild antithesis: "The corpus is the asset. The conversation isn't." Not clever, not cute.
+
+## Don't
+
+- **No em dashes.** Hard rule for all landing copy. Use periods, commas, or parentheses. This also forces the staccato rhythm we want.
+- **No three-beat marketing chants.** "Your agent. Your data. Your servers." is the single clearest AI tell. Kill it on sight.
+- **No rhetorical questions** as a transition ("So why store the noise?").
+- **No stacked tricolons** or relentless "not X, but Y" balance in every paragraph. One antithesis per stretch, not five.
+- **No clever-for-clever's-sake** word pairs ("noise vs signal", "same goal, different cut", "strictly harder"). They read as filler.
+- **No hedging AI filler:** "it's worth noting", "on one hand / on the other", "in today's world".
+- **Don't paraphrase the source** section by section. Engage two or three points with depth instead of touring all of them.
+
+## Shape
+
+- Comparison or opinion posts: roughly 600 to 700 words.
+- 3 to 5 sentences per paragraph, rarely longer.
+- Quote a source verbatim when it sharpens the point, but keep quotes short.
+
+## The test
+
+Read it out loud. If a line sounds like a slide deck or a press release, rewrite it. If it sounds like you talking, keep it.

--- a/packages/landing/src/content/blog/shopifys-aquifer-in-the-open.mdx
+++ b/packages/landing/src/content/blog/shopifys-aquifer-in-the-open.mdx
@@ -1,0 +1,44 @@
+---
+title: "Shopify's Aquifer, in the Open"
+description: "Shopify bet that an agent's corpus is the compounding asset. We made the same bet, with two differences: we keep the signal instead of the chat, and we built it for many companies instead of one."
+date: 2026-05-29
+author: Burak Emre Kabakcı
+authorAvatar: https://gravatar.com/avatar/6d785cc20f0e9b685be6343f475a7f2a?s=64
+authorUrl: https://x.com/bu7emba
+tags: [architecture, agents, memory]
+draft: true
+---
+
+Shopify published [Under the River](https://shopify.engineering/under-the-river), the writeup of the substrate they built so agents could become real participants in how they ship code. Read past the Slack bot and there's a bet. They state it plainly: "the corpus is the compounding asset; the privacy of an agent thread is a disadvantage."
+
+We made the same bet. An agent that only helps the person at the keyboard is autocomplete. An agent that learns from everyone is infrastructure. The disagreement is narrow, and it is about what you write down.
+
+## The corpus is the asset. The conversation isn't.
+
+River is public by default. The threads pile up in Slack, stay searchable, and the patterns get fed back into River's skills later. The corpus is the chat. The signal gets pulled out after the fact.
+
+We don't keep the chat. We keep what the chat was about. Every interaction becomes an event in an append-only log: structured, embedded, searchable. Extraction happens once, at write time, instead of every time you read. The conversation is scaffolding. The event is the thing that lasts.
+
+This is the warehouse, not the notebook. I wrote about that split in [Filesystem vs Database for Agent Memory](/blog/filesystem-vs-database-agent-memory/). The filesystem is where the agent thinks. The memory layer is where the company remembers.
+
+Shopify are halfway here. River writes its own sessions to a `river_sessions` table. We have a table too. The difference is that ours is not a log bolted onto one agent. In Lobu the events log is the platform. Every agent reads it and writes it. They share one memory. A new agent inherits the whole history instead of starting on an empty table.
+
+## One memory. Everyone.
+
+This is what turns a fast assistant into a useful one. You ask, and it already knows. The colleague who hit the same wall last week. The decision made in another channel. The customer a sales thread mentioned. One agent, one company memory, and it gets denser every day the company shows up.
+
+## One company is the easy version
+
+Under the River never says the word "organization." It doesn't have to. Everything lives inside Shopify. One company, one corpus, shared by default.
+
+That is the easy version. The hard one is many companies at once. The memory stays separate per org. The credentials per tenant. All on the same machines, and no org's agent ever touches another's data. That is the real work, and it is what Lobu is built around. Each org gets its own memory that compounds, on shared infrastructure, walled off from the rest. A single company never has to solve this. A product does.
+
+## Keep the agent away from the secrets
+
+Their first lesson is to keep the harness out of the sandbox. The agent loop should not live where the code runs, so a bad turn has a small blast radius. We agree, and we draw a second line. The worker never holds a real secret. A proxy sits in front of it and swaps placeholder tokens for the real ones only as a request leaves the box. The agent uses credentials it never sees and can never leak.
+
+## The difference
+
+River runs inside Shopify and that is where it stays. Lobu is the version you run yourself. Same memory, same agent everyone talks to, except the database is yours and the data never leaves your org. The only thing we really had to add is the part where it holds up for a thousand companies on one install, not one company that owns the whole place.
+
+Start with the [docs](/getting-started/), or read how the [memory layer](/getting-started/memory/) works.


### PR DESCRIPTION
Adds a draft blog post comparing Lobu to the architecture in Shopify's "Under the River" (Aquifer/River), plus a reusable blog voice guide.

## What's in it
- `packages/landing/src/content/blog/shopifys-aquifer-in-the-open.mdx` — `draft: true`, so it does **not** publish in production (drafts only render in dev). Argues two points: the compounding asset is the distilled event, not the chat thread; and multi-tenant is the harder version of Shopify's single-company bet. Includes the `river_sessions` vs Lobu events-log comparison and the credential-egress-proxy safety angle.
- `packages/landing/BLOG_VOICE.md` — contributor guide capturing the voice we converged on (Under the River cadence in first person, no em dashes, no marketing chants).

## Notes
- No em dashes (landing copy rule).
- Renders clean in `astro dev`; YAML frontmatter validated.
- Unrelated dirty `packages/owletto` submodule pointer was deliberately left out of this PR.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1150"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782618570&installation_id=136316292&pr_number=1150&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1150&signature=f0c33e1926dd933c4ab840676a32798cbd6fa7ad3002a2163ecede2314ac7f27"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Published a new blog post introducing Shopify's Aquifer agent-memory model, exploring how the durable corpus serves as a compounding asset. The post covers append-only event log approaches, contrasts between shared and multi-tenant memory architectures, and best practices for maintaining agent security.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lobu-ai/lobu/pull/1150?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->