### PR TITLE
fix(server,cli): migrate external DATABASE_URL on `lobu run` + honor LOBU_DATA_DIR

### DIFF
--- a/packages/cli/src/commands/dev.ts
+++ b/packages/cli/src/commands/dev.ts
@@ -218,12 +218,16 @@ export async function devCommand(
   }
 
   // Embedded: resolve the data root and pass it through as the explicit
-  // DATABASE_URL path the single server bundle reads. A path-form DATABASE_URL
-  // wins; otherwise default to the user's home dir. The bundle puts the cluster
-  // at <root>/.lobu/pgdata.
+  // DATABASE_URL path the single server bundle reads. Precedence: an explicit
+  // path-form DATABASE_URL wins; else LOBU_DATA_DIR (the documented override in
+  // docs/reference/cli.md); else the user's home dir. The bundle puts the
+  // cluster at <root>/.lobu/pgdata.
   let embeddedDataRoot: string | null = null;
   if (mode === "embedded") {
-    embeddedDataRoot = resolveEmbeddedDataRoot(databaseUrlRaw || "~");
+    const dataDirOverride = mergedEnv.LOBU_DATA_DIR?.trim();
+    embeddedDataRoot = resolveEmbeddedDataRoot(
+      databaseUrlRaw || dataDirOverride || "~"
+    );
     mergedEnv.DATABASE_URL = embeddedDataRoot;
   }
 
@@ -343,6 +347,12 @@ export async function devCommand(
   const childEnv: Record<string, string> = {
     ...mergedEnv,
     LOBU_DEV_PROJECT_PATH: projectPath,
+    // `lobu run` owns the local DB lifecycle for both backends. The embedded
+    // path already migrates on boot; this flag tells the server bundle to also
+    // apply migrations when pointed at an external (postgres://) DATABASE_URL,
+    // so a fresh/empty local Postgres is set up before serving. Prod never sets
+    // it — there a separate dbmate migration Job owns migrations.
+    LOBU_RUN_OWNS_DB: "1",
     ...(providerRegistryPath
       ? { LOBU_PROVIDER_REGISTRY_PATH: providerRegistryPath }
       : {}),

--- a/packages/server/src/embedded-runtime.ts
+++ b/packages/server/src/embedded-runtime.ts
@@ -206,7 +206,16 @@ export async function startEmbeddedRuntime(): Promise<EmbeddedRuntime> {
 	};
 }
 
-async function runMigrations(databaseUrl: string): Promise<void> {
+/**
+ * Apply `db/migrations/*.sql` (the same set dbmate runs in prod) against
+ * `databaseUrl`. Idempotent: the squashed baseline is gated by the
+ * `schema_migrations` ledger (with a duplicate-object fallback) and forward
+ * deltas use `IF NOT EXISTS`, so replaying against an already-migrated DB is a
+ * no-op. Used by the embedded runtime AND by the external-DATABASE_URL `lobu
+ * run` path (`server.ts`), which owns the local DB lifecycle. Prod never calls
+ * this — dbmate's migration Job applies migrations separately.
+ */
+export async function runMigrations(databaseUrl: string): Promise<void> {
 	// Same migrations dbmate uses for prod, applied unconditionally. The dir is
 	// a single squashed baseline + forward deltas; both replay idempotently
 	// (baseline gated by the schema_migrations ledger, deltas use IF NOT EXISTS).

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -38,7 +38,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { assertExternalDepsResolvable } from "@lobu/connector-worker/compile";
 import { getDb, probeListenNotify } from "./db/client";
-import { startEmbeddedRuntime } from "./embedded-runtime";
+import { runMigrations, startEmbeddedRuntime } from "./embedded-runtime";
 import { getEnvFromProcess } from "./utils/env";
 import logger from "./utils/logger";
 import { assertSchemaUpToDate } from "./utils/schema-version-check";
@@ -75,8 +75,24 @@ async function main(): Promise<void> {
 	let extraTeardown: Array<() => Promise<void> | void> = [];
 
 	if (external) {
-		process.env.DATABASE_URL = raw;
+		// `external` is true only for a non-empty postgres:// URL, so `raw` is
+		// defined here; bind it to a non-optional local for the closure below.
+		const externalDatabaseUrl = raw as string;
+		process.env.DATABASE_URL = externalDatabaseUrl;
 		databaseReadiness = async () => {
+			// `lobu run` owns the local DB lifecycle, so it must apply migrations
+			// itself before the schema-version gate runs — otherwise a fresh/empty
+			// external Postgres throws `relation "schema_migrations" does not exist`.
+			// The CLI sets LOBU_RUN_OWNS_DB=1 when it spawns this bundle. Prod never
+			// sets it: there a separate dbmate migration Job applies migrations, and
+			// the app only asserts the DB is up to date (below). runMigrations is
+			// idempotent, so replaying against an already-migrated DB is a no-op.
+			if (process.env.LOBU_RUN_OWNS_DB === "1") {
+				logger.info(
+					"[migrations] LOBU_RUN_OWNS_DB=1 — applying migrations to external DATABASE_URL",
+				);
+				await runMigrations(externalDatabaseUrl);
+			}
 			// Refuse to boot if the image expects a migration the DB hasn't applied.
 			// Skippable via SKIP_SCHEMA_VERSION_CHECK=1 for emergency forward-flight.
 			if (process.env.SKIP_SCHEMA_VERSION_CHECK !== "1") {


### PR DESCRIPTION
## What

Two local-dev infra bugs that block `lobu run` against an external Postgres / custom data dir (found while running a benchmark that needed an external Postgres).

### 1. PRIMARY — external `DATABASE_URL` boot skips migrations

`lobu run` pointed at an external `postgres://` DATABASE_URL with a fresh/empty schema failed at boot:

```
PostgresError: relation "public.schema_migrations" does not exist
    at readAppliedSchemaVersion (.../server.bundle.mjs)
```

Root cause: `runMigrations()` was only invoked on the **embedded**-postgres path (via `EmbeddedRuntime.databaseReadiness`). The external-DATABASE_URL path in `server.ts` went straight to `assertSchemaUpToDate` → `readAppliedSchemaVersion`, which queries `schema_migrations` and throws on a never-migrated DB.

Fix: `lobu run` owns the local DB lifecycle, so the CLI (`dev.ts`) now sets `LOBU_RUN_OWNS_DB=1` when it spawns the server bundle. When that flag is set, `server.ts` runs the existing, idempotent `runMigrations()` (now `export`ed from `embedded-runtime.ts`) against the external DB **before** the schema-version gate. The migration set is the exact one dbmate uses (squashed baseline gated by `schema_migrations`, deltas use `IF NOT EXISTS`), so replaying against an already-migrated DB is a no-op.

**Prod is unchanged:** prod never sets `LOBU_RUN_OWNS_DB`. There the separate dbmate migration Job (Helm `migration-job.yaml`) still owns migrations, and the app only *asserts* the DB is up to date.

### 2. SECONDARY — `LOBU_DATA_DIR` was ignored (genuine source bug)

`docs/reference/cli.md` documents that the embedded data dir defaults to `~/.lobu/data` and is "override with `LOBU_DATA_DIR`", but nothing in source read `LOBU_DATA_DIR` — the embedded data root came only from `DATABASE_URL` (defaulted to `~` by the CLI). Now `dev.ts` honors `LOBU_DATA_DIR` as the embedded data root when `DATABASE_URL` is unset (explicit path-form `DATABASE_URL` still wins). This was a real source gap, not just a stale global bundle.

## Red → Green proof (PRIMARY)

Throwaway external Postgres: `initdb -D /tmp/it-pg` (pg17), `pg_ctl -o "-p 5544" start`, `createdb lobutest`, `CREATE EXTENSION vector`. Ran the freshly built `server.bundle.mjs` on `PORT=8831`.

**RED** (no `LOBU_RUN_OWNS_DB`, fresh DB) — server never starts:
```
err: relation "public.schema_migrations" does not exist  (code 42P01)
     at readAppliedSchemaVersion (server.bundle.mjs)
msg: "Failed to start server"
curl /api/health → 000
```

**GREEN** (`LOBU_RUN_OWNS_DB=1`, same fresh DB):
```
[migrations] LOBU_RUN_OWNS_DB=1 — applying migrations to external DATABASE_URL
Running migrations... / Migrations complete
[schema-check] schema version up to date  expected=20260528120000 applied=20260528120000
curl /api/health → 200
```
Post-state in the external DB: 71 public tables, 8 rows in `schema_migrations`, `events` table present.

**Idempotency** — restart against the now-migrated DB: migrations re-run as a clean no-op, `/api/health → 200`.

**Prod path unchanged** — run WITHOUT `LOBU_RUN_OWNS_DB` against the migrated DB: 0 migration runs, schema-check passes, `/api/health → 200`.

(SECONDARY `LOBU_DATA_DIR` was additionally exercised by the `make review` pi reviewer on the embedded path: migrations completed and health returned 200 under a temp `LOBU_DATA_DIR`.)

## Validation

`make review BASE=origin/main`: **bug_free 84, simplicity 86, 0 bugs, 0 blockers**; typecheck=0, unit=0, integration=0 (all green). Per-package `tsc --noEmit` for server + cli both exit 0.

## Out of scope (known gaps, not touched here)

- Embeddings forked-child failing to bind / slow async backfill (deep/flaky).
- `search_memory` / `knowledge.search` being entity-gated (likely intentional).
- Auth bootstrap on a fresh DB (already in flight as PR `feat/install-operator-bootstrap`).
- The qmsum-demo agent SOUL citation rule (different repo).
- The globally-installed `@lobu/cli` bundle is stale w.r.t. these fixes — picking them up needs a CLI rebuild/publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1154"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782650633&installation_id=136316292&pr_number=1154&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1154&signature=d7d83203815344b4ad8727738978ba27fb10a0d1552c04b58bb6cc8d6f63b9a6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->