### PR TITLE
feat(connector-sdk): extensionDomScrape helper; use it in LinkedIn home_feed

### DIFF
--- a/packages/connector-sdk/src/__tests__/extension-dom-scrape.test.ts
+++ b/packages/connector-sdk/src/__tests__/extension-dom-scrape.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Unit tests for extensionDomScrape. Drives the helper with a stub
+ * ChromeActionDispatcher that records the dispatched action + input and
+ * returns a canned cs_scrape observation.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import type { ExtensionScrapeObservation } from '../extension-dom-scrape.js';
+import { extensionDomScrape } from '../extension-dom-scrape.js';
+import type { ChromeActionDispatcher } from '../extension-network.js';
+
+interface DispatchLog {
+  action: string;
+  input: Record<string, unknown>;
+}
+
+function makeDispatcher(observation: ExtensionScrapeObservation): {
+  dispatcher: ChromeActionDispatcher;
+  log: DispatchLog[];
+} {
+  const log: DispatchLog[] = [];
+  const dispatcher: ChromeActionDispatcher = {
+    dispatch: async (action: string, input: Record<string, unknown>) => {
+      log.push({ action, input });
+      return observation as never;
+    },
+  };
+  return { dispatcher, log };
+}
+
+describe('extensionDomScrape', () => {
+  test('dispatches a single cs_scrape navigate with the config + allowlist', async () => {
+    const { dispatcher, log } = makeDispatcher({
+      tab_id: 7,
+      cs_scrape: true,
+      result: {
+        loggedIn: true,
+        count: 2,
+        host: 'www.example.com',
+        rows: [{ id: 'a' }, { id: 'b' }],
+      },
+    });
+
+    const config = { rowSelector: 'div.row', scroll: { max: 4 } };
+    const res = await extensionDomScrape<{ id?: string }>({
+      dispatcher,
+      url: 'https://www.example.com/feed/',
+      config,
+      parseRows: (rows) => rows as { id?: string }[],
+      allowedOrigins: ['example.com', '*.example.com'],
+    });
+
+    expect(log).toHaveLength(1);
+    expect(log[0].action).toBe('navigate');
+    expect(log[0].input.cs_scrape).toBe(true);
+    expect(log[0].input.persistent).toBe(true);
+    expect(log[0].input.focus).toBe(true);
+    expect(log[0].input.url).toBe('https://www.example.com/feed/');
+    expect(log[0].input.scrape_config).toBe(config);
+    expect(log[0].input.allowed_origins).toEqual(['example.com', '*.example.com']);
+
+    expect(res.items).toEqual([{ id: 'a' }, { id: 'b' }]);
+    expect(res.loggedIn).toBe(true);
+    expect(res.count).toBe(2);
+    expect(res.host).toBe('www.example.com');
+  });
+
+  test('treats absent loggedIn as logged in and defaults count to item length', async () => {
+    const { dispatcher } = makeDispatcher({ result: { rows: [{ id: 'x' }] } });
+    const res = await extensionDomScrape<{ id?: string }>({
+      dispatcher,
+      url: 'https://www.example.com/feed/',
+      config: {},
+      parseRows: (rows) => rows as { id?: string }[],
+      allowedOrigins: ['example.com'],
+    });
+    expect(res.loggedIn).toBe(true);
+    expect(res.count).toBe(1);
+    expect(res.items).toHaveLength(1);
+  });
+
+  test('surfaces loggedIn:false', async () => {
+    const { dispatcher } = makeDispatcher({
+      result: { loggedIn: false, rows: [] },
+    });
+    const res = await extensionDomScrape<{ id?: string }>({
+      dispatcher,
+      url: 'https://www.example.com/feed/',
+      config: {},
+      parseRows: (rows) => rows as { id?: string }[],
+      allowedOrigins: ['example.com'],
+    });
+    expect(res.loggedIn).toBe(false);
+    expect(res.items).toEqual([]);
+    expect(res.count).toBe(0);
+  });
+
+  test('honors persistent/focus overrides and handles a missing result envelope', async () => {
+    const { dispatcher, log } = makeDispatcher({});
+    const res = await extensionDomScrape<{ id?: string }>({
+      dispatcher,
+      url: 'https://www.example.com/feed/',
+      config: {},
+      parseRows: (rows) => rows as { id?: string }[],
+      allowedOrigins: ['example.com'],
+      persistent: false,
+      focus: false,
+    });
+    expect(log[0].input.persistent).toBe(false);
+    expect(log[0].input.focus).toBe(false);
+    // No `result` → empty rows, logged-in by default, count 0.
+    expect(res.items).toEqual([]);
+    expect(res.loggedIn).toBe(true);
+    expect(res.count).toBe(0);
+  });
+});

--- a/packages/connector-sdk/src/extension-dom-scrape.ts
+++ b/packages/connector-sdk/src/extension-dom-scrape.ts
@@ -1,0 +1,152 @@
+/**
+ * Extension DOM Scrape
+ *
+ * Companion to `extensionNetworkSync` (extension-network.ts) for the feeds
+ * that CAN'T be read by passive network capture. Attaching the CDP debugger
+ * (which the Network-domain intercept needs) stops some personalized feeds
+ * from rendering, so the Voyager-style XHRs never fire. For those, the Owletto
+ * extension exposes a content-script scrape op (`cs_scrape`): a single
+ * `navigate` dispatch that opens/reuses a tab, runs the extension's
+ * site-agnostic `genericScrape` engine over the live DOM using a declarative
+ * `scrape_config`, scrolls, and hands back the extracted rows.
+ *
+ * Why this exists: connectors used to hand-wire that `navigate` dispatch
+ * inline (LinkedIn's home feed), which left the SDK asymmetric: a helper for
+ * the network path, a raw dispatch for the DOM path. This wraps the single
+ * dispatch so every extension feed goes through the SDK, and the connector
+ * only supplies the (site-specific) selector config + a row parser.
+ *
+ * Generic by design: the SDK names no site. The `scrape_config` selectors and
+ * the `allowedOrigins` are supplied by the caller; the extension interprets
+ * the config (apps/chrome content-script genericScrape).
+ *
+ * Wire shape: the dispatcher returns the same `observation` envelope the
+ * extension produces on /api/workers/complete-action. The connector awaits the
+ * dispatcher and never needs to know how the run was routed (sync vs queued).
+ */
+
+import type { ChromeActionDispatcher } from './extension-network.js';
+
+// ── Wire types (mirror the extension's genericScrape config + result) ──
+
+/**
+ * Declarative selector config the extension's content-script `genericScrape`
+ * interprets. The SDK passes this through verbatim as `scrape_config`; the
+ * connector owns the site-specific selectors. Kept structurally permissive
+ * (an index signature) so connectors can add engine fields the SDK doesn't
+ * need to know about without widening this type.
+ */
+export interface ExtensionScrapeConfig {
+  /**
+   * Scroll loop bounds. `max` iterations; `stall` = consecutive no-growth
+   * scrolls before stopping; `waitMs` between scrolls; `deep` = deeper walk.
+   */
+  scroll?: { max?: number; stall?: number; waitMs?: number; deep?: boolean };
+  /** When the landed page matches, the extension reports `loggedIn: false`. */
+  loggedOutWhen?: { pathRegex?: string; hostRegex?: string };
+  /** CSS selector for each row container. */
+  rowSelector?: string;
+  /** Optional grouping selector. */
+  group?: string;
+  /** How to derive the row id from the matched element. */
+  id?: { source: string; name?: string; regex?: string; group?: number };
+  /** Rows missing any of these extracted fields are dropped. */
+  requireFields?: readonly string[];
+  /** Field extractors keyed by output field name. */
+  fields?: Record<
+    string,
+    {
+      selector?: string;
+      take?: string;
+      attr?: string;
+      firstLine?: boolean;
+      const?: unknown;
+    }
+  >;
+  [k: string]: unknown;
+}
+
+/** The `.result` payload of a `cs_scrape` dispatch. */
+export interface ExtensionScrapeResult {
+  count?: number;
+  host?: string;
+  landedUrl?: string;
+  loggedIn?: boolean;
+  rows?: Array<Record<string, unknown>>;
+  [k: string]: unknown;
+}
+
+/**
+ * The dispatch observation wrapping a `cs_scrape` result. The index signature
+ * keeps it assignable to ChromeActionDispatcher.dispatch's `ChromeActionOutput`
+ * (= Record<string, unknown>) constraint.
+ */
+export type ExtensionScrapeObservation = Record<string, unknown> & {
+  tab_id?: number;
+  cs_scrape?: boolean;
+  persistent_reused?: boolean;
+  result?: ExtensionScrapeResult;
+};
+
+export interface ExtensionDomScrapeResult<TItem> {
+  items: TItem[];
+  loggedIn: boolean;
+  count: number;
+  host?: string;
+  landedUrl?: string;
+}
+
+// ── Main entrypoint ───────────────────────────────────────────────────────
+
+/**
+ * Drive a single content-script `cs_scrape` navigate against the extension and
+ * return the parsed rows. Mirrors `extensionNetworkSync` for the DOM path: the
+ * connector supplies the declarative `config` (its own selectors) and a
+ * `parseRows` mapper; the SDK owns the dispatch shape.
+ *
+ * `persistent`/`focus` default to true so a reused, focused window lets the
+ * user clear an auth wall in place for the next run.
+ */
+export async function extensionDomScrape<TItem>(opts: {
+  dispatcher: ChromeActionDispatcher;
+  url: string;
+  /** The declarative scrape config the extension interprets (site selectors). */
+  config: ExtensionScrapeConfig;
+  /** Map the extension's raw extracted rows into typed items. */
+  parseRows: (rows: Array<Record<string, unknown>>) => TItem[];
+  /**
+   * Origins the dispatched navigate is allowed to touch. Forwarded as
+   * `allowed_origins` so the extension's per-run origin gate blocks anything
+   * off-host (mirrors extensionNetworkSync's allowlist).
+   */
+  allowedOrigins: string[];
+  /** Reuse a persistent window (default true). */
+  persistent?: boolean;
+  /** Focus the window so an auth wall can be cleared in place (default true). */
+  focus?: boolean;
+}): Promise<ExtensionDomScrapeResult<TItem>> {
+  const observation = await opts.dispatcher.dispatch<ExtensionScrapeObservation>(
+    'navigate',
+    {
+      cs_scrape: true,
+      persistent: opts.persistent ?? true,
+      focus: opts.focus ?? true,
+      url: opts.url,
+      scrape_config: opts.config,
+      allowed_origins: opts.allowedOrigins,
+    }
+  );
+
+  const result = observation?.result;
+  const rows = result?.rows ?? [];
+  const items = opts.parseRows(rows);
+
+  return {
+    items,
+    // Only an explicit `false` means logged out; absence is treated as ok.
+    loggedIn: result?.loggedIn !== false,
+    count: result?.count ?? items.length,
+    host: result?.host,
+    landedUrl: result?.landedUrl,
+  };
+}

--- a/packages/connector-sdk/src/extension-dom-scrape.ts
+++ b/packages/connector-sdk/src/extension-dom-scrape.ts
@@ -1,67 +1,24 @@
-/**
- * Extension DOM Scrape
- *
- * Companion to `extensionNetworkSync` (extension-network.ts) for the feeds
- * that CAN'T be read by passive network capture. Attaching the CDP debugger
- * (which the Network-domain intercept needs) stops some personalized feeds
- * from rendering, so the Voyager-style XHRs never fire. For those, the Owletto
- * extension exposes a content-script scrape op (`cs_scrape`): a single
- * `navigate` dispatch that opens/reuses a tab, runs the extension's
- * site-agnostic `genericScrape` engine over the live DOM using a declarative
- * `scrape_config`, scrolls, and hands back the extracted rows.
- *
- * Why this exists: connectors used to hand-wire that `navigate` dispatch
- * inline (LinkedIn's home feed), which left the SDK asymmetric: a helper for
- * the network path, a raw dispatch for the DOM path. This wraps the single
- * dispatch so every extension feed goes through the SDK, and the connector
- * only supplies the (site-specific) selector config + a row parser.
- *
- * Generic by design: the SDK names no site. The `scrape_config` selectors and
- * the `allowedOrigins` are supplied by the caller; the extension interprets
- * the config (apps/chrome content-script genericScrape).
- *
- * Wire shape: the dispatcher returns the same `observation` envelope the
- * extension produces on /api/workers/complete-action. The connector awaits the
- * dispatcher and never needs to know how the run was routed (sync vs queued).
- */
-
 import type { ChromeActionDispatcher } from './extension-network.js';
 
-// ── Wire types (mirror the extension's genericScrape config + result) ──
-
 /**
- * Declarative selector config the extension's content-script `genericScrape`
- * interprets. The SDK passes this through verbatim as `scrape_config`; the
- * connector owns the site-specific selectors. Kept structurally permissive
- * (an index signature) so connectors can add engine fields the SDK doesn't
- * need to know about without widening this type.
+ * Companion to `extensionNetworkSync` for feeds that can't be read by passive
+ * network capture — the CDP debugger the intercept needs stops some
+ * personalized feeds from rendering. Wraps the extension's content-script
+ * `cs_scrape` op in one dispatch so the DOM path goes through the SDK like the
+ * network path; the connector supplies only its selector config + a row parser.
  */
+
+/** Declarative config the extension's `genericScrape` interprets; forwarded verbatim as `scrape_config`. */
 export interface ExtensionScrapeConfig {
-  /**
-   * Scroll loop bounds. `max` iterations; `stall` = consecutive no-growth
-   * scrolls before stopping; `waitMs` between scrolls; `deep` = deeper walk.
-   */
   scroll?: { max?: number; stall?: number; waitMs?: number; deep?: boolean };
-  /** When the landed page matches, the extension reports `loggedIn: false`. */
   loggedOutWhen?: { pathRegex?: string; hostRegex?: string };
-  /** CSS selector for each row container. */
   rowSelector?: string;
-  /** Optional grouping selector. */
   group?: string;
-  /** How to derive the row id from the matched element. */
   id?: { source: string; name?: string; regex?: string; group?: number };
-  /** Rows missing any of these extracted fields are dropped. */
   requireFields?: readonly string[];
-  /** Field extractors keyed by output field name. */
   fields?: Record<
     string,
-    {
-      selector?: string;
-      take?: string;
-      attr?: string;
-      firstLine?: boolean;
-      const?: unknown;
-    }
+    { selector?: string; take?: string; attr?: string; firstLine?: boolean; const?: unknown }
   >;
   [k: string]: unknown;
 }
@@ -76,11 +33,7 @@ export interface ExtensionScrapeResult {
   [k: string]: unknown;
 }
 
-/**
- * The dispatch observation wrapping a `cs_scrape` result. The index signature
- * keeps it assignable to ChromeActionDispatcher.dispatch's `ChromeActionOutput`
- * (= Record<string, unknown>) constraint.
- */
+/** Dispatcher observation envelope; the index signature satisfies `ChromeActionOutput`. */
 export type ExtensionScrapeObservation = Record<string, unknown> & {
   tab_id?: number;
   cs_scrape?: boolean;
@@ -96,54 +49,32 @@ export interface ExtensionDomScrapeResult<TItem> {
   landedUrl?: string;
 }
 
-// ── Main entrypoint ───────────────────────────────────────────────────────
-
 /**
- * Drive a single content-script `cs_scrape` navigate against the extension and
- * return the parsed rows. Mirrors `extensionNetworkSync` for the DOM path: the
- * connector supplies the declarative `config` (its own selectors) and a
- * `parseRows` mapper; the SDK owns the dispatch shape.
- *
- * `persistent`/`focus` default to true so a reused, focused window lets the
- * user clear an auth wall in place for the next run.
+ * Drive one content-script `cs_scrape` navigate and return parsed rows.
+ * `persistent`/`focus` default true so a reused, focused window lets the user
+ * clear an auth wall in place.
  */
 export async function extensionDomScrape<TItem>(opts: {
   dispatcher: ChromeActionDispatcher;
   url: string;
-  /** The declarative scrape config the extension interprets (site selectors). */
   config: ExtensionScrapeConfig;
-  /** Map the extension's raw extracted rows into typed items. */
   parseRows: (rows: Array<Record<string, unknown>>) => TItem[];
-  /**
-   * Origins the dispatched navigate is allowed to touch. Forwarded as
-   * `allowed_origins` so the extension's per-run origin gate blocks anything
-   * off-host (mirrors extensionNetworkSync's allowlist).
-   */
   allowedOrigins: string[];
-  /** Reuse a persistent window (default true). */
   persistent?: boolean;
-  /** Focus the window so an auth wall can be cleared in place (default true). */
   focus?: boolean;
 }): Promise<ExtensionDomScrapeResult<TItem>> {
-  const observation = await opts.dispatcher.dispatch<ExtensionScrapeObservation>(
-    'navigate',
-    {
-      cs_scrape: true,
-      persistent: opts.persistent ?? true,
-      focus: opts.focus ?? true,
-      url: opts.url,
-      scrape_config: opts.config,
-      allowed_origins: opts.allowedOrigins,
-    }
-  );
-
+  const observation = await opts.dispatcher.dispatch<ExtensionScrapeObservation>('navigate', {
+    cs_scrape: true,
+    persistent: opts.persistent ?? true,
+    focus: opts.focus ?? true,
+    url: opts.url,
+    scrape_config: opts.config,
+    allowed_origins: opts.allowedOrigins,
+  });
   const result = observation?.result;
-  const rows = result?.rows ?? [];
-  const items = opts.parseRows(rows);
-
+  const items = opts.parseRows(result?.rows ?? []);
   return {
     items,
-    // Only an explicit `false` means logged out; absence is treated as ok.
     loggedIn: result?.loggedIn !== false,
     count: result?.count ?? items.length,
     host: result?.host,

--- a/packages/connector-sdk/src/index.ts
+++ b/packages/connector-sdk/src/index.ts
@@ -144,6 +144,13 @@ export {
 export type { BrowserNetworkConfig, BrowserNetworkResult } from './browser-network.js';
 export { browserNetworkSync } from './browser-network.js';
 export type {
+  ExtensionDomScrapeResult,
+  ExtensionScrapeConfig,
+  ExtensionScrapeObservation,
+  ExtensionScrapeResult,
+} from './extension-dom-scrape.js';
+export { extensionDomScrape } from './extension-dom-scrape.js';
+export type {
   ChromeActionDispatcher,
   ChromeActionInput,
   ChromeActionOutput,

--- a/packages/connectors/src/__tests__/browser-scraper-utils.test.ts
+++ b/packages/connectors/src/__tests__/browser-scraper-utils.test.ts
@@ -20,6 +20,38 @@ mock.module('@lobu/connector-sdk', () => ({
   extensionNetworkSync: () => {
     throw new Error('not used in unit tests');
   },
+  // Faithful re-implementation of the SDK helper so the shared mock satisfies
+  // linkedin's home-feed path regardless of file order (mirrors the helper in
+  // packages/connector-sdk; its own unit tests cover the real implementation).
+  extensionDomScrape: async (opts: {
+    // biome-ignore lint/suspicious/noExplicitAny: stub dispatcher return
+    dispatcher: { dispatch: (a: string, i: Record<string, unknown>) => Promise<any> };
+    url: string;
+    config: Record<string, unknown>;
+    parseRows: (rows: Array<Record<string, unknown>>) => unknown[];
+    allowedOrigins: string[];
+    persistent?: boolean;
+    focus?: boolean;
+  }) => {
+    const observation = await opts.dispatcher.dispatch('navigate', {
+      cs_scrape: true,
+      persistent: opts.persistent ?? true,
+      focus: opts.focus ?? true,
+      url: opts.url,
+      scrape_config: opts.config,
+      allowed_origins: opts.allowedOrigins,
+    });
+    const result = observation?.result;
+    const rows = result?.rows ?? [];
+    const items = opts.parseRows(rows);
+    return {
+      items,
+      loggedIn: result?.loggedIn !== false,
+      count: result?.count ?? items.length,
+      host: result?.host,
+      landedUrl: result?.landedUrl,
+    };
+  },
 }));
 
 const {

--- a/packages/connectors/src/__tests__/browser-scraper-utils.test.ts
+++ b/packages/connectors/src/__tests__/browser-scraper-utils.test.ts
@@ -1,58 +1,9 @@
 import { describe, expect, mock, test } from 'bun:test';
+import { connectorSdkMock } from './connector-sdk.mock';
 
-// browser-scraper-utils.ts pulls runtime symbols (acquireBrowser,
-// captureErrorArtifacts) from @lobu/connector-sdk, which itself pulls in
-// playwright. Stub the SDK so the pure helpers (validateUrlDomain,
-// getBrowserCookies, validateCookieNotExpired, filterByCheckpoint) can be
-// imported without spinning up a real browser stack.
-mock.module('@lobu/connector-sdk', () => ({
-  acquireBrowser: () => {
-    throw new Error('not used in unit tests');
-  },
-  captureErrorArtifacts: () => {
-    throw new Error('not used in unit tests');
-  },
-  // Other connector tests (linkedin) load the same stubbed module in the same
-  // run; expose the symbols they need so the shared mock satisfies every
-  // importer regardless of file order.
-  ConnectorRuntime: class {},
-  calculateEngagementScore: () => 0,
-  extensionNetworkSync: () => {
-    throw new Error('not used in unit tests');
-  },
-  // Faithful re-implementation of the SDK helper so the shared mock satisfies
-  // linkedin's home-feed path regardless of file order (mirrors the helper in
-  // packages/connector-sdk; its own unit tests cover the real implementation).
-  extensionDomScrape: async (opts: {
-    // biome-ignore lint/suspicious/noExplicitAny: stub dispatcher return
-    dispatcher: { dispatch: (a: string, i: Record<string, unknown>) => Promise<any> };
-    url: string;
-    config: Record<string, unknown>;
-    parseRows: (rows: Array<Record<string, unknown>>) => unknown[];
-    allowedOrigins: string[];
-    persistent?: boolean;
-    focus?: boolean;
-  }) => {
-    const observation = await opts.dispatcher.dispatch('navigate', {
-      cs_scrape: true,
-      persistent: opts.persistent ?? true,
-      focus: opts.focus ?? true,
-      url: opts.url,
-      scrape_config: opts.config,
-      allowed_origins: opts.allowedOrigins,
-    });
-    const result = observation?.result;
-    const rows = result?.rows ?? [];
-    const items = opts.parseRows(rows);
-    return {
-      items,
-      loggedIn: result?.loggedIn !== false,
-      count: result?.count ?? items.length,
-      host: result?.host,
-      landedUrl: result?.landedUrl,
-    };
-  },
-}));
+// Stub @lobu/connector-sdk (it pulls in playwright) so the pure helpers import
+// without the browser stack. Shared superset — see connector-sdk.mock.ts.
+mock.module('@lobu/connector-sdk', connectorSdkMock);
 
 const {
   filterByCheckpoint,

--- a/packages/connectors/src/__tests__/connector-sdk.mock.ts
+++ b/packages/connectors/src/__tests__/connector-sdk.mock.ts
@@ -1,0 +1,58 @@
+// Shared @lobu/connector-sdk mock for connector unit tests.
+//
+// mock.module replaces the WHOLE module and bun shares the mock registry
+// across files in a run, so every connector test that stubs the SDK must
+// expose the same superset of symbols regardless of file order. This is the
+// single source for that superset — `mock.module('@lobu/connector-sdk',
+// connectorSdkMock)` in each test file.
+//
+// The SDK pulls in playwright; stubbing lets the pure connector logic be
+// imported without the browser stack. The runtime-only symbols throw if a
+// test actually reaches them; extensionDomScrape is faithfully re-implemented
+// so the home-feed path exercises the same dispatch shape (the real helper has
+// its own tests in packages/connector-sdk).
+
+interface DomScrapeOpts {
+  dispatcher: {
+    // biome-ignore lint/suspicious/noExplicitAny: stub dispatcher return
+    dispatch: (action: string, input: Record<string, unknown>) => Promise<any>;
+  };
+  url: string;
+  config: Record<string, unknown>;
+  parseRows: (rows: Array<Record<string, unknown>>) => unknown[];
+  allowedOrigins: string[];
+  persistent?: boolean;
+  focus?: boolean;
+}
+
+export function connectorSdkMock() {
+  const notUsed = (name: string) => () => {
+    throw new Error(`${name} is not used in connector unit tests`);
+  };
+  return {
+    acquireBrowser: notUsed('acquireBrowser'),
+    captureErrorArtifacts: notUsed('captureErrorArtifacts'),
+    extensionNetworkSync: notUsed('extensionNetworkSync'),
+    ConnectorRuntime: class {},
+    calculateEngagementScore: () => 0,
+    extensionDomScrape: async (opts: DomScrapeOpts) => {
+      const observation = await opts.dispatcher.dispatch('navigate', {
+        cs_scrape: true,
+        persistent: opts.persistent ?? true,
+        focus: opts.focus ?? true,
+        url: opts.url,
+        scrape_config: opts.config,
+        allowed_origins: opts.allowedOrigins,
+      });
+      const result = observation?.result;
+      const items = opts.parseRows(result?.rows ?? []);
+      return {
+        items,
+        loggedIn: result?.loggedIn !== false,
+        count: result?.count ?? items.length,
+        host: result?.host,
+        landedUrl: result?.landedUrl,
+      };
+    },
+  };
+}

--- a/packages/connectors/src/__tests__/linkedin.test.ts
+++ b/packages/connectors/src/__tests__/linkedin.test.ts
@@ -11,6 +11,38 @@ mock.module('@lobu/connector-sdk', () => ({
   extensionNetworkSync: () => {
     throw new Error('not used in home_feed unit tests');
   },
+  // Faithful re-implementation of the SDK helper so the connector's
+  // home-feed path exercises the same dispatch shape under test. The real
+  // helper has its own unit tests in packages/connector-sdk.
+  extensionDomScrape: async (opts: {
+    // biome-ignore lint/suspicious/noExplicitAny: stub dispatcher return
+    dispatcher: { dispatch: (a: string, i: Record<string, unknown>) => Promise<any> };
+    url: string;
+    config: Record<string, unknown>;
+    parseRows: (rows: Array<Record<string, unknown>>) => unknown[];
+    allowedOrigins: string[];
+    persistent?: boolean;
+    focus?: boolean;
+  }) => {
+    const observation = await opts.dispatcher.dispatch('navigate', {
+      cs_scrape: true,
+      persistent: opts.persistent ?? true,
+      focus: opts.focus ?? true,
+      url: opts.url,
+      scrape_config: opts.config,
+      allowed_origins: opts.allowedOrigins,
+    });
+    const result = observation?.result;
+    const rows = result?.rows ?? [];
+    const items = opts.parseRows(rows);
+    return {
+      items,
+      loggedIn: result?.loggedIn !== false,
+      count: result?.count ?? items.length,
+      host: result?.host,
+      landedUrl: result?.landedUrl,
+    };
+  },
 }));
 
 // biome-ignore lint/suspicious/noExplicitAny: dynamic import after mock

--- a/packages/connectors/src/__tests__/linkedin.test.ts
+++ b/packages/connectors/src/__tests__/linkedin.test.ts
@@ -1,49 +1,9 @@
 import { beforeAll, describe, expect, mock, test } from 'bun:test';
+import { connectorSdkMock } from './connector-sdk.mock';
 
-// linkedin.ts imports ConnectorRuntime / calculateEngagementScore /
-// extensionNetworkSync from @lobu/connector-sdk, which pulls in playwright.
-// Stub the SDK so the connector can be imported + instantiated without the
-// real browser stack. ConnectorRuntime is a no-op base class here; the
-// home-feed path only needs the dispatcher we pass in.
-mock.module('@lobu/connector-sdk', () => ({
-  ConnectorRuntime: class {},
-  calculateEngagementScore: () => 0,
-  extensionNetworkSync: () => {
-    throw new Error('not used in home_feed unit tests');
-  },
-  // Faithful re-implementation of the SDK helper so the connector's
-  // home-feed path exercises the same dispatch shape under test. The real
-  // helper has its own unit tests in packages/connector-sdk.
-  extensionDomScrape: async (opts: {
-    // biome-ignore lint/suspicious/noExplicitAny: stub dispatcher return
-    dispatcher: { dispatch: (a: string, i: Record<string, unknown>) => Promise<any> };
-    url: string;
-    config: Record<string, unknown>;
-    parseRows: (rows: Array<Record<string, unknown>>) => unknown[];
-    allowedOrigins: string[];
-    persistent?: boolean;
-    focus?: boolean;
-  }) => {
-    const observation = await opts.dispatcher.dispatch('navigate', {
-      cs_scrape: true,
-      persistent: opts.persistent ?? true,
-      focus: opts.focus ?? true,
-      url: opts.url,
-      scrape_config: opts.config,
-      allowed_origins: opts.allowedOrigins,
-    });
-    const result = observation?.result;
-    const rows = result?.rows ?? [];
-    const items = opts.parseRows(rows);
-    return {
-      items,
-      loggedIn: result?.loggedIn !== false,
-      count: result?.count ?? items.length,
-      host: result?.host,
-      landedUrl: result?.landedUrl,
-    };
-  },
-}));
+// Stub @lobu/connector-sdk (it pulls in playwright) so the connector imports
+// without the browser stack. Shared superset — see connector-sdk.mock.ts.
+mock.module('@lobu/connector-sdk', connectorSdkMock);
 
 // biome-ignore lint/suspicious/noExplicitAny: dynamic import after mock
 let LinkedInConnector: any;

--- a/packages/connectors/src/linkedin.ts
+++ b/packages/connectors/src/linkedin.ts
@@ -20,6 +20,7 @@ import {
   ConnectorRuntime,
   calculateEngagementScore,
   type EventEnvelope,
+  extensionDomScrape,
   extensionNetworkSync,
   type SyncContext,
   type SyncResult,
@@ -74,27 +75,6 @@ interface HomeFeedRow {
   body?: string;
   author?: string;
 }
-
-/** The `.result` payload of a cs_scrape dispatch. */
-interface HomeFeedScrapeResult {
-  count?: number;
-  host?: string;
-  landedUrl?: string;
-  loggedIn?: boolean;
-  rows?: HomeFeedRow[];
-}
-
-/**
- * The dispatch observation wrapping a cs_scrape result. The index signature
- * keeps it assignable to ChromeActionDispatcher.dispatch's `ChromeActionOutput`
- * (= Record<string, unknown>) constraint.
- */
-type CsScrapeObservation = Record<string, unknown> & {
-  tab_id?: number;
-  cs_scrape?: boolean;
-  persistent_reused?: boolean;
-  result?: HomeFeedScrapeResult;
-};
 
 /** LinkedIn origins the cs_scrape window is allowed to touch. */
 const LINKEDIN_ALLOWED_ORIGINS = ['linkedin.com', '*.linkedin.com'];
@@ -486,26 +466,23 @@ export default class LinkedInConnector extends ConnectorRuntime {
     checkpoint: LinkedInCheckpoint,
     dispatcher: ChromeActionDispatcher
   ): Promise<SyncResult> {
-    const observation = await dispatcher.dispatch<CsScrapeObservation>('navigate', {
-      cs_scrape: true,
-      persistent: true,
-      focus: true,
+    const { items: rows, loggedIn } = await extensionDomScrape<HomeFeedRow>({
+      dispatcher,
       url: 'https://www.linkedin.com/feed/',
-      scrape_config: {
+      config: {
         ...HOME_FEED_SCRAPE_CONFIG,
         scroll: { ...HOME_FEED_SCRAPE_CONFIG.scroll, max: maxScrolls },
       },
-      allowed_origins: LINKEDIN_ALLOWED_ORIGINS,
+      parseRows: (raw) => raw as HomeFeedRow[],
+      allowedOrigins: LINKEDIN_ALLOWED_ORIGINS,
     });
 
-    const result = observation?.result;
-    if (result?.loggedIn === false) {
+    if (!loggedIn) {
       throw new Error(
         'Not logged into LinkedIn. The home feed could not be read — sign in to LinkedIn in the focused Owletto window, then re-run the sync.'
       );
     }
 
-    const rows = result?.rows ?? [];
     const events = buildHomeFeedEvents(rows, new Date());
 
     return {


### PR DESCRIPTION
## What

Adds the missing SDK helper for the **content-script DOM path** so the LinkedIn home feed goes through the SDK like the network feeds, instead of a raw inline dispatch.

The connector SDK already had `extensionNetworkSync` for passive network capture (company updates, jobs, Revolut, X). But the LinkedIn **home feed** can't use network capture — attaching the CDP debugger that the Network-domain intercept needs stops the personalized feed from rendering, so the Voyager XHRs never fire. Instead it reads the live DOM via the extension's content-script op `cs_scrape`. That path was hand-wired **inline** in `linkedin.ts` (`dispatcher.dispatch('navigate', { cs_scrape: true, ... })` + reading `observation.result.{rows,loggedIn}`), leaving the SDK asymmetric: a helper for the network path, a raw dispatch for the DOM path.

This PR closes that gap.

## Changes

- **`packages/connector-sdk/src/extension-dom-scrape.ts`** (new): `extensionDomScrape<TItem>({ dispatcher, url, config, parseRows, allowedOrigins, persistent?, focus? })`. Does the single `navigate`+`cs_scrape` dispatch (defaulting `persistent`/`focus` to true), reads `observation.result`, returns `{ items, loggedIn, count, host?, landedUrl? }` (`loggedIn` is `true` unless the extension reports an explicit `false`). Reuses the existing `ChromeActionDispatcher` type from `extension-network.ts` — no second definition. Exports `extensionDomScrape` + `ExtensionScrapeConfig`/`ExtensionScrapeResult`/`ExtensionScrapeObservation`/`ExtensionDomScrapeResult` from the package index.
- **`packages/connectors/src/linkedin.ts`**: `syncHomeFeed` now calls `extensionDomScrape` instead of the inline dispatch. Deletes the now-dead local `CsScrapeObservation` / `HomeFeedScrapeResult` types (keeps `HomeFeedRow`, `HOME_FEED_SCRAPE_CONFIG`, `buildHomeFeedEvents`). `company_updates`/`jobs` stay on `extensionNetworkSync`.

The SDK helper stays **generic and names no site** — the selectors (`HOME_FEED_SCRAPE_CONFIG`) and allowed origins stay in the connector, where they belong (CSP/site-specific constraint).

## No behavior change

Same single `navigate` + `cs_scrape` dispatch with the same `scrape_config`/`allowed_origins`, same logged-out error message — just wrapped behind the SDK.

## Tests / typecheck

- `bun test packages/connectors/src/__tests__/ packages/connector-sdk/src/__tests__/extension-dom-scrape.test.ts packages/connector-sdk/src/__tests__/extension-network.test.ts` → **38 pass / 0 fail**. Existing LinkedIn home-feed tests still pass; added `extension-dom-scrape.test.ts` (stub dispatcher → asserts dispatch shape, row parsing, and `loggedIn` true/false/absent handling).
- `bunx tsc --noEmit` on `packages/connector-sdk` → clean. On `packages/connectors`, no new errors in touched files (linkedin.ts clean); remaining errors are the known pre-existing baseline in other connectors + `.ts`-import-extension config noise.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1155"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782650710&installation_id=136316292&pr_number=1155&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1155&signature=9e871d5d03771362397d4f52544298916061354051c1d54f62952f189cea34de"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added extension DOM scraping capabilities to the connector SDK, enabling improved web content extraction with enhanced configuration and result handling for browser extension-based scraping operations.

* **Improvements**
  * Updated LinkedIn connector to leverage improved content extraction mechanisms for more reliable data retrieval.

* **Tests**
  * Refactored test infrastructure to use shared mock implementations, improving consistency and maintainability across connector unit tests.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lobu-ai/lobu/pull/1155?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->