### PR TITLE
fix(server): repair connections.entity_ids schema drift (query_sql)

### DIFF
--- a/db/migrations/20260529120000_connections_entity_ids.sql
+++ b/db/migrations/20260529120000_connections_entity_ids.sql
@@ -1,0 +1,22 @@
+-- migrate:up
+
+-- Schema drift repair: `connections.entity_ids` exists in the squashed baseline
+-- (00000000000000_baseline.sql) with a GIN index, but installs provisioned from
+-- an *older* pre-squash baseline applied the column to events/watchers/feeds and
+-- never to connections. Those databases (e.g. the prod `owletto` DB) are missing
+-- both the column and its index, so any query that projects connections.entity_ids
+-- — including the admin `query_sql` tool whose SAFE_COLUMN_DEFS allowlist lists it
+-- — fails with `column "entity_ids" does not exist`.
+--
+-- This delta is idempotent: a no-op on fresh installs (baseline already created
+-- the column + index) and a repair on drifted databases. Matches the baseline
+-- definition exactly so the allowlist stays consistent with the real schema.
+ALTER TABLE public.connections ADD COLUMN IF NOT EXISTS entity_ids bigint[];
+
+CREATE INDEX IF NOT EXISTS idx_connections_entity_ids ON public.connections USING gin (entity_ids);
+
+-- migrate:down
+
+DROP INDEX IF EXISTS public.idx_connections_entity_ids;
+
+ALTER TABLE public.connections DROP COLUMN IF EXISTS entity_ids;


### PR DESCRIPTION
## Problem
The admin `query_sql` tool crashes on the `connections` table in prod: `SQL_ERROR: column "entity_ids" does not exist`, even when `entity_ids` isn't selected — it builds the projection from the `SAFE_COLUMN_DEFS` allowlist, which (correctly) lists `entity_ids`.

## Root cause
`connections.entity_ids bigint[]` and its GIN index are defined in the squashed baseline (`db/migrations/00000000000000_baseline.sql:716,3522`). The prod serving DB (`owletto`) was provisioned from an older pre-squash baseline plus a migration series no longer present in the repo, so `connections.entity_ids` (added only in the squash) was never applied — while sibling tables (events/watchers/feeds) did get it. Classic squashed-baseline drift; the allowlist is correct, the prod table is behind.

## Fix
Idempotent delta migration adding the column + GIN index `IF NOT EXISTS`: a no-op on fresh installs (baseline already has it) and a repair on drifted DBs. No change to `table-schema.ts`.

## Validation — red→green on real Postgres matching prod's drifted shape
- Created a scratch DB in the prod PG engine, recreated the drifted `connections` shape (no `entity_ids`), ran the exact allowlist projection `query_sql` builds → reproduced `column "entity_ids" does not exist` (RED).
- Applied the migration up-section → `SELECT slug, status FROM connections ORDER BY updated_at DESC` returned rows (GREEN). Idempotency confirmed (re-run = skip). Scratch DB dropped.
- `tsc --noEmit` (packages/server): clean.

## Follow-ups (not in this PR)
- The drift test (`packages/server/src/utils/__tests__/table-schema.test.ts`) only checks DB→allowlist, not allowlist→DB, and runs against the current baseline — so it could not have caught this. Add the reverse-direction assertion.
- `connections.entity_ids` is provisioned but not yet wired into the product (connection↔entity association). Tracked as a separate feature.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1157"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782659407&installation_id=136316292&pr_number=1157&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1157&signature=322e5ba05ae59c9dc944e577c203b06f61311570b91e4ad6602e28eee42c33a7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Applied a database maintenance update to ensure schema consistency and improve data retrieval performance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lobu-ai/lobu/pull/1157?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->