### PR TITLE
fix(auth): set username at signup + bump owletto (new-user org routing)

### DIFF
--- a/packages/server/src/__tests__/integration/auth/personal-org-username.test.ts
+++ b/packages/server/src/__tests__/integration/auth/personal-org-username.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Integration tests for the username side effect of
+ * `ensurePersonalOrganization`. The frontend resolves a user's home org from
+ * `session.user.username` (personalOrgSlug); mirroring the personal org slug
+ * onto username lets the home route resolve synchronously instead of waiting
+ * on `/api/organizations`. Must be set-when-null, idempotent, and never
+ * collide with another user's username.
+ */
+
+import { beforeEach, describe, expect, it } from "vitest";
+import { generateSecureToken } from "../../../auth/oauth/utils";
+import { ensurePersonalOrganization } from "../../../auth/personal-org-provisioning";
+import { cleanupTestDatabase, getTestDb } from "../../setup/test-db";
+
+async function seedUser(opts: {
+	name: string;
+	username?: string | null;
+}): Promise<{ id: string; email: string }> {
+	const id = `user_${generateSecureToken(6)}`;
+	const email = `${id}@test.local`;
+	const sql = getTestDb();
+	await sql`
+    INSERT INTO "user" (id, name, email, username, "emailVerified", "createdAt", "updatedAt")
+    VALUES (${id}, ${opts.name}, ${email}, ${opts.username ?? null}, true, NOW(), NOW())
+  `;
+	return { id, email };
+}
+
+async function readUsername(userId: string): Promise<string | null> {
+	const sql = getTestDb();
+	const rows =
+		await sql`SELECT username FROM "user" WHERE id = ${userId} LIMIT 1`;
+	return (rows[0]?.username as string | null) ?? null;
+}
+
+describe("ensurePersonalOrganization username backfill", () => {
+	beforeEach(async () => {
+		await cleanupTestDatabase();
+	});
+
+	it("sets username to the personal org slug when unset, and creates an owner membership", async () => {
+		const { id, email } = await seedUser({
+			name: "Backfill Me",
+			username: null,
+		});
+
+		const res = await ensurePersonalOrganization({
+			id,
+			email,
+			name: "Backfill Me",
+			username: null,
+		});
+		expect(res.created).toBe(true);
+		expect(res.slug).toBe("backfill-me");
+
+		expect(await readUsername(id)).toBe(res.slug);
+
+		const sql = getTestDb();
+		const members = await sql`
+      SELECT role FROM "member" WHERE "userId" = ${id} AND "organizationId" = ${res.organizationId}
+    `;
+		expect(members).toHaveLength(1);
+		expect(String(members[0].role)).toBe("owner");
+	});
+
+	it("does not overwrite an existing username (idempotent)", async () => {
+		const { id, email } = await seedUser({
+			name: "Has Handle",
+			username: "custom-handle",
+		});
+
+		await ensurePersonalOrganization({
+			id,
+			email,
+			name: "Has Handle",
+			username: "custom-handle",
+		});
+
+		expect(await readUsername(id)).toBe("custom-handle");
+	});
+
+	it("leaves username null when the slug is already taken by another user", async () => {
+		// User A squats the username 'clash' (no org).
+		await seedUser({ name: "A", username: "clash" });
+		// User B's personal org slug derives to 'clash'.
+		const { id, email } = await seedUser({ name: "Clash", username: null });
+
+		const res = await ensurePersonalOrganization({
+			id,
+			email,
+			name: "Clash",
+			username: null,
+		});
+		expect(res.slug).toBe("clash");
+
+		// The NOT EXISTS guard prevents stealing A's username; B stays null.
+		expect(await readUsername(id)).toBeNull();
+	});
+});

--- a/packages/server/src/auth/personal-org-provisioning.ts
+++ b/packages/server/src/auth/personal-org-provisioning.ts
@@ -7,16 +7,16 @@
  * to receive auto-installed agents or per-user mirrored schemas.
  */
 
-import { getDb } from '../db/client';
-import { RESERVED_PATHS_SET } from '../utils/reserved';
-import { generateSecureToken } from './oauth/utils';
-import { provisionMemberAndCoreIdentities } from './subject-identities';
+import { getDb } from "../db/client";
+import { RESERVED_PATHS_SET } from "../utils/reserved";
+import { generateSecureToken } from "./oauth/utils";
+import { provisionMemberAndCoreIdentities } from "./subject-identities";
 
 interface UserLike {
-  id: string;
-  email?: string | null;
-  name?: string | null;
-  username?: string | null;
+	id: string;
+	email?: string | null;
+	name?: string | null;
+	username?: string | null;
 }
 
 // Reserved owner-slug names. Re-exports the canonical set from utils/reserved
@@ -36,58 +36,60 @@ const PERSONAL_ORG_LOCK_NAMESPACE = 0x706f7267; // "porg"
 type Sql = ReturnType<typeof getDb>;
 
 export function slugify(input: string): string {
-  return input
-    .toLowerCase()
-    .normalize('NFKD')
-    .replace(/[\u0300-\u036f]/g, '')
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-+|-+$/g, '')
-    .slice(0, MAX_SLUG_LENGTH);
+	return input
+		.toLowerCase()
+		.normalize("NFKD")
+		.replace(/[\u0300-\u036f]/g, "")
+		.replace(/[^a-z0-9]+/g, "-")
+		.replace(/^-+|-+$/g, "")
+		.slice(0, MAX_SLUG_LENGTH);
 }
 
 export function deriveSlugCandidate(user: UserLike): string {
-  const candidates = [user.username, user.name, user.email?.split('@')[0]];
-  for (const raw of candidates) {
-    if (!raw) continue;
-    const s = slugify(raw);
-    if (s) return s;
-  }
-  return `user-${user.id.slice(0, 8).toLowerCase()}`;
+	const candidates = [user.username, user.name, user.email?.split("@")[0]];
+	for (const raw of candidates) {
+		if (!raw) continue;
+		const s = slugify(raw);
+		if (s) return s;
+	}
+	return `user-${user.id.slice(0, 8).toLowerCase()}`;
 }
 
 async function findAvailableSlug(base: string, sql: Sql): Promise<string> {
-  const safeBase = RESERVED_SLUGS.has(base) ? `${base}-1` : base;
-  let candidate = safeBase;
-  for (let attempt = 0; attempt < MAX_COLLISION_ATTEMPTS; attempt++) {
-    if (!RESERVED_SLUGS.has(candidate)) {
-      const rows = await sql`
+	const safeBase = RESERVED_SLUGS.has(base) ? `${base}-1` : base;
+	let candidate = safeBase;
+	for (let attempt = 0; attempt < MAX_COLLISION_ATTEMPTS; attempt++) {
+		if (!RESERVED_SLUGS.has(candidate)) {
+			const rows = await sql`
         SELECT 1 FROM "organization" WHERE slug = ${candidate} LIMIT 1
       `;
-      if (rows.length === 0) return candidate;
-    }
-    candidate = `${safeBase}-${attempt + 2}`;
-  }
-  // Last-resort suffix — astronomically unlikely to reach this branch.
-  return `${safeBase}-${generateSecureToken(4).toLowerCase().replace(/[^a-z0-9]/g, '')}`;
+			if (rows.length === 0) return candidate;
+		}
+		candidate = `${safeBase}-${attempt + 2}`;
+	}
+	// Last-resort suffix — astronomically unlikely to reach this branch.
+	return `${safeBase}-${generateSecureToken(4)
+		.toLowerCase()
+		.replace(/[^a-z0-9]/g, "")}`;
 }
 
 interface EnsureResult {
-  organizationId: string;
-  slug: string;
-  created: boolean;
+	organizationId: string;
+	slug: string;
+	created: boolean;
 }
 
 export function personalOrgLockKey(userId: string): number {
-  let hash = 0x811c9dc5;
-  for (let i = 0; i < userId.length; i++) {
-    hash ^= userId.charCodeAt(i);
-    hash = Math.imul(hash, 0x01000193);
-  }
-  return hash | 0;
+	let hash = 0x811c9dc5;
+	for (let i = 0; i < userId.length; i++) {
+		hash ^= userId.charCodeAt(i);
+		hash = Math.imul(hash, 0x01000193);
+	}
+	return hash | 0;
 }
 
 async function lockPersonalOrgForUser(userId: string, sql: Sql): Promise<void> {
-  await sql`
+	await sql`
     SELECT pg_advisory_xact_lock(
       ${PERSONAL_ORG_LOCK_NAMESPACE},
       ${personalOrgLockKey(userId)}
@@ -96,84 +98,122 @@ async function lockPersonalOrgForUser(userId: string, sql: Sql): Promise<void> {
 }
 
 export async function findExistingPersonalOrg(
-  userId: string,
-  sql: Sql
+	userId: string,
+	sql: Sql,
 ): Promise<{ id: string; slug: string } | null> {
-  // Idempotency: an org tagged with this user.id in metadata is already this
-  // user's personal one. Re-running the hook (e.g. after a transient failure)
-  // is a no-op. The ORDER BY keeps resolution deterministic if legacy data ever
-  // contains duplicates.
-  // organization.metadata is `text` storing JSON; cast to jsonb and use ->>
-  // instead of LIKE so a userId containing % or _ can't match unintended rows.
-  const existing = await sql`
+	// Idempotency: an org tagged with this user.id in metadata is already this
+	// user's personal one. Re-running the hook (e.g. after a transient failure)
+	// is a no-op. The ORDER BY keeps resolution deterministic if legacy data ever
+	// contains duplicates.
+	// organization.metadata is `text` storing JSON; cast to jsonb and use ->>
+	// instead of LIKE so a userId containing % or _ can't match unintended rows.
+	const existing = await sql`
     SELECT id, slug FROM "organization"
     WHERE metadata IS NOT NULL
       AND (metadata::jsonb)->>'personal_org_for_user_id' = ${userId}
     ORDER BY "createdAt" ASC, id ASC
     LIMIT 1
   `;
-  if (existing.length === 0) return null;
-  return existing[0] as { id: string; slug: string };
+	if (existing.length === 0) return null;
+	return existing[0] as { id: string; slug: string };
 }
 
-export async function ensurePersonalOrganization(user: UserLike): Promise<EnsureResult> {
-  const sql = getDb();
-  let result: EnsureResult | null = null;
+export async function ensurePersonalOrganization(
+	user: UserLike,
+): Promise<EnsureResult> {
+	const sql = getDb();
+	let result: EnsureResult | null = null;
 
-  await sql.begin(async (tx) => {
-    await lockPersonalOrgForUser(user.id, tx);
+	await sql.begin(async (tx) => {
+		await lockPersonalOrgForUser(user.id, tx);
 
-    const existing = await findExistingPersonalOrg(user.id, tx);
-    if (existing) {
-      result = { organizationId: existing.id, slug: existing.slug, created: false };
-      return;
-    }
+		const existing = await findExistingPersonalOrg(user.id, tx);
+		if (existing) {
+			result = {
+				organizationId: existing.id,
+				slug: existing.slug,
+				created: false,
+			};
+			return;
+		}
 
-    const baseSlug = deriveSlugCandidate(user);
-    const slug = await findAvailableSlug(baseSlug, tx);
-    const orgId = `org_${generateSecureToken(8)}`;
-    const memberId = `member_${generateSecureToken(8)}`;
-    const orgName = user.name?.trim() || user.email?.split('@')[0] || slug;
-    const metadata = JSON.stringify({ personal_org_for_user_id: user.id });
+		const baseSlug = deriveSlugCandidate(user);
+		const slug = await findAvailableSlug(baseSlug, tx);
+		const orgId = `org_${generateSecureToken(8)}`;
+		const memberId = `member_${generateSecureToken(8)}`;
+		const orgName = user.name?.trim() || user.email?.split("@")[0] || slug;
+		const metadata = JSON.stringify({ personal_org_for_user_id: user.id });
 
-    await tx`
+		await tx`
       INSERT INTO "organization" (id, name, slug, visibility, metadata, "createdAt")
       VALUES (${orgId}, ${orgName}, ${slug}, 'private', ${metadata}, NOW())
     `;
-    await tx`
+		await tx`
       INSERT INTO "member" (id, "userId", "organizationId", role, "createdAt")
       VALUES (${memberId}, ${user.id}, ${orgId}, 'owner', NOW())
     `;
 
-    result = { organizationId: orgId, slug, created: true };
-  });
+		result = { organizationId: orgId, slug, created: true };
+	});
 
-  const finalResult = result as EnsureResult | null;
-  if (!finalResult) {
-    throw new Error('Personal organization transaction did not produce a result');
-  }
+	const finalResult = result as EnsureResult | null;
+	if (!finalResult) {
+		throw new Error(
+			"Personal organization transaction did not produce a result",
+		);
+	}
 
-  // Provision the $member entity + core identifiers (auth_user_id, email)
-  // outside the transaction. ensureMemberEntity uses createEntity which
-  // manages its own transaction and seeds the $member entity type if absent.
-  // Failures here shouldn't roll back the org creation — the user has a
-  // valid org, identity rows can be backfilled later. Run this for both newly
-  // created and pre-existing personal orgs; the helper is idempotent.
-  if (user.email) {
-    try {
-      await provisionMemberAndCoreIdentities(finalResult.organizationId, {
-        userId: user.id,
-        email: user.email,
-        name: user.name,
-      });
-    } catch (error) {
-      console.error('[Auth] Failed to provision $member entity for personal org:', {
-        orgId: finalResult.organizationId,
-        userId: user.id,
-        error: String(error),
-      });
-    }
-  }
+	// Mirror the personal org slug onto the user's username when unset. The
+	// frontend resolves a user's home org from session.user.username
+	// (personalOrgSlug); having it set means the home route can route to the
+	// personal org synchronously instead of waiting on the `/api/organizations`
+	// fetch. Non-fatal and idempotent (only fills a null username); the NOT
+	// EXISTS guard avoids colliding with another user's username. Runs for both
+	// newly created and pre-existing personal orgs so legacy users self-heal on
+	// their next login.
+	try {
+		await sql`
+      UPDATE "user"
+      SET username = ${finalResult.slug}
+      WHERE id = ${user.id}
+        AND username IS NULL
+        AND NOT EXISTS (
+          SELECT 1 FROM "user" u2
+          WHERE u2.username = ${finalResult.slug} AND u2.id <> ${user.id}
+        )
+    `;
+	} catch (error) {
+		console.error("[Auth] Failed to set username for personal org:", {
+			userId: user.id,
+			slug: finalResult.slug,
+			error: String(error),
+		});
+	}
 
-  return finalResult;
+	// Provision the $member entity + core identifiers (auth_user_id, email)
+	// outside the transaction. ensureMemberEntity uses createEntity which
+	// manages its own transaction and seeds the $member entity type if absent.
+	// Failures here shouldn't roll back the org creation — the user has a
+	// valid org, identity rows can be backfilled later. Run this for both newly
+	// created and pre-existing personal orgs; the helper is idempotent.
+	if (user.email) {
+		try {
+			await provisionMemberAndCoreIdentities(finalResult.organizationId, {
+				userId: user.id,
+				email: user.email,
+				name: user.name,
+			});
+		} catch (error) {
+			console.error(
+				"[Auth] Failed to provision $member entity for personal org:",
+				{
+					orgId: finalResult.organizationId,
+					userId: user.id,
+					error: String(error),
+				},
+			);
+		}
+	}
+
+	return finalResult;
 }


### PR DESCRIPTION
## Problem
New users couldn't reach their workspace after login — they landed on `/account/settings` and the sidebar showed "Pick an organization to continue." despite having a valid personal org.

## Root cause (two layers)
1. **Frontend race** (fixed in owletto#251): the home route redirected to Settings before `/api/organizations` settled, and `replace:true` unmounted the route so it never recovered.
2. **Backend gap** (this PR): the frontend resolves a user's home org synchronously from `session.user.username` (`personalOrgSlug`). That field was **never set at signup**, so `currentOwner` depended entirely on the org fetch — exposing the race for every new user. Only ~6 legacy users (with a username from an older path) were immune.

## Fix
`ensurePersonalOrganization` now mirrors the personal-org slug onto `user.username` when it's null:
- **Set-when-null** (idempotent) — won't overwrite a chosen handle.
- **`NOT EXISTS` guard** — can't steal another user's username.
- **Non-fatal** — a failure logs and doesn't roll back org creation.
- Runs for both freshly created and pre-existing personal orgs, so **legacy users self-heal on next login**.

Submodule pointer bumped to the owletto fix.

## Tests
- `src/__tests__/integration/auth/personal-org-username.test.ts` (DB-backed): set-when-null + owner membership, idempotent (no overwrite), collision guard leaves username null. 3/3 green.
- Server `tsc --noEmit` clean.

## E2E / reproducer
The user-facing bug is the routing race; its red→green reproducer lives in owletto#251 (`src/app/index.test.tsx`). Prod data for the ~12 accounts created during the broken window was backfilled out-of-band (personal orgs + usernames).

Related: lobu-ai/owletto#251

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1160"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782666387&installation_id=136316292&pr_number=1160&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1160&signature=2e99a7e4a557678b3ee11f8970dfc175caf79cdb9a3da003d2265d2755806f8d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Users without a username are now automatically assigned one derived from their personal organization, improving account completeness.
  * Automatic username assignment avoids overwriting existing usernames (idempotent) and prevents collisions with other users’ identifiers.
  * Ensures created personal organizations properly establish ownership so users gain expected access immediately.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lobu-ai/lobu/pull/1160?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->