### PR TITLE
fix(auth): expose username in session for synchronous home routing

### DIFF
--- a/packages/server/src/auth/index.tsx
+++ b/packages/server/src/auth/index.tsx
@@ -3,7 +3,6 @@ import { passkey } from "@better-auth/passkey";
 import { APIError, betterAuth } from "better-auth";
 import { magicLink, organization, phoneNumber } from "better-auth/plugins";
 import { bearer } from "better-auth/plugins/bearer";
-import type { Env } from "../index";
 import { getAuthDialect, getDb } from "../db/client";
 import { sendTransactionalEmail } from "../email/send";
 import {
@@ -20,7 +19,10 @@ import {
 	passwordResetSubject,
 } from "../email/templates/password-reset";
 import { WelcomeEmail, welcomeSubject } from "../email/templates/welcome";
+import { connectorCapabilityRegistry } from "../identity/capability-registry";
+import type { Env } from "../index";
 import { notifyInvitationReceived } from "../notifications/triggers";
+import { recordLifecycleEvent } from "../utils/insert-event";
 import {
 	deleteMemberEntity,
 	ensureMemberEntity,
@@ -31,10 +33,8 @@ import {
 	getConfiguredPublicOrigin,
 	normalizeHost,
 } from "../utils/public-origin";
-import { recordLifecycleEvent } from "../utils/insert-event";
 import { TtlCache } from "../utils/ttl-cache";
 import { resolveBaseUrl, safeParseUrl } from "./base-url";
-import { findExistingPersonalOrg } from "./personal-org-provisioning";
 import {
 	getAuthConfig as getAuthConfigFromEnv,
 	getEnabledLoginProviderConfigs,
@@ -42,7 +42,7 @@ import {
 	resolveLoginProviderCredentials,
 	resolveRequestOrganizationId,
 } from "./config";
-import { connectorCapabilityRegistry } from "../identity/capability-registry";
+import { findExistingPersonalOrg } from "./personal-org-provisioning";
 // Side-effect imports: each connector self-registers on load, so the
 // registry is fully populated before any auth hook can fire. Add a new
 // import here when adding a connector under `../identity/connectors/`.
@@ -53,6 +53,7 @@ if (connectorCapabilityRegistry.size() === 0) {
 		"identity connector registry is empty — check side-effect imports in auth/index.tsx",
 	);
 }
+
 import {
 	scheduleIdentityIngest,
 	scheduleIdentityTombstoneOnAccountDelete,
@@ -189,7 +190,11 @@ export async function createAuth(env: Env, request?: Request) {
 
 	const auth = betterAuth({
 		...(env.BETTER_AUTH_SECRET ? { secret: env.BETTER_AUTH_SECRET } : {}),
-		database: { dialect: getAuthDialect(), type: "postgres", transaction: true },
+		database: {
+			dialect: getAuthDialect(),
+			type: "postgres",
+			transaction: true,
+		},
 		baseURL: resolveBaseUrl({ request }),
 		basePath: "/api/auth",
 
@@ -241,6 +246,19 @@ export async function createAuth(env: Env, request?: Request) {
 					returned: false,
 					required: false,
 				},
+				// Surface `username` in the session payload. The SPA derives a
+				// user's home org from session.user.username (personalOrgSlug) to
+				// route them straight to /$owner — without this it's absent from
+				// the session, so routing falls back to the (slow) /api/organizations
+				// fetch on every cold load. `input: false`: it's set server-side by
+				// the personal-org provisioner, never by client signup input.
+				username: {
+					type: "string",
+					fieldName: "username",
+					input: false,
+					returned: true,
+					required: false,
+				},
 			},
 		},
 
@@ -282,17 +300,11 @@ export async function createAuth(env: Env, request?: Request) {
 					// their first org via the UI, ends up with NULL `workerOrgIds`
 					// in the device-worker auth middleware (index.ts:602-607), so
 					// their Lobu bridge gets a 403 on every poll.
-					afterCreateOrganization: async ({
-						organization: org,
-						user,
-					}) => {
+					afterCreateOrganization: async ({ organization: org, user }) => {
 						try {
 							if (org.visibility !== "private") return;
 							const sql = getDb();
-							const existing = await findExistingPersonalOrg(
-								user.id,
-								sql,
-							);
+							const existing = await findExistingPersonalOrg(user.id, sql);
 							if (existing) return;
 							await sql`
 								UPDATE "organization"
@@ -324,14 +336,14 @@ export async function createAuth(env: Env, request?: Request) {
 								"../workspace/multi-tenant"
 							);
 							invalidateMembershipRoleCache(org.id, user.id);
-								recordLifecycleEvent({
-									organizationId: org.id,
-									entityType: "member",
-									op: "created",
-									entityId: member.id,
-									summary: `Member "${user.name || user.email}" added`,
-									extra: { user_id: user.id, role: member.role },
-								});
+							recordLifecycleEvent({
+								organizationId: org.id,
+								entityType: "member",
+								op: "created",
+								entityId: member.id,
+								summary: `Member "${user.name || user.email}" added`,
+								extra: { user_id: user.id, role: member.role },
+							});
 						} catch (err) {
 							console.error(
 								"[Auth] Failed to create $member entity after addMember:",
@@ -370,13 +382,13 @@ export async function createAuth(env: Env, request?: Request) {
 					afterRemoveMember: async ({ user, organization: org }) => {
 						try {
 							await deleteMemberEntity(org.id, user.email);
-								recordLifecycleEvent({
-									organizationId: org.id,
-									entityType: "member",
-									op: "deleted",
-									entityId: user.id,
-									summary: `Member "${user.name || user.email}" removed`,
-								});
+							recordLifecycleEvent({
+								organizationId: org.id,
+								entityType: "member",
+								op: "deleted",
+								entityId: user.id,
+								summary: `Member "${user.name || user.email}" removed`,
+							});
 							const { invalidateMembershipRoleCache } = await import(
 								"../workspace/multi-tenant"
 							);
@@ -538,8 +550,10 @@ export async function createAuth(env: Env, request?: Request) {
 					// doesn't grant third-party access thinking they're just signing in.
 					let isAuthorizeRequest = false;
 					try {
-						const callbackUrl = new URL(url).searchParams.get("callbackURL") ?? "";
-						isAuthorizeRequest = decodeURIComponent(callbackUrl).includes("/oauth/device");
+						const callbackUrl =
+							new URL(url).searchParams.get("callbackURL") ?? "";
+						isAuthorizeRequest =
+							decodeURIComponent(callbackUrl).includes("/oauth/device");
 					} catch {
 						isAuthorizeRequest = false;
 					}
@@ -547,7 +561,9 @@ export async function createAuth(env: Env, request?: Request) {
 						env,
 						to: email,
 						category: "auth",
-						subject: isAuthorizeRequest ? authorizeAppSubject : magicLinkSubject,
+						subject: isAuthorizeRequest
+							? authorizeAppSubject
+							: magicLinkSubject,
 						react: (
 							<MagicLinkEmail
 								url={url}
@@ -727,7 +743,10 @@ export async function createAuth(env: Env, request?: Request) {
 								),
 							});
 						} catch (error) {
-							console.error("[Auth] Failed to send signup welcome email:", error);
+							console.error(
+								"[Auth] Failed to send signup welcome email:",
+								error,
+							);
 						}
 					},
 				},


### PR DESCRIPTION
## Why
Follow-up to #1160 / owletto#251. A **prod e2e** (fresh signup on app.lobu.ai) revealed the org-routing fix worked but was slow and fragile:

- The session payload did **not** include `username`. Session user fields were `name, email, emailVerified, image, createdAt, updatedAt, phoneNumber, phoneNumberVerified, id` — no `username`. So `personalOrgSlug` (= `session.user.username`) was always null and the synchronous routing path never fired.
- Routing therefore depended entirely on `/api/organizations`, which on prod took **7–18s** (first request timed out at ~10s, retry 7.6s). Result: a long "Loading…" and, when the fetch timed out, a wrong bounce to `/account/settings`.

So the backend `username` write from #1160 was correct but invisible to the SPA.

## Fix
Declare `username` in `user.additionalFields` with `returned: true` (and `input: false` — it's set server-side by the personal-org provisioner, never by signup input). The session now carries `username`, so `personalOrgSlug` resolves synchronously and routing no longer waits on the org-list query.

Applies to existing users too: `get-session` re-reads the user, so the already-backfilled usernames surface on next load.

## Evidence (prod e2e)
Fresh signup `lobu-e2e-…@example.com`:
- DB: `username=lobu-e2e-test`, personal org `org_-DMeSCi9lXs` (owner) ✅
- Session before fix: `username` absent ❌ → routing fell to the slow `/api/organizations` (10s timeout + 7.6s retry) → eventually landed on `/lobu-e2e-test/connectors` after ~15s, and bounced to `/account/settings` on the first (timed-out) attempt.

## Verification plan
Re-run the prod signup e2e after deploy: expect immediate landing on `/$owner/connectors` with no org-fetch dependency.

## Known follow-up (separate)
`/api/organizations` is pathologically slow on prod (~7–10s, first attempt times out). Worth a perf pass (likely per-request `createAuth` + `getSession` + `listOrganizations` overhead). Not required for this routing fix once `username` is in the session.

Related: #1160, lobu-ai/owletto#251

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1162"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782730704&installation_id=136316292&pr_number=1162&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1162&signature=1f529a81cb24235fd38dc4414c0cf1b8c5c887805fd7a01b2f5efde8aa5d239c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added username field to user session information, enabling personalization through automatic organization slug derivation.

* **Improvements**
  * Reorganized authentication module structure and refactored organization lifecycle hooks. Enhanced magic-link email handling and error logging for improved code clarity and consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lobu-ai/lobu/pull/1162?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->