### PR TITLE
perf(auth): don't block signup on the welcome email

### DIFF
--- a/packages/server/src/auth/index.tsx
+++ b/packages/server/src/auth/index.tsx
@@ -720,34 +720,41 @@ export async function createAuth(env: Env, request?: Request) {
 							console.error("[Auth] Failed to provision personal org:", error);
 						}
 
-						try {
-							if (!env.RESEND_API_KEY && runtimeNodeEnv !== "production") {
-								console.info(
-									{ email: user.email },
-									"[Auth] Development signup welcome email skipped (RESEND_API_KEY not configured)",
-								);
-								return;
-							}
-							await sendTransactionalEmail({
-								env,
-								to: user.email,
-								category: "auth",
-								subject: welcomeSubject,
-								react: (
-									<WelcomeEmail
-										name={user.name}
-										appUrl={resolveBaseUrl({
-											request: context?.request ?? undefined,
-										})}
-									/>
-								),
-							});
-						} catch (error) {
+						if (!env.RESEND_API_KEY && runtimeNodeEnv !== "production") {
+							console.info(
+								{ email: user.email },
+								"[Auth] Development signup welcome email skipped (RESEND_API_KEY not configured)",
+							);
+							return;
+						}
+						// Fire-and-forget: the welcome email hits an external API
+						// (Resend). Better Auth awaits user.create.after before
+						// completing signup, so awaiting the send blocks the signup
+						// response on an external HTTP call. On a busy single node that
+						// blocked request contends with the SPA's immediate
+						// /api/organizations fetch — observed pushing it to multi-second
+						// latency right after signup. The email is non-critical; send it
+						// in the background. (appUrl is resolved synchronously here, before
+						// the request context is torn down.)
+						void sendTransactionalEmail({
+							env,
+							to: user.email,
+							category: "auth",
+							subject: welcomeSubject,
+							react: (
+								<WelcomeEmail
+									name={user.name}
+									appUrl={resolveBaseUrl({
+										request: context?.request ?? undefined,
+									})}
+								/>
+							),
+						}).catch((error) => {
 							console.error(
 								"[Auth] Failed to send signup welcome email:",
 								error,
 							);
-						}
+						});
 					},
 				},
 			},


### PR DESCRIPTION
## Context
Follow-up from digging into "/api/organizations is slow on prod." It isn't — the endpoint is healthy; the slowness was transient signup-burst contention.

## Measurements (live prod)
| What | Latency |
|---|---|
| `listOrganizations` SQL (EXPLAIN ANALYZE) | 0.49ms |
| `createAuth` cold / warm | 30ms / 0ms |
| `getSession` cold / warm | 20ms / 1ms |
| in-pod HTTP `/api/organizations` | ~4ms |
| over-network, authenticated, idle | ~0.2–0.66s |

So `/api/organizations` is ~0.5s (network/ingress dominated), not 7s. The browser saw 7–18s **only right after signup**.

## Root cause
Better Auth awaits `databaseHooks.user.create.after` before completing signup. That hook **`await`ed `sendTransactionalEmail`** — an external Resend HTTP call. On the hot single-node prod, the blocked signup request contends with the SPA's immediate `/api/organizations` fetch (single node, shared DB pool), pushing it to multi-second latency and tripping the client's ~10s abort.

## Fix
Send the welcome email **fire-and-forget** (`void … .catch(log)`) so it's off the signup critical path. It's non-critical; errors are still logged. `appUrl` is resolved synchronously before the request context is torn down.

## Scope note
Left `ensurePersonalOrganization` (must be sync — the org must exist before routing) and `ensureDefaultAgent` (best-effort, has a boot backstop) awaited. The routing UX impact was already resolved by exposing `username` in the session (#1162); this just stops signup from blocking on non-critical work.

Related: #1162

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1163"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782731919&installation_id=136316292&pr_number=1163&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1163&signature=24a1b6d44bb39d487373c4a2d4baacb2d56354a1eb026b81279b26998602ae4f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->