### PR TITLE
feat(landing): add /schedule page + revamp 404

### DIFF
--- a/packages/landing/src/components/ScheduleDialog.tsx
+++ b/packages/landing/src/components/ScheduleDialog.tsx
@@ -1,7 +1,7 @@
 import type { ComponentChildren } from "preact";
 import { useRef, useState } from "preact/hooks";
 
-const CAL_URL =
+export const CAL_URL =
   "https://cal.com/buremba/lobu-discovery?duration=15&overlayCalendar=true&embed=true&layout=month_view";
 
 export function ScheduleCallIcon() {

--- a/packages/landing/src/pages/404.astro
+++ b/packages/landing/src/pages/404.astro
@@ -1,39 +1,73 @@
 ---
 import BaseLayout from "../layouts/BaseLayout.astro";
+import "../globals.css";
+import { Footer } from "../components/Footer";
+import { Nav } from "../components/Nav";
 ---
 
 <BaseLayout title="404 - Lobu" description="Page not found.">
-  <main
-    style="min-height: 100vh; display: grid; place-items: center; background: #09090b; color: #f4f4f5; padding: 2rem;"
+  <div
+    class="min-h-screen flex flex-col"
+    style={{ backgroundColor: "var(--color-page-bg)" }}
   >
-    <div style="max-width: 32rem; text-align: center;">
-      <p
-        style="margin: 0 0 0.75rem; font-size: 0.75rem; letter-spacing: 0.18em; text-transform: uppercase; color: #a1a1aa;"
-      >
-        404
-      </p>
-      <h1 style="margin: 0 0 1rem; font-size: 2.5rem; line-height: 1.1;">
-        Page not found
-      </h1>
-      <p style="margin: 0 0 1.5rem; color: #d4d4d8; line-height: 1.7;">
-        Check the URL or jump back to the main site or docs.
-      </p>
-      <div
-        style="display: flex; gap: 0.75rem; justify-content: center; flex-wrap: wrap;"
-      >
-        <a
-          href="/"
-          style="display: inline-flex; align-items: center; justify-content: center; padding: 0.75rem 1rem; border-radius: 0.75rem; background: #f4f4f5; color: #09090b; font-weight: 600; text-decoration: none;"
+    <Nav client:load currentPath={Astro.url.pathname} />
+    <main
+      class="relative z-[1] flex flex-1 items-center justify-center px-6 py-24"
+    >
+      <div class="max-w-[34rem] text-center">
+        <p
+          class="text-xs uppercase tracking-[0.18em] mb-3"
+          style={{ color: "var(--color-page-text-muted)" }}
         >
-          Go home
-        </a>
-        <a
-          href="/getting-started/"
-          style="display: inline-flex; align-items: center; justify-content: center; padding: 0.75rem 1rem; border-radius: 0.75rem; border: 1px solid #27272a; color: #f4f4f5; font-weight: 600; text-decoration: none;"
+          404
+        </p>
+        <h1
+          class="text-4xl font-bold mb-4"
+          style={{ color: "var(--color-page-text)" }}
         >
-          Open docs
-        </a>
+          Page not found
+        </h1>
+        <p
+          class="text-base mb-8 leading-relaxed"
+          style={{ color: "var(--color-page-text-muted)" }}
+        >
+          The page you're looking for moved or never existed. Head back to the
+          main site or the docs, or grab time with us.
+        </p>
+        <div class="flex gap-3 justify-center flex-wrap">
+          <a
+            href="/"
+            class="inline-flex items-center justify-center px-4 py-3 rounded-lg font-semibold no-underline"
+            style={{
+              backgroundColor: "var(--color-page-text)",
+              color: "var(--color-page-bg)",
+            }}
+          >
+            Go home
+          </a>
+          <a
+            href="/getting-started/"
+            class="inline-flex items-center justify-center px-4 py-3 rounded-lg font-semibold no-underline"
+            style={{
+              border: "1px solid var(--color-page-border)",
+              color: "var(--color-page-text)",
+            }}
+          >
+            Open docs
+          </a>
+          <a
+            href="/schedule/"
+            class="inline-flex items-center justify-center px-4 py-3 rounded-lg font-semibold no-underline"
+            style={{
+              border: "1px solid var(--color-page-border)",
+              color: "var(--color-page-text)",
+            }}
+          >
+            Schedule a call
+          </a>
+        </div>
       </div>
-    </div>
-  </main>
+    </main>
+    <Footer />
+  </div>
 </BaseLayout>

--- a/packages/landing/src/pages/schedule.astro
+++ b/packages/landing/src/pages/schedule.astro
@@ -1,0 +1,67 @@
+---
+import BaseLayout from "../layouts/BaseLayout.astro";
+import "../globals.css";
+import { Footer } from "../components/Footer";
+import { Nav } from "../components/Nav";
+import { CAL_URL } from "../components/ScheduleDialog";
+---
+
+<BaseLayout
+  title="Schedule a call - Lobu"
+  description="Book a 15-minute call with the Lobu founder to talk through your use case, see the workspace, and get early access to apps we haven't published yet."
+>
+  <div class="min-h-screen" style={{ backgroundColor: "var(--color-page-bg)" }}>
+    <Nav client:load currentPath={Astro.url.pathname} />
+    <main class="relative z-[1] max-w-[60rem] mx-auto px-6 py-16">
+      <div class="text-center mb-10">
+        <p
+          class="text-xs uppercase tracking-[0.18em] mb-3"
+          style={{ color: "var(--color-page-text-muted)" }}
+        >
+          Talk to us
+        </p>
+        <h1
+          class="text-4xl font-bold mb-4"
+          style={{ color: "var(--color-page-text)" }}
+        >
+          Schedule a call
+        </h1>
+        <p
+          class="text-base max-w-[40rem] mx-auto leading-relaxed"
+          style={{ color: "var(--color-page-text-muted)" }}
+        >
+          Book 15 minutes with the founder to talk through your use case, see the
+          workspace, and get early access to the apps we haven't published yet.
+        </p>
+      </div>
+
+      <div
+        class="overflow-hidden rounded-2xl"
+        style={{
+          border: "1px solid var(--color-page-border)",
+          backgroundColor: "var(--color-page-surface)",
+        }}
+      >
+        <iframe
+          src={CAL_URL}
+          title="Schedule a call with the Lobu founder"
+          loading="lazy"
+          style="width: 100%; height: 80vh; min-height: 640px; border: 0; display: block;"
+        ></iframe>
+      </div>
+
+      <p
+        class="text-sm text-center mt-6"
+        style={{ color: "var(--color-page-text-muted)" }}
+      >
+        Prefer email? Reach us at{" "}
+        <a
+          href="mailto:hello@lobu.ai"
+          class="underline"
+          style={{ color: "var(--color-page-text)" }}>hello@lobu.ai</a
+        >.
+      </p>
+    </main>
+    <Footer />
+  </div>
+</BaseLayout>


### PR DESCRIPTION
## What

- **New `/schedule` page** — embeds the founder's cal.com discovery call (reuses `CAL_URL` from `ScheduleDialog`) inside the site's `Nav` + `Footer` + page color tokens. This is the destination the Owletto macOS device card now links to (instead of an unpublished `.dmg`).
- **Revamped 404** — was a bare inline-styled block with no nav/footer. Now uses `BaseLayout` + `Nav` + `Footer` + the page color tokens, with Go home / Open docs / Schedule a call actions.
- Export `CAL_URL` from `ScheduleDialog` so the page can reuse the single source of truth.

## Verification
- `bun run build` — green; `/schedule/` and `/404.html` emit, `/schedule` contains the cal.com embed.
- No em dashes in user-facing copy (landing rule).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1166"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782867687&installation_id=136316292&pr_number=1166&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1166&signature=b34beba304f66f8a95d3906a038abc41504cda455987e756d391e3f7dd6aec9c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dedicated "Schedule a call" page with integrated scheduling interface and contact information.

* **Improvements**
  * Enhanced the 404 error page with improved design and styling; added "Schedule a call" button for quick navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->