### PR TITLE
feat(memory): guide the agent to supersede stored facts on update

### DIFF
--- a/packages/core/src/lobu-guidance.ts
+++ b/packages/core/src/lobu-guidance.ts
@@ -12,6 +12,7 @@ const MEMORY_RULE_TEMPLATES = [
   "To search, call {{searchTool}}. Results include view_url links to the web interface.",
   "NEVER construct Lobu URLs yourself. When the user asks for a link, call {{searchTool}} to get the correct view_url.",
   'When the user says "remember this", save it to Lobu immediately.',
+  "When a message changes a fact you already stored (an updated preference, status, count, location, or plan), first {{searchTool}} for the prior memory to get its id, then {{saveTool}} the new value with supersedes_event_id set to that id. This replaces the stale value so future recalls return the current one; the old value stays in history but is hidden from normal search.",
 ];
 
 function renderTemplate(template: string, tools: MemoryGuidanceTools): string {

--- a/skills/lobu/SKILL.md
+++ b/skills/lobu/SKILL.md
@@ -53,6 +53,7 @@ Your long-term memory is powered by Lobu. Do NOT use local files (memory/, MEMOR
 - To search, call search_memory. Results include view_url links to the web interface.
 - NEVER construct Lobu URLs yourself. When the user asks for a link, call search_memory to get the correct view_url.
 - When the user says "remember this", save it to Lobu immediately.
+- When a message changes a fact you already stored (an updated preference, status, count, location, or plan), first search_memory for the prior memory to get its id, then save_memory the new value with supersedes_event_id set to that id. This replaces the stale value so future recalls return the current one; the old value stays in history but is hidden from normal search.
 <!-- lobu-memory-guidance:end -->
 
 ## Lobu Memory


### PR DESCRIPTION
## What
One rule added to the shared memory guidance: when a message changes a fact the agent already stored (an updated preference, status, count, location, or plan), it should `search_memory` for the prior memory's id, then `save_memory` the new value with `supersedes_event_id` set to it. The old value drops out of normal recall but stays in history.

Flows to both the runtime plugin prompt (`renderFallbackSystemContext`, wired at `openclaw-plugin/src/index.ts:1076`) and the bundled CLI skill (`skills/lobu/SKILL.md`, regenerated via the guidance-sync script).

## Why this is the fix
Lobu already had every primitive for SOTA knowledge-update:
- append-only `events` + `supersedes_event_id`
- the `current_event_records` view that masks superseded rows from search
- `occurred_at` (validity interval is *derivable* — `valid_at` = `occurred_at`, `invalid_at` = the superseder's `occurred_at`; no new column needed)
- a **UNIQUE partial index** `idx_events_superseded_by` that already prevents two turns from forking a parent under multi-replica

What was missing was telling the agent to use them — the runtime memory prompt never mentioned superseding, so the live agent blind-appended contradictory observations and never resolved them.

## Benchmark basis (honest)
On LongMemEval knowledge-update (in [`agent-memory-benchmark`](https://github.com/lobu-ai/agent-memory-benchmark)), the supersede mechanism masks stale values cleanly. **The measured lift is ordering-dependent:** with embedding-free recency-ordered retrieval an adapter simulating this loop scored 10/10 vs 8/10, but on the production *vector*-retrieval path the incremental lift over Lobu's existing recency answerer rule is **modest (~+1, within single-trial noise)**. Overall stays ~70% in every variant — this change does **not** by itself move the headline number or beat the strongest hosted system.

The case for shipping it anyway: the mechanism is sound and **its real-product value — clean current-value resolution over long horizons — exceeds what 2-session oracle benchmark scenarios capture**, and it's the missing piece that makes the *live* agent use primitives Lobu already has. Robust per-category benchmark claims would need multi-trial runs (single-trial bounces ±2).

## Deferred / out of scope
- `autoCapture` LLM-judge backstop for untagged corrections (heavier, separately scoped).
- single-session-preference scores 0/10 for *every* system — an eval/grading mismatch (preference questions graded against meta-descriptions), not a Lobu gap.
- **Not yet E2E'd against a live worker-agent** (search→supersede); the benchmark only *simulates* the loop. That verification is owed before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)