### PR TITLE
feat(server): server-side focused retrieval for read_knowledge (#1172) [experimental — does not yet beat baseline]

### DIFF
--- a/packages/server/src/__tests__/integration/events/focused-retrieval.test.ts
+++ b/packages/server/src/__tests__/integration/events/focused-retrieval.test.ts
@@ -4,29 +4,33 @@
  * Exercises the full build → serve loop against a real Postgres:
  *
  *   1. The async builder `triggerFactExtraction` scans long events, calls the
- *      (stubbed) extractor, and writes one `semantic_type='extracted_fact'`
- *      event per fact, stamped with `metadata.{derived_from_event_id,
+ *      extractor, and writes one `semantic_type='extracted_fact'` event per
+ *      fact, stamped with `metadata.{derived_from_event_id,
  *      fact_extractor_version}` and inheriting the parent's entity_ids +
  *      occurred_at.
  *   2. `getContent({ focused: true })` replaces the parent's text_content /
- *      payload_text with the joined facts, and never lists the derived
- *      fact rows as standalone content.
+ *      payload_text with the joined facts (current extractor version only),
+ *      and never lists the derived fact rows as standalone content.
  *   3. `getContent({ focused: false })` returns the raw payload and never
  *      leaks a derived fact row into the list or the count.
  *   4. The builder is idempotent at a fixed extractor version (NOT EXISTS
  *      guard), and re-extracts when the version stamp changes.
  *
- * The LLM is stubbed via `vi.mock` so the test is deterministic and offline.
- * `factExtractorVersion` is also stubbed (to a controllable string) so the
- * version-stamp + NOT EXISTS guard are exercised with a known value and the
- * version-bump branch can be driven.
+ * The extractor is exercised for real — the LLM is stubbed at the network
+ * boundary (`global.fetch` returns a canned chat-completion), NOT via module
+ * mocking, so the test is robust under the canonical full-suite runner
+ * (`vitest run` over the whole integration dir). The extractor version is
+ * driven through `FACT_EXTRACTOR_MODEL` (real `factExtractorVersion`), so the
+ * version-stamp + NOT EXISTS guard + version-bump branch run with real values.
  */
 
-import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import { getDb, parsePgNumberArray } from '../../../db/client';
 import type { Env } from '../../../index';
 import { getContent } from '../../../tools/get_content';
 import type { ToolContext } from '../../../tools/registry';
+import { factExtractorVersion } from '../../../utils/fact-extractor';
+import { triggerFactExtraction } from '../../../scheduled/trigger-fact-extraction';
 import { initWorkspaceProvider } from '../../../workspace';
 import { cleanupTestDatabase } from '../../setup/test-db';
 import {
@@ -38,25 +42,34 @@ import {
   seedSystemEntityTypes,
 } from '../../setup/test-fixtures';
 
-// ── Stub the extractor LLM ────────────────────────────────────────────────
-// `vi.hoisted` lets the mock factory close over mutable state the test mutates
-// (the fact list + the version stamp) so we can drive idempotency and the
-// version-bump branch without re-mocking.
-const stub = vi.hoisted(() => ({
-  facts: ['User lives in NYC.', 'User owns a dog named Rex.', 'User owns a cat named Whiskers.'],
-  version: 'fact-extract-test:v1',
-}));
+const FACTS = ['User lives in NYC.', 'User owns a dog named Rex.', 'User owns a cat named Whiskers.'];
 
-vi.mock('../../../utils/fact-extractor', () => ({
-  extractFacts: vi.fn(async () => stub.facts),
-  factExtractorVersion: vi.fn(() => stub.version),
-  factExtractorModel: vi.fn(() => 'stub-model'),
-}));
+// The extractor reads these off the passed `env`; setting them makes the REAL
+// extractFacts run (no module mock). FACT_EXTRACTOR_MODEL feeds the version
+// stamp, so mutating it drives the version-bump branch.
+const TEST_ENV = {
+  ENVIRONMENT: 'test',
+  DATABASE_URL: process.env.DATABASE_URL,
+  FACT_EXTRACTOR_API_KEY: 'test-key',
+  FACT_EXTRACTOR_BASE_URL: 'https://stub.invalid/v1',
+  FACT_EXTRACTOR_MODEL: 'stub-model-v1',
+} as Env;
 
-// Import AFTER the mock so the builder picks up the stubbed extractor.
-import { triggerFactExtraction } from '../../../scheduled/trigger-fact-extraction';
-
-const TEST_ENV = { ENVIRONMENT: 'test', DATABASE_URL: process.env.DATABASE_URL } as Env;
+// Stub the LLM at the network boundary: intercept the extractor's
+// /chat/completions call, pass everything else through to the real fetch.
+const originalFetch = global.fetch;
+function installFetchStub() {
+  global.fetch = (async (input: Parameters<typeof fetch>[0], init?: Parameters<typeof fetch>[1]) => {
+    const url = typeof input === 'string' ? input : input.toString();
+    if (url.includes('/chat/completions')) {
+      return new Response(
+        JSON.stringify({ choices: [{ message: { content: FACTS.join('\n') } }] }),
+        { status: 200, headers: { 'content-type': 'application/json' } }
+      );
+    }
+    return originalFetch(input, init);
+  }) as typeof fetch;
+}
 
 // A parent payload well over the 200-char extraction floor.
 const PARENT_BLOB =
@@ -90,6 +103,8 @@ describe('focused retrieval (#1172) — build + serve loop', () => {
     await initWorkspaceProvider();
     await cleanupTestDatabase();
     await seedSystemEntityTypes();
+    installFetchStub();
+    TEST_ENV.FACT_EXTRACTOR_MODEL = 'stub-model-v1';
 
     org = await createTestOrganization({ name: 'Focused Retrieval Org' });
     user = await createTestUser({ email: 'focused@example.com' });
@@ -111,14 +126,10 @@ describe('focused retrieval (#1172) — build + serve loop', () => {
       semantic_type: 'content',
     });
     parentEventId = parent.id;
-
-    // Reset the stub to its default state for each fresh suite run.
-    stub.facts = ['User lives in NYC.', 'User owns a dog named Rex.', 'User owns a cat named Whiskers.'];
-    stub.version = 'fact-extract-test:v1';
   });
 
   afterAll(() => {
-    vi.restoreAllMocks();
+    global.fetch = originalFetch;
   });
 
   it('builder extracts 3 facts as derived events with the right stamp + inherited fields', async () => {
@@ -147,24 +158,19 @@ describe('focused retrieval (#1172) — build + serve loop', () => {
     }>;
 
     expect(factRows).toHaveLength(3);
-    expect(factRows.map((r) => r.payload_text)).toEqual([
-      'User lives in NYC.',
-      'User owns a dog named Rex.',
-      'User owns a cat named Whiskers.',
-    ]);
+    expect(factRows.map((r) => r.payload_text)).toEqual(FACTS);
 
+    const expectedVersion = factExtractorVersion(TEST_ENV);
     for (const row of factRows) {
       expect(row.semantic_type).toBe('extracted_fact');
       expect(Number(row.metadata.derived_from_event_id)).toBe(parentEventId);
-      expect(row.metadata.fact_extractor_version).toBe('fact-extract-test:v1');
+      expect(row.metadata.fact_extractor_version).toBe(expectedVersion);
       expect(row.organization_id).toBe(org.id);
       // entity_ids inherited from the parent.
       const ids = parsePgNumberArray(row.entity_ids);
       expect(ids).toContain(entity.id);
       // occurred_at inherited from the parent.
-      expect(new Date(row.occurred_at as string).toISOString()).toBe(
-        parentOccurredAt.toISOString()
-      );
+      expect(new Date(row.occurred_at as string).toISOString()).toBe(parentOccurredAt.toISOString());
     }
   });
 
@@ -175,11 +181,7 @@ describe('focused retrieval (#1172) — build + serve loop', () => {
       ctx()
     );
 
-    const expectedFacts = [
-      'User lives in NYC.',
-      'User owns a dog named Rex.',
-      'User owns a cat named Whiskers.',
-    ].join('\n');
+    const expectedFacts = FACTS.join('\n');
 
     // The parent item carries the focused facts in BOTH fields.
     const parentItem = result.content.find((c) => c.id === parentEventId);
@@ -254,10 +256,13 @@ describe('focused retrieval (#1172) — build + serve loop', () => {
     expect(count).toBe(3);
   });
 
-  it('version bump re-extracts: new stamp produces a fresh set of fact rows', async () => {
-    // Bump the stubbed extractor version → the NOT EXISTS guard no longer
-    // matches the v1 rows, so the parent is re-extracted under v2.
-    stub.version = 'fact-extract-test:v2';
+  it('version bump re-extracts under a new stamp, and focused reads serve ONLY the current version', async () => {
+    const v1 = factExtractorVersion(TEST_ENV);
+    // Bump the model → factExtractorVersion changes → the NOT EXISTS guard no
+    // longer matches the v1 rows, so the parent is re-extracted under v2.
+    TEST_ENV.FACT_EXTRACTOR_MODEL = 'stub-model-v2';
+    const v2 = factExtractorVersion(TEST_ENV);
+    expect(v2).not.toBe(v1);
 
     const third = await triggerFactExtraction(TEST_ENV);
     expect(third.factsCreated).toBe(3);
@@ -271,10 +276,12 @@ describe('focused retrieval (#1172) — build + serve loop', () => {
         AND (metadata->>'derived_from_event_id')::bigint = ${parentEventId}
       ORDER BY v
     `) as Array<{ v: string }>;
-    expect(versions.map((r) => r.v)).toEqual(['fact-extract-test:v1', 'fact-extract-test:v2']);
+    // Both versions coexist in the append-only log (6 rows total)...
+    expect(versions.map((r) => r.v).sort()).toEqual([v1, v2].sort());
 
-    // Focused read now aggregates BOTH versions' facts (6 lines). It still
-    // serves facts (not the raw blob) and still lists only the parent.
+    // ...but the focused read serves ONLY the current (v2) version's 3 facts —
+    // never a mix of stale + current. Still serves facts (not raw), lists only
+    // the parent.
     const result = await getContent(
       { entity_id: entity.id, limit: 100, focused: true } as never,
       TEST_ENV as never,
@@ -282,7 +289,8 @@ describe('focused retrieval (#1172) — build + serve loop', () => {
     );
     const parentItem = result.content.find((c) => c.id === parentEventId);
     expect(parentItem).toBeDefined();
-    expect(parentItem!.text_content.split('\n')).toHaveLength(6);
+    expect(parentItem!.text_content.split('\n')).toHaveLength(3);
+    expect(parentItem!.text_content).toBe(FACTS.join('\n'));
     expect(parentItem!.text_content).not.toContain('walk-up apartment');
     expect(result.content.some((c) => c.semantic_type === 'extracted_fact')).toBe(false);
     expect(result.content).toHaveLength(1);

--- a/packages/server/src/__tests__/integration/events/focused-retrieval.test.ts
+++ b/packages/server/src/__tests__/integration/events/focused-retrieval.test.ts
@@ -1,0 +1,290 @@
+/**
+ * Integration test: server-side focused retrieval (#1172).
+ *
+ * Exercises the full build → serve loop against a real Postgres:
+ *
+ *   1. The async builder `triggerFactExtraction` scans long events, calls the
+ *      (stubbed) extractor, and writes one `semantic_type='extracted_fact'`
+ *      event per fact, stamped with `metadata.{derived_from_event_id,
+ *      fact_extractor_version}` and inheriting the parent's entity_ids +
+ *      occurred_at.
+ *   2. `getContent({ focused: true })` replaces the parent's text_content /
+ *      payload_text with the joined facts, and never lists the derived
+ *      fact rows as standalone content.
+ *   3. `getContent({ focused: false })` returns the raw payload and never
+ *      leaks a derived fact row into the list or the count.
+ *   4. The builder is idempotent at a fixed extractor version (NOT EXISTS
+ *      guard), and re-extracts when the version stamp changes.
+ *
+ * The LLM is stubbed via `vi.mock` so the test is deterministic and offline.
+ * `factExtractorVersion` is also stubbed (to a controllable string) so the
+ * version-stamp + NOT EXISTS guard are exercised with a known value and the
+ * version-bump branch can be driven.
+ */
+
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import { getDb, parsePgNumberArray } from '../../../db/client';
+import type { Env } from '../../../index';
+import { getContent } from '../../../tools/get_content';
+import type { ToolContext } from '../../../tools/registry';
+import { initWorkspaceProvider } from '../../../workspace';
+import { cleanupTestDatabase } from '../../setup/test-db';
+import {
+  addUserToOrganization,
+  createTestEntity,
+  createTestEvent,
+  createTestOrganization,
+  createTestUser,
+  seedSystemEntityTypes,
+} from '../../setup/test-fixtures';
+
+// ── Stub the extractor LLM ────────────────────────────────────────────────
+// `vi.hoisted` lets the mock factory close over mutable state the test mutates
+// (the fact list + the version stamp) so we can drive idempotency and the
+// version-bump branch without re-mocking.
+const stub = vi.hoisted(() => ({
+  facts: ['User lives in NYC.', 'User owns a dog named Rex.', 'User owns a cat named Whiskers.'],
+  version: 'fact-extract-test:v1',
+}));
+
+vi.mock('../../../utils/fact-extractor', () => ({
+  extractFacts: vi.fn(async () => stub.facts),
+  factExtractorVersion: vi.fn(() => stub.version),
+  factExtractorModel: vi.fn(() => 'stub-model'),
+}));
+
+// Import AFTER the mock so the builder picks up the stubbed extractor.
+import { triggerFactExtraction } from '../../../scheduled/trigger-fact-extraction';
+
+const TEST_ENV = { ENVIRONMENT: 'test', DATABASE_URL: process.env.DATABASE_URL } as Env;
+
+// A parent payload well over the 200-char extraction floor.
+const PARENT_BLOB =
+  'Over the course of our conversations the user shared a lot of personal detail. ' +
+  'They mentioned that they live in New York City, in a walk-up apartment in the East Village. ' +
+  'They talked at length about their pets: a dog named Rex who is a 4-year-old border collie, ' +
+  'and a cat named Whiskers who is 7. They also described a recent trip and several purchases. ' +
+  'This blob is intentionally long so it clears the focused-extraction length threshold.';
+
+describe('focused retrieval (#1172) — build + serve loop', () => {
+  let org: Awaited<ReturnType<typeof createTestOrganization>>;
+  let user: Awaited<ReturnType<typeof createTestUser>>;
+  let entity: Awaited<ReturnType<typeof createTestEntity>>;
+  let parentEventId: number;
+  let parentOccurredAt: Date;
+
+  function ctx(): ToolContext {
+    return {
+      organizationId: org.id,
+      userId: user.id,
+      memberRole: 'owner',
+      isAuthenticated: true,
+      tokenType: 'oauth',
+      scopedToOrg: false,
+      allowCrossOrg: true,
+      scopes: ['mcp:read'],
+    };
+  }
+
+  beforeAll(async () => {
+    await initWorkspaceProvider();
+    await cleanupTestDatabase();
+    await seedSystemEntityTypes();
+
+    org = await createTestOrganization({ name: 'Focused Retrieval Org' });
+    user = await createTestUser({ email: 'focused@example.com' });
+    await addUserToOrganization(user.id, org.id, 'owner');
+
+    entity = await createTestEntity({
+      name: 'Focused Retrieval Entity',
+      organization_id: org.id,
+    });
+
+    // Pin occurred_at so we can assert the derived facts inherit it.
+    parentOccurredAt = new Date('2026-01-15T12:00:00.000Z');
+    const parent = await createTestEvent({
+      organization_id: org.id,
+      entity_id: entity.id,
+      content: PARENT_BLOB,
+      occurred_at: parentOccurredAt,
+      // 'content' semantic type — the builder must NOT treat it as a fact.
+      semantic_type: 'content',
+    });
+    parentEventId = parent.id;
+
+    // Reset the stub to its default state for each fresh suite run.
+    stub.facts = ['User lives in NYC.', 'User owns a dog named Rex.', 'User owns a cat named Whiskers.'];
+    stub.version = 'fact-extract-test:v1';
+  });
+
+  afterAll(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('builder extracts 3 facts as derived events with the right stamp + inherited fields', async () => {
+    const result = await triggerFactExtraction(TEST_ENV);
+
+    expect(result.events).toBe(1);
+    expect(result.factsCreated).toBe(3);
+
+    const sql = getDb();
+    const factRows = (await sql`
+      SELECT id, payload_text, semantic_type, entity_ids, occurred_at, organization_id, metadata
+      FROM events
+      WHERE semantic_type = 'extracted_fact'
+        AND (metadata->>'derived_from_event_id')::bigint = ${parentEventId}
+      ORDER BY id ASC
+    `) as Array<{
+      id: number;
+      payload_text: string;
+      semantic_type: string;
+      // `bigint[]` reads back as a Postgres array-literal string under the prod
+      // PG value options (`fetch_types: false`) — parse via parsePgNumberArray.
+      entity_ids: unknown;
+      occurred_at: string | null;
+      organization_id: string;
+      metadata: Record<string, unknown>;
+    }>;
+
+    expect(factRows).toHaveLength(3);
+    expect(factRows.map((r) => r.payload_text)).toEqual([
+      'User lives in NYC.',
+      'User owns a dog named Rex.',
+      'User owns a cat named Whiskers.',
+    ]);
+
+    for (const row of factRows) {
+      expect(row.semantic_type).toBe('extracted_fact');
+      expect(Number(row.metadata.derived_from_event_id)).toBe(parentEventId);
+      expect(row.metadata.fact_extractor_version).toBe('fact-extract-test:v1');
+      expect(row.organization_id).toBe(org.id);
+      // entity_ids inherited from the parent.
+      const ids = parsePgNumberArray(row.entity_ids);
+      expect(ids).toContain(entity.id);
+      // occurred_at inherited from the parent.
+      expect(new Date(row.occurred_at as string).toISOString()).toBe(
+        parentOccurredAt.toISOString()
+      );
+    }
+  });
+
+  it('focused read returns the joined facts as the parent text, with no standalone fact rows', async () => {
+    const result = await getContent(
+      { entity_id: entity.id, limit: 100, focused: true } as never,
+      TEST_ENV as never,
+      ctx()
+    );
+
+    const expectedFacts = [
+      'User lives in NYC.',
+      'User owns a dog named Rex.',
+      'User owns a cat named Whiskers.',
+    ].join('\n');
+
+    // The parent item carries the focused facts in BOTH fields.
+    const parentItem = result.content.find((c) => c.id === parentEventId);
+    expect(parentItem).toBeDefined();
+    expect(parentItem!.text_content).toBe(expectedFacts);
+    expect(parentItem!.payload_text).toBe(expectedFacts);
+    // It is NOT the raw blob.
+    expect(parentItem!.text_content).not.toContain('walk-up apartment');
+
+    // No derived fact row appears as its own content item.
+    const factRowLeaked = result.content.some((c) => c.semantic_type === 'extracted_fact');
+    expect(factRowLeaked).toBe(false);
+
+    // Exactly the parent shows up (the 3 facts are joined in, not listed).
+    expect(result.content).toHaveLength(1);
+    expect(result.total).toBe(1);
+  });
+
+  it('non-focused read returns the raw blob and never leaks a derived fact row', async () => {
+    const result = await getContent(
+      { entity_id: entity.id, limit: 100, focused: false } as never,
+      TEST_ENV as never,
+      ctx()
+    );
+
+    const parentItem = result.content.find((c) => c.id === parentEventId);
+    expect(parentItem).toBeDefined();
+    expect(parentItem!.text_content).toBe(PARENT_BLOB);
+    expect(parentItem!.payload_text).toBe(PARENT_BLOB);
+
+    // No extracted_fact rows in the list, and the count reflects that too.
+    expect(result.content.some((c) => c.semantic_type === 'extracted_fact')).toBe(false);
+    expect(result.content).toHaveLength(1);
+    expect(result.total).toBe(1);
+  });
+
+  it('non-focused score-sorted read also excludes derived facts from list + count', async () => {
+    const result = await getContent(
+      { entity_id: entity.id, limit: 100, sort_by: 'score' } as never,
+      TEST_ENV as never,
+      ctx()
+    );
+    expect(result.content.some((c) => c.semantic_type === 'extracted_fact')).toBe(false);
+    expect(result.total).toBe(result.content.length);
+    expect(result.content).toHaveLength(1);
+  });
+
+  it('explicitly requesting semantic_type=extracted_fact surfaces the derived rows (escape hatch)', async () => {
+    const result = await getContent(
+      { entity_id: entity.id, limit: 100, semantic_type: 'extracted_fact' } as never,
+      TEST_ENV as never,
+      ctx()
+    );
+    const factItems = result.content.filter((c) => c.semantic_type === 'extracted_fact');
+    expect(factItems).toHaveLength(3);
+    // And only facts come back — the parent 'content' row is filtered out.
+    expect(result.content.every((c) => c.semantic_type === 'extracted_fact')).toBe(true);
+  });
+
+  it('builder is idempotent at a fixed version — second run creates 0 new facts', async () => {
+    const second = await triggerFactExtraction(TEST_ENV);
+    expect(second.factsCreated).toBe(0);
+    expect(second.events).toBe(0);
+
+    const sql = getDb();
+    const [{ count }] = (await sql`
+      SELECT COUNT(*)::int AS count
+      FROM events
+      WHERE semantic_type = 'extracted_fact'
+        AND (metadata->>'derived_from_event_id')::bigint = ${parentEventId}
+    `) as Array<{ count: number }>;
+    expect(count).toBe(3);
+  });
+
+  it('version bump re-extracts: new stamp produces a fresh set of fact rows', async () => {
+    // Bump the stubbed extractor version → the NOT EXISTS guard no longer
+    // matches the v1 rows, so the parent is re-extracted under v2.
+    stub.version = 'fact-extract-test:v2';
+
+    const third = await triggerFactExtraction(TEST_ENV);
+    expect(third.factsCreated).toBe(3);
+    expect(third.events).toBe(1);
+
+    const sql = getDb();
+    const versions = (await sql`
+      SELECT DISTINCT metadata->>'fact_extractor_version' AS v
+      FROM events
+      WHERE semantic_type = 'extracted_fact'
+        AND (metadata->>'derived_from_event_id')::bigint = ${parentEventId}
+      ORDER BY v
+    `) as Array<{ v: string }>;
+    expect(versions.map((r) => r.v)).toEqual(['fact-extract-test:v1', 'fact-extract-test:v2']);
+
+    // Focused read now aggregates BOTH versions' facts (6 lines). It still
+    // serves facts (not the raw blob) and still lists only the parent.
+    const result = await getContent(
+      { entity_id: entity.id, limit: 100, focused: true } as never,
+      TEST_ENV as never,
+      ctx()
+    );
+    const parentItem = result.content.find((c) => c.id === parentEventId);
+    expect(parentItem).toBeDefined();
+    expect(parentItem!.text_content.split('\n')).toHaveLength(6);
+    expect(parentItem!.text_content).not.toContain('walk-up apartment');
+    expect(result.content.some((c) => c.semantic_type === 'extracted_fact')).toBe(false);
+    expect(result.content).toHaveLength(1);
+  });
+});

--- a/packages/server/src/scheduled/classification-reconciliation.ts
+++ b/packages/server/src/scheduled/classification-reconciliation.ts
@@ -80,6 +80,7 @@ export async function runClassificationReconciliation(_env: Env): Promise<{
           FROM events e
           JOIN event_embeddings emb ON emb.event_id = e.id
           WHERE e.entity_ids @> ARRAY[ent.id]
+            AND e.semantic_type <> 'extracted_fact'
             AND e.created_at > now() - interval '7 days'
             AND NOT EXISTS (
               SELECT 1 FROM events newer WHERE newer.supersedes_event_id = e.id
@@ -148,6 +149,7 @@ export async function runClassificationReconciliation(_env: Env): Promise<{
             LEFT JOIN event_classifiers fc ON ecv.classifier_id = fc.id
             WHERE ${sql.unsafe(entityLinkMatchSql(`${Number(entityId)}::bigint`, 'ev'))}
               AND ev.embedding IS NOT NULL
+              AND ev.semantic_type <> 'extracted_fact'
             GROUP BY ev.id
           ) per_event
           WHERE per_event.classified_count < ${expectedCount}

--- a/packages/server/src/scheduled/jobs.ts
+++ b/packages/server/src/scheduled/jobs.ts
@@ -16,6 +16,7 @@ import { runClassificationReconciliation } from './classification-reconciliation
 import { registerScheduledJobsTicker } from './scheduled-jobs-service';
 import { TaskScheduler } from './task-scheduler';
 import { triggerEmbedBackfill } from './trigger-embed-backfill';
+import { triggerFactExtraction } from './trigger-fact-extraction';
 import { getDb, pgTextArray } from '../db/client';
 import { createNotificationForUsers } from '../notifications/service';
 import {
@@ -123,6 +124,20 @@ function registerMaintenanceTasks(
       const result = await triggerEmbedBackfill(env);
       if (result.runsCreated > 0) {
         logger.info({ ...result }, '[task] trigger-embed-backfill enqueued runs');
+      }
+    },
+    { cron: '*/5 * * * *' },
+  );
+
+  // Query-focused fact extraction: distills long raw events into atomic
+  // `extracted_fact` events that back focused reads. Same cadence/family as
+  // embed-backfill; runs inline (runs-queue-claimed, so multi-replica-safe).
+  scheduler.register(
+    'trigger-fact-extraction',
+    async () => {
+      const result = await triggerFactExtraction(env);
+      if (result.factsCreated > 0) {
+        logger.info({ ...result }, '[task] trigger-fact-extraction created facts');
       }
     },
     { cron: '*/5 * * * *' },

--- a/packages/server/src/scheduled/trigger-fact-extraction.ts
+++ b/packages/server/src/scheduled/trigger-fact-extraction.ts
@@ -1,17 +1,11 @@
 /**
- * Scheduled Job: Trigger Query-Focused Fact Extraction
+ * Scheduled job: distill long raw events into atomic `extracted_fact` events
+ * that back focused reads (`read_knowledge({ focused: true })`).
  *
- * Runs periodically to distill long raw events into atomic `extracted_fact`
- * events that back focused reads (`read_knowledge({ focused: true })`).
- *
- * Unlike embed-backfill (which enqueues a worker run per org), this job does
- * the extraction INLINE: the scheduled tick is itself a runs-queue-claimed
- * task (see scheduled/jobs.ts header), so exactly one replica runs a given
- * tick — there is no in-memory shared state and no cross-pod fan-out needed.
- * The `NOT EXISTS` guard below makes the scan idempotent even if two ticks
- * race: an event already extracted at the current extractor version is skipped,
- * and a duplicate insert from an overlapping tick is harmless (focused reads
- * `string_agg` the facts, and the next tick re-skips the parent).
+ * Extraction runs INLINE in the tick (not via a worker run like embed-backfill):
+ * the tick is runs-queue-claimed, so one replica runs it, and the NOT EXISTS
+ * guard keyed on (derived_from_event_id, fact_extractor_version) keeps it
+ * idempotent.
  */
 
 import { getDb, parsePgNumberArray } from '../db/client';

--- a/packages/server/src/scheduled/trigger-fact-extraction.ts
+++ b/packages/server/src/scheduled/trigger-fact-extraction.ts
@@ -63,7 +63,7 @@ export async function triggerFactExtraction(env: Env): Promise<FactExtractionRes
         SELECT 1
         FROM events d
         WHERE d.semantic_type = 'extracted_fact'
-          AND (d.metadata->>'derived_from_event_id')::bigint = ev.id
+          AND d.metadata->>'derived_from_event_id' = ev.id::text
           AND d.metadata->>'fact_extractor_version' = ${version}
       )
     ORDER BY ev.created_at DESC

--- a/packages/server/src/scheduled/trigger-fact-extraction.ts
+++ b/packages/server/src/scheduled/trigger-fact-extraction.ts
@@ -1,0 +1,168 @@
+/**
+ * Scheduled Job: Trigger Query-Focused Fact Extraction
+ *
+ * Runs periodically to distill long raw events into atomic `extracted_fact`
+ * events that back focused reads (`read_knowledge({ focused: true })`).
+ *
+ * Unlike embed-backfill (which enqueues a worker run per org), this job does
+ * the extraction INLINE: the scheduled tick is itself a runs-queue-claimed
+ * task (see scheduled/jobs.ts header), so exactly one replica runs a given
+ * tick — there is no in-memory shared state and no cross-pod fan-out needed.
+ * The `NOT EXISTS` guard below makes the scan idempotent even if two ticks
+ * race: an event already extracted at the current extractor version is skipped,
+ * and a duplicate insert from an overlapping tick is harmless (focused reads
+ * `string_agg` the facts, and the next tick re-skips the parent).
+ */
+
+import { getDb, parsePgNumberArray } from '../db/client';
+import type { Env } from '../index';
+import { extractFacts, factExtractorVersion } from '../utils/fact-extractor';
+import { insertEvent } from '../utils/insert-event';
+import logger from '../utils/logger';
+
+/** Events scanned per tick — bounded so a tick stays cheap and predictable. */
+const EVENT_BATCH_LIMIT = 50;
+/** Min payload length to bother extracting — shorter events are already focused. */
+const MIN_PAYLOAD_LENGTH = 200;
+/** How many events to extract concurrently (LLM calls are the bottleneck). */
+const EXTRACTION_CONCURRENCY = 4;
+
+interface FactExtractionResult {
+  events: number;
+  factsCreated: number;
+}
+
+interface ExtractionCandidate {
+  id: number;
+  organization_id: string;
+  // Under the prod PG value options (`fetch_types: false`) a `bigint[]` column
+  // comes back as a Postgres array literal STRING (e.g. `{12,34}`), not a JS
+  // array — so this is `unknown` and parsed via `parsePgNumberArray`.
+  entity_ids: unknown;
+  occurred_at: string | null;
+  payload_text: string;
+}
+
+export async function triggerFactExtraction(env: Env): Promise<FactExtractionResult> {
+  const sql = getDb();
+  const version = factExtractorVersion(env);
+
+  // Find events needing extraction at the current extractor version. The
+  // NOT EXISTS guard keys on (derived_from_event_id, fact_extractor_version)
+  // so a model/prompt bump re-extracts, and an already-extracted event is
+  // skipped (idempotent across overlapping ticks). We never extract facts
+  // from facts. The version is bound as a parameter.
+  const candidates = (await sql`
+    SELECT
+      ev.id,
+      ev.organization_id,
+      ev.entity_ids,
+      ev.occurred_at,
+      ev.payload_text
+    FROM current_event_records ev
+    WHERE ev.semantic_type <> 'extracted_fact'
+      AND ev.payload_text IS NOT NULL
+      AND ev.payload_text != ''
+      AND ev.organization_id IS NOT NULL
+      AND length(ev.payload_text) > ${MIN_PAYLOAD_LENGTH}
+      AND NOT EXISTS (
+        SELECT 1
+        FROM events d
+        WHERE d.semantic_type = 'extracted_fact'
+          AND (d.metadata->>'derived_from_event_id')::bigint = ev.id
+          AND d.metadata->>'fact_extractor_version' = ${version}
+      )
+    ORDER BY ev.created_at DESC
+    LIMIT ${EVENT_BATCH_LIMIT}
+  `) as unknown as ExtractionCandidate[];
+
+  if (candidates.length === 0) {
+    return { events: 0, factsCreated: 0 };
+  }
+
+  let factsCreated = 0;
+  let processed = 0;
+
+  // Bounded concurrency: process EXTRACTION_CONCURRENCY events at a time so a
+  // batch of 50 doesn't fire 50 simultaneous LLM calls nor block serially for
+  // minutes. Each chunk awaits before the next starts.
+  for (let i = 0; i < candidates.length; i += EXTRACTION_CONCURRENCY) {
+    const chunk = candidates.slice(i, i + EXTRACTION_CONCURRENCY);
+    const created = await Promise.all(
+      chunk.map((candidate) => extractAndInsert(candidate, version, env))
+    );
+    for (const n of created) {
+      factsCreated += n;
+      processed += 1;
+    }
+  }
+
+  if (factsCreated > 0) {
+    logger.info(
+      { events: processed, factsCreated, version },
+      '[FactExtraction] Extracted facts for events'
+    );
+  }
+
+  return { events: processed, factsCreated };
+}
+
+/**
+ * Extract facts for one parent event and insert each as a derived
+ * `extracted_fact` event. Returns the number of facts inserted (0 when the
+ * extractor is unconfigured or yields nothing). Inherits the parent's org,
+ * entity links, and occurred_at so focused reads can join + window correctly.
+ * Embeddings are left to the existing embed_backfill job — the fact events
+ * carry `payload_text`, so they get embedded on the next backfill tick.
+ */
+async function extractAndInsert(
+  candidate: ExtractionCandidate,
+  version: string,
+  env: Env
+): Promise<number> {
+  let facts: string[];
+  try {
+    facts = await extractFacts(candidate.payload_text, env);
+  } catch (err) {
+    logger.warn(
+      { err: err instanceof Error ? err.message : String(err), parentId: candidate.id },
+      '[FactExtraction] extractFacts threw; skipping event'
+    );
+    return 0;
+  }
+
+  if (facts.length === 0) return 0;
+
+  // `entity_ids` is a Postgres array literal string under `fetch_types: false`
+  // (prod value options) — parse it the same way the rest of the read path does.
+  const entityIds = parsePgNumberArray(candidate.entity_ids);
+
+  let inserted = 0;
+  for (let idx = 0; idx < facts.length; idx += 1) {
+    const fact = facts[idx];
+    try {
+      await insertEvent({
+        entityIds,
+        organizationId: candidate.organization_id,
+        // Stable, unique origin id per (parent, fact, version) so re-running
+        // a tick can't collide and a version bump produces fresh rows.
+        originId: `extracted_fact:${candidate.id}:${version}:${idx}`,
+        content: fact,
+        semanticType: 'extracted_fact',
+        occurredAt: candidate.occurred_at ?? null,
+        metadata: {
+          derived_from_event_id: candidate.id,
+          fact_extractor_version: version,
+        },
+      });
+      inserted += 1;
+    } catch (err) {
+      logger.warn(
+        { err: err instanceof Error ? err.message : String(err), parentId: candidate.id, idx },
+        '[FactExtraction] failed to insert derived fact'
+      );
+    }
+  }
+
+  return inserted;
+}

--- a/packages/server/src/tools/get_content.ts
+++ b/packages/server/src/tools/get_content.ts
@@ -1284,13 +1284,13 @@ export async function getContent(
         // rows remain (events is append-only) but must not be aggregated in — else
         // focused reads would mix stale + current facts for the same parent.
         const factRows = await sql`
-          SELECT (d.metadata->>'derived_from_event_id')::bigint AS parent_id,
+          SELECT d.metadata->>'derived_from_event_id' AS parent_id,
                  string_agg(d.payload_text, E'\n' ORDER BY d.id) AS facts
           FROM events d
           WHERE d.semantic_type = 'extracted_fact'
             AND d.organization_id = ${ctx.organizationId}
             AND d.metadata->>'fact_extractor_version' = ${factExtractorVersion(env)}
-            AND (d.metadata->>'derived_from_event_id')::bigint = ANY(${`{${retrievedIds.join(',')}}`}::bigint[])
+            AND d.metadata->>'derived_from_event_id' = ANY(${pgTextArray(retrievedIds.map(String))}::text[])
           GROUP BY parent_id
         `;
         for (const row of factRows as Array<{ parent_id: number | string; facts: string | null }>) {

--- a/packages/server/src/tools/get_content.ts
+++ b/packages/server/src/tools/get_content.ts
@@ -29,6 +29,7 @@ import {
   fetchEntityIdentityScopes,
   searchContentByText,
 } from '../utils/content-search';
+import { factExtractorVersion } from '../utils/fact-extractor';
 import { parseJsonObject } from '@lobu/core';
 import { parseDateAlias, toEndOfDay } from '../utils/date-aliases';
 import { type DataSourceContext, executeDataSources } from '../utils/execute-data-sources';
@@ -1278,12 +1279,17 @@ export async function getContent(
     if (args.focused && rawContent.length > 0) {
       const retrievedIds = rawContent.map((r) => Number(r.id)).filter((id) => Number.isFinite(id));
       if (retrievedIds.length > 0) {
+        // Serve ONLY the current extractor version's facts. After a model/prompt
+        // bump the builder re-extracts under a new version stamp; the old-version
+        // rows remain (events is append-only) but must not be aggregated in — else
+        // focused reads would mix stale + current facts for the same parent.
         const factRows = await sql`
           SELECT (d.metadata->>'derived_from_event_id')::bigint AS parent_id,
                  string_agg(d.payload_text, E'\n' ORDER BY d.id) AS facts
           FROM events d
           WHERE d.semantic_type = 'extracted_fact'
             AND d.organization_id = ${ctx.organizationId}
+            AND d.metadata->>'fact_extractor_version' = ${factExtractorVersion(env)}
             AND (d.metadata->>'derived_from_event_id')::bigint = ANY(${`{${retrievedIds.join(',')}}`}::bigint[])
           GROUP BY parent_id
         `;

--- a/packages/server/src/tools/get_content.ts
+++ b/packages/server/src/tools/get_content.ts
@@ -24,6 +24,8 @@ import {
 import {
   buildConnectionVisibilityClause,
   buildEntityLinkUnion,
+  excludeExtractedFactClause,
+  excludeExtractedFactCondition,
   fetchEntityIdentityScopes,
   searchContentByText,
 } from '../utils/content-search';
@@ -206,6 +208,13 @@ export const GetContentSchema = Type.Object({
         'Weight of vector similarity vs text rank in combined_score (0.0-1.0, default: 0.6). Higher values favor semantic match over keyword overlap. Only applies when a query and embeddings are both present.',
       minimum: 0.0,
       maximum: 1.0,
+    })
+  ),
+  focused: Type.Optional(
+    Type.Boolean({
+      description:
+        'Return query-focused extracted facts (semantic_type=extracted_fact) for the retrieved events when a focused index exists; fall back to raw payload_text otherwise. Default: false.',
+      default: false,
     })
   ),
   classification_filters: Type.Optional(
@@ -779,12 +788,16 @@ export async function getContent(
       });
       queryParams.push(...visibility.params);
 
+      // Derived facts are an internal focused-read index — exclude them even
+      // when fetched by explicit id, unless `extracted_fact` was requested.
+      const factExclusion = excludeExtractedFactClause(args.semantic_type, 'f');
+
       // Query content by IDs with classifications
       const result = await sql.unsafe(
         buildContentQuery({
           table: 'current_event_records',
           alias: 'f',
-          where: `f.id IN (${idPlaceholders}) ${orgScope}${entityFilter} ${visibility.sql}`,
+          where: `f.id IN (${idPlaceholders}) ${orgScope}${entityFilter} ${visibility.sql} ${factExclusion}`,
           orderBy: 'f.occurred_at DESC',
           limit,
           offset,
@@ -800,6 +813,7 @@ export async function getContent(
           ${orgScope}
           ${entityFilter}
           ${visibility.sql}
+          ${factExclusion}
       `,
         queryParams
       );
@@ -905,6 +919,9 @@ export async function getContent(
         queryParams.push(pgTextArray(types));
         paramIndex += 1;
       }
+      // Derived facts are an internal focused-read index — exclude from the
+      // superseded-history listing unless `extracted_fact` was requested.
+      conditions.push(excludeExtractedFactCondition(args.semantic_type, 'e'));
       if (args.interaction_status) {
         conditions.push(`e.interaction_status = $${paramIndex}`);
         queryParams.push(args.interaction_status);
@@ -1049,6 +1066,9 @@ export async function getContent(
     if (includeClassificationSummary) {
       // Build dynamic WHERE conditions using inline SQL
       const conditions: string[] = ['1=1'];
+      // Derived facts are an internal focused-read index — keep them out of the
+      // classification-stats distribution unless `extracted_fact` was requested.
+      conditions.push(excludeExtractedFactCondition(args.semantic_type, 'f'));
       const params: any[] = [];
       let paramIndex = 1;
 
@@ -1250,8 +1270,34 @@ export async function getContent(
       });
     }
 
+    // Focused read: replace each retrieved event's text with its query-focused
+    // extracted facts (semantic_type='extracted_fact') when a focused index
+    // exists for it. One round-trip joins the derived facts back to their
+    // parents; events with no facts fall back to raw payload_text below.
+    const factsByParent = new Map<number, string>();
+    if (args.focused && rawContent.length > 0) {
+      const retrievedIds = rawContent.map((r) => Number(r.id)).filter((id) => Number.isFinite(id));
+      if (retrievedIds.length > 0) {
+        const factRows = await sql`
+          SELECT (d.metadata->>'derived_from_event_id')::bigint AS parent_id,
+                 string_agg(d.payload_text, E'\n' ORDER BY d.id) AS facts
+          FROM events d
+          WHERE d.semantic_type = 'extracted_fact'
+            AND d.organization_id = ${ctx.organizationId}
+            AND (d.metadata->>'derived_from_event_id')::bigint = ANY(${`{${retrievedIds.join(',')}}`}::bigint[])
+          GROUP BY parent_id
+        `;
+        for (const row of factRows as Array<{ parent_id: number | string; facts: string | null }>) {
+          if (row.facts) {
+            factsByParent.set(Number(row.parent_id), row.facts);
+          }
+        }
+      }
+    }
+
     // Map to the canonical content item shape used across the app.
     const contentItems: ContentItem[] = rawContent.map((f) => {
+      const focusedFacts = args.focused ? factsByParent.get(f.id) : undefined;
       const metadata = parseJsonObject(f.metadata);
       const classifications = parseJsonObject(f.classifications);
 
@@ -1263,14 +1309,14 @@ export async function getContent(
         semantic_type: f.semantic_type ?? 'content',
         origin_type: f.origin_type ?? null,
         payload_type: f.payload_type ?? 'text',
-        payload_text: f.payload_text ?? '',
+        payload_text: focusedFacts ?? f.payload_text ?? '',
         payload_data: parseJsonObject(f.payload_data),
         payload_template: f.payload_template ? parseJsonObject(f.payload_template) : null,
         attachments: parseRecordArray(f.attachments),
         author_name: f.author_name ?? null,
         client_name: f.client_name ?? clientNameMap.get(f.id) ?? null,
         title: f.title,
-        text_content: f.payload_text ?? '',
+        text_content: focusedFacts ?? f.payload_text ?? '',
         rating: (metadata.rating as string) || null,
         source_url: f.source_url ?? null,
         score: Number(f.score) || 0,
@@ -1722,6 +1768,7 @@ async function handleWatcherMode(
       WHERE c.entity_ids && ARRAY[${entityIdPlaceholders}]::bigint[]
         AND c.occurred_at >= $${sourceEntityIds.length + 1}
         AND c.occurred_at < $${sourceEntityIds.length + 2}
+        ${excludeExtractedFactClause(undefined, 'c')}
     `,
       [...sourceEntityIds, windowStartIso, windowEndIso]
     ),
@@ -1780,6 +1827,7 @@ async function handleWatcherMode(
           COUNT(*) as total
         FROM current_event_records c
         WHERE c.entity_ids && ARRAY[${entityIdPlaceholders}]::bigint[]
+          ${excludeExtractedFactClause(undefined, 'c')}
         GROUP BY DATE_TRUNC('month', c.occurred_at)
         ORDER BY month
       `,
@@ -1795,6 +1843,7 @@ async function handleWatcherMode(
         JOIN watcher_windows iw ON iwc.window_id = iw.id
         WHERE c.entity_ids && ARRAY[${entityIdPlaceholders}]::bigint[]
           AND iw.watcher_id = $${sourceEntityIds.length + 1}
+          ${excludeExtractedFactClause(undefined, 'c')}
         GROUP BY DATE_TRUNC('month', c.occurred_at)
       `,
         [...sourceEntityIds, watcherId]

--- a/packages/server/src/tools/search.ts
+++ b/packages/server/src/tools/search.ts
@@ -10,7 +10,11 @@
 import { type Static, Type } from '@sinclair/typebox';
 import { getDb } from '../db/client';
 import type { Env } from '../index';
-import { entityLinkMatchSql, searchContentByText } from '../utils/content-search';
+import {
+  entityLinkMatchSql,
+  excludeExtractedFactCondition,
+  searchContentByText,
+} from '../utils/content-search';
 import { toVectorLiteral } from '../utils/entity-management';
 import logger from '../utils/logger';
 import { expandSearchQueries } from '../utils/query-expansion';
@@ -430,7 +434,7 @@ async function fetchTopEntitiesByType(
     JOIN entity_types et ON et.id = e.entity_type_id
     WHERE e.organization_id = ${organizationId}
       AND e.deleted_at IS NULL
-    ORDER BY (SELECT COUNT(*) FROM current_event_records ev WHERE ${sql.unsafe(entityLinkMatchSql('e.id::bigint', 'ev'))}) DESC
+    ORDER BY (SELECT COUNT(*) FROM current_event_records ev WHERE ${sql.unsafe(entityLinkMatchSql('e.id::bigint', 'ev'))} AND ${sql.unsafe(excludeExtractedFactCondition(undefined, 'ev'))}) DESC
     LIMIT 30
   `;
 
@@ -467,6 +471,7 @@ function entitySelectColumns(callerOrgParamIdx: number): string {
       SELECT COUNT(*) FROM current_event_records ev
       WHERE ${entityLinkMatchSql('e.id::bigint', 'ev')}
         AND ev.organization_id = e.organization_id
+        AND ${excludeExtractedFactCondition(undefined, 'ev')}
     ), 0)
   ELSE 0 END as content_count,
   CASE WHEN ${ownOrg} THEN
@@ -736,7 +741,8 @@ async function formatEntityResult(
           COALESCE(
             (SELECT COUNT(*) FROM current_event_records ev
               WHERE e.id = ANY(ev.entity_ids)
-                AND ev.organization_id = e.organization_id),
+                AND ev.organization_id = e.organization_id
+                AND ev.semantic_type <> 'extracted_fact'),
             0
           )
         ELSE 0 END as content_count

--- a/packages/server/src/utils/content-scoring.ts
+++ b/packages/server/src/utils/content-scoring.ts
@@ -9,6 +9,7 @@ import {
   buildEntityLinkUnion,
   type EntityIdentityScope,
   entityLinkMatchSql,
+  excludeExtractedFactCondition,
   fetchEntityIdentityScopes,
 } from './content-search';
 import logger from './logger';
@@ -119,6 +120,10 @@ function buildFilterConditionsAndJoins(
   }
   const filterConditions: string[] = [entityLinkSql];
   const additionalJoins: string[] = [];
+
+  // Derived facts are an internal focused-read index — exclude from score-sorted
+  // lists/counts unless the caller explicitly requested `extracted_fact`.
+  filterConditions.push(excludeExtractedFactCondition(filters?.semantic_type, 'f'));
 
   if (filters?.connection_ids && filters.connection_ids.length > 0) {
     const validatedIds = validateAndFormatIds(filters.connection_ids, 'connection_ids');

--- a/packages/server/src/utils/content-search.ts
+++ b/packages/server/src/utils/content-search.ts
@@ -191,6 +191,54 @@ export const STANDARD_IDENTITY_NAMESPACES = [
 ] as const;
 
 /**
+ * Derived `extracted_fact` events are an internal focused-read index (built by
+ * trigger-fact-extraction.ts, served by the `focused` flag in get_content),
+ * NOT first-class content. They must never leak into normal content lists,
+ * search_memory results, watcher windows, the Atlas events page, or counts —
+ * so every raw events list/search/count excludes them by default.
+ *
+ * Returns an empty string (no exclusion) when the caller explicitly asked for
+ * `extracted_fact` via `semantic_type`; otherwise an `AND <alias>.semantic_type
+ * <> 'extracted_fact'` fragment. The literal is constant, so it's safe to inline.
+ */
+export const EXTRACTED_FACT_SEMANTIC_TYPE = 'extracted_fact';
+
+export function callerRequestedExtractedFact(
+  semanticType: string | string[] | undefined
+): boolean {
+  if (!semanticType) return false;
+  const types = Array.isArray(semanticType) ? semanticType : [semanticType];
+  return types.includes(EXTRACTED_FACT_SEMANTIC_TYPE);
+}
+
+/**
+ * Bare predicate (no leading `AND`) excluding derived facts, or `'1=1'` when the
+ * caller explicitly requested them. Use where a condition is joined into an
+ * array with `' AND '`. `alias` defaults to `f`.
+ */
+export function excludeExtractedFactCondition(
+  semanticType: string | string[] | undefined,
+  alias = 'f'
+): string {
+  return callerRequestedExtractedFact(semanticType)
+    ? '1=1'
+    : `${alias}.semantic_type <> '${EXTRACTED_FACT_SEMANTIC_TYPE}'`;
+}
+
+/**
+ * `AND`-prefixed variant of {@link excludeExtractedFactCondition}, for splicing
+ * into an inline WHERE body. Empty string when the caller requested facts.
+ */
+export function excludeExtractedFactClause(
+  semanticType: string | string[] | undefined,
+  alias = 'f'
+): string {
+  return callerRequestedExtractedFact(semanticType)
+    ? ''
+    : `AND ${alias}.semantic_type <> '${EXTRACTED_FACT_SEMANTIC_TYPE}'`;
+}
+
+/**
  * SQL predicate: "event `<alias>` is linked to entity `<paramRef>`".
  *
  * Matches two ways:
@@ -1255,6 +1303,9 @@ async function listContentInternal(
       baseParams.push(options.agent_id);
       baseConditions.push(`f.metadata->>'agent_id' = $${baseParams.length}`);
     }
+    // Derived facts are an internal focused-read index — never list them unless
+    // the caller explicitly asked for `extracted_fact`.
+    baseConditions.push(excludeExtractedFactCondition(options.semantic_type, 'f'));
 
     const classificationExists = buildClassificationExistsClauses(
       filtersBySlug,
@@ -1362,6 +1413,7 @@ async function listContentInternal(
           AND ${connectionCondition}
           AND ${feedCondition}
           AND ${runCondition}
+          ${excludeExtractedFactClause(options.semantic_type, 'f')}
           ${excludeClause.sql}
           ${visibilityClause.sql}
           ${orgScope.sql}`,
@@ -1600,6 +1652,7 @@ async function searchContentBySingleQuery(
           AND ($9::text[] IS NULL OR f.semantic_type = ANY($9::text[]))
           AND ($10::text IS NULL OR f.interaction_status = $10::text)
           AND ($11::text IS NULL OR f.metadata->>'agent_id' = $11::text)
+          ${excludeExtractedFactClause(options.semantic_type, 'f')}
           ${excludeClause.sql}
           ${visibilityClause.sql}
           ${orgScope.sql}`;

--- a/packages/server/src/utils/fact-extractor.ts
+++ b/packages/server/src/utils/fact-extractor.ts
@@ -39,11 +39,14 @@ export const FACT_EXTRACTION_PROMPT_HASH = createHash('sha256')
   .slice(0, 8);
 
 /**
- * Resolve the extractor model name from env, defaulting to a small Haiku.
+ * Resolve the extractor model name from env. Defaults to a small
+ * OpenAI-compatible model, coherent with the OpenAI-compatible `/chat/completions`
+ * default base URL below — deployments point both at their own provider (Haiku,
+ * GLM, Gemini's OpenAI endpoint, …) via FACT_EXTRACTOR_MODEL + _BASE_URL.
  * Exported so the builder can compose the version stamp from the same source.
  */
 export function factExtractorModel(env: Env): string {
-  return env.FACT_EXTRACTOR_MODEL || 'claude-haiku-4-5';
+  return env.FACT_EXTRACTOR_MODEL || 'gpt-4o-mini';
 }
 
 /**

--- a/packages/server/src/utils/fact-extractor.ts
+++ b/packages/server/src/utils/fact-extractor.ts
@@ -1,0 +1,146 @@
+/**
+ * Query-focused fact extraction.
+ *
+ * Distills a long raw event payload into a set of atomic, standalone facts so
+ * that focused reads (`read_knowledge({ focused: true })`) can serve compact,
+ * specific evidence instead of the full conversation. The derived facts are an
+ * internal index — they are written back as `semantic_type='extracted_fact'`
+ * events (see trigger-fact-extraction.ts) and never surface as first-class
+ * content on normal reads.
+ *
+ * The LLM call is opt-in: without `FACT_EXTRACTOR_API_KEY` configured the
+ * extractor returns `[]`, so the feature degrades gracefully (focused reads
+ * fall back to raw payload_text and the builder is a no-op).
+ */
+
+import { createHash } from 'node:crypto';
+import type { Env } from '../index';
+import logger from './logger';
+
+/**
+ * The proven extraction prompt, ported verbatim from the validated benchmark
+ * adapter. It recovers knowledge-update + multi-session accuracy by forcing
+ * verbatim specifics and one-fact-per-item decomposition. The hash of this
+ * string is the prompt half of the extractor-version stamp — editing the text
+ * MUST change the stamp so previously-extracted events get re-extracted.
+ */
+export const FACT_EXTRACTION_PROMPT =
+  'Extract a COMPLETE, FAITHFUL set of atomic facts from the conversation below. ' +
+  'PRESERVE ALL SPECIFICS VERBATIM: numbers, counts, dates, names, prices, durations, locations. ' +
+  'When the user has MULTIPLE of something (multiple pets, trips, purchases, devices), emit ONE fact PER ITEM; ' +
+  'never collapse a collection into a summary. ' +
+  'Each fact is a standalone declarative sentence understandable without the conversation. ' +
+  'Output one fact per line, no numbering, no preamble.';
+
+/** Short, stable hash of the prompt — used in the extractor-version stamp. */
+export const FACT_EXTRACTION_PROMPT_HASH = createHash('sha256')
+  .update(FACT_EXTRACTION_PROMPT)
+  .digest('hex')
+  .slice(0, 8);
+
+/**
+ * Resolve the extractor model name from env, defaulting to a small Haiku.
+ * Exported so the builder can compose the version stamp from the same source.
+ */
+export function factExtractorModel(env: Env): string {
+  return env.FACT_EXTRACTOR_MODEL || 'claude-haiku-4-5';
+}
+
+/**
+ * The stable extractor-version stamp: `<model>+<prompt-hash>`. Persisted on
+ * each derived fact's metadata so the builder's NOT EXISTS guard can detect
+ * events that were extracted under an older model/prompt and re-extract them.
+ */
+export function factExtractorVersion(env: Env): string {
+  return `fact-extract-v1:${factExtractorModel(env)}+${FACT_EXTRACTION_PROMPT_HASH}`;
+}
+
+/** Cap on payload size handed to the model — controls cost and latency. */
+const MAX_INPUT_CHARS = 12_000;
+const REQUEST_TIMEOUT_MS = 30_000;
+
+interface ChatCompletionResponse {
+  choices?: Array<{ message?: { content?: string | null } }>;
+}
+
+/**
+ * Extract atomic facts from `text` via an OpenAI-compatible chat completion.
+ *
+ * Returns `[]` (no facts) when:
+ *  - no `FACT_EXTRACTOR_API_KEY` is configured (feature is opt-in), or
+ *  - the request fails / times out / returns no parseable lines.
+ *
+ * Callers treat `[]` as "nothing to derive" — the focused read path then
+ * falls back to raw `payload_text`.
+ */
+export async function extractFacts(text: string, env: Env): Promise<string[]> {
+  const apiKey = env.FACT_EXTRACTOR_API_KEY;
+  if (!apiKey) return [];
+
+  const trimmed = text.trim();
+  if (trimmed.length === 0) return [];
+  const input = trimmed.length > MAX_INPUT_CHARS ? trimmed.slice(0, MAX_INPUT_CHARS) : trimmed;
+
+  const baseUrl = (env.FACT_EXTRACTOR_BASE_URL || 'https://api.openai.com/v1').replace(/\/+$/, '');
+  const model = factExtractorModel(env);
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+  try {
+    const response = await fetch(`${baseUrl}/chat/completions`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify({
+        model,
+        temperature: 0,
+        messages: [
+          { role: 'system', content: FACT_EXTRACTION_PROMPT },
+          { role: 'user', content: input },
+        ],
+      }),
+      signal: controller.signal,
+    });
+
+    if (!response.ok) {
+      const detail = await response.text().catch(() => '');
+      logger.warn(
+        { status: response.status, detail: detail.slice(0, 200) },
+        '[fact-extractor] chat completion request failed'
+      );
+      return [];
+    }
+
+    const data = (await response.json()) as ChatCompletionResponse;
+    const content = data.choices?.[0]?.message?.content ?? '';
+    return parseFactLines(content);
+  } catch (err) {
+    logger.warn(
+      { err: err instanceof Error ? err.message : String(err) },
+      '[fact-extractor] extraction failed; returning no facts'
+    );
+    return [];
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
+ * Parse the model's line-per-fact output into clean fact strings. Drops empty
+ * lines, list numbering / bullet prefixes the model may add despite the prompt,
+ * and any obvious preamble line ("Here are the facts:").
+ */
+export function parseFactLines(raw: string): string[] {
+  return raw
+    .split('\n')
+    .map((line) =>
+      line
+        // strip leading bullet / numbering markers: "- ", "* ", "1. ", "2) "
+        .replace(/^\s*(?:[-*•]|\d+[.)])\s+/, '')
+        .trim()
+    )
+    .filter((line) => line.length > 0)
+    .filter((line) => !/^(?:here (?:are|is)\b|facts?:|the facts?\b)/i.test(line));
+}


### PR DESCRIPTION
Re: #1172. **Status: experimental, do NOT merge as a benchmark win — it isn't one yet.** Opt-in, default `false`, so it does not regress existing behavior.

## What this is

Infrastructure for server-side **focused retrieval**: an async, off-hot-path builder distills long raw events into derived `extracted_fact` events, and an opt-in `focused` flag on `read_knowledge` serves those facts instead of whole 10k–25k-char sessions. Mechanically complete, multi-replica-safe, tested.

## Honest benchmark result — it regresses, not improves

Validated on LongMemEval mixed-60 (the public [agent-memory-benchmark](https://github.com/lobu-ai/agent-memory-benchmark)), gemini LLM-judge, with the SAME extraction this feature ports:

| Category | Baseline (whole-session, 80%) | Focused | Δ |
| --- | --- | --- | --- |
| knowledge-update | 97 | 90 | −7 |
| multi-session | 70 | 50 | −20 |
| single-session-assistant | 90 | 40 | −50 |
| single-session-preference | 37 | 30 | −7 |
| single-session-user | 77 | 70 | −7 |
| temporal-reasoning | 100 | 60 | −40 |
| **Overall** | **80.0%** | **56.7%** | **−23** |

Recall stayed 95.6% (retrieval finds the right sessions). The regression is purely the shared answerer (glm-5.1) reasoning **better over lossless whole sessions than over lossy extracted facts**. Supermemory's 85% shows focused retrieval *can* beat whole-session, but only with near-lossless, well-targeted extraction. The extraction ported here drops assistant content (ss-assistant −50), temporal framing (temporal −40), and aggregation detail (multi-session −20).

**This is an extraction-quality problem, not an infrastructure one.** The read-path + async-builder machinery here is correct and reusable; it just needs an extractor good enough to not lose what the answerer needs.

## Engineering quality (independent of the benchmark verdict)

- `make review`: bug_free 78, 0 blockers, slop 0 after two fix rounds; the reviewer independently reran the new integration test 7/7.
- Integration test against real embedded PG (7 tests): builder stamp/links/inheritance, focused vs raw, exclusion on list+count+score branches, escape hatch, idempotency, version-bump (version-filtered focused read).
- Multi-replica-safe: builder runs inline under the runs-queue claim (one replica/tick) + NOT EXISTS idempotency; `<model>+<prompt-hash>` version stamp for controlled rebuilds.
- Real-LLM extractor smoke validated (OpenAI-compatible shape, clean line-per-fact output).
- The 3 failing suite tests are pre-existing `HOSTED_UI_FALLBACK_ORIGIN`/mcp-proxy env failures in untouched files, not this change.

## Recommendation

Hold as a draft. Don't merge until an extractor is demonstrated to beat the 80% whole-session baseline on the public benchmark. The honest current standing — Lobu a strong second at 80% via the fair retrieval fixes (already in the benchmark repo) — stands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)