### PR TITLE
feat(auth): global login-provider baseline; drop default-org pointer

### DIFF
--- a/packages/server/src/auth/__tests__/config.baseline.integration.test.ts
+++ b/packages/server/src/auth/__tests__/config.baseline.integration.test.ts
@@ -1,0 +1,130 @@
+/**
+ * Integration test for the global login-provider baseline.
+ *
+ * Reproduces the original symptom — an org-scoped login page (resolved from a
+ * `/market/...` callback) returned `social: {}` while the default login page
+ * showed Google/GitHub — and proves the fix: every deployment exposes the
+ * baseline providers (those with env credentials) regardless of org context,
+ * with no AUTH_DEFAULT_ORGANIZATION_SLUG pointer.
+ *
+ * Unlike config.test.ts, this does NOT mock the catalog or the DB: it scans the
+ * real bundled connector catalog (via the prebuilt manifest) and uses the
+ * embedded-Postgres test database. It therefore exercises the actual
+ * catalog → collect → merge → credential-gate path end to end.
+ */
+
+import { resolve } from 'node:path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { getTestDb } from '../../__tests__/setup/test-db';
+import { createTestOrganization } from '../../__tests__/setup/test-fixtures';
+import type { Env } from '../../index';
+import {
+  clearLoginProviderCachesForTests,
+  getAuthConfig,
+  getEnabledLoginProviderConfigs,
+} from '../config';
+
+// Point at the bundled connectors that ship a `.catalog-manifest.json`, so the
+// scan is a fast manifest lookup instead of compiling every connector.
+const DIST_CONNECTORS = resolve(__dirname, '../../../dist/connectors');
+
+// Dummy credentials are enough: getAuthConfig only needs clientId + clientSecret
+// to *resolve* for a provider to be marked enabled — it never calls the IdP here.
+const ENV = {
+  GOOGLE_CLIENT_ID: 'test-google-id',
+  GOOGLE_CLIENT_SECRET: 'test-google-secret',
+  GITHUB_CLIENT_ID: 'test-github-id',
+  GITHUB_CLIENT_SECRET: 'test-github-secret',
+} as unknown as Env;
+
+describe('login provider baseline (integration)', () => {
+  let prevCatalogUris: string | undefined;
+
+  beforeAll(() => {
+    prevCatalogUris = process.env.CONNECTOR_CATALOG_URIS;
+    process.env.CONNECTOR_CATALOG_URIS = DIST_CONNECTORS;
+    clearLoginProviderCachesForTests();
+  });
+
+  afterAll(() => {
+    if (prevCatalogUris === undefined) delete process.env.CONNECTOR_CATALOG_URIS;
+    else process.env.CONNECTOR_CATALOG_URIS = prevCatalogUris;
+    clearLoginProviderCachesForTests();
+  });
+
+  it('exposes baseline providers with no org context (the default login page)', async () => {
+    const config = await getAuthConfig(ENV, { organizationId: null });
+    expect(config.social.google).toBe(true);
+    expect(config.social.github).toBe(true);
+  });
+
+  it('exposes the SAME baseline for an org with no login_enabled connectors (the /market case)', async () => {
+    // An org id that has no rows in connector_definitions — exactly the state
+    // that previously produced `social: {}`. It must now inherit the baseline.
+    const config = await getAuthConfig(ENV, { organizationId: 'org-with-no-login-connectors' });
+    expect(config.social.google).toBe(true);
+    expect(config.social.github).toBe(true);
+  });
+
+  it('hides providers whose credentials are absent (no silent enable)', async () => {
+    // Only Google creds present → GitHub must not appear.
+    const googleOnly = {
+      GOOGLE_CLIENT_ID: 'test-google-id',
+      GOOGLE_CLIENT_SECRET: 'test-google-secret',
+    } as unknown as Env;
+    const config = await getAuthConfig(googleOnly, { organizationId: null });
+    expect(config.social.google).toBe(true);
+    expect(config.social.github).toBeUndefined();
+  });
+
+  it('unions an org-specific login connector on top of the baseline (real DB)', async () => {
+    const org = await createTestOrganization();
+    const sql = getTestDb();
+    // A login-enabled connector for a provider NOT in the bundled catalog,
+    // scoped to this org. It must be additive — baseline providers survive.
+    await sql`
+      INSERT INTO connector_definitions (key, name, version, auth_schema, organization_id, status, login_enabled, created_at, updated_at)
+      VALUES (
+        'acme.sso',
+        'Acme SSO',
+        '1.0.0',
+        ${sql.json({ methods: [{ type: 'oauth', provider: 'acme', loginScopes: ['openid'] }] })},
+        ${org.id},
+        'active',
+        true,
+        NOW(), NOW()
+      )
+    `;
+    clearLoginProviderCachesForTests();
+
+    const providers = (await getEnabledLoginProviderConfigs(org.id)).map((c) => c.provider);
+    expect(providers).toContain('acme'); // org-specific, additive
+    expect(providers).toContain('google'); // baseline preserved
+    expect(providers).toContain('github'); // baseline preserved
+  });
+
+  it('lets an org override a baseline provider with its own connector key (real DB)', async () => {
+    const org = await createTestOrganization();
+    const sql = getTestDb();
+    // Org brings its own `google` login connector — it must shadow the baseline
+    // google entry (same provider, org's connectorKey wins).
+    await sql`
+      INSERT INTO connector_definitions (key, name, version, auth_schema, organization_id, status, login_enabled, created_at, updated_at)
+      VALUES (
+        'org.google',
+        'Org Google',
+        '1.0.0',
+        ${sql.json({ methods: [{ type: 'oauth', provider: 'google', loginScopes: ['openid', 'email'] }] })},
+        ${org.id},
+        'active',
+        true,
+        NOW(), NOW()
+      )
+    `;
+    clearLoginProviderCachesForTests();
+
+    const configs = await getEnabledLoginProviderConfigs(org.id);
+    const google = configs.find((c) => c.provider === 'google');
+    expect(google?.connectorKey).toBe('org.google');
+  });
+});

--- a/packages/server/src/auth/__tests__/config.test.ts
+++ b/packages/server/src/auth/__tests__/config.test.ts
@@ -1,5 +1,12 @@
 /**
- * Auth Config Tests
+ * Auth Config — pure helper unit tests.
+ *
+ * These cover the side-effect-free logic only (scope extraction, provider
+ * collection, baseline↔org merge). The catalog/DB-backed paths
+ * (getBaselineLoginProviderConfigs, getEnabledLoginProviderConfigs, getAuthConfig)
+ * are exercised against the real catalog + embedded Postgres in
+ * config.baseline.integration.test.ts — mocking those modules is unreliable here
+ * because the suite runs with `isolate: false` (shared module registry).
  */
 
 import { afterEach, describe, expect, it, vi } from 'vitest';
@@ -7,6 +14,7 @@ import {
   collectEnabledLoginProviderConfigs,
   getAuthConfig,
   getLoginProviderScopes,
+  mergeLoginProviderConfigs,
 } from '../config';
 
 describe('login provider helpers', () => {
@@ -115,11 +123,93 @@ describe('login provider helpers', () => {
     ]);
     expect(warnSpy).toHaveBeenCalled();
   });
+
+  it('quiet mode suppresses the no-scope / multi-connector warnings (catalog baseline)', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const configs = collectEnabledLoginProviderConfigs(
+      [
+        {
+          key: 'google.calendar',
+          auth_schema: {
+            methods: [{ type: 'oauth', provider: 'google', loginScopes: ['openid', 'email'] }],
+          },
+        },
+        {
+          // Same provider via a second connector — would warn without quiet.
+          key: 'google.gmail',
+          auth_schema: {
+            methods: [{ type: 'oauth', provider: 'google', loginScopes: ['openid', 'email'] }],
+          },
+        },
+        {
+          // OAuth but no login scopes — would warn without quiet.
+          key: 'reddit',
+          auth_schema: {
+            methods: [{ type: 'oauth', provider: 'reddit', requiredScopes: ['read'] }],
+          },
+        },
+      ],
+      { quiet: true }
+    );
+
+    expect(configs.map((c) => c.provider)).toEqual(['google']);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe('mergeLoginProviderConfigs', () => {
+  const baselineGoogle = {
+    connectorKey: 'google.gmail',
+    provider: 'google',
+    loginScopes: ['openid', 'email', 'profile'],
+    clientIdKey: 'GOOGLE_CLIENT_ID',
+    clientSecretKey: 'GOOGLE_CLIENT_SECRET',
+  };
+  const baselineGithub = {
+    connectorKey: 'github.issues',
+    provider: 'github',
+    loginScopes: ['read:user'],
+    clientIdKey: 'GITHUB_CLIENT_ID',
+    clientSecretKey: 'GITHUB_CLIENT_SECRET',
+  };
+
+  it('returns the baseline unchanged when the org adds nothing', () => {
+    expect(mergeLoginProviderConfigs([baselineGoogle, baselineGithub], [])).toEqual([
+      baselineGoogle,
+      baselineGithub,
+    ]);
+  });
+
+  it('is additive — an org-only provider is appended, the baseline is never dropped', () => {
+    const orgOnly = {
+      connectorKey: 'okta.sso',
+      provider: 'okta',
+      loginScopes: ['openid'],
+      clientIdKey: 'OKTA_CLIENT_ID',
+      clientSecretKey: 'OKTA_CLIENT_SECRET',
+    };
+    const merged = mergeLoginProviderConfigs([baselineGoogle], [orgOnly]);
+    expect(merged).toEqual([baselineGoogle, orgOnly]);
+  });
+
+  it('lets an org override the baseline for the same provider (BYO OAuth app)', () => {
+    const orgGoogle = {
+      connectorKey: 'org.google',
+      provider: 'google',
+      loginScopes: ['openid', 'email'],
+      clientIdKey: 'ORG_GOOGLE_ID',
+      clientSecretKey: 'ORG_GOOGLE_SECRET',
+    };
+    const merged = mergeLoginProviderConfigs([baselineGoogle, baselineGithub], [orgGoogle]);
+    // google is replaced by the org config; github (baseline) survives.
+    expect(merged).toEqual([orgGoogle, baselineGithub]);
+  });
 });
 
 describe('getAuthConfig', () => {
   it('should be an async function', () => {
-    const result = getAuthConfig({} as any);
+    const result = getAuthConfig({} as never);
     result.catch(() => {});
     expect(result).toBeInstanceOf(Promise);
   });
@@ -127,11 +217,4 @@ describe('getAuthConfig', () => {
   it('should export getAuthConfig function', () => {
     expect(typeof getAuthConfig).toBe('function');
   });
-
-  // Full integration tests with a real database connection should still verify:
-  // - OAuth providers enabled when login_enabled=true in DB and credentials in env
-  // - Magic link enabled with RESEND_API_KEY
-  // - Phone auth enabled with Twilio credentials
-  // - Email/password fallback logic
-  // - AUTH_DEFAULT_ORGANIZATION_SLUG fallback when no org context
 });

--- a/packages/server/src/auth/config.ts
+++ b/packages/server/src/auth/config.ts
@@ -1,6 +1,7 @@
 import { getDb } from '../db/client';
 import type { Env } from '../index';
 import { getPrimaryAuthProfileForKind, normalizeAuthValues } from '../utils/auth-profiles';
+import { listCatalogConnectorDefinitions } from '../utils/connector-catalog';
 import { TtlCache } from '../utils/ttl-cache';
 import { safeParseUrl } from './base-url';
 
@@ -92,7 +93,13 @@ function getOAuthMethodsFromSchema(
 }
 
 export function collectEnabledLoginProviderConfigs(
-  rows: LoginProviderConfigRow[]
+  rows: LoginProviderConfigRow[],
+  // The catalog-derived baseline scans EVERY bundled connector, so it expects to
+  // see OAuth connectors without login scopes (e.g. read-only feed connectors)
+  // and several connectors per provider (calendar/gmail/youtube all = google).
+  // Those are normal there, not misconfiguration — `quiet` suppresses the warns
+  // that are only meaningful for an explicit per-org `login_enabled` set.
+  options: { quiet?: boolean } = {}
 ): EnabledLoginProviderConfig[] {
   const configs: EnabledLoginProviderConfig[] = [];
   const seenProviders = new Map<string, string>();
@@ -109,15 +116,17 @@ export function collectEnabledLoginProviderConfigs(
 
       const loginScopes = getLoginProviderScopes(provider, method.loginScopes);
       if (!loginScopes || loginScopes.length === 0) {
-        console.warn(
-          `[Auth] Ignoring login-enabled connector '${connectorKey}' for unsupported provider '${provider}'.`
-        );
+        if (!options.quiet) {
+          console.warn(
+            `[Auth] Ignoring login-enabled connector '${connectorKey}' for unsupported provider '${provider}'.`
+          );
+        }
         continue;
       }
 
       const existingConnectorKey = seenProviders.get(provider);
       if (existingConnectorKey) {
-        if (existingConnectorKey !== connectorKey) {
+        if (existingConnectorKey !== connectorKey && !options.quiet) {
           console.warn(
             `[Auth] Multiple login-enabled connectors configured for provider '${provider}'. ` +
               `Using '${existingConnectorKey}' and ignoring '${connectorKey}'.`
@@ -271,40 +280,79 @@ export async function resolveLoginProviderCredentials(params: {
 }
 
 /**
- * Get enabled OAuth login provider configs from connector_definitions.
+ * Global baseline login providers.
  *
- * When organizationId is null (e.g. login page without org context),
- * falls back to AUTH_DEFAULT_ORGANIZATION_SLUG if configured.
+ * Every bundled connector that declares `loginScopes` is a login candidate on
+ * every deployment, independent of any organization. Whether a candidate
+ * actually renders is decided downstream by credential resolution (env vars or
+ * an org's OAuth-app auth profile) — see getAuthConfig / createAuth.
+ *
+ * This is the connector-owned model applied globally: core still never assumes
+ * scopes for a provider (the connector declares them), it just no longer needs
+ * a designated "default org" to carry the standard providers. The old
+ * AUTH_DEFAULT_ORGANIZATION_SLUG pointer — and the silent empty-provider page
+ * for any org that hadn't enabled its own connectors — are gone.
  */
 const loginProviderCache = new TtlCache<EnabledLoginProviderConfig[]>(60_000);
-const defaultOrgCache = new TtlCache<string | null>(60_000);
+const baselineProviderCache = new TtlCache<EnabledLoginProviderConfig[]>(60_000);
+const BASELINE_CACHE_KEY = '__baseline__';
 
-export async function resolveDefaultOrganizationId(): Promise<string | null> {
-  const defaultSlug = process.env.AUTH_DEFAULT_ORGANIZATION_SLUG;
-  if (!defaultSlug) return null;
-  const cached = defaultOrgCache.get(defaultSlug);
-  if (cached !== undefined) return cached;
-  const db = getDb();
-  const rows = await db`SELECT id FROM "organization" WHERE slug = ${defaultSlug} LIMIT 1`;
-  const id = rows.length > 0 ? String((rows[0] as { id: string }).id) : null;
-  defaultOrgCache.set(defaultSlug, id);
-  return id;
+/**
+ * Drop the cached baseline + per-org provider configs. Tests that vary the
+ * catalog or org connector rows between cases must call this, or a stale 60s
+ * cache entry serves the wrong set.
+ */
+export function clearLoginProviderCachesForTests(): void {
+  loginProviderCache.clear();
+  baselineProviderCache.clear();
+}
+
+export async function getBaselineLoginProviderConfigs(): Promise<EnabledLoginProviderConfig[]> {
+  const cached = baselineProviderCache.get(BASELINE_CACHE_KEY);
+  if (cached) return cached;
+
+  // Same catalog source the connector picker uses (manage_connections passes
+  // env.CONNECTOR_CATALOG_URIS); defaults to the bundled connectors next to the
+  // server, which ship a prebuilt manifest so this is a cheap lookup, not a
+  // cold compile of every connector.
+  const defs = await listCatalogConnectorDefinitions(process.env.CONNECTOR_CATALOG_URIS);
+  const rows: LoginProviderConfigRow[] = defs.map((def) => ({
+    key: def.key,
+    auth_schema: (def.auth_schema as LoginProviderConfigRow['auth_schema']) ?? null,
+  }));
+  const configs = collectEnabledLoginProviderConfigs(rows, { quiet: true });
+
+  baselineProviderCache.set(BASELINE_CACHE_KEY, configs);
+  return configs;
+}
+
+/**
+ * Merge org-specific login providers onto the global baseline. An org bringing
+ * its own OAuth app for a provider (e.g. `google`) shadows the global one for
+ * that provider; everything else is additive. The union guarantees a branded
+ * org login page can never silently end up with *fewer* providers than the
+ * default — it can only add. (Narrowing to org-only — enterprise SSO-only mode
+ * — would be a future explicit flag, deliberately not inferred here.)
+ */
+export function mergeLoginProviderConfigs(
+  baseline: EnabledLoginProviderConfig[],
+  orgConfigs: EnabledLoginProviderConfig[]
+): EnabledLoginProviderConfig[] {
+  const byProvider = new Map<string, EnabledLoginProviderConfig>();
+  for (const config of baseline) byProvider.set(config.provider, config);
+  for (const config of orgConfigs) byProvider.set(config.provider, config);
+  return Array.from(byProvider.values());
 }
 
 export async function getEnabledLoginProviderConfigs(
   organizationId?: string | null
 ): Promise<EnabledLoginProviderConfig[]> {
-  let effectiveOrgId = organizationId ?? null;
+  const baseline = await getBaselineLoginProviderConfigs();
+  const orgId = organizationId ?? null;
+  if (!orgId) return baseline;
 
-  if (!effectiveOrgId) {
-    effectiveOrgId = await resolveDefaultOrganizationId();
-  }
-
-  if (!effectiveOrgId) return [];
-
-  const cacheKey = effectiveOrgId;
-  const cached = loginProviderCache.get(cacheKey);
-  if (cached) return cached;
+  const cached = loginProviderCache.get(orgId);
+  if (cached) return mergeLoginProviderConfigs(baseline, cached);
 
   const db = getDb();
   const rows = await db`
@@ -312,13 +360,13 @@ export async function getEnabledLoginProviderConfigs(
     FROM connector_definitions
     WHERE login_enabled = true
       AND status = 'active'
-      AND organization_id = ${effectiveOrgId}
+      AND organization_id = ${orgId}
     ORDER BY key ASC
   `;
-  const configs = collectEnabledLoginProviderConfigs(rows as LoginProviderConfigRow[]);
+  const orgConfigs = collectEnabledLoginProviderConfigs(rows as LoginProviderConfigRow[]);
 
-  loginProviderCache.set(cacheKey, configs);
-  return configs;
+  loginProviderCache.set(orgId, orgConfigs);
+  return mergeLoginProviderConfigs(baseline, orgConfigs);
 }
 
 /**
@@ -328,13 +376,10 @@ export async function getAuthConfig(
   env: Env,
   options: AuthConfigOptions = {}
 ): Promise<AuthConfig> {
-  let organizationId =
+  const organizationId =
     options.organizationId !== undefined
       ? options.organizationId
       : ((await resolveRequestOrganizationId(options.request)) ?? null);
-  if (!organizationId) {
-    organizationId = await resolveDefaultOrganizationId();
-  }
   const providerConfigs = await getEnabledLoginProviderConfigs(organizationId);
   const runtimeNodeEnv = env.NODE_ENV || process.env.NODE_ENV || 'development';
   const isProduction = runtimeNodeEnv === 'production';

--- a/packages/server/src/auth/index.tsx
+++ b/packages/server/src/auth/index.tsx
@@ -38,7 +38,6 @@ import { resolveBaseUrl, safeParseUrl } from "./base-url";
 import {
 	getAuthConfig as getAuthConfigFromEnv,
 	getEnabledLoginProviderConfigs,
-	resolveDefaultOrganizationId,
 	resolveLoginProviderCredentials,
 	resolveRequestOrganizationId,
 } from "./config";
@@ -100,9 +99,7 @@ export async function createAuth(env: Env, request?: Request) {
 	});
 	const runtimeNodeEnv = env.NODE_ENV || process.env.NODE_ENV || "development";
 
-	const effectiveOrgId =
-		organizationId ?? (await resolveDefaultOrganizationId());
-	const providerRows = await getEnabledLoginProviderConfigs(effectiveOrgId);
+	const providerRows = await getEnabledLoginProviderConfigs(organizationId);
 
 	// Build dynamic social providers from enabled connectors
 	const socialProviders: Record<
@@ -118,7 +115,7 @@ export async function createAuth(env: Env, request?: Request) {
 			connectorKey: row.connectorKey,
 			clientIdKey: row.clientIdKey,
 			clientSecretKey: row.clientSecretKey,
-			organizationId: effectiveOrgId,
+			organizationId,
 		});
 		const clientId = credentials.clientId ?? "";
 		const clientSecret = credentials.clientSecret ?? "";


### PR DESCRIPTION
## Problem

Login providers were resolved per-organization, and `AUTH_DEFAULT_ORGANIZATION_SLUG` pointed at one org whose `login_enabled` connectors acted as the default set for the no-org login page. Any org **without** its own enabled connectors got `social: {}` — a branded `/{org}` login page silently lost every OAuth button.

Repro (prod): `GET /api/auth-config?callbackUrl=%2Fmarket%2Fconnectors` → `{"social":{}}` while the bare endpoint returned `{github,google,linkedin,twitter}`.

## Change

Consolidate to a **global baseline**: every bundled connector that declares `loginScopes` is a login candidate on every deployment (still connector-owned — core never assumes scopes), gated downstream by whether the deployment has that provider's credentials (env var, or the request org's `oauth_app` profile). Per-org connectors **merge on top** of the baseline — additive, with an org's own provider overriding the baseline for that provider. A branded org login page can now only *add* providers, never silently show fewer than the default.

- `getBaselineLoginProviderConfigs()` — reads the bundled connector catalog (manifest-backed; same source as the connector picker).
- `mergeLoginProviderConfigs()` — baseline ∪ org, org wins per provider.
- `getEnabledLoginProviderConfigs()` — baseline (no org) or the merge.
- Removed `resolveDefaultOrganizationId` + the `AUTH_DEFAULT_ORGANIZATION_SLUG` read in `config.ts` and `createAuth` (`index.tsx`).
- `collectEnabledLoginProviderConfigs` gains `quiet` (the catalog scan legitimately has many connectors per provider; the per-org misconfig warnings are noise there).

## Tests

- Pure helpers (collect / scopes / merge) — unit.
- `config.baseline.integration.test.ts` — real bundled catalog + embedded Postgres: reproduces the `/market` empty-page symptom, and proves baseline, org union, per-provider override, and credential gating.
- Full `src/auth/` suite green (8 files / 127 tests); `tsc --noEmit` clean.

## Deploy ordering (important)

1. **Done:** `LINKEDIN_CLIENT_ID/SECRET` added to prod env — lobu-ai/owletto#256 (merged). LinkedIn's creds previously lived only in the `app` org's `oauth_app` profile, so without env it would drop from the default page under the baseline.
2. This PR ships → baseline goes live with all four providers (github/google/twitter from existing env, linkedin from the new env).
3. **Follow-up:** `AUTH_DEFAULT_ORGANIZATION_SLUG` is now inert; remove it from the prod kustomization in a separate owletto PR *after* this is live (removing it against the old code would re-introduce the empty page).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1183"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783159473&installation_id=136316292&pr_number=1183&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1183&signature=05ce4dc423df2bab4d2c4b292cbbbe1aca023eb885b0e3cc2aadb88eb5dc051a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced authentication configuration to support baseline login providers alongside organization-specific customizations.
  * Organizations can now override global login provider settings with their own connectors.

* **Bug Fixes**
  * Fixed login provider logic to prevent silently enabling providers without valid credentials.

* **Tests**
  * Added comprehensive integration tests for baseline login provider behavior.
  * Added unit tests for login provider merging and quiet mode functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->