### PR TITLE
fix(sdk): correct search_sdk metadata + validate viewTemplates args

### DIFF
--- a/packages/server/src/__tests__/unit/tools/manage-view-templates-validation.test.ts
+++ b/packages/server/src/__tests__/unit/tools/manage-view-templates-validation.test.ts
@@ -1,0 +1,130 @@
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { manageViewTemplates } from "../../../tools/admin/manage_view_templates";
+import { closeDbSingleton } from "../../../db/client";
+import { ToolUserError } from "../../../utils/errors";
+import type { ToolContext } from "../../../tools/registry";
+
+/**
+ * Unit guard for the viewTemplates SDK path. A bad-shaped `get` call
+ * (`{ resource: 'entity' }` instead of `{ resource_type, resource_id }`) used to
+ * reach Postgres as `WHERE id = Number(undefined)` → `NaN` → a raw
+ * `invalid input syntax for type bigint: "NaN"` error, because neither the SDK
+ * namespace dispatcher (action-call.ts) nor the REST/registry path
+ * (execute.ts only validates query_sdk/run_sdk) runs the TypeBox schema before
+ * the handler. The handler now rejects the bad shape with a clean ToolUserError
+ * BEFORE any DB query, so this test needs no live Postgres: the guard fires
+ * before the (lazy) postgres.js client ever connects.
+ */
+
+// Point at a refused port so any query that *does* slip past the guard fails
+// fast (ECONNREFUSED) instead of hanging — and never touches a real database.
+const ORIGINAL_DATABASE_URL = process.env.DATABASE_URL;
+
+const ctx: ToolContext = {
+  organizationId: "test-org",
+  userId: "test-user",
+  memberRole: "owner",
+  isAuthenticated: true,
+  tokenType: "oauth",
+  scopedToOrg: false,
+  allowCrossOrg: true,
+};
+
+beforeAll(async () => {
+  // Reset any singleton built from a real URL, then bind a non-connecting one.
+  await closeDbSingleton();
+  process.env.DATABASE_URL = "postgres://localhost:1/none";
+});
+
+afterAll(async () => {
+  await closeDbSingleton();
+  if (ORIGINAL_DATABASE_URL === undefined) {
+    delete process.env.DATABASE_URL;
+  } else {
+    process.env.DATABASE_URL = ORIGINAL_DATABASE_URL;
+  }
+});
+
+describe("manage_view_templates arg validation", () => {
+  it("rejects a missing resource_type/resource_id with a clean ToolUserError (no Postgres NaN)", async () => {
+    let caught: unknown;
+    try {
+      // The exact bad shape from the audit: `{ resource: 'entity' }`.
+      await manageViewTemplates(
+        { action: "get", resource: "entity" } as never,
+        undefined,
+        ctx,
+      );
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(ToolUserError);
+    const message = (caught as Error).message;
+    expect(message).toMatch(/resource_type/);
+    // Must NOT be the raw Postgres error.
+    expect(message).not.toMatch(/NaN/);
+    expect(message).not.toMatch(/invalid input syntax/);
+  });
+
+  it("rejects a non-numeric resource_id on the entity branch with a clean ToolUserError", async () => {
+    let caught: unknown;
+    try {
+      await manageViewTemplates(
+        { action: "get", resource_type: "entity", resource_id: "not-a-number" } as never,
+        undefined,
+        ctx,
+      );
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(ToolUserError);
+    const message = (caught as Error).message;
+    expect(message).toMatch(/resource_id/);
+    expect(message).not.toMatch(/NaN/);
+    expect(message).not.toMatch(/invalid input syntax/);
+  });
+
+  it("rejects entity_type get with a missing resource_id before any DB query", async () => {
+    // entity_type stringifies a missing resource_id to the literal "undefined"
+    // and would query `WHERE slug = 'undefined'`; the up-front presence guard
+    // must reject it handler-side instead of reaching the DB (ECONNREFUSED here).
+    let caught: unknown;
+    try {
+      await manageViewTemplates(
+        { action: "get", resource_type: "entity_type" } as never,
+        undefined,
+        ctx,
+      );
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(ToolUserError);
+    const message = (caught as Error).message;
+    expect(message).toMatch(/resource_id/);
+    // Proves the guard fired before the (non-connecting) DB client was used.
+    expect(message).not.toMatch(/ECONNREFUSED/);
+    expect(message).not.toMatch(/connect/i);
+  });
+
+  it("accepts a well-shaped get and passes the guard through to the DB layer", async () => {
+    // A valid shape must NOT be rejected by the guard. With no reachable DB the
+    // call fails at the connection layer, which proves validation passed: the
+    // error is a DB/connection error, NOT our ToolUserError validation error.
+    let caught: unknown;
+    try {
+      await manageViewTemplates(
+        { action: "get", resource_type: "entity", resource_id: 42 } as never,
+        undefined,
+        ctx,
+      );
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeDefined();
+    expect(caught).not.toBeInstanceOf(ToolUserError);
+    const message = (caught as Error).message;
+    // Whatever the DB-layer failure is, it must not be the old NaN bigint error
+    // (that would mean a bad value reached the query unguarded).
+    expect(message).not.toMatch(/invalid input syntax for type bigint: "NaN"/);
+  });
+});

--- a/packages/server/src/sandbox/method-metadata.ts
+++ b/packages/server/src/sandbox/method-metadata.ts
@@ -95,10 +95,12 @@ export default async (_ctx, client) => {
     access: "read",
   },
   "entities.search": {
-    summary: "Fuzzy search entities by name, optionally filtered by type.",
+    summary:
+      "Fuzzy search entities by name. POSITIONAL signature: search(query: string, options?: { limit?: number }). The query is the first positional argument — passing an object like { query: '...' } throws (the handler calls query.slice).",
     access: "read",
     example: "const hits = await client.entities.search('acme', { limit: 5 });",
     usageExample: `// Resolve a free-text mention into entity ids before linking knowledge to it.
+// First arg is the query string; second is options. Do NOT pass { query }.
 export default async (_ctx, client) => {
   return client.entities.search('Acme', { limit: 5 });
 };`,
@@ -118,8 +120,11 @@ export default async (_ctx, client) => {
     access: "read",
   },
   "entitySchema.createType": {
-    summary: "Create an entity type.",
+    summary:
+      "Create an entity type. The metadata shape goes in `metadata_schema` (a JSON Schema), NOT `properties` — a top-level `properties` key is silently ignored.",
     access: "write",
+    example:
+      "await client.entitySchema.createType({ slug: 'widget', name: 'Widget', metadata_schema: { type: 'object', properties: { color: { type: 'string' } } } });",
   },
   "entitySchema.updateType": {
     summary: "Update an entity type.",
@@ -246,17 +251,27 @@ export default async (ctx, client) => {
     throws: ["WatcherNotFound"],
   },
   "watchers.create": {
-    summary: "Create a watcher with prompt, extraction schema, and sources.",
+    summary:
+      "Create a watcher. REQUIRES slug, prompt, agent_id (the executing agent — a watcher without one is a zombie row), and extraction_schema as a FULL JSON Schema (top-level `type: 'object'` + `properties`). Each sources[].query must be a read-only SELECT/WITH projecting an `id` column (it runs against org-scoped virtual tables, NOT a URL). entity_id is optional (omit for an org-scoped watcher).",
     access: "write",
     throws: ["EntityNotFound", "InvalidExtractionSchema"],
-    example: "await client.watchers.create({ entity_id: 42, prompt: '...', extraction_schema: {...} });",
-    usageExample: `// Stand up a watcher that extracts pricing facts from a customer's site.
+    example:
+      "await client.watchers.create({ slug: 'pricing', agent_id: 'agt_123', prompt: 'Extract pricing from {{content}}.', extraction_schema: { type: 'object', properties: { price: { type: 'number' } } }, sources: [{ name: 'content', query: 'SELECT id, content FROM events ORDER BY occurred_at DESC' }] });",
+    usageExample: `// Stand up a watcher that extracts pricing facts from recent events.
+// extraction_schema is a FULL JSON Schema; sources[].query is a read-only
+// SELECT projecting \`id\` (a URL here would be rejected).
 export default async (_ctx, client) => {
   return client.watchers.create({
-    entity_id: 42,
-    prompt: 'Extract current pricing.',
-    extraction_schema: { price: { type: 'number' } },
-    sources: [{ name: 'home', query: 'https://example.com/pricing' }],
+    slug: 'pricing-watcher',
+    agent_id: 'agt_123', // the agent that executes this watcher (required)
+    prompt: 'Extract current pricing from {{content}}.',
+    extraction_schema: {
+      type: 'object',
+      properties: { price: { type: 'number' } },
+    },
+    sources: [
+      { name: 'content', query: 'SELECT id, content FROM events ORDER BY occurred_at DESC' },
+    ],
   });
 };`,
   },
@@ -508,12 +523,18 @@ export default async (_ctx, client) => {
     access: "write",
   },
   "viewTemplates.get": {
-    summary: "Get the active view template for a resource.",
+    summary:
+      "Get the active view template for a resource. Params: { resource_type: 'entity' | 'entity_type', resource_id, tab_name? } — resource_id is the entity id (number) for resource_type 'entity', or the entity-type slug (string) for 'entity_type'. Both resource_type and resource_id are required.",
     access: "read",
+    example:
+      "await client.viewTemplates.get({ resource_type: 'entity', resource_id: 42 });",
   },
   "viewTemplates.set": {
-    summary: "Create or update a view template.",
+    summary:
+      "Create or update a view template version. Params: { resource_type: 'entity' | 'entity_type', resource_id, json_template, tab_name?, tab_order?, change_notes? }. json_template may nest a `data_sources` key of named read-only SQL queries.",
     access: "write",
+    example:
+      "await client.viewTemplates.set({ resource_type: 'entity', resource_id: 42, json_template: { layout: 'overview' } });",
   },
   "viewTemplates.rollback": {
     summary: "Roll back to a previous template version.",

--- a/packages/server/src/tools/admin/manage_view_templates.ts
+++ b/packages/server/src/tools/admin/manage_view_templates.ts
@@ -10,6 +10,7 @@ import { getDb } from '../../db/client';
 import { emit } from '../../events/emitter';
 import { validateDataSourceQuery } from '../../utils/execute-data-sources';
 import { resolveUsernames } from '../../utils/resolve-usernames';
+import { ToolUserError } from '../../utils/errors';
 import type { ToolContext } from '../registry';
 import { routeAction } from './action-router';
 
@@ -148,6 +149,34 @@ async function verifyAccess(
   if (requireWrite && !ctx.userId) throw new Error('Authentication required');
 
   const rt = args.resource_type;
+
+  // Neither the SDK namespace path (action-call.ts) nor the REST/registry path
+  // (execute.ts only TypeBox-validates query_sdk/run_sdk) validates these args
+  // before the handler runs, so a missing/wrong-shaped call (e.g.
+  // `{ resource: 'entity' }`) reaches here with resource_type/resource_id
+  // undefined. For the entity branch that meant `WHERE id = Number(undefined)`
+  // → NaN → a raw `invalid input syntax for type bigint: "NaN"` Postgres error.
+  // Reject the bad shape with a clean ToolUserError instead.
+  if (rt !== 'entity_type' && rt !== 'entity') {
+    throw new ToolUserError(
+      `resource_type is required and must be 'entity' or 'entity_type' (got ${JSON.stringify(rt)})`
+    );
+  }
+
+  // Both branches below dereference resource_id; a missing one must fail
+  // handler-side, not reach the DB. (entity_type stringifies undefined to the
+  // literal "undefined" and queries by slug; entity coerces to NaN — both are
+  // rejected here so every shape fails consistently before any query.)
+  if (
+    args.resource_id === undefined ||
+    args.resource_id === null ||
+    String(args.resource_id).trim() === ''
+  ) {
+    throw new ToolUserError(
+      `resource_id is required (got ${JSON.stringify(args.resource_id)})`
+    );
+  }
+
   const id = rid(args);
 
   if (rt === 'entity_type') {
@@ -165,9 +194,15 @@ async function verifyAccess(
   }
 
   // entity
+  const numericId = Number(id);
+  if (!Number.isFinite(numericId)) {
+    throw new ToolUserError(
+      `resource_id must be a numeric entity id for resource_type 'entity' (got ${JSON.stringify(args.resource_id)})`
+    );
+  }
   const rows = await sql`
     SELECT id FROM entities
-    WHERE id = ${Number(id)} AND organization_id = ${ctx.organizationId}
+    WHERE id = ${numericId} AND organization_id = ${ctx.organizationId}
     LIMIT 1
   `;
   if (rows.length === 0) throw new Error(`Entity ${id} not found`);


### PR DESCRIPTION
## Why

An e2e pass over the MCP/SDK surface turned up two developer-experience defects that make connected clients fail in confusing ways.

## What

**1. `search_sdk` discovery metadata was thin or wrong** (`packages/server/src/sandbox/method-metadata.ts`). Callers had to read source to call methods correctly; one example was actively misleading. Corrected against the live validators/handlers:
- `watchers.create` — replaced the wrong `{entity_id, prompt, shorthand-schema, URL-source}` example with a correct one: `slug`, `agent_id`, full-JSON-Schema `extraction_schema`, `sources[].query` as a read-only `SELECT` projecting `id`.
- `entities.search` — documented the positional `search(query, options)` signature (passing `{query}` throws `args.query.slice is not a function`).
- `entitySchema.createType` — uses `metadata_schema`, not `properties`.
- `viewTemplates.get`/`set` — added the real param names.

**2. `viewTemplates` SDK path had no arg validation.** `viewTemplates.get({ resource: "entity" })` reached Postgres as `WHERE id = Number(undefined)` → `NaN` → a raw `invalid input syntax for type bigint: "NaN"`, because neither the SDK dispatcher (`action-call.ts`) nor the REST path validates `manage_*` args. Added a guard in `verifyAccess` (`manage_view_templates.ts`) that rejects a missing/unknown `resource_type` and a missing/non-numeric `resource_id` with a clean `ToolUserError` before any query — fixing both transport paths in one place.

## Testing

- New PG-free unit test (`manage-view-templates-validation.test.ts`): bad shape, non-numeric id, missing-id-on-entity_type → clean `ToolUserError`; well-shaped call passes through to the DB layer.
- `make review BASE=origin/main`: typecheck/unit/integration all green, verdict bug_free 89, 0 bugs, 0 blockers. (First pass found a missing `entity_type` guard; fixed + test added, re-review clean.)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1184"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783161613&installation_id=136316292&pr_number=1184&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1184&signature=163f32b34a9e4e52525b21bd28b837753b8368a0224998980494a2bb8eab6dce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive unit tests for view template parameter validation

* **Documentation**
  * Updated SDK documentation for search, entity schema creation, watchers, and view template operations with enhanced usage examples and parameter constraints

* **Bug Fixes**
  * Improved input validation for view template operations to provide clearer error messages instead of database-level errors

<!-- end of auto-generated comment: release notes by coderabbit.ai -->