### PR TITLE
feat(cli): add --org override to lobu chat

### DIFF
--- a/packages/cli/src/__tests__/chat-org.test.ts
+++ b/packages/cli/src/__tests__/chat-org.test.ts
@@ -1,0 +1,211 @@
+/**
+ * Unit tests for `lobu chat --org` resolution and header threading.
+ *
+ * Covers:
+ *  - `resolveChatOrg` precedence: explicit --org > LOBU_ORG env > context activeOrg.
+ *  - The resolved org rides every Agent API call as the `x-lobu-org` header
+ *    (POST /agents session create, POST /messages, GET /events SSE), and is
+ *    absent when no org is configured (preserving the pre-flag behavior).
+ */
+
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  spyOn,
+  test,
+} from "bun:test";
+import { chatCommand, resolveChatOrg } from "../commands/chat.js";
+import * as context from "../internal/context.js";
+
+const originalFetch = globalThis.fetch;
+const originalStdoutWrite = process.stdout.write.bind(process.stdout);
+const originalStderrWrite = process.stderr.write.bind(process.stderr);
+const originalToken = process.env.LOBU_API_TOKEN;
+const originalOrg = process.env.LOBU_ORG;
+
+function silenceTerminal(): void {
+  // `writeStdout`/`writeStderr` in chat.ts wrap process.*.write in a Promise
+  // that only resolves when the write callback fires — a stub that ignores the
+  // callback would hang the stream loop. Invoke it like the real stream does.
+  const sink = ((_chunk: string | Uint8Array, cb?: unknown) => {
+    if (typeof cb === "function") (cb as (error?: Error | null) => void)(null);
+    return true;
+  }) as typeof process.stdout.write;
+  process.stdout.write = sink;
+  process.stderr.write = sink;
+}
+
+function createSseResponse(
+  events: Array<{ event: string; data: Record<string, unknown> }>
+): Response {
+  const encoder = new TextEncoder();
+  const payload = events
+    .map(
+      ({ event, data }) => `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`
+    )
+    .join("");
+  return new Response(
+    new ReadableStream({
+      start(controller) {
+        controller.enqueue(encoder.encode(payload));
+        controller.close();
+      },
+    }),
+    { status: 200, headers: { "Content-Type": "text/event-stream" } }
+  );
+}
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  process.stdout.write = originalStdoutWrite;
+  process.stderr.write = originalStderrWrite;
+  if (originalToken === undefined) delete process.env.LOBU_API_TOKEN;
+  else process.env.LOBU_API_TOKEN = originalToken;
+  if (originalOrg === undefined) delete process.env.LOBU_ORG;
+  else process.env.LOBU_ORG = originalOrg;
+  mock.restore();
+});
+
+describe("resolveChatOrg — precedence", () => {
+  beforeEach(() => {
+    delete process.env.LOBU_ORG;
+  });
+
+  test("explicit --org wins over the context activeOrg", async () => {
+    const spy = spyOn(context, "getActiveOrg").mockResolvedValue("ctx-org");
+    const resolved = await resolveChatOrg({ org: "scratch", context: "prod" });
+    expect(resolved).toBe("scratch");
+    // Explicit flag short-circuits the context lookup entirely.
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  test("blank --org falls through to the context activeOrg", async () => {
+    spyOn(context, "getActiveOrg").mockResolvedValue("ctx-org");
+    const resolved = await resolveChatOrg({ org: "   ", context: "prod" });
+    expect(resolved).toBe("ctx-org");
+  });
+
+  test("no --org → falls back to context activeOrg (env folded in by getActiveOrg)", async () => {
+    spyOn(context, "getActiveOrg").mockResolvedValue("ctx-org");
+    const resolved = await resolveChatOrg({ context: "prod" });
+    expect(resolved).toBe("ctx-org");
+  });
+
+  test("no --org and no active org → undefined (server falls back to default)", async () => {
+    spyOn(context, "getActiveOrg").mockResolvedValue(undefined);
+    const resolved = await resolveChatOrg({});
+    expect(resolved).toBeUndefined();
+  });
+});
+
+describe("chatCommand — x-lobu-org header threading", () => {
+  test("--org rides every Agent API request as x-lobu-org", async () => {
+    process.env.LOBU_API_TOKEN = "test-token";
+    delete process.env.LOBU_ORG;
+    silenceTerminal();
+    spyOn(context, "getActiveOrg").mockResolvedValue(undefined);
+
+    const headerSeen: Record<string, string | null> = {};
+
+    globalThis.fetch = mock(
+      async (input: string | URL | Request, init?: RequestInit) => {
+        const url = String(input);
+        const orgHeader =
+          (init?.headers as Record<string, string> | undefined)?.[
+            "x-lobu-org"
+          ] ?? null;
+
+        if (
+          url === "http://gateway.test/lobu/api/v1/agents" &&
+          init?.method === "POST"
+        ) {
+          headerSeen.create = orgHeader;
+          return Response.json({
+            agentId: "session-1",
+            token: "session-token",
+          });
+        }
+        if (
+          url === "http://gateway.test/lobu/api/v1/agents/session-1/events" &&
+          !init?.method
+        ) {
+          headerSeen.events = orgHeader;
+          return createSseResponse([
+            { event: "output", data: { content: "hi\n" } },
+            { event: "complete", data: {} },
+          ]);
+        }
+        if (
+          url === "http://gateway.test/lobu/api/v1/agents/session-1/messages" &&
+          init?.method === "POST"
+        ) {
+          headerSeen.messages = orgHeader;
+          return Response.json({ success: true });
+        }
+        throw new Error(`Unexpected fetch: ${url}`);
+      }
+    ) as unknown as typeof fetch;
+
+    await chatCommand("/tmp/does-not-matter", "hello", {
+      gateway: "http://gateway.test",
+      agent: "vc-tracking",
+      org: "scratch",
+      new: true,
+    });
+
+    expect(headerSeen.create).toBe("scratch");
+    expect(headerSeen.messages).toBe("scratch");
+    expect(headerSeen.events).toBe("scratch");
+  });
+
+  test("no org configured → x-lobu-org header is omitted", async () => {
+    process.env.LOBU_API_TOKEN = "test-token";
+    delete process.env.LOBU_ORG;
+    silenceTerminal();
+    spyOn(context, "getActiveOrg").mockResolvedValue(undefined);
+
+    let createHadOrgHeader = true;
+
+    globalThis.fetch = mock(
+      async (input: string | URL | Request, init?: RequestInit) => {
+        const url = String(input);
+        if (
+          url === "http://gateway.test/lobu/api/v1/agents" &&
+          init?.method === "POST"
+        ) {
+          createHadOrgHeader = Object.keys(
+            (init?.headers as Record<string, string>) ?? {}
+          ).includes("x-lobu-org");
+          return Response.json({
+            agentId: "session-1",
+            token: "session-token",
+          });
+        }
+        if (
+          url === "http://gateway.test/lobu/api/v1/agents/session-1/events" &&
+          !init?.method
+        ) {
+          return createSseResponse([{ event: "complete", data: {} }]);
+        }
+        if (
+          url === "http://gateway.test/lobu/api/v1/agents/session-1/messages" &&
+          init?.method === "POST"
+        ) {
+          return Response.json({ success: true });
+        }
+        throw new Error(`Unexpected fetch: ${url}`);
+      }
+    ) as unknown as typeof fetch;
+
+    await chatCommand("/tmp/does-not-matter", "hello", {
+      gateway: "http://gateway.test",
+      agent: "vc-tracking",
+      new: true,
+    });
+
+    expect(createHadOrgHeader).toBe(false);
+  });
+});

--- a/packages/cli/src/commands/chat.ts
+++ b/packages/cli/src/commands/chat.ts
@@ -2,17 +2,18 @@ import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { createInterface } from "node:readline";
 import chalk from "chalk";
+import { LOBU_CONFIG_DIR } from "../internal/context.js";
 import {
   agentApiBase,
   apiBaseFromContextUrl,
+  getActiveOrg,
   getAgentApiToken,
   getCurrentContextName,
   resolveContext,
   resolveGatewayUrl,
 } from "../internal/index.js";
-import { LOBU_CONFIG_DIR } from "../internal/context.js";
-import { loadProjectConfig } from "./_lib/apply/desired-state.js";
 import { renderMarkdown } from "../utils/markdown.js";
+import { loadProjectConfig } from "./_lib/apply/desired-state.js";
 
 const THREADS_FILE = join(LOBU_CONFIG_DIR, "threads.json");
 
@@ -57,8 +58,46 @@ export interface ChatOptions {
   new?: boolean;
   continue?: boolean;
   context?: string;
+  org?: string;
   autoApprove?: boolean;
   json?: boolean;
+}
+
+/**
+ * Resolve which org the chat invocation targets. Precedence mirrors the other
+ * org-scoped commands (`lobu memory run`, `lobu call`): explicit `--org` >
+ * `LOBU_ORG` env > the context's stored `activeOrg`. `getActiveOrg` already
+ * folds in the env var and context lookup, so an explicit flag is the only
+ * thing layered on top.
+ *
+ * Returns `undefined` when nothing is configured — the server then falls back
+ * to the PAT-bound org / the user's default membership, preserving the
+ * pre-flag behavior for callers that never pass `--org`.
+ */
+export async function resolveChatOrg(
+  options: Pick<ChatOptions, "org" | "context">
+): Promise<string | undefined> {
+  if (options.org?.trim()) return options.org.trim();
+  return getActiveOrg(options.context);
+}
+
+/**
+ * Build the Authorization header plus an optional `x-lobu-org` override the
+ * embedded gateway honors per-request (membership-checked server-side). The
+ * header is omitted entirely when no org is resolved, so unflagged invocations
+ * are byte-for-byte identical to the previous behavior.
+ */
+function agentApiHeaders(
+  authToken: string,
+  org: string | undefined,
+  extra?: Record<string, string>
+): Record<string, string> {
+  const headers: Record<string, string> = {
+    Authorization: `Bearer ${authToken}`,
+    ...extra,
+  };
+  if (org) headers["x-lobu-org"] = org;
+  return headers;
 }
 
 /**
@@ -101,6 +140,9 @@ export async function chatCommand(
   const agentId = options.agent ?? (await resolveAgentId(cwd));
   const platformUser = options.user ? parsePlatformUser(options.user) : null;
   const contextName = options.context ?? (await getCurrentContextName());
+  // Explicit `--org` overrides the context's activeOrg for this invocation
+  // only (no config write). Threaded as `x-lobu-org` on every Agent API call.
+  const org = await resolveChatOrg(options);
 
   // Resolve thread: explicit --thread > --continue (last for this agent)
   let threadId = options.thread;
@@ -123,6 +165,7 @@ export async function chatCommand(
       message: prompt,
       thread: threadId,
       json: options.json,
+      org,
     });
   } else {
     await sendViaApi(gatewayUrl, authToken, {
@@ -134,6 +177,7 @@ export async function chatCommand(
       autoApprove: options.autoApprove,
       json: options.json,
       contextName,
+      org,
     });
   }
 }
@@ -159,6 +203,7 @@ async function sendViaPlatform(
     message: string;
     thread?: string;
     json?: boolean;
+    org?: string;
   }
 ): Promise<void> {
   const agentId = opts.agentId || `test-${opts.platform}`;
@@ -179,10 +224,9 @@ async function sendViaPlatform(
     `${gatewayUrl}/api/v1/agents/${encodeURIComponent(agentId)}/messages`,
     {
       method: "POST",
-      headers: {
+      headers: agentApiHeaders(authToken, opts.org, {
         "Content-Type": "application/json",
-        Authorization: `Bearer ${authToken}`,
-      },
+      }),
       body: JSON.stringify(body),
     }
   );
@@ -212,6 +256,7 @@ async function sendViaPlatform(
     await streamResponse(sseUrl, authToken, sseController, {
       expectedMessageId: result.messageId,
       json: opts.json,
+      org: opts.org,
     });
   } else {
     console.log(
@@ -231,6 +276,7 @@ interface ApiSendOptions {
   autoApprove?: boolean;
   json?: boolean;
   contextName?: string;
+  org?: string;
 }
 
 interface ApiSession {
@@ -247,6 +293,7 @@ async function createSession(
     thread?: string;
     dryRun?: boolean;
     forceNew?: boolean;
+    org?: string;
   }
 ): Promise<ApiSession> {
   const createBody: Record<string, any> = {};
@@ -257,10 +304,9 @@ async function createSession(
 
   const createRes = await fetch(`${gatewayUrl}/api/v1/agents`, {
     method: "POST",
-    headers: {
+    headers: agentApiHeaders(authToken, opts.org, {
       "Content-Type": "application/json",
-      Authorization: `Bearer ${authToken}`,
-    },
+    }),
     body: JSON.stringify(createBody),
   });
 
@@ -301,6 +347,7 @@ async function sendViaApi(
     thread: opts.thread,
     dryRun: opts.dryRun,
     forceNew: opts.forceNew,
+    org: opts.org,
   });
 
   const base = `${gatewayUrl}/api/v1/agents/${session.agentId}`;
@@ -311,14 +358,14 @@ async function sendViaApi(
   const streaming = streamResponse(sseUrl, session.token, sseController, {
     autoApprove: opts.autoApprove,
     json: opts.json,
+    org: opts.org,
   });
 
   const msgRes = await fetch(messagesUrl, {
     method: "POST",
-    headers: {
+    headers: agentApiHeaders(session.token, opts.org, {
       "Content-Type": "application/json",
-      Authorization: `Bearer ${session.token}`,
-    },
+    }),
     body: JSON.stringify({ content: opts.message }),
   });
 
@@ -375,6 +422,7 @@ interface StreamOptions {
   expectedMessageId?: string;
   autoApprove?: boolean;
   json?: boolean;
+  org?: string;
 }
 
 async function streamResponse(
@@ -401,7 +449,7 @@ async function streamResponse(
 
   try {
     const res = await fetch(sseUrl, {
-      headers: { Authorization: `Bearer ${token}` },
+      headers: agentApiHeaders(token, options.org),
       signal: controller.signal,
     });
 
@@ -530,10 +578,9 @@ async function streamResponse(
                 .replace(/\/api\/v1\/agents\/[^/]+/, "/api/v1/agents/approve");
               const approveRes = await fetch(approveUrl, {
                 method: "POST",
-                headers: {
+                headers: agentApiHeaders(token, options.org, {
                   "Content-Type": "application/json",
-                  Authorization: `Bearer ${token}`,
-                },
+                }),
                 body: JSON.stringify({ requestId: data.requestId, decision }),
               });
               if (approveRes.ok) {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -266,6 +266,10 @@ Memory:
     )
     .option("--json", "Emit raw SSE events as JSON lines instead of text")
     .option("-c, --context <name>", "Use a named context")
+    .option(
+      "--org <slug>",
+      "Org slug override for this run (defaults to active context org; no config write)"
+    )
     .action(
       async (
         prompt: string,
@@ -278,6 +282,7 @@ Memory:
           new?: boolean;
           continue?: boolean;
           context?: string;
+          org?: string;
           autoApprove?: boolean;
           json?: boolean;
         }

--- a/packages/server/src/__tests__/integration/lobu/gateway-org-context.test.ts
+++ b/packages/server/src/__tests__/integration/lobu/gateway-org-context.test.ts
@@ -3,16 +3,26 @@
  * (`createLobuOrgContextMiddleware` in `src/lobu/gateway.ts`).
  *
  * Covers the `x-lobu-org` per-request override that backs `lobu chat --org`:
- *   - header present + member       → org context is the header's org (not the
- *     PAT-bound org), so a multi-org user can target a scratch org for one run
+ *
+ * Session auth (Better Auth login — the normal `lobu login` CLI path):
+ *   - header present + member       → org context is the header's org, so a
+ *     multi-org user can target a scratch org for one run
  *   - header present + non-member   → 403 (cannot escalate cross-tenant)
  *   - header present + unknown slug → 404
- *   - header absent                 → falls back to the PAT-bound org
- *     (pre-flag behavior preserved)
  *
- * The middleware reads `c.get('user')`, which `createLobuAuthBridge` populates,
- * so the test app mounts the bridge first (production order) and a handler that
- * mirrors the resolved `organizationId` back as JSON.
+ * PAT auth (owl_pat_* bearer): the token stays pinned to the org it was minted
+ * for — same rule as the MCP's query_sql, which rejects org overrides under
+ * PAT auth:
+ *   - header naming the pinned org  → 200 no-op (the CLI auto-sends the
+ *     context's activeOrg, so the equal case must not error)
+ *   - header naming ANY other org   → 403, even when the user is a member
+ *   - header absent                 → falls back to the PAT-bound org
+ *
+ * The real PAT path goes through `createLobuAuthBridge` (production order).
+ * The session-auth path stubs the upstream auth middleware with a session whose
+ * id is not `pat:`-prefixed — the middleware's contract is `c.get('user')` /
+ * `c.get('session')` / `c.get('organizationId')`, which is exactly what Better
+ * Auth populates.
  */
 
 import { Hono } from "hono";
@@ -40,7 +50,7 @@ const testEnv: Env = {
   RATE_LIMIT_ENABLED: "false",
 };
 
-function buildApp(): Hono<{ Bindings: Env }> {
+function buildPatApp(): Hono<{ Bindings: Env }> {
   const app = new Hono<{ Bindings: Env }>();
   app.use("*", createLobuAuthBridge());
   app.use("*", createLobuOrgContextMiddleware());
@@ -49,6 +59,21 @@ function buildApp(): Hono<{ Bindings: Env }> {
     const organizationId = c.get("organizationId") ?? null;
     if (!user) return c.json({ ok: false, reason: "no-user" }, 401);
     return c.json({ ok: true, userId: user.id, organizationId });
+  });
+  return app;
+}
+
+/** Simulates the Better Auth session path: user + non-PAT session, no org pin. */
+function buildSessionApp(userId: string): Hono<{ Bindings: Env }> {
+  const app = new Hono<{ Bindings: Env }>();
+  app.use("*", async (c: any, next: any) => {
+    c.set("user", { id: userId });
+    c.set("session", { id: "sess_better_auth_token", userId });
+    await next();
+  });
+  app.use("*", createLobuOrgContextMiddleware());
+  app.get("/test", (c: any) => {
+    return c.json({ ok: true, organizationId: c.get("organizationId") ?? null });
   });
   return app;
 }
@@ -79,7 +104,7 @@ describe("Lobu embedded Agent API org-context middleware (x-lobu-org)", () => {
   let scratchOrg: Awaited<ReturnType<typeof createTestOrganization>>;
   let foreignOrg: Awaited<ReturnType<typeof createTestOrganization>>;
   let user: Awaited<ReturnType<typeof createTestUser>>;
-  let app: Hono<{ Bindings: Env }>;
+  let patApp: Hono<{ Bindings: Env }>;
 
   beforeAll(async () => {
     await cleanupTestDatabase();
@@ -95,52 +120,87 @@ describe("Lobu embedded Agent API org-context middleware (x-lobu-org)", () => {
 
   beforeEach(() => {
     clearMultiTenantCachesForTests();
-    app = buildApp();
+    patApp = buildPatApp();
   });
 
-  it("no x-lobu-org header → resolves to the PAT-bound org (pre-flag behavior)", async () => {
-    const { token } = await createTestPAT(user.id, patOrg.id);
-    const { status, body } = await fetchTest(app, { token });
-    expect(status).toBe(200);
-    expect(body.organizationId).toBe(patOrg.id);
-  });
-
-  it("x-lobu-org for a member org overrides the PAT-bound org", async () => {
-    const { token } = await createTestPAT(user.id, patOrg.id);
-    const { status, body } = await fetchTest(app, {
-      token,
-      org: scratchOrg.slug,
+  describe("session auth (Better Auth login)", () => {
+    it("x-lobu-org for a member org wins", async () => {
+      const app = buildSessionApp(user.id);
+      const { status, body } = await fetchTest(app, { org: scratchOrg.slug });
+      expect(status).toBe(200);
+      expect(body.organizationId).toBe(scratchOrg.id);
     });
-    expect(status).toBe(200);
-    // The override wins: context is the scratch org, not the PAT's org.
-    expect(body.organizationId).toBe(scratchOrg.id);
-    expect(body.organizationId).not.toBe(patOrg.id);
-  });
 
-  it("x-lobu-org for an org the user is NOT a member of → 403", async () => {
-    const { token } = await createTestPAT(user.id, patOrg.id);
-    const { status, body } = await fetchTest(app, {
-      token,
-      org: foreignOrg.slug,
+    it("x-lobu-org for an org the user is NOT a member of → 403", async () => {
+      const app = buildSessionApp(user.id);
+      const { status, body } = await fetchTest(app, { org: foreignOrg.slug });
+      expect(status).toBe(403);
+      expect(String(body.error)).toMatch(/Not a member/);
     });
-    expect(status).toBe(403);
-    expect(String(body.error)).toMatch(/Not a member/);
-  });
 
-  it("x-lobu-org for an unknown slug → 404", async () => {
-    const { token } = await createTestPAT(user.id, patOrg.id);
-    const { status, body } = await fetchTest(app, {
-      token,
-      org: "no-such-org-slug-xyz",
+    it("x-lobu-org for an unknown slug → 404", async () => {
+      const app = buildSessionApp(user.id);
+      const { status, body } = await fetchTest(app, {
+        org: "no-such-org-slug-xyz",
+      });
+      expect(status).toBe(404);
+      expect(String(body.error)).toMatch(/Unknown organization/);
     });
-    expect(status).toBe(404);
-    expect(String(body.error)).toMatch(/Unknown organization/);
   });
 
-  it("blank x-lobu-org header is ignored → falls back to PAT-bound org", async () => {
-    const { token } = await createTestPAT(user.id, patOrg.id);
-    const { status, body } = await fetchTest(app, { token, org: "   " });
-    expect(status).toBe(200);
-    expect(body.organizationId).toBe(patOrg.id);
+  describe("PAT auth (org-pinned)", () => {
+    it("no x-lobu-org header → resolves to the PAT-bound org (pre-flag behavior)", async () => {
+      const { token } = await createTestPAT(user.id, patOrg.id);
+      const { status, body } = await fetchTest(patApp, { token });
+      expect(status).toBe(200);
+      expect(body.organizationId).toBe(patOrg.id);
+    });
+
+    it("x-lobu-org naming the pinned org is a no-op (CLI auto-sends activeOrg)", async () => {
+      const { token } = await createTestPAT(user.id, patOrg.id);
+      const { status, body } = await fetchTest(patApp, {
+        token,
+        org: patOrg.slug,
+      });
+      expect(status).toBe(200);
+      expect(body.organizationId).toBe(patOrg.id);
+    });
+
+    it("x-lobu-org for a DIFFERENT member org → 403 (PAT stays pinned, like MCP query_sql)", async () => {
+      const { token } = await createTestPAT(user.id, patOrg.id);
+      const { status, body } = await fetchTest(patApp, {
+        token,
+        org: scratchOrg.slug,
+      });
+      expect(status).toBe(403);
+      expect(String(body.error)).toMatch(/PAT auth/);
+    });
+
+    it("x-lobu-org for a non-member org → 403 (PAT pin rejects before membership)", async () => {
+      const { token } = await createTestPAT(user.id, patOrg.id);
+      const { status, body } = await fetchTest(patApp, {
+        token,
+        org: foreignOrg.slug,
+      });
+      expect(status).toBe(403);
+      expect(String(body.error)).toMatch(/PAT auth/);
+    });
+
+    it("x-lobu-org for an unknown slug → 404", async () => {
+      const { token } = await createTestPAT(user.id, patOrg.id);
+      const { status, body } = await fetchTest(patApp, {
+        token,
+        org: "no-such-org-slug-xyz",
+      });
+      expect(status).toBe(404);
+      expect(String(body.error)).toMatch(/Unknown organization/);
+    });
+
+    it("blank x-lobu-org header is ignored → falls back to PAT-bound org", async () => {
+      const { token } = await createTestPAT(user.id, patOrg.id);
+      const { status, body } = await fetchTest(patApp, { token, org: "   " });
+      expect(status).toBe(200);
+      expect(body.organizationId).toBe(patOrg.id);
+    });
   });
 });

--- a/packages/server/src/__tests__/integration/lobu/gateway-org-context.test.ts
+++ b/packages/server/src/__tests__/integration/lobu/gateway-org-context.test.ts
@@ -1,0 +1,146 @@
+/**
+ * Integration tests for the embedded Lobu Agent API org-context middleware
+ * (`createLobuOrgContextMiddleware` in `src/lobu/gateway.ts`).
+ *
+ * Covers the `x-lobu-org` per-request override that backs `lobu chat --org`:
+ *   - header present + member       → org context is the header's org (not the
+ *     PAT-bound org), so a multi-org user can target a scratch org for one run
+ *   - header present + non-member   → 403 (cannot escalate cross-tenant)
+ *   - header present + unknown slug → 404
+ *   - header absent                 → falls back to the PAT-bound org
+ *     (pre-flag behavior preserved)
+ *
+ * The middleware reads `c.get('user')`, which `createLobuAuthBridge` populates,
+ * so the test app mounts the bridge first (production order) and a handler that
+ * mirrors the resolved `organizationId` back as JSON.
+ */
+
+import { Hono } from "hono";
+import { beforeAll, beforeEach, describe, expect, it } from "vitest";
+import type { Env } from "../../../index";
+import {
+  createLobuAuthBridge,
+  createLobuOrgContextMiddleware,
+} from "../../../lobu/gateway";
+import { clearMultiTenantCachesForTests } from "../../../workspace/multi-tenant";
+import { cleanupTestDatabase } from "../../setup/test-db";
+import {
+  addUserToOrganization,
+  createTestOrganization,
+  createTestPAT,
+  createTestUser,
+} from "../../setup/test-fixtures";
+
+const testEnv: Env = {
+  ENVIRONMENT: "test",
+  DATABASE_URL: process.env.DATABASE_URL,
+  JWT_SECRET: "test-jwt-secret-for-testing-only",
+  BETTER_AUTH_SECRET: "test-auth-secret-for-testing-only",
+  MAX_CONSECUTIVE_FAILURES: "3",
+  RATE_LIMIT_ENABLED: "false",
+};
+
+function buildApp(): Hono<{ Bindings: Env }> {
+  const app = new Hono<{ Bindings: Env }>();
+  app.use("*", createLobuAuthBridge());
+  app.use("*", createLobuOrgContextMiddleware());
+  app.get("/test", (c: any) => {
+    const user = c.get("user");
+    const organizationId = c.get("organizationId") ?? null;
+    if (!user) return c.json({ ok: false, reason: "no-user" }, 401);
+    return c.json({ ok: true, userId: user.id, organizationId });
+  });
+  return app;
+}
+
+async function fetchTest(
+  app: Hono<{ Bindings: Env }>,
+  options: { token?: string; org?: string } = {},
+): Promise<{ status: number; body: any }> {
+  const headers: Record<string, string> = {};
+  if (options.token) headers.Authorization = `Bearer ${options.token}`;
+  if (options.org !== undefined) headers["x-lobu-org"] = options.org;
+  const res = await app.fetch(
+    new Request("http://test.local/test", { headers }),
+    testEnv,
+  );
+  const text = await res.text();
+  let body: any = null;
+  try {
+    body = JSON.parse(text);
+  } catch {
+    body = text;
+  }
+  return { status: res.status, body };
+}
+
+describe("Lobu embedded Agent API org-context middleware (x-lobu-org)", () => {
+  let patOrg: Awaited<ReturnType<typeof createTestOrganization>>;
+  let scratchOrg: Awaited<ReturnType<typeof createTestOrganization>>;
+  let foreignOrg: Awaited<ReturnType<typeof createTestOrganization>>;
+  let user: Awaited<ReturnType<typeof createTestUser>>;
+  let app: Hono<{ Bindings: Env }>;
+
+  beforeAll(async () => {
+    await cleanupTestDatabase();
+    patOrg = await createTestOrganization({ name: "Chat Org PAT" });
+    scratchOrg = await createTestOrganization({ name: "Chat Org Scratch" });
+    foreignOrg = await createTestOrganization({ name: "Chat Org Foreign" });
+    user = await createTestUser({});
+    // The user belongs to BOTH the PAT org and the scratch org, but NOT the
+    // foreign org — the override must respect that membership boundary.
+    await addUserToOrganization(user.id, patOrg.id);
+    await addUserToOrganization(user.id, scratchOrg.id);
+  });
+
+  beforeEach(() => {
+    clearMultiTenantCachesForTests();
+    app = buildApp();
+  });
+
+  it("no x-lobu-org header → resolves to the PAT-bound org (pre-flag behavior)", async () => {
+    const { token } = await createTestPAT(user.id, patOrg.id);
+    const { status, body } = await fetchTest(app, { token });
+    expect(status).toBe(200);
+    expect(body.organizationId).toBe(patOrg.id);
+  });
+
+  it("x-lobu-org for a member org overrides the PAT-bound org", async () => {
+    const { token } = await createTestPAT(user.id, patOrg.id);
+    const { status, body } = await fetchTest(app, {
+      token,
+      org: scratchOrg.slug,
+    });
+    expect(status).toBe(200);
+    // The override wins: context is the scratch org, not the PAT's org.
+    expect(body.organizationId).toBe(scratchOrg.id);
+    expect(body.organizationId).not.toBe(patOrg.id);
+  });
+
+  it("x-lobu-org for an org the user is NOT a member of → 403", async () => {
+    const { token } = await createTestPAT(user.id, patOrg.id);
+    const { status, body } = await fetchTest(app, {
+      token,
+      org: foreignOrg.slug,
+    });
+    expect(status).toBe(403);
+    expect(String(body.error)).toMatch(/Not a member/);
+  });
+
+  it("x-lobu-org for an unknown slug → 404", async () => {
+    const { token } = await createTestPAT(user.id, patOrg.id);
+    const { status, body } = await fetchTest(app, {
+      token,
+      org: "no-such-org-slug-xyz",
+    });
+    expect(status).toBe(404);
+    expect(String(body.error)).toMatch(/Unknown organization/);
+  });
+
+  it("blank x-lobu-org header is ignored → falls back to PAT-bound org", async () => {
+    const { token } = await createTestPAT(user.id, patOrg.id);
+    const { status, body } = await fetchTest(app, { token, org: "   " });
+    expect(status).toBe(200);
+    expect(body.organizationId).toBe(patOrg.id);
+  });
+});

--- a/packages/server/src/lobu/gateway.ts
+++ b/packages/server/src/lobu/gateway.ts
@@ -26,6 +26,10 @@ import type { Env } from '../index';
 import logger from '../utils/logger';
 import { getConfiguredPublicOrigin } from '../utils/public-origin';
 import { getDb } from '../db/client';
+import {
+  getCachedMembershipRole,
+  getCachedOrgBySlug,
+} from '../workspace/multi-tenant';
 import { orgContext } from './stores/org-context';
 import { PostgresSecretStore } from './stores/postgres-secret-store';
 import {
@@ -196,6 +200,80 @@ export function createLobuAuthBridge() {
 }
 
 /**
+ * Org-context middleware for the embedded Lobu app.
+ *
+ * Resolves the organization a request runs under and wraps the rest of the
+ * request in `orgContext.run()` so Postgres-backed stores (which read the org
+ * id from AsyncLocalStorage via `getOrgId()`) work for routes that don't carry
+ * an explicit org slug in the path — `POST /api/v1/agents` in particular, which
+ * auto-provisions ephemeral agents and needs the user's existing agents to
+ * inherit `pluginsConfig`. (The mainApp's `workspace/multi-tenant.ts` already
+ * handles `/api/:orgSlug/*`; this is the equivalent for the lobu-app's unscoped
+ * routes.)
+ *
+ * Resolution precedence:
+ *   1. `x-lobu-org` header (sent by `lobu chat --org <slug>`) — an explicit
+ *      per-request override of both the PAT pin and the user's default org.
+ *      Honored ONLY after re-verifying the authenticated user is a member of
+ *      that org (unknown slug → 404, non-member → 403), so a header can never
+ *      escalate cross-tenant access — the same invariant the PAT path enforces.
+ *   2. The PAT-bound org (`organizationId` set by `createLobuAuthBridge`).
+ *   3. The user's default org membership.
+ *
+ * Exported for tests; production wires it via `lobuApp.use('*', …)`.
+ */
+export function createLobuOrgContextMiddleware() {
+  return async (c: any, next: any) => {
+    const user = c.get('user') as { id?: string } | null;
+    if (!user?.id) {
+      await next();
+      return;
+    }
+
+    const orgHeader = c.req.header('x-lobu-org')?.trim();
+    if (orgHeader) {
+      let resolvedOrg: { id: string } | null;
+      try {
+        resolvedOrg = await getCachedOrgBySlug(orgHeader);
+      } catch {
+        return c.json({ error: 'Unable to resolve organization' }, 503);
+      }
+      if (!resolvedOrg) {
+        return c.json({ error: `Unknown organization "${orgHeader}"` }, 404);
+      }
+      const role = await getCachedMembershipRole(resolvedOrg.id, user.id);
+      if (!role) {
+        return c.json(
+          { error: `Not a member of organization "${orgHeader}"` },
+          403
+        );
+      }
+      c.set('organizationId', resolvedOrg.id);
+      await orgContext.run({ organizationId: resolvedOrg.id }, () => next());
+      return;
+    }
+
+    // PAT-hydration middleware above sets `organizationId` when the PAT is
+    // bound to one. Honor that pin first so the org-scoped stores see the same
+    // tenant the PAT was minted for; only fall back to the user's default
+    // membership when no pin exists.
+    let orgId: string | null = (c.get('organizationId') as string | null) ?? null;
+    if (!orgId) {
+      try {
+        orgId = await resolveDefaultOrgId(user.id);
+      } catch {
+        return c.json({ error: 'Unable to resolve organization membership' }, 503);
+      }
+      if (!orgId) {
+        return c.json({ error: 'No organization membership found' }, 404);
+      }
+      c.set('organizationId', orgId);
+    }
+    await orgContext.run({ organizationId: orgId }, () => next());
+  };
+}
+
+/**
  * Initialize the embedded Lobu gateway.
  * Returns the Hono app to mount, or null if DATABASE_URL is not configured.
  */
@@ -337,40 +415,10 @@ export async function initLobuGateway(): Promise<Hono | null> {
     lobuApp = new HonoApp<{ Bindings: Env }>();
     lobuApp.use('*', createLobuAuthBridge());
 
-    // Resolve the signed-in user's primary org and wrap the rest of the
-    // request in orgContext.run() so Postgres-backed stores (which read the
-    // org id from AsyncLocalStorage via getOrgId()) work for routes that
-    // don't carry an explicit org slug — POST /api/v1/agents in particular,
-    // which auto-provisions ephemeral agents and needs to look up the
-    // user's existing agents to inherit pluginsConfig.
-    //
-    // The mainApp's multi-tenant middleware (workspace/multi-tenant.ts)
-    // already handles /api/:orgSlug/* — that's a separate path. This
-    // middleware is the equivalent for the lobu-app's unscoped routes.
-    lobuApp.use('*', async (c: any, next: any) => {
-      const user = c.get('user') as { id?: string } | null;
-      if (!user?.id) {
-        await next();
-        return;
-      }
-      // PAT-hydration middleware above sets `organizationId` when the PAT
-      // is bound to one. Honor that pin first so the org-scoped stores see
-      // the same tenant the PAT was minted for; only fall back to the user's
-      // default membership when no pin exists.
-      let orgId: string | null = (c.get('organizationId') as string | null) ?? null;
-      if (!orgId) {
-        try {
-          orgId = await resolveDefaultOrgId(user.id);
-        } catch {
-          return c.json({ error: 'Unable to resolve organization membership' }, 503);
-        }
-        if (!orgId) {
-          return c.json({ error: 'No organization membership found' }, 404);
-        }
-        c.set('organizationId', orgId);
-      }
-      await orgContext.run({ organizationId: orgId }, () => next());
-    });
+    // Resolve the request's org (x-lobu-org override > PAT pin > default
+    // membership) and wrap the rest of the request in orgContext.run(). See
+    // createLobuOrgContextMiddleware for the precedence + membership invariant.
+    lobuApp.use('*', createLobuOrgContextMiddleware());
 
     // Worker gateway routes must be mounted first (before rawLobuApp's catch-all)
     if (workerGateway?.getApp) {

--- a/packages/server/src/lobu/gateway.ts
+++ b/packages/server/src/lobu/gateway.ts
@@ -212,11 +212,13 @@ export function createLobuAuthBridge() {
  * routes.)
  *
  * Resolution precedence:
- *   1. `x-lobu-org` header (sent by `lobu chat --org <slug>`) — an explicit
- *      per-request override of both the PAT pin and the user's default org.
- *      Honored ONLY after re-verifying the authenticated user is a member of
- *      that org (unknown slug → 404, non-member → 403), so a header can never
- *      escalate cross-tenant access — the same invariant the PAT path enforces.
+ *   1. `x-lobu-org` header (sent by `lobu chat --org <slug>`) — a per-request
+ *      override of the user's default org, honored ONLY after re-verifying the
+ *      authenticated user is a member of that org (unknown slug → 404,
+ *      non-member → 403). Under PAT auth the header cannot select a different
+ *      org than the PAT's pin (→ 403; naming the pinned org is a no-op) — the
+ *      same rule as the MCP's query_sql, so an org-bound credential never
+ *      widens into the holder's other orgs.
  *   2. The PAT-bound org (`organizationId` set by `createLobuAuthBridge`).
  *   3. The user's default org membership.
  *
@@ -241,6 +243,28 @@ export function createLobuOrgContextMiddleware() {
       if (!resolvedOrg) {
         return c.json({ error: `Unknown organization "${orgHeader}"` }, 404);
       }
+
+      // A PAT stays pinned to the org it was minted for — same rule as the
+      // MCP's query_sql, which rejects org overrides under PAT auth. A header
+      // naming the pinned org is a harmless no-op (the CLI auto-sends the
+      // context's activeOrg), but a different org is rejected even when the
+      // user is a member: minting an org-bound credential is an intentional
+      // scope decision, and a stolen PAT must not widen into every org its
+      // owner belongs to.
+      const session = c.get('session') as { id?: string } | null;
+      const isPat =
+        typeof session?.id === 'string' && session.id.startsWith('pat:');
+      if (isPat && resolvedOrg.id !== c.get('organizationId')) {
+        return c.json(
+          {
+            error:
+              `x-lobu-org "${orgHeader}" is not allowed with PAT auth: the token stays pinned to the organization it was minted for. ` +
+              'Mint a PAT for the target organization, or sign in with `lobu login`.',
+          },
+          403
+        );
+      }
+
       const role = await getCachedMembershipRole(resolvedOrg.id, user.id);
       if (!role) {
         return c.json(


### PR DESCRIPTION
## Why

`lobu chat` had no `--org` flag — org was bound to the active context's `activeOrg`, so you couldn't target a different org without globally mutating CLI state (`lobu context use` / org set). That blocks safe multi-org use and scratch-org testing. (There was even a stale `fix-chat-org-1068` context flagging this.)

## What

This turned out to be a CLI **+ server** change, because the Agent API resolves org server-side from the PAT/default org — a CLI-only flag would have been a silent no-op.

- **CLI** (`packages/cli`): new `--org <slug>` on `lobu chat`. Resolution precedence: explicit `--org` > `LOBU_ORG` env > context `activeOrg` (reusing the shared helper, matching `lobu memory run` / `lobu call`). The resolved org rides every Agent API request as an `x-lobu-org` header (omitted entirely when none resolves, so unflagged runs are byte-identical to before).
- **Server** (`packages/server/src/lobu/gateway.ts`): extracted the inline org-context middleware into a testable function that honors `x-lobu-org` — after re-verifying the authenticated user is a member of that org (unknown slug → 404, non-member → 403). Per-request resolution from PG-backed caches, no new in-memory cross-pod state.
- **PAT scoping (decided):** under PAT auth the header **cannot select a different org than the PAT's pin** (→ 403; naming the pinned org is a harmless no-op since the CLI auto-sends the context's activeOrg). Same rule as the MCP's `query_sql` — an org-bound credential never widens into the holder's other orgs. Session/OAuth auth gets the membership-checked override.

## Testing

- CLI suite green (382 pass); `chat-org.test.ts` asserts `resolveChatOrg` precedence + that `x-lobu-org` rides the create/messages/events calls and is omitted when no org. Built bin `lobu chat --help` shows the flag.
- `gateway-org-context.test.ts` (9 tests) **executed against a real embedded Postgres**: session-auth member-override-wins / 403 non-member / 404 unknown; PAT no-header fallback, pinned-org no-op, 403 different-member-org, 403 non-member-org, 404 unknown, blank-header fallback.
- `make review BASE=origin/main`: typecheck/unit/integration green, verdict bug_free 86, 0 bugs, 0 blockers.
- Not yet run: a real `lobu chat --org <scratch>` against a live agent (needs a configured agent + provider key in a scratch org).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The `lobu chat` command now accepts an `--org` flag to scope chat sessions to a specific organization.
  * Org resolution follows priority: explicit flag > environment variable > active context.

* **Tests**
  * Added unit tests for org resolution and API header propagation.
  * Added integration tests validating org context middleware and member access control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->