### PR TITLE
feat(server): query-rewrite recall mode for read_knowledge

### DIFF
--- a/packages/server/src/__tests__/integration/events/get-content-query-rewrite.test.ts
+++ b/packages/server/src/__tests__/integration/events/get-content-query-rewrite.test.ts
@@ -1,0 +1,250 @@
+/**
+ * Integration test: server-side query-rewrite recall expansion in
+ * `read_knowledge` / `getContent`.
+ *
+ * The recall gap this closes: a conversational/underspecified query embeds and
+ * keyword-matches poorly, so the gold session ranks below the cutoff — and a
+ * synonym gap ("physician") misses sessions that say "dermatologist". The LLM
+ * query rewriter expands the raw query into focused keyword variants; the search
+ * branch runs the RAW query first (preserving its ranking) and unions each
+ * variant's rows deduped by event id. Purely additive: variants only surface
+ * sessions the raw query missed.
+ *
+ * The benchmark adapter gets this lift by calling
+ * read_knowledge({ rewrite_query: true }) — the recall improvement lives in the
+ * SERVER (the product), not in adapter glue.
+ *
+ * Harness: vitest + embedded Postgres (real PG18 + pgvector), mirroring
+ * get-content-visibility.test.ts. The LLM is stubbed at the FETCH boundary (not
+ * vi.mock, which does not apply under the canonical full-suite runner): we swap
+ * global.fetch for a counting stub that returns a canned chat-completions
+ * payload for /chat/completions. No EMBEDDINGS_SERVICE_URL is configured, so
+ * searchContentByText runs text-only (fulltext/trigram) and never calls fetch —
+ * the only fetch calls in this file come from the query rewriter, which makes
+ * the "no rewrite → no fetch" assertion exact.
+ */
+
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { getContent } from '../../../tools/get_content';
+import type { Env } from '../../../index';
+import type { ToolContext } from '../../../tools/registry';
+import { initWorkspaceProvider } from '../../../workspace';
+import { cleanupTestDatabase } from '../../setup/test-db';
+import {
+  addUserToOrganization,
+  createTestEntity,
+  createTestEvent,
+  createTestOrganization,
+  createTestUser,
+  seedSystemEntityTypes,
+} from '../../setup/test-fixtures';
+
+const REWRITER_ENV: Env = {
+  ENVIRONMENT: 'test',
+  QUERY_REWRITER_API_KEY: 'test-key',
+  QUERY_REWRITER_MODEL: 'gpt-4o-mini',
+} as Env;
+
+const NO_KEY_ENV: Env = {
+  ENVIRONMENT: 'test',
+} as Env;
+
+// The variants the stubbed LLM "rewrites" the raw query into.
+let cannedVariants: string[] = [];
+let fetchCalls: string[] = [];
+const realFetch = global.fetch;
+
+function installFetchStub(): void {
+  fetchCalls = [];
+  global.fetch = (async (input: RequestInfo | URL, _init?: RequestInit) => {
+    const url = typeof input === 'string' ? input : input.toString();
+    fetchCalls.push(url);
+    if (url.includes('/chat/completions')) {
+      const body = JSON.stringify({
+        choices: [
+          { message: { content: JSON.stringify({ queries: cannedVariants }) } },
+        ],
+      });
+      return new Response(body, {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+    throw new Error(`Unexpected fetch in test: ${url}`);
+  }) as typeof fetch;
+}
+
+describe('getContent > rewrite_query recall expansion', () => {
+  let org: Awaited<ReturnType<typeof createTestOrganization>>;
+  let user: Awaited<ReturnType<typeof createTestUser>>;
+  let entity: Awaited<ReturnType<typeof createTestEntity>>;
+
+  // The raw query "physician" matches this one via fulltext.
+  let physicianEventId: number;
+  // The raw query "physician" MISSES this (text says "dermatologist"); only a
+  // rewritten variant "dermatologist" surfaces it.
+  let dermatologistEventId: number;
+  // Extra synonym sessions used to prove `limit` is respected under union.
+  let entEventId: number;
+  let specialistEventId: number;
+
+  function ctx(): ToolContext {
+    return {
+      organizationId: org.id,
+      userId: user.id,
+      memberRole: 'owner',
+      isAuthenticated: true,
+      tokenType: 'oauth',
+      scopedToOrg: false,
+      allowCrossOrg: true,
+      scopes: ['mcp:read'],
+    };
+  }
+
+  beforeAll(async () => {
+    await initWorkspaceProvider();
+    await cleanupTestDatabase();
+    await seedSystemEntityTypes();
+
+    org = await createTestOrganization({ name: 'Query Rewrite Org' });
+    user = await createTestUser({ email: 'rewrite@example.com' });
+    await addUserToOrganization(user.id, org.id, 'owner');
+    entity = await createTestEntity({ name: 'Rewrite Entity', organization_id: org.id });
+
+    physicianEventId = (
+      await createTestEvent({
+        organization_id: org.id,
+        entity_id: entity.id,
+        content: 'I scheduled a checkup with my physician last Tuesday afternoon.',
+      })
+    ).id;
+
+    dermatologistEventId = (
+      await createTestEvent({
+        organization_id: org.id,
+        entity_id: entity.id,
+        content: 'The dermatologist recommended a new prescription for my skin condition.',
+      })
+    ).id;
+
+    entEventId = (
+      await createTestEvent({
+        organization_id: org.id,
+        entity_id: entity.id,
+        content: 'My ENT specialist looked at my recurring sinus problems again.',
+      })
+    ).id;
+
+    specialistEventId = (
+      await createTestEvent({
+        organization_id: org.id,
+        entity_id: entity.id,
+        content: 'The specialist ordered a follow-up scan for next month.',
+      })
+    ).id;
+  });
+
+  afterAll(() => {
+    global.fetch = realFetch;
+  });
+
+  beforeEach(() => {
+    cannedVariants = [];
+    installFetchStub();
+  });
+
+  it('(a) rewrite_query=true surfaces a session the raw query missed (recall improves)', async () => {
+    // Baseline: the raw query "physician" finds the physician session but not the
+    // dermatologist one (different keyword, no embeddings to bridge the synonym).
+    const baseline = await getContent(
+      { entity_id: entity.id, query: 'physician', limit: 50 } as never,
+      NO_KEY_ENV as never,
+      ctx()
+    );
+    const baselineIds = new Set(baseline.content.map((c) => c.id));
+    expect(baselineIds.has(physicianEventId)).toBe(true);
+    expect(baselineIds.has(dermatologistEventId)).toBe(false);
+    expect(fetchCalls.length).toBe(0); // text-only, no embeddings/rewrite fetch
+
+    // With rewrite_query, the LLM rewrites "physician" → ["dermatologist"],
+    // whose results union in and surface the previously-missed session.
+    cannedVariants = ['dermatologist'];
+    const expanded = await getContent(
+      { entity_id: entity.id, query: 'physician', limit: 50, rewrite_query: true } as never,
+      REWRITER_ENV as never,
+      ctx()
+    );
+    const expandedIds = new Set(expanded.content.map((c) => c.id));
+
+    // Raw-query result preserved AND the missed session now appears.
+    expect(expandedIds.has(physicianEventId)).toBe(true);
+    expect(expandedIds.has(dermatologistEventId)).toBe(true);
+
+    // The rewriter was actually consulted (exactly one chat/completions call).
+    const rewriteCalls = fetchCalls.filter((u) => u.includes('/chat/completions'));
+    expect(rewriteCalls.length).toBe(1);
+
+    // Raw result ranks first (additive union preserves raw ordering).
+    expect(expanded.content[0].id).toBe(physicianEventId);
+  });
+
+  it('(b) rewrite_query=false is identical to baseline — no rewrite, no fetch', async () => {
+    cannedVariants = ['dermatologist']; // would expand IF rewrite ran
+    const result = await getContent(
+      { entity_id: entity.id, query: 'physician', limit: 50, rewrite_query: false } as never,
+      REWRITER_ENV as never,
+      ctx()
+    );
+    const ids = new Set(result.content.map((c) => c.id));
+
+    expect(ids.has(physicianEventId)).toBe(true);
+    expect(ids.has(dermatologistEventId)).toBe(false);
+    // No rewrite path → zero fetch calls at all.
+    expect(fetchCalls.length).toBe(0);
+  });
+
+  it('(c) no API key → graceful: raw query only, no crash, no rewrite fetch', async () => {
+    cannedVariants = ['dermatologist'];
+    const result = await getContent(
+      // rewrite_query=true but the env has no QUERY_REWRITER_API_KEY.
+      { entity_id: entity.id, query: 'physician', limit: 50, rewrite_query: true } as never,
+      NO_KEY_ENV as never,
+      ctx()
+    );
+    const ids = new Set(result.content.map((c) => c.id));
+
+    expect(ids.has(physicianEventId)).toBe(true);
+    expect(ids.has(dermatologistEventId)).toBe(false);
+    // rewriteQueries() short-circuits on the missing key before any fetch.
+    expect(fetchCalls.length).toBe(0);
+  });
+
+  it('(d) union never exceeds the caller-supplied limit', async () => {
+    // Raw "physician" matches 1 session; variants would add 3 more synonym
+    // sessions. With limit=2 the union must cap at 2 rows total.
+    cannedVariants = ['dermatologist', 'ENT', 'specialist'];
+    const result = await getContent(
+      { entity_id: entity.id, query: 'physician', limit: 2, rewrite_query: true } as never,
+      REWRITER_ENV as never,
+      ctx()
+    );
+
+    expect(result.content.length).toBeLessThanOrEqual(2);
+    // Raw match is retained as the highest-priority row.
+    expect(result.content.map((c) => c.id)).toContain(physicianEventId);
+
+    // Sanity: the synonym sessions exist and a larger limit DOES pull extras in,
+    // proving the cap above was the limiter (not a missing fixture).
+    cannedVariants = ['dermatologist', 'ENT', 'specialist'];
+    const wide = await getContent(
+      { entity_id: entity.id, query: 'physician', limit: 50, rewrite_query: true } as never,
+      REWRITER_ENV as never,
+      ctx()
+    );
+    const wideIds = new Set(wide.content.map((c) => c.id));
+    expect(wideIds.has(physicianEventId)).toBe(true);
+    expect(wideIds.has(dermatologistEventId)).toBe(true);
+    expect(wideIds.has(entEventId)).toBe(true);
+    expect(wideIds.has(specialistEventId)).toBe(true);
+  });
+});

--- a/packages/server/src/__tests__/integration/events/get-content-query-rewrite.test.ts
+++ b/packages/server/src/__tests__/integration/events/get-content-query-rewrite.test.ts
@@ -6,9 +6,11 @@
  * keyword-matches poorly, so the gold session ranks below the cutoff — and a
  * synonym gap ("physician") misses sessions that say "dermatologist". The LLM
  * query rewriter expands the raw query into focused keyword variants; the search
- * branch runs the RAW query first (preserving its ranking) and unions each
- * variant's rows deduped by event id. Purely additive: variants only surface
- * sessions the raw query missed.
+ * branch runs raw + each variant with an over-fetched internal limit and FUSES
+ * the candidates (max score per event id, re-ranked, caller's offset/limit
+ * applied to the fused pool) — so a variant hit can displace a less-relevant
+ * raw row into the top-k. Fusion only applies to score-sorted, non-cursor
+ * searches; date feeds keep their ordering via the single-query path.
  *
  * The benchmark adapter gets this lift by calling
  * read_knowledge({ rewrite_query: true }) — the recall improvement lives in the
@@ -324,5 +326,65 @@ describe('getContent > rewrite_query recall expansion', () => {
     // The union held more distinct matches than the page → has_more is set.
     expect(fused.page.has_more).toBe(true);
     expect(fused.total).toBeGreaterThan(3);
+  });
+
+  it('(f) sort_by=date keeps chronological semantics — fusion is skipped entirely', async () => {
+    // Fusion re-ranks by relevance, which would destroy a chronological feed.
+    // With sort_by='date', rewrite_query must be inert: no rewriter call, and
+    // the results come back date-ordered from the single-query path.
+    cannedVariants = ['dermatologist'];
+    const result = await getContent(
+      {
+        entity_id: entity.id,
+        query: 'physician',
+        limit: 50,
+        rewrite_query: true,
+        sort_by: 'date',
+      } as never,
+      REWRITER_ENV as never,
+      ctx()
+    );
+
+    // No rewrite fetch happened (fusion ineligible under date sort)...
+    expect(fetchCalls.filter((u) => u.includes('/chat/completions')).length).toBe(0);
+    // ...so the variant-only session is absent,
+    const ids = new Set(result.content.map((c) => c.id));
+    expect(ids.has(dermatologistEventId)).toBe(false);
+    // ...and the rows are in date order (desc by default).
+    const dates = result.content.map((c) => new Date(c.occurred_at).getTime());
+    for (let i = 1; i < dates.length; i++) {
+      expect(dates[i - 1]).toBeGreaterThanOrEqual(dates[i]);
+    }
+  });
+
+  it('(g) offset pages through the FUSED ranking without overlap', async () => {
+    // The fused pool for raw "physician" + 3 variants holds 4 distinct synonym
+    // sessions. Page 1 (limit=2, offset=0) and page 2 (limit=2, offset=2) must
+    // be disjoint and together equal the wide fused result's top-4 — proving the
+    // caller's offset applies to the fused pool, not per internal query.
+    cannedVariants = ['dermatologist', 'ENT', 'specialist'];
+    const page1 = await getContent(
+      { entity_id: entity.id, query: 'physician', limit: 2, offset: 0, rewrite_query: true } as never,
+      REWRITER_ENV as never,
+      ctx()
+    );
+    cannedVariants = ['dermatologist', 'ENT', 'specialist'];
+    const page2 = await getContent(
+      { entity_id: entity.id, query: 'physician', limit: 2, offset: 2, rewrite_query: true } as never,
+      REWRITER_ENV as never,
+      ctx()
+    );
+
+    expect(page1.content.length).toBe(2);
+    expect(page2.content.length).toBeGreaterThanOrEqual(1);
+    const ids1 = new Set(page1.content.map((c) => c.id));
+    for (const row of page2.content) {
+      expect(ids1.has(row.id)).toBe(false); // disjoint pages
+    }
+    // Combined pages cover all 4 distinct synonym sessions.
+    const combined = new Set([...page1.content, ...page2.content].map((c) => c.id));
+    for (const id of [physicianEventId, dermatologistEventId, entEventId, specialistEventId]) {
+      expect(combined.has(id)).toBe(true);
+    }
   });
 });

--- a/packages/server/src/__tests__/integration/events/get-content-query-rewrite.test.ts
+++ b/packages/server/src/__tests__/integration/events/get-content-query-rewrite.test.ts
@@ -56,7 +56,7 @@ const realFetch = global.fetch;
 
 function installFetchStub(): void {
   fetchCalls = [];
-  global.fetch = (async (input: RequestInfo | URL, _init?: RequestInit) => {
+  global.fetch = (async (input: RequestInfo | URL) => {
     const url = typeof input === 'string' ? input : input.toString();
     fetchCalls.push(url);
     if (url.includes('/chat/completions')) {
@@ -87,6 +87,13 @@ describe('getContent > rewrite_query recall expansion', () => {
   // Extra synonym sessions used to prove `limit` is respected under union.
   let entEventId: number;
   let specialistEventId: number;
+
+  // Fusion / displacement fixtures (BUG-1 reproducer). The raw query
+  // "appointment" matches several low-relevance filler sessions; a rewritten
+  // variant "cardiologist" matches one short, highly-relevant session that must
+  // displace a filler row INTO the top-k even when raw already filled the page.
+  let cardiologistEventId: number;
+  const fillerAppointmentEventIds: number[] = [];
 
   function ctx(): ToolContext {
     return {
@@ -142,6 +149,42 @@ describe('getContent > rewrite_query recall expansion', () => {
         content: 'The specialist ordered a follow-up scan for next month.',
       })
     ).id;
+
+    // Three filler sessions match the raw query "appointment" and fill a limit=3
+    // page. Two contain the literal "appointment" (so the ranker's ILIKE
+    // whole-query-substring boost applies → score ≈ 1.4). The first uses the
+    // stem-only form "appoints" — it matches the english-tsquery for
+    // "appointment" (both stem to "appoint") but NOT the ILIKE '%appointment%'
+    // substring, so it forgoes that boost and scores LOW (≈ 0.4). That makes it
+    // the deterministically weakest raw hit — the one a strong variant hit must
+    // displace from the top-k.
+    const fillerContents = [
+      'I keep appoints lined up across many errands, groceries, laundry, emails, ' +
+        'meetings and assorted chores that fill the whole long rambling busy day.',
+      'Random note one: I had an appointment among errands, groceries, laundry, ' +
+        'emails, meetings and chores that fill the whole long rambling busy day.',
+      'Random note two: I had an appointment among errands, groceries, laundry, ' +
+        'emails, meetings and chores that fill the whole long rambling busy day.',
+    ];
+    for (const content of fillerContents) {
+      const id = (
+        await createTestEvent({ organization_id: org.id, entity_id: entity.id, content })
+      ).id;
+      fillerAppointmentEventIds.push(id);
+    }
+
+    // A short, on-topic session for the variant term "cardiologist". It does NOT
+    // contain "appointment", so the raw query misses it entirely; only the
+    // variant surfaces it, and as the dominant token in a short doc it scores
+    // HIGH — so fusion must promote it into the top-k, displacing a low-relevance
+    // filler row.
+    cardiologistEventId = (
+      await createTestEvent({
+        organization_id: org.id,
+        entity_id: entity.id,
+        content: 'Cardiologist visit.',
+      })
+    ).id;
   });
 
   afterAll(() => {
@@ -176,16 +219,14 @@ describe('getContent > rewrite_query recall expansion', () => {
     );
     const expandedIds = new Set(expanded.content.map((c) => c.id));
 
-    // Raw-query result preserved AND the missed session now appears.
+    // Raw-query result preserved AND the missed session now appears (fusion pools
+    // both queries' hits and re-ranks by relevance).
     expect(expandedIds.has(physicianEventId)).toBe(true);
     expect(expandedIds.has(dermatologistEventId)).toBe(true);
 
     // The rewriter was actually consulted (exactly one chat/completions call).
     const rewriteCalls = fetchCalls.filter((u) => u.includes('/chat/completions'));
     expect(rewriteCalls.length).toBe(1);
-
-    // Raw result ranks first (additive union preserves raw ordering).
-    expect(expanded.content[0].id).toBe(physicianEventId);
   });
 
   it('(b) rewrite_query=false is identical to baseline — no rewrite, no fetch', async () => {
@@ -219,9 +260,9 @@ describe('getContent > rewrite_query recall expansion', () => {
     expect(fetchCalls.length).toBe(0);
   });
 
-  it('(d) union never exceeds the caller-supplied limit', async () => {
-    // Raw "physician" matches 1 session; variants would add 3 more synonym
-    // sessions. With limit=2 the union must cap at 2 rows total.
+  it('(d) fusion never exceeds the caller-supplied limit (and flags has_more)', async () => {
+    // Raw "physician" + variants match 4 distinct synonym sessions. With limit=2
+    // the fused, re-ranked result must cap at 2 rows and report has_more.
     cannedVariants = ['dermatologist', 'ENT', 'specialist'];
     const result = await getContent(
       { entity_id: entity.id, query: 'physician', limit: 2, rewrite_query: true } as never,
@@ -229,11 +270,11 @@ describe('getContent > rewrite_query recall expansion', () => {
       ctx()
     );
 
-    expect(result.content.length).toBeLessThanOrEqual(2);
-    // Raw match is retained as the highest-priority row.
-    expect(result.content.map((c) => c.id)).toContain(physicianEventId);
+    expect(result.content.length).toBe(2);
+    expect(result.total).toBeGreaterThan(2); // pool had more distinct matches
+    expect(result.page.has_more).toBe(true);
 
-    // Sanity: the synonym sessions exist and a larger limit DOES pull extras in,
+    // Sanity: the synonym sessions exist and a larger limit DOES pull them all in,
     // proving the cap above was the limiter (not a missing fixture).
     cannedVariants = ['dermatologist', 'ENT', 'specialist'];
     const wide = await getContent(
@@ -246,5 +287,42 @@ describe('getContent > rewrite_query recall expansion', () => {
     expect(wideIds.has(dermatologistEventId)).toBe(true);
     expect(wideIds.has(entEventId)).toBe(true);
     expect(wideIds.has(specialistEventId)).toBe(true);
+  });
+
+  it('(e) fusion pulls a more-relevant variant hit into a full top-k page (displaces filler)', async () => {
+    // Baseline: with rewrite OFF, the raw query "appointment" returns a full
+    // limit=3 page of low-relevance filler sessions and does NOT surface the
+    // highly-relevant "Cardiologist appointment." session as the variant term.
+    const baseline = await getContent(
+      { entity_id: entity.id, query: 'appointment', limit: 3 } as never,
+      NO_KEY_ENV as never,
+      ctx()
+    );
+    const baselineIds = new Set(baseline.content.map((c) => c.id));
+    // The raw page is full (3) and made entirely of filler; the cardiologist row
+    // does not match "appointment" at all, so it is absent pre-rewrite.
+    expect(baseline.content.length).toBe(3);
+    for (const id of baselineIds) {
+      expect(fillerAppointmentEventIds).toContain(id);
+    }
+    expect(baselineIds.has(cardiologistEventId)).toBe(false);
+
+    // With rewrite ON, the variant "cardiologist" scores the short on-topic
+    // session HIGH; fusion re-ranks across raw+variant and the cardiologist row
+    // must now appear in the top-k even though raw already filled the page —
+    // proving fusion (displacement), not fill-leftover-slots.
+    cannedVariants = ['cardiologist'];
+    const fused = await getContent(
+      { entity_id: entity.id, query: 'appointment', limit: 3, rewrite_query: true } as never,
+      REWRITER_ENV as never,
+      ctx()
+    );
+    const fusedIds = new Set(fused.content.map((c) => c.id));
+
+    expect(fused.content.length).toBe(3);
+    expect(fusedIds.has(cardiologistEventId)).toBe(true);
+    // The union held more distinct matches than the page → has_more is set.
+    expect(fused.page.has_more).toBe(true);
+    expect(fused.total).toBeGreaterThan(3);
   });
 });

--- a/packages/server/src/tools/get_content.ts
+++ b/packages/server/src/tools/get_content.ts
@@ -1046,43 +1046,60 @@ export async function getContent(
         after_id: args.after_id,
       };
 
-      const result = await searchContentByText(args.query ?? null, searchOptions, env);
-
       // Query-rewrite recall expansion (opt-in, only with an actual text query).
-      // Run the RAW query first (preserving its ranking), then each LLM-rewritten
-      // variant, and union the rows deduped by event id. This is purely additive:
-      // variants only contribute sessions the raw query missed, so existing
-      // callers (default rewrite_query=false) are byte-for-byte unaffected, and a
-      // rewrite that returns no variants behaves exactly like a single raw query.
-      // Stateless per-request — correct under N>1 replicas (no shared state).
-      if (args.rewrite_query === true && args.query) {
-        const variants = await rewriteQueries(args.query, env);
-        if (variants.length > 0) {
-          const merged: typeof result.content = [...result.content];
-          const seenIds = new Set(merged.map((row) => row.id));
+      // Instead of filling leftover slots after the raw page (which can't help
+      // when the raw query already returns a full `limit` page of the WRONG
+      // sessions), do proper multi-query relevance fusion: search the raw query
+      // and each LLM-rewritten variant with an over-fetched internal limit, pool
+      // the candidates keyed by event id keeping each id's MAX relevance score,
+      // then sort by score and slice to the caller's `limit`. A variant-found
+      // session can thus displace a less-relevant raw row INTO the top-k while
+      // the result stays relevance-ranked. Variants are focused versions of the
+      // same question, so regression risk is low. Stateless per-request —
+      // correct under N>1 replicas (no shared state). Default rewrite_query=false
+      // keeps every existing caller on the single-query path below, unchanged.
+      const variants =
+        args.rewrite_query === true && args.query ? await rewriteQueries(args.query, env) : [];
 
-          for (const variant of variants) {
-            if (merged.length >= limit) break;
-            const variantResult = await searchContentByText(variant, searchOptions, env);
-            for (const row of variantResult.content) {
-              if (merged.length >= limit) break;
-              if (seenIds.has(row.id)) continue;
-              seenIds.add(row.id);
-              merged.push(row);
+      if (variants.length > 0 && args.query) {
+        // Over-fetch per query so fusion has a real candidate pool to re-rank
+        // (a variant's best hit may sit past the caller's `limit` in its own
+        // ranking). The caller's `limit` is only applied to the final pool.
+        const fetchLimit = Math.max(limit * 4, 40);
+        const fusionOptions = { ...searchOptions, limit: fetchLimit };
+
+        // candidate pool: event id -> best (max-score) row seen across all queries.
+        const pool = new Map<number, { row: ContentRow; score: number }>();
+        const fuseInto = (rows: ContentRow[]) => {
+          for (const row of rows) {
+            const score = row.combined_score ?? row.similarity ?? 0;
+            const existing = pool.get(row.id);
+            if (!existing || score > existing.score) {
+              pool.set(row.id, { row, score });
             }
           }
+        };
 
-          rawContent = merged;
-          // Reflect the unioned recall in total without ever shrinking it below
-          // the raw query's own total (the union only adds rows).
-          total = Math.max(result.total, merged.length);
-          pageInfo = result.page;
-        } else {
-          rawContent = result.content;
-          total = result.total;
-          pageInfo = result.page;
+        const rawResult = await searchContentByText(args.query, fusionOptions, env);
+        fuseInto(rawResult.content);
+        for (const variant of variants) {
+          const variantResult = await searchContentByText(variant, fusionOptions, env);
+          fuseInto(variantResult.content);
         }
+
+        const ranked = [...pool.values()].sort((a, b) => b.score - a.score).map((c) => c.row);
+
+        rawContent = ranked.slice(0, limit);
+        // total = distinct matching rows across raw+variants (pre-slice); has_more
+        // when the pool held more than we returned.
+        total = ranked.length;
+        pageInfo = {
+          limit,
+          offset,
+          has_more: ranked.length > limit,
+        };
       } else {
+        const result = await searchContentByText(args.query ?? null, searchOptions, env);
         rawContent = result.content;
         total = result.total;
         pageInfo = result.page;

--- a/packages/server/src/tools/get_content.ts
+++ b/packages/server/src/tools/get_content.ts
@@ -1058,15 +1058,29 @@ export async function getContent(
       // same question, so regression risk is low. Stateless per-request —
       // correct under N>1 replicas (no shared state). Default rewrite_query=false
       // keeps every existing caller on the single-query path below, unchanged.
-      const variants =
-        args.rewrite_query === true && args.query ? await rewriteQueries(args.query, env) : [];
+      // Fusion is relevance-ranked by construction, so it only applies to
+      // score-sorted searches. A chronological feed (sort_by='date') or a
+      // cursor-anchored page must keep its ordering semantics — those fall
+      // through to the single-query path even when rewrite_query is set.
+      const fusionEligible =
+        args.rewrite_query === true &&
+        !!args.query &&
+        (args.sort_by ?? 'score') === 'score' &&
+        !args.before_occurred_at &&
+        !args.after_occurred_at;
+      const variants = fusionEligible ? await rewriteQueries(args.query as string, env) : [];
 
       if (variants.length > 0 && args.query) {
         // Over-fetch per query so fusion has a real candidate pool to re-rank
         // (a variant's best hit may sit past the caller's `limit` in its own
-        // ranking). The caller's `limit` is only applied to the final pool.
-        const fetchLimit = Math.max(limit * 4, 40);
-        const fusionOptions = { ...searchOptions, limit: fetchLimit };
+        // ranking), capped so a large caller limit can't fan out into tens of
+        // thousands of rows across the variant queries. The caller's
+        // limit/offset apply to the FINAL fused pool only — each internal
+        // search reads its query's top-of-ranking from offset 0 (re-applying
+        // the caller's offset per query would skip different rows per query
+        // and break the fused page).
+        const fetchLimit = Math.min(Math.max((limit + offset) * 4, 40), 400);
+        const fusionOptions = { ...searchOptions, limit: fetchLimit, offset: 0 };
 
         // candidate pool: event id -> best (max-score) row seen across all queries.
         const pool = new Map<number, { row: ContentRow; score: number }>();
@@ -1089,14 +1103,15 @@ export async function getContent(
 
         const ranked = [...pool.values()].sort((a, b) => b.score - a.score).map((c) => c.row);
 
-        rawContent = ranked.slice(0, limit);
+        // The caller's offset/limit page out of the FUSED ranking.
+        rawContent = ranked.slice(offset, offset + limit);
         // total = distinct matching rows across raw+variants (pre-slice); has_more
-        // when the pool held more than we returned.
+        // when the pool extends past this page.
         total = ranked.length;
         pageInfo = {
           limit,
           offset,
-          has_more: ranked.length > limit,
+          has_more: ranked.length > offset + limit,
         };
       } else {
         const result = await searchContentByText(args.query ?? null, searchOptions, env);

--- a/packages/server/src/tools/get_content.ts
+++ b/packages/server/src/tools/get_content.ts
@@ -31,6 +31,7 @@ import { parseJsonObject } from '@lobu/core';
 import { parseDateAlias, toEndOfDay } from '../utils/date-aliases';
 import { type DataSourceContext, executeDataSources } from '../utils/execute-data-sources';
 import logger from '../utils/logger';
+import { rewriteQueries } from '../utils/query-rewriter';
 
 /**
  * Build the common SELECT columns, JOINs, and classification subquery
@@ -206,6 +207,13 @@ export const GetContentSchema = Type.Object({
         'Weight of vector similarity vs text rank in combined_score (0.0-1.0, default: 0.6). Higher values favor semantic match over keyword overlap. Only applies when a query and embeddings are both present.',
       minimum: 0.0,
       maximum: 1.0,
+    })
+  ),
+  rewrite_query: Type.Optional(
+    Type.Boolean({
+      description:
+        'Expand a conversational/underspecified query into focused keyword variants (LLM) and union their results to improve recall. Default false.',
+      default: false,
     })
   ),
   classification_filters: Type.Optional(
@@ -999,47 +1007,86 @@ export async function getContent(
       };
     } else {
       logger.info(`[get_content] ${args.query ? 'Search query provided' : 'Listing content'}`);
-      const result = await searchContentByText(
-        args.query ?? null,
-        {
-          entity_id: args.entity_id,
-          organization_id: !args.entity_id ? ctx.organizationId : undefined,
-          connection_ids: effectiveConnectionIds,
-          feed_ids: args.feed_ids,
-          run_ids: args.run_ids,
-          visibility_scope: visibilityScope,
-          window_id: args.window_id,
-          exclude_watcher_id: args.exclude_watcher_id,
-          platform: effectivePlatform,
-          since: args.since,
-          until: args.until,
-          engagement_min: args.engagement_min,
-          engagement_max: args.engagement_max,
-          min_similarity: args.min_similarity,
-          include_classifications: true,
-          classification_filters: classificationFilters,
-          classification_source: args.classification_source,
-          semantic_type: args.semantic_type,
-          interaction_status: args.interaction_status,
-          limit,
-          offset,
-          // When a query is provided and no explicit sort_by, rank by combined_score
-          // (text + vector). Defaulting to 'date' here quietly bypasses semantic ranking
-          // and orders results newest-first, which is not what most semantic callers want.
-          // Callers can still request chronological by passing sort_by='date' explicitly.
-          sort_by: args.sort_by || (args.query ? 'score' : 'date'),
-          sort_order: args.sort_order,
-          ...(args.vector_weight !== undefined && { vector_weight: args.vector_weight }),
-          before_occurred_at: args.before_occurred_at,
-          before_id: args.before_id,
-          after_occurred_at: args.after_occurred_at,
-          after_id: args.after_id,
-        },
-        env
-      );
-      rawContent = result.content;
-      total = result.total;
-      pageInfo = result.page;
+
+      // Shared options for every searchContentByText call below. Only the query
+      // text varies across the raw query and its rewritten variants, so the
+      // per-query call stays DRY (built once, run in a loop).
+      const searchOptions = {
+        entity_id: args.entity_id,
+        organization_id: !args.entity_id ? ctx.organizationId : undefined,
+        connection_ids: effectiveConnectionIds,
+        feed_ids: args.feed_ids,
+        run_ids: args.run_ids,
+        visibility_scope: visibilityScope,
+        window_id: args.window_id,
+        exclude_watcher_id: args.exclude_watcher_id,
+        platform: effectivePlatform,
+        since: args.since,
+        until: args.until,
+        engagement_min: args.engagement_min,
+        engagement_max: args.engagement_max,
+        min_similarity: args.min_similarity,
+        include_classifications: true,
+        classification_filters: classificationFilters,
+        classification_source: args.classification_source,
+        semantic_type: args.semantic_type,
+        interaction_status: args.interaction_status,
+        limit,
+        offset,
+        // When a query is provided and no explicit sort_by, rank by combined_score
+        // (text + vector). Defaulting to 'date' here quietly bypasses semantic ranking
+        // and orders results newest-first, which is not what most semantic callers want.
+        // Callers can still request chronological by passing sort_by='date' explicitly.
+        sort_by: args.sort_by || (args.query ? 'score' : 'date'),
+        sort_order: args.sort_order,
+        ...(args.vector_weight !== undefined && { vector_weight: args.vector_weight }),
+        before_occurred_at: args.before_occurred_at,
+        before_id: args.before_id,
+        after_occurred_at: args.after_occurred_at,
+        after_id: args.after_id,
+      };
+
+      const result = await searchContentByText(args.query ?? null, searchOptions, env);
+
+      // Query-rewrite recall expansion (opt-in, only with an actual text query).
+      // Run the RAW query first (preserving its ranking), then each LLM-rewritten
+      // variant, and union the rows deduped by event id. This is purely additive:
+      // variants only contribute sessions the raw query missed, so existing
+      // callers (default rewrite_query=false) are byte-for-byte unaffected, and a
+      // rewrite that returns no variants behaves exactly like a single raw query.
+      // Stateless per-request — correct under N>1 replicas (no shared state).
+      if (args.rewrite_query === true && args.query) {
+        const variants = await rewriteQueries(args.query, env);
+        if (variants.length > 0) {
+          const merged: typeof result.content = [...result.content];
+          const seenIds = new Set(merged.map((row) => row.id));
+
+          for (const variant of variants) {
+            if (merged.length >= limit) break;
+            const variantResult = await searchContentByText(variant, searchOptions, env);
+            for (const row of variantResult.content) {
+              if (merged.length >= limit) break;
+              if (seenIds.has(row.id)) continue;
+              seenIds.add(row.id);
+              merged.push(row);
+            }
+          }
+
+          rawContent = merged;
+          // Reflect the unioned recall in total without ever shrinking it below
+          // the raw query's own total (the union only adds rows).
+          total = Math.max(result.total, merged.length);
+          pageInfo = result.page;
+        } else {
+          rawContent = result.content;
+          total = result.total;
+          pageInfo = result.page;
+        }
+      } else {
+        rawContent = result.content;
+        total = result.total;
+        pageInfo = result.page;
+      }
     }
 
     // Optionally fetch classification statistics (aggregated across ALL matching content, not just paginated results)

--- a/packages/server/src/tools/get_content.ts
+++ b/packages/server/src/tools/get_content.ts
@@ -1008,9 +1008,6 @@ export async function getContent(
     } else {
       logger.info(`[get_content] ${args.query ? 'Search query provided' : 'Listing content'}`);
 
-      // Shared options for every searchContentByText call below. Only the query
-      // text varies across the raw query and its rewritten variants, so the
-      // per-query call stays DRY (built once, run in a loop).
       const searchOptions = {
         entity_id: args.entity_id,
         organization_id: !args.entity_id ? ctx.organizationId : undefined,
@@ -1046,40 +1043,35 @@ export async function getContent(
         after_id: args.after_id,
       };
 
-      // Query-rewrite recall expansion (opt-in, only with an actual text query).
-      // Instead of filling leftover slots after the raw page (which can't help
-      // when the raw query already returns a full `limit` page of the WRONG
-      // sessions), do proper multi-query relevance fusion: search the raw query
-      // and each LLM-rewritten variant with an over-fetched internal limit, pool
-      // the candidates keyed by event id keeping each id's MAX relevance score,
-      // then sort by score and slice to the caller's `limit`. A variant-found
-      // session can thus displace a less-relevant raw row INTO the top-k while
-      // the result stays relevance-ranked. Variants are focused versions of the
-      // same question, so regression risk is low. Stateless per-request —
-      // correct under N>1 replicas (no shared state). Default rewrite_query=false
-      // keeps every existing caller on the single-query path below, unchanged.
-      // Fusion is relevance-ranked by construction, so it only applies to
-      // score-sorted searches. A chronological feed (sort_by='date') or a
-      // cursor-anchored page must keep its ordering semantics — those fall
-      // through to the single-query path even when rewrite_query is set.
+      // Query-rewrite recall expansion (opt-in): multi-query relevance fusion
+      // over the raw query + LLM-rewritten variants, so a variant-found row can
+      // displace a less-relevant raw row into the top-k. Fusion re-ranks by
+      // relevance, so it only applies to score-sorted, non-cursor searches with
+      // a page window inside the fetch cap — date feeds, cursor pages, and
+      // deeper windows keep single-query semantics even when rewrite_query is
+      // set. Stateless per-request (multi-replica-safe); default false leaves
+      // existing callers on the single-query path unchanged.
+      const FUSION_FETCH_CAP = 400;
       const fusionEligible =
         args.rewrite_query === true &&
         !!args.query &&
         (args.sort_by ?? 'score') === 'score' &&
         !args.before_occurred_at &&
-        !args.after_occurred_at;
+        !args.after_occurred_at &&
+        offset + limit <= FUSION_FETCH_CAP;
       const variants = fusionEligible ? await rewriteQueries(args.query as string, env) : [];
 
       if (variants.length > 0 && args.query) {
         // Over-fetch per query so fusion has a real candidate pool to re-rank
         // (a variant's best hit may sit past the caller's `limit` in its own
         // ranking), capped so a large caller limit can't fan out into tens of
-        // thousands of rows across the variant queries. The caller's
-        // limit/offset apply to the FINAL fused pool only — each internal
-        // search reads its query's top-of-ranking from offset 0 (re-applying
-        // the caller's offset per query would skip different rows per query
-        // and break the fused page).
-        const fetchLimit = Math.min(Math.max((limit + offset) * 4, 40), 400);
+        // thousands of rows across the variant queries. Eligibility above
+        // guarantees offset+limit fits inside the cap, so the slice below can
+        // never page past the fetched pool. Each internal search reads its
+        // query's top-of-ranking from offset 0 (re-applying the caller's
+        // offset per query would skip different rows per query and break the
+        // fused page).
+        const fetchLimit = Math.min(Math.max((limit + offset) * 4, 40), FUSION_FETCH_CAP);
         const fusionOptions = { ...searchOptions, limit: fetchLimit, offset: 0 };
 
         // candidate pool: event id -> best (max-score) row seen across all queries.
@@ -1094,24 +1086,30 @@ export async function getContent(
           }
         };
 
+        // Sentinel: a query whose fetch came back full may have more matches
+        // beyond the cap, so the pool is a LOWER BOUND on the true fused total
+        // and deep pages must not be reported as exhausted.
+        let poolTruncated = false;
         const rawResult = await searchContentByText(args.query, fusionOptions, env);
         fuseInto(rawResult.content);
+        poolTruncated ||= rawResult.content.length >= fetchLimit;
         for (const variant of variants) {
           const variantResult = await searchContentByText(variant, fusionOptions, env);
           fuseInto(variantResult.content);
+          poolTruncated ||= variantResult.content.length >= fetchLimit;
         }
 
         const ranked = [...pool.values()].sort((a, b) => b.score - a.score).map((c) => c.row);
 
         // The caller's offset/limit page out of the FUSED ranking.
         rawContent = ranked.slice(offset, offset + limit);
-        // total = distinct matching rows across raw+variants (pre-slice); has_more
-        // when the pool extends past this page.
+        // total = distinct fused candidates (a lower bound when any per-query
+        // fetch hit the cap); has_more stays conservative via the sentinel.
         total = ranked.length;
         pageInfo = {
           limit,
           offset,
-          has_more: ranked.length > offset + limit,
+          has_more: poolTruncated || ranked.length > offset + limit,
         };
       } else {
         const result = await searchContentByText(args.query ?? null, searchOptions, env);

--- a/packages/server/src/utils/query-rewriter.ts
+++ b/packages/server/src/utils/query-rewriter.ts
@@ -1,0 +1,138 @@
+/**
+ * Server-side query rewriter for retrieval recall.
+ *
+ * Conversational / underspecified questions retrieve poorly:
+ *   - Filler ("I think we discussed X earlier, can you remind me…") embeds and
+ *     keyword-matches noisily, so the gold session ranks below the cutoff.
+ *   - Synonym gaps ("how many doctors") miss sessions that say
+ *     "physician" / "ENT" / "dermatologist".
+ *
+ * This helper asks a small LLM to rewrite the question into a few focused
+ * keyword search queries (filler stripped, synonym variants added). The caller
+ * (read_knowledge / get_content) runs the RAW query first, then unions these
+ * variants' results — so the feature is purely additive: variants only surface
+ * sessions the raw query missed. The benchmark adapter calls
+ * read_knowledge({ rewrite_query: true }) and gets this recall lift from the
+ * SERVER, so it's a product capability, not adapter glue.
+ *
+ * Statelessness: this is a pure per-request retrieval helper. It holds no
+ * shared/in-memory state, so it is trivially correct under N>1 app replicas —
+ * each request rewrites independently, nothing to fan out across pods.
+ *
+ * Opt-in: rewriting only runs when QUERY_REWRITER_API_KEY is configured. With
+ * no key (or on any failure) it returns [] and the caller falls back to the raw
+ * query alone — so default behavior is byte-for-byte unchanged.
+ */
+
+import type { Env } from '../index';
+import logger from './logger';
+
+const DEFAULT_BASE_URL = 'https://api.openai.com/v1';
+const DEFAULT_MODEL = 'gpt-4o-mini';
+const MAX_INPUT_CHARS = 12_000;
+const TIMEOUT_MS = 30_000;
+const MAX_VARIANTS = 4;
+
+const SYSTEM_PROMPT =
+  'Rewrite the user\'s question into 3 short keyword search queries that retrieve the relevant past conversation sessions from a memory store. Strip conversational filler. Include synonym variants (doctor/physician/specialist; job/role/position). Return STRICT JSON {"queries":["...","...","..."]} only.';
+
+interface ChatCompletionResponse {
+  choices?: Array<{ message?: { content?: string | null } | null } | null> | null;
+}
+
+/**
+ * Rewrite a conversational/underspecified query into up to 4 focused keyword
+ * search-query variants (NOT including the original). Returns [] on any failure
+ * or when unconfigured — the caller falls back to the raw query only.
+ */
+export async function rewriteQueries(query: string, env: Env): Promise<string[]> {
+  const apiKey = env.QUERY_REWRITER_API_KEY;
+  // Opt-in via the API key. No key → no rewrite (graceful, default-off).
+  if (!apiKey) return [];
+
+  const trimmed = query.trim();
+  if (trimmed.length === 0) return [];
+
+  const baseUrl = (env.QUERY_REWRITER_BASE_URL || DEFAULT_BASE_URL).replace(/\/+$/, '');
+  const model = env.QUERY_REWRITER_MODEL || DEFAULT_MODEL;
+  const input = trimmed.slice(0, MAX_INPUT_CHARS);
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), TIMEOUT_MS);
+
+  try {
+    const response = await fetch(`${baseUrl}/chat/completions`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify({
+        model,
+        temperature: 0,
+        messages: [
+          { role: 'system', content: SYSTEM_PROMPT },
+          { role: 'user', content: input },
+        ],
+      }),
+      signal: controller.signal,
+    });
+
+    if (!response.ok) {
+      logger.warn(
+        { status: response.status },
+        '[query-rewriter] chat completion request failed; falling back to raw query'
+      );
+      return [];
+    }
+
+    const data = (await response.json()) as ChatCompletionResponse;
+    const content = data.choices?.[0]?.message?.content;
+    if (!content) return [];
+
+    return parseQueries(content);
+  } catch (error) {
+    // Fail open: any error (timeout/abort, network, parse) means the caller
+    // proceeds with the raw query alone.
+    logger.warn(
+      { error: error instanceof Error ? error.message : String(error) },
+      '[query-rewriter] rewrite failed; falling back to raw query'
+    );
+    return [];
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+/**
+ * Parse the model's `{"queries":[...]}` JSON (tolerating markdown code fences),
+ * drop empties, and cap at MAX_VARIANTS.
+ */
+function parseQueries(raw: string): string[] {
+  const cleaned = stripCodeFence(raw.trim());
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(cleaned);
+  } catch {
+    return [];
+  }
+
+  if (!parsed || typeof parsed !== 'object') return [];
+  const queries = (parsed as { queries?: unknown }).queries;
+  if (!Array.isArray(queries)) return [];
+
+  const out: string[] = [];
+  for (const q of queries) {
+    if (typeof q !== 'string') continue;
+    const v = q.trim();
+    if (v.length === 0) continue;
+    out.push(v);
+    if (out.length >= MAX_VARIANTS) break;
+  }
+  return out;
+}
+
+function stripCodeFence(text: string): string {
+  const fenced = text.match(/^```(?:json)?\s*([\s\S]*?)\s*```$/i);
+  return fenced?.[1] ? fenced[1].trim() : text;
+}

--- a/packages/server/src/utils/query-rewriter.ts
+++ b/packages/server/src/utils/query-rewriter.ts
@@ -9,9 +9,10 @@
  *
  * This helper asks a small LLM to rewrite the question into a few focused
  * keyword search queries (filler stripped, synonym variants added). The caller
- * (read_knowledge / get_content) runs the RAW query first, then unions these
- * variants' results — so the feature is purely additive: variants only surface
- * sessions the raw query missed. The benchmark adapter calls
+ * (read_knowledge / get_content) searches the raw query AND each variant with
+ * an over-fetched internal limit, then FUSES the candidates by best relevance
+ * score per event — so a variant-found session can displace a less-relevant
+ * raw row into the top-k. The benchmark adapter calls
  * read_knowledge({ rewrite_query: true }) and gets this recall lift from the
  * SERVER, so it's a product capability, not adapter glue.
  *


### PR DESCRIPTION
## What

Opt-in **`rewrite_query`** flag on `read_knowledge`: a small LLM expands a conversational/underspecified query into focused keyword variants, and the search branch **fuses** raw + variant results by best relevance score per event — improving retrieval recall for queries that embed poorly (conversational filler) or have synonym gaps.

## Why — recall is the one real lever (measured)

A per-question decomposition of the public [agent-memory-benchmark](https://github.com/lobu-ai/agent-memory-benchmark) showed Lobu's *entire* judged gap to the leader (80% vs 85%) was **retrieval recall** — +9 trials across 3 questions whose gold sessions Supermemory retrieved and Lobu missed. The "focused/extracted context" hypothesis was falsified (same chunks fed at same recall), which is why all extraction-side experiments regressed.

**Confirmed 3-trial mixed-60 result** (same suite/answerer/grader as the published baseline; method in the benchmark repo's METHODOLOGY):

| | Baseline (whole sessions) | + query rewrite |
| --- | --- | --- |
| Retrieval recall | 95.6% | **100.0% (all 3 trials)** |
| Answer (substring) | 68.3% (66.7–70.0) | 69.4% (68.3–70.0) |
| multi-session | 67% | **87%** |
| knowledge-update | 93% | 83% (adapter-context effect; server-side supersede masking prevents it in real deployments) |

LLM-judged number pending (judge quota); the leaderboard keeps the judged 80% baseline until then.

## Design

- `query-rewriter.ts`: OpenAI-compatible rewrite helper, **opt-in via `QUERY_REWRITER_API_KEY`** (no key → raw query only). 12k cap, 30s timeout, fails open.
- `read_knowledge` `rewrite_query` (**default false** → existing callers byte-for-byte unaffected): multi-query relevance **fusion** — each query searched with an over-fetched internal limit (capped 400), candidates pooled by max score per event id, caller's offset/limit applied to the fused ranking. Gated to score-sorted, non-cursor searches with the page window inside the cap; date feeds/cursors keep single-query semantics.
- **Multi-replica-safe**: stateless per request.

## Validation

- Integration tests vs real embedded PG (**7 cases**, green): variant surfaces a raw-missed session; off = byte-identical baseline (zero LLM calls); no-key graceful; limit cap + `has_more`; **displacement** (variant hit enters a full top-k page); date-sort passthrough (fusion skipped, ordering preserved); offset paging through the fused ranking (disjoint pages).
- Hardened across three review rounds (mine + 2× pi): fixed union short-circuit → fusion, date-sort ordering, offset double-application, unbounded fan-out, deep-page slice past the pool, falsely-exhausted `has_more` on capped pools.
- tsc clean; typecheck/unit/integration suites green (remaining suite reds are pre-existing env flakes in untouched tests, confirmed by the reviewer).

## Follow-ups (not blocking)

- Optionally default-resolve `QUERY_REWRITER_*` from existing provider config so the product gets it without net-new env vars.
- Re-grade the benchmark config with the LLM judge when quota resets; update the public leaderboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)