### PR TITLE
fix(gateway): deliver ask_user/tool-approval/link-button cards cross-replica

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -513,6 +513,16 @@ export interface ThreadResponsePayload {
   customEvent?: {
     name: string;
     data: Record<string, unknown>;
+    /**
+     * When true, this customEvent is an interaction card (ask_user question,
+     * tool-approval, link-button) that must reach the browser's SSE socket,
+     * which lives on exactly one pod. The thread_response consumer treats such
+     * rows like terminal API rows: a pod that does not hold the SSE connection
+     * re-queues so the owning pod (pinned by ClientIP affinity) delivers it.
+     * Without this the card is broadcast into a pod-local SseManager the
+     * browser is not connected to and the user never sees it, hanging the turn.
+     */
+    requireSseOwner?: boolean;
   };
 
   // Exec-specific response fields (for jobType === "exec")

--- a/packages/server/src/gateway/__tests__/unified-thread-consumer.test.ts
+++ b/packages/server/src/gateway/__tests__/unified-thread-consumer.test.ts
@@ -120,6 +120,84 @@ describe("UnifiedThreadResponseConsumer customEvent broadcast", () => {
   });
 });
 
+describe("UnifiedThreadResponseConsumer interaction card owner-routing", () => {
+  function makeInteractionConsumer(hasActiveConnection: boolean) {
+    const queue = {
+      start: mock(async () => undefined),
+      stop: mock(async () => undefined),
+      createQueue: mock(async () => undefined),
+      work: mock(async () => undefined),
+    };
+    const broadcast = mock(() => undefined);
+    const sseManager = {
+      broadcast,
+      hasActiveConnection: mock(() => hasActiveConnection),
+    };
+    const platformRegistry = {
+      get: mock(() => ({
+        getResponseRenderer: () => ({
+          handleCompletion: mock(async () => undefined),
+          handleError: mock(async () => undefined),
+        }),
+      })),
+    };
+    const consumer = new UnifiedThreadResponseConsumer(
+      queue as any,
+      platformRegistry as any,
+      sseManager as any
+    ) as any;
+    return { consumer, broadcast, sseManager };
+  }
+
+  const interactionPayload = {
+    messageId: "m-int-1",
+    channelId: "api:conv-1",
+    conversationId: "api:conv-1",
+    userId: "u1",
+    teamId: "api",
+    platform: "api",
+    timestamp: 1234,
+    customEvent: {
+      name: "question",
+      data: { type: "question", questionId: "q_1", question: "Proceed?" },
+      requireSseOwner: true,
+    },
+  };
+
+  test("re-queues an ask_user card when this pod does not own the SSE", async () => {
+    const { consumer, broadcast, sseManager } = makeInteractionConsumer(false);
+
+    await expect(
+      consumer.handleThreadResponse({ id: "job-1", data: interactionPayload })
+    ).rejects.toThrow(/not owned by this gateway instance/);
+
+    expect(sseManager.hasActiveConnection).toHaveBeenCalledWith("api:conv-1");
+    // Must NOT broadcast into the wrong pod's SseManager.
+    expect(broadcast).not.toHaveBeenCalled();
+  });
+
+  test("delivers the card on the pod that owns the SSE connection", async () => {
+    const { consumer, broadcast } = makeInteractionConsumer(true);
+
+    await consumer.handleThreadResponse({
+      id: "job-2",
+      data: interactionPayload,
+    });
+
+    const questionBroadcasts = broadcast.mock.calls.filter(
+      (call: any[]) => call[1] === "question"
+    );
+    expect(questionBroadcasts.length).toBe(1);
+    expect(questionBroadcasts[0][0]).toBe("api:conv-1");
+    expect(questionBroadcasts[0][2]).toMatchObject({
+      type: "question",
+      questionId: "q_1",
+      messageId: "m-int-1",
+      timestamp: 1234,
+    });
+  });
+});
+
 describe("UnifiedThreadResponseConsumer Chat SDK ownership", () => {
   test("throws for Chat SDK connection responses not owned by this gateway", async () => {
     const chatResponseBridge = {

--- a/packages/server/src/gateway/api/platform.ts
+++ b/packages/server/src/gateway/api/platform.ts
@@ -7,7 +7,13 @@
  */
 
 import { randomUUID } from "node:crypto";
-import { createLogger, type InstructionProvider } from "@lobu/core";
+import {
+  createLogger,
+  type InstructionProvider,
+  type ThreadResponsePayload,
+} from "@lobu/core";
+import type { IMessageQueue } from "../infrastructure/queue/index.js";
+import { TERMINAL_DELIVERY_SEND_OPTS } from "../infrastructure/queue/index.js";
 import type { CoreServices, PlatformAdapter } from "../platform.js";
 import type { ResponseRenderer } from "../platform/response-renderer.js";
 import { ApiResponseRenderer } from "./response-renderer.js";
@@ -46,34 +52,43 @@ export class ApiPlatform implements PlatformAdapter {
       watcherRunTracker
     );
 
-    // Subscribe to interaction events to broadcast to SSE clients
+    // Subscribe to interaction events and deliver them to SSE clients.
+    //
+    // These cards (ask_user question, tool-approval, link-button) are raised by
+    // the worker on ITS pod, but the browser's SSE stream is pinned by ClientIP
+    // affinity to a possibly DIFFERENT pod. The SseManager is per-pod and
+    // in-memory, so broadcasting directly here would land the card on the
+    // worker's pod, which the browser is not connected to — the user never sees
+    // it and the turn hangs. Instead we enqueue each card onto the Postgres
+    // thread_response queue marked `requireSseOwner`, so the consumer's
+    // owner-routing re-queue delivers it on the pod that holds the SSE socket
+    // (same mechanism that already owner-routes terminal API completions).
     const interactionService = services.getInteractionService();
+    const queue = services.getQueue();
 
     interactionService.on("question:created", (event: any) => {
       if (event.platform !== "api") return;
-      sseManager.broadcast(event.conversationId, "question", {
+      this.enqueueInteractionCard(queue, event, "question", {
         type: "question",
         questionId: event.id,
         question: event.question,
         options: event.options,
-        timestamp: Date.now(),
       });
     });
 
     interactionService.on("link-button:created", (event: any) => {
       if (event.platform !== "api") return;
-      sseManager.broadcast(event.conversationId, "link-button", {
+      this.enqueueInteractionCard(queue, event, "link-button", {
         type: "link-button",
         url: event.url,
         label: event.label,
         linkType: event.linkType,
-        timestamp: Date.now(),
       });
     });
 
     interactionService.on("tool:approval-needed", (event: any) => {
       if (event.platform !== "api") return;
-      sseManager.broadcast(event.conversationId, "tool-approval", {
+      this.enqueueInteractionCard(queue, event, "tool-approval", {
         type: "tool-approval",
         requestId: event.id,
         mcpId: event.mcpId,
@@ -81,20 +96,51 @@ export class ApiPlatform implements PlatformAdapter {
         args: event.args,
         grantPattern: event.grantPattern,
         durationOptions: ["1h", "24h", "always"],
-        timestamp: Date.now(),
       });
     });
 
     interactionService.on("suggestion:created", (event: any) => {
       if (event.platform !== "api") return;
-      sseManager.broadcast(event.conversationId, "suggestion", {
+      this.enqueueInteractionCard(queue, event, "suggestion", {
         type: "suggestion",
         prompts: event.prompts,
-        timestamp: Date.now(),
       });
     });
 
     logger.debug("✅ API platform initialized");
+  }
+
+  /**
+   * Enqueue an interaction card onto the thread_response queue so the pod that
+   * owns the browser's SSE connection delivers it (cross-replica safe). The
+   * consumer broadcasts `customEvent.name` on `conversationId`; the
+   * `requireSseOwner` flag makes a non-owning pod re-queue rather than drop it.
+   */
+  private enqueueInteractionCard(
+    queue: IMessageQueue,
+    event: { conversationId: string; userId?: string },
+    name: string,
+    data: Record<string, unknown>
+  ): void {
+    const payload: ThreadResponsePayload = {
+      messageId: randomUUID(),
+      conversationId: event.conversationId,
+      // For the API platform channelId == conversationId == the SSE key.
+      channelId: event.conversationId,
+      userId: event.userId ?? "api",
+      platform: "api",
+      teamId: "api",
+      timestamp: Date.now(),
+      customEvent: { name, data, requireSseOwner: true },
+    };
+    void queue
+      .send("thread_response", payload, TERMINAL_DELIVERY_SEND_OPTS)
+      .catch((err) => {
+        logger.error(
+          `Failed to enqueue ${name} interaction card for ${event.conversationId}:`,
+          err
+        );
+      });
   }
 
   /**

--- a/packages/server/src/gateway/platform/unified-thread-consumer.ts
+++ b/packages/server/src/gateway/platform/unified-thread-consumer.ts
@@ -195,10 +195,22 @@ export class UnifiedThreadResponseConsumer {
         data.error ||
         (data.processedMessageIds && data.processedMessageIds.length)
       );
+      // Interaction cards (ask_user question, tool-approval, link-button) are
+      // pushed to the browser's SSE socket, which lives on exactly one pod.
+      // Like terminal rows they must be owner-routed: a non-owning pod
+      // re-queues so the pod holding the SSE connection (pinned by ClientIP
+      // affinity) delivers the card. Without this the card lands in a pod-local
+      // SseManager the browser is not connected to and the user never sees it,
+      // leaving the ask_user/tool-approval turn hung. The card-bearing rows are
+      // enqueued with `customEvent.requireSseOwner` set (see api/platform.ts)
+      // and the same raised-retry send opts as terminal rows so the re-queue
+      // window covers the cross-pod hand-off and the browser's POST→connect gap.
+      const requiresSseOwner =
+        isTerminal || data.customEvent?.requireSseOwner === true;
       const sseKey =
         (data.platformMetadata?.sessionId as string) || data.conversationId;
       if (
-        isTerminal &&
+        requiresSseOwner &&
         sseKey &&
         !this.sseManager.hasActiveConnection(sseKey)
       ) {


### PR DESCRIPTION
## Summary

Fixes the highest-impact multi-replica gap from the audit: **`ask_user` / tool-approval / link-button cards never reach the browser under `replicaCount>=2`, hanging the turn.**

### The bug
Interaction cards on the API/SSE path were broadcast straight into the in-process `InteractionService` EventEmitter → a **pod-local** `SseManager`. Under `replicaCount>=2` with `sessionAffinity: ClientIP`, the worker raises the card on *its* pod, but the browser's SSE stream is pinned to a *different* pod. The broadcast lands where no client is connected, the user never sees the card, and the `ask_user`/tool-approval turn hangs forever.

### The key insight
The worker does **not** block — it ends the turn and resumes from the Postgres-backed inbound queue when the answer arrives (already cross-pod safe). So the *only* thing broken cross-pod was **delivering the card to the browser's SSE socket on the right pod**.

The `thread_response` queue already solves exactly this for terminal API completions, via an owner-routing re-queue gated on `SseManager.hasActiveConnection` (`unified-thread-consumer.ts`). This change reuses that proven mechanism rather than inventing a new one.

## Changes
- **`api/platform.ts`** — the 4 interaction listeners now enqueue a `thread_response` `customEvent` row (marked `requireSseOwner`, with the same raised-retry `TERMINAL_DELIVERY_SEND_OPTS`) instead of calling `sseManager.broadcast` directly.
- **`unified-thread-consumer.ts`** — the API owner-gate re-queues a `customEvent` row with `requireSseOwner` when this pod does not hold the SSE connection, so the owning pod (pinned by ClientIP) delivers it.
- **core types** — adds `ThreadResponsePayload.customEvent.requireSseOwner`.

## Why it holds under N>1
worker emits on pod A → enqueue (Postgres) → pods A/B/C compete via `SKIP-LOCKED` → non-owner pods re-queue → the pod holding the browser SSE (pinned by ClientIP) claims and broadcasts. The **platform path is unchanged** (it already owner-routes by `connectionId`).

## Tests (red→green reproducer)
`unified-thread-consumer.test.ts` adds two cases that directly encode the bug and fix:
- **re-queues** an `ask_user` card (throws "not owned by this gateway instance", does **not** broadcast) when this pod lacks the SSE connection — the previous code would have silently broadcast into the void here;
- **delivers** the card (`broadcast(conversationId, "question", …)`) when this pod owns the SSE.

All 6 consumer tests pass; `sse-manager` (existing) and `agent-session-create` suites pass; `tsc` clean across core + server.

## Scope notes
- The pre-existing `suggestion:created` dead-path (the event carries no `platform` field, so `event.platform !== "api"` is always true) is **not** fixed here — it needs a separate change to set `platform` on `UserSuggestion`. The listener is converted to the new path for consistency but remains dormant until that fix.
- Backlog replay across pods (2-min TTL, pod-local) remains the documented future hardening for the disconnected-browser case; this PR fixes the connected-browser delivery, which is the hang.

Part of the production-readiness series following #1192 (security fixes).

https://claude.ai/code/session_016nCJY2vegv4byo3R4CPrbf

---
_Generated by [Claude Code](https://claude.ai/code/session_016nCJY2vegv4byo3R4CPrbf)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1194"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783653286&installation_id=136316292&pr_number=1194&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1194&signature=a1ba96ac6b270b9c0c64ce0f1a6cb0481501cf0dc346e2f235f05690e33bb9f9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->