### PR TITLE
fix(server): drain HTTP and flip readiness on shutdown so rollouts don't drop in-flight work

### DIFF
--- a/charts/lobu/templates/deployment.yaml
+++ b/charts/lobu/templates/deployment.yaml
@@ -24,6 +24,11 @@ spec:
       labels:
         {{- include "lobu.appSelectorLabels" . | nindent 8 }}
     spec:
+      # Give the app time to drain on rollout: flip readiness to 503, let the
+      # LB deregister this pod, drain in-flight HTTP, then tear down the gateway
+      # and DB pool (see server-lifecycle.ts shutdown). The kube default of 30s
+      # can SIGKILL mid-drain and drop in-flight agent runs.
+      terminationGracePeriodSeconds: {{ .Values.app.terminationGracePeriodSeconds | default 60 }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/charts/lobu/values.yaml
+++ b/charts/lobu/values.yaml
@@ -24,6 +24,11 @@ app:
   # Recreate below.
   strategy: {}
 
+  # Grace period for the app pod to drain on rollout/scale-down. Must exceed
+  # SHUTDOWN_READINESS_DELAY_MS + SHUTDOWN_HTTP_DRAIN_DEADLINE_MS (defaults
+  # 5s + 15s) plus worker drain headroom, or k8s SIGKILLs mid-drain.
+  terminationGracePeriodSeconds: 60
+
   resources:
     requests:
       cpu: 100m

--- a/packages/server/src/__tests__/lifecycle-state.test.ts
+++ b/packages/server/src/__tests__/lifecycle-state.test.ts
@@ -1,0 +1,99 @@
+import http from "node:http";
+import { afterEach, describe, expect, test } from "vitest";
+import {
+  drainHttpServer,
+  isShuttingDown,
+  parseDurationMs,
+  setShuttingDown,
+} from "../lifecycle-state.js";
+
+describe("lifecycle-state shutdown flag", () => {
+  afterEach(() => setShuttingDown(false));
+
+  test("toggles the draining flag", () => {
+    expect(isShuttingDown()).toBe(false);
+    setShuttingDown(true);
+    expect(isShuttingDown()).toBe(true);
+    setShuttingDown(false);
+    expect(isShuttingDown()).toBe(false);
+  });
+});
+
+describe("parseDurationMs", () => {
+  test("falls back on absent or invalid values, accepts valid", () => {
+    delete process.env.__TEST_DUR__;
+    expect(parseDurationMs("__TEST_DUR__", 5000)).toBe(5000);
+    process.env.__TEST_DUR__ = "not-a-number";
+    expect(parseDurationMs("__TEST_DUR__", 5000)).toBe(5000);
+    process.env.__TEST_DUR__ = "-1";
+    expect(parseDurationMs("__TEST_DUR__", 5000)).toBe(5000);
+    process.env.__TEST_DUR__ = "0";
+    expect(parseDurationMs("__TEST_DUR__", 5000)).toBe(0);
+    process.env.__TEST_DUR__ = "250";
+    expect(parseDurationMs("__TEST_DUR__", 5000)).toBe(250);
+    delete process.env.__TEST_DUR__;
+  });
+});
+
+describe("drainHttpServer", () => {
+  let server: http.Server;
+
+  afterEach(async () => {
+    if (server?.listening) {
+      await new Promise<void>((r) => server.close(() => r()));
+    }
+  });
+
+  function listen(s: http.Server): Promise<number> {
+    return new Promise((resolve) => {
+      s.listen(0, "127.0.0.1", () => {
+        resolve((s.address() as { port: number }).port);
+      });
+    });
+  }
+
+  test("closes an idle server promptly and stops accepting connections", async () => {
+    server = http.createServer((_req, res) => res.end("ok"));
+    const port = await listen(server);
+
+    await drainHttpServer(server, 5000);
+    expect(server.listening).toBe(false);
+
+    // New connections are refused after drain.
+    await expect(
+      new Promise((_resolve, reject) => {
+        const req = http.get({ host: "127.0.0.1", port, timeout: 1000 });
+        req.on("error", reject);
+        req.on("timeout", () => reject(new Error("timeout")));
+      })
+    ).rejects.toBeDefined();
+  });
+
+  test("force-closes lingering connections after the deadline", async () => {
+    let forced = 0;
+    // Handler never responds → the request is held open past the deadline.
+    server = http.createServer(() => {
+      /* intentionally no response */
+    });
+    const port = await listen(server);
+
+    // Open a request and leave it hanging.
+    const hanging = http.get({ host: "127.0.0.1", port });
+    hanging.on("error", () => {
+      /* expected: socket force-closed */
+    });
+    // Give the connection a tick to establish.
+    await new Promise((r) => setTimeout(r, 50));
+
+    const start = Date.now();
+    await drainHttpServer(server, 200, () => {
+      forced += 1;
+    });
+    const elapsed = Date.now() - start;
+
+    expect(forced).toBe(1);
+    expect(server.listening).toBe(false);
+    // Resolved around the deadline, not hung on the open socket.
+    expect(elapsed).toBeLessThan(2000);
+  });
+});

--- a/packages/server/src/__tests__/server-lifecycle.test.ts
+++ b/packages/server/src/__tests__/server-lifecycle.test.ts
@@ -328,18 +328,30 @@ describe("createServerLifecycle (source-level contract)", () => {
 		const vite = indexOf('safe("vite.close"');
 		const reaper = indexOf('safe("stopReaper"');
 		const scheduler = indexOf('safe("taskScheduler.stop"');
+		const drain = indexOf('safe("drainHttpServer"');
 		const gateway = indexOf('safe("stopLobuGateway"');
 		const db = indexOf('safe("closeDbSingleton"');
 		const extra = indexOf("safe(`extraTeardown[");
-		const close = indexOf("httpServer.close();");
 
 		expect(worker).toBeLessThan(vite);
 		expect(vite).toBeLessThan(reaper);
 		expect(reaper).toBeLessThan(scheduler);
-		expect(scheduler).toBeLessThan(gateway);
+		// HTTP is drained AFTER background loops stop but BEFORE the gateway and
+		// DB pool tear down, so in-flight requests don't hit a dead pool.
+		expect(scheduler).toBeLessThan(drain);
+		expect(drain).toBeLessThan(gateway);
 		expect(gateway).toBeLessThan(db);
 		expect(db).toBeLessThan(extra);
-		expect(extra).toBeLessThan(close);
+	});
+
+	it("flips readiness to draining before any teardown", () => {
+		// setShuttingDown(true) must run before the gateway/DB are stopped so
+		// /health/ready returns 503 and the Service deregisters the pod while
+		// in-flight requests drain. Lock the ordering against future reshuffles.
+		const flip = indexOf("setShuttingDown(true)");
+		const gateway = indexOf('safe("stopLobuGateway"');
+		expect(flip).toBeGreaterThanOrEqual(0);
+		expect(flip).toBeLessThan(gateway);
 	});
 
 	it("wraps every shutdown step in a safe() helper (one failing step does not skip the rest)", () => {

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -15,6 +15,7 @@ import { compress } from 'hono/compress';
 import { cors } from 'hono/cors';
 import { pinoLogger } from 'hono-pino';
 import { LOBU_LOGO_PNG_BASE64 } from './assets/logo';
+import { isShuttingDown } from './lifecycle-state';
 import { createAuth } from './auth';
 import { getAuthConfig as getAuthConfigFromEnv } from './auth/config';
 import { mcpAuth } from './auth/middleware';
@@ -463,6 +464,12 @@ app.get('/health', (c) => {
  * it, which is the right semantic for transient DB unavailability.
  */
 app.get('/health/ready', async (c) => {
+  // During graceful shutdown report unready FIRST, before touching the DB, so
+  // the Service deregisters this pod and stops routing new traffic while we
+  // drain in-flight requests and tear down the gateway/DB pool.
+  if (isShuttingDown()) {
+    return c.json({ status: 'draining', service: 'lobu-api' }, 503);
+  }
   try {
     const sql = getDb();
     await sql`SELECT 1`;

--- a/packages/server/src/lifecycle-state.ts
+++ b/packages/server/src/lifecycle-state.ts
@@ -1,0 +1,69 @@
+/**
+ * Process-wide lifecycle flag shared between the shutdown sequence
+ * (`server-lifecycle.ts`) and the readiness probe (`index.ts`).
+ *
+ * On SIGTERM the shutdown handler flips this to `true` BEFORE tearing anything
+ * down, so `/health/ready` immediately starts returning 503. That deregisters
+ * the pod from the k8s Service endpoint set, letting in-flight requests drain
+ * while kube-proxy stops routing new ones to a pod that is about to close its
+ * gateway and DB pool. Without it, readiness stays 200 until the listener
+ * closes at the very end of shutdown and new requests keep landing on a
+ * half-torn-down process (500s/resets on every rollout).
+ */
+import type http from "node:http";
+
+let shuttingDown = false;
+
+export function setShuttingDown(value: boolean): void {
+  shuttingDown = value;
+}
+
+export function isShuttingDown(): boolean {
+  return shuttingDown;
+}
+
+/** Parse a non-negative duration (ms) env var, falling back on absent/invalid. */
+export function parseDurationMs(name: string, fallbackMs: number): number {
+  const raw = process.env[name];
+  if (!raw) return fallbackMs;
+  const n = Number(raw);
+  return Number.isFinite(n) && n >= 0 ? n : fallbackMs;
+}
+
+/** Sleep without keeping the event loop alive solely for the timer. */
+export function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    const t = setTimeout(resolve, ms);
+    (t as { unref?: () => void }).unref?.();
+  });
+}
+
+/**
+ * Stop accepting new connections and wait for in-flight requests to finish,
+ * up to `deadlineMs`. After the deadline, force-close lingering sockets
+ * (long-lived SSE / keep-alive) so teardown can proceed. Draining the HTTP
+ * server BEFORE the gateway and DB pool means in-flight requests don't hit a
+ * half-torn-down process during a rollout. Resolves once closed or forced.
+ */
+export async function drainHttpServer(
+  server: http.Server,
+  deadlineMs: number,
+  onForceClose?: (deadlineMs: number) => void
+): Promise<void> {
+  await new Promise<void>((resolve) => {
+    let settled = false;
+    const finish = () => {
+      if (!settled) {
+        settled = true;
+        resolve();
+      }
+    };
+    server.close(() => finish());
+    const timer = setTimeout(() => {
+      onForceClose?.(deadlineMs);
+      (server as { closeAllConnections?: () => void }).closeAllConnections?.();
+      finish();
+    }, deadlineMs);
+    (timer as { unref?: () => void }).unref?.();
+  });
+}

--- a/packages/server/src/server-lifecycle.ts
+++ b/packages/server/src/server-lifecycle.ts
@@ -20,6 +20,13 @@ import * as Sentry from "@sentry/node";
 import { Hono } from "hono";
 import { closeDbSingleton } from "./db/client";
 import { mountViteDev } from "./dev-vite";
+import {
+	delay,
+	drainHttpServer,
+	parseDurationMs,
+	setShuttingDown,
+} from "./lifecycle-state";
+import { isCloudMode } from "./utils/cloud-mode";
 import type { Env } from "./index";
 import { app as mainApp } from "./index";
 import {
@@ -360,10 +367,27 @@ export function createServerLifecycle(
 		let embeddedWorker: ReturnType<typeof startEmbeddedConnectorWorker> = null;
 
 		const shutdown = async (signal: string): Promise<void> => {
+			// Flip readiness to 503 FIRST so the k8s Service deregisters this pod
+			// before we tear anything down. Then wait for that to propagate
+			// through kube-proxy so new traffic stops landing here. Defaults to
+			// 5s in cloud mode (override via SHUTDOWN_READINESS_DELAY_MS), 0 in
+			// dev/embedded where there is no LB in front of the process.
+			setShuttingDown(true);
 			logger.info(
 				{ signal, mode },
 				"Received shutdown signal, stopping gracefully...",
 			);
+			const readinessDelayMs = parseDurationMs(
+				"SHUTDOWN_READINESS_DELAY_MS",
+				isCloudMode() ? 5_000 : 0,
+			);
+			if (readinessDelayMs > 0) {
+				logger.info(
+					{ readinessDelayMs, mode },
+					"Readiness now draining (503); waiting for the load balancer to deregister this pod",
+				);
+				await delay(readinessDelayMs);
+			}
 			// Each step is wrapped in try/catch so one failing teardown can't
 			// block the rest — we still want the listener closed and the
 			// process gone, even if (say) the gateway drain rejects. Catch +
@@ -393,6 +417,25 @@ export function createServerLifecycle(
 			await safe("stopReaper", () => stopReaper());
 			//   d. Stop the task scheduler dispatch loop.
 			await safe("taskScheduler.stop", () => taskScheduler.stop());
+			//   d2. Stop accepting new HTTP and drain in-flight requests BEFORE
+			//       tearing down the gateway + DB pool those requests depend on.
+			//       Previously the listener was only closed at the very end (step
+			//       h), after the DB pool had already closed, so any request still
+			//       in flight during teardown hit a half-dead process. The embedded
+			//       connector worker (step a) is stopped first so its in-process
+			//       HTTP calls to the gateway aren't cut off by this drain.
+			const drainDeadlineMs = parseDurationMs(
+				"SHUTDOWN_HTTP_DRAIN_DEADLINE_MS",
+				15_000,
+			);
+			await safe("drainHttpServer", () =>
+				drainHttpServer(httpServer, drainDeadlineMs, (ms) =>
+					logger.warn(
+						{ deadlineMs: ms, mode },
+						"HTTP drain deadline reached; force-closing remaining connections",
+					),
+				),
+			);
 			//   e. Drain MCP sessions / DB listeners / secret-proxy. Gateway
 			//      holds postgres.js connections that must be released before
 			//      mode-specific db teardown runs.
@@ -404,9 +447,7 @@ export function createServerLifecycle(
 			for (let i = 0; i < extraTeardown.length; i++) {
 				await safe(`extraTeardown[${i}]`, extraTeardown[i]);
 			}
-			//   h. Finally, close the listener. Matches the historical behavior of
-			//      not awaiting (server.ts:260; embedded-runtime.ts:200).
-			httpServer.close();
+			//   h. Listener was already drained + closed in step d2; just exit.
 			process.exit(0);
 		};
 		// Single-flight guard: SIGTERM+SIGINT or a double-tap on either must


### PR DESCRIPTION
## Summary

Fixes the rollout/shutdown gap from the audit: **every deploy 502s in-flight traffic and can drop running agent turns.**

### The bug
On SIGTERM, `shutdown()` tore down the gateway and DB pool **before** closing the HTTP listener (`httpServer.close()` ran last), and `/health/ready` kept returning 200 the entire time. During a rolling update kube-proxy therefore kept routing new requests to a pod whose gateway + DB pool were already gone, and in-flight requests hit a half-dead process → 500s / connection resets on every deploy. There was also **no `terminationGracePeriodSeconds`**, so the kube default (30s) could SIGKILL the pod mid-teardown.

### The fix
Shutdown now drains in the correct order:
1. **Flip readiness to 503 first** (`lifecycle-state.isShuttingDown`) so the Service deregisters the pod before anything is torn down.
2. **Wait `SHUTDOWN_READINESS_DELAY_MS`** (default 5s in cloud mode, 0 in dev) for kube-proxy/LB to observe the deregistration.
3. **Drain in-flight HTTP** — stop accepting new connections and wait for active requests, with a `SHUTDOWN_HTTP_DRAIN_DEADLINE_MS=15s` deadline that force-closes lingering SSE/keep-alive sockets — **before** stopping the gateway and closing the DB pool.
4. Chart sets **`terminationGracePeriodSeconds: 60`** (configurable) so k8s waits for the drain instead of SIGKILLing.

The readiness probe returns `503 {status:"draining"}` while shutting down, before even touching the DB.

## Files
- `lifecycle-state.ts` (new) — shared `isShuttingDown` flag + `drainHttpServer` / `parseDurationMs` / `delay` helpers (lightweight module so the route and the shutdown path agree, and the drain logic is unit-testable).
- `index.ts` — `/health/ready` returns 503 when draining.
- `server-lifecycle.ts` — readiness flip + drain delay at the top of `shutdown`, HTTP drain inserted before `stopLobuGateway`/`closeDbSingleton`, redundant trailing `close()` removed.
- `charts/lobu/{templates/deployment.yaml,values.yaml}` — `terminationGracePeriodSeconds`.

## Tests
- `lifecycle-state.test.ts` (new): `drainHttpServer` closes an idle server and **force-closes a hung connection at the deadline** (asserts the force-close callback fires and it resolves near the deadline, not hung); `parseDurationMs` edge cases; the draining flag.
- `server-lifecycle.test.ts` (updated): the ordering contract now locks **"readiness flips before teardown"** and **"HTTP drains before gateway/DB"** (replacing the old `extra < httpServer.close()` assertion). 24 vitest tests pass.

## Validation
- `tsc` clean; pre-commit (biome + root tsc) green; 24 lifecycle vitest tests pass.
- The k8s chart change (`terminationGracePeriodSeconds`) is config-only and renders valid YAML; full cluster rollout behavior isn't exercised in CI (no cluster), but the app-level drain/readiness logic — the substance — is unit-tested.

## Scope notes
- This PR covers the **HTTP/readiness** drain. Bounding the **worker-subprocess** drain and fixing the SIGKILL-orphans-the-wrapper issue (the `make clean-workers` root cause) are a separate follow-up.
- Independent of #1192 (security) and #1194 (interaction delivery); all three branch off `main`.

https://claude.ai/code/session_016nCJY2vegv4byo3R4CPrbf

---
_Generated by [Claude Code](https://claude.ai/code/session_016nCJY2vegv4byo3R4CPrbf)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1195"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783653774&installation_id=136316292&pr_number=1195&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1195&signature=587087b45360f62b2f1521b6774b2b52c3128b4fdabff0f8244cf769a0c285bf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->