### PR TITLE
fix(orchestration): kill the worker process group on teardown and bound the drain

### DIFF
--- a/packages/server/src/__tests__/unit/signal-worker-group.test.ts
+++ b/packages/server/src/__tests__/unit/signal-worker-group.test.ts
@@ -1,0 +1,62 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { signalWorkerGroup } from "../../gateway/orchestration/impl/embedded-deployment";
+
+const realKill = process.kill;
+afterEach(() => {
+  process.kill = realKill;
+});
+
+describe("signalWorkerGroup", () => {
+  it("signals the negative pid (process group), not just the child", () => {
+    const calls: Array<[number, string | number]> = [];
+    process.kill = ((pid: number, sig: string | number) => {
+      calls.push([pid, sig]);
+      return true;
+    }) as typeof process.kill;
+    const childKill = () => {
+      throw new Error("child.kill should not be called when group send works");
+    };
+
+    const ok = signalWorkerGroup({ pid: 4242, kill: childKill as any }, "SIGTERM");
+
+    expect(ok).toBe(true);
+    expect(calls).toEqual([[-4242, "SIGTERM"]]);
+  });
+
+  it("falls back to child.kill when the group send fails", () => {
+    process.kill = (() => {
+      throw new Error("ESRCH");
+    }) as typeof process.kill;
+    let childSignal: NodeJS.Signals | undefined;
+    const child = {
+      pid: 99,
+      kill: (sig: NodeJS.Signals) => {
+        childSignal = sig;
+        return true;
+      },
+    };
+
+    const ok = signalWorkerGroup(child as any, "SIGKILL");
+
+    expect(ok).toBe(true);
+    expect(childSignal).toBe("SIGKILL");
+  });
+
+  it("returns false when there is no pid", () => {
+    const ok = signalWorkerGroup({ pid: undefined, kill: () => true } as any, "SIGTERM");
+    expect(ok).toBe(false);
+  });
+
+  it("returns false when both the group send and child.kill throw", () => {
+    process.kill = (() => {
+      throw new Error("ESRCH");
+    }) as typeof process.kill;
+    const child = {
+      pid: 7,
+      kill: () => {
+        throw new Error("already gone");
+      },
+    };
+    expect(signalWorkerGroup(child as any, "SIGKILL")).toBe(false);
+  });
+});

--- a/packages/server/src/gateway/orchestration/impl/embedded-deployment.ts
+++ b/packages/server/src/gateway/orchestration/impl/embedded-deployment.ts
@@ -30,6 +30,34 @@ const logger = createLogger("orchestrator");
 // (`workerKillTimeoutMs`), env-overridable.
 
 /**
+ * Signal a worker's entire process group. Workers are spawned `detached`, so
+ * `child.pid` is the process-group leader; on Linux the direct child is a
+ * wrapper (`systemd-run --scope` / `nix-shell --run`) with the real worker as a
+ * descendant in the same group. `process.kill(-pid, …)` reaches the wrapper AND
+ * the worker, where `child.kill()` would hit only the wrapper and orphan the
+ * worker. Falls back to the single child if the group send fails (e.g. the
+ * leader already exited, or the platform doesn't support group signals).
+ * Returns true if a signal was delivered.
+ */
+export function signalWorkerGroup(
+  child: Pick<ChildProcess, "pid" | "kill">,
+  signal: NodeJS.Signals
+): boolean {
+  const pid = child.pid;
+  if (pid === undefined) return false;
+  try {
+    process.kill(-pid, signal);
+    return true;
+  } catch {
+    try {
+      return child.kill(signal);
+    } catch {
+      return false;
+    }
+  }
+}
+
+/**
  * Detect once whether `systemd-run --user` is available. On Linux production
  * hosts this lets us spawn each worker as a transient systemd unit with
  * cgroup limits + IPAddressDeny + capability drops. macOS dev hosts and
@@ -768,6 +796,14 @@ export class EmbeddedDeploymentManager extends BaseDeploymentManager {
         env: commonEnvVars,
         cwd: workspaceDir,
         stdio: ["ignore", "pipe", "pipe"],
+        // Run the worker in its OWN process group (child.pid == pgid). The
+        // direct child is usually a wrapper — `systemd-run --scope` on Linux,
+        // `nix-shell --run` for native-dep connectors — so a plain
+        // `child.kill()` signals only the wrapper and reparents the real worker
+        // to init (the orphan `make clean-workers` exists to reap). With a
+        // dedicated group we can signal the wrapper AND the worker together via
+        // the negative pid in killWorker(). See signalWorkerGroup().
+        detached: true,
       });
     } catch (err) {
       // Pre-spawn throw (generateEnvironmentVariables, nix package
@@ -988,14 +1024,14 @@ export class EmbeddedDeploymentManager extends BaseDeploymentManager {
       child.once("exit", () => resolve());
     });
 
-    child.kill("SIGTERM");
+    signalWorkerGroup(child, "SIGTERM");
 
     const killTimer = setTimeout(() => {
       if (child.exitCode === null && child.signalCode === null) {
         logger.warn(
           `Embedded worker ${deploymentName} did not exit after SIGTERM, sending SIGKILL`
         );
-        child.kill("SIGKILL");
+        signalWorkerGroup(child, "SIGKILL");
       }
     }, intervals.workerKillTimeoutMs);
 

--- a/packages/server/src/gateway/orchestration/impl/embedded-deployment.ts
+++ b/packages/server/src/gateway/orchestration/impl/embedded-deployment.ts
@@ -1024,14 +1024,27 @@ export class EmbeddedDeploymentManager extends BaseDeploymentManager {
       child.once("exit", () => resolve());
     });
 
-    signalWorkerGroup(child, "SIGTERM");
+    // A false return means we couldn't deliver the signal at all (no pid, or
+    // both the group send and the child.kill fallback threw). Surface it — the
+    // old child.kill() would have thrown, so silence here would otherwise hide
+    // a worker we failed to stop. (process.kill itself returns void on success,
+    // so a true return is not proof of reaping — see signalWorkerGroup.)
+    if (!signalWorkerGroup(child, "SIGTERM")) {
+      logger.warn(
+        `Embedded worker ${deploymentName} (pid=${child.pid}) could not be signalled with SIGTERM`
+      );
+    }
 
     const killTimer = setTimeout(() => {
       if (child.exitCode === null && child.signalCode === null) {
         logger.warn(
           `Embedded worker ${deploymentName} did not exit after SIGTERM, sending SIGKILL`
         );
-        signalWorkerGroup(child, "SIGKILL");
+        if (!signalWorkerGroup(child, "SIGKILL")) {
+          logger.warn(
+            `Embedded worker ${deploymentName} (pid=${child.pid}) could not be signalled with SIGKILL`
+          );
+        }
       }
     }, intervals.workerKillTimeoutMs);
 

--- a/packages/server/src/gateway/orchestration/index.ts
+++ b/packages/server/src/gateway/orchestration/index.ts
@@ -150,11 +150,31 @@ export class Orchestrator {
       // exit; other impls would no-op locally and that's fine.
       try {
         const active = await this.deploymentManager.listDeployments();
-        await Promise.allSettled(
+        // Bound the overall drain: each deleteDeployment awaits the worker's
+        // exit (SIGTERM, then SIGKILL after KILL_TIMEOUT_MS), but a wedged or
+        // zombie worker whose `exit` never fires would otherwise hang shutdown
+        // until k8s SIGKILLs the whole pod (re-orphaning every other worker).
+        // Cap the wait so we always reach the rest of teardown.
+        const drainDeadlineMs = (() => {
+          const raw = Number(process.env.SHUTDOWN_WORKER_DRAIN_MS);
+          return Number.isFinite(raw) && raw > 0 ? raw : 25_000;
+        })();
+        const drained = Promise.allSettled(
           active.map((d) =>
             this.deploymentManager.deleteDeployment(d.deploymentName)
           )
         );
+        const result = await Promise.race([
+          drained.then(() => "drained" as const),
+          new Promise<"timeout">((resolve) =>
+            setTimeout(() => resolve("timeout"), drainDeadlineMs)
+          ),
+        ]);
+        if (result === "timeout") {
+          logger.warn(
+            `Worker drain exceeded ${drainDeadlineMs}ms; continuing shutdown (${active.length} workers were active)`
+          );
+        }
       } catch (error) {
         logger.error("Error draining workers during shutdown:", error);
       }


### PR DESCRIPTION
## Summary

Fixes the worker-orphan root cause from the audit — the reason `make clean-workers` exists. Pairs with #1195 (graceful shutdown).

### The bug
Workers are wrapped on Linux in `systemd-run --scope` (and native-dep connectors in `nix-shell --run`), so the process the gateway holds (`child`) is a **wrapper**, not the worker. `child.kill("SIGTERM"/"SIGKILL")` signalled only the wrapper and reparented the real worker to init. Every idle reap / agent delete / graceful shutdown therefore leaked a worker (holding memory, FDs, and a reserved PG connection). The drain was also unbounded — a wedged worker whose `exit` never fires would hang shutdown until k8s SIGKILLs the whole pod, re-orphaning every other worker.

### The fix
- **Spawn `detached: true`** so `child.pid` is the process-group leader and the wrapper + worker share one group.
- **`killWorker()` signals the whole group** via `process.kill(-pid, …)` (new `signalWorkerGroup` helper) for both SIGTERM and the SIGKILL escalation, with a fallback to `child.kill()` if the group send fails (leader already exited / platform without group signals).
- **Bound the shutdown drain** with `SHUTDOWN_WORKER_DRAIN_MS` (default 25s) so a zombie worker can't hang teardown.

## Tests
`signal-worker-group.test.ts`: the group send (`-pid`) is used; falls back to the single child on failure; returns false with no pid and when both throw. Existing `embedded-deployment` + `orchestration-harden` suites (83 tests) still pass.

## ⚠️ Why draft
The group-kill logic is unit-tested and type-checks, but reaching the worker **through the `systemd-run --scope` cgroup** can only be smoke-tested on a real Linux host with a user systemd session — it is **not reproducible in this CI/sandbox** (no systemd, no real worker spawn). Per the repo's E2E gate I'm not claiming a green host repro I don't have. **Please smoke-test on a Linux host before merge:** start a worker, confirm SIGTERM/SIGKILL via the gateway actually reaps the `bun`/`node` worker inside the scope (no orphan in `pgrep -f agent-worker`), and confirm `nix-shell`-wrapped connector workers are reaped too.

### Residual scope
This makes the **explicit kill paths** (idle reap, delete, graceful shutdown) reap the worker. Orphan-on-hard-crash of the gateway is a separate concern (needs a cgroup/systemd reaper) and is not addressed here.

Independent of #1192/#1194/#1195; branches off `main`.

https://claude.ai/code/session_016nCJY2vegv4byo3R4CPrbf

---
_Generated by [Claude Code](https://claude.ai/code/session_016nCJY2vegv4byo3R4CPrbf)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1197"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783654253&installation_id=136316292&pr_number=1197&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1197&signature=95c01a2f2ae86f3856922cbf5d4e6dc3b61e26e96a3a237d1ee777e5bb9bb7fa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added configurable timeout for worker drain during shutdown (defaults to 25 seconds), preventing indefinite hangs during service shutdown.

* **Bug Fixes**
  * Improved worker termination handling with enhanced process group signaling and automatic fallback mechanisms for more reliable shutdown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->