### PR TITLE
fix(guardrails): execute skill-declared and agent-inline guardrails (wire the dead aggregator)

### DIFF
--- a/packages/core/src/__tests__/run-guardrail-instances.test.ts
+++ b/packages/core/src/__tests__/run-guardrail-instances.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "bun:test";
+import { runGuardrailInstances } from "../guardrails/runner";
+import type { Guardrail, InputGuardrailContext } from "../guardrails/types";
+
+const ctx: InputGuardrailContext = {
+  agentId: "a1",
+  userId: "u1",
+  message: "hi",
+  platform: "api",
+  conversationId: "c1",
+};
+
+function g(
+  name: string,
+  result: { tripped: boolean; reason?: string } | "throw"
+): Guardrail<"input"> {
+  return {
+    name,
+    stage: "input",
+    run: async () => {
+      if (result === "throw") throw new Error("boom");
+      return result;
+    },
+  };
+}
+
+describe("runGuardrailInstances", () => {
+  it("returns no-trip for an empty list", async () => {
+    const outcome = await runGuardrailInstances("input", [], ctx);
+    expect(outcome.tripped).toBeNull();
+    expect(outcome.ran).toEqual([]);
+  });
+
+  it("passes when all instances pass", async () => {
+    const outcome = await runGuardrailInstances(
+      "input",
+      [g("a", { tripped: false }), g("b", { tripped: false })],
+      ctx
+    );
+    expect(outcome.tripped).toBeNull();
+    expect(outcome.ran.sort()).toEqual(["a", "b"]);
+  });
+
+  it("reports the first trip and short-circuits", async () => {
+    const outcome = await runGuardrailInstances(
+      "input",
+      [g("tripper", { tripped: true, reason: "blocked" })],
+      ctx
+    );
+    expect(outcome.tripped?.guardrail).toBe("tripper");
+    expect(outcome.tripped?.reason).toBe("blocked");
+  });
+
+  it("fails open on a thrown guardrail (treats as pass)", async () => {
+    const outcome = await runGuardrailInstances(
+      "input",
+      [g("thrower", "throw"), g("ok", { tripped: false })],
+      ctx
+    );
+    expect(outcome.tripped).toBeNull();
+  });
+});

--- a/packages/core/src/__tests__/run-guardrail-instances.test.ts
+++ b/packages/core/src/__tests__/run-guardrail-instances.test.ts
@@ -41,14 +41,29 @@ describe("runGuardrailInstances", () => {
     expect(outcome.ran.sort()).toEqual(["a", "b"]);
   });
 
-  it("reports the first trip and short-circuits", async () => {
+  it("reports the first trip and short-circuits before slower guardrails finish", async () => {
+    let slowRan = false;
+    const slowPass: Guardrail<"input"> = {
+      name: "slow-pass",
+      stage: "input",
+      run: async () => {
+        await new Promise((resolve) => setTimeout(resolve, 25));
+        slowRan = true;
+        return { tripped: false };
+      },
+    };
     const outcome = await runGuardrailInstances(
       "input",
-      [g("tripper", { tripped: true, reason: "blocked" })],
+      [g("tripper", { tripped: true, reason: "blocked" }), slowPass],
       ctx
     );
     expect(outcome.tripped?.guardrail).toBe("tripper");
     expect(outcome.tripped?.reason).toBe("blocked");
+    // The outcome resolves on the first trip; the slow guardrail's result is
+    // not reflected in `ran` (it's still running when we short-circuit).
+    expect(outcome.ran).toContain("tripper");
+    expect(outcome.ran).not.toContain("slow-pass");
+    expect(slowRan).toBe(false);
   });
 
   it("fails open on a thrown guardrail (treats as pass)", async () => {

--- a/packages/core/src/guardrails/index.ts
+++ b/packages/core/src/guardrails/index.ts
@@ -1,6 +1,6 @@
 export { createNoopGuardrail } from "./builtins/noop";
 export { GuardrailRegistry } from "./registry";
-export { runGuardrails } from "./runner";
+export { runGuardrailInstances, runGuardrails } from "./runner";
 export type {
   Guardrail,
   GuardrailContext,

--- a/packages/core/src/guardrails/runner.ts
+++ b/packages/core/src/guardrails/runner.ts
@@ -31,8 +31,23 @@ export async function runGuardrails<S extends GuardrailStage>(
   if (enabled.length === 0) {
     return { tripped: null, ran: [] };
   }
-
   const guardrails = registry.resolve(stage, enabled) as Guardrail<S>[];
+  return runGuardrailInstances(stage, guardrails, ctx);
+}
+
+/**
+ * Like {@link runGuardrails} but takes already-resolved {@link Guardrail}
+ * instances instead of names. Used by the gateway's per-agent aggregator, which
+ * produces a mix of registry-backed built-ins and per-agent/skill judge
+ * guardrails that cannot be registered on the shared (collision-prone, global)
+ * registry. Same parallel-race + first-trip short-circuit + fail-open-on-throw
+ * semantics as the name-based path.
+ */
+export async function runGuardrailInstances<S extends GuardrailStage>(
+  stage: S,
+  guardrails: readonly Guardrail<S>[],
+  ctx: GuardrailContext[S]
+): Promise<GuardrailRunOutcome> {
   if (guardrails.length === 0) {
     return { tripped: null, ran: [] };
   }

--- a/packages/server/src/gateway/auth/mcp/proxy.ts
+++ b/packages/server/src/gateway/auth/mcp/proxy.ts
@@ -613,6 +613,23 @@ export class McpProxy {
       return c.json({ error: "Invalid JSON body" }, 400);
     }
 
+    // Pre-tool guardrails — same enforcement as the JSON-RPC path so this REST
+    // entrypoint can't bypass the stage. Runs before approval and independently
+    // of grantStore.
+    if (
+      await this.runPreToolGuardrails(
+        agentId,
+        auth.tokenData,
+        toolName,
+        toolArguments
+      )
+    ) {
+      return c.json({
+        content: [{ type: "text", text: "Tool call blocked by policy." }],
+        isError: true,
+      });
+    }
+
     // Check tool approval based on annotations and grants.
     const approval = await this.evaluateToolApproval(
       mcpId,
@@ -892,9 +909,12 @@ export class McpProxy {
       );
     }
 
-    // Check tool approval for tools/call JSON-RPC requests.
-    // Clone the request so the body can be read twice (once here, once in forwardRequest).
-    if (this.grantStore && c.req.method === "POST") {
+    // Pre-tool guardrails + tool approval for tools/call JSON-RPC requests.
+    // Clone the request so the body can be read twice (once here, once in
+    // forwardRequest). NOTE: this runs on any POST, NOT gated on grantStore —
+    // guardrail enforcement must not depend on the approval subsystem being
+    // configured (the approval check below is what's gated on grantStore).
+    if (c.req.method === "POST") {
       try {
         const clonedReq = c.req.raw.clone();
         const bodyText = await clonedReq.text();
@@ -904,133 +924,51 @@ export class McpProxy {
             const toolName = jsonRpc.params.name;
             const toolArgs = jsonRpc.params.arguments || {};
 
-            // Pre-tool guardrails: run before the existing approval check so
-            // a blocked tool never enters the approval funnel. The worker
-            // sees a generic policy message — the specific reason is
-            // intentionally NOT surfaced (evasion surface).
-            if (this.guardrailRegistry && this.agentSettingsStore) {
-              try {
-                const settings =
-                  await this.agentSettingsStore.getSettings(agentId);
-                // Resolve the agent's built-in names PLUS skill-declared
-                // pre-tool guardrails (SKILL.md) into runnable instances. Until
-                // this was wired, skill-declared guardrails were silently
-                // ignored. NOTE: judge guardrails fail CLOSED (an unreachable
-                // judge denies → blocks the tool) — a deliberate posture; see
-                // judge-factory.ts.
-                const resolved = resolveAgentGuardrails(
-                  settings ?? { guardrails: [] },
-                  (settings?.skillsConfig?.skills ?? []).filter(
-                    (s) => s.enabled
-                  ),
-                  this.guardrailRegistry
-                );
-                const list = resolved.byStage["pre-tool"];
-                if (list.length > 0) {
-                  const outcome = await runGuardrailInstances(
-                    "pre-tool",
-                    list,
-                    {
-                      agentId,
-                      userId: tokenData.userId,
-                      toolName,
-                      arguments: toolArgs,
-                      conversationId: tokenData.conversationId,
-                    }
-                  );
-                  if (outcome.tripped) {
-                    // Resolve org id with a metadata fallback — per-job
-                    // tokens carry it, but legacy deployment-lifetime
-                    // tokens may not, and an unaudited trip is a security
-                    // log gap.
-                    let resolvedOrgId = tokenData.organizationId;
-                    if (!resolvedOrgId) {
-                      try {
-                        const md =
-                          await this.agentSettingsStore.getMetadata(agentId);
-                        resolvedOrgId = md?.organizationId;
-                      } catch (lookupErr) {
-                        logger.warn(
-                          {
-                            agentId,
-                            err:
-                              lookupErr instanceof Error
-                                ? lookupErr.message
-                                : String(lookupErr),
-                          },
-                          "Pre-tool guardrail trip: orgId metadata lookup failed (audit may be skipped)"
-                        );
-                      }
-                    }
-                    void recordGuardrailTrip({
-                      organizationId: resolvedOrgId,
-                      agentId,
-                      userId: tokenData.userId,
-                      conversationId: tokenData.conversationId,
-                      stage: "pre-tool",
-                      guardrail: outcome.tripped.guardrail,
-                      reason: outcome.tripped.reason,
-                      metadata: outcome.tripped.metadata,
-                    });
-                    logger.info(
-                      {
-                        agentId,
-                        toolName,
-                        guardrail: outcome.tripped.guardrail,
-                      },
-                      "Pre-tool guardrail tripped — returning generic policy block to worker"
-                    );
-                    return c.json({
-                      jsonrpc: "2.0",
-                      id: jsonRpc.id,
-                      result: {
-                        content: [
-                          {
-                            type: "text",
-                            text: "Tool call blocked by policy.",
-                          },
-                        ],
-                        isError: true,
-                      },
-                    });
-                  }
-                }
-              } catch (err) {
-                // Fail open on store/registry-level errors — the runner
-                // already fail-opens on per-guardrail throws.
-                logger.warn(
-                  {
-                    agentId,
-                    toolName,
-                    err: err instanceof Error ? err.message : String(err),
-                  },
-                  "Pre-tool guardrail check failed — proceeding without guardrails"
-                );
-              }
-            }
-
-            const approval = await this.evaluateToolApproval(
-              mcpId,
-              toolName,
-              toolArgs,
-              agentId,
-              tokenData,
-              sessionToken
-            );
-            if (approval !== "allow") {
+            // Pre-tool guardrails run before approval so a blocked tool never
+            // enters the approval funnel, and independently of grantStore.
+            if (
+              await this.runPreToolGuardrails(
+                agentId,
+                tokenData,
+                toolName,
+                toolArgs
+              )
+            ) {
               return c.json({
                 jsonrpc: "2.0",
                 id: jsonRpc.id,
                 result: {
-                  content: [
-                    {
-                      type: "text",
-                      text: "Tool call requires approval. The user has been asked to approve. Your session will end. The result will arrive as your next message.",
-                    },
-                  ],
+                  content: [{ type: "text", text: "Tool call blocked by policy." }],
                   isError: true,
                 },
               });
+            }
+
+            // Tool approval is gated on the approval subsystem (grantStore).
+            if (this.grantStore) {
+              const approval = await this.evaluateToolApproval(
+                mcpId,
+                toolName,
+                toolArgs,
+                agentId,
+                tokenData,
+                sessionToken
+              );
+              if (approval !== "allow") {
+                return c.json({
+                  jsonrpc: "2.0",
+                  id: jsonRpc.id,
+                  result: {
+                    content: [
+                      {
+                        type: "text",
+                        text: "Tool call requires approval. The user has been asked to approve. Your session will end. The result will arrive as your next message.",
+                      },
+                    ],
+                    isError: true,
+                  },
+                });
+              }
             }
           }
         }
@@ -1070,6 +1008,100 @@ export class McpProxy {
         -32603,
         `Failed to connect to MCP '${mcpId}': ${error instanceof Error ? error.message : "Unknown error"}`
       );
+    }
+  }
+
+  /**
+   * Run the agent's resolved pre-tool guardrails (built-in names + skill-
+   * declared SKILL.md guardrails) for a `tools/call`. Returns true if a
+   * guardrail tripped and the call must be blocked — the caller then returns a
+   * generic, platform-shaped "blocked by policy" response (the specific reason
+   * is never surfaced to the worker; that would be an evasion oracle).
+   *
+   * Shared by BOTH tool-call entrypoints — the JSON-RPC forward path
+   * (`handleProxyRequest`) and the REST `handleCallTool` — so neither can
+   * bypass the stage, and independent of `grantStore` so guardrails enforce
+   * even when the approval subsystem isn't configured.
+   *
+   * Fails OPEN on store/registry-level errors (per-guardrail throws already
+   * fail open in the runner); judge guardrails fail CLOSED by design.
+   */
+  private async runPreToolGuardrails(
+    agentId: string,
+    tokenData: {
+      userId: string;
+      conversationId?: string;
+      organizationId?: string;
+    },
+    toolName: string,
+    toolArgs: Record<string, unknown>
+  ): Promise<boolean> {
+    if (!this.guardrailRegistry || !this.agentSettingsStore) return false;
+    try {
+      const settings = await this.agentSettingsStore.getSettings(agentId);
+      const resolved = resolveAgentGuardrails(
+        settings ?? { guardrails: [] },
+        (settings?.skillsConfig?.skills ?? []).filter((s) => s.enabled),
+        this.guardrailRegistry
+      );
+      const list = resolved.byStage["pre-tool"];
+      if (list.length === 0) return false;
+      const outcome = await runGuardrailInstances("pre-tool", list, {
+        agentId,
+        userId: tokenData.userId,
+        toolName,
+        arguments: toolArgs,
+        conversationId: tokenData.conversationId,
+      });
+      if (!outcome.tripped) return false;
+      // Resolve org id with a metadata fallback — per-job tokens carry it, but
+      // legacy deployment-lifetime tokens may not, and an unaudited trip is a
+      // security log gap.
+      let resolvedOrgId = tokenData.organizationId;
+      if (!resolvedOrgId) {
+        try {
+          const md = await this.agentSettingsStore.getMetadata(agentId);
+          resolvedOrgId = md?.organizationId;
+        } catch (lookupErr) {
+          logger.warn(
+            {
+              agentId,
+              err:
+                lookupErr instanceof Error
+                  ? lookupErr.message
+                  : String(lookupErr),
+            },
+            "Pre-tool guardrail trip: orgId metadata lookup failed (audit may be skipped)"
+          );
+        }
+      }
+      void recordGuardrailTrip({
+        organizationId: resolvedOrgId,
+        agentId,
+        userId: tokenData.userId,
+        conversationId: tokenData.conversationId,
+        stage: "pre-tool",
+        guardrail: outcome.tripped.guardrail,
+        reason: outcome.tripped.reason,
+        metadata: outcome.tripped.metadata,
+      });
+      logger.info(
+        { agentId, toolName, guardrail: outcome.tripped.guardrail },
+        "Pre-tool guardrail tripped — blocking tool call with generic policy message"
+      );
+      return true;
+    } catch (err) {
+      // Fail open on store/registry-level errors — the runner already
+      // fail-opens on per-guardrail throws.
+      logger.warn(
+        {
+          agentId,
+          toolName,
+          err: err instanceof Error ? err.message : String(err),
+        },
+        "Pre-tool guardrail check failed — proceeding without guardrails"
+      );
+      return false;
     }
   }
 

--- a/packages/server/src/gateway/auth/mcp/proxy.ts
+++ b/packages/server/src/gateway/auth/mcp/proxy.ts
@@ -2,9 +2,10 @@ import { randomUUID } from "node:crypto";
 import {
   createLogger,
   type GuardrailRegistry,
-  runGuardrails,
+  runGuardrailInstances,
   verifyWorkerToken,
 } from "@lobu/core";
+import { resolveAgentGuardrails } from "../../guardrails/aggregator.js";
 import type { Context } from "hono";
 import { Hono } from "hono";
 import { storePendingTool } from "./pending-tool-store.js";
@@ -911,12 +912,24 @@ export class McpProxy {
               try {
                 const settings =
                   await this.agentSettingsStore.getSettings(agentId);
-                const enabled = settings?.guardrails ?? [];
-                if (enabled.length > 0) {
-                  const outcome = await runGuardrails(
-                    this.guardrailRegistry,
+                // Resolve the agent's built-in names PLUS skill-declared
+                // pre-tool guardrails (SKILL.md) into runnable instances. Until
+                // this was wired, skill-declared guardrails were silently
+                // ignored. NOTE: judge guardrails fail CLOSED (an unreachable
+                // judge denies → blocks the tool) — a deliberate posture; see
+                // judge-factory.ts.
+                const resolved = resolveAgentGuardrails(
+                  settings ?? { guardrails: [] },
+                  (settings?.skillsConfig?.skills ?? []).filter(
+                    (s) => s.enabled
+                  ),
+                  this.guardrailRegistry
+                );
+                const list = resolved.byStage["pre-tool"];
+                if (list.length > 0) {
+                  const outcome = await runGuardrailInstances(
                     "pre-tool",
-                    enabled,
+                    list,
                     {
                       agentId,
                       userId: tokenData.userId,

--- a/packages/server/src/gateway/connections/chat-response-bridge.ts
+++ b/packages/server/src/gateway/connections/chat-response-bridge.ts
@@ -16,11 +16,12 @@ import { resolve } from "node:path";
 import {
   createLogger,
   type GuardrailRegistry,
-  runGuardrails,
+  runGuardrailInstances,
 } from "@lobu/core";
 import { getDb } from "../../db/client.js";
 import { getOrganizationSlug } from "../../utils/url-builder.js";
 import type { AgentSettingsStore } from "../auth/settings/agent-settings-store.js";
+import { resolveAgentGuardrails } from "../guardrails/aggregator.js";
 import { recordGuardrailTrip } from "../guardrails/audit.js";
 import type { ThreadResponsePayload } from "../infrastructure/queue/index.js";
 import { extractSettingsLinkButtons } from "../platform/link-buttons.js";
@@ -210,20 +211,20 @@ export class ChatResponseBridge implements ResponseRenderer {
 
     try {
       const settings = await this.agentSettingsStore.getSettings(agentId);
-      const enabled = settings?.guardrails ?? [];
-      if (enabled.length === 0) return null;
-      const outcome = await runGuardrails(
-        this.guardrailRegistry,
-        "output",
-        enabled,
-        {
-          agentId,
-          userId: payload.userId,
-          text: scanText,
-          platform: ctx.platform,
-          conversationId: payload.conversationId,
-        }
+      const resolved = resolveAgentGuardrails(
+        settings ?? { guardrails: [] },
+        (settings?.skillsConfig?.skills ?? []).filter((s) => s.enabled),
+        this.guardrailRegistry
       );
+      const list = resolved.byStage.output;
+      if (list.length === 0) return null;
+      const outcome = await runGuardrailInstances("output", list, {
+        agentId,
+        userId: payload.userId,
+        text: scanText,
+        platform: ctx.platform,
+        conversationId: payload.conversationId,
+      });
       if (!outcome.tripped) return null;
       // Fire-and-forget — the block message must not wait on the audit write.
       void recordGuardrailTrip({

--- a/packages/server/src/gateway/orchestration/message-consumer.ts
+++ b/packages/server/src/gateway/orchestration/message-consumer.ts
@@ -10,9 +10,10 @@ import {
   type MessagePayload,
   OrchestratorError,
   retryWithBackoff,
-  runGuardrails,
+  runGuardrailInstances,
   SpanStatusCode,
 } from "@lobu/core";
+import { resolveAgentGuardrails } from "../guardrails/aggregator.js";
 import * as Sentry from "@sentry/node";
 import type { AgentSettingsStore } from "../auth/settings/agent-settings-store.js";
 import { platformMetadataString } from "../connections/platform-metadata.js";
@@ -245,20 +246,20 @@ export class MessageConsumer {
           const settings = await this.agentSettingsStore.getSettings(
             data.agentId
           );
-          const enabled = settings?.guardrails ?? [];
-          if (enabled.length > 0) {
-            const outcome = await runGuardrails(
-              this.guardrailRegistry,
-              "input",
-              enabled,
-              {
-                agentId: data.agentId,
-                userId: data.userId,
-                message: data.messageText,
-                platform: data.platform,
-                conversationId: effectiveConversationId,
-              }
-            );
+          const resolved = resolveAgentGuardrails(
+            settings ?? { guardrails: [] },
+            (settings?.skillsConfig?.skills ?? []).filter((s) => s.enabled),
+            this.guardrailRegistry
+          );
+          const list = resolved.byStage.input;
+          if (list.length > 0) {
+            const outcome = await runGuardrailInstances("input", list, {
+              agentId: data.agentId,
+              userId: data.userId,
+              message: data.messageText,
+              platform: data.platform,
+              conversationId: effectiveConversationId,
+            });
             if (outcome.tripped) {
               // Resolve org id with a metadata fallback so a trip never
               // silently drops the audit — legacy/test enqueues can omit it.


### PR DESCRIPTION
## Summary

Fixes the dead-code finding from the audit: **`resolveAgentGuardrails` (the per-agent guardrail aggregator) and `createJudgeGuardrail` had zero runtime call sites.** All three stages called `runGuardrails` with only the built-in *names* from `settings.guardrails`, so **skill-declared `pre-tool` guardrails (SKILL.md) and any agent LLM-judge guardrails were silently ignored** — only the three hardcoded built-ins (secret-scan, pii-scan, forbidden-tools) ever ran.

## Changes
- **core** — add `runGuardrailInstances(stage, guardrails[], ctx)`: same parallel-race + first-trip short-circuit + fail-open-on-throw semantics as `runGuardrails`, but takes resolved `Guardrail` *instances*. (Judge guardrails can't go through the name→registry path: the shared registry throws on duplicate name+stage and judges have per-agent identity.) `runGuardrails` now resolves names then delegates — **zero behavior change** for existing callers.
- **gateway** — the pre-tool (`auth/mcp/proxy.ts`), input (`orchestration/message-consumer.ts`), and output (`connections/chat-response-bridge.ts`) sites now call `resolveAgentGuardrails(settings, enabledSkills, registry)` and run `resolved.byStage[stage]`. Built-ins are re-resolved from the **same registry instances**, so secret-scan/pii-scan/forbidden-tools stay byte-identical; the empty-list guard and the existing fail-open-on-store-error try/catch are preserved.

Skill-declared `pre-tool` guardrails (persisted in `settings.skillsConfig`) **activate immediately**. Agent-inline judges (`guardrails_inline`) have no storage field yet, so `extras` stays empty and they remain inert — the wiring is ready for them once a field is added (follow-up).

## ⚠️ Posture decision (deliberate, confirmed): fail CLOSED
LLM-judge guardrails **fail closed** — an unreachable judge (Anthropic down, timeout, circuit-open, or missing `ANTHROPIC_API_KEY`) returns `deny`, which **blocks** the message/tool. The built-in scanners remain fail-open. This is the chosen posture for this PR; note the availability implication: a judge declared on input/output with the judge backend unavailable will block that traffic.

## Tests / validation
- `run-guardrail-instances.test.ts` (new): locks the new function — empty list, all-pass, first-trip short-circuit, fail-open-on-throw. **4 pass.**
- Existing core guardrail suites (**296 pass**, incl. the runner which now delegates) and server bun guardrail suites (**45 pass**, incl. the aggregator) are green.
- `tsc` clean across core + server; pre-commit (biome + root tsc) green.
- **Not run locally:** the DB-backed `guardrails-runtime.test.ts` (the end-to-end wired-call-site integration test) — this sandbox has no Postgres (embedded PG fails on a missing `libicuuc.so.60`). It runs in CI against a real Postgres; that's the e2e gate for the wired call sites.

Independent of the other production-readiness PRs; branches off `main`.

https://claude.ai/code/session_016nCJY2vegv4byo3R4CPrbf

---
_Generated by [Claude Code](https://claude.ai/code/session_016nCJY2vegv4byo3R4CPrbf)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1200"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783672478&installation_id=136316292&pr_number=1200&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1200&signature=5bd3cb8cdc68cdf5130dd0e193a18b58304ec177b9063e2a57022dfa85a150a2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for guardrail execution, including error handling and trip detection scenarios.

* **Refactor**
  * Refactored guardrail execution architecture to improve code organization and ensure consistent behavior across platform components handling message input, tool execution, and output processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->