### PR TITLE
feat(queue): failed-run metric + durable dead-letter retention for dropped replies

### DIFF
--- a/packages/server/src/gateway/__tests__/runs-failed-metric.test.ts
+++ b/packages/server/src/gateway/__tests__/runs-failed-metric.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, test } from "bun:test";
+import {
+  getMetricsText,
+  incrementCounter,
+} from "../metrics/prometheus.js";
+
+describe("lobu_runs_failed_total metric", () => {
+  test("is registered as a counter and renders with run_type + queue labels", () => {
+    const text0 = getMetricsText();
+    expect(text0).toContain("# TYPE lobu_runs_failed_total counter");
+
+    incrementCounter("lobu_runs_failed_total", {
+      run_type: "chat_message",
+      queue: "thread_response",
+    });
+
+    const text = getMetricsText();
+    const line = text
+      .split("\n")
+      .find(
+        (l) =>
+          l.startsWith("lobu_runs_failed_total{") &&
+          l.includes('run_type="chat_message"') &&
+          l.includes('queue="thread_response"')
+      );
+    expect(line).toBeDefined();
+    // Value is the trailing number on the sample line.
+    expect(Number(line?.trim().split(/\s+/).pop())).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/packages/server/src/gateway/infrastructure/queue/runs-queue.ts
+++ b/packages/server/src/gateway/infrastructure/queue/runs-queue.ts
@@ -22,6 +22,7 @@ import { randomUUID } from "node:crypto";
 import { createLogger } from "@lobu/core";
 import * as Sentry from "@sentry/node";
 import { getDb, getDbListener, type DbClient } from "../../../db/client.js";
+import { incrementCounter } from "../../metrics/prometheus.js";
 import type {
   IMessageQueue,
   JobHandler,
@@ -695,7 +696,7 @@ export class RunsQueue implements IMessageQueue {
   private async markFailed(runId: number, err: unknown): Promise<void> {
     const sql = getDb();
     const message = err instanceof Error ? err.message : String(err);
-    await sql`
+    const rows = await sql`
       UPDATE public.runs
       SET status = 'failed',
           completed_at = now(),
@@ -704,15 +705,27 @@ export class RunsQueue implements IMessageQueue {
       WHERE id = ${runId}
         AND status = 'claimed'
         AND claimed_by = ${this.claimedBy}
+      RETURNING run_type, queue_name
     `;
+    const row = rows[0] as
+      | { run_type?: string; queue_name?: string }
+      | undefined;
+    // Only emit when we actually transitioned the row (a sibling pod may have
+    // reclaimed it after a heartbeat gap). The failed `runs` row is the durable
+    // dead-letter record (kept FAILED_RUNS_RETENTION_DAYS); this counter is the
+    // aggregate, alertable signal the log alone never provided — a
+    // user-facing reply (run_type='chat_message') here was silently dropped.
+    if (row) {
+      incrementCounter("lobu_runs_failed_total", {
+        run_type: row.run_type ?? "unknown",
+        queue: row.queue_name ?? "unknown",
+      });
+    }
     // Logged as a warning; not emitted to Sentry. Per-run terminal failures
     // are high-volume and low-actionable (each is a separate event in Sentry,
     // burning the org quota with no per-incident signal beyond the log).
-    // The aggregate "we have failed runs" signal belongs on a metric/dash,
-    // not in the error feed.
-    logger.warn(
-      `Run ${runId} failed after retries: ${message}`,
-    );
+    // The aggregate "we have failed runs" signal lives on lobu_runs_failed_total.
+    logger.warn(`Run ${runId} failed after retries: ${message}`);
   }
 
   private async scheduleRetry(
@@ -860,6 +873,17 @@ export async function sweepCompletedRuns(): Promise<number> {
     const raw = Number(process.env.RUNS_RETENTION_DAYS);
     return Number.isFinite(raw) && raw > 0 ? raw : 30;
   })();
+  // Failed runs are the dead-letter record an operator inspects/replays. Keep
+  // them at least as long as completed runs, but allow a longer, independent
+  // window via FAILED_RUNS_RETENTION_DAYS so the dead-letter lane isn't pruned
+  // at the same cadence as routine completions. Defaults to retentionDays, so
+  // behavior is unchanged unless an operator opts into a longer window.
+  const failedRetentionDays = (() => {
+    const raw = Number(process.env.FAILED_RUNS_RETENTION_DAYS);
+    return Number.isFinite(raw) && raw > 0
+      ? Math.max(raw, retentionDays)
+      : retentionDays;
+  })();
 
   let total = 0;
 
@@ -879,7 +903,7 @@ export async function sweepCompletedRuns(): Promise<number> {
   const aged = await sql`
     WITH d AS (
       DELETE FROM runs
-      WHERE status IN ('completed', 'failed', 'cancelled', 'timeout')
+      WHERE status IN ('completed', 'cancelled', 'timeout')
         AND run_type IN ('chat_message', 'schedule', 'agent_run', 'internal', 'task')
         AND completed_at IS NOT NULL
         AND completed_at < now() - (${retentionDays}::int * interval '1 day')
@@ -888,6 +912,20 @@ export async function sweepCompletedRuns(): Promise<number> {
     SELECT count(*)::int AS count FROM d
   `;
   total += Number((aged[0] as { count?: number } | undefined)?.count ?? 0);
+
+  // Dead-letter lane: prune failed runs on their own (>=) retention window.
+  const agedFailed = await sql`
+    WITH d AS (
+      DELETE FROM runs
+      WHERE status = 'failed'
+        AND run_type IN ('chat_message', 'schedule', 'agent_run', 'internal', 'task')
+        AND completed_at IS NOT NULL
+        AND completed_at < now() - (${failedRetentionDays}::int * interval '1 day')
+      RETURNING id
+    )
+    SELECT count(*)::int AS count FROM d
+  `;
+  total += Number((agedFailed[0] as { count?: number } | undefined)?.count ?? 0);
 
   return total;
 }

--- a/packages/server/src/gateway/metrics/prometheus.ts
+++ b/packages/server/src/gateway/metrics/prometheus.ts
@@ -59,6 +59,16 @@ function initializeMetrics() {
     "Total number of blocked proxy requests",
     "counter"
   );
+  // Terminal run failures (exhausted retries) by run_type + queue. A
+  // user-facing reply (run_type='chat_message') that lands here was dropped —
+  // alert on rate(lobu_runs_failed_total{run_type="chat_message"}[5m]). The
+  // failed `runs` rows are the durable dead-letter record (see
+  // FAILED_RUNS_RETENTION_DAYS); this counter is the actionable signal.
+  registerMetric(
+    "lobu_runs_failed_total",
+    "Runs that reached terminal 'failed' after exhausting retries, by run_type and queue",
+    "counter"
+  );
   registerMetric(
     "lobu_process_start_time_seconds",
     "Start time of the process since unix epoch in seconds",


### PR DESCRIPTION
## Summary

Addresses the audit finding that **permanently-failed runs produce no actionable signal**. When a run (e.g. a user-facing chat reply) exhausts its retries, `markFailed` only logged a `warn` — no metric, no alert, no dead-letter lane. Its own comment said the aggregate signal "belongs on a metric/dash," but none was ever wired. A dropped reply was discoverable only by ad-hoc SQL on `runs WHERE status='failed'`, and those rows were pruned on the same retention cadence as routine completions.

## Changes
- **Metric** — register and emit `lobu_runs_failed_total{run_type,queue}` in `markFailed` (only when *this* pod actually transitioned the row, via `RETURNING run_type, queue_name`). Operators can now alert on `rate(lobu_runs_failed_total{run_type="chat_message"}[5m])` — i.e. a user reply was dropped. This also revives one of the registered-but-never-emitted metrics the audit flagged.
- **Dead-letter lane** — prune failed runs on an independent `FAILED_RUNS_RETENTION_DAYS` window (defaults to `RUNS_RETENTION_DAYS`, clamped to be no shorter), so the failed `runs` rows persist as an inspectable / replayable dead-letter record instead of being aged out alongside completed runs. **Default behavior is unchanged** unless an operator opts into a longer window.

No new table or migration — the existing `runs` table + `status='failed'` is the dead-letter store; this makes it observable and durable.

## Tests / validation
- `runs-failed-metric.test.ts` (new): `lobu_runs_failed_total` registers as a counter and renders with `run_type`/`queue` labels. **1 pass.**
- Existing DB-free `runs-queue.test.ts` (13) still green; `tsc` + pre-commit clean.
- **Not run locally:** the DB-backed `markFailed`/`sweepCompletedRuns` paths (this sandbox has no Postgres — embedded PG fails on a missing `libicuuc.so.60`). They run in CI against a real Postgres.

## Scope note
This is the **metric + durable-retention** half of the DLQ ask. A dedicated dead-letter *table* with an operator replay UI is a larger follow-up (migration + UX) — deliberately not bundled here. Combined with #1195 (graceful shutdown) and #1194 (cross-pod delivery), this closes the "dropped reply is invisible" gap.

Branches off `main`; independent of the other production-readiness PRs.

https://claude.ai/code/session_016nCJY2vegv4byo3R4CPrbf

---
_Generated by [Claude Code](https://claude.ai/code/session_016nCJY2vegv4byo3R4CPrbf)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1201"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783672785&installation_id=136316292&pr_number=1201&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1201&signature=83608af0c2a5b873fd8ee18809df3daf12f51c1e88a50cc27e8cda49a0c3d597"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added monitoring metric to track failed runs with run type and queue details
  * Implemented separate retention policy for failed runs

* **Tests**
  * Added test coverage for run failure metrics

<!-- end of auto-generated comment: release notes by coderabbit.ai -->