### PR TITLE
ci(providers): scheduled live-provider validation + document z-ai env naming

### DIFF
--- a/.github/workflows/providers-live.yml
+++ b/.github/workflows/providers-live.yml
@@ -35,6 +35,10 @@ jobs:
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
+        with:
+          # This job only reads + runs tests; the submodule fetch rides the
+          # SSH deploy key below, so the persisted token is never needed.
+          persist-credentials: false
 
       # Matches the other CI jobs; the live suite itself doesn't touch owletto,
       # but `bun install` resolves the full workspace.

--- a/.github/workflows/providers-live.yml
+++ b/.github/workflows/providers-live.yml
@@ -1,0 +1,72 @@
+name: Live Providers
+
+# Networked, key-gated validation of every provider in config/providers.json.
+# Deliberately NOT in the CI gate (it hits real provider APIs and needs
+# secrets) — it runs on a schedule so a provider deprecating a model, moving
+# an endpoint, or changing its auth scheme surfaces here instead of in prod.
+#
+# Two tiers (both driven by `make test-providers-live`):
+#   - keyless: probes every composed chat/models route against the real API
+#     (a wrong path 404s, a right path 401s) and checks each defaultModel
+#     against the public catalogs. Runs with NO secrets, every time.
+#   - keyed:   full models + chat + tool-call round-trip for each provider
+#     whose API key is present below; the rest skip cleanly. Add a repo
+#     secret named after the provider's env var (e.g. OPENAI_API_KEY) to
+#     light up its row — no code change needed.
+
+on:
+  schedule:
+    # Mondays 06:00 UTC — weekly is enough to catch upstream drift early
+    # without burning provider quota.
+    - cron: "0 6 * * 1"
+  workflow_dispatch: {}
+
+# Never let two scheduled/manual runs race; the later one wins.
+concurrency:
+  group: live-providers
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  live-providers:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+
+      # Matches the other CI jobs; the live suite itself doesn't touch owletto,
+      # but `bun install` resolves the full workspace.
+      - uses: ./.github/actions/setup-submodule
+        with:
+          deploy-key: ${{ secrets.OWLETTO_WEB_DEPLOY_KEY }}
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.5
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Validate providers (keyless + keyed)
+        run: make test-providers-live
+        env:
+          GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+          TOGETHER_API_KEY: ${{ secrets.TOGETHER_API_KEY }}
+          NVIDIA_API_KEY: ${{ secrets.NVIDIA_API_KEY }}
+          # z-ai: the live suite accepts either name; provide whichever exists.
+          Z_AI_API_KEY: ${{ secrets.Z_AI_API_KEY }}
+          ZAI_API_KEY: ${{ secrets.ZAI_API_KEY }}
+          ELEVENLABS_API_KEY: ${{ secrets.ELEVENLABS_API_KEY }}
+          FIREWORKS_API_KEY: ${{ secrets.FIREWORKS_API_KEY }}
+          MISTRAL_API_KEY: ${{ secrets.MISTRAL_API_KEY }}
+          DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
+          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+          CEREBRAS_API_KEY: ${{ secrets.CEREBRAS_API_KEY }}
+          OPENCODE_ZEN_API_KEY: ${{ secrets.OPENCODE_ZEN_API_KEY }}
+          XAI_API_KEY: ${{ secrets.XAI_API_KEY }}
+          PERPLEXITY_API_KEY: ${{ secrets.PERPLEXITY_API_KEY }}
+          COHERE_API_KEY: ${{ secrets.COHERE_API_KEY }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}

--- a/packages/openclaw-plugin/test/e2e/helpers.ts
+++ b/packages/openclaw-plugin/test/e2e/helpers.ts
@@ -595,6 +595,10 @@ export function runOpenclawAgent(
 
   const cmd = [
     'docker exec',
+    // `openclaw agent --local` is standalone pi-ai, which reads ZAI_API_KEY for
+    // z.ai (see @mariozechner/pi-ai env-api-keys: `zai: "ZAI_API_KEY"`). This is
+    // intentionally NOT the lobu gateway's `Z_AI_API_KEY` — different system,
+    // different convention. Don't "reconcile" the names; they're both correct.
     `-e ZAI_API_KEY="${process.env.ZAI_API_KEY || ''}"`,
     'openclaw-plugin-1',
     'openclaw agent --local',


### PR DESCRIPTION
Follow-ups to #1193.

## 1. Scheduled live-provider validation (`.github/workflows/providers-live.yml`)

A weekly (Mon 06:00 UTC) + manual (`workflow_dispatch`) job running `make test-providers-live`, **deliberately kept out of the CI merge gate** (it hits real provider APIs and needs secrets). Two tiers, both driven from `config/providers.json`:

- **keyless** — probes every composed chat/models route against the real API (wrong path 404s, right path 401s) and checks each `defaultModel` against the public catalogs. Runs with **no secrets**, every time. Verified live here: 28 pass / 4 skip / 0 fail.
- **keyed** — full models + chat + tool-call round-trip per provider whose API-key secret is present; the rest skip cleanly. **Add a repo secret named after the provider's env var (e.g. `XAI_API_KEY`, `COHERE_API_KEY`) to light up its row — no code change.** This is exactly what would settle the two stale-default suspects called out in #1193 (xai `grok-3`, cohere `command-r-plus`, whose catalogs are auth-gated).

Setup mirrors the existing CI jobs (`setup-submodule` → `setup-bun 1.3.5` → `bun install`); `concurrency` prevents overlapping runs.

## 2. z-ai env naming — investigated, **not a bug** (documented)

#1193 flagged the openclaw e2e harness passing `ZAI_API_KEY` while the lobu gateway reads `Z_AI_API_KEY` as a suspected inconsistency. It isn't: the harness runs **standalone pi-ai** (`openclaw agent --local`), whose env map is `zai: "ZAI_API_KEY"` (`@mariozechner/pi-ai/dist/env-api-keys.js`). Different system, different convention — both names are correct in their own context, and "reconciling" them would break the openclaw path.

So instead of a code change, this adds a comment at the call site so nobody (including a future me) mistakes it for a bug and "fixes" it into a regression. The workflow provides **both** names for robustness regardless of how the secret is named.

## Validation

- YAML parses; `make test-providers-live` target present; `setup-submodule` action present.
- Keyless tier re-run live: 28/28.
- Pre-commit clean: full-repo `tsc --noEmit` + biome.

https://claude.ai/code/session_01WbENJMjXUEWfXVvKubBmGs

---
_Generated by [Claude Code](https://claude.ai/code/session_01WbENJMjXUEWfXVvKubBmGs)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1206"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783765754&installation_id=136316292&pr_number=1206&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1206&signature=3a2455d4de484faa861c1111cebcf9b4f3b3fc9551f11cc1c8560739dfe2a18a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a scheduled "Live Providers" automated test workflow for provider integrations, with a manual trigger and protections to avoid overlapping runs.

* **Documentation**
  * Improved helper comments clarifying how the local provider test agent reads API keys for testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->