### PR TITLE
fix(sentry): stop worker traces + cut server span sampling to fit the span quota

### DIFF
--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -641,6 +641,14 @@ export async function initCommand(
       value:
         "https://c5910e58d1a134d64ff93a95a9c535bb@o4507291398897664.ingest.us.sentry.io/4511097466781696",
     });
+    // The shared community DSN reports into the same Sentry project as the
+    // hosted deployment, and instrument.ts defaults environment to
+    // "production" — tag self-hosted installs so their errors are filterable
+    // and never read as hosted-prod incidents.
+    envSecrets.push({
+      envVar: "ENVIRONMENT",
+      value: "self-host",
+    });
   }
 
   let allowedDomains: string;

--- a/packages/cli/src/commands/telemetry.ts
+++ b/packages/cli/src/commands/telemetry.ts
@@ -41,6 +41,13 @@ export async function telemetryOnCommand(
   const cwd = options.cwd ?? process.cwd();
   const dsn = options.dsn ?? SENTRY_DSN_DEFAULT;
   await setLocalEnvValue(cwd, "SENTRY_DSN", dsn);
+  // The shared community DSN points at the same Sentry project as the hosted
+  // deployment, and instrument.ts defaults environment to "production" when
+  // ENVIRONMENT is unset — so without this tag a self-hosted install's errors
+  // are indistinguishable from real prod incidents in the feed.
+  if (!options.dsn) {
+    await setLocalEnvValue(cwd, "ENVIRONMENT", "self-host");
+  }
   console.log(chalk.green("\n  Telemetry enabled."));
   console.log(chalk.dim(`  Wrote SENTRY_DSN to ${join(cwd, ".env")}\n`));
 }

--- a/packages/core/src/sentry.ts
+++ b/packages/core/src/sentry.ts
@@ -66,8 +66,12 @@ export async function initSentry() {
       // Do not ship IP/cookies/headers by default — user content and identifiers
       // travel through this stack and Sentry has no scrubbing for our schema.
       sendDefaultPii: false,
-      profileSessionSampleRate: 1.0,
-      tracesSampleRate: 1.0, // Capture 100% of traces for better visibility
+      // Worker Sentry exists for ISSUES (provider/model failures), not tracing.
+      // Every agent run spawns a worker; at 1.0 the fleet would burn the org's
+      // span quota (5M/mo on the current plan was exhausted by the server alone
+      // at 0.1) and drown the server's traces. Errors are unaffected — error
+      // capture uses sampleRate (default 1.0), not tracesSampleRate.
+      tracesSampleRate: 0,
       integrations: [
         Sentry.consoleLoggingIntegration({ levels: ["log", "warn", "error"] }),
       ],

--- a/packages/server/src/instrument.ts
+++ b/packages/server/src/instrument.ts
@@ -28,7 +28,11 @@ if (dsn) {
     dsn,
     environment: process.env.ENVIRONMENT || 'production',
     release: process.env.SENTRY_RELEASE || process.env.APP_GIT_SHA || undefined,
-    tracesSampleRate: isDev ? 1.0 : 0.1,
+    // 0.1 produced ~250k spans/day (~7.5M/mo) and exhausted the plan's 5M span
+    // quota by day ~20 of the usage period. 0.02 keeps ~50k/day (~1.5M/mo) —
+    // comfortably inside quota with headroom for growth. Errors are unaffected
+    // (sampleRate below governs those).
+    tracesSampleRate: isDev ? 1.0 : 0.02,
     // Error events: capture 100%. Error volume is low (~5/day) so there's no
     // quota pressure, and the captureMessage spam that once motivated 0.5
     // sampling was removed (runs-queue.ts). Sampling rare provider/model


### PR DESCRIPTION
## Why

The Sentry billing page shows both quotas exhausted for the May 11 – Jun 10 period on the Developer plan: errors 5K/5K (21K ingested, 76% dropped over-quota — mostly localhost dev noise, since fixed) and **spans 5M/5M** (the server's `tracesSampleRate: 0.1` alone produced ~250k spans/day ≈ 7.5M/mo, exhausting the span quota by day ~20).

Worse, #1186 gave workers a DSN for error reporting — but the worker init (`core/sentry.ts`) still carried `tracesSampleRate: 1.0` + `profileSessionSampleRate: 1.0` from when it was dead code. From the next deploy, every agent run would have sent 100% traces, burning the new period's span budget in days.

## What

- `packages/core/src/sentry.ts` (worker init): `tracesSampleRate` 1.0 → **0**, dropped `profileSessionSampleRate`. Worker Sentry exists for Issues; error capture (`sampleRate`, default 1.0) is unaffected.
- `packages/server/src/instrument.ts`: prod `tracesSampleRate` 0.1 → **0.02** (~50k spans/day ≈ 1.5M/mo — inside the 5M quota with headroom). Dev stays 1.0. Error `sampleRate: 1.0` untouched.

## Testing

Strict tsc clean (core + server); sentry-proxy unit tests green. Constants-only change.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1207"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783781925&installation_id=136316292&pr_number=1207&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1207&signature=efe60650170eba730208d1db19990b8bf4becb086f0fea06f5134af2e539f411"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Refined Sentry error tracking and distributed tracing configuration. Worker processes now focus on error capture with tracing disabled. Server-side distributed tracing uses environment-specific sampling rates (100% in development, 2% in production). Full error monitoring remains enabled across all environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->