### PR TITLE
fix(cli): point community telemetry at the dedicated lobu-oss Sentry org

### DIFF
--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -639,7 +639,7 @@ export async function initCommand(
     envSecrets.push({
       envVar: "SENTRY_DSN",
       value:
-        "https://c5910e58d1a134d64ff93a95a9c535bb@o4507291398897664.ingest.us.sentry.io/4511097466781696",
+        "https://63abd848f1338116c41d4a8a29091c7c@o4511547660042240.ingest.us.sentry.io/4511547664171008",
     });
     // The shared community DSN reports into the same Sentry project as the
     // hosted deployment, and instrument.ts defaults environment to

--- a/packages/cli/src/commands/telemetry.ts
+++ b/packages/cli/src/commands/telemetry.ts
@@ -5,7 +5,7 @@ import { setLocalEnvValue } from "../internal/local-env.js";
 import { parseEnvContent } from "../internal/env-file.js";
 
 const SENTRY_DSN_DEFAULT =
-  "https://c5910e58d1a134d64ff93a95a9c535bb@o4507291398897664.ingest.us.sentry.io/4511097466781696";
+  "https://63abd848f1338116c41d4a8a29091c7c@o4511547660042240.ingest.us.sentry.io/4511547664171008";
 
 interface TelemetryOptions {
   cwd?: string;


### PR DESCRIPTION
## Why

The CLI shipped the hosted deployment's `lobu-backend` DSN as the community telemetry default (`telemetry.ts` + the `lobu init` opt-in). Self-hosted installs therefore reported into the prod Sentry project — tagged `environment=production` until #1207 — and shared the org-wide 5K errors/month quota. Seen live on Jun 11: one external self-hoster's broken DB config (`getaddrinfo ENOTFOUND lobu-postgres`) burned ~720 events overnight.

## What

Swap the default DSN in `packages/cli/src/commands/{telemetry,init}.ts` to a dedicated free Sentry org/project (`lobu-oss` / `self-host`, created for exactly this). Community telemetry now has its own quota and feed; the hosted project only ever receives the hosted deployment's events. The `ENVIRONMENT=self-host` stamping from #1207 stays.

Existing installs keep the old DSN they already have in `.env` — only new opt-ins use the new org.

## Testing

Strict tsc clean for the cli package. Constants-only change.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1208"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783786369&installation_id=136316292&pr_number=1208&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1208&signature=bf7386b93110ebd9585b3c7f49f7ce613da094a2b4e35e9a22bcbdf640bdf36a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated default Sentry endpoint configuration used during project initialization and telemetry setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->