### PR TITLE
fix(cli): document canonical dotted connector keys in scaffolded AGENTS.md

### DIFF
--- a/packages/cli/src/__tests__/template-connector-keys.test.ts
+++ b/packages/cli/src/__tests__/template-connector-keys.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, test } from "bun:test";
+import { readdirSync, readFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+
+/**
+ * Guards the scaffolded AGENTS.md against connector-key drift (#1178): the
+ * template once documented `google_gmail` while the catalog key is
+ * `google.gmail`, so generated configs failed `lobu apply` with
+ * "connector ... is not installed in the org".
+ *
+ * The catalog source of truth is the first `key:` literal in each connector
+ * definition under packages/connectors/src (filenames use underscores, keys
+ * use dots) — the same extraction the landing's gen-connectors script uses.
+ */
+
+const TEMPLATE_PATH = resolve(import.meta.dir, "../templates/AGENTS.md.tmpl");
+const CONNECTORS_SRC_DIR = resolve(
+  import.meta.dir,
+  "../../../connectors/src"
+);
+
+function catalogKeys(): Set<string> {
+  const keys = new Set<string>();
+  for (const file of readdirSync(CONNECTORS_SRC_DIR)) {
+    if (!file.endsWith(".ts") || file.endsWith(".test.ts")) continue;
+    const source = readFileSync(join(CONNECTORS_SRC_DIR, file), "utf-8");
+    const match = source.match(/key:\s*["']([^"']+)["']/);
+    if (match) keys.add(match[1]);
+  }
+  return keys;
+}
+
+function documentedKeys(): string[] {
+  const template = readFileSync(TEMPLATE_PATH, "utf-8");
+  const paragraph = template.match(
+    /\*\*Bundled connector keys\*\*[\s\S]*?(?:\n\n|$)/
+  )?.[0];
+  expect(paragraph).toBeDefined();
+  // The key list starts after the parenthesized prose ("... `google_gmail`):").
+  // Tokens before it are prose examples (including deliberately wrong keys).
+  const listStart = (paragraph as string).indexOf("):");
+  expect(listStart).toBeGreaterThan(-1);
+  const list = (paragraph as string).slice(listStart);
+  const keys = [...list.matchAll(/`([^`]+)`/g)].map((m) => m[1]);
+  expect(keys.length).toBeGreaterThan(10); // parse sanity, not a real bound
+  return keys;
+}
+
+describe("AGENTS.md.tmpl bundled connector keys", () => {
+  test("every documented key exists in the connector catalog", () => {
+    const catalog = catalogKeys();
+    const unknown = documentedKeys().filter((key) => !catalog.has(key));
+    expect(unknown).toEqual([]);
+  });
+
+  test("every catalog key is documented", () => {
+    const documented = new Set(documentedKeys());
+    const undocumented = [...catalogKeys()].filter(
+      (key) => !documented.has(key)
+    );
+    expect(undocumented).toEqual([]);
+  });
+
+  test("the canonical dotted Google keys are documented", () => {
+    const documented = documentedKeys();
+    expect(documented).toContain("google.gmail");
+    expect(documented).toContain("google.calendar");
+    expect(documented).not.toContain("google_gmail");
+    expect(documented).not.toContain("google_calendar");
+  });
+});

--- a/packages/cli/src/__tests__/template-connector-keys.test.ts
+++ b/packages/cli/src/__tests__/template-connector-keys.test.ts
@@ -14,10 +14,7 @@ import { join, resolve } from "node:path";
  */
 
 const TEMPLATE_PATH = resolve(import.meta.dir, "../templates/AGENTS.md.tmpl");
-const CONNECTORS_SRC_DIR = resolve(
-  import.meta.dir,
-  "../../../connectors/src"
-);
+const CONNECTORS_SRC_DIR = resolve(import.meta.dir, "../../../connectors/src");
 
 function catalogKeys(): Set<string> {
   const keys = new Set<string>();

--- a/packages/cli/src/templates/AGENTS.md.tmpl
+++ b/packages/cli/src/templates/AGENTS.md.tmpl
@@ -124,12 +124,14 @@ const gh = defineConnection({
 });
 ```
 
-**Bundled connector keys** — use the exact key (Gmail is `google_gmail`, not
-`gmail`): `github`, `google_gmail`, `google_calendar`, `microsoft_outlook`,
-`website`, `rss`, `hackernews`, `reddit`, `x`, `linkedin`, `youtube`, `spotify`,
-`producthunt`, `g2`, `capterra`, `glassdoor`, `trustpilot`, `revolut`, `gmaps`,
-plus on-device connectors (`apple_health`, `apple_photos`, `apple_screen_time`,
-`chrome*`, `local_directory`, `whatsapp_local`).
+**Bundled connector keys** — use the exact key; several are dotted (Gmail is
+`google.gmail`, not `gmail` or `google_gmail`): `github`, `google.gmail`,
+`google.calendar`, `microsoft.outlook`, `website`, `rss`, `postgres`,
+`hackernews`, `reddit`, `x`, `linkedin`, `youtube`, `spotify`, `producthunt`,
+`google_play`, `ios_appstore`, `g2`, `capterra`, `glassdoor`, `trustpilot`,
+`revolut`, `gmaps`, `whatsapp`, plus on-device connectors (`apple.health`,
+`apple.photos`, `apple.screen_time`, `chrome`, `chrome.history`,
+`chrome.bookmarks`, `chrome.downloads`, `local.directory`, `whatsapp.local`).
 
 Each connector defines its own `config` keys and feed keys — don't guess them. If
 you're unsure of a connector's config shape, ask the user or read its definition;


### PR DESCRIPTION
Fixes #1178

## Problem

The scaffolded `AGENTS.md` (from `packages/cli/src/templates/AGENTS.md.tmpl`) documented bundled connector keys with underscores, including the explicitly wrong note "Gmail is `google_gmail`, not `gmail`". The catalog keys are dotted: filenames use underscores (`google_gmail.ts`), keys use dots (`key: 'google.gmail'`). Apply's org-install matching is key-exact, so configs written from the template fail.

Confirmed e2e on published CLI 11.0.0 — `defineAuthProfile({ connector: "google_gmail", ... })`:

```
connector "google_gmail" referenced by auth profile "gmail-main" is not installed in the org — check the connector key
```

Switching to `google.gmail` applies cleanly.

## Audit: documented key vs catalog key

Every key in the template's "Bundled connector keys" list was checked against the `key:` literal in `packages/connectors/src/*.ts`:

| Documented (before) | Catalog key | Action |
|---|---|---|
| `google_gmail` | `google.gmail` | fixed |
| `google_calendar` | `google.calendar` | fixed |
| `microsoft_outlook` | `microsoft.outlook` | fixed |
| `apple_health` | `apple.health` | fixed |
| `apple_photos` | `apple.photos` | fixed |
| `apple_screen_time` | `apple.screen_time` | fixed |
| `local_directory` | `local.directory` | fixed |
| `whatsapp_local` | `whatsapp.local` | fixed |
| `chrome*` (vague glob) | `chrome`, `chrome.history`, `chrome.bookmarks`, `chrome.downloads` | expanded to exact keys |
| `github`, `website`, `rss`, `hackernews`, `reddit`, `x`, `linkedin`, `youtube`, `spotify`, `producthunt`, `g2`, `capterra`, `glassdoor`, `trustpilot`, `revolut`, `gmaps` | same | already correct |
| — (missing) | `postgres`, `whatsapp`, `google_play`, `ios_appstore` | added (note: these two scraper keys really are underscored in the catalog) |

Swept the rest of the repo (`*.md`, `*.tmpl`, `*.mdx`, example `*.ts` configs) for the same underscore drift — the template was the only offender; `README.md.tmpl` / `TESTING.md.tmpl` / `docs/` are clean.

## Regression test

`packages/cli/src/__tests__/template-connector-keys.test.ts` parses the documented key list out of the template and the first `key:` literal out of each `packages/connectors/src/*.ts` (same extraction the landing's `gen-connectors.ts` uses), then asserts two-way sync (documented ⊆ catalog and catalog ⊆ documented) plus pins `google.gmail`/`google.calendar`.

Red on the old template (all 3 tests fail, listing the underscore keys), green after the fix:

```
0 pass / 3 fail   # against the pre-fix template
3 pass / 0 fail   # after
```

## Validation

- `bun test src/__tests__/template-connector-keys.test.ts` — 3 pass
- `bunx tsc --noEmit` in `packages/cli` — clean (after building workspace deps)
- `cli-ux.test.ts` has 1 pre-existing local failure (`browser-auth --help` flags), verified identical on pristine origin/main state — unrelated

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1209"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783787704&installation_id=136316292&pr_number=1209&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1209&signature=1c90f6e4fd84513f7b9785096282bcda654cba5d9d36ddbc1ccd67626d7ff37f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->