### PR TITLE
fix(gateway): stop forwarding content-length/hop-by-hop headers in secret-proxy (#1176)

### DIFF
--- a/packages/server/src/gateway/__tests__/secret-proxy-harden.test.ts
+++ b/packages/server/src/gateway/__tests__/secret-proxy-harden.test.ts
@@ -720,3 +720,64 @@ describe("generatePlaceholder → resolve via proxy", () => {
     expect(forwardedAuth).toBe(`Bearer ${secretValue}`);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Header forwarding — hop-by-hop + content-length must be stripped (#1176)
+// ---------------------------------------------------------------------------
+//
+// The proxy re-sends the body via fetch, which recomputes content-length.
+// Forwarding the inbound content-length breaks when a foreign undici global
+// dispatcher (pi-ai's http-proxy side-effect: `setGlobalDispatcher(new
+// EnvHttpProxyAgent())`) is installed and the dispatching npm undici is
+// >= 7.27: it throws `InvalidArgumentError: invalid content-length header`
+// before any network I/O, turning EVERY agent LLM call into a 500.
+// `expect` / `keep-alive` / `upgrade` are hop-by-hop headers undici
+// hard-rejects the same way.
+
+describe("secret-proxy forward — header stripping (#1176)", () => {
+  test("content-length and hop-by-hop headers are NOT forwarded; regular headers are", async () => {
+    const secretStore = makeSecretStore({});
+    const proxy = buildProxy(secretStore);
+
+    let forwarded: Record<string, string> | null = null;
+    await withFetch(async (_input, init) => {
+      forwarded = (init?.headers as Record<string, string>) ?? null;
+      return new Response("{}", {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }, async () => {
+      const res = await proxy.getApp().request("/v1/chat/completions", {
+        method: "POST",
+        headers: {
+          authorization: "Bearer some-token",
+          "content-type": "application/json",
+          "content-length": "5",
+          expect: "100-continue",
+          "keep-alive": "timeout=5",
+          upgrade: "h2c",
+          connection: "keep-alive",
+          "transfer-encoding": "chunked",
+          host: "worker.internal",
+          "x-custom-header": "kept",
+        },
+        body: "hello",
+      });
+      expect(res.status).toBe(200);
+    });
+
+    expect(forwarded).not.toBeNull();
+    const keys = Object.keys(forwarded ?? {}).map((k) => k.toLowerCase());
+    // Stripped: stale/hop-by-hop values that break or poison the egress fetch.
+    expect(keys).not.toContain("content-length");
+    expect(keys).not.toContain("expect");
+    expect(keys).not.toContain("keep-alive");
+    expect(keys).not.toContain("upgrade");
+    expect(keys).not.toContain("connection");
+    expect(keys).not.toContain("transfer-encoding");
+    expect(keys).not.toContain("host");
+    // Kept: regular request headers still reach the upstream.
+    expect(forwarded?.["content-type"]).toBe("application/json");
+    expect(forwarded?.["x-custom-header"]).toBe("kept");
+  });
+});

--- a/packages/server/src/gateway/proxy/secret-proxy.ts
+++ b/packages/server/src/gateway/proxy/secret-proxy.ts
@@ -355,7 +355,23 @@ export class SecretProxy {
     try {
       return await this.forward(c);
     } catch (error) {
-      logger.error("Secret proxy error:", error);
+      // JSON.stringify(Error) renders `{}` (Error has no enumerable props),
+      // which hid the real failure behind "Secret proxy error: {}" (#1176).
+      // Extract the fields explicitly (same { err } shape as
+      // packages/core/src/worker/auth.ts), including `cause` — undici wraps
+      // the underlying dispatch error there.
+      logger.error(
+        {
+          err:
+            error instanceof Error
+              ? { name: error.name, message: error.message, stack: error.stack }
+              : error,
+          cause: (error as { cause?: unknown })?.cause
+            ? String((error as { cause?: unknown }).cause)
+            : undefined,
+        },
+        "Secret proxy error"
+      );
       return c.json({ error: "Internal proxy error" }, 500);
     }
   }
@@ -667,6 +683,17 @@ export class SecretProxy {
       "host",
       "connection",
       "transfer-encoding",
+      // Never forward the inbound content-length: fetch recomputes it from the
+      // body we pass. Forwarding it breaks when a foreign undici global
+      // dispatcher is installed (pi-ai's http-proxy side-effect) and the
+      // dispatching undici is >= 7.27 — it throws
+      // `InvalidArgumentError: invalid content-length header` before any
+      // network I/O, turning EVERY LLM call into a 500 (#1176).
+      "content-length",
+      // Hop-by-hop headers undici hard-rejects on egress.
+      "expect",
+      "keep-alive",
+      "upgrade",
       "authorization",
       "x-api-key",
     ]);


### PR DESCRIPTION
Fixes #1176

## Root cause (proven by live e2e bisect on published @lobu/cli 11.0.0)

1. `@mariozechner/pi-ai/dist/utils/http-proxy.js`, loaded in the gateway process, side-effect-runs `setGlobalDispatcher(new EnvHttpProxyAgent())` from **npm** undici. The dispatcher symbol is `Symbol.for`-shared, so Node's **built-in** fetch dispatches through the foreign npm-undici client.
2. The secret-proxy forwarded the inbound `content-length` header to its egress fetch (the skip set only had host/connection/transfer-encoding/authorization/x-api-key). Under that cross-version dispatch with undici >= 7.27 (7.27.2 verified; 7.25.0 / 7.19.1 fine), the fetch throws `InvalidArgumentError: invalid content-length header` **before any network I/O** → caught → 500 `Internal proxy error` for ALL providers. Fresh installs float pi-ai's `^7.19.1` to 7.27.x; the repo lockfile pins 7.25.0, which is why dev/CI/prod never saw it.
3. The error was swallowed: the catch logged `logger.error("Secret proxy error:", error)`, and `JSON.stringify(Error)` renders `{}` — the real cause never reached the logs.
4. Stacked bug: `config/providers.json` openai `upstreamBaseUrl` was missing `/v1` — **already fixed on main by #1193** this morning (openai + groq + 10 other providers, with contract + keyless-live + key-gated-live test coverage), so this PR does not touch providers.json. The sdk-e2e fixture (`scripts/sdk-e2e/providers.json`) uses a local mock URL that already includes `/v1` — no change needed there either.

## Minimal repro (red)

Node 22:

```js
const { EnvHttpProxyAgent, setGlobalDispatcher } = require("undici"); // npm undici 7.27.2
setGlobalDispatcher(new EnvHttpProxyAgent());
fetch(url, { method: "POST", headers: { "content-length": "5" }, body: "hello" });
// → InvalidArgumentError: invalid content-length header (before any network I/O)
```

## Fix

- `secret-proxy.ts`: add `content-length` to the forwarded-header skip set, plus `expect`, `keep-alive`, `upgrade` (hop-by-hop headers undici hard-rejects on egress). fetch recomputes content-length from the body string, so stripping is correct reverse-proxy behavior.
- `secret-proxy.ts` catch: log the real error — explicit `{ err: { name, message, stack }, cause: String(cause) }` (the console logger JSON.stringifies the meta object, so a raw Error would still render `{}`; same shape as `packages/core/src/worker/auth.ts`).

## Test (red → green)

New regression test in `secret-proxy-harden.test.ts` drives the full forward path via the existing fetch-stub harness and asserts `content-length` / `expect` / `keep-alive` / `upgrade` / `connection` / `transfer-encoding` / `host` are NOT forwarded while regular headers (`content-type`, custom) are. Verified red: with the skip-set additions reverted, the test fails; with the fix, all 17 harden tests pass. Verified the test is not vacuous: Bun's `Request` constructor preserves all of those inbound headers, so the stripping really happens in the proxy.

A dispatcher-level reproducer (`setGlobalDispatcher(new EnvHttpProxyAgent())` + real forward) was considered and skipped: the repo's undici is pinned at 7.25.0, which does not exhibit the rejection, so that test would pass even without the fix — the header-stripping assertion is the durable guard.

## What green looks like

- Fresh `lobu init` + `lobu run` with floated undici 7.27.x: the proxied LLM call reaches the upstream instead of dying pre-network with a 500.
- Any future secret-proxy failure logs `name`/`message`/`stack`/`cause` instead of `{}`.
- `bun test src/gateway/__tests__/secret-proxy*.test.ts` + `src/__tests__/unit/secret-proxy-lifecycle.test.ts`: 34 pass, 0 fail. `bunx tsc --noEmit` in packages/server: clean.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1210"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783787931&installation_id=136316292&pr_number=1210&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1210&signature=c4bd02c24c780dfad1caad2dd4a58fcadac5febff1246e2ed000b90b3646cccd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->