### PR TITLE
fix(apply): surface schema-validation errors instead of misreporting them as duplicates

### DIFF
--- a/packages/cli/src/commands/_lib/apply/__tests__/client.test.ts
+++ b/packages/cli/src/commands/_lib/apply/__tests__/client.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
-import { ApplyClient } from "../client.js";
+import { ApiError } from "../../../memory/_lib/errors.js";
+import { ApplyClient, isDuplicateError } from "../client.js";
 
 describe("ApplyClient", () => {
   test("patchAgentMetadata uses PATCH /agents/:agentId", async () => {
@@ -236,5 +237,104 @@ describe("ApplyClient — prune", () => {
 
     const body = JSON.parse(String(calls[0]?.init?.body));
     expect(body.backing).toBeNull();
+  });
+});
+
+// Issue #1177: a 422 schema-validation error from `create` must NOT be
+// mistaken for "already exists" (which retried as `update` and buried the
+// real message under "Entity type not found").
+describe("isDuplicateError", () => {
+  test("coded duplicates are duplicates", () => {
+    for (const code of [
+      "entity_type_exists",
+      "relationship_type_exists",
+      "already_exists",
+    ]) {
+      expect(
+        isDuplicateError(
+          new ApiError(`POST /x failed: [${code}] thing already exists`, 409)
+        )
+      ).toBe(true);
+    }
+  });
+
+  test("bare 409 without a code is still a duplicate", () => {
+    expect(isDuplicateError(new ApiError("POST /x failed: conflict", 409))).toBe(
+      true
+    );
+  });
+
+  test("422 validation error is NOT a duplicate", () => {
+    expect(
+      isDuplicateError(
+        new ApiError(
+          "POST /x failed: [invalid_schema] At most 4 metadata fields can have x-table-column=true.",
+          422
+        )
+      )
+    ).toBe(false);
+  });
+
+  test("code-less 400 is NOT a duplicate", () => {
+    expect(
+      isDuplicateError(new ApiError("POST /x failed: slug is required", 400))
+    ).toBe(false);
+  });
+
+  test("missing status is NOT a duplicate", () => {
+    expect(isDuplicateError(new ApiError("Invalid JSON from /x"))).toBe(false);
+  });
+});
+
+describe("ApplyClient — upsert create/update flow", () => {
+  test("create → coded 409 duplicate → retries as update (idempotent)", async () => {
+    const calls: Array<{ url: string; init?: RequestInit }> = [];
+    const client = new ApplyClient(
+      { apiBaseUrl: "https://example.test", orgSlug: "acme", token: "tok" },
+      (async (url, init) => {
+        calls.push({ url: String(url), init });
+        const body = JSON.parse(String(init?.body));
+        if (body.action === "create") {
+          return new Response(
+            JSON.stringify({
+              error:
+                "[entity_type_exists] Entity type with slug 'task' already exists",
+            }),
+            { status: 409 }
+          );
+        }
+        return new Response(JSON.stringify({ success: true }), { status: 200 });
+      }) as typeof fetch
+    );
+
+    const result = await client.upsertEntityType({ slug: "task", name: "Task" });
+    expect(result).toEqual({ updated: true });
+    expect(calls).toHaveLength(2);
+    expect(JSON.parse(String(calls[0]?.init?.body)).action).toBe("create");
+    expect(JSON.parse(String(calls[1]?.init?.body)).action).toBe("update");
+  });
+
+  test("create → 422 validation error surfaces verbatim, no update retry", async () => {
+    const calls: Array<{ url: string; init?: RequestInit }> = [];
+    const client = new ApplyClient(
+      { apiBaseUrl: "https://example.test", orgSlug: "acme", token: "tok" },
+      (async (url, init) => {
+        calls.push({ url: String(url), init });
+        return new Response(
+          JSON.stringify({
+            error:
+              "[invalid_schema] At most 4 metadata fields can have x-table-column=true.",
+          }),
+          { status: 422 }
+        );
+      }) as typeof fetch
+    );
+
+    await expect(
+      client.upsertEntityType({ slug: "task", name: "Task" })
+    ).rejects.toThrow(/At most 4 metadata fields can have x-table-column=true/);
+    // The doomed `update` retry (which produced the misleading
+    // "Entity type 'task' not found") must not happen.
+    expect(calls).toHaveLength(1);
   });
 });

--- a/packages/cli/src/commands/_lib/apply/__tests__/client.test.ts
+++ b/packages/cli/src/commands/_lib/apply/__tests__/client.test.ts
@@ -259,9 +259,9 @@ describe("isDuplicateError", () => {
   });
 
   test("bare 409 without a code is still a duplicate", () => {
-    expect(isDuplicateError(new ApiError("POST /x failed: conflict", 409))).toBe(
-      true
-    );
+    expect(
+      isDuplicateError(new ApiError("POST /x failed: conflict", 409))
+    ).toBe(true);
   });
 
   test("422 validation error is NOT a duplicate", () => {
@@ -307,7 +307,10 @@ describe("ApplyClient — upsert create/update flow", () => {
       }) as typeof fetch
     );
 
-    const result = await client.upsertEntityType({ slug: "task", name: "Task" });
+    const result = await client.upsertEntityType({
+      slug: "task",
+      name: "Task",
+    });
     expect(result).toEqual({ updated: true });
     expect(calls).toHaveLength(2);
     expect(JSON.parse(String(calls[0]?.init?.body)).action).toBe("create");

--- a/packages/cli/src/commands/_lib/apply/client.ts
+++ b/packages/cli/src/commands/_lib/apply/client.ts
@@ -528,9 +528,12 @@ export class ApplyClient {
 
   /**
    * The `manage_entity_schema` admin tool exposes separate `create` / `update`
-   * actions and surfaces duplicates as a structured error code rather than a
-   * 4xx. Probe with `create`; on a duplicate-named-resource code, retry with
-   * `update`.
+   * actions and surfaces duplicates as a coded 409 (`[entity_type_exists]` /
+   * `[relationship_type_exists]`). Probe with `create`; on that explicit
+   * duplicate signal retry with `update`. Any other error (e.g. a 422
+   * `[invalid_schema]` validation failure) propagates verbatim — retrying it
+   * as an update used to mask the real message behind "Entity type not
+   * found" (issue #1177).
    */
   private async upsertSchemaResource(
     schemaType: "entity_type" | "relationship_type",
@@ -1284,33 +1287,29 @@ export class ApplyClient {
 
 /**
  * Recognise duplicate-name errors from the admin tools without substring
- * matching the user-facing message. The server emits a structured code in
- * `error.code` (e.g. `entity_type_exists`, `already_exists`) that the
- * proxy surfaces in the error payload. This helper centralises that check
- * so we can extend the code list as the server grows.
+ * matching the user-facing message. The server stamps a bracketed code into
+ * the error message of every duplicate path `apply` upserts through
+ * (`manage_entity_schema` create / add_rule → `[entity_type_exists]`,
+ * `[relationship_type_exists]`, `[already_exists]`, all httpStatus 409).
  *
- * Tradeoff: the existing `manage_entity_schema` handler doesn't currently
- * stamp a stable code for every duplicate path. Until it does, we accept
- * structured codes when present and fall back to the http status alone
- * (any 4xx for a `create` action is treated as duplicate-or-bad-payload;
- * the subsequent `update` will fail noisily on the latter).
+ * Anything else is NOT a duplicate. In particular a 422 schema-validation
+ * error (`[invalid_schema]`, e.g. ">4 x-table-column fields") must surface
+ * verbatim — the old status-only fallback treated any 4xx as "already
+ * exists", retried with `action: update`, and buried the real message under
+ * a misleading "Entity type not found" (issue #1177). The 409 fallback stays
+ * as a belt-and-braces signal for duplicate paths that predate the codes.
  */
-function isDuplicateError(err: ApiError): boolean {
-  if (typeof err.status === "number" && err.status >= 400 && err.status < 500) {
-    const message = err.message.toLowerCase();
-    if (
-      message.includes("[entity_type_exists]") ||
-      message.includes("[relationship_type_exists]") ||
-      message.includes("[already_exists]")
-    ) {
-      return true;
-    }
-    // Fall back to status-only when no code is stamped. This is loose; we
-    // accept the loss because the v1 plan explicitly limits us to
-    // server endpoints whose error shape we don't control.
-    return err.status === 409 || err.status === 422 || err.status === 400;
+export function isDuplicateError(err: ApiError): boolean {
+  if (typeof err.status !== "number") return false;
+  const message = err.message.toLowerCase();
+  if (
+    message.includes("[entity_type_exists]") ||
+    message.includes("[relationship_type_exists]") ||
+    message.includes("[already_exists]")
+  ) {
+    return true;
   }
-  return false;
+  return err.status === 409;
 }
 
 // ── Top-level resolver ─────────────────────────────────────────────────────

--- a/packages/server/src/__tests__/integration/entity-schema/entity-types.test.ts
+++ b/packages/server/src/__tests__/integration/entity-schema/entity-types.test.ts
@@ -61,12 +61,47 @@ describe('entity schema CRUD', () => {
       expect(tombstone.entity_type).toBeNull();
     });
 
-    it('rejects a duplicate slug create', async () => {
+    it('rejects a duplicate slug create with a coded 409', async () => {
       await owner.entity_schema.createType({ slug: 'dup-asset', name: 'Dup' });
-      await expect(
-        owner.entity_schema.createType({ slug: 'dup-asset', name: 'Dup 2' })
-      ).rejects.toThrow(/already exists|duplicate/i);
+      // `lobu apply` upserts by probing create and retrying as update ONLY on
+      // this explicit duplicate signal — the code + 409 are load-bearing.
+      const err = await owner.entity_schema
+        .createType({ slug: 'dup-asset', name: 'Dup 2' })
+        .then(() => null)
+        .catch((e: unknown) => e as Error & { httpStatus?: number });
+      expect(err).not.toBeNull();
+      expect(err?.message).toMatch(/\[entity_type_exists\].*already exists/);
+      expect(err?.httpStatus).toBe(409);
       await owner.entity_schema.deleteType('dup-asset');
+    });
+
+    it('rejects >4 x-table-column fields with a 422 carrying the real message (issue #1177)', async () => {
+      // Five flagged columns; before the fix this surfaced through `lobu apply`
+      // as a misleading "Entity type 'task' not found" instead of the message.
+      const properties = Object.fromEntries(
+        ['a', 'b', 'c', 'd', 'e'].map((f) => [
+          f,
+          { type: 'string', 'x-table-column': true },
+        ])
+      );
+      const err = await owner.entity_schema
+        .createType({
+          slug: 'too-many-columns',
+          name: 'Too Many',
+          metadata_schema: { type: 'object', properties },
+        })
+        .then(() => null)
+        .catch((e: unknown) => e as Error & { httpStatus?: number });
+      expect(err).not.toBeNull();
+      expect(err?.message).toContain('[invalid_schema]');
+      expect(err?.message).toContain('At most 4 metadata fields can have x-table-column=true.');
+      expect(err?.httpStatus).toBe(422);
+      // Validation rejected the create entirely — nothing persisted, so a
+      // follow-up create-after-fix is a clean create (not an update).
+      const got = (await owner.entity_schema.getType('too-many-columns')) as {
+        entity_type: unknown;
+      };
+      expect(got.entity_type).toBeNull();
     });
 
     it('lists user-created types alongside system types', async () => {
@@ -156,11 +191,15 @@ describe('entity schema CRUD', () => {
       await owner.entity_schema.deleteRelType('collaborates-with');
     });
 
-    it('rejects a duplicate relationship slug', async () => {
+    it('rejects a duplicate relationship slug with a coded 409', async () => {
       await owner.entity_schema.createRelType({ slug: 'dup-rel', name: 'Dup' });
-      await expect(
-        owner.entity_schema.createRelType({ slug: 'dup-rel', name: 'Dup 2' })
-      ).rejects.toThrow(/already exists|duplicate/i);
+      const err = await owner.entity_schema
+        .createRelType({ slug: 'dup-rel', name: 'Dup 2' })
+        .then(() => null)
+        .catch((e: unknown) => e as Error & { httpStatus?: number });
+      expect(err).not.toBeNull();
+      expect(err?.message).toMatch(/\[relationship_type_exists\].*already exists/);
+      expect(err?.httpStatus).toBe(409);
       await owner.entity_schema.deleteRelType('dup-rel');
     });
   });

--- a/packages/server/src/tools/admin/manage_entity_schema.ts
+++ b/packages/server/src/tools/admin/manage_entity_schema.ts
@@ -18,6 +18,7 @@ import { compileRulesMetadata, ruleHashFor } from '../../identity/rules';
 import { ensureMemberEntityType } from '../../utils/member-entity-type';
 import { RESERVED_ENTITY_TYPES } from '../../utils/reserved';
 import { resolveUsernames } from '../../utils/resolve-usernames';
+import { ToolUserError } from '../../utils/errors';
 import type { ToolContext } from '../registry';
 import { routeAction } from './action-router';
 
@@ -307,6 +308,18 @@ function mapRowToEntityType(row: Record<string, unknown>): EntityTypeRow {
   };
 }
 
+/**
+ * Schema-validation failures are user input errors, not duplicates: they carry
+ * a `[invalid_schema]` marker + httpStatus 422 so REST callers (`lobu apply`)
+ * can tell them apart from create-on-duplicate (`[entity_type_exists]`, 409)
+ * instead of guessing from the status code alone (issue #1177 — a 422 here
+ * used to be mistaken for "already exists", triggering a doomed update retry
+ * that buried the real message under "Entity type not found").
+ */
+function invalidSchema(message: string): ToolUserError {
+  return new ToolUserError(`[invalid_schema] ${message}`, 422);
+}
+
 function validateEntityMetadataSchemaDisplayConfig(
   metadataSchema: Record<string, unknown> | undefined
 ): void {
@@ -328,17 +341,17 @@ function validateEntityMetadataSchemaDisplayConfig(
     if (tableColumn === true) {
       tableColumnCount += 1;
     } else if (tableColumn !== undefined && typeof tableColumn !== 'boolean') {
-      throw new Error(`metadata_schema.properties.${field}.x-table-column must be a boolean`);
+      throw invalidSchema(`metadata_schema.properties.${field}.x-table-column must be a boolean`);
     }
 
     const tableLabel = (prop as Record<string, unknown>)['x-table-label'];
     if (tableLabel !== undefined && typeof tableLabel !== 'string') {
-      throw new Error(`metadata_schema.properties.${field}.x-table-label must be a string`);
+      throw invalidSchema(`metadata_schema.properties.${field}.x-table-label must be a string`);
     }
   }
 
   if (tableColumnCount > 4) {
-    throw new Error('At most 4 metadata fields can have x-table-column=true.');
+    throw invalidSchema('At most 4 metadata fields can have x-table-column=true.');
   }
 }
 
@@ -350,12 +363,12 @@ function validateEntityMetadataSchemaDisplayConfig(
  */
 function assertValidBacking(backing: ManageEntitySchemaArgs['backing']): void {
   if (backing && typeof backing.sql === 'string' && backing.sql.trim() === '') {
-    throw new Error('backing.sql cannot be empty');
+    throw invalidSchema('backing.sql cannot be empty');
   }
   // Symmetric guard: an empty `connection` would persist backing_source='' — a
   // slug that resolves to no connection, failing only at read time.
   if (backing && typeof backing.connection === 'string' && backing.connection.trim() === '') {
-    throw new Error('backing.connection cannot be empty');
+    throw invalidSchema('backing.connection cannot be empty');
   }
 }
 
@@ -535,7 +548,9 @@ async function etHandleCreate(
     LIMIT 1
   `;
   if (existing.length > 0) {
-    throw new Error(`Entity type with slug '${slug}' already exists`);
+    // Coded 409 (not a generic 400): `lobu apply` upserts by probing `create`
+    // and retrying as `update` ONLY on an explicit duplicate signal.
+    throw new ToolUserError(`[entity_type_exists] Entity type with slug '${slug}' already exists`, 409);
   }
 
   validateEntityMetadataSchemaDisplayConfig(args.metadata_schema);
@@ -1007,7 +1022,11 @@ async function rtHandleCreate(
     LIMIT 1
   `;
   if (existing.length > 0) {
-    throw new Error(`Relationship type with slug "${args.slug}" already exists`);
+    // Coded 409 — same duplicate-signal contract as entity-type create.
+    throw new ToolUserError(
+      `[relationship_type_exists] Relationship type with slug "${args.slug}" already exists`,
+      409
+    );
   }
 
   let inverseTypeId: number | null = null;
@@ -1201,8 +1220,10 @@ async function rtHandleAddRule(
     LIMIT 1
   `;
   if (existingRule.length > 0) {
-    throw new Error(
-      `Rule already exists for ${args.source_entity_type_slug} → ${args.target_entity_type_slug}`
+    // Coded 409 — `lobu apply` treats a duplicate add_rule as success (idempotent).
+    throw new ToolUserError(
+      `[already_exists] Rule already exists for ${args.source_entity_type_slug} → ${args.target_entity_type_slug}`,
+      409
     );
   }
 


### PR DESCRIPTION
Fixes #1177

## Red (reproduced e2e on published CLI 11.0.0)

An entity type with 5 `"x-table-column": true` properties made `lobu apply` print:

```
POST /api/<org>/manage_entity_schema failed: Entity type 'task' not found
```

instead of the real validation error. Cause: `isDuplicateError()` in the apply client treated ANY 409/422/400 from `create` as "already exists" and retried with `action: update`, which then failed with "not found" on the never-created type — burying the actual message.

## Green

The same config now fails with the real message, verbatim:

```
POST /api/<org>/manage_entity_schema failed: [invalid_schema] At most 4 metadata fields can have x-table-column=true.
```

## Changes

**Server (`manage_entity_schema.ts`)** — nothing server-side stamped the duplicate codes the CLI was already looking for; every error here was a plain 400:
- User-input validation (`x-table-column`/`x-table-label` type checks, the >4 table-column cap, empty `backing.sql`/`backing.connection`) → `ToolUserError` 422 with an `[invalid_schema]` marker.
- The three duplicate paths `lobu apply` upserts through → `ToolUserError` 409 with the coded markers the CLI recognises:
  - entity_type create-on-exists → `[entity_type_exists]`
  - relationship_type create-on-exists → `[relationship_type_exists]`
  - add_rule on an existing rule → `[already_exists]`

**CLI (`apply/client.ts`)** — `isDuplicateError()` keeps the explicit code checks and restricts the status-only fallback to **409 only** (was 409/422/400), so validation errors propagate instead of triggering the doomed update retry.

### Call-site audit (idempotency preserved)

`isDuplicateError` has exactly two call sites, both in the apply client:
1. `upsertSchemaResource` (entity types + relationship types): create-on-exists is now a coded 409 → still retries as `update`. Verified by integration test (coded 409 asserted) + CLI flow test (create → 409 → update, returns `{updated: true}`).
2. `upsertRelationshipType` rule reconcile (`add_rule` race): duplicate rule is now a coded 409 → still treated as success.

No duplicate path returns a code-less 422/400 anymore, so nothing depended on the dropped fallback.

## Tests

- `packages/cli` `client.test.ts`: unit tests for `isDuplicateError` (coded duplicates → true, bare 409 → true, 422 `[invalid_schema]` → false, code-less 400 → false, no status → false) + flow tests: create→coded-409→update idempotency, and create→422 surfaces the validation message verbatim with **no** update retry. 18 pass.
- `packages/server` `entity-types.test.ts` (real embedded PG): >4 x-table-column create rejects with httpStatus 422 + `[invalid_schema]` + the exact message, and nothing is persisted; duplicate entity-type and relationship-type creates reject with coded 409s. 11 pass.
- Adjacent suites exercising `manage_entity_schema` (prune, derived-entity-query, relationships-contract, cross-org isolation): 37/37 pass.
- `bunx tsc --noEmit` clean for both `packages/cli` and `packages/server`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1211"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783787985&installation_id=136316292&pr_number=1211&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1211&signature=2f19a2ce757b79473c58bf864b88c793b77ed3165b19efe48a5f7c193f059f00"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->