### PR TITLE
fix(server): accept rest as a first-class adapterless platform

### DIFF
--- a/packages/server/src/gateway/connections/chat-instance-manager.ts
+++ b/packages/server/src/gateway/connections/chat-instance-manager.ts
@@ -152,6 +152,24 @@ const ADAPTER_FACTORIES: Record<string, (config: any) => Promise<any>> = {
     (await import("@chat-adapter/gchat")).createGoogleChatAdapter(c),
 };
 
+/**
+ * Platforms that are valid to declare on an agent but have no chat adapter to
+ * run. `rest` is the HTTP Agent API (`POST /lobu/api/v1/agents/:id/messages`),
+ * which is registered unconditionally in gateway/routes/public/agent.ts —
+ * declaring it just persists the `agent_connections` row so `lobu apply`
+ * converges; there is no instance to start/stop/restart and no webhook to
+ * route. Deliberately NOT in ADAPTER_FACTORIES: createPlatformAdapters()
+ * derives the PlatformRegistry entries from that map, and an adapterless
+ * platform must not get a registry entry either. Stateless by construction,
+ * so it is multi-replica safe — every pod's boot reconciliation sees the row
+ * as healthy (`active`) rather than retrying a doomed adapter start.
+ */
+const ADAPTERLESS_PLATFORMS = new Set<string>(["rest"]);
+
+function isAdapterlessPlatform(platform: string): boolean {
+  return ADAPTERLESS_PLATFORMS.has(platform);
+}
+
 interface ManagedInstance {
   connection: PlatformConnection;
   chat: any; // Chat SDK instance
@@ -345,7 +363,7 @@ export class ChatInstanceManager {
     metadata: Record<string, any> = {},
     stableId?: string
   ): Promise<PlatformConnection> {
-    if (!(platform in ADAPTER_FACTORIES)) {
+    if (!(platform in ADAPTER_FACTORIES) && !isAdapterlessPlatform(platform)) {
       throw new Error(`Unsupported platform: ${platform}`);
     }
     if (config.platform !== platform) {
@@ -787,6 +805,21 @@ export class ChatInstanceManager {
   }
 
   private async startInstance(connection: PlatformConnection): Promise<void> {
+    // Adapterless platforms (`rest`) have nothing to boot: no Chat SDK
+    // adapter, no webhook, no `instances` entry. Returning early keeps the
+    // connection `active` (not `error`), so boot-time reconciliation on every
+    // replica treats the row as healthy instead of retrying a doomed adapter
+    // start. All lifecycle paths funnel through here (initialize(),
+    // addConnection(), restartConnection(), updateConnection()'s restart),
+    // so this is the single skip point.
+    if (isAdapterlessPlatform(connection.platform)) {
+      logger.debug(
+        { id: connection.id, platform: connection.platform },
+        "Adapterless platform — persisted only, no chat instance to start"
+      );
+      return;
+    }
+
     // Multi-tenant secret resolution: PostgresSecretStore.get/put route
     // by AsyncLocalStorage org context (see #516). Some callers reach
     // here with org context already bound (HTTP routes via agent-routes

--- a/packages/server/src/gateway/connections/types.ts
+++ b/packages/server/src/gateway/connections/types.ts
@@ -30,13 +30,23 @@ export type GoogleChatAdapterConfig = NonNullable<
   Parameters<typeof createGoogleChatAdapter>[0]
 > & { platform: "gchat" };
 
+/**
+ * `rest` is the always-on HTTP Agent API
+ * (`POST /lobu/api/v1/agents/:id/messages`, registered unconditionally in
+ * gateway/routes/public/agent.ts). It is declarable on an agent — so
+ * `lobu apply` can converge on the scaffolded `{ type: "rest", config: {} }`
+ * binding — but it has no Chat SDK adapter and takes no config.
+ */
+export type RestPlatformConfig = { platform: "rest" };
+
 export type PlatformAdapterConfig =
   | TelegramAdapterConfig
   | SlackAdapterConfig
   | DiscordAdapterConfig
   | WhatsAppAdapterConfig
   | TeamsAdapterConfig
-  | GoogleChatAdapterConfig;
+  | GoogleChatAdapterConfig
+  | RestPlatformConfig;
 
 /** Narrow a connection's config to the Telegram shape. */
 export function isTelegramConfig(

--- a/packages/server/src/lobu/__tests__/agent-routes-rest-platform.test.ts
+++ b/packages/server/src/lobu/__tests__/agent-routes-rest-platform.test.ts
@@ -1,0 +1,272 @@
+/**
+ * Reproducer + regression coverage for lobu-ai/lobu#1179.
+ *
+ * The scaffolded AGENTS.md documents a `rest` platform binding
+ * (`{ type: "rest", config: {} }` — the HTTP Agent API) and `lobu validate`
+ * accepts it, but `lobu apply` failed server-side:
+ *
+ *   PUT /api/<org>/agents/<id>/platforms/by-stable-id/<id>-rest
+ *   → 400 "Unsupported platform: rest"
+ *
+ * because ChatInstanceManager.addConnection() rejected any platform without
+ * an ADAPTER_FACTORIES entry and startInstance() eagerly booted a chat
+ * adapter. `rest` is now a first-class adapterless platform: the row is
+ * persisted, but no chat instance is ever created.
+ *
+ * Unlike agent-routes-apply.test.ts (which installs a delegating manager
+ * stub), these tests wire the REAL ChatInstanceManager into the route so the
+ * `Unsupported platform` guard and the startInstance() skip are actually
+ * exercised end-to-end:
+ *
+ *   1. PUT by-stable-id with type `rest` succeeds (201) and persists the row
+ *      — and no chat instance is registered for it.
+ *   2. Re-applying the same body is idempotent (200 noop).
+ *   3. Boot reconciliation (a fresh manager's initialize(), i.e. another
+ *      replica or the next deploy) keeps the rest row `active` — it is not
+ *      treated as a perpetually-failing adapter start.
+ *   4. The start/stop run-state endpoints don't crash on an adapterless row.
+ *   5. Genuinely unknown platforms are still rejected with
+ *      "Unsupported platform: …" (other platform types unaffected).
+ *
+ * Uses the embedded Postgres gateway test harness; no network.
+ */
+
+import { beforeAll, beforeEach, describe, expect, mock, test } from 'bun:test';
+import {
+  ensureDbForGatewayTests,
+  resetTestDatabase,
+} from '../../gateway/__tests__/helpers/db-setup.js';
+
+const TEST_ENCRYPTION_KEY =
+  '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
+
+// Mocked auth middleware — same contract as agent-routes-apply.test.ts.
+const authStash: {
+  user: { id: string; name: string; email: string; emailVerified: boolean } | null;
+  organizationId: string | null;
+  authSource: 'session' | 'pat' | 'oauth' | null;
+  mcpAuthInfo: { scopes: string[] } | null;
+} = {
+  user: { id: 'u1', name: 'Test', email: 'u1@test', emailVerified: true },
+  organizationId: 'org-rest',
+  authSource: 'session',
+  mcpAuthInfo: null,
+};
+
+mock.module('../../auth/middleware', () => ({
+  mcpAuth: async (c: any, next: any) => {
+    c.set('user', authStash.user);
+    c.set('organizationId', authStash.organizationId);
+    c.set('authSource', authStash.authSource);
+    c.set('mcpAuthInfo', authStash.mcpAuthInfo);
+    return next();
+  },
+  requireAuth: async (_c: any, next: any) => next(),
+}));
+
+// The route reads the manager via getChatInstanceManager(); install the REAL
+// ChatInstanceManager built by buildRealManager() below.
+const chatManagerStash: { manager: any } = { manager: null };
+
+mock.module('../gateway', () => ({
+  getChatInstanceManager: () => chatManagerStash.manager,
+  getLobuCoreServices: () => null,
+  initLobuGateway: async () => null,
+  stopLobuGateway: async () => {},
+  isLobuGatewayRunning: () => false,
+  ensureEmbeddedGatewaySecrets: () => {},
+}));
+
+const ORG = 'org-rest';
+const AGENT = 'rest-agent';
+const STABLE_ID = `${AGENT}-rest`;
+
+beforeAll(async () => {
+  await ensureDbForGatewayTests();
+  process.env.ENCRYPTION_KEY = TEST_ENCRYPTION_KEY;
+}, 60_000);
+
+async function importAgentRoutes() {
+  const mod = await import('../agent-routes.js');
+  return mod.agentRoutes;
+}
+
+async function seedOrgAndAgent(orgId: string, agentId: string): Promise<void> {
+  const { getDb } = await import('../../db/client.js');
+  const sql = getDb();
+  await sql`
+    INSERT INTO organization (id, name, slug)
+    VALUES (${orgId}, ${orgId}, ${orgId})
+    ON CONFLICT (id) DO NOTHING
+  `;
+  await sql`
+    INSERT INTO agents (id, organization_id, name)
+    VALUES (${agentId}, ${orgId}, ${agentId})
+    ON CONFLICT (organization_id, id) DO NOTHING
+  `;
+}
+
+/**
+ * Real ChatInstanceManager over the real Postgres stores — startInstance is
+ * NOT stubbed, so an adapter-requiring platform would actually try to boot.
+ * Mirrors the buildManager() harness in chat-instance-manager-config.test.ts.
+ */
+async function buildRealManager() {
+  const { ChatInstanceManager } = await import(
+    '../../gateway/connections/chat-instance-manager.js'
+  );
+  const { createPostgresAgentConnectionStore } = await import(
+    '../stores/postgres-stores.js'
+  );
+  const { PostgresSecretStore } = await import(
+    '../stores/postgres-secret-store.js'
+  );
+  const { SecretStoreRegistry } = await import('../../gateway/secrets/index.js');
+  const { orgContext } = await import('../stores/org-context.js');
+
+  const connectionStore = createPostgresAgentConnectionStore();
+  const postgresSecretStore = new PostgresSecretStore();
+  const secretStore = new SecretStoreRegistry(postgresSecretStore, {
+    secret: postgresSecretStore,
+  });
+
+  const services = {
+    getPublicGatewayUrl: () => '',
+    getSecretStore: () => secretStore,
+    getConnectionStore: () => connectionStore,
+    getChannelBindingService: () => ({ getBinding: async () => null }),
+    getCommandRegistry: () => undefined,
+  } as any;
+
+  const manager = new ChatInstanceManager() as any;
+  manager.services = services;
+  manager.publicGatewayUrl = '';
+  manager.connectionStore = connectionStore;
+  manager.slackCoordinator = manager.buildSlackCoordinator();
+
+  return { manager, services, connectionStore, orgContext };
+}
+
+async function putRestPlatform(app: any, stableId: string = STABLE_ID) {
+  return app.request(`/${AGENT}/platforms/by-stable-id/${stableId}`, {
+    method: 'PUT',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ platform: 'rest', config: {} }),
+  });
+}
+
+beforeEach(async () => {
+  await resetTestDatabase();
+  await seedOrgAndAgent(ORG, AGENT);
+  authStash.user = { id: 'u1', name: 'Test', email: 'u1@test', emailVerified: true };
+  authStash.organizationId = ORG;
+  authStash.authSource = 'session';
+  authStash.mcpAuthInfo = null;
+  const { manager } = await buildRealManager();
+  chatManagerStash.manager = manager;
+}, 30_000);
+
+describe('PUT /agents/:agentId/platforms/by-stable-id — type rest (#1179)', () => {
+  test('creates the platform row without instantiating a chat adapter', async () => {
+    const app = await importAgentRoutes();
+
+    const res = await putRestPlatform(app);
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as any;
+    expect(body.platform.id).toBe(STABLE_ID);
+    expect(body.platform.platform).toBe('rest');
+    expect(body.platform.status).toBe('active');
+
+    // Persisted (visible to a plain store read in the same org)…
+    const { connectionStore, orgContext } = await buildRealManager();
+    const stored = await orgContext.run({ organizationId: ORG }, () =>
+      connectionStore.getConnection(STABLE_ID)
+    );
+    expect(stored).not.toBeNull();
+    expect(stored!.platform).toBe('rest');
+    expect(stored!.status).toBe('active');
+
+    // …but no chat instance was created: rest is adapterless.
+    expect(chatManagerStash.manager.has(STABLE_ID)).toBe(false);
+    expect(chatManagerStash.manager.getInstance(STABLE_ID)).toBeUndefined();
+  });
+
+  test('re-apply with the same body is an idempotent noop', async () => {
+    const app = await importAgentRoutes();
+
+    const first = await putRestPlatform(app);
+    expect(first.status).toBe(201);
+
+    const second = await putRestPlatform(app);
+    expect(second.status).toBe(200);
+    const body = (await second.json()) as any;
+    expect(body.noop).toBe(true);
+    expect(body.platform.id).toBe(STABLE_ID);
+
+    // Still no instance after the re-apply.
+    expect(chatManagerStash.manager.has(STABLE_ID)).toBe(false);
+  });
+
+  test('boot reconciliation on another replica keeps the rest row active', async () => {
+    const app = await importAgentRoutes();
+    expect((await putRestPlatform(app)).status).toBe(201);
+
+    // A fresh manager booting from the same store — i.e. another replica, or
+    // the next deploy. The rest row must come through `active` with no error
+    // marker (not "perpetually failed to start"), and still adapterless.
+    const { manager: replica, services, connectionStore, orgContext } =
+      await buildRealManager();
+    await replica.initialize(services);
+
+    const stored = await orgContext.run({ organizationId: ORG }, () =>
+      connectionStore.getConnection(STABLE_ID)
+    );
+    expect(stored).not.toBeNull();
+    expect(stored!.status).toBe('active');
+    expect(stored!.errorMessage ?? null).toBeNull();
+    expect(replica.has(STABLE_ID)).toBe(false);
+  });
+
+  test('start/stop run-state endpoints work on an adapterless platform', async () => {
+    const app = await importAgentRoutes();
+    expect((await putRestPlatform(app)).status).toBe(201);
+
+    const stop = await app.request(`/${AGENT}/platforms/${STABLE_ID}/stop`, {
+      method: 'POST',
+    });
+    expect(stop.status).toBe(200);
+    expect(((await stop.json()) as any).success).toBe(true);
+
+    const start = await app.request(`/${AGENT}/platforms/${STABLE_ID}/start`, {
+      method: 'POST',
+    });
+    expect(start.status).toBe(200);
+    const startBody = (await start.json()) as any;
+    expect(startBody.success).toBe(true);
+    expect(startBody.platform.status).toBe('active');
+    expect(chatManagerStash.manager.has(STABLE_ID)).toBe(false);
+  });
+
+  test('genuinely unknown platforms are still rejected', async () => {
+    const app = await importAgentRoutes();
+
+    const res = await app.request(
+      `/${AGENT}/platforms/by-stable-id/${AGENT}-fax`,
+      {
+        method: 'PUT',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ platform: 'fax', config: {} }),
+      }
+    );
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as any;
+    expect(body.error).toContain('Unsupported platform: fax');
+
+    // The placeholder claim row is rolled back on failure.
+    const { connectionStore, orgContext } = await buildRealManager();
+    const stored = await orgContext.run({ organizationId: ORG }, () =>
+      connectionStore.getConnection(`${AGENT}-fax`)
+    );
+    expect(stored).toBeNull();
+  });
+});


### PR DESCRIPTION
Fixes #1179

## Problem

The scaffolded AGENTS.md documents a `rest` platform binding (`{ type: "rest", config: {} }` — "HTTP API — always config: {}") and `lobu validate` accepts it, but apply fails server-side (confirmed e2e on published CLI 11.0.0):

```
PUT /api/<org>/agents/<id>/platforms/by-stable-id/<id>-rest failed: Unsupported platform: rest
```

`ChatInstanceManager.addConnection` rejected any platform without an `ADAPTER_FACTORIES` entry (telegram/slack/discord/whatsapp/teams/gchat), and `startInstance` eagerly booted a Chat SDK adapter. Meanwhile the HTTP Agent API (`POST /lobu/api/v1/agents/:id/messages`) is registered unconditionally — `rest` is a valid declarable platform that simply needs no adapter.

## Fix

`rest` is now a first-class adapterless platform:

- `ADAPTERLESS_PLATFORMS` set next to `ADAPTER_FACTORIES`; `addConnection` accepts it, `startInstance` returns early — the `agent_connections` row is persisted, no chat instance is ever registered.
- Deliberately NOT registered in `ADAPTER_FACTORIES`, so `createPlatformAdapters()` doesn't derive a bogus PlatformRegistry entry for it.
- `RestPlatformConfig` added to the `PlatformAdapterConfig` union.
- Multi-replica: stateless by construction — the early return keeps the row `active` (not `error`), so every replica's boot reconciliation sees it as healthy instead of retrying a doomed adapter start. Verified the surrounding paths: restart/stop/delete are no-ops on a missing instance, webhook routing 404s (rest has no webhook), notification fan-out only targets channel-bound connections and catches per-target failures, connections list APIs are store-based.

## Red → Green

Tests drive the real `PUT /agents/:agentId/platforms/by-stable-id/:stableId` route wired to the **real** `ChatInstanceManager` (the existing apply tests use a delegating stub that bypasses the guard).

On `origin/main` (red):

```
(fail) PUT ... — type rest (#1179) > creates the platform row without instantiating a chat adapter
  Expected: 201 / Received: 400   ("Unsupported platform: rest")
(fail) ... > re-apply with the same body is an idempotent noop
(fail) ... > boot reconciliation on another replica keeps the rest row active
(fail) ... > start/stop run-state endpoints work on an adapterless platform
 1 pass, 4 fail
```

With the fix (green):

```
 5 pass, 0 fail, 29 expect() calls
Ran 5 tests across 1 file. [2.55s]
```

Coverage: create persists + no instance (`manager.has() === false`); re-apply → `200 {noop:true}`; a fresh manager's `initialize()` (another replica / next deploy) keeps the row `active` with no error marker; start/stop endpoints succeed; unknown platforms (`fax`) still rejected with placeholder rollback.

Also ran: `bunx tsc --noEmit` (server) clean; `chat-instance-manager-config/boot`, `connections-platform-isolation` (95 pass); `agent-routes-apply`, `multi-tenant-integration`, `restart-connection-orgless` (32 pass).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1212"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783790684&installation_id=136316292&pr_number=1212&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1212&signature=92c1715e9a6cc87e1e2821a74a3f92ed90fd9d80900dc2ad487dccd13a1d3e22"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->