### PR TITLE
fix(server): provision install operator + default org on external-DB lobu run

### DIFF
--- a/packages/server/src/__tests__/integration/local-bootstrap.test.ts
+++ b/packages/server/src/__tests__/integration/local-bootstrap.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Integration test for `local-bootstrap.ts` — the shared `lobu run`
+ * provisioning hooks (issue #1180).
+ *
+ * Pins two contracts against a real Postgres:
+ *
+ *   1. With LOBU_RUN_OWNS_DB=1 (the CLI-set local-install marker), running
+ *      the external-DB bootstrap hooks on a fresh, migrated database
+ *      provisions the install operator, its personal org, and the default
+ *      agent — i.e. `/api/local-init` has a first user to mint a session
+ *      for.
+ *   2. WITHOUT the flag (every cloud/prod deployment), the external-DB
+ *      branch gets ZERO hooks and the database stays empty — prod must
+ *      never auto-provision users/orgs.
+ */
+
+import { beforeEach, describe, expect, it } from 'vitest';
+import { DEFAULT_AGENT_ID } from '../../auth/default-provisioning';
+import { INSTALL_OPERATOR_KIND } from '../../auth/install-operator';
+import { externalDbBootstrapHooks } from '../../local-bootstrap';
+import { cleanupTestDatabase, getTestDb } from '../setup/test-db';
+
+function testDatabaseUrl(): string {
+  const url = process.env.DATABASE_URL;
+  if (!url) throw new Error('DATABASE_URL must be set by the test harness');
+  return url;
+}
+
+async function countRows(table: 'user' | 'organization'): Promise<number> {
+  const sql = getTestDb();
+  const rows = (await sql`
+    SELECT count(*)::int AS count FROM ${sql(table)}
+  `) as unknown as Array<{ count: number }>;
+  return rows[0]?.count ?? 0;
+}
+
+describe('externalDbBootstrapHooks', () => {
+  // Canonical 32-byte hex key so ensureInstallOperator's assertEncryptionKey
+  // passes (same convention as install-operator.test.ts).
+  const VALID_KEY = 'a'.repeat(64);
+
+  beforeEach(async () => {
+    // Truncates every table — the suite starts from the exact fresh-install
+    // state the bug report describes (SELECT count(*) FROM "user" → 0).
+    await cleanupTestDatabase();
+    process.env.ENCRYPTION_KEY = VALID_KEY;
+  });
+
+  it('with LOBU_RUN_OWNS_DB=1: provisions operator + personal org + default agent on an empty DB', async () => {
+    expect(await countRows('user')).toBe(0);
+    expect(await countRows('organization')).toBe(0);
+
+    const hooks = externalDbBootstrapHooks(testDatabaseUrl(), {
+      LOBU_RUN_OWNS_DB: '1',
+    });
+    expect(hooks.length).toBeGreaterThan(0);
+    for (const hook of hooks) await hook();
+
+    const sql = getTestDb();
+    const operators = (await sql`
+      SELECT id FROM "user" WHERE principal_kind = ${INSTALL_OPERATOR_KIND}
+    `) as unknown as Array<{ id: string }>;
+    expect(operators).toHaveLength(1);
+
+    const orgs = (await sql`
+      SELECT id FROM "organization"
+      WHERE (metadata::jsonb)->>'personal_org_for_user_id' = ${operators[0]!.id}
+    `) as unknown as Array<{ id: string }>;
+    expect(orgs).toHaveLength(1);
+
+    const agents = (await sql`
+      SELECT id FROM agents
+      WHERE organization_id = ${orgs[0]!.id} AND id = ${DEFAULT_AGENT_ID}
+    `) as unknown as Array<unknown>;
+    expect(agents).toHaveLength(1);
+  });
+
+  it('with LOBU_RUN_OWNS_DB=1: re-running the hooks is idempotent', async () => {
+    const hooks = externalDbBootstrapHooks(testDatabaseUrl(), {
+      LOBU_RUN_OWNS_DB: '1',
+    });
+    for (const hook of hooks) await hook();
+    for (const hook of hooks) await hook();
+
+    expect(await countRows('user')).toBe(1);
+    expect(await countRows('organization')).toBe(1);
+  });
+
+  it('WITHOUT the flag: returns no hooks and the DB stays empty (prod safety)', async () => {
+    for (const env of [{}, { LOBU_RUN_OWNS_DB: '0' }, { LOBU_RUN_OWNS_DB: 'true' }]) {
+      const hooks = externalDbBootstrapHooks(testDatabaseUrl(), env);
+      expect(hooks).toHaveLength(0);
+    }
+
+    expect(await countRows('user')).toBe(0);
+    expect(await countRows('organization')).toBe(0);
+  });
+});

--- a/packages/server/src/embedded-runtime.ts
+++ b/packages/server/src/embedded-runtime.ts
@@ -17,12 +17,11 @@ import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import postgres from "postgres";
-import { ensureDefaultAgent } from "./auth/default-provisioning";
-import { ensureInstallOperator } from "./auth/install-operator";
 import {
 	listMigrationFiles,
 	loadMigrationUpSection,
 } from "./db/migration-loader";
+import { buildLocalBootstrapHooks } from "./local-bootstrap";
 import logger from "./utils/logger";
 
 const APP_ROOT = join(fileURLToPath(new URL(".", import.meta.url)), "..");
@@ -163,38 +162,9 @@ export async function startEmbeddedRuntime(): Promise<EmbeddedRuntime> {
 		databaseUrl,
 		dataDir: pgDataDir,
 		databaseReadiness: () => runMigrations(databaseUrl),
-		preListenHooks: [
-			// BEFORE listen so headless installs (CI, containers) sign in via
-			// better-auth without a chicken-and-egg /sign-up. Provisions the
-			// synthetic `install_operator` user; idempotent. Never crash boot.
-			async () => {
-				try {
-					await ensureInstallOperator();
-				} catch (err) {
-					logger.error({ err }, "Install-operator provisioning failed");
-				}
-			},
-			// Default-agent provisioning: resolve the personal org id each boot so
-			// a returning user picks up the default agent.
-			async () => {
-				try {
-					const rows = postgres(databaseUrl, { max: 1 });
-					try {
-						const orgs = (await rows`
-              SELECT id FROM "organization"
-              WHERE (metadata::jsonb)->>'personal_org_for_user_id' IS NOT NULL
-              ORDER BY "createdAt" ASC LIMIT 1
-            `) as unknown as Array<{ id: string }>;
-						const orgId = orgs[0]?.id ?? null;
-						if (orgId) await ensureDefaultAgent(orgId);
-					} finally {
-						await rows.end({ timeout: 1 });
-					}
-				} catch (err) {
-					logger.warn({ err }, "Default-agent provisioning failed");
-				}
-			},
-		],
+		// Install-operator + default-agent provisioning, shared with the
+		// external-DB `lobu run` path (see local-bootstrap.ts).
+		preListenHooks: buildLocalBootstrapHooks(databaseUrl),
 		// Runs after stopLobuGateway + closeDbSingleton so gateway connections
 		// release before the embeddings child + PG child are stopped.
 		extraTeardown: [
@@ -204,6 +174,27 @@ export async function startEmbeddedRuntime(): Promise<EmbeddedRuntime> {
 			() => pg.stop(),
 		],
 	};
+}
+
+/**
+ * Locate the bundled `db/migrations` directory. The published `@lobu/cli`
+ * copies migrations next to the server bundle (`dist/db/migrations`); a
+ * monorepo checkout finds them at the repo root; running from a project
+ * subdir falls back to cwd-relative candidates. Returns null when nothing
+ * exists (the callers decide whether that's fatal). Used by `runMigrations`
+ * AND by `server.ts`'s boot-time schema-version check, which previously
+ * resolved a bundle-relative `../../../db/migrations` that lands on
+ * `node_modules/db/migrations` (ENOENT) in the published CLI.
+ */
+export function resolveMigrationsDir(): string | null {
+	return resolveExistingPath(
+		// Published @lobu/cli copies migrations next to the bundle under dist/db/migrations.
+		join(fileURLToPath(new URL(".", import.meta.url)), "db", "migrations"),
+		join(APP_ROOT, "db", "migrations"),
+		join(APP_ROOT, "..", "..", "db", "migrations"),
+		join(process.cwd(), "db", "migrations"),
+		join(process.cwd(), "..", "..", "db", "migrations"),
+	);
 }
 
 /**
@@ -222,14 +213,7 @@ export async function runMigrations(databaseUrl: string): Promise<void> {
 	const sql = postgres(databaseUrl, { max: 1 });
 
 	try {
-		const migrationsDir = resolveExistingPath(
-			// Published @lobu/cli copies migrations next to the bundle under dist/db/migrations.
-			join(fileURLToPath(new URL(".", import.meta.url)), "db", "migrations"),
-			join(APP_ROOT, "db", "migrations"),
-			join(APP_ROOT, "..", "..", "db", "migrations"),
-			join(process.cwd(), "db", "migrations"),
-			join(process.cwd(), "..", "..", "db", "migrations"),
-		);
+		const migrationsDir = resolveMigrationsDir();
 		if (!migrationsDir) throw new Error("Migrations directory not found.");
 
 		await sql.unsafe(`

--- a/packages/server/src/local-bootstrap.ts
+++ b/packages/server/src/local-bootstrap.ts
@@ -1,0 +1,84 @@
+/**
+ * Local-install bootstrap hooks — shared by BOTH `lobu run` backends:
+ *
+ *   - embedded Postgres (`embedded-runtime.ts`), always;
+ *   - external postgres:// DATABASE_URL (`server.ts`), only when the CLI set
+ *     LOBU_RUN_OWNS_DB=1.
+ *
+ * The hooks provision the synthetic `install_operator` user (+ its personal
+ * org) and the default agent, so a fresh install is sign-in-able via
+ * `/api/local-init` without a chicken-and-egg /sign-up. Both steps are
+ * idempotent and never crash boot. They must run as pre-listen hooks: the
+ * gateway init that precedes them establishes ENCRYPTION_KEY, which
+ * `ensureInstallOperator` requires.
+ *
+ * 🚨 SAFETY INVARIANT — cloud/multi-replica prod must NEVER auto-provision
+ * users or orgs. `LOBU_RUN_OWNS_DB=1` is set in exactly one place: the CLI's
+ * `lobu run` command (`packages/cli/src/commands/dev.ts`) when it spawns the
+ * server bundle for a single-operator local install. The prod chart
+ * (`charts/lobu`) and deployment manifests never set it, so
+ * `externalDbBootstrapHooks` returns `[]` there and prod boots stay
+ * bootstrap-free. Do not gate bootstrap on anything weaker than this explicit
+ * opt-in flag, and never set the flag from inside the server.
+ */
+
+import postgres from "postgres";
+import { ensureDefaultAgent } from "./auth/default-provisioning";
+import { ensureInstallOperator } from "./auth/install-operator";
+import logger from "./utils/logger";
+
+export type PreListenHook = () => Promise<void> | void;
+
+/**
+ * The two local-install provisioning hooks, in order. `databaseUrl` must be
+ * the final resolved postgres:// URL (embedded: the spawned cluster's TCP
+ * URL; external: DATABASE_URL itself).
+ */
+export function buildLocalBootstrapHooks(databaseUrl: string): PreListenHook[] {
+	return [
+		// BEFORE listen so headless installs (CI, containers) sign in via
+		// better-auth without a chicken-and-egg /sign-up. Provisions the
+		// synthetic `install_operator` user; idempotent. Never crash boot.
+		async () => {
+			try {
+				await ensureInstallOperator();
+			} catch (err) {
+				logger.error({ err }, "Install-operator provisioning failed");
+			}
+		},
+		// Default-agent provisioning: resolve the personal org id each boot so
+		// a returning user picks up the default agent.
+		async () => {
+			try {
+				const rows = postgres(databaseUrl, { max: 1 });
+				try {
+					const orgs = (await rows`
+            SELECT id FROM "organization"
+            WHERE (metadata::jsonb)->>'personal_org_for_user_id' IS NOT NULL
+            ORDER BY "createdAt" ASC LIMIT 1
+          `) as unknown as Array<{ id: string }>;
+					const orgId = orgs[0]?.id ?? null;
+					if (orgId) await ensureDefaultAgent(orgId);
+				} finally {
+					await rows.end({ timeout: 1 });
+				}
+			} catch (err) {
+				logger.warn({ err }, "Default-agent provisioning failed");
+			}
+		},
+	];
+}
+
+/**
+ * Flag-gated bootstrap for the external-DATABASE_URL branch. Returns the
+ * bootstrap hooks ONLY when `LOBU_RUN_OWNS_DB === "1"` (the CLI-owned local
+ * install marker — see the safety invariant above); otherwise `[]`, which is
+ * what every cloud/prod deployment gets.
+ */
+export function externalDbBootstrapHooks(
+	databaseUrl: string,
+	env: NodeJS.ProcessEnv,
+): PreListenHook[] {
+	if (env.LOBU_RUN_OWNS_DB !== "1") return [];
+	return buildLocalBootstrapHooks(databaseUrl);
+}

--- a/packages/server/src/server-lifecycle.ts
+++ b/packages/server/src/server-lifecycle.ts
@@ -50,7 +50,9 @@ export interface ServerLifecycleConfig {
 	databaseReadiness: () => Promise<void>;
 	/**
 	 * Runs after gateway + scheduler boot, before `httpServer.listen()`.
-	 * The embedded backend uses this for `ensureInstallOperator` + `ensureDefaultAgent`.
+	 * Both `lobu run` backends use this for `ensureInstallOperator` +
+	 * `ensureDefaultAgent` (embedded always; external only with
+	 * LOBU_RUN_OWNS_DB=1 — see local-bootstrap.ts).
 	 */
 	preListenHooks?: Array<() => Promise<void> | void>;
 	/**

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -38,7 +38,12 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { assertExternalDepsResolvable } from "@lobu/connector-worker/compile";
 import { getDb, probeListenNotify } from "./db/client";
-import { runMigrations, startEmbeddedRuntime } from "./embedded-runtime";
+import {
+	resolveMigrationsDir,
+	runMigrations,
+	startEmbeddedRuntime,
+} from "./embedded-runtime";
+import { externalDbBootstrapHooks } from "./local-bootstrap";
 import { getEnvFromProcess } from "./utils/env";
 import logger from "./utils/logger";
 import { assertSchemaUpToDate } from "./utils/schema-version-check";
@@ -74,11 +79,44 @@ async function main(): Promise<void> {
 	let preListenHooks: Array<() => Promise<void> | void> = [];
 	let extraTeardown: Array<() => Promise<void> | void> = [];
 
+	// Local-install conveniences — ephemeral secrets + localhost URLs so a bare
+	// `lobu run` works without hand-written env. Applies to the embedded backend
+	// always, and to an external DATABASE_URL only when the CLI marked this
+	// process a single-operator local install (LOBU_RUN_OWNS_DB=1 — see the
+	// safety invariant below). Prod never sets the flag and always has these
+	// set explicitly, so every guard no-ops there.
+	if (!external || process.env.LOBU_RUN_OWNS_DB === "1") {
+		if (!process.env.BETTER_AUTH_SECRET) {
+			process.env.BETTER_AUTH_SECRET = randomBytes(32).toString("base64");
+			logger.info(
+				"Generated ephemeral BETTER_AUTH_SECRET — set in .env to persist sessions",
+			);
+		}
+		if (!process.env.JWT_SECRET) {
+			process.env.JWT_SECRET = randomBytes(32).toString("base64");
+		}
+		if (!process.env.PUBLIC_WEB_URL) {
+			process.env.PUBLIC_WEB_URL = `http://localhost:${port}`;
+		}
+		if (!process.env.NODE_ENV) {
+			process.env.NODE_ENV = "development";
+		}
+	}
+
 	if (external) {
 		// `external` is true only for a non-empty postgres:// URL, so `raw` is
 		// defined here; bind it to a non-optional local for the closure below.
 		const externalDatabaseUrl = raw as string;
 		process.env.DATABASE_URL = externalDatabaseUrl;
+		// 🚨 SAFETY INVARIANT: cloud/multi-replica prod must NEVER auto-provision
+		// users or orgs. LOBU_RUN_OWNS_DB=1 is set ONLY by the CLI's `lobu run`
+		// (packages/cli/src/commands/dev.ts) for single-operator local installs;
+		// charts/lobu and the prod manifests never set it, so this returns [] in
+		// prod. Without these hooks an external-DB `lobu run` migrated the schema
+		// but left `user`/`organization` empty — `/api/local-init` then failed
+		// with `unexpected_empty_user_table` and there was no path to a first
+		// user (issue #1180).
+		preListenHooks = externalDbBootstrapHooks(externalDatabaseUrl, process.env);
 		databaseReadiness = async () => {
 			// `lobu run` owns the local DB lifecycle, so it must apply migrations
 			// itself before the schema-version gate runs — otherwise a fresh/empty
@@ -96,8 +134,13 @@ async function main(): Promise<void> {
 			// Refuse to boot if the image expects a migration the DB hasn't applied.
 			// Skippable via SKIP_SCHEMA_VERSION_CHECK=1 for emergency forward-flight.
 			if (process.env.SKIP_SCHEMA_VERSION_CHECK !== "1") {
+				// resolveMigrationsDir covers the published CLI (migrations live next
+				// to the bundle, where the repo-root-relative path resolved to
+				// node_modules/db/migrations → ENOENT warning); the PACKAGE_REPO_ROOT
+				// fallback preserves the previous behaviour everywhere else.
 				const migrationsDir =
 					process.env.LOBU_MIGRATIONS_DIR?.trim() ||
+					resolveMigrationsDir() ||
 					path.join(PACKAGE_REPO_ROOT, "db", "migrations");
 				await assertSchemaUpToDate(getDb(), { migrationsDir });
 			} else {
@@ -121,25 +164,6 @@ async function main(): Promise<void> {
 			}
 		};
 	} else {
-		// Embedded/local conveniences — ephemeral secrets + localhost URLs so a
-		// bare `lobu run` works. (In prod these are always already set, so the
-		// guards no-op; this branch only runs for path/file:// DATABASE_URLs.)
-		if (!process.env.BETTER_AUTH_SECRET) {
-			process.env.BETTER_AUTH_SECRET = randomBytes(32).toString("base64");
-			logger.info(
-				"Generated ephemeral BETTER_AUTH_SECRET — set in .env to persist sessions",
-			);
-		}
-		if (!process.env.JWT_SECRET) {
-			process.env.JWT_SECRET = randomBytes(32).toString("base64");
-		}
-		if (!process.env.PUBLIC_WEB_URL) {
-			process.env.PUBLIC_WEB_URL = `http://localhost:${port}`;
-		}
-		if (!process.env.NODE_ENV) {
-			process.env.NODE_ENV = "development";
-		}
-
 		// Lazy: pulls embedded-postgres + the pgvector injector ONLY here, spawns
 		// the cluster, sets process.env.DATABASE_URL to its TCP URL.
 		const rt = await startEmbeddedRuntime();


### PR DESCRIPTION
Fixes #1180

## Problem

`lobu run` against an external `postgres://` `DATABASE_URL` applies migrations (`LOBU_RUN_OWNS_DB=1`) but never runs the local-install bootstrap: `server.ts` initialized `preListenHooks = []` and only the embedded branch (via `startEmbeddedRuntime()`) populated it with `ensureInstallOperator` + `ensureDefaultAgent`. Result: `user` and `organization` stay empty, `POST /api/local-init` returns `unexpected_empty_user_table`, and there is no other path to create the first user — the instance is unusable via the local CLI.

### Red reproducer (published CLI 11.0.0, Homebrew PG17+pgvector on :5433, 2026-06-11)

```
[migrations] LOBU_RUN_OWNS_DB=1 — applying migrations to external DATABASE_URL
SELECT count(*) FROM "user";         → 0
SELECT count(*) FROM organization;   → 0
POST /api/local-init                 → {"error":"unexpected_empty_user_table", ...} (500)
```

## Fix

- **`packages/server/src/local-bootstrap.ts` (new):** the install-operator + default-agent pre-listen hooks, extracted verbatim from `embedded-runtime.ts` (static imports only — no new dynamic imports). `externalDbBootstrapHooks(databaseUrl, env)` returns the hooks only when `env.LOBU_RUN_OWNS_DB === "1"`, else `[]`.
- **`server.ts` external branch:** wires `preListenHooks = externalDbBootstrapHooks(...)`, and extends the local-install env conveniences (ephemeral `BETTER_AUTH_SECRET` / `JWT_SECRET`, localhost `PUBLIC_WEB_URL`, `NODE_ENV=development`) to the flagged external branch. Without the secret piece the fix was incomplete: rows existed but `/api/local-init` then failed with `session_create_failed` (`BETTER_AUTH_SECRET not set`) — the CLI never sets it and only the embedded branch generated one.
- **`embedded-runtime.ts`:** now consumes the shared helper; behavior unchanged.

### Green (this branch, fresh `lobu_1180_e2e` DB on the same PG17, real server boot with `LOBU_RUN_OWNS_DB=1` and no `BETTER_AUTH_SECRET` in env)

```
[default-provisioning] Provisioned default agent (org_..., owletto-default, user_install_...)
SELECT count(*) FROM "user";         → 1   (principal_kind = install_operator)
SELECT count(*) FROM organization;   → 1
POST /api/local-init                 → 200 {"session_token":"...","device_token":"owl_pat_...", "user":{...}}
```

## Cloud safety analysis

🚨 Invariant (documented in `local-bootstrap.ts` and at the `server.ts` call site): **cloud/multi-replica prod must never auto-provision users or orgs.**

- `LOBU_RUN_OWNS_DB` is set in exactly one place: the CLI's run command (`packages/cli/src/commands/dev.ts:355`). `grep -rn LOBU_RUN_OWNS_DB` across `charts/`, `docker/`, `scripts/`, and all packages confirms neither `charts/lobu` nor any deployment manifest sets it — prod boots get `[]` hooks and zero env-convenience defaults (prod always sets its secrets explicitly, so those guards no-op anyway).
- Verified on the real boot path: rebooted the same migrated DB **without** the flag (prod-style env) → 0 users, 0 orgs, zero provisioning log lines, and no migration replay.
- The hooks themselves are unchanged, idempotent, and fail-soft (caught + logged), same as the embedded path; under N replicas racing, `ensureInstallOperator` / `ensureDefaultAgent` already guard with existence checks + `ON CONFLICT DO NOTHING` — and prod never runs them at all.

## Drive-by

Under external DB the boot-time schema check warned `ENOENT scandir '<cli-install>/node_modules/db/migrations'`: `server.ts` resolved the migrations dir bundle-relative (`../../../db/migrations`), which lands on `node_modules/db/migrations` in the published CLI. It now reuses `runMigrations`' candidate resolution via the extracted `resolveMigrationsDir()` (published CLI ships migrations next to the bundle at `dist/db/migrations`), keeping the old path as the final fallback so prod images resolve exactly as before.

## Tests

New `packages/server/src/__tests__/integration/local-bootstrap.test.ts` (real Postgres via the vitest harness):

1. flag set + empty DB → install operator + personal org + default agent exist
2. flag set, hooks run twice → idempotent (still 1 user / 1 org)
3. flag absent / `"0"` / `"true"` → zero hooks, DB stays empty (prod safety)

`vitest run` on the new file + `install-operator.test.ts` + `default-provisioning.test.ts`: **19/19 passed**. `bunx tsc --noEmit` (server): clean.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1213"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783788434&installation_id=136316292&pr_number=1213&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1213&signature=4d740f8f289bee80060090ab77d57210bfc5ac1d06b529e8e37308c81df9ef13"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->