### PR TITLE
fix(connectors): resolve connector SDK for metadata extraction in projects without node_modules

### DIFF
--- a/packages/cli/src/commands/_lib/__tests__/ensure-deps-installed.test.ts
+++ b/packages/cli/src/commands/_lib/__tests__/ensure-deps-installed.test.ts
@@ -1,0 +1,151 @@
+/**
+ * Tests for the project dependency installer (#1181).
+ *
+ * The installer is exercised against a fake `npm` binary staged on a
+ * test-controlled PATH (a recorder script that logs argv + cwd), so no real
+ * package-manager work or network happens. npm — not bun — because the bun
+ * test runner intercepts spawns of `bun` and runs the real binary regardless
+ * of PATH. A `package-lock.json` in each fixture pins `pickInstaller` to npm.
+ * The failure path uses a recorder that exits non-zero to assert
+ * warn-don't-fail semantics in `lobu init`.
+ */
+import { afterEach, describe, expect, test } from "bun:test";
+import {
+  chmodSync,
+  mkdtempSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { initCommand, installScaffoldedProjectDeps } from "../../init.js";
+import { installProjectDeps } from "../ensure-deps-installed.js";
+
+const ORIGINAL_PATH = process.env.PATH;
+const tempDirs: string[] = [];
+
+function mkTempDir(prefix: string): string {
+  const dir = mkdtempSync(join(tmpdir(), prefix));
+  tempDirs.push(dir);
+  return dir;
+}
+
+/** Project fixture whose package-lock.json pins pickInstaller to npm. */
+function mkNpmProject(): string {
+  const root = mkTempDir("lobu-proj-");
+  writeFileSync(join(root, "package.json"), JSON.stringify({ name: "p" }));
+  writeFileSync(join(root, "package-lock.json"), "{}");
+  return root;
+}
+
+/**
+ * Stage a fake `npm` on a fresh PATH dir: a recorder script that appends
+ * argv + cwd to `logFile` and exits with `exitCode`.
+ */
+function stageFakeNpm(opts: { logFile: string; exitCode?: number }): string {
+  const binDir = mkTempDir("lobu-fake-bin-");
+  const script = [
+    "#!/bin/sh",
+    `{ echo "args=$@"; echo "cwd=$(pwd)"; } >> "${opts.logFile}"`,
+    `exit ${opts.exitCode ?? 0}`,
+    "",
+  ].join("\n");
+  const binPath = join(binDir, "npm");
+  writeFileSync(binPath, script);
+  chmodSync(binPath, 0o755);
+  return binDir;
+}
+
+afterEach(() => {
+  process.env.PATH = ORIGINAL_PATH;
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe("installProjectDeps", () => {
+  test("invokes the picked installer with --ignore-scripts in the project root", () => {
+    const root = mkNpmProject();
+    const logFile = join(mkTempDir("lobu-log-"), "install.log");
+    process.env.PATH = stageFakeNpm({ logFile });
+
+    const { installer } = installProjectDeps(root, { stdio: "pipe" });
+
+    expect(installer).toBe("npm");
+    const log = readFileSync(logFile, "utf-8");
+    expect(log).toContain("args=install --ignore-scripts --no-audit --no-fund");
+    // $(pwd) resolves macOS /var → /private/var; compare realpaths.
+    expect(log).toContain(`cwd=${realpathSync(root)}`);
+  });
+
+  test("throws when the installer exits non-zero", () => {
+    const root = mkNpmProject();
+    const logFile = join(mkTempDir("lobu-log-"), "install.log");
+    process.env.PATH = stageFakeNpm({ logFile, exitCode: 1 });
+
+    expect(() => installProjectDeps(root, { stdio: "pipe" })).toThrow();
+  });
+
+  test("throws when the installer binary is missing", () => {
+    const root = mkNpmProject();
+    process.env.PATH = mkTempDir("lobu-empty-bin-"); // no npm here
+
+    expect(() => installProjectDeps(root, { stdio: "pipe" })).toThrow();
+  });
+});
+
+describe("installScaffoldedProjectDeps (lobu init wiring)", () => {
+  test("returns null on success", () => {
+    const root = mkNpmProject();
+    const logFile = join(mkTempDir("lobu-log-"), "install.log");
+    process.env.PATH = stageFakeNpm({ logFile });
+
+    expect(installScaffoldedProjectDeps(root)).toBeNull();
+    expect(readFileSync(logFile, "utf-8")).toContain(
+      "args=install --ignore-scripts"
+    );
+  });
+
+  test("warns (does not throw) when the install fails", () => {
+    const root = mkNpmProject();
+    const logFile = join(mkTempDir("lobu-log-"), "install.log");
+    process.env.PATH = stageFakeNpm({ logFile, exitCode: 1 });
+
+    const warning = installScaffoldedProjectDeps(root);
+    expect(warning).toContain("npm install");
+    expect(warning).toContain("bun install");
+  });
+
+  test("warns (does not throw) when the installer binary is missing", () => {
+    const root = mkNpmProject();
+    process.env.PATH = mkTempDir("lobu-empty-bin-"); // no npm here
+
+    const warning = installScaffoldedProjectDeps(root);
+    expect(warning).toContain("npm install");
+  });
+});
+
+describe("lobu init runs the dependency install", () => {
+  test("scaffold installs devDependencies into the new project", async () => {
+    // `--here` into a dir pre-seeded with package-lock.json so pickInstaller
+    // selects the fake npm recorder (see header comment for why not bun).
+    const projectDir = mkTempDir("lobu-init-cwd-");
+    writeFileSync(join(projectDir, "package-lock.json"), "{}");
+    const logFile = join(mkTempDir("lobu-log-"), "install.log");
+    process.env.PATH = stageFakeNpm({ logFile });
+
+    await initCommand(projectDir, undefined, { yes: true, here: true });
+
+    const pkg = JSON.parse(
+      readFileSync(join(projectDir, "package.json"), "utf-8")
+    );
+    expect(pkg.devDependencies["@lobu/connector-sdk"]).toBeDefined();
+    expect(pkg.devDependencies["@lobu/cli"]).toBeDefined();
+
+    const log = readFileSync(logFile, "utf-8");
+    expect(log).toContain("args=install --ignore-scripts");
+    expect(log).toContain(`cwd=${realpathSync(projectDir)}`);
+  }, 30_000);
+});

--- a/packages/cli/src/commands/_lib/ensure-deps-installed.ts
+++ b/packages/cli/src/commands/_lib/ensure-deps-installed.ts
@@ -57,7 +57,10 @@ function installIsStale(root: string): boolean {
 
 function hasOnPath(bin: string): boolean {
   try {
-    execFileSync(bin, ["--version"], { stdio: "ignore" });
+    // `env: process.env` is node's default; passed explicitly because bun
+    // otherwise resolves the binary against the STARTUP environment's PATH,
+    // ignoring runtime changes (which the tests rely on to stage fakes).
+    execFileSync(bin, ["--version"], { stdio: "ignore", env: process.env });
     return true;
   } catch {
     return false;
@@ -88,6 +91,29 @@ function pickInstaller(root: string): { cmd: string; args: string[] } {
 }
 
 /**
+ * Run the project's dependency install in `root` with the picked installer
+ * (bun if available, else npm; `--ignore-scripts` always). Throws when the
+ * install fails or the installer binary is missing — callers decide whether
+ * that's fatal (`lobu apply` compile path) or a warning (`lobu init`).
+ */
+export function installProjectDeps(
+  root: string,
+  opts: {
+    /** "inherit" streams installer output to the terminal; "pipe" keeps it quiet. */
+    stdio?: "inherit" | "pipe";
+  } = {}
+): { installer: string } {
+  const installer = pickInstaller(root);
+  // `env: process.env` — see hasOnPath for why it's passed explicitly.
+  execFileSync(installer.cmd, installer.args, {
+    cwd: root,
+    stdio: opts.stdio ?? "inherit",
+    env: process.env,
+  });
+  return { installer: installer.cmd };
+}
+
+/**
  * Install the connector project's deps if missing/stale. No-op when the
  * connector has no `package.json` (no declared npm deps to bundle).
  */
@@ -107,11 +133,7 @@ export function ensureProjectDepsInstalled(
     ensuredRoots.add(root);
     return;
   }
-  const installer = pickInstaller(root);
-  log(`Installing connector dependencies in ${root} via ${installer.cmd}...`);
-  execFileSync(installer.cmd, installer.args, {
-    cwd: root,
-    stdio: "inherit",
-  });
+  log(`Installing connector dependencies in ${root}...`);
+  installProjectDeps(root, { stdio: "inherit" });
   ensuredRoots.add(root);
 }

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -21,6 +21,7 @@ import {
 import { DEFAULT_LOBU_MCP_URL } from "../internal/context.js";
 import { setLocalEnvValue } from "../internal/local-env.js";
 import { renderTemplate } from "../utils/template.js";
+import { installProjectDeps } from "./_lib/ensure-deps-installed.js";
 import { initFromOrg } from "./_lib/init-from-org/bootstrap.js";
 import { isPortFree } from "./dev.js";
 
@@ -336,6 +337,13 @@ export async function initCommand(
     // Same package.json/tsconfig the blank scaffold writes, so the bootstrapped
     // lobu.config.ts can resolve @lobu/cli/config + re-apply outside this monorepo.
     await scaffoldProjectPackaging(projectDir, projectName, cliVersion);
+    const depsSpinner = ora("Installing project dependencies...").start();
+    const depsWarning = installScaffoldedProjectDeps(projectDir);
+    if (depsWarning) {
+      depsSpinner.warn(depsWarning);
+    } else {
+      depsSpinner.succeed("Project dependencies installed");
+    }
     if (!here) {
       console.log(chalk.cyan(`\n  Next: cd ${projectName}\n`));
     }
@@ -798,6 +806,13 @@ export async function initCommand(
     await mkdir(join(projectDir, "connectors"), { recursive: true });
     await writeFile(join(projectDir, "connectors", ".gitkeep"), "");
 
+    // Install the freshly-declared devDependencies now so the runtime can
+    // resolve @lobu/connector-sdk from the project and editor types work
+    // out of the box. Warn-don't-fail (printed after the spinner settles).
+    spinner.text = "Installing project dependencies...";
+    const depsWarning = installScaffoldedProjectDeps(projectDir);
+    spinner.text = "Creating Lobu project...";
+
     await renderTemplate(
       "AGENTS.md.tmpl",
       variables,
@@ -810,6 +825,10 @@ export async function initCommand(
     );
 
     spinner.succeed("Project created successfully!");
+
+    if (depsWarning) {
+      console.log(chalk.yellow(`\n⚠ ${depsWarning}`));
+    }
 
     const gatewayUrl = `http://localhost:${gatewayPort}`;
     console.log(chalk.green("\n✓ Lobu initialized!\n"));
@@ -1077,6 +1096,30 @@ export async function generateLobuConfig(
   ];
 
   await writeFile(join(projectDir, "lobu.config.ts"), lines.join("\n"));
+}
+
+/**
+ * Install the scaffolded project's devDependencies (@lobu/cli +
+ * @lobu/connector-sdk) right after `lobu init` writes package.json. Without
+ * this, the project has no node_modules, so the first bundled-connector
+ * install fails metadata extraction with `Cannot find package
+ * '@lobu/connector-sdk'` (#1181) — and editor types don't resolve either.
+ * Warn-don't-fail: a broken/missing installer must not abort the scaffold, so
+ * the failure is returned as a warning string for the caller to print.
+ */
+export function installScaffoldedProjectDeps(
+  projectDir: string
+): string | null {
+  try {
+    installProjectDeps(projectDir, { stdio: "pipe" });
+    return null;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return (
+      `Could not install project dependencies (${message.trim()}). ` +
+      `Run \`npm install\` (or \`bun install\`) in ${projectDir} before \`lobu apply\`.`
+    );
+  }
 }
 
 async function getCliVersion(): Promise<string> {

--- a/packages/server/src/utils/__tests__/connector-metadata-resolution.test.ts
+++ b/packages/server/src/utils/__tests__/connector-metadata-resolution.test.ts
@@ -1,0 +1,119 @@
+/**
+ * Reproducer for #1181: the gateway's bundled-connector install path compiles
+ * a connector with `@lobu/connector-sdk` externalized, then extracts metadata
+ * in a subprocess from a temp dir under `process.cwd()`. When the server runs
+ * inside a user project with no node_modules (fresh `lobu init` + `lobu run`),
+ * the bundle's bare SDK import used to fail with
+ * `Cannot find package '@lobu/connector-sdk'` because resolution only walked
+ * UP from the temp dir. `extractMetadata` now stages a node_modules inside the
+ * temp dir, symlinking the runtime-provided packages as the server resolves
+ * them — so extraction succeeds regardless of the project's node_modules.
+ *
+ * Vitest (not the bun unit lane) on purpose: the extraction subprocess is a
+ * `fork()` of the test runtime, and under bun the child would auto-install
+ * the missing SDK from npm, silently masking the regression. Prod and the
+ * embedded `lobu run` both run under node, which vitest matches.
+ */
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { createConnectorCompiler } from '@lobu/connector-worker/compile';
+import { afterAll, beforeAll, describe, expect, test } from 'vitest';
+import { formatMetadataExtractionError } from '../compiler-core';
+import { extractConnectorMetadata } from '../connector-compiler';
+
+const CONNECTOR_SOURCE = `
+import { ConnectorRuntime } from '@lobu/connector-sdk';
+
+export default class MetaResolutionProbeConnector extends ConnectorRuntime {
+  definition = {
+    key: 'meta_resolution_probe',
+    name: 'Metadata Resolution Probe',
+    description: 'Synthetic connector for the #1181 extraction reproducer.',
+    version: '0.0.1',
+    authSchema: { methods: [{ type: 'none' }] },
+    feeds: {},
+  };
+
+  async sync() {
+    return { events: [], checkpoint: null, metadata: { items_found: 0, items_skipped: 0 } };
+  }
+}
+`;
+
+describe('extractConnectorMetadata in a project dir without node_modules', () => {
+  const originalCwd = process.cwd();
+  let sourceDir: string;
+  let emptyProjectDir: string;
+
+  beforeAll(() => {
+    sourceDir = mkdtempSync(join(tmpdir(), 'lobu-1181-src-'));
+    // Stands in for a fresh `lobu init` project: no node_modules anywhere up
+    // the OS tmpdir ancestry.
+    emptyProjectDir = mkdtempSync(join(tmpdir(), 'lobu-1181-proj-'));
+  });
+
+  afterAll(() => {
+    process.chdir(originalCwd);
+    rmSync(sourceDir, { recursive: true, force: true });
+    rmSync(emptyProjectDir, { recursive: true, force: true });
+  });
+
+  test('extracts metadata from an SDK-externalized bundle', async () => {
+    const connectorPath = join(sourceDir, 'meta_resolution_probe.ts');
+    writeFileSync(connectorPath, CONNECTOR_SOURCE);
+
+    // Same compiler the gateway's bundled-connector install path uses:
+    // leaves `@lobu/connector-sdk` as a bare external import in the bundle.
+    const { compileConnectorFromFile } = createConnectorCompiler();
+    const compiled = await compileConnectorFromFile(connectorPath);
+    expect(compiled).toContain('@lobu/connector-sdk');
+
+    process.chdir(emptyProjectDir);
+    try {
+      const metadata = await extractConnectorMetadata(compiled);
+      expect(metadata.key).toBe('meta_resolution_probe');
+      expect(metadata.name).toBe('Metadata Resolution Probe');
+      expect(metadata.version).toBe('0.0.1');
+    } finally {
+      process.chdir(originalCwd);
+    }
+  }, 30_000);
+});
+
+describe('formatMetadataExtractionError', () => {
+  test('appends install guidance when the connector SDK is unresolvable', () => {
+    const raw =
+      "Cannot find package '@lobu/connector-sdk' imported from /tmp/proj/.connector-meta-XXXX/source.mjs";
+    const formatted = formatMetadataExtractionError(raw);
+    expect(formatted).toContain('Metadata extraction failed:');
+    expect(formatted).toContain(raw);
+    expect(formatted).toContain('npm install');
+    expect(formatted).toContain('bun install');
+    expect(formatted).toContain('@lobu/connector-sdk');
+  });
+
+  test('handles the bare `lobu` alias specifier too', () => {
+    const formatted = formatMetadataExtractionError(
+      "Cannot find package 'lobu' imported from /tmp/x/source.mjs"
+    );
+    expect(formatted).toContain('npm install');
+  });
+
+  test('leaves unrelated errors untouched', () => {
+    const formatted = formatMetadataExtractionError(
+      'No ConnectorRuntime class found in compiled code.'
+    );
+    expect(formatted).toBe(
+      'Metadata extraction failed: No ConnectorRuntime class found in compiled code.'
+    );
+    expect(formatted).not.toContain('npm install');
+  });
+
+  test('does not misfire on other missing packages', () => {
+    const formatted = formatMetadataExtractionError(
+      "Cannot find package 'left-pad' imported from /tmp/x/source.mjs"
+    );
+    expect(formatted).not.toContain('npm install');
+  });
+});

--- a/packages/server/src/utils/compiler-core.ts
+++ b/packages/server/src/utils/compiler-core.ts
@@ -14,9 +14,11 @@
 
 import { fork } from 'node:child_process';
 import { createHash } from 'node:crypto';
-import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { existsSync, readFileSync } from 'node:fs';
+import { mkdir, mkdtemp, readFile, rm, symlink, writeFile } from 'node:fs/promises';
 import { createRequire } from 'node:module';
-import { join } from 'node:path';
+import { basename, dirname, join } from 'node:path';
+import { EXTERNAL_RUNTIME_DEPS } from '@lobu/connector-worker/compile';
 import { type BuildOptions, build } from 'esbuild';
 import logger from './logger';
 
@@ -159,6 +161,110 @@ export async function compileSource(
 }
 
 /**
+ * Bare specifiers the compiled bundle may import at load time: the connector
+ * SDK (always externalized by `createConnectorCompiler`) plus the
+ * EXTERNAL_RUNTIME_DEPS (native/binary deps esbuild leaves external).
+ */
+const RUNTIME_PROVIDED_PACKAGES: readonly string[] = [
+  '@lobu/connector-sdk',
+  ...EXTERNAL_RUNTIME_DEPS,
+];
+
+/**
+ * Resolve the on-disk package root for a bare specifier, as THIS process (the
+ * server, which always has the SDK installed) resolves it. Walks up from the
+ * resolved entry file and accepts a directory when its package.json declares
+ * the package's name (covers workspace layouts where require.resolve
+ * realpath's through a symlink to e.g. `packages/connector-sdk`, outside any
+ * node_modules) or when it sits directly under a node_modules dir (covers
+ * npm-aliased installs like `playwright` → patchright, whose package.json
+ * name differs from the specifier).
+ */
+function resolvePackageRoot(pkgName: string): string | null {
+  let entry: string;
+  try {
+    entry = require.resolve(pkgName);
+  } catch {
+    return null;
+  }
+  let dir = dirname(entry);
+  for (let i = 0; i < 30; i++) {
+    if (existsSync(join(dir, 'package.json'))) {
+      const parent = dirname(dir);
+      const underNodeModules =
+        basename(parent) === 'node_modules' ||
+        (basename(parent).startsWith('@') && basename(dirname(parent)) === 'node_modules');
+      if (underNodeModules) return dir;
+      try {
+        const pkg = JSON.parse(readFileSync(join(dir, 'package.json'), 'utf-8')) as {
+          name?: string;
+        };
+        if (pkg.name === pkgName) return dir;
+      } catch {
+        // unreadable/invalid package.json — keep walking
+      }
+    }
+    const parent = dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  return null;
+}
+
+const packageRootCache = new Map<string, string | null>();
+
+/**
+ * Stage a `node_modules` inside the extraction temp dir with symlinks to the
+ * runtime-provided packages, resolved from the server's own installation.
+ *
+ * Why: the temp dir lives under `process.cwd()`, which for an embedded
+ * `lobu run` is the USER'S project directory. The compiled bundle imports
+ * `@lobu/connector-sdk` as a bare (externalized) specifier, so Node resolves
+ * it by walking up from the temp dir — which only worked when the server's
+ * installation happened to be an ancestor. A fresh `lobu init` project has no
+ * node_modules, so the first bundled-connector install failed with
+ * `Cannot find package '@lobu/connector-sdk'` (#1181). Symlinks (not
+ * NODE_PATH) because ESM resolution ignores NODE_PATH entirely. Packages that
+ * don't resolve from the server are skipped — the subprocess then falls back
+ * to the ancestor walk exactly as before.
+ */
+async function stageRuntimeProvidedPackages(tmpDir: string): Promise<void> {
+  for (const pkgName of RUNTIME_PROVIDED_PACKAGES) {
+    if (!packageRootCache.has(pkgName)) {
+      packageRootCache.set(pkgName, resolvePackageRoot(pkgName));
+    }
+    const root = packageRootCache.get(pkgName);
+    if (!root) continue;
+    const linkPath = join(tmpDir, 'node_modules', pkgName);
+    try {
+      await mkdir(dirname(linkPath), { recursive: true });
+      // 'junction' only matters on Windows (ignored elsewhere); junctions
+      // don't need elevated privileges there.
+      await symlink(root, linkPath, 'junction');
+    } catch (err) {
+      logger.warn({ pkgName, err }, 'Failed to stage runtime-provided package for extraction');
+    }
+  }
+}
+
+/**
+ * Map a raw extraction failure to an actionable message. Safety net for
+ * environments where staging didn't cover resolution: a missing connector SDK
+ * means the project's npm deps were never installed, so say exactly that.
+ */
+export function formatMetadataExtractionError(rawError: string): string {
+  const base = `Metadata extraction failed: ${rawError}`;
+  if (/Cannot find (?:package|module) '(?:@lobu\/connector-sdk|lobu)'/.test(rawError)) {
+    return (
+      `${base}. The connector SDK could not be resolved from the project — ` +
+      'run `npm install` (or `bun install`) in the project directory to install ' +
+      '@lobu/connector-sdk, then retry.'
+    );
+  }
+  return base;
+}
+
+/**
  * Step 2: Extract metadata from compiled code via subprocess.
  * Spawns a child process to safely instantiate the class and read metadata.
  */
@@ -169,6 +275,7 @@ export async function extractMetadata<TMetadata>(
   const tmpDir = await mkdtemp(join(process.cwd(), config.tmpPrefix));
 
   try {
+    await stageRuntimeProvidedPackages(tmpDir);
     const codePath = join(tmpDir, 'source.mjs');
     const runnerPath = join(tmpDir, 'runner.mjs');
 
@@ -194,7 +301,7 @@ export async function extractMetadata<TMetadata>(
         if (msg.success) {
           resolve(msg.metadata);
         } else {
-          reject(new Error(`Metadata extraction failed: ${msg.error}`));
+          reject(new Error(formatMetadataExtractionError(String(msg.error))));
         }
       });
 
@@ -212,7 +319,7 @@ export async function extractMetadata<TMetadata>(
           reject(
             new Error(
               stderr
-                ? `Metadata extraction subprocess exited with code ${code}: ${stderr}`
+                ? formatMetadataExtractionError(`subprocess exited with code ${code}: ${stderr}`)
                 : `Metadata extraction subprocess exited with code ${code}`
             )
           );


### PR DESCRIPTION
Fixes #1181.

## Bug

After `lobu init` (writes `package.json` with `@lobu/connector-sdk` as a devDependency but runs no install), the first `lobu apply`/`lobu run` that installs a bundled connector fails. Red e2e (published CLI 11.0.0, today):

```
Install failed: Metadata extraction failed: Cannot find package '@lobu/connector-sdk' imported from /private/tmp/lobu-1181/proj/.connector-meta-zF4z6o/source.mjs
```

Root cause: the gateway's bundled-connector install path (`packages/server/src/utils/connector-compiler.ts` → `compiler-core.ts:extractMetadata`) forks a subprocess that imports the compiled bundle from a `.connector-meta-*` temp dir created under `process.cwd()` — which for embedded `lobu run` is the **user's project dir**. The compile step (`packages/connector-worker/src/compile/index.ts`, `createSdkExternalPlugin`) externalizes `@lobu/connector-sdk`, so the subprocess resolves the bare import by walking `node_modules` UP from the temp dir. A fresh project has no `node_modules`, so resolution dies; it only ever "worked" when the CLI/server installation happened to sit in an ancestor directory.

## Layers shipped (all three)

1. **Robust fix (server, `compiler-core.ts`)** — `extractMetadata` now stages a `node_modules` inside the extraction temp dir with symlinks to the runtime-provided packages (`@lobu/connector-sdk` + `EXTERNAL_RUNTIME_DEPS`) resolved from the **server's own installation** via `require.resolve`. Symlinks rather than `NODE_PATH` because ESM resolution ignores `NODE_PATH` entirely. Package-root detection handles both layouts: workspace/prod-image (where `require.resolve` realpaths through the `/app/node_modules/@lobu/connector-sdk → packages/connector-sdk` symlink, matched by package.json `name`) and npm/global installs incl. npm-aliased packages like `playwright` → patchright (matched by parent-is-`node_modules`). Unresolvable packages are skipped, preserving the previous ancestor-walk fallback, so nothing can get worse. The connector-worker self-check is untouched and stays green (no changes to that package).
2. **`lobu init` installs project deps** — right after scaffolding (both the blank scaffold and `--from-org`), reusing the `lobu apply` installer-picking logic (`bun` if on PATH else `npm`, always `--ignore-scripts`). Warn-don't-fail: a missing/broken installer prints a warning telling the user to run `npm install`, never aborts the scaffold. Also makes editor types resolve out of the box.
3. **Actionable error** — extraction failures matching `Cannot find package '@lobu/connector-sdk'` (or the `lobu` alias) now append: *"run `npm install` (or `bun install`) in the project directory to install @lobu/connector-sdk, then retry."*

## Red → green reproducer

`packages/server/src/utils/__tests__/connector-metadata-resolution.test.ts` (vitest on purpose: a bun-forked child auto-installs the missing SDK from npm and masks the regression; prod + embedded `lobu run` are node, which vitest matches). It compiles an SDK-externalized connector and extracts metadata from an empty temp cwd with no `node_modules` anywhere up the ancestry.

Red (staging call commented out):

```
× extractConnectorMetadata in a project dir without node_modules > extracts metadata from an SDK-externalized bundle
  → Metadata extraction failed: Cannot find package '@lobu/connector-sdk' imported from /private/var/folders/.../lobu-1181-proj-VY6hcF/.connector-meta-yrAAJX/source.mjs. The connector SDK could not be resolved from the project — run `npm install` (or `bun install`) in the project directory to install @lobu/connector-sdk, then retry.
```

Green (this PR): `Test Files 1 passed | Tests 5 passed`.

Init-flow e2e with the built CLI from this branch: `node packages/cli/bin/lobu.js init proj --yes` in a clean `/tmp` dir now leaves `proj/node_modules/@lobu/connector-sdk` (11.0.0) installed.

## Validation

- `tsc --noEmit` clean in `packages/server`, `packages/cli`, `packages/connector-worker`
- `bun test packages/cli` — 493 tests / 0 fail (includes the new installer/init tests: fake-`npm` PATH recorder asserting `install --ignore-scripts` runs in the project root, warn-don't-fail on failing/missing installer, and a full `initCommand --yes` drive asserting the install lands in the scaffolded project)
- `bun test packages/server/src/__tests__/unit` — 324 tests / 0 fail; `bun test packages/core` — 608 / 0 fail
- New vitest file passes standalone (`SKIP_TEST_DB_SETUP=1`); full integration lane runs in CI

Note on test mechanics: the installer tests stage a fake `npm` (not `bun`) because the bun test runner intercepts `bun` spawns and runs the real binary regardless of PATH; `execFileSync` now passes `env: process.env` explicitly (node's default) since bun otherwise resolves binaries against the startup environment's PATH.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1214"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783789456&installation_id=136316292&pr_number=1214&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1214&signature=e69ec33e9727e596fbf171d61c91ddc105b879db6247c186cdf9f1e146373df6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatic dependency installation after scaffolding new projects with `lobu init`.
  * Enhanced error messages for metadata extraction failures with clear installation guidance.

* **Bug Fixes**
  * Improved handling of missing dependencies during metadata extraction with better error formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->