### PR TITLE
fix(gateway): resolve org-shared provider keys at the egress proxy

### DIFF
--- a/packages/agent-worker/src/__tests__/error-handler.test.ts
+++ b/packages/agent-worker/src/__tests__/error-handler.test.ts
@@ -103,6 +103,15 @@ describe("classifyError", () => {
     expect(classifyError(new Error("incorrect api key provided"))).toBe(
       "PROVIDER_AUTH"
     );
+    // The secret-proxy's every-tier-missed 401 (live red-test LOBU-BACKEND-W
+    // landed as `unclassified` and dodged the PROVIDER_* alert).
+    expect(
+      classifyError(
+        new Error(
+          "401 No provider credentials configured. End-user provider setup is not available in chat yet."
+        )
+      )
+    ).toBe("PROVIDER_AUTH");
   });
 
   test("recognizes unknown-model failures", () => {

--- a/packages/agent-worker/src/core/error-handler.ts
+++ b/packages/agent-worker/src/core/error-handler.ts
@@ -59,7 +59,9 @@ export function classifyError(error: unknown): string | undefined {
   // (LOBU-BACKEND-W) landed as `unclassified` because the auth-hint regex
   // doesn't cover this shape — and an unclassified event dodges the
   // PROVIDER_* Sentry alert.
-  if (/no\s+(provider\s+)?credentials\s+configured|no_credentials/i.test(message))
+  if (
+    /no\s+(provider\s+)?credentials\s+configured|no_credentials/i.test(message)
+  )
     return "PROVIDER_AUTH";
   // `worker.ts` throws "Model \"<id>\" not found for provider ..." and pi-ai /
   // upstream surface "<x> is not a valid model"/"unknown model"/"model ... not found".

--- a/packages/agent-worker/src/core/error-handler.ts
+++ b/packages/agent-worker/src/core/error-handler.ts
@@ -54,6 +54,13 @@ export function classifyError(error: unknown): string | undefined {
   // classification matches the same auth-failure strings the worker already
   // detects elsewhere.
   if (getProviderAuthHintFromError(message)) return "PROVIDER_AUTH";
+  // The gateway secret-proxy 401s with "No provider credentials configured"
+  // (code no_credentials) when every credential tier misses. The live red-test
+  // (LOBU-BACKEND-W) landed as `unclassified` because the auth-hint regex
+  // doesn't cover this shape — and an unclassified event dodges the
+  // PROVIDER_* Sentry alert.
+  if (/no\s+(provider\s+)?credentials\s+configured|no_credentials/i.test(message))
+    return "PROVIDER_AUTH";
   // `worker.ts` throws "Model \"<id>\" not found for provider ..." and pi-ai /
   // upstream surface "<x> is not a valid model"/"unknown model"/"model ... not found".
   if (/not a valid model|unknown model|model .* not found/i.test(message))

--- a/packages/server/src/gateway/__tests__/secret-proxy.test.ts
+++ b/packages/server/src/gateway/__tests__/secret-proxy.test.ts
@@ -4,6 +4,7 @@ import {
   __resetPlaceholderCacheForTests,
   generatePlaceholder,
   lookupPlaceholderMapping,
+  resolveProviderCredential,
   SecretProxy,
   type SecretMapping,
   storeSecretMapping,
@@ -246,5 +247,75 @@ describe("SecretProxy user-scoped provider routing", () => {
     } finally {
       globalThis.fetch = originalFetch;
     }
+  });
+});
+
+describe("resolveProviderCredential (egress resolution chain)", () => {
+  const neverDb = async (): Promise<string | null> => {
+    throw new Error("DB lookup must not run for this tier");
+  };
+
+  test("tier 1: profile credential wins without touching org or system tiers", async () => {
+    const credential = await resolveProviderCredential({
+      profileCredential: "profile-key",
+      providerId: "openai",
+      organizationId: "org-a",
+      readOrgSharedKey: neverDb,
+      systemKeyResolver: () => {
+        throw new Error("system tier must not run");
+      },
+    });
+    expect(credential).toBe("profile-key");
+  });
+
+  test("tier 2: org-shared apply-provisioned key resolves when no profile exists (LOBU-BACKEND-W regression)", async () => {
+    const calls: Array<[string, string]> = [];
+    const credential = await resolveProviderCredential({
+      profileCredential: null,
+      providerId: "openai",
+      organizationId: "org-a",
+      readOrgSharedKey: async (providerId, organizationId) => {
+        calls.push([providerId, organizationId]);
+        return "org-shared-key";
+      },
+      systemKeyResolver: () => {
+        throw new Error("system tier must not run when org key exists");
+      },
+    });
+    expect(credential).toBe("org-shared-key");
+    expect(calls).toEqual([["openai", "org-a"]]);
+  });
+
+  test("tier 2 is skipped without an organizationId (no unscoped reads)", async () => {
+    const credential = await resolveProviderCredential({
+      profileCredential: null,
+      providerId: "openai",
+      organizationId: undefined,
+      readOrgSharedKey: neverDb,
+      systemKeyResolver: () => "system-key",
+    });
+    expect(credential).toBe("system-key");
+  });
+
+  test("tier 3: system key resolves when profile and org tiers miss", async () => {
+    const credential = await resolveProviderCredential({
+      profileCredential: null,
+      providerId: "openai",
+      organizationId: "org-a",
+      readOrgSharedKey: async () => null,
+      systemKeyResolver: () => "system-key",
+    });
+    expect(credential).toBe("system-key");
+  });
+
+  test("null when every tier misses (handler 401s with no_credentials)", async () => {
+    const credential = await resolveProviderCredential({
+      profileCredential: null,
+      providerId: "openai",
+      organizationId: "org-a",
+      readOrgSharedKey: async () => null,
+      systemKeyResolver: undefined,
+    });
+    expect(credential).toBeNull();
   });
 });

--- a/packages/server/src/gateway/auth/base-provider-module.ts
+++ b/packages/server/src/gateway/auth/base-provider-module.ts
@@ -1,8 +1,7 @@
-import { createLogger, decrypt } from "@lobu/core";
+import { createLogger } from "@lobu/core";
 import { Hono } from "hono";
-import { getDb } from "../../db/client.js";
 import { tryGetOrgId } from "../../lobu/stores/org-context.js";
-import { providerOrgSecretName } from "../../lobu/stores/provider-secrets.js";
+import { readOrgSharedProviderApiKey } from "../../lobu/stores/provider-secrets.js";
 import type { ProviderCredentialContext } from "../embedded.js";
 import {
   BaseModule,
@@ -15,14 +14,9 @@ import type { AuthProfilesManager } from "./settings/auth-profiles-manager.js";
 const logger = createLogger("base-provider-module");
 
 /**
- * Look up the org-shared API key for this provider. Used as the second-tier
- * fallback after per-user `auth_profiles` and before deployment-wide
- * `process.env`. Returns null when no row exists or the ciphertext fails to
- * decrypt — every miss path is silent so the caller can keep walking the
- * resolution chain.
- *
- * The lookup is keyed strictly on `(organization_id, name)` against
- * `agent_secrets`. The orgId comes from one of two sources, in order:
+ * Look up the org-shared API key for this provider (tier 2 of the resolution
+ * chain — see provider-secrets.ts, which owns the actual lookup). The orgId
+ * comes from one of two sources, in order:
  * 1. `context.organizationId` — set by the worker-spawn code path that
  *    threads the org id through `ProviderCredentialContext`.
  * 2. `tryGetOrgId()` — the AsyncLocalStorage-backed org context set by
@@ -38,25 +32,7 @@ async function readOrgSharedProviderKey(
 ): Promise<string | null> {
   const orgId = context?.organizationId ?? tryGetOrgId();
   if (!orgId) return null;
-  const sql = getDb();
-  const rows = (await sql`
-    SELECT ciphertext
-    FROM agent_secrets
-    WHERE organization_id = ${orgId}
-      AND name = ${providerOrgSecretName(providerId)}
-      AND (expires_at IS NULL OR expires_at > now())
-    LIMIT 1
-  `) as Array<{ ciphertext: string }>;
-  const ciphertext = rows[0]?.ciphertext;
-  if (!ciphertext) return null;
-  try {
-    return decrypt(ciphertext);
-  } catch (error) {
-    logger.warn(
-      `Failed to decrypt org-shared key for provider ${providerId}: ${error instanceof Error ? error.message : String(error)}`
-    );
-    return null;
-  }
+  return readOrgSharedProviderApiKey(providerId, orgId);
 }
 
 interface BaseProviderConfig {

--- a/packages/server/src/gateway/proxy/secret-proxy.ts
+++ b/packages/server/src/gateway/proxy/secret-proxy.ts
@@ -6,6 +6,7 @@ import type { AuthProfilesManager } from "../auth/settings/auth-profiles-manager
 import type { ProviderCredentialContext } from "../embedded.js";
 import type { ProviderUpstreamConfig } from "../modules/module-system.js";
 import { orgContext } from "../../lobu/stores/org-context.js";
+import { readOrgSharedProviderApiKey } from "../../lobu/stores/provider-secrets.js";
 import type { SecretStore } from "../secrets/index.js";
 import { getClientIp } from "../utils/rate-limiter.js";
 
@@ -739,31 +740,30 @@ export class SecretProxy {
               })
             )
           : profile?.credential;
-        if (credential) {
-          headers.authorization = `Bearer ${credential}`;
-        } else if (this.systemKeyResolver) {
-          const systemKey = this.systemKeyResolver(providerId);
-          if (systemKey) {
-            headers.authorization = `Bearer ${systemKey}`;
-          } else {
-            logger.warn(
-              `No auth profile or system key for agent ${urlAgentId}, provider ${providerId}`
-            );
-            return c.json(
-              {
-                error: {
-                  message:
-                    "No provider credentials configured. End-user provider setup is not available in chat yet. Ask an admin to connect a provider for the base agent.",
-                  type: "authentication_error",
-                  code: "no_credentials",
-                },
-              },
-              401
-            );
-          }
+        // Walk the documented resolution chain (provider-secrets.ts):
+        //   1. per-user auth profile (above)
+        //   2. org-shared `agent_secrets` key written by `lobu apply`
+        //   3. deployment-wide system key (env)
+        // Run dispatch admits the run when ANY tier matches (`hasCredentials`
+        // in base-provider-module.ts walks the same chain), so skipping tier 2
+        // here meant an apply-provisioned org dispatched its agent only to
+        // 401 at the first provider call — found live by the Sentry red-test
+        // (LOBU-BACKEND-W).
+        let resolvedCredential: string | null = credential ?? null;
+        if (!resolvedCredential && expectedOrganizationId) {
+          resolvedCredential = await readOrgSharedProviderApiKey(
+            providerId,
+            expectedOrganizationId
+          );
+        }
+        if (!resolvedCredential && this.systemKeyResolver) {
+          resolvedCredential = this.systemKeyResolver(providerId) ?? null;
+        }
+        if (resolvedCredential) {
+          headers.authorization = `Bearer ${resolvedCredential}`;
         } else {
           logger.warn(
-            `No auth profile for agent ${urlAgentId}, provider ${providerId}`
+            `No auth profile, org-shared key, or system key for agent ${urlAgentId}, provider ${providerId}`
           );
           return c.json(
             {

--- a/packages/server/src/gateway/proxy/secret-proxy.ts
+++ b/packages/server/src/gateway/proxy/secret-proxy.ts
@@ -240,6 +240,43 @@ function safeDecodePathSegment(value: string | undefined): string | undefined {
   }
 }
 
+/**
+ * Walk the documented provider-credential resolution chain
+ * (provider-secrets.ts) at the egress proxy:
+ *   1. per-user auth profile credential (resolved by the caller)
+ *   2. org-shared `agent_secrets` key written by `lobu apply`
+ *   3. deployment-wide system key (env)
+ *
+ * Run dispatch admits a run when `hasSystemKey() || hasCredentials()` passes
+ * (base-provider-module.ts), and `hasCredentials` covers tiers 1–2 — so the
+ * proxy MUST resolve the same tiers. Skipping tier 2 here meant an
+ * apply-provisioned org dispatched its agent only to 401 at the first
+ * provider call — found live by the Sentry red-test (LOBU-BACKEND-W).
+ *
+ * Exported for tests; dependencies are injected so the tier ORDER is testable
+ * without a database or upstream.
+ */
+export async function resolveProviderCredential(params: {
+  profileCredential: string | null;
+  providerId: string;
+  organizationId: string | undefined;
+  readOrgSharedKey: (
+    providerId: string,
+    organizationId: string
+  ) => Promise<string | null>;
+  systemKeyResolver?: (providerId: string) => string | undefined;
+}): Promise<string | null> {
+  if (params.profileCredential) return params.profileCredential;
+  if (params.organizationId) {
+    const orgKey = await params.readOrgSharedKey(
+      params.providerId,
+      params.organizationId
+    );
+    if (orgKey) return orgKey;
+  }
+  return params.systemKeyResolver?.(params.providerId) ?? null;
+}
+
 export interface SecretMapping {
   agentId: string;
   /**
@@ -740,25 +777,13 @@ export class SecretProxy {
               })
             )
           : profile?.credential;
-        // Walk the documented resolution chain (provider-secrets.ts):
-        //   1. per-user auth profile (above)
-        //   2. org-shared `agent_secrets` key written by `lobu apply`
-        //   3. deployment-wide system key (env)
-        // Run dispatch admits the run when ANY tier matches (`hasCredentials`
-        // in base-provider-module.ts walks the same chain), so skipping tier 2
-        // here meant an apply-provisioned org dispatched its agent only to
-        // 401 at the first provider call — found live by the Sentry red-test
-        // (LOBU-BACKEND-W).
-        let resolvedCredential: string | null = credential ?? null;
-        if (!resolvedCredential && expectedOrganizationId) {
-          resolvedCredential = await readOrgSharedProviderApiKey(
-            providerId,
-            expectedOrganizationId
-          );
-        }
-        if (!resolvedCredential && this.systemKeyResolver) {
-          resolvedCredential = this.systemKeyResolver(providerId) ?? null;
-        }
+        const resolvedCredential = await resolveProviderCredential({
+          profileCredential: credential ?? null,
+          providerId,
+          organizationId: expectedOrganizationId,
+          readOrgSharedKey: readOrgSharedProviderApiKey,
+          systemKeyResolver: this.systemKeyResolver,
+        });
         if (resolvedCredential) {
           headers.authorization = `Bearer ${resolvedCredential}`;
         } else {

--- a/packages/server/src/lobu/stores/provider-secrets.ts
+++ b/packages/server/src/lobu/stores/provider-secrets.ts
@@ -13,6 +13,47 @@
  * no per-agent override exists today (the same key is used by every agent in
  * the org that calls this provider).
  */
+
+import { createLogger, decrypt } from "@lobu/core";
+import { getDb } from "../../db/client.js";
+
+const logger = createLogger("provider-secrets");
+
 export function providerOrgSecretName(providerId: string): string {
   return `provider:${providerId}:apiKey`;
+}
+
+/**
+ * Read + decrypt the org-shared API key for a provider (tier 2 of the
+ * resolution chain above). Returns null when no row exists, the row expired,
+ * or the ciphertext fails to decrypt — every miss is silent so callers keep
+ * walking the chain. Shared by the worker-spawn credential path
+ * (base-provider-module.ts) and the egress secret-proxy, which MUST agree on
+ * this tier: run dispatch checks it via `hasCredentials`, so a proxy that
+ * skips it lets an apply-provisioned org dispatch its agent only to 401 at
+ * the first provider call.
+ */
+export async function readOrgSharedProviderApiKey(
+  providerId: string,
+  organizationId: string
+): Promise<string | null> {
+  const sql = getDb();
+  const rows = (await sql`
+    SELECT ciphertext
+    FROM agent_secrets
+    WHERE organization_id = ${organizationId}
+      AND name = ${providerOrgSecretName(providerId)}
+      AND (expires_at IS NULL OR expires_at > now())
+    LIMIT 1
+  `) as Array<{ ciphertext: string }>;
+  const ciphertext = rows[0]?.ciphertext;
+  if (!ciphertext) return null;
+  try {
+    return decrypt(ciphertext);
+  } catch (error) {
+    logger.warn(
+      `Failed to decrypt org-shared key for provider ${providerId}: ${error instanceof Error ? error.message : String(error)}`
+    );
+    return null;
+  }
 }


### PR DESCRIPTION
## Why

Found live by the Sentry red-test (LOBU-BACKEND-W): an org provisioned entirely via the landing-page path (`lobu init` → `lobu apply` with a provider key) dispatches its agent fine, then the very first provider call 401s with "No provider credentials configured".

Root cause: the documented credential chain (provider-secrets.ts) is per-user `auth_profiles` → org-shared `agent_secrets` (`provider:<id>:apiKey`, what `lobu apply` writes) → deployment env. Run dispatch admits the run via `hasSystemKey() || hasCredentials()`, and `hasCredentials` walks tiers 1–2 — but the egress secret-proxy's URL-based resolution only checked tier 1 (`getBestProfile`) and tier 3 (`systemKeyResolver`), skipping tier 2 entirely. The same gap was patched at the dispatch layer once before (see the existing comment in `hasCredentials`); the proxy layer never got it.

## What

- `provider-secrets.ts` now owns the org-shared lookup (`readOrgSharedProviderApiKey`); `base-provider-module.ts` delegates to it (dedupe).
- `secret-proxy.ts`: extracted `resolveProviderCredential` (exported, dependency-injected) walking profile → org-shared → system key, called from the handler with the already-fail-closed `expectedOrganizationId`. Misses still 401 with `no_credentials`.
- Worker `classifyError`: "No provider credentials configured" / `no_credentials` now classifies as `PROVIDER_AUTH` (the live event landed `unclassified` and dodged the PROVIDER_* Sentry alert). First regex draft was wrong — the new unit test caught it (prose has "provider" between "No" and "credentials").

## Testing

- 5 new tier-order unit tests on `resolveProviderCredential` (profile wins / org key when profile misses / no unscoped reads without an org id / system fallback / null → 401).
- New classifyError regression for the exact live message; 9/9 error-handler tests, 16/16 secret-proxy tests, 34 pre-existing proxy tests green.
- `make review BASE=origin/main`: bug_free 82, 0 bugs, 0 blockers, tests adequate (integration exit-1 was an env flake in an untouched file).
- Post-deploy live verification planned: re-run the bogus-key agent e2e — expect the run to reach OpenAI's real 401, classify `PROVIDER_AUTH`, and fire the Sentry alert email.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1215"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783803545&installation_id=136316292&pr_number=1215&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1215&signature=fb5108b3406d048349cfe753442bf21f525cf4c4c8bbbd75bfd7d1148d5045b4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for organization-level shared provider credentials with multi-tier resolution.

* **Bug Fixes**
  * Improved classification of provider authentication errors to correctly identify missing credential configurations.

* **Tests**
  * Added tests verifying credential resolution across multiple lookup tiers and error classification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->