### PR TITLE
fix(sentry): classify provider auth hints; suppress only the readiness drain 503

### DIFF
--- a/packages/agent-worker/src/__tests__/error-handler.test.ts
+++ b/packages/agent-worker/src/__tests__/error-handler.test.ts
@@ -112,6 +112,15 @@ describe("classifyError", () => {
         )
       )
     ).toBe("PROVIDER_AUTH");
+    // The admin-facing auth hint that session-runner substitutes for the raw
+    // provider 401 before the worker's capture sees it.
+    expect(
+      classifyError(
+        new Error(
+          "To use gpt-4o, an admin needs to connect openai on the base agent. Ask an admin to configure openai and then try again."
+        )
+      )
+    ).toBe("PROVIDER_AUTH");
   });
 
   test("recognizes unknown-model failures", () => {

--- a/packages/agent-worker/src/core/error-handler.ts
+++ b/packages/agent-worker/src/core/error-handler.ts
@@ -63,6 +63,13 @@ export function classifyError(error: unknown): string | undefined {
     /no\s+(provider\s+)?credentials\s+configured|no_credentials/i.test(message)
   )
     return "PROVIDER_AUTH";
+  // session-runner replaces a raw provider 401 with the admin-facing hint
+  // BEFORE the worker's failure branch captures it (maybeBuildAuthHintMessage),
+  // so the captured message is the hint, not the original "Incorrect API key".
+  // Classify the hint shape too or auth failures stay `unclassified` and dodge
+  // the PROVIDER_* Sentry alert (second live red-test round, LOBU-BACKEND-W).
+  if (/needs to connect .+ on the base agent/i.test(message))
+    return "PROVIDER_AUTH";
   // `worker.ts` throws "Model \"<id>\" not found for provider ..." and pi-ai /
   // upstream surface "<x> is not a valid model"/"unknown model"/"model ... not found".
   if (/not a valid model|unknown model|model .* not found/i.test(message))

--- a/packages/server/src/__tests__/server-lifecycle.test.ts
+++ b/packages/server/src/__tests__/server-lifecycle.test.ts
@@ -227,6 +227,33 @@ describe("buildWrapperApp", () => {
 		expect(opts.tags.source).toBe("http_response");
 	});
 
+	it("suppresses ONLY the draining readiness 503; other health 5xx still report", async () => {
+		const { buildWrapperApp } = await import("../server-lifecycle");
+		const sentry = await import("@sentry/node");
+		const { Hono } = await import("hono");
+		const captureMessage = sentry.captureMessage as ReturnType<typeof vi.fn>;
+
+		// Expected deploy-drain shape → suppressed (was LOBU-BACKEND-X noise).
+		const draining = buildWrapperApp({} as never, new Hono());
+		draining.get("/health/ready", (c) =>
+			c.json({ status: "draining", service: "lobu-api" }, 503),
+		);
+		captureMessage.mockClear();
+		const drainRes = await draining.request("/health/ready");
+		expect(drainRes.status).toBe(503);
+		expect(captureMessage).not.toHaveBeenCalled();
+
+		// Same endpoint, non-draining body (e.g. DB unreachable) → still reports.
+		const broken = buildWrapperApp({} as never, new Hono());
+		broken.get("/health/ready", (c) =>
+			c.json({ status: "error", error: "db unreachable" }, 503),
+		);
+		captureMessage.mockClear();
+		const brokenRes = await broken.request("/health/ready");
+		expect(brokenRes.status).toBe(503);
+		expect(captureMessage).toHaveBeenCalled();
+	});
+
 	it("routes thrown exceptions through onError + Sentry.captureException", async () => {
 		const { buildWrapperApp } = await import("../server-lifecycle");
 		const sentry = await import("@sentry/node");
@@ -331,7 +358,9 @@ describe("createServerLifecycle (source-level contract)", () => {
 		const gateway = indexOf('safe("stopLobuGateway"');
 		const db = indexOf('safe("closeDbSingleton"');
 		const extra = indexOf("safe(`extraTeardown[");
-		const close = indexOf("httpServer.close();");
+		// #1191 wrapped the close in the same safe() step pattern as the rest of
+		// teardown; match the stable step label, not the raw call.
+		const close = indexOf('safe("httpServer.close"');
 
 		expect(worker).toBeLessThan(vite);
 		expect(vite).toBeLessThan(reaper);

--- a/packages/server/src/server-lifecycle.ts
+++ b/packages/server/src/server-lifecycle.ts
@@ -194,18 +194,27 @@ export function buildWrapperApp(
 	// so this is safe to wire unconditionally.
 	wrapper.use("*", async (c, next) => {
 		await next();
-		// Readiness probes intentionally 503 during the graceful-shutdown drain
-		// (SHUTDOWN_READINESS_DRAIN_MS) — capturing them turns every deploy
-		// rollover into a Sentry issue (LOBU-BACKEND-X).
-		if (c.req.path === "/health" || c.req.path === "/health/ready") {
-			return;
-		}
 		if (c.res.status >= 500 && !isSentryReported(c)) {
 			let body: unknown = null;
 			try {
 				body = await c.res.clone().json();
 			} catch {
 				// response wasn't JSON; ignore
+			}
+			// Readiness probes intentionally 503 `{status:"draining"}` during the
+			// graceful-shutdown drain (SHUTDOWN_READINESS_DRAIN_MS) — capturing
+			// that turns every deploy rollover into a Sentry issue
+			// (LOBU-BACKEND-X). Skip ONLY that exact shape: a health 5xx with any
+			// other body (DB unreachable, crash) is a real incident and must
+			// still report.
+			if (
+				c.req.path.startsWith("/health") &&
+				c.res.status === 503 &&
+				body !== null &&
+				typeof body === "object" &&
+				(body as { status?: unknown }).status === "draining"
+			) {
+				return;
 			}
 			const message =
 				(body &&

--- a/packages/server/src/server-lifecycle.ts
+++ b/packages/server/src/server-lifecycle.ts
@@ -194,6 +194,12 @@ export function buildWrapperApp(
 	// so this is safe to wire unconditionally.
 	wrapper.use("*", async (c, next) => {
 		await next();
+		// Readiness probes intentionally 503 during the graceful-shutdown drain
+		// (SHUTDOWN_READINESS_DRAIN_MS) — capturing them turns every deploy
+		// rollover into a Sentry issue (LOBU-BACKEND-X).
+		if (c.req.path === "/health" || c.req.path === "/health/ready") {
+			return;
+		}
 		if (c.res.status >= 500 && !isSentryReported(c)) {
 			let body: unknown = null;
 			try {

--- a/packages/server/src/server-lifecycle.ts
+++ b/packages/server/src/server-lifecycle.ts
@@ -208,7 +208,7 @@ export function buildWrapperApp(
 			// other body (DB unreachable, crash) is a real incident and must
 			// still report.
 			if (
-				c.req.path.startsWith("/health") &&
+				c.req.path === "/health/ready" &&
 				c.res.status === 503 &&
 				body !== null &&
 				typeof body === "object" &&


### PR DESCRIPTION
## Why

Round 2 of the live provider-failure red-test (after #1215) showed two remaining gaps:

1. The run now reaches OpenAI and fails authentically, but `session-runner` swaps the raw 401 for the admin-facing hint ("To use gpt-4o, an admin needs to connect openai…") **before** the worker's capture sees it — so the event lands `classification: unclassified` and dodges the PROVIDER_* Sentry alert.
2. The #1191 graceful-shutdown drain makes `/health/ready` return 503 `{status:"draining"}` during every deploy rollover, and the 5xx post-response middleware faithfully captures it (LOBU-BACKEND-X) — alert-feed noise on every deploy.

## What

- `classifyError`: the auth-hint shape ("needs to connect <provider> on the base agent") now classifies as `PROVIDER_AUTH`.
- 5xx middleware: skip capture **only** for `/health/ready` + 503 + `{status:"draining"}` (the exact deploy-drain shape). Any other health 5xx — DB unreachable, crash — still reports. (First draft skipped all health paths; review correctly tightened it.)
- Repairs a stale source-contract needle in `server-lifecycle.test.ts` (`httpServer.close();` → the `safe("httpServer.close"` step label introduced by #1191) — this test has been failing on main.

## Testing

- New two-sided suppression test: draining 503 → no capture; non-draining `/health/ready` 503 → captured. Full server-lifecycle vitest suite 20/20 (was 19/20 on main due to the stale needle).
- New classifyError regression for the hint shape; error-handler suite 9/9.
- Strict tsc clean (server + agent-worker). `make review`: 0 bugs, 0 blockers across both rounds.
- Final live verification after deploy: re-run the bogus-key agent → expect `classification: PROVIDER_AUTH` and the "Provider/model failure (worker)" alert email.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1218"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783807430&installation_id=136316292&pr_number=1218&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1218&signature=87826061c0c448943f178cde8034d0fe0023fe8fadf8894c851f0788fe5716a2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authentication error classification to recognize additional failure patterns and route alerts appropriately.
  * Fixed Sentry alerts being incorrectly reported for expected health check drain responses, reducing monitoring noise.

* **Tests**
  * Added test coverage for authentication error handling and health check monitoring behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->