### PR TITLE
fix(tests): raise live-provider max_tokens so reasoning-default models aren't starved

### DIFF
--- a/packages/server/src/__tests__/live-providers/provider-smoke.test.ts
+++ b/packages/server/src/__tests__/live-providers/provider-smoke.test.ts
@@ -183,7 +183,10 @@ for (const { id, provider } of flattened) {
 							content: "Reply with exactly the single word: pong",
 						},
 					],
-					max_tokens: 16,
+					// Generous cap, not a target: reasoning-default models (gemini-2.5-*)
+					// spend "thinking" tokens from this budget before emitting text — at
+					// 16 they hit finish_reason=length with zero visible output.
+					max_tokens: 1024,
 					stream: false,
 				}),
 			});
@@ -232,7 +235,7 @@ for (const { id, provider } of flattened) {
 						},
 					],
 					tool_choice: "auto",
-					max_tokens: 64,
+					max_tokens: 1024,
 					stream: false,
 				}),
 			});


### PR DESCRIPTION
## Problem
`gemini-2.5-flash` (Gemini's default model) thinks by default, and thinking tokens draw from the OpenAI-compat `max_tokens` budget. The chat smoke test caps at 16, so the model burns the whole budget on reasoning and returns `finish_reason: "length"` with zero visible text — the Gemini keyed row can never pass, regardless of key. This was masked until now because the previous `GEMINI_API_KEY` 429'd (spend cap) before reaching this assertion.

## Fix
Raise `max_tokens` 16→1024 (chat) and 64→1024 (tool-call). It's a ceiling, not a target — non-reasoning providers still answer "pong" in a couple of tokens, so cost is unchanged for them.

## Red→green reproducer (live, fresh free-tier key)
- main + valid key: `(fail) live: gemini (Gemini) > answers a chat completion` — `finish_reason: "length"`, `completion_tokens: 0`
- this branch + same key: `3 pass / 0 fail` (models + chat + tool-call round-trip)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1219"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783809188&installation_id=136316292&pr_number=1219&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1219&signature=8929a9dcb1339a9ddb69a7a07fdf117ed0153ce1f15dace3a561735f29adb9fa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->