### PR TITLE
fix(server): truthful vitest exit codes, fail-closed CI gate, and the 8 red integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -347,7 +347,15 @@ jobs:
 
       - name: server integration suite (vitest under Node)
         working-directory: packages/server
-        run: node ../../node_modules/.bin/vitest run --reporter=default
+        # Fail-closed double gate (#1216): vitest's exit code alone went green
+        # on a run with 8 failed tests (a `beforeExit` hook from a transitive
+        # dep force-exited 0 after the summary). The JSON report is written by
+        # the reporter while vitest still owns the process, so a second step
+        # independently asserts zero failures — and a missing/unparseable
+        # report (crashed run) also fails.
+        run: |
+          node ../../node_modules/.bin/vitest run --reporter=default --reporter=json --outputFile.json="$RUNNER_TEMP/vitest-report.json"
+          node ../../scripts/assert-vitest-report-clean.mjs "$RUNNER_TEMP/vitest-report.json"
 
       - name: server gateway suite (bun:test, needs Postgres)
         # The gateway code that used to live in packages/gateway is now under

--- a/packages/cli/src/__tests__/cli-ux.test.ts
+++ b/packages/cli/src/__tests__/cli-ux.test.ts
@@ -79,6 +79,10 @@ describe("project-link round-trip", () => {
 });
 
 describe("lobu init --yes", () => {
+  // initCommand runs a real `bun install --ignore-scripts` in the scaffold
+  // (the #1181 fix), so these tests are network-bound — bun's 5s default
+  // timeout flakes on slow CI runners (observed 5.7s).
+  const INIT_TIMEOUT = 120_000;
   let cwd: string;
   beforeEach(() => {
     cwd = mkdtempSync(join(tmpdir(), "lobu-init-yes-"));
@@ -87,67 +91,89 @@ describe("lobu init --yes", () => {
     rmSync(cwd, { recursive: true, force: true });
   });
 
-  test("scaffolds a non-interactive project with defaults", async () => {
-    await initCommand(cwd, "demo", { yes: true });
-    const proj = join(cwd, "demo");
-    expect(existsSync(join(proj, "lobu.config.ts"))).toBe(true);
-    expect(existsSync(join(proj, ".env"))).toBe(true);
-    expect(existsSync(join(proj, "agents", "demo", "IDENTITY.md"))).toBe(true);
-    const env = readFileSync(join(proj, ".env"), "utf-8");
-    expect(env.includes("SENTRY_DSN=")).toBe(false);
-    // The generated lobu.config.ts imports @lobu/cli/config, so the scaffolded
-    // package.json MUST declare @lobu/cli — else `lobu apply` (jiti) can't
-    // resolve it outside this monorepo. Regression guard for that blocker.
-    const pkg = JSON.parse(readFileSync(join(proj, "package.json"), "utf-8"));
-    expect(pkg.devDependencies["@lobu/cli"]).toBeDefined();
-    expect(pkg.devDependencies["@lobu/connector-sdk"]).toBeDefined();
-    const tsconfig = JSON.parse(
-      readFileSync(join(proj, "tsconfig.json"), "utf-8")
-    );
-    expect(tsconfig.include).toContain("lobu.config.ts");
-  });
+  test(
+    "scaffolds a non-interactive project with defaults",
+    async () => {
+      await initCommand(cwd, "demo", { yes: true });
+      const proj = join(cwd, "demo");
+      expect(existsSync(join(proj, "lobu.config.ts"))).toBe(true);
+      expect(existsSync(join(proj, ".env"))).toBe(true);
+      expect(existsSync(join(proj, "agents", "demo", "IDENTITY.md"))).toBe(
+        true
+      );
+      const env = readFileSync(join(proj, ".env"), "utf-8");
+      expect(env.includes("SENTRY_DSN=")).toBe(false);
+      // The generated lobu.config.ts imports @lobu/cli/config, so the scaffolded
+      // package.json MUST declare @lobu/cli — else `lobu apply` (jiti) can't
+      // resolve it outside this monorepo. Regression guard for that blocker.
+      const pkg = JSON.parse(readFileSync(join(proj, "package.json"), "utf-8"));
+      expect(pkg.devDependencies["@lobu/cli"]).toBeDefined();
+      expect(pkg.devDependencies["@lobu/connector-sdk"]).toBeDefined();
+      const tsconfig = JSON.parse(
+        readFileSync(join(proj, "tsconfig.json"), "utf-8")
+      );
+      expect(tsconfig.include).toContain("lobu.config.ts");
+    },
+    INIT_TIMEOUT
+  );
 
-  test("scaffolded lobu.config.ts loads into desired state", async () => {
-    // jiti resolves the externalized `@lobu/cli/config` import relative to the config
-    // file, so scaffold inside the package tree (where node_modules is
-    // reachable), not the tmpdir() used by the other init tests.
-    const fixtureRoot = mkdtempSync(join(import.meta.dir, "init-load-"));
-    try {
-      await initCommand(fixtureRoot, "loadable", { yes: true });
-      const proj = join(fixtureRoot, "loadable");
-      const { state } = await loadDesiredStateFromConfig({ cwd: proj });
-      expect(state.agents).toHaveLength(1);
-      expect(state.agents[0]?.metadata.agentId).toBe("loadable");
-      // SOUL/IDENTITY/USER.md from the agent dir are merged into settings.
-      expect(state.agents[0]?.settings.identityMd).toContain("loadable");
-    } finally {
-      rmSync(fixtureRoot, { recursive: true, force: true });
-    }
-  });
+  test(
+    "scaffolded lobu.config.ts loads into desired state",
+    async () => {
+      // jiti resolves the externalized `@lobu/cli/config` import relative to the config
+      // file, so scaffold inside the package tree (where node_modules is
+      // reachable), not the tmpdir() used by the other init tests.
+      const fixtureRoot = mkdtempSync(join(import.meta.dir, "init-load-"));
+      try {
+        await initCommand(fixtureRoot, "loadable", { yes: true });
+        const proj = join(fixtureRoot, "loadable");
+        const { state } = await loadDesiredStateFromConfig({ cwd: proj });
+        expect(state.agents).toHaveLength(1);
+        expect(state.agents[0]?.metadata.agentId).toBe("loadable");
+        // SOUL/IDENTITY/USER.md from the agent dir are merged into settings.
+        expect(state.agents[0]?.settings.identityMd).toContain("loadable");
+      } finally {
+        rmSync(fixtureRoot, { recursive: true, force: true });
+      }
+    },
+    INIT_TIMEOUT
+  );
 
-  test("--here scaffolds into the current directory", async () => {
-    await initCommand(cwd, undefined, { yes: true, here: true });
-    expect(existsSync(join(cwd, "lobu.config.ts"))).toBe(true);
-    expect(existsSync(join(cwd, "agents"))).toBe(true);
-  });
+  test(
+    "--here scaffolds into the current directory",
+    async () => {
+      await initCommand(cwd, undefined, { yes: true, here: true });
+      expect(existsSync(join(cwd, "lobu.config.ts"))).toBe(true);
+      expect(existsSync(join(cwd, "agents"))).toBe(true);
+    },
+    INIT_TIMEOUT
+  );
 
-  test("--sentry writes SENTRY_DSN", async () => {
-    await initCommand(cwd, "sentry-on", { yes: true, sentry: true });
-    const env = readFileSync(join(cwd, "sentry-on", ".env"), "utf-8");
-    expect(env).toMatch(/SENTRY_DSN=/);
-  });
+  test(
+    "--sentry writes SENTRY_DSN",
+    async () => {
+      await initCommand(cwd, "sentry-on", { yes: true, sentry: true });
+      const env = readFileSync(join(cwd, "sentry-on", ".env"), "utf-8");
+      expect(env).toMatch(/SENTRY_DSN=/);
+    },
+    INIT_TIMEOUT
+  );
 
-  test("--slack-preview writes agent preview config", async () => {
-    await initCommand(cwd, "preview-on", { yes: true, slackPreview: true });
-    const config = readFileSync(
-      join(cwd, "preview-on", "lobu.config.ts"),
-      "utf-8"
-    );
-    expect(config).toContain("preview:");
-    expect(config).toContain("slack:");
-    expect(config).toContain("enabled: true");
-    expect(config).toContain('surfaces: ["dm"]');
-  });
+  test(
+    "--slack-preview writes agent preview config",
+    async () => {
+      await initCommand(cwd, "preview-on", { yes: true, slackPreview: true });
+      const config = readFileSync(
+        join(cwd, "preview-on", "lobu.config.ts"),
+        "utf-8"
+      );
+      expect(config).toContain("preview:");
+      expect(config).toContain("slack:");
+      expect(config).toContain("enabled: true");
+      expect(config).toContain('surfaces: ["dm"]');
+    },
+    INIT_TIMEOUT
+  );
 
   test("--provider with bad id throws before writing files", async () => {
     await expect(

--- a/packages/server/src/__tests__/integration/auth/anonymous-device-registration.test.ts
+++ b/packages/server/src/__tests__/integration/auth/anonymous-device-registration.test.ts
@@ -6,7 +6,8 @@
  * fix (worker-api.ts) re-anchors such a poll to the user that already owns the
  * posted worker_id in a non-cloud install, so the device_workers capability
  * registration (which drives connector wiring) still happens. Cloud
- * (LOBU_CLOUD_MODE) must stay strict.
+ * (LOBU_CLOUD_MODE) must stay strict: since the #1192 security audit the
+ * middleware fails anonymous workers-API calls closed with a 401 there.
  */
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
@@ -81,8 +82,10 @@ describe('anonymous device-worker registration (local/non-cloud)', () => {
     const { workerId } = await seedDeviceOwner({ caps: {}, appVersion: '8.0.0' });
     process.env.LOBU_CLOUD_MODE = '1';
 
+    // #1192: anonymous workers-API access in cloud mode is rejected outright
+    // (fail-closed 401), so the poll never reaches registration at all.
     const res = await post('/api/workers/poll', { body: pollBody(workerId) });
-    expect(res.status).toBe(200);
+    expect(res.status).toBe(401);
 
     const dev = await readDevice(workerId);
     expect(dev?.caps).not.toContain('screentime');

--- a/packages/server/src/__tests__/integration/connectors/postgres-sync-cloud-gate.test.ts
+++ b/packages/server/src/__tests__/integration/connectors/postgres-sync-cloud-gate.test.ts
@@ -29,8 +29,8 @@ async function setupPostgresFeed(): Promise<{ feedId: number; connId: number; or
     version: CONNECTOR_VERSION,
     organization_id: org.id,
   });
-  // A non-device-pinned, active connection with required_capability NULL — so an
-  // anonymous worker poll (branch 1A) can claim its run and reach the gate.
+  // A non-device-pinned, active connection with required_capability NULL — so a
+  // fleet worker poll (branch 1A) can claim its run and reach the gate.
   const conn = await createTestConnection({
     organization_id: org.id,
     connector_key: 'postgres',
@@ -111,8 +111,13 @@ describe('pollWorkerJob cloud gate (postgres) — execution-time', () => {
 
     process.env.LOBU_CLOUD_MODE = '1';
     try {
+      // #1192 fails anonymous workers-API calls closed (401) under cloud mode,
+      // so authenticate as a trusted fleet worker — the execution-time gate
+      // inside pollWorkerJob is what this test is about.
       const res = await post('/api/workers/poll', {
         body: { worker_id: 'cloud-gate-worker', capabilities: {} },
+        token: 'test-fleet-token',
+        env: { WORKER_API_TOKEN: 'test-fleet-token' },
       });
       expect(res.status).toBe(200);
       const body = (await res.json()) as {

--- a/packages/server/src/__tests__/integration/events/get-content-visibility.test.ts
+++ b/packages/server/src/__tests__/integration/events/get-content-visibility.test.ts
@@ -34,6 +34,10 @@ import { beforeAll, describe, expect, it } from 'vitest';
 import { getDb } from '../../../db/client';
 import { getContent } from '../../../tools/get_content';
 import type { ToolContext } from '../../../tools/registry';
+import {
+  __resetPublicOriginCachesForTests,
+  __setLocalFrontendForTests,
+} from '../../../utils/public-origin';
 import { initWorkspaceProvider } from '../../../workspace';
 import { cleanupTestDatabase, getTestDb } from '../../setup/test-db';
 import {
@@ -338,20 +342,31 @@ describe('getContent > response shape (view_url present, stats opt-in)', () => {
   });
 
   it('empty entity returns content=[], total=0, view_url populated, no classification_stats by default', async () => {
-    const result = await getContent(
-      { entity_id: emptyEntity.id, limit: 50, sort_by: 'date', sort_order: 'desc' } as never,
-      {} as never,
-      ctx()
-    );
+    // Pin "no local frontend" so the URL builder takes the absolute
+    // hosted-UI fallback deterministically: with a built
+    // packages/owletto/dist on the machine (any owletto build, e.g.
+    // make review) hasLocalFrontend() flips and view_url comes back
+    // relative — the assertion below is about the URL being usable by
+    // an MCP client, not about the machine's build state.
+    __setLocalFrontendForTests(false);
+    try {
+      const result = await getContent(
+        { entity_id: emptyEntity.id, limit: 50, sort_by: 'date', sort_order: 'desc' } as never,
+        {} as never,
+        ctx()
+      );
 
-    expect(result.content).toEqual([]);
-    expect(result.total).toBe(0);
-    // view_url is consumed by LLM agents reading read_knowledge over MCP.
-    // It must always be populated when an entity is in scope.
-    const viewUrl = (result as { view_url?: string }).view_url;
-    expect(typeof viewUrl).toBe('string');
-    expect(viewUrl).toMatch(/^https?:\/\//);
-    expect(result.classification_stats).toBeUndefined();
+      expect(result.content).toEqual([]);
+      expect(result.total).toBe(0);
+      // view_url is consumed by LLM agents reading read_knowledge over MCP.
+      // It must always be populated when an entity is in scope.
+      const viewUrl = (result as { view_url?: string }).view_url;
+      expect(typeof viewUrl).toBe('string');
+      expect(viewUrl).toMatch(/^https?:\/\//);
+      expect(result.classification_stats).toBeUndefined();
+    } finally {
+      __resetPublicOriginCachesForTests();
+    }
   });
 
   it('classification_stats is populated only when include_classification=summary is set', async () => {

--- a/packages/server/src/__tests__/setup/embedded-postgres-backend.ts
+++ b/packages/server/src/__tests__/setup/embedded-postgres-backend.ts
@@ -13,8 +13,23 @@ import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { injectPgvector, resolveEmbeddedNativeDir } from '@lobu/pgvector-embedded';
+import exitHook from 'async-exit-hook';
 import EmbeddedPostgres from 'embedded-postgres';
 import { withFreePortRetry } from './free-port';
+
+// Importing `embedded-postgres` registers async-exit-hook, whose `beforeExit`
+// handler force-exits with code 0 (`process.nextTick(process.exit.bind(null, 0))`).
+// Because the vitest globalSetup imports this module, that hook lives in the
+// MAIN vitest process: after a failed run vitest sets `process.exitCode = 1`
+// and lets the loop drain, Node emits `beforeExit`, and the hook overwrites the
+// failure with exit 0 — CI went green on a run with 8 failed tests (#1216).
+// The `exit` hook is removed too: it calls the async gracefulShutdown without
+// a `done` callback (`done is not a function` unhandled rejection on every
+// clean run), and async cleanup can't execute during `exit` anyway. Signal
+// hooks (SIGINT/SIGTERM/SIGHUP) stay so Ctrl-C still stops embedded clusters;
+// the normal path stops them explicitly in teardown().
+exitHook.unhookEvent('beforeExit');
+exitHook.unhookEvent('exit');
 
 export interface EmbeddedBackend {
   url: string;

--- a/packages/server/src/auth/__tests__/config.baseline.integration.test.ts
+++ b/packages/server/src/auth/__tests__/config.baseline.integration.test.ts
@@ -45,18 +45,38 @@ const ENV = {
   GITHUB_CLIENT_SECRET: 'test-github-secret',
 } as unknown as Env;
 
+// resolveLoginProviderCredentials falls back to process.env
+// (`authValues[key] || env[key] || process.env[key]`), so ambient
+// GOOGLE_*/GITHUB_*/… credentials in a dev shell would silently enable
+// providers these tests assert are hidden. Scrub them for the duration of
+// the file (every test passes its credentials via an explicit Env object)
+// and restore after — the suite runs single-fork with isolate:false, so a
+// leaked deletion would bleed into later files.
+const CREDENTIAL_ENV_KEYS = ['GOOGLE', 'GITHUB', 'LINKEDIN', 'MICROSOFT', 'SLACK'].flatMap(
+  (provider) => [`${provider}_CLIENT_ID`, `${provider}_CLIENT_SECRET`]
+);
+
 describe('login provider baseline (integration)', () => {
   let prevCatalogUris: string | undefined;
+  const ambientCredentials = new Map<string, string | undefined>();
 
   beforeAll(() => {
     prevCatalogUris = process.env.CONNECTOR_CATALOG_URIS;
     process.env.CONNECTOR_CATALOG_URIS = CATALOG_DIR;
+    for (const key of CREDENTIAL_ENV_KEYS) {
+      ambientCredentials.set(key, process.env[key]);
+      delete process.env[key];
+    }
     clearLoginProviderCachesForTests();
   });
 
   afterAll(() => {
     if (prevCatalogUris === undefined) delete process.env.CONNECTOR_CATALOG_URIS;
     else process.env.CONNECTOR_CATALOG_URIS = prevCatalogUris;
+    for (const [key, value] of ambientCredentials) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
     clearLoginProviderCachesForTests();
   });
 

--- a/packages/server/src/auth/__tests__/config.baseline.integration.test.ts
+++ b/packages/server/src/auth/__tests__/config.baseline.integration.test.ts
@@ -13,6 +13,7 @@
  * catalog → collect → merge → credential-gate path end to end.
  */
 
+import { existsSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import { getTestDb } from '../../__tests__/setup/test-db';
@@ -24,9 +25,16 @@ import {
   getEnabledLoginProviderConfigs,
 } from '../config';
 
-// Point at the bundled connectors that ship a `.catalog-manifest.json`, so the
-// scan is a fast manifest lookup instead of compiling every connector.
+// Prefer the built bundled connectors (they ship a `.catalog-manifest.json`,
+// so the scan is a fast manifest lookup), and fall back to the connector
+// sources when `build:server` hasn't run — CI's integration job and fresh
+// checkouts have no dist/, which made every baseline assertion fail with
+// `social: {}`. The source path takes the manifest-miss branch (compile +
+// extract per connector); slower, but it exercises the same
+// catalog → collect → merge → credential-gate pipeline.
 const DIST_CONNECTORS = resolve(__dirname, '../../../dist/connectors');
+const SRC_CONNECTORS = resolve(__dirname, '../../../../connectors/src');
+const CATALOG_DIR = existsSync(DIST_CONNECTORS) ? DIST_CONNECTORS : SRC_CONNECTORS;
 
 // Dummy credentials are enough: getAuthConfig only needs clientId + clientSecret
 // to *resolve* for a provider to be marked enabled — it never calls the IdP here.
@@ -42,7 +50,7 @@ describe('login provider baseline (integration)', () => {
 
   beforeAll(() => {
     prevCatalogUris = process.env.CONNECTOR_CATALOG_URIS;
-    process.env.CONNECTOR_CATALOG_URIS = DIST_CONNECTORS;
+    process.env.CONNECTOR_CATALOG_URIS = CATALOG_DIR;
     clearLoginProviderCachesForTests();
   });
 

--- a/packages/server/src/lobu/__tests__/agent-routes-apply.test.ts
+++ b/packages/server/src/lobu/__tests__/agent-routes-apply.test.ts
@@ -11,61 +11,24 @@
  * PR-2 of `docs/plans/lobu-apply.md`.
  */
 
-import { beforeAll, beforeEach, describe, expect, mock, test } from 'bun:test';
+import { beforeAll, beforeEach, describe, expect, test } from 'bun:test';
 import {
   ensureDbForGatewayTests,
   resetTestDatabase,
 } from '../../gateway/__tests__/helpers/db-setup.js';
+// Module mocks for `../../auth/middleware` and `../gateway` are shared with
+// agent-routes-rest-platform.test.ts: mock.module is process-global and the
+// cached agent-routes module keeps the FIRST file's mock bindings, so each
+// file mocking with its own closures broke whichever file ran second. The
+// helper installs the mocks ONCE over shared mutable stashes; each test sets
+// its per-test values on them in beforeEach (see helpers/route-test-mocks.ts).
+import {
+  authStash,
+  chatManagerStash,
+  installRouteTestMocks,
+} from './helpers/route-test-mocks';
 
-// Stash for the mocked `mcpAuth` middleware. Each test sets the user/org it
-// wants the route handler to see; the middleware below copies them onto the
-// Hono context. Using a mutable holder keeps the mocked module trivial — no
-// per-test re-mocking needed.
-const authStash: {
-  user: { id: string; name: string; email: string; emailVerified: boolean } | null;
-  organizationId: string | null;
-  // `authSource` mirrors the real middleware contract so admin-tier routes
-  // gated by `requireSessionOrAdminPat` see a non-null value. Default to
-  // 'session' — the existing apply tests simulate a web user.
-  authSource: 'session' | 'pat' | 'oauth' | null;
-  mcpAuthInfo: { scopes: string[] } | null;
-} = {
-  user: { id: 'u1', name: 'Test', email: 'u1@test', emailVerified: true },
-  organizationId: 'org-a',
-  authSource: 'session',
-  mcpAuthInfo: null,
-};
-
-mock.module('../../auth/middleware', () => ({
-  mcpAuth: async (c: any, next: any) => {
-    c.set('user', authStash.user);
-    c.set('organizationId', authStash.organizationId);
-    c.set('authSource', authStash.authSource);
-    c.set('mcpAuthInfo', authStash.mcpAuthInfo);
-    return next();
-  },
-  // requireAuth is referenced elsewhere in the module — provide a passthrough
-  // so importing files that destructure it still get a function.
-  requireAuth: async (_c: any, next: any) => next(),
-}));
-
-// `getChatInstanceManager` returns whatever the active test installs into
-// `chatManagerStash.manager`. The route refuses platform writes when the
-// manager is null (would otherwise persist plaintext secrets bypassing
-// secret-ref normalization), so `beforeEach` installs a thin stub that
-// just delegates persistence to the real connectionStore — enough for
-// route-level idempotency / ownership / racing tests that don't care
-// about secret-store roundtrip.
-const chatManagerStash: { manager: unknown } = { manager: null };
-
-mock.module('../gateway', () => ({
-  getChatInstanceManager: () => chatManagerStash.manager,
-  getLobuCoreServices: () => null,
-  initLobuGateway: async () => null,
-  stopLobuGateway: async () => {},
-  isLobuGatewayRunning: () => false,
-  ensureEmbeddedGatewaySecrets: () => {},
-}));
+installRouteTestMocks();
 
 /**
  * Minimal manager stub for route tests. addConnection / updateConnection

--- a/packages/server/src/lobu/__tests__/agent-routes-rest-platform.test.ts
+++ b/packages/server/src/lobu/__tests__/agent-routes-rest-platform.test.ts
@@ -31,51 +31,29 @@
  * Uses the embedded Postgres gateway test harness; no network.
  */
 
-import { beforeAll, beforeEach, describe, expect, mock, test } from 'bun:test';
+import { beforeAll, beforeEach, describe, expect, test } from 'bun:test';
 import {
   ensureDbForGatewayTests,
   resetTestDatabase,
 } from '../../gateway/__tests__/helpers/db-setup.js';
+// Shared module mocks — see helpers/route-test-mocks.ts. This file previously
+// re-mocked `../../auth/middleware` / `../gateway` with its own closures, but
+// the cached agent-routes module stayed bound to agent-routes-apply.test.ts's
+// mocks (bun mock.module is process-global, module evaluation is cached), so
+// every request here authenticated under the OTHER file's stash (wrong org)
+// and 404'd when both files ran in one process. The shared stashes below are
+// set per-test in beforeEach instead; the manager installed is the REAL
+// ChatInstanceManager built by buildRealManager().
+import {
+  authStash,
+  chatManagerStash,
+  installRouteTestMocks,
+} from './helpers/route-test-mocks';
+
+installRouteTestMocks();
 
 const TEST_ENCRYPTION_KEY =
   '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
-
-// Mocked auth middleware — same contract as agent-routes-apply.test.ts.
-const authStash: {
-  user: { id: string; name: string; email: string; emailVerified: boolean } | null;
-  organizationId: string | null;
-  authSource: 'session' | 'pat' | 'oauth' | null;
-  mcpAuthInfo: { scopes: string[] } | null;
-} = {
-  user: { id: 'u1', name: 'Test', email: 'u1@test', emailVerified: true },
-  organizationId: 'org-rest',
-  authSource: 'session',
-  mcpAuthInfo: null,
-};
-
-mock.module('../../auth/middleware', () => ({
-  mcpAuth: async (c: any, next: any) => {
-    c.set('user', authStash.user);
-    c.set('organizationId', authStash.organizationId);
-    c.set('authSource', authStash.authSource);
-    c.set('mcpAuthInfo', authStash.mcpAuthInfo);
-    return next();
-  },
-  requireAuth: async (_c: any, next: any) => next(),
-}));
-
-// The route reads the manager via getChatInstanceManager(); install the REAL
-// ChatInstanceManager built by buildRealManager() below.
-const chatManagerStash: { manager: any } = { manager: null };
-
-mock.module('../gateway', () => ({
-  getChatInstanceManager: () => chatManagerStash.manager,
-  getLobuCoreServices: () => null,
-  initLobuGateway: async () => null,
-  stopLobuGateway: async () => {},
-  isLobuGatewayRunning: () => false,
-  ensureEmbeddedGatewaySecrets: () => {},
-}));
 
 const ORG = 'org-rest';
 const AGENT = 'rest-agent';

--- a/packages/server/src/lobu/__tests__/helpers/route-test-mocks.ts
+++ b/packages/server/src/lobu/__tests__/helpers/route-test-mocks.ts
@@ -1,0 +1,80 @@
+/**
+ * Shared mutable mock state for the src/lobu route test files.
+ *
+ * bun:test's `mock.module` is process-global and module evaluation is cached:
+ * the FIRST test file to import `../agent-routes.js` permanently binds it to
+ * whatever mock factories are installed at that moment. When each test file
+ * registered its own `mock.module('../../auth/middleware', …)` closing over
+ * its OWN stash objects, the second file's re-mock never reached the
+ * already-evaluated agent-routes module — its requests kept authenticating
+ * against the first file's stash (wrong org) and hitting the first file's
+ * manager stub, so every lookup 404'd whenever both files ran in one process
+ * (`bun test src/lobu/__tests__`), while each file passed alone.
+ *
+ * Fix: install ONE process-wide mock per specifier, closing over these shared
+ * mutable stashes. Each test file sets its per-test values on the stashes in
+ * `beforeEach` — bun runs files sequentially in a single process, so there is
+ * no cross-talk.
+ */
+import { mock } from 'bun:test';
+
+export interface AuthStash {
+  user: { id: string; name: string; email: string; emailVerified: boolean } | null;
+  organizationId: string | null;
+  // `authSource` mirrors the real middleware contract so admin-tier routes
+  // gated by `requireSessionOrAdminPat` see a non-null value.
+  authSource: 'session' | 'pat' | 'oauth' | null;
+  mcpAuthInfo: { scopes: string[] } | null;
+}
+
+/** Mutable holder the mocked `mcpAuth` middleware copies onto the Hono context. */
+export const authStash: AuthStash = {
+  user: { id: 'u1', name: 'Test', email: 'u1@test', emailVerified: true },
+  organizationId: 'org-a',
+  authSource: 'session',
+  mcpAuthInfo: null,
+};
+
+/**
+ * Mutable holder for whatever `getChatInstanceManager()` should return —
+ * a delegating stub (agent-routes-apply.test.ts) or the real
+ * ChatInstanceManager (agent-routes-rest-platform.test.ts).
+ */
+export const chatManagerStash: { manager: any } = { manager: null };
+
+let installed = false;
+
+/**
+ * Idempotent: the module mocks are installed once per process, bound to the
+ * shared stashes above. Call at the top of every test file that imports
+ * `../agent-routes.js` (directly or transitively), BEFORE that import runs.
+ */
+export function installRouteTestMocks(): void {
+  if (installed) return;
+  installed = true;
+
+  // Resolves to src/auth/middleware — the specifier agent-routes.ts imports
+  // as `../auth/middleware`.
+  mock.module('../../../auth/middleware', () => ({
+    mcpAuth: async (c: any, next: any) => {
+      c.set('user', authStash.user);
+      c.set('organizationId', authStash.organizationId);
+      c.set('authSource', authStash.authSource);
+      c.set('mcpAuthInfo', authStash.mcpAuthInfo);
+      return next();
+    },
+    // requireAuth is referenced elsewhere in the module — provide a
+    // passthrough so importing files that destructure it still get a function.
+    requireAuth: async (_c: any, next: any) => next(),
+  }));
+
+  // Resolves to src/lobu/gateway — imported by agent-routes.ts as `./gateway`.
+  mock.module('../../gateway', () => ({
+    getChatInstanceManager: () => chatManagerStash.manager,
+    getLobuCoreServices: () => null,
+    initLobuGateway: async () => null,
+    stopLobuGateway: async () => {},
+    isLobuGatewayRunning: () => false,
+    ensureEmbeddedGatewaySecrets: () => {},
+  }));
+}

--- a/packages/server/src/tools/admin/manage_watchers/complete-window.ts
+++ b/packages/server/src/tools/admin/manage_watchers/complete-window.ts
@@ -6,7 +6,7 @@
  */
 
 import Ajv from 'ajv';
-import { createDbClientFromEnv, getDb } from '../../../db/client';
+import { createDbClientFromEnv, getDb, pgBigintArray } from '../../../db/client';
 import type { Env } from '../../../index';
 import { ToolUserError } from '../../../utils/errors';
 import { verifyWindowToken } from '../../../utils/jwt';
@@ -310,6 +310,10 @@ export async function handleCompleteWindow(
     // the same transaction as the INSERT or the lock releases before the INSERT
     // and two concurrent device-worker rollup completions race on the PK (both
     // compute the same MAX(id)+1). Mirror the leaf-window path below.
+    //
+    // source_window_ids is integer[]; the prod pool runs fetch_types: false, so
+    // postgres.js can't serialize a bare JS array (it ships "5,6" and PG throws
+    // `malformed array literal`) — bind via the explicit literal idiom (#1046).
     const newWindowId = await sql.begin(async (tx) => {
       const allocatedWindowId = await getNextNumericId(tx, 'watcher_windows');
       await tx`
@@ -320,7 +324,7 @@ export async function handleCompleteWindow(
         ) VALUES (
           ${allocatedWindowId}, ${watcherId}, ${resolvedVersionId}, ${window_start}, ${window_end}, ${granularity || timeGranularity},
           ${tx.json(extractedData)}, 0, ${provenanceModel}, ${provenanceClientId}, ${tx.json(provenanceMetadata)},
-          true, ${depth}, ${sourceIds}, ${watcherRunId}, NOW()
+          true, ${depth}, ${pgBigintArray(sourceIds)}::int[], ${watcherRunId}, NOW()
         )
       `;
       return allocatedWindowId;

--- a/packages/server/src/types/async-exit-hook.d.ts
+++ b/packages/server/src/types/async-exit-hook.d.ts
@@ -1,0 +1,16 @@
+/**
+ * Minimal typings for `async-exit-hook` (ships untyped; transitive dep of
+ * `embedded-postgres`). Only the surface used by embedded-postgres-backend.ts.
+ */
+declare module 'async-exit-hook' {
+  interface AsyncExitHook {
+    (hook: (done?: () => void) => void): void;
+    /** Remove the listener async-exit-hook registered for a process event. */
+    unhookEvent(event: string): void;
+    hookEvent(event: string, code?: number, filter?: (...args: unknown[]) => boolean): void;
+    hookedEvents(): string[];
+    forceExitTimeout(ms: number): void;
+  }
+  const exitHook: AsyncExitHook;
+  export default exitHook;
+}

--- a/packages/server/src/utils/__tests__/url-builder.test.ts
+++ b/packages/server/src/utils/__tests__/url-builder.test.ts
@@ -3,6 +3,7 @@ import { buildEntityUrl, getPublicWebUrl } from '../url-builder';
 import {
   HOSTED_UI_FALLBACK_ORIGIN,
   __resetPublicOriginCachesForTests,
+  __setLocalFrontendForTests,
 } from '../public-origin';
 
 /**
@@ -56,10 +57,15 @@ describe('getPublicWebUrl', () => {
   });
 
   it('falls back to HOSTED_UI_FALLBACK_ORIGIN when no env, no baseUrl, no local frontend', () => {
+    // Pin the precondition: a built packages/owletto/dist on the dev machine
+    // (any owletto build, e.g. make review) would otherwise flip
+    // hasLocalFrontend() and break the assertion.
+    __setLocalFrontendForTests(false);
     expect(getPublicWebUrl(undefined, undefined)).toBe(HOSTED_UI_FALLBACK_ORIGIN);
   });
 
   it('falls back to HOSTED_UI_FALLBACK_ORIGIN even when requestUrl is given (backend-only host)', () => {
+    __setLocalFrontendForTests(false);
     expect(getPublicWebUrl('https://request.lobu.com/mcp')).toBe(HOSTED_UI_FALLBACK_ORIGIN);
   });
 });

--- a/packages/server/src/utils/public-origin.ts
+++ b/packages/server/src/utils/public-origin.ts
@@ -37,6 +37,16 @@ export function __resetPublicOriginCachesForTests(): void {
   localFrontendCache = undefined;
 }
 
+/**
+ * Test-only: pin `hasLocalFrontend()` so tests asserting the backend-only
+ * fallback don't depend on whether a frontend bundle happens to exist on the
+ * machine — `packages/owletto/dist/index.html` is present after any owletto
+ * build (e.g. `make review`), absent in CI and fresh checkouts.
+ */
+export function __setLocalFrontendForTests(value: boolean | undefined): void {
+  localFrontendCache = value;
+}
+
 const APP_ROOT = path.resolve(fileURLToPath(new URL('.', import.meta.url)), '../..');
 
 let localFrontendCache: boolean | undefined;

--- a/scripts/assert-vitest-report-clean.mjs
+++ b/scripts/assert-vitest-report-clean.mjs
@@ -1,0 +1,59 @@
+#!/usr/bin/env node
+/**
+ * Fail-closed guard for vitest exit codes in CI (#1216).
+ *
+ * vitest's exit code is not trustworthy on its own: anything that hooks
+ * `beforeExit` in the main process (async-exit-hook, registered as a side
+ * effect of importing `embedded-postgres`, force-exits 0) can overwrite a
+ * failing `process.exitCode` after the summary prints — CI run 27363592280
+ * went green with "Test Files 5 failed". The root cause is unhooked in
+ * src/__tests__/setup/embedded-postgres-backend.ts, but the gate must not
+ * depend on every future import staying side-effect-free.
+ *
+ * Usage: run vitest with `--reporter=json --outputFile.json=<path>`, then
+ *   node scripts/assert-vitest-report-clean.mjs <path>
+ * Exits non-zero unless the report exists, parses, ran at least one test,
+ * and recorded zero failures.
+ */
+import { readFileSync } from "node:fs";
+
+const reportPath = process.argv[2];
+if (!reportPath) {
+  console.error(
+    "[vitest-guard] usage: assert-vitest-report-clean.mjs <report.json>"
+  );
+  process.exit(1);
+}
+
+let report;
+try {
+  report = JSON.parse(readFileSync(reportPath, "utf-8"));
+} catch (err) {
+  console.error(
+    `[vitest-guard] FAIL-CLOSED: cannot read/parse ${reportPath}: ${err.message}`
+  );
+  console.error(
+    "[vitest-guard] (a crashed or interrupted vitest run never writes the report)"
+  );
+  process.exit(1);
+}
+
+const { success, numTotalTests, numFailedTests, numFailedTestSuites } = report;
+console.log(
+  `[vitest-guard] report: success=${success} total=${numTotalTests} ` +
+    `failedTests=${numFailedTests} failedSuites=${numFailedTestSuites}`
+);
+
+if (success !== true || numFailedTests !== 0 || numFailedTestSuites !== 0) {
+  console.error(
+    "[vitest-guard] FAIL: vitest reported failures (regardless of its exit code)"
+  );
+  process.exit(1);
+}
+if (!Number.isInteger(numTotalTests) || numTotalTests < 1) {
+  console.error(
+    "[vitest-guard] FAIL-CLOSED: zero tests ran — refusing to treat that as green"
+  );
+  process.exit(1);
+}
+console.log("[vitest-guard] OK");


### PR DESCRIPTION
Fixes #1216

## Part A — why CI went green over 8 failures

`node .../vitest run` has no pipe, so the shell wasn't swallowing anything — **vitest's own process exited 0**. Traced with a `process.exit` interceptor:

```
[trace-exit pid=… argv1=.bin/vitest] process.exit(0) called; process.exitCode=1
    at processTicksAndRejections   ← bare callback, zero user frames
```

Root cause chain:
1. The vitest globalSetup statically imports `embedded-postgres` (test backend), which **at module load** registers `async-exit-hook` — in the **main vitest process**.
2. `async-exit-hook` hooks `beforeExit` with code 0. After a failed run, vitest sets `process.exitCode = 1` and lets the loop drain; Node emits `beforeExit`; the hook runs and then `process.nextTick(process.exit.bind(null, 0))` overwrites the failure with exit 0.
3. Nondeterminism between runs 27363592280 (silent green) and 27364008324 (correct red): `beforeExit` only fires when the loop fully drains. A straggling handle means vitest's teardown-timeout `process.exit()` (no-arg → uses exitCode=1) wins instead.

Reproduced deterministically in a minimal repro: `import 'embedded-postgres'` in a globalSetup flips a failing run's exit code from 1 to 0.

**Fix (two layers, both validated):**
- Root cause: `embedded-postgres-backend.ts` unhooks async-exit-hook's `beforeExit` (and its broken `exit` hook, which calls the async cleanup without a `done` callback and throws an unhandled `done is not a function` rejection on every *clean* run once the clobber is gone). Signal hooks stay; `teardown()` stops clusters explicitly.
- Fail-closed CI gate: the vitest step now also writes `--reporter=json`, and `scripts/assert-vitest-report-clean.mjs` independently asserts `success && 0 failed && ≥1 test ran`, failing also when the report is missing/unparseable (crashed run). The gate no longer depends on every future import staying side-effect-free.

## Part B — per-test root causes

| Test | Verdict | Root cause |
|---|---|---|
| server-lifecycle "shuts down in documented order" | stale test | #1191 rewrote `httpServer.close();` into `safe("httpServer.close", …)` bounded drain; needle updated to the step label (main fixed this concurrently in #1218 — kept main's hunk on rebase). All other needles in the block verified against current source. |
| config.baseline.integration ×4 | broken test env | Test pointed `CONNECTOR_CATALOG_URIS` at `packages/server/dist/connectors`, which the integration job (and any fresh checkout) **never builds** → empty catalog → empty login baseline. Now falls back to `packages/connectors/src` (manifest-miss compile path, ~10s, same catalog→collect→merge→credential-gate pipeline). Not a prod bug. |
| anonymous-device-registration "cloud mode strict" | stale test | #1192 (security audit) made anonymous workers-API access **fail closed with 401** under `LOBU_CLOUD_MODE`; the test predates it (#1017) and expected a degraded 200. Now asserts 401 + no registration — strictly stronger than the test's original intent. |
| postgres-sync-cloud-gate "execution-time gate" | stale test | Same #1192 gate rejects the anonymous poll before it reaches the code under test. The poll now authenticates as a trusted fleet worker (`WORKER_API_TOKEN` via the test env override) so it exercises the execution-time cloud gate in `pollWorkerJob`. |
| rollup-window-id-race | 🚨 **REAL PROD BUG** | `complete_window`'s rollup INSERT bound a bare JS array into `source_window_ids integer[]`. The prod pool runs `fetch_types: false`, so postgres.js can't infer the element type and ships `"5,6"` → PG `malformed array literal` → **every rollup completion fails in prod** (same bug class as the 12-day watcher wedge fixed in #1046; the test harness was deliberately aligned to prod options there so this surfaces). Fixed with the established `pgBigintArray(...)::int[]` literal idiom. |

None of the 8 were cross-file env pollution — all reproduced when running the 5 files alone, and 6-7 reproduced per-file in isolation.

## Validation

- Full `vitest run` (packages/server, Node 22, embedded PG): **122 files / 1031-1032 passed, 0 failed — three times** (twice pre-rebase, once post-rebase onto current main), guard `OK` each time.
- Part A demonstration: injected a deliberately failing test → vitest exits **1** (root-cause fix) and the JSON guard exits **1** independently; guard also exits 1 on a missing report; green run → vitest 0 + guard OK. Injection reverted.
- `bun test src/gateway/__tests__` and `bun test src/lobu/__tests__ src/workspace/__tests__`: 12 + 5 failures locally, but **byte-identical failure sets on a clean origin/main worktree with the same DATABASE_URL** (and green in actual CI) → pre-existing local-env issues, untouched by this PR.
- `bunx tsc --noEmit` clean in packages/server.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1220"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783809917&installation_id=136316292&pr_number=1220&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1220&signature=7863d13c753f1bd04e7c4bc1e92462de4c9e171775843d374bd64eb95f9e7500"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced CI reliability with stricter test failure detection in Vitest JSON reports
  * Improved authentication and cloud-mode security test validations
  * Refactored shared test utilities to reduce redundancy across integration test suites
  * Fixed test isolation and determinism issues in content visibility and configuration tests

* **Bug Fixes**
  * Corrected database parameter handling for integer arrays in admin tools

<!-- end of auto-generated comment: release notes by coderabbit.ai -->