### PR TITLE
fix(cli): stop the scaffolded npm install shadowing the workspace connector-sdk in the smoke gates

### DIFF
--- a/scripts/cli-smoke.sh
+++ b/scripts/cli-smoke.sh
@@ -156,9 +156,17 @@ expect_grep "lobu init --list-providers" "--provider" "$WT" init --list-provider
 # Scaffold the project we'll boot. Mirror sdk-e2e: scaffold, drop package.json
 # so jiti resolves the workspace @lobu/cli/config, then overwrite the config to
 # point the agent at the deterministic mock provider.
+#
+# node_modules/bun.lock must go for the same reason as package.json: `lobu
+# init` runs `bun install`, which plants the *published* @lobu/connector-sdk
+# in $PROJ/node_modules. Compiled connector bundles are staged under cwd
+# ($PROJ here), so their externalized bare `@lobu/connector-sdk` import would
+# resolve that stale npm copy instead of the workspace dist under test --
+# making the runtime-self-check fail for any in-repo connector that uses an
+# SDK export newer than the last npm release (#1222).
 PROJ="$RUN_DIR/proj"; mkdir -p "$PROJ"
 expect_grep "lobu init . --here" "Lobu initialized" "$PROJ" init . -y --here --provider gemini
-rm -f "$PROJ/package.json"
+rm -rf "$PROJ/package.json" "$PROJ/node_modules" "$PROJ/bun.lock"
 cat > "$PROJ/lobu.config.ts" <<'TS'
 import { defineAgent, defineConfig, defineEntityType, secret } from "@lobu/cli/config";
 

--- a/scripts/sdk-e2e.sh
+++ b/scripts/sdk-e2e.sh
@@ -76,9 +76,14 @@ curl -fsS -X POST "http://127.0.0.1:$MOCK_PORT/v1/chat/completions" -H 'content-
 echo "✓ mock provider up"
 
 # 2) Scaffold a project (inside the repo so jiti resolves the workspace @lobu/cli/config).
+# Drop node_modules/bun.lock too: `lobu init` installs the *published*
+# @lobu/connector-sdk there, and connector bundles staged under cwd ($PROJ)
+# would resolve that stale copy instead of the workspace dist under test
+# whenever a connector uses an SDK export newer than the last npm release
+# (#1222 — this is what turned cli-smoke red).
 PROJ="$RUN_DIR/proj"; mkdir -p "$PROJ"
 ( cd "$PROJ" && $LOBU init . -y --here --provider gemini >/dev/null 2>&1 )
-rm -f "$PROJ/package.json"
+rm -rf "$PROJ/package.json" "$PROJ/node_modules" "$PROJ/bun.lock"
 cat > "$PROJ/lobu.config.ts" <<'TS'
 import { connectorFromFile, defineAgent, defineConfig, defineConnection, defineEntityType, defineRelationshipType, defineWatcher, reactionFromFile, secret } from "@lobu/cli/config";
 import type PulseConnector from "./connectors/pulse.connector.ts";


### PR DESCRIPTION
Fixes #1222.

## Root cause

`scripts/cli-smoke.sh` scaffolds its test project with `lobu init`, which (since #1214) runs `bun install` in `$PROJ` — planting the **published** `@lobu/connector-sdk` (npm 11.1.0, pre-#1205) in `$PROJ/node_modules`. The harness removes `$PROJ/package.json` precisely so everything resolves from the workspace, but it left `node_modules` behind.

The connector runtime-self-check stages compiled connector bundles under `process.cwd()` (`$PROJ`), so the bundle's externalized bare `@lobu/connector-sdk` import resolved the stale npm copy instead of the freshly built workspace dist — while the `resolve:@lobu/connector-sdk` probe (anchored at connector-worker) resolved the workspace dist. Split-brain resolution.

This was latent until #1205, which added `createHttpClient`/`paginateByOffset` to the SDK **and** used them in nine bundled connectors. `github.ts` is the 10th connector alphabetically, so the check died there:

```
"connectors-instantiate": "The requested module '@lobu/connector-sdk' does not provide an export named 'createHttpClient'"
"connector-keys-unique": "9 unique keys."
```

— exactly matching the CI red ("9 unique keys" in the run 27379936750 log tail). Running the same command from a clean cwd (no project `node_modules`) is green, which is why the failure looked "built-CLI-specific": the variable was cwd contents, not built-vs-source.

By construction the published SDK can never contain not-yet-released exports, so the gate as it stood would go red for *any* legitimate "add SDK export + use it in a bundled connector" change.

## Fix

Remove `node_modules` and `bun.lock` alongside the existing `package.json` removal in `cli-smoke.sh`, restoring the harness invariant that the artifacts under test (workspace-built dist) are what gets resolved. `sdk-e2e.sh` has the identical latent hole (its `pulse.connector.ts` executes with `cwd=$PROJ`), so it gets the same one-liner.

No check is skipped or softened — all 11 self-check assertions still run over all 32 bundled connectors, now against the workspace SDK.

## Red → green

Red (unmodified worktree at origin/main, full `scripts/cli-smoke.sh`, macOS + Node 22):

```
  [FAIL] lobu connector runtime-self-check --json (exit=1)
  CLI smoke summary: 65 passed, 1 failed, 4 skipped
RESULT: CLI smoke FAILED (1 command(s) broken)
```

with the failing check captured as:

```
"connectors-instantiate": ok=false, "The requested module '@lobu/connector-sdk' does not provide an export named 'createHttpClient'", connectorCount=9
```

Green (same machine, with this fix):

```
  CLI smoke summary: 66 passed, 0 failed, 4 skipped
RESULT: CLI smoke PASSED -- every runnable command works
```

`scripts/sdk-e2e.sh` also re-run end-to-end with the change: `✅ SDK lifecycle e2e PASSED` (exit 0).

## Follow-up worth tracking (not this PR)

The same skew exists in real installs: bundled connectors staged under a project cwd resolve the *project's* `@lobu/connector-sdk` (e.g. a project scaffolded on CLI 11.1.0, then run with a newer CLI whose bundled connectors use newer SDK exports). The SDK is documented as runtime-provided, so execution staging should arguably anchor SDK resolution at the runtime artifact rather than cwd — a deliberate prod-semantics change, out of scope here.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1223"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783812876&installation_id=136316292&pr_number=1223&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1223&signature=1032cb936cb14c8a845e20af35b8367734a45d142f6ce8b07a40573aca603283"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced test scaffolding to ensure consistent dependency resolution by removing stale artifacts during project initialization, preventing outdated modules from interfering with test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->