### PR TITLE
fix(chart): numeric runAsUser/UID so runAsNonRoot validates (prod rollout wedge)

### DIFF
--- a/charts/lobu/values.yaml
+++ b/charts/lobu/values.yaml
@@ -110,10 +110,15 @@ worker:
   terminationGracePeriodSeconds: 300
 
   # The worker executes untrusted agent/connector code — the highest-value
-  # container to harden. The image already runs as a non-root user
-  # (docker/worker/Dockerfile: USER worker), so runAsNonRoot is enforceable.
+  # container to harden. runAsUser must stay numeric and match the image's
+  # UID (docker/worker/Dockerfile: useradd -u 1001): the kubelet cannot
+  # verify runAsNonRoot from a named image USER and rejects the container
+  # with CreateContainerConfigError, wedging the rollout until Helm's
+  # --wait timeout.
   containerSecurityContext:
     runAsNonRoot: true
+    runAsUser: 1001
+    runAsGroup: 1001
     allowPrivilegeEscalation: false
     capabilities:
       drop:
@@ -153,10 +158,13 @@ embeddings:
     fsGroup: 1001
     fsGroupChangePolicy: OnRootMismatch
 
-  # The image runs as a non-root user (docker/embeddings-service/Dockerfile:
-  # USER embeddings), so runAsNonRoot is enforceable.
+  # runAsUser must stay numeric and match the image's UID
+  # (docker/embeddings-service/Dockerfile: useradd -u 1001) so the kubelet
+  # can verify runAsNonRoot without inferring from image metadata.
   containerSecurityContext:
     runAsNonRoot: true
+    runAsUser: 1001
+    runAsGroup: 1001
     allowPrivilegeEscalation: false
     capabilities:
       drop:

--- a/docker/embeddings-service/Dockerfile
+++ b/docker/embeddings-service/Dockerfile
@@ -51,7 +51,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 ENV PATH="/usr/local/bin:${PATH}"
 
-RUN useradd -m -s /bin/bash embeddings && \
+# Pinned UID and numeric final USER so the kubelet can verify
+# runAsNonRoot (a named USER fails CreateContainerConfigError
+# "non-numeric user"). Keep in sync with
+# embeddings.containerSecurityContext.runAsUser in charts/lobu.
+RUN useradd -m -u 1001 -s /bin/bash embeddings && \
     mkdir -p /app/.cache/transformers && \
     chown -R embeddings:embeddings /app
 
@@ -67,7 +71,7 @@ EXPOSE 8790
 HEALTHCHECK --interval=30s --timeout=10s --start-period=30s --retries=3 \
   CMD node -e "fetch('http://localhost:8790/health').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))"
 
-USER embeddings
+USER 1001
 WORKDIR /app/packages/embeddings
 
 CMD ["bun", "src/server.ts"]

--- a/docker/worker/Dockerfile
+++ b/docker/worker/Dockerfile
@@ -74,8 +74,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 ENV PATH="/usr/local/bin:${PATH}"
 
-# Non-root user
-RUN useradd -m -s /bin/bash worker && \
+# Non-root user. Pinned UID and numeric final USER so the kubelet can
+# verify runAsNonRoot — a named USER fails CreateContainerConfigError
+# ("non-numeric user, cannot verify user is non-root"). Keep in sync
+# with worker.containerSecurityContext.runAsUser in charts/lobu.
+RUN useradd -m -u 1001 -s /bin/bash worker && \
     mkdir -p /app/.cache/transformers /ms-playwright && \
     chown -R worker:worker /app /ms-playwright
 
@@ -94,7 +97,7 @@ COPY --from=builder --chown=worker:worker /app/packages/connector-worker ./packa
 
 # Install patchright's Chromium (declared as `playwright` alias in worker package.json).
 # Use bunx from the worker workspace so bun's resolver finds the alias.
-USER worker
+USER 1001
 WORKDIR /app/packages/connector-worker
 RUN bunx --bun playwright install chromium
 WORKDIR /app


### PR DESCRIPTION
## Problem
Chart 11.2.0 (#1191 hardening, released via #1217) sets `runAsNonRoot: true` on the worker and embeddings containers, but both images declare a **named** `USER` (`worker` / `embeddings`). The kubelet refuses to start such a container:

```
CreateContainerConfigError: container has runAsNonRoot and image has non-numeric user (worker), cannot verify user is non-root
```

Reproduced live in prod against `lobu-worker:20260612-151807` with a throwaway pod. Effect: every chart 11.0.0→11.2.0 upgrade attempt wedged until Helm's 15m `--wait` timeout, Flux remediation rolled back, and after 3 attempts the HelmRelease stalled (`RetriesExceeded`) — prod spent 2026-06-12 pinned to the 11.0.0 snapshot with the previous day's image.

## Fix
Both sides, kept in sync at UID 1001 (the UID `useradd` already assigned in both images, verified with `id` in-cluster):
- `docker/worker/Dockerfile`, `docker/embeddings-service/Dockerfile`: `useradd -u 1001` + numeric final `USER 1001` — the image alone now satisfies runAsNonRoot verification.
- `charts/lobu/values.yaml`: `runAsUser: 1001` + `runAsGroup: 1001` in both `containerSecurityContext` defaults — the kubelet validates against the explicit UID regardless of image metadata, so the chart can't re-wedge on an image that forgets the numeric USER.

Prod was unblocked immediately via the same values pinned in the GitOps overlay (lobu-ai/owletto#259); once this releases, that override is redundant and can be dropped.

## Validation
- `helm lint` clean; `helm template` renders `runAsUser: 1001` on embeddings, worker init, and worker main containers.
- Live repro + UID verification done in-cluster (throwaway pods, deleted).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1228"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783880398&installation_id=136316292&pr_number=1228&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1228&signature=6fae64e93200695297a8f35c88b22cc686ef3bc22e94557819b23c7ba58660bb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->