### PR TITLE
fix(server): drop dead connector_definitions.api_type column (contract phase of #1044)

### DIFF
--- a/db/migrations/20260612190000_drop_connector_api_type.sql
+++ b/db/migrations/20260612190000_drop_connector_api_type.sql
@@ -1,0 +1,12 @@
+-- migrate:up
+
+-- Contract phase of #1044: the 'browser'/'api' worker-claim axis was removed
+-- in #1042, and #1226 (deployed) removed api_type from the query_sql allowlist
+-- so no running replica emits it in scoped CTEs anymore. Nothing reads or
+-- writes the column; dropping it is safe under a rolling upgrade.
+ALTER TABLE public.connector_definitions DROP COLUMN IF EXISTS api_type;
+
+-- migrate:down
+
+ALTER TABLE public.connector_definitions
+    ADD COLUMN IF NOT EXISTS api_type text DEFAULT 'api'::text NOT NULL;

--- a/packages/server/src/utils/__tests__/table-schema.test.ts
+++ b/packages/server/src/utils/__tests__/table-schema.test.ts
@@ -123,10 +123,6 @@ describe('QUERYABLE_SCHEMA vs database (drift detection)', () => {
     // Large per-connector JSONB blobs — too big and structure-dependent to expose
     // via raw SQL. Callers should hit the typed connector handler instead.
     connector_definitions: new Set([
-      // Dead since #1042 (nothing reads or writes it); omitted here during the
-      // expand phase so old replicas stop emitting it in scoped CTEs before a
-      // later release drops the column (#1044).
-      'api_type',
       'mcp_config',
       'api_config',
       'openapi_config',


### PR DESCRIPTION
Contract phase of #1044, completing the two-phase removal started in #1226.

## What
- dbmate migration dropping `connector_definitions.api_type` (`DROP COLUMN IF EXISTS`; down re-adds `text DEFAULT 'api' NOT NULL`).
- Removes the `INTENTIONALLY_OMITTED` entry from the schema drift test.

## Rollout safety
#1226's image (`20260612-184312`) is live on both prod replicas (verified via kubectl + live `query_sql` probes: normal queries work, `SELECT api_type` is rejected by validation). No running code selects or writes the column, so the Helm pre-upgrade drop is safe under a rolling upgrade.

## Verification (red→green)
- **Red:** with the drift-test omission removed but the migration absent, `table-schema.test.ts` fails: `DB columns missing from QUERYABLE_SCHEMA: connector_definitions.api_type`.
- **Green:** with the migration, a fresh embedded-PG boot applies the full chain and the suite passes 14/14.

Closes #1044

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1232"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783883047&installation_id=136316292&pr_number=1232&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1232&signature=3426f7d2f8a3e1abe2e60080be1c0009ed98352b682780aea81c8e84de06e991"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->