### PR TITLE
fix(server): enforce TypeBox arg validation for all tools at one chokepoint

### DIFF
--- a/packages/server/src/__tests__/integration/tools/all-tools-e2e.test.ts
+++ b/packages/server/src/__tests__/integration/tools/all-tools-e2e.test.ts
@@ -143,7 +143,7 @@ describe("all agent MCP tools — registry-driven e2e (model-free)", () => {
 				note: "lists entities of a type (create→delete asserted separately)",
 			},
 			manage_entity_schema: {
-				args: { action: "list" },
+				args: { schema_type: "entity_type", action: "list" },
 				coverage: "reachable",
 				note: "lists entity-type schemas for the org",
 			},

--- a/packages/server/src/__tests__/integration/watchers/feedback-contract.test.ts
+++ b/packages/server/src/__tests__/integration/watchers/feedback-contract.test.ts
@@ -195,7 +195,9 @@ describe('watcher feedback contract', () => {
         {} as never,
         ownerCtx(workspace)
       )
-    ).rejects.toThrow(/unsupported mutation/);
+      // Boundary validation rejects the bad enum before the handler's own
+      // "unsupported mutation" check — both name the offending field.
+    ).rejects.toThrow(/mutation/);
 
     const other = await TestWorkspace.create({ name: 'Feedback Stranger Org' });
     const foreign = await seedWatcher(other, 'foreign');

--- a/packages/server/src/__tests__/integration/watchers/watchers-crud.test.ts
+++ b/packages/server/src/__tests__/integration/watchers/watchers-crud.test.ts
@@ -184,13 +184,14 @@ describe('watcher CRUD', () => {
     await expect(
       owner.watchers.create({ ...base, slug: 'bad-1', execution_config: { timeout_seconds: 0 } })
     ).rejects.toThrow(/execution_config/i);
-    // wrong type (string where integer expected) — would otherwise brick the
-    // Swift payload decode at run time.
+    // uncoercible type (non-numeric string where integer expected) — would
+    // otherwise brick the Swift payload decode at run time. A numeric string
+    // like '600' is coerced to 600 by boundary validation instead.
     await expect(
       owner.watchers.create({
         ...base,
         slug: 'bad-2',
-        execution_config: { timeout_seconds: '600' },
+        execution_config: { timeout_seconds: 'abc' },
       } as never)
     ).rejects.toThrow(/execution_config/i);
     // unknown key (additionalProperties: false)

--- a/packages/server/src/__tests__/unit/validate-args.test.ts
+++ b/packages/server/src/__tests__/unit/validate-args.test.ts
@@ -1,0 +1,166 @@
+import { describe, expect, it } from "bun:test";
+import { Type } from "@sinclair/typebox";
+import { getAllTools, getTool } from "../../tools/registry";
+import { validatedToolName, validateToolArgs, withValidatedArgs } from "../../tools/validate-args";
+import { ToolUserError } from "../../utils/errors";
+
+describe("validateToolArgs coercion", () => {
+  const schema = Type.Object({
+    id: Type.Number(),
+    name: Type.String(),
+    limit: Type.Optional(Type.Number({ default: 50 })),
+  });
+
+  it("coerces a numeric string to number and a number to string", () => {
+    const out = validateToolArgs("t", schema, { id: "42", name: 7 }) as Record<string, unknown>;
+    expect(out.id).toBe(42);
+    expect(out.name).toBe("7");
+  });
+
+  it("does NOT materialize schema defaults — handlers own defaulting", () => {
+    // read_knowledge declares `sort_by: { default: 'score' }` while its
+    // include_superseded path requires sort_by to be UNSET; injecting schema
+    // defaults at the boundary broke it. `default:` stays client-facing docs.
+    const out = validateToolArgs("t", schema, { id: 1, name: "a" }) as Record<string, unknown>;
+    expect("limit" in out).toBe(false);
+  });
+
+  it("rejects a missing required field, naming it once", () => {
+    let caught: unknown;
+    try {
+      validateToolArgs("t", schema, { id: 1 });
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(ToolUserError);
+    const msg = (caught as ToolUserError).message;
+    expect(msg).toMatch(/name/);
+    expect(msg.match(/\/name/g)?.length).toBe(1);
+  });
+
+  it("rejects an uncoercible value", () => {
+    expect(() => validateToolArgs("t", schema, { id: "abc", name: "x" })).toThrow(ToolUserError);
+  });
+
+  it("passes explicitly-undefined optional keys (REST query-param pattern)", () => {
+    const out = validateToolArgs("t", schema, {
+      id: 1,
+      name: "a",
+      limit: undefined,
+    }) as Record<string, unknown>;
+    expect(out.id).toBe(1);
+  });
+
+  it("passes an explicitly-undefined Optional(Array) key (Convert would wrap it as [undefined])", () => {
+    const arrSchema = Type.Object({
+      name: Type.String(),
+      tags: Type.Optional(Type.Array(Type.String())),
+    });
+    const out = validateToolArgs("t", arrSchema, {
+      name: "x",
+      tags: undefined,
+    }) as Record<string, unknown>;
+    expect(out.tags).toBeUndefined();
+  });
+
+  it("rejects null for an optional non-nullable field", () => {
+    const optSchema = Type.Object({ note: Type.Optional(Type.String()) });
+    expect(() => validateToolArgs("t", optSchema, { note: null })).toThrow(ToolUserError);
+  });
+
+  it("rejects unknown properties only under additionalProperties:false", () => {
+    const strict = Type.Object({ a: Type.String() }, { additionalProperties: false });
+    const open = Type.Object({ a: Type.String() });
+    expect(() => validateToolArgs("t", strict, { a: "x", extra: 1 })).toThrow(ToolUserError);
+    const out = validateToolArgs("t", open, { a: "x", extra: 1 }) as Record<string, unknown>;
+    expect(out.extra).toBe(1);
+  });
+
+  it("accepts a valid uuid format and rejects a bad one", () => {
+    const s = Type.Object({ id: Type.String({ format: "uuid" }) });
+    const ok = validateToolArgs("t", s, {
+      id: "f6a7b2c1-3d4e-4f50-8a9b-0c1d2e3f4a5b",
+    }) as Record<string, unknown>;
+    expect(ok.id).toBe("f6a7b2c1-3d4e-4f50-8a9b-0c1d2e3f4a5b");
+    expect(() => validateToolArgs("t", s, { id: "not-a-uuid" })).toThrow(ToolUserError);
+  });
+});
+
+describe("validateToolArgs union variant dispatch", () => {
+  const union = Type.Union([
+    Type.Object({ action: Type.Literal("create"), name: Type.String() }),
+    Type.Object({ action: Type.Literal("delete"), id: Type.Number() }),
+  ]);
+
+  it("validates against the matched variant only", () => {
+    const out = validateToolArgs("t", union, { action: "delete", id: "5" }) as Record<
+      string,
+      unknown
+    >;
+    expect(out.id).toBe(5);
+  });
+
+  it("tolerates fields from other variants (flattened advertised schema)", () => {
+    const out = validateToolArgs("t", union, {
+      action: "create",
+      name: "x",
+      id: 99,
+    }) as Record<string, unknown>;
+    expect(out.name).toBe("x");
+  });
+
+  it("reports the variant's missing field, not a union blob", () => {
+    let caught: unknown;
+    try {
+      validateToolArgs("t", union, { action: "create" });
+    } catch (err) {
+      caught = err;
+    }
+    expect((caught as ToolUserError).message).toMatch(/name/);
+  });
+
+  it("rejects an unknown action listing the valid ones", () => {
+    let caught: unknown;
+    try {
+      validateToolArgs("t", union, { action: "explode" });
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(ToolUserError);
+    expect((caught as ToolUserError).message).toMatch(/create, delete/);
+  });
+
+  it("rejects a missing action the same way", () => {
+    expect(() => validateToolArgs("t", union, {})).toThrow(ToolUserError);
+  });
+});
+
+describe("withValidatedArgs", () => {
+  it("passes the coerced args to the handler and forwards the rest", async () => {
+    const schema = Type.Object({ id: Type.Number() });
+    const fn = withValidatedArgs(
+      "t",
+      schema,
+      async (args: { id: number }, extra: string) => `${args.id}:${typeof args.id}:${extra}`
+    );
+    await expect(fn({ id: "9" } as never, "env")).resolves.toBe("9:number:env");
+  });
+
+  it("brands the wrapped handler with the tool name", () => {
+    const fn = withValidatedArgs("my_tool", Type.Object({}), async () => null);
+    expect(validatedToolName(fn)).toBe("my_tool");
+  });
+});
+
+describe("registry completeness", () => {
+  it("every registered tool handler is wrapped with withValidatedArgs", () => {
+    // `list_organizations` is a throw-stub in the registry: executeTool
+    // special-cases it and calls the (wrapped) listOrganizations directly.
+    const exempt = new Set(["list_organizations"]);
+    const unwrapped = getAllTools({ includeInternalTools: true })
+      .map((t) => t.name)
+      .filter((name) => !exempt.has(name))
+      .filter((name) => validatedToolName(getTool(name)?.handler) !== name);
+    expect(unwrapped).toEqual([]);
+  });
+});

--- a/packages/server/src/__tests__/unit/watcher-execution-config.test.ts
+++ b/packages/server/src/__tests__/unit/watcher-execution-config.test.ts
@@ -3,13 +3,31 @@
  * elevated permission modes. The end-to-end persistence/round-trip is covered
  * in __tests__/integration/watchers/watchers-crud.test.ts; this pins the
  * validation rules and the privilege gate without the integration harness.
+ *
+ * Shape/type/range validation moved to the tool boundary (lobu#1137):
+ * WatcherExecutionConfigSchema is embedded in ManageWatchersSchema, and
+ * `withValidatedArgs` enforces it before the handler runs. The schema tests
+ * below therefore go through `validateToolArgs` with the full tool schema —
+ * the same path a real manage_watchers call takes — while the role-policy
+ * gate stays on `assertValidExecutionConfig`.
  */
 
 import { describe, expect, it } from 'bun:test';
+import { ManageWatchersSchema } from '../../tools/admin/manage_watchers';
 import {
   assertValidExecutionConfig,
   type ExecutionConfigCaller,
 } from '../../tools/admin/watcher-execution-config';
+import { validateToolArgs } from '../../tools/validate-args';
+import { ToolUserError } from '../../utils/errors';
+
+function validateUpdateWith(executionConfig: unknown): unknown {
+  return validateToolArgs('manage_watchers', ManageWatchersSchema, {
+    action: 'update',
+    watcher_id: '1',
+    execution_config: executionConfig,
+  });
+}
 
 const owner: ExecutionConfigCaller = { memberRole: 'owner', userId: 'u1', isAuthenticated: true };
 const admin: ExecutionConfigCaller = { memberRole: 'admin', userId: 'u2', isAuthenticated: true };
@@ -39,37 +57,34 @@ describe('assertValidExecutionConfig — passthrough', () => {
   });
 });
 
-describe('assertValidExecutionConfig — schema validation', () => {
+describe('execution_config boundary validation (via ManageWatchersSchema)', () => {
   it('rejects a non-object', () => {
-    expect(() => assertValidExecutionConfig('nope', owner)).toThrow(/must be a JSON object/i);
-    expect(() => assertValidExecutionConfig([1, 2], owner)).toThrow(/must be a JSON object/i);
+    expect(() => validateUpdateWith('nope')).toThrow(ToolUserError);
+    expect(() => validateUpdateWith([1, 2])).toThrow(ToolUserError);
   });
 
   it('rejects out-of-range timeout_seconds', () => {
-    expect(() => assertValidExecutionConfig({ timeout_seconds: 0 }, owner)).toThrow(
-      /execution_config/i
-    );
-    expect(() => assertValidExecutionConfig({ timeout_seconds: 999_999 }, owner)).toThrow(
-      /execution_config/i
-    );
+    expect(() => validateUpdateWith({ timeout_seconds: 0 })).toThrow(/execution_config/i);
+    expect(() => validateUpdateWith({ timeout_seconds: 999_999 })).toThrow(/execution_config/i);
   });
 
-  it('rejects a wrong-typed field (string where integer expected)', () => {
-    // This is the silent-brick case: an unvalidated string would fail the
-    // device-worker's strict payload decode and disable every run.
-    expect(() => assertValidExecutionConfig({ timeout_seconds: '600' }, owner)).toThrow(
-      /execution_config/i
-    );
+  it('coerces a numeric string timeout to an integer (silent-brick case)', () => {
+    // An unvalidated string would fail the device-worker's strict payload
+    // decode and disable every run. The boundary coerces '600' → 600, so the
+    // persisted value is a well-typed integer; a non-numeric string rejects.
+    const out = validateUpdateWith({ timeout_seconds: '600' }) as {
+      execution_config: { timeout_seconds: number };
+    };
+    expect(out.execution_config.timeout_seconds).toBe(600);
+    expect(() => validateUpdateWith({ timeout_seconds: 'abc' })).toThrow(/execution_config/i);
   });
 
   it('rejects unknown keys (additionalProperties: false)', () => {
-    expect(() => assertValidExecutionConfig({ bogus: true }, owner)).toThrow(/execution_config/i);
+    expect(() => validateUpdateWith({ bogus: true })).toThrow(/execution_config/i);
   });
 
   it('rejects an invalid permission_mode enum value', () => {
-    expect(() => assertValidExecutionConfig({ permission_mode: 'yolo' }, owner)).toThrow(
-      /execution_config/i
-    );
+    expect(() => validateUpdateWith({ permission_mode: 'yolo' })).toThrow(/execution_config/i);
   });
 });
 

--- a/packages/server/src/tools/admin/__tests__/query_sql.test.ts
+++ b/packages/server/src/tools/admin/__tests__/query_sql.test.ts
@@ -15,24 +15,19 @@ const ctx: ToolContext = {
 };
 
 describe('querySql input validation', () => {
-  it('returns a structured error when callers send query instead of sql', async () => {
-    const result = await querySql(
-      { query: 'select * from events', sort_by: 'id' } as unknown as QuerySqlArgs,
-      {},
-      ctx
-    );
-
-    expect(result.error).toBe('sql (string) is required.');
-    expect(result.rows).toEqual([]);
-    expect(result.total_count).toBe(0);
+  // Shape errors (missing/mistyped fields, non-object args) now reject at the
+  // tool boundary (withValidatedArgs, lobu#1137) with the field name in the
+  // message, instead of resolving to a structured { error } result.
+  it('rejects callers that send query instead of sql, naming the missing field', async () => {
+    await expect(
+      querySql({ query: 'select * from events', sort_by: 'id' } as unknown as QuerySqlArgs, {}, ctx)
+    ).rejects.toThrow(/sql/);
   });
 
-  it('returns a structured error when tool arguments are not an object', async () => {
-    const result = await querySql(null as unknown as QuerySqlArgs, {}, ctx);
-
-    expect(result.error).toBe('Tool arguments must be an object.');
-    expect(result.rows).toEqual([]);
-    expect(result.total_count).toBe(0);
+  it('rejects non-object tool arguments', async () => {
+    await expect(querySql(null as unknown as QuerySqlArgs, {}, ctx)).rejects.toThrow(
+      /Invalid arguments for query_sql/
+    );
   });
 
   it('rejects an invalid sort_by column name (sort_by is optional, but must be a bare identifier when given)', async () => {

--- a/packages/server/src/tools/admin/action-tool.ts
+++ b/packages/server/src/tools/admin/action-tool.ts
@@ -2,10 +2,9 @@
  * Generic factory for action-discriminated admin tools.
  *
  * The `manage_*` tools all share the same shape: an `action` discriminator,
- * a per-action handler, per-action required-field checks, and dispatch via
- * `routeAction` (which enforces the per-action access policy). This module
- * lets a tool declare itself as a map of `action -> { schema, handler }`
- * instead of hand-rolling that plumbing.
+ * a per-action handler, and dispatch via `routeAction` (which enforces the
+ * per-action access policy). This module lets a tool declare itself as a map
+ * of `action -> { schema, handler }` instead of hand-rolling that plumbing.
  *
  * Two flavors, matching the two schema shapes that exist today:
  *
@@ -14,6 +13,8 @@
  *   The factory derives the union schema from the declared variants, so the
  *   exposed JSON schema is identical to the previous hand-written
  *   `Type.Union([...])` as long as variants are declared in the same order.
+ *   Args are coerced + validated against the matched variant before dispatch
+ *   (`withValidatedArgs`), so per-action required fields come from the schema.
  *
  * - `defineFlatActionTool` — for tools that intentionally expose a single
  *   flat object schema with an `action` enum (kept flat for MCP clients and
@@ -31,23 +32,21 @@ import type { Static, TObject, TUnion } from '@sinclair/typebox';
 import { Type } from '@sinclair/typebox';
 import type { Env } from '../../index';
 import type { ToolContext } from '../registry';
+import { withValidatedArgs } from '../validate-args';
 import { requireField, routeAction } from './action-router';
 
 export interface ActionDefinition<S extends TObject = TObject, R = unknown> {
   /** TypeBox variant for this action (must carry the `action` literal). */
   schema: S;
-  /** Args fields asserted present (via `requireField`) before the handler runs. */
-  requires?: string[];
   handler: (args: Static<S>, ctx: ToolContext, env: Env) => Promise<R>;
 }
 
 /** Pair an action's TypeBox variant with its typed handler. */
 export function action<S extends TObject, R>(
   schema: S,
-  handler: (args: Static<S>, ctx: ToolContext, env: Env) => Promise<R>,
-  options?: { requires?: string[] }
+  handler: (args: Static<S>, ctx: ToolContext, env: Env) => Promise<R>
 ): ActionDefinition<S, R> {
-  return { schema, handler, requires: options?.requires };
+  return { schema, handler };
 }
 
 type AnyActions = Record<string, ActionDefinition<any, any>>;
@@ -65,12 +64,7 @@ function runActions<T extends AnyActions>(
   const record = args as Record<string, unknown> & { action: string };
   const handlers: Record<string, () => Promise<ResultOf<T>>> = {};
   for (const [name, def] of Object.entries(actions)) {
-    handlers[name] = () => {
-      for (const field of def.requires ?? []) {
-        requireField(record[field], field, name);
-      }
-      return def.handler(args, ctx, env);
-    };
+    handlers[name] = () => def.handler(args, ctx, env);
   }
   return routeAction<ResultOf<T>>(toolName, record.action, ctx, handlers);
 }
@@ -78,7 +72,9 @@ function runActions<T extends AnyActions>(
 /**
  * Define a union-schema action tool. Returns the derived `Type.Union` input
  * schema (variants in declaration order) and the `(args, env, ctx)` runner
- * used as the registry handler.
+ * used as the registry handler. The runner coerces + validates args against
+ * the matched action variant before dispatch (lobu#1137), so per-action
+ * required fields are enforced by the schema, not `requires` lists.
  */
 export function defineActionTool<T extends AnyActions>(
   toolName: string,
@@ -92,7 +88,9 @@ export function defineActionTool<T extends AnyActions>(
   >;
   return {
     schema,
-    run: (args, env, ctx) => runActions(toolName, actions, args, env, ctx),
+    run: withValidatedArgs(toolName, schema, (args: ArgsOf<T>, env: Env, ctx: ToolContext) =>
+      runActions(toolName, actions, args, env, ctx)
+    ),
   };
 }
 

--- a/packages/server/src/tools/admin/manage_classifiers.ts
+++ b/packages/server/src/tools/admin/manage_classifiers.ts
@@ -27,6 +27,7 @@ import {
 import logger from '../../utils/logger';
 import { resolveUsernames } from '../../utils/resolve-usernames';
 import type { ToolContext } from '../registry';
+import { withValidatedArgs } from '../validate-args';
 import { defineFlatActionTool, flatAction } from './action-tool';
 
 // ============================================
@@ -240,19 +241,20 @@ function stripEmbeddingsFromAttributeValues(
 // Main Function (Action Router)
 // ============================================
 
-export const manageClassifiers = defineFlatActionTool<
-  ManageClassifiersArgs,
-  ManageClassifiersResult
->('manage_classifiers', {
-  create: flatAction((args, ctx, env) => handleCreate(args, env, ctx)),
-  create_version: flatAction((args, ctx, env) => handleCreateVersion(args, env, ctx)),
-  list: flatAction(handleList),
-  get_versions: flatAction(handleGetVersions),
-  set_current_version: flatAction(handleSetCurrentVersion),
-  generate_embeddings: flatAction((args, ctx, env) => handleGenerateEmbeddings(args, env, ctx)),
-  delete: flatAction(handleDelete),
-  classify: flatAction(handleClassify),
-});
+export const manageClassifiers = withValidatedArgs(
+  'manage_classifiers',
+  ManageClassifiersSchema,
+  defineFlatActionTool<ManageClassifiersArgs, ManageClassifiersResult>('manage_classifiers', {
+    create: flatAction((args, ctx, env) => handleCreate(args, env, ctx)),
+    create_version: flatAction((args, ctx, env) => handleCreateVersion(args, env, ctx)),
+    list: flatAction(handleList),
+    get_versions: flatAction(handleGetVersions),
+    set_current_version: flatAction(handleSetCurrentVersion),
+    generate_embeddings: flatAction((args, ctx, env) => handleGenerateEmbeddings(args, env, ctx)),
+    delete: flatAction(handleDelete),
+    classify: flatAction(handleClassify),
+  })
+);
 
 // ============================================
 // Template CRUD Handlers

--- a/packages/server/src/tools/admin/manage_entity.ts
+++ b/packages/server/src/tools/admin/manage_entity.ts
@@ -47,6 +47,7 @@ import { trackWatcherReaction } from '../../utils/watcher-reactions';
 import { isAdminOrOwnerRole } from '../access-control';
 import { MEMBER_ENTITY_TYPE_SLUG } from '../constants';
 import type { ToolContext } from '../registry';
+import { withValidatedArgs } from '../validate-args';
 import { buildEntityViewUrl, getOrgUrlContext, toEntityInfo } from '../view-urls';
 import { defineFlatActionTool, flatAction } from './action-tool';
 import { SortOrderField } from './schemas/common-fields';
@@ -375,7 +376,13 @@ const runManageEntity = defineFlatActionTool<ManageEntityArgs, ManageEntityResul
   }
 );
 
-export async function manageEntity(
+export const manageEntity = withValidatedArgs(
+  'manage_entity',
+  ManageEntitySchema,
+  manageEntityImpl
+);
+
+async function manageEntityImpl(
   args: ManageEntityArgs,
   env: Env,
   ctx: ToolContext

--- a/packages/server/src/tools/admin/manage_entity_schema.ts
+++ b/packages/server/src/tools/admin/manage_entity_schema.ts
@@ -20,6 +20,7 @@ import { RESERVED_ENTITY_TYPES } from '../../utils/reserved';
 import { resolveUsernames } from '../../utils/resolve-usernames';
 import { ToolUserError } from '../../utils/errors';
 import type { ToolContext } from '../registry';
+import { withValidatedArgs } from '../validate-args';
 import { defineFlatActionTool, flatAction } from './action-tool';
 
 // ============================================
@@ -285,7 +286,13 @@ const runRelationshipTypeActions = defineFlatActionTool<
   list_rules: flatAction(rtHandleListRules),
 });
 
-export async function manageEntitySchema(
+export const manageEntitySchema = withValidatedArgs(
+  'manage_entity_schema',
+  ManageEntitySchemaSchema,
+  manageEntitySchemaImpl
+);
+
+async function manageEntitySchemaImpl(
   args: ManageEntitySchemaArgs,
   env: Env,
   ctx: ToolContext
@@ -365,10 +372,11 @@ function validateEntityMetadataSchemaDisplayConfig(
 }
 
 /**
- * Reject an empty/whitespace `backing.sql`. TypeBox's `minLength: 1` is not
- * enforced for this tool (it isn't in VALIDATED_TOOLS), so without this guard a
- * caller could persist a "derived" type whose view is blank — unqueryable and
- * with no inferable measures. `backing: null` (revert to stored) is fine.
+ * Reject an empty/whitespace `backing.sql`. TypeBox `minLength: 1` accepts a
+ * whitespace-only string, so boundary validation alone would let a caller
+ * persist a "derived" type whose view is blank — unqueryable and with no
+ * inferable measures. `backing: null` (revert to stored) is fine. The
+ * `[invalid_schema]`/422 error shape here is a contract `lobu apply` parses.
  */
 function assertValidBacking(backing: ManageEntitySchemaArgs['backing']): void {
   if (backing && typeof backing.sql === 'string' && backing.sql.trim() === '') {

--- a/packages/server/src/tools/admin/manage_schedules.ts
+++ b/packages/server/src/tools/admin/manage_schedules.ts
@@ -19,7 +19,6 @@
  */
 
 import { type Static, Type } from '@sinclair/typebox';
-import { TypeCompiler } from '@sinclair/typebox/compiler';
 import { action, defineActionTool } from './action-tool';
 import {
   createScheduledJob,
@@ -106,8 +105,6 @@ const CancelAction = Type.Object({
   id: Type.String({ format: 'uuid' }),
 });
 
-const createValidator = TypeCompiler.Compile(CreateAction);
-
 // ============================================
 // Handler
 // ============================================
@@ -133,10 +130,6 @@ async function handleCreate(
   args: Static<typeof CreateAction>,
   ctx: ToolContext
 ): Promise<ToolResult> {
-  if (!createValidator.Check(args)) {
-    const errs = [...createValidator.Errors(args)];
-    return { error: `Invalid args: ${errs.map((e) => `${e.path} ${e.message}`).join('; ')}` };
-  }
   const runAtDate = new Date(args.run_at);
   if (Number.isNaN(runAtDate.getTime())) {
     return { error: `run_at is not a valid ISO timestamp: ${args.run_at}` };

--- a/packages/server/src/tools/admin/manage_view_templates.ts
+++ b/packages/server/src/tools/admin/manage_view_templates.ts
@@ -12,6 +12,7 @@ import { ToolUserError } from '../../utils/errors';
 import { validateDataSourceQuery } from '../../utils/execute-data-sources';
 import { resolveUsernames } from '../../utils/resolve-usernames';
 import type { ToolContext } from '../registry';
+import { withValidatedArgs } from '../validate-args';
 import { defineFlatActionTool, flatAction } from './action-tool';
 
 // ============================================
@@ -110,15 +111,19 @@ type ManageViewTemplatesResult =
 // Main Function
 // ============================================
 
-export const manageViewTemplates = defineFlatActionTool<
-  ManageViewTemplatesArgs,
-  ManageViewTemplatesResult
->('manage_view_templates', {
-  set: flatAction(handleSet),
-  get: flatAction(handleGet),
-  rollback: flatAction(handleRollback),
-  remove_tab: flatAction(handleRemoveTab),
-});
+export const manageViewTemplates = withValidatedArgs(
+  'manage_view_templates',
+  ManageViewTemplatesSchema,
+  defineFlatActionTool<ManageViewTemplatesArgs, ManageViewTemplatesResult>(
+    'manage_view_templates',
+    {
+      set: flatAction(handleSet),
+      get: flatAction(handleGet),
+      rollback: flatAction(handleRollback),
+      remove_tab: flatAction(handleRemoveTab),
+    }
+  )
+);
 
 // ============================================
 // Helpers
@@ -147,31 +152,11 @@ async function verifyAccess(
 
   const rt = args.resource_type;
 
-  // Neither the SDK namespace path (action-call.ts) nor the REST/registry path
-  // (execute.ts only TypeBox-validates query_sdk/run_sdk) validates these args
-  // before the handler runs, so a missing/wrong-shaped call (e.g.
-  // `{ resource: 'entity' }`) reaches here with resource_type/resource_id
-  // undefined. For the entity branch that meant `WHERE id = Number(undefined)`
-  // → NaN → a raw `invalid input syntax for type bigint: "NaN"` Postgres error.
-  // Reject the bad shape with a clean ToolUserError instead.
-  if (rt !== 'entity_type' && rt !== 'entity') {
-    throw new ToolUserError(
-      `resource_type is required and must be 'entity' or 'entity_type' (got ${JSON.stringify(rt)})`
-    );
-  }
-
-  // Both branches below dereference resource_id; a missing one must fail
-  // handler-side, not reach the DB. (entity_type stringifies undefined to the
-  // literal "undefined" and queries by slug; entity coerces to NaN — both are
-  // rejected here so every shape fails consistently before any query.)
-  if (
-    args.resource_id === undefined ||
-    args.resource_id === null ||
-    String(args.resource_id).trim() === ''
-  ) {
-    throw new ToolUserError(
-      `resource_id is required (got ${JSON.stringify(args.resource_id)})`
-    );
+  // Boundary validation (`withValidatedArgs`) guarantees resource_type and
+  // resource_id are present and well-typed, but a whitespace-only string
+  // still satisfies the schema and would query for a blank slug.
+  if (String(args.resource_id).trim() === '') {
+    throw new ToolUserError(`resource_id is required (got ${JSON.stringify(args.resource_id)})`);
   }
 
   const id = rid(args);

--- a/packages/server/src/tools/admin/manage_watchers.ts
+++ b/packages/server/src/tools/admin/manage_watchers.ts
@@ -34,6 +34,7 @@ import {
 } from '../../utils/organization-access';
 import { WatcherExecutionConfigSchema } from './watcher-execution-config';
 import type { ToolContext } from '../registry';
+import { withValidatedArgs } from '../validate-args';
 import { defineFlatActionTool, flatAction } from './action-tool';
 import { requireWatcherAccess } from './manage_watchers/shared';
 import { handleCreate, handleUpdate, handleDelete, handleCreateFromVersion } from './manage_watchers/crud';
@@ -215,8 +216,8 @@ export const ManageWatchersSchema = Type.Object({
   model_config: Type.Optional(Type.Any({ description: '[create/update] AI model configuration' })),
   // Union with Null so `update` can clear a previously-saved config back to
   // NULL/defaults — omitted = unchanged, null = clear, object = replace. The
-  // object shape lives in WatcherExecutionConfigSchema (below) so it can also
-  // be compiled into a runtime validator (assertValidExecutionConfig).
+  // object shape lives in WatcherExecutionConfigSchema; the role-policy gate
+  // (assertValidExecutionConfig) stays in the CRUD handlers.
   execution_config: Type.Optional(Type.Union([Type.Null(), WatcherExecutionConfigSchema])),
   tags: Type.Optional(Type.Array(Type.String(), { description: '[create] Tags for filtering' })),
 
@@ -471,7 +472,13 @@ export const ListWatchersSchema = Type.Object({
 // Main Function
 // ============================================
 
-export async function manageWatchers(
+export const manageWatchers = withValidatedArgs(
+  'manage_watchers',
+  ManageWatchersSchema,
+  manageWatchersImpl
+);
+
+async function manageWatchersImpl(
   args: ManageWatchersArgs,
   env: Env,
   ctx: ToolContext
@@ -542,7 +549,13 @@ const runManageWatchers = defineFlatActionTool<ManageWatchersArgs, ManageWatcher
   }
 );
 
-export async function listWatchers(
+export const listWatchers = withValidatedArgs(
+  'list_watchers',
+  ListWatchersSchema,
+  listWatchersImpl
+);
+
+async function listWatchersImpl(
   args: ListWatchersArgs,
   env: Env,
   ctx: ToolContext

--- a/packages/server/src/tools/admin/metric_series.ts
+++ b/packages/server/src/tools/admin/metric_series.ts
@@ -26,6 +26,7 @@ import { ADMIN_ONLY_QUERYABLE_TABLES, SAFE_COLUMN_DEFS } from '../../utils/table
 import { ToolUserError } from '../../utils/errors';
 import logger from '../../utils/logger';
 import type { ToolContext } from '../registry';
+import { withValidatedArgs } from '../validate-args';
 import { isAdminOrOwnerRole } from '../access-control';
 
 export const MetricSeriesSchema = Type.Object({
@@ -51,7 +52,9 @@ export interface MetricSeriesResult {
   rows: unknown[][];
 }
 
-export async function metricSeries(
+export const metricSeries = withValidatedArgs('metric_series', MetricSeriesSchema, metricSeriesImpl);
+
+async function metricSeriesImpl(
   args: MetricSeriesArgs,
   _env: unknown,
   ctx: ToolContext

--- a/packages/server/src/tools/admin/query_sql.ts
+++ b/packages/server/src/tools/admin/query_sql.ts
@@ -15,6 +15,7 @@ import { raceAbort } from '../../utils/race-abort';
 import { ADMIN_ONLY_QUERYABLE_TABLES, SAFE_COLUMN_DEFS } from '../../utils/table-schema';
 import { getCachedMembershipRole, getCachedOrgBySlug } from '../../workspace/multi-tenant';
 import type { ToolContext } from '../registry';
+import { withValidatedArgs } from '../validate-args';
 import { SortOrderField } from './schemas/common-fields';
 import { isAdminOrOwnerRole } from '../access-control';
 
@@ -136,19 +137,14 @@ function errorResult(message: string, startTime: number): QuerySqlResult {
   };
 }
 
-export async function querySql(
+export const querySql = withValidatedArgs('query_sql', QuerySqlSchema, querySqlImpl);
+
+async function querySqlImpl(
   args: QuerySqlArgs,
   _env: unknown,
   ctx: ToolContext
 ): Promise<QuerySqlResult> {
   const startTime = Date.now();
-
-  if (!args || typeof args !== 'object') {
-    return errorResult('Tool arguments must be an object.', startTime);
-  }
-  if (typeof args.sql !== 'string') {
-    return errorResult('sql (string) is required.', startTime);
-  }
 
   const baseSql = args.sql.trim();
   if (!baseSql) return errorResult('SQL query is required.', startTime);

--- a/packages/server/src/tools/admin/watcher-execution-config.ts
+++ b/packages/server/src/tools/admin/watcher-execution-config.ts
@@ -1,15 +1,15 @@
 import { Type } from '@sinclair/typebox';
-import { TypeCompiler } from '@sinclair/typebox/compiler';
 import { ToolUserError } from '../../utils/errors';
 import { isAdminOrOwnerRole } from '../access-control';
 
 /**
  * Per-watcher device-worker CLI execution settings (stored as the
- * `watchers.execution_config` jsonb). Standalone so the same shape both feeds
- * ManageWatchersSchema and compiles into a runtime validator — manage_watchers
- * args are otherwise NOT schema-validated at the call boundary, and an
- * unvalidated, type-wrong value would silently fail the device-worker's strict
- * payload decode (bricking every run of that watcher).
+ * `watchers.execution_config` jsonb). Standalone so the shape can feed
+ * ManageWatchersSchema (where boundary validation enforces it) while the
+ * authorization gate below stays callable from the CRUD handlers. A
+ * type-wrong value would silently fail the device-worker's strict payload
+ * decode (bricking every run of that watcher), hence `additionalProperties:
+ * false` — a typo'd setting must be rejected, not stored and ignored.
  */
 export const WatcherExecutionConfigSchema = Type.Object(
   {
@@ -55,8 +55,6 @@ export const WatcherExecutionConfigSchema = Type.Object(
   }
 );
 
-const executionConfigValidator = TypeCompiler.Compile(WatcherExecutionConfigSchema);
-
 // Permission modes that let the spawned agent act unattended without prompting.
 // Restricted to org owner/admin: a member-write actor can pin a watcher to
 // another user's device, so allowing them to set these would be a privilege
@@ -71,23 +69,13 @@ export interface ExecutionConfigCaller {
 }
 
 /**
- * Validate an incoming `execution_config`. `undefined` = unchanged, `null` =
- * clear — both pass. An object is validated against the schema
- * (types/enums/range); elevated permission modes require owner/admin. Throws
- * ToolUserError on rejection.
+ * Authorize an incoming `execution_config`. `undefined` = unchanged, `null` =
+ * clear — both pass. Shape/type/range validation happens at the tool boundary
+ * (WatcherExecutionConfigSchema is embedded in ManageWatchersSchema); this
+ * gate only enforces the role policy, which a schema cannot express.
  */
 export function assertValidExecutionConfig(value: unknown, caller: ExecutionConfigCaller): void {
   if (value === undefined || value === null) return;
-  if (typeof value !== 'object' || Array.isArray(value)) {
-    throw new ToolUserError('execution_config must be a JSON object or null.');
-  }
-  if (!executionConfigValidator.Check(value)) {
-    const errs = [...executionConfigValidator.Errors(value)]
-      .slice(0, 5)
-      .map((e) => `${e.path || '/'}: ${e.message}`)
-      .join('; ');
-    throw new ToolUserError(`Invalid execution_config — ${errs}`);
-  }
   const mode = (value as { permission_mode?: string }).permission_mode;
   // System/internal callers (apply, automation, default-provisioning) carry no
   // memberRole and already bypass action-access enforcement; don't block them.

--- a/packages/server/src/tools/delete_content.ts
+++ b/packages/server/src/tools/delete_content.ts
@@ -26,6 +26,7 @@ import logger from '../utils/logger';
 import { isSystemContext } from './access-control';
 import { TOMBSTONE_SEMANTIC_TYPE } from './constants';
 import type { ToolContext } from './registry';
+import { withValidatedArgs } from './validate-args';
 
 const DeleteContentSchema = Type.Object({
   event_id: Type.Optional(
@@ -55,7 +56,13 @@ export interface DeleteContentResult {
   already_superseded_ids: number[];
 }
 
-export async function deleteContent(
+export const deleteContent = withValidatedArgs(
+  'delete_knowledge',
+  DeleteContentSchema,
+  deleteContentImpl
+);
+
+async function deleteContentImpl(
   args: DeleteContentArgs,
   _env: Env,
   ctx: ToolContext

--- a/packages/server/src/tools/execute.ts
+++ b/packages/server/src/tools/execute.ts
@@ -4,12 +4,11 @@
  * Used by both the MCP Streamable HTTP handler and the REST API proxy.
  */
 
-import { TypeCompiler, type TypeCheck } from '@sinclair/typebox/compiler';
 import type { Context } from 'hono';
 import { getRequiredAccessLevel, hasRequiredMcpScope, isPublicReadable } from '../auth/tool-access';
 import type { Env } from '../index';
 import { trackMCPToolCall } from '../sentry';
-import { ToolNotRegisteredError, ToolUserError } from '../utils/errors';
+import { ToolNotRegisteredError } from '../utils/errors';
 import { getConfiguredPublicOrigin } from '../utils/public-origin';
 import { enforceRoleScopeAccess } from './access-control';
 import { recordToolInvocationAudit } from './audit';
@@ -137,73 +136,13 @@ export function checkToolAccess(toolName: string, args: unknown, authCtx: AuthCo
 }
 
 /**
- * Tools whose args are TypeBox-validated at the boundary before the handler
- * runs. Deliberately narrow: only the two SDK-scripting tools where a missing
- * field produced an opaque internal stack trace
- * (`Cannot read properties of undefined (reading 'replace')` from the sandbox
- * compiler). The `manage_*` tools are intentionally NOT here — they carry
- * `_id: Type.Number` round-trip fields and `additionalProperties: false`
- * schemas that lenient handlers tolerated, so flipping strict validation on
- * for them could 400 previously-working external MCP calls. Widening this set
- * requires a per-tool audit — tracked in lobu#1137
- * ("Audit + enable global tool-arg validation safely").
- */
-const VALIDATED_TOOLS = new Set(['query_sdk', 'run_sdk']);
-
-/**
- * Per-tool compiled TypeBox validator cache.
- *
- * Tool registrations carry their TypeBox schema as `inputSchema`. Without
- * validating at the boundary, a missing/mistyped field tunnels into the
- * handler and surfaces as a stack trace from deep inside the implementation
- * (e.g. `query_sdk` without `script` exploded as
- * `Cannot read properties of undefined (reading 'replace')` from the sandbox
- * compiler). Compiling once and reusing is what every other validator in
- * this codebase does — see `manage_schedules.ts`, `watcher-execution-config.ts`.
- *
- * Tools whose schema isn't a TypeBox object (e.g. unusual hand-rolled JSON
- * Schema) fall back to no validation rather than crashing the boundary; the
- * handler stays responsible for its own input checks in that case.
- */
-const validatorCache = new Map<string, TypeCheck<any> | null>();
-
-function getValidator(toolName: string, schema: unknown): TypeCheck<any> | null {
-  if (validatorCache.has(toolName)) {
-    return validatorCache.get(toolName) ?? null;
-  }
-  let validator: TypeCheck<any> | null = null;
-  try {
-    validator = TypeCompiler.Compile(schema as any);
-  } catch {
-    validator = null;
-  }
-  validatorCache.set(toolName, validator);
-  return validator;
-}
-
-function validateToolArgs(toolName: string, schema: unknown, args: unknown): void {
-  if (!schema || typeof schema !== 'object') return;
-  const validator = getValidator(toolName, schema);
-  if (!validator) return;
-  if (validator.Check(args)) return;
-  // Deduplicate by path — TypeBox emits both `Expected required property` and
-  // `Expected <type>` against the same missing field, which would otherwise
-  // duplicate the field name in the error message.
-  const seen = new Set<string>();
-  const errs: string[] = [];
-  for (const e of validator.Errors(args)) {
-    const path = e.path || '/';
-    if (seen.has(path)) continue;
-    seen.add(path);
-    errs.push(`${path}: ${e.message}`);
-    if (errs.length >= 3) break;
-  }
-  throw new ToolUserError(`Invalid arguments for ${toolName}: ${errs.join('; ')}`);
-}
-
-/**
  * Execute a tool by name with access control and Sentry tracking.
  * Returns the raw tool result (caller decides formatting).
+ *
+ * Arg validation does NOT live here: every registered handler is wrapped
+ * with `withValidatedArgs` at its definition (`tools/validate-args.ts`), so
+ * direct REST calls and the sandbox SDK namespaces get the same coerce +
+ * validate behavior as this path (lobu#1137).
  */
 export async function executeTool(
   toolName: string,
@@ -231,23 +170,6 @@ export async function executeTool(
   const tool = getTool(toolName)!;
   const toolContext = toToolContext(authCtx);
   const startTime = Date.now();
-
-  // Validate args against the tool's TypeBox schema BEFORE the handler runs,
-  // so a missing/mistyped field returns a clean 400 with the offending name
-  // rather than a stack-trace from deep inside the handler.
-  //
-  // Scoped to `query_sdk`/`run_sdk` only — the two tools that produced the
-  // user-visible failure this fix targets (a missing `script` exploded as
-  // `Cannot read properties of undefined (reading 'replace')` from inside the
-  // sandbox compiler). Enabling strict validation across ALL tools at once is
-  // a much wider blast radius: several `manage_*` tools have `_id: Type.Number`
-  // fields and `additionalProperties: false` schemas that lenient handlers
-  // historically tolerated, and live external MCP clients may rely on that.
-  // Rolling validation out globally needs a per-tool round-trip audit first —
-  // tracked in lobu#1137.
-  if (VALIDATED_TOOLS.has(toolName)) {
-    validateToolArgs(toolName, tool.inputSchema, args);
-  }
 
   try {
     const result = await trackMCPToolCall(toolName, args, () => tool.handler(args, env, toolContext));

--- a/packages/server/src/tools/get_content/handler.ts
+++ b/packages/server/src/tools/get_content/handler.ts
@@ -31,15 +31,18 @@ import {
   fetchIncludeSuperseded,
 } from './query';
 import { buildContentItems, fetchClassificationExcerpts } from './render';
-import { type GetContentArgs, getIncludeSupersededValidationErrors } from './schema';
+import { GetContentSchema, type GetContentArgs, getIncludeSupersededValidationErrors } from './schema';
 import type { ContentRow, GetContentResult, IdRow } from './types';
 import { handleWatcherMode } from './watcher-mode';
+import { withValidatedArgs } from '../validate-args';
 
 // ============================================
 // Main Function
 // ============================================
 
-export async function getContent(
+export const getContent = withValidatedArgs('read_knowledge', GetContentSchema, getContentImpl);
+
+async function getContentImpl(
   args: GetContentArgs,
   env: Env,
   ctx: ToolContext

--- a/packages/server/src/tools/get_watchers.ts
+++ b/packages/server/src/tools/get_watchers.ts
@@ -48,6 +48,7 @@ import {
 import { buildLatestWatcherRunJoinSql } from '../watchers/automation';
 import { getWorkspaceProvider } from '../workspace';
 import type { ToolContext } from './registry';
+import { withValidatedArgs } from './validate-args';
 
 // ============================================
 // Typebox Schema
@@ -319,7 +320,9 @@ async function requireWatcherReadAccess(
 // Tool Implementation
 // ============================================
 
-export async function getWatcher(
+export const getWatcher = withValidatedArgs('get_watcher', GetWatcherSchema, getWatcherImpl);
+
+async function getWatcherImpl(
   args: GetWatcherArgs,
   env: Env,
   ctx: ToolContext

--- a/packages/server/src/tools/organizations.ts
+++ b/packages/server/src/tools/organizations.ts
@@ -16,6 +16,7 @@ import { type Static, Type } from '@sinclair/typebox';
 import type { Env } from '../index';
 import { getWorkspaceProvider } from '../workspace';
 import type { OrgInfo } from '../workspace/types';
+import { withValidatedArgs } from './validate-args';
 
 export const ListOrganizationsSchema = Type.Object({
   search: Type.Optional(
@@ -23,7 +24,13 @@ export const ListOrganizationsSchema = Type.Object({
   ),
 });
 
-export async function listOrganizations(
+export const listOrganizations = withValidatedArgs(
+  'list_organizations',
+  ListOrganizationsSchema,
+  listOrganizationsImpl
+);
+
+async function listOrganizationsImpl(
   args: Static<typeof ListOrganizationsSchema>,
   _env: Env,
   ctx: { userId: string; currentOrganizationId: string | null }

--- a/packages/server/src/tools/resolve_path.ts
+++ b/packages/server/src/tools/resolve_path.ts
@@ -25,6 +25,7 @@ import { getWorkspaceProvider } from '../workspace';
 import { isAdminOrOwnerRole } from './access-control';
 import { MEMBER_ENTITY_TYPE_SLUG } from './constants';
 import type { ToolContext } from './registry';
+import { withValidatedArgs } from './validate-args';
 
 export const ResolvePathSchema = Type.Object({
   path: Type.String({
@@ -261,16 +262,15 @@ function parsePathAndQuery(rawPath: string): { path: string; query: Record<strin
   return { path, query };
 }
 
-export function resolvePath(
-  args: ResolvePathArgs,
-  _env: Env,
-  ctx: ToolContext
-): Promise<ResolvePathResult> {
-  return Sentry.startSpan(
-    { name: 'resolve_path', op: 'function', attributes: { path: args.path } },
-    () => _resolvePath(args, ctx)
-  );
-}
+export const resolvePath = withValidatedArgs(
+  'resolve_path',
+  ResolvePathSchema,
+  (args: ResolvePathArgs, _env: Env, ctx: ToolContext): Promise<ResolvePathResult> =>
+    Sentry.startSpan(
+      { name: 'resolve_path', op: 'function', attributes: { path: args.path } },
+      () => _resolvePath(args, ctx)
+    )
+);
 
 async function _resolvePath(
   args: ResolvePathArgs,

--- a/packages/server/src/tools/save_content.ts
+++ b/packages/server/src/tools/save_content.ts
@@ -23,6 +23,7 @@ import { trackWatcherReaction } from '../utils/watcher-reactions';
 import { isSystemContext } from './access-control';
 import { MEMBER_ENTITY_TYPE_SLUG } from './constants';
 import type { ToolContext } from './registry';
+import { withValidatedArgs } from './validate-args';
 import { buildEventViewUrl } from './view-urls';
 
 // ============================================
@@ -129,7 +130,9 @@ interface SaveContentResult {
 // Handler
 // ============================================
 
-export async function saveContent(
+export const saveContent = withValidatedArgs('save_memory', SaveContentSchema, saveContentImpl);
+
+async function saveContentImpl(
   args: SaveContentArgs,
   _env: Env,
   ctx: ToolContext

--- a/packages/server/src/tools/sdk_run.ts
+++ b/packages/server/src/tools/sdk_run.ts
@@ -3,6 +3,7 @@ import type { Env } from "../index";
 import { buildClientSDK, type SDKMode } from "../sandbox/client-sdk";
 import { runScript } from "../sandbox/run-script";
 import type { ToolContext } from "./registry";
+import { withValidatedArgs } from "./validate-args";
 
 const SCRIPT_FIELDS = {
   script: Type.String({
@@ -66,8 +67,14 @@ async function runSandbox(
   };
 }
 
-export const runSdkScript = (args: RunArgs, env: Env, ctx: ToolContext) =>
-  runSandbox("full", args, env, ctx);
+export const runSdkScript = withValidatedArgs(
+  "run_sdk",
+  RunSchema,
+  (args: RunArgs, env: Env, ctx: ToolContext) => runSandbox("full", args, env, ctx),
+);
 
-export const querySdkScript = (args: QueryArgs, env: Env, ctx: ToolContext) =>
-  runSandbox("read", args, env, ctx);
+export const querySdkScript = withValidatedArgs(
+  "query_sdk",
+  QuerySchema,
+  (args: QueryArgs, env: Env, ctx: ToolContext) => runSandbox("read", args, env, ctx),
+);

--- a/packages/server/src/tools/sdk_search.ts
+++ b/packages/server/src/tools/sdk_search.ts
@@ -8,6 +8,7 @@ import { type Static, Type } from "@sinclair/typebox";
 import type { Env } from "../index";
 import { METHOD_METADATA, type MethodMetadata } from "../sandbox/method-metadata";
 import type { ToolContext } from "./registry";
+import { withValidatedArgs } from "./validate-args";
 
 export const SdkSearchSchema = Type.Object({
   query: Type.String({
@@ -62,7 +63,9 @@ function renderDrillDown(path: string, meta: MethodMetadata): string {
   return lines.join("\n");
 }
 
-export async function sdkSearch(
+export const sdkSearch = withValidatedArgs("search_sdk", SdkSearchSchema, sdkSearchImpl);
+
+async function sdkSearchImpl(
   args: SdkSearchArgs,
   _env: Env,
   _ctx: ToolContext,

--- a/packages/server/src/tools/search.ts
+++ b/packages/server/src/tools/search.ts
@@ -18,6 +18,7 @@ import { expandSearchQueries } from '../utils/query-expansion';
 import { buildEntityUrl, getPublicWebUrl } from '../utils/url-builder';
 import { getWorkspaceProvider } from '../workspace';
 import type { ToolContext } from './registry';
+import { withValidatedArgs } from './validate-args';
 
 // ============================================
 // Typebox Schema
@@ -300,7 +301,9 @@ async function fetchContentSnippets(
   }));
 }
 
-export async function search(
+export const search = withValidatedArgs('search_memory', SearchSchema, searchImpl);
+
+async function searchImpl(
   args: SearchArgs,
   env: Env,
   ctx: ToolContext

--- a/packages/server/src/tools/validate-args.ts
+++ b/packages/server/src/tools/validate-args.ts
@@ -1,0 +1,187 @@
+/**
+ * Single chokepoint for tool-arg validation (lobu#1137).
+ *
+ * Tool handlers are wrapped with `withValidatedArgs` at their definition
+ * (`defineActionTool`) or export site, so every entry path — executeTool
+ * (MCP + REST), direct REST handler calls, and the sandbox SDK namespaces —
+ * runs the same coerce-then-validate pipeline. This is deliberately a leaf
+ * module (typebox + errors only): the registry imports tool modules which
+ * import the sandbox namespaces, so anything heavier here would close an
+ * import cycle.
+ *
+ * Coercion before validation (`Value.Convert`) is load-bearing: the callers
+ * of this boundary are LLMs and external MCP clients,
+ * and the historical failure class was round-trip type drift (a list action
+ * returns `watcher_id` as a number, the update schema gates on Type.String —
+ * see #1131). Coercing `123` → `"123"` and `"5"` → `5` makes that whole
+ * class a non-issue instead of a per-tool audit.
+ */
+
+import type { TSchema } from '@sinclair/typebox';
+import { FormatRegistry } from '@sinclair/typebox';
+import { TypeCompiler, type TypeCheck } from '@sinclair/typebox/compiler';
+import { Value } from '@sinclair/typebox/value';
+import { ToolUserError } from '../utils/errors';
+
+// typebox's Value.Check FAILS (returns false) on any `format` constraint that
+// isn't registered — there is no permissive default. `manage_schedules` gates
+// ids with `format: 'uuid'`, so without this registration every pause/cancel
+// would 400 the moment validation runs.
+if (!FormatRegistry.Has('uuid')) {
+  FormatRegistry.Set('uuid', (value) =>
+    /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(value)
+  );
+}
+
+interface SchemaWithVariants {
+  anyOf?: Array<{ properties?: { action?: { const?: unknown } } }>;
+}
+
+/**
+ * For a `Type.Union` of per-action variants, validation must dispatch on the
+ * `action` literal and check ONLY the matched variant: the schema advertised
+ * to MCP clients is the FLATTENED union (registry `flattenUnionSchema`), so a
+ * call that is valid against the advertised schema can carry fields from any
+ * variant — naive full-union checking would reject it, and TypeBox's union
+ * errors ("Expected union value") name no field anyway.
+ */
+function unionVariants(schema: TSchema): TSchema[] | null {
+  const anyOf = (schema as SchemaWithVariants).anyOf;
+  if (!Array.isArray(anyOf) || anyOf.length === 0) return null;
+  if (!anyOf.every((v) => v.properties?.action?.const !== undefined)) return null;
+  return anyOf as unknown as TSchema[];
+}
+
+function actionOf(variant: TSchema): string {
+  return String(
+    (variant as { properties?: { action?: { const?: unknown } } }).properties?.action?.const
+  );
+}
+
+/**
+ * Normalize in-process arg values to their wire (JSON) equivalents before
+ * coercion. Wire callers can only send JSON, but direct callers (REST param
+ * builders, sandbox namespaces, tests feeding a tool's output back into its
+ * input) pass richer values that JSON.stringify would have flattened:
+ *
+ * - Keys with `undefined` values mean "absent" and are dropped —
+ *   `Value.Convert` would wrap an explicitly-undefined Optional(Array) key
+ *   into `[undefined]` and fail validation. Array ELEMENTS are not dropped;
+ *   an `undefined` element is a genuine caller bug and must fail.
+ * - `Date` instances become ISO strings — e.g. read_knowledge returns
+ *   `occurred_at` as a Date and its own cursor inputs
+ *   (`before_occurred_at`) are Type.String; the list→page round trip must
+ *   survive validation.
+ */
+function normalizeArgs(value: unknown): unknown {
+  if (value instanceof Date) return value.toISOString();
+  if (Array.isArray(value)) return value.map(normalizeArgs);
+  if (value && typeof value === 'object') {
+    const proto = Object.getPrototypeOf(value);
+    if (proto === Object.prototype || proto === null) {
+      const out: Record<string, unknown> = {};
+      for (const [k, v] of Object.entries(value)) {
+        if (v !== undefined) out[k] = normalizeArgs(v);
+      }
+      return out;
+    }
+  }
+  return value;
+}
+
+const compiledCache = new Map<TSchema, TypeCheck<TSchema>>();
+
+function compileSchema(schema: TSchema): TypeCheck<TSchema> {
+  let compiled = compiledCache.get(schema);
+  if (!compiled) {
+    compiled = TypeCompiler.Compile(schema);
+    compiledCache.set(schema, compiled);
+  }
+  return compiled;
+}
+
+function checkAgainst(toolName: string, schema: TSchema, args: unknown): unknown {
+  // Convert returns a coerced copy — the handler must receive it, otherwise
+  // coercion would satisfy the validator but the handler would still see the
+  // raw value. Deliberately NO `Value.Default`: schema `default:` annotations
+  // are client-facing documentation, and handlers apply their own defaults
+  // via `??`. Materializing them here changes behavior — e.g. read_knowledge
+  // declares `sort_by: { default: 'score' }` while its include_superseded
+  // path requires sort_by to be UNSET; injecting the default broke it.
+  const coerced = Value.Convert(schema, normalizeArgs(args));
+  const validator = compileSchema(schema);
+  if (validator.Check(coerced)) return coerced;
+
+  // Deduplicate by path — TypeBox emits both `Expected required property` and
+  // `Expected <type>` against the same missing field, which would otherwise
+  // duplicate the field name in the error message.
+  const seen = new Set<string>();
+  const errs: string[] = [];
+  for (const e of validator.Errors(coerced)) {
+    const path = e.path || '/';
+    if (seen.has(path)) continue;
+    seen.add(path);
+    errs.push(`${path}: ${e.message}`);
+    if (errs.length >= 3) break;
+  }
+  throw new ToolUserError(`Invalid arguments for ${toolName}: ${errs.join('; ')}`);
+}
+
+/**
+ * Validate (and coerce) `args` against a tool's TypeBox input schema.
+ * Returns the value the handler must receive. Throws `ToolUserError` (400)
+ * naming the offending fields on mismatch.
+ */
+export function validateToolArgs(toolName: string, schema: TSchema, args: unknown): unknown {
+  const variants = unionVariants(schema);
+  if (variants) {
+    const action =
+      args && typeof args === 'object' ? (args as Record<string, unknown>).action : undefined;
+    const variant = variants.find((v) => actionOf(v) === action);
+    if (!variant) {
+      const actions = variants.map(actionOf).join(', ');
+      throw new ToolUserError(
+        `Invalid arguments for ${toolName}: action must be one of: ${actions} (got ${JSON.stringify(action)})`
+      );
+    }
+    return checkAgainst(toolName, variant, args);
+  }
+  return checkAgainst(toolName, schema, args);
+}
+
+const VALIDATED_BRAND = Symbol.for('lobu.validated-tool-handler');
+
+interface BrandedHandler {
+  [VALIDATED_BRAND]?: string;
+}
+
+/** The tool name a handler was wrapped for, or undefined if unwrapped. */
+export function validatedToolName(handler: unknown): string | undefined {
+  return (handler as BrandedHandler)?.[VALIDATED_BRAND];
+}
+
+/**
+ * Wrap a tool handler so its first argument is coerced + validated against
+ * `schema` before the handler runs. Signature-preserving: remaining params
+ * are forwarded untouched, so it fits both the registry `(args, env, ctx)`
+ * shape and divergent ones like `listOrganizations`. Compiles eagerly — a
+ * schema TypeCompiler can't handle must explode at module load, not silently
+ * skip validation at call time.
+ */
+export function withValidatedArgs<A, R extends unknown[], T>(
+  toolName: string,
+  schema: TSchema,
+  handler: (args: A, ...rest: R) => Promise<T>
+): (args: A, ...rest: R) => Promise<T> {
+  for (const s of unionVariants(schema) ?? [schema]) {
+    compileSchema(s);
+  }
+  // `async` so a validation failure REJECTS the returned promise instead of
+  // throwing synchronously — callers (`await`, `.rejects`, .catch chains)
+  // treat tool handlers as promise-returning and a sync throw would escape
+  // them.
+  const wrapped = async (args: A, ...rest: R): Promise<T> =>
+    handler(validateToolArgs(toolName, schema, args) as A, ...rest);
+  (wrapped as BrandedHandler)[VALIDATED_BRAND] = toolName;
+  return wrapped;
+}


### PR DESCRIPTION
## Summary

Closes #1137.

Every registered tool handler is wrapped with `withValidatedArgs` (new `tools/validate-args.ts`) at its definition (`defineActionTool`) or export site, so all three entry paths — `executeTool` (MCP + REST), direct REST handler calls, and the sandbox SDK namespaces via `createActionCaller` — run the same coerce-then-validate pipeline. Previously validation ran for exactly 2 of ~23 tools on one of three paths; bad args tunneled into handlers and surfaced as `invalid input syntax for type bigint: "NaN"` Postgres errors or sandbox-compiler stack traces, and individual PRs kept hand-rolling per-tool guards (#1184, `assertValidBacking`).

## Design

- **Coerce, then validate.** `Value.Convert` runs before the compiled `Check`, so the round-trip type-drift class (#1131's `watcher_id`: list returns a number, update gates on `Type.String`) is absorbed wholesale instead of audited per tool. `'5'` → `5`, `123` → `'123'`.
- **Union-aware.** `Type.Union` action schemas dispatch on the `action` literal and validate the matched variant only — required because MCP clients see the *flattened* union from `flattenUnionSchema`, and because TypeBox union errors name no field. Unknown action → 400 listing valid actions.
- **Wrap at handler definition, not the registry.** Sandbox namespaces import handler functions directly, and wrapping in the registry would close an import cycle (`registry → sdk_run → client-sdk → namespaces → registry`). A registry completeness test (symbol brand) prevents unwrapped tools from being registered.
- **`uuid` format registered.** typebox 0.34 fails `Check` on unregistered formats; without this every `manage_schedules` pause/cancel would 400.
- **In-process args normalized to wire equivalents.** `undefined`-valued keys dropped (REST `{key: cond ? v : undefined}` builders; `Value.Convert` otherwise wraps an undefined Optional(Array) into `[undefined]`), `Date` → ISO string (read_knowledge's own `occurred_at` output feeds its `before_occurred_at` cursor input).
- **No `Value.Default`.** Schema `default:` annotations stay client-facing docs; handlers own defaulting. Materializing them broke read_knowledge (`sort_by: {default: 'score'}` vs the include_superseded path requiring it unset).
- **`additionalProperties: false` stays strict** (`manage_entity_schema`, `watcher-execution-config`) — in schema-authoring tools, silently dropping a typo'd key is worse than a 400. Decision recorded per #1137's acceptance criteria.

## Deleted

- `VALIDATED_TOOLS` gate + validator plumbing in `execute.ts`
- #1184's hand-rolled `resource_type`/`resource_id` shape guards in `manage_view_templates` (whitespace + NaN cross-field checks kept — schemas can't express them)
- Standalone `TypeCompiler` validators in `manage_schedules` and `watcher-execution-config` (`WatcherExecutionConfigSchema` is embedded in `ManageWatchersSchema`, so the boundary now enforces it; the role-policy gate stays)
- Dead `requires` plumbing in `defineActionTool` (schema-declared required fields cover it)

## Behavior changes

- Invalid args now 400 with the offending field name (`Invalid arguments for manage_feeds: /feed_id: Expected number`) on **all** tools and **all** paths, including `query_sdk`/`run_sdk` scripts calling SDK namespaces.
- `query_sql` shape errors throw `ToolUserError` instead of resolving to a structured `{error}` result; `manage_schedules` invalid create likewise.
- Numeric-string fields coerce instead of erroring (e.g. `execution_config.timeout_seconds: '600'` → `600`).

## Validation

- `make typecheck` clean; unit suite 338 pass; **full vitest integration suite under Node 22: 122 files, 1032 tests, 0 failures**.
- New unit coverage: coercion both directions, union variant dispatch, unknown action, `additionalProperties:false`, uuid format, explicit-undefined keys, undefined Optional(Array), null-for-optional rejection, error-path dedup, registry completeness.
- Red→green during development: the boundary itself caught the `[undefined]` Convert hazard (watchers-crud), the `Value.Default` regression (get-content suites), and the schema/handler drift in `manage_entity_schema` (`schema_type` required but omitted by the e2e fixture).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1234"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783883942&installation_id=136316292&pr_number=1234&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1234&signature=a0bce730ce65148e2a526a6fd92255407d5782e64e7ae7218f212fb9c6e20f73"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->