### PR TITLE
fix: resolve mcp credentials in worker org context

### DIFF
--- a/packages/server/src/gateway/__tests__/interaction-bridge-action-handlers.test.ts
+++ b/packages/server/src/gateway/__tests__/interaction-bridge-action-handlers.test.ts
@@ -81,6 +81,7 @@ const PENDING: PendingToolInvocation = {
   args: { title: "hi" },
   agentId: "agent-1",
   userId: "user-1",
+	organizationId: "org-1",
 };
 
 async function seedPending(requestId: string): Promise<void> {
@@ -127,6 +128,7 @@ describe("registerActionHandlers — tool approval", () => {
       "github",
       "create_issue",
       { title: "hi" },
+			{ organizationId: "org-1" },
     ]);
 
     expect(h.post).toHaveBeenCalledWith("issue #42");

--- a/packages/server/src/gateway/__tests__/interaction-bridge-slack-webhook.test.ts
+++ b/packages/server/src/gateway/__tests__/interaction-bridge-slack-webhook.test.ts
@@ -102,6 +102,7 @@ describe("Slack block_actions → registerActionHandlers (Tier B integration)", 
       args: { title: "from slack" },
       agentId: "agent-1",
       userId: "user-1",
+			organizationId: "org-1",
     };
     await storePendingTool("req-slack-1", pending, 24 * 60 * 60);
 
@@ -184,6 +185,7 @@ describe("Slack block_actions → registerActionHandlers (Tier B integration)", 
       args: {},
       agentId: "a",
       userId: "u",
+			organizationId: "org-1",
     };
     await storePendingTool("req-bad", pending, 24 * 60 * 60);
 

--- a/packages/server/src/gateway/__tests__/mcp-oauth-org-context.test.ts
+++ b/packages/server/src/gateway/__tests__/mcp-oauth-org-context.test.ts
@@ -43,6 +43,9 @@ class OrgScopedWritableStore implements WritableSecretStore {
 	}
 
 	async delete(nameOrRef: string): Promise<void> {
+		if (tryGetOrgId() !== this.organizationId) {
+			throw new Error("test secret delete missing org context");
+		}
 		const name = nameOrRef.startsWith("secret://")
 			? decodeURIComponent(nameOrRef.slice("secret://".length))
 			: nameOrRef;

--- a/packages/server/src/gateway/__tests__/mcp-oauth-org-context.test.ts
+++ b/packages/server/src/gateway/__tests__/mcp-oauth-org-context.test.ts
@@ -119,4 +119,37 @@ describe("MCP OAuth org context", () => {
 			"oauth-access-token",
 		);
 	});
+
+	test("callback rejects OAuth state missing organizationId before token exchange", async () => {
+		const store = new OrgScopedWritableStore("org-oauth-callback-test");
+		statePayload = {
+			userId: "user-oauth",
+			agentId: "agent-oauth",
+			codeVerifier: "verifier",
+			mcpId: "oauth-mcp",
+			scopeKey: "user-oauth",
+			endpoints: { tokenEndpoint: "https://issuer.example/oauth/token" },
+			client: { clientId: "client-id", tokenEndpointAuthMethod: "none" },
+			platform: "slack",
+			channelId: "channel",
+			conversationId: "conversation",
+		};
+		const fetchMock = mock(() =>
+			Response.json({
+				access_token: "oauth-access-token",
+			}),
+		);
+		globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+		const { completeAuthCodeFlow } = await import("../auth/mcp/oauth-flow.js");
+		await expect(
+			completeAuthCodeFlow({
+				secretStore: store,
+				state: "state-token",
+				code: "code",
+				redirectUri: "https://gateway.example/mcp/oauth/callback",
+			}),
+		).rejects.toThrow("OAuth state missing organizationId");
+		expect(fetchMock).not.toHaveBeenCalled();
+	});
 });

--- a/packages/server/src/gateway/__tests__/mcp-oauth-org-context.test.ts
+++ b/packages/server/src/gateway/__tests__/mcp-oauth-org-context.test.ts
@@ -1,0 +1,119 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import type { SecretRef } from "@lobu/core";
+import { orgContext, tryGetOrgId } from "../../lobu/stores/org-context.js";
+import type { SecretListEntry, WritableSecretStore } from "../secrets/index.js";
+
+let statePayload: Record<string, unknown> | null = null;
+
+mock.module("../auth/oauth/state-store.js", () => ({
+	OAuthStateStore: class {
+		async create(data: Record<string, unknown>) {
+			statePayload = data;
+			return "state-token";
+		}
+
+		async peek() {
+			return statePayload ? { ...statePayload, createdAt: Date.now() } : null;
+		}
+
+		async consume() {
+			return statePayload ? { ...statePayload, createdAt: Date.now() } : null;
+		}
+	},
+}));
+
+class OrgScopedWritableStore implements WritableSecretStore {
+	private readonly entries = new Map<string, string>();
+
+	constructor(private readonly organizationId: string) {}
+
+	async get(ref: SecretRef): Promise<string | null> {
+		if (tryGetOrgId() !== this.organizationId) return null;
+		if (!ref.startsWith("secret://")) return null;
+		const name = decodeURIComponent(ref.slice("secret://".length));
+		return this.entries.get(name) ?? null;
+	}
+
+	async put(name: string, value: string): Promise<SecretRef> {
+		if (tryGetOrgId() !== this.organizationId) {
+			throw new Error("test secret write missing org context");
+		}
+		this.entries.set(name, value);
+		return `secret://${encodeURIComponent(name)}` as SecretRef;
+	}
+
+	async delete(nameOrRef: string): Promise<void> {
+		const name = nameOrRef.startsWith("secret://")
+			? decodeURIComponent(nameOrRef.slice("secret://".length))
+			: nameOrRef;
+		this.entries.delete(name);
+	}
+
+	async list(prefix?: string): Promise<SecretListEntry[]> {
+		if (tryGetOrgId() !== this.organizationId) return [];
+		return Array.from(this.entries.keys())
+			.filter((name) => !prefix || name.startsWith(prefix))
+			.map((name) => ({
+				ref: `secret://${encodeURIComponent(name)}` as SecretRef,
+				backend: "memory",
+				name,
+				updatedAt: Date.now(),
+			}));
+	}
+}
+
+describe("MCP OAuth org context", () => {
+	const originalFetch = globalThis.fetch;
+
+	afterEach(() => {
+		statePayload = null;
+		globalThis.fetch = originalFetch;
+		mock.restore();
+	});
+
+	test("callback stores credentials in the organization persisted in OAuth state", async () => {
+		const orgId = "org-oauth-callback-test";
+		const agentId = "agent-oauth";
+		const userId = "user-oauth";
+		const mcpId = "oauth-mcp";
+		const store = new OrgScopedWritableStore(orgId);
+		statePayload = {
+			userId,
+			agentId,
+			organizationId: orgId,
+			codeVerifier: "verifier",
+			mcpId,
+			scopeKey: userId,
+			endpoints: { tokenEndpoint: "https://issuer.example/oauth/token" },
+			client: { clientId: "client-id", tokenEndpointAuthMethod: "none" },
+			platform: "slack",
+			channelId: "channel",
+			conversationId: "conversation",
+		};
+		globalThis.fetch = async () =>
+			Response.json({
+				access_token: "oauth-access-token",
+				refresh_token: "oauth-refresh-token",
+				expires_in: 3600,
+			});
+
+		const { completeAuthCodeFlow } = await import("../auth/mcp/oauth-flow.js");
+		await completeAuthCodeFlow({
+			secretStore: store,
+			state: "state-token",
+			code: "code",
+			redirectUri: "https://gateway.example/mcp/oauth/callback",
+		});
+
+		const credential = await orgContext.run({ organizationId: orgId }, () =>
+			store.get(
+				`secret://${encodeURIComponent(
+					`mcp-auth/${agentId}/${userId}/${mcpId}/credential`,
+				)}` as SecretRef,
+			),
+		);
+		expect(JSON.parse(credential ?? "{}").accessToken).toBe(
+			"oauth-access-token",
+		);
+	});
+});

--- a/packages/server/src/gateway/__tests__/mcp-proxy-edge-cases.test.ts
+++ b/packages/server/src/gateway/__tests__/mcp-proxy-edge-cases.test.ts
@@ -134,10 +134,12 @@ beforeAll(async () => {
   agent1Token = generateWorkerToken("user1", "conv1", "deploy1", {
     channelId: "ch1",
     agentId: "agent1",
+		organizationId: "test-org",
   });
   agent2Token = generateWorkerToken("user2", "conv2", "deploy2", {
     channelId: "ch2",
     agentId: "agent2",
+		organizationId: "test-org",
   });
 });
 
@@ -964,7 +966,8 @@ describe("executeToolDirect", () => {
       "user1",
       "direct-mcp",
       "some_tool",
-      { arg1: "val1" }
+			{ arg1: "val1" },
+			{ organizationId: "org-1" },
     );
 
     expect(result.isError).toBe(false);
@@ -982,7 +985,8 @@ describe("executeToolDirect", () => {
       "user1",
       "nonexistent-mcp",
       "some_tool",
-      {}
+			{},
+			{ organizationId: "org-1" },
     );
 
     expect(result.isError).toBe(true);
@@ -1009,7 +1013,8 @@ describe("executeToolDirect", () => {
       "user1",
       "flaky-mcp",
       "any_tool",
-      {}
+			{},
+			{ organizationId: "org-1" },
     );
 
     expect(result.isError).toBe(true);

--- a/packages/server/src/gateway/__tests__/mcp-proxy-org-context.test.ts
+++ b/packages/server/src/gateway/__tests__/mcp-proxy-org-context.test.ts
@@ -292,7 +292,12 @@ describe("McpProxy org context", () => {
 		);
 
 		expect(tools.map((tool) => tool.name)).toEqual(["list_repos"]);
-		expect(capturedAuthorizations.every((value) => value === "Bearer discovery-access-token")).toBe(true);
+		expect(capturedAuthorizations.length).toBeGreaterThan(0);
+		expect(
+			capturedAuthorizations.every(
+				(value) => value === "Bearer discovery-access-token",
+			),
+		).toBe(true);
 	});
 
 	test("approved tool execution resolves credentials from the pending invocation organization", async () => {

--- a/packages/server/src/gateway/__tests__/mcp-proxy-org-context.test.ts
+++ b/packages/server/src/gateway/__tests__/mcp-proxy-org-context.test.ts
@@ -1,0 +1,135 @@
+import { afterAll, afterEach, beforeAll, describe, expect, test } from "bun:test";
+import { encrypt, type SecretRef, type WorkerTokenData } from "@lobu/core";
+import { tryGetOrgId } from "../../lobu/stores/org-context.js";
+import { McpProxy } from "../auth/mcp/proxy.js";
+import type { SecretListEntry, WritableSecretStore } from "../secrets/index.js";
+
+class OrgScopedWritableStore implements WritableSecretStore {
+	private readonly entries = new Map<string, string>();
+
+	constructor(private readonly organizationId: string) {}
+
+	async get(ref: SecretRef): Promise<string | null> {
+		if (tryGetOrgId() !== this.organizationId) return null;
+		if (!ref.startsWith("secret://")) return null;
+		const name = decodeURIComponent(ref.slice("secret://".length));
+		return this.entries.get(name) ?? null;
+	}
+
+	async put(name: string, value: string): Promise<SecretRef> {
+		this.entries.set(name, value);
+		return `secret://${encodeURIComponent(name)}` as SecretRef;
+	}
+
+	async delete(nameOrRef: string): Promise<void> {
+		const name = nameOrRef.startsWith("secret://")
+			? decodeURIComponent(nameOrRef.slice("secret://".length))
+			: nameOrRef;
+		this.entries.delete(name);
+	}
+
+	async list(prefix?: string): Promise<SecretListEntry[]> {
+		return Array.from(this.entries.keys())
+			.filter((name) => !prefix || name.startsWith(prefix))
+			.map((name) => ({
+				ref: `secret://${encodeURIComponent(name)}` as SecretRef,
+				backend: "memory",
+				name,
+				updatedAt: Date.now(),
+			}));
+	}
+}
+
+function createWorkerToken(data: Omit<WorkerTokenData, "timestamp">): string {
+	return encrypt(JSON.stringify({ ...data, timestamp: Date.now() }));
+}
+
+describe("McpProxy org context", () => {
+	const originalFetch = globalThis.fetch;
+	const originalEncryptionKey = process.env.ENCRYPTION_KEY;
+
+	beforeAll(() => {
+		process.env.ENCRYPTION_KEY =
+			"0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+	});
+
+	afterEach(() => {
+		globalThis.fetch = originalFetch;
+	});
+
+	afterAll(() => {
+		if (originalEncryptionKey === undefined) {
+			delete process.env.ENCRYPTION_KEY;
+		} else {
+			process.env.ENCRYPTION_KEY = originalEncryptionKey;
+		}
+	});
+
+	test("resolves org-scoped MCP credentials from the worker token organization", async () => {
+		const orgId = "org-mcp-proxy-test";
+		const mcpId = "test-mcp";
+		const agentId = "agent1";
+		const userId = "user1";
+		const store = new OrgScopedWritableStore(orgId);
+		await store.put(
+			`mcp-auth/${agentId}/${userId}/${mcpId}/credential`,
+			JSON.stringify({
+				accessToken: "oauth-access-token",
+				refreshToken: "refresh-token",
+				expiresAt: Date.now() + 60 * 60 * 1000,
+				clientId: "client-id",
+				tokenUrl: "https://auth.example/token",
+				tokenEndpointAuthMethod: "none",
+			}),
+		);
+		const token = createWorkerToken({
+			userId,
+			conversationId: "conv1",
+			deploymentName: "deploy1",
+			channelId: "ch1",
+			agentId,
+			organizationId: orgId,
+		});
+		const proxy = new McpProxy(
+			{
+				getHttpServer: async () => ({
+					id: mcpId,
+					upstreamUrl: "https://upstream.example/mcp",
+				}),
+				getAllHttpServers: async () => new Map(),
+			},
+			{ secretStore: store },
+		);
+
+		let capturedAuthorization: string | null = null;
+		globalThis.fetch = async (_url, init) => {
+			capturedAuthorization = new Headers(init?.headers).get("Authorization");
+			return new Response(
+				JSON.stringify({
+					jsonrpc: "2.0",
+					id: 1,
+					result: {
+						content: [{ type: "text", text: "ok" }],
+						isError: false,
+					},
+				}),
+				{
+					status: 200,
+					headers: { "Content-Type": "application/json" },
+				},
+			);
+		};
+
+		const res = await proxy.getApp().request(`/${mcpId}/tools/my_tool`, {
+			method: "POST",
+			headers: {
+				Authorization: `Bearer ${token}`,
+				"Content-Type": "application/json",
+			},
+			body: JSON.stringify({ arg1: "value1" }),
+		});
+
+		expect(res.status).toBe(200);
+		expect(capturedAuthorization).toBe("Bearer oauth-access-token");
+	});
+});

--- a/packages/server/src/gateway/__tests__/mcp-proxy-org-context.test.ts
+++ b/packages/server/src/gateway/__tests__/mcp-proxy-org-context.test.ts
@@ -21,6 +21,10 @@ class OrgScopedWritableStore implements WritableSecretStore {
 		this.entries.set(name, value);
 	}
 
+	read(name: string): string | null {
+		return this.entries.get(name) ?? null;
+	}
+
 	async get(ref: SecretRef): Promise<string | null> {
 		if (tryGetOrgId() !== this.organizationId) return null;
 		if (!ref.startsWith("secret://")) return null;
@@ -63,7 +67,10 @@ function createWorkerToken(data: Omit<WorkerTokenData, "timestamp">): string {
 	return encrypt(JSON.stringify({ ...data, timestamp: Date.now() }));
 }
 
-function storedCredential(accessToken: string): string {
+function storedCredential(
+	accessToken: string,
+	overrides: Record<string, unknown> = {},
+): string {
 	return JSON.stringify({
 		accessToken,
 		refreshToken: "refresh-token",
@@ -71,6 +78,7 @@ function storedCredential(accessToken: string): string {
 		clientId: "client-id",
 		tokenUrl: "https://auth.example/token",
 		tokenEndpointAuthMethod: "none",
+		...overrides,
 	});
 }
 
@@ -298,6 +306,189 @@ describe("McpProxy org context", () => {
 				(value) => value === "Bearer discovery-access-token",
 			),
 		).toBe(true);
+	});
+
+	test("direct tool discovery refreshes and re-stores credentials inside token organization", async () => {
+		const orgId = "org-tool-refresh-test";
+		const mcpId = "refresh-mcp";
+		const agentId = "agent-refresh";
+		const userId = "user-refresh";
+		const credentialKey = `mcp-auth/${agentId}/${userId}/${mcpId}/credential`;
+		const store = new OrgScopedWritableStore(orgId);
+		store.seed(
+			credentialKey,
+			storedCredential("expired-access-token", {
+				expiresAt: Date.now() - 1,
+			}),
+		);
+		const tokenData: WorkerTokenData = {
+			userId,
+			conversationId: "conv-refresh",
+			deploymentName: "deploy-refresh",
+			channelId: "ch-refresh",
+			agentId,
+			organizationId: orgId,
+			timestamp: Date.now(),
+		};
+		const proxy = new McpProxy(
+			{
+				getHttpServer: async () => ({
+					id: mcpId,
+					upstreamUrl: "https://upstream.example/mcp",
+				}),
+				getAllHttpServers: async () => new Map(),
+			},
+			{ secretStore: store },
+		);
+
+		let refreshCalls = 0;
+		const capturedAuthorizations: Array<string | null> = [];
+		globalThis.fetch = async (url, init) => {
+			const href = String(url);
+			if (href === "https://auth.example/token") {
+				refreshCalls++;
+				const body = String(init?.body ?? "");
+				expect(body).toContain("grant_type=refresh_token");
+				expect(body).toContain("refresh_token=refresh-token");
+				return Response.json({
+					access_token: "refreshed-access-token",
+					refresh_token: "refresh-token-2",
+					expires_in: 3600,
+				});
+			}
+
+			capturedAuthorizations.push(
+				new Headers(init?.headers).get("Authorization"),
+			);
+			const body = String(init?.body ?? "");
+			if (body.includes('"method":"tools/list"')) {
+				return Response.json({
+					jsonrpc: "2.0",
+					id: 1,
+					result: { tools: [{ name: "list_repos" }] },
+				});
+			}
+			return Response.json({
+				jsonrpc: "2.0",
+				id: 0,
+				result: {},
+			});
+		};
+
+		const { tools } = await proxy.fetchToolsForMcp(
+			mcpId,
+			agentId,
+			tokenData,
+		);
+
+		expect(tools.map((tool) => tool.name)).toEqual(["list_repos"]);
+		expect(refreshCalls).toBe(1);
+		expect(capturedAuthorizations.length).toBeGreaterThan(0);
+		expect(
+			capturedAuthorizations.every(
+				(value) => value === "Bearer refreshed-access-token",
+			),
+		).toBe(true);
+		const persisted = JSON.parse(store.read(credentialKey) ?? "{}") as {
+			accessToken?: string;
+			refreshToken?: string;
+		};
+		expect(persisted.accessToken).toBe("refreshed-access-token");
+		expect(persisted.refreshToken).toBe("refresh-token-2");
+	});
+
+	test("REST tool calls without token organization fail before upstream access", async () => {
+		const mcpId = "rest-missing-org-mcp";
+		const store = new OrgScopedWritableStore("unused-org");
+		const token = createWorkerToken({
+			userId: "user-rest-missing-org",
+			conversationId: "conv-rest-missing-org",
+			deploymentName: "deploy-rest-missing-org",
+			channelId: "ch-rest-missing-org",
+			agentId: "agent-rest-missing-org",
+		});
+		const proxy = new McpProxy(
+			{
+				getHttpServer: async () => {
+					throw new Error("config lookup should not happen");
+				},
+				getAllHttpServers: async () => new Map(),
+			},
+			{ secretStore: store },
+		);
+
+		let upstreamCalled = false;
+		globalThis.fetch = async () => {
+			upstreamCalled = true;
+			throw new Error("upstream should not be called");
+		};
+
+		const res = await proxy.getApp().request(`/${mcpId}/tools/my_tool`, {
+			method: "POST",
+			headers: {
+				Authorization: `Bearer ${token}`,
+				"Content-Type": "application/json",
+			},
+			body: JSON.stringify({ arg1: "value1" }),
+		});
+
+		expect(res.status).toBe(401);
+		expect(await res.json()).toEqual({
+			error: "Worker token missing organizationId",
+		});
+		expect(upstreamCalled).toBe(false);
+	});
+
+	test("JSON-RPC proxy calls without token organization fail before upstream access", async () => {
+		const mcpId = "proxy-missing-org-mcp";
+		const store = new OrgScopedWritableStore("unused-org");
+		const token = createWorkerToken({
+			userId: "user-proxy-missing-org",
+			conversationId: "conv-proxy-missing-org",
+			deploymentName: "deploy-proxy-missing-org",
+			channelId: "ch-proxy-missing-org",
+			agentId: "agent-proxy-missing-org",
+		});
+		const proxy = new McpProxy(
+			{
+				getHttpServer: async () => {
+					throw new Error("config lookup should not happen");
+				},
+				getAllHttpServers: async () => new Map(),
+			},
+			{ secretStore: store },
+		);
+
+		let upstreamCalled = false;
+		globalThis.fetch = async () => {
+			upstreamCalled = true;
+			throw new Error("upstream should not be called");
+		};
+
+		const res = await proxy.getApp().request(`/${mcpId}`, {
+			method: "POST",
+			headers: {
+				Authorization: `Bearer ${token}`,
+				"Content-Type": "application/json",
+			},
+			body: JSON.stringify({
+				jsonrpc: "2.0",
+				id: 1,
+				method: "tools/call",
+				params: { name: "my_tool", arguments: { arg1: "value1" } },
+			}),
+		});
+
+		expect(res.status).toBe(200);
+		expect(await res.json()).toEqual({
+			jsonrpc: "2.0",
+			id: null,
+			error: {
+				code: -32600,
+				message: "Worker token missing organizationId",
+			},
+		});
+		expect(upstreamCalled).toBe(false);
 	});
 
 	test("approved tool execution resolves credentials from the pending invocation organization", async () => {

--- a/packages/server/src/gateway/__tests__/mcp-proxy-org-context.test.ts
+++ b/packages/server/src/gateway/__tests__/mcp-proxy-org-context.test.ts
@@ -29,6 +29,7 @@ class OrgScopedWritableStore implements WritableSecretStore {
 	}
 
 	async list(prefix?: string): Promise<SecretListEntry[]> {
+		if (tryGetOrgId() !== this.organizationId) return [];
 		return Array.from(this.entries.keys())
 			.filter((name) => !prefix || name.startsWith(prefix))
 			.map((name) => ({

--- a/packages/server/src/gateway/__tests__/mcp-proxy-org-context.test.ts
+++ b/packages/server/src/gateway/__tests__/mcp-proxy-org-context.test.ts
@@ -37,6 +37,9 @@ class OrgScopedWritableStore implements WritableSecretStore {
 	}
 
 	async delete(nameOrRef: string): Promise<void> {
+		if (tryGetOrgId() !== this.organizationId) {
+			throw new Error("test secret delete missing org context");
+		}
 		const name = nameOrRef.startsWith("secret://")
 			? decodeURIComponent(nameOrRef.slice("secret://".length))
 			: nameOrRef;

--- a/packages/server/src/gateway/__tests__/mcp-proxy-org-context.test.ts
+++ b/packages/server/src/gateway/__tests__/mcp-proxy-org-context.test.ts
@@ -1,13 +1,25 @@
-import { afterAll, afterEach, beforeAll, describe, expect, test } from "bun:test";
+import {
+	afterAll,
+	afterEach,
+	beforeAll,
+	describe,
+	expect,
+	test,
+} from "bun:test";
 import { encrypt, type SecretRef, type WorkerTokenData } from "@lobu/core";
 import { tryGetOrgId } from "../../lobu/stores/org-context.js";
 import { McpProxy } from "../auth/mcp/proxy.js";
+import { createDeviceAuthRoutes } from "../routes/internal/device-auth.js";
 import type { SecretListEntry, WritableSecretStore } from "../secrets/index.js";
 
 class OrgScopedWritableStore implements WritableSecretStore {
 	private readonly entries = new Map<string, string>();
 
 	constructor(private readonly organizationId: string) {}
+
+	seed(name: string, value: string): void {
+		this.entries.set(name, value);
+	}
 
 	async get(ref: SecretRef): Promise<string | null> {
 		if (tryGetOrgId() !== this.organizationId) return null;
@@ -17,6 +29,9 @@ class OrgScopedWritableStore implements WritableSecretStore {
 	}
 
 	async put(name: string, value: string): Promise<SecretRef> {
+		if (tryGetOrgId() !== this.organizationId) {
+			throw new Error("test secret write missing org context");
+		}
 		this.entries.set(name, value);
 		return `secret://${encodeURIComponent(name)}` as SecretRef;
 	}
@@ -43,6 +58,17 @@ class OrgScopedWritableStore implements WritableSecretStore {
 
 function createWorkerToken(data: Omit<WorkerTokenData, "timestamp">): string {
 	return encrypt(JSON.stringify({ ...data, timestamp: Date.now() }));
+}
+
+function storedCredential(accessToken: string): string {
+	return JSON.stringify({
+		accessToken,
+		refreshToken: "refresh-token",
+		expiresAt: Date.now() + 60 * 60 * 1000,
+		clientId: "client-id",
+		tokenUrl: "https://auth.example/token",
+		tokenEndpointAuthMethod: "none",
+	});
 }
 
 describe("McpProxy org context", () => {
@@ -72,16 +98,9 @@ describe("McpProxy org context", () => {
 		const agentId = "agent1";
 		const userId = "user1";
 		const store = new OrgScopedWritableStore(orgId);
-		await store.put(
+		store.seed(
 			`mcp-auth/${agentId}/${userId}/${mcpId}/credential`,
-			JSON.stringify({
-				accessToken: "oauth-access-token",
-				refreshToken: "refresh-token",
-				expiresAt: Date.now() + 60 * 60 * 1000,
-				clientId: "client-id",
-				tokenUrl: "https://auth.example/token",
-				tokenEndpointAuthMethod: "none",
-			}),
+			storedCredential("oauth-access-token"),
 		);
 		const token = createWorkerToken({
 			userId,
@@ -132,5 +151,191 @@ describe("McpProxy org context", () => {
 
 		expect(res.status).toBe(200);
 		expect(capturedAuthorization).toBe("Bearer oauth-access-token");
+	});
+
+	test("device-auth worker routes write and read credentials in the worker token organization", async () => {
+		const orgId = "org-device-auth-test";
+		const mcpId = "device-mcp";
+		const agentId = "agent-device";
+		const userId = "user-device";
+		const store = new OrgScopedWritableStore(orgId);
+		const token = createWorkerToken({
+			userId,
+			conversationId: "conv-device",
+			deploymentName: "deploy-device",
+			channelId: "ch-device",
+			agentId,
+			organizationId: orgId,
+		});
+		const router = createDeviceAuthRoutes({
+			secretStore: store,
+			mcpConfigService: {
+				getHttpServer: async () => ({
+					upstreamUrl: "https://issuer.example/mcp",
+					oauth: {
+						clientId: "client-id",
+						deviceAuthorizationUrl:
+							"https://issuer.example/oauth/device_authorization",
+						tokenUrl: "https://issuer.example/oauth/token",
+					},
+				}),
+			} as unknown as Parameters<
+				typeof createDeviceAuthRoutes
+			>[0]["mcpConfigService"],
+		});
+
+		globalThis.fetch = async (url) => {
+			const href = String(url);
+			if (href.endsWith("/oauth/device_authorization")) {
+				return Response.json({
+					device_code: "device-code",
+					user_code: "USER-CODE",
+					verification_uri: "https://issuer.example/device",
+					expires_in: 600,
+					interval: 1,
+				});
+			}
+			if (href.endsWith("/oauth/token")) {
+				return Response.json({
+					access_token: "device-access-token",
+					refresh_token: "device-refresh-token",
+					expires_in: 3600,
+				});
+			}
+			throw new Error(`unexpected fetch ${href}`);
+		};
+
+		const authHeaders = {
+			Authorization: `Bearer ${token}`,
+			"Content-Type": "application/json",
+		};
+		const start = await router.request("/internal/device-auth/start", {
+			method: "POST",
+			headers: authHeaders,
+			body: JSON.stringify({ mcpId }),
+		});
+		expect(start.status).toBe(200);
+
+		const poll = await router.request("/internal/device-auth/poll", {
+			method: "POST",
+			headers: authHeaders,
+			body: JSON.stringify({ mcpId }),
+		});
+		expect(poll.status).toBe(200);
+		expect(await poll.json()).toEqual({ status: "complete" });
+
+		const status = await router.request(
+			`/internal/device-auth/status?mcpId=${mcpId}`,
+			{ headers: { Authorization: `Bearer ${token}` } },
+		);
+		expect(status.status).toBe(200);
+		expect(await status.json()).toEqual({ authenticated: true });
+	});
+
+	test("direct tool discovery resolves credentials from token organization", async () => {
+		const orgId = "org-tool-discovery-test";
+		const mcpId = "discovery-mcp";
+		const agentId = "agent-discovery";
+		const userId = "user-discovery";
+		const store = new OrgScopedWritableStore(orgId);
+		store.seed(
+			`mcp-auth/${agentId}/${userId}/${mcpId}/credential`,
+			storedCredential("discovery-access-token"),
+		);
+		const tokenData: WorkerTokenData = {
+			userId,
+			conversationId: "conv-discovery",
+			deploymentName: "deploy-discovery",
+			channelId: "ch-discovery",
+			agentId,
+			organizationId: orgId,
+			timestamp: Date.now(),
+		};
+		const proxy = new McpProxy(
+			{
+				getHttpServer: async () => ({
+					id: mcpId,
+					upstreamUrl: "https://upstream.example/mcp",
+				}),
+				getAllHttpServers: async () => new Map(),
+			},
+			{ secretStore: store },
+		);
+
+		const capturedAuthorizations: Array<string | null> = [];
+		globalThis.fetch = async (_url, init) => {
+			capturedAuthorizations.push(
+				new Headers(init?.headers).get("Authorization"),
+			);
+			const body = String(init?.body ?? "");
+			if (body.includes('"method":"tools/list"')) {
+				return Response.json({
+					jsonrpc: "2.0",
+					id: 1,
+					result: { tools: [{ name: "list_repos" }] },
+				});
+			}
+			return Response.json({
+				jsonrpc: "2.0",
+				id: 0,
+				result: {},
+			});
+		};
+
+		const { tools } = await proxy.fetchToolsForMcp(
+			mcpId,
+			agentId,
+			tokenData,
+		);
+
+		expect(tools.map((tool) => tool.name)).toEqual(["list_repos"]);
+		expect(capturedAuthorizations.every((value) => value === "Bearer discovery-access-token")).toBe(true);
+	});
+
+	test("approved tool execution resolves credentials from the pending invocation organization", async () => {
+		const orgId = "org-approved-tool-test";
+		const mcpId = "approved-mcp";
+		const agentId = "agent-approved";
+		const userId = "user-approved";
+		const store = new OrgScopedWritableStore(orgId);
+		store.seed(
+			`mcp-auth/${agentId}/${userId}/${mcpId}/credential`,
+			storedCredential("approved-access-token"),
+		);
+		const proxy = new McpProxy(
+			{
+				getHttpServer: async () => ({
+					id: mcpId,
+					upstreamUrl: "https://upstream.example/mcp",
+				}),
+				getAllHttpServers: async () => new Map(),
+			},
+			{ secretStore: store },
+		);
+
+		let capturedAuthorization: string | null = null;
+		globalThis.fetch = async (_url, init) => {
+			capturedAuthorization = new Headers(init?.headers).get("Authorization");
+			return Response.json({
+				jsonrpc: "2.0",
+				id: 1,
+				result: {
+					content: [{ type: "text", text: "approved" }],
+					isError: false,
+				},
+			});
+		};
+
+		const result = await proxy.executeToolDirect(
+			agentId,
+			userId,
+			mcpId,
+			"approved_tool",
+			{},
+			{ organizationId: orgId },
+		);
+
+		expect(result.isError).toBe(false);
+		expect(capturedAuthorization).toBe("Bearer approved-access-token");
 	});
 });

--- a/packages/server/src/gateway/auth/mcp/oauth-flow.ts
+++ b/packages/server/src/gateway/auth/mcp/oauth-flow.ts
@@ -252,6 +252,10 @@ export async function completeAuthCodeFlow(
     connectionId,
   } = stateData;
 
+	if (!organizationId) {
+		throw new Error("OAuth state missing organizationId");
+	}
+
   const body: Record<string, string> = {
     grant_type: "authorization_code",
     code,

--- a/packages/server/src/gateway/auth/mcp/oauth-flow.ts
+++ b/packages/server/src/gateway/auth/mcp/oauth-flow.ts
@@ -12,20 +12,21 @@
 
 import { createLogger, type McpOAuthConfig } from "@lobu/core";
 import {
-  generateCodeChallenge,
-  generateCodeVerifier,
+	generateCodeChallenge,
+	generateCodeVerifier,
 } from "../../../utils/pkce.js";
-import {
-  OAuthStateStore,
-  type ProviderOAuthStateData,
-} from "../oauth/state-store.js";
 import { storeCredentialForScope } from "../../routes/internal/device-auth.js";
 import type { WritableSecretStore } from "../../secrets/index.js";
 import {
-  discoverOAuth,
-  type DiscoveredOAuthEndpoints,
-  type DiscoveredClient,
+	OAuthStateStore,
+	type ProviderOAuthStateData,
+} from "../oauth/state-store.js";
+import {
+	type DiscoveredClient,
+	type DiscoveredOAuthEndpoints,
+	discoverOAuth,
 } from "./oauth-discovery.js";
+import { runWithOrganizationContext } from "./proxy-shared.js";
 
 const logger = createLogger("mcp-oauth-flow");
 
@@ -37,53 +38,55 @@ const STATE_KEY_PREFIX = "mcp-oauth:state";
  * returned `code` for tokens.
  */
 interface McpOAuthStateData extends ProviderOAuthStateData {
-  mcpId: string;
-  /** Opaque credential-scope key — `userId` for per-user, `channel-<id>` for channel scope. */
-  scopeKey: string;
-  /** Endpoints resolved at discovery time. */
-  endpoints: DiscoveredOAuthEndpoints;
-  /** Client registered (or configured) at discovery time. */
-  client: DiscoveredClient;
-  /** Space-separated scope string actually requested. */
-  scope?: string;
-  /** RFC 8707 resource indicator. */
-  resource?: string;
-  /** Chat context so the callback success page can deep-link back, and for auditing. */
-  platform: string;
-  channelId: string;
-  conversationId: string;
-  teamId?: string;
-  connectionId?: string;
+	mcpId: string;
+	organizationId: string;
+	/** Opaque credential-scope key — `userId` for per-user, `channel-<id>` for channel scope. */
+	scopeKey: string;
+	/** Endpoints resolved at discovery time. */
+	endpoints: DiscoveredOAuthEndpoints;
+	/** Client registered (or configured) at discovery time. */
+	client: DiscoveredClient;
+	/** Space-separated scope string actually requested. */
+	scope?: string;
+	/** RFC 8707 resource indicator. */
+	resource?: string;
+	/** Chat context so the callback success page can deep-link back, and for auditing. */
+	platform: string;
+	channelId: string;
+	conversationId: string;
+	teamId?: string;
+	connectionId?: string;
 }
 
 function getStateStore(): OAuthStateStore<McpOAuthStateData> {
-  return new OAuthStateStore<McpOAuthStateData>(
-    STATE_KEY_PREFIX,
-    "mcp-oauth-state"
-  );
+	return new OAuthStateStore<McpOAuthStateData>(
+		STATE_KEY_PREFIX,
+		"mcp-oauth-state",
+	);
 }
 
 interface StartFlowOptions {
-  secretStore: WritableSecretStore;
-  mcpId: string;
-  upstreamUrl: string;
-  agentId: string;
-  userId: string;
-  scopeKey: string;
-  wwwAuthenticate: string | null;
-  /** Absolute callback URL — `{publicGatewayUrl}/mcp/oauth/callback`. */
-  redirectUri: string;
-  staticOauth?: McpOAuthConfig;
-  platform: string;
-  channelId: string;
-  conversationId: string;
-  teamId?: string;
-  connectionId?: string;
+	secretStore: WritableSecretStore;
+	mcpId: string;
+	upstreamUrl: string;
+	agentId: string;
+	userId: string;
+	organizationId: string;
+	scopeKey: string;
+	wwwAuthenticate: string | null;
+	/** Absolute callback URL — `{publicGatewayUrl}/mcp/oauth/callback`. */
+	redirectUri: string;
+	staticOauth?: McpOAuthConfig;
+	platform: string;
+	channelId: string;
+	conversationId: string;
+	teamId?: string;
+	connectionId?: string;
 }
 
 interface StartFlowResult {
-  authorizationUrl: string;
-  state: string;
+	authorizationUrl: string;
+	state: string;
 }
 
 /**
@@ -92,117 +95,127 @@ interface StartFlowResult {
  * resumes from the `state` parameter.
  */
 export async function startAuthCodeFlow(
-  options: StartFlowOptions
+	options: StartFlowOptions,
 ): Promise<StartFlowResult> {
-  const {
-    secretStore,
-    mcpId,
-    upstreamUrl,
-    agentId,
-    userId,
-    scopeKey,
-    wwwAuthenticate,
-    redirectUri,
-    staticOauth,
-    platform,
-    channelId,
-    conversationId,
-    teamId,
-    connectionId,
-  } = options;
+	return runWithOrganizationContext(options.organizationId, () =>
+		startAuthCodeFlowScoped(options),
+	);
+}
 
-  const discovery = await discoverOAuth({
-    mcpId,
-    agentId,
-    upstreamUrl,
-    wwwAuthenticate,
-    redirectUri,
-    secretStore,
-    staticClientId: staticOauth?.clientId,
-    staticClientSecret: staticOauth?.clientSecret,
-    requestedScopes: staticOauth?.scopes,
-  });
+async function startAuthCodeFlowScoped(
+	options: StartFlowOptions,
+): Promise<StartFlowResult> {
+	const {
+		secretStore,
+		mcpId,
+		upstreamUrl,
+		agentId,
+		userId,
+		organizationId,
+		scopeKey,
+		wwwAuthenticate,
+		redirectUri,
+		staticOauth,
+		platform,
+		channelId,
+		conversationId,
+		teamId,
+		connectionId,
+	} = options;
 
-  const { endpoints, client } = discovery;
+	const discovery = await discoverOAuth({
+		mcpId,
+		agentId,
+		upstreamUrl,
+		wwwAuthenticate,
+		redirectUri,
+		secretStore,
+		staticClientId: staticOauth?.clientId,
+		staticClientSecret: staticOauth?.clientSecret,
+		requestedScopes: staticOauth?.scopes,
+	});
 
-  // Prefer operator-configured scopes; fall back to advertised ones.
-  const scopes =
-    staticOauth?.scopes && staticOauth.scopes.length > 0
-      ? staticOauth.scopes
-      : endpoints.scopesSupported;
-  const scopeString = scopes?.length ? scopes.join(" ") : undefined;
+	const { endpoints, client } = discovery;
 
-  // RFC 8707 resource indicator — MCP servers like Sentry require this.
-  const resource = staticOauth?.resource ?? endpoints.resource ?? upstreamUrl;
+	// Prefer operator-configured scopes; fall back to advertised ones.
+	const scopes =
+		staticOauth?.scopes && staticOauth.scopes.length > 0
+			? staticOauth.scopes
+			: endpoints.scopesSupported;
+	const scopeString = scopes?.length ? scopes.join(" ") : undefined;
 
-  const codeVerifier = generateCodeVerifier();
-  const codeChallenge = generateCodeChallenge(codeVerifier);
+	// RFC 8707 resource indicator — MCP servers like Sentry require this.
+	const resource = staticOauth?.resource ?? endpoints.resource ?? upstreamUrl;
 
-  const stateStore = getStateStore();
-  const state = await stateStore.create({
-    userId,
-    agentId,
-    codeVerifier,
-    mcpId,
-    scopeKey,
-    endpoints,
-    client,
-    scope: scopeString,
-    resource,
-    platform,
-    channelId,
-    conversationId,
-    teamId,
-    connectionId,
-  });
+	const codeVerifier = generateCodeVerifier();
+	const codeChallenge = generateCodeChallenge(codeVerifier);
 
-  const authUrl = new URL(endpoints.authorizationEndpoint);
-  authUrl.searchParams.set("response_type", "code");
-  authUrl.searchParams.set("client_id", client.clientId);
-  authUrl.searchParams.set("redirect_uri", redirectUri);
-  authUrl.searchParams.set("code_challenge", codeChallenge);
-  authUrl.searchParams.set("code_challenge_method", "S256");
-  authUrl.searchParams.set("state", state);
-  if (scopeString) {
-    authUrl.searchParams.set("scope", scopeString);
-  }
-  if (resource) {
-    authUrl.searchParams.set("resource", resource);
-  }
+	const stateStore = getStateStore();
+	const state = await stateStore.create({
+		userId,
+		agentId,
+		organizationId,
+		codeVerifier,
+		mcpId,
+		scopeKey,
+		endpoints,
+		client,
+		scope: scopeString,
+		resource,
+		platform,
+		channelId,
+		conversationId,
+		teamId,
+		connectionId,
+	});
 
-  logger.info("Started MCP OAuth auth-code flow", {
-    mcpId,
-    agentId,
-    scopeKey,
-    clientId: client.clientId,
-    hasResource: !!resource,
-  });
+	const authUrl = new URL(endpoints.authorizationEndpoint);
+	authUrl.searchParams.set("response_type", "code");
+	authUrl.searchParams.set("client_id", client.clientId);
+	authUrl.searchParams.set("redirect_uri", redirectUri);
+	authUrl.searchParams.set("code_challenge", codeChallenge);
+	authUrl.searchParams.set("code_challenge_method", "S256");
+	authUrl.searchParams.set("state", state);
+	if (scopeString) {
+		authUrl.searchParams.set("scope", scopeString);
+	}
+	if (resource) {
+		authUrl.searchParams.set("resource", resource);
+	}
 
-  return {
-    authorizationUrl: authUrl.toString(),
-    state,
-  };
+	logger.info("Started MCP OAuth auth-code flow", {
+		mcpId,
+		agentId,
+		scopeKey,
+		clientId: client.clientId,
+		hasResource: !!resource,
+	});
+
+	return {
+		authorizationUrl: authUrl.toString(),
+		state,
+	};
 }
 
 interface CompleteFlowOptions {
-  secretStore: WritableSecretStore;
-  state: string;
-  code: string;
-  redirectUri: string;
+	secretStore: WritableSecretStore;
+	state: string;
+	code: string;
+	redirectUri: string;
 }
 
 interface CompleteFlowResult {
-  mcpId: string;
-  agentId: string;
-  userId: string;
-  scopeKey: string;
-  platform: string;
-  channelId: string;
-  conversationId: string;
-  teamId?: string;
-  connectionId?: string;
-  /** Space-separated scopes actually granted (provider-reported) or requested. */
-  scope?: string;
+	mcpId: string;
+	agentId: string;
+	userId: string;
+	scopeKey: string;
+	platform: string;
+	channelId: string;
+	conversationId: string;
+	teamId?: string;
+	connectionId?: string;
+	/** Space-separated scopes actually granted (provider-reported) or requested. */
+	scope?: string;
 }
 
 /**
@@ -211,128 +224,131 @@ interface CompleteFlowResult {
  * the context fields the callback page needs to render a success message.
  */
 export async function completeAuthCodeFlow(
-  options: CompleteFlowOptions
+	options: CompleteFlowOptions,
 ): Promise<CompleteFlowResult> {
-  const { secretStore, state, code, redirectUri } = options;
+	const { secretStore, state, code, redirectUri } = options;
 
-  const stateStore = getStateStore();
-  const stateData = await stateStore.consume(state);
-  if (!stateData) {
-    throw new Error("Invalid or expired OAuth state");
-  }
+	const stateStore = getStateStore();
+	const stateData = await stateStore.consume(state);
+	if (!stateData) {
+		throw new Error("Invalid or expired OAuth state");
+	}
 
-  const {
-    mcpId,
-    agentId,
-    userId,
-    scopeKey,
-    endpoints,
-    client,
-    codeVerifier,
-    scope,
-    resource,
-    platform,
-    channelId,
-    conversationId,
-    teamId,
-    connectionId,
-  } = stateData;
+	const {
+		mcpId,
+		agentId,
+		userId,
+		organizationId,
+		scopeKey,
+		endpoints,
+		client,
+		codeVerifier,
+		scope,
+		resource,
+		platform,
+		channelId,
+		conversationId,
+		teamId,
+		connectionId,
+	} = stateData;
 
-  const body: Record<string, string> = {
-    grant_type: "authorization_code",
-    code,
-    redirect_uri: redirectUri,
-    code_verifier: codeVerifier,
-    client_id: client.clientId,
-  };
-  if (resource) {
-    body.resource = resource;
-  }
+	const body: Record<string, string> = {
+		grant_type: "authorization_code",
+		code,
+		redirect_uri: redirectUri,
+		code_verifier: codeVerifier,
+		client_id: client.clientId,
+	};
+	if (resource) {
+		body.resource = resource;
+	}
 
-  const headers: Record<string, string> = {
-    "Content-Type": "application/x-www-form-urlencoded",
-    Accept: "application/json",
-  };
-  // RFC 6749 §2.3.1 — `client_secret_basic` is the default. Only fall back to
-  // `_post` when the AS advertises it explicitly (and we have a secret). A
-  // public PKCE client ("none") sends no secret at all.
-  if (client.clientSecret && client.tokenEndpointAuthMethod !== "none") {
-    if (client.tokenEndpointAuthMethod === "client_secret_post") {
-      body.client_secret = client.clientSecret;
-    } else {
-      const basic = Buffer.from(
-        `${encodeURIComponent(client.clientId)}:${encodeURIComponent(client.clientSecret)}`
-      ).toString("base64");
-      headers.Authorization = `Basic ${basic}`;
-    }
-  }
+	const headers: Record<string, string> = {
+		"Content-Type": "application/x-www-form-urlencoded",
+		Accept: "application/json",
+	};
+	// RFC 6749 §2.3.1 — `client_secret_basic` is the default. Only fall back to
+	// `_post` when the AS advertises it explicitly (and we have a secret). A
+	// public PKCE client ("none") sends no secret at all.
+	if (client.clientSecret && client.tokenEndpointAuthMethod !== "none") {
+		if (client.tokenEndpointAuthMethod === "client_secret_post") {
+			body.client_secret = client.clientSecret;
+		} else {
+			const basic = Buffer.from(
+				`${encodeURIComponent(client.clientId)}:${encodeURIComponent(client.clientSecret)}`,
+			).toString("base64");
+			headers.Authorization = `Basic ${basic}`;
+		}
+	}
 
-  const response = await fetch(endpoints.tokenEndpoint, {
-    method: "POST",
-    headers,
-    body: new URLSearchParams(body).toString(),
-  });
+	const response = await fetch(endpoints.tokenEndpoint, {
+		method: "POST",
+		headers,
+		body: new URLSearchParams(body).toString(),
+	});
 
-  if (!response.ok) {
-    const text = await response.text().catch(() => "");
-    logger.error("Token exchange failed", {
-      mcpId,
-      status: response.status,
-      body: text.slice(0, 500),
-    });
-    throw new Error(`Token exchange failed: ${response.status}`);
-  }
+	if (!response.ok) {
+		const text = await response.text().catch(() => "");
+		logger.error("Token exchange failed", {
+			mcpId,
+			status: response.status,
+			body: text.slice(0, 500),
+		});
+		throw new Error(`Token exchange failed: ${response.status}`);
+	}
 
-  const tokenData = (await response.json()) as {
-    access_token?: string;
-    refresh_token?: string;
-    expires_in?: number;
-    token_type?: string;
-    scope?: string;
-  };
+	const tokenData = (await response.json()) as {
+		access_token?: string;
+		refresh_token?: string;
+		expires_in?: number;
+		token_type?: string;
+		scope?: string;
+	};
 
-  if (!tokenData.access_token) {
-    throw new Error("Token exchange response missing access_token");
-  }
+	if (!tokenData.access_token) {
+		throw new Error("Token exchange response missing access_token");
+	}
 
-  const expiresAt =
-    typeof tokenData.expires_in === "number"
-      ? Date.now() + tokenData.expires_in * 1000
-      : Date.now() + 3_600_000; // default 1h if not reported
+	const expiresAt =
+		typeof tokenData.expires_in === "number"
+			? Date.now() + tokenData.expires_in * 1000
+			: Date.now() + 3_600_000; // default 1h if not reported
 
-  await storeCredentialForScope(secretStore, agentId, scopeKey, mcpId, {
-    accessToken: tokenData.access_token,
-    refreshToken: tokenData.refresh_token,
-    expiresAt,
-    clientId: client.clientId,
-    clientSecret: client.clientSecret,
-    tokenUrl: endpoints.tokenEndpoint,
-    resource,
-    tokenEndpointAuthMethod:
-      client.tokenEndpointAuthMethod === "client_secret_basic" ||
-      client.tokenEndpointAuthMethod === "client_secret_post" ||
-      client.tokenEndpointAuthMethod === "none"
-        ? client.tokenEndpointAuthMethod
-        : undefined,
-  });
+	await runWithOrganizationContext(organizationId, () =>
+		storeCredentialForScope(secretStore, agentId, scopeKey, mcpId, {
+			accessToken: tokenData.access_token,
+			refreshToken: tokenData.refresh_token,
+			expiresAt,
+			clientId: client.clientId,
+			clientSecret: client.clientSecret,
+			tokenUrl: endpoints.tokenEndpoint,
+			resource,
+			tokenEndpointAuthMethod:
+				client.tokenEndpointAuthMethod === "client_secret_basic" ||
+				client.tokenEndpointAuthMethod === "client_secret_post" ||
+				client.tokenEndpointAuthMethod === "none"
+					? client.tokenEndpointAuthMethod
+					: undefined,
+		}),
+	);
 
-  logger.info("MCP OAuth auth-code flow completed", {
-    mcpId,
-    agentId,
-    scopeKey,
-    scope: scope ?? tokenData.scope,
-  });
+	logger.info("MCP OAuth auth-code flow completed", {
+		mcpId,
+		agentId,
+		scopeKey,
+		scope: scope ?? tokenData.scope,
+	});
 
-  return {
-    mcpId,
-    agentId,
-    userId,
-    scopeKey,
-    platform,
-    channelId,
-    conversationId,
-    teamId,
-    connectionId,
-    scope: tokenData.scope ?? scope,
-  };
+	return {
+		mcpId,
+		agentId,
+		userId,
+		scopeKey,
+		platform,
+		channelId,
+		conversationId,
+		teamId,
+		connectionId,
+		scope: tokenData.scope ?? scope,
+	};
 }

--- a/packages/server/src/gateway/auth/mcp/oauth-flow.ts
+++ b/packages/server/src/gateway/auth/mcp/oauth-flow.ts
@@ -12,17 +12,17 @@
 
 import { createLogger, type McpOAuthConfig } from "@lobu/core";
 import {
-	generateCodeChallenge,
-	generateCodeVerifier,
+  generateCodeChallenge,
+  generateCodeVerifier,
 } from "../../../utils/pkce.js";
 import { storeCredentialForScope } from "../../routes/internal/device-auth.js";
 import type { WritableSecretStore } from "../../secrets/index.js";
 import {
-	OAuthStateStore,
-	type ProviderOAuthStateData,
+  OAuthStateStore,
+  type ProviderOAuthStateData,
 } from "../oauth/state-store.js";
 import {
-	type DiscoveredClient,
+  type DiscoveredClient,
 	type DiscoveredOAuthEndpoints,
 	discoverOAuth,
 } from "./oauth-discovery.js";
@@ -38,55 +38,55 @@ const STATE_KEY_PREFIX = "mcp-oauth:state";
  * returned `code` for tokens.
  */
 interface McpOAuthStateData extends ProviderOAuthStateData {
-	mcpId: string;
+  mcpId: string;
 	organizationId: string;
-	/** Opaque credential-scope key — `userId` for per-user, `channel-<id>` for channel scope. */
-	scopeKey: string;
-	/** Endpoints resolved at discovery time. */
-	endpoints: DiscoveredOAuthEndpoints;
-	/** Client registered (or configured) at discovery time. */
-	client: DiscoveredClient;
-	/** Space-separated scope string actually requested. */
-	scope?: string;
-	/** RFC 8707 resource indicator. */
-	resource?: string;
-	/** Chat context so the callback success page can deep-link back, and for auditing. */
-	platform: string;
-	channelId: string;
-	conversationId: string;
-	teamId?: string;
-	connectionId?: string;
+  /** Opaque credential-scope key — `userId` for per-user, `channel-<id>` for channel scope. */
+  scopeKey: string;
+  /** Endpoints resolved at discovery time. */
+  endpoints: DiscoveredOAuthEndpoints;
+  /** Client registered (or configured) at discovery time. */
+  client: DiscoveredClient;
+  /** Space-separated scope string actually requested. */
+  scope?: string;
+  /** RFC 8707 resource indicator. */
+  resource?: string;
+  /** Chat context so the callback success page can deep-link back, and for auditing. */
+  platform: string;
+  channelId: string;
+  conversationId: string;
+  teamId?: string;
+  connectionId?: string;
 }
 
 function getStateStore(): OAuthStateStore<McpOAuthStateData> {
-	return new OAuthStateStore<McpOAuthStateData>(
-		STATE_KEY_PREFIX,
+  return new OAuthStateStore<McpOAuthStateData>(
+    STATE_KEY_PREFIX,
 		"mcp-oauth-state",
-	);
+  );
 }
 
 interface StartFlowOptions {
-	secretStore: WritableSecretStore;
-	mcpId: string;
-	upstreamUrl: string;
-	agentId: string;
-	userId: string;
+  secretStore: WritableSecretStore;
+  mcpId: string;
+  upstreamUrl: string;
+  agentId: string;
+  userId: string;
 	organizationId: string;
-	scopeKey: string;
-	wwwAuthenticate: string | null;
-	/** Absolute callback URL — `{publicGatewayUrl}/mcp/oauth/callback`. */
-	redirectUri: string;
-	staticOauth?: McpOAuthConfig;
-	platform: string;
-	channelId: string;
-	conversationId: string;
-	teamId?: string;
-	connectionId?: string;
+  scopeKey: string;
+  wwwAuthenticate: string | null;
+  /** Absolute callback URL — `{publicGatewayUrl}/mcp/oauth/callback`. */
+  redirectUri: string;
+  staticOauth?: McpOAuthConfig;
+  platform: string;
+  channelId: string;
+  conversationId: string;
+  teamId?: string;
+  connectionId?: string;
 }
 
 interface StartFlowResult {
-	authorizationUrl: string;
-	state: string;
+  authorizationUrl: string;
+  state: string;
 }
 
 /**
@@ -105,117 +105,117 @@ export async function startAuthCodeFlow(
 async function startAuthCodeFlowScoped(
 	options: StartFlowOptions,
 ): Promise<StartFlowResult> {
-	const {
-		secretStore,
-		mcpId,
-		upstreamUrl,
-		agentId,
-		userId,
+  const {
+    secretStore,
+    mcpId,
+    upstreamUrl,
+    agentId,
+    userId,
 		organizationId,
-		scopeKey,
-		wwwAuthenticate,
-		redirectUri,
-		staticOauth,
-		platform,
-		channelId,
-		conversationId,
-		teamId,
-		connectionId,
-	} = options;
+    scopeKey,
+    wwwAuthenticate,
+    redirectUri,
+    staticOauth,
+    platform,
+    channelId,
+    conversationId,
+    teamId,
+    connectionId,
+  } = options;
 
-	const discovery = await discoverOAuth({
-		mcpId,
-		agentId,
-		upstreamUrl,
-		wwwAuthenticate,
-		redirectUri,
-		secretStore,
-		staticClientId: staticOauth?.clientId,
-		staticClientSecret: staticOauth?.clientSecret,
-		requestedScopes: staticOauth?.scopes,
-	});
+  const discovery = await discoverOAuth({
+    mcpId,
+    agentId,
+    upstreamUrl,
+    wwwAuthenticate,
+    redirectUri,
+    secretStore,
+    staticClientId: staticOauth?.clientId,
+    staticClientSecret: staticOauth?.clientSecret,
+    requestedScopes: staticOauth?.scopes,
+  });
 
-	const { endpoints, client } = discovery;
+  const { endpoints, client } = discovery;
 
-	// Prefer operator-configured scopes; fall back to advertised ones.
-	const scopes =
-		staticOauth?.scopes && staticOauth.scopes.length > 0
-			? staticOauth.scopes
-			: endpoints.scopesSupported;
-	const scopeString = scopes?.length ? scopes.join(" ") : undefined;
+  // Prefer operator-configured scopes; fall back to advertised ones.
+  const scopes =
+    staticOauth?.scopes && staticOauth.scopes.length > 0
+      ? staticOauth.scopes
+      : endpoints.scopesSupported;
+  const scopeString = scopes?.length ? scopes.join(" ") : undefined;
 
-	// RFC 8707 resource indicator — MCP servers like Sentry require this.
-	const resource = staticOauth?.resource ?? endpoints.resource ?? upstreamUrl;
+  // RFC 8707 resource indicator — MCP servers like Sentry require this.
+  const resource = staticOauth?.resource ?? endpoints.resource ?? upstreamUrl;
 
-	const codeVerifier = generateCodeVerifier();
-	const codeChallenge = generateCodeChallenge(codeVerifier);
+  const codeVerifier = generateCodeVerifier();
+  const codeChallenge = generateCodeChallenge(codeVerifier);
 
-	const stateStore = getStateStore();
-	const state = await stateStore.create({
-		userId,
-		agentId,
+  const stateStore = getStateStore();
+  const state = await stateStore.create({
+    userId,
+    agentId,
 		organizationId,
-		codeVerifier,
-		mcpId,
-		scopeKey,
-		endpoints,
-		client,
-		scope: scopeString,
-		resource,
-		platform,
-		channelId,
-		conversationId,
-		teamId,
-		connectionId,
-	});
+    codeVerifier,
+    mcpId,
+    scopeKey,
+    endpoints,
+    client,
+    scope: scopeString,
+    resource,
+    platform,
+    channelId,
+    conversationId,
+    teamId,
+    connectionId,
+  });
 
-	const authUrl = new URL(endpoints.authorizationEndpoint);
-	authUrl.searchParams.set("response_type", "code");
-	authUrl.searchParams.set("client_id", client.clientId);
-	authUrl.searchParams.set("redirect_uri", redirectUri);
-	authUrl.searchParams.set("code_challenge", codeChallenge);
-	authUrl.searchParams.set("code_challenge_method", "S256");
-	authUrl.searchParams.set("state", state);
-	if (scopeString) {
-		authUrl.searchParams.set("scope", scopeString);
-	}
-	if (resource) {
-		authUrl.searchParams.set("resource", resource);
-	}
+  const authUrl = new URL(endpoints.authorizationEndpoint);
+  authUrl.searchParams.set("response_type", "code");
+  authUrl.searchParams.set("client_id", client.clientId);
+  authUrl.searchParams.set("redirect_uri", redirectUri);
+  authUrl.searchParams.set("code_challenge", codeChallenge);
+  authUrl.searchParams.set("code_challenge_method", "S256");
+  authUrl.searchParams.set("state", state);
+  if (scopeString) {
+    authUrl.searchParams.set("scope", scopeString);
+  }
+  if (resource) {
+    authUrl.searchParams.set("resource", resource);
+  }
 
-	logger.info("Started MCP OAuth auth-code flow", {
-		mcpId,
-		agentId,
-		scopeKey,
-		clientId: client.clientId,
-		hasResource: !!resource,
-	});
+  logger.info("Started MCP OAuth auth-code flow", {
+    mcpId,
+    agentId,
+    scopeKey,
+    clientId: client.clientId,
+    hasResource: !!resource,
+  });
 
-	return {
-		authorizationUrl: authUrl.toString(),
-		state,
-	};
+  return {
+    authorizationUrl: authUrl.toString(),
+    state,
+  };
 }
 
 interface CompleteFlowOptions {
-	secretStore: WritableSecretStore;
-	state: string;
-	code: string;
-	redirectUri: string;
+  secretStore: WritableSecretStore;
+  state: string;
+  code: string;
+  redirectUri: string;
 }
 
 interface CompleteFlowResult {
-	mcpId: string;
-	agentId: string;
-	userId: string;
-	scopeKey: string;
-	platform: string;
-	channelId: string;
-	conversationId: string;
-	teamId?: string;
-	connectionId?: string;
-	/** Space-separated scopes actually granted (provider-reported) or requested. */
-	scope?: string;
+  mcpId: string;
+  agentId: string;
+  userId: string;
+  scopeKey: string;
+  platform: string;
+  channelId: string;
+  conversationId: string;
+  teamId?: string;
+  connectionId?: string;
+  /** Space-separated scopes actually granted (provider-reported) or requested. */
+  scope?: string;
 }
 
 /**
@@ -226,129 +226,129 @@ interface CompleteFlowResult {
 export async function completeAuthCodeFlow(
 	options: CompleteFlowOptions,
 ): Promise<CompleteFlowResult> {
-	const { secretStore, state, code, redirectUri } = options;
+  const { secretStore, state, code, redirectUri } = options;
 
-	const stateStore = getStateStore();
-	const stateData = await stateStore.consume(state);
-	if (!stateData) {
-		throw new Error("Invalid or expired OAuth state");
-	}
+  const stateStore = getStateStore();
+  const stateData = await stateStore.consume(state);
+  if (!stateData) {
+    throw new Error("Invalid or expired OAuth state");
+  }
 
-	const {
-		mcpId,
-		agentId,
-		userId,
+  const {
+    mcpId,
+    agentId,
+    userId,
 		organizationId,
-		scopeKey,
-		endpoints,
-		client,
-		codeVerifier,
-		scope,
-		resource,
-		platform,
-		channelId,
-		conversationId,
-		teamId,
-		connectionId,
-	} = stateData;
+    scopeKey,
+    endpoints,
+    client,
+    codeVerifier,
+    scope,
+    resource,
+    platform,
+    channelId,
+    conversationId,
+    teamId,
+    connectionId,
+  } = stateData;
 
-	const body: Record<string, string> = {
-		grant_type: "authorization_code",
-		code,
-		redirect_uri: redirectUri,
-		code_verifier: codeVerifier,
-		client_id: client.clientId,
-	};
-	if (resource) {
-		body.resource = resource;
-	}
+  const body: Record<string, string> = {
+    grant_type: "authorization_code",
+    code,
+    redirect_uri: redirectUri,
+    code_verifier: codeVerifier,
+    client_id: client.clientId,
+  };
+  if (resource) {
+    body.resource = resource;
+  }
 
-	const headers: Record<string, string> = {
-		"Content-Type": "application/x-www-form-urlencoded",
-		Accept: "application/json",
-	};
-	// RFC 6749 §2.3.1 — `client_secret_basic` is the default. Only fall back to
-	// `_post` when the AS advertises it explicitly (and we have a secret). A
-	// public PKCE client ("none") sends no secret at all.
-	if (client.clientSecret && client.tokenEndpointAuthMethod !== "none") {
-		if (client.tokenEndpointAuthMethod === "client_secret_post") {
-			body.client_secret = client.clientSecret;
-		} else {
-			const basic = Buffer.from(
+  const headers: Record<string, string> = {
+    "Content-Type": "application/x-www-form-urlencoded",
+    Accept: "application/json",
+  };
+  // RFC 6749 §2.3.1 — `client_secret_basic` is the default. Only fall back to
+  // `_post` when the AS advertises it explicitly (and we have a secret). A
+  // public PKCE client ("none") sends no secret at all.
+  if (client.clientSecret && client.tokenEndpointAuthMethod !== "none") {
+    if (client.tokenEndpointAuthMethod === "client_secret_post") {
+      body.client_secret = client.clientSecret;
+    } else {
+      const basic = Buffer.from(
 				`${encodeURIComponent(client.clientId)}:${encodeURIComponent(client.clientSecret)}`,
-			).toString("base64");
-			headers.Authorization = `Basic ${basic}`;
-		}
-	}
+      ).toString("base64");
+      headers.Authorization = `Basic ${basic}`;
+    }
+  }
 
-	const response = await fetch(endpoints.tokenEndpoint, {
-		method: "POST",
-		headers,
-		body: new URLSearchParams(body).toString(),
-	});
+  const response = await fetch(endpoints.tokenEndpoint, {
+    method: "POST",
+    headers,
+    body: new URLSearchParams(body).toString(),
+  });
 
-	if (!response.ok) {
-		const text = await response.text().catch(() => "");
-		logger.error("Token exchange failed", {
-			mcpId,
-			status: response.status,
-			body: text.slice(0, 500),
-		});
-		throw new Error(`Token exchange failed: ${response.status}`);
-	}
+  if (!response.ok) {
+    const text = await response.text().catch(() => "");
+    logger.error("Token exchange failed", {
+      mcpId,
+      status: response.status,
+      body: text.slice(0, 500),
+    });
+    throw new Error(`Token exchange failed: ${response.status}`);
+  }
 
-	const tokenData = (await response.json()) as {
-		access_token?: string;
-		refresh_token?: string;
-		expires_in?: number;
-		token_type?: string;
-		scope?: string;
-	};
+  const tokenData = (await response.json()) as {
+    access_token?: string;
+    refresh_token?: string;
+    expires_in?: number;
+    token_type?: string;
+    scope?: string;
+  };
 
-	if (!tokenData.access_token) {
-		throw new Error("Token exchange response missing access_token");
-	}
+  if (!tokenData.access_token) {
+    throw new Error("Token exchange response missing access_token");
+  }
 
-	const expiresAt =
-		typeof tokenData.expires_in === "number"
-			? Date.now() + tokenData.expires_in * 1000
-			: Date.now() + 3_600_000; // default 1h if not reported
+  const expiresAt =
+    typeof tokenData.expires_in === "number"
+      ? Date.now() + tokenData.expires_in * 1000
+      : Date.now() + 3_600_000; // default 1h if not reported
 
 	await runWithOrganizationContext(organizationId, () =>
 		storeCredentialForScope(secretStore, agentId, scopeKey, mcpId, {
-			accessToken: tokenData.access_token,
-			refreshToken: tokenData.refresh_token,
-			expiresAt,
-			clientId: client.clientId,
-			clientSecret: client.clientSecret,
-			tokenUrl: endpoints.tokenEndpoint,
-			resource,
-			tokenEndpointAuthMethod:
-				client.tokenEndpointAuthMethod === "client_secret_basic" ||
-				client.tokenEndpointAuthMethod === "client_secret_post" ||
-				client.tokenEndpointAuthMethod === "none"
-					? client.tokenEndpointAuthMethod
-					: undefined,
+    accessToken: tokenData.access_token,
+    refreshToken: tokenData.refresh_token,
+    expiresAt,
+    clientId: client.clientId,
+    clientSecret: client.clientSecret,
+    tokenUrl: endpoints.tokenEndpoint,
+    resource,
+    tokenEndpointAuthMethod:
+      client.tokenEndpointAuthMethod === "client_secret_basic" ||
+      client.tokenEndpointAuthMethod === "client_secret_post" ||
+      client.tokenEndpointAuthMethod === "none"
+        ? client.tokenEndpointAuthMethod
+        : undefined,
 		}),
 	);
 
-	logger.info("MCP OAuth auth-code flow completed", {
-		mcpId,
-		agentId,
-		scopeKey,
-		scope: scope ?? tokenData.scope,
-	});
+  logger.info("MCP OAuth auth-code flow completed", {
+    mcpId,
+    agentId,
+    scopeKey,
+    scope: scope ?? tokenData.scope,
+  });
 
-	return {
-		mcpId,
-		agentId,
-		userId,
-		scopeKey,
-		platform,
-		channelId,
-		conversationId,
-		teamId,
-		connectionId,
-		scope: tokenData.scope ?? scope,
-	};
+  return {
+    mcpId,
+    agentId,
+    userId,
+    scopeKey,
+    platform,
+    channelId,
+    conversationId,
+    teamId,
+    connectionId,
+    scope: tokenData.scope ?? scope,
+  };
 }

--- a/packages/server/src/gateway/auth/mcp/pending-tool-store.ts
+++ b/packages/server/src/gateway/auth/mcp/pending-tool-store.ts
@@ -10,25 +10,26 @@ import { getDb } from "../../../db/client.js";
 const SCOPE = "pending-tool";
 
 export interface PendingToolInvocation {
-  mcpId: string;
-  toolName: string;
-  args: Record<string, unknown>;
-  agentId: string;
-  userId: string;
-  channelId?: string;
-  conversationId?: string;
-  teamId?: string;
-  connectionId?: string;
+	mcpId: string;
+	toolName: string;
+	args: Record<string, unknown>;
+	agentId: string;
+	userId: string;
+	organizationId?: string;
+	channelId?: string;
+	conversationId?: string;
+	teamId?: string;
+	connectionId?: string;
 }
 
 export async function storePendingTool(
-  requestId: string,
-  invocation: PendingToolInvocation,
-  ttlSeconds: number
+	requestId: string,
+	invocation: PendingToolInvocation,
+	ttlSeconds: number,
 ): Promise<void> {
-  const sql = getDb();
-  const expiresAt = new Date(Date.now() + ttlSeconds * 1000);
-  await sql`
+	const sql = getDb();
+	const expiresAt = new Date(Date.now() + ttlSeconds * 1000);
+	await sql`
     INSERT INTO oauth_states (id, scope, payload, expires_at)
     VALUES (${requestId}, ${SCOPE}, ${sql.json(invocation as object)}, ${expiresAt})
     ON CONFLICT (id) DO UPDATE SET
@@ -45,16 +46,16 @@ export async function storePendingTool(
  * click see null and no-op.
  */
 export async function takePendingTool(
-  requestId: string
+	requestId: string,
 ): Promise<PendingToolInvocation | null> {
-  const sql = getDb();
-  const rows = await sql`
+	const sql = getDb();
+	const rows = await sql`
     DELETE FROM oauth_states
     WHERE id = ${requestId}
       AND scope = ${SCOPE}
       AND expires_at > now()
     RETURNING payload
   `;
-  if (rows.length === 0) return null;
-  return ((rows[0] as { payload: PendingToolInvocation }).payload) ?? null;
+	if (rows.length === 0) return null;
+	return (rows[0] as { payload: PendingToolInvocation }).payload ?? null;
 }

--- a/packages/server/src/gateway/auth/mcp/pending-tool-store.ts
+++ b/packages/server/src/gateway/auth/mcp/pending-tool-store.ts
@@ -15,7 +15,7 @@ export interface PendingToolInvocation {
   args: Record<string, unknown>;
   agentId: string;
   userId: string;
-	organizationId?: string;
+	organizationId: string;
   channelId?: string;
   conversationId?: string;
   teamId?: string;

--- a/packages/server/src/gateway/auth/mcp/pending-tool-store.ts
+++ b/packages/server/src/gateway/auth/mcp/pending-tool-store.ts
@@ -10,26 +10,26 @@ import { getDb } from "../../../db/client.js";
 const SCOPE = "pending-tool";
 
 export interface PendingToolInvocation {
-	mcpId: string;
-	toolName: string;
-	args: Record<string, unknown>;
-	agentId: string;
-	userId: string;
+  mcpId: string;
+  toolName: string;
+  args: Record<string, unknown>;
+  agentId: string;
+  userId: string;
 	organizationId?: string;
-	channelId?: string;
-	conversationId?: string;
-	teamId?: string;
-	connectionId?: string;
+  channelId?: string;
+  conversationId?: string;
+  teamId?: string;
+  connectionId?: string;
 }
 
 export async function storePendingTool(
-	requestId: string,
-	invocation: PendingToolInvocation,
+  requestId: string,
+  invocation: PendingToolInvocation,
 	ttlSeconds: number,
 ): Promise<void> {
-	const sql = getDb();
-	const expiresAt = new Date(Date.now() + ttlSeconds * 1000);
-	await sql`
+  const sql = getDb();
+  const expiresAt = new Date(Date.now() + ttlSeconds * 1000);
+  await sql`
     INSERT INTO oauth_states (id, scope, payload, expires_at)
     VALUES (${requestId}, ${SCOPE}, ${sql.json(invocation as object)}, ${expiresAt})
     ON CONFLICT (id) DO UPDATE SET
@@ -48,14 +48,14 @@ export async function storePendingTool(
 export async function takePendingTool(
 	requestId: string,
 ): Promise<PendingToolInvocation | null> {
-	const sql = getDb();
-	const rows = await sql`
+  const sql = getDb();
+  const rows = await sql`
     DELETE FROM oauth_states
     WHERE id = ${requestId}
       AND scope = ${SCOPE}
       AND expires_at > now()
     RETURNING payload
   `;
-	if (rows.length === 0) return null;
+  if (rows.length === 0) return null;
 	return (rows[0] as { payload: PendingToolInvocation }).payload ?? null;
 }

--- a/packages/server/src/gateway/auth/mcp/proxy-auth-flows.ts
+++ b/packages/server/src/gateway/auth/mcp/proxy-auth-flows.ts
@@ -7,6 +7,7 @@ import type {
 	HttpMcpServerConfig,
 	McpConfigSource,
 } from "./proxy-shared.js";
+import { runWithOrganizationContext } from "./proxy-shared.js";
 
 const logger = createLogger("mcp-proxy");
 
@@ -108,6 +109,7 @@ export class McpAuthFlows {
 				params.mcpId,
 				params.agentId,
 				params.scopeKey,
+				params.organizationId,
 			);
 			if (legacyAuth) return fire(legacyAuth);
 		}
@@ -258,6 +260,25 @@ export class McpAuthFlows {
 	 * Returns a user-facing message with the verification URL, or null on failure.
 	 */
 	async tryAutoDeviceAuth(
+		mcpId: string,
+		agentId: string,
+		scopeKey: string,
+		organizationId?: string,
+	): Promise<AuthRequiredPayload | null> {
+		if (!organizationId) {
+			logger.warn("Device-auth flow skipped: worker token has no organizationId", {
+				mcpId,
+				agentId,
+			});
+			return null;
+		}
+
+		return runWithOrganizationContext(organizationId, () =>
+			this.tryAutoDeviceAuthScoped(mcpId, agentId, scopeKey),
+		);
+	}
+
+	private async tryAutoDeviceAuthScoped(
 		mcpId: string,
 		agentId: string,
 		scopeKey: string,

--- a/packages/server/src/gateway/auth/mcp/proxy-auth-flows.ts
+++ b/packages/server/src/gateway/auth/mcp/proxy-auth-flows.ts
@@ -2,12 +2,12 @@ import { createLogger, type WorkerTokenData } from "@lobu/core";
 import { startDeviceAuth } from "../../routes/internal/device-auth.js";
 import type { WritableSecretStore } from "../../secrets/index.js";
 import { startAuthCodeFlow } from "./oauth-flow.js";
-import type {
-	AuthRequiredPayload,
-	HttpMcpServerConfig,
-	McpConfigSource,
+import {
+	runWithOrganizationContext,
+	type AuthRequiredPayload,
+	type HttpMcpServerConfig,
+	type McpConfigSource,
 } from "./proxy-shared.js";
-import { runWithOrganizationContext } from "./proxy-shared.js";
 
 const logger = createLogger("mcp-proxy");
 
@@ -48,9 +48,9 @@ export class McpAuthFlows {
 	/**
 	 * Handle an HTTP 401 from an MCP upstream: drain the response body, attempt
 	 * the OAuth 2.1 auth-code flow (RFC 9728 → 8414 → 7591 discovery), and —
-	 * when `deviceAuthFallback` is set — fall back to the legacy device-code
-	 * flow. Fires `onAuthRequired` with whichever payload succeeds and returns
-	 * it (or null when no flow could be started).
+	 * when `deviceAuthFallback` is set — fall back to device-code auth. Fires
+	 * `onAuthRequired` with whichever payload succeeds and returns it (or null
+	 * when no flow could be started).
 	 */
 	async handleUpstream401(params: {
 		response?: Response;
@@ -105,13 +105,13 @@ export class McpAuthFlows {
 		if (authCodeResult) return fire(authCodeResult);
 
 		if (params.deviceAuthFallback) {
-			const legacyAuth = await this.tryAutoDeviceAuth(
+			const deviceAuth = await this.tryAutoDeviceAuth(
 				params.mcpId,
 				params.agentId,
 				params.scopeKey,
 				params.organizationId,
 			);
-			if (legacyAuth) return fire(legacyAuth);
+			if (deviceAuth) return fire(deviceAuth);
 		}
 
 		return null;

--- a/packages/server/src/gateway/auth/mcp/proxy-auth-flows.ts
+++ b/packages/server/src/gateway/auth/mcp/proxy-auth-flows.ts
@@ -56,6 +56,7 @@ export class McpAuthFlows {
 		mcpId: string;
 		agentId: string;
 		userId: string;
+		organizationId?: string;
 		scopeKey: string;
 		httpServer: HttpMcpServerConfig;
 		wwwAuthenticate: string | null;
@@ -90,6 +91,7 @@ export class McpAuthFlows {
 			mcpId: params.mcpId,
 			agentId: params.agentId,
 			userId: params.userId,
+			organizationId: params.organizationId,
 			scopeKey: params.scopeKey,
 			httpServer: params.httpServer,
 			wwwAuthenticate: params.wwwAuthenticate,
@@ -163,6 +165,7 @@ export class McpAuthFlows {
 			mcpId,
 			agentId,
 			userId: tokenData?.userId || scopeKey,
+			organizationId: tokenData?.organizationId,
 			scopeKey,
 			httpServer,
 			wwwAuthenticate,
@@ -185,6 +188,7 @@ export class McpAuthFlows {
 		mcpId: string;
 		agentId: string;
 		userId: string;
+		organizationId?: string;
 		scopeKey: string;
 		httpServer: HttpMcpServerConfig;
 		wwwAuthenticate: string | null;
@@ -204,6 +208,16 @@ export class McpAuthFlows {
 			});
 			return null;
 		}
+		if (!params.organizationId) {
+			logger.warn(
+				"Auth-code flow skipped: worker token has no organizationId",
+				{
+					mcpId: params.mcpId,
+					agentId: params.agentId,
+				},
+			);
+			return null;
+		}
 
 		try {
 			const redirectUri = `${this.publicGatewayUrl.replace(/\/+$/, "")}/mcp/oauth/callback`;
@@ -213,6 +227,7 @@ export class McpAuthFlows {
 				upstreamUrl: params.httpServer.upstreamUrl,
 				agentId: params.agentId,
 				userId: params.userId,
+				organizationId: params.organizationId,
 				scopeKey: params.scopeKey,
 				wwwAuthenticate: params.wwwAuthenticate,
 				redirectUri,

--- a/packages/server/src/gateway/auth/mcp/proxy-forward.ts
+++ b/packages/server/src/gateway/auth/mcp/proxy-forward.ts
@@ -93,7 +93,9 @@ async function handleProxyRequestAuthenticated(
 							jsonrpc: "2.0",
 							id: jsonRpc.id,
 							result: {
-								content: [{ type: "text", text: "Tool call blocked by policy." }],
+								content: [
+									{ type: "text", text: "Tool call blocked by policy." },
+								],
 								isError: true,
 							},
 						});
@@ -151,6 +153,7 @@ async function handleProxyRequestAuthenticated(
 				teamId: tokenData.teamId,
 				connectionId: tokenData.connectionId,
 				workerToken: sessionToken,
+				organizationId: tokenData.organizationId,
 			},
 		);
 	} catch (error) {
@@ -178,6 +181,7 @@ async function forwardRequest(
 		teamId?: string;
 		connectionId?: string;
 		workerToken?: string;
+		organizationId?: string;
 	},
 ): Promise<Response> {
 	const ssrfBlock = await ssrfBlockResponse(httpServer, mcpId, agentId);
@@ -267,6 +271,7 @@ async function forwardRequest(
 			mcpId,
 			agentId,
 			userId: authContext.userId,
+			organizationId: authContext.organizationId,
 			scopeKey: scopeKey ?? authContext.userId,
 			httpServer,
 			wwwAuthenticate: response.headers.get("www-authenticate"),

--- a/packages/server/src/gateway/auth/mcp/proxy-forward.ts
+++ b/packages/server/src/gateway/auth/mcp/proxy-forward.ts
@@ -9,6 +9,7 @@ import {
 	getRequestBodyAsText,
 	type HttpMcpServerConfig,
 	MAX_BODY_SIZE,
+	runWithWorkerOrgContext,
 	sendJsonRpcError,
 	UPSTREAM_FETCH_TIMEOUT_MS,
 	upstreamTimeoutSignal,
@@ -44,6 +45,18 @@ export async function handleProxyRequest(
 		return sendJsonRpcError(c, -32600, "Invalid authentication token");
 	}
 
+	return runWithWorkerOrgContext(tokenData, () =>
+		handleProxyRequestAuthenticated(proxy, c, mcpId, sessionToken, tokenData),
+	);
+}
+
+async function handleProxyRequestAuthenticated(
+	proxy: McpProxy,
+	c: Context,
+	mcpId: string,
+	sessionToken: string,
+	tokenData: NonNullable<ReturnType<typeof verifyWorkerToken>>,
+): Promise<Response> {
 	const agentId = tokenData.agentId || tokenData.userId;
 	const httpServer = await proxy.configService.getHttpServer(mcpId, agentId);
 

--- a/packages/server/src/gateway/auth/mcp/proxy-forward.ts
+++ b/packages/server/src/gateway/auth/mcp/proxy-forward.ts
@@ -44,6 +44,9 @@ export async function handleProxyRequest(
 	if (!tokenData) {
 		return sendJsonRpcError(c, -32600, "Invalid authentication token");
 	}
+	if (!tokenData.organizationId) {
+		return sendJsonRpcError(c, -32600, "Worker token missing organizationId");
+	}
 
 	return runWithWorkerOrgContext(tokenData, () =>
 		handleProxyRequestAuthenticated(proxy, c, mcpId, sessionToken, tokenData),

--- a/packages/server/src/gateway/auth/mcp/proxy-rest-routes.ts
+++ b/packages/server/src/gateway/auth/mcp/proxy-rest-routes.ts
@@ -297,6 +297,7 @@ async function handleCallToolAuthenticated(
 					mcpId,
 					agentId,
 					scopeKey,
+					auth.tokenData.organizationId,
 				);
 				if (autoAuthResult) {
 					await proxy.authFlows.fireAuthRequired(

--- a/packages/server/src/gateway/auth/mcp/proxy-rest-routes.ts
+++ b/packages/server/src/gateway/auth/mcp/proxy-rest-routes.ts
@@ -7,6 +7,7 @@ import {
 	type JsonRpcResponse,
 	MAX_BODY_SIZE,
 	parseJsonRpcResponse,
+	runWithWorkerOrgContext,
 } from "./proxy-shared.js";
 import { ssrfBlockResponse } from "./proxy-upstream.js";
 import type { McpTool } from "./tool-cache.js";
@@ -22,6 +23,17 @@ export async function handleListTools(
 	const auth = await authenticateRequest(c);
 	if (!auth) return c.json({ error: "Invalid authentication token" }, 401);
 
+	return runWithWorkerOrgContext(auth.tokenData, () =>
+		handleListToolsAuthenticated(proxy, c, auth, mcpId),
+	);
+}
+
+async function handleListToolsAuthenticated(
+	proxy: McpProxy,
+	c: Context,
+	auth: NonNullable<Awaited<ReturnType<typeof authenticateRequest>>>,
+	mcpId: string,
+): Promise<Response> {
 	const agentId = auth.tokenData.agentId || auth.tokenData.userId;
 	const requesterUserId = auth.tokenData.userId;
 	if (!agentId || !requesterUserId) {
@@ -70,6 +82,18 @@ export async function handleCallTool(
 	const auth = await authenticateRequest(c);
 	if (!auth) return c.json({ error: "Invalid authentication token" }, 401);
 
+	return runWithWorkerOrgContext(auth.tokenData, () =>
+		handleCallToolAuthenticated(proxy, c, auth, mcpId, toolName),
+	);
+}
+
+async function handleCallToolAuthenticated(
+	proxy: McpProxy,
+	c: Context,
+	auth: NonNullable<Awaited<ReturnType<typeof authenticateRequest>>>,
+	mcpId: string,
+	toolName: string,
+): Promise<Response> {
 	const agentId = auth.tokenData.agentId || auth.tokenData.userId;
 	const requesterUserId = auth.tokenData.userId;
 	if (!agentId || !requesterUserId) {
@@ -337,6 +361,16 @@ export async function handleListAllTools(
 	const auth = await authenticateRequest(c);
 	if (!auth) return c.json({ error: "Invalid authentication token" }, 401);
 
+	return runWithWorkerOrgContext(auth.tokenData, () =>
+		handleListAllToolsAuthenticated(proxy, c, auth),
+	);
+}
+
+async function handleListAllToolsAuthenticated(
+	proxy: McpProxy,
+	c: Context,
+	auth: NonNullable<Awaited<ReturnType<typeof authenticateRequest>>>,
+): Promise<Response> {
 	const agentId = auth.tokenData.agentId || auth.tokenData.userId;
 
 	const allHttpServers = await proxy.configService.getAllHttpServers(agentId);

--- a/packages/server/src/gateway/auth/mcp/proxy-rest-routes.ts
+++ b/packages/server/src/gateway/auth/mcp/proxy-rest-routes.ts
@@ -214,6 +214,7 @@ async function handleCallToolAuthenticated(
 				mcpId,
 				agentId,
 				userId: requesterUserId,
+				organizationId: auth.tokenData.organizationId,
 				scopeKey,
 				httpServer,
 				wwwAuthenticate: response.headers.get("www-authenticate"),

--- a/packages/server/src/gateway/auth/mcp/proxy-rest-routes.ts
+++ b/packages/server/src/gateway/auth/mcp/proxy-rest-routes.ts
@@ -22,6 +22,9 @@ export async function handleListTools(
 	if (!mcpId) return c.json({ error: "Missing MCP server id" }, 400);
 	const auth = await authenticateRequest(c);
 	if (!auth) return c.json({ error: "Invalid authentication token" }, 401);
+	if (!auth.tokenData.organizationId) {
+		return c.json({ error: "Worker token missing organizationId" }, 401);
+	}
 
 	return runWithWorkerOrgContext(auth.tokenData, () =>
 		handleListToolsAuthenticated(proxy, c, auth, mcpId),
@@ -81,6 +84,9 @@ export async function handleCallTool(
 	}
 	const auth = await authenticateRequest(c);
 	if (!auth) return c.json({ error: "Invalid authentication token" }, 401);
+	if (!auth.tokenData.organizationId) {
+		return c.json({ error: "Worker token missing organizationId" }, 401);
+	}
 
 	return runWithWorkerOrgContext(auth.tokenData, () =>
 		handleCallToolAuthenticated(proxy, c, auth, mcpId, toolName),
@@ -362,6 +368,9 @@ export async function handleListAllTools(
 ): Promise<Response> {
 	const auth = await authenticateRequest(c);
 	if (!auth) return c.json({ error: "Invalid authentication token" }, 401);
+	if (!auth.tokenData.organizationId) {
+		return c.json({ error: "Worker token missing organizationId" }, 401);
+	}
 
 	return runWithWorkerOrgContext(auth.tokenData, () =>
 		handleListAllToolsAuthenticated(proxy, c, auth),

--- a/packages/server/src/gateway/auth/mcp/proxy-shared.ts
+++ b/packages/server/src/gateway/auth/mcp/proxy-shared.ts
@@ -1,5 +1,6 @@
 import { verifyWorkerToken, type WorkerTokenData } from "@lobu/core";
 import type { Context } from "hono";
+import { orgContext } from "../../../lobu/stores/org-context.js";
 import { getRevokedTokenStore } from "../revoked-token-store.js";
 import type { McpTool } from "./tool-cache.js";
 
@@ -126,6 +127,14 @@ export async function authenticateRequest(
 	}
 
 	return { tokenData, token: sessionToken };
+}
+
+export function runWithWorkerOrgContext<T>(
+	tokenData: WorkerTokenData,
+	fn: () => T,
+): T {
+	if (!tokenData.organizationId) return fn();
+	return orgContext.run({ organizationId: tokenData.organizationId }, fn);
 }
 
 export function extractSessionToken(c: Context): string | null {

--- a/packages/server/src/gateway/auth/mcp/proxy-shared.ts
+++ b/packages/server/src/gateway/auth/mcp/proxy-shared.ts
@@ -140,8 +140,15 @@ export function runWithWorkerOrgContext<T>(
 	tokenData: WorkerTokenData,
 	fn: () => T,
 ): T {
-	if (!tokenData.organizationId) return fn();
-	return orgContext.run({ organizationId: tokenData.organizationId }, fn);
+	return runWithOrganizationContext(tokenData.organizationId, fn);
+}
+
+export function runWithOrganizationContext<T>(
+	organizationId: string | null | undefined,
+	fn: () => T,
+): T {
+	if (!organizationId) return fn();
+	return orgContext.run({ organizationId }, fn);
 }
 
 export function extractSessionToken(c: Context): string | null {

--- a/packages/server/src/gateway/auth/mcp/proxy-shared.ts
+++ b/packages/server/src/gateway/auth/mcp/proxy-shared.ts
@@ -129,6 +129,13 @@ export async function authenticateRequest(
 	return { tokenData, token: sessionToken };
 }
 
+/**
+ * Run MCP proxy work inside the organization bound to the worker token.
+ *
+ * The Postgres secret store resolves org-scoped credentials from
+ * AsyncLocalStorage, so authenticated MCP routes must install the token's
+ * organization context before reading OAuth credentials.
+ */
 export function runWithWorkerOrgContext<T>(
 	tokenData: WorkerTokenData,
 	fn: () => T,

--- a/packages/server/src/gateway/auth/mcp/proxy-shared.ts
+++ b/packages/server/src/gateway/auth/mcp/proxy-shared.ts
@@ -147,7 +147,9 @@ export function runWithOrganizationContext<T>(
 	organizationId: string | null | undefined,
 	fn: () => T,
 ): T {
-	if (!organizationId) return fn();
+	if (!organizationId) {
+		throw new Error("MCP organization context requires organizationId");
+	}
 	return orgContext.run({ organizationId }, fn);
 }
 

--- a/packages/server/src/gateway/auth/mcp/proxy.ts
+++ b/packages/server/src/gateway/auth/mcp/proxy.ts
@@ -444,22 +444,22 @@ export class McpProxy {
 	}
 
 	/**
-	 * Run the agent's resolved pre-tool guardrails (built-in names + skill-
-	 * declared SKILL.md guardrails) for a `tools/call`. Returns true if a
-	 * guardrail tripped and the call must be blocked — the caller then returns a
-	 * generic, platform-shaped "blocked by policy" response (the specific reason
-	 * is never surfaced to the worker; that would be an evasion oracle).
-	 *
-	 * Shared by BOTH tool-call entrypoints — the JSON-RPC forward path
-	 * (`handleProxyRequest`) and the REST `handleCallTool` — so neither can
-	 * bypass the stage, and independent of `grantStore` so guardrails enforce
-	 * even when the approval subsystem isn't configured.
-	 *
-	 * Fails OPEN on store/registry-level errors (per-guardrail throws already
-	 * fail open in the runner); judge guardrails fail CLOSED by design.
-	 *
-	 * @internal Public only for the route-handler modules.
-	 */
+	* Run the agent's resolved pre-tool guardrails (built-in names + skill-
+	* declared SKILL.md guardrails) for a `tools/call`. Returns true if a
+	* guardrail tripped and the call must be blocked — the caller then returns a
+	* generic, platform-shaped "blocked by policy" response (the specific reason
+	* is never surfaced to the worker; that would be an evasion oracle).
+	*
+	* Shared by BOTH tool-call entrypoints — the JSON-RPC forward path
+	* (`handleProxyRequest`) and the REST `handleCallTool` — so neither can
+	* bypass the stage, and independent of `grantStore` so guardrails enforce
+	* even when the approval subsystem isn't configured.
+	*
+	* Fails OPEN on store/registry-level errors (per-guardrail throws already
+	* fail open in the runner); judge guardrails fail CLOSED by design.
+	*
+	* @internal Public only for the route-handler modules.
+	*/
 	async runPreToolGuardrails(
 		agentId: string,
 		tokenData: {

--- a/packages/server/src/gateway/auth/mcp/proxy.ts
+++ b/packages/server/src/gateway/auth/mcp/proxy.ts
@@ -125,7 +125,7 @@ export class McpProxy {
 		mcpId: string,
 		toolName: string,
 		args: Record<string, unknown>,
-		options?: { organizationId?: string },
+		options: { organizationId: string },
 	): Promise<{
 		content: Array<{ type: string; text: string }>;
 		isError: boolean;
@@ -586,6 +586,13 @@ export class McpProxy {
 		});
 
 		if (!this.onToolBlocked) return "blocked-no-channel";
+		if (!tokenData.organizationId) {
+			logger.error(
+				{ agentId, mcpId, toolName },
+				"Refusing to store pending MCP tool approval without organizationId",
+			);
+			return "blocked-no-channel";
+		}
 
 		const requestId = `ta_${randomUUID()}`;
 		await storePendingTool(

--- a/packages/server/src/gateway/auth/mcp/proxy.ts
+++ b/packages/server/src/gateway/auth/mcp/proxy.ts
@@ -7,10 +7,10 @@ import {
 } from "@lobu/core";
 import type { Context } from "hono";
 import { Hono } from "hono";
-import { requiresToolApproval } from "../../permissions/approval-policy.js";
-import type { GrantStore } from "../../permissions/grant-store.js";
 import { resolveAgentGuardrails } from "../../guardrails/aggregator.js";
 import { recordGuardrailTrip } from "../../guardrails/audit.js";
+import { requiresToolApproval } from "../../permissions/approval-policy.js";
+import type { GrantStore } from "../../permissions/grant-store.js";
 import type { WritableSecretStore } from "../../secrets/index.js";
 import type { AgentSettingsStore } from "../settings/agent-settings-store.js";
 import { storePendingTool } from "./pending-tool-store.js";
@@ -30,6 +30,7 @@ import {
 	type JsonRpcResponse,
 	type McpConfigSource,
 	parseJsonRpcResponse,
+	runWithOrganizationContext,
 } from "./proxy-shared.js";
 import { McpUpstreamClient } from "./proxy-upstream.js";
 import type { CachedMcpServer, McpTool, McpToolCache } from "./tool-cache.js";
@@ -124,6 +125,22 @@ export class McpProxy {
 		mcpId: string,
 		toolName: string,
 		args: Record<string, unknown>,
+		options?: { organizationId?: string },
+	): Promise<{
+		content: Array<{ type: string; text: string }>;
+		isError: boolean;
+	}> {
+		return runWithOrganizationContext(options?.organizationId, () =>
+			this.executeToolDirectScoped(agentId, userId, mcpId, toolName, args),
+		);
+	}
+
+	private async executeToolDirectScoped(
+		agentId: string,
+		userId: string,
+		mcpId: string,
+		toolName: string,
+		args: Record<string, unknown>,
 	): Promise<{
 		content: Array<{ type: string; text: string }>;
 		isError: boolean;
@@ -172,7 +189,14 @@ export class McpProxy {
 				};
 			}
 
-			const json = (await parseJsonRpcResponse(response)) as any;
+			const json = (await parseJsonRpcResponse(response)) as {
+				result?: {
+					content?: Array<{ type: string; text: string }>;
+					isError?: boolean;
+				};
+				content?: Array<{ type: string; text: string }>;
+				isError?: boolean;
+			};
 			const result = json.result || json;
 			return {
 				content: result.content || [
@@ -207,6 +231,24 @@ export class McpProxy {
 	 * then fetches tool list.
 	 */
 	async fetchToolsForMcp(
+		mcpId: string,
+		agentId: string,
+		tokenData: WorkerTokenData,
+		workerToken?: string,
+		options?: { surfaceErrors?: boolean },
+	): Promise<{ tools: McpTool[]; instructions?: string }> {
+		return runWithOrganizationContext(tokenData.organizationId, () =>
+			this.fetchToolsForMcpScoped(
+				mcpId,
+				agentId,
+				tokenData,
+				workerToken,
+				options,
+			),
+		);
+	}
+
+	private async fetchToolsForMcpScoped(
 		mcpId: string,
 		agentId: string,
 		tokenData: WorkerTokenData,
@@ -402,22 +444,22 @@ export class McpProxy {
 	}
 
 	/**
-	* Run the agent's resolved pre-tool guardrails (built-in names + skill-
-	* declared SKILL.md guardrails) for a `tools/call`. Returns true if a
-	* guardrail tripped and the call must be blocked — the caller then returns a
-	* generic, platform-shaped "blocked by policy" response (the specific reason
-	* is never surfaced to the worker; that would be an evasion oracle).
-	*
-	* Shared by BOTH tool-call entrypoints — the JSON-RPC forward path
-	* (`handleProxyRequest`) and the REST `handleCallTool` — so neither can
-	* bypass the stage, and independent of `grantStore` so guardrails enforce
-	* even when the approval subsystem isn't configured.
-	*
-	* Fails OPEN on store/registry-level errors (per-guardrail throws already
-	* fail open in the runner); judge guardrails fail CLOSED by design.
-	*
-	* @internal Public only for the route-handler modules.
-	*/
+	 * Run the agent's resolved pre-tool guardrails (built-in names + skill-
+	 * declared SKILL.md guardrails) for a `tools/call`. Returns true if a
+	 * guardrail tripped and the call must be blocked — the caller then returns a
+	 * generic, platform-shaped "blocked by policy" response (the specific reason
+	 * is never surfaced to the worker; that would be an evasion oracle).
+	 *
+	 * Shared by BOTH tool-call entrypoints — the JSON-RPC forward path
+	 * (`handleProxyRequest`) and the REST `handleCallTool` — so neither can
+	 * bypass the stage, and independent of `grantStore` so guardrails enforce
+	 * even when the approval subsystem isn't configured.
+	 *
+	 * Fails OPEN on store/registry-level errors (per-guardrail throws already
+	 * fail open in the runner); judge guardrails fail CLOSED by design.
+	 *
+	 * @internal Public only for the route-handler modules.
+	 */
 	async runPreToolGuardrails(
 		agentId: string,
 		tokenData: {
@@ -426,7 +468,7 @@ export class McpProxy {
 			organizationId?: string;
 		},
 		toolName: string,
-		toolArgs: Record<string, unknown>
+		toolArgs: Record<string, unknown>,
 	): Promise<boolean> {
 		if (!this.guardrailRegistry || !this.agentSettingsStore) return false;
 		try {
@@ -434,7 +476,7 @@ export class McpProxy {
 			const resolved = resolveAgentGuardrails(
 				settings ?? { guardrails: [] },
 				(settings?.skillsConfig?.skills ?? []).filter((s) => s.enabled),
-				this.guardrailRegistry
+				this.guardrailRegistry,
 			);
 			const list = resolved.byStage["pre-tool"];
 			if (list.length === 0) return false;
@@ -463,7 +505,7 @@ export class McpProxy {
 									? lookupErr.message
 									: String(lookupErr),
 						},
-						"Pre-tool guardrail trip: orgId metadata lookup failed (audit may be skipped)"
+						"Pre-tool guardrail trip: orgId metadata lookup failed (audit may be skipped)",
 					);
 				}
 			}
@@ -479,7 +521,7 @@ export class McpProxy {
 			});
 			logger.info(
 				{ agentId, toolName, guardrail: outcome.tripped.guardrail },
-				"Pre-tool guardrail tripped — blocking tool call with generic policy message"
+				"Pre-tool guardrail tripped — blocking tool call with generic policy message",
 			);
 			return true;
 		} catch (err) {
@@ -491,7 +533,7 @@ export class McpProxy {
 					toolName,
 					err: err instanceof Error ? err.message : String(err),
 				},
-				"Pre-tool guardrail check failed — proceeding without guardrails"
+				"Pre-tool guardrail check failed — proceeding without guardrails",
 			);
 			return false;
 		}
@@ -554,6 +596,7 @@ export class McpProxy {
 				args: toolArgs,
 				agentId,
 				userId: tokenData.userId,
+				organizationId: tokenData.organizationId,
 				channelId: tokenData.channelId || "",
 				conversationId: tokenData.conversationId || "",
 				teamId: tokenData.teamId,

--- a/packages/server/src/gateway/cli/gateway.ts
+++ b/packages/server/src/gateway/cli/gateway.ts
@@ -273,6 +273,18 @@ export function createGatewayApp(
         agentMetadataStore: coreServices.getAgentMetadataStore(),
         platformRegistry,
         approveToolCall: async (requestId: string, decision: string) => {
+          const expiresMap = {
+            "1h": Date.now() + 3_600_000,
+            "24h": Date.now() + 86_400_000,
+            always: null,
+          } satisfies Record<string, number | null>;
+          const isGrantDecision = (
+            value: string,
+          ): value is keyof typeof expiresMap => value in expiresMap;
+          if (decision !== "deny" && !isGrantDecision(decision)) {
+            return { success: false, error: "Invalid decision" };
+          }
+
           // DELETE ... RETURNING atomically claims the pending invocation
           // so a retry of POST /api/v1/agents/approve (CLI re-tries,
           // double-clicks, Slack webhook retries) cannot double-execute the
@@ -282,24 +294,19 @@ export function createGatewayApp(
           if (!pending)
             return { success: false, error: "Request not found or expired" };
           const pattern = `/mcp/${pending.mcpId}/tools/${pending.toolName}`;
-          const expiresMap: Record<string, number | null> = {
-            "1h": Date.now() + 3_600_000,
-            "24h": Date.now() + 86_400_000,
-            always: null,
-          };
           if (decision === "deny") {
             await approveGrantStore?.grant(
               pending.agentId,
               pattern,
               null,
-							true,
+              true,
             );
             return { success: true };
           }
           await approveGrantStore?.grant(
             pending.agentId,
             pattern,
-						decision in expiresMap ? expiresMap[decision]! : null,
+            expiresMap[decision],
           );
           if (approveMcpProxy) {
             const result = await approveMcpProxy.executeToolDirect(
@@ -307,10 +314,10 @@ export function createGatewayApp(
               pending.userId,
               pending.mcpId,
               pending.toolName,
-							pending.args,
-							...(pending.organizationId
-								? [{ organizationId: pending.organizationId }]
-								: []),
+              pending.args,
+              ...(pending.organizationId
+                ? [{ organizationId: pending.organizationId }]
+                : []),
             );
             return { success: true, result } as any;
           }

--- a/packages/server/src/gateway/cli/gateway.ts
+++ b/packages/server/src/gateway/cli/gateway.ts
@@ -27,36 +27,36 @@ import { createAgentRoutes } from "../routes/public/agents.js";
 import { createChannelBindingRoutes } from "../routes/public/channels.js";
 import { createConnectAuthRoutes } from "../routes/public/connect-auth.js";
 import {
-	createConnectionCrudRoutes,
-	createConnectionWebhookRoutes,
+  createConnectionCrudRoutes,
+  createConnectionWebhookRoutes,
 } from "../routes/public/connections.js";
 import { createPublicFileRoutes } from "../routes/public/files.js";
 import { createLandingRoutes } from "../routes/public/landing.js";
 import { createMcpOAuthRoutes } from "../routes/public/mcp-oauth.js";
 import {
-	createOAuthRoutes,
-	type ProviderCredentialStore,
+  createOAuthRoutes,
+  type ProviderCredentialStore,
 } from "../routes/public/oauth.js";
 import {
-	setAuthProvider,
-	verifySettingsSessionOrToken,
+  setAuthProvider,
+  verifySettingsSessionOrToken,
 } from "../routes/public/settings-auth.js";
 import { createSlackRoutes } from "../routes/public/slack.js";
 
 const logger = createLogger("gateway-startup");
 
 interface CreateGatewayAppOptions {
-	secretProxy: any;
-	workerGateway: any;
-	mcpProxy: any;
-	interactionService?: any;
-	platformRegistry?: any;
-	coreServices?: any;
-	chatInstanceManager?:
-		| import("../connections/chat-instance-manager.js").ChatInstanceManager
-		| null;
-	/** Custom auth provider for embedded mode. When set, gateway delegates auth to this function instead of using cookie-based sessions. */
-	authProvider?: import("../routes/public/settings-auth.js").AuthProvider;
+  secretProxy: any;
+  workerGateway: any;
+  mcpProxy: any;
+  interactionService?: any;
+  platformRegistry?: any;
+  coreServices?: any;
+  chatInstanceManager?:
+    | import("../connections/chat-instance-manager.js").ChatInstanceManager
+    | null;
+  /** Custom auth provider for embedded mode. When set, gateway delegates auth to this function instead of using cookie-based sessions. */
+  authProvider?: import("../routes/public/settings-auth.js").AuthProvider;
 }
 
 /**
@@ -67,719 +67,719 @@ interface CreateGatewayAppOptions {
 export function createGatewayApp(
 	options: CreateGatewayAppOptions,
 ): OpenAPIHono {
-	const {
-		secretProxy,
-		workerGateway,
-		mcpProxy,
-		interactionService,
-		platformRegistry,
-		coreServices,
-		chatInstanceManager,
-		authProvider,
-	} = options;
+  const {
+    secretProxy,
+    workerGateway,
+    mcpProxy,
+    interactionService,
+    platformRegistry,
+    coreServices,
+    chatInstanceManager,
+    authProvider,
+  } = options;
 
-	if (authProvider) {
-		setAuthProvider(authProvider);
-	}
+  if (authProvider) {
+    setAuthProvider(authProvider);
+  }
 
-	const app = new OpenAPIHono();
+  const app = new OpenAPIHono();
 
-	app.use(
-		"*",
-		secureHeaders({
-			xFrameOptions: false,
-			xContentTypeOptions: "nosniff",
-			referrerPolicy: "strict-origin-when-cross-origin",
-			strictTransportSecurity: "max-age=63072000; includeSubDomains",
-			contentSecurityPolicy: {
-				defaultSrc: ["'self'"],
-				frameAncestors: ["'self'", "*"],
-				scriptSrc: ["'self'", "'unsafe-inline'", "https://cdn.jsdelivr.net"],
-				styleSrc: ["'self'", "'unsafe-inline'"],
-				imgSrc: ["'self'", "data:", "https:"],
-				connectSrc: ["'self'", "ws:", "wss:"],
-				fontSrc: ["'self'", "https://fonts.gstatic.com"],
-			},
+  app.use(
+    "*",
+    secureHeaders({
+      xFrameOptions: false,
+      xContentTypeOptions: "nosniff",
+      referrerPolicy: "strict-origin-when-cross-origin",
+      strictTransportSecurity: "max-age=63072000; includeSubDomains",
+      contentSecurityPolicy: {
+        defaultSrc: ["'self'"],
+        frameAncestors: ["'self'", "*"],
+        scriptSrc: ["'self'", "'unsafe-inline'", "https://cdn.jsdelivr.net"],
+        styleSrc: ["'self'", "'unsafe-inline'"],
+        imgSrc: ["'self'", "data:", "https:"],
+        connectSrc: ["'self'", "ws:", "wss:"],
+        fontSrc: ["'self'", "https://fonts.gstatic.com"],
+      },
 		}),
-	);
-	app.use(
-		"*",
-		cors({
-			origin: process.env.ALLOWED_ORIGINS
-				? process.env.ALLOWED_ORIGINS.split(",")
-				: [],
-			credentials: true,
+  );
+  app.use(
+    "*",
+    cors({
+      origin: process.env.ALLOWED_ORIGINS
+        ? process.env.ALLOWED_ORIGINS.split(",")
+        : [],
+      credentials: true,
 		}),
-	);
+  );
 
-	app.get("/health", (c) => {
-		const mode = process.env.LOBU_MODE || "cloud";
+  app.get("/health", (c) => {
+    const mode = process.env.LOBU_MODE || "cloud";
 
-		return c.json({
-			status: "ok",
-			mode,
-			version: process.env.npm_package_version || "2.3.0",
-			timestamp: new Date().toISOString(),
-			publicGatewayUrl:
-				coreServices?.getPublicGatewayUrl?.() || process.env.PUBLIC_GATEWAY_URL,
-			capabilities: {
-				agents: ["claude"],
-				streaming: true,
-				toolApproval: true,
-			},
-			wsUrl: `ws://localhost:${process.env.PORT || process.env.GATEWAY_PORT || "8787"}/ws`,
-			secretProxy: !!secretProxy,
-		});
-	});
+    return c.json({
+      status: "ok",
+      mode,
+      version: process.env.npm_package_version || "2.3.0",
+      timestamp: new Date().toISOString(),
+      publicGatewayUrl:
+        coreServices?.getPublicGatewayUrl?.() || process.env.PUBLIC_GATEWAY_URL,
+      capabilities: {
+        agents: ["claude"],
+        streaming: true,
+        toolApproval: true,
+      },
+      wsUrl: `ws://localhost:${process.env.PORT || process.env.GATEWAY_PORT || "8787"}/ws`,
+      secretProxy: !!secretProxy,
+    });
+  });
 
-	app.get("/ready", (c) => c.json({ ready: true }));
+  app.get("/ready", (c) => c.json({ ready: true }));
 
-	// Metrics auth is optional so existing ServiceMonitor configs continue to scrape.
-	app.get("/metrics", async (c) => {
-		const metricsAuthToken = process.env.METRICS_AUTH_TOKEN;
-		if (metricsAuthToken) {
-			const authHeader = c.req.header("Authorization");
-			if (authHeader !== `Bearer ${metricsAuthToken}`) {
-				return c.text("Unauthorized", 401);
-			}
-		}
-		const { getMetricsText } = await import("../metrics/prometheus.js");
-		c.header("Content-Type", "text/plain; version=0.0.4; charset=utf-8");
-		return c.text(getMetricsText());
-	});
+  // Metrics auth is optional so existing ServiceMonitor configs continue to scrape.
+  app.get("/metrics", async (c) => {
+    const metricsAuthToken = process.env.METRICS_AUTH_TOKEN;
+    if (metricsAuthToken) {
+      const authHeader = c.req.header("Authorization");
+      if (authHeader !== `Bearer ${metricsAuthToken}`) {
+        return c.text("Unauthorized", 401);
+      }
+    }
+    const { getMetricsText } = await import("../metrics/prometheus.js");
+    c.header("Content-Type", "text/plain; version=0.0.4; charset=utf-8");
+    return c.text(getMetricsText());
+  });
 
-	if (secretProxy) {
-		app.route("/api/proxy", secretProxy.getApp());
-		logger.debug("Secret proxy enabled at :8080/api/proxy");
-	}
+  if (secretProxy) {
+    app.route("/api/proxy", secretProxy.getApp());
+    logger.debug("Secret proxy enabled at :8080/api/proxy");
+  }
 
-	if (coreServices) {
-		const bedrockOpenAIService = coreServices.getBedrockOpenAIService?.();
-		if (bedrockOpenAIService) {
-			app.route("/api/bedrock", bedrockOpenAIService.getApp());
-			logger.debug("Bedrock routes enabled at :8080/api/bedrock/*");
-		}
-	}
+  if (coreServices) {
+    const bedrockOpenAIService = coreServices.getBedrockOpenAIService?.();
+    if (bedrockOpenAIService) {
+      app.route("/api/bedrock", bedrockOpenAIService.getApp());
+      logger.debug("Bedrock routes enabled at :8080/api/bedrock/*");
+    }
+  }
 
-	if (workerGateway) {
-		app.route("/worker", workerGateway.getApp());
-		logger.debug("Worker gateway routes enabled at :8080/worker/*");
-	}
+  if (workerGateway) {
+    app.route("/worker", workerGateway.getApp());
+    logger.debug("Worker gateway routes enabled at :8080/worker/*");
+  }
 
-	// MCP OAuth callback MUST register before the MCP proxy mount at /mcp,
-	// otherwise the proxy's `/:mcpId/*` route swallows /mcp/oauth/callback.
-	if (coreServices) {
-		const mcpOAuthRouter = createMcpOAuthRoutes({
-			secretStore: coreServices.getSecretStore(),
-			publicGatewayUrl: coreServices.getPublicGatewayUrl(),
-			coreServices,
-			chatInstanceManager: chatInstanceManager ?? undefined,
-		});
-		app.route("", mcpOAuthRouter);
-		logger.debug(
+  // MCP OAuth callback MUST register before the MCP proxy mount at /mcp,
+  // otherwise the proxy's `/:mcpId/*` route swallows /mcp/oauth/callback.
+  if (coreServices) {
+    const mcpOAuthRouter = createMcpOAuthRoutes({
+      secretStore: coreServices.getSecretStore(),
+      publicGatewayUrl: coreServices.getPublicGatewayUrl(),
+      coreServices,
+      chatInstanceManager: chatInstanceManager ?? undefined,
+    });
+    app.route("", mcpOAuthRouter);
+    logger.debug(
 			"MCP OAuth callback route enabled at :8080/mcp/oauth/callback",
-		);
-	}
+    );
+  }
 
-	if (mcpProxy) {
-		app.all("/", async (c, next) => {
-			if (mcpProxy.isMcpRequest(c)) {
-				return mcpProxy.getApp().fetch(c.req.raw);
-			}
-			return next();
-		});
-		app.route("/mcp", mcpProxy.getApp());
-		logger.debug("MCP proxy routes enabled at :8080/mcp/*");
-	}
+  if (mcpProxy) {
+    app.all("/", async (c, next) => {
+      if (mcpProxy.isMcpRequest(c)) {
+        return mcpProxy.getApp().fetch(c.req.raw);
+      }
+      return next();
+    });
+    app.route("/mcp", mcpProxy.getApp());
+    logger.debug("MCP proxy routes enabled at :8080/mcp/*");
+  }
 
-	if (platformRegistry && coreServices) {
-		const artifactStore = coreServices.getArtifactStore();
-		const fileRouter = createFileRoutes(
-			platformRegistry,
-			artifactStore,
+  if (platformRegistry && coreServices) {
+    const artifactStore = coreServices.getArtifactStore();
+    const fileRouter = createFileRoutes(
+      platformRegistry,
+      artifactStore,
 			coreServices.getPublicGatewayUrl(),
-		);
-		app.route("/internal/files", fileRouter);
+    );
+    app.route("/internal/files", fileRouter);
 
-		app.route("", createPublicFileRoutes(artifactStore));
-		logger.debug(
+    app.route("", createPublicFileRoutes(artifactStore));
+    logger.debug(
 			"File routes enabled at :8080/internal/files/* and /api/v1/files/*",
-		);
-	}
+    );
+  }
 
-	{
-		const historyRouter = createHistoryRoutes();
-		app.route("/internal", historyRouter);
-		logger.debug("History routes enabled at :8080/internal/history");
-	}
+  {
+    const historyRouter = createHistoryRoutes();
+    app.route("/internal", historyRouter);
+    logger.debug("History routes enabled at :8080/internal/history");
+  }
 
-	if (coreServices) {
-		const mcpConfigService = coreServices.getMcpConfigService();
-		if (mcpConfigService) {
-			const deviceAuthRouter = createDeviceAuthRoutes({
-				mcpConfigService,
-				secretStore: coreServices.getSecretStore(),
-			});
-			app.route("", deviceAuthRouter);
-			logger.debug(
+  if (coreServices) {
+    const mcpConfigService = coreServices.getMcpConfigService();
+    if (mcpConfigService) {
+      const deviceAuthRouter = createDeviceAuthRoutes({
+        mcpConfigService,
+        secretStore: coreServices.getSecretStore(),
+      });
+      app.route("", deviceAuthRouter);
+      logger.debug(
 				"Device auth routes enabled at :8080/internal/device-auth/*",
-			);
-		}
-	}
+      );
+    }
+  }
 
-	if (coreServices) {
-		const transcriptionService = coreServices.getTranscriptionService();
-		if (transcriptionService) {
-			const audioRouter = createAudioRoutes(transcriptionService);
-			app.route("", audioRouter);
-			logger.debug("Audio routes enabled at :8080/internal/audio/*");
-		}
-	}
+  if (coreServices) {
+    const transcriptionService = coreServices.getTranscriptionService();
+    if (transcriptionService) {
+      const audioRouter = createAudioRoutes(transcriptionService);
+      app.route("", audioRouter);
+      logger.debug("Audio routes enabled at :8080/internal/audio/*");
+    }
+  }
 
-	if (coreServices) {
-		const imageGenerationService = coreServices.getImageGenerationService();
-		if (imageGenerationService) {
-			const imageRouter = createImageRoutes(imageGenerationService);
-			app.route("", imageRouter);
-			logger.debug("Image routes enabled at :8080/internal/images/*");
-		}
-	}
+  if (coreServices) {
+    const imageGenerationService = coreServices.getImageGenerationService();
+    if (imageGenerationService) {
+      const imageRouter = createImageRoutes(imageGenerationService);
+      app.route("", imageRouter);
+      logger.debug("Image routes enabled at :8080/internal/images/*");
+    }
+  }
 
-	if (interactionService) {
-		const internalRouter = createInteractionRoutes(interactionService);
-		app.route("", internalRouter);
-		logger.debug("Internal interaction routes enabled");
-	}
+  if (interactionService) {
+    const internalRouter = createInteractionRoutes(interactionService);
+    app.route("", internalRouter);
+    logger.debug("Internal interaction routes enabled");
+  }
 
-	if (coreServices) {
-		const queueProducer = coreServices.getQueueProducer();
-		const sessionMgr = coreServices.getSessionManager();
-		const interactionSvc = coreServices.getInteractionService();
-		const publicUrl = coreServices.getPublicGatewayUrl();
+  if (coreServices) {
+    const queueProducer = coreServices.getQueueProducer();
+    const sessionMgr = coreServices.getSessionManager();
+    const interactionSvc = coreServices.getInteractionService();
+    const publicUrl = coreServices.getPublicGatewayUrl();
 
-		if (queueProducer && sessionMgr && interactionSvc) {
-			const approveGrantStore = coreServices.getGrantStore();
-			const approveMcpProxy = coreServices.getMcpProxy();
+    if (queueProducer && sessionMgr && interactionSvc) {
+      const approveGrantStore = coreServices.getGrantStore();
+      const approveMcpProxy = coreServices.getMcpProxy();
 
-			const agentApi = createAgentApi({
-				queueProducer,
-				sessionManager: sessionMgr,
-				sseManager: coreServices.getSseManager(),
-				publicGatewayUrl: publicUrl,
-				externalAuthClient: coreServices.getExternalAuthClient(),
-				agentSettingsStore: coreServices.getAgentSettingsStore(),
-				agentConfigStore: coreServices.getConfigStore(),
-				userAgentsStore: coreServices.getUserAgentsStore(),
-				agentMetadataStore: coreServices.getAgentMetadataStore(),
-				platformRegistry,
-				approveToolCall: async (requestId: string, decision: string) => {
-					// DELETE ... RETURNING atomically claims the pending invocation
-					// so a retry of POST /api/v1/agents/approve (CLI re-tries,
-					// double-clicks, Slack webhook retries) cannot double-execute the
-					// tool. The Slack/Telegram interaction-bridge path uses the same
-					// helper.
-					const pending = await takePendingTool(requestId);
-					if (!pending)
-						return { success: false, error: "Request not found or expired" };
-					const pattern = `/mcp/${pending.mcpId}/tools/${pending.toolName}`;
-					const expiresMap: Record<string, number | null> = {
-						"1h": Date.now() + 3_600_000,
-						"24h": Date.now() + 86_400_000,
-						always: null,
-					};
-					if (decision === "deny") {
-						await approveGrantStore?.grant(
-							pending.agentId,
-							pattern,
-							null,
+      const agentApi = createAgentApi({
+        queueProducer,
+        sessionManager: sessionMgr,
+        sseManager: coreServices.getSseManager(),
+        publicGatewayUrl: publicUrl,
+        externalAuthClient: coreServices.getExternalAuthClient(),
+        agentSettingsStore: coreServices.getAgentSettingsStore(),
+        agentConfigStore: coreServices.getConfigStore(),
+        userAgentsStore: coreServices.getUserAgentsStore(),
+        agentMetadataStore: coreServices.getAgentMetadataStore(),
+        platformRegistry,
+        approveToolCall: async (requestId: string, decision: string) => {
+          // DELETE ... RETURNING atomically claims the pending invocation
+          // so a retry of POST /api/v1/agents/approve (CLI re-tries,
+          // double-clicks, Slack webhook retries) cannot double-execute the
+          // tool. The Slack/Telegram interaction-bridge path uses the same
+          // helper.
+          const pending = await takePendingTool(requestId);
+          if (!pending)
+            return { success: false, error: "Request not found or expired" };
+          const pattern = `/mcp/${pending.mcpId}/tools/${pending.toolName}`;
+          const expiresMap: Record<string, number | null> = {
+            "1h": Date.now() + 3_600_000,
+            "24h": Date.now() + 86_400_000,
+            always: null,
+          };
+          if (decision === "deny") {
+            await approveGrantStore?.grant(
+              pending.agentId,
+              pattern,
+              null,
 							true,
-						);
-						return { success: true };
-					}
-					await approveGrantStore?.grant(
-						pending.agentId,
-						pattern,
+            );
+            return { success: true };
+          }
+          await approveGrantStore?.grant(
+            pending.agentId,
+            pattern,
 						decision in expiresMap ? expiresMap[decision]! : null,
-					);
-					if (approveMcpProxy) {
-						const result = await approveMcpProxy.executeToolDirect(
-							pending.agentId,
-							pending.userId,
-							pending.mcpId,
-							pending.toolName,
+          );
+          if (approveMcpProxy) {
+            const result = await approveMcpProxy.executeToolDirect(
+              pending.agentId,
+              pending.userId,
+              pending.mcpId,
+              pending.toolName,
 							pending.args,
 							...(pending.organizationId
 								? [{ organizationId: pending.organizationId }]
 								: []),
-						);
-						return { success: true, result } as any;
-					}
-					return { success: true };
-				},
-			});
-			app.route("", agentApi);
-			logger.debug(
+            );
+            return { success: true, result } as any;
+          }
+          return { success: true };
+        },
+      });
+      app.route("", agentApi);
+      logger.debug(
 				"Agent API enabled at :8080/api/v1/agents/* with docs at :8080/api/docs",
-			);
-		}
-	}
+      );
+    }
+  }
 
-	if (coreServices) {
-		const authRouter = new OpenAPIHono();
-		const registeredProviders: string[] = [];
+  if (coreServices) {
+    const authRouter = new OpenAPIHono();
+    const registeredProviders: string[] = [];
 
-		{
-			const connectAuthRouter = createConnectAuthRoutes({
-				externalAuthClient: coreServices.getExternalAuthClient(),
-			});
-			app.route("", connectAuthRouter);
-		}
+    {
+      const connectAuthRouter = createConnectAuthRoutes({
+        externalAuthClient: coreServices.getExternalAuthClient(),
+      });
+      app.route("", connectAuthRouter);
+    }
 
-		const providerModules = getModelProviderModules();
+    const providerModules = getModelProviderModules();
 
-		const authProfilesManager = coreServices.getAuthProfilesManager();
-		if (authProfilesManager) {
-			const agentMetadataStore = coreServices.getAgentMetadataStore();
-			const userAgentsStore = coreServices.getUserAgentsStore();
+    const authProfilesManager = coreServices.getAuthProfilesManager();
+    if (authProfilesManager) {
+      const agentMetadataStore = coreServices.getAgentMetadataStore();
+      const userAgentsStore = coreServices.getUserAgentsStore();
 
-			const verifyProviderAuth = async (
-				c: any,
+      const verifyProviderAuth = async (
+        c: any,
 				agentId: string,
-			): Promise<{ userId: string; platform: string } | null> => {
-				const payload = await verifySettingsSessionOrToken(c);
-				if (!payload) return null;
-				const principal = {
-					userId: payload.userId,
-					platform: payload.platform,
-				};
-				if (payload.isAdmin) return principal;
+      ): Promise<{ userId: string; platform: string } | null> => {
+        const payload = await verifySettingsSessionOrToken(c);
+        if (!payload) return null;
+        const principal = {
+          userId: payload.userId,
+          platform: payload.platform,
+        };
+        if (payload.isAdmin) return principal;
 
-				if (payload.agentId)
-					return payload.agentId === agentId ? principal : null;
+        if (payload.agentId)
+          return payload.agentId === agentId ? principal : null;
 
-				if (userAgentsStore) {
-					const owns = await userAgentsStore.ownsAgent(
-						payload.platform,
-						payload.userId,
+        if (userAgentsStore) {
+          const owns = await userAgentsStore.ownsAgent(
+            payload.platform,
+            payload.userId,
 						agentId,
-					);
-					if (owns) return principal;
-				}
+          );
+          if (owns) return principal;
+        }
 
-				if (agentMetadataStore) {
-					const metadata = await agentMetadataStore.getMetadata(agentId);
-					const isOwner =
-						metadata?.owner?.platform === payload.platform &&
-						metadata?.owner?.userId === payload.userId;
-					if (isOwner) {
-						userAgentsStore
-							?.addAgent(payload.platform, payload.userId, agentId)
-							.catch(() => {
-								/* best-effort reconciliation */
-							});
-						return principal;
-					}
-				}
+        if (agentMetadataStore) {
+          const metadata = await agentMetadataStore.getMetadata(agentId);
+          const isOwner =
+            metadata?.owner?.platform === payload.platform &&
+            metadata?.owner?.userId === payload.userId;
+          if (isOwner) {
+            userAgentsStore
+              ?.addAgent(payload.platform, payload.userId, agentId)
+              .catch(() => {
+                /* best-effort reconciliation */
+              });
+            return principal;
+          }
+        }
 
-				return null;
-			};
+        return null;
+      };
 
-			// Each provider-auth handler does the same envelope work: resolve the
-			// `:provider` module (404 if unknown), then a try/catch that logs and
-			// returns a 500 with `errorLabel`. Factor that out so the bodies are
-			// just the per-route logic.
-			const withProviderAndAuth =
-				(
-					errorLabel: string,
-					handler: (args: {
-						c: any;
-						mod: ReturnType<typeof getModelProviderModules>[number];
-						providerId: string;
+      // Each provider-auth handler does the same envelope work: resolve the
+      // `:provider` module (404 if unknown), then a try/catch that logs and
+      // returns a 500 with `errorLabel`. Factor that out so the bodies are
+      // just the per-route logic.
+      const withProviderAndAuth =
+        (
+          errorLabel: string,
+          handler: (args: {
+            c: any;
+            mod: ReturnType<typeof getModelProviderModules>[number];
+            providerId: string;
 					}) => Promise<Response>,
-				) =>
-				async (c: any): Promise<Response> => {
-					try {
-						const providerId = c.req.param("provider");
-						const mod = getModelProviderModules().find(
+        ) =>
+        async (c: any): Promise<Response> => {
+          try {
+            const providerId = c.req.param("provider");
+            const mod = getModelProviderModules().find(
 							(m) => m.providerId === providerId,
-						);
-						if (!mod) return c.json({ error: "Unknown provider" }, 404);
-						return await handler({ c, mod, providerId });
-					} catch (error) {
-						logger.error(errorLabel, { error });
-						return c.json({ error: errorLabel }, 500);
-					}
-				};
+            );
+            if (!mod) return c.json({ error: "Unknown provider" }, 404);
+            return await handler({ c, mod, providerId });
+          } catch (error) {
+            logger.error(errorLabel, { error });
+            return c.json({ error: errorLabel }, 500);
+          }
+        };
 
-			const requireDeviceCode = (
-				c: any,
-				mod: ReturnType<typeof getModelProviderModules>[number],
+      const requireDeviceCode = (
+        c: any,
+        mod: ReturnType<typeof getModelProviderModules>[number],
 				method: "startDeviceCode" | "pollDeviceCode",
-			): Response | null => {
-				const supportsDeviceCode =
-					mod.authType === "device-code" ||
-					mod.supportedAuthTypes?.includes("device-code");
-				if (!supportsDeviceCode) {
-					return c.json(
-						{ error: "Provider does not support device code" },
+      ): Response | null => {
+        const supportsDeviceCode =
+          mod.authType === "device-code" ||
+          mod.supportedAuthTypes?.includes("device-code");
+        if (!supportsDeviceCode) {
+          return c.json(
+            { error: "Provider does not support device code" },
 						400,
-					);
-				}
-				if (typeof mod[method] !== "function") {
-					return c.json(
-						{
-							error:
-								method === "startDeviceCode"
-									? "Device code start not implemented"
-									: "Device code poll not implemented",
-						},
+          );
+        }
+        if (typeof mod[method] !== "function") {
+          return c.json(
+            {
+              error:
+                method === "startDeviceCode"
+                  ? "Device code start not implemented"
+                  : "Device code poll not implemented",
+            },
 						501,
-					);
-				}
-				return null;
-			};
+          );
+        }
+        return null;
+      };
 
-			authRouter.post(
-				"/:provider/save-key",
-				withProviderAndAuth(
-					"Failed to save API key",
-					async ({ c, mod, providerId }) => {
-						const body = await c.req.json();
-						const { agentId, apiKey } = body;
-						if (!agentId || !apiKey) {
-							return c.json({ error: "Missing agentId or apiKey" }, 400);
-						}
+      authRouter.post(
+        "/:provider/save-key",
+        withProviderAndAuth(
+          "Failed to save API key",
+          async ({ c, mod, providerId }) => {
+            const body = await c.req.json();
+            const { agentId, apiKey } = body;
+            if (!agentId || !apiKey) {
+              return c.json({ error: "Missing agentId or apiKey" }, 400);
+            }
 
-						const principal = await verifyProviderAuth(c, agentId);
-						if (!principal) {
-							return c.json({ error: "Unauthorized" }, 401);
-						}
+            const principal = await verifyProviderAuth(c, agentId);
+            if (!principal) {
+              return c.json({ error: "Unauthorized" }, 401);
+            }
 
-						await authProfilesManager.upsertProfile({
-							agentId,
-							userId: principal.userId,
-							provider: providerId,
-							credential: apiKey,
-							authType: "api-key",
-							label: createAuthProfileLabel(mod.providerDisplayName, apiKey),
-							makePrimary: true,
-						});
+            await authProfilesManager.upsertProfile({
+              agentId,
+              userId: principal.userId,
+              provider: providerId,
+              credential: apiKey,
+              authType: "api-key",
+              label: createAuthProfileLabel(mod.providerDisplayName, apiKey),
+              makePrimary: true,
+            });
 
-						return c.json({ success: true });
+            return c.json({ success: true });
 					},
 				),
-			);
+      );
 
-			authRouter.post(
-				"/:provider/start",
-				withProviderAndAuth(
-					"Failed to start device code flow",
-					async ({ c, mod }) => {
-						const unsupported = requireDeviceCode(c, mod, "startDeviceCode");
-						if (unsupported) return unsupported;
+      authRouter.post(
+        "/:provider/start",
+        withProviderAndAuth(
+          "Failed to start device code flow",
+          async ({ c, mod }) => {
+            const unsupported = requireDeviceCode(c, mod, "startDeviceCode");
+            if (unsupported) return unsupported;
 
-						const body = (await c.req.json().catch(() => ({}))) as {
-							agentId?: string;
-						};
-						const agentId = body.agentId?.trim();
-						if (!agentId) return c.json({ error: "Missing agentId" }, 400);
+            const body = (await c.req.json().catch(() => ({}))) as {
+              agentId?: string;
+            };
+            const agentId = body.agentId?.trim();
+            if (!agentId) return c.json({ error: "Missing agentId" }, 400);
 
-						if (!(await verifyProviderAuth(c, agentId))) {
-							return c.json({ error: "Unauthorized" }, 401);
-						}
+            if (!(await verifyProviderAuth(c, agentId))) {
+              return c.json({ error: "Unauthorized" }, 401);
+            }
 
-						const result = await mod.startDeviceCode!(agentId);
-						return c.json(result);
+            const result = await mod.startDeviceCode!(agentId);
+            return c.json(result);
 					},
 				),
-			);
+      );
 
-			authRouter.post(
-				"/:provider/poll",
-				withProviderAndAuth(
-					"Failed to poll device code flow",
-					async ({ c, mod }) => {
-						const unsupported = requireDeviceCode(c, mod, "pollDeviceCode");
-						if (unsupported) return unsupported;
+      authRouter.post(
+        "/:provider/poll",
+        withProviderAndAuth(
+          "Failed to poll device code flow",
+          async ({ c, mod }) => {
+            const unsupported = requireDeviceCode(c, mod, "pollDeviceCode");
+            if (unsupported) return unsupported;
 
-						const body = (await c.req.json().catch(() => ({}))) as {
-							agentId?: string;
-							deviceAuthId?: string;
-							userCode?: string;
-						};
-						const agentId = body.agentId?.trim();
-						const deviceAuthId = body.deviceAuthId?.trim();
-						const userCode = body.userCode?.trim();
-						if (!agentId || !deviceAuthId || !userCode) {
-							return c.json(
-								{ error: "Missing agentId, deviceAuthId, or userCode" },
+            const body = (await c.req.json().catch(() => ({}))) as {
+              agentId?: string;
+              deviceAuthId?: string;
+              userCode?: string;
+            };
+            const agentId = body.agentId?.trim();
+            const deviceAuthId = body.deviceAuthId?.trim();
+            const userCode = body.userCode?.trim();
+            if (!agentId || !deviceAuthId || !userCode) {
+              return c.json(
+                { error: "Missing agentId, deviceAuthId, or userCode" },
 								400,
-							);
-						}
+              );
+            }
 
-						const principal = await verifyProviderAuth(c, agentId);
-						if (!principal) {
-							return c.json({ error: "Unauthorized" }, 401);
-						}
+            const principal = await verifyProviderAuth(c, agentId);
+            if (!principal) {
+              return c.json({ error: "Unauthorized" }, 401);
+            }
 
 						const result = await mod.pollDeviceCode!(
 							agentId,
 							principal.userId,
 							{
-								deviceAuthId,
-								userCode,
+              deviceAuthId,
+              userCode,
 							},
 						);
-						return c.json(result);
+            return c.json(result);
 					},
 				),
-			);
+      );
 
-			authRouter.post(
-				"/:provider/logout",
+      authRouter.post(
+        "/:provider/logout",
 				withProviderAndAuth("Failed to logout", async ({ c, providerId }) => {
-					const body = await c.req.json().catch(() => ({}));
-					const agentId = body.agentId || c.req.query("agentId");
-					if (!agentId) {
-						return c.json({ error: "Missing agentId" }, 400);
-					}
+            const body = await c.req.json().catch(() => ({}));
+            const agentId = body.agentId || c.req.query("agentId");
+            if (!agentId) {
+              return c.json({ error: "Missing agentId" }, 400);
+            }
 
-					const principal = await verifyProviderAuth(c, agentId);
-					if (!principal) {
-						return c.json({ error: "Unauthorized" }, 401);
-					}
+            const principal = await verifyProviderAuth(c, agentId);
+            if (!principal) {
+              return c.json({ error: "Unauthorized" }, 401);
+            }
 
-					await authProfilesManager.deleteProviderProfiles(
-						agentId,
-						providerId,
-						{
-							userId: principal.userId,
-							...(body.profileId ? { profileId: body.profileId } : {}),
+            await authProfilesManager.deleteProviderProfiles(
+              agentId,
+              providerId,
+              {
+                userId: principal.userId,
+                ...(body.profileId ? { profileId: body.profileId } : {}),
 						},
-					);
+            );
 
-					return c.json({ success: true });
+            return c.json({ success: true });
 				}),
-			);
-		}
+      );
+    }
 
-		const agentSettingsStore = coreServices.getAgentSettingsStore();
-		const claudeOAuthStateStore = coreServices.getOAuthStateStore();
+    const agentSettingsStore = coreServices.getAgentSettingsStore();
+    const claudeOAuthStateStore = coreServices.getOAuthStateStore();
 
-		const providerStores: Record<
-			string,
-			{ hasCredentials(agentId: string): Promise<boolean> }
-		> = {};
-		const providerConnectedOverrides: Record<string, boolean> = {};
-		for (const mod of providerModules) {
-			providerStores[mod.providerId] = mod;
-			providerConnectedOverrides[mod.providerId] = mod.hasSystemKey();
-			if (mod.getApp) {
-				authRouter.route(`/${mod.providerId}`, mod.getApp());
-				registeredProviders.push(mod.providerId);
-			}
-		}
+    const providerStores: Record<
+      string,
+      { hasCredentials(agentId: string): Promise<boolean> }
+    > = {};
+    const providerConnectedOverrides: Record<string, boolean> = {};
+    for (const mod of providerModules) {
+      providerStores[mod.providerId] = mod;
+      providerConnectedOverrides[mod.providerId] = mod.hasSystemKey();
+      if (mod.getApp) {
+        authRouter.route(`/${mod.providerId}`, mod.getApp());
+        registeredProviders.push(mod.providerId);
+      }
+    }
 
-		const providerRegistryService = coreServices.getProviderRegistryService();
+    const providerRegistryService = coreServices.getProviderRegistryService();
 
-		if (providerRegistryService) {
-			const systemEnvStore = new SystemEnvStore(coreServices.getSecretStore());
-			systemEnvStore.refreshCache().catch((e: any) => {
-				logger.error("Failed to refresh system env cache", { error: e });
-			});
-			setEnvResolver((key: string) => systemEnvStore.resolve(key));
-		}
+    if (providerRegistryService) {
+      const systemEnvStore = new SystemEnvStore(coreServices.getSecretStore());
+      systemEnvStore.refreshCache().catch((e: any) => {
+        logger.error("Failed to refresh system env cache", { error: e });
+      });
+      setEnvResolver((key: string) => systemEnvStore.resolve(key));
+    }
 
-		{
-			const landingRouter = createLandingRoutes();
-			app.route("", landingRouter);
-			logger.debug("Landing page enabled at :8080/");
-		}
+    {
+      const landingRouter = createLandingRoutes();
+      app.route("", landingRouter);
+      logger.debug("Landing page enabled at :8080/");
+    }
 
-		{
-			const connectionManager = coreServices
-				.getWorkerGateway()
-				?.getConnectionManager();
-			if (connectionManager) {
-				const agentHistoryRouter = createAgentHistoryRoutes({
-					connectionManager,
-					agentConfigStore: coreServices.getConfigStore(),
-					userAgentsStore: coreServices.getUserAgentsStore(),
-				});
-				app.route("/api/v1/agents/:agentId/history", agentHistoryRouter);
-				logger.debug(
+    {
+      const connectionManager = coreServices
+        .getWorkerGateway()
+        ?.getConnectionManager();
+      if (connectionManager) {
+        const agentHistoryRouter = createAgentHistoryRoutes({
+          connectionManager,
+          agentConfigStore: coreServices.getConfigStore(),
+          userAgentsStore: coreServices.getUserAgentsStore(),
+        });
+        app.route("/api/v1/agents/:agentId/history", agentHistoryRouter);
+        logger.debug(
 					"Agent history routes enabled at :8080/api/v1/agents/{agentId}/history/*",
-				);
-			}
-		}
+        );
+      }
+    }
 
-		if (agentSettingsStore) {
-			const agentConfigRouter = createAgentConfigRoutes({
-				agentSettingsStore,
-				agentConfigStore: coreServices.getConfigStore()!,
-				userAgentsStore: coreServices.getUserAgentsStore(),
-				queue: coreServices.getQueue(),
-				providerStores:
-					Object.keys(providerStores).length > 0 ? providerStores : undefined,
-				providerConnectedOverrides,
-				providerCatalogService: coreServices.getProviderCatalogService(),
-				authProfilesManager: coreServices.getAuthProfilesManager(),
-				connectionManager: coreServices
-					.getWorkerGateway()
-					?.getConnectionManager(),
-				grantStore: coreServices.getGrantStore(),
-			});
-			app.route("/api/v1/agents/:agentId/config", agentConfigRouter);
-			logger.debug(
+    if (agentSettingsStore) {
+      const agentConfigRouter = createAgentConfigRoutes({
+        agentSettingsStore,
+        agentConfigStore: coreServices.getConfigStore()!,
+        userAgentsStore: coreServices.getUserAgentsStore(),
+        queue: coreServices.getQueue(),
+        providerStores:
+          Object.keys(providerStores).length > 0 ? providerStores : undefined,
+        providerConnectedOverrides,
+        providerCatalogService: coreServices.getProviderCatalogService(),
+        authProfilesManager: coreServices.getAuthProfilesManager(),
+        connectionManager: coreServices
+          .getWorkerGateway()
+          ?.getConnectionManager(),
+        grantStore: coreServices.getGrantStore(),
+      });
+      app.route("/api/v1/agents/:agentId/config", agentConfigRouter);
+      logger.debug(
 				"Agent config routes enabled at :8080/api/v1/agents/{id}/config",
-			);
-		}
+      );
+    }
 
-		if (agentSettingsStore) {
-			const claudeOAuthClient = new OAuthClient(CLAUDE_PROVIDER);
-			const oauthRouter = createOAuthRoutes({
-				providerStores:
-					Object.keys(providerStores).length > 0
-						? (providerStores as Record<string, ProviderCredentialStore>)
-						: undefined,
-				oauthClients: { claude: claudeOAuthClient },
-				oauthStateStore: claudeOAuthStateStore,
-			});
-			authRouter.route("", oauthRouter);
-			registeredProviders.push("oauth");
-		}
+    if (agentSettingsStore) {
+      const claudeOAuthClient = new OAuthClient(CLAUDE_PROVIDER);
+      const oauthRouter = createOAuthRoutes({
+        providerStores:
+          Object.keys(providerStores).length > 0
+            ? (providerStores as Record<string, ProviderCredentialStore>)
+            : undefined,
+        oauthClients: { claude: claudeOAuthClient },
+        oauthStateStore: claudeOAuthStateStore,
+      });
+      authRouter.route("", oauthRouter);
+      registeredProviders.push("oauth");
+    }
 
-		if (registeredProviders.length > 0) {
-			app.route("/api/v1/auth", authRouter);
-			logger.debug(
+    if (registeredProviders.length > 0) {
+      app.route("/api/v1/auth", authRouter);
+      logger.debug(
 				`Auth routes enabled at :8080/api/v1/auth/* for: ${registeredProviders.join(", ")}`,
-			);
-		}
+      );
+    }
 
-		const channelBindingService = coreServices.getChannelBindingService();
-		if (channelBindingService) {
-			const channelBindingRouter = createChannelBindingRoutes({
-				channelBindingService,
-				userAgentsStore: coreServices.getUserAgentsStore(),
-				agentMetadataStore: coreServices.getAgentMetadataStore(),
-			});
-			app.route("/api/v1/agents/:agentId/channels", channelBindingRouter);
-			logger.debug(
+    const channelBindingService = coreServices.getChannelBindingService();
+    if (channelBindingService) {
+      const channelBindingRouter = createChannelBindingRoutes({
+        channelBindingService,
+        userAgentsStore: coreServices.getUserAgentsStore(),
+        agentMetadataStore: coreServices.getAgentMetadataStore(),
+      });
+      app.route("/api/v1/agents/:agentId/channels", channelBindingRouter);
+      logger.debug(
 				"Channel binding routes enabled at :8080/api/v1/agents/{agentId}/channels/*",
-			);
-		}
+      );
+    }
 
-		{
-			const userAgentsStore = coreServices.getUserAgentsStore();
-			const agentMetadataStore = coreServices.getAgentMetadataStore();
-			const agentManagementRouter = createAgentRoutes({
-				userAgentsStore,
-				agentMetadataStore,
-				agentSettingsStore,
-				channelBindingService,
-			});
-			app.route("/api/v1/agents", agentManagementRouter);
-			logger.debug("Agent management routes enabled at :8080/api/v1/agents/*");
-		}
-	}
+    {
+      const userAgentsStore = coreServices.getUserAgentsStore();
+      const agentMetadataStore = coreServices.getAgentMetadataStore();
+      const agentManagementRouter = createAgentRoutes({
+        userAgentsStore,
+        agentMetadataStore,
+        agentSettingsStore,
+        channelBindingService,
+      });
+      app.route("/api/v1/agents", agentManagementRouter);
+      logger.debug("Agent management routes enabled at :8080/api/v1/agents/*");
+    }
+  }
 
-	if (chatInstanceManager) {
-		app.route("", createSlackRoutes(chatInstanceManager));
-		app.route("", createConnectionWebhookRoutes(chatInstanceManager));
-		app.route(
-			"",
-			createConnectionCrudRoutes(chatInstanceManager, {
-				userAgentsStore: coreServices.getUserAgentsStore(),
-				agentMetadataStore: coreServices.getConfigStore()!,
+  if (chatInstanceManager) {
+    app.route("", createSlackRoutes(chatInstanceManager));
+    app.route("", createConnectionWebhookRoutes(chatInstanceManager));
+    app.route(
+      "",
+      createConnectionCrudRoutes(chatInstanceManager, {
+        userAgentsStore: coreServices.getUserAgentsStore(),
+        agentMetadataStore: coreServices.getConfigStore()!,
 			}),
-		);
-		logger.debug(
+    );
+    logger.debug(
 			"Slack and connection routes enabled at :8080/slack/*, :8080/api/v1/connections/*, and :8080/api/v1/webhooks/*",
-		);
-	}
+    );
+  }
 
-	async function hasDevRouteAccess(c: any): Promise<boolean> {
-		if (await verifySettingsSessionOrToken(c)) return true;
-		const authHeader = c.req.header("Authorization");
-		if (!authHeader?.startsWith("Bearer ")) return false;
-		const token = authHeader.slice(7);
-		const externalAuthClient = coreServices?.getExternalAuthClient?.();
-		if (!externalAuthClient) return false;
-		try {
-			const userInfo = await externalAuthClient.fetchUserInfo(token);
-			return Boolean(userInfo?.sub);
-		} catch {
-			return false;
-		}
-	}
+  async function hasDevRouteAccess(c: any): Promise<boolean> {
+    if (await verifySettingsSessionOrToken(c)) return true;
+    const authHeader = c.req.header("Authorization");
+    if (!authHeader?.startsWith("Bearer ")) return false;
+    const token = authHeader.slice(7);
+    const externalAuthClient = coreServices?.getExternalAuthClient?.();
+    if (!externalAuthClient) return false;
+    try {
+      const userInfo = await externalAuthClient.fetchUserInfo(token);
+      return Boolean(userInfo?.sub);
+    } catch {
+      return false;
+    }
+  }
 
-	app.get("/internal/status", async (c) => {
-		if (process.env.NODE_ENV === "production") {
-			return c.json({ error: "Not found" }, 404);
-		}
-		if (!(await hasDevRouteAccess(c))) {
-			return c.json({ error: "Unauthorized" }, 401);
-		}
+  app.get("/internal/status", async (c) => {
+    if (process.env.NODE_ENV === "production") {
+      return c.json({ error: "Not found" }, 404);
+    }
+    if (!(await hasDevRouteAccess(c))) {
+      return c.json({ error: "Unauthorized" }, 401);
+    }
 
-		const agentConfigStore = coreServices?.getConfigStore();
+    const agentConfigStore = coreServices?.getConfigStore();
 
-		const allAgents: AgentMetadata[] = agentConfigStore
-			? await agentConfigStore.listAgents()
-			: [];
+    const allAgents: AgentMetadata[] = agentConfigStore
+      ? await agentConfigStore.listAgents()
+      : [];
 
-		const connections = chatInstanceManager
-			? await chatInstanceManager.listConnections()
-			: [];
+    const connections = chatInstanceManager
+      ? await chatInstanceManager.listConnections()
+      : [];
 
-		const agentDetails = [];
-		for (const a of allAgents) {
-			const settings = agentConfigStore
-				? await agentConfigStore.getSettings(a.agentId)
-				: null;
-			const providers = (settings?.installedProviders || []).map(
+    const agentDetails = [];
+    for (const a of allAgents) {
+      const settings = agentConfigStore
+        ? await agentConfigStore.getSettings(a.agentId)
+        : null;
+      const providers = (settings?.installedProviders || []).map(
 				(p: { providerId: string }) => p.providerId,
-			);
-			agentDetails.push({
-				agentId: a.agentId,
-				name: a.name,
-				providers,
-				model:
-					settings?.modelSelection?.mode === "pinned"
-						? (settings.modelSelection as { pinnedModel?: string })
-								.pinnedModel || "pinned"
-						: settings?.modelSelection?.mode || "auto",
-			});
-		}
+      );
+      agentDetails.push({
+        agentId: a.agentId,
+        name: a.name,
+        providers,
+        model:
+          settings?.modelSelection?.mode === "pinned"
+            ? (settings.modelSelection as { pinnedModel?: string })
+                .pinnedModel || "pinned"
+            : settings?.modelSelection?.mode || "auto",
+      });
+    }
 
-		return c.json({
-			agents: agentDetails,
-			connections: connections.map(
-				(conn: {
-					id: string;
-					platform: string;
-					agentId?: string;
-					metadata?: Record<string, string>;
-				}) => ({
-					id: conn.id,
-					platform: conn.platform,
-					status: chatInstanceManager?.getInstance(conn.id)
-						? "connected"
-						: "disconnected",
-					agentId: conn.agentId || null,
-					botUsername: conn.metadata?.botUsername || null,
+    return c.json({
+      agents: agentDetails,
+      connections: connections.map(
+        (conn: {
+          id: string;
+          platform: string;
+          agentId?: string;
+          metadata?: Record<string, string>;
+        }) => ({
+          id: conn.id,
+          platform: conn.platform,
+          status: chatInstanceManager?.getInstance(conn.id)
+            ? "connected"
+            : "disconnected",
+          agentId: conn.agentId || null,
+          botUsername: conn.metadata?.botUsername || null,
 				}),
-			),
-		});
-	});
+      ),
+    });
+  });
 
-	registerAutoOpenApiRoutes(app);
+  registerAutoOpenApiRoutes(app);
 
-	app.doc("/api/docs/openapi.json", {
-		openapi: "3.0.0",
-		info: {
-			title: "Lobu API",
-			version: "1.0.0",
-			description: `
+  app.doc("/api/docs/openapi.json", {
+    openapi: "3.0.0",
+    info: {
+      title: "Lobu API",
+      version: "1.0.0",
+      description: `
 ## Overview
 
 The Lobu API allows you to create and interact with AI agents programmatically.
@@ -819,65 +819,65 @@ Agents can be configured with custom MCP (Model Context Protocol) servers:
 }
 \`\`\`
       `,
-		},
-		tags: [
-			{
-				name: "Agents",
-				description: "Create, list, update, and delete agents.",
-			},
-			{
-				name: "Messages",
-				description:
-					"Send messages to agents and subscribe to real-time events (SSE).",
-			},
-			{
-				name: "Configuration",
-				description:
-					"Agent configuration — LLM providers, Nix packages, domain grants.",
-			},
-			{
-				name: "Channels",
-				description:
-					"Bind agents to messaging platform channels (Slack, Telegram, WhatsApp).",
-			},
-			{
-				name: "Connections",
-				description:
-					"Manage Chat SDK-backed platform connections and their lifecycle.",
-			},
-			{
-				name: "Schedules",
-				description: "Scheduled wakeups and recurring reminders.",
-			},
-			{
-				name: "History",
-				description: "Session messages, stats, and connection status.",
-			},
-			{
-				name: "Auth",
-				description:
-					"Provider authentication — API keys, OAuth, device code flows.",
-			},
-			{
-				name: "Integrations",
-				description: "Browse and install skills and MCP servers.",
-			},
-		],
-		servers: [
-			{ url: "http://localhost:8787", description: "Local development" },
-		],
-	});
+    },
+    tags: [
+      {
+        name: "Agents",
+        description: "Create, list, update, and delete agents.",
+      },
+      {
+        name: "Messages",
+        description:
+          "Send messages to agents and subscribe to real-time events (SSE).",
+      },
+      {
+        name: "Configuration",
+        description:
+          "Agent configuration — LLM providers, Nix packages, domain grants.",
+      },
+      {
+        name: "Channels",
+        description:
+          "Bind agents to messaging platform channels (Slack, Telegram, WhatsApp).",
+      },
+      {
+        name: "Connections",
+        description:
+          "Manage Chat SDK-backed platform connections and their lifecycle.",
+      },
+      {
+        name: "Schedules",
+        description: "Scheduled wakeups and recurring reminders.",
+      },
+      {
+        name: "History",
+        description: "Session messages, stats, and connection status.",
+      },
+      {
+        name: "Auth",
+        description:
+          "Provider authentication — API keys, OAuth, device code flows.",
+      },
+      {
+        name: "Integrations",
+        description: "Browse and install skills and MCP servers.",
+      },
+    ],
+    servers: [
+      { url: "http://localhost:8787", description: "Local development" },
+    ],
+  });
 
-	app.get(
-		"/api/docs",
-		apiReference({
-			url: "/api/docs/openapi.json",
-			theme: "kepler",
-			layout: "modern",
-			defaultHttpClient: { targetKey: "js", clientKey: "fetch" },
+  app.get(
+    "/api/docs",
+    apiReference({
+      url: "/api/docs/openapi.json",
+      theme: "kepler",
+      layout: "modern",
+      defaultHttpClient: { targetKey: "js", clientKey: "fetch" },
 		}),
-	);
-	logger.debug("API docs enabled at /api/docs");
+  );
+  logger.debug("API docs enabled at /api/docs");
 
-	return app;
+  return app;
 }

--- a/packages/server/src/gateway/cli/gateway.ts
+++ b/packages/server/src/gateway/cli/gateway.ts
@@ -27,36 +27,36 @@ import { createAgentRoutes } from "../routes/public/agents.js";
 import { createChannelBindingRoutes } from "../routes/public/channels.js";
 import { createConnectAuthRoutes } from "../routes/public/connect-auth.js";
 import {
-  createConnectionCrudRoutes,
-  createConnectionWebhookRoutes,
+	createConnectionCrudRoutes,
+	createConnectionWebhookRoutes,
 } from "../routes/public/connections.js";
 import { createPublicFileRoutes } from "../routes/public/files.js";
 import { createLandingRoutes } from "../routes/public/landing.js";
 import { createMcpOAuthRoutes } from "../routes/public/mcp-oauth.js";
 import {
-  createOAuthRoutes,
-  type ProviderCredentialStore,
+	createOAuthRoutes,
+	type ProviderCredentialStore,
 } from "../routes/public/oauth.js";
 import {
-  setAuthProvider,
-  verifySettingsSessionOrToken,
+	setAuthProvider,
+	verifySettingsSessionOrToken,
 } from "../routes/public/settings-auth.js";
 import { createSlackRoutes } from "../routes/public/slack.js";
 
 const logger = createLogger("gateway-startup");
 
 interface CreateGatewayAppOptions {
-  secretProxy: any;
-  workerGateway: any;
-  mcpProxy: any;
-  interactionService?: any;
-  platformRegistry?: any;
-  coreServices?: any;
-  chatInstanceManager?:
-    | import("../connections/chat-instance-manager.js").ChatInstanceManager
-    | null;
-  /** Custom auth provider for embedded mode. When set, gateway delegates auth to this function instead of using cookie-based sessions. */
-  authProvider?: import("../routes/public/settings-auth.js").AuthProvider;
+	secretProxy: any;
+	workerGateway: any;
+	mcpProxy: any;
+	interactionService?: any;
+	platformRegistry?: any;
+	coreServices?: any;
+	chatInstanceManager?:
+		| import("../connections/chat-instance-manager.js").ChatInstanceManager
+		| null;
+	/** Custom auth provider for embedded mode. When set, gateway delegates auth to this function instead of using cookie-based sessions. */
+	authProvider?: import("../routes/public/settings-auth.js").AuthProvider;
 }
 
 /**
@@ -65,717 +65,721 @@ interface CreateGatewayAppOptions {
  * own server (embedded mode; see `src/server.ts` / `src/lobu/gateway.ts`).
  */
 export function createGatewayApp(
-  options: CreateGatewayAppOptions
+	options: CreateGatewayAppOptions,
 ): OpenAPIHono {
-  const {
-    secretProxy,
-    workerGateway,
-    mcpProxy,
-    interactionService,
-    platformRegistry,
-    coreServices,
-    chatInstanceManager,
-    authProvider,
-  } = options;
-
-  if (authProvider) {
-    setAuthProvider(authProvider);
-  }
-
-  const app = new OpenAPIHono();
-
-  app.use(
-    "*",
-    secureHeaders({
-      xFrameOptions: false,
-      xContentTypeOptions: "nosniff",
-      referrerPolicy: "strict-origin-when-cross-origin",
-      strictTransportSecurity: "max-age=63072000; includeSubDomains",
-      contentSecurityPolicy: {
-        defaultSrc: ["'self'"],
-        frameAncestors: ["'self'", "*"],
-        scriptSrc: ["'self'", "'unsafe-inline'", "https://cdn.jsdelivr.net"],
-        styleSrc: ["'self'", "'unsafe-inline'"],
-        imgSrc: ["'self'", "data:", "https:"],
-        connectSrc: ["'self'", "ws:", "wss:"],
-        fontSrc: ["'self'", "https://fonts.gstatic.com"],
-      },
-    })
-  );
-  app.use(
-    "*",
-    cors({
-      origin: process.env.ALLOWED_ORIGINS
-        ? process.env.ALLOWED_ORIGINS.split(",")
-        : [],
-      credentials: true,
-    })
-  );
-
-  app.get("/health", (c) => {
-    const mode = process.env.LOBU_MODE || "cloud";
-
-    return c.json({
-      status: "ok",
-      mode,
-      version: process.env.npm_package_version || "2.3.0",
-      timestamp: new Date().toISOString(),
-      publicGatewayUrl:
-        coreServices?.getPublicGatewayUrl?.() || process.env.PUBLIC_GATEWAY_URL,
-      capabilities: {
-        agents: ["claude"],
-        streaming: true,
-        toolApproval: true,
-      },
-      wsUrl: `ws://localhost:${process.env.PORT || process.env.GATEWAY_PORT || "8787"}/ws`,
-      secretProxy: !!secretProxy,
-    });
-  });
-
-  app.get("/ready", (c) => c.json({ ready: true }));
-
-  // Metrics auth is optional so existing ServiceMonitor configs continue to scrape.
-  app.get("/metrics", async (c) => {
-    const metricsAuthToken = process.env.METRICS_AUTH_TOKEN;
-    if (metricsAuthToken) {
-      const authHeader = c.req.header("Authorization");
-      if (authHeader !== `Bearer ${metricsAuthToken}`) {
-        return c.text("Unauthorized", 401);
-      }
-    }
-    const { getMetricsText } = await import("../metrics/prometheus.js");
-    c.header("Content-Type", "text/plain; version=0.0.4; charset=utf-8");
-    return c.text(getMetricsText());
-  });
-
-  if (secretProxy) {
-    app.route("/api/proxy", secretProxy.getApp());
-    logger.debug("Secret proxy enabled at :8080/api/proxy");
-  }
-
-  if (coreServices) {
-    const bedrockOpenAIService = coreServices.getBedrockOpenAIService?.();
-    if (bedrockOpenAIService) {
-      app.route("/api/bedrock", bedrockOpenAIService.getApp());
-      logger.debug("Bedrock routes enabled at :8080/api/bedrock/*");
-    }
-  }
-
-  if (workerGateway) {
-    app.route("/worker", workerGateway.getApp());
-    logger.debug("Worker gateway routes enabled at :8080/worker/*");
-  }
-
-  // MCP OAuth callback MUST register before the MCP proxy mount at /mcp,
-  // otherwise the proxy's `/:mcpId/*` route swallows /mcp/oauth/callback.
-  if (coreServices) {
-    const mcpOAuthRouter = createMcpOAuthRoutes({
-      secretStore: coreServices.getSecretStore(),
-      publicGatewayUrl: coreServices.getPublicGatewayUrl(),
-      coreServices,
-      chatInstanceManager: chatInstanceManager ?? undefined,
-    });
-    app.route("", mcpOAuthRouter);
-    logger.debug(
-      "MCP OAuth callback route enabled at :8080/mcp/oauth/callback"
-    );
-  }
-
-  if (mcpProxy) {
-    app.all("/", async (c, next) => {
-      if (mcpProxy.isMcpRequest(c)) {
-        return mcpProxy.getApp().fetch(c.req.raw);
-      }
-      return next();
-    });
-    app.route("/mcp", mcpProxy.getApp());
-    logger.debug("MCP proxy routes enabled at :8080/mcp/*");
-  }
-
-  if (platformRegistry && coreServices) {
-    const artifactStore = coreServices.getArtifactStore();
-    const fileRouter = createFileRoutes(
-      platformRegistry,
-      artifactStore,
-      coreServices.getPublicGatewayUrl()
-    );
-    app.route("/internal/files", fileRouter);
-
-    app.route("", createPublicFileRoutes(artifactStore));
-    logger.debug(
-      "File routes enabled at :8080/internal/files/* and /api/v1/files/*"
-    );
-  }
-
-  {
-    const historyRouter = createHistoryRoutes();
-    app.route("/internal", historyRouter);
-    logger.debug("History routes enabled at :8080/internal/history");
-  }
-
-  if (coreServices) {
-    const mcpConfigService = coreServices.getMcpConfigService();
-    if (mcpConfigService) {
-      const deviceAuthRouter = createDeviceAuthRoutes({
-        mcpConfigService,
-        secretStore: coreServices.getSecretStore(),
-      });
-      app.route("", deviceAuthRouter);
-      logger.debug(
-        "Device auth routes enabled at :8080/internal/device-auth/*"
-      );
-    }
-  }
-
-  if (coreServices) {
-    const transcriptionService = coreServices.getTranscriptionService();
-    if (transcriptionService) {
-      const audioRouter = createAudioRoutes(transcriptionService);
-      app.route("", audioRouter);
-      logger.debug("Audio routes enabled at :8080/internal/audio/*");
-    }
-  }
-
-  if (coreServices) {
-    const imageGenerationService = coreServices.getImageGenerationService();
-    if (imageGenerationService) {
-      const imageRouter = createImageRoutes(imageGenerationService);
-      app.route("", imageRouter);
-      logger.debug("Image routes enabled at :8080/internal/images/*");
-    }
-  }
-
-  if (interactionService) {
-    const internalRouter = createInteractionRoutes(interactionService);
-    app.route("", internalRouter);
-    logger.debug("Internal interaction routes enabled");
-  }
-
-  if (coreServices) {
-    const queueProducer = coreServices.getQueueProducer();
-    const sessionMgr = coreServices.getSessionManager();
-    const interactionSvc = coreServices.getInteractionService();
-    const publicUrl = coreServices.getPublicGatewayUrl();
-
-    if (queueProducer && sessionMgr && interactionSvc) {
-      const approveGrantStore = coreServices.getGrantStore();
-      const approveMcpProxy = coreServices.getMcpProxy();
-
-      const agentApi = createAgentApi({
-        queueProducer,
-        sessionManager: sessionMgr,
-        sseManager: coreServices.getSseManager(),
-        publicGatewayUrl: publicUrl,
-        externalAuthClient: coreServices.getExternalAuthClient(),
-        agentSettingsStore: coreServices.getAgentSettingsStore(),
-        agentConfigStore: coreServices.getConfigStore(),
-        userAgentsStore: coreServices.getUserAgentsStore(),
-        agentMetadataStore: coreServices.getAgentMetadataStore(),
-        platformRegistry,
-        approveToolCall: async (requestId: string, decision: string) => {
-          // DELETE ... RETURNING atomically claims the pending invocation
-          // so a retry of POST /api/v1/agents/approve (CLI re-tries,
-          // double-clicks, Slack webhook retries) cannot double-execute the
-          // tool. The Slack/Telegram interaction-bridge path uses the same
-          // helper.
-          const pending = await takePendingTool(requestId);
-          if (!pending)
-            return { success: false, error: "Request not found or expired" };
-          const pattern = `/mcp/${pending.mcpId}/tools/${pending.toolName}`;
-          const expiresMap: Record<string, number | null> = {
-            "1h": Date.now() + 3_600_000,
-            "24h": Date.now() + 86_400_000,
-            always: null,
-          };
-          if (decision === "deny") {
-            await approveGrantStore?.grant(
-              pending.agentId,
-              pattern,
-              null,
-              true
-            );
-            return { success: true };
-          }
-          await approveGrantStore?.grant(
-            pending.agentId,
-            pattern,
-            decision in expiresMap ? expiresMap[decision]! : null
-          );
-          if (approveMcpProxy) {
-            const result = await approveMcpProxy.executeToolDirect(
-              pending.agentId,
-              pending.userId,
-              pending.mcpId,
-              pending.toolName,
-              pending.args
-            );
-            return { success: true, result } as any;
-          }
-          return { success: true };
-        },
-      });
-      app.route("", agentApi);
-      logger.debug(
-        "Agent API enabled at :8080/api/v1/agents/* with docs at :8080/api/docs"
-      );
-    }
-  }
-
-  if (coreServices) {
-    const authRouter = new OpenAPIHono();
-    const registeredProviders: string[] = [];
-
-    {
-      const connectAuthRouter = createConnectAuthRoutes({
-        externalAuthClient: coreServices.getExternalAuthClient(),
-      });
-      app.route("", connectAuthRouter);
-    }
-
-    const providerModules = getModelProviderModules();
-
-    const authProfilesManager = coreServices.getAuthProfilesManager();
-    if (authProfilesManager) {
-      const agentMetadataStore = coreServices.getAgentMetadataStore();
-      const userAgentsStore = coreServices.getUserAgentsStore();
-
-      const verifyProviderAuth = async (
-        c: any,
-        agentId: string
-      ): Promise<{ userId: string; platform: string } | null> => {
-        const payload = await verifySettingsSessionOrToken(c);
-        if (!payload) return null;
-        const principal = {
-          userId: payload.userId,
-          platform: payload.platform,
-        };
-        if (payload.isAdmin) return principal;
-
-        if (payload.agentId)
-          return payload.agentId === agentId ? principal : null;
-
-        if (userAgentsStore) {
-          const owns = await userAgentsStore.ownsAgent(
-            payload.platform,
-            payload.userId,
-            agentId
-          );
-          if (owns) return principal;
-        }
-
-        if (agentMetadataStore) {
-          const metadata = await agentMetadataStore.getMetadata(agentId);
-          const isOwner =
-            metadata?.owner?.platform === payload.platform &&
-            metadata?.owner?.userId === payload.userId;
-          if (isOwner) {
-            userAgentsStore
-              ?.addAgent(payload.platform, payload.userId, agentId)
-              .catch(() => {
-                /* best-effort reconciliation */
-              });
-            return principal;
-          }
-        }
-
-        return null;
-      };
-
-      // Each provider-auth handler does the same envelope work: resolve the
-      // `:provider` module (404 if unknown), then a try/catch that logs and
-      // returns a 500 with `errorLabel`. Factor that out so the bodies are
-      // just the per-route logic.
-      const withProviderAndAuth =
-        (
-          errorLabel: string,
-          handler: (args: {
-            c: any;
-            mod: ReturnType<typeof getModelProviderModules>[number];
-            providerId: string;
-          }) => Promise<Response>
-        ) =>
-        async (c: any): Promise<Response> => {
-          try {
-            const providerId = c.req.param("provider");
-            const mod = getModelProviderModules().find(
-              (m) => m.providerId === providerId
-            );
-            if (!mod) return c.json({ error: "Unknown provider" }, 404);
-            return await handler({ c, mod, providerId });
-          } catch (error) {
-            logger.error(errorLabel, { error });
-            return c.json({ error: errorLabel }, 500);
-          }
-        };
-
-      const requireDeviceCode = (
-        c: any,
-        mod: ReturnType<typeof getModelProviderModules>[number],
-        method: "startDeviceCode" | "pollDeviceCode"
-      ): Response | null => {
-        const supportsDeviceCode =
-          mod.authType === "device-code" ||
-          mod.supportedAuthTypes?.includes("device-code");
-        if (!supportsDeviceCode) {
-          return c.json(
-            { error: "Provider does not support device code" },
-            400
-          );
-        }
-        if (typeof mod[method] !== "function") {
-          return c.json(
-            {
-              error:
-                method === "startDeviceCode"
-                  ? "Device code start not implemented"
-                  : "Device code poll not implemented",
-            },
-            501
-          );
-        }
-        return null;
-      };
-
-      authRouter.post(
-        "/:provider/save-key",
-        withProviderAndAuth(
-          "Failed to save API key",
-          async ({ c, mod, providerId }) => {
-            const body = await c.req.json();
-            const { agentId, apiKey } = body;
-            if (!agentId || !apiKey) {
-              return c.json({ error: "Missing agentId or apiKey" }, 400);
-            }
-
-            const principal = await verifyProviderAuth(c, agentId);
-            if (!principal) {
-              return c.json({ error: "Unauthorized" }, 401);
-            }
-
-            await authProfilesManager.upsertProfile({
-              agentId,
-              userId: principal.userId,
-              provider: providerId,
-              credential: apiKey,
-              authType: "api-key",
-              label: createAuthProfileLabel(mod.providerDisplayName, apiKey),
-              makePrimary: true,
-            });
-
-            return c.json({ success: true });
-          }
-        )
-      );
-
-      authRouter.post(
-        "/:provider/start",
-        withProviderAndAuth(
-          "Failed to start device code flow",
-          async ({ c, mod }) => {
-            const unsupported = requireDeviceCode(c, mod, "startDeviceCode");
-            if (unsupported) return unsupported;
-
-            const body = (await c.req.json().catch(() => ({}))) as {
-              agentId?: string;
-            };
-            const agentId = body.agentId?.trim();
-            if (!agentId) return c.json({ error: "Missing agentId" }, 400);
-
-            if (!(await verifyProviderAuth(c, agentId))) {
-              return c.json({ error: "Unauthorized" }, 401);
-            }
-
-            const result = await mod.startDeviceCode!(agentId);
-            return c.json(result);
-          }
-        )
-      );
-
-      authRouter.post(
-        "/:provider/poll",
-        withProviderAndAuth(
-          "Failed to poll device code flow",
-          async ({ c, mod }) => {
-            const unsupported = requireDeviceCode(c, mod, "pollDeviceCode");
-            if (unsupported) return unsupported;
-
-            const body = (await c.req.json().catch(() => ({}))) as {
-              agentId?: string;
-              deviceAuthId?: string;
-              userCode?: string;
-            };
-            const agentId = body.agentId?.trim();
-            const deviceAuthId = body.deviceAuthId?.trim();
-            const userCode = body.userCode?.trim();
-            if (!agentId || !deviceAuthId || !userCode) {
-              return c.json(
-                { error: "Missing agentId, deviceAuthId, or userCode" },
-                400
-              );
-            }
-
-            const principal = await verifyProviderAuth(c, agentId);
-            if (!principal) {
-              return c.json({ error: "Unauthorized" }, 401);
-            }
-
-            const result = await mod.pollDeviceCode!(agentId, principal.userId, {
-              deviceAuthId,
-              userCode,
-            });
-            return c.json(result);
-          }
-        )
-      );
-
-      authRouter.post(
-        "/:provider/logout",
-        withProviderAndAuth(
-          "Failed to logout",
-          async ({ c, providerId }) => {
-            const body = await c.req.json().catch(() => ({}));
-            const agentId = body.agentId || c.req.query("agentId");
-            if (!agentId) {
-              return c.json({ error: "Missing agentId" }, 400);
-            }
-
-            const principal = await verifyProviderAuth(c, agentId);
-            if (!principal) {
-              return c.json({ error: "Unauthorized" }, 401);
-            }
-
-            await authProfilesManager.deleteProviderProfiles(
-              agentId,
-              providerId,
-              {
-                userId: principal.userId,
-                ...(body.profileId ? { profileId: body.profileId } : {}),
-              }
-            );
-
-            return c.json({ success: true });
-          }
-        )
-      );
-    }
-
-    const agentSettingsStore = coreServices.getAgentSettingsStore();
-    const claudeOAuthStateStore = coreServices.getOAuthStateStore();
-
-    const providerStores: Record<
-      string,
-      { hasCredentials(agentId: string): Promise<boolean> }
-    > = {};
-    const providerConnectedOverrides: Record<string, boolean> = {};
-    for (const mod of providerModules) {
-      providerStores[mod.providerId] = mod;
-      providerConnectedOverrides[mod.providerId] = mod.hasSystemKey();
-      if (mod.getApp) {
-        authRouter.route(`/${mod.providerId}`, mod.getApp());
-        registeredProviders.push(mod.providerId);
-      }
-    }
-
-    const providerRegistryService = coreServices.getProviderRegistryService();
-
-    if (providerRegistryService) {
-      const systemEnvStore = new SystemEnvStore(coreServices.getSecretStore());
-      systemEnvStore.refreshCache().catch((e: any) => {
-        logger.error("Failed to refresh system env cache", { error: e });
-      });
-      setEnvResolver((key: string) => systemEnvStore.resolve(key));
-    }
-
-    {
-      const landingRouter = createLandingRoutes();
-      app.route("", landingRouter);
-      logger.debug("Landing page enabled at :8080/");
-    }
-
-    {
-      const connectionManager = coreServices
-        .getWorkerGateway()
-        ?.getConnectionManager();
-      if (connectionManager) {
-        const agentHistoryRouter = createAgentHistoryRoutes({
-          connectionManager,
-          agentConfigStore: coreServices.getConfigStore(),
-          userAgentsStore: coreServices.getUserAgentsStore(),
-        });
-        app.route("/api/v1/agents/:agentId/history", agentHistoryRouter);
-        logger.debug(
-          "Agent history routes enabled at :8080/api/v1/agents/{agentId}/history/*"
-        );
-      }
-    }
-
-    if (agentSettingsStore) {
-      const agentConfigRouter = createAgentConfigRoutes({
-        agentSettingsStore,
-        agentConfigStore: coreServices.getConfigStore()!,
-        userAgentsStore: coreServices.getUserAgentsStore(),
-        queue: coreServices.getQueue(),
-        providerStores:
-          Object.keys(providerStores).length > 0 ? providerStores : undefined,
-        providerConnectedOverrides,
-        providerCatalogService: coreServices.getProviderCatalogService(),
-        authProfilesManager: coreServices.getAuthProfilesManager(),
-        connectionManager: coreServices
-          .getWorkerGateway()
-          ?.getConnectionManager(),
-        grantStore: coreServices.getGrantStore(),
-      });
-      app.route("/api/v1/agents/:agentId/config", agentConfigRouter);
-      logger.debug(
-        "Agent config routes enabled at :8080/api/v1/agents/{id}/config"
-      );
-    }
-
-    if (agentSettingsStore) {
-      const claudeOAuthClient = new OAuthClient(CLAUDE_PROVIDER);
-      const oauthRouter = createOAuthRoutes({
-        providerStores:
-          Object.keys(providerStores).length > 0
-            ? (providerStores as Record<string, ProviderCredentialStore>)
-            : undefined,
-        oauthClients: { claude: claudeOAuthClient },
-        oauthStateStore: claudeOAuthStateStore,
-      });
-      authRouter.route("", oauthRouter);
-      registeredProviders.push("oauth");
-    }
-
-    if (registeredProviders.length > 0) {
-      app.route("/api/v1/auth", authRouter);
-      logger.debug(
-        `Auth routes enabled at :8080/api/v1/auth/* for: ${registeredProviders.join(", ")}`
-      );
-    }
-
-    const channelBindingService = coreServices.getChannelBindingService();
-    if (channelBindingService) {
-      const channelBindingRouter = createChannelBindingRoutes({
-        channelBindingService,
-        userAgentsStore: coreServices.getUserAgentsStore(),
-        agentMetadataStore: coreServices.getAgentMetadataStore(),
-      });
-      app.route("/api/v1/agents/:agentId/channels", channelBindingRouter);
-      logger.debug(
-        "Channel binding routes enabled at :8080/api/v1/agents/{agentId}/channels/*"
-      );
-    }
-
-    {
-      const userAgentsStore = coreServices.getUserAgentsStore();
-      const agentMetadataStore = coreServices.getAgentMetadataStore();
-      const agentManagementRouter = createAgentRoutes({
-        userAgentsStore,
-        agentMetadataStore,
-        agentSettingsStore,
-        channelBindingService,
-      });
-      app.route("/api/v1/agents", agentManagementRouter);
-      logger.debug("Agent management routes enabled at :8080/api/v1/agents/*");
-    }
-  }
-
-  if (chatInstanceManager) {
-    app.route("", createSlackRoutes(chatInstanceManager));
-    app.route("", createConnectionWebhookRoutes(chatInstanceManager));
-    app.route(
-      "",
-      createConnectionCrudRoutes(chatInstanceManager, {
-        userAgentsStore: coreServices.getUserAgentsStore(),
-        agentMetadataStore: coreServices.getConfigStore()!,
-      })
-    );
-    logger.debug(
-      "Slack and connection routes enabled at :8080/slack/*, :8080/api/v1/connections/*, and :8080/api/v1/webhooks/*"
-    );
-  }
-
-  async function hasDevRouteAccess(c: any): Promise<boolean> {
-    if (await verifySettingsSessionOrToken(c)) return true;
-    const authHeader = c.req.header("Authorization");
-    if (!authHeader?.startsWith("Bearer ")) return false;
-    const token = authHeader.slice(7);
-    const externalAuthClient = coreServices?.getExternalAuthClient?.();
-    if (!externalAuthClient) return false;
-    try {
-      const userInfo = await externalAuthClient.fetchUserInfo(token);
-      return Boolean(userInfo?.sub);
-    } catch {
-      return false;
-    }
-  }
-
-  app.get("/internal/status", async (c) => {
-    if (process.env.NODE_ENV === "production") {
-      return c.json({ error: "Not found" }, 404);
-    }
-    if (!(await hasDevRouteAccess(c))) {
-      return c.json({ error: "Unauthorized" }, 401);
-    }
-
-    const agentConfigStore = coreServices?.getConfigStore();
-
-    const allAgents: AgentMetadata[] = agentConfigStore
-      ? await agentConfigStore.listAgents()
-      : [];
-
-    const connections = chatInstanceManager
-      ? await chatInstanceManager.listConnections()
-      : [];
-
-    const agentDetails = [];
-    for (const a of allAgents) {
-      const settings = agentConfigStore
-        ? await agentConfigStore.getSettings(a.agentId)
-        : null;
-      const providers = (settings?.installedProviders || []).map(
-        (p: { providerId: string }) => p.providerId
-      );
-      agentDetails.push({
-        agentId: a.agentId,
-        name: a.name,
-        providers,
-        model:
-          settings?.modelSelection?.mode === "pinned"
-            ? (settings.modelSelection as { pinnedModel?: string })
-                .pinnedModel || "pinned"
-            : settings?.modelSelection?.mode || "auto",
-      });
-    }
-
-    return c.json({
-      agents: agentDetails,
-      connections: connections.map(
-        (conn: {
-          id: string;
-          platform: string;
-          agentId?: string;
-          metadata?: Record<string, string>;
-        }) => ({
-          id: conn.id,
-          platform: conn.platform,
-          status: chatInstanceManager?.getInstance(conn.id)
-            ? "connected"
-            : "disconnected",
-          agentId: conn.agentId || null,
-          botUsername: conn.metadata?.botUsername || null,
-        })
-      ),
-    });
-  });
-
-  registerAutoOpenApiRoutes(app);
-
-  app.doc("/api/docs/openapi.json", {
-    openapi: "3.0.0",
-    info: {
-      title: "Lobu API",
-      version: "1.0.0",
-      description: `
+	const {
+		secretProxy,
+		workerGateway,
+		mcpProxy,
+		interactionService,
+		platformRegistry,
+		coreServices,
+		chatInstanceManager,
+		authProvider,
+	} = options;
+
+	if (authProvider) {
+		setAuthProvider(authProvider);
+	}
+
+	const app = new OpenAPIHono();
+
+	app.use(
+		"*",
+		secureHeaders({
+			xFrameOptions: false,
+			xContentTypeOptions: "nosniff",
+			referrerPolicy: "strict-origin-when-cross-origin",
+			strictTransportSecurity: "max-age=63072000; includeSubDomains",
+			contentSecurityPolicy: {
+				defaultSrc: ["'self'"],
+				frameAncestors: ["'self'", "*"],
+				scriptSrc: ["'self'", "'unsafe-inline'", "https://cdn.jsdelivr.net"],
+				styleSrc: ["'self'", "'unsafe-inline'"],
+				imgSrc: ["'self'", "data:", "https:"],
+				connectSrc: ["'self'", "ws:", "wss:"],
+				fontSrc: ["'self'", "https://fonts.gstatic.com"],
+			},
+		}),
+	);
+	app.use(
+		"*",
+		cors({
+			origin: process.env.ALLOWED_ORIGINS
+				? process.env.ALLOWED_ORIGINS.split(",")
+				: [],
+			credentials: true,
+		}),
+	);
+
+	app.get("/health", (c) => {
+		const mode = process.env.LOBU_MODE || "cloud";
+
+		return c.json({
+			status: "ok",
+			mode,
+			version: process.env.npm_package_version || "2.3.0",
+			timestamp: new Date().toISOString(),
+			publicGatewayUrl:
+				coreServices?.getPublicGatewayUrl?.() || process.env.PUBLIC_GATEWAY_URL,
+			capabilities: {
+				agents: ["claude"],
+				streaming: true,
+				toolApproval: true,
+			},
+			wsUrl: `ws://localhost:${process.env.PORT || process.env.GATEWAY_PORT || "8787"}/ws`,
+			secretProxy: !!secretProxy,
+		});
+	});
+
+	app.get("/ready", (c) => c.json({ ready: true }));
+
+	// Metrics auth is optional so existing ServiceMonitor configs continue to scrape.
+	app.get("/metrics", async (c) => {
+		const metricsAuthToken = process.env.METRICS_AUTH_TOKEN;
+		if (metricsAuthToken) {
+			const authHeader = c.req.header("Authorization");
+			if (authHeader !== `Bearer ${metricsAuthToken}`) {
+				return c.text("Unauthorized", 401);
+			}
+		}
+		const { getMetricsText } = await import("../metrics/prometheus.js");
+		c.header("Content-Type", "text/plain; version=0.0.4; charset=utf-8");
+		return c.text(getMetricsText());
+	});
+
+	if (secretProxy) {
+		app.route("/api/proxy", secretProxy.getApp());
+		logger.debug("Secret proxy enabled at :8080/api/proxy");
+	}
+
+	if (coreServices) {
+		const bedrockOpenAIService = coreServices.getBedrockOpenAIService?.();
+		if (bedrockOpenAIService) {
+			app.route("/api/bedrock", bedrockOpenAIService.getApp());
+			logger.debug("Bedrock routes enabled at :8080/api/bedrock/*");
+		}
+	}
+
+	if (workerGateway) {
+		app.route("/worker", workerGateway.getApp());
+		logger.debug("Worker gateway routes enabled at :8080/worker/*");
+	}
+
+	// MCP OAuth callback MUST register before the MCP proxy mount at /mcp,
+	// otherwise the proxy's `/:mcpId/*` route swallows /mcp/oauth/callback.
+	if (coreServices) {
+		const mcpOAuthRouter = createMcpOAuthRoutes({
+			secretStore: coreServices.getSecretStore(),
+			publicGatewayUrl: coreServices.getPublicGatewayUrl(),
+			coreServices,
+			chatInstanceManager: chatInstanceManager ?? undefined,
+		});
+		app.route("", mcpOAuthRouter);
+		logger.debug(
+			"MCP OAuth callback route enabled at :8080/mcp/oauth/callback",
+		);
+	}
+
+	if (mcpProxy) {
+		app.all("/", async (c, next) => {
+			if (mcpProxy.isMcpRequest(c)) {
+				return mcpProxy.getApp().fetch(c.req.raw);
+			}
+			return next();
+		});
+		app.route("/mcp", mcpProxy.getApp());
+		logger.debug("MCP proxy routes enabled at :8080/mcp/*");
+	}
+
+	if (platformRegistry && coreServices) {
+		const artifactStore = coreServices.getArtifactStore();
+		const fileRouter = createFileRoutes(
+			platformRegistry,
+			artifactStore,
+			coreServices.getPublicGatewayUrl(),
+		);
+		app.route("/internal/files", fileRouter);
+
+		app.route("", createPublicFileRoutes(artifactStore));
+		logger.debug(
+			"File routes enabled at :8080/internal/files/* and /api/v1/files/*",
+		);
+	}
+
+	{
+		const historyRouter = createHistoryRoutes();
+		app.route("/internal", historyRouter);
+		logger.debug("History routes enabled at :8080/internal/history");
+	}
+
+	if (coreServices) {
+		const mcpConfigService = coreServices.getMcpConfigService();
+		if (mcpConfigService) {
+			const deviceAuthRouter = createDeviceAuthRoutes({
+				mcpConfigService,
+				secretStore: coreServices.getSecretStore(),
+			});
+			app.route("", deviceAuthRouter);
+			logger.debug(
+				"Device auth routes enabled at :8080/internal/device-auth/*",
+			);
+		}
+	}
+
+	if (coreServices) {
+		const transcriptionService = coreServices.getTranscriptionService();
+		if (transcriptionService) {
+			const audioRouter = createAudioRoutes(transcriptionService);
+			app.route("", audioRouter);
+			logger.debug("Audio routes enabled at :8080/internal/audio/*");
+		}
+	}
+
+	if (coreServices) {
+		const imageGenerationService = coreServices.getImageGenerationService();
+		if (imageGenerationService) {
+			const imageRouter = createImageRoutes(imageGenerationService);
+			app.route("", imageRouter);
+			logger.debug("Image routes enabled at :8080/internal/images/*");
+		}
+	}
+
+	if (interactionService) {
+		const internalRouter = createInteractionRoutes(interactionService);
+		app.route("", internalRouter);
+		logger.debug("Internal interaction routes enabled");
+	}
+
+	if (coreServices) {
+		const queueProducer = coreServices.getQueueProducer();
+		const sessionMgr = coreServices.getSessionManager();
+		const interactionSvc = coreServices.getInteractionService();
+		const publicUrl = coreServices.getPublicGatewayUrl();
+
+		if (queueProducer && sessionMgr && interactionSvc) {
+			const approveGrantStore = coreServices.getGrantStore();
+			const approveMcpProxy = coreServices.getMcpProxy();
+
+			const agentApi = createAgentApi({
+				queueProducer,
+				sessionManager: sessionMgr,
+				sseManager: coreServices.getSseManager(),
+				publicGatewayUrl: publicUrl,
+				externalAuthClient: coreServices.getExternalAuthClient(),
+				agentSettingsStore: coreServices.getAgentSettingsStore(),
+				agentConfigStore: coreServices.getConfigStore(),
+				userAgentsStore: coreServices.getUserAgentsStore(),
+				agentMetadataStore: coreServices.getAgentMetadataStore(),
+				platformRegistry,
+				approveToolCall: async (requestId: string, decision: string) => {
+					// DELETE ... RETURNING atomically claims the pending invocation
+					// so a retry of POST /api/v1/agents/approve (CLI re-tries,
+					// double-clicks, Slack webhook retries) cannot double-execute the
+					// tool. The Slack/Telegram interaction-bridge path uses the same
+					// helper.
+					const pending = await takePendingTool(requestId);
+					if (!pending)
+						return { success: false, error: "Request not found or expired" };
+					const pattern = `/mcp/${pending.mcpId}/tools/${pending.toolName}`;
+					const expiresMap: Record<string, number | null> = {
+						"1h": Date.now() + 3_600_000,
+						"24h": Date.now() + 86_400_000,
+						always: null,
+					};
+					if (decision === "deny") {
+						await approveGrantStore?.grant(
+							pending.agentId,
+							pattern,
+							null,
+							true,
+						);
+						return { success: true };
+					}
+					await approveGrantStore?.grant(
+						pending.agentId,
+						pattern,
+						decision in expiresMap ? expiresMap[decision]! : null,
+					);
+					if (approveMcpProxy) {
+						const result = await approveMcpProxy.executeToolDirect(
+							pending.agentId,
+							pending.userId,
+							pending.mcpId,
+							pending.toolName,
+							pending.args,
+							...(pending.organizationId
+								? [{ organizationId: pending.organizationId }]
+								: []),
+						);
+						return { success: true, result } as any;
+					}
+					return { success: true };
+				},
+			});
+			app.route("", agentApi);
+			logger.debug(
+				"Agent API enabled at :8080/api/v1/agents/* with docs at :8080/api/docs",
+			);
+		}
+	}
+
+	if (coreServices) {
+		const authRouter = new OpenAPIHono();
+		const registeredProviders: string[] = [];
+
+		{
+			const connectAuthRouter = createConnectAuthRoutes({
+				externalAuthClient: coreServices.getExternalAuthClient(),
+			});
+			app.route("", connectAuthRouter);
+		}
+
+		const providerModules = getModelProviderModules();
+
+		const authProfilesManager = coreServices.getAuthProfilesManager();
+		if (authProfilesManager) {
+			const agentMetadataStore = coreServices.getAgentMetadataStore();
+			const userAgentsStore = coreServices.getUserAgentsStore();
+
+			const verifyProviderAuth = async (
+				c: any,
+				agentId: string,
+			): Promise<{ userId: string; platform: string } | null> => {
+				const payload = await verifySettingsSessionOrToken(c);
+				if (!payload) return null;
+				const principal = {
+					userId: payload.userId,
+					platform: payload.platform,
+				};
+				if (payload.isAdmin) return principal;
+
+				if (payload.agentId)
+					return payload.agentId === agentId ? principal : null;
+
+				if (userAgentsStore) {
+					const owns = await userAgentsStore.ownsAgent(
+						payload.platform,
+						payload.userId,
+						agentId,
+					);
+					if (owns) return principal;
+				}
+
+				if (agentMetadataStore) {
+					const metadata = await agentMetadataStore.getMetadata(agentId);
+					const isOwner =
+						metadata?.owner?.platform === payload.platform &&
+						metadata?.owner?.userId === payload.userId;
+					if (isOwner) {
+						userAgentsStore
+							?.addAgent(payload.platform, payload.userId, agentId)
+							.catch(() => {
+								/* best-effort reconciliation */
+							});
+						return principal;
+					}
+				}
+
+				return null;
+			};
+
+			// Each provider-auth handler does the same envelope work: resolve the
+			// `:provider` module (404 if unknown), then a try/catch that logs and
+			// returns a 500 with `errorLabel`. Factor that out so the bodies are
+			// just the per-route logic.
+			const withProviderAndAuth =
+				(
+					errorLabel: string,
+					handler: (args: {
+						c: any;
+						mod: ReturnType<typeof getModelProviderModules>[number];
+						providerId: string;
+					}) => Promise<Response>,
+				) =>
+				async (c: any): Promise<Response> => {
+					try {
+						const providerId = c.req.param("provider");
+						const mod = getModelProviderModules().find(
+							(m) => m.providerId === providerId,
+						);
+						if (!mod) return c.json({ error: "Unknown provider" }, 404);
+						return await handler({ c, mod, providerId });
+					} catch (error) {
+						logger.error(errorLabel, { error });
+						return c.json({ error: errorLabel }, 500);
+					}
+				};
+
+			const requireDeviceCode = (
+				c: any,
+				mod: ReturnType<typeof getModelProviderModules>[number],
+				method: "startDeviceCode" | "pollDeviceCode",
+			): Response | null => {
+				const supportsDeviceCode =
+					mod.authType === "device-code" ||
+					mod.supportedAuthTypes?.includes("device-code");
+				if (!supportsDeviceCode) {
+					return c.json(
+						{ error: "Provider does not support device code" },
+						400,
+					);
+				}
+				if (typeof mod[method] !== "function") {
+					return c.json(
+						{
+							error:
+								method === "startDeviceCode"
+									? "Device code start not implemented"
+									: "Device code poll not implemented",
+						},
+						501,
+					);
+				}
+				return null;
+			};
+
+			authRouter.post(
+				"/:provider/save-key",
+				withProviderAndAuth(
+					"Failed to save API key",
+					async ({ c, mod, providerId }) => {
+						const body = await c.req.json();
+						const { agentId, apiKey } = body;
+						if (!agentId || !apiKey) {
+							return c.json({ error: "Missing agentId or apiKey" }, 400);
+						}
+
+						const principal = await verifyProviderAuth(c, agentId);
+						if (!principal) {
+							return c.json({ error: "Unauthorized" }, 401);
+						}
+
+						await authProfilesManager.upsertProfile({
+							agentId,
+							userId: principal.userId,
+							provider: providerId,
+							credential: apiKey,
+							authType: "api-key",
+							label: createAuthProfileLabel(mod.providerDisplayName, apiKey),
+							makePrimary: true,
+						});
+
+						return c.json({ success: true });
+					},
+				),
+			);
+
+			authRouter.post(
+				"/:provider/start",
+				withProviderAndAuth(
+					"Failed to start device code flow",
+					async ({ c, mod }) => {
+						const unsupported = requireDeviceCode(c, mod, "startDeviceCode");
+						if (unsupported) return unsupported;
+
+						const body = (await c.req.json().catch(() => ({}))) as {
+							agentId?: string;
+						};
+						const agentId = body.agentId?.trim();
+						if (!agentId) return c.json({ error: "Missing agentId" }, 400);
+
+						if (!(await verifyProviderAuth(c, agentId))) {
+							return c.json({ error: "Unauthorized" }, 401);
+						}
+
+						const result = await mod.startDeviceCode!(agentId);
+						return c.json(result);
+					},
+				),
+			);
+
+			authRouter.post(
+				"/:provider/poll",
+				withProviderAndAuth(
+					"Failed to poll device code flow",
+					async ({ c, mod }) => {
+						const unsupported = requireDeviceCode(c, mod, "pollDeviceCode");
+						if (unsupported) return unsupported;
+
+						const body = (await c.req.json().catch(() => ({}))) as {
+							agentId?: string;
+							deviceAuthId?: string;
+							userCode?: string;
+						};
+						const agentId = body.agentId?.trim();
+						const deviceAuthId = body.deviceAuthId?.trim();
+						const userCode = body.userCode?.trim();
+						if (!agentId || !deviceAuthId || !userCode) {
+							return c.json(
+								{ error: "Missing agentId, deviceAuthId, or userCode" },
+								400,
+							);
+						}
+
+						const principal = await verifyProviderAuth(c, agentId);
+						if (!principal) {
+							return c.json({ error: "Unauthorized" }, 401);
+						}
+
+						const result = await mod.pollDeviceCode!(
+							agentId,
+							principal.userId,
+							{
+								deviceAuthId,
+								userCode,
+							},
+						);
+						return c.json(result);
+					},
+				),
+			);
+
+			authRouter.post(
+				"/:provider/logout",
+				withProviderAndAuth("Failed to logout", async ({ c, providerId }) => {
+					const body = await c.req.json().catch(() => ({}));
+					const agentId = body.agentId || c.req.query("agentId");
+					if (!agentId) {
+						return c.json({ error: "Missing agentId" }, 400);
+					}
+
+					const principal = await verifyProviderAuth(c, agentId);
+					if (!principal) {
+						return c.json({ error: "Unauthorized" }, 401);
+					}
+
+					await authProfilesManager.deleteProviderProfiles(
+						agentId,
+						providerId,
+						{
+							userId: principal.userId,
+							...(body.profileId ? { profileId: body.profileId } : {}),
+						},
+					);
+
+					return c.json({ success: true });
+				}),
+			);
+		}
+
+		const agentSettingsStore = coreServices.getAgentSettingsStore();
+		const claudeOAuthStateStore = coreServices.getOAuthStateStore();
+
+		const providerStores: Record<
+			string,
+			{ hasCredentials(agentId: string): Promise<boolean> }
+		> = {};
+		const providerConnectedOverrides: Record<string, boolean> = {};
+		for (const mod of providerModules) {
+			providerStores[mod.providerId] = mod;
+			providerConnectedOverrides[mod.providerId] = mod.hasSystemKey();
+			if (mod.getApp) {
+				authRouter.route(`/${mod.providerId}`, mod.getApp());
+				registeredProviders.push(mod.providerId);
+			}
+		}
+
+		const providerRegistryService = coreServices.getProviderRegistryService();
+
+		if (providerRegistryService) {
+			const systemEnvStore = new SystemEnvStore(coreServices.getSecretStore());
+			systemEnvStore.refreshCache().catch((e: any) => {
+				logger.error("Failed to refresh system env cache", { error: e });
+			});
+			setEnvResolver((key: string) => systemEnvStore.resolve(key));
+		}
+
+		{
+			const landingRouter = createLandingRoutes();
+			app.route("", landingRouter);
+			logger.debug("Landing page enabled at :8080/");
+		}
+
+		{
+			const connectionManager = coreServices
+				.getWorkerGateway()
+				?.getConnectionManager();
+			if (connectionManager) {
+				const agentHistoryRouter = createAgentHistoryRoutes({
+					connectionManager,
+					agentConfigStore: coreServices.getConfigStore(),
+					userAgentsStore: coreServices.getUserAgentsStore(),
+				});
+				app.route("/api/v1/agents/:agentId/history", agentHistoryRouter);
+				logger.debug(
+					"Agent history routes enabled at :8080/api/v1/agents/{agentId}/history/*",
+				);
+			}
+		}
+
+		if (agentSettingsStore) {
+			const agentConfigRouter = createAgentConfigRoutes({
+				agentSettingsStore,
+				agentConfigStore: coreServices.getConfigStore()!,
+				userAgentsStore: coreServices.getUserAgentsStore(),
+				queue: coreServices.getQueue(),
+				providerStores:
+					Object.keys(providerStores).length > 0 ? providerStores : undefined,
+				providerConnectedOverrides,
+				providerCatalogService: coreServices.getProviderCatalogService(),
+				authProfilesManager: coreServices.getAuthProfilesManager(),
+				connectionManager: coreServices
+					.getWorkerGateway()
+					?.getConnectionManager(),
+				grantStore: coreServices.getGrantStore(),
+			});
+			app.route("/api/v1/agents/:agentId/config", agentConfigRouter);
+			logger.debug(
+				"Agent config routes enabled at :8080/api/v1/agents/{id}/config",
+			);
+		}
+
+		if (agentSettingsStore) {
+			const claudeOAuthClient = new OAuthClient(CLAUDE_PROVIDER);
+			const oauthRouter = createOAuthRoutes({
+				providerStores:
+					Object.keys(providerStores).length > 0
+						? (providerStores as Record<string, ProviderCredentialStore>)
+						: undefined,
+				oauthClients: { claude: claudeOAuthClient },
+				oauthStateStore: claudeOAuthStateStore,
+			});
+			authRouter.route("", oauthRouter);
+			registeredProviders.push("oauth");
+		}
+
+		if (registeredProviders.length > 0) {
+			app.route("/api/v1/auth", authRouter);
+			logger.debug(
+				`Auth routes enabled at :8080/api/v1/auth/* for: ${registeredProviders.join(", ")}`,
+			);
+		}
+
+		const channelBindingService = coreServices.getChannelBindingService();
+		if (channelBindingService) {
+			const channelBindingRouter = createChannelBindingRoutes({
+				channelBindingService,
+				userAgentsStore: coreServices.getUserAgentsStore(),
+				agentMetadataStore: coreServices.getAgentMetadataStore(),
+			});
+			app.route("/api/v1/agents/:agentId/channels", channelBindingRouter);
+			logger.debug(
+				"Channel binding routes enabled at :8080/api/v1/agents/{agentId}/channels/*",
+			);
+		}
+
+		{
+			const userAgentsStore = coreServices.getUserAgentsStore();
+			const agentMetadataStore = coreServices.getAgentMetadataStore();
+			const agentManagementRouter = createAgentRoutes({
+				userAgentsStore,
+				agentMetadataStore,
+				agentSettingsStore,
+				channelBindingService,
+			});
+			app.route("/api/v1/agents", agentManagementRouter);
+			logger.debug("Agent management routes enabled at :8080/api/v1/agents/*");
+		}
+	}
+
+	if (chatInstanceManager) {
+		app.route("", createSlackRoutes(chatInstanceManager));
+		app.route("", createConnectionWebhookRoutes(chatInstanceManager));
+		app.route(
+			"",
+			createConnectionCrudRoutes(chatInstanceManager, {
+				userAgentsStore: coreServices.getUserAgentsStore(),
+				agentMetadataStore: coreServices.getConfigStore()!,
+			}),
+		);
+		logger.debug(
+			"Slack and connection routes enabled at :8080/slack/*, :8080/api/v1/connections/*, and :8080/api/v1/webhooks/*",
+		);
+	}
+
+	async function hasDevRouteAccess(c: any): Promise<boolean> {
+		if (await verifySettingsSessionOrToken(c)) return true;
+		const authHeader = c.req.header("Authorization");
+		if (!authHeader?.startsWith("Bearer ")) return false;
+		const token = authHeader.slice(7);
+		const externalAuthClient = coreServices?.getExternalAuthClient?.();
+		if (!externalAuthClient) return false;
+		try {
+			const userInfo = await externalAuthClient.fetchUserInfo(token);
+			return Boolean(userInfo?.sub);
+		} catch {
+			return false;
+		}
+	}
+
+	app.get("/internal/status", async (c) => {
+		if (process.env.NODE_ENV === "production") {
+			return c.json({ error: "Not found" }, 404);
+		}
+		if (!(await hasDevRouteAccess(c))) {
+			return c.json({ error: "Unauthorized" }, 401);
+		}
+
+		const agentConfigStore = coreServices?.getConfigStore();
+
+		const allAgents: AgentMetadata[] = agentConfigStore
+			? await agentConfigStore.listAgents()
+			: [];
+
+		const connections = chatInstanceManager
+			? await chatInstanceManager.listConnections()
+			: [];
+
+		const agentDetails = [];
+		for (const a of allAgents) {
+			const settings = agentConfigStore
+				? await agentConfigStore.getSettings(a.agentId)
+				: null;
+			const providers = (settings?.installedProviders || []).map(
+				(p: { providerId: string }) => p.providerId,
+			);
+			agentDetails.push({
+				agentId: a.agentId,
+				name: a.name,
+				providers,
+				model:
+					settings?.modelSelection?.mode === "pinned"
+						? (settings.modelSelection as { pinnedModel?: string })
+								.pinnedModel || "pinned"
+						: settings?.modelSelection?.mode || "auto",
+			});
+		}
+
+		return c.json({
+			agents: agentDetails,
+			connections: connections.map(
+				(conn: {
+					id: string;
+					platform: string;
+					agentId?: string;
+					metadata?: Record<string, string>;
+				}) => ({
+					id: conn.id,
+					platform: conn.platform,
+					status: chatInstanceManager?.getInstance(conn.id)
+						? "connected"
+						: "disconnected",
+					agentId: conn.agentId || null,
+					botUsername: conn.metadata?.botUsername || null,
+				}),
+			),
+		});
+	});
+
+	registerAutoOpenApiRoutes(app);
+
+	app.doc("/api/docs/openapi.json", {
+		openapi: "3.0.0",
+		info: {
+			title: "Lobu API",
+			version: "1.0.0",
+			description: `
 ## Overview
 
 The Lobu API allows you to create and interact with AI agents programmatically.
@@ -815,65 +819,65 @@ Agents can be configured with custom MCP (Model Context Protocol) servers:
 }
 \`\`\`
       `,
-    },
-    tags: [
-      {
-        name: "Agents",
-        description: "Create, list, update, and delete agents.",
-      },
-      {
-        name: "Messages",
-        description:
-          "Send messages to agents and subscribe to real-time events (SSE).",
-      },
-      {
-        name: "Configuration",
-        description:
-          "Agent configuration — LLM providers, Nix packages, domain grants.",
-      },
-      {
-        name: "Channels",
-        description:
-          "Bind agents to messaging platform channels (Slack, Telegram, WhatsApp).",
-      },
-      {
-        name: "Connections",
-        description:
-          "Manage Chat SDK-backed platform connections and their lifecycle.",
-      },
-      {
-        name: "Schedules",
-        description: "Scheduled wakeups and recurring reminders.",
-      },
-      {
-        name: "History",
-        description: "Session messages, stats, and connection status.",
-      },
-      {
-        name: "Auth",
-        description:
-          "Provider authentication — API keys, OAuth, device code flows.",
-      },
-      {
-        name: "Integrations",
-        description: "Browse and install skills and MCP servers.",
-      },
-    ],
-    servers: [
-      { url: "http://localhost:8787", description: "Local development" },
-    ],
-  });
+		},
+		tags: [
+			{
+				name: "Agents",
+				description: "Create, list, update, and delete agents.",
+			},
+			{
+				name: "Messages",
+				description:
+					"Send messages to agents and subscribe to real-time events (SSE).",
+			},
+			{
+				name: "Configuration",
+				description:
+					"Agent configuration — LLM providers, Nix packages, domain grants.",
+			},
+			{
+				name: "Channels",
+				description:
+					"Bind agents to messaging platform channels (Slack, Telegram, WhatsApp).",
+			},
+			{
+				name: "Connections",
+				description:
+					"Manage Chat SDK-backed platform connections and their lifecycle.",
+			},
+			{
+				name: "Schedules",
+				description: "Scheduled wakeups and recurring reminders.",
+			},
+			{
+				name: "History",
+				description: "Session messages, stats, and connection status.",
+			},
+			{
+				name: "Auth",
+				description:
+					"Provider authentication — API keys, OAuth, device code flows.",
+			},
+			{
+				name: "Integrations",
+				description: "Browse and install skills and MCP servers.",
+			},
+		],
+		servers: [
+			{ url: "http://localhost:8787", description: "Local development" },
+		],
+	});
 
-  app.get(
-    "/api/docs",
-    apiReference({
-      url: "/api/docs/openapi.json",
-      theme: "kepler",
-      layout: "modern",
-      defaultHttpClient: { targetKey: "js", clientKey: "fetch" },
-    })
-  );
-  logger.debug("API docs enabled at /api/docs");
+	app.get(
+		"/api/docs",
+		apiReference({
+			url: "/api/docs/openapi.json",
+			theme: "kepler",
+			layout: "modern",
+			defaultHttpClient: { targetKey: "js", clientKey: "fetch" },
+		}),
+	);
+	logger.debug("API docs enabled at /api/docs");
 
-  return app;
+	return app;
 }

--- a/packages/server/src/gateway/cli/gateway.ts
+++ b/packages/server/src/gateway/cli/gateway.ts
@@ -293,6 +293,12 @@ export function createGatewayApp(
           const pending = await takePendingTool(requestId);
           if (!pending)
             return { success: false, error: "Request not found or expired" };
+          if (!pending.organizationId) {
+            return {
+              success: false,
+              error: "Tool approval missing organization context",
+            };
+          }
           const pattern = `/mcp/${pending.mcpId}/tools/${pending.toolName}`;
           if (decision === "deny") {
             await approveGrantStore?.grant(
@@ -315,9 +321,7 @@ export function createGatewayApp(
               pending.mcpId,
               pending.toolName,
               pending.args,
-              ...(pending.organizationId
-                ? [{ organizationId: pending.organizationId }]
-                : []),
+              { organizationId: pending.organizationId },
             );
             return { success: true, result } as any;
           }

--- a/packages/server/src/gateway/cli/gateway.ts
+++ b/packages/server/src/gateway/cli/gateway.ts
@@ -12,6 +12,7 @@ import { OAuthClient } from "../auth/oauth/client.js";
 import { CLAUDE_PROVIDER } from "../auth/oauth/providers.js";
 import { createAuthProfileLabel } from "../auth/settings/auth-profiles-manager.js";
 import { SystemEnvStore } from "../auth/system-env-store.js";
+import { getMetricsText } from "../metrics/prometheus.js";
 import { getModelProviderModules } from "../modules/module-system.js";
 import { createAudioRoutes } from "../routes/internal/audio.js";
 import { createDeviceAuthRoutes } from "../routes/internal/device-auth.js";
@@ -143,7 +144,6 @@ export function createGatewayApp(
         return c.text("Unauthorized", 401);
       }
     }
-    const { getMetricsText } = await import("../metrics/prometheus.js");
     c.header("Content-Type", "text/plain; version=0.0.4; charset=utf-8");
     return c.text(getMetricsText());
   });
@@ -451,8 +451,14 @@ export function createGatewayApp(
         withProviderAndAuth(
           "Failed to save API key",
           async ({ c, mod, providerId }) => {
-            const body = await c.req.json();
-            const { agentId, apiKey } = body;
+            const body = await c.req.json().catch(() => null);
+            if (!body || typeof body !== "object") {
+              return c.json({ error: "Invalid JSON body" }, 400);
+            }
+            const { agentId, apiKey } = body as {
+              agentId?: string;
+              apiKey?: string;
+            };
             if (!agentId || !apiKey) {
               return c.json({ error: "Missing agentId or apiKey" }, 400);
             }

--- a/packages/server/src/gateway/connections/interaction-bridge.ts
+++ b/packages/server/src/gateway/connections/interaction-bridge.ts
@@ -28,7 +28,7 @@ type ExecuteToolDirectFn = (
   mcpId: string,
   toolName: string,
 	args: Record<string, unknown>,
-	options?: { organizationId?: string },
+	options: { organizationId: string },
 ) => Promise<{
   content: Array<{ type: string; text: string }>;
   isError: boolean;
@@ -830,15 +830,24 @@ export function registerActionHandlers(
       // Execute the pending tool call
       if (executeToolDirect) {
         try {
-					const organizationId =
-						pending.organizationId ?? connection.organizationId;
+					const organizationId = pending.organizationId;
+					if (!organizationId) {
+						logger.error(
+							{ requestId, mcpId: pending.mcpId, toolName: pending.toolName },
+							"Refusing to execute approved MCP tool without organizationId",
+						);
+						await postTarget.post(
+							"This tool approval is missing organization context. Re-send your request to retry.",
+						);
+						return;
+					}
           const result = await executeToolDirect(
             pending.agentId,
             pending.userId,
             pending.mcpId,
             pending.toolName,
 						pending.args,
-						...(organizationId ? [{ organizationId }] : []),
+						{ organizationId },
           );
 
           const resultText = result.content.map((c) => c.text).join("\n");

--- a/packages/server/src/gateway/connections/interaction-bridge.ts
+++ b/packages/server/src/gateway/connections/interaction-bridge.ts
@@ -1,21 +1,21 @@
 import { createLogger } from "@lobu/core";
 import {
-	type PendingToolInvocation,
+  type PendingToolInvocation,
 	takePendingTool,
 } from "../auth/mcp/pending-tool-store.js";
 import type {
-	InteractionService,
-	PostedLinkButton,
-	PostedQuestion,
-	PostedStatusMessage,
-	PostedToolApproval,
+  InteractionService,
+  PostedLinkButton,
+  PostedQuestion,
+  PostedStatusMessage,
+  PostedToolApproval,
 } from "../interactions.js";
 import type { GrantStore } from "../permissions/grant-store.js";
 import type { ChatInstanceManager } from "./chat-instance-manager.js";
 import {
-	claimPendingQuestion,
-	deletePendingQuestion,
-	storePendingQuestion,
+  claimPendingQuestion,
+  deletePendingQuestion,
+  storePendingQuestion,
 } from "./pending-interaction-store.js";
 import type { PlatformConnection } from "./types.js";
 
@@ -23,15 +23,15 @@ const logger = createLogger("chat-interaction-bridge");
 
 /** Signature for the direct tool execution function injected from the MCP proxy. */
 type ExecuteToolDirectFn = (
-	agentId: string,
-	userId: string,
-	mcpId: string,
-	toolName: string,
+  agentId: string,
+  userId: string,
+  mcpId: string,
+  toolName: string,
 	args: Record<string, unknown>,
 	options?: { organizationId?: string },
 ) => Promise<{
-	content: Array<{ type: string; text: string }>;
-	isError: boolean;
+  content: Array<{ type: string; text: string }>;
+  isError: boolean;
 }>;
 
 /**
@@ -42,37 +42,37 @@ type ExecuteToolDirectFn = (
 type SentMessage = { edit: (newContent: any) => Promise<unknown> };
 
 async function postWithFallback(
-	thread: any,
-	primary: { card: any; fallbackText: string },
-	connectionId: string,
+  thread: any,
+  primary: { card: any; fallbackText: string },
+  connectionId: string,
 	context: string,
 ): Promise<SentMessage | null> {
-	try {
-		return (await thread.post(primary)) as SentMessage;
-	} catch (error) {
-		logger.warn(
-			{ connectionId, error: String(error) },
+  try {
+    return (await thread.post(primary)) as SentMessage;
+  } catch (error) {
+    logger.warn(
+      { connectionId, error: String(error) },
 			`Failed to post ${context}`,
-		);
-		try {
-			return (await thread.post(primary.fallbackText)) as SentMessage;
-		} catch {
-			return null;
-		}
-	}
+    );
+    try {
+      return (await thread.post(primary.fallbackText)) as SentMessage;
+    } catch {
+      return null;
+    }
+  }
 }
 
 function resolveGrantExpiresAt(duration: string): number | null {
-	switch (duration) {
-		case "1h":
-			return Date.now() + 3_600_000;
-		case "24h":
-			return Date.now() + 86_400_000;
-		case "always":
-			return null;
-		default:
-			return null;
-	}
+  switch (duration) {
+    case "1h":
+      return Date.now() + 3_600_000;
+    case "24h":
+      return Date.now() + 86_400_000;
+    case "always":
+      return null;
+    default:
+      return null;
+  }
 }
 
 /**
@@ -83,22 +83,22 @@ function resolveGrantExpiresAt(duration: string): number | null {
 async function takePendingToolInvocation(
 	requestId: string,
 ): Promise<PendingToolInvocation | null> {
-	return takePendingTool(requestId);
+  return takePendingTool(requestId);
 }
 
 function describeDecision(decision: string): string {
-	switch (decision) {
-		case "1h":
-			return "Approved (1h)";
-		case "24h":
-			return "Approved (24h)";
-		case "always":
-			return "Approved (always)";
-		case "deny":
-			return "Denied";
-		default:
-			return `Decision: ${decision}`;
-	}
+  switch (decision) {
+    case "1h":
+      return "Approved (1h)";
+    case "24h":
+      return "Approved (24h)";
+    case "always":
+      return "Approved (always)";
+    case "deny":
+      return "Denied";
+    default:
+      return `Decision: ${decision}`;
+  }
 }
 
 /**
@@ -107,32 +107,32 @@ function describeDecision(decision: string): string {
  * after a long gap, or the platform may not support edits).
  */
 async function stripApprovalButtons(
-	sent: SentMessage | undefined,
-	pending: {
-		mcpId: string;
-		toolName: string;
-		args: Record<string, unknown>;
-	},
+  sent: SentMessage | undefined,
+  pending: {
+    mcpId: string;
+    toolName: string;
+    args: Record<string, unknown>;
+  },
 	decision: string,
 ): Promise<void> {
-	if (!sent) return;
-	const summary =
-		`*Tool Approval*\n${pending.mcpId} → ${pending.toolName}\n` +
-		`${formatToolArgs(pending.args)}\n\n_${describeDecision(decision)}_`;
-	try {
-		await sent.edit(summary);
-	} catch {
-		// best effort — card may be stale, edit may be unsupported
-	}
+  if (!sent) return;
+  const summary =
+    `*Tool Approval*\n${pending.mcpId} → ${pending.toolName}\n` +
+    `${formatToolArgs(pending.args)}\n\n_${describeDecision(decision)}_`;
+  try {
+    await sent.edit(summary);
+  } catch {
+    // best effort — card may be stale, edit may be unsupported
+  }
 }
 
 function formatToolArgs(args: Record<string, unknown>): string {
-	return Object.entries(args)
-		.map(([k, v]) => {
-			const val = typeof v === "string" ? v : JSON.stringify(v);
-			return `  ${k}: ${val}`;
-		})
-		.join("\n");
+  return Object.entries(args)
+    .map(([k, v]) => {
+      const val = typeof v === "string" ? v : JSON.stringify(v);
+      return `  ${k}: ${val}`;
+    })
+    .join("\n");
 }
 
 /** Context tracked per posted question so the click handler can feed the
@@ -140,520 +140,520 @@ function formatToolArgs(args: Record<string, unknown>): string {
  *  message (userId/conversationId/channelId/teamId). Also holds the SentMessage
  *  for the card so buttons can be stripped after a click. */
 interface PendingQuestionEntry {
-	question: PostedQuestion;
-	sent?: SentMessage;
+  question: PostedQuestion;
+  sent?: SentMessage;
 }
 
 export function registerInteractionBridge(
-	interactionService: InteractionService,
-	manager: ChatInstanceManager,
-	connection: PlatformConnection,
-	chat: any,
-	grantStore?: GrantStore,
+  interactionService: InteractionService,
+  manager: ChatInstanceManager,
+  connection: PlatformConnection,
+  chat: any,
+  grantStore?: GrantStore,
 	executeToolDirect?: ExecuteToolDirectFn,
 ): () => void {
-	const { id: connectionId, platform } = connection;
+  const { id: connectionId, platform } = connection;
 
-	// Per-connection state (avoids cross-contamination between connections)
-	const handledEvents = new Set<string>();
-	const activeTimers = new Set<NodeJS.Timeout>();
-	// Slack retries event_callback webhooks at ~1s/2s/5s/30s/60s/3min on
-	// missed acks; a 30s dedup window let late retries through and
-	// double-processed the event. 5min covers the full retry envelope.
-	const HANDLED_EVENT_TTL_MS = 5 * 60_000;
-	function markHandled(id: string): void {
-		handledEvents.add(id);
-		const timer = setTimeout(() => {
-			handledEvents.delete(id);
-			activeTimers.delete(timer);
-		}, HANDLED_EVENT_TTL_MS);
-		activeTimers.add(timer);
-	}
+  // Per-connection state (avoids cross-contamination between connections)
+  const handledEvents = new Set<string>();
+  const activeTimers = new Set<NodeJS.Timeout>();
+  // Slack retries event_callback webhooks at ~1s/2s/5s/30s/60s/3min on
+  // missed acks; a 30s dedup window let late retries through and
+  // double-processed the event. 5min covers the full retry envelope.
+  const HANDLED_EVENT_TTL_MS = 5 * 60_000;
+  function markHandled(id: string): void {
+    handledEvents.add(id);
+    const timer = setTimeout(() => {
+      handledEvents.delete(id);
+      activeTimers.delete(timer);
+    }, HANDLED_EVENT_TTL_MS);
+    activeTimers.add(timer);
+  }
 
-	// Tracks posted tool-approval cards so we can edit them on click to strip
-	// the buttons. Keyed by requestId (== PostedToolApproval.id == pending-tool
-	// store key). Auto-expire window matches the pending-tool TTL (24h) so a
-	// late click can still find the card to strip.
-	const APPROVAL_CARD_TTL_MS = 24 * 60 * 60 * 1000;
-	const pendingApprovalCards = new Map<string, SentMessage>();
-	const pendingApprovalTimers = new Map<string, NodeJS.Timeout>();
-	function trackApprovalCard(requestId: string, sent: SentMessage): void {
-		pendingApprovalCards.set(requestId, sent);
-		const timer = setTimeout(() => {
-			pendingApprovalCards.delete(requestId);
-			pendingApprovalTimers.delete(requestId);
-		}, APPROVAL_CARD_TTL_MS);
-		pendingApprovalTimers.set(requestId, timer);
-	}
-	function claimApprovalCard(requestId: string): SentMessage | undefined {
-		const sent = pendingApprovalCards.get(requestId);
-		pendingApprovalCards.delete(requestId);
-		const timer = pendingApprovalTimers.get(requestId);
-		if (timer) {
-			clearTimeout(timer);
-			pendingApprovalTimers.delete(requestId);
-		}
-		return sent;
-	}
+  // Tracks posted tool-approval cards so we can edit them on click to strip
+  // the buttons. Keyed by requestId (== PostedToolApproval.id == pending-tool
+  // store key). Auto-expire window matches the pending-tool TTL (24h) so a
+  // late click can still find the card to strip.
+  const APPROVAL_CARD_TTL_MS = 24 * 60 * 60 * 1000;
+  const pendingApprovalCards = new Map<string, SentMessage>();
+  const pendingApprovalTimers = new Map<string, NodeJS.Timeout>();
+  function trackApprovalCard(requestId: string, sent: SentMessage): void {
+    pendingApprovalCards.set(requestId, sent);
+    const timer = setTimeout(() => {
+      pendingApprovalCards.delete(requestId);
+      pendingApprovalTimers.delete(requestId);
+    }, APPROVAL_CARD_TTL_MS);
+    pendingApprovalTimers.set(requestId, timer);
+  }
+  function claimApprovalCard(requestId: string): SentMessage | undefined {
+    const sent = pendingApprovalCards.get(requestId);
+    pendingApprovalCards.delete(requestId);
+    const timer = pendingApprovalTimers.get(requestId);
+    if (timer) {
+      clearTimeout(timer);
+      pendingApprovalTimers.delete(requestId);
+    }
+    return sent;
+  }
 
-	// Pending questions are persisted in `public.pending_interactions` so a
-	// click landing on a different pod can still claim the entry. The local
-	// `pendingSentMessages` map holds the non-serializable platform
-	// `SentMessage` (used to strip card buttons on click) — losing it
-	// cross-pod is best-effort UX, not correctness.
-	//
-	// DB-row sweeping is owned globally by `coreServices.sweepEphemeralTables`
-	// (scheduled every 5 minutes in `packages/server/src/scheduled/jobs.ts`).
-	// We do NOT call `sweepStalePendingInteractions` per-bridge — N bridges
-	// hitting the same table N times is wasted work. The local sweep below
-	// is in-memory only: it evicts cache entries past their TTL so the Map
-	// doesn't grow unbounded for questions that are never clicked.
-	const PENDING_SENT_TTL_MS = 24 * 60 * 60 * 1000;
-	const PENDING_SENT_SWEEP_INTERVAL_MS = 60 * 60 * 1000;
-	interface CachedSent {
-		sent: SentMessage;
-		registeredAt: number;
-	}
-	const pendingSentMessages = new Map<string, CachedSent>();
-	const pendingSentSweepTimer = setInterval(() => {
-		const ttlCutoff = Date.now() - PENDING_SENT_TTL_MS;
-		for (const [id, entry] of pendingSentMessages) {
-			if (entry.registeredAt <= ttlCutoff) {
-				pendingSentMessages.delete(id);
-			}
-		}
-	}, PENDING_SENT_SWEEP_INTERVAL_MS);
-	pendingSentSweepTimer.unref?.();
-	/**
-	 * Persist a pending question row, then cache its SentMessage handle so a
-	 * click on this pod can edit the card. The persist happens first — see
-	 * `onQuestionCreated` for the post-then-persist policy that wraps the
-	 * card-post; this function is invoked only after the row is durable.
-	 */
-	function rememberSentMessage(
-		questionId: string,
+  // Pending questions are persisted in `public.pending_interactions` so a
+  // click landing on a different pod can still claim the entry. The local
+  // `pendingSentMessages` map holds the non-serializable platform
+  // `SentMessage` (used to strip card buttons on click) — losing it
+  // cross-pod is best-effort UX, not correctness.
+  //
+  // DB-row sweeping is owned globally by `coreServices.sweepEphemeralTables`
+  // (scheduled every 5 minutes in `packages/server/src/scheduled/jobs.ts`).
+  // We do NOT call `sweepStalePendingInteractions` per-bridge — N bridges
+  // hitting the same table N times is wasted work. The local sweep below
+  // is in-memory only: it evicts cache entries past their TTL so the Map
+  // doesn't grow unbounded for questions that are never clicked.
+  const PENDING_SENT_TTL_MS = 24 * 60 * 60 * 1000;
+  const PENDING_SENT_SWEEP_INTERVAL_MS = 60 * 60 * 1000;
+  interface CachedSent {
+    sent: SentMessage;
+    registeredAt: number;
+  }
+  const pendingSentMessages = new Map<string, CachedSent>();
+  const pendingSentSweepTimer = setInterval(() => {
+    const ttlCutoff = Date.now() - PENDING_SENT_TTL_MS;
+    for (const [id, entry] of pendingSentMessages) {
+      if (entry.registeredAt <= ttlCutoff) {
+        pendingSentMessages.delete(id);
+      }
+    }
+  }, PENDING_SENT_SWEEP_INTERVAL_MS);
+  pendingSentSweepTimer.unref?.();
+  /**
+   * Persist a pending question row, then cache its SentMessage handle so a
+   * click on this pod can edit the card. The persist happens first — see
+   * `onQuestionCreated` for the post-then-persist policy that wraps the
+   * card-post; this function is invoked only after the row is durable.
+   */
+  function rememberSentMessage(
+    questionId: string,
 		sent: SentMessage | undefined,
-	): void {
-		if (!sent) return;
-		pendingSentMessages.set(questionId, {
-			sent,
-			registeredAt: Date.now(),
-		});
-	}
-	async function claimQuestion(
-		questionId: string,
-		organizationId: string,
+  ): void {
+    if (!sent) return;
+    pendingSentMessages.set(questionId, {
+      sent,
+      registeredAt: Date.now(),
+    });
+  }
+  async function claimQuestion(
+    questionId: string,
+    organizationId: string,
 		expectedUserId: string,
-	): Promise<PendingQuestionEntry | undefined> {
-		const stored = await claimPendingQuestion(
-			questionId,
-			organizationId,
-			connectionId,
+  ): Promise<PendingQuestionEntry | undefined> {
+    const stored = await claimPendingQuestion(
+      questionId,
+      organizationId,
+      connectionId,
 			expectedUserId,
-		).catch((error) => {
-			logger.error(
-				{ connectionId, questionId, error: String(error) },
+    ).catch((error) => {
+      logger.error(
+        { connectionId, questionId, error: String(error) },
 				"Failed to claim pending question",
-			);
-			return null;
-		});
-		if (!stored) return undefined;
-		const cached = pendingSentMessages.get(questionId);
-		pendingSentMessages.delete(questionId);
-		return { question: stored.question, sent: cached?.sent };
-	}
-	const onQuestionCreated = async (event: PostedQuestion) => {
-		try {
-			if (!shouldHandle(event, platform, connectionId, manager)) return;
-			if (handledEvents.has(event.id)) return;
-			markHandled(event.id);
+      );
+      return null;
+    });
+    if (!stored) return undefined;
+    const cached = pendingSentMessages.get(questionId);
+    pendingSentMessages.delete(questionId);
+    return { question: stored.question, sent: cached?.sent };
+  }
+  const onQuestionCreated = async (event: PostedQuestion) => {
+    try {
+      if (!shouldHandle(event, platform, connectionId, manager)) return;
+      if (handledEvents.has(event.id)) return;
+      markHandled(event.id);
 
-			// Cross-tenant scoping: every pending row must carry the bridge's
-			// org. Without a known org we can't safely persist or claim, so
-			// drop the event rather than write an un-scoped row.
-			const organizationId = connection.organizationId;
-			if (!organizationId) {
-				logger.warn(
-					{ connectionId, questionId: event.id },
+      // Cross-tenant scoping: every pending row must carry the bridge's
+      // org. Without a known org we can't safely persist or claim, so
+      // drop the event rather than write an un-scoped row.
+      const organizationId = connection.organizationId;
+      if (!organizationId) {
+        logger.warn(
+          { connectionId, questionId: event.id },
 					"Skipping question:created — connection has no organizationId",
-				);
-				return;
-			}
-			if (!event.userId) {
-				logger.warn(
-					{ connectionId, questionId: event.id },
+        );
+        return;
+      }
+      if (!event.userId) {
+        logger.warn(
+          { connectionId, questionId: event.id },
 					"Skipping question:created — event has no userId",
-				);
-				return;
-			}
+        );
+        return;
+      }
 
-			const thread = await resolveThread(
-				manager,
-				connectionId,
-				event.channelId,
+      const thread = await resolveThread(
+        manager,
+        connectionId,
+        event.channelId,
 				event.conversationId,
-			);
-			if (!thread) return;
+      );
+      if (!thread) return;
 
-			// Persist the pending row BEFORE posting the card. If the persist
-			// fails we never show buttons that would no-op on click. If the row
-			// is written but the post fails, we delete it on the way out so a
-			// stale row doesn't sit waiting for a click that will never arrive.
-			try {
-				await storePendingQuestion(
-					event.id,
-					organizationId,
-					connectionId,
-					event.userId,
+      // Persist the pending row BEFORE posting the card. If the persist
+      // fails we never show buttons that would no-op on click. If the row
+      // is written but the post fails, we delete it on the way out so a
+      // stale row doesn't sit waiting for a click that will never arrive.
+      try {
+        await storePendingQuestion(
+          event.id,
+          organizationId,
+          connectionId,
+          event.userId,
 					{ question: event },
-				);
-			} catch (error) {
-				logger.error(
-					{ connectionId, questionId: event.id, error: String(error) },
+        );
+      } catch (error) {
+        logger.error(
+          { connectionId, questionId: event.id, error: String(error) },
 					"Failed to persist pending question — not posting card",
-				);
-				return;
-			}
+        );
+        return;
+      }
 
-			const { Card, CardText, Actions, Button } = await import("chat");
-			const buttons = event.options.map((option, i) =>
-				Button({
-					id: `question:${event.id}:${i}`,
-					label: option,
-					value: option,
+      const { Card, CardText, Actions, Button } = await import("chat");
+      const buttons = event.options.map((option, i) =>
+        Button({
+          id: `question:${event.id}:${i}`,
+          label: option,
+          value: option,
 				}),
-			);
-			const card = Card({
-				children: [CardText(event.question), Actions(buttons)],
-			});
-			const fallbackText = `${event.question}\n${event.options.map((o, i) => `${i + 1}. ${o}`).join("\n")}`;
-			const sent = await postWithFallback(
-				thread,
-				{ card, fallbackText },
-				connectionId,
+      );
+      const card = Card({
+        children: [CardText(event.question), Actions(buttons)],
+      });
+      const fallbackText = `${event.question}\n${event.options.map((o, i) => `${i + 1}. ${o}`).join("\n")}`;
+      const sent = await postWithFallback(
+        thread,
+        { card, fallbackText },
+        connectionId,
 				"question interaction",
-			);
-			if (!sent) {
-				// Post failed entirely. The row exists but no card was rendered,
-				// so a click can never come — DELETE the row to keep the table
-				// clean. Pre-fix used `claimPendingQuestion` (UPDATE setting
-				// claimed_at), which leaves a phantom row sitting around with
-				// claimed_at set until the 24h sweep. Hard-delete is the
-				// semantically correct end state, and the four-field scoping
-				// matches the claim path's safety invariant: a leaked id alone
-				// cannot delete another tenant's row.
-				try {
-					await deletePendingQuestion(
-						event.id,
-						organizationId,
-						connectionId,
+      );
+      if (!sent) {
+        // Post failed entirely. The row exists but no card was rendered,
+        // so a click can never come — DELETE the row to keep the table
+        // clean. Pre-fix used `claimPendingQuestion` (UPDATE setting
+        // claimed_at), which leaves a phantom row sitting around with
+        // claimed_at set until the 24h sweep. Hard-delete is the
+        // semantically correct end state, and the four-field scoping
+        // matches the claim path's safety invariant: a leaked id alone
+        // cannot delete another tenant's row.
+        try {
+          await deletePendingQuestion(
+            event.id,
+            organizationId,
+            connectionId,
 						event.userId,
-					);
-				} catch (error) {
-					logger.debug(
-						{ connectionId, questionId: event.id, error: String(error) },
+          );
+        } catch (error) {
+          logger.debug(
+            { connectionId, questionId: event.id, error: String(error) },
 						"Failed to drop pending row after post failure",
-					);
-				}
-				return;
-			}
-			rememberSentMessage(event.id, sent);
-		} catch (error) {
-			logger.error(
-				{ connectionId, error: String(error) },
+          );
+        }
+        return;
+      }
+      rememberSentMessage(event.id, sent);
+    } catch (error) {
+      logger.error(
+        { connectionId, error: String(error) },
 				"Unhandled error in question:created handler",
-			);
-		}
-	};
+      );
+    }
+  };
 
-	const onToolApprovalNeeded = async (event: PostedToolApproval) => {
-		try {
-			if (!shouldHandle(event, platform, connectionId, manager)) return;
-			if (handledEvents.has(event.id)) return;
-			markHandled(event.id);
+  const onToolApprovalNeeded = async (event: PostedToolApproval) => {
+    try {
+      if (!shouldHandle(event, platform, connectionId, manager)) return;
+      if (handledEvents.has(event.id)) return;
+      markHandled(event.id);
 
-			const argsText = formatToolArgs(event.args);
-			const text = `Tool Approval\n${event.mcpId} → ${event.toolName}\n${argsText}`;
-			const tid = event.id;
+      const argsText = formatToolArgs(event.args);
+      const text = `Tool Approval\n${event.mcpId} → ${event.toolName}\n${argsText}`;
+      const tid = event.id;
 
-			const thread = await resolveThread(
-				manager,
-				connectionId,
-				event.channelId,
+      const thread = await resolveThread(
+        manager,
+        connectionId,
+        event.channelId,
 				event.conversationId,
-			);
-			if (!thread) return;
+      );
+      if (!thread) return;
 
-			const { Card, CardText, Actions, Button } = await import("chat");
-			const card = Card({
-				children: [
-					CardText(
+      const { Card, CardText, Actions, Button } = await import("chat");
+      const card = Card({
+        children: [
+          CardText(
 						`*Tool Approval*\n${event.mcpId} → ${event.toolName}\n${argsText}`,
-					),
-					Actions([
-						Button({
-							id: `tool:${tid}:1h`,
-							label: "Allow 1h",
-							style: "primary",
-							value: "1h",
-						}),
-						Button({
-							id: `tool:${tid}:24h`,
-							label: "Allow 24h",
-							style: "primary",
-							value: "24h",
-						}),
-						Button({
-							id: `tool:${tid}:always`,
-							label: "Allow always",
-							style: "primary",
-							value: "always",
-						}),
-						Button({
-							id: `tool:${tid}:deny`,
-							label: "Deny always",
-							style: "danger",
-							value: "deny",
-						}),
-					]),
-				],
-			});
-			const sent = await postWithFallback(
-				thread,
-				{ card, fallbackText: text },
-				connectionId,
+          ),
+          Actions([
+            Button({
+              id: `tool:${tid}:1h`,
+              label: "Allow 1h",
+              style: "primary",
+              value: "1h",
+            }),
+            Button({
+              id: `tool:${tid}:24h`,
+              label: "Allow 24h",
+              style: "primary",
+              value: "24h",
+            }),
+            Button({
+              id: `tool:${tid}:always`,
+              label: "Allow always",
+              style: "primary",
+              value: "always",
+            }),
+            Button({
+              id: `tool:${tid}:deny`,
+              label: "Deny always",
+              style: "danger",
+              value: "deny",
+            }),
+          ]),
+        ],
+      });
+      const sent = await postWithFallback(
+        thread,
+        { card, fallbackText: text },
+        connectionId,
 				"tool approval interaction",
-			);
-			if (sent) {
-				trackApprovalCard(tid, sent);
-			}
-		} catch (error) {
-			logger.error(
-				{ connectionId, error: String(error) },
+      );
+      if (sent) {
+        trackApprovalCard(tid, sent);
+      }
+    } catch (error) {
+      logger.error(
+        { connectionId, error: String(error) },
 				"Unhandled error in tool:approval-needed handler",
-			);
-		}
-	};
+      );
+    }
+  };
 
-	const onLinkButtonCreated = async (event: PostedLinkButton) => {
-		try {
-			if (!shouldHandle(event, platform, connectionId, manager)) return;
-			if (handledEvents.has(event.id)) return;
-			markHandled(event.id);
+  const onLinkButtonCreated = async (event: PostedLinkButton) => {
+    try {
+      if (!shouldHandle(event, platform, connectionId, manager)) return;
+      if (handledEvents.has(event.id)) return;
+      markHandled(event.id);
 
-			const thread = await resolveThread(
-				manager,
-				connectionId,
-				event.channelId,
+      const thread = await resolveThread(
+        manager,
+        connectionId,
+        event.channelId,
 				event.conversationId,
-			);
-			if (!thread) return;
+      );
+      if (!thread) return;
 
-			const { Card, CardText, Actions, LinkButton } = await import("chat");
-			const linkButton = LinkButton({
-				url: event.url,
-				label: event.label,
-			});
-			// The button itself carries the label — only render an extra line of
-			// card-body text when the caller supplied a distinct `body` explaining
-			// *why* (e.g. for OAuth, "Authorize {mcp} to continue."). Falling back
-			// to `label` again would produce the "Connect sentry / [Connect sentry]"
-			// duplication we saw in Slack.
-			const bodyText = event.body?.trim();
-			const cardChildren =
-				bodyText && bodyText !== event.label
-					? [CardText(bodyText), Actions([linkButton])]
-					: [Actions([linkButton])];
-			const card = Card({ children: cardChildren });
-			const fallbackText = bodyText
-				? `${bodyText} ${event.label}: ${event.url}`
-				: `${event.label}: ${event.url}`;
-			await postWithFallback(
-				thread,
-				{ card, fallbackText },
-				connectionId,
+      const { Card, CardText, Actions, LinkButton } = await import("chat");
+      const linkButton = LinkButton({
+        url: event.url,
+        label: event.label,
+      });
+      // The button itself carries the label — only render an extra line of
+      // card-body text when the caller supplied a distinct `body` explaining
+      // *why* (e.g. for OAuth, "Authorize {mcp} to continue."). Falling back
+      // to `label` again would produce the "Connect sentry / [Connect sentry]"
+      // duplication we saw in Slack.
+      const bodyText = event.body?.trim();
+      const cardChildren =
+        bodyText && bodyText !== event.label
+          ? [CardText(bodyText), Actions([linkButton])]
+          : [Actions([linkButton])];
+      const card = Card({ children: cardChildren });
+      const fallbackText = bodyText
+        ? `${bodyText} ${event.label}: ${event.url}`
+        : `${event.label}: ${event.url}`;
+      await postWithFallback(
+        thread,
+        { card, fallbackText },
+        connectionId,
 				"link button interaction",
-			);
-		} catch (error) {
-			logger.error(
-				{ connectionId, error: String(error) },
+      );
+    } catch (error) {
+      logger.error(
+        { connectionId, error: String(error) },
 				"Unhandled error in link-button:created handler",
-			);
-		}
-	};
+      );
+    }
+  };
 
-	const onStatusMessageCreated = async (event: PostedStatusMessage) => {
-		try {
-			if (!shouldHandle(event, platform, connectionId, manager)) return;
-			if (handledEvents.has(event.id)) return;
-			markHandled(event.id);
+  const onStatusMessageCreated = async (event: PostedStatusMessage) => {
+    try {
+      if (!shouldHandle(event, platform, connectionId, manager)) return;
+      if (handledEvents.has(event.id)) return;
+      markHandled(event.id);
 
-			const thread = await resolveThread(
-				manager,
-				connectionId,
-				event.channelId,
+      const thread = await resolveThread(
+        manager,
+        connectionId,
+        event.channelId,
 				event.conversationId,
-			);
-			if (!thread) return;
+      );
+      if (!thread) return;
 
-			try {
-				await thread.post(event.text);
-			} catch (error) {
-				logger.warn(
-					{ connectionId, error: String(error) },
+      try {
+        await thread.post(event.text);
+      } catch (error) {
+        logger.warn(
+          { connectionId, error: String(error) },
 					"Failed to post status message interaction",
-				);
-			}
-		} catch (error) {
-			logger.error(
-				{ connectionId, error: String(error) },
+        );
+      }
+    } catch (error) {
+      logger.error(
+        { connectionId, error: String(error) },
 				"Unhandled error in status-message:created handler",
-			);
-		}
-	};
+      );
+    }
+  };
 
-	interactionService.on("question:created", onQuestionCreated);
-	interactionService.on("tool:approval-needed", onToolApprovalNeeded);
-	interactionService.on("link-button:created", onLinkButtonCreated);
-	interactionService.on("status-message:created", onStatusMessageCreated);
+  interactionService.on("question:created", onQuestionCreated);
+  interactionService.on("tool:approval-needed", onToolApprovalNeeded);
+  interactionService.on("link-button:created", onLinkButtonCreated);
+  interactionService.on("status-message:created", onStatusMessageCreated);
 
-	registerActionHandlers(
-		chat,
-		connection,
-		grantStore,
-		executeToolDirect,
-		claimApprovalCard,
-		async (questionId, value, thread, author) => {
-			// Fast path — Slack's block_actions webhook requires a <3s response.
-			// The claim is a single `UPDATE … RETURNING` on a PK and stays well
-			// under the budget; the slow platform API calls (post receipt, edit
-			// card, enqueue worker turn) still fire-and-forget below.
-			//
-			// Authorisation lives INSIDE the SQL claim: the row only matches when
-			// `(organization_id, connection_id, expected_user_id)` line up with
-			// the clicker's context. Wrong-user / cross-connection / cross-tenant
-			// clicks return null without consuming the row — no claim-then-auth
-			// race, no restash needed.
-			const organizationId = connection.organizationId;
-			if (!organizationId) {
-				logger.warn(
-					{ connectionId, questionId },
+  registerActionHandlers(
+    chat,
+    connection,
+    grantStore,
+    executeToolDirect,
+    claimApprovalCard,
+    async (questionId, value, thread, author) => {
+      // Fast path — Slack's block_actions webhook requires a <3s response.
+      // The claim is a single `UPDATE … RETURNING` on a PK and stays well
+      // under the budget; the slow platform API calls (post receipt, edit
+      // card, enqueue worker turn) still fire-and-forget below.
+      //
+      // Authorisation lives INSIDE the SQL claim: the row only matches when
+      // `(organization_id, connection_id, expected_user_id)` line up with
+      // the clicker's context. Wrong-user / cross-connection / cross-tenant
+      // clicks return null without consuming the row — no claim-then-auth
+      // race, no restash needed.
+      const organizationId = connection.organizationId;
+      if (!organizationId) {
+        logger.warn(
+          { connectionId, questionId },
 					"Question click on connection with no organizationId — ignoring",
-				);
-				return;
-			}
-			if (!author?.userId) {
-				logger.debug(
-					{ connectionId, questionId },
+        );
+        return;
+      }
+      if (!author?.userId) {
+        logger.debug(
+          { connectionId, questionId },
 					"Question click without author.userId — ignoring",
-				);
-				return;
-			}
+        );
+        return;
+      }
 
-			const entry = await claimQuestion(
-				questionId,
-				organizationId,
+      const entry = await claimQuestion(
+        questionId,
+        organizationId,
 				author.userId,
-			);
-			if (!entry) {
-				logger.debug(
-					{ connectionId, questionId, clickerUserId: author.userId },
+      );
+      if (!entry) {
+        logger.debug(
+          { connectionId, questionId, clickerUserId: author.userId },
 					"Question click did not match any pending row — ignoring",
-				);
-				return;
-			}
+        );
+        return;
+      }
 
-			const instance = manager.getInstance(connectionId);
-			if (!instance) {
-				logger.warn(
-					{ connectionId },
+      const instance = manager.getInstance(connectionId);
+      if (!instance) {
+        logger.warn(
+          { connectionId },
 					"Question click: no instance for connection",
-				);
-				return;
-			}
+        );
+        return;
+      }
 
-			const { question } = entry;
-			const receiptText = value
-				? `*You submitted:* ${value}`
-				: "*You submitted a response.*";
+      const { question } = entry;
+      const receiptText = value
+        ? `*You submitted:* ${value}`
+        : "*You submitted a response.*";
 
-			void (async () => {
-				// Visible "user submitted X" receipt so the click is acknowledged
-				// in-thread even before the worker responds.
-				try {
-					const { Card, CardText } = await import("chat");
-					const card = Card({ children: [CardText(receiptText)] });
-					await thread
-						.post({ card, fallbackText: receiptText })
-						.catch(async () => {
-							await thread.post(receiptText);
-						});
-				} catch {
-					try {
-						await thread.post(receiptText);
-					} catch {
-						// best effort — even the plain-text fallback failed
-					}
-				}
+      void (async () => {
+        // Visible "user submitted X" receipt so the click is acknowledged
+        // in-thread even before the worker responds.
+        try {
+          const { Card, CardText } = await import("chat");
+          const card = Card({ children: [CardText(receiptText)] });
+          await thread
+            .post({ card, fallbackText: receiptText })
+            .catch(async () => {
+              await thread.post(receiptText);
+            });
+        } catch {
+          try {
+            await thread.post(receiptText);
+          } catch {
+            // best effort — even the plain-text fallback failed
+          }
+        }
 
-				// Strip the original card's buttons so it can't be clicked again.
-				if (entry.sent) {
-					try {
-						await entry.sent.edit(
+        // Strip the original card's buttons so it can't be clicked again.
+        if (entry.sent) {
+          try {
+            await entry.sent.edit(
 							`${question.question}\n\n_Answered: ${value}_`,
-						);
-					} catch {
-						// best effort — card may be stale or un-editable
-					}
-				}
+            );
+          } catch {
+            // best effort — card may be stale or un-editable
+          }
+        }
 
-				// MUST route with question.userId (the original message's user), not
-				// author.userId (who physically clicked). The worker session is keyed
-				// on the original userId and will reject SSE deliveries that don't match.
-				await instance.messageBridge.ingestClick({
-					userId: question.userId,
-					channelId: question.channelId,
-					conversationId: question.conversationId,
-					teamId: question.teamId,
-					authorName: author?.fullName,
-					authorUsername: author?.userName,
-					value,
-					thread,
-					responseThreadId:
-						typeof thread?.id === "string" ? thread.id : undefined,
-				});
-			})().catch((error) => {
-				logger.error(
-					{ connectionId, questionId, error: String(error) },
+        // MUST route with question.userId (the original message's user), not
+        // author.userId (who physically clicked). The worker session is keyed
+        // on the original userId and will reject SSE deliveries that don't match.
+        await instance.messageBridge.ingestClick({
+          userId: question.userId,
+          channelId: question.channelId,
+          conversationId: question.conversationId,
+          teamId: question.teamId,
+          authorName: author?.fullName,
+          authorUsername: author?.userName,
+          value,
+          thread,
+          responseThreadId:
+            typeof thread?.id === "string" ? thread.id : undefined,
+        });
+      })().catch((error) => {
+        logger.error(
+          { connectionId, questionId, error: String(error) },
 					"Background question-click processing failed",
-				);
-			});
-		},
-		async (channelId, conversationId) =>
+        );
+      });
+    },
+    async (channelId, conversationId) =>
 			resolveThread(manager, connectionId, channelId, conversationId),
-	);
+  );
 
-	logger.info({ connectionId, platform }, "Interaction bridge registered");
+  logger.info({ connectionId, platform }, "Interaction bridge registered");
 
-	return () => {
-		interactionService.off("question:created", onQuestionCreated);
-		interactionService.off("tool:approval-needed", onToolApprovalNeeded);
-		interactionService.off("link-button:created", onLinkButtonCreated);
-		interactionService.off("status-message:created", onStatusMessageCreated);
-		for (const timer of activeTimers) {
-			clearTimeout(timer);
-		}
-		activeTimers.clear();
-		handledEvents.clear();
-		for (const timer of pendingApprovalTimers.values()) {
-			clearTimeout(timer);
-		}
-		pendingApprovalTimers.clear();
-		pendingApprovalCards.clear();
-		clearInterval(pendingSentSweepTimer);
-		pendingSentMessages.clear();
-		logger.info({ connectionId, platform }, "Interaction bridge unregistered");
-	};
+  return () => {
+    interactionService.off("question:created", onQuestionCreated);
+    interactionService.off("tool:approval-needed", onToolApprovalNeeded);
+    interactionService.off("link-button:created", onLinkButtonCreated);
+    interactionService.off("status-message:created", onStatusMessageCreated);
+    for (const timer of activeTimers) {
+      clearTimeout(timer);
+    }
+    activeTimers.clear();
+    handledEvents.clear();
+    for (const timer of pendingApprovalTimers.values()) {
+      clearTimeout(timer);
+    }
+    pendingApprovalTimers.clear();
+    pendingApprovalCards.clear();
+    clearInterval(pendingSentSweepTimer);
+    pendingSentMessages.clear();
+    logger.info({ connectionId, platform }, "Interaction bridge unregistered");
+  };
 }
 
 /**
@@ -663,9 +663,9 @@ export function registerInteractionBridge(
  * the raw click through.
  */
 type OnQuestionClickFn = (
-	questionId: string,
-	value: string,
-	thread: any,
+  questionId: string,
+  value: string,
+  thread: any,
 	author: { userId?: string; userName?: string; fullName?: string } | undefined,
 ) => Promise<void>;
 
@@ -681,336 +681,336 @@ type OnQuestionClickFn = (
  * in tests that only exercise tool-approval flows.
  */
 export function registerActionHandlers(
-	chat: any,
-	connection: PlatformConnection,
-	grantStore: GrantStore | undefined,
-	executeToolDirect?: ExecuteToolDirectFn,
-	claimApprovalCard?: (requestId: string) => SentMessage | undefined,
-	onQuestionClick?: OnQuestionClickFn,
-	resolveApprovalTarget?: (
-		channelId: string,
+  chat: any,
+  connection: PlatformConnection,
+  grantStore: GrantStore | undefined,
+  executeToolDirect?: ExecuteToolDirectFn,
+  claimApprovalCard?: (requestId: string) => SentMessage | undefined,
+  onQuestionClick?: OnQuestionClickFn,
+  resolveApprovalTarget?: (
+    channelId: string,
 		conversationId: string,
 	) => Promise<any | null>,
 ): void {
-	chat.onAction(async (event: any) => {
-		const actionId: string = event.actionId ?? "";
-		const value: string = event.value ?? "";
-		const thread = event.thread;
+  chat.onAction(async (event: any) => {
+    const actionId: string = event.actionId ?? "";
+    const value: string = event.value ?? "";
+    const thread = event.thread;
 
-		if (!thread || !actionId) return;
+    if (!thread || !actionId) return;
 
-		// Handle tool approval — store grant, execute tool, post result
-		if (actionId.startsWith("tool:")) {
-			const parts = actionId.split(":");
-			const requestId = parts[1];
-			const decision = parts[2] ?? "deny";
+    // Handle tool approval — store grant, execute tool, post result
+    if (actionId.startsWith("tool:")) {
+      const parts = actionId.split(":");
+      const requestId = parts[1];
+      const decision = parts[2] ?? "deny";
 
-			if (!requestId) return;
+      if (!requestId) return;
 
-			// GETDEL atomically claims the pending invocation. On Slack retries of
-			// the same block_actions webhook the second GETDEL returns null and we
-			// silently no-op (the first click already won). But if the card was
-			// never claimed before — i.e. the in-memory approval card is still
-			// tracked — this is a real first click landing on an expired/missing
-			// pending key, and we MUST surface that to the user. Otherwise the
-			// click looks like it did nothing.
-			const pending = await takePendingToolInvocation(requestId).catch(
+      // GETDEL atomically claims the pending invocation. On Slack retries of
+      // the same block_actions webhook the second GETDEL returns null and we
+      // silently no-op (the first click already won). But if the card was
+      // never claimed before — i.e. the in-memory approval card is still
+      // tracked — this is a real first click landing on an expired/missing
+      // pending key, and we MUST surface that to the user. Otherwise the
+      // click looks like it did nothing.
+      const pending = await takePendingToolInvocation(requestId).catch(
 				() => null,
-			);
-			if (!pending) {
-				const sent = claimApprovalCard?.(requestId);
-				if (sent) {
-					logger.info(
-						{ requestId, decision },
+      );
+      if (!pending) {
+        const sent = claimApprovalCard?.(requestId);
+        if (sent) {
+          logger.info(
+            { requestId, decision },
 						"Tool approval click with no pending invocation — likely expired",
-					);
-					try {
-						await sent.edit(
+          );
+          try {
+            await sent.edit(
 							"*Tool Approval*\n\n_This approval request expired before it could be acted on. Re-send your last message to retry._",
-						);
-					} catch {
-						// best effort
-					}
-					try {
-						await thread.post(
+            );
+          } catch {
+            // best effort
+          }
+          try {
+            await thread.post(
 							"This tool approval request expired before it could be acted on. Re-send your last message to retry.",
-						);
-					} catch {
-						// best effort
-					}
-				} else {
-					logger.debug(
-						{ requestId, decision },
+            );
+          } catch {
+            // best effort
+          }
+        } else {
+          logger.debug(
+            { requestId, decision },
 						"Tool approval click with no pending invocation and no tracked card — ignoring (already handled)",
-					);
-				}
-				return;
-			}
+          );
+        }
+        return;
+      }
 
-			const pattern = `/mcp/${pending.mcpId}/tools/${pending.toolName}`;
+      const pattern = `/mcp/${pending.mcpId}/tools/${pending.toolName}`;
 
-			// Edit the posted card to strip buttons so it can't be clicked again.
-			await stripApprovalButtons(
-				claimApprovalCard?.(requestId),
-				pending,
+      // Edit the posted card to strip buttons so it can't be clicked again.
+      await stripApprovalButtons(
+        claimApprovalCard?.(requestId),
+        pending,
 				decision,
-			);
+      );
 
-			// Resolve the post target. Prefer the original conversation captured at
-			// the time the tool call was blocked (saved alongside the pending
-			// record) so the result lands in the same Slack/Telegram thread the
-			// user originally pinged the bot in. Fall back to the click event's
-			// thread (the card the user just clicked) only if we don't have the
-			// original context — that fallback can be wrong on Slack when the card
-			// ended up posted at channel level.
-			let postTarget: any = thread;
-			if (
-				resolveApprovalTarget &&
-				(pending.conversationId || pending.channelId)
-			) {
-				const resolved = await resolveApprovalTarget(
-					pending.channelId ?? "",
+      // Resolve the post target. Prefer the original conversation captured at
+      // the time the tool call was blocked (saved alongside the pending
+      // record) so the result lands in the same Slack/Telegram thread the
+      // user originally pinged the bot in. Fall back to the click event's
+      // thread (the card the user just clicked) only if we don't have the
+      // original context — that fallback can be wrong on Slack when the card
+      // ended up posted at channel level.
+      let postTarget: any = thread;
+      if (
+        resolveApprovalTarget &&
+        (pending.conversationId || pending.channelId)
+      ) {
+        const resolved = await resolveApprovalTarget(
+          pending.channelId ?? "",
 					pending.conversationId ?? "",
-				).catch(() => null);
-				if (resolved) postTarget = resolved;
-			}
+        ).catch(() => null);
+        if (resolved) postTarget = resolved;
+      }
 
-			if (decision === "deny") {
-				if (grantStore) {
-					await grantStore
-						.grant(
-							pending.agentId,
-							pattern,
-							null,
-							true,
+      if (decision === "deny") {
+        if (grantStore) {
+          await grantStore
+            .grant(
+              pending.agentId,
+              pattern,
+              null,
+              true,
 							connection.organizationId,
-						)
-						.catch(() => undefined);
-				}
-				try {
-					await postTarget.post(
+            )
+            .catch(() => undefined);
+        }
+        try {
+          await postTarget.post(
 						"Tool call denied. Let me know if you'd like me to try a different approach.",
-					);
-				} catch {
-					// best effort
-				}
-				return;
-			}
+          );
+        } catch {
+          // best effort
+        }
+        return;
+      }
 
-			// Approved — store grant, execute, post result
-			const expiresAt = resolveGrantExpiresAt(decision);
+      // Approved — store grant, execute, post result
+      const expiresAt = resolveGrantExpiresAt(decision);
 
-			if (grantStore) {
-				try {
-					await grantStore.grant(
-						pending.agentId,
-						pattern,
-						expiresAt,
-						undefined,
+      if (grantStore) {
+        try {
+          await grantStore.grant(
+            pending.agentId,
+            pattern,
+            expiresAt,
+            undefined,
 						connection.organizationId,
-					);
-					logger.info(
-						{
-							requestId,
-							agentId: pending.agentId,
-							pattern,
-							decision,
-							expiresAt,
-						},
+          );
+          logger.info(
+            {
+              requestId,
+              agentId: pending.agentId,
+              pattern,
+              decision,
+              expiresAt,
+            },
 						"Grant stored via tool approval",
-					);
-				} catch (error) {
-					logger.error(
-						{ requestId, error: String(error) },
+          );
+        } catch (error) {
+          logger.error(
+            { requestId, error: String(error) },
 						"Failed to store grant",
-					);
-				}
-			}
+          );
+        }
+      }
 
-			// Execute the pending tool call
-			if (executeToolDirect) {
-				try {
+      // Execute the pending tool call
+      if (executeToolDirect) {
+        try {
 					const organizationId =
 						pending.organizationId ?? connection.organizationId;
-					const result = await executeToolDirect(
-						pending.agentId,
-						pending.userId,
-						pending.mcpId,
-						pending.toolName,
+          const result = await executeToolDirect(
+            pending.agentId,
+            pending.userId,
+            pending.mcpId,
+            pending.toolName,
 						pending.args,
 						...(organizationId ? [{ organizationId }] : []),
-					);
+          );
 
-					const resultText = result.content.map((c) => c.text).join("\n");
-					await postTarget.post(
+          const resultText = result.content.map((c) => c.text).join("\n");
+          await postTarget.post(
 						result.isError ? `Tool error: ${resultText}` : resultText,
-					);
-					logger.info(
-						{
-							requestId,
-							mcpId: pending.mcpId,
-							toolName: pending.toolName,
-							isError: result.isError,
-						},
+          );
+          logger.info(
+            {
+              requestId,
+              mcpId: pending.mcpId,
+              toolName: pending.toolName,
+              isError: result.isError,
+            },
 						"Tool executed after approval",
-					);
-				} catch (error) {
-					logger.error(
-						{ requestId, error: String(error) },
+          );
+        } catch (error) {
+          logger.error(
+            { requestId, error: String(error) },
 						"Failed to execute tool after approval",
-					);
-					try {
-						await postTarget.post(`Failed to execute tool: ${String(error)}`);
-					} catch {
-						// best effort
-					}
-				}
-			} else {
-				try {
-					await postTarget.post("approve");
-				} catch {
-					// best effort
-				}
-			}
-			return;
-		}
+          );
+          try {
+            await postTarget.post(`Failed to execute tool: ${String(error)}`);
+          } catch {
+            // best effort
+          }
+        }
+      } else {
+        try {
+          await postTarget.post("approve");
+        } catch {
+          // best effort
+        }
+      }
+      return;
+    }
 
-		// Handle question responses — Button value carries the option text on all platforms
-		if (actionId.startsWith("question:")) {
-			const parts = actionId.split(":");
-			const questionId = parts[1] ?? "";
-			const responseText = value || parts[2] || "";
-			if (!questionId) return;
-			if (!onQuestionClick) {
-				// Tests / minimal registrations without a click pipeline — best-effort
-				// post the value so the click is at least visible.
-				try {
-					await thread.post(responseText);
-				} catch {
-					// best effort
-				}
-				return;
-			}
-			try {
-				await onQuestionClick(questionId, responseText, thread, event.user);
-			} catch (error) {
-				logger.error(
-					{ connectionId: connection.id, error: String(error) },
+    // Handle question responses — Button value carries the option text on all platforms
+    if (actionId.startsWith("question:")) {
+      const parts = actionId.split(":");
+      const questionId = parts[1] ?? "";
+      const responseText = value || parts[2] || "";
+      if (!questionId) return;
+      if (!onQuestionClick) {
+        // Tests / minimal registrations without a click pipeline — best-effort
+        // post the value so the click is at least visible.
+        try {
+          await thread.post(responseText);
+        } catch {
+          // best effort
+        }
+        return;
+      }
+      try {
+        await onQuestionClick(questionId, responseText, thread, event.user);
+      } catch (error) {
+        logger.error(
+          { connectionId: connection.id, error: String(error) },
 					"Failed to handle question click",
-				);
-			}
-		}
-	});
+        );
+      }
+    }
+  });
 }
 
 function shouldHandle(
-	event: { teamId?: string; channelId: string; connectionId?: string },
-	platform: string,
-	connectionId: string,
+  event: { teamId?: string; channelId: string; connectionId?: string },
+  platform: string,
+  connectionId: string,
 	manager: ChatInstanceManager,
 ): boolean {
-	if (!manager.has(connectionId)) {
-		logger.debug(
-			{ connectionId, eventConnectionId: event.connectionId },
+  if (!manager.has(connectionId)) {
+    logger.debug(
+      { connectionId, eventConnectionId: event.connectionId },
 			"shouldHandle: manager does not have connection",
-		);
-		return false;
-	}
-	if (event.connectionId && event.connectionId !== connectionId) {
-		return false;
-	}
-	const instance = manager.getInstance(connectionId);
-	if (!instance) {
-		logger.debug({ connectionId }, "shouldHandle: no instance found");
-		return false;
-	}
-	const matches = instance.connection.platform === platform;
-	logger.debug({ connectionId, platform, matches }, "shouldHandle: result");
-	if (!matches) {
-		logger.debug(
-			{
-				connectionId,
-				instancePlatform: instance.connection.platform,
-				eventPlatform: platform,
-			},
+    );
+    return false;
+  }
+  if (event.connectionId && event.connectionId !== connectionId) {
+    return false;
+  }
+  const instance = manager.getInstance(connectionId);
+  if (!instance) {
+    logger.debug({ connectionId }, "shouldHandle: no instance found");
+    return false;
+  }
+  const matches = instance.connection.platform === platform;
+  logger.debug({ connectionId, platform, matches }, "shouldHandle: result");
+  if (!matches) {
+    logger.debug(
+      {
+        connectionId,
+        instancePlatform: instance.connection.platform,
+        eventPlatform: platform,
+      },
 			"shouldHandle: platform mismatch",
-		);
-	}
-	return matches;
+    );
+  }
+  return matches;
 }
 
 async function resolveThread(
-	manager: ChatInstanceManager,
-	connectionId: string,
-	channelId: string,
+  manager: ChatInstanceManager,
+  connectionId: string,
+  channelId: string,
 	conversationId: string,
 ): Promise<any | null> {
-	const instance = manager.getInstance(connectionId);
-	if (!instance) {
-		logger.debug({ connectionId }, "resolveThread: no instance for connection");
-		return null;
-	}
+  const instance = manager.getInstance(connectionId);
+  if (!instance) {
+    logger.debug({ connectionId }, "resolveThread: no instance for connection");
+    return null;
+  }
 
-	try {
-		const chat = instance.chat;
-		const platform = instance.connection.platform;
+  try {
+    const chat = instance.chat;
+    const platform = instance.connection.platform;
 
-		// `channelId` is the bare platform channel id (e.g. `"C09EH3ASNQ1"`). The
-		// Chat SDK's `chat.channel()` parses the first `:`-segment as the adapter
-		// name, so we must prefix with `${platform}:`.
-		const channelKey = `${platform}:${channelId}`;
+    // `channelId` is the bare platform channel id (e.g. `"C09EH3ASNQ1"`). The
+    // Chat SDK's `chat.channel()` parses the first `:`-segment as the adapter
+    // name, so we must prefix with `${platform}:`.
+    const channelKey = `${platform}:${channelId}`;
 
-		// DM shortcut: buildMessagePayload stores `conversationId === channelId`
-		// for DMs (channel-level, not thread-level).
-		if (!conversationId || conversationId === channelId) {
-			const channel = chat.channel?.(channelKey);
-			if (channel) return channel;
-			logger.debug(
-				{ connectionId, platform, channelId, channelKey },
+    // DM shortcut: buildMessagePayload stores `conversationId === channelId`
+    // for DMs (channel-level, not thread-level).
+    if (!conversationId || conversationId === channelId) {
+      const channel = chat.channel?.(channelKey);
+      if (channel) return channel;
+      logger.debug(
+        { connectionId, platform, channelId, channelKey },
 				"resolveThread: chat.channel() returned null for DM",
-			);
-			return null;
-		}
+      );
+      return null;
+    }
 
-		// Group threads: conversationId is the Chat SDK's canonical `thread.id`
-		// (e.g. `"slack:{channel}:{parent_thread_ts}"`). Pass it directly to
-		// `createThread` — the adapter decodes it back into the correct
-		// thread-scoped post (e.g. `conversations.replies` for Slack).
-		const adapter = chat.getAdapter?.(platform);
-		const createThread = (chat as any).createThread;
-		if (adapter && typeof createThread === "function") {
-			try {
-				const thread = await createThread.call(
-					chat,
-					adapter,
-					conversationId,
-					undefined,
+    // Group threads: conversationId is the Chat SDK's canonical `thread.id`
+    // (e.g. `"slack:{channel}:{parent_thread_ts}"`). Pass it directly to
+    // `createThread` — the adapter decodes it back into the correct
+    // thread-scoped post (e.g. `conversations.replies` for Slack).
+    const adapter = chat.getAdapter?.(platform);
+    const createThread = (chat as any).createThread;
+    if (adapter && typeof createThread === "function") {
+      try {
+        const thread = await createThread.call(
+          chat,
+          adapter,
+          conversationId,
+          undefined,
 					false,
-				);
-				if (thread) return thread;
-			} catch (error) {
-				logger.debug(
-					{ connectionId, platform, conversationId, error: String(error) },
+        );
+        if (thread) return thread;
+      } catch (error) {
+        logger.debug(
+          { connectionId, platform, conversationId, error: String(error) },
 					"resolveThread: createThread failed",
-				);
-			}
-		}
+        );
+      }
+    }
 
-		// Last-resort fallback: post at channel level so we still surface the
-		// interaction instead of silently dropping it.
-		const channel = chat.channel?.(channelKey);
-		if (!channel) {
-			logger.warn(
-				{ connectionId, platform, channelId, channelKey, conversationId },
+    // Last-resort fallback: post at channel level so we still surface the
+    // interaction instead of silently dropping it.
+    const channel = chat.channel?.(channelKey);
+    if (!channel) {
+      logger.warn(
+        { connectionId, platform, channelId, channelKey, conversationId },
 				"resolveThread: unable to resolve thread or channel — dropping interaction",
-			);
-		}
-		return channel ?? null;
-	} catch (error) {
-		logger.debug(
-			{ connectionId, channelId, conversationId, error: String(error) },
+      );
+    }
+    return channel ?? null;
+  } catch (error) {
+    logger.debug(
+      { connectionId, channelId, conversationId, error: String(error) },
 			"Failed to resolve thread for interaction",
-		);
-		return null;
-	}
+    );
+    return null;
+  }
 }

--- a/packages/server/src/gateway/connections/interaction-bridge.ts
+++ b/packages/server/src/gateway/connections/interaction-bridge.ts
@@ -1,21 +1,21 @@
 import { createLogger } from "@lobu/core";
 import {
-  takePendingTool,
-  type PendingToolInvocation,
+	type PendingToolInvocation,
+	takePendingTool,
 } from "../auth/mcp/pending-tool-store.js";
 import type {
-  InteractionService,
-  PostedLinkButton,
-  PostedQuestion,
-  PostedStatusMessage,
-  PostedToolApproval,
+	InteractionService,
+	PostedLinkButton,
+	PostedQuestion,
+	PostedStatusMessage,
+	PostedToolApproval,
 } from "../interactions.js";
 import type { GrantStore } from "../permissions/grant-store.js";
 import type { ChatInstanceManager } from "./chat-instance-manager.js";
 import {
-  claimPendingQuestion,
-  deletePendingQuestion,
-  storePendingQuestion,
+	claimPendingQuestion,
+	deletePendingQuestion,
+	storePendingQuestion,
 } from "./pending-interaction-store.js";
 import type { PlatformConnection } from "./types.js";
 
@@ -23,14 +23,15 @@ const logger = createLogger("chat-interaction-bridge");
 
 /** Signature for the direct tool execution function injected from the MCP proxy. */
 type ExecuteToolDirectFn = (
-  agentId: string,
-  userId: string,
-  mcpId: string,
-  toolName: string,
-  args: Record<string, unknown>
+	agentId: string,
+	userId: string,
+	mcpId: string,
+	toolName: string,
+	args: Record<string, unknown>,
+	options?: { organizationId?: string },
 ) => Promise<{
-  content: Array<{ type: string; text: string }>;
-  isError: boolean;
+	content: Array<{ type: string; text: string }>;
+	isError: boolean;
 }>;
 
 /**
@@ -41,37 +42,37 @@ type ExecuteToolDirectFn = (
 type SentMessage = { edit: (newContent: any) => Promise<unknown> };
 
 async function postWithFallback(
-  thread: any,
-  primary: { card: any; fallbackText: string },
-  connectionId: string,
-  context: string
+	thread: any,
+	primary: { card: any; fallbackText: string },
+	connectionId: string,
+	context: string,
 ): Promise<SentMessage | null> {
-  try {
-    return (await thread.post(primary)) as SentMessage;
-  } catch (error) {
-    logger.warn(
-      { connectionId, error: String(error) },
-      `Failed to post ${context}`
-    );
-    try {
-      return (await thread.post(primary.fallbackText)) as SentMessage;
-    } catch {
-      return null;
-    }
-  }
+	try {
+		return (await thread.post(primary)) as SentMessage;
+	} catch (error) {
+		logger.warn(
+			{ connectionId, error: String(error) },
+			`Failed to post ${context}`,
+		);
+		try {
+			return (await thread.post(primary.fallbackText)) as SentMessage;
+		} catch {
+			return null;
+		}
+	}
 }
 
 function resolveGrantExpiresAt(duration: string): number | null {
-  switch (duration) {
-    case "1h":
-      return Date.now() + 3_600_000;
-    case "24h":
-      return Date.now() + 86_400_000;
-    case "always":
-      return null;
-    default:
-      return null;
-  }
+	switch (duration) {
+		case "1h":
+			return Date.now() + 3_600_000;
+		case "24h":
+			return Date.now() + 86_400_000;
+		case "always":
+			return null;
+		default:
+			return null;
+	}
 }
 
 /**
@@ -80,24 +81,24 @@ function resolveGrantExpiresAt(duration: string): number | null {
  * the payload and subsequent webhook retries see null and no-op.
  */
 async function takePendingToolInvocation(
-  requestId: string
+	requestId: string,
 ): Promise<PendingToolInvocation | null> {
-  return takePendingTool(requestId);
+	return takePendingTool(requestId);
 }
 
 function describeDecision(decision: string): string {
-  switch (decision) {
-    case "1h":
-      return "Approved (1h)";
-    case "24h":
-      return "Approved (24h)";
-    case "always":
-      return "Approved (always)";
-    case "deny":
-      return "Denied";
-    default:
-      return `Decision: ${decision}`;
-  }
+	switch (decision) {
+		case "1h":
+			return "Approved (1h)";
+		case "24h":
+			return "Approved (24h)";
+		case "always":
+			return "Approved (always)";
+		case "deny":
+			return "Denied";
+		default:
+			return `Decision: ${decision}`;
+	}
 }
 
 /**
@@ -106,32 +107,32 @@ function describeDecision(decision: string): string {
  * after a long gap, or the platform may not support edits).
  */
 async function stripApprovalButtons(
-  sent: SentMessage | undefined,
-  pending: {
-    mcpId: string;
-    toolName: string;
-    args: Record<string, unknown>;
-  },
-  decision: string
+	sent: SentMessage | undefined,
+	pending: {
+		mcpId: string;
+		toolName: string;
+		args: Record<string, unknown>;
+	},
+	decision: string,
 ): Promise<void> {
-  if (!sent) return;
-  const summary =
-    `*Tool Approval*\n${pending.mcpId} → ${pending.toolName}\n` +
-    `${formatToolArgs(pending.args)}\n\n_${describeDecision(decision)}_`;
-  try {
-    await sent.edit(summary);
-  } catch {
-    // best effort — card may be stale, edit may be unsupported
-  }
+	if (!sent) return;
+	const summary =
+		`*Tool Approval*\n${pending.mcpId} → ${pending.toolName}\n` +
+		`${formatToolArgs(pending.args)}\n\n_${describeDecision(decision)}_`;
+	try {
+		await sent.edit(summary);
+	} catch {
+		// best effort — card may be stale, edit may be unsupported
+	}
 }
 
 function formatToolArgs(args: Record<string, unknown>): string {
-  return Object.entries(args)
-    .map(([k, v]) => {
-      const val = typeof v === "string" ? v : JSON.stringify(v);
-      return `  ${k}: ${val}`;
-    })
-    .join("\n");
+	return Object.entries(args)
+		.map(([k, v]) => {
+			const val = typeof v === "string" ? v : JSON.stringify(v);
+			return `  ${k}: ${val}`;
+		})
+		.join("\n");
 }
 
 /** Context tracked per posted question so the click handler can feed the
@@ -139,520 +140,520 @@ function formatToolArgs(args: Record<string, unknown>): string {
  *  message (userId/conversationId/channelId/teamId). Also holds the SentMessage
  *  for the card so buttons can be stripped after a click. */
 interface PendingQuestionEntry {
-  question: PostedQuestion;
-  sent?: SentMessage;
+	question: PostedQuestion;
+	sent?: SentMessage;
 }
 
 export function registerInteractionBridge(
-  interactionService: InteractionService,
-  manager: ChatInstanceManager,
-  connection: PlatformConnection,
-  chat: any,
-  grantStore?: GrantStore,
-  executeToolDirect?: ExecuteToolDirectFn
+	interactionService: InteractionService,
+	manager: ChatInstanceManager,
+	connection: PlatformConnection,
+	chat: any,
+	grantStore?: GrantStore,
+	executeToolDirect?: ExecuteToolDirectFn,
 ): () => void {
-  const { id: connectionId, platform } = connection;
+	const { id: connectionId, platform } = connection;
 
-  // Per-connection state (avoids cross-contamination between connections)
-  const handledEvents = new Set<string>();
-  const activeTimers = new Set<NodeJS.Timeout>();
-  // Slack retries event_callback webhooks at ~1s/2s/5s/30s/60s/3min on
-  // missed acks; a 30s dedup window let late retries through and
-  // double-processed the event. 5min covers the full retry envelope.
-  const HANDLED_EVENT_TTL_MS = 5 * 60_000;
-  function markHandled(id: string): void {
-    handledEvents.add(id);
-    const timer = setTimeout(() => {
-      handledEvents.delete(id);
-      activeTimers.delete(timer);
-    }, HANDLED_EVENT_TTL_MS);
-    activeTimers.add(timer);
-  }
+	// Per-connection state (avoids cross-contamination between connections)
+	const handledEvents = new Set<string>();
+	const activeTimers = new Set<NodeJS.Timeout>();
+	// Slack retries event_callback webhooks at ~1s/2s/5s/30s/60s/3min on
+	// missed acks; a 30s dedup window let late retries through and
+	// double-processed the event. 5min covers the full retry envelope.
+	const HANDLED_EVENT_TTL_MS = 5 * 60_000;
+	function markHandled(id: string): void {
+		handledEvents.add(id);
+		const timer = setTimeout(() => {
+			handledEvents.delete(id);
+			activeTimers.delete(timer);
+		}, HANDLED_EVENT_TTL_MS);
+		activeTimers.add(timer);
+	}
 
-  // Tracks posted tool-approval cards so we can edit them on click to strip
-  // the buttons. Keyed by requestId (== PostedToolApproval.id == pending-tool
-  // store key). Auto-expire window matches the pending-tool TTL (24h) so a
-  // late click can still find the card to strip.
-  const APPROVAL_CARD_TTL_MS = 24 * 60 * 60 * 1000;
-  const pendingApprovalCards = new Map<string, SentMessage>();
-  const pendingApprovalTimers = new Map<string, NodeJS.Timeout>();
-  function trackApprovalCard(requestId: string, sent: SentMessage): void {
-    pendingApprovalCards.set(requestId, sent);
-    const timer = setTimeout(() => {
-      pendingApprovalCards.delete(requestId);
-      pendingApprovalTimers.delete(requestId);
-    }, APPROVAL_CARD_TTL_MS);
-    pendingApprovalTimers.set(requestId, timer);
-  }
-  function claimApprovalCard(requestId: string): SentMessage | undefined {
-    const sent = pendingApprovalCards.get(requestId);
-    pendingApprovalCards.delete(requestId);
-    const timer = pendingApprovalTimers.get(requestId);
-    if (timer) {
-      clearTimeout(timer);
-      pendingApprovalTimers.delete(requestId);
-    }
-    return sent;
-  }
+	// Tracks posted tool-approval cards so we can edit them on click to strip
+	// the buttons. Keyed by requestId (== PostedToolApproval.id == pending-tool
+	// store key). Auto-expire window matches the pending-tool TTL (24h) so a
+	// late click can still find the card to strip.
+	const APPROVAL_CARD_TTL_MS = 24 * 60 * 60 * 1000;
+	const pendingApprovalCards = new Map<string, SentMessage>();
+	const pendingApprovalTimers = new Map<string, NodeJS.Timeout>();
+	function trackApprovalCard(requestId: string, sent: SentMessage): void {
+		pendingApprovalCards.set(requestId, sent);
+		const timer = setTimeout(() => {
+			pendingApprovalCards.delete(requestId);
+			pendingApprovalTimers.delete(requestId);
+		}, APPROVAL_CARD_TTL_MS);
+		pendingApprovalTimers.set(requestId, timer);
+	}
+	function claimApprovalCard(requestId: string): SentMessage | undefined {
+		const sent = pendingApprovalCards.get(requestId);
+		pendingApprovalCards.delete(requestId);
+		const timer = pendingApprovalTimers.get(requestId);
+		if (timer) {
+			clearTimeout(timer);
+			pendingApprovalTimers.delete(requestId);
+		}
+		return sent;
+	}
 
-  // Pending questions are persisted in `public.pending_interactions` so a
-  // click landing on a different pod can still claim the entry. The local
-  // `pendingSentMessages` map holds the non-serializable platform
-  // `SentMessage` (used to strip card buttons on click) — losing it
-  // cross-pod is best-effort UX, not correctness.
-  //
-  // DB-row sweeping is owned globally by `coreServices.sweepEphemeralTables`
-  // (scheduled every 5 minutes in `packages/server/src/scheduled/jobs.ts`).
-  // We do NOT call `sweepStalePendingInteractions` per-bridge — N bridges
-  // hitting the same table N times is wasted work. The local sweep below
-  // is in-memory only: it evicts cache entries past their TTL so the Map
-  // doesn't grow unbounded for questions that are never clicked.
-  const PENDING_SENT_TTL_MS = 24 * 60 * 60 * 1000;
-  const PENDING_SENT_SWEEP_INTERVAL_MS = 60 * 60 * 1000;
-  interface CachedSent {
-    sent: SentMessage;
-    registeredAt: number;
-  }
-  const pendingSentMessages = new Map<string, CachedSent>();
-  const pendingSentSweepTimer = setInterval(() => {
-    const ttlCutoff = Date.now() - PENDING_SENT_TTL_MS;
-    for (const [id, entry] of pendingSentMessages) {
-      if (entry.registeredAt <= ttlCutoff) {
-        pendingSentMessages.delete(id);
-      }
-    }
-  }, PENDING_SENT_SWEEP_INTERVAL_MS);
-  pendingSentSweepTimer.unref?.();
-  /**
-   * Persist a pending question row, then cache its SentMessage handle so a
-   * click on this pod can edit the card. The persist happens first — see
-   * `onQuestionCreated` for the post-then-persist policy that wraps the
-   * card-post; this function is invoked only after the row is durable.
-   */
-  function rememberSentMessage(
-    questionId: string,
-    sent: SentMessage | undefined
-  ): void {
-    if (!sent) return;
-    pendingSentMessages.set(questionId, {
-      sent,
-      registeredAt: Date.now(),
-    });
-  }
-  async function claimQuestion(
-    questionId: string,
-    organizationId: string,
-    expectedUserId: string
-  ): Promise<PendingQuestionEntry | undefined> {
-    const stored = await claimPendingQuestion(
-      questionId,
-      organizationId,
-      connectionId,
-      expectedUserId
-    ).catch((error) => {
-      logger.error(
-        { connectionId, questionId, error: String(error) },
-        "Failed to claim pending question"
-      );
-      return null;
-    });
-    if (!stored) return undefined;
-    const cached = pendingSentMessages.get(questionId);
-    pendingSentMessages.delete(questionId);
-    return { question: stored.question, sent: cached?.sent };
-  }
-  const onQuestionCreated = async (event: PostedQuestion) => {
-    try {
-      if (!shouldHandle(event, platform, connectionId, manager)) return;
-      if (handledEvents.has(event.id)) return;
-      markHandled(event.id);
+	// Pending questions are persisted in `public.pending_interactions` so a
+	// click landing on a different pod can still claim the entry. The local
+	// `pendingSentMessages` map holds the non-serializable platform
+	// `SentMessage` (used to strip card buttons on click) — losing it
+	// cross-pod is best-effort UX, not correctness.
+	//
+	// DB-row sweeping is owned globally by `coreServices.sweepEphemeralTables`
+	// (scheduled every 5 minutes in `packages/server/src/scheduled/jobs.ts`).
+	// We do NOT call `sweepStalePendingInteractions` per-bridge — N bridges
+	// hitting the same table N times is wasted work. The local sweep below
+	// is in-memory only: it evicts cache entries past their TTL so the Map
+	// doesn't grow unbounded for questions that are never clicked.
+	const PENDING_SENT_TTL_MS = 24 * 60 * 60 * 1000;
+	const PENDING_SENT_SWEEP_INTERVAL_MS = 60 * 60 * 1000;
+	interface CachedSent {
+		sent: SentMessage;
+		registeredAt: number;
+	}
+	const pendingSentMessages = new Map<string, CachedSent>();
+	const pendingSentSweepTimer = setInterval(() => {
+		const ttlCutoff = Date.now() - PENDING_SENT_TTL_MS;
+		for (const [id, entry] of pendingSentMessages) {
+			if (entry.registeredAt <= ttlCutoff) {
+				pendingSentMessages.delete(id);
+			}
+		}
+	}, PENDING_SENT_SWEEP_INTERVAL_MS);
+	pendingSentSweepTimer.unref?.();
+	/**
+	 * Persist a pending question row, then cache its SentMessage handle so a
+	 * click on this pod can edit the card. The persist happens first — see
+	 * `onQuestionCreated` for the post-then-persist policy that wraps the
+	 * card-post; this function is invoked only after the row is durable.
+	 */
+	function rememberSentMessage(
+		questionId: string,
+		sent: SentMessage | undefined,
+	): void {
+		if (!sent) return;
+		pendingSentMessages.set(questionId, {
+			sent,
+			registeredAt: Date.now(),
+		});
+	}
+	async function claimQuestion(
+		questionId: string,
+		organizationId: string,
+		expectedUserId: string,
+	): Promise<PendingQuestionEntry | undefined> {
+		const stored = await claimPendingQuestion(
+			questionId,
+			organizationId,
+			connectionId,
+			expectedUserId,
+		).catch((error) => {
+			logger.error(
+				{ connectionId, questionId, error: String(error) },
+				"Failed to claim pending question",
+			);
+			return null;
+		});
+		if (!stored) return undefined;
+		const cached = pendingSentMessages.get(questionId);
+		pendingSentMessages.delete(questionId);
+		return { question: stored.question, sent: cached?.sent };
+	}
+	const onQuestionCreated = async (event: PostedQuestion) => {
+		try {
+			if (!shouldHandle(event, platform, connectionId, manager)) return;
+			if (handledEvents.has(event.id)) return;
+			markHandled(event.id);
 
-      // Cross-tenant scoping: every pending row must carry the bridge's
-      // org. Without a known org we can't safely persist or claim, so
-      // drop the event rather than write an un-scoped row.
-      const organizationId = connection.organizationId;
-      if (!organizationId) {
-        logger.warn(
-          { connectionId, questionId: event.id },
-          "Skipping question:created — connection has no organizationId"
-        );
-        return;
-      }
-      if (!event.userId) {
-        logger.warn(
-          { connectionId, questionId: event.id },
-          "Skipping question:created — event has no userId"
-        );
-        return;
-      }
+			// Cross-tenant scoping: every pending row must carry the bridge's
+			// org. Without a known org we can't safely persist or claim, so
+			// drop the event rather than write an un-scoped row.
+			const organizationId = connection.organizationId;
+			if (!organizationId) {
+				logger.warn(
+					{ connectionId, questionId: event.id },
+					"Skipping question:created — connection has no organizationId",
+				);
+				return;
+			}
+			if (!event.userId) {
+				logger.warn(
+					{ connectionId, questionId: event.id },
+					"Skipping question:created — event has no userId",
+				);
+				return;
+			}
 
-      const thread = await resolveThread(
-        manager,
-        connectionId,
-        event.channelId,
-        event.conversationId
-      );
-      if (!thread) return;
+			const thread = await resolveThread(
+				manager,
+				connectionId,
+				event.channelId,
+				event.conversationId,
+			);
+			if (!thread) return;
 
-      // Persist the pending row BEFORE posting the card. If the persist
-      // fails we never show buttons that would no-op on click. If the row
-      // is written but the post fails, we delete it on the way out so a
-      // stale row doesn't sit waiting for a click that will never arrive.
-      try {
-        await storePendingQuestion(
-          event.id,
-          organizationId,
-          connectionId,
-          event.userId,
-          { question: event }
-        );
-      } catch (error) {
-        logger.error(
-          { connectionId, questionId: event.id, error: String(error) },
-          "Failed to persist pending question — not posting card"
-        );
-        return;
-      }
+			// Persist the pending row BEFORE posting the card. If the persist
+			// fails we never show buttons that would no-op on click. If the row
+			// is written but the post fails, we delete it on the way out so a
+			// stale row doesn't sit waiting for a click that will never arrive.
+			try {
+				await storePendingQuestion(
+					event.id,
+					organizationId,
+					connectionId,
+					event.userId,
+					{ question: event },
+				);
+			} catch (error) {
+				logger.error(
+					{ connectionId, questionId: event.id, error: String(error) },
+					"Failed to persist pending question — not posting card",
+				);
+				return;
+			}
 
-      const { Card, CardText, Actions, Button } = await import("chat");
-      const buttons = event.options.map((option, i) =>
-        Button({
-          id: `question:${event.id}:${i}`,
-          label: option,
-          value: option,
-        })
-      );
-      const card = Card({
-        children: [CardText(event.question), Actions(buttons)],
-      });
-      const fallbackText = `${event.question}\n${event.options.map((o, i) => `${i + 1}. ${o}`).join("\n")}`;
-      const sent = await postWithFallback(
-        thread,
-        { card, fallbackText },
-        connectionId,
-        "question interaction"
-      );
-      if (!sent) {
-        // Post failed entirely. The row exists but no card was rendered,
-        // so a click can never come — DELETE the row to keep the table
-        // clean. Pre-fix used `claimPendingQuestion` (UPDATE setting
-        // claimed_at), which leaves a phantom row sitting around with
-        // claimed_at set until the 24h sweep. Hard-delete is the
-        // semantically correct end state, and the four-field scoping
-        // matches the claim path's safety invariant: a leaked id alone
-        // cannot delete another tenant's row.
-        try {
-          await deletePendingQuestion(
-            event.id,
-            organizationId,
-            connectionId,
-            event.userId
-          );
-        } catch (error) {
-          logger.debug(
-            { connectionId, questionId: event.id, error: String(error) },
-            "Failed to drop pending row after post failure"
-          );
-        }
-        return;
-      }
-      rememberSentMessage(event.id, sent);
-    } catch (error) {
-      logger.error(
-        { connectionId, error: String(error) },
-        "Unhandled error in question:created handler"
-      );
-    }
-  };
+			const { Card, CardText, Actions, Button } = await import("chat");
+			const buttons = event.options.map((option, i) =>
+				Button({
+					id: `question:${event.id}:${i}`,
+					label: option,
+					value: option,
+				}),
+			);
+			const card = Card({
+				children: [CardText(event.question), Actions(buttons)],
+			});
+			const fallbackText = `${event.question}\n${event.options.map((o, i) => `${i + 1}. ${o}`).join("\n")}`;
+			const sent = await postWithFallback(
+				thread,
+				{ card, fallbackText },
+				connectionId,
+				"question interaction",
+			);
+			if (!sent) {
+				// Post failed entirely. The row exists but no card was rendered,
+				// so a click can never come — DELETE the row to keep the table
+				// clean. Pre-fix used `claimPendingQuestion` (UPDATE setting
+				// claimed_at), which leaves a phantom row sitting around with
+				// claimed_at set until the 24h sweep. Hard-delete is the
+				// semantically correct end state, and the four-field scoping
+				// matches the claim path's safety invariant: a leaked id alone
+				// cannot delete another tenant's row.
+				try {
+					await deletePendingQuestion(
+						event.id,
+						organizationId,
+						connectionId,
+						event.userId,
+					);
+				} catch (error) {
+					logger.debug(
+						{ connectionId, questionId: event.id, error: String(error) },
+						"Failed to drop pending row after post failure",
+					);
+				}
+				return;
+			}
+			rememberSentMessage(event.id, sent);
+		} catch (error) {
+			logger.error(
+				{ connectionId, error: String(error) },
+				"Unhandled error in question:created handler",
+			);
+		}
+	};
 
-  const onToolApprovalNeeded = async (event: PostedToolApproval) => {
-    try {
-      if (!shouldHandle(event, platform, connectionId, manager)) return;
-      if (handledEvents.has(event.id)) return;
-      markHandled(event.id);
+	const onToolApprovalNeeded = async (event: PostedToolApproval) => {
+		try {
+			if (!shouldHandle(event, platform, connectionId, manager)) return;
+			if (handledEvents.has(event.id)) return;
+			markHandled(event.id);
 
-      const argsText = formatToolArgs(event.args);
-      const text = `Tool Approval\n${event.mcpId} → ${event.toolName}\n${argsText}`;
-      const tid = event.id;
+			const argsText = formatToolArgs(event.args);
+			const text = `Tool Approval\n${event.mcpId} → ${event.toolName}\n${argsText}`;
+			const tid = event.id;
 
-      const thread = await resolveThread(
-        manager,
-        connectionId,
-        event.channelId,
-        event.conversationId
-      );
-      if (!thread) return;
+			const thread = await resolveThread(
+				manager,
+				connectionId,
+				event.channelId,
+				event.conversationId,
+			);
+			if (!thread) return;
 
-      const { Card, CardText, Actions, Button } = await import("chat");
-      const card = Card({
-        children: [
-          CardText(
-            `*Tool Approval*\n${event.mcpId} → ${event.toolName}\n${argsText}`
-          ),
-          Actions([
-            Button({
-              id: `tool:${tid}:1h`,
-              label: "Allow 1h",
-              style: "primary",
-              value: "1h",
-            }),
-            Button({
-              id: `tool:${tid}:24h`,
-              label: "Allow 24h",
-              style: "primary",
-              value: "24h",
-            }),
-            Button({
-              id: `tool:${tid}:always`,
-              label: "Allow always",
-              style: "primary",
-              value: "always",
-            }),
-            Button({
-              id: `tool:${tid}:deny`,
-              label: "Deny always",
-              style: "danger",
-              value: "deny",
-            }),
-          ]),
-        ],
-      });
-      const sent = await postWithFallback(
-        thread,
-        { card, fallbackText: text },
-        connectionId,
-        "tool approval interaction"
-      );
-      if (sent) {
-        trackApprovalCard(tid, sent);
-      }
-    } catch (error) {
-      logger.error(
-        { connectionId, error: String(error) },
-        "Unhandled error in tool:approval-needed handler"
-      );
-    }
-  };
+			const { Card, CardText, Actions, Button } = await import("chat");
+			const card = Card({
+				children: [
+					CardText(
+						`*Tool Approval*\n${event.mcpId} → ${event.toolName}\n${argsText}`,
+					),
+					Actions([
+						Button({
+							id: `tool:${tid}:1h`,
+							label: "Allow 1h",
+							style: "primary",
+							value: "1h",
+						}),
+						Button({
+							id: `tool:${tid}:24h`,
+							label: "Allow 24h",
+							style: "primary",
+							value: "24h",
+						}),
+						Button({
+							id: `tool:${tid}:always`,
+							label: "Allow always",
+							style: "primary",
+							value: "always",
+						}),
+						Button({
+							id: `tool:${tid}:deny`,
+							label: "Deny always",
+							style: "danger",
+							value: "deny",
+						}),
+					]),
+				],
+			});
+			const sent = await postWithFallback(
+				thread,
+				{ card, fallbackText: text },
+				connectionId,
+				"tool approval interaction",
+			);
+			if (sent) {
+				trackApprovalCard(tid, sent);
+			}
+		} catch (error) {
+			logger.error(
+				{ connectionId, error: String(error) },
+				"Unhandled error in tool:approval-needed handler",
+			);
+		}
+	};
 
-  const onLinkButtonCreated = async (event: PostedLinkButton) => {
-    try {
-      if (!shouldHandle(event, platform, connectionId, manager)) return;
-      if (handledEvents.has(event.id)) return;
-      markHandled(event.id);
+	const onLinkButtonCreated = async (event: PostedLinkButton) => {
+		try {
+			if (!shouldHandle(event, platform, connectionId, manager)) return;
+			if (handledEvents.has(event.id)) return;
+			markHandled(event.id);
 
-      const thread = await resolveThread(
-        manager,
-        connectionId,
-        event.channelId,
-        event.conversationId
-      );
-      if (!thread) return;
+			const thread = await resolveThread(
+				manager,
+				connectionId,
+				event.channelId,
+				event.conversationId,
+			);
+			if (!thread) return;
 
-      const { Card, CardText, Actions, LinkButton } = await import("chat");
-      const linkButton = LinkButton({
-        url: event.url,
-        label: event.label,
-      });
-      // The button itself carries the label — only render an extra line of
-      // card-body text when the caller supplied a distinct `body` explaining
-      // *why* (e.g. for OAuth, "Authorize {mcp} to continue."). Falling back
-      // to `label` again would produce the "Connect sentry / [Connect sentry]"
-      // duplication we saw in Slack.
-      const bodyText = event.body?.trim();
-      const cardChildren =
-        bodyText && bodyText !== event.label
-          ? [CardText(bodyText), Actions([linkButton])]
-          : [Actions([linkButton])];
-      const card = Card({ children: cardChildren });
-      const fallbackText = bodyText
-        ? `${bodyText} ${event.label}: ${event.url}`
-        : `${event.label}: ${event.url}`;
-      await postWithFallback(
-        thread,
-        { card, fallbackText },
-        connectionId,
-        "link button interaction"
-      );
-    } catch (error) {
-      logger.error(
-        { connectionId, error: String(error) },
-        "Unhandled error in link-button:created handler"
-      );
-    }
-  };
+			const { Card, CardText, Actions, LinkButton } = await import("chat");
+			const linkButton = LinkButton({
+				url: event.url,
+				label: event.label,
+			});
+			// The button itself carries the label — only render an extra line of
+			// card-body text when the caller supplied a distinct `body` explaining
+			// *why* (e.g. for OAuth, "Authorize {mcp} to continue."). Falling back
+			// to `label` again would produce the "Connect sentry / [Connect sentry]"
+			// duplication we saw in Slack.
+			const bodyText = event.body?.trim();
+			const cardChildren =
+				bodyText && bodyText !== event.label
+					? [CardText(bodyText), Actions([linkButton])]
+					: [Actions([linkButton])];
+			const card = Card({ children: cardChildren });
+			const fallbackText = bodyText
+				? `${bodyText} ${event.label}: ${event.url}`
+				: `${event.label}: ${event.url}`;
+			await postWithFallback(
+				thread,
+				{ card, fallbackText },
+				connectionId,
+				"link button interaction",
+			);
+		} catch (error) {
+			logger.error(
+				{ connectionId, error: String(error) },
+				"Unhandled error in link-button:created handler",
+			);
+		}
+	};
 
-  const onStatusMessageCreated = async (event: PostedStatusMessage) => {
-    try {
-      if (!shouldHandle(event, platform, connectionId, manager)) return;
-      if (handledEvents.has(event.id)) return;
-      markHandled(event.id);
+	const onStatusMessageCreated = async (event: PostedStatusMessage) => {
+		try {
+			if (!shouldHandle(event, platform, connectionId, manager)) return;
+			if (handledEvents.has(event.id)) return;
+			markHandled(event.id);
 
-      const thread = await resolveThread(
-        manager,
-        connectionId,
-        event.channelId,
-        event.conversationId
-      );
-      if (!thread) return;
+			const thread = await resolveThread(
+				manager,
+				connectionId,
+				event.channelId,
+				event.conversationId,
+			);
+			if (!thread) return;
 
-      try {
-        await thread.post(event.text);
-      } catch (error) {
-        logger.warn(
-          { connectionId, error: String(error) },
-          "Failed to post status message interaction"
-        );
-      }
-    } catch (error) {
-      logger.error(
-        { connectionId, error: String(error) },
-        "Unhandled error in status-message:created handler"
-      );
-    }
-  };
+			try {
+				await thread.post(event.text);
+			} catch (error) {
+				logger.warn(
+					{ connectionId, error: String(error) },
+					"Failed to post status message interaction",
+				);
+			}
+		} catch (error) {
+			logger.error(
+				{ connectionId, error: String(error) },
+				"Unhandled error in status-message:created handler",
+			);
+		}
+	};
 
-  interactionService.on("question:created", onQuestionCreated);
-  interactionService.on("tool:approval-needed", onToolApprovalNeeded);
-  interactionService.on("link-button:created", onLinkButtonCreated);
-  interactionService.on("status-message:created", onStatusMessageCreated);
+	interactionService.on("question:created", onQuestionCreated);
+	interactionService.on("tool:approval-needed", onToolApprovalNeeded);
+	interactionService.on("link-button:created", onLinkButtonCreated);
+	interactionService.on("status-message:created", onStatusMessageCreated);
 
-  registerActionHandlers(
-    chat,
-    connection,
-    grantStore,
-    executeToolDirect,
-    claimApprovalCard,
-    async (questionId, value, thread, author) => {
-      // Fast path — Slack's block_actions webhook requires a <3s response.
-      // The claim is a single `UPDATE … RETURNING` on a PK and stays well
-      // under the budget; the slow platform API calls (post receipt, edit
-      // card, enqueue worker turn) still fire-and-forget below.
-      //
-      // Authorisation lives INSIDE the SQL claim: the row only matches when
-      // `(organization_id, connection_id, expected_user_id)` line up with
-      // the clicker's context. Wrong-user / cross-connection / cross-tenant
-      // clicks return null without consuming the row — no claim-then-auth
-      // race, no restash needed.
-      const organizationId = connection.organizationId;
-      if (!organizationId) {
-        logger.warn(
-          { connectionId, questionId },
-          "Question click on connection with no organizationId — ignoring"
-        );
-        return;
-      }
-      if (!author?.userId) {
-        logger.debug(
-          { connectionId, questionId },
-          "Question click without author.userId — ignoring"
-        );
-        return;
-      }
+	registerActionHandlers(
+		chat,
+		connection,
+		grantStore,
+		executeToolDirect,
+		claimApprovalCard,
+		async (questionId, value, thread, author) => {
+			// Fast path — Slack's block_actions webhook requires a <3s response.
+			// The claim is a single `UPDATE … RETURNING` on a PK and stays well
+			// under the budget; the slow platform API calls (post receipt, edit
+			// card, enqueue worker turn) still fire-and-forget below.
+			//
+			// Authorisation lives INSIDE the SQL claim: the row only matches when
+			// `(organization_id, connection_id, expected_user_id)` line up with
+			// the clicker's context. Wrong-user / cross-connection / cross-tenant
+			// clicks return null without consuming the row — no claim-then-auth
+			// race, no restash needed.
+			const organizationId = connection.organizationId;
+			if (!organizationId) {
+				logger.warn(
+					{ connectionId, questionId },
+					"Question click on connection with no organizationId — ignoring",
+				);
+				return;
+			}
+			if (!author?.userId) {
+				logger.debug(
+					{ connectionId, questionId },
+					"Question click without author.userId — ignoring",
+				);
+				return;
+			}
 
-      const entry = await claimQuestion(
-        questionId,
-        organizationId,
-        author.userId
-      );
-      if (!entry) {
-        logger.debug(
-          { connectionId, questionId, clickerUserId: author.userId },
-          "Question click did not match any pending row — ignoring"
-        );
-        return;
-      }
+			const entry = await claimQuestion(
+				questionId,
+				organizationId,
+				author.userId,
+			);
+			if (!entry) {
+				logger.debug(
+					{ connectionId, questionId, clickerUserId: author.userId },
+					"Question click did not match any pending row — ignoring",
+				);
+				return;
+			}
 
-      const instance = manager.getInstance(connectionId);
-      if (!instance) {
-        logger.warn(
-          { connectionId },
-          "Question click: no instance for connection"
-        );
-        return;
-      }
+			const instance = manager.getInstance(connectionId);
+			if (!instance) {
+				logger.warn(
+					{ connectionId },
+					"Question click: no instance for connection",
+				);
+				return;
+			}
 
-      const { question } = entry;
-      const receiptText = value
-        ? `*You submitted:* ${value}`
-        : "*You submitted a response.*";
+			const { question } = entry;
+			const receiptText = value
+				? `*You submitted:* ${value}`
+				: "*You submitted a response.*";
 
-      void (async () => {
-        // Visible "user submitted X" receipt so the click is acknowledged
-        // in-thread even before the worker responds.
-        try {
-          const { Card, CardText } = await import("chat");
-          const card = Card({ children: [CardText(receiptText)] });
-          await thread
-            .post({ card, fallbackText: receiptText })
-            .catch(async () => {
-              await thread.post(receiptText);
-            });
-        } catch {
-          try {
-            await thread.post(receiptText);
-          } catch {
-            // best effort — even the plain-text fallback failed
-          }
-        }
+			void (async () => {
+				// Visible "user submitted X" receipt so the click is acknowledged
+				// in-thread even before the worker responds.
+				try {
+					const { Card, CardText } = await import("chat");
+					const card = Card({ children: [CardText(receiptText)] });
+					await thread
+						.post({ card, fallbackText: receiptText })
+						.catch(async () => {
+							await thread.post(receiptText);
+						});
+				} catch {
+					try {
+						await thread.post(receiptText);
+					} catch {
+						// best effort — even the plain-text fallback failed
+					}
+				}
 
-        // Strip the original card's buttons so it can't be clicked again.
-        if (entry.sent) {
-          try {
-            await entry.sent.edit(
-              `${question.question}\n\n_Answered: ${value}_`
-            );
-          } catch {
-            // best effort — card may be stale or un-editable
-          }
-        }
+				// Strip the original card's buttons so it can't be clicked again.
+				if (entry.sent) {
+					try {
+						await entry.sent.edit(
+							`${question.question}\n\n_Answered: ${value}_`,
+						);
+					} catch {
+						// best effort — card may be stale or un-editable
+					}
+				}
 
-        // MUST route with question.userId (the original message's user), not
-        // author.userId (who physically clicked). The worker session is keyed
-        // on the original userId and will reject SSE deliveries that don't match.
-        await instance.messageBridge.ingestClick({
-          userId: question.userId,
-          channelId: question.channelId,
-          conversationId: question.conversationId,
-          teamId: question.teamId,
-          authorName: author?.fullName,
-          authorUsername: author?.userName,
-          value,
-          thread,
-          responseThreadId:
-            typeof thread?.id === "string" ? thread.id : undefined,
-        });
-      })().catch((error) => {
-        logger.error(
-          { connectionId, questionId, error: String(error) },
-          "Background question-click processing failed"
-        );
-      });
-    },
-    async (channelId, conversationId) =>
-      resolveThread(manager, connectionId, channelId, conversationId)
-  );
+				// MUST route with question.userId (the original message's user), not
+				// author.userId (who physically clicked). The worker session is keyed
+				// on the original userId and will reject SSE deliveries that don't match.
+				await instance.messageBridge.ingestClick({
+					userId: question.userId,
+					channelId: question.channelId,
+					conversationId: question.conversationId,
+					teamId: question.teamId,
+					authorName: author?.fullName,
+					authorUsername: author?.userName,
+					value,
+					thread,
+					responseThreadId:
+						typeof thread?.id === "string" ? thread.id : undefined,
+				});
+			})().catch((error) => {
+				logger.error(
+					{ connectionId, questionId, error: String(error) },
+					"Background question-click processing failed",
+				);
+			});
+		},
+		async (channelId, conversationId) =>
+			resolveThread(manager, connectionId, channelId, conversationId),
+	);
 
-  logger.info({ connectionId, platform }, "Interaction bridge registered");
+	logger.info({ connectionId, platform }, "Interaction bridge registered");
 
-  return () => {
-    interactionService.off("question:created", onQuestionCreated);
-    interactionService.off("tool:approval-needed", onToolApprovalNeeded);
-    interactionService.off("link-button:created", onLinkButtonCreated);
-    interactionService.off("status-message:created", onStatusMessageCreated);
-    for (const timer of activeTimers) {
-      clearTimeout(timer);
-    }
-    activeTimers.clear();
-    handledEvents.clear();
-    for (const timer of pendingApprovalTimers.values()) {
-      clearTimeout(timer);
-    }
-    pendingApprovalTimers.clear();
-    pendingApprovalCards.clear();
-    clearInterval(pendingSentSweepTimer);
-    pendingSentMessages.clear();
-    logger.info({ connectionId, platform }, "Interaction bridge unregistered");
-  };
+	return () => {
+		interactionService.off("question:created", onQuestionCreated);
+		interactionService.off("tool:approval-needed", onToolApprovalNeeded);
+		interactionService.off("link-button:created", onLinkButtonCreated);
+		interactionService.off("status-message:created", onStatusMessageCreated);
+		for (const timer of activeTimers) {
+			clearTimeout(timer);
+		}
+		activeTimers.clear();
+		handledEvents.clear();
+		for (const timer of pendingApprovalTimers.values()) {
+			clearTimeout(timer);
+		}
+		pendingApprovalTimers.clear();
+		pendingApprovalCards.clear();
+		clearInterval(pendingSentSweepTimer);
+		pendingSentMessages.clear();
+		logger.info({ connectionId, platform }, "Interaction bridge unregistered");
+	};
 }
 
 /**
@@ -662,10 +663,10 @@ export function registerInteractionBridge(
  * the raw click through.
  */
 type OnQuestionClickFn = (
-  questionId: string,
-  value: string,
-  thread: any,
-  author: { userId?: string; userName?: string; fullName?: string } | undefined
+	questionId: string,
+	value: string,
+	thread: any,
+	author: { userId?: string; userName?: string; fullName?: string } | undefined,
 ) => Promise<void>;
 
 /**
@@ -680,333 +681,336 @@ type OnQuestionClickFn = (
  * in tests that only exercise tool-approval flows.
  */
 export function registerActionHandlers(
-  chat: any,
-  connection: PlatformConnection,
-  grantStore: GrantStore | undefined,
-  executeToolDirect?: ExecuteToolDirectFn,
-  claimApprovalCard?: (requestId: string) => SentMessage | undefined,
-  onQuestionClick?: OnQuestionClickFn,
-  resolveApprovalTarget?: (
-    channelId: string,
-    conversationId: string
-  ) => Promise<any | null>
+	chat: any,
+	connection: PlatformConnection,
+	grantStore: GrantStore | undefined,
+	executeToolDirect?: ExecuteToolDirectFn,
+	claimApprovalCard?: (requestId: string) => SentMessage | undefined,
+	onQuestionClick?: OnQuestionClickFn,
+	resolveApprovalTarget?: (
+		channelId: string,
+		conversationId: string,
+	) => Promise<any | null>,
 ): void {
-  chat.onAction(async (event: any) => {
-    const actionId: string = event.actionId ?? "";
-    const value: string = event.value ?? "";
-    const thread = event.thread;
+	chat.onAction(async (event: any) => {
+		const actionId: string = event.actionId ?? "";
+		const value: string = event.value ?? "";
+		const thread = event.thread;
 
-    if (!thread || !actionId) return;
+		if (!thread || !actionId) return;
 
-    // Handle tool approval — store grant, execute tool, post result
-    if (actionId.startsWith("tool:")) {
-      const parts = actionId.split(":");
-      const requestId = parts[1];
-      const decision = parts[2] ?? "deny";
+		// Handle tool approval — store grant, execute tool, post result
+		if (actionId.startsWith("tool:")) {
+			const parts = actionId.split(":");
+			const requestId = parts[1];
+			const decision = parts[2] ?? "deny";
 
-      if (!requestId) return;
+			if (!requestId) return;
 
-      // GETDEL atomically claims the pending invocation. On Slack retries of
-      // the same block_actions webhook the second GETDEL returns null and we
-      // silently no-op (the first click already won). But if the card was
-      // never claimed before — i.e. the in-memory approval card is still
-      // tracked — this is a real first click landing on an expired/missing
-      // pending key, and we MUST surface that to the user. Otherwise the
-      // click looks like it did nothing.
-      const pending = await takePendingToolInvocation(requestId).catch(
-        () => null
-      );
-      if (!pending) {
-        const sent = claimApprovalCard?.(requestId);
-        if (sent) {
-          logger.info(
-            { requestId, decision },
-            "Tool approval click with no pending invocation — likely expired"
-          );
-          try {
-            await sent.edit(
-              "*Tool Approval*\n\n_This approval request expired before it could be acted on. Re-send your last message to retry._"
-            );
-          } catch {
-            // best effort
-          }
-          try {
-            await thread.post(
-              "This tool approval request expired before it could be acted on. Re-send your last message to retry."
-            );
-          } catch {
-            // best effort
-          }
-        } else {
-          logger.debug(
-            { requestId, decision },
-            "Tool approval click with no pending invocation and no tracked card — ignoring (already handled)"
-          );
-        }
-        return;
-      }
+			// GETDEL atomically claims the pending invocation. On Slack retries of
+			// the same block_actions webhook the second GETDEL returns null and we
+			// silently no-op (the first click already won). But if the card was
+			// never claimed before — i.e. the in-memory approval card is still
+			// tracked — this is a real first click landing on an expired/missing
+			// pending key, and we MUST surface that to the user. Otherwise the
+			// click looks like it did nothing.
+			const pending = await takePendingToolInvocation(requestId).catch(
+				() => null,
+			);
+			if (!pending) {
+				const sent = claimApprovalCard?.(requestId);
+				if (sent) {
+					logger.info(
+						{ requestId, decision },
+						"Tool approval click with no pending invocation — likely expired",
+					);
+					try {
+						await sent.edit(
+							"*Tool Approval*\n\n_This approval request expired before it could be acted on. Re-send your last message to retry._",
+						);
+					} catch {
+						// best effort
+					}
+					try {
+						await thread.post(
+							"This tool approval request expired before it could be acted on. Re-send your last message to retry.",
+						);
+					} catch {
+						// best effort
+					}
+				} else {
+					logger.debug(
+						{ requestId, decision },
+						"Tool approval click with no pending invocation and no tracked card — ignoring (already handled)",
+					);
+				}
+				return;
+			}
 
-      const pattern = `/mcp/${pending.mcpId}/tools/${pending.toolName}`;
+			const pattern = `/mcp/${pending.mcpId}/tools/${pending.toolName}`;
 
-      // Edit the posted card to strip buttons so it can't be clicked again.
-      await stripApprovalButtons(
-        claimApprovalCard?.(requestId),
-        pending,
-        decision
-      );
+			// Edit the posted card to strip buttons so it can't be clicked again.
+			await stripApprovalButtons(
+				claimApprovalCard?.(requestId),
+				pending,
+				decision,
+			);
 
-      // Resolve the post target. Prefer the original conversation captured at
-      // the time the tool call was blocked (saved alongside the pending
-      // record) so the result lands in the same Slack/Telegram thread the
-      // user originally pinged the bot in. Fall back to the click event's
-      // thread (the card the user just clicked) only if we don't have the
-      // original context — that fallback can be wrong on Slack when the card
-      // ended up posted at channel level.
-      let postTarget: any = thread;
-      if (
-        resolveApprovalTarget &&
-        (pending.conversationId || pending.channelId)
-      ) {
-        const resolved = await resolveApprovalTarget(
-          pending.channelId ?? "",
-          pending.conversationId ?? ""
-        ).catch(() => null);
-        if (resolved) postTarget = resolved;
-      }
+			// Resolve the post target. Prefer the original conversation captured at
+			// the time the tool call was blocked (saved alongside the pending
+			// record) so the result lands in the same Slack/Telegram thread the
+			// user originally pinged the bot in. Fall back to the click event's
+			// thread (the card the user just clicked) only if we don't have the
+			// original context — that fallback can be wrong on Slack when the card
+			// ended up posted at channel level.
+			let postTarget: any = thread;
+			if (
+				resolveApprovalTarget &&
+				(pending.conversationId || pending.channelId)
+			) {
+				const resolved = await resolveApprovalTarget(
+					pending.channelId ?? "",
+					pending.conversationId ?? "",
+				).catch(() => null);
+				if (resolved) postTarget = resolved;
+			}
 
-      if (decision === "deny") {
-        if (grantStore) {
-          await grantStore
-            .grant(
-              pending.agentId,
-              pattern,
-              null,
-              true,
-              connection.organizationId
-            )
-            .catch(() => undefined);
-        }
-        try {
-          await postTarget.post(
-            "Tool call denied. Let me know if you'd like me to try a different approach."
-          );
-        } catch {
-          // best effort
-        }
-        return;
-      }
+			if (decision === "deny") {
+				if (grantStore) {
+					await grantStore
+						.grant(
+							pending.agentId,
+							pattern,
+							null,
+							true,
+							connection.organizationId,
+						)
+						.catch(() => undefined);
+				}
+				try {
+					await postTarget.post(
+						"Tool call denied. Let me know if you'd like me to try a different approach.",
+					);
+				} catch {
+					// best effort
+				}
+				return;
+			}
 
-      // Approved — store grant, execute, post result
-      const expiresAt = resolveGrantExpiresAt(decision);
+			// Approved — store grant, execute, post result
+			const expiresAt = resolveGrantExpiresAt(decision);
 
-      if (grantStore) {
-        try {
-          await grantStore.grant(
-            pending.agentId,
-            pattern,
-            expiresAt,
-            undefined,
-            connection.organizationId
-          );
-          logger.info(
-            {
-              requestId,
-              agentId: pending.agentId,
-              pattern,
-              decision,
-              expiresAt,
-            },
-            "Grant stored via tool approval"
-          );
-        } catch (error) {
-          logger.error(
-            { requestId, error: String(error) },
-            "Failed to store grant"
-          );
-        }
-      }
+			if (grantStore) {
+				try {
+					await grantStore.grant(
+						pending.agentId,
+						pattern,
+						expiresAt,
+						undefined,
+						connection.organizationId,
+					);
+					logger.info(
+						{
+							requestId,
+							agentId: pending.agentId,
+							pattern,
+							decision,
+							expiresAt,
+						},
+						"Grant stored via tool approval",
+					);
+				} catch (error) {
+					logger.error(
+						{ requestId, error: String(error) },
+						"Failed to store grant",
+					);
+				}
+			}
 
-      // Execute the pending tool call
-      if (executeToolDirect) {
-        try {
-          const result = await executeToolDirect(
-            pending.agentId,
-            pending.userId,
-            pending.mcpId,
-            pending.toolName,
-            pending.args
-          );
+			// Execute the pending tool call
+			if (executeToolDirect) {
+				try {
+					const organizationId =
+						pending.organizationId ?? connection.organizationId;
+					const result = await executeToolDirect(
+						pending.agentId,
+						pending.userId,
+						pending.mcpId,
+						pending.toolName,
+						pending.args,
+						...(organizationId ? [{ organizationId }] : []),
+					);
 
-          const resultText = result.content.map((c) => c.text).join("\n");
-          await postTarget.post(
-            result.isError ? `Tool error: ${resultText}` : resultText
-          );
-          logger.info(
-            {
-              requestId,
-              mcpId: pending.mcpId,
-              toolName: pending.toolName,
-              isError: result.isError,
-            },
-            "Tool executed after approval"
-          );
-        } catch (error) {
-          logger.error(
-            { requestId, error: String(error) },
-            "Failed to execute tool after approval"
-          );
-          try {
-            await postTarget.post(`Failed to execute tool: ${String(error)}`);
-          } catch {
-            // best effort
-          }
-        }
-      } else {
-        try {
-          await postTarget.post("approve");
-        } catch {
-          // best effort
-        }
-      }
-      return;
-    }
+					const resultText = result.content.map((c) => c.text).join("\n");
+					await postTarget.post(
+						result.isError ? `Tool error: ${resultText}` : resultText,
+					);
+					logger.info(
+						{
+							requestId,
+							mcpId: pending.mcpId,
+							toolName: pending.toolName,
+							isError: result.isError,
+						},
+						"Tool executed after approval",
+					);
+				} catch (error) {
+					logger.error(
+						{ requestId, error: String(error) },
+						"Failed to execute tool after approval",
+					);
+					try {
+						await postTarget.post(`Failed to execute tool: ${String(error)}`);
+					} catch {
+						// best effort
+					}
+				}
+			} else {
+				try {
+					await postTarget.post("approve");
+				} catch {
+					// best effort
+				}
+			}
+			return;
+		}
 
-    // Handle question responses — Button value carries the option text on all platforms
-    if (actionId.startsWith("question:")) {
-      const parts = actionId.split(":");
-      const questionId = parts[1] ?? "";
-      const responseText = value || parts[2] || "";
-      if (!questionId) return;
-      if (!onQuestionClick) {
-        // Tests / minimal registrations without a click pipeline — best-effort
-        // post the value so the click is at least visible.
-        try {
-          await thread.post(responseText);
-        } catch {
-          // best effort
-        }
-        return;
-      }
-      try {
-        await onQuestionClick(questionId, responseText, thread, event.user);
-      } catch (error) {
-        logger.error(
-          { connectionId: connection.id, error: String(error) },
-          "Failed to handle question click"
-        );
-      }
-    }
-  });
+		// Handle question responses — Button value carries the option text on all platforms
+		if (actionId.startsWith("question:")) {
+			const parts = actionId.split(":");
+			const questionId = parts[1] ?? "";
+			const responseText = value || parts[2] || "";
+			if (!questionId) return;
+			if (!onQuestionClick) {
+				// Tests / minimal registrations without a click pipeline — best-effort
+				// post the value so the click is at least visible.
+				try {
+					await thread.post(responseText);
+				} catch {
+					// best effort
+				}
+				return;
+			}
+			try {
+				await onQuestionClick(questionId, responseText, thread, event.user);
+			} catch (error) {
+				logger.error(
+					{ connectionId: connection.id, error: String(error) },
+					"Failed to handle question click",
+				);
+			}
+		}
+	});
 }
 
 function shouldHandle(
-  event: { teamId?: string; channelId: string; connectionId?: string },
-  platform: string,
-  connectionId: string,
-  manager: ChatInstanceManager
+	event: { teamId?: string; channelId: string; connectionId?: string },
+	platform: string,
+	connectionId: string,
+	manager: ChatInstanceManager,
 ): boolean {
-  if (!manager.has(connectionId)) {
-    logger.debug(
-      { connectionId, eventConnectionId: event.connectionId },
-      "shouldHandle: manager does not have connection"
-    );
-    return false;
-  }
-  if (event.connectionId && event.connectionId !== connectionId) {
-    return false;
-  }
-  const instance = manager.getInstance(connectionId);
-  if (!instance) {
-    logger.debug({ connectionId }, "shouldHandle: no instance found");
-    return false;
-  }
-  const matches = instance.connection.platform === platform;
-  logger.debug({ connectionId, platform, matches }, "shouldHandle: result");
-  if (!matches) {
-    logger.debug(
-      {
-        connectionId,
-        instancePlatform: instance.connection.platform,
-        eventPlatform: platform,
-      },
-      "shouldHandle: platform mismatch"
-    );
-  }
-  return matches;
+	if (!manager.has(connectionId)) {
+		logger.debug(
+			{ connectionId, eventConnectionId: event.connectionId },
+			"shouldHandle: manager does not have connection",
+		);
+		return false;
+	}
+	if (event.connectionId && event.connectionId !== connectionId) {
+		return false;
+	}
+	const instance = manager.getInstance(connectionId);
+	if (!instance) {
+		logger.debug({ connectionId }, "shouldHandle: no instance found");
+		return false;
+	}
+	const matches = instance.connection.platform === platform;
+	logger.debug({ connectionId, platform, matches }, "shouldHandle: result");
+	if (!matches) {
+		logger.debug(
+			{
+				connectionId,
+				instancePlatform: instance.connection.platform,
+				eventPlatform: platform,
+			},
+			"shouldHandle: platform mismatch",
+		);
+	}
+	return matches;
 }
 
 async function resolveThread(
-  manager: ChatInstanceManager,
-  connectionId: string,
-  channelId: string,
-  conversationId: string
+	manager: ChatInstanceManager,
+	connectionId: string,
+	channelId: string,
+	conversationId: string,
 ): Promise<any | null> {
-  const instance = manager.getInstance(connectionId);
-  if (!instance) {
-    logger.debug({ connectionId }, "resolveThread: no instance for connection");
-    return null;
-  }
+	const instance = manager.getInstance(connectionId);
+	if (!instance) {
+		logger.debug({ connectionId }, "resolveThread: no instance for connection");
+		return null;
+	}
 
-  try {
-    const chat = instance.chat;
-    const platform = instance.connection.platform;
+	try {
+		const chat = instance.chat;
+		const platform = instance.connection.platform;
 
-    // `channelId` is the bare platform channel id (e.g. `"C09EH3ASNQ1"`). The
-    // Chat SDK's `chat.channel()` parses the first `:`-segment as the adapter
-    // name, so we must prefix with `${platform}:`.
-    const channelKey = `${platform}:${channelId}`;
+		// `channelId` is the bare platform channel id (e.g. `"C09EH3ASNQ1"`). The
+		// Chat SDK's `chat.channel()` parses the first `:`-segment as the adapter
+		// name, so we must prefix with `${platform}:`.
+		const channelKey = `${platform}:${channelId}`;
 
-    // DM shortcut: buildMessagePayload stores `conversationId === channelId`
-    // for DMs (channel-level, not thread-level).
-    if (!conversationId || conversationId === channelId) {
-      const channel = chat.channel?.(channelKey);
-      if (channel) return channel;
-      logger.debug(
-        { connectionId, platform, channelId, channelKey },
-        "resolveThread: chat.channel() returned null for DM"
-      );
-      return null;
-    }
+		// DM shortcut: buildMessagePayload stores `conversationId === channelId`
+		// for DMs (channel-level, not thread-level).
+		if (!conversationId || conversationId === channelId) {
+			const channel = chat.channel?.(channelKey);
+			if (channel) return channel;
+			logger.debug(
+				{ connectionId, platform, channelId, channelKey },
+				"resolveThread: chat.channel() returned null for DM",
+			);
+			return null;
+		}
 
-    // Group threads: conversationId is the Chat SDK's canonical `thread.id`
-    // (e.g. `"slack:{channel}:{parent_thread_ts}"`). Pass it directly to
-    // `createThread` — the adapter decodes it back into the correct
-    // thread-scoped post (e.g. `conversations.replies` for Slack).
-    const adapter = chat.getAdapter?.(platform);
-    const createThread = (chat as any).createThread;
-    if (adapter && typeof createThread === "function") {
-      try {
-        const thread = await createThread.call(
-          chat,
-          adapter,
-          conversationId,
-          undefined,
-          false
-        );
-        if (thread) return thread;
-      } catch (error) {
-        logger.debug(
-          { connectionId, platform, conversationId, error: String(error) },
-          "resolveThread: createThread failed"
-        );
-      }
-    }
+		// Group threads: conversationId is the Chat SDK's canonical `thread.id`
+		// (e.g. `"slack:{channel}:{parent_thread_ts}"`). Pass it directly to
+		// `createThread` — the adapter decodes it back into the correct
+		// thread-scoped post (e.g. `conversations.replies` for Slack).
+		const adapter = chat.getAdapter?.(platform);
+		const createThread = (chat as any).createThread;
+		if (adapter && typeof createThread === "function") {
+			try {
+				const thread = await createThread.call(
+					chat,
+					adapter,
+					conversationId,
+					undefined,
+					false,
+				);
+				if (thread) return thread;
+			} catch (error) {
+				logger.debug(
+					{ connectionId, platform, conversationId, error: String(error) },
+					"resolveThread: createThread failed",
+				);
+			}
+		}
 
-    // Last-resort fallback: post at channel level so we still surface the
-    // interaction instead of silently dropping it.
-    const channel = chat.channel?.(channelKey);
-    if (!channel) {
-      logger.warn(
-        { connectionId, platform, channelId, channelKey, conversationId },
-        "resolveThread: unable to resolve thread or channel — dropping interaction"
-      );
-    }
-    return channel ?? null;
-  } catch (error) {
-    logger.debug(
-      { connectionId, channelId, conversationId, error: String(error) },
-      "Failed to resolve thread for interaction"
-    );
-    return null;
-  }
+		// Last-resort fallback: post at channel level so we still surface the
+		// interaction instead of silently dropping it.
+		const channel = chat.channel?.(channelKey);
+		if (!channel) {
+			logger.warn(
+				{ connectionId, platform, channelId, channelKey, conversationId },
+				"resolveThread: unable to resolve thread or channel — dropping interaction",
+			);
+		}
+		return channel ?? null;
+	} catch (error) {
+		logger.debug(
+			{ connectionId, channelId, conversationId, error: String(error) },
+			"Failed to resolve thread for interaction",
+		);
+		return null;
+	}
 }

--- a/packages/server/src/gateway/connections/slack-platform-bridge.ts
+++ b/packages/server/src/gateway/connections/slack-platform-bridge.ts
@@ -1,414 +1,415 @@
 import { createLogger } from "@lobu/core";
 import type { McpConfigService } from "../auth/mcp/config-service.js";
 import { startAuthCodeFlow } from "../auth/mcp/oauth-flow.js";
+import { runWithOrganizationContext } from "../auth/mcp/proxy-shared.js";
+import type { CommandDispatcher } from "../commands/command-dispatcher.js";
+import { createChatReply } from "../commands/command-reply-adapters.js";
 import {
-  deleteCredential,
-  getStoredCredential,
+	deleteCredential,
+	getStoredCredential,
 } from "../routes/internal/device-auth.js";
 import type { WritableSecretStore } from "../secrets/index.js";
-import { createChatReply } from "../commands/command-reply-adapters.js";
-import type { CommandDispatcher } from "../commands/command-dispatcher.js";
 import type { PlatformConnection } from "./types.js";
 
 const logger = createLogger("slack-platform-bridge");
 
 const DEFAULT_SLACK_COMMAND = "/lobu";
 const DEFAULT_SLACK_TEAM_JOIN_WELCOME =
-  "Mention me in a channel or send me a DM to start a thread. Use `/lobu help` to see the built-in commands.";
+	"Mention me in a channel or send me a DM to start a thread. Use `/lobu help` to see the built-in commands.";
 const DEFAULT_SLACK_APP_NAME = "Lobu";
 
 const HOME_ACTION_CONNECT = "lobu_home_connect";
 const HOME_ACTION_DISCONNECT = "lobu_home_disconnect";
 
 type SlackSlashEvent = {
-  text?: string;
-  raw?: Record<string, unknown>;
-  user?: { userId?: string };
-  channel?: { post: (content: any) => Promise<unknown> };
+	text?: string;
+	raw?: Record<string, unknown>;
+	user?: { userId?: string };
+	channel?: { post: (content: any) => Promise<unknown> };
 };
 
 type SlackTeamJoinPayload = {
-  type?: string;
-  team_id?: string;
-  event?: {
-    type?: string;
-    user?: {
-      id?: string;
-      is_bot?: boolean;
-      deleted?: boolean;
-      real_name?: string;
-      profile?: {
-        display_name?: string;
-        real_name?: string;
-      };
-    };
-  };
+	type?: string;
+	team_id?: string;
+	event?: {
+		type?: string;
+		user?: {
+			id?: string;
+			is_bot?: boolean;
+			deleted?: boolean;
+			real_name?: string;
+			profile?: {
+				display_name?: string;
+				real_name?: string;
+			};
+		};
+	};
 };
 
 export type ParsedSlackTeamJoinEvent = {
-  teamId: string;
-  userId: string;
-  displayName?: string;
+	teamId: string;
+	userId: string;
+	displayName?: string;
 };
 
 function isSlackGroupChannel(channelId: string): boolean {
-  return !channelId.startsWith("D");
+	return !channelId.startsWith("D");
 }
 
 function parseSlackCommandText(text: string | undefined): {
-  commandName: string;
-  commandArgs: string;
+	commandName: string;
+	commandArgs: string;
 } {
-  const trimmed = text?.trim() || "";
-  if (!trimmed) {
-    return { commandName: "help", commandArgs: "" };
-  }
+	const trimmed = text?.trim() || "";
+	if (!trimmed) {
+		return { commandName: "help", commandArgs: "" };
+	}
 
-  const [firstToken = "", ...rest] = trimmed.split(/\s+/);
-  return {
-    commandName: firstToken.replace(/^\/+/, "").toLowerCase() || "help",
-    commandArgs: rest.join(" ").trim(),
-  };
+	const [firstToken = "", ...rest] = trimmed.split(/\s+/);
+	return {
+		commandName: firstToken.replace(/^\/+/, "").toLowerCase() || "help",
+		commandArgs: rest.join(" ").trim(),
+	};
 }
 
 export function registerSlackPlatformHandlers(
-  chat: any,
-  connection: PlatformConnection,
-  commandDispatcher?: CommandDispatcher
+	chat: any,
+	connection: PlatformConnection,
+	commandDispatcher?: CommandDispatcher,
 ): void {
-  if (connection.platform !== "slack" || !commandDispatcher) {
-    return;
-  }
+	if (connection.platform !== "slack" || !commandDispatcher) {
+		return;
+	}
 
-  chat.onSlashCommand(DEFAULT_SLACK_COMMAND, async (event: SlackSlashEvent) => {
-    const raw = event.raw || {};
-    const rawChannelId =
-      typeof raw.channel_id === "string" ? raw.channel_id : undefined;
-    const teamId = typeof raw.team_id === "string" ? raw.team_id : undefined;
-    const userId =
-      event.user?.userId ||
-      (typeof raw.user_id === "string" ? raw.user_id : undefined);
+	chat.onSlashCommand(DEFAULT_SLACK_COMMAND, async (event: SlackSlashEvent) => {
+		const raw = event.raw || {};
+		const rawChannelId =
+			typeof raw.channel_id === "string" ? raw.channel_id : undefined;
+		const teamId = typeof raw.team_id === "string" ? raw.team_id : undefined;
+		const userId =
+			event.user?.userId ||
+			(typeof raw.user_id === "string" ? raw.user_id : undefined);
 
-    if (!rawChannelId || !userId || !event.channel) {
-      return;
-    }
+		if (!rawChannelId || !userId || !event.channel) {
+			return;
+		}
 
-    // Slack hands slash commands the bare channel id (`C…`/`D…`), but inbound
-    // messages reach the dispatcher with the Chat SDK's `slack:<id>` thread
-    // channel id — and `agent_channel_bindings` is keyed on that form. Use it
-    // here too so `getBinding` lookups (and preview `/lobu link` bindings)
-    // agree across both ingress paths.
-    const channelId = `slack:${rawChannelId}`;
+		// Slack hands slash commands the bare channel id (`C…`/`D…`), but inbound
+		// messages reach the dispatcher with the Chat SDK's `slack:<id>` thread
+		// channel id — and `agent_channel_bindings` is keyed on that form. Use it
+		// here too so `getBinding` lookups (and preview `/lobu link` bindings)
+		// agree across both ingress paths.
+		const channelId = `slack:${rawChannelId}`;
 
-    const { commandName, commandArgs } = parseSlackCommandText(event.text);
-    const reply = createChatReply(async (content) => {
-      await event.channel!.post(content);
-    });
-    const handled = await commandDispatcher.tryHandle(
-      commandName,
-      commandArgs,
-      {
-        platform: "slack",
-        userId,
-        channelId,
-        teamId,
-        isGroup: isSlackGroupChannel(rawChannelId),
-        connectionId: connection.id,
-        organizationId: connection.organizationId,
-        reply,
-      }
-    );
+		const { commandName, commandArgs } = parseSlackCommandText(event.text);
+		const reply = createChatReply(async (content) => {
+			await event.channel!.post(content);
+		});
+		const handled = await commandDispatcher.tryHandle(
+			commandName,
+			commandArgs,
+			{
+				platform: "slack",
+				userId,
+				channelId,
+				teamId,
+				isGroup: isSlackGroupChannel(rawChannelId),
+				connectionId: connection.id,
+				organizationId: connection.organizationId,
+				reply,
+			},
+		);
 
-    if (!handled) {
-      await reply(
-        `Unknown /lobu subcommand: ${commandName}. Try \`/lobu help\`.`
-      );
-    }
-  });
+		if (!handled) {
+			await reply(
+				`Unknown /lobu subcommand: ${commandName}. Try \`/lobu help\`.`,
+			);
+		}
+	});
 }
 
 /** Adapter surface used by the home tab — `publishHomeView` lives on the Slack adapter. */
 type SlackHomeAdapter = {
-  publishHomeView?: (
-    userId: string,
-    view: Record<string, unknown>
-  ) => Promise<void>;
+	publishHomeView?: (
+		userId: string,
+		view: Record<string, unknown>,
+	) => Promise<void>;
 };
 
 type SlackAppHomeEvent = {
-  userId: string;
-  adapter?: SlackHomeAdapter;
+	userId: string;
+	adapter?: SlackHomeAdapter;
 };
 
 type SlackActionEvent = {
-  actionId: string;
-  value?: string;
-  user: { userId: string };
-  adapter?: SlackHomeAdapter;
-  raw?: unknown;
+	actionId: string;
+	value?: string;
+	user: { userId: string };
+	adapter?: SlackHomeAdapter;
+	raw?: unknown;
 };
 
 /** Dependencies the App Home tab needs to render status and run OAuth. */
 interface SlackAppHomeDeps {
-  /**
-   * The initialized Slack adapter — the one with the live `@slack/web-api`
-   * client. The adapter handed to event handlers via `event.adapter` is the
-   * webhook-dispatch instance and has no `client`, so `publishHomeView` must
-   * go through this one.
-   */
-  adapter?: SlackHomeAdapter;
-  mcpConfigService?: McpConfigService;
-  secretStore?: WritableSecretStore;
-  /** Public origin of the gateway — used to build the OAuth redirect URI. */
-  publicGatewayUrl?: string;
+	/**
+	 * The initialized Slack adapter — the one with the live `@slack/web-api`
+	 * client. The adapter handed to event handlers via `event.adapter` is the
+	 * webhook-dispatch instance and has no `client`, so `publishHomeView` must
+	 * go through this one.
+	 */
+	adapter?: SlackHomeAdapter;
+	mcpConfigService?: McpConfigService;
+	secretStore?: WritableSecretStore;
+	/** Public origin of the gateway — used to build the OAuth redirect URI. */
+	publicGatewayUrl?: string;
 }
 
 // Internal plumbing MCPs (e.g. the Lobu memory backend) — not user integrations.
 const HIDDEN_HOME_INTEGRATION_IDS = new Set(["lobu-memory"]);
 
 function humanizeIntegrationName(id: string): string {
-  return id
-    .replace(/[-_]+/g, " ")
-    .replace(/\b\w/g, (c) => c.toUpperCase());
+	return id.replace(/[-_]+/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
 }
 
 function teamIdFromRawPayload(raw: unknown): string | undefined {
-  const team = (raw as { team?: { id?: unknown } } | undefined)?.team?.id;
-  return typeof team === "string" ? team : undefined;
+	const team = (raw as { team?: { id?: unknown } } | undefined)?.team?.id;
+	return typeof team === "string" ? team : undefined;
 }
 
 type IntegrationStatus = {
-  id: string;
-  name: string;
-  requiresAuth: boolean;
-  connected: boolean;
+	id: string;
+	name: string;
+	requiresAuth: boolean;
+	connected: boolean;
 };
 
 function integrationSection(
-  status: IntegrationStatus,
-  pendingAuthUrl?: string
+	status: IntegrationStatus,
+	pendingAuthUrl?: string,
 ): Record<string, unknown> {
-  if (!status.requiresAuth) {
-    return {
-      type: "section",
-      text: { type: "mrkdwn", text: `:white_circle: *${status.name}*` },
-    };
-  }
-  if (status.connected) {
-    return {
-      type: "section",
-      text: {
-        type: "mrkdwn",
-        text: `:white_check_mark: *${status.name}*  ·  connected`,
-      },
-      accessory: {
-        type: "button",
-        text: { type: "plain_text", text: "Disconnect" },
-        action_id: HOME_ACTION_DISCONNECT,
-        value: status.id,
-        style: "danger",
-      },
-    };
-  }
-  if (pendingAuthUrl) {
-    return {
-      type: "section",
-      text: {
-        type: "mrkdwn",
-        text: `:hourglass_flowing_sand: *${status.name}*  ·  finish signing in`,
-      },
-      accessory: {
-        type: "button",
-        text: { type: "plain_text", text: "Open sign-in ↗" },
-        url: pendingAuthUrl,
-      },
-    };
-  }
-  return {
-    type: "section",
-    text: {
-      type: "mrkdwn",
-      text: `:white_circle: *${status.name}*  ·  not connected`,
-    },
-    accessory: {
-      type: "button",
-      text: { type: "plain_text", text: "Connect" },
-      action_id: HOME_ACTION_CONNECT,
-      value: status.id,
-      style: "primary",
-    },
-  };
+	if (!status.requiresAuth) {
+		return {
+			type: "section",
+			text: { type: "mrkdwn", text: `:white_circle: *${status.name}*` },
+		};
+	}
+	if (status.connected) {
+		return {
+			type: "section",
+			text: {
+				type: "mrkdwn",
+				text: `:white_check_mark: *${status.name}*  ·  connected`,
+			},
+			accessory: {
+				type: "button",
+				text: { type: "plain_text", text: "Disconnect" },
+				action_id: HOME_ACTION_DISCONNECT,
+				value: status.id,
+				style: "danger",
+			},
+		};
+	}
+	if (pendingAuthUrl) {
+		return {
+			type: "section",
+			text: {
+				type: "mrkdwn",
+				text: `:hourglass_flowing_sand: *${status.name}*  ·  finish signing in`,
+			},
+			accessory: {
+				type: "button",
+				text: { type: "plain_text", text: "Open sign-in ↗" },
+				url: pendingAuthUrl,
+			},
+		};
+	}
+	return {
+		type: "section",
+		text: {
+			type: "mrkdwn",
+			text: `:white_circle: *${status.name}*  ·  not connected`,
+		},
+		accessory: {
+			type: "button",
+			text: { type: "plain_text", text: "Connect" },
+			action_id: HOME_ACTION_CONNECT,
+			value: status.id,
+			style: "primary",
+		},
+	};
 }
 
 interface HomeViewParams {
-  connection: PlatformConnection;
-  deps: SlackAppHomeDeps;
-  /** Slack user the home tab is being rendered for (credential scope key). */
-  userId: string;
-  /** MCP ids → freshly-minted authorization URL, shown as an "Open sign-in" link. */
-  pendingAuthUrls?: Record<string, string>;
+	connection: PlatformConnection;
+	deps: SlackAppHomeDeps;
+	/** Slack user the home tab is being rendered for (credential scope key). */
+	userId: string;
+	/** MCP ids → freshly-minted authorization URL, shown as an "Open sign-in" link. */
+	pendingAuthUrls?: Record<string, string>;
 }
 
-async function buildSlackHomeBlocks(params: HomeViewParams): Promise<unknown[]> {
-  const { connection, deps, userId, pendingAuthUrls } = params;
-  const botName =
-    (typeof connection.metadata?.botUsername === "string" &&
-      connection.metadata.botUsername) ||
-    DEFAULT_SLACK_APP_NAME;
-  const isPreview = connection.settings?.previewMode === true;
+async function buildSlackHomeBlocks(
+	params: HomeViewParams,
+): Promise<unknown[]> {
+	const { connection, deps, userId, pendingAuthUrls } = params;
+	const botName =
+		(typeof connection.metadata?.botUsername === "string" &&
+			connection.metadata.botUsername) ||
+		DEFAULT_SLACK_APP_NAME;
+	const isPreview = connection.settings?.previewMode === true;
 
-  const blocks: unknown[] = [
-    {
-      type: "section",
-      text: {
-        type: "mrkdwn",
-        text: `*${botName}* :wave:\n\nMention me in any channel, or send me a DM, to start a thread.`,
-      },
-    },
-    { type: "divider" },
-  ];
+	const blocks: unknown[] = [
+		{
+			type: "section",
+			text: {
+				type: "mrkdwn",
+				text: `*${botName}* :wave:\n\nMention me in any channel, or send me a DM, to start a thread.`,
+			},
+		},
+		{ type: "divider" },
+	];
 
-  if (!isPreview && connection.agentId && deps.mcpConfigService) {
-    try {
-      const statuses = await loadIntegrationStatusesScoped(
-        connection.agentId,
-        userId,
-        deps
-      );
-      blocks.push({
-        type: "header",
-        text: { type: "plain_text", text: "Integrations" },
-      });
-      if (statuses.length === 0) {
-        blocks.push({
-          type: "section",
-          text: {
-            type: "mrkdwn",
-            text: "_No integrations connected yet._",
-          },
-        });
-      } else {
-        for (const status of statuses) {
-          blocks.push(integrationSection(status, pendingAuthUrls?.[status.id]));
-        }
-      }
-      blocks.push({ type: "divider" });
-    } catch (error) {
-      logger.warn(
-        { error, agentId: connection.agentId },
-        "Failed to load integrations for Slack home tab; rendering without them"
-      );
-    }
-  }
+	if (!isPreview && connection.agentId && deps.mcpConfigService) {
+		try {
+			const statuses = await loadIntegrationStatusesScoped(
+				connection.agentId,
+				userId,
+				connection.organizationId,
+				deps,
+			);
+			blocks.push({
+				type: "header",
+				text: { type: "plain_text", text: "Integrations" },
+			});
+			if (statuses.length === 0) {
+				blocks.push({
+					type: "section",
+					text: {
+						type: "mrkdwn",
+						text: "_No integrations connected yet._",
+					},
+				});
+			} else {
+				for (const status of statuses) {
+					blocks.push(integrationSection(status, pendingAuthUrls?.[status.id]));
+				}
+			}
+			blocks.push({ type: "divider" });
+		} catch (error) {
+			logger.warn(
+				{ error, agentId: connection.agentId },
+				"Failed to load integrations for Slack home tab; rendering without them",
+			);
+		}
+	}
 
-  blocks.push({
-    type: "section",
-    text: {
-      type: "mrkdwn",
-      text: isPreview
-        ? "This is a *preview* workspace. Run `lobu run`, then use `/lobu link <code>` in a channel to connect your own agent."
-        : "*Tips*\n• Mention me in a channel, or DM me directly.\n• `/lobu help` lists the built-in commands.\n• Integrations that need you to sign in will also prompt you with a button right in the thread.",
-    },
-  });
+	blocks.push({
+		type: "section",
+		text: {
+			type: "mrkdwn",
+			text: isPreview
+				? "This is a *preview* workspace. Run `lobu run`, then use `/lobu link <code>` in a channel to connect your own agent."
+				: "*Tips*\n• Mention me in a channel, or DM me directly.\n• `/lobu help` lists the built-in commands.\n• Integrations that need you to sign in will also prompt you with a button right in the thread.",
+		},
+	});
 
-  return blocks;
+	return blocks;
 }
 
 // Resolve the agent's integrations plus this user's connection status. The
 // Slack user id is the credential scope key (home-tab connect is per-user).
 async function loadIntegrationStatusesScoped(
-  agentId: string,
-  userId: string,
-  deps: SlackAppHomeDeps
+	agentId: string,
+	userId: string,
+	organizationId: string | undefined,
+	deps: SlackAppHomeDeps,
 ): Promise<IntegrationStatus[]> {
-  const mcpConfigService = deps.mcpConfigService;
-  if (!mcpConfigService) return [];
-  const statuses = (await mcpConfigService.getMcpStatus(agentId)).filter(
-    (s) => !HIDDEN_HOME_INTEGRATION_IDS.has(s.id)
-  );
-  const result: IntegrationStatus[] = [];
-  for (const s of statuses) {
-    let connected = false;
-    if (s.requiresAuth && deps.secretStore) {
-      try {
-        connected = !!(await getStoredCredential(
-          deps.secretStore,
-          agentId,
-          userId,
-          s.id
-        ));
-      } catch {
-        connected = false;
-      }
-    }
-    result.push({
-      id: s.id,
-      name: humanizeIntegrationName(s.name || s.id),
-      requiresAuth: s.requiresAuth,
-      connected,
-    });
-  }
-  return result;
+	const mcpConfigService = deps.mcpConfigService;
+	if (!mcpConfigService) return [];
+	const statuses = (await mcpConfigService.getMcpStatus(agentId)).filter(
+		(s) => !HIDDEN_HOME_INTEGRATION_IDS.has(s.id),
+	);
+	const result: IntegrationStatus[] = [];
+	for (const s of statuses) {
+		let connected = false;
+		const secretStore = deps.secretStore;
+		if (s.requiresAuth && secretStore) {
+			try {
+				connected = !!(await runWithOrganizationContext(organizationId, () =>
+					getStoredCredential(secretStore, agentId, userId, s.id),
+				));
+			} catch {
+				connected = false;
+			}
+		}
+		result.push({
+			id: s.id,
+			name: humanizeIntegrationName(s.name || s.id),
+			requiresAuth: s.requiresAuth,
+			connected,
+		});
+	}
+	return result;
 }
 
 /** Extract something useful out of a Slack `WebAPIPlatformError` (or anything). */
 function errorDetail(error: unknown): Record<string, unknown> {
-  if (error instanceof Error) {
-    const data = (error as { data?: unknown }).data;
-    return {
-      message: error.message,
-      ...(data && typeof data === "object" ? { slack: data } : {}),
-    };
-  }
-  return { message: String(error) };
+	if (error instanceof Error) {
+		const data = (error as { data?: unknown }).data;
+		return {
+			message: error.message,
+			...(data && typeof data === "object" ? { slack: data } : {}),
+		};
+	}
+	return { message: String(error) };
 }
 
 const HOME_FALLBACK_BLOCKS: unknown[] = [
-  {
-    type: "section",
-    text: {
-      type: "mrkdwn",
-      text: "*Lobu* :wave:\n\nMention me in any channel, or send me a DM, to start a thread. Use `/lobu help` for the built-in commands.",
-    },
-  },
+	{
+		type: "section",
+		text: {
+			type: "mrkdwn",
+			text: "*Lobu* :wave:\n\nMention me in any channel, or send me a DM, to start a thread. Use `/lobu help` for the built-in commands.",
+		},
+	},
 ];
 
 async function publishHome(
-  adapter: SlackHomeAdapter | undefined,
-  params: HomeViewParams
+	adapter: SlackHomeAdapter | undefined,
+	params: HomeViewParams,
 ): Promise<void> {
-  const publishHomeView = adapter?.publishHomeView;
-  if (typeof publishHomeView !== "function") return;
-  try {
-    const blocks = await buildSlackHomeBlocks(params);
-    await publishHomeView(params.userId, { type: "home", blocks });
-  } catch (error) {
-    logger.warn(
-      {
-        error: errorDetail(error),
-        connectionId: params.connection.id,
-        userId: params.userId,
-      },
-      "Failed to publish Slack home tab; falling back to a minimal view"
-    );
-    // The rich view failed (likely Block Kit validation). Don't leave the user
-    // staring at a stale cached view — publish a plain text-only home tab.
-    try {
-      await publishHomeView(params.userId, {
-        type: "home",
-        blocks: HOME_FALLBACK_BLOCKS,
-      });
-    } catch (fallbackError) {
-      logger.warn(
-        {
-          error: errorDetail(fallbackError),
-          connectionId: params.connection.id,
-          userId: params.userId,
-        },
-        "Failed to publish fallback Slack home tab"
-      );
-    }
-  }
+	const publishHomeView = adapter?.publishHomeView;
+	if (typeof publishHomeView !== "function") return;
+	try {
+		const blocks = await buildSlackHomeBlocks(params);
+		await publishHomeView(params.userId, { type: "home", blocks });
+	} catch (error) {
+		logger.warn(
+			{
+				error: errorDetail(error),
+				connectionId: params.connection.id,
+				userId: params.userId,
+			},
+			"Failed to publish Slack home tab; falling back to a minimal view",
+		);
+		// The rich view failed (likely Block Kit validation). Don't leave the user
+		// staring at a stale cached view — publish a plain text-only home tab.
+		try {
+			await publishHomeView(params.userId, {
+				type: "home",
+				blocks: HOME_FALLBACK_BLOCKS,
+			});
+		} catch (fallbackError) {
+			logger.warn(
+				{
+					error: errorDetail(fallbackError),
+					connectionId: params.connection.id,
+					userId: params.userId,
+				},
+				"Failed to publish fallback Slack home tab",
+			);
+		}
+	}
 }
 
 /**
@@ -418,55 +419,56 @@ async function publishHome(
  * `secretStore.delete` with an attacker-supplied key string.
  */
 async function isKnownIntegration(
-  agentId: string,
-  mcpId: string,
-  deps: SlackAppHomeDeps
+	agentId: string,
+	mcpId: string,
+	deps: SlackAppHomeDeps,
 ): Promise<boolean> {
-  if (HIDDEN_HOME_INTEGRATION_IDS.has(mcpId)) return false;
-  const mcpConfigService = deps.mcpConfigService;
-  if (!mcpConfigService) return false;
-  try {
-    const statuses = await mcpConfigService.getMcpStatus(agentId);
-    return statuses.some((s) => s.id === mcpId);
-  } catch {
-    return false;
-  }
+	if (HIDDEN_HOME_INTEGRATION_IDS.has(mcpId)) return false;
+	const mcpConfigService = deps.mcpConfigService;
+	if (!mcpConfigService) return false;
+	try {
+		const statuses = await mcpConfigService.getMcpStatus(agentId);
+		return statuses.some((s) => s.id === mcpId);
+	} catch {
+		return false;
+	}
 }
 
 async function startMcpConnectFlow(params: {
-  connection: PlatformConnection;
-  deps: SlackAppHomeDeps;
-  agentId: string;
-  userId: string;
-  mcpId: string;
-  teamId?: string;
+	connection: PlatformConnection;
+	deps: SlackAppHomeDeps;
+	agentId: string;
+	userId: string;
+	mcpId: string;
+	teamId?: string;
 }): Promise<string | null> {
-  const { connection, deps, agentId, userId, mcpId, teamId } = params;
-  const mcpConfigService = deps.mcpConfigService;
-  if (!mcpConfigService || !deps.secretStore || !deps.publicGatewayUrl) {
-    return null;
-  }
-  const httpServer = await mcpConfigService.getHttpServer(mcpId, agentId);
-  if (!httpServer) return null;
-  const redirectUri = `${deps.publicGatewayUrl.replace(/\/+$/, "")}/mcp/oauth/callback`;
-  const { authorizationUrl } = await startAuthCodeFlow({
-    secretStore: deps.secretStore,
-    mcpId,
-    upstreamUrl: httpServer.upstreamUrl,
-    agentId,
-    userId,
-    // Home-tab connect is always per-user.
-    scopeKey: userId,
-    wwwAuthenticate: null,
-    redirectUri,
-    staticOauth: httpServer.oauth,
-    platform: "slack",
-    channelId: userId,
-    conversationId: userId,
-    teamId,
-    connectionId: connection.id,
-  });
-  return authorizationUrl;
+	const { connection, deps, agentId, userId, mcpId, teamId } = params;
+	const mcpConfigService = deps.mcpConfigService;
+	if (!mcpConfigService || !deps.secretStore || !deps.publicGatewayUrl) {
+		return null;
+	}
+	const httpServer = await mcpConfigService.getHttpServer(mcpId, agentId);
+	if (!httpServer) return null;
+	const redirectUri = `${deps.publicGatewayUrl.replace(/\/+$/, "")}/mcp/oauth/callback`;
+	const { authorizationUrl } = await startAuthCodeFlow({
+		secretStore: deps.secretStore,
+		mcpId,
+		upstreamUrl: httpServer.upstreamUrl,
+		agentId,
+		userId,
+		organizationId: connection.organizationId,
+		// Home-tab connect is always per-user.
+		scopeKey: userId,
+		wwwAuthenticate: null,
+		redirectUri,
+		staticOauth: httpServer.oauth,
+		platform: "slack",
+		channelId: userId,
+		conversationId: userId,
+		teamId,
+		connectionId: connection.id,
+	});
+	return authorizationUrl;
 }
 
 /**
@@ -480,126 +482,133 @@ async function startMcpConnectFlow(params: {
  * store aren't available.
  */
 export function registerSlackAppHome(
-  chat: any,
-  connection: PlatformConnection,
-  deps: SlackAppHomeDeps = {}
+	chat: any,
+	connection: PlatformConnection,
+	deps: SlackAppHomeDeps = {},
 ): void {
-  if (connection.platform !== "slack") {
-    return;
-  }
+	if (connection.platform !== "slack") {
+		return;
+	}
 
-  chat.onAppHomeOpened(async (event: SlackAppHomeEvent) => {
-    await publishHome(deps.adapter ?? event.adapter, {
-      connection,
-      deps,
-      userId: event.userId,
-    });
-  });
+	chat.onAppHomeOpened(async (event: SlackAppHomeEvent) => {
+		await publishHome(deps.adapter ?? event.adapter, {
+			connection,
+			deps,
+			userId: event.userId,
+		});
+	});
 
-  chat.onAction(
-    [HOME_ACTION_CONNECT, HOME_ACTION_DISCONNECT],
-    async (event: SlackActionEvent) => {
-      const mcpId = event.value;
-      const userId = event.user?.userId;
-      const agentId = connection.agentId;
-      if (!mcpId || !userId || !agentId) return;
-      // `mcpId` comes from the (Slack-signed) button payload, but only the
-      // button labels are ours — reject anything not in the agent's config.
-      if (!(await isKnownIntegration(agentId, mcpId, deps))) {
-        logger.warn(
-          { agentId, userId, mcpId, actionId: event.actionId },
-          "Ignoring Slack home action for an unknown integration"
-        );
-        return;
-      }
+	chat.onAction(
+		[HOME_ACTION_CONNECT, HOME_ACTION_DISCONNECT],
+		async (event: SlackActionEvent) => {
+			const mcpId = event.value;
+			const userId = event.user?.userId;
+			const agentId = connection.agentId;
+			if (!mcpId || !userId || !agentId) return;
+			// `mcpId` comes from the (Slack-signed) button payload, but only the
+			// button labels are ours — reject anything not in the agent's config.
+			if (!(await isKnownIntegration(agentId, mcpId, deps))) {
+				logger.warn(
+					{ agentId, userId, mcpId, actionId: event.actionId },
+					"Ignoring Slack home action for an unknown integration",
+				);
+				return;
+			}
 
-      if (event.actionId === HOME_ACTION_DISCONNECT) {
-        if (deps.secretStore) {
-          try {
-            await deleteCredential(deps.secretStore, agentId, userId, mcpId);
-          } catch (error) {
-            logger.warn(
-              { error, agentId, userId, mcpId },
-              "Failed to disconnect MCP credential from Slack home tab"
-            );
-          }
-        }
-        await publishHome(deps.adapter ?? event.adapter, { connection, deps, userId });
-        return;
-      }
+			if (event.actionId === HOME_ACTION_DISCONNECT) {
+				const secretStore = deps.secretStore;
+				if (secretStore) {
+					try {
+						await runWithOrganizationContext(connection.organizationId, () =>
+							deleteCredential(secretStore, agentId, userId, mcpId),
+						);
+					} catch (error) {
+						logger.warn(
+							{ error, agentId, userId, mcpId },
+							"Failed to disconnect MCP credential from Slack home tab",
+						);
+					}
+				}
+				await publishHome(deps.adapter ?? event.adapter, {
+					connection,
+					deps,
+					userId,
+				});
+				return;
+			}
 
-      // Connect: mint an authorization URL, then re-publish with the link.
-      let authorizationUrl: string | null = null;
-      try {
-        authorizationUrl = await startMcpConnectFlow({
-          connection,
-          deps,
-          agentId,
-          userId,
-          mcpId,
-          teamId: teamIdFromRawPayload(event.raw),
-        });
-      } catch (error) {
-        logger.warn(
-          { error, agentId, userId, mcpId },
-          "Failed to start MCP OAuth flow from Slack home tab"
-        );
-      }
-      await publishHome(deps.adapter ?? event.adapter, {
-        connection,
-        deps,
-        userId,
-        pendingAuthUrls: authorizationUrl ? { [mcpId]: authorizationUrl } : {},
-      });
-    }
-  );
+			// Connect: mint an authorization URL, then re-publish with the link.
+			let authorizationUrl: string | null = null;
+			try {
+				authorizationUrl = await startMcpConnectFlow({
+					connection,
+					deps,
+					agentId,
+					userId,
+					mcpId,
+					teamId: teamIdFromRawPayload(event.raw),
+				});
+			} catch (error) {
+				logger.warn(
+					{ error, agentId, userId, mcpId },
+					"Failed to start MCP OAuth flow from Slack home tab",
+				);
+			}
+			await publishHome(deps.adapter ?? event.adapter, {
+				connection,
+				deps,
+				userId,
+				pendingAuthUrls: authorizationUrl ? { [mcpId]: authorizationUrl } : {},
+			});
+		},
+	);
 }
 
 export function parseSlackTeamJoinEvent(
-  body: string,
-  contentType: string
+	body: string,
+	contentType: string,
 ): ParsedSlackTeamJoinEvent | null {
-  if (!contentType.includes("application/json")) {
-    return null;
-  }
+	if (!contentType.includes("application/json")) {
+		return null;
+	}
 
-  let payload: SlackTeamJoinPayload;
-  try {
-    payload = JSON.parse(body) as SlackTeamJoinPayload;
-  } catch {
-    return null;
-  }
+	let payload: SlackTeamJoinPayload;
+	try {
+		payload = JSON.parse(body) as SlackTeamJoinPayload;
+	} catch {
+		return null;
+	}
 
-  if (
-    payload.type !== "event_callback" ||
-    payload.event?.type !== "team_join"
-  ) {
-    return null;
-  }
+	if (
+		payload.type !== "event_callback" ||
+		payload.event?.type !== "team_join"
+	) {
+		return null;
+	}
 
-  const teamId = payload.team_id;
-  const user = payload.event.user;
-  if (!teamId || !user?.id || user.is_bot || user.deleted) {
-    return null;
-  }
+	const teamId = payload.team_id;
+	const user = payload.event.user;
+	if (!teamId || !user?.id || user.is_bot || user.deleted) {
+		return null;
+	}
 
-  const displayName =
-    user.profile?.display_name || user.profile?.real_name || user.real_name;
+	const displayName =
+		user.profile?.display_name || user.profile?.real_name || user.real_name;
 
-  return {
-    teamId,
-    userId: user.id,
-    ...(displayName ? { displayName } : {}),
-  };
+	return {
+		teamId,
+		userId: user.id,
+		...(displayName ? { displayName } : {}),
+	};
 }
 
 export async function postSlackTeamJoinWelcome(
-  chat: any,
-  event: ParsedSlackTeamJoinEvent
+	chat: any,
+	event: ParsedSlackTeamJoinEvent,
 ): Promise<void> {
-  const thread = await chat.openDM(event.userId);
-  const greeting = event.displayName
-    ? `Welcome to Lobu, ${event.displayName}.`
-    : "Welcome to Lobu.";
-  await thread.post(`${greeting} ${DEFAULT_SLACK_TEAM_JOIN_WELCOME}`);
+	const thread = await chat.openDM(event.userId);
+	const greeting = event.displayName
+		? `Welcome to Lobu, ${event.displayName}.`
+		: "Welcome to Lobu.";
+	await thread.post(`${greeting} ${DEFAULT_SLACK_TEAM_JOIN_WELCOME}`);
 }

--- a/packages/server/src/gateway/connections/slack-platform-bridge.ts
+++ b/packages/server/src/gateway/connections/slack-platform-bridge.ts
@@ -5,8 +5,8 @@ import { runWithOrganizationContext } from "../auth/mcp/proxy-shared.js";
 import type { CommandDispatcher } from "../commands/command-dispatcher.js";
 import { createChatReply } from "../commands/command-reply-adapters.js";
 import {
-	deleteCredential,
-	getStoredCredential,
+  deleteCredential,
+  getStoredCredential,
 } from "../routes/internal/device-auth.js";
 import type { WritableSecretStore } from "../secrets/index.js";
 import type { PlatformConnection } from "./types.js";
@@ -15,153 +15,153 @@ const logger = createLogger("slack-platform-bridge");
 
 const DEFAULT_SLACK_COMMAND = "/lobu";
 const DEFAULT_SLACK_TEAM_JOIN_WELCOME =
-	"Mention me in a channel or send me a DM to start a thread. Use `/lobu help` to see the built-in commands.";
+  "Mention me in a channel or send me a DM to start a thread. Use `/lobu help` to see the built-in commands.";
 const DEFAULT_SLACK_APP_NAME = "Lobu";
 
 const HOME_ACTION_CONNECT = "lobu_home_connect";
 const HOME_ACTION_DISCONNECT = "lobu_home_disconnect";
 
 type SlackSlashEvent = {
-	text?: string;
-	raw?: Record<string, unknown>;
-	user?: { userId?: string };
-	channel?: { post: (content: any) => Promise<unknown> };
+  text?: string;
+  raw?: Record<string, unknown>;
+  user?: { userId?: string };
+  channel?: { post: (content: any) => Promise<unknown> };
 };
 
 type SlackTeamJoinPayload = {
-	type?: string;
-	team_id?: string;
-	event?: {
-		type?: string;
-		user?: {
-			id?: string;
-			is_bot?: boolean;
-			deleted?: boolean;
-			real_name?: string;
-			profile?: {
-				display_name?: string;
-				real_name?: string;
-			};
-		};
-	};
+  type?: string;
+  team_id?: string;
+  event?: {
+    type?: string;
+    user?: {
+      id?: string;
+      is_bot?: boolean;
+      deleted?: boolean;
+      real_name?: string;
+      profile?: {
+        display_name?: string;
+        real_name?: string;
+      };
+    };
+  };
 };
 
 export type ParsedSlackTeamJoinEvent = {
-	teamId: string;
-	userId: string;
-	displayName?: string;
+  teamId: string;
+  userId: string;
+  displayName?: string;
 };
 
 function isSlackGroupChannel(channelId: string): boolean {
-	return !channelId.startsWith("D");
+  return !channelId.startsWith("D");
 }
 
 function parseSlackCommandText(text: string | undefined): {
-	commandName: string;
-	commandArgs: string;
+  commandName: string;
+  commandArgs: string;
 } {
-	const trimmed = text?.trim() || "";
-	if (!trimmed) {
-		return { commandName: "help", commandArgs: "" };
-	}
+  const trimmed = text?.trim() || "";
+  if (!trimmed) {
+    return { commandName: "help", commandArgs: "" };
+  }
 
-	const [firstToken = "", ...rest] = trimmed.split(/\s+/);
-	return {
-		commandName: firstToken.replace(/^\/+/, "").toLowerCase() || "help",
-		commandArgs: rest.join(" ").trim(),
-	};
+  const [firstToken = "", ...rest] = trimmed.split(/\s+/);
+  return {
+    commandName: firstToken.replace(/^\/+/, "").toLowerCase() || "help",
+    commandArgs: rest.join(" ").trim(),
+  };
 }
 
 export function registerSlackPlatformHandlers(
-	chat: any,
-	connection: PlatformConnection,
+  chat: any,
+  connection: PlatformConnection,
 	commandDispatcher?: CommandDispatcher,
 ): void {
-	if (connection.platform !== "slack" || !commandDispatcher) {
-		return;
-	}
+  if (connection.platform !== "slack" || !commandDispatcher) {
+    return;
+  }
 
-	chat.onSlashCommand(DEFAULT_SLACK_COMMAND, async (event: SlackSlashEvent) => {
-		const raw = event.raw || {};
-		const rawChannelId =
-			typeof raw.channel_id === "string" ? raw.channel_id : undefined;
-		const teamId = typeof raw.team_id === "string" ? raw.team_id : undefined;
-		const userId =
-			event.user?.userId ||
-			(typeof raw.user_id === "string" ? raw.user_id : undefined);
+  chat.onSlashCommand(DEFAULT_SLACK_COMMAND, async (event: SlackSlashEvent) => {
+    const raw = event.raw || {};
+    const rawChannelId =
+      typeof raw.channel_id === "string" ? raw.channel_id : undefined;
+    const teamId = typeof raw.team_id === "string" ? raw.team_id : undefined;
+    const userId =
+      event.user?.userId ||
+      (typeof raw.user_id === "string" ? raw.user_id : undefined);
 
-		if (!rawChannelId || !userId || !event.channel) {
-			return;
-		}
+    if (!rawChannelId || !userId || !event.channel) {
+      return;
+    }
 
-		// Slack hands slash commands the bare channel id (`C…`/`D…`), but inbound
-		// messages reach the dispatcher with the Chat SDK's `slack:<id>` thread
-		// channel id — and `agent_channel_bindings` is keyed on that form. Use it
-		// here too so `getBinding` lookups (and preview `/lobu link` bindings)
-		// agree across both ingress paths.
-		const channelId = `slack:${rawChannelId}`;
+    // Slack hands slash commands the bare channel id (`C…`/`D…`), but inbound
+    // messages reach the dispatcher with the Chat SDK's `slack:<id>` thread
+    // channel id — and `agent_channel_bindings` is keyed on that form. Use it
+    // here too so `getBinding` lookups (and preview `/lobu link` bindings)
+    // agree across both ingress paths.
+    const channelId = `slack:${rawChannelId}`;
 
-		const { commandName, commandArgs } = parseSlackCommandText(event.text);
-		const reply = createChatReply(async (content) => {
-			await event.channel!.post(content);
-		});
-		const handled = await commandDispatcher.tryHandle(
-			commandName,
-			commandArgs,
-			{
-				platform: "slack",
-				userId,
-				channelId,
-				teamId,
-				isGroup: isSlackGroupChannel(rawChannelId),
-				connectionId: connection.id,
-				organizationId: connection.organizationId,
-				reply,
+    const { commandName, commandArgs } = parseSlackCommandText(event.text);
+    const reply = createChatReply(async (content) => {
+      await event.channel!.post(content);
+    });
+    const handled = await commandDispatcher.tryHandle(
+      commandName,
+      commandArgs,
+      {
+        platform: "slack",
+        userId,
+        channelId,
+        teamId,
+        isGroup: isSlackGroupChannel(rawChannelId),
+        connectionId: connection.id,
+        organizationId: connection.organizationId,
+        reply,
 			},
-		);
+    );
 
-		if (!handled) {
-			await reply(
+    if (!handled) {
+      await reply(
 				`Unknown /lobu subcommand: ${commandName}. Try \`/lobu help\`.`,
-			);
-		}
-	});
+      );
+    }
+  });
 }
 
 /** Adapter surface used by the home tab — `publishHomeView` lives on the Slack adapter. */
 type SlackHomeAdapter = {
-	publishHomeView?: (
-		userId: string,
+  publishHomeView?: (
+    userId: string,
 		view: Record<string, unknown>,
-	) => Promise<void>;
+  ) => Promise<void>;
 };
 
 type SlackAppHomeEvent = {
-	userId: string;
-	adapter?: SlackHomeAdapter;
+  userId: string;
+  adapter?: SlackHomeAdapter;
 };
 
 type SlackActionEvent = {
-	actionId: string;
-	value?: string;
-	user: { userId: string };
-	adapter?: SlackHomeAdapter;
-	raw?: unknown;
+  actionId: string;
+  value?: string;
+  user: { userId: string };
+  adapter?: SlackHomeAdapter;
+  raw?: unknown;
 };
 
 /** Dependencies the App Home tab needs to render status and run OAuth. */
 interface SlackAppHomeDeps {
-	/**
-	 * The initialized Slack adapter — the one with the live `@slack/web-api`
-	 * client. The adapter handed to event handlers via `event.adapter` is the
-	 * webhook-dispatch instance and has no `client`, so `publishHomeView` must
-	 * go through this one.
-	 */
-	adapter?: SlackHomeAdapter;
-	mcpConfigService?: McpConfigService;
-	secretStore?: WritableSecretStore;
-	/** Public origin of the gateway — used to build the OAuth redirect URI. */
-	publicGatewayUrl?: string;
+  /**
+   * The initialized Slack adapter — the one with the live `@slack/web-api`
+   * client. The adapter handed to event handlers via `event.adapter` is the
+   * webhook-dispatch instance and has no `client`, so `publishHomeView` must
+   * go through this one.
+   */
+  adapter?: SlackHomeAdapter;
+  mcpConfigService?: McpConfigService;
+  secretStore?: WritableSecretStore;
+  /** Public origin of the gateway — used to build the OAuth redirect URI. */
+  publicGatewayUrl?: string;
 }
 
 // Internal plumbing MCPs (e.g. the Lobu memory backend) — not user integrations.
@@ -172,244 +172,244 @@ function humanizeIntegrationName(id: string): string {
 }
 
 function teamIdFromRawPayload(raw: unknown): string | undefined {
-	const team = (raw as { team?: { id?: unknown } } | undefined)?.team?.id;
-	return typeof team === "string" ? team : undefined;
+  const team = (raw as { team?: { id?: unknown } } | undefined)?.team?.id;
+  return typeof team === "string" ? team : undefined;
 }
 
 type IntegrationStatus = {
-	id: string;
-	name: string;
-	requiresAuth: boolean;
-	connected: boolean;
+  id: string;
+  name: string;
+  requiresAuth: boolean;
+  connected: boolean;
 };
 
 function integrationSection(
-	status: IntegrationStatus,
+  status: IntegrationStatus,
 	pendingAuthUrl?: string,
 ): Record<string, unknown> {
-	if (!status.requiresAuth) {
-		return {
-			type: "section",
-			text: { type: "mrkdwn", text: `:white_circle: *${status.name}*` },
-		};
-	}
-	if (status.connected) {
-		return {
-			type: "section",
-			text: {
-				type: "mrkdwn",
-				text: `:white_check_mark: *${status.name}*  ·  connected`,
-			},
-			accessory: {
-				type: "button",
-				text: { type: "plain_text", text: "Disconnect" },
-				action_id: HOME_ACTION_DISCONNECT,
-				value: status.id,
-				style: "danger",
-			},
-		};
-	}
-	if (pendingAuthUrl) {
-		return {
-			type: "section",
-			text: {
-				type: "mrkdwn",
-				text: `:hourglass_flowing_sand: *${status.name}*  ·  finish signing in`,
-			},
-			accessory: {
-				type: "button",
-				text: { type: "plain_text", text: "Open sign-in ↗" },
-				url: pendingAuthUrl,
-			},
-		};
-	}
-	return {
-		type: "section",
-		text: {
-			type: "mrkdwn",
-			text: `:white_circle: *${status.name}*  ·  not connected`,
-		},
-		accessory: {
-			type: "button",
-			text: { type: "plain_text", text: "Connect" },
-			action_id: HOME_ACTION_CONNECT,
-			value: status.id,
-			style: "primary",
-		},
-	};
+  if (!status.requiresAuth) {
+    return {
+      type: "section",
+      text: { type: "mrkdwn", text: `:white_circle: *${status.name}*` },
+    };
+  }
+  if (status.connected) {
+    return {
+      type: "section",
+      text: {
+        type: "mrkdwn",
+        text: `:white_check_mark: *${status.name}*  ·  connected`,
+      },
+      accessory: {
+        type: "button",
+        text: { type: "plain_text", text: "Disconnect" },
+        action_id: HOME_ACTION_DISCONNECT,
+        value: status.id,
+        style: "danger",
+      },
+    };
+  }
+  if (pendingAuthUrl) {
+    return {
+      type: "section",
+      text: {
+        type: "mrkdwn",
+        text: `:hourglass_flowing_sand: *${status.name}*  ·  finish signing in`,
+      },
+      accessory: {
+        type: "button",
+        text: { type: "plain_text", text: "Open sign-in ↗" },
+        url: pendingAuthUrl,
+      },
+    };
+  }
+  return {
+    type: "section",
+    text: {
+      type: "mrkdwn",
+      text: `:white_circle: *${status.name}*  ·  not connected`,
+    },
+    accessory: {
+      type: "button",
+      text: { type: "plain_text", text: "Connect" },
+      action_id: HOME_ACTION_CONNECT,
+      value: status.id,
+      style: "primary",
+    },
+  };
 }
 
 interface HomeViewParams {
-	connection: PlatformConnection;
-	deps: SlackAppHomeDeps;
-	/** Slack user the home tab is being rendered for (credential scope key). */
-	userId: string;
-	/** MCP ids → freshly-minted authorization URL, shown as an "Open sign-in" link. */
-	pendingAuthUrls?: Record<string, string>;
+  connection: PlatformConnection;
+  deps: SlackAppHomeDeps;
+  /** Slack user the home tab is being rendered for (credential scope key). */
+  userId: string;
+  /** MCP ids → freshly-minted authorization URL, shown as an "Open sign-in" link. */
+  pendingAuthUrls?: Record<string, string>;
 }
 
 async function buildSlackHomeBlocks(
 	params: HomeViewParams,
 ): Promise<unknown[]> {
-	const { connection, deps, userId, pendingAuthUrls } = params;
-	const botName =
-		(typeof connection.metadata?.botUsername === "string" &&
-			connection.metadata.botUsername) ||
-		DEFAULT_SLACK_APP_NAME;
-	const isPreview = connection.settings?.previewMode === true;
+  const { connection, deps, userId, pendingAuthUrls } = params;
+  const botName =
+    (typeof connection.metadata?.botUsername === "string" &&
+      connection.metadata.botUsername) ||
+    DEFAULT_SLACK_APP_NAME;
+  const isPreview = connection.settings?.previewMode === true;
 
-	const blocks: unknown[] = [
-		{
-			type: "section",
-			text: {
-				type: "mrkdwn",
-				text: `*${botName}* :wave:\n\nMention me in any channel, or send me a DM, to start a thread.`,
-			},
-		},
-		{ type: "divider" },
-	];
+  const blocks: unknown[] = [
+    {
+      type: "section",
+      text: {
+        type: "mrkdwn",
+        text: `*${botName}* :wave:\n\nMention me in any channel, or send me a DM, to start a thread.`,
+      },
+    },
+    { type: "divider" },
+  ];
 
-	if (!isPreview && connection.agentId && deps.mcpConfigService) {
-		try {
-			const statuses = await loadIntegrationStatusesScoped(
-				connection.agentId,
-				userId,
+  if (!isPreview && connection.agentId && deps.mcpConfigService) {
+    try {
+      const statuses = await loadIntegrationStatusesScoped(
+        connection.agentId,
+        userId,
 				connection.organizationId,
 				deps,
-			);
-			blocks.push({
-				type: "header",
-				text: { type: "plain_text", text: "Integrations" },
-			});
-			if (statuses.length === 0) {
-				blocks.push({
-					type: "section",
-					text: {
-						type: "mrkdwn",
-						text: "_No integrations connected yet._",
-					},
-				});
-			} else {
-				for (const status of statuses) {
-					blocks.push(integrationSection(status, pendingAuthUrls?.[status.id]));
-				}
-			}
-			blocks.push({ type: "divider" });
-		} catch (error) {
-			logger.warn(
-				{ error, agentId: connection.agentId },
+      );
+      blocks.push({
+        type: "header",
+        text: { type: "plain_text", text: "Integrations" },
+      });
+      if (statuses.length === 0) {
+        blocks.push({
+          type: "section",
+          text: {
+            type: "mrkdwn",
+            text: "_No integrations connected yet._",
+          },
+        });
+      } else {
+        for (const status of statuses) {
+          blocks.push(integrationSection(status, pendingAuthUrls?.[status.id]));
+        }
+      }
+      blocks.push({ type: "divider" });
+    } catch (error) {
+      logger.warn(
+        { error, agentId: connection.agentId },
 				"Failed to load integrations for Slack home tab; rendering without them",
-			);
-		}
-	}
+      );
+    }
+  }
 
-	blocks.push({
-		type: "section",
-		text: {
-			type: "mrkdwn",
-			text: isPreview
-				? "This is a *preview* workspace. Run `lobu run`, then use `/lobu link <code>` in a channel to connect your own agent."
-				: "*Tips*\n• Mention me in a channel, or DM me directly.\n• `/lobu help` lists the built-in commands.\n• Integrations that need you to sign in will also prompt you with a button right in the thread.",
-		},
-	});
+  blocks.push({
+    type: "section",
+    text: {
+      type: "mrkdwn",
+      text: isPreview
+        ? "This is a *preview* workspace. Run `lobu run`, then use `/lobu link <code>` in a channel to connect your own agent."
+        : "*Tips*\n• Mention me in a channel, or DM me directly.\n• `/lobu help` lists the built-in commands.\n• Integrations that need you to sign in will also prompt you with a button right in the thread.",
+    },
+  });
 
-	return blocks;
+  return blocks;
 }
 
 // Resolve the agent's integrations plus this user's connection status. The
 // Slack user id is the credential scope key (home-tab connect is per-user).
 async function loadIntegrationStatusesScoped(
-	agentId: string,
-	userId: string,
+  agentId: string,
+  userId: string,
 	organizationId: string | undefined,
 	deps: SlackAppHomeDeps,
 ): Promise<IntegrationStatus[]> {
-	const mcpConfigService = deps.mcpConfigService;
-	if (!mcpConfigService) return [];
-	const statuses = (await mcpConfigService.getMcpStatus(agentId)).filter(
+  const mcpConfigService = deps.mcpConfigService;
+  if (!mcpConfigService) return [];
+  const statuses = (await mcpConfigService.getMcpStatus(agentId)).filter(
 		(s) => !HIDDEN_HOME_INTEGRATION_IDS.has(s.id),
-	);
-	const result: IntegrationStatus[] = [];
-	for (const s of statuses) {
-		let connected = false;
+  );
+  const result: IntegrationStatus[] = [];
+  for (const s of statuses) {
+    let connected = false;
 		const secretStore = deps.secretStore;
 		if (s.requiresAuth && secretStore) {
-			try {
+      try {
 				connected = !!(await runWithOrganizationContext(organizationId, () =>
 					getStoredCredential(secretStore, agentId, userId, s.id),
-				));
-			} catch {
-				connected = false;
-			}
-		}
-		result.push({
-			id: s.id,
-			name: humanizeIntegrationName(s.name || s.id),
-			requiresAuth: s.requiresAuth,
-			connected,
-		});
-	}
-	return result;
+        ));
+      } catch {
+        connected = false;
+      }
+    }
+    result.push({
+      id: s.id,
+      name: humanizeIntegrationName(s.name || s.id),
+      requiresAuth: s.requiresAuth,
+      connected,
+    });
+  }
+  return result;
 }
 
 /** Extract something useful out of a Slack `WebAPIPlatformError` (or anything). */
 function errorDetail(error: unknown): Record<string, unknown> {
-	if (error instanceof Error) {
-		const data = (error as { data?: unknown }).data;
-		return {
-			message: error.message,
-			...(data && typeof data === "object" ? { slack: data } : {}),
-		};
-	}
-	return { message: String(error) };
+  if (error instanceof Error) {
+    const data = (error as { data?: unknown }).data;
+    return {
+      message: error.message,
+      ...(data && typeof data === "object" ? { slack: data } : {}),
+    };
+  }
+  return { message: String(error) };
 }
 
 const HOME_FALLBACK_BLOCKS: unknown[] = [
-	{
-		type: "section",
-		text: {
-			type: "mrkdwn",
-			text: "*Lobu* :wave:\n\nMention me in any channel, or send me a DM, to start a thread. Use `/lobu help` for the built-in commands.",
-		},
-	},
+  {
+    type: "section",
+    text: {
+      type: "mrkdwn",
+      text: "*Lobu* :wave:\n\nMention me in any channel, or send me a DM, to start a thread. Use `/lobu help` for the built-in commands.",
+    },
+  },
 ];
 
 async function publishHome(
-	adapter: SlackHomeAdapter | undefined,
+  adapter: SlackHomeAdapter | undefined,
 	params: HomeViewParams,
 ): Promise<void> {
-	const publishHomeView = adapter?.publishHomeView;
-	if (typeof publishHomeView !== "function") return;
-	try {
-		const blocks = await buildSlackHomeBlocks(params);
-		await publishHomeView(params.userId, { type: "home", blocks });
-	} catch (error) {
-		logger.warn(
-			{
-				error: errorDetail(error),
-				connectionId: params.connection.id,
-				userId: params.userId,
-			},
+  const publishHomeView = adapter?.publishHomeView;
+  if (typeof publishHomeView !== "function") return;
+  try {
+    const blocks = await buildSlackHomeBlocks(params);
+    await publishHomeView(params.userId, { type: "home", blocks });
+  } catch (error) {
+    logger.warn(
+      {
+        error: errorDetail(error),
+        connectionId: params.connection.id,
+        userId: params.userId,
+      },
 			"Failed to publish Slack home tab; falling back to a minimal view",
-		);
-		// The rich view failed (likely Block Kit validation). Don't leave the user
-		// staring at a stale cached view — publish a plain text-only home tab.
-		try {
-			await publishHomeView(params.userId, {
-				type: "home",
-				blocks: HOME_FALLBACK_BLOCKS,
-			});
-		} catch (fallbackError) {
-			logger.warn(
-				{
-					error: errorDetail(fallbackError),
-					connectionId: params.connection.id,
-					userId: params.userId,
-				},
+    );
+    // The rich view failed (likely Block Kit validation). Don't leave the user
+    // staring at a stale cached view — publish a plain text-only home tab.
+    try {
+      await publishHomeView(params.userId, {
+        type: "home",
+        blocks: HOME_FALLBACK_BLOCKS,
+      });
+    } catch (fallbackError) {
+      logger.warn(
+        {
+          error: errorDetail(fallbackError),
+          connectionId: params.connection.id,
+          userId: params.userId,
+        },
 				"Failed to publish fallback Slack home tab",
-			);
-		}
-	}
+      );
+    }
+  }
 }
 
 /**
@@ -419,56 +419,56 @@ async function publishHome(
  * `secretStore.delete` with an attacker-supplied key string.
  */
 async function isKnownIntegration(
-	agentId: string,
-	mcpId: string,
+  agentId: string,
+  mcpId: string,
 	deps: SlackAppHomeDeps,
 ): Promise<boolean> {
-	if (HIDDEN_HOME_INTEGRATION_IDS.has(mcpId)) return false;
-	const mcpConfigService = deps.mcpConfigService;
-	if (!mcpConfigService) return false;
-	try {
-		const statuses = await mcpConfigService.getMcpStatus(agentId);
-		return statuses.some((s) => s.id === mcpId);
-	} catch {
-		return false;
-	}
+  if (HIDDEN_HOME_INTEGRATION_IDS.has(mcpId)) return false;
+  const mcpConfigService = deps.mcpConfigService;
+  if (!mcpConfigService) return false;
+  try {
+    const statuses = await mcpConfigService.getMcpStatus(agentId);
+    return statuses.some((s) => s.id === mcpId);
+  } catch {
+    return false;
+  }
 }
 
 async function startMcpConnectFlow(params: {
-	connection: PlatformConnection;
-	deps: SlackAppHomeDeps;
-	agentId: string;
-	userId: string;
-	mcpId: string;
-	teamId?: string;
+  connection: PlatformConnection;
+  deps: SlackAppHomeDeps;
+  agentId: string;
+  userId: string;
+  mcpId: string;
+  teamId?: string;
 }): Promise<string | null> {
-	const { connection, deps, agentId, userId, mcpId, teamId } = params;
-	const mcpConfigService = deps.mcpConfigService;
-	if (!mcpConfigService || !deps.secretStore || !deps.publicGatewayUrl) {
-		return null;
-	}
-	const httpServer = await mcpConfigService.getHttpServer(mcpId, agentId);
-	if (!httpServer) return null;
-	const redirectUri = `${deps.publicGatewayUrl.replace(/\/+$/, "")}/mcp/oauth/callback`;
-	const { authorizationUrl } = await startAuthCodeFlow({
-		secretStore: deps.secretStore,
-		mcpId,
-		upstreamUrl: httpServer.upstreamUrl,
-		agentId,
-		userId,
+  const { connection, deps, agentId, userId, mcpId, teamId } = params;
+  const mcpConfigService = deps.mcpConfigService;
+  if (!mcpConfigService || !deps.secretStore || !deps.publicGatewayUrl) {
+    return null;
+  }
+  const httpServer = await mcpConfigService.getHttpServer(mcpId, agentId);
+  if (!httpServer) return null;
+  const redirectUri = `${deps.publicGatewayUrl.replace(/\/+$/, "")}/mcp/oauth/callback`;
+  const { authorizationUrl } = await startAuthCodeFlow({
+    secretStore: deps.secretStore,
+    mcpId,
+    upstreamUrl: httpServer.upstreamUrl,
+    agentId,
+    userId,
 		organizationId: connection.organizationId,
-		// Home-tab connect is always per-user.
-		scopeKey: userId,
-		wwwAuthenticate: null,
-		redirectUri,
-		staticOauth: httpServer.oauth,
-		platform: "slack",
-		channelId: userId,
-		conversationId: userId,
-		teamId,
-		connectionId: connection.id,
-	});
-	return authorizationUrl;
+    // Home-tab connect is always per-user.
+    scopeKey: userId,
+    wwwAuthenticate: null,
+    redirectUri,
+    staticOauth: httpServer.oauth,
+    platform: "slack",
+    channelId: userId,
+    conversationId: userId,
+    teamId,
+    connectionId: connection.id,
+  });
+  return authorizationUrl;
 }
 
 /**
@@ -482,133 +482,133 @@ async function startMcpConnectFlow(params: {
  * store aren't available.
  */
 export function registerSlackAppHome(
-	chat: any,
-	connection: PlatformConnection,
+  chat: any,
+  connection: PlatformConnection,
 	deps: SlackAppHomeDeps = {},
 ): void {
-	if (connection.platform !== "slack") {
-		return;
-	}
+  if (connection.platform !== "slack") {
+    return;
+  }
 
-	chat.onAppHomeOpened(async (event: SlackAppHomeEvent) => {
-		await publishHome(deps.adapter ?? event.adapter, {
-			connection,
-			deps,
-			userId: event.userId,
-		});
-	});
+  chat.onAppHomeOpened(async (event: SlackAppHomeEvent) => {
+    await publishHome(deps.adapter ?? event.adapter, {
+      connection,
+      deps,
+      userId: event.userId,
+    });
+  });
 
-	chat.onAction(
-		[HOME_ACTION_CONNECT, HOME_ACTION_DISCONNECT],
-		async (event: SlackActionEvent) => {
-			const mcpId = event.value;
-			const userId = event.user?.userId;
-			const agentId = connection.agentId;
-			if (!mcpId || !userId || !agentId) return;
-			// `mcpId` comes from the (Slack-signed) button payload, but only the
-			// button labels are ours — reject anything not in the agent's config.
-			if (!(await isKnownIntegration(agentId, mcpId, deps))) {
-				logger.warn(
-					{ agentId, userId, mcpId, actionId: event.actionId },
+  chat.onAction(
+    [HOME_ACTION_CONNECT, HOME_ACTION_DISCONNECT],
+    async (event: SlackActionEvent) => {
+      const mcpId = event.value;
+      const userId = event.user?.userId;
+      const agentId = connection.agentId;
+      if (!mcpId || !userId || !agentId) return;
+      // `mcpId` comes from the (Slack-signed) button payload, but only the
+      // button labels are ours — reject anything not in the agent's config.
+      if (!(await isKnownIntegration(agentId, mcpId, deps))) {
+        logger.warn(
+          { agentId, userId, mcpId, actionId: event.actionId },
 					"Ignoring Slack home action for an unknown integration",
-				);
-				return;
-			}
+        );
+        return;
+      }
 
-			if (event.actionId === HOME_ACTION_DISCONNECT) {
+      if (event.actionId === HOME_ACTION_DISCONNECT) {
 				const secretStore = deps.secretStore;
 				if (secretStore) {
-					try {
+          try {
 						await runWithOrganizationContext(connection.organizationId, () =>
 							deleteCredential(secretStore, agentId, userId, mcpId),
 						);
-					} catch (error) {
-						logger.warn(
-							{ error, agentId, userId, mcpId },
+          } catch (error) {
+            logger.warn(
+              { error, agentId, userId, mcpId },
 							"Failed to disconnect MCP credential from Slack home tab",
-						);
-					}
-				}
+            );
+          }
+        }
 				await publishHome(deps.adapter ?? event.adapter, {
 					connection,
 					deps,
 					userId,
 				});
-				return;
-			}
+        return;
+      }
 
-			// Connect: mint an authorization URL, then re-publish with the link.
-			let authorizationUrl: string | null = null;
-			try {
-				authorizationUrl = await startMcpConnectFlow({
-					connection,
-					deps,
-					agentId,
-					userId,
-					mcpId,
-					teamId: teamIdFromRawPayload(event.raw),
-				});
-			} catch (error) {
-				logger.warn(
-					{ error, agentId, userId, mcpId },
+      // Connect: mint an authorization URL, then re-publish with the link.
+      let authorizationUrl: string | null = null;
+      try {
+        authorizationUrl = await startMcpConnectFlow({
+          connection,
+          deps,
+          agentId,
+          userId,
+          mcpId,
+          teamId: teamIdFromRawPayload(event.raw),
+        });
+      } catch (error) {
+        logger.warn(
+          { error, agentId, userId, mcpId },
 					"Failed to start MCP OAuth flow from Slack home tab",
-				);
-			}
-			await publishHome(deps.adapter ?? event.adapter, {
-				connection,
-				deps,
-				userId,
-				pendingAuthUrls: authorizationUrl ? { [mcpId]: authorizationUrl } : {},
-			});
+        );
+      }
+      await publishHome(deps.adapter ?? event.adapter, {
+        connection,
+        deps,
+        userId,
+        pendingAuthUrls: authorizationUrl ? { [mcpId]: authorizationUrl } : {},
+      });
 		},
-	);
+  );
 }
 
 export function parseSlackTeamJoinEvent(
-	body: string,
+  body: string,
 	contentType: string,
 ): ParsedSlackTeamJoinEvent | null {
-	if (!contentType.includes("application/json")) {
-		return null;
-	}
+  if (!contentType.includes("application/json")) {
+    return null;
+  }
 
-	let payload: SlackTeamJoinPayload;
-	try {
-		payload = JSON.parse(body) as SlackTeamJoinPayload;
-	} catch {
-		return null;
-	}
+  let payload: SlackTeamJoinPayload;
+  try {
+    payload = JSON.parse(body) as SlackTeamJoinPayload;
+  } catch {
+    return null;
+  }
 
-	if (
-		payload.type !== "event_callback" ||
-		payload.event?.type !== "team_join"
-	) {
-		return null;
-	}
+  if (
+    payload.type !== "event_callback" ||
+    payload.event?.type !== "team_join"
+  ) {
+    return null;
+  }
 
-	const teamId = payload.team_id;
-	const user = payload.event.user;
-	if (!teamId || !user?.id || user.is_bot || user.deleted) {
-		return null;
-	}
+  const teamId = payload.team_id;
+  const user = payload.event.user;
+  if (!teamId || !user?.id || user.is_bot || user.deleted) {
+    return null;
+  }
 
-	const displayName =
-		user.profile?.display_name || user.profile?.real_name || user.real_name;
+  const displayName =
+    user.profile?.display_name || user.profile?.real_name || user.real_name;
 
-	return {
-		teamId,
-		userId: user.id,
-		...(displayName ? { displayName } : {}),
-	};
+  return {
+    teamId,
+    userId: user.id,
+    ...(displayName ? { displayName } : {}),
+  };
 }
 
 export async function postSlackTeamJoinWelcome(
-	chat: any,
+  chat: any,
 	event: ParsedSlackTeamJoinEvent,
 ): Promise<void> {
-	const thread = await chat.openDM(event.userId);
-	const greeting = event.displayName
-		? `Welcome to Lobu, ${event.displayName}.`
-		: "Welcome to Lobu.";
-	await thread.post(`${greeting} ${DEFAULT_SLACK_TEAM_JOIN_WELCOME}`);
+  const thread = await chat.openDM(event.userId);
+  const greeting = event.displayName
+    ? `Welcome to Lobu, ${event.displayName}.`
+    : "Welcome to Lobu.";
+  await thread.post(`${greeting} ${DEFAULT_SLACK_TEAM_JOIN_WELCOME}`);
 }

--- a/packages/server/src/gateway/routes/internal/device-auth.ts
+++ b/packages/server/src/gateway/routes/internal/device-auth.ts
@@ -8,6 +8,7 @@ import {
 import { GenericDeviceCodeClient } from "../../auth/external/device-code-client.js";
 import type { McpConfigService } from "../../auth/mcp/config-service.js";
 import { runWithWorkerOrgContext } from "../../auth/mcp/proxy-shared.js";
+import { tryGetOrgId } from "../../../lobu/stores/org-context.js";
 import type { WritableSecretStore } from "../../secrets/index.js";
 import { errorResponse, getVerifiedWorker } from "../shared/helpers.js";
 import { authenticateWorker } from "./middleware.js";
@@ -153,11 +154,12 @@ const refreshLocks = new Map<string, number>();
 const REFRESH_LOCK_TTL_MS = 30_000;
 
 function tryAcquireRefreshLock(
+	organizationId: string,
   agentId: string,
   userId: string,
 	mcpId: string,
 ): boolean {
-  const key = `${agentId}:${userId}:${mcpId}`;
+	const key = `${organizationId}:${agentId}:${userId}:${mcpId}`;
   const expiresAt = refreshLocks.get(key);
   if (expiresAt && expiresAt > Date.now()) return false;
   refreshLocks.set(key, Date.now() + REFRESH_LOCK_TTL_MS);
@@ -165,11 +167,12 @@ function tryAcquireRefreshLock(
 }
 
 function releaseRefreshLock(
+	organizationId: string,
   agentId: string,
   userId: string,
 	mcpId: string,
 ): void {
-  refreshLocks.delete(`${agentId}:${userId}:${mcpId}`);
+	refreshLocks.delete(`${organizationId}:${agentId}:${userId}:${mcpId}`);
 }
 
 function deriveOAuthBaseUrl(upstreamUrl: string): string {
@@ -282,7 +285,17 @@ export async function refreshCredential(
 ): Promise<StoredCredential | null> {
   if (!credential.refreshToken) return null;
 
-  const acquired = tryAcquireRefreshLock(agentId, userId, mcpId);
+	const organizationId = tryGetOrgId();
+	if (!organizationId) {
+		logger.error("Refusing to refresh MCP credential without org context", {
+			agentId,
+			userId,
+			mcpId,
+		});
+		return null;
+	}
+
+	const acquired = tryAcquireRefreshLock(organizationId, agentId, userId, mcpId);
 
   if (!acquired) {
     // Another request is refreshing — wait briefly and re-read
@@ -340,7 +353,7 @@ export async function refreshCredential(
     logger.error("Token refresh error", { error, agentId, userId, mcpId });
     return null;
   } finally {
-    releaseRefreshLock(agentId, userId, mcpId);
+		releaseRefreshLock(organizationId, agentId, userId, mcpId);
   }
 }
 

--- a/packages/server/src/gateway/routes/internal/device-auth.ts
+++ b/packages/server/src/gateway/routes/internal/device-auth.ts
@@ -608,6 +608,9 @@ export function createDeviceAuthRoutes(
 
 	router.use("/internal/device-auth/*", authenticateWorker, async (c, next) => {
 		const worker = getVerifiedWorker(c);
+		if (!worker.organizationId) {
+			return errorResponse(c, "Worker token missing organizationId", 401);
+		}
 		return runWithWorkerOrgContext(worker, () => next());
 	});
 

--- a/packages/server/src/gateway/routes/internal/device-auth.ts
+++ b/packages/server/src/gateway/routes/internal/device-auth.ts
@@ -2,8 +2,8 @@ import { createLogger, type McpOAuthConfig, type SecretRef } from "@lobu/core";
 import { Hono } from "hono";
 import { DEFAULT_MCP_DEVICE_SCOPE } from "../../../auth/oauth/scopes.js";
 import {
-	buildRefreshRequest,
-	parseTokenRefreshResponse,
+  buildRefreshRequest,
+  parseTokenRefreshResponse,
 } from "../../../auth/oauth/token-refresh.js";
 import { GenericDeviceCodeClient } from "../../auth/external/device-code-client.js";
 import type { McpConfigService } from "../../auth/mcp/config-service.js";
@@ -17,131 +17,131 @@ const logger = createLogger("device-auth");
 const DEVICE_CODE_GRANT_TYPE = "urn:ietf:params:oauth:grant-type:device_code";
 
 interface StoredCredential {
-	accessToken: string;
-	refreshToken?: string;
-	expiresAt: number;
-	clientId: string;
-	clientSecret?: string;
-	tokenUrl: string;
-	/** RFC 8707 resource indicator, included in refresh requests. */
-	resource?: string;
-	/**
-	 * How to authenticate to the token endpoint on refresh.
-	 * - `none` — public PKCE client, send no secret.
-	 * - `client_secret_basic` — send secret via HTTP Basic header (RFC 6749 §2.3.1 default).
-	 * - `client_secret_post` — send secret in form body.
-	 *
-	 * Omitted → legacy device-code behavior (secret in body, JSON content-type).
-	 */
-	tokenEndpointAuthMethod?:
-		| "none"
-		| "client_secret_basic"
-		| "client_secret_post";
+  accessToken: string;
+  refreshToken?: string;
+  expiresAt: number;
+  clientId: string;
+  clientSecret?: string;
+  tokenUrl: string;
+  /** RFC 8707 resource indicator, included in refresh requests. */
+  resource?: string;
+  /**
+   * How to authenticate to the token endpoint on refresh.
+   * - `none` — public PKCE client, send no secret.
+   * - `client_secret_basic` — send secret via HTTP Basic header (RFC 6749 §2.3.1 default).
+   * - `client_secret_post` — send secret in form body.
+   *
+   * Omitted → legacy device-code behavior (secret in body, JSON content-type).
+   */
+  tokenEndpointAuthMethod?:
+    | "none"
+    | "client_secret_basic"
+    | "client_secret_post";
 }
 
 interface StoredDeviceAuth {
-	deviceCode: string;
-	userCode?: string;
-	clientId: string;
-	clientSecret?: string;
-	interval: number;
-	expiresAt: number;
-	tokenUrl: string;
-	issuer: string;
-	/** Stored so poll/complete can reconstruct the client without re-deriving. */
-	deviceAuthorizationUrl?: string;
-	/** RFC 8707 resource indicator. */
-	resource?: string;
-	/** Custom scopes from oauth config. */
-	scope?: string;
+  deviceCode: string;
+  userCode?: string;
+  clientId: string;
+  clientSecret?: string;
+  interval: number;
+  expiresAt: number;
+  tokenUrl: string;
+  issuer: string;
+  /** Stored so poll/complete can reconstruct the client without re-deriving. */
+  deviceAuthorizationUrl?: string;
+  /** RFC 8707 resource indicator. */
+  resource?: string;
+  /** Custom scopes from oauth config. */
+  scope?: string;
 }
 
 interface StoredClient {
-	clientId: string;
-	clientSecret?: string;
+  clientId: string;
+  clientSecret?: string;
 }
 
 interface DeviceAuthConfig {
-	mcpConfigService: McpConfigService;
-	secretStore: WritableSecretStore;
+  mcpConfigService: McpConfigService;
+  secretStore: WritableSecretStore;
 }
 
 interface ResolvedOAuthEndpoints {
-	registrationUrl: string;
-	deviceAuthorizationUrl: string;
-	tokenUrl: string;
-	verificationUri: string;
-	scope: string;
-	clientId?: string;
-	clientSecret?: string;
-	resource?: string;
+  registrationUrl: string;
+  deviceAuthorizationUrl: string;
+  tokenUrl: string;
+  verificationUri: string;
+  scope: string;
+  clientId?: string;
+  clientSecret?: string;
+  resource?: string;
 }
 
 /** Read a JSON payload directly from the secret store. */
 async function getSecretJson<T>(
-	secretStore: WritableSecretStore,
-	name: string,
+  secretStore: WritableSecretStore,
+  name: string,
 	context: Record<string, unknown>,
 ): Promise<T | null> {
-	// The secret store's `get` accepts a SecretRef; we always store under the
-	// default `secret://` scheme so the ref form is mechanical.
+  // The secret store's `get` accepts a SecretRef; we always store under the
+  // default `secret://` scheme so the ref form is mechanical.
 	const ref = `secret://${encodeURIComponent(name)}` as SecretRef;
 	const value = await secretStore.get(ref);
-	if (!value) return null;
-	try {
-		return JSON.parse(value) as T;
-	} catch (error) {
-		logger.warn("Failed to parse JSON payload from secret store", {
-			name,
-			...context,
-			error: error instanceof Error ? error.message : String(error),
-		});
-		return null;
-	}
+  if (!value) return null;
+  try {
+    return JSON.parse(value) as T;
+  } catch (error) {
+    logger.warn("Failed to parse JSON payload from secret store", {
+      name,
+      ...context,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return null;
+  }
 }
 
 async function putSecretJson<T>(
-	secretStore: WritableSecretStore,
-	name: string,
-	value: T,
+  secretStore: WritableSecretStore,
+  name: string,
+  value: T,
 	ttlSeconds?: number,
 ): Promise<void> {
-	await secretStore.put(name, JSON.stringify(value), { ttlSeconds });
+  await secretStore.put(name, JSON.stringify(value), { ttlSeconds });
 }
 
 async function deleteSecretJson(
-	secretStore: WritableSecretStore,
-	name: string,
+  secretStore: WritableSecretStore,
+  name: string,
 	_context: Record<string, unknown>,
 ): Promise<boolean> {
-	// delete() is idempotent for the underlying store; we don't know if a row
-	// existed before, but for cleanup that doesn't matter.
-	try {
-		await secretStore.delete(name);
-		return true;
-	} catch {
-		return false;
-	}
+  // delete() is idempotent for the underlying store; we don't know if a row
+  // existed before, but for cleanup that doesn't matter.
+  try {
+    await secretStore.delete(name);
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 function credentialName(
-	agentId: string,
-	userId: string,
+  agentId: string,
+  userId: string,
 	mcpId: string,
 ): string {
-	return `mcp-auth/${agentId}/${userId}/${mcpId}/credential`;
+  return `mcp-auth/${agentId}/${userId}/${mcpId}/credential`;
 }
 
 function deviceAuthName(
-	agentId: string,
-	userId: string,
+  agentId: string,
+  userId: string,
 	mcpId: string,
 ): string {
-	return `mcp-auth/${agentId}/${userId}/${mcpId}/device-auth`;
+  return `mcp-auth/${agentId}/${userId}/${mcpId}/device-auth`;
 }
 
 function clientCacheName(mcpId: string): string {
-	return `mcp-auth/clients/${mcpId}/registration`;
+  return `mcp-auth/clients/${mcpId}/registration`;
 }
 
 /**
@@ -153,31 +153,31 @@ const refreshLocks = new Map<string, number>();
 const REFRESH_LOCK_TTL_MS = 30_000;
 
 function tryAcquireRefreshLock(
-	agentId: string,
-	userId: string,
+  agentId: string,
+  userId: string,
 	mcpId: string,
 ): boolean {
-	const key = `${agentId}:${userId}:${mcpId}`;
-	const expiresAt = refreshLocks.get(key);
-	if (expiresAt && expiresAt > Date.now()) return false;
-	refreshLocks.set(key, Date.now() + REFRESH_LOCK_TTL_MS);
-	return true;
+  const key = `${agentId}:${userId}:${mcpId}`;
+  const expiresAt = refreshLocks.get(key);
+  if (expiresAt && expiresAt > Date.now()) return false;
+  refreshLocks.set(key, Date.now() + REFRESH_LOCK_TTL_MS);
+  return true;
 }
 
 function releaseRefreshLock(
-	agentId: string,
-	userId: string,
+  agentId: string,
+  userId: string,
 	mcpId: string,
 ): void {
-	refreshLocks.delete(`${agentId}:${userId}:${mcpId}`);
+  refreshLocks.delete(`${agentId}:${userId}:${mcpId}`);
 }
 
 function deriveOAuthBaseUrl(upstreamUrl: string): string {
-	const url = new URL(upstreamUrl);
-	url.pathname = "/";
-	url.search = "";
-	url.hash = "";
-	return url.toString().replace(/\/$/, "");
+  const url = new URL(upstreamUrl);
+  url.pathname = "/";
+  url.search = "";
+  url.hash = "";
+  return url.toString().replace(/\/$/, "");
 }
 
 /**
@@ -185,49 +185,49 @@ function deriveOAuthBaseUrl(upstreamUrl: string): string {
  * auto-derived endpoints from the MCP server's URL origin.
  */
 function resolveOAuthEndpoints(
-	upstreamUrl: string,
+  upstreamUrl: string,
 	oauth?: McpOAuthConfig,
 ): ResolvedOAuthEndpoints {
-	const issuer = deriveOAuthBaseUrl(upstreamUrl);
-	return {
-		registrationUrl: oauth?.registrationUrl ?? `${issuer}/oauth/register`,
-		deviceAuthorizationUrl:
-			oauth?.deviceAuthorizationUrl ?? `${issuer}/oauth/device_authorization`,
-		tokenUrl: oauth?.tokenUrl ?? `${issuer}/oauth/token`,
-		verificationUri: oauth?.authUrl ?? `${issuer}/oauth/device`,
-		scope: oauth?.scopes?.join(" ") || DEFAULT_MCP_DEVICE_SCOPE,
-		clientId: oauth?.clientId,
-		clientSecret: oauth?.clientSecret,
-		resource: oauth?.resource,
-	};
+  const issuer = deriveOAuthBaseUrl(upstreamUrl);
+  return {
+    registrationUrl: oauth?.registrationUrl ?? `${issuer}/oauth/register`,
+    deviceAuthorizationUrl:
+      oauth?.deviceAuthorizationUrl ?? `${issuer}/oauth/device_authorization`,
+    tokenUrl: oauth?.tokenUrl ?? `${issuer}/oauth/token`,
+    verificationUri: oauth?.authUrl ?? `${issuer}/oauth/device`,
+    scope: oauth?.scopes?.join(" ") || DEFAULT_MCP_DEVICE_SCOPE,
+    clientId: oauth?.clientId,
+    clientSecret: oauth?.clientSecret,
+    resource: oauth?.resource,
+  };
 }
 
 export async function getStoredCredential(
-	secretStore: WritableSecretStore,
-	agentId: string,
-	userId: string,
+  secretStore: WritableSecretStore,
+  agentId: string,
+  userId: string,
 	mcpId: string,
 ): Promise<StoredCredential | null> {
-	return getSecretJson<StoredCredential>(
-		secretStore,
-		credentialName(agentId, userId, mcpId),
+  return getSecretJson<StoredCredential>(
+    secretStore,
+    credentialName(agentId, userId, mcpId),
 		{ agentId, userId, mcpId },
-	);
+  );
 }
 
 async function storeCredential(
-	secretStore: WritableSecretStore,
-	agentId: string,
-	userId: string,
-	mcpId: string,
+  secretStore: WritableSecretStore,
+  agentId: string,
+  userId: string,
+  mcpId: string,
 	credential: StoredCredential,
 ): Promise<void> {
-	await putSecretJson(
-		secretStore,
-		credentialName(agentId, userId, mcpId),
-		credential,
+  await putSecretJson(
+    secretStore,
+    credentialName(agentId, userId, mcpId),
+    credential,
 		90 * 24 * 60 * 60,
-	);
+  );
 }
 
 /**
@@ -237,13 +237,13 @@ async function storeCredential(
  * internal helpers.
  */
 export async function storeCredentialForScope(
-	secretStore: WritableSecretStore,
-	agentId: string,
-	scopeKey: string,
-	mcpId: string,
+  secretStore: WritableSecretStore,
+  agentId: string,
+  scopeKey: string,
+  mcpId: string,
 	credential: StoredCredential,
 ): Promise<void> {
-	await storeCredential(secretStore, agentId, scopeKey, mcpId, credential);
+  await storeCredential(secretStore, agentId, scopeKey, mcpId, credential);
 }
 
 /**
@@ -253,95 +253,95 @@ export async function storeCredentialForScope(
  * scope, `channel-<id>` for channel scope.
  */
 export async function deleteCredential(
-	secretStore: WritableSecretStore,
-	agentId: string,
-	userId: string,
+  secretStore: WritableSecretStore,
+  agentId: string,
+  userId: string,
 	mcpId: string,
 ): Promise<boolean> {
-	const deleted = await deleteSecretJson(
-		secretStore,
-		credentialName(agentId, userId, mcpId),
+  const deleted = await deleteSecretJson(
+    secretStore,
+    credentialName(agentId, userId, mcpId),
 		{ agentId, userId, mcpId },
-	);
+  );
 	await deleteSecretJson(secretStore, deviceAuthName(agentId, userId, mcpId), {
 		agentId,
 		userId,
 		mcpId,
 		scope: "device-auth",
 	});
-	logger.info("Deleted MCP credential", { agentId, userId, mcpId });
-	return deleted;
+  logger.info("Deleted MCP credential", { agentId, userId, mcpId });
+  return deleted;
 }
 
 export async function refreshCredential(
-	secretStore: WritableSecretStore,
-	agentId: string,
-	userId: string,
-	mcpId: string,
+  secretStore: WritableSecretStore,
+  agentId: string,
+  userId: string,
+  mcpId: string,
 	credential: StoredCredential,
 ): Promise<StoredCredential | null> {
-	if (!credential.refreshToken) return null;
+  if (!credential.refreshToken) return null;
 
-	const acquired = tryAcquireRefreshLock(agentId, userId, mcpId);
+  const acquired = tryAcquireRefreshLock(agentId, userId, mcpId);
 
-	if (!acquired) {
-		// Another request is refreshing — wait briefly and re-read
-		await new Promise((r) => setTimeout(r, 150));
-		return getStoredCredential(secretStore, agentId, userId, mcpId);
-	}
+  if (!acquired) {
+    // Another request is refreshing — wait briefly and re-read
+    await new Promise((r) => setTimeout(r, 150));
+    return getStoredCredential(secretStore, agentId, userId, mcpId);
+  }
 
-	try {
-		const { headers, body } = buildRefreshRequest({
-			profile: "mcp-credential",
-			clientId: credential.clientId,
-			clientSecret: credential.clientSecret,
-			refreshToken: credential.refreshToken,
-			authMethod: credential.tokenEndpointAuthMethod,
-			resource: credential.resource,
-		});
+  try {
+    const { headers, body } = buildRefreshRequest({
+      profile: "mcp-credential",
+      clientId: credential.clientId,
+      clientSecret: credential.clientSecret,
+      refreshToken: credential.refreshToken,
+      authMethod: credential.tokenEndpointAuthMethod,
+      resource: credential.resource,
+    });
 
-		const response = await fetch(credential.tokenUrl, {
-			method: "POST",
-			headers,
-			body,
-		});
+    const response = await fetch(credential.tokenUrl, {
+      method: "POST",
+      headers,
+      body,
+    });
 
-		if (!response.ok) {
-			logger.error("Token refresh failed", {
-				status: response.status,
-				agentId,
-				userId,
-				mcpId,
-			});
-			return null;
-		}
+    if (!response.ok) {
+      logger.error("Token refresh failed", {
+        status: response.status,
+        agentId,
+        userId,
+        mcpId,
+      });
+      return null;
+    }
 
-		const data = (await response.json()) as Record<string, unknown>;
-		const parsed = parseTokenRefreshResponse(data, {
-			previousRefreshToken: credential.refreshToken,
-		});
-		if (!parsed) return null;
+    const data = (await response.json()) as Record<string, unknown>;
+    const parsed = parseTokenRefreshResponse(data, {
+      previousRefreshToken: credential.refreshToken,
+    });
+    if (!parsed) return null;
 
-		const refreshed: StoredCredential = {
-			accessToken: parsed.accessToken,
-			refreshToken: parsed.refreshToken,
-			expiresAt: parsed.expiresAtMs,
-			clientId: credential.clientId,
-			clientSecret: credential.clientSecret,
-			tokenUrl: credential.tokenUrl,
-			resource: credential.resource,
-			tokenEndpointAuthMethod: credential.tokenEndpointAuthMethod,
-		};
+    const refreshed: StoredCredential = {
+      accessToken: parsed.accessToken,
+      refreshToken: parsed.refreshToken,
+      expiresAt: parsed.expiresAtMs,
+      clientId: credential.clientId,
+      clientSecret: credential.clientSecret,
+      tokenUrl: credential.tokenUrl,
+      resource: credential.resource,
+      tokenEndpointAuthMethod: credential.tokenEndpointAuthMethod,
+    };
 
-		await storeCredential(secretStore, agentId, userId, mcpId, refreshed);
-		logger.info("Token refreshed", { agentId, userId, mcpId });
-		return refreshed;
-	} catch (error) {
-		logger.error("Token refresh error", { error, agentId, userId, mcpId });
-		return null;
-	} finally {
-		releaseRefreshLock(agentId, userId, mcpId);
-	}
+    await storeCredential(secretStore, agentId, userId, mcpId, refreshed);
+    logger.info("Token refreshed", { agentId, userId, mcpId });
+    return refreshed;
+  } catch (error) {
+    logger.error("Token refresh error", { error, agentId, userId, mcpId });
+    return null;
+  } finally {
+    releaseRefreshLock(agentId, userId, mcpId);
+  }
 }
 
 /**
@@ -351,92 +351,92 @@ export async function refreshCredential(
  * Returns the access token on success, null if pending or no flow in progress.
  */
 export async function tryCompletePendingDeviceAuth(
-	secretStore: WritableSecretStore,
-	agentId: string,
-	userId: string,
+  secretStore: WritableSecretStore,
+  agentId: string,
+  userId: string,
 	mcpId: string,
 ): Promise<string | null> {
-	const deviceState = await getSecretJson<StoredDeviceAuth>(
-		secretStore,
-		deviceAuthName(agentId, userId, mcpId),
+  const deviceState = await getSecretJson<StoredDeviceAuth>(
+    secretStore,
+    deviceAuthName(agentId, userId, mcpId),
 		{ agentId, userId, mcpId, scope: "device-auth" },
-	);
-	if (!deviceState) return null;
+  );
+  if (!deviceState) return null;
 
-	if (Date.now() > deviceState.expiresAt) {
-		await deleteSecretJson(
-			secretStore,
-			deviceAuthName(agentId, userId, mcpId),
+  if (Date.now() > deviceState.expiresAt) {
+    await deleteSecretJson(
+      secretStore,
+      deviceAuthName(agentId, userId, mcpId),
 			{ agentId, userId, mcpId, scope: "device-auth" },
-		);
-		return null;
-	}
+    );
+    return null;
+  }
 
-	try {
-		const deviceCodeClient = new GenericDeviceCodeClient({
-			clientId: deviceState.clientId,
-			clientSecret: deviceState.clientSecret,
-			tokenUrl: deviceState.tokenUrl,
-			deviceAuthorizationUrl:
-				deviceState.deviceAuthorizationUrl ??
-				`${deviceState.issuer}/oauth/device_authorization`,
-			scope: deviceState.scope ?? DEFAULT_MCP_DEVICE_SCOPE,
-			resource: deviceState.resource,
-			tokenEndpointAuthMethod: deviceState.clientSecret
-				? "client_secret_post"
-				: "none",
-		});
+  try {
+    const deviceCodeClient = new GenericDeviceCodeClient({
+      clientId: deviceState.clientId,
+      clientSecret: deviceState.clientSecret,
+      tokenUrl: deviceState.tokenUrl,
+      deviceAuthorizationUrl:
+        deviceState.deviceAuthorizationUrl ??
+        `${deviceState.issuer}/oauth/device_authorization`,
+      scope: deviceState.scope ?? DEFAULT_MCP_DEVICE_SCOPE,
+      resource: deviceState.resource,
+      tokenEndpointAuthMethod: deviceState.clientSecret
+        ? "client_secret_post"
+        : "none",
+    });
 
-		const pollResult = await deviceCodeClient.pollForToken(
-			deviceState.deviceCode,
+    const pollResult = await deviceCodeClient.pollForToken(
+      deviceState.deviceCode,
 			deviceState.interval,
-		);
+    );
 
-		if (pollResult.status === "pending") {
-			return null;
-		}
+    if (pollResult.status === "pending") {
+      return null;
+    }
 
-		if (pollResult.status === "error") {
-			await deleteSecretJson(
-				secretStore,
-				deviceAuthName(agentId, userId, mcpId),
+    if (pollResult.status === "error") {
+      await deleteSecretJson(
+        secretStore,
+        deviceAuthName(agentId, userId, mcpId),
 				{ agentId, userId, mcpId, scope: "device-auth" },
-			);
-			return null;
-		}
+      );
+      return null;
+    }
 
-		// Success — store credential and clean up
-		const { credentials } = pollResult;
-		const storedCred: StoredCredential = {
-			accessToken: credentials.accessToken,
-			refreshToken: credentials.refreshToken,
-			expiresAt: credentials.expiresAt,
-			clientId: deviceState.clientId,
-			clientSecret: deviceState.clientSecret,
-			tokenUrl: deviceState.tokenUrl,
-			resource: deviceState.resource,
-		};
+    // Success — store credential and clean up
+    const { credentials } = pollResult;
+    const storedCred: StoredCredential = {
+      accessToken: credentials.accessToken,
+      refreshToken: credentials.refreshToken,
+      expiresAt: credentials.expiresAt,
+      clientId: deviceState.clientId,
+      clientSecret: deviceState.clientSecret,
+      tokenUrl: deviceState.tokenUrl,
+      resource: deviceState.resource,
+    };
 
-		await storeCredential(secretStore, agentId, userId, mcpId, storedCred);
-		await deleteSecretJson(
-			secretStore,
-			deviceAuthName(agentId, userId, mcpId),
+    await storeCredential(secretStore, agentId, userId, mcpId, storedCred);
+    await deleteSecretJson(
+      secretStore,
+      deviceAuthName(agentId, userId, mcpId),
 			{ agentId, userId, mcpId, scope: "device-auth" },
-		);
+    );
 
-		logger.info("Device auth auto-completed by proxy", {
-			mcpId,
-			agentId,
-			userId,
-		});
-		return credentials.accessToken;
-	} catch (error) {
-		logger.warn("Auto-complete device auth failed", {
-			mcpId,
-			error: error instanceof Error ? error.message : String(error),
-		});
-		return null;
-	}
+    logger.info("Device auth auto-completed by proxy", {
+      mcpId,
+      agentId,
+      userId,
+    });
+    return credentials.accessToken;
+  } catch (error) {
+    logger.warn("Auto-complete device auth failed", {
+      mcpId,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return null;
+  }
 }
 
 /**
@@ -447,376 +447,376 @@ export async function tryCompletePendingDeviceAuth(
  * registration is skipped entirely.
  */
 export async function startDeviceAuth(
-	secretStore: WritableSecretStore,
-	mcpConfigService: {
-		getHttpServer: (
-			id: string,
+  secretStore: WritableSecretStore,
+  mcpConfigService: {
+    getHttpServer: (
+      id: string,
 			agentId?: string,
-		) => Promise<{ upstreamUrl: string; oauth?: McpOAuthConfig } | undefined>;
-	},
-	mcpId: string,
-	agentId: string,
+    ) => Promise<{ upstreamUrl: string; oauth?: McpOAuthConfig } | undefined>;
+  },
+  mcpId: string,
+  agentId: string,
 	userId: string,
 ): Promise<{
-	userCode: string;
-	verificationUri: string;
-	verificationUriComplete?: string;
-	expiresIn: number;
+  userCode: string;
+  verificationUri: string;
+  verificationUriComplete?: string;
+  expiresIn: number;
 } | null> {
-	// Reuse existing pending device auth flow if not expired
-	const existing = await getSecretJson<StoredDeviceAuth>(
-		secretStore,
-		deviceAuthName(agentId, userId, mcpId),
+  // Reuse existing pending device auth flow if not expired
+  const existing = await getSecretJson<StoredDeviceAuth>(
+    secretStore,
+    deviceAuthName(agentId, userId, mcpId),
 		{ agentId, userId, mcpId, scope: "device-auth" },
-	);
-	if (existing?.expiresAt && existing.expiresAt > Date.now()) {
-		const httpServer = await mcpConfigService.getHttpServer(mcpId, agentId);
-		const issuer = httpServer
-			? deriveOAuthBaseUrl(httpServer.upstreamUrl)
-			: existing.issuer;
-		const endpoints = httpServer
-			? resolveOAuthEndpoints(httpServer.upstreamUrl, httpServer.oauth)
-			: null;
-		const verificationUri =
-			endpoints?.verificationUri ?? `${issuer}/oauth/device`;
-		logger.info("Reusing existing pending device auth", {
-			mcpId,
-			agentId,
-			userId,
-		});
-		return {
-			userCode: existing.userCode || "",
-			verificationUri,
-			verificationUriComplete: existing.userCode
-				? `${verificationUri}?user_code=${existing.userCode}`
-				: verificationUri,
-			expiresIn: Math.floor((existing.expiresAt - Date.now()) / 1000),
-		};
-	}
+  );
+  if (existing?.expiresAt && existing.expiresAt > Date.now()) {
+    const httpServer = await mcpConfigService.getHttpServer(mcpId, agentId);
+    const issuer = httpServer
+      ? deriveOAuthBaseUrl(httpServer.upstreamUrl)
+      : existing.issuer;
+    const endpoints = httpServer
+      ? resolveOAuthEndpoints(httpServer.upstreamUrl, httpServer.oauth)
+      : null;
+    const verificationUri =
+      endpoints?.verificationUri ?? `${issuer}/oauth/device`;
+    logger.info("Reusing existing pending device auth", {
+      mcpId,
+      agentId,
+      userId,
+    });
+    return {
+      userCode: existing.userCode || "",
+      verificationUri,
+      verificationUriComplete: existing.userCode
+        ? `${verificationUri}?user_code=${existing.userCode}`
+        : verificationUri,
+      expiresIn: Math.floor((existing.expiresAt - Date.now()) / 1000),
+    };
+  }
 
-	const httpServer = await mcpConfigService.getHttpServer(mcpId, agentId);
-	if (!httpServer) {
-		logger.warn("startDeviceAuth: httpServer not found", { mcpId, agentId });
-		return null;
-	}
+  const httpServer = await mcpConfigService.getHttpServer(mcpId, agentId);
+  if (!httpServer) {
+    logger.warn("startDeviceAuth: httpServer not found", { mcpId, agentId });
+    return null;
+  }
 
-	const endpoints = resolveOAuthEndpoints(
-		httpServer.upstreamUrl,
+  const endpoints = resolveOAuthEndpoints(
+    httpServer.upstreamUrl,
 		httpServer.oauth,
-	);
+  );
 
-	// Resolve client: use explicit config clientId, or cached registration, or register new
-	let client: StoredClient | null = null;
+  // Resolve client: use explicit config clientId, or cached registration, or register new
+  let client: StoredClient | null = null;
 
-	if (endpoints.clientId) {
-		// Config provides a pre-registered client — skip dynamic registration
-		client = {
-			clientId: endpoints.clientId,
-			clientSecret: endpoints.clientSecret,
-		};
-		logger.info("Using pre-registered OAuth client from config", {
-			mcpId,
-			clientId: endpoints.clientId,
-		});
-	} else {
-		// Check cached client registration
-		client = await getSecretJson<StoredClient>(
-			secretStore,
-			clientCacheName(mcpId),
+  if (endpoints.clientId) {
+    // Config provides a pre-registered client — skip dynamic registration
+    client = {
+      clientId: endpoints.clientId,
+      clientSecret: endpoints.clientSecret,
+    };
+    logger.info("Using pre-registered OAuth client from config", {
+      mcpId,
+      clientId: endpoints.clientId,
+    });
+  } else {
+    // Check cached client registration
+    client = await getSecretJson<StoredClient>(
+      secretStore,
+      clientCacheName(mcpId),
 			{ mcpId, scope: "device-client" },
-		);
+    );
 
-		// Register a new client if needed
-		if (!client) {
-			const regResponse = await fetch(endpoints.registrationUrl, {
-				method: "POST",
-				headers: { "Content-Type": "application/json" },
-				body: JSON.stringify({
-					grant_types: [DEVICE_CODE_GRANT_TYPE, "refresh_token"],
-					token_endpoint_auth_method: "none",
-					client_name: "Lobu Gateway Device Auth",
-					scope: endpoints.scope,
-				}),
-			});
+    // Register a new client if needed
+    if (!client) {
+      const regResponse = await fetch(endpoints.registrationUrl, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          grant_types: [DEVICE_CODE_GRANT_TYPE, "refresh_token"],
+          token_endpoint_auth_method: "none",
+          client_name: "Lobu Gateway Device Auth",
+          scope: endpoints.scope,
+        }),
+      });
 
-			if (!regResponse.ok) return null;
+      if (!regResponse.ok) return null;
 
-			const registration = (await regResponse.json()) as {
-				client_id: string;
-				client_secret?: string;
-			};
+      const registration = (await regResponse.json()) as {
+        client_id: string;
+        client_secret?: string;
+      };
 
-			client = {
-				clientId: registration.client_id,
-				clientSecret: registration.client_secret,
-			};
+      client = {
+        clientId: registration.client_id,
+        clientSecret: registration.client_secret,
+      };
 
-			await putSecretJson(secretStore, clientCacheName(mcpId), client);
-		}
-	}
+      await putSecretJson(secretStore, clientCacheName(mcpId), client);
+    }
+  }
 
-	const deviceCodeClient = new GenericDeviceCodeClient({
-		clientId: client.clientId,
-		clientSecret: client.clientSecret,
-		tokenUrl: endpoints.tokenUrl,
-		deviceAuthorizationUrl: endpoints.deviceAuthorizationUrl,
-		scope: endpoints.scope,
-		resource: endpoints.resource,
-		tokenEndpointAuthMethod: client.clientSecret
-			? "client_secret_post"
-			: "none",
-	});
+  const deviceCodeClient = new GenericDeviceCodeClient({
+    clientId: client.clientId,
+    clientSecret: client.clientSecret,
+    tokenUrl: endpoints.tokenUrl,
+    deviceAuthorizationUrl: endpoints.deviceAuthorizationUrl,
+    scope: endpoints.scope,
+    resource: endpoints.resource,
+    tokenEndpointAuthMethod: client.clientSecret
+      ? "client_secret_post"
+      : "none",
+  });
 
-	const started = await deviceCodeClient.requestDeviceCode();
+  const started = await deviceCodeClient.requestDeviceCode();
 
-	const deviceState: StoredDeviceAuth = {
-		deviceCode: started.deviceAuthId,
-		userCode: started.userCode,
-		clientId: client.clientId,
-		clientSecret: client.clientSecret,
-		interval: started.interval,
-		expiresAt: Date.now() + started.expiresIn * 1000,
-		tokenUrl: endpoints.tokenUrl,
-		issuer: deriveOAuthBaseUrl(httpServer.upstreamUrl),
-		deviceAuthorizationUrl: endpoints.deviceAuthorizationUrl,
-		resource: endpoints.resource,
-		scope: endpoints.scope,
-	};
+  const deviceState: StoredDeviceAuth = {
+    deviceCode: started.deviceAuthId,
+    userCode: started.userCode,
+    clientId: client.clientId,
+    clientSecret: client.clientSecret,
+    interval: started.interval,
+    expiresAt: Date.now() + started.expiresIn * 1000,
+    tokenUrl: endpoints.tokenUrl,
+    issuer: deriveOAuthBaseUrl(httpServer.upstreamUrl),
+    deviceAuthorizationUrl: endpoints.deviceAuthorizationUrl,
+    resource: endpoints.resource,
+    scope: endpoints.scope,
+  };
 
-	await putSecretJson(
-		secretStore,
-		deviceAuthName(agentId, userId, mcpId),
-		deviceState,
+  await putSecretJson(
+    secretStore,
+    deviceAuthName(agentId, userId, mcpId),
+    deviceState,
 		started.expiresIn,
-	);
+  );
 
-	logger.info("Device auth started (auto)", { mcpId, agentId, userId });
+  logger.info("Device auth started (auto)", { mcpId, agentId, userId });
 
-	return {
-		userCode: started.userCode,
-		verificationUri: started.verificationUri,
-		verificationUriComplete: started.verificationUriComplete,
-		expiresIn: started.expiresIn,
-	};
+  return {
+    userCode: started.userCode,
+    verificationUri: started.verificationUri,
+    verificationUriComplete: started.verificationUriComplete,
+    expiresIn: started.expiresIn,
+  };
 }
 
 export function createDeviceAuthRoutes(
 	config: DeviceAuthConfig,
 ): Hono<WorkerContext> {
-	const { mcpConfigService } = config;
-	const router = new Hono<WorkerContext>();
+  const { mcpConfigService } = config;
+  const router = new Hono<WorkerContext>();
 
 	router.use("/internal/device-auth/*", authenticateWorker, async (c, next) => {
 		const worker = getVerifiedWorker(c);
 		return runWithWorkerOrgContext(worker, () => next());
 	});
 
-	// POST /internal/device-auth/start
+  // POST /internal/device-auth/start
 	router.post("/internal/device-auth/start", async (c) => {
-		const body = await c.req.json<{ mcpId: string }>();
-		const mcpId = body?.mcpId;
-		if (!mcpId) {
-			return errorResponse(c, "Missing required field: mcpId", 400);
-		}
+    const body = await c.req.json<{ mcpId: string }>();
+    const mcpId = body?.mcpId;
+    if (!mcpId) {
+      return errorResponse(c, "Missing required field: mcpId", 400);
+    }
 
-		const worker = getVerifiedWorker(c);
-		const agentId = worker.agentId || worker.userId;
-		const userId = worker.userId;
+    const worker = getVerifiedWorker(c);
+    const agentId = worker.agentId || worker.userId;
+    const userId = worker.userId;
 
-		try {
-			const result = await startDeviceAuth(
-				config.secretStore,
-				mcpConfigService,
-				mcpId,
-				agentId,
+    try {
+      const result = await startDeviceAuth(
+        config.secretStore,
+        mcpConfigService,
+        mcpId,
+        agentId,
 				userId,
-			);
+      );
 
-			if (!result) {
-				return errorResponse(
-					c,
-					`MCP server '${mcpId}' not found or client registration failed`,
+      if (!result) {
+        return errorResponse(
+          c,
+          `MCP server '${mcpId}' not found or client registration failed`,
 					404,
-				);
-			}
+        );
+      }
 
-			return c.json(result);
-		} catch (error) {
-			logger.error("Failed to start device auth", {
-				mcpId,
-				error: error instanceof Error ? error.message : String(error),
-				stack: error instanceof Error ? error.stack : undefined,
-			});
-			return errorResponse(c, "Failed to start device authentication", 500);
-		}
-	});
+      return c.json(result);
+    } catch (error) {
+      logger.error("Failed to start device auth", {
+        mcpId,
+        error: error instanceof Error ? error.message : String(error),
+        stack: error instanceof Error ? error.stack : undefined,
+      });
+      return errorResponse(c, "Failed to start device authentication", 500);
+    }
+  });
 
-	// POST /internal/device-auth/poll
+  // POST /internal/device-auth/poll
 	router.post("/internal/device-auth/poll", async (c) => {
-		const body = await c.req.json<{ mcpId: string }>();
-		const mcpId = body?.mcpId;
-		if (!mcpId) {
-			return errorResponse(c, "Missing required field: mcpId", 400);
-		}
+    const body = await c.req.json<{ mcpId: string }>();
+    const mcpId = body?.mcpId;
+    if (!mcpId) {
+      return errorResponse(c, "Missing required field: mcpId", 400);
+    }
 
-		const worker = getVerifiedWorker(c);
-		const agentId = worker.agentId || worker.userId;
-		const userId = worker.userId;
+    const worker = getVerifiedWorker(c);
+    const agentId = worker.agentId || worker.userId;
+    const userId = worker.userId;
 
-		const deviceState = await getSecretJson<StoredDeviceAuth>(
-			config.secretStore,
-			deviceAuthName(agentId, userId, mcpId),
+    const deviceState = await getSecretJson<StoredDeviceAuth>(
+      config.secretStore,
+      deviceAuthName(agentId, userId, mcpId),
 			{ agentId, userId, mcpId, scope: "device-auth" },
-		);
-		if (!deviceState) {
-			return c.json(
-				{
-					status: "error",
-					message: "No device auth in progress. Call start first.",
-				},
+    );
+    if (!deviceState) {
+      return c.json(
+        {
+          status: "error",
+          message: "No device auth in progress. Call start first.",
+        },
 				400,
-			);
-		}
+      );
+    }
 
-		if (Date.now() > deviceState.expiresAt) {
-			await deleteSecretJson(
-				config.secretStore,
-				deviceAuthName(agentId, userId, mcpId),
+    if (Date.now() > deviceState.expiresAt) {
+      await deleteSecretJson(
+        config.secretStore,
+        deviceAuthName(agentId, userId, mcpId),
 				{ agentId, userId, mcpId, scope: "device-auth" },
-			);
-			return c.json(
-				{ status: "error", message: "Device code expired. Start again." },
+      );
+      return c.json(
+        { status: "error", message: "Device code expired. Start again." },
 				400,
-			);
-		}
+      );
+    }
 
-		try {
-			const deviceCodeClient = new GenericDeviceCodeClient({
-				clientId: deviceState.clientId,
-				clientSecret: deviceState.clientSecret,
-				tokenUrl: deviceState.tokenUrl,
-				deviceAuthorizationUrl:
-					deviceState.deviceAuthorizationUrl ??
-					`${deviceState.issuer}/oauth/device_authorization`,
-				scope: deviceState.scope ?? DEFAULT_MCP_DEVICE_SCOPE,
-				resource: deviceState.resource,
-				tokenEndpointAuthMethod: deviceState.clientSecret
-					? "client_secret_post"
-					: "none",
-			});
+    try {
+      const deviceCodeClient = new GenericDeviceCodeClient({
+        clientId: deviceState.clientId,
+        clientSecret: deviceState.clientSecret,
+        tokenUrl: deviceState.tokenUrl,
+        deviceAuthorizationUrl:
+          deviceState.deviceAuthorizationUrl ??
+          `${deviceState.issuer}/oauth/device_authorization`,
+        scope: deviceState.scope ?? DEFAULT_MCP_DEVICE_SCOPE,
+        resource: deviceState.resource,
+        tokenEndpointAuthMethod: deviceState.clientSecret
+          ? "client_secret_post"
+          : "none",
+      });
 
-			const pollResult = await deviceCodeClient.pollForToken(
-				deviceState.deviceCode,
+      const pollResult = await deviceCodeClient.pollForToken(
+        deviceState.deviceCode,
 				deviceState.interval,
-			);
+      );
 
-			if (pollResult.status === "pending") {
-				// Update interval if slow_down was received
-				if (
-					pollResult.interval &&
-					pollResult.interval !== deviceState.interval
-				) {
-					deviceState.interval = pollResult.interval;
-					const ttl = Math.max(
-						Math.floor((deviceState.expiresAt - Date.now()) / 1000),
+      if (pollResult.status === "pending") {
+        // Update interval if slow_down was received
+        if (
+          pollResult.interval &&
+          pollResult.interval !== deviceState.interval
+        ) {
+          deviceState.interval = pollResult.interval;
+          const ttl = Math.max(
+            Math.floor((deviceState.expiresAt - Date.now()) / 1000),
 						10,
-					);
-					await putSecretJson(
-						config.secretStore,
-						deviceAuthName(agentId, userId, mcpId),
-						deviceState,
+          );
+          await putSecretJson(
+            config.secretStore,
+            deviceAuthName(agentId, userId, mcpId),
+            deviceState,
 						ttl,
-					);
-				}
-				return c.json({ status: "pending" });
-			}
+          );
+        }
+        return c.json({ status: "pending" });
+      }
 
-			if (pollResult.status === "error") {
-				await deleteSecretJson(
-					config.secretStore,
-					deviceAuthName(agentId, userId, mcpId),
+      if (pollResult.status === "error") {
+        await deleteSecretJson(
+          config.secretStore,
+          deviceAuthName(agentId, userId, mcpId),
 					{ agentId, userId, mcpId, scope: "device-auth" },
-				);
-				return c.json({ status: "error", message: pollResult.error });
-			}
+        );
+        return c.json({ status: "error", message: pollResult.error });
+      }
 
-			// Success — store credential and clean up device auth state
-			const { credentials } = pollResult;
-			const storedCred: StoredCredential = {
-				accessToken: credentials.accessToken,
-				refreshToken: credentials.refreshToken,
-				expiresAt: credentials.expiresAt,
-				clientId: deviceState.clientId,
-				clientSecret: deviceState.clientSecret,
-				tokenUrl: deviceState.tokenUrl,
-				resource: deviceState.resource,
-			};
+      // Success — store credential and clean up device auth state
+      const { credentials } = pollResult;
+      const storedCred: StoredCredential = {
+        accessToken: credentials.accessToken,
+        refreshToken: credentials.refreshToken,
+        expiresAt: credentials.expiresAt,
+        clientId: deviceState.clientId,
+        clientSecret: deviceState.clientSecret,
+        tokenUrl: deviceState.tokenUrl,
+        resource: deviceState.resource,
+      };
 
-			await storeCredential(
-				config.secretStore,
-				agentId,
-				userId,
-				mcpId,
+      await storeCredential(
+        config.secretStore,
+        agentId,
+        userId,
+        mcpId,
 				storedCred,
-			);
-			await deleteSecretJson(
-				config.secretStore,
-				deviceAuthName(agentId, userId, mcpId),
+      );
+      await deleteSecretJson(
+        config.secretStore,
+        deviceAuthName(agentId, userId, mcpId),
 				{ agentId, userId, mcpId, scope: "device-auth" },
-			);
+      );
 
-			logger.info("Device auth completed", { mcpId, agentId, userId });
-			return c.json({ status: "complete" });
-		} catch (error) {
-			logger.error("Failed to poll device auth", { mcpId, error });
-			return c.json(
-				{ status: "error", message: "Failed to poll device auth" },
+      logger.info("Device auth completed", { mcpId, agentId, userId });
+      return c.json({ status: "complete" });
+    } catch (error) {
+      logger.error("Failed to poll device auth", { mcpId, error });
+      return c.json(
+        { status: "error", message: "Failed to poll device auth" },
 				500,
-			);
-		}
-	});
+      );
+    }
+  });
 
-	// GET /internal/device-auth/status?mcpId=lobu
+  // GET /internal/device-auth/status?mcpId=lobu
 	router.get("/internal/device-auth/status", async (c) => {
-		const mcpId = c.req.query("mcpId");
-		if (!mcpId) {
-			return errorResponse(c, "Missing required query param: mcpId", 400);
-		}
+    const mcpId = c.req.query("mcpId");
+    if (!mcpId) {
+      return errorResponse(c, "Missing required query param: mcpId", 400);
+    }
 
-		const worker = getVerifiedWorker(c);
-		const agentId = worker.agentId || worker.userId;
-		const userId = worker.userId;
+    const worker = getVerifiedWorker(c);
+    const agentId = worker.agentId || worker.userId;
+    const userId = worker.userId;
 
-		const credential = await getStoredCredential(
-			config.secretStore,
-			agentId,
-			userId,
+    const credential = await getStoredCredential(
+      config.secretStore,
+      agentId,
+      userId,
 			mcpId,
-		);
-		return c.json({ authenticated: !!credential });
-	});
+    );
+    return c.json({ authenticated: !!credential });
+  });
 
-	// DELETE /internal/device-auth/credential?mcpId=lobu
-	// Logout: revoke a stored credential + purge the underlying secret.
+  // DELETE /internal/device-auth/credential?mcpId=lobu
+  // Logout: revoke a stored credential + purge the underlying secret.
 	router.delete("/internal/device-auth/credential", async (c) => {
-		const mcpId = c.req.query("mcpId");
-		if (!mcpId) {
-			return errorResponse(c, "Missing required query param: mcpId", 400);
-		}
+      const mcpId = c.req.query("mcpId");
+      if (!mcpId) {
+        return errorResponse(c, "Missing required query param: mcpId", 400);
+      }
 
-		const worker = getVerifiedWorker(c);
-		const agentId = worker.agentId || worker.userId;
-		const userId = worker.userId;
+      const worker = getVerifiedWorker(c);
+      const agentId = worker.agentId || worker.userId;
+      const userId = worker.userId;
 
-		const deleted = await deleteCredential(
-			config.secretStore,
-			agentId,
-			userId,
+      const deleted = await deleteCredential(
+        config.secretStore,
+        agentId,
+        userId,
 			mcpId,
-		);
-		return c.json({ deleted });
+      );
+      return c.json({ deleted });
 	});
 
-	logger.debug("Device auth routes registered");
-	return router;
+  logger.debug("Device auth routes registered");
+  return router;
 }

--- a/packages/server/src/gateway/routes/internal/device-auth.ts
+++ b/packages/server/src/gateway/routes/internal/device-auth.ts
@@ -1,12 +1,13 @@
-import { createLogger, type McpOAuthConfig } from "@lobu/core";
+import { createLogger, type McpOAuthConfig, type SecretRef } from "@lobu/core";
 import { Hono } from "hono";
 import { DEFAULT_MCP_DEVICE_SCOPE } from "../../../auth/oauth/scopes.js";
 import {
-  buildRefreshRequest,
-  parseTokenRefreshResponse,
+	buildRefreshRequest,
+	parseTokenRefreshResponse,
 } from "../../../auth/oauth/token-refresh.js";
 import { GenericDeviceCodeClient } from "../../auth/external/device-code-client.js";
 import type { McpConfigService } from "../../auth/mcp/config-service.js";
+import { runWithWorkerOrgContext } from "../../auth/mcp/proxy-shared.js";
 import type { WritableSecretStore } from "../../secrets/index.js";
 import { errorResponse, getVerifiedWorker } from "../shared/helpers.js";
 import { authenticateWorker } from "./middleware.js";
@@ -16,131 +17,131 @@ const logger = createLogger("device-auth");
 const DEVICE_CODE_GRANT_TYPE = "urn:ietf:params:oauth:grant-type:device_code";
 
 interface StoredCredential {
-  accessToken: string;
-  refreshToken?: string;
-  expiresAt: number;
-  clientId: string;
-  clientSecret?: string;
-  tokenUrl: string;
-  /** RFC 8707 resource indicator, included in refresh requests. */
-  resource?: string;
-  /**
-   * How to authenticate to the token endpoint on refresh.
-   * - `none` — public PKCE client, send no secret.
-   * - `client_secret_basic` — send secret via HTTP Basic header (RFC 6749 §2.3.1 default).
-   * - `client_secret_post` — send secret in form body.
-   *
-   * Omitted → legacy device-code behavior (secret in body, JSON content-type).
-   */
-  tokenEndpointAuthMethod?:
-    | "none"
-    | "client_secret_basic"
-    | "client_secret_post";
+	accessToken: string;
+	refreshToken?: string;
+	expiresAt: number;
+	clientId: string;
+	clientSecret?: string;
+	tokenUrl: string;
+	/** RFC 8707 resource indicator, included in refresh requests. */
+	resource?: string;
+	/**
+	 * How to authenticate to the token endpoint on refresh.
+	 * - `none` — public PKCE client, send no secret.
+	 * - `client_secret_basic` — send secret via HTTP Basic header (RFC 6749 §2.3.1 default).
+	 * - `client_secret_post` — send secret in form body.
+	 *
+	 * Omitted → legacy device-code behavior (secret in body, JSON content-type).
+	 */
+	tokenEndpointAuthMethod?:
+		| "none"
+		| "client_secret_basic"
+		| "client_secret_post";
 }
 
 interface StoredDeviceAuth {
-  deviceCode: string;
-  userCode?: string;
-  clientId: string;
-  clientSecret?: string;
-  interval: number;
-  expiresAt: number;
-  tokenUrl: string;
-  issuer: string;
-  /** Stored so poll/complete can reconstruct the client without re-deriving. */
-  deviceAuthorizationUrl?: string;
-  /** RFC 8707 resource indicator. */
-  resource?: string;
-  /** Custom scopes from oauth config. */
-  scope?: string;
+	deviceCode: string;
+	userCode?: string;
+	clientId: string;
+	clientSecret?: string;
+	interval: number;
+	expiresAt: number;
+	tokenUrl: string;
+	issuer: string;
+	/** Stored so poll/complete can reconstruct the client without re-deriving. */
+	deviceAuthorizationUrl?: string;
+	/** RFC 8707 resource indicator. */
+	resource?: string;
+	/** Custom scopes from oauth config. */
+	scope?: string;
 }
 
 interface StoredClient {
-  clientId: string;
-  clientSecret?: string;
+	clientId: string;
+	clientSecret?: string;
 }
 
 interface DeviceAuthConfig {
-  mcpConfigService: McpConfigService;
-  secretStore: WritableSecretStore;
+	mcpConfigService: McpConfigService;
+	secretStore: WritableSecretStore;
 }
 
 interface ResolvedOAuthEndpoints {
-  registrationUrl: string;
-  deviceAuthorizationUrl: string;
-  tokenUrl: string;
-  verificationUri: string;
-  scope: string;
-  clientId?: string;
-  clientSecret?: string;
-  resource?: string;
+	registrationUrl: string;
+	deviceAuthorizationUrl: string;
+	tokenUrl: string;
+	verificationUri: string;
+	scope: string;
+	clientId?: string;
+	clientSecret?: string;
+	resource?: string;
 }
 
 /** Read a JSON payload directly from the secret store. */
 async function getSecretJson<T>(
-  secretStore: WritableSecretStore,
-  name: string,
-  context: Record<string, unknown>
+	secretStore: WritableSecretStore,
+	name: string,
+	context: Record<string, unknown>,
 ): Promise<T | null> {
-  // The secret store's `get` accepts a SecretRef; we always store under the
-  // default `secret://` scheme so the ref form is mechanical.
-  const ref = `secret://${encodeURIComponent(name)}` as const;
-  const value = await secretStore.get(ref as any);
-  if (!value) return null;
-  try {
-    return JSON.parse(value) as T;
-  } catch (error) {
-    logger.warn("Failed to parse JSON payload from secret store", {
-      name,
-      ...context,
-      error: error instanceof Error ? error.message : String(error),
-    });
-    return null;
-  }
+	// The secret store's `get` accepts a SecretRef; we always store under the
+	// default `secret://` scheme so the ref form is mechanical.
+	const ref = `secret://${encodeURIComponent(name)}` as SecretRef;
+	const value = await secretStore.get(ref);
+	if (!value) return null;
+	try {
+		return JSON.parse(value) as T;
+	} catch (error) {
+		logger.warn("Failed to parse JSON payload from secret store", {
+			name,
+			...context,
+			error: error instanceof Error ? error.message : String(error),
+		});
+		return null;
+	}
 }
 
 async function putSecretJson<T>(
-  secretStore: WritableSecretStore,
-  name: string,
-  value: T,
-  ttlSeconds?: number
+	secretStore: WritableSecretStore,
+	name: string,
+	value: T,
+	ttlSeconds?: number,
 ): Promise<void> {
-  await secretStore.put(name, JSON.stringify(value), { ttlSeconds });
+	await secretStore.put(name, JSON.stringify(value), { ttlSeconds });
 }
 
 async function deleteSecretJson(
-  secretStore: WritableSecretStore,
-  name: string,
-  _context: Record<string, unknown>
+	secretStore: WritableSecretStore,
+	name: string,
+	_context: Record<string, unknown>,
 ): Promise<boolean> {
-  // delete() is idempotent for the underlying store; we don't know if a row
-  // existed before, but for cleanup that doesn't matter.
-  try {
-    await secretStore.delete(name);
-    return true;
-  } catch {
-    return false;
-  }
+	// delete() is idempotent for the underlying store; we don't know if a row
+	// existed before, but for cleanup that doesn't matter.
+	try {
+		await secretStore.delete(name);
+		return true;
+	} catch {
+		return false;
+	}
 }
 
 function credentialName(
-  agentId: string,
-  userId: string,
-  mcpId: string
+	agentId: string,
+	userId: string,
+	mcpId: string,
 ): string {
-  return `mcp-auth/${agentId}/${userId}/${mcpId}/credential`;
+	return `mcp-auth/${agentId}/${userId}/${mcpId}/credential`;
 }
 
 function deviceAuthName(
-  agentId: string,
-  userId: string,
-  mcpId: string
+	agentId: string,
+	userId: string,
+	mcpId: string,
 ): string {
-  return `mcp-auth/${agentId}/${userId}/${mcpId}/device-auth`;
+	return `mcp-auth/${agentId}/${userId}/${mcpId}/device-auth`;
 }
 
 function clientCacheName(mcpId: string): string {
-  return `mcp-auth/clients/${mcpId}/registration`;
+	return `mcp-auth/clients/${mcpId}/registration`;
 }
 
 /**
@@ -152,31 +153,31 @@ const refreshLocks = new Map<string, number>();
 const REFRESH_LOCK_TTL_MS = 30_000;
 
 function tryAcquireRefreshLock(
-  agentId: string,
-  userId: string,
-  mcpId: string
+	agentId: string,
+	userId: string,
+	mcpId: string,
 ): boolean {
-  const key = `${agentId}:${userId}:${mcpId}`;
-  const expiresAt = refreshLocks.get(key);
-  if (expiresAt && expiresAt > Date.now()) return false;
-  refreshLocks.set(key, Date.now() + REFRESH_LOCK_TTL_MS);
-  return true;
+	const key = `${agentId}:${userId}:${mcpId}`;
+	const expiresAt = refreshLocks.get(key);
+	if (expiresAt && expiresAt > Date.now()) return false;
+	refreshLocks.set(key, Date.now() + REFRESH_LOCK_TTL_MS);
+	return true;
 }
 
 function releaseRefreshLock(
-  agentId: string,
-  userId: string,
-  mcpId: string
+	agentId: string,
+	userId: string,
+	mcpId: string,
 ): void {
-  refreshLocks.delete(`${agentId}:${userId}:${mcpId}`);
+	refreshLocks.delete(`${agentId}:${userId}:${mcpId}`);
 }
 
 function deriveOAuthBaseUrl(upstreamUrl: string): string {
-  const url = new URL(upstreamUrl);
-  url.pathname = "/";
-  url.search = "";
-  url.hash = "";
-  return url.toString().replace(/\/$/, "");
+	const url = new URL(upstreamUrl);
+	url.pathname = "/";
+	url.search = "";
+	url.hash = "";
+	return url.toString().replace(/\/$/, "");
 }
 
 /**
@@ -184,49 +185,49 @@ function deriveOAuthBaseUrl(upstreamUrl: string): string {
  * auto-derived endpoints from the MCP server's URL origin.
  */
 function resolveOAuthEndpoints(
-  upstreamUrl: string,
-  oauth?: McpOAuthConfig
+	upstreamUrl: string,
+	oauth?: McpOAuthConfig,
 ): ResolvedOAuthEndpoints {
-  const issuer = deriveOAuthBaseUrl(upstreamUrl);
-  return {
-    registrationUrl: oauth?.registrationUrl ?? `${issuer}/oauth/register`,
-    deviceAuthorizationUrl:
-      oauth?.deviceAuthorizationUrl ?? `${issuer}/oauth/device_authorization`,
-    tokenUrl: oauth?.tokenUrl ?? `${issuer}/oauth/token`,
-    verificationUri: oauth?.authUrl ?? `${issuer}/oauth/device`,
-    scope: oauth?.scopes?.join(" ") || DEFAULT_MCP_DEVICE_SCOPE,
-    clientId: oauth?.clientId,
-    clientSecret: oauth?.clientSecret,
-    resource: oauth?.resource,
-  };
+	const issuer = deriveOAuthBaseUrl(upstreamUrl);
+	return {
+		registrationUrl: oauth?.registrationUrl ?? `${issuer}/oauth/register`,
+		deviceAuthorizationUrl:
+			oauth?.deviceAuthorizationUrl ?? `${issuer}/oauth/device_authorization`,
+		tokenUrl: oauth?.tokenUrl ?? `${issuer}/oauth/token`,
+		verificationUri: oauth?.authUrl ?? `${issuer}/oauth/device`,
+		scope: oauth?.scopes?.join(" ") || DEFAULT_MCP_DEVICE_SCOPE,
+		clientId: oauth?.clientId,
+		clientSecret: oauth?.clientSecret,
+		resource: oauth?.resource,
+	};
 }
 
 export async function getStoredCredential(
-  secretStore: WritableSecretStore,
-  agentId: string,
-  userId: string,
-  mcpId: string
+	secretStore: WritableSecretStore,
+	agentId: string,
+	userId: string,
+	mcpId: string,
 ): Promise<StoredCredential | null> {
-  return getSecretJson<StoredCredential>(
-    secretStore,
-    credentialName(agentId, userId, mcpId),
-    { agentId, userId, mcpId }
-  );
+	return getSecretJson<StoredCredential>(
+		secretStore,
+		credentialName(agentId, userId, mcpId),
+		{ agentId, userId, mcpId },
+	);
 }
 
 async function storeCredential(
-  secretStore: WritableSecretStore,
-  agentId: string,
-  userId: string,
-  mcpId: string,
-  credential: StoredCredential
+	secretStore: WritableSecretStore,
+	agentId: string,
+	userId: string,
+	mcpId: string,
+	credential: StoredCredential,
 ): Promise<void> {
-  await putSecretJson(
-    secretStore,
-    credentialName(agentId, userId, mcpId),
-    credential,
-    90 * 24 * 60 * 60
-  );
+	await putSecretJson(
+		secretStore,
+		credentialName(agentId, userId, mcpId),
+		credential,
+		90 * 24 * 60 * 60,
+	);
 }
 
 /**
@@ -236,13 +237,13 @@ async function storeCredential(
  * internal helpers.
  */
 export async function storeCredentialForScope(
-  secretStore: WritableSecretStore,
-  agentId: string,
-  scopeKey: string,
-  mcpId: string,
-  credential: StoredCredential
+	secretStore: WritableSecretStore,
+	agentId: string,
+	scopeKey: string,
+	mcpId: string,
+	credential: StoredCredential,
 ): Promise<void> {
-  await storeCredential(secretStore, agentId, scopeKey, mcpId, credential);
+	await storeCredential(secretStore, agentId, scopeKey, mcpId, credential);
 }
 
 /**
@@ -252,94 +253,95 @@ export async function storeCredentialForScope(
  * scope, `channel-<id>` for channel scope.
  */
 export async function deleteCredential(
-  secretStore: WritableSecretStore,
-  agentId: string,
-  userId: string,
-  mcpId: string
+	secretStore: WritableSecretStore,
+	agentId: string,
+	userId: string,
+	mcpId: string,
 ): Promise<boolean> {
-  const deleted = await deleteSecretJson(
-    secretStore,
-    credentialName(agentId, userId, mcpId),
-    { agentId, userId, mcpId }
-  );
-  await deleteSecretJson(
-    secretStore,
-    deviceAuthName(agentId, userId, mcpId),
-    { agentId, userId, mcpId, scope: "device-auth" }
-  );
-  logger.info("Deleted MCP credential", { agentId, userId, mcpId });
-  return deleted;
+	const deleted = await deleteSecretJson(
+		secretStore,
+		credentialName(agentId, userId, mcpId),
+		{ agentId, userId, mcpId },
+	);
+	await deleteSecretJson(secretStore, deviceAuthName(agentId, userId, mcpId), {
+		agentId,
+		userId,
+		mcpId,
+		scope: "device-auth",
+	});
+	logger.info("Deleted MCP credential", { agentId, userId, mcpId });
+	return deleted;
 }
 
 export async function refreshCredential(
-  secretStore: WritableSecretStore,
-  agentId: string,
-  userId: string,
-  mcpId: string,
-  credential: StoredCredential
+	secretStore: WritableSecretStore,
+	agentId: string,
+	userId: string,
+	mcpId: string,
+	credential: StoredCredential,
 ): Promise<StoredCredential | null> {
-  if (!credential.refreshToken) return null;
+	if (!credential.refreshToken) return null;
 
-  const acquired = tryAcquireRefreshLock(agentId, userId, mcpId);
+	const acquired = tryAcquireRefreshLock(agentId, userId, mcpId);
 
-  if (!acquired) {
-    // Another request is refreshing — wait briefly and re-read
-    await new Promise((r) => setTimeout(r, 150));
-    return getStoredCredential(secretStore, agentId, userId, mcpId);
-  }
+	if (!acquired) {
+		// Another request is refreshing — wait briefly and re-read
+		await new Promise((r) => setTimeout(r, 150));
+		return getStoredCredential(secretStore, agentId, userId, mcpId);
+	}
 
-  try {
-    const { headers, body } = buildRefreshRequest({
-      profile: "mcp-credential",
-      clientId: credential.clientId,
-      clientSecret: credential.clientSecret,
-      refreshToken: credential.refreshToken,
-      authMethod: credential.tokenEndpointAuthMethod,
-      resource: credential.resource,
-    });
+	try {
+		const { headers, body } = buildRefreshRequest({
+			profile: "mcp-credential",
+			clientId: credential.clientId,
+			clientSecret: credential.clientSecret,
+			refreshToken: credential.refreshToken,
+			authMethod: credential.tokenEndpointAuthMethod,
+			resource: credential.resource,
+		});
 
-    const response = await fetch(credential.tokenUrl, {
-      method: "POST",
-      headers,
-      body,
-    });
+		const response = await fetch(credential.tokenUrl, {
+			method: "POST",
+			headers,
+			body,
+		});
 
-    if (!response.ok) {
-      logger.error("Token refresh failed", {
-        status: response.status,
-        agentId,
-        userId,
-        mcpId,
-      });
-      return null;
-    }
+		if (!response.ok) {
+			logger.error("Token refresh failed", {
+				status: response.status,
+				agentId,
+				userId,
+				mcpId,
+			});
+			return null;
+		}
 
-    const data = (await response.json()) as Record<string, unknown>;
-    const parsed = parseTokenRefreshResponse(data, {
-      previousRefreshToken: credential.refreshToken,
-    });
-    if (!parsed) return null;
+		const data = (await response.json()) as Record<string, unknown>;
+		const parsed = parseTokenRefreshResponse(data, {
+			previousRefreshToken: credential.refreshToken,
+		});
+		if (!parsed) return null;
 
-    const refreshed: StoredCredential = {
-      accessToken: parsed.accessToken,
-      refreshToken: parsed.refreshToken,
-      expiresAt: parsed.expiresAtMs,
-      clientId: credential.clientId,
-      clientSecret: credential.clientSecret,
-      tokenUrl: credential.tokenUrl,
-      resource: credential.resource,
-      tokenEndpointAuthMethod: credential.tokenEndpointAuthMethod,
-    };
+		const refreshed: StoredCredential = {
+			accessToken: parsed.accessToken,
+			refreshToken: parsed.refreshToken,
+			expiresAt: parsed.expiresAtMs,
+			clientId: credential.clientId,
+			clientSecret: credential.clientSecret,
+			tokenUrl: credential.tokenUrl,
+			resource: credential.resource,
+			tokenEndpointAuthMethod: credential.tokenEndpointAuthMethod,
+		};
 
-    await storeCredential(secretStore, agentId, userId, mcpId, refreshed);
-    logger.info("Token refreshed", { agentId, userId, mcpId });
-    return refreshed;
-  } catch (error) {
-    logger.error("Token refresh error", { error, agentId, userId, mcpId });
-    return null;
-  } finally {
-    releaseRefreshLock(agentId, userId, mcpId);
-  }
+		await storeCredential(secretStore, agentId, userId, mcpId, refreshed);
+		logger.info("Token refreshed", { agentId, userId, mcpId });
+		return refreshed;
+	} catch (error) {
+		logger.error("Token refresh error", { error, agentId, userId, mcpId });
+		return null;
+	} finally {
+		releaseRefreshLock(agentId, userId, mcpId);
+	}
 }
 
 /**
@@ -349,92 +351,92 @@ export async function refreshCredential(
  * Returns the access token on success, null if pending or no flow in progress.
  */
 export async function tryCompletePendingDeviceAuth(
-  secretStore: WritableSecretStore,
-  agentId: string,
-  userId: string,
-  mcpId: string
+	secretStore: WritableSecretStore,
+	agentId: string,
+	userId: string,
+	mcpId: string,
 ): Promise<string | null> {
-  const deviceState = await getSecretJson<StoredDeviceAuth>(
-    secretStore,
-    deviceAuthName(agentId, userId, mcpId),
-    { agentId, userId, mcpId, scope: "device-auth" }
-  );
-  if (!deviceState) return null;
+	const deviceState = await getSecretJson<StoredDeviceAuth>(
+		secretStore,
+		deviceAuthName(agentId, userId, mcpId),
+		{ agentId, userId, mcpId, scope: "device-auth" },
+	);
+	if (!deviceState) return null;
 
-  if (Date.now() > deviceState.expiresAt) {
-    await deleteSecretJson(
-      secretStore,
-      deviceAuthName(agentId, userId, mcpId),
-      { agentId, userId, mcpId, scope: "device-auth" }
-    );
-    return null;
-  }
+	if (Date.now() > deviceState.expiresAt) {
+		await deleteSecretJson(
+			secretStore,
+			deviceAuthName(agentId, userId, mcpId),
+			{ agentId, userId, mcpId, scope: "device-auth" },
+		);
+		return null;
+	}
 
-  try {
-    const deviceCodeClient = new GenericDeviceCodeClient({
-      clientId: deviceState.clientId,
-      clientSecret: deviceState.clientSecret,
-      tokenUrl: deviceState.tokenUrl,
-      deviceAuthorizationUrl:
-        deviceState.deviceAuthorizationUrl ??
-        `${deviceState.issuer}/oauth/device_authorization`,
-      scope: deviceState.scope ?? DEFAULT_MCP_DEVICE_SCOPE,
-      resource: deviceState.resource,
-      tokenEndpointAuthMethod: deviceState.clientSecret
-        ? "client_secret_post"
-        : "none",
-    });
+	try {
+		const deviceCodeClient = new GenericDeviceCodeClient({
+			clientId: deviceState.clientId,
+			clientSecret: deviceState.clientSecret,
+			tokenUrl: deviceState.tokenUrl,
+			deviceAuthorizationUrl:
+				deviceState.deviceAuthorizationUrl ??
+				`${deviceState.issuer}/oauth/device_authorization`,
+			scope: deviceState.scope ?? DEFAULT_MCP_DEVICE_SCOPE,
+			resource: deviceState.resource,
+			tokenEndpointAuthMethod: deviceState.clientSecret
+				? "client_secret_post"
+				: "none",
+		});
 
-    const pollResult = await deviceCodeClient.pollForToken(
-      deviceState.deviceCode,
-      deviceState.interval
-    );
+		const pollResult = await deviceCodeClient.pollForToken(
+			deviceState.deviceCode,
+			deviceState.interval,
+		);
 
-    if (pollResult.status === "pending") {
-      return null;
-    }
+		if (pollResult.status === "pending") {
+			return null;
+		}
 
-    if (pollResult.status === "error") {
-      await deleteSecretJson(
-        secretStore,
-        deviceAuthName(agentId, userId, mcpId),
-        { agentId, userId, mcpId, scope: "device-auth" }
-      );
-      return null;
-    }
+		if (pollResult.status === "error") {
+			await deleteSecretJson(
+				secretStore,
+				deviceAuthName(agentId, userId, mcpId),
+				{ agentId, userId, mcpId, scope: "device-auth" },
+			);
+			return null;
+		}
 
-    // Success — store credential and clean up
-    const { credentials } = pollResult;
-    const storedCred: StoredCredential = {
-      accessToken: credentials.accessToken,
-      refreshToken: credentials.refreshToken,
-      expiresAt: credentials.expiresAt,
-      clientId: deviceState.clientId,
-      clientSecret: deviceState.clientSecret,
-      tokenUrl: deviceState.tokenUrl,
-      resource: deviceState.resource,
-    };
+		// Success — store credential and clean up
+		const { credentials } = pollResult;
+		const storedCred: StoredCredential = {
+			accessToken: credentials.accessToken,
+			refreshToken: credentials.refreshToken,
+			expiresAt: credentials.expiresAt,
+			clientId: deviceState.clientId,
+			clientSecret: deviceState.clientSecret,
+			tokenUrl: deviceState.tokenUrl,
+			resource: deviceState.resource,
+		};
 
-    await storeCredential(secretStore, agentId, userId, mcpId, storedCred);
-    await deleteSecretJson(
-      secretStore,
-      deviceAuthName(agentId, userId, mcpId),
-      { agentId, userId, mcpId, scope: "device-auth" }
-    );
+		await storeCredential(secretStore, agentId, userId, mcpId, storedCred);
+		await deleteSecretJson(
+			secretStore,
+			deviceAuthName(agentId, userId, mcpId),
+			{ agentId, userId, mcpId, scope: "device-auth" },
+		);
 
-    logger.info("Device auth auto-completed by proxy", {
-      mcpId,
-      agentId,
-      userId,
-    });
-    return credentials.accessToken;
-  } catch (error) {
-    logger.warn("Auto-complete device auth failed", {
-      mcpId,
-      error: error instanceof Error ? error.message : String(error),
-    });
-    return null;
-  }
+		logger.info("Device auth auto-completed by proxy", {
+			mcpId,
+			agentId,
+			userId,
+		});
+		return credentials.accessToken;
+	} catch (error) {
+		logger.warn("Auto-complete device auth failed", {
+			mcpId,
+			error: error instanceof Error ? error.message : String(error),
+		});
+		return null;
+	}
 }
 
 /**
@@ -445,375 +447,376 @@ export async function tryCompletePendingDeviceAuth(
  * registration is skipped entirely.
  */
 export async function startDeviceAuth(
-  secretStore: WritableSecretStore,
-  mcpConfigService: {
-    getHttpServer: (
-      id: string,
-      agentId?: string
-    ) => Promise<{ upstreamUrl: string; oauth?: McpOAuthConfig } | undefined>;
-  },
-  mcpId: string,
-  agentId: string,
-  userId: string
+	secretStore: WritableSecretStore,
+	mcpConfigService: {
+		getHttpServer: (
+			id: string,
+			agentId?: string,
+		) => Promise<{ upstreamUrl: string; oauth?: McpOAuthConfig } | undefined>;
+	},
+	mcpId: string,
+	agentId: string,
+	userId: string,
 ): Promise<{
-  userCode: string;
-  verificationUri: string;
-  verificationUriComplete?: string;
-  expiresIn: number;
+	userCode: string;
+	verificationUri: string;
+	verificationUriComplete?: string;
+	expiresIn: number;
 } | null> {
-  // Reuse existing pending device auth flow if not expired
-  const existing = await getSecretJson<StoredDeviceAuth>(
-    secretStore,
-    deviceAuthName(agentId, userId, mcpId),
-    { agentId, userId, mcpId, scope: "device-auth" }
-  );
-  if (existing?.expiresAt && existing.expiresAt > Date.now()) {
-    const httpServer = await mcpConfigService.getHttpServer(mcpId, agentId);
-    const issuer = httpServer
-      ? deriveOAuthBaseUrl(httpServer.upstreamUrl)
-      : existing.issuer;
-    const endpoints = httpServer
-      ? resolveOAuthEndpoints(httpServer.upstreamUrl, httpServer.oauth)
-      : null;
-    const verificationUri =
-      endpoints?.verificationUri ?? `${issuer}/oauth/device`;
-    logger.info("Reusing existing pending device auth", {
-      mcpId,
-      agentId,
-      userId,
-    });
-    return {
-      userCode: existing.userCode || "",
-      verificationUri,
-      verificationUriComplete: existing.userCode
-        ? `${verificationUri}?user_code=${existing.userCode}`
-        : verificationUri,
-      expiresIn: Math.floor((existing.expiresAt - Date.now()) / 1000),
-    };
-  }
+	// Reuse existing pending device auth flow if not expired
+	const existing = await getSecretJson<StoredDeviceAuth>(
+		secretStore,
+		deviceAuthName(agentId, userId, mcpId),
+		{ agentId, userId, mcpId, scope: "device-auth" },
+	);
+	if (existing?.expiresAt && existing.expiresAt > Date.now()) {
+		const httpServer = await mcpConfigService.getHttpServer(mcpId, agentId);
+		const issuer = httpServer
+			? deriveOAuthBaseUrl(httpServer.upstreamUrl)
+			: existing.issuer;
+		const endpoints = httpServer
+			? resolveOAuthEndpoints(httpServer.upstreamUrl, httpServer.oauth)
+			: null;
+		const verificationUri =
+			endpoints?.verificationUri ?? `${issuer}/oauth/device`;
+		logger.info("Reusing existing pending device auth", {
+			mcpId,
+			agentId,
+			userId,
+		});
+		return {
+			userCode: existing.userCode || "",
+			verificationUri,
+			verificationUriComplete: existing.userCode
+				? `${verificationUri}?user_code=${existing.userCode}`
+				: verificationUri,
+			expiresIn: Math.floor((existing.expiresAt - Date.now()) / 1000),
+		};
+	}
 
-  const httpServer = await mcpConfigService.getHttpServer(mcpId, agentId);
-  if (!httpServer) {
-    logger.warn("startDeviceAuth: httpServer not found", { mcpId, agentId });
-    return null;
-  }
+	const httpServer = await mcpConfigService.getHttpServer(mcpId, agentId);
+	if (!httpServer) {
+		logger.warn("startDeviceAuth: httpServer not found", { mcpId, agentId });
+		return null;
+	}
 
-  const endpoints = resolveOAuthEndpoints(
-    httpServer.upstreamUrl,
-    httpServer.oauth
-  );
+	const endpoints = resolveOAuthEndpoints(
+		httpServer.upstreamUrl,
+		httpServer.oauth,
+	);
 
-  // Resolve client: use explicit config clientId, or cached registration, or register new
-  let client: StoredClient | null = null;
+	// Resolve client: use explicit config clientId, or cached registration, or register new
+	let client: StoredClient | null = null;
 
-  if (endpoints.clientId) {
-    // Config provides a pre-registered client — skip dynamic registration
-    client = {
-      clientId: endpoints.clientId,
-      clientSecret: endpoints.clientSecret,
-    };
-    logger.info("Using pre-registered OAuth client from config", {
-      mcpId,
-      clientId: endpoints.clientId,
-    });
-  } else {
-    // Check cached client registration
-    client = await getSecretJson<StoredClient>(
-      secretStore,
-      clientCacheName(mcpId),
-      { mcpId, scope: "device-client" }
-    );
+	if (endpoints.clientId) {
+		// Config provides a pre-registered client — skip dynamic registration
+		client = {
+			clientId: endpoints.clientId,
+			clientSecret: endpoints.clientSecret,
+		};
+		logger.info("Using pre-registered OAuth client from config", {
+			mcpId,
+			clientId: endpoints.clientId,
+		});
+	} else {
+		// Check cached client registration
+		client = await getSecretJson<StoredClient>(
+			secretStore,
+			clientCacheName(mcpId),
+			{ mcpId, scope: "device-client" },
+		);
 
-    // Register a new client if needed
-    if (!client) {
-      const regResponse = await fetch(endpoints.registrationUrl, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          grant_types: [DEVICE_CODE_GRANT_TYPE, "refresh_token"],
-          token_endpoint_auth_method: "none",
-          client_name: "Lobu Gateway Device Auth",
-          scope: endpoints.scope,
-        }),
-      });
+		// Register a new client if needed
+		if (!client) {
+			const regResponse = await fetch(endpoints.registrationUrl, {
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({
+					grant_types: [DEVICE_CODE_GRANT_TYPE, "refresh_token"],
+					token_endpoint_auth_method: "none",
+					client_name: "Lobu Gateway Device Auth",
+					scope: endpoints.scope,
+				}),
+			});
 
-      if (!regResponse.ok) return null;
+			if (!regResponse.ok) return null;
 
-      const registration = (await regResponse.json()) as {
-        client_id: string;
-        client_secret?: string;
-      };
+			const registration = (await regResponse.json()) as {
+				client_id: string;
+				client_secret?: string;
+			};
 
-      client = {
-        clientId: registration.client_id,
-        clientSecret: registration.client_secret,
-      };
+			client = {
+				clientId: registration.client_id,
+				clientSecret: registration.client_secret,
+			};
 
-      await putSecretJson(secretStore, clientCacheName(mcpId), client);
-    }
-  }
+			await putSecretJson(secretStore, clientCacheName(mcpId), client);
+		}
+	}
 
-  const deviceCodeClient = new GenericDeviceCodeClient({
-    clientId: client.clientId,
-    clientSecret: client.clientSecret,
-    tokenUrl: endpoints.tokenUrl,
-    deviceAuthorizationUrl: endpoints.deviceAuthorizationUrl,
-    scope: endpoints.scope,
-    resource: endpoints.resource,
-    tokenEndpointAuthMethod: client.clientSecret
-      ? "client_secret_post"
-      : "none",
-  });
+	const deviceCodeClient = new GenericDeviceCodeClient({
+		clientId: client.clientId,
+		clientSecret: client.clientSecret,
+		tokenUrl: endpoints.tokenUrl,
+		deviceAuthorizationUrl: endpoints.deviceAuthorizationUrl,
+		scope: endpoints.scope,
+		resource: endpoints.resource,
+		tokenEndpointAuthMethod: client.clientSecret
+			? "client_secret_post"
+			: "none",
+	});
 
-  const started = await deviceCodeClient.requestDeviceCode();
+	const started = await deviceCodeClient.requestDeviceCode();
 
-  const deviceState: StoredDeviceAuth = {
-    deviceCode: started.deviceAuthId,
-    userCode: started.userCode,
-    clientId: client.clientId,
-    clientSecret: client.clientSecret,
-    interval: started.interval,
-    expiresAt: Date.now() + started.expiresIn * 1000,
-    tokenUrl: endpoints.tokenUrl,
-    issuer: deriveOAuthBaseUrl(httpServer.upstreamUrl),
-    deviceAuthorizationUrl: endpoints.deviceAuthorizationUrl,
-    resource: endpoints.resource,
-    scope: endpoints.scope,
-  };
+	const deviceState: StoredDeviceAuth = {
+		deviceCode: started.deviceAuthId,
+		userCode: started.userCode,
+		clientId: client.clientId,
+		clientSecret: client.clientSecret,
+		interval: started.interval,
+		expiresAt: Date.now() + started.expiresIn * 1000,
+		tokenUrl: endpoints.tokenUrl,
+		issuer: deriveOAuthBaseUrl(httpServer.upstreamUrl),
+		deviceAuthorizationUrl: endpoints.deviceAuthorizationUrl,
+		resource: endpoints.resource,
+		scope: endpoints.scope,
+	};
 
-  await putSecretJson(
-    secretStore,
-    deviceAuthName(agentId, userId, mcpId),
-    deviceState,
-    started.expiresIn
-  );
+	await putSecretJson(
+		secretStore,
+		deviceAuthName(agentId, userId, mcpId),
+		deviceState,
+		started.expiresIn,
+	);
 
-  logger.info("Device auth started (auto)", { mcpId, agentId, userId });
+	logger.info("Device auth started (auto)", { mcpId, agentId, userId });
 
-  return {
-    userCode: started.userCode,
-    verificationUri: started.verificationUri,
-    verificationUriComplete: started.verificationUriComplete,
-    expiresIn: started.expiresIn,
-  };
+	return {
+		userCode: started.userCode,
+		verificationUri: started.verificationUri,
+		verificationUriComplete: started.verificationUriComplete,
+		expiresIn: started.expiresIn,
+	};
 }
 
 export function createDeviceAuthRoutes(
-  config: DeviceAuthConfig
+	config: DeviceAuthConfig,
 ): Hono<WorkerContext> {
-  const { mcpConfigService } = config;
-  const router = new Hono<WorkerContext>();
+	const { mcpConfigService } = config;
+	const router = new Hono<WorkerContext>();
 
-  // POST /internal/device-auth/start
-  router.post("/internal/device-auth/start", authenticateWorker, async (c) => {
-    const body = await c.req.json<{ mcpId: string }>();
-    const mcpId = body?.mcpId;
-    if (!mcpId) {
-      return errorResponse(c, "Missing required field: mcpId", 400);
-    }
+	router.use("/internal/device-auth/*", authenticateWorker, async (c, next) => {
+		const worker = getVerifiedWorker(c);
+		return runWithWorkerOrgContext(worker, () => next());
+	});
 
-    const worker = getVerifiedWorker(c);
-    const agentId = worker.agentId || worker.userId;
-    const userId = worker.userId;
+	// POST /internal/device-auth/start
+	router.post("/internal/device-auth/start", async (c) => {
+		const body = await c.req.json<{ mcpId: string }>();
+		const mcpId = body?.mcpId;
+		if (!mcpId) {
+			return errorResponse(c, "Missing required field: mcpId", 400);
+		}
 
-    try {
-      const result = await startDeviceAuth(
-        config.secretStore,
-        mcpConfigService,
-        mcpId,
-        agentId,
-        userId
-      );
+		const worker = getVerifiedWorker(c);
+		const agentId = worker.agentId || worker.userId;
+		const userId = worker.userId;
 
-      if (!result) {
-        return errorResponse(
-          c,
-          `MCP server '${mcpId}' not found or client registration failed`,
-          404
-        );
-      }
+		try {
+			const result = await startDeviceAuth(
+				config.secretStore,
+				mcpConfigService,
+				mcpId,
+				agentId,
+				userId,
+			);
 
-      return c.json(result);
-    } catch (error) {
-      logger.error("Failed to start device auth", {
-        mcpId,
-        error: error instanceof Error ? error.message : String(error),
-        stack: error instanceof Error ? error.stack : undefined,
-      });
-      return errorResponse(c, "Failed to start device authentication", 500);
-    }
-  });
+			if (!result) {
+				return errorResponse(
+					c,
+					`MCP server '${mcpId}' not found or client registration failed`,
+					404,
+				);
+			}
 
-  // POST /internal/device-auth/poll
-  router.post("/internal/device-auth/poll", authenticateWorker, async (c) => {
-    const body = await c.req.json<{ mcpId: string }>();
-    const mcpId = body?.mcpId;
-    if (!mcpId) {
-      return errorResponse(c, "Missing required field: mcpId", 400);
-    }
+			return c.json(result);
+		} catch (error) {
+			logger.error("Failed to start device auth", {
+				mcpId,
+				error: error instanceof Error ? error.message : String(error),
+				stack: error instanceof Error ? error.stack : undefined,
+			});
+			return errorResponse(c, "Failed to start device authentication", 500);
+		}
+	});
 
-    const worker = getVerifiedWorker(c);
-    const agentId = worker.agentId || worker.userId;
-    const userId = worker.userId;
+	// POST /internal/device-auth/poll
+	router.post("/internal/device-auth/poll", async (c) => {
+		const body = await c.req.json<{ mcpId: string }>();
+		const mcpId = body?.mcpId;
+		if (!mcpId) {
+			return errorResponse(c, "Missing required field: mcpId", 400);
+		}
 
-    const deviceState = await getSecretJson<StoredDeviceAuth>(
-      config.secretStore,
-      deviceAuthName(agentId, userId, mcpId),
-      { agentId, userId, mcpId, scope: "device-auth" }
-    );
-    if (!deviceState) {
-      return c.json(
-        {
-          status: "error",
-          message: "No device auth in progress. Call start first.",
-        },
-        400
-      );
-    }
+		const worker = getVerifiedWorker(c);
+		const agentId = worker.agentId || worker.userId;
+		const userId = worker.userId;
 
-    if (Date.now() > deviceState.expiresAt) {
-      await deleteSecretJson(
-        config.secretStore,
-        deviceAuthName(agentId, userId, mcpId),
-        { agentId, userId, mcpId, scope: "device-auth" }
-      );
-      return c.json(
-        { status: "error", message: "Device code expired. Start again." },
-        400
-      );
-    }
+		const deviceState = await getSecretJson<StoredDeviceAuth>(
+			config.secretStore,
+			deviceAuthName(agentId, userId, mcpId),
+			{ agentId, userId, mcpId, scope: "device-auth" },
+		);
+		if (!deviceState) {
+			return c.json(
+				{
+					status: "error",
+					message: "No device auth in progress. Call start first.",
+				},
+				400,
+			);
+		}
 
-    try {
-      const deviceCodeClient = new GenericDeviceCodeClient({
-        clientId: deviceState.clientId,
-        clientSecret: deviceState.clientSecret,
-        tokenUrl: deviceState.tokenUrl,
-        deviceAuthorizationUrl:
-          deviceState.deviceAuthorizationUrl ??
-          `${deviceState.issuer}/oauth/device_authorization`,
-        scope: deviceState.scope ?? DEFAULT_MCP_DEVICE_SCOPE,
-        resource: deviceState.resource,
-        tokenEndpointAuthMethod: deviceState.clientSecret
-          ? "client_secret_post"
-          : "none",
-      });
+		if (Date.now() > deviceState.expiresAt) {
+			await deleteSecretJson(
+				config.secretStore,
+				deviceAuthName(agentId, userId, mcpId),
+				{ agentId, userId, mcpId, scope: "device-auth" },
+			);
+			return c.json(
+				{ status: "error", message: "Device code expired. Start again." },
+				400,
+			);
+		}
 
-      const pollResult = await deviceCodeClient.pollForToken(
-        deviceState.deviceCode,
-        deviceState.interval
-      );
+		try {
+			const deviceCodeClient = new GenericDeviceCodeClient({
+				clientId: deviceState.clientId,
+				clientSecret: deviceState.clientSecret,
+				tokenUrl: deviceState.tokenUrl,
+				deviceAuthorizationUrl:
+					deviceState.deviceAuthorizationUrl ??
+					`${deviceState.issuer}/oauth/device_authorization`,
+				scope: deviceState.scope ?? DEFAULT_MCP_DEVICE_SCOPE,
+				resource: deviceState.resource,
+				tokenEndpointAuthMethod: deviceState.clientSecret
+					? "client_secret_post"
+					: "none",
+			});
 
-      if (pollResult.status === "pending") {
-        // Update interval if slow_down was received
-        if (
-          pollResult.interval &&
-          pollResult.interval !== deviceState.interval
-        ) {
-          deviceState.interval = pollResult.interval;
-          const ttl = Math.max(
-            Math.floor((deviceState.expiresAt - Date.now()) / 1000),
-            10
-          );
-          await putSecretJson(
-            config.secretStore,
-            deviceAuthName(agentId, userId, mcpId),
-            deviceState,
-            ttl
-          );
-        }
-        return c.json({ status: "pending" });
-      }
+			const pollResult = await deviceCodeClient.pollForToken(
+				deviceState.deviceCode,
+				deviceState.interval,
+			);
 
-      if (pollResult.status === "error") {
-        await deleteSecretJson(
-          config.secretStore,
-          deviceAuthName(agentId, userId, mcpId),
-          { agentId, userId, mcpId, scope: "device-auth" }
-        );
-        return c.json({ status: "error", message: pollResult.error });
-      }
+			if (pollResult.status === "pending") {
+				// Update interval if slow_down was received
+				if (
+					pollResult.interval &&
+					pollResult.interval !== deviceState.interval
+				) {
+					deviceState.interval = pollResult.interval;
+					const ttl = Math.max(
+						Math.floor((deviceState.expiresAt - Date.now()) / 1000),
+						10,
+					);
+					await putSecretJson(
+						config.secretStore,
+						deviceAuthName(agentId, userId, mcpId),
+						deviceState,
+						ttl,
+					);
+				}
+				return c.json({ status: "pending" });
+			}
 
-      // Success — store credential and clean up device auth state
-      const { credentials } = pollResult;
-      const storedCred: StoredCredential = {
-        accessToken: credentials.accessToken,
-        refreshToken: credentials.refreshToken,
-        expiresAt: credentials.expiresAt,
-        clientId: deviceState.clientId,
-        clientSecret: deviceState.clientSecret,
-        tokenUrl: deviceState.tokenUrl,
-        resource: deviceState.resource,
-      };
+			if (pollResult.status === "error") {
+				await deleteSecretJson(
+					config.secretStore,
+					deviceAuthName(agentId, userId, mcpId),
+					{ agentId, userId, mcpId, scope: "device-auth" },
+				);
+				return c.json({ status: "error", message: pollResult.error });
+			}
 
-      await storeCredential(
-        config.secretStore,
-        agentId,
-        userId,
-        mcpId,
-        storedCred
-      );
-      await deleteSecretJson(
-        config.secretStore,
-        deviceAuthName(agentId, userId, mcpId),
-        { agentId, userId, mcpId, scope: "device-auth" }
-      );
+			// Success — store credential and clean up device auth state
+			const { credentials } = pollResult;
+			const storedCred: StoredCredential = {
+				accessToken: credentials.accessToken,
+				refreshToken: credentials.refreshToken,
+				expiresAt: credentials.expiresAt,
+				clientId: deviceState.clientId,
+				clientSecret: deviceState.clientSecret,
+				tokenUrl: deviceState.tokenUrl,
+				resource: deviceState.resource,
+			};
 
-      logger.info("Device auth completed", { mcpId, agentId, userId });
-      return c.json({ status: "complete" });
-    } catch (error) {
-      logger.error("Failed to poll device auth", { mcpId, error });
-      return c.json(
-        { status: "error", message: "Failed to poll device auth" },
-        500
-      );
-    }
-  });
+			await storeCredential(
+				config.secretStore,
+				agentId,
+				userId,
+				mcpId,
+				storedCred,
+			);
+			await deleteSecretJson(
+				config.secretStore,
+				deviceAuthName(agentId, userId, mcpId),
+				{ agentId, userId, mcpId, scope: "device-auth" },
+			);
 
-  // GET /internal/device-auth/status?mcpId=lobu
-  router.get("/internal/device-auth/status", authenticateWorker, async (c) => {
-    const mcpId = c.req.query("mcpId");
-    if (!mcpId) {
-      return errorResponse(c, "Missing required query param: mcpId", 400);
-    }
+			logger.info("Device auth completed", { mcpId, agentId, userId });
+			return c.json({ status: "complete" });
+		} catch (error) {
+			logger.error("Failed to poll device auth", { mcpId, error });
+			return c.json(
+				{ status: "error", message: "Failed to poll device auth" },
+				500,
+			);
+		}
+	});
 
-    const worker = getVerifiedWorker(c);
-    const agentId = worker.agentId || worker.userId;
-    const userId = worker.userId;
+	// GET /internal/device-auth/status?mcpId=lobu
+	router.get("/internal/device-auth/status", async (c) => {
+		const mcpId = c.req.query("mcpId");
+		if (!mcpId) {
+			return errorResponse(c, "Missing required query param: mcpId", 400);
+		}
 
-    const credential = await getStoredCredential(
-      config.secretStore,
-      agentId,
-      userId,
-      mcpId
-    );
-    return c.json({ authenticated: !!credential });
-  });
+		const worker = getVerifiedWorker(c);
+		const agentId = worker.agentId || worker.userId;
+		const userId = worker.userId;
 
-  // DELETE /internal/device-auth/credential?mcpId=lobu
-  // Logout: revoke a stored credential + purge the underlying secret.
-  router.delete(
-    "/internal/device-auth/credential",
-    authenticateWorker,
-    async (c) => {
-      const mcpId = c.req.query("mcpId");
-      if (!mcpId) {
-        return errorResponse(c, "Missing required query param: mcpId", 400);
-      }
+		const credential = await getStoredCredential(
+			config.secretStore,
+			agentId,
+			userId,
+			mcpId,
+		);
+		return c.json({ authenticated: !!credential });
+	});
 
-      const worker = getVerifiedWorker(c);
-      const agentId = worker.agentId || worker.userId;
-      const userId = worker.userId;
+	// DELETE /internal/device-auth/credential?mcpId=lobu
+	// Logout: revoke a stored credential + purge the underlying secret.
+	router.delete("/internal/device-auth/credential", async (c) => {
+		const mcpId = c.req.query("mcpId");
+		if (!mcpId) {
+			return errorResponse(c, "Missing required query param: mcpId", 400);
+		}
 
-      const deleted = await deleteCredential(
-        config.secretStore,
-        agentId,
-        userId,
-        mcpId
-      );
-      return c.json({ deleted });
-    }
-  );
+		const worker = getVerifiedWorker(c);
+		const agentId = worker.agentId || worker.userId;
+		const userId = worker.userId;
 
-  logger.debug("Device auth routes registered");
-  return router;
+		const deleted = await deleteCredential(
+			config.secretStore,
+			agentId,
+			userId,
+			mcpId,
+		);
+		return c.json({ deleted });
+	});
+
+	logger.debug("Device auth routes registered");
+	return router;
 }


### PR DESCRIPTION
## Summary
- Scope MCP credential reads and writes to the worker token organization across proxy, REST, direct discovery, approval execution, device auth, OAuth callback/start, and Slack connect/disconnect flows.
- Persist `organizationId` in OAuth state and pending tool invocations so delayed/resumed work resolves credentials in the same trusted org context.
- Fail closed when org context is missing so credential-writing/auth flows cannot fall back to an unscoped namespace.
- Harden credential refresh with an explicit org-context requirement and org-scoped refresh lock keys.
- Tighten approval decision validation and org-context test fixtures so unscoped credential access is caught.

## Test plan
- [x] `bun test packages/server/src/gateway/__tests__/mcp-proxy-org-context.test.ts packages/server/src/gateway/__tests__/mcp-oauth-org-context.test.ts packages/server/src/gateway/__tests__/interaction-bridge-action-handlers.test.ts packages/server/src/gateway/__tests__/interaction-bridge-slack-webhook.test.ts packages/server/src/gateway/__tests__/mcp-proxy-edge-cases.test.ts` (63 passing)
- [x] `bun run check`
- [x] `bun run typecheck`
- [x] Gemini CLI review: no blockers after strict org-context follow-up
- [x] Claude Code Opus review: summary-only gaps checked; refresh path and missing-org REST/proxy coverage added; OAuth state confirmed Postgres-backed

## Notes
No public docs update needed: this changes internal MCP credential scoping behavior and regression coverage, not user-facing configuration or API shape.
