### PR TITLE
feat(examples): derive subscription and trip views in personal-agent

### DIFF
--- a/examples/personal-agent/lobu.config.ts
+++ b/examples/personal-agent/lobu.config.ts
@@ -139,19 +139,91 @@ const asset = defineEntityType({
   },
 });
 
+const subscriptionBackingSql = `
+SELECT
+  s.id,
+  s.name,
+  s.slug,
+  CASE
+    WHEN s.last_seen_date >= s.data_as_of - interval '45 days' THEN 'active'
+    WHEN s.last_seen_date >= s.data_as_of - interval '120 days' THEN 'changed'
+    ELSE 'cancelled'
+  END AS status,
+  s.category,
+  s.currency,
+  s.frequency,
+  s.amount,
+  s.first_seen_date::text AS first_seen,
+  s.last_seen_date::text AS last_seen,
+  s.billing_day,
+  s.total_spent,
+  s.charge_count,
+  s.active_months
+FROM (
+  SELECT
+  'subscription:' || md5(tx.merchant_key || ':' || tx.currency) AS id,
+  regexp_replace(initcap(max(tx.merchant_name)), '\\s+', ' ', 'g') AS name,
+  'subscription-' || md5(tx.merchant_key || ':' || tx.currency) AS slug,
+  'subscription' AS category,
+  tx.currency,
+  CASE
+    WHEN count(*) <= count(distinct date_trunc('month', tx.occurred_at)) + 2 THEN 'monthly'
+    ELSE 'periodic'
+  END AS frequency,
+  round((array_agg(tx.amount ORDER BY tx.occurred_at DESC))[1], 2) AS amount,
+  min(tx.tx_date) AS first_seen_date,
+  max(tx.tx_date) AS last_seen_date,
+  round(avg(extract(day from tx.occurred_at)))::int AS billing_day,
+  round(sum(tx.amount), 2) AS total_spent,
+  count(*)::int AS charge_count,
+  count(distinct date_trunc('month', tx.occurred_at))::int AS active_months,
+  max(tx.data_as_of) AS data_as_of
+FROM (
+  SELECT
+    id,
+    occurred_at,
+    occurred_at::date AS tx_date,
+    max(occurred_at::date) OVER () AS data_as_of,
+    lower(regexp_replace(coalesce(metadata->>'description', payload_text, 'unknown'), '[^a-z0-9]+', ' ', 'g')) AS merchant_key,
+    coalesce(metadata->>'description', payload_text, 'Unknown') AS merchant_name,
+    nullif(metadata->>'amount', '')::numeric AS amount,
+    coalesce(metadata->>'currency', 'GBP') AS currency
+  FROM events
+  WHERE semantic_type = 'transaction'
+    AND metadata->>'direction' = 'out'
+    AND nullif(metadata->>'amount', '') IS NOT NULL
+    AND lower(coalesce(metadata->>'description', payload_text, 'unknown')) !~ '^(to|from|transfer from|transfer to|exchanged to|cash withdrawal|withdrawing savings|withdrawing)'
+    AND lower(coalesce(metadata->>'description', payload_text, 'unknown')) !~ '(aldi|amazon fresh|antepliler|b\\s*&\\s*m|bar|bolt|boots|british airways|buns from home|camden chippy|chipotle|co-?op|coco di mama|coffee|deliveroo|dishoom|dostlar|five guys|fortnum|galata|gokyuzu|grocery|hair studio|kolkati|marks\\s*&\\s*spencer|m&s|netil|nisa|ocakbasi|porte|pub|rave coffee|redemption roasters|resident advisor|restaurant|sainsbury|santander cycles|sushi|the constitution|trainline|uber|umut|waitrose|wasabi|whsmith)'
+) tx
+GROUP BY tx.merchant_key, tx.currency
+HAVING count(distinct date_trunc('month', tx.occurred_at)) >= 3
+   AND max(tx.amount) <= greatest(avg(tx.amount) * 3, 50)
+   AND count(*) <= count(distinct date_trunc('month', tx.occurred_at)) * 2
+   AND sum(tx.amount) >= 20
+) s
+ORDER BY s.total_spent DESC
+`;
+
 const subscription = defineEntityType({
   key: "subscription",
   name: "Subscription",
   description:
-    "Recurring costs and obligations - subscriptions, bills, insurance, memberships",
+    "Recurring costs and obligations derived from repeated transaction patterns",
   metadata: { icon: "🔄", color: "#EF4444" },
-  required: ["category"],
+  backing: { sql: subscriptionBackingSql },
   properties: {
-    amount: { type: "number", description: "Current charge amount" },
+    amount: {
+      type: "number",
+      description: "Current charge amount",
+      "x-table-column": true,
+      "x-table-label": "Amount",
+    },
     status: {
       type: "string",
       enum: ["active", "cancelled", "changed"],
       description: "Current status",
+      "x-table-column": true,
+      "x-table-label": "Status",
     },
     category: {
       type: "string",
@@ -164,7 +236,12 @@ const subscription = defineEntityType({
       enum: ["monthly", "annual", "periodic"],
       description: "How often charged",
     },
-    last_seen: { type: "string", format: "date" },
+    last_seen: {
+      type: "string",
+      format: "date",
+      "x-table-column": true,
+      "x-table-label": "Last Seen",
+    },
     first_seen: { type: "string", format: "date" },
     billing_day: {
       type: "number",
@@ -173,7 +250,11 @@ const subscription = defineEntityType({
     total_spent: {
       type: "number",
       description: "Total spent over tracked period",
+      "x-table-column": true,
+      "x-table-label": "Total",
     },
+    charge_count: { type: "integer" },
+    active_months: { type: "integer" },
   },
 });
 
@@ -188,19 +269,84 @@ const topic = defineEntityType({
   },
 });
 
+const tripBackingSql = `
+SELECT
+  'trip:' || md5(date_trunc('month', occurred_at)::date::text || ':' || coalesce(metadata->>'currency', 'GBP')) AS id,
+  CASE coalesce(metadata->>'currency', 'GBP')
+    WHEN 'VND' THEN 'Vietnam trip'
+    WHEN 'EUR' THEN 'Europe trip'
+    WHEN 'USD' THEN 'US or international trip'
+    WHEN 'TRY' THEN 'Turkey trip'
+    WHEN 'JPY' THEN 'Japan trip'
+    WHEN 'KRW' THEN 'Korea trip'
+    ELSE coalesce(metadata->>'currency', 'GBP') || ' trip'
+  END || ' (' || min(occurred_at::date)::text || ' to ' || max(occurred_at::date)::text || ')' AS name,
+  'trip-' || date_trunc('month', occurred_at)::date::text || '-' || lower(coalesce(metadata->>'currency', 'GBP')) AS slug,
+  CASE coalesce(metadata->>'currency', 'GBP')
+    WHEN 'VND' THEN 'Vietnam'
+    WHEN 'EUR' THEN 'Europe'
+    WHEN 'USD' THEN 'US or international'
+    WHEN 'TRY' THEN 'Turkey'
+    WHEN 'JPY' THEN 'Japan'
+    WHEN 'KRW' THEN 'Korea'
+    ELSE coalesce(metadata->>'currency', 'GBP')
+  END AS destination,
+  min(occurred_at::date)::text AS start_date,
+  max(occurred_at::date)::text AS end_date,
+  coalesce(metadata->>'currency', 'GBP') AS currency,
+  round(sum(nullif(metadata->>'amount', '')::numeric), 2) AS total_cost,
+  count(*)::int AS transaction_count,
+  count(*)::int AS foreign_transaction_count,
+  CASE
+    WHEN count(*) >= 5 THEN 'high'
+    WHEN count(*) >= 3 THEN 'medium'
+    ELSE 'low'
+  END AS confidence
+FROM events
+WHERE semantic_type = 'transaction'
+  AND metadata->>'direction' = 'out'
+  AND coalesce(metadata->>'currency', 'GBP') <> 'GBP'
+  AND nullif(metadata->>'amount', '') IS NOT NULL
+GROUP BY date_trunc('month', occurred_at)::date, coalesce(metadata->>'currency', 'GBP')
+HAVING count(*) >= 2
+ORDER BY start_date DESC
+`;
+
 const trip = defineEntityType({
   key: "trip",
   name: "Trip",
-  description: "Travel experiences with associated spending",
+  description:
+    "Travel experiences derived from foreign-currency transaction clusters",
   metadata: { icon: "✈️", color: "#F59E0B" },
-  required: ["destination"],
+  backing: { sql: tripBackingSql },
   properties: {
-    people: { type: "number", description: "Number of travellers" },
     currency: { type: "string" },
-    end_date: { type: "string", format: "date" },
-    start_date: { type: "string", format: "date" },
-    total_cost: { type: "number" },
-    destination: { type: "string", description: "Primary destination" },
+    end_date: {
+      type: "string",
+      format: "date",
+      "x-table-column": true,
+      "x-table-label": "End",
+    },
+    start_date: {
+      type: "string",
+      format: "date",
+      "x-table-column": true,
+      "x-table-label": "Start",
+    },
+    total_cost: {
+      type: "number",
+      "x-table-column": true,
+      "x-table-label": "Total",
+    },
+    destination: {
+      type: "string",
+      description: "Primary destination",
+      "x-table-column": true,
+      "x-table-label": "Destination",
+    },
+    transaction_count: { type: "integer" },
+    foreign_transaction_count: { type: "integer" },
+    confidence: { type: "string", enum: ["low", "medium", "high"] },
   },
 });
 


### PR DESCRIPTION
## Summary
- Add derived `subscription` and `trip` entity types to the personal-agent example, backed by SQL over Revolut transaction events
- Bump `packages/owletto` to include clickable derived-entity rows and sidebar cleanup

**Depends on:** lobu-ai/owletto#260 (merge owletto first, then this pointer is already correct)

## Test plan
- [ ] `lobu apply` in `examples/personal-agent` — subscription and trip types appear
- [ ] With Revolut transaction data, subscription/trip views populate and rows are clickable

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1242"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784068035&installation_id=136316292&pr_number=1242&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1242&signature=9c0dfd34b0f515374c797040823e9aac5c4d946601d51b8a02462154ad03065a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced subscription tracking by automatically identifying and categorizing recurring transactions with frequency, spending totals, and activity status
  * Added trip insights that organize travel spending by destination and currency with confidence metrics

<!-- end of auto-generated comment: release notes by coderabbit.ai -->