### PR TITLE
fix(server): unblock app image build after MCP org-context merge

### DIFF
--- a/packages/server/src/gateway/auth/mcp/oauth-flow.ts
+++ b/packages/server/src/gateway/auth/mcp/oauth-flow.ts
@@ -312,6 +312,7 @@ export async function completeAuthCodeFlow(
   if (!tokenData.access_token) {
     throw new Error("Token exchange response missing access_token");
   }
+  const accessToken = tokenData.access_token;
 
   const expiresAt =
     typeof tokenData.expires_in === "number"
@@ -320,7 +321,7 @@ export async function completeAuthCodeFlow(
 
 	await runWithOrganizationContext(organizationId, () =>
 		storeCredentialForScope(secretStore, agentId, scopeKey, mcpId, {
-    accessToken: tokenData.access_token,
+    accessToken,
     refreshToken: tokenData.refresh_token,
     expiresAt,
     clientId: client.clientId,

--- a/packages/server/src/gateway/connections/slack-platform-bridge.ts
+++ b/packages/server/src/gateway/connections/slack-platform-bridge.ts
@@ -449,6 +449,8 @@ async function startMcpConnectFlow(params: {
   }
   const httpServer = await mcpConfigService.getHttpServer(mcpId, agentId);
   if (!httpServer) return null;
+  const organizationId = connection.organizationId;
+  if (!organizationId) return null;
   const redirectUri = `${deps.publicGatewayUrl.replace(/\/+$/, "")}/mcp/oauth/callback`;
   const { authorizationUrl } = await startAuthCodeFlow({
     secretStore: deps.secretStore,
@@ -456,7 +458,7 @@ async function startMcpConnectFlow(params: {
     upstreamUrl: httpServer.upstreamUrl,
     agentId,
     userId,
-		organizationId: connection.organizationId,
+		organizationId,
     // Home-tab connect is always per-user.
     scopeKey: userId,
     wwwAuthenticate: null,

--- a/packages/server/src/gateway/routes/internal/types.ts
+++ b/packages/server/src/gateway/routes/internal/types.ts
@@ -1,3 +1,5 @@
+import type { WorkerTokenData } from "@lobu/core";
+
 /**
  * Shared types for internal worker-facing routes.
  */
@@ -8,15 +10,6 @@
  */
 export type WorkerContext = {
   Variables: {
-    worker: {
-      userId: string;
-      conversationId: string;
-      channelId: string;
-      teamId?: string;
-      agentId?: string;
-      deploymentName: string;
-      platform?: string;
-      connectionId?: string;
-    };
+    worker: WorkerTokenData;
   };
 };


### PR DESCRIPTION
## Summary
Unblocks `Build and Push Images` on main — the Docker build runs `packages/server` typecheck and was failing on three #1240 follow-up gaps.

- `WorkerContext.worker` → `WorkerTokenData` (includes `organizationId`, `timestamp`)
- Narrow OAuth `access_token` before the org-context ALS callback
- Guard Slack home-tab MCP connect when `connection.organizationId` is missing

## Test plan
- [x] `cd packages/server && bunx tsc --noEmit`
- [ ] `Build and Push Images` workflow green on merge

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1243"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784070600&installation_id=136316292&pr_number=1243&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1243&signature=5d991b37d18aa897b3c52d82b455bd34f29316a5fe99c23564b6777af20519e0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal code improvements for better maintainability and type safety across authentication and connection systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->