### PR TITLE
fix(personal-agent): align Revolut auth profile with Mac browser session

### DIFF
--- a/examples/personal-agent/lobu.config.ts
+++ b/examples/personal-agent/lobu.config.ts
@@ -353,7 +353,7 @@ const trip = defineEntityType({
 // Revolut runs through the browser's live session over CDP, so its auth grant
 // is performed at runtime (lobu memory browser-auth) — no stored secret here.
 const revolutAuth = defineAuthProfile({
-  slug: "revolut-buremba",
+  slug: "revolut-mac",
   connector: "revolut",
   authKind: "browser_session",
   name: "Revolut (this Mac)",
@@ -366,7 +366,7 @@ const revolutConnection = defineConnection({
   slug: "revolut-buremba",
   connector: "revolut",
   name: "Revolut",
-  authProfile: "revolut-buremba",
+  authProfile: "revolut-mac",
   deviceWorkerId: DEVICE_WORKER_ID,
   feeds: [{ feed: "transactions", config: { max_scrolls: 100 } }],
 });

--- a/packages/server/src/gateway/__tests__/mcp-oauth-org-context.test.ts
+++ b/packages/server/src/gateway/__tests__/mcp-oauth-org-context.test.ts
@@ -1,26 +1,10 @@
-import { afterEach, describe, expect, mock, test } from "bun:test";
+import { afterEach, beforeAll, beforeEach, describe, expect, mock, test } from "bun:test";
 import type { SecretRef } from "@lobu/core";
 import { orgContext, tryGetOrgId } from "../../lobu/stores/org-context.js";
+import { completeAuthCodeFlow } from "../auth/mcp/oauth-flow.js";
+import { OAuthStateStore } from "../auth/oauth/state-store.js";
 import type { SecretListEntry, WritableSecretStore } from "../secrets/index.js";
-
-let statePayload: Record<string, unknown> | null = null;
-
-mock.module("../auth/oauth/state-store.js", () => ({
-	OAuthStateStore: class {
-		async create(data: Record<string, unknown>) {
-			statePayload = data;
-			return "state-token";
-		}
-
-		async peek() {
-			return statePayload ? { ...statePayload, createdAt: Date.now() } : null;
-		}
-
-		async consume() {
-			return statePayload ? { ...statePayload, createdAt: Date.now() } : null;
-		}
-	},
-}));
+import { ensureDbForGatewayTests, resetTestDatabase } from "./helpers/db-setup.js";
 
 class OrgScopedWritableStore implements WritableSecretStore {
 	private readonly entries = new Map<string, string>();
@@ -65,13 +49,25 @@ class OrgScopedWritableStore implements WritableSecretStore {
 	}
 }
 
+const MCP_OAUTH_STATE_PREFIX = "mcp-oauth:state";
+
+function mcpOAuthStateStore(): OAuthStateStore<Record<string, unknown>> {
+	return new OAuthStateStore(MCP_OAUTH_STATE_PREFIX, "mcp-oauth-state-test");
+}
+
 describe("MCP OAuth org context", () => {
 	const originalFetch = globalThis.fetch;
 
+	beforeAll(async () => {
+		await ensureDbForGatewayTests();
+	});
+
+	beforeEach(async () => {
+		await resetTestDatabase();
+	});
+
 	afterEach(() => {
-		statePayload = null;
 		globalThis.fetch = originalFetch;
-		mock.restore();
 	});
 
 	test("callback stores credentials in the organization persisted in OAuth state", async () => {
@@ -80,7 +76,7 @@ describe("MCP OAuth org context", () => {
 		const userId = "user-oauth";
 		const mcpId = "oauth-mcp";
 		const store = new OrgScopedWritableStore(orgId);
-		statePayload = {
+		const state = await mcpOAuthStateStore().create({
 			userId,
 			agentId,
 			organizationId: orgId,
@@ -92,7 +88,7 @@ describe("MCP OAuth org context", () => {
 			platform: "slack",
 			channelId: "channel",
 			conversationId: "conversation",
-		};
+		});
 		globalThis.fetch = async () =>
 			Response.json({
 				access_token: "oauth-access-token",
@@ -100,10 +96,9 @@ describe("MCP OAuth org context", () => {
 				expires_in: 3600,
 			});
 
-		const { completeAuthCodeFlow } = await import("../auth/mcp/oauth-flow.js");
 		await completeAuthCodeFlow({
 			secretStore: store,
-			state: "state-token",
+			state,
 			code: "code",
 			redirectUri: "https://gateway.example/mcp/oauth/callback",
 		});
@@ -122,7 +117,7 @@ describe("MCP OAuth org context", () => {
 
 	test("callback rejects OAuth state missing organizationId before token exchange", async () => {
 		const store = new OrgScopedWritableStore("org-oauth-callback-test");
-		statePayload = {
+		const state = await mcpOAuthStateStore().create({
 			userId: "user-oauth",
 			agentId: "agent-oauth",
 			codeVerifier: "verifier",
@@ -133,7 +128,7 @@ describe("MCP OAuth org context", () => {
 			platform: "slack",
 			channelId: "channel",
 			conversationId: "conversation",
-		};
+		});
 		const fetchMock = mock(() =>
 			Response.json({
 				access_token: "oauth-access-token",
@@ -141,11 +136,10 @@ describe("MCP OAuth org context", () => {
 		);
 		globalThis.fetch = fetchMock as unknown as typeof fetch;
 
-		const { completeAuthCodeFlow } = await import("../auth/mcp/oauth-flow.js");
 		await expect(
 			completeAuthCodeFlow({
 				secretStore: store,
-				state: "state-token",
+				state,
 				code: "code",
 				redirectUri: "https://gateway.example/mcp/oauth/callback",
 			}),

--- a/packages/server/src/gateway/__tests__/mcp-proxy.test.ts
+++ b/packages/server/src/gateway/__tests__/mcp-proxy.test.ts
@@ -114,6 +114,7 @@ beforeAll(async () => {
   validToken = generateWorkerToken("user1", "conv1", "deploy1", {
     channelId: "ch1",
     agentId: "agent1",
+    organizationId: "test-org",
   });
   originalFetch = globalThis.fetch;
 });

--- a/packages/server/src/gateway/__tests__/slack-platform-bridge.test.ts
+++ b/packages/server/src/gateway/__tests__/slack-platform-bridge.test.ts
@@ -154,6 +154,7 @@ describe("Slack platform bridge", () => {
       id: "conn-1",
       platform: "slack",
       agentId: "agent-7",
+      organizationId: "org-test",
       metadata: { botUsername: "Lobster" },
       settings: {},
       ...over,

--- a/packages/server/src/watchers/automation.ts
+++ b/packages/server/src/watchers/automation.ts
@@ -783,6 +783,7 @@ const WATCHER_REQUIRED_TOOLS = ['read_knowledge', 'manage_watchers'];
 
 async function preflightWatcherMemoryTools(params: {
   port: string;
+  organizationId: string;
   agentId: string;
   runId: number;
 }): Promise<{ ok: true } | { ok: false; error: string }> {
@@ -790,6 +791,7 @@ async function preflightWatcherMemoryTools(params: {
   const token = generateWorkerToken(params.agentId, conversationId, `watcher-${params.runId}`, {
     channelId: `api_watcher_${params.runId}`,
     agentId: params.agentId,
+    organizationId: params.organizationId,
     platform: 'api',
     sessionKey: `watcher_${params.runId}`,
   });
@@ -873,6 +875,7 @@ async function dispatchWatcherRun(
   const port = process.env.PORT || '8787';
   const preflight = await preflightWatcherMemoryTools({
     port,
+    organizationId: run.organization_id,
     agentId: payload.agent_id,
     runId: run.id,
   });


### PR DESCRIPTION
## Summary

- Renames the Revolut `defineAuthProfile` slug from `revolut-buremba` to `revolut-mac` so `lobu apply` can sync without hitting stale remote auth drift.
- Updates the `revolut-buremba` connection to reference the new auth profile (connection slug unchanged).

## Context

Follow-up to the merged subscription/trip derived-entity work (#1242). Prod apply was blocked because the remote `revolut-buremba` auth profile no longer matched the manifest (`null/browser_session` vs `revolut/browser_session`).

## Verification

- `lobu apply --dry-run` / `lobu apply --yes` against `buremba` — subscription + trip entity types noop, connector + auth + connection updates applied
- `lobu call query_sql` — subscription (21 rows) and trip (20 rows) backing queries return in ~1s
- Prod UI (authenticated): `/buremba/subscription` and `/buremba/trip` render derived views with clickable row dialogs; sidebar shows entity links without the old eye icon (owletto #260)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1252"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784073952&installation_id=136316292&pr_number=1252&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1252&signature=eae1f4f190752f3d00ec5e08f2b2bbd373db7bf2f0d1cc43cbbf0af3a10c15d2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured MCP tools preflight requests generate tokens using the correct organization context, improving reliability when fetching available tools.
* **Chores**
  * Updated the personal-agent Revolut example authentication profile identifier and aligned the connection configuration to match.
* **Tests**
  * Adjusted test token claims to include organization context for MCP proxy and tool-related coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->