### PR TITLE
fix(lobu-crm): switch crm agent to z-ai/glm-5.2

### DIFF
--- a/examples/lobu-crm/lobu.config.ts
+++ b/examples/lobu-crm/lobu.config.ts
@@ -25,7 +25,7 @@ const crm = defineAgent({
   providers: [
     {
       id: "z-ai",
-      model: "z-ai/glm-4.7",
+      model: "z-ai/glm-5.2",
       key: secret("Z_AI_API_KEY"),
     },
   ],


### PR DESCRIPTION
## Problem
The prod `crm` agent (org `org_lobucrm`) stopped answering Slack DMs. Root cause: **glm-4.7 on z.ai returns short/greeting replies entirely inside the `reasoning_content` (thinking) channel with an empty `text` content**. The Slack response bridge only posts text content, so nothing visible lands — yet every layer logs success (`Session completed successfully`, `Response completed via Chat SDK bridge`), so it went unnoticed.

## Fix
Switch the model to `z-ai/glm-5.2`, which emits proper `text` content.

## E2E (verified live in prod before this PR)
Read the worker session transcript for DM `D095U1QV667`:
- **glm-4.7**: `content:[{type:"thinking", "Hello! How can I help you today?"}]` — empty text, nothing delivered.
- **glm-5.2**: `content:[{type:"text", "Hi there! What can I help you with today?"}]` — delivered. ✅

Prod DB was already flipped (`provider_model_preferences = {"z-ai":"z-ai/glm-5.2"}`) for immediate effect; this PR makes the config source-of-truth match so the next `lobu apply` doesn't revert it.

## Follow-up (not in this PR)
Harden the worker: when an assistant turn has reasoning content but empty final text, fall back to posting the reasoning — and have the response bridge treat empty text as a delivery failure instead of silent success.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1254"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784121973&installation_id=136316292&pr_number=1254&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1254&signature=6f75261ec71073f75fb50310363fcae79cf873fc60efc1db69ab705a389d986d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the AI model version used by the CRM agent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->