### PR TITLE
fix(server): stop orphaned embedded Postgres after bun:test runs

### DIFF
--- a/packages/server/bunfig.toml
+++ b/packages/server/bunfig.toml
@@ -1,0 +1,2 @@
+[test]
+preload = ["./src/__tests__/setup/bun-test-teardown.ts"]

--- a/packages/server/src/__tests__/setup/bun-test-teardown.ts
+++ b/packages/server/src/__tests__/setup/bun-test-teardown.ts
@@ -1,0 +1,14 @@
+/**
+ * Global bun:test teardown for embedded Postgres started by db-setup.ts.
+ * Preload runs in the test runner root so this afterAll fires once per
+ * `bun test` invocation, after every test file finishes.
+ *
+ * Lazy-import db-setup so unit tests that never touch Postgres do not load
+ * embedded-postgres at preload time.
+ */
+import { afterAll } from 'bun:test';
+
+afterAll(async () => {
+  const { stopDbForGatewayTests } = await import('../../gateway/__tests__/helpers/db-setup.js');
+  await stopDbForGatewayTests();
+});

--- a/packages/server/src/__tests__/setup/embedded-postgres-backend.ts
+++ b/packages/server/src/__tests__/setup/embedded-postgres-backend.ts
@@ -9,9 +9,10 @@
  * cube/earthdistance, pgvector).
  */
 
+import { spawnSync } from 'node:child_process';
 import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { dirname, join } from 'node:path';
 import { injectPgvector, resolveEmbeddedNativeDir } from '@lobu/pgvector-embedded';
 import exitHook from 'async-exit-hook';
 import EmbeddedPostgres from 'embedded-postgres';
@@ -27,7 +28,7 @@ import { withFreePortRetry } from './free-port';
 // a `done` callback (`done is not a function` unhandled rejection on every
 // clean run), and async cleanup can't execute during `exit` anyway. Signal
 // hooks (SIGINT/SIGTERM/SIGHUP) stay so Ctrl-C still stops embedded clusters;
-// the normal path stops them explicitly in teardown().
+// the normal path stops them explicitly through stopActiveEmbeddedBackend().
 exitHook.unhookEvent('beforeExit');
 exitHook.unhookEvent('exit');
 
@@ -37,12 +38,64 @@ export interface EmbeddedBackend {
 }
 
 let active: EmbeddedBackend | null = null;
+let activeStopImpl: (() => Promise<void>) | null = null;
+let activeExitStopImpl: (() => void) | null = null;
+let stopPromise: Promise<void> | null = null;
+let shutdownHooksRegistered = false;
+
+function registerShutdownHooks(): void {
+  if (shutdownHooksRegistered) return;
+  shutdownHooksRegistered = true;
+
+  // Best-effort cleanup for vitest/node paths that let the event loop drain.
+  // Unlike async-exit-hook, this never calls process.exit(0) and therefore
+  // cannot mask a failing test run's exit code.
+  process.on('beforeExit', () => {
+    // Keep the process alive until async pg.stop() finishes; never call
+    // process.exit() here (#1216).
+    const pending = stopActiveEmbeddedBackend().catch((err) => {
+      console.error('[embedded-postgres-test] cleanup failed during beforeExit', err);
+    });
+    void pending;
+  });
+
+  // Bun may skip `beforeExit` and, with shared module caching across test files,
+  // the per-file afterAll owner can finish before the final embedded backend is
+  // started. `exit` cannot await async cleanup, so only issue a synchronous
+  // pg_ctl stop as a last-ditch orphan-prevention fallback; never change the
+  // process exit code.
+  process.on('exit', () => {
+    activeExitStopImpl?.();
+  });
+}
+
+/** Stop the active embedded Postgres, if any, serializing concurrent callers. */
+export function stopActiveEmbeddedBackend(): Promise<void> {
+  if (stopPromise) return stopPromise;
+  if (!activeStopImpl) {
+    active = null;
+    activeExitStopImpl = null;
+    return Promise.resolve();
+  }
+
+  const stopImpl = activeStopImpl;
+  stopPromise = stopImpl().finally(() => {
+    if (activeStopImpl === stopImpl) {
+      activeStopImpl = null;
+    }
+    active = null;
+    activeExitStopImpl = null;
+    stopPromise = null;
+  });
+  return stopPromise;
+}
 
 /**
  * Start an ephemeral embedded Postgres and return a connectable DATABASE_URL.
  * Idempotent: repeated calls return the same instance until `stop()` runs.
  */
 export async function startEmbeddedBackend(): Promise<EmbeddedBackend> {
+  if (stopPromise) await stopPromise;
   if (active) return active;
 
   injectPgvector(resolveEmbeddedNativeDir());
@@ -68,6 +121,12 @@ export async function startEmbeddedBackend(): Promise<EmbeddedBackend> {
         log += message;
       },
     });
+    const originalStop = instance.stop.bind(instance);
+    let instanceStopPromise: Promise<void> | null = null;
+    instance.stop = async () => {
+      instanceStopPromise ??= originalStop();
+      await instanceStopPromise;
+    };
     try {
       await instance.initialise();
       await instance.start();
@@ -95,16 +154,27 @@ export async function startEmbeddedBackend(): Promise<EmbeddedBackend> {
   });
 
   const url = `postgresql://postgres:postgres@127.0.0.1:${port}/lobu_test?sslmode=disable`;
+  const child = (pg as unknown as { process?: { spawnfile?: string } }).process;
+  const pgCtl = child?.spawnfile ? join(dirname(child.spawnfile), 'pg_ctl') : null;
+  activeExitStopImpl = () => {
+    if (!pgCtl) return;
+    spawnSync(pgCtl, ['stop', '-D', dataDir, '-m', 'fast', '-w'], {
+      stdio: 'ignore',
+      timeout: 5000,
+    });
+    rmSync(dataDir, { recursive: true, force: true });
+  };
+  activeStopImpl = async () => {
+    try {
+      await pg.stop();
+    } finally {
+      rmSync(dataDir, { recursive: true, force: true });
+    }
+  };
   active = {
     url,
-    stop: async () => {
-      try {
-        await pg.stop();
-      } finally {
-        rmSync(dataDir, { recursive: true, force: true });
-        active = null;
-      }
-    },
+    stop: stopActiveEmbeddedBackend,
   };
+  registerShutdownHooks();
   return active;
 }

--- a/packages/server/src/__tests__/setup/global-setup.ts
+++ b/packages/server/src/__tests__/setup/global-setup.ts
@@ -12,7 +12,7 @@
 
 import type { GlobalSetupContext } from 'vitest/node';
 import { closeDbSingleton } from '../../db/client';
-import { type EmbeddedBackend, startEmbeddedBackend } from './embedded-postgres-backend';
+import { startEmbeddedBackend, stopActiveEmbeddedBackend } from './embedded-postgres-backend';
 import { closeTestDb, setupTestDatabase } from './test-db';
 
 // Make the resolved test DATABASE_URL available to forked test workers via
@@ -27,8 +27,6 @@ declare module 'vitest' {
   }
 }
 
-let embedded: EmbeddedBackend | null = null;
-
 export async function setup({ provide }: GlobalSetupContext): Promise<void> {
   if (process.env.SKIP_TEST_DB_SETUP === '1') {
     console.log('\n⚠️  Skipping test database setup (SKIP_TEST_DB_SETUP=1).\n');
@@ -42,7 +40,7 @@ export async function setup({ provide }: GlobalSetupContext): Promise<void> {
     console.log(`\n🗄️  Using Postgres at ${databaseUrl}`);
   } else {
     console.log('\n🐘 No DATABASE_URL — spawning ephemeral embedded Postgres...');
-    embedded = await startEmbeddedBackend();
+    const embedded = await startEmbeddedBackend();
     process.env.DATABASE_URL = embedded.url;
     process.env.PGSSLMODE = 'disable';
     console.log(`✅ Embedded Postgres ready at ${embedded.url}`);
@@ -67,8 +65,5 @@ export async function setup({ provide }: GlobalSetupContext): Promise<void> {
 }
 
 export async function teardown(): Promise<void> {
-  if (embedded) {
-    await embedded.stop();
-    embedded = null;
-  }
+  await stopActiveEmbeddedBackend();
 }

--- a/packages/server/src/gateway/__tests__/helpers/db-setup.ts
+++ b/packages/server/src/gateway/__tests__/helpers/db-setup.ts
@@ -8,12 +8,16 @@
  *
  * Tests that don't need PG (pure helpers, classification logic, etc.) can
  * skip calling this entirely and pay no cost.
+ *
+ * Suite teardown is registered in bun-test-teardown.ts (bunfig preload).
+ * startEmbeddedBackend's beforeExit/exit hooks are a fallback on interrupt.
  */
 
 import { closeDbSingleton, getDb } from "../../../db/client.js";
 import {
   type EmbeddedBackend,
   startEmbeddedBackend,
+  stopActiveEmbeddedBackend,
 } from "../../../__tests__/setup/embedded-postgres-backend.js";
 import {
   cleanupTestDatabase,
@@ -47,9 +51,27 @@ export function ensureDbForGatewayTests(): Promise<void> {
     // setup-time connections around.
     await closeTestDb();
     await closeDbSingleton();
-  })();
+  })().catch(async (err) => {
+    await stopDbForGatewayTests();
+    throw err;
+  });
 
   return initPromise;
+}
+
+/** Stop and forget the embedded gateway-test database, if this process owns one. */
+export async function stopDbForGatewayTests(): Promise<void> {
+  const embeddedUrl = backend?.url;
+  await closeTestDb();
+  await closeDbSingleton();
+  if (backend) {
+    await stopActiveEmbeddedBackend();
+  }
+  if (embeddedUrl && process.env.DATABASE_URL === embeddedUrl) {
+    delete process.env.DATABASE_URL;
+  }
+  backend = null;
+  initPromise = null;
 }
 
 /**
@@ -68,6 +90,11 @@ export function ensureEncryptionKey(): void {
 
 /** Truncate every test-known table without dropping the schema. */
 export async function resetTestDatabase(): Promise<void> {
+  if (!process.env.DATABASE_URL || !initPromise) {
+    await ensureDbForGatewayTests();
+  } else {
+    await initPromise;
+  }
   await cleanupTestDatabase();
 }
 

--- a/packages/server/src/gateway/__tests__/runs-queue-integration.test.ts
+++ b/packages/server/src/gateway/__tests__/runs-queue-integration.test.ts
@@ -5,13 +5,11 @@
  * SKIP LOCKED concurrency, graceful shutdown release, priority + expires_at +
  * retryDelay options, startup recovery scan.
  *
- * The SKIP LOCKED concurrency test drives multiple pooled connections against
- * the real embedded Postgres; the production guarantee (FOR UPDATE SKIP LOCKED
- * is row-locked at the heap-tuple level) holds because the SQL is identical.
+ * The SKIP LOCKED test runs the production claim SQL against real embedded
+ * Postgres so row-lock semantics are covered without SQL mocks.
  */
 
 import {
-  afterAll,
   afterEach,
   beforeAll,
   beforeEach,
@@ -45,10 +43,6 @@ afterEach(async () => {
   }
 });
 
-afterAll(async () => {
-  // No global teardown — db-setup.ts owns the embedded Postgres lifecycle.
-});
-
 describe("RunsQueue — SKIP LOCKED claim concurrency", () => {
   test("each row is consumed exactly once across concurrent claim loops", async () => {
     if (!queue) throw new Error("queue not started");
@@ -62,11 +56,9 @@ describe("RunsQueue — SKIP LOCKED claim concurrency", () => {
       consumed.push(job.data.i);
     };
 
-    // Spawn 4 worker registrations against the same queue. Inside one
-    // RunsQueue instance, each work() call replaces the previous worker for
-    // the same queue name, so we test the single-worker SKIP LOCKED path.
-    // Cross-process contention is identical SQL so this still demonstrates
-    // the row-level claim semantics.
+    // Inside one RunsQueue instance, a queue name has one active worker loop.
+    // This still exercises the production SKIP LOCKED claim SQL against real
+    // Postgres, without mocking the row-lock behavior.
     await queue.work("test-skip-locked", handler);
 
     // Drain — poll until all claimed.
@@ -191,11 +183,13 @@ describe("RunsQueue — action_input JSONB shape", () => {
     }>;
 
     expect(rows).toHaveLength(1);
-    expect(rows[0]!.shape).toBe("object");
+    const row = rows[0];
+    expect(row).toBeDefined();
+    expect(row?.shape).toBe("object");
     // Direct `->>` extraction works on the object shape — the exact
     // accessor the snapshot-route verifier relies on.
-    expect(rows[0]!.extracted_agent_id).toBe("marketing");
-    expect(rows[0]!.extracted_conv_id).toBe("telegram:6570514069");
+    expect(row?.extracted_agent_id).toBe("marketing");
+    expect(row?.extracted_conv_id).toBe("telegram:6570514069");
   });
 });
 

--- a/scripts/review.sh
+++ b/scripts/review.sh
@@ -150,6 +150,9 @@ UNIT_EXIT=0
 } > "$UNIT_LOG" 2>&1
 set -e
 
+echo ">> make clean-test-pg before integration"
+make clean-test-pg
+
 echo ">> integration tests → $INTEGRATION_LOG"
 set +e
 INTEGRATION_EXIT=0


### PR DESCRIPTION
## Problem

`make review` and local `bun test` runs leave `lobu-test-pg-*` embedded Postgres clusters alive on macOS. With `kern.sysv.shmmni=32`, this saturates shared memory and later runs fail with `could not create shared memory segment: No space left on device`.

Root cause: vitest cleans up via `global-setup.ts` teardown, but the bun:test path (`db-setup.ts`) never stopped embedded Postgres on normal exit after we unhooked `async-exit-hook`'s `beforeExit`/`exit` handlers (#1216).

## Fix

- **`stopActiveEmbeddedBackend()`** in `embedded-postgres-backend.ts` — serialized stops, custom `beforeExit`/`exit` hooks (sync `pg_ctl` fallback), keeps #1216 unhooks
- **Vitest** teardown delegates to `stopActiveEmbeddedBackend()`
- **`stopDbForGatewayTests()`** in `db-setup.ts` with init-error cleanup
- **`packages/server/bunfig.toml` preload** + `bun-test-teardown.ts` — global bun `afterAll` (lazy-imports db-setup so unit tests don't load embedded-postgres)
- **`review.sh`** runs `make clean-test-pg` before integration (macOS defense)

## Verification

Pi verification (REVISE): confirmed root cause; ruled out `beforeExit`-only and detached reaper approaches.

Local repro after `make clean-test-pg` + `unset DATABASE_URL`:
- `bun test src/gateway/__tests__/runs-queue-integration.test.ts` → 7 pass, 0 `lobu-test-pg` processes
- `bun test src/lobu/__tests__ src/workspace/__tests__` → 35 pass, 0 orphans

## Review notes

Claude review: request changes on preload eager import (fixed with lazy import). Open follow-ups: CI doesn't exercise embedded bun path (always has `DATABASE_URL`); `review.sh` lacks vitest JSON #1216 guard.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1255"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784124126&installation_id=136316292&pr_number=1255&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1255&signature=bb5af5cb8edc232212344844ba327241ce0e1ce3aa303eb0ab83fed6ca46d6d9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Tests
* Improved test infrastructure reliability with deterministic database cleanup and proper Postgres shutdown after test runs
* Enhanced test database lifecycle management to prevent orphaned database instances
* Refactored test setup and teardown to ensure proper resource cleanup across concurrent test execution

<!-- end of auto-generated comment: release notes by coderabbit.ai -->