### PR TITLE
feat(lobu-crm): enable hosted Slack preview (crm via preview code)

### DIFF
--- a/examples/lobu-crm/lobu.config.ts
+++ b/examples/lobu-crm/lobu.config.ts
@@ -29,6 +29,11 @@ const crm = defineAgent({
       key: secret("Z_AI_API_KEY"),
     },
   ],
+  // Hosted Slack preview: redeem a `/lobu link <code>` by DMing the hosted Lobu
+  // Slack bot to bind a DM/channel to this agent (writes agent_channel_bindings).
+  preview: {
+    slack: { enabled: true, surfaces: ["dm", "channel"], codeTtlMinutes: 15 },
+  },
   network: {
     allowed: [
       "github.com",


### PR DESCRIPTION
Part of moving the prod Slack bot off the per-connection BYO crm wiring onto the **hosted preview** model.

Adds `preview.slack` to the crm agent so a `/lobu link <code>` (redeemed by DMing the hosted Lobu Slack bot) binds a DM/channel to crm via `agent_channel_bindings` — instead of crm owning a dedicated Slack app + per-connection webhook.

Companion infra change: lobu-ai/owletto#262 (SLACK_CLIENT_ID/SECRET/SIGNING_SECRET sealed into summaries-prod).

Prod already migrated live (this PR makes it declarative):
- SLACK_* sealed + deployed; `/lobu/slack/events` verified (signed url_verification → challenge echoed).
- connection cfa916c95eb64939 set `previewMode:true`; existing channel + the test DM bound to crm.

Note: the connection's owning agent is still crm, so the demo-agent menu excludes it (listPreviewAgents excludes the owning agent). Reaching crm via code works; a follow-up could introduce a placeholder owning agent so crm shows in the menu.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1256"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784125311&installation_id=136316292&pr_number=1256&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1256&signature=b4471b35d1fa2af76a939fabb19f0f72e0daa1ec3c370a502746dca6611d80a9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled hosted Slack preview functionality for the CRM agent, now available in direct messages and channels. Users can deploy and bind instances via the `/lobu link <code>` command. Verification codes expire after 15 minutes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->