### PR TITLE
fix(server): drop losing-replica worker spawn silently when conversation is owned by another pod

### DIFF
--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -100,6 +100,27 @@ export class OrchestratorError extends BaseError {
   }
 }
 
+/**
+ * Thrown when a worker spawn is declined because another replica already holds
+ * the per-conversation lock for this turn — i.e. another pod legitimately OWNS
+ * this conversation turn and is running it to completion.
+ *
+ * This is NOT a failure. It is the cross-pod "handled elsewhere" signal. Under
+ * N>1 app replicas both pods drain the shared `thread_message` queue and race to
+ * spawn the same per-conversation worker; exactly one wins the advisory lock.
+ * The loser MUST drop silently — no user-facing error, no Critical log, no
+ * retry (the winner holds the lock for the entire worker subprocess lifetime, so
+ * retrying can never win). The winning pod discharges the shared turn-liveness
+ * marker on its successful reply, so the user still receives the answer.
+ *
+ * Distinguished by type (not a magic message string) so the orchestrator can
+ * tell "owned by another pod" apart from a genuine worker-startup failure (OOM,
+ * spawn failure, bad config) which MUST still surface an error to the user.
+ */
+export class ConversationOwnedElsewhereError extends BaseError {
+  readonly name = "ConversationOwnedElsewhereError";
+}
+
 export class ConfigError extends BaseError {
   readonly name = "ConfigError";
 }

--- a/packages/server/src/gateway/__tests__/conversation-owned-elsewhere.test.ts
+++ b/packages/server/src/gateway/__tests__/conversation-owned-elsewhere.test.ts
@@ -95,14 +95,22 @@ function makePayload(): MessagePayload {
   } as unknown as MessagePayload;
 }
 
-/** Poll `pred` until true or the deadline lapses. */
+/**
+ * Poll `pred` until true, THROWING if the deadline lapses. Throwing (vs
+ * returning silently) is load-bearing: the negative assertions below
+ * ("trackFailedDeployment never called") would pass spuriously if the awaited
+ * background path simply never ran — a timeout must fail the test, not be
+ * mistaken for the expected behavior.
+ */
 async function waitFor(
   pred: () => boolean,
   timeoutMs = 20_000,
 ): Promise<void> {
   const start = Date.now();
   while (!pred()) {
-    if (Date.now() - start > timeoutMs) return;
+    if (Date.now() - start > timeoutMs) {
+      throw new Error(`waitFor: predicate not satisfied within ${timeoutMs}ms`);
+    }
     await new Promise((r) => setTimeout(r, 25));
   }
 }

--- a/packages/server/src/gateway/__tests__/conversation-owned-elsewhere.test.ts
+++ b/packages/server/src/gateway/__tests__/conversation-owned-elsewhere.test.ts
@@ -1,0 +1,215 @@
+/**
+ * Multi-replica reliability: a losing replica must DROP a spawn silently when
+ * another pod already owns the conversation turn.
+ *
+ * ## The bug (prod, 2026-06-15)
+ * Under N>1 app replicas both pods drain the shared `thread_message` queue and
+ * race to spawn the same per-conversation worker. Exactly one wins the
+ * per-conversation advisory lock and runs the worker to completion. The LOSING
+ * pod hit "Conversation lock busy on another pod", burned 3 retries (~14s),
+ * then surfaced a user-facing "Worker startup failed …" error (and a Critical
+ * log) — clobbering the winner's real reply ~50% of the time on slow models.
+ *
+ * ## The fix
+ * Lock-busy-on-another-pod is the cross-pod "handled elsewhere" signal, not a
+ * failure. The deployment manager throws the typed
+ * `ConversationOwnedElsewhereError`; the consumer drops it silently: no retry,
+ * no `trackFailedDeployment` (which would emit the user error AND race the
+ * winner's reply to terminalize the shared turn marker). A GENUINE startup
+ * failure (OOM, spawn failure, bad config) still surfaces via
+ * `trackFailedDeployment`.
+ *
+ * RED before the fix: the owned-elsewhere case called `trackFailedDeployment`
+ * (user error) just like a genuine failure. GREEN after: only the genuine
+ * failure does.
+ */
+
+import { describe, expect, mock, spyOn, test } from "bun:test";
+import {
+  ConversationOwnedElsewhereError,
+  type MessagePayload,
+} from "@lobu/core";
+import type { IMessageQueue } from "../infrastructure/queue/index.js";
+import type {
+  BaseDeploymentManager,
+  OrchestratorConfig,
+} from "../orchestration/base-deployment-manager.js";
+import { MessageConsumer } from "../orchestration/message-consumer.js";
+
+// A no-op queue so `armTurnTimeout` / `sendToWorkerQueue` don't touch Postgres.
+// `send` returns a non-empty jobId so `sendToWorkerQueue`'s null-check passes.
+function makeFakeQueue(): IMessageQueue {
+  return {
+    start: mock(async () => {}),
+    stop: mock(async () => {}),
+    createQueue: mock(async () => {}),
+    send: mock(async () => "job-1"),
+    work: mock(async () => {}),
+    pauseWorker: mock(async () => {}),
+    resumeWorker: mock(async () => {}),
+    getQueueStats: mock(async () => ({
+      waiting: 0,
+      active: 0,
+      completed: 0,
+      failed: 0,
+    })),
+    isHealthy: mock(() => true),
+  } as unknown as IMessageQueue;
+}
+
+function makeConfig(): OrchestratorConfig {
+  return {
+    queues: { retryLimit: 3, expireInSeconds: 600 },
+    worker: { maxDeployments: 0 },
+  } as unknown as OrchestratorConfig;
+}
+
+// A deployment manager whose `createWorkerDeployment` throws a caller-supplied
+// error. `listDeployments` returns empty so `ensureWorkerExists` takes the
+// "new thread → create" branch.
+function makeDeploymentManager(
+  throwOnCreate: Error,
+): BaseDeploymentManager {
+  return {
+    listDeployments: mock(async () => []),
+    scaleDeployment: mock(async () => {}),
+    updateDeploymentActivity: mock(async () => {}),
+    syncNetworkConfigGrants: mock(async () => {}),
+    createWorkerDeployment: mock(async () => {
+      throw throwOnCreate;
+    }),
+  } as unknown as BaseDeploymentManager;
+}
+
+function makePayload(): MessagePayload {
+  return {
+    messageId: "msg-1",
+    userId: "user-1",
+    channelId: "chan-1",
+    conversationId: "conv-1",
+    platform: "slack",
+    organizationId: "org-1",
+    agentId: "agent-1",
+    messageText: "hi",
+    platformMetadata: {},
+  } as unknown as MessagePayload;
+}
+
+/** Poll `pred` until true or the deadline lapses. */
+async function waitFor(
+  pred: () => boolean,
+  timeoutMs = 20_000,
+): Promise<void> {
+  const start = Date.now();
+  while (!pred()) {
+    if (Date.now() - start > timeoutMs) return;
+    await new Promise((r) => setTimeout(r, 25));
+  }
+}
+
+/**
+ * Drive `handleMessage`, then wait for the background `ensureWorkerExists` chain
+ * (and its `.catch`) to settle — it's fire-and-forget. `done` lets the caller
+ * poll for the terminal observable (spy called, or createWorkerDeployment
+ * attempted N times) instead of guessing a fixed sleep; the genuine-failure
+ * path burns ~14s of retry backoff before it settles.
+ */
+async function runTurn(
+  consumer: MessageConsumer,
+  done: () => boolean,
+): Promise<void> {
+  await (
+    consumer as unknown as {
+      handleMessage: (job: unknown) => Promise<void>;
+    }
+  ).handleMessage({ id: "1", data: makePayload() });
+  await waitFor(done);
+  // Brief settle so any trailing `.catch`/`.then` microtasks flush before the
+  // negative assertions ("never called") read the spy.
+  await new Promise((r) => setTimeout(r, 50));
+}
+
+describe("multi-replica: conversation owned by another pod", () => {
+  test("owned-elsewhere → drops silently, no user-facing failure", async () => {
+    const consumer = new MessageConsumer(
+      makeConfig(),
+      makeDeploymentManager(
+        new ConversationOwnedElsewhereError("owned by another replica"),
+      ),
+      makeFakeQueue(),
+    );
+
+    const dm = (consumer as unknown as { deploymentManager: BaseDeploymentManager })
+      .deploymentManager;
+    const trackSpy = spyOn(
+      consumer as unknown as {
+        trackFailedDeployment: (...args: unknown[]) => Promise<void>;
+      },
+      "trackFailedDeployment",
+    ).mockResolvedValue(undefined);
+
+    // The owned-elsewhere signal aborts after exactly one create attempt, so we
+    // can wait on that as the terminal observable.
+    await runTurn(
+      consumer,
+      () =>
+        (dm.createWorkerDeployment as unknown as { mock: { calls: unknown[] } })
+          .mock.calls.length >= 1,
+    );
+
+    // The whole point: the losing replica must NOT surface a startup-failure
+    // error to the user. `trackFailedDeployment` is the sole producer of the
+    // "Worker startup failed …" terminal error, so it must never run here.
+    expect(trackSpy).not.toHaveBeenCalled();
+  });
+
+  test("genuine startup failure → still surfaces a user-facing error", async () => {
+    const consumer = new MessageConsumer(
+      makeConfig(),
+      makeDeploymentManager(new Error("worker spawn failed: OOM")),
+      makeFakeQueue(),
+    );
+
+    const trackSpy = spyOn(
+      consumer as unknown as {
+        trackFailedDeployment: (...args: unknown[]) => Promise<void>;
+      },
+      "trackFailedDeployment",
+    ).mockResolvedValue(undefined);
+
+    // Genuine failures retry 3× with linear backoff (~14s) before
+    // `trackFailedDeployment` fires, so wait on the spy directly.
+    await runTurn(consumer, () => trackSpy.mock.calls.length >= 1);
+
+    // A real failure MUST still reach the user — don't regress the genuine path.
+    expect(trackSpy).toHaveBeenCalledTimes(1);
+  }, 30_000);
+
+  test("owned-elsewhere aborts retries immediately (no 3× backoff)", async () => {
+    const dm = makeDeploymentManager(
+      new ConversationOwnedElsewhereError("owned by another replica"),
+    );
+    const consumer = new MessageConsumer(makeConfig(), dm, makeFakeQueue());
+
+    spyOn(
+      consumer as unknown as {
+        trackFailedDeployment: (...args: unknown[]) => Promise<void>;
+      },
+      "trackFailedDeployment",
+    ).mockResolvedValue(undefined);
+
+    await runTurn(
+      consumer,
+      () =>
+        (dm.createWorkerDeployment as unknown as { mock: { calls: unknown[] } })
+          .mock.calls.length >= 1,
+    );
+
+    // shouldRetry short-circuits the owned-elsewhere signal: createWorkerDeployment
+    // is attempted exactly once, not maxRetries+1 times (~14s of wasted backoff).
+    expect(
+      (dm.createWorkerDeployment as unknown as { mock: { calls: unknown[] } })
+        .mock.calls.length,
+    ).toBe(1);
+  });
+});

--- a/packages/server/src/gateway/orchestration/base-deployment-manager.ts
+++ b/packages/server/src/gateway/orchestration/base-deployment-manager.ts
@@ -1,5 +1,6 @@
 import { createHash } from "node:crypto";
 import {
+  ConversationOwnedElsewhereError,
   createLogger,
   ErrorCode,
   extractTraceId,
@@ -361,6 +362,14 @@ export abstract class BaseDeploymentManager {
 
       await this.ensureDeployment(deploymentName, userId, userId, messageData);
     } catch (error) {
+      // "Owned by another replica" is not a failure — it's the cross-pod
+      // handled-elsewhere signal. Re-throw it UNCHANGED so the orchestrator can
+      // distinguish it from a genuine startup failure and drop silently;
+      // wrapping it in DEPLOYMENT_CREATE_FAILED here would erase that
+      // distinction and resurface the user-facing "Worker startup failed".
+      if (error instanceof ConversationOwnedElsewhereError) {
+        throw error;
+      }
       throw new OrchestratorError(
         ErrorCode.DEPLOYMENT_CREATE_FAILED,
         `Failed to create worker deployment: ${error instanceof Error ? error.message : String(error)}`,

--- a/packages/server/src/gateway/orchestration/impl/embedded-deployment.ts
+++ b/packages/server/src/gateway/orchestration/impl/embedded-deployment.ts
@@ -2,6 +2,7 @@ import { type ChildProcess, execFileSync, spawn } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 import {
+  ConversationOwnedElsewhereError,
   createLogger,
   ErrorCode,
   type MessagePayload,
@@ -681,16 +682,20 @@ export class EmbeddedDeploymentManager extends BaseDeploymentManager {
         );
       }
       if (!convLock) {
-        // Another pod is running this conversation. Surface as a
-        // re-queueable failure — the runs queue's standard retry path
-        // re-delivers with a delay (`retry_delay_seconds` set per
-        // run_type). No need to special-case here.
+        // Another pod legitimately OWNS this conversation turn and is running
+        // the worker to completion. This is NOT a failure — it is the cross-pod
+        // "handled elsewhere" signal. Throw the typed
+        // `ConversationOwnedElsewhereError` so the orchestrator drops THIS pod's
+        // spawn silently (no retry, no user-facing "Worker startup failed", no
+        // Critical log). The winning pod discharges the shared turn-liveness
+        // marker on its successful reply, so the user still gets the answer.
+        // Retrying here can never win: the winner holds the session-level
+        // advisory lock for the entire worker subprocess lifetime.
         logger.info(
-          `Conversation lock busy for ${organizationId}/${agentId}/${conversationId}; deferring spawn`
+          `Conversation lock owned by another pod for ${organizationId}/${agentId}/${conversationId}; dropping this pod's spawn (handled elsewhere)`
         );
-        throw new OrchestratorError(
-          ErrorCode.DEPLOYMENT_CREATE_FAILED,
-          "Conversation lock busy on another pod"
+        throw new ConversationOwnedElsewhereError(
+          "Conversation owned by another replica"
         );
       }
     }

--- a/packages/server/src/gateway/orchestration/impl/embedded-deployment.ts
+++ b/packages/server/src/gateway/orchestration/impl/embedded-deployment.ts
@@ -624,9 +624,11 @@ export class EmbeddedDeploymentManager extends BaseDeploymentManager {
     //
     // The lock is held by a reserved Postgres connection for the lifetime
     // of the worker subprocess (released in the `exit` handler below). If
-    // another pod has the lock we surface a re-queueable failure so the
-    // runs queue retries on a different pod or after the current holder
-    // releases.
+    // another pod has the lock, that pod legitimately OWNS this turn and is
+    // running it to completion — we throw `ConversationOwnedElsewhereError`
+    // so this pod drops the spawn silently (no retry, no user-facing error).
+    // Retrying could never win: the holder keeps the lock for the whole
+    // worker lifetime.
     const conversationId =
       typeof messageData?.conversationId === "string"
         ? messageData.conversationId

--- a/packages/server/src/gateway/orchestration/message-consumer.ts
+++ b/packages/server/src/gateway/orchestration/message-consumer.ts
@@ -1,4 +1,5 @@
 import {
+  ConversationOwnedElsewhereError,
   createChildSpan,
   createLogger,
   ErrorCode,
@@ -54,10 +55,14 @@ export class MessageConsumer {
   constructor(
     config: OrchestratorConfig,
     deploymentManager: BaseDeploymentManager,
+    // Test seam: the production path always uses the real Postgres-backed
+    // RunsQueue. Tests inject a fake so `handleMessage` can be driven without a
+    // database. Not a configuration knob — no caller passes this outside tests.
+    queue: IMessageQueue = new RunsQueue(),
   ) {
     this.config = config;
     this.deploymentManager = deploymentManager;
-    this.queue = new RunsQueue();
+    this.queue = queue;
   }
 
   /**
@@ -401,6 +406,26 @@ export class MessageConsumer {
         traceId,
         childTraceparent
       ).catch((bgError) => {
+        // Cross-pod handled-elsewhere signal: another replica won the
+        // per-conversation lock and is running this turn to completion. This is
+        // NOT a failure on this pod — drop silently. No Sentry capture, no
+        // Critical log, no `trackFailedDeployment` (which would surface a
+        // spurious "Worker startup failed" to the user and, via
+        // `failTurnIfPending`, race the winning pod's reply to terminalize the
+        // shared turn marker). The winner discharges the marker on its reply.
+        if (bgError instanceof ConversationOwnedElsewhereError) {
+          logger.info(
+            {
+              traceId,
+              deploymentName,
+              userId: data.userId,
+              conversationId: effectiveConversationId,
+            },
+            "Conversation owned by another replica — dropping this pod's spawn (handled elsewhere)"
+          );
+          return;
+        }
+
         // Capture error for monitoring and alerting
         Sentry.captureException(bgError, {
           tags: {
@@ -662,6 +687,12 @@ export class MessageConsumer {
         baseDelay: 2000,
         strategy: "linear",
         jitter: true,
+        // Don't burn retries (~14s) on the cross-pod handled-elsewhere signal:
+        // the winning replica holds the session-level advisory lock for the
+        // whole worker subprocess lifetime, so a retry here can never win.
+        // Abort immediately and let the `.catch` above drop silently.
+        shouldRetry: (error) =>
+          !(error instanceof ConversationOwnedElsewhereError),
         onRetry: (attempt, error) => {
           logger.warn(
             { traceId, deploymentName, attempt, maxAttempts: 3 },


### PR DESCRIPTION
## Root cause (prod, 2026-06-15)

Under N>1 app replicas both pods drain the shared Postgres `thread_message`
queue and BOTH try to spawn the same per-conversation worker
(`lobu-worker-slack-<id>`). Exactly one pod wins the session-level
per-conversation advisory lock (`acquireConversationLock`) and runs the worker
to completion successfully.

The LOSING pod hit `acquireConversationLock() → null`, which threw a generic
`OrchestratorError(DEPLOYMENT_CREATE_FAILED, "Conversation lock busy on another
pod")`. That:

1. Was retried 3× by `retryWithBackoff` (~14s of linear backoff) — which can
   never win, because the winner holds the session-level lock for the entire
   worker subprocess lifetime.
2. After exhausting retries, was treated identically to a genuine startup
   failure: `trackFailedDeployment` → `failTurnIfPending` emitted the
   user-facing `"Worker startup failed and your request could not be processed.
   Please retry in a moment."` and a `Critical:` log.

Result: ~50% of the time on slow models (glm-5.2, 12-24s to first output) the
user got ONLY the error while the winning pod's real reply was lost. Faster
models (glm-4.7, ~7s) mostly avoided the window.

Prod log evidence:
- `[orchestrator] Conversation lock busy for org_lobucrm/crm/slack:…; deferring spawn`
- `[orchestrator] Retry attempt failed: Failed to create worker deployment: Conversation lock busy on another pod {attempt:1..3, maxAttempts:3}`
- `[orchestrator] Critical: Background worker creation failed …`
- meanwhile the other pod: `[worker] Session completed successfully` + `[chat-response-bridge] Response completed via Chat SDK bridge`

## Fix

`"lock busy on another pod"` is NOT a failure — it's the cross-pod **"handled
elsewhere"** signal. Introduce a typed `ConversationOwnedElsewhereError` (in
`@lobu/core`, distinguished by type not by a magic message string) so the
orchestrator can tell it apart from a genuine startup failure (OOM, spawn
failure, bad config):

- **embedded-deployment.ts** — throws `ConversationOwnedElsewhereError` instead
  of `OrchestratorError(DEPLOYMENT_CREATE_FAILED)` when the advisory lock is held
  elsewhere.
- **base-deployment-manager.ts** — re-throws it unchanged instead of wrapping it
  into `DEPLOYMENT_CREATE_FAILED` (the wrap had erased the distinction).
- **message-consumer.ts** — `shouldRetry` aborts the retry loop immediately
  (no ~14s of doomed backoff); the background `.catch` drops it silently: no
  Sentry capture, no `Critical` log, no `trackFailedDeployment`.

Genuine worker-startup failures are unchanged: they still retry and still
surface the user-facing error (regression-guarded by the reproducer).

## Why the winner's reply still reaches the user

Both pods arm the **shared** Postgres turn-liveness marker (idempotent via
`singletonKey`). The winning pod's worker discharges that shared marker via
`commitTerminalReply` on its successful reply, and the terminal `thread_response`
is owner-routed to the pod holding the client's SSE. The loser dropping silently
is therefore correct — it must NOT call `failTurnIfPending`, which would race the
winner to terminalize the shared marker and emit a duplicate/spurious error.

## Red → green reproducer

`packages/server/src/gateway/__tests__/conversation-owned-elsewhere.test.ts`
(bun:test, runs in the integration suite via `bun test packages/server/src/gateway/__tests__`):

- **RED (before):** owned-elsewhere went through the same `.catch` →
  `trackFailedDeployment` path as a genuine failure → user-facing error. The
  test asserts `trackFailedDeployment` is NOT called for owned-elsewhere, which
  fails against the old behavior.
- **GREEN (after):**
  1. `owned-elsewhere → drops silently` — `trackFailedDeployment` never called.
  2. `genuine startup failure → still surfaces a user-facing error` —
     `trackFailedDeployment` called exactly once (regression guard).
  3. `owned-elsewhere aborts retries immediately` — `createWorkerDeployment`
     attempted exactly once, not `maxRetries+1`.

All 3 pass; `make typecheck` clean; existing `embedded-deployment.test.ts`
(27 tests) and core `errors.test.ts` (19 tests) still green.

## Does this hold with 3 replicas behind ClientIP affinity?

Yes. The only cross-pod coordination is the **existing** Postgres session-level
advisory lock (`pg_try_advisory_lock`) and the **existing** Postgres-mediated
turn-liveness marker. With 3 replicas, exactly one wins the lock; the other two
each throw `ConversationOwnedElsewhereError` and drop silently. No new in-memory
cross-pod state is introduced — the change only reclassifies an existing
PG-mediated signal and removes the spurious error/retry on the losing path.

Note: a true 2-replica e2e can't run locally; validated via the unit reproducer
driving `MessageConsumer.handleMessage` with a mocked deployment manager that
returns the owned-elsewhere / genuine-failure outcomes, plus typecheck and the
existing orchestration suite.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1257"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784128483&installation_id=136316292&pr_number=1257&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1257&signature=c03c44e604d2fc6eb66c12257b982806a8f0e86eaf694bdf5889d36541ad50d7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dedicated “handled elsewhere” error signal to represent cases where a conversation turn is already owned by another replica.

* **Bug Fixes**
  * Improved worker orchestration to silently drop duplicate spawn attempts when another replica holds the conversation lock, avoiding unnecessary re-queueable retries and failed-deployment tracking.

* **Tests**
  * Added multi-replica test coverage for owned-by-elsewhere behavior, including retry suppression.
  * Enhanced message consumer testability via optional injectable queue behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->