### PR TITLE
feat: derived entity rows resolve & list like stored entities (+ owletto unified UI)

### DIFF
--- a/packages/server/src/__tests__/integration/entity-schema/derived-entity-routing.test.ts
+++ b/packages/server/src/__tests__/integration/entity-schema/derived-entity-routing.test.ts
@@ -1,0 +1,152 @@
+/**
+ * Derived-entity ROUTING path.
+ *
+ * Derived ("view") entity types have no rows in `entities` — their rows come
+ * from `backing_sql`. This proves the backend abstracts that away so the
+ * frontend treats derived rows like stored entities:
+ *   - `manage_entity` list returns derived rows in the standard entity shape
+ *     (flagged `is_derived`), org-scoped.
+ *   - `resolve_path` resolves a single derived row by slug into a read-only
+ *     entity (with inferred `measure_columns`), and 404s an unknown slug.
+ */
+
+import { beforeAll, describe, expect, it } from 'vitest';
+import { cleanupTestDatabase } from '../../setup/test-db';
+import {
+  addUserToOrganization,
+  createTestAccessToken,
+  createTestEvent,
+  createTestOAuthClient,
+  createTestOrganization,
+  createTestUser,
+} from '../../setup/test-fixtures';
+import { post } from '../../setup/test-helpers';
+import { TestApiClient } from '../../setup/test-mcp-client';
+
+// A derived view over events that emits id/slug/name (so its rows can be routed
+// like stored entities) plus two aggregate measures.
+const SPEND_VIEW_SQL = `
+  SELECT
+    'vendor:' || (metadata->>'vendor') AS id,
+    (metadata->>'vendor') AS name,
+    'vendor-' || (metadata->>'vendor') AS slug,
+    SUM((metadata->>'amount')::numeric) AS total_spend,
+    COUNT(*) AS purchases
+  FROM events
+  WHERE metadata->>'vendor' IS NOT NULL
+  GROUP BY 1, 2, 3
+`;
+
+describe('derived entity routing (list + resolve_path)', () => {
+  let api: TestApiClient;
+  let orgAId: string;
+  let orgBId: string;
+  let orgSlug: string;
+  let token: string;
+
+  beforeAll(async () => {
+    await cleanupTestDatabase();
+    const orgA = await createTestOrganization({ name: 'Derived Routing A' });
+    const orgB = await createTestOrganization({ name: 'Derived Routing B' });
+    orgAId = orgA.id;
+    orgBId = orgB.id;
+    orgSlug = orgA.slug;
+    const user = await createTestUser({ email: 'derived-routing@test.com' });
+    await addUserToOrganization(user.id, orgA.id, 'owner');
+    api = await TestApiClient.for({
+      organizationId: orgA.id,
+      userId: user.id,
+      memberRole: 'owner',
+    });
+
+    await api.entity_schema.createType({
+      slug: 'spend-vendor',
+      name: 'Spend by vendor',
+      backing: { sql: SPEND_VIEW_SQL },
+    });
+
+    // Org A: acme x2 (=15), globex x1 (=20). Org B: acme x1 (=99) — must not leak.
+    await createTestEvent({ organization_id: orgAId, content: 'a1', metadata: { vendor: 'acme', amount: '10' } });
+    await createTestEvent({ organization_id: orgAId, content: 'a2', metadata: { vendor: 'acme', amount: '5' } });
+    await createTestEvent({ organization_id: orgAId, content: 'a3', metadata: { vendor: 'globex', amount: '20' } });
+    await createTestEvent({ organization_id: orgBId, content: 'b1', metadata: { vendor: 'acme', amount: '99' } });
+
+    const oauthClient = await createTestOAuthClient();
+    token = (await createTestAccessToken(user.id, orgA.id, oauthClient.client_id)).token;
+  });
+
+  async function resolvePath(args: Record<string, unknown>) {
+    const response = await post(`/api/${orgSlug}/resolve_path`, { body: args, token });
+    if (response.status >= 400) {
+      const body = (await response.json()) as { error?: string };
+      throw new Error(body.error ?? `HTTP ${response.status}`);
+    }
+    return response.json();
+  }
+
+  it('lists derived rows in the standard entity shape (org-scoped)', async () => {
+    const res = (await api.entities.list({ entity_type: 'spend-vendor' })) as {
+      entities: Array<{
+        name: string;
+        slug: string;
+        metadata: Record<string, unknown>;
+      }>;
+    };
+    const byName = Object.fromEntries(res.entities.map((e) => [e.name, e]));
+    expect(Object.keys(byName).sort()).toEqual(['acme', 'globex']);
+    expect(byName.acme.slug).toBe('vendor-acme');
+    // Org B's $99 acme event must NOT leak into org A's aggregate.
+    expect(Number(byName.acme.metadata.total_spend)).toBe(15);
+    expect(Number(byName.acme.metadata.purchases)).toBe(2);
+  });
+
+  it('resolve_path resolves a derived row by slug into a read-only entity', async () => {
+    const result = (await resolvePath({ path: `/${orgSlug}/spend-vendor/vendor-acme` })) as {
+      entity?: {
+        name: string;
+        slug: string;
+        is_derived?: boolean;
+        measure_columns?: string[];
+        metadata: Record<string, unknown>;
+      };
+    };
+    expect(result.entity?.name).toBe('acme');
+    expect(result.entity?.slug).toBe('vendor-acme');
+    expect(result.entity?.is_derived).toBe(true);
+    expect(Number(result.entity?.metadata.total_spend)).toBe(15);
+    // measure_columns is inferred from the backing SQL (same as get_type).
+    expect((result.entity?.measure_columns ?? []).sort()).toEqual(['purchases', 'total_spend']);
+  });
+
+  it('resolve_path 404s an unknown derived slug (no silent fallback)', async () => {
+    await expect(
+      resolvePath({ path: `/${orgSlug}/spend-vendor/vendor-missing` })
+    ).rejects.toThrow();
+  });
+
+  it('falls back to the id column for routing when the view projects no slug', async () => {
+    // A view that emits `id`/`name` but no `slug`. The row must still be
+    // routable: the slug falls back to the id, in both list and resolve.
+    await api.entity_schema.createType({
+      slug: 'vendor-noslug',
+      name: 'Vendor (no slug)',
+      backing: {
+        sql: `SELECT (metadata->>'vendor') AS id, (metadata->>'vendor') AS name,
+                COUNT(*) AS purchases
+              FROM events WHERE metadata->>'vendor' IS NOT NULL GROUP BY 1, 2`,
+      },
+    });
+
+    const list = (await api.entities.list({ entity_type: 'vendor-noslug' })) as {
+      entities: Array<{ slug: string; name: string }>;
+    };
+    const acme = list.entities.find((e) => e.name === 'acme');
+    expect(acme?.slug).toBe('acme'); // slug fell back to the id column
+
+    const resolved = (await resolvePath({
+      path: `/${orgSlug}/vendor-noslug/acme`,
+    })) as { entity?: { name: string; is_derived?: boolean } };
+    expect(resolved.entity?.name).toBe('acme');
+    expect(resolved.entity?.is_derived).toBe(true);
+  });
+});

--- a/packages/server/src/tools/admin/query_sql.ts
+++ b/packages/server/src/tools/admin/query_sql.ts
@@ -139,7 +139,7 @@ function errorResult(message: string, startTime: number): QuerySqlResult {
 
 export const querySql = withValidatedArgs('query_sql', QuerySqlSchema, querySqlImpl);
 
-async function querySqlImpl(
+export async function querySqlImpl(
   args: QuerySqlArgs,
   _env: unknown,
   ctx: ToolContext

--- a/packages/server/src/tools/resolve_path.ts
+++ b/packages/server/src/tools/resolve_path.ts
@@ -20,8 +20,11 @@ import {
 import { ToolUserError } from '../utils/errors';
 import { resolveMemberSchemaFieldsFromSchema } from '../utils/member-entity-type';
 import { stripMemberEmailsFromRows } from '../utils/member-redaction';
+import { derivedRowName, derivedRowSlug } from '../utils/entity-management';
+import { measureColumns as inferMeasureColumns } from '../utils/infer-measures';
 import { RESERVED_PATHS } from '../utils/reserved';
 import { getWorkspaceProvider } from '../workspace';
+import { querySqlImpl } from './admin/query_sql';
 import { isAdminOrOwnerRole } from './access-control';
 import { MEMBER_ENTITY_TYPE_SLUG } from './constants';
 import type { ToolContext } from './registry';
@@ -78,6 +81,11 @@ export interface ResolvedEntityDetails extends ResolvedPathEntity {
   total_content: number;
   active_connections: number;
   watchers_count: number;
+  // Derived ("view") entity: synthesized from the type's `backing_sql` filtered
+  // to this slug, not a stored `entities` row. `metadata` holds the full view
+  // row; `measure_columns` are its aggregate columns. Stored entities omit both.
+  is_derived?: boolean;
+  measure_columns?: string[];
 }
 
 export interface ChildEntity {
@@ -435,6 +443,21 @@ async function _resolvePath(
       `;
 
     if (row.length === 0) {
+      // The slug isn't a stored entity. It may be a row of a DERIVED ("view")
+      // entity type, whose rows are produced by `backing_sql`, not stored in
+      // `entities`. Synthesize the same response shape so the routed detail page
+      // renders it like any other entity (read-only, id-keyed tabs hidden).
+      const derived = await resolveDerivedLeaf(sql, ctx, workspace, segment);
+      if (derived) {
+        resolvedPath.push({
+          id: derived.id,
+          entity_type: derived.entity_type,
+          slug: derived.slug,
+          name: derived.name,
+        });
+        resolvedEntity = derived;
+        continue;
+      }
       throw new ToolUserError(
         `Entity not found for ${segment.entity_type}/${segment.slug}`,
         404
@@ -550,7 +573,7 @@ async function _resolvePath(
   let children: ChildEntity[] = [];
   let siblings: SiblingEntity[] = [];
 
-  if (resolvedEntity) {
+  if (resolvedEntity && !resolvedEntity.is_derived) {
     // Fetch children + siblings without per-row COUNT subqueries.
     // content_count is omitted to avoid expensive GIN index scans over the events table.
     const [childRows, siblingRows] = await Promise.all([
@@ -617,6 +640,85 @@ type DbClient = ReturnType<typeof getDb>;
 
 function toVersionNumber(v: unknown): number | null {
   return v ? Number(v) : null;
+}
+
+/**
+ * Resolve a single row of a derived ("view") entity type by slug. Returns null
+ * when the type isn't derived or the slug isn't among its rows — the caller then
+ * falls back to the normal 404.
+ *
+ * Derived rows aren't stored in `entities`; the type's `backing_sql` produces
+ * them with stable `id`/`slug` columns. We run that SQL through the same
+ * executor the list view uses (`querySqlImpl` — internal org-scoping or
+ * connection pushdown, both already validated for this view), then match the
+ * requested slug in memory. We page through the view (not just the first page)
+ * so a row past the first page still resolves; matching in memory — rather than
+ * interpolating the slug into the view SQL — keeps the SQL injection-free for
+ * both the internal and connection-backed paths.
+ */
+async function resolveDerivedLeaf(
+  sql: DbClient,
+  ctx: ToolContext,
+  workspace: ResolvedWorkspace,
+  segment: { entity_type: string; slug: string }
+): Promise<ResolvedEntityDetails | null> {
+  const etRows = await sql`
+    SELECT backing_sql, backing_source
+    FROM entity_types
+    WHERE slug = ${segment.entity_type}
+      AND organization_id = ${workspace.id}
+      AND deleted_at IS NULL
+    LIMIT 1
+  `;
+  const backingSql = etRows[0]?.backing_sql as string | null | undefined;
+  if (!backingSql) return null;
+
+  const backingSource = (etRows[0]?.backing_source as string | null | undefined) ?? undefined;
+  // measure_columns isn't stored — it's inferred from the backing SQL (same as
+  // `get_type`), so the detail view can right-align/badge aggregate columns.
+  const measures = inferMeasureColumns(backingSql);
+
+  // Page through the view until the slug is found or the rows run out. A bounded
+  // page count caps the work on a pathologically large view (which would also be
+  // slow to list); in practice derived types have tens of rows, so page 1 hits.
+  const PAGE = 500;
+  const MAX_PAGES = 40;
+  let match: Record<string, unknown> | undefined;
+  for (let pageNum = 0; pageNum < MAX_PAGES; pageNum += 1) {
+    const result = await querySqlImpl(
+      { sql: backingSql, connection: backingSource, limit: PAGE, offset: pageNum * PAGE },
+      undefined,
+      ctx
+    );
+    if (result.error) return null;
+    match = result.rows.find((r) => derivedRowSlug(r) === segment.slug);
+    if (match) break;
+    if (!result.has_more || result.rows.length < PAGE) break;
+  }
+  if (!match) return null;
+
+  const name = derivedRowName(match, segment.slug);
+
+  return {
+    // Derived rows have no stored numeric id; routing/identity use the slug, and
+    // the id-keyed tabs (knowledge/connectors/watchers) are hidden client-side.
+    id: 0,
+    entity_type: segment.entity_type,
+    slug: segment.slug,
+    name,
+    parent_id: null,
+    metadata: match,
+    json_template: null,
+    json_template_version: null,
+    template_data: null,
+    tabs: [],
+    created_at: new Date().toISOString(),
+    total_content: 0,
+    active_connections: 0,
+    watchers_count: 0,
+    is_derived: true,
+    measure_columns: measures,
+  };
 }
 
 function emptyResult(

--- a/packages/server/src/utils/entity-management.ts
+++ b/packages/server/src/utils/entity-management.ts
@@ -14,6 +14,7 @@ import {
   pgTextArray,
 } from '../db/client';
 import type { Env } from '../index';
+import { querySqlImpl } from '../tools/admin/query_sql';
 import type { ToolContext } from '../tools/registry';
 import { entityLinkMatchSql } from './content-search';
 import { type EntityHookContext, getEntityHooks } from './entity-hooks';
@@ -809,6 +810,30 @@ export async function listEntities(
     };
   }
 
+  // Derived ("view") entity types have no rows in `entities` — their rows come
+  // from `backing_sql`. Return them in the standard list shape so the frontend
+  // renders them with the normal table (no derived-specific UI path).
+  if (filters.entity_type) {
+    const etRows = await sql`
+      SELECT backing_sql, backing_source
+      FROM entity_types
+      WHERE slug = ${filters.entity_type}
+        AND organization_id = ${ctx.organizationId}
+        AND deleted_at IS NULL
+      LIMIT 1
+    `;
+    const backingSql = etRows[0]?.backing_sql as string | null | undefined;
+    if (backingSql) {
+      return listDerivedEntities(
+        filters.entity_type,
+        backingSql,
+        (etRows[0]?.backing_source as string | null | undefined) ?? undefined,
+        { limit, offset, search: filters.search },
+        ctx
+      );
+    }
+  }
+
   const conditions: string[] = ['e.deleted_at IS NULL'];
   const params: unknown[] = [];
   let paramIdx = 1;
@@ -915,6 +940,94 @@ export async function listEntities(
   const totalCount = Number(totalCountResult[0]?.total_count || 0);
 
   return { entities, hasMore, totalCount, limit, offset, sortBy, sortOrder: normalizedSortOrder };
+}
+
+/**
+ * Routing key for a derived row: the slug the backing SQL projects, falling
+ * back to its `id` column. Both the list and the detail resolver derive the key
+ * the same way so a listed row's link always resolves. Empty ⇒ unroutable.
+ */
+export function derivedRowSlug(row: Record<string, unknown>): string {
+  const raw = row.slug ?? row.id;
+  return raw != null ? String(raw).trim() : '';
+}
+
+/** Display name for a derived row: its name/title column, else the slug. */
+export function derivedRowName(row: Record<string, unknown>, slug: string): string {
+  const raw = row.name ?? row.title ?? slug;
+  return raw != null && String(raw).trim() ? String(raw) : slug;
+}
+
+/**
+ * List rows of a derived ("view") entity type by running its `backing_sql`
+ * through the same executor the detail/query paths use (`querySqlImpl` —
+ * internal org-scoping or connection pushdown, both already validated for this
+ * view). Maps each row to the standard `CreatedEntity` shape so the frontend
+ * treats derived rows like any other entity. Rows have no stored numeric id;
+ * the projected `slug` (or `id`) is the routing key, so the synthetic `id` is
+ * page-local and used only for table keys. Rows that project no slug/id are
+ * unroutable and dropped (they can't link to a detail page).
+ */
+async function listDerivedEntities(
+  entityType: string,
+  backingSql: string,
+  backingSource: string | undefined,
+  page: { limit: number; offset: number; search?: string },
+  ctx: ToolContext
+): Promise<{
+  entities: CreatedEntity[];
+  hasMore: boolean;
+  totalCount: number;
+  limit: number;
+  offset: number;
+  sortBy: string;
+  sortOrder: 'asc' | 'desc';
+}> {
+  // Search pushes down only on the internal path (the connection path rejects
+  // search_term); external derived views simply ignore the search box.
+  const search =
+    page.search && !backingSource
+      ? { search_term: page.search, search_columns: ['name'] }
+      : {};
+  const result = await querySqlImpl(
+    { sql: backingSql, connection: backingSource, limit: page.limit, offset: page.offset, ...search },
+    undefined,
+    ctx
+  );
+  if (result.error) {
+    throw new ToolUserError(`Derived view '${entityType}' failed: ${result.error}`, 400);
+  }
+
+  const createdAt = new Date();
+  const entities: CreatedEntity[] = [];
+  result.rows.forEach((row, index) => {
+    const slug = derivedRowSlug(row);
+    // Drop unroutable rows: without a slug/id the detail link goes nowhere.
+    if (!slug) return;
+    entities.push({
+      id: page.offset + index + 1,
+      entity_type: entityType,
+      name: derivedRowName(row, slug),
+      slug,
+      parent_id: null,
+      metadata: row,
+      created_at: createdAt,
+      total_content: 0,
+      active_connections: 0,
+      watchers_count: 0,
+      children_count: 0,
+    });
+  });
+
+  return {
+    entities,
+    hasMore: result.has_more,
+    totalCount: result.total_count,
+    limit: page.limit,
+    offset: page.offset,
+    sortBy: 'created_at',
+    sortOrder: 'desc',
+  };
 }
 
 // ============================================


### PR DESCRIPTION
## What

Make the backend own the "derived entity" abstraction so the frontend has a single entity path.

Derived ("view") entity types have no rows in \`entities\` — their rows come from \`backing_sql\`. Previously the frontend ran \`backing_sql\` itself (\`useDerivedEntityRows\`) and rendered a separate \`DerivedEntityView\` + modal. Now:

**Server**
- \`resolve_path\`: \`resolveDerivedLeaf()\` synthesizes a read-only \`ResolvedEntityDetails\` for a derived row matched by slug (paginated lookup; \`measure_columns\` inferred from the SQL).
- \`manage_entity\` list: \`listDerivedEntities()\` runs \`backing_sql\` and maps rows to the standard \`CreatedEntity\` shape.
- Shared \`derivedRowSlug\`/\`derivedRowName\` helpers (slug falls back to the \`id\` column; unroutable rows dropped). Reuses \`querySqlImpl\` (org-scoping / connection pushdown).

**Frontend (owletto #265, merged)**
- Deleted \`DerivedEntityView\` + \`useDerivedEntityRows\` (~540 lines). The normal entity table renders derived rows (measure-aware / all-columns fallback); rows deep-link to the routed detail page; detail is read-only. Backing SQL stays only on the entity-type settings form.

## Testing
- New integration tests (real PG): derived list (org-scoped), resolve-by-slug + inferred measures, unknown-slug 404, id-fallback routing — 4/4 pass.
- \`formatDerivedValue\` unit test (owletto).
- pi review caught 2 bugs (resolve 500-row cap; empty-slug rows) — both fixed + covered.

## Not yet done
- Browser e2e of the unified UI (typecheck/lint verified only).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1259"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784131507&installation_id=136316292&pr_number=1259&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1259&signature=e0cbeea8eed524b653c2657d76b1f8e0d4615e498f5429ffc7603845b82cb6b6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for derived entities (SQL views) in entity listing and path resolution
  * Derived entities now appear in query results with metadata indicating their derived nature and measurement columns

<!-- end of auto-generated comment: release notes by coderabbit.ai -->