### PR TITLE
test(server): regression coverage for supersession, json-template save, interaction guards

### DIFF
--- a/packages/server/src/__tests__/integration/events/save-content-json-template.test.ts
+++ b/packages/server/src/__tests__/integration/events/save-content-json-template.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Integration test: save_content payload_type='json_template' save-side schema.
+ *
+ * save_content (save_memory) validates the json_template contract at the
+ * handler level (save_content.ts), AFTER the org write gate and after
+ * `ensureMemberEntityType` (a DB write) — so this is necessarily a DB-backed
+ * test, not a pure unit test.
+ *
+ * Pinned behavior:
+ *   - payload_type='json_template' with NO payload_template → ToolUserError
+ *     ("payload_template is required when payload_type is 'json_template'").
+ *   - payload_type='json_template' WITH a payload_template that lacks a `root`
+ *     key → the handler does NOT enforce template structure; the save
+ *     SUCCEEDS and stores the template verbatim. (Structure is the renderer's
+ *     problem — and the renderer degrades gracefully on malformed templates;
+ *     see packages/owletto json-renderer/renderer.test.ts.)
+ *
+ * Vitest CI gap note (mirrors neighbors): runs locally / in the CI
+ * integration job against the pgvector DB via DATABASE_URL.
+ */
+
+import { beforeAll, describe, expect, it } from 'vitest';
+import { saveContent } from '../../../tools/save_content';
+import type { ToolContext } from '../../../tools/registry';
+import { initWorkspaceProvider } from '../../../workspace';
+import { cleanupTestDatabase, getTestDb } from '../../setup/test-db';
+import {
+  addUserToOrganization,
+  createTestOrganization,
+  createTestUser,
+  seedSystemEntityTypes,
+} from '../../setup/test-fixtures';
+
+describe('saveContent > json_template save-side schema', () => {
+  let org: Awaited<ReturnType<typeof createTestOrganization>>;
+  let user: Awaited<ReturnType<typeof createTestUser>>;
+  let ctx: ToolContext;
+
+  beforeAll(async () => {
+    await initWorkspaceProvider();
+    await cleanupTestDatabase();
+    await seedSystemEntityTypes();
+
+    org = await createTestOrganization({ name: 'JSON Template Org' });
+    user = await createTestUser({ email: 'json-template@example.com' });
+    await addUserToOrganization(user.id, org.id, 'owner');
+
+    ctx = {
+      organizationId: org.id,
+      userId: user.id,
+      memberRole: 'owner',
+      isAuthenticated: true,
+      tokenType: 'oauth',
+      scopedToOrg: false,
+      allowCrossOrg: true,
+      scopes: ['mcp:write'],
+    };
+  });
+
+  it("throws when payload_type='json_template' and payload_template is missing", async () => {
+    await expect(
+      saveContent(
+        {
+          payload_type: 'json_template',
+          payload_data: { score: 42 },
+          semantic_type: 'content',
+          metadata: {},
+        } as never,
+        {} as never,
+        ctx
+      )
+    ).rejects.toThrow(/payload_template is required when payload_type is 'json_template'/);
+  });
+
+  it('saves successfully when payload_template lacks a `root` key (no structural enforcement)', async () => {
+    // The handler only checks presence of payload_template, not its shape. A
+    // template missing `root` is accepted and stored verbatim; the renderer is
+    // responsible for graceful degradation at display time.
+    const result = await saveContent(
+      {
+        payload_type: 'json_template',
+        payload_template: { version: 1 /* no `root` */ },
+        payload_data: { score: 42 },
+        semantic_type: 'content',
+        title: 'Rootless template',
+        metadata: {},
+      } as never,
+      {} as never,
+      ctx
+    );
+
+    expect(result.id).toBeGreaterThan(0);
+    expect(result.semantic_type).toBe('content');
+
+    // The rootless template is persisted exactly as given.
+    const sql = getTestDb();
+    const rows = await sql`
+      SELECT payload_type, payload_template FROM events WHERE id = ${result.id}
+    `;
+    expect(rows).toHaveLength(1);
+    expect(rows[0].payload_type).toBe('json_template');
+    expect(rows[0].payload_template).toMatchObject({ version: 1 });
+    expect((rows[0].payload_template as Record<string, unknown>).root).toBeUndefined();
+  });
+});

--- a/packages/server/src/__tests__/integration/events/supersession-hidden-not-deleted.test.ts
+++ b/packages/server/src/__tests__/integration/events/supersession-hidden-not-deleted.test.ts
@@ -1,0 +1,162 @@
+/**
+ * Integration test: the "hidden, not deleted" supersession contract.
+ *
+ * `events` is append-only — superseding a row never physically removes it.
+ * The contract (advertised in the save_memory tool description and depended on
+ * by get_content.include_superseded) is:
+ *
+ *   1. The superseded row stays PHYSICALLY present in the raw `events` table.
+ *   2. It is ABSENT from `current_event_records` (the view that masks rows
+ *      with a newer superseder) and therefore absent from default get_content.
+ *   3. `include_superseded: true` on an entity-scoped chronological listing
+ *      surfaces BOTH the superseded original and its successor.
+ *
+ * Sibling coverage: delete-content-tombstone.test.ts pins the same contract
+ * for the tombstone (delete) path; get-content-visibility.test.ts pins the
+ * visibility predicate across the include_superseded branch. This file pins
+ * the raw-table-vs-view split directly.
+ *
+ * Vitest CI gap note (mirrors neighbors): runs locally against the dev/CI
+ * pgvector DB via DATABASE_URL; the integration job runs it in CI.
+ */
+
+import { beforeAll, describe, expect, it } from 'vitest';
+import { getContent } from '../../../tools/get_content';
+import type { ToolContext } from '../../../tools/registry';
+import { initWorkspaceProvider } from '../../../workspace';
+import { cleanupTestDatabase, getTestDb } from '../../setup/test-db';
+import {
+  addUserToOrganization,
+  createTestEntity,
+  createTestEvent,
+  createTestOrganization,
+  createTestUser,
+  seedSystemEntityTypes,
+} from '../../setup/test-fixtures';
+
+describe('supersession > hidden, not deleted', () => {
+  let org: Awaited<ReturnType<typeof createTestOrganization>>;
+  let user: Awaited<ReturnType<typeof createTestUser>>;
+  let entity: Awaited<ReturnType<typeof createTestEntity>>;
+  let ctx: ToolContext;
+
+  let originalId: number;
+  let successorId: number;
+
+  beforeAll(async () => {
+    await initWorkspaceProvider();
+    await cleanupTestDatabase();
+    await seedSystemEntityTypes();
+
+    org = await createTestOrganization({ name: 'Supersession Contract Org' });
+    user = await createTestUser({ email: 'supersession@example.com' });
+    await addUserToOrganization(user.id, org.id, 'owner');
+    entity = await createTestEntity({
+      name: 'Supersession Entity',
+      organization_id: org.id,
+    });
+
+    ctx = {
+      organizationId: org.id,
+      userId: user.id,
+      memberRole: 'owner',
+      isAuthenticated: true,
+      tokenType: 'oauth',
+      scopedToOrg: false,
+      allowCrossOrg: true,
+      scopes: ['mcp:read'],
+    };
+
+    // Original "old preference" event.
+    const original = await createTestEvent({
+      organization_id: org.id,
+      entity_id: entity.id,
+      content: 'Budget cap is 1000',
+      semantic_type: 'preference',
+    });
+    originalId = original.id;
+
+    // Successor event that supersedes the original. createTestEvent does not
+    // expose supersedes_event_id, so insert the successor with the linkage
+    // directly — the same approach delete-content-tombstone.test.ts uses for
+    // the tombstone row.
+    const sql = getTestDb();
+    const [succ] = await sql`
+      INSERT INTO events (
+        entity_ids, origin_id, payload_type, payload_text, occurred_at,
+        semantic_type, connector_key, metadata, organization_id,
+        supersedes_event_id, created_at
+      ) VALUES (
+        ${`{${entity.id}}`}::bigint[],
+        ${`test-supersede-${originalId}`},
+        'text',
+        'Budget cap is 2000',
+        NOW(),
+        'preference',
+        'test.connector',
+        ${sql.json({})},
+        ${org.id},
+        ${originalId},
+        NOW()
+      )
+      RETURNING id
+    `;
+    successorId = Number(succ.id);
+  });
+
+  it('keeps the superseded original PHYSICALLY present in the raw events table', async () => {
+    const sql = getTestDb();
+    const raw = await sql`SELECT id FROM events WHERE id = ${originalId}`;
+    expect(raw).toHaveLength(1);
+
+    // And the successor really does point at it.
+    const link = await sql`
+      SELECT supersedes_event_id FROM events WHERE id = ${successorId}
+    `;
+    expect(Number(link[0].supersedes_event_id)).toBe(originalId);
+  });
+
+  it('hides the superseded original from current_event_records (the masking view)', async () => {
+    const sql = getTestDb();
+    const inView = await sql`
+      SELECT id FROM current_event_records WHERE id = ${originalId}
+    `;
+    expect(inView).toHaveLength(0);
+
+    // The successor, having no newer superseder, IS in the view.
+    const successorInView = await sql`
+      SELECT id FROM current_event_records WHERE id = ${successorId}
+    `;
+    expect(successorInView).toHaveLength(1);
+  });
+
+  it('default get_content omits the superseded original but returns the successor', async () => {
+    const result = await getContent(
+      { entity_id: entity.id, limit: 100, sort_by: 'date', sort_order: 'desc' } as never,
+      {} as never,
+      ctx
+    );
+    const visibleIds = new Set(result.content.map((c) => c.id));
+
+    expect(visibleIds.has(originalId)).toBe(false);
+    expect(visibleIds.has(successorId)).toBe(true);
+  });
+
+  it('include_superseded=true returns BOTH the superseded original and the successor', async () => {
+    const result = await getContent(
+      {
+        entity_id: entity.id,
+        include_superseded: true,
+        limit: 100,
+        sort_by: 'date',
+        sort_order: 'desc',
+      } as never,
+      {} as never,
+      ctx
+    );
+    const ids = new Set(result.content.map((c) => c.id));
+
+    expect(ids.has(originalId)).toBe(true);
+    expect(ids.has(successorId)).toBe(true);
+  });
+});

--- a/packages/server/src/gateway/__tests__/interaction-guards.test.ts
+++ b/packages/server/src/gateway/__tests__/interaction-guards.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, test } from "bun:test";
+import {
+  assertRoutableInteraction,
+  assertSafeLinkButtonUrl,
+} from "../interactions.js";
+
+// These two guards are the post-time fail-closed checks that protect against
+// (a) cross-platform/cross-tenant event leakage when a chat-platform
+// interaction is posted without a routing key (#847), and (b) posting a link
+// button whose scheme could execute code in the user's client. They are pure
+// functions, so we exercise them directly.
+
+describe("assertRoutableInteraction", () => {
+  test("rejects a chat-platform interaction with no connectionId", () => {
+    expect(() =>
+      assertRoutableInteraction(undefined, "telegram", "question")
+    ).toThrow(/connectionId is required to prevent cross-platform event leakage/);
+  });
+
+  test("rejects an empty-string connectionId on a chat platform", () => {
+    expect(() =>
+      assertRoutableInteraction("", "slack", "link button")
+    ).toThrow(/connectionId is required/);
+  });
+
+  test("includes the interaction kind in the error message", () => {
+    expect(() =>
+      assertRoutableInteraction(undefined, "telegram", "tool approval")
+    ).toThrow(/Refusing to post tool approval/);
+  });
+
+  test("accepts a chat-platform interaction with a non-empty connectionId", () => {
+    expect(() =>
+      assertRoutableInteraction("marketing-telegram", "telegram", "question")
+    ).not.toThrow();
+  });
+
+  test("exempts platform=api even without a connectionId", () => {
+    // API sessions have no Chat SDK connection; their cards route by
+    // conversationId through the api platform's own subscriptions. Requiring a
+    // connectionId here is what silently broke ask_user/tool-approval for every
+    // API/SPA session (#847).
+    expect(() =>
+      assertRoutableInteraction(undefined, "api", "question")
+    ).not.toThrow();
+  });
+
+  test("api exemption also holds for status messages (no connectionId)", () => {
+    expect(() =>
+      assertRoutableInteraction(undefined, "api", "status message")
+    ).not.toThrow();
+  });
+});
+
+describe("assertSafeLinkButtonUrl", () => {
+  test("accepts https URLs", () => {
+    expect(() =>
+      assertSafeLinkButtonUrl("https://example.com/oauth/start")
+    ).not.toThrow();
+  });
+
+  test("accepts http URLs", () => {
+    expect(() =>
+      assertSafeLinkButtonUrl("http://localhost:8787/connect")
+    ).not.toThrow();
+  });
+
+  test("rejects javascript: scheme", () => {
+    expect(() =>
+      assertSafeLinkButtonUrl("javascript:alert(document.cookie)")
+    ).toThrow(/unsafe scheme: javascript:/);
+  });
+
+  test("rejects data: scheme", () => {
+    expect(() =>
+      assertSafeLinkButtonUrl("data:text/html,<script>alert(1)</script>")
+    ).toThrow(/unsafe scheme: data:/);
+  });
+
+  test("rejects file: scheme", () => {
+    expect(() => assertSafeLinkButtonUrl("file:///etc/passwd")).toThrow(
+      /unsafe scheme: file:/
+    );
+  });
+
+  test("rejects vbscript: scheme", () => {
+    expect(() =>
+      assertSafeLinkButtonUrl("vbscript:msgbox(1)")
+    ).toThrow(/unsafe scheme: vbscript:/);
+  });
+
+  test("rejects an unparseable URL", () => {
+    expect(() => assertSafeLinkButtonUrl("not a url")).toThrow(
+      /Invalid link button URL/
+    );
+  });
+});

--- a/packages/server/src/gateway/interactions.ts
+++ b/packages/server/src/gateway/interactions.ts
@@ -17,7 +17,7 @@ const SAFE_LINK_BUTTON_SCHEMES = new Set(["http:", "https:"]);
  * client (e.g. `javascript:`, `data:`, `vbscript:`, `file:`) when posted
  * as a link button. We only accept normal web URLs.
  */
-function assertSafeLinkButtonUrl(url: string): void {
+export function assertSafeLinkButtonUrl(url: string): void {
   let parsed: URL;
   try {
     parsed = new URL(url);
@@ -49,7 +49,7 @@ function assertSafeLinkButtonUrl(url: string): void {
  * there is no bridge to leak through. Requiring a connectionId here is what
  * silently broke ask_user/tool-approval for every API/SPA session (#847).
  */
-function assertRoutableInteraction(
+export function assertRoutableInteraction(
   connectionId: string | undefined,
   platform: string,
   kind: string


### PR DESCRIPTION
## What

Adds regression tests for three "advanced" features that were under-protected, after a prod audit confirmed they work but had coverage gaps.

### Server (this PR)
- **supersession-hidden-not-deleted.test.ts** — asserts a superseded event row is physically present in raw `events` but masked from `current_event_records` and default `get_content`; `include_superseded:true` returns both original and successor (the "hidden, not deleted" append-only contract).
- **save-content-json-template.test.ts** — `payload_type=json_template` without `payload_template` throws `ToolUserError`; a template lacking `root` persists verbatim (pins current behavior).
- **interaction-guards.test.ts** — unit tests for `assertRoutableInteraction` (chat platform requires `connectionId`; `platform:"api"` exempt) and `assertSafeLinkButtonUrl` (rejects `javascript:`/`data:`/`file:`/`vbscript:`/unparseable).
- Exported the two interaction guard helpers from `interactions.ts` so they're directly unit-testable (no behavior change).

### Owletto (separate PR)
The JSON-UI `renderer.test.ts` (+278 lines: card family, data-binding, metric, table, if/each, charts, and graceful degradation of malformed templates) lives in the `packages/owletto` submodule and ships via its own PR; the submodule pointer will be bumped after that merges.

## Verification
- `make review BASE=origin/main`: bug_free 88, simplicity 88, 0 bugs, 0 blockers, tests_adequate=true.
- New suites run green (bun interaction-guards; vitest new integration event tests). The integration `exit=1` in the run is a pre-existing unrelated `media.test.ts` hook timeout on untouched code.

## Background
The audit also surfaced two product findings handled separately: the JSON-UI DSL is undocumented, and the owletto SPA "Chat" returns 403 for agent runs (anonymous web userId not in agent owners) — fix in progress on its own branch.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1263"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784145285&installation_id=136316292&pr_number=1263&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1263&signature=8e7705dad1dcdbba08c388d3693b90fc5da5778ae5ca3b4fe987a999dd7155fc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->