### PR TITLE
fix(gateway): SPA agent runs 403 — authorize by agent's resolved org, not ambient default org

### DIFF
--- a/packages/server/src/gateway/__tests__/agent-session-create-cross-org-owner.test.ts
+++ b/packages/server/src/gateway/__tests__/agent-session-create-cross-org-owner.test.ts
@@ -120,10 +120,13 @@ function makeApp(
   return { app, getStored: session.getStored };
 }
 
-async function postCreate(app: Hono): Promise<Response> {
+async function postCreate(
+  app: Hono,
+  extraHeaders: Record<string, string> = {}
+): Promise<Response> {
   return app.request("/api/v1/agents", {
     method: "POST",
-    headers: { "content-type": "application/json" },
+    headers: { "content-type": "application/json", ...extraHeaders },
     // The body userId is the SPA's synthetic per-browser id — irrelevant to
     // ownership, which is resolved from the authenticated session.
     body: JSON.stringify({
@@ -283,5 +286,47 @@ describe("POST /api/v1/agents — owner of a non-default-org agent", () => {
     const res = await postCreate(app);
 
     expect(res.status).toBe(403);
+  });
+
+  test("org-bound Bearer/PAT (authoritative org=A) is DENIED an agent that resolves to org=B, mints NO session", async () => {
+    // Tenant-isolation BLOCKER (pi-confirmed): the create path passes no
+    // `sessionForTenantCheck` (no pre-existing session), so the early guard
+    // can't fire. A Bearer/PAT pinned to org A whose user ALSO owns the same
+    // agentId in org B must NOT be allowed to mint a session for the org-B
+    // agent — that would be cross-tenant escalation. `authorizeOwnership`'s
+    // authoritative-caller-org guard catches it.
+    //
+    // Setup: the same OWNER_USER_ID owns `crm` in AGENT_ORG (seeded in
+    // beforeEach), but this request is pinned to CALLER_DEFAULT_ORG via a
+    // Bearer + ambient org. `findAgentOrganizations` resolves crm to AGENT_ORG;
+    // authoritativeCallerOrgId = CALLER_DEFAULT_ORG → mismatch → 403.
+    //
+    // NOTE: the COOKIE form of this exact scenario (same user, same orgs, NO
+    // Bearer) is the legitimate SPA case and returns 201 — proven by the first
+    // test above. The ONLY difference is the presence of an authoritative
+    // (Bearer-bound) caller org.
+    setAuthProvider(() => ownerSession());
+    const { app, getStored } = makeApp(
+      userAgentsStore,
+      agentMetadataStore,
+      // Ambient org is the PAT's pinned org A — authoritative because a Bearer
+      // is present on the request.
+      CALLER_DEFAULT_ORG
+    );
+
+    const res = await postCreate(app, {
+      // A non-worker, non-OAuth Bearer (PAT-shaped). The settings-session
+      // provider authenticates the user; the Bearer's presence is what makes
+      // the ambient org authoritative in requireAgentOwnership.
+      Authorization: "Bearer owl_pat_test_token",
+    });
+
+    expect(res.status).toBe(403);
+    expect((await res.json()) as { error?: string }).toEqual({
+      success: false,
+      error: "Forbidden",
+    });
+    // No session may be minted for the org-B agent.
+    expect(getStored()).toBeNull();
   });
 });

--- a/packages/server/src/gateway/__tests__/agent-session-create-cross-org-owner.test.ts
+++ b/packages/server/src/gateway/__tests__/agent-session-create-cross-org-owner.test.ts
@@ -1,0 +1,287 @@
+/**
+ * POST /api/v1/agents — a signed-in owner can start a chat session for an
+ * agent that lives in a NON-default org (regression for the SPA "Chat" 403).
+ *
+ * Prod repro: the owletto SPA POSTs `/lobu/api/v1/agents` with the better-auth
+ * cookie. `createLobuOrgContextMiddleware` pins the request's ambient
+ * org-context to the user's DEFAULT org. But the agent the user is chatting
+ * with (e.g. `crm`) lives in a DIFFERENT org (`org_lobucrm`). The old
+ * ownership check called `UserAgentsStore.ownsAgent`, which reads the ambient
+ * org from AsyncLocalStorage — so it queried `agent_users` in the wrong org,
+ * found nothing, and returned 403 for every chat run against a non-default-org
+ * agent.
+ *
+ * The fix authorizes against the org the agent ACTUALLY lives in, resolved
+ * from `agent_users` independent of the ambient org-context. This test pins the
+ * ALS org to a different org than the agent's and asserts the owner is now
+ * authorized (201), and stamps the session with the agent's REAL org — while a
+ * non-owner / cross-org caller still gets 403.
+ */
+
+import { afterEach, beforeAll, beforeEach, describe, expect, test } from "bun:test";
+import { Hono } from "hono";
+import { createAgentApi } from "../routes/public/agent.js";
+import { setAuthProvider } from "../routes/public/settings-auth.js";
+import { AgentMetadataStore } from "../auth/agent-metadata-store.js";
+import { UserAgentsStore } from "../auth/user-agents-store.js";
+import type { SettingsTokenPayload } from "../auth/settings/token-service.js";
+import { createPostgresAgentConfigStore } from "../../lobu/stores/postgres-stores.js";
+import { orgContext } from "../../lobu/stores/org-context.js";
+import type { ThreadSession } from "../session.js";
+import {
+  ensureDbForGatewayTests,
+  resetTestDatabase,
+  seedAgentRow,
+} from "./helpers/db-setup.js";
+
+// The agent lives here; the caller's ambient/default org is intentionally
+// something else to reproduce the prod mismatch.
+const AGENT_ORG = "org-lobucrm-test";
+const CALLER_DEFAULT_ORG = "org-personal-default-test";
+const OTHER_ORG = "org-outsider-test";
+
+const AGENT_ID = "crm";
+const OWNER_USER_ID = "owner-user-8a2D";
+const OUTSIDER_USER_ID = "outsider-user-zzz";
+
+function ownerSession(): SettingsTokenPayload {
+  // Mirrors the embedded authProvider: better-auth user → external identity,
+  // no oauthUserId, so the lookup key is `userId`.
+  return {
+    userId: OWNER_USER_ID,
+    platform: "external",
+    exp: Date.now() + 60_000,
+  };
+}
+
+function outsiderSession(): SettingsTokenPayload {
+  return {
+    userId: OUTSIDER_USER_ID,
+    platform: "external",
+    exp: Date.now() + 60_000,
+  };
+}
+
+/**
+ * Session manager that stores sessions by conversationId so the follow-up
+ * GET route can resolve the row created by POST.
+ */
+function makeSessionManager() {
+  const store = new Map<string, ThreadSession>();
+  let lastStored: ThreadSession | null = null;
+  return {
+    mgr: {
+      async getSession(key: string) {
+        return store.get(key) ?? null;
+      },
+      async setSession(session: ThreadSession) {
+        store.set(session.conversationId, session);
+        lastStored = session;
+      },
+      async touchSession() {},
+      async deleteSession(key: string) {
+        store.delete(key);
+      },
+    } as never,
+    getStored: () => lastStored,
+  };
+}
+
+/**
+ * Mount `createAgentApi` behind a wrapper that reproduces the production
+ * ambient org-context: `createLobuOrgContextMiddleware` calls
+ * `c.set("organizationId", <default org>)` AND wraps the request in
+ * `orgContext.run()`. The early tenant guard in `requireAgentOwnership` reads
+ * `c.get("organizationId")`, so the bug is only reproducible when that ambient
+ * value is set on the Hono context — not merely present in AsyncLocalStorage.
+ */
+function makeApp(
+  userAgentsStore: UserAgentsStore,
+  agentMetadataStore: AgentMetadataStore,
+  ambientOrg: string
+) {
+  const session = makeSessionManager();
+  const agentApi = createAgentApi({
+    queueProducer: {} as never,
+    sessionManager: session.mgr,
+    sseManager: { hasActiveConnection: () => false } as never,
+    publicGatewayUrl: "http://localhost:8787",
+    userAgentsStore,
+    agentMetadataStore: agentMetadataStore as never,
+  });
+
+  const app = new Hono();
+  app.use("*", async (c, next) => {
+    c.set("organizationId", ambientOrg);
+    return orgContext.run({ organizationId: ambientOrg }, () => next());
+  });
+  app.route("/", agentApi);
+
+  return { app, getStored: session.getStored };
+}
+
+async function postCreate(app: Hono): Promise<Response> {
+  return app.request("/api/v1/agents", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    // The body userId is the SPA's synthetic per-browser id — irrelevant to
+    // ownership, which is resolved from the authenticated session.
+    body: JSON.stringify({
+      agentId: AGENT_ID,
+      userId: "web-aede75e7",
+      thread: "agent-panel",
+    }),
+  });
+}
+
+async function getStatus(app: Hono, sessionKey: string): Promise<Response> {
+  return app.request(`/api/v1/agents/${encodeURIComponent(sessionKey)}`, {
+    method: "GET",
+  });
+}
+
+describe("POST /api/v1/agents — owner of a non-default-org agent", () => {
+  let userAgentsStore: UserAgentsStore;
+  let agentMetadataStore: AgentMetadataStore;
+
+  beforeAll(async () => {
+    // First call boots an embedded Postgres + runs migrations — allow ample
+    // time so the boot doesn't leak into the per-test beforeEach window.
+    await ensureDbForGatewayTests();
+  }, 120_000);
+
+  beforeEach(async () => {
+    await resetTestDatabase();
+    const configStore = createPostgresAgentConfigStore();
+    agentMetadataStore = new AgentMetadataStore(configStore);
+    userAgentsStore = new UserAgentsStore();
+
+    // The agent + its owner mapping live in AGENT_ORG only.
+    await orgContext.run({ organizationId: AGENT_ORG }, async () => {
+      await seedAgentRow(AGENT_ID, {
+        organizationId: AGENT_ORG,
+        ownerPlatform: "external",
+        ownerUserId: OWNER_USER_ID,
+      });
+      await userAgentsStore.addAgent("external", OWNER_USER_ID, AGENT_ID);
+    });
+
+    // Ensure the caller's default org and the outsider org exist as rows
+    // (they have NO agent_users entry for AGENT_ID).
+    await seedAgentRow("placeholder-default", { organizationId: CALLER_DEFAULT_ORG });
+    await seedAgentRow("placeholder-other", { organizationId: OTHER_ORG });
+  }, 60_000);
+
+  afterEach(() => {
+    setAuthProvider(null);
+  });
+
+  test("owner is authorized even when the ambient org is their DIFFERENT default org (was 403)", async () => {
+    setAuthProvider(() => ownerSession());
+    // Ambient org = caller's default org, which is NOT where the agent lives.
+    const { app, getStored } = makeApp(
+      userAgentsStore,
+      agentMetadataStore,
+      CALLER_DEFAULT_ORG
+    );
+
+    const res = await postCreate(app);
+
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as { success: boolean };
+    expect(body.success).toBe(true);
+
+    // The session must be stamped with the agent's REAL org, not the
+    // caller's ambient default org — otherwise the worker would run under the
+    // wrong tenant (wrong secrets/MCP scope).
+    const stored = getStored();
+    expect(stored?.organizationId).toBe(AGENT_ORG);
+  });
+
+  test("FOLLOW-UP GET /api/v1/agents/:sessionKey succeeds for the owner under their default ambient org (was 403)", async () => {
+    setAuthProvider(() => ownerSession());
+    const { app } = makeApp(
+      userAgentsStore,
+      agentMetadataStore,
+      CALLER_DEFAULT_ORG
+    );
+
+    // 1. Create the session (already proven to 201).
+    const createRes = await postCreate(app);
+    expect(createRes.status).toBe(201);
+    const { agentId: sessionKey } = (await createRes.json()) as {
+      agentId: string;
+    };
+
+    // 2. The SPA's NEXT request (status / SSE / messages all share the same
+    //    early ambient-org guard). The session row is stamped with AGENT_ORG
+    //    while the request's ambient org is still CALLER_DEFAULT_ORG. Before
+    //    the follow-up fix, the early guard saw
+    //    `c.get("organizationId") (CALLER_DEFAULT_ORG) !==
+    //    session.organizationId (AGENT_ORG)` and returned 403, so SPA chat
+    //    broke on the second request even though POST succeeded.
+    const getRes = await getStatus(app, sessionKey);
+    expect(getRes.status).toBe(200);
+    const getBody = (await getRes.json()) as { success: boolean };
+    expect(getBody.success).toBe(true);
+  });
+
+  test("FOLLOW-UP GET still 403s for a cross-org non-owner sharing the session key (tenant isolation preserved)", async () => {
+    // The owner creates a session (stamped with AGENT_ORG).
+    setAuthProvider(() => ownerSession());
+    const owned = makeApp(userAgentsStore, agentMetadataStore, AGENT_ORG);
+    const createRes = await postCreate(owned.app);
+    expect(createRes.status).toBe(201);
+    const { agentId: sessionKey } = (await createRes.json()) as {
+      agentId: string;
+    };
+
+    // An outsider (member of OTHER_ORG, owns no agent_users row for crm) tries
+    // to read the owner's session via the same key. Drive the request through
+    // the OWNER's app instance so the session row actually exists — this forces
+    // the OWNERSHIP gate (not a 404 short-circuit on a missing session). The
+    // early ambient-org guard is now skipped for cookie auth, so the
+    // authoritative resolved-org check in authorizeOwnership must still deny:
+    // the outsider resolves no owning org for crm, so `verifyOwnedAgentAccess`
+    // is unauthorized → 403.
+    setAuthProvider(() => outsiderSession());
+    const getRes = await getStatus(owned.app, sessionKey);
+    expect(getRes.status).toBe(403);
+    expect((await getRes.json()) as { error?: string }).toEqual({
+      success: false,
+      error: "Forbidden",
+    });
+  });
+
+  test("a non-owner in a different org still gets 403 on create (tenant isolation preserved)", async () => {
+    setAuthProvider(() => outsiderSession());
+    // Outsider authenticated, ambient org is their own — they own no
+    // agent_users row for crm in ANY org.
+    const { app, getStored } = makeApp(
+      userAgentsStore,
+      agentMetadataStore,
+      OTHER_ORG
+    );
+
+    const res = await postCreate(app);
+
+    expect(res.status).toBe(403);
+    expect((await res.json()) as { error?: string }).toEqual({
+      success: false,
+      error: "Forbidden",
+    });
+    expect(getStored()).toBeNull();
+  });
+
+  test("even when an outsider's ambient org IS the agent's org, ownership still denies (no agent_users row)", async () => {
+    // Defense-in-depth: a caller cannot piggyback on the agent's org just by
+    // having the ambient context point there. Authorization is keyed on the
+    // caller's own (platform, userId) agent_users row, which the outsider lacks.
+    setAuthProvider(() => outsiderSession());
+    const { app } = makeApp(userAgentsStore, agentMetadataStore, AGENT_ORG);
+
+    const res = await postCreate(app);
+
+    expect(res.status).toBe(403);
+  });
+});

--- a/packages/server/src/gateway/routes/public/agent.ts
+++ b/packages/server/src/gateway/routes/public/agent.ts
@@ -517,6 +517,20 @@ export function createAgentApi(config: AgentApiConfig): OpenAPIHono {
 
     const bearer = tokenFromHeader(c);
 
+    // The caller's AUTHORITATIVE org, if the auth method bound one:
+    //   - `authContext.organizationId` is set only by token auth (worker
+    //     token payload / external-OAuth userinfo).
+    //   - For PAT auth, `createLobuAuthBridge` sets `c.get("organizationId")`
+    //     from the PAT's pinned org (or a membership-verified `x-lobu-org`),
+    //     and a PAT always carries a Bearer token — so gate the ambient read
+    //     on `bearer` to exclude the cookie path, whose `c.get("organizationId")`
+    //     is just the user's DEFAULT org (NOT authoritative for this agent).
+    // Undefined for the settings-session COOKIE path (no bearer, no authContext
+    // org), which correctly falls through to ownership resolution below.
+    const authoritativeCallerOrgId =
+      c.get("authContext")?.organizationId ??
+      (bearer ? (c.get("organizationId") as string | undefined) : undefined);
+
     // Tenant guard: agent-id-string ownership is per (platform, userId,
     // agentId) — but the agentId string can repeat across tenants (the
     // global `DEFAULT_AGENT_ID` constant, or two orgs that happen to share
@@ -549,12 +563,9 @@ export function createAgentApi(config: AgentApiConfig): OpenAPIHono {
     //     can only authorize against agent_users rows naming their own
     //     (platform, userId), never another tenant's agent.
     if (sessionForTenantCheck?.organizationId) {
-      const callerOrgId =
-        c.get("authContext")?.organizationId ??
-        (bearer ? (c.get("organizationId") as string | undefined) : undefined);
       if (
-        callerOrgId &&
-        sessionForTenantCheck.organizationId !== callerOrgId
+        authoritativeCallerOrgId &&
+        sessionForTenantCheck.organizationId !== authoritativeCallerOrgId
       ) {
         return deny();
       }
@@ -576,6 +587,30 @@ export function createAgentApi(config: AgentApiConfig): OpenAPIHono {
       organizationId?: string;
     }): Response | { organizationId?: string } => {
       if (!access.authorized) return deny();
+
+      // Cross-tenant guard #1: a caller with an AUTHORITATIVE org (token/PAT)
+      // must not act on an agent that resolves to a DIFFERENT org. createAgent
+      // passes no `sessionForTenantCheck` (there's no pre-existing session), so
+      // the early guard above can't catch this — without this check a PAT
+      // pinned to orgA whose user ALSO owns the same agentId in orgB would mint
+      // a session stamped orgB (cross-tenant escalation). The cookie path has
+      // no authoritative org → `authoritativeCallerOrgId` is undefined → this
+      // never fires for it (its isolation rides guard #2 below).
+      if (
+        authoritativeCallerOrgId &&
+        access.organizationId &&
+        access.organizationId !== authoritativeCallerOrgId
+      ) {
+        return deny();
+      }
+
+      // Cross-tenant guard #2: when a pre-existing session is supplied, the
+      // agent's resolved org must match the session's org. This is the
+      // authoritative isolation check for the settings-session COOKIE path
+      // (which has no `authoritativeCallerOrgId`): e.g. a cookie user reaching
+      // another org's session via a shared agentId (the global
+      // DEFAULT_AGENT_ID) resolves to their own org, which differs from the
+      // session's → deny.
       const tenantOrg = sessionForTenantCheck?.organizationId;
       if (
         tenantOrg &&

--- a/packages/server/src/gateway/routes/public/agent.ts
+++ b/packages/server/src/gateway/routes/public/agent.ts
@@ -501,15 +501,21 @@ export function createAgentApi(config: AgentApiConfig): OpenAPIHono {
    *                            run through verifyOwnedAgentAccess
    *
    * Returns a Response when the caller is not authorized (the handler
-   * should early-return it). Returns null on success.
+   * should early-return it). On success returns `{ organizationId }` — the
+   * org the agent was authorized under (resolved from `agent_users`, NOT the
+   * caller's ambient org-context), so the handler can stamp the worker token
+   * and session with the agent's real tenant. `organizationId` may be
+   * undefined for auth paths that don't resolve one (worker token / admin).
    */
   async function requireAgentOwnership(
     c: Context,
     resolvedAgentId: string,
     sessionForTenantCheck?: { organizationId?: string } | null
-  ): Promise<Response | null> {
+  ): Promise<Response | { organizationId?: string }> {
     const deny = () =>
       c.json({ success: false, error: "Forbidden" }, 403) as Response;
+
+    const bearer = tokenFromHeader(c);
 
     // Tenant guard: agent-id-string ownership is per (platform, userId,
     // agentId) — but the agentId string can repeat across tenants (the
@@ -521,10 +527,31 @@ export function createAgentApi(config: AgentApiConfig): OpenAPIHono {
     // ownership keeps the response uniform (no enumeration oracle on which
     // check failed). Routes that load a session before calling this MUST
     // pass it in; createAgent has no pre-existing session and passes null.
+    //
+    // The org we compare against MUST be an AUTHORITATIVE auth-method-bound
+    // org, NOT the request's ambient org-context:
+    //   - `authContext.organizationId` is set only by token auth (worker
+    //     token payload / external-OAuth userinfo) — authoritative.
+    //   - For PAT auth, `createLobuAuthBridge` sets `c.get("organizationId")`
+    //     from the PAT's pinned org (or a membership-verified `x-lobu-org`) —
+    //     authoritative, and a PAT always carries a Bearer token.
+    //   - For the SETTINGS-SESSION COOKIE path (the owletto SPA), there is NO
+    //     Bearer token; `createLobuOrgContextMiddleware` sets
+    //     `c.get("organizationId")` to the user's DEFAULT org, which need NOT
+    //     match the agent's org (e.g. owning `crm` in `org_lobucrm` while the
+    //     default org is personal). Using that ambient default here produced a
+    //     spurious 403 on every follow-up SPA request (GET / SSE / messages)
+    //     even though POST succeeded. So skip the ambient `organizationId`
+    //     guard for the cookie path and let `authorizeOwnership` below enforce
+    //     tenant isolation via the agent's REAL org resolved from
+    //     `agent_users` vs the session (the same authoritative resolution the
+    //     create path uses). Tenant isolation is preserved: a cookie caller
+    //     can only authorize against agent_users rows naming their own
+    //     (platform, userId), never another tenant's agent.
     if (sessionForTenantCheck?.organizationId) {
       const callerOrgId =
-        (c.get("organizationId") as string | undefined) ??
-        c.get("authContext")?.organizationId;
+        c.get("authContext")?.organizationId ??
+        (bearer ? (c.get("organizationId") as string | undefined) : undefined);
       if (
         callerOrgId &&
         sessionForTenantCheck.organizationId !== callerOrgId
@@ -547,7 +574,7 @@ export function createAgentApi(config: AgentApiConfig): OpenAPIHono {
     const authorizeOwnership = (access: {
       authorized: boolean;
       organizationId?: string;
-    }): Response | null => {
+    }): Response | { organizationId?: string } => {
       if (!access.authorized) return deny();
       const tenantOrg = sessionForTenantCheck?.organizationId;
       if (
@@ -557,10 +584,8 @@ export function createAgentApi(config: AgentApiConfig): OpenAPIHono {
       ) {
         return deny();
       }
-      return null;
+      return { organizationId: access.organizationId };
     };
-
-    const bearer = tokenFromHeader(c);
 
     // 1. Settings session cookie (or injected auth provider for embedded mode).
     const settingsSession = await verifySettingsSession(c);
@@ -587,7 +612,9 @@ export function createAgentApi(config: AgentApiConfig): OpenAPIHono {
         return deny();
       }
       const workerAgentId = workerData.agentId || workerData.userId;
-      return workerAgentId && workerAgentId === resolvedAgentId ? null : deny();
+      return workerAgentId && workerAgentId === resolvedAgentId
+        ? { organizationId: workerData.organizationId }
+        : deny();
     }
 
     // 3. External OAuth (Lobu / memory-url userinfo).
@@ -711,18 +738,22 @@ export function createAgentApi(config: AgentApiConfig): OpenAPIHono {
       agentId = DEFAULT_AGENT_ID;
     }
 
-    const ownershipDenial = await requireAgentOwnership(c, agentId);
-    if (ownershipDenial) return ownershipDenial;
+    const ownership = await requireAgentOwnership(c, agentId);
+    if (ownership instanceof Response) return ownership;
 
     // Stamp the worker token with the agent's owning org so the egress
-    // proxy's per-tenant gates (grant/deny, judge cache, judge policy)
-    // can scope decisions by org. Prefer the agent's metadata; fall back
-    // to the caller's auth-context org for the default-agent route where
-    // the lookup above already proved ownership.
+    // proxy's per-tenant gates (grant/deny, judge cache, judge policy) can
+    // scope decisions by org. Prefer the org the ownership check resolved
+    // from `agent_users` — that's the agent's REAL tenant, even when the
+    // caller's ambient org-context is their (different) default org, which
+    // is exactly the SPA-chat case for an agent in a non-default org. Fall
+    // back to the ALS-scoped metadata lookup and then the caller's
+    // auth-context org for paths that don't resolve one (worker token).
     const metadataOrgId = ownershipMetadataStore
       ? (await ownershipMetadataStore.getMetadata(agentId))?.organizationId
       : undefined;
-    const tokenOrganizationId = metadataOrgId ?? callerOrgId;
+    const tokenOrganizationId =
+      ownership.organizationId ?? metadataOrgId ?? callerOrgId;
 
     const watcherIntent = intent?.kind === "watcher_run" ? intent : null;
     // userId backs `conversationId = ${agentId}_${userId}[_${thread}]`, which
@@ -889,7 +920,7 @@ export function createAgentApi(config: AgentApiConfig): OpenAPIHono {
       session.agentId || sessionKey,
       session
     );
-    if (denial) return denial;
+    if (denial instanceof Response) return denial;
 
     const hasActiveConnection = sseManager.hasActiveConnection(sessionKey);
 
@@ -918,7 +949,7 @@ export function createAgentApi(config: AgentApiConfig): OpenAPIHono {
       existingSession?.agentId || sessionKey,
       existingSession
     );
-    if (denial) return denial;
+    if (denial instanceof Response) return denial;
 
     // Close connections + drop backlog so a later connection with the same
     // key (rare, but possible with deterministic conversationIds) can't
@@ -955,7 +986,7 @@ export function createAgentApi(config: AgentApiConfig): OpenAPIHono {
       session.agentId || sessionKey,
       session
     );
-    if (denial) return denial;
+    if (denial instanceof Response) return denial;
 
     // Check connection limits
     if (sseManager.totalConnections() >= MAX_TOTAL_CONNECTIONS) {
@@ -1073,7 +1104,7 @@ export function createAgentApi(config: AgentApiConfig): OpenAPIHono {
       preSession?.agentId || agentId,
       preSession
     );
-    if (ownershipDenial) return ownershipDenial;
+    if (ownershipDenial instanceof Response) return ownershipDenial;
 
     // Parse body — multipart for file uploads, JSON otherwise
     const contentType = c.req.header("content-type") || "";

--- a/packages/server/src/gateway/routes/shared/agent-ownership.ts
+++ b/packages/server/src/gateway/routes/shared/agent-ownership.ts
@@ -57,12 +57,16 @@ function sessionMatchesMetadataOwner(
  * human owning the same agentId across two orgs would get the wrong
  * row. Codex round 2 finding B on PR #865.
  *
- * Returns `undefined` if no `agent_users` row matches — the caller's
- * authorisation already required `ownsAgent` to be true, so this only
- * triggers for the admin / session.agentId paths where ownership isn't
- * enforced. Downstream code (snapshot fallback) treats `undefined` as
- * "no scope to query under" and returns null rather than serving cross-
- * tenant bytes.
+ * Returns `undefined` when the user owns no instance of `agentId` (no
+ * matching `agent_users` row in any org) OR owns it in more than one org.
+ * The non-admin path now treats a defined result as the authorisation
+ * signal itself: a single owning org means the caller demonstrably owns
+ * this agent (the row names their own platform+userId) and that org is the
+ * agent's real tenant — independent of the request's ambient org-context,
+ * which on the unscoped chat route is the caller's DEFAULT org and need
+ * not match the agent's org. Downstream code (snapshot fallback) treats
+ * `undefined` as "no scope to query under" and returns null rather than
+ * serving cross-tenant bytes.
  *
  * When `agent_users` has multiple rows (same user, same agentId,
  * multiple orgs) we deliberately take none — there's no way to pick
@@ -121,18 +125,30 @@ export async function verifyOwnedAgentAccess(
 
   const lookupUserId = resolveSettingsLookupUserId(session);
   if (config.userAgentsStore) {
-    const owns = await config.userAgentsStore.ownsAgent(
+    // Authorize against the org the agent ACTUALLY lives in, resolved from
+    // the authoritative `agent_users` mapping — NOT the caller's ambient
+    // org-context. The cookie/session routes (SPA chat: POST/GET
+    // /api/v1/agents[/*] + the EventSource SSE that can't send headers)
+    // reach here under `createLobuOrgContextMiddleware`, which pins the ALS
+    // org to the user's DEFAULT org. A user whose default org differs from
+    // the agent's org (e.g. owning `crm` in `org_lobucrm` while their
+    // personal org is the default) would fail an ALS-scoped `ownsAgent`
+    // lookup and get a spurious 403 on every chat run. `findAgentOrganizations`
+    // answers "which orgs does THIS user own THIS agent in" independent of
+    // the ambient org, so chat works for any agent the signed-in user
+    // legitimately owns. Tenant isolation holds: the result is keyed on the
+    // caller's own (platform, userId) — a caller can only authorize against
+    // agent_users rows that name them, never another tenant's agent. When the
+    // user owns the same agentId in multiple orgs we decline (orgs.length !==
+    // 1 in resolveAuthorizedOrgId) because the unscoped route carries no org
+    // selector to disambiguate tenant-safely.
+    const organizationId = await resolveAuthorizedOrgId(
+      config.userAgentsStore,
+      agentId,
       session.platform,
-      lookupUserId,
-      agentId
+      lookupUserId
     );
-    if (owns) {
-      const organizationId = await resolveAuthorizedOrgId(
-        config.userAgentsStore,
-        agentId,
-        session.platform,
-        lookupUserId
-      );
+    if (organizationId) {
       return {
         authorized: true,
         ownerPlatform: session.platform,


### PR DESCRIPTION
## The bug (found live in prod)

The owletto SPA **Chat** tab returned 403 on every agent run whose org differs from the caller's default org — i.e. effectively all of them. Captured live: `POST /lobu/api/v1/agents` `{"agentId":"crm",...}` → `403 {"error":"Forbidden"}`.

Root cause: SPA chat hits the **unscoped** `/api/v1/agents` route (the EventSource SSE can't send an org header), so `createLobuOrgContextMiddleware` pins the ambient org to the user's **default org**. Ownership was checked against that ambient org via `ownsAgent` → `agent_users WHERE organization_id = <defaultOrg>` → 0 rows → 403, even though the user owns the agent in another org (e.g. `crm` in `org_lobucrm` while the default org is personal).

## The fix

- `agent-ownership.ts` — authorize from `agent_users` (the agent's **real** org) independent of ambient org-context; decline ambiguous multi-org ownership (unscoped route can't disambiguate tenant-safely).
- `agent.ts` — `requireAgentOwnership` returns the agent's real org and stamps the worker session with it. The early ambient-org tenant guard now only trusts an **authoritative** auth-bound org (worker/OAuth `authContext`, or `c.get("organizationId")` when a Bearer is present), so the cookie/SPA path falls through to `authorizeOwnership`. One guard covers all 5 routes (POST/GET/DELETE/SSE/messages) — the create-only fix initially missed the follow-up routes (caught in review).

## Tenant isolation

Preserved — authorization is keyed on the caller's own `(platform, userId)` `agent_users` rows; a caller can only authorize against rows naming them, never another tenant's agent. Cross-org non-members still get 403.

## Tests
`agent-session-create-cross-org-owner.test.ts` (DB-backed): POST create → GET session → **200** (red→green, was 403); cross-org non-owner GET → **403**. Existing cross-tenant cookie/token isolation suites stay green.

## Verification
`make review BASE=origin/main`: **bug_free 86, 0 bugs, 0 blockers, tests_adequate**. Independently corroborated (the initial create-only fix's follow-up-route gap was caught by pi review and fixed).

## Owed
Live browser→worker SSE e2e against a non-default-org agent (POST 201 **and** a streamed reply) — the runtime payoff, not yet driven on a prod-like stack.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1265"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784148196&installation_id=136316292&pr_number=1265&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1265&signature=b54ebae82d268d19d8e11f04bca76853e34a70f016a931c0bd79dacff76179ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->