### PR TITLE
feat(metrics): metric compiler (alias resolver) + runMetric + golden test

### DIFF
--- a/packages/server/src/__tests__/integration/metrics/compiler-golden.test.ts
+++ b/packages/server/src/__tests__/integration/metrics/compiler-golden.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Golden test for the metric compiler (alias resolver). Seeds Revolut-style
+ * charges + a "company" entity with aliases, then runs the declared
+ * `company.spend` measure end-to-end (compile → org-scope → execute) and asserts
+ * the DEDUPED, outflow-only, per-currency sum. This is the correctness gate:
+ * it covers alias matching, dedupe, segment filtering, the currency dimension,
+ * and SUM — the exact pipeline that must not silently over/under-count.
+ */
+
+import { beforeAll, describe, expect, it } from 'vitest';
+import {
+  addUserToOrganization,
+  createTestEntity,
+  createTestEvent,
+  createTestOrganization,
+  createTestUser,
+} from '../../setup/test-fixtures';
+import { getTestDb } from '../../setup/test-db';
+import { cleanupTestDatabase } from '../../setup/test-db';
+import { TestApiClient } from '../../setup/test-mcp-client';
+import { runMetric } from '../../../metrics/run-metric';
+
+const METRICS = {
+  eventSets: {
+    charges: {
+      by: 'alias',
+      field: "metadata->>'description'",
+      against: 'aliases',
+      where: "semantic_type='transaction' AND connector_key='revolut'",
+      dedupeKey: ["metadata->>'date'", "metadata->>'amount'", "metadata->>'description'"],
+    },
+  },
+  segments: {
+    outflow: {
+      description: 'Money leaving the account.',
+      where: "metadata->>'direction'='out'",
+      on: 'event',
+      appliedBefore: 'dedupe',
+    },
+  },
+  measures: {
+    spend: {
+      eventSet: 'charges',
+      agg: 'sum',
+      expr: "(metadata->>'amount')::numeric",
+      segments: ['outflow'],
+      description: 'Total outflow to this company, by currency.',
+    },
+    charges: {
+      eventSet: 'charges',
+      agg: 'count',
+      segments: ['outflow'],
+      description: 'Number of distinct outflow charges.',
+    },
+  },
+  dimensions: {
+    currency: { expr: "metadata->>'currency'", description: 'Charge currency.' },
+  },
+};
+
+describe('metric compiler — alias resolver golden', () => {
+  let orgId: string;
+
+  beforeAll(async () => {
+    await cleanupTestDatabase();
+    const org = await createTestOrganization({ name: 'Metric Golden Org' });
+    orgId = org.id;
+    const user = await createTestUser({ email: 'metric-golden@test.com' });
+    await addUserToOrganization(user.id, org.id, 'owner');
+    const owner = await TestApiClient.for({
+      organizationId: org.id,
+      userId: user.id,
+      memberRole: 'owner',
+    });
+
+    // The declared metric layer for "company".
+    await owner.entity_schema.createType({
+      slug: 'company',
+      name: 'Company',
+      metrics_config: METRICS,
+    });
+
+    // The Anthropic company with its aliases (what the resolver matches on).
+    const company = await createTestEntity({
+      name: 'Anthropic',
+      entity_type: 'company',
+      organization_id: orgId,
+    });
+    const sql = getTestDb();
+    await sql`
+      UPDATE entities SET metadata = ${sql.json({ aliases: ['Claude.ai', 'Anthropic'] })}
+      WHERE id = ${company.id}
+    `;
+
+    // Seed charges. Expected GBP spend = 78.35 + 20.00 = 98.35:
+    const charge = (m: Record<string, unknown>) =>
+      createTestEvent({
+        organization_id: orgId,
+        content: 'charge',
+        semantic_type: 'transaction',
+        connector_key: 'revolut',
+        metadata: m,
+      });
+    await charge({ date: '2025-10-08', amount: 78.35, currency: 'GBP', direction: 'out', description: 'Claude.ai' });
+    await charge({ date: '2025-11-01', amount: 20.0, currency: 'GBP', direction: 'out', description: 'Anthropic' });
+    // exact duplicate (Revolut double-ingest) → deduped away by dedupeKey
+    await charge({ date: '2025-11-01', amount: 20.0, currency: 'GBP', direction: 'out', description: 'Anthropic' });
+    // refund (direction in) → excluded by the outflow segment
+    await charge({ date: '2025-11-05', amount: 99.0, currency: 'GBP', direction: 'in', description: 'Claude.ai' });
+    // USD charge → its own currency row
+    await charge({ date: '2026-03-14', amount: 23.93, currency: 'USD', direction: 'out', description: 'Claude.ai' });
+    // a non-Anthropic vendor → not matched by aliases
+    await charge({ date: '2025-11-10', amount: 5.0, currency: 'GBP', direction: 'out', description: 'Spotify' });
+  });
+
+  it('sums deduped outflow by currency, matching only aliased charges', async () => {
+    const rows = await runMetric({
+      organizationId: orgId,
+      entityType: 'company',
+      measure: 'spend',
+      by: ['currency'],
+    });
+    const byCur = Object.fromEntries(rows.map((r) => [r.currency as string, Number(r.spend)]));
+    expect(byCur.GBP).toBeCloseTo(98.35, 2); // dup collapsed, refund + Spotify excluded
+    expect(byCur.USD).toBeCloseTo(23.93, 2);
+  });
+
+  it('counts deduped outflow charges', async () => {
+    const rows = await runMetric({
+      organizationId: orgId,
+      entityType: 'company',
+      measure: 'charges',
+      by: ['currency'],
+    });
+    const byCur = Object.fromEntries(rows.map((r) => [r.currency as string, Number(r.charges)]));
+    expect(byCur.GBP).toBe(2); // Claude.ai 78.35 + Anthropic 20.00 (dup collapsed)
+    expect(byCur.USD).toBe(1);
+  });
+});

--- a/packages/server/src/metrics/compiler.ts
+++ b/packages/server/src/metrics/compiler.ts
@@ -1,0 +1,167 @@
+/**
+ * Metric compiler — "producer A": lowers a declared metric (an entity type's
+ * eventSets/measures/dimensions/segments) into org-scopable SQL over the event
+ * stream, then aggregates it. The output SELECT references `events` + `entities`
+ * as plain tables; the caller passes it through `validateAndScopeQuery`, which
+ * rewrites `events` → `current_event_records` (superseded rows masked) and
+ * org-scopes both — so this module never writes scoping or masking itself.
+ *
+ * Consolidation: the `aggregate` step (SELECT agg(expr) … GROUP BY dims) is the
+ * SAME step a federated warehouse metric flows through — only the *relation*
+ * differs (here a resolved/deduped CTE over events; there a connector's
+ * SEMANTIC_VIEW). That step is the Malloy-swappable seam.
+ *
+ * v1 scope: `eventSet.by: "alias"` + `reads: "current"` only. window/link,
+ * raw/asOf reads, and cross-entity joins are deferred (NotImplemented).
+ */
+
+import type { EntityMetrics } from "@lobu/connector-sdk";
+
+export class MetricCompileError extends Error {}
+export class MetricNotImplementedError extends MetricCompileError {}
+
+export interface CompileMetricInput {
+  /** entity_types.id, for the alias-resolution join. */
+  entityTypeId: number;
+  /** The entity type's declared metric contract (from metrics_config). */
+  metrics: EntityMetrics;
+  /** Measure name to compute. */
+  measure: string;
+  /** Dimension names to group by (default: none → a single grand-total row per entity). */
+  by?: string[];
+  /** Extra segment name to AND in, beyond the measure's own `segments`. */
+  segment?: string;
+  /** Restrict to one entity (entities.id); omitted ⇒ all entities of the type. */
+  entityId?: number;
+}
+
+const SANE_IDENT = /^[a-zA-Z_][a-zA-Z0-9_]*$/;
+
+/** Output column alias for a dimension / measure — guarded so names can't inject. */
+function outName(kind: string, name: string): string {
+  if (!SANE_IDENT.test(name)) {
+    throw new MetricCompileError(`${kind} name "${name}" must be a plain identifier`);
+  }
+  return name;
+}
+
+/**
+ * Compile a measure into a single SELECT (no top-level WITH). Throws
+ * MetricCompileError on bad references and MetricNotImplementedError for
+ * deferred features. The result is NOT yet org-scoped — pass it through
+ * `validateAndScopeQuery`.
+ */
+export function compileMetricSql(input: CompileMetricInput): string {
+  const { metrics, entityTypeId } = input;
+  const measure = metrics.measures?.[input.measure];
+  if (!measure) {
+    throw new MetricCompileError(`measure "${input.measure}" is not declared`);
+  }
+  const eventSet = metrics.eventSets?.[measure.eventSet];
+  if (!eventSet) {
+    throw new MetricCompileError(
+      `measure "${input.measure}" references eventSet "${measure.eventSet}" which is not declared`,
+    );
+  }
+  if (eventSet.by !== "alias") {
+    throw new MetricNotImplementedError(
+      `eventSet resolver "${eventSet.by}" is not implemented in v1 (alias only)`,
+    );
+  }
+  const reads = eventSet.reads ?? "current";
+  if (reads !== "current") {
+    throw new MetricNotImplementedError(
+      `reads mode "${JSON.stringify(reads)}" is not implemented in v1 ("current" only)`,
+    );
+  }
+  if (!eventSet.field) {
+    throw new MetricCompileError(`alias eventSet "${measure.eventSet}" needs a "field"`);
+  }
+
+  // ── Resolve segments (measure's own + the caller's override) ──────────────
+  const segNames = [...(measure.segments ?? []), ...(input.segment ? [input.segment] : [])];
+  const segWheres: string[] = [];
+  for (const name of segNames) {
+    const seg = metrics.segments?.[name];
+    if (!seg) throw new MetricCompileError(`segment "${name}" is not declared`);
+    segWheres.push(`(${seg.where})`);
+  }
+
+  // ── Dimensions to group by ────────────────────────────────────────────────
+  const dims = (input.by ?? []).map((name) => {
+    const dim = metrics.dimensions?.[name];
+    if (!dim) throw new MetricCompileError(`dimension "${name}" is not declared`);
+    return { col: outName("dimension", name), expr: dim.expr };
+  });
+
+  // ── Inner: filtered events (single table → `metadata` is unambiguous, no
+  //    qualifier needed for the config-authored predicates). ─────────────────
+  const innerWhere = [
+    eventSet.where ? `(${eventSet.where})` : null,
+    measure.where ? `(${measure.where})` : null,
+    ...segWheres,
+  ].filter(Boolean);
+  const evt = `SELECT * FROM events${
+    innerWhere.length ? ` WHERE ${innerWhere.join(" AND ")}` : ""
+  }`;
+
+  // ── Alias resolution: flatten (entity_id, alias) so `entities.metadata`
+  //    never enters the expr scope (keeps `metadata` = the event's). ─────────
+  const entWhere = [`ent.entity_type_id = ${Number(entityTypeId)}`, `ent.deleted_at IS NULL`];
+  if (input.entityId !== undefined) entWhere.push(`ent.id = ${Number(input.entityId)}`);
+  const entAlias = `SELECT ent.id AS entity_id, a.alias
+       FROM entities ent, jsonb_array_elements_text(ent.metadata->'aliases') AS a(alias)
+       WHERE ${entWhere.join(" AND ")}`;
+
+  // ── Resolved + deduped relation. DISTINCT over the dedupe tuple ∪ entity ∪
+  //    dims ∪ measure expr so summing over distinct rows is correct (a missing
+  //    dim in the dedupe set would wrongly collapse rows across that dim). ────
+  const dedupeCols = (eventSet.dedupeKey ?? []).map((e, i) => `(${e}) AS __dk${i}`);
+  const measureExprSel = measure.expr ? `(${measure.expr}) AS __m` : null;
+  const dimSels = dims.map((d) => `(${d.expr}) AS ${d.col}`);
+  const distinct = eventSet.dedupeKey && eventSet.dedupeKey.length > 0 ? "DISTINCT " : "";
+  const relationCols = [
+    "ea.entity_id",
+    ...dimSels,
+    ...(measureExprSel ? [measureExprSel] : []),
+    ...dedupeCols,
+  ].join(", ");
+  const fieldExpr = `evt.${eventSet.field}`;
+  const resolved = `SELECT ${distinct}${relationCols}
+     FROM (${evt}) evt
+     JOIN (${entAlias}) ea ON ea.alias = ${fieldExpr}`;
+
+  // ── Aggregate (the shared, Malloy-swappable seam) ─────────────────────────
+  const measureName = outName("measure", input.measure);
+  const aggExpr = aggregateExpr(measure.agg, measure.expr ? "__m" : null, measureName);
+  const groupCols = ["entity_id", ...dims.map((d) => d.col)];
+  const selectCols = [...groupCols, aggExpr].join(", ");
+  return `SELECT ${selectCols}
+     FROM (${resolved}) resolved
+     GROUP BY ${groupCols.join(", ")}`;
+}
+
+/** The aggregate column for a measure. `count` ⇒ COUNT(*); others aggregate the
+ *  measure expr (aliased `__m` in the relation). */
+function aggregateExpr(
+  agg: string,
+  exprCol: string | null,
+  outAlias: string,
+): string {
+  if (agg === "count") return `COUNT(*) AS ${outAlias}`;
+  if (!exprCol) {
+    throw new MetricCompileError(`agg "${agg}" requires an expr`);
+  }
+  switch (agg) {
+    case "sum":
+      return `SUM(${exprCol}) AS ${outAlias}`;
+    case "min":
+      return `MIN(${exprCol}) AS ${outAlias}`;
+    case "max":
+      return `MAX(${exprCol}) AS ${outAlias}`;
+    case "count_distinct":
+      return `COUNT(DISTINCT ${exprCol}) AS ${outAlias}`;
+    default:
+      throw new MetricCompileError(`unsupported agg "${agg}"`);
+  }
+}

--- a/packages/server/src/metrics/run-metric.ts
+++ b/packages/server/src/metrics/run-metric.ts
@@ -1,0 +1,62 @@
+/**
+ * runMetric — the shared metric execution path. Loads an entity type's declared
+ * metrics_config, compiles the requested measure to SQL (compiler.ts), org-scopes
+ * it via `validateAndScopeQuery` (which rewrites `events` → current_event_records
+ * + scopes both tables), and runs it read-only.
+ *
+ * This is the single entry point a `query_metric` MCP tool will wrap, and the
+ * same aggregation/execution path a federated warehouse metric flows through —
+ * only the relation differs (compiled-over-events here vs a connector's view).
+ */
+
+import type { EntityMetrics } from "@lobu/connector-sdk";
+import { getDb } from "../db/client";
+import { validateAndScopeQuery } from "../utils/execute-data-sources";
+import { compileMetricSql } from "./compiler";
+
+export interface RunMetricInput {
+  organizationId: string;
+  /** Entity type slug (e.g. "company"). */
+  entityType: string;
+  /** Declared measure name (e.g. "spend"). */
+  measure: string;
+  /** Dimension names to group by. */
+  by?: string[];
+  /** Extra segment name to AND in. */
+  segment?: string;
+  /** Restrict to one entity (entities.id). */
+  entityId?: number;
+}
+
+export async function runMetric(input: RunMetricInput): Promise<Record<string, unknown>[]> {
+  const sql = getDb();
+  const found = await sql`
+    SELECT id, metrics_config
+    FROM entity_types
+    WHERE slug = ${input.entityType}
+      AND organization_id = ${input.organizationId}
+      AND deleted_at IS NULL
+    LIMIT 1
+  `;
+  if (found.length === 0) {
+    throw new Error(`entity type "${input.entityType}" not found`);
+  }
+  const entityTypeId = Number(found[0].id);
+  const metrics = (found[0].metrics_config ?? {}) as EntityMetrics;
+
+  const rawSql = compileMetricSql({
+    entityTypeId,
+    metrics,
+    measure: input.measure,
+    by: input.by,
+    segment: input.segment,
+    entityId: input.entityId,
+  });
+  const scoped = validateAndScopeQuery(rawSql, input.organizationId);
+
+  const rows = await sql.begin(async (tx: typeof sql) => {
+    await tx`SET TRANSACTION READ ONLY`;
+    return tx.unsafe(scoped.sql, scoped.params as unknown[]);
+  });
+  return rows as unknown as Record<string, unknown>[];
+}


### PR DESCRIPTION
Builds on the merged metric layer (#1262). The load-bearing piece that turns a *declared* measure into actual numbers.

**Consolidated, single query path** (per the design discussion): a metric = a relation + an aggregation. `compileMetricSql` is producer A (internal `eventSet` → resolved/deduped relation over events); `reflectMetrics` is producer B (warehouse view). Both flow through the same `aggregate`/`runMetric` step and the same execution (`validateAndScopeQuery` → read-only). The `aggregate()` emit is the Malloy-swappable seam — so adopting Malloy later upgrades internal + federated at once, no fork.

**v1 scope:** `eventSet.by: alias` + `reads: current`. window/link, raw/asOf, and cross-entity joins are deferred (NotImplemented + the `backing.sql` derived-entity escape hatch covers cross-entity meanwhile).

**Correctness:** alias resolution via a flattened `(entity_id, alias)` subquery (keeps event `metadata` unambiguous); `DISTINCT` over `dedupeKey ∪ entity ∪ dims ∪ measure-expr`; no top-level `WITH`. Golden integration test (real Postgres in CI) seeds charges incl. a duplicate / refund / non-match / USD row and asserts deduped `SUM`=98.35 GBP, 23.93 USD and `COUNT`=2/1.

Generated SQL was eyeball-traced locally (pure fn); the golden test is the CI gate (no local PG + Node 26 here).

Next: `query_metric`/`list_metrics` MCP tools + soft routing + fallback telemetry wrap `runMetric`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1267"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784150167&installation_id=136316292&pr_number=1267&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1267&signature=25ba55039c5a3394785f8da8395190a4e59cec9a1700fb03aa83264c130f1a18"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a metric system enabling querying and aggregation of entity data with support for filtering by segments, grouping by dimensions, and record deduplication. Includes alias resolution for flexible entity matching and multiple aggregation options (sum, count, min, max, count_distinct).

* **Tests**
  * Added comprehensive integration test validating end-to-end metric compilation and execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->