### PR TITLE
feat(metrics): query_metric + list_metrics MCP tools (semantic-first routing)

### DIFF
--- a/packages/server/src/__tests__/integration/metrics/metric-tools.test.ts
+++ b/packages/server/src/__tests__/integration/metrics/metric-tools.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Integration tests for the metric MCP tools (query_metric + list_metrics) over
+ * the real DB. Seeds a declared "company" metric + an aliased entity + charges,
+ * then exercises the tool handlers: query_metric returns the deduped governed
+ * number, and list_metrics surfaces the catalog (and filters by keyword).
+ */
+
+import { beforeAll, describe, expect, it } from 'vitest';
+import {
+  addUserToOrganization,
+  createTestEntity,
+  createTestEvent,
+  createTestOrganization,
+  createTestUser,
+} from '../../setup/test-fixtures';
+import { cleanupTestDatabase, getTestDb } from '../../setup/test-db';
+import { TestApiClient } from '../../setup/test-mcp-client';
+import type { Env } from '../../../index';
+import type { ToolContext } from '../../../tools/registry';
+import { listMetrics } from '../../../tools/admin/list_metrics';
+import { queryMetric } from '../../../tools/admin/query_metric';
+
+const METRICS = {
+  eventSets: {
+    charges: {
+      by: 'alias',
+      field: "metadata->>'description'",
+      against: 'aliases',
+      where: "semantic_type='transaction' AND connector_key='revolut'",
+      dedupeKey: ["metadata->>'date'", "metadata->>'amount'", "metadata->>'description'"],
+    },
+  },
+  segments: {
+    outflow: { description: 'Money leaving the account.', where: "metadata->>'direction'='out'", on: 'event', appliedBefore: 'dedupe' },
+  },
+  measures: {
+    spend: { eventSet: 'charges', agg: 'sum', expr: "(metadata->>'amount')::numeric", segments: ['outflow'], description: 'Total outflow to this company, by currency.' },
+  },
+  dimensions: { currency: { expr: "metadata->>'currency'", description: 'Charge currency.' } },
+};
+
+describe('metric MCP tools', () => {
+  let ctx: ToolContext;
+  const env = {} as Env;
+
+  beforeAll(async () => {
+    await cleanupTestDatabase();
+    const org = await createTestOrganization({ name: 'Metric Tools Org' });
+    const user = await createTestUser({ email: 'metric-tools@test.com' });
+    await addUserToOrganization(user.id, org.id, 'owner');
+    ctx = { organizationId: org.id, userId: user.id, memberRole: 'owner', isAuthenticated: true };
+
+    const owner = await TestApiClient.for({ organizationId: org.id, userId: user.id, memberRole: 'owner' });
+    await owner.entity_schema.createType({ slug: 'company', name: 'Company', metrics_config: METRICS });
+
+    const company = await createTestEntity({ name: 'Anthropic', entity_type: 'company', organization_id: org.id });
+    const sql = getTestDb();
+    await sql`UPDATE entities SET metadata = ${sql.json({ aliases: ['Claude.ai', 'Anthropic'] })} WHERE id = ${company.id}`;
+
+    const charge = (m: Record<string, unknown>) =>
+      createTestEvent({ organization_id: org.id, content: 'charge', semantic_type: 'transaction', connector_key: 'revolut', metadata: m });
+    await charge({ date: '2025-10-08', amount: 78.35, currency: 'GBP', direction: 'out', description: 'Claude.ai' });
+    await charge({ date: '2025-11-01', amount: 20.0, currency: 'GBP', direction: 'out', description: 'Anthropic' });
+    await charge({ date: '2025-11-01', amount: 20.0, currency: 'GBP', direction: 'out', description: 'Anthropic' }); // dup
+    await charge({ date: '2025-11-05', amount: 99.0, currency: 'GBP', direction: 'in', description: 'Claude.ai' }); // refund
+  });
+
+  it('query_metric returns the deduped, governed sum', async () => {
+    const res = (await queryMetric(
+      { entity_type: 'company', measure: 'spend', by: ['currency'] },
+      env,
+      ctx,
+    )) as { rows: Record<string, unknown>[]; row_count: number };
+    const gbp = res.rows.find((r) => r.currency === 'GBP');
+    expect(Number(gbp?.spend)).toBeCloseTo(98.35, 2);
+  });
+
+  it('list_metrics surfaces the catalog', async () => {
+    const res = (await listMetrics({}, env, ctx)) as {
+      entity_types: Array<{ entity_type: string; measures: { name: string }[]; dimensions: { name: string }[]; segments: { name: string }[] }>;
+    };
+    const company = res.entity_types.find((e) => e.entity_type === 'company');
+    expect(company?.measures.map((m) => m.name)).toContain('spend');
+    expect(company?.dimensions.map((d) => d.name)).toContain('currency');
+    expect(company?.segments.map((s) => s.name)).toContain('outflow');
+  });
+
+  it('list_metrics keyword filter narrows to matching members', async () => {
+    const res = (await listMetrics({ q: 'outflow' }, env, ctx)) as {
+      entity_types: Array<{ entity_type: string; segments: { name: string }[]; dimensions: { name: string }[] }>;
+    };
+    const company = res.entity_types.find((e) => e.entity_type === 'company');
+    expect(company?.segments.map((s) => s.name)).toContain('outflow');
+    // "currency" dimension doesn't match "outflow" → filtered out.
+    expect(company?.dimensions.length).toBe(0);
+  });
+});

--- a/packages/server/src/__tests__/integration/tools/all-tools-e2e.test.ts
+++ b/packages/server/src/__tests__/integration/tools/all-tools-e2e.test.ts
@@ -134,6 +134,17 @@ describe("all agent MCP tools — registry-driven e2e (model-free)", () => {
 				coverage: "reachable",
 				note: "full SDK sandbox in dry_run mode — reads run, writes are previewed, no model",
 			},
+			// ── metric layer ────────────────────────────────────────────────────────
+			list_metrics: {
+				args: {},
+				coverage: "reachable",
+				note: "lists the declared metric catalog (measures/dimensions/segments) for the org",
+			},
+			query_metric: {
+				args: { entity_type: "metric_co", measure: "n" },
+				coverage: "round-trip",
+				note: "runs a declared measure end-to-end (compile → scope → execute); 0 rows is fine",
+			},
 			// ── REST/admin surface ──────────────────────────────────────────────────
 			manage_entity: {
 				// The create→delete round-trip is asserted in its own dedicated test;
@@ -290,6 +301,24 @@ describe("all agent MCP tools — registry-driven e2e (model-free)", () => {
 		const createdEntityId = created.entity?.id;
 		expect(createdEntityId).toBeDefined();
 		entityId = createdEntityId as number;
+
+		// Seed a metric-bearing entity type so query_metric/list_metrics are real
+		// round-trips (no events → 0 rows, which is a valid, error-free result).
+		await executeTool(
+			"manage_entity_schema",
+			{
+				schema_type: "entity_type",
+				action: "create",
+				slug: "metric_co",
+				name: "Metric Co",
+				metrics_config: {
+					eventSets: { charges: { by: "alias", field: "metadata->>'description'" } },
+					measures: { n: { eventSet: "charges", agg: "count", description: "Charge count." } },
+				},
+			},
+			TEST_ENV,
+			authCtx,
+		);
 
 		// Seed one watcher so get_watcher / list_watchers are real round-trips.
 		const watcher = (await executeTool(

--- a/packages/server/src/__tests__/integration/tools/all-tools-e2e.test.ts
+++ b/packages/server/src/__tests__/integration/tools/all-tools-e2e.test.ts
@@ -141,7 +141,7 @@ describe("all agent MCP tools — registry-driven e2e (model-free)", () => {
 				note: "lists the declared metric catalog (measures/dimensions/segments) for the org",
 			},
 			query_metric: {
-				args: { entity_type: "metric_co", measure: "n" },
+				args: { entity_type: "metric-co", measure: "n" },
 				coverage: "round-trip",
 				note: "runs a declared measure end-to-end (compile → scope → execute); 0 rows is fine",
 			},
@@ -309,7 +309,7 @@ describe("all agent MCP tools — registry-driven e2e (model-free)", () => {
 			{
 				schema_type: "entity_type",
 				action: "create",
-				slug: "metric_co",
+				slug: "metric-co",
 				name: "Metric Co",
 				metrics_config: {
 					eventSets: { charges: { by: "alias", field: "metadata->>'description'" } },

--- a/packages/server/src/tools/admin/list_metrics.ts
+++ b/packages/server/src/tools/admin/list_metrics.ts
@@ -1,0 +1,94 @@
+/**
+ * list_metrics — the metric catalog. Lists the DECLARED measures / dimensions /
+ * segments per entity type (with their descriptions), so the agent can discover
+ * what governed metrics exist and call `query_metric` instead of hand-writing
+ * SQL. This is the "semantic-first" discovery step: search here, then
+ * query_metric; only fall back to query_sql when nothing covers the ask.
+ */
+
+import { type Static, Type } from '@sinclair/typebox';
+import type { EntityMetrics } from '@lobu/connector-sdk';
+import { getDb } from '../../db/client';
+import type { Env } from '../../index';
+import type { ToolContext } from '../registry';
+import { withValidatedArgs } from '../validate-args';
+
+export const ListMetricsSchema = Type.Object({
+  entity_type: Type.Optional(
+    Type.String({ description: 'Filter to one entity type slug (e.g. "company").' }),
+  ),
+  q: Type.Optional(
+    Type.String({
+      description: 'Keyword filter (case-insensitive) over measure/dimension/segment names + descriptions.',
+    }),
+  ),
+});
+
+interface MetricCatalogEntry {
+  entity_type: string;
+  name: string | null;
+  measures: Array<{
+    name: string;
+    agg: string;
+    eventSet: string;
+    description: string;
+    tier?: string;
+    owner?: string;
+  }>;
+  dimensions: Array<{ name: string; description: string }>;
+  segments: Array<{ name: string; description: string }>;
+}
+
+async function listMetricsImpl(
+  args: Static<typeof ListMetricsSchema>,
+  _env: Env,
+  ctx: ToolContext,
+): Promise<{ entity_types: MetricCatalogEntry[] }> {
+  if (!ctx.organizationId) {
+    throw new Error('list_metrics requires a bound organization');
+  }
+  const sql = getDb();
+  const rows = await sql<{ slug: string; name: string | null; metrics_config: unknown }[]>`
+    SELECT slug, name, metrics_config
+    FROM entity_types
+    WHERE organization_id = ${ctx.organizationId}
+      AND deleted_at IS NULL
+      AND metrics_config IS NOT NULL
+      ${args.entity_type ? sql`AND slug = ${args.entity_type}` : sql``}
+    ORDER BY slug
+  `;
+
+  const needle = args.q?.toLowerCase();
+  const matches = (...vals: (string | undefined)[]) =>
+    !needle || vals.some((v) => v?.toLowerCase().includes(needle));
+
+  const entity_types: MetricCatalogEntry[] = [];
+  for (const row of rows) {
+    const m = (row.metrics_config ?? {}) as EntityMetrics;
+    const measures = Object.entries(m.measures ?? {})
+      .filter(([name, def]) => matches(name, def.description))
+      .map(([name, def]) => ({
+        name,
+        agg: def.agg,
+        eventSet: def.eventSet,
+        description: def.description,
+        ...(def.tier ? { tier: def.tier } : {}),
+        ...(def.owner ? { owner: def.owner } : {}),
+      }));
+    const dimensions = Object.entries(m.dimensions ?? {})
+      .filter(([name, def]) => matches(name, def.description))
+      .map(([name, def]) => ({ name, description: def.description }));
+    const segments = Object.entries(m.segments ?? {})
+      .filter(([name, def]) => matches(name, def.description))
+      .map(([name, def]) => ({ name, description: def.description }));
+
+    // With a keyword, only surface entity types that have a matching member.
+    if (needle && measures.length === 0 && dimensions.length === 0 && segments.length === 0) {
+      continue;
+    }
+    entity_types.push({ entity_type: row.slug, name: row.name, measures, dimensions, segments });
+  }
+  return { entity_types };
+}
+
+export const listMetrics = withValidatedArgs('list_metrics', ListMetricsSchema, listMetricsImpl);

--- a/packages/server/src/tools/admin/list_metrics.ts
+++ b/packages/server/src/tools/admin/list_metrics.ts
@@ -48,7 +48,7 @@ async function listMetricsImpl(
     throw new Error('list_metrics requires a bound organization');
   }
   const sql = getDb();
-  const rows = await sql<{ slug: string; name: string | null; metrics_config: unknown }[]>`
+  const rows = (await sql`
     SELECT slug, name, metrics_config
     FROM entity_types
     WHERE organization_id = ${ctx.organizationId}
@@ -56,7 +56,7 @@ async function listMetricsImpl(
       AND metrics_config IS NOT NULL
       ${args.entity_type ? sql`AND slug = ${args.entity_type}` : sql``}
     ORDER BY slug
-  `;
+  `) as unknown as Array<{ slug: string; name: string | null; metrics_config: unknown }>;
 
   const needle = args.q?.toLowerCase();
   const matches = (...vals: (string | undefined)[]) =>

--- a/packages/server/src/tools/admin/query_metric.ts
+++ b/packages/server/src/tools/admin/query_metric.ts
@@ -1,0 +1,58 @@
+/**
+ * query_metric — run a DECLARED, governed metric and return its rows.
+ *
+ * Prefer this over `query_sql` whenever a declared measure answers the question:
+ * the metric layer enforces the resolution, dedupe, segment, and aggregation so
+ * the numbers are consistent. Discover what exists with `list_metrics`; fall
+ * back to `query_sql` only when no measure covers the ask.
+ *
+ * Thin wrapper over runMetric (compile → org-scope → read-only execute) — the
+ * same path a federated warehouse metric flows through.
+ */
+
+import { type Static, Type } from '@sinclair/typebox';
+import type { Env } from '../../index';
+import { runMetric } from '../../metrics/run-metric';
+import type { ToolContext } from '../registry';
+import { withValidatedArgs } from '../validate-args';
+
+export const QueryMetricSchema = Type.Object({
+  entity_type: Type.String({
+    description: 'Entity type slug that declares the metric (e.g. "company"). See list_metrics.',
+  }),
+  measure: Type.String({
+    description: 'Declared measure name on that entity type (e.g. "spend").',
+  }),
+  by: Type.Optional(
+    Type.Array(Type.String(), {
+      description: 'Dimension names to group by (e.g. ["currency","month"]). Omit for a grand total per entity.',
+    }),
+  ),
+  segment: Type.Optional(
+    Type.String({ description: 'An extra declared segment (named population filter) to AND in.' }),
+  ),
+  entity_id: Type.Optional(
+    Type.Number({ description: 'Restrict to a single entity (entities.id); omit for all entities of the type.' }),
+  ),
+});
+
+async function queryMetricImpl(
+  args: Static<typeof QueryMetricSchema>,
+  _env: Env,
+  ctx: ToolContext,
+): Promise<{ rows: Record<string, unknown>[]; row_count: number }> {
+  if (!ctx.organizationId) {
+    throw new Error('query_metric requires a bound organization');
+  }
+  const rows = await runMetric({
+    organizationId: ctx.organizationId,
+    entityType: args.entity_type,
+    measure: args.measure,
+    by: args.by,
+    segment: args.segment,
+    entityId: args.entity_id,
+  });
+  return { rows, row_count: rows.length };
+}
+
+export const queryMetric = withValidatedArgs('query_metric', QueryMetricSchema, queryMetricImpl);

--- a/packages/server/src/tools/registry.ts
+++ b/packages/server/src/tools/registry.ts
@@ -20,7 +20,9 @@
 import { getPublicReadableActions, getRequiredAccessLevel } from '../auth/tool-access';
 import type { Env } from '../index';
 import { INTERNAL_REST_TOOLS } from './admin';
+import { ListMetricsSchema, listMetrics } from './admin/list_metrics';
 import { MetricSeriesSchema, metricSeries } from './admin/metric_series';
+import { QueryMetricSchema, queryMetric } from './admin/query_metric';
 import { QuerySqlSchema, querySql } from './admin/query_sql';
 import { ListOrganizationsSchema } from './organizations';
 import { ResolvePathSchema, resolvePath } from './resolve_path';
@@ -150,9 +152,25 @@ const TOOLS: ToolDefinition[] = [
     handler: querySdkScript,
   },
   {
+    name: 'list_metrics',
+    description:
+      'List the DECLARED, governed metrics — measures / dimensions / segments (with descriptions) per entity type. Use this FIRST to discover what metrics exist; pass `q` to keyword-search. Then run one with `query_metric`. Prefer governed metrics over hand-written `query_sql` so numbers stay consistent.',
+    inputSchema: ListMetricsSchema,
+    annotations: READ_ONLY,
+    handler: listMetrics,
+  },
+  {
+    name: 'query_metric',
+    description:
+      'Run a DECLARED metric (discover them via `list_metrics`) and get its rows: pass entity_type + measure, optional `by` dimensions / `segment` / `entity_id`. The metric layer enforces resolution, dedupe, segment, and aggregation, so results are consistent and governed. PREFER this over `query_sql` whenever a declared measure answers the question; fall back to `query_sql` only when no metric covers the ask.',
+    inputSchema: QueryMetricSchema,
+    annotations: READ_ONLY,
+    handler: queryMetric,
+  },
+  {
     name: 'query_sql',
     description:
-      'Run a paginated, sortable, searchable read-only SQL query. Table references auto-scope to the bound org. The query is wrapped as a subquery, so inner ORDER BY / LIMIT / window functions are fine; pagination + sort come from the sort_by/limit/offset args. Do NOT use positional parameters ($1, $2, …). Optional `org_slug` (OAuth on /mcp only) redirects the query to a different member org; rejected on /mcp/{slug} and on PAT auth.',
+      'Run a paginated, sortable, searchable read-only SQL query. Table references auto-scope to the bound org. The query is wrapped as a subquery, so inner ORDER BY / LIMIT / window functions are fine; pagination + sort come from the sort_by/limit/offset args. Do NOT use positional parameters ($1, $2, …). Optional `org_slug` (OAuth on /mcp only) redirects the query to a different member org; rejected on /mcp/{slug} and on PAT auth. NOTE: this is the FALLBACK — if a declared metric covers the ask, use `query_metric` (see `list_metrics`) instead, so numbers match the governed definitions.',
     inputSchema: QuerySqlSchema,
     annotations: READ_ONLY,
     handler: querySql,


### PR DESCRIPTION
The consumption half of the metric layer — the agent's path into governed metrics. Builds on the merged compiler/runMetric (#1267).

- **list_metrics** — the catalog: declared measures/dimensions/segments (with descriptions) per entity type; `q` keyword-filters. Discover first.
- **query_metric** — runs a declared measure (entity_type + measure + optional by/segment/entity_id) through `runMetric`; returns governed, deduped rows. Thin wrapper over the verified compiler path.
- **Soft routing** via tool descriptions: `list_metrics`/`query_metric` are 'prefer these'; `query_sql`'s description now flags it as the FALLBACK when no declared metric covers the ask. Both READ_ONLY → default read tier.

Same consolidated path as federation: `query_metric` and a future federated warehouse metric both flow through one aggregate/execute step; the relation differs, the seam (Malloy) is shared.

**Test:** integration test (real Postgres in CI) — `query_metric` returns the deduped 98.35 GBP; `list_metrics` surfaces the catalog and keyword-filters to matching members.

Deferred (the harder routing instrumentation): agent-policy `TOOL_INTENT_RULES` + structured fallback telemetry (semantic-miss logging).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1268"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784150820&installation_id=136316292&pr_number=1268&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1268&signature=ba248864854b99dd2847b0d57bf7760352803e89c47f300728ae578e7f3e4b09"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->