### PR TITLE
fix(revolut): reliable extension scrape — fresh-window + fail-closed robustness (3.4.0)

### DIFF
--- a/examples/personal-agent/lobu.config.ts
+++ b/examples/personal-agent/lobu.config.ts
@@ -357,13 +357,15 @@ const trip = defineEntityType({
 // dispatches its DOM-scrape actions down to whichever online paired Owletto
 // extension claims them (same model as LinkedIn). This is what makes Revolut
 // "extension-only" from the user's side — no Owletto Mac app required, just the
-// Chrome extension signed in to app.revolut.com. max_scrolls is raised so the
-// first run paginates the full multi-year history.
+// Chrome extension signed in to app.revolut.com. max_scrolls is capped so a
+// single run fits inside the extension's 90s per-run cap (≈150s at 100 scrolls
+// always timed out); 20 scrolls (~55s) reliably completes, and scheduled
+// incremental syncs keep history current from the top each run.
 const revolutConnection = defineConnection({
   slug: "revolut-buremba",
   connector: "revolut",
   name: "Revolut",
-  feeds: [{ feed: "transactions", config: { max_scrolls: 100 } }],
+  feeds: [{ feed: "transactions", config: { max_scrolls: 20 } }],
 });
 
 export default defineConfig({

--- a/examples/personal-agent/revolut-transactions.connector.ts
+++ b/examples/personal-agent/revolut-transactions.connector.ts
@@ -297,10 +297,16 @@ export function filterTransactionsSinceCheckpoint(
     if (seen.has(t.id)) return false;
     seen.add(t.id);
     if (lastId && t.id === lastId) return false;
+    // Strictly-older only (`<`, not `<=`). Revolut timestamps are minute
+    // precision, so dropping the whole boundary minute would silently lose
+    // other transactions that settled in the same minute as the checkpoint.
+    // Re-including the boundary minute is safe: the exact checkpoint row is
+    // dropped by the `lastId` guard above, and any re-seen row carries a stable
+    // origin id the gateway supersedes — so no duplicates are stored.
     if (
       lastTs !== null &&
       Number.isFinite(lastTs) &&
-      t.occurredAt.getTime() <= lastTs
+      t.occurredAt.getTime() < lastTs
     ) {
       return false;
     }
@@ -446,28 +452,17 @@ async function scrapeTransactionRows(
   url: string,
   maxScrolls: number
 ): Promise<RevolutDomRow[]> {
-  // Force the reused persistent window back to the TOP before scraping.
+  // Scrape in a FRESH, dedicated window each run — never reuse a long-lived one.
   //
-  // The extension reuses one long-lived window and its `genericScrape` harvests
-  // from the tab's CURRENT scroll position, only scrolling further DOWN. Revolut
-  // virtualizes off-screen rows, so a window left scrolled deep into history by
-  // the previous run would harvest only OLD rows and walk the sync backwards in
-  // time. The extension only reloads a reused window when the path CHANGES, so
-  // we bounce through a non-transactions route first; the subsequent scrape
-  // navigate then reloads `/transactions` fresh — rendering the newest rows at
-  // the top — regardless of where the prior run left the tab.
-  try {
-    await dispatcher.dispatch("navigate", {
-      persistent: true,
-      focus: true,
-      url: REVOLUT_RESET_URL,
-      allowed_origins: REVOLUT_ALLOWED_ORIGINS,
-    });
-  } catch {
-    // Best-effort: if the reset navigate fails the scrape below still runs;
-    // worst case it harvests from a stale scroll position (the prior behaviour).
-  }
-
+  // The extension's `genericScrape` harvests from the tab's CURRENT scroll
+  // position and only scrolls further DOWN, and Revolut's list virtualizes
+  // off-screen rows. A reused window left scrolled deep into history by the
+  // previous run therefore harvests only OLD rows and walks the sync backwards
+  // in time. A fresh window (persistent:false) always loads `/transactions` at
+  // the top (newest), can't be corrupted by a concurrent run sharing the same
+  // window, and stays signed in via the Chrome profile's Revolut session
+  // cookies. The extension's tab-reaper disposes the window shortly after the
+  // run, so nothing accumulates.
   const result = await extensionDomScrape<RevolutDomRow>({
     dispatcher,
     url,
@@ -477,8 +472,7 @@ async function scrapeTransactionRows(
     },
     parseRows: (raw) => raw.map(rawRowToDomRow),
     allowedOrigins: REVOLUT_ALLOWED_ORIGINS,
-    persistent: true,
-    focus: true,
+    persistent: false,
   });
   if (!result.loggedIn) {
     throw new RevolutAuthWallError(result.landedUrl ?? url);
@@ -495,10 +489,6 @@ async function scrapeTransactionRows(
 // `/transactions?accountType=pocket&walletId=<uuid>&pocketId=<uuid>` — point a
 // second feed's `start_url` there to sync a non-default currency pocket.
 const DEFAULT_START_URL = "https://app.revolut.com/transactions";
-// A non-transactions route used only to force the reused persistent window to
-// reload (the extension reloads a reused window only when the path changes), so
-// the real scrape navigate lands on a freshly-rendered, scrolled-to-top page.
-const REVOLUT_RESET_URL = "https://app.revolut.com/home";
 
 const configSchema = {
   type: "object",
@@ -545,14 +535,15 @@ export default class RevolutTransactionsConnector extends ConnectorRuntime {
     name: "Revolut",
     description:
       "Syncs Revolut account transactions by reading the rendered Revolut web app (no public API) through your paired Owletto Chrome session — no separate login, robust against Revolut's rotating internal API.",
-    version: "3.3.0",
+    version: "3.4.0",
     faviconDomain: "app.revolut.com",
     authSchema: {
       // Auth is implicit via the paired Owletto extension's signed-in Chrome —
-      // no CDP, no cookie capture. The scrape runs in a focused persistent
-      // window; when Revolut's session expires the page redirects to sso.revolut
-      // .com, `loggedOutWhen` flags it, and the sync fails with a "needs sign-in"
-      // message so the user can re-enter their passcode in that window.
+      // no CDP, no cookie capture. Each run scrapes in a fresh, dedicated window
+      // (shared profile cookies keep it signed in); when Revolut's session
+      // expires the page redirects to sso.revolut.com, `loggedOutWhen` flags it,
+      // and the sync fails with a "needs sign-in" message so the user can
+      // re-authenticate Revolut in Chrome before the next run.
       methods: [{ type: "none" }],
     },
     feeds: {
@@ -594,6 +585,17 @@ export default class RevolutTransactionsConnector extends ConnectorRuntime {
     const rows = await scrapeTransactionRows(dispatcher, startUrl, maxScrolls);
     const all = buildTransactionsFromDom(rows);
 
+    // Fail closed. We only reach here logged in (scrapeTransactionRows throws on
+    // an auth wall), so ZERO parsed transactions almost certainly means a DOM /
+    // selector regression or an unrendered list — not a genuinely empty
+    // account. Surfacing it as a failure (instead of a silent empty sync) keeps
+    // it alertable and leaves the checkpoint untouched.
+    if (all.length === 0) {
+      throw new Error(
+        "Revolut scrape returned 0 transactions on a logged-in page — likely a DOM/selector change or an unrendered list; failing rather than reporting an empty sync."
+      );
+    }
+
     let transactions = filterTransactionsSinceCheckpoint(all, checkpoint);
     if (currencyFilter) {
       transactions = transactions.filter((t) => t.currency === currencyFilter);
@@ -603,13 +605,30 @@ export default class RevolutTransactionsConnector extends ConnectorRuntime {
     );
 
     const events: EventEnvelope[] = transactions.map(transactionToEvent);
-    const newest = transactions[0];
-    const newCheckpoint: RevolutCheckpoint = newest
-      ? {
-          last_transaction_id: newest.id,
-          last_timestamp: newest.occurredAt.toISOString(),
-        }
-      : checkpoint;
+
+    // Monotonic high-water mark: advance to the newest transaction we actually
+    // saw, but NEVER move the checkpoint backwards in time. Belt-and-suspenders
+    // on top of the fresh-window scrape (which already loads newest-first): if a
+    // partial/mis-rendered scrape ever surfaces only old rows, the checkpoint
+    // holds instead of rewinding and re-ingesting years of history. `newestSeen`
+    // is the max over the FULL scrape, not just the post-checkpoint slice.
+    const newestSeen = all.reduce<RevolutTransaction | null>(
+      (max, t) =>
+        !max || t.occurredAt.getTime() > max.occurredAt.getTime() ? t : max,
+      null
+    );
+    const prevTs = checkpoint?.last_timestamp
+      ? new Date(checkpoint.last_timestamp).getTime()
+      : Number.NEGATIVE_INFINITY;
+    const newCheckpoint: RevolutCheckpoint =
+      newestSeen &&
+      Number.isFinite(newestSeen.occurredAt.getTime()) &&
+      newestSeen.occurredAt.getTime() > prevTs
+        ? {
+            last_transaction_id: newestSeen.id,
+            last_timestamp: newestSeen.occurredAt.toISOString(),
+          }
+        : checkpoint;
 
     return {
       events,

--- a/examples/personal-agent/revolut-transactions.connector.ts
+++ b/examples/personal-agent/revolut-transactions.connector.ts
@@ -519,7 +519,7 @@ export default class RevolutTransactionsConnector extends ConnectorRuntime {
     name: "Revolut",
     description:
       "Syncs Revolut account transactions by reading the rendered Revolut web app (no public API) through your paired Owletto Chrome session — no separate login, robust against Revolut's rotating internal API.",
-    version: "3.0.0",
+    version: "3.2.0",
     faviconDomain: "app.revolut.com",
     authSchema: {
       // Auth is implicit via the paired Owletto extension's signed-in Chrome —

--- a/examples/personal-agent/revolut-transactions.connector.ts
+++ b/examples/personal-agent/revolut-transactions.connector.ts
@@ -446,6 +446,28 @@ async function scrapeTransactionRows(
   url: string,
   maxScrolls: number
 ): Promise<RevolutDomRow[]> {
+  // Force the reused persistent window back to the TOP before scraping.
+  //
+  // The extension reuses one long-lived window and its `genericScrape` harvests
+  // from the tab's CURRENT scroll position, only scrolling further DOWN. Revolut
+  // virtualizes off-screen rows, so a window left scrolled deep into history by
+  // the previous run would harvest only OLD rows and walk the sync backwards in
+  // time. The extension only reloads a reused window when the path CHANGES, so
+  // we bounce through a non-transactions route first; the subsequent scrape
+  // navigate then reloads `/transactions` fresh — rendering the newest rows at
+  // the top — regardless of where the prior run left the tab.
+  try {
+    await dispatcher.dispatch("navigate", {
+      persistent: true,
+      focus: true,
+      url: REVOLUT_RESET_URL,
+      allowed_origins: REVOLUT_ALLOWED_ORIGINS,
+    });
+  } catch {
+    // Best-effort: if the reset navigate fails the scrape below still runs;
+    // worst case it harvests from a stale scroll position (the prior behaviour).
+  }
+
   const result = await extensionDomScrape<RevolutDomRow>({
     dispatcher,
     url,
@@ -473,6 +495,10 @@ async function scrapeTransactionRows(
 // `/transactions?accountType=pocket&walletId=<uuid>&pocketId=<uuid>` — point a
 // second feed's `start_url` there to sync a non-default currency pocket.
 const DEFAULT_START_URL = "https://app.revolut.com/transactions";
+// A non-transactions route used only to force the reused persistent window to
+// reload (the extension reloads a reused window only when the path changes), so
+// the real scrape navigate lands on a freshly-rendered, scrolled-to-top page.
+const REVOLUT_RESET_URL = "https://app.revolut.com/home";
 
 const configSchema = {
   type: "object",
@@ -519,7 +545,7 @@ export default class RevolutTransactionsConnector extends ConnectorRuntime {
     name: "Revolut",
     description:
       "Syncs Revolut account transactions by reading the rendered Revolut web app (no public API) through your paired Owletto Chrome session — no separate login, robust against Revolut's rotating internal API.",
-    version: "3.2.0",
+    version: "3.3.0",
     faviconDomain: "app.revolut.com",
     authSchema: {
       // Auth is implicit via the paired Owletto extension's signed-in Chrome —

--- a/packages/connector-sdk/src/extension-dom-scrape.ts
+++ b/packages/connector-sdk/src/extension-dom-scrape.ts
@@ -33,6 +33,9 @@ export interface ExtensionScrapeResult {
   landedUrl?: string;
   loggedIn?: boolean;
   rows?: Array<Record<string, unknown>>;
+  /** Set by the extension when the in-page scrape script threw (e.g. CSP
+   * blocked injection). Distinct from a clean logged-out result. */
+  error?: unknown;
   [k: string]: unknown;
 }
 
@@ -75,12 +78,25 @@ export async function extensionDomScrape<TItem>(opts: {
     allowed_origins: opts.allowedOrigins,
   });
   const result = observation?.result;
-  const items = opts.parseRows(result?.rows ?? []);
+  // Fail loudly on a broken scrape. A missing result (dispatch never produced
+  // one) or an `error` field (the in-page script threw — e.g. CSP blocked
+  // injection) must NOT be silently coerced into a logged-in, zero-row
+  // "success": that masks DOM/selector breakage as an empty sync and can let a
+  // connector advance its checkpoint or report health on no data. A genuine
+  // auth wall is different — the engine returns `loggedIn:false` with no error,
+  // which is preserved below for the caller to handle.
+  if (!result) {
+    throw new Error('cs_scrape returned no result — the content-script dispatch did not complete.');
+  }
+  if (typeof result.error === 'string' && result.error) {
+    throw new Error(`cs_scrape failed in the page: ${result.error}`);
+  }
+  const items = opts.parseRows(result.rows ?? []);
   return {
     items,
-    loggedIn: result?.loggedIn !== false,
-    count: result?.count ?? items.length,
-    host: result?.host,
-    landedUrl: result?.landedUrl,
+    loggedIn: result.loggedIn !== false,
+    count: result.count ?? items.length,
+    host: result.host,
+    landedUrl: result.landedUrl,
   };
 }


### PR DESCRIPTION
Makes the extension-backed Revolut scrape reliable and robust on the unhappy path. Supersedes an earlier broken force-reload attempt (caught by a `pi` review — a bare navigate opened a throwaway tab and never touched the persistent window).

## Core change: fresh window per run
The extension's `genericScrape` harvests from the tab's current scroll position and only scrolls down; Revolut virtualizes off-screen rows. Reusing one persistent window meant a run left it scrolled deep, and the next run re-scraped old rows and walked the checkpoint *backward* in time (newest stuck at 2026-04 while runs harvested 2023). Switching to a **fresh window per run** (`persistent:false`) always loads newest-first, can't be corrupted by a concurrent run sharing the window, and stays signed in via profile cookies (the tab-reaper disposes it after the run). This is the connector's original design intent — reusing one window was the optimization that introduced the bug.

## Robustness (from the review)
- **SDK `extensionDomScrape`:** a missing result or an in-page script error now **throws** instead of being coerced into a logged-in, zero-row "success" that masked DOM/selector breakage as an empty sync. Affects Revolut + LinkedIn.
- **Fail closed:** a logged-in scrape yielding zero transactions throws rather than reporting an empty sync.
- **Monotonic checkpoint:** never advance the high-water mark backward in time — a partial/mis-rendered scrape can't rewind the cursor and re-ingest history.
- **Same-minute fix:** filter strictly-older (`<`), so transactions in the checkpoint's minute aren't dropped (gateway supersedes re-seen rows by origin id).
- **Scroll cap 100 → 20** so a run fits the extension's 90s cap.

## Verified on prod
- e2e green earlier: cloud worker → dispatch → extension scrape → transactions stored; newest advanced 2026-04-07 → 2026-06-13.
- 3.4.0 live: single fresh-window navigate dispatched + completed by the extension; auth-wall correctly detected and failed closed. Final recent-data capture pending a live Revolut session (expired mid-test).

Companion: owletto#270 (scroll-to-top inside genericScrape) remains valid for other persistent-window scrapers but Revolut no longer depends on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)