### PR TITLE
fix(gateway): fan out chat interaction cards cross-pod (multi-replica ask_user)

### DIFF
--- a/packages/server/src/gateway/__tests__/chat-interaction-fanout-crosspod.test.ts
+++ b/packages/server/src/gateway/__tests__/chat-interaction-fanout-crosspod.test.ts
@@ -1,0 +1,323 @@
+/**
+ * Cross-pod fan-out for CHAT-PLATFORM interaction cards — the most faithful
+ * single-process seam test of the multi-replica delivery path.
+ *
+ * The production bug: a worker posts an `ask_user`/approval/link-button card
+ * into ITS pod's `InteractionService`, but under N>1 replicas (Slack webhooks
+ * don't pin to the connection's pod) that pod rarely owns the connection's
+ * in-process interaction bridge — so the card was silently lost.
+ *
+ * This test stands up BOTH sides of the seam in one process:
+ *
+ *   - COLD replica: a real `InteractionService` with the real fan-out producer
+ *     (`registerChatInteractionFanout`) wired as NOT-warm-locally, so a posted
+ *     card is enqueued onto the (stubbed) `thread_response` queue instead of
+ *     rendered locally — exactly what the worker's pod does.
+ *
+ *   - WARM replica: a real `InteractionService` with the REAL interaction
+ *     bridge (`registerInteractionBridge`) registered for the connection, plus a
+ *     real `UnifiedThreadResponseConsumer` whose `ensureDeliverable` returns
+ *     true (this replica owns the connection). The consumer claims the enqueued
+ *     row and re-emits the card onto the warm `InteractionService`, which the
+ *     real bridge renders.
+ *
+ * WHAT THIS COVERS (real, not mocked):
+ *   - real fan-out producer + envelope construction
+ *   - real consumer branch (`handleChatInteraction`) incl. connectionId guard
+ *   - the REAL `registerInteractionBridge` rendering path: it writes a real
+ *     `pending_interactions` row (real Postgres) and posts exactly one card
+ *   - the bridge's per-connection `handledEvents` dedup across a queue re-claim
+ *
+ * WHAT THIS DOES NOT COVER (still owed):
+ *   - the Postgres `thread_response` queue itself (single-claim/SKIP-LOCKED,
+ *     re-queue-on-throw) — stubbed here; verified by the queue's own tests
+ *   - two genuinely separate OS processes/pods and ClientIP affinity
+ *   - the real Chat SDK platform post to Slack (the `thread.post` is a mock)
+ *
+ * A live two-pod e2e (or a post-deploy live Slack `ask_user` round-trip) is
+ * still the owed hard gate per AGENTS.md.
+ */
+
+import { beforeAll, beforeEach, describe, expect, mock, test } from "bun:test";
+import { getDb } from "../../db/client.js";
+import { registerInteractionBridge } from "../connections/interaction-bridge.js";
+import type { PlatformConnection } from "../connections/types.js";
+import { InteractionService, type PostedQuestion } from "../interactions.js";
+import {
+  registerChatInteractionFanout,
+  UnifiedThreadResponseConsumer,
+} from "../platform/unified-thread-consumer.js";
+import {
+  ensureDbForGatewayTests,
+  resetTestDatabase,
+} from "./helpers/db-setup.js";
+
+const ORG = "test-org-fanout";
+const CONN = "conn-slack-fanout";
+const USER = "U_FANOUT";
+
+/**
+ * Poll `check` until it returns true or `timeoutMs` elapses, throwing on
+ * timeout. Replaces fixed sleeps so the bridge's async render (resolveThread →
+ * import("chat") → post) is awaited by CONDITION, not a guessed duration — the
+ * 50ms fixed sleep flaked on a cold run under CI/SHMMNI pressure.
+ */
+async function waitFor(
+  check: () => boolean | Promise<boolean>,
+  label: string,
+  timeoutMs = 5000,
+  pollMs = 5
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    if (await check()) return;
+    if (Date.now() >= deadline) {
+      throw new Error(`waitFor timed out after ${timeoutMs}ms: ${label}`);
+    }
+    await new Promise((r) => setTimeout(r, pollMs));
+  }
+}
+
+/**
+ * Assert a NO-OP negative: that `value()` stays equal to `expected` across a
+ * short stable window. Used for the dedup / "no additional render" checks where
+ * the absence of an event can't be polled-for positively. The window is short
+ * because the dedup path is synchronous (handledEvents is checked before any
+ * await), so a re-render, if it happened, would already be in flight.
+ */
+async function expectStable<T>(
+  value: () => T,
+  expected: T,
+  label: string,
+  windowMs = 100,
+  pollMs = 5
+): Promise<void> {
+  const deadline = Date.now() + windowMs;
+  for (;;) {
+    if (value() !== expected) {
+      throw new Error(
+        `expectStable: ${label} changed from ${String(expected)} to ${String(
+          value()
+        )}`
+      );
+    }
+    if (Date.now() >= deadline) return;
+    await new Promise((r) => setTimeout(r, pollMs));
+  }
+}
+
+async function seedOrg(id: string): Promise<void> {
+  const sql = getDb();
+  await sql`
+    INSERT INTO organization (id, name, slug)
+    VALUES (${id}, ${id}, ${id})
+    ON CONFLICT (id) DO NOTHING
+  `;
+}
+
+function makeConnection(): PlatformConnection {
+  return {
+    id: CONN,
+    organizationId: ORG,
+    platform: "slack",
+    config: { platform: "slack" } as any,
+    settings: {},
+    metadata: {},
+    status: "active",
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+  };
+}
+
+/** Minimal chat stub the real bridge needs to resolve a DM thread and post. */
+function makeChat(threadPost: ReturnType<typeof mock>) {
+  return {
+    onAction: mock((_handler: any) => undefined),
+    // DM path: conversationId === channelId → bridge calls chat.channel().
+    channel: mock((_key: string) => ({ post: threadPost })),
+    getAdapter: mock((_platform: string) => null),
+    createThread: null,
+  };
+}
+
+/** Manager stub that reports the connection warm with the given chat. */
+function makeManager(instanceChat: any) {
+  const connection = makeConnection();
+  const instance = {
+    connection,
+    chat: instanceChat,
+    messageBridge: { ingestClick: mock(async () => undefined) },
+    conversationState: {},
+  };
+  return {
+    has: (id: string) => id === CONN,
+    getInstance: (id: string) => (id === CONN ? instance : undefined),
+  };
+}
+
+const slackQuestion: PostedQuestion = {
+  id: "q_fanout_1",
+  userId: USER,
+  // DM: conversationId === channelId so resolveThread takes the channel path.
+  conversationId: "D095",
+  channelId: "D095",
+  teamId: "T1",
+  connectionId: CONN,
+  platform: "slack",
+  question: "Proceed with the cross-pod card?",
+  options: ["Yes", "No"],
+};
+
+describe("chat interaction card cross-pod fan-out (faithful seam, real bridge + real DB)", () => {
+  beforeAll(async () => {
+    await ensureDbForGatewayTests();
+  });
+  beforeEach(async () => {
+    await resetTestDatabase();
+    await seedOrg(ORG);
+  });
+
+  test("card posted on a COLD replica is delivered exactly once by the REAL bridge on the WARM replica", async () => {
+    // --- COLD replica: producer enqueues instead of rendering ----------------
+    const coldSvc = new InteractionService();
+    const enqueued: any[] = [];
+    const coldQueue = {
+      send: mock(async (_name: string, data: any) => {
+        enqueued.push(data);
+        return "job-id";
+      }),
+    } as any;
+    // Not warm locally → producer must enqueue (the worker-pod case).
+    const coldCleanup = registerChatInteractionFanout(
+      coldSvc,
+      coldQueue,
+      (_id: string) => false
+    );
+
+    coldSvc.emit("question:created", slackQuestion);
+
+    expect(coldQueue.send).toHaveBeenCalledTimes(1);
+    expect(enqueued.length).toBe(1);
+    const row = enqueued[0];
+    expect(row.platformMetadata.connectionId).toBe(CONN);
+    expect(row.customEvent.name).toBe("chat-interaction");
+
+    // --- WARM replica: real bridge + real consumer ---------------------------
+    const warmSvc = new InteractionService();
+    const threadPost = mock(async () => ({ edit: mock(async () => undefined) }));
+    const instanceChat = makeChat(threadPost);
+    const manager = makeManager(instanceChat);
+    const actionChat = makeChat(threadPost);
+
+    const bridgeCleanup = registerInteractionBridge(
+      warmSvc,
+      manager as any,
+      makeConnection(),
+      actionChat as any
+    );
+
+    const consumer = new UnifiedThreadResponseConsumer(
+      { send: mock(async () => "id") } as any,
+      { get: mock(() => undefined) } as any,
+      { broadcast: mock(() => undefined) } as any
+    ) as any;
+    // This replica OWNS the connection → ensureDeliverable true.
+    consumer.setChatResponseBridge({
+      ensureDeliverable: mock(async () => true),
+      handleCompletion: mock(async () => undefined),
+      handleError: mock(async () => undefined),
+    });
+    // Wire re-emit onto the warm InteractionService (warm-locally guard true so
+    // its own producer never re-enqueues).
+    consumer.setInteractionService(warmSvc, (_id: string) => true);
+
+    // The COLD replica's enqueued row is claimed here.
+    await consumer.handleThreadResponse({ id: "job-1", data: row });
+    // Bridge render is async (resolveThread → import("chat") → post). Wait on
+    // the CONDITION (one post) rather than a fixed sleep.
+    await waitFor(
+      () => threadPost.mock.calls.length === 1,
+      "warm-replica bridge posts the card exactly once"
+    );
+
+    // Exactly ONE platform card posted.
+    expect(threadPost).toHaveBeenCalledTimes(1);
+
+    // Exactly ONE pending_interactions row written (real DB). The bridge
+    // persists the row before posting, so once the post is observed the row is
+    // already durable; poll defensively to absorb any commit lag.
+    const sql = getDb();
+    const countPendingRows = async (): Promise<number> => {
+      const rows = await sql<{ id: string }>`
+        SELECT id FROM pending_interactions WHERE id = ${slackQuestion.id}
+      `;
+      return rows.length;
+    };
+    await waitFor(
+      async () => (await countPendingRows()) === 1,
+      "exactly one pending_interactions row written"
+    );
+
+    // --- Re-claim the SAME row (queue retry) — must NOT double-render --------
+    await consumer.handleThreadResponse({ id: "job-1-retry", data: row });
+
+    // Still exactly one card and one pending row — the bridge's handledEvents
+    // dedup (same id) makes the re-emit a no-op. Assert STABILITY (the count
+    // does not climb to 2) across a short window rather than a fixed sleep.
+    await expectStable(
+      () => threadPost.mock.calls.length,
+      1,
+      "card post count stays at 1 after queue re-claim"
+    );
+    expect(await countPendingRows()).toBe(1);
+
+    coldCleanup();
+    bridgeCleanup();
+  });
+
+  test("N=1 / worker-pod == owner-pod: producer skips the queue, local bridge renders once", async () => {
+    // Single replica: the same InteractionService backs both the worker post
+    // and the warm bridge. The producer's warm-locally guard short-circuits the
+    // enqueue, and the local bridge renders directly.
+    const svc = new InteractionService();
+    const threadPost = mock(async () => ({ edit: mock(async () => undefined) }));
+    const instanceChat = makeChat(threadPost);
+    const manager = makeManager(instanceChat);
+    const actionChat = makeChat(threadPost);
+
+    const bridgeCleanup = registerInteractionBridge(
+      svc,
+      manager as any,
+      makeConnection(),
+      actionChat as any
+    );
+
+    const queue = { send: mock(async () => "id") } as any;
+    // Warm locally → producer must NOT enqueue.
+    const fanoutCleanup = registerChatInteractionFanout(
+      svc,
+      queue,
+      (_id: string) => true
+    );
+
+    svc.emit("question:created", slackQuestion);
+    // Wait on the render CONDITION rather than a fixed sleep.
+    await waitFor(
+      () => threadPost.mock.calls.length === 1,
+      "local bridge renders the card once (N=1)"
+    );
+
+    // No queue traffic, exactly one local render.
+    expect(queue.send).not.toHaveBeenCalled();
+    expect(threadPost).toHaveBeenCalledTimes(1);
+
+    const sql = getDb();
+    const rows = await sql<{ id: string }>`
+      SELECT id FROM pending_interactions WHERE id = ${slackQuestion.id}
+    `;
+    expect(rows.length).toBe(1);
+
+    fanoutCleanup();
+    bridgeCleanup();
+  });
+});

--- a/packages/server/src/gateway/__tests__/unified-thread-consumer.test.ts
+++ b/packages/server/src/gateway/__tests__/unified-thread-consumer.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, mock, test } from "bun:test";
-import { UnifiedThreadResponseConsumer } from "../platform/unified-thread-consumer.js";
+import { InteractionService } from "../interactions.js";
+import {
+  registerChatInteractionFanout,
+  UnifiedThreadResponseConsumer,
+} from "../platform/unified-thread-consumer.js";
 
 const basePayload = {
   messageId: "m1",
@@ -404,5 +408,256 @@ describe("UnifiedThreadResponseConsumer Chat SDK hydrate-on-claim", () => {
 
     expect(platformRegistry.get).toHaveBeenCalledWith("telegram");
     expect(renderer.handleCompletion).toHaveBeenCalledTimes(1);
+  });
+});
+
+// Cross-pod fan-out for CHAT-PLATFORM interaction cards (the bug fixed here):
+// a worker posts an ask_user card into ITS pod's InteractionService, but under
+// N>1 replicas (Slack webhooks don't pin to the connection's pod) that pod
+// rarely owns the connection's interaction bridge — so the card was lost. The
+// producer rides the thread_response queue; the consumer re-emits it on the
+// owning pod, gated by the same ensureDeliverable/warmConnection owner-gate the
+// text path uses, and dedups against the bridge's per-connection handledEvents.
+describe("chat interaction fan-out producer (registerChatInteractionFanout)", () => {
+  function makeFanout(opts?: { warmLocally?: boolean }) {
+    const send = mock(async () => "job-id");
+    const queue = { send } as any;
+    const svc = new InteractionService();
+    const warm = opts?.warmLocally ?? false;
+    const cleanup = registerChatInteractionFanout(
+      svc,
+      queue,
+      (_id: string) => warm
+    );
+    return { svc, send, cleanup };
+  }
+
+  const slackQuestion = {
+    id: "q_slack_1",
+    userId: "U1",
+    conversationId: "slack:D095:thread",
+    channelId: "D095",
+    teamId: "T1",
+    connectionId: "cfa916c95eb64939",
+    platform: "slack",
+    question: "Proceed?",
+    options: ["Yes", "No"],
+  };
+
+  test("enqueues a chat card when this pod does NOT own the connection", () => {
+    const { svc, send } = makeFanout({ warmLocally: false });
+
+    svc.emit("question:created", slackQuestion);
+
+    expect(send).toHaveBeenCalledTimes(1);
+    const [queueName, payload, opts] = send.mock.calls[0] as any[];
+    expect(queueName).toBe("thread_response");
+    // connectionId rides platformMetadata so ensureDeliverable can warm the
+    // owning replica's connection.
+    expect(payload.platformMetadata.connectionId).toBe("cfa916c95eb64939");
+    expect(payload.platform).toBe("slack");
+    expect(payload.customEvent.name).toBe("chat-interaction");
+    expect(payload.customEvent.data.eventName).toBe("question:created");
+    expect(payload.customEvent.data.event.id).toBe("q_slack_1");
+    // Raised-retry re-claim budget, same as terminal/API-card delivery.
+    expect(opts).toMatchObject({ retryLimit: 30, retryDelay: 1 });
+  });
+
+  test("does NOT enqueue when this pod already owns the connection (local render handles it)", () => {
+    const { svc, send } = makeFanout({ warmLocally: true });
+
+    svc.emit("question:created", slackQuestion);
+
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  test("does NOT enqueue api cards (ApiPlatform owner-routes those to the SSE)", () => {
+    const { svc, send } = makeFanout({ warmLocally: false });
+
+    svc.emit("question:created", {
+      ...slackQuestion,
+      platform: "api",
+      connectionId: undefined,
+    });
+
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  test("does NOT enqueue chat cards missing a connectionId", () => {
+    const { svc, send } = makeFanout({ warmLocally: false });
+
+    svc.emit("question:created", { ...slackQuestion, connectionId: undefined });
+
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  test("fans out every interaction channel (approval, link-button, status)", () => {
+    const { svc, send } = makeFanout({ warmLocally: false });
+
+    svc.emit("tool:approval-needed", {
+      ...slackQuestion,
+      id: "req_1",
+    });
+    svc.emit("link-button:created", {
+      ...slackQuestion,
+      id: "lb_1",
+    });
+    svc.emit("status-message:created", {
+      ...slackQuestion,
+      id: "sm_1",
+    });
+
+    expect(send).toHaveBeenCalledTimes(3);
+    const names = send.mock.calls.map(
+      (c: any[]) => c[1].customEvent.data.eventName
+    );
+    expect(names).toEqual([
+      "tool:approval-needed",
+      "link-button:created",
+      "status-message:created",
+    ]);
+  });
+
+  test("cleanup detaches all listeners (no fan-out after teardown)", () => {
+    const { svc, send, cleanup } = makeFanout({ warmLocally: false });
+    cleanup();
+
+    svc.emit("question:created", slackQuestion);
+
+    expect(send).not.toHaveBeenCalled();
+  });
+});
+
+describe("chat interaction fan-out consumer (handleChatInteraction)", () => {
+  function makeChatInteractionRow(connectionId = "cfa916c95eb64939") {
+    return {
+      messageId: "q_slack_1",
+      conversationId: "slack:D095:thread",
+      channelId: "D095",
+      userId: "U1",
+      platform: "slack",
+      teamId: "slack",
+      timestamp: 42,
+      platformMetadata: { connectionId },
+      customEvent: {
+        name: "chat-interaction",
+        data: {
+          eventName: "question:created",
+          event: {
+            id: "q_slack_1",
+            connectionId,
+            platform: "slack",
+            question: "Proceed?",
+            options: ["Yes", "No"],
+          },
+        },
+      },
+    };
+  }
+
+  function makeConsumer(ensureDeliverable: boolean) {
+    const queue = {
+      start: mock(async () => undefined),
+      stop: mock(async () => undefined),
+      createQueue: mock(async () => undefined),
+      work: mock(async () => undefined),
+      send: mock(async () => "id"),
+    };
+    const platformRegistry = { get: mock(() => undefined) };
+    const sseManager = { broadcast: mock(() => undefined) };
+    const consumer = new UnifiedThreadResponseConsumer(
+      queue as any,
+      platformRegistry as any,
+      sseManager as any
+    ) as any;
+    const chatResponseBridge = {
+      ensureDeliverable: mock(async () => ensureDeliverable),
+      handleCompletion: mock(async () => undefined),
+      handleError: mock(async () => undefined),
+    };
+    consumer.setChatResponseBridge(chatResponseBridge);
+    const svc = new InteractionService();
+    // Wire the interaction service with a not-warm-locally producer guard so
+    // re-emit drives the consumer-side path under test.
+    consumer.setInteractionService(svc, (_id: string) => false);
+    return { consumer, svc, chatResponseBridge, platformRegistry };
+  }
+
+  test("re-emits the card onto the local InteractionService on the OWNING pod", async () => {
+    const { consumer, svc, chatResponseBridge, platformRegistry } =
+      makeConsumer(true);
+    const rendered: any[] = [];
+    svc.on("question:created", (e: any) => rendered.push(e));
+
+    await consumer.handleThreadResponse({
+      id: "job-1",
+      data: makeChatInteractionRow(),
+    });
+
+    // Owner-gate consulted (warmConnection), then re-emitted exactly once with
+    // the ORIGINAL id (drives the bridge's handledEvents dedup).
+    expect(chatResponseBridge.ensureDeliverable).toHaveBeenCalledTimes(1);
+    expect(rendered.length).toBe(1);
+    expect(rendered[0].id).toBe("q_slack_1");
+    // Never falls through to the platform-renderer text path.
+    expect(platformRegistry.get).not.toHaveBeenCalled();
+  });
+
+  test("re-queues (throws) and does NOT render on a pod that can't serve the connection", async () => {
+    const { consumer, svc, chatResponseBridge } = makeConsumer(false);
+    const rendered: any[] = [];
+    svc.on("question:created", (e: any) => rendered.push(e));
+
+    await expect(
+      consumer.handleThreadResponse({ id: "job-2", data: makeChatInteractionRow() })
+    ).rejects.toThrow(/cannot be served by this gateway instance/);
+
+    expect(chatResponseBridge.ensureDeliverable).toHaveBeenCalledTimes(1);
+    // The card is NOT lost on the wrong pod — it throws to re-queue, and never
+    // renders locally.
+    expect(rendered.length).toBe(0);
+  });
+
+  test("drops (does NOT re-emit) when the envelope connectionId mismatches the row connectionId", async () => {
+    const { consumer, svc, chatResponseBridge } = makeConsumer(true);
+    const rendered: any[] = [];
+    svc.on("question:created", (e: any) => rendered.push(e));
+
+    const row = makeChatInteractionRow("conn-A");
+    // Corrupt the envelope so the event is tagged for a DIFFERENT connection
+    // than the row's routing key (what ensureDeliverable would warm).
+    (row.customEvent.data.event as any).connectionId = "conn-B";
+
+    await consumer.handleThreadResponse({ id: "job-mismatch", data: row });
+
+    // Guard fires before the owner-gate: we must not warm or render a misrouted
+    // card onto connection conn-A's warm pod.
+    expect(rendered.length).toBe(0);
+    expect(chatResponseBridge.ensureDeliverable).not.toHaveBeenCalled();
+  });
+
+  test("idempotent / at-most-once: a re-claim of the SAME card renders once via the bridge dedup", async () => {
+    // Simulate the bridge's per-connection handledEvents dedup: a listener that
+    // renders each id at most once. Both the local emit (owner pod produced) and
+    // the queue re-emit carry the SAME id, so the second is a no-op — proving no
+    // double-render across the produce+consume seam.
+    const { consumer, svc } = makeConsumer(true);
+    const handled = new Set<string>();
+    let renders = 0;
+    svc.on("question:created", (e: any) => {
+      if (handled.has(e.id)) return; // mirrors bridge markHandled(event.id)
+      handled.add(e.id);
+      renders += 1;
+    });
+
+    // First delivery (e.g. local emit on the owner pod, or first queue claim).
+    svc.emit("question:created", makeChatInteractionRow().customEvent.data.event);
+    // Second delivery of the same card via the queue consumer (re-claim/retry).
+    await consumer.handleThreadResponse({
+      id: "job-3",
+      data: makeChatInteractionRow(),
+    });
+
+    expect(renders).toBe(1);
   });
 });

--- a/packages/server/src/gateway/platform/unified-thread-consumer.ts
+++ b/packages/server/src/gateway/platform/unified-thread-consumer.ts
@@ -11,11 +11,48 @@ import type {
   QueueJob,
   ThreadResponsePayload,
 } from "../infrastructure/queue/index.js";
+import { TERMINAL_DELIVERY_SEND_OPTS } from "../infrastructure/queue/index.js";
+import type { InteractionService } from "../interactions.js";
 import type { PlatformRegistry } from "../platform.js";
 import type { SseManager } from "../services/sse-manager.js";
 import type { ResponseRenderer } from "./response-renderer.js";
 
 const logger = createLogger("unified-thread-consumer");
+
+/**
+ * customEvent.name for a CHAT-PLATFORM interaction card (ask_user question,
+ * tool-approval, link-button, status message) that must reach the pod holding
+ * the connection's in-process interaction bridge.
+ *
+ * Unlike API interaction cards — which the browser receives over an SSE socket
+ * pinned to one pod and which `routeToRenderer` owner-gates on
+ * `SseManager.hasActiveConnection` — a chat card is rendered by the in-process
+ * `registerInteractionBridge` listener that only exists on the pod where the
+ * connection is warm. The worker posts the card into ITS pod's local
+ * `InteractionService`; under N>1 replicas (Slack webhooks don't pin to the
+ * connection's pod) that is routinely NOT the bridge pod, so the card was lost.
+ *
+ * Fan-out mirrors the API path: the producer (`registerChatInteractionFanout`)
+ * enqueues every non-api interaction onto the shared `thread_response` queue;
+ * the consumer below claims it on some replica, gates delivery on
+ * `ChatResponseBridge.ensureDeliverable` (the SAME `warmConnection` owner-gate
+ * the chat-response text path uses), and on success re-emits the event onto
+ * THIS pod's local `InteractionService` so the existing bridge renders it
+ * unchanged. A non-owning pod throws to re-queue until the owning pod claims.
+ */
+const CHAT_INTERACTION_EVENT = "chat-interaction";
+
+/**
+ * Map of InteractionService emit channel → the event payload that travels on
+ * it. Carried inside the `chat-interaction` customEvent so the consumer can
+ * re-emit on the correct channel without re-deriving it.
+ */
+interface ChatInteractionEnvelope {
+  /** The InteractionService event name (e.g. "question:created"). */
+  eventName: string;
+  /** The original posted-interaction payload (PostedQuestion, etc.). */
+  event: Record<string, unknown> & { id?: string; connectionId?: string };
+}
 
 /**
  * `platformMetadata.source` values for turns dispatched server-side with no
@@ -37,6 +74,8 @@ const HEADLESS_SOURCES = new Set([
  */
 export class UnifiedThreadResponseConsumer {
   private chatResponseBridge?: ChatResponseBridge;
+  private interactionService?: InteractionService;
+  private chatInteractionFanoutCleanup?: () => void;
 
   constructor(
     private queue: IMessageQueue,
@@ -46,6 +85,36 @@ export class UnifiedThreadResponseConsumer {
 
   setChatResponseBridge(bridge: ChatResponseBridge): void {
     this.chatResponseBridge = bridge;
+  }
+
+  /**
+   * Wire the cross-pod fan-out for CHAT-PLATFORM interaction cards. Registers a
+   * producer that enqueues a non-api posted interaction onto the
+   * `thread_response` queue ONLY when this (producing) pod does not already own
+   * the connection's bridge, and stores the service so the consumer can re-emit
+   * a claimed card onto this pod's local bridge. Idempotent: re-registering
+   * tears down the previous subscriber first.
+   *
+   * `isConnectionWarmLocally` lets the producer skip the enqueue when the local
+   * bridge will render the card in-process (same `emit` cycle) — that prevents a
+   * double render in the worker-pod == owner-pod topology, and makes the N=1
+   * path a pure no-op (no queue traffic, local render only).
+   *
+   * Must be called alongside `setChatResponseBridge` — the consumer branch for
+   * `chat-interaction` rows gates on `ensureDeliverable`, so without the bridge
+   * a fanned-out card can never be delivered.
+   */
+  setInteractionService(
+    interactionService: InteractionService,
+    isConnectionWarmLocally: (connectionId: string) => boolean
+  ): void {
+    this.chatInteractionFanoutCleanup?.();
+    this.interactionService = interactionService;
+    this.chatInteractionFanoutCleanup = registerChatInteractionFanout(
+      interactionService,
+      this.queue,
+      isConnectionWarmLocally
+    );
   }
 
   /**
@@ -72,6 +141,8 @@ export class UnifiedThreadResponseConsumer {
    * Stop the consumer.
    */
   async stop(): Promise<void> {
+    this.chatInteractionFanoutCleanup?.();
+    this.chatInteractionFanoutCleanup = undefined;
     await this.queue.stop();
     logger.info("Unified thread response consumer stopped");
   }
@@ -86,6 +157,16 @@ export class UnifiedThreadResponseConsumer {
 
     if (!data?.messageId) {
       logger.error(`Invalid thread response data: ${JSON.stringify(data)}`);
+      return;
+    }
+
+    // CHAT-PLATFORM interaction card fan-out (ask_user/tool-approval/
+    // link-button/status). Handled before the text/terminal routing below
+    // because these rows also carry a `connectionId` and would otherwise be
+    // mis-routed through the chat-response-bridge text path. See
+    // CHAT_INTERACTION_EVENT for the cross-pod rationale.
+    if (data.customEvent?.name === CHAT_INTERACTION_EVENT) {
+      await this.handleChatInteraction(data);
       return;
     }
 
@@ -164,6 +245,83 @@ export class UnifiedThreadResponseConsumer {
     } finally {
       span?.end();
     }
+  }
+
+  /**
+   * Deliver a fanned-out CHAT-PLATFORM interaction card on the pod that owns
+   * the connection's bridge.
+   *
+   * Owner-gate: `ensureDeliverable` warms the connection from its row on this
+   * replica and returns false only when this replica genuinely can't run it
+   * (deleted/stopped, or an exclusive transport leased to another replica). On
+   * false we throw so the row re-queues until the owning pod claims it — exactly
+   * the chat-response text path's behaviour. On true the connection is warm
+   * here, so `registerInteractionBridge` is subscribed to this pod's
+   * `InteractionService`; re-emitting the original event renders the card.
+   *
+   * No-double-render: the re-emitted event keeps its ORIGINAL `id`. The bridge's
+   * per-connection `handledEvents` set dedups by id, so if this same pod also
+   * produced the card (N=1, or worker-pod == bridge-pod), the local emit already
+   * rendered it and the re-emit is a no-op. The has-check + mark happen
+   * synchronously at the top of each bridge handler, before any await, so even a
+   * concurrent local-emit + re-emit cannot both render.
+   */
+  private async handleChatInteraction(
+    data: ThreadResponsePayload
+  ): Promise<void> {
+    const envelope = data.customEvent?.data as
+      | ChatInteractionEnvelope
+      | undefined;
+    if (!envelope?.eventName || !envelope.event) {
+      logger.error(
+        `Invalid chat-interaction envelope for message ${data.messageId}`
+      );
+      return;
+    }
+
+    if (!this.interactionService) {
+      // Fail the job so it re-queues until a replica with the fan-out wired
+      // claims it, rather than silently dropping the card.
+      throw new Error(
+        `Chat interaction card ${data.messageId} cannot be delivered: no InteractionService wired on this gateway instance`
+      );
+    }
+
+    // Defense-in-depth: the row's routing key (platformMetadata.connectionId,
+    // what ensureDeliverable warms) MUST match the connectionId tagged on the
+    // event we're about to re-emit. A mismatched/corrupted envelope could
+    // otherwise render an event tagged for connection A onto connection B's
+    // warm pod. Drop on mismatch — never re-emit a misrouted card.
+    const rowConnectionId = data.platformMetadata?.connectionId as
+      | string
+      | undefined;
+    const eventConnectionId = envelope.event.connectionId;
+    if (
+      eventConnectionId &&
+      rowConnectionId &&
+      eventConnectionId !== rowConnectionId
+    ) {
+      logger.warn(
+        `Dropping chat interaction ${envelope.event.id ?? data.messageId} (${envelope.eventName}): envelope connectionId ${eventConnectionId} does not match row connectionId ${rowConnectionId}`
+      );
+      return;
+    }
+
+    const deliverable = await this.chatResponseBridge?.ensureDeliverable(data);
+    if (!deliverable) {
+      throw new Error(
+        `Chat interaction card for connection ${
+          rowConnectionId ?? "unknown"
+        } cannot be served by this gateway instance (deleted, stopped, or leased to another replica); re-queueing for owner delivery`
+      );
+    }
+
+    // Re-emit on this pod's local InteractionService so the in-process bridge
+    // (now warm for this connection) renders the card with the original id.
+    this.interactionService.emit(envelope.eventName, envelope.event);
+    logger.info(
+      `Delivered chat interaction ${envelope.event.id ?? data.messageId} (${envelope.eventName}) on owning replica`
+    );
   }
 
   /**
@@ -307,4 +465,110 @@ export class UnifiedThreadResponseConsumer {
     }
   }
 
+}
+
+/**
+ * The InteractionService emit channels that carry a CHAT-PLATFORM interaction
+ * card, mapped to whether the event's `id` is durable enough to drive the
+ * bridge's per-connection `handledEvents` dedup (all of them are — every posted
+ * interaction gets a unique `id`). Status messages are included so a cross-pod
+ * status note isn't silently dropped.
+ */
+const CHAT_INTERACTION_CHANNELS = [
+  "question:created",
+  "tool:approval-needed",
+  "link-button:created",
+  "status-message:created",
+] as const;
+
+/**
+ * Register the producer side of the chat-interaction fan-out.
+ *
+ * For every NON-api posted interaction, enqueue a `thread_response` row carrying
+ * the event so the consumer delivers it on the connection-owning pod. API
+ * interactions are skipped — `ApiPlatform` already fans those out to the SSE
+ * owner. Returns a cleanup function that detaches every listener.
+ *
+ * Mirrors `ApiPlatform.enqueueInteractionCard`: same queue, same
+ * `TERMINAL_DELIVERY_SEND_OPTS` re-claim budget. The card's `connectionId` is
+ * placed on `platformMetadata` so `ensureDeliverable` can warm the connection,
+ * and on the row's `platform`/`teamId` so the row is unambiguously a chat row.
+ *
+ * `isConnectionWarmLocally(connectionId)` short-circuits the enqueue when this
+ * pod already owns the connection: the local interaction bridge renders the
+ * card from the same `emit`, so a queue round-trip would only risk a duplicate
+ * render on whichever pod claims it.
+ */
+export function registerChatInteractionFanout(
+  interactionService: InteractionService,
+  queue: IMessageQueue,
+  isConnectionWarmLocally: (connectionId: string) => boolean
+): () => void {
+  const handlers: Array<[string, (event: unknown) => void]> = [];
+
+  for (const eventName of CHAT_INTERACTION_CHANNELS) {
+    const handler = (event: unknown) => {
+      const ev = event as {
+        id?: string;
+        platform?: string;
+        connectionId?: string;
+        conversationId?: string;
+        channelId?: string;
+        userId?: string;
+        teamId?: string;
+      };
+      // API cards are owner-routed to the SSE socket by ApiPlatform; chat cards
+      // need a connectionId to warm the owning pod's bridge.
+      if (!ev || ev.platform === "api") return;
+      if (!ev.connectionId) return;
+
+      // This pod already owns the connection — the in-process bridge renders
+      // the card from this same emit (and its per-connection `handledEvents`
+      // dedups any later re-emit). Enqueuing would risk a duplicate render on
+      // whichever pod claims the job. Skip the cross-pod hop entirely.
+      if (isConnectionWarmLocally(ev.connectionId)) return;
+
+      const envelope: ChatInteractionEnvelope = {
+        eventName,
+        event: ev as Record<string, unknown>,
+      };
+      const payload: ThreadResponsePayload = {
+        messageId: ev.id ?? `chat-int-${Date.now()}`,
+        conversationId: ev.conversationId ?? ev.channelId ?? "",
+        channelId: ev.channelId ?? "",
+        userId: ev.userId ?? "",
+        platform: ev.platform,
+        teamId: ev.teamId ?? ev.platform ?? "",
+        timestamp: Date.now(),
+        // connectionId on platformMetadata is what ensureDeliverable reads to
+        // warm the owning replica's connection.
+        platformMetadata: { connectionId: ev.connectionId },
+        customEvent: {
+          name: CHAT_INTERACTION_EVENT,
+          data: envelope as unknown as Record<string, unknown>,
+        },
+      };
+      // The enqueue is fire-and-forget (the emitter is synchronous), but for an
+      // interaction card a silent enqueue failure means a PERMANENTLY LOST card
+      // with no retry — the worker's ask_user/approval turn hangs forever. Log
+      // it as an error with full routing context so the drop is observable
+      // rather than invisible.
+      void queue
+        .send("thread_response", payload, TERMINAL_DELIVERY_SEND_OPTS)
+        .catch((err) => {
+          logger.error(
+            `Failed to enqueue chat interaction card ${ev.id ?? "unknown"} (${eventName}) for connection ${ev.connectionId} — card is LOST (no retry):`,
+            err
+          );
+        });
+    };
+    interactionService.on(eventName, handler);
+    handlers.push([eventName, handler]);
+  }
+
+  return () => {
+    for (const [eventName, handler] of handlers) {
+      interactionService.off(eventName, handler);
+    }
+  };
 }

--- a/packages/server/src/lobu/gateway.ts
+++ b/packages/server/src/lobu/gateway.ts
@@ -384,6 +384,17 @@ export async function initLobuGateway(): Promise<Hono | null> {
           coreServices.getAgentSettingsStore()
         );
         unifiedConsumer.setChatResponseBridge(bridge);
+        // Cross-pod fan-out for chat-platform interaction cards (ask_user,
+        // tool-approval, link-button, status). The worker posts a card into
+        // its own pod's InteractionService; under N>1 replicas that pod
+        // rarely owns the connection's bridge, so the card must ride the
+        // thread_response queue to the owning pod. The local-warm check skips
+        // the queue when this pod already renders the card in-process.
+        const manager = chatInstanceManager;
+        unifiedConsumer.setInteractionService(
+          coreServices.getInteractionService(),
+          (connectionId: string) => manager.has(connectionId)
+        );
       }
     } catch (error) {
       logger.warn(


### PR DESCRIPTION
## The bug (confirmed live in prod)

In N>1 app replicas, a Slack `ask_user`/interaction card is **silently lost** when the worker runs on a different pod than the one holding the connection's interaction-bridge. Confirmed from prod logs: worker on pod A called `ask_user` and posted question `q_d3866303`, but the Slack bridge on pod B never rendered it — the card never appeared. (Live re-test later rendered only because both pods happened to be warm for the connection — i.e. it's intermittent today, ~coin-flip per request.)

Root cause: the worker posts the card into **its own pod's** in-process `InteractionService`; the render bridge usually lives on another pod (Slack webhooks don't pin under ClientIP affinity), so `shouldHandle` drops it on the producing pod and it never reaches the owner. Text responses already cross pods via `thread_response`; interaction cards did not (the documented planned follow-up from #1236).

## The fix (mirrors the existing API-card fan-out)

- **Producer** (`registerChatInteractionFanout`): subscribes to the four chat interaction emits; when this pod is **not** warm for the connection, enqueues a `thread_response` row (`customEvent "chat-interaction"`, `TERMINAL_DELIVERY_SEND_OPTS`). When warm locally, it **skips** the enqueue and the in-process bridge renders once (no queue traffic, no double-render).
- **Consumer** (`handleChatInteraction`): single-claim (SKIP-LOCKED) → owner-gate via `ensureDeliverable` (`warmConnection`) → on the owning pod re-emits onto the local `InteractionService` so the existing bridge renders. Non-owners throw-to-requeue.
- **Hardening**: failed enqueue logged as a permanent loss (not silent); `connectionId` mismatch between envelope and row is dropped before render; re-emit preserves `event.id` so the bridge `handledEvents` dedup no-ops re-claims.

## No double-render / N=1
- N>1 worker≠owner: producer not warm → enqueue → single-claim delivers once on owner. Exactly one render.
- N>1 worker==owner / N=1: producer skips enqueue → local bridge renders once. No queue traffic.
- Re-claim: dedup on preserved id → no-op.

## Tests
Unit producer/consumer/guard + a **real-bridge + real-Postgres cross-pod test** (`chat-interaction-fanout-crosspod.test.ts`): cold replica enqueues, warm replica's consumer re-emits → real `registerInteractionBridge` renders exactly **one** card + writes **one** `pending_interactions` row; a re-claim renders zero additional. Condition-based waits (no fixed sleeps), 3× deterministic. 143 interaction/consumer tests green; `tsc` clean.

## Review
- pi `make review`: 0 product bugs (the one prior blocker was a test-timing flake, now fixed with polling waits).
- Independent grok + gemini reviews: both "correct for N>1 without double-render".

## ⚠️ Owed before merge (AGENTS.md hard gate)
Live **two-pod** / post-deploy Slack `ask_user` e2e: confirm a card posted on a non-owner pod renders on the owner pod every time (including when the worker is on the cold pod). Can't run locally (needs two real replicas + Slack); verify post-deploy via Flux rollout + `scripts/test-bot.sh`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1270"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784152591&installation_id=136316292&pr_number=1270&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1270&signature=2705d53059cb583fcebd8f65b660778ed67fd83a075935412785dc0773b3c201"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->