### PR TITLE
fix(gateway): include connectionId in per-run worker token (ask_user 500 hotfix)

### DIFF
--- a/packages/server/src/gateway/__tests__/runjobtoken-connectionid.test.ts
+++ b/packages/server/src/gateway/__tests__/runjobtoken-connectionid.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, test } from "bun:test";
+import { generateWorkerToken, verifyWorkerToken } from "@lobu/core";
+import { assertRoutableInteraction } from "../interactions.js";
+
+/**
+ * Regression for the prod incident where every chat-platform `ask_user`
+ * 500'd. #1271 made the worker use the per-run token as its PRIMARY gateway
+ * auth (`session-runner`: `runJobToken || WORKER_TOKEN`), but `MessageConsumer`
+ * minted that token WITHOUT `connectionId`. So the interaction route's
+ * `assertRoutableInteraction` rejected the post (a chat-platform interaction
+ * with no connectionId) and `postQuestion` threw before emitting.
+ *
+ * These tests pin the contract: the per-run worker token must carry
+ * connectionId, and a token that carries it routes; one that doesn't is
+ * exactly the failure we shipped.
+ */
+describe("runJobToken carries connectionId for interaction routing", () => {
+  const CONN = "cfa916c95eb64939";
+
+  test("a per-run token minted WITH connectionId routes interactions", () => {
+    const token = generateWorkerToken("U_USER", "slack:DM:123.456", "dep-1", {
+      channelId: "slack:DM",
+      teamId: "T_TEAM",
+      agentId: "crm",
+      organizationId: "org_lobucrm",
+      platform: "slack",
+      connectionId: CONN,
+      runId: 42,
+    });
+    const decoded = verifyWorkerToken(token);
+    expect(decoded?.connectionId).toBe(CONN);
+    // The route does exactly this with the decoded worker context; must not throw.
+    expect(() =>
+      assertRoutableInteraction(decoded?.connectionId, "slack", "question")
+    ).not.toThrow();
+  });
+
+  test("the shipped bug: a per-run token WITHOUT connectionId is rejected", () => {
+    const token = generateWorkerToken("U_USER", "slack:DM:123.456", "dep-1", {
+      channelId: "slack:DM",
+      teamId: "T_TEAM",
+      agentId: "crm",
+      organizationId: "org_lobucrm",
+      platform: "slack",
+      runId: 42,
+      // connectionId intentionally omitted — reproduces the #1271 regression
+    });
+    const decoded = verifyWorkerToken(token);
+    expect(decoded?.connectionId).toBeUndefined();
+    expect(() =>
+      assertRoutableInteraction(decoded?.connectionId, "slack", "question")
+    ).toThrow();
+  });
+
+  test("api platform is exempt (no connectionId required)", () => {
+    expect(() =>
+      assertRoutableInteraction(undefined, "api", "question")
+    ).not.toThrow();
+  });
+});

--- a/packages/server/src/gateway/orchestration/message-consumer.ts
+++ b/packages/server/src/gateway/orchestration/message-consumer.ts
@@ -225,6 +225,17 @@ export class MessageConsumer {
             agentId: data.agentId,
             organizationId: data.organizationId,
             platform: data.platform,
+            // The worker uses this per-run token as its PRIMARY gateway auth
+            // (session-runner: `runJobToken || WORKER_TOKEN`), so it must carry
+            // connectionId — otherwise interaction posts (ask_user / tool
+            // approval / link button) hit `assertRoutableInteraction`, which
+            // rejects a chat-platform interaction with no connectionId, and
+            // every ask_user 500s. Mirrors base-deployment-manager's
+            // deployment-lifetime worker token.
+            connectionId:
+              typeof data.platformMetadata?.connectionId === "string"
+                ? data.platformMetadata.connectionId
+                : undefined,
             // Carry the headless run origin so interaction cards emitted from
             // this turn can be stamped headless and skip the SSE-owner gate.
             source:


### PR DESCRIPTION
## P0 incident

Every chat-platform `ask_user` / tool-approval / link-button **500'd in prod** (found via live Slack e2e of the interaction work). Sentry: `LOBU-BACKEND-1B`, 500 at `/lobu/internal/interactions/create`, release `50b5e26f`.

## Root cause

`#1271` made the worker use the **per-run token** as its PRIMARY gateway auth (`session-runner.ts`: `runJobToken || WORKER_TOKEN`). But `MessageConsumer` mints that per-run token **without `connectionId`**. The interaction route's `assertRoutableInteraction` rejects a chat-platform interaction that has no `connectionId` (cross-platform-leak guard), so `postQuestion` threw before emitting → worker got 500. The deployment `WORKER_TOKEN` *has* connectionId, but it's only the fallback once `runJobToken` exists — so the bug was masked until #1271 flipped the primary token.

## Fix

Stamp `connectionId` onto the per-run token from `platformMetadata.connectionId`, mirroring `base-deployment-manager`'s deployment-lifetime token. One field, +11 lines.

## Test

`runjobtoken-connectionid.test.ts` (3 pass): a per-run token *with* connectionId routes via `assertRoutableInteraction`; one *without* is exactly the 500 we shipped; api platform exempt.

## Verification owed (hard gate)

Live Slack `ask_user` after this deploys — must render the buttons (re-running the exact repro that 500'd). Will confirm post-rollout.

## Follow-ups (separate, not blocking)
- Pre-existing server type errors: `source` missing from `WorkerTokenData` / `PostedQuestion`/`PostedLinkButton`/`PostedToolApproval` (also from #1271; slip CI because `bun run typecheck` excludes server). 
- `#1266` cut worker-token TTL 24h→2h: long-lived per-conversation workers will 401 after 2h — needs a refresh path.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1274"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784161526&installation_id=136316292&pr_number=1274&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1274&signature=6024956a2d84283ba4db5a7aadb28a2369acfd99e99fb0b326821533d937d9d9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->