### PR TITLE
fix(gateway): API status-message cross-pod fan-out + terminal finalText repair

### DIFF
--- a/packages/server/src/gateway/api/__tests__/platform-card-source.test.ts
+++ b/packages/server/src/gateway/api/__tests__/platform-card-source.test.ts
@@ -79,3 +79,85 @@ describe("ApiPlatform interaction-card source stamping (F12)", () => {
     expect(ctx.sends[0]!.payload.customEvent?.requireSseOwner).toBe(true);
   });
 });
+
+// Gap A: API/SPA "Processing…" status messages were the one interaction the API
+// platform did NOT fan out cross-pod, so under N>1 they were lost (posted on the
+// worker's pod, the browser's SSE pinned to another). They must ride the same
+// owner-gated thread_response queue as question/link-button/tool-approval, and
+// surface as the SSE `status` event the SPA reads (`{ type: "status", status }`).
+describe("ApiPlatform status-message cross-pod fan-out (Gap A)", () => {
+  let platform: ApiPlatform;
+  let ctx: ReturnType<typeof makePlatform>;
+
+  beforeEach(async () => {
+    platform = new ApiPlatform();
+    ctx = makePlatform();
+    await platform.initialize(ctx.services as never);
+  });
+
+  test("enqueues an interactive status message as the SSE `status` event", async () => {
+    await ctx.interactionService.postStatusMessage(
+      "api:conv-1",
+      "api:conv-1",
+      undefined,
+      undefined,
+      "api",
+      "Processing…"
+      // no source — interactive, browser-driven turn → owner-gated
+    );
+
+    expect(ctx.sends).toHaveLength(1);
+    const { topic, payload } = ctx.sends[0]!;
+    expect(topic).toBe("thread_response");
+    // SSE event name the consumer broadcasts and the SPA listens for.
+    expect(payload.customEvent?.name).toBe("status");
+    // SPA reads payload.status (lobu-runtime-provider) — must match this shape.
+    expect(payload.customEvent?.data).toEqual({
+      type: "status",
+      status: "Processing…",
+    });
+    // Owner-gated like the other API cards (browser SSE lives on one pod).
+    expect(payload.customEvent?.requireSseOwner).toBe(true);
+    // Interactive turn carries no source, so it stays owner-routed.
+    expect(payload.platformMetadata).toBeUndefined();
+    expect(payload.conversationId).toBe("api:conv-1");
+  });
+
+  test("propagates source so a headless status message bypasses the owner-gate", async () => {
+    await ctx.interactionService.postStatusMessage(
+      "api:conv-2",
+      "api:conv-2",
+      undefined,
+      undefined,
+      "api",
+      "Refreshing connection…",
+      "connector-repair"
+    );
+
+    expect(ctx.sends).toHaveLength(1);
+    const { payload } = ctx.sends[0]!;
+    // Headless source stamped → consumer's headless exemption applies (no SSE
+    // owner exists on any pod for a connector-repair turn).
+    expect(payload.platformMetadata).toEqual({ source: "connector-repair" });
+    expect(payload.customEvent?.name).toBe("status");
+    expect(payload.customEvent?.data).toEqual({
+      type: "status",
+      status: "Refreshing connection…",
+    });
+  });
+
+  test("does NOT fan out a non-api status message (chat path owns those)", async () => {
+    await ctx.interactionService.postStatusMessage(
+      "slack:conv",
+      "slack:conv",
+      undefined,
+      "conn-1",
+      "slack",
+      "Working…"
+    );
+
+    // ApiPlatform filters on platform === "api"; chat status fans out via
+    // registerChatInteractionFanout, not here.
+    expect(ctx.sends).toHaveLength(0);
+  });
+});

--- a/packages/server/src/gateway/api/__tests__/response-renderer-finaltext.test.ts
+++ b/packages/server/src/gateway/api/__tests__/response-renderer-finaltext.test.ts
@@ -1,0 +1,65 @@
+/**
+ * Terminal-repair (Gap C): streaming `output` deltas are best-effort under N>1
+ * replicas — a delta claimed on a pod that doesn't hold the client's SSE socket
+ * is lost, leaving the SPA's accumulated text truncated. The worker stamps the
+ * full authoritative reply onto the terminal row as `finalText`
+ * (gateway-integration.signalCompletion); the API renderer MUST forward it on
+ * the `complete` SSE event so the SPA can repair. Without it a cross-pod delta
+ * loss is permanent with no repair path.
+ */
+
+import { describe, expect, mock, test } from "bun:test";
+import { ApiResponseRenderer } from "../response-renderer.js";
+import type { ThreadResponsePayload } from "../../infrastructure/queue/types.js";
+
+function makeRenderer() {
+  const broadcasts: Array<{ key: string; event: string; data: any }> = [];
+  const sseManager = {
+    broadcast: mock((key: string, event: string, data: any) => {
+      broadcasts.push({ key, event, data });
+    }),
+  };
+  const renderer = new ApiResponseRenderer(sseManager as never);
+  return { renderer, broadcasts };
+}
+
+const basePayload = (over: Partial<ThreadResponsePayload>): ThreadResponsePayload =>
+  ({
+    messageId: "m1",
+    conversationId: "api:conv-1",
+    channelId: "api:conv-1",
+    userId: "api",
+    teamId: "api",
+    timestamp: 100,
+    processedMessageIds: ["m1"],
+    ...over,
+  }) as ThreadResponsePayload;
+
+describe("ApiResponseRenderer.handleCompletion finalText repair", () => {
+  test("forwards finalText on the complete SSE event", async () => {
+    const { renderer, broadcasts } = makeRenderer();
+
+    await renderer.handleCompletion(
+      basePayload({ finalText: "the full assistant reply" }),
+      "session-key"
+    );
+
+    const complete = broadcasts.find((b) => b.event === "complete");
+    expect(complete).toBeDefined();
+    expect(complete?.key).toBe("api:conv-1");
+    expect(complete?.data).toMatchObject({
+      type: "complete",
+      messageId: "m1",
+      finalText: "the full assistant reply",
+    });
+  });
+
+  test("leaves finalText undefined when the worker streamed nothing extra", async () => {
+    const { renderer, broadcasts } = makeRenderer();
+
+    await renderer.handleCompletion(basePayload({}), "session-key");
+
+    const complete = broadcasts.find((b) => b.event === "complete");
+    expect(complete?.data.finalText).toBeUndefined();
+  });
+});

--- a/packages/server/src/gateway/api/platform.ts
+++ b/packages/server/src/gateway/api/platform.ts
@@ -50,8 +50,9 @@ export class ApiPlatform implements PlatformAdapter {
 
     // Subscribe to interaction events and deliver them to SSE clients.
     //
-    // These cards (ask_user question, tool-approval, link-button) are raised by
-    // the worker on ITS pod, but the browser's SSE stream is pinned by ClientIP
+    // These cards (ask_user question, tool-approval, link-button, status
+    // message) are raised by the worker on ITS pod, but the browser's SSE
+    // stream is pinned by ClientIP
     // affinity to a possibly DIFFERENT pod. The SseManager is per-pod and
     // in-memory, so broadcasting directly here would land the card on the
     // worker's pod, which the browser is not connected to — the user never sees
@@ -100,6 +101,22 @@ export class ApiPlatform implements PlatformAdapter {
       this.enqueueInteractionCard(queue, event, "suggestion", {
         type: "suggestion",
         prompts: event.prompts,
+      });
+    });
+
+    // Status messages (e.g. "Processing…", MCP auth prompts) are pushed to the
+    // browser's SSE socket the same way as the cards above, so under N>1 they
+    // hit the same cross-pod loss: posted on the worker's pod, the browser's SSE
+    // is pinned to a different pod and never sees the status. Enqueue onto the
+    // owner-gated thread_response queue like the others. The SSE event name is
+    // `status` and the SPA reads `payload.status` (see ApiResponseRenderer.
+    // handleStatusUpdate + owletto lobu-runtime-provider), so the card data must
+    // surface as `{ type: "status", status: <text> }`.
+    interactionService.on("status-message:created", (event: any) => {
+      if (event.platform !== "api") return;
+      this.enqueueInteractionCard(queue, event, "status", {
+        type: "status",
+        status: event.text,
       });
     });
 

--- a/packages/server/src/gateway/api/response-renderer.ts
+++ b/packages/server/src/gateway/api/response-renderer.ts
@@ -74,11 +74,21 @@ export class ApiResponseRenderer implements ResponseRenderer {
       return;
     }
 
-    // Broadcast completion to SSE clients
+    // Broadcast completion to SSE clients.
+    //
+    // Carry the worker's authoritative `finalText` (the full assistant reply,
+    // added to the terminal row in gateway-integration.signalCompletion for
+    // exactly this cross-replica reason). Streaming `output` deltas stay
+    // best-effort under N>1: a delta row claimed on a non-owning pod is lost
+    // (the SseManager is per-pod), so the SPA's accumulated text can be
+    // truncated. The SPA repairs from `finalText` on this terminal event —
+    // without it a cross-pod delta loss would leave a permanently truncated
+    // message with no repair. (Empty string when nothing was streamed.)
     this.sseManager.broadcast(sessionId, "complete", {
       type: "complete",
       messageId: payload.messageId,
       processedMessageIds: payload.processedMessageIds,
+      finalText: payload.finalText,
       timestamp: payload.timestamp || Date.now(),
     });
 

--- a/packages/server/src/gateway/interactions.ts
+++ b/packages/server/src/gateway/interactions.ts
@@ -108,6 +108,15 @@ export interface PostedToolApproval extends BaseMessage {
 export interface PostedStatusMessage extends BaseMessage {
   platform: string;
   text: string;
+  /**
+   * Dispatch origin (watcher-run/connector-repair/scheduled-job/internal) for a
+   * headless turn. Propagated onto the cross-pod thread_response row so the
+   * consumer's headless owner-gate exemption applies — without it a status
+   * message from a headless turn would owner-gate, re-queue 30x and dead-letter
+   * (no SSE/bridge owner exists on any pod). Matches PostedQuestion/
+   * PostedToolApproval.
+   */
+  source?: string;
 }
 
 /**
@@ -310,7 +319,8 @@ export class InteractionService extends EventEmitter {
     teamId: string | undefined,
     connectionId: string | undefined,
     platform: string,
-    text: string
+    text: string,
+    source?: string
   ): Promise<PostedStatusMessage> {
     assertRoutableInteraction(connectionId, platform, "status message");
     if (this.beforeCreateHook) {
@@ -325,6 +335,7 @@ export class InteractionService extends EventEmitter {
       connectionId,
       platform,
       text,
+      source,
     };
 
     logger.info(

--- a/packages/server/src/gateway/platform/unified-thread-consumer.ts
+++ b/packages/server/src/gateway/platform/unified-thread-consumer.ts
@@ -442,7 +442,17 @@ export class UnifiedThreadResponseConsumer {
       return;
     }
 
-    // Handle streaming delta
+    // Handle streaming delta.
+    //
+    // Deltas (and the typing/status heartbeat above) stay best-effort under N>1
+    // replicas: they are NOT owner-gated (the isApiRow gate above scopes to
+    // terminal + requireSseOwner rows only), so a delta row claimed on a pod
+    // that does not hold the client's SSE socket is silently lost — re-queuing
+    // every delta would churn the queue with no benefit. This is accepted: the
+    // terminal `complete` event carries the worker's authoritative `finalText`,
+    // from which the API renderer/SPA repair any missed deltas (see
+    // ApiResponseRenderer.handleCompletion). Per-delta cross-pod fan-out (a
+    // durable SSE-session→pod registry) is the future hardening, deferred.
     if (data.delta && renderer.handleDelta) {
       await renderer.handleDelta(data, sessionKey);
       // Early return if no error - delta processing is complete

--- a/packages/server/src/gateway/services/core-services.ts
+++ b/packages/server/src/gateway/services/core-services.ts
@@ -822,7 +822,8 @@ export class CoreServices {
         teamId,
         connectionId,
         platform || "unknown",
-        payload.message
+        payload.message,
+        source
       );
     };
     logger.debug("MCP proxy initialized");


### PR DESCRIPTION
Closes two multi-replica interaction-streaming gaps on the API/SPA path. Companion owletto PR: lobu-ai/owletto#272.

## 1. API status-message cross-pod fan-out (Gap A)

Status messages (MCP auth prompts, "Processing…") were pushed straight to the browser's per-pod SSE socket. Under N>1 replicas the SSE stream is pinned by ClientIP to a possibly different pod than the worker, so a status posted on the worker's pod never reached the browser — same failure mode the ask_user / tool-approval / link-button cards had before #1270.

Now the API platform subscribes to `status-message:created` and enqueues onto the owner-gated `thread_response` queue like the other cards (`{ type: "status", status: <text> }`, SSE event `status`, read by the SPA as `payload.status`). `PostedStatusMessage.source` is propagated (via `core-services` → `postStatusMessage`) so a headless turn's status is exempted from the owner gate and delivered on first claim instead of dead-lettering.

## 2. Terminal finalText repair (real bug found)

The API `complete` SSE event dropped the worker's authoritative `finalText`. The SPA accumulates assistant text from streaming `output` deltas, but deltas stay best-effort under N>1 (not owner-gated — re-queuing every delta would churn the queue): a delta claimed on a pod that doesn't hold the client's SSE socket is silently lost. With no `finalText` on the terminal event, a cross-pod delta loss left the SPA message **permanently truncated with no repair**.

The chat strategies already render from `payload.finalText` for exactly this reason; the API path didn't. Now `ApiResponseRenderer.handleCompletion` carries `payload.finalText` (already a field on `ThreadResponsePayload`, set in `signalCompletion`) on the `complete` event, and the SPA prefers it whenever present (owletto#272).

`unified-thread-consumer.ts` change is comment-only — documents why deltas stay best-effort and that `finalText` is the repair path.

## Server tsc note (CI-invisible)

`bun run typecheck` EXCLUDES `packages/server`, so server type errors don't gate CI. Confirmed server tsc is clean (0 errors) after building the core dist (`make build-packages`) — the `WorkerTokenData.source` / `Posted*.source` fields referenced here already landed in #1271/#1274; a stale/absent core dist in a fresh worktree makes tsc report spurious `'source' does not exist` errors that vanish once core is built. No interface edits were needed.

## Tests

- `platform-card-source.test.ts` — status card enqueued cross-pod with `source`, filtered to `platform === "api"`.
- `response-renderer-finaltext.test.ts` — `finalText` carried on the `complete` broadcast.
- `unified-thread-consumer.test.ts` — 26 pass (unchanged behavior).

All pass; root typecheck clean; server tsc clean.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1276"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784161955&installation_id=136316292&pr_number=1276&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1276&signature=79a11f1bfdb79aa5f9fedb9c2b49a946018580c871c8840e055b7a2d2ae1fa4d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->