### PR TITLE
feat(server): replace opt-in rewrite_query with auto on-miss recall rescue

### DIFF
--- a/packages/server/src/__tests__/integration/events/get-content-query-rewrite.test.ts
+++ b/packages/server/src/__tests__/integration/events/get-content-query-rewrite.test.ts
@@ -1,29 +1,24 @@
 /**
- * Integration test: server-side query-rewrite recall expansion in
+ * Integration test: auto on-miss query-rewrite recall rescue in
  * `read_knowledge` / `getContent`.
  *
- * The recall gap this closes: a conversational/underspecified query embeds and
- * keyword-matches poorly, so the gold session ranks below the cutoff — and a
- * synonym gap ("physician") misses sessions that say "dermatologist". The LLM
- * query rewriter expands the raw query into focused keyword variants; the search
- * branch runs raw + each variant with an over-fetched internal limit and FUSES
- * the candidates (max score per event id, re-ranked, caller's offset/limit
- * applied to the fused pool) — so a variant hit can displace a less-relevant
- * raw row into the top-k. Fusion only applies to score-sorted, non-cursor
- * searches; date feeds keep their ordering via the single-query path.
- *
- * The benchmark adapter gets this lift by calling
- * read_knowledge({ rewrite_query: true }) — the recall improvement lives in the
- * SERVER (the product), not in adapter glue.
+ * There is no longer a `rewrite_query` param. Instead, when a score-sorted text
+ * query returns NOTHING on the first page, the search path treats the raw
+ * phrasing as too conversational/underspecified, expands it into LLM-rewritten
+ * keyword variants, and fuses their hits. The rescue fires ONLY on a total
+ * miss, so any query that already found something pays no extra LLM call — that
+ * is the behaviour this file pins down:
+ *   - miss  → rewriter consulted, variant hits recovered
+ *   - hit   → rewriter NEVER consulted (no fetch), result unchanged
+ *   - no key / date sort / offset>0 → rescue skipped, graceful
  *
  * Harness: vitest + embedded Postgres (real PG18 + pgvector), mirroring
- * get-content-visibility.test.ts. The LLM is stubbed at the FETCH boundary (not
- * vi.mock, which does not apply under the canonical full-suite runner): we swap
- * global.fetch for a counting stub that returns a canned chat-completions
+ * get-content-visibility.test.ts. The LLM is stubbed at the FETCH boundary: we
+ * swap global.fetch for a counting stub that returns a canned chat-completions
  * payload for /chat/completions. No EMBEDDINGS_SERVICE_URL is configured, so
  * searchContentByText runs text-only (fulltext/trigram) and never calls fetch —
  * the only fetch calls in this file come from the query rewriter, which makes
- * the "no rewrite → no fetch" assertion exact.
+ * the "found something → no fetch" assertion exact.
  */
 
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
@@ -63,9 +58,7 @@ function installFetchStub(): void {
     fetchCalls.push(url);
     if (url.includes('/chat/completions')) {
       const body = JSON.stringify({
-        choices: [
-          { message: { content: JSON.stringify({ queries: cannedVariants }) } },
-        ],
+        choices: [{ message: { content: JSON.stringify({ queries: cannedVariants }) } }],
       });
       return new Response(body, {
         status: 200,
@@ -76,26 +69,20 @@ function installFetchStub(): void {
   }) as typeof fetch;
 }
 
-describe('getContent > rewrite_query recall expansion', () => {
+const rewriteCalls = () => fetchCalls.filter((u) => u.includes('/chat/completions'));
+
+describe('getContent > auto on-miss recall rescue', () => {
   let org: Awaited<ReturnType<typeof createTestOrganization>>;
   let user: Awaited<ReturnType<typeof createTestUser>>;
   let entity: Awaited<ReturnType<typeof createTestEntity>>;
 
-  // The raw query "physician" matches this one via fulltext.
-  let physicianEventId: number;
-  // The raw query "physician" MISSES this (text says "dermatologist"); only a
-  // rewritten variant "dermatologist" surfaces it.
+  // NOTE: there is deliberately NO event containing the word "physician", so the
+  // raw query "physician" is a guaranteed total miss → it is the trigger that
+  // drives the on-miss rescue. The synonym sessions below are only reachable via
+  // a rewritten variant.
   let dermatologistEventId: number;
-  // Extra synonym sessions used to prove `limit` is respected under union.
   let entEventId: number;
   let specialistEventId: number;
-
-  // Fusion / displacement fixtures (BUG-1 reproducer). The raw query
-  // "appointment" matches several low-relevance filler sessions; a rewritten
-  // variant "cardiologist" matches one short, highly-relevant session that must
-  // displace a filler row INTO the top-k even when raw already filled the page.
-  let cardiologistEventId: number;
-  const fillerAppointmentEventIds: number[] = [];
 
   function ctx(): ToolContext {
     return {
@@ -115,18 +102,10 @@ describe('getContent > rewrite_query recall expansion', () => {
     await cleanupTestDatabase();
     await seedSystemEntityTypes();
 
-    org = await createTestOrganization({ name: 'Query Rewrite Org' });
-    user = await createTestUser({ email: 'rewrite@example.com' });
+    org = await createTestOrganization({ name: 'Recall Rescue Org' });
+    user = await createTestUser({ email: 'rescue@example.com' });
     await addUserToOrganization(user.id, org.id, 'owner');
-    entity = await createTestEntity({ name: 'Rewrite Entity', organization_id: org.id });
-
-    physicianEventId = (
-      await createTestEvent({
-        organization_id: org.id,
-        entity_id: entity.id,
-        content: 'I scheduled a checkup with my physician last Tuesday afternoon.',
-      })
-    ).id;
+    entity = await createTestEntity({ name: 'Rescue Entity', organization_id: org.id });
 
     dermatologistEventId = (
       await createTestEvent({
@@ -151,42 +130,6 @@ describe('getContent > rewrite_query recall expansion', () => {
         content: 'The specialist ordered a follow-up scan for next month.',
       })
     ).id;
-
-    // Three filler sessions match the raw query "appointment" and fill a limit=3
-    // page. Two contain the literal "appointment" (so the ranker's ILIKE
-    // whole-query-substring boost applies → score ≈ 1.4). The first uses the
-    // stem-only form "appoints" — it matches the english-tsquery for
-    // "appointment" (both stem to "appoint") but NOT the ILIKE '%appointment%'
-    // substring, so it forgoes that boost and scores LOW (≈ 0.4). That makes it
-    // the deterministically weakest raw hit — the one a strong variant hit must
-    // displace from the top-k.
-    const fillerContents = [
-      'I keep appoints lined up across many errands, groceries, laundry, emails, ' +
-        'meetings and assorted chores that fill the whole long rambling busy day.',
-      'Random note one: I had an appointment among errands, groceries, laundry, ' +
-        'emails, meetings and chores that fill the whole long rambling busy day.',
-      'Random note two: I had an appointment among errands, groceries, laundry, ' +
-        'emails, meetings and chores that fill the whole long rambling busy day.',
-    ];
-    for (const content of fillerContents) {
-      const id = (
-        await createTestEvent({ organization_id: org.id, entity_id: entity.id, content })
-      ).id;
-      fillerAppointmentEventIds.push(id);
-    }
-
-    // A short, on-topic session for the variant term "cardiologist". It does NOT
-    // contain "appointment", so the raw query misses it entirely; only the
-    // variant surfaces it, and as the dominant token in a short doc it scores
-    // HIGH — so fusion must promote it into the top-k, displacing a low-relevance
-    // filler row.
-    cardiologistEventId = (
-      await createTestEvent({
-        organization_id: org.id,
-        entity_id: entity.id,
-        content: 'Cardiologist visit.',
-      })
-    ).id;
   });
 
   afterAll(() => {
@@ -198,193 +141,106 @@ describe('getContent > rewrite_query recall expansion', () => {
     installFetchStub();
   });
 
-  it('(a) rewrite_query=true surfaces a session the raw query missed (recall improves)', async () => {
-    // Baseline: the raw query "physician" finds the physician session but not the
-    // dermatologist one (different keyword, no embeddings to bridge the synonym).
-    const baseline = await getContent(
+  it('(a) a total miss triggers the rescue and recovers a variant-only session', async () => {
+    // Confirm the trigger: the raw query "physician" matches nothing.
+    const miss = await getContent(
       { entity_id: entity.id, query: 'physician', limit: 50 } as never,
       NO_KEY_ENV as never,
       ctx()
     );
-    const baselineIds = new Set(baseline.content.map((c) => c.id));
-    expect(baselineIds.has(physicianEventId)).toBe(true);
-    expect(baselineIds.has(dermatologistEventId)).toBe(false);
-    expect(fetchCalls.length).toBe(0); // text-only, no embeddings/rewrite fetch
+    expect(miss.content.length).toBe(0);
+    expect(fetchCalls.length).toBe(0); // text-only path, no fetch at all
 
-    // With rewrite_query, the LLM rewrites "physician" → ["dermatologist"],
-    // whose results union in and surface the previously-missed session.
+    // With a rewriter key present, the same raw miss expands "physician" →
+    // ["dermatologist"] and the previously-unreachable session is recovered.
     cannedVariants = ['dermatologist'];
-    const expanded = await getContent(
-      { entity_id: entity.id, query: 'physician', limit: 50, rewrite_query: true } as never,
+    const rescued = await getContent(
+      { entity_id: entity.id, query: 'physician', limit: 50 } as never,
       REWRITER_ENV as never,
       ctx()
     );
-    const expandedIds = new Set(expanded.content.map((c) => c.id));
-
-    // Raw-query result preserved AND the missed session now appears (fusion pools
-    // both queries' hits and re-ranks by relevance).
-    expect(expandedIds.has(physicianEventId)).toBe(true);
-    expect(expandedIds.has(dermatologistEventId)).toBe(true);
-
-    // The rewriter was actually consulted (exactly one chat/completions call).
-    const rewriteCalls = fetchCalls.filter((u) => u.includes('/chat/completions'));
-    expect(rewriteCalls.length).toBe(1);
+    const ids = new Set(rescued.content.map((c) => c.id));
+    expect(ids.has(dermatologistEventId)).toBe(true);
+    // The rewriter was consulted exactly once.
+    expect(rewriteCalls().length).toBe(1);
   });
 
-  it('(b) rewrite_query=false is identical to baseline — no rewrite, no fetch', async () => {
-    cannedVariants = ['dermatologist']; // would expand IF rewrite ran
+  it('(b) a query that finds something NEVER consults the rewriter (common case is free)', async () => {
+    // "dermatologist" matches the dermatologist session directly, so the first
+    // page is non-empty → the rescue must not fire, even with a key + variants
+    // staged that WOULD expand if it ran.
+    cannedVariants = ['specialist', 'ENT'];
     const result = await getContent(
-      { entity_id: entity.id, query: 'physician', limit: 50, rewrite_query: false } as never,
+      { entity_id: entity.id, query: 'dermatologist', limit: 50 } as never,
       REWRITER_ENV as never,
       ctx()
     );
     const ids = new Set(result.content.map((c) => c.id));
-
-    expect(ids.has(physicianEventId)).toBe(true);
-    expect(ids.has(dermatologistEventId)).toBe(false);
-    // No rewrite path → zero fetch calls at all.
-    expect(fetchCalls.length).toBe(0);
+    expect(ids.has(dermatologistEventId)).toBe(true);
+    // No miss → zero rewriter calls. This is the whole point of on-miss.
+    expect(rewriteCalls().length).toBe(0);
   });
 
-  it('(c) no API key → graceful: raw query only, no crash, no rewrite fetch', async () => {
-    cannedVariants = ['dermatologist'];
+  it('(c) miss with no API key is graceful: empty result, no crash, no fetch', async () => {
+    cannedVariants = ['dermatologist']; // would recover IF the rewriter ran
     const result = await getContent(
-      // rewrite_query=true but the env has no QUERY_REWRITER_API_KEY.
-      { entity_id: entity.id, query: 'physician', limit: 50, rewrite_query: true } as never,
+      { entity_id: entity.id, query: 'physician', limit: 50 } as never,
       NO_KEY_ENV as never,
       ctx()
     );
-    const ids = new Set(result.content.map((c) => c.id));
-
-    expect(ids.has(physicianEventId)).toBe(true);
-    expect(ids.has(dermatologistEventId)).toBe(false);
+    expect(result.content.length).toBe(0);
     // rewriteQueries() short-circuits on the missing key before any fetch.
     expect(fetchCalls.length).toBe(0);
   });
 
-  it('(d) fusion never exceeds the caller-supplied limit (and flags has_more)', async () => {
-    // Raw "physician" + variants match 4 distinct synonym sessions. With limit=2
-    // the fused, re-ranked result must cap at 2 rows and report has_more.
+  it('(d) rescue fusion never exceeds the caller-supplied limit (and flags has_more)', async () => {
     cannedVariants = ['dermatologist', 'ENT', 'specialist'];
     const result = await getContent(
-      { entity_id: entity.id, query: 'physician', limit: 2, rewrite_query: true } as never,
+      { entity_id: entity.id, query: 'physician', limit: 2 } as never,
       REWRITER_ENV as never,
       ctx()
     );
-
     expect(result.content.length).toBe(2);
     expect(result.total).toBeGreaterThan(2); // pool had more distinct matches
     expect(result.page.has_more).toBe(true);
 
-    // Sanity: the synonym sessions exist and a larger limit DOES pull them all in,
-    // proving the cap above was the limiter (not a missing fixture).
+    // A larger limit pulls all three synonym sessions in, proving the cap above
+    // was the limiter, not a missing fixture.
     cannedVariants = ['dermatologist', 'ENT', 'specialist'];
     const wide = await getContent(
-      { entity_id: entity.id, query: 'physician', limit: 50, rewrite_query: true } as never,
+      { entity_id: entity.id, query: 'physician', limit: 50 } as never,
       REWRITER_ENV as never,
       ctx()
     );
     const wideIds = new Set(wide.content.map((c) => c.id));
-    expect(wideIds.has(physicianEventId)).toBe(true);
     expect(wideIds.has(dermatologistEventId)).toBe(true);
     expect(wideIds.has(entEventId)).toBe(true);
     expect(wideIds.has(specialistEventId)).toBe(true);
   });
 
-  it('(e) fusion pulls a more-relevant variant hit into a full top-k page (displaces filler)', async () => {
-    // Baseline: with rewrite OFF, the raw query "appointment" returns a full
-    // limit=3 page of low-relevance filler sessions and does NOT surface the
-    // highly-relevant "Cardiologist appointment." session as the variant term.
-    const baseline = await getContent(
-      { entity_id: entity.id, query: 'appointment', limit: 3 } as never,
-      NO_KEY_ENV as never,
-      ctx()
-    );
-    const baselineIds = new Set(baseline.content.map((c) => c.id));
-    // The raw page is full (3) and made entirely of filler; the cardiologist row
-    // does not match "appointment" at all, so it is absent pre-rewrite.
-    expect(baseline.content.length).toBe(3);
-    for (const id of baselineIds) {
-      expect(fillerAppointmentEventIds).toContain(id);
-    }
-    expect(baselineIds.has(cardiologistEventId)).toBe(false);
-
-    // With rewrite ON, the variant "cardiologist" scores the short on-topic
-    // session HIGH; fusion re-ranks across raw+variant and the cardiologist row
-    // must now appear in the top-k even though raw already filled the page —
-    // proving fusion (displacement), not fill-leftover-slots.
-    cannedVariants = ['cardiologist'];
-    const fused = await getContent(
-      { entity_id: entity.id, query: 'appointment', limit: 3, rewrite_query: true } as never,
-      REWRITER_ENV as never,
-      ctx()
-    );
-    const fusedIds = new Set(fused.content.map((c) => c.id));
-
-    expect(fused.content.length).toBe(3);
-    expect(fusedIds.has(cardiologistEventId)).toBe(true);
-    // The union held more distinct matches than the page → has_more is set.
-    expect(fused.page.has_more).toBe(true);
-    expect(fused.total).toBeGreaterThan(3);
-  });
-
-  it('(f) sort_by=date keeps chronological semantics — fusion is skipped entirely', async () => {
-    // Fusion re-ranks by relevance, which would destroy a chronological feed.
-    // With sort_by='date', rewrite_query must be inert: no rewriter call, and
-    // the results come back date-ordered from the single-query path.
+  it('(e) sort_by=date skips the rescue entirely (no rewriter call)', async () => {
+    // Fusion re-ranks by relevance, which would destroy a chronological feed, so
+    // the rescue is inert under date sort even on a miss.
     cannedVariants = ['dermatologist'];
     const result = await getContent(
-      {
-        entity_id: entity.id,
-        query: 'physician',
-        limit: 50,
-        rewrite_query: true,
-        sort_by: 'date',
-      } as never,
+      { entity_id: entity.id, query: 'physician', limit: 50, sort_by: 'date' } as never,
       REWRITER_ENV as never,
       ctx()
     );
-
-    // No rewrite fetch happened (fusion ineligible under date sort)...
-    expect(fetchCalls.filter((u) => u.includes('/chat/completions')).length).toBe(0);
-    // ...so the variant-only session is absent,
-    const ids = new Set(result.content.map((c) => c.id));
-    expect(ids.has(dermatologistEventId)).toBe(false);
-    // ...and the rows are in date order (desc by default).
-    const dates = result.content.map((c) => new Date(c.occurred_at).getTime());
-    for (let i = 1; i < dates.length; i++) {
-      expect(dates[i - 1]).toBeGreaterThanOrEqual(dates[i]);
-    }
+    expect(rewriteCalls().length).toBe(0);
+    expect(result.content.length).toBe(0);
   });
 
-  it('(g) offset pages through the FUSED ranking without overlap', async () => {
-    // The fused pool for raw "physician" + 3 variants holds 4 distinct synonym
-    // sessions. Page 1 (limit=2, offset=0) and page 2 (limit=2, offset=2) must
-    // be disjoint and together equal the wide fused result's top-4 — proving the
-    // caller's offset applies to the fused pool, not per internal query.
-    cannedVariants = ['dermatologist', 'ENT', 'specialist'];
-    const page1 = await getContent(
-      { entity_id: entity.id, query: 'physician', limit: 2, offset: 0, rewrite_query: true } as never,
+  it('(f) an empty page at offset>0 does NOT trigger the rescue (only a first-page miss)', async () => {
+    // offset>0 returning empty means "paged past the end", not "found nothing" —
+    // it must not fire an LLM expansion.
+    cannedVariants = ['dermatologist'];
+    const result = await getContent(
+      { entity_id: entity.id, query: 'physician', limit: 2, offset: 2 } as never,
       REWRITER_ENV as never,
       ctx()
     );
-    cannedVariants = ['dermatologist', 'ENT', 'specialist'];
-    const page2 = await getContent(
-      { entity_id: entity.id, query: 'physician', limit: 2, offset: 2, rewrite_query: true } as never,
-      REWRITER_ENV as never,
-      ctx()
-    );
-
-    expect(page1.content.length).toBe(2);
-    expect(page2.content.length).toBeGreaterThanOrEqual(1);
-    const ids1 = new Set(page1.content.map((c) => c.id));
-    for (const row of page2.content) {
-      expect(ids1.has(row.id)).toBe(false); // disjoint pages
-    }
-    // Combined pages cover all 4 distinct synonym sessions.
-    const combined = new Set([...page1.content, ...page2.content].map((c) => c.id));
-    for (const id of [physicianEventId, dermatologistEventId, entEventId, specialistEventId]) {
-      expect(combined.has(id)).toBe(true);
-    }
+    expect(result.content.length).toBe(0);
+    expect(rewriteCalls().length).toBe(0);
   });
 });

--- a/packages/server/src/tools/get_content/handler.ts
+++ b/packages/server/src/tools/get_content/handler.ts
@@ -327,38 +327,42 @@ async function getContentImpl(
         after_id: args.after_id,
       };
 
-      // Query-rewrite recall expansion (opt-in): multi-query relevance fusion
-      // over the raw query + LLM-rewritten variants, so a variant-found row can
-      // displace a less-relevant raw row into the top-k. Fusion re-ranks by
-      // relevance, so it only applies to score-sorted, non-cursor searches with
-      // a page window inside the fetch cap — date feeds, cursor pages, and
-      // deeper windows keep single-query semantics even when rewrite_query is
-      // set. Stateless per-request (multi-replica-safe); default false leaves
-      // existing callers on the single-query path unchanged.
-      const FUSION_FETCH_CAP = 400;
-      const fusionEligible =
-        args.rewrite_query === true &&
+      // Primary single-query search. A capable agent already phrases its own
+      // search query, so this is the path the vast majority of calls take.
+      const result = await searchContentByText(args.query ?? null, searchOptions, env);
+      rawContent = result.content;
+      total = result.total;
+      pageInfo = result.page;
+
+      // Auto recall-rescue: if a score-sorted text query found NOTHING on the
+      // first page, the raw phrasing was likely too conversational/underspecified
+      // to match. Expand it into LLM-rewritten keyword variants and fuse their
+      // hits. Fires ONLY on a total miss, so the common (found-something) path
+      // pays no extra LLM call or round-trip. Stateless per-request
+      // (multi-replica-safe); date feeds, cursor pages, and deep windows keep
+      // single-query semantics. Replaces the old opt-in `rewrite_query` param:
+      // callers no longer reason about it — it self-heals on a miss.
+      const FALLBACK_FETCH_CAP = 400;
+      const fallbackEligible =
+        rawContent.length === 0 &&
         !!args.query &&
         (args.sort_by ?? 'score') === 'score' &&
         !args.before_occurred_at &&
         !args.after_occurred_at &&
-        offset + limit <= FUSION_FETCH_CAP;
-      const variants = fusionEligible ? await rewriteQueries(args.query as string, env) : [];
+        offset === 0 &&
+        limit <= FALLBACK_FETCH_CAP;
+      const variants = fallbackEligible ? await rewriteQueries(args.query as string, env) : [];
 
       if (variants.length > 0 && args.query) {
-        // Over-fetch per query so fusion has a real candidate pool to re-rank
+        // Over-fetch per variant so fusion has a real candidate pool to re-rank
         // (a variant's best hit may sit past the caller's `limit` in its own
         // ranking), capped so a large caller limit can't fan out into tens of
-        // thousands of rows across the variant queries. Eligibility above
-        // guarantees offset+limit fits inside the cap, so the slice below can
-        // never page past the fetched pool. Each internal search reads its
-        // query's top-of-ranking from offset 0 (re-applying the caller's
-        // offset per query would skip different rows per query and break the
-        // fused page).
-        const fetchLimit = Math.min(Math.max((limit + offset) * 4, 40), FUSION_FETCH_CAP);
+        // thousands of rows. The raw query already returned nothing, so only the
+        // variants are searched here.
+        const fetchLimit = Math.min(Math.max(limit * 4, 40), FALLBACK_FETCH_CAP);
         const fusionOptions = { ...searchOptions, limit: fetchLimit, offset: 0 };
 
-        // candidate pool: event id -> best (max-score) row seen across all queries.
+        // candidate pool: event id -> best (max-score) row seen across variants.
         const pool = new Map<number, { row: ContentRow; score: number }>();
         const fuseInto = (rows: ContentRow[]) => {
           for (const row of rows) {
@@ -370,13 +374,10 @@ async function getContentImpl(
           }
         };
 
-        // Sentinel: a query whose fetch came back full may have more matches
+        // Sentinel: a variant whose fetch came back full may have more matches
         // beyond the cap, so the pool is a LOWER BOUND on the true fused total
         // and deep pages must not be reported as exhausted.
         let poolTruncated = false;
-        const rawResult = await searchContentByText(args.query, fusionOptions, env);
-        fuseInto(rawResult.content);
-        poolTruncated ||= rawResult.content.length >= fetchLimit;
         for (const variant of variants) {
           const variantResult = await searchContentByText(variant, fusionOptions, env);
           fuseInto(variantResult.content);
@@ -385,21 +386,10 @@ async function getContentImpl(
 
         const ranked = [...pool.values()].sort((a, b) => b.score - a.score).map((c) => c.row);
 
-        // The caller's offset/limit page out of the FUSED ranking.
-        rawContent = ranked.slice(offset, offset + limit);
-        // total = distinct fused candidates (a lower bound when any per-query
-        // fetch hit the cap); has_more stays conservative via the sentinel.
+        // The caller's limit pages out of the FUSED ranking (offset is 0 here).
+        rawContent = ranked.slice(0, limit);
         total = ranked.length;
-        pageInfo = {
-          limit,
-          offset,
-          has_more: poolTruncated || ranked.length > offset + limit,
-        };
-      } else {
-        const result = await searchContentByText(args.query ?? null, searchOptions, env);
-        rawContent = result.content;
-        total = result.total;
-        pageInfo = result.page;
+        pageInfo = { limit, offset: 0, has_more: poolTruncated || ranked.length > limit };
       }
     }
 

--- a/packages/server/src/tools/get_content/schema.ts
+++ b/packages/server/src/tools/get_content/schema.ts
@@ -87,13 +87,6 @@ export const GetContentSchema = Type.Object({
       maximum: 1.0,
     })
   ),
-  rewrite_query: Type.Optional(
-    Type.Boolean({
-      description:
-        'Expand a conversational/underspecified query into focused keyword variants (LLM) and union their results to improve recall. Default false.',
-      default: false,
-    })
-  ),
   classification_filters: Type.Optional(
     Type.Record(Type.String(), Type.Array(Type.String()), {
       description:

--- a/packages/server/src/utils/query-rewriter.ts
+++ b/packages/server/src/utils/query-rewriter.ts
@@ -9,12 +9,12 @@
  *
  * This helper asks a small LLM to rewrite the question into a few focused
  * keyword search queries (filler stripped, synonym variants added). The caller
- * (read_knowledge / get_content) searches the raw query AND each variant with
- * an over-fetched internal limit, then FUSES the candidates by best relevance
- * score per event — so a variant-found session can displace a less-relevant
- * raw row into the top-k. The benchmark adapter calls
- * read_knowledge({ rewrite_query: true }) and gets this recall lift from the
- * SERVER, so it's a product capability, not adapter glue.
+ * (read_knowledge / get_content) invokes it ONLY as an on-miss rescue: when the
+ * primary single-query search returns nothing, it searches each variant with an
+ * over-fetched internal limit and FUSES the candidates by best relevance score
+ * per event, recovering a session the raw phrasing could not reach. There is no
+ * caller-facing flag — the rescue self-heals on a total miss, so a query that
+ * already found something never pays for it.
  *
  * Statelessness: this is a pure per-request retrieval helper. It holds no
  * shared/in-memory state, so it is trivially correct under N>1 app replicas —


### PR DESCRIPTION
## What

Deletes the `rewrite_query` boolean from the `read_knowledge` / `get_content` contract and replaces it with an internal **auto on-miss recall rescue**: query expansion now fires only when a score-sorted text query returns nothing on the first page. A query that already found something never calls the rewriter, so the common path pays no extra LLM round-trip.

```
before:  if (rewrite_query === true) { fuse raw + variants }  else { plain search }
after:   plain search → if (results === 0 && first-page && score-sorted) { expand + fuse variants }
```

## Why

Benchmarking on LongMemEval (self-hosted parity vs Supermemory) showed current Lobu plain retrieval already hits 100% recall on these suites — the recall gap the opt-in rewrite was built to close has closed. Always-on rewrite then only adds latency (and was a wash-to-slightly-negative on answer accuracy). Folding it into an on-miss reflex keeps the safety net for the rare total miss (and for weak/non-agentic callers) while removing a knob the agent rarely needs — fewer agent-facing params, less to fumble.

## Behavior change

- `rewrite_query` is gone from the tool schema (medium behavior-change risk: expansion is now automatic-on-miss instead of caller-controlled, and never runs when the query found something).
- Date feeds, cursor pages, `offset > 0`, and missing-key all skip the rescue, unchanged.

## Tests

Rewrote `get-content-query-rewrite.test.ts` for on-miss semantics (real embedded Postgres):
- miss → rescue fires, recovers a variant-only session (exactly 1 rewriter call)
- **hit → rewriter never consulted** (common case is free)
- no-key / date-sort / offset>0 → skipped, graceful
- limit cap + `has_more` respected

`make review`: typecheck clean, 0 bugs, 0 blockers, simplicity 84, tests adequate. (Unrelated suite failures in isolated-vm sandbox / public-pages are pre-existing, untouched areas.)

## Still owed before merge

Benchmark no-regression run (autofallback ≡ plain on a current suite; the rescue's lift is only visible on a miss-heavy suite like xAFS).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1277"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784163025&installation_id=136316292&pr_number=1277&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1277&signature=74a4b465608a3b172ee7b910274529176daaeb81fd5f9514c3baca83d37d0025"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->