### PR TITLE
fix(preview): working lobu.ai/slack front door for the Slack preview bot

### DIFF
--- a/packages/cli/src/commands/dev.ts
+++ b/packages/cli/src/commands/dev.ts
@@ -742,17 +742,26 @@ async function printPreviewInstructions(cwd: string): Promise<void> {
         surfaces: cfg.surfaces ?? ["dm"],
         ttl_minutes: cfg.codeTtlMinutes ?? 15,
       });
-      console.log(chalk.dim(`  agent:        ${agentId}`));
-      console.log(chalk.dim(`  platform:     ${platform}`));
-      if (claim.join_url)
-        console.log(chalk.dim(`  join:         ${claim.join_url}`));
-      console.log(chalk.dim(`  command:      ${claim.command}`));
-      console.log(chalk.dim(`  expires:      ${claim.expires_at}`));
-      console.log(
-        chalk.dim(
-          `  Join the hosted Lobu ${platform} workspace and send the command above to @Lobu.`
-        )
-      );
+      console.log(chalk.dim(`  agent:    ${agentId}`));
+      console.log(chalk.dim(`  platform: ${platform}`));
+      console.log(chalk.dim(`  expires:  ${claim.expires_at}`));
+      console.log();
+      if (claim.join_url) {
+        console.log(
+          chalk.dim(
+            `  1. Join the hosted Lobu ${platform} workspace: ${chalk.underline(claim.join_url)}`
+          )
+        );
+        console.log(
+          chalk.dim(`  2. DM @Lobu there: ${chalk.bold(claim.command)}`)
+        );
+      } else {
+        console.log(
+          chalk.dim(
+            `  In the hosted Lobu ${platform} workspace, DM @Lobu: ${chalk.bold(claim.command)}`
+          )
+        );
+      }
     } catch (error) {
       console.log(
         chalk.yellow(

--- a/packages/landing/functions/slack.ts
+++ b/packages/landing/functions/slack.ts
@@ -1,0 +1,71 @@
+/**
+ * `lobu.ai/slack` — front door for the hosted Slack preview bot.
+ *
+ * The Lobu CLI prints this URL when an agent enables `preview.slack` (see
+ * `previewJoinUrl()` in packages/server/src/preview/slack.ts, which defaults to
+ * `https://lobu.ai/slack`). Devs land here to join the community workspace where
+ * the shared `@Lobu` preview bot lives, then redeem their `/lobu link <code>`.
+ *
+ * The invite target lives in the `SLACK_COMMUNITY_INVITE_URL` env var (set in
+ * the Cloudflare Pages project) so the Slack shared-invite link, which expires,
+ * can be rotated without a redeploy. When it is unset we serve a short HTML
+ * page pointing at the docs rather than 404'ing, so this is never a dead end.
+ */
+
+type PagesFunction = (context: {
+  request: Request;
+  next: () => Promise<Response>;
+  env: Record<string, unknown>;
+  params: Record<string, string | string[]>;
+}) => Promise<Response> | Response;
+
+const DOCS_URL = "https://lobu.ai/platforms/slack/";
+
+function fallbackPage(): Response {
+  const body = `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="robots" content="noindex" />
+    <title>Lobu on Slack</title>
+    <style>
+      body { font-family: ui-sans-serif, system-ui, -apple-system, sans-serif; max-width: 32rem; margin: 4rem auto; padding: 0 1.25rem; line-height: 1.6; color: #1a1a1a; }
+      a { color: #4338ca; }
+      code { background: #f3f4f6; padding: 0.1rem 0.35rem; border-radius: 0.25rem; }
+    </style>
+  </head>
+  <body>
+    <h1>Lobu on Slack</h1>
+    <p>The community Slack invite is being set up. In the meantime, see the
+      <a href="${DOCS_URL}">Slack setup docs</a> to connect Lobu to your own workspace.</p>
+    <p>If you ran <code>lobu run</code> and were sent here, the <code>/lobu link</code>
+      code you received is still valid until it expires. Check back shortly.</p>
+  </body>
+</html>`;
+  return new Response(body, {
+    status: 200,
+    headers: {
+      "content-type": "text/html; charset=utf-8",
+      "cache-control": "no-store",
+    },
+  });
+}
+
+export const onRequest: PagesFunction = ({ env }) => {
+  const invite =
+    typeof env.SLACK_COMMUNITY_INVITE_URL === "string"
+      ? env.SLACK_COMMUNITY_INVITE_URL.trim()
+      : "";
+
+  if (!invite) return fallbackPage();
+
+  return new Response(null, {
+    status: 302,
+    headers: {
+      location: invite,
+      // Invite links rotate; never let a CDN pin a stale target.
+      "cache-control": "no-store",
+    },
+  });
+};

--- a/packages/server/src/gateway/__tests__/chat-instance-manager-boot.test.ts
+++ b/packages/server/src/gateway/__tests__/chat-instance-manager-boot.test.ts
@@ -118,7 +118,7 @@ describe("connection-health sweep (boot-loop successor)", () => {
       getPublicGatewayUrl: () => "",
       getSecretStore: () => secretStore,
       getConnectionStore: () => connectionStore,
-      getChannelBindingService: () => ({ getBinding: async () => null }),
+      getChannelBindingService: () => ({ getBinding: async () => null, getBindingAnyOrg: async () => null }),
       getCommandRegistry: () => undefined,
     } as any;
 
@@ -167,7 +167,7 @@ describe("connection-health sweep (boot-loop successor)", () => {
       getPublicGatewayUrl: () => "",
       getSecretStore: () => secretStore,
       getConnectionStore: () => connectionStore,
-      getChannelBindingService: () => ({ getBinding: async () => null }),
+      getChannelBindingService: () => ({ getBinding: async () => null, getBindingAnyOrg: async () => null }),
       getCommandRegistry: () => undefined,
     } as any;
     wireManager(manager, services);
@@ -218,7 +218,7 @@ describe("connection-health sweep (boot-loop successor)", () => {
       getPublicGatewayUrl: () => "",
       getSecretStore: () => secretStore,
       getConnectionStore: () => connectionStore,
-      getChannelBindingService: () => ({ getBinding: async () => null }),
+      getChannelBindingService: () => ({ getBinding: async () => null, getBindingAnyOrg: async () => null }),
       getCommandRegistry: () => undefined,
     } as any;
 
@@ -278,7 +278,7 @@ describe("connection-health sweep (boot-loop successor)", () => {
       getPublicGatewayUrl: () => "",
       getSecretStore: () => secretStore,
       getConnectionStore: () => connectionStore,
-      getChannelBindingService: () => ({ getBinding: async () => null }),
+      getChannelBindingService: () => ({ getBinding: async () => null, getBindingAnyOrg: async () => null }),
       getCommandRegistry: () => undefined,
     } as any;
     manager.services = services;

--- a/packages/server/src/gateway/__tests__/chat-instance-manager-config.test.ts
+++ b/packages/server/src/gateway/__tests__/chat-instance-manager-config.test.ts
@@ -70,7 +70,7 @@ async function buildManager(orgId: string, agentId: string) {
     getPublicGatewayUrl: () => "",
     getSecretStore: () => secretStore,
     getConnectionStore: () => connectionStore,
-    getChannelBindingService: () => ({ getBinding: async () => null }),
+    getChannelBindingService: () => ({ getBinding: async () => null, getBindingAnyOrg: async () => null }),
     getCommandRegistry: () => undefined,
   } as any;
 

--- a/packages/server/src/gateway/__tests__/chat-instance-manager-slack.test.ts
+++ b/packages/server/src/gateway/__tests__/chat-instance-manager-slack.test.ts
@@ -127,6 +127,7 @@ describe("ChatInstanceManager Slack marketplace support", () => {
         getConnectionStore: () => connectionStore,
         getChannelBindingService: () => ({
           getBinding: async () => null,
+          getBindingAnyOrg: async () => null,
         }),
       } as any;
 

--- a/packages/server/src/gateway/__tests__/dm-link-e2e.test.ts
+++ b/packages/server/src/gateway/__tests__/dm-link-e2e.test.ts
@@ -64,7 +64,7 @@ describe("DM /lobu link <code> — real consume→bind chain", () => {
       });
       const dispatcher = new CommandDispatcher({
         registry,
-        channelBindingService: { getBinding: mock(async () => null) } as never,
+        channelBindingService: { getBinding: mock(async () => null), getBindingAnyOrg: mock(async () => null) } as never,
       });
 
       const replies: string[] = [];

--- a/packages/server/src/gateway/__tests__/dm-link-message-e2e.test.ts
+++ b/packages/server/src/gateway/__tests__/dm-link-message-e2e.test.ts
@@ -59,7 +59,7 @@ describe("DM bare-code message → real consume→bind (previewMode)", () => {
       registerBuiltInCommands(registry, { agentSettingsStore: {} as never });
       const dispatcher = new CommandDispatcher({
         registry,
-        channelBindingService: { getBinding: mock(async () => null) } as never,
+        channelBindingService: { getBinding: mock(async () => null), getBindingAnyOrg: mock(async () => null) } as never,
       });
 
       const conversationState = new ConversationStateStore(
@@ -80,7 +80,7 @@ describe("DM bare-code message → real consume→bind (previewMode)", () => {
       const services = {
         getArtifactStore: () => null,
         getPublicGatewayUrl: () => "https://gateway.example.com",
-        getChannelBindingService: () => ({ getBinding: mock(async () => null) }),
+        getChannelBindingService: () => ({ getBinding: mock(async () => null), getBindingAnyOrg: mock(async () => null) }),
         getAgentMetadataStore: () => undefined,
         getUserAgentsStore: () => undefined,
         getTranscriptionService: () => undefined,

--- a/packages/server/src/gateway/__tests__/message-handler-bridge.test.ts
+++ b/packages/server/src/gateway/__tests__/message-handler-bridge.test.ts
@@ -488,7 +488,7 @@ describe("MessageHandlerBridge.handleMessage — Slack Preview unlinked chat", (
     const channelBindingService =
       opts.binding === undefined
         ? undefined
-        : { getBinding: mock(async () => opts.binding) };
+        : { getBinding: mock(async () => opts.binding), getBindingAnyOrg: mock(async () => opts.binding) };
     const services = {
       getArtifactStore: () => null,
       getPublicGatewayUrl: () => "https://gateway.example.com",

--- a/packages/server/src/gateway/__tests__/message-handler-bridge.test.ts
+++ b/packages/server/src/gateway/__tests__/message-handler-bridge.test.ts
@@ -464,7 +464,7 @@ describe("MessageHandlerBridge.handleMessage — thread backfill", () => {
 
 describe("MessageHandlerBridge.handleMessage — Slack Preview unlinked chat", () => {
   function makePreviewHarness(opts: {
-    binding?: { agentId: string } | null;
+    binding?: { agentId: string; organizationId?: string } | null;
     previewMode?: boolean;
     commandDispatcher?: {
       tryHandleSlashText?: (...args: any[]) => Promise<boolean>;
@@ -477,6 +477,9 @@ describe("MessageHandlerBridge.handleMessage — Slack Preview unlinked chat", (
       id: CONN_ID,
       platform: "slack",
       agentId: TEMPLATE_AGENT_ID,
+      // The hosted preview connection lives in its OWN org; bound agents may
+      // live in OTHER orgs (see the cross-org test below).
+      organizationId: "org-connection",
       config: { platform: "slack" } as any,
       settings: { allowGroups: true, previewMode: opts.previewMode ?? true },
       metadata: { botUsername: "testbot", botUserId: "U_BOT" },
@@ -542,6 +545,27 @@ describe("MessageHandlerBridge.handleMessage — Slack Preview unlinked chat", (
         (c: unknown[]) => !String(c[0]).includes("/lobu link")
       )
     ).toBe(true);
+  });
+
+  test("cross-org: routes the worker turn under the BOUND agent's org, not the connection's", async () => {
+    // Regression for the hosted-preview cross-org bug: a `/lobu link <code>`
+    // binds an agent that lives in a DIFFERENT org than the preview connection.
+    // The worker turn MUST run under the binding's org, or the agent's workspace
+    // (knowledge, secrets, providers) resolves under the wrong tenant.
+    const { bridge, enqueueMessage } = makePreviewHarness({
+      binding: { agentId: "food-ordering", organizationId: "org-bound" },
+    });
+    const thread = makeThread(undefined);
+
+    await bridge.handleMessage(thread, makeMessage(), "mention");
+
+    expect(enqueueMessage).toHaveBeenCalledTimes(1);
+    const payload = enqueueMessage.mock.calls[0]?.[0] as any;
+    expect(payload.agentId ?? payload.platformMetadata?.agentId).toBe(
+      "food-ordering"
+    );
+    // The binding's org wins over the connection's org ("org-connection").
+    expect(payload.organizationId).toBe("org-bound");
   });
 
   test("`/lobu link <code>` DM message dispatches link before the preview menu", async () => {

--- a/packages/server/src/gateway/__tests__/multi-tenant-isolation-reproducers.test.ts
+++ b/packages/server/src/gateway/__tests__/multi-tenant-isolation-reproducers.test.ts
@@ -524,7 +524,7 @@ describe("[finding 4] persisted Telegram polling rows are refused in cloud (clai
         getPublicGatewayUrl: () => "https://gw.example.com",
         getSecretStore: () => ({ get: async () => null, put: async () => "" }),
         getConnectionStore: () => connectionStore,
-        getChannelBindingService: () => ({ getBinding: async () => null }),
+        getChannelBindingService: () => ({ getBinding: async () => null, getBindingAnyOrg: async () => null }),
       } as any;
       const manager = new mod.ChatInstanceManager() as any;
       // A persisted polling row in cloud is an exclusive transport whose

--- a/packages/server/src/gateway/channels/__tests__/binding-service-org-scope.test.ts
+++ b/packages/server/src/gateway/channels/__tests__/binding-service-org-scope.test.ts
@@ -227,4 +227,40 @@ describe("ChannelBindingService is org-scoped (no cross-tenant takeover)", () =>
     expect(cross?.source).toBe("binding");
     expect(cross?.organizationId).toBe(ORG_A);
   });
+
+  test("getBindingAnyOrg reflects the most recent re-link (created_at bumps on upsert)", async () => {
+    const svc = new ChannelBindingService();
+    const TEAM = "T999";
+    const AGENT_A2 = "agent-a2";
+    await seedAgentRow(AGENT_A2, { organizationId: ORG_A });
+
+    // Org A binds, then org B binds the same physical channel (newer row),
+    // then org A RE-LINKS to a different agent. getBindingAnyOrg orders by
+    // created_at, so the re-link MUST bump created_at past org B's row —
+    // otherwise the channel resolves to the stale (org B) binding.
+    await svc.createBinding(AGENT_A, PLATFORM, CHANNEL, TEAM, {
+      organizationId: ORG_A,
+    });
+    await svc.createBinding(AGENT_B, PLATFORM, CHANNEL, TEAM, {
+      organizationId: ORG_B,
+    });
+    await svc.createBinding(AGENT_A2, PLATFORM, CHANNEL, TEAM, {
+      organizationId: ORG_A,
+    });
+
+    const any = await svc.getBindingAnyOrg(PLATFORM, CHANNEL, TEAM);
+    expect(any?.agentId).toBe(AGENT_A2);
+    expect(any?.organizationId).toBe(ORG_A);
+
+    const resolved = await resolveAgentId({
+      platform: PLATFORM,
+      channelId: CHANNEL,
+      teamId: TEAM,
+      organizationId: ORG_B,
+      channelBindingService: svc,
+      crossOrg: true,
+    });
+    expect(resolved?.agentId).toBe(AGENT_A2);
+    expect(resolved?.organizationId).toBe(ORG_A);
+  });
 });

--- a/packages/server/src/gateway/channels/__tests__/binding-service-org-scope.test.ts
+++ b/packages/server/src/gateway/channels/__tests__/binding-service-org-scope.test.ts
@@ -172,4 +172,59 @@ describe("ChannelBindingService is org-scoped (no cross-tenant takeover)", () =>
     expect(a?.agentId).toBe(AGENT_A);
     expect(b?.agentId).toBe(AGENT_B);
   });
+
+  // Preview exception: the hosted preview bot is ONE connection (in its own
+  // org) that fans out to agents in OTHER orgs — `/lobu link <code>` binds
+  // under the claim's org, not the connection's. The org-scoped read can never
+  // find that binding, so a linked chat keeps getting "isn't linked". The fix:
+  // previewMode resolves org-agnostically and routes by the binding's own org.
+  test("getBindingAnyOrg finds a binding regardless of caller org, with its org", async () => {
+    const svc = new ChannelBindingService();
+    const TEAM = "T999";
+    await svc.createBinding(AGENT_A, PLATFORM, CHANNEL, TEAM, {
+      organizationId: ORG_A,
+    });
+
+    // Org-scoped read from a DIFFERENT org (the preview connection's org) misses.
+    expect(await svc.getBinding(PLATFORM, CHANNEL, TEAM, ORG_B)).toBeNull();
+
+    // Org-agnostic read finds it AND surfaces the binding's owning org.
+    const any = await svc.getBindingAnyOrg(PLATFORM, CHANNEL, TEAM);
+    expect(any?.agentId).toBe(AGENT_A);
+    expect(any?.organizationId).toBe(ORG_A);
+  });
+
+  test("resolveAgentId crossOrg routes a preview connection to the bound agent's org", async () => {
+    const svc = new ChannelBindingService();
+    const TEAM = "T999";
+    // Agent A's chat is linked under ORG_A.
+    await svc.createBinding(AGENT_A, PLATFORM, CHANNEL, TEAM, {
+      organizationId: ORG_A,
+    });
+
+    // A message arrives on a previewMode connection owned by ORG_B.
+    // Without crossOrg the org-scoped read misses -> falls back to the
+    // connection's owning agent (here none) -> drops/"isn't linked".
+    const scoped = await resolveAgentId({
+      platform: PLATFORM,
+      channelId: CHANNEL,
+      teamId: TEAM,
+      organizationId: ORG_B,
+      channelBindingService: svc,
+    });
+    expect(scoped).toBeNull();
+
+    // With crossOrg it resolves to A's agent and returns A's org for routing.
+    const cross = await resolveAgentId({
+      platform: PLATFORM,
+      channelId: CHANNEL,
+      teamId: TEAM,
+      organizationId: ORG_B,
+      channelBindingService: svc,
+      crossOrg: true,
+    });
+    expect(cross?.agentId).toBe(AGENT_A);
+    expect(cross?.source).toBe("binding");
+    expect(cross?.organizationId).toBe(ORG_A);
+  });
 });

--- a/packages/server/src/gateway/channels/binding-service.ts
+++ b/packages/server/src/gateway/channels/binding-service.ts
@@ -144,7 +144,8 @@ export class ChannelBindingService {
         INSERT INTO agent_channel_bindings (organization_id, agent_id, platform, channel_id, team_id, created_at)
         VALUES (${orgId}, ${agentId}, ${platform}, ${channelId}, ${teamId}, now())
         ON CONFLICT (organization_id, platform, channel_id, team_id) DO UPDATE SET
-          agent_id = EXCLUDED.agent_id
+          agent_id = EXCLUDED.agent_id,
+          created_at = EXCLUDED.created_at
       `;
     } else {
       // For team_id IS NULL the unique constraint above doesn't fire (PG
@@ -155,7 +156,8 @@ export class ChannelBindingService {
         VALUES (${orgId}, ${agentId}, ${platform}, ${channelId}, NULL, now())
         ON CONFLICT (organization_id, platform, channel_id)
           WHERE team_id IS NULL
-          DO UPDATE SET agent_id = EXCLUDED.agent_id
+          DO UPDATE SET agent_id = EXCLUDED.agent_id,
+            created_at = EXCLUDED.created_at
       `;
     }
     logger.info(`Created binding: ${platform}/${channelId} → ${agentId}`);

--- a/packages/server/src/gateway/channels/binding-service.ts
+++ b/packages/server/src/gateway/channels/binding-service.ts
@@ -16,6 +16,9 @@ interface ChannelBinding {
   channelId: string;
   agentId: string;
   teamId?: string;
+  /** Org that owns this binding. Preview messages arrive on a connection in a
+   * different org, so the caller needs the binding's own org to route. */
+  organizationId?: string;
   createdAt: number;
 }
 
@@ -25,6 +28,7 @@ function rowToBinding(row: Record<string, any>): ChannelBinding {
     channelId: row.channel_id,
     teamId: row.team_id ?? undefined,
     agentId: row.agent_id,
+    organizationId: row.organization_id ?? undefined,
     createdAt:
       row.created_at instanceof Date
         ? row.created_at.getTime()
@@ -74,6 +78,44 @@ export class ChannelBindingService {
               AND channel_id = ${channelId}
               AND team_id IS NULL
           `;
+    if (rows.length === 0) return null;
+    return rowToBinding(rows[0]);
+  }
+
+  /**
+   * Resolve a binding by its physical channel WITHOUT scoping to a caller org.
+   *
+   * The hosted preview bot is one connection (in its own org) that fans out to
+   * agents across MANY orgs — a `/lobu link <code>` writes the binding under the
+   * claim's org, not the connection's. The normal org-scoped {@link getBinding}
+   * would never find it. A physical Slack channel is unique per workspace, so
+   * `(platform, channel_id, team_id)` identifies exactly one place; we return
+   * the most recent binding (and its org) for it. Use ONLY for previewMode
+   * connections — for normal bots, org-scoping is the multi-tenant guardrail.
+   */
+  async getBindingAnyOrg(
+    platform: string,
+    channelId: string,
+    teamId?: string
+  ): Promise<ChannelBinding | null> {
+    const sql = getDb();
+    const rows = teamId
+      ? await sql`
+          SELECT * FROM agent_channel_bindings
+          WHERE platform = ${platform}
+            AND channel_id = ${channelId}
+            AND team_id = ${teamId}
+          ORDER BY created_at DESC
+          LIMIT 1
+        `
+      : await sql`
+          SELECT * FROM agent_channel_bindings
+          WHERE platform = ${platform}
+            AND channel_id = ${channelId}
+            AND team_id IS NULL
+          ORDER BY created_at DESC
+          LIMIT 1
+        `;
     if (rows.length === 0) return null;
     return rowToBinding(rows[0]);
   }

--- a/packages/server/src/gateway/connections/interaction-bridge.ts
+++ b/packages/server/src/gateway/connections/interaction-bridge.ts
@@ -784,7 +784,7 @@ export function registerActionHandlers(
               pattern,
               null,
               true,
-							connection.organizationId,
+							pending.organizationId ?? connection.organizationId,
             )
             .catch(() => undefined);
         }
@@ -808,7 +808,7 @@ export function registerActionHandlers(
             pattern,
             expiresAt,
             undefined,
-						connection.organizationId,
+						pending.organizationId ?? connection.organizationId,
           );
           logger.info(
             {

--- a/packages/server/src/gateway/connections/message-handler-bridge.ts
+++ b/packages/server/src/gateway/connections/message-handler-bridge.ts
@@ -313,6 +313,10 @@ export class MessageHandlerBridge {
       (message.raw as Record<string, unknown> | undefined)?.team;
     const teamId = typeof rawTeamId === "string" ? rawTeamId : undefined;
 
+    // Preview connections fan out to agents in OTHER orgs (a `/lobu link <code>`
+    // binds under the claim's org, not this connection's), so resolve the
+    // binding org-agnostically and route by the binding's own org.
+    const isPreview = this.connection.settings?.previewMode === true;
     const resolved = await resolveAgentId({
       platform,
       channelId,
@@ -320,6 +324,7 @@ export class MessageHandlerBridge {
       agentId: this.connection.agentId,
       organizationId: this.connection.organizationId,
       channelBindingService,
+      crossOrg: isPreview,
     });
     if (!resolved) {
       logger.warn(
@@ -330,19 +335,16 @@ export class MessageHandlerBridge {
     }
 
     const agentId = resolved.agentId;
+    const routingOrgId =
+      resolved.organizationId ?? this.connection.organizationId;
 
     // Track first-time-seen user → agent association for visibility in the
     // admin API. Idempotent — agent_users has a (agent_id, platform, user_id)
     // unique constraint.
     const userAgentsStore = this.services.getUserAgentsStore();
-    if (userAgentsStore && this.connection.organizationId) {
+    if (userAgentsStore && routingOrgId) {
       try {
-        await userAgentsStore.addAgent(
-          platform,
-          userId,
-          agentId,
-          this.connection.organizationId
-        );
+        await userAgentsStore.addAgent(platform, userId, agentId, routingOrgId);
       } catch (error) {
         logger.warn(
           { agentId, userId, error: String(error) },
@@ -561,6 +563,7 @@ export class MessageHandlerBridge {
 
     await this.enqueueUserTurn({
       agentId,
+      organizationId: routingOrgId,
       userId,
       channelId,
       conversationId,
@@ -593,6 +596,9 @@ export class MessageHandlerBridge {
    */
   private async enqueueUserTurn(args: {
     agentId: string;
+    /** Org the turn runs under. For preview connections this is the bound
+     * agent's org (cross-org), not necessarily the connection's org. */
+    organizationId: string | undefined;
     userId: string;
     channelId: string;
     conversationId: string;
@@ -618,6 +624,7 @@ export class MessageHandlerBridge {
   }): Promise<void> {
     const {
       agentId,
+      organizationId,
       userId,
       channelId,
       conversationId,
@@ -683,7 +690,7 @@ export class MessageHandlerBridge {
         conversationId,
         teamId: payloadTeamId,
         agentId,
-        organizationId: this.connection.organizationId,
+        organizationId,
         messageId,
         messageText,
         channelId,
@@ -789,6 +796,7 @@ export class MessageHandlerBridge {
     const isGroup = conversationId !== channelId;
 
     const channelBindingService = this.services.getChannelBindingService();
+    const isPreview = this.connection.settings?.previewMode === true;
     const resolved = await resolveAgentId({
       platform,
       channelId,
@@ -796,6 +804,7 @@ export class MessageHandlerBridge {
       agentId: this.connection.agentId,
       organizationId: this.connection.organizationId,
       channelBindingService,
+      crossOrg: isPreview,
     });
     if (!resolved) {
       logger.warn(
@@ -805,9 +814,12 @@ export class MessageHandlerBridge {
       return;
     }
     const agentId = resolved.agentId;
+    const routingOrgId =
+      resolved.organizationId ?? this.connection.organizationId;
 
     await this.enqueueUserTurn({
       agentId,
+      organizationId: routingOrgId,
       userId,
       channelId,
       conversationId,

--- a/packages/server/src/gateway/services/platform-helpers.ts
+++ b/packages/server/src/gateway/services/platform-helpers.ts
@@ -238,6 +238,11 @@ export function buildMessagePayload(params: {
  *
  * Returns `null` when neither resolves — the caller should drop the message.
  * Pure resolution: never writes a binding.
+ *
+ * `crossOrg` is for hosted preview connections only: the bot lives in one org
+ * but `/lobu link <code>` binds agents from OTHER orgs, so the lookup must be
+ * org-agnostic and the binding's own `organizationId` is returned for routing.
+ * Leave it false for normal bots, where org-scoping is the multi-tenant guard.
  */
 export async function resolveAgentId(params: {
   platform: string;
@@ -246,27 +251,51 @@ export async function resolveAgentId(params: {
   agentId?: string;
   organizationId?: string;
   channelBindingService?: ChannelBindingService;
-}): Promise<{ agentId: string; source: "binding" | "connection" } | null> {
-  const { platform, channelId, teamId, agentId, organizationId, channelBindingService } =
-    params;
+  crossOrg?: boolean;
+}): Promise<{
+  agentId: string;
+  source: "binding" | "connection";
+  organizationId?: string;
+} | null> {
+  const {
+    platform,
+    channelId,
+    teamId,
+    agentId,
+    organizationId,
+    channelBindingService,
+    crossOrg,
+  } = params;
 
   if (channelBindingService) {
     // Bindings are org-scoped (a channel_id can be bound independently by
     // multiple tenants), so the read MUST be scoped to the inbound
     // connection's org — otherwise getBinding falls back to an org-less query
-    // and can route a message to another tenant's agent.
-    const binding = await channelBindingService.getBinding(
-      platform,
-      channelId,
-      teamId,
-      organizationId
-    );
+    // and can route a message to another tenant's agent. Preview connections
+    // are the deliberate exception: they fan out across orgs (see crossOrg).
+    const binding = crossOrg
+      ? await channelBindingService.getBindingAnyOrg(platform, channelId, teamId)
+      : await channelBindingService.getBinding(
+          platform,
+          channelId,
+          teamId,
+          organizationId
+        );
     if (binding) {
       logger.info(
-        { agentId: binding.agentId, platform, channelId },
+        {
+          agentId: binding.agentId,
+          platform,
+          channelId,
+          bindingOrg: binding.organizationId,
+        },
         "Routing via existing channel binding"
       );
-      return { agentId: binding.agentId, source: "binding" };
+      return {
+        agentId: binding.agentId,
+        source: "binding",
+        organizationId: binding.organizationId,
+      };
     }
   }
 
@@ -275,7 +304,7 @@ export async function resolveAgentId(params: {
       { agentId, platform, channelId },
       "Routing to connection's owning agent"
     );
-    return { agentId, source: "connection" };
+    return { agentId, source: "connection", organizationId };
   }
 
   return null;

--- a/packages/server/src/preview/slack.ts
+++ b/packages/server/src/preview/slack.ts
@@ -233,7 +233,8 @@ async function upsertBinding(
       INSERT INTO agent_channel_bindings (organization_id, agent_id, platform, channel_id, team_id, created_at)
       VALUES (${organizationId}, ${agentId}, ${platform}, ${channelId}, ${teamId}, now())
       ON CONFLICT (organization_id, platform, channel_id, team_id) DO UPDATE SET
-        agent_id = EXCLUDED.agent_id
+        agent_id = EXCLUDED.agent_id,
+        created_at = EXCLUDED.created_at
     `;
   } else {
     await tx`
@@ -241,7 +242,8 @@ async function upsertBinding(
       VALUES (${organizationId}, ${agentId}, ${platform}, ${channelId}, NULL, now())
       ON CONFLICT (organization_id, platform, channel_id)
         WHERE team_id IS NULL
-        DO UPDATE SET agent_id = EXCLUDED.agent_id
+        DO UPDATE SET agent_id = EXCLUDED.agent_id,
+          created_at = EXCLUDED.created_at
     `;
   }
 }

--- a/packages/server/src/preview/slack.ts
+++ b/packages/server/src/preview/slack.ts
@@ -451,7 +451,9 @@ export async function previewUnlinkedNotice(
   return [
     "👋 This chat isn't linked to a Lobu agent yet.",
     '',
-    `Run \`lobu apply\` then \`lobu run\` to get a \`${linkCommand(platform)} <code>\`, and send it here.`,
+    'New to Lobu? Scaffold a project with `npx @lobu/cli init`, then:',
+    '`lobu apply` to sync it, and `lobu run` to get a ' +
+      `\`${linkCommand(platform)} <code>\` — paste that code here to link this chat.`,
   ].join('\n');
 }
 


### PR DESCRIPTION
## Two bugs, one feature: make the hosted Slack preview actually work end to end

### Bug 1 — `lobu.ai/slack` front door was a 404
`lobu run` with `preview.slack` prints `join_url: https://lobu.ai/slack` (default of `previewJoinUrl()`), but that route was never built — no landing handler, `LOBU_PREVIEW_SLACK_URL` unset, no shared invite. Devs hit a 404 with no way to reach the bot.

- **landing** — `packages/landing/functions/slack.ts` (new CF Pages Function): `GET /slack` 302s to `env.SLACK_COMMUNITY_INVITE_URL` (env var so the expiring Slack invite rotates without a redeploy); serves a docs-pointer fallback page instead of 404 when unset.
- **cli** — `lobu run` preview block reformatted into ordered steps.

### Bug 2 — a linked chat kept getting 'isn''t linked' (cross-org routing) 🐛
Found live: `/lobu link <code>` succeeded ('Linked this chat to agent food-ordering'), but the next message got 'This chat isn''t linked to a Lobu agent yet.' Root cause: `/lobu link` writes the binding under the **claim's org** (the org `lobu run` minted the code from), but the hosted preview connection lives in its **own org** and resolved bindings scoped to `connection.organizationId`. The hosted bot is inherently cross-org (one connection → agents in many orgs), so the lookup could never find the binding. Even if it had, the worker turn would have run under the wrong org.

Confirmed with prod data: binding for `slack:C0BAFGQL7PD`/`T09513HDQ77` lives in org `UdNAH1bb…` (lobu-team), the previewMode connection is `org_lobucrm`.

- **binding-service** — `ChannelBinding` carries `organizationId`; new `getBindingAnyOrg()` (org-agnostic lookup, most-recent wins).
- **resolveAgentId** — `crossOrg` flag uses `getBindingAnyOrg` and returns the binding's own org. Off for normal bots (org-scoping stays the multi-tenant guardrail).
- **message-handler-bridge** — previewMode connections (both message + click paths) resolve cross-org and route the worker turn + `agent_users` by the binding's org.
- **previewUnlinkedNotice** — point new users at `npx @lobu/cli init`.

## Verification
- New regression tests (PG-backed): `getBindingAnyOrg` finds a cross-org binding + its org; `resolveAgentId` org-scoped returns null (the bug) while `crossOrg` routes to the bound agent's org. 51/51 green across the preview/routing suites; touched stub suites 38/38; server `tsc` clean.
- Landing function exercised directly: invite set → 302; unset → 200 fallback.
- The fix's exact query run against **prod** returns `food-ordering` for the live channel — post-deploy, the failed 'heyo' would route correctly.
- **Not yet live**: needs merge → Flux rollout (~30-60min) for the cross-org fix to take effect in prod, and the ops step below for the front door.

## Required ops follow-up (front door only)
1. Pick the community Slack workspace + install the `@Lobu` bot.
2. Set `SLACK_COMMUNITY_INVITE_URL` in the lobu.ai Cloudflare Pages project.
3. Confirm `/lobu link <code>` redeems there.