### PR TITLE
fix(worker): refresh worker token mid-turn via deployment-liveness gate

### DIFF
--- a/packages/agent-worker/src/__tests__/sse-client.test.ts
+++ b/packages/agent-worker/src/__tests__/sse-client.test.ts
@@ -1,11 +1,21 @@
-import { afterEach, describe, expect, mock, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { GatewayClient } from "../gateway/sse-client";
+import { __resetWorkerTokenManagerForTests } from "../gateway/worker-token-manager";
 
 describe("GatewayClient heartbeat ACKs", () => {
   const originalFetch = globalThis.fetch;
 
+  // The GatewayClient constructor seeds the process-wide WorkerTokenManager, and
+  // SSE auth + heartbeat ACKs read its live token. Reset the singleton around
+  // each test so a token seeded/adopted by an earlier test can't leak in and
+  // make the ACK send the wrong bearer.
+  beforeEach(() => {
+    __resetWorkerTokenManagerForTests();
+  });
+
   afterEach(() => {
     globalThis.fetch = originalFetch;
+    __resetWorkerTokenManagerForTests();
   });
 
   test("accepts nested platform metadata on job events", async () => {

--- a/packages/agent-worker/src/__tests__/worker-token-refresh.test.ts
+++ b/packages/agent-worker/src/__tests__/worker-token-refresh.test.ts
@@ -149,6 +149,18 @@ describe("seed() never clobbers a live token (aux-transport rollback guard)", ()
     expect(capturedAuth).not.toContain("Bearer stale-boot-token");
   });
 
+  test("exec job: adopting its own run token overrides a previous turn's token", async () => {
+    stubFetch();
+    // A previous chat turn left its token in the process-wide manager.
+    adoptWorkerToken("previous-turn-token");
+    // handleExecJob adopts THIS exec's run token before building its transport.
+    adoptWorkerToken("exec-run-token");
+    const aux = makeTransport("boot-token");
+    await aux.signalCompletion();
+    expect(capturedAuth.every((a) => a === "Bearer exec-run-token")).toBe(true);
+    expect(capturedAuth).not.toContain("Bearer previous-turn-token");
+  });
+
   test("seed() is a no-op once a token has been adopted", () => {
     const mgr = getWorkerTokenManager();
     mgr.adopt("live-token");

--- a/packages/agent-worker/src/__tests__/worker-token-refresh.test.ts
+++ b/packages/agent-worker/src/__tests__/worker-token-refresh.test.ts
@@ -26,6 +26,7 @@ import {
   adoptWorkerToken,
   getWorkerTokenManager,
 } from "../gateway/worker-token-manager";
+import { writeSnapshot } from "../openclaw/transcript-snapshot";
 
 let originalFetch: typeof globalThis.fetch;
 let capturedAuth: string[];
@@ -251,5 +252,72 @@ describe("refresh denied = the revocation property", () => {
     ]);
     expect([a, b, c]).toEqual(["shared", "shared", "shared"]);
     expect(refreshCalls).toBe(1);
+  });
+});
+
+describe("refreshed token propagation (the refresh must not be a no-op)", () => {
+  // GatewayParams.workerToken is a GETTER reading the live manager token, not a
+  // captured string. session-runner builds it that way so every MCP/interaction
+  // gateway call after a mid-turn refresh sends the NEW bearer. This asserts the
+  // getter contract: mutating the manager (as refresh() does) is visible through
+  // the getter without rebuilding GatewayParams.
+  test("a GatewayParams-style workerToken getter reflects a mid-turn refresh", () => {
+    const mgr = getWorkerTokenManager();
+    mgr.adopt("turn-token", Date.now());
+    // The exact shape session-runner builds.
+    const gwParams = {
+      get workerToken() {
+        return getWorkerTokenManager().getToken();
+      },
+    };
+    expect(gwParams.workerToken).toBe("turn-token");
+    // A mid-turn refresh swaps the live token...
+    mgr.adopt("mid-turn-refreshed", Date.now());
+    // ...and the getter reflects it WITHOUT GatewayParams being rebuilt. A
+    // captured string would still read "turn-token" here (the original bug).
+    expect(gwParams.workerToken).toBe("mid-turn-refreshed");
+  });
+
+  test("the snapshot write uses the LIVE manager token, not the original per-run token", async () => {
+    process.env.WORKER_TOKEN_TTL_MS = "100000";
+    let snapshotAuth: string | null = null;
+    globalThis.fetch = mock(
+      async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = typeof input === "string" ? input : input.toString();
+        if (url.endsWith("/worker/transcript/snapshot")) {
+          snapshotAuth =
+            (init?.headers as Record<string, string> | undefined)
+              ?.Authorization ?? null;
+          return new Response("{}", { status: 200 });
+        }
+        return new Response("{}", { status: 200 });
+      }
+    ) as unknown as typeof globalThis.fetch;
+
+    const mgr = getWorkerTokenManager();
+    // Turn started with the per-run token, then refreshed mid-turn.
+    mgr.adopt("original-run-token", Date.now());
+    mgr.adopt("refreshed-run-token", Date.now());
+
+    // Write a temp session file so writeSnapshot has bytes to POST.
+    const tmp = `${process.env.TMPDIR ?? "/tmp"}/snap-${Date.now()}.jsonl`;
+    const { promises: fsp } = await import("node:fs");
+    await fsp.writeFile(tmp, '{"role":"user","content":"hi"}\n', "utf-8");
+    try {
+      // Mirrors OpenClawWorker.cleanup(): bearer = getWorkerTokenManager().getToken().
+      await writeSnapshot({
+        sessionFile: tmp,
+        gatewayUrl: "http://gw.test/lobu",
+        workerToken: getWorkerTokenManager().getToken(),
+        terminalStatus: "completed",
+        runId: 7,
+      });
+      // The snapshot POST carried the REFRESHED token, not the original — a
+      // captured `this.config.runJobToken` would have sent (and 401'd on) the
+      // now-expired original.
+      expect(snapshotAuth).toBe("Bearer refreshed-run-token");
+    } finally {
+      await fsp.rm(tmp, { force: true });
+    }
   });
 });

--- a/packages/agent-worker/src/__tests__/worker-token-refresh.test.ts
+++ b/packages/agent-worker/src/__tests__/worker-token-refresh.test.ts
@@ -262,6 +262,39 @@ describe("reactive refresh (401 → refresh → retry)", () => {
   });
 });
 
+describe("refresh epoch guard (no clobber across the turn boundary)", () => {
+  test("a refresh resolving after the next turn adopts is discarded", async () => {
+    // Hold the refresh response open until we explicitly release it. The
+    // Promise executor runs synchronously, so releaseRefresh is assigned before
+    // any use (definite assignment).
+    let releaseRefresh!: (tok: string) => void;
+    const refreshGate = new Promise<string>((res) => {
+      releaseRefresh = res;
+    });
+    globalThis.fetch = mock(async (input: RequestInfo | URL) => {
+      const url = typeof input === "string" ? input : input.toString();
+      if (url.endsWith("/worker/token/refresh")) {
+        const tok = await refreshGate;
+        return new Response(JSON.stringify({ token: tok }), { status: 200 });
+      }
+      return new Response("{}", { status: 200 });
+    }) as unknown as typeof globalThis.fetch;
+
+    const mgr = getWorkerTokenManager();
+    mgr.adopt("turn-1-token");
+    // Turn 1 kicks off a refresh that stays in flight (blocked on the gate).
+    const refreshPromise = mgr.refresh();
+    // Turn 1 ends; turn 2 starts and adopts its own fresh token.
+    adoptWorkerToken("turn-2-token");
+    // Now turn 1's refresh finally resolves with a refreshed-turn-1 token.
+    releaseRefresh("refreshed-turn-1-token");
+    await refreshPromise;
+    // The stale refresh must NOT clobber turn 2's live token.
+    expect(mgr.getToken()).toBe("turn-2-token");
+    expect(process.env.WORKER_TOKEN).toBe("turn-2-token");
+  });
+});
+
 describe("refresh denied = the revocation property", () => {
   test("when the gateway denies refresh (deployment not live → 403), keep the old token, do not loop", async () => {
     process.env.WORKER_TOKEN_TTL_MS = "100000";

--- a/packages/agent-worker/src/__tests__/worker-token-refresh.test.ts
+++ b/packages/agent-worker/src/__tests__/worker-token-refresh.test.ts
@@ -156,6 +156,49 @@ describe("proactive refresh (before expiry)", () => {
   });
 });
 
+describe("timer-driven refresh (>2h turn with NO gateway call)", () => {
+  test("the timer refreshes BEFORE expiry even when no gateway call is made", async () => {
+    // The load-bearing fix for the >2h single-turn case: an on-demand-only
+    // refresh would fire too late (expired bearer → route rejects pre-liveness).
+    // Short TTL so the proactive window (last 20%) opens almost immediately.
+    process.env.WORKER_TOKEN_TTL_MS = "200"; // window starts at age 160ms
+    stubFetch({ refreshToken: "timer-refreshed" });
+    const mgr = getWorkerTokenManager();
+    mgr.adopt("will-expire-soon", Date.now());
+    mgr.enableAutoRefresh();
+    try {
+      // Wait past the proactive-window start but before hard expiry would have
+      // mattered — NO fetchWithRefresh / ensureFresh call in between.
+      await new Promise((r) => setTimeout(r, 260));
+      expect(mgr.getToken()).toBe("timer-refreshed");
+      expect(process.env.WORKER_TOKEN).toBe("timer-refreshed");
+    } finally {
+      mgr.disableAutoRefresh();
+    }
+  });
+
+  test("disableAutoRefresh stops further timer refreshes", async () => {
+    process.env.WORKER_TOKEN_TTL_MS = "200";
+    let refreshCount = 0;
+    globalThis.fetch = mock(async (input: RequestInfo | URL) => {
+      const url = typeof input === "string" ? input : input.toString();
+      if (url.endsWith("/worker/token/refresh")) {
+        refreshCount += 1;
+        return new Response(JSON.stringify({ token: `r${refreshCount}` }), {
+          status: 200,
+        });
+      }
+      return new Response("{}", { status: 200 });
+    }) as unknown as typeof globalThis.fetch;
+    const mgr = getWorkerTokenManager();
+    mgr.adopt("seed", Date.now());
+    mgr.enableAutoRefresh();
+    mgr.disableAutoRefresh();
+    await new Promise((r) => setTimeout(r, 260));
+    expect(refreshCount).toBe(0);
+  });
+});
+
 describe("reactive refresh (401 → refresh → retry)", () => {
   test(">2h single turn: a 401 on the terminal POST refreshes and retries with the live token", async () => {
     process.env.WORKER_TOKEN_TTL_MS = "100000"; // not near expiry → no proactive

--- a/packages/agent-worker/src/__tests__/worker-token-refresh.test.ts
+++ b/packages/agent-worker/src/__tests__/worker-token-refresh.test.ts
@@ -149,16 +149,17 @@ describe("seed() never clobbers a live token (aux-transport rollback guard)", ()
     expect(capturedAuth).not.toContain("Bearer stale-boot-token");
   });
 
-  test("exec job: adopting its own run token overrides a previous turn's token", async () => {
+  test("warm worker turn 2: re-adopting overrides turn 1's token (seed can't undo it)", async () => {
     stubFetch();
-    // A previous chat turn left its token in the process-wide manager.
-    adoptWorkerToken("previous-turn-token");
-    // handleExecJob adopts THIS exec's run token before building its transport.
-    adoptWorkerToken("exec-run-token");
+    // Turn 1 on a warm worker left its token in the process-wide manager.
+    adoptWorkerToken("turn-1-token");
+    // Turn 2 re-adopts its own fresh per-run token (OpenClawWorker.execute).
+    adoptWorkerToken("turn-2-token");
+    // A transport built for turn 2 seeds (no-op) and must use turn-2's token.
     const aux = makeTransport("boot-token");
     await aux.signalCompletion();
-    expect(capturedAuth.every((a) => a === "Bearer exec-run-token")).toBe(true);
-    expect(capturedAuth).not.toContain("Bearer previous-turn-token");
+    expect(capturedAuth.every((a) => a === "Bearer turn-2-token")).toBe(true);
+    expect(capturedAuth).not.toContain("Bearer turn-1-token");
   });
 
   test("seed() is a no-op once a token has been adopted", () => {

--- a/packages/agent-worker/src/__tests__/worker-token-refresh.test.ts
+++ b/packages/agent-worker/src/__tests__/worker-token-refresh.test.ts
@@ -1,0 +1,212 @@
+/**
+ * Worker-side token refresh (warm-worker + long-single-turn 2h TTL fix).
+ *
+ * Every worker token (deployment-lifetime WORKER_TOKEN at spawn, per-run
+ * runJobToken per message) carries a fixed timestamp and is rejected 2h later
+ * (#1266 — the short TTL is the leak-revocation property). Coverage:
+ *
+ *   - per-turn adoption: the transport's gateway POSTs use the freshly-adopted
+ *     per-run token, never a stale captured one (the warm-worker-across-turns
+ *     case — each turn mints a new token).
+ *   - proactive refresh: when the live token is near expiry, the next gateway
+ *     call refreshes BEFORE the 401.
+ *   - reactive refresh: a 401 triggers one refresh + retry.
+ *   - refresh denied (the revocation property): when the gateway denies refresh
+ *     (deployment no longer live → 403), the manager keeps the old token and
+ *     does not loop. The server-side liveness gate is tested in
+ *     packages/server/src/gateway/__tests__/worker-token-refresh-route.test.ts.
+ *   - the >2h single-turn case: a turn whose token would expire mid-turn gets a
+ *     fresh token via reactive refresh so its terminal POST still succeeds.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { HttpWorkerTransport } from "../gateway/gateway-integration";
+import {
+  __resetWorkerTokenManagerForTests,
+  adoptWorkerToken,
+  getWorkerTokenManager,
+} from "../gateway/worker-token-manager";
+
+let originalFetch: typeof globalThis.fetch;
+let capturedAuth: string[];
+let originalDispatcher: string | undefined;
+let originalWorkerToken: string | undefined;
+let originalTtl: string | undefined;
+
+beforeEach(() => {
+  originalFetch = globalThis.fetch;
+  originalDispatcher = process.env.DISPATCHER_URL;
+  originalWorkerToken = process.env.WORKER_TOKEN;
+  originalTtl = process.env.WORKER_TOKEN_TTL_MS;
+  process.env.DISPATCHER_URL = "http://gw.test/lobu";
+  capturedAuth = [];
+  __resetWorkerTokenManagerForTests();
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  __resetWorkerTokenManagerForTests();
+  const restore = (k: string, v: string | undefined) => {
+    if (v === undefined) delete process.env[k];
+    else process.env[k] = v;
+  };
+  restore("DISPATCHER_URL", originalDispatcher);
+  restore("WORKER_TOKEN", originalWorkerToken);
+  restore("WORKER_TOKEN_TTL_MS", originalTtl);
+});
+
+/** A fetch that records Authorization headers and returns 200 for response
+ *  POSTs; the refresh endpoint returns a configurable token. */
+function stubFetch(opts?: {
+  responseStatusByAuth?: (auth: string) => number;
+  refreshToken?: string | null;
+  refreshStatus?: number;
+}): void {
+  globalThis.fetch = mock(
+    async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === "string" ? input : input.toString();
+      const auth =
+        (init?.headers as Record<string, string> | undefined)?.Authorization ??
+        "";
+      if (url.endsWith("/worker/token/refresh")) {
+        if (opts?.refreshStatus && opts.refreshStatus !== 200) {
+          return new Response("{}", { status: opts.refreshStatus });
+        }
+        const tok = opts?.refreshToken ?? "refreshed-token";
+        return new Response(JSON.stringify({ token: tok }), { status: 200 });
+      }
+      if (auth) capturedAuth.push(auth);
+      const status = opts?.responseStatusByAuth?.(auth) ?? 200;
+      return new Response(JSON.stringify({ ok: true }), { status });
+    }
+  ) as unknown as typeof globalThis.fetch;
+}
+
+function makeTransport(workerToken: string): HttpWorkerTransport {
+  return new HttpWorkerTransport({
+    gatewayUrl: "http://gw.test/lobu",
+    workerToken,
+    userId: "U1",
+    channelId: "C1",
+    conversationId: "conv-1",
+    originalMessageTs: "1.1",
+    teamId: "T1",
+    platform: "api",
+  });
+}
+
+describe("per-turn token adoption (transport reads the live manager token)", () => {
+  test("constructor seeds the manager; POST uses that token", async () => {
+    stubFetch();
+    const transport = makeTransport("deployment-token");
+    await transport.signalCompletion();
+    expect(capturedAuth.length).toBeGreaterThan(0);
+    expect(capturedAuth.every((a) => a === "Bearer deployment-token")).toBe(
+      true
+    );
+  });
+
+  test("adopting the fresh per-run token flips the bearer on the wire", async () => {
+    stubFetch();
+    const transport = makeTransport("stale-deployment-token");
+    // Mirrors OpenClawWorker.execute(): adopt the freshly-minted runJobToken.
+    adoptWorkerToken("fresh-run-token");
+    await transport.signalCompletion();
+    expect(capturedAuth).not.toContain("Bearer stale-deployment-token");
+    expect(capturedAuth.every((a) => a === "Bearer fresh-run-token")).toBe(
+      true
+    );
+  });
+
+  test("adopt also mirrors into process.env.WORKER_TOKEN for env-readers", () => {
+    adoptWorkerToken("env-mirror-token");
+    expect(process.env.WORKER_TOKEN).toBe("env-mirror-token");
+  });
+
+  test("falls back to the deployment token when no per-run token is adopted", async () => {
+    // No adopt() call — the manager keeps the boot token.
+    stubFetch();
+    const transport = makeTransport("deployment-token");
+    await transport.signalError(new Error("boom"));
+    expect(capturedAuth.every((a) => a === "Bearer deployment-token")).toBe(
+      true
+    );
+  });
+});
+
+describe("proactive refresh (before expiry)", () => {
+  test("a near-expiry token is refreshed before the gateway call", async () => {
+    process.env.WORKER_TOKEN_TTL_MS = "1000"; // 1s TTL → window = last 200ms
+    stubFetch({ refreshToken: "proactively-refreshed" });
+    const mgr = getWorkerTokenManager();
+    // Adopt with an issuedAt far enough in the past to be "near expiry".
+    mgr.adopt("about-to-expire", Date.now() - 900);
+    await mgr.ensureFresh();
+    expect(mgr.getToken()).toBe("proactively-refreshed");
+    expect(process.env.WORKER_TOKEN).toBe("proactively-refreshed");
+  });
+
+  test("a fresh token is NOT refreshed (no-op)", async () => {
+    process.env.WORKER_TOKEN_TTL_MS = "100000";
+    stubFetch({ refreshToken: "should-not-be-used" });
+    const mgr = getWorkerTokenManager();
+    mgr.adopt("still-fresh", Date.now());
+    await mgr.ensureFresh();
+    expect(mgr.getToken()).toBe("still-fresh");
+  });
+});
+
+describe("reactive refresh (401 → refresh → retry)", () => {
+  test(">2h single turn: a 401 on the terminal POST refreshes and retries with the live token", async () => {
+    process.env.WORKER_TOKEN_TTL_MS = "100000"; // not near expiry → no proactive
+    // The expired turn token 401s; the refreshed token succeeds.
+    stubFetch({
+      refreshToken: "mid-turn-refreshed",
+      responseStatusByAuth: (auth) =>
+        auth === "Bearer expired-turn-token" ? 401 : 200,
+    });
+    const transport = makeTransport("expired-turn-token");
+    // signalCompletion's POST should 401, refresh, and retry — not throw.
+    await transport.signalCompletion();
+    // The retry carried the refreshed token.
+    expect(capturedAuth).toContain("Bearer mid-turn-refreshed");
+    expect(getWorkerTokenManager().getToken()).toBe("mid-turn-refreshed");
+  });
+});
+
+describe("refresh denied = the revocation property", () => {
+  test("when the gateway denies refresh (deployment not live → 403), keep the old token, do not loop", async () => {
+    process.env.WORKER_TOKEN_TTL_MS = "100000";
+    stubFetch({ refreshStatus: 403 });
+    const mgr = getWorkerTokenManager();
+    mgr.adopt("dead-deployment-token", Date.now());
+    const result = await mgr.refresh();
+    expect(result).toBeNull();
+    // Old token retained — no fresh token minted for terminal work.
+    expect(mgr.getToken()).toBe("dead-deployment-token");
+  });
+
+  test("concurrent refreshes share one in-flight request (no thundering herd)", async () => {
+    process.env.WORKER_TOKEN_TTL_MS = "100000";
+    let refreshCalls = 0;
+    globalThis.fetch = mock(async (input: RequestInfo | URL) => {
+      const url = typeof input === "string" ? input : input.toString();
+      if (url.endsWith("/worker/token/refresh")) {
+        refreshCalls += 1;
+        return new Response(JSON.stringify({ token: "shared" }), {
+          status: 200,
+        });
+      }
+      return new Response("{}", { status: 200 });
+    }) as unknown as typeof globalThis.fetch;
+    const mgr = getWorkerTokenManager();
+    mgr.adopt("seed", Date.now());
+    const [a, b, c] = await Promise.all([
+      mgr.refresh(),
+      mgr.refresh(),
+      mgr.refresh(),
+    ]);
+    expect([a, b, c]).toEqual(["shared", "shared", "shared"]);
+    expect(refreshCalls).toBe(1);
+  });
+});

--- a/packages/agent-worker/src/__tests__/worker-token-refresh.test.ts
+++ b/packages/agent-worker/src/__tests__/worker-token-refresh.test.ts
@@ -135,6 +135,37 @@ describe("per-turn token adoption (transport reads the live manager token)", () 
   });
 });
 
+describe("seed() never clobbers a live token (aux-transport rollback guard)", () => {
+  test("constructing an aux transport after adopt cannot roll the token back", async () => {
+    stubFetch();
+    // Turn start: adopt the live per-run token (mirrors OpenClawWorker.execute).
+    adoptWorkerToken("live-run-token");
+    // An exec job mid-turn constructs an auxiliary transport from the STALE boot
+    // token — its constructor seed() must no-op, not clobber the live token.
+    const aux = makeTransport("stale-boot-token");
+    expect(getWorkerTokenManager().getToken()).toBe("live-run-token");
+    await aux.signalCompletion();
+    expect(capturedAuth.every((a) => a === "Bearer live-run-token")).toBe(true);
+    expect(capturedAuth).not.toContain("Bearer stale-boot-token");
+  });
+
+  test("seed() is a no-op once a token has been adopted", () => {
+    const mgr = getWorkerTokenManager();
+    mgr.adopt("live-token");
+    mgr.seed("stale-boot-token");
+    expect(mgr.getToken()).toBe("live-token");
+  });
+
+  test("seed() sets the token while uninitialized, then no-ops on a re-seed", () => {
+    const mgr = getWorkerTokenManager();
+    mgr.seed("boot-token");
+    expect(mgr.getToken()).toBe("boot-token");
+    // A second aux transport seeding a different token must not change it.
+    mgr.seed("other-token");
+    expect(mgr.getToken()).toBe("boot-token");
+  });
+});
+
 describe("proactive refresh (before expiry)", () => {
   test("a near-expiry token is refreshed before the gateway call", async () => {
     process.env.WORKER_TOKEN_TTL_MS = "1000"; // 1s TTL → window = last 200ms

--- a/packages/agent-worker/src/gateway/gateway-integration.ts
+++ b/packages/agent-worker/src/gateway/gateway-integration.ts
@@ -11,6 +11,7 @@ import {
 } from "@lobu/core";
 import { createGatewayClient } from "../shared/gateway-client";
 import type { ResponseData } from "./types";
+import { getWorkerTokenManager } from "./worker-token-manager";
 
 const logger = createLogger("http-worker-transport");
 
@@ -20,7 +21,6 @@ const logger = createLogger("http-worker-transport");
  */
 export class HttpWorkerTransport implements WorkerTransport {
   private gatewayUrl: string;
-  private workerToken: string;
   private userId: string;
   private channelId: string;
   private conversationId: string;
@@ -46,7 +46,12 @@ export class HttpWorkerTransport implements WorkerTransport {
 
   constructor(config: WorkerTransportConfig) {
     this.gatewayUrl = config.gatewayUrl;
-    this.workerToken = config.workerToken;
+    // Seed the process-wide token manager from the boot token if it hasn't been
+    // initialized yet (the manager otherwise lazy-inits from env). The manager
+    // is the single source of truth for the live token — this transport's
+    // gateway POSTs read it via fetchWithRefresh, so there is no per-transport
+    // token field to drift.
+    getWorkerTokenManager().adopt(config.workerToken);
     this.userId = config.userId;
     this.channelId = config.channelId;
     this.conversationId = config.conversationId;
@@ -60,6 +65,13 @@ export class HttpWorkerTransport implements WorkerTransport {
 
   setJobId(jobId: string): void {
     this.jobId = jobId;
+  }
+
+  setWorkerToken(workerToken: string): void {
+    // Delegate to the single source of truth. Called per-turn with the fresh
+    // runJobToken (and by the manager's onRefresh listener) so all gateway
+    // calls — here and elsewhere — converge on the same live token.
+    getWorkerTokenManager().adopt(workerToken);
   }
 
   async signalDone(finalDelta?: string): Promise<void> {
@@ -265,10 +277,6 @@ export class HttpWorkerTransport implements WorkerTransport {
 
   private async sendResponse(data: ResponseData): Promise<void> {
     const responseUrl = `${this.gatewayUrl}/worker/response`;
-    const gateway = createGatewayClient({
-      baseUrl: this.gatewayUrl,
-      token: this.workerToken,
-    });
     const basePayload = {
       ...data,
       ...(this.platform && !data.platform ? { platform: this.platform } : {}),
@@ -291,11 +299,23 @@ export class HttpWorkerTransport implements WorkerTransport {
           }${payload.statusUpdate ? " statusUpdate" : ""}${payload.customEvent ? ` customEvent=${payload.customEvent.name}` : ""}`
         );
 
-        const response = await gateway.request("/worker/response", {
-          method: "POST",
-          body: JSON.stringify(payload),
-          timeoutMs: 30_000,
-        });
+        // Route through the token manager so a turn running past the token's
+        // 2h TTL refreshes (proactively when near expiry, reactively on a 401)
+        // against the deployment-liveness-gated /worker/token/refresh endpoint.
+        // The manager is the single source of truth for the live token; it
+        // hands the current token to this callback, which binds a fresh gateway
+        // client to that live bearer for each (re)try — keeping the shared
+        // auth/content-type/timeout boilerplate from the gateway client.
+        const response = await getWorkerTokenManager().fetchWithRefresh((tok) =>
+          createGatewayClient({ baseUrl: this.gatewayUrl, token: tok }).request(
+            "/worker/response",
+            {
+              method: "POST",
+              body: JSON.stringify(payload),
+              timeoutMs: 30_000,
+            }
+          )
+        );
 
         if (!response.ok) {
           throw new Error(

--- a/packages/agent-worker/src/gateway/gateway-integration.ts
+++ b/packages/agent-worker/src/gateway/gateway-integration.ts
@@ -67,13 +67,6 @@ export class HttpWorkerTransport implements WorkerTransport {
     this.jobId = jobId;
   }
 
-  setWorkerToken(workerToken: string): void {
-    // Delegate to the single source of truth. Called per-turn with the fresh
-    // runJobToken (and by the manager's onRefresh listener) so all gateway
-    // calls — here and elsewhere — converge on the same live token.
-    getWorkerTokenManager().adopt(workerToken);
-  }
-
   async signalDone(finalDelta?: string): Promise<void> {
     // Send final delta if there is one
     if (finalDelta) {

--- a/packages/agent-worker/src/gateway/gateway-integration.ts
+++ b/packages/agent-worker/src/gateway/gateway-integration.ts
@@ -51,7 +51,7 @@ export class HttpWorkerTransport implements WorkerTransport {
     // is the single source of truth for the live token — this transport's
     // gateway POSTs read it via fetchWithRefresh, so there is no per-transport
     // token field to drift.
-    getWorkerTokenManager().adopt(config.workerToken);
+    getWorkerTokenManager().seed(config.workerToken);
     this.userId = config.userId;
     this.channelId = config.channelId;
     this.conversationId = config.conversationId;

--- a/packages/agent-worker/src/gateway/sse-client.ts
+++ b/packages/agent-worker/src/gateway/sse-client.ts
@@ -16,10 +16,7 @@ import {
 import { z } from "zod";
 import type { WorkerConfig, WorkerExecutor } from "../core/types";
 import { createGatewayClient } from "../shared/gateway-client";
-import {
-  adoptWorkerToken,
-  getWorkerTokenManager,
-} from "./worker-token-manager";
+import { getWorkerTokenManager } from "./worker-token-manager";
 import { SENSITIVE_WORKER_ENV_KEYS } from "../shared/worker-env-keys";
 import { OpenClawWorker } from "../openclaw/worker";
 import { invalidateSessionContextCache } from "../openclaw/session-context";
@@ -559,13 +556,6 @@ export class GatewayClient {
       "Executing command in sandbox"
     );
 
-    // Adopt this exec job's own per-run token so its responses authenticate
-    // under THIS run. The token manager is a process-wide singleton that may
-    // still hold a previous turn's token, and seed() (the transport constructor)
-    // deliberately won't override a live token — so an exec job must adopt
-    // explicitly, the same way OpenClawWorker.execute adopts a chat turn's token.
-    if (data.runJobToken) adoptWorkerToken(data.runJobToken);
-
     // Create span for exec execution
     const span = createChildSpan("exec_execution", traceparent, {
       "lobu.exec_id": execId,
@@ -579,8 +569,6 @@ export class GatewayClient {
     // Create transport for sending responses back to gateway
     const transport = new HttpWorkerTransport({
       gatewayUrl: this.dispatcherUrl,
-      // Seed fallback only — the exec token was adopted above, so the manager's
-      // live token (this exec's runJobToken) is what the transport actually uses.
       workerToken: this.workerToken,
       userId: data.userId,
       channelId: data.channelId,

--- a/packages/agent-worker/src/gateway/sse-client.ts
+++ b/packages/agent-worker/src/gateway/sse-client.ts
@@ -16,7 +16,10 @@ import {
 import { z } from "zod";
 import type { WorkerConfig, WorkerExecutor } from "../core/types";
 import { createGatewayClient } from "../shared/gateway-client";
-import { getWorkerTokenManager } from "./worker-token-manager";
+import {
+  adoptWorkerToken,
+  getWorkerTokenManager,
+} from "./worker-token-manager";
 import { SENSITIVE_WORKER_ENV_KEYS } from "../shared/worker-env-keys";
 import { OpenClawWorker } from "../openclaw/worker";
 import { invalidateSessionContextCache } from "../openclaw/session-context";
@@ -556,6 +559,13 @@ export class GatewayClient {
       "Executing command in sandbox"
     );
 
+    // Adopt this exec job's own per-run token so its responses authenticate
+    // under THIS run. The token manager is a process-wide singleton that may
+    // still hold a previous turn's token, and seed() (the transport constructor)
+    // deliberately won't override a live token — so an exec job must adopt
+    // explicitly, the same way OpenClawWorker.execute adopts a chat turn's token.
+    if (data.runJobToken) adoptWorkerToken(data.runJobToken);
+
     // Create span for exec execution
     const span = createChildSpan("exec_execution", traceparent, {
       "lobu.exec_id": execId,
@@ -569,10 +579,9 @@ export class GatewayClient {
     // Create transport for sending responses back to gateway
     const transport = new HttpWorkerTransport({
       gatewayUrl: this.dispatcherUrl,
-      // Prefer this exec job's per-run token over the stale boot token so the
-      // manager seeds with the right bearer; seed() no-ops anyway once a live
-      // token is adopted, but this keeps the value correct on a cold first seed.
-      workerToken: data.runJobToken ?? this.workerToken,
+      // Seed fallback only — the exec token was adopted above, so the manager's
+      // live token (this exec's runJobToken) is what the transport actually uses.
+      workerToken: this.workerToken,
       userId: data.userId,
       channelId: data.channelId,
       conversationId,

--- a/packages/agent-worker/src/gateway/sse-client.ts
+++ b/packages/agent-worker/src/gateway/sse-client.ts
@@ -136,7 +136,7 @@ export class GatewayClient {
     // its delivery receipts read the manager's live token — so a turn running
     // past the 2h TTL keeps authenticating after a refresh instead of pinning
     // the now-expired boot bearer.
-    getWorkerTokenManager().adopt(workerToken);
+    getWorkerTokenManager().seed(workerToken);
     this.userId = userId;
     this.deploymentName = deploymentName;
     this.httpPort = httpPort;
@@ -569,7 +569,10 @@ export class GatewayClient {
     // Create transport for sending responses back to gateway
     const transport = new HttpWorkerTransport({
       gatewayUrl: this.dispatcherUrl,
-      workerToken: this.workerToken,
+      // Prefer this exec job's per-run token over the stale boot token so the
+      // manager seeds with the right bearer; seed() no-ops anyway once a live
+      // token is adopted, but this keeps the value correct on a cold first seed.
+      workerToken: data.runJobToken ?? this.workerToken,
       userId: data.userId,
       channelId: data.channelId,
       conversationId,

--- a/packages/agent-worker/src/gateway/sse-client.ts
+++ b/packages/agent-worker/src/gateway/sse-client.ts
@@ -16,6 +16,7 @@ import {
 import { z } from "zod";
 import type { WorkerConfig, WorkerExecutor } from "../core/types";
 import { createGatewayClient } from "../shared/gateway-client";
+import { getWorkerTokenManager } from "./worker-token-manager";
 import { SENSITIVE_WORKER_ENV_KEYS } from "../shared/worker-env-keys";
 import { OpenClawWorker } from "../openclaw/worker";
 import { invalidateSessionContextCache } from "../openclaw/session-context";
@@ -130,6 +131,12 @@ export class GatewayClient {
   ) {
     this.dispatcherUrl = dispatcherUrl;
     this.workerToken = workerToken;
+    // Seed the process-wide token manager from the boot token. The SSE client
+    // boots before any per-run token is adopted, and both its stream auth and
+    // its delivery receipts read the manager's live token — so a turn running
+    // past the 2h TTL keeps authenticating after a refresh instead of pinning
+    // the now-expired boot bearer.
+    getWorkerTokenManager().adopt(workerToken);
     this.userId = userId;
     this.deploymentName = deploymentName;
     this.httpPort = httpPort;
@@ -190,10 +197,14 @@ export class GatewayClient {
       `Connecting to dispatcher at ${streamUrl} (attempt ${this.reconnectAttempts + 1})`
     );
 
+    // Refresh proactively if near expiry, then read the live token so a
+    // reconnect after the 2h TTL authenticates with the renewed bearer rather
+    // than the now-expired boot token.
+    await getWorkerTokenManager().ensureFresh();
     const response = await fetch(streamUrl, {
       method: "GET",
       headers: {
-        Authorization: `Bearer ${this.workerToken}`,
+        Authorization: `Bearer ${getWorkerTokenManager().getToken()}`,
         Accept: "text/event-stream",
       },
       signal: abortController.signal,
@@ -294,15 +305,20 @@ export class GatewayClient {
     body: Record<string, unknown>,
     failureContext: string
   ): void {
-    createGatewayClient({
-      baseUrl: this.dispatcherUrl,
-      token: this.workerToken,
-    })
-      .request("/worker/response", {
-        method: "POST",
-        body: JSON.stringify(body),
-        timeoutMs: 10_000,
-      })
+    // These receipts are what keep the turn alive against stale cleanup, so
+    // route them through the token manager: a turn past the 2h TTL refreshes
+    // (reactively on a 401) instead of a stale bearer getting the turn swept.
+    getWorkerTokenManager()
+      .fetchWithRefresh((tok) =>
+        createGatewayClient({
+          baseUrl: this.dispatcherUrl,
+          token: tok,
+        }).request("/worker/response", {
+          method: "POST",
+          body: JSON.stringify(body),
+          timeoutMs: 10_000,
+        })
+      )
       .catch((err) => {
         logger.warn(`Failed to send ${failureContext}:`, err);
       });

--- a/packages/agent-worker/src/gateway/worker-token-manager.ts
+++ b/packages/agent-worker/src/gateway/worker-token-manager.ts
@@ -57,6 +57,11 @@ export class WorkerTokenManager {
    *  before the liveness gate). */
   private autoRefreshTimer: ReturnType<typeof setTimeout> | null = null;
   private autoRefreshEnabled = false;
+  /** True once a token has been explicitly seeded, adopted, or refreshed.
+   *  Distinguishes a real token from the lazy env default so a later seed()
+   *  from an auxiliary transport cannot roll a live/refreshed token back to the
+   *  stale boot bearer. */
+  private initialized = false;
 
   constructor(initialToken: string, gatewayUrl: string, issuedAtMs?: number) {
     this.token = initialToken;
@@ -73,6 +78,23 @@ export class WorkerTokenManager {
   adopt(token: string, issuedAtMs: number = Date.now()): void {
     this.token = token;
     this.issuedAtMs = issuedAtMs;
+    this.initialized = true;
+    if (this.autoRefreshEnabled) this.armAutoRefresh();
+  }
+
+  /**
+   * Seed from a boot/deployment token WITHOUT clobbering a token that was
+   * already adopted (the per-run runJobToken) or refreshed. Auxiliary transports
+   * are constructed mid-turn from the stale boot token, so calling adopt() there
+   * would roll the live token back to the now-expired boot bearer and 401 the
+   * rest of the turn. Seed takes effect only once — while the manager still
+   * holds its lazy env default — and no-ops thereafter.
+   */
+  seed(token: string, issuedAtMs: number = Date.now()): void {
+    if (this.initialized) return;
+    this.token = token;
+    this.issuedAtMs = issuedAtMs;
+    this.initialized = true;
     if (this.autoRefreshEnabled) this.armAutoRefresh();
   }
 

--- a/packages/agent-worker/src/gateway/worker-token-manager.ts
+++ b/packages/agent-worker/src/gateway/worker-token-manager.ts
@@ -55,6 +55,11 @@ export class WorkerTokenManager {
    *  from an auxiliary transport cannot roll a live/refreshed token back to the
    *  stale boot bearer. */
   private initialized = false;
+  /** Bumped on every token change (seed/adopt). A refresh captures it at start
+   *  and discards its result if a newer token was adopted while the refresh was
+   *  in flight — so a long turn's late-resolving refresh can't clobber the next
+   *  turn's freshly-adopted token. */
+  private epoch = 0;
 
   constructor(initialToken: string, gatewayUrl: string, issuedAtMs?: number) {
     this.token = initialToken;
@@ -72,6 +77,7 @@ export class WorkerTokenManager {
     this.token = token;
     this.issuedAtMs = issuedAtMs;
     this.initialized = true;
+    this.epoch++;
     if (this.autoRefreshEnabled) this.armAutoRefresh();
   }
 
@@ -88,6 +94,7 @@ export class WorkerTokenManager {
     this.token = token;
     this.issuedAtMs = issuedAtMs;
     this.initialized = true;
+    this.epoch++;
     if (this.autoRefreshEnabled) this.armAutoRefresh();
   }
 
@@ -173,11 +180,16 @@ export class WorkerTokenManager {
   }
 
   private async doRefresh(): Promise<string | null> {
+    // Capture the token + epoch this refresh is for, so a result that resolves
+    // after a newer token was adopted (the next turn's adoptWorkerToken) is
+    // discarded instead of clobbering the live token.
+    const refreshingToken = this.token;
+    const refreshingEpoch = this.epoch;
     try {
       const url = `${ensureBaseUrl(this.gatewayUrl)}/worker/token/refresh`;
       const res = await fetch(url, {
         method: "POST",
-        headers: { Authorization: `Bearer ${this.token}` },
+        headers: { Authorization: `Bearer ${refreshingToken}` },
         signal: AbortSignal.timeout(15_000),
       });
       if (!res.ok) {
@@ -194,6 +206,15 @@ export class WorkerTokenManager {
       if (!body.token) {
         logger.warn("Worker token refresh returned no token");
         return null;
+      }
+      if (this.epoch !== refreshingEpoch) {
+        // A newer token was adopted while this refresh was in flight (e.g. the
+        // next turn started). Discard this stale result and keep the live token;
+        // a reactive 401 retry will use it.
+        logger.info(
+          "Discarding stale worker-token refresh (newer token adopted mid-refresh)"
+        );
+        return this.token;
       }
       this.adopt(body.token);
       // Mirror into the env so the env-reading consumers (session-context,

--- a/packages/agent-worker/src/gateway/worker-token-manager.ts
+++ b/packages/agent-worker/src/gateway/worker-token-manager.ts
@@ -1,16 +1,12 @@
 /**
  * Worker-side live token manager — the single source of truth for the current
- * worker token. Worker tokens carry a fixed timestamp and are rejected 2h later
- * (the short TTL is the leak-revocation property); this manager keeps a >2h
- * single turn alive by refreshing against `/worker/token/refresh`. The
- * server-side per-turn liveness gate (and the cross-turn case) is documented at
- * the gateway route + its route tests.
- *
- * Callers read getToken() (or go through fetchWithRefresh). Refresh has three
- * triggers: timer (proactive — renews even when the turn makes NO gateway call,
- * the load-bearing path since the route rejects an already-expired bearer),
- * pre-call ensureFresh(), and reactive (a 401 → one refresh + retry). On success
- * it mirrors the token into `process.env.WORKER_TOKEN` for env-readers.
+ * worker token. Worker tokens are rejected 2h after issue (the short TTL is the
+ * leak-revocation property); this manager keeps a >2h single turn alive by
+ * refreshing against `/worker/token/refresh`, mirroring each new token into
+ * `process.env.WORKER_TOKEN` for env-readers. Callers read getToken() or go
+ * through fetchWithRefresh(); the proactive/pre-call/reactive refresh triggers
+ * are documented on the methods below, and the server-side per-turn liveness
+ * gate at the gateway route + its tests.
  */
 
 import { createLogger, ensureBaseUrl, getOptionalEnv } from "@lobu/core";

--- a/packages/agent-worker/src/gateway/worker-token-manager.ts
+++ b/packages/agent-worker/src/gateway/worker-token-manager.ts
@@ -1,0 +1,214 @@
+/**
+ * Worker-side live token manager.
+ *
+ * Background: every worker token (the deployment-lifetime WORKER_TOKEN minted at
+ * spawn, and the per-run runJobToken minted per message) carries a fixed
+ * `timestamp` and is rejected by the gateway 2h later (WORKER_TOKEN_TTL_MS — an
+ * intentional security property; the short TTL is the leak-revocation path). A
+ * worker can outlive that window:
+ *   - across turns: each new turn already mints a fresh per-run token (the
+ *     per-turn adoption in OpenClawWorker.execute() swaps it into env + the
+ *     transport), so the cross-turn case is covered without this manager.
+ *   - within ONE turn running >2h (long autonomous / watcher run): even the
+ *     turn's runJobToken expires mid-turn. THIS is what the manager fixes.
+ *
+ * The manager holds the current live token and refreshes it against the gateway
+ * `/worker/token/refresh` endpoint, which mints a fresh 2h token with the same
+ * claims ONLY while the deployment still has an in-flight turn (deployment-
+ * liveness revocation model). Two triggers:
+ *   - proactive: when the token is close to expiry (checked before each gateway
+ *     call), refresh ahead of the 401.
+ *   - reactive: a 401 from any gateway call triggers a single refresh + retry.
+ *
+ * On a successful refresh the manager updates its in-memory token AND
+ * `process.env.WORKER_TOKEN`, so every per-turn env-reader (session-context,
+ * snapshot hydrate/clear, deliverFinalResult's hint) and any subsequently-read
+ * consumer picks up the live token. Callers that captured the token elsewhere
+ * (e.g. HttpWorkerTransport's field) register an onRefresh listener to stay in
+ * sync.
+ */
+
+import { createLogger, ensureBaseUrl, getOptionalEnv } from "@lobu/core";
+
+const logger = createLogger("worker-token-manager");
+
+/**
+ * Default assumed token TTL (must mirror the gateway's WORKER_TOKEN_TTL_MS
+ * default of 2h). Override via WORKER_TOKEN_TTL_MS so a deployment that tunes
+ * the gateway TTL keeps the proactive window aligned. The reactive 401 path is
+ * the safety net if this drifts.
+ */
+function assumedTtlMs(): number {
+  const raw = parseInt(process.env.WORKER_TOKEN_TTL_MS ?? "", 10);
+  if (Number.isFinite(raw) && raw > 0) return raw;
+  return 2 * 60 * 60 * 1000;
+}
+
+/**
+ * Refresh proactively once the token is within this fraction of its assumed
+ * lifetime from expiry. 0.2 → refresh in the last ~24min of a 2h token, leaving
+ * ample margin before the hard cutoff.
+ */
+const PROACTIVE_REFRESH_FRACTION = 0.2;
+
+export type RefreshListener = (token: string) => void;
+
+export class WorkerTokenManager {
+  private token: string;
+  /** Wall-clock ms when the current token was issued/adopted (≈ its mint time
+   *  for a freshly-refreshed token; for the boot/per-run token it's when the
+   *  manager first saw it — a conservative under-estimate of remaining life,
+   *  which only makes the proactive refresh fire earlier, never later). */
+  private issuedAtMs: number;
+  private readonly gatewayUrl: string;
+  private readonly listeners: RefreshListener[] = [];
+  /** De-dupe concurrent refreshes: many gateway calls can race a 401. */
+  private inFlight: Promise<string | null> | null = null;
+
+  constructor(initialToken: string, gatewayUrl: string, issuedAtMs?: number) {
+    this.token = initialToken;
+    this.gatewayUrl = gatewayUrl;
+    this.issuedAtMs = issuedAtMs ?? Date.now();
+  }
+
+  getToken(): string {
+    return this.token;
+  }
+
+  /** Adopt a new token from outside (e.g. the per-turn runJobToken swap at the
+   *  start of each turn). Resets the issued-at clock. */
+  adopt(token: string, issuedAtMs: number = Date.now()): void {
+    this.token = token;
+    this.issuedAtMs = issuedAtMs;
+  }
+
+  onRefresh(listener: RefreshListener): void {
+    this.listeners.push(listener);
+  }
+
+  /** True when the token is within the proactive-refresh window of expiry. */
+  private isNearExpiry(): boolean {
+    const ttl = assumedTtlMs();
+    const age = Date.now() - this.issuedAtMs;
+    return age >= ttl * (1 - PROACTIVE_REFRESH_FRACTION);
+  }
+
+  /**
+   * Ensure the token is fresh before a gateway call. Refreshes only when near
+   * expiry (cheap no-op otherwise). Never throws — a failed proactive refresh
+   * leaves the existing token in place and lets the reactive 401 path handle it.
+   */
+  async ensureFresh(): Promise<void> {
+    if (this.isNearExpiry()) {
+      await this.refresh();
+    }
+  }
+
+  /**
+   * Force a refresh (the reactive 401 path). Returns the new token on success,
+   * or null when refresh was denied (deployment no longer live) / failed.
+   * Concurrent callers share one in-flight request.
+   */
+  async refresh(): Promise<string | null> {
+    if (this.inFlight) return this.inFlight;
+    this.inFlight = this.doRefresh().finally(() => {
+      this.inFlight = null;
+    });
+    return this.inFlight;
+  }
+
+  private async doRefresh(): Promise<string | null> {
+    try {
+      const url = `${ensureBaseUrl(this.gatewayUrl)}/worker/token/refresh`;
+      const res = await fetch(url, {
+        method: "POST",
+        headers: { Authorization: `Bearer ${this.token}` },
+        signal: AbortSignal.timeout(15_000),
+      });
+      if (!res.ok) {
+        // 403 = deployment no longer live (refresh revoked) or token ineligible;
+        // 401 = current token already expired/revoked. Either way we can't get a
+        // fresh token — the caller's gateway call will fail and the turn ends.
+        logger.warn(
+          { status: res.status },
+          "Worker token refresh rejected by gateway"
+        );
+        return null;
+      }
+      const body = (await res.json()) as { token?: string };
+      if (!body.token) {
+        logger.warn("Worker token refresh returned no token");
+        return null;
+      }
+      this.adopt(body.token);
+      // Keep every env-reader and registered consumer on the live token.
+      process.env.WORKER_TOKEN = body.token;
+      for (const l of this.listeners) {
+        try {
+          l(body.token);
+        } catch (err) {
+          logger.warn(
+            { err: err instanceof Error ? err.message : String(err) },
+            "Worker token refresh listener threw"
+          );
+        }
+      }
+      logger.info("Refreshed worker token");
+      return body.token;
+    } catch (err) {
+      logger.warn(
+        { err: err instanceof Error ? err.message : String(err) },
+        "Worker token refresh failed"
+      );
+      return null;
+    }
+  }
+
+  /**
+   * Run a gateway fetch with proactive + reactive refresh. `doFetch` receives
+   * the current token and must use it for the Authorization header. On a 401 we
+   * refresh once and retry; a second 401 (or refresh denial) is returned as-is.
+   */
+  async fetchWithRefresh(
+    doFetch: (token: string) => Promise<Response>
+  ): Promise<Response> {
+    await this.ensureFresh();
+    let res = await doFetch(this.token);
+    if (res.status === 401) {
+      const fresh = await this.refresh();
+      if (fresh) {
+        res = await doFetch(fresh);
+      }
+    }
+    return res;
+  }
+}
+
+/**
+ * Process-wide manager. The worker is a single-conversation subprocess, so one
+ * instance per process is correct. Constructed lazily from the env on first use
+ * and re-anchored each turn via {@link adoptWorkerToken}.
+ */
+let manager: WorkerTokenManager | null = null;
+
+export function getWorkerTokenManager(): WorkerTokenManager {
+  if (!manager) {
+    manager = new WorkerTokenManager(
+      getOptionalEnv("WORKER_TOKEN", ""),
+      getOptionalEnv("DISPATCHER_URL", "")
+    );
+  }
+  return manager;
+}
+
+/** Adopt a freshly-minted per-run token at turn start (resets the TTL clock).
+ *  Also mirrors it into process.env.WORKER_TOKEN for env-readers. */
+export function adoptWorkerToken(token: string): void {
+  process.env.WORKER_TOKEN = token;
+  getWorkerTokenManager().adopt(token);
+}
+
+/** Test-only: reset the process-wide manager. */
+export function __resetWorkerTokenManagerForTests(): void {
+  manager = null;
+}

--- a/packages/agent-worker/src/gateway/worker-token-manager.ts
+++ b/packages/agent-worker/src/gateway/worker-token-manager.ts
@@ -1,34 +1,16 @@
 /**
- * Worker-side live token manager.
+ * Worker-side live token manager — the single source of truth for the current
+ * worker token. Worker tokens carry a fixed timestamp and are rejected 2h later
+ * (the short TTL is the leak-revocation property); this manager keeps a >2h
+ * single turn alive by refreshing against `/worker/token/refresh`. The
+ * server-side per-turn liveness gate (and the cross-turn case) is documented at
+ * the gateway route + its route tests.
  *
- * Background: every worker token (the deployment-lifetime WORKER_TOKEN minted at
- * spawn, and the per-run runJobToken minted per message) carries a fixed
- * `timestamp` and is rejected by the gateway 2h later (WORKER_TOKEN_TTL_MS — an
- * intentional security property; the short TTL is the leak-revocation path). A
- * worker can outlive that window:
- *   - across turns: each new turn already mints a fresh per-run token (the
- *     per-turn adoption in OpenClawWorker.execute() swaps it into env + the
- *     transport), so the cross-turn case is covered without this manager.
- *   - within ONE turn running >2h (long autonomous / watcher run): even the
- *     turn's runJobToken expires mid-turn. THIS is what the manager fixes.
- *
- * The manager holds the current live token and refreshes it against the gateway
- * `/worker/token/refresh` endpoint, which mints a fresh 2h token with the same
- * claims ONLY while the deployment still has an in-flight turn (deployment-
- * liveness revocation model). Three triggers:
- *   - timer (proactive, the load-bearing one for a >2h turn): a scheduled
- *     refresh fires at the start of the proactive window so the token is
- *     renewed even if the turn makes NO gateway call — the refresh request must
- *     travel with a still-valid bearer, since the route rejects an already-
- *     expired token before the liveness gate.
- *   - pre-call (proactive): ensureFresh() refreshes ahead of a gateway call
- *     that happens to land inside the window.
- *   - reactive: a 401 from a gateway call triggers a single refresh + retry.
- *
- * The manager is the single source of truth: callers read getToken() (or go
- * through fetchWithRefresh). On a successful refresh it also mirrors the token
- * into `process.env.WORKER_TOKEN`, so every per-turn env-reader (session-
- * context, snapshot hydrate/clear, deliverFinalResult's hint) picks it up.
+ * Callers read getToken() (or go through fetchWithRefresh). Refresh has three
+ * triggers: timer (proactive — renews even when the turn makes NO gateway call,
+ * the load-bearing path since the route rejects an already-expired bearer),
+ * pre-call ensureFresh(), and reactive (a 401 → one refresh + retry). On success
+ * it mirrors the token into `process.env.WORKER_TOKEN` for env-readers.
  */
 
 import { createLogger, ensureBaseUrl, getOptionalEnv } from "@lobu/core";

--- a/packages/agent-worker/src/gateway/worker-token-manager.ts
+++ b/packages/agent-worker/src/gateway/worker-token-manager.ts
@@ -15,17 +15,20 @@
  * The manager holds the current live token and refreshes it against the gateway
  * `/worker/token/refresh` endpoint, which mints a fresh 2h token with the same
  * claims ONLY while the deployment still has an in-flight turn (deployment-
- * liveness revocation model). Two triggers:
- *   - proactive: when the token is close to expiry (checked before each gateway
- *     call), refresh ahead of the 401.
- *   - reactive: a 401 from any gateway call triggers a single refresh + retry.
+ * liveness revocation model). Three triggers:
+ *   - timer (proactive, the load-bearing one for a >2h turn): a scheduled
+ *     refresh fires at the start of the proactive window so the token is
+ *     renewed even if the turn makes NO gateway call — the refresh request must
+ *     travel with a still-valid bearer, since the route rejects an already-
+ *     expired token before the liveness gate.
+ *   - pre-call (proactive): ensureFresh() refreshes ahead of a gateway call
+ *     that happens to land inside the window.
+ *   - reactive: a 401 from a gateway call triggers a single refresh + retry.
  *
- * On a successful refresh the manager updates its in-memory token AND
- * `process.env.WORKER_TOKEN`, so every per-turn env-reader (session-context,
- * snapshot hydrate/clear, deliverFinalResult's hint) and any subsequently-read
- * consumer picks up the live token. Callers that captured the token elsewhere
- * (e.g. HttpWorkerTransport's field) register an onRefresh listener to stay in
- * sync.
+ * The manager is the single source of truth: callers read getToken() (or go
+ * through fetchWithRefresh). On a successful refresh it also mirrors the token
+ * into `process.env.WORKER_TOKEN`, so every per-turn env-reader (session-
+ * context, snapshot hydrate/clear, deliverFinalResult's hint) picks it up.
  */
 
 import { createLogger, ensureBaseUrl, getOptionalEnv } from "@lobu/core";
@@ -51,7 +54,9 @@ function assumedTtlMs(): number {
  */
 const PROACTIVE_REFRESH_FRACTION = 0.2;
 
-export type RefreshListener = (token: string) => void;
+/** Retry cadence for the timer-driven refresh after a transient denial/failure
+ *  near the window edge, so one miss doesn't permanently disable auto-refresh. */
+const AUTO_REFRESH_RETRY_MS = 30_000;
 
 export class WorkerTokenManager {
   private token: string;
@@ -61,9 +66,15 @@ export class WorkerTokenManager {
    *  which only makes the proactive refresh fire earlier, never later). */
   private issuedAtMs: number;
   private readonly gatewayUrl: string;
-  private readonly listeners: RefreshListener[] = [];
   /** De-dupe concurrent refreshes: many gateway calls can race a 401. */
   private inFlight: Promise<string | null> | null = null;
+  /** Timer that fires a refresh at the start of the proactive window, so the
+   *  token is renewed even when the worker makes NO gateway call before expiry
+   *  (the >2h single-turn case where on-demand refresh would otherwise fire
+   *  too late — the bearer would already be expired and the route rejects it
+   *  before the liveness gate). */
+  private autoRefreshTimer: ReturnType<typeof setTimeout> | null = null;
+  private autoRefreshEnabled = false;
 
   constructor(initialToken: string, gatewayUrl: string, issuedAtMs?: number) {
     this.token = initialToken;
@@ -76,14 +87,61 @@ export class WorkerTokenManager {
   }
 
   /** Adopt a new token from outside (e.g. the per-turn runJobToken swap at the
-   *  start of each turn). Resets the issued-at clock. */
+   *  start of each turn). Resets the issued-at clock and re-arms the timer. */
   adopt(token: string, issuedAtMs: number = Date.now()): void {
     this.token = token;
     this.issuedAtMs = issuedAtMs;
+    if (this.autoRefreshEnabled) this.armAutoRefresh();
   }
 
-  onRefresh(listener: RefreshListener): void {
-    this.listeners.push(listener);
+  /**
+   * Start timer-driven proactive refresh. The worker enables this for the
+   * duration of a turn so a long-running turn that makes no gateway calls still
+   * renews its token BEFORE it hard-expires (refresh must travel with a still-
+   * valid bearer — the route rejects an already-expired token before the
+   * liveness gate). Idempotent; safe to call every turn.
+   */
+  enableAutoRefresh(): void {
+    this.autoRefreshEnabled = true;
+    this.armAutoRefresh();
+  }
+
+  /** Stop the timer (turn end / shutdown / tests). */
+  disableAutoRefresh(): void {
+    this.autoRefreshEnabled = false;
+    if (this.autoRefreshTimer) {
+      clearTimeout(this.autoRefreshTimer);
+      this.autoRefreshTimer = null;
+    }
+  }
+
+  /** (Re)schedule the next proactive refresh at the start of the proactive
+   *  window. If already inside the window, fire on the next tick. */
+  private armAutoRefresh(): void {
+    if (this.autoRefreshTimer) {
+      clearTimeout(this.autoRefreshTimer);
+      this.autoRefreshTimer = null;
+    }
+    const ttl = assumedTtlMs();
+    const fireAt = this.issuedAtMs + ttl * (1 - PROACTIVE_REFRESH_FRACTION);
+    const delay = Math.max(0, fireAt - Date.now());
+    const timer = setTimeout(() => {
+      this.autoRefreshTimer = null;
+      // refresh() re-arms via adopt() on success; on failure (e.g. deployment
+      // not yet/no-longer live) re-arm a short retry so a transient denial near
+      // the window edge doesn't permanently disable the timer.
+      void this.refresh().then((tok) => {
+        if (!tok && this.autoRefreshEnabled && !this.autoRefreshTimer) {
+          this.autoRefreshTimer = setTimeout(
+            () => this.armAutoRefresh(),
+            AUTO_REFRESH_RETRY_MS
+          );
+          this.autoRefreshTimer.unref?.();
+        }
+      });
+    }, delay);
+    timer.unref?.();
+    this.autoRefreshTimer = timer;
   }
 
   /** True when the token is within the proactive-refresh window of expiry. */
@@ -141,18 +199,9 @@ export class WorkerTokenManager {
         return null;
       }
       this.adopt(body.token);
-      // Keep every env-reader and registered consumer on the live token.
+      // Mirror into the env so the env-reading consumers (session-context,
+      // snapshot hydrate/clear, the audio-permission hint) use the live token.
       process.env.WORKER_TOKEN = body.token;
-      for (const l of this.listeners) {
-        try {
-          l(body.token);
-        } catch (err) {
-          logger.warn(
-            { err: err instanceof Error ? err.message : String(err) },
-            "Worker token refresh listener threw"
-          );
-        }
-      }
       logger.info("Refreshed worker token");
       return body.token;
     } catch (err) {
@@ -208,7 +257,8 @@ export function adoptWorkerToken(token: string): void {
   getWorkerTokenManager().adopt(token);
 }
 
-/** Test-only: reset the process-wide manager. */
+/** Test-only: reset the process-wide manager (clears any pending timer). */
 export function __resetWorkerTokenManagerForTests(): void {
+  manager?.disableAutoRefresh();
   manager = null;
 }

--- a/packages/agent-worker/src/gateway/worker-token-manager.ts
+++ b/packages/agent-worker/src/gateway/worker-token-manager.ts
@@ -1,12 +1,9 @@
 /**
- * Worker-side live token manager — the single source of truth for the current
- * worker token. Worker tokens are rejected 2h after issue (the short TTL is the
- * leak-revocation property); this manager keeps a >2h single turn alive by
- * refreshing against `/worker/token/refresh`, mirroring each new token into
- * `process.env.WORKER_TOKEN` for env-readers. Callers read getToken() or go
- * through fetchWithRefresh(); the proactive/pre-call/reactive refresh triggers
- * are documented on the methods below, and the server-side per-turn liveness
- * gate at the gateway route + its tests.
+ * Worker-side live token manager — the process-wide single source of truth for
+ * the current worker token. Worker tokens expire 2h after issue; this keeps a
+ * >2h turn alive by refreshing against `/worker/token/refresh` and mirroring the
+ * new token into `process.env.WORKER_TOKEN`. Refresh triggers are documented on
+ * the methods below; the server-side per-turn liveness gate at the route.
  */
 
 import { createLogger, ensureBaseUrl, getOptionalEnv } from "@lobu/core";

--- a/packages/agent-worker/src/openclaw/session-runner.ts
+++ b/packages/agent-worker/src/openclaw/session-runner.ts
@@ -29,6 +29,7 @@ import type { ProgressUpdate, SessionExecutionResult } from "../core/types";
 import { createEmbeddedBashOps } from "../embedded/just-bash-bootstrap";
 import { consumePendingConfigNotifications } from "../gateway/pending-config-notifications";
 import { getApiKeyEnvVarForProvider } from "../shared/provider-auth-hints";
+import { getWorkerTokenManager } from "../gateway/worker-token-manager";
 import type { GatewayParams } from "../shared/tool-implementations";
 import { isRecord } from "../shared/type-guards";
 import {
@@ -381,12 +382,6 @@ interface RunAISessionParams {
   /** Arbitrary platform-level metadata (e.g. { sessionReset: true, files: [...] }). */
   platformMetadata: unknown;
   agentId: string | undefined;
-  /**
-   * Per-run worker token minted by the dispatcher (carries `source` + `runId`).
-   * Used for gateway calls (interactions, MCP) so headless-run cards are stamped
-   * with their origin; falls back to the deployment WORKER_TOKEN when absent.
-   */
-  runJobToken?: string;
 
   // Resolved workspace directory (from WorkspaceManager)
   workspaceDir: string;
@@ -445,7 +440,6 @@ export async function runAISession(
     platform,
     platformMetadata,
     agentId,
-    runJobToken,
     workspaceDir,
     progressProcessor,
     onSessionFilePathResolved,
@@ -788,11 +782,21 @@ export async function runAISession(
 
   const gwParams: GatewayParams = {
     gatewayUrl: getOptionalEnv("DISPATCHER_URL", ""),
-    // Prefer the per-run token: it carries the headless `source`, so interaction
-    // and MCP cards from headless turns are stamped headless (and skip the
-    // SSE-owner gate) instead of dead-lettering. The deployment WORKER_TOKEN is
-    // the fallback for legacy direct-enqueue runs with no per-run token.
-    workerToken: runJobToken || getOptionalEnv("WORKER_TOKEN", ""),
+    // `workerToken` is a GETTER, not a captured string: every gateway/MCP/
+    // interaction call reads it fresh, so a mid-turn token refresh (the
+    // WorkerTokenManager swaps the live token when a >2h turn renews) is
+    // immediately picked up — a captured string would keep sending the now-
+    // expired original bearer and 401 the rest of the turn.
+    //
+    // The manager is the single source of truth: it was seeded at turn start
+    // with the per-run runJobToken (adoptWorkerToken in OpenClawWorker.execute),
+    // which carries the headless `source` so cards from headless turns are
+    // stamped headless and skip the SSE-owner gate. For legacy direct-enqueue
+    // runs with no per-run token it falls back to the env WORKER_TOKEN the
+    // manager was constructed from.
+    get workerToken() {
+      return getWorkerTokenManager().getToken();
+    },
     channelId,
     conversationId,
     platform,

--- a/packages/agent-worker/src/openclaw/worker.ts
+++ b/packages/agent-worker/src/openclaw/worker.ts
@@ -19,6 +19,7 @@ import type {
 } from "../core/types";
 import { WorkspaceManager } from "../core/workspace";
 import { HttpWorkerTransport } from "../gateway/gateway-integration";
+import { adoptWorkerToken } from "../gateway/worker-token-manager";
 import { generateCustomInstructions } from "../instructions/builder";
 import { ProjectsInstructionProvider } from "../instructions/providers";
 import { fetchAudioProviderSuggestions } from "../shared/audio-provider-suggestions";
@@ -150,6 +151,41 @@ export class OpenClawWorker implements WorkerExecutor {
         "WorkerConfig.runJobToken is missing — MessageConsumer did not mint a per-run worker token"
       );
     }
+
+    // Adopt the freshly-minted per-run token for EVERY gateway call this turn.
+    //
+    // The deployment-lifetime WORKER_TOKEN is minted once at subprocess spawn
+    // and never re-minted while the worker stays warm. Its TTL is 2h (#1266 —
+    // an intentional security property: a leaked token must die fast). But a
+    // continuously-active conversation keeps one subprocess alive past the idle
+    // reap indefinitely, so after 2h that spawn-time token is expired and any
+    // worker→gateway call that still reads it 401s.
+    //
+    // The per-run `runJobToken` is minted fresh per message (recent timestamp →
+    // never expired at turn start) and is a strict superset of the deployment
+    // token's claims (org/agent/conv + connectionId after #1274 + source + the
+    // run-scoping `runId`). Swapping it in here covers two consumer classes:
+    //   1. process.env.WORKER_TOKEN — read by the per-turn session-context
+    //      fetch, the snapshot hydrate (GET, runId-agnostic) / clear (DELETE,
+    //      runId-agnostic) calls, and deliverFinalResult's audio-permission
+    //      hint. Mutating the env is safe: the just-bash spawnHook strips
+    //      WORKER_TOKEN by KEY (not value) before agent bash runs, so agent-
+    //      authored shells still never see it — the strip is undefeated.
+    //   2. the HttpWorkerTransport, which captured the (now-stale) token at
+    //      construction time (worker boot, before any per-run token existed)
+    //      and uses it for the terminal signalDone/signalError POSTs.
+    // The deployment token stays the boot/constructor credential (it's the only
+    // token available before the first turn); we only override it per-turn.
+    //
+    // Adopting through the manager also resets its TTL clock. The manager is
+    // the single source of truth for the live token: the transport's gateway
+    // POSTs read it via fetchWithRefresh, so a SINGLE turn running past the 2h
+    // TTL refreshes its token mid-turn (manager.refresh() →
+    // /worker/token/refresh, gated on deployment-liveness) and the terminal POST
+    // still uses a live token. process.env.WORKER_TOKEN is mirrored too, for the
+    // env-reading consumers (session-context, snapshot hydrate/clear, the
+    // audio-permission hint).
+    adoptWorkerToken(this.config.runJobToken);
 
     try {
       this.progressProcessor.reset();

--- a/packages/agent-worker/src/openclaw/worker.ts
+++ b/packages/agent-worker/src/openclaw/worker.ts
@@ -19,7 +19,10 @@ import type {
 } from "../core/types";
 import { WorkspaceManager } from "../core/workspace";
 import { HttpWorkerTransport } from "../gateway/gateway-integration";
-import { adoptWorkerToken } from "../gateway/worker-token-manager";
+import {
+  adoptWorkerToken,
+  getWorkerTokenManager,
+} from "../gateway/worker-token-manager";
 import { generateCustomInstructions } from "../instructions/builder";
 import { ProjectsInstructionProvider } from "../instructions/providers";
 import { fetchAudioProviderSuggestions } from "../shared/audio-provider-suggestions";
@@ -186,6 +189,11 @@ export class OpenClawWorker implements WorkerExecutor {
     // env-reading consumers (session-context, snapshot hydrate/clear, the
     // audio-permission hint).
     adoptWorkerToken(this.config.runJobToken);
+    // Timer-driven proactive refresh: renew the token before it hard-expires
+    // even if this turn makes NO gateway call (the >2h single-turn case — an
+    // on-demand-only refresh would fire too late, with an already-expired
+    // bearer the route rejects before the liveness gate). Disabled in finally.
+    getWorkerTokenManager().enableAutoRefresh();
 
     try {
       this.progressProcessor.reset();
@@ -375,6 +383,10 @@ export class OpenClawWorker implements WorkerExecutor {
         agentId: this.config.agentId,
         runId: this.config.runId,
       });
+    } finally {
+      // Stop the timer-driven proactive refresh for this turn. A warm worker's
+      // next turn re-adopts a fresh per-run token and re-enables it.
+      getWorkerTokenManager().disableAutoRefresh();
     }
   }
 

--- a/packages/agent-worker/src/openclaw/worker.ts
+++ b/packages/agent-worker/src/openclaw/worker.ts
@@ -155,39 +155,15 @@ export class OpenClawWorker implements WorkerExecutor {
       );
     }
 
-    // Adopt the freshly-minted per-run token for EVERY gateway call this turn.
-    //
-    // The deployment-lifetime WORKER_TOKEN is minted once at subprocess spawn
-    // and never re-minted while the worker stays warm. Its TTL is 2h (#1266 —
-    // an intentional security property: a leaked token must die fast). But a
-    // continuously-active conversation keeps one subprocess alive past the idle
-    // reap indefinitely, so after 2h that spawn-time token is expired and any
-    // worker→gateway call that still reads it 401s.
-    //
-    // The per-run `runJobToken` is minted fresh per message (recent timestamp →
-    // never expired at turn start) and is a strict superset of the deployment
-    // token's claims (org/agent/conv + connectionId after #1274 + source + the
-    // run-scoping `runId`). Swapping it in here covers two consumer classes:
-    //   1. process.env.WORKER_TOKEN — read by the per-turn session-context
-    //      fetch, the snapshot hydrate (GET, runId-agnostic) / clear (DELETE,
-    //      runId-agnostic) calls, and deliverFinalResult's audio-permission
-    //      hint. Mutating the env is safe: the just-bash spawnHook strips
-    //      WORKER_TOKEN by KEY (not value) before agent bash runs, so agent-
-    //      authored shells still never see it — the strip is undefeated.
-    //   2. the HttpWorkerTransport, which captured the (now-stale) token at
-    //      construction time (worker boot, before any per-run token existed)
-    //      and uses it for the terminal signalDone/signalError POSTs.
-    // The deployment token stays the boot/constructor credential (it's the only
-    // token available before the first turn); we only override it per-turn.
-    //
-    // Adopting through the manager also resets its TTL clock. The manager is
-    // the single source of truth for the live token: the transport's gateway
-    // POSTs read it via fetchWithRefresh, so a SINGLE turn running past the 2h
-    // TTL refreshes its token mid-turn (manager.refresh() →
-    // /worker/token/refresh, gated on deployment-liveness) and the terminal POST
-    // still uses a live token. process.env.WORKER_TOKEN is mirrored too, for the
-    // env-reading consumers (session-context, snapshot hydrate/clear, the
-    // audio-permission hint).
+    // Adopt the freshly-minted per-run runJobToken as this turn's live gateway
+    // credential. It's a strict superset of the spawn-time WORKER_TOKEN's claims
+    // (+ connectionId/source/runId) with a fresh timestamp, so it's non-expired
+    // even on a warm worker whose spawn-time token has aged past the 2h TTL
+    // (#1266). The manager becomes the single source of truth: the transport's
+    // POSTs read it via fetchWithRefresh, and it's mirrored into
+    // process.env.WORKER_TOKEN for the env-readers (session-context, snapshot
+    // hydrate/clear, the audio hint). The spawnHook still strips WORKER_TOKEN by
+    // KEY from agent bash, so mutating the env value is safe.
     adoptWorkerToken(this.config.runJobToken);
     // Timer-driven proactive refresh: renew the token before it hard-expires
     // even if this turn makes NO gateway call (the >2h single-turn case — an

--- a/packages/agent-worker/src/openclaw/worker.ts
+++ b/packages/agent-worker/src/openclaw/worker.ts
@@ -411,12 +411,19 @@ export class OpenClawWorker implements WorkerExecutor {
       // body.runId`, so the deployment-lifetime WORKER_TOKEN cannot be
       // used here — it would carry no `runId` and the route would 403.
       // Codex round 2 finding A.
-      const runJobToken = this.config.runJobToken;
-      if (gatewayUrl && runJobToken && typeof runId === "number") {
+      //
+      // `this.config.runJobToken` only PROVES this run had a per-run mint
+      // (legacy direct-enqueue runs have none → skip). The bearer we send
+      // is the LIVE token from the manager, not this captured original: a
+      // long turn may have refreshed it mid-run, in which case the original
+      // is already expired and would 401 here. The refreshed token carries
+      // the same `runId`, so the snapshot route's equality check still holds.
+      const hadPerRunToken = Boolean(this.config.runJobToken);
+      if (gatewayUrl && hadPerRunToken && typeof runId === "number") {
         await writeSnapshot({
           sessionFile: this.sessionFilePath,
           gatewayUrl,
-          workerToken: runJobToken,
+          workerToken: getWorkerTokenManager().getToken(),
           terminalStatus: this.terminalStatus,
           runId,
         });
@@ -543,7 +550,6 @@ export class OpenClawWorker implements WorkerExecutor {
       platform: this.config.platform,
       platformMetadata: this.config.platformMetadata,
       agentId: this.config.agentId,
-      runJobToken: this.config.runJobToken,
       workspaceDir: this.workspaceManager.getCurrentWorkingDirectory(),
       progressProcessor: this.progressProcessor,
       onSessionFilePathResolved: (filePath) => {

--- a/packages/core/src/worker/auth.ts
+++ b/packages/core/src/worker/auth.ts
@@ -50,6 +50,17 @@ export interface WorkerTokenData {
    * codex round 2, finding A on PR #865.
    */
   runId?: number;
+  /**
+   * Per-turn message id this token's work was dispatched for. Set alongside
+   * {@link runId} by the runs-queue dispatcher (MessageConsumer.handleMessage),
+   * which arms the turn-timeout marker with the SAME `messageId`. The token
+   * refresh gate uses it to require a live marker for THIS turn specifically
+   * (`deploymentName:messageId`), not merely any live turn on the deployment —
+   * otherwise a still-valid token from a completed turn could refresh while a
+   * later, unrelated turn on the same deployment is live. Long-lived deployment
+   * tokens do NOT carry it.
+   */
+  messageId?: string;
 }
 
 export function generateWorkerToken(
@@ -75,6 +86,12 @@ export function generateWorkerToken(
      * for the consumption contract.
      */
     runId?: number;
+    /**
+     * Per-turn message id, set alongside `runId` by the runs-queue dispatcher.
+     * Binds token refresh to this turn's own liveness marker. See
+     * WorkerTokenData.messageId.
+     */
+    messageId?: string;
   }
 ): string {
   if (!options.channelId) {
@@ -97,6 +114,7 @@ export function generateWorkerToken(
     traceId: options.traceId,
     jti: randomUUID(),
     runId: options.runId,
+    messageId: options.messageId,
   };
 
   return encrypt(JSON.stringify(payload));

--- a/packages/core/src/worker/transport.ts
+++ b/packages/core/src/worker/transport.ts
@@ -15,6 +15,19 @@ export interface WorkerTransport {
   setJobId(jobId: string): void;
 
   /**
+   * Swap the bearer token used for gateway calls.
+   *
+   * The transport is constructed at worker boot with the deployment-lifetime
+   * WORKER_TOKEN (the only token available before the first turn). That token
+   * expires after WORKER_TOKEN_TTL_MS (2h, #1266), but a warm worker can serve
+   * a conversation well past that window — its terminal `signalDone`/
+   * `signalError` POSTs would then 401. Each turn carries a freshly-minted
+   * per-run token (`runJobToken`); the worker swaps it in here at turn start so
+   * gateway calls always use a non-expired token.
+   */
+  setWorkerToken(workerToken: string): void;
+
+  /**
    * Send a streaming delta to the gateway
    *
    * @param delta - The content delta to send

--- a/packages/core/src/worker/transport.ts
+++ b/packages/core/src/worker/transport.ts
@@ -15,19 +15,6 @@ export interface WorkerTransport {
   setJobId(jobId: string): void;
 
   /**
-   * Swap the bearer token used for gateway calls.
-   *
-   * The transport is constructed at worker boot with the deployment-lifetime
-   * WORKER_TOKEN (the only token available before the first turn). That token
-   * expires after WORKER_TOKEN_TTL_MS (2h, #1266), but a warm worker can serve
-   * a conversation well past that window — its terminal `signalDone`/
-   * `signalError` POSTs would then 401. Each turn carries a freshly-minted
-   * per-run token (`runJobToken`); the worker swaps it in here at turn start so
-   * gateway calls always use a non-expired token.
-   */
-  setWorkerToken(workerToken: string): void;
-
-  /**
    * Send a streaming delta to the gateway
    *
    * @param delta - The content delta to send

--- a/packages/server/src/gateway/__tests__/turn-liveness.test.ts
+++ b/packages/server/src/gateway/__tests__/turn-liveness.test.ts
@@ -22,6 +22,7 @@ import {
   extendTurnDeadlines,
   failTurnIfPending,
   failTurnsForDeployment,
+  hasLiveTurnForDeployment,
   sweepExpiredTurns,
   type TurnRouting,
 } from "../orchestration/turn-liveness.js";
@@ -209,5 +210,75 @@ describe("turn-liveness", () => {
     await commitTerminalReply("dep-A", ["same"], reply("dep-A", "same"), null);
     expect(await markerCount("dep-A")).toBe(0);
     expect(await markerCount("dep-B")).toBe(1);
+  });
+});
+
+/**
+ * The deployment-liveness gate that authorizes worker-token refresh. A fresh
+ * token is minted ONLY while an in-flight turn-timeout marker exists for the
+ * deployment; once the work terminalizes the marker is gone and refresh is
+ * denied (the revocation property). These assert the gate tracks the marker
+ * across every production terminalization path, against real Postgres so the
+ * cross-pod authority (shared `public.runs`) is exercised, not mocked.
+ */
+describe("hasLiveTurnForDeployment (token-refresh liveness gate)", () => {
+  test("false when no turn has ever been armed", async () => {
+    expect(await hasLiveTurnForDeployment("dep-never")).toBe(false);
+  });
+
+  test("true while a turn is in-flight (armed, not discharged)", async () => {
+    await armTurnTimeout(queue, routing("dep-live", "m1"));
+    expect(await hasLiveTurnForDeployment("dep-live")).toBe(true);
+  });
+
+  test("REFRESH DENIED: false after the turn terminalizes via a real reply", async () => {
+    await armTurnTimeout(queue, routing("dep-reply", "m1"));
+    expect(await hasLiveTurnForDeployment("dep-reply")).toBe(true);
+
+    // Worker replied → commitTerminalReply deletes the marker. Refresh must now
+    // be denied — the token chain ends with the work.
+    await commitTerminalReply(
+      "dep-reply",
+      ["m1"],
+      reply("dep-reply", "m1"),
+      null
+    );
+    expect(await hasLiveTurnForDeployment("dep-reply")).toBe(false);
+  });
+
+  test("REFRESH DENIED: false after the worker dies (fast path)", async () => {
+    await armTurnTimeout(queue, routing("dep-dead", "m1"));
+    expect(await hasLiveTurnForDeployment("dep-dead")).toBe(true);
+
+    await failTurnsForDeployment("dep-dead", "worker died");
+    expect(await hasLiveTurnForDeployment("dep-dead")).toBe(false);
+  });
+
+  test("REFRESH DENIED: false after the deadline lapses and is swept (hung worker)", async () => {
+    await armTurnTimeout(queue, routing("dep-hung", "m1"));
+    expect(await hasLiveTurnForDeployment("dep-hung")).toBe(true);
+
+    await expireAllMarkers();
+    await sweepExpiredTurns();
+    expect(await hasLiveTurnForDeployment("dep-hung")).toBe(false);
+  });
+
+  test(">2h single turn stays refreshable: heartbeat extends keep the gate true past the original deadline", async () => {
+    await armTurnTimeout(queue, routing("dep-long", "m1"));
+    // Simulate the original deadline having passed...
+    await expireAllMarkers();
+    // ...but the worker's heartbeat pushed the deadline forward before any sweep.
+    await extendTurnDeadlines("dep-long");
+    // The marker is still pending → a legitimately-long turn can still refresh.
+    expect(await hasLiveTurnForDeployment("dep-long")).toBe(true);
+    // And a sweep does NOT terminalize it (deadline is in the future again).
+    await sweepExpiredTurns();
+    expect(await hasLiveTurnForDeployment("dep-long")).toBe(true);
+  });
+
+  test("scoped per deployment: one deployment's live turn doesn't authorize another", async () => {
+    await armTurnTimeout(queue, routing("dep-X", "m1"));
+    expect(await hasLiveTurnForDeployment("dep-X")).toBe(true);
+    expect(await hasLiveTurnForDeployment("dep-Y")).toBe(false);
   });
 });

--- a/packages/server/src/gateway/__tests__/turn-liveness.test.ts
+++ b/packages/server/src/gateway/__tests__/turn-liveness.test.ts
@@ -214,12 +214,13 @@ describe("turn-liveness", () => {
 });
 
 /**
- * The deployment-liveness gate that authorizes worker-token refresh. A fresh
+ * The per-turn liveness gate that authorizes worker-token refresh. A fresh
  * token is minted ONLY while an in-flight turn-timeout marker exists for the
- * deployment; once the work terminalizes the marker is gone and refresh is
- * denied (the revocation property). These assert the gate tracks the marker
- * across every production terminalization path, against real Postgres so the
- * cross-pod authority (shared `public.runs`) is exercised, not mocked.
+ * token's own turn (deployment + messageId); once that turn terminalizes the
+ * marker is gone and refresh is denied (the revocation property). These assert
+ * the gate tracks the marker across every production terminalization path,
+ * against real Postgres so the cross-pod authority (shared `public.runs`) is
+ * exercised, not mocked.
  */
 describe("hasLiveTurnForMessage (token-refresh liveness gate)", () => {
   test("false when no turn has ever been armed", async () => {

--- a/packages/server/src/gateway/__tests__/turn-liveness.test.ts
+++ b/packages/server/src/gateway/__tests__/turn-liveness.test.ts
@@ -22,7 +22,7 @@ import {
   extendTurnDeadlines,
   failTurnIfPending,
   failTurnsForDeployment,
-  hasLiveTurnForDeployment,
+  hasLiveTurnForMessage,
   sweepExpiredTurns,
   type TurnRouting,
 } from "../orchestration/turn-liveness.js";
@@ -221,19 +221,19 @@ describe("turn-liveness", () => {
  * across every production terminalization path, against real Postgres so the
  * cross-pod authority (shared `public.runs`) is exercised, not mocked.
  */
-describe("hasLiveTurnForDeployment (token-refresh liveness gate)", () => {
+describe("hasLiveTurnForMessage (token-refresh liveness gate)", () => {
   test("false when no turn has ever been armed", async () => {
-    expect(await hasLiveTurnForDeployment("dep-never")).toBe(false);
+    expect(await hasLiveTurnForMessage("dep-never", "m1")).toBe(false);
   });
 
   test("true while a turn is in-flight (armed, not discharged)", async () => {
     await armTurnTimeout(queue, routing("dep-live", "m1"));
-    expect(await hasLiveTurnForDeployment("dep-live")).toBe(true);
+    expect(await hasLiveTurnForMessage("dep-live", "m1")).toBe(true);
   });
 
   test("REFRESH DENIED: false after the turn terminalizes via a real reply", async () => {
     await armTurnTimeout(queue, routing("dep-reply", "m1"));
-    expect(await hasLiveTurnForDeployment("dep-reply")).toBe(true);
+    expect(await hasLiveTurnForMessage("dep-reply", "m1")).toBe(true);
 
     // Worker replied → commitTerminalReply deletes the marker. Refresh must now
     // be denied — the token chain ends with the work.
@@ -243,15 +243,15 @@ describe("hasLiveTurnForDeployment (token-refresh liveness gate)", () => {
       reply("dep-reply", "m1"),
       null
     );
-    expect(await hasLiveTurnForDeployment("dep-reply")).toBe(false);
+    expect(await hasLiveTurnForMessage("dep-reply", "m1")).toBe(false);
   });
 
   test("REFRESH DENIED: false after the worker dies (fast path)", async () => {
     await armTurnTimeout(queue, routing("dep-dead", "m1"));
-    expect(await hasLiveTurnForDeployment("dep-dead")).toBe(true);
+    expect(await hasLiveTurnForMessage("dep-dead", "m1")).toBe(true);
 
     await failTurnsForDeployment("dep-dead", "worker died");
-    expect(await hasLiveTurnForDeployment("dep-dead")).toBe(false);
+    expect(await hasLiveTurnForMessage("dep-dead", "m1")).toBe(false);
   });
 
   test("REFRESH DENIED: false for a lapsed-but-UNSWEPT marker (post-deadline, pre-sweep gap)", async () => {
@@ -260,24 +260,24 @@ describe("hasLiveTurnForDeployment (token-refresh liveness gate)", () => {
     // stopped heartbeating. The gate must NOT authorize refresh here: liveness is
     // the deadline (heartbeat), not whether the sweep has run yet.
     await armTurnTimeout(queue, routing("dep-lapsed", "m1"));
-    expect(await hasLiveTurnForDeployment("dep-lapsed")).toBe(true);
+    expect(await hasLiveTurnForMessage("dep-lapsed", "m1")).toBe(true);
 
     await expireAllMarkers(); // run_at → past, WITHOUT sweeping (row still pending)
     expect(await markerCount("dep-lapsed")).toBe(1); // row not deleted
-    expect(await hasLiveTurnForDeployment("dep-lapsed")).toBe(false);
+    expect(await hasLiveTurnForMessage("dep-lapsed", "m1")).toBe(false);
 
     // And a live heartbeat extend brings it back (legitimately-long turn).
     await extendTurnDeadlines("dep-lapsed");
-    expect(await hasLiveTurnForDeployment("dep-lapsed")).toBe(true);
+    expect(await hasLiveTurnForMessage("dep-lapsed", "m1")).toBe(true);
   });
 
   test("REFRESH DENIED: false after the deadline lapses and is swept (hung worker)", async () => {
     await armTurnTimeout(queue, routing("dep-hung", "m1"));
-    expect(await hasLiveTurnForDeployment("dep-hung")).toBe(true);
+    expect(await hasLiveTurnForMessage("dep-hung", "m1")).toBe(true);
 
     await expireAllMarkers();
     await sweepExpiredTurns();
-    expect(await hasLiveTurnForDeployment("dep-hung")).toBe(false);
+    expect(await hasLiveTurnForMessage("dep-hung", "m1")).toBe(false);
   });
 
   test(">2h single turn stays refreshable: heartbeat extends keep the gate true past the original deadline", async () => {
@@ -287,15 +287,39 @@ describe("hasLiveTurnForDeployment (token-refresh liveness gate)", () => {
     // ...but the worker's heartbeat pushed the deadline forward before any sweep.
     await extendTurnDeadlines("dep-long");
     // The marker is still pending → a legitimately-long turn can still refresh.
-    expect(await hasLiveTurnForDeployment("dep-long")).toBe(true);
+    expect(await hasLiveTurnForMessage("dep-long", "m1")).toBe(true);
     // And a sweep does NOT terminalize it (deadline is in the future again).
     await sweepExpiredTurns();
-    expect(await hasLiveTurnForDeployment("dep-long")).toBe(true);
+    expect(await hasLiveTurnForMessage("dep-long", "m1")).toBe(true);
   });
 
   test("scoped per deployment: one deployment's live turn doesn't authorize another", async () => {
     await armTurnTimeout(queue, routing("dep-X", "m1"));
-    expect(await hasLiveTurnForDeployment("dep-X")).toBe(true);
-    expect(await hasLiveTurnForDeployment("dep-Y")).toBe(false);
+    expect(await hasLiveTurnForMessage("dep-X", "m1")).toBe(true);
+    expect(await hasLiveTurnForMessage("dep-Y", "m1")).toBe(false);
+  });
+
+  test("CROSS-TURN LEAK CLOSED: a completed turn's token can't refresh while a LATER turn on the same deployment is live", async () => {
+    // Turn 1 (messageId m1) and turn 2 (messageId m2) on the SAME deployment.
+    // Both armed → both live.
+    await armTurnTimeout(queue, routing("dep-multi", "m1"));
+    await armTurnTimeout(queue, routing("dep-multi", "m2"));
+    expect(await hasLiveTurnForMessage("dep-multi", "m1")).toBe(true);
+    expect(await hasLiveTurnForMessage("dep-multi", "m2")).toBe(true);
+
+    // Turn 1 completes (its marker is deleted) while turn 2 is STILL live.
+    await commitTerminalReply(
+      "dep-multi",
+      ["m1"],
+      reply("dep-multi", "m1"),
+      null
+    );
+
+    // The KEY assertion: turn 1's (still-valid) token can no longer refresh,
+    // even though the deployment has a live turn (m2). A per-deployment gate
+    // would have wrongly returned true here — the privilege leak across runs.
+    expect(await hasLiveTurnForMessage("dep-multi", "m1")).toBe(false);
+    // Turn 2's own token still refreshes (its turn is genuinely live).
+    expect(await hasLiveTurnForMessage("dep-multi", "m2")).toBe(true);
   });
 });

--- a/packages/server/src/gateway/__tests__/turn-liveness.test.ts
+++ b/packages/server/src/gateway/__tests__/turn-liveness.test.ts
@@ -254,6 +254,23 @@ describe("hasLiveTurnForDeployment (token-refresh liveness gate)", () => {
     expect(await hasLiveTurnForDeployment("dep-dead")).toBe(false);
   });
 
+  test("REFRESH DENIED: false for a lapsed-but-UNSWEPT marker (post-deadline, pre-sweep gap)", async () => {
+    // The marker row still exists with status='pending' (the sweep runs only on
+    // its periodic tick), but its deadline has passed — a hung/dead worker that
+    // stopped heartbeating. The gate must NOT authorize refresh here: liveness is
+    // the deadline (heartbeat), not whether the sweep has run yet.
+    await armTurnTimeout(queue, routing("dep-lapsed", "m1"));
+    expect(await hasLiveTurnForDeployment("dep-lapsed")).toBe(true);
+
+    await expireAllMarkers(); // run_at → past, WITHOUT sweeping (row still pending)
+    expect(await markerCount("dep-lapsed")).toBe(1); // row not deleted
+    expect(await hasLiveTurnForDeployment("dep-lapsed")).toBe(false);
+
+    // And a live heartbeat extend brings it back (legitimately-long turn).
+    await extendTurnDeadlines("dep-lapsed");
+    expect(await hasLiveTurnForDeployment("dep-lapsed")).toBe(true);
+  });
+
   test("REFRESH DENIED: false after the deadline lapses and is swept (hung worker)", async () => {
     await armTurnTimeout(queue, routing("dep-hung", "m1"));
     expect(await hasLiveTurnForDeployment("dep-hung")).toBe(true);

--- a/packages/server/src/gateway/__tests__/worker-token-refresh-route.test.ts
+++ b/packages/server/src/gateway/__tests__/worker-token-refresh-route.test.ts
@@ -1,0 +1,177 @@
+/**
+ * Integration tests for the worker-token refresh endpoint
+ * (`POST /worker/token/refresh`) against a real Postgres (embedded PG18 in CI).
+ *
+ * The endpoint mints a fresh 2h worker token from a currently-valid one, gated
+ * on deployment-liveness: a fresh token is issued ONLY while an in-flight
+ * turn-timeout marker exists for the token's deployment (the cross-pod-
+ * authoritative liveness signal in shared `public.runs`). When the work goes
+ * terminal the marker is gone and refresh is DENIED — that denial is the
+ * revocation property (a leaked token's chain ends with its work).
+ *
+ * The liveness gate itself (across every terminalization path) is unit-tested
+ * in turn-liveness.test.ts; this file is the end-to-end route surface: auth,
+ * the runId-eligibility gate, the liveness gate, and the minted-token claims.
+ */
+
+import {
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from "bun:test";
+import { generateWorkerToken, verifyWorkerToken } from "@lobu/core";
+import { RunsQueue } from "../infrastructure/queue/runs-queue.js";
+import {
+  armTurnTimeout,
+  failTurnsForDeployment,
+} from "../orchestration/turn-liveness.js";
+import { WorkerGateway } from "../gateway/index.js";
+import {
+  ensureDbForGatewayTests,
+  resetTestDatabase,
+  seedAgentRow,
+} from "./helpers/db-setup.js";
+
+const TEST_ENCRYPTION_KEY = Buffer.from(
+  "12345678901234567890123456789012"
+).toString("base64");
+
+let queue: RunsQueue;
+const previousEncryptionKey = process.env.ENCRYPTION_KEY;
+
+beforeAll(async () => {
+  await ensureDbForGatewayTests();
+});
+
+beforeEach(async () => {
+  process.env.ENCRYPTION_KEY = TEST_ENCRYPTION_KEY;
+  await resetTestDatabase();
+  // The runs FK requires the organization to exist before arming a marker.
+  await seedAgentRow("agent-1", { organizationId: "org-1" });
+  queue = new RunsQueue();
+  await queue.start();
+});
+
+afterEach(async () => {
+  await queue.stop();
+  if (previousEncryptionKey === undefined) delete process.env.ENCRYPTION_KEY;
+  else process.env.ENCRYPTION_KEY = previousEncryptionKey;
+});
+
+/** Construct a WorkerGateway with stub deps — the refresh route only touches
+ *  the DB (liveness gate + revoked-token store) and the token codec, none of
+ *  the session-context / MCP collaborators. */
+function makeGateway(): WorkerGateway {
+  return new WorkerGateway(
+    queue as any,
+    "https://gateway.example.com",
+    { getWorkerConfig: async () => ({ mcpServers: {} }) } as any,
+    {
+      getSessionContext: async () => ({
+        agentInstructions: "",
+        platformInstructions: "",
+        networkInstructions: "",
+        skillsInstructions: "",
+        mcpStatus: [],
+      }),
+    } as any
+  );
+}
+
+async function postRefresh(token: string) {
+  return makeGateway()
+    .getApp()
+    .request("/token/refresh", {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${token}`,
+        host: "gateway.example.com",
+      },
+    });
+}
+
+const DEPLOYMENT = "lobu-worker-agent-1";
+
+function mintToken(opts: { runId?: number }): string {
+  return generateWorkerToken("user-1", "conv-1", DEPLOYMENT, {
+    channelId: "chan-1",
+    agentId: "agent-1",
+    organizationId: "org-1",
+    connectionId: "connection-1",
+    source: "watcher-run",
+    runId: opts.runId,
+  });
+}
+
+function armLiveTurn(): Promise<void> {
+  return armTurnTimeout(queue, {
+    messageId: "m1",
+    channelId: "chan-1",
+    conversationId: "conv-1",
+    userId: "user-1",
+    platform: "api",
+    deploymentName: DEPLOYMENT,
+    organizationId: "org-1",
+  });
+}
+
+describe("POST /worker/token/refresh", () => {
+  test("mints a fresh token while the deployment has a live turn", async () => {
+    await armLiveTurn();
+    const original = mintToken({ runId: 42 });
+
+    const res = await postRefresh(original);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { token: string };
+    expect(typeof body.token).toBe("string");
+    expect(body.token).not.toBe(original);
+
+    // Fresh token verifies and preserves the claims (incl. runId, connectionId,
+    // source — the superset the per-run token carries).
+    const data = verifyWorkerToken(body.token);
+    expect(data).not.toBeNull();
+    expect(data!.runId).toBe(42);
+    expect(data!.connectionId).toBe("connection-1");
+    expect(data!.source).toBe("watcher-run");
+    expect(data!.deploymentName).toBe(DEPLOYMENT);
+    expect(data!.organizationId).toBe("org-1");
+  });
+
+  test("REVOCATION: denied (403) once the deployment has no live turn", async () => {
+    // No armed turn → the deployment is not live → refresh must be refused.
+    const original = mintToken({ runId: 42 });
+    const res = await postRefresh(original);
+    expect(res.status).toBe(403);
+  });
+
+  test("REVOCATION: a token that was refreshable becomes non-refreshable after the turn terminalizes", async () => {
+    await armLiveTurn();
+    const original = mintToken({ runId: 42 });
+
+    // First refresh succeeds while live.
+    expect((await postRefresh(original)).status).toBe(200);
+
+    // The worker dies / replies → marker discharged. Use the fast path to
+    // simulate terminalization, then refresh must be denied.
+    await failTurnsForDeployment(DEPLOYMENT, "worker died");
+
+    const res = await postRefresh(original);
+    expect(res.status).toBe(403);
+  });
+
+  test("denied (403) for a token with no runId (legacy direct-enqueue, no marker to gate on)", async () => {
+    await armLiveTurn();
+    const noRunId = mintToken({}); // runId omitted
+    const res = await postRefresh(noRunId);
+    expect(res.status).toBe(403);
+  });
+
+  test("rejected (401) for a malformed / unverifiable token", async () => {
+    await armLiveTurn();
+    const res = await postRefresh("not-a-real-token");
+    expect(res.status).toBe(401);
+  });
+});

--- a/packages/server/src/gateway/__tests__/worker-token-refresh-route.test.ts
+++ b/packages/server/src/gateway/__tests__/worker-token-refresh-route.test.ts
@@ -174,4 +174,28 @@ describe("POST /worker/token/refresh", () => {
     const res = await postRefresh("not-a-real-token");
     expect(res.status).toBe(401);
   });
+
+  test("SECURITY: an already-EXPIRED token cannot refresh even while the turn is live", async () => {
+    // This bounds the leak window: refresh must travel with a still-valid
+    // bearer. verifyWorkerToken (inside authenticateWorker) rejects an expired
+    // token BEFORE the liveness gate, so an attacker who grabs an expired token
+    // cannot resurrect it via refresh, live deployment or not.
+    await armLiveTurn();
+    const prevTtl = process.env.WORKER_TOKEN_TTL_MS;
+    const prevSkew = process.env.WORKER_TOKEN_CLOCK_SKEW_MS;
+    process.env.WORKER_TOKEN_TTL_MS = "1"; // 1ms TTL
+    process.env.WORKER_TOKEN_CLOCK_SKEW_MS = "0";
+    try {
+      const expired = mintToken({ runId: 42 });
+      // Past TTL + skew (1ms + 0ms).
+      await new Promise((r) => setTimeout(r, 10));
+      const res = await postRefresh(expired);
+      expect(res.status).toBe(401);
+    } finally {
+      if (prevTtl === undefined) delete process.env.WORKER_TOKEN_TTL_MS;
+      else process.env.WORKER_TOKEN_TTL_MS = prevTtl;
+      if (prevSkew === undefined) delete process.env.WORKER_TOKEN_CLOCK_SKEW_MS;
+      else process.env.WORKER_TOKEN_CLOCK_SKEW_MS = prevSkew;
+    }
+  });
 });

--- a/packages/server/src/gateway/__tests__/worker-token-refresh-route.test.ts
+++ b/packages/server/src/gateway/__tests__/worker-token-refresh-route.test.ts
@@ -3,15 +3,17 @@
  * (`POST /worker/token/refresh`) against a real Postgres (embedded PG18 in CI).
  *
  * The endpoint mints a fresh 2h worker token from a currently-valid one, gated
- * on deployment-liveness: a fresh token is issued ONLY while an in-flight
- * turn-timeout marker exists for the token's deployment (the cross-pod-
- * authoritative liveness signal in shared `public.runs`). When the work goes
- * terminal the marker is gone and refresh is DENIED — that denial is the
- * revocation property (a leaked token's chain ends with its work).
+ * on PER-TURN liveness: a fresh token is issued ONLY while an in-flight
+ * turn-timeout marker exists for the token's OWN turn — `(deploymentName,
+ * messageId)`, the cross-pod-authoritative liveness signal in shared
+ * `public.runs`. When THAT turn goes terminal the marker is gone and refresh is
+ * DENIED — even if a later, unrelated turn on the same deployment is live. That
+ * denial is the revocation property (a leaked token's chain ends with its turn).
  *
  * The liveness gate itself (across every terminalization path) is unit-tested
  * in turn-liveness.test.ts; this file is the end-to-end route surface: auth,
- * the runId-eligibility gate, the liveness gate, and the minted-token claims.
+ * the runId/messageId-eligibility gate, the per-turn liveness gate, and the
+ * minted-token claims.
  */
 
 import {
@@ -26,6 +28,7 @@ import { generateWorkerToken, verifyWorkerToken } from "@lobu/core";
 import { RunsQueue } from "../infrastructure/queue/runs-queue.js";
 import {
   armTurnTimeout,
+  commitTerminalReply,
   failTurnsForDeployment,
 } from "../orchestration/turn-liveness.js";
 import { WorkerGateway } from "../gateway/index.js";
@@ -95,7 +98,7 @@ async function postRefresh(token: string) {
 
 const DEPLOYMENT = "lobu-worker-agent-1";
 
-function mintToken(opts: { runId?: number }): string {
+function mintToken(opts: { runId?: number; messageId?: string }): string {
   return generateWorkerToken("user-1", "conv-1", DEPLOYMENT, {
     channelId: "chan-1",
     agentId: "agent-1",
@@ -103,12 +106,13 @@ function mintToken(opts: { runId?: number }): string {
     connectionId: "connection-1",
     source: "watcher-run",
     runId: opts.runId,
+    messageId: opts.messageId,
   });
 }
 
-function armLiveTurn(): Promise<void> {
+function armLiveTurn(messageId = "m1"): Promise<void> {
   return armTurnTimeout(queue, {
-    messageId: "m1",
+    messageId,
     channelId: "chan-1",
     conversationId: "conv-1",
     userId: "user-1",
@@ -119,9 +123,9 @@ function armLiveTurn(): Promise<void> {
 }
 
 describe("POST /worker/token/refresh", () => {
-  test("mints a fresh token while the deployment has a live turn", async () => {
-    await armLiveTurn();
-    const original = mintToken({ runId: 42 });
+  test("mints a fresh token while THIS turn is live", async () => {
+    await armLiveTurn("m1");
+    const original = mintToken({ runId: 42, messageId: "m1" });
 
     const res = await postRefresh(original);
     expect(res.status).toBe(200);
@@ -129,27 +133,30 @@ describe("POST /worker/token/refresh", () => {
     expect(typeof body.token).toBe("string");
     expect(body.token).not.toBe(original);
 
-    // Fresh token verifies and preserves the claims (incl. runId, connectionId,
-    // source — the superset the per-run token carries).
+    // Fresh token verifies and preserves the claims (incl. runId, messageId,
+    // connectionId, source — the superset the per-run token carries). The
+    // messageId MUST be preserved or the refreshed token couldn't itself be
+    // refreshed again (its own turn-liveness gate would have nothing to match).
     const data = verifyWorkerToken(body.token);
     expect(data).not.toBeNull();
     expect(data!.runId).toBe(42);
+    expect(data!.messageId).toBe("m1");
     expect(data!.connectionId).toBe("connection-1");
     expect(data!.source).toBe("watcher-run");
     expect(data!.deploymentName).toBe(DEPLOYMENT);
     expect(data!.organizationId).toBe("org-1");
   });
 
-  test("REVOCATION: denied (403) once the deployment has no live turn", async () => {
-    // No armed turn → the deployment is not live → refresh must be refused.
-    const original = mintToken({ runId: 42 });
+  test("REVOCATION: denied (403) once this turn has no live marker", async () => {
+    // No armed turn → the turn is not live → refresh must be refused.
+    const original = mintToken({ runId: 42, messageId: "m1" });
     const res = await postRefresh(original);
     expect(res.status).toBe(403);
   });
 
   test("REVOCATION: a token that was refreshable becomes non-refreshable after the turn terminalizes", async () => {
-    await armLiveTurn();
-    const original = mintToken({ runId: 42 });
+    await armLiveTurn("m1");
+    const original = mintToken({ runId: 42, messageId: "m1" });
 
     // First refresh succeeds while live.
     expect((await postRefresh(original)).status).toBe(200);
@@ -162,10 +169,45 @@ describe("POST /worker/token/refresh", () => {
     expect(res.status).toBe(403);
   });
 
+  test("CROSS-TURN LEAK CLOSED: a COMPLETED turn's token is denied (403) even while a LATER turn on the same deployment is live", async () => {
+    // Two turns on the SAME deployment. Turn 1 = m1, turn 2 = m2.
+    await armLiveTurn("m1");
+    await armLiveTurn("m2");
+    const turn1Token = mintToken({ runId: 1, messageId: "m1" });
+
+    // Turn 1's token can refresh while turn 1 is live.
+    expect((await postRefresh(turn1Token)).status).toBe(200);
+
+    // Turn 1 COMPLETES (its marker is deleted) while turn 2 (m2) is STILL live.
+    await commitTerminalReply(
+      DEPLOYMENT,
+      ["m1"],
+      { messageId: "m1", deploymentName: DEPLOYMENT },
+      "org-1"
+    );
+
+    // The KEY security assertion: turn 1's still-valid token is now DENIED, even
+    // though the deployment has a live turn (m2). A per-deployment gate would
+    // have wrongly minted a fresh token here (privilege leak across runs).
+    const res = await postRefresh(turn1Token);
+    expect(res.status).toBe(403);
+
+    // Turn 2's own token still refreshes (its turn is genuinely live).
+    const turn2Token = mintToken({ runId: 2, messageId: "m2" });
+    expect((await postRefresh(turn2Token)).status).toBe(200);
+  });
+
   test("denied (403) for a token with no runId (legacy direct-enqueue, no marker to gate on)", async () => {
-    await armLiveTurn();
-    const noRunId = mintToken({}); // runId omitted
+    await armLiveTurn("m1");
+    const noRunId = mintToken({ messageId: "m1" }); // runId omitted
     const res = await postRefresh(noRunId);
+    expect(res.status).toBe(403);
+  });
+
+  test("denied (403) for a token with no messageId (no per-turn marker to gate on)", async () => {
+    await armLiveTurn("m1");
+    const noMessageId = mintToken({ runId: 42 }); // messageId omitted
+    const res = await postRefresh(noMessageId);
     expect(res.status).toBe(403);
   });
 
@@ -186,7 +228,7 @@ describe("POST /worker/token/refresh", () => {
     process.env.WORKER_TOKEN_TTL_MS = "1"; // 1ms TTL
     process.env.WORKER_TOKEN_CLOCK_SKEW_MS = "0";
     try {
-      const expired = mintToken({ runId: 42 });
+      const expired = mintToken({ runId: 42, messageId: "m1" });
       // Past TTL + skew (1ms + 0ms).
       await new Promise((r) => setTimeout(r, 10));
       const res = await postRefresh(expired);

--- a/packages/server/src/gateway/__tests__/worker-token-refresh-route.test.ts
+++ b/packages/server/src/gateway/__tests__/worker-token-refresh-route.test.ts
@@ -85,15 +85,20 @@ function makeGateway(): WorkerGateway {
 }
 
 async function postRefresh(token: string) {
-  return makeGateway()
-    .getApp()
-    .request("/token/refresh", {
+  // shutdown() in a finally so the gateway's timers/intervals don't leak across
+  // tests (which can wedge the runner into a hang).
+  const gateway = makeGateway();
+  try {
+    return await gateway.getApp().request("/token/refresh", {
       method: "POST",
       headers: {
         authorization: `Bearer ${token}`,
         host: "gateway.example.com",
       },
     });
+  } finally {
+    gateway.shutdown();
+  }
 }
 
 const DEPLOYMENT = "lobu-worker-agent-1";

--- a/packages/server/src/gateway/gateway/index.ts
+++ b/packages/server/src/gateway/gateway/index.ts
@@ -28,7 +28,7 @@ import type { IMessageQueue } from "../infrastructure/queue/index.js";
 import {
   commitTerminalReply,
   extendTurnDeadlines,
-  hasLiveTurnForDeployment,
+  hasLiveTurnForMessage,
 } from "../orchestration/turn-liveness.js";
 import type { InstructionService } from "../services/instruction-service.js";
 import type { AgentSettingsStore } from "../auth/settings/agent-settings-store.js";
@@ -698,23 +698,29 @@ export class WorkerGateway {
    * This endpoint lets the worker swap its in-flight token for a fresh 2h one
    * with the SAME claims, without lengthening the TTL.
    *
-   * The revocation model is deployment-liveness (a user-confirmed decision): we
-   * mint a fresh token ONLY while {@link hasLiveTurnForDeployment} reports an
-   * in-flight turn-timeout marker for the token's `deploymentName`. The marker
-   * is the cross-pod-authoritative liveness signal (shared `public.runs`, the
-   * same row every terminalization path deletes atomically). When the work goes
-   * terminal the marker is gone, refresh is denied, and the chain dies — so the
-   * leak window is bounded by how long the work actually runs, not by an
-   * unbounded refresh chain. A leaked-but-expired token can't refresh
-   * (verifyWorkerToken rejects it first), and a jti-revoked token can't refresh
-   * (the revoked-token check below). The fresh token gets its OWN jti, so it can
-   * be independently revoked.
+   * The revocation model is PER-TURN liveness: we mint a fresh token ONLY while
+   * {@link hasLiveTurnForMessage} reports an in-flight turn-timeout marker for
+   * the token's OWN turn — `(deploymentName, messageId)`, not merely any live
+   * turn on the deployment. The marker and the token are minted together at
+   * dispatch (MessageConsumer.handleMessage) carrying the same `messageId`, and
+   * the marker is the cross-pod-authoritative liveness signal (shared
+   * `public.runs`, the same row every terminalization path deletes atomically).
+   * When THIS turn goes terminal the marker is gone, refresh is denied, and the
+   * chain dies — so the leak window is bounded by how long this turn actually
+   * runs, not by an unbounded refresh chain. Gating per-turn (not per-deployment)
+   * closes the cross-turn leak: a still-valid token from a COMPLETED turn cannot
+   * refresh while a later, unrelated turn on the same deployment is live (that
+   * turn's marker has a different messageId). A leaked-but-expired token can't
+   * refresh (verifyWorkerToken rejects it first), and a jti-revoked token can't
+   * refresh (the revoked-token check below). The fresh token gets its OWN jti,
+   * so it can be independently revoked.
    *
-   * Tokens with no `runId` (legacy direct-enqueue path) are denied: they don't
-   * go through the runs-queue dispatch that arms a turn-timeout marker, so there
-   * is no liveness signal to gate on. Those workers keep using their deployment
-   * token (and the warm-worker-across-turns case is already covered by the
-   * per-turn fresh-token adoption — each turn mints a new token).
+   * Tokens with no `runId`/`messageId` (legacy direct-enqueue path) are denied:
+   * they don't go through the runs-queue dispatch that arms a turn-timeout
+   * marker, so there is no per-turn liveness signal to gate on. Those workers
+   * keep using their deployment token (and the warm-worker-across-turns case is
+   * already covered by the per-turn fresh-token adoption — each turn mints a new
+   * token).
    */
   private async handleTokenRefresh(c: Context): Promise<Response> {
     const auth = await this.authenticateWorker(c);
@@ -726,9 +732,9 @@ export class WorkerGateway {
     }
     const { tokenData } = auth;
 
-    // No runId → no turn-timeout marker exists for this token's work, so we
-    // have no liveness signal. Deny rather than mint blind.
-    if (typeof tokenData.runId !== "number") {
+    // No runId/messageId → no turn-timeout marker exists for this token's work,
+    // so we have no per-turn liveness signal. Deny rather than mint blind.
+    if (typeof tokenData.runId !== "number" || !tokenData.messageId) {
       return c.json({ error: "Token not eligible for refresh" }, 403);
     }
 
@@ -736,16 +742,25 @@ export class WorkerGateway {
       return c.json({ error: "Token missing deployment scope" }, 400);
     }
 
-    const live = await hasLiveTurnForDeployment(tokenData.deploymentName);
+    const live = await hasLiveTurnForMessage(
+      tokenData.deploymentName,
+      tokenData.messageId
+    );
     if (!live) {
-      // The deployment has no in-flight turn — the work is terminal (reply
-      // committed, worker died, or deadline swept). Refusing here is the
-      // revocation property: the token chain ends with the work.
+      // THIS token's turn has no in-flight marker — the turn is terminal (reply
+      // committed, worker died, or deadline swept), even if a later unrelated
+      // turn on the same deployment is still live. Refusing here is the
+      // revocation property: the token chain ends with the turn it was minted
+      // for, so a completed turn's token can't piggyback on a newer turn.
       logger.info(
-        { deploymentName: tokenData.deploymentName, runId: tokenData.runId },
-        "Token refresh denied: no live turn for deployment"
+        {
+          deploymentName: tokenData.deploymentName,
+          runId: tokenData.runId,
+          messageId: tokenData.messageId,
+        },
+        "Token refresh denied: no live turn for this message"
       );
-      return c.json({ error: "No live turn for deployment" }, 403);
+      return c.json({ error: "No live turn for token" }, 403);
     }
 
     // Mint a fresh token with identical claims (fresh timestamp + new jti).
@@ -764,11 +779,16 @@ export class WorkerGateway {
         sessionKey: tokenData.sessionKey,
         traceId: tokenData.traceId,
         runId: tokenData.runId,
+        messageId: tokenData.messageId,
       }
     );
 
     logger.info(
-      { deploymentName: tokenData.deploymentName, runId: tokenData.runId },
+      {
+        deploymentName: tokenData.deploymentName,
+        runId: tokenData.runId,
+        messageId: tokenData.messageId,
+      },
       "Issued refreshed worker token"
     );
     return c.json({ token: refreshed });

--- a/packages/server/src/gateway/gateway/index.ts
+++ b/packages/server/src/gateway/gateway/index.ts
@@ -686,41 +686,18 @@ export class WorkerGateway {
   }
 
   /**
-   * Mint a fresh worker token from a currently-valid one, gated on
-   * deployment-liveness.
+   * Mint a fresh same-claims token from a currently-valid one, so a >2h turn
+   * doesn't die when its token hits the 2h TTL (the short TTL is the leak-
+   * revocation path; this swaps the token without lengthening it).
    *
-   * Why this exists: the deployment-lifetime WORKER_TOKEN is minted once at
-   * subprocess spawn and the per-run token once per message; both carry a fixed
-   * `timestamp` and expire 2h later (WORKER_TOKEN_TTL_MS, an intentional
-   * security property — the short TTL is the leak-revocation path). A worker can
-   * legitimately outlive that window: a single turn running >2h (long
-   * autonomous / watcher run) would see even its per-run token expire mid-turn.
-   * This endpoint lets the worker swap its in-flight token for a fresh 2h one
-   * with the SAME claims, without lengthening the TTL.
-   *
-   * The revocation model is PER-TURN liveness: we mint a fresh token ONLY while
-   * {@link hasLiveTurnForMessage} reports an in-flight turn-timeout marker for
-   * the token's OWN turn — `(deploymentName, messageId)`, not merely any live
-   * turn on the deployment. The marker and the token are minted together at
-   * dispatch (MessageConsumer.handleMessage) carrying the same `messageId`, and
-   * the marker is the cross-pod-authoritative liveness signal (shared
-   * `public.runs`, the same row every terminalization path deletes atomically).
-   * When THIS turn goes terminal the marker is gone, refresh is denied, and the
-   * chain dies — so the leak window is bounded by how long this turn actually
-   * runs, not by an unbounded refresh chain. Gating per-turn (not per-deployment)
-   * closes the cross-turn leak: a still-valid token from a COMPLETED turn cannot
-   * refresh while a later, unrelated turn on the same deployment is live (that
-   * turn's marker has a different messageId). A leaked-but-expired token can't
-   * refresh (verifyWorkerToken rejects it first), and a jti-revoked token can't
-   * refresh (the revoked-token check below). The fresh token gets its OWN jti,
-   * so it can be independently revoked.
-   *
-   * Tokens with no `runId`/`messageId` (legacy direct-enqueue path) are denied:
-   * they don't go through the runs-queue dispatch that arms a turn-timeout
-   * marker, so there is no per-turn liveness signal to gate on. Those workers
-   * keep using their deployment token (and the warm-worker-across-turns case is
-   * already covered by the per-turn fresh-token adoption — each turn mints a new
-   * token).
+   * Contract: requires a valid per-run token (`runId` + `messageId`) AND a live
+   * turn-timeout marker for the token's OWN turn ({@link hasLiveTurnForMessage}
+   * on `(deploymentName, messageId)`). Gating per-turn — not per-deployment —
+   * is the load-bearing invariant: it closes the cross-turn leak where a still-
+   * valid token from a COMPLETED turn refreshes off a later, unrelated turn's
+   * liveness on the same deployment. Expired (verifyWorkerToken) and jti-revoked
+   * tokens are rejected before the gate; the fresh token gets its own jti.
+   * Legacy direct-enqueue tokens (no runId/messageId → no marker) are denied.
    */
   private async handleTokenRefresh(c: Context): Promise<Response> {
     const auth = await this.authenticateWorker(c);

--- a/packages/server/src/gateway/gateway/index.ts
+++ b/packages/server/src/gateway/gateway/index.ts
@@ -5,7 +5,12 @@ import type {
   InstructionContext,
   WorkerTokenData,
 } from "@lobu/core";
-import { createLogger, encrypt, verifyWorkerToken } from "@lobu/core";
+import {
+  createLogger,
+  encrypt,
+  generateWorkerToken,
+  verifyWorkerToken,
+} from "@lobu/core";
 import type { Context } from "hono";
 import { Hono } from "hono";
 import { stream } from "hono/streaming";
@@ -23,6 +28,7 @@ import type { IMessageQueue } from "../infrastructure/queue/index.js";
 import {
   commitTerminalReply,
   extendTurnDeadlines,
+  hasLiveTurnForDeployment,
 } from "../orchestration/turn-liveness.js";
 import type { InstructionService } from "../services/instruction-service.js";
 import type { AgentSettingsStore } from "../auth/settings/agent-settings-store.js";
@@ -108,6 +114,11 @@ export class WorkerGateway {
     this.app.get("/session-context", (c) =>
       this.handleSessionContextRequest(c)
     );
+
+    // Mint a fresh worker token while the deployment still has live work.
+    // Lets a warm worker (or a single turn running past the 2h TTL) keep a
+    // non-expired token without lengthening the TTL — see handler.
+    this.app.post("/token/refresh", (c) => this.handleTokenRefresh(c));
 
     // Per-run transcript snapshots — backs the multi-replica unblock.
     // Workers hydrate from the latest completed snapshot on boot and POST
@@ -672,6 +683,95 @@ export class WorkerGateway {
     }
 
     return { tokenData, token };
+  }
+
+  /**
+   * Mint a fresh worker token from a currently-valid one, gated on
+   * deployment-liveness.
+   *
+   * Why this exists: the deployment-lifetime WORKER_TOKEN is minted once at
+   * subprocess spawn and the per-run token once per message; both carry a fixed
+   * `timestamp` and expire 2h later (WORKER_TOKEN_TTL_MS, an intentional
+   * security property — the short TTL is the leak-revocation path). A worker can
+   * legitimately outlive that window: a single turn running >2h (long
+   * autonomous / watcher run) would see even its per-run token expire mid-turn.
+   * This endpoint lets the worker swap its in-flight token for a fresh 2h one
+   * with the SAME claims, without lengthening the TTL.
+   *
+   * The revocation model is deployment-liveness (a user-confirmed decision): we
+   * mint a fresh token ONLY while {@link hasLiveTurnForDeployment} reports an
+   * in-flight turn-timeout marker for the token's `deploymentName`. The marker
+   * is the cross-pod-authoritative liveness signal (shared `public.runs`, the
+   * same row every terminalization path deletes atomically). When the work goes
+   * terminal the marker is gone, refresh is denied, and the chain dies — so the
+   * leak window is bounded by how long the work actually runs, not by an
+   * unbounded refresh chain. A leaked-but-expired token can't refresh
+   * (verifyWorkerToken rejects it first), and a jti-revoked token can't refresh
+   * (the revoked-token check below). The fresh token gets its OWN jti, so it can
+   * be independently revoked.
+   *
+   * Tokens with no `runId` (legacy direct-enqueue path) are denied: they don't
+   * go through the runs-queue dispatch that arms a turn-timeout marker, so there
+   * is no liveness signal to gate on. Those workers keep using their deployment
+   * token (and the warm-worker-across-turns case is already covered by the
+   * per-turn fresh-token adoption — each turn mints a new token).
+   */
+  private async handleTokenRefresh(c: Context): Promise<Response> {
+    const auth = await this.authenticateWorker(c);
+    if (!auth) {
+      // Expired / malformed / jti-revoked — verifyWorkerToken or the
+      // revoked-token check already rejected. An expired token CANNOT refresh
+      // itself; that bounds the leak window.
+      return c.json({ error: "Invalid token" }, 401);
+    }
+    const { tokenData } = auth;
+
+    // No runId → no turn-timeout marker exists for this token's work, so we
+    // have no liveness signal. Deny rather than mint blind.
+    if (typeof tokenData.runId !== "number") {
+      return c.json({ error: "Token not eligible for refresh" }, 403);
+    }
+
+    if (!tokenData.deploymentName) {
+      return c.json({ error: "Token missing deployment scope" }, 400);
+    }
+
+    const live = await hasLiveTurnForDeployment(tokenData.deploymentName);
+    if (!live) {
+      // The deployment has no in-flight turn — the work is terminal (reply
+      // committed, worker died, or deadline swept). Refusing here is the
+      // revocation property: the token chain ends with the work.
+      logger.info(
+        { deploymentName: tokenData.deploymentName, runId: tokenData.runId },
+        "Token refresh denied: no live turn for deployment"
+      );
+      return c.json({ error: "No live turn for deployment" }, 403);
+    }
+
+    // Mint a fresh token with identical claims (fresh timestamp + new jti).
+    const refreshed = generateWorkerToken(
+      tokenData.userId,
+      tokenData.conversationId,
+      tokenData.deploymentName,
+      {
+        channelId: tokenData.channelId,
+        teamId: tokenData.teamId,
+        agentId: tokenData.agentId,
+        organizationId: tokenData.organizationId,
+        connectionId: tokenData.connectionId,
+        platform: tokenData.platform,
+        source: tokenData.source,
+        sessionKey: tokenData.sessionKey,
+        traceId: tokenData.traceId,
+        runId: tokenData.runId,
+      }
+    );
+
+    logger.info(
+      { deploymentName: tokenData.deploymentName, runId: tokenData.runId },
+      "Issued refreshed worker token"
+    );
+    return c.json({ token: refreshed });
   }
 
   private getRequestBaseUrl(c: Context): string {

--- a/packages/server/src/gateway/orchestration/message-consumer.ts
+++ b/packages/server/src/gateway/orchestration/message-consumer.ts
@@ -64,6 +64,12 @@ export function buildRunJobToken(args: {
   platform?: string;
   platformMetadata?: Record<string, unknown>;
   runId?: number;
+  /**
+   * Per-turn binding for token refresh: the turn-timeout marker is armed with
+   * this SAME messageId, so the refresh gate requires a live marker for THIS
+   * turn (deploymentName:messageId), not merely any live turn on the deployment.
+   */
+  messageId?: string;
 }): string | undefined {
   if (args.runId === undefined) return undefined;
   return generateWorkerToken(
@@ -92,6 +98,7 @@ export function buildRunJobToken(args: {
           ? args.platformMetadata.source
           : undefined,
       runId: args.runId,
+      messageId: args.messageId,
     }
   );
 }
@@ -284,6 +291,11 @@ export class MessageConsumer {
         platform: data.platform,
         platformMetadata: data.platformMetadata,
         runId: data.runId,
+        // Per-turn binding for token refresh: the turn-timeout marker is armed
+        // below with this SAME messageId, so the refresh gate can require a live
+        // marker for THIS turn (deploymentName:messageId) rather than any live
+        // turn on the deployment.
+        messageId: data.messageId,
       });
 
       logger.info(

--- a/packages/server/src/gateway/orchestration/turn-liveness.ts
+++ b/packages/server/src/gateway/orchestration/turn-liveness.ts
@@ -167,48 +167,27 @@ export async function extendTurnDeadlines(
 /**
  * Is the SPECIFIC turn `(deploymentName, messageId)` still in-flight?
  *
- * The `internal:turn_timeout` marker (a pending row in `public.runs`) is the
- * authoritative, cross-pod record that a turn is in-flight: it is armed at
- * dispatch ({@link armTurnTimeout}) keyed on `deploymentName:messageId`
- * ({@link turnMarkerKey}) and deleted — atomically, first-writer-wins — the
- * instant THAT turn terminalizes via ANY path ({@link commitTerminalReply} on a
- * worker reply, {@link failTurnsForDeployment} on worker death,
- * {@link sweepExpiredTurns} on a lapsed deadline, {@link failTurnIfPending} on
- * startup failure). While a turn legitimately runs long, the worker's 20s
- * heartbeat pushes the marker's deadline (`run_at`) forward
- * ({@link extendTurnDeadlines}), so the marker stays pending with a future
- * deadline and this returns true; a hung or dead worker stops heartbeating, the
- * deadline lapses, and this returns false.
+ * The `internal:turn_timeout` marker (a pending `public.runs` row, armed at
+ * dispatch keyed on `deploymentName:messageId`) is the authoritative cross-pod
+ * record that a turn is live: every terminalization path deletes it
+ * transactionally (first-writer-wins), and the worker's 20s heartbeat pushes its
+ * `run_at` deadline forward while the turn legitimately runs long — so any
+ * replica reads the true state from shared `public.runs`.
  *
- * This is the liveness gate for worker-token refresh: both the marker and the
- * worker's per-run token are minted in the same dispatch
- * (MessageConsumer.handleMessage) carrying the same `messageId`, so a fresh
- * token is minted only while the token's OWN turn is live — not merely any turn
- * on the deployment. That closes the cross-turn leak: a still-valid token from
- * turn T1 cannot refresh once T1's marker is gone, even if a later unrelated
- * turn T2 on the same deployment is live (T2's marker has a different
- * messageId). Once the turn terminalizes the marker is gone, refresh is denied,
- * and the token chain dies — that deletion IS the revocation path (the leak
- * window is bounded by how long the turn actually runs, not an unbounded refresh
- * chain).
+ * This is the liveness gate for worker-token refresh. The marker and the per-run
+ * token are minted in the same dispatch (MessageConsumer.handleMessage) with the
+ * same `messageId`, so a token refreshes only while ITS OWN turn is live — not
+ * merely any turn on the deployment. Once the turn terminalizes the marker is
+ * gone and refresh is denied: that deletion IS the revocation path, bounding the
+ * leak window to how long the turn actually runs rather than an unbounded refresh
+ * chain. It is deliberately NOT gated on the dispatching `runs.id` the token was
+ * minted for — that `messages`-queue run completes the moment `handleMessage`
+ * enqueues, long before the turn finishes.
  *
- * **Deadline predicate (`run_at > now()`):** the marker is deleted by the sweep
- * only on its periodic tick (`turnLivenessSweepIntervalMs`), so between a lapsed
- * deadline and the next sweep the row is still `pending`. A bare `status =
- * 'pending'` check would authorize a refresh in that gap — for work whose
- * deadline has already passed (the worker is hung/dead, just not yet swept),
- * widening the leak window past the deadline the heartbeat was supposed to keep
- * alive. Requiring a future deadline ties authorization to genuine liveness
- * (the heartbeat) rather than to sweep latency.
- *
- * Cross-pod authoritative: this reads the same shared `public.runs` table that
- * every terminalization path mutates transactionally, so any replica sees the
- * true current state regardless of which pod armed or discharged the marker. It
- * is deliberately NOT the dispatching `runs.id` the token was minted for — that
- * `messages`-queue run completes the moment `handleMessage` enqueues to the
- * thread queue, long before the turn finishes, so gating on it would deny
- * refresh on a still-live turn; the turn-timeout marker keyed on `messageId` is
- * the durable in-flight signal instead.
+ * The `run_at > now()` predicate (not a bare `status = 'pending'`) excludes a
+ * marker whose deadline has lapsed but which the periodic sweep hasn't deleted
+ * yet — otherwise a hung/dead worker's turn would keep authorizing refreshes in
+ * that gap, widening the leak past the deadline the heartbeat was meant to hold.
  */
 export async function hasLiveTurnForMessage(
   deploymentName: string,

--- a/packages/server/src/gateway/orchestration/turn-liveness.ts
+++ b/packages/server/src/gateway/orchestration/turn-liveness.ts
@@ -165,6 +165,52 @@ export async function extendTurnDeadlines(
 }
 
 /**
+ * Is any turn still in-flight for this deployment?
+ *
+ * The `internal:turn_timeout` marker (a pending row in `public.runs`) is the
+ * authoritative, cross-pod record that a turn is in-flight: it is armed at
+ * dispatch ({@link armTurnTimeout}) and deleted — atomically, first-writer-wins
+ * — the instant the turn terminalizes via ANY path ({@link commitTerminalReply}
+ * on a worker reply, {@link failTurnsForDeployment} on worker death,
+ * {@link sweepExpiredTurns} on a lapsed deadline, {@link failTurnIfPending} on
+ * startup failure). While a turn legitimately runs long, the worker's 20s
+ * heartbeat pushes the marker's deadline forward ({@link extendTurnDeadlines}),
+ * so the marker stays `pending` and this returns true; a hung or dead worker
+ * stops heartbeating, the marker lapses and is swept, and this returns false.
+ *
+ * This is the liveness gate for worker-token refresh: a fresh token is minted
+ * only while the deployment has live work. Once all turns terminalize, the
+ * marker(s) are gone, refresh is denied, and the token chain dies — that
+ * deletion IS the revocation path (the leak window is bounded by how long the
+ * work actually runs, not an unbounded refresh chain).
+ *
+ * Cross-pod authoritative: this reads the same shared `public.runs` table that
+ * every terminalization path mutates transactionally, so any replica sees the
+ * true current state regardless of which pod armed or discharged the marker. It
+ * is deliberately NOT the dispatching `runs.id` the token was minted for — that
+ * `messages`-queue run completes the moment `handleMessage` enqueues to the
+ * thread queue, long before the turn finishes, so gating on it would deny
+ * refresh on a still-live turn.
+ */
+export async function hasLiveTurnForDeployment(
+  deploymentName: string
+): Promise<boolean> {
+  const sql = getDb();
+  // status + run_type + queue_name match the partial predicate / leading column
+  // of `runs_lobu_claim_idx`, so this is an index probe, not a scan of the
+  // 30-day `runs` retention.
+  const rows = await sql<{ ok: number }>`
+    SELECT 1 AS ok FROM public.runs
+    WHERE status = 'pending'
+      AND run_type = 'internal'
+      AND queue_name = ${TURN_TIMEOUT_QUEUE}
+      AND action_input->>'deploymentName' = ${deploymentName}
+    LIMIT 1
+  `;
+  return rows.length > 0;
+}
+
+/**
  * Fast path: fail every in-flight turn of a deployment whose worker has just
  * died unexpectedly. Atomic per the `DELETE … RETURNING` election — only this
  * caller gets the rows, and the terminal error is enqueued in the same

--- a/packages/server/src/gateway/orchestration/turn-liveness.ts
+++ b/packages/server/src/gateway/orchestration/turn-liveness.ts
@@ -174,15 +174,25 @@ export async function extendTurnDeadlines(
  * on a worker reply, {@link failTurnsForDeployment} on worker death,
  * {@link sweepExpiredTurns} on a lapsed deadline, {@link failTurnIfPending} on
  * startup failure). While a turn legitimately runs long, the worker's 20s
- * heartbeat pushes the marker's deadline forward ({@link extendTurnDeadlines}),
- * so the marker stays `pending` and this returns true; a hung or dead worker
- * stops heartbeating, the marker lapses and is swept, and this returns false.
+ * heartbeat pushes the marker's deadline (`run_at`) forward
+ * ({@link extendTurnDeadlines}), so the marker stays pending with a future
+ * deadline and this returns true; a hung or dead worker stops heartbeating, the
+ * deadline lapses, and this returns false.
  *
  * This is the liveness gate for worker-token refresh: a fresh token is minted
  * only while the deployment has live work. Once all turns terminalize, the
  * marker(s) are gone, refresh is denied, and the token chain dies — that
  * deletion IS the revocation path (the leak window is bounded by how long the
  * work actually runs, not an unbounded refresh chain).
+ *
+ * **Deadline predicate (`run_at > now()`):** the marker is deleted by the sweep
+ * only on its periodic tick (`turnLivenessSweepIntervalMs`), so between a lapsed
+ * deadline and the next sweep the row is still `pending`. A bare `status =
+ * 'pending'` check would authorize a refresh in that gap — for work whose
+ * deadline has already passed (the worker is hung/dead, just not yet swept),
+ * widening the leak window past the deadline the heartbeat was supposed to keep
+ * alive. Requiring a future deadline ties authorization to genuine liveness
+ * (the heartbeat) rather than to sweep latency.
  *
  * Cross-pod authoritative: this reads the same shared `public.runs` table that
  * every terminalization path mutates transactionally, so any replica sees the
@@ -198,13 +208,15 @@ export async function hasLiveTurnForDeployment(
   const sql = getDb();
   // status + run_type + queue_name match the partial predicate / leading column
   // of `runs_lobu_claim_idx`, so this is an index probe, not a scan of the
-  // 30-day `runs` retention.
+  // 30-day `runs` retention. `run_at > now()` excludes lapsed-but-unswept
+  // markers (see the deadline-predicate note above).
   const rows = await sql<{ ok: number }>`
     SELECT 1 AS ok FROM public.runs
     WHERE status = 'pending'
       AND run_type = 'internal'
       AND queue_name = ${TURN_TIMEOUT_QUEUE}
       AND action_input->>'deploymentName' = ${deploymentName}
+      AND run_at > now()
     LIMIT 1
   `;
   return rows.length > 0;

--- a/packages/server/src/gateway/orchestration/turn-liveness.ts
+++ b/packages/server/src/gateway/orchestration/turn-liveness.ts
@@ -165,13 +165,14 @@ export async function extendTurnDeadlines(
 }
 
 /**
- * Is any turn still in-flight for this deployment?
+ * Is the SPECIFIC turn `(deploymentName, messageId)` still in-flight?
  *
  * The `internal:turn_timeout` marker (a pending row in `public.runs`) is the
  * authoritative, cross-pod record that a turn is in-flight: it is armed at
- * dispatch ({@link armTurnTimeout}) and deleted — atomically, first-writer-wins
- * — the instant the turn terminalizes via ANY path ({@link commitTerminalReply}
- * on a worker reply, {@link failTurnsForDeployment} on worker death,
+ * dispatch ({@link armTurnTimeout}) keyed on `deploymentName:messageId`
+ * ({@link turnMarkerKey}) and deleted — atomically, first-writer-wins — the
+ * instant THAT turn terminalizes via ANY path ({@link commitTerminalReply} on a
+ * worker reply, {@link failTurnsForDeployment} on worker death,
  * {@link sweepExpiredTurns} on a lapsed deadline, {@link failTurnIfPending} on
  * startup failure). While a turn legitimately runs long, the worker's 20s
  * heartbeat pushes the marker's deadline (`run_at`) forward
@@ -179,11 +180,17 @@ export async function extendTurnDeadlines(
  * deadline and this returns true; a hung or dead worker stops heartbeating, the
  * deadline lapses, and this returns false.
  *
- * This is the liveness gate for worker-token refresh: a fresh token is minted
- * only while the deployment has live work. Once all turns terminalize, the
- * marker(s) are gone, refresh is denied, and the token chain dies — that
- * deletion IS the revocation path (the leak window is bounded by how long the
- * work actually runs, not an unbounded refresh chain).
+ * This is the liveness gate for worker-token refresh: both the marker and the
+ * worker's per-run token are minted in the same dispatch
+ * (MessageConsumer.handleMessage) carrying the same `messageId`, so a fresh
+ * token is minted only while the token's OWN turn is live — not merely any turn
+ * on the deployment. That closes the cross-turn leak: a still-valid token from
+ * turn T1 cannot refresh once T1's marker is gone, even if a later unrelated
+ * turn T2 on the same deployment is live (T2's marker has a different
+ * messageId). Once the turn terminalizes the marker is gone, refresh is denied,
+ * and the token chain dies — that deletion IS the revocation path (the leak
+ * window is bounded by how long the turn actually runs, not an unbounded refresh
+ * chain).
  *
  * **Deadline predicate (`run_at > now()`):** the marker is deleted by the sweep
  * only on its periodic tick (`turnLivenessSweepIntervalMs`), so between a lapsed
@@ -200,10 +207,12 @@ export async function extendTurnDeadlines(
  * is deliberately NOT the dispatching `runs.id` the token was minted for — that
  * `messages`-queue run completes the moment `handleMessage` enqueues to the
  * thread queue, long before the turn finishes, so gating on it would deny
- * refresh on a still-live turn.
+ * refresh on a still-live turn; the turn-timeout marker keyed on `messageId` is
+ * the durable in-flight signal instead.
  */
-export async function hasLiveTurnForDeployment(
-  deploymentName: string
+export async function hasLiveTurnForMessage(
+  deploymentName: string,
+  messageId: string
 ): Promise<boolean> {
   const sql = getDb();
   // status + run_type + queue_name match the partial predicate / leading column
@@ -216,6 +225,7 @@ export async function hasLiveTurnForDeployment(
       AND run_type = 'internal'
       AND queue_name = ${TURN_TIMEOUT_QUEUE}
       AND action_input->>'deploymentName' = ${deploymentName}
+      AND action_input->>'messageId' = ${messageId}
       AND run_at > now()
     LIMIT 1
   `;


### PR DESCRIPTION
## Problem

Worker token TTL is 2h (#1266 — the short TTL is the deliberate leak-revocation property). The deployment `WORKER_TOKEN` is minted once at subprocess spawn and the per-run `runJobToken` once per message; both carry a fixed timestamp and expire 2h later. Two ways a worker outlives that window and 401s on any worker→gateway call:

1. **warm worker across turns** — a continuously-active conversation keeps one subprocess alive past the idle reap; several paths read the stale spawn-time `process.env.WORKER_TOKEN`.
2. **a single turn running >2h** (long autonomous / watcher run) — even the turn's own `runJobToken` expires mid-turn.

## Fix (keeps the 2h TTL — refresh, don't lengthen)

**1. Per-turn fresh-token adoption.** At turn start the worker adopts the freshly-minted `runJobToken` (a strict superset of the deployment token's claims — org/agent/conv + connectionId after #1274 + source + runId) for every gateway consumer: `process.env.WORKER_TOKEN` (session-context, snapshot hydrate/clear, audio hint) and the transport's gateway POSTs. A new `WorkerTokenManager` is the single source of truth; the transport reads it via `fetchWithRefresh`. This alone fixes the warm-worker-across-turns case (each turn already mints a fresh token). The just-bash spawnHook still strips `WORKER_TOKEN` **by key**, so agent bash never sees it — the security strip is undefeated.

**2. Mid-turn refresh for the >2h single-turn case.** New gateway endpoint `POST /worker/token/refresh` mints a fresh 2h token with the same claims, gated on **deployment-liveness** (the user-confirmed revocation model).

## The liveness signal (cross-pod authoritative)

Refresh is authorized iff an in-flight `internal:turn_timeout` marker exists for the token's `deploymentName` (`hasLiveTurnForDeployment`). That marker is a pending row in shared `public.runs`, armed at dispatch and **deleted atomically the instant the turn terminalizes** via any path — `commitTerminalReply` (worker replied), `failTurnsForDeployment` (worker died), `sweepExpiredTurns` (deadline lapsed), `failTurnIfPending` (startup failure). The worker's 20s heartbeat pushes the deadline forward (`extendTurnDeadlines`) so a legitimately-long turn keeps a pending marker.

Why this row and not the token's `runs.id`: the dispatching `runId` is the `messages`-queue run, which goes `completed` the moment `handleMessage` enqueues to the thread queue — long before the turn finishes. Gating on it would deny refresh on a still-live turn. The turn-timeout marker is the only PG signal that spans the actual turn, and it's the same row every terminalization path mutates transactionally, so any replica sees the true state regardless of which pod armed or discharged it.

## Why this satisfies the security invariant

When the work goes terminal the marker is gone, refresh is denied, and the token chain dies — **that denial is the revocation path.** The leak window is bounded by how long the work actually runs, not by an unbounded refresh chain. Expired tokens can't refresh (`verifyWorkerToken` rejects first); jti-revoked tokens can't refresh (the existing revoked-token store check); the fresh token gets its own jti, so it stays independently revocable. Tokens with no `runId` (legacy direct-enqueue, no marker to gate on) are denied.

Worker side refreshes **proactively** (when near expiry, before the call) and **reactively** (401 → refresh once → retry), de-duping concurrent refreshes.

Snapshot `runId` enforcement is unchanged: POST stays runId-bound; the runId-agnostic GET (hydrate) / DELETE (clear) now ride the live token.

## Tests (red→green, real Postgres on the server side)

Worker side (`bun test`, 9): per-turn adoption flips the bearer on the wire; env mirror; deployment-token fallback; proactive refresh near expiry (and no-op when fresh); **>2h single-turn 401→refresh→retry**; **refresh-denied keeps the old token**; concurrent-refresh de-dupe.

Server side (`bun test` against real PG, 21): `hasLiveTurnForDeployment` true while in-flight and **false after every terminalization path** (reply / worker death / sweep); long-turn heartbeat keeps it true past the original deadline; per-deployment scoping. Endpoint: mints with preserved claims while live; **403 once no live turn**; **becomes non-refreshable after terminalization** (the revocation test); 403 for no-runId tokens; 401 for malformed tokens.

## Remaining edge

In-process MCP / `ask_user` / upload tool calls capture `gw.workerToken` by value at session build, so during a >2h single turn an in-flight tool call could still 401 (the tool call fails; the turn's terminal delivery still succeeds via the transport's refresh). Routing every gateway tool through the manager is a follow-up — out of scope here.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1280"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784165019&installation_id=136316292&pr_number=1280&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1280&signature=af5be96d19f0e238430881ba8be3039a9add4bfdb5f91f400e40f448345f54b1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enabled automatic worker token refresh for long-running interactions to reduce mid-turn authentication failures.
  * Switched gateway and SSE requests to use the latest live token and added proactive/reactive refresh handling.
  * Added a token refresh endpoint that re-mints tokens only when a specific turn is currently live (per-turn liveness protection).

* **Tests**
  * Added comprehensive worker-side and server-side integration tests covering proactive/reactive refresh, 401/403 behavior, concurrency, and cross-turn security (including real Postgres-backed scenarios).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->