### PR TITLE
fix(server): read_knowledge 400 on whitespace-prefixed queries + 1440-combo query fuzz guard

### DIFF
--- a/packages/server/src/__tests__/integration/events/search-content-tsquery-robustness.test.ts
+++ b/packages/server/src/__tests__/integration/events/search-content-tsquery-robustness.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Property/fuzz regression: searchContentByText (read_knowledge / get_content)
+ * must NEVER throw on adversarial query text — it returns matches or an empty
+ * list, but a malformed query can't surface a Postgres error to the caller.
+ *
+ * Origin bug: a leading newline survived Postgres `trim()` (which strips spaces
+ * only) and became a leading ' | ' in the constructed tsquery, so
+ * `to_tsquery('english', ' | foo')` threw `syntax error in tsquery` → a 400 from
+ * read_knowledge. A single hand-picked case wouldn't catch the next variant, so
+ * this test generates a cross-product of whitespace / tsquery-operator / unicode
+ * / oversized / injection-ish fragments and asserts the whole space is safe.
+ *
+ * If you add a new way to build the fulltext query, this test is the guard:
+ * every (prefix × core × suffix) combination must resolve, not throw.
+ *
+ * Harness: vitest + embedded Postgres, text-only (no EMBEDDINGS_SERVICE_URL), so
+ * the fulltext TSQUERY_SQL branch is exercised on every query.
+ */
+
+import { beforeAll, describe, expect, it } from 'vitest';
+import { searchContentByText } from '../../../utils/content-search';
+import { cleanupTestDatabase } from '../../setup/test-db';
+import {
+  addUserToOrganization,
+  createTestEntity,
+  createTestEvent,
+  createTestOrganization,
+  createTestUser,
+  seedSystemEntityTypes,
+} from '../../setup/test-fixtures';
+
+// Fragments that have historically broken naive tsquery construction.
+const PREFIXES = [
+  '',
+  '\n',
+  '\t',
+  '\r\n',
+  '   ',
+  '\n\n\n',
+  '---\n',
+  '| ',
+  '& ',
+  '!(',
+  ':: ',
+  '*',
+];
+const CORES = [
+  'quarterly revenue',
+  'budget & forecast',
+  'a:b:c',
+  'foo|bar',
+  '(unbalanced',
+  'wildcard*prefix',
+  '<-> phrase op',
+  '🎉 emoji 日本語 query',
+  "O'Brien's Q3 report",
+  "'; DROP TABLE events; --",
+  '!!! ??? &&& |||',
+  '1234567890',
+  'the and of to is', // all stopwords
+  '', // empty core
+  'x'.repeat(6000), // oversized
+];
+const SUFFIXES = ['', '\n', ' |', ' &', '   \t', ')', ':*', '\r'];
+
+describe('searchContentByText > fuzz: no query input may throw', () => {
+  let org: Awaited<ReturnType<typeof createTestOrganization>>;
+  let eventId: number;
+
+  beforeAll(async () => {
+    await cleanupTestDatabase();
+    await seedSystemEntityTypes();
+    org = await createTestOrganization({ name: 'TSQuery Fuzz Org' });
+    const user = await createTestUser({ email: 'tsquery-fuzz@example.com' });
+    await addUserToOrganization(user.id, org.id, 'owner');
+    const entity = await createTestEntity({ name: 'Fuzz Entity', organization_id: org.id });
+    eventId = (
+      await createTestEvent({
+        organization_id: org.id,
+        entity_id: entity.id,
+        content: 'The quarterly revenue review covered forecasts and budgets.',
+      })
+    ).id;
+  });
+
+  it(`survives every (prefix × core × suffix) combination (${PREFIXES.length * CORES.length * SUFFIXES.length} queries)`, async () => {
+    const failures: Array<{ query: string; error: string }> = [];
+    let ran = 0;
+    for (const p of PREFIXES) {
+      for (const c of CORES) {
+        for (const s of SUFFIXES) {
+          const query = p + c + s;
+          try {
+            const result = await searchContentByText(query, {
+              organization_id: org.id,
+              limit: 10,
+              sort_by: 'score',
+            });
+            expect(Array.isArray(result.content)).toBe(true);
+            ran++;
+          } catch (e) {
+            failures.push({ query: JSON.stringify(query).slice(0, 80), error: String(e).slice(0, 160) });
+          }
+        }
+      }
+    }
+    if (failures.length > 0) {
+      throw new Error(
+        `${failures.length}/${ran + failures.length} query combinations threw:\n` +
+          failures.slice(0, 10).map((f) => `  ${f.query} -> ${f.error}`).join('\n')
+      );
+    }
+    expect(ran).toBe(PREFIXES.length * CORES.length * SUFFIXES.length);
+  });
+
+  it('still finds content when the query is wrapped in whitespace/operators (recall preserved)', async () => {
+    for (const q of ['\n  quarterly revenue\t', '| quarterly revenue |', '\n\nquarterly\trevenue\n']) {
+      const result = await searchContentByText(q, { organization_id: org.id, limit: 10, sort_by: 'score' });
+      expect(result.content.map((c) => c.id)).toContain(eventId);
+    }
+  });
+});

--- a/packages/server/src/utils/content-search/fts.ts
+++ b/packages/server/src/utils/content-search/fts.ts
@@ -54,7 +54,14 @@ export function buildTsqueryString(queryText: string): string | null {
   return tokens.length > 0 ? tokens.join(' | ') : null;
 }
 
-const NORMALIZED_QUERY_SQL = `trim(regexp_replace(regexp_replace(lower($1), '\\m(${STOPWORDS.join('|')})\\M', ' ', 'g'), '[^a-z0-9\\s]+', ' ', 'g'))`;
+// NOTE: the final `regexp_replace(..., '\\s+', ' ', 'g')` collapses ALL
+// whitespace runs (incl. newlines/tabs) to a single space BEFORE trim. Postgres
+// `trim()` only strips spaces, so without this a query with a leading newline or
+// tab survives trim and the TSQUERY_SQL `\\s+ -> ' | '` step below turns it into
+// a leading ' | ' — which makes `to_tsquery` throw a syntax error (a multi-line
+// or content-derived read_knowledge query would 400). Collapsing first keeps the
+// OR-of-lexemes semantics while making the tsquery robust to arbitrary input.
+const NORMALIZED_QUERY_SQL = `trim(regexp_replace(regexp_replace(regexp_replace(lower($1), '\\m(${STOPWORDS.join('|')})\\M', ' ', 'g'), '[^a-z0-9\\s]+', ' ', 'g'), '\\s+', ' ', 'g'))`;
 export const TSQUERY_SQL = `CASE WHEN NULLIF(${NORMALIZED_QUERY_SQL}, '') IS NOT NULL THEN to_tsquery('english', regexp_replace(${NORMALIZED_QUERY_SQL}, '\\s+', ' | ', 'g')) ELSE NULL END`;
 
 export function buildSearchDocumentExpr(alias: string): string {


### PR DESCRIPTION
## Bug (surfaced by the xAFS benchmark)

`read_knowledge` / `searchContentByText` returned a **400** on any query containing a leading newline or tab:

```
syntax error in tsquery: " | date | 2026 | 04 | 22 | time | 09 | 00 | pt | ..."
```

Root cause: `NORMALIZED_QUERY_SQL` used Postgres `trim()`, which strips **spaces only** — not newlines/tabs. A leading newline survived trim, then the `TSQUERY_SQL` `\s+ -> ' | '` step turned it into a leading `" | "`, and `to_tsquery('english', ' | foo')` throws. Any multi-line paste or content-derived query (an agent searching a chunk of text) hits this in production.

## Fix

One line in `fts.ts`: collapse **all** whitespace to single spaces *before* `trim`, so the constructed tsquery is always `lexeme | lexeme` with no leading/trailing separator. Preserves the OR-of-lexemes semantics.

## Why a fuzz test, not a one-off

A single hand-picked case wouldn't catch the next variant. The regression is a **property/fuzz test**: a cross-product of `prefix × core × suffix` fragments (whitespace, tsquery operators `&|!():*`, unicode/emoji, a 6k-char query, stopword-only, injection-ish) = **1,440 query combinations**, asserting the search path never throws. Recall is also checked (whitespace/operator-wrapped queries still match content). This guards the whole class of "adversarial query input crashes retrieval," and auto-covers future query-builder changes.

All 1,440 combinations pass (oversized/stopword-only degrade to a Postgres NOTICE, not an error). Typecheck clean.

## Red→green

Red = the live xAFS 400 above. Green = the 1,440-combo fuzz test passing.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1281"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784166106&installation_id=136316292&pr_number=1281&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1281&signature=3b6dab56944623a89818c1225e422438861a6433f1dd1dff4cbb302a77d190ce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->