### PR TITLE
fix(e2e): tear down auto-provisioned personal orgs + add prod-host guard

### DIFF
--- a/packages/openclaw-plugin/test/e2e/helpers.ts
+++ b/packages/openclaw-plugin/test/e2e/helpers.ts
@@ -13,8 +13,45 @@ import { resolve } from 'node:path';
 import postgres from 'postgres';
 
 // ---------------------------------------------------------------------------
+// Prod safety guard
+// ---------------------------------------------------------------------------
+
+// This suite signs up REAL users and writes to whatever DB/app DATABASE_URL +
+// APP_URL point at. Pointed at prod it permanently contaminates it (this is how
+// the orphaned `E2E User e2e-*` personal orgs ended up in prod). Hard-abort on
+// any host that looks like prod. Substrings are matched against the raw
+// connection string / URL so a Postgres URL host, a k8s service host, and an
+// http origin are all covered.
+const PROD_HOST_MARKERS = [
+  'lobu.ai', // app.lobu.ai, lobu.ai, *.lobu.ai (APP_URL + any prod HTTP origin)
+  'lobu-ai-prod-db', // prod Postgres StatefulSet service host
+  'summaries-prod', // prod k8s namespace embedded in service hostnames
+];
+
+function assertNotProd(label: string, value: string | undefined): void {
+  if (!value) return;
+  const lower = value.toLowerCase();
+  const hit = PROD_HOST_MARKERS.find((m) => lower.includes(m));
+  if (hit) {
+    throw new Error(
+      `[e2e] Refusing to run: ${label} resolves to a production host ` +
+        `(matched "${hit}"). This suite creates real users/orgs and would ` +
+        `contaminate prod. Point DATABASE_URL and APP_URL at a local/dev ` +
+        `instance instead.`
+    );
+  }
+}
+
+function assertNotProdTargets(): void {
+  assertNotProd('APP_URL', process.env.APP_URL);
+  assertNotProd('DATABASE_URL', process.env.DATABASE_URL);
+}
+
+// ---------------------------------------------------------------------------
 // Config
 // ---------------------------------------------------------------------------
+
+assertNotProdTargets();
 
 export const APP_URL = process.env.APP_URL || 'http://localhost:8787';
 
@@ -26,6 +63,7 @@ function getDb(): postgres.Sql {
     if (!url) {
       throw new Error('DATABASE_URL is required for e2e tests');
     }
+    assertNotProd('DATABASE_URL', url);
     sql = postgres(url, {
       max: 3,
       idle_timeout: 20,
@@ -665,6 +703,26 @@ export async function cleanupTestData(): Promise<void> {
   await db`DELETE FROM "member" WHERE "userId" IN (
     SELECT id FROM "user" WHERE email LIKE '%@e2e-test.example.com'
   )`;
+  // signUpTestUser() hits the real /api/auth/sign-up/email endpoint, which runs
+  // ensurePersonalOrganization() and auto-provisions a *private personal org*
+  // for the new user. That org's id is `org_<token>` (NOT `org_e2e_*`), so the
+  // `org_e2e_%` filters below never matched it — it survived teardown as an
+  // orphan (0 members, a lone `$member` entity type, 0 events). Ownership is
+  // recorded in organization.metadata (text JSON) under `personal_org_for_user_id`
+  // = user.id (see personal-org-provisioning.ts). Resolve those orgs by the
+  // still-present e2e user rows and tear them down too, in FK-dependency order
+  // (events/entities/entity_types/member → organization), BEFORE the user rows
+  // are deleted below.
+  await db`
+    UPDATE entities SET parent_id = NULL
+    WHERE organization_id IN (
+      SELECT id FROM "organization"
+      WHERE metadata IS NOT NULL
+        AND (metadata::jsonb)->>'personal_org_for_user_id' IN (
+          SELECT id FROM "user" WHERE email LIKE '%@e2e-test.example.com'
+        )
+    )
+  `;
   // Delete events + entities in test orgs (must precede user/org deletion due to FKs).
   // events has a DB-level append-only guard (trg_events_append_only); test
   // teardown is sanctioned maintenance, so opt in with the transaction-scoped
@@ -673,10 +731,51 @@ export async function cleanupTestData(): Promise<void> {
   await db.begin(async (tx) => {
     await tx`SET LOCAL lobu.allow_event_delete = 'on'`;
     await tx`DELETE FROM events WHERE organization_id LIKE 'org_e2e_%'`;
+    await tx`
+      DELETE FROM events
+      WHERE organization_id IN (
+        SELECT id FROM "organization"
+        WHERE metadata IS NOT NULL
+          AND (metadata::jsonb)->>'personal_org_for_user_id' IN (
+            SELECT id FROM "user" WHERE email LIKE '%@e2e-test.example.com'
+          )
+      )
+    `;
   });
   // Clear parent references before deleting entities (parent_id has RESTRICT)
   await db`UPDATE entities SET parent_id = NULL WHERE organization_id LIKE 'org_e2e_%'`;
   await db`DELETE FROM entities WHERE organization_id LIKE 'org_e2e_%'`;
+  await db`
+    DELETE FROM entities
+    WHERE organization_id IN (
+      SELECT id FROM "organization"
+      WHERE metadata IS NOT NULL
+        AND (metadata::jsonb)->>'personal_org_for_user_id' IN (
+          SELECT id FROM "user" WHERE email LIKE '%@e2e-test.example.com'
+        )
+    )
+  `;
+  await db`
+    DELETE FROM entity_types
+    WHERE organization_id IN (
+      SELECT id FROM "organization"
+      WHERE metadata IS NOT NULL
+        AND (metadata::jsonb)->>'personal_org_for_user_id' IN (
+          SELECT id FROM "user" WHERE email LIKE '%@e2e-test.example.com'
+        )
+    )
+  `;
+
+  // Drop the auto-provisioned personal orgs while the e2e user rows still exist
+  // (the membership/metadata link is resolved off user.id). Their member rows
+  // were already removed above by the email-matched member delete.
+  await db`
+    DELETE FROM "organization"
+    WHERE metadata IS NOT NULL
+      AND (metadata::jsonb)->>'personal_org_for_user_id' IN (
+        SELECT id FROM "user" WHERE email LIKE '%@e2e-test.example.com'
+      )
+  `;
 
   await db`DELETE FROM "user" WHERE email LIKE '%@e2e-test.example.com'`;
   await db`DELETE FROM "user" WHERE id LIKE 'user_e2e_%'`;

--- a/scripts/run-e2e.sh
+++ b/scripts/run-e2e.sh
@@ -28,6 +28,22 @@ cd "$REPO_ROOT"
 
 PORT="${PORT:-8787}"
 APP_URL="${APP_URL:-http://127.0.0.1:${PORT}}"
+
+# Prod safety guard: this suite signs up REAL users and writes to whatever
+# DATABASE_URL + APP_URL point at. Pointed at prod it permanently contaminates
+# it (that is how the orphaned `E2E User e2e-*` personal orgs ended up in prod).
+# Hard-abort on any host that looks like prod before booting anything. Keep in
+# sync with PROD_HOST_MARKERS in packages/openclaw-plugin/test/e2e/helpers.ts.
+for marker in lobu.ai lobu-ai-prod-db summaries-prod; do
+  for target in "DATABASE_URL=$DATABASE_URL" "APP_URL=$APP_URL"; do
+    if [[ "${target#*=}" == *"$marker"* ]]; then
+      echo "Refusing to run: ${target%%=*} resolves to a production host (matched \"$marker\")." >&2
+      echo "   This suite creates real users/orgs and would contaminate prod." >&2
+      echo "   Point DATABASE_URL and APP_URL at a local/dev instance instead." >&2
+      exit 1
+    fi
+  done
+done
 LOG="$(mktemp -t lobu-e2e-server.XXXXXX.log)"
 PIDFILE="$(mktemp -t lobu-e2e-server.XXXXXX.pid)"
 FAKE_LLM_PIDFILE="$(mktemp -t lobu-e2e-fake-llm.XXXXXX.pid)"


### PR DESCRIPTION
## What

Two test-only fixes to the openclaw-plugin e2e suite:

1. **`cleanupTestData()` now tears down the auto-provisioned personal orgs** it leaks.
2. **A prod-host guard** (in both `helpers.ts` and `run-e2e.sh`) that hard-aborts if `DATABASE_URL`/`APP_URL` resolve to a prod host.

## Root cause

`signUpTestUser()` hits the real `/api/auth/sign-up/email` endpoint. That triggers `ensurePersonalOrganization()` (`packages/server/src/auth/personal-org-provisioning.ts`), which auto-provisions a **private personal "filing cabinet" org per user** — org id `org_<token>` (NOT `org_e2e_*`), tagged via `organization.metadata->>'personal_org_for_user_id' = user.id`, plus a system `$member` entity type.

`cleanupTestData()` deleted:
- `user` rows by `email LIKE '%@e2e-test.example.com'`
- `member` rows by that same email match
- `organization` rows **only** by `id LIKE 'org_e2e_%'`

The personal org id has no `e2e` infix, so it was never matched. The user + member got deleted; the personal org was **orphaned** — 0 members, a lone `$member` entity type, 0 events.

This suite is not in CI (it's the manual `scripts/run-e2e.sh`, `APP_URL` defaults to localhost, you supply `DATABASE_URL`). The contamination happened when someone ran it with `DATABASE_URL`/`APP_URL` pointed at prod (dates line up with the auth/device-flow/personal-org work in late Apr / early May).

## Affected prod orgs (9 — still present today, NOT deleted by this PR)

Org-by-org prod cleanup stays a separate proposal; this PR does **not** touch prod data. The orphans this bug produced:

| org id | name | created |
|---|---|---|
| `org_zT54_WxZeZ8` | E2E User e2e-a6510d30d592 | 2026-05-08 |
| `org_8Wcxg8qFsvU` | E2E User e2e-5fa0e08794da | 2026-05-08 |
| `org_et4R4kkOPk0` | E2E User e2e-e6ebfcd98c70 | 2026-05-08 |
| `org_vBK-Z_P4wJU` | E2E User e2e-722e4a656971 | 2026-04-28 |
| `org_sjsdzwxKs4k` | E2E User e2e-1ce6ae894b9c | 2026-04-28 |
| `org_a46VCxlYlUE` | E2E User e2e-ea82fce5b98e | 2026-04-28 |
| `org_geF0d-Z1_KU` | E2E User e2e-3c09606ad8b6 | 2026-04-28 |
| `org_kDVtqveH9G0` | E2E User e2e-37519d76aa02 | 2026-04-28 |
| `org_8uQXO13fjj8` | E2E User e2e-4a3b483c31cd | 2026-04-28 |

Each: 0 members, 0 events, 1 entity type (`$member`). Their `user`/`account`/`session` rows are already gone (cleanup removed those); only the orgs linger.

## The fixes

**1. Personal-org teardown** — `cleanupTestData()` resolves the orgs via `organization.metadata->>'personal_org_for_user_id'` against the still-present e2e user rows (so it runs **before** the user-row delete), then tears them down in FK-dependency order: `events` (under the `lobu.allow_event_delete` GUC) → `entities` (parent refs nulled first; `parent_id` is RESTRICT) → `entity_types` → `organization`. The member rows are already removed by the existing email-matched delete.

**2. Prod-host guard** — `PROD_HOST_MARKERS = [lobu.ai, lobu-ai-prod-db, summaries-prod]`, substring-matched against `DATABASE_URL` and `APP_URL`. `helpers.ts` throws at import + on `getDb()`; `run-e2e.sh` aborts before booting anything. Anything on the `lobu.ai` domain is prod-tier (dev is localhost), so this can't false-positive a legit dev run.

## Validation

- `make typecheck` — clean (server + owletto).
- `bunx tsc` on `packages/openclaw-plugin/test/e2e/helpers.ts` in package context — clean (the package's own `tsconfig` excludes `test/`, so this is the file's real typecheck).
- `bash -n scripts/run-e2e.sh` — clean.
- Guard behavioral check: prod `DATABASE_URL`/`APP_URL` → abort (exit 1, matched marker reported); local/dev → would-run.

Full e2e suite not run end-to-end here (requires a booted local server + DB); the SQL is additive and mirrors the existing dependency-ordered deletes.

## Out of scope

- No prod deletion. The 9 orphan orgs + the broader long-tail cleanup remain a human-approved, org-by-org proposal.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1285"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784167923&installation_id=136316292&pr_number=1285&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1285&signature=db7db679fcff49bf0ae4624563e3377bfe4cb924e9ae406d7cec21b5de82162a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->