### PR TITLE
fix(events): serialize dedup insert per (connection_id, origin_id)

### DIFF
--- a/packages/server/src/__tests__/integration/events/insert-event-dedup-race.test.ts
+++ b/packages/server/src/__tests__/integration/events/insert-event-dedup-race.test.ts
@@ -1,0 +1,166 @@
+/**
+ * Integration test: concurrent dedup on (connection_id, origin_id).
+ *
+ * `insertEvent(..., { onConflictUpdate: true })` is the connector-ingest dedup
+ * path. It is a read-then-insert: it looks up the current row for
+ * (connection_id, origin_id), then either supersedes it (content changed) or
+ * inserts fresh (no current row). There is NO unique constraint on
+ * (connection_id, origin_id) — the only DB guard is the partial unique index
+ * `idx_events_superseded_by` on supersedes_event_id.
+ *
+ * Without serialization, two concurrent ingests of the SAME item race:
+ *
+ *   - New origin_id, two concurrent inserts: both see "no current row", both
+ *     insert with supersedes_event_id NULL → TWO permanent current rows for the
+ *     same key. (Observed in prod: org Market had 224k+ such reddit duplicates,
+ *     all within a single connection_id, still growing ~2.5k/week.)
+ *
+ *   - Existing origin_id, two concurrent updates: both target the same row to
+ *     supersede → one wins idx_events_superseded_by, the other throws a
+ *     duplicate-key error that fails the whole stream batch.
+ *
+ * The fix serializes the read-then-insert with a transaction-scoped advisory
+ * lock keyed on (connection_id, origin_id). This test pins the invariant:
+ * after N concurrent ingests of the same (connection_id, origin_id) — half
+ * fresh-new, half content-changing — there is EXACTLY ONE current
+ * (non-superseded) row, and no insert throws.
+ *
+ * Vitest CI gap note (mirrors neighbors): runs against the dev/CI pgvector DB
+ * via DATABASE_URL; the integration job runs it in CI.
+ */
+
+import { beforeAll, describe, expect, it } from 'vitest';
+import { insertEvent } from '../../../utils/insert-event';
+import { initWorkspaceProvider } from '../../../workspace';
+import { cleanupTestDatabase, getTestDb } from '../../setup/test-db';
+import {
+  createTestConnection,
+  createTestOrganization,
+  seedSystemEntityTypes,
+} from '../../setup/test-fixtures';
+
+describe('insertEvent > concurrent dedup on (connection_id, origin_id)', () => {
+  let org: Awaited<ReturnType<typeof createTestOrganization>>;
+  let connectionId: number;
+
+  beforeAll(async () => {
+    await initWorkspaceProvider();
+    await cleanupTestDatabase();
+    await seedSystemEntityTypes();
+
+    org = await createTestOrganization({ name: 'Dedup Race Org' });
+    const conn = await createTestConnection({
+      organization_id: org.id,
+      connector_key: 'reddit',
+    });
+    connectionId = Number(conn.id);
+  });
+
+  it('keeps exactly ONE current row when the same item is ingested concurrently', async () => {
+    const originId = 'reddit_post_t3_race_fresh';
+
+    // 8 concurrent ingests of a brand-new origin_id. On the unserialized path
+    // every racer sees "no current row" and inserts fresh with
+    // supersedes_event_id NULL → 8 current rows. With the advisory lock they
+    // serialize: the first inserts, the rest dedup/supersede, leaving one.
+    const params = (content: string) => ({
+      entityIds: [],
+      organizationId: org.id,
+      originId,
+      title: 'Bitbucket down?',
+      content,
+      semanticType: 'content',
+      originType: 'post',
+      connectorKey: 'reddit',
+      connectionId,
+      occurredAt: new Date('2026-04-07T18:05:55Z'),
+      metadata: {},
+    });
+
+    const results = await Promise.allSettled(
+      Array.from({ length: 8 }, (_, i) =>
+        // Mix identical and content-changing payloads to exercise both the
+        // fresh-insert and the supersede branch under contention.
+        insertEvent(params(i % 2 === 0 ? 'same body' : `changed body ${i}`), {
+          onConflictUpdate: true,
+        })
+      )
+    );
+
+    const rejected = results.filter((r) => r.status === 'rejected');
+    expect(
+      rejected.map((r) => (r as PromiseRejectedResult).reason?.message ?? String(r))
+    ).toEqual([]);
+
+    const sql = getTestDb();
+    const current = await sql`
+      SELECT id FROM current_event_records
+      WHERE organization_id = ${org.id}
+        AND connection_id = ${connectionId}
+        AND origin_id = ${originId}
+    `;
+    expect(current).toHaveLength(1);
+  });
+
+  it('survives a concurrent burst of content updates without duplicate-key failures', async () => {
+    const originId = 'reddit_post_t3_race_update';
+
+    // Seed one current row first.
+    await insertEvent(
+      {
+        entityIds: [],
+        organizationId: org.id,
+        originId,
+        title: 'Score post',
+        content: 'score 1',
+        semanticType: 'content',
+        originType: 'post',
+        connectorKey: 'reddit',
+        connectionId,
+        occurredAt: new Date('2026-04-08T00:00:00Z'),
+        score: 1,
+        metadata: {},
+      },
+      { onConflictUpdate: true }
+    );
+
+    // 10 concurrent score updates (each a distinct payload → each wants to
+    // supersede the current row). On the unserialized path several collide on
+    // idx_events_superseded_by and throw.
+    const results = await Promise.allSettled(
+      Array.from({ length: 10 }, (_, i) =>
+        insertEvent(
+          {
+            entityIds: [],
+            organizationId: org.id,
+            originId,
+            title: 'Score post',
+            content: `score ${i + 2}`,
+            semanticType: 'content',
+            originType: 'post',
+            connectorKey: 'reddit',
+            connectionId,
+            occurredAt: new Date('2026-04-08T00:00:00Z'),
+            score: i + 2,
+            metadata: {},
+          },
+          { onConflictUpdate: true }
+        )
+      )
+    );
+
+    const rejected = results.filter((r) => r.status === 'rejected');
+    expect(
+      rejected.map((r) => (r as PromiseRejectedResult).reason?.message ?? String(r))
+    ).toEqual([]);
+
+    const sql = getTestDb();
+    const current = await sql`
+      SELECT id FROM current_event_records
+      WHERE organization_id = ${org.id}
+        AND connection_id = ${connectionId}
+        AND origin_id = ${originId}
+    `;
+    expect(current).toHaveLength(1);
+  });
+});

--- a/packages/server/src/utils/insert-event.ts
+++ b/packages/server/src/utils/insert-event.ts
@@ -22,6 +22,29 @@ import logger from './logger';
  */
 const AUDIT_EVENT_RETRY = { maxRetries: 1, baseDelay: 500 } as const;
 
+// Namespace for pg_advisory_xact_lock(key1, key2) used to serialize the
+// dedup-on-(connection_id, origin_id) read-then-insert path below. Kept in the
+// signed int32 range required by PostgreSQL's two-key advisory lock overload.
+// "evdd" = events-dedup.
+const EVENT_DEDUP_LOCK_NAMESPACE = 0x65766464;
+
+/**
+ * Stable 32-bit FNV-1a hash of `connection_id:origin_id`, used as the second
+ * key for pg_advisory_xact_lock. Concurrent ingests of the SAME item
+ * (same connection + origin) serialize on this key; different items never
+ * contend. Collisions only cost a little extra serialization, never
+ * correctness.
+ */
+export function eventDedupLockKey(connectionId: number, originId: string): number {
+  let hash = 0x811c9dc5;
+  const s = `${connectionId}:${originId}`;
+  for (let i = 0; i < s.length; i++) {
+    hash ^= s.charCodeAt(i);
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return hash | 0;
+}
+
 // ============================================
 // Types
 // ============================================
@@ -239,45 +262,64 @@ export async function insertEvent(
   }
 
   const entityIdsValue = params.entityIds.length > 0 ? `{${params.entityIds.join(',')}}` : null;
-  let supersedesEventId = params.supersedesEventId ?? null;
 
   const requestedClientId = params.clientId ?? null;
 
-  if (options?.onConflictUpdate) {
-    const existing = await findCurrentEventByOrigin(sql, params);
-    if (existing) {
-      if (isSemanticallyEqual(existing, params)) {
-        // Reread before touching the embedding. If the row got
-        // deleted / tombstoned between findCurrentEventByOrigin and
-        // here, upsertEmbedding would FK-fail instead of letting us
-        // fall through cleanly to a fresh insert (CodeRabbit catch
-        // on PR #780).
-        const existingRows = await sql`
-          SELECT id, entity_ids, origin_id, title, semantic_type, created_at
-          FROM events
-          WHERE id = ${existing.id}
-          LIMIT 1
-        `;
-        const existingRow = existingRows[0] as InsertedEvent | undefined;
-        if (existingRow) {
-          await upsertEmbedding(existingRow.id, params.embedding, params.embeddingModel, sql);
-          return existingRow;
+  // Core find→decide→insert, parameterized on the active SQL handle so it can
+  // run either directly on the singleton pool or inside the dedup transaction
+  // below (which holds an advisory lock for the duration).
+  const runInsert = async (
+    activeSql: ReturnType<typeof getDb>
+  ): Promise<InsertedEvent> => {
+    let supersedesEventId = params.supersedesEventId ?? null;
+
+    if (options?.onConflictUpdate) {
+      const existing = await findCurrentEventByOrigin(activeSql, params);
+      if (existing) {
+        if (isSemanticallyEqual(existing, params)) {
+          // Reread before touching the embedding. If the row got
+          // deleted / tombstoned between findCurrentEventByOrigin and
+          // here, upsertEmbedding would FK-fail instead of letting us
+          // fall through cleanly to a fresh insert (CodeRabbit catch
+          // on PR #780).
+          const existingRows = await activeSql`
+            SELECT id, entity_ids, origin_id, title, semantic_type, created_at
+            FROM events
+            WHERE id = ${existing.id}
+            LIMIT 1
+          `;
+          const existingRow = existingRows[0] as InsertedEvent | undefined;
+          if (existingRow) {
+            await upsertEmbedding(
+              existingRow.id,
+              params.embedding,
+              params.embeddingModel,
+              activeSql
+            );
+            return existingRow;
+          }
+          // Race: the existing row was deleted/tombstoned between the
+          // findCurrentEventByOrigin lookup above and the SELECT here. Fall
+          // through into the INSERT path with `supersedesEventId` unset so we
+          // create a fresh row instead of crashing on `undefined.id`.
+          logger.warn(
+            { existingId: existing.id, originId: params.originId },
+            '[insert-event] existing row vanished between find and reread — proceeding with fresh insert'
+          );
+        } else {
+          supersedesEventId = existing.id;
         }
-        // Race: the existing row was deleted/tombstoned between the
-        // findCurrentEventByOrigin lookup above and the SELECT here. Fall
-        // through into the INSERT path with `supersedesEventId` unset so we
-        // create a fresh row instead of crashing on `undefined.id`.
-        logger.warn(
-          { existingId: existing.id, originId: params.originId },
-          '[insert-event] existing row vanished between find and reread — proceeding with fresh insert'
-        );
-      } else {
-        supersedesEventId = existing.id;
       }
     }
-  }
 
-  const insertWithClientId = (clientId: string | null) => sql`
+    return insertRow(activeSql, supersedesEventId);
+  };
+
+  const insertRow = async (
+    sql: ReturnType<typeof getDb>,
+    supersedesEventId: number | null
+  ): Promise<InsertedEvent> => {
+    const insertWithClientId = (clientId: string | null) => sql`
     INSERT INTO events (
       entity_ids, organization_id, origin_id, title,
       payload_type, payload_text, payload_data, payload_template, attachments, metadata,
@@ -362,8 +404,32 @@ export async function insertEvent(
         `Row was not persisted; check server logs for diagnostic context.`
     );
   }
-  await upsertEmbedding(inserted.id, params.embedding, params.embeddingModel, sql);
-  return inserted;
+    await upsertEmbedding(inserted.id, params.embedding, params.embeddingModel, sql);
+    return inserted;
+  };
+
+  // The dedup path (onConflictUpdate) is a non-atomic read-then-insert: it
+  // looks up the current row for (connection_id, origin_id), then either
+  // supersedes it or inserts fresh. Without serialization, two concurrent
+  // ingests of the SAME item — common under N>1 app replicas and even two
+  // overlapping runs on one replica — can both see "no current row" and both
+  // insert with supersedes_event_id NULL (→ permanent duplicate current rows),
+  // or both target the same row to supersede (→ duplicate-key error on
+  // idx_events_superseded_by, which fails the whole stream batch). Hold a
+  // transaction-scoped advisory lock keyed on (connection_id, origin_id) so
+  // these serialize. Only engage when we own the connection (no caller-supplied
+  // tx, which already runs in its own atomic scope) and have both keys.
+  if (options?.onConflictUpdate && !options.sql && params.connectionId && params.originId) {
+    const lockKey = eventDedupLockKey(params.connectionId, params.originId);
+    return sql.begin(async (tx) => {
+      await tx`
+        SELECT pg_advisory_xact_lock(${EVENT_DEDUP_LOCK_NAMESPACE}, ${lockKey})
+      `;
+      return runInsert(tx as unknown as ReturnType<typeof getDb>);
+    }) as Promise<InsertedEvent>;
+  }
+
+  return runInsert(sql);
 }
 
 // ============================================


### PR DESCRIPTION
## Problem

`insertEvent(..., { onConflictUpdate: true })` — the connector-ingest dedup path — is a non-atomic read-then-insert: it looks up the current row for `(connection_id, origin_id)`, then either supersedes it (content changed) or inserts fresh (no current row). There is **no unique constraint** on `(connection_id, origin_id)`; the only DB guard is the partial unique index `idx_events_superseded_by` on `supersedes_event_id`. The param name `onConflictUpdate` is misleading — there is no `ON CONFLICT`.

Under N>1 app replicas (prod reality per AGENTS.md) and even two overlapping runs on a single replica, two concurrent ingests of the **same** item race:

- **New origin_id:** both racers see "no current row" and both insert with `supersedes_event_id = NULL` → **two permanent current rows** for one key. Later updates supersede only one chain, leaving the other as a forever-orphan duplicate.
- **Existing origin_id:** both target the same current row to supersede → one wins `idx_events_superseded_by`, the other throws `duplicate key value violates unique constraint "idx_events_superseded_by"`, which fails the whole stream batch.

### Found live in prod (org `Market`, `org_617e78013e6ff72d`)

- **224,232 duplicate reddit current rows** (55,712 dup `(connection_id, origin_id)` groups), every one within a *single* `connection_id` — not the multi-connection artifact. Still growing **~2,532/week** (last full week).
- Recurring reddit run failures with exactly the `idx_events_superseded_by` duplicate-key message.
- Cross-connector current-record duplicates: hackernews +21k, x +17k, ios_appstore +14k.

## Fix

Wrap the read→decide→insert in a transaction holding a transaction-scoped `pg_advisory_xact_lock` keyed on `(connection_id, origin_id)` (FNV-1a hash, dedicated namespace), so concurrent ingests of the same item serialize while different items never contend. This reuses the established advisory-lock pattern from `personal-org-provisioning.ts`.

Engaged **only** for the connector dedup path (`onConflictUpdate`, no caller-supplied tx, both keys present). Caller-supplied transactions (identity engine) and non-dedup inserts are unchanged.

## Reproducer (red → green)

`src/__tests__/integration/events/insert-event-dedup-race.test.ts` fires concurrent bursts (8 fresh inserts mixing identical + content-changing payloads; 10 concurrent score updates) at one `(connection_id, origin_id)` and asserts exactly one current row survives and nothing throws.

**Without the fix:**
```
AssertionError: expected [ …(7) ] to deeply equal []
+   "duplicate key value violates unique constraint \"idx_events_superseded_by\"",  (×7)
 Tests  2 failed (2)
```
**With the fix:** `Tests 2 passed (2)`. Neighbor suites (supersession-hidden-not-deleted, delete-content-tombstone, embedding-model-stamp) still green: 12 passed. Server `tsc --noEmit` clean.

## Notes / not included
- This stops *new* duplicate creation. The ~287k existing duplicate current rows in prod need a separate, guarded backfill (supersede the older row in each `(connection_id, origin_id)` group) — not part of this PR.
- A belt-and-suspenders DB-level dedup (partial unique index) is impractical because supersession is expressed by a *second* row, not a column on the row itself; the advisory lock is the correct serialization point.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1286"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784168093&installation_id=136316292&pr_number=1286&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1286&signature=aeb3521248783f712a2f47ce6426772b4ef3984cad25f2ca52da3217c444dfe7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->