### PR TITLE
fix(spotify): stable origin_id for id-less tracks + day-bucketed top-track snapshots

### DIFF
--- a/packages/connectors/src/__tests__/connector-sdk.mock.ts
+++ b/packages/connectors/src/__tests__/connector-sdk.mock.ts
@@ -33,6 +33,9 @@ export function connectorSdkMock() {
     acquireBrowser: notUsed('acquireBrowser'),
     captureErrorArtifacts: notUsed('captureErrorArtifacts'),
     extensionNetworkSync: notUsed('extensionNetworkSync'),
+    createHttpClient: notUsed('createHttpClient'),
+    paginateByCursor: notUsed('paginateByCursor'),
+    paginateByOffset: notUsed('paginateByOffset'),
     ConnectorRuntime: class {},
     calculateEngagementScore: () => 0,
     extensionDomScrape: async (opts: DomScrapeOpts) => {

--- a/packages/connectors/src/__tests__/spotify.test.ts
+++ b/packages/connectors/src/__tests__/spotify.test.ts
@@ -1,0 +1,37 @@
+import { beforeAll, describe, expect, mock, test } from 'bun:test';
+import { connectorSdkMock } from './connector-sdk.mock';
+
+// Stub @lobu/connector-sdk so the connector imports without the browser stack.
+mock.module('@lobu/connector-sdk', connectorSdkMock);
+
+// biome-ignore lint/suspicious/noExplicitAny: dynamic import after mock
+let trackKey: any;
+
+beforeAll(async () => {
+  const mod = await import('../spotify');
+  trackKey = mod.trackKey;
+});
+
+describe('trackKey', () => {
+  test('uses the catalog id when present', () => {
+    expect(trackKey({ id: '6rguovIe3aoqPhdpiDVOae', uri: 'spotify:track:6rguovIe3aoqPhdpiDVOae' })).toBe(
+      '6rguovIe3aoqPhdpiDVOae'
+    );
+  });
+
+  // Regression: local files / unavailable tracks have id === null. Keying the
+  // origin_id on `track.id` directly produced `..._track_null` for ALL of them,
+  // so they collided and the dedup path superseded distinct tracks down to one
+  // surviving row (observed in prod: 50 distinct local tracks → 6 current rows).
+  test('falls back to the uri when id is null so distinct local tracks stay distinct', () => {
+    const a = trackKey({ id: null, uri: 'spotify:local:Artist+A:Album:Track+A:200' });
+    const b = trackKey({ id: null, uri: 'spotify:local:Artist+B:Album:Track+B:240' });
+
+    expect(a).toBe('spotify:local:Artist+A:Album:Track+A:200');
+    expect(b).toBe('spotify:local:Artist+B:Album:Track+B:240');
+    expect(a).not.toBe(b);
+    // Neither collapses onto the old `null` collision key.
+    expect(a).not.toBe('null');
+    expect(b).not.toBe('null');
+  });
+});

--- a/packages/connectors/src/spotify.ts
+++ b/packages/connectors/src/spotify.ts
@@ -42,7 +42,13 @@ interface SpotifyAlbum {
 }
 
 interface SpotifyTrack {
-  id: string;
+  /**
+   * Spotify catalog track id. Null for local files and unavailable tracks —
+   * use `trackKey()` for a stable per-track identifier, never `track.id`
+   * directly in an origin_id (otherwise every local track collides on
+   * `..._track_null` and supersedes the others).
+   */
+  id: string | null;
   name: string;
   artists: SpotifyArtist[];
   album: SpotifyAlbum;
@@ -110,6 +116,17 @@ interface SpotifyCheckpoint {
 
 function artistNames(artists: SpotifyArtist[]): string {
   return artists.map((a) => a.name).join(', ');
+}
+
+/**
+ * Stable per-track identifier for origin_ids. Spotify omits `id` for local
+ * files and unavailable tracks; falling back to the always-present `uri`
+ * (e.g. `spotify:local:...`) keeps each track distinct. Without this, every
+ * id-less track collapses onto `..._track_null` and the dedup path supersedes
+ * them down to a single surviving row (silent data loss).
+ */
+export function trackKey(track: { id: string | null; uri: string }): string {
+  return track.id ?? track.uri;
 }
 
 function albumArt(images: SpotifyImage[]): string | undefined {
@@ -331,7 +348,7 @@ export default class SpotifyConnector extends ConnectorRuntime {
       for (const item of items) {
         const track = item.track;
         events.push({
-          origin_id: `spotify_track_${track.id}`,
+          origin_id: `spotify_track_${trackKey(track)}`,
           title: track.name,
           payload_text: `${track.name} by ${artistNames(track.artists)} — ${track.album.name}`,
           author_name: artistNames(track.artists),
@@ -423,7 +440,7 @@ export default class SpotifyConnector extends ConnectorRuntime {
           if (!item.track) continue;
           const track = item.track;
           trackEvents.push({
-            origin_id: `spotify_pl_${pl.id}_track_${track.id}`,
+            origin_id: `spotify_pl_${pl.id}_track_${trackKey(track)}`,
             title: track.name,
             payload_text: `${track.name} by ${artistNames(track.artists)}`,
             author_name: artistNames(track.artists),
@@ -490,7 +507,7 @@ export default class SpotifyConnector extends ConnectorRuntime {
         const track = item.track;
         const playedAt = new Date(item.played_at);
         events.push({
-          origin_id: `spotify_play_${track.id}_${playedAt.getTime()}`,
+          origin_id: `spotify_play_${trackKey(track)}_${playedAt.getTime()}`,
           title: track.name,
           payload_text: `${track.name} by ${artistNames(track.artists)}`,
           author_name: artistNames(track.artists),
@@ -527,6 +544,8 @@ export default class SpotifyConnector extends ConnectorRuntime {
     const timeRange = (ctx.config.time_range as string) ?? 'medium_term';
     const events: EventEnvelope[] = [];
     let rank = 1;
+    // UTC-midnight bucket so re-syncs within the same day dedup (see occurred_at below).
+    const snapshotDay = new Date(`${new Date().toISOString().slice(0, 10)}T00:00:00.000Z`);
 
     const pages = paginateByOffset(
       async (offset) => {
@@ -541,12 +560,18 @@ export default class SpotifyConnector extends ConnectorRuntime {
     for await (const items of pages) {
       for (const track of items) {
         events.push({
-          origin_id: `spotify_top_${timeRange}_${track.id}`,
+          origin_id: `spotify_top_${timeRange}_${trackKey(track)}`,
           title: `#${rank} ${track.name}`,
           payload_text: `${track.name} by ${artistNames(track.artists)} — ${track.album.name}`,
           author_name: artistNames(track.artists),
           source_url: track.external_urls.spotify,
-          occurred_at: new Date(),
+          // Day-bucketed snapshot time. A bare `new Date()` makes every sync
+          // look new (occurred_at always differs), so an unchanged top-tracks
+          // ranking supersedes itself on each run and the events table grows
+          // unbounded with masked rows. Bucketing to UTC midnight lets an
+          // identical same-day snapshot dedup while still recording the new
+          // ranking whenever it actually shifts.
+          occurred_at: snapshotDay,
           origin_type: 'top_track',
           metadata: {
             artist: artistNames(track.artists),


### PR DESCRIPTION
## What

Two Spotify connector data-collection bugs found during a prod org audit (buremba personal org).

### Bug 1 — \`_track_null\` origin_id collision (data loss)
Local files and unavailable tracks have \`track.id === null\`, so every origin_id built from \`track.id\` collapsed onto \`..._track_null\`. The \`(connection_id, origin_id)\` dedup in \`insert-event.ts\` then **superseded distinct tracks down to a single surviving row**.

Prod evidence (buremba org): the \`spotify_pl_*_track_null\` bucket held 2,656 rows but only **6 current** (50 distinct payloads collapsed). Different local tracks were silently overwriting each other.

Fix: \`trackKey(track) = track.id ?? track.uri\`, used in all four origin_id sites (saved, playlist, recently-played, top tracks). \`uri\` is always present and unique (e.g. \`spotify:local:...\`).

### Bug 2 — top-tracks snapshot bloat
\`syncTopTracks\` stamped \`occurred_at: new Date()\`. Since occurred_at always differs, an **unchanged** top-tracks ranking failed \`isSemanticallyEqual\` on every sync and superseded itself, growing the events table unbounded with masked rows. Prod: one stable top-track origin_id had **16 superseded copies** across two days.

Fix: bucket \`occurred_at\` to UTC midnight so an identical same-day snapshot dedups, while a genuine ranking change still writes a new row.

## Reproducer (red→green)
\`packages/connectors/src/__tests__/spotify.test.ts\` asserts \`trackKey\` keeps two id-less local tracks distinct and never collapses onto \`null\`. Before this change \`trackKey\` did not exist and the inline \`track.id\` path produced the collision.

\`\`\`
bun test src/__tests__/spotify.test.ts  →  2 pass, 0 fail
bun run typecheck                        →  clean
\`\`\`

## Notes
- Type tightened: \`SpotifyTrack.id\` is now \`string | null\` (matches reality; propagates through all track-bearing types).
- Shared connector-sdk test mock gains \`createHttpClient\`/\`paginateByCursor\`/\`paginateByOffset\` stubs (superset requirement); linkedin tests still green.
- This fixes new collection going forward; existing superseded/duplicate prod rows are append-only history and are not rewritten.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1287"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784168099&installation_id=136316292&pr_number=1287&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1287&signature=6d66af52803a616b06c6a6a734e4ce32fc821cc8049280399d4ddd623a426268"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->