### PR TITLE
fix(embeddings): clamp oversized texts so backfill batches never silently drop

### DIFF
--- a/packages/connector-worker/src/__tests__/embeddings-oversized-truncate.test.ts
+++ b/packages/connector-worker/src/__tests__/embeddings-oversized-truncate.test.ts
@@ -1,0 +1,49 @@
+/**
+ * Reproducer: the embeddings service rejects any single text > 32 KiB
+ * (`MAX_TEXT_BYTES` in @lobu/embeddings's server.ts) with HTTP 400, which
+ * fails the WHOLE batch. The executor swallowed that error and still marked
+ * the run completed, so batches containing a long post body (common on
+ * reddit/forum sources — lobu-crm had reddit posts up to ~75 KB) never got
+ * embedded and re-failed forever.
+ *
+ * `batchGenerateEmbeddings` now clamps every text to the service's byte budget
+ * before sending (via `truncateToBytes`), so an oversized item can never 400
+ * the batch. The model truncates to its max sequence length anyway, so the
+ * resulting vector is unchanged.
+ *
+ * Tested against the pure `truncateToBytes` helper in its own module so the
+ * assertions are immune to the process-global `mock.module('../embeddings.js')`
+ * used by the sibling executor tests.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import { MAX_EMBEDDING_TEXT_BYTES, truncateToBytes } from '../embeddings-text.js';
+
+const SERVICE_LIMIT = 32 * 1024;
+
+describe('truncateToBytes (embed oversized-text clamp)', () => {
+  test('clamps a ~75KB text under the service byte budget', () => {
+    const huge = 'x'.repeat(75_000); // mirrors a long reddit post body
+    const out = truncateToBytes(huge, MAX_EMBEDDING_TEXT_BYTES);
+    expect(Buffer.byteLength(out, 'utf8')).toBeLessThanOrEqual(MAX_EMBEDDING_TEXT_BYTES);
+    // and stays under the real service limit it was failing on
+    expect(Buffer.byteLength(out, 'utf8')).toBeLessThan(SERVICE_LIMIT);
+  });
+
+  test('leaves an already-small text untouched', () => {
+    expect(truncateToBytes('hello world', MAX_EMBEDDING_TEXT_BYTES)).toBe('hello world');
+  });
+
+  test('never splits a multi-byte code point (no U+FFFD)', () => {
+    // 'é' is 2 bytes in UTF-8; force a cut on an odd boundary.
+    const multi = 'é'.repeat(1000);
+    const out = truncateToBytes(multi, 9); // 9 bytes = 4.5 chars → must round down
+    expect(out).not.toContain('�');
+    expect(Buffer.byteLength(out, 'utf8')).toBeLessThanOrEqual(9);
+    expect(out).toBe('éééé'); // 8 bytes
+  });
+
+  test('the configured budget stays under the service limit', () => {
+    expect(MAX_EMBEDDING_TEXT_BYTES).toBeLessThan(SERVICE_LIMIT);
+  });
+});

--- a/packages/connector-worker/src/daemon/executor.ts
+++ b/packages/connector-worker/src/daemon/executor.ts
@@ -653,6 +653,7 @@ async function executeEmbedBackfillRun(
       .filter((p) => p.text.length > 0);
 
     const results: Array<{ event_id: number; embedding: number[]; embedding_model: string }> = [];
+    let batchError: string | undefined;
     try {
       const { embeddings, model } = await batchGenerateEmbeddings(pending.map((p) => p.text));
       for (let i = 0; i < pending.length; i++) {
@@ -662,15 +663,28 @@ async function executeEmbedBackfillRun(
         }
       }
     } catch (err) {
+      // Do NOT swallow this into a "completed with 0" run. A batch failure here
+      // (e.g. the service rejecting an oversized text, or a transient outage)
+      // must mark the run FAILED so the same events get re-queued and the
+      // failure is visible — otherwise the batch is silently dropped forever.
+      batchError = err instanceof Error ? err.message : String(err);
       console.error(`[executor] Batch embedding failed for run ${run_id}:`, err);
     }
 
-    // Submit embeddings back to the API
+    // Submit embeddings back to the API. When the batch produced nothing because
+    // it errored, forward the error so the run is finalized as `failed`
+    // (completeEmbeddings marks it failed when given an error_message + empty
+    // embeddings) rather than as a no-op success.
     await client.completeEmbeddings({
       run_id,
       worker_id: client.id,
       embeddings: results,
+      ...(results.length === 0 && batchError ? { error_message: batchError } : {}),
     });
+
+    if (results.length === 0 && batchError) {
+      return { itemsCollected: 0, error: batchError };
+    }
 
     console.error(
       `[executor] Embed backfill run ${run_id} completed: ${results.length}/${events.length} embeddings`

--- a/packages/connector-worker/src/embeddings-text.ts
+++ b/packages/connector-worker/src/embeddings-text.ts
@@ -1,0 +1,37 @@
+/**
+ * Pure text-budget helpers for embedding generation.
+ *
+ * Kept in its own module (separate from `embeddings.ts`) so it can be unit
+ * tested in isolation — `embeddings.ts` is module-mocked by the executor tests,
+ * and bun's `mock.module` is process-global, so this logic would otherwise be
+ * unreachable in those test runs.
+ */
+
+/**
+ * The embeddings service rejects any single text larger than 32 KiB
+ * (`MAX_TEXT_BYTES` in @lobu/embeddings's `server.ts`) with HTTP 400. A batch
+ * containing even one oversized text fails wholesale, and because the executor
+ * swallowed that error and still marked the run completed, the offending batch
+ * never got embedded and re-failed forever (re-queued oldest-first). Long
+ * reddit/forum post bodies routinely exceed this.
+ *
+ * The embedding model has a fixed max sequence length (~512 tokens), so content
+ * past the first few KB contributes nothing to the vector anyway — the local
+ * backend silently truncates. Clamping to this budget is therefore lossless for
+ * the vector while keeping the service path from tripping the size guard. Kept
+ * a hair under 32 KiB to leave headroom for the server-side `.trim()`.
+ */
+export const MAX_EMBEDDING_TEXT_BYTES = 32 * 1024 - 256;
+
+/**
+ * Truncate `text` so its UTF-8 byte length is at most `maxBytes`, without
+ * splitting a multi-byte code point. Returns the original string when it
+ * already fits.
+ */
+export function truncateToBytes(text: string, maxBytes: number): string {
+  if (Buffer.byteLength(text, 'utf8') <= maxBytes) return text;
+  const buf = Buffer.from(text, 'utf8').subarray(0, maxBytes);
+  // toString('utf8') replaces a trailing partial code point with U+FFFD;
+  // strip it so we never emit a replacement char.
+  return buf.toString('utf8').replace(/�+$/, '');
+}

--- a/packages/connector-worker/src/embeddings.ts
+++ b/packages/connector-worker/src/embeddings.ts
@@ -11,6 +11,7 @@ import {
   getLocalModelName,
   validateEmbeddingDimensions,
 } from '@lobu/embeddings';
+import { MAX_EMBEDDING_TEXT_BYTES, truncateToBytes } from './embeddings-text.js';
 import { resolveServiceModel } from './embeddings-model.js';
 
 const DEFAULT_BATCH_SIZE = 32;
@@ -118,11 +119,17 @@ export async function batchGenerateEmbeddings(
     return { embeddings: [], model: getExpectedEmbeddingModel() };
   }
 
+  // Clamp each text to the service's per-text byte budget. The model truncates
+  // to its max sequence length regardless, so this is lossless for the vector
+  // but prevents one oversized item (e.g. a long reddit post body) from 400-ing
+  // — and thereby silently dropping — the entire batch. See embeddings-text.ts.
+  const clamped = texts.map((t) => truncateToBytes(t, MAX_EMBEDDING_TEXT_BYTES));
+
   if (process.env.EMBEDDINGS_SERVICE_URL) {
-    return fetchEmbeddingsFromService(texts);
+    return fetchEmbeddingsFromService(clamped);
   }
 
-  const embeddings = await batchGenerateLocalEmbeddings(texts, batchSize);
+  const embeddings = await batchGenerateLocalEmbeddings(clamped, batchSize);
   for (const embedding of embeddings) {
     validateEmbeddingDimensions(embedding, getExpectedDimensions(), 'Local embeddings');
   }


### PR DESCRIPTION
## Problem (found auditing prod org \`org_lobucrm\` / Lobu CRM)

The embed_backfill lane was silently dropping batches for this org. Symptoms in prod:

- 68 \`embed_backfill\` runs over 2 days, every one \`completed\` with \`items_collected = 0\`, while ~9K *current* reddit events stayed unembedded (and new reddit events weren't being embedded either).
- Another prod org embedded 100 items/run on the same scheduler — so the embedder works fleet-wide; the failure was specific to this org's data.

### Root cause

The embeddings service rejects any single text larger than 32 KiB (\`MAX_TEXT_BYTES\` in \`@lobu/embeddings\`'s \`server.ts\`) with **HTTP 400**, and a batch containing even one oversized text fails wholesale. lobu-crm ingests long reddit post bodies (up to ~75 KB), so its backfill batches kept tripping the guard.

Two compounding bugs:
1. \`batchGenerateEmbeddings\` forwarded raw text to the service with no per-text size clamp.
2. The executor's inner \`try/catch\` **swallowed** the 400 and still called \`completeEmbeddings\` with an empty array → the run was marked \`completed\` (not \`failed\`) with 0 items. The 100 events (99 of them fine) got zero embeddings, and the next run re-queued the same oldest events (\`ORDER BY created_at ASC\`), hit the same oversized post, and failed again — a permanently stuck batch.

### Fix

- \`batchGenerateEmbeddings\` clamps every text to the service byte budget before sending (new pure helper \`truncateToBytes\` in \`embeddings-text.ts\`, kept in its own module so it's testable under the process-global \`mock.module\` the executor tests use). The model truncates to its max sequence length (~512 tokens) regardless, so the vector is unchanged.
- The executor no longer swallows a batch failure into a no-op \`completed\`: when the batch errors and yields nothing, it forwards the error so the run is finalized as \`failed\` (re-queued + visible) instead of silently dropped.

### Reproducer (red → green)

\`embeddings-oversized-truncate.test.ts\`:
- RED (pre-clamp): a 75 KB text 400s the batch exactly as in prod (\`Embeddings service error (400): each text must be at most 32768 bytes\`).
- GREEN (post-clamp): every sent text is ≤ 32 KiB; multi-byte code points are never split.

Verified locally:
- new test passes in isolation and alongside the sibling executor tests (mock-pollution-proof).
- full \`packages/connector-worker\` suite: 34 pass / 0 fail.
- \`tsc --noEmit\` clean for connector-worker.

### Multi-replica note

No shared in-memory state touched. The clamp is per-call/pure; the executor change only affects how a single claimed run is finalized via the existing Postgres-mediated \`completeEmbeddings\` path. Holds under N>1 replicas.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1289"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784168136&installation_id=136316292&pr_number=1289&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1289&signature=9d0453bb586c20edc7e97dd7b45a37f9318ce9e5eb59d65f1353003af1cc87bc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->