### PR TITLE
fix(test): reap orphaned lobu-test-pg clusters (65G disk leak)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -185,14 +185,20 @@ clean-workers:
 # Orphaned `lobu-test-pg-*` embedded-Postgres clusters from other worktrees'
 # integration runs eat macOS shared-memory slots (SHMMNI=32), and `lobu run` /
 # `make review`'s integration suite then fail with "could not create shared
-# memory segment: No space left on device" (shmget). Reap them.
+# memory segment: No space left on device" (shmget). They ALSO leak their data
+# dir (~150-400 MB each) to $TMPDIR — a session of killed runs once piled up
+# 65 GB and filled the disk. Reap both the processes (SHM) and the dirs (disk).
 clean-test-pg:
 	@echo "🧹 Reaping orphaned lobu-test-pg embedded-Postgres clusters..."
 	@pkill -f 'lobu-test-pg' 2>/dev/null || true
 	@pkill -f '@embedded-postgres' 2>/dev/null || true
 	@sleep 1
+	@before=$$(df -m "$${TMPDIR:-/tmp}" 2>/dev/null | awk 'END{print $$4}'); \
+		find "$${TMPDIR:-/tmp}" -maxdepth 1 -name 'lobu-test-pg-*' -prune -exec rm -rf {} + 2>/dev/null || true; \
+		after=$$(df -m "$${TMPDIR:-/tmp}" 2>/dev/null | awk 'END{print $$4}'); \
+		echo "freed ~$$((after - before)) MB of leaked cluster dirs"
 	@echo "shm segments now: $$(ipcs -m 2>/dev/null | awk '/^m/{c++} END{print c+0}') / 32"
-	@echo "✅ Test-PG clusters reaped"
+	@echo "✅ Test-PG clusters + dirs reaped"
 
 # --- Local AI review gate ---------------------------------------------------
 # Local-only: runs the deterministic suites in cwd, then invokes pi against

--- a/Makefile
+++ b/Makefile
@@ -194,9 +194,16 @@ clean-test-pg:
 	@pkill -f '@embedded-postgres' 2>/dev/null || true
 	@sleep 1
 	@before=$$(df -m "$${TMPDIR:-/tmp}" 2>/dev/null | awk 'END{print $$4}'); \
-		find "$${TMPDIR:-/tmp}" -maxdepth 1 -name 'lobu-test-pg-*' -prune -exec rm -rf {} + 2>/dev/null || true; \
+		for d in "$${TMPDIR:-/tmp}"/lobu-test-pg-*; do \
+			[ -d "$$d" ] || continue; \
+			pid=$$(head -1 "$$d/postmaster.pid" 2>/dev/null); \
+			if [ -n "$$pid" ] && kill -0 "$$pid" 2>/dev/null; then \
+				echo "  skip live cluster $$d (pid $$pid)"; continue; \
+			fi; \
+			rm -rf "$$d"; \
+		done; \
 		after=$$(df -m "$${TMPDIR:-/tmp}" 2>/dev/null | awk 'END{print $$4}'); \
-		echo "freed ~$$((after - before)) MB of leaked cluster dirs"
+		echo "freed ~$$((after - before)) MB of leaked cluster dirs (live clusters skipped)"
 	@echo "shm segments now: $$(ipcs -m 2>/dev/null | awk '/^m/{c++} END{print c+0}') / 32"
 	@echo "✅ Test-PG clusters + dirs reaped"
 

--- a/packages/server/src/__tests__/setup/embedded-postgres-backend.ts
+++ b/packages/server/src/__tests__/setup/embedded-postgres-backend.ts
@@ -10,7 +10,7 @@
  */
 
 import { spawnSync } from 'node:child_process';
-import { mkdtempSync, rmSync } from 'node:fs';
+import { mkdtempSync, readdirSync, rmSync, statSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { injectPgvector, resolveEmbeddedNativeDir } from '@lobu/pgvector-embedded';
@@ -38,6 +38,54 @@ export interface EmbeddedBackend {
 }
 
 let active: EmbeddedBackend | null = null;
+let reapedStaleClusters = false;
+
+/**
+ * Reap orphaned `lobu-test-pg-*` clusters left by prior runs that were KILLED
+ * (SIGKILL / timeout / OOM / ENOSPC / `pkill`) before teardown could run — those
+ * paths skip BOTH the `beforeExit` hook and `async-exit-hook`, so the data dir
+ * (~150-400 MB each) leaks to tmp forever. A whole session of killed runs once
+ * piled up 65 GB and filled the disk; `make clean-test-pg` only freed SHM slots,
+ * never the dirs. This reaps any cluster older than the threshold (no test run
+ * lives that long), once per process, best-effort. Self-healing: every run
+ * cleans up the previous runs' leaks, so a kill can never accumulate.
+ */
+/** 1h — far longer than any integration run, so a hit is definitely orphaned. */
+export const STALE_CLUSTER_MS = 60 * 60 * 1000;
+
+/**
+ * Pure, testable core: remove `lobu-test-pg-*` dirs under `dir` whose mtime is
+ * older than `staleMs` relative to `now`. Returns how many were removed.
+ */
+export function reapStaleClustersIn(dir: string, now: number, staleMs: number): number {
+  let entries: string[];
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return 0;
+  }
+  let removed = 0;
+  for (const name of entries) {
+    if (!name.startsWith('lobu-test-pg-')) continue;
+    const path = join(dir, name);
+    try {
+      if (now - statSync(path).mtimeMs > staleMs) {
+        rmSync(path, { recursive: true, force: true });
+        removed++;
+      }
+    } catch {
+      // Racing another run's own cleanup, or a permission quirk — ignore.
+    }
+  }
+  return removed;
+}
+
+function reapStaleClusters(): void {
+  if (reapedStaleClusters) return;
+  reapedStaleClusters = true;
+  reapStaleClustersIn(tmpdir(), Date.now(), STALE_CLUSTER_MS);
+}
+
 let activeStopImpl: (() => Promise<void>) | null = null;
 let activeExitStopImpl: (() => void) | null = null;
 let stopPromise: Promise<void> | null = null;
@@ -97,6 +145,10 @@ export function stopActiveEmbeddedBackend(): Promise<void> {
 export async function startEmbeddedBackend(): Promise<EmbeddedBackend> {
   if (stopPromise) await stopPromise;
   if (active) return active;
+
+  // Self-heal: clear orphaned clusters from previously-killed runs before we add
+  // our own, so a kill can never accumulate disk (see reapStaleClusters).
+  reapStaleClusters();
 
   injectPgvector(resolveEmbeddedNativeDir());
 

--- a/packages/server/src/__tests__/setup/embedded-postgres-backend.ts
+++ b/packages/server/src/__tests__/setup/embedded-postgres-backend.ts
@@ -10,13 +10,14 @@
  */
 
 import { spawnSync } from 'node:child_process';
-import { mkdtempSync, readFileSync, readdirSync, rmSync, statSync } from 'node:fs';
+import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { injectPgvector, resolveEmbeddedNativeDir } from '@lobu/pgvector-embedded';
 import exitHook from 'async-exit-hook';
 import EmbeddedPostgres from 'embedded-postgres';
 import { withFreePortRetry } from './free-port';
+import { reapStaleClustersIn, STALE_CLUSTER_MS } from './reap-stale-clusters';
 
 // Importing `embedded-postgres` registers async-exit-hook, whose `beforeExit`
 // handler force-exits with code 0 (`process.nextTick(process.exit.bind(null, 0))`).
@@ -46,66 +47,11 @@ let reapedStaleClusters = false;
  * paths skip BOTH the `beforeExit` hook and `async-exit-hook`, so the data dir
  * (~150-400 MB each) leaks to tmp forever. A whole session of killed runs once
  * piled up 65 GB and filled the disk; `make clean-test-pg` only freed SHM slots,
- * never the dirs. This reaps any cluster older than the threshold (no test run
- * lives that long), once per process, best-effort. Self-healing: every run
- * cleans up the previous runs' leaks, so a kill can never accumulate.
+ * never the dirs. Self-healing: every run reaps the previous runs' leaks, once
+ * per process, before adding its own — so a kill can never accumulate. The pure
+ * logic lives in ./reap-stale-clusters (no embedded-postgres import, so the
+ * no-database unit suite can test it directly).
  */
-/** 1h — far longer than any integration run, so an *idle* hit is orphaned. */
-export const STALE_CLUSTER_MS = 60 * 60 * 1000;
-
-/**
- * True if `dir` holds a running Postgres: a `postmaster.pid` whose PID is a live
- * process. embedded-postgres writes this on start and removes it on clean stop,
- * so it's the authoritative "is this cluster in use" marker — never reap a dir
- * with a live owner, regardless of age (a long watch/CI run can exceed 1h).
- */
-function clusterIsLive(dir: string): boolean {
-  let pid: number;
-  try {
-    pid = Number.parseInt(readFileSync(join(dir, 'postmaster.pid'), 'utf8').split('\n', 1)[0], 10);
-  } catch {
-    return false; // no pid file → cleanly stopped or never started
-  }
-  if (!Number.isInteger(pid) || pid <= 0) return false;
-  try {
-    process.kill(pid, 0); // signal 0 = liveness probe; throws if the PID is gone
-    return true;
-  } catch (err) {
-    // ESRCH → process gone (dead, safe to reap). EPERM → exists but not ours
-    // (another user's live cluster) → treat as live, do not reap.
-    return (err as NodeJS.ErrnoException).code === 'EPERM';
-  }
-}
-
-/**
- * Pure, testable core: remove `lobu-test-pg-*` dirs under `dir` that are both
- * older than `staleMs` (relative to `now`) AND have no live Postgres owner.
- * The liveness gate means a still-running cluster is never deleted even if it
- * has outlived the staleness window. Returns how many were removed.
- */
-export function reapStaleClustersIn(dir: string, now: number, staleMs: number): number {
-  let entries: string[];
-  try {
-    entries = readdirSync(dir);
-  } catch {
-    return 0;
-  }
-  let removed = 0;
-  for (const name of entries) {
-    if (!name.startsWith('lobu-test-pg-')) continue;
-    const path = join(dir, name);
-    try {
-      if (now - statSync(path).mtimeMs <= staleMs) continue; // too young — maybe active
-      if (clusterIsLive(path)) continue; // running owner — never reap, any age
-      rmSync(path, { recursive: true, force: true });
-      removed++;
-    } catch {
-      // Racing another run's own cleanup, or a permission quirk — ignore.
-    }
-  }
-  return removed;
-}
-
 function reapStaleClusters(): void {
   if (reapedStaleClusters) return;
   reapedStaleClusters = true;

--- a/packages/server/src/__tests__/setup/embedded-postgres-backend.ts
+++ b/packages/server/src/__tests__/setup/embedded-postgres-backend.ts
@@ -10,7 +10,7 @@
  */
 
 import { spawnSync } from 'node:child_process';
-import { mkdtempSync, readdirSync, rmSync, statSync } from 'node:fs';
+import { mkdtempSync, readFileSync, readdirSync, rmSync, statSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { injectPgvector, resolveEmbeddedNativeDir } from '@lobu/pgvector-embedded';
@@ -50,12 +50,38 @@ let reapedStaleClusters = false;
  * lives that long), once per process, best-effort. Self-healing: every run
  * cleans up the previous runs' leaks, so a kill can never accumulate.
  */
-/** 1h — far longer than any integration run, so a hit is definitely orphaned. */
+/** 1h — far longer than any integration run, so an *idle* hit is orphaned. */
 export const STALE_CLUSTER_MS = 60 * 60 * 1000;
 
 /**
- * Pure, testable core: remove `lobu-test-pg-*` dirs under `dir` whose mtime is
- * older than `staleMs` relative to `now`. Returns how many were removed.
+ * True if `dir` holds a running Postgres: a `postmaster.pid` whose PID is a live
+ * process. embedded-postgres writes this on start and removes it on clean stop,
+ * so it's the authoritative "is this cluster in use" marker — never reap a dir
+ * with a live owner, regardless of age (a long watch/CI run can exceed 1h).
+ */
+function clusterIsLive(dir: string): boolean {
+  let pid: number;
+  try {
+    pid = Number.parseInt(readFileSync(join(dir, 'postmaster.pid'), 'utf8').split('\n', 1)[0], 10);
+  } catch {
+    return false; // no pid file → cleanly stopped or never started
+  }
+  if (!Number.isInteger(pid) || pid <= 0) return false;
+  try {
+    process.kill(pid, 0); // signal 0 = liveness probe; throws if the PID is gone
+    return true;
+  } catch (err) {
+    // ESRCH → process gone (dead, safe to reap). EPERM → exists but not ours
+    // (another user's live cluster) → treat as live, do not reap.
+    return (err as NodeJS.ErrnoException).code === 'EPERM';
+  }
+}
+
+/**
+ * Pure, testable core: remove `lobu-test-pg-*` dirs under `dir` that are both
+ * older than `staleMs` (relative to `now`) AND have no live Postgres owner.
+ * The liveness gate means a still-running cluster is never deleted even if it
+ * has outlived the staleness window. Returns how many were removed.
  */
 export function reapStaleClustersIn(dir: string, now: number, staleMs: number): number {
   let entries: string[];
@@ -69,10 +95,10 @@ export function reapStaleClustersIn(dir: string, now: number, staleMs: number): 
     if (!name.startsWith('lobu-test-pg-')) continue;
     const path = join(dir, name);
     try {
-      if (now - statSync(path).mtimeMs > staleMs) {
-        rmSync(path, { recursive: true, force: true });
-        removed++;
-      }
+      if (now - statSync(path).mtimeMs <= staleMs) continue; // too young — maybe active
+      if (clusterIsLive(path)) continue; // running owner — never reap, any age
+      rmSync(path, { recursive: true, force: true });
+      removed++;
     } catch {
       // Racing another run's own cleanup, or a permission quirk — ignore.
     }

--- a/packages/server/src/__tests__/setup/reap-stale-clusters.ts
+++ b/packages/server/src/__tests__/setup/reap-stale-clusters.ts
@@ -1,0 +1,71 @@
+/**
+ * Pure, side-effect-free reaper for orphaned embedded-Postgres test clusters.
+ *
+ * Killed test runs (SIGKILL / timeout / OOM / ENOSPC / `pkill`) skip teardown
+ * and leak their `lobu-test-pg-*` data dir (~150-400 MB) to tmp; a session of
+ * them once filled 65 GB. `startEmbeddedBackend()` calls this before creating
+ * its own cluster, so a kill can never accumulate.
+ *
+ * Deliberately imports ONLY node:fs/path — no `embedded-postgres` — so the
+ * no-database unit suite can import and test it without pulling the native
+ * embedded-Postgres package (the reason this lives in its own module).
+ */
+
+import { readFileSync, readdirSync, rmSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+
+/** 1h — far longer than any integration run, so an *idle* hit is orphaned. */
+export const STALE_CLUSTER_MS = 60 * 60 * 1000;
+
+/**
+ * True if `dir` holds a running Postgres: a `postmaster.pid` whose PID is a live
+ * process. embedded-postgres writes this on start and removes it on clean stop,
+ * so it's the authoritative "is this cluster in use" marker — never reap a dir
+ * with a live owner, regardless of age (a long watch/CI run can exceed 1h).
+ */
+export function clusterIsLive(dir: string): boolean {
+  let pid: number;
+  try {
+    pid = Number.parseInt(readFileSync(join(dir, 'postmaster.pid'), 'utf8').split('\n', 1)[0], 10);
+  } catch {
+    return false; // no pid file → cleanly stopped or never started
+  }
+  if (!Number.isInteger(pid) || pid <= 0) return false;
+  try {
+    process.kill(pid, 0); // signal 0 = liveness probe; throws if the PID is gone
+    return true;
+  } catch (err) {
+    // ESRCH → process gone (dead, safe to reap). EPERM → exists but not ours
+    // (another user's live cluster) → treat as live, do not reap.
+    return (err as NodeJS.ErrnoException).code === 'EPERM';
+  }
+}
+
+/**
+ * Remove `lobu-test-pg-*` dirs under `dir` that are both older than `staleMs`
+ * (relative to `now`) AND have no live Postgres owner. The liveness gate means a
+ * still-running cluster is never deleted even if it has outlived the staleness
+ * window. Returns how many were removed.
+ */
+export function reapStaleClustersIn(dir: string, now: number, staleMs: number): number {
+  let entries: string[];
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return 0;
+  }
+  let removed = 0;
+  for (const name of entries) {
+    if (!name.startsWith('lobu-test-pg-')) continue;
+    const path = join(dir, name);
+    try {
+      if (now - statSync(path).mtimeMs <= staleMs) continue; // too young — maybe active
+      if (clusterIsLive(path)) continue; // running owner — never reap, any age
+      rmSync(path, { recursive: true, force: true });
+      removed++;
+    } catch {
+      // Racing another run's own cleanup, or a permission quirk — ignore.
+    }
+  }
+  return removed;
+}

--- a/packages/server/src/__tests__/unit/reap-stale-clusters.test.ts
+++ b/packages/server/src/__tests__/unit/reap-stale-clusters.test.ts
@@ -7,7 +7,14 @@
  * every embedded-PG start, so a kill can never accumulate. This pins that logic.
  */
 
-import { existsSync, mkdirSync, mkdtempSync, rmSync, utimesSync } from 'node:fs';
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  utimesSync,
+  writeFileSync,
+} from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
@@ -46,6 +53,21 @@ describe('reapStaleClustersIn', () => {
     expect(existsSync(stale)).toBe(false); // reaped
     expect(existsSync(fresh)).toBe(true); // too young — a possibly-active run
     expect(existsSync(other)).toBe(true); // wrong prefix — never touched
+  });
+
+  it('keeps an OLD cluster that is still running (live postmaster.pid)', () => {
+    // A long watch/CI run can outlive the staleness window — its data dir must
+    // never be reaped while the cluster is alive (the review blocker).
+    const live = makeDir('lobu-test-pg-LIVE', STALE_CLUSTER_MS + 60_000);
+    writeFileSync(join(live, 'postmaster.pid'), `${process.pid}\n/some/data\n`); // our own live PID
+    const deadOwner = makeDir('lobu-test-pg-DEAD', STALE_CLUSTER_MS + 60_000);
+    writeFileSync(join(deadOwner, 'postmaster.pid'), '2147483646\n/some/data\n'); // PID that isn't running
+
+    const removed = reapStaleClustersIn(root, now, STALE_CLUSTER_MS);
+
+    expect(existsSync(live)).toBe(true); // live owner → never reaped, despite age
+    expect(existsSync(deadOwner)).toBe(false); // stale pid file, process gone → reaped
+    expect(removed).toBe(1);
   });
 
   it('is a no-op on a missing directory (never throws)', () => {

--- a/packages/server/src/__tests__/unit/reap-stale-clusters.test.ts
+++ b/packages/server/src/__tests__/unit/reap-stale-clusters.test.ts
@@ -7,6 +7,7 @@
  * every embedded-PG start, so a kill can never accumulate. This pins that logic.
  */
 
+import { spawnSync } from 'node:child_process';
 import {
   existsSync,
   mkdirSync,
@@ -15,13 +16,21 @@ import {
   utimesSync,
   writeFileSync,
 } from 'node:fs';
+
+/**
+ * A PID that is reliably dead across runtimes: spawn a process to completion
+ * (spawnSync reaps it), so its PID is freed. More portable than a magic
+ * out-of-range number, which `process.kill(pid, 0)` handles inconsistently
+ * (node throws ESRCH; bun can report it as alive).
+ */
+function deadPid(): number {
+  const r = spawnSync(process.execPath, ['-e', '0']);
+  return r.pid ?? 2147483646;
+}
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
-import {
-  reapStaleClustersIn,
-  STALE_CLUSTER_MS,
-} from '../setup/embedded-postgres-backend';
+import { reapStaleClustersIn, STALE_CLUSTER_MS } from '../setup/reap-stale-clusters';
 
 describe('reapStaleClustersIn', () => {
   let root: string;
@@ -61,7 +70,7 @@ describe('reapStaleClustersIn', () => {
     const live = makeDir('lobu-test-pg-LIVE', STALE_CLUSTER_MS + 60_000);
     writeFileSync(join(live, 'postmaster.pid'), `${process.pid}\n/some/data\n`); // our own live PID
     const deadOwner = makeDir('lobu-test-pg-DEAD', STALE_CLUSTER_MS + 60_000);
-    writeFileSync(join(deadOwner, 'postmaster.pid'), '2147483646\n/some/data\n'); // PID that isn't running
+    writeFileSync(join(deadOwner, 'postmaster.pid'), `${deadPid()}\n/some/data\n`); // reaped PID — not running
 
     const removed = reapStaleClustersIn(root, now, STALE_CLUSTER_MS);
 

--- a/packages/server/src/__tests__/unit/reap-stale-clusters.test.ts
+++ b/packages/server/src/__tests__/unit/reap-stale-clusters.test.ts
@@ -43,9 +43,13 @@ describe('reapStaleClustersIn', () => {
     rmSync(root, { recursive: true, force: true });
   });
 
-  function makeDir(name: string, ageMs: number): string {
+  // Writing the pid file must happen BEFORE utimesSync — creating a file inside
+  // the dir bumps the dir's mtime, which would otherwise make a "stale" dir look
+  // fresh and the reaper would skip it.
+  function makeDir(name: string, ageMs: number, pid?: number): string {
     const p = join(root, name);
     mkdirSync(p, { recursive: true });
+    if (pid !== undefined) writeFileSync(join(p, 'postmaster.pid'), `${pid}\n/some/data\n`);
     const t = (now - ageMs) / 1000; // utimes wants seconds
     utimesSync(p, t, t);
     return p;
@@ -67,10 +71,8 @@ describe('reapStaleClustersIn', () => {
   it('keeps an OLD cluster that is still running (live postmaster.pid)', () => {
     // A long watch/CI run can outlive the staleness window — its data dir must
     // never be reaped while the cluster is alive (the review blocker).
-    const live = makeDir('lobu-test-pg-LIVE', STALE_CLUSTER_MS + 60_000);
-    writeFileSync(join(live, 'postmaster.pid'), `${process.pid}\n/some/data\n`); // our own live PID
-    const deadOwner = makeDir('lobu-test-pg-DEAD', STALE_CLUSTER_MS + 60_000);
-    writeFileSync(join(deadOwner, 'postmaster.pid'), `${deadPid()}\n/some/data\n`); // reaped PID — not running
+    const live = makeDir('lobu-test-pg-LIVE', STALE_CLUSTER_MS + 60_000, process.pid); // our own live PID
+    const deadOwner = makeDir('lobu-test-pg-DEAD', STALE_CLUSTER_MS + 60_000, deadPid()); // reaped PID
 
     const removed = reapStaleClustersIn(root, now, STALE_CLUSTER_MS);
 

--- a/packages/server/src/__tests__/unit/reap-stale-clusters.test.ts
+++ b/packages/server/src/__tests__/unit/reap-stale-clusters.test.ts
@@ -1,0 +1,54 @@
+/**
+ * Unit test for the orphaned-cluster reaper (embedded-postgres-backend).
+ *
+ * Killed test runs (SIGKILL / timeout / OOM / ENOSPC) skip teardown and leak
+ * their `lobu-test-pg-*` data dir to tmp; a session of them once filled 65 GB.
+ * The reaper removes clusters older than the staleness threshold at the start of
+ * every embedded-PG start, so a kill can never accumulate. This pins that logic.
+ */
+
+import { existsSync, mkdirSync, mkdtempSync, rmSync, utimesSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import {
+  reapStaleClustersIn,
+  STALE_CLUSTER_MS,
+} from '../setup/embedded-postgres-backend';
+
+describe('reapStaleClustersIn', () => {
+  let root: string;
+  const now = Date.now();
+
+  beforeAll(() => {
+    root = mkdtempSync(join(tmpdir(), 'reaper-test-'));
+  });
+  afterAll(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  function makeDir(name: string, ageMs: number): string {
+    const p = join(root, name);
+    mkdirSync(p, { recursive: true });
+    const t = (now - ageMs) / 1000; // utimes wants seconds
+    utimesSync(p, t, t);
+    return p;
+  }
+
+  it('removes only stale lobu-test-pg-* dirs, keeps fresh and non-matching', () => {
+    const stale = makeDir('lobu-test-pg-OLD', STALE_CLUSTER_MS + 60_000);
+    const fresh = makeDir('lobu-test-pg-NEW', 5_000); // 5s old — active
+    const other = makeDir('some-other-dir', STALE_CLUSTER_MS + 60_000); // not ours
+
+    const removed = reapStaleClustersIn(root, now, STALE_CLUSTER_MS);
+
+    expect(removed).toBe(1);
+    expect(existsSync(stale)).toBe(false); // reaped
+    expect(existsSync(fresh)).toBe(true); // too young — a possibly-active run
+    expect(existsSync(other)).toBe(true); // wrong prefix — never touched
+  });
+
+  it('is a no-op on a missing directory (never throws)', () => {
+    expect(reapStaleClustersIn(join(root, 'does-not-exist'), now, STALE_CLUSTER_MS)).toBe(0);
+  });
+});


### PR DESCRIPTION
## Root cause

Embedded-Postgres (the no-external-DB test backend) creates a `lobu-test-pg-*` data dir per integration run. Normal teardown removes it — but a **killed** run (SIGKILL / timeout / OOM / ENOSPC / `pkill`) skips both the `beforeExit` hook and `async-exit-hook`, so the dir (~150-400 MB each) leaks to `$TMPDIR` forever. A session of killed runs **piled up 65 GB and filled the disk** (which then crashed running servers mid-task).

`make clean-test-pg` only `pkill`ed processes to free macOS SHM slots — it **never removed the dirs**, so the disk leak was unbounded.

## Fix

1. **Self-healing startup reaper.** `startEmbeddedBackend()` now removes any `lobu-test-pg-*` dir older than 1h *before* creating its own. Independent of how the prior run died, so a kill can never accumulate. Extracted as a pure, testable `reapStaleClustersIn(dir, now, staleMs)`.
2. **`make clean-test-pg` now `rm`s the dirs** (and reports freed MB), not just `pkill`.
3. **Unit test** for the reaper: stale removed, fresh/active + non-matching kept, missing dir is a no-throw.

## Validation

- Reaper logic verified (removes stale, keeps fresh/active + non-matching, no-throw on missing dir).
- `make clean-test-pg` functionally removes real cluster dirs and reports freed space.
- (This session: the manual cleanup freed 65G → disk went 123Mi → 66G.)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1291"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784168243&installation_id=136316292&pr_number=1291&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1291&signature=14abea8c907feb3b73fbc018b5c73848f1e7792301e9e0882528815084383ff7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed incomplete cleanup of orphaned Postgres test processes and temporary directories causing disk space leaks.

* **Chores**
  * Enhanced test environment maintenance with proactive cleanup of stale test directories and improved disk space reporting.

* **Tests**
  * Added comprehensive test coverage for cleanup functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->