### PR TITLE
fix(server): unblock Docker image build (createAuth TS2742 portability)

### DIFF
--- a/packages/server/src/auth/index.tsx
+++ b/packages/server/src/auth/index.tsx
@@ -86,7 +86,14 @@ export function clearAuthCacheForTests(): void {
  * OAuth providers are dynamically loaded from connector_definitions where login_enabled=true.
  * This allows enabling/disabling login providers via the admin UI without code changes.
  */
-export async function createAuth(env: Env, request?: Request) {
+// Return type is annotated explicitly (matching `authCache`'s element type)
+// rather than inferred: the inferred `betterAuth({...})` instance type inlines
+// a reference to better-auth's bundled `zod/v4/core`, which is non-portable in
+// a clean (Docker) install layout and trips TS2742 during `tsc --noEmit`.
+export async function createAuth(
+	env: Env,
+	request?: Request
+): Promise<ReturnType<typeof betterAuth>> {
 	const organizationId = (await resolveRequestOrganizationId(request)) ?? null;
 	const cacheKey = organizationId ?? "__system__";
 	const cached = authCache.get(cacheKey);
@@ -880,5 +887,5 @@ export async function createAuth(env: Env, request?: Request) {
 	// shape, required-vs-optional database/secret); the cache stores the general
 	// Auth<BetterAuthOptions> shape, so widen via unknown.
 	authCache.set(cacheKey, auth as unknown as ReturnType<typeof betterAuth>);
-	return auth;
+	return auth as unknown as ReturnType<typeof betterAuth>;
 }


### PR DESCRIPTION
## Prod-blocking: no lobu-app image has built since ~01:00

`Build and Push Images` → `build-app` has failed on **every** commit since ~01:00 (well before my preview PR #1279), so Flux has no new lobu-app image to roll — prod is frozen on the pre-01:00 image.

```
src/auth/index.tsx(89,23): error TS2742: The inferred type of 'createAuth'
cannot be named without a reference to 'better-auth/node_modules/zod/v4/core'.
This is likely not portable. A type annotation is necessary.
```

The inferred `betterAuth({...})` instance type returned by `createAuth` inlines a reference to better-auth's **bundled** `zod/v4/core`. Under bun's workspace hoisting (local + `make typecheck`) that path is nameable, so it passes; in the clean Docker install layout it isn't → TS2742 → `tsc --noEmit` exit 2 → image build fails.

## Fix
Annotate `createAuth`'s return as `Promise<ReturnType<typeof betterAuth>>` and cast `return auth` to it — matching what `authCache` already stores (line 889). Pins the public type to the nameable `Auth` type instead of the inlined structural one. No behavior change.

## Validation
- Local `bunx tsc --noEmit` (the exact Docker command) passes (it always did locally — the error is env-specific).
- **Authoritative:** triggered `build-images.yml` via workflow_dispatch on this branch to run the real Docker `build-app` step. Merging once that's green.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1294"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784190403&installation_id=136316292&pr_number=1294&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1294&signature=737f57acf60d0b3db21344fe72c4dc4aecd6f5354c59b0d9296a105428c612c2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Improved type safety and consistency in the authentication module through explicit type annotations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->