### PR TITLE
fix(server): stop expected 4xx tool faults from creating Sentry issues

### DIFF
--- a/packages/server/src/tools/admin/__tests__/action-router.test.ts
+++ b/packages/server/src/tools/admin/__tests__/action-router.test.ts
@@ -1,0 +1,31 @@
+/**
+ * Tests for routeAction's error-level classification.
+ *
+ * ToolUserError is an expected client fault (the REST/MCP layer turns it into a
+ * 4xx for the caller). routeAction must log it at `warn`, not `error`, so it
+ * stays out of the error log and the pino → Sentry alert feed. Genuine handler
+ * faults must still log at `error`.
+ *
+ * Tested via the exported pure `errorLogLevel` helper rather than by mocking the
+ * logger: the integration suite runs with `isolate: false` (shared module
+ * registry), so per-file mocks of the already-loaded logger singleton are
+ * unreliable.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { ToolUserError } from '../../../utils/errors';
+import { errorLogLevel } from '../action-router';
+
+describe('errorLogLevel', () => {
+  it('logs a ToolUserError at warn (any status)', () => {
+    expect(errorLogLevel(new ToolUserError('access denied', 403))).toBe('warn');
+    expect(errorLogLevel(new ToolUserError('already exists', 409))).toBe('warn');
+    expect(errorLogLevel(new ToolUserError('bad input'))).toBe('warn');
+  });
+
+  it('logs a genuine Error (and non-Error throwables) at error', () => {
+    expect(errorLogLevel(new Error('boom'))).toBe('error');
+    expect(errorLogLevel('a thrown string')).toBe('error');
+    expect(errorLogLevel(undefined)).toBe('error');
+  });
+});

--- a/packages/server/src/tools/admin/action-router.ts
+++ b/packages/server/src/tools/admin/action-router.ts
@@ -1,4 +1,5 @@
 import { getRequiredAccessLevel } from '../../auth/tool-access';
+import { ToolUserError } from '../../utils/errors';
 import logger from '../../utils/logger';
 import { enforceRoleScopeAccess, isSystemContext } from '../access-control';
 import type { ToolContext } from '../registry';
@@ -13,6 +14,16 @@ import type { ToolContext } from '../registry';
  *     list: () => handleList(args, env, ctx),
  *   });
  */
+/**
+ * Log level for an error caught in `routeAction`. ToolUserError is an expected
+ * client fault (the REST/MCP layer turns it into a 4xx) — log it at `warn` so it
+ * stays diagnosable without paging or leaking to the Sentry alert feed. Genuine
+ * handler faults log at `error`. Exported for direct unit testing.
+ */
+export function errorLogLevel(error: unknown): 'warn' | 'error' {
+  return error instanceof ToolUserError ? 'warn' : 'error';
+}
+
 function enforceActionAccess(toolName: string, action: string, ctx: ToolContext): void {
   // Watcher reactions and other in-process system calls historically run with
   // userId=null + isAuthenticated=true. Preserve that path while enforcing the
@@ -45,7 +56,13 @@ export async function routeAction<TResult>(
   try {
     return await handler();
   } catch (error) {
-    logger.error(
+    // ToolUserError is an expected client fault (bad input, not-found,
+    // permission denied, conflict) that the REST/MCP layer turns into a 4xx for
+    // the caller — it is NOT an operational error. Logging it at `error` both
+    // spams the error log and (via the pino→Sentry bridge) created noisy alerts
+    // for routine 409/403 outcomes. Log at `warn` so it stays diagnosable
+    // without paging; genuine handler faults still log at `error`.
+    logger[errorLogLevel(error)](
       {
         error,
         error_message: error instanceof Error ? error.message : String(error),

--- a/packages/server/src/tools/admin/manage_watchers/shared.ts
+++ b/packages/server/src/tools/admin/manage_watchers/shared.ts
@@ -274,7 +274,13 @@ export async function requireWatcherAccess(
   for (const row of rows) {
     const watcherOrgId = row.organization_id ? String(row.organization_id) : null;
     if (!watcherOrgId || watcherOrgId !== ctx.organizationId) {
-      throw new Error(`Access denied: watcher ${row.id} does not belong to your organization`);
+      // Cross-org access attempt is a client/permission fault, not a server
+      // error — surface it as a 403 ToolUserError so the REST layer returns the
+      // right status and it stays out of the operational alert feed.
+      throw new ToolUserError(
+        `Access denied: watcher ${row.id} does not belong to your organization`,
+        403
+      );
     }
 
     const entityIds = parseWatcherEntityIds(row.entity_ids);

--- a/packages/server/src/utils/__tests__/logger.test.ts
+++ b/packages/server/src/utils/__tests__/logger.test.ts
@@ -1,0 +1,36 @@
+/**
+ * Tests for the pino → Sentry forwarding guard in utils/logger.ts.
+ *
+ * Expected client-fault outcomes (ToolUserError / 4xx httpStatus) must NOT be
+ * forwarded to Sentry — they are returned to the caller as a 4xx and are not
+ * operational alerts. Genuine operational errors must still be captured. This
+ * is the path that previously turned routine 409/403 tool outcomes into Sentry
+ * issues (LOBU-BACKEND-12, LOBU-BACKEND-Z, LOBU-BACKEND-11).
+ *
+ * Tested via the exported pure predicate rather than by mocking `@sentry/node`:
+ * the integration suite runs with `isolate: false` (shared module registry),
+ * so per-file module mocks of an already-loaded singleton are unreliable.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { isExpectedClientFaultLog } from '../logger';
+
+describe('isExpectedClientFaultLog', () => {
+  it('skips a ToolUserError regardless of status', () => {
+    expect(isExpectedClientFaultLog({ type: 'ToolUserError', httpStatus: 409 })).toBe(true);
+    expect(isExpectedClientFaultLog({ type: 'ToolUserError' })).toBe(true);
+  });
+
+  it('skips any 4xx httpStatus (e.g. a 403 thrown as a plain Error)', () => {
+    expect(isExpectedClientFaultLog({ type: 'Error', httpStatus: 403 })).toBe(true);
+    expect(isExpectedClientFaultLog({ httpStatus: 400 })).toBe(true);
+    expect(isExpectedClientFaultLog({ httpStatus: 499 })).toBe(true);
+  });
+
+  it('forwards genuine operational errors (no 4xx status, not a ToolUserError)', () => {
+    expect(isExpectedClientFaultLog({ type: 'Error', message: 'db boom' })).toBe(false);
+    expect(isExpectedClientFaultLog({ type: 'Error', httpStatus: 500 })).toBe(false);
+    expect(isExpectedClientFaultLog({ httpStatus: 503 })).toBe(false);
+    expect(isExpectedClientFaultLog(undefined)).toBe(false);
+  });
+});

--- a/packages/server/src/utils/logger.ts
+++ b/packages/server/src/utils/logger.ts
@@ -51,6 +51,23 @@ const SENTRY_DEDUPE_WINDOW_MS = 60_000;
 const SENTRY_DEDUPE_MAX_ENTRIES = 1000;
 const sentryDedupe: Map<string, number> = new Map();
 
+/**
+ * True when a pino-serialized error represents an expected client fault that
+ * should NOT be forwarded to Sentry: a `ToolUserError`, or anything carrying a
+ * 4xx `httpStatus` (bad input, not-found, permission denied, conflict). These
+ * are already returned to the caller as a 4xx and are not operational alerts.
+ * Exported for direct unit testing (the integration suite runs with
+ * `isolate: false`, so module-level mocking of this path is unreliable).
+ */
+export function isExpectedClientFaultLog(
+  errObj: { type?: string; httpStatus?: number } | undefined
+): boolean {
+  if (!errObj) return false;
+  if (errObj.type === 'ToolUserError') return true;
+  const status = errObj.httpStatus;
+  return typeof status === 'number' && status >= 400 && status < 500;
+}
+
 function fingerprintAndCapture(parsed: Record<string, unknown>): void {
   const level = parsed.level;
   if (level !== 'error' && level !== 'fatal') return;
@@ -61,10 +78,24 @@ function fingerprintAndCapture(parsed: Record<string, unknown>): void {
 
   const msg = typeof parsed.msg === 'string' ? parsed.msg : 'logger.error';
   // pino.stdSerializers.err normalises both `err` and `error` (see serializers
-  // config below) to objects with `type` / `message` / `stack`.
+  // config below) to objects with `type` / `message` / `stack` (plus any own
+  // enumerable fields such as ToolUserError's `httpStatus`).
   const errObj =
-    (parsed.err as { type?: string; message?: string; stack?: string } | undefined) ??
-    (parsed.error as { type?: string; message?: string; stack?: string } | undefined);
+    (parsed.err as
+      | { type?: string; message?: string; stack?: string; httpStatus?: number }
+      | undefined) ??
+    (parsed.error as
+      | { type?: string; message?: string; stack?: string; httpStatus?: number }
+      | undefined);
+
+  // Expected client-fault outcomes (ToolUserError and anything carrying a 4xx
+  // httpStatus — bad input, not-found, permission denied, conflict) are already
+  // returned to the caller as a 4xx response; they are NOT operational alerts.
+  // `trackMCPToolCall` / `captureServerError` already skip them at the
+  // captureException layer, but a handler that *logs* the error (e.g.
+  // `routeAction`'s catch) still reaches this pino bridge. Skip here too so the
+  // three capture paths stay consistent and the alert feed stays clean.
+  if (isExpectedClientFaultLog(errObj)) return;
 
   // Include err.message in the fingerprint — pre-fix, "(msg, err.type,
   // top stack frame)" grouped distinct errors raised from the same


### PR DESCRIPTION
## What

Expected 4xx tool outcomes were creating Sentry issues. There are three Sentry-capture paths and only two skipped `ToolUserError`: `trackMCPToolCall` and `captureServerError` skip it, but `routeAction` catches every handler error, logs it at `error`, and the **pino→Sentry bridge** (`utils/logger.ts`) forwarded it. That turned routine 409/403 outcomes into alerts.

- **LOBU-BACKEND-12** — `entity_type_exists` (409 `ToolUserError`), 17 events
- **LOBU-BACKEND-Z** — `Access denied: watcher … does not belong to your organization` (a handled 403 thrown as a plain `Error`)

## Fixes (3 aligned edits)

- `utils/logger.ts` — the pino→Sentry bridge now skips `ToolUserError` / 4xx-`httpStatus` errors, matching the other two capture paths.
- `tools/admin/action-router.ts` — `routeAction` logs `ToolUserError` at `warn`, not `error` (root cause at the choke point; also de-spams the error log).
- `tools/admin/manage_watchers/shared.ts` — cross-org watcher access throws `ToolUserError(…, 403)` instead of a plain `Error` (also fixes the wrong 500 → 403 status).

## Tests

New unit tests, both green:
- `utils/__tests__/logger.test.ts` — bridge forwards a genuine `Error`, skips 409/403 `ToolUserError`.
- `tools/admin/__tests__/action-router.test.ts` — `ToolUserError` logs at `warn`, genuine `Error` at `error`.

## Verification

`make review BASE=origin/main`: **bug_free 86, simplicity 88, bugs 0, 0 blockers, tests_adequate: true, risk: low.** typecheck=0, unit=0. The integration suite's 3 failures are pre-existing `[env]` files untouched by this diff (`public-origin`, `public-pages-contract`, `sandbox/isolated-vm`), confirmed by pi.

This is logging/error-classification only — no product behavior change beyond the watcher 500→403 status correction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1295"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784198312&installation_id=136316292&pr_number=1295&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1295&signature=611bb8084c074db8d0575a972067350699a246a9daed25cdbee91b732e7cf20a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error classification to distinguish between user-caused errors (logged at warn level) and system errors (logged at error level).
  * Client-fault errors with 4xx status codes are now properly filtered and not forwarded to error tracking services.

* **Tests**
  * Added test suites for action router error handling and logger's Sentry integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->