### PR TITLE
fix(orchestrator): gracefully fall back when nix-shell is absent

### DIFF
--- a/packages/server/src/gateway/__tests__/embedded-deployment.test.ts
+++ b/packages/server/src/gateway/__tests__/embedded-deployment.test.ts
@@ -193,6 +193,30 @@ describe("EmbeddedDeploymentManager", () => {
       ]);
     });
 
+    test("falls back to a plain spawn when nix packages are declared but nix-shell is absent", async () => {
+      // Where nix-shell is unavailable (the prod app image bakes Chromium in
+      // directly rather than via Nix), an agent that declares nix packages must
+      // still spawn — degraded, without those packages — rather than crash the
+      // worker with `spawn nix-shell ENOENT`. Force the absent path via the
+      // operator flag so the test is deterministic regardless of host nix.
+      const prev = process.env.LOBU_DISABLE_NIX_SHELL;
+      process.env.LOBU_DISABLE_NIX_SHELL = "1";
+      try {
+        const msg = createTestMessagePayload({
+          nixConfig: { packages: ["chromium"] },
+        });
+        await manager.ensureDeployment("worker-nix", "user-1", "user-1", msg);
+        expect(mockChildProcesses).toHaveLength(1);
+        const cmd = mockSpawn.mock.calls.at(-1)?.[0];
+        // NOT nix-shell — fell back to the direct worker invocation.
+        expect(cmd).not.toBe("nix-shell");
+        expect(cmd).toBe(process.execPath);
+      } finally {
+        if (prev === undefined) process.env.LOBU_DISABLE_NIX_SHELL = undefined;
+        else process.env.LOBU_DISABLE_NIX_SHELL = prev;
+      }
+    });
+
     test("ensureDeployment with different names returns multiple entries", async () => {
       const msg1 = createTestMessagePayload({ agentId: "agent-a" });
       const msg2 = createTestMessagePayload({

--- a/packages/server/src/gateway/orchestration/impl/embedded-deployment.ts
+++ b/packages/server/src/gateway/orchestration/impl/embedded-deployment.ts
@@ -64,35 +64,6 @@ export function signalWorkerGroup(
  * cgroup limits + IPAddressDeny + capability drops. macOS dev hosts and
  * Linux hosts without user systemd fall back to plain `child_process.spawn`.
  */
-/**
- * Detect once whether `nix-shell` is available. Skills/agents declare native
- * deps via `nixConfig.packages`, which we normally provision by wrapping the
- * worker in `nix-shell -p …`. Containers/hosts without Nix (e.g. the prod app
- * image, which bakes Chromium in directly rather than via Nix) won't have it,
- * so we fall back to a plain spawn — mirroring `locateSystemdRun`'s graceful
- * degradation — instead of crashing the worker with `spawn nix-shell ENOENT`.
- * The declared packages are simply unavailable in that turn unless the image
- * already provides them; a turn that doesn't use them runs fine.
- */
-let cachedNixShell: string | null | undefined;
-function locateNixShell(): string | null {
-  if (cachedNixShell !== undefined) return cachedNixShell;
-  if (process.env.LOBU_DISABLE_NIX_SHELL === "1") {
-    cachedNixShell = null;
-    return cachedNixShell;
-  }
-  try {
-    execFileSync("nix-shell", ["--version"], {
-      stdio: "ignore",
-      timeout: 5_000,
-    });
-    cachedNixShell = "nix-shell";
-  } catch {
-    cachedNixShell = null;
-  }
-  return cachedNixShell;
-}
-
 let cachedSystemdRun: string | null | undefined;
 function locateSystemdRun(): string | null {
   if (cachedSystemdRun !== undefined) return cachedSystemdRun;
@@ -126,6 +97,35 @@ function locateSystemdRun(): string | null {
     cachedSystemdRun = null;
   }
   return cachedSystemdRun;
+}
+
+/**
+ * Detect once whether `nix-shell` is available. Skills/agents declare native
+ * deps via `nixConfig.packages`, which we normally provision by wrapping the
+ * worker in `nix-shell -p …`. Containers/hosts without Nix (e.g. the prod app
+ * image, which bakes Chromium in directly rather than via Nix) won't have it,
+ * so we fall back to a plain spawn — mirroring `locateSystemdRun`'s graceful
+ * degradation — instead of crashing the worker with `spawn nix-shell ENOENT`.
+ * The declared packages are simply unavailable in that turn unless the image
+ * already provides them; a turn that doesn't use them runs fine.
+ */
+let cachedNixShell: string | null | undefined;
+function locateNixShell(): string | null {
+  if (cachedNixShell !== undefined) return cachedNixShell;
+  if (process.env.LOBU_DISABLE_NIX_SHELL === "1") {
+    cachedNixShell = null;
+    return cachedNixShell;
+  }
+  try {
+    execFileSync("nix-shell", ["--version"], {
+      stdio: "ignore",
+      timeout: 5_000,
+    });
+    cachedNixShell = "nix-shell";
+  } catch {
+    cachedNixShell = null;
+  }
+  return cachedNixShell;
 }
 
 /**
@@ -774,6 +774,16 @@ export class EmbeddedDeploymentManager extends BaseDeploymentManager {
       let command: string;
       let spawnArgs: string[];
 
+      // ALWAYS validate declared nix package names, even when we end up falling
+      // back to a plain spawn below. `nix-shell -p <arg>` evaluates each <arg>
+      // as a Nix *expression*, so a bare string like `pkgs.fetchurl;
+      // builtins.exec …` or `import ./evil.nix` would run code at evaluation
+      // time. Never forward the raw skill string: validate it to a strict leaf
+      // (or known `<namespace>.<leaf>`) identifier and re-emit an explicit
+      // `pkgs.<name>` attribute reference instead. Done before the nix-shell
+      // presence check so a malicious package name is rejected regardless.
+      const packageRefs = nixPackages.map(nixPackageAttrRef);
+
       // Only wrap in nix-shell when nix packages are declared AND nix-shell is
       // actually present. Without it (e.g. the prod app image, which bakes
       // Chromium in directly), fall back to a plain spawn rather than crashing
@@ -781,13 +791,6 @@ export class EmbeddedDeploymentManager extends BaseDeploymentManager {
       // degradation as the systemd-run wrap below.
       const nixShell = nixPackages.length > 0 ? locateNixShell() : null;
       if (nixPackages.length > 0 && nixShell) {
-        // `nix-shell -p <arg>` evaluates each <arg> as a Nix *expression*, so a
-        // bare package string like `pkgs.fetchurl; builtins.exec …` or
-        // `import ./evil.nix` would run code at evaluation time. Never forward
-        // the raw skill string: validate it to a strict leaf (or known
-        // `<namespace>.<leaf>`) identifier and re-emit an explicit `pkgs.<name>`
-        // attribute reference instead.
-        const packageRefs = nixPackages.map(nixPackageAttrRef);
         // Wrap in nix-shell so nix binaries are on PATH. `-E` takes a single
         // expression that resolves to the build inputs; `pkgs` is bound to the
         // nixpkgs set via a `let` and every ref was validated above.

--- a/packages/server/src/gateway/orchestration/impl/embedded-deployment.ts
+++ b/packages/server/src/gateway/orchestration/impl/embedded-deployment.ts
@@ -64,6 +64,35 @@ export function signalWorkerGroup(
  * cgroup limits + IPAddressDeny + capability drops. macOS dev hosts and
  * Linux hosts without user systemd fall back to plain `child_process.spawn`.
  */
+/**
+ * Detect once whether `nix-shell` is available. Skills/agents declare native
+ * deps via `nixConfig.packages`, which we normally provision by wrapping the
+ * worker in `nix-shell -p …`. Containers/hosts without Nix (e.g. the prod app
+ * image, which bakes Chromium in directly rather than via Nix) won't have it,
+ * so we fall back to a plain spawn — mirroring `locateSystemdRun`'s graceful
+ * degradation — instead of crashing the worker with `spawn nix-shell ENOENT`.
+ * The declared packages are simply unavailable in that turn unless the image
+ * already provides them; a turn that doesn't use them runs fine.
+ */
+let cachedNixShell: string | null | undefined;
+function locateNixShell(): string | null {
+  if (cachedNixShell !== undefined) return cachedNixShell;
+  if (process.env.LOBU_DISABLE_NIX_SHELL === "1") {
+    cachedNixShell = null;
+    return cachedNixShell;
+  }
+  try {
+    execFileSync("nix-shell", ["--version"], {
+      stdio: "ignore",
+      timeout: 5_000,
+    });
+    cachedNixShell = "nix-shell";
+  } catch {
+    cachedNixShell = null;
+  }
+  return cachedNixShell;
+}
+
 let cachedSystemdRun: string | null | undefined;
 function locateSystemdRun(): string | null {
   if (cachedSystemdRun !== undefined) return cachedSystemdRun;
@@ -745,7 +774,13 @@ export class EmbeddedDeploymentManager extends BaseDeploymentManager {
       let command: string;
       let spawnArgs: string[];
 
-      if (nixPackages.length > 0) {
+      // Only wrap in nix-shell when nix packages are declared AND nix-shell is
+      // actually present. Without it (e.g. the prod app image, which bakes
+      // Chromium in directly), fall back to a plain spawn rather than crashing
+      // the worker with `spawn nix-shell ENOENT` — the same graceful
+      // degradation as the systemd-run wrap below.
+      const nixShell = nixPackages.length > 0 ? locateNixShell() : null;
+      if (nixPackages.length > 0 && nixShell) {
         // `nix-shell -p <arg>` evaluates each <arg> as a Nix *expression*, so a
         // bare package string like `pkgs.fetchurl; builtins.exec …` or
         // `import ./evil.nix` would run code at evaluation time. Never forward
@@ -756,7 +791,7 @@ export class EmbeddedDeploymentManager extends BaseDeploymentManager {
         // Wrap in nix-shell so nix binaries are on PATH. `-E` takes a single
         // expression that resolves to the build inputs; `pkgs` is bound to the
         // nixpkgs set via a `let` and every ref was validated above.
-        command = "nix-shell";
+        command = nixShell;
         spawnArgs = [
           "-E",
           `let pkgs = import <nixpkgs> {}; in pkgs.mkShell { buildInputs = [ ${packageRefs.join(" ")} ]; }`,
@@ -767,6 +802,11 @@ export class EmbeddedDeploymentManager extends BaseDeploymentManager {
           `Spawning embedded worker ${deploymentName} with nix packages: ${nixPackages.join(", ")}`
         );
       } else {
+        if (nixPackages.length > 0) {
+          logger.warn(
+            `nix-shell not available — spawning worker ${deploymentName} WITHOUT nix packages [${nixPackages.join(", ")}]. Declared native deps are unavailable unless baked into the runtime image; set LOBU_DISABLE_NIX_SHELL=1 to silence this probe.`
+          );
+        }
         command = workerInvocation.command;
         spawnArgs = workerInvocation.args;
       }


### PR DESCRIPTION
## Problem (found in prod e2e)
Verifying the Slack preview cross-org fix, food-ordering's worker died: `spawn nix-shell ENOENT`. The prod app container has **no nix-shell** (`kubectl exec … which nix-shell` → absent), but office-bot's deliveroo skill declares `nixPackages: chromium`, so the orchestrator wrapped the worker in `nix-shell -p …` unconditionally → crash → the user gets a worker-startup error instead of a reply. This blocks **any** nix-declaring agent in this cluster.

Note: the app image already bakes Chromium in (`docker/app/Dockerfile` → `patchright install chromium`), so provisioning chromium via Nix is redundant here — the right fix is to not hard-require nix-shell.

## Fix
Mirror the existing `locateSystemdRun()` graceful-degradation pattern: add `locateNixShell()` (probes `nix-shell --version`, cached, honors `LOBU_DISABLE_NIX_SHELL=1`) and only wrap in nix-shell when it's present. Otherwise spawn the worker directly and `warn` that declared native deps are unavailable unless baked into the image. No crash; turns that don't need the nix package run fine.

## Test
`embedded-deployment.test.ts`: an agent declaring `nixConfig.packages` spawns the plain worker invocation (not `nix-shell`) when nix-shell is forced absent via the flag. 28/28 pass.

## Verify plan
Merge → image build → Flux roll → re-send a Slack message to the food-ordering-linked channel → worker spawns (no ENOENT) and replies.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1297"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784198769&installation_id=136316292&pr_number=1297&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1297&signature=6dc0631eaf3bf8f07c063292f64888ce3222db6341ec0ce25b6e1b1ea470b950"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->