### PR TITLE
fix(gateway): deep config compare in agent-config update (stop spurious adapter restarts)

### DIFF
--- a/packages/server/src/__tests__/unit/config-equal.test.ts
+++ b/packages/server/src/__tests__/unit/config-equal.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "bun:test";
+import { configsEqual } from "../../gateway/connections/config-equal";
+
+// The agent-config update route uses configsEqual to decide whether a platform
+// update is a noop or must restart the adapter. It previously used a SHALLOW
+// compare, which compared nested objects by reference — so re-submitting an
+// identical config (a fresh object built per request) looked "changed" and
+// triggered a spurious adapter restart. configsEqual is deep + key-order
+// independent so an unchanged config is correctly a noop.
+
+// The old shallow logic, kept here to prove the regression it caused.
+function shallowEqual(
+  a: Record<string, unknown>,
+  b: Record<string, unknown>
+): boolean {
+  const aKeys = Object.keys(a);
+  const bKeys = Object.keys(b);
+  if (aKeys.length !== bKeys.length) return false;
+  for (const key of aKeys) {
+    if (a[key] !== b[key]) return false;
+  }
+  return true;
+}
+
+describe("configsEqual", () => {
+  it("regression: identical nested config is equal (no spurious restart)", () => {
+    // A freshly-built request body with the same Discord OAuth block + scopes.
+    const previous = {
+      platform: "discord",
+      oauth: { clientId: "abc", clientSecret: "***" },
+      scopes: ["bot", "messages.read"],
+    };
+    const resubmitted = {
+      platform: "discord",
+      oauth: { clientId: "abc", clientSecret: "***" },
+      scopes: ["bot", "messages.read"],
+    };
+
+    // The bug: shallow compared the nested oauth/scopes by reference → "changed".
+    expect(shallowEqual(resubmitted, previous)).toBe(false);
+    // The fix: deep compare sees they are structurally identical → noop.
+    expect(configsEqual(resubmitted, previous)).toBe(true);
+  });
+
+  it("is independent of object key insertion order", () => {
+    expect(
+      configsEqual(
+        { a: 1, nested: { x: 1, y: 2 } },
+        { nested: { y: 2, x: 1 }, a: 1 }
+      )
+    ).toBe(true);
+  });
+
+  it("detects a changed nested field", () => {
+    expect(
+      configsEqual({ oauth: { clientId: "abc" } }, { oauth: { clientId: "xyz" } })
+    ).toBe(false);
+  });
+
+  it("treats array order as significant (scope lists)", () => {
+    expect(configsEqual({ scopes: ["a", "b"] }, { scopes: ["b", "a"] })).toBe(
+      false
+    );
+  });
+
+  it("detects added or removed keys", () => {
+    expect(configsEqual({ a: 1 }, { a: 1, b: 2 })).toBe(false);
+    expect(configsEqual({ a: 1, b: 2 }, { a: 1 })).toBe(false);
+  });
+});

--- a/packages/server/src/gateway/connections/chat-instance-manager.ts
+++ b/packages/server/src/gateway/connections/chat-instance-manager.ts
@@ -53,41 +53,8 @@ import {
   type PlatformAdapterConfig,
   type PlatformConnection,
 } from "./types.js";
+import { configsEqual } from "./config-equal.js";
 
-/**
- * Stable canonical JSON serialization: object keys sorted recursively so two
- * structurally-equal configs serialize identically regardless of key insertion
- * order. Arrays preserve order (order is significant for things like scope
- * lists). Used by `configsEqual` to deep-compare nested config (Discord/Teams
- * OAuth blocks, scope arrays) — a shallow `!==` compares nested objects by
- * reference and never sees a changed inner field, so a stale config would
- * persist without restarting the adapter.
- */
-function stableStringify(value: unknown): string {
-  if (value === null || typeof value !== "object") {
-    return JSON.stringify(value) ?? "null";
-  }
-  if (Array.isArray(value)) {
-    return `[${value.map((item) => stableStringify(item)).join(",")}]`;
-  }
-  const entries = Object.keys(value as Record<string, unknown>)
-    .sort()
-    .map(
-      (key) =>
-        `${JSON.stringify(key)}:${stableStringify(
-          (value as Record<string, unknown>)[key]
-        )}`
-    );
-  return `{${entries.join(",")}}`;
-}
-
-/** Deep structural equality for plain config objects (nested-aware). */
-function configsEqual(
-  a: Record<string, unknown>,
-  b: Record<string, unknown>
-): boolean {
-  return stableStringify(a) === stableStringify(b);
-}
 
 const logger = createLogger("chat-instance-manager");
 

--- a/packages/server/src/gateway/connections/config-equal.ts
+++ b/packages/server/src/gateway/connections/config-equal.ts
@@ -1,0 +1,41 @@
+/**
+ * Stable canonical JSON serialization: object keys sorted recursively so two
+ * structurally-equal configs serialize identically regardless of key insertion
+ * order. Arrays preserve order (order is significant for things like scope
+ * lists). Used by `configsEqual` to deep-compare nested config (Discord/Teams
+ * OAuth blocks, scope arrays) — a shallow `!==` compares nested objects by
+ * reference and never sees a changed inner field, so a stale config would
+ * persist without restarting the adapter (and, conversely, an identical config
+ * re-submitted as a fresh object would spuriously look "changed").
+ */
+function stableStringify(value: unknown): string {
+  if (value === null || typeof value !== "object") {
+    return JSON.stringify(value) ?? "null";
+  }
+  if (Array.isArray(value)) {
+    return `[${value.map((item) => stableStringify(item)).join(",")}]`;
+  }
+  const entries = Object.keys(value as Record<string, unknown>)
+    .sort()
+    .map(
+      (key) =>
+        `${JSON.stringify(key)}:${stableStringify(
+          (value as Record<string, unknown>)[key]
+        )}`
+    );
+  return `{${entries.join(",")}}`;
+}
+
+/**
+ * Deep structural equality for plain config objects (nested-aware, key-order
+ * independent). Shared by `ChatInstanceManager` (decides whether to restart an
+ * adapter) and the agent-config update route (decides whether an update is a
+ * noop). These two MUST agree: the route used to use a shallow compare, which
+ * over-reported changes for nested config and triggered spurious restarts.
+ */
+export function configsEqual(
+  a: Record<string, unknown>,
+  b: Record<string, unknown>
+): boolean {
+  return stableStringify(a) === stableStringify(b);
+}

--- a/packages/server/src/lobu/agent-routes.ts
+++ b/packages/server/src/lobu/agent-routes.ts
@@ -14,6 +14,7 @@ import { providerOrgSecretName } from './stores/provider-secrets';
 import { OAuthClient } from '../gateway/auth/oauth/client';
 import { CLAUDE_PROVIDER } from '../gateway/auth/oauth/providers';
 import { ChannelBindingService } from '../gateway/channels/binding-service';
+import { configsEqual } from '../gateway/connections/config-equal';
 import { createAuthProfileLabel } from '../gateway/auth/settings/auth-profiles-manager';
 import type { Env } from '../index';
 import { getConfiguredPublicOrigin } from '../utils/public-origin';
@@ -1244,13 +1245,13 @@ routes.put('/:agentId/platforms/by-stable-id/:stableId', async (c) => {
     }
     merged.platform = platform;
 
-    const configChanged = !configsShallowEqual(merged, previousConfig);
+    const configChanged = !configsEqual(merged, previousConfig);
     // Settings (allowFrom, allowGroups, etc.) are persisted alongside the
     // platform config and are part of "did anything change?" — a
     // settings-only update must trigger willRestart, not be silently noop'd.
     const previousSettings = (current.settings ?? {}) as Record<string, unknown>;
     const mergedSettings = { allowGroups: true, ...settings } as Record<string, unknown>;
-    const settingsChanged = !configsShallowEqual(mergedSettings, previousSettings);
+    const settingsChanged = !configsEqual(mergedSettings, previousSettings);
 
     if (!configChanged && !settingsChanged) {
       return c.json({ noop: true, platform: current }, 200);
@@ -1279,20 +1280,6 @@ routes.put('/:agentId/platforms/by-stable-id/:stableId', async (c) => {
     );
   });
 });
-
-// Shallow equality check matching ChatInstanceManager.configsEqual semantics.
-function configsShallowEqual(
-  a: Record<string, unknown>,
-  b: Record<string, unknown>
-): boolean {
-  const aKeys = Object.keys(a);
-  const bKeys = Object.keys(b);
-  if (aKeys.length !== bKeys.length) return false;
-  for (const key of aKeys) {
-    if (a[key] !== b[key]) return false;
-  }
-  return true;
-}
 
 // ── Get platform ─────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
The agent-config platform update route decided 'did anything change?' with a shallow equality check, while ChatInstanceManager uses a deep one, even though a comment claimed they matched. The shallow compare looked at nested config (Discord/Teams OAuth blocks, scope arrays) by reference, so re-submitting an identical config (a fresh object built per request) always looked changed and triggered a spurious adapter restart instead of a noop.

This extracts the deep, key-order-independent configsEqual (stableStringify-based) into gateway/connections/config-equal.ts and shares it between ChatInstanceManager and the update route. The route now noops correctly when nothing actually changed. It never under-reports a real change since the deep compare is strictly more precise than shallow, so the only behavior change is removing false-positive restarts.

Reproducer in config-equal.test.ts: asserts the old shallow logic returns false (restart) for identical nested config while configsEqual returns true (noop), plus key-order independence, nested-change detection, array-order significance, and added/removed keys. Red on the old shallow impl, green on the deep one.

This is the configsEqual item deferred from #1293, done as its own tested PR since it is a behavior change rather than a no-op refactor.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1299"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784199526&installation_id=136316292&pr_number=1299&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1299&signature=e8c13b7fa497cd5c0c5a3f039e69c9b5a85bfaa879fc607a364c45ea4ed6e3bd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->