### PR TITLE
chore(db): hygiene round 2 — drop lobucrm scratch table + 3 redundant indexes

### DIFF
--- a/db/migrations/20260616130000_drop_mig_lobucrm_scratch.sql
+++ b/db/migrations/20260616130000_drop_mig_lobucrm_scratch.sql
@@ -1,0 +1,20 @@
+-- migrate:up
+
+-- Retire the one-off backfill scratch table from the 2026-05-26 lobucrm org
+-- reassignment. It maps event/feed ids to their original org (a rollback net
+-- for that migration), has ~155k rows / ~13 MB, no primary key, no indexes, and
+-- zero references in code or SQL. The reassignment is long verified in prod
+-- (org_lobucrm is active), so the net is no longer needed. Prod-only artifact —
+-- never in the baseline, so this is a no-op on fresh DBs via IF EXISTS.
+
+DROP TABLE IF EXISTS public._mig_lobucrm_20260526;
+
+-- migrate:down
+
+-- Reversibility restores the empty shell only; the ~155k rollback-map rows are
+-- not recoverable (and aren't needed — the reassignment is verified).
+CREATE TABLE IF NOT EXISTS public._mig_lobucrm_20260526 (
+    id bigint,
+    tbl text,
+    orig_org text
+);

--- a/db/migrations/20260616130010_drop_idx_events_source_embedding.sql
+++ b/db/migrations/20260616130010_drop_idx_events_source_embedding.sql
@@ -1,0 +1,20 @@
+-- migrate:up transaction:false
+
+-- Drop idx_events_source_embedding: a plain btree(event_id) on event_embeddings
+-- that exactly duplicates event_embeddings_pkey (also btree(event_id)). The PK
+-- serves every lookup the secondary did, so this is pure write + disk overhead
+-- on a hot ~15 GB / ~1.4M-row table. Redundancy is structural — independent of
+-- usage stats.
+--
+-- CONCURRENTLY (transaction:false, single statement) so the catalog drop never
+-- contends with readers/writers of event_embeddings during the Helm hook. One
+-- statement per transaction:false migration: dbmate sends the whole up block as
+-- one simple-query batch and Postgres wraps a multi-statement batch in an
+-- implicit transaction that CONCURRENTLY refuses to run inside.
+
+DROP INDEX CONCURRENTLY IF EXISTS public.idx_events_source_embedding;
+
+-- migrate:down transaction:false
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_events_source_embedding
+    ON public.event_embeddings (event_id);

--- a/db/migrations/20260616130020_drop_redundant_small_indexes.sql
+++ b/db/migrations/20260616130020_drop_redundant_small_indexes.sql
@@ -1,0 +1,37 @@
+-- migrate:up
+
+-- Two more provably-redundant indexes on small / low-write tables, where a plain
+-- DROP INDEX (momentary ACCESS EXCLUSIVE) is fine — no CONCURRENTLY needed.
+--
+--   geo_places_location_idx — gist(location), the postgis geometry index. The
+--       live reverse-geocoding path is the geo_lookup() function, which orders
+--       by ll_to_earth(lat,lng) KNN and is served entirely by
+--       geo_places_earth_idx (see migration 20260520120000). The `location`
+--       column + this 11 MB index are the superseded postgis approach — dead,
+--       not merely idle. (The vestigial `location` column itself is left for a
+--       separate change.)
+--   idx_connect_tokens_token — btree(token) that duplicates the UNIQUE
+--       connect_tokens_token_key on the same column; the unique index serves
+--       every lookup.
+
+DROP INDEX IF EXISTS public.geo_places_location_idx;
+DROP INDEX IF EXISTS public.idx_connect_tokens_token;
+
+-- migrate:down
+
+-- geo_places.location is prod-only drift (never in the #908 baseline), so guard
+-- the restore: recreate the index only where the column exists (prod), no-op on
+-- fresh DBs that never had it.
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public' AND table_name = 'geo_places' AND column_name = 'location'
+  ) THEN
+    CREATE INDEX IF NOT EXISTS geo_places_location_idx
+        ON public.geo_places USING gist (location);
+  END IF;
+END $$;
+
+CREATE INDEX IF NOT EXISTS idx_connect_tokens_token
+    ON public.connect_tokens USING btree (token);

--- a/packages/server/src/__tests__/integration/db/migration-invariants.test.ts
+++ b/packages/server/src/__tests__/integration/db/migration-invariants.test.ts
@@ -122,6 +122,31 @@ describe('migration invariants', () => {
       `;
       expect(hashIdx.map((r) => r.indexname)).toEqual(['oauth_tokens_token_hash_key']);
     });
+
+    it('redundant/dead indexes are dropped while their covering indexes remain (2026-06-16 audit round 2)', async () => {
+      const sql = getTestDb();
+      // Dropped: idx_events_source_embedding (dup of event_embeddings_pkey),
+      // idx_connect_tokens_token (dup of the UNIQUE connect_tokens_token_key),
+      // geo_places_location_idx (postgis index superseded by geo_places_earth_idx).
+      const dropped = await sql<{ indexname: string }[]>`
+        SELECT indexname FROM pg_indexes
+        WHERE schemaname = 'public'
+          AND indexname IN ('idx_events_source_embedding', 'idx_connect_tokens_token', 'geo_places_location_idx')
+      `;
+      expect(dropped).toHaveLength(0);
+
+      // The covering indexes that make the drops safe must still exist.
+      const kept = await sql<{ indexname: string }[]>`
+        SELECT indexname FROM pg_indexes
+        WHERE schemaname = 'public'
+          AND indexname IN ('event_embeddings_pkey', 'connect_tokens_token_key', 'geo_places_earth_idx')
+      `;
+      expect(kept.map((r) => r.indexname).sort()).toEqual([
+        'connect_tokens_token_key',
+        'event_embeddings_pkey',
+        'geo_places_earth_idx',
+      ]);
+    });
   });
 
   describe('functional contract: pending oauth_account uniqueness is per-user (#1121)', () => {

--- a/packages/server/src/__tests__/setup/test-db.ts
+++ b/packages/server/src/__tests__/setup/test-db.ts
@@ -442,7 +442,6 @@ async function fixSchemaConstraints(db: postgres.Sql): Promise<void> {
         completed_at timestamp with time zone,
         created_at timestamp with time zone NOT NULL DEFAULT now()
       );
-      CREATE INDEX IF NOT EXISTS idx_connect_tokens_token ON connect_tokens (token);
       CREATE INDEX IF NOT EXISTS idx_connect_tokens_connection_id ON connect_tokens (connection_id);
     `);
   } catch {


### PR DESCRIPTION
Follow-up to the 2026-06-16 prod schema audit (#1290). Drops one prod-only scratch table and three **provably-redundant / dead** indexes.

## Changes
| Migration | Drops |
|---|---|
| `…130000_drop_mig_lobucrm_scratch` | `_mig_lobucrm_20260526` — one-off backfill rollback-map (~155k rows / ~13 MB) from the 2026-05-26 lobucrm org reassignment; verified done, zero code refs, prod-only (no-op on fresh DBs) |
| `…130010_drop_idx_events_source_embedding` | `idx_events_source_embedding` — exact duplicate of `event_embeddings_pkey` (`btree(event_id)`) on the hot ~15 GB table; `CONCURRENTLY` |
| `…130020_drop_redundant_small_indexes` | `idx_connect_tokens_token` (dup of UNIQUE `connect_tokens_token_key`) + `geo_places_location_idx` (11 MB postgis `gist(location)` for the superseded geocoding path) |

## Why these, and why *not* the rest
The audit flagged ~100 cold (`idx_scan=0`) indexes, but **`idx_scan=0` is an unreliable drop signal here** — unique-constraint enforcement doesn't increment it (so `session_token_key`, webhook-dedupe, etc. all read as "unused"), and several back features that just run intermittently. So this PR drops **only** indexes that are redundant by *structure* or *dead code*, independent of usage stats:

- `idx_events_source_embedding` / `idx_connect_tokens_token` — byte-for-byte duplicates of another index on the same column; the covering index serves every lookup.
- `geo_places_location_idx` — the live `geo_lookup()` function orders by `ll_to_earth(lat,lng)` KNN and is served entirely by `geo_places_earth_idx` (migration `20260520120000`). The postgis `location` column + this index are the superseded approach — dead, not idle. (The vestigial `location` column itself is left for a separate change.)

Dormant-but-live feature indexes (`entities` vector/tsv/name, `event_classifications` GIN/source, `oauth_tokens_active`) are **kept** — dropping them would regress those queries when the feature next runs.

## Validation
Full **up → rollback → re-up** against the real baseline→latest chain with dbmate. Caught and fixed a prod-only-drift trap: `geo_places.location` isn't in the #908 baseline, so the rollback's index re-create is guarded to only run where the column exists (no-op on fresh DBs). New `migration-invariants` assertions pin the post-migration state in CI.

## Note (not in this PR)
The audit also found the embedding-gap question (#3): of 479k events lacking embeddings, ~102k have no text and ~357k are superseded (both correct); only ~19.5k are genuinely embeddable-but-stranded, due to the embed-backfill's recency bias for firehose orgs. Tracked separately.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1300"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784199804&installation_id=136316292&pr_number=1300&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1300&signature=1c0bad01c08c8e18870f8cf6464edbb79a2473d81dbaf03115af86338bf50428"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->