### PR TITLE
fix(server): expected entity-schema tool faults throw ToolUserError, not Error

### DIFF
--- a/packages/server/src/tools/admin/__tests__/action-router.test.ts
+++ b/packages/server/src/tools/admin/__tests__/action-router.test.ts
@@ -14,7 +14,16 @@
 
 import { describe, expect, it } from 'vitest';
 import { ToolUserError } from '../../../utils/errors';
-import { errorLogLevel } from '../action-router';
+import { errorLogLevel, requireField, routeAction } from '../action-router';
+import type { ToolContext } from '../../registry';
+
+const systemCtx = {
+  organizationId: 'org_123',
+  userId: null,
+  memberRole: null,
+  isAuthenticated: true,
+  scopes: ['mcp:admin'],
+} as unknown as ToolContext;
 
 describe('errorLogLevel', () => {
   it('logs a ToolUserError at warn (any status)', () => {
@@ -27,5 +36,29 @@ describe('errorLogLevel', () => {
     expect(errorLogLevel(new Error('boom'))).toBe('error');
     expect(errorLogLevel('a thrown string')).toBe('error');
     expect(errorLogLevel(undefined)).toBe('error');
+  });
+});
+
+describe('requireField', () => {
+  it('throws a 400 ToolUserError when the value is missing', () => {
+    try {
+      requireField(undefined, 'slug', 'create');
+      throw new Error('should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(ToolUserError);
+      expect((err as ToolUserError).httpStatus).toBe(400);
+    }
+  });
+
+  it('returns the value when present', () => {
+    expect(requireField('x', 'slug', 'create')).toBe('x');
+  });
+});
+
+describe('routeAction unknown action', () => {
+  it('throws a 400 ToolUserError for an unregistered action', async () => {
+    await expect(routeAction('manage_entity', 'nope', systemCtx, {})).rejects.toBeInstanceOf(
+      ToolUserError
+    );
   });
 });

--- a/packages/server/src/tools/admin/action-router.ts
+++ b/packages/server/src/tools/admin/action-router.ts
@@ -48,7 +48,8 @@ export async function routeAction<TResult>(
 ): Promise<TResult> {
   const handler = handlers[action];
   if (!handler) {
-    throw new Error(`Unknown action: ${action}`);
+    // Unknown action is a caller/input fault (a 4xx), not an operational error.
+    throw new ToolUserError(`Unknown action: ${action}`, 400);
   }
 
   enforceActionAccess(toolName, action, ctx);
@@ -80,7 +81,9 @@ export async function routeAction<TResult>(
  */
 export function requireField<T>(value: T | undefined | null, fieldName: string, action: string): T {
   if (value === undefined || value === null) {
-    throw new Error(`${fieldName} is required for ${action} action`);
+    // Missing required input is a caller fault (a 400), not an operational
+    // error — so it returns the right status and stays out of the Sentry feed.
+    throw new ToolUserError(`${fieldName} is required for ${action} action`, 400);
   }
   return value;
 }

--- a/packages/server/src/tools/admin/manage_entity_schema.ts
+++ b/packages/server/src/tools/admin/manage_entity_schema.ts
@@ -518,7 +518,7 @@ async function etHandleGet(
   slug: string | undefined,
   ctx: ToolContext
 ): Promise<ManageEntitySchemaResult> {
-  if (!slug) throw new Error('slug is required for get action');
+  if (!slug) throw new ToolUserError('slug is required for get action', 400);
 
   const sql = getDb();
   const fetchRow = () =>
@@ -562,19 +562,20 @@ async function etHandleCreate(
   args: ManageEntitySchemaArgs,
   ctx: ToolContext
 ): Promise<ManageEntitySchemaResult> {
-  if (!args.slug) throw new Error('slug is required for create action');
-  if (!args.name) throw new Error('name is required for create action');
-  if (!ctx.userId) throw new Error('Authentication required to create entity types');
+  if (!args.slug) throw new ToolUserError('slug is required for create action', 400);
+  if (!args.name) throw new ToolUserError('name is required for create action', 400);
+  if (!ctx.userId) throw new ToolUserError('Authentication required to create entity types', 401);
 
   if (args.slug.startsWith('$')) {
-    throw new Error("Entity type slugs starting with '$' are reserved for system types");
+    throw new ToolUserError("Entity type slugs starting with '$' are reserved for system types", 422);
   }
 
   const slug = args.slug.toLowerCase().replace(/[^a-z0-9-]/g, '-');
 
   if (RESERVED_ENTITY_TYPES.includes(slug)) {
-    throw new Error(
-      `Cannot create entity type with reserved slug '${slug}'. Reserved: ${RESERVED_ENTITY_TYPES.join(', ')}`
+    throw new ToolUserError(
+      `Cannot create entity type with reserved slug '${slug}'. Reserved: ${RESERVED_ENTITY_TYPES.join(', ')}`,
+      422
     );
   }
 
@@ -650,8 +651,8 @@ async function etHandleUpdate(
   args: ManageEntitySchemaArgs,
   ctx: ToolContext
 ): Promise<ManageEntitySchemaResult> {
-  if (!args.slug) throw new Error('slug is required for update action');
-  if (!ctx.userId) throw new Error('Authentication required to update entity types');
+  if (!args.slug) throw new ToolUserError('slug is required for update action', 400);
+  if (!ctx.userId) throw new ToolUserError('Authentication required to update entity types', 401);
 
   const sql = getDb();
 
@@ -662,7 +663,7 @@ async function etHandleUpdate(
       AND organization_id = ${ctx.organizationId}
     LIMIT 1
   `;
-  if (existing.length === 0) throw new Error(`Entity type '${args.slug}' not found`);
+  if (existing.length === 0) throw new ToolUserError(`Entity type '${args.slug}' not found`, 404);
 
   const current = existing[0];
 
@@ -677,8 +678,9 @@ async function etHandleUpdate(
   if (args.backing?.sql) {
     const existingCount = await getEntityCountForType(Number(current.id), ctx.organizationId);
     if (existingCount > 0) {
-      throw new Error(
-        `Cannot make entity type '${args.slug}' derived: ${existingCount} stored ${existingCount === 1 ? 'entity exists' : 'entities exist'}. Delete them first.`
+      throw new ToolUserError(
+        `Cannot make entity type '${args.slug}' derived: ${existingCount} stored ${existingCount === 1 ? 'entity exists' : 'entities exist'}. Delete them first.`,
+        409
       );
     }
   }
@@ -753,8 +755,8 @@ async function etHandleDelete(
   slug: string | undefined,
   ctx: ToolContext
 ): Promise<ManageEntitySchemaResult> {
-  if (!slug) throw new Error('slug is required for delete action');
-  if (!ctx.userId) throw new Error('Authentication required to delete entity types');
+  if (!slug) throw new ToolUserError('slug is required for delete action', 400);
+  if (!ctx.userId) throw new ToolUserError('Authentication required to delete entity types', 401);
 
   const sql = getDb();
 
@@ -765,13 +767,14 @@ async function etHandleDelete(
       AND organization_id = ${ctx.organizationId}
     LIMIT 1
   `;
-  if (existing.length === 0) throw new Error(`Entity type '${slug}' not found`);
+  if (existing.length === 0) throw new ToolUserError(`Entity type '${slug}' not found`, 404);
 
   const current = existing[0];
   const entityCount = await getEntityCountForType(Number(current.id), ctx.organizationId);
   if (entityCount > 0) {
-    throw new Error(
-      `Cannot delete entity type '${slug}': ${entityCount} entities of this type exist. Remove or reassign them first.`
+    throw new ToolUserError(
+      `Cannot delete entity type '${slug}': ${entityCount} entities of this type exist. Remove or reassign them first.`,
+      409
     );
   }
 
@@ -804,7 +807,7 @@ async function etHandleAudit(
   slug: string | undefined,
   ctx: ToolContext
 ): Promise<ManageEntitySchemaResult> {
-  if (!slug) throw new Error('slug is required for audit action');
+  if (!slug) throw new ToolUserError('slug is required for audit action', 400);
 
   const sql = getDb();
 
@@ -816,7 +819,7 @@ async function etHandleAudit(
      LIMIT 1`,
     [slug, ctx.organizationId]
   );
-  if (existing.length === 0) throw new Error(`Entity type '${slug}' not found`);
+  if (existing.length === 0) throw new ToolUserError(`Entity type '${slug}' not found`, 404);
 
   const entityTypeId = existing[0].id;
 
@@ -876,7 +879,7 @@ async function requireRelationshipType(
   ctx: ToolContext,
   mode: 'read' | 'write' = 'write'
 ): Promise<{ typeId: number; sql: ReturnType<typeof getDb> }> {
-  if (!slug) throw new Error(`slug is required for ${action} action`);
+  if (!slug) throw new ToolUserError(`slug is required for ${action} action`, 400);
 
   const sql = getDb();
 
@@ -891,7 +894,7 @@ async function requireRelationshipType(
       ORDER BY (rt.organization_id = ${ctx.organizationId}) DESC, rt.id ASC
       LIMIT 1
     `;
-    if (rows.length === 0) throw new Error(`Relationship type "${slug}" not found`);
+    if (rows.length === 0) throw new ToolUserError(`Relationship type "${slug}" not found`, 404);
     return { typeId: Number(rows[0].id), sql };
   }
 
@@ -907,7 +910,7 @@ async function requireRelationshipType(
       AND organization_id = ${ctx.organizationId}
     LIMIT 1
   `;
-  if (existing.length === 0) throw new Error(`Relationship type "${slug}" not found`);
+  if (existing.length === 0) throw new ToolUserError(`Relationship type "${slug}" not found`, 404);
 
   return { typeId: Number(existing[0].id), sql };
 }
@@ -938,7 +941,7 @@ async function resolveInverseType(
     LIMIT 1
   `;
   if (rows.length === 0) {
-    throw new Error(`Inverse relationship type "${inverseSlug}" not found`);
+    throw new ToolUserError(`Inverse relationship type "${inverseSlug}" not found`, 404);
   }
   return { id: Number(rows[0].id), ownedByCaller: Boolean(rows[0].owned) };
 }
@@ -1020,7 +1023,7 @@ async function rtHandleGet(
   args: ManageEntitySchemaArgs,
   ctx: ToolContext
 ): Promise<ManageEntitySchemaResult> {
-  if (!args.slug) throw new Error('slug is required for get action');
+  if (!args.slug) throw new ToolUserError('slug is required for get action', 400);
 
   const sql = getDb();
   const rows = await sql`
@@ -1056,11 +1059,11 @@ async function rtHandleCreate(
   args: ManageEntitySchemaArgs,
   ctx: ToolContext
 ): Promise<ManageEntitySchemaResult> {
-  if (!args.slug) throw new Error('slug is required for create action');
-  if (!args.name) throw new Error('name is required for create action');
+  if (!args.slug) throw new ToolUserError('slug is required for create action', 400);
+  if (!args.name) throw new ToolUserError('name is required for create action', 400);
 
   if (args.slug.startsWith('$')) {
-    throw new Error("Relationship type slugs starting with '$' are reserved for system types");
+    throw new ToolUserError("Relationship type slugs starting with '$' are reserved for system types", 422);
   }
 
   const sql = getDb();
@@ -1155,7 +1158,7 @@ async function rtHandleUpdate(
       inverseTypeId = null;
     } else {
       const inverse = await resolveInverseType(sql, args.inverse_type_slug, ctx);
-      if (inverse.id === typeId) throw new Error('inverse_type_id cannot point to self');
+      if (inverse.id === typeId) throw new ToolUserError('inverse_type_id cannot point to self', 422);
       inverseTypeId = inverse.id;
     }
   }
@@ -1221,8 +1224,9 @@ async function rtHandleDelete(
   // under a deleted definition.
   const relationshipCount = await getRelationshipCountForType(typeId, ctx.organizationId);
   if (relationshipCount > 0) {
-    throw new Error(
-      `Cannot delete relationship type '${args.slug}': ${relationshipCount} relationships of this type exist. Remove or reassign them first.`
+    throw new ToolUserError(
+      `Cannot delete relationship type '${args.slug}': ${relationshipCount} relationships of this type exist. Remove or reassign them first.`,
+      409
     );
   }
 
@@ -1258,9 +1262,9 @@ async function rtHandleAddRule(
   ctx: ToolContext
 ): Promise<ManageEntitySchemaResult> {
   if (!args.source_entity_type_slug)
-    throw new Error('source_entity_type_slug is required for add_rule action');
+    throw new ToolUserError('source_entity_type_slug is required for add_rule action', 400);
   if (!args.target_entity_type_slug)
-    throw new Error('target_entity_type_slug is required for add_rule action');
+    throw new ToolUserError('target_entity_type_slug is required for add_rule action', 400);
 
   const { typeId, sql } = await requireRelationshipType(args.slug, 'add_rule', ctx);
 
@@ -1312,7 +1316,7 @@ async function rtHandleRemoveRule(
   args: ManageEntitySchemaArgs,
   ctx: ToolContext
 ): Promise<ManageEntitySchemaResult> {
-  if (!args.rule_id) throw new Error('rule_id is required for remove_rule action');
+  if (!args.rule_id) throw new ToolUserError('rule_id is required for remove_rule action', 400);
 
   const sql = getDb();
 
@@ -1323,11 +1327,11 @@ async function rtHandleRemoveRule(
     WHERE r.id = ${args.rule_id} AND r.deleted_at IS NULL
     LIMIT 1
   `;
-  if (ruleRows.length === 0) throw new Error(`Rule ${args.rule_id} not found`);
+  if (ruleRows.length === 0) throw new ToolUserError(`Rule ${args.rule_id} not found`, 404);
 
   const ruleOrgId = String(ruleRows[0].organization_id ?? '');
   if (ruleOrgId && ruleOrgId !== ctx.organizationId) {
-    throw new Error('Access denied: rule belongs to another organization');
+    throw new ToolUserError('Access denied: rule belongs to another organization', 403);
   }
 
   await sql`


### PR DESCRIPTION
Follow-up to #1295. The `manage_entity_schema` handlers and the shared `action-router` helpers threw plain `Error` for **expected client faults** (missing args, not-found, already-exists, can't-delete-while-referenced, reserved slug, cross-org access). `routeAction` logged those at `error` and the pino→Sentry bridge forwarded them (the entity/relationship-type leaks seen in the #1295 CI logs, same class as LOBU-BACKEND-11/12), and the REST layer returned **500 instead of the right 4xx**.

## Changes
- `manage_entity_schema.ts` — every expected fault now throws `ToolUserError` with an accurate status: **400** missing-input, **401** unauthenticated, **403** cross-org, **404** not-found, **409** conflict (delete-while-referenced / derived-with-entities), **422** invalid/reserved. Genuine internal invariants (`Failed to create entity type`, `not found after update`) stay plain `Error` so they still alert.
- `action-router.ts` — `requireField` and the "Unknown action" guard now throw `ToolUserError(400)`. Central: this fixes the "X is required" pattern for **every** handler that uses `requireField`.

## Tests
- `requireField` → 400 ToolUserError; unknown-action → ToolUserError; `errorLogLevel` classification.
- Full `make review`: bug_free 88 / simplicity 92 / 0 bugs / 0 blockers, behavior_change_risk low. `entity-types`/`prune`/`relationships-contract` integration suites pass with the new statuses; the one integration non-pass is the pre-existing `media.test.ts` afterEach env-timeout, outside this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1302"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784202378&installation_id=136316292&pr_number=1302&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1302&signature=40bac65a9f2c96658077c9f77b2b8d9a26ea08aef239a730a94104d734e87ab8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->