### PR TITLE
perf(ci): app image cache-to mode=min + dedicated scope

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -151,8 +151,8 @@ jobs:
             SKIP_WEB_BUILD=${{ steps.submodule.outputs.stubbed == 'true' }}
             VITE_SENTRY_DSN=${{ secrets.VITE_SENTRY_DSN }}
             VITE_ENVIRONMENT=production
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=app
+          cache-to: type=gha,mode=min,scope=app
 
       - name: Make image public
         run: |


### PR DESCRIPTION
Profiled the prod **app** image build (the merge→live critical path; `build-worker` ~0.6m and `build-embeddings` ~2.2m run in parallel and finish first):

| layer | step | time |
|---|---|---|
| #61 | **exporting cache → GHA Cache** (`cache-to mode=max`) | **152s** |
| #59 | exporting + pushing image → ghcr | 83s |
| #39 | `bun run build:server` | 40s |
| #41 | Vite frontend build | 36s |

The ~152s cache export is ~37% of the 6.8-min build and is **pure waste**: the Dockerfile's `ARG CACHEBUST=${{github.sha}}` invalidates all source layers every commit, so the exported builder-layer cache can never be reused.

## Change (app build only)
- `cache-to mode=max → mode=min` — export only final-image layers. **Zero build-correctness impact** (changes what's cached, not what's built; the image is byte-identical). Expected ~120–150s faster.
- `scope=app` — app shared the default gha scope with the embeddings build and they evicted each other; give it a dedicated scope.

Worker/embeddings untouched: off the critical path, and worker intentionally shares its cache scope with `connector-parity-smoke`.

Note: `build-images.yml` runs on push-to-`main` (no PR build), so this takes effect on the merge commit's build — I'll confirm the timing on the next run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1303"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784202787&installation_id=136316292&pr_number=1303&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1303&signature=08ef350d9fe092b7aff6b6da5011bb5dddd4da8ef2d62397e8bdb5fde6f8e9b9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->