### PR TITLE
fix(oauth): form-encode Claude token exchange to fix login

### DIFF
--- a/packages/server/src/gateway/auth/oauth/__tests__/client-token-format.test.ts
+++ b/packages/server/src/gateway/auth/oauth/__tests__/client-token-format.test.ts
@@ -1,0 +1,100 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { OAuthClient } from "../client.js";
+import { CLAUDE_PROVIDER, type OAuthProviderConfig } from "../providers.js";
+
+/**
+ * Regression guard for the Claude OAuth "Token exchange failed: 400 Bad Request"
+ * incident. Anthropic's token endpoint requires an
+ * `application/x-www-form-urlencoded` body (RFC 6749 §4.1.3); when the gateway
+ * sent JSON, Anthropic failed to parse the body and returned
+ * `invalid_grant: Invalid 'redirect_uri'`. The fix is `tokenRequestFormat:
+ * "form"` on CLAUDE_PROVIDER. These tests pin the request shape without hitting
+ * the network.
+ */
+
+interface CapturedRequest {
+  url: string;
+  contentType: string | null;
+  rawBody: string;
+}
+
+const originalFetch = globalThis.fetch;
+let captured: CapturedRequest | null;
+
+function stubFetch(): void {
+  captured = null;
+  globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const headers = new Headers(init?.headers);
+    captured = {
+      url: typeof input === "string" ? input : input.toString(),
+      contentType: headers.get("Content-Type"),
+      rawBody: String(init?.body ?? ""),
+    };
+    return new Response(
+      JSON.stringify({
+        access_token: "at_test",
+        refresh_token: "rt_test",
+        token_type: "Bearer",
+        expires_in: 3600,
+        scope: "user:inference",
+      }),
+      { status: 200, headers: { "content-type": "application/json" } }
+    );
+  }) as typeof globalThis.fetch;
+}
+
+beforeEach(stubFetch);
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+describe("OAuthClient token-request encoding", () => {
+  test("Claude exchange POSTs form-encoded body with the genuine field set", async () => {
+    const client = new OAuthClient(CLAUDE_PROVIDER);
+
+    await client.exchangeCodeForToken("auth_code_xyz", "verifier_abc", undefined, "state_123");
+
+    expect(captured).not.toBeNull();
+    const req = captured!;
+    expect(req.url).toBe(CLAUDE_PROVIDER.tokenUrl);
+    // The bug: this was "application/json". Anthropic requires form-encoding.
+    expect(req.contentType).toBe("application/x-www-form-urlencoded");
+
+    // Body must be parseable as form data with the exact genuine field set.
+    const form = new URLSearchParams(req.rawBody);
+    expect(form.get("grant_type")).toBe("authorization_code");
+    expect(form.get("code")).toBe("auth_code_xyz");
+    expect(form.get("code_verifier")).toBe("verifier_abc");
+    expect(form.get("state")).toBe("state_123");
+    expect(form.get("client_id")).toBe(CLAUDE_PROVIDER.clientId);
+    expect(form.get("redirect_uri")).toBe(CLAUDE_PROVIDER.redirectUri);
+    // The genuine claude-code exchange does NOT send expires_in.
+    expect(form.get("expires_in")).toBeNull();
+    // Sanity: it must not be JSON.
+    expect(req.rawBody.trim().startsWith("{")).toBe(false);
+  });
+
+  test("a provider without tokenRequestFormat still uses JSON (no regression for other providers)", async () => {
+    const jsonProvider: OAuthProviderConfig = {
+      id: "external-auth",
+      name: "External Auth",
+      clientId: "client_json",
+      authUrl: "https://provider.example/authorize",
+      tokenUrl: "https://provider.example/token",
+      redirectUri: "https://app.example/callback",
+      scope: "openid",
+      usePKCE: true,
+      requireRefreshToken: false,
+    };
+    const client = new OAuthClient(jsonProvider);
+
+    await client.exchangeCodeForToken("code_j", "verifier_j");
+
+    expect(captured).not.toBeNull();
+    const req = captured!;
+    expect(req.contentType).toBe("application/json");
+    const parsed = JSON.parse(req.rawBody);
+    expect(parsed.grant_type).toBe("authorization_code");
+    expect(parsed.client_id).toBe("client_json");
+  });
+});

--- a/packages/server/src/gateway/auth/oauth/client.ts
+++ b/packages/server/src/gateway/auth/oauth/client.ts
@@ -82,7 +82,7 @@ export class OAuthClient extends BaseOAuth2Client {
     const tokenData = await this.exchangeToken<OAuthTokenResponse>(
       this.config.tokenUrl,
       body,
-      "json",
+      this.config.tokenRequestFormat ?? "json",
       this.config.customHeaders
     );
 
@@ -106,7 +106,7 @@ export class OAuthClient extends BaseOAuth2Client {
       refreshToken,
       {
         customHeaders: this.config.customHeaders,
-        contentType: "json",
+        contentType: this.config.tokenRequestFormat ?? "json",
         tokenEndpointAuthMethod: this.config.tokenEndpointAuthMethod,
       }
     );

--- a/packages/server/src/gateway/auth/oauth/providers.ts
+++ b/packages/server/src/gateway/auth/oauth/providers.ts
@@ -41,6 +41,13 @@ export interface OAuthProviderConfig {
   extraAuthParams?: Record<string, string>;
   /** Extra static fields to include in the token exchange body */
   extraTokenParams?: Record<string, string | number>;
+  /**
+   * Encoding for the token-endpoint request body. RFC 6749 §4.1.3 mandates
+   * `form` (`application/x-www-form-urlencoded`); some lenient providers also
+   * accept `json`. Defaults to `json` to preserve existing behavior for
+   * providers not explicitly set.
+   */
+  tokenRequestFormat?: "json" | "form";
 }
 
 /**
@@ -50,11 +57,17 @@ export interface OAuthProviderConfig {
  * (`loginWithClaudeAi: true, inferenceOnly: true`). Anthropic's token endpoint
  * 429s any failed code exchange using this client_id, so we must match the
  * expected request shape exactly: claude.com authorize URL, the `code=true`
- * query flag, `user:inference` scope, and a long `expires_in` in the exchange.
+ * query flag, `user:inference` scope, and — critically — an
+ * `application/x-www-form-urlencoded` token-exchange body (`tokenRequestFormat:
+ * "form"`). The binary POSTs the exchange as form-encoded; sending JSON makes
+ * Anthropic fail to parse the body and return
+ * `invalid_grant: Invalid 'redirect_uri'`.
  *
- * Endpoints extracted from the current `@anthropic-ai/claude-code` binary —
- * Anthropic moved them from `claude.ai`/`console.anthropic.com` to
- * `claude.com`/`platform.claude.com` and the old hosts reject requests.
+ * Endpoints + request shape extracted from the current `@anthropic-ai/claude-code`
+ * binary — Anthropic moved hosts from `claude.ai`/`console.anthropic.com` to
+ * `claude.com`/`platform.claude.com` and the old hosts reject requests. The
+ * genuine exchange body is `{grant_type, code, redirect_uri, client_id,
+ * code_verifier, state}` with no `expires_in`.
  */
 export const CLAUDE_PROVIDER: OAuthProviderConfig = {
   id: "claude",
@@ -70,5 +83,5 @@ export const CLAUDE_PROVIDER: OAuthProviderConfig = {
   tokenEndpointAuthMethod: "none",
   requireRefreshToken: true,
   extraAuthParams: { code: "true" },
-  extraTokenParams: { expires_in: 31536000 },
+  tokenRequestFormat: "form",
 };


### PR DESCRIPTION
## Problem

Every Claude OAuth ("Login with Claude") attempt failed at the final step with a toast: **Token exchange failed: 400 Bad Request**.

Prod log (ground truth) showed Anthropic's own response:

```
[claude-client] Token exchange failed: 400
{"errorText":"{\"error\":\"invalid_grant\",\"error_description\":\"Invalid 'redirect_uri' in request.\"}"}
```

It was *not* PKCE/state (Postgres-backed, consumed on the same pod), not multi-replica, and not a wrong redirect_uri value.

## Root cause

The gateway POSTed the token exchange as `application/json`. Anthropic's token endpoint (`platform.claude.com/v1/oauth/token`) requires `application/x-www-form-urlencoded` per **RFC 6749 §4.1.3**. Given JSON, it parses no form fields, so `redirect_uri` (a required field) reads as absent → `invalid_grant: Invalid 'redirect_uri'`.

Triple-sourced:
- the genuine `@anthropic-ai/claude-code` binary POSTs the exchange with `Content-Type: application/x-www-form-urlencoded`, body `{grant_type, code, redirect_uri, client_id, code_verifier, state}` (no `expires_in`);
- RFC 6749 mandates form-encoding at the token endpoint;
- our own working sibling `connect/oauth-providers.ts` already form-encodes.

## Fix

- Add `tokenRequestFormat?: "json" | "form"` to `OAuthProviderConfig`, **defaulting to `"json"`** so every other provider (external-auth, etc.) is byte-identical.
- Set `CLAUDE_PROVIDER.tokenRequestFormat = "form"` for both the code exchange and the refresh path.
- Drop the non-standard `expires_in` body param the genuine client never sends.

## Verification

**Unit reproducer (red→green)** — `__tests__/client-token-format.test.ts`:
- On the old JSON code the Claude test fails exactly on `expect(contentType).toBe("application/x-www-form-urlencoded")`.
- On the fix both pass; a second case asserts a provider without `tokenRequestFormat` still uses JSON (no regression for other providers).

**Live E2E against real Anthropic** — drove the real `OAuthClient` code path through a genuine subscription consent + exchange:

```
✅ EXCHANGE OK
  access_token: sk-ant-oat01…
  refresh_token: present
  scopes: [ "user:inference" ]
```

## Other providers

Unaffected. API-key providers don't use `OAuthClient`; device-code uses `GenericDeviceCodeClient`; `connect/oauth-providers.ts` already form-encodes; external-auth keeps the `json` default (asserted by the unit test).

## Note (follow-up, not in this PR)

The issued access token's `expiresAt` is ~8h, not the year the old comment implied — these tokens need active refresh. The refresh path is now also form-encoded (fixed here), but whether anything calls it before expiry is a separate item to confirm.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1305"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784203390&installation_id=136316292&pr_number=1305&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1305&signature=1fc6ec13cf3d2ce2b086c6801e622adf381dcc6f74a20a8b09c2b54e60e7b3df"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->