### PR TITLE
fix(office-bot): flat-allow Deliveroo instead of LLM-judged egress

### DIFF
--- a/examples/office-bot/lobu.config.ts
+++ b/examples/office-bot/lobu.config.ts
@@ -7,9 +7,6 @@ import {
   skillFromFile,
 } from "@lobu/cli/config";
 
-const DELIVEROO_JUDGE =
-  "Allow GET requests that read restaurant listings, menus, item details, and the\ncurrent basket. Allow POST/PUT requests whose effect is limited to building or\nmodifying a basket / group order (adding, removing, changing quantity of items;\ncreating a shareable group-order link). DENY anything that completes checkout,\nsubmits payment, reads or writes saved payment methods, changes the delivery\naddress, or modifies the account profile. If the request's effect is unclear,\nfail closed and deny with a reason.\n";
-
 const foodOrdering = defineAgent({
   id: "food-ordering",
   name: "food-ordering",
@@ -28,6 +25,10 @@ const foodOrdering = defineAgent({
     slack: { enabled: true, surfaces: ["dm", "channel"], codeTtlMinutes: 15 },
   },
   network: {
+    // Deliveroo is a flat allow rather than LLM-judged: the egress judge needs
+    // an ANTHROPIC_API_KEY (OAuth tokens are rejected for direct API use), and
+    // the deliveroo-order skill's script has no checkout/payment path, so the
+    // per-request judge was defense-in-depth we opt out of here.
     allowed: [
       "api.z.ai",
       ".z.ai",
@@ -35,14 +36,11 @@ const foodOrdering = defineAgent({
       ".npmjs.org",
       "playwright.azureedge.net",
       "cdn.playwright.dev",
+      "deliveroo.co.uk",
+      ".deliveroo.co.uk",
+      "deliveroo.com",
+      ".deliveroo.com",
     ],
-    judged: [
-      { domain: "deliveroo.co.uk", judge: "deliveroo" },
-      { domain: ".deliveroo.co.uk", judge: "deliveroo" },
-      { domain: "deliveroo.com", judge: "deliveroo" },
-      { domain: ".deliveroo.com", judge: "deliveroo" },
-    ],
-    judges: { deliveroo: DELIVEROO_JUDGE },
   },
 });
 

--- a/examples/office-bot/skills/deliveroo-order/SKILL.md
+++ b/examples/office-bot/skills/deliveroo-order/SKILL.md
@@ -4,29 +4,17 @@ description: Read a restaurant's Deliveroo menu and assemble a group-order baske
 nixPackages:
   - chromium
 network:
+  # Deliveroo is a flat allow (not LLM-judged): the egress judge needs an
+  # ANTHROPIC_API_KEY, and this skill's script has no checkout/payment path.
   allow:
     - registry.npmjs.org
     - .npmjs.org
     - playwright.azureedge.net
     - cdn.playwright.dev
-  judge:
-    - domain: deliveroo.co.uk
-      judge: deliveroo
-    - domain: .deliveroo.co.uk
-      judge: deliveroo
-    - domain: deliveroo.com
-      judge: deliveroo
-    - domain: .deliveroo.com
-      judge: deliveroo
-judges:
-  deliveroo: >
-    Allow GET requests that read restaurant listings, menus, item details, and
-    the current basket. Allow POST/PUT requests whose effect is limited to
-    building or modifying a basket / group order (add, remove, change quantity;
-    create a shareable group-order link). DENY anything that completes checkout,
-    submits payment, reads or writes saved payment methods, changes the delivery
-    address, or modifies the account profile. If the effect is unclear, fail
-    closed and deny with a reason.
+    - deliveroo.co.uk
+    - .deliveroo.co.uk
+    - deliveroo.com
+    - .deliveroo.com
 ---
 
 # Deliveroo group order


### PR DESCRIPTION
## Why
The egress judge gating `deliveroo.co.uk` needs an `ANTHROPIC_API_KEY` for direct `/v1/messages`. Claude OAuth / Claude Code subscription tokens are **rejected** for direct API use — verified against the live API:
```
403 permission_error: OAuth authentication is currently not allowed for this organization
```
Rather than take an Anthropic-key dependency just for the judge, drop the per-request judge for Deliveroo. The `deliveroo-order` skill's script (`deliveroo.ts`) has **no checkout/payment path** — it reads menus and builds a basket, never pays — so the LLM judge was defense-in-depth, not a hard safety boundary.

## Change
Move `deliveroo.*` from `network.judged` → `network.allowed` in both the agent config and the skill `SKILL.md`; remove the now-unused judge prompt. `lobu validate` passes.

## Note
This removes the egress-judge blocker, but Deliveroo still can't complete a real order until the office-account cookies are provisioned (`lobu memory browser-auth --connector deliveroo --auth-profile-slug office`) — a separate, human-login step. The browser runtime itself (playwright + Chromium) is verified working in prod.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1306"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784203694&installation_id=136316292&pr_number=1306&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1306&signature=a815629be8166a3412e905c7d10f8372103a018dbde56b9d73cce542f725314e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->