### PR TITLE
test(oauth): pin ChatGPT device-code token-exchange encoding

### DIFF
--- a/packages/server/src/gateway/auth/chatgpt/__tests__/device-code-client.test.ts
+++ b/packages/server/src/gateway/auth/chatgpt/__tests__/device-code-client.test.ts
@@ -1,0 +1,137 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { ChatGPTDeviceCodeClient } from "../device-code-client.js";
+
+/**
+ * Regression guard for the ChatGPT (OpenAI Codex) device-code OAuth flow.
+ *
+ * The OAuth token exchange at https://auth.openai.com/oauth/token MUST be
+ * `application/x-www-form-urlencoded` (RFC 6749 §4.1.3) — the same class of bug
+ * that broke Claude login when its exchange was sent as JSON (see
+ * oauth/__tests__/client-token-format.test.ts). The device-auth endpoints
+ * (/api/accounts/deviceauth/*) are OpenAI's own JSON API and correctly use
+ * application/json. These tests pin both, without hitting the network.
+ */
+
+const TOKEN_EXCHANGE_URL = "https://auth.openai.com/oauth/token";
+const DEVICE_CODE_URL =
+  "https://auth.openai.com/api/accounts/deviceauth/usercode";
+const DEVICE_TOKEN_URL = "https://auth.openai.com/api/accounts/deviceauth/token";
+
+interface Captured {
+  url: string;
+  contentType: string | null;
+  rawBody: string;
+}
+
+// A throwaway unsigned JWT carrying the account claim, so extractAccountId works.
+function fakeJwt(accountId: string): string {
+  const header = Buffer.from(JSON.stringify({ alg: "none", typ: "JWT" })).toString(
+    "base64url"
+  );
+  const payload = Buffer.from(
+    JSON.stringify({
+      "https://api.openai.com/auth": { chatgpt_account_id: accountId },
+    })
+  ).toString("base64url");
+  return `${header}.${payload}.sig`;
+}
+
+const originalFetch = globalThis.fetch;
+let calls: Captured[];
+
+beforeEach(() => {
+  calls = [];
+  globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = typeof input === "string" ? input : input.toString();
+    const headers = new Headers(init?.headers);
+    calls.push({
+      url,
+      contentType: headers.get("Content-Type"),
+      rawBody: String(init?.body ?? ""),
+    });
+
+    if (url === DEVICE_CODE_URL) {
+      return new Response(
+        JSON.stringify({
+          device_auth_id: "dev_abc",
+          user_code: "ABCD-1234",
+          interval: 5,
+        }),
+        { status: 200, headers: { "content-type": "application/json" } }
+      );
+    }
+    if (url === DEVICE_TOKEN_URL) {
+      // User has authorized: return the authorization_code + verifier.
+      return new Response(
+        JSON.stringify({
+          authorization_code: "authcode_xyz",
+          code_verifier: "verifier_abc",
+        }),
+        { status: 200, headers: { "content-type": "application/json" } }
+      );
+    }
+    if (url === TOKEN_EXCHANGE_URL) {
+      return new Response(
+        JSON.stringify({
+          access_token: fakeJwt("acc_123"),
+          refresh_token: "rt_test",
+          expires_in: 864_000,
+        }),
+        { status: 200, headers: { "content-type": "application/json" } }
+      );
+    }
+    throw new Error(`unexpected fetch: ${url}`);
+  }) as typeof globalThis.fetch;
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+describe("ChatGPTDeviceCodeClient encoding", () => {
+  test("device-code request uses JSON (OpenAI's device-auth API)", async () => {
+    const client = new ChatGPTDeviceCodeClient();
+    await client.requestDeviceCode();
+
+    const call = calls.find((c) => c.url === DEVICE_CODE_URL);
+    expect(call).toBeDefined();
+    expect(call!.contentType).toBe("application/json");
+    expect(JSON.parse(call!.rawBody).client_id).toBeTruthy();
+  });
+
+  test("OAuth token exchange is form-encoded (RFC 6749) — the Claude-class regression guard", async () => {
+    const client = new ChatGPTDeviceCodeClient();
+    const result = await client.pollForToken("dev_abc", "ABCD-1234");
+
+    expect(result).not.toBeNull();
+    expect(result!.refreshToken).toBe("rt_test");
+    expect(result!.accountId).toBe("acc_123");
+
+    const exchange = calls.find((c) => c.url === TOKEN_EXCHANGE_URL);
+    expect(exchange).toBeDefined();
+    // The critical assertion: must NOT be application/json.
+    expect(exchange!.contentType).toBe("application/x-www-form-urlencoded");
+
+    const form = new URLSearchParams(exchange!.rawBody);
+    expect(form.get("grant_type")).toBe("authorization_code");
+    expect(form.get("code")).toBe("authcode_xyz");
+    expect(form.get("code_verifier")).toBe("verifier_abc");
+    expect(form.get("redirect_uri")).toBe(
+      "https://auth.openai.com/deviceauth/callback"
+    );
+    expect(form.get("client_id")).toBeTruthy();
+    // Sanity: it must not be JSON.
+    expect(exchange!.rawBody.trim().startsWith("{")).toBe(false);
+  });
+
+  test("poll returns null (pending) on 403 without authorizing", async () => {
+    globalThis.fetch = (async (input: RequestInfo | URL) => {
+      const url = typeof input === "string" ? input : input.toString();
+      if (url === DEVICE_TOKEN_URL) return new Response("", { status: 403 });
+      throw new Error(`unexpected fetch: ${url}`);
+    }) as typeof globalThis.fetch;
+
+    const client = new ChatGPTDeviceCodeClient();
+    expect(await client.pollForToken("dev_abc", "ABCD-1234")).toBeNull();
+  });
+});


### PR DESCRIPTION
## What

Adds a regression guard for the **ChatGPT (OpenAI Codex) device-code OAuth flow** so it can't silently regress to the wrong content-type the way Claude login did (#1305).

## Why

ChatGPT login uses a different code path from Claude (`ChatGPTDeviceCodeClient`, device-code flow), and its OAuth token exchange at `auth.openai.com/oauth/token` is already correctly `application/x-www-form-urlencoded`. But there was **no test** pinning that — a future refactor could flip it to JSON and reintroduce the exact Claude-class bug (`invalid_grant`), with no CI signal.

## Test (`device-code-client.test.ts`)

- **Token exchange is form-encoded** — the critical guard. Mocks the full poll→exchange and asserts `Content-Type: application/x-www-form-urlencoded` + a urlencoded body (`grant_type`/`code`/`code_verifier`/`redirect_uri`/`client_id`), and that it is not JSON.
- **Device-auth API stays JSON** — the `/deviceauth/*` calls are OpenAI's own JSON API; asserts they remain `application/json`.
- **Pending path** — a 403 poll returns `null` (still pending), not an error.

Red→green verified: flipping the token header to `application/json` fails the exchange test exactly on the encoding assertion.

## Live E2E

Before adding the test, ran the real device-code flow end-to-end (request code → authorized at `auth.openai.com/codex/device` → poll → exchange):

```
RESULT=OK
  access_token: eyJhbGciOiJSUz…   (real JWT)
  refresh_token: present
  expires_in: 864000s  (~10 days)
  accountId: 92f6050b-…
```

Test-only change — no production code touched.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1308"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784204479&installation_id=136316292&pr_number=1308&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1308&signature=30bed220068d0c7da1a876e11a8d17447659b24b786c679f80892cceb1296693"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->