### PR TITLE
revert(ci): back out #1307 — mode=min is faster than mode=max here

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -145,13 +145,14 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
+            CACHEBUST=${{ github.sha }}
             APP_GIT_SHA=${{ github.sha }}
             APP_BUILD_TIME=${{ github.event.head_commit.timestamp || github.run_id }}
             SKIP_WEB_BUILD=${{ steps.submodule.outputs.stubbed == 'true' }}
             VITE_SENTRY_DSN=${{ secrets.VITE_SENTRY_DSN }}
             VITE_ENVIRONMENT=production
           cache-from: type=gha,scope=app
-          cache-to: type=gha,mode=max,scope=app
+          cache-to: type=gha,mode=min,scope=app
 
       - name: Make image public
         run: |

--- a/docker/app/Dockerfile
+++ b/docker/app/Dockerfile
@@ -54,13 +54,13 @@ RUN mkdir -p packages/cli packages/landing packages/lobu-cli packages/browser-ex
 # Node doesn't understand.
 RUN --mount=type=cache,target=/root/.bun/install/cache bun install --linker=hoisted
 
-# Source code. BuildKit content-hashes each COPY, so a change to any package's
-# source invalidates that layer and everything downstream (tsc/bundle/frontend)
-# automatically — no manual cache-bust needed. The previous
-# `ARG CACHEBUST=${git.sha}` busted ALL source layers on every commit, forcing a
-# full recompile each build even when nothing relevant changed; dropping it lets
-# unchanged layers be reused from the cache (see cache-to mode=max in
-# build-images.yml).
+# Force rebuild of source layers
+ARG CACHEBUST=default
+ARG APP_GIT_SHA=unknown
+ARG APP_BUILD_TIME=unknown
+RUN echo "Build: ${CACHEBUST}" && date > /tmp/.build-time
+
+# Source code
 COPY config/ config/
 COPY packages/core/ packages/core/
 COPY packages/agent-worker/ packages/agent-worker/


### PR DESCRIPTION
Reverts #1307. **Empirical result contradicted the hypothesis.**

Measured `build-app` times from the actual main builds:
- #1303 (`cache-to mode=min`): **5.5 min** (the "Build and push App image" step = 4.9 min — mode=min skips the ~152s cache export)
- #1307 (`mode=max` + drop CACHEBUST): **7.4 min** — and the builds on the 3 commits *after* #1307 were also 7.1–7.6 min, i.e. no warm-cache speedup.

The expected layer reuse from dropping CACHEBUST never materialized: `docker/app/Dockerfile` copies all package sources and then runs monolithic `tsc` / `bundle` / frontend steps, so virtually any commit invalidates those expensive layers regardless of CACHEBUST. So #1307 just re-added mode=max's ~152s export cost for ~zero reuse benefit, making the build ~2 min slower.

Reverting to #1303's `mode=min` (the measured-fastest config). The real further win would require restructuring the Dockerfile for genuine layer granularity (separate per-package COPY+build so unchanged packages cache) — a bigger change, deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1311"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784205952&installation_id=136316292&pr_number=1311&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1311&signature=7e42c24f6d9b0426013e58807340d1562271cb280d914209bb3623bacb7660c8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->