### PR TITLE
feat(connectors): alert when a connector silently dies

### DIFF
--- a/db/migrations/20260616140000_connections_unhealthy_alerted_at.sql
+++ b/db/migrations/20260616140000_connections_unhealthy_alerted_at.sql
@@ -1,0 +1,25 @@
+-- migrate:up
+
+-- Transition marker for the connector-health alerter.
+--
+-- A connector silently dying (every feed failing, zero feeds, or no successful
+-- sync in N days) currently surfaces to nobody. The `connector-health-alert`
+-- scheduled job (single-claimant, runs-queue-mediated) scans active connections
+-- each tick and emits a `logger.error` — which the pino→Sentry bridge forwards
+-- to the existing Sentry→Slack alert path — when a connection newly becomes
+-- unhealthy.
+--
+-- This column is the multi-replica-safe dedupe: the alert fires only on the
+-- NULL → set transition (the tick that flips it claims the alert via an atomic
+-- conditional UPDATE), so N replicas ticking concurrently can never double-fire.
+-- It is cleared back to NULL when the connection recovers, which re-arms the
+-- alert for the next time it dies. No per-pod in-memory state is involved.
+ALTER TABLE public.connections
+    ADD COLUMN IF NOT EXISTS unhealthy_alerted_at timestamp with time zone;
+
+COMMENT ON COLUMN public.connections.unhealthy_alerted_at IS
+    'Set by the connector-health-alert job when the connection is flagged unhealthy; cleared on recovery. Drives transition-only (not every-tick) alerting, multi-replica-safe.';
+
+-- migrate:down
+
+ALTER TABLE public.connections DROP COLUMN IF EXISTS unhealthy_alerted_at;

--- a/packages/server/src/__tests__/integration/connector-health-alert.test.ts
+++ b/packages/server/src/__tests__/integration/connector-health-alert.test.ts
@@ -1,0 +1,274 @@
+/**
+ * connector-health alerter — integration test against real Postgres.
+ *
+ * Seeds four active connections in one org:
+ *   1. all-feeds-failing (every non-deleted feed last_sync_status='failed')
+ *   2. zero-feeds (active connection, no non-deleted feeds, past grace age)
+ *   3. healthy (a feed that synced successfully recently)
+ *   4. deliberately-paused (paused feed, consecutive_failures=0, past success)
+ *
+ * Asserts the check flags ONLY (1) and (2), leaves (3) and (4) alone, and
+ * alerts on the transition into unhealthy — not on every run.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import {
+  DEFAULT_CONNECTOR_HEALTH_CONFIG,
+  runConnectorHealthCheck,
+  type UnhealthyReason,
+} from '../../connectors/connector-health';
+import { cleanupTestDatabase, getTestDb } from '../setup/test-db';
+import { createTestOrganization, createTestUser } from '../setup/test-fixtures';
+
+const cfg = DEFAULT_CONNECTOR_HEALTH_CONFIG;
+// Created comfortably outside the min-age grace window so age never masks a flag.
+const OLD = new Date(Date.now() - (cfg.minConnectionAgeHours + 24) * 60 * 60 * 1000);
+
+interface SeededConn {
+  id: number;
+}
+
+async function seedConnection(opts: {
+  orgId: string;
+  userId: string;
+  connectorKey: string;
+  slug: string;
+  createdAt: Date;
+}): Promise<SeededConn> {
+  const sql = getTestDb();
+  const [row] = await sql`
+    INSERT INTO connections (
+      organization_id, connector_key, slug, display_name, status,
+      created_by, visibility, created_at, updated_at
+    ) VALUES (
+      ${opts.orgId}, ${opts.connectorKey}, ${opts.slug},
+      ${`Conn ${opts.slug}`}, 'active', ${opts.userId}, 'org',
+      ${opts.createdAt}, ${opts.createdAt}
+    )
+    RETURNING id
+  `;
+  return { id: Number(row.id) };
+}
+
+async function seedFeed(opts: {
+  orgId: string;
+  connectionId: number;
+  feedKey: string;
+  status?: string;
+  lastSyncStatus?: string | null;
+  lastSyncAt?: Date | null;
+  consecutiveFailures?: number;
+  lastError?: string | null;
+  deletedAt?: Date | null;
+}): Promise<void> {
+  const sql = getTestDb();
+  await sql`
+    INSERT INTO feeds (
+      organization_id, connection_id, feed_key, status,
+      last_sync_status, last_sync_at, consecutive_failures, last_error,
+      deleted_at, created_at, updated_at
+    ) VALUES (
+      ${opts.orgId}, ${opts.connectionId}, ${opts.feedKey},
+      ${opts.status ?? 'active'},
+      ${opts.lastSyncStatus ?? null}, ${opts.lastSyncAt ?? null},
+      ${opts.consecutiveFailures ?? 0}, ${opts.lastError ?? null},
+      ${opts.deletedAt ?? null}, NOW(), NOW()
+    )
+  `;
+}
+
+describe('connector-health alerter', () => {
+  let orgId: string;
+  let userId: string;
+  let allFailingId: number;
+  let zeroFeedsId: number;
+  let healthyId: number;
+  let pausedId: number;
+
+  beforeAll(async () => {
+    await cleanupTestDatabase();
+    const org = await createTestOrganization({ name: 'Connector Health Org' });
+    orgId = org.id;
+    const user = await createTestUser({ email: 'health-owner@test.com' });
+    userId = user.id;
+
+    // 1. all-feeds-failing: two feeds, both last_sync_status='failed'.
+    const allFailing = await seedConnection({
+      orgId,
+      userId,
+      connectorKey: 'revolut',
+      slug: 'all-failing',
+      createdAt: OLD,
+    });
+    allFailingId = allFailing.id;
+    await seedFeed({
+      orgId,
+      connectionId: allFailingId,
+      feedKey: 'a',
+      lastSyncStatus: 'failed',
+      consecutiveFailures: 5,
+      lastError: 'Authentication failed — cookies may be expired',
+      lastSyncAt: new Date(Date.now() - 2 * 24 * 60 * 60 * 1000),
+    });
+    await seedFeed({
+      orgId,
+      connectionId: allFailingId,
+      feedKey: 'b',
+      lastSyncStatus: 'failed',
+      consecutiveFailures: 4,
+      lastError: 'Revolut session needs sign-in',
+    });
+    // A deleted feed that once succeeded must NOT rescue the connection.
+    await seedFeed({
+      orgId,
+      connectionId: allFailingId,
+      feedKey: 'deleted-ok',
+      lastSyncStatus: 'success',
+      lastSyncAt: new Date(),
+      deletedAt: new Date(),
+    });
+
+    // 2. zero-feeds: active connection with no non-deleted feeds.
+    const zeroFeeds = await seedConnection({
+      orgId,
+      userId,
+      connectorKey: 'linkedin',
+      slug: 'zero-feeds',
+      createdAt: OLD,
+    });
+    zeroFeedsId = zeroFeeds.id;
+    // Only a deleted feed — counts as zero live feeds.
+    await seedFeed({
+      orgId,
+      connectionId: zeroFeedsId,
+      feedKey: 'gone',
+      lastSyncStatus: 'success',
+      lastSyncAt: new Date(),
+      deletedAt: new Date(),
+    });
+
+    // 3. healthy: a feed that synced successfully today.
+    const healthy = await seedConnection({
+      orgId,
+      userId,
+      connectorKey: 'github',
+      slug: 'healthy',
+      createdAt: OLD,
+    });
+    healthyId = healthy.id;
+    await seedFeed({
+      orgId,
+      connectionId: healthyId,
+      feedKey: 'a',
+      lastSyncStatus: 'success',
+      lastSyncAt: new Date(),
+      consecutiveFailures: 0,
+    });
+    // A second feed currently failing but the connection is NOT all-failing.
+    await seedFeed({
+      orgId,
+      connectionId: healthyId,
+      feedKey: 'b',
+      lastSyncStatus: 'failed',
+      consecutiveFailures: 1,
+    });
+
+    // 4. deliberately-paused: only a paused, never-failing feed with a past
+    //    success. Operator intent — must not be flagged.
+    const paused = await seedConnection({
+      orgId,
+      userId,
+      connectorKey: 'gmail',
+      slug: 'paused',
+      createdAt: OLD,
+    });
+    pausedId = paused.id;
+    await seedFeed({
+      orgId,
+      connectionId: pausedId,
+      feedKey: 'a',
+      status: 'paused',
+      lastSyncStatus: 'success',
+      lastSyncAt: new Date(Date.now() - 30 * 24 * 60 * 60 * 1000),
+      consecutiveFailures: 0,
+    });
+  });
+
+  afterAll(async () => {
+    await cleanupTestDatabase();
+  });
+
+  function reasonFor(
+    details: Awaited<ReturnType<typeof runConnectorHealthCheck>>['details'],
+    id: number
+  ): UnhealthyReason | undefined {
+    return details.find((d) => d.connectionId === id)?.reason;
+  }
+
+  it('flags only the unhealthy connections and alerts on the transition', async () => {
+    const first = await runConnectorHealthCheck();
+
+    const flagged = new Set(first.details.map((d) => d.connectionId));
+    expect(flagged.has(allFailingId)).toBe(true);
+    expect(flagged.has(zeroFeedsId)).toBe(true);
+    expect(flagged.has(healthyId)).toBe(false);
+    expect(flagged.has(pausedId)).toBe(false);
+
+    expect(reasonFor(first.details, allFailingId)).toBe('all_feeds_failing');
+    expect(reasonFor(first.details, zeroFeedsId)).toBe('zero_feeds');
+
+    // First run is the transition → both alerts fire.
+    expect(first.unhealthy).toBe(2);
+    expect(first.newlyAlerted).toBe(2);
+
+    // The marker was persisted for the flagged connections only.
+    const sql = getTestDb();
+    const marked = (await sql`
+      SELECT id FROM connections
+      WHERE unhealthy_alerted_at IS NOT NULL
+      ORDER BY id
+    `) as unknown as Array<{ id: string }>;
+    expect(marked.map((r) => Number(r.id)).sort((a, b) => a - b)).toEqual(
+      [allFailingId, zeroFeedsId].sort((a, b) => a - b)
+    );
+  });
+
+  it('does not re-alert on the next run while still unhealthy', async () => {
+    const second = await runConnectorHealthCheck();
+    // Still detected as unhealthy...
+    expect(second.unhealthy).toBe(2);
+    // ...but no new alert fires (transition already claimed).
+    expect(second.newlyAlerted).toBe(0);
+    expect(second.recovered).toBe(0);
+  });
+
+  it('re-arms and re-alerts after recovery', async () => {
+    const sql = getTestDb();
+    // Recover the all-failing connection: its feeds now succeed.
+    await sql`
+      UPDATE feeds
+      SET last_sync_status = 'success',
+          last_sync_at = NOW(),
+          consecutive_failures = 0
+      WHERE connection_id = ${allFailingId} AND deleted_at IS NULL
+    `;
+
+    const afterRecovery = await runConnectorHealthCheck();
+    expect(afterRecovery.recovered).toBe(1);
+    // Marker cleared.
+    const [row] = (await sql`
+      SELECT unhealthy_alerted_at FROM connections WHERE id = ${allFailingId}
+    `) as unknown as Array<{ unhealthy_alerted_at: Date | null }>;
+    expect(row.unhealthy_alerted_at).toBeNull();
+
+    // Break it again → alert re-fires (transition NULL→set once more).
+    await sql`
+      UPDATE feeds
+      SET last_sync_status = 'failed', consecutive_failures = 6
+      WHERE connection_id = ${allFailingId} AND deleted_at IS NULL
+    `;
+    const broken = await runConnectorHealthCheck();
+    expect(broken.newlyAlerted).toBe(1);
+    expect(reasonFor(broken.details, allFailingId)).toBe('all_feeds_failing');
+  });
+});

--- a/packages/server/src/connectors/connector-health.ts
+++ b/packages/server/src/connectors/connector-health.ts
@@ -1,0 +1,287 @@
+/**
+ * Connector-health alerter.
+ *
+ * The per-feed repair-agent (`repair-agent.ts`) only fires when a worker
+ * actually RUNS and fails — it cannot catch a connector that has silently
+ * stopped scheduling runs, an active connection that collects nothing, or a
+ * whole connection whose every feed is dead. Those failure modes currently
+ * surface to nobody and have gone unnoticed for weeks in prod (expired Revolut
+ * sessions, "Authentication failed — cookies may be expired", etc.).
+ *
+ * This module is a periodic, read-only scan over `connections` + `feeds` that
+ * classifies each active connection as healthy or unhealthy by clear rules and
+ * emits a structured `logger.error` for each NEWLY-unhealthy connection. That
+ * `logger.error` is forwarded by the pino→Sentry bridge (`utils/logger.ts`) to
+ * the existing Sentry→Slack alert path — no new alerting infra.
+ *
+ * Multi-replica safety: registered as a single-claimant scheduled job (one
+ * claimant per tick via the runs-queue), AND the per-connection dedupe is
+ * Postgres-mediated — `connections.unhealthy_alerted_at` is flipped NULL→now()
+ * by an atomic conditional UPDATE, so the alert fires exactly once on the
+ * transition into unhealthy (re-armed by a NULL reset on recovery). No per-pod
+ * in-memory state is read or mutated across replicas.
+ */
+
+import { type DbClient, getDb } from '../db/client';
+import logger from '../utils/logger';
+
+/**
+ * A feed is "failing" if its most recent sync failed OR it has accumulated at
+ * least this many consecutive failures. Matches the repair-agent default.
+ */
+const FAILURE_THRESHOLD = 3;
+
+/**
+ * Don't flag a connection until it has had time to do its first sync. A
+ * just-created connection with no successful sync yet is not "dying".
+ */
+const MIN_CONNECTION_AGE_HOURS = 24;
+
+/**
+ * An active connection with zero non-deleted feeds older than this is
+ * collecting nothing and is flagged. (Consent-only / managed-grant connections
+ * legitimately have no feeds, but they are not `status='active'` collectors —
+ * see scoping in the query.)
+ */
+const ZERO_FEEDS_GRACE_HOURS = 48;
+
+/**
+ * A connection that was collecting (at least one feed has a past successful
+ * sync) but whose newest successful sync across all feeds is older than this is
+ * flagged as "stopped collecting".
+ */
+const NO_SYNC_DAYS = 7;
+
+export interface ConnectorHealthConfig {
+  failureThreshold: number;
+  minConnectionAgeHours: number;
+  zeroFeedsGraceHours: number;
+  noSyncDays: number;
+}
+
+export const DEFAULT_CONNECTOR_HEALTH_CONFIG: ConnectorHealthConfig = {
+  failureThreshold: FAILURE_THRESHOLD,
+  minConnectionAgeHours: MIN_CONNECTION_AGE_HOURS,
+  zeroFeedsGraceHours: ZERO_FEEDS_GRACE_HOURS,
+  noSyncDays: NO_SYNC_DAYS,
+};
+
+export type UnhealthyReason = 'all_feeds_failing' | 'zero_feeds' | 'no_recent_sync';
+
+export interface UnhealthyConnection {
+  connectionId: number;
+  organizationId: string;
+  connectorKey: string;
+  displayName: string | null;
+  reason: UnhealthyReason;
+  feedCount: number;
+  failingFeedCount: number;
+  lastSyncAt: string | null;
+  lastError: string | null;
+}
+
+export interface ConnectorHealthResult {
+  scanned: number;
+  unhealthy: number;
+  /** Connections that transitioned into unhealthy on THIS run (alerts fired). */
+  newlyAlerted: number;
+  /** Connections that recovered on THIS run (marker re-armed). */
+  recovered: number;
+  details: UnhealthyConnection[];
+}
+
+interface HealthDeps {
+  sql?: DbClient;
+  config?: ConnectorHealthConfig;
+  now?: () => number;
+}
+
+interface UnhealthyRow {
+  id: string;
+  organization_id: string;
+  connector_key: string;
+  display_name: string | null;
+  feed_count: string;
+  failing_feed_count: string;
+  active_feed_count: string;
+  newest_sync_at: Date | null;
+  last_error: string | null;
+}
+
+/**
+ * The detection query. Read-only. Returns one row per active, non-deleted
+ * connection that is past the min-age grace window, with aggregates over its
+ * non-deleted feeds, so the JS classifier can decide healthy vs. unhealthy
+ * (and which rule tripped). Chat connections live in a separate table
+ * (`agent_connections`) and are intentionally NOT scanned here.
+ */
+async function loadConnectionHealthRows(
+  sql: DbClient,
+  cfg: ConnectorHealthConfig
+): Promise<UnhealthyRow[]> {
+  return (await sql`
+    SELECT
+      c.id,
+      c.organization_id,
+      c.connector_key,
+      c.display_name,
+      COUNT(f.id) AS feed_count,
+      COUNT(f.id) FILTER (
+        WHERE f.last_sync_status = 'failed'
+           OR f.consecutive_failures >= ${cfg.failureThreshold}
+      ) AS failing_feed_count,
+      -- A feed counts toward "healthy collector" if it is NOT a deliberately
+      -- paused, never-failing feed. Paused feeds with consecutive_failures = 0
+      -- are operator-intended pauses — they must not make the connection look
+      -- unhealthy.
+      COUNT(f.id) FILTER (
+        WHERE NOT (f.status = 'paused' AND f.consecutive_failures = 0)
+      ) AS active_feed_count,
+      MAX(f.last_sync_at) FILTER (WHERE f.last_sync_status = 'success') AS newest_sync_at,
+      (ARRAY_AGG(f.last_error) FILTER (WHERE f.last_error IS NOT NULL))[1] AS last_error
+    FROM connections c
+    LEFT JOIN feeds f
+      ON f.connection_id = c.id
+     AND f.deleted_at IS NULL
+    WHERE c.status = 'active'
+      AND c.deleted_at IS NULL
+      AND c.created_at <= now() - make_interval(hours => ${cfg.minConnectionAgeHours})
+    GROUP BY c.id, c.organization_id, c.connector_key, c.display_name
+  `) as unknown as UnhealthyRow[];
+}
+
+/**
+ * Classify a single connection row. Returns the tripped rule, or null if
+ * healthy. Order matters: zero-feeds is checked before all-feeds-failing
+ * (which is vacuously true with zero feeds).
+ */
+function classify(
+  row: UnhealthyRow,
+  cfg: ConnectorHealthConfig,
+  nowMs: number
+): UnhealthyReason | null {
+  const feedCount = Number(row.feed_count);
+  const failingCount = Number(row.failing_feed_count);
+  const activeCount = Number(row.active_feed_count);
+
+  // Rule B: active connection, zero non-deleted feeds. (Grace handled by the
+  // query's min-age window — a connection that has existed > min age and still
+  // has no feeds is collecting nothing.)
+  if (feedCount === 0) return 'zero_feeds';
+
+  // A connection whose only feeds are deliberately paused (cf=0) is NOT
+  // unhealthy — operator intent. activeCount === 0 means every feed is a
+  // paused-clean feed.
+  if (activeCount === 0) return null;
+
+  // Rule A: every non-deleted feed is failing.
+  if (failingCount === feedCount) return 'all_feeds_failing';
+
+  // Rule C: was collecting but stopped. Only applies when at least one feed
+  // once succeeded (newest_sync_at not null) — a connection that never synced
+  // is covered by the failing/zero rules, not this one (avoids false-flagging
+  // brand-new feeds that simply haven't had a successful run yet).
+  if (row.newest_sync_at) {
+    const ageMs = nowMs - new Date(row.newest_sync_at).getTime();
+    if (ageMs > cfg.noSyncDays * 24 * 60 * 60 * 1000) return 'no_recent_sync';
+  }
+
+  return null;
+}
+
+/**
+ * Run one connector-health scan. Emits a `logger.error` per newly-unhealthy
+ * connection (transition into unhealthy), re-arms the marker for recovered
+ * connections, and is a no-op alert-wise for connections that are still
+ * unhealthy from a prior run.
+ */
+export async function runConnectorHealthCheck(
+  deps: HealthDeps = {}
+): Promise<ConnectorHealthResult> {
+  const sql = deps.sql ?? getDb();
+  const cfg = deps.config ?? DEFAULT_CONNECTOR_HEALTH_CONFIG;
+  const nowMs = (deps.now ?? (() => Date.now()))();
+
+  const rows = await loadConnectionHealthRows(sql, cfg);
+
+  const result: ConnectorHealthResult = {
+    scanned: rows.length,
+    unhealthy: 0,
+    newlyAlerted: 0,
+    recovered: 0,
+    details: [],
+  };
+
+  const unhealthyIds: number[] = [];
+
+  for (const row of rows) {
+    const reason = classify(row, cfg, nowMs);
+    const connectionId = Number(row.id);
+
+    if (!reason) {
+      // Healthy: re-arm the alert if it was previously flagged. The conditional
+      // WHERE makes this a no-op for connections that were already healthy, and
+      // counts a real recovery exactly once across replicas.
+      const cleared = (await sql`
+        UPDATE connections
+        SET unhealthy_alerted_at = NULL, updated_at = now()
+        WHERE id = ${connectionId}
+          AND unhealthy_alerted_at IS NOT NULL
+        RETURNING id
+      `) as unknown as Array<{ id: string }>;
+      if (cleared.length > 0) result.recovered += 1;
+      continue;
+    }
+
+    result.unhealthy += 1;
+    unhealthyIds.push(connectionId);
+
+    const detail: UnhealthyConnection = {
+      connectionId,
+      organizationId: row.organization_id,
+      connectorKey: row.connector_key,
+      displayName: row.display_name,
+      reason,
+      feedCount: Number(row.feed_count),
+      failingFeedCount: Number(row.failing_feed_count),
+      lastSyncAt: row.newest_sync_at ? new Date(row.newest_sync_at).toISOString() : null,
+      lastError: row.last_error,
+    };
+    result.details.push(detail);
+
+    // Transition claim: only the replica whose UPDATE actually flips the marker
+    // NULL→now() owns the alert. Concurrent ticks on other replicas get zero
+    // rows back and stay silent — Postgres-mediated, no in-memory dedupe.
+    const claimed = (await sql`
+      UPDATE connections
+      SET unhealthy_alerted_at = now(), updated_at = now()
+      WHERE id = ${connectionId}
+        AND unhealthy_alerted_at IS NULL
+      RETURNING id
+    `) as unknown as Array<{ id: string }>;
+
+    if (claimed.length === 0) continue; // already alerted on a prior tick
+
+    result.newlyAlerted += 1;
+
+    // The alert. logger.error → pino→Sentry bridge → Sentry→Slack. A stable
+    // `msg` keeps Sentry grouping per reason; the structured fields carry the
+    // org/connector identifiers an operator needs to act.
+    logger.error(
+      {
+        connection_id: connectionId,
+        organization_id: row.organization_id,
+        connector_key: row.connector_key,
+        connection_display_name: row.display_name,
+        reason,
+        feed_count: detail.feedCount,
+        failing_feed_count: detail.failingFeedCount,
+        last_successful_sync_at: detail.lastSyncAt,
+        last_error: detail.lastError,
+      },
+      `[connector-health] connector unhealthy (${reason}): ${row.connector_key}`
+    );
+  }
+
+  return result;
+}

--- a/packages/server/src/scheduled/jobs.ts
+++ b/packages/server/src/scheduled/jobs.ts
@@ -13,6 +13,7 @@ import { cleanupExpiredMcpSessions } from '../mcp-handler';
 import logger from '../utils/logger';
 import { runWatcherAutomationTick } from '../watchers/automation';
 import { checkStalledExecutions } from './check-stalled-executions';
+import { runConnectorHealthCheck } from '../connectors/connector-health';
 import { runClassificationReconciliation } from './classification-reconciliation';
 import { registerScheduledJobsTicker } from './scheduled-jobs-service';
 import { TaskScheduler } from './task-scheduler';
@@ -144,6 +145,32 @@ function registerMaintenanceTasks(
       }
     },
     { cron: '*/5 * * * *' },
+  );
+
+  // Connector health alerter — surfaces connectors that have silently died
+  // (every feed failing, an active connection collecting nothing, or a feed
+  // that stopped syncing for days) which the per-feed repair-agent can't catch
+  // (it only fires when a worker actually runs). Single-claimant per tick;
+  // alerts fire on the transition into unhealthy via a Postgres-mediated marker
+  // (connections.unhealthy_alerted_at), and ride the existing pino→Sentry→Slack
+  // path — no new alerting infra. Read-only over connections/feeds otherwise.
+  scheduler.register(
+    'connector-health-alert',
+    async () => {
+      const result = await runConnectorHealthCheck();
+      if (result.newlyAlerted > 0 || result.recovered > 0) {
+        logger.info(
+          {
+            scanned: result.scanned,
+            unhealthy: result.unhealthy,
+            newly_alerted: result.newlyAlerted,
+            recovered: result.recovered,
+          },
+          '[task] connector-health-alert swept'
+        );
+      }
+    },
+    { cron: '*/15 * * * *' }
   );
 
   scheduler.register(

--- a/packages/server/src/utils/__tests__/table-schema.test.ts
+++ b/packages/server/src/utils/__tests__/table-schema.test.ts
@@ -119,7 +119,7 @@ describe('QUERYABLE_SCHEMA vs database (drift detection)', () => {
   const INTENTIONALLY_OMITTED: Record<string, Set<string>> = {
     entities: new Set(['embedding', 'content_tsv', 'content_hash']),
     events: new Set([]),
-    connections: new Set(['credentials']),
+    connections: new Set(['credentials', 'unhealthy_alerted_at']),
     // Large per-connector JSONB blobs — too big and structure-dependent to expose
     // via raw SQL. Callers should hit the typed connector handler instead.
     connector_definitions: new Set([


### PR DESCRIPTION
## Problem
The per-feed repair-agent (`repair-agent.ts`) only fires when a worker actually **runs and fails**. It cannot catch a connector that has silently stopped:
- every feed failing repeatedly (`Authentication failed — cookies may be expired`, `Revolut session needs sign-in`),
- an **active** connection with **zero feeds** (collects nothing) for days,
- a connector that was collecting daily then **stopped scheduling runs** (no successful sync in N days) while still `active`.

These surface to nobody and have gone unnoticed for weeks in prod.

## What this adds
A single-claimant scheduled job `connector-health-alert` (`*/15`), registered alongside the existing `connection-health` task in `scheduled/jobs.ts`. It scans active, non-deleted `connections` + their `feeds` **read-only** and classifies each connection.

### Unhealthy rules + thresholds (named constants in `connector-health.ts`)
| reason | rule | threshold |
|---|---|---|
| `zero_feeds` | active connection, **zero** non-deleted feeds | connection older than `ZERO_FEEDS_GRACE_HOURS` (48h, via the min-age window) |
| `all_feeds_failing` | **every** non-deleted feed has `last_sync_status='failed'` OR `consecutive_failures >= FAILURE_THRESHOLD` | `FAILURE_THRESHOLD = 3` |
| `no_recent_sync` | was collecting (a feed has a past success) but newest success across feeds is stale | `NO_SYNC_DAYS = 7` |

All connections are skipped until `MIN_CONNECTION_AGE_HOURS` (24h) so a brand-new connection that hasn't done its first sync isn't flagged.

**False-positive guard:** a deliberately-paused feed (`status='paused'` + `consecutive_failures=0` + a past success) is excluded from the "is this a live collector" set — operator pauses are never flagged.

### Alert channel — existing path, no new infra
Each newly-unhealthy connection emits a structured `logger.error(...)`. The pino→Sentry bridge in `utils/logger.ts` already forwards `level:'error'` lines to Sentry, and the existing Sentry→Slack AlertmanagerConfig delivers them. Nothing new is wired.

### Multi-replica correctness
De-dupe is **Postgres-mediated**, not in-memory (the logger's dedupe is per-pod / 60s — insufficient for "alert on transition"). New column `connections.unhealthy_alerted_at`:
- flipped `NULL → now()` by an **atomic conditional UPDATE** — only the replica whose UPDATE returns a row fires the alert, so N replicas ticking concurrently never double-fire;
- cleared back to `NULL` on recovery (atomic UPDATE, counted once), re-arming the alert.

No per-pod state another replica must read. Holds with 3 replicas behind ClientIP affinity.

## Test (red→green)
`__tests__/integration/connector-health-alert.test.ts` (real Postgres) seeds in one org:
1. all-feeds-failing (2 failed feeds + a deleted once-OK feed that must not rescue it)
2. zero-feeds (only a deleted feed)
3. healthy (a feed synced today; a second feed failing but not all-failing)
4. deliberately-paused (paused, cf=0, past success)

Asserts: only (1) and (2) are flagged with the right reasons; (3) and (4) are not; alerts fire on the first run (transition) but **not** the second run while still unhealthy; and after recovery the marker clears and a re-break re-fires.

```
Test Files  1 passed (1)
     Tests  3 passed (3)
```
The column + module are net-new, so the suite is inherently red without this change (the test DB has no `unhealthy_alerted_at` and `runConnectorHealthCheck` doesn't exist).

`make typecheck` (strict, packages/server + owletto): clean.

## Not changed
Connector execution is untouched — this is read-only over connections/feeds plus the marker UPDATE and the alert emission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1312"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784206420&installation_id=136316292&pr_number=1312&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1312&signature=432519641b5f156a31671d2aa17bc803a0ed326d7307cf67270c856976e2104f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->