### PR TITLE
fix(docker): pin PLAYWRIGHT_BROWSERS_PATH so browser connectors find Chromium

### DIFF
--- a/docker/app/Dockerfile
+++ b/docker/app/Dockerfile
@@ -156,8 +156,17 @@ COPY --from=builder /app/packages/owletto ./packages/owletto
 # Database migrations
 COPY db/migrations ./db/migrations
 
-# Install Playwright/patchright Chromium for browser-based connectors
-RUN npx patchright install chromium 2>/dev/null || npx playwright install chromium 2>/dev/null || true
+# Install Playwright/patchright Chromium for browser-based connectors.
+# PLAYWRIGHT_BROWSERS_PATH pins both the install target and the runtime lookup to
+# an absolute, HOME-independent path (default is $HOME/.cache/ms-playwright, which
+# differs by USER and breaks the connector child forked in another cwd). chmod 755
+# keeps it readable regardless of which user the runtime resolves to. The install
+# must fail the build loudly — the old `2>/dev/null ... || true` silently shipped
+# images with no Chromium. `playwright` is the patchright alias, so a single
+# patchright install is deterministic.
+RUN mkdir -p /ms-playwright && chmod 755 /ms-playwright
+ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright
+RUN npx patchright install chromium
 
 # Build metadata + environment defaults
 ARG APP_GIT_SHA=unknown

--- a/docker/worker/Dockerfile
+++ b/docker/worker/Dockerfile
@@ -97,6 +97,13 @@ COPY --from=builder --chown=worker:worker /app/packages/connector-worker ./packa
 
 # Install patchright's Chromium (declared as `playwright` alias in worker package.json).
 # Use bunx from the worker workspace so bun's resolver finds the alias.
+# PLAYWRIGHT_BROWSERS_PATH pins BOTH the install target and the runtime lookup to
+# an absolute, HOME-independent path. Without it patchright defaults to
+# $HOME/.cache/ms-playwright (/home/worker/.cache/ms-playwright), and the connector
+# child spawned via fork() in a different cwd can fail to resolve the binary ->
+# "Executable doesn't exist". /ms-playwright is created + chowned to worker above;
+# subprocess.ts already forwards PLAYWRIGHT_BROWSERS_PATH to the connector child.
+ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright
 USER 1001
 WORKDIR /app/packages/connector-worker
 RUN bunx --bun playwright install chromium

--- a/packages/connector-sdk/src/browser/launcher.ts
+++ b/packages/connector-sdk/src/browser/launcher.ts
@@ -105,9 +105,22 @@ export async function launchBrowser(
       screenshotDir,
     };
   } catch (error: any) {
-    if (error.message?.includes("Executable doesn't exist") || error.code === 'MODULE_NOT_FOUND') {
+    // The Chromium binary is present in the image but the runtime looked in the
+    // wrong directory — almost always a PLAYWRIGHT_BROWSERS_PATH mismatch between
+    // the install path and the lookup path (e.g. $HOME/.cache vs /ms-playwright).
+    if (error.message?.includes("Executable doesn't exist")) {
+      const browsersPath = process.env.PLAYWRIGHT_BROWSERS_PATH ?? '(unset → $HOME/.cache/ms-playwright)';
       throw new Error(
-        'Playwright not installed or Chromium browser missing.\n' +
+        `Chromium binary not found at PLAYWRIGHT_BROWSERS_PATH=${browsersPath} — image install path mismatch.\n` +
+          'Ensure Chromium is installed into this exact directory (npx playwright install chromium) ' +
+          'and that PLAYWRIGHT_BROWSERS_PATH matches both at install time and at runtime.'
+      );
+    }
+
+    // The playwright/patchright package itself is not resolvable.
+    if (error.code === 'MODULE_NOT_FOUND') {
+      throw new Error(
+        'Playwright not installed.\n' +
           'Install with: npm install -D playwright && npx playwright install chromium'
       );
     }


### PR DESCRIPTION
## Problem

Browser connectors (g2/capterra/trustpilot/x, revolut, website) intermittently failed in prod with:

```
Playwright not installed or Chromium browser missing.
```

The failure was non-deterministic: it succeeded when the **app** pod claimed the connector run and failed when the **worker** pod claimed it.

## Verified root cause (ground truth from live prod pods)

Both worker images install Chromium but to a `HOME`-dependent path and never set `PLAYWRIGHT_BROWSERS_PATH`, so the install target and the runtime lookup path diverge.

- **`docker/worker/Dockerfile`** creates + chowns `/ms-playwright` but never sets `ENV PLAYWRIGHT_BROWSERS_PATH`. The install runs as `USER 1001`, so `bunx playwright install chromium` lands Chromium in `/home/worker/.cache/ms-playwright` (the default) while `/ms-playwright` stays empty. Verified: worker pod has Chromium at `/home/worker/.cache/ms-playwright/chromium-1223`, `PLAYWRIGHT_BROWSERS_PATH` unset, and browser-connector runs claimed by the worker pod **fail**.
- **`docker/app/Dockerfile`** runs the install as root, landing Chromium in `/root/.cache/ms-playwright`, and `2>/dev/null ... || true` **silently swallowed** a failed install (the image could ship with no Chromium and still pass the build). Verified: app pod has Chromium at `/root/.cache/ms-playwright/chromium-1217`; the app pod runs as root so the default path happens to resolve and runs **succeed** — which is exactly why the failures were intermittent.
- `playwright` is an alias for `patchright`; patchright honors `PLAYWRIGHT_BROWSERS_PATH` for both the install target and the runtime lookup.
- The connector child is spawned via `fork()` (browser connectors declare no nix packages), and `packages/connector-worker/src/executor/subprocess.ts` already includes `PLAYWRIGHT_BROWSERS_PATH` in `SYSTEM_ENV_KEYS`, so a container-level `ENV PLAYWRIGHT_BROWSERS_PATH` propagates to the child automatically. **No app/runtime code change is needed.**

The error string in `launcher.ts` was also mislabeled: it rethrew the underlying `"Executable doesn't exist"` (Chromium binary not found) as "Playwright not installed", which sent the diagnosis down the wrong path.

## The fix (Dockerfiles + one error-message split)

1. **`docker/worker/Dockerfile`**: add `ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright` before the `bunx --bun playwright install chromium` step. `/ms-playwright` is already created + chowned to worker, so install and runtime now both use the absolute, HOME-independent path.
2. **`docker/app/Dockerfile`**: `mkdir -p /ms-playwright && chmod 755`, set `ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright`, and replace the swallowing `npx patchright ... 2>/dev/null || ... || true` with a single deterministic `RUN npx patchright install chromium` that fails the build loudly.
3. **`packages/connector-sdk/src/browser/launcher.ts`**: split the catch so `"Executable doesn't exist"` reports `Chromium binary not found at PLAYWRIGHT_BROWSERS_PATH=… — image install path mismatch` while `MODULE_NOT_FOUND` reports the package-missing message — prevents the next misdiagnosis.

No capability-routing or app code was added; env propagation through `fork()` already works.

## Validation

- `make typecheck` — clean (`✅ Typecheck clean.`), full server + owletto strict pass.
- Pre-commit biome + tsc passed.
- This is image/Docker config; the image can't be built in this environment. The fix aligns the install path with the runtime lookup path on both images and removes the silent install failure on the app image. **Needs a deploy to confirm in prod.**

## Post-merge verification (one check)

After the new images roll out, on the **worker** pod:

```
kubectl exec <worker-pod> -- printenv PLAYWRIGHT_BROWSERS_PATH   # -> /ms-playwright
kubectl exec <worker-pod> -- ls /ms-playwright/chromium-*        # -> chromium-<rev> present
```

Then trigger a browser-connector run and confirm it succeeds regardless of which pod claims it.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1313"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784206554&installation_id=136316292&pr_number=1313&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1313&signature=7339cd9d778c8821763b534eccd352563424f260c28c0cb7228eb616ae86b098"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->