### PR TITLE
fix(worker): install the patchright Chromium revision the runtime expects

### DIFF
--- a/docker/worker/Dockerfile
+++ b/docker/worker/Dockerfile
@@ -95,18 +95,23 @@ COPY --from=builder --chown=worker:worker /app/packages/connectors ./packages/co
 COPY --from=builder --chown=worker:worker /app/packages/embeddings ./packages/embeddings
 COPY --from=builder --chown=worker:worker /app/packages/connector-worker ./packages/connector-worker
 
-# Install patchright's Chromium (declared as `playwright` alias in worker package.json).
-# Use bunx from the worker workspace so bun's resolver finds the alias.
-# PLAYWRIGHT_BROWSERS_PATH pins BOTH the install target and the runtime lookup to
-# an absolute, HOME-independent path. Without it patchright defaults to
-# $HOME/.cache/ms-playwright (/home/worker/.cache/ms-playwright), and the connector
-# child spawned via fork() in a different cwd can fail to resolve the binary ->
-# "Executable doesn't exist". /ms-playwright is created + chowned to worker above;
-# subprocess.ts already forwards PLAYWRIGHT_BROWSERS_PATH to the connector child.
+# Install patchright's Chromium for browser-based connectors.
+# The runtime resolves `require('playwright')` to patchright (the
+# `npm:patchright` alias in package.json), so the installed Chromium revision
+# MUST be patchright's, not vanilla playwright's. `bunx --bun playwright install`
+# resolved to the vanilla `playwright` bin (node_modules/.bin/playwright ->
+# playwright-vanilla/cli.js won the bin-name conflict) and installed a DIFFERENT
+# revision (chromium-1223) than runtime patchright expects (chromium-1217) ->
+# `Executable doesn't exist`. Invoke patchright's own cli (node_modules/playwright
+# == patchright) so install revision == runtime revision by construction.
+# PLAYWRIGHT_BROWSERS_PATH pins BOTH install target and runtime lookup to an
+# absolute, HOME-independent path (default $HOME/.cache/ms-playwright differs by
+# USER and breaks the connector child forked in another cwd). /ms-playwright is
+# created + chowned to worker above; subprocess.ts forwards the var to the child.
 ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright
 USER 1001
 WORKDIR /app/packages/connector-worker
-RUN bunx --bun playwright install chromium
+RUN node node_modules/playwright/cli.js install chromium
 WORKDIR /app
 
 ENV NODE_ENV=production


### PR DESCRIPTION
## Problem
Follow-up to #1313. After #1313 fixed the install/runtime `PLAYWRIGHT_BROWSERS_PATH` mismatch, browser connectors still failed **on the worker pod** (user 1001) while succeeding on the app pod — with the now-precise error `Chromium binary not found at PLAYWRIGHT_BROWSERS_PATH=/ms-playwright`.

## Root cause (verified live in prod pods)
The runtime resolves `require('playwright')` to **patchright** (the `npm:patchright@^1.57.0` alias), which pins **chromium-1217**. But `docker/worker/Dockerfile` installed via `bunx --bun playwright install chromium`, and `node_modules/.bin/playwright` symlinks to **playwright-vanilla** (vanilla won the bin-name conflict) → it installed **chromium-1223**. So `/ms-playwright/chromium-1223` existed but patchright looked for `/ms-playwright/chromium-1217` → `Executable doesn't exist`. The app pod was fine because its Dockerfile uses `npx patchright install` (→ 1217).

Verified in the worker pod:
- `require('playwright').chromium.executablePath()` → `/ms-playwright/chromium-1217/chrome-linux64/chrome` (EXISTS: false)
- `node_modules/.bin/playwright install` → chromium-1223
- `node node_modules/playwright/cli.js install` (patchright's own cli) → **chromium-1217** ✅

## Fix
Install via patchright's own cli (`node_modules/playwright` == patchright) so install revision == runtime revision by construction.

## Verification owed
Image needs a deploy; after rollout, on a fresh worker pod: `node -e "require('playwright').chromium.executablePath()"` path exists, and worker-claimed g2/trustpilot/x runs complete (no `Chromium` errors).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1315"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784208885&installation_id=136316292&pr_number=1315&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1315&signature=b2efc73fc7058abb892e2da325271a939b4b687934ae4c78a2cccfc060840c60"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker runtime configuration to improve Chromium installation reliability and ensure proper version compatibility during container builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->