### PR TITLE
fix(oauth): implement ChatGPT token refresh so device-code login self-heals

### DIFF
--- a/packages/server/src/gateway/__tests__/token-refresh-lock.test.ts
+++ b/packages/server/src/gateway/__tests__/token-refresh-lock.test.ts
@@ -105,7 +105,7 @@ describe("TokenRefreshJob advisory lock (F5)", () => {
     });
 
     const job = new TokenRefreshJob(manager as never, [
-      { providerId: "claude", oauthClient: oauthClient as never },
+      { providerId: "claude", refresher: oauthClient as never },
     ], () => fakeDb);
     await job.refreshForUserAgent("u1", "agent-1");
 
@@ -123,7 +123,7 @@ describe("TokenRefreshJob advisory lock (F5)", () => {
     });
 
     const job = new TokenRefreshJob(manager as never, [
-      { providerId: "claude", oauthClient: oauthClient as never },
+      { providerId: "claude", refresher: oauthClient as never },
     ], () => fakeDb);
     await job.refreshForUserAgent("u1", "agent-1");
 
@@ -140,7 +140,7 @@ describe("TokenRefreshJob advisory lock (F5)", () => {
     });
 
     const job = new TokenRefreshJob(manager as never, [
-      { providerId: "claude", oauthClient: oauthClient as never },
+      { providerId: "claude", refresher: oauthClient as never },
     ], () => fakeDb);
     await job.refreshForUserAgent("u1", "agent-1");
 

--- a/packages/server/src/gateway/auth/chatgpt/__tests__/device-code-client.test.ts
+++ b/packages/server/src/gateway/auth/chatgpt/__tests__/device-code-client.test.ts
@@ -134,4 +134,40 @@ describe("ChatGPTDeviceCodeClient encoding", () => {
     const client = new ChatGPTDeviceCodeClient();
     expect(await client.pollForToken("dev_abc", "ABCD-1234")).toBeNull();
   });
+
+  test("refresh exchange is form-encoded with grant_type=refresh_token", async () => {
+    const client = new ChatGPTDeviceCodeClient();
+    const creds = await client.refreshToken("rt_old");
+
+    expect(creds.accessToken).toBe(fakeJwt("acc_123"));
+    expect(creds.refreshToken).toBe("rt_test"); // rotated value from the response
+
+    const refresh = calls.find((c) => c.url === TOKEN_EXCHANGE_URL);
+    expect(refresh).toBeDefined();
+    expect(refresh!.contentType).toBe("application/x-www-form-urlencoded");
+    const form = new URLSearchParams(refresh!.rawBody);
+    expect(form.get("grant_type")).toBe("refresh_token");
+    expect(form.get("refresh_token")).toBe("rt_old");
+    expect(form.get("client_id")).toBeTruthy();
+    expect(form.get("scope")).toBeTruthy();
+    expect(refresh!.rawBody.trim().startsWith("{")).toBe(false);
+  });
+
+  test("refresh preserves the existing refresh_token when the response omits it", async () => {
+    globalThis.fetch = (async (input: RequestInfo | URL) => {
+      const url = typeof input === "string" ? input : input.toString();
+      if (url === TOKEN_EXCHANGE_URL) {
+        return new Response(
+          // No refresh_token in the response — OpenAI doesn't always rotate it.
+          JSON.stringify({ access_token: fakeJwt("acc_9"), expires_in: 864_000 }),
+          { status: 200, headers: { "content-type": "application/json" } }
+        );
+      }
+      throw new Error(`unexpected fetch: ${url}`);
+    }) as typeof globalThis.fetch;
+
+    const client = new ChatGPTDeviceCodeClient();
+    const creds = await client.refreshToken("rt_keep");
+    expect(creds.refreshToken).toBe("rt_keep"); // not wiped
+  });
 });

--- a/packages/server/src/gateway/auth/chatgpt/device-code-client.ts
+++ b/packages/server/src/gateway/auth/chatgpt/device-code-client.ts
@@ -1,4 +1,5 @@
 import { createLogger } from "@lobu/core";
+import type { OAuthCredentials } from "../oauth/credentials.js";
 
 const logger = createLogger("chatgpt-device-code");
 
@@ -181,6 +182,56 @@ export class ChatGPTDeviceCodeClient {
       refreshToken: data.refresh_token,
       expiresIn: data.expires_in,
       accountId,
+    };
+  }
+
+  /**
+   * Exchange a stored refresh token for a fresh access token.
+   *
+   * Same OAuth token endpoint and form-encoding as {@link exchangeCode} (RFC
+   * 6749 §6). Returns {@link OAuthCredentials} so this client can be registered
+   * directly in the gateway's `TokenRefreshJob` alongside the Claude
+   * `OAuthClient`. OpenAI does not always rotate the refresh token, so the
+   * existing one is preserved when the response omits it — otherwise the stored
+   * refresh token would be wiped on every refresh.
+   */
+  async refreshToken(refreshToken: string): Promise<OAuthCredentials> {
+    const response = await fetch(TOKEN_EXCHANGE_URL, {
+      method: "POST",
+      headers: TOKEN_HEADERS,
+      body: new URLSearchParams({
+        grant_type: "refresh_token",
+        client_id: CLIENT_ID,
+        refresh_token: refreshToken,
+        scope: OAUTH_SCOPE,
+      }).toString(),
+    });
+
+    if (!response.ok) {
+      const text = await response.text().catch(() => "");
+      logger.error("Token refresh failed", {
+        status: response.status,
+        body: text,
+      });
+      throw new Error(`Token refresh failed: ${response.status}`);
+    }
+
+    const data = (await response.json()) as {
+      access_token?: string;
+      refresh_token?: string;
+      expires_in?: number;
+    };
+
+    if (!data.access_token) {
+      throw new Error("Refresh response missing access_token");
+    }
+
+    return {
+      accessToken: data.access_token,
+      refreshToken: data.refresh_token ?? refreshToken,
+      tokenType: "Bearer",
+      expiresAt: Date.now() + (data.expires_in ?? 0) * 1000,
+      scopes: OAUTH_SCOPE.split(" "),
     };
   }
 

--- a/packages/server/src/gateway/proxy/token-refresh-job.ts
+++ b/packages/server/src/gateway/proxy/token-refresh-job.ts
@@ -1,16 +1,30 @@
 import { createLogger } from "@lobu/core";
 import { type DbClient, getDb } from "../../db/client.js";
 import { orgContext } from "../../lobu/stores/org-context.js";
-import type { OAuthClient } from "../auth/oauth/client.js";
+import type { OAuthCredentials } from "../auth/oauth/credentials.js";
 import type { AuthProfilesManager } from "../auth/settings/auth-profiles-manager.js";
 
 const logger = createLogger("token-refresh-job");
 
 const EXPIRY_BUFFER_MS = 5 * 60 * 1000; // Refresh tokens expiring within 5 minutes
 
+// Profile auth types that carry a refresh token we can rotate. "oauth" =
+// Claude (authorization-code), "device-code" = ChatGPT/Codex.
+const REFRESHABLE_AUTH_TYPES = new Set(["oauth", "device-code"]);
+
+/**
+ * Anything that can swap a refresh token for fresh credentials. Both the
+ * Claude `OAuthClient` (authorization-code flow) and the ChatGPT
+ * `ChatGPTDeviceCodeClient` (device-code flow) implement this, so both can be
+ * registered as refreshable providers.
+ */
+export interface TokenRefresher {
+  refreshToken(refreshToken: string): Promise<OAuthCredentials>;
+}
+
 interface RefreshableProvider {
   providerId: string;
-  oauthClient: OAuthClient;
+  refresher: TokenRefresher;
 }
 
 /**
@@ -113,7 +127,7 @@ export class TokenRefreshJob {
   }
 
   private async doRefresh(userId: string, agentId: string): Promise<void> {
-    for (const { providerId, oauthClient } of this.refreshableProviders) {
+    for (const { providerId, refresher } of this.refreshableProviders) {
       const profiles = await this.authProfilesManager.getProviderProfiles(
         agentId,
         providerId,
@@ -121,7 +135,8 @@ export class TokenRefreshJob {
       );
       const oauthProfile = profiles.find(
         (profile) =>
-          profile.authType === "oauth" && !!profile.metadata?.refreshToken
+          REFRESHABLE_AUTH_TYPES.has(profile.authType) &&
+          !!profile.metadata?.refreshToken
       );
 
       if (!oauthProfile?.metadata?.refreshToken) continue;
@@ -136,7 +151,7 @@ export class TokenRefreshJob {
           userId,
           agentId,
           providerId,
-          oauthClient,
+          refresher,
           oauthProfile.id
         );
       } catch (error) {
@@ -162,7 +177,7 @@ export class TokenRefreshJob {
     userId: string,
     agentId: string,
     providerId: string,
-    oauthClient: OAuthClient,
+    refresher: TokenRefresher,
     profileId: string
   ): Promise<void> {
     const sql = this.getDbFn();
@@ -181,7 +196,7 @@ export class TokenRefreshJob {
       const oauthProfile = profiles.find((profile) => profile.id === profileId);
       if (
         !oauthProfile ||
-        oauthProfile.authType !== "oauth" ||
+        !REFRESHABLE_AUTH_TYPES.has(oauthProfile.authType) ||
         !oauthProfile.metadata?.refreshToken
       ) {
         return;
@@ -201,7 +216,7 @@ export class TokenRefreshJob {
         { expiresAt: new Date(expiresAt).toISOString() }
       );
 
-      const newCredentials = await oauthClient.refreshToken(
+      const newCredentials = await refresher.refreshToken(
         oauthProfile.metadata.refreshToken
       );
 
@@ -211,7 +226,7 @@ export class TokenRefreshJob {
         id: oauthProfile.id,
         provider: oauthProfile.provider,
         credential: newCredentials.accessToken,
-        authType: "oauth",
+        authType: oauthProfile.authType,
         label: oauthProfile.label,
         model: oauthProfile.model,
         metadata: {

--- a/packages/server/src/gateway/services/core-services.ts
+++ b/packages/server/src/gateway/services/core-services.ts
@@ -15,6 +15,7 @@ import { AgentMetadataStore } from "../auth/agent-metadata-store.js";
 import { ApiKeyProviderModule } from "../auth/api-key-provider-module.js";
 import { BedrockProviderModule } from "../auth/bedrock/provider-module.js";
 import { ChatGPTOAuthModule } from "../auth/chatgpt/chatgpt-oauth-module.js";
+import { ChatGPTDeviceCodeClient } from "../auth/chatgpt/device-code-client.js";
 import { ClaudeOAuthModule } from "../auth/claude/oauth-module.js";
 import { ExternalAuthClient } from "../auth/external/client.js";
 import { GeminiCliModule } from "../auth/gemini/cli-module.js";
@@ -553,7 +554,11 @@ export class CoreServices {
       );
     }
     this.tokenRefreshJob = new TokenRefreshJob(this.authProfilesManager, [
-      { providerId: "claude", oauthClient: new OAuthClient(CLAUDE_PROVIDER) },
+      { providerId: "claude", refresher: new OAuthClient(CLAUDE_PROVIDER) },
+      {
+        providerId: "chatgpt",
+        refresher: new ChatGPTDeviceCodeClient(),
+      },
     ]);
     logger.debug("Token refresh job constructed");
 


### PR DESCRIPTION
## Problem

Investigating "are these OAuth tokens actually refreshed before expiry?" surfaced a real gap:

- **Claude** — refresh works (30-min cron + at-use-time lazy refresh; live re-verified — exchange → refresh rotates the token). It was actually broken before #1305 too, since the refresh path used the same JSON encoding; #1305 fixed both.
- **ChatGPT (OpenAI Codex)** — **stored a `refresh_token` but never used it.** `ChatGPTDeviceCodeClient` had no refresh method, and `TokenRefreshJob` only refreshed `authType === "oauth"` profiles (Claude). ChatGPT profiles are `authType: "device-code"`, so they were never refreshed → token dies after ~10 days, forcing manual re-auth.

## Fix

- **`ChatGPTDeviceCodeClient.refreshToken()`** — form-encoded POST to OpenAI's `/oauth/token` (RFC 6749 §6, same shape as the existing code exchange). Preserves the existing refresh token when OpenAI omits it in the response (it doesn't always rotate — otherwise we'd wipe it).
- **Generalize `TokenRefreshJob`** — `oauthClient` → `refresher: TokenRefresher`, an interface both the Claude `OAuthClient` and the ChatGPT device-code client satisfy.
- **Broaden the refreshable filter** from `authType === "oauth"` to `{"oauth","device-code"}` (in both the pre-check and the in-lock re-read), and persist the profile's own `authType` instead of a hard-coded `"oauth"` so ChatGPT profiles stay `device-code`.
- **Register `chatgpt`** in the refresh job → covered by both the 30-min cron safety net and the lazy at-use-time path.

Multi-replica safety is unchanged: same per-profile advisory lock + in-lock expiry re-read.

## Verification

**Live E2E (both providers):**
```
ChatGPT: device-auth → refresh_token → refreshToken() → new access_token (rotated), new refresh_token, expires ~10d ✅
Claude:  exchange → refreshToken() → new access_token (rotated), new refresh_token ✅
```

**Tests:**
- `device-code-client.test.ts` (+2): refresh exchange is form-encoded with `grant_type=refresh_token`; refresh preserves the existing refresh token when the response omits it.
- `token-refresh-lock.test.ts`: updated for the renamed `refresher` field (advisory-lock behavior unchanged, still green).

8/8 tests pass; typecheck clean.

> Note: `pi` review was unavailable (Codex usage limit / 429 at the time). Change is small, fully typed, tested, and live-verified.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1317"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784209002&installation_id=136316292&pr_number=1317&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1317&signature=c1e294aa53decf2f97811b05de7a67bf486a6ff698770e92cb47e2ff62b92791"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->