### PR TITLE
chore: chrome-ext store prep — bump owletto pointer (#283) + privacy extension section

### DIFF
--- a/packages/landing/src/pages/privacy.astro
+++ b/packages/landing/src/pages/privacy.astro
@@ -118,6 +118,18 @@ import { Nav } from "../components/Nav";
 
         <section class="mb-10">
           <h2 class="text-xl font-semibold mb-3" style={{ color: "var(--color-page-text)" }}>
+            Browser Extension (Owletto for Chrome)
+          </h2>
+          <p class="mb-4 leading-relaxed" style={{ color: "var(--color-page-text-muted)" }}>
+            The Owletto Chrome extension connects a Chrome profile to an Owletto agent that you run, either self-hosted or on Lobu Cloud. Its single purpose is to let that agent see and act on your browser on your behalf. All data it reads is sent only to the gateway URL you configure during pairing; it is not collected by, routed through, or stored on any separate Owletto-operated server, and it is never sold or shared with third parties.
+          </p>
+          <p class="mb-4 leading-relaxed" style={{ color: "var(--color-page-text-muted)" }}>
+            With your permission the extension can access: your open tabs; the content of pages on sites you explicitly grant access to (read via Chrome's debugger API to let the agent act on those pages); and, only if you opt in from the extension's Permissions panel, your browsing history, bookmarks, and download history. Site access is off by default. You grant it per site, or all sites, by an explicit click in the panel, and every permission can be revoked at any time. The extension does not use remote code, and it accesses sites only to carry out the actions you ask your agent to perform.
+          </p>
+        </section>
+
+        <section class="mb-10">
+          <h2 class="text-xl font-semibold mb-3" style={{ color: "var(--color-page-text)" }}>
             Changes to This Policy
           </h2>
           <p class="mb-4 leading-relaxed" style={{ color: "var(--color-page-text-muted)" }}>


### PR DESCRIPTION
## What

Lobu-side prep for the Owletto Chrome extension Web Store submission.

- **Bump owletto submodule pointer** to `dd13ee9` (owletto#283 — cloud default gateway, runtime site grants, token refresh, Store packaging script).
- **privacy.astro**: add a "Browser Extension (Owletto for Chrome)" section. `lobu.ai/privacy` is the privacy-policy URL the Store listing will reference, and Web Store review checks that the policy discloses what the extension's permissions collect. The section covers: tabs, opt-in history/bookmarks/downloads, page content read via the debugger API on user-granted sites, that all data flows only to the user's configured gateway (no separate Owletto-operated collection), and that there's no remote code.

## Notes

- Landing builds clean (`bun run build`), no em dashes (per landing copy rule).
- The owletto changes are extension-only (`apps/chrome/`); no gateway/runtime behavior changes from the pointer bump.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1318"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784212702&installation_id=136316292&pr_number=1318&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1318&signature=ce7ae968afffd1a21e9d38e8ec5a93b8b7677b8dc6b462ed59a80b071f211fdb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a privacy policy for Owletto for Chrome browser extension, detailing data collection practices, where data is transmitted, and explaining all permission requirements including opt-in choices for browsing history, bookmarks, and download history.

* **Chores**
  * Updated project submodule references to latest versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->