### PR TITLE
fix(oauth): match Claude exchange redirect_uri to the authorize step

### DIFF
--- a/packages/server/src/lobu/__tests__/agent-routes-oauth-redirect.test.ts
+++ b/packages/server/src/lobu/__tests__/agent-routes-oauth-redirect.test.ts
@@ -1,0 +1,207 @@
+/**
+ * Reproducer + regression coverage for the Claude "Login with Claude" OAuth
+ * `invalid_grant: Invalid 'redirect_uri'` prod failure.
+ *
+ * The org-scoped SPA handlers in lobu/agent-routes.ts run a PKCE
+ * authorization-code flow across two requests:
+ *
+ *   GET  /:agentId/providers/claude/oauth/start  → 302 to Anthropic's authorize
+ *        URL, built by `OAuthClient.buildAuthUrl` (redirect_uri =
+ *        CLAUDE_PROVIDER.redirectUri = https://platform.claude.com/oauth/code/callback)
+ *   POST /:agentId/providers/claude/oauth/code   → exchanges the pasted
+ *        `code#state` at Anthropic's token endpoint
+ *
+ * RFC 6749 §4.1.3 requires the `redirect_uri` sent at the token exchange to be
+ * byte-identical to the one used at authorize. The /code handler used to pass a
+ * hardcoded `https://console.anthropic.com/oauth/code/callback` override —
+ * a DIFFERENT host from what /start sent — so Anthropic rejected every exchange
+ * with `invalid_grant: Invalid 'redirect_uri'`. (The earlier form-encoding fix
+ * in #1305 only made the form parse far enough for Anthropic to read, and then
+ * reject, the mismatched value.)
+ *
+ * This test drives BOTH real handlers through the Hono app with a mocked token
+ * endpoint and asserts the exchange's redirect_uri equals the one /start sent —
+ * the invariant the override violated. With the override removed it passes;
+ * with the override restored it fails (the captured exchange redirect_uri is
+ * console.anthropic.com, the authorize one is platform.claude.com).
+ *
+ * Uses the embedded Postgres gateway test harness (real oauth_states +
+ * agents rows); the only network call (the token exchange) is mocked.
+ */
+
+import {
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from 'bun:test';
+import {
+  ensureDbForGatewayTests,
+  resetTestDatabase,
+} from '../../gateway/__tests__/helpers/db-setup.js';
+import { createOAuthStateStore } from '../../gateway/auth/oauth/state-store.js';
+import {
+  authStash,
+  coreServicesStash,
+  installRouteTestMocks,
+} from './helpers/route-test-mocks';
+
+installRouteTestMocks();
+
+const TEST_ENCRYPTION_KEY =
+  '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
+
+const ORG = 'org-oauth';
+const AGENT = 'oauth-agent';
+const USER = 'u1';
+
+const EXPECTED_REDIRECT_URI =
+  'https://platform.claude.com/oauth/code/callback';
+
+const realFetch = globalThis.fetch;
+
+beforeAll(async () => {
+  await ensureDbForGatewayTests();
+  process.env.ENCRYPTION_KEY = TEST_ENCRYPTION_KEY;
+}, 60_000);
+
+async function importAgentRoutes() {
+  const mod = await import('../agent-routes.js');
+  return mod.agentRoutes;
+}
+
+async function seedOrgAndAgent(): Promise<void> {
+  const { getDb } = await import('../../db/client.js');
+  const sql = getDb();
+  await sql`
+    INSERT INTO organization (id, name, slug)
+    VALUES (${ORG}, ${ORG}, ${ORG})
+    ON CONFLICT (id) DO NOTHING
+  `;
+  await sql`
+    INSERT INTO agents (id, organization_id, name)
+    VALUES (${AGENT}, ${ORG}, ${AGENT})
+    ON CONFLICT (organization_id, id) DO NOTHING
+  `;
+}
+
+interface UpsertCapture {
+  calls: any[];
+}
+
+function installCoreServices(upsert: UpsertCapture): void {
+  const stateStore = createOAuthStateStore('claude');
+  coreServicesStash.services = {
+    getOAuthStateStore: () => stateStore,
+    getAuthProfilesManager: () => ({
+      async upsertProfile(args: any) {
+        upsert.calls.push(args);
+      },
+    }),
+  };
+}
+
+/** Captures the body POSTed to Anthropic's token endpoint, returns a fake
+ *  token. Every other URL falls through to the real fetch. */
+function installTokenEndpointMock(captured: {
+  url?: string;
+  contentType?: string | null;
+  body?: string;
+}): void {
+  globalThis.fetch = (async (input: any, init?: any) => {
+    const url = typeof input === 'string' ? input : input.url;
+    if (url.includes('platform.claude.com') && url.includes('/oauth/token')) {
+      captured.url = url;
+      captured.contentType = init?.headers?.['Content-Type'] ?? null;
+      captured.body = typeof init?.body === 'string' ? init.body : '';
+      return new Response(
+        JSON.stringify({
+          access_token: 'sk-ant-oat01-test-access',
+          refresh_token: 'sk-ant-ort01-test-refresh',
+          token_type: 'Bearer',
+          expires_in: 28800,
+          scope: 'user:inference',
+        }),
+        { status: 200, headers: { 'content-type': 'application/json' } }
+      );
+    }
+    return realFetch(input, init);
+  }) as typeof fetch;
+}
+
+describe('Claude OAuth redirect_uri must match between authorize and exchange', () => {
+  beforeEach(async () => {
+    await resetTestDatabase();
+    await seedOrgAndAgent();
+    authStash.user = {
+      id: USER,
+      name: 'Test',
+      email: 'u1@test',
+      emailVerified: true,
+    };
+    authStash.organizationId = ORG;
+    authStash.authSource = 'session';
+    authStash.mcpAuthInfo = null;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = realFetch;
+    coreServicesStash.services = null;
+  });
+
+  test('exchange reuses the authorize redirect_uri (no console.anthropic.com override)', async () => {
+    const upsert: UpsertCapture = { calls: [] };
+    installCoreServices(upsert);
+    const captured: {
+      url?: string;
+      contentType?: string | null;
+      body?: string;
+    } = {};
+    installTokenEndpointMock(captured);
+
+    const app = await importAgentRoutes();
+
+    // 1. /start → 302 to Anthropic authorize; pull redirect_uri + state from it.
+    const startRes = await app.request(
+      `/${AGENT}/providers/claude/oauth/start`,
+      { method: 'GET' }
+    );
+    expect(startRes.status).toBe(302);
+    const authorizeUrl = new URL(startRes.headers.get('location')!);
+    const authorizeRedirectUri = authorizeUrl.searchParams.get('redirect_uri');
+    const state = authorizeUrl.searchParams.get('state');
+    expect(authorizeRedirectUri).toBe(EXPECTED_REDIRECT_URI);
+    expect(state).toBeTruthy();
+
+    // 2. /code with the pasted `code#state` → token exchange.
+    const codeRes = await app.request(
+      `/${AGENT}/providers/claude/oauth/code`,
+      {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ code: `fake-auth-code#${state}` }),
+      }
+    );
+    expect(codeRes.status).toBe(200);
+    expect(await codeRes.json()).toEqual({ success: true });
+
+    // The exchange must have been form-encoded (RFC 6749) and carried the SAME
+    // redirect_uri the authorize step used — this is the invariant the old
+    // hardcoded console.anthropic.com override violated.
+    expect(captured.contentType).toBe('application/x-www-form-urlencoded');
+    const exchangeParams = new URLSearchParams(captured.body ?? '');
+    expect(exchangeParams.get('redirect_uri')).toBe(authorizeRedirectUri);
+    expect(exchangeParams.get('redirect_uri')).toBe(EXPECTED_REDIRECT_URI);
+
+    // The rotated credentials were persisted as a Claude oauth profile.
+    expect(upsert.calls).toHaveLength(1);
+    expect(upsert.calls[0]).toMatchObject({
+      agentId: AGENT,
+      provider: 'claude',
+      authType: 'oauth',
+      credential: 'sk-ant-oat01-test-access',
+    });
+  });
+});

--- a/packages/server/src/lobu/__tests__/helpers/route-test-mocks.ts
+++ b/packages/server/src/lobu/__tests__/helpers/route-test-mocks.ts
@@ -42,6 +42,15 @@ export const authStash: AuthStash = {
  */
 export const chatManagerStash: { manager: any } = { manager: null };
 
+/**
+ * Mutable holder for whatever `getLobuCoreServices()` should return. Defaults
+ * to `null` (the historical behavior every other route test relies on); the
+ * OAuth-route test (agent-routes-oauth-redirect.test.ts) sets a fake exposing
+ * `getOAuthStateStore()` + `getAuthProfilesManager()` so the
+ * `/providers/:provider/oauth/{start,code}` handlers can run.
+ */
+export const coreServicesStash: { services: any } = { services: null };
+
 let installed = false;
 
 /**
@@ -71,7 +80,7 @@ export function installRouteTestMocks(): void {
   // Resolves to src/lobu/gateway — imported by agent-routes.ts as `./gateway`.
   mock.module('../../gateway', () => ({
     getChatInstanceManager: () => chatManagerStash.manager,
-    getLobuCoreServices: () => null,
+    getLobuCoreServices: () => coreServicesStash.services,
     initLobuGateway: async () => null,
     stopLobuGateway: async () => {},
     isLobuGatewayRunning: () => false,

--- a/packages/server/src/lobu/agent-routes.ts
+++ b/packages/server/src/lobu/agent-routes.ts
@@ -763,7 +763,12 @@ routes.post('/:agentId/providers/:providerId/oauth/code', async (c) => {
     const credentials = await oauthClient.exchangeCodeForToken(
       parts[0].trim(),
       stateData.codeVerifier,
-      'https://console.anthropic.com/oauth/code/callback',
+      // No redirect_uri override: the exchange MUST reuse the exact redirect_uri
+      // the authorize step sent (CLAUDE_PROVIDER.redirectUri, via buildAuthUrl in
+      // the /start handler above). Passing a different value here — the old
+      // `console.anthropic.com` callback — makes Anthropic reject the exchange
+      // with `invalid_grant: Invalid 'redirect_uri'`.
+      undefined,
       parts[1].trim()
     );
 


### PR DESCRIPTION
## The gap (after #1305)

\`#1305\` (form-encode the Claude token exchange) **is merged and live in prod** — the running pods serve the new image and the prod log now shows \`{"contentType":"form"}\`. But Claude "Login with Claude" still failed with the **same** toast:

\`\`\`
Token exchange failed: 400
invalid_grant: Invalid 'redirect_uri' in request.
\`\`\`

Two independent bugs produce that identical error; #1305 fixed only the first:

1. **#1305 (fixed):** exchange body was JSON, not form-encoded. Anthropic couldn't parse it, so \`redirect_uri\` read as *absent* → "Invalid redirect_uri".
2. **This PR:** the org-scoped SPA handler that prod actually uses — \`POST /api/<org>/agents/<slug>/providers/claude/oauth/code\` in \`packages/server/src/lobu/agent-routes.ts\` — exchanged the code with a **hardcoded** \`redirect_uri = https://console.anthropic.com/oauth/code/callback\`, while \`/oauth/start\` authorizes with \`CLAUDE_PROVIDER.redirectUri = https://platform.claude.com/oauth/code/callback\`. RFC 6749 §4.1.3 requires the exchange redirect_uri to byte-match the authorize one → Anthropic rejects the mismatch.

#1305 peeled the first layer (the form now parses), which let Anthropic *read* — and reject — the genuinely-mismatched redirect_uri value. Same error string, different cause. My earlier live verification used a throwaway script + the older \`/api/v1/auth\` route (which passes \`undefined\` → correct redirect), so it never exercised this SPA handler.

## Fix

Drop the override so the exchange reuses the authorize \`redirect_uri\` (one-line removal of the stale \`console.anthropic.com\` value).

## Root cause from prod logs

\`\`\`
[claude-client] Exchanging code for token at https://platform.claude.com/v1/oauth/token {"contentType":"form"}   ← #1305 IS live
[claude-client] Token exchange failed: 400 {"errorText":"invalid_grant: Invalid 'redirect_uri' in request."}     ← the remaining mismatch
\`\`\`
authorize sent \`platform.claude.com/...\`, exchange sent \`console.anthropic.com/...\`.

## Tests (red→green reproducer)

New DB-backed \`agent-routes-oauth-redirect.test.ts\` drives **both real handlers** (\`/start\` then \`/code\`) through the Hono app with a mocked token endpoint and asserts the exchange redirect_uri equals the authorize one:

- **red** (override restored): \`Expected platform.claude.com… / Received console.anthropic.com…\`
- **green** (fix): exchange redirect_uri == authorize redirect_uri == \`platform.claude.com/oauth/code/callback\`; form-encoded; profile persisted.

Harness: extended shared \`route-test-mocks.ts\` with an additive \`coreServicesStash\` (defaults \`null\`; other route tests unaffected). \`32 pass\` across \`src/lobu/__tests__\`, \`make typecheck\` clean.

## Live E2E

Anthropic's authorize endpoint accepts \`redirect_uri=platform.claude.com/oauth/code/callback\` (consent screen renders, no "Invalid request format"), and a prior session obtained a real \`sk-ant-oat01…\` token via that exact redirect. Full live round-trip through the fixed redirect being confirmed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1319"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784215164&installation_id=136316292&pr_number=1319&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1319&signature=441dd99524eef6cdc71805229757b5a5f36313862e1d419e05f2af1d95e18d52"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Claude OAuth authentication to properly align redirect URIs between authorization and token-exchange steps, preventing mismatch failures.

* **Tests**
  * Added regression test coverage for Claude OAuth redirect URI handling during the authentication flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->