### PR TITLE
fix(oauth): pass userId when persisting the Claude OAuth profile

### DIFF
--- a/packages/server/src/lobu/__tests__/agent-routes-oauth-redirect.test.ts
+++ b/packages/server/src/lobu/__tests__/agent-routes-oauth-redirect.test.ts
@@ -97,6 +97,16 @@ function installCoreServices(upsert: UpsertCapture): void {
     getOAuthStateStore: () => stateStore,
     getAuthProfilesManager: () => ({
       async upsertProfile(args: any) {
+        // Mirror the real AuthProfilesManager.upsertProfile guard: persisting a
+        // profile requires the owning principal's userId. If the route omits it
+        // (the prod bug after the redirect_uri fix), the persist throws and the
+        // whole login fails AFTER a successful token exchange — so the fake must
+        // enforce it too, or the test would pass against a broken route.
+        if (!args.userId) {
+          throw new Error(
+            'upsertProfile requires userId — declared agents cannot be mutated'
+          );
+        }
         upsert.calls.push(args);
       },
     }),
@@ -195,10 +205,13 @@ describe('Claude OAuth redirect_uri must match between authorize and exchange', 
     expect(exchangeParams.get('redirect_uri')).toBe(authorizeRedirectUri);
     expect(exchangeParams.get('redirect_uri')).toBe(EXPECTED_REDIRECT_URI);
 
-    // The rotated credentials were persisted as a Claude oauth profile.
+    // The rotated credentials were persisted as a Claude oauth profile —
+    // crucially scoped to the authenticated session user (`userId`), which the
+    // real upsertProfile guard requires. Omitting it threw post-exchange in prod.
     expect(upsert.calls).toHaveLength(1);
     expect(upsert.calls[0]).toMatchObject({
       agentId: AGENT,
+      userId: USER,
       provider: 'claude',
       authType: 'oauth',
       credential: 'sk-ant-oat01-test-access',

--- a/packages/server/src/lobu/agent-routes.ts
+++ b/packages/server/src/lobu/agent-routes.ts
@@ -774,6 +774,12 @@ routes.post('/:agentId/providers/:providerId/oauth/code', async (c) => {
 
     await authProfilesManager.upsertProfile({
       agentId,
+      // The profile is owned by the authenticated session user (the same
+      // principal whose id was checked against the OAuth state above).
+      // upsertProfile requires it — without it the persist throws
+      // "upsertProfile requires userId" and the whole login fails AFTER a
+      // successful token exchange.
+      userId: user.id,
       provider: providerId,
       credential: credentials.accessToken,
       authType: 'oauth',


### PR DESCRIPTION
## Found by live-testing the real prod flow after #1319

#1319 fixed the redirect_uri mismatch, and the prod token exchange now succeeds (`claude-client: Token exchange successful, scopes: user:inference`). But driving the actual "Login with Claude" UI surfaced the **next** failure on the same handler:

> upsertProfile requires userId — declared agents cannot be mutated; runtime agents must specify the owning principal

The SPA handler `POST /:agentId/providers/claude/oauth/code` (`packages/server/src/lobu/agent-routes.ts`) persists the credential via `authProfilesManager.upsertProfile(...)` but omitted `userId`. `AuthProfilesManager.upsertProfile` requires it (the owning principal). So the login failed at the persist step **after** a successful Anthropic token exchange — a real, separate bug from the redirect_uri one.

This is the third and final layer behind "Login with Claude" not working: (1) JSON vs form-encoding [#1305], (2) redirect_uri mismatch [#1319], (3) missing userId on persist [this PR].

## Fix

Pass `userId: user.id`. The handler already has the authenticated session user — it validates `stateData.userId === user.id` immediately above. Every other `upsertProfile` call site (api-key path, device-code module, refresh job, the sibling apply path in this same file) already passes `userId`; this one was the lone omission.

```
audit of all upsertProfile call sites — only the /oauth/code handler lacked userId:
  agent-routes.ts:332 (apply)        userId ✓
  agent-routes.ts:770 (oauth/code)   userId ✗  ← this PR
  gateway.ts:476 (api-key)           userId ✓
  token-refresh-job.ts:223           userId ✓
  chatgpt-oauth-module.ts:140        userId ✓
  claude/oauth-module.ts:187         userId ✓
```

## Tests (red→green)

Strengthens the #1319 DB-backed regression test so it actually guards this:
- the fake `authProfilesManager` now **mirrors the real `userId` guard** (throws when omitted). Previously it ignored `userId`, which is exactly why the bug reached prod despite a "passing" test.
- asserts `userId: USER` is in the persisted profile.

Red with the line removed (route → 400, persist throws), green with the fix. Full `src/lobu/__tests__`: 32 pass; `make typecheck` clean.

## Live E2E

Prod logs for the pre-fix attempt confirm the exact failure shape: token exchange succeeded, then `/oauth/code` returned 400. After deploy I'll re-run the real "Login with Claude" UI flow and confirm the profile saves (success, no toast).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1321"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784219351&installation_id=136316292&pr_number=1321&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1321&signature=d777878a13a276d33710ab2880e9c651674fea43406c1b39dbcf7743ca39366d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Fixed OAuth profile persistence to ensure exchanged credentials are properly scoped to the authenticated user's session, preventing login failures after successful token exchange.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->