### PR TITLE
test(oauth): tear down the real CoreServices the hardened OAuth test builds

### DIFF
--- a/packages/server/src/lobu/__tests__/agent-routes-oauth-redirect.test.ts
+++ b/packages/server/src/lobu/__tests__/agent-routes-oauth-redirect.test.ts
@@ -147,9 +147,12 @@ describe('Claude OAuth redirect_uri must match between authorize and exchange', 
     };
   });
 
-  afterEach(() => {
+  afterEach(async () => {
     globalThis.fetch = realFetch;
     coreServicesStash.services = null;
+    // Stop the SSE fanout / queue listeners the real CoreServices started so
+    // they don't leak into later tests sharing the Bun process.
+    await stack?.shutdown();
   });
 
   test('exchange reuses the authorize redirect_uri (no console.anthropic.com override)', async () => {

--- a/packages/server/src/lobu/__tests__/helpers/real-claude-auth-stack.ts
+++ b/packages/server/src/lobu/__tests__/helpers/real-claude-auth-stack.ts
@@ -88,6 +88,14 @@ function minimalGatewayConfig(): GatewayConfig {
 export interface RealClaudeAuthStack {
   authProfilesManager: AuthProfilesManager;
   oauthStateStore: ProviderOAuthStateStore;
+  /**
+   * Stop the SSE fanout / queue listeners this stack started. Call from the
+   * test's `afterEach` — `initializeClaudeServices()` also registers provider
+   * modules into the process-global `moduleRegistry` bound to THIS stack's
+   * manager, so leaving it running leaks listeners into later tests that share
+   * the Bun process.
+   */
+  shutdown(): Promise<void>;
 }
 
 /**
@@ -140,8 +148,12 @@ export async function buildRealClaudeAuthStack(): Promise<RealClaudeAuthStack> {
       ownsAgent: async () => true,
     } as never,
   });
-  (coreServices as unknown as { queue: unknown }).queue =
-    new MockMessageQueue();
+  // MockMessageQueue has no stop(); coreServices.shutdown() calls queue.stop(),
+  // so give the injected queue a no-op stop to keep teardown clean.
+  (coreServices as unknown as { queue: unknown }).queue = Object.assign(
+    new MockMessageQueue(),
+    { stop: async () => {} }
+  );
 
   await (
     coreServices as unknown as {
@@ -160,5 +172,9 @@ export async function buildRealClaudeAuthStack(): Promise<RealClaudeAuthStack> {
   if (!authProfilesManager || !oauthStateStore) {
     throw new Error('CoreServices did not initialize the Claude auth stack');
   }
-  return { authProfilesManager, oauthStateStore };
+  return {
+    authProfilesManager,
+    oauthStateStore,
+    shutdown: () => coreServices.shutdown(),
+  };
 }


### PR DESCRIPTION
Follow-up to #1322, addressing a finding from a multi-model review (grok + pi + gemini) of that PR.

## Finding (pi, MEDIUM)
`agent-routes-oauth-redirect.test.ts` builds a real `CoreServices` per `beforeEach` via `buildRealClaudeAuthStack()` but never tore it down. `initializeClaudeServices()` starts the SSE fanout and registers provider modules into the **process-global** `moduleRegistry` bound to that stack's `AuthProfilesManager`. Left running, those listeners leak into later tests sharing the Bun process. (`moduleRegistry.register` does `Map.set` — it overwrites rather than throws, so this is a resource/listener leak, not a hard cross-test failure — but still worth closing.)

## Fix
- `RealClaudeAuthStack` now exposes `shutdown()` → `CoreServices.shutdown()` (stops SSE fanout + queue listeners).
- The test calls it in `afterEach`.
- The injected `MockMessageQueue` gets a no-op `stop()` (shutdown() calls `queue.stop()`).

## Verification
- 37 tests pass (`src/lobu/__tests__` + chatgpt device-code).
- red→green via the **real** `userId` guard still holds (remove `userId` → route 400s → test fails).
- typecheck clean.

## Review notes (other findings, no action needed)
- grok: **No blocking issues**; confirmed the #1322 deletion doesn't touch the live SPA or device-code routes, and the test hardening has no false-pass path.
- LOW (known): the auto-generated client SDK still lists `POST /api/v1/auth/{provider}/code`; it re-derives from the live OpenAPI spec on the next `npm run generate`, and isn't hand-edited.
- gemini: produced no usable review (kept trying to shell out).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1323"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784224153&installation_id=136316292&pr_number=1323&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1323&signature=b247fc0096200b129366b1d03e90685c3d6583aaaa7d21fc53c15eeadb0f71fc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->