### PR TITLE
refactor(oauth): inline getClaudeOAuthRuntime + fix stale test comment

### DIFF
--- a/packages/server/src/lobu/__tests__/helpers/route-test-mocks.ts
+++ b/packages/server/src/lobu/__tests__/helpers/route-test-mocks.ts
@@ -45,9 +45,11 @@ export const chatManagerStash: { manager: any } = { manager: null };
 /**
  * Mutable holder for whatever `getLobuCoreServices()` should return. Defaults
  * to `null` (the historical behavior every other route test relies on); the
- * OAuth-route test (agent-routes-oauth-redirect.test.ts) sets a fake exposing
- * `getOAuthStateStore()` + `getAuthProfilesManager()` so the
- * `/providers/:provider/oauth/{start,code}` handlers can run.
+ * OAuth-route test (agent-routes-oauth-redirect.test.ts) sets it to a REAL
+ * `AuthProfilesManager` + OAuth state store (DB-backed, via
+ * `buildRealClaudeAuthStack()`) so the
+ * `/providers/:provider/oauth/{start,code}` handlers run against the genuine
+ * `upsertProfile` guard — not a fake that would mask a missing `userId`.
  */
 export const coreServicesStash: { services: any } = { services: null };
 

--- a/packages/server/src/lobu/agent-routes.ts
+++ b/packages/server/src/lobu/agent-routes.ts
@@ -198,13 +198,6 @@ function normalizeRuntimeProvider(provider: any, models: ProviderModelOption[]):
   };
 }
 
-function getClaudeOAuthRuntime() {
-  return {
-    oauthClient: new OAuthClient(CLAUDE_PROVIDER),
-    createAuthProfileLabel,
-  };
-}
-
 // ── Route-level middleware ───────────────────────────────────────────────────
 //
 // Every agent route is org-scoped: it requires a valid auth context (`mcpAuth`)
@@ -704,7 +697,7 @@ routes.get('/:agentId/providers/:providerId/oauth/start', async (c) => {
     return c.json({ error: 'Embedded Lobu auth is not available' }, 503);
   }
 
-  const { oauthClient } = getClaudeOAuthRuntime();
+  const oauthClient = new OAuthClient(CLAUDE_PROVIDER);
   const codeVerifier = oauthClient.generateCodeVerifier();
   const state = await oauthStateStore.create({
     userId: user.id,
@@ -757,7 +750,7 @@ routes.post('/:agentId/providers/:providerId/oauth/code', async (c) => {
   if (stateData.agentId !== agentId || stateData.userId !== user.id) {
     return c.json({ error: 'OAuth state does not match this agent session' }, 403);
   }
-  const { oauthClient, createAuthProfileLabel } = getClaudeOAuthRuntime();
+  const oauthClient = new OAuthClient(CLAUDE_PROVIDER);
 
   try {
     const credentials = await oauthClient.exchangeCodeForToken(


### PR DESCRIPTION
Final cleanup from the multi-model review of the Claude OAuth work.

1. **Simplify**: dropped the `getClaudeOAuthRuntime()` wrapper — it just returned `new OAuthClient(CLAUDE_PROVIDER)` + `createAuthProfileLabel` (already a module-level import). Inlined at both call sites (`/oauth/start`, `/oauth/code`).
2. **NIT (grok)**: `route-test-mocks.ts` `coreServicesStash` comment still said the OAuth test sets a 'fake' manager; it now wires the REAL DB-backed `AuthProfilesManager`. Fixed.
3. **Ownership note (grok) — investigated, no change**: `/oauth/start` doesn't call `verifyOwnedAgentAccess`, but neither do its siblings. All three provider-mutating SPA routes (`oauth/start`, `oauth/code`, `api-key`) share the same gate: `requireSessionOrAdminPat` + `hasAgent`, and `hasAgent` filters `WHERE organization_id = orgId` — cross-org is blocked, within-org is the intended model. Adding per-user ownership to only the OAuth routes would be inconsistent.

Covered by `agent-routes-oauth-redirect` (drives the real `/start`+`/code` handlers): 32 pass, typecheck clean.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1324"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784224890&installation_id=136316292&pr_number=1324&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1324&signature=4178c6deddcf95031397cb3228925590d385f68f6b4e253b4d0f04013391f452"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified OAuth client initialization by removing an intermediary helper and using direct instantiation instead.

* **Tests**
  * Updated OAuth route test configuration to exercise real authentication implementations rather than mocked versions, ensuring handlers validate actual profile behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->