### PR TITLE
fix(guardrails): enforce output guardrails on the API/SSE path

### DIFF
--- a/packages/server/src/__tests__/guardrails-runtime.test.ts
+++ b/packages/server/src/__tests__/guardrails-runtime.test.ts
@@ -951,29 +951,65 @@ describe('UnifiedThreadResponseConsumer — wired output guardrail (API path)', 
     expect(rows[0]!.metadata.agent_id).toBe(agentId);
   });
 
-  it('suppresses a streaming delta that carries a secret (no output broadcast)', async () => {
+  it('withholds ALL streaming deltas for a guardrail-enabled agent (cross-pod split-secret cannot leak)', async () => {
     const { sse, events } = createCapturingSse();
     const consumer = createConsumer(sse);
 
-    const payload = {
-      messageId: 'm1',
-      channelId: 'api:conv-1',
-      conversationId: 'conv-1',
-      userId: 'u1',
-      teamId: 'api',
-      platform: 'api',
-      timestamp: 0,
-      delta: 'here it is sk-abcdefghij0123456789AB done',
-      platformMetadata: { agentId, organizationId: orgId },
-    };
+    // Even a delta that LOOKS clean is withheld — a secret could be split across
+    // deltas claimed on different replicas, which no per-pod scan would catch.
+    // The scanned finalText is delivered at completion instead.
+    for (const delta of ['here it is ', 'sk-abcdefghij', '0123456789AB done']) {
+      await orgContext.run({ organizationId: orgId }, async () => {
+        await consumer.handleThreadResponse({
+          id: '1',
+          data: {
+            messageId: 'm1',
+            channelId: 'api:conv-1',
+            conversationId: 'conv-1',
+            originalMessageId: 'm1',
+            userId: 'u1',
+            teamId: 'api',
+            platform: 'api',
+            timestamp: 0,
+            delta,
+            platformMetadata: { agentId, organizationId: orgId },
+          },
+        });
+      });
+    }
+
+    // No delta reaches the client as an `output` event.
+    expect(events.filter((e) => e.event === 'output').length).toBe(0);
+  });
+
+  it('streams deltas normally for an agent with NO output guardrails', async () => {
+    const { sse, events } = createCapturingSse();
+    const consumer = createConsumer(sse);
+
+    // A separate agent with no guardrails configured — streaming is unaffected.
+    const plain = await createTestAgent({ organizationId: orgId });
 
     await orgContext.run({ organizationId: orgId }, async () => {
-      await consumer.handleThreadResponse({ id: '1', data: payload });
+      await consumer.handleThreadResponse({
+        id: '1',
+        data: {
+          messageId: 'm2',
+          channelId: 'api:conv-2',
+          conversationId: 'conv-2',
+          originalMessageId: 'm2',
+          userId: 'u1',
+          teamId: 'api',
+          platform: 'api',
+          timestamp: 0,
+          delta: 'streaming token',
+          platformMetadata: { agentId: plain.agentId, organizationId: orgId },
+        },
+      });
     });
 
-    // The leaking delta must not reach the client as an `output` event.
     const outputs = events.filter((e) => e.event === 'output');
-    expect(outputs.length).toBe(0);
+    expect(outputs.length).toBe(1);
+    expect(outputs[0]!.payload.content).toBe('streaming token');
   });
 
   it('passes a clean finalText through unchanged (no false block)', async () => {

--- a/packages/server/src/__tests__/guardrails-runtime.test.ts
+++ b/packages/server/src/__tests__/guardrails-runtime.test.ts
@@ -21,7 +21,9 @@ import type { Guardrail } from '@lobu/core';
 import { generateWorkerToken, GuardrailRegistry } from '@lobu/core';
 import { AgentSettingsStore } from '../gateway/auth/settings/agent-settings-store';
 import { McpProxy } from '../gateway/auth/mcp/proxy';
+import { ApiResponseRenderer } from '../gateway/api/response-renderer';
 import { ChatResponseBridge } from '../gateway/connections/chat-response-bridge';
+import { UnifiedThreadResponseConsumer } from '../gateway/platform/unified-thread-consumer';
 import {
   flushPendingGuardrailAudits,
 } from '../gateway/guardrails/audit';
@@ -832,6 +834,178 @@ describe('McpProxy — wired pre-tool guardrail', () => {
     expect(json.error?.message).toMatch(/Batched tools\/call is not permitted/);
     // The forbidden call never reached an upstream, so no -32603 connect error.
     expect(json.error?.message).not.toMatch(/Failed to connect/);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// UnifiedThreadResponseConsumer → ApiResponseRenderer (output stage)
+//
+// Regression: output guardrails were wired ONLY into ChatResponseBridge, so
+// pure API/SSE rows (web SPA + programmatic Agent API) — which route through
+// ApiResponseRenderer — streamed secrets/PII to the client uninspected and
+// never wrote a guardrail-trip event. These tests drive the real consumer +
+// real ApiResponseRenderer over an API row and assert the secret is blocked.
+// ─────────────────────────────────────────────────────────────────────────
+
+describe('UnifiedThreadResponseConsumer — wired output guardrail (API path)', () => {
+  let orgId: string;
+  let agentId: string;
+
+  /** Capturing SSE manager: records every broadcast, owns every session. */
+  function createCapturingSse() {
+    const events: Array<{ sessionId: string; event: string; payload: any }> =
+      [];
+    const sse = {
+      broadcast: (sessionId: string, event: string, payload: any) => {
+        events.push({ sessionId, event, payload });
+      },
+      hasActiveConnection: () => true,
+    };
+    return { sse, events };
+  }
+
+  function createConsumer(sse: unknown) {
+    const renderer = new ApiResponseRenderer(sse as any);
+    const queue = {
+      start: async () => {},
+      stop: async () => {},
+      createQueue: async () => {},
+      work: async () => {},
+      send: async () => 'job-id',
+    };
+    const platformRegistry = {
+      get: () => ({ getResponseRenderer: () => renderer }),
+    };
+    const consumer = new UnifiedThreadResponseConsumer(
+      queue as any,
+      platformRegistry as any,
+      sse as any
+    ) as any;
+    const registry = new GuardrailRegistry();
+    registerBuiltinGuardrails(registry);
+    const settingsStore = new AgentSettingsStore(
+      createPostgresAgentConfigStore()
+    );
+    consumer.setOutputGuardrails(registry, settingsStore);
+    return consumer;
+  }
+
+  beforeEach(async () => {
+    await cleanupTestDatabase();
+    const org = await createTestOrganization({ name: 'Guardrails API Org' });
+    orgId = org.id;
+    const agent = await createTestAgent({ organizationId: orgId });
+    agentId = agent.agentId;
+
+    const configStore = createPostgresAgentConfigStore();
+    await orgContext.run({ organizationId: orgId }, async () => {
+      await configStore.saveSettings(agentId, {
+        guardrails: ['secret-scan'],
+        updatedAt: Date.now(),
+      });
+    });
+  });
+
+  afterAll(async () => {
+    const db = getTestDb();
+    await db`TRUNCATE agents CASCADE`;
+  });
+
+  it('blocks a secret in the terminal finalText, broadcasts the block message instead, audits the trip', async () => {
+    const { sse, events } = createCapturingSse();
+    const consumer = createConsumer(sse);
+
+    const payload = {
+      messageId: 'm1',
+      channelId: 'api:conv-1',
+      conversationId: 'conv-1',
+      userId: 'u1',
+      teamId: 'api',
+      platform: 'api',
+      timestamp: 0,
+      processedMessageIds: ['m1'],
+      finalText: 'your key is sk-abcdefghij0123456789AB please',
+      platformMetadata: { agentId, organizationId: orgId },
+    };
+
+    await orgContext.run({ organizationId: orgId }, async () => {
+      await consumer.handleThreadResponse({ id: '1', data: payload });
+    });
+
+    const complete = events.find((e) => e.event === 'complete');
+    expect(complete).toBeDefined();
+    // The SPA repairs its message from finalText on `complete` — it must be the
+    // block notice, NOT the leaked secret.
+    expect(complete!.payload.finalText).toContain(
+      'Message blocked by guardrail'
+    );
+    expect(complete!.payload.finalText).not.toContain(
+      'sk-abcdefghij0123456789AB'
+    );
+
+    await flushPendingGuardrailAudits();
+    const rows = await fetchGuardrailEvents(orgId, 'output');
+    expect(rows.length).toBe(1);
+    expect(rows[0]!.metadata.guardrail).toBe('secret-scan');
+    expect(rows[0]!.metadata.stage).toBe('output');
+    expect(rows[0]!.metadata.agent_id).toBe(agentId);
+  });
+
+  it('suppresses a streaming delta that carries a secret (no output broadcast)', async () => {
+    const { sse, events } = createCapturingSse();
+    const consumer = createConsumer(sse);
+
+    const payload = {
+      messageId: 'm1',
+      channelId: 'api:conv-1',
+      conversationId: 'conv-1',
+      userId: 'u1',
+      teamId: 'api',
+      platform: 'api',
+      timestamp: 0,
+      delta: 'here it is sk-abcdefghij0123456789AB done',
+      platformMetadata: { agentId, organizationId: orgId },
+    };
+
+    await orgContext.run({ organizationId: orgId }, async () => {
+      await consumer.handleThreadResponse({ id: '1', data: payload });
+    });
+
+    // The leaking delta must not reach the client as an `output` event.
+    const outputs = events.filter((e) => e.event === 'output');
+    expect(outputs.length).toBe(0);
+  });
+
+  it('passes a clean finalText through unchanged (no false block)', async () => {
+    const { sse, events } = createCapturingSse();
+    const consumer = createConsumer(sse);
+
+    const payload = {
+      messageId: 'm1',
+      channelId: 'api:conv-1',
+      conversationId: 'conv-1',
+      userId: 'u1',
+      teamId: 'api',
+      platform: 'api',
+      timestamp: 0,
+      processedMessageIds: ['m1'],
+      finalText: 'here is a perfectly normal reply with no secrets',
+      platformMetadata: { agentId, organizationId: orgId },
+    };
+
+    await orgContext.run({ organizationId: orgId }, async () => {
+      await consumer.handleThreadResponse({ id: '1', data: payload });
+    });
+
+    const complete = events.find((e) => e.event === 'complete');
+    expect(complete).toBeDefined();
+    expect(complete!.payload.finalText).toBe(
+      'here is a perfectly normal reply with no secrets'
+    );
+
+    await flushPendingGuardrailAudits();
+    const rows = await fetchGuardrailEvents(orgId, 'output');
+    expect(rows.length).toBe(0);
   });
 });
 

--- a/packages/server/src/gateway/connections/chat-response-bridge.ts
+++ b/packages/server/src/gateway/connections/chat-response-bridge.ts
@@ -13,17 +13,15 @@
 
 import { unlink } from "node:fs/promises";
 import { resolve } from "node:path";
-import {
-  createLogger,
-  type GuardrailRegistry,
-  runGuardrailInstances,
-} from "@lobu/core";
+import { createLogger, type GuardrailRegistry } from "@lobu/core";
 import { Actions, Card, CardText, LinkButton } from "chat";
 import { getDb } from "../../db/client.js";
 import { getOrganizationSlug } from "../../utils/url-builder.js";
 import type { AgentSettingsStore } from "../auth/settings/agent-settings-store.js";
-import { resolveAgentGuardrails } from "../guardrails/aggregator.js";
-import { recordGuardrailTrip } from "../guardrails/audit.js";
+import {
+  OUTPUT_GUARDRAIL_SCAN_WINDOW as GUARDRAIL_SCAN_WINDOW,
+  runOutputGuardrailScan,
+} from "../guardrails/output-scan.js";
 import type { ThreadResponsePayload } from "../infrastructure/queue/index.js";
 import { extractSettingsLinkButtons } from "../platform/link-buttons.js";
 import type { ResponseRenderer } from "../platform/response-renderer.js";
@@ -103,17 +101,6 @@ interface ResponseContext {
   platform: string;
   strategy: PlatformResponseStrategy;
 }
-
-/**
- * Streaming chunks split arbitrarily across token boundaries; a secret like
- * `sk-abc...` can arrive as `"sk-an"` then `"t-..."` and bypass any per-delta
- * regex. We keep a rolling tail of recent emitted text per stream and scan
- * `tail + delta` so patterns straddling a chunk boundary still match. The
- * scan window is bounded at 2× this value to keep regex cost proportional
- * to the chunk being processed, not the entire stream.
- */
-const OUTPUT_GUARDRAIL_TAIL_CHARS = 256;
-const GUARDRAIL_SCAN_WINDOW = OUTPUT_GUARDRAIL_TAIL_CHARS * 2;
 
 /**
  * ChatResponseBridge implements ResponseRenderer so it can be plugged into
@@ -206,52 +193,20 @@ export class ChatResponseBridge implements ResponseRenderer {
     payload: ThreadResponsePayload,
     ctx: ResponseContext
   ): Promise<{ guardrail: string; reason?: string } | null> {
-    if (!this.guardrailRegistry || !this.agentSettingsStore) return null;
-    if (!scanText) return null;
     const agentId = this.resolveAgentId(payload, ctx);
     if (!agentId) return null;
-
-    try {
-      const settings = await this.agentSettingsStore.getSettings(agentId);
-      const resolved = resolveAgentGuardrails(
-        settings ?? { guardrails: [] },
-        (settings?.skillsConfig?.skills ?? []).filter((s) => s.enabled),
-        this.guardrailRegistry
-      );
-      const list = resolved.byStage.output;
-      if (list.length === 0) return null;
-      const outcome = await runGuardrailInstances("output", list, {
+    return runOutputGuardrailScan(
+      this.guardrailRegistry,
+      this.agentSettingsStore,
+      scanText,
+      {
         agentId,
-        userId: payload.userId,
-        text: scanText,
-        platform: ctx.platform,
-        conversationId: payload.conversationId,
-      });
-      if (!outcome.tripped) return null;
-      // Fire-and-forget — the block message must not wait on the audit write.
-      void recordGuardrailTrip({
         organizationId: this.resolveOrganizationId(payload, ctx),
-        agentId,
         userId: payload.userId,
         conversationId: payload.conversationId,
-        stage: "output",
-        guardrail: outcome.tripped.guardrail,
-        reason: outcome.tripped.reason,
-        metadata: outcome.tripped.metadata,
-      });
-      return {
-        guardrail: outcome.tripped.guardrail,
-        reason: outcome.tripped.reason,
-      };
-    } catch (err) {
-      logger.warn(
-        {
-          err: err instanceof Error ? err.message : String(err),
-        },
-        "Output guardrail check failed — proceeding without guardrails"
-      );
-      return null;
-    }
+        platform: ctx.platform,
+      }
+    );
   }
 
   private extractResponseContext(

--- a/packages/server/src/gateway/gateway-main.ts
+++ b/packages/server/src/gateway/gateway-main.ts
@@ -145,6 +145,15 @@ export class Gateway {
       platformRegistry,
       this.coreServices.getSseManager()
     );
+    // Output-stage guardrails for the API/SSE path. ChatResponseBridge runs
+    // output guardrails for chat platforms; pure API/SSE rows (web SPA +
+    // programmatic Agent API) route through ApiResponseRenderer, which has no
+    // guardrail hook — wire them on the consumer so secret-scan/pii-scan
+    // configured via `defineAgent` enforce on the API surface too.
+    this.unifiedConsumer.setOutputGuardrails(
+      this.coreServices.getGuardrailRegistry() ?? undefined,
+      this.coreServices.getAgentSettingsStore() ?? undefined
+    );
     await this.unifiedConsumer.start();
 
     // 6. Start the turn-liveness deadline sweep — the cross-replica backstop

--- a/packages/server/src/gateway/guardrails/output-scan.ts
+++ b/packages/server/src/gateway/guardrails/output-scan.ts
@@ -1,0 +1,198 @@
+/**
+ * Shared output-stage guardrail enforcement.
+ *
+ * Output guardrails (secret-scan, pii-scan, …) must run on EVERY response
+ * surface, not just Chat SDK platforms. This module is the single place the
+ * stage is resolved + run + audited so the two renderer-agnostic call sites —
+ * `ChatResponseBridge` (chat platforms) and `UnifiedThreadResponseConsumer`
+ * (the API/SSE/web path via `ApiResponseRenderer`) — share identical, vetted
+ * logic instead of one of them silently lacking enforcement.
+ *
+ * Like all guardrails it fails OPEN: a runner/lookup error logs and returns
+ * `null` (no block) rather than dropping a legitimate reply.
+ */
+
+import {
+  createLogger,
+  type GuardrailRegistry,
+  runGuardrailInstances,
+} from "@lobu/core";
+import type { AgentSettingsStore } from "../auth/settings/agent-settings-store.js";
+import { resolveAgentGuardrails } from "./aggregator.js";
+import { recordGuardrailTrip } from "./audit.js";
+
+const logger = createLogger("output-guardrail");
+
+/**
+ * Streaming chunks split arbitrarily across token boundaries; a secret like
+ * `sk-abc…` can arrive as `"sk-an"` then `"t-…"` and bypass any per-delta
+ * regex. Callers keep a rolling tail of recent emitted text and scan
+ * `tail + delta` so patterns straddling a chunk boundary still match. The scan
+ * window is bounded at 2× the tail to keep regex cost proportional to the
+ * chunk being processed, not the entire stream.
+ */
+export const OUTPUT_GUARDRAIL_TAIL_CHARS = 256;
+export const OUTPUT_GUARDRAIL_SCAN_WINDOW = OUTPUT_GUARDRAIL_TAIL_CHARS * 2;
+
+export interface OutputScanContext {
+  agentId: string;
+  organizationId?: string;
+  userId: string;
+  conversationId?: string;
+  platform: string;
+}
+
+export interface OutputGuardrailTrip {
+  guardrail: string;
+  reason?: string;
+}
+
+/**
+ * Run output-stage guardrails for `scanText`. Returns the trip outcome
+ * (already audited via `recordGuardrailTrip`) on block, or `null` when safe to
+ * send. Returns `null` (pass) when guardrails aren't wired, the text is empty,
+ * no agent is resolved, the agent has no output guardrails, or the runner
+ * throws — guardrails fail open.
+ */
+export async function runOutputGuardrailScan(
+  registry: GuardrailRegistry | undefined,
+  settingsStore: AgentSettingsStore | undefined,
+  scanText: string,
+  ctx: OutputScanContext
+): Promise<OutputGuardrailTrip | null> {
+  if (!registry || !settingsStore) return null;
+  if (!scanText) return null;
+  if (!ctx.agentId) return null;
+
+  try {
+    const settings = await settingsStore.getSettings(ctx.agentId);
+    const resolved = resolveAgentGuardrails(
+      settings ?? { guardrails: [] },
+      (settings?.skillsConfig?.skills ?? []).filter((s) => s.enabled),
+      registry
+    );
+    const list = resolved.byStage.output;
+    if (list.length === 0) return null;
+
+    const outcome = await runGuardrailInstances("output", list, {
+      agentId: ctx.agentId,
+      userId: ctx.userId,
+      text: scanText,
+      platform: ctx.platform,
+      conversationId: ctx.conversationId,
+    });
+    if (!outcome.tripped) return null;
+
+    // Fire-and-forget — the block decision must not wait on the audit write.
+    void recordGuardrailTrip({
+      organizationId: ctx.organizationId,
+      agentId: ctx.agentId,
+      userId: ctx.userId,
+      conversationId: ctx.conversationId,
+      stage: "output",
+      guardrail: outcome.tripped.guardrail,
+      reason: outcome.tripped.reason,
+      metadata: outcome.tripped.metadata,
+    });
+    return {
+      guardrail: outcome.tripped.guardrail,
+      reason: outcome.tripped.reason,
+    };
+  } catch (err) {
+    logger.warn(
+      { err: err instanceof Error ? err.message : String(err) },
+      "Output guardrail check failed — proceeding without guardrails"
+    );
+    return null;
+  }
+}
+
+/**
+ * Stateful output-guardrail scanner for renderers that lack their own stream
+ * state (the API/SSE path). Owns the per-session rolling tail and a blocked-set
+ * so once a stream trips, subsequent deltas on this pod are suppressed. The
+ * authoritative enforcement is the terminal `scanFinal` on the worker's full
+ * `finalText` (owner-gated, replica-safe); per-delta scanning is best-effort
+ * defense-in-depth (deltas aren't owner-gated under N>1, so a delta claimed on
+ * another pod is lost anyway — the terminal scan re-checks the full text).
+ */
+export class OutputGuardrailScanner {
+  private registry?: GuardrailRegistry;
+  private settingsStore?: AgentSettingsStore;
+  private tails = new Map<string, string>();
+  private blocked = new Set<string>();
+
+  setGuardrails(
+    registry?: GuardrailRegistry,
+    settingsStore?: AgentSettingsStore
+  ): void {
+    this.registry = registry;
+    this.settingsStore = settingsStore;
+  }
+
+  get enabled(): boolean {
+    return !!(this.registry && this.settingsStore);
+  }
+
+  isBlocked(key: string): boolean {
+    return this.blocked.has(key);
+  }
+
+  /**
+   * Scan a streaming delta using `tail + delta`. On a trip, marks the session
+   * blocked and clears the tail. Returns the trip (already audited) or `null`.
+   */
+  async scanDelta(
+    key: string,
+    delta: string,
+    ctx: OutputScanContext
+  ): Promise<OutputGuardrailTrip | null> {
+    if (!this.enabled || !delta) return null;
+    const combined = (this.tails.get(key) ?? "") + delta;
+    const window =
+      combined.length > OUTPUT_GUARDRAIL_SCAN_WINDOW
+        ? combined.slice(-OUTPUT_GUARDRAIL_SCAN_WINDOW)
+        : combined;
+    this.tails.set(key, window);
+
+    const trip = await runOutputGuardrailScan(
+      this.registry,
+      this.settingsStore,
+      window,
+      ctx
+    );
+    if (trip) {
+      this.blocked.add(key);
+      this.tails.delete(key);
+    }
+    return trip;
+  }
+
+  /**
+   * Scan the authoritative final text at terminal time. Returns the trip
+   * (already audited) or `null`. Does not need prior delta state — it scans the
+   * full text, so it blocks correctly even when delta rows landed on other
+   * replicas.
+   */
+  async scanFinal(
+    key: string,
+    text: string,
+    ctx: OutputScanContext
+  ): Promise<OutputGuardrailTrip | null> {
+    if (!this.enabled) return null;
+    const trip = await runOutputGuardrailScan(
+      this.registry,
+      this.settingsStore,
+      text,
+      ctx
+    );
+    if (trip) this.blocked.add(key);
+    return trip;
+  }
+
+  /** Release per-session state once a stream reaches its terminal row. */
+  clear(key: string): void {
+    this.tails.delete(key);
+    this.blocked.delete(key);
+  }
+}

--- a/packages/server/src/gateway/guardrails/output-scan.ts
+++ b/packages/server/src/gateway/guardrails/output-scan.ts
@@ -108,19 +108,23 @@ export async function runOutputGuardrailScan(
 }
 
 /**
- * Stateful output-guardrail scanner for renderers that lack their own stream
- * state (the API/SSE path). Owns the per-session rolling tail and a blocked-set
- * so once a stream trips, subsequent deltas on this pod are suppressed. The
- * authoritative enforcement is the terminal `scanFinal` on the worker's full
- * `finalText` (owner-gated, replica-safe); per-delta scanning is best-effort
- * defense-in-depth (deltas aren't owner-gated under N>1, so a delta claimed on
- * another pod is lost anyway — the terminal scan re-checks the full text).
+ * Output-guardrail scanner for renderers that lack their own stream state (the
+ * API/SSE path). Enforcement is the terminal `scanFinal` on the worker's full,
+ * authoritative `finalText` — owner-gated, so it runs on the SSE-owning pod and
+ * is replica-safe regardless of how delta rows scattered.
+ *
+ * Per-delta scanning is deliberately NOT done here: deltas are not owner-gated
+ * under N>1, so a secret split across deltas claimed on different pods would
+ * trip no per-pod scan and could reach a streaming client before the terminal
+ * scan. Instead, `hasOutputGuardrails` lets the consumer WITHHOLD streaming
+ * deltas entirely for an agent that configured output guardrails and deliver
+ * only the scanned `finalText` at completion — a hard guarantee that no
+ * unscanned token reaches the client, at the cost of token-by-token streaming
+ * for those agents. Agents without output guardrails stream unaffected.
  */
 export class OutputGuardrailScanner {
   private registry?: GuardrailRegistry;
   private settingsStore?: AgentSettingsStore;
-  private tails = new Map<string, string>();
-  private blocked = new Set<string>();
 
   setGuardrails(
     registry?: GuardrailRegistry,
@@ -134,65 +138,38 @@ export class OutputGuardrailScanner {
     return !!(this.registry && this.settingsStore);
   }
 
-  isBlocked(key: string): boolean {
-    return this.blocked.has(key);
-  }
-
   /**
-   * Scan a streaming delta using `tail + delta`. On a trip, marks the session
-   * blocked and clears the tail. Returns the trip (already audited) or `null`.
+   * Whether `agentId` has ANY output-stage guardrail configured. When true the
+   * consumer withholds streaming deltas and delivers only the scanned
+   * `finalText`. Fails open (returns false) on a lookup error — consistent with
+   * guardrails never blocking on infra failure. Resolution rides the
+   * AgentSettingsStore's own memoization (the chat bridge resolves per-delta the
+   * same way), so no extra cache is kept here (avoids config-edit staleness).
    */
-  async scanDelta(
-    key: string,
-    delta: string,
-    ctx: OutputScanContext
-  ): Promise<OutputGuardrailTrip | null> {
-    if (!this.enabled || !delta) return null;
-    const combined = (this.tails.get(key) ?? "") + delta;
-    const window =
-      combined.length > OUTPUT_GUARDRAIL_SCAN_WINDOW
-        ? combined.slice(-OUTPUT_GUARDRAIL_SCAN_WINDOW)
-        : combined;
-    this.tails.set(key, window);
-
-    const trip = await runOutputGuardrailScan(
-      this.registry,
-      this.settingsStore,
-      window,
-      ctx
-    );
-    if (trip) {
-      this.blocked.add(key);
-      this.tails.delete(key);
+  async hasOutputGuardrails(agentId: string): Promise<boolean> {
+    if (!this.enabled || !agentId) return false;
+    try {
+      const settings = await this.settingsStore!.getSettings(agentId);
+      const resolved = resolveAgentGuardrails(
+        settings ?? { guardrails: [] },
+        (settings?.skillsConfig?.skills ?? []).filter((s) => s.enabled),
+        this.registry!
+      );
+      return resolved.byStage.output.length > 0;
+    } catch {
+      return false;
     }
-    return trip;
   }
 
   /**
    * Scan the authoritative final text at terminal time. Returns the trip
-   * (already audited) or `null`. Does not need prior delta state — it scans the
-   * full text, so it blocks correctly even when delta rows landed on other
-   * replicas.
+   * (already audited) or `null`. Scans the full text, so it blocks correctly
+   * even when delta rows landed on other replicas.
    */
   async scanFinal(
-    key: string,
     text: string,
     ctx: OutputScanContext
   ): Promise<OutputGuardrailTrip | null> {
-    if (!this.enabled) return null;
-    const trip = await runOutputGuardrailScan(
-      this.registry,
-      this.settingsStore,
-      text,
-      ctx
-    );
-    if (trip) this.blocked.add(key);
-    return trip;
-  }
-
-  /** Release per-session state once a stream reaches its terminal row. */
-  clear(key: string): void {
-    this.tails.delete(key);
-    this.blocked.delete(key);
+    return runOutputGuardrailScan(this.registry, this.settingsStore, text, ctx);
   }
 }

--- a/packages/server/src/gateway/platform/unified-thread-consumer.ts
+++ b/packages/server/src/gateway/platform/unified-thread-consumer.ts
@@ -439,50 +439,29 @@ export class UnifiedThreadResponseConsumer {
       const md = readPlatformMetadata(data.platformMetadata);
       const agentId = md.agentId;
       if (agentId) {
-        const gctx = {
-          agentId,
-          organizationId: md.organizationId,
-          userId: data.userId,
-          conversationId: data.conversationId,
-          platform: "api",
-        };
-        // Key the rolling-tail + blocked state per TURN, not per conversation:
-        // a worker's deltas and its terminal row share `originalMessageId`, but a
-        // conversation hosts many turns. Keying on conversationId would let one
-        // turn's leftover tail (`…sk-a`) fuse with the next turn's first delta
-        // (`bcdef…`) into a phantom match, or let one turn's terminal clear()
-        // wipe a concurrent turn's blocked flag. originalMessageId scopes both
-        // to a single turn.
-        const guardKey = data.originalMessageId || data.messageId;
-
-        // Suppress streaming deltas that carry — or, via the rolling tail,
-        // complete — a secret. Best-effort under N>1: deltas aren't owner-gated,
-        // so a delta claimed on another replica is lost regardless; the terminal
-        // scan below re-checks the full finalText on the owning pod.
+        // Withhold streaming deltas for agents that configured output
+        // guardrails. Deltas are NOT owner-gated under N>1, so a secret split
+        // across deltas claimed on different pods would trip no per-pod scan and
+        // could reach a streaming SSE client before the terminal scan. We can't
+        // scan a partial cross-pod stream safely, so we don't stream at all:
+        // the full, scanned `finalText` is delivered on the terminal `complete`
+        // event instead (the SPA renders from it). Agents without output
+        // guardrails stream normally — `hasOutputGuardrails` returns false.
         if (data.delta) {
-          if (this.outputGuardrail.isBlocked(guardKey)) return;
-          const trip = await this.outputGuardrail.scanDelta(
-            guardKey,
-            data.delta,
-            gctx
-          );
-          if (trip) return;
-        }
-
-        // Terminal rows carry the worker's authoritative finalText. Scan it; on
-        // a trip, replace the broadcast text with the block notice so the SPA's
-        // finalText repair (ApiResponseRenderer.handleCompletion) shows the
-        // block instead of the secret. Then release per-session scanner state.
-        const isTerminalRow = !!(
-          data.error || data.processedMessageIds?.length
-        );
-        if (isTerminalRow) {
+          if (await this.outputGuardrail.hasOutputGuardrails(agentId)) return;
+        } else if (data.error || data.processedMessageIds?.length) {
+          // Terminal row: scan the worker's authoritative finalText on this
+          // (owner-gated) pod. On a trip, replace the broadcast text with the
+          // block notice so the secret never reaches the client and never lands
+          // in stored history.
           if (data.finalText) {
-            const trip = await this.outputGuardrail.scanFinal(
-              guardKey,
-              data.finalText,
-              gctx
-            );
+            const trip = await this.outputGuardrail.scanFinal(data.finalText, {
+              agentId,
+              organizationId: md.organizationId,
+              userId: data.userId,
+              conversationId: data.conversationId,
+              platform: "api",
+            });
             if (trip) {
               data = {
                 ...data,
@@ -492,7 +471,6 @@ export class UnifiedThreadResponseConsumer {
               };
             }
           }
-          this.outputGuardrail.clear(guardKey);
         }
       }
     }

--- a/packages/server/src/gateway/platform/unified-thread-consumer.ts
+++ b/packages/server/src/gateway/platform/unified-thread-consumer.ts
@@ -446,9 +446,14 @@ export class UnifiedThreadResponseConsumer {
           conversationId: data.conversationId,
           platform: "api",
         };
-        // SSE sessions key on conversationId (see ApiResponseRenderer); reuse it
-        // so delta rolling-tail + terminal scan share one per-turn key.
-        const guardKey = data.conversationId || data.messageId;
+        // Key the rolling-tail + blocked state per TURN, not per conversation:
+        // a worker's deltas and its terminal row share `originalMessageId`, but a
+        // conversation hosts many turns. Keying on conversationId would let one
+        // turn's leftover tail (`…sk-a`) fuse with the next turn's first delta
+        // (`bcdef…`) into a phantom match, or let one turn's terminal clear()
+        // wipe a concurrent turn's blocked flag. originalMessageId scopes both
+        // to a single turn.
+        const guardKey = data.originalMessageId || data.messageId;
 
         // Suppress streaming deltas that carry — or, via the rolling tail,
         // complete — a secret. Best-effort under N>1: deltas aren't owner-gated,

--- a/packages/server/src/gateway/platform/unified-thread-consumer.ts
+++ b/packages/server/src/gateway/platform/unified-thread-consumer.ts
@@ -4,8 +4,11 @@
  * via the PlatformRegistry, eliminating duplicate queue filtering logic.
  */
 
-import { createChildSpan, createLogger } from "@lobu/core";
+import { createChildSpan, createLogger, type GuardrailRegistry } from "@lobu/core";
+import type { AgentSettingsStore } from "../auth/settings/agent-settings-store.js";
 import type { ChatResponseBridge } from "../connections/chat-response-bridge.js";
+import { readPlatformMetadata } from "../connections/platform-metadata.js";
+import { OutputGuardrailScanner } from "../guardrails/output-scan.js";
 import type {
   IMessageQueue,
   QueueJob,
@@ -76,6 +79,14 @@ export class UnifiedThreadResponseConsumer {
   private chatResponseBridge?: ChatResponseBridge;
   private interactionService?: InteractionService;
   private chatInteractionFanoutCleanup?: () => void;
+  /**
+   * Output-stage guardrails for the API/SSE path. The ChatResponseBridge runs
+   * output guardrails for chat platforms, but pure API/SSE rows (web SPA +
+   * programmatic Agent API) route through ApiResponseRenderer, which has no
+   * guardrail hook — so without this, secret-scan/pii-scan configured via
+   * `defineAgent` never run on the API surface (the primary web chat surface).
+   */
+  private readonly outputGuardrail = new OutputGuardrailScanner();
 
   constructor(
     private queue: IMessageQueue,
@@ -85,6 +96,18 @@ export class UnifiedThreadResponseConsumer {
 
   setChatResponseBridge(bridge: ChatResponseBridge): void {
     this.chatResponseBridge = bridge;
+  }
+
+  /**
+   * Wire output-stage guardrails for the API/SSE path. Both args must be set
+   * for guardrails to run; with neither, the API path behaves as before. Chat
+   * rows are unaffected — the ChatResponseBridge owns their output scanning.
+   */
+  setOutputGuardrails(
+    registry?: GuardrailRegistry,
+    settingsStore?: AgentSettingsStore
+  ): void {
+    this.outputGuardrail.setGuardrails(registry, settingsStore);
   }
 
   /**
@@ -404,6 +427,68 @@ export class UnifiedThreadResponseConsumer {
         throw new Error(
           `API SSE session ${sseKey} not owned by this gateway instance; re-queueing for owner delivery`
         );
+      }
+    }
+
+    // Output-stage guardrails for the API/SSE path (see `outputGuardrail`).
+    // Scoped to API rows — chat rows route through ChatResponseBridge, which
+    // owns their output scanning, so scanning them here would double-enforce.
+    // Runs on the owning pod (terminal rows are owner-gated above), so the
+    // authoritative finalText scan is replica-safe.
+    if (isApiRow && this.outputGuardrail.enabled) {
+      const md = readPlatformMetadata(data.platformMetadata);
+      const agentId = md.agentId;
+      if (agentId) {
+        const gctx = {
+          agentId,
+          organizationId: md.organizationId,
+          userId: data.userId,
+          conversationId: data.conversationId,
+          platform: "api",
+        };
+        // SSE sessions key on conversationId (see ApiResponseRenderer); reuse it
+        // so delta rolling-tail + terminal scan share one per-turn key.
+        const guardKey = data.conversationId || data.messageId;
+
+        // Suppress streaming deltas that carry — or, via the rolling tail,
+        // complete — a secret. Best-effort under N>1: deltas aren't owner-gated,
+        // so a delta claimed on another replica is lost regardless; the terminal
+        // scan below re-checks the full finalText on the owning pod.
+        if (data.delta) {
+          if (this.outputGuardrail.isBlocked(guardKey)) return;
+          const trip = await this.outputGuardrail.scanDelta(
+            guardKey,
+            data.delta,
+            gctx
+          );
+          if (trip) return;
+        }
+
+        // Terminal rows carry the worker's authoritative finalText. Scan it; on
+        // a trip, replace the broadcast text with the block notice so the SPA's
+        // finalText repair (ApiResponseRenderer.handleCompletion) shows the
+        // block instead of the secret. Then release per-session scanner state.
+        const isTerminalRow = !!(
+          data.error || data.processedMessageIds?.length
+        );
+        if (isTerminalRow) {
+          if (data.finalText) {
+            const trip = await this.outputGuardrail.scanFinal(
+              guardKey,
+              data.finalText,
+              gctx
+            );
+            if (trip) {
+              data = {
+                ...data,
+                finalText: `Message blocked by guardrail: ${
+                  trip.reason ?? trip.guardrail
+                }`,
+              };
+            }
+          }
+          this.outputGuardrail.clear(guardKey);
+        }
       }
     }
 

--- a/packages/server/src/gateway/routes/public/agent.ts
+++ b/packages/server/src/gateway/routes/public/agent.ts
@@ -1360,6 +1360,12 @@ export function createAgentApi(config: AgentApiConfig): OpenAPIHono {
         messageText: messageContent,
         platformMetadata: {
           agentId: realAgentId,
+          // Echoed back on every response row (gateway-integration carries
+          // platformMetadata) so the API/SSE output-guardrail scan can attribute
+          // a trip to the right org (the audit `events` row is org-scoped).
+          ...(session.organizationId
+            ? { organizationId: session.organizationId }
+            : {}),
           source: session.intent?.kind === "watcher_run" ? "watcher-run" : "direct-api",
           traceparent: traceparent || undefined,
           dryRun: session.dryRun || false,


### PR DESCRIPTION
## Bug (deep bug-hunt finding #1, high · adversarially verified at 93%)

Output-stage guardrails (`secret-scan`, `pii-scan`) were wired **only** into `ChatResponseBridge`. Pure API/SSE rows — the web SPA and programmatic Agent API, which route through `ApiResponseRenderer` — had **zero** guardrail invocations. So an agent that leaked an API key / JWT / PII was blocked over Slack/Telegram but the identical reply streamed **uninspected** to the web UI and API caller (the primary surface), and **no `guardrail-trip` event** was written, leaving operators blind.

## Fix

- Extract the output-guardrail run + audit into a shared helper `gateway/guardrails/output-scan.ts` (`runOutputGuardrailScan` + a stateful `OutputGuardrailScanner`), used by **both** `ChatResponseBridge` (refactored to delegate — no behaviour change) and the consumer.
- Wire the scanner into `UnifiedThreadResponseConsumer`, scoped to **API rows only** (chat rows keep using the bridge, no double-enforcement):
  - **Deltas:** suppress a leaking delta (best-effort under N>1 — deltas aren't owner-gated).
  - **Terminal:** scan the worker's authoritative `finalText` on the **owner-gated** pod (replica-safe) and, on a trip, replace it with the block notice so the SPA's `finalText` repair shows the block instead of the secret.
- Carry `organizationId` on the API dispatch `platformMetadata` so the trip audit (`events` row is org-scoped) attributes the right org.

Fails open like all guardrails.

## Multi-replica

The reliable enforcement point is the terminal `finalText` scan, which runs on the SSE-owning pod (terminal API rows are already owner-gated in `routeToRenderer`). Delta suppression is best-effort/pod-local and documented as such — consistent with the existing "deltas are best-effort under N>1" invariant.

## E2E — red→green reproducer (`guardrails-runtime.test.ts`, "API path")

Drives the real `UnifiedThreadResponseConsumer` + real `ApiResponseRenderer` over an API row with `secret-scan` enabled:

- **RED** (enforcement disabled): `expected 'your key is sk-abcdefghij0123456789AB…' to contain 'Message blocked by guardrail'` — secret broadcast to SSE; delta produced an `output` event.
- **GREEN** (fix): terminal `complete` broadcasts the block message (no secret), the leaking delta is suppressed (no `output` event), a `guardrail-trip` event is written, and a clean reply passes through unchanged. Full file: **11 passed**.

Server `tsc --noEmit`: 0 errors.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1326"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784230747&installation_id=136316292&pr_number=1326&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1326&signature=26c7c566da363a8f58e47d2e8ac38b072a502f2ea989ccf177cc3611e5dd0194"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Output content safeguards now expanded to API responses, blocking sensitive content in streaming deltas and final message text with a notice to users.

* **Tests**
  * Added comprehensive test coverage for guardrail enforcement across API/SSE delivery paths, including content-blocking and audit logging scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->