### PR TITLE
refactor: cross-cutting simplification & de-duplication sweep

### DIFF
--- a/packages/agent-worker/src/embedded/mcp-cli-commands.ts
+++ b/packages/agent-worker/src/embedded/mcp-cli-commands.ts
@@ -19,6 +19,7 @@ import type { GatewayParams } from "../shared/tool-implementations";
 import {
   callMcpTool,
   checkMcpLogin,
+  joinTextContent,
   logoutMcp,
   startMcpLogin,
 } from "../shared/tool-implementations";
@@ -236,10 +237,7 @@ export function buildMcpServerHandler(
 
     try {
       const result = await deps.callTool(gw, mcpId, subcommand, parsed.payload);
-      const text = result.content
-        .filter((c) => c.type === "text")
-        .map((c) => c.text)
-        .join("\n");
+      const text = joinTextContent(result.content);
       return { stdout: text ? `${text}\n` : "", stderr: "", exitCode: 0 };
     } catch (err) {
       return {
@@ -277,7 +275,7 @@ async function runAuthSubcommand(
 
   if (verb === "login") {
     const res = await startMcpLogin(gw, { mcpId });
-    const text = extractText(res.content);
+    const text = joinTextContent(res.content);
     return {
       stdout: `${summariseAuthStart(text, mcpId)}\n`,
       stderr: "",
@@ -287,7 +285,7 @@ async function runAuthSubcommand(
 
   if (verb === "check") {
     const res = await checkMcpLogin(gw, { mcpId });
-    const text = extractText(res.content);
+    const text = joinTextContent(res.content);
     const parsed = tryJson(text);
     if (parsed?.authenticated === true) {
       await refreshRef(ref, mcpId, "check");
@@ -301,7 +299,7 @@ async function runAuthSubcommand(
 
   if (verb === "logout") {
     const res = await logoutMcp(gw, { mcpId });
-    const text = extractText(res.content);
+    const text = joinTextContent(res.content);
     // Tools that required auth are now unreachable — refresh so the next
     // invocation sees the empty state.
     await refreshRef(ref, mcpId, "logout");
@@ -313,16 +311,6 @@ async function runAuthSubcommand(
     stderr: `unknown auth subcommand: ${verb ?? "(none)"}. Use login|check|logout.\n`,
     exitCode: 2,
   };
-}
-
-function extractText(content: Array<{ type: string; text?: string }>): string {
-  return content
-    .filter(
-      (c): c is { type: "text"; text: string } =>
-        c.type === "text" && typeof c.text === "string"
-    )
-    .map((c) => c.text)
-    .join("\n");
 }
 
 export function summariseAuthStart(rawText: string, mcpId: string): string {

--- a/packages/agent-worker/src/openclaw/session-runner.ts
+++ b/packages/agent-worker/src/openclaw/session-runner.ts
@@ -1022,6 +1022,33 @@ Use it when the user references past discussions or you need context.`);
     messageProvider: platform,
   };
 
+  // Fire the plugin `agent_end` hook with the live session messages. No-op
+  // when the session never came up (the catch path before construction). An
+  // `error` makes it a failure; its absence makes it a success.
+  const emitAgentEnd = async (error?: string): Promise<void> => {
+    if (!session) return;
+    await runPluginHooks({
+      plugins: loadedPlugins,
+      hook: "agent_end",
+      event: {
+        success: error === undefined,
+        ...(error !== undefined ? { error } : {}),
+        messages: session.messages as unknown as Record<string, unknown>[],
+      },
+      ctx: pluginHookContext,
+    });
+  };
+
+  // The single `SessionExecutionResult` shape every exit path returns. An
+  // `error` flips success off and sets exitCode 1.
+  const buildResult = (error?: string): SessionExecutionResult => ({
+    success: error === undefined,
+    exitCode: error === undefined ? 0 : 1,
+    output: "",
+    ...(error !== undefined ? { error } : {}),
+    sessionKey,
+  });
+
   try {
     const createdSession = await buildAgentSession({
       cwd: workspaceDir,
@@ -1360,12 +1387,7 @@ Use it when the user references past discussions or you need context.`);
       if (deltaTimer) clearTimeout(deltaTimer);
       await stopPluginServices(loadedPlugins);
 
-      return {
-        success: true,
-        exitCode: 0,
-        output: "",
-        sessionKey,
-      };
+      return buildResult();
     }
 
     // Consume any pending config change notifications from SSE events.
@@ -1425,39 +1447,16 @@ Use it when the user references past discussions or you need context.`);
 
     const sessionError = progressProcessor.consumeFatalErrorMessage();
     if (sessionError) {
-      await runPluginHooks({
-        plugins: loadedPlugins,
-        hook: "agent_end",
-        event: {
-          success: false,
-          error: sessionError,
-          messages: session.messages as unknown as Record<string, unknown>[],
-        },
-        ctx: pluginHookContext,
-      });
+      await emitAgentEnd(sessionError);
       const errorWithHint = maybeBuildAuthHintMessage(
         sessionError,
         rawProvider,
         modelId
       );
-      return {
-        success: false,
-        exitCode: 1,
-        output: "",
-        error: errorWithHint,
-        sessionKey,
-      };
+      return buildResult(errorWithHint);
     }
 
-    await runPluginHooks({
-      plugins: loadedPlugins,
-      hook: "agent_end",
-      event: {
-        success: true,
-        messages: session.messages as unknown as Record<string, unknown>[],
-      },
-      ctx: pluginHookContext,
-    });
+    await emitAgentEnd();
 
     // Hand the fully-streamed assistant output to the progress processor so
     // the success path's checkSandboxLeak() (worker.execute) actually runs
@@ -1468,39 +1467,17 @@ Use it when the user references past discussions or you need context.`);
       isFinal: true,
     });
 
-    return {
-      success: true,
-      exitCode: 0,
-      output: "",
-      sessionKey,
-    };
+    return buildResult();
   } catch (error) {
     const errorMsg = error instanceof Error ? error.message : String(error);
-    if (session) {
-      await runPluginHooks({
-        plugins: loadedPlugins,
-        hook: "agent_end",
-        event: {
-          success: false,
-          error: errorMsg,
-          messages: session.messages as unknown as Record<string, unknown>[],
-        },
-        ctx: pluginHookContext,
-      });
-    }
+    await emitAgentEnd(errorMsg);
     const errorWithHint = maybeBuildAuthHintMessage(
       errorMsg,
       provider,
       modelId
     );
 
-    return {
-      success: false,
-      exitCode: 1,
-      output: "",
-      error: errorWithHint,
-      sessionKey,
-    };
+    return buildResult(errorWithHint);
   } finally {
     if (heartbeatTimer) {
       clearInterval(heartbeatTimer);

--- a/packages/agent-worker/src/shared/tool-implementations.ts
+++ b/packages/agent-worker/src/shared/tool-implementations.ts
@@ -21,6 +21,24 @@ function textResult(text: string): TextResult {
   return { content: [{ type: "text" as const, text }] };
 }
 
+/**
+ * Join the `text` of every `{ type: "text" }` block in an MCP/tool content
+ * array with newlines. Centralizes the `.filter(...).map(...).join("\n")`
+ * idiom that every caller (link-button errors, MCP tool results, the MCP CLI)
+ * otherwise hand-rolls. Tolerates blocks with a missing `text` field.
+ */
+export function joinTextContent(
+  content: Array<{ type: string; text?: string }> | undefined
+): string {
+  return (content ?? [])
+    .filter(
+      (c): c is { type: "text"; text: string } =>
+        c.type === "text" && typeof c.text === "string"
+    )
+    .map((c) => c.text)
+    .join("\n");
+}
+
 /** TextResult carrying a JSON-encoded payload (MCP auth tool responses). */
 function jsonResult(payload: Record<string, unknown>): TextResult {
   return textResult(JSON.stringify(payload));
@@ -120,10 +138,7 @@ async function postLinkButton(
   );
 
   if (error) {
-    const text = error.content
-      .filter((c) => c.type === "text")
-      .map((c) => c.text)
-      .join("\n");
+    const text = joinTextContent(error.content);
     throw new Error(text || "Failed to post link button");
   }
 }
@@ -202,6 +217,58 @@ async function formDataToBuffer(formData: FormData): Promise<Buffer> {
     formData.on("error", (err: Error) => reject(err));
     formData.resume();
   });
+}
+
+// ============================================================================
+// Utility: multipart upload to /internal/files/upload
+// ============================================================================
+
+/**
+ * POST a pre-built `FormData` to the gateway's file-upload endpoint. Owns the
+ * buffer-serialization, the worker-auth + channel/conversation headers, the
+ * `Content-Length`, the abort budget, and the `TimeoutError` → discriminated
+ * result mapping that both `uploadUserFile` and `uploadGeneratedFile`
+ * otherwise hand-roll. Callers keep their own success/error body handling
+ * (the two endpoints surface different fields), so this returns the raw
+ * `Response` on success and a `timedOut` flag instead of a `TextResult`.
+ *
+ * The `FormData` body is built by the caller (buffer vs. read-stream), so the
+ * streaming behaviour of generated-file uploads is preserved exactly.
+ */
+async function uploadMultipart(
+  gw: GatewayParams,
+  options: {
+    formData: FormData;
+    extraHeaders?: Record<string, string>;
+    timeoutMs?: number;
+  }
+): Promise<{ ok: true; response: Response } | { ok: false; timedOut: true }> {
+  const formDataBuffer = await formDataToBuffer(options.formData);
+  const fdHeaders = options.formData.getHeaders();
+
+  try {
+    const response = await fetch(`${gw.gatewayUrl}/internal/files/upload`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${gw.workerToken}`,
+        "X-Channel-Id": gw.channelId,
+        "X-Conversation-Id": gw.conversationId,
+        ...fdHeaders,
+        "Content-Length": formDataBuffer.length.toString(),
+        ...options.extraHeaders,
+      },
+      body: formDataBuffer,
+      // A stalled gateway upload must not wedge the agent turn forever —
+      // a 5-minute ceiling is well above any legitimate file delivery.
+      signal: AbortSignal.timeout(options.timeoutMs ?? 300_000),
+    });
+    return { ok: true, response };
+  } catch (err) {
+    if (err instanceof Error && err.name === "TimeoutError") {
+      return { ok: false, timedOut: true };
+    }
+    throw err;
+  }
 }
 
 // ============================================================================
@@ -306,33 +373,11 @@ export async function uploadUserFile(
       formData.append("comment", args.description);
     }
 
-    const formDataBuffer = await formDataToBuffer(formData);
-    const fdHeaders = formData.getHeaders();
-
-    let response: Response;
-    try {
-      response = await fetch(`${gw.gatewayUrl}/internal/files/upload`, {
-        method: "POST",
-        headers: {
-          Authorization: `Bearer ${gw.workerToken}`,
-          "X-Channel-Id": gw.channelId,
-          "X-Conversation-Id": gw.conversationId,
-          ...fdHeaders,
-          "Content-Length": formDataBuffer.length.toString(),
-        },
-        body: formDataBuffer,
-        // A stalled gateway upload must not wedge the agent turn forever —
-        // a 5-minute ceiling is well above any legitimate file delivery.
-        signal: AbortSignal.timeout(300_000),
-      });
-    } catch (err) {
-      if (err instanceof Error && err.name === "TimeoutError") {
-        return textResult(
-          `Error: Failed to show file to user: upload timed out`
-        );
-      }
-      throw err;
+    const upload = await uploadMultipart(gw, { formData });
+    if (!upload.ok) {
+      return textResult(`Error: Failed to show file to user: upload timed out`);
     }
+    const response = upload.response;
 
     if (!response.ok) {
       const error = await response.text();
@@ -616,33 +661,13 @@ async function uploadGeneratedFile(
     formData.append("filename", filename);
     formData.append("comment", "Generated content");
 
-    const formDataBuffer = await formDataToBuffer(formData);
-    const fdHeaders = formData.getHeaders();
-
-    let uploadResponse: Response;
-    try {
-      uploadResponse = await fetch(`${gw.gatewayUrl}/internal/files/upload`, {
-        method: "POST",
-        headers: {
-          Authorization: `Bearer ${gw.workerToken}`,
-          "X-Channel-Id": gw.channelId,
-          "X-Conversation-Id": gw.conversationId,
-          ...fdHeaders,
-          "Content-Length": formDataBuffer.length.toString(),
-          ...extraHeaders,
-        },
-        body: formDataBuffer,
-        signal: AbortSignal.timeout(300_000),
-      });
-    } catch (err) {
-      if (err instanceof Error && err.name === "TimeoutError") {
-        return textResult(`Generated content but upload timed out`);
-      }
-      throw err;
+    const upload = await uploadMultipart(gw, { formData, extraHeaders });
+    if (!upload.ok) {
+      return textResult(`Generated content but upload timed out`);
     }
 
-    if (!uploadResponse.ok) {
-      const uploadError = await uploadResponse.text();
+    if (!upload.response.ok) {
+      const uploadError = await upload.response.text();
       return textResult(`Generated content but failed to send: ${uploadError}`);
     }
 
@@ -652,6 +677,108 @@ async function uploadGeneratedFile(
       await fs.unlink(tempPath).catch(() => undefined);
     }
   }
+}
+
+// ============================================================================
+// Shared driver: generate media → upload to the user
+// ============================================================================
+
+/**
+ * Shared skeleton for `generate_image` / `generate_audio`: optional preflight
+ * "is this configured?" check → POST the generate request → map `!ok` into one
+ * of three operator-facing messages (provider-list / missing-scope / generic)
+ * → read the binary body → upload it via `uploadGeneratedFile`. The two public
+ * tools below are thin config objects over this; only the endpoint, preflight,
+ * MIME→ext mapping, scope-substring match, and wording differ.
+ */
+async function generateAndUploadMedia(
+  gw: GatewayParams,
+  config: {
+    label: string;
+    logLine: string;
+    /**
+     * Pre-generation gate. Returns a `notConfigured` message to short-circuit
+     * with, or `null` to proceed. Also exposes the resolved provider list so
+     * the missing-scope branch can reference it.
+     */
+    preflight: () => Promise<{
+      notConfigured: string | null;
+      providerList: string;
+    }>;
+    endpoint: string;
+    requestBody: Record<string, unknown>;
+    /** Substring scan over the lowercased error message → missing-scope path. */
+    missingScopeMatch: (lowerError: string) => boolean;
+    extFromMime: (mimeType: string) => string;
+    defaultMimeType: string;
+    providerHeader: string;
+    uploadFilename: (ext: string) => string;
+    uploadHeaders?: Record<string, string>;
+    messages: {
+      providerListFailure: (errorMessage: string) => string;
+      missingScopeFailure: (providerList: string) => string;
+      genericFailure: (errorMessage: string) => string;
+      success: (provider: string) => string;
+      uploadLog: (provider: string) => string;
+    };
+  }
+): Promise<TextResult> {
+  return withErrorHandling(config.label, async () => {
+    logger.info(config.logLine);
+
+    const { notConfigured, providerList } = await config.preflight();
+    if (notConfigured) {
+      return textResult(notConfigured);
+    }
+
+    const response = await createGatewayClient({
+      baseUrl: gw.gatewayUrl,
+      token: gw.workerToken,
+    }).request(config.endpoint, {
+      method: "POST",
+      body: JSON.stringify(config.requestBody),
+      // Generation can take a while at high quality, but never minutes — cap
+      // the wait so a stalled upstream provider doesn't hang the agent turn.
+      timeoutMs: 120_000,
+    });
+
+    if (!response.ok) {
+      const errorData = (await parseErrorBody(response)) as {
+        error?: string;
+        availableProviders?: string[];
+      };
+      const errorMessage = errorData.error || "Unknown error";
+      const lowerError = errorMessage.toLowerCase();
+
+      if (errorData.availableProviders?.length) {
+        return textResult(config.messages.providerListFailure(errorMessage));
+      }
+
+      if (config.missingScopeMatch(lowerError)) {
+        return textResult(config.messages.missingScopeFailure(providerList));
+      }
+
+      return textResult(config.messages.genericFailure(errorMessage));
+    }
+
+    const buffer = await response.arrayBuffer();
+    const mimeType =
+      response.headers.get("Content-Type") || config.defaultMimeType;
+    const provider = response.headers.get(config.providerHeader) || "unknown";
+    const ext = config.extFromMime(mimeType);
+
+    const uploadError = await uploadGeneratedFile(
+      gw,
+      buffer,
+      config.uploadFilename(ext),
+      mimeType,
+      config.uploadHeaders
+    );
+    if (uploadError) return uploadError;
+
+    logger.info(config.messages.uploadLog(provider));
+    return textResult(config.messages.success(provider));
+  });
 }
 
 // ============================================================================
@@ -674,93 +801,59 @@ export async function generateImage(
     format?: "png" | "jpeg" | "webp";
   }
 ): Promise<TextResult> {
-  return withErrorHandling("generate_image", async () => {
-    logger.info(`generate_image: ${args.prompt.substring(0, 80)}...`);
+  return generateAndUploadMedia(gw, {
+    label: "generate_image",
+    logLine: `generate_image: ${args.prompt.substring(0, 80)}...`,
+    preflight: async () => {
+      const capResponse = await createGatewayClient({
+        baseUrl: gw.gatewayUrl,
+        token: gw.workerToken,
+      }).request("/internal/images/capabilities", { timeoutMs: 30_000 });
 
-    const capResponse = await fetch(
-      `${gw.gatewayUrl}/internal/images/capabilities`,
-      {
-        headers: { Authorization: `Bearer ${gw.workerToken}` },
-        signal: AbortSignal.timeout(30_000),
+      if (capResponse.ok) {
+        const capabilities = (await capResponse.json()) as {
+          available: boolean;
+          providers?: Array<{ provider: string; name: string }>;
+        };
+        if (!capabilities.available) {
+          const providerList =
+            capabilities.providers?.map((p) => p.name).join(", ") || "OpenAI";
+          return {
+            notConfigured: `Image generation is not configured. Supported providers: ${providerList}.\n\nAsk an admin to connect one of these providers for the base agent.`,
+            providerList,
+          };
+        }
       }
-    );
-
-    if (capResponse.ok) {
-      const capabilities = (await capResponse.json()) as {
-        available: boolean;
-        providers?: Array<{ provider: string; name: string }>;
-      };
-      if (!capabilities.available) {
-        const providerList =
-          capabilities.providers?.map((p) => p.name).join(", ") || "OpenAI";
-        return textResult(
-          `Image generation is not configured. Supported providers: ${providerList}.\n\nAsk an admin to connect one of these providers for the base agent.`
-        );
-      }
-    }
-
-    const response = await fetch(`${gw.gatewayUrl}/internal/images/generate`, {
-      method: "POST",
-      headers: {
-        Authorization: `Bearer ${gw.workerToken}`,
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({
-        prompt: args.prompt,
-        size: args.size,
-        quality: args.quality,
-        background: args.background,
-        format: args.format,
-      }),
-      // Image gen can take a while at high quality, but never minutes — cap
-      // the wait so a stalled upstream provider doesn't hang the agent turn.
-      signal: AbortSignal.timeout(120_000),
-    });
-
-    if (!response.ok) {
-      const errorData = (await parseErrorBody(response)) as {
-        error?: string;
-        availableProviders?: string[];
-      };
-      const errorMessage = errorData.error || "Unknown error";
-      const lowerError = errorMessage.toLowerCase();
-      const missingImagePermission =
-        lowerError.includes("missing scopes") ||
-        lowerError.includes("missing_scope") ||
-        (lowerError.includes("scope") &&
-          (lowerError.includes("image") ||
-            lowerError.includes("model.request")));
-
-      if (errorData.availableProviders?.length) {
-        return textResult(
-          `Image generation failed: ${errorMessage}.\n\nAsk an admin to connect one of the supported providers for the base agent.`
-        );
-      }
-
-      if (missingImagePermission) {
-        return textResult(
-          `Image generation failed because the current credential lacks required image permissions.\n\nAsk an admin to connect a provider with image generation access for the base agent.`
-        );
-      }
-
-      return textResult(`Error generating image: ${errorMessage}`);
-    }
-
-    const imageBuffer = await response.arrayBuffer();
-    const mimeType = response.headers.get("Content-Type") || "image/png";
-    const provider = response.headers.get("X-Image-Provider") || "unknown";
-    const ext = imageExtFromMime(mimeType);
-
-    const uploadError = await uploadGeneratedFile(
-      gw,
-      imageBuffer,
-      `generated_image.${ext}`,
-      mimeType
-    );
-    if (uploadError) return uploadError;
-
-    logger.info(`Image generated and sent using ${provider}`);
-    return textResult(`Image sent successfully (generated with ${provider}).`);
+      return { notConfigured: null, providerList: "OpenAI" };
+    },
+    endpoint: "/internal/images/generate",
+    requestBody: {
+      prompt: args.prompt,
+      size: args.size,
+      quality: args.quality,
+      background: args.background,
+      format: args.format,
+    },
+    missingScopeMatch: (lowerError) =>
+      lowerError.includes("missing scopes") ||
+      lowerError.includes("missing_scope") ||
+      (lowerError.includes("scope") &&
+        (lowerError.includes("image") || lowerError.includes("model.request"))),
+    extFromMime: imageExtFromMime,
+    defaultMimeType: "image/png",
+    providerHeader: "X-Image-Provider",
+    uploadFilename: (ext) => `generated_image.${ext}`,
+    messages: {
+      providerListFailure: (errorMessage) =>
+        `Image generation failed: ${errorMessage}.\n\nAsk an admin to connect one of the supported providers for the base agent.`,
+      missingScopeFailure: () =>
+        `Image generation failed because the current credential lacks required image permissions.\n\nAsk an admin to connect a provider with image generation access for the base agent.`,
+      genericFailure: (errorMessage) =>
+        `Error generating image: ${errorMessage}`,
+      success: (provider) =>
+        `Image sent successfully (generated with ${provider}).`,
+      uploadLog: (provider) => `Image generated and sent using ${provider}`,
+    },
   });
 }
 
@@ -778,81 +871,51 @@ export async function generateAudio(
   gw: GatewayParams,
   args: { text: string; voice?: string; speed?: number }
 ): Promise<TextResult> {
-  return withErrorHandling("generate_audio", async () => {
-    logger.info(`generate_audio: ${args.text.substring(0, 50)}...`);
+  return generateAndUploadMedia(gw, {
+    label: "generate_audio",
+    logLine: `generate_audio: ${args.text.substring(0, 50)}...`,
+    preflight: async () => {
+      const suggestions = await fetchAudioProviderSuggestions({
+        gatewayUrl: gw.gatewayUrl,
+        workerToken: gw.workerToken,
+      });
+      const providerList =
+        suggestions.providerDisplayList || "an audio-capable provider";
 
-    const suggestions = await fetchAudioProviderSuggestions({
-      gatewayUrl: gw.gatewayUrl,
-      workerToken: gw.workerToken,
-    });
-    const providerList =
-      suggestions.providerDisplayList || "an audio-capable provider";
-
-    if (suggestions.available === false) {
-      return textResult(
-        `Audio generation is not configured. To enable it, ask an admin to connect one of the available providers for the base agent: ${providerList}.`
-      );
-    }
-
-    const response = await fetch(`${gw.gatewayUrl}/internal/audio/synthesize`, {
-      method: "POST",
-      headers: {
-        Authorization: `Bearer ${gw.workerToken}`,
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({
-        text: args.text,
-        voice: args.voice,
-        speed: args.speed,
-      }),
-      signal: AbortSignal.timeout(120_000),
-    });
-
-    if (!response.ok) {
-      const errorData = (await parseErrorBody(response)) as {
-        error?: string;
-        availableProviders?: string[];
-      };
-      const errorMessage = errorData.error || "Unknown error";
-      const lowerError = errorMessage.toLowerCase();
-      const missingOpenAiAudioScope =
-        (lowerError.includes("missing scopes") ||
-          lowerError.includes("missing_scope")) &&
-        lowerError.includes("api.model.audio.request");
-
-      if (errorData.availableProviders?.length) {
-        return textResult(
-          `Audio generation failed: ${errorMessage}. No provider configured.\n\nAsk an admin to connect an audio provider for the base agent.`
-        );
+      if (suggestions.available === false) {
+        return {
+          notConfigured: `Audio generation is not configured. To enable it, ask an admin to connect one of the available providers for the base agent: ${providerList}.`,
+          providerList,
+        };
       }
-
-      if (missingOpenAiAudioScope) {
-        return textResult(
-          `Audio generation failed because the current OpenAI token lacks api.model.audio.request.\n\nAsk an admin to connect a provider with audio permission for the base agent, or to connect an alternative audio provider (${providerList}).`
-        );
-      }
-
-      return textResult(`Error generating audio: ${errorMessage}`);
-    }
-
-    const audioBuffer = await response.arrayBuffer();
-    const mimeType = response.headers.get("Content-Type") || "audio/mpeg";
-    const provider = response.headers.get("X-Audio-Provider") || "unknown";
-    const ext = audioExtFromMime(mimeType);
-
-    const uploadError = await uploadGeneratedFile(
-      gw,
-      audioBuffer,
-      `voice_response.${ext}`,
-      mimeType,
-      { "X-Voice-Message": "true" }
-    );
-    if (uploadError) return uploadError;
-
-    logger.info(`Audio generated and sent using ${provider}`);
-    return textResult(
-      `Voice message sent successfully (generated with ${provider}).`
-    );
+      return { notConfigured: null, providerList };
+    },
+    endpoint: "/internal/audio/synthesize",
+    requestBody: {
+      text: args.text,
+      voice: args.voice,
+      speed: args.speed,
+    },
+    missingScopeMatch: (lowerError) =>
+      (lowerError.includes("missing scopes") ||
+        lowerError.includes("missing_scope")) &&
+      lowerError.includes("api.model.audio.request"),
+    extFromMime: audioExtFromMime,
+    defaultMimeType: "audio/mpeg",
+    providerHeader: "X-Audio-Provider",
+    uploadFilename: (ext) => `voice_response.${ext}`,
+    uploadHeaders: { "X-Voice-Message": "true" },
+    messages: {
+      providerListFailure: (errorMessage) =>
+        `Audio generation failed: ${errorMessage}. No provider configured.\n\nAsk an admin to connect an audio provider for the base agent.`,
+      missingScopeFailure: (providerList) =>
+        `Audio generation failed because the current OpenAI token lacks api.model.audio.request.\n\nAsk an admin to connect a provider with audio permission for the base agent, or to connect an alternative audio provider (${providerList}).`,
+      genericFailure: (errorMessage) =>
+        `Error generating audio: ${errorMessage}`,
+      success: (provider) =>
+        `Voice message sent successfully (generated with ${provider}).`,
+      uploadLog: (provider) => `Audio generated and sent using ${provider}`,
+    },
   });
 }
 
@@ -958,27 +1021,22 @@ export async function callMcpTool(
     let response: Response;
     const wantsJson = TOOLS_REQUESTING_JSON_FORMAT.has(toolName);
     try {
-      const headers: Record<string, string> = {
-        Authorization: `Bearer ${gw.workerToken}`,
-        "Content-Type": "application/json",
-      };
       // Retrieval tools (`search_memory`) opt into JSON-encoded results so the
       // worker → SSE `tool_use` event can carry structured `result_summary`
       // (event ids + snippet text) to clients like @lobu/promptfoo-provider for
       // RAG assertions. Other tools keep the formatted-markdown output the
       // agent has been seeing. External MCP servers ignore the header.
-      if (wantsJson) headers["x-mcp-format"] = "json";
-      response = await fetch(
-        `${gw.gatewayUrl}/mcp/${mcpId}/tools/${toolName}`,
-        {
-          method: "POST",
-          headers,
-          body: JSON.stringify(args),
-          // Third-party MCP server on the other side — give it a generous
-          // budget but never wait forever.
-          signal: AbortSignal.timeout(120_000),
-        }
-      );
+      response = await createGatewayClient({
+        baseUrl: gw.gatewayUrl,
+        token: gw.workerToken,
+      }).request(`/mcp/${mcpId}/tools/${toolName}`, {
+        method: "POST",
+        headers: wantsJson ? { "x-mcp-format": "json" } : undefined,
+        body: JSON.stringify(args),
+        // Third-party MCP server on the other side — give it a generous
+        // budget but never wait forever.
+        timeoutMs: 120_000,
+      });
     } catch (err) {
       if (err instanceof Error && err.name === "TimeoutError") {
         return textResult(`Error: MCP tool ${mcpId}/${toolName} timed out`);
@@ -1010,19 +1068,13 @@ export async function callMcpTool(
     }
 
     if (!response.ok || data.isError) {
-      const contentText = data.content
-        ?.filter((c) => c.type === "text")
-        .map((c) => c.text)
-        .join("\n");
+      const contentText = joinTextContent(data.content);
       const errorMsg =
         data.error || contentText || `${toolName} failed (${response.status})`;
       return textResult(`Error: ${errorMsg}`);
     }
 
-    const text = data.content
-      ?.filter((c) => c.type === "text")
-      .map((c) => c.text)
-      .join("\n");
+    const text = joinTextContent(data.content);
     return textResult(text || `${toolName} completed.`);
   });
 }

--- a/packages/cli/src/commands/_lib/agents-view.ts
+++ b/packages/cli/src/commands/_lib/agents-view.ts
@@ -1,0 +1,38 @@
+import { resolveApiClient } from "../../internal/index.js";
+
+/**
+ * Shape returned by `GET /api/<org>/agents`. Superset of the fields the
+ * `status` and `agent list` views render — both commands fetch the same
+ * endpoint, so the type and fetch live here once.
+ */
+export interface AgentSummary {
+  agentId: string;
+  name: string;
+  description?: string;
+  connectionCount?: number;
+  activeConnectionCount?: number;
+  clientCount?: number;
+  status?: string;
+}
+
+export interface FetchedAgents {
+  agents: AgentSummary[];
+  orgSlug: string;
+  apiBaseUrl: string;
+}
+
+/** Resolve the API client + org and fetch the org's agents. */
+export async function fetchAgents(
+  options: { context?: string; org?: string } = {}
+): Promise<FetchedAgents> {
+  const { client, orgSlug, apiBaseUrl } = await resolveApiClient(options);
+  const data = await client.get<{ agents?: AgentSummary[] }>(
+    `/api/${orgSlug}/agents`
+  );
+  return { agents: data.agents ?? [], orgSlug, apiBaseUrl };
+}
+
+/** The `connections:X active:Y clients:Z` counts fragment shared by both views. */
+export function agentCountsText(agent: AgentSummary): string {
+  return `connections:${agent.connectionCount ?? 0} active:${agent.activeConnectionCount ?? 0} clients:${agent.clientCount ?? 0}`;
+}

--- a/packages/cli/src/commands/_lib/apply/client.ts
+++ b/packages/cli/src/commands/_lib/apply/client.ts
@@ -1,10 +1,6 @@
 import type { EntityMetrics } from "@lobu/connector-sdk";
 import type { AgentSettings } from "@lobu/core";
-import {
-  extractApiError,
-  fetchWithRetry,
-  parseJsonResponse,
-} from "../../../internal/http.js";
+import { ApiClient, type HttpMethod } from "../../../internal/api-client.js";
 import { resolveApiClient } from "../../../internal/index.js";
 import { ApiError } from "../../memory/_lib/errors.js";
 import type {
@@ -250,17 +246,6 @@ function hoistEntityTypeSchema(
   return out;
 }
 
-async function parseResponseBody(
-  res: Response,
-  url: string
-): Promise<Record<string, unknown>> {
-  const parsed = await parseJsonResponse(res, url, (message) => {
-    throw new ApiError(message);
-  });
-  if (parsed === undefined) return {};
-  return isRecord(parsed) ? parsed : { value: parsed };
-}
-
 // ── Client ─────────────────────────────────────────────────────────────────
 
 interface ApplyClientConfig {
@@ -277,58 +262,55 @@ interface ApplyClientConfig {
  * unset and pick up `globalThis.fetch`.
  */
 export class ApplyClient {
-  private readonly apiBaseUrl: string;
   private readonly orgSlug: string;
-  private readonly token: string;
-  private readonly fetchImpl: typeof fetch;
+  private readonly http: ApiClient;
 
   constructor(cfg: ApplyClientConfig, fetchImpl: typeof fetch = fetch) {
-    this.apiBaseUrl = cfg.apiBaseUrl;
     this.orgSlug = cfg.orgSlug;
-    this.token = cfg.token;
-    this.fetchImpl = fetchImpl;
+    this.http = new ApiClient(cfg.apiBaseUrl, cfg.token, fetchImpl);
   }
 
-  // ── HTTP shape (mirrors openclaw-cmd.ts:postJson, locally scoped) ────────
-
+  /**
+   * Delegates the fetch/parse/non-ok-error pipeline to the shared
+   * {@link ApiClient}, then layers on the apply-specific shape:
+   *   - the body is coerced to a record (`undefined`→`{}`, non-record→`{value}`)
+   *   - a body-level `error` string is treated as a failure even on a 2xx
+   *
+   * Apply endpoints only ever return the listed `okStatuses` (200/201/204) on
+   * success or a 4xx/5xx on failure, so `ApiClient`'s status gate produces the
+   * same outcome the local pipeline did. `Content-Type: application/json` is
+   * sent on every request (no `Accept`) to mirror the previous wire shape.
+   */
   private async request<T>(
-    method: "GET" | "POST" | "PUT" | "PATCH" | "DELETE",
+    method: HttpMethod,
     path: string,
     body?: unknown,
     okStatuses: number[] = [200, 201, 204]
   ): Promise<{ status: number; body: T }> {
-    const url = `${this.apiBaseUrl}${path}`;
-    const init: RequestInit = {
+    const { status, body: raw } = await this.http.requestWithStatus<unknown>(
       method,
-      headers: {
-        "Content-Type": "application/json",
-        Authorization: `Bearer ${this.token}`,
-      },
-    };
-    if (body !== undefined) init.body = JSON.stringify(body);
-    const res = await fetchWithRetry(url, init, { fetchImpl: this.fetchImpl });
-    const parsed = await parseResponseBody(res, url);
+      path,
+      body,
+      { okStatuses, sendAccept: false, alwaysJsonContentType: true }
+    );
 
-    if (!okStatuses.includes(res.status) && !res.ok) {
-      const { message, code } = extractApiError(
-        parsed,
-        res.status,
-        res.statusText
-      );
-      throw new ApiError(
-        `${method} ${path} failed: ${message}${code ? ` [${code}]` : ""}`,
-        res.status
-      );
+    let parsed: Record<string, unknown>;
+    if (raw === undefined) {
+      parsed = {};
+    } else if (isRecord(raw)) {
+      parsed = raw;
+    } else {
+      parsed = { value: raw };
     }
 
     if (typeof parsed.error === "string" && parsed.error.length > 0) {
       throw new ApiError(
         `${method} ${path} returned error: ${parsed.error}`,
-        res.status
+        status
       );
     }
 
-    return { status: res.status, body: parsed as T };
+    return { status, body: parsed as T };
   }
 
   // ── Organization ──────────────────────────────────────────────────────────

--- a/packages/cli/src/commands/agent.ts
+++ b/packages/cli/src/commands/agent.ts
@@ -9,31 +9,18 @@ import { join } from "node:path";
 import chalk from "chalk";
 import { resolveApiClient } from "../internal/index.js";
 import { printJson } from "../internal/output.js";
+import { agentCountsText, fetchAgents } from "./_lib/agents-view.js";
 
-interface AgentCommandOptions {
+export interface AgentCommandOptions {
   context?: string;
   org?: string;
   json?: boolean;
 }
 
-interface AgentItem {
-  agentId: string;
-  name: string;
-  description?: string;
-  connectionCount?: number;
-  activeConnectionCount?: number;
-  clientCount?: number;
-  status?: string;
-}
-
 export async function agentListCommand(
   options: AgentCommandOptions = {}
 ): Promise<void> {
-  const { client, orgSlug } = await resolveApiClient(options);
-  const data = await client.get<{ agents?: AgentItem[] }>(
-    `/api/${orgSlug}/agents`
-  );
-  const agents = data.agents ?? [];
+  const { agents, orgSlug } = await fetchAgents(options);
 
   if (options.json) {
     printJson(agents);
@@ -51,9 +38,7 @@ export async function agentListCommand(
     const description = agent.description
       ? chalk.dim(` — ${agent.description}`)
       : "";
-    const counts = chalk.dim(
-      `connections:${agent.connectionCount ?? 0} active:${agent.activeConnectionCount ?? 0} clients:${agent.clientCount ?? 0}`
-    );
+    const counts = chalk.dim(agentCountsText(agent));
     console.log(
       `  ${chalk.green("●")} ${chalk.bold(agent.agentId)} ${counts}${status}${description}`
     );

--- a/packages/cli/src/commands/call.ts
+++ b/packages/cli/src/commands/call.ts
@@ -18,7 +18,7 @@
 import { readFile } from "node:fs/promises";
 
 import { printJson } from "../internal/output.js";
-import { ValidationError } from "./memory/_lib/errors.js";
+import { parseJsonObject, ValidationError } from "./memory/_lib/errors.js";
 import { restGet, restToolCall } from "./memory/_lib/mcp.js";
 import {
   getSessionForOrg,
@@ -88,19 +88,7 @@ async function readStdinJson(): Promise<Record<string, unknown> | null> {
   }
   const raw = Buffer.concat(chunks).toString("utf8").trim();
   if (!raw) return null;
-  try {
-    const parsed = JSON.parse(raw);
-    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
-      throw new ValidationError(
-        "stdin JSON must be a top-level object (got array or primitive)."
-      );
-    }
-    return parsed as Record<string, unknown>;
-  } catch (error) {
-    if (error instanceof ValidationError) throw error;
-    const message = error instanceof Error ? error.message : String(error);
-    throw new ValidationError(`Invalid JSON on stdin: ${message}`);
-  }
+  return parseJsonObject(raw, "on stdin");
 }
 
 async function readInputFile(path: string): Promise<Record<string, unknown>> {
@@ -113,19 +101,7 @@ async function readInputFile(path: string): Promise<Record<string, unknown>> {
       `Failed to read --input-file ${path}: ${message}`
     );
   }
-  try {
-    const parsed = JSON.parse(raw);
-    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
-      throw new ValidationError(
-        `--input-file ${path}: JSON must be a top-level object.`
-      );
-    }
-    return parsed as Record<string, unknown>;
-  } catch (error) {
-    if (error instanceof ValidationError) throw error;
-    const message = error instanceof Error ? error.message : String(error);
-    throw new ValidationError(`Invalid JSON in ${path}: ${message}`);
-  }
+  return parseJsonObject(raw, `in ${path}`);
 }
 
 /** Build the args payload from the three mutually-exclusive sources. */

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -10,7 +10,7 @@ import {
 } from "node:fs/promises";
 import { basename, join, resolve } from "node:path";
 import { confirm, input, password, select } from "@inquirer/prompts";
-import { DEFAULT_AGENT_MODEL } from "@lobu/core";
+import { DEFAULT_AGENT_MODEL, slugify } from "@lobu/core";
 import chalk from "chalk";
 import ora from "ora";
 import { promptPlatformConfig } from "../commands/platforms/platform-prompts.js";
@@ -37,7 +37,7 @@ type NetworkChoice = (typeof NETWORK_CHOICES)[number];
 const MEMORY_CHOICES = ["none", "lobu-cloud", "lobu-custom"] as const;
 type MemoryChoice = (typeof MEMORY_CHOICES)[number];
 
-interface InitOptions {
+export interface InitOptions {
   yes?: boolean;
   here?: boolean;
   port?: string;
@@ -871,14 +871,6 @@ function validateProjectName(value: string): string | true {
     return "Project name must be lowercase alphanumeric with hyphens only";
   }
   return true;
-}
-
-function slugify(s: string): string {
-  return s
-    .toLowerCase()
-    .replace(/[^a-z0-9-]+/g, "-")
-    .replace(/-+/g, "-")
-    .replace(/^-|-$/g, "");
 }
 
 interface PromptOrDefaultOptions<T> {

--- a/packages/cli/src/commands/memory/_lib/errors.ts
+++ b/packages/cli/src/commands/memory/_lib/errors.ts
@@ -18,9 +18,35 @@ export class ValidationError extends CliError {
 export class ApiError extends CliError {
   constructor(
     message: string,
-    public status?: number
+    public status?: number,
+    public code?: string
   ) {
     super(message, 3);
     this.name = "ApiError";
   }
+}
+
+/**
+ * Parse `raw` as a JSON object, throwing {@link ValidationError} when it is not
+ * valid JSON or not a top-level object (arrays and primitives are rejected).
+ * `label` names the source for the error messages, e.g. `"on stdin"` or
+ * `` `in ${path}` ``.
+ */
+export function parseJsonObject(
+  raw: string,
+  label: string
+): Record<string, unknown> {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new ValidationError(`Invalid JSON ${label}: ${message}`);
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new ValidationError(
+      `JSON ${label} must be a top-level object (got array or primitive).`
+    );
+  }
+  return parsed as Record<string, unknown>;
 }

--- a/packages/cli/src/commands/memory/_lib/mcp.ts
+++ b/packages/cli/src/commands/memory/_lib/mcp.ts
@@ -1,4 +1,5 @@
 import { MCP_PROTOCOL_VERSION } from "@lobu/core";
+import { extractApiError } from "../../../internal/http.js";
 import { ApiError } from "./errors.js";
 import {
   getUsableToken,
@@ -268,8 +269,11 @@ async function restCall<T>(
     let message = `${res.status} ${res.statusText}`;
     if (raw) {
       try {
-        const body = JSON.parse(raw) as { error?: string };
-        if (body?.error) message = body.error;
+        message = extractApiError(
+          JSON.parse(raw),
+          res.status,
+          res.statusText
+        ).message;
       } catch {
         message = raw;
       }

--- a/packages/cli/src/commands/status.ts
+++ b/packages/cli/src/commands/status.ts
@@ -1,23 +1,10 @@
 import chalk from "chalk";
-import { resolveApiClient } from "../internal/index.js";
-
-interface AgentStatusItem {
-  agentId: string;
-  name: string;
-  connectionCount?: number;
-  activeConnectionCount?: number;
-  clientCount?: number;
-  status?: string;
-}
+import { agentCountsText, fetchAgents } from "./_lib/agents-view.js";
 
 export async function statusCommand(
   options: { context?: string; org?: string } = {}
 ): Promise<void> {
-  const { client, orgSlug, apiBaseUrl } = await resolveApiClient(options);
-  const data = await client.get<{ agents?: AgentStatusItem[] }>(
-    `/api/${orgSlug}/agents`
-  );
-  const agents = data.agents ?? [];
+  const { agents, orgSlug, apiBaseUrl } = await fetchAgents(options);
 
   console.log(chalk.bold("\n  Lobu"));
   console.log(chalk.dim(`  API: ${apiBaseUrl}`));
@@ -35,7 +22,7 @@ export async function statusCommand(
     const icon = active ? chalk.green("●") : chalk.dim("○");
     console.log(
       `  ${icon} ${chalk.bold(agent.name)} ${chalk.dim(`(${agent.agentId})`)}  ${chalk.dim(
-        `connections:${agent.connectionCount ?? 0} active:${agent.activeConnectionCount ?? 0} clients:${agent.clientCount ?? 0}`
+        agentCountsText(agent)
       )}`
     );
   }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -36,6 +36,11 @@ import { fileURLToPath } from "node:url";
 
 import chalk from "chalk";
 import { Command } from "commander";
+// Type-only imports of command option shapes. These are erased at compile time
+// (no runtime module load), so they do NOT defeat the lazy-import hot path —
+// the handler modules are still pulled in only inside each `.action`.
+import type { AgentCommandOptions } from "./commands/agent.js";
+import type { InitOptions } from "./commands/init.js";
 import { GATEWAY_DEFAULT_URL } from "./internal/index.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -173,53 +178,28 @@ Memory:
     .action(
       async (
         name: string | undefined,
-        options: {
-          yes?: boolean;
-          here?: boolean;
-          port?: string;
-          publicUrl?: string;
-          network?: string;
-          provider?: string;
-          providerKey?: string;
-          platform?: string;
-          memory?: string;
-          memoryUrl?: string;
-          otelEndpoint?: string;
+        // Commander's raw shape: `sentry` is a tristate (true=--sentry,
+        // false=--no-sentry, undefined=neither) and `fromOrg` is string|true.
+        // Every other field maps 1:1 onto InitOptions, so we spread and only
+        // normalize those two below.
+        options: Omit<InitOptions, "sentry" | "noSentry" | "fromOrg"> & {
           sentry?: boolean;
-          slackPreview?: boolean;
-          listProviders?: boolean;
-          fromOrg?: string | boolean;
-          url?: string;
+          fromOrg?: string | true;
         }
       ) => {
         const { initCommand } = await import("./commands/init.js");
-        // Commander gives a tristate: true for --sentry, false for
-        // --no-sentry, undefined for neither.
         // `--from-org` with no value is `true`; normalize to "" (active org).
         const fromOrg =
           options.fromOrg === undefined
             ? undefined
             : options.fromOrg === true
               ? ""
-              : (options.fromOrg as string);
+              : options.fromOrg;
         await initCommand(process.cwd(), name, {
-          yes: options.yes,
-          here: options.here,
-          port: options.port,
-          publicUrl: options.publicUrl,
-          network: options.network,
-          provider: options.provider,
-          providerKey: options.providerKey,
-          platform: options.platform,
-          memory: options.memory,
-          memoryUrl: options.memoryUrl,
-          otelEndpoint: options.otelEndpoint,
+          ...options,
           sentry: options.sentry === true,
           noSentry: options.sentry === false,
-          slackPreview: options.slackPreview,
-          listProviders: options.listProviders,
           fromOrg,
-          url: options.url,
         });
       }
     );
@@ -629,21 +609,17 @@ Memory:
   withCommonOpts(agent.command("list").description("List agents"), {
     org: true,
     json: true,
-  }).action(
-    async (options: { context?: string; org?: string; json?: boolean }) => {
-      const { agentListCommand } = await import("./commands/agent.js");
-      await agentListCommand(options);
-    }
-  );
+  }).action(async (options: AgentCommandOptions) => {
+    const { agentListCommand } = await import("./commands/agent.js");
+    await agentListCommand(options);
+  });
 
   withCommonOpts(agent.command("get <agentId>").description("Get an agent"), {
     org: true,
-  }).action(
-    async (agentId: string, options: { context?: string; org?: string }) => {
-      const { agentGetCommand } = await import("./commands/agent.js");
-      await agentGetCommand(agentId, options);
-    }
-  );
+  }).action(async (agentId: string, options: AgentCommandOptions) => {
+    const { agentGetCommand } = await import("./commands/agent.js");
+    await agentGetCommand(agentId, options);
+  });
 
   withCommonOpts(
     agent
@@ -655,13 +631,7 @@ Memory:
   ).action(
     async (
       agentId: string,
-      options: {
-        name?: string;
-        description?: string;
-        context?: string;
-        org?: string;
-        json?: boolean;
-      }
+      options: AgentCommandOptions & { name?: string; description?: string }
     ) => {
       const { agentCreateCommand } = await import("./commands/agent.js");
       await agentCreateCommand(agentId, options);
@@ -695,13 +665,7 @@ Memory:
   ).action(
     async (
       agentId: string,
-      options: {
-        name?: string;
-        description?: string;
-        context?: string;
-        org?: string;
-        json?: boolean;
-      }
+      options: AgentCommandOptions & { name?: string; description?: string }
     ) => {
       const { agentUpdateCommand } = await import("./commands/agent.js");
       await agentUpdateCommand(agentId, options);
@@ -717,7 +681,7 @@ Memory:
   ).action(
     async (
       agentId: string,
-      options: { yes?: boolean; context?: string; org?: string }
+      options: AgentCommandOptions & { yes?: boolean }
     ) => {
       const { agentDeleteCommand } = await import("./commands/agent.js");
       await agentDeleteCommand(agentId, options);
@@ -737,7 +701,7 @@ Memory:
   ).action(
     async (
       agentId: string,
-      options: { output?: string; context?: string; org?: string }
+      options: AgentCommandOptions & { output?: string }
     ) => {
       const { agentConfigGetCommand } = await import("./commands/agent.js");
       await agentConfigGetCommand(agentId, options);
@@ -756,12 +720,7 @@ Memory:
   ).action(
     async (
       agentId: string,
-      options: {
-        file: string;
-        context?: string;
-        org?: string;
-        json?: boolean;
-      }
+      options: AgentCommandOptions & { file: string }
     ) => {
       const { agentConfigPatchCommand } = await import("./commands/agent.js");
       await agentConfigPatchCommand(agentId, options);

--- a/packages/cli/src/internal/api-client.ts
+++ b/packages/cli/src/internal/api-client.ts
@@ -1,3 +1,4 @@
+import { ApiError } from "../commands/memory/_lib/errors.js";
 import {
   findContextByUrl,
   getActiveOrg,
@@ -28,15 +29,18 @@ interface OrganizationInfo {
   name?: string;
 }
 
-class ApiClientError extends Error {
-  constructor(
-    message: string,
-    public readonly status?: number,
-    public readonly code?: string
-  ) {
-    super(message);
-    this.name = "ApiClientError";
-  }
+/** HTTP verbs the CLI's REST clients issue. */
+export type HttpMethod = "GET" | "POST" | "PUT" | "PATCH" | "DELETE";
+
+export interface RequestWithStatusOptions {
+  okStatuses?: number[];
+  /** Send `Accept: application/json` (default). Off matches the apply client. */
+  sendAccept?: boolean;
+  /**
+   * Always send `Content-Type: application/json` even with no body. Default
+   * sends it only when a body is present.
+   */
+  alwaysJsonContentType?: boolean;
 }
 
 export class ApiClient {
@@ -46,28 +50,36 @@ export class ApiClient {
     private readonly fetchImpl: typeof fetch = fetch
   ) {}
 
-  async request<T>(
-    method: "GET" | "POST" | "PUT" | "PATCH" | "DELETE",
+  /**
+   * Single HTTP chokepoint: fetch (with retry) → parse JSON → throw `ApiError`
+   * on a non-ok / non-allowed status. Returns the response status alongside the
+   * parsed body so callers that branch on status (e.g. `lobu apply`'s 404/409
+   * handling) don't reimplement the fetch/parse/error pipeline.
+   */
+  async requestWithStatus<T>(
+    method: HttpMethod,
     path: string,
     body?: unknown,
-    options: { okStatuses?: number[] } = {}
-  ): Promise<T> {
+    options: RequestWithStatusOptions = {}
+  ): Promise<{ status: number; body: T }> {
     const url = path.startsWith("http") ? path : `${this.apiBaseUrl}${path}`;
     const headers: Record<string, string> = {
-      Accept: "application/json",
       Authorization: `Bearer ${this.token}`,
     };
+    if (options.sendAccept !== false) headers.Accept = "application/json";
     const init: RequestInit = { method, headers };
     if (body !== undefined) {
       headers["Content-Type"] = "application/json";
       init.body = JSON.stringify(body);
+    } else if (options.alwaysJsonContentType) {
+      headers["Content-Type"] = "application/json";
     }
 
     const response = await fetchWithRetry(url, init, {
       fetchImpl: this.fetchImpl,
     });
     const parsed = await parseJsonResponse(response, url, (message) => {
-      throw new ApiClientError(message, response.status);
+      throw new ApiError(message, response.status);
     });
     const okStatuses = options.okStatuses ?? [200, 201, 204];
     if (!response.ok || !okStatuses.includes(response.status)) {
@@ -76,13 +88,28 @@ export class ApiClient {
         response.status,
         response.statusText
       );
-      throw new ApiClientError(
+      throw new ApiError(
         `${method} ${path} failed: ${message}`,
         response.status,
         code
       );
     }
-    return parsed as T;
+    return { status: response.status, body: parsed as T };
+  }
+
+  async request<T>(
+    method: HttpMethod,
+    path: string,
+    body?: unknown,
+    options: { okStatuses?: number[] } = {}
+  ): Promise<T> {
+    const { body: parsed } = await this.requestWithStatus<T>(
+      method,
+      path,
+      body,
+      options
+    );
+    return parsed;
   }
 
   get<T>(path: string): Promise<T> {
@@ -112,7 +139,7 @@ export async function resolveApiClient(
   const token = process.env.LOBU_API_TOKEN || (await getToken(target.name));
 
   if (!token) {
-    throw new ApiClientError(
+    throw new ApiError(
       `Not logged in to context "${target.name}". Run \`lobu login${options.context ? ` --context ${target.name}` : ""}\` first.`,
       401
     );
@@ -141,7 +168,7 @@ export async function listOrganizations(
   const target = await resolveApiTarget(options);
   const token = process.env.LOBU_API_TOKEN || (await getToken(target.name));
   if (!token) {
-    throw new ApiClientError(
+    throw new ApiError(
       `Not logged in to context "${target.name}". Run \`lobu login${options.context ? ` --context ${target.name}` : ""}\` first.`,
       401
     );
@@ -175,7 +202,7 @@ async function resolveApiTarget(
   const apiBaseUrl = apiBaseFromContextUrl(options.apiUrl);
   const contextApiBaseUrl = apiBaseFromContextUrl(requested.url);
   if (!process.env.LOBU_API_TOKEN && apiBaseUrl !== contextApiBaseUrl) {
-    throw new ApiClientError(
+    throw new ApiError(
       `Refusing to send stored context credentials for "${requested.name}" to ${apiBaseUrl}. Add a context for that URL or set LOBU_API_TOKEN explicitly.`
     );
   }
@@ -222,12 +249,12 @@ async function resolveOrgSlug(
   }
 
   if (organizations.length > 1) {
-    throw new ApiClientError(
+    throw new ApiError(
       `Multiple organizations are available (${organizations.map((org) => org.slug).join(", ")}). Run \`lobu org set <slug>\` or pass \`--org <slug>\`.`
     );
   }
 
-  throw new ApiClientError(
+  throw new ApiError(
     "No organization selected. Run `lobu org set <slug>` or pass `--org <slug>`."
   );
 }
@@ -277,13 +304,13 @@ async function getOrganizationsFromUserInfo(
 }
 
 /**
- * Wrap the shared {@link validateOrgSlugShared} so the typed `ApiClientError`
+ * Wrap the shared {@link validateOrgSlugShared} so the typed `ApiError`
  * (carrying the same human message) propagates instead of a bare `Error`.
  */
 function validateOrgSlug(slug: string): string {
   try {
     return validateOrgSlugShared(slug);
   } catch (err) {
-    throw new ApiClientError(err instanceof Error ? err.message : String(err));
+    throw new ApiError(err instanceof Error ? err.message : String(err));
   }
 }

--- a/packages/connector-sdk/src/connector-runtime.ts
+++ b/packages/connector-sdk/src/connector-runtime.ts
@@ -125,3 +125,37 @@ export abstract class ConnectorRuntime<C = Record<string, unknown>, F = Record<s
     throw new Error(`${this.definition.key} does not support interactive authentication`);
   }
 }
+
+/**
+ * Base class for device-bound connectors whose real `sync()`/`execute()` run
+ * inside a device bridge (the Owletto Chrome extension or the Lobu Mac/iOS app),
+ * not on the server-side worker fleet. The server only ever holds the connector
+ * DEFINITION; the cloud-side methods exist purely as safety stubs that throw if a
+ * worker without the connector's `requiredCapability` somehow claims the run.
+ *
+ * Subclasses declare only their `definition` and pass the bridge-only message to
+ * `super()`; both `sync()` and `execute()` throw that exact message.
+ *
+ * @example
+ * ```ts
+ * export default class ChromeHistoryConnector extends BridgeOnlyConnector {
+ *   constructor() {
+ *     super('chrome.history runs only on a worker advertising capability "browser.history".');
+ *   }
+ *   readonly definition: ConnectorDefinition = { ... };
+ * }
+ * ```
+ */
+export abstract class BridgeOnlyConnector extends ConnectorRuntime {
+  constructor(private readonly bridgeMessage: string) {
+    super();
+  }
+
+  async sync(): Promise<SyncResult> {
+    throw new Error(this.bridgeMessage);
+  }
+
+  async execute(): Promise<ActionResult> {
+    throw new Error(this.bridgeMessage);
+  }
+}

--- a/packages/connector-sdk/src/http-client.ts
+++ b/packages/connector-sdk/src/http-client.ts
@@ -8,6 +8,7 @@
  * truncated response body.
  */
 
+import type { SyncCredentials } from './connector-types.js';
 import { withHttpRetry } from './retry.js';
 import { sleep } from './sleep.js';
 
@@ -57,6 +58,13 @@ interface HttpClientRetryOptions {
 }
 
 export interface CreateHttpClientOptions {
+  /**
+   * Static bearer token shorthand: sent as `Authorization: Bearer <token>`
+   * (unless the request already sets one). Use this when the token never
+   * changes for the client's lifetime; for refresh/rotation use
+   * `getAccessToken`. Ignored when `getAccessToken` is also set.
+   */
+  token?: string;
   /**
    * Called once per request; a truthy return value is sent as
    * `Authorization: Bearer <token>` (unless the request already sets one).
@@ -111,8 +119,8 @@ export function createHttpClient(options: CreateHttpClientOptions = {}): HttpCli
     new Headers(init?.headers).forEach((value, key) => {
       headers.set(key, value);
     });
-    if (options.getAccessToken && !headers.has('authorization')) {
-      const token = await options.getAccessToken();
+    if (!headers.has('authorization')) {
+      const token = options.getAccessToken ? await options.getAccessToken() : options.token;
       if (token) headers.set('Authorization', `Bearer ${token}`);
     }
     return headers;
@@ -193,4 +201,39 @@ export function createHttpClient(options: CreateHttpClientOptions = {}): HttpCli
   };
 
   return { raw, request, json, get, post };
+}
+
+export interface RequireBearerClientOptions {
+  /** Prefix for error messages, e.g. `'Spotify API'`. Default `'HTTP'`. */
+  errorPrefix?: string;
+  /**
+   * Human-readable connector name for the missing-auth error message
+   * (`'<label> requires OAuth authentication.'`). Defaults to `errorPrefix`.
+   */
+  label?: string;
+  /** Static headers applied to every request (per-request headers win). */
+  headers?: Record<string, string>;
+}
+
+/**
+ * Resolve a connector's OAuth bearer token and build an auth-aware
+ * `HttpClient` for it. Throws if `credentials.accessToken` is missing — the
+ * preamble every OAuth-backed connector hand-rolls. For connectors that fall
+ * back to an app-only token or an API key, keep the custom resolution and call
+ * `createHttpClient({ token })` directly.
+ */
+export function requireBearerClient(
+  credentials: SyncCredentials | null,
+  options: RequireBearerClientOptions = {}
+): HttpClient {
+  const accessToken = credentials?.accessToken;
+  if (!accessToken) {
+    const label = options.label ?? options.errorPrefix ?? 'This connector';
+    throw new Error(`${label} requires OAuth authentication.`);
+  }
+  return createHttpClient({
+    token: accessToken,
+    errorPrefix: options.errorPrefix,
+    headers: options.headers,
+  });
 }

--- a/packages/connector-sdk/src/index.ts
+++ b/packages/connector-sdk/src/index.ts
@@ -9,7 +9,7 @@ export { Type } from '@sinclair/typebox';
 export type { KyInstance, Options } from 'ky';
 export { default as ky, HTTPError } from 'ky';
 // Connector runtime & types (primary API)
-export { ConnectorRuntime } from './connector-runtime.js';
+export { BridgeOnlyConnector, ConnectorRuntime } from './connector-runtime.js';
 export { defineConnector } from './define-connector.js';
 export { validateEntityMetrics } from './metrics.js';
 // Entity-bound metric layer contract (shared by CLI authoring + server
@@ -122,8 +122,12 @@ export {
   normalizeWaJid,
 } from './identity-normalize.js';
 // HTTP client (auth + retry + 429 Retry-After)
-export type { CreateHttpClientOptions, HttpClient } from './http-client.js';
-export { createHttpClient, HttpStatusError } from './http-client.js';
+export type {
+  CreateHttpClientOptions,
+  HttpClient,
+  RequireBearerClientOptions,
+} from './http-client.js';
+export { createHttpClient, HttpStatusError, requireBearerClient } from './http-client.js';
 // Logger
 export { sdkLogger, sdkLogger as logger } from './logger.js';
 // Pagination generators

--- a/packages/connectors/src/apple_health.ts
+++ b/packages/connectors/src/apple_health.ts
@@ -22,19 +22,17 @@
  * the run would throw immediately instead of silently producing no events.
  */
 
-import {
-  type ActionResult,
-  type ConnectorDefinition,
-  ConnectorRuntime,
-  type SyncContext,
-  type SyncResult,
-} from '@lobu/connector-sdk';
+import { BridgeOnlyConnector, type ConnectorDefinition } from '@lobu/connector-sdk';
 
 const BRIDGE_ONLY_MESSAGE =
   'apple.health runs only on a worker advertising capability "healthkit" (Lobu with Apple Health permission). ' +
   'This run was claimed by a worker without that capability — check connector_definitions.required_capability and the poll-time capability filter.';
 
-export default class AppleHealthConnector extends ConnectorRuntime {
+export default class AppleHealthConnector extends BridgeOnlyConnector {
+  constructor() {
+    super(BRIDGE_ONLY_MESSAGE);
+  }
+
   readonly definition: ConnectorDefinition = {
     key: 'apple.health',
     name: 'Apple Health',
@@ -127,12 +125,4 @@ export default class AppleHealthConnector extends ConnectorRuntime {
       },
     },
   };
-
-  async sync(_ctx: SyncContext): Promise<SyncResult> {
-    throw new Error(BRIDGE_ONLY_MESSAGE);
-  }
-
-  async execute(): Promise<ActionResult> {
-    throw new Error(BRIDGE_ONLY_MESSAGE);
-  }
 }

--- a/packages/connectors/src/apple_photos.ts
+++ b/packages/connectors/src/apple_photos.ts
@@ -30,19 +30,17 @@
  * throws immediately instead of silently producing zero events.
  */
 
-import {
-  type ActionResult,
-  type ConnectorDefinition,
-  ConnectorRuntime,
-  type SyncContext,
-  type SyncResult,
-} from '@lobu/connector-sdk';
+import { BridgeOnlyConnector, type ConnectorDefinition } from '@lobu/connector-sdk';
 
 const BRIDGE_ONLY_MESSAGE =
   'apple.photos runs only on a worker advertising capability "photos" (Lobu Mac app with Photos permission). ' +
   'This run was claimed by a worker without that capability — check connector_definitions.required_capability and the poll-time capability filter.';
 
-export default class ApplePhotosConnector extends ConnectorRuntime {
+export default class ApplePhotosConnector extends BridgeOnlyConnector {
+  constructor() {
+    super(BRIDGE_ONLY_MESSAGE);
+  }
+
   readonly definition: ConnectorDefinition = {
     key: 'apple.photos',
     name: 'Apple Photos',
@@ -171,12 +169,4 @@ export default class ApplePhotosConnector extends ConnectorRuntime {
       },
     },
   };
-
-  async sync(_ctx: SyncContext): Promise<SyncResult> {
-    throw new Error(BRIDGE_ONLY_MESSAGE);
-  }
-
-  async execute(): Promise<ActionResult> {
-    throw new Error(BRIDGE_ONLY_MESSAGE);
-  }
 }

--- a/packages/connectors/src/apple_screen_time.ts
+++ b/packages/connectors/src/apple_screen_time.ts
@@ -12,18 +12,16 @@
  * leaving the device on iOS. The Mac path is the workable one.
  */
 
-import {
-  type ActionResult,
-  type ConnectorDefinition,
-  ConnectorRuntime,
-  type SyncContext,
-  type SyncResult,
-} from '@lobu/connector-sdk';
+import { BridgeOnlyConnector, type ConnectorDefinition } from '@lobu/connector-sdk';
 
 const BRIDGE_ONLY =
   'Apple Screen Time runs only on a worker advertising capability "screentime" (Lobu for Mac with Full Disk Access).';
 
-export default class AppleScreenTimeConnector extends ConnectorRuntime {
+export default class AppleScreenTimeConnector extends BridgeOnlyConnector {
+  constructor() {
+    super(BRIDGE_ONLY);
+  }
+
   readonly definition: ConnectorDefinition = {
     key: 'apple.screen_time',
     name: 'Apple Screen Time',
@@ -71,12 +69,4 @@ export default class AppleScreenTimeConnector extends ConnectorRuntime {
       },
     },
   };
-
-  async sync(_ctx: SyncContext): Promise<SyncResult> {
-    throw new Error(BRIDGE_ONLY);
-  }
-
-  async execute(): Promise<ActionResult> {
-    throw new Error(BRIDGE_ONLY);
-  }
 }

--- a/packages/connectors/src/chrome_bookmarks.ts
+++ b/packages/connectors/src/chrome_bookmarks.ts
@@ -14,18 +14,16 @@
  * apps/chrome/feeds-bookmarks.js in the extension.
  */
 
-import {
-  type ActionResult,
-  type ConnectorDefinition,
-  ConnectorRuntime,
-  type SyncContext,
-  type SyncResult,
-} from '@lobu/connector-sdk';
+import { BridgeOnlyConnector, type ConnectorDefinition } from '@lobu/connector-sdk';
 
 const BRIDGE_ONLY =
   'chrome.bookmarks runs only on a worker advertising capability "browser.bookmarks" (Owletto for Chrome with bookmarks permission granted).';
 
-export default class ChromeBookmarksConnector extends ConnectorRuntime {
+export default class ChromeBookmarksConnector extends BridgeOnlyConnector {
+  constructor() {
+    super(BRIDGE_ONLY);
+  }
+
   readonly definition: ConnectorDefinition = {
     key: 'chrome.bookmarks',
     name: 'Chrome bookmarks',
@@ -68,12 +66,4 @@ export default class ChromeBookmarksConnector extends ConnectorRuntime {
       },
     },
   };
-
-  async sync(_ctx: SyncContext): Promise<SyncResult> {
-    throw new Error(BRIDGE_ONLY);
-  }
-
-  async execute(): Promise<ActionResult> {
-    throw new Error(BRIDGE_ONLY);
-  }
 }

--- a/packages/connectors/src/chrome_downloads.ts
+++ b/packages/connectors/src/chrome_downloads.ts
@@ -15,18 +15,16 @@
  * apps/chrome/feeds-downloads.js in the extension.
  */
 
-import {
-  type ActionResult,
-  type ConnectorDefinition,
-  ConnectorRuntime,
-  type SyncContext,
-  type SyncResult,
-} from '@lobu/connector-sdk';
+import { BridgeOnlyConnector, type ConnectorDefinition } from '@lobu/connector-sdk';
 
 const BRIDGE_ONLY =
   'chrome.downloads runs only on a worker advertising capability "browser.downloads" (Owletto for Chrome with downloads permission granted).';
 
-export default class ChromeDownloadsConnector extends ConnectorRuntime {
+export default class ChromeDownloadsConnector extends BridgeOnlyConnector {
+  constructor() {
+    super(BRIDGE_ONLY);
+  }
+
   readonly definition: ConnectorDefinition = {
     key: 'chrome.downloads',
     name: 'Chrome downloads',
@@ -69,12 +67,4 @@ export default class ChromeDownloadsConnector extends ConnectorRuntime {
       },
     },
   };
-
-  async sync(_ctx: SyncContext): Promise<SyncResult> {
-    throw new Error(BRIDGE_ONLY);
-  }
-
-  async execute(): Promise<ActionResult> {
-    throw new Error(BRIDGE_ONLY);
-  }
 }

--- a/packages/connectors/src/chrome_history.ts
+++ b/packages/connectors/src/chrome_history.ts
@@ -14,18 +14,16 @@
  * apps/chrome/feeds-history.js in the extension.
  */
 
-import {
-  type ActionResult,
-  type ConnectorDefinition,
-  ConnectorRuntime,
-  type SyncContext,
-  type SyncResult,
-} from '@lobu/connector-sdk';
+import { BridgeOnlyConnector, type ConnectorDefinition } from '@lobu/connector-sdk';
 
 const BRIDGE_ONLY =
   'chrome.history runs only on a worker advertising capability "browser.history" (Owletto for Chrome with history permission granted).';
 
-export default class ChromeHistoryConnector extends ConnectorRuntime {
+export default class ChromeHistoryConnector extends BridgeOnlyConnector {
+  constructor() {
+    super(BRIDGE_ONLY);
+  }
+
   readonly definition: ConnectorDefinition = {
     key: 'chrome.history',
     name: 'Chrome history',
@@ -69,12 +67,4 @@ export default class ChromeHistoryConnector extends ConnectorRuntime {
       },
     },
   };
-
-  async sync(_ctx: SyncContext): Promise<SyncResult> {
-    throw new Error(BRIDGE_ONLY);
-  }
-
-  async execute(): Promise<ActionResult> {
-    throw new Error(BRIDGE_ONLY);
-  }
 }

--- a/packages/connectors/src/google_gmail.ts
+++ b/packages/connectors/src/google_gmail.ts
@@ -760,6 +760,6 @@ export default class GmailConnector extends ConnectorRuntime<GmailCheckpoint, Gm
   }
 
   private createClient(token: string): HttpClient {
-    return createHttpClient({ getAccessToken: () => token, errorPrefix: 'Gmail API' });
+    return createHttpClient({ token, errorPrefix: 'Gmail API' });
   }
 }

--- a/packages/connectors/src/local_directory.ts
+++ b/packages/connectors/src/local_directory.ts
@@ -10,19 +10,17 @@
  * somehow bypassed the capability gate — same pattern as apple_screen_time.ts.
  */
 
-import {
-  type ActionResult,
-  type ConnectorDefinition,
-  ConnectorRuntime,
-  type SyncContext,
-  type SyncResult,
-} from '@lobu/connector-sdk';
+import { BridgeOnlyConnector, type ConnectorDefinition } from '@lobu/connector-sdk';
 
 const BRIDGE_ONLY_MESSAGE =
   'local.directory runs only on a worker advertising capability "local_directory" (Lobu for Mac). ' +
   'This run was claimed by a worker without that capability — check connector_definitions.required_capability and the poll-time capability filter.';
 
-export default class LocalDirectoryConnector extends ConnectorRuntime {
+export default class LocalDirectoryConnector extends BridgeOnlyConnector {
+  constructor() {
+    super(BRIDGE_ONLY_MESSAGE);
+  }
+
   readonly definition: ConnectorDefinition = {
     key: 'local.directory',
     name: 'Local Folder',
@@ -80,12 +78,4 @@ export default class LocalDirectoryConnector extends ConnectorRuntime {
       },
     },
   };
-
-  async sync(_ctx: SyncContext): Promise<SyncResult> {
-    throw new Error(BRIDGE_ONLY_MESSAGE);
-  }
-
-  async execute(): Promise<ActionResult> {
-    throw new Error(BRIDGE_ONLY_MESSAGE);
-  }
 }

--- a/packages/connectors/src/microsoft_outlook.ts
+++ b/packages/connectors/src/microsoft_outlook.ts
@@ -8,10 +8,10 @@
 import {
   type ConnectorDefinition,
   ConnectorRuntime,
-  createHttpClient,
   type EventEnvelope,
   type HttpClient,
   paginateByCursor,
+  requireBearerClient,
   type SyncContext,
   type SyncResult,
 } from '@lobu/connector-sdk';
@@ -227,15 +227,10 @@ export default class MicrosoftOutlookConnector extends ConnectorRuntime {
   // -------------------------------------------------------------------------
 
   async sync(ctx: SyncContext): Promise<SyncResult> {
-    const accessToken = ctx.credentials?.accessToken;
-    if (!accessToken) {
-      throw new Error('Microsoft Outlook requires OAuth authentication.');
-    }
-
-    const http = createHttpClient({
-      getAccessToken: () => accessToken,
-      headers: { 'Content-Type': 'application/json' },
+    const http = requireBearerClient(ctx.credentials, {
       errorPrefix: 'Microsoft Graph API',
+      label: 'Microsoft Outlook',
+      headers: { 'Content-Type': 'application/json' },
     });
 
     switch (ctx.feedKey) {

--- a/packages/connectors/src/producthunt.ts
+++ b/packages/connectors/src/producthunt.ts
@@ -269,7 +269,7 @@ export default class ProductHuntConnector extends ConnectorRuntime {
     const previousCheckpoint = ctx.checkpoint as ProductHuntCheckpoint | null;
 
     const http = createHttpClient({
-      getAccessToken: () => token,
+      token,
       headers: { Accept: 'application/json' },
       errorPrefix: 'Product Hunt API',
     });

--- a/packages/connectors/src/reddit.ts
+++ b/packages/connectors/src/reddit.ts
@@ -294,7 +294,7 @@ export default class RedditConnector extends ConnectorRuntime {
     cutoffDate.setDate(cutoffDate.getDate() - lookbackDays);
 
     const http = createHttpClient({
-      getAccessToken: () => accessToken,
+      token: accessToken,
       headers: { 'User-Agent': this.USER_AGENT },
       errorPrefix: 'Reddit API',
     });

--- a/packages/connectors/src/spotify.ts
+++ b/packages/connectors/src/spotify.ts
@@ -8,11 +8,11 @@
 import {
   type ConnectorDefinition,
   ConnectorRuntime,
-  createHttpClient,
   type EventEnvelope,
   type HttpClient,
   paginateByCursor,
   paginateByOffset,
+  requireBearerClient,
   type SyncContext,
   type SyncResult,
 } from '@lobu/connector-sdk';
@@ -300,14 +300,9 @@ export default class SpotifyConnector extends ConnectorRuntime {
   // -------------------------------------------------------------------------
 
   async sync(ctx: SyncContext): Promise<SyncResult> {
-    const accessToken = ctx.credentials?.accessToken;
-    if (!accessToken) {
-      throw new Error('Spotify requires OAuth authentication.');
-    }
-
-    const http = createHttpClient({
-      getAccessToken: () => accessToken,
+    const http = requireBearerClient(ctx.credentials, {
       errorPrefix: 'Spotify API',
+      label: 'Spotify',
     });
 
     switch (ctx.feedKey) {

--- a/packages/connectors/src/whatsapp_local.ts
+++ b/packages/connectors/src/whatsapp_local.ts
@@ -15,19 +15,16 @@
  *   - Bound to one specific Mac; requires WhatsApp Desktop installed.
  */
 
-import {
-  type ActionResult,
-  type ConnectorDefinition,
-  ConnectorRuntime,
-  IDENTITY,
-  type SyncContext,
-  type SyncResult,
-} from '@lobu/connector-sdk';
+import { BridgeOnlyConnector, type ConnectorDefinition, IDENTITY } from '@lobu/connector-sdk';
 
 const BRIDGE_ONLY =
   'WhatsApp (local) runs only on a worker advertising capability "whatsapp_local" (Lobu for Mac with WhatsApp Desktop installed).';
 
-export default class WhatsAppLocalConnector extends ConnectorRuntime {
+export default class WhatsAppLocalConnector extends BridgeOnlyConnector {
+  constructor() {
+    super(BRIDGE_ONLY);
+  }
+
   readonly definition: ConnectorDefinition = {
     key: 'whatsapp.local',
     name: 'WhatsApp (this Mac)',
@@ -114,12 +111,4 @@ export default class WhatsAppLocalConnector extends ConnectorRuntime {
       },
     },
   };
-
-  async sync(_ctx: SyncContext): Promise<SyncResult> {
-    throw new Error(BRIDGE_ONLY);
-  }
-
-  async execute(): Promise<ActionResult> {
-    throw new Error(BRIDGE_ONLY);
-  }
 }

--- a/packages/connectors/src/x.ts
+++ b/packages/connectors/src/x.ts
@@ -265,7 +265,7 @@ async function syncViaOAuthApi(
   }
 
   const http = createHttpClient({
-    getAccessToken: () => accessToken,
+    token: accessToken,
     headers: { 'Content-Type': 'application/json' },
     errorPrefix: 'X API',
   });

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -141,6 +141,7 @@ export type { McpStatus, McpToolDef } from "./utils/mcp-tool-instructions";
 export * from "./utils/network-domains";
 export * from "./utils/retry";
 export * from "./utils/sanitize";
+export { slugify } from "./utils/slug";
 // Shared OpenClaw session.jsonl parser (gateway + worker).
 export {
   entryToMessage,

--- a/packages/core/src/utils/slug.ts
+++ b/packages/core/src/utils/slug.ts
@@ -1,0 +1,26 @@
+/**
+ * Canonical URL-safe slug generator shared across packages.
+ *
+ * Lowercase, runs of non-alphanumeric characters collapse to a single hyphen,
+ * leading/trailing hyphens trimmed. Returns an empty string when the input has
+ * no alphanumeric characters (callers decide on a fallback).
+ *
+ * @example
+ * slugify('Hello World')            // 'hello-world'
+ * slugify('Café Münchën', { normalize: true }) // 'cafe-munchen'
+ * slugify('x'.repeat(60), { maxLength: 32 })    // 32-char slug
+ */
+export function slugify(
+  input: string,
+  options?: { normalize?: boolean; maxLength?: number }
+): string {
+  let slug = input.toLowerCase();
+  if (options?.normalize) {
+    // Decompose accented characters and drop the combining diacritical marks
+    // so e.g. "café" -> "cafe" instead of "caf".
+    slug = slug.normalize("NFKD").replace(/[̀-ͯ]/g, "");
+  }
+  slug = slug.replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "");
+  if (options?.maxLength != null) slug = slug.slice(0, options.maxLength);
+  return slug;
+}

--- a/packages/landing/src/components/DataTable.tsx
+++ b/packages/landing/src/components/DataTable.tsx
@@ -1,0 +1,53 @@
+import type { ComponentChildren } from "preact";
+
+/**
+ * Shared inline-style scaffold for the registry tables (SkillsRegistryTable,
+ * ProvidersRegistryTable). Keeps the cell/header style objects and the
+ * horizontally-scrollable `<table>` shell in one place so the two tables can't
+ * drift. PlatformConfigTable styles its tables via Tailwind/global CSS and is
+ * intentionally not built on this.
+ */
+
+export const cellStyle = {
+  padding: "8px 12px",
+  borderBottom: "1px solid var(--color-page-border)",
+  fontSize: "13px",
+  color: "var(--color-page-text-muted)",
+};
+
+export const headerCellStyle = {
+  ...cellStyle,
+  fontWeight: 600,
+  color: "var(--color-page-text)",
+  backgroundColor: "var(--color-page-surface-dim)",
+};
+
+type DataTableProps = {
+  headers: string[];
+  children: ComponentChildren;
+};
+
+export function DataTable({ headers, children }: DataTableProps) {
+  return (
+    <div style={{ overflowX: "auto" }}>
+      <table
+        style={{
+          width: "100%",
+          borderCollapse: "collapse",
+          border: "1px solid var(--color-page-border)",
+        }}
+      >
+        <thead>
+          <tr>
+            {headers.map((header) => (
+              <th key={header} style={headerCellStyle}>
+                {header}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>{children}</tbody>
+      </table>
+    </div>
+  );
+}

--- a/packages/landing/src/components/ProvidersRegistryTable.tsx
+++ b/packages/landing/src/components/ProvidersRegistryTable.tsx
@@ -1,4 +1,5 @@
 import providersConfig from "@providers-config";
+import { cellStyle, DataTable } from "./DataTable";
 
 interface ProviderConfig {
   displayName: string;
@@ -25,20 +26,6 @@ const providerRows = providers.flatMap((providerEntry) =>
   }))
 );
 
-const cellStyle = {
-  padding: "8px 12px",
-  borderBottom: "1px solid var(--color-page-border)",
-  fontSize: "13px",
-  color: "var(--color-page-text-muted)",
-};
-
-const headerCellStyle = {
-  ...cellStyle,
-  fontWeight: 600,
-  color: "var(--color-page-text)",
-  backgroundColor: "var(--color-page-surface-dim)",
-};
-
 function Badge({ text }: { text: string }) {
   return (
     <span
@@ -60,61 +47,44 @@ function Badge({ text }: { text: string }) {
 
 export function ProvidersRegistryTable() {
   return (
-    <div style={{ overflowX: "auto" }}>
-      <table
-        style={{
-          width: "100%",
-          borderCollapse: "collapse",
-          border: "1px solid var(--color-page-border)",
-        }}
-      >
-        <thead>
-          <tr>
-            <th style={headerCellStyle}>Provider</th>
-            <th style={headerCellStyle}>ID</th>
-            <th style={headerCellStyle}>Default Model</th>
-            <th style={headerCellStyle}>SDK Compat</th>
-            <th style={headerCellStyle}>Base URL</th>
-            <th style={headerCellStyle}>Models Endpoint</th>
-          </tr>
-        </thead>
-        <tbody>
-          {providerRows.map((provider) => (
-            <tr key={`${provider.id}:${provider.displayName}`}>
-              <td
-                style={{
-                  ...cellStyle,
-                  fontWeight: 500,
-                  color: "var(--color-page-text)",
-                }}
-              >
-                {provider.displayName}
-              </td>
-              <td style={cellStyle}>
-                <Badge text={provider.id} />
-              </td>
-              <td style={cellStyle}>
-                <code style={{ fontSize: "12px" }}>
-                  {provider.defaultModel}
-                </code>
-              </td>
-              <td style={cellStyle}>
-                <Badge text={provider.sdkCompat} />
-              </td>
-              <td style={cellStyle}>
-                <code style={{ fontSize: "12px" }}>
-                  {provider.upstreamBaseUrl}
-                </code>
-              </td>
-              <td style={cellStyle}>
-                <code style={{ fontSize: "12px" }}>
-                  {provider.modelsEndpoint}
-                </code>
-              </td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
-    </div>
+    <DataTable
+      headers={[
+        "Provider",
+        "ID",
+        "Default Model",
+        "SDK Compat",
+        "Base URL",
+        "Models Endpoint",
+      ]}
+    >
+      {providerRows.map((provider) => (
+        <tr key={`${provider.id}:${provider.displayName}`}>
+          <td
+            style={{
+              ...cellStyle,
+              fontWeight: 500,
+              color: "var(--color-page-text)",
+            }}
+          >
+            {provider.displayName}
+          </td>
+          <td style={cellStyle}>
+            <Badge text={provider.id} />
+          </td>
+          <td style={cellStyle}>
+            <code style={{ fontSize: "12px" }}>{provider.defaultModel}</code>
+          </td>
+          <td style={cellStyle}>
+            <Badge text={provider.sdkCompat} />
+          </td>
+          <td style={cellStyle}>
+            <code style={{ fontSize: "12px" }}>{provider.upstreamBaseUrl}</code>
+          </td>
+          <td style={cellStyle}>
+            <code style={{ fontSize: "12px" }}>{provider.modelsEndpoint}</code>
+          </td>
+        </tr>
+      ))}
+    </DataTable>
   );
 }

--- a/packages/landing/src/components/SkillsRegistryTable.tsx
+++ b/packages/landing/src/components/SkillsRegistryTable.tsx
@@ -1,16 +1,4 @@
-const cellStyle = {
-  padding: "8px 12px",
-  borderBottom: "1px solid var(--color-page-border)",
-  fontSize: "13px",
-  color: "var(--color-page-text-muted)",
-};
-
-const headerCellStyle = {
-  ...cellStyle,
-  fontWeight: 600,
-  color: "var(--color-page-text)",
-  backgroundColor: "var(--color-page-surface-dim)",
-};
+import { cellStyle, DataTable } from "./DataTable";
 
 const starterSkills = [
   {
@@ -29,46 +17,27 @@ export function SkillsRegistryTable() {
         <code>skills/&lt;name&gt;/SKILL.md</code> or{" "}
         <code>agents/&lt;agent-id&gt;/skills/&lt;name&gt;/SKILL.md</code>.
       </p>
-      <div style={{ overflowX: "auto" }}>
-        <table
-          style={{
-            width: "100%",
-            borderCollapse: "collapse",
-            border: "1px solid var(--color-page-border)",
-          }}
-        >
-          <thead>
-            <tr>
-              <th style={headerCellStyle}>Product</th>
-              <th style={headerCellStyle}>Install</th>
-              <th style={headerCellStyle}>What it adds</th>
-            </tr>
-          </thead>
-          <tbody>
-            {starterSkills.map((skill) => (
-              <tr key={skill.install}>
-                <td style={cellStyle}>{skill.product}</td>
-                <td style={cellStyle}>
-                  <code>{skill.install}</code>
-                </td>
-                <td style={cellStyle}>{skill.adds}</td>
-              </tr>
-            ))}
-            <tr>
-              <td style={cellStyle}>Local skill</td>
-              <td style={cellStyle}>
-                <code>skills/&lt;name&gt;/SKILL.md</code> or{" "}
-                <code>
-                  agents/&lt;agent-id&gt;/skills/&lt;name&gt;/SKILL.md
-                </code>
-              </td>
-              <td style={cellStyle}>
-                A project-owned custom skill discovered automatically
-              </td>
-            </tr>
-          </tbody>
-        </table>
-      </div>
+      <DataTable headers={["Product", "Install", "What it adds"]}>
+        {starterSkills.map((skill) => (
+          <tr key={skill.install}>
+            <td style={cellStyle}>{skill.product}</td>
+            <td style={cellStyle}>
+              <code>{skill.install}</code>
+            </td>
+            <td style={cellStyle}>{skill.adds}</td>
+          </tr>
+        ))}
+        <tr>
+          <td style={cellStyle}>Local skill</td>
+          <td style={cellStyle}>
+            <code>skills/&lt;name&gt;/SKILL.md</code> or{" "}
+            <code>agents/&lt;agent-id&gt;/skills/&lt;name&gt;/SKILL.md</code>
+          </td>
+          <td style={cellStyle}>
+            A project-owned custom skill discovered automatically
+          </td>
+        </tr>
+      </DataTable>
     </div>
   );
 }

--- a/packages/landing/src/use-case-definitions.ts
+++ b/packages/landing/src/use-case-definitions.ts
@@ -28,13 +28,27 @@ type ExampleLink = {
   href: string;
 };
 
+/**
+ * Agent-connection client a how-it-works panel item is attributed to. The
+ * human-readable label is derived from {@link USE_CASE_PLATFORM_LABELS} at
+ * render time, so the data only stores the id.
+ */
+export type UseCasePlatformId = "slack" | "openclaw" | "chatgpt" | "claude";
+
+/** Canonical id → display label for {@link UseCasePlatformId}. */
+export const USE_CASE_PLATFORM_LABELS: Record<UseCasePlatformId, string> = {
+  slack: "Slack",
+  openclaw: "OpenClaw",
+  chatgpt: "ChatGPT",
+  claude: "Claude",
+};
+
 type HowItWorksPanelItem = {
   label: string;
   detail: string;
   meta?: string;
   platform?: {
-    id: "slack" | "openclaw" | "chatgpt" | "claude";
-    label: string;
+    id: UseCasePlatformId;
   };
 };
 

--- a/packages/landing/src/use-case-showcases.ts
+++ b/packages/landing/src/use-case-showcases.ts
@@ -151,19 +151,19 @@ const memoryStepPanels: Record<
         {
           label: "Community concierge",
           detail: "Answers questions like who should meet this week and why.",
-          platform: { id: "slack", label: "Slack" },
+          platform: { id: "slack" },
         },
         {
           label: "Member search agent",
           detail:
             "Finds members by topic, project, or recent activity using the shared graph.",
-          platform: { id: "openclaw", label: "OpenClaw" },
+          platform: { id: "openclaw" },
         },
         {
           label: "Intro drafting workflow",
           detail:
             "Prepares warm intro drafts for Slack or email and waits for approval before sending.",
-          platform: { id: "claude", label: "Claude" },
+          platform: { id: "claude" },
         },
       ],
     },
@@ -240,19 +240,19 @@ const memoryStepPanels: Record<
           label: "Subscription manager",
           detail:
             "Handles plan changes, skips, and upgrades with customer context and approval flows.",
-          platform: { id: "slack", label: "Slack" },
+          platform: { id: "slack" },
         },
         {
           label: "Order support agent",
           detail:
             "Resolves order inquiries, tracks deliveries, and processes returns.",
-          platform: { id: "openclaw", label: "OpenClaw" },
+          platform: { id: "openclaw" },
         },
         {
           label: "Customer insights assistant",
           detail:
             "Summarizes customer history, preferences, and lifetime value for support and sales.",
-          platform: { id: "claude", label: "Claude" },
+          platform: { id: "claude" },
         },
       ],
     },
@@ -329,19 +329,19 @@ const memoryStepPanels: Record<
           label: "Deal screener",
           detail:
             "Checks company signals, funding history, and team background before first calls.",
-          platform: { id: "slack", label: "Slack" },
+          platform: { id: "slack" },
         },
         {
           label: "Portfolio monitor",
           detail:
             "Tracks portfolio company growth, competitive moves, and follow-on opportunities.",
-          platform: { id: "openclaw", label: "OpenClaw" },
+          platform: { id: "openclaw" },
         },
         {
           label: "IC assistant",
           detail:
             "Prep investment committee memos with company context and market analysis.",
-          platform: { id: "claude", label: "Claude" },
+          platform: { id: "claude" },
         },
       ],
     },
@@ -418,25 +418,25 @@ const memoryStepPanels: Record<
           label: "Risk review agent",
           detail:
             "Flags unresolved clauses and approval blockers in active negotiations.",
-          platform: { id: "slack", label: "Slack" },
+          platform: { id: "slack" },
         },
         {
           label: "Negotiation assistant",
           detail:
             "Recalls fallback language and prior concessions before the next draft.",
-          platform: { id: "claude", label: "Claude" },
+          platform: { id: "claude" },
         },
         {
           label: "Counterparty brief agent",
           detail:
             "Summarizes prior asks, objections, and open terms for the same external party.",
-          platform: { id: "chatgpt", label: "ChatGPT" },
+          platform: { id: "chatgpt" },
         },
         {
           label: "Draft prep workflow",
           detail:
             "Carries approved edits and unresolved risks into the next review cycle.",
-          platform: { id: "openclaw", label: "OpenClaw" },
+          platform: { id: "openclaw" },
         },
       ],
     },
@@ -513,25 +513,25 @@ const memoryStepPanels: Record<
           label: "Variance analyst",
           detail:
             "Explains why an account moved and what still needs reconciliation before close.",
-          platform: { id: "slack", label: "Slack" },
+          platform: { id: "slack" },
         },
         {
           label: "Reporting assistant",
           detail:
             "Carries reconciliation context into month-end updates and leadership reporting.",
-          platform: { id: "claude", label: "Claude" },
+          platform: { id: "claude" },
         },
         {
           label: "Exception triage agent",
           detail:
             "Surfaces which refunds, payouts, or adjustments still need owner follow-up.",
-          platform: { id: "chatgpt", label: "ChatGPT" },
+          platform: { id: "chatgpt" },
         },
         {
           label: "Audit prep workflow",
           detail:
             "Keeps explanations attached to the originating systems and imported evidence.",
-          platform: { id: "openclaw", label: "OpenClaw" },
+          platform: { id: "openclaw" },
         },
       ],
     },
@@ -608,25 +608,25 @@ const memoryStepPanels: Record<
           label: "Renewal prep agent",
           detail:
             "Pulls current risks, owners, and blockers before a customer call or QBR.",
-          platform: { id: "slack", label: "Slack" },
+          platform: { id: "slack" },
         },
         {
           label: "Forecast brief assistant",
           detail:
             "Generates consistent leadership updates from the same account memory.",
-          platform: { id: "claude", label: "Claude" },
+          platform: { id: "claude" },
         },
         {
           label: "Expansion context agent",
           detail:
             "Recalls which team owns the rollout, where adoption is growing, and what is blocking expansion.",
-          platform: { id: "chatgpt", label: "ChatGPT" },
+          platform: { id: "chatgpt" },
         },
         {
           label: "Next-step workflow",
           detail:
             "Hands the right commercial follow-up to chat agents and planning tools.",
-          platform: { id: "openclaw", label: "OpenClaw" },
+          platform: { id: "openclaw" },
         },
       ],
     },
@@ -703,25 +703,25 @@ const memoryStepPanels: Record<
           label: "Standup agent",
           detail:
             "Answers what is blocked, who owns it, and which milestone is at risk.",
-          platform: { id: "slack", label: "Slack" },
+          platform: { id: "slack" },
         },
         {
           label: "Planning assistant",
           detail:
             "Brings prior docs, owners, and dependencies into the next planning session.",
-          platform: { id: "claude", label: "Claude" },
+          platform: { id: "claude" },
         },
         {
           label: "Launch readiness agent",
           detail:
             "Uses one shared memory graph for rollout status, docs, and unresolved risks.",
-          platform: { id: "chatgpt", label: "ChatGPT" },
+          platform: { id: "chatgpt" },
         },
         {
           label: "Stakeholder update workflow",
           detail:
             "Generates Monday risk updates from the same project record leadership already trusts.",
-          platform: { id: "openclaw", label: "OpenClaw" },
+          platform: { id: "openclaw" },
         },
       ],
     },
@@ -798,25 +798,25 @@ const memoryStepPanels: Record<
           label: "Decision recall agent",
           detail:
             "Answers what was approved, what is blocked, and which region or budget line it affects.",
-          platform: { id: "claude", label: "Claude" },
+          platform: { id: "claude" },
         },
         {
           label: "Assignment tracker",
           detail:
             "Keeps action items visible across future workflows and follow-ups.",
-          platform: { id: "slack", label: "Slack" },
+          platform: { id: "slack" },
         },
         {
           label: "Document QA assistant",
           detail:
             "Answers from the extracted graph without re-reading every memo in full.",
-          platform: { id: "chatgpt", label: "ChatGPT" },
+          platform: { id: "chatgpt" },
         },
         {
           label: "Board prep workflow",
           detail:
             "Carries pending decisions and blockers into the next briefing cycle.",
-          platform: { id: "openclaw", label: "OpenClaw" },
+          platform: { id: "openclaw" },
         },
       ],
     },

--- a/packages/server/src/__tests__/setup/test-fixtures.ts
+++ b/packages/server/src/__tests__/setup/test-fixtures.ts
@@ -7,11 +7,11 @@
 
 import { serializeSigned } from 'hono/utils/cookie';
 import { hashClientSecret } from '../../auth/oauth/clients';
+import { slugify } from '@lobu/core';
 import { generateSecureToken, hashToken } from '../../auth/oauth/utils';
 import { pgBigintArray, pgTextArray } from '../../db/client';
 import { ensureUniqueConnectionSlug } from '../../utils/connections';
 import { getConfiguredEmbeddingModel } from '../../utils/embeddings';
-import { generateSlug } from '../../utils/entity-management';
 import type { ToolContext } from '../../tools/registry';
 import { getTestDb } from './test-db';
 
@@ -293,7 +293,7 @@ export async function createTestEntity(options: {
   created_by?: string;
 }): Promise<TestEntity> {
   const sql = getTestDb();
-  const slug = generateSlug(options.name);
+  const slug = slugify(options.name);
   const metadata = options.domain ? { domain: options.domain } : {};
 
   // Resolve created_by: use provided user ID or find any existing user in the org

--- a/packages/server/src/auth/personal-org-provisioning.ts
+++ b/packages/server/src/auth/personal-org-provisioning.ts
@@ -7,6 +7,7 @@
  * to receive auto-installed agents or per-user mirrored schemas.
  */
 
+import { slugify as slugifyBase } from "@lobu/core";
 import { getDb } from "../db/client";
 import { RESERVED_PATHS_SET } from "../utils/reserved";
 import { generateSecureToken } from "./oauth/utils";
@@ -35,14 +36,9 @@ const PERSONAL_ORG_LOCK_NAMESPACE = 0x706f7267; // "porg"
 
 type Sql = ReturnType<typeof getDb>;
 
+// Org slugs strip diacritics (NFKD) and cap length so they stay route-safe.
 export function slugify(input: string): string {
-	return input
-		.toLowerCase()
-		.normalize("NFKD")
-		.replace(/[\u0300-\u036f]/g, "")
-		.replace(/[^a-z0-9]+/g, "-")
-		.replace(/^-+|-+$/g, "")
-		.slice(0, MAX_SLUG_LENGTH);
+	return slugifyBase(input, { normalize: true, maxLength: MAX_SLUG_LENGTH });
 }
 
 export function deriveSlugCandidate(user: UserLike): string {

--- a/packages/server/src/gateway/auth/base-provider-module.ts
+++ b/packages/server/src/gateway/auth/base-provider-module.ts
@@ -213,6 +213,60 @@ export abstract class BaseProviderModule
     return envVars;
   }
 
+  /**
+   * Resolve a usable credential for the agent, applying the standard precedence:
+   *   1. per-user auth profile (refreshed when a userId is in context)
+   *   2. org-shared API key written by `lobu apply`
+   *   3. system env var (only when `includeSystemEnv` is set)
+   *
+   * Returns the credential and which tier produced it, so callers can keep
+   * their tier-specific logging. `buildEnvVars` omits the system-env tier (the
+   * worker resolves that via `injectSystemKeyFallback`); `getCredential`
+   * includes it.
+   */
+  private async resolveCredential(
+    agentId: string,
+    context: ProviderCredentialContext | undefined,
+    opts: { includeSystemEnv: boolean }
+  ): Promise<{
+    credential: string;
+    source: "profile" | "org" | "system";
+  } | null> {
+    const profile = await this.authProfilesManager.getBestProfile(
+      agentId,
+      this.providerId,
+      undefined,
+      context
+    );
+    const profileCredential =
+      profile && context?.userId
+        ? await this.authProfilesManager.ensureFreshCredential(profile, {
+            userId: context.userId,
+            agentId,
+          })
+        : profile?.credential;
+    if (profileCredential) {
+      return { credential: profileCredential, source: "profile" };
+    }
+
+    const orgKey = await readOrgSharedProviderKey(this.providerId, context);
+    if (orgKey) {
+      return { credential: orgKey, source: "org" };
+    }
+
+    if (opts.includeSystemEnv) {
+      const sysVar =
+        this.providerConfig.systemEnvVarName ||
+        this.providerConfig.credentialEnvVarName;
+      const systemKey = process.env[sysVar];
+      if (systemKey) {
+        return { credential: systemKey, source: "system" };
+      }
+    }
+
+    return null;
+  }
+
   async buildEnvVars(
     agentId: string,
     envVars: Record<string, string>,
@@ -220,33 +274,16 @@ export abstract class BaseProviderModule
   ): Promise<Record<string, string>> {
     const credVar = this.providerConfig.credentialEnvVarName;
     if (!envVars[credVar]) {
-      const profile = await this.authProfilesManager.getBestProfile(
-        agentId,
-        this.providerId,
-        undefined,
-        context
-      );
-      const credential = profile && context?.userId
-        ? await this.authProfilesManager.ensureFreshCredential(profile, {
-            userId: context.userId,
-            agentId,
-          })
-        : profile?.credential;
-      if (credential) {
+      const resolved = await this.resolveCredential(agentId, context, {
+        includeSystemEnv: false,
+      });
+      if (resolved) {
         logger.info(
-          `Injecting ${credVar} for agent ${agentId} (${this.providerId})`
+          resolved.source === "org"
+            ? `Injecting ${credVar} for agent ${agentId} (${this.providerId}) from org-shared secret`
+            : `Injecting ${credVar} for agent ${agentId} (${this.providerId})`
         );
-        envVars[credVar] = credential;
-      } else {
-        // No per-user auth profile — fall back to the org-shared API key
-        // declared via `lobu apply` (`provider:<id>:apiKey` in agent_secrets).
-        const orgKey = await readOrgSharedProviderKey(this.providerId, context);
-        if (orgKey) {
-          logger.info(
-            `Injecting ${credVar} for agent ${agentId} (${this.providerId}) from org-shared secret`
-          );
-          envVars[credVar] = orgKey;
-        }
+        envVars[credVar] = resolved.credential;
       }
     }
     return envVars;
@@ -260,27 +297,10 @@ export abstract class BaseProviderModule
     agentId: string,
     context?: ProviderCredentialContext
   ): Promise<string | null> {
-    const profile = await this.authProfilesManager.getBestProfile(
-      agentId,
-      this.providerId,
-      undefined,
-      context
-    );
-    const credential = profile && context?.userId
-      ? await this.authProfilesManager.ensureFreshCredential(profile, {
-          userId: context.userId,
-          agentId,
-        })
-      : profile?.credential;
-    if (credential) {
-      return credential;
-    }
-    const orgKey = await readOrgSharedProviderKey(this.providerId, context);
-    if (orgKey) return orgKey;
-    const sysVar =
-      this.providerConfig.systemEnvVarName ||
-      this.providerConfig.credentialEnvVarName;
-    return process.env[sysVar] || null;
+    const resolved = await this.resolveCredential(agentId, context, {
+      includeSystemEnv: true,
+    });
+    return resolved?.credential ?? null;
   }
 
   /** Build a structured placeholder for proxy mode (default: "lobu-proxy"). */

--- a/packages/server/src/gateway/auth/chatgpt/device-code-client.ts
+++ b/packages/server/src/gateway/auth/chatgpt/device-code-client.ts
@@ -1,7 +1,5 @@
-import { createLogger } from "@lobu/core";
+import { BaseOAuth2Client } from "../oauth/base-client.js";
 import type { OAuthCredentials } from "../oauth/credentials.js";
-
-const logger = createLogger("chatgpt-device-code");
 
 const CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann";
 const DEVICE_CODE_URL =
@@ -23,13 +21,10 @@ const OAUTH_SCOPE =
     "api.model.audio.request",
   ].join(" ");
 const JWT_CLAIM_PATH = "https://api.openai.com/auth";
+const TOKEN_USER_AGENT = "reqwest/0.12.24";
 const DEVICE_HEADERS = {
   "Content-Type": "application/json",
-  "User-Agent": "reqwest/0.12.24",
-};
-const TOKEN_HEADERS = {
-  "Content-Type": "application/x-www-form-urlencoded",
-  "User-Agent": "reqwest/0.12.24",
+  "User-Agent": TOKEN_USER_AGENT,
 };
 
 interface DeviceCodeResponse {
@@ -48,8 +43,17 @@ interface DeviceTokenResult {
 /**
  * Client for OpenAI device code authentication flow.
  * Based on sub-bridge's device code implementation.
+ *
+ * Extends {@link BaseOAuth2Client} so the standard OAuth token exchange and
+ * refresh ride the shared `exchangeToken` / `refreshAccessToken` HTTP plumbing.
+ * The device-auth handshake (`/api/accounts/deviceauth/*`) is OpenAI's own JSON
+ * API — not RFC 6749 — so those two requests keep their bespoke JSON shape here.
  */
-export class ChatGPTDeviceCodeClient {
+export class ChatGPTDeviceCodeClient extends BaseOAuth2Client {
+  constructor() {
+    super("chatgpt-device-code");
+  }
+
   /**
    * Request a device code from OpenAI.
    * Returns user_code for display and device_auth_id for polling.
@@ -66,7 +70,7 @@ export class ChatGPTDeviceCodeClient {
 
     if (!response.ok) {
       const text = await response.text().catch(() => "");
-      logger.error("Device code request failed", {
+      this.logger.error("Device code request failed", {
         status: response.status,
         body: text,
       });
@@ -114,7 +118,7 @@ export class ChatGPTDeviceCodeClient {
 
     if (!response.ok) {
       const text = await response.text().catch(() => "");
-      logger.error("Device token poll failed", {
+      this.logger.error("Device token poll failed", {
         status: response.status,
         body: text,
       });
@@ -127,7 +131,9 @@ export class ChatGPTDeviceCodeClient {
     };
 
     if (!data.authorization_code || !data.code_verifier) {
-      logger.warn("Poll response missing authorization fields, still pending");
+      this.logger.warn(
+        "Poll response missing authorization fields, still pending"
+      );
       return null;
     }
 
@@ -137,51 +143,43 @@ export class ChatGPTDeviceCodeClient {
 
   /**
    * Exchange authorization code for access/refresh tokens.
+   *
+   * Form-encoded per RFC 6749 §4.1.3 via the shared {@link exchangeToken}
+   * plumbing. The OpenAI `reqwest` User-Agent is preserved — `Content-Type`
+   * is owned by the base client (form-urlencoded for `contentType: "form"`).
    */
   private async exchangeCode(
     authorizationCode: string,
     codeVerifier: string
   ): Promise<DeviceTokenResult> {
-    const response = await fetch(TOKEN_EXCHANGE_URL, {
-      method: "POST",
-      headers: TOKEN_HEADERS,
-      body: new URLSearchParams({
+    const data = await this.exchangeToken<{
+      access_token: string;
+      refresh_token: string;
+      expires_in: number;
+      id_token?: string;
+    }>(
+      TOKEN_EXCHANGE_URL,
+      {
         grant_type: "authorization_code",
         client_id: CLIENT_ID,
         code: authorizationCode,
         code_verifier: codeVerifier,
         redirect_uri: DEVICE_REDIRECT_URI,
         scope: OAUTH_SCOPE,
-      }).toString(),
-    });
+      },
+      "form",
+      { "User-Agent": TOKEN_USER_AGENT }
+    );
 
-    if (!response.ok) {
-      const text = await response.text().catch(() => "");
-      logger.error("Token exchange failed", {
-        status: response.status,
-        body: text,
-      });
-      throw new Error(`Token exchange failed: ${response.status}`);
-    }
-
-    const data = (await response.json()) as {
-      access_token: string;
-      refresh_token: string;
-      expires_in: number;
-      id_token?: string;
-    };
-
-    if (!data.access_token || !data.refresh_token) {
+    if (!data.refresh_token) {
       throw new Error("Token response missing required fields");
     }
-
-    const accountId = this.extractAccountId(data.access_token);
 
     return {
       accessToken: data.access_token,
       refreshToken: data.refresh_token,
       expiresIn: data.expires_in,
-      accountId,
+      accountId: this.extractAccountId(data.access_token),
     };
   }
 
@@ -189,49 +187,38 @@ export class ChatGPTDeviceCodeClient {
    * Exchange a stored refresh token for a fresh access token.
    *
    * Same OAuth token endpoint and form-encoding as {@link exchangeCode} (RFC
-   * 6749 §6). Returns {@link OAuthCredentials} so this client can be registered
-   * directly in the gateway's `TokenRefreshJob` alongside the Claude
-   * `OAuthClient`. OpenAI does not always rotate the refresh token, so the
-   * existing one is preserved when the response omits it — otherwise the stored
-   * refresh token would be wiped on every refresh.
+   * 6749 §6), via the shared {@link refreshAccessToken} plumbing. Returns
+   * {@link OAuthCredentials} so this client can be registered directly in the
+   * gateway's `TokenRefreshJob` alongside the Claude `OAuthClient`. OpenAI does
+   * not always rotate the refresh token, so the existing one is preserved when
+   * the response omits it — otherwise the stored refresh token would be wiped on
+   * every refresh. The `scope` parameter (which the generic
+   * `refreshTokenWithConfig` does not carry) is part of OpenAI's required wire
+   * shape, so the body is built explicitly here.
    */
   async refreshToken(refreshToken: string): Promise<OAuthCredentials> {
-    const response = await fetch(TOKEN_EXCHANGE_URL, {
-      method: "POST",
-      headers: TOKEN_HEADERS,
-      body: new URLSearchParams({
+    const data = await this.refreshAccessToken<{
+      access_token: string;
+      refresh_token?: string;
+      expires_in?: number;
+    }>(
+      TOKEN_EXCHANGE_URL,
+      {
         grant_type: "refresh_token",
         client_id: CLIENT_ID,
         refresh_token: refreshToken,
         scope: OAUTH_SCOPE,
-      }).toString(),
-    });
-
-    if (!response.ok) {
-      const text = await response.text().catch(() => "");
-      logger.error("Token refresh failed", {
-        status: response.status,
-        body: text,
-      });
-      throw new Error(`Token refresh failed: ${response.status}`);
-    }
-
-    const data = (await response.json()) as {
-      access_token?: string;
-      refresh_token?: string;
-      expires_in?: number;
-    };
-
-    if (!data.access_token) {
-      throw new Error("Refresh response missing access_token");
-    }
+      },
+      "form",
+      { "User-Agent": TOKEN_USER_AGENT }
+    );
 
     return {
       accessToken: data.access_token,
       refreshToken: data.refresh_token ?? refreshToken,
       tokenType: "Bearer",
-      expiresAt: Date.now() + (data.expires_in ?? 0) * 1000,
-      scopes: OAUTH_SCOPE.split(" "),
+      expiresAt: this.calculateExpiresAt(data.expires_in ?? 0) ?? Date.now(),
+      scopes: this.parseScopes(OAUTH_SCOPE),
     };
   }
 
@@ -262,7 +249,7 @@ export class ChatGPTDeviceCodeClient {
 
       return undefined;
     } catch (error) {
-      logger.warn("Failed to extract account ID from JWT", { error });
+      this.logger.warn("Failed to extract account ID from JWT", { error });
       return undefined;
     }
   }

--- a/packages/server/src/gateway/auth/oauth/base-client.ts
+++ b/packages/server/src/gateway/auth/oauth/base-client.ts
@@ -84,19 +84,20 @@ export abstract class BaseOAuth2Client {
   // ============================================================================
 
   /**
-   * Common token exchange implementation
-   * Subclasses must implement buildTokenExchangeRequest
+   * Shared POST to a token endpoint. Serializes the body per `contentType`,
+   * sets the matching `Content-Type` header (merged after any caller headers so
+   * it always wins), checks `response.ok`, parses the token response, and
+   * validates for OAuth errors / a present `access_token`. The two public
+   * operations differ only in their log prefix and whether a form-encoded
+   * response body is accepted (`parseFormResponse`), so both delegate here.
    */
-  protected async exchangeToken<T>(
+  private async postTokenRequest<T>(
     tokenUrl: string,
     requestBody: Record<string, string | number> | URLSearchParams,
-    contentType: "json" | "form" = "json",
-    additionalHeaders?: Record<string, string>
+    contentType: "json" | "form",
+    additionalHeaders: Record<string, string> | undefined,
+    opts: { label: string; failPrefix: string; parseFormResponse: boolean }
   ): Promise<T> {
-    this.logger.info(`Exchanging code for token at ${tokenUrl}`, {
-      contentType,
-    });
-
     try {
       const body =
         contentType === "json"
@@ -118,11 +119,6 @@ export abstract class BaseOAuth2Client {
         headers["Content-Type"] = "application/x-www-form-urlencoded";
       }
 
-      this.logger.debug(`Token exchange request`, {
-        contentType,
-        tokenUrl,
-      });
-
       const response = await fetch(tokenUrl, {
         method: "POST",
         headers,
@@ -131,21 +127,20 @@ export abstract class BaseOAuth2Client {
 
       if (!response.ok) {
         const errorText = await response.text();
-        this.logger.error(`Token exchange failed: ${response.status}`, {
+        this.logger.error(`${opts.failPrefix}: ${response.status}`, {
           errorText,
         });
         throw new Error(
-          `Token exchange failed: ${response.status} ${response.statusText}`
+          `${opts.failPrefix}: ${response.status} ${response.statusText}`
         );
       }
 
-      const responseContentType = response.headers.get("content-type") || "";
       let tokenData: any;
-
-      // Parse response based on content type
-      if (responseContentType.includes("application/json")) {
-        tokenData = await response.json();
-      } else {
+      const responseContentType = response.headers.get("content-type") || "";
+      if (
+        opts.parseFormResponse &&
+        !responseContentType.includes("application/json")
+      ) {
         // Handle form-encoded responses (e.g., some OAuth providers)
         const text = await response.text();
         const params = new URLSearchParams(text);
@@ -158,9 +153,10 @@ export abstract class BaseOAuth2Client {
           refresh_token: params.get("refresh_token") || undefined,
           scope: params.get("scope") || undefined,
         };
+      } else {
+        tokenData = await response.json();
       }
 
-      // Check for OAuth error response
       if ("error" in tokenData) {
         throw new Error(
           `OAuth error: ${tokenData.error} - ${tokenData.error_description || ""}`
@@ -168,18 +164,44 @@ export abstract class BaseOAuth2Client {
       }
 
       if (!tokenData.access_token) {
-        throw new Error("No access token in response");
+        throw new Error(`No access token in ${opts.label} response`);
       }
 
       this.logger.info(
-        `Token exchange successful, expires_in: ${tokenData.expires_in}s`
+        `${opts.label} successful, expires_in: ${tokenData.expires_in}s`
       );
 
       return tokenData as T;
     } catch (error) {
-      this.logger.error("Token exchange failed", { error });
+      this.logger.error(`${opts.label} failed`, { error });
       throw error;
     }
+  }
+
+  /**
+   * Common token exchange implementation
+   * Subclasses must implement buildTokenExchangeRequest
+   */
+  protected async exchangeToken<T>(
+    tokenUrl: string,
+    requestBody: Record<string, string | number> | URLSearchParams,
+    contentType: "json" | "form" = "json",
+    additionalHeaders?: Record<string, string>
+  ): Promise<T> {
+    this.logger.info(`Exchanging code for token at ${tokenUrl}`, {
+      contentType,
+    });
+    return this.postTokenRequest<T>(
+      tokenUrl,
+      requestBody,
+      contentType,
+      additionalHeaders,
+      {
+        label: "Token exchange",
+        failPrefix: "Token exchange failed",
+        parseFormResponse: true,
+      }
+    );
   }
 
   /**
@@ -193,65 +215,17 @@ export abstract class BaseOAuth2Client {
     additionalHeaders?: Record<string, string>
   ): Promise<T> {
     this.logger.info(`Refreshing token at ${tokenUrl}`);
-
-    try {
-      const body =
-        contentType === "json"
-          ? JSON.stringify(requestBody)
-          : requestBody instanceof URLSearchParams
-            ? requestBody.toString()
-            : new URLSearchParams(
-                requestBody as Record<string, string>
-              ).toString();
-
-      const headers: Record<string, string> = {
-        Accept: "application/json",
-        ...additionalHeaders,
-      };
-
-      if (contentType === "json") {
-        headers["Content-Type"] = "application/json";
-      } else {
-        headers["Content-Type"] = "application/x-www-form-urlencoded";
+    return this.postTokenRequest<T>(
+      tokenUrl,
+      requestBody,
+      contentType,
+      additionalHeaders,
+      {
+        label: "Token refresh",
+        failPrefix: "Token refresh failed",
+        parseFormResponse: false,
       }
-
-      const response = await fetch(tokenUrl, {
-        method: "POST",
-        headers,
-        body,
-      });
-
-      if (!response.ok) {
-        const errorText = await response.text();
-        this.logger.error(`Token refresh failed: ${response.status}`, {
-          errorText,
-        });
-        throw new Error(
-          `Token refresh failed: ${response.status} ${response.statusText}`
-        );
-      }
-
-      const tokenData = (await response.json()) as any;
-
-      if ("error" in tokenData) {
-        throw new Error(
-          `OAuth error: ${tokenData.error} - ${tokenData.error_description || ""}`
-        );
-      }
-
-      if (!tokenData.access_token) {
-        throw new Error("No access token in refresh response");
-      }
-
-      this.logger.info(
-        `Token refresh successful, expires_in: ${tokenData.expires_in}s`
-      );
-
-      return tokenData as T;
-    } catch (error) {
-      this.logger.error("Token refresh failed", { error });
-      throw error;
-    }
+    );
   }
 
   /**

--- a/packages/server/src/gateway/connections/chat-response-bridge.ts
+++ b/packages/server/src/gateway/connections/chat-response-bridge.ts
@@ -18,6 +18,7 @@ import {
   type GuardrailRegistry,
   runGuardrailInstances,
 } from "@lobu/core";
+import { Actions, Card, CardText, LinkButton } from "chat";
 import { getDb } from "../../db/client.js";
 import { getOrganizationSlug } from "../../utils/url-builder.js";
 import type { AgentSettingsStore } from "../auth/settings/agent-settings-store.js";
@@ -346,11 +347,10 @@ export class ChatResponseBridge implements ResponseRenderer {
         }
         this.streams.delete(key);
       }
-      const blockText = `Message blocked by guardrail: ${trip.reason ?? trip.guardrail}`;
-      await this.postToPayloadTarget(
+      await this.postGuardrailBlock(
         payload,
         ctx,
-        blockText,
+        trip,
         "Failed to post guardrail block message"
       );
       return null;
@@ -443,11 +443,10 @@ export class ChatResponseBridge implements ResponseRenderer {
         const trip = await this.runOutputGuardrails(completionText, payload, ctx);
         if (trip) {
           blockedAtCompletion = true;
-          const blockText = `Message blocked by guardrail: ${trip.reason ?? trip.guardrail}`;
-          await this.postToPayloadTarget(
+          await this.postGuardrailBlock(
             payload,
             ctx,
-            blockText,
+            trip,
             "Failed to post guardrail block message at completion"
           );
         }
@@ -632,14 +631,11 @@ export class ChatResponseBridge implements ResponseRenderer {
     // into the admin UI when we can resolve one. The settings page for an
     // agent is `<publicWebUrl>/<orgSlug>/agents/<agentId>`.
     if (payload.errorCode === "NO_MODEL_CONFIGURED") {
-      const errCtx = this.extractResponseContext(payload);
-      const settingsUrl = errCtx
-        ? await buildAgentSettingsUrl(
-            this.manager.getPublicGatewayUrl(),
-            this.resolveOrganizationId(payload, errCtx) ?? undefined,
-            this.resolveAgentId(payload, errCtx) ?? undefined
-          )
-        : null;
+      const settingsUrl = await buildAgentSettingsUrl(
+        this.manager.getPublicGatewayUrl(),
+        this.resolveOrganizationId(payload, ctx) ?? undefined,
+        this.resolveAgentId(payload, ctx) ?? undefined
+      );
       payload.error = settingsUrl
         ? `No model configured. Connect a provider at ${settingsUrl}`
         : "No model configured. Ask an admin to connect a provider for the base agent.";
@@ -686,9 +682,6 @@ export class ChatResponseBridge implements ResponseRenderer {
 
         if (linkButtons.length > 0) {
           try {
-            const { Actions, Card, CardText, LinkButton } = await import(
-              "chat"
-            );
             const card = Card({
               children: [
                 CardText(processedContent),
@@ -762,6 +755,21 @@ export class ChatResponseBridge implements ResponseRenderer {
     } catch (err) {
       logger.error({ connectionId: ctx.connectionId, err: String(err) }, logMessage);
     }
+  }
+
+  /**
+   * Post the user-facing "blocked by guardrail" notice for a trip. Shared by
+   * the per-delta scan in handleDelta and the post-once scan in
+   * handleCompletion so the block copy stays identical across both paths.
+   */
+  private postGuardrailBlock(
+    payload: ThreadResponsePayload,
+    ctx: ResponseContext,
+    trip: { guardrail: string; reason?: string },
+    logMessage: string
+  ): Promise<void> {
+    const blockText = `Message blocked by guardrail: ${trip.reason ?? trip.guardrail}`;
+    return this.postToPayloadTarget(payload, ctx, blockText, logMessage);
   }
 
   private async resolveTarget(

--- a/packages/server/src/gateway/connections/interaction-bridge.ts
+++ b/packages/server/src/gateway/connections/interaction-bridge.ts
@@ -1,4 +1,5 @@
 import { createLogger } from "@lobu/core";
+import { Actions, Button, Card, CardText, LinkButton } from "chat";
 import {
   type PendingToolInvocation,
 	takePendingTool,
@@ -263,12 +264,52 @@ export function registerInteractionBridge(
     pendingSentMessages.delete(questionId);
     return { question: stored.question, sent: cached?.sent };
   }
-  const onQuestionCreated = async (event: PostedQuestion) => {
-    try {
-      if (!shouldHandle(event, platform, connectionId, manager)) return;
-      if (handledEvents.has(event.id)) return;
-      markHandled(event.id);
 
+  /**
+   * Shared preamble for every InteractionService handler: platform/tenant
+   * guard, per-connection dedup (Slack retries the same webhook for up to
+   * 5min), thread resolution, and a catch-all so one handler's failure never
+   * escapes into the event emitter. `handler` runs only once per event id with
+   * a resolved thread; org/user sub-checks stay inline in each body.
+   */
+  function withResolvedThread<
+    E extends {
+      id: string;
+      channelId: string;
+      conversationId: string;
+      platform?: string;
+    },
+  >(
+    eventName: string,
+    handler: (event: E, thread: any) => Promise<void>,
+  ): (event: E) => Promise<void> {
+    return async (event: E) => {
+      try {
+        if (!shouldHandle(event, platform, connectionId, manager)) return;
+        if (handledEvents.has(event.id)) return;
+        markHandled(event.id);
+
+        const thread = await resolveThread(
+          manager,
+          connectionId,
+          event.channelId,
+          event.conversationId,
+        );
+        if (!thread) return;
+
+        await handler(event, thread);
+      } catch (error) {
+        logger.error(
+          { connectionId, error: String(error) },
+          `Unhandled error in ${eventName} handler`,
+        );
+      }
+    };
+  }
+
+  const onQuestionCreated = withResolvedThread<PostedQuestion>(
+    "question:created",
+    async (event, thread) => {
       // Cross-tenant scoping: every pending row must carry the bridge's
       // org. Without a known org we can't safely persist or claim, so
       // drop the event rather than write an un-scoped row.
@@ -287,14 +328,6 @@ export function registerInteractionBridge(
         );
         return;
       }
-
-      const thread = await resolveThread(
-        manager,
-        connectionId,
-        event.channelId,
-				event.conversationId,
-      );
-      if (!thread) return;
 
       // Persist the pending row BEFORE posting the card. If the persist
       // fails we never show buttons that would no-op on click. If the row
@@ -316,7 +349,6 @@ export function registerInteractionBridge(
         return;
       }
 
-      const { Card, CardText, Actions, Button } = await import("chat");
       const buttons = event.options.map((option, i) =>
         Button({
           id: `question:${event.id}:${i}`,
@@ -359,33 +391,16 @@ export function registerInteractionBridge(
         return;
       }
       rememberSentMessage(event.id, sent);
-    } catch (error) {
-      logger.error(
-        { connectionId, error: String(error) },
-				"Unhandled error in question:created handler",
-      );
-    }
-  };
+    },
+  );
 
-  const onToolApprovalNeeded = async (event: PostedToolApproval) => {
-    try {
-      if (!shouldHandle(event, platform, connectionId, manager)) return;
-      if (handledEvents.has(event.id)) return;
-      markHandled(event.id);
-
+  const onToolApprovalNeeded = withResolvedThread<PostedToolApproval>(
+    "tool:approval-needed",
+    async (event, thread) => {
       const argsText = formatToolArgs(event.args);
       const text = `Tool Approval\n${event.mcpId} → ${event.toolName}\n${argsText}`;
       const tid = event.id;
 
-      const thread = await resolveThread(
-        manager,
-        connectionId,
-        event.channelId,
-				event.conversationId,
-      );
-      if (!thread) return;
-
-      const { Card, CardText, Actions, Button } = await import("chat");
       const card = Card({
         children: [
           CardText(
@@ -428,29 +443,12 @@ export function registerInteractionBridge(
       if (sent) {
         trackApprovalCard(tid, sent);
       }
-    } catch (error) {
-      logger.error(
-        { connectionId, error: String(error) },
-				"Unhandled error in tool:approval-needed handler",
-      );
-    }
-  };
+    },
+  );
 
-  const onLinkButtonCreated = async (event: PostedLinkButton) => {
-    try {
-      if (!shouldHandle(event, platform, connectionId, manager)) return;
-      if (handledEvents.has(event.id)) return;
-      markHandled(event.id);
-
-      const thread = await resolveThread(
-        manager,
-        connectionId,
-        event.channelId,
-				event.conversationId,
-      );
-      if (!thread) return;
-
-      const { Card, CardText, Actions, LinkButton } = await import("chat");
+  const onLinkButtonCreated = withResolvedThread<PostedLinkButton>(
+    "link-button:created",
+    async (event, thread) => {
       const linkButton = LinkButton({
         url: event.url,
         label: event.label,
@@ -475,28 +473,12 @@ export function registerInteractionBridge(
         connectionId,
 				"link button interaction",
       );
-    } catch (error) {
-      logger.error(
-        { connectionId, error: String(error) },
-				"Unhandled error in link-button:created handler",
-      );
-    }
-  };
+    },
+  );
 
-  const onStatusMessageCreated = async (event: PostedStatusMessage) => {
-    try {
-      if (!shouldHandle(event, platform, connectionId, manager)) return;
-      if (handledEvents.has(event.id)) return;
-      markHandled(event.id);
-
-      const thread = await resolveThread(
-        manager,
-        connectionId,
-        event.channelId,
-				event.conversationId,
-      );
-      if (!thread) return;
-
+  const onStatusMessageCreated = withResolvedThread<PostedStatusMessage>(
+    "status-message:created",
+    async (event, thread) => {
       try {
         await thread.post(event.text);
       } catch (error) {
@@ -505,13 +487,8 @@ export function registerInteractionBridge(
 					"Failed to post status message interaction",
         );
       }
-    } catch (error) {
-      logger.error(
-        { connectionId, error: String(error) },
-				"Unhandled error in status-message:created handler",
-      );
-    }
-  };
+    },
+  );
 
   interactionService.on("question:created", onQuestionCreated);
   interactionService.on("tool:approval-needed", onToolApprovalNeeded);
@@ -582,7 +559,6 @@ export function registerInteractionBridge(
         // Visible "user submitted X" receipt so the click is acknowledged
         // in-thread even before the worker responds.
         try {
-          const { Card, CardText } = await import("chat");
           const card = Card({ children: [CardText(receiptText)] });
           await thread
             .post({ card, fallbackText: receiptText })

--- a/packages/server/src/gateway/connections/slack-connection-coordinator.ts
+++ b/packages/server/src/gateway/connections/slack-connection-coordinator.ts
@@ -1,4 +1,5 @@
 import { createLogger } from "@lobu/core";
+import { Chat } from "chat";
 import { isUniqueViolation } from "../../utils/pg-errors.js";
 import type { PlatformAdapterConfig, PlatformConnection } from "./types.js";
 import {
@@ -404,7 +405,6 @@ export class SlackConnectionCoordinator {
   }
 
   private async createOAuthChat(options?: { requireOAuth?: boolean }) {
-    const { Chat } = await import("chat");
     const { createSlackAdapter } = await import("@chat-adapter/slack");
 
     const adapter = createSlackAdapter(

--- a/packages/server/src/gateway/guardrails/builtins.ts
+++ b/packages/server/src/gateway/guardrails/builtins.ts
@@ -1,13 +1,11 @@
 import type {
   Guardrail,
-  GuardrailContext,
   GuardrailRegistry,
   GuardrailStage,
-  InputGuardrailContext,
   OutputGuardrailContext,
   PreToolGuardrailContext,
 } from "@lobu/core";
-import { safeStringify } from "./safe-stringify.js";
+import { extractStageText } from "./stage-text.js";
 
 /**
  * Built-in guardrails registered by the gateway at startup. Three primitives:
@@ -79,25 +77,6 @@ function scanForPii(text: string): { kind: string; match: string } | null {
   return scanCreditCard(text);
 }
 
-function extractTextForPii<S extends GuardrailStage>(
-  stage: S,
-  ctx: GuardrailContext[S]
-): string {
-  switch (stage) {
-    case "input":
-      return (ctx as InputGuardrailContext).message;
-    case "output":
-      return (ctx as OutputGuardrailContext).text;
-    case "pre-tool":
-      // safeStringify so BigInt / circular tool args don't throw — a thrown
-      // guardrail is treated as a pass by the runner, which silently weakens
-      // pii-scan exactly when the input is weird enough to deserve scrutiny.
-      return safeStringify((ctx as PreToolGuardrailContext).arguments);
-    default:
-      return "";
-  }
-}
-
 export function createPiiScanGuardrail<S extends GuardrailStage>(
   stage: S,
   name = "pii-scan"
@@ -106,7 +85,8 @@ export function createPiiScanGuardrail<S extends GuardrailStage>(
     name,
     stage,
     async run(ctx) {
-      const text = extractTextForPii(stage, ctx);
+      // pii-scan scans the tool arguments alone (no tool-name prefix).
+      const text = extractStageText(stage, ctx);
       const hit = scanForPii(text);
       if (!hit) return { tripped: false };
       return {

--- a/packages/server/src/gateway/guardrails/judge-factory.ts
+++ b/packages/server/src/gateway/guardrails/judge-factory.ts
@@ -1,14 +1,11 @@
 import { createHash } from "node:crypto";
 import type {
   Guardrail,
-  GuardrailContext,
   GuardrailStage,
-  InputGuardrailContext,
-  OutputGuardrailContext,
   PreToolGuardrailContext,
 } from "@lobu/core";
 import { TextJudge } from "../proxy/egress-judge/text-judge.js";
-import { safeStringify } from "./safe-stringify.js";
+import { extractStageText } from "./stage-text.js";
 
 /**
  * Lazily-constructed singleton TextJudge so multiple judge guardrails share
@@ -21,30 +18,6 @@ function getSharedJudge(): TextJudge {
   return sharedJudge;
 }
 
-/**
- * Extract the inspectable text from each stage's context. `pre-tool` has no
- * single text field, so we serialize the tool name + arguments so the judge
- * can reason about it.
- */
-function extractText<S extends GuardrailStage>(
-  stage: S,
-  ctx: GuardrailContext[S]
-): string {
-  switch (stage) {
-    case "input":
-      return (ctx as InputGuardrailContext).message;
-    case "output":
-      return (ctx as OutputGuardrailContext).text;
-    case "pre-tool": {
-      const c = ctx as PreToolGuardrailContext;
-      // safeStringify so BigInt / circular args don't throw — a thrown
-      // guardrail is treated as a pass by the runner.
-      return `tool: ${c.toolName}\narguments: ${safeStringify(c.arguments)}`;
-    }
-    default:
-      throw new Error(`Unknown guardrail stage: ${String(stage)}`);
-  }
-}
 
 /**
  * Short stable id for an inline judge — first 8 chars of
@@ -129,7 +102,12 @@ export function createJudgeGuardrail<S extends GuardrailStage>(
         }
       }
       const judge = options.judge ?? getSharedJudge();
-      const text = extractText(stage, ctx);
+      // Prefix `pre-tool` args with the tool name so the judge can reason
+      // about which tool is being called.
+      const text = extractStageText(stage, ctx, {
+        includeToolName: true,
+        throwOnUnknown: true,
+      });
       const verdict = await judge.decide(policy, text, { model: options.model });
       if (verdict.allow) {
         return { tripped: false };

--- a/packages/server/src/gateway/guardrails/stage-text.ts
+++ b/packages/server/src/gateway/guardrails/stage-text.ts
@@ -1,0 +1,51 @@
+import type {
+  GuardrailContext,
+  GuardrailStage,
+  InputGuardrailContext,
+  OutputGuardrailContext,
+  PreToolGuardrailContext,
+} from "@lobu/core";
+import { safeStringify } from "./safe-stringify.js";
+
+/**
+ * Extract the inspectable text from a guardrail stage's context. Shared by the
+ * built-in pii-scan and the judge-factory so the two never drift on what gets
+ * scanned per stage.
+ *
+ * `pre-tool` has no single text field, so the tool arguments are serialized.
+ * `safeStringify` is used so BigInt / circular tool args don't throw — a
+ * thrown guardrail is treated as a pass by the runner, which would silently
+ * weaken the check exactly when the input is weird enough to deserve scrutiny.
+ *
+ * `includeToolName` prefixes the serialized arguments with `tool: <name>` so a
+ * judge can reason about which tool is being called (the pii-scan path leaves
+ * it off and scans the arguments alone).
+ *
+ * `throwOnUnknown` controls the (statically unreachable) default branch: the
+ * judge path throws — failing open via the runner's error handling rather than
+ * silently scanning an empty string — while pii-scan returns "".
+ */
+export function extractStageText<S extends GuardrailStage>(
+  stage: S,
+  ctx: GuardrailContext[S],
+  options: { includeToolName?: boolean; throwOnUnknown?: boolean } = {}
+): string {
+  switch (stage) {
+    case "input":
+      return (ctx as InputGuardrailContext).message;
+    case "output":
+      return (ctx as OutputGuardrailContext).text;
+    case "pre-tool": {
+      const c = ctx as PreToolGuardrailContext;
+      const args = safeStringify(c.arguments);
+      return options.includeToolName
+        ? `tool: ${c.toolName}\narguments: ${args}`
+        : args;
+    }
+    default:
+      if (options.throwOnUnknown) {
+        throw new Error(`Unknown guardrail stage: ${String(stage)}`);
+      }
+      return "";
+  }
+}

--- a/packages/server/src/gateway/orchestration/base-deployment-manager.ts
+++ b/packages/server/src/gateway/orchestration/base-deployment-manager.ts
@@ -25,6 +25,7 @@ import {
   type WritableSecretStore,
 } from "../secrets/index.js";
 import { runInBatches } from "./deployment-utils.js";
+import { buildWorkerTokenClaims } from "./worker-token-claims.js";
 
 const logger = createLogger("orchestrator");
 
@@ -55,23 +56,12 @@ export function buildDeploymentWorkerToken(args: {
     args.conversationId,
     args.deploymentName,
     {
-      channelId: args.channelId,
-      teamId: args.teamId,
-      platform: args.platform,
-      agentId: args.agentId,
-      organizationId: args.organizationId,
-      connectionId:
-        typeof args.platformMetadata?.connectionId === "string"
-          ? args.platformMetadata.connectionId
-          : undefined,
-      // Headless run origin — mirror runJobToken so a worker that falls back
-      // to this deployment-lifetime token still stamps headless interaction
-      // cards instead of dead-lettering them behind the SSE-owner gate. Same
-      // omitted-claim class as the connectionId P0 (#1274).
-      source:
-        typeof args.platformMetadata?.source === "string"
-          ? args.platformMetadata.source
-          : undefined,
+      // Shared routing claims — kept in lockstep with the per-run mint via
+      // `buildWorkerTokenClaims` so a worker that falls back to this
+      // deployment-lifetime token carries the same connectionId/source and
+      // doesn't dead-letter its interaction cards (#1274).
+      ...buildWorkerTokenClaims(args),
+      // Deployment-token-specific claim.
       traceId: args.traceId,
     }
   );

--- a/packages/server/src/gateway/orchestration/message-consumer.ts
+++ b/packages/server/src/gateway/orchestration/message-consumer.ts
@@ -34,6 +34,7 @@ import {
   generateDeploymentName,
   type OrchestratorConfig,
 } from "./base-deployment-manager.js";
+import { buildWorkerTokenClaims } from "./worker-token-claims.js";
 
 const logger = createLogger("orchestrator");
 
@@ -77,26 +78,13 @@ export function buildRunJobToken(args: {
     args.conversationId,
     args.deploymentName,
     {
-      channelId: args.channelId,
-      teamId: args.teamId,
-      agentId: args.agentId,
-      organizationId: args.organizationId,
-      platform: args.platform,
-      // PRIMARY auth → must carry connectionId, or interaction posts
-      // (ask_user / tool approval / link button) hit
-      // `assertRoutableInteraction`, which rejects a chat-platform
-      // interaction with no connectionId, and every ask_user 500s (#1274).
-      connectionId:
-        typeof args.platformMetadata?.connectionId === "string"
-          ? args.platformMetadata.connectionId
-          : undefined,
-      // Headless run origin → interaction cards from this turn are stamped
-      // headless and skip the SSE-owner gate (no browser SSE exists on any
-      // pod for a headless run, so an owner-gated card dead-letters).
-      source:
-        typeof args.platformMetadata?.source === "string"
-          ? args.platformMetadata.source
-          : undefined,
+      // PRIMARY auth → shared routing claims (channelId, teamId, platform,
+      // agentId, organizationId, connectionId, source) are minted via
+      // `buildWorkerTokenClaims`, kept in lockstep with the deployment-token
+      // mint. connectionId in particular MUST be present or interaction posts
+      // hit `assertRoutableInteraction` and every ask_user 500s (#1274).
+      ...buildWorkerTokenClaims(args),
+      // Per-run-token-specific claims.
       runId: args.runId,
       messageId: args.messageId,
     }

--- a/packages/server/src/gateway/orchestration/worker-token-claims.ts
+++ b/packages/server/src/gateway/orchestration/worker-token-claims.ts
@@ -1,0 +1,62 @@
+/**
+ * Shared claim extraction for the two worker-token mints — the per-run
+ * `runJobToken` (message-consumer) and the deployment-lifetime `WORKER_TOKEN`
+ * (base-deployment-manager). Both read the SAME routing claims off the message;
+ * the #1274 P0 was an omitted-claim divergence between exactly these two mints
+ * (the per-run mint dropped `connectionId`, so every chat `ask_user` 500'd at
+ * `assertRoutableInteraction`).
+ *
+ * Keeping the common bag here makes that parity invariant structural: any
+ * routing claim a downstream consumer reads off the verified token
+ * (channelId, teamId, platform, agentId, organizationId, connectionId, source)
+ * is set in ONE place for both mints. Mint-specific claims (runId+messageId for
+ * the per-run token, traceId for the deployment token) stay with each caller.
+ */
+export interface WorkerTokenClaimsArgs {
+  channelId: string;
+  teamId?: string;
+  agentId?: string;
+  organizationId?: string;
+  platform?: string;
+  platformMetadata?: Record<string, unknown>;
+}
+
+/**
+ * The routing claims common to both worker-token mints, in the exact shape the
+ * `generateWorkerToken` options object expects. `connectionId` and `source` are
+ * lifted off `platformMetadata` (string-guarded — both default to `undefined`
+ * when absent or non-string).
+ *
+ * `connectionId`: PRIMARY/fallback auth must carry it or interaction posts
+ * (ask_user / tool approval / link button) hit `assertRoutableInteraction`,
+ * which rejects a chat-platform interaction with no connectionId (#1274).
+ *
+ * `source`: headless run origin — interaction cards from this turn are stamped
+ * headless and skip the SSE-owner gate (no browser SSE exists on any pod for a
+ * headless run, so an owner-gated card would dead-letter).
+ */
+export function buildWorkerTokenClaims(args: WorkerTokenClaimsArgs): {
+  channelId: string;
+  teamId?: string;
+  agentId?: string;
+  organizationId?: string;
+  platform?: string;
+  connectionId?: string;
+  source?: string;
+} {
+  return {
+    channelId: args.channelId,
+    teamId: args.teamId,
+    agentId: args.agentId,
+    organizationId: args.organizationId,
+    platform: args.platform,
+    connectionId:
+      typeof args.platformMetadata?.connectionId === "string"
+        ? args.platformMetadata.connectionId
+        : undefined,
+    source:
+      typeof args.platformMetadata?.source === "string"
+        ? args.platformMetadata.source
+        : undefined,
+  };
+}

--- a/packages/server/src/gateway/proxy/egress-judge/judge-runner.ts
+++ b/packages/server/src/gateway/proxy/egress-judge/judge-runner.ts
@@ -1,0 +1,213 @@
+import { createLogger } from "@lobu/core";
+import { AnthropicJudgeClient } from "./anthropic-client.js";
+import { VerdictCache } from "./cache.js";
+import { CircuitBreaker } from "./circuit-breaker.js";
+import type { JudgeClient, JudgeVerdict } from "./types.js";
+import {
+  DEFAULT_JUDGE_MODEL,
+  DEFAULT_JUDGE_TIMEOUT_MS,
+  JudgeTimeoutError,
+  envTimeoutMs,
+  withTimeout,
+} from "./judge-utils.js";
+
+/**
+ * Shared tuning knobs for any judge runner. Both the egress judge and the
+ * text judge wrap a {@link JudgeClient} with the same verdict cache + circuit
+ * breaker + per-call timeout shape; the defaults live here so the two stay in
+ * sync when these values change.
+ */
+export interface JudgeRunnerOptions {
+  client?: JudgeClient;
+  defaultModel?: string;
+  cacheTtlMs?: number;
+  cacheMaxEntries?: number;
+  breakerFailureThreshold?: number;
+  breakerCooldownMs?: number;
+  judgeTimeoutMs?: number;
+}
+
+/**
+ * Per-runner labels for the (otherwise identical) log lines and fail-closed
+ * verdict reasons. The egress judge and text judge differ only in a name
+ * prefix, the em-dash vs `--` separator, and `request denied` vs `denied`.
+ */
+export interface JudgeRunnerLabels {
+  /** Logger name + the human prefix used in log messages, e.g. "egress-judge" / "Egress judge". */
+  loggerName: string;
+  logPrefix: string;
+  /** Separator in the "<prefix> circuit open <sep> failing closed" lines. */
+  separator: string;
+  /** Suffix appended to the fail-closed reason, e.g. "request denied" or "denied". */
+  deniedSuffix: string;
+}
+
+/**
+ * Everything {@link JudgeRunner.run} needs to evaluate a single decision. The
+ * three seams (cache key, prompts, result decoration) are supplied per-call so
+ * the egress judge and text judge can share the cache/breaker/timeout/dedup
+ * machinery while keeping their own key composition, prompt harness, and
+ * return shape.
+ */
+export interface JudgeRunInput<TResult> {
+  /** Tenant/policy-scoped verdict cache key. */
+  cacheKey: string;
+  /** Circuit-breaker key — trips independently per policy. */
+  policyHash: string;
+  /** Model override for this call; falls back to the runner default. */
+  model?: string;
+  /**
+   * Extra structured fields the subclass wants in its warn/error logs
+   * (e.g. `hostname` for egress). Merged into the fail-closed log records.
+   */
+  logFields?: Record<string, unknown>;
+  /** Prompts handed to the underlying {@link JudgeClient}. */
+  buildPrompts(): { systemPrompt: string; userPrompt: string };
+  /**
+   * Shape the verdict into the caller's result type. `source` distinguishes a
+   * cache hit, a live judge call, a circuit-open fail-closed, and a
+   * judge-error fail-closed so callers can emit accurate audit data.
+   * `latencyMs` is the live call latency (0 for cache/circuit-open).
+   */
+  decorate(
+    verdict: JudgeVerdict,
+    meta: {
+      source: "judge" | "cache" | "circuit-open" | "judge-error";
+      latencyMs: number;
+    }
+  ): TResult;
+}
+
+/**
+ * Generic judge runner: a {@link JudgeClient} fronted by a per-policy verdict
+ * cache, a circuit breaker, an in-flight dedup map, and a per-call timeout.
+ *
+ * Subclasses expose their own `decide(...)` surface and translate it into a
+ * {@link JudgeRunInput} passed to {@link run}. The control flow (cache → dedup
+ * → breaker → timeout → fail-closed deny) and the fail-closed verdict payloads
+ * are owned here so the two judges can't drift on their security-critical
+ * paths.
+ *
+ * Thread-safety: single-threaded Node event loop; no locks. Concurrent calls
+ * with the same cache key are coalesced via the in-flight map.
+ */
+export abstract class JudgeRunner<TResult> {
+  private readonly cache: VerdictCache;
+  private readonly breaker: CircuitBreaker;
+  private readonly defaultModel: string;
+  private readonly judgeTimeoutMs: number;
+  private readonly inFlight = new Map<string, Promise<TResult>>();
+  private readonly logger: ReturnType<typeof createLogger>;
+  private readonly labels: JudgeRunnerLabels;
+  private _client: JudgeClient | undefined;
+
+  constructor(labels: JudgeRunnerLabels, options: JudgeRunnerOptions = {}) {
+    this.labels = labels;
+    this.logger = createLogger(labels.loggerName);
+    this.cache = new VerdictCache(
+      options.cacheTtlMs ?? 5 * 60_000,
+      options.cacheMaxEntries ?? 2000
+    );
+    this.breaker = new CircuitBreaker(
+      options.breakerFailureThreshold ?? 5,
+      options.breakerCooldownMs ?? 30_000
+    );
+    this.defaultModel = options.defaultModel ?? DEFAULT_JUDGE_MODEL;
+    this.judgeTimeoutMs =
+      options.judgeTimeoutMs ?? envTimeoutMs() ?? DEFAULT_JUDGE_TIMEOUT_MS;
+    this._client = options.client;
+  }
+
+  /**
+   * Defer client construction until the first call so callers with no judge
+   * rules/guardrails never require ANTHROPIC_API_KEY.
+   */
+  private get client(): JudgeClient {
+    if (!this._client) {
+      this._client = new AnthropicJudgeClient();
+    }
+    return this._client;
+  }
+
+  /**
+   * Cache lookup → in-flight dedup → live judge call. Returns the decorated
+   * result. Cache hits and dedup'd concurrent calls reuse the shared machinery;
+   * a live call goes through {@link runLiveJudge}.
+   */
+  protected async run(input: JudgeRunInput<TResult>): Promise<TResult> {
+    const cached = this.cache.get(input.cacheKey);
+    if (cached) {
+      return input.decorate(cached, { source: "cache", latencyMs: 0 });
+    }
+
+    const existing = this.inFlight.get(input.cacheKey);
+    if (existing) return existing;
+
+    const pending = this.runLiveJudge(input).finally(() => {
+      this.inFlight.delete(input.cacheKey);
+    });
+    this.inFlight.set(input.cacheKey, pending);
+    return pending;
+  }
+
+  /**
+   * Single live judge call: breaker gate → timeout-bounded client call →
+   * cache + decorate. Fails closed (deny) on an open circuit or any error,
+   * recording a breaker failure in the latter case.
+   */
+  private async runLiveJudge(input: JudgeRunInput<TResult>): Promise<TResult> {
+    const { logPrefix, separator, deniedSuffix } = this.labels;
+
+    if (!this.breaker.canProceed(input.policyHash)) {
+      this.logger.warn(`${logPrefix} circuit open ${separator} failing closed`, {
+        policyHash: input.policyHash,
+        ...input.logFields,
+      });
+      return input.decorate(
+        {
+          verdict: "deny",
+          reason: `Judge unavailable (circuit breaker open); ${deniedSuffix}`,
+        },
+        { source: "circuit-open", latencyMs: 0 }
+      );
+    }
+
+    const started = Date.now();
+    const model = input.model ?? this.defaultModel;
+    const { systemPrompt, userPrompt } = input.buildPrompts();
+    try {
+      const verdict = await withTimeout(
+        this.client.judge({ model, systemPrompt, userPrompt }),
+        this.judgeTimeoutMs
+      );
+      const latencyMs = Date.now() - started;
+      this.breaker.onSuccess(input.policyHash);
+      this.cache.set(input.cacheKey, verdict);
+      return input.decorate(verdict, { source: "judge", latencyMs });
+    } catch (err) {
+      this.breaker.onFailure(input.policyHash);
+      const timedOut = err instanceof JudgeTimeoutError;
+      this.logger.error(
+        timedOut
+          ? `${logPrefix} call timed out ${separator} failing closed`
+          : `${logPrefix} call failed ${separator} failing closed`,
+        {
+          policyHash: input.policyHash,
+          ...input.logFields,
+          model,
+          timeoutMs: timedOut ? this.judgeTimeoutMs : undefined,
+          error: err instanceof Error ? err.message : String(err),
+        }
+      );
+      return input.decorate(
+        {
+          verdict: "deny",
+          reason: timedOut
+            ? `Judge call timed out; ${deniedSuffix}`
+            : `Judge call failed; ${deniedSuffix}`,
+        },
+        { source: "judge-error", latencyMs: Date.now() - started }
+      );
+    }
+  }
+}

--- a/packages/server/src/gateway/proxy/egress-judge/judge.ts
+++ b/packages/server/src/gateway/proxy/egress-judge/judge.ts
@@ -1,38 +1,8 @@
-import { createLogger } from "@lobu/core";
 import type { ResolvedJudgeRule } from "../../permissions/policy-store.js";
-import { AnthropicJudgeClient } from "./anthropic-client.js";
 import { VerdictCache } from "./cache.js";
-import { CircuitBreaker } from "./circuit-breaker.js";
+import { JudgeRunner, type JudgeRunnerOptions } from "./judge-runner.js";
 import { buildSystemPrompt, buildUserPrompt } from "./policy-composer.js";
-import type { JudgeClient, JudgeDecision, JudgeRequest } from "./types.js";
-import {
-  DEFAULT_JUDGE_MODEL,
-  DEFAULT_JUDGE_TIMEOUT_MS,
-  JudgeTimeoutError,
-  envTimeoutMs,
-  withTimeout,
-} from "./judge-utils.js";
-
-const logger = createLogger("egress-judge");
-
-interface EgressJudgeOptions {
-  client?: JudgeClient;
-  /** Judge model identifier (overridable per-agent via `egressConfig.judgeModel`). */
-  defaultModel?: string;
-  /** Verdict cache TTL. Default: 5 min. */
-  cacheTtlMs?: number;
-  /** Max verdict cache entries. Default: 2000. */
-  cacheMaxEntries?: number;
-  /** Consecutive-failure threshold before the circuit trips. Default: 5. */
-  breakerFailureThreshold?: number;
-  /** Cooldown before the circuit half-opens again. Default: 30s. */
-  breakerCooldownMs?: number;
-  /**
-   * Per-call timeout. Default: `EGRESS_JUDGE_TIMEOUT_MS` env or 8s. On
-   * expiry the verdict fails closed and the breaker records a failure.
-   */
-  judgeTimeoutMs?: number;
-}
+import type { JudgeDecision, JudgeRequest } from "./types.js";
 
 /**
  * Egress judge: wraps a JudgeClient with a per-policy verdict cache and
@@ -40,41 +10,21 @@ interface EgressJudgeOptions {
  * request.
  *
  * Thread-safety: single-threaded Node event loop; no locks needed. The
- * in-flight dedup map coalesces concurrent judge calls for the same
- * cache key so a burst of identical requests costs exactly one API call.
+ * in-flight dedup map (owned by {@link JudgeRunner}) coalesces concurrent
+ * judge calls for the same cache key so a burst of identical requests costs
+ * exactly one API call.
  */
-export class EgressJudge {
-  private readonly cache: VerdictCache;
-  private readonly breaker: CircuitBreaker;
-  private readonly inFlight = new Map<string, Promise<JudgeDecision>>();
-  private readonly defaultModel: string;
-  private readonly judgeTimeoutMs: number;
-  private _client: JudgeClient | undefined;
-
-  constructor(options: EgressJudgeOptions = {}) {
-    this.cache = new VerdictCache(
-      options.cacheTtlMs ?? 5 * 60_000,
-      options.cacheMaxEntries ?? 2000
+export class EgressJudge extends JudgeRunner<JudgeDecision> {
+  constructor(options: JudgeRunnerOptions = {}) {
+    super(
+      {
+        loggerName: "egress-judge",
+        logPrefix: "Egress judge",
+        separator: "—",
+        deniedSuffix: "request denied",
+      },
+      options
     );
-    this.breaker = new CircuitBreaker(
-      options.breakerFailureThreshold ?? 5,
-      options.breakerCooldownMs ?? 30_000
-    );
-    this.defaultModel = options.defaultModel ?? DEFAULT_JUDGE_MODEL;
-    this.judgeTimeoutMs =
-      options.judgeTimeoutMs ?? envTimeoutMs() ?? DEFAULT_JUDGE_TIMEOUT_MS;
-    this._client = options.client;
-  }
-
-  /**
-   * Defer Anthropic client construction until the first judge call so
-   * gateways with no `judge`-action rules never require ANTHROPIC_API_KEY.
-   */
-  private get client(): JudgeClient {
-    if (!this._client) {
-      this._client = new AnthropicJudgeClient();
-    }
-    return this._client;
   }
 
   async decide(
@@ -89,94 +39,23 @@ export class EgressJudge {
       path: request.path,
     });
 
-    const cached = this.cache.get(cacheKey);
-    if (cached) {
-      return {
-        ...cached,
-        source: "cache",
-        latencyMs: 0,
-        policyHash: rule.policyHash,
-        judgeName: rule.judgeName,
-      };
-    }
-
-    const existing = this.inFlight.get(cacheKey);
-    if (existing) return existing;
-
-    const pending = this.runJudge(request, rule, cacheKey).finally(() => {
-      this.inFlight.delete(cacheKey);
-    });
-    this.inFlight.set(cacheKey, pending);
-    return pending;
-  }
-
-  private async runJudge(
-    request: JudgeRequest,
-    rule: ResolvedJudgeRule,
-    cacheKey: string
-  ): Promise<JudgeDecision> {
-    if (!this.breaker.canProceed(rule.policyHash)) {
-      logger.warn("Egress judge circuit open — failing closed", {
-        policyHash: rule.policyHash,
-        hostname: request.hostname,
-      });
-      return {
-        verdict: "deny",
-        reason: "Judge unavailable (circuit breaker open); request denied",
-        source: "circuit-open",
-        latencyMs: 0,
-        policyHash: rule.policyHash,
-        judgeName: rule.judgeName,
-      };
-    }
-
-    const started = Date.now();
-    const model = rule.judgeModel ?? this.defaultModel;
-    try {
-      const verdict = await withTimeout(
-        this.client.judge({
-          model,
-          systemPrompt: buildSystemPrompt(),
-          userPrompt: buildUserPrompt({ policy: rule.policy, request }),
-        }),
-        this.judgeTimeoutMs
-      );
-      const latencyMs = Date.now() - started;
-      this.breaker.onSuccess(rule.policyHash);
-      this.cache.set(cacheKey, verdict);
-      return {
+    return this.run({
+      cacheKey,
+      policyHash: rule.policyHash,
+      // Per-agent model override via `egressConfig.judgeModel`.
+      model: rule.judgeModel,
+      logFields: { hostname: request.hostname },
+      buildPrompts: () => ({
+        systemPrompt: buildSystemPrompt(),
+        userPrompt: buildUserPrompt({ policy: rule.policy, request }),
+      }),
+      decorate: (verdict, meta) => ({
         ...verdict,
-        source: "judge",
-        latencyMs,
+        source: meta.source,
+        latencyMs: meta.latencyMs,
         policyHash: rule.policyHash,
         judgeName: rule.judgeName,
-      };
-    } catch (err) {
-      this.breaker.onFailure(rule.policyHash);
-      const timedOut = err instanceof JudgeTimeoutError;
-      logger.error(
-        timedOut
-          ? "Egress judge call timed out — failing closed"
-          : "Egress judge call failed — failing closed",
-        {
-          policyHash: rule.policyHash,
-          hostname: request.hostname,
-          model,
-          timeoutMs: timedOut ? this.judgeTimeoutMs : undefined,
-          error: err instanceof Error ? err.message : String(err),
-        }
-      );
-      return {
-        verdict: "deny",
-        reason: timedOut
-          ? "Judge call timed out; request denied"
-          : "Judge call failed; request denied",
-        source: "judge-error",
-        latencyMs: Date.now() - started,
-        policyHash: rule.policyHash,
-        judgeName: rule.judgeName,
-      };
-    }
+      }),
+    });
   }
-
 }

--- a/packages/server/src/gateway/proxy/egress-judge/text-judge.ts
+++ b/packages/server/src/gateway/proxy/egress-judge/text-judge.ts
@@ -1,18 +1,6 @@
 import { createHash } from "node:crypto";
-import { createLogger } from "@lobu/core";
-import { AnthropicJudgeClient } from "./anthropic-client.js";
 import { VerdictCache } from "./cache.js";
-import { CircuitBreaker } from "./circuit-breaker.js";
-import type { JudgeClient, JudgeVerdict } from "./types.js";
-import {
-  DEFAULT_JUDGE_MODEL,
-  DEFAULT_JUDGE_TIMEOUT_MS,
-  JudgeTimeoutError,
-  envTimeoutMs,
-  withTimeout,
-} from "./judge-utils.js";
-
-const logger = createLogger("text-judge");
+import { JudgeRunner, type JudgeRunnerOptions } from "./judge-runner.js";
 
 /**
  * Separator between policy and text when hashing the cache key. ASCII 0x1F
@@ -56,58 +44,26 @@ function hashPolicy(policy: string): string {
   return createHash("sha256").update(policy).digest("hex");
 }
 
-interface TextJudgeOptions {
-  client?: JudgeClient;
-  defaultModel?: string;
-  cacheTtlMs?: number;
-  cacheMaxEntries?: number;
-  breakerFailureThreshold?: number;
-  breakerCooldownMs?: number;
-  judgeTimeoutMs?: number;
-}
-
 /**
  * Reusable text judge: takes a policy + a chunk of text and returns
- * `{ allow, reason }`. Shares the same Anthropic client, verdict cache and
- * circuit breaker shape as the egress judge -- the cache is scoped to text
- * judges (separate instance) so verdicts from request-shaped requests can't
- * satisfy text-shaped ones.
+ * `{ allow, reason }`. Shares the cache/breaker/timeout/dedup machinery with
+ * the egress judge via {@link JudgeRunner} -- the cache is a separate instance
+ * so verdicts from request-shaped requests can't satisfy text-shaped ones.
  *
  * Single-threaded Node event loop; no locks. Concurrent calls for the same
- * `(policy, text)` are deduped via the in-flight map.
+ * `(policy, text)` are deduped via the runner's in-flight map.
  */
-export class TextJudge {
-  private readonly cache: VerdictCache;
-  private readonly breaker: CircuitBreaker;
-  private readonly inFlight = new Map<string, Promise<JudgeVerdict>>();
-  private readonly defaultModel: string;
-  private readonly judgeTimeoutMs: number;
-  private _client: JudgeClient | undefined;
-
-  constructor(options: TextJudgeOptions = {}) {
-    this.cache = new VerdictCache(
-      options.cacheTtlMs ?? 5 * 60_000,
-      options.cacheMaxEntries ?? 2000
+export class TextJudge extends JudgeRunner<{ allow: boolean; reason: string }> {
+  constructor(options: JudgeRunnerOptions = {}) {
+    super(
+      {
+        loggerName: "text-judge",
+        logPrefix: "Text judge",
+        separator: "--",
+        deniedSuffix: "denied",
+      },
+      options
     );
-    this.breaker = new CircuitBreaker(
-      options.breakerFailureThreshold ?? 5,
-      options.breakerCooldownMs ?? 30_000
-    );
-    this.defaultModel = options.defaultModel ?? DEFAULT_JUDGE_MODEL;
-    this.judgeTimeoutMs =
-      options.judgeTimeoutMs ?? envTimeoutMs() ?? DEFAULT_JUDGE_TIMEOUT_MS;
-    this._client = options.client;
-  }
-
-  /**
-   * Defer client construction until first call so callers with no judge
-   * guardrails never require ANTHROPIC_API_KEY.
-   */
-  private get client(): JudgeClient {
-    if (!this._client) {
-      this._client = new AnthropicJudgeClient();
-    }
-    return this._client;
   }
 
   /**
@@ -135,80 +91,18 @@ export class TextJudge {
       hostname: hashTextJudgeKey(policy, text),
     });
 
-    const cached = this.cache.get(cacheKey);
-    if (cached) {
-      return { allow: cached.verdict === "allow", reason: cached.reason };
-    }
-
-    const existing = this.inFlight.get(cacheKey);
-    if (existing) {
-      const v = await existing;
-      return { allow: v.verdict === "allow", reason: v.reason };
-    }
-
-    const pending = this.runJudge(
-      policy,
-      text,
-      policyHash,
+    return this.run({
       cacheKey,
-      options
-    ).finally(() => {
-      this.inFlight.delete(cacheKey);
+      policyHash,
+      model: options.model,
+      buildPrompts: () => ({
+        systemPrompt: TEXT_JUDGE_SYSTEM_PROMPT,
+        userPrompt: buildUserPrompt(policy, text),
+      }),
+      decorate: (verdict) => ({
+        allow: verdict.verdict === "allow",
+        reason: verdict.reason,
+      }),
     });
-    this.inFlight.set(cacheKey, pending);
-    const v = await pending;
-    return { allow: v.verdict === "allow", reason: v.reason };
   }
-
-  private async runJudge(
-    policy: string,
-    text: string,
-    policyHash: string,
-    cacheKey: string,
-    options: { model?: string }
-  ): Promise<JudgeVerdict> {
-    if (!this.breaker.canProceed(policyHash)) {
-      logger.warn("Text judge circuit open -- failing closed", { policyHash });
-      return {
-        verdict: "deny",
-        reason: "Judge unavailable (circuit breaker open); denied",
-      };
-    }
-
-    const model = options.model ?? this.defaultModel;
-    try {
-      const verdict = await withTimeout(
-        this.client.judge({
-          model,
-          systemPrompt: TEXT_JUDGE_SYSTEM_PROMPT,
-          userPrompt: buildUserPrompt(policy, text),
-        }),
-        this.judgeTimeoutMs
-      );
-      this.breaker.onSuccess(policyHash);
-      this.cache.set(cacheKey, verdict);
-      return verdict;
-    } catch (err) {
-      this.breaker.onFailure(policyHash);
-      const timedOut = err instanceof JudgeTimeoutError;
-      logger.error(
-        timedOut
-          ? "Text judge call timed out -- failing closed"
-          : "Text judge call failed -- failing closed",
-        {
-          policyHash,
-          model,
-          timeoutMs: timedOut ? this.judgeTimeoutMs : undefined,
-          error: err instanceof Error ? err.message : String(err),
-        }
-      );
-      return {
-        verdict: "deny",
-        reason: timedOut
-          ? "Judge call timed out; denied"
-          : "Judge call failed; denied",
-      };
-    }
-  }
-
 }

--- a/packages/server/src/gateway/proxy/secret-proxy.ts
+++ b/packages/server/src/gateway/proxy/secret-proxy.ts
@@ -241,6 +241,20 @@ function safeDecodePathSegment(value: string | undefined): string | undefined {
 }
 
 /**
+ * Parse the token out of a `Bearer <token>` authorization header. Returns the
+ * token (possibly empty string for `"Bearer "`) when the header is a
+ * well-formed two-part bearer, else null. Case-insensitive on the scheme.
+ */
+function parseBearer(authHeader: string | undefined): string | null {
+  if (!authHeader) return null;
+  const parts = authHeader.split(" ");
+  if (parts.length === 2 && parts[0]?.toLowerCase() === "bearer") {
+    return parts[1] ?? null;
+  }
+  return null;
+}
+
+/**
  * Walk the documented provider-credential resolution chain
  * (provider-secrets.ts) at the egress proxy:
  *   1. per-user auth profile credential (resolved by the caller)
@@ -455,69 +469,64 @@ export class SecretProxy {
   }
 
   /**
-   * Extract the worker token from a dedicated `x-lobu-worker-token` header
-   * (or query param of the same name — useful for SSE that can't set
-   * headers), verify it, and return the bound `organizationId`. Falls back
-   * to verifying the bearer credential when it isn't a placeholder.
-   *
-   * Returns `undefined` when no verifiable token is present — the caller
-   * then relies on `agentOrgResolver` (DB lookup keyed by URL agentId) to
-   * fill in the expected org.
+   * The dedicated worker-token string: `x-lobu-worker-token` header (either
+   * casing) or the `worker_token` query param (used by SSE callers that can't
+   * set headers). Returns undefined when neither is present.
    */
+  private getWorkerTokenString(c: Context): string | undefined {
+    const header =
+      c.req.header("x-lobu-worker-token") ||
+      c.req.header("X-Lobu-Worker-Token");
+    return header || c.req.query("worker_token") || undefined;
+  }
+
+  /**
+   * Verified worker-token claims in resolution order: the dedicated
+   * worker-token first, then the `authorization: Bearer` credential WHEN it
+   * isn't a `lobu_secret_<uuid>` placeholder (the bearer is normally a
+   * placeholder, but legacy callers pass the worker JWT directly). Each entry
+   * is the decoded payload; callers read the first that carries the field they
+   * need, preserving the original per-field fallback precedence.
+   */
+  private verifiedWorkerClaims(
+    c: Context
+  ): Array<NonNullable<ReturnType<typeof verifyWorkerToken>>> {
+    const out: Array<NonNullable<ReturnType<typeof verifyWorkerToken>>> = [];
+    const candidate = this.getWorkerTokenString(c);
+    if (candidate) {
+      const data = verifyWorkerToken(candidate);
+      if (data) out.push(data);
+    }
+    const tok = parseBearer(c.req.header("authorization"));
+    if (tok && !tok.includes(PLACEHOLDER_PREFIX)) {
+      const data = verifyWorkerToken(tok);
+      if (data) out.push(data);
+    }
+    return out;
+  }
+
   /**
    * Stable, non-spoofable identity for abuse-tracking, taken from the SIGNED
    * worker token (agentId, else deployment). Returns undefined when no valid
    * token is present so the caller can fall back to a weaker signal.
    */
   private extractWorkerTokenIdentity(c: Context): string | undefined {
-    const header =
-      c.req.header("x-lobu-worker-token") ||
-      c.req.header("X-Lobu-Worker-Token");
-    const candidate = header || c.req.query("worker_token") || undefined;
-    const fromToken = (data: ReturnType<typeof verifyWorkerToken>) =>
-      data?.agentId ?? data?.deploymentName ?? undefined;
-    if (candidate) {
-      const id = fromToken(verifyWorkerToken(candidate));
+    for (const data of this.verifiedWorkerClaims(c)) {
+      const id = data.agentId ?? data.deploymentName ?? undefined;
       if (id) return id;
-    }
-    const auth = c.req.header("authorization");
-    if (auth) {
-      const parts = auth.split(" ");
-      const tok =
-        parts.length === 2 && parts[0]?.toLowerCase() === "bearer"
-          ? parts[1]
-          : null;
-      if (tok && !tok.includes(PLACEHOLDER_PREFIX)) {
-        const id = fromToken(verifyWorkerToken(tok));
-        if (id) return id;
-      }
     }
     return undefined;
   }
 
+  /**
+   * The `organizationId` bound into the SIGNED worker token. Returns undefined
+   * when no verifiable token carries one — the caller then relies on
+   * `agentOrgResolver` (DB lookup keyed by URL agentId) to fill in the
+   * expected org.
+   */
   private extractWorkerTokenOrg(c: Context): string | undefined {
-    const header =
-      c.req.header("x-lobu-worker-token") ||
-      c.req.header("X-Lobu-Worker-Token");
-    const candidate = header || c.req.query("worker_token") || undefined;
-    if (candidate) {
-      const data = verifyWorkerToken(candidate);
-      if (data?.organizationId) return data.organizationId;
-    }
-    // The bearer credential is normally a `lobu_secret_<uuid>` placeholder
-    // but legacy callers may pass the worker JWT directly. Verify if it
-    // looks like one (long, no placeholder prefix).
-    const auth = c.req.header("authorization");
-    if (auth) {
-      const parts = auth.split(" ");
-      const tok =
-        parts.length === 2 && parts[0]?.toLowerCase() === "bearer"
-          ? parts[1]
-          : null;
-      if (tok && !tok.includes(PLACEHOLDER_PREFIX)) {
-        const data = verifyWorkerToken(tok);
-        if (data?.organizationId) return data.organizationId;
-      }
+    for (const data of this.verifiedWorkerClaims(c)) {
+      if (data.organizationId) return data.organizationId;
     }
     return undefined;
   }
@@ -531,11 +540,7 @@ export class SecretProxy {
     if (apiKey) return apiKey;
     const auth = c.req.header("authorization");
     if (!auth) return null;
-    const parts = auth.split(" ");
-    if (parts.length === 2 && parts[0]?.toLowerCase() === "bearer") {
-      return parts[1] ?? null;
-    }
-    return auth;
+    return parseBearer(auth) ?? auth;
   }
 
   /**
@@ -699,9 +704,7 @@ export class SecretProxy {
         // provider-credential path below, which injects the URL agent's real
         // key). The token already carries the agentId it was minted for.
         const workerTokenStr =
-          c.req.header("x-lobu-worker-token") ||
-          c.req.header("X-Lobu-Worker-Token") ||
-          c.req.query("worker_token") ||
+          this.getWorkerTokenString(c) ||
           (!callerToken.includes(PLACEHOLDER_PREFIX)
             ? callerToken
             : undefined);
@@ -863,10 +866,10 @@ export class SecretProxy {
 
       const auth = c.req.header("authorization");
       if (auth) {
-        const parts = auth.split(" ");
-        if (parts.length === 2 && parts[0]?.toLowerCase() === "bearer") {
+        const bearer = parseBearer(auth);
+        if (bearer !== null) {
           const swapped = await this.swap(
-            parts[1]!,
+            bearer,
             source,
             expectedOrganizationId
           );

--- a/packages/server/src/gateway/routes/public/agent-config.ts
+++ b/packages/server/src/gateway/routes/public/agent-config.ts
@@ -10,6 +10,7 @@ import type {
   ModelOption,
   SkillConfig,
 } from "@lobu/core";
+import type { Context } from "hono";
 import type { ProviderCatalogService } from "../../auth/provider-catalog.js";
 import { collectProviderModelOptions } from "../../auth/provider-model-options.js";
 
@@ -35,12 +36,15 @@ import {
   type ModelProviderModule,
 } from "../../modules/module-system.js";
 import type { GrantStore } from "../../permissions/grant-store.js";
-import { errorResponse } from "../shared/helpers.js";
 import { createTokenVerifier } from "../shared/agent-ownership.js";
+import { errorResponse } from "../shared/helpers.js";
+import {
+  ErrorResponseSchema,
+  errorResponses,
+} from "../shared/openapi-responses.js";
 import { verifySettingsSessionOrToken } from "./settings-auth.js";
 
 const TAG = "Configuration";
-const ErrorResponse = z.object({ error: z.string() });
 const TokenQuery = z.object({ token: z.string().optional() });
 const REDACTED_VALUE = "__LOBU_REDACTED__";
 
@@ -64,10 +68,9 @@ const getConfigRoute = createRoute({
         },
       },
     },
-    401: {
-      description: "Unauthorized",
-      content: { "application/json": { schema: ErrorResponse } },
-    },
+    ...errorResponses(ErrorResponseSchema, {
+      401: "Unauthorized",
+    }),
   },
 });
 
@@ -352,10 +355,27 @@ export function createAgentConfigRoutes(
     };
   };
 
-  app.openapi(getConfigRoute, async (c): Promise<any> => {
+  /**
+   * Resolve the `agentId` path param and verify the settings session/token for
+   * it. Returns the verified payload plus agentId, or a 401 Response to
+   * early-return. Collapses the identical preamble every config handler ran.
+   */
+  const requireConfigAuth = async (
+    c: Context
+  ): Promise<{ agentId: string; payload: SettingsTokenPayload } | Response> => {
     const agentId = c.req.param("agentId") || "";
-    const payload = await verifyToken(await verifySettingsSessionOrToken(c), agentId);
+    const payload = await verifyToken(
+      await verifySettingsSessionOrToken(c),
+      agentId
+    );
     if (!payload) return errorResponse(c, "Unauthorized", 401);
+    return { agentId, payload };
+  };
+
+  app.openapi(getConfigRoute, async (c): Promise<any> => {
+    const auth = await requireConfigAuth(c);
+    if (auth instanceof Response) return auth;
+    const { agentId, payload } = auth;
     const providerModels = await collectProviderModelOptions(
       agentId,
       payload.userId
@@ -374,9 +394,9 @@ export function createAgentConfigRoutes(
 
   // GET /providers/catalog
   app.get("/providers/catalog", async (c): Promise<any> => {
-    const agentId = c.req.param("agentId") || "";
-    const payload = await verifyToken(await verifySettingsSessionOrToken(c), agentId);
-    if (!payload) return errorResponse(c, "Unauthorized", 401);
+    const auth = await requireConfigAuth(c);
+    if (auth instanceof Response) return auth;
+    const { agentId } = auth;
 
     if (!config.providerCatalogService) {
       return errorResponse(c, "Provider catalog not available", 503);
@@ -407,14 +427,10 @@ export function createAgentConfigRoutes(
 
     // GET /grants - List all active grants
     app.get("/grants", async (c) => {
-      const agentId = c.req.param("agentId") || "";
-      const payload = await verifyToken(
-        await verifySettingsSessionOrToken(c),
-        agentId
-      );
-      if (!payload) return errorResponse(c, "Unauthorized", 401);
+      const auth = await requireConfigAuth(c);
+      if (auth instanceof Response) return auth;
 
-      const grants = await grantStore.listGrants(agentId);
+      const grants = await grantStore.listGrants(auth.agentId);
       return c.json(grants);
     });
   }

--- a/packages/server/src/gateway/routes/public/agent.ts
+++ b/packages/server/src/gateway/routes/public/agent.ts
@@ -32,6 +32,7 @@ import type { SseManager } from "../../services/sse-manager.js";
 import type { ISessionManager, ThreadSession } from "../../session.js";
 import { verifyOwnedAgentAccess } from "../shared/agent-ownership.js";
 import { errorResponse } from "../shared/helpers.js";
+import { errorResponses } from "../shared/openapi-responses.js";
 import { verifySettingsSession } from "./settings-auth.js";
 
 const logger = createLogger("agent-api");
@@ -283,14 +284,10 @@ const createAgentRoute = createRoute({
       description: "Agent created",
       content: { "application/json": { schema: CreateAgentResponseSchema } },
     },
-    400: {
-      description: "Invalid request",
-      content: { "application/json": { schema: ErrorResponseSchema } },
-    },
-    401: {
-      description: "Unauthorized",
-      content: { "application/json": { schema: ErrorResponseSchema } },
-    },
+    ...errorResponses(ErrorResponseSchema, {
+      400: "Invalid request",
+      401: "Unauthorized",
+    }),
   },
 });
 
@@ -306,14 +303,10 @@ const getAgentRoute = createRoute({
       description: "Agent status",
       content: { "application/json": { schema: AgentStatusResponseSchema } },
     },
-    401: {
-      description: "Unauthorized",
-      content: { "application/json": { schema: ErrorResponseSchema } },
-    },
-    404: {
-      description: "Not found",
-      content: { "application/json": { schema: ErrorResponseSchema } },
-    },
+    ...errorResponses(ErrorResponseSchema, {
+      401: "Unauthorized",
+      404: "Not found",
+    }),
   },
 });
 
@@ -329,14 +322,10 @@ const deleteAgentRoute = createRoute({
       description: "Agent deleted",
       content: { "application/json": { schema: SuccessResponseSchema } },
     },
-    401: {
-      description: "Unauthorized",
-      content: { "application/json": { schema: ErrorResponseSchema } },
-    },
-    404: {
-      description: "Not found",
-      content: { "application/json": { schema: ErrorResponseSchema } },
-    },
+    ...errorResponses(ErrorResponseSchema, {
+      401: "Unauthorized",
+      404: "Not found",
+    }),
   },
 });
 
@@ -353,14 +342,10 @@ const getAgentEventsRoute = createRoute({
       description: "SSE stream",
       content: { "text/event-stream": { schema: z.string() } },
     },
-    401: {
-      description: "Unauthorized",
-      content: { "application/json": { schema: ErrorResponseSchema } },
-    },
-    429: {
-      description: "Too many connections",
-      content: { "application/json": { schema: ErrorResponseSchema } },
-    },
+    ...errorResponses(ErrorResponseSchema, {
+      401: "Unauthorized",
+      429: "Too many connections",
+    }),
   },
 });
 
@@ -386,22 +371,12 @@ const sendMessageRoute = createRoute({
       description: "Message queued",
       content: { "application/json": { schema: SendMessageResponseSchema } },
     },
-    400: {
-      description: "Invalid request",
-      content: { "application/json": { schema: ErrorResponseSchema } },
-    },
-    401: {
-      description: "Unauthorized",
-      content: { "application/json": { schema: ErrorResponseSchema } },
-    },
-    403: {
-      description: "Forbidden - worker tokens cannot route to platforms",
-      content: { "application/json": { schema: ErrorResponseSchema } },
-    },
-    404: {
-      description: "Agent not found",
-      content: { "application/json": { schema: ErrorResponseSchema } },
-    },
+    ...errorResponses(ErrorResponseSchema, {
+      400: "Invalid request",
+      401: "Unauthorized",
+      403: "Forbidden - worker tokens cannot route to platforms",
+      404: "Agent not found",
+    }),
   },
 });
 

--- a/packages/server/src/gateway/routes/public/agents.ts
+++ b/packages/server/src/gateway/routes/public/agents.ts
@@ -18,11 +18,12 @@ import type {
 import type { SettingsTokenPayload } from "../../auth/settings/token-service.js";
 import type { UserAgentsStore } from "../../auth/user-agents-store.js";
 import type { ChannelBindingService } from "../../channels/binding-service.js";
+import { resolveSettingsLookupUserId } from "../shared/agent-ownership.js";
 import {
-  resolveSettingsLookupUserId,
-  verifyOwnedAgentAccess,
-} from "../shared/agent-ownership.js";
-import { errorResponse, requireSession } from "../shared/helpers.js";
+  errorResponse,
+  requireSession,
+  withOwnedAgent,
+} from "../shared/helpers.js";
 
 const logger = createLogger("agent-routes");
 
@@ -198,128 +199,110 @@ export function createAgentRoutes(config: AgentRoutesConfig): Hono {
     }
   });
 
+  const ownershipAccessConfig = {
+    userAgentsStore: config.userAgentsStore,
+    agentMetadataStore: config.agentMetadataStore,
+  };
+
   // PATCH /api/v1/agents/{agentId} - Update agent name/description
-  router.patch("/:agentId", async (c) => {
-    const payload = await requireSession(c);
-    if (payload instanceof Response) return payload;
+  router.patch("/:agentId", async (c) =>
+    withOwnedAgent(
+      c,
+      {
+        access: ownershipAccessConfig,
+        errorLabel: "Failed to update agent",
+        logger,
+      },
+      async ({ agentId }) => {
+        const body = await c.req.json<{
+          name?: string;
+          description?: string;
+        }>();
+        const updates: { name?: string; description?: string } = {};
 
-    const agentId = c.req.param("agentId");
-    if (!agentId) {
-      return errorResponse(c, "Missing agentId", 400);
-    }
-
-    try {
-      // Verify ownership (admins bypass)
-      if (!payload.isAdmin) {
-        const access = await verifyOwnedAgentAccess(payload, agentId, {
-          userAgentsStore: config.userAgentsStore,
-          agentMetadataStore: config.agentMetadataStore,
-        });
-        if (!access.authorized) {
-          return errorResponse(c, "Agent not found or not owned by you", 404);
+        if (body.name !== undefined) {
+          const name = body.name.trim();
+          if (!name || name.length > 100) {
+            return errorResponse(c, "Name must be 1-100 characters", 400);
+          }
+          updates.name = name;
         }
-      }
 
-      const body = await c.req.json<{ name?: string; description?: string }>();
-      const updates: { name?: string; description?: string } = {};
-
-      if (body.name !== undefined) {
-        const name = body.name.trim();
-        if (!name || name.length > 100) {
-          return errorResponse(c, "Name must be 1-100 characters", 400);
+        if (body.description !== undefined) {
+          const desc = body.description.trim();
+          if (desc.length > 200) {
+            return errorResponse(
+              c,
+              "Description must be at most 200 characters",
+              400
+            );
+          }
+          updates.description = desc;
         }
-        updates.name = name;
-      }
 
-      if (body.description !== undefined) {
-        const desc = body.description.trim();
-        if (desc.length > 200) {
-          return errorResponse(
-            c,
-            "Description must be at most 200 characters",
-            400
-          );
+        if (Object.keys(updates).length === 0) {
+          return errorResponse(c, "No fields to update", 400);
         }
-        updates.description = desc;
-      }
 
-      if (Object.keys(updates).length === 0) {
-        return errorResponse(c, "No fields to update", 400);
+        await config.agentMetadataStore.updateMetadata(agentId, updates);
+        logger.info(`Updated agent identity for ${agentId}`);
+        return c.json({ success: true });
       }
-
-      await config.agentMetadataStore.updateMetadata(agentId, updates);
-      logger.info(`Updated agent identity for ${agentId}`);
-      return c.json({ success: true });
-    } catch (error) {
-      logger.error("Failed to update agent", { error, agentId });
-      return errorResponse(c, "Internal server error", 500);
-    }
-  });
+    )
+  );
 
   // DELETE /api/v1/agents/{agentId} - Delete an agent
-  router.delete("/:agentId", async (c) => {
-    const payload = await requireSession(c);
-    if (payload instanceof Response) return payload;
+  router.delete("/:agentId", async (c) =>
+    withOwnedAgent(
+      c,
+      {
+        access: ownershipAccessConfig,
+        errorLabel: "Failed to delete agent",
+        logger,
+      },
+      async ({ session, agentId, access }) => {
+        // Owner fields are only populated for non-admin sessions (admins
+        // bypass the ownership check), matching the prior inline behavior.
+        const ownerPlatform = access.ownerPlatform;
+        const ownerUserId = access.ownerUserId;
 
-    const agentId = c.req.param("agentId");
-    if (!agentId) {
-      return errorResponse(c, "Missing agentId", 400);
-    }
+        // Auto-unbind all channels
+        const unboundCount =
+          await config.channelBindingService.deleteAllBindings(agentId);
 
-    try {
-      // Verify ownership (admins bypass)
-      let ownerPlatform: string | undefined;
-      let ownerUserId: string | undefined;
-      if (!payload.isAdmin) {
-        const access = await verifyOwnedAgentAccess(payload, agentId, {
-          userAgentsStore: config.userAgentsStore,
-          agentMetadataStore: config.agentMetadataStore,
-        });
-        if (!access.authorized) {
-          return errorResponse(c, "Agent not found or not owned by you", 404);
-        }
-        ownerPlatform = access.ownerPlatform;
-        ownerUserId = access.ownerUserId;
-      }
+        // Delete settings
+        await config.agentSettingsStore.deleteSettings(agentId);
 
-      // Auto-unbind all channels
-      const unboundCount =
-        await config.channelBindingService.deleteAllBindings(agentId);
+        // Delete metadata
+        await config.agentMetadataStore.deleteAgent(agentId);
 
-      // Delete settings
-      await config.agentSettingsStore.deleteSettings(agentId);
-
-      // Delete metadata
-      await config.agentMetadataStore.deleteAgent(agentId);
-
-      // Remove from user's list
-      await config.userAgentsStore.removeAgent(
-        payload.platform,
-        resolveSettingsLookupUserId(payload),
-        agentId
-      );
-      if (
-        ownerPlatform &&
-        ownerUserId &&
-        (ownerPlatform !== payload.platform || ownerUserId !== payload.userId)
-      ) {
+        // Remove from user's list
         await config.userAgentsStore.removeAgent(
-          ownerPlatform,
-          ownerUserId,
+          session.platform,
+          resolveSettingsLookupUserId(session),
           agentId
         );
+        if (
+          ownerPlatform &&
+          ownerUserId &&
+          (ownerPlatform !== session.platform ||
+            ownerUserId !== session.userId)
+        ) {
+          await config.userAgentsStore.removeAgent(
+            ownerPlatform,
+            ownerUserId,
+            agentId
+          );
+        }
+
+        logger.info(
+          `Deleted agent ${agentId} (unbound ${unboundCount} channels)`
+        );
+
+        return c.json({ success: true, unboundChannels: unboundCount });
       }
-
-      logger.info(
-        `Deleted agent ${agentId} (unbound ${unboundCount} channels)`
-      );
-
-      return c.json({ success: true, unboundChannels: unboundCount });
-    } catch (error) {
-      logger.error("Failed to delete agent", { error, agentId });
-      return errorResponse(c, "Internal server error", 500);
-    }
-  });
+    )
+  );
 
   logger.debug("Agent management routes registered");
   return router;

--- a/packages/server/src/gateway/routes/public/channels.ts
+++ b/packages/server/src/gateway/routes/public/channels.ts
@@ -8,11 +8,13 @@
  */
 
 import { createLogger } from "@lobu/core";
-import { Hono } from "hono";
+import { type Context, Hono } from "hono";
 import type { AgentMetadataStore } from "../../auth/agent-metadata-store.js";
+import type { SettingsTokenPayload } from "../../auth/settings/token-service.js";
 import type { UserAgentsStore } from "../../auth/user-agents-store.js";
 import type { ChannelBindingService } from "../../channels/binding-service.js";
 import { createTokenVerifier } from "../shared/agent-ownership.js";
+import { errorResponse } from "../shared/helpers.js";
 import { verifySettingsSession } from "./settings-auth.js";
 
 const logger = createLogger("channel-binding-routes");
@@ -34,21 +36,35 @@ export function createChannelBindingRoutes(
 
   const verifyToken = createTokenVerifier(config);
 
-  const verifyAuth = async (c: any, agentId: string) => {
+  const verifyAuth = async (
+    c: Context,
+    agentId: string
+  ): Promise<SettingsTokenPayload | null> => {
     return verifyToken(await verifySettingsSession(c), agentId);
+  };
+
+  // Resolve the `agentId` path param and authorize the caller in one step.
+  // Returns the verified token payload, or an early-return Response (400 when
+  // the param is missing, 401 when the session is not authorized for it).
+  const authorize = async (
+    c: Context
+  ): Promise<{ agentId: string; payload: SettingsTokenPayload } | Response> => {
+    const agentId = c.req.param("agentId");
+    if (!agentId) {
+      return errorResponse(c, "Missing agentId", 400);
+    }
+    const payload = await verifyAuth(c, agentId);
+    if (!payload) {
+      return errorResponse(c, "Unauthorized", 401);
+    }
+    return { agentId, payload };
   };
 
   // GET /api/v1/agents/{agentId}/channels - List all bindings for an agent
   router.get("/", async (c) => {
-    const agentId = c.req.param("agentId");
-
-    if (!agentId) {
-      return c.json({ error: "Missing agentId" }, 400);
-    }
-
-    if (!(await verifyAuth(c, agentId))) {
-      return c.json({ error: "Unauthorized" }, 401);
-    }
+    const auth = await authorize(c);
+    if (auth instanceof Response) return auth;
+    const { agentId } = auth;
 
     try {
       const bindings = await config.channelBindingService.listBindings(agentId);
@@ -64,22 +80,15 @@ export function createChannelBindingRoutes(
       });
     } catch (error) {
       logger.error("Failed to list bindings", { error, agentId });
-      return c.json({ error: "Failed to list bindings" }, 500);
+      return errorResponse(c, "Failed to list bindings", 500);
     }
   });
 
   // POST /api/v1/agents/{agentId}/channels - Create a new binding
   router.post("/", async (c) => {
-    const agentId = c.req.param("agentId");
-
-    if (!agentId) {
-      return c.json({ error: "Missing agentId" }, 400);
-    }
-
-    const authPayload = await verifyAuth(c, agentId);
-    if (!authPayload) {
-      return c.json({ error: "Unauthorized" }, 401);
-    }
+    const auth = await authorize(c);
+    if (auth instanceof Response) return auth;
+    const { agentId, payload: authPayload } = auth;
 
     try {
       const body = await c.req.json<{
@@ -90,23 +99,25 @@ export function createChannelBindingRoutes(
 
       // Validate required fields
       if (!body.platform || !body.channelId) {
-        return c.json(
-          { error: "Missing required fields: platform, channelId" },
+        return errorResponse(
+          c,
+          "Missing required fields: platform, channelId",
           400
         );
       }
 
       // Validate platform format (alphanumeric, lowercase)
       if (!/^[a-z][a-z0-9_-]*$/.test(body.platform)) {
-        return c.json(
-          { error: "Invalid platform format. Must be lowercase alphanumeric." },
+        return errorResponse(
+          c,
+          "Invalid platform format. Must be lowercase alphanumeric.",
           400
         );
       }
 
       // Validate channelId format
       if (typeof body.channelId !== "string" || !body.channelId.trim()) {
-        return c.json({ error: "Invalid channelId" }, 400);
+        return errorResponse(c, "Invalid channelId", 400);
       }
 
       // Validate optional teamId
@@ -114,7 +125,7 @@ export function createChannelBindingRoutes(
         body.teamId &&
         (typeof body.teamId !== "string" || !body.teamId.trim())
       ) {
-        return c.json({ error: "Invalid teamId" }, 400);
+        return errorResponse(c, "Invalid teamId", 400);
       }
 
       await config.channelBindingService.createBinding(
@@ -138,33 +149,30 @@ export function createChannelBindingRoutes(
       });
     } catch (error) {
       logger.error("Failed to create binding", { error, agentId });
-      return c.json(
-        {
-          error: "Failed to create binding",
-        },
-        400
-      );
+      return errorResponse(c, "Failed to create binding", 400);
     }
   });
 
   // DELETE /api/v1/agents/{agentId}/channels/{platform}/{channelId} - Delete a binding
   router.delete("/:platform/:channelId", async (c) => {
-    const agentId = c.req.param("agentId");
     const platform = c.req.param("platform");
     const channelId = c.req.param("channelId");
     const teamId = c.req.query("teamId"); // Optional query param for multi-tenant platforms
 
+    // Authorize on the agentId before validating the route-specific params so
+    // the 401 takes precedence over a 400, matching the prior behavior.
+    const agentId = c.req.param("agentId");
     if (!agentId || !platform || !channelId) {
-      return c.json({ error: "Missing required parameters" }, 400);
+      return errorResponse(c, "Missing required parameters", 400);
     }
 
     if (!(await verifyAuth(c, agentId))) {
-      return c.json({ error: "Unauthorized" }, 401);
+      return errorResponse(c, "Unauthorized", 401);
     }
 
     // Validate platform format
     if (!/^[a-z][a-z0-9_-]*$/.test(platform)) {
-      return c.json({ error: "Invalid platform format" }, 400);
+      return errorResponse(c, "Invalid platform format", 400);
     }
 
     try {
@@ -176,14 +184,14 @@ export function createChannelBindingRoutes(
       );
 
       if (!deleted) {
-        return c.json({ error: "Binding not found" }, 404);
+        return errorResponse(c, "Binding not found", 404);
       }
 
       logger.info(`Deleted binding: ${platform}/${channelId} -> ${agentId}`);
       return c.json({ success: true });
     } catch (error) {
       logger.error("Failed to delete binding", { error, agentId });
-      return c.json({ error: "Failed to delete binding" }, 500);
+      return errorResponse(c, "Failed to delete binding", 500);
     }
   });
 

--- a/packages/server/src/gateway/routes/public/connections.ts
+++ b/packages/server/src/gateway/routes/public/connections.ts
@@ -11,19 +11,23 @@
 import { createRoute, OpenAPIHono, z } from "@hono/zod-openapi";
 import type { AgentConfigStore } from "@lobu/core";
 import { createLogger } from "@lobu/core";
-import { Hono } from "hono";
+import { type Context, Hono } from "hono";
 import type { UserAgentsStore } from "../../auth/user-agents-store.js";
 import type { ChatInstanceManager } from "../../connections/chat-instance-manager.js";
+import type { PlatformConnection } from "../../connections/types.js";
 import {
   PlatformAdapterConfigSchema,
   SupportedPlatformSchema,
 } from "../schemas/platform-config.js";
 import { verifyOwnedAgentAccess } from "../shared/agent-ownership.js";
 import { requireSession } from "../shared/helpers.js";
+import {
+  ErrorResponseSchema,
+  errorResponses,
+} from "../shared/openapi-responses.js";
 
 const logger = createLogger("connection-routes");
 const TAG = "Connections";
-const ErrorResponseSchema = z.object({ error: z.string() });
 const FlexibleObjectSchema = z.record(z.string(), z.unknown());
 
 const UserConfigScopeSchema = z.enum([
@@ -57,6 +61,28 @@ async function getLocalTestDefaultTarget(
 ): Promise<string | undefined> {
   const channels = await manager.listHistoryChannels(connectionId);
   return channels[0];
+}
+
+/**
+ * Shared scaffolding for the dev-only local-test endpoints: refuse in
+ * production, then return the active connections on a locally-testable
+ * platform. Returns `null` to signal the production refusal (the caller maps
+ * it to a 404). Status-based, not warm-instance-based: connections hydrate
+ * lazily, so an active row with no local instance is still usable.
+ */
+async function getActiveLocalTestConnections(
+  manager: ChatInstanceManager
+): Promise<PlatformConnection[] | null> {
+  if (process.env.NODE_ENV === "production") {
+    return null;
+  }
+
+  const supported = new Set<string>(LOCAL_TEST_PLATFORMS);
+  const connections = await manager.listConnections();
+  return connections.filter(
+    (connection) =>
+      connection.status === "active" && supported.has(connection.platform)
+  );
 }
 
 // Per-platform config Zod schemas live in ../schemas/platform-config.ts —
@@ -105,22 +131,10 @@ const ListConnectionsRoute = createRoute({
         },
       },
     },
-    401: {
-      description: "Unauthorized",
-      content: {
-        "application/json": {
-          schema: ErrorResponseSchema,
-        },
-      },
-    },
-    403: {
-      description: "Forbidden",
-      content: {
-        "application/json": {
-          schema: ErrorResponseSchema,
-        },
-      },
-    },
+    ...errorResponses(ErrorResponseSchema, {
+      401: "Unauthorized",
+      403: "Forbidden",
+    }),
   },
 });
 
@@ -141,30 +155,11 @@ const GetConnectionRoute = createRoute({
         },
       },
     },
-    401: {
-      description: "Unauthorized",
-      content: {
-        "application/json": {
-          schema: ErrorResponseSchema,
-        },
-      },
-    },
-    403: {
-      description: "Forbidden",
-      content: {
-        "application/json": {
-          schema: ErrorResponseSchema,
-        },
-      },
-    },
-    404: {
-      description: "Connection not found",
-      content: {
-        "application/json": {
-          schema: ErrorResponseSchema,
-        },
-      },
-    },
+    ...errorResponses(ErrorResponseSchema, {
+      401: "Unauthorized",
+      403: "Forbidden",
+      404: "Connection not found",
+    }),
   },
 });
 
@@ -228,50 +223,31 @@ export function createConnectionCrudRoutes(
 ): OpenAPIHono {
   const app = new OpenAPIHono();
 
-  const listLocalTestPlatforms = async (c: any): Promise<any> => {
-    if (process.env.NODE_ENV === "production") {
+  const listLocalTestPlatforms = async (c: Context): Promise<Response> => {
+    const connections = await getActiveLocalTestConnections(manager);
+    if (!connections) {
       return c.json({ error: "Not found" }, 404);
     }
 
-    const supported = new Set<string>(LOCAL_TEST_PLATFORMS);
-    const connections = await manager.listConnections();
     const platforms = [
-      ...new Set(
-        connections
-          // Status-based, not warm-instance-based: connections hydrate
-          // lazily, so an active row with no local instance is still usable.
-          .filter(
-            (connection) =>
-              connection.status === "active" &&
-              supported.has(connection.platform)
-          )
-          .map((connection) => connection.platform)
-      ),
+      ...new Set(connections.map((connection) => connection.platform)),
     ];
 
     return c.json(platforms);
   };
 
-  const listLocalTestTargets = async (c: any): Promise<any> => {
-    if (process.env.NODE_ENV === "production") {
+  const listLocalTestTargets = async (c: Context): Promise<Response> => {
+    const connections = await getActiveLocalTestConnections(manager);
+    if (!connections) {
       return c.json({ error: "Not found" }, 404);
     }
 
-    const supported = new Set<string>(LOCAL_TEST_PLATFORMS);
-    const connections = await manager.listConnections();
     const targets = new Map<
       string,
       { platform: string; defaultTarget?: string; agentId?: string }
     >();
 
     for (const connection of connections) {
-      if (
-        connection.status !== "active" ||
-        !supported.has(connection.platform)
-      ) {
-        continue;
-      }
-
       if (!targets.has(connection.platform)) {
         targets.set(connection.platform, {
           platform: connection.platform,

--- a/packages/server/src/gateway/routes/shared/agent-ownership.ts
+++ b/packages/server/src/gateway/routes/shared/agent-ownership.ts
@@ -2,12 +2,12 @@ import type { AgentConfigStore } from "@lobu/core";
 import type { SettingsTokenPayload } from "../../auth/settings/token-service.js";
 import type { UserAgentsStore } from "../../auth/user-agents-store.js";
 
-interface AgentOwnershipConfig {
+export interface AgentOwnershipConfig {
   userAgentsStore?: UserAgentsStore;
   agentMetadataStore?: Pick<AgentConfigStore, "getMetadata">;
 }
 
-interface AgentOwnershipResult {
+export interface AgentOwnershipResult {
   authorized: boolean;
   ownerPlatform?: string;
   ownerUserId?: string;

--- a/packages/server/src/gateway/routes/shared/helpers.ts
+++ b/packages/server/src/gateway/routes/shared/helpers.ts
@@ -11,6 +11,11 @@ import type { ContentfulStatusCode } from "hono/utils/http-status";
 import type { SettingsTokenPayload } from "../../auth/settings/token-service.js";
 import { verifySettingsSession } from "../public/settings-auth.js";
 import type { WorkerContext } from "../internal/types.js";
+import {
+  type AgentOwnershipConfig,
+  type AgentOwnershipResult,
+  verifyOwnedAgentAccess,
+} from "./agent-ownership.js";
 
 /**
  * Return a standard JSON error response with the shape `{ error: message }`.
@@ -81,4 +86,74 @@ export function getVerifiedWorker(
     );
   }
   return worker;
+}
+
+interface WithOwnedAgentOptions {
+  /** Ownership stores used by `verifyOwnedAgentAccess`. */
+  access: AgentOwnershipConfig;
+  /** Logged on the unexpected-error 500 path, e.g. "Failed to delete agent". */
+  errorLabel: string;
+  /** Logger used for the 500 path. Matches `createLogger`'s (message, meta). */
+  logger: { error: (message: string, meta?: unknown) => void };
+  /** Status returned when ownership is denied (404 for agents, 403 elsewhere). */
+  deniedStatus?: ContentfulStatusCode;
+  /** Body message returned when ownership is denied. */
+  deniedMessage?: string;
+}
+
+/**
+ * Collapse the auth → agentId-param → ownership → try/catch preamble that every
+ * agent-scoped CRUD handler reimplements.
+ *
+ * Behavior contract (preserved byte-for-byte from the inline handlers):
+ *  - missing session → 401 `Unauthorized` (via `requireSession`)
+ *  - missing `agentId` path param → 400 `Missing agentId`
+ *  - admin sessions BYPASS the ownership check entirely; `access` is then
+ *    `{ authorized: true }` with no owner fields, exactly like the inline code
+ *  - non-admin sessions run `verifyOwnedAgentAccess`; on denial the configured
+ *    `deniedStatus`/`deniedMessage` is returned (default 404 / "Agent not found
+ *    or not owned by you")
+ *  - the handler runs inside a try/catch that logs `errorLabel` and returns
+ *    500 `Internal server error`
+ *
+ * The handler receives the resolved `{ session, agentId, access }` so callers
+ * that need `ownerPlatform`/`ownerUserId` (delete) read them off `access`.
+ */
+export async function withOwnedAgent(
+  c: Context,
+  options: WithOwnedAgentOptions,
+  handler: (ctx: {
+    session: SettingsTokenPayload;
+    agentId: string;
+    access: AgentOwnershipResult;
+  }) => Promise<Response>
+): Promise<Response> {
+  const session = await requireSession(c);
+  if (session instanceof Response) return session;
+
+  const agentId = c.req.param("agentId");
+  if (!agentId) {
+    return errorResponse(c, "Missing agentId", 400);
+  }
+
+  // Ownership resolution runs inside the try/catch so a thrown store error maps
+  // to the same logged 500 the inline handlers produced.
+  try {
+    let access: AgentOwnershipResult = { authorized: true };
+    if (!session.isAdmin) {
+      access = await verifyOwnedAgentAccess(session, agentId, options.access);
+      if (!access.authorized) {
+        return errorResponse(
+          c,
+          options.deniedMessage ?? "Agent not found or not owned by you",
+          options.deniedStatus ?? 404
+        );
+      }
+    }
+
+    return await handler({ session, agentId, access });
+  } catch (error) {
+    options.logger.error(options.errorLabel, { error, agentId });
+    return errorResponse(c, "Internal server error", 500);
+  }
 }

--- a/packages/server/src/gateway/routes/shared/openapi-responses.ts
+++ b/packages/server/src/gateway/routes/shared/openapi-responses.ts
@@ -1,0 +1,61 @@
+/**
+ * Shared OpenAPI response building blocks.
+ *
+ * Collapses the stamped-out
+ *   `4xx: { description, content: { "application/json": { schema } } }`
+ * blocks that every `createRoute` definition repeats. The shape and the
+ * canonical `{ error }` schema were previously redeclared per route file.
+ */
+
+import { z } from "@hono/zod-openapi";
+
+/**
+ * Canonical flat error response: `{ error: string }`.
+ *
+ * The single source for the `{ error }` shape used by connection, config, and
+ * most CRUD routes. Routes with a richer error envelope (e.g. agent.ts's
+ * `{ success, error, details? }`) pass their own schema to `errorResponses`.
+ */
+export const ErrorResponseSchema = z.object({ error: z.string() });
+
+/**
+ * A single OpenAPI JSON response block for `schema`.
+ */
+type JsonResponseBlock<Schema> = {
+  description: string;
+  content: { "application/json": { schema: Schema } };
+};
+
+/**
+ * Build a set of error-response blocks keyed by HTTP status code.
+ *
+ * Usage:
+ *   responses: {
+ *     200: { ... },
+ *     ...errorResponses(ErrorResponseSchema, { 401: "Unauthorized", 404: "Not found" }),
+ *   }
+ *
+ * `schema` is the error body schema; pass a custom schema for routes with a
+ * richer envelope.
+ *
+ * The return type preserves the exact set of status-code keys (via the
+ * `Codes` generic) so the spread into `createRoute({ responses })` keeps
+ * per-code precision and `app.openapi(route, handler)` still infers a precise
+ * handler return type — a plain `Record<number, …>` would widen it.
+ */
+export function errorResponses<Schema, Codes extends number>(
+  schema: Schema,
+  descriptions: Record<Codes, string>
+): { [Code in Codes]: JsonResponseBlock<Schema> } {
+  const out = {} as { [Code in Codes]: JsonResponseBlock<Schema> };
+  for (const [code, description] of Object.entries(descriptions) as [
+    `${Codes}`,
+    string,
+  ][]) {
+    out[Number(code) as Codes] = {
+      description,
+      content: { "application/json": { schema } },
+    };
+  }
+  return out;
+}

--- a/packages/server/src/preview/slack.ts
+++ b/packages/server/src/preview/slack.ts
@@ -1,4 +1,5 @@
 import { createHash, randomInt } from 'node:crypto';
+import { slugify } from '@lobu/core';
 import type { Context } from 'hono';
 import { getDb } from '../db/client';
 import type { Env } from '../index';
@@ -59,14 +60,6 @@ interface ClaimPayload {
 
 function codeHash(code: string): string {
   return createHash('sha256').update(code.trim().toLowerCase()).digest('hex');
-}
-
-function slugify(value: string): string {
-  return value
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-+|-+$/g, '')
-    .slice(0, 32);
 }
 
 // Uppercase letters + digits — readable, no ambiguous punctuation, and a fixed
@@ -154,7 +147,7 @@ export async function createPreviewClaim(c: Context<{ Bindings: Env }>) {
 
   const surfaces = normalizeSurfaces(body.surfaces);
   const ttlMinutes = normalizeTtlMinutes(body.ttl_minutes);
-  const codePrefix = slugify(agentId) || 'agent';
+  const codePrefix = slugify(agentId, { maxLength: 32 }) || 'agent';
   const sql = getDb();
 
   const agentRows = await sql<{ id: string }>`

--- a/packages/server/src/tools/admin/helpers/db-helpers.ts
+++ b/packages/server/src/tools/admin/helpers/db-helpers.ts
@@ -6,6 +6,27 @@
  */
 
 import { type DbClient, pgBigintArray } from '../../../db/client';
+import { getWorkspaceRole } from '../../../utils/organization-access';
+import { isAdminOrOwnerRole } from '../../access-control';
+
+/**
+ * Resolve whether the caller holds admin-tier (admin/owner) access in their
+ * bound org. Anonymous / userless callers (`userId == null`) are never admin,
+ * so we skip the membership lookup and return false — matching the hand-rolled
+ * `ctx.userId ? getWorkspaceRole(...) : null` + `isAdminOrOwnerRole(role)`
+ * pattern these handlers previously inlined.
+ *
+ * Takes an explicit `sql` so callers inside a transaction pass their tx client
+ * (admin gating must see uncommitted rows in the same tx).
+ */
+export async function callerIsAdmin(
+  sql: DbClient,
+  ctx: { organizationId: string; userId: string | null }
+): Promise<boolean> {
+  if (!ctx.userId) return false;
+  const role = await getWorkspaceRole(sql, ctx.organizationId, ctx.userId);
+  return isAdminOrOwnerRole(role);
+}
 
 /**
  * Valid tables for requireExists. Uses a whitelist so we can safely

--- a/packages/server/src/tools/admin/manage_auth_profiles.ts
+++ b/packages/server/src/tools/admin/manage_auth_profiles.ts
@@ -32,10 +32,10 @@ import {
   updateAuthProfile,
 } from '../../utils/auth-profiles';
 import { createConnectToken } from '../../utils/connect-tokens';
-import { getWorkspaceRole } from '../../utils/organization-access';
 import type { ToolContext } from '../registry';
 import { action, defineActionTool } from './action-tool';
 import { getScopedConnectorDefinition } from './connector-definition-helpers';
+import { callerIsAdmin } from './helpers/db-helpers';
 import {
   buildOAuthConnectConfig,
   getBrowserMethods,
@@ -46,7 +46,6 @@ import {
   resolveRequestedOAuthScopes,
   serializeAuthProfile,
 } from './helpers/connection-helpers';
-import { isAdminOrOwnerRole } from '../access-control';
 
 // ============================================
 // Schema
@@ -182,6 +181,16 @@ type ManageAuthProfilesResult =
       auth_profile: any | null;
     };
 
+/**
+ * Standard "auth profile not found" error result. Centralizes the message that
+ * four handlers (get / test / delete / set_default) previously repeated
+ * verbatim after a `getAuthProfileBySlug` miss. Returns the `{ error }` shape
+ * (not a throw) to preserve the existing 200-with-error-body response.
+ */
+function authProfileNotFound(slug: string): { error: string } {
+  return { error: `Auth profile '${slug}' not found` };
+}
+
 // ============================================
 // Main Function (Action Router)
 // ============================================
@@ -226,7 +235,7 @@ async function handleGetAuthProfile(
 ): Promise<ManageAuthProfilesResult> {
   const authProfile = await getAuthProfileBySlug(ctx.organizationId, args.auth_profile_slug);
   if (!authProfile) {
-    return { error: `Auth profile '${args.auth_profile_slug}' not found` };
+    return authProfileNotFound(args.auth_profile_slug);
   }
 
   return {
@@ -241,7 +250,7 @@ async function handleTestAuthProfile(
 ): Promise<ManageAuthProfilesResult> {
   const authProfile = await getAuthProfileBySlug(ctx.organizationId, args.auth_profile_slug);
   if (!authProfile) {
-    return { error: `Auth profile '${args.auth_profile_slug}' not found` };
+    return authProfileNotFound(args.auth_profile_slug);
   }
 
   if (authProfile.profile_kind === 'browser_session') {
@@ -418,10 +427,7 @@ async function handleCreateAuthProfile(
   // org-shared credential (env keys, OAuth app client_id/secret, browser
   // session, interactive). Gate non-personal kinds on admin role.
   if (args.profile_kind !== 'oauth_account') {
-    const role = ctx.userId
-      ? await getWorkspaceRole(getDb(), ctx.organizationId, ctx.userId)
-      : null;
-    if (role !== 'admin' && role !== 'owner') {
+    if (!(await callerIsAdmin(getDb(), ctx))) {
       return {
         error: `Only admins can create ${args.profile_kind} auth profiles. Ask an organization owner or admin to configure these credentials.`,
       };
@@ -494,11 +500,7 @@ async function handleCreateAuthProfile(
       // otherwise a member who knows another member's pending profile slug
       // could mint a fresh connect token for it and complete OAuth into a
       // profile already referenced by someone else's connections.
-      const role = ctx.userId
-        ? await getWorkspaceRole(getDb(), ctx.organizationId, ctx.userId)
-        : null;
-      const callerIsAdmin = isAdminOrOwnerRole(role);
-      if (!callerIsAdmin && existing.created_by !== ctx.userId) {
+      if (!(await callerIsAdmin(getDb(), ctx)) && existing.created_by !== ctx.userId) {
         return {
           error: `Auth profile '${existing.slug}' belongs to another user. Choose a different slug.`,
         };
@@ -678,17 +680,14 @@ async function handleUpdateAuthProfile(
     args.auth_profile_slug
   );
   if (existingForRoleCheck) {
-    const role = ctx.userId
-      ? await getWorkspaceRole(getDb(), ctx.organizationId, ctx.userId)
-      : null;
-    const callerIsAdmin = isAdminOrOwnerRole(role);
-    if (existingForRoleCheck.profile_kind !== 'oauth_account' && !callerIsAdmin) {
+    const isAdmin = await callerIsAdmin(getDb(), ctx);
+    if (existingForRoleCheck.profile_kind !== 'oauth_account' && !isAdmin) {
       return {
         error: `Only admins can modify ${existingForRoleCheck.profile_kind} auth profiles.`,
       };
     }
     if (
-      !callerIsAdmin &&
+      !isAdmin &&
       existingForRoleCheck.profile_kind === 'oauth_account' &&
       existingForRoleCheck.created_by !== ctx.userId
     ) {
@@ -858,7 +857,7 @@ async function handleDeleteAuthProfile(
   const sql = getDb();
   const existing = await getAuthProfileBySlug(ctx.organizationId, args.auth_profile_slug);
   if (!existing) {
-    return { error: `Auth profile '${args.auth_profile_slug}' not found` };
+    return authProfileNotFound(args.auth_profile_slug);
   }
 
   // Check if active connections reference this profile
@@ -974,7 +973,7 @@ async function handleSetDefaultAuthProfile(
   if (args.auth_profile_slug !== null) {
     const target = await getAuthProfileBySlug(ctx.organizationId, args.auth_profile_slug);
     if (!target) {
-      return { error: `Auth profile '${args.auth_profile_slug}' not found` };
+      return authProfileNotFound(args.auth_profile_slug);
     }
     if (target.profile_kind !== 'oauth_app') {
       return {

--- a/packages/server/src/tools/admin/manage_connections/handlers/auth-actions.ts
+++ b/packages/server/src/tools/admin/manage_connections/handlers/auth-actions.ts
@@ -9,12 +9,11 @@ import {
   normalizeAuthValues,
   summarizeBrowserSessionAuthData,
 } from '../../../../utils/auth-profiles';
-import { getWorkspaceRole } from '../../../../utils/organization-access';
 import { createAuthRun } from '../../../../runs/queue-service';
 import { ACTIVE_RUN_STATUSES, runStatusLiteral } from '../../../../utils/run-statuses';
 import type { ToolContext } from '../../../registry';
 import type { ManageConnectionsResult, ConnectionsArgs } from '../schemas';
-import { isAdminOrOwnerRole } from '../../../access-control';
+import { callerIsAdmin as resolveCallerIsAdmin } from '../../helpers/db-helpers';
 
 // ============================================
 // handleReauthenticate
@@ -66,8 +65,7 @@ export async function handleReauthenticate(
   // `pending_auth` and kicks off an auth run — that has to be the connection
   // owner or an admin/owner. Without this gate, any org member could disrupt
   // (or hijack the pairing of) another member's interactive connection.
-  const callerRole = await getWorkspaceRole(sql, organizationId, ctx.userId);
-  const callerIsAdmin = isAdminOrOwnerRole(callerRole);
+  const callerIsAdmin = await resolveCallerIsAdmin(sql, { organizationId, userId: ctx.userId });
   if (!callerIsAdmin && row.connection_created_by !== ctx.userId) {
     return { error: 'You can only re-authenticate connections you created.' };
   }

--- a/packages/server/src/tools/admin/manage_connections/handlers/crud.ts
+++ b/packages/server/src/tools/admin/manage_connections/handlers/crud.ts
@@ -39,7 +39,7 @@ import {
   resolveConnectionDisplayName,
   resolveConnectionVisibility,
 } from '../../helpers/connection-helpers';
-import { assertEntityIdsInOrg } from '../../helpers/db-helpers';
+import { assertEntityIdsInOrg, callerIsAdmin as resolveCallerIsAdmin } from '../../helpers/db-helpers';
 import { type FeedDefinition, splitConfigByFeedScope } from '../../helpers/feed-helpers';
 import { getScopedConnectorDefinition } from '../../connector-definition-helpers';
 import type { ToolContext } from '../../../registry';
@@ -47,7 +47,6 @@ import type { ManageConnectionsResult, ConnectionsArgs } from '../schemas';
 import { resolveDeviceBinding, isManagedPublicOrgConnect } from './device-binding';
 import { assertConnectorAllowedInCloud } from '../../../../utils/connector-cloud-gate';
 import { ensureConnectorInstalled } from '../../../../utils/ensure-connector-installed';
-import { isAdminOrOwnerRole } from '../../../access-control';
 
 // ============================================
 // handleList
@@ -305,8 +304,7 @@ export async function handleCreate(
 
   // Resolve caller role once — we use it for created_by overrides, explicit
   // app_auth_profile picks, and member-friendly error messages downstream.
-  const callerRole = userId ? await getWorkspaceRole(sql, organizationId, userId) : null;
-  const callerIsAdmin = isAdminOrOwnerRole(callerRole);
+  const callerIsAdmin = await resolveCallerIsAdmin(sql, { organizationId, userId });
 
   // Resolve effective owner — admins can create connections on behalf of other users
   let effectiveCreatedBy = userId;
@@ -835,10 +833,10 @@ export async function handleUpdate(
   // connection. Resolve the caller's role once up front and gate every
   // member action on "I created this connection" — admins/owners are
   // unrestricted.
-  const callerRole = ctx.userId
-    ? await getWorkspaceRole(sql, organizationId, ctx.userId)
-    : null;
-  const callerIsAdmin = isAdminOrOwnerRole(callerRole);
+  const callerIsAdmin = await resolveCallerIsAdmin(sql, {
+    organizationId,
+    userId: ctx.userId,
+  });
 
   if (!callerIsAdmin) {
     if (!ctx.userId || existing.created_by !== ctx.userId) {

--- a/packages/server/src/utils/__tests__/date-aliases.test.ts
+++ b/packages/server/src/utils/__tests__/date-aliases.test.ts
@@ -3,13 +3,7 @@
  */
 
 import { describe, expect, it } from 'vitest';
-import {
-  daysBetween,
-  formatDateISO,
-  inferGranularity,
-  parseDateAlias,
-  toEndOfDay,
-} from '../date-aliases';
+import { formatDateISO, parseDateAlias, toEndOfDay } from '../date-aliases';
 
 describe('parseDateAlias', () => {
   const ref = new Date('2025-06-15T12:00:00Z');
@@ -111,47 +105,6 @@ describe('parseDateAlias', () => {
     it('should throw for invalid ISO date', () => {
       expect(() => parseDateAlias('2025-99-99', ref)).toThrow();
     });
-  });
-});
-
-describe('daysBetween', () => {
-  it('should calculate days between two dates', () => {
-    const a = new Date('2025-01-01');
-    const b = new Date('2025-01-15');
-    expect(daysBetween(a, b)).toBe(14);
-  });
-
-  it('should return absolute difference', () => {
-    const a = new Date('2025-01-15');
-    const b = new Date('2025-01-01');
-    expect(daysBetween(a, b)).toBe(14);
-  });
-
-  it('should return 0 for same date', () => {
-    const a = new Date('2025-01-01');
-    expect(daysBetween(a, a)).toBe(0);
-  });
-});
-
-describe('inferGranularity', () => {
-  it('should return daily for <= 14 days', () => {
-    expect(inferGranularity(7)).toBe('daily');
-    expect(inferGranularity(14)).toBe('daily');
-  });
-
-  it('should return weekly for 15-90 days', () => {
-    expect(inferGranularity(15)).toBe('weekly');
-    expect(inferGranularity(90)).toBe('weekly');
-  });
-
-  it('should return monthly for 91-365 days', () => {
-    expect(inferGranularity(91)).toBe('monthly');
-    expect(inferGranularity(365)).toBe('monthly');
-  });
-
-  it('should return quarterly for > 365 days', () => {
-    expect(inferGranularity(366)).toBe('quarterly');
-    expect(inferGranularity(730)).toBe('quarterly');
   });
 });
 

--- a/packages/server/src/utils/auth-profiles.ts
+++ b/packages/server/src/utils/auth-profiles.ts
@@ -1,5 +1,5 @@
+import { slugify } from '@lobu/core';
 import { getDb } from '../db/client';
-import { generateSlug } from './entity-management';
 import { ToolUserError } from './errors';
 import { isUniqueViolation } from './pg-errors';
 
@@ -216,7 +216,7 @@ export function browserSessionIsUsable(
 }
 
 function sanitizeProfileSlug(value: string): string {
-  const slug = generateSlug(value);
+  const slug = slugify(value);
   if (!slug) {
     throw new Error('Auth profile slug must contain at least one letter or number');
   }

--- a/packages/server/src/utils/connections.ts
+++ b/packages/server/src/utils/connections.ts
@@ -7,8 +7,8 @@
  * in db/migrations/20260512131703_connections_slug.sql mirrors their semantics.
  */
 
+import { slugify } from '@lobu/core';
 import { type DbClient, getDb } from '../db/client';
-import { generateSlug } from './entity-management';
 
 /**
  * Server-side slug format guard. Lowercase letters/digits/hyphens, 1–63 chars,
@@ -50,7 +50,7 @@ export function isConnectionSlugUniqueViolation(err: unknown): boolean {
  */
 export function slugifyConnectionName(value: string | null | undefined): string {
   if (!value) return '';
-  return generateSlug(value);
+  return slugify(value);
 }
 
 /** Whether a slug is already used by a live (`deleted_at IS NULL`) connection in the org. */

--- a/packages/server/src/utils/date-aliases.ts
+++ b/packages/server/src/utils/date-aliases.ts
@@ -1,5 +1,3 @@
-import { inferWatcherGranularityFromDays } from '@lobu/connector-sdk';
-
 /**
  * Date Alias Parsing Utility
  *
@@ -131,24 +129,6 @@ export function parseDateAlias(alias: string, referenceDate: Date = new Date()):
       '  - Relative: 7d, 30d, 90d, 1m, 3m, 6m, 1y (d=days, w=weeks, m=months, q=quarters, y=years)\n' +
       '  - ISO 8601: 2025-01-01 or 2025-01-01T12:00:00Z'
   );
-}
-
-/**
- * Calculate the difference in days between two dates
- * Used for granularity inference
- */
-export function daysBetween(start: Date, end: Date): number {
-  const msPerDay = 1000 * 60 * 60 * 24;
-  return Math.abs(Math.floor((end.getTime() - start.getTime()) / msPerDay));
-}
-
-/**
- * Infer the best granularity based on a date range
- * @param daysDiff - Number of days in the range
- * @returns Suggested granularity
- */
-export function inferGranularity(daysDiff: number): string {
-  return inferWatcherGranularityFromDays(daysDiff);
 }
 
 /**

--- a/packages/server/src/utils/entity-link-upsert.ts
+++ b/packages/server/src/utils/entity-link-upsert.ts
@@ -22,6 +22,8 @@ import { normalizeIdentifier } from '@lobu/connector-sdk';
 import { getDb, pgTextArray } from '../db/client';
 import { resolveEntityLinkRules } from './entity-link-validation';
 import logger from './logger';
+import { getValueAtPath } from './object-path';
+import { TtlCache } from './ttl-cache';
 
 interface BatchItem {
   origin_type?: string;
@@ -34,36 +36,23 @@ interface RuleMap {
 }
 
 const RULES_CACHE_TTL_MS = 60_000;
-const rulesCache = new Map<string, { value: RuleMap; expiresAt: number }>();
-const creatorCache = new Map<string, { value: string | null; expiresAt: number }>();
+// Per-pod caches — no cross-replica sharing.
+const rulesCache = new TtlCache<RuleMap>(RULES_CACHE_TTL_MS);
+const creatorCache = new TtlCache<string | null>(RULES_CACHE_TTL_MS);
 
 async function resolveOrgCreator(orgId: string): Promise<string | null> {
-  const now = Date.now();
-  const cached = creatorCache.get(orgId);
-  if (cached && cached.expiresAt > now) return cached.value;
-
-  const sql = getDb();
-  const rows = await sql<{ userId: string }>`
-    SELECT "userId"
-    FROM "member"
-    WHERE "organizationId" = ${orgId}
-    ORDER BY CASE role WHEN 'owner' THEN 0 WHEN 'admin' THEN 1 ELSE 2 END,
-             "createdAt" ASC
-    LIMIT 1
-  `;
-  const value = rows.length > 0 ? rows[0].userId : null;
-  creatorCache.set(orgId, { value, expiresAt: now + RULES_CACHE_TTL_MS });
-  return value;
-}
-
-function readPath(source: unknown, path: string): unknown {
-  const parts = path.split('.');
-  let cur: unknown = source;
-  for (const p of parts) {
-    if (cur == null || typeof cur !== 'object') return undefined;
-    cur = (cur as Record<string, unknown>)[p];
-  }
-  return cur;
+  return creatorCache.getOrSet(orgId, async () => {
+    const sql = getDb();
+    const rows = await sql<{ userId: string }>`
+      SELECT "userId"
+      FROM "member"
+      WHERE "organizationId" = ${orgId}
+      ORDER BY CASE role WHEN 'owner' THEN 0 WHEN 'admin' THEN 1 ELSE 2 END,
+               "createdAt" ASC
+      LIMIT 1
+    `;
+    return rows.length > 0 ? rows[0].userId : null;
+  });
 }
 
 function randomSlug(entityType: string): string {
@@ -81,37 +70,33 @@ async function loadEntityLinkRules(params: {
   orgId: string;
 }): Promise<RuleMap> {
   const cacheKey = `${params.orgId}:${params.connectorKey}:${params.feedKey}`;
-  const now = Date.now();
-  const cached = rulesCache.get(cacheKey);
-  if (cached && cached.expiresAt > now) return cached.value;
+  return rulesCache.getOrSet(cacheKey, async () => {
+    const sql = getDb();
+    const rows = await sql`
+      SELECT feeds_schema, entity_link_overrides
+      FROM connector_definitions
+      WHERE key = ${params.connectorKey}
+        AND organization_id = ${params.orgId}
+      LIMIT 1
+    `;
 
-  const sql = getDb();
-  const rows = await sql`
-    SELECT feeds_schema, entity_link_overrides
-    FROM connector_definitions
-    WHERE key = ${params.connectorKey}
-      AND organization_id = ${params.orgId}
-    LIMIT 1
-  `;
-
-  const result: RuleMap = {};
-  const feedsSchema = rows[0]?.feeds_schema as Record<string, any> | null | undefined;
-  const overrides = rows[0]?.entity_link_overrides as EntityLinkOverrides | null | undefined;
-  const feedDef = feedsSchema?.[params.feedKey];
-  const eventKinds = feedDef?.eventKinds as
-    | Record<string, { entityLinks?: EntityLinkRule[] }>
-    | undefined;
-  if (eventKinds) {
-    for (const [kind, def] of Object.entries(eventKinds)) {
-      if (Array.isArray(def?.entityLinks) && def.entityLinks.length > 0) {
-        const resolved = resolveEntityLinkRules(def.entityLinks, overrides);
-        if (resolved.length > 0) result[kind] = resolved;
+    const result: RuleMap = {};
+    const feedsSchema = rows[0]?.feeds_schema as Record<string, any> | null | undefined;
+    const overrides = rows[0]?.entity_link_overrides as EntityLinkOverrides | null | undefined;
+    const feedDef = feedsSchema?.[params.feedKey];
+    const eventKinds = feedDef?.eventKinds as
+      | Record<string, { entityLinks?: EntityLinkRule[] }>
+      | undefined;
+    if (eventKinds) {
+      for (const [kind, def] of Object.entries(eventKinds)) {
+        if (Array.isArray(def?.entityLinks) && def.entityLinks.length > 0) {
+          const resolved = resolveEntityLinkRules(def.entityLinks, overrides);
+          if (resolved.length > 0) result[kind] = resolved;
+        }
       }
     }
-  }
-
-  rulesCache.set(cacheKey, { value: result, expiresAt: now + RULES_CACHE_TTL_MS });
-  return result;
+    return result;
+  });
 }
 
 export function clearEntityLinkRulesCache(): void {
@@ -128,7 +113,7 @@ type ExtractedLink = {
 function extractLink(item: BatchItem, rule: EntityLinkRule): ExtractedLink | null {
   const identities: ExtractedLink['identities'] = [];
   for (const spec of rule.identities) {
-    const raw = readPath(item, spec.eventPath);
+    const raw = getValueAtPath(item, spec.eventPath);
     if (typeof raw !== 'string' || raw.length === 0) continue;
     const normalized = normalizeIdentifier(spec.namespace, raw);
     if (!normalized) continue;
@@ -143,12 +128,12 @@ function extractLink(item: BatchItem, rule: EntityLinkRule): ExtractedLink | nul
   const traits = new Map<string, unknown>();
   if (rule.traits) {
     for (const [key, spec] of Object.entries(rule.traits)) {
-      const value = readPath(item, spec.eventPath);
+      const value = getValueAtPath(item, spec.eventPath);
       if (value !== undefined) traits.set(key, value);
     }
   }
 
-  const rawTitle = rule.titlePath ? readPath(item, rule.titlePath) : undefined;
+  const rawTitle = rule.titlePath ? getValueAtPath(item, rule.titlePath) : undefined;
   const title = typeof rawTitle === 'string' && rawTitle.trim() ? rawTitle.trim() : '';
 
   return { identities, traits, title };

--- a/packages/server/src/utils/entity-management.ts
+++ b/packages/server/src/utils/entity-management.ts
@@ -6,6 +6,7 @@
  * Organization scoping ensures data isolation.
  */
 
+import { slugify } from '@lobu/core';
 import {
   createDbClientFromEnv,
   type DbClient,
@@ -106,17 +107,6 @@ export interface EntityData {
   external_ids?: Record<string, any>;
   market?: string | null;
   link?: string | null;
-}
-
-/**
- * Generate a URL-safe slug from a string.
- * NOTE: duplicated in packages/owletto/src/lib/url.ts (separate package boundary).
- */
-export function generateSlug(name: string): string {
-  return name
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-+|-+$/g, ''); // trim leading/trailing hyphens
 }
 
 export interface CreatedEntity {
@@ -278,7 +268,7 @@ export async function createEntity(
   const entityTypeId = typeRow[0].id;
 
   // Generate slug from name if not provided
-  const slug = data.slug || generateSlug(data.name);
+  const slug = data.slug || slugify(data.name);
 
   const metadata = mergeConvenienceFields(data, data.metadata || {}, 'create');
 
@@ -368,7 +358,7 @@ export async function updateEntity(
   }
 
   // Generate new slug if provided or name is being updated
-  const newSlug = data.slug ?? (data.name ? generateSlug(data.name) : null);
+  const newSlug = data.slug ?? (data.name ? slugify(data.name) : null);
 
   const metadataUpdates = mergeConvenienceFields(data, data.metadata ?? {}, 'update');
   const hasMetadataUpdates = Object.keys(metadataUpdates).length > 0;

--- a/packages/server/src/utils/event-kind-validation.ts
+++ b/packages/server/src/utils/event-kind-validation.ts
@@ -12,6 +12,7 @@
 import { getDb } from '../db/client';
 import { formatAjvError, getAjv } from './ajv-singleton';
 import { exceedsValidationLimits, isEmptyObject } from './metadata-limits';
+import { TtlCache } from './ttl-cache';
 
 // ============================================
 // Types
@@ -75,12 +76,9 @@ function findClosestKind(kind: string, validKinds: string[]): string | null {
 
 const CACHE_TTL_MS = 60_000; // 60 seconds
 
-interface EventKindsCacheEntry {
-  value: Record<string, EventKindDefinition> | null;
-  expiresAt: number;
-}
-
-const eventKindsCache = new Map<string, EventKindsCacheEntry>();
+// Per-pod cache. A cached `null` means "no event_kinds defined, accept any kind"
+// and is a real value, distinct from a cache miss.
+const eventKindsCache = new TtlCache<Record<string, EventKindDefinition> | null>(CACHE_TTL_MS);
 
 // ============================================
 // Event Kinds Resolution
@@ -93,29 +91,24 @@ const eventKindsCache = new Map<string, EventKindsCacheEntry>();
 async function getMemberEventKinds(
   orgId: string
 ): Promise<Record<string, EventKindDefinition> | null> {
-  const cacheKey = `${orgId}:$member`;
-  const now = Date.now();
-  const cached = eventKindsCache.get(cacheKey);
-  if (cached && cached.expiresAt > now) return cached.value;
-
-  const sql = getDb();
-  const rows = await sql`
-    SELECT event_kinds
-    FROM entity_types
-    WHERE slug = '$member'
-      AND organization_id = ${orgId}
-      AND deleted_at IS NULL
-    LIMIT 1
-  `;
-  let result: Record<string, EventKindDefinition> | null = null;
-  if (rows.length > 0) {
-    const eventKinds = rows[0].event_kinds;
-    if (eventKinds && typeof eventKinds === 'object') {
-      result = eventKinds as Record<string, EventKindDefinition>;
+  return eventKindsCache.getOrSet(`${orgId}:$member`, async () => {
+    const sql = getDb();
+    const rows = await sql`
+      SELECT event_kinds
+      FROM entity_types
+      WHERE slug = '$member'
+        AND organization_id = ${orgId}
+        AND deleted_at IS NULL
+      LIMIT 1
+    `;
+    if (rows.length > 0) {
+      const eventKinds = rows[0].event_kinds;
+      if (eventKinds && typeof eventKinds === 'object') {
+        return eventKinds as Record<string, EventKindDefinition>;
+      }
     }
-  }
-  eventKindsCache.set(cacheKey, { value: result, expiresAt: now + CACHE_TTL_MS });
-  return result;
+    return null;
+  });
 }
 
 /**
@@ -126,31 +119,26 @@ async function getEntityTypeEventKinds(
   orgId: string,
   entityId: number
 ): Promise<Record<string, EventKindDefinition> | null> {
-  const cacheKey = `${orgId}:entity:${entityId}`;
-  const now = Date.now();
-  const cached = eventKindsCache.get(cacheKey);
-  if (cached && cached.expiresAt > now) return cached.value;
-
-  const sql = getDb();
-  const rows = await sql`
-    SELECT et.event_kinds
-    FROM entities e
-    JOIN entity_types et ON et.id = e.entity_type_id
-    WHERE e.id = ${entityId}
-      AND e.organization_id = ${orgId}
-      AND e.deleted_at IS NULL
-      AND et.deleted_at IS NULL
-    LIMIT 1
-  `;
-  let result: Record<string, EventKindDefinition> | null = null;
-  if (rows.length > 0) {
-    const eventKinds = rows[0].event_kinds;
-    if (eventKinds && typeof eventKinds === 'object') {
-      result = eventKinds as Record<string, EventKindDefinition>;
+  return eventKindsCache.getOrSet(`${orgId}:entity:${entityId}`, async () => {
+    const sql = getDb();
+    const rows = await sql`
+      SELECT et.event_kinds
+      FROM entities e
+      JOIN entity_types et ON et.id = e.entity_type_id
+      WHERE e.id = ${entityId}
+        AND e.organization_id = ${orgId}
+        AND e.deleted_at IS NULL
+        AND et.deleted_at IS NULL
+      LIMIT 1
+    `;
+    if (rows.length > 0) {
+      const eventKinds = rows[0].event_kinds;
+      if (eventKinds && typeof eventKinds === 'object') {
+        return eventKinds as Record<string, EventKindDefinition>;
+      }
     }
-  }
-  eventKindsCache.set(cacheKey, { value: result, expiresAt: now + CACHE_TTL_MS });
-  return result;
+    return null;
+  });
 }
 
 /**
@@ -162,31 +150,26 @@ async function getConnectorEventKinds(
   feedKey: string,
   orgId: string
 ): Promise<Record<string, EventKindDefinition> | null> {
-  const cacheKey = `${orgId}:${connectorKey}:${feedKey}`;
-  const now = Date.now();
-  const cached = eventKindsCache.get(cacheKey);
-  if (cached && cached.expiresAt > now) return cached.value;
-
-  const sql = getDb();
-  const rows = await sql`
-    SELECT feeds_schema
-    FROM connector_definitions
-    WHERE key = ${connectorKey}
-      AND organization_id = ${orgId}
-    LIMIT 1
-  `;
-  let result: Record<string, EventKindDefinition> | null = null;
-  if (rows.length > 0) {
-    const feedsSchema = rows[0].feeds_schema as Record<string, any> | null;
-    if (feedsSchema) {
-      const feedDef = feedsSchema[feedKey];
-      if (feedDef?.eventKinds) {
-        result = feedDef.eventKinds as Record<string, EventKindDefinition>;
+  return eventKindsCache.getOrSet(`${orgId}:${connectorKey}:${feedKey}`, async () => {
+    const sql = getDb();
+    const rows = await sql`
+      SELECT feeds_schema
+      FROM connector_definitions
+      WHERE key = ${connectorKey}
+        AND organization_id = ${orgId}
+      LIMIT 1
+    `;
+    if (rows.length > 0) {
+      const feedsSchema = rows[0].feeds_schema as Record<string, any> | null;
+      if (feedsSchema) {
+        const feedDef = feedsSchema[feedKey];
+        if (feedDef?.eventKinds) {
+          return feedDef.eventKinds as Record<string, EventKindDefinition>;
+        }
       }
     }
-  }
-  eventKindsCache.set(cacheKey, { value: result, expiresAt: now + CACHE_TTL_MS });
-  return result;
+    return null;
+  });
 }
 
 // ============================================

--- a/packages/server/src/utils/object-path.ts
+++ b/packages/server/src/utils/object-path.ts
@@ -1,0 +1,22 @@
+/**
+ * Read a nested value from an object using a dot-notation path.
+ *
+ * Returns `undefined` when any segment is missing or a non-object is
+ * encountered along the way.
+ *
+ * @example
+ * getValueAtPath({ a: { b: 1 } }, 'a.b') // 1
+ * getValueAtPath({ a: {} }, 'a.b.c')     // undefined
+ */
+export function getValueAtPath(source: unknown, path: string): unknown {
+  let current: unknown = source;
+  for (const segment of path.split('.')) {
+    if (current == null || typeof current !== 'object') return undefined;
+    // `segment in current` (not bare bracket access) so a missing key stops
+    // traversal deterministically — matches the original keyed lookup and
+    // avoids surprises on sparse arrays / absent intermediates.
+    if (!(segment in (current as Record<string, unknown>))) return undefined;
+    current = (current as Record<string, unknown>)[segment];
+  }
+  return current;
+}

--- a/packages/server/src/utils/stable-keys.ts
+++ b/packages/server/src/utils/stable-keys.ts
@@ -9,10 +9,15 @@
  */
 
 import type { KeyingConfig } from '../types/watchers';
+import { getValueAtPath } from './object-path';
 
 /**
  * Slugify a string for use in stable keys.
- * Converts to lowercase, replaces spaces/special chars with hyphens.
+ *
+ * NOTE: This is intentionally NOT the shared `generateSlug`. Stable keys are
+ * persisted and used to merge entities across windows, so its output must stay
+ * byte-stable — it keeps word chars (`\w`) and converts underscores, which
+ * differs from the URL-slug rules. Do not consolidate this with generateSlug.
  */
 function slugify(value: string): string {
   return value
@@ -22,21 +27,6 @@ function slugify(value: string): string {
     .replace(/[\s_]+/g, '-') // Replace spaces and underscores with hyphens
     .replace(/-+/g, '-') // Collapse multiple hyphens
     .replace(/^-|-$/g, ''); // Remove leading/trailing hyphens
-}
-
-/**
- * Get a nested value from an object using a dot-notation path.
- * Example: getPath({a: {b: 1}}, 'a.b') returns 1
- */
-function getPath(obj: unknown, path: string): unknown {
-  if (!obj || typeof obj !== 'object') return undefined;
-
-  return path.split('.').reduce((acc, key) => {
-    if (acc && typeof acc === 'object' && key in acc) {
-      return (acc as Record<string, unknown>)[key];
-    }
-    return undefined;
-  }, obj as unknown);
 }
 
 /**
@@ -59,7 +49,7 @@ function getPath(obj: unknown, path: string): unknown {
  * { problems: [{ category: "Stability", name: "App Crashes", problem_key: "stability::app-crashes" }] }
  */
 export function computeStableKeys(data: Record<string, unknown>, config: KeyingConfig): void {
-  const entities = getPath(data, config.entity_path);
+  const entities = getValueAtPath(data, config.entity_path);
 
   if (!Array.isArray(entities)) {
     // No entities to process, or path doesn't resolve to an array

--- a/packages/server/src/utils/ttl-cache.ts
+++ b/packages/server/src/utils/ttl-cache.ts
@@ -19,6 +19,20 @@ export class TtlCache<V> {
     this.store.set(key, { value, expiresAt: Date.now() + this.ttlMs });
   }
 
+  /**
+   * Return the cached value for `key`, or compute it via `loader`, store it, and
+   * return it on a miss. Collapses the get/null-check/set boilerplate at call
+   * sites. Per-pod cache (no cross-replica sharing) — identical semantics to a
+   * manual get-then-set.
+   */
+  async getOrSet(key: string, loader: () => Promise<V>): Promise<V> {
+    const cached = this.get(key);
+    if (cached !== undefined) return cached;
+    const value = await loader();
+    this.set(key, value);
+    return value;
+  }
+
   delete(key: string): void {
     this.store.delete(key);
   }


### PR DESCRIPTION
Behavior-preserving simplification & de-duplication across 10 areas of the codebase, surfaced by a fan-out scan and implemented one area per file-set. **Net ~-500 LOC (+1641 / -2137), 8 new shared-helper files, 78 files touched.**

## What changed (by area)
- **utils**: `TtlCache.getOrSet` + migrate the event-kind / entity-link caches; one canonical `slugify` in `@lobu/core` (6 duplicates removed); shared `getValueAtPath`; delete dead `daysBetween`/`inferGranularity`. (Left `stable-keys` slugify alone — different regex, produces persisted entity-merge keys.)
- **cli**: collapse 3 HTTP request layers onto `ApiClient` (single `ApiError`); shared `fetchAgents`/agent-line view; export command option interfaces (init passthrough); `parseJsonObject` helper.
- **gateway/routes**: `withOwnedAgent` wrapper (preserves each route's exact denied status + admin bypass); shared `ErrorResponseSchema` + `errorResponses()` OpenAPI helper; migrate stray `c.json`/`c.req.json`; local-test connection helper.
- **gateway/auth**: `ChatGPTDeviceCodeClient` now extends `BaseOAuth2Client`; dedup `exchangeToken`/`refreshAccessToken` via a shared `postTokenRequest`; `resolveCredential`. ChatGPT wire format (form-encode, UA, `scope`) preserved.
- **gateway/orchestration+proxy+guardrails**: unify `TextJudge`/`EgressJudge` behind one `JudgeRunner` (fail-closed deny payloads + both public surfaces preserved); `extractStageText` helper; `buildWorkerTokenClaims` shared bag (makes the #1274 parity invariant structural); secret-proxy token-parser helpers (precedence + placeholder guard preserved).
- **agent-worker**: `uploadMultipart` helper + `generateAndUploadMedia` driver; `joinTextContent`; session-runner `emitAgentEnd`/`buildResult` closures.
- **tools**: `callerIsAdmin` + auth-profile-not-found helpers (existing `{error}` response shapes kept — no contract change).
- **connectors**: `BridgeOnlyConnector` base (8 device connectors); `requireBearerClient` + `token` shorthand (OAuth connectors; each connector's custom auth-error message preserved).
- **gateway/connections**: 6 `await import("chat")` -> static imports; `withResolvedThread` wrapper; `postGuardrailBlock` helper.
- **landing**: `USE_CASE_PLATFORM_LABELS` map (29 repeated literals removed); shared `<DataTable>` for the registry tables.

## Verification
- `make typecheck` (server + owletto) clean; `make build-packages` + landing build green. Two real fixes applied during the build pass: cli init `fromOrg` tristate type, and an unused import.

## Deliberately deferred (follow-ups — each needs verification beyond a mechanical edit)
- tools `{error}`/`{success:false}` -> `throw ToolUserError` sweep (needs per-caller frontend-contract audit) and `list_organizations` dispatch refactor.
- cli: delete the `openclaw-auth` org pass-through wrappers (must also own `dev.ts` + `openclaw-cmd.ts`).
- connectors: single-feed `optionsSchema` removal; checkpoint-util promotion.
- http-proxy `authorizeEgress` extraction (highest security sensitivity).
- cross-package 15-file TTL-cache sweep; `memory org` command collapse.

## Reviewer notes (teammate-flagged)
- auth: ChatGPT refresh stays on lower-level `refreshAccessToken` (not `refreshTokenWithConfig`, which would drop `scope`); one new `Accept: application/json` header on token requests.
- cli: `ApiClient` failures now exit code 3 (was 1) via the shared `ApiError`.
- connections: `onQuestionCreated` org/user guards now run after the read-only `resolveThread` (outcome identical).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1327"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784230854&installation_id=136316292&pr_number=1327&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1327&signature=5281921d59dc1da7d03f8e8d7647729254ff48e21a0c411f7ce19ba9cf5aed25"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Consolidated internal HTTP client request handling and improved error messages across APIs
  * Unified OAuth token authentication patterns for consistent credential handling
  * Standardized error response formatting for better consistency
  * Improved agent display and filtering in CLI commands

* **Bug Fixes**
  * Enhanced connector runtime validation to prevent incorrect execution outside required environments
  * Better timeout and error handling for media generation and file uploads
  * Improved guardrail and judge processing for more reliable policy enforcement

* **Chores**
  * Consolidated shared utilities for slug generation and request handling
  * Improved internal code organization and helper reusability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->