### PR TITLE
fix(mcp): reject batched tools/call that bypasses pre-tool guardrails + approval

### DIFF
--- a/packages/server/src/__tests__/guardrails-runtime.test.ts
+++ b/packages/server/src/__tests__/guardrails-runtime.test.ts
@@ -752,6 +752,87 @@ describe('McpProxy — wired pre-tool guardrail', () => {
     // to the worker — operators need it.
     expect(rows[0]!.metadata.reason).toMatch(/delete_repo/);
   });
+
+  it('rejects a JSON-RPC BATCH wrapping a forbidden tools/call instead of forwarding it unguarded', async () => {
+    // Regression: the pre-tool gate only fired when `jsonRpc.method` was
+    // "tools/call". A top-level JSON-RPC array (batch) has `method` undefined,
+    // so the whole guardrail + approval block was skipped and the raw batch was
+    // forwarded verbatim — a spec-compliant upstream then executes the batched
+    // tool call with zero enforcement. The fix rejects any batch containing a
+    // tools/call at the proxy (-32600) rather than forwarding it.
+    const fakeConfigService = {
+      // Unresolvable upstream: if the batch were ever forwarded (pre-fix) the
+      // fetch would fail with -32603 "Failed to connect", NOT our -32600. So a
+      // -32600 invalid-request response proves the gate rejected it pre-forward.
+      getHttpServer: async () => ({
+        url: 'http://upstream.invalid/mcp',
+        type: 'http' as const,
+      }),
+      getAllHttpServers: async () => new Map(),
+    };
+
+    const defaultSecretStore = new PostgresSecretStore();
+    const secretStore = new SecretStoreRegistry(defaultSecretStore, {
+      secret: defaultSecretStore,
+    });
+    const grantStore = new GrantStore();
+    const settingsStore = new AgentSettingsStore(
+      createPostgresAgentConfigStore()
+    );
+
+    const registry = new GuardrailRegistry();
+    registerBuiltinGuardrails(registry);
+
+    const proxy = new McpProxy(fakeConfigService as any, {
+      secretStore,
+      grantStore,
+      agentSettingsStore: settingsStore,
+      guardrailRegistry: registry,
+    });
+
+    const token = generateWorkerToken('u1', 'conv-1', 'deployment-1', {
+      channelId: 'c1',
+      teamId: 't1',
+      agentId,
+      organizationId: orgId,
+      platform: 'telegram',
+    });
+
+    // Top-level ARRAY (JSON-RPC batch) wrapping the forbidden tool call.
+    const body = JSON.stringify([
+      {
+        jsonrpc: '2.0',
+        id: 7,
+        method: 'tools/call',
+        params: { name: 'delete_repo', arguments: { repo: 'org/x' } },
+      },
+    ]);
+
+    const response = await orgContext.run(
+      { organizationId: orgId },
+      async () => {
+        return proxy.getApp().fetch(
+          new Request('http://localhost/test-mcp', {
+            method: 'POST',
+            headers: {
+              authorization: `Bearer ${token}`,
+              'content-type': 'application/json',
+            },
+            body,
+          })
+        );
+      }
+    );
+
+    expect(response.status).toBe(200);
+    const json = (await response.json()) as any;
+    expect(json.jsonrpc).toBe('2.0');
+    // Rejected at the proxy with an invalid-request error — NOT forwarded.
+    expect(json.error?.code).toBe(-32600);
+    expect(json.error?.message).toMatch(/Batched tools\/call is not permitted/);
+    // The forbidden call never reached an upstream, so no -32603 connect error.
+    expect(json.error?.message).not.toMatch(/Failed to connect/);
+  });
 });
 
 // ─────────────────────────────────────────────────────────────────────────

--- a/packages/server/src/gateway/auth/mcp/proxy-forward.ts
+++ b/packages/server/src/gateway/auth/mcp/proxy-forward.ts
@@ -78,7 +78,29 @@ async function handleProxyRequestAuthenticated(
 			const bodyText = await clonedReq.text();
 			if (bodyText) {
 				const jsonRpc = JSON.parse(bodyText);
-				if (jsonRpc.method === "tools/call" && jsonRpc.params?.name) {
+
+				// JSON-RPC 2.0 / the MCP streamable-HTTP transport permit BATCH
+				// requests: a top-level ARRAY of request objects. The single-request
+				// gate below keys on `jsonRpc.method`, which is `undefined` for an
+				// array — so a batched `tools/call` would skip BOTH the pre-tool
+				// guardrails and the approval gate and be forwarded verbatim, and a
+				// spec-compliant upstream executes the whole batch. The worker's MCP
+				// client never legitimately batches tool calls, so reject any batch
+				// containing one rather than forward it unguarded. Batches with no
+				// tools/call (e.g. notification batches) still pass through.
+				if (Array.isArray(jsonRpc)) {
+					if (jsonRpc.some((m) => m?.method === "tools/call")) {
+						logger.warn(
+							"Rejecting batched tools/call — guardrails and approval cannot be enforced on a JSON-RPC batch",
+							{ mcpId, agentId },
+						);
+						return sendJsonRpcError(
+							c,
+							-32600,
+							"Batched tools/call is not permitted; send each tool call as a single JSON-RPC request.",
+						);
+					}
+				} else if (jsonRpc.method === "tools/call" && jsonRpc.params?.name) {
 					const toolName = jsonRpc.params.name;
 					const toolArgs = jsonRpc.params.arguments || {};
 


### PR DESCRIPTION
## Bug (deep bug-hunt finding #2, high · adversarially verified at 88%)

The JSON-RPC proxy gate (`proxy-forward.ts`) ran pre-tool guardrails (`forbidden-tools`, `secret-scan`, `pii-scan`) and the tool-approval check only when the parsed body had `jsonRpc.method === "tools/call"`. JSON-RPC 2.0 and the MCP streamable-HTTP transport also permit **batch** requests: a top-level **array** of request objects. For an array body, `jsonRpc.method` is `undefined`, so the entire guardrail + approval block was skipped and the raw body forwarded verbatim. A spec-compliant upstream (`@modelcontextprotocol/sdk` executes batched arrays) then runs the batched `tools/call` with **zero enforcement** — defeating `forbidden-tools` and the approval gate by wrapping the call in a one-element array.

The `proxy.ts` design comment asserts guardrails run on both tool-call entrypoints "so neither can bypass the stage" — the batch form falsified that for the JSON-RPC path.

## Fix

The worker's MCP client never legitimately batches tool calls, so reject any top-level JSON-RPC array containing a `tools/call` with `-32600` before forwarding. Batches with no `tools/call` (e.g. notification batches) still pass through unchanged; single `tools/call` requests keep their existing guardrail + approval path.

## E2E — red→green reproducer (`guardrails-runtime.test.ts`, McpProxy)

A JSON-RPC batch `[{… tools/call delete_repo …}]` against an agent with `forbidden-tools` enabled:

- **RED** (rejection disabled): the gate is skipped and the forbidden call reaches `forwardRequest` unguarded (only the unrelated SSRF check stops the `.invalid` upstream — on a real allowed upstream it would execute).
- **GREEN** (fix): rejected at the proxy with `-32600` / "Batched tools/call is not permitted" before any forward; the existing single-call block test still passes. Full file: **9 passed**.

Server `tsc --noEmit`: 0 errors.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1328"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784231043&installation_id=136316292&pr_number=1328&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1328&signature=c7df9812f29de12ab6874064e332d671c918ddf56b6fc43dde6ab1ee933946b7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed security vulnerability where batched tool call requests could circumvent proxy-level guardrails. Batch requests containing tool calls are now explicitly detected and rejected at the proxy layer with appropriate error responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->