### PR TITLE
fix(data-sources): mask excluded columns + gate admin tables in view-template/watcher queries

### DIFF
--- a/packages/server/src/__tests__/integration/entity-schema/datasource-column-masking.test.ts
+++ b/packages/server/src/__tests__/integration/entity-schema/datasource-column-masking.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Data-source column masking + admin-table gate.
+ *
+ * Regression: `executeDataSources` (the runtime path for view-template
+ * `data_sources` and watcher source queries) called `buildScopedQuery` with NO
+ * options, so the org-scoped CTEs fell back to `SELECT *` and exposed EVERY
+ * physical column — including the ones the schema deliberately excludes
+ * (connections.credentials, oauth_tokens.token_hash, …). It also never applied
+ * the admin-only-table gate, so oauth_tokens/oauth_clients/user were freely
+ * referenceable. A view-template data source surfaced via the PUBLIC_READ
+ * `resolve_path` could therefore dump another tenant-surface's secret columns
+ * to any member/anonymous reader.
+ */
+
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+  executeDataSources,
+  validateDataSourceQuery,
+} from '../../../utils/execute-data-sources';
+import { cleanupTestDatabase, getTestDb } from '../../setup/test-db';
+import { createTestOrganization } from '../../setup/test-fixtures';
+
+describe('data source column masking + admin-table gate', () => {
+  let orgId: string;
+
+  beforeEach(async () => {
+    await cleanupTestDatabase();
+    const org = await createTestOrganization({ name: 'DS Masking Org' });
+    orgId = org.id;
+  });
+
+  async function seedConnectionWithSecret(secret: string) {
+    const sql = getTestDb();
+    await sql`
+      INSERT INTO connections (
+        organization_id, connector_key, slug, display_name, status,
+        credentials, created_at, updated_at
+      ) VALUES (
+        ${orgId}, 'test', 'masking-conn', 'Masking Conn', 'active',
+        ${sql.json({ token: secret })}, NOW(), NOW()
+      )
+    `;
+  }
+
+  it('masks connections.credentials (excluded column) — the secret never reaches the rows', async () => {
+    await seedConnectionWithSecret('SUPERSECRET-TOKEN');
+    const sql = getTestDb();
+    const results = await executeDataSources(
+      { leak: { query: 'SELECT slug, credentials FROM connections' } },
+      { organizationId: orgId },
+      sql
+    );
+    // The masked CTE has no `credentials` column, so the outer SELECT errors and
+    // the source yields no rows. Critically, the secret must not appear anywhere.
+    expect(JSON.stringify(results)).not.toContain('SUPERSECRET-TOKEN');
+    expect(results.leak).toEqual([]);
+  });
+
+  it('still returns allowlisted columns (masking does not break legitimate data sources)', async () => {
+    await seedConnectionWithSecret('SUPERSECRET-TOKEN');
+    const sql = getTestDb();
+    const results = await executeDataSources(
+      { ok: { query: 'SELECT slug FROM connections' } },
+      { organizationId: orgId },
+      sql
+    );
+    expect(results.ok.length).toBe(1);
+    expect((results.ok[0] as { slug: string }).slug).toBe('masking-conn');
+  });
+
+  it('blocks admin-only auth/identity tables (oauth_tokens) at runtime', async () => {
+    const sql = getTestDb();
+    const results = await executeDataSources(
+      { adm: { query: 'SELECT id FROM oauth_tokens' } },
+      { organizationId: orgId },
+      sql
+    );
+    expect(results.adm).toEqual([]);
+  });
+
+  it('rejects admin-only tables at save time (validateDataSourceQuery parse)', () => {
+    expect(() =>
+      validateDataSourceQuery('ds', 'SELECT token_hash FROM oauth_tokens', true)
+    ).toThrow(/admin-only table/);
+    expect(() =>
+      validateDataSourceQuery('ds', 'SELECT email FROM "user"', true)
+    ).toThrow(/admin-only table/);
+  });
+});

--- a/packages/server/src/utils/execute-data-sources.ts
+++ b/packages/server/src/utils/execute-data-sources.ts
@@ -23,6 +23,7 @@ import {
   buildColumnList,
   type ColumnDef,
   QUERYABLE_TABLE_NAMES,
+  SAFE_COLUMN_DEFS,
   validateTableQuery,
 } from './table-schema';
 
@@ -654,7 +655,18 @@ export function validateDataSourceQuery(name: string, query: string, parse = fal
     try {
       const res = parseSql(stripPlaceholders(trimmed), Dialect.PostgreSQL);
       if (!res.success) throw new Error(res.error ?? 'could not parse query');
-      extractTableRefs(trimmed);
+      // Reject auth/identity tables at save time so a template that would only
+      // be masked at runtime fails fast with a clear error. (Runtime masking via
+      // SAFE_COLUMN_DEFS is the enforcement; this is early, defense-in-depth
+      // feedback.) Column-level allowlisting is intentionally NOT applied here —
+      // data sources legitimately reference entity-type slugs (unknown tables).
+      const refs = extractTableRefs(trimmed);
+      const restricted = refs.filter((t) => ADMIN_ONLY_QUERYABLE_TABLES.has(t));
+      if (restricted.length > 0) {
+        throw new Error(
+          `references admin-only table(s): ${[...new Set(restricted)].join(', ')}`
+        );
+      }
     } catch (err) {
       throw new Error(`Data source '${name}': ${err instanceof Error ? err.message : String(err)}`);
     }
@@ -702,7 +714,30 @@ export async function executeDataSources(
       try {
         validateDataSourceQuery(name, query);
         const tableRefs = extractTableRefs(query);
-        let { sql: scopedQuery, params } = buildScopedQuery(query, tableRefs, context);
+
+        // Auth/identity tables (oauth_tokens, oauth_clients, user) must not be
+        // referenceable from a view-template / watcher data source — these
+        // results surface to public/member readers via resolve_path. Mirror
+        // query_sql's non-admin gate. (Entity-type slugs are never in this set.)
+        const restricted = tableRefs.filter((t) =>
+          ADMIN_ONLY_QUERYABLE_TABLES.has(t)
+        );
+        if (restricted.length > 0) {
+          throw new Error(
+            `Source '${name}': table(s) require admin access: ${[...new Set(restricted)].join(', ')}`
+          );
+        }
+
+        // safeColumns masks each core-table CTE to its allowlisted columns, so
+        // excluded secret columns (connections.credentials, oauth_tokens.
+        // token_hash, oauth_clients.client_secret, user.email/phoneNumber,
+        // events.embedding, feeds.checkpoint) are never emitted even when the
+        // query selects them. Without it the CTE fell back to SELECT *, leaking
+        // every physical column. Entity-type slug CTEs (no allowlist entry) keep
+        // their SELECT * — entity data is the template's intended payload.
+        let { sql: scopedQuery, params } = buildScopedQuery(query, tableRefs, context, {
+          safeColumns: SAFE_COLUMN_DEFS,
+        });
 
         // Validate param count matches placeholders in scoped query
         const placeholderMatches = scopedQuery.match(/\$(\d+)/g);


### PR DESCRIPTION
## Bug (deep bug-hunt finding #3, high · adversarially verified at 88%)

`executeDataSources` — the runtime for view-template `data_sources` and watcher source queries — called `buildScopedQuery` with **no options**, so the org-scoped CTEs fell back to `SELECT *` and exposed **every physical column**, including the ones `table-schema.ts` deliberately excludes: `connections.credentials`, `oauth_tokens.token_hash`, `oauth_clients.client_secret`, `user.email`/`phoneNumber`, `events.embedding`, `feeds.checkpoint`. It also never applied the admin-only-table gate, so `oauth_tokens`/`oauth_clients`/`user` were freely referenceable. A data source surfaced via the **PUBLIC_READ** `resolve_path` could therefore dump secret columns to any member/anonymous reader — defeating both enforcement layers the schema header promises.

## Fix

- Pass `safeColumns: SAFE_COLUMN_DEFS` to `buildScopedQuery` so each core-table CTE emits only allowlisted columns. A query selecting an excluded column references a column the CTE never produced → it errors → the source yields no rows; the secret is never emitted.
- Reject `ADMIN_ONLY_QUERYABLE_TABLES` (`oauth_tokens`/`oauth_clients`/`user`) at **runtime** and at **save time** (`validateDataSourceQuery` parse branch), mirroring `query_sql`'s non-admin gate.

Entity-type slug CTEs (the common data-source case) keep `SELECT *` — entity data is the template's intended payload, and they have no `safeColumns` entry so behavior is unchanged. Column-level allowlisting (`validateTableQuery`) is intentionally **not** applied to data sources because they legitimately reference entity-type slugs (unknown tables), which that validator rejects (E200).

## E2E — red→green reproducer (`datasource-column-masking.test.ts`)

A connection seeded with `credentials = {"token":"SUPERSECRET-TOKEN"}`:

- **RED**: `SELECT slug, credentials FROM connections` returns `{slug, credentials:{token:"SUPERSECRET-TOKEN"}}` (secret leaked); `SELECT token_hash FROM oauth_tokens` saves OK.
- **GREEN**: `credentials` is masked (no rows, secret never present); `SELECT slug FROM connections` still returns the row (masking doesn't break legit queries); `oauth_tokens`/`user` are rejected at save. **4 passed.**

No regression: 83 `bun test` unit cases (watcher source projection + scoped-query schema rejection) pass; entity-slug behavior unchanged. Server `tsc --noEmit`: 0 errors.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1329"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784231576&installation_id=136316292&pr_number=1329&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1329&signature=df4d1c9f40b2a3589c85e0797b11c8d4baee3cbfd33d9dfd8e0c88826203ef9c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->