### PR TITLE
fix(files): bind worker upload destination to the verified token, not request headers

### DIFF
--- a/packages/server/src/gateway/__tests__/file-routes.test.ts
+++ b/packages/server/src/gateway/__tests__/file-routes.test.ts
@@ -126,4 +126,54 @@ describe("file routes", () => {
     );
     expect(await downloadResponse.text()).toBe(contents);
   });
+
+  // SECURITY regression: the upload route read the destination channel from the
+  // X-Channel-Id / X-Conversation-Id request headers, never comparing them to
+  // the verified worker token. A worker could override them to deliver
+  // attachments to ANY channel the connection's bot can reach. The route must
+  // use the token-bound channel/conversation and ignore the headers.
+  test("upload routes to the TOKEN-bound channel, not attacker-supplied headers", async () => {
+    let seen: { channelId?: string; threadTs?: string } | undefined;
+    const handler: IFileHandler = {
+      uploadFile: async (_stream, opts) => {
+        seen = { channelId: opts.channelId, threadTs: opts.threadTs };
+        return {
+          fileId: "f1",
+          permalink: "https://example.test/f1",
+          name: opts.filename ?? "f",
+          size: 1,
+          delivery: "platform-upload" as const,
+        };
+      },
+    };
+    const app = buildApp(handler);
+
+    // Token scopes the worker to channel-1 / conv-1.
+    const token = generateWorkerToken("user-1", "conv-1", "worker-1", {
+      channelId: "channel-1",
+      platform: "telegram",
+    });
+    const form = new FormData();
+    form.set("file", new File(["x"], "p.txt", { type: "text/plain" }));
+    form.set("filename", "p.txt");
+
+    // Attacker-supplied headers point at a different channel/conversation.
+    const res = await app.request("/internal/files/upload", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "X-Channel-Id": "victim-channel",
+        "X-Conversation-Id": "victim-conv",
+      },
+      body: form,
+    });
+
+    expect(res.status).toBe(200);
+    // The file handler must have been invoked with the token-bound channel,
+    // NOT the attacker's header values.
+    expect(seen?.channelId).toBe("channel-1");
+    expect(seen?.threadTs).toBe("conv-1");
+    expect(seen?.channelId).not.toBe("victim-channel");
+    expect(seen?.threadTs).not.toBe("victim-conv");
+  });
 });

--- a/packages/server/src/gateway/routes/internal/files.ts
+++ b/packages/server/src/gateway/routes/internal/files.ts
@@ -76,8 +76,15 @@ export function createFileRoutes(
   router.post("/upload", authenticateWorker, async (c) => {
     try {
       const worker = getVerifiedWorker(c);
-      const channelId = c.req.header("x-channel-id");
-      const conversationId = c.req.header("x-conversation-id");
+      // SECURITY: the channel/conversation a worker may upload to is fixed by
+      // its verified token, NOT by request headers. Trusting the X-Channel-Id /
+      // X-Conversation-Id headers let a worker (or anyone holding a worker
+      // token) deliver attachments to ANY channel the connection's bot can
+      // reach — cross-channel/cross-conversation disclosure. Mirror the history
+      // route, which is token-bound for exactly this reason. Only the voice-
+      // message flag stays caller-controlled (it's not a routing decision).
+      const channelId = worker.channelId;
+      const conversationId = worker.conversationId;
       const voiceMessage = c.req.header("x-voice-message") === "true";
 
       if (!channelId || !conversationId) {
@@ -179,8 +186,11 @@ export function createFileRoutes(
   router.post("/upload-batch", authenticateWorker, async (c) => {
     try {
       const worker = getVerifiedWorker(c);
-      const channelId = c.req.header("x-channel-id");
-      const conversationId = c.req.header("x-conversation-id");
+      // SECURITY: token-bound channel/conversation (see /upload above) — never
+      // the X-Channel-Id / X-Conversation-Id headers, which a worker could
+      // override to deliver attachments to an arbitrary channel.
+      const channelId = worker.channelId;
+      const conversationId = worker.conversationId;
 
       if (!channelId || !conversationId) {
         return errorResponse(c, "Missing channel or conversation ID", 400);


### PR DESCRIPTION
## Bug (deep bug-hunt finding #4, high · adversarially verified at 85%)

`/internal/files/upload` and `/upload-batch` read the destination channel + conversation from the `X-Channel-Id` / `X-Conversation-Id` request headers and never compared them to the verified worker token. A prompt-injected or otherwise subverted worker (or anyone holding a worker token) could override the headers and deliver attachments (`upload_file` / `generate_image` / `generate_audio`) to **any channel the connection's bot can reach** — cross-channel/cross-conversation disclosure within the tenant.

The sibling `history` route was explicitly hardened against exactly this ("the channel a worker may read is fixed by its verified token, NOT by request input"); upload was missed.

## Fix

Use the token-bound `worker.channelId` / `worker.conversationId` and ignore the headers, in both routes. Only the `X-Voice-Message` flag stays caller-controlled (it's not a routing decision).

## E2E — red→green reproducer (`file-routes.test.ts`)

A worker token scoped to `channel-1`/`conv-1` uploads with `X-Channel-Id: victim-channel`, `X-Conversation-Id: victim-conv`:

- **RED**: the file handler is invoked with `victim-channel` (header wins).
- **GREEN**: it is invoked with the token-bound `channel-1`/`conv-1`; the two existing fallback tests still pass. **3 passed.**

Server `tsc --noEmit`: 0 errors.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1330"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784231836&installation_id=136316292&pr_number=1330&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1330&signature=5eab4e2d9c9fbe24807a5797204963f7ab99e6d2626ce59981f50e3d2f53dcdd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->