### PR TITLE
fix(notifications): deliver proactive notifications to preview-linked channels (cross-org)

### DIFF
--- a/packages/server/src/__tests__/integration/notifications/bot-delivery.test.ts
+++ b/packages/server/src/__tests__/integration/notifications/bot-delivery.test.ts
@@ -17,6 +17,8 @@ async function seedSlackConnection(opts: {
   agentId: string;
   connectionId: string;
   status?: string;
+  settings?: Record<string, unknown>;
+  metadata?: Record<string, unknown>;
 }): Promise<void> {
   const sql = getTestDb();
   await sql`
@@ -24,7 +26,7 @@ async function seedSlackConnection(opts: {
       (id, organization_id, agent_id, platform, config, settings, metadata, status, created_at, updated_at)
     VALUES (
       ${opts.connectionId}, ${opts.organizationId}, ${opts.agentId}, 'slack',
-      ${sql.json({})}, ${sql.json({})}, ${sql.json({})}, ${opts.status ?? 'active'}, NOW(), NOW()
+      ${sql.json({})}, ${sql.json(opts.settings ?? {})}, ${sql.json(opts.metadata ?? {})}, ${opts.status ?? 'active'}, NOW(), NOW()
     )
   `;
 }
@@ -135,5 +137,112 @@ describe('resolveBotDeliveryTargets', () => {
 
     const targets = await resolveBotDeliveryTargets(org.id, 'conn-2');
     expect(targets.map((t) => t.connectionId)).toEqual(['conn-2']);
+  });
+
+  // --- Hosted-preview cross-org delivery (the proactive-notification bug) ---
+  // The shared preview bot is ONE connection, in its OWN org, under a placeholder
+  // agent, that fans out to agents across many orgs. A `/lobu link <code>` writes
+  // the binding under the LINKING org. So the org-scoped (org, agent) JOIN misses
+  // it on both columns and proactive notifications (incl. reaction posts) drop.
+
+  it('cross-org: delivers a tenant org binding through the shared previewMode connection', async () => {
+    const hostOrg = await createTestOrganization(); // where the hosted preview conn lives
+    const tenantOrg = await createTestOrganization(); // the org that /lobu link'd a channel
+    await createTestAgent({ organizationId: hostOrg.id, agentId: 'concierge' });
+    await createTestAgent({ organizationId: tenantOrg.id, agentId: 'food-ordering' });
+
+    await seedSlackConnection({
+      organizationId: hostOrg.id,
+      agentId: 'concierge',
+      connectionId: 'preview-conn',
+      settings: { previewMode: true },
+      metadata: {}, // hosted preview invariant: no teamId
+    });
+    await seedBinding({
+      organizationId: tenantOrg.id, // binding lives in the TENANT org, not the conn's org
+      agentId: 'food-ordering', // and points at a DIFFERENT agent than the conn's
+      channelId: 'slack:C0LUNCH',
+    });
+
+    const targets = await resolveBotDeliveryTargets(tenantOrg.id);
+    expect(targets).toEqual([
+      { connectionId: 'preview-conn', platform: 'slack', channelKey: 'slack:C0LUNCH' },
+    ]);
+  });
+
+  it('cross-org guardrail: a NORMAL (non-preview) connection in another org is never used', async () => {
+    const otherOrg = await createTestOrganization();
+    const tenantOrg = await createTestOrganization();
+    await createTestAgent({ organizationId: otherOrg.id, agentId: 'crm' });
+    await createTestAgent({ organizationId: tenantOrg.id, agentId: 'food-ordering' });
+
+    await seedSlackConnection({
+      organizationId: otherOrg.id,
+      agentId: 'crm',
+      connectionId: 'normal-conn',
+      settings: {}, // NOT previewMode
+    });
+    await seedBinding({
+      organizationId: tenantOrg.id,
+      agentId: 'food-ordering',
+      channelId: 'slack:C0LUNCH',
+    });
+
+    // Multi-tenant wall: org-scoping holds for normal bots.
+    expect(await resolveBotDeliveryTargets(tenantOrg.id)).toEqual([]);
+  });
+
+  it('cross-org guardrail: a previewMode connection WITH metadata.teamId is not used cross-org', async () => {
+    const hostOrg = await createTestOrganization();
+    const tenantOrg = await createTestOrganization();
+    await createTestAgent({ organizationId: hostOrg.id, agentId: 'concierge' });
+    await createTestAgent({ organizationId: tenantOrg.id, agentId: 'food-ordering' });
+
+    await seedSlackConnection({
+      organizationId: hostOrg.id,
+      agentId: 'concierge',
+      connectionId: 'preview-conn',
+      settings: { previewMode: true },
+      metadata: { teamId: 'T_HOST' }, // a real workspace-bound install, not the hosted preview
+    });
+    await seedBinding({
+      organizationId: tenantOrg.id,
+      agentId: 'food-ordering',
+      channelId: 'slack:C0LUNCH',
+    });
+
+    expect(await resolveBotDeliveryTargets(tenantOrg.id)).toEqual([]);
+  });
+
+  it('does not double-deliver when the org owns its own connection on that channel', async () => {
+    const hostOrg = await createTestOrganization();
+    const tenantOrg = await createTestOrganization();
+    await createTestAgent({ organizationId: hostOrg.id, agentId: 'concierge' });
+    const tenantAgent = await createTestAgent({
+      organizationId: tenantOrg.id,
+      agentId: 'food-ordering',
+    });
+
+    await seedSlackConnection({
+      organizationId: hostOrg.id,
+      agentId: 'concierge',
+      connectionId: 'preview-conn',
+      settings: { previewMode: true },
+    });
+    await seedSlackConnection({
+      organizationId: tenantOrg.id,
+      agentId: tenantAgent.agentId,
+      connectionId: 'own-conn',
+    });
+    await seedBinding({
+      organizationId: tenantOrg.id,
+      agentId: tenantAgent.agentId,
+      channelId: 'slack:C0LUNCH',
+    });
+
+    // Only the org's own connection — the preview branch is skipped (NOT EXISTS).
+    expect(await resolveBotDeliveryTargets(tenantOrg.id)).toEqual([
+      { connectionId: 'own-conn', platform: 'slack', channelKey: 'slack:C0LUNCH' },
+    ]);
   });
 });

--- a/packages/server/src/notifications/service.ts
+++ b/packages/server/src/notifications/service.ts
@@ -49,30 +49,94 @@ interface BotDeliveryTarget {
 }
 
 /**
- * Resolve where a notification should be posted: the org's active chat
- * connections JOINed to their channel bindings. A connection with no binding
- * has no target and is omitted; a connection bound to several channels yields
- * one target each. Exported for testing the delivery path against a real DB.
+ * Resolve where a notification should be posted.
+ *
+ * Two branches, UNIONed:
+ *
+ *   (A) The org's OWN active chat connections JOINed to their channel bindings,
+ *       scoped to (org, agent) — the multi-tenant default. A connection with no
+ *       binding has no target; a connection bound to several channels yields one
+ *       target each.
+ *
+ *   (B) Hosted-preview cross-org delivery. The hosted preview bot is ONE
+ *       connection living in its OWN org under a placeholder agent, that fans
+ *       out to agents across MANY orgs — a `/lobu link <code>` writes the
+ *       binding under the claim's org, never the connection's. So branch (A)'s
+ *       `(org, agent)` JOIN misses it on BOTH columns and proactive
+ *       notifications silently drop. This branch resolves the org's bindings
+ *       through the shared preview connection, mirroring the inbound
+ *       `getBindingAnyOrg` exception. It is gated HARD to previewMode
+ *       connections with no `metadata.teamId` (the hosted-bot invariant, same as
+ *       `getDefaultConnection`) and is NOT joined on `agent_id`, so a normal
+ *       tenant bot can never be used to deliver cross-org.
+ *
+ * Single-workspace assumption: with exactly one hosted preview connection per
+ * platform today, (B) matches on platform alone. When a second hosted workspace
+ * appears, persist its Slack team id (e.g. `settings.hostedWorkspaceTeamId`) and
+ * add `AND ac.settings->>'hostedWorkspaceTeamId' = b.team_id` so a binding only
+ * resolves the connection actually installed in its workspace (Slack channel ids
+ * are workspace-scoped, not global).
+ *
+ * Exported for testing the delivery path against a real DB.
  */
 export async function resolveBotDeliveryTargets(
   organizationId: string,
   connectionId?: string | null
 ): Promise<BotDeliveryTarget[]> {
   const sql = getDb();
+  const connFilterA = connectionId ? sql`AND ac.id = ${connectionId}` : sql``;
+  const connFilterB = connectionId ? sql`AND pc.id = ${connectionId}` : sql``;
   const rows = (await sql`
-    SELECT ac.id, ac.platform, b.channel_id
-    FROM agent_connections ac
-    JOIN agent_channel_bindings b
-      ON b.organization_id = ac.organization_id
-     AND b.agent_id = ac.agent_id
-     AND b.platform = ac.platform
-    WHERE ac.organization_id = ${organizationId}
-      AND ac.status = 'active'
-      ${connectionId ? sql`AND ac.id = ${connectionId}` : sql``}
+    SELECT id, platform, channel_id, created_at FROM (
+      -- (A) the org's own connections, scoped to (org, agent)
+      SELECT ac.id, ac.platform, b.channel_id, b.created_at
+      FROM agent_connections ac
+      JOIN agent_channel_bindings b
+        ON b.organization_id = ac.organization_id
+       AND b.agent_id = ac.agent_id
+       AND b.platform = ac.platform
+      WHERE ac.organization_id = ${organizationId}
+        AND ac.status = 'active'
+        ${connFilterA}
+
+      UNION
+
+      -- (B) hosted-preview cross-org: this org's bindings via the shared preview
+      -- connection. NO agent_id join (preview conn's agent != the binding's);
+      -- gated to previewMode + no metadata.teamId so a normal bot is never used.
+      SELECT pc.id, pc.platform, b.channel_id, b.created_at
+      FROM agent_channel_bindings b
+      JOIN agent_connections pc
+        ON pc.platform = b.platform
+       AND pc.status = 'active'
+       AND pc.settings->'previewMode' = 'true'::jsonb
+       AND (pc.metadata->>'teamId') IS NULL
+      WHERE b.organization_id = ${organizationId}
+        ${connFilterB}
+        -- Skip if the org already owns an active connection on this channel
+        -- (branch A covers it) so we don't double-post.
+        AND NOT EXISTS (
+          SELECT 1
+          FROM agent_connections own
+          JOIN agent_channel_bindings ob
+            ON ob.organization_id = own.organization_id
+           AND ob.agent_id = own.agent_id
+           AND ob.platform = own.platform
+          WHERE own.organization_id = ${organizationId}
+            AND own.status = 'active'
+            AND ob.platform = b.platform
+            AND ob.channel_id = b.channel_id
+        )
+    ) targets
     -- Deliver in binding-creation order so earlier bindings (the primary
     -- channel) are attempted first when an agent is bound to several.
-    ORDER BY b.created_at ASC
-  `) as Array<{ id: string; platform: string; channel_id: string }>;
+    ORDER BY created_at ASC
+  `) as Array<{
+    id: string;
+    platform: string;
+    channel_id: string;
+    created_at: Date;
+  }>;
 
   return rows.map((row) => ({
     connectionId: row.id,


### PR DESCRIPTION
## The gap

The hosted preview Slack bot is **one** connection, living in **its own org** (`org_lobucrm`) under a placeholder agent, that fans out to agents across many orgs — a `/lobu link <code>` writes the channel binding under the **linking** org (e.g. `lobu-team`). Inbound routing already resolves this cross-org via `getBindingAnyOrg`; **outbound delivery never did.**

`resolveBotDeliveryTargets` only joined `agent_connections` → `agent_channel_bindings` on `(organization_id, agent_id)`. For a preview link that's a *double* miss: the connection is in another org **and** owned by a different agent. So proactive notifications — watcher notifications, and the reaction's `notifications.send` (e.g. the office-bot's live Deliveroo menu) — silently resolved zero targets and dropped. Confirmed on prod: `resolveBotDeliveryTargets(lobu-team)` returns 0; the same query without the org filter returns exactly one target (the preview connection → the linked channel).

## The fix

A UNION branch that resolves the org's bindings through the shared preview connection, mirroring the inbound exception. Gated **hard** to `previewMode` connections with no `metadata.teamId` (the hosted-bot invariant, same as `getDefaultConnection`) and **not** joined on `agent_id`, so a normal tenant bot can never be used cross-org. A `NOT EXISTS` skips the preview branch when the org already owns a connection on the channel (no double-post). Single hosted workspace today; a comment documents the `team_id` match to add when a second appears (Slack channel ids are workspace-scoped).

## Tests
- cross-org delivery resolves through the preview connection
- a non-preview connection in another org is never used (multi-tenant wall)
- a previewMode connection **with** `metadata.teamId` is rejected cross-org
- no double-delivery when the org owns its own connection on the channel

Diagnosis and fix shape were independently reviewed by **Gemini** and **Grok** — both confirmed the root cause (including the `agent_id` double-miss) and the previewMode-only guardrail.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1331"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784232513&installation_id=136316292&pr_number=1331&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1331&signature=0bcf2d3e479e01e747b4d87b98f1105844a6152b974655fa6028d5dda869c696"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->