### PR TITLE
fix(guardrails): harden secret-scan coverage + always scan full completion text

### DIFF
--- a/packages/server/src/__tests__/guardrails-runtime.test.ts
+++ b/packages/server/src/__tests__/guardrails-runtime.test.ts
@@ -417,6 +417,55 @@ describe('ChatResponseBridge — wired output guardrail', () => {
     expect(rows.length).toBe(1);
     expect(rows[0]!.metadata.guardrail).toBe('secret-scan');
   });
+
+  it('scans finalText at completion for a LIVE-STREAMING (telegram) reply — catches a secret longer than the per-delta window', async () => {
+    // Regression: the completion full-text scan was gated on
+    // `deliversAtCompletion`, so live-streaming platforms (telegram) only had
+    // the bounded per-delta window. A secret LONGER than that window trips no
+    // per-delta scan and previously landed in history unscanned. The completion
+    // scan now runs for every strategy.
+    const { target, posted } = createCapturingTarget();
+    const manager = createManager(target, agentId, orgId); // telegram = live-streaming
+    const bridge = new ChatResponseBridge(manager as any);
+
+    const registry = new GuardrailRegistry();
+    registerBuiltinGuardrails(registry);
+    const settingsStore = new AgentSettingsStore(
+      createPostgresAgentConfigStore()
+    );
+    bridge.setGuardrails(registry, settingsStore);
+
+    // A JWT well over the 512-char per-delta window — only the full-text
+    // completion scan can see it whole. No handleDelta is called.
+    const longJwt = `eyJhbGciOiJSUzI1NiJ9.eyJ${'A'.repeat(900)}.${'S'.repeat(342)}`;
+    const payload = {
+      messageId: 'm1',
+      channelId: '123',
+      conversationId: '123',
+      userId: 'u1',
+      teamId: 't1',
+      timestamp: 0,
+      platform: 'telegram',
+      platformMetadata: { connectionId: 'conn-1', chatId: '123' },
+      finalText: `your token is ${longJwt}`,
+      processedMessageIds: ['m1'],
+    };
+
+    await orgContext.run({ organizationId: orgId }, async () => {
+      await bridge.handleCompletion(payload as any, 's');
+    });
+
+    const blockPost = posted.find((p) =>
+      p.text?.startsWith('Message blocked by guardrail')
+    );
+    expect(blockPost).toBeDefined();
+    expect(blockPost!.text).toMatch(/jwt/);
+
+    await flushPendingGuardrailAudits();
+    const rows = await fetchGuardrailEvents(orgId, 'output');
+    expect(rows.length).toBe(1);
+    expect(rows[0]!.metadata.guardrail).toBe('secret-scan');
+  });
 });
 
 // ─────────────────────────────────────────────────────────────────────────

--- a/packages/server/src/gateway/connections/chat-response-bridge.ts
+++ b/packages/server/src/gateway/connections/chat-response-bridge.ts
@@ -381,18 +381,21 @@ export class ChatResponseBridge implements ResponseRenderer {
     const canDeliverFromFinalText =
       strategy.deliversAtCompletion && !!payload.finalText?.trim();
 
-    // Output guardrail for the post-once path. A post-once strategy delivers
-    // here from the full text, so the per-delta scan in handleDelta is NOT a
-    // sufficient guard under N>1 replicas: this completing pod may have scanned
-    // no deltas (cross-pod) or only the subset it claimed, and a secret split
-    // across deltas that scattered to different pods trips no per-delta scan.
-    // `blockedStreams` is pod-local and cannot protect a cross-replica
-    // completion. So scan the full delivered text once here; on a trip, post
-    // the block message and suppress both delivery and history. (Live-streaming
-    // strategies can't defer — they already streamed per-delta — so this only
-    // runs for deliversAtCompletion strategies.)
+    // Output guardrail on the full delivered text, for EVERY strategy. The
+    // per-delta scan in handleDelta only sees a bounded rolling window, so a
+    // secret LONGER than that window (e.g. a multi-hundred-char JWT / OAuth
+    // access token) trips no per-delta scan at all. And under N>1 replicas a
+    // completing pod may have scanned no deltas (cross-pod) or only the subset
+    // it claimed; `blockedStreams` is pod-local and can't protect a cross-pod
+    // completion. So scan the full authoritative text once here regardless of
+    // strategy. On a trip: post the block message and suppress both delivery
+    // and history. (A live-streaming strategy already emitted its per-delta
+    // bytes — those can't be unsent — but this keeps the secret OUT of stored
+    // history and audits the trip; a post-once strategy blocks before any
+    // delivery. Previously this scan ran only for post-once strategies, so a
+    // long secret streamed live escaped entirely.)
     let blockedAtCompletion = false;
-    if (strategy.deliversAtCompletion) {
+    {
       const completionText = payload.finalText ?? stream?.buffer ?? "";
       if (completionText.trim()) {
         const trip = await this.runOutputGuardrails(completionText, payload, ctx);

--- a/packages/server/src/gateway/guardrails/__tests__/guardrails.test.ts
+++ b/packages/server/src/gateway/guardrails/__tests__/guardrails.test.ts
@@ -125,6 +125,68 @@ describe("safeStringify", () => {
   });
 });
 
+// --- secret-scan -----------------------------------------------------------
+
+describe("secret-scan builtin", () => {
+  function secretScan() {
+    const reg = new GuardrailRegistry();
+    registerBuiltinGuardrails(reg);
+    const g = reg.get("output", "secret-scan");
+    if (!g) throw new Error("secret-scan not registered");
+    return g;
+  }
+
+  async function tripped(text: string): Promise<boolean> {
+    const r = await secretScan().run({
+      agentId: "a",
+      userId: "u",
+      platform: "slack",
+      text,
+    });
+    return r.tripped === true;
+  }
+
+  // A canonical HS256 JWT: header is base64url({"alg":"HS256","typ":"JWT"}) =
+  // 36 chars (only 33 after `eyJ`), which the old `{40,}` floor missed.
+  const HS256_JWT =
+    "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9" +
+    ".eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ" +
+    ".SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c";
+
+  test("trips on a standard HS256 JWT (regression: 33-char header < old {40,} floor)", async () => {
+    expect(await tripped(`token: ${HS256_JWT}`)).toBe(true);
+  });
+
+  test("trips on a JWT longer than the per-delta scan window", async () => {
+    // A realistic OIDC access token with a large payload — well over 512 chars.
+    const bigPayload = "A".repeat(900);
+    const longJwt = `eyJhbGciOiJSUzI1NiJ9.eyJ${bigPayload}.${"S".repeat(342)}`;
+    expect(longJwt.length).toBeGreaterThan(512);
+    expect(await tripped(longJwt)).toBe(true);
+  });
+
+  test("trips on GitHub OAuth/app tokens (gho_/ghu_/ghs_/ghr_) and fine-grained PATs", async () => {
+    expect(await tripped(`gho_${"A".repeat(36)}`)).toBe(true);
+    expect(await tripped(`ghs_${"b".repeat(36)}`)).toBe(true);
+    expect(await tripped(`github_pat_${"1aB2".repeat(8)}`)).toBe(true);
+    // Classic PAT still caught.
+    expect(await tripped(`ghp_${"c".repeat(36)}`)).toBe(true);
+  });
+
+  test("trips on AWS temporary (STS / ASIA) and other principal-id access keys", async () => {
+    expect(await tripped("ASIAY34FZKBOKMUTVV7A")).toBe(true);
+    expect(await tripped("AROAEXAMPLEID1234567")).toBe(true);
+    // Long-term AKIA still caught.
+    expect(await tripped("AKIAIOSFODNN7EXAMPLE")).toBe(true);
+  });
+
+  test("does NOT trip on benign prose (no false positive)", async () => {
+    expect(await tripped("Here is a perfectly normal sentence about tokens.")).toBe(
+      false
+    );
+  });
+});
+
 // --- pii-scan --------------------------------------------------------------
 
 describe("pii-scan builtin", () => {

--- a/packages/server/src/gateway/guardrails/builtins.ts
+++ b/packages/server/src/gateway/guardrails/builtins.ts
@@ -104,11 +104,24 @@ const SECRET_PATTERNS: Array<{ name: string; re: RegExp }> = [
   // Allow hyphens so prefixed keys (Anthropic `sk-ant-…`, OpenAI `sk-proj-…`)
   // are matched, not truncated at the first hyphen.
   { name: "openai-key", re: /sk-[a-zA-Z0-9-]{20,}/ },
-  { name: "github-pat", re: /ghp_[a-zA-Z0-9]{36}/ },
-  { name: "aws-access-key", re: /AKIA[0-9A-Z]{16}/ },
+  // GitHub tokens: classic PAT (ghp_) AND OAuth/app/user/refresh tokens
+  // (gho_/ghu_/ghs_/ghr_) — the `ghp_`-only pattern missed every non-PAT form.
+  { name: "github-token", re: /gh[oprsu]_[A-Za-z0-9]{36,}/ },
+  // GitHub fine-grained PAT (`github_pat_…`) — a different shape entirely.
+  { name: "github-fine-grained-pat", re: /github_pat_[0-9A-Za-z_]{22,}/ },
+  // AWS access key IDs. AKIA = long-term; ASIA = temporary/STS session creds
+  // (ubiquitous in assumed-role agent environments); AGPA/AIDA/AROA = other
+  // principal-id prefixes. The AKIA-only pattern missed STS keys entirely.
+  { name: "aws-access-key", re: /(AKIA|ASIA|AGPA|AIDA|AROA)[0-9A-Z]{16}/ },
+  // JWT: header.payload.signature, all base64url. Header AND payload each
+  // base64url-encode a JSON object, so both begin `eyJ`. The previous `{40,}`
+  // floor on the header missed standard tokens — a canonical HS256 header is
+  // only 33 base64url chars after `eyJ`. Require `eyJ` on the first two
+  // segments (a strong structural signal that avoids false positives) with a
+  // sane minimum length on each.
   {
     name: "jwt",
-    re: /eyJ[A-Za-z0-9_-]{40,}\.eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+/,
+    re: /eyJ[A-Za-z0-9_-]{10,}\.eyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}/,
   },
 ];
 


### PR DESCRIPTION
## Bundle: three secret-scan gaps (deep bug-hunt findings #7, #8, #9)

### #8 — JWT regex missed standard tokens (medium · 93%)
`eyJ[A-Za-z0-9_-]{40,}\.eyJ…` required ≥40 base64url chars in the header, but a canonical HS256 header is only **33** chars after `eyJ` — so jwt.io's own sample token and most real session/OAuth JWTs slipped through. New pattern requires `eyJ` on **both** the header and payload segments (a strong structural signal that avoids false positives) with a sane per-segment minimum.

### #9 — missing credential formats (medium · 90%)
secret-scan only matched classic `ghp_` PATs and `AKIA` long-term AWS keys. Added:
- GitHub OAuth/app/user/refresh tokens — `gho_`/`ghu_`/`ghs_`/`ghr_`
- GitHub fine-grained PATs — `github_pat_…`
- AWS temporary/STS + principal-id keys — `ASIA` (assumed-role session creds, ubiquitous in agent envs), `AGPA`/`AIDA`/`AROA`

### #7 — full-text completion scan skipped for live-streaming (high · 88%)
The completion full-text scan was gated on `deliversAtCompletion`, so live-streaming platforms (telegram) only had the bounded 512-char per-delta window. A secret **longer than the window** (a multi-hundred-char JWT / OAuth access token) tripped no per-delta scan and landed in stored history unflagged. The completion scan now runs for **every** strategy — keeping the secret out of history and auditing the trip even when the live bytes already streamed.

## E2E — red→green reproducers

**Unit** (`guardrails.test.ts`, 5 new cases): standard HS256 JWT, a >512-char JWT, GitHub OAuth + fine-grained tokens, AWS STS keys — all **fail on the old regexes**, pass on the new; benign prose stays clean. 53 pass.

**Integration** (`guardrails-runtime.test.ts`): a telegram (live-streaming) completion with a JWT longer than the per-delta window — **RED**: no block (gate skipped telegram); **GREEN**: block message posted + trip audited. 9 pass (incl. the existing Slack post-once test).

Server `tsc --noEmit`: 0 errors.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1332"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784232522&installation_id=136316292&pr_number=1332&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1332&signature=10841f95c95323cb3c1779f97c7a8071385102c8acfedea0add5297d4305377d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->