### PR TITLE
chore(diag): remove temp cf-partition probe

### DIFF
--- a/packages/server/src/auth/routes.ts
+++ b/packages/server/src/auth/routes.ts
@@ -437,19 +437,6 @@ credentialRoutes.post('/exchange-token', async (c) => {
   return handleExchangeToken(c, token, next, true);
 });
 
-// TEMP diagnostic — remove after diagnosing the embedded-iframe sign-in.
-// Unauthenticated; sets a cookie with the SAME attributes as the real
-// partitioned session cookie (mintSessionCookieValue) so we can curl it through
-// Cloudflare and verify whether the `Partitioned` (CHIPS) attribute survives the
-// proxy. The value is a constant; no auth, no real data.
-credentialRoutes.get('/__cf-partition-probe', (c) => {
-  c.header('Cache-Control', 'no-store');
-  c.header(
-    'Set-Cookie',
-    '__Secure-cf_partition_probe=ok; Path=/; HttpOnly; SameSite=None; Secure; Partitioned; Max-Age=60'
-  );
-  return c.json({ ok: true });
-});
 
 /**
  * Bootstrap page for the Owletto extension's side-panel iframe.


### PR DESCRIPTION
Probe confirmed Cloudflare preserves `Partitioned` (cookie arrives intact). CF is not the cause. Removing the temp endpoint.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1334"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784234157&installation_id=136316292&pr_number=1334&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1334&signature=4d3e43c87b8298e1b6279e1b02287ce5c28137c1e324301ad60ccf9ab6076847"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->