### PR TITLE
ci: add jscpd duplication gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -394,6 +394,9 @@ jobs:
       - name: Run biome lint check
         run: bun run lint
 
+      - name: Duplication gate (jscpd)
+        run: bun run dupes
+
   typecheck:
     runs-on: ubuntu-latest
     timeout-minutes: 20

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "test:packages": "cd packages/core && bun run test && cd ../agent-worker && bun run test",
     "typecheck:packages": "cd packages/core && bun run typecheck && cd ../client && bun run typecheck && cd ../agent-worker && bun run typecheck",
     "knip": "bunx knip --config config/knip.ts",
+    "dupes": "jscpd --silent --reporters console --threshold 1 --pattern 'packages/{core,server,cli,connectors,connector-sdk,connector-worker,client,embeddings,landing}/src/**/*.{ts,tsx}' --ignore '**/__tests__/**,**/*.test.ts,**/*.test.tsx,**/dist/**,**/node_modules/**,**/generated/**' .",
     "slack:manifest:print": "bun run scripts/slack-manifest.ts print",
     "slack:manifest:validate": "bun run scripts/slack-manifest.ts validate",
     "slack:manifest:update": "bun run scripts/slack-manifest.ts update",


### PR DESCRIPTION
Locks in the de-duplication from #1327 so it can't silently decay.

## What
- New `bun run dupes` script: runs `jscpd` over first-party package `src` (ts/tsx; excludes tests, dist, generated, node_modules, owletto) and **fails if duplicated lines exceed 1%**.
- Wired into the existing `format-lint` CI job (deps already installed there — no extra build/submodule cost).

## Baseline / threshold
- Current duplication on `main`: **0.85%** (99 clones). Threshold set to **1.0%** — ~0.15pp headroom so small legitimate additions pass, but a new copy-paste block trips it.
- Verified both directions: passes at 1.0, fails at 0.5 (`ERROR: jscpd found too many duplicates (0.85%) over threshold`).

## Notes
- Scope is driven by CLI flags, not a config file — jscpd's config-file `pattern`/`format` aren't honored alongside a positional path in this version, so the flags are the reliable single source of truth.
- To see *where* duplication lives when the gate trips: `bunx jscpd --reporters consoleFull --pattern '...' .` locally.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1335"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784235282&installation_id=136316292&pr_number=1335&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1335&signature=6e21e8b670a29b3af9f56e7cf571411c7c9e7e780481c17412cb580f5661950b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->