### PR TITLE
fix(server): Bearer-auth the embedded extension iframe; drop dead partitioned-cookie path

### DIFF
--- a/packages/server/src/__tests__/integration/lobu/gateway-auth.test.ts
+++ b/packages/server/src/__tests__/integration/lobu/gateway-auth.test.ts
@@ -345,4 +345,36 @@ describe('Lobu embedded Agent API auth bridge', () => {
       expect(body.error_description).toContain('not scoped to an organization');
     });
   });
+
+  describe('Better Auth session token via Bearer (embedded extension iframe)', () => {
+    it('resolves the user from a Bearer session token (the path /api/extension-session feeds)', async () => {
+      // The embedded iframe sends the session token from /api/extension-session
+      // as `Authorization: Bearer`. With no owl_pat_ prefix the bridge falls
+      // through the PAT check into getSession({ headers }), where the bearer()
+      // plugin resolves the raw session token directly (no cookie signature
+      // needed). This is the exact link that feeds c.get('user') → authProvider
+      // → verifySettingsSession on the org-scoped /api/:orgSlug/* routes the
+      // panel calls — so proving it here proves the panel authenticates.
+      const session = await createTestSession(user.id);
+
+      const { status, body } = await fetchTest(app, { token: session.token });
+
+      expect(status).toBe(200);
+      expect(body.ok).toBe(true);
+      expect(body.userId).toBe(user.id);
+      // A real Better Auth session, not the PAT pseudo-session (`pat:*`).
+      expect(body.sessionId).not.toMatch(/^pat:/);
+    });
+
+    it('rejects a bogus Bearer session token (no user)', async () => {
+      const { status, body } = await fetchTest(app, {
+        token: 'definitely-not-a-real-session-token',
+      });
+
+      expect(status).toBe(401);
+      expect(body.reason).toBe('no-user');
+      // Falls through to Better Auth (not the PAT path) → no bridge-level error.
+      expect(body.error).toBeUndefined();
+    });
+  });
 });

--- a/packages/server/src/auth/__tests__/exchange-token-cookie.test.ts
+++ b/packages/server/src/auth/__tests__/exchange-token-cookie.test.ts
@@ -10,12 +10,13 @@ import {
 } from '../../__tests__/setup/test-fixtures';
 import { get, postForm } from '../../__tests__/setup/test-helpers';
 
-// The Owletto extension embeds owletto-web as a cross-site iframe (top-level
-// chrome-extension://). Lax cookies are withheld there, so the deep-link cookie
-// posture differs by entry point: the extension iframe (POST, set inside its
-// own partition) needs CHIPS Partitioned; SameSite=None; the CLI/menu-bar
-// first-party deep-link (GET, top-level tab) keeps Lax. See auth/routes.ts.
-describe('exchange-token cookie posture', () => {
+// Two deep-link entry points, two postures:
+//   - GET /exchange-token: first-party tab (CLI/menu-bar) → Lax session cookie.
+//   - POST /extension-session: the Owletto extension's cross-site iframe
+//     (top-level chrome-extension://) can't depend on a cookie, so it gets the
+//     raw Better Auth session token in the body and sends it as Bearer.
+// See auth/routes.ts.
+describe('deep-link token exchange', () => {
   beforeEach(async () => {
     await cleanupTestDatabase();
   });
@@ -28,21 +29,21 @@ describe('exchange-token cookie posture', () => {
     return token;
   }
 
-  it('POST mints a CHIPS partitioned cross-site cookie (extension iframe)', async () => {
+  it('POST /extension-session returns a session token for Bearer use (extension iframe)', async () => {
     const token = await patForNewUser('xt-post-org', 'xt-post@test.example.com');
-    const res = await postForm('/api/exchange-token', { token, next: '/#worker=abc' });
+    const res = await postForm('/api/extension-session', { token });
 
-    expect(res.status).toBe(302);
-    expect(res.headers.get('location')).toBe('/#worker=abc');
-    const cookie = res.headers.get('set-cookie') ?? '';
-    expect(cookie).toMatch(/SameSite=None/i);
-    expect(cookie).toMatch(/Secure/i);
-    expect(cookie).toMatch(/Partitioned/i);
+    expect(res.status).toBe(200);
+    // No cookie is set — the iframe authenticates via the returned token.
+    expect(res.headers.get('set-cookie')).toBeNull();
+    const body = (await res.json()) as { session_token?: string };
+    expect(typeof body.session_token).toBe('string');
+    expect((body.session_token ?? '').length).toBeGreaterThan(0);
   });
 
-  it('POST resolves an OAuth device-code access token (cloud pairing path)', async () => {
+  it('POST /extension-session resolves an OAuth device-code access token (cloud pairing path)', async () => {
     // The extension's cloud (OAuth device-code) pairing stores an oauth_tokens
-    // access token, NOT an owl_pat_ PAT — exchange-token must resolve it or the
+    // access token, NOT an owl_pat_ PAT — the endpoint must resolve it or the
     // cloud iframe 401s and renders signed-out.
     const org = await createTestOrganization({ slug: 'xt-oauth-org' });
     const user = await createTestUser({ email: 'xt-oauth@test.example.com' });
@@ -53,12 +54,13 @@ describe('exchange-token cookie posture', () => {
     });
     expect(token.startsWith('owl_pat_')).toBe(false); // genuinely an OAuth access token
 
-    const res = await postForm('/api/exchange-token', { token, next: '/' });
-    expect(res.status).toBe(302);
-    expect(res.headers.get('set-cookie') ?? '').toMatch(/Partitioned/i);
+    const res = await postForm('/api/extension-session', { token });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { session_token?: string };
+    expect((body.session_token ?? '').length).toBeGreaterThan(0);
   });
 
-  it('GET keeps a first-party Lax cookie — never Partitioned/None (CLI/menu-bar)', async () => {
+  it('GET /exchange-token keeps a first-party Lax cookie — never Partitioned/None (CLI/menu-bar)', async () => {
     const token = await patForNewUser('xt-get-org', 'xt-get@test.example.com');
     const res = await get(`/api/exchange-token?token=${encodeURIComponent(token)}&next=/`);
 
@@ -70,17 +72,54 @@ describe('exchange-token cookie posture', () => {
   });
 
   it('rejects a missing or invalid token', async () => {
-    expect((await postForm('/api/exchange-token', { next: '/' })).status).toBe(400);
-    expect((await postForm('/api/exchange-token', { token: 'owl_pat_nope', next: '/' })).status).toBe(401);
+    expect((await postForm('/api/extension-session', {})).status).toBe(400);
+    expect((await postForm('/api/extension-session', { token: 'owl_pat_nope' })).status).toBe(401);
   });
 
-  it('serves the in-iframe bootstrap page (POSTs the token, strips the fragment)', async () => {
+  it('serves the in-iframe bootstrap page (exchanges the token, strips the fragment)', async () => {
     const res = await get('/api/extension-bootstrap');
     expect(res.status).toBe(200);
     expect(res.headers.get('content-type') ?? '').toMatch(/text\/html/i);
     const html = await res.text();
-    expect(html).toContain('/api/exchange-token');
+    expect(html).toContain('/api/extension-session');
+    expect(html).toContain('sessionStorage');
     expect(html).toContain('location.hash');
     expect(html).toContain('replaceState');
+  });
+
+  // The load-bearing claim: the session token from /extension-session, sent as
+  // `Authorization: Bearer`, authenticates the user on a real protected route
+  // via the same `getSession({ headers })` path the cloud auth bridge uses (the
+  // bearer() plugin honours the header). This is what makes the embedded iframe
+  // work without a cookie.
+  it('Bearer session token authenticates the user on a protected API route (e2e)', async () => {
+    const slug = 'xt-bearer-org';
+    const org = await createTestOrganization({ slug });
+    const user = await createTestUser({ email: 'xt-bearer@test.example.com' });
+    await addUserToOrganization(user.id, org.id, 'owner');
+    const { token: pat } = await createTestPAT(user.id, org.id, { scope: 'profile:read' });
+
+    // Exchange the extension's deep-link token for a session token.
+    const exchange = await postForm('/api/extension-session', { token: pat });
+    expect(exchange.status).toBe(200);
+    const { session_token: sessionToken } = (await exchange.json()) as {
+      session_token: string;
+    };
+    expect(sessionToken.length).toBeGreaterThan(0);
+
+    // Sent as Bearer, it resolves the user — the org they belong to is returned.
+    const authed = await get('/api/organizations', { token: sessionToken });
+    expect(authed.status).toBe(200);
+    const authedSlugs = ((await authed.json()).organizations as Array<{ slug: string }>).map(
+      (o) => o.slug
+    );
+    expect(authedSlugs).toContain(slug);
+
+    // Without it, the same user-scoped org is not resolved.
+    const anon = await get('/api/organizations');
+    const anonSlugs = ((await anon.json()).organizations as Array<{ slug: string }>).map(
+      (o) => o.slug
+    );
+    expect(anonSlugs).not.toContain(slug);
   });
 });

--- a/packages/server/src/auth/routes.ts
+++ b/packages/server/src/auth/routes.ts
@@ -275,46 +275,45 @@ function assertLoopbackClient(
 }
 
 /**
- * Mint a Better Auth session for a user and return the Set-Cookie value.
+ * Mint a Better Auth session for a user and return the raw session token.
  *
- * `partitioned` controls the cross-site posture of the cookie:
- *   - false (default): SameSite=Lax (+ Secure on https). For first-party
- *     callers — the CLI/menu-bar deep-link (GET /exchange-token) and
- *     /local-init both run in a top-level browser tab where Lax is correct.
- *   - true: SameSite=None; Secure; Partitioned (CHIPS). For the Owletto
- *     extension's side-panel iframe (POST /exchange-token), which is a
- *     CROSS-SITE iframe (top-level origin chrome-extension://…). A Lax cookie
- *     is withheld on cross-site iframe loads, so the embedded app rendered
- *     signed-out. Because the POST runs INSIDE the iframe, the cookie's
- *     partition key is the chrome-extension://<id> top-level: it's delivered on
- *     later same-partition iframe requests and ISOLATED from every other site's
- *     partition — so it does NOT widen CSRF the way an unpartitioned
- *     SameSite=None cookie would, and it survives third-party-cookie
- *     deprecation. Verified with cross-site-iframe cookie probes from the
- *     extension top-level (Lax → withheld; None;Secure;Partitioned set in the
- *     partition → delivered same-partition, absent elsewhere).
- *
- * SameSite=None/Partitioned require Secure, which the browser only honours on a
- * secure context (https or http://localhost). On a plain-http non-loopback
- * self-host the partitioned variant can't be set, so it falls back to Lax — the
- * extension's embedded view is unsupported there (first-party use is unaffected).
+ * The same token works two ways: baked into the session cookie (first-party
+ * deep links, below) or sent as `Authorization: Bearer <token>` by non-cookie
+ * clients (the CLI, the macOS app, and the Owletto extension's embedded
+ * side-panel iframe). The cloud auth bridge resolves both — see
+ * `createLobuAuthBridge`, which passes the request headers to Better Auth so
+ * the `bearer()` plugin honours the header form.
+ */
+async function createSessionToken(
+  c: Context<{ Bindings: Env }>,
+  userId: string
+): Promise<string | null> {
+  const auth = await createAuth(c.env, c.req.raw);
+  const ctx = await auth.$context;
+  const session = await ctx.internalAdapter.createSession(userId);
+  return session?.token ?? null;
+}
+
+/**
+ * Mint a Better Auth session for a user and return the first-party Set-Cookie
+ * value (SameSite=Lax, +Secure on https). For deep links that land in a
+ * top-level browser tab — the CLI/menu-bar `GET /exchange-token` and
+ * `/local-init`. Cross-site embeds (the extension iframe) can't rely on this
+ * cookie and use Bearer auth via `/extension-session` instead.
  */
 async function mintSessionCookieValue(
   c: Context<{ Bindings: Env }>,
-  userId: string,
-  opts: { partitioned?: boolean } = {}
+  userId: string
 ): Promise<{ cookieName: string; cookieHeader: string; sessionToken: string } | { error: string }> {
   const secret = c.env.BETTER_AUTH_SECRET;
   if (!secret) return { error: 'BETTER_AUTH_SECRET not set' };
 
-  const auth = await createAuth(c.env, c.req.raw);
-  const ctx = await auth.$context;
-  const session = await ctx.internalAdapter.createSession(userId);
-  if (!session?.token) return { error: 'failed to mint session' };
+  const sessionToken = await createSessionToken(c, userId);
+  if (!sessionToken) return { error: 'failed to mint session' };
 
   // Cookie shape: `<token>.<base64(HMAC-SHA256(token, secret))>`, URL-encoded.
-  const sig = createHmac('sha256', secret).update(session.token).digest('base64');
-  const cookieValue = encodeURIComponent(`${session.token}.${sig}`);
+  const sig = createHmac('sha256', secret).update(sessionToken).digest('base64');
+  const cookieValue = encodeURIComponent(`${sessionToken}.${sig}`);
   // __Secure- prefix iff the canonical baseURL is https — matches whatever
   // Better Auth would set during normal sign-in even when TLS is terminated
   // by a reverse proxy and the bind itself speaks plain HTTP.
@@ -322,23 +321,15 @@ async function mintSessionCookieValue(
   const isHttps = baseUrl.startsWith('https://');
   const cookieName = isHttps ? '__Secure-better-auth.session_token' : 'better-auth.session_token';
 
-  const isLocalhost = /^https?:\/\/(localhost|127\.0\.0\.1|\[::1\])(:|\/|$)/i.test(baseUrl);
-  const secureContext = isHttps || isLocalhost;
-  const partitioned = Boolean(opts.partitioned) && secureContext;
   const parts = [
     `${cookieName}=${cookieValue}`,
     'Path=/',
     'HttpOnly',
-    partitioned ? 'SameSite=None' : 'SameSite=Lax',
+    'SameSite=Lax',
     `Max-Age=${60 * 60 * 24 * 7}`,
   ];
-  if (partitioned) {
-    parts.push('Secure');
-    parts.push('Partitioned');
-  } else if (isHttps) {
-    parts.push('Secure');
-  }
-  return { cookieName, cookieHeader: parts.join('; '), sessionToken: session.token };
+  if (isHttps) parts.push('Secure');
+  return { cookieName, cookieHeader: parts.join('; '), sessionToken };
 }
 
 /**
@@ -372,27 +363,22 @@ async function resolveDeepLinkToken(
 
 /**
  * Exchange a deep-link token (PAT or Better Auth session token) for a
- * Better Auth session cookie scoped to the same user, then 302 to `next`.
+ * first-party Better Auth session cookie scoped to the same user, then 302 to
+ * `next`.
  *
  * Lets a holder of a valid bootstrap PAT / menu-bar session hop into the
  * web UI without typing a password. `next` is restricted to relative paths
  * to prevent open-redirect abuse; Referrer-Policy keeps the token out of
  * the next page's Referer.
  *
- * Shared by GET (CLI/menu-bar deep-link in a top-level browser tab, token in
- * the query string) and POST (the Owletto extension's iframe bootstrap, token
- * in the request body so it never lands in a URL — see extension-bootstrap).
- * The Set-Cookie lands in whatever partition the request runs in: a top-level
- * tab → first-party; the extension iframe → the chrome-extension partition,
- * which is exactly what the CHIPS Partitioned cookie needs.
+ * GET only — the CLI/menu-bar deep link, in a top-level browser tab, with the
+ * token in the query string. The cross-site extension iframe can't use this
+ * cookie; it uses Bearer auth via `/extension-session` (see extension-bootstrap).
  */
 async function handleExchangeToken(
   c: Context<{ Bindings: Env }>,
   token: string | undefined,
-  rawNext: string | undefined,
-  // true only for the extension iframe (POST): mint a CHIPS Partitioned cookie
-  // so it's delivered in the cross-site iframe. GET (first-party tab) → false.
-  partitioned: boolean
+  rawNext: string | undefined
 ) {
   c.header('Referrer-Policy', 'no-referrer');
 
@@ -412,7 +398,7 @@ async function handleExchangeToken(
     );
   }
 
-  const minted = await mintSessionCookieValue(c, userId, { partitioned });
+  const minted = await mintSessionCookieValue(c, userId);
   if ('error' in minted) {
     return c.json(
       { error: 'session_create_failed', error_description: minted.error },
@@ -427,16 +413,51 @@ async function handleExchangeToken(
 }
 
 credentialRoutes.get('/exchange-token', async (c) =>
-  handleExchangeToken(c, c.req.query('token'), c.req.query('next'), false)
+  handleExchangeToken(c, c.req.query('token'), c.req.query('next'))
 );
 
-credentialRoutes.post('/exchange-token', async (c) => {
-  const body = await c.req.parseBody();
-  const token = typeof body.token === 'string' ? body.token : undefined;
-  const next = typeof body.next === 'string' ? body.next : undefined;
-  return handleExchangeToken(c, token, next, true);
-});
+/**
+ * Exchange a deep-link token (PAT / OAuth / Better Auth session) for a fresh
+ * Better Auth session token, returned in the JSON body for Bearer use.
+ *
+ * The Owletto extension's side-panel iframe is a CROSS-SITE iframe (top-level
+ * origin `chrome-extension://…`); a session cookie set here is unreliable
+ * inside that partition. So instead of a cookie, the iframe gets the raw
+ * session token and sends it as `Authorization: Bearer` — which the cloud auth
+ * bridge already accepts (it passes request headers to Better Auth's
+ * `getSession`, and the `bearer()` plugin honours the header). Same token
+ * shape `/local-init` hands non-cookie clients.
+ */
+credentialRoutes.post('/extension-session', async (c) => {
+  c.header('Referrer-Policy', 'no-referrer');
+  c.header('Cache-Control', 'no-store');
 
+  const body = await c.req.parseBody();
+  const token = typeof body.token === 'string' ? body.token.trim() : '';
+  if (!token) {
+    return c.json(
+      { error: 'missing_token', error_description: 'token is required' },
+      400
+    );
+  }
+
+  const userId = await resolveDeepLinkToken(c, token);
+  if (!userId) {
+    return c.json(
+      { error: 'invalid_token', error_description: 'token is invalid, expired, or revoked' },
+      401
+    );
+  }
+
+  const sessionToken = await createSessionToken(c, userId);
+  if (!sessionToken) {
+    return c.json(
+      { error: 'session_create_failed', error_description: 'failed to mint session' },
+      500
+    );
+  }
+  return c.json({ session_token: sessionToken });
+});
 
 /**
  * Bootstrap page for the Owletto extension's side-panel iframe.
@@ -445,12 +466,10 @@ credentialRoutes.post('/exchange-token', async (c) => {
  * URL **fragment** (`#token=…&worker=…`) — fragments are never sent to a server
  * and the page strips it from history immediately, so the long-lived token
  * never appears in a request URL, server log, or browser history entry. The
- * page then POSTs the token to /api/exchange-token (same-origin, so the
- * Set-Cookie is honoured) which sets the CHIPS Partitioned session cookie in
- * THIS iframe's partition, then redirects the iframe to the app. This is the
- * only place the partitioned cookie can be installed, because the partition key
- * must be the chrome-extension:// top-level — a separate top-level tab would
- * write it to the wrong partition.
+ * page POSTs the token to /api/extension-session (same-origin), stashes the
+ * returned Better Auth session token in `sessionStorage` for the SPA to send as
+ * `Authorization: Bearer`, then redirects the iframe to the app. No session
+ * cookie is involved — a cross-site iframe can't depend on one.
  */
 credentialRoutes.get('/extension-bootstrap', (c) => {
   c.header('Referrer-Policy', 'no-referrer');
@@ -465,19 +484,23 @@ credentialRoutes.get('/extension-bootstrap', (c) => {
   var worker = h.get("worker") || "";
   // Strip the token out of the URL before doing anything else.
   history.replaceState(null, "", location.pathname);
+  var next = worker ? "/#worker=" + encodeURIComponent(worker) : "/";
   if (!token) { location.replace("/"); return; }
-  var form = document.createElement("form");
-  form.method = "POST";
-  form.action = "/api/exchange-token";
-  function add(name, value) {
-    var i = document.createElement("input");
-    i.type = "hidden"; i.name = name; i.value = value;
-    form.appendChild(i);
-  }
-  add("token", token);
-  add("next", worker ? "/#worker=" + encodeURIComponent(worker) : "/");
-  document.body.appendChild(form);
-  form.submit();
+  var body = new URLSearchParams();
+  body.set("token", token);
+  fetch("/api/extension-session", {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: body.toString(),
+  })
+    .then(function (r) { return r.ok ? r.json() : null; })
+    .then(function (data) {
+      if (data && data.session_token) {
+        try { sessionStorage.setItem("owletto.session_token", data.session_token); } catch (e) {}
+      }
+      location.replace(next);
+    })
+    .catch(function () { location.replace(next); });
 })();
 </script></body>`
   );


### PR DESCRIPTION
## Why
The Owletto extension embeds owletto-web as a **cross-site iframe** (top-level `chrome-extension://`). The CHIPS `Partitioned` session cookie set by `POST /exchange-token` isn't reliably delivered inside that partition, so the embedded app rendered signed-out (the spinner). A prod probe confirmed **Cloudflare preserves `Partitioned`** — Chrome simply doesn't deliver the partitioned cookie in an extension-embedded iframe, so the cross-site cookie approach is a dead end there.

## What
Switch the embedded iframe to **Bearer auth**, which the cloud auth bridge *already* accepts — `createLobuAuthBridge` passes request headers to Better Auth's `getSession`, and the `bearer()` plugin honours the header. No new auth logic.

- **Add `POST /api/extension-session`** — resolves the extension's deep-link token (PAT / OAuth / session) and returns a fresh Better Auth session token as JSON, for the iframe to send as `Authorization: Bearer` (same token shape `/local-init` hands non-cookie clients).
- **Rewrite `/api/extension-bootstrap`** — exchanges the token and stashes the session token in `sessionStorage` for the SPA, instead of setting a partitioned cookie.
- **Delete the dead partitioned-cookie path** — `POST /exchange-token` and the `partitioned` (`SameSite=None; Secure; Partitioned`) branch in `mintSessionCookieValue`. `GET /exchange-token` (first-party CLI/menu-bar, Lax) is unchanged. Net: **-101 lines / +163** (mostly comments), dead code removed.

Pairs with owletto#287 (SPA reads the token + sends Bearer). Both deploy together via the gateway. **No extension change, no Store re-submission** — existing installs fix on deploy.

## E2E (red → green)
`packages/server/src/auth/__tests__/exchange-token-cookie.test.ts` (6 tests, all green against local pgvector):
- **Load-bearing:** mint a session token via `POST /api/extension-session`, send it as `Authorization: Bearer` to a real protected route (`GET /api/organizations`, which uses the exact `getSession({ headers })` bridge) → the user's org is returned; **without** the token it is not. This proves the embedded Bearer path authenticates through the real bridge.
- `/extension-session` returns a token (200), resolves an OAuth device-code token, rejects missing (400) / invalid (401).
- `GET /exchange-token` still sets a first-party **Lax** cookie (never Partitioned/None).
- Bootstrap page serves the exchange + `sessionStorage` handoff.

Was red before the fix (the old test asserted the now-removed `POST /exchange-token` + Partitioned cookie); rewritten to the Bearer flow and green.

## Note
Submodule pointer bump to owletto#287 lands as a follow-up commit on this branch once owletto merges (keeps the SHA reachable).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1336"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784235971&installation_id=136316292&pr_number=1336&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1336&signature=28d52d0cb7dd6d3e6a21daa7e6b86c6d2f81f0ddd7133b7f4c8bb3312c116e0d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Bearer token authentication support for embedded extension iframe flows.
  * Introduced new session token endpoint for secure cross-site iframe integration, replacing previous cookie-based authentication.

* **Tests**
  * Enhanced test coverage for Bearer token validation and session token handling.
  * Added integration tests verifying proper handling of valid and invalid authentication tokens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->