### PR TITLE
ci: add knip dead-code report (non-blocking baseline)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -435,6 +435,13 @@ jobs:
             echo "::endgroup::"
           done
 
+      # Report-only for now: knip surfaces unused files / exports / deps to
+      # establish a baseline. Non-blocking (continue-on-error) until the
+      # baseline is triaged — then this can be promoted to a hard gate.
+      - name: Dead-code report (knip, non-blocking)
+        continue-on-error: true
+        run: bun run knip
+
   migrations:
     # Catches the class of bug that has now broken prod twice in one
     # session: a migration file that's syntactically a SQL file but that


### PR DESCRIPTION
Adds knip to CI as a **report-only** signal to establish a dead-code baseline (follow-up to the #1327 dedup + #1335 jscpd gate).

## What
- New step in the `typecheck` job (packages already built there, so knip resolves cross-package imports accurately): `bun run knip` with `continue-on-error: true`.
- **Non-blocking** — it surfaces findings in the CI log without failing the build. Once the baseline is triaged, it can be promoted to a hard gate (drop `continue-on-error`).
- No new dependency or script — `knip` + `config/knip.ts` already exist; this just runs it in CI.

## Baseline (current `main`)
| Category | Count |
|---|---|
| Unused files | 5 |
| Unused exports | 11 |
| Unused exported types | 16 |
| Unused devDependencies | 1 |
| Unlisted dependencies | 49 |
| Unlisted binaries | 2 |
| Unresolved imports | 1 |

## Notes / follow-up
- The **49 "unlisted dependencies"** are mostly monorepo-hoist false positives (deps used in a package's `src` but declared only at the workspace root). These want `config/knip.ts` tuning (per-workspace `ignoreDependencies`) before this becomes a hard gate, else the signal is noisy.
- A few "unused exported types" are internal interfaces from the recent dedup work (e.g. `AgentSummary`, `WorkerTokenClaimsArgs`, `JudgeRunnerLabels`) — export hygiene, safe to un-export in a cleanup pass.
- Why report-only first: dead-code is the higher-ROI maintainability signal than duplication here, but the raw baseline is too noisy to block on day one.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1337"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784236073&installation_id=136316292&pr_number=1337&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1337&signature=424013f4777ff91b44309388932014514cbe2bcd9e16c1adf931dd25cb7e71d2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->