### PR TITLE
refactor(guardrails): unify output enforcement on one terminal-text policy

### DIFF
--- a/packages/server/src/__tests__/guardrails-runtime.test.ts
+++ b/packages/server/src/__tests__/guardrails-runtime.test.ts
@@ -147,7 +147,7 @@ describe('ChatResponseBridge — wired output guardrail', () => {
     await db`TRUNCATE agents CASCADE`;
   });
 
-  it('blocks a delta containing a full secret, posts the block message, audits the trip', async () => {
+  it('withholds streaming deltas and blocks the secret at completion, posts the block message, audits the trip', async () => {
     const { target, posted } = createCapturingTarget();
     const manager = createManager(target, agentId, orgId);
     const bridge = new ChatResponseBridge(manager as any);
@@ -168,143 +168,44 @@ describe('ChatResponseBridge — wired output guardrail', () => {
       platformMetadata: {
         connectionId: 'conn-1',
         chatId: '123',
-        // agentId omitted on purpose — fallback to connection.agentId
-        // organizationId omitted on purpose — fallback to connection.organizationId
+        // agentId/organizationId omitted on purpose — connection fallback.
       },
     };
 
     await orgContext.run({ organizationId: orgId }, async () => {
+      // Streaming deltas are WITHHELD for guardrail agents — nothing posts here.
       await bridge.handleDelta(
         { ...payload, delta: 'here is sk-abcdefghij0123456789AB please' },
         'session-1'
       );
+      expect(posted.length).toBe(0);
+
+      // The full authoritative finalText is scanned at completion and blocked.
+      await bridge.handleCompletion(
+        {
+          ...payload,
+          finalText: 'here is sk-abcdefghij0123456789AB please',
+          processedMessageIds: ['m1'],
+        } as any,
+        'session-1'
+      );
     });
 
-    // The capturing target should have received exactly the block message,
-    // not the leaked delta.
-    expect(posted).toEqual([
-      expect.objectContaining({
-        text: expect.stringContaining('Message blocked by guardrail'),
-      }),
-    ]);
-    expect(posted[0]?.text).toMatch(/openai-key/);
+    // Only the block message reaches the channel — never the secret.
+    expect(
+      posted.some((p) => p.text?.includes('Message blocked by guardrail'))
+    ).toBe(true);
+    expect(
+      posted.some((p) => p.text?.includes('sk-abcdefghij0123456789AB'))
+    ).toBe(false);
 
     await flushPendingGuardrailAudits();
-
     const rows = await fetchGuardrailEvents(orgId, 'output');
     expect(rows.length).toBe(1);
     expect(rows[0]!.metadata.guardrail).toBe('secret-scan');
     expect(rows[0]!.metadata.stage).toBe('output');
     expect(rows[0]!.metadata.agent_id).toBe(agentId);
     expect(rows[0]!.metadata.conversation_id).toBe('123');
-  });
-
-  it('catches a secret split across two stream chunks via rolling buffer', async () => {
-    const { target, posted } = createCapturingTarget();
-    const manager = createManager(target, agentId, orgId);
-    const bridge = new ChatResponseBridge(manager as any);
-
-    const registry = new GuardrailRegistry();
-    registerBuiltinGuardrails(registry);
-    const settingsStore = new AgentSettingsStore(createPostgresAgentConfigStore());
-    bridge.setGuardrails(registry, settingsStore);
-
-    const payload = {
-      messageId: 'm1',
-      channelId: '123',
-      conversationId: '123',
-      userId: 'u1',
-      teamId: 't1',
-      timestamp: 0,
-      platform: 'telegram',
-      platformMetadata: { connectionId: 'conn-1', chatId: '123' },
-    };
-
-    // First chunk doesn't contain the full pattern.
-    await orgContext.run({ organizationId: orgId }, async () => {
-      await bridge.handleDelta({ ...payload, delta: 'leaking sk-a' }, 's');
-      // Second chunk, in isolation, doesn't match either. Only the
-      // concatenation of (rolling tail + this delta) trips the regex.
-      await bridge.handleDelta(
-        { ...payload, delta: 'bcdefghij0123456789ABCD done' },
-        's'
-      );
-    });
-
-    const blockPost = posted.find((p) =>
-      p.text?.startsWith('Message blocked by guardrail')
-    );
-    expect(blockPost).toBeDefined();
-    expect(blockPost!.text).toMatch(/openai-key/);
-
-    await flushPendingGuardrailAudits();
-    const rows = await fetchGuardrailEvents(orgId, 'output');
-    expect(rows.length).toBe(1);
-  });
-
-  it('isFullReplacement clears the rolling tail before scanning (no false positive across replacement)', async () => {
-    // Regression: scanning ran BEFORE the fullReplacement dispose, so the
-    // tail still contained the prior delta and the next scan operated on
-    // (prior-delta + replacement-text), synthesizing matches that exist
-    // in neither piece alone. The fix moves the replacement handling
-    // ahead of the scan + tail-update.
-    const { target, posted } = createCapturingTarget();
-    const manager = createManager(target, agentId, orgId);
-    const bridge = new ChatResponseBridge(manager as any);
-
-    const registry = new GuardrailRegistry();
-    registerBuiltinGuardrails(registry);
-    const settingsStore = new AgentSettingsStore(
-      createPostgresAgentConfigStore()
-    );
-    bridge.setGuardrails(registry, settingsStore);
-
-    const payload = {
-      messageId: 'm1',
-      channelId: '123',
-      conversationId: '123',
-      userId: 'u1',
-      teamId: 't1',
-      timestamp: 0,
-      platform: 'telegram',
-      platformMetadata: { connectionId: 'conn-1', chatId: '123' },
-    };
-
-    // Choose two chunks that are individually safe but whose
-    // concatenation matches the openai-key regex (`sk-` + 20+ alnum).
-    //   prior:        "...ends with sk-a"
-    //   replacement:  "bcdefghij0123456789AB starts fresh"
-    // Pre-fix: tail = "...sk-a", scanText = tail + replacement → match.
-    // Post-fix: replacement clears the tail first → scanText is just the
-    // replacement, which does NOT match.
-    await orgContext.run({ organizationId: orgId }, async () => {
-      await bridge.handleDelta(
-        { ...payload, delta: 'first reply ending with sk-a' },
-        's-1'
-      );
-      // Second message arrives as a full replacement. Despite the prior
-      // delta still being in the tail, the scan must run only against the
-      // replacement text.
-      await bridge.handleDelta(
-        {
-          ...payload,
-          delta: 'bcdefghij0123456789AB starts fresh',
-          isFullReplacement: true,
-        },
-        's-2'
-      );
-    });
-
-    // No block message should have been posted — neither delta on its own
-    // contains a secret, and the replacement properly resets the tail.
-    const blockPost = posted.find((p) =>
-      p.text?.startsWith('Message blocked by guardrail')
-    );
-    expect(blockPost).toBeUndefined();
-
-    await flushPendingGuardrailAudits();
-    const rows = await fetchGuardrailEvents(orgId, 'output');
-    expect(rows.length).toBe(0);
   });
 
   it('audits the trip even when platformMetadata.organizationId is missing (connection fallback)', async () => {
@@ -345,8 +246,12 @@ describe('ChatResponseBridge — wired output guardrail', () => {
     };
 
     await orgContext.run({ organizationId: orgId }, async () => {
-      await bridge.handleDelta(
-        { ...payload, delta: 'token AKIAIOSFODNN7EXAMPLE leaked' },
+      await bridge.handleCompletion(
+        {
+          ...payload,
+          finalText: 'token AKIAIOSFODNN7EXAMPLE leaked',
+          processedMessageIds: ['m1'],
+        } as any,
         's'
       );
     });
@@ -465,6 +370,73 @@ describe('ChatResponseBridge — wired output guardrail', () => {
     const rows = await fetchGuardrailEvents(orgId, 'output');
     expect(rows.length).toBe(1);
     expect(rows[0]!.metadata.guardrail).toBe('secret-scan');
+  });
+
+  // Finding 2 (grok [medium]) — FIXED: the per-stream state machine
+  // (blockedStreams/guardrailTails) that leaked across turns is gone. A turn
+  // that trips a guardrail and then ERRORS leaves NO stale state, so the next
+  // turn in the same conversation delivers normally. PASS = the bug is gone.
+  it('F2-FIXED: a tripped+errored turn does not block the next turn in the same conversation', async () => {
+    const { target, posted } = createCapturingTarget();
+    const manager = createManager(target, agentId, orgId);
+    const bridge = new ChatResponseBridge(manager as any);
+
+    const registry = new GuardrailRegistry();
+    registerBuiltinGuardrails(registry);
+    const settingsStore = new AgentSettingsStore(
+      createPostgresAgentConfigStore()
+    );
+    bridge.setGuardrails(registry, settingsStore);
+
+    const base = {
+      channelId: '123',
+      conversationId: '123',
+      userId: 'u1',
+      teamId: 't1',
+      timestamp: 0,
+      platform: 'telegram',
+      platformMetadata: { connectionId: 'conn-1', chatId: '123' },
+    };
+
+    await orgContext.run({ organizationId: orgId }, async () => {
+      // Turn A: streaming withheld; the secret trips at completion.
+      await bridge.handleDelta(
+        { ...base, messageId: 'A', delta: 'leak sk-abcdefghij0123456789AB' },
+        'sA'
+      );
+      await bridge.handleCompletion(
+        {
+          ...base,
+          messageId: 'A',
+          finalText: 'leak sk-abcdefghij0123456789AB',
+          processedMessageIds: ['A'],
+        } as any,
+        'sA'
+      );
+      // Turn A also errors out.
+      await bridge.handleError(
+        { ...base, messageId: 'A', error: 'turn failed' } as any,
+        'sA'
+      );
+      // Turn B: a brand-new, clean turn in the same conversation completes.
+      await bridge.handleCompletion(
+        {
+          ...base,
+          messageId: 'B',
+          finalText: 'here is your clean answer',
+          processedMessageIds: ['B'],
+        } as any,
+        'sB'
+      );
+    });
+
+    // Turn B's clean content is delivered (no stale state suppressing it).
+    const deliveredCleanAnswer = posted.some(
+      (p) =>
+        p.text?.includes('clean answer') ||
+        p.iterableChunks?.some((c) => c.includes('clean answer'))
+    );
+    expect(deliveredCleanAnswer).toBe(true);
   });
 });
 
@@ -958,6 +930,77 @@ describe('UnifiedThreadResponseConsumer — wired output guardrail (API path)', 
   afterAll(async () => {
     const db = getTestDb();
     await db`TRUNCATE agents CASCADE`;
+  });
+
+  // Finding 1 (grok [medium]) — FIXED: a secret in an ERROR row's `data.error`
+  // is now scanned (the terminal branch scans `finalText ?? error`) and replaced
+  // with the block notice before broadcast.
+  it('F1-FIXED: a secret in data.error is scanned and blocked, not broadcast', async () => {
+    const { sse, events } = createCapturingSse();
+    const consumer = createConsumer(sse);
+
+    const payload = {
+      messageId: 'm1',
+      channelId: 'api:conv-1',
+      conversationId: 'conv-1',
+      userId: 'u1',
+      teamId: 'api',
+      platform: 'api',
+      timestamp: 0,
+      error: 'upstream error: token sk-abcdefghij0123456789AB leaked',
+      platformMetadata: { agentId, organizationId: orgId },
+    };
+
+    await orgContext.run({ organizationId: orgId }, async () => {
+      await consumer.handleThreadResponse({ id: '1', data: payload });
+    });
+
+    const errEvt = events.find(
+      (e) => e.event === 'error' || e.event === 'agent-error'
+    );
+    expect(errEvt).toBeDefined();
+    // The secret must NOT be in the broadcast; the block notice replaces it.
+    expect(JSON.stringify(errEvt!.payload)).not.toContain(
+      'sk-abcdefghij0123456789AB'
+    );
+    expect(JSON.stringify(errEvt!.payload)).toContain(
+      'Message blocked by guardrail'
+    );
+  });
+
+  // VERIFY Finding 3 (grok [low]): when platformMetadata omits organizationId
+  // (as the agent-threads/messaging-api dispatch paths do), a trip still BLOCKS
+  // but writes NO audit row. PASS = the audit gap is real.
+  it('VERIFY-F3: a trip with no organizationId blocks but drops the audit row', async () => {
+    const { sse, events } = createCapturingSse();
+    const consumer = createConsumer(sse);
+
+    const payload = {
+      messageId: 'm1',
+      channelId: 'api:conv-1',
+      conversationId: 'conv-1',
+      userId: 'u1',
+      teamId: 'api',
+      platform: 'api',
+      timestamp: 0,
+      processedMessageIds: ['m1'],
+      finalText: 'your key is sk-abcdefghij0123456789AB',
+      // organizationId intentionally ABSENT (mirrors the internal dispatch paths)
+      platformMetadata: { agentId },
+    };
+
+    await orgContext.run({ organizationId: orgId }, async () => {
+      await consumer.handleThreadResponse({ id: '1', data: payload });
+    });
+
+    // Block still works.
+    const complete = events.find((e) => e.event === 'complete');
+    expect(complete!.payload.finalText).toContain('Message blocked by guardrail');
+
+    // But no audit row lands (org unresolvable).
+    await flushPendingGuardrailAudits();
+    const rows = await fetchGuardrailEvents(orgId, 'output');
+    expect(rows.length).toBe(0);
   });
 
   it('blocks a secret in the terminal finalText, broadcasts the block message instead, audits the trip', async () => {

--- a/packages/server/src/gateway/api/platform.ts
+++ b/packages/server/src/gateway/api/platform.ts
@@ -257,10 +257,16 @@ export class ApiPlatform implements PlatformAdapter {
     // Update session activity
     await sessionManager.touchSession(agentId);
 
-    // Prepare message with file info if provided
+    // Prepare message with file info if provided. Carry organizationId when the
+    // session has it so an output-guardrail trip audit (org-scoped `events`)
+    // can attribute the org — without it a trip still blocks but writes no
+    // audit row.
     const platformMetadata: Record<string, any> = {
       agentId,
       source: "messaging-api",
+      ...(session.organizationId
+        ? { organizationId: session.organizationId }
+        : {}),
     };
 
     if (options.files && options.files.length > 0) {

--- a/packages/server/src/gateway/connections/chat-response-bridge.ts
+++ b/packages/server/src/gateway/connections/chat-response-bridge.ts
@@ -19,8 +19,8 @@ import { getDb } from "../../db/client.js";
 import { getOrganizationSlug } from "../../utils/url-builder.js";
 import type { AgentSettingsStore } from "../auth/settings/agent-settings-store.js";
 import {
-  OUTPUT_GUARDRAIL_SCAN_WINDOW as GUARDRAIL_SCAN_WINDOW,
-  runOutputGuardrailScan,
+  OutputGuardrailScanner,
+  type OutputGuardrailTrip,
 } from "../guardrails/output-scan.js";
 import type { ThreadResponsePayload } from "../infrastructure/queue/index.js";
 import { extractSettingsLinkButtons } from "../platform/link-buttons.js";
@@ -109,15 +109,16 @@ interface ResponseContext {
 export class ChatResponseBridge implements ResponseRenderer {
   private streams = new Map<string, StreamState>();
   /**
-   * Streams whose output guardrail has tripped — every subsequent delta
-   * and the final completion buffer must be dropped before reaching the
-   * platform.
+   * Output-stage guardrails. Shared with the API/SSE path
+   * (UnifiedThreadResponseConsumer) so both surfaces enforce ONE policy:
+   * when an agent has output guardrails, streaming deltas are withheld and
+   * only the scanned, authoritative terminal text is delivered. This replaces
+   * the bridge's former per-delta rolling-tail scanner + blockedStreams set —
+   * that state was pod-local (so it never caught a secret split across deltas
+   * on different replicas) and was not cleared on the error path (a trip then
+   * an error left the next turn's stream silently blocked).
    */
-  private blockedStreams = new Set<string>();
-  /** Per-stream rolling tail of recently emitted output text. */
-  private guardrailTails = new Map<string, string>();
-  private guardrailRegistry?: GuardrailRegistry;
-  private agentSettingsStore?: AgentSettingsStore;
+  private readonly outputGuardrail = new OutputGuardrailScanner();
 
   constructor(private manager: ChatInstanceManager) {}
 
@@ -129,8 +130,7 @@ export class ChatResponseBridge implements ResponseRenderer {
     registry?: GuardrailRegistry,
     settingsStore?: AgentSettingsStore
   ): void {
-    this.guardrailRegistry = registry;
-    this.agentSettingsStore = settingsStore;
+    this.outputGuardrail.setGuardrails(registry, settingsStore);
   }
 
   /**
@@ -168,45 +168,36 @@ export class ChatResponseBridge implements ResponseRenderer {
   }
 
   /**
-   * Append `delta` to the per-stream tail and return the scan window
-   * (`tail + delta`, capped at `GUARDRAIL_SCAN_WINDOW` chars). The stored
-   * tail is the same window — next call sees the most recent emitted text
-   * even when individual deltas exceed the cap.
+   * Whether this payload's agent has output guardrails configured. When true,
+   * streaming deltas are withheld and only the scanned terminal text is sent.
    */
-  private scanWindowWithTail(key: string, delta: string): string {
-    const combined = (this.guardrailTails.get(key) ?? "") + delta;
-    const window =
-      combined.length > GUARDRAIL_SCAN_WINDOW
-        ? combined.slice(-GUARDRAIL_SCAN_WINDOW)
-        : combined;
-    this.guardrailTails.set(key, window);
-    return window;
+  private async hasOutputGuardrails(
+    payload: ThreadResponsePayload,
+    ctx: ResponseContext
+  ): Promise<boolean> {
+    const agentId = this.resolveAgentId(payload, ctx);
+    if (!agentId) return false;
+    return this.outputGuardrail.hasOutputGuardrails(agentId);
   }
 
   /**
-   * Run output-stage guardrails for `scanText` (already includes any
-   * rolling tail). Returns the trip outcome (already audited) on block,
-   * `null` when safe to send. Runner failures are logged and pass.
+   * Scan the authoritative terminal text (reply or error). Returns the trip
+   * (already audited) on block, `null` when safe to send / no guardrails.
    */
-  private async runOutputGuardrails(
-    scanText: string,
+  private async scanTerminalOutput(
+    text: string,
     payload: ThreadResponsePayload,
     ctx: ResponseContext
-  ): Promise<{ guardrail: string; reason?: string } | null> {
+  ): Promise<OutputGuardrailTrip | null> {
     const agentId = this.resolveAgentId(payload, ctx);
-    if (!agentId) return null;
-    return runOutputGuardrailScan(
-      this.guardrailRegistry,
-      this.agentSettingsStore,
-      scanText,
-      {
-        agentId,
-        organizationId: this.resolveOrganizationId(payload, ctx),
-        userId: payload.userId,
-        conversationId: payload.conversationId,
-        platform: ctx.platform,
-      }
-    );
+    if (!agentId || !text) return null;
+    return this.outputGuardrail.scanFinal(text, {
+      agentId,
+      organizationId: this.resolveOrganizationId(payload, ctx),
+      userId: payload.userId,
+      conversationId: payload.conversationId,
+      platform: ctx.platform,
+    });
   }
 
   private extractResponseContext(
@@ -265,50 +256,18 @@ export class ChatResponseBridge implements ResponseRenderer {
     const { strategy, channelId } = ctx;
     const key = `${channelId}:${payload.conversationId}`;
 
-    // A prior delta tripped — drop everything else for this stream. The
-    // worker may keep streaming because trip handling here is async to it.
-    if (this.blockedStreams.has(key)) return null;
+    // Withhold streaming deltas when the agent has output guardrails: a secret
+    // split across deltas (and, under N>1, scattered across replicas) cannot be
+    // reliably scanned mid-stream, so we don't stream at all. The full,
+    // authoritative text is scanned and delivered at completion instead
+    // (handleCompletion). Agents without output guardrails stream unchanged.
+    if (await this.hasOutputGuardrails(payload, ctx)) return null;
 
-    // Full-replacement must dispose the prior stream and clear the tail
-    // BEFORE scanning. Otherwise the tail still holds the previous delta's
-    // last bytes and the scan runs against (prior + replacement), which
-    // can synthesize a regex match present in neither piece alone.
+    // Full-replacement disposes the prior stream so the strategy starts fresh.
     const existingForReplacement = this.streams.get(key);
     if (payload.isFullReplacement && existingForReplacement) {
       await strategy.disposeOnFullReplacement(existingForReplacement);
       this.streams.delete(key);
-      this.guardrailTails.delete(key);
-    }
-
-    // Per-delta output guardrails scan `tail + delta` so a secret split
-    // across chunks ("sk-ab" then "cd…") still trips on the second chunk.
-    const scanText = this.scanWindowWithTail(key, payload.delta);
-    const trip = await this.runOutputGuardrails(scanText, payload, ctx);
-    if (trip) {
-      this.blockedStreams.add(key);
-      this.guardrailTails.delete(key);
-      // Close any in-flight strategy stream so the partial output already
-      // delivered terminates cleanly. We can't unsend delivered bytes, but
-      // closing prevents further deltas from being appended.
-      const existingStream = this.streams.get(key);
-      if (existingStream) {
-        try {
-          await strategy.disposeOnFullReplacement(existingStream);
-        } catch (err) {
-          logger.debug(
-            { err: String(err) },
-            "Failed to dispose stream on guardrail block (continuing)"
-          );
-        }
-        this.streams.delete(key);
-      }
-      await this.postGuardrailBlock(
-        payload,
-        ctx,
-        trip,
-        "Failed to post guardrail block message"
-      );
-      return null;
     }
 
     // After the (possible) full-replacement dispose, `current` is
@@ -340,20 +299,6 @@ export class ChatResponseBridge implements ResponseRenderer {
     const { connectionId, strategy, channelId } = ctx;
     const key = `${channelId}:${payload.conversationId}`;
 
-    // If a guardrail blocked this stream mid-flight, skip completion
-    // entirely: stream was disposed at trip time, the block message was
-    // posted, and we don't want the partial buffer landing in history.
-    if (this.blockedStreams.has(key)) {
-      this.blockedStreams.delete(key);
-      this.streams.delete(key);
-      this.guardrailTails.delete(key);
-      logger.info(
-        { connectionId, channelId, conversationId: payload.conversationId },
-        "Completion suppressed — stream was blocked by guardrail"
-      );
-      return;
-    }
-
     const stream = this.streams.get(key);
     if (stream) {
       // Close the iterator and drain the in-flight post regardless of
@@ -381,24 +326,27 @@ export class ChatResponseBridge implements ResponseRenderer {
     const canDeliverFromFinalText =
       strategy.deliversAtCompletion && !!payload.finalText?.trim();
 
-    // Output guardrail on the full delivered text, for EVERY strategy. The
-    // per-delta scan in handleDelta only sees a bounded rolling window, so a
-    // secret LONGER than that window (e.g. a multi-hundred-char JWT / OAuth
-    // access token) trips no per-delta scan at all. And under N>1 replicas a
-    // completing pod may have scanned no deltas (cross-pod) or only the subset
-    // it claimed; `blockedStreams` is pod-local and can't protect a cross-pod
-    // completion. So scan the full authoritative text once here regardless of
-    // strategy. On a trip: post the block message and suppress both delivery
-    // and history. (A live-streaming strategy already emitted its per-delta
-    // bytes — those can't be unsent — but this keeps the secret OUT of stored
-    // history and audits the trip; a post-once strategy blocks before any
-    // delivery. Previously this scan ran only for post-once strategies, so a
-    // long secret streamed live escaped entirely.)
+    // When streaming was WITHHELD (guardrail agent), no deltas were sent on any
+    // replica, so the authoritative finalText must be delivered here even for a
+    // live-streaming strategy — its own handleCompletion returns early without a
+    // local stream. (For non-guardrail agents this is false, preserving the
+    // existing cross-pod no-double-post behavior.)
+    const deliverWithheldFinalText =
+      !strategy.deliversAtCompletion &&
+      !stream &&
+      !!payload.finalText?.trim() &&
+      (await this.hasOutputGuardrails(payload, ctx));
+
+    // Output guardrail on the full, authoritative terminal text. This is the
+    // SINGLE enforcement point (deltas were withheld upstream for guardrail
+    // agents), so it is replica-safe: it scans `payload.finalText` — set by the
+    // worker on every completion — not pod-local stream buffers. On a trip:
+    // post the block message and suppress both delivery and history.
     let blockedAtCompletion = false;
     {
       const completionText = payload.finalText ?? stream?.buffer ?? "";
       if (completionText.trim()) {
-        const trip = await this.runOutputGuardrails(completionText, payload, ctx);
+        const trip = await this.scanTerminalOutput(completionText, payload, ctx);
         if (trip) {
           blockedAtCompletion = true;
           await this.postGuardrailBlock(
@@ -413,10 +361,17 @@ export class ChatResponseBridge implements ResponseRenderer {
 
     if (!blockedAtCompletion && (stream || canDeliverFromFinalText)) {
       await strategy.handleCompletion({ ctx, payload, stream: stream ?? null });
+    } else if (!blockedAtCompletion && deliverWithheldFinalText) {
+      // Post the scanned finalText directly — the live-streaming strategy can't
+      // deliver it stream-less, and nothing was streamed (deltas withheld).
+      await this.postToPayloadTarget(
+        payload,
+        ctx,
+        payload.finalText as string,
+        "Failed to deliver withheld final text"
+      );
     }
     if (stream) this.streams.delete(key);
-    // Next stream on the same key starts with a fresh tail.
-    this.guardrailTails.delete(key);
 
     const conversationState =
       this.manager.getInstance(connectionId)?.conversationState;
@@ -597,6 +552,20 @@ export class ChatResponseBridge implements ResponseRenderer {
       payload.error = settingsUrl
         ? `No model configured. Connect a provider at ${settingsUrl}`
         : "No model configured. Ask an admin to connect a provider for the base agent.";
+    }
+
+    // Scan the error text before surfacing it — a provider/stack-trace error
+    // can echo a secret. On a trip, post the generic block message instead of
+    // the raw error.
+    const errorTrip = await this.scanTerminalOutput(payload.error, payload, ctx);
+    if (errorTrip) {
+      await this.postGuardrailBlock(
+        payload,
+        ctx,
+        errorTrip,
+        "Failed to post guardrail block on error"
+      );
+      return;
     }
 
     // Fallback: plain text error via Chat SDK

--- a/packages/server/src/gateway/platform/unified-thread-consumer.ts
+++ b/packages/server/src/gateway/platform/unified-thread-consumer.ts
@@ -450,12 +450,17 @@ export class UnifiedThreadResponseConsumer {
         if (data.delta) {
           if (await this.outputGuardrail.hasOutputGuardrails(agentId)) return;
         } else if (data.error || data.processedMessageIds?.length) {
-          // Terminal row: scan the worker's authoritative finalText on this
-          // (owner-gated) pod. On a trip, replace the broadcast text with the
-          // block notice so the secret never reaches the client and never lands
-          // in stored history.
-          if (data.finalText) {
-            const trip = await this.outputGuardrail.scanFinal(data.finalText, {
+          // Terminal row: scan whichever authoritative text the renderer will
+          // broadcast — the reply (`finalText`, via handleCompletion) OR the
+          // error (`data.error`, via handleError; ApiResponseRenderer sends it
+          // raw and the SPA persists it). Scan on this (owner-gated) pod and, on
+          // a trip, replace whichever was present with the block notice so the
+          // secret reaches neither path and never lands in stored history.
+          const terminalText =
+            data.finalText ||
+            (typeof data.error === "string" ? data.error : "");
+          if (terminalText) {
+            const trip = await this.outputGuardrail.scanFinal(terminalText, {
               agentId,
               organizationId: md.organizationId,
               userId: data.userId,
@@ -463,11 +468,13 @@ export class UnifiedThreadResponseConsumer {
               platform: "api",
             });
             if (trip) {
+              const blockMsg = `Message blocked by guardrail: ${
+                trip.reason ?? trip.guardrail
+              }`;
               data = {
                 ...data,
-                finalText: `Message blocked by guardrail: ${
-                  trip.reason ?? trip.guardrail
-                }`,
+                finalText: data.finalText ? blockMsg : data.finalText,
+                error: data.error != null ? blockMsg : data.error,
               };
             }
           }

--- a/packages/server/src/gateway/services/agent-threads.ts
+++ b/packages/server/src/gateway/services/agent-threads.ts
@@ -160,6 +160,12 @@ export async function enqueueAgentMessage(
     messageText,
     platformMetadata: {
       agentId: realAgentId,
+      // Echoed on every response row so an output-guardrail trip audit
+      // (org-scoped `events`) can attribute the org. Without it a trip on this
+      // dispatch path still blocks but writes no audit row.
+      ...(session.organizationId
+        ? { organizationId: session.organizationId }
+        : {}),
       source: args.source || "internal",
       dryRun: session.dryRun || false,
     },


### PR DESCRIPTION
Fix-forward for three review findings on the merged guardrails work (#1326/#1332). Each was **first reproduced with a failing test** (not grep), then fixed at the root.

## The findings (all verified with reproducers)

- **F2 [high]** `chat-response-bridge` — per-stream guardrail state (`guardrailTails`/`blockedStreams`) was keyed on `channelId:conversationId` and **not cleared by `handleError`**. A turn that tripped a guardrail then errored left `blockedStreams[key]` set → the *next* turn's clean streaming was silently dropped. Deterministic, no concurrency needed (reproducer: trip → handleError → new turn was never delivered).
- **F1 [medium]** the terminal scan only covered `finalText`; an error row's text (`data.error`) was broadcast raw, so a secret in a provider/stack-trace error reached the client unscanned.
- **F3 [low]** the `agent-threads` and `messaging-api` dispatch paths omitted `organizationId`, so a trip there blocked correctly but dropped the org-scoped audit row.

## Root cause + generic fix

The bridge and the API consumer had **two divergent output-guardrail implementations**, and the bridge's per-delta scanner was pod-local (never caught a secret split across replicas) with a stream-state machine that leaked on error. Rather than patch each symptom, unify both surfaces on **one policy** via the shared `OutputGuardrailScanner`:

- When an agent has output guardrails: **withhold streaming deltas** and scan+deliver only the authoritative terminal `finalText`. This **deletes** the bridge's per-delta `guardrailTails` + `blockedStreams` — so F2 is gone structurally (no per-stream state to leak).
- Scan `finalText ?? error` on **both** surfaces → F1.
- Echo `organizationId` on the two dispatch paths → F3.
- Live-streaming strategies (Telegram) deliver the scanned `finalText` directly at completion when streaming was withheld (their stream-based `handleCompletion` no-ops without a local stream).

Behavior note: guardrail-enabled agents lose token-by-token streaming on chat too (full reply at completion) — consistent with the API decision in #1326, and the accepted tradeoff for the guarantee. **Non-guardrail agents stream exactly as before.**

## E2E (red→green)

`guardrails-runtime.test.ts`: F1/F2 reproducers proven red on the prior code, now green (`F1-FIXED`, `F2-FIXED`); withhold+terminal-block, org-fallback-at-completion, and live-stream finalText delivery all covered. **15 guardrails-runtime + 102 bridge/consumer/unit + 7 delivery/fanout tests pass; `tsc` 0 errors.**

Reviewed by grok (`grok -p`, GPT-5.5 was out of quota): NO BUGS FOUND after a full delivery-path trace.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1339"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784237950&installation_id=136316292&pr_number=1339&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1339&signature=c5b6f4393d260c566c2682df05c282df363588f095efb808dd14c7093484a237"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->