### PR TITLE
fix(server): SSE auth ticket for embedded panel + bootstrap retry-on-failure

### DIFF
--- a/packages/server/src/auth/__tests__/exchange-token-cookie.test.ts
+++ b/packages/server/src/auth/__tests__/exchange-token-cookie.test.ts
@@ -1,3 +1,4 @@
+import { Hono } from 'hono';
 import { beforeEach, describe, expect, it } from 'vitest';
 import { cleanupTestDatabase } from '../../__tests__/setup/test-db';
 import {
@@ -9,7 +10,10 @@ import {
   createTestUser,
 } from '../../__tests__/setup/test-fixtures';
 import { get, postForm } from '../../__tests__/setup/test-helpers';
-import { verifySettingsToken } from '../../gateway/routes/public/settings-auth';
+import {
+  verifySettingsSessionOrToken,
+  verifySettingsToken,
+} from '../../gateway/routes/public/settings-auth';
 
 // Two deep-link entry points, two postures:
 //   - GET /exchange-token: first-party tab (CLI/menu-bar) → Lax session cookie.
@@ -167,6 +171,37 @@ describe('SSE ticket (/api/sse-ticket)', () => {
     const payload = await verifySettingsToken(ticket);
     expect(payload?.platform).toBe('external');
     expect((payload?.userId ?? '').length).toBeGreaterThan(0);
+  });
+
+  it('the ticket authenticates through the gate the agent SSE route uses', async () => {
+    const sessionToken = await sessionTokenForNewUser(
+      'sse-gate-org',
+      'sse-gate@test.example.com'
+    );
+    const { ticket } = (await (
+      await get('/api/sse-ticket', { token: sessionToken })
+    ).json()) as { ticket: string };
+
+    // Mirror the agent-events ownership gate verbatim: verifySettingsSessionOrToken(c,'token').
+    const probe = new Hono();
+    probe.get('/probe', async (c) => {
+      const s = await verifySettingsSessionOrToken(c, 'token');
+      return c.json({ userId: s?.userId ?? null, platform: s?.platform ?? null });
+    });
+
+    const withTicket = (await (
+      await probe.fetch(
+        new Request(`http://localhost/probe?token=${encodeURIComponent(ticket)}`)
+      )
+    ).json()) as { userId: string | null; platform: string | null };
+    expect(withTicket.userId).toBeTruthy();
+    expect(withTicket.platform).toBe('external');
+
+    // No ?token → the gate resolves no session (would deny ownership).
+    const without = (await (
+      await probe.fetch(new Request('http://localhost/probe'))
+    ).json()) as { userId: string | null };
+    expect(without.userId).toBeNull();
   });
 
   it('serves the bootstrap page with retry-on-failure handling (no silent redirect)', async () => {

--- a/packages/server/src/auth/__tests__/exchange-token-cookie.test.ts
+++ b/packages/server/src/auth/__tests__/exchange-token-cookie.test.ts
@@ -9,6 +9,7 @@ import {
   createTestUser,
 } from '../../__tests__/setup/test-fixtures';
 import { get, postForm } from '../../__tests__/setup/test-helpers';
+import { verifySettingsToken } from '../../gateway/routes/public/settings-auth';
 
 // Two deep-link entry points, two postures:
 //   - GET /exchange-token: first-party tab (CLI/menu-bar) → Lax session cookie.
@@ -121,5 +122,59 @@ describe('deep-link token exchange', () => {
       (o) => o.slug
     );
     expect(anonSlugs).not.toContain(slug);
+  });
+});
+
+// EventSource can't send Authorization, so the embedded panel's SSE streams
+// authenticate with a short-lived ?token= ticket from /api/sse-ticket. The
+// ticket decrypts to the same SettingsSession shape the cookie path yields, so
+// the agent-ownership check (verifySettingsSessionOrToken) accepts it.
+describe('SSE ticket (/api/sse-ticket)', () => {
+  beforeEach(async () => {
+    await cleanupTestDatabase();
+  });
+
+  async function sessionTokenForNewUser(slug: string, email: string): Promise<string> {
+    const org = await createTestOrganization({ slug });
+    const user = await createTestUser({ email });
+    await addUserToOrganization(user.id, org.id, 'owner');
+    const { token: pat } = await createTestPAT(user.id, org.id, { scope: 'profile:read' });
+    const exchange = await postForm('/api/extension-session', { token: pat });
+    return ((await exchange.json()) as { session_token: string }).session_token;
+  }
+
+  it('requires a Bearer token', async () => {
+    expect((await get('/api/sse-ticket')).status).toBe(401);
+    expect((await get('/api/sse-ticket', { token: 'garbage' })).status).toBe(401);
+  });
+
+  it('mints a ticket that decrypts to the user as a first-party-shaped settings session', async () => {
+    const sessionToken = await sessionTokenForNewUser(
+      'sse-ticket-org',
+      'sse-ticket@test.example.com'
+    );
+
+    const res = await get('/api/sse-ticket', { token: sessionToken });
+    expect(res.status).toBe(200);
+    const { ticket } = (await res.json()) as { ticket: string };
+    expect(ticket.length).toBeGreaterThan(0);
+    // The ticket never carries the raw session token.
+    expect(ticket).not.toContain(sessionToken);
+
+    // It decrypts to the user with platform 'external' — the shape
+    // verifyOwnedAgentAccess keys on for the web/cookie path, so the agent
+    // stream authorizes the same owner.
+    const payload = await verifySettingsToken(ticket);
+    expect(payload?.platform).toBe('external');
+    expect((payload?.userId ?? '').length).toBeGreaterThan(0);
+  });
+
+  it('serves the bootstrap page with retry-on-failure handling (no silent redirect)', async () => {
+    const res = await get('/api/extension-bootstrap');
+    const html = await res.text();
+    // On exchange failure it surfaces an error + Retry instead of redirecting
+    // to a token-less app (which would just hang on a spinner).
+    expect(html).toContain('owl-retry');
+    expect(html).toContain('function fail');
   });
 });

--- a/packages/server/src/auth/routes.ts
+++ b/packages/server/src/auth/routes.ts
@@ -8,6 +8,7 @@
  */
 
 import { createHmac } from 'node:crypto';
+import { encrypt } from '@lobu/core';
 import { type Context, Hono } from 'hono';
 import { createDbClientFromEnv } from '../db/client';
 import type { Env } from '../index';
@@ -459,6 +460,54 @@ credentialRoutes.post('/extension-session', async (c) => {
   return c.json({ session_token: sessionToken });
 });
 
+// TTL for SSE tickets — long enough to cover a single agent response (incl.
+// EventSource auto-reconnects mid-stream), short enough that a leaked URL is
+// near-useless. The SPA mints a fresh ticket per stream.
+const SSE_TICKET_TTL_MS = 10 * 60 * 1000;
+
+/**
+ * Mint a short-lived ticket the embedded SPA appends to SSE URLs as
+ * `?access_token=`.
+ *
+ * EventSource can't send `Authorization`, so the cross-site iframe (which has
+ * no session cookie) can't authenticate its streams the way `fetch` does. This
+ * endpoint — authenticated by the Bearer session token the SPA already holds —
+ * returns an encrypted, short-lived token (the same `verifySettingsToken`
+ * shape) carrying just the user id. Stateless: any replica decrypts it, so it's
+ * multi-replica safe with no shared store. The raw session token never goes in
+ * a URL.
+ */
+credentialRoutes.get('/sse-ticket', async (c) => {
+  c.header('Referrer-Policy', 'no-referrer');
+  c.header('Cache-Control', 'no-store');
+
+  const authHeader = c.req.header('Authorization');
+  const bearer = authHeader?.startsWith('Bearer ') ? authHeader.slice(7).trim() : '';
+  if (!bearer) {
+    return c.json(
+      { error: 'unauthorized', error_description: 'Bearer token required' },
+      401
+    );
+  }
+
+  const userId = await resolveDeepLinkToken(c, bearer);
+  if (!userId) {
+    return c.json(
+      { error: 'invalid_token', error_description: 'token is invalid, expired, or revoked' },
+      401
+    );
+  }
+
+  // platform: 'external' matches the owletto web/cookie session shape so the
+  // agent-ownership check (`verifyOwnedAgentAccess`, which keys on platform)
+  // resolves the SAME owner it would for a first-party web session. No jti →
+  // no revocation lookup needed; the short TTL is the bound.
+  const ticket = encrypt(
+    JSON.stringify({ userId, platform: 'external', exp: Date.now() + SSE_TICKET_TTL_MS })
+  );
+  return c.json({ ticket });
+});
+
 /**
  * Bootstrap page for the Owletto extension's side-panel iframe.
  *
@@ -486,21 +535,41 @@ credentialRoutes.get('/extension-bootstrap', (c) => {
   history.replaceState(null, "", location.pathname);
   var next = worker ? "/#worker=" + encodeURIComponent(worker) : "/";
   if (!token) { location.replace("/"); return; }
-  var body = new URLSearchParams();
-  body.set("token", token);
-  fetch("/api/extension-session", {
-    method: "POST",
-    headers: { "Content-Type": "application/x-www-form-urlencoded" },
-    body: body.toString(),
-  })
-    .then(function (r) { return r.ok ? r.json() : null; })
-    .then(function (data) {
-      if (data && data.session_token) {
-        try { sessionStorage.setItem("owletto.session_token", data.session_token); } catch (e) {}
-      }
-      location.replace(next);
+  function fail(msg) {
+    // Surface a real error instead of redirecting to a token-less app, which
+    // would just render signed-out and hang on a spinner — the exact failure
+    // this whole flow exists to avoid.
+    document.body.innerHTML =
+      '<div style="font:14px/1.5 system-ui,sans-serif;color:#334155;padding:24px;max-width:24rem">' +
+      '<p style="margin:0 0 .5rem;font-weight:600">Could not connect to your Owletto.</p>' +
+      '<p style="margin:0 0 1rem;color:#64748b"></p>' +
+      '<button id="owl-retry" style="font:inherit;padding:.4rem .9rem;border:1px solid #cbd5e1;border-radius:.4rem;background:#f8fafc;cursor:pointer">Retry</button>' +
+      '</div>';
+    document.querySelectorAll("p")[1].textContent = msg;
+    var b = document.getElementById("owl-retry");
+    if (b) b.onclick = attempt;
+  }
+  function attempt() {
+    document.body.textContent = "Connecting\\u2026";
+    var body = new URLSearchParams();
+    body.set("token", token);
+    fetch("/api/extension-session", {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: body.toString(),
     })
-    .catch(function () { location.replace(next); });
+      .then(function (r) { return r.ok ? r.json() : null; })
+      .then(function (data) {
+        if (data && data.session_token) {
+          try { sessionStorage.setItem("owletto.session_token", data.session_token); } catch (e) {}
+          location.replace(next);
+        } else {
+          fail("Your session may have expired. Re-pair from the extension if this keeps happening.");
+        }
+      })
+      .catch(function () { fail("Network error reaching the gateway."); });
+  }
+  attempt();
 })();
 </script></body>`
   );

--- a/packages/server/src/auth/routes.ts
+++ b/packages/server/src/auth/routes.ts
@@ -466,8 +466,7 @@ credentialRoutes.post('/extension-session', async (c) => {
 const SSE_TICKET_TTL_MS = 10 * 60 * 1000;
 
 /**
- * Mint a short-lived ticket the embedded SPA appends to SSE URLs as
- * `?access_token=`.
+ * Mint a short-lived ticket the embedded SPA appends to SSE URLs as `?token=`.
  *
  * EventSource can't send `Authorization`, so the cross-site iframe (which has
  * no session cookie) can't authenticate its streams the way `fetch` does. This

--- a/packages/server/src/gateway/routes/public/agent.ts
+++ b/packages/server/src/gateway/routes/public/agent.ts
@@ -33,7 +33,7 @@ import type { ISessionManager, ThreadSession } from "../../session.js";
 import { verifyOwnedAgentAccess } from "../shared/agent-ownership.js";
 import { errorResponse } from "../shared/helpers.js";
 import { errorResponses } from "../shared/openapi-responses.js";
-import { verifySettingsSession } from "./settings-auth.js";
+import { verifySettingsSessionOrToken } from "./settings-auth.js";
 
 const logger = createLogger("agent-api");
 
@@ -597,8 +597,12 @@ export function createAgentApi(config: AgentApiConfig): OpenAPIHono {
       return { organizationId: access.organizationId };
     };
 
-    // 1. Settings session cookie (or injected auth provider for embedded mode).
-    const settingsSession = await verifySettingsSession(c);
+    // 1. Settings session cookie (or injected auth provider for embedded mode),
+    //    or a short-lived `?token=` ticket — the embedded panel's SSE stream
+    //    uses EventSource, which can't send Authorization, so it authenticates
+    //    via a ticket from /api/sse-ticket. verifySettingsToken decrypts it to
+    //    the same SettingsSession shape the cookie path yields.
+    const settingsSession = await verifySettingsSessionOrToken(c, "token");
     if (settingsSession) {
       const access = await verifyOwnedAgentAccess(
         settingsSession,


### PR DESCRIPTION
Follow-up to #1336. After merging the Bearer fix, I ran grok against the real diff (which I should have done pre-merge) — it caught two genuine gaps, both verified in code and fixed here.

## 1. SSE / chat streaming (the material one)
`EventSource` can't send `Authorization`, so in the cross-site iframe (no session cookie) the agent **response stream** had no auth — the panel sent messages (POSTs go through Bearer) but never showed the streamed reply.

- **`GET /api/sse-ticket`** — authenticated by the Bearer session token; returns a short-lived (10 min) **encrypted ticket** carrying the user id, `platform: 'external'` so `verifyOwnedAgentAccess` resolves the *same* owner as the web/cookie path. Stateless (any replica decrypts → multi-replica safe); the raw session token never enters a URL.
- The agent-events ownership gate now uses **`verifySettingsSessionOrToken(c, 'token')`** — with no `?token` query it is **identical** to the previous `verifySettingsSession(c)` (pure superset, no first-party regression); with the ticket it authenticates the stream.
- SPA appends `?token=<ticket>` to the SSE URL when embedded (owletto#289).

## 2. Bootstrap silent-redirect-on-failure (High, easy)
`/api/extension-bootstrap` redirected to the SPA even when the token exchange failed → token-less app → the **same spinner, quietly**. Now surfaces an error + **Retry**.

(Also owletto#289: `signOut` clears the embedded token.)

## Tests (green, local pgvector)
`exchange-token-cookie.test.ts` (9 total): `/api/sse-ticket` requires Bearer (401), mints a ticket that **decrypts to the user with `platform:'external'`** and never contains the raw session token; bootstrap HTML carries the retry handler. owletto: jsdom `clearEmbeddedSessionToken` + tsc + lint.

## Known deferral
The **live-invalidation** SSE (`/api/:orgSlug/events`, `mcpAuth`) still relies on the cookie in the embed — it degrades gracefully (data refreshes on manual navigation, not push). Separate auth layer; tracked as follow-up.

Submodule pointer bumps to owletto#289 after it merges.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1340"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784239266&installation_id=136316292&pr_number=1340&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1340&signature=555b31eab87b8d425ccae0e60b8491a5202d2f5306a15f3c9fd02ee20d7d5038"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->