### PR TITLE
ci: lock-safety lint for new migrations (squawk)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -511,6 +511,32 @@ jobs:
             exit 1
           fi
 
+      - name: Lock-safety lint for new migrations (squawk)
+        # `dbmate up` proves a migration APPLIES to an empty DB; it does not
+        # prove it's safe to apply at prod row counts. squawk catches the
+        # prod-lock-outage class — CREATE INDEX without CONCURRENTLY,
+        # table-rewriting NOT NULL / DEFAULT adds, constraints missing NOT
+        # VALID, etc. Scoped to migrations ADDED/MODIFIED in this PR (the
+        # squashed baseline is unparseable + immutable, and the existing
+        # backlog shouldn't block new work). Excludes:
+        #   - ban-drop-column: this repo does intentional two-phase column drops
+        #   - require-timeout-settings: handled at the deploy layer (no existing
+        #     migration sets per-statement timeouts)
+        # Pinned squawk version matches the `db:lint` package.json script.
+        if: github.event_name == 'pull_request'
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          changed=$(git diff --name-only --diff-filter=AM "$BASE_SHA"...HEAD -- 'db/migrations/*.sql' \
+            | grep -v '^db/migrations/00000000000000_baseline\.sql$' || true)
+          if [ -z "$changed" ]; then
+            echo "No new or modified migrations to lint."
+            exit 0
+          fi
+          echo "Linting migrations:"
+          echo "$changed"
+          echo "$changed" | xargs npx --yes squawk-cli@2.58.0 --exclude=ban-drop-column,require-timeout-settings
+
       - name: Install dbmate
         run: |
           curl -fsSL -o /usr/local/bin/dbmate \

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "test:packages": "cd packages/core && bun run test && cd ../agent-worker && bun run test",
     "typecheck:packages": "cd packages/core && bun run typecheck && cd ../client && bun run typecheck && cd ../agent-worker && bun run typecheck",
     "knip": "bunx knip --config config/knip.ts",
+    "db:lint": "npx --yes squawk-cli@2.58.0 --exclude=ban-drop-column,require-timeout-settings",
     "dupes": "jscpd --silent --reporters console --threshold 1 --pattern 'packages/{core,server,cli,connectors,connector-sdk,connector-worker,client,embeddings,landing}/src/**/*.{ts,tsx}' --ignore '**/__tests__/**,**/*.test.ts,**/*.test.tsx,**/dist/**,**/node_modules/**,**/generated/**' .",
     "slack:manifest:print": "bun run scripts/slack-manifest.ts print",
     "slack:manifest:validate": "bun run scripts/slack-manifest.ts validate",


### PR DESCRIPTION
Adds a **squawk** gate to the `migrations` CI job — the follow-up validated in the tooling test pass.

## Why
`dbmate up` proves a migration *applies to an empty DB*; it does **not** prove it's safe at prod row counts. squawk catches the prod-lock-outage class that `dbmate` can't: `CREATE INDEX` without `CONCURRENTLY`, table-rewriting `NOT NULL`/`DEFAULT` adds, constraints missing `NOT VALID`, non-concurrent index drops. This is the class your `docs/MIGRATIONS.md` says took `events` down twice.

## Design (calibrated against the repo)
- **Scoped to migrations ADDED/MODIFIED in the PR** (`git diff --diff-filter=AM BASE...HEAD`), so the existing backlog (415 issues, mostly in the unparseable squashed baseline) doesn't block new work. A PR that touches no migrations is a clean no-op.
- **Excludes** two rules that are noise here: `ban-drop-column` (this repo does intentional two-phase column drops) and `require-timeout-settings` (0/27 existing migrations set per-statement timeouts — handled at the deploy layer).
- **Keeps** the high-value rules the repo already follows: `require-concurrent-index-creation`/`-deletion` (6 migrations use `CONCURRENTLY`), `prefer-robust-stmts` (21 use `IF [NOT] EXISTS`), `constraint-missing-not-valid`, `ban-drop-table`, `prefer-bigint-over-int`.
- squawk pinned to **2.58.0** (CI via `npx`; matches the new `bun run db:lint` local script). No new devDependency / lockfile churn — the `migrations` job has no `bun install`.

## Verified locally
- Unsafe migration (`CREATE INDEX` without `CONCURRENTLY`) → squawk flags `require-concurrent-index-creation` + `require-concurrent-index-deletion`, **exit 1** (gate blocks). ✅
- A normal recent migration → 0 issues. ✅
- No changed migrations → "No new or modified migrations to lint", **exit 0** (no-op). ✅

This PR changes no migrations, so its own `migrations` job exercises the no-op path.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1341"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784240132&installation_id=136316292&pr_number=1341&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1341&signature=301698771c54bf67a7a263995bb52b7b729eb3b3e8640bd473a1f7dbdb1126a9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced database migration validation in CI to catch potential issues earlier in the development cycle.
  * Added a new database schema linting command for local development.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->