### PR TITLE
fix(turn-liveness): keep active long-running workers alive on every worker signal

### DIFF
--- a/packages/server/src/config/intervals.ts
+++ b/packages/server/src/config/intervals.ts
@@ -81,9 +81,10 @@ export const intervals = {
   },
 
   /** Default turn-liveness deadline. Comfortably exceeds the worker's 20s
-   *  heartbeat interval so a live worker (which extends on every heartbeat)
-   *  is never falsely failed; a silent/dead worker lapses within this window
-   *  of its last heartbeat. */
+   *  status_update interval so a live worker (which extends the deadline on
+   *  every status_update — plus on the 30s SSE-ping ACK and delivery receipts)
+   *  is never falsely failed; a silent/dead worker lapses within this window of
+   *  its last worker-driven signal. */
   get turnDefaultDeadlineMs(): number {
     return parseEnvInt('TURN_DEFAULT_DEADLINE_MS', 60_000);
   },

--- a/packages/server/src/gateway/__tests__/worker-response-liveness.test.ts
+++ b/packages/server/src/gateway/__tests__/worker-response-liveness.test.ts
@@ -1,0 +1,244 @@
+/**
+ * End-to-end tests for the worker-response liveness signals (#12 / #14) against
+ * a real Postgres (embedded PG18 in CI). Drives the gateway's
+ * `POST /worker/response` handler the way a real worker subprocess does and
+ * asserts the two liveness clocks it must refresh:
+ *
+ *  - #14: a 20s `status_update` (NO `received` flag) must push the turn-liveness
+ *    marker's `run_at` deadline forward. Before the fix only the 30s SSE-ping
+ *    ACK extended it, so a live worker emitting status updates every 20s could
+ *    still lapse the 60s deadline on ~2 missed ping ACKs and be falsely failed.
+ *
+ *  - #12: every worker-driven response must refresh the DEPLOYMENT manager's
+ *    idle clock (`updateDeploymentActivity`), not just the connection manager's
+ *    stale-SSE clock — otherwise the idle reaper scales a long-running worker to
+ *    0 mid-turn. Asserted via a stub tracker injected with
+ *    `setDeploymentActivityTracker`.
+ */
+
+import {
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from "bun:test";
+import { generateWorkerToken } from "@lobu/core";
+import { getDb } from "../../db/client.js";
+import { RunsQueue } from "../infrastructure/queue/runs-queue.js";
+import { armTurnTimeout } from "../orchestration/turn-liveness.js";
+import { WorkerGateway } from "../gateway/index.js";
+import {
+  ensureDbForGatewayTests,
+  resetTestDatabase,
+  seedAgentRow,
+} from "./helpers/db-setup.js";
+
+const TEST_ENCRYPTION_KEY = Buffer.from(
+  "12345678901234567890123456789012"
+).toString("base64");
+
+const TURN_TIMEOUT_QUEUE = "internal:turn_timeout";
+const DEPLOYMENT = "lobu-worker-agent-1";
+
+let queue: RunsQueue;
+const previousEncryptionKey = process.env.ENCRYPTION_KEY;
+
+beforeAll(async () => {
+  await ensureDbForGatewayTests();
+});
+
+beforeEach(async () => {
+  process.env.ENCRYPTION_KEY = TEST_ENCRYPTION_KEY;
+  await resetTestDatabase();
+  // The runs FK requires the organization to exist before arming a marker.
+  await seedAgentRow("agent-1", { organizationId: "org-1" });
+  queue = new RunsQueue();
+  await queue.start();
+});
+
+afterEach(async () => {
+  await queue.stop();
+  if (previousEncryptionKey === undefined) delete process.env.ENCRYPTION_KEY;
+  else process.env.ENCRYPTION_KEY = previousEncryptionKey;
+});
+
+function makeGateway(): WorkerGateway {
+  return new WorkerGateway(
+    queue as any,
+    "https://gateway.example.com",
+    { getWorkerConfig: async () => ({ mcpServers: {} }) } as any,
+    {
+      getSessionContext: async () => ({
+        agentInstructions: "",
+        platformInstructions: "",
+        networkInstructions: "",
+        skillsInstructions: "",
+        mcpStatus: [],
+      }),
+    } as any
+  );
+}
+
+function mintToken(): string {
+  return generateWorkerToken("user-1", "conv-1", DEPLOYMENT, {
+    channelId: "chan-1",
+    agentId: "agent-1",
+    organizationId: "org-1",
+    connectionId: "connection-1",
+    source: "watcher-run",
+    runId: 1,
+    messageId: "m1",
+  });
+}
+
+function armLiveTurn(messageId = "m1"): Promise<void> {
+  return armTurnTimeout(queue, {
+    messageId,
+    channelId: "chan-1",
+    conversationId: "conv-1",
+    userId: "user-1",
+    platform: "api",
+    deploymentName: DEPLOYMENT,
+    organizationId: "org-1",
+  });
+}
+
+/** Post a body to `/worker/response` through the real Hono handler. The gateway
+ *  is shut down in a finally so its timers/intervals don't leak across tests. */
+async function postWorkerResponse(
+  body: unknown,
+  opts?: { tracker?: { updateDeploymentActivity: (d: string) => Promise<void> } }
+): Promise<Response> {
+  const gateway = makeGateway();
+  if (opts?.tracker) gateway.setDeploymentActivityTracker(opts.tracker);
+  try {
+    return await gateway.getApp().request("/response", {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${mintToken()}`,
+        host: "gateway.example.com",
+        "content-type": "application/json",
+      },
+      body: JSON.stringify(body),
+    });
+  } finally {
+    gateway.shutdown();
+  }
+}
+
+/** Read the marker's `run_at` (epoch ms) for the live turn, or null if gone. */
+async function markerRunAtMs(): Promise<number | null> {
+  const rows = await getDb()<{ run_at: Date }>`
+    SELECT run_at FROM public.runs
+    WHERE queue_name = ${TURN_TIMEOUT_QUEUE}
+      AND action_input->>'deploymentName' = ${DEPLOYMENT}
+      AND action_input->>'messageId' = 'm1'
+    LIMIT 1`;
+  return rows[0] ? new Date(rows[0].run_at).getTime() : null;
+}
+
+/** Force the marker's deadline to a known PAST instant so any extend is
+ *  observable as a forward jump (and so the marker counts as lapsed). */
+async function expireMarker(): Promise<number> {
+  await getDb()`
+    UPDATE public.runs SET run_at = now() - interval '5 minutes'
+    WHERE queue_name = ${TURN_TIMEOUT_QUEUE}`;
+  const at = await markerRunAtMs();
+  if (at === null) throw new Error("marker missing after expire");
+  return at;
+}
+
+describe("POST /worker/response — turn-liveness deadline (#14)", () => {
+  test("a 20s status_update (no `received`) extends the deadline", async () => {
+    await armLiveTurn("m1");
+    const lapsedAt = await expireMarker();
+    expect(lapsedAt).toBeLessThan(Date.now()); // sanity: deadline is in the past
+
+    // A status_update response carries `statusUpdate` and NO `received` flag —
+    // exactly what GatewayIntegration.sendStatusUpdate emits every 20s.
+    const res = await postWorkerResponse({
+      messageId: "m1",
+      conversationId: "conv-1",
+      statusUpdate: { elapsedSeconds: 40, state: "working" },
+    });
+    expect(res.status).toBe(200);
+
+    // The extend is best-effort/fire-and-forget; poll briefly for the UPDATE to
+    // land rather than racing it.
+    let after: number | null = null;
+    for (let i = 0; i < 50; i++) {
+      after = await markerRunAtMs();
+      if (after !== null && after > lapsedAt + 1000) break;
+      await new Promise((r) => setTimeout(r, 20));
+    }
+    expect(after).not.toBeNull();
+    // The deadline must have jumped forward into the FUTURE — before the fix a
+    // status_update never extended, so run_at would stay at `lapsedAt` (past).
+    expect(after!).toBeGreaterThan(Date.now());
+    expect(after!).toBeGreaterThan(lapsedAt);
+  });
+
+  test("a delivery/heartbeat ACK (`received`) still extends the deadline", async () => {
+    await armLiveTurn("m1");
+    const lapsedAt = await expireMarker();
+
+    const res = await postWorkerResponse({ received: true, heartbeat: true });
+    expect(res.status).toBe(200);
+
+    let after: number | null = null;
+    for (let i = 0; i < 50; i++) {
+      after = await markerRunAtMs();
+      if (after !== null && after > lapsedAt + 1000) break;
+      await new Promise((r) => setTimeout(r, 20));
+    }
+    expect(after!).toBeGreaterThan(Date.now());
+  });
+});
+
+describe("POST /worker/response — deployment idle clock (#12)", () => {
+  test("a status_update refreshes the deployment activity tracker", async () => {
+    await armLiveTurn("m1");
+    const touched: string[] = [];
+    const tracker = {
+      updateDeploymentActivity: async (d: string) => {
+        touched.push(d);
+      },
+    };
+
+    const res = await postWorkerResponse(
+      {
+        messageId: "m1",
+        conversationId: "conv-1",
+        statusUpdate: { elapsedSeconds: 40, state: "working" },
+      },
+      { tracker }
+    );
+    expect(res.status).toBe(200);
+
+    // The handler awaits nothing on the tracker (fire-and-forget); give the
+    // microtask a tick to flush.
+    await new Promise((r) => setTimeout(r, 20));
+    expect(touched).toContain(DEPLOYMENT);
+  });
+
+  test("a delivery ACK also refreshes the deployment activity tracker", async () => {
+    await armLiveTurn("m1");
+    const touched: string[] = [];
+    const tracker = {
+      updateDeploymentActivity: async (d: string) => {
+        touched.push(d);
+      },
+    };
+
+    const res = await postWorkerResponse(
+      { received: true, heartbeat: true },
+      { tracker }
+    );
+    expect(res.status).toBe(200);
+
+    await new Promise((r) => setTimeout(r, 20));
+    expect(touched).toContain(DEPLOYMENT);
+  });
+});

--- a/packages/server/src/gateway/gateway/index.ts
+++ b/packages/server/src/gateway/gateway/index.ts
@@ -42,6 +42,17 @@ import { createTranscriptRoutes } from "./transcript-routes.js";
 const logger = createLogger("worker-gateway");
 
 /**
+ * Minimal seam onto the deployment manager's idle clock. Any worker-driven
+ * signal (HTTP response / ACK) must refresh the deployment's `lastActivity` so
+ * the idle reaper doesn't scale a long-running-but-active worker to 0 mid-turn.
+ * Narrow on purpose: the gateway only needs to touch the idle clock, not the
+ * full deployment lifecycle.
+ */
+export interface DeploymentActivityTracker {
+  updateDeploymentActivity(deploymentName: string): Promise<void>;
+}
+
+/**
  * Worker Gateway - SSE and HTTP endpoints for worker communication
  * Workers connect via SSE to receive jobs, send responses via HTTP POST
  * Uses encrypted tokens for authentication and routing
@@ -58,6 +69,7 @@ export class WorkerGateway {
   private providerCatalogService?: ProviderCatalogService;
   private agentSettingsStore?: AgentSettingsStore;
   private secretStore?: WritableSecretStore;
+  private deploymentActivityTracker?: DeploymentActivityTracker;
 
   constructor(
     queue: IMessageQueue,
@@ -97,6 +109,18 @@ export class WorkerGateway {
    */
   getConnectionManager(): WorkerConnectionManager {
     return this.connectionManager;
+  }
+
+  /**
+   * Wire the deployment manager's idle clock so worker responses keep a
+   * long-running worker alive in the idle reaper. Injected after construction
+   * because the gateway and the orchestrator (which owns the deployment
+   * manager) are built separately; the gateway runs without it (the tracker is
+   * optional) but then a worker active past WORKER_IDLE_CLEANUP_MINUTES with no
+   * new inbound message can be reaped mid-turn.
+   */
+  setDeploymentActivityTracker(tracker: DeploymentActivityTracker): void {
+    this.deploymentActivityTracker = tracker;
   }
 
   /**
@@ -377,8 +401,25 @@ export class WorkerGateway {
 
     const { deploymentName } = auth.tokenData;
 
-    // Update connection activity
+    // Update connection activity (SSE stale-cleanup clock).
     this.connectionManager.touchConnection(deploymentName);
+    // Also refresh the DEPLOYMENT manager's idle clock. `touchConnection` above
+    // only feeds the connection manager's stale-SSE sweep — it does NOT touch
+    // `EmbeddedWorkerEntry.lastActivity`, which the idle reaper
+    // (reconcileDeployments → buildDeploymentInfoSummary.isIdle) reads. Without
+    // this, that timestamp stays frozen at the last dispatch, so a worker
+    // running a single long turn (no new inbound message) past
+    // WORKER_IDLE_CLEANUP_MINUTES is scaled to 0 and killed mid-turn. Every
+    // worker-driven HTTP response (delta, status_update, ACK, terminal reply)
+    // hits this path, so any liveness signal keeps the idle clock fresh; a
+    // truly silent worker still stops POSTing and ages out as intended.
+    void this.deploymentActivityTracker
+      ?.updateDeploymentActivity(deploymentName)
+      .catch((err) => {
+        logger.warn(
+          `[WORKER-GATEWAY] Failed to refresh deployment activity for ${deploymentName}: ${err}`
+        );
+      });
 
     try {
       const body = await c.req.json();
@@ -424,6 +465,18 @@ export class WorkerGateway {
         // but slow worker is never falsely failed by the sweep. Best-effort.
         void extendTurnDeadlines(deploymentName);
         return c.json({ success: true });
+      }
+
+      // The worker's 20s status_update (HEARTBEAT_INTERVAL_MS in
+      // session-runner.ts) carries `statusUpdate` and NO `received` flag, so it
+      // falls through the ACK block above. It is the most frequent worker-driven
+      // liveness signal — far more frequent than the 30s SSE-ping ACK — so it
+      // must refresh the turn-liveness deadline too, otherwise a live worker
+      // emitting status updates every 20s could still lapse the 60s deadline on
+      // ~2 consecutive missed ping ACKs and be falsely failed by the sweep.
+      // Best-effort, same as the ACK path.
+      if (enrichedResponse.statusUpdate) {
+        void extendTurnDeadlines(deploymentName);
       }
 
       // Log for debugging

--- a/packages/server/src/gateway/orchestration/turn-liveness.ts
+++ b/packages/server/src/gateway/orchestration/turn-liveness.ts
@@ -25,9 +25,11 @@
  *  - Backstop (deadline): {@link sweepExpiredTurns} runs periodically on every
  *    replica and fails markers whose deadline has lapsed. Covers a hung worker
  *    (alive, never replies) and a worker-pod death (the marker outlives the pod
- *    and another replica sweeps it). The deadline is pushed forward by the
- *    worker's 20s heartbeat ({@link extendTurnDeadlines}), so a live-but-slow
- *    worker is never falsely failed, while a silent one lapses.
+ *    and another replica sweeps it). The deadline is pushed forward
+ *    ({@link extendTurnDeadlines}) by any worker-driven liveness signal —
+ *    primarily the worker's 20s status_update, plus the 30s SSE-ping ACK and
+ *    delivery receipts — so a live-but-slow worker is never falsely failed,
+ *    while a silent one lapses.
  *
  * ## Multi-replica
  * Arming/extending/discharging all happen on the worker's owning pod (worker
@@ -125,8 +127,9 @@ export async function armTurnTimeout(
 
 /**
  * Push the deadline forward for all in-flight turns of a deployment. Called on
- * the worker's heartbeat ACK — a worker-driven liveness signal, so a live but
- * slow worker keeps its markers fresh while a silent one lapses.
+ * any worker-driven liveness signal — primarily the worker's 20s status_update,
+ * plus the 30s SSE-ping ACK and delivery receipts — so a live but slow worker
+ * keeps its markers fresh while a silent one lapses.
  */
 export async function extendTurnDeadlines(
   deploymentName: string,
@@ -170,9 +173,10 @@ export async function extendTurnDeadlines(
  * The `internal:turn_timeout` marker (a pending `public.runs` row, armed at
  * dispatch keyed on `deploymentName:messageId`) is the authoritative cross-pod
  * record that a turn is live: every terminalization path deletes it
- * transactionally (first-writer-wins), and the worker's 20s heartbeat pushes its
- * `run_at` deadline forward while the turn legitimately runs long — so any
- * replica reads the true state from shared `public.runs`.
+ * transactionally (first-writer-wins), and any worker-driven liveness signal
+ * (primarily the worker's 20s status_update) pushes its `run_at` deadline
+ * forward while the turn legitimately runs long — so any replica reads the true
+ * state from shared `public.runs`.
  *
  * This is the liveness gate for worker-token refresh. The marker and the per-run
  * token are minted in the same dispatch (MessageConsumer.handleMessage) with the

--- a/packages/server/src/lobu/gateway.ts
+++ b/packages/server/src/lobu/gateway.ts
@@ -366,6 +366,16 @@ export async function initLobuGateway(): Promise<Hono | null> {
     );
     logger.info('[Lobu] Embedded orchestrator injected core services');
 
+    // Wire the deployment manager's idle clock into the worker gateway so every
+    // worker-driven HTTP response (delta / status_update / ACK / terminal reply)
+    // refreshes the deployment's lastActivity. Without this the idle reaper can
+    // scale a worker running one long turn to 0 mid-turn (its lastActivity stays
+    // frozen at last dispatch). Both objects exist here; they are built
+    // separately so the wiring lives at the composition root.
+    coreServices
+      .getWorkerGateway()
+      ?.setDeploymentActivityTracker(orchestrator.getDeploymentManager());
+
     // Initialize Chat SDK connection manager for platform connections
     chatInstanceManager = new ChatInstanceManager();
     try {


### PR DESCRIPTION
## Problem

Two findings, one shared root cause: the worker's frequent **20s status_update refreshed NEITHER safety timer**, so a worker running a single long turn could be falsely killed.

### #12 — Active long-running worker reaped mid-turn (medium)
`updateDeploymentActivity` (the only writer of the workers-map `entry.lastActivity`) was called **only at dispatch** from `MessageConsumer.ensureWorkerExists`. Per-turn worker responses hit `handleWorkerResponse`, which called `connectionManager.touchConnection` — that refreshes the **connection** manager's clock (SSE stale cleanup), not the **deployment** manager's. So `buildDeploymentInfoSummary.isIdle` read a timestamp frozen at last dispatch, and `reconcileDeployments` scaled an idle-looking worker to 0 → `killWorker` → `intentionalExits` → the exit handler **skips** `failTurnsForDeployment`. A turn running past `WORKER_IDLE_CLEANUP_MINUTES` (default 60) with no new inbound message was killed mid-turn; the sweep then emitted a spurious "worker stopped responding".

### #14 — Deadline only extended on the 30s ping ACK, not the 20s status_update (medium-high)
`extendTurnDeadlines` was called **only inside** the `if (enrichedResponse.received)` branch. The worker's 20s `status_update` (`HEARTBEAT_INTERVAL_MS` in session-runner.ts) is sent via `sendStatusUpdate` → `buildBaseResponse` with **no `received` flag**, so it fell through and never extended the deadline. The only thing that extended it was the heartbeat ACK reacting to the gateway's 30s SSE ping. With `turnDefaultDeadlineMs=60000` and a 30s ping cadence, ~2 consecutive missed ping ACKs falsely failed a **live** worker. Three comments also wrongly claimed the "20s heartbeat" extends the deadline (conflating the 20s status_update with the 30s ping ACK).

## Fix

- **#12:** add a narrow `DeploymentActivityTracker` seam on `WorkerGateway`; call `updateDeploymentActivity(deploymentName)` on **every** worker response/ACK in `handleWorkerResponse` (alongside `touchConnection`). Wired at the composition root (`lobu/gateway.ts`) from `orchestrator.getDeploymentManager()`. A truly silent worker still stops POSTing, so its `lastActivity` still ages out — the idle reaper's purpose is preserved.
- **#14:** extend the turn-liveness deadline for `statusUpdate` responses too (the `received` ACK path is unchanged). Corrected the misleading comments in `turn-liveness.ts` (×2 blocks) and `intervals.ts` to describe the real mechanism (any worker-driven signal — primarily the 20s status_update — extends; the 30s ping ACK and delivery receipts also do).

## Red → green (E2E, real Postgres)

New `worker-response-liveness.test.ts` drives the gateway's `POST /worker/response` handler the way a real worker does (mints a worker token, posts a `statusUpdate` body) and asserts against the real `public.runs` marker.

Reverting the two source files and running against the original code:
```
(fail) #14 status_update extends the deadline
  Expected: > 1781649425822 (now)
  Received:   1781649124629  (lapsedAt — run_at stayed in the PAST)
(fail) #12 status_update refreshes the tracker — setDeploymentActivityTracker is not a function
(fail) #12 delivery ACK refreshes the tracker — same
(pass) #14 received-ACK still extends   ← ACK path always worked; unchanged
 1 pass / 3 fail
```
With the fix restored: **4 pass / 0 fail**. Existing `turn-liveness.test.ts` (18) and `worker-token-refresh-route.test.ts` / session-context (9) stay green. `cd packages/server && npx tsc --noEmit` → 0 errors.

## Multi-replica note
The deployment manager's `workers` map is pod-local; the worker subprocess POSTs `/worker/response` to the **same** pod that spawned it (co-located), so refreshing that pod's idle clock from its own worker's response is correct — no cross-pod state is read or mutated. The turn-liveness marker itself remains the Postgres-mediated cross-pod authority.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1343"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784241514&installation_id=136316292&pr_number=1343&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1343&signature=83104a3ee2b3a32c4021c124297fbd92a31220310ed43bb30db2730e6948395e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->