### PR TITLE
fix(connections): bounded retry for exclusive-start failures + claim cleanup + save_memory supersede TOCTOU

### DIFF
--- a/packages/server/src/__tests__/integration/events/save-content-supersede-race.test.ts
+++ b/packages/server/src/__tests__/integration/events/save-content-supersede-race.test.ts
@@ -1,0 +1,179 @@
+/**
+ * Integration test: save_content (save_memory) supersession robustness.
+ *
+ * save_content's supersede path is a read-then-insert TOCTOU:
+ *   1. SELECT "is this target already superseded?" (non-atomic)
+ *   2. insertEvent(..., supersedesEventId) — NO advisory lock (save_content
+ *      doesn't pass the onConflictUpdate/connectionId/originId combo that
+ *      insert-event.ts locks on).
+ *
+ * Two concurrent supersedes of the SAME target both pass the read, both
+ * INSERT, and the loser hits the partial unique index
+ * `idx_events_superseded_by` with a raw Postgres 23505. Because that raw error
+ * is NOT a ToolUserError, it was captured to Sentry as noise (sentry.ts) even
+ * though no data is lost — the unique index correctly protects the invariant.
+ *
+ * Pinned behavior after the fix:
+ *   - Concurrent supersede race: the loser gets a clean ToolUserError (409),
+ *     not a raw 23505. Exactly one supersede succeeds.
+ *   - A stale supersede target (already superseded, or not found in the org)
+ *     throws ToolUserError — a user fault, not an infra error — so it doesn't
+ *     fire a Sentry alert.
+ *
+ * Vitest CI gap note (mirrors neighbors): runs locally / in the CI integration
+ * job against the pgvector DB via DATABASE_URL.
+ */
+
+import { beforeAll, describe, expect, it } from 'vitest';
+import { saveContent } from '../../../tools/save_content';
+import type { ToolContext } from '../../../tools/registry';
+import { ToolUserError } from '../../../utils/errors';
+import { initWorkspaceProvider } from '../../../workspace';
+import { cleanupTestDatabase, getTestDb } from '../../setup/test-db';
+import {
+  addUserToOrganization,
+  createTestEvent,
+  createTestOrganization,
+  createTestUser,
+  seedSystemEntityTypes,
+} from '../../setup/test-fixtures';
+
+describe('saveContent > supersession robustness', () => {
+  let org: Awaited<ReturnType<typeof createTestOrganization>>;
+  let user: Awaited<ReturnType<typeof createTestUser>>;
+  let ctx: ToolContext;
+
+  beforeAll(async () => {
+    await initWorkspaceProvider();
+    await cleanupTestDatabase();
+    await seedSystemEntityTypes();
+
+    org = await createTestOrganization({ name: 'Supersede Race Org' });
+    user = await createTestUser({ email: 'supersede-race@example.com' });
+    await addUserToOrganization(user.id, org.id, 'owner');
+
+    ctx = {
+      organizationId: org.id,
+      userId: user.id,
+      memberRole: 'owner',
+      isAuthenticated: true,
+      tokenType: 'oauth',
+      scopedToOrg: false,
+      allowCrossOrg: true,
+      scopes: ['mcp:write'],
+    } as ToolContext;
+  });
+
+  it('the loser of a concurrent-supersede race gets a clean ToolUserError, not a raw 23505', async () => {
+    // Seed one target event to supersede.
+    const target = await createTestEvent({
+      organization_id: org.id,
+      title: 'Old fact',
+      content: 'the original value',
+      semantic_type: 'content',
+    });
+
+    // 6 concurrent supersedes of the SAME target. The non-atomic "already
+    // superseded?" read lets several through; the partial unique index lets
+    // exactly one win — the rest must surface as ToolUserError(409), NOT a raw
+    // Postgres 23505 (which would be Sentry noise).
+    const results = await Promise.allSettled(
+      Array.from({ length: 6 }, (_, i) =>
+        saveContent(
+          {
+            content: `replacement ${i}`,
+            title: 'New fact',
+            semantic_type: 'content',
+            supersedes_event_id: target.id,
+            metadata: {},
+          } as never,
+          {} as never,
+          ctx
+        )
+      )
+    );
+
+    const fulfilled = results.filter((r) => r.status === 'fulfilled');
+    const rejected = results.filter(
+      (r) => r.status === 'rejected'
+    ) as PromiseRejectedResult[];
+
+    // Exactly one winner.
+    expect(fulfilled).toHaveLength(1);
+    expect(rejected.length).toBeGreaterThan(0);
+
+    // Every loser is a ToolUserError (409), never a raw 23505 / generic Error.
+    for (const r of rejected) {
+      expect(r.reason).toBeInstanceOf(ToolUserError);
+      expect((r.reason as ToolUserError).httpStatus).toBe(409);
+      expect((r.reason as ToolUserError).message).toMatch(/already superseded/i);
+      // A raw postgres error would carry code 23505; the clean error must not.
+      expect((r.reason as { code?: string }).code).toBeUndefined();
+    }
+
+    // DB invariant intact: exactly one row supersedes the target.
+    const sql = getTestDb();
+    const superseders = await sql`
+      SELECT id FROM events WHERE supersedes_event_id = ${target.id}
+    `;
+    expect(superseders).toHaveLength(1);
+  });
+
+  it('superseding an already-superseded target throws ToolUserError (stale target, not infra error)', async () => {
+    const target = await createTestEvent({
+      organization_id: org.id,
+      title: 'Target',
+      content: 'v1',
+      semantic_type: 'content',
+    });
+
+    // First supersede wins.
+    await saveContent(
+      {
+        content: 'v2',
+        title: 'Target',
+        semantic_type: 'content',
+        supersedes_event_id: target.id,
+        metadata: {},
+      } as never,
+      {} as never,
+      ctx
+    );
+
+    // Second supersede of the SAME (now stale) target: the pre-insert read
+    // catches it and throws ToolUserError (409), not a plain Error.
+    const err = await saveContent(
+      {
+        content: 'v3',
+        title: 'Target',
+        semantic_type: 'content',
+        supersedes_event_id: target.id,
+        metadata: {},
+      } as never,
+      {} as never,
+      ctx
+    ).catch((e) => e);
+
+    expect(err).toBeInstanceOf(ToolUserError);
+    expect((err as ToolUserError).httpStatus).toBe(409);
+    expect((err as ToolUserError).message).toMatch(/already superseded/i);
+  });
+
+  it('superseding a non-existent target throws ToolUserError (404), not a plain Error', async () => {
+    const err = await saveContent(
+      {
+        content: 'orphan',
+        title: 'Orphan',
+        semantic_type: 'content',
+        supersedes_event_id: 999_999_999,
+        metadata: {},
+      } as never,
+      {} as never,
+      ctx
+    ).catch((e) => e);
+
+    expect(err).toBeInstanceOf(ToolUserError);
+    expect((err as ToolUserError).httpStatus).toBe(404);
+    expect((err as ToolUserError).message).toMatch(/not found/i);
+  });
+});

--- a/packages/server/src/gateway/connections/__tests__/connection-claims.test.ts
+++ b/packages/server/src/gateway/connections/__tests__/connection-claims.test.ts
@@ -203,6 +203,44 @@ describe("connection_claims lease (exclusive transports)", () => {
     expect(manager.exclusiveFailures.has("conn-transient")).toBe(false);
   });
 
+  test("backoff accumulates across retries even when the transient error MESSAGE varies (no updated_at churn)", async () => {
+    const { manager, connectionStore } = await buildReplica();
+    await seedTelegramPolling(
+      connectionStore,
+      "org-vary",
+      "agent-vary",
+      "conn-vary"
+    );
+
+    // Every hydrate throws with a DIFFERENT message — real transient start
+    // errors vary between attempts (ETIMEDOUT vs ECONNRESET, socket addresses,
+    // request ids). The error STATUS must only be written on the first failure,
+    // otherwise a changing message bumps updated_at every retry, resets the
+    // backoff record (keyed on updated_at), and defeats the exponential backoff.
+    let calls = 0;
+    manager.hydrateFromRow = async () => {
+      calls += 1;
+      throw new Error(`transient boom #${calls}`);
+    };
+
+    // Tick 1: first failure → status written once, attempts = 1.
+    await manager.exclusiveTick();
+    const afterFirst = await connectionStore.getConnection("conn-vary");
+    const v1 = afterFirst!.updatedAt;
+    expect(manager.exclusiveFailures.get("conn-vary")!.attempts).toBe(1);
+
+    // Elapse the backoff and retry — fails again with a DIFFERENT message.
+    manager.exclusiveFailures.get("conn-vary")!.nextRetryAt = Date.now() - 1;
+    await manager.exclusiveTick();
+    expect(calls).toBe(2);
+
+    const afterSecond = await connectionStore.getConnection("conn-vary");
+    // The varying message must NOT re-write the status / bump updated_at...
+    expect(afterSecond!.updatedAt).toBe(v1);
+    // ...so the backoff keeps ACCUMULATING (attempts → 2) instead of resetting.
+    expect(manager.exclusiveFailures.get("conn-vary")!.attempts).toBe(2);
+  });
+
   test("removeConnection deletes the connection_claims lease row (no orphan)", async () => {
     const { getDb } = await import("../../../db/client.js");
     const { manager, connectionStore } = await buildReplica();

--- a/packages/server/src/gateway/connections/__tests__/connection-claims.test.ts
+++ b/packages/server/src/gateway/connections/__tests__/connection-claims.test.ts
@@ -154,6 +154,95 @@ describe("connection_claims lease (exclusive transports)", () => {
     expect(other.instances.has("conn-poll")).toBe(false);
   });
 
+  test("a TRANSIENT exclusive-start failure is retried automatically after backoff, with NO row edit", async () => {
+    const { manager, connectionStore } = await buildReplica();
+    await seedTelegramPolling(
+      connectionStore,
+      "org-transient",
+      "agent-transient",
+      "conn-transient"
+    );
+
+    // First hydrate throws (Telegram 5xx / DB blip class) — this leaves the
+    // row errored. Subsequent hydrates succeed.
+    let calls = 0;
+    manager.hydrateFromRow = async (stored: any) => {
+      calls += 1;
+      if (calls === 1) throw new Error("transient boom (5xx)");
+      manager.instances.set(stored.id, {
+        connection: { id: stored.id, platform: stored.platform },
+        chat: {},
+        conversationState: {},
+        messageBridge: {},
+        rowVersion: stored.updatedAt,
+      });
+    };
+
+    // Tick 1: claims the lease, hydrate throws → row errored, backoff scheduled.
+    await manager.exclusiveTick();
+    expect(manager.instances.has("conn-transient")).toBe(false);
+    const errored = await connectionStore.getConnection("conn-transient");
+    expect(errored!.status).toBe("error");
+    expect(errored!.errorMessage ?? "").toContain("Startup failed");
+
+    // A failure record exists and gates the very next tick (still in backoff).
+    const failure = manager.exclusiveFailures.get("conn-transient");
+    expect(failure).toBeDefined();
+    await manager.exclusiveTick();
+    expect(manager.instances.has("conn-transient")).toBe(false);
+    expect(calls).toBe(1); // gated — no second hydrate attempt yet
+
+    // Simulate elapsed backoff WITHOUT any config/row edit: the time-based gate
+    // must now allow re-hydration. (Old code keyed retry purely on updated_at,
+    // so it would NEVER retry without a human edit — this is the regression.)
+    manager.exclusiveFailures.get("conn-transient").nextRetryAt = Date.now() - 1;
+    await manager.exclusiveTick();
+    expect(calls).toBe(2);
+    expect(manager.instances.has("conn-transient")).toBe(true);
+    // Success clears the failure record.
+    expect(manager.exclusiveFailures.has("conn-transient")).toBe(false);
+  });
+
+  test("removeConnection deletes the connection_claims lease row (no orphan)", async () => {
+    const { getDb } = await import("../../../db/client.js");
+    const { manager, connectionStore } = await buildReplica();
+    await seedTelegramPolling(
+      connectionStore,
+      "org-rm",
+      "agent-rm",
+      "conn-rm-claim"
+    );
+
+    // Register a minimal instance whose conversationState is a no-op stub, so
+    // removeConnection's history-cleanup is network/DB-free and the test
+    // isolates the claim-row deletion (the behaviour under test).
+    manager.hydrateFromRow = async (stored: any) => {
+      manager.instances.set(stored.id, {
+        connection: { id: stored.id, platform: stored.platform },
+        conversationState: { clearAllHistory: async () => 0 },
+        rowVersion: stored.updatedAt,
+      });
+    };
+
+    // Claim the lease for this connection.
+    await manager.exclusiveTick();
+    expect(manager.instances.has("conn-rm-claim")).toBe(true);
+    const before = await getDb()`
+      SELECT 1 FROM connection_claims WHERE connection_id = 'conn-rm-claim'
+    `;
+    expect(before.length).toBe(1);
+
+    // Remove the connection: the lease row must be gone (no FK cascade exists).
+    const { orgContext } = await import("../../../lobu/stores/org-context.js");
+    await orgContext.run({ organizationId: "org-rm" }, () =>
+      manager.removeConnection("conn-rm-claim")
+    );
+    const after = await getDb()`
+      SELECT 1 FROM connection_claims WHERE connection_id = 'conn-rm-claim'
+    `;
+    expect(after.length).toBe(0);
+  });
+
   test("request paths never start an exclusive connection on a non-owner replica", async () => {
     const { manager: a } = await buildReplica();
     const { manager: b, connectionStore } = await buildReplica();

--- a/packages/server/src/gateway/connections/chat-instance-manager.ts
+++ b/packages/server/src/gateway/connections/chat-instance-manager.ts
@@ -68,6 +68,16 @@ const EXCLUSIVE_TICK_MS = 15_000;
 const CLAIM_TTL_SECONDS = 45;
 
 /**
+ * Bounded exponential backoff for a failed exclusive start. A transient
+ * failure must be retried automatically (instead of latching DEAD until a
+ * human edits the row), but the retry must NOT flap: the backoff starts at one
+ * tick and doubles, capped so a genuinely-broken connection costs at most one
+ * short start attempt per `EXCLUSIVE_FAILURE_MAX_BACKOFF_MS` window.
+ */
+const EXCLUSIVE_FAILURE_BASE_BACKOFF_MS = EXCLUSIVE_TICK_MS;
+const EXCLUSIVE_FAILURE_MAX_BACKOFF_MS = 10 * 60_000;
+
+/**
  * Platforms that are valid to declare on an agent but have no chat adapter to
  * run. `rest` is the HTTP Agent API (`POST /lobu/api/v1/agents/:id/messages`),
  * which is registered unconditionally in gateway/routes/public/agent.ts —
@@ -121,11 +131,19 @@ export class ChatInstanceManager {
   /** Exclusive connections this replica currently holds the lease for. */
   private exclusiveOwned = new Set<string>();
   /**
-   * rowVersion of the last failed exclusive start per connection, so a
-   * broken config is retried once per row edit instead of every tick.
-   * Pod-local on purpose: retry bookkeeping is a local decision.
+   * Backoff bookkeeping for a failed exclusive start, keyed by connection id.
+   * `rowVersion` is the post-failure `updated_at` so a row edit resets the
+   * backoff; `attempts` drives exponential backoff; `nextRetryAt` is the
+   * epoch-ms gate so a TRANSIENT failure (Telegram 5xx, DB blip, secret
+   * hiccup) is retried automatically instead of latching DEAD forever, while
+   * a genuinely-bad config still only burns one short tick per backoff window.
+   * Pod-local on purpose: this replica holds the lease, so its retry cadence
+   * is a purely local decision (see the N>1 reasoning in the PR body).
    */
-  private lastExclusiveFailure = new Map<string, number>();
+  private exclusiveFailures = new Map<
+    string,
+    { rowVersion: number; attempts: number; nextRetryAt: number }
+  >();
   private exclusiveTickInFlight = false;
 
   /**
@@ -339,6 +357,13 @@ export class ChatInstanceManager {
     );
     await this.connectionStore.deleteConnection(id);
 
+    // Drop any lease row for this connection. `connection_claims` has no FK
+    // cascade onto agent_connections, so without this an exclusive connection's
+    // claim leaks if the owner pod crashes before its next tick. Delete by
+    // connection_id only (NOT podId-scoped): removeConnection can run on a
+    // non-owner replica, which must still be able to clear the dead owner's row.
+    await this.deleteClaimForConnection(id);
+
     logger.info({ id, historyDeleted, secretsDeleted }, "Connection removed");
   }
 
@@ -361,7 +386,7 @@ export class ChatInstanceManager {
     // claim runner (here or on the owning replica) retry on its next tick,
     // but a request path never starts the polling loop itself.
     if (this.isExclusiveStored(stored)) {
-      this.lastExclusiveFailure.delete(id);
+      this.exclusiveFailures.delete(id);
       return;
     }
 
@@ -495,7 +520,7 @@ export class ChatInstanceManager {
         // Lease-owned: drop any local loop; the claim owner re-hydrates on
         // its next tick via the rowVersion mismatch.
         await this.stopInstance(id);
-        this.lastExclusiveFailure.delete(id);
+        this.exclusiveFailures.delete(id);
       } else {
         // Eager restart on the serving pod for immediate config validation;
         // other replicas converge lazily via the rowVersion memo. On failure
@@ -1260,7 +1285,7 @@ export class ChatInstanceManager {
       if (!exclusiveRows.has(id)) {
         await this.stopInstance(id);
         this.exclusiveOwned.delete(id);
-        this.lastExclusiveFailure.delete(id);
+        this.exclusiveFailures.delete(id);
         await this.releaseClaim(id);
       }
     }
@@ -1298,11 +1323,25 @@ export class ChatInstanceManager {
       this.exclusiveOwned.add(s.id);
       const instance = this.instances.get(s.id);
       if (instance && instance.rowVersion === s.updatedAt) continue;
-      if (this.lastExclusiveFailure.get(s.id) === s.updatedAt) continue;
+
+      // Backoff gate: skip a re-hydration only while a prior failure for THIS
+      // row version is still inside its backoff window. Once nextRetryAt has
+      // passed we retry even though updated_at is unchanged — that's what turns
+      // a transient start failure from "DEAD until a human edits the row" into
+      // "retried automatically with exponential backoff". A row edit (different
+      // updatedAt) clears the record below and retries immediately.
+      const failure = this.exclusiveFailures.get(s.id);
+      if (
+        failure &&
+        failure.rowVersion === s.updatedAt &&
+        Date.now() < failure.nextRetryAt
+      ) {
+        continue;
+      }
 
       try {
         await this.hydrateFromRow(s);
-        this.lastExclusiveFailure.delete(s.id);
+        this.exclusiveFailures.delete(s.id);
       } catch (error) {
         logger.error(
           { id: s.id, error: String(error) },
@@ -1313,10 +1352,28 @@ export class ChatInstanceManager {
           "error",
           `Startup failed: ${error instanceof Error ? error.message : String(error)}`
         );
-        // Remember the post-write rowVersion so we retry only when the row
-        // actually changes (the status write itself bumps updated_at).
+        // Schedule a bounded, exponentially-backed-off retry. The status write
+        // above bumps updated_at, so key the record on the POST-write version:
+        // a genuine config edit later produces yet another version and resets
+        // the backoff (record cleared on the version mismatch). We KEEP the
+        // lease through the failure (no releaseClaim) on purpose — releasing it
+        // would just bounce the same transient failure around N replicas
+        // (flapping). One owner retrying on a capped backoff is the calmer,
+        // multi-replica-correct behaviour.
         const reread = await this.connectionStore.getConnection(s.id);
-        this.lastExclusiveFailure.set(s.id, reread?.updatedAt ?? s.updatedAt);
+        const rowVersion = reread?.updatedAt ?? s.updatedAt;
+        const prior =
+          failure && failure.rowVersion === rowVersion ? failure.attempts : 0;
+        const attempts = prior + 1;
+        const backoff = Math.min(
+          EXCLUSIVE_FAILURE_BASE_BACKOFF_MS * 2 ** (attempts - 1),
+          EXCLUSIVE_FAILURE_MAX_BACKOFF_MS
+        );
+        this.exclusiveFailures.set(s.id, {
+          rowVersion,
+          attempts,
+          nextRetryAt: Date.now() + backoff,
+        });
       }
     }
   }
@@ -1352,6 +1409,25 @@ export class ChatInstanceManager {
       logger.warn(
         { id: connectionId, error: String(error) },
         "Failed to release exclusive claim"
+      );
+    }
+  }
+
+  /**
+   * Pod-agnostic claim delete for connection removal. Unlike `releaseClaim`,
+   * this is NOT scoped to `this.podId`: the connection row is being deleted, so
+   * any replica's lease for it is dead and must go, even if a different replica
+   * (or a since-crashed one) owns it.
+   */
+  private async deleteClaimForConnection(connectionId: string): Promise<void> {
+    try {
+      await getDb()`
+        DELETE FROM connection_claims WHERE connection_id = ${connectionId}
+      `;
+    } catch (error) {
+      logger.warn(
+        { id: connectionId, error: String(error) },
+        "Failed to delete exclusive claim on connection removal"
       );
     }
   }

--- a/packages/server/src/gateway/connections/chat-instance-manager.ts
+++ b/packages/server/src/gateway/connections/chat-instance-manager.ts
@@ -1347,18 +1347,29 @@ export class ChatInstanceManager {
           { id: s.id, error: String(error) },
           "Failed to start exclusive connection"
         );
-        await this.writeConnectionStatus(
-          s,
-          "error",
-          `Startup failed: ${error instanceof Error ? error.message : String(error)}`
-        );
-        // Schedule a bounded, exponentially-backed-off retry. The status write
-        // above bumps updated_at, so key the record on the POST-write version:
-        // a genuine config edit later produces yet another version and resets
-        // the backoff (record cleared on the version mismatch). We KEEP the
-        // lease through the failure (no releaseClaim) on purpose — releasing it
-        // would just bounce the same transient failure around N replicas
-        // (flapping). One owner retrying on a capped backoff is the calmer,
+        // Write the error STATUS only on the FIRST failure for this config
+        // version. On a backed-off retry we deliberately do NOT re-write it:
+        // transient start errors vary between attempts (ETIMEDOUT vs
+        // ECONNRESET, socket addresses, request ids), and writing a *different*
+        // message would bump updated_at every tick — which resets the backoff
+        // (the record is keyed on updated_at) and churns the DB. The first
+        // error is representative; every attempt's detail is in the log above.
+        const isRetry = !!failure && failure.rowVersion === s.updatedAt;
+        if (!isRetry) {
+          await this.writeConnectionStatus(
+            s,
+            "error",
+            `Startup failed: ${error instanceof Error ? error.message : String(error)}`
+          );
+        }
+        // Schedule a bounded, exponentially-backed-off retry. The first-failure
+        // status write above bumps updated_at once; subsequent retries leave it
+        // stable, so the record keys cleanly on the post-write version. A
+        // genuine config edit later produces yet another version and resets the
+        // backoff (record cleared on the version mismatch). We KEEP the lease
+        // through the failure (no releaseClaim) on purpose — releasing it would
+        // just bounce the same transient failure around N replicas (flapping).
+        // One owner retrying on a capped backoff is the calmer,
         // multi-replica-correct behaviour.
         const reread = await this.connectionStore.getConnection(s.id);
         const rowVersion = reread?.updatedAt ?? s.updatedAt;

--- a/packages/server/src/tools/save_content.ts
+++ b/packages/server/src/tools/save_content.ts
@@ -26,6 +26,27 @@ import type { ToolContext } from './registry';
 import { withValidatedArgs } from './validate-args';
 import { buildEventViewUrl } from './view-urls';
 
+/**
+ * True when a Postgres error is the unique-violation (23505) on the partial
+ * index that guards "at most one event supersedes a given target". The loser
+ * of a concurrent-supersede race hits this; postgres.js exposes the SQLSTATE
+ * on `code` and the index name on `constraint`/`constraint_name`.
+ */
+function isSupersededByUniqueViolation(error: unknown): boolean {
+  const err = error as {
+    code?: unknown;
+    constraint?: unknown;
+    constraint_name?: unknown;
+    message?: unknown;
+  };
+  if (err?.code !== '23505') return false;
+  return (
+    err.constraint === 'idx_events_superseded_by' ||
+    err.constraint_name === 'idx_events_superseded_by' ||
+    (typeof err.message === 'string' && err.message.includes('idx_events_superseded_by'))
+  );
+}
+
 // ============================================
 // Typebox Schema
 // ============================================
@@ -266,8 +287,11 @@ async function saveContentImpl(
         AND organization_id = ${ctx.organizationId}
     `;
     if (existing.length === 0) {
-      throw new Error(
-        `Cannot supersede event ${args.supersedes_event_id}: not found in this organization`
+      // Stale supersede target (already gone / wrong org) is a user fault, not
+      // an infra error — ToolUserError so it doesn't fire a Sentry alert.
+      throw new ToolUserError(
+        `Cannot supersede event ${args.supersedes_event_id}: not found in this organization`,
+        404
       );
     }
     const superseding = await sql`
@@ -276,8 +300,9 @@ async function saveContentImpl(
       LIMIT 1
     `;
     if (superseding.length > 0) {
-      throw new Error(
-        `Cannot supersede event ${args.supersedes_event_id}: already superseded by event ${superseding[0].id}`
+      throw new ToolUserError(
+        `Cannot supersede event ${args.supersedes_event_id}: already superseded by event ${superseding[0].id}`,
+        409
       );
     }
   }
@@ -285,25 +310,44 @@ async function saveContentImpl(
   // 6. Insert into events
   const externalId = `uc_${crypto.randomUUID()}`;
 
-  const row = await insertEvent({
-    entityIds: finalEntityIds,
-    organizationId: ctx.organizationId,
-    originId: externalId,
-    title: args.title,
-    payloadType,
-    content: args.content ?? null,
-    payloadData: args.payload_data,
-    payloadTemplate: args.payload_template ?? null,
-    attachments: args.attachments,
-    authorName: args.author,
-    sourceUrl: args.source_url ?? null,
-    occurredAt: args.occurred_at ?? null,
-    semanticType,
-    metadata: args.metadata,
-    createdBy: ctx.userId,
-    clientId: ctx.clientId,
-    supersedesEventId: args.supersedes_event_id ?? null,
-  });
+  let row: Awaited<ReturnType<typeof insertEvent>>;
+  try {
+    row = await insertEvent({
+      entityIds: finalEntityIds,
+      organizationId: ctx.organizationId,
+      originId: externalId,
+      title: args.title,
+      payloadType,
+      content: args.content ?? null,
+      payloadData: args.payload_data,
+      payloadTemplate: args.payload_template ?? null,
+      attachments: args.attachments,
+      authorName: args.author,
+      sourceUrl: args.source_url ?? null,
+      occurredAt: args.occurred_at ?? null,
+      semanticType,
+      metadata: args.metadata,
+      createdBy: ctx.userId,
+      clientId: ctx.clientId,
+      supersedesEventId: args.supersedes_event_id ?? null,
+    });
+  } catch (error) {
+    // The "already superseded?" SELECT above is non-atomic: two concurrent
+    // supersedes of the same target both pass the read, both INSERT, and the
+    // loser hits the partial unique index idx_events_superseded_by with a raw
+    // 23505. The unique index protects the invariant (no data loss) — surface
+    // it as a clean 409 user error instead of a raw DB error + Sentry alert.
+    if (
+      args.supersedes_event_id &&
+      isSupersededByUniqueViolation(error)
+    ) {
+      throw new ToolUserError(
+        `Cannot supersede event ${args.supersedes_event_id}: already superseded by a concurrent write`,
+        409
+      );
+    }
+    throw error;
+  }
 
   // 6b. Auto-link: scan content for entity name mentions.
   // Awaited so the background work doesn't outlive the tool call and reject


### PR DESCRIPTION
Three connection-lifecycle / save_memory robustness fixes. All three are verified-real bugs with red→green reproducers.

## #13 [HIGH] Exclusive connection latched DEAD on a transient start failure

`chat-instance-manager.ts` `exclusiveTickInner`: when an exclusive (Telegram-polling) connection's `hydrateFromRow` threw, the row was written `Startup failed: …` and the retry guard `lastExclusiveFailure.get(id) === s.updatedAt` skipped re-hydration on every future tick. Meanwhile `claimExclusive` kept renewing the lease for the owning pod forever, so **no peer ever reclaimed it**, and `sweepConnectionHealth` only recovers `Health check failed:` / `Failed to resolve secret ref` errors — not generic `Startup failed:`. Net: a **transient** failure (Telegram 5xx, DB blip, transient secret hiccup) left the connection permanently dead until a human edited the row.

**Fix:** replace the `updated_at`-only guard with a per-connection **bounded exponential backoff** (`{ rowVersion, attempts, nextRetryAt }`). A failure schedules `nextRetryAt = now + backoff`; once it passes, the owner re-hydrates even though `updated_at` is unchanged. Backoff starts at one tick (15s) and doubles to a **10-minute cap** — a genuinely-broken config costs at most one short start attempt per window (no flapping, no tight loop). A successful hydrate or a row edit (new `updated_at`, which clears the record) resets the backoff. The existing "retry once per row-version for bad config" intent is preserved; this adds time-based retry for the transient case.

### Multi-replica (N>1) reasoning

- The backoff map (`exclusiveFailures`) is **pod-local and only consulted by the pod that holds the lease**. Only the lease owner runs `hydrateFromRow` for an exclusive connection, so its retry cadence is purely a local decision — no other replica reads or mutates it. This holds with 3 replicas behind ClientIP affinity because the *lease*, not the in-memory map, is the cross-pod coordination point.
- **The lease is deliberately KEPT through a start failure** (no `releaseClaim` on failure). The alternative — release on failure so a peer can try — was rejected: a transient failure (e.g. Telegram 5xx) would hit *every* replica in turn, so releasing just bounces the lease around N pods, each writing `error` and thrashing the claim row. One owner retrying on a capped backoff is the calmer, split-brain-free behavior. If the owner pod dies, the existing 45s heartbeat TTL still hands the lease (and a fresh retry, with no inherited backoff state) to a peer — so a dead pod is not a permanent stall.
- The fail-closed claim paths (claim SQL unreachable → stop + drop ownership) are untouched.

## #16 [low] Orphan `connection_claims` row on delete

`removeConnection` stopped the instance and deleted the `agent_connections` row but never deleted the lease row (`connection_claims` has no FK cascade), so an exclusive connection's claim leaked if the owner pod crashed before its next tick.

**Fix:** delete the claim by `connection_id` only (pod-agnostic — `removeConnection` can run on a non-owner replica, which must still clear a dead owner's row; the existing `releaseClaim` is `podId`-scoped and would miss it).

## #17 [low] save_memory supersede TOCTOU → raw 23505 + Sentry noise

`save_content.ts`: the "already superseded?" SELECT is non-atomic and `insertEvent` takes no advisory lock for this path, so two concurrent supersedes of the same target both pass the read, both INSERT, and the loser hits the partial unique index `idx_events_superseded_by` with a **raw Postgres 23505** — captured to Sentry because it isn't a `ToolUserError`. The two pre-insert validators (not-found / already-superseded) also threw plain `Error`, firing Sentry on the happy-path guards too.

**Fix:** (a) validators throw `ToolUserError` (404 not-found / 409 already-superseded — these are stale-target user faults); (b) the insert is wrapped to translate a 23505 on `idx_events_superseded_by` into a clean `ToolUserError(409)`. **No data loss** — the unique index already protects the invariant; this purely converts a raw-DB-error + Sentry alert into a clean user error.

## Red → Green (each proven red by temporary revert)

**#13 + #16** — `packages/server/src/gateway/connections/__tests__/connection-claims.test.ts` (bun):
- transient exclusive-start failure: first hydrate throws, row goes `error`; next tick is gated (still in backoff); after `nextRetryAt` elapses **with no row edit**, the owner re-hydrates and the instance starts. Red on old code: `calls` stays 1 (never retries).
- `removeConnection` deletes the `connection_claims` row. Red on old code: row remains (`after.length === 1`).

**#17** — `packages/server/src/__tests__/integration/events/save-content-supersede-race.test.ts` (vitest):
- 6 concurrent supersedes of one target: exactly one wins, every loser is `ToolUserError(409)` with no `.code` (not a raw 23505); DB still has exactly one superseder. Red on old code: loser is `PostgresError: duplicate key value` (23505).
- stale (already-superseded) target → `ToolUserError(409)`; non-existent target → `ToolUserError(404)`. Red on old code: plain `Error`.

`packages/server` `npx tsc --noEmit`: **0 errors**.

⚠️ Please review #13 (the lease/backoff change) before merge.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1344"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784241657&installation_id=136316292&pr_number=1344&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1344&signature=8c588e7d7b9bf99f6381e8eb367e4fed8b7972b8907fea8f22a9e99f0d4b24ec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved error responses for content supersession operations with clearer HTTP status codes (404 for not found, 409 for conflicts)
  * Enhanced race condition handling for concurrent supersession attempts
  * Added exponential backoff retry logic for connection failures

* **Tests**
  * Added comprehensive integration tests for content supersession robustness
  * Expanded connection reliability and cleanup test coverage

<!-- end of auto-generated comment: release notes by coderabbit.ai -->