### PR TITLE
test(server): prove agent SSE events route authenticates the ?token= ticket

### DIFF
--- a/packages/server/src/gateway/__tests__/agent-events-sse-ticket.test.ts
+++ b/packages/server/src/gateway/__tests__/agent-events-sse-ticket.test.ts
@@ -1,0 +1,73 @@
+/**
+ * End-to-end-ish proof on the REAL agent API route (no server boot): the
+ * embedded panel opens GET /api/v1/agents/:id/events with EventSource (no
+ * Authorization header) and a `?token=` ticket. This must get PAST the outer
+ * auth gate (createApiAuthMiddleware) — the bug that shipped in #1340 was that
+ * the gate 401'd it before the handler ran.
+ *
+ * The events handler returns 404 ("Agent not found") once auth passes and the
+ * session lookup misses. So with a stub sessionManager that returns null:
+ *   - auth REJECTED  → 401 (outer gate)
+ *   - auth ACCEPTED  → 404 (past the gate, into the handler)
+ * That 401-vs-404 split is the auth proof, without a live agent runtime.
+ */
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { encrypt } from "@lobu/core";
+import { createAgentApi } from "../routes/public/agent.js";
+import { setAuthProvider } from "../routes/public/settings-auth.js";
+
+const TEST_KEY =
+  "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+
+let savedKey: string | undefined;
+beforeEach(() => {
+  savedKey = process.env.ENCRYPTION_KEY;
+  process.env.ENCRYPTION_KEY = TEST_KEY;
+  setAuthProvider(null);
+});
+afterEach(() => {
+  if (savedKey === undefined) delete process.env.ENCRYPTION_KEY;
+  else process.env.ENCRYPTION_KEY = savedKey;
+  setAuthProvider(null);
+});
+
+function makeApp() {
+  return createAgentApi({
+    queueProducer: {} as never,
+    // getSession returns null → the handler answers 404 once auth has passed.
+    sessionManager: { async getSession() { return null; } } as never,
+    sseManager: {} as never,
+    publicGatewayUrl: "http://localhost:8787",
+  });
+}
+
+const ticket = (userId: string, exp = Date.now() + 60_000): string =>
+  encrypt(JSON.stringify({ userId, platform: "external", exp }));
+
+const eventsStatus = async (query: string): Promise<number> => {
+  const res = await makeApp().request(`/api/v1/agents/some-session/events${query}`, {
+    method: "GET",
+  });
+  return res.status;
+};
+
+describe("GET /api/v1/agents/:id/events — embedded SSE ticket auth", () => {
+  test("a valid ?token= ticket gets past the outer auth gate (404, not 401)", async () => {
+    // 404 = auth passed, session-lookup missed. The point is it is NOT 401.
+    expect(await eventsStatus(`?token=${encodeURIComponent(ticket("u1"))}`)).toBe(404);
+  });
+
+  test("no token / no Authorization header is rejected at the gate (401)", async () => {
+    expect(await eventsStatus("")).toBe(401);
+  });
+
+  test("a tampered ticket is rejected at the gate (401)", async () => {
+    expect(await eventsStatus("?token=not-a-real-ticket")).toBe(401);
+  });
+
+  test("an expired ticket is rejected at the gate (401)", async () => {
+    expect(await eventsStatus(`?token=${encodeURIComponent(ticket("u1", Date.now() - 1000))}`)).toBe(
+      401,
+    );
+  });
+});


### PR DESCRIPTION
Real-route regression coverage for the embedded-panel stream auth (#1342, #1340).

On `GET /api/v1/agents/:id/events` (the route EventSource opens): a valid `?token=` ticket gets **past the outer auth gate** → 404 (session-not-found), **not 401**; no-token / tampered / expired → 401 at the gate. The 401-vs-404 split is the auth proof without a live agent runtime.

This is the exact path that shipped **broken** in #1340 (outer gate 401'd the header-less ticket) and was fixed in #1342. Test-only. 4/4 `bun test` green.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1345"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784241739&installation_id=136316292&pr_number=1345&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1345&signature=c24d2248d2e689c8e548e4dbe8d683d8fe87321ab007f8be790e7c7d8ee885cb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->