### PR TITLE
fix(mcp,egress): org-scope MCP caches and IDNA-normalize egress matching

### DIFF
--- a/packages/core/src/__tests__/network-domains.test.ts
+++ b/packages/core/src/__tests__/network-domains.test.ts
@@ -67,6 +67,28 @@ describe("normalizeDomainPattern", () => {
     expect(normalizeDomainPattern("api.github.com")).toBe("api.github.com");
   });
 
+  // IDN / Unicode → punycode (#10): stored patterns must be ASCII so they
+  // compare equal to the xn-- host that `new URL().hostname` produces on the
+  // HTTP egress path. Runtime fact: new URL("http://münchen.de/").hostname
+  // === "xn--mnchen-3ya.de".
+  test("converts a Unicode host to punycode", () => {
+    expect(normalizeDomainPattern("münchen.de")).toBe("xn--mnchen-3ya.de");
+  });
+
+  test("converts a Unicode wildcard suffix to punycode", () => {
+    expect(normalizeDomainPattern("*.münchen.de")).toBe(".xn--mnchen-3ya.de");
+  });
+
+  test("uppercase Unicode host lowercases then punycodes", () => {
+    expect(normalizeDomainPattern("MÜNCHEN.DE")).toBe("xn--mnchen-3ya.de");
+  });
+
+  test("leaves an already-punycode host unchanged (idempotent)", () => {
+    expect(normalizeDomainPattern("xn--mnchen-3ya.de")).toBe(
+      "xn--mnchen-3ya.de"
+    );
+  });
+
   // Star-only wildcard (edge)
   test("star-only becomes empty dot prefix (.)", () => {
     // "*.".slice(2) = "" → "." + "" = "."

--- a/packages/core/src/utils/network-domains.ts
+++ b/packages/core/src/utils/network-domains.ts
@@ -1,3 +1,17 @@
+import { domainToASCII } from "node:url";
+
+/**
+ * Convert an IDN/Unicode host (or wildcard suffix) to its ASCII/punycode form
+ * so stored patterns compare equal to the `xn--` hostnames that `new URL().hostname`
+ * (HTTP path) and the canonicalized CONNECT host produce. `domainToASCII`
+ * returns "" for inputs it can't convert, in which case we keep the lowercased
+ * original so plain-ASCII hosts (and odd inputs) still match.
+ */
+function toAscii(host: string): string {
+  const ascii = domainToASCII(host);
+  return ascii !== "" ? ascii : host.toLowerCase();
+}
+
 export function normalizeDomainPattern(pattern: string): string {
   const trimmed = pattern.trim();
 
@@ -8,10 +22,10 @@ export function normalizeDomainPattern(pattern: string): string {
   const normalized = trimmed.toLowerCase();
 
   if (normalized.startsWith("*.")) {
-    return `.${normalized.slice(2)}`;
+    return `.${toAscii(normalized.slice(2))}`;
   }
 
-  return normalized;
+  return toAscii(normalized);
 }
 
 export function normalizeDomainPatterns(

--- a/packages/server/src/gateway/__tests__/http-proxy.test.ts
+++ b/packages/server/src/gateway/__tests__/http-proxy.test.ts
@@ -406,6 +406,56 @@ describe("HTTP Proxy Domain Filtering (unrestricted mode)", () => {
   });
 });
 
+// ─── IDN / Unicode egress matching (#10 + #11) ───────────────────────────────
+// A Unicode WORKER_DISALLOWED_DOMAINS entry must block BOTH the punycode host
+// the HTTP path derives (`new URL().hostname` === "xn--mnchen-3ya.de") AND the
+// raw Unicode host the CONNECT path extracts verbatim ("münchen.de"). Before
+// the fix, normalizeDomainPattern only lowercased the pattern (stayed Unicode)
+// and canonicalizeHostname didn't punycode the CONNECT host, so the HTTP host
+// slipped past the blocklist and CONNECT vs HTTP disagreed for the same host.
+
+describe("HTTP Proxy IDN/Unicode egress matching", () => {
+  const HTTP_HOST = "xn--mnchen-3ya.de"; // what `new URL("http://münchen.de/").hostname` yields
+  const CONNECT_HOST = "münchen.de"; // what the CONNECT parser returns verbatim
+
+  beforeAll(() => {
+    process.env.WORKER_ALLOWED_DOMAINS = "*";
+    process.env.WORKER_DISALLOWED_DOMAINS = "münchen.de";
+    __testOnly.reset();
+  });
+
+  afterAll(() => {
+    process.env.WORKER_ALLOWED_DOMAINS = "*";
+    delete process.env.WORKER_DISALLOWED_DOMAINS;
+    __testOnly.reset();
+  });
+
+  test("punycode host (HTTP path) is blocked by the Unicode blocklist entry", async () => {
+    const decision = await __testOnly.checkDomainAccess(
+      HTTP_HOST,
+      "idn-test-agent",
+      undefined
+    );
+    expect(decision.allowed).toBe(false);
+    expect(decision.source).toBe("global");
+  });
+
+  test("Unicode host (CONNECT path) is blocked by the same blocklist entry", async () => {
+    const decision = await __testOnly.checkDomainAccess(
+      CONNECT_HOST,
+      "idn-test-agent",
+      undefined
+    );
+    expect(decision.allowed).toBe(false);
+    expect(decision.source).toBe("global");
+  });
+
+  test("CONNECT and HTTP forms canonicalize to the same ASCII name", () => {
+    expect(__testOnly.canonicalizeHostname(CONNECT_HOST)).toBe(HTTP_HOST);
+    expect(__testOnly.canonicalizeHostname(HTTP_HOST)).toBe(HTTP_HOST);
+  });
+});
+
 // ─── DNS pinning / rebinding tests ───────────────────────────────────────────
 // Regression coverage for https://github.com/lobu-ai/lobu/issues/252.
 // The proxy must do exactly one DNS lookup per request, validate that result,

--- a/packages/server/src/gateway/__tests__/mcp-cache-org-isolation.test.ts
+++ b/packages/server/src/gateway/__tests__/mcp-cache-org-isolation.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Regression coverage for the org-blind MCP caches (#5 + #6).
+ *
+ * The McpToolCache and the upstream-session key were keyed only by
+ * (agentId, mcpId[, scope]) with NO organization. Both live in process-wide
+ * singletons shared by every org. agentId is NOT globally unique (agents PK is
+ * (organization_id, id) and ids are human slugs), so two orgs with the same
+ * agentId+mcpId collided:
+ *   #5 — org A's cached tool metadata/annotations satisfied an org B lookup,
+ *        so a destructive tool the upstream marks safe for org A could
+ *        auto-approve for org B (approval-gate poisoning).
+ *   #6 — two orgs shared a single upstream Mcp-Session-Id (session-handle bleed).
+ *
+ * Both keys now derive the org from `runWithOrganizationContext`, so a lookup
+ * in org B's context must NOT see org A's entry.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { orgContext } from "../../lobu/stores/org-context.js";
+import { buildSessionKey } from "../auth/mcp/proxy-shared.js";
+import { McpToolCache } from "../auth/mcp/tool-cache.js";
+
+const ORG_A = "org-aaaaaaaa";
+const ORG_B = "org-bbbbbbbb";
+const AGENT = "shared-agent"; // same human slug in both orgs
+const MCP = "github";
+
+function inOrg<T>(orgId: string, fn: () => T): T {
+  return orgContext.run({ organizationId: orgId }, fn);
+}
+
+describe("McpToolCache org isolation (#5)", () => {
+  test("org A's cached tool list does NOT satisfy an org B lookup", () => {
+    const cache = new McpToolCache();
+
+    inOrg(ORG_A, () => {
+      cache.set(MCP, [{ name: "delete_repo" }], AGENT);
+    });
+
+    // org A sees its own entry
+    expect(inOrg(ORG_A, () => cache.get(MCP, AGENT))?.map((t) => t.name)).toEqual([
+      "delete_repo",
+    ]);
+
+    // org B, same (agentId, mcpId), must get a clean miss — no cross-tenant bleed
+    expect(inOrg(ORG_B, () => cache.get(MCP, AGENT))).toBeNull();
+  });
+
+  test("org A's annotations do NOT leak into org B's approval gate", () => {
+    const cache = new McpToolCache();
+
+    // Org A's upstream marks the tool read-only (would auto-approve).
+    inOrg(ORG_A, () => {
+      cache.set(
+        MCP,
+        [{ name: "wipe", annotations: { readOnlyHint: true } }],
+        AGENT
+      );
+    });
+
+    const orgATool = inOrg(ORG_A, () => cache.get(MCP, AGENT))?.[0];
+    expect(orgATool?.annotations?.readOnlyHint).toBe(true);
+
+    // Org B must NOT inherit org A's "safe" annotations — it gets a miss, which
+    // at the proxy layer means `found=false` → approval required (fail closed).
+    expect(inOrg(ORG_B, () => cache.get(MCP, AGENT))).toBeNull();
+  });
+
+  test("getServerInfo / getInstructions are also org-scoped", () => {
+    const cache = new McpToolCache();
+    inOrg(ORG_A, () => {
+      cache.setServerInfo(MCP, { tools: [], instructions: "org-a only" }, AGENT);
+    });
+    expect(inOrg(ORG_A, () => cache.getInstructions(MCP, AGENT))).toBe(
+      "org-a only"
+    );
+    expect(inOrg(ORG_B, () => cache.getInstructions(MCP, AGENT))).toBeUndefined();
+    expect(inOrg(ORG_B, () => cache.getServerInfo(MCP, AGENT))).toBeNull();
+  });
+});
+
+describe("MCP upstream session key org isolation (#6)", () => {
+  test("two orgs with the same (agentId, mcpId, scope) get DIFFERENT session keys", () => {
+    const scope = "user-1";
+    const keyA = inOrg(ORG_A, () => buildSessionKey(AGENT, MCP, scope));
+    const keyB = inOrg(ORG_B, () => buildSessionKey(AGENT, MCP, scope));
+
+    expect(keyA).not.toBe(keyB);
+    expect(keyA).toContain(ORG_A);
+    expect(keyB).toContain(ORG_B);
+  });
+
+  test("same org + same triple is stable (still shares a session within the org)", () => {
+    const scope = "user-1";
+    const first = inOrg(ORG_A, () => buildSessionKey(AGENT, MCP, scope));
+    const second = inOrg(ORG_A, () => buildSessionKey(AGENT, MCP, scope));
+    expect(first).toBe(second);
+  });
+});

--- a/packages/server/src/gateway/__tests__/mcp-proxy-edge-cases.test.ts
+++ b/packages/server/src/gateway/__tests__/mcp-proxy-edge-cases.test.ts
@@ -23,6 +23,7 @@ import {
 } from "bun:test";
 import { generateWorkerToken, type SecretRef } from "@lobu/core";
 import { MockMessageQueue } from "@lobu/core/testing";
+import { orgContext } from "../../lobu/stores/org-context.js";
 import { McpProxy } from "../auth/mcp/proxy.js";
 import { McpToolCache } from "../auth/mcp/tool-cache.js";
 import { GrantStore } from "../permissions/grant-store.js";
@@ -448,9 +449,12 @@ describe("cross-agent JWT isolation", () => {
     });
     const app = proxy.getApp();
 
-    // Seed destructive tool in cache for both agents
-    await toolCache.set("shared-mcp", [{ name: "delete_everything" }], "agent1");
-    await toolCache.set("shared-mcp", [{ name: "delete_everything" }], "agent2");
+    // Seed destructive tool in cache for both agents (org-scoped cache → seed
+    // in the same org as the agent tokens).
+    orgContext.run({ organizationId: "test-org" }, () => {
+      toolCache.set("shared-mcp", [{ name: "delete_everything" }], "agent1");
+      toolCache.set("shared-mcp", [{ name: "delete_everything" }], "agent2");
+    });
 
     // Grant only to agent1
     await grantStore.grant(
@@ -554,11 +558,17 @@ describe("tool registry collision — same tool name on two MCPs", () => {
 
   test("tool cache is keyed per (mcpId, agentId) — no cross-MCP cache pollution", async () => {
     const toolCache = new McpToolCache();
-    await toolCache.set("mcp-a", [{ name: "send_message", annotations: { readOnlyHint: true } }], "agent1");
-    await toolCache.set("mcp-b", [{ name: "send_message" }], "agent1");
-
-    const toolsA = await toolCache.get("mcp-a", "agent1");
-    const toolsB = await toolCache.get("mcp-b", "agent1");
+    const { toolsA, toolsB } = orgContext.run(
+      { organizationId: "test-org" },
+      () => {
+        toolCache.set("mcp-a", [{ name: "send_message", annotations: { readOnlyHint: true } }], "agent1");
+        toolCache.set("mcp-b", [{ name: "send_message" }], "agent1");
+        return {
+          toolsA: toolCache.get("mcp-a", "agent1"),
+          toolsB: toolCache.get("mcp-b", "agent1"),
+        };
+      }
+    );
 
     expect(toolsA).toHaveLength(1);
     expect(toolsB).toHaveLength(1);
@@ -594,7 +604,9 @@ describe("tool approval — onToolBlocked and wildcard grants", () => {
     };
 
     const app = proxy.getApp();
-    await toolCache.set("test-mcp", [{ name: "nuke_db" }], "agent1");
+    orgContext.run({ organizationId: "test-org" }, () => {
+      toolCache.set("test-mcp", [{ name: "nuke_db" }], "agent1");
+    });
 
     successFetch({ jsonrpc: "2.0", id: 1, result: { content: [{ type: "text", text: "done" }] } });
 
@@ -616,14 +628,16 @@ describe("tool approval — onToolBlocked and wildcard grants", () => {
   test("wildcard grant /mcp/<id>/tools/* covers all tools of that server", async () => {
     const toolCache = new McpToolCache();
     const grantStore = new GrantStore();
-    await toolCache.set(
-      "gh-mcp",
-      [
-        { name: "create_issue" },
-        { name: "delete_repo" },
-      ],
-      "agent1"
-    );
+    orgContext.run({ organizationId: "test-org" }, () => {
+      toolCache.set(
+        "gh-mcp",
+        [
+          { name: "create_issue" },
+          { name: "delete_repo" },
+        ],
+        "agent1"
+      );
+    });
 
     // Wildcard grant for the whole server
     await grantStore.grant(
@@ -728,7 +742,9 @@ describe("tool approval — onToolBlocked and wildcard grants", () => {
   test("onToolBlocked receives correct agentId and tool metadata", async () => {
     const toolCache = new McpToolCache();
     const grantStore = new GrantStore();
-    await toolCache.set("audit-mcp", [{ name: "drop_table" }], "agent1");
+    orgContext.run({ organizationId: "test-org" }, () => {
+      toolCache.set("audit-mcp", [{ name: "drop_table" }], "agent1");
+    });
 
     const configSource = createConfigSource({
       "audit-mcp": { id: "audit-mcp", upstreamUrl: "http://audit.example.com/mcp" },
@@ -854,31 +870,36 @@ describe("SSE-framed JSON-RPC response", () => {
 // ---------------------------------------------------------------------------
 
 describe("in-memory session TTL", () => {
-  test("McpToolCache returns null after TTL expires", async () => {
+  test("McpToolCache returns null after TTL expires", () => {
     const cache = new McpToolCache();
-    await cache.set("mcp-x", [{ name: "tool1" }], "agent1");
+    // Cache reads/writes derive the org from context.
+    orgContext.run({ organizationId: "test-org" }, () => {
+      cache.set("mcp-x", [{ name: "tool1" }], "agent1");
 
-    // Check hit immediately
-    const hit = await cache.get("mcp-x", "agent1");
-    expect(hit).not.toBeNull();
-    expect(hit![0].name).toBe("tool1");
+      // Check hit immediately
+      const hit = cache.get("mcp-x", "agent1");
+      expect(hit).not.toBeNull();
+      expect(hit![0].name).toBe("tool1");
 
-    // Manually expire by probing the expiry logic via a never-set key
-    const miss = await cache.get("mcp-x-nonexistent", "agent1");
-    expect(miss).toBeNull();
+      // Manually expire by probing the expiry logic via a never-set key
+      const miss = cache.get("mcp-x-nonexistent", "agent1");
+      expect(miss).toBeNull();
+    });
   });
 
-  test("McpToolCache per-agent isolation — agent2 cache miss for agent1 entry", async () => {
+  test("McpToolCache per-agent isolation — agent2 cache miss for agent1 entry", () => {
     const cache = new McpToolCache();
-    await cache.set("mcp-iso", [{ name: "private_tool" }], "agent1");
+    orgContext.run({ organizationId: "test-org" }, () => {
+      cache.set("mcp-iso", [{ name: "private_tool" }], "agent1");
 
-    const forAgent1 = await cache.get("mcp-iso", "agent1");
-    const forAgent2 = await cache.get("mcp-iso", "agent2");
-    const noAgent = await cache.get("mcp-iso");
+      const forAgent1 = cache.get("mcp-iso", "agent1");
+      const forAgent2 = cache.get("mcp-iso", "agent2");
+      const noAgent = cache.get("mcp-iso");
 
-    expect(forAgent1).not.toBeNull();
-    expect(forAgent2).toBeNull();
-    expect(noAgent).toBeNull();
+      expect(forAgent1).not.toBeNull();
+      expect(forAgent2).toBeNull();
+      expect(noAgent).toBeNull();
+    });
   });
 });
 

--- a/packages/server/src/gateway/__tests__/mcp-proxy.test.ts
+++ b/packages/server/src/gateway/__tests__/mcp-proxy.test.ts
@@ -8,6 +8,7 @@ import {
 } from "bun:test";
 import { generateWorkerToken, type SecretRef } from "@lobu/core";
 import { MockMessageQueue } from "@lobu/core/testing";
+import { orgContext } from "../../lobu/stores/org-context.js";
 import { McpProxy } from "../auth/mcp/proxy.js";
 import { McpToolCache } from "../auth/mcp/tool-cache.js";
 import { GrantStore } from "../permissions/grant-store.js";
@@ -511,8 +512,11 @@ describe("McpProxy", () => {
       });
       const app = proxy.getApp();
 
-      // Pre-populate cache with a tool that has no annotations (default destructive)
-      await toolCache.set("test-mcp", [{ name: "dangerous_tool" }], "agent1");
+      // Pre-populate cache with a tool that has no annotations (default destructive).
+      // The cache is org-scoped, so seed it in the same org as `validToken`.
+      orgContext.run({ organizationId: "test-org" }, () => {
+        toolCache.set("test-mcp", [{ name: "dangerous_tool" }], "agent1");
+      });
 
       const res = await app.request("/test-mcp/tools/dangerous_tool", {
         method: "POST",
@@ -534,8 +538,11 @@ describe("McpProxy", () => {
       });
       const app = proxy.getApp();
 
-      // Pre-populate cache with a tool that has no annotations (default destructive)
-      await toolCache.set("test-mcp", [{ name: "dangerous_tool" }], "agent1");
+      // Pre-populate cache with a tool that has no annotations (default destructive).
+      // The cache is org-scoped, so seed it in the same org as `validToken`.
+      orgContext.run({ organizationId: "test-org" }, () => {
+        toolCache.set("test-mcp", [{ name: "dangerous_tool" }], "agent1");
+      });
 
       // Grant access
       await grantStore.grant(
@@ -574,12 +581,14 @@ describe("McpProxy", () => {
       });
       const app = proxy.getApp();
 
-      // Pre-populate cache with a read-only tool
-      await toolCache.set(
-        "test-mcp",
-        [{ name: "read_tool", annotations: { readOnlyHint: true } }],
-        "agent1"
-      );
+      // Pre-populate cache with a read-only tool (seed in `validToken`'s org).
+      orgContext.run({ organizationId: "test-org" }, () => {
+        toolCache.set(
+          "test-mcp",
+          [{ name: "read_tool", annotations: { readOnlyHint: true } }],
+          "agent1"
+        );
+      });
 
       mockUpstreamFetch({
         jsonrpc: "2.0",
@@ -607,12 +616,14 @@ describe("McpProxy", () => {
       });
       const app = proxy.getApp();
 
-      // Pre-populate cache with a non-destructive tool
-      await toolCache.set(
-        "test-mcp",
-        [{ name: "safe_tool", annotations: { destructiveHint: false } }],
-        "agent1"
-      );
+      // Pre-populate cache with a non-destructive tool (seed in `validToken`'s org).
+      orgContext.run({ organizationId: "test-org" }, () => {
+        toolCache.set(
+          "test-mcp",
+          [{ name: "safe_tool", annotations: { destructiveHint: false } }],
+          "agent1"
+        );
+      });
 
       mockUpstreamFetch({
         jsonrpc: "2.0",

--- a/packages/server/src/gateway/auth/mcp/proxy-shared.ts
+++ b/packages/server/src/gateway/auth/mcp/proxy-shared.ts
@@ -1,6 +1,6 @@
 import { verifyWorkerToken, type WorkerTokenData } from "@lobu/core";
 import type { Context } from "hono";
-import { orgContext } from "../../../lobu/stores/org-context.js";
+import { getOrgId, orgContext } from "../../../lobu/stores/org-context.js";
 import { getRevokedTokenStore } from "../revoked-token-store.js";
 import type { McpTool } from "./tool-cache.js";
 
@@ -218,17 +218,23 @@ export function computeScopeKey(
 
 /**
  * Build a session-store key for the upstream Mcp-Session-Id associated
- * with a specific (agent, mcp, scope) triple. Scoping by scopeKey prevents
- * two users (or user-vs-channel credentials) from sharing a single
- * upstream session, which would leak context across scopes.
+ * with a specific (org, agent, mcp, scope) tuple. The session store is a
+ * process-wide Map, and agentId is NOT globally unique (agents PK is
+ * (organization_id, id)), so the key MUST be org-scoped to stop two orgs
+ * sharing the same agentId+mcpId from bleeding upstream session handles into
+ * each other. Scoping by scopeKey additionally prevents two users (or
+ * user-vs-channel credentials) within an org from sharing a single upstream
+ * session. The org is read from `runWithOrganizationContext` (every caller
+ * runs inside it) so no signature need carry it.
  */
 export function buildSessionKey(
 	agentId: string,
 	mcpId: string,
 	scopeKey?: string,
 ): string {
+	const orgId = getOrgId();
 	const scope = scopeKey ?? "_unscoped";
-	return `mcp:session:${agentId}:${mcpId}:${scope}`;
+	return `mcp:session:${orgId}:${agentId}:${mcpId}:${scope}`;
 }
 
 export async function getRequestBodyAsText(c: Context): Promise<string> {

--- a/packages/server/src/gateway/auth/mcp/tool-cache.ts
+++ b/packages/server/src/gateway/auth/mcp/tool-cache.ts
@@ -1,4 +1,5 @@
 import { createLogger } from "@lobu/core";
+import { getOrgId } from "../../../lobu/stores/org-context.js";
 
 const logger = createLogger("mcp-tool-cache");
 
@@ -83,10 +84,21 @@ export class McpToolCache {
     return info?.instructions;
   }
 
+  /**
+   * Cache keys are org-scoped. The McpToolCache is a process-wide singleton
+   * shared by every org, but agentId is NOT globally unique (agents PK is
+   * (organization_id, id) and ids are human slugs), so two orgs with the same
+   * agentId+mcpId would otherwise collide — letting org A's tool annotations
+   * auto-approve org B's destructive tool call. Every get/set runs inside
+   * `runWithOrganizationContext`, so we derive the org from that context
+   * rather than threading it through every signature (which could be forgotten
+   * at a call site).
+   */
   private buildKey(mcpId: string, agentId?: string): string {
+    const orgId = getOrgId();
     if (agentId) {
-      return `mcp:tools:${agentId}:${mcpId}`;
+      return `mcp:tools:${orgId}:${agentId}:${mcpId}`;
     }
-    return `mcp:tools:${mcpId}`;
+    return `mcp:tools:${orgId}:${mcpId}`;
   }
 }

--- a/packages/server/src/gateway/proxy/http-proxy.ts
+++ b/packages/server/src/gateway/proxy/http-proxy.ts
@@ -3,6 +3,7 @@ import type { LookupAddress } from "node:dns";
 import * as dns from "node:dns/promises";
 import * as http from "node:http";
 import * as net from "node:net";
+import { domainToASCII } from "node:url";
 import type { WorkerTokenData } from "@lobu/core";
 import { createLogger, verifyWorkerToken } from "@lobu/core";
 import {
@@ -446,9 +447,19 @@ async function validateProxyAuth(
  * blocklist in unrestricted+blocklist mode (matches neither the exact nor the
  * `.suffix` pattern) while the plain form is blocked. Strip trailing dots so
  * every matcher sees the same name DNS will ultimately resolve.
+ *
+ * It also IDNA/punycode-normalizes the host. The HTTP path derives the host
+ * from `new URL().hostname` (already `xn--` ASCII), but the CONNECT path's raw
+ * parser returns the host verbatim (possibly Unicode). Configured allow/deny
+ * patterns are stored as punycode (see `normalizeDomainPattern`), so a Unicode
+ * CONNECT host would otherwise never match its punycode blocklist entry (and
+ * CONNECT vs HTTP would disagree for the same IDN host). Routing both through
+ * `domainToASCII` makes every matcher see the one canonical ASCII name.
  */
 function canonicalizeHostname(hostname: string): string {
-  return hostname.replace(/\.+$/, "");
+  const stripped = hostname.replace(/\.+$/, "");
+  const ascii = domainToASCII(stripped);
+  return (ascii !== "" ? ascii : stripped).toLowerCase();
 }
 
 function matchesDomainPattern(hostname: string, patterns: string[]): boolean {


### PR DESCRIPTION
Four verified findings, two concerns: cross-tenant MCP cache isolation and IDN egress-matcher gaps. All run under N>1 replicas (the caches are pod-local process singletons; the fixes make the *keys* org-scoped so a single pod's cache can never serve org A's data to org B).

## Findings & fixes

### #5 [high] MCP tool cache was org-blind → tool-metadata + approval-gate poisoning
`McpToolCache.buildKey(mcpId, agentId)` returned `mcp:tools:${agentId}:${mcpId}` with no org. The cache is a process-wide singleton and `agentId` is **not** globally unique (agents PK is `(organization_id, id)`, human slugs), so two orgs with the same `agentId+mcpId` collided. The cache is checked **before** the org-scoped `getHttpServer`, so a hit bypassed the only org gate; and `getToolAnnotations` reads the same key and feeds `evaluateToolApproval`/`requiresToolApproval`, so org A's `readOnlyHint`/`destructiveHint:false` annotations could auto-approve org B's destructive call.
Fix: `buildKey` now prefixes the org — `mcp:tools:${orgId}:${agentId}:${mcpId}`. Every `get`/`set`/`getServerInfo`/`setServerInfo`/`getInstructions` runs inside `runWithOrganizationContext`, so the org is read from that context (`getOrgId()`) rather than threaded through every signature — there is **no** orgId param a call site can forget.

### #6 [medium] MCP upstream session cache was org-blind (session-handle bleed)
`buildSessionKey(agentId, mcpId, scopeKey)` had no org, and `McpUpstreamClient.sessions` is a process-wide Map, so two orgs sharing `agentId+mcpId+scope` shared one upstream `Mcp-Session-Id`. Fix: org-prefixed key `mcp:session:${orgId}:${agentId}:${mcpId}:${scope}`, same context-derived approach. (Not a cred leak — creds are re-resolved org-scoped per request; that path is untouched.)

### #10 + #11 [low] IDN/Unicode egress matcher gaps (shared root: never IDNA-normalized)
`normalizeDomainPattern` only trimmed + lowercased. But the HTTP egress path matches on `new URL(targetUrl).hostname` (punycode `xn--`), while the CONNECT path's raw parser (`extractConnectHostname`) returns the host verbatim (Unicode). So a Unicode `WORKER_DISALLOWED_DOMAINS` entry never matched the punycode HTTP host (**bypass**), and CONNECT vs HTTP disagreed for the same IDN host.
Fix: `normalizeDomainPattern` now runs hosts through `node:url` `domainToASCII` (stored patterns become punycode), and `canonicalizeHostname` in `http-proxy.ts` — the single funnel **both** egress paths hit via `checkDomainAccess` — does the same, so every matcher sees one canonical ASCII name. Userinfo/`@` handling is unchanged (a CONNECT target with `@` still 400s).

## Red → green evidence
Each finding has a test that fails on the old behavior and passes after the fix (proved by temporarily reverting each change, then restoring).

- **#5/#6** `packages/server/src/gateway/__tests__/mcp-cache-org-isolation.test.ts` (new). With the org-blind keys restored: **4 fail / 1 pass** (org B reads org A's cached tools/annotations/instructions; both orgs get the same session key). With the fix: **5 pass**.
- **#10/#11** `packages/core/.../network-domains.test.ts` (Unicode→punycode) + `packages/server/.../http-proxy.test.ts` (Unicode `WORKER_DISALLOWED_DOMAINS` blocks both the punycode HTTP host and the Unicode CONNECT host; both forms canonicalize to the same ASCII name). With the fix reverted: core **3 fail**, server **2 fail** (`new URL().hostname`-derived punycode host slips the blocklist: `Expected false, Received true`). With the fix: **all pass**.

Runtime fact relied on: `new URL("http://münchen.de/").hostname === "xn--mnchen-3ya.de"`.

Pre-existing MCP cache tests (`mcp-proxy.test.ts`, `mcp-proxy-edge-cases.test.ts`) were updated to seed the now-org-scoped cache inside org context, matching how production always seeds it.

## Validation
- `cd packages/server && npx tsc --noEmit` → 0 errors
- Affected bun suites: `mcp-proxy` + `mcp-proxy-org-context` + `mcp-proxy-edge-cases` + `mcp-cache-org-isolation` + `http-proxy` + `session-manager` → 108 pass / 0 fail; `network-domains` → 21 pass / 0 fail; egress-judge suites → 22 pass / 0 fail

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1346"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784241847&installation_id=136316292&pr_number=1346&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1346&signature=ebd3b920ef62ab95d5875560211bef47c3359767fbe4bbb2ba3f12568aac21e8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->