### PR TITLE
fix(server): accept SSE ?token= ticket on the invalidation events route

### DIFF
--- a/packages/server/src/events/__tests__/sse-invalidation-auth.test.ts
+++ b/packages/server/src/events/__tests__/sse-invalidation-auth.test.ts
@@ -61,6 +61,18 @@ describe('invalidationSseAuth (embedded SSE ticket)', () => {
     expect(res.status).not.toBe(200);
   });
 
+  it('a member of org A cannot open org B\'s stream with their ticket (cross-org isolation)', async () => {
+    const orgA = await createTestOrganization({ slug: 'inv-org-a' });
+    const orgB = await createTestOrganization({ slug: 'inv-org-b' });
+    const user = await createTestUser({ email: 'inv-cross@test.example.com' });
+    await addUserToOrganization(user.id, orgA.id, 'owner'); // member of A only
+
+    // Their valid ticket, pointed at org B's slug → membership check fails → not 200.
+    const res = await getEvents('inv-org-b', `?token=${encodeURIComponent(ticket(user.id))}`);
+    expect(res.status).not.toBe(200);
+    expect(orgB.id).not.toBe(orgA.id);
+  });
+
   it('no ticket falls through to mcpAuth (not 200 without a cookie/bearer)', async () => {
     await createTestOrganization({ slug: 'inv-noticket-org' });
     const res = await getEvents('inv-noticket-org', '');

--- a/packages/server/src/events/__tests__/sse-invalidation-auth.test.ts
+++ b/packages/server/src/events/__tests__/sse-invalidation-auth.test.ts
@@ -1,0 +1,87 @@
+import { encrypt } from '@lobu/core';
+import { Hono } from 'hono';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { cleanupTestDatabase } from '../../__tests__/setup/test-db';
+import {
+  addUserToOrganization,
+  createTestOrganization,
+  createTestUser,
+} from '../../__tests__/setup/test-fixtures';
+import { initWorkspaceProvider } from '../../workspace';
+import { invalidationSseAuth } from '../sse-invalidation-auth';
+
+// The embedded panel opens GET /api/:orgSlug/events with EventSource (no
+// Authorization header, no usable cookie) and a ?token= ticket. invalidationSseAuth
+// must resolve that ticket to a member of the org and set organizationId; anything
+// else falls through to mcpAuth (cookie / Bearer / nothing).
+const ticket = (userId: string, exp = Date.now() + 60_000): string =>
+  encrypt(JSON.stringify({ userId, platform: 'external', exp }));
+
+function makeApp() {
+  const app = new Hono();
+  app.get('/api/:orgSlug/events', invalidationSseAuth, (c) => {
+    const orgId = (c.get as (k: string) => unknown)('organizationId');
+    if (!orgId) return c.json({ ok: false }, 401);
+    return c.json({ ok: true, organizationId: orgId });
+  });
+  return app;
+}
+
+const getEvents = async (slug: string, query: string) =>
+  makeApp().request(`/api/${slug}/events${query}`, { method: 'GET' });
+
+describe('invalidationSseAuth (embedded SSE ticket)', () => {
+  beforeEach(async () => {
+    await cleanupTestDatabase();
+    await initWorkspaceProvider(); // mcpAuth fallback path needs the provider
+  });
+
+  it('a ticket for an org member resolves the organization and passes', async () => {
+    const org = await createTestOrganization({ slug: 'inv-member-org' });
+    const user = await createTestUser({ email: 'inv-member@test.example.com' });
+    await addUserToOrganization(user.id, org.id, 'owner');
+
+    const res = await getEvents('inv-member-org', `?token=${encodeURIComponent(ticket(user.id))}`);
+    expect(res.status).toBe(200);
+    expect((await res.json()) as { organizationId: string }).toEqual({
+      ok: true,
+      organizationId: org.id,
+    });
+  });
+
+  it('a ticket for a NON-member does not resolve the org (falls through, not 200)', async () => {
+    const org = await createTestOrganization({ slug: 'inv-nonmember-org' });
+    const outsider = await createTestUser({ email: 'inv-outsider@test.example.com' });
+    // outsider is intentionally NOT added to the org.
+
+    const res = await getEvents(
+      'inv-nonmember-org',
+      `?token=${encodeURIComponent(ticket(outsider.id))}`
+    );
+    expect(res.status).not.toBe(200);
+  });
+
+  it('no ticket falls through to mcpAuth (not 200 without a cookie/bearer)', async () => {
+    await createTestOrganization({ slug: 'inv-noticket-org' });
+    const res = await getEvents('inv-noticket-org', '');
+    expect(res.status).not.toBe(200);
+  });
+
+  it('a tampered ticket falls through (not 200)', async () => {
+    await createTestOrganization({ slug: 'inv-garbage-org' });
+    const res = await getEvents('inv-garbage-org', '?token=not-a-real-ticket');
+    expect(res.status).not.toBe(200);
+  });
+
+  it('an expired ticket does not resolve the org (not 200)', async () => {
+    const org = await createTestOrganization({ slug: 'inv-expired-org' });
+    const user = await createTestUser({ email: 'inv-expired@test.example.com' });
+    await addUserToOrganization(user.id, org.id, 'owner');
+
+    const res = await getEvents(
+      'inv-expired-org',
+      `?token=${encodeURIComponent(ticket(user.id, Date.now() - 1000))}`
+    );
+    expect(res.status).not.toBe(200);
+  });
+});

--- a/packages/server/src/events/sse-invalidation-auth.ts
+++ b/packages/server/src/events/sse-invalidation-auth.ts
@@ -17,6 +17,8 @@ import { getCachedOrgBySlug } from "../workspace/multi-tenant.js";
  * normal `mcpAuth` path unchanged. GET-only (EventSource is always GET).
  */
 export async function invalidationSseAuth(c: Context, next: Next) {
+  // Keep the ?token= ticket out of the next page's Referer.
+  c.header("Referrer-Policy", "no-referrer");
   const ticket = c.req.method === "GET" ? c.req.query("token") : undefined;
   if (ticket) {
     const session = await verifySettingsToken(ticket);

--- a/packages/server/src/events/sse-invalidation-auth.ts
+++ b/packages/server/src/events/sse-invalidation-auth.ts
@@ -1,0 +1,41 @@
+import type { Context, Next } from "hono";
+import { getDb } from "../db/client.js";
+import { verifySettingsToken } from "../gateway/routes/public/settings-auth.js";
+import { mcpAuth } from "../auth/middleware.js";
+import { getCachedOrgBySlug } from "../workspace/multi-tenant.js";
+
+/**
+ * Auth for the SSE invalidation stream (`GET /api/:orgSlug/events`).
+ *
+ * The embedded panel opens this with EventSource, which can't send an
+ * Authorization header and has no usable session cookie in the cross-site
+ * iframe — so it appends a short-lived `?token=` ticket (from /api/sse-ticket),
+ * the same one the agent stream uses. This middleware resolves that ticket to a
+ * user, verifies org membership for the requested slug, and sets
+ * `organizationId` so the handler can scope the stream. Anything else —
+ * first-party cookie / Bearer session token / no ticket — falls through to the
+ * normal `mcpAuth` path unchanged. GET-only (EventSource is always GET).
+ */
+export async function invalidationSseAuth(c: Context, next: Next) {
+  const ticket = c.req.method === "GET" ? c.req.query("token") : undefined;
+  if (ticket) {
+    const session = await verifySettingsToken(ticket);
+    const orgSlug = c.req.param("orgSlug");
+    if (session?.userId && orgSlug) {
+      const org = await getCachedOrgBySlug(orgSlug);
+      if (org) {
+        const rows = await getDb()`
+          SELECT role FROM "member"
+          WHERE "organizationId" = ${org.id} AND "userId" = ${session.userId}
+          LIMIT 1
+        `;
+        if (rows.length > 0) {
+          c.set("organizationId", org.id);
+          c.set("memberRole", rows[0].role as string);
+          return next();
+        }
+      }
+    }
+  }
+  return mcpAuth(c, next);
+}

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -28,6 +28,7 @@ import { connectRoutes } from './connect/routes';
 import { getDb } from './db/client';
 import * as invalidationEmitter from './events/emitter';
 import { streamInvalidationEvents } from './events/sse';
+import { invalidationSseAuth } from './events/sse-invalidation-auth';
 import { isExcludedSpaPath } from './http/spa-route-filter';
 import { isShuttingDown } from './lifecycle-state';
 import { restGetAuthProfileForRun, restGetFeedForRun } from './connector-run/routes';
@@ -1177,7 +1178,7 @@ app.route('/api/agents/platforms', platformSchemaRoutes);
 // ============================================
 // SSE Invalidation Events (for frontend cache sync)
 // ============================================
-app.get('/api/:orgSlug/events', mcpAuth, async (c) => {
+app.get('/api/:orgSlug/events', invalidationSseAuth, async (c) => {
   const orgId = c.get('organizationId');
   if (!orgId) return c.json({ error: 'Organization context required' }, 401);
 


### PR DESCRIPTION
Closes the last embedded-panel SSE gap (deferred from #1342). The live cache-invalidation stream `GET /api/:orgSlug/events` uses EventSource (no Authorization header, no usable cookie in the cross-site iframe) so it failed auth — the panel got no live updates.

New `invalidationSseAuth` middleware on that route: for a GET with a `?token=` ticket, resolve it to a user, **verify org membership for the slug**, set `organizationId`; anything else (cookie / Bearer / nothing) falls through to `mcpAuth` unchanged. GET-only, membership-verified, stateless ticket (multi-replica safe) — the same ticket the agent stream uses.

## Test (`sse-invalidation-auth.test.ts`, 5 green)
member ticket → resolves the org (200 + correct organizationId); non-member / no-ticket / tampered / expired → falls through, not 200.

Server-only on the route side; SPA appends `?token=` (owletto PR). Pointer bump after owletto merges.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1347"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784242821&installation_id=136316292&pr_number=1347&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1347&signature=40252485eb4b878416f06e0b1952bf1ef926e7a788f0c1861941df9711feaea4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->