### PR TITLE
chore(docker): drop Chromium from the gateway image

### DIFF
--- a/docker/app/Dockerfile
+++ b/docker/app/Dockerfile
@@ -124,12 +124,13 @@ FROM node:22-slim AS runtime
 
 WORKDIR /app
 
-# curl for health checks, dbmate for migrations, bun for tsx-equivalent, Chromium deps for connectors
+# curl for health checks, dbmate for migrations, bun for tsx-equivalent.
+# No Chromium runtime libs: browser-based connectors (website/trustpilot) run on
+# the external worker fleet (its own image ships Chromium) and the Owletto Chrome
+# extension — the gateway never launches a browser, so the ~150MB Chromium
+# install + its X11/GTK deps are dropped here to shrink the image + speed builds.
 RUN apt-get update && apt-get install -y --no-install-recommends \
       curl ca-certificates unzip \
-      libnss3 libnspr4 libatk1.0-0 libatk-bridge2.0-0 libcups2 libdrm2 libdbus-1-3 \
-      libxkbcommon0 libatspi2.0-0 libxcomposite1 libxdamage1 libxfixes3 libxrandr2 \
-      libgbm1 libpango-1.0-0 libcairo2 libasound2 libwayland-client0 \
     && rm -rf /var/lib/apt/lists/* \
     && curl -fsSL https://github.com/amacneil/dbmate/releases/download/v2.22.0/dbmate-linux-amd64 -o /usr/local/bin/dbmate \
     && chmod +x /usr/local/bin/dbmate \
@@ -156,17 +157,10 @@ COPY --from=builder /app/packages/owletto ./packages/owletto
 # Database migrations
 COPY db/migrations ./db/migrations
 
-# Install Playwright/patchright Chromium for browser-based connectors.
-# PLAYWRIGHT_BROWSERS_PATH pins both the install target and the runtime lookup to
-# an absolute, HOME-independent path (default is $HOME/.cache/ms-playwright, which
-# differs by USER and breaks the connector child forked in another cwd). chmod 755
-# keeps it readable regardless of which user the runtime resolves to. The install
-# must fail the build loudly — the old `2>/dev/null ... || true` silently shipped
-# images with no Chromium. `playwright` is the patchright alias, so a single
-# patchright install is deterministic.
-RUN mkdir -p /ms-playwright && chmod 755 /ms-playwright
-ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright
-RUN npx patchright install chromium
+# No Chromium install: the gateway never launches a browser. Browser-based
+# connectors run on the external worker fleet (docker/worker/Dockerfile ships
+# Chromium) and via the Owletto Chrome extension. Dropping the ~150MB patchright
+# install removes the single biggest per-build download from this image.
 
 # Build metadata + environment defaults
 ARG APP_GIT_SHA=unknown


### PR DESCRIPTION
The app image **is the gateway** — it never launches a browser. Browser-based connectors (`website`/`trustpilot`) run on the **external worker fleet** (`docker/worker/Dockerfile` keeps Chromium) and via the **Owletto Chrome extension**.

Removes from `docker/app/Dockerfile`:
- `RUN npx patchright install chromium` — the **~150MB** download, the single biggest per-build cost (and it was ordered *after* the per-build COPY layers, so it re-ran every deploy).
- `PLAYWRIGHT_BROWSERS_PATH` env + `/ms-playwright` mkdir.
- The Chromium X11/GTK apt deps (libnss3, libgbm1, libpango, …).

**Boot-safety (verified by code, not just claimed):** `assertExternalDepsResolvable` probes connector-SDK/core resolution, *not* Chromium; the embedded connector daemon has no eager browser launch (only per-job); `browser-scraper-utils`/`website` use `import type` so nothing loads a browser at boot. The gateway boots normally — only an *in-process* browser-connector run would fail with 'Executable doesn't exist', and those belong on the worker fleet.

Net: smaller gateway image + faster builds. Worker image unchanged.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1348"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784245197&installation_id=136316292&pr_number=1348&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1348&signature=85d4e6ef620978b5229c18f85e8483a61d8bb769499b5d4c4bb21a1e03eb4a19"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined Docker image by removing browser runtime dependencies. Browser-based operations are now handled by dedicated external services and extensions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->