### PR TITLE
fix(sentry): default environment to development, not production

### DIFF
--- a/packages/server/src/instrument.ts
+++ b/packages/server/src/instrument.ts
@@ -26,7 +26,14 @@ if (dsn) {
 
   Sentry.init({
     dsn,
-    environment: process.env.ENVIRONMENT || 'production',
+    // Default to 'development', NOT 'production'. Prod deployments set ENVIRONMENT
+    // explicitly (charts/lobu), so the only stacks that hit this fallback are
+    // local/dev/example ones that happen to carry a SENTRY_DSN. Defaulting to
+    // 'production' made those mislabel as prod and pollute the prod Sentry view
+    // (e.g. a docker-compose stack dialing the dev-default `lobu-postgres` host
+    // surfaced as the #1 "production" error). A non-prod default keeps the prod
+    // environment filter trustworthy.
+    environment: process.env.ENVIRONMENT || 'development',
     release: process.env.SENTRY_RELEASE || process.env.APP_GIT_SHA || undefined,
     // 0.1 produced ~250k spans/day (~7.5M/mo) and exhausted the plan's 5M span
     // quota by day ~20 of the usage period. 0.02 keeps ~50k/day (~1.5M/mo) —


### PR DESCRIPTION
## What
`Sentry.init` defaulted `environment` to `'production'` when `ENVIRONMENT` is unset. Any local/dev/example stack carrying a `SENTRY_DSN` therefore mislabeled itself as prod and polluted the production Sentry view.

## Evidence
The #1 "production" error in Sentry (700+ in 14d) was `getaddrinfo ENOTFOUND lobu-postgres` — a docker-compose/local stack (bare-hex `server_name`, dialing the dev-default `lobu-postgres` host that only exists in `docker-compose.example.yml`) reporting as `environment=production`. The real prod app is healthy and connects to `lobu-ai-prod-db-pooler`.

## Fix
Default the Sentry environment to `'development'`. Prod deployments set `ENVIRONMENT=production` explicitly (verified in the live `charts/lobu` k8s env), so prod is unaffected; only unset-environment stacks change — which is the goal. `isDev`/trace-sampling unchanged (reads raw `process.env.ENVIRONMENT`).

## Verification
- Built all workspace packages in dep order; server `tsc --noEmit` clean.
- One-line behavior change (string default) + explanatory comment.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1354"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784252223&installation_id=136316292&pr_number=1354&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1354&signature=cbd7cbd9f242af17e1705c4be4ae4fab5f0e6cd7f8a5e0eeed3c4d346efcdb30"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->