### PR TITLE
feat(landing): unify the operating-loop section across homepage and /for pages

### DIFF
--- a/packages/landing/src/components/LandingPage.tsx
+++ b/packages/landing/src/components/LandingPage.tsx
@@ -3,11 +3,15 @@ import connectorsManifest from "../generated/connectors.json";
 import snippetsManifest from "../generated/landing-snippets.json";
 import { GITHUB_CONNECTORS_BLOB_URL, GITHUB_EXAMPLES_URL } from "../lib/urls";
 import { getLobuBaseUrl } from "../use-case-showcases";
-import { ArchitectureDiagram } from "./ArchitectureDiagram";
 import { CodeBlock, type CodeSnippet } from "./CodeBlock";
 import { CTA } from "./CTA";
 import { LatestBlogPosts, type LatestBlogPost } from "./LatestBlogPosts";
-import { ProactiveLoop } from "./ProactiveLoop";
+import {
+  loopForUseCase,
+  MemoryLoop,
+  ProactiveLoop,
+  SALES_LOOP,
+} from "./ProactiveLoop";
 import { ScheduleCallButton, ScheduleCallIcon } from "./ScheduleDialog";
 
 type ExampleEntry = {
@@ -97,7 +101,12 @@ export function LandingPage(props: {
       ) : (
         <>
           <Container className="py-14 sm:py-20">
-            <ArchitectureDiagram slug={activeUseCase} />
+            <MemoryLoop
+              data={{
+                ...(loopForUseCase(activeUseCase) ?? SALES_LOOP),
+                heading: undefined,
+              }}
+            />
           </Container>
           <UseCaseShowcaseSection
             slug={activeUseCase}
@@ -489,12 +498,11 @@ type ShowcaseTab = {
   id: string;
   eyebrow: string;
   blurb: string;
-  primary: { snippet: CodeSnippet; badge: string; maxHeight: string };
+  primary: { snippet: CodeSnippet; badge: string };
   secondary?: {
     snippet: CodeSnippet;
     badge: string;
     intro: string;
-    maxHeight: string;
   };
   docHref: string;
   docLabel: string;
@@ -526,7 +534,6 @@ function UseCaseShowcaseSection({
       primary: {
         snippet: agentConfig,
         badge: "lobu.config.ts",
-        maxHeight: "36rem",
       },
       docHref: "/getting-started/",
       docLabel: "Agents guide",
@@ -538,7 +545,6 @@ function UseCaseShowcaseSection({
       primary: {
         snippet: connector,
         badge: "typescript",
-        maxHeight: "36rem",
       },
       docHref: "/getting-started/connector-sdk/",
       docLabel: "Connector SDK docs",
@@ -551,7 +557,6 @@ function UseCaseShowcaseSection({
       primary: {
         snippet: memorySchema,
         badge: "entities",
-        maxHeight: "36rem",
       },
       docHref: "/getting-started/memory/",
       docLabel: "Memory guide",
@@ -563,14 +568,12 @@ function UseCaseShowcaseSection({
       primary: {
         snippet: watcher,
         badge: "reactive + dreaming",
-        maxHeight: "26rem",
       },
       secondary: reaction
         ? {
             snippet: reaction,
             badge: "optional · typescript",
             intro: "Reactions run code when memory changes:",
-            maxHeight: "26rem",
           }
         : undefined,
       docHref: "/getting-started/memory/",
@@ -582,7 +585,7 @@ function UseCaseShowcaseSection({
       id: "skills",
       eyebrow: "Skills",
       blurb: "Instructions, tools, packages, and network policy in one folder.",
-      primary: { snippet: skill, badge: "skill", maxHeight: "32rem" },
+      primary: { snippet: skill, badge: "skill" },
       docHref: "/getting-started/",
       docLabel: "Skills guide",
     });
@@ -594,13 +597,17 @@ function UseCaseShowcaseSection({
   return (
     <Container className="py-16 sm:py-20">
       <div class="mb-8 text-center">
-        <Eyebrow>What ships</Eyebrow>
-        <SectionHeading className="mx-auto">See what ships.</SectionHeading>
+        <Eyebrow>For engineers</Eyebrow>
+        <SectionHeading className="mx-auto">
+          The whole agent, in code.
+        </SectionHeading>
         <p
-          class="mx-auto mt-3 max-w-[42rem] text-[15px]"
+          class="mx-auto mt-3 max-w-[44rem] text-[15px]"
           style={{ color: "var(--color-page-text-muted)" }}
         >
-          Pick a piece to inspect the code. Click again to hide.
+          One project defines it end to end: the agent, its connectors, the
+          memory schema, watchers, and skills. Write it yourself, or let your
+          coding agent generate it. Pick a piece to read the code.
         </p>
       </div>
 
@@ -652,7 +659,6 @@ function UseCaseShowcaseSection({
           <CodeBlock
             badge={active.primary.badge}
             snippet={active.primary.snippet}
-            maxHeight={active.primary.maxHeight}
           />
           {active.secondary ? (
             <>
@@ -665,7 +671,6 @@ function UseCaseShowcaseSection({
               <CodeBlock
                 badge={active.secondary.badge}
                 snippet={active.secondary.snippet}
-                maxHeight={active.secondary.maxHeight}
               />
             </>
           ) : null}
@@ -689,21 +694,28 @@ function RunAnywhereSection() {
     eyebrow: string;
     title: string;
     body: preact.ComponentChildren;
+    links: Array<{ label: string; href: string }>;
   }> = [
     {
       eyebrow: "Local",
       title: "Run on your laptop.",
       body: "Boot the gateway, workers, memory, and embeddings with one command.",
+      links: [{ label: "Quickstart", href: "/getting-started/" }],
     },
     {
       eyebrow: "Self-host",
       title: "Run in your cloud.",
       body: "Deploy with Docker or Helm when data and controls need to stay with you.",
+      links: [
+        { label: "Docker", href: "/deployment/docker/" },
+        { label: "Kubernetes", href: "/deployment/kubernetes/" },
+      ],
     },
     {
       eyebrow: "Lobu Cloud",
       title: "Let Lobu run it.",
       body: "Use the same project with managed isolation, secrets, and upgrades.",
+      links: [{ label: "Lobu Cloud", href: "/deployment/cloud/" }],
     },
   ];
   return (
@@ -737,6 +749,18 @@ function RunAnywhereSection() {
             >
               {card.body}
             </p>
+            <div class="mt-auto flex flex-wrap gap-x-4 gap-y-1 pt-4">
+              {card.links.map((link) => (
+                <a
+                  key={link.href}
+                  href={link.href}
+                  class="inline-flex items-center gap-1 font-mono text-[12px] text-[color:var(--color-page-text-muted)] transition-colors hover:text-[color:var(--color-tg-accent)]"
+                >
+                  {link.label}
+                  <span aria-hidden="true">↗</span>
+                </a>
+              ))}
+            </div>
           </div>
         ))}
       </div>

--- a/packages/landing/src/components/ProactiveLoop.tsx
+++ b/packages/landing/src/components/ProactiveLoop.tsx
@@ -1,147 +1,289 @@
 /**
- * Outcome artifact for the homepage: shows the proactive loop end to end
- * WITHOUT any code, so a non-TS reader gets the value in one glance.
+ * Data-driven "operating loop" artifact, shared by the homepage and every
+ * /for/<use-case> page. Renders ONE design, parameterized by a `LoopData`:
  *
- *   raw events  ──►  graph derives a typed entity  ──►  agent acts (surfaces in chat)
+ *   SOURCES ───watches───▶ STANDING GOAL
+ *      │ builds                 │ fires
+ *      ▼                        ▼
+ *   LIVE MEMORY              CHAT (the agent acts)
  *
- * The graph (left) is the substance; the chat (right) is just one surface.
- * Reuses SampleChat with a custom proactive (bot-first) message list.
+ * A CSS grid forces each row's two cards to equal height (SOURCES = GOAL,
+ * MEMORY = CHAT), keeping both columns level. Reuses SampleChat for the chat.
+ *
+ * The homepage passes SALES_LOOP (the renewal-risk story). /for/<slug> pages
+ * pass a config built from that vertical's connectors / entities / watcher.
  */
 
+import {
+  siDatadog,
+  siGithub,
+  siGmail,
+  siGoogledrive,
+  siHubspot,
+  siJira,
+  siLinear,
+  siNotion,
+  siPostgresql,
+  siShopify,
+  siSnowflake,
+  siStripe,
+  siZendesk,
+} from "simple-icons";
 import type { UseCase } from "../types";
+import { messagingChannels } from "./platforms";
 import { SampleChat, SLACK_THEME } from "./SampleChat";
 
-// Proactive: the agent speaks first, unprompted, because the graph changed.
-const PROACTIVE_SCENARIO: UseCase = {
-  id: "proactive-renewal",
-  tabLabel: "Renewal risk",
-  title: "Proactive renewal risk",
-  description: "The agent flags churn risk before anyone asks.",
-  settingsLabel: "",
-  chatLabel: "",
-  botName: "Revenue agent",
-  botInitial: "R",
-  botColor: "#36c5ab",
-  messages: [
-    {
-      role: "bot",
-      text: "Heads up: Acme Corp is trending toward churn. Logins are down 38% over 14 days and their renewal is in 21 days.\n\nWant me to draft a check-in for their CSM?",
-      buttons: [{ label: "Draft the email", action: "link" }],
-    },
-    {
-      role: "user",
-      text: "Yes, and include the usage drop.",
-    },
-    {
-      role: "bot",
-      text: "Drafted. Saved it to the Acme account and pinged @dana.",
-    },
-  ],
+const ACCENT = "var(--color-tg-accent)";
+const RISK = "#f5a524"; // amber: "at risk"
+const OK = "#36c5ab"; // teal: "healthy" (matches the Slack agent color)
+
+// --- Types -------------------------------------------------------------------
+
+/** Minimal shape of a simple-icons icon (title + svg path). */
+export type LoopIcon = { title: string; path: string };
+/** A connector chip: shows a brand logo when known, a text chip otherwise. */
+export type LoopConnector = { label: string; icon?: LoopIcon };
+export type LoopStatus = { label: string; tone: "risk" | "ok" };
+export type LoopField = readonly [label: string, value: string];
+export type LoopEvent = { age: string; summary: string; source: string };
+export type LoopProfile = { name: string; status: LoopStatus };
+
+export interface LoopData {
+  /** Section heading. Omitted when embedded under an existing page heading. */
+  heading?: { eyebrow: string; title: string; subtitle: string };
+  connectors: {
+    items: LoopConnector[];
+    moreLabel?: string;
+    caption: string;
+    /** The differentiator line (rendered after a `</>` glyph). */
+    codeLine: string;
+    /** e.g. "1,204 events" */
+    countLabel: string;
+  };
+  buildsLabel: string;
+  memory: {
+    /** Eyebrow, e.g. "Live company memory · 19 accounts". */
+    label: string;
+    /** Entity-type chip, e.g. "account". */
+    typeChip: string;
+    primary: {
+      name: string;
+      contact?: string;
+      status: LoopStatus;
+      fields: LoopField[];
+      eventsLabel: string;
+      events: LoopEvent[];
+    };
+    others: LoopProfile[];
+    moreLabel?: string;
+  };
+  goal: {
+    label: string;
+    schedule: string;
+    prompt: string;
+    footer: string;
+  };
+  firesLabel: string;
+  chat: UseCase;
+  docs: { connectors: string; memory: string; watchers: string };
+}
+
+function statusColor(tone: LoopStatus["tone"]): string {
+  return tone === "risk" ? RISK : OK;
+}
+
+// --- Connector logo registry -------------------------------------------------
+
+// Known connector labels → brand mark. Anything not here renders as a text
+// chip, so arbitrary per-use-case connectors (Crunchbase, News feeds…) degrade
+// gracefully. Keys are matched case-insensitively against the connector label.
+const CONNECTOR_ICONS: Record<string, LoopIcon> = {
+  hubspot: siHubspot,
+  stripe: siStripe,
+  zendesk: siZendesk,
+  notion: siNotion,
+  snowflake: siSnowflake,
+  postgres: siPostgresql,
+  postgresql: siPostgresql,
+  github: siGithub,
+  shopify: siShopify,
+  linear: siLinear,
+  datadog: siDatadog,
+  jira: siJira,
+  gmail: siGmail,
+  drive: siGoogledrive,
+  "google drive": siGoogledrive,
 };
 
-// The "what the graph knew" record that triggered the message above. Field
-// names match the sales example's entity types (account / renewal-risk).
-const GRAPH_FIELDS: ReadonlyArray<readonly [string, string]> = [
-  ["account", "Acme Corp"],
-  ["health", "at risk"],
-  ["signal", "logins −38% / 14d"],
-  ["renewal_in", "21 days"],
-];
+/** Resolve a connector label to {label, icon?} for the Sources card. */
+export function toConnector(label: string): LoopConnector {
+  const icon = CONNECTOR_ICONS[label.trim().toLowerCase()];
+  return icon ? { label, icon } : { label };
+}
 
-const SOURCE_EVENTS = [
-  "Product usage",
-  "CRM renewal date",
-  "Support tickets",
-  "Slack notes",
-] as const;
+// --- Primitives --------------------------------------------------------------
 
-function GraphCard() {
+function Eyebrow({ children }: { children: preact.ComponentChildren }) {
+  return (
+    <span
+      class="font-mono text-[10.5px] uppercase tracking-[0.16em]"
+      style={{ color: "var(--color-page-text-muted)" }}
+    >
+      {children}
+    </span>
+  );
+}
+
+function Card({
+  children,
+  class: cls = "",
+}: {
+  children: preact.ComponentChildren;
+  class?: string;
+}) {
   return (
     <div
-      class="flex w-full flex-col gap-3 rounded-[14px] border p-4"
+      class={`flex w-full flex-col gap-2.5 rounded-[14px] border p-4 ${cls}`}
       style={{
         borderColor: "var(--color-page-border)",
         backgroundColor: "var(--color-page-bg)",
-        minWidth: "280px",
-        maxWidth: "460px",
       }}
     >
-      <div class="flex items-center justify-between">
-        <span
-          class="font-mono text-[11px] uppercase tracking-[0.16em]"
-          style={{ color: "var(--color-page-text-muted)" }}
-        >
-          Live company memory
-        </span>
-        <span
-          class="rounded-md border px-2 py-0.5 font-mono text-[10.5px]"
-          style={{
-            borderColor: "var(--color-page-border)",
-            color: "var(--color-tg-accent)",
-          }}
-        >
-          account
-        </span>
-      </div>
+      {children}
+    </div>
+  );
+}
 
-      <div class="flex flex-col">
-        {GRAPH_FIELDS.map((row, idx) => (
-          <div
-            key={row[0]}
-            class="grid grid-cols-[100px_1fr] gap-x-3 py-1.5 font-mono text-[12.5px]"
-            style={{
-              borderTop:
-                idx === 0 ? undefined : "1px solid var(--color-page-border)",
-            }}
-          >
-            <span style={{ color: "var(--color-page-text-muted)" }}>
-              {row[0]}
-            </span>
-            <span style={{ color: "var(--color-page-text)" }}>{row[1]}</span>
-          </div>
-        ))}
-      </div>
+function StatusBadge({ status }: { status: LoopStatus }) {
+  const color = statusColor(status.tone);
+  return (
+    <span
+      class="rounded-md px-1.5 py-0.5 font-mono text-[10.5px]"
+      style={{ color, backgroundColor: `${color}1f` }}
+    >
+      {status.label}
+    </span>
+  );
+}
 
-      <div
-        class="border-t pt-2"
-        style={{ borderColor: "var(--color-page-border)" }}
+function DocLink({ href, children }: { href: string; children: string }) {
+  return (
+    <a
+      href={href}
+      class="inline-flex items-center gap-1 whitespace-nowrap font-mono text-[10.5px] text-[color:var(--color-page-text-muted)] transition-colors hover:text-[color:var(--color-tg-accent)]"
+    >
+      {children}
+      <span aria-hidden="true">↗</span>
+    </a>
+  );
+}
+
+function BrandLogo({ icon }: { icon: LoopIcon }) {
+  return (
+    <svg
+      role="img"
+      viewBox="0 0 24 24"
+      width="20"
+      height="20"
+      class="shrink-0"
+      style={{ fill: "var(--color-page-text-muted)" }}
+    >
+      <title>{icon.title}</title>
+      <path d={icon.path} />
+    </svg>
+  );
+}
+
+function TextChip({ label }: { label: string }) {
+  return (
+    <span
+      class="rounded-md border px-1.5 py-0.5 font-mono text-[10px]"
+      style={{
+        borderColor: "var(--color-page-border)",
+        color: "var(--color-page-text-muted)",
+        backgroundColor: "var(--color-page-surface)",
+      }}
+    >
+      {label}
+    </span>
+  );
+}
+
+// Where the agent's reply lands: the team's chat platform, or your own app over
+// the API. Same everywhere — Lobu speaks every channel.
+function ChatChannels({ class: cls = "" }: { class?: string }) {
+  return (
+    <div class={`flex flex-col gap-2 px-1 ${cls}`}>
+      <span
+        class="text-[11px]"
+        style={{ color: "var(--color-page-text-muted)" }}
       >
-        <div
-          class="mb-2 text-[11.5px]"
-          style={{ color: "var(--color-page-text-muted)" }}
+        Replies in your team's chat, or your own app over the API:
+      </span>
+      <div class="flex flex-wrap items-center gap-x-3.5 gap-y-2">
+        {messagingChannels.map((ch) => (
+          <a
+            key={ch.id}
+            href={ch.href}
+            title={ch.label}
+            aria-label={ch.label}
+            class="text-[color:var(--color-page-text-muted)] transition-colors hover:text-[color:var(--color-page-text)]"
+          >
+            {ch.renderIcon(18)}
+          </a>
+        ))}
+        <a
+          href="/sdks/rest-api/"
+          class="font-mono text-[11px] text-[color:var(--color-page-text-muted)] transition-colors hover:text-[color:var(--color-tg-accent)]"
         >
-          Built from 1,204 source events:
-        </div>
-        <div class="flex flex-wrap gap-1.5">
-          {SOURCE_EVENTS.map((event) => (
-            <span
-              key={event}
-              class="rounded-md border px-2 py-1 text-[11px]"
-              style={{
-                borderColor: "var(--color-page-border)",
-                color: "var(--color-page-text-muted)",
-                backgroundColor: "var(--color-page-surface)",
-              }}
-            >
-              {event}
-            </span>
-          ))}
-        </div>
+          API ↗
+        </a>
       </div>
     </div>
   );
 }
 
-// Small labelled arrow: "graph changed → agent acts". Horizontal on desktop,
-// vertical (rotated) on mobile so the two cards stack cleanly.
-function FlowArrow() {
+// Vertical "this becomes that" connector (SOURCES->MEMORY, GOAL->CHAT).
+function DownArrow({
+  label,
+  class: cls = "",
+}: {
+  label: string;
+  class?: string;
+}) {
   return (
-    <div class="flex shrink-0 flex-col items-center justify-center gap-1.5 md:px-1">
+    <div class={`flex flex-col items-center gap-1 ${cls}`}>
+      <svg width="12" height="18" viewBox="0 0 12 18" aria-hidden="true">
+        <title>{label}</title>
+        <path
+          d="M6 0 V13 M2.5 9.5 L6 13 L9.5 9.5"
+          stroke={ACCENT}
+          stroke-width="1.5"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          fill="none"
+        />
+      </svg>
+      <span
+        class="text-center font-mono text-[10px] uppercase tracking-[0.12em]"
+        style={{ color: "var(--color-page-text-muted)" }}
+      >
+        {label}
+      </span>
+    </div>
+  );
+}
+
+// Horizontal "the goal watches the memory" connector. Rotates to vertical on
+// mobile so the four blocks stack into a single readable column.
+function WatchesArrow({ class: cls = "" }: { class?: string }) {
+  return (
+    <div class={`flex flex-col items-center justify-center gap-1.5 ${cls}`}>
       <span
         class="font-mono text-[10.5px] uppercase tracking-[0.12em]"
         style={{ color: "var(--color-page-text-muted)" }}
       >
-        acts
+        watches
       </span>
       <svg
         class="rotate-90 md:rotate-0"
@@ -150,10 +292,10 @@ function FlowArrow() {
         viewBox="0 0 40 12"
         aria-hidden="true"
       >
-        <title>flow</title>
+        <title>watches</title>
         <path
           d="M0 6 H32 M28 2.5 L33 6 L28 9.5"
-          stroke="var(--color-tg-accent)"
+          stroke={ACCENT}
           stroke-width="1.5"
           stroke-linecap="round"
           stroke-linejoin="round"
@@ -164,36 +306,1124 @@ function FlowArrow() {
   );
 }
 
-export function ProactiveLoop() {
+// --- Blocks ------------------------------------------------------------------
+
+function SourcesCardImpl({
+  connectors,
+  docsHref,
+  class: cls = "",
+}: {
+  connectors: LoopData["connectors"];
+  docsHref: string;
+  class?: string;
+}) {
   return (
-    <div class="flex flex-col items-center gap-8">
-      <div class="flex flex-col items-center text-center">
-        <div
-          class="mb-3 font-mono text-[11.5px] font-semibold uppercase tracking-[0.12em]"
-          style={{ color: "var(--color-tg-accent)" }}
+    <Card class={cls}>
+      <div class="flex items-center justify-between">
+        <Eyebrow>Connectors</Eyebrow>
+        <span
+          class="inline-flex items-center gap-1.5 font-mono text-[10.5px]"
+          style={{ color: OK }}
         >
-          What it does
-        </div>
-        <h2
-          class="font-display text-[1.85rem] font-bold leading-[1.1] tracking-tight sm:text-[2.25rem]"
-          style={{ color: "var(--color-page-text)" }}
-        >
-          Shared memory updates. The agent acts.
-        </h2>
-        <p
-          class="mx-auto mt-3 max-w-2xl text-[15px] leading-relaxed"
-          style={{ color: "var(--color-page-text-muted)" }}
-        >
-          Usage, CRM, support, and Slack updates become one account record. When
-          renewal risk rises, the revenue agent proposes the next step.
-        </p>
+          <span
+            class="inline-block h-1.5 w-1.5 rounded-full"
+            style={{ backgroundColor: OK }}
+          />
+          live
+        </span>
       </div>
 
-      <div class="flex w-full flex-col items-center justify-center gap-4 md:flex-row md:items-stretch">
-        <GraphCard />
-        <FlowArrow />
-        <SampleChat useCase={PROACTIVE_SCENARIO} theme={SLACK_THEME} />
+      <div class="flex flex-wrap items-center gap-x-4 gap-y-2.5">
+        {connectors.items.map((c) =>
+          c.icon ? (
+            <BrandLogo key={c.label} icon={c.icon} />
+          ) : (
+            <TextChip key={c.label} label={c.label} />
+          )
+        )}
+        {connectors.moreLabel ? (
+          <TextChip label={connectors.moreLabel} />
+        ) : null}
+      </div>
+
+      <div
+        class="text-[11.5px] leading-snug"
+        style={{ color: "var(--color-page-text-muted)" }}
+      >
+        {connectors.caption}
+      </div>
+
+      <div class="flex items-center gap-2">
+        <span
+          class="font-mono text-[12px]"
+          style={{ color: ACCENT }}
+          aria-hidden="true"
+        >
+          &lt;/&gt;
+        </span>
+        <span
+          class="text-[12px] leading-snug"
+          style={{ color: "var(--color-page-text)" }}
+        >
+          {connectors.codeLine}
+        </span>
+      </div>
+
+      <div
+        class="mt-auto flex items-center justify-between gap-3 border-t pt-2"
+        style={{ borderColor: "var(--color-page-border)" }}
+      >
+        <span
+          class="text-[11.5px]"
+          style={{ color: "var(--color-page-text-muted)" }}
+        >
+          One event stream ·{" "}
+          <span style={{ color: "var(--color-page-text)" }}>
+            {connectors.countLabel}
+          </span>
+        </span>
+        <DocLink href={docsHref}>Connector SDK</DocLink>
+      </div>
+    </Card>
+  );
+}
+
+function MemoryCard({
+  memory,
+  docsHref,
+  class: cls = "",
+}: {
+  memory: LoopData["memory"];
+  docsHref: string;
+  class?: string;
+}) {
+  const { primary } = memory;
+  return (
+    <Card class={cls}>
+      <div class="flex items-center justify-between">
+        <Eyebrow>{memory.label}</Eyebrow>
+        <span
+          class="rounded-md border px-2 py-0.5 font-mono text-[10.5px]"
+          style={{ borderColor: "var(--color-page-border)", color: ACCENT }}
+        >
+          {memory.typeChip}
+        </span>
+      </div>
+
+      {/* Expanded: the record that drifted */}
+      <div
+        class="rounded-[10px] border"
+        style={{
+          borderColor: `${statusColor(primary.status.tone)}55`,
+          backgroundColor: "var(--color-page-surface)",
+        }}
+      >
+        <div class="flex items-start justify-between gap-3 px-3 py-2">
+          <div class="min-w-0">
+            <div
+              class="font-mono text-[13px]"
+              style={{ color: "var(--color-page-text)" }}
+            >
+              {primary.name}
+            </div>
+            {primary.contact ? (
+              <div
+                class="truncate font-mono text-[11px]"
+                style={{ color: "var(--color-page-text-muted)" }}
+              >
+                {primary.contact}
+              </div>
+            ) : null}
+          </div>
+          <StatusBadge status={primary.status} />
+        </div>
+
+        <div
+          class="flex flex-wrap gap-x-6 gap-y-1 border-t px-3 py-2 font-mono text-[12px]"
+          style={{ borderColor: "var(--color-page-border)" }}
+        >
+          {primary.fields.map((row) => (
+            <span key={row[0]}>
+              <span style={{ color: "var(--color-page-text-muted)" }}>
+                {row[0]}{" "}
+              </span>
+              <span style={{ color: "var(--color-page-text)" }}>{row[1]}</span>
+            </span>
+          ))}
+        </div>
+
+        {/* Event timeline the values above are derived from */}
+        <div
+          class="border-t px-3 py-2.5"
+          style={{ borderColor: "var(--color-page-border)" }}
+        >
+          <div
+            class="mb-2 text-[11px]"
+            style={{ color: "var(--color-page-text-muted)" }}
+          >
+            {primary.eventsLabel}
+          </div>
+          <div class="flex flex-col">
+            {primary.events.map((ev, idx) => (
+              <div
+                key={ev.summary}
+                class="grid grid-cols-[14px_1fr] items-start gap-x-2"
+              >
+                {/* timeline rail: dot + connecting line */}
+                <div class="flex flex-col items-center self-stretch">
+                  <span
+                    class="mt-[5px] h-[6px] w-[6px] shrink-0 rounded-full"
+                    style={{
+                      backgroundColor:
+                        idx === 0 ? statusColor(primary.status.tone) : ACCENT,
+                    }}
+                  />
+                  {idx < primary.events.length - 1 ? (
+                    <span
+                      class="w-px flex-1"
+                      style={{ backgroundColor: "var(--color-page-border)" }}
+                    />
+                  ) : null}
+                </div>
+                <div class="pb-2.5">
+                  <div
+                    class="text-[12px] leading-snug"
+                    style={{ color: "var(--color-page-text)" }}
+                  >
+                    {ev.summary}
+                  </div>
+                  <div
+                    class="font-mono text-[10px]"
+                    style={{ color: "var(--color-page-text-muted)" }}
+                  >
+                    {ev.age} ago · {ev.source}
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      {/* Collapsed: the rest of the book */}
+      {memory.others.map((row) => (
+        <div
+          key={row.name}
+          class="flex items-center justify-between rounded-[10px] border px-3 py-2"
+          style={{ borderColor: "var(--color-page-border)" }}
+        >
+          <span
+            class="font-mono text-[13px]"
+            style={{ color: "var(--color-page-text)" }}
+          >
+            {row.name}
+          </span>
+          <StatusBadge status={row.status} />
+        </div>
+      ))}
+      <div class="mt-auto flex items-center justify-between gap-3 pt-0.5">
+        <span
+          class="text-[11.5px]"
+          style={{ color: "var(--color-page-text-muted)" }}
+        >
+          {memory.moreLabel}
+        </span>
+        <DocLink href={docsHref}>Memory &amp; entities</DocLink>
+      </div>
+    </Card>
+  );
+}
+
+function GoalCard({
+  goal,
+  docsHref,
+  class: cls = "",
+}: {
+  goal: LoopData["goal"];
+  docsHref: string;
+  class?: string;
+}) {
+  return (
+    <Card class={cls}>
+      <div class="flex items-center justify-between">
+        <Eyebrow>{goal.label}</Eyebrow>
+        <span
+          class="inline-flex items-center gap-1.5 rounded-md border px-2 py-0.5 font-mono text-[10.5px]"
+          style={{ borderColor: "var(--color-page-border)", color: ACCENT }}
+        >
+          <svg width="11" height="11" viewBox="0 0 12 12" aria-hidden="true">
+            <title>schedule</title>
+            <circle
+              cx="6"
+              cy="6"
+              r="5"
+              fill="none"
+              stroke={ACCENT}
+              stroke-width="1.3"
+            />
+            <path
+              d="M6 3.2 V6 L8 7.2"
+              fill="none"
+              stroke={ACCENT}
+              stroke-width="1.3"
+              stroke-linecap="round"
+            />
+          </svg>
+          {goal.schedule}
+        </span>
+      </div>
+      <p
+        class="text-[12.5px] leading-relaxed"
+        style={{ color: "var(--color-page-text)" }}
+      >
+        “{goal.prompt}”
+      </p>
+      <div
+        class="mt-auto flex items-center justify-between gap-3 border-t pt-2"
+        style={{ borderColor: "var(--color-page-border)" }}
+      >
+        <span
+          class="text-[11.5px]"
+          style={{ color: "var(--color-page-text-muted)" }}
+        >
+          {goal.footer}
+        </span>
+        <DocLink href={docsHref}>Watchers</DocLink>
+      </div>
+    </Card>
+  );
+}
+
+// --- Composed component ------------------------------------------------------
+
+export function MemoryLoop({ data }: { data: LoopData }) {
+  return (
+    <div class="flex flex-col items-center gap-8">
+      {data.heading ? (
+        <div class="flex flex-col items-center text-center">
+          <div
+            class="mb-3 font-mono text-[11.5px] font-semibold uppercase tracking-[0.12em]"
+            style={{ color: ACCENT }}
+          >
+            {data.heading.eyebrow}
+          </div>
+          <h2
+            class="font-display text-[1.85rem] font-bold leading-[1.1] tracking-tight sm:text-[2.25rem]"
+            style={{ color: "var(--color-page-text)" }}
+          >
+            {data.heading.title}
+          </h2>
+          <p
+            class="mx-auto mt-3 max-w-2xl text-[15px] leading-relaxed"
+            style={{ color: "var(--color-page-text-muted)" }}
+          >
+            {data.heading.subtitle}
+          </p>
+        </div>
+      ) : null}
+
+      {/*
+        Explicit grid placement (md:col-start / md:row-start) decouples DOM order
+        from desktop layout: the DOM order below reads top-to-bottom on mobile
+        (sources -> memory -> goal -> chat), while on desktop the cards snap into
+        a 2x2 with arrows between. Row stretch keeps each row's two cards equal
+        height, so the columns stay level.
+      */}
+      <div class="grid w-full grid-cols-1 justify-items-center gap-y-2 md:grid-cols-[minmax(0,460px)_auto_minmax(0,460px)] md:justify-center md:gap-x-5">
+        <SourcesCardImpl
+          connectors={data.connectors}
+          docsHref={data.docs.connectors}
+          class="md:col-start-1 md:row-start-1"
+        />
+        <DownArrow
+          label={data.buildsLabel}
+          class="md:col-start-1 md:row-start-2 md:self-center"
+        />
+        <MemoryCard
+          memory={data.memory}
+          docsHref={data.docs.memory}
+          class="md:col-start-1 md:row-start-3"
+        />
+
+        <WatchesArrow class="md:col-start-2 md:row-start-1 md:self-center" />
+
+        <GoalCard
+          goal={data.goal}
+          docsHref={data.docs.watchers}
+          class="md:col-start-3 md:row-start-1"
+        />
+        <DownArrow
+          label={data.firesLabel}
+          class="md:col-start-3 md:row-start-2 md:self-center"
+        />
+        <div
+          class="flex w-full flex-col gap-3 md:col-start-3 md:row-start-3"
+          style={{ minWidth: "280px", maxWidth: "460px" }}
+        >
+          <SampleChat useCase={data.chat} theme={SLACK_THEME} class="flex-1" />
+          <ChatChannels />
+        </div>
       </div>
     </div>
   );
+}
+
+// --- Homepage config (the renewal-risk story) --------------------------------
+
+export const SALES_LOOP: LoopData = {
+  heading: {
+    eyebrow: "Why Lobu",
+    title: "Catch what you'd miss.",
+    subtitle:
+      "Lobu turns every source into one typed record, watches all of them against your goals, and drafts the next step the moment something drifts.",
+  },
+  connectors: {
+    items: [
+      { label: "HubSpot", icon: siHubspot },
+      { label: "Stripe", icon: siStripe },
+      { label: "Zendesk", icon: siZendesk },
+      { label: "Notion", icon: siNotion },
+      { label: "Snowflake", icon: siSnowflake },
+      { label: "Postgres", icon: siPostgresql },
+    ],
+    moreLabel: "50+ more",
+    caption:
+      "Reuse a prebuilt connector, or point Lobu at any database you use.",
+    codeLine: "Your agent writes code to bring in live data.",
+    countLabel: "1,204 events",
+  },
+  buildsLabel: "builds profiles",
+  memory: {
+    label: "Live company memory · 19 accounts",
+    typeChip: "account",
+    primary: {
+      name: "Acme Corp",
+      contact: "Jordan Lee, VP Eng",
+      status: { label: "at risk", tone: "risk" },
+      fields: [
+        ["plan", "Enterprise · 120 seats"],
+        ["renewal", "Jun 30 · 21 days"],
+      ],
+      eventsLabel: "Derived from recent events:",
+      events: [
+        {
+          age: "2d",
+          summary: '"API latency on /sync" ticket opened',
+          source: "Zendesk",
+        },
+        {
+          age: "5d",
+          summary: "Logins fell 38% over 14 days",
+          source: "Product",
+        },
+        { age: "9d", summary: "Renewal date set to Jun 30", source: "CRM" },
+        { age: "12d", summary: '"Champion left the company"', source: "Slack" },
+      ],
+    },
+    others: [
+      { name: "Globex Inc", status: { label: "healthy", tone: "ok" } },
+      { name: "Initech", status: { label: "healthy", tone: "ok" } },
+    ],
+    moreLabel: "+ 16 more accounts",
+  },
+  goal: {
+    label: "Standing goal · all 19 accounts",
+    schedule: "every weekday · 9:00",
+    prompt:
+      "Watch every account for churn risk. When health turns at-risk within 30 days of renewal, draft a CSM check-in and ask me to approve.",
+    footer: "Runs unattended · asks before it sends.",
+  },
+  firesLabel: "fired on Acme Corp",
+  chat: {
+    id: "proactive-renewal",
+    tabLabel: "Renewal risk",
+    title: "Proactive renewal risk",
+    description: "The agent flags churn risk before anyone asks.",
+    settingsLabel: "",
+    chatLabel: "",
+    botName: "Revenue agent",
+    botInitial: "R",
+    botColor: "#36c5ab",
+    messages: [
+      {
+        role: "bot",
+        text: "Heads up: Acme Corp is trending toward churn. Logins are down 38% over 14 days and their renewal is in 21 days.\n\nWant me to draft a check-in for their CSM?",
+        buttons: [{ label: "Draft the email", action: "link" }],
+      },
+      { role: "user", text: "Yes, and include the usage drop." },
+      {
+        role: "bot",
+        text: "Drafted. Saved it to the Acme account and pinged @dana.",
+        buttons: [{ label: "See drafted email", action: "link" }],
+      },
+    ],
+  },
+  docs: {
+    connectors: "/sdks/connectors/",
+    memory: "/getting-started/memory/",
+    watchers: "/getting-started/memory/#watchers",
+  },
+};
+
+// --- Per-vertical configs ----------------------------------------------------
+
+// Venture-capital deal sourcing. Grounded in the `market` showcase watcher
+// (daily Crunchbase/news/web sweep over portfolio + watchlist).
+export const MARKET_LOOP: LoopData = {
+  connectors: {
+    items: [
+      toConnector("Crunchbase"),
+      toConnector("PitchBook"),
+      toConnector("News feeds"),
+      toConnector("Company sites"),
+    ],
+    moreLabel: "50+ more",
+    caption:
+      "Reuse a prebuilt connector, or point Lobu at any database you use.",
+    codeLine: "Your agent writes code to scrape sites and feeds.",
+    countLabel: "2,400 signals",
+  },
+  buildsLabel: "builds companies",
+  memory: {
+    label: "Live deal memory · 312 companies",
+    typeChip: "company",
+    primary: {
+      name: "Lovable",
+      contact: "In portfolio · Q4 thesis",
+      status: { label: "new round", tone: "ok" },
+      fields: [
+        ["raised", "$15M Series A"],
+        ["lead", "Accel"],
+      ],
+      eventsLabel: "Derived from recent events:",
+      events: [
+        {
+          age: "2h",
+          summary: "Closed a $15M Series A led by Accel",
+          source: "Crunchbase",
+        },
+        {
+          age: "3h",
+          summary: "v0, Bolt, Replit Agent posted product signals",
+          source: "Market feed",
+        },
+        {
+          age: "5h",
+          summary: "Adam K. flagged a warm ex-Replit intro",
+          source: "Network",
+        },
+      ],
+    },
+    others: [
+      { name: "Cursor", status: { label: "watchlist", tone: "ok" } },
+      { name: "Vercel", status: { label: "portfolio", tone: "ok" } },
+    ],
+    moreLabel: "+ 309 more companies",
+  },
+  goal: {
+    label: "Standing goal · portfolio + watchlist",
+    schedule: "daily · 8:00",
+    prompt:
+      "Pull new funding, launches, and market signals on portfolio and watchlist companies, and surface what to track next.",
+    footer: "Runs unattended · posts to #deal-flow.",
+  },
+  firesLabel: "new signal · Lovable",
+  chat: {
+    id: "market-deal-flow",
+    tabLabel: "Deal flow",
+    title: "Deal sourcing",
+    description: "The agent surfaces new funding and signals each morning.",
+    settingsLabel: "",
+    chatLabel: "",
+    botName: "VC agent",
+    botInitial: "V",
+    botColor: "#36c5ab",
+    messages: [
+      {
+        role: "bot",
+        text: "Lovable just closed a $15M Series A led by Accel, already in your portfolio. Also worth tracking: v0, Bolt, and Replit Agent in the same prompt-to-app space.\n\nWant an IC memo?",
+        buttons: [{ label: "Draft IC memo", action: "link" }],
+      },
+      { role: "user", text: "Yes, and add the warm intro." },
+      {
+        role: "bot",
+        text: "Drafted. Adam K. (ex-Replit) is a warm path in. Posted it to #deal-flow.",
+        buttons: [{ label: "See the memo", action: "link" }],
+      },
+    ],
+  },
+  docs: {
+    connectors: "/sdks/connectors/",
+    memory: "/getting-started/memory/",
+    watchers: "/getting-started/memory/#watchers",
+  },
+};
+
+// Legal contract review. Grounded in the `legal` showcase watcher.
+export const LEGAL_LOOP: LoopData = {
+  connectors: {
+    items: [
+      toConnector("DocuSign"),
+      toConnector("Drive"),
+      toConnector("Gmail"),
+      toConnector("Jira"),
+    ],
+    moreLabel: "50+ more",
+    caption:
+      "Reuse a prebuilt connector, or point Lobu at any database you use.",
+    codeLine: "Your agent writes code to parse contracts and clauses.",
+    countLabel: "1,860 events",
+  },
+  buildsLabel: "builds contracts",
+  memory: {
+    label: "Live contract memory · 26 contracts",
+    typeChip: "contract",
+    primary: {
+      name: "Redwood NDA v2",
+      contact: "Counterparty · Redwood",
+      status: { label: "counsel review", tone: "risk" },
+      fields: [
+        ["clauses", "9 · §7 flagged"],
+        ["stage", "pre-signature"],
+      ],
+      eventsLabel: "Derived from recent events:",
+      events: [
+        {
+          age: "2h",
+          summary: "Uploaded NDA v2 for signature review",
+          source: "Redwood",
+        },
+        {
+          age: "2h",
+          summary: "Updated indemnity language in §7",
+          source: "DocuSign",
+        },
+        {
+          age: "1h",
+          summary: "Lena needs a readout before the call",
+          source: "Slack",
+        },
+      ],
+    },
+    others: [
+      { name: "Acme MSA", status: { label: "clear", tone: "ok" } },
+      { name: "Globex DPA", status: { label: "clear", tone: "ok" } },
+    ],
+    moreLabel: "+ 24 more contracts",
+  },
+  goal: {
+    label: "Standing goal · every new contract",
+    schedule: "on new contract",
+    prompt:
+      "Review new contracts for risk, flag clauses that need counsel approval, and file a review ticket.",
+    footer: "Runs unattended · files to #legal-reviews.",
+  },
+  firesLabel: "flagged · Redwood NDA",
+  chat: {
+    id: "legal-review",
+    tabLabel: "Contract review",
+    title: "Contract review",
+    description: "The agent flags risky clauses before you countersign.",
+    settingsLabel: "",
+    chatLabel: "",
+    botName: "Legal agent",
+    botInitial: "L",
+    botColor: "#36c5ab",
+    messages: [
+      {
+        role: "bot",
+        text: "Heads up: Redwood NDA §7 has uncapped indemnity, the same pattern that blocked the Acme NDA in September. It needs counsel sign-off before you countersign.\n\nWant me to file a review ticket?",
+        buttons: [{ label: "File review ticket", action: "link" }],
+      },
+      { role: "user", text: "Yes, assign it to Priya." },
+      {
+        role: "bot",
+        text: "Filed REV-88 with Priya and linked §7 to the Redwood record. Posted to #legal-reviews.",
+        buttons: [{ label: "See the review", action: "link" }],
+      },
+    ],
+  },
+  docs: {
+    connectors: "/sdks/connectors/",
+    memory: "/getting-started/memory/",
+    watchers: "/getting-started/memory/#watchers",
+  },
+};
+
+// Finance reconciliation. Grounded in the `finance` showcase watcher.
+export const FINANCE_LOOP: LoopData = {
+  connectors: {
+    items: [
+      toConnector("Stripe"),
+      toConnector("NetSuite"),
+      toConnector("Snowflake"),
+      toConnector("Postgres"),
+    ],
+    moreLabel: "50+ more",
+    caption:
+      "Reuse a prebuilt connector, or point Lobu at any database you use.",
+    codeLine: "Your agent writes code to reconcile any ledger.",
+    countLabel: "9,300 events",
+  },
+  buildsLabel: "builds accounts",
+  memory: {
+    label: "Live finance memory · 40 accounts",
+    typeChip: "account",
+    primary: {
+      name: "Account 4100",
+      contact: "Merchant · STR-44",
+      status: { label: "variance", tone: "risk" },
+      fields: [
+        ["balance", "$187,420"],
+        ["variance", "$12,480"],
+      ],
+      eventsLabel: "Derived from recent events:",
+      events: [
+        {
+          age: "9m",
+          summary: "Opened with a $12,480 variance",
+          source: "NetSuite",
+        },
+        {
+          age: "7m",
+          summary: "3 refunds settled after the cutoff",
+          source: "Stripe",
+        },
+        {
+          age: "4m",
+          summary: "Month-end reconciliation note due",
+          source: "Close checklist",
+        },
+      ],
+    },
+    others: [
+      { name: "Account 4000", status: { label: "reconciled", tone: "ok" } },
+      { name: "Account 5200", status: { label: "reconciled", tone: "ok" } },
+    ],
+    moreLabel: "+ 38 more accounts",
+  },
+  goal: {
+    label: "Standing goal · every ledger account",
+    schedule: "daily · 7:00",
+    prompt:
+      "Reconcile payment sources against the ledger, explain any variances, and prep the reconciliation note.",
+    footer: "Runs unattended · posts to #finance-digest.",
+  },
+  firesLabel: "variance · Account 4100",
+  chat: {
+    id: "finance-recon",
+    tabLabel: "Reconciliation",
+    title: "Reconciliation",
+    description: "The agent explains variances and preps the month-end note.",
+    settingsLabel: "",
+    chatLabel: "",
+    botName: "Finance agent",
+    botInitial: "F",
+    botColor: "#36c5ab",
+    messages: [
+      {
+        role: "bot",
+        text: "The 4100 variance traces to merchant STR-44, the same 3-day settlement lag we saw in September, $12,480 net.\n\nWant me to draft the month-end note?",
+        buttons: [{ label: "Draft the note", action: "link" }],
+      },
+      { role: "user", text: "Yes, ready it for sign-off." },
+      {
+        role: "bot",
+        text: "Drafted and ready for your sign-off. Posted to #finance-digest.",
+        buttons: [{ label: "See the note", action: "link" }],
+      },
+    ],
+  },
+  docs: {
+    connectors: "/sdks/connectors/",
+    memory: "/getting-started/memory/",
+    watchers: "/getting-started/memory/#watchers",
+  },
+};
+
+// Exec / board summaries. Grounded in the `leadership` showcase watcher.
+export const LEADERSHIP_LOOP: LoopData = {
+  connectors: {
+    items: [toConnector("Notion"), toConnector("Drive"), toConnector("Gmail")],
+    moreLabel: "50+ more",
+    caption:
+      "Reuse a prebuilt connector, or point Lobu at any database you use.",
+    codeLine: "Your agent writes code to read memos and minutes.",
+    countLabel: "live feed",
+  },
+  buildsLabel: "builds decisions",
+  memory: {
+    label: "Live decision memory · 11 memos",
+    typeChip: "decision",
+    primary: {
+      name: "Board memo Q4",
+      contact: "Owner · Priya",
+      status: { label: "action needed", tone: "risk" },
+      fields: [
+        ["approved", "Series A bridge"],
+        ["blocked", "Frankfurt lease"],
+      ],
+      eventsLabel: "Derived from recent events:",
+      events: [
+        {
+          age: "1h",
+          summary: "Board memo Q4 posted to the exec workspace",
+          source: "Notion",
+        },
+        {
+          age: "1h",
+          summary: "Bridge approved, hiring freeze reaffirmed",
+          source: "Board notes",
+        },
+        {
+          age: "55m",
+          summary: "Frankfurt lease counter due Apr 25",
+          source: "Slack",
+        },
+      ],
+    },
+    others: [
+      { name: "Board memo Q3", status: { label: "closed", tone: "ok" } },
+      { name: "Offsite plan", status: { label: "approved", tone: "ok" } },
+    ],
+    moreLabel: "+ 9 more memos",
+  },
+  goal: {
+    label: "Standing goal · every board memo",
+    schedule: "on new memo",
+    prompt:
+      "Summarize new board memos: what was approved, what is blocked, and who owns each next action.",
+    footer: "Runs unattended · posts to #exec-digest.",
+  },
+  firesLabel: "new memo · Board Q4",
+  chat: {
+    id: "leadership-digest",
+    tabLabel: "Board digest",
+    title: "Board digest",
+    description: "The agent turns board memos into owners and next actions.",
+    settingsLabel: "",
+    chatLabel: "",
+    botName: "Chief of staff",
+    botInitial: "C",
+    botColor: "#36c5ab",
+    messages: [
+      {
+        role: "bot",
+        text: "Board approved the $4M Series A bridge and the Q1 hiring freeze. Blocked: the Frankfurt lease, pending legal diligence.\n\nWant the exec digest with owners?",
+        buttons: [{ label: "Draft the digest", action: "link" }],
+      },
+      { role: "user", text: "Yes, and flag Priya's deadline." },
+      {
+        role: "bot",
+        text: "Drafted. Priya owns the Frankfurt counter, due Fri Apr 25. Posted to #exec-digest.",
+        buttons: [{ label: "See the digest", action: "link" }],
+      },
+    ],
+  },
+  docs: {
+    connectors: "/sdks/connectors/",
+    memory: "/getting-started/memory/",
+    watchers: "/getting-started/memory/#watchers",
+  },
+};
+
+// Community member matchmaking. Grounded in the `agent-community` watcher.
+export const COMMUNITY_LOOP: LoopData = {
+  connectors: {
+    items: [
+      toConnector("GitHub"),
+      toConnector("LinkedIn"),
+      toConnector("Notion"),
+    ],
+    moreLabel: "50+ more",
+    caption:
+      "Reuse a prebuilt connector, or point Lobu at any database you use.",
+    codeLine: "Your agent writes code to pull profiles and launches.",
+    countLabel: "live feed",
+  },
+  buildsLabel: "builds members",
+  memory: {
+    label: "Live member memory · 315 members",
+    typeChip: "member",
+    primary: {
+      name: "Sarah",
+      contact: "Needs · embeddings, MCP",
+      status: { label: "wants intros", tone: "ok" },
+      fields: [
+        ["topics", "embeddings · MCP"],
+        ["matches", "Devon · Mira"],
+      ],
+      eventsLabel: "Derived from recent events:",
+      events: [
+        {
+          age: "15m",
+          summary: "Asked for two intros in embeddings infra",
+          source: "Sarah",
+        },
+        {
+          age: "9m",
+          summary: "Devon shipped an embeddings eval harness",
+          source: "GitHub",
+        },
+        {
+          age: "3m",
+          summary: "Mira posted an MCP auth breakdown",
+          source: "Community feed",
+        },
+      ],
+    },
+    others: [
+      { name: "Devon Lin", status: { label: "open to intros", tone: "ok" } },
+      { name: "Mira Sato", status: { label: "active", tone: "ok" } },
+    ],
+    moreLabel: "+ 312 more members",
+  },
+  goal: {
+    label: "Standing goal · every member + launch",
+    schedule: "every 15 min",
+    prompt:
+      "Match community members to new launches and posts in their space, and draft intro messages for the best two matches.",
+    footer: "Runs unattended · posts to #community-matches.",
+  },
+  firesLabel: "matched · Sarah",
+  chat: {
+    id: "community-matches",
+    tabLabel: "Matchmaking",
+    title: "Member matchmaking",
+    description: "The agent matches members and drafts the intros.",
+    settingsLabel: "",
+    chatLabel: "",
+    botName: "Community agent",
+    botInitial: "C",
+    botColor: "#36c5ab",
+    messages: [
+      {
+        role: "bot",
+        text: "Top matches for Sarah this week: Devon Lin (shipped a similar embeddings eval harness) and Mira Sato (deep MCP work).\n\nWant me to draft intros to both?",
+        buttons: [{ label: "Draft intros", action: "link" }],
+      },
+      { role: "user", text: "Yes, reference Devon's repo." },
+      {
+        role: "bot",
+        text: "Drafted both, referencing Devon's repo and Mira's post. Queued in your outbox.",
+        buttons: [{ label: "See the intros", action: "link" }],
+      },
+    ],
+  },
+  docs: {
+    connectors: "/sdks/connectors/",
+    memory: "/getting-started/memory/",
+    watchers: "/getting-started/memory/#watchers",
+  },
+};
+
+// Delivery / rollout tracking. Authored from the `delivery` watcher data.
+// Not a featured /for page yet — kept ready for when it ships.
+export const DELIVERY_LOOP: LoopData = {
+  connectors: {
+    items: [
+      toConnector("Linear"),
+      toConnector("Datadog"),
+      toConnector("GitHub"),
+      toConnector("Slack"),
+    ],
+    moreLabel: "50+ more",
+    caption:
+      "Reuse a prebuilt connector, or point Lobu at any database you use.",
+    codeLine: "Your agent writes code to pull rollout and error data.",
+    countLabel: "5,100 events",
+  },
+  buildsLabel: "builds projects",
+  memory: {
+    label: "Live delivery memory · 14 projects",
+    typeChip: "project",
+    primary: {
+      name: "Phoenix rollout",
+      contact: "Owner · Lena (backend)",
+      status: { label: "blocked", tone: "risk" },
+      fields: [
+        ["progress", "72% · 28 shards"],
+        ["blocker", "shard-14"],
+      ],
+      eventsLabel: "Derived from recent events:",
+      events: [
+        {
+          age: "30m",
+          summary: "Marked 72% complete, 28 shards pending",
+          source: "Linear",
+        },
+        {
+          age: "25m",
+          summary: "shard-14 DB timeouts since 03:14",
+          source: "Datadog",
+        },
+        {
+          age: "20m",
+          summary: "Rahul wants an escalation draft ready",
+          source: "Slack",
+        },
+      ],
+    },
+    others: [
+      { name: "Apollo", status: { label: "shipped", tone: "ok" } },
+      { name: "Orion", status: { label: "on track", tone: "ok" } },
+    ],
+    moreLabel: "+ 11 more projects",
+  },
+  goal: {
+    label: "Standing goal · active rollouts",
+    schedule: "weekdays · 8:00",
+    prompt:
+      "Give me the Monday Phoenix rollout update with blockers, owners, and the next escalation.",
+    footer: "Runs unattended · posts to #delivery-standup.",
+  },
+  firesLabel: "blocked · Phoenix",
+  chat: {
+    id: "delivery-standup",
+    tabLabel: "Rollout",
+    title: "Rollout status",
+    description:
+      "The agent flags blockers with owners and the next escalation.",
+    settingsLabel: "",
+    chatLabel: "",
+    botName: "Delivery agent",
+    botInitial: "D",
+    botColor: "#36c5ab",
+    messages: [
+      {
+        role: "bot",
+        text: "Phoenix is blocked on shard-14, the same pattern as the Apollo rollout. Lena owns the backend fix.\n\nWant an escalation draft for Rahul?",
+        buttons: [{ label: "Draft escalation", action: "link" }],
+      },
+      { role: "user", text: "Yes, send if it's not cleared by Tuesday." },
+      {
+        role: "bot",
+        text: "Drafted. Queued to Rahul if shard-14 isn't cleared by end of day Tuesday. Posted to #delivery-standup.",
+        buttons: [{ label: "See the draft", action: "link" }],
+      },
+    ],
+  },
+  docs: {
+    connectors: "/sdks/connectors/",
+    memory: "/getting-started/memory/",
+    watchers: "/getting-started/memory/#watchers",
+  },
+};
+
+// E-commerce subscription ops. Authored from the `ecommerce` watcher data.
+// Not a featured /for page yet — kept ready for when it ships.
+export const ECOMMERCE_LOOP: LoopData = {
+  connectors: {
+    items: [
+      toConnector("Shopify"),
+      toConnector("Stripe"),
+      toConnector("Zendesk"),
+      toConnector("Gmail"),
+    ],
+    moreLabel: "50+ more",
+    caption:
+      "Reuse a prebuilt connector, or point Lobu at any database you use.",
+    codeLine: "Your agent writes code to drive any storefront.",
+    countLabel: "12,400 events",
+  },
+  buildsLabel: "builds customers",
+  memory: {
+    label: "Live customer memory · 1,243 customers",
+    typeChip: "customer",
+    primary: {
+      name: "Emma K",
+      contact: "Plan · monthly $20/mo",
+      status: { label: "change request", tone: "ok" },
+      fields: [
+        ["next ship", "Apr 3"],
+        ["cancel risk", "low"],
+      ],
+      eventsLabel: "Derived from recent events:",
+      events: [
+        {
+          age: "5m",
+          summary: "Asked to switch to annual, skip next box",
+          source: "Customer DM",
+        },
+        {
+          age: "4m",
+          summary: "Next shipment scheduled for Apr 3",
+          source: "Shopify",
+        },
+        {
+          age: "2m",
+          summary: "Last cancel attempt was in the Aug window",
+          source: "Retention log",
+        },
+      ],
+    },
+    others: [
+      { name: "Liam T", status: { label: "active", tone: "ok" } },
+      { name: "Noah P", status: { label: "active", tone: "ok" } },
+    ],
+    moreLabel: "+ 1,240 more customers",
+  },
+  goal: {
+    label: "Standing goal · every subscription request",
+    schedule: "on new request",
+    prompt:
+      "Switch Emma's subscription from monthly to annual and skip next month's delivery.",
+    footer: "Runs unattended · replies in the customer DM.",
+  },
+  firesLabel: "request · Emma K",
+  chat: {
+    id: "ecommerce-subs",
+    tabLabel: "Subscriptions",
+    title: "Subscription change",
+    description: "The agent handles subscription changes with your approval.",
+    settingsLabel: "",
+    chatLabel: "",
+    botName: "Store agent",
+    botInitial: "S",
+    botColor: "#36c5ab",
+    messages: [
+      {
+        role: "bot",
+        text: "Emma wants to move monthly to annual and skip April's box. Annual is $199/yr (saves $48), and she's low cancel-risk.\n\nMake the change?",
+        buttons: [{ label: "Make the change", action: "link" }],
+      },
+      { role: "user", text: "Yes, and confirm by email." },
+      {
+        role: "bot",
+        text: "Switched to annual and skipped April; next delivery May 3. Confirmation email queued.",
+        buttons: [{ label: "See the order", action: "link" }],
+      },
+    ],
+  },
+  docs: {
+    connectors: "/sdks/connectors/",
+    memory: "/getting-started/memory/",
+    watchers: "/getting-started/memory/#watchers",
+  },
+};
+
+// Hand-authored loops, keyed by the showcase id each /for/<slug> page resolves
+// to. The six featured verticals render today; delivery + ecommerce are
+// authored and ready but have no /for page yet. loopForUseCase falls back to
+// SALES_LOOP for any unknown slug.
+const USE_CASE_LOOPS: Record<string, LoopData> = {
+  sales: SALES_LOOP,
+  market: MARKET_LOOP,
+  legal: LEGAL_LOOP,
+  finance: FINANCE_LOOP,
+  leadership: LEADERSHIP_LOOP,
+  "agent-community": COMMUNITY_LOOP,
+  delivery: DELIVERY_LOOP,
+  ecommerce: ECOMMERCE_LOOP,
+};
+
+/** The authored loop for a /for/<slug> page, or null to use the fallback. */
+export function loopForUseCase(slug?: string): LoopData | null {
+  if (!slug) return null;
+  return USE_CASE_LOOPS[slug] ?? null;
+}
+
+/** Homepage wrapper: the canonical renewal-risk loop. */
+export function ProactiveLoop() {
+  return <MemoryLoop data={SALES_LOOP} />;
 }

--- a/packages/landing/src/components/SampleChat.tsx
+++ b/packages/landing/src/components/SampleChat.tsx
@@ -195,6 +195,8 @@ interface SampleChatProps {
   /** Custom content for the message area. Overrides useCase messages. */
   children?: preact.ComponentChildren;
   onButtonHover?: (hovering: boolean) => void;
+  /** Extra classes for the outer window (e.g. `h-full` to fill a grid cell). */
+  class?: string;
 }
 
 export function SampleChat({
@@ -205,6 +207,7 @@ export function SampleChat({
   theme = TELEGRAM_THEME,
   children,
   onButtonHover,
+  class: cls = "",
 }: SampleChatProps) {
   const name = botName ?? useCase?.botName ?? "Bot";
   const initial = botInitial ?? useCase?.botInitial ?? "B";
@@ -241,7 +244,7 @@ export function SampleChat({
 
   return (
     <div
-      class="rounded-[14px] overflow-hidden w-full"
+      class={`flex flex-col rounded-[14px] overflow-hidden w-full ${cls}`}
       style={{
         border: `1px solid ${theme.border}`,
         backgroundColor: theme.bg,
@@ -307,7 +310,7 @@ export function SampleChat({
 
       {/* Messages */}
       <div
-        class="flex flex-col px-2 pb-2.5 pt-1"
+        class="flex flex-1 flex-col px-2 pb-2.5 pt-1"
         style={{ backgroundColor: theme.bg }}
       >
         {children ?? (useCase ? renderDefaultMessages(useCase.messages) : null)}


### PR DESCRIPTION
## What

Replaces the bespoke homepage `ProactiveLoop` **and** the legacy per-vertical `ArchitectureDiagram` with one data-driven `MemoryLoop({ data })`. Same design everywhere, parameterized per use case.

- **Sources** card: brand logos when known (simple-icons), text chips otherwise; an "agent writes code" line; Connector SDK doc link.
- **Memory** card: compact entity (contact in header, plan/renewal inline), event timeline, collapsed peers, Memory & entities doc link.
- **Standing goal** card: prompt + schedule + Watchers doc link.
- **Chat** fills its cell; platform + API logo strip pinned beneath, linking to each platform's docs.
- Hand-authored, data-grounded loops for the six featured verticals (sales, market, legal, finance, leadership, agent-community); delivery + ecommerce authored but not yet a `/for` page.
- Headline reworked to **"Catch what you'd miss."**
- "Run anywhere" cards link to deployment docs (Quickstart / Docker / Kubernetes / Lobu Cloud).
- "See what ships" reframed **for engineers**; code shown in full (removed the internal scroll).

## Verification

- `bun run build` clean; pre-commit `tsc --noEmit` passes.
- Verified live in Chrome: homepage, /for/{market,legal,agent-community,finance,leadership}, and the "see what ships" section.
- Mobile (<768px) is single-column by construction (grid-cols-1 + rotating arrow) but not visually emulated in this environment — worth a real-device check.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1357"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784308543&installation_id=136316292&pr_number=1357&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1357&signature=a411413ff1a4aab8f4e9b0d2024a3e2674f768a73713ac3585cb2fa211d8056c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added use-case-specific demonstration loops for Sales, Market, Legal, Finance, Leadership, Community, Delivery, and Ecommerce scenarios.
  * Enhanced "Run anywhere" section with quick-access deployment links (Quickstart, Docker, Kubernetes, Lobu Cloud).
  * Improved content showcase layout with better visual hierarchy and event timeline visualization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->