### PR TITLE
feat(landing): rebuild operating-loop as centered timeline + polish visuals

### DIFF
--- a/packages/landing/src/components/LandingPage.tsx
+++ b/packages/landing/src/components/LandingPage.tsx
@@ -1,4 +1,5 @@
 import { useState } from "preact/hooks";
+import { siClaude, siCursor } from "simple-icons";
 import connectorsManifest from "../generated/connectors.json";
 import snippetsManifest from "../generated/landing-snippets.json";
 import { GITHUB_CONNECTORS_BLOB_URL, GITHUB_EXAMPLES_URL } from "../lib/urls";
@@ -219,7 +220,7 @@ function Hero() {
         </p>
         <div class="hero-rise hero-rise-3 mt-8 flex flex-wrap items-center justify-center gap-3">
           <button
-            class="inline-flex items-center gap-2 rounded-lg px-5 py-3 text-[14.5px] font-semibold transition-transform hover:-translate-y-px"
+            class="inline-flex items-center gap-3 rounded-xl px-5 py-3 text-[14.5px] font-semibold shadow-sm transition-opacity hover:opacity-90"
             onClick={() => copy("prompt")}
             style={{
               backgroundColor: "var(--color-page-text)",
@@ -227,7 +228,12 @@ function Hero() {
             }}
             type="button"
           >
-            <CopyIcon copied={copied === "prompt"} />
+            <span class="flex items-center gap-2.5" aria-hidden="true">
+              <ClaudeMark />
+              <ChatGptMark />
+              <CursorMark />
+              <OpenCodeMark />
+            </span>
             <span>
               {copied === "prompt"
                 ? "Copied, paste into your agent"
@@ -235,7 +241,7 @@ function Hero() {
             </span>
           </button>
           <ScheduleCallButton
-            class="inline-flex items-center gap-2 rounded-lg border px-5 py-3 text-[14.5px] font-semibold transition-colors hover:bg-[var(--color-page-surface-dim)]"
+            class="inline-flex items-center gap-2 rounded-xl border px-5 py-3 text-[14.5px] font-semibold transition-colors hover:bg-[var(--color-page-surface-dim)]"
             style={{
               borderColor: "var(--color-page-border)",
               color: "var(--color-page-text)",
@@ -250,9 +256,7 @@ function Hero() {
           class="hero-rise hero-rise-4 mt-3.5 text-[13px]"
           style={{ color: "var(--color-page-text-muted)" }}
         >
-          Paste into <span class="font-mono">claude code</span>,{" "}
-          <span class="font-mono">cursor</span>, or{" "}
-          <span class="font-mono">opencode</span> to scaffold a project.
+          Paste into your coding agent to scaffold a project.
         </p>
         <p
           class="hero-rise hero-rise-4 mt-2.5 flex flex-wrap items-center justify-center gap-2 text-[13px]"
@@ -276,6 +280,70 @@ function Hero() {
         </p>
       </Container>
     </section>
+  );
+}
+
+function ClaudeMark() {
+  return (
+    <svg
+      aria-hidden="true"
+      class="h-[18px] w-[18px] shrink-0"
+      fill="currentColor"
+      viewBox="0 0 24 24"
+    >
+      <title>Claude</title>
+      <path d={siClaude.path} />
+    </svg>
+  );
+}
+
+/* Official OpenAI mark (ChatGPT / Codex) — not in simple-icons, so the
+   canonical single-path SVG is inlined. Rendered with currentColor. */
+function ChatGptMark() {
+  return (
+    <svg
+      aria-hidden="true"
+      class="h-[18px] w-[18px] shrink-0"
+      fill="currentColor"
+      viewBox="0 0 24 24"
+    >
+      <title>ChatGPT</title>
+      <path d="M22.2819 9.8211a5.9847 5.9847 0 0 0-.5157-4.9108 6.0462 6.0462 0 0 0-6.5098-2.9A6.0651 6.0651 0 0 0 4.9807 4.1818a5.9847 5.9847 0 0 0-3.9977 2.9 6.0462 6.0462 0 0 0 .7427 7.0966 5.98 5.98 0 0 0 .511 4.9107 6.051 6.051 0 0 0 6.5146 2.9001A5.9847 5.9847 0 0 0 13.2599 24a6.0557 6.0557 0 0 0 5.7718-4.2058 5.9894 5.9894 0 0 0 3.9977-2.9001 6.0557 6.0557 0 0 0-.7475-7.0729zm-9.022 12.6081a4.4755 4.4755 0 0 1-2.8764-1.0408l.1419-.0804 4.7783-2.7582a.7948.7948 0 0 0 .3927-.6813v-6.7369l2.02 1.1686a.071.071 0 0 1 .038.052v5.5826a4.504 4.504 0 0 1-4.4945 4.4944zm-9.6607-4.1254a4.4708 4.4708 0 0 1-.5346-3.0137l.142.0852 4.783 2.7582a.7712.7712 0 0 0 .7800 0l5.8428-3.3685v2.3324a.0804.0804 0 0 1-.0332.0615L9.74 19.9502a4.4992 4.4992 0 0 1-6.1408-1.6464zM2.3408 7.8956a4.485 4.485 0 0 1 2.3655-1.9728V11.6a.7664.7664 0 0 0 .3879.6765l5.8144 3.3543-2.0201 1.1685a.0757.0757 0 0 1-.071 0l-4.8303-2.7865A4.504 4.504 0 0 1 2.3408 7.872zm16.5963 3.8558L13.1038 8.364 15.1192 7.2a.0757.0757 0 0 1 .071 0l4.8303 2.7913a4.4944 4.4944 0 0 1-.6765 8.1042v-5.6772a.79.79 0 0 0-.407-.667zm2.0107-3.0231l-.142-.0852-4.7735-2.7818a.7759.7759 0 0 0-.7852 0L9.409 9.2297V6.8974a.0662.0662 0 0 1 .0284-.0615l4.8303-2.7866a4.4992 4.4992 0 0 1 6.6802 4.66zM8.3065 12.869l-2.02-1.1638a.0804.0804 0 0 1-.038-.0567V6.0742a4.4992 4.4992 0 0 1 7.3757-3.4537l-.142.0804L8.704 5.459a.7948.7948 0 0 0-.3927.6813zm1.0976-2.3654l2.602-1.4998 2.6069 1.4998v2.9994l-2.5974 1.4997-2.6067-1.4997Z" />
+    </svg>
+  );
+}
+
+function CursorMark() {
+  return (
+    <svg
+      aria-hidden="true"
+      class="h-[18px] w-[18px] shrink-0"
+      fill="currentColor"
+      viewBox="0 0 24 24"
+    >
+      <title>Cursor</title>
+      <path d={siCursor.path} />
+    </svg>
+  );
+}
+
+/* OpenCode has no brand mark in simple-icons; a clean </> glyph stands in. */
+function OpenCodeMark() {
+  return (
+    <svg
+      aria-hidden="true"
+      class="h-[17px] w-[18px] shrink-0"
+      fill="none"
+      stroke="currentColor"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      stroke-width="2.4"
+      viewBox="0 0 24 24"
+    >
+      <title>OpenCode</title>
+      <polyline points="9 8 4 12 9 16" />
+      <polyline points="15 8 20 12 15 16" />
+    </svg>
   );
 }
 
@@ -337,9 +405,9 @@ function BrowseExamplesSection() {
     <section class="py-16">
       <Container>
         <div class="mb-10 text-center">
-          <Eyebrow>Solutions</Eyebrow>
+          <Eyebrow>Examples</Eyebrow>
           <SectionHeading className="mx-auto">
-            See what agents can watch.
+            Explore agent workflows.
           </SectionHeading>
           <p
             class="mx-auto mt-3 max-w-[42rem] text-[14.5px]"

--- a/packages/landing/src/components/Nav.tsx
+++ b/packages/landing/src/components/Nav.tsx
@@ -282,7 +282,8 @@ export function Nav({ currentPath: _currentPath = "/" }: NavProps) {
       <nav
         class="sticky top-0 z-40 px-4 sm:px-8"
         style={{
-          backgroundColor: "var(--color-page-bg-overlay)",
+          backgroundColor:
+            "color-mix(in oklch, var(--color-page-bg) 68%, transparent)",
           backdropFilter: "blur(12px)",
         }}
       >

--- a/packages/landing/src/components/ProactiveLoop.tsx
+++ b/packages/landing/src/components/ProactiveLoop.tsx
@@ -29,6 +29,7 @@ import {
   siStripe,
   siZendesk,
 } from "simple-icons";
+import { GITHUB_EXAMPLES_URL } from "../lib/urls";
 import type { UseCase } from "../types";
 import { messagingChannels } from "./platforms";
 import { SampleChat, SLACK_THEME } from "./SampleChat";
@@ -55,9 +56,9 @@ export interface LoopData {
     items: LoopConnector[];
     moreLabel?: string;
     caption: string;
-    /** The differentiator line (rendered after a `</>` glyph). */
+    /** Optional differentiator line (rendered after a `</>` glyph). */
     codeLine: string;
-    /** e.g. "1,204 events" */
+    /** e.g. "Watching changes across every source" */
     countLabel: string;
   };
   buildsLabel: string;
@@ -85,6 +86,7 @@ export interface LoopData {
   };
   firesLabel: string;
   chat: UseCase;
+  sourceHref?: string;
   docs: { connectors: string; memory: string; watchers: string };
 }
 
@@ -126,8 +128,8 @@ export function toConnector(label: string): LoopConnector {
 function Eyebrow({ children }: { children: preact.ComponentChildren }) {
   return (
     <span
-      class="font-mono text-[10.5px] uppercase tracking-[0.16em]"
-      style={{ color: "var(--color-page-text-muted)" }}
+      class="text-[11px] font-bold uppercase tracking-[0.08em]"
+      style={{ color: "var(--color-page-text)" }}
     >
       {children}
     </span>
@@ -143,10 +145,13 @@ function Card({
 }) {
   return (
     <div
-      class={`flex w-full flex-col gap-2.5 rounded-[14px] border p-4 ${cls}`}
+      class={`flex w-full flex-col gap-2.5 rounded-2xl border p-5 ${cls}`}
       style={{
         borderColor: "var(--color-page-border)",
-        backgroundColor: "var(--color-page-bg)",
+        backgroundImage:
+          "linear-gradient(to bottom, var(--color-page-bg-elevated), var(--color-page-bg))",
+        boxShadow:
+          "0 1px 2px rgb(0 0 0 / 0.04), 0 14px 34px -18px rgb(0 0 0 / 0.14)",
       }}
     >
       {children}
@@ -175,6 +180,81 @@ function DocLink({ href, children }: { href: string; children: string }) {
       {children}
       <span aria-hidden="true">↗</span>
     </a>
+  );
+}
+
+function SourceLink({ href }: { href: string }) {
+  return (
+    <a
+      class="mt-3 inline-flex items-center gap-1 text-[12px] font-semibold transition-colors hover:text-[color:var(--color-tg-accent)]"
+      href={href}
+      rel="noopener noreferrer"
+      style={{ color: "var(--color-page-text-muted)" }}
+      target="_blank"
+    >
+      See source <span aria-hidden="true">↗</span>
+    </a>
+  );
+}
+
+function StepText({
+  title,
+  children,
+}: {
+  title: string;
+  children: preact.ComponentChildren;
+}) {
+  return (
+    <div class="max-w-[360px] px-1 md:px-0">
+      <h3
+        class="text-[1.2rem] font-bold leading-tight tracking-tight"
+        style={{ color: "var(--color-page-text)" }}
+      >
+        {title}
+      </h3>
+      <p
+        class="mt-2 text-[13.5px] leading-relaxed"
+        style={{ color: "var(--color-page-text-muted)" }}
+      >
+        {children}
+      </p>
+    </div>
+  );
+}
+
+function TimelineStep({
+  number,
+  title,
+  children,
+  visual,
+}: {
+  number: number;
+  title: string;
+  children: preact.ComponentChildren;
+  visual: preact.ComponentChildren;
+  last?: boolean;
+}) {
+  return (
+    <div class="relative z-10 grid w-full grid-cols-[34px_minmax(0,1fr)] items-start gap-x-4 md:grid-cols-[40px_minmax(250px,300px)_minmax(0,460px)] md:items-center md:gap-x-6 md:justify-center">
+      <div class="relative col-start-1 row-span-2 self-stretch md:row-span-1 md:row-start-1">
+        <span
+          class="absolute left-1/2 top-1 flex h-7 w-7 -translate-x-1/2 items-center justify-center rounded-full border text-[12px] font-bold md:top-1/2 md:-translate-y-1/2"
+          style={{
+            borderColor: ACCENT,
+            color: ACCENT,
+            backgroundColor: "var(--color-page-bg)",
+          }}
+        >
+          {number}
+        </span>
+      </div>
+      <div class="col-start-2 md:row-start-1">
+        <StepText title={title}>{children}</StepText>
+      </div>
+      <div class="col-start-2 mt-3 min-w-0 md:col-start-3 md:row-start-1 md:mt-0">
+        {visual}
+      </div>
+    </div>
   );
 }
 
@@ -243,69 +323,6 @@ function ChatChannels({ class: cls = "" }: { class?: string }) {
   );
 }
 
-// Vertical "this becomes that" connector (SOURCES->MEMORY, GOAL->CHAT).
-function DownArrow({
-  label,
-  class: cls = "",
-}: {
-  label: string;
-  class?: string;
-}) {
-  return (
-    <div class={`flex flex-col items-center gap-1 ${cls}`}>
-      <svg width="12" height="18" viewBox="0 0 12 18" aria-hidden="true">
-        <title>{label}</title>
-        <path
-          d="M6 0 V13 M2.5 9.5 L6 13 L9.5 9.5"
-          stroke={ACCENT}
-          stroke-width="1.5"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          fill="none"
-        />
-      </svg>
-      <span
-        class="text-center font-mono text-[10px] uppercase tracking-[0.12em]"
-        style={{ color: "var(--color-page-text-muted)" }}
-      >
-        {label}
-      </span>
-    </div>
-  );
-}
-
-// Horizontal "the goal watches the memory" connector. Rotates to vertical on
-// mobile so the four blocks stack into a single readable column.
-function WatchesArrow({ class: cls = "" }: { class?: string }) {
-  return (
-    <div class={`flex flex-col items-center justify-center gap-1.5 ${cls}`}>
-      <span
-        class="font-mono text-[10.5px] uppercase tracking-[0.12em]"
-        style={{ color: "var(--color-page-text-muted)" }}
-      >
-        watches
-      </span>
-      <svg
-        class="rotate-90 md:rotate-0"
-        width="40"
-        height="12"
-        viewBox="0 0 40 12"
-        aria-hidden="true"
-      >
-        <title>watches</title>
-        <path
-          d="M0 6 H32 M28 2.5 L33 6 L28 9.5"
-          stroke={ACCENT}
-          stroke-width="1.5"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          fill="none"
-        />
-      </svg>
-    </div>
-  );
-}
-
 // --- Blocks ------------------------------------------------------------------
 
 function SourcesCardImpl({
@@ -319,20 +336,6 @@ function SourcesCardImpl({
 }) {
   return (
     <Card class={cls}>
-      <div class="flex items-center justify-between">
-        <Eyebrow>Connectors</Eyebrow>
-        <span
-          class="inline-flex items-center gap-1.5 font-mono text-[10.5px]"
-          style={{ color: OK }}
-        >
-          <span
-            class="inline-block h-1.5 w-1.5 rounded-full"
-            style={{ backgroundColor: OK }}
-          />
-          live
-        </span>
-      </div>
-
       <div class="flex flex-wrap items-center gap-x-4 gap-y-2.5">
         {connectors.items.map((c) =>
           c.icon ? (
@@ -353,21 +356,23 @@ function SourcesCardImpl({
         {connectors.caption}
       </div>
 
-      <div class="flex items-center gap-2">
-        <span
-          class="font-mono text-[12px]"
-          style={{ color: ACCENT }}
-          aria-hidden="true"
-        >
-          &lt;/&gt;
-        </span>
-        <span
-          class="text-[12px] leading-snug"
-          style={{ color: "var(--color-page-text)" }}
-        >
-          {connectors.codeLine}
-        </span>
-      </div>
+      {connectors.codeLine ? (
+        <div class="flex items-center gap-2">
+          <span
+            class="font-mono text-[12px]"
+            style={{ color: ACCENT }}
+            aria-hidden="true"
+          >
+            &lt;/&gt;
+          </span>
+          <span
+            class="text-[12px] leading-snug"
+            style={{ color: "var(--color-page-text)" }}
+          >
+            {connectors.codeLine}
+          </span>
+        </div>
+      ) : null}
 
       <div
         class="mt-auto flex items-center justify-between gap-3 border-t pt-2"
@@ -377,7 +382,6 @@ function SourcesCardImpl({
           class="text-[11.5px]"
           style={{ color: "var(--color-page-text-muted)" }}
         >
-          One event stream ·{" "}
           <span style={{ color: "var(--color-page-text)" }}>
             {connectors.countLabel}
           </span>
@@ -392,27 +396,33 @@ function MemoryCard({
   memory,
   docsHref,
   class: cls = "",
+  scanning = false,
 }: {
   memory: LoopData["memory"];
   docsHref: string;
   class?: string;
+  scanning?: boolean;
 }) {
   const { primary } = memory;
   return (
     <Card class={cls}>
-      <div class="flex items-center justify-between">
-        <Eyebrow>{memory.label}</Eyebrow>
-        <span
-          class="rounded-md border px-2 py-0.5 font-mono text-[10.5px]"
-          style={{ borderColor: "var(--color-page-border)", color: ACCENT }}
-        >
-          {memory.typeChip}
-        </span>
-      </div>
+      {memory.label || memory.typeChip ? (
+        <div class="flex items-center justify-between">
+          {memory.label ? <Eyebrow>{memory.label}</Eyebrow> : <span />}
+          {memory.typeChip ? (
+            <span
+              class="rounded-md border px-2 py-0.5 font-mono text-[10.5px]"
+              style={{ borderColor: "var(--color-page-border)", color: ACCENT }}
+            >
+              {memory.typeChip}
+            </span>
+          ) : null}
+        </div>
+      ) : null}
 
       {/* Expanded: the record that drifted */}
       <div
-        class="rounded-[10px] border"
+        class={`rounded-[10px] border ${scanning ? "memory-scan-shell" : ""}`}
         style={{
           borderColor: `${statusColor(primary.status.tone)}55`,
           backgroundColor: "var(--color-page-surface)",
@@ -545,33 +555,6 @@ function GoalCard({
 }) {
   return (
     <Card class={cls}>
-      <div class="flex items-center justify-between">
-        <Eyebrow>{goal.label}</Eyebrow>
-        <span
-          class="inline-flex items-center gap-1.5 rounded-md border px-2 py-0.5 font-mono text-[10.5px]"
-          style={{ borderColor: "var(--color-page-border)", color: ACCENT }}
-        >
-          <svg width="11" height="11" viewBox="0 0 12 12" aria-hidden="true">
-            <title>schedule</title>
-            <circle
-              cx="6"
-              cy="6"
-              r="5"
-              fill="none"
-              stroke={ACCENT}
-              stroke-width="1.3"
-            />
-            <path
-              d="M6 3.2 V6 L8 7.2"
-              fill="none"
-              stroke={ACCENT}
-              stroke-width="1.3"
-              stroke-linecap="round"
-            />
-          </svg>
-          {goal.schedule}
-        </span>
-      </div>
       <p
         class="text-[12.5px] leading-relaxed"
         style={{ color: "var(--color-page-text)" }}
@@ -586,7 +569,7 @@ function GoalCard({
           class="text-[11.5px]"
           style={{ color: "var(--color-page-text-muted)" }}
         >
-          {goal.footer}
+          {goal.footer || `Runs ${goal.schedule}`}
         </span>
         <DocLink href={docsHref}>Watchers</DocLink>
       </div>
@@ -619,51 +602,90 @@ export function MemoryLoop({ data }: { data: LoopData }) {
           >
             {data.heading.subtitle}
           </p>
+          {data.sourceHref ? <SourceLink href={data.sourceHref} /> : null}
         </div>
       ) : null}
 
-      {/*
-        Explicit grid placement (md:col-start / md:row-start) decouples DOM order
-        from desktop layout: the DOM order below reads top-to-bottom on mobile
-        (sources -> memory -> goal -> chat), while on desktop the cards snap into
-        a 2x2 with arrows between. Row stretch keeps each row's two cards equal
-        height, so the columns stay level.
-      */}
-      <div class="grid w-full grid-cols-1 justify-items-center gap-y-2 md:grid-cols-[minmax(0,460px)_auto_minmax(0,460px)] md:justify-center md:gap-x-5">
-        <SourcesCardImpl
-          connectors={data.connectors}
-          docsHref={data.docs.connectors}
-          class="md:col-start-1 md:row-start-1"
-        />
-        <DownArrow
-          label={data.buildsLabel}
-          class="md:col-start-1 md:row-start-2 md:self-center"
-        />
-        <MemoryCard
-          memory={data.memory}
-          docsHref={data.docs.memory}
-          class="md:col-start-1 md:row-start-3"
-        />
-
-        <WatchesArrow class="md:col-start-2 md:row-start-1 md:self-center" />
-
-        <GoalCard
-          goal={data.goal}
-          docsHref={data.docs.watchers}
-          class="md:col-start-3 md:row-start-1"
-        />
-        <DownArrow
-          label={data.firesLabel}
-          class="md:col-start-3 md:row-start-2 md:self-center"
-        />
-        <div
-          class="flex w-full flex-col gap-3 md:col-start-3 md:row-start-3"
-          style={{ minWidth: "280px", maxWidth: "460px" }}
+      <div class="relative flex w-full max-w-[1040px] flex-col gap-10 md:gap-14">
+        <TimelineStep
+          number={1}
+          title="Connect your data"
+          visual={
+            <SourcesCardImpl
+              connectors={data.connectors}
+              docsHref={data.docs.connectors}
+            />
+          }
         >
-          <SampleChat useCase={data.chat} theme={SLACK_THEME} class="flex-1" />
-          <ChatChannels />
-        </div>
+          Pick the systems it can read. Lobu turns those updates into live customer memory.
+        </TimelineStep>
+
+        <TimelineStep
+          number={2}
+          title="Define the goal"
+          visual={<GoalCard goal={data.goal} docsHref={data.docs.watchers} />}
+        >
+          Tell it what to watch for and when to ask before acting.
+        </TimelineStep>
+
+        <TimelineStep
+          number={3}
+          title="Your agent works autonomously"
+          visual={<MemoryCard memory={data.memory} docsHref={data.docs.memory} scanning />}
+        >
+          It scans memory on schedule, spots the account at risk, and keeps the evidence attached.
+        </TimelineStep>
+
+        <TimelineStep
+          number={4}
+          title="You review and approve"
+          last
+          visual={
+            <div class="flex w-full flex-col gap-3" style={{ minWidth: "280px" }}>
+              <SampleChat useCase={data.chat} theme={SLACK_THEME} />
+              <ChatChannels />
+            </div>
+          }
+        >
+          You can edit the draft, send it, or leave it.
+        </TimelineStep>
       </div>
+      {!data.heading && data.sourceHref ? <SourceLink href={data.sourceHref} /> : null}
+      <style>{`
+        @keyframes lobu-memory-scan {
+          0%, 12% { transform: translateY(-120%); opacity: 0; }
+          22% { opacity: 1; }
+          72% { opacity: 1; }
+          88%, 100% { transform: translateY(245%); opacity: 0; }
+        }
+        .memory-scan-shell {
+          position: relative;
+          overflow: hidden;
+        }
+        .memory-scan-shell::after {
+          content: "";
+          position: absolute;
+          inset: 0;
+          height: 44%;
+          pointer-events: none;
+          background: linear-gradient(
+            to bottom,
+            rgba(54, 197, 171, 0),
+            rgba(54, 197, 171, 0.08),
+            rgba(249, 115, 22, 0.16),
+            rgba(54, 197, 171, 0)
+          );
+          border-top: 1px solid rgba(249, 115, 22, 0.45);
+          animation: lobu-memory-scan 4.8s ease-in-out infinite;
+        }
+        @media (prefers-reduced-motion: reduce) {
+          .memory-scan-shell::after {
+            animation: none;
+            opacity: 0.35;
+            transform: translateY(95%);
+          }
+        }
+      `}</style>
     </div>
   );
 }
@@ -675,27 +697,30 @@ export const SALES_LOOP: LoopData = {
     eyebrow: "Why Lobu",
     title: "Catch what you'd miss.",
     subtitle:
-      "Lobu turns every source into one typed record, watches all of them against your goals, and drafts the next step the moment something drifts.",
+      "Connect your data. Set a goal. Lobu watches for changes and prepares the next step.",
   },
   connectors: {
     items: [
       { label: "HubSpot", icon: siHubspot },
       { label: "Stripe", icon: siStripe },
       { label: "Zendesk", icon: siZendesk },
+      { label: "Gmail", icon: siGmail },
+      { label: "Drive", icon: siGoogledrive },
+      { label: "GitHub", icon: siGithub },
       { label: "Notion", icon: siNotion },
       { label: "Snowflake", icon: siSnowflake },
       { label: "Postgres", icon: siPostgresql },
     ],
     moreLabel: "50+ more",
     caption:
-      "Reuse a prebuilt connector, or point Lobu at any database you use.",
-    codeLine: "Your agent writes code to bring in live data.",
-    countLabel: "1,204 events",
+      "Use existing connectors, or let your agent write code to connect any data.",
+    codeLine: "",
+    countLabel: "Watching changes across every source",
   },
-  buildsLabel: "builds profiles",
+  buildsLabel: "builds customer memory",
   memory: {
-    label: "Live company memory · 19 accounts",
-    typeChip: "account",
+    label: "",
+    typeChip: "",
     primary: {
       name: "Acme Corp",
       contact: "Jordan Lee, VP Eng",
@@ -717,23 +742,22 @@ export const SALES_LOOP: LoopData = {
           source: "Product",
         },
         { age: "9d", summary: "Renewal date set to Jun 30", source: "CRM" },
-        { age: "12d", summary: '"Champion left the company"', source: "Slack" },
       ],
     },
     others: [
       { name: "Globex Inc", status: { label: "healthy", tone: "ok" } },
-      { name: "Initech", status: { label: "healthy", tone: "ok" } },
     ],
-    moreLabel: "+ 16 more accounts",
+    moreLabel: "+ 17 more customers",
   },
   goal: {
-    label: "Standing goal · all 19 accounts",
+    label: "Define goal",
     schedule: "every weekday · 9:00",
     prompt:
-      "Watch every account for churn risk. When health turns at-risk within 30 days of renewal, draft a CSM check-in and ask me to approve.",
-    footer: "Runs unattended · asks before it sends.",
+      "Watch every account for churn risk. If renewal is within 30 days and health drops, draft a CSM check-in for approval.",
+    footer: "",
   },
-  firesLabel: "fired on Acme Corp",
+  firesLabel: "posts in Slack",
+  sourceHref: `${GITHUB_EXAMPLES_URL}/sales`,
   chat: {
     id: "proactive-renewal",
     tabLabel: "Renewal risk",

--- a/packages/landing/src/components/SampleChat.tsx
+++ b/packages/landing/src/components/SampleChat.tsx
@@ -244,14 +244,13 @@ export function SampleChat({
 
   return (
     <div
-      class={`flex flex-col rounded-[14px] overflow-hidden w-full ${cls}`}
+      class={`flex flex-col rounded-2xl overflow-hidden w-full ${cls}`}
       style={{
         border: `1px solid ${theme.border}`,
         backgroundColor: theme.bg,
         fontFamily:
           '-apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif',
         minWidth: "280px",
-        maxWidth: "460px",
       }}
     >
       {/* Header */}

--- a/packages/landing/src/globals.css
+++ b/packages/landing/src/globals.css
@@ -55,6 +55,7 @@ button {
 }
 
 html {
+  overflow-x: hidden;
   background-color: var(--color-page-bg);
   color: var(--color-page-text);
   font-family: "Manrope", ui-sans-serif, system-ui, -apple-system, sans-serif;
@@ -72,6 +73,47 @@ h3,
 .font-display {
   font-family: "Manrope", ui-sans-serif, system-ui, -apple-system, sans-serif;
   letter-spacing: -0.02em;
+}
+
+/* Subtle homepage depth: a neutral top wash plus a signal grid that fades out. */
+.landing-backdrop {
+  background-image: linear-gradient(
+    to bottom,
+    color-mix(in oklch, var(--color-page-bg-elevated) 72%, var(--color-page-bg)),
+    var(--color-page-bg) 34rem
+  );
+  background-position: center top;
+  position: relative;
+}
+
+.landing-backdrop::after {
+  content: "";
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 48rem;
+  pointer-events: none;
+  z-index: 0;
+  background-image:
+    linear-gradient(var(--color-page-grid) 1px, transparent 1px),
+    linear-gradient(90deg, var(--color-page-grid) 1px, transparent 1px);
+  background-size: 76px 76px;
+  background-position: center top;
+  -webkit-mask-image: linear-gradient(
+    to bottom,
+    rgba(0, 0, 0, 0.6) 0,
+    rgba(0, 0, 0, 0.32) 14rem,
+    rgba(0, 0, 0, 0.1) 30rem,
+    transparent 46rem
+  );
+  mask-image: linear-gradient(
+    to bottom,
+    rgba(0, 0, 0, 0.6) 0,
+    rgba(0, 0, 0, 0.32) 14rem,
+    rgba(0, 0, 0, 0.1) 30rem,
+    transparent 46rem
+  );
 }
 
 /* Vercel-style edge lines */

--- a/packages/landing/src/pages/index.astro
+++ b/packages/landing/src/pages/index.astro
@@ -11,7 +11,7 @@ const latestPosts = await getLatestPosts(3);
 
 <BaseLayout>
   <div
-    class="min-h-screen grid-lines overflow-x-hidden"
+    class="landing-backdrop min-h-screen grid-lines"
     style={{
       backgroundColor: "var(--color-page-bg)",
       "--grid-max-w": "72rem",


### PR DESCRIPTION
## Summary

- Rebuilt the operating-loop section as a clean 4-step vertical timeline (1. Connect your data, 2. Define the goal, 3. Your agent works autonomously, 4. You review and approve) with number rail, explanation, and visual card per row.
- All four visual cards now match the chat widget width at 460px.
- Cards get elevated treatment: rounded-2xl, subtle gradient background, soft shadow for depth.
- Whole row group centered on the page (`md:justify-center`).
- Fixed sticky nav (moved `overflow-x: hidden` off the backdrop wrapper to `<html>` so sticky works).
- Background: subtle top-fading grid on its own pseudo-element (no more full-page grid or "too AI" glows).
- Hero CTA: high-contrast theme-inverting button (dark in light, white in dark) with real agent brand marks (Claude, ChatGPT, Cursor, OpenCode) using currentColor.
- Copy polish: simpler section subtitle, connector caption, goal footer; "Solutions" → "Examples".

## Changes
- `ProactiveLoop.tsx`: timeline refactor, card styling, animation (with reduced-motion fallback), data tweaks.
- `LandingPage.tsx`: CTA with logos, helper text, examples heading.
- `Nav.tsx`, `globals.css`, `index.astro`: sticky + backdrop fixes.
- `SampleChat.tsx`: radius + width unification.

Build passes, no new biome errors introduced.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1360"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784341515&installation_id=136316292&pr_number=1360&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1360&signature=0d9cecccb7f9bdbafae5e7f4bc936e95a64912425713903731f1864a70febb22"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added brand marks for AI agents (Claude, ChatGPT, Cursor) to the hero section
  * Redesigned operating loop from grid layout to sequential timeline view
  * Updated Examples section heading and messaging

* **Style**
  * Refined navigation background styling
  * Enhanced backdrop with gradient and grid pattern effects
  * Adjusted sample chat container styling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->