### PR TITLE
fix(auth): scope settings query token to exact SSE route only

### DIFF
--- a/packages/server/src/gateway/auth/__tests__/api-auth-middleware-query-token.test.ts
+++ b/packages/server/src/gateway/auth/__tests__/api-auth-middleware-query-token.test.ts
@@ -2,7 +2,8 @@
  * `allowSettingsQueryToken` on createApiAuthMiddleware — the embedded panel's
  * agent SSE stream uses EventSource (no Authorization header) and authenticates
  * with an encrypted `?token=` ticket. The gate must accept that ticket, but
- * ONLY for GET, so a leaked URL ticket can't drive headerless mutations.
+ * ONLY for the opted-in GET stream route, so a leaked URL ticket can't drive
+ * headerless mutations or unrelated GET routes.
  */
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { encrypt } from "@lobu/core";
@@ -31,14 +32,15 @@ function app() {
     "*",
     createApiAuthMiddleware({
       allowSettingsSession: true,
-      allowSettingsQueryToken: true,
+      allowSettingsQueryToken: (c) => c.req.path === "/r/events",
       allowWorkerToken: false,
     }),
   );
   const handler = (c: { get: (k: string) => { userId?: string } | undefined; json: (o: unknown) => Response }) =>
     c.json({ userId: c.get("authContext")?.userId ?? null });
   a.get("/r", handler as never);
-  a.post("/r", handler as never);
+  a.get("/r/events", handler as never);
+  a.post("/r/events", handler as never);
   return a;
 }
 
@@ -49,28 +51,33 @@ const qTicket = (userId: string, exp?: number) =>
   `?token=${encodeURIComponent(ticket(userId, exp))}`;
 
 describe("createApiAuthMiddleware allowSettingsQueryToken", () => {
-  test("GET with a valid ?token= ticket authenticates (the EventSource path)", async () => {
-    const res = await app().request(`/r${qTicket("user-1")}`, { method: "GET" });
+  test("GET with a valid ?token= ticket authenticates on the opted-in EventSource path", async () => {
+    const res = await app().request(`/r/events${qTicket("user-1")}`, { method: "GET" });
     expect(res.status).toBe(200);
     expect((await res.json()) as { userId: string }).toEqual({ userId: "user-1" });
   });
 
   test("POST with the same valid ticket is rejected — mutations need a header", async () => {
-    const res = await app().request(`/r${qTicket("user-1")}`, { method: "POST" });
+    const res = await app().request(`/r/events${qTicket("user-1")}`, { method: "POST" });
+    expect(res.status).toBe(401);
+  });
+
+  test("GET with the same valid ticket on an unrelated route is rejected", async () => {
+    const res = await app().request(`/r${qTicket("user-1")}`, { method: "GET" });
     expect(res.status).toBe(401);
   });
 
   test("GET with no auth at all → 401", async () => {
-    expect((await app().request("/r", { method: "GET" })).status).toBe(401);
+    expect((await app().request("/r/events", { method: "GET" })).status).toBe(401);
   });
 
   test("GET with a tampered/garbage ticket → 401", async () => {
-    const res = await app().request("/r?token=not-a-real-ticket", { method: "GET" });
+    const res = await app().request("/r/events?token=not-a-real-ticket", { method: "GET" });
     expect(res.status).toBe(401);
   });
 
   test("GET with an expired ticket → 401", async () => {
-    const res = await app().request(`/r${qTicket("user-1", Date.now() - 1000)}`, {
+    const res = await app().request(`/r/events${qTicket("user-1", Date.now() - 1000)}`, {
       method: "GET",
     });
     expect(res.status).toBe(401);

--- a/packages/server/src/gateway/auth/api-auth-middleware.ts
+++ b/packages/server/src/gateway/auth/api-auth-middleware.ts
@@ -51,14 +51,12 @@ export function createApiAuthMiddleware(opts: {
   allowSettingsSession?: boolean;
   /**
    * Also accept the settings session via a `?token=` query param (an encrypted,
-   * short-lived ticket) — but only for **GET** requests. Needed for the agent
-   * SSE stream: the embedded panel opens it with EventSource (always a GET),
-   * which can't send an Authorization header; without this, a header-less ticket
-   * request is 401'd here before the route's own ownership check runs. Scoped to
-   * GET so a leaked URL ticket can't drive headerless mutations (create / send /
-   * delete / approve) — those still require an Authorization header.
+   * short-lived ticket) for specific **GET** requests. Needed for EventSource
+   * streams: the embedded panel can't send an Authorization header, so the
+   * caller must opt in only for the exact stream route that needs it. Mutations
+   * and unrelated GET routes still require cookie/header auth.
    */
-  allowSettingsQueryToken?: boolean;
+  allowSettingsQueryToken?: (c: Context) => boolean;
 }) {
   const revokedTokens = getRevokedTokenStore();
 
@@ -78,15 +76,17 @@ export function createApiAuthMiddleware(opts: {
 
   return async (c: Context, next: Next) => {
     // 1. Try settings session cookie when explicitly allowed (and, when opted
-    //    in, a `?token=` ticket for header-less EventSource SSE clients).
-    //    verifySettingsSession now enforces jti revocation internally.
+    //    in for this route, a `?token=` ticket for header-less EventSource SSE
+    //    clients). verifySettingsSession now enforces jti revocation internally.
     if (opts.allowSettingsSession) {
-      // The `?token=` ticket is accepted only for GET (EventSource SSE);
-      // mutations always require an Authorization header.
-      const session =
-        opts.allowSettingsQueryToken && c.req.method === "GET"
-          ? await verifySettingsSessionOrToken(c, "token")
-          : await verifySettingsSession(c);
+      // The `?token=` ticket is accepted only for GET routes the caller opts
+      // into (EventSource SSE); mutations and unrelated GETs always require an
+      // Authorization header if the cookie path doesn't authenticate.
+      const allowQueryToken =
+        c.req.method === "GET" && opts.allowSettingsQueryToken?.(c) === true;
+      const session = allowQueryToken
+        ? await verifySettingsSessionOrToken(c, "token")
+        : await verifySettingsSession(c);
       if (session) {
         return runWithContext({ userId: session.userId }, c, next);
       }

--- a/packages/server/src/gateway/routes/public/agent.ts
+++ b/packages/server/src/gateway/routes/public/agent.ts
@@ -427,7 +427,10 @@ export function createAgentApi(config: AgentApiConfig): OpenAPIHono {
       allowSettingsSession: true,
       // The embedded panel opens the SSE stream with EventSource (no
       // Authorization header), authenticating via a short-lived ?token= ticket.
-      allowSettingsQueryToken: true,
+      // Scope that query-token path to the SSE route only; other GETs under the
+      // agent API still require the normal cookie/header auth path.
+      allowSettingsQueryToken: (c) =>
+        /^\/api\/v1\/agents\/[^/]+\/events$/.test(c.req.path),
     })
   );
 


### PR DESCRIPTION
Narrow  from blanket  (any GET) to a predicate that only permits the agent events SSE stream. Mutations and other GETs continue to require cookie/header auth. Includes test updates.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1361"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784341578&installation_id=136316292&pr_number=1361&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1361&signature=7804b5bc9b700bc48d6cef5ba0a8a405866593e96de2b8c253f6daee46d79bda"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->