### PR TITLE
fix: pre-release onboarding fixes (initdb locale, auto-apply org, HN sync budget)

### DIFF
--- a/packages/cli/src/__tests__/dev.test.ts
+++ b/packages/cli/src/__tests__/dev.test.ts
@@ -315,8 +315,12 @@ describe("shouldAutoApplyLocalProject", () => {
 
 describe("autoApplyLocalProject — org is pinned to the local-init slug (#1366)", () => {
   test("passes the local org slug through to applyCommand as opts.org", async () => {
-    const calls: Array<{ cwd: string; yes: boolean; url: string; org?: string }> =
-      [];
+    const calls: Array<{
+      cwd: string;
+      yes: boolean;
+      url: string;
+      org?: string;
+    }> = [];
     await autoApplyLocalProject(
       "/proj",
       "http://localhost:8788",

--- a/packages/cli/src/__tests__/dev.test.ts
+++ b/packages/cli/src/__tests__/dev.test.ts
@@ -11,6 +11,7 @@ import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import {
+  autoApplyLocalProject,
   findEnclosingMonorepoRoot,
   isSharedDatabaseUrl,
   resolveBackendBundle,
@@ -309,5 +310,49 @@ describe("shouldAutoApplyLocalProject", () => {
         hasLobuConfig: false,
       })
     ).toBe(false);
+  });
+});
+
+describe("autoApplyLocalProject — org is pinned to the local-init slug (#1366)", () => {
+  test("passes the local org slug through to applyCommand as opts.org", async () => {
+    const calls: Array<{ cwd: string; yes: boolean; url: string; org?: string }> =
+      [];
+    await autoApplyLocalProject(
+      "/proj",
+      "http://localhost:8788",
+      "local-install",
+      async (opts) => {
+        calls.push(opts);
+      }
+    );
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toMatchObject({
+      cwd: "/proj",
+      yes: true,
+      url: "http://localhost:8788",
+      org: "local-install",
+    });
+  });
+
+  test("omits org when /api/local-init returned no slug (falls back to config)", async () => {
+    const calls: Array<{ org?: string }> = [];
+    await autoApplyLocalProject(
+      "/proj",
+      "http://localhost:8788",
+      undefined,
+      async (opts) => {
+        calls.push(opts);
+      }
+    );
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.org).toBeUndefined();
+  });
+
+  test("swallows apply failures so a bad apply never crashes the running server", async () => {
+    await expect(
+      autoApplyLocalProject("/proj", "http://localhost:8788", "x", async () => {
+        throw new Error("boom");
+      })
+    ).resolves.toBeUndefined();
   });
 });

--- a/packages/cli/src/commands/dev.ts
+++ b/packages/cli/src/commands/dev.ts
@@ -452,13 +452,21 @@ export function shouldAutoApplyLocalProject(opts: {
  * `lobu run`'s module-load path — see the dynamic-import allow-list in
  * AGENTS.md.
  */
-async function autoApplyLocalProject(
+export async function autoApplyLocalProject(
   cwd: string,
   gatewayUrl: string,
-  localOrgSlug?: string
+  localOrgSlug?: string,
+  // Test seam — defaults to the lazily-imported applyCommand.
+  applyImpl?: (opts: {
+    cwd: string;
+    yes: boolean;
+    url: string;
+    org?: string;
+  }) => Promise<unknown>
 ): Promise<void> {
   try {
-    const { applyCommand } = await import("./_lib/apply/apply-cmd.js");
+    const applyCommand =
+      applyImpl ?? (await import("./_lib/apply/apply-cmd.js")).applyCommand;
     // Pin the apply to the embedded server's URL. `resolveApiTarget` matches
     // the `local` context by URL — and refuses to send any other context's
     // credentials to a different URL — so this can only ever target the local

--- a/packages/cli/src/commands/dev.ts
+++ b/packages/cli/src/commands/dev.ts
@@ -380,7 +380,7 @@ export async function devCommand(
   // persists the session as the `local` CLI context so `lobu chat -c local`
   // works without a separate `lobu login`.
   void announceLocalSignIn(gatewayUrl, mode === "embedded").then(
-    (localContextReady) => {
+    ({ ready: localContextReady, localOrgSlug }) => {
       // Once the `local` context is confirmed registered + active, push the
       // project's lobu.config.ts into the embedded DB so the scaffolded agent is
       // usable via `lobu chat -c local …` with no separate `lobu apply`.
@@ -394,7 +394,7 @@ export async function devCommand(
           hasLobuConfig: existsSync(join(cwd, "lobu.config.ts")),
         })
       ) {
-        return autoApplyLocalProject(cwd, gatewayUrl);
+        return autoApplyLocalProject(cwd, gatewayUrl, localOrgSlug);
       }
     }
   );
@@ -454,15 +454,24 @@ export function shouldAutoApplyLocalProject(opts: {
  */
 async function autoApplyLocalProject(
   cwd: string,
-  gatewayUrl: string
+  gatewayUrl: string,
+  localOrgSlug?: string
 ): Promise<void> {
   try {
     const { applyCommand } = await import("./_lib/apply/apply-cmd.js");
     // Pin the apply to the embedded server's URL. `resolveApiTarget` matches
     // the `local` context by URL — and refuses to send any other context's
     // credentials to a different URL — so this can only ever target the local
-    // server, never a cloud/prod org.
-    await applyCommand({ cwd, yes: true, url: gatewayUrl });
+    // server, never a cloud/prod org. Also pin the ORG to the embedded server's
+    // bootstrap org (from /api/local-init) so a `defineConfig({ org })` naming a
+    // cloud org can't redirect this local apply to a slug that doesn't exist
+    // here — that previously 404'd and silently applied nothing.
+    await applyCommand({
+      cwd,
+      yes: true,
+      url: gatewayUrl,
+      ...(localOrgSlug ? { org: localOrgSlug } : {}),
+    });
   } catch (err) {
     console.warn(
       chalk.dim(
@@ -556,23 +565,23 @@ export function resolveBackendBundle(
 async function announceLocalSignIn(
   gatewayUrl: string,
   embedded: boolean
-): Promise<boolean> {
+): Promise<{ ready: boolean; localOrgSlug?: string }> {
   // Poll briefly so the announce lands AFTER the server's own startup
   // banner without racing it.
   const reachable = await waitForServerReachable(gatewayUrl);
-  if (!reachable) return false;
+  if (!reachable) return { ready: false };
 
   // Only the embedded path seeds the bootstrap user → /local-init will refuse
   // on an external-Postgres deployment with real signups. Skip the network
   // call entirely in that case to keep the banner quiet.
-  if (!embedded) return false;
+  if (!embedded) return { ready: false };
 
   try {
     const res = await fetch(`${gatewayUrl}/api/local-init`, {
       method: "POST",
       headers: { "X-Lobu-Client": "lobu-run" },
     });
-    if (!res.ok) return false;
+    if (!res.ok) return { ready: false };
     const body = (await res.json()) as {
       device_token?: string;
       session_token?: string;
@@ -586,7 +595,7 @@ async function announceLocalSignIn(
     // same session token is passed to the browser deep-link URL so the SPA
     // hook reaches /api/exchange-token → Better Auth session cookie.
     const cliToken = body.session_token ?? body.device_token;
-    if (!cliToken) return false;
+    if (!cliToken) return { ready: false };
 
     const contextName = "local";
     await addContext(contextName, gatewayUrl);
@@ -638,11 +647,13 @@ async function announceLocalSignIn(
     );
     console.log();
     // The `local` context is registered, credentialed, and active — safe to
-    // auto-apply the project against it.
-    return true;
+    // auto-apply the project against it. Return the bootstrap org slug so the
+    // auto-apply can target the local org explicitly (a config `org:` for a
+    // cloud org must not redirect the local apply — that 404s silently).
+    return { ready: true, localOrgSlug: orgSlug };
   } catch {
     // Swallow — the banner is best-effort.
-    return false;
+    return { ready: false };
   }
 }
 

--- a/packages/connectors/src/__tests__/hackernews-budget.test.ts
+++ b/packages/connectors/src/__tests__/hackernews-budget.test.ts
@@ -1,0 +1,71 @@
+// #1365: the stories sync must not stall on a broad query with blocked egress.
+// We import the REAL SDK (no process-global mock.module — that leaks across the
+// run) and stub only global.fetch: one Algolia page of high-engagement stories,
+// then content fetches that always fail (egress down). The connector must
+// short-circuit enrichment after a few consecutive failures instead of grinding
+// through every story at ~5s each.
+
+import { afterEach, beforeEach, expect, test } from 'bun:test';
+
+const realFetch = globalThis.fetch;
+afterEach(() => {
+  globalThis.fetch = realFetch;
+});
+
+function algoliaPage(n: number) {
+  return {
+    hits: Array.from({ length: n }, (_, i) => ({
+      objectID: String(i),
+      created_at: '2026-01-01T00:00:00Z',
+      created_at_i: 1_767_225_600,
+      author: 'someone',
+      title: `Story ${i}`,
+      url: `https://example.com/article-${i}`,
+      points: 200, // > ENGAGEMENT_THRESHOLD (50) so each is an enrichment candidate
+      num_comments: 10,
+      story_id: i,
+      _tags: ['story'],
+    })),
+    nbHits: n,
+    page: 0,
+    nbPages: 1, // single page → pagination stops immediately
+    hitsPerPage: 100,
+  };
+}
+
+let contentFetches = 0;
+beforeEach(() => {
+  contentFetches = 0;
+  globalThis.fetch = (async (input: string | URL | Request) => {
+    const url = typeof input === 'string' ? input : input.toString();
+    if (url.includes('hn.algolia.com')) {
+      return new Response(JSON.stringify(algoliaPage(20)), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    }
+    // Content enrichment fetch → simulate blocked egress (always fails).
+    contentFetches++;
+    throw new Error('network unreachable');
+  }) as typeof fetch;
+});
+
+test('stories enrichment short-circuits after consecutive egress failures', async () => {
+  const { default: HackerNewsConnector } = await import('../hackernews');
+  const connector = new HackerNewsConnector();
+  const logs: string[] = [];
+  const ctx = {
+    feedKey: 'stories',
+    config: { search_query: 'AI agents' },
+    log: (m: string) => logs.push(m),
+  };
+  // biome-ignore lint/suspicious/noExplicitAny: minimal SyncContext for unit test
+  const result = await connector.sync(ctx as any);
+
+  // All 20 stories are still returned — enrichment is best-effort.
+  expect(result.events.length).toBe(20);
+  // But we stopped fetching content after the consecutive-failure threshold (3),
+  // not after all 20 — that's the anti-stall guard.
+  expect(contentFetches).toBeLessThanOrEqual(3);
+  expect(logs.some((l) => l.includes('consecutive content fetches failed'))).toBe(true);
+}, 20_000);

--- a/packages/connectors/src/__tests__/hackernews-budget.test.ts
+++ b/packages/connectors/src/__tests__/hackernews-budget.test.ts
@@ -38,7 +38,7 @@ beforeEach(() => {
   contentFetches = 0;
   globalThis.fetch = (async (input: string | URL | Request) => {
     const url = typeof input === 'string' ? input : input.toString();
-    if (url.includes('hn.algolia.com')) {
+    if (new URL(url).hostname === 'hn.algolia.com') {
       return new Response(JSON.stringify(algoliaPage(20)), {
         status: 200,
         headers: { 'content-type': 'application/json' },
@@ -78,7 +78,7 @@ test('non-HTML/non-OK results do NOT trip the egress short-circuit', async () =>
   let nthContent = 0;
   globalThis.fetch = (async (input: string | URL | Request) => {
     const url = typeof input === 'string' ? input : input.toString();
-    if (url.includes('hn.algolia.com')) {
+    if (new URL(url).hostname === 'hn.algolia.com') {
       return new Response(JSON.stringify(algoliaPage(5)), {
         status: 200,
         headers: { 'content-type': 'application/json' },

--- a/packages/connectors/src/__tests__/hackernews-budget.test.ts
+++ b/packages/connectors/src/__tests__/hackernews-budget.test.ts
@@ -69,3 +69,43 @@ test('stories enrichment short-circuits after consecutive egress failures', asyn
   expect(contentFetches).toBeLessThanOrEqual(3);
   expect(logs.some((l) => l.includes('consecutive content fetches failed'))).toBe(true);
 }, 20_000);
+
+test('non-HTML/non-OK results do NOT trip the egress short-circuit', async () => {
+  // First three content fetches succeed at the HTTP level but return non-article
+  // content (PDF, image, 404); the fourth is a real HTML article. Egress is
+  // fine, so enrichment must continue and enrich the fourth — these are skips,
+  // not network failures.
+  let nthContent = 0;
+  globalThis.fetch = (async (input: string | URL | Request) => {
+    const url = typeof input === 'string' ? input : input.toString();
+    if (url.includes('hn.algolia.com')) {
+      return new Response(JSON.stringify(algoliaPage(5)), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    }
+    contentFetches++;
+    nthContent++;
+    if (nthContent === 1)
+      return new Response('%PDF-1.7', { status: 200, headers: { 'content-type': 'application/pdf' } });
+    if (nthContent === 2)
+      return new Response('binary', { status: 200, headers: { 'content-type': 'image/png' } });
+    if (nthContent === 3) return new Response('nope', { status: 404 });
+    // 4th: a real HTML article long enough to survive the >=100-char filter.
+    return new Response(
+      `<html><body><article><h1>Real Article</h1><p>${'lorem ipsum dolor sit amet '.repeat(20)}</p></article></body></html>`,
+      { status: 200, headers: { 'content-type': 'text/html' } }
+    );
+  }) as typeof fetch;
+
+  const { default: HackerNewsConnector } = await import('../hackernews');
+  const connector = new HackerNewsConnector();
+  // biome-ignore lint/suspicious/noExplicitAny: minimal SyncContext for unit test
+  const result = await connector.sync({ feedKey: 'stories', config: { search_query: 'x' } } as any);
+
+  // Reached the 4th fetch (would be <=3 if non-HTML wrongly tripped the guard).
+  expect(contentFetches).toBeGreaterThanOrEqual(4);
+  // The 4th story got real content; the first three did not.
+  expect(result.events[3]?.content).toBeTruthy();
+  expect(result.events[0]?.content).toBeFalsy();
+}, 20_000);

--- a/packages/connectors/src/hackernews.ts
+++ b/packages/connectors/src/hackernews.ts
@@ -235,6 +235,17 @@ export default class HackerNewsConnector extends ConnectorRuntime {
   private readonly MAX_PAGES = 50;
   private readonly PAGE_DELAY_MS = 1000;
   private readonly FETCH_DELAY_MS = 2000;
+  // Hard wall-clock budget for a single sync. A broad query (up to 50 pages ×
+  // 1s) plus per-article content enrichment (5s timeout each) could otherwise
+  // run for many minutes — or effectively never finish on a box with blocked
+  // egress where every content fetch times out. On hitting the budget we return
+  // what we have; the next scheduled run continues (the window is re-queried,
+  // the connector isn't incremental).
+  private readonly SYNC_BUDGET_MS = 4 * 60_000;
+  // Cap external content enrichment so a large result set can't burn minutes on
+  // per-article fetches, and bail once egress is clearly down.
+  private readonly MAX_CONTENT_FETCHES = 25;
+  private readonly MAX_CONSECUTIVE_FETCH_FAILURES = 3;
   private turndownService: TurndownService;
 
   constructor() {
@@ -269,8 +280,9 @@ export default class HackerNewsConnector extends ConnectorRuntime {
     const events: EventEnvelope[] = [];
     let page = 0;
     let hasMore = true;
+    const deadline = Date.now() + this.SYNC_BUDGET_MS;
 
-    while (hasMore && page < this.MAX_PAGES) {
+    while (hasMore && page < this.MAX_PAGES && Date.now() < deadline) {
       const url = isFrontPage
         ? `${this.BASE_URL}/search?tags=front_page&hitsPerPage=100&page=${page}` +
           (minScore > 0 ? `&numericFilters=${encodeURIComponent(`points>=${minScore}`)}` : '')
@@ -323,15 +335,23 @@ export default class HackerNewsConnector extends ConnectorRuntime {
 
       hasMore = data.page < data.nbPages - 1 && data.hits.length > 0;
       page++;
+      ctx.log?.(`HN: fetched page ${page} (${events.length} items so far)`);
 
       if (hasMore) {
         await sleep(this.PAGE_DELAY_MS);
       }
     }
 
-    // Enrich high-engagement stories with external content
+    if (hasMore && Date.now() >= deadline) {
+      ctx.log?.(
+        `HN: hit the ${Math.round(this.SYNC_BUDGET_MS / 1000)}s sync budget after ${page} page(s); returning ${events.length} items (next run continues)`
+      );
+    }
+
+    // Enrich high-engagement stories with external content (bounded by the
+    // remaining time budget + a fetch cap; skipped entirely if it's exhausted).
     if (contentType !== 'comment') {
-      await this.enrichStoriesWithExternalContent(events);
+      await this.enrichStoriesWithExternalContent(events, deadline, ctx);
     }
 
     return {
@@ -421,20 +441,44 @@ export default class HackerNewsConnector extends ConnectorRuntime {
   // External content enrichment
   // -------------------------------------------------------------------------
 
-  private async enrichStoriesWithExternalContent(events: EventEnvelope[]): Promise<void> {
+  private async enrichStoriesWithExternalContent(
+    events: EventEnvelope[],
+    deadline: number,
+    ctx: SyncContext
+  ): Promise<void> {
+    let fetches = 0;
+    let consecutiveFailures = 0;
     for (const event of events) {
+      if (fetches >= this.MAX_CONTENT_FETCHES) break;
+      if (Date.now() >= deadline) {
+        ctx.log?.(`HN: content-enrichment time budget reached after ${fetches} fetch(es)`);
+        break;
+      }
+
       const externalUrl = event.metadata?.external_url as string | undefined;
       const points = event.metadata?.score as number | undefined;
 
       if (!event.content && externalUrl && points != null && points >= this.ENGAGEMENT_THRESHOLD) {
+        fetches++;
         const fetched = await this.fetchExternalContent(externalUrl);
         if (fetched) {
+          consecutiveFailures = 0;
           event.content = fetched;
           event.metadata = {
             ...event.metadata,
             fetched_content: true,
             original_url: externalUrl,
           };
+        } else {
+          consecutiveFailures++;
+          // A run of failures means egress is blocked/unreachable; stop instead
+          // of burning ~5s (the fetch timeout) per remaining story.
+          if (consecutiveFailures >= this.MAX_CONSECUTIVE_FETCH_FAILURES) {
+            ctx.log?.(
+              `HN: ${consecutiveFailures} consecutive content fetches failed — skipping enrichment for the rest`
+            );
+            break;
+          }
         }
 
         await sleep(this.FETCH_DELAY_MS);

--- a/packages/connectors/src/hackernews.ts
+++ b/packages/connectors/src/hackernews.ts
@@ -460,25 +460,31 @@ export default class HackerNewsConnector extends ConnectorRuntime {
 
       if (!event.content && externalUrl && points != null && points >= this.ENGAGEMENT_THRESHOLD) {
         fetches++;
-        const fetched = await this.fetchExternalContent(externalUrl);
-        if (fetched) {
+        const res = await this.fetchExternalContent(externalUrl);
+        if (res.ok) {
           consecutiveFailures = 0;
-          event.content = fetched;
+          event.content = res.content;
           event.metadata = {
             ...event.metadata,
             fetched_content: true,
             original_url: externalUrl,
           };
-        } else {
+        } else if (res.network) {
+          // A run of genuine network/timeout failures means egress is
+          // blocked/unreachable; stop instead of burning ~5s (the fetch
+          // timeout) per remaining story.
           consecutiveFailures++;
-          // A run of failures means egress is blocked/unreachable; stop instead
-          // of burning ~5s (the fetch timeout) per remaining story.
           if (consecutiveFailures >= this.MAX_CONSECUTIVE_FETCH_FAILURES) {
             ctx.log?.(
-              `HN: ${consecutiveFailures} consecutive content fetches failed — skipping enrichment for the rest`
+              `HN: ${consecutiveFailures} consecutive content fetches failed (egress) — skipping enrichment for the rest`
             );
             break;
           }
+        } else {
+          // Non-network skip (non-HTML, non-OK, SSRF-blocked, too short) — the
+          // story just has no usable article content. Don't let it trip the
+          // egress guard, or a few PDFs/images in a row would halt enrichment.
+          consecutiveFailures = 0;
         }
 
         await sleep(this.FETCH_DELAY_MS);
@@ -486,34 +492,46 @@ export default class HackerNewsConnector extends ConnectorRuntime {
     }
   }
 
-  private async fetchExternalContent(url: string): Promise<string | null> {
+  // Returns the article markdown on success. On failure, `network` distinguishes
+  // a genuine egress failure (timeout/abort/connection — the case that stalls a
+  // sync) from a non-network skip (SSRF-blocked, non-OK, non-HTML, too short),
+  // so only real egress failures trip the consecutive-failure short-circuit.
+  private async fetchExternalContent(
+    url: string
+  ): Promise<{ ok: true; content: string } | { ok: false; network: boolean }> {
+    // SSRF guard — `url` is supplied by whoever submitted the HN story and is
+    // therefore attacker-controllable. Refuse private/internal addresses
+    // (loopback, 169.254.169.254 cloud metadata, RFC1918, etc.). Not an egress
+    // failure.
     try {
-      // SSRF guard — `url` is supplied by whoever submitted the HN story and
-      // is therefore attacker-controllable. Refuse to fetch private/internal
-      // addresses (loopback, 169.254.169.254 cloud metadata, RFC1918, etc.).
-      try {
-        validatePublicUrl(url);
-      } catch {
-        return null;
-      }
+      validatePublicUrl(url);
+    } catch {
+      return { ok: false, network: false };
+    }
 
-      const controller = new AbortController();
-      const timeoutId = setTimeout(() => controller.abort(), this.CONTENT_FETCH_TIMEOUT);
-
-      const response = await fetch(url, {
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), this.CONTENT_FETCH_TIMEOUT);
+    let response: Response;
+    try {
+      response = await fetch(url, {
         signal: controller.signal,
         headers: {
           'User-Agent': 'Mozilla/5.0 (compatible; HNBot/1.0)',
           Accept: 'text/html,application/xhtml+xml',
         },
       });
-
+    } catch {
+      // Timeout/abort/DNS/connection refused — a genuine egress failure.
+      return { ok: false, network: true };
+    } finally {
       clearTimeout(timeoutId);
+    }
 
-      if (!response.ok) return null;
+    try {
+      if (!response.ok) return { ok: false, network: false };
 
       const contentType = response.headers.get('content-type') ?? '';
-      if (!contentType.includes('text/html')) return null;
+      if (!contentType.includes('text/html')) return { ok: false, network: false };
 
       const html = await response.text();
 
@@ -548,9 +566,13 @@ export default class HackerNewsConnector extends ConnectorRuntime {
       const markdown = this.turndownService.turndown(cleanHtml);
       const trimmed = markdown.trim().substring(0, 2000);
 
-      return trimmed.length >= 100 ? trimmed : null;
+      return trimmed.length >= 100
+        ? { ok: true, content: trimmed }
+        : { ok: false, network: false };
     } catch {
-      return null;
+      // A body-read/parse error after a successful response isn't an egress
+      // outage — treat as a skip, not a network failure.
+      return { ok: false, network: false };
     }
   }
 }

--- a/packages/server/src/__tests__/embedded-pg-options.test.ts
+++ b/packages/server/src/__tests__/embedded-pg-options.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { embeddedPgOptions } from "../embedded-runtime";
+
+// #1364: embedded Postgres must initdb with an always-present locale so `lobu run`
+// boots on a minimal Linux box where the host locale (e.g. LANG=en_GB.UTF-8) is
+// set but not generated.
+describe("embeddedPgOptions", () => {
+	it("pins initdb to the C locale with UTF-8 encoding", () => {
+		const opts = embeddedPgOptions("/tmp/pgdata", 5599);
+		expect(opts.initdbFlags).toEqual(["--locale=C", "--encoding=UTF8"]);
+	});
+
+	it("passes through the data dir and port", () => {
+		const opts = embeddedPgOptions("/var/lib/lobu/pg", 6123);
+		expect(opts.databaseDir).toBe("/var/lib/lobu/pg");
+		expect(opts.port).toBe(6123);
+		expect(opts.persistent).toBe(true);
+	});
+});

--- a/packages/server/src/embedded-runtime.ts
+++ b/packages/server/src/embedded-runtime.ts
@@ -142,6 +142,14 @@ export async function startEmbeddedRuntime(): Promise<EmbeddedRuntime> {
 		password: "postgres",
 		port: pgPort,
 		persistent: true,
+		// Pin initdb to the always-present C locale with UTF-8 encoding. Otherwise
+		// initdb inherits the host locale (e.g. LANG=en_GB.UTF-8) and aborts on a
+		// minimal box where that locale isn't generated — only C/POSIX exist —
+		// killing `lobu run` on first boot. C never needs generation; the explicit
+		// UTF8 encoding keeps Unicode storage (C alone would default to SQL_ASCII).
+		// Only applied on first cluster init (guarded below), so existing clusters
+		// keep their original locale/encoding.
+		initdbFlags: ["--locale=C", "--encoding=UTF8"],
 	});
 
 	// initdb refuses a non-empty datadir; skip it when the cluster already

--- a/packages/server/src/embedded-runtime.ts
+++ b/packages/server/src/embedded-runtime.ts
@@ -108,6 +108,28 @@ function findFreePort(): Promise<number> {
 }
 
 /**
+ * Build the EmbeddedPostgres constructor options.
+ *
+ * `initdbFlags` pins the cluster to the always-present C locale with UTF-8
+ * encoding. Otherwise initdb inherits the host locale (e.g. LANG=en_GB.UTF-8)
+ * and aborts on a minimal box where that locale isn't generated — only C/POSIX
+ * exist — killing `lobu run` on first boot. C never needs generation; the
+ * explicit UTF8 encoding keeps Unicode storage (C alone would default to
+ * SQL_ASCII). initdb only runs on first cluster init (guarded by the caller), so
+ * existing clusters keep their original locale/encoding.
+ */
+export function embeddedPgOptions(databaseDir: string, port: number) {
+	return {
+		databaseDir,
+		user: "postgres",
+		password: "postgres",
+		port,
+		persistent: true,
+		initdbFlags: ["--locale=C", "--encoding=UTF8"],
+	};
+}
+
+/**
  * Spawn an embedded PostgreSQL (injecting pgvector), set process.env.DATABASE_URL
  * to its TCP URL, fork the embeddings child, and return the lifecycle hooks.
  */
@@ -136,21 +158,7 @@ export async function startEmbeddedRuntime(): Promise<EmbeddedRuntime> {
 
 	const pgPort =
 		parseInt(process.env.LOBU_PG_PORT || "", 10) || (await findFreePort());
-	const pg = new EmbeddedPostgres({
-		databaseDir: pgDataDir,
-		user: "postgres",
-		password: "postgres",
-		port: pgPort,
-		persistent: true,
-		// Pin initdb to the always-present C locale with UTF-8 encoding. Otherwise
-		// initdb inherits the host locale (e.g. LANG=en_GB.UTF-8) and aborts on a
-		// minimal box where that locale isn't generated — only C/POSIX exist —
-		// killing `lobu run` on first boot. C never needs generation; the explicit
-		// UTF8 encoding keeps Unicode storage (C alone would default to SQL_ASCII).
-		// Only applied on first cluster init (guarded below), so existing clusters
-		// keep their original locale/encoding.
-		initdbFlags: ["--locale=C", "--encoding=UTF8"],
-	});
+	const pg = new EmbeddedPostgres(embeddedPgOptions(pgDataDir, pgPort));
 
 	// initdb refuses a non-empty datadir; skip it when the cluster already
 	// exists so restarts reuse the same data instead of erroring.


### PR DESCRIPTION
Pre-12.0.0 fixes for onboarding/run robustness found while testing the copy-prompt flow on a fresh VM.

## Fixes
- **#1364 embedded Postgres initdb locale** — `embedded-runtime.ts` now passes `initdbFlags: [--locale=C, --encoding=UTF8]` so `lobu run` boots on a minimal Linux box where the host locale isn't generated. Idempotent (first-init only).
- **#1366 lobu run auto-apply silent 404** — auto-apply now pins to the embedded server's bootstrap org (from `/api/local-init`) instead of resolving the config's `org:`, so a cloud `org:` in lobu.config.ts can't make the local apply 404 and silently apply nothing.
- **#1365 Hacker News sync stall** — added a wall-clock sync budget + bounded content enrichment that bails after consecutive egress failures + `ctx.log` progress. No config-contract change. Test imports the real SDK and stubs fetch to prove the egress short-circuit.

## Not fixed here — #1368 was a false positive
The filed root cause ("PATCH /agents/:id/config endpoint missing") is wrong — the endpoint exists (agent-routes.ts:850), and the full apply path maps `defineAgent({ providers })` → settings (`map-config.ts:348`) → `patchAgentSettings` (`apply-cmd.ts:651`) → endpoint → `updateSettings`. The original 'provider didn't switch' observation was confounded by the local 403/quota mess. Updating the issue with the corrected analysis rather than shipping a speculative change to a working path.

## Validation
- Connectors suite 142/0; strict `tsc` passes (all packages build).
- HN budget test (real-SDK, fetch-stub) green.
- initdb/auto-apply are boot-path changes — see make review verdict; CI integration runs on Node 22.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1369"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784394343&installation_id=136316292&pr_number=1369&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1369&signature=715c81dc9000c606ee391b1f7791619d21cd39fd57644ef9861b6d573c39486d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * When using local sign-in, local auto-apply can now be automatically pinned to the detected organization.

* **Bug Fixes**
  * HackerNews sync now continues best-effort during outbound network/egress issues without stalling enrichment.
  * Prevents enrichment from repeatedly failing or reading non-HTML content in a way that previously could degrade sync.

* **Performance**
  * Added hard time budgeting for connector syncing and capped enrichment attempts to avoid excessive work.

* **Tests**
  * Added coverage for local auto-apply forwarding and embedded database init settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---
Fixes #1364
Fixes #1365
Fixes #1366
