### PR TITLE
fix(server): hydrate embedded Postgres SONAME symlinks at boot (#1371)

### DIFF
--- a/packages/server/src/__tests__/embedded-pg-symlinks.test.ts
+++ b/packages/server/src/__tests__/embedded-pg-symlinks.test.ts
@@ -1,0 +1,63 @@
+import { existsSync, lstatSync, mkdirSync, mkdtempSync, readlinkSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { hydrateEmbeddedPgSymlinks } from "../embedded-runtime";
+
+// #1371: the @embedded-postgres binary's SONAME symlinks (created by a postinstall
+// npm runs but bun skips) must be hydrated at boot so the bundled libs load.
+describe("hydrateEmbeddedPgSymlinks", () => {
+	const dirs: string[] = [];
+	afterEach(() => {
+		while (dirs.length) rmSync(dirs.pop()!, { recursive: true, force: true });
+	});
+
+	function fixture(): string {
+		const root = mkdtempSync(join(tmpdir(), "lobu-pgsym-"));
+		dirs.push(root);
+		const lib = join(root, "native", "lib");
+		mkdirSync(lib, { recursive: true });
+		writeFileSync(join(lib, "libicuuc.so.60.2"), "x");
+		writeFileSync(join(lib, "libpq.so.5.18"), "x");
+		writeFileSync(
+			join(root, "native", "pg-symlinks.json"),
+			JSON.stringify([
+				{ source: "native/lib/libicuuc.so.60.2", target: "native/lib/libicuuc.so.60" },
+				{ source: "native/lib/libpq.so.5.18", target: "native/lib/libpq.so.5" },
+			])
+		);
+		return root;
+	}
+
+	it("creates the missing SONAME symlinks pointing at the bundled libs", () => {
+		const root = fixture();
+		hydrateEmbeddedPgSymlinks(join(root, "native"));
+		const icu = join(root, "native", "lib", "libicuuc.so.60");
+		const pq = join(root, "native", "lib", "libpq.so.5");
+		expect(lstatSync(icu).isSymbolicLink()).toBe(true);
+		expect(readlinkSync(icu)).toBe("libicuuc.so.60.2");
+		expect(readlinkSync(pq)).toBe("libpq.so.5.18");
+	});
+
+	it("is idempotent — a second run does not throw or duplicate", () => {
+		const root = fixture();
+		hydrateEmbeddedPgSymlinks(join(root, "native"));
+		expect(() => hydrateEmbeddedPgSymlinks(join(root, "native"))).not.toThrow();
+		expect(readlinkSync(join(root, "native", "lib", "libpq.so.5"))).toBe("libpq.so.5.18");
+	});
+
+	it("leaves an already-correct symlink alone", () => {
+		const root = fixture();
+		symlinkSync("libpq.so.5.18", join(root, "native", "lib", "libpq.so.5"));
+		expect(() => hydrateEmbeddedPgSymlinks(join(root, "native"))).not.toThrow();
+		expect(readlinkSync(join(root, "native", "lib", "libpq.so.5"))).toBe("libpq.so.5.18");
+	});
+
+	it("no-ops when the manifest is absent", () => {
+		const root = mkdtempSync(join(tmpdir(), "lobu-pgsym-"));
+		dirs.push(root);
+		mkdirSync(join(root, "native"), { recursive: true });
+		expect(() => hydrateEmbeddedPgSymlinks(join(root, "native"))).not.toThrow();
+		expect(existsSync(join(root, "native", "lib"))).toBe(false);
+	});
+});

--- a/packages/server/src/embedded-runtime.ts
+++ b/packages/server/src/embedded-runtime.ts
@@ -10,11 +10,11 @@
  */
 
 import { fork } from "node:child_process";
-import { existsSync } from "node:fs";
+import { existsSync, readFileSync, symlinkSync } from "node:fs";
 import http from "node:http";
 import { createRequire } from "node:module";
 import { homedir } from "node:os";
-import { dirname, join } from "node:path";
+import { dirname, join, relative } from "node:path";
 import { fileURLToPath } from "node:url";
 import postgres from "postgres";
 import {
@@ -130,6 +130,50 @@ export function embeddedPgOptions(databaseDir: string, port: number) {
 }
 
 /**
+ * Ensure the @embedded-postgres platform binary's SONAME symlinks exist.
+ *
+ * Each `@embedded-postgres/<platform>` package ships its shared libs (ICU, libpq)
+ * under `native/lib` as versioned files (`libicuuc.so.60.2`, …) plus a
+ * `pg-symlinks.json` manifest; its `postinstall` (hydrate-symlinks) creates the
+ * SONAME symlinks (`libicuuc.so.60` → `…60.2`) that the binary's
+ * `RUNPATH=$ORIGIN/../lib` resolves. npm/npx run that postinstall, but
+ * `bun install` (no `trustedDependencies`) and some installs skip it — leaving
+ * the binary unable to load on a host without those exact old system libs
+ * (e.g. ICU 60 on modern Linux), so `lobu run` dies at initdb with
+ * "error while loading shared libraries: libicuuc.so.60". Recreate the symlinks
+ * idempotently at boot so embedded Postgres works regardless of installer.
+ */
+export function hydrateEmbeddedPgSymlinks(nativeDir: string): void {
+	const manifest = join(nativeDir, "pg-symlinks.json");
+	if (!existsSync(manifest)) return;
+	let entries: Array<{ source: string; target: string }>;
+	try {
+		entries = JSON.parse(readFileSync(manifest, "utf8"));
+	} catch {
+		return;
+	}
+	const pkgRoot = dirname(nativeDir);
+	let created = 0;
+	for (const { source, target } of entries) {
+		const targetPath = join(pkgRoot, target);
+		if (existsSync(targetPath)) continue; // already hydrated (e.g. by npm postinstall)
+		const rel = relative(dirname(targetPath), join(pkgRoot, source));
+		try {
+			symlinkSync(rel, targetPath);
+			created++;
+		} catch {
+			// best-effort — a race or read-only fs must not crash boot
+		}
+	}
+	if (created > 0) {
+		logger.info(
+			{ nativeDir, created },
+			"Hydrated embedded Postgres library symlinks"
+		);
+	}
+}
+
+/**
  * Spawn an embedded PostgreSQL (injecting pgvector), set process.env.DATABASE_URL
  * to its TCP URL, fork the embeddings child, and return the lifecycle hooks.
  */
@@ -150,11 +194,16 @@ export async function startEmbeddedRuntime(): Promise<EmbeddedRuntime> {
 	const { default: EmbeddedPostgres } = await import("embedded-postgres");
 	const { injectPgvector, resolveEmbeddedNativeDir } =
 		await importPgvectorEmbedded();
+	const nativeDir = resolveEmbeddedNativeDir();
+
+	// The bundled Postgres binary needs its SONAME symlinks in place before it can
+	// load (the postinstall that creates them is skipped by bun / some installers).
+	hydrateEmbeddedPgSymlinks(nativeDir);
 
 	// embedded-postgres bundles pg_trgm but not pgvector — inject the host
 	// platform's prebuilt vector library into the binary tree before boot
 	// (idempotent). cube + earthdistance are already in the stock binary.
-	injectPgvector(resolveEmbeddedNativeDir());
+	injectPgvector(nativeDir);
 
 	const pgPort =
 		parseInt(process.env.LOBU_PG_PORT || "", 10) || (await findFreePort());


### PR DESCRIPTION
Fixes #1371.

## Problem
On a fresh modern Linux box, `lobu run` dies at initdb: `error while loading shared libraries: libicuuc.so.60` (then `libpq.so.5`). The `@embedded-postgres/<platform>` package bundles its ICU/libpq libs under `native/lib` as versioned files (`libicuuc.so.60.2`, …) plus a `pg-symlinks.json` manifest, and the binary's `RUNPATH=$ORIGIN/../lib` expects the SONAME symlinks (`libicuuc.so.60` → `…60.2`). Those symlinks are created by a `postinstall` (hydrate-symlinks) that **npm/npx run but `bun install` (no trustedDependencies) and some installers skip** — so the bundled binary can't load (ICU 60 isn't on modern distros; Ubuntu 24.04 ships ICU 74).

Scope: affects source/bun/bunx installs. Published `npx @lobu/cli` users were already fine (npm runs the postinstall) — so this is **not a 12.0.0 regression**, but it broke `lobu run` from source / for bun-installers.

## Fix
`embedded-runtime.ts` recreates the SONAME symlinks **idempotently at boot** (using the already-resolved `resolveEmbeddedNativeDir()`), before embedded PG starts — covering every installer.

## Validation
- **Fresh Ubuntu 24.04 VM, clean box** (removed system libpq5 + libicu60 AND the symlinks): with the fix, boot logs `Hydrated embedded Postgres library symlinks … created: 14` → `Embedded PostgreSQL ready` → `lobu run` HTTP 200. Without it, initdb died on the missing libs.
- Unit tests (creates symlinks, idempotent, leaves correct alone, no-ops on missing manifest).

Found during the 12.0.0 pre-release end-to-end on a fresh Linux VM (where #1364/#1366/#1365 also validated).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1376"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784401631&installation_id=136316292&pr_number=1376&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1376&signature=786e59275e8e6a1ac1e203f2fb79040d6ebe207a57f44d9924d1e0a81c1c26a6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->