### PR TITLE
docs: restructure README, fix dead docs links, sharpen setup prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,24 +1,10 @@
 # Lobu — Multi-tenant OpenClaw for Organizations
 
-**Lobu** is an open-source multi-tenant gateway for [OpenClaw](https://github.com/openclaw/openclaw). One sandbox and filesystem per user/channel. Shared memory across contexts. Agents never see secrets.
+**Lobu** is an open-source multi-tenant gateway for [OpenClaw](https://github.com/openclaw/openclaw): one sandbox and filesystem per user/channel, shared memory across contexts, and agents that never see secrets. OpenClaw is a full agent runtime (~800k LOC) but it's [single-tenant by design](https://x.com/steipete/status/2026092642623201379) — every user shares the same filesystem and bash session. Lobu rewrites only the gateway layer (~40k LOC) to be multi-tenant and keeps OpenClaw's Pi harness untouched inside each worker.
 
-OpenClaw is a full agent runtime (~800k LOC) but it's [single-tenant by design](https://x.com/steipete/status/2026092642623201379) — every user shares the same filesystem and bash session. Lobu rewrites only the gateway layer (~40k LOC) to be multi-tenant and keeps OpenClaw's Pi harness untouched inside each worker.
-
-**Embedded mode** uses [just-bash](https://www.npmjs.com/package/just-bash) + Nix for reproducible packages. Each user gets an isolated virtual filesystem and bash session at ~50MB per instance — tested at 300 concurrent instances on a single machine, no Docker needed.
-
-Embed OpenClaw-powered agents into your product, or give your team agents without managing a separate instance per person.
+**Embedded mode** uses [just-bash](https://www.npmjs.com/package/just-bash) + Nix for reproducible packages: each user gets an isolated virtual filesystem and bash session at ~50MB per instance — tested at 300 concurrent instances on a single machine, no Docker needed. Embed OpenClaw-powered agents into your product, or give your team agents without managing a separate instance per person.
 
 https://github.com/user-attachments/assets/d72a9286-0325-4b8b-afc0-c1efe9c96f4e
-
-## Channels & API
-
-- **REST API** — programmatic agent creation, control, and state. [![API Docs](https://img.shields.io/badge/API_Docs-0096FF?style=for-the-badge&logo=readme&logoColor=white)](https://lobu.ai/reference/api-reference/)
-- **Slack** — multi-channel/DM agents with rich interactivity.
-- **Telegram** — webhook or polling bot with interactive workflows.
-- **WhatsApp** — WhatsApp Business Cloud API.
-- **Discord** — channel + DM bot support.
-- **Teams** — Microsoft Teams bot.
-- **Google Chat** — Cards v2, Workspace spaces.
 
 ## Quick Start
 
@@ -31,35 +17,7 @@ npx @lobu/cli@latest run                      # boots the stack and applies your
 npx @lobu/cli@latest chat -c local "hello"    # talk to it
 ```
 
-`lobu run` (embedded) auto-applies your `lobu.config.ts`, so the scaffolded agent is usable immediately. To use an external Postgres, set `DATABASE_URL` in `.env`; to push later config changes, run `lobu apply`.
-
-## Agent configuration
-
-Runtime configuration is managed through the web app or the same org-scoped REST API used by the CLI:
-
-```bash
-npx @lobu/cli@latest login
-npx @lobu/cli@latest org set my-org
-npx @lobu/cli@latest agent list
-```
-
-Local `lobu.config.ts` projects are still useful for `lobu validate` and `lobu apply` workflows.
-
-### Deployment
-
-Single-process Node remains the simplest deployment: run it with `node`, `pm2`, `systemd`, or another process supervisor. The app needs `DATABASE_URL` (Postgres + pgvector) reachable from its environment.
-
-- **Local dev** (contributing to Lobu itself): clone, `make setup`, `make dev` (boots embedded gateway + workers + Vite HMR on `:8787`).
-- **Production (VM/bare metal)**: `bun run --cwd packages/server build:server`, then `node packages/server/dist/server.bundle.mjs` under your process supervisor of choice.
-- **Production (Kubernetes)**: use the public Helm chart in `charts/lobu`:
-  ```bash
-  helm install lobu oci://ghcr.io/lobu-ai/charts/lobu \
-    --namespace lobu --create-namespace \
-    -f your-values.yaml
-  ```
-  See `charts/lobu/values.yaml` for the full set of tunables. At minimum supply an
-  ingress host, a `secretName` Secret containing `DATABASE_URL` + `ENCRYPTION_KEY` +
-  `BETTER_AUTH_SECRET` + provider API keys, and a `database.existingSecret`.
+`lobu run` (embedded) auto-applies your `lobu.config.ts`, so the scaffolded agent is usable immediately. To use an external Postgres, set `DATABASE_URL` in `.env`; to push later config changes, run `lobu apply`. The same agents are reachable over a [REST API](https://lobu.ai/reference/api-reference/) and every chat platform — see [Channels](#channels).
 
 ## Architecture
 
@@ -100,18 +58,19 @@ Every Lobu agent ships with tools for autonomous execution and persistence:
 | **Managed MCP proxy** — any MCP server with secret injection | [MCP Proxy](docs/SECURITY.md#credentials) |
 | **Nix + external MCP** — browsing, headless UI, custom tools | `bash` (Nix), MCP servers |
 
+### Channels
+
+One instance serves **Slack, Telegram, WhatsApp, Discord, Teams, Google Chat**, and a [REST API](https://lobu.ai/reference/api-reference/) [![API Docs](https://img.shields.io/badge/API_Docs-0096FF?style=for-the-badge&logo=readme&logoColor=white)](https://lobu.ai/reference/api-reference/). Each channel/DM gets its own runtime, model, tools, credentials, and Nix packages. Webhook is the default transport (Telegram also supports polling).
+
 ### Popular MCP integrations
 
 - **Productivity:** Google Calendar, Slack, Jira, Notion
 - **Development:** GitHub, GitLab, Postgres, Docker
 - **Knowledge:** Wikipedia, Brave Search, YouTube, PDF Search
 
-### Design
+### Runtime
 
-- **Gateway as single egress.** All worker traffic — internet and MCP — routes through the gateway. Workers have no direct network access; domain filtering controls which services they reach.
-- **MCP proxy.** Gateway resolves `${env:VAR}` secrets and routes to upstream MCP servers. OAuth for third-party APIs stays in Lobu — workers never see tokens.
-- **Multi-platform, multi-tenant.** One instance serves Slack, Telegram, WhatsApp, Discord, Teams, and the REST API. Each channel/DM gets its own runtime, model, tools, credentials, and Nix packages.
-- **OpenClaw runtime.** Workers run [OpenClaw Pi Agent](https://openclaw.ai/) with per-agent model selection. Supports OpenClaw skills and `IDENTITY.md` / `SOUL.md` / `USER.md` workspace files.
+- **OpenClaw runtime.** Workers run [OpenClaw Pi Agent](https://openclaw.ai/) with per-agent model selection, OpenClaw skills, and `IDENTITY.md` / `SOUL.md` / `USER.md` workspace files.
 - **Multi-provider auth.** 16 LLM providers (OpenAI, Gemini, Groq, DeepSeek, Mistral, …) via a config-driven registry. API keys stay on the gateway.
 
 ## How Lobu Differs
@@ -128,6 +87,35 @@ Lobu is the **infrastructure layer** for autonomous agents. Frameworks like Lang
 | MCP access | Proxied through gateway, secrets isolated | Direct from agent |
 | Network | Sandboxed, domain-filtered egress | No built-in isolation |
 | Deployment | Single Node process (BYO Postgres) | Single node |
+
+## Agent configuration
+
+Runtime configuration is managed through the web app or the same org-scoped REST API used by the CLI:
+
+```bash
+npx @lobu/cli@latest login
+npx @lobu/cli@latest org set my-org
+npx @lobu/cli@latest agent list
+```
+
+Local `lobu.config.ts` projects are still useful for `lobu validate` and `lobu apply` workflows.
+
+## Deployment
+
+Single-process Node remains the simplest deployment: run it with `node`, `pm2`, `systemd`, or another process supervisor. The app needs `DATABASE_URL` (Postgres + pgvector) reachable from its environment.
+
+- **Local dev** (contributing to Lobu itself): clone, `make setup`, `make dev` (boots embedded gateway + workers + Vite HMR on `:8787`).
+- **Production (VM/bare metal)**: `bun run --cwd packages/server build:server`, then `node packages/server/dist/server.bundle.mjs` under your process supervisor of choice.
+- **Production (Docker)**: a single self-hosting image — see [docs/DOCKER.md](docs/DOCKER.md).
+- **Production (Kubernetes)**: use the public Helm chart in `charts/lobu`:
+  ```bash
+  helm install lobu oci://ghcr.io/lobu-ai/charts/lobu \
+    --namespace lobu --create-namespace \
+    -f your-values.yaml
+  ```
+  See `charts/lobu/values.yaml` for the full set of tunables. At minimum supply an
+  ingress host, a `secretName` Secret containing `DATABASE_URL` + `ENCRYPTION_KEY` +
+  `BETTER_AUTH_SECRET` + provider API keys, and a `database.existingSecret`.
 
 ## Security and Privacy
 

--- a/packages/cli/src/commands/_lib/init-from-org/bootstrap.ts
+++ b/packages/cli/src/commands/_lib/init-from-org/bootstrap.ts
@@ -1135,7 +1135,7 @@ function generateProject(
 
   const header = [
     "// lobu.config.ts — bootstrapped by `lobu init --from-org`",
-    "// Docs: https://lobu.ai/docs/getting-started",
+    "// Docs: https://lobu.ai/getting-started/",
     "//",
     "// Secrets are write-only on the server, so provider keys, auth-profile",
     '// credentials, and MCP client secrets are emitted as secret("ENV_VAR")',

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -1035,7 +1035,7 @@ async function generateLobuConfig(
 
   const lines = [
     "// lobu.config.ts — Lobu project configuration",
-    "// Docs: https://lobu.ai/docs/getting-started",
+    "// Docs: https://lobu.ai/getting-started/",
     "//",
     "// `dir` points to a folder with IDENTITY.md, SOUL.md, USER.md, and an",
     "// optional skills/ directory. Shared skills in the root skills/ directory",

--- a/packages/landing/src/components/LandingPage.tsx
+++ b/packages/landing/src/components/LandingPage.tsx
@@ -47,6 +47,8 @@ const SETUP_PROMPT = `I want to build a Lobu agent with you. Lobu helps create i
 
 1. Interview me, one question at a time. Wait for my answer before the next. Don't batch them, don't guess, and don't fake any credentials:
    - What is the agent for? (one sentence)
+   - What should we call it? (a short name — used for both the project and the agent)
+   - How should it behave, and what may it do on its own? (tone/persona, plus which actions it can take unattended vs. which need my approval)
    - Who uses it: just me, my team, or each of my customers (multi-tenant)?
    - What should it remember? (we'll model this as 1-3 entity types)
    - Where does its data come from? Lobu has built-in connectors for Gmail, GitHub, Google Calendar, Outlook, websites, RSS, Reddit, X, LinkedIn, YouTube, Hacker News, Product Hunt, WhatsApp, Spotify, and more, or you can write a custom connector for any other source (an API, a webhook, a CSV). Tell me the source and I'll map it to a built-in connector or plan a custom one. Pick one to start.
@@ -54,13 +56,15 @@ const SETUP_PROMPT = `I want to build a Lobu agent with you. Lobu helps create i
    - Anything on a schedule? (optional: one watcher, e.g. a daily summary)
    - Which LLM provider key do I have: Anthropic (ANTHROPIC_API_KEY), OpenAI, Gemini, Groq, DeepSeek, Mistral, Z.ai, or another (16 providers supported)?
 
-2. Scaffold it: check my Node is 22-24 (Lobu rejects 25+; help me switch if not), then run npx @lobu/cli@latest init with the name and the provider from above. Postgres is built in, so lobu run starts an embedded one. Don't ask me for a database unless I want an external Postgres (then I set DATABASE_URL). Read the AGENTS.md it writes (your guide to the config API: the define* helpers, connectors, auth, watchers, memory), and read examples/lobu-crm/lobu.config.ts before writing any connection, watcher, or reaction so you match the real field names instead of guessing. Then, before writing config, explain to me in plain terms how Lobu will work for my case: how the connector collects my data incrementally (feeds run on a schedule and only pull what's new since the last run, no re-ingesting), how each item becomes an event that memory turns into the entities above, and how both the watcher and the chat read that memory. Keep it short.
+   When you have my answers, play them back as a short numbered recap and wait for me to confirm or fix them before you scaffold anything.
+
+2. Scaffold it: check my Node is 22-24 or 26+ (only Node 25 is unsupported; help me switch if not), then run npx @lobu/cli@latest init with the name and the provider from above. Postgres is built in, so lobu run starts an embedded one. Don't ask me for a database unless I want an external Postgres (then I set DATABASE_URL). Read the AGENTS.md it writes (your guide to the config API: the define* helpers, connectors, auth, watchers, memory), and read examples/lobu-crm/lobu.config.ts before writing any connection, watcher, or reaction so you match the real field names instead of guessing. Then, before writing config, explain to me in plain terms how Lobu will work for my case: how the connector collects my data incrementally (feeds run on a schedule and only pull what's new since the last run, no re-ingesting), how each item becomes an event that memory turns into the entities above, and how both the watcher and the chat read that memory. Keep it short.
 
 3. Build it from my answers: edit lobu.config.ts plus any connector, reaction, and skill files it needs. Then tell me in one go every secret you'll need (API keys, OAuth client id/secret, bot tokens) and we'll add them to .env together as secret(...) placeholders. Never invent one, and for OAuth sources authorize the account in the admin UI rather than hand-crafting a token.
 
-4. Run and verify: run npx @lobu/cli@latest validate and fix any errors, then boot with npx @lobu/cli@latest run. Send a test message on the channel I chose, trigger the data source manually (don't wait on a poll or cron), and show me the memory event that was written plus the admin UI at http://localhost:8787.
+4. Run and verify: run npx @lobu/cli@latest validate and fix any errors, then boot with npx @lobu/cli@latest run. Send a test message on the channel I chose, trigger the data source manually (don't wait on a poll or cron), and show me the memory event that was written plus the admin UI at http://localhost:8787. If I set up a watcher or an action, exercise that too: run the watcher once, and confirm any action triggers in approval mode rather than firing for real.
 
-Repo: https://github.com/lobu-ai/lobu. Docs: https://lobu.ai/docs/`;
+Repo: https://github.com/lobu-ai/lobu. Docs: https://lobu.ai/getting-started/`;
 
 // The canonical "test it" command, kept in sync with InstallSection.
 const QUICKSTART_CMD = "npx @lobu/cli@latest init my-agent";


### PR DESCRIPTION
## What

Documentation + onboarding cleanup (no runtime code changes).

### README
- Reordered to a `try → understand → operate → trust` arc.
- Dissolved the redundant **Channels & API** and **Design** sections (their content was already carried by the Architecture diagram, Capabilities table, and Security section).
- Promoted **Deployment** from an H3 buried under "Agent configuration" to a top-level section.
- Added a Docker deployment doc link (`docs/DOCKER.md`).
- ~152 → ~140 lines, no information lost.

### Dead docs links
- `https://lobu.ai/docs/` was a 404 (verified). Fixed to `https://lobu.ai/getting-started/` (200) in:
  - the landing-page setup prompt (`LandingPage.tsx`)
  - the `// Docs:` header written into every scaffolded `lobu.config.ts` (`init.ts`, `bootstrap.ts`)

### Setup prompt (LandingPage.tsx)
- Added an agent-name question (step 2 referenced "the name from above" but the interview never asked for one).
- Added a behavior/persona + action-scope question.
- Added a recap-and-confirm gate before scaffolding.
- Verify step now exercises a watcher/action if one was configured.
- Widened the Node note: `22-24 or 26+ (only Node 25 is unsupported)`.

## Test
Copy-only changes (markdown + string literals + code comments). No logic touched.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1377"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784409674&installation_id=136316292&pr_number=1377&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1377&signature=15e2e94fbf1516ef644560e0322861efddc426c1607bdce3c4f5422c4493b3cb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced getting started guides with improved setup prompts, expanded configuration steps, and verification instructions
  * Updated README with deployment options including Docker and Kubernetes guidance
  * Clarified platform capabilities, channel integration documentation, and configuration workflow
  * Refreshed documentation references across setup tools

<!-- end of auto-generated comment: release notes by coderabbit.ai -->