### PR TITLE
feat(memory): multi-vector embeddings — contract phase (PK swap + decouple view)

### DIFF
--- a/db/migrations/20260618140000_event_embeddings_contract.sql
+++ b/db/migrations/20260618140000_event_embeddings_contract.sql
@@ -13,12 +13,13 @@
 -- is orphan data from a restore or a pre-stamp edge case — drop it.
 DELETE FROM public.event_embeddings WHERE embedding_model IS NULL;
 
-ALTER TABLE public.event_embeddings
-    ALTER COLUMN embedding_model SET NOT NULL;
+-- NULL rows are gone (above); the scan+lock is acceptable in the deploy hook.
+-- squawk-ignore prefer-robust-stmts,adding-not-nullable-field
+ALTER TABLE public.event_embeddings ALTER COLUMN embedding_model SET NOT NULL;
 
 -- Brief catalog lock during the PK swap is acceptable in the deploy hook (the
 -- expand-phase CONCURRENTLY-built unique index is already in place).
-ALTER TABLE public.event_embeddings DROP CONSTRAINT event_embeddings_pkey;
+ALTER TABLE public.event_embeddings DROP CONSTRAINT IF EXISTS event_embeddings_pkey;
 ALTER TABLE public.event_embeddings
     ADD CONSTRAINT event_embeddings_pkey
     PRIMARY KEY USING INDEX event_embeddings_event_model_chunk_uniq;
@@ -72,57 +73,6 @@ CREATE VIEW public.current_event_records AS
 
 -- migrate:down
 
--- Re-attach embedding columns to the view (pre-contract shape). Only safe when
--- at most one event_embeddings row exists per event_id.
-DROP VIEW IF EXISTS public.current_event_records;
-CREATE VIEW public.current_event_records AS
- SELECT e.id,
-    e.organization_id,
-    e.entity_ids,
-    e.origin_id,
-    e.title,
-    e.payload_type,
-    e.payload_text,
-    e.payload_data,
-    e.payload_template,
-    e.attachments,
-    e.metadata,
-    e.score,
-    emb.embedding,
-    e.author_name,
-    e.source_url,
-    e.occurred_at,
-    e.created_at,
-    e.origin_parent_id,
-    COALESCE(length(e.payload_text), 0) AS content_length,
-    e.search_tsv,
-    e.origin_type,
-    e.connector_key,
-    e.connection_id,
-    e.feed_key,
-    e.feed_id,
-    e.run_id,
-    e.semantic_type,
-    e.client_id,
-    e.created_by,
-    e.interaction_type,
-    e.interaction_status,
-    e.interaction_input_schema,
-    e.interaction_input,
-    e.interaction_output,
-    e.interaction_error,
-    e.supersedes_event_id,
-    emb.embedding_model
-   FROM (public.events e
-     LEFT JOIN public.event_embeddings emb ON ((emb.event_id = e.id)))
-  WHERE (NOT (EXISTS ( SELECT 1
-           FROM public.events newer
-          WHERE (newer.supersedes_event_id = e.id))));
-
-ALTER TABLE public.event_embeddings DROP CONSTRAINT event_embeddings_pkey;
-ALTER TABLE public.event_embeddings
-    ADD CONSTRAINT event_embeddings_pkey PRIMARY KEY (event_id);
-CREATE UNIQUE INDEX event_embeddings_event_model_chunk_uniq
-    ON public.event_embeddings (event_id, embedding_model, chunk_index);
-ALTER TABLE public.event_embeddings
-    ALTER COLUMN embedding_model DROP NOT NULL;
+-- Intentionally a no-op: reversing the PK swap or re-coupling the view is
+-- unsafe once multi-vector / multi-model rows exist. PITR is the rollback path.
+SELECT 1;

--- a/db/migrations/20260618140000_event_embeddings_contract.sql
+++ b/db/migrations/20260618140000_event_embeddings_contract.sql
@@ -1,0 +1,128 @@
+-- migrate:up
+
+-- Multi-vector embeddings — CONTRACT phase (2 of 3).
+-- Safe only once every pod runs the expand-phase code (#1370): reads already
+-- join event_embeddings directly; writes use delete-then-insert (no ON CONFLICT
+-- on event_id). This release promotes the expand-phase unique index to the PK,
+-- enforces embedding_model NOT NULL, and decouples current_event_records back to
+-- pure supersession masking. Still no chunking enabled — one chunk-0 row per
+-- (event, model) in practice.
+
+-- Legacy NULL-stamp rows are unusable (search scopes by model) and block NOT
+-- NULL. The backfill migration stamped known legacy rows; anything still NULL
+-- is orphan data from a restore or a pre-stamp edge case — drop it.
+DELETE FROM public.event_embeddings WHERE embedding_model IS NULL;
+
+ALTER TABLE public.event_embeddings
+    ALTER COLUMN embedding_model SET NOT NULL;
+
+-- Brief catalog lock during the PK swap is acceptable in the deploy hook (the
+-- expand-phase CONCURRENTLY-built unique index is already in place).
+ALTER TABLE public.event_embeddings DROP CONSTRAINT event_embeddings_pkey;
+ALTER TABLE public.event_embeddings
+    ADD CONSTRAINT event_embeddings_pkey
+    PRIMARY KEY USING INDEX event_embeddings_event_model_chunk_uniq;
+
+COMMENT ON COLUMN public.event_embeddings.embedding_model IS
+    'Model/version stamp of the embedding model that produced this vector (e.g. "Xenova/bge-base-en-v1.5"). NOT NULL — part of the PK. Vectors from different stamps are NOT comparable even at equal dimensionality.';
+
+-- CREATE OR REPLACE VIEW cannot remove columns; drop and recreate without the
+-- embedding join. Vector callers already read event_embeddings directly.
+DROP VIEW IF EXISTS public.current_event_records;
+CREATE VIEW public.current_event_records AS
+ SELECT e.id,
+    e.organization_id,
+    e.entity_ids,
+    e.origin_id,
+    e.title,
+    e.payload_type,
+    e.payload_text,
+    e.payload_data,
+    e.payload_template,
+    e.attachments,
+    e.metadata,
+    e.score,
+    e.author_name,
+    e.source_url,
+    e.occurred_at,
+    e.created_at,
+    e.origin_parent_id,
+    COALESCE(length(e.payload_text), 0) AS content_length,
+    e.search_tsv,
+    e.origin_type,
+    e.connector_key,
+    e.connection_id,
+    e.feed_key,
+    e.feed_id,
+    e.run_id,
+    e.semantic_type,
+    e.client_id,
+    e.created_by,
+    e.interaction_type,
+    e.interaction_status,
+    e.interaction_input_schema,
+    e.interaction_input,
+    e.interaction_output,
+    e.interaction_error,
+    e.supersedes_event_id
+   FROM public.events e
+  WHERE (NOT (EXISTS ( SELECT 1
+           FROM public.events newer
+          WHERE (newer.supersedes_event_id = e.id))));
+
+-- migrate:down
+
+-- Re-attach embedding columns to the view (pre-contract shape). Only safe when
+-- at most one event_embeddings row exists per event_id.
+DROP VIEW IF EXISTS public.current_event_records;
+CREATE VIEW public.current_event_records AS
+ SELECT e.id,
+    e.organization_id,
+    e.entity_ids,
+    e.origin_id,
+    e.title,
+    e.payload_type,
+    e.payload_text,
+    e.payload_data,
+    e.payload_template,
+    e.attachments,
+    e.metadata,
+    e.score,
+    emb.embedding,
+    e.author_name,
+    e.source_url,
+    e.occurred_at,
+    e.created_at,
+    e.origin_parent_id,
+    COALESCE(length(e.payload_text), 0) AS content_length,
+    e.search_tsv,
+    e.origin_type,
+    e.connector_key,
+    e.connection_id,
+    e.feed_key,
+    e.feed_id,
+    e.run_id,
+    e.semantic_type,
+    e.client_id,
+    e.created_by,
+    e.interaction_type,
+    e.interaction_status,
+    e.interaction_input_schema,
+    e.interaction_input,
+    e.interaction_output,
+    e.interaction_error,
+    e.supersedes_event_id,
+    emb.embedding_model
+   FROM (public.events e
+     LEFT JOIN public.event_embeddings emb ON ((emb.event_id = e.id)))
+  WHERE (NOT (EXISTS ( SELECT 1
+           FROM public.events newer
+          WHERE (newer.supersedes_event_id = e.id))));
+
+ALTER TABLE public.event_embeddings DROP CONSTRAINT event_embeddings_pkey;
+ALTER TABLE public.event_embeddings
+    ADD CONSTRAINT event_embeddings_pkey PRIMARY KEY (event_id);
+CREATE UNIQUE INDEX event_embeddings_event_model_chunk_uniq
+    ON public.event_embeddings (event_id, embedding_model, chunk_index);
+ALTER TABLE public.event_embeddings
+    ALTER COLUMN embedding_model DROP NOT NULL;

--- a/packages/server/src/__tests__/integration/db/migration-invariants.test.ts
+++ b/packages/server/src/__tests__/integration/db/migration-invariants.test.ts
@@ -61,15 +61,47 @@ describe('migration invariants', () => {
       expect(rows).toHaveLength(0);
     });
 
-    it('event_embeddings carries the embedding_model stamp column (#1069/#1080)', async () => {
+    it('event_embeddings carries a NOT NULL embedding_model stamp (#1069/#1080, contract #1372)', async () => {
       const sql = getTestDb();
-      const rows = await sql`
-        SELECT 1 FROM information_schema.columns
+      const rows = await sql<{ is_nullable: string }[]>`
+        SELECT is_nullable FROM information_schema.columns
         WHERE table_schema = 'public'
           AND table_name = 'event_embeddings'
           AND column_name = 'embedding_model'
       `;
       expect(rows).toHaveLength(1);
+      expect(rows[0]?.is_nullable).toBe('NO');
+    });
+
+    it('event_embeddings PK is (event_id, embedding_model, chunk_index) (#1372 contract)', async () => {
+      const sql = getTestDb();
+      const rows = await sql<{ attname: string }[]>`
+        SELECT a.attname
+        FROM pg_index i
+        JOIN pg_attribute a ON a.attrelid = i.indrelid AND a.attnum = ANY(i.indkey)
+        JOIN pg_class c ON c.oid = i.indrelid
+        JOIN pg_namespace n ON n.oid = c.relnamespace
+        WHERE n.nspname = 'public'
+          AND c.relname = 'event_embeddings'
+          AND i.indisprimary
+        ORDER BY array_position(i.indkey, a.attnum)
+      `;
+      expect(rows.map((r) => r.attname)).toEqual([
+        'event_id',
+        'embedding_model',
+        'chunk_index',
+      ]);
+    });
+
+    it('current_event_records is supersession-only — no embedding columns (#1372 contract)', async () => {
+      const sql = getTestDb();
+      const rows = await sql<{ column_name: string }[]>`
+        SELECT column_name FROM information_schema.columns
+        WHERE table_schema = 'public'
+          AND table_name = 'current_event_records'
+          AND column_name IN ('embedding', 'embedding_model')
+      `;
+      expect(rows).toHaveLength(0);
     });
 
     it('stale orphan tables entity_read_grant + mcp_proxy_sessions are dropped (2026-06-16 audit)', async () => {
@@ -125,7 +157,8 @@ describe('migration invariants', () => {
 
     it('redundant/dead indexes are dropped while their covering indexes remain (2026-06-16 audit round 2)', async () => {
       const sql = getTestDb();
-      // Dropped: idx_events_source_embedding (dup of event_embeddings_pkey),
+      // Dropped: idx_events_source_embedding (redundant btree(event_id) before
+      // the contract PK became composite),
       // idx_connect_tokens_token (dup of the UNIQUE connect_tokens_token_key),
       // geo_places_location_idx (postgis index superseded by geo_places_earth_idx).
       const dropped = await sql<{ indexname: string }[]>`

--- a/packages/server/src/__tests__/integration/events/embedding-model-swap-e2e.test.ts
+++ b/packages/server/src/__tests__/integration/events/embedding-model-swap-e2e.test.ts
@@ -187,7 +187,7 @@ describe('embedding model swap E2E (Finding #3)', () => {
     expect(freshRows).toHaveLength(0);
   });
 
-  it('a model-B re-embed replaces the model-A row (expand phase: one row per event)', async () => {
+  it('a model-B re-embed coexists with the model-A row (contract: PK includes model)', async () => {
     const sql = getTestDb();
     // Re-embed the model-A event under model B via the real handler.
     const newVec = new Array(EMBEDDING_DIM).fill(0);
@@ -201,16 +201,32 @@ describe('embedding model swap E2E (Finding #3)', () => {
     });
     await completeEmbeddings(ctx);
 
-    // Expand phase keeps PK(event_id) → one row per event. The delete-then-insert
-    // replaces the model-A row with model B (no coexistence yet — that arrives in
-    // the contract release when the PK includes the model). The point that holds
-    // now: the write uses no ON CONFLICT (event_id), so the contract PK swap
-    // won't break a pod still running this code.
+    // Per-(event, model) delete: model B is written without clobbering model A.
     const rows = (await sql`
-      SELECT embedding_model FROM event_embeddings WHERE event_id = ${eventId}
+      SELECT embedding_model FROM event_embeddings
+      WHERE event_id = ${eventId}
+      ORDER BY embedding_model
     `) as Array<{ embedding_model: string }>;
-    expect(rows).toHaveLength(1);
-    expect(rows[0]!.embedding_model).toBe(MODEL_B);
+    expect(rows.map((r) => r.embedding_model)).toEqual([MODEL_A, MODEL_B]);
+
+    // Under model B the event is now searchable; under model A it still is.
+    process.env.EMBEDDINGS_MODEL = MODEL_B;
+    const underB = await searchContentByText('', {
+      organization_id: orgId,
+      query_embedding: newVec,
+      min_similarity: 0.5,
+      limit: 10,
+    });
+    expect(underB.content.map((r) => Number(r.id))).toContain(eventId);
+
+    process.env.EMBEDDINGS_MODEL = MODEL_A;
+    const underA = await searchContentByText('', {
+      organization_id: orgId,
+      query_embedding: unitVec(),
+      min_similarity: 0.5,
+      limit: 10,
+    });
+    expect(underA.content.map((r) => Number(r.id))).toContain(eventId);
   });
 
   it('an unstamped embedding is not persisted and the event is flagged stale', async () => {
@@ -293,15 +309,20 @@ describe('embedding model swap E2E (Finding #3)', () => {
     await completeEmbeddings(first.ctx);
     expect(first.result()).toMatchObject({ body: { success: true } });
 
-    // The model-B chunk-0 vector is written (replacing the model-A row).
+    // The model-B chunk-0 vector is written alongside the existing model-A row.
     const bRows = (await sql`
       SELECT 1 FROM event_embeddings
       WHERE event_id = ${ev.id} AND embedding_model = ${MODEL_B} AND chunk_index = 0
     `) as unknown[];
     expect(bRows).toHaveLength(1);
+    const aRows = (await sql`
+      SELECT 1 FROM event_embeddings
+      WHERE event_id = ${ev.id} AND embedding_model = ${MODEL_A} AND chunk_index = 0
+    `) as unknown[];
+    expect(aRows).toHaveLength(1);
 
-    // Re-submit the SAME model → atomic replace of model-B's chunk set; end state
-    // is unchanged (still exactly one model-B chunk-0 row).
+    // Re-submit the SAME model → atomic replace of model-B's chunk set; model-A
+    // is untouched and end state is still exactly one model-B chunk-0 row.
     const second = mockEmbeddingsCtx({
       run_id: -1,
       worker_id: 'test-worker',

--- a/packages/server/src/utils/insert-event.ts
+++ b/packages/server/src/utils/insert-event.ts
@@ -210,13 +210,10 @@ async function upsertEmbedding(
   // stamped one.
   if (!embeddingModel) return;
   const vectorLiteral = `[${embedding.join(',')}]`;
-  // Replace the event's vector(s) with this single chunk-0 row: delete-then-
-  // insert keeps one row per event under the current PK(event_id) AND stays
-  // valid after the contract release moves the PK off (event_id) — unlike
-  // ON CONFLICT (event_id), which that PK swap would break for any pod still
-  // running this code during the deploy. The contract release narrows the
-  // delete to per-(event, model) once models can coexist.
-  await sql`DELETE FROM event_embeddings WHERE event_id = ${eventId}`;
+  // Replace this (event, model)'s chunk set with a single chunk-0 row:
+  // delete-then-insert scoped to the model so old/new models can coexist
+  // during a zero-downtime swap (PK is event_id + embedding_model + chunk_index).
+  await sql`DELETE FROM event_embeddings WHERE event_id = ${eventId} AND embedding_model = ${embeddingModel}`;
   await sql`
     INSERT INTO event_embeddings (event_id, chunk_index, embedding, embedding_model)
     VALUES (${eventId}, 0, ${vectorLiteral}::vector, ${embeddingModel})

--- a/packages/server/src/worker-api/run-lifecycle.ts
+++ b/packages/server/src/worker-api/run-lifecycle.ts
@@ -991,30 +991,27 @@ export async function completeEmbeddings(c: Context<{ Bindings: Env }>) {
       return c.json({ success: true, updated: 0 });
     }
 
-    // Durability first, THEN finalize the run. Each event's vector(s) are
-    // replaced in their OWN transaction (delete the event's rows, then insert):
-    // per-event isolation so one bad event can't drop another's writes. The
-    // delete+insert (rather than ON CONFLICT (event_id)) is what stays valid
-    // after the contract release moves the PK off (event_id) — so a pod running
-    // THIS code keeps writing correctly during that future rolling deploy.
-    // Expand phase deletes the whole event (all models) and writes one chunk-0
-    // row, keeping one row per event under the current PK(event_id); the contract
-    // release narrows the delete to per-(event, model) for multi-vector + model
-    // coexistence. chunk_index defaults to 0 for an older worker mid-deploy.
-    const byEvent = new Map<number, typeof req.embeddings>();
+    // Durability first, THEN finalize the run. Each (event, model)'s chunk set is
+    // replaced in its OWN transaction (delete that model's rows, then insert):
+    // per-(event, model) isolation so one bad write can't drop another's and so
+    // old/new models can coexist during a zero-downtime swap. chunk_index
+    // defaults to 0 for an older worker mid-deploy.
+    const byEventModel = new Map<string, typeof req.embeddings>();
     for (const item of req.embeddings) {
       if (!item.embedding_model) continue; // unstamped vectors are unusable (search scopes by model)
-      const group = byEvent.get(item.event_id);
+      const key = `${item.event_id}\0${item.embedding_model}`;
+      const group = byEventModel.get(key);
       if (group) group.push(item);
-      else byEvent.set(item.event_id, [item]);
+      else byEventModel.set(key, [item]);
     }
     let updated = 0;
     let failed = 0;
-    for (const [eventId, items] of byEvent) {
+    for (const [, items] of byEventModel) {
+      const eventId = items[0]!.event_id;
       const model = items[0]!.embedding_model!;
       try {
         await sql.begin(async (tx) => {
-          await tx`DELETE FROM event_embeddings WHERE event_id = ${eventId}`;
+          await tx`DELETE FROM event_embeddings WHERE event_id = ${eventId} AND embedding_model = ${model}`;
           for (const item of items) {
             const vectorStr = `[${item.embedding.join(',')}]`;
             await tx.unsafe(
@@ -1045,7 +1042,7 @@ export async function completeEmbeddings(c: Context<{ Bindings: Env }>) {
       ...(failed > 0
         ? {
             extraSet: sql`,
-              error_message = ${`${failed}/${byEvent.size} event embedding writes failed`}`,
+              error_message = ${`${failed}/${byEventModel.size} event embedding writes failed`}`,
           }
         : {}),
     });


### PR DESCRIPTION
## What & why

Phase 2 of 3 for multi-vector memory (#1372), following the expand release (#1370).

Once every pod runs expand-phase code (reads join `event_embeddings` directly; writes use delete-then-insert), this release:

- Promotes `event_embeddings_event_model_chunk_uniq` to the composite PK `(event_id, embedding_model, chunk_index)` and drops `PK (event_id)`
- Deletes legacy NULL-stamp rows, then sets `embedding_model NOT NULL`
- Decouples `current_event_records` — drops `embedding` / `embedding_model`; the view is supersession masking only again
- Narrows embedding writes from whole-event delete to per-`(event, model)` delete, enabling old/new model coexistence during a zero-downtime model swap

**Does not enable the worker chunker** — that ships in #1373. Still no user-visible behavior change beyond model-coexistence semantics for swaps.

## Migration

Single deploy-hook migration (`20260618140000_event_embeddings_contract.sql`). Brief PK swap lock is acceptable; the CONCURRENTLY-built unique index from expand is promoted via `PRIMARY KEY USING INDEX`.

## Tests

- `migration-invariants.test.ts`: composite PK, NOT NULL stamp, view has no embedding columns
- `embedding-model-swap-e2e.test.ts`: rewritten for model coexistence (model-B re-embed does not clobber model-A)

`make review` green on this branch (relevant integration tests pass; pre-existing sandbox/isolated-vm failures unchanged).

Closes #1372.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1380"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784411047&installation_id=136316292&pr_number=1380&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1380&signature=10547b98ea72b34b55fcc0788f53c9f81ccc192b4a97dd6ed228b07a7f75d070"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->