### PR TITLE
feat(connectors): harden install_connector source_url fetch (SSRF + allowlist)

### DIFF
--- a/packages/server/src/utils/__tests__/connector-source-url-guard.test.ts
+++ b/packages/server/src/utils/__tests__/connector-source-url-guard.test.ts
@@ -1,8 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { resolveConnectorInstallSource } from '../connector-definition-install';
 
-// These cases all reject BEFORE any network fetch (scheme/SSRF/allowlist checks),
-// so they need no mocking and make no outbound request.
+// These cases all reject BEFORE any network fetch (scheme/allowlist/SSRF on IP
+// literals), so they need no mocking and make no outbound request. SSRF cases use
+// CONNECTOR_SOURCE_ALLOWLIST='*' to pass the allowlist and reach the SSRF check,
+// and IP literals (not hostnames) so the reserved-IP check is deterministic.
 describe('connector source_url install guard', () => {
   const prev = process.env.CONNECTOR_SOURCE_ALLOWLIST;
   beforeEach(() => {
@@ -19,32 +21,40 @@ describe('connector source_url install guard', () => {
     ).rejects.toThrow(/must use https/i);
   });
 
-  it('blocks cloud-metadata / link-local addresses (SSRF)', async () => {
-    await expect(
-      resolveConnectorInstallSource({ sourceUrl: 'https://169.254.169.254/latest/meta-data/' })
-    ).rejects.toThrow(/blocked/i);
-  });
-
-  it('blocks loopback and private hosts (SSRF)', async () => {
-    await expect(
-      resolveConnectorInstallSource({ sourceUrl: 'https://localhost/x.ts' })
-    ).rejects.toThrow(/blocked/i);
-    await expect(
-      resolveConnectorInstallSource({ sourceUrl: 'https://10.0.0.5/x.ts' })
-    ).rejects.toThrow(/blocked/i);
-  });
-
   it('rejects hosts not on the allowlist', async () => {
     await expect(
       resolveConnectorInstallSource({ sourceUrl: 'https://evil.example.com/x.ts' })
     ).rejects.toThrow(/allowlist/i);
   });
 
-  it('allows hosts added via CONNECTOR_SOURCE_ALLOWLIST past the guard', async () => {
-    process.env.CONNECTOR_SOURCE_ALLOWLIST = 'evil.example.com';
-    // Passes the guard, then fails at the (unmocked) fetch — proving the guard let it through.
+  it('blocks cloud-metadata / link-local addresses (SSRF) even with wildcard', async () => {
+    process.env.CONNECTOR_SOURCE_ALLOWLIST = '*';
     await expect(
-      resolveConnectorInstallSource({ sourceUrl: 'https://evil.example.com/does-not-exist.ts' })
+      resolveConnectorInstallSource({ sourceUrl: 'https://169.254.169.254/latest/meta-data/' })
+    ).rejects.toThrow(/blocked/i);
+  });
+
+  it('blocks loopback and private IP literals (SSRF) even with wildcard', async () => {
+    process.env.CONNECTOR_SOURCE_ALLOWLIST = '*';
+    await expect(
+      resolveConnectorInstallSource({ sourceUrl: 'https://127.0.0.1/x.ts' })
+    ).rejects.toThrow(/blocked/i);
+    await expect(
+      resolveConnectorInstallSource({ sourceUrl: 'https://10.0.0.5/x.ts' })
+    ).rejects.toThrow(/blocked/i);
+  });
+
+  it('blocks IPv4-mapped IPv6 loopback even with wildcard (regression for SSRF bypass)', async () => {
+    process.env.CONNECTOR_SOURCE_ALLOWLIST = '*';
+    await expect(
+      resolveConnectorInstallSource({ sourceUrl: 'https://[::ffff:127.0.0.1]/x.ts' })
+    ).rejects.toThrow(/blocked/i);
+  });
+
+  it('lets an allowlisted public host past the guard (fails later at fetch, not the guard)', async () => {
+    process.env.CONNECTOR_SOURCE_ALLOWLIST = 'connectors.example.com';
+    await expect(
+      resolveConnectorInstallSource({ sourceUrl: 'https://connectors.example.com/nope.ts' })
     ).rejects.not.toThrow(/allowlist|must use https|blocked/i);
   });
 });

--- a/packages/server/src/utils/__tests__/connector-source-url-guard.test.ts
+++ b/packages/server/src/utils/__tests__/connector-source-url-guard.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { resolveConnectorInstallSource } from '../connector-definition-install';
 
 // These cases all reject BEFORE any network fetch (scheme/allowlist/SSRF on IP
@@ -56,5 +56,66 @@ describe('connector source_url install guard', () => {
     await expect(
       resolveConnectorInstallSource({ sourceUrl: 'https://connectors.example.com/nope.ts' })
     ).rejects.not.toThrow(/allowlist|must use https|blocked/i);
+  });
+});
+
+// Redirect re-validation + body cap need a mocked fetch. `.invalid` hosts are
+// RFC-2606 guaranteed-NXDOMAIN, so the initial SSRF/DNS check passes fast and
+// deterministically without real network, then our mock drives the behavior.
+describe('connector source_url fetch: redirect validation + body cap', () => {
+  const prev = process.env.CONNECTOR_SOURCE_ALLOWLIST;
+  beforeEach(() => {
+    process.env.CONNECTOR_SOURCE_ALLOWLIST = 'host.invalid';
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+    if (prev === undefined) delete process.env.CONNECTOR_SOURCE_ALLOWLIST;
+    else process.env.CONNECTOR_SOURCE_ALLOWLIST = prev;
+  });
+
+  it('re-validates redirect hops: a redirect to http:// is rejected', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response(null, { status: 302, headers: { location: 'http://host.invalid/y.ts' } })
+    );
+    await expect(
+      resolveConnectorInstallSource({ sourceUrl: 'https://host.invalid/x.ts' })
+    ).rejects.toThrow(/must use https/i);
+  });
+
+  it('re-validates redirect hops: a redirect to an off-allowlist host is rejected', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response(null, { status: 302, headers: { location: 'https://elsewhere.invalid/y.ts' } })
+    );
+    await expect(
+      resolveConnectorInstallSource({ sourceUrl: 'https://host.invalid/x.ts' })
+    ).rejects.toThrow(/allowlist/i);
+  });
+
+  it('rejects an oversized declared Content-Length', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response('x', { status: 200, headers: { 'content-length': String(6 * 1024 * 1024) } })
+    );
+    await expect(
+      resolveConnectorInstallSource({ sourceUrl: 'https://host.invalid/x.ts' })
+    ).rejects.toThrow(/too large/i);
+  });
+
+  it('aborts a streamed body that exceeds the cap (no/lying Content-Length)', async () => {
+    const chunk = new Uint8Array(2 * 1024 * 1024); // 2 MiB per chunk; 3rd pushes past 5 MiB
+    let sent = 0;
+    const stream = new ReadableStream<Uint8Array>({
+      pull(controller) {
+        if (sent >= 4) {
+          controller.close();
+          return;
+        }
+        sent += 1;
+        controller.enqueue(chunk);
+      },
+    });
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(new Response(stream, { status: 200 }));
+    await expect(
+      resolveConnectorInstallSource({ sourceUrl: 'https://host.invalid/x.ts' })
+    ).rejects.toThrow(/too large/i);
   });
 });

--- a/packages/server/src/utils/__tests__/connector-source-url-guard.test.ts
+++ b/packages/server/src/utils/__tests__/connector-source-url-guard.test.ts
@@ -1,0 +1,50 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { resolveConnectorInstallSource } from '../connector-definition-install';
+
+// These cases all reject BEFORE any network fetch (scheme/SSRF/allowlist checks),
+// so they need no mocking and make no outbound request.
+describe('connector source_url install guard', () => {
+  const prev = process.env.CONNECTOR_SOURCE_ALLOWLIST;
+  beforeEach(() => {
+    process.env.CONNECTOR_SOURCE_ALLOWLIST = '';
+  });
+  afterEach(() => {
+    if (prev === undefined) delete process.env.CONNECTOR_SOURCE_ALLOWLIST;
+    else process.env.CONNECTOR_SOURCE_ALLOWLIST = prev;
+  });
+
+  it('rejects non-https schemes', async () => {
+    await expect(
+      resolveConnectorInstallSource({ sourceUrl: 'http://raw.githubusercontent.com/x/y/z.ts' })
+    ).rejects.toThrow(/must use https/i);
+  });
+
+  it('blocks cloud-metadata / link-local addresses (SSRF)', async () => {
+    await expect(
+      resolveConnectorInstallSource({ sourceUrl: 'https://169.254.169.254/latest/meta-data/' })
+    ).rejects.toThrow(/blocked/i);
+  });
+
+  it('blocks loopback and private hosts (SSRF)', async () => {
+    await expect(
+      resolveConnectorInstallSource({ sourceUrl: 'https://localhost/x.ts' })
+    ).rejects.toThrow(/blocked/i);
+    await expect(
+      resolveConnectorInstallSource({ sourceUrl: 'https://10.0.0.5/x.ts' })
+    ).rejects.toThrow(/blocked/i);
+  });
+
+  it('rejects hosts not on the allowlist', async () => {
+    await expect(
+      resolveConnectorInstallSource({ sourceUrl: 'https://evil.example.com/x.ts' })
+    ).rejects.toThrow(/allowlist/i);
+  });
+
+  it('allows hosts added via CONNECTOR_SOURCE_ALLOWLIST past the guard', async () => {
+    process.env.CONNECTOR_SOURCE_ALLOWLIST = 'evil.example.com';
+    // Passes the guard, then fails at the (unmocked) fetch — proving the guard let it through.
+    await expect(
+      resolveConnectorInstallSource({ sourceUrl: 'https://evil.example.com/does-not-exist.ts' })
+    ).rejects.not.toThrow(/allowlist|must use https|blocked/i);
+  });
+});

--- a/packages/server/src/utils/connector-definition-install.ts
+++ b/packages/server/src/utils/connector-definition-install.ts
@@ -16,6 +16,7 @@ import {
   extractConnectorMetadata,
   validateConnectorMetadata,
 } from './connector-compiler';
+import { isInternalUrl } from '../gateway/proxy/ssrf-guard';
 
 type SqlClient = ReturnType<typeof getDb>;
 
@@ -102,25 +103,7 @@ const DEFAULT_CONNECTOR_SOURCE_HOSTS = [
 
 const MAX_CONNECTOR_SOURCE_BYTES = 5 * 1024 * 1024;
 const CONNECTOR_SOURCE_FETCH_TIMEOUT_MS = 30_000;
-
-/** Block loopback/private/link-local hosts to prevent SSRF (e.g. cloud metadata 169.254.169.254). */
-function isBlockedSourceHost(hostname: string): boolean {
-  const h = hostname.toLowerCase().replace(/^\[|\]$/g, '');
-  if (h === 'localhost' || h.endsWith('.localhost') || h.endsWith('.internal') || h === '0.0.0.0') {
-    return true;
-  }
-  if (h === '::1' || h.startsWith('fe80:') || h.startsWith('fc') || h.startsWith('fd')) return true;
-  const m = h.match(/^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.\d{1,3}$/);
-  if (m) {
-    const a = Number(m[1]);
-    const b = Number(m[2]);
-    if (a === 0 || a === 10 || a === 127) return true;
-    if (a === 169 && b === 254) return true; // link-local incl. cloud metadata
-    if (a === 172 && b >= 16 && b <= 31) return true;
-    if (a === 192 && b === 168) return true;
-  }
-  return false;
-}
+const MAX_CONNECTOR_SOURCE_REDIRECTS = 5;
 
 function allowedConnectorSourceHosts(): string[] {
   const extra = (process.env.CONNECTOR_SOURCE_ALLOWLIST ?? '')
@@ -131,13 +114,13 @@ function allowedConnectorSourceHosts(): string[] {
 }
 
 /**
- * Validate a connector `source_url` before fetching: https only, no
- * private/loopback hosts (SSRF), and host on the allowlist. `CONNECTOR_SOURCE_ALLOWLIST`
- * adds hosts (`.example.com` matches subdomains); `*` allows any public host.
- * Note: redirects are followed, so the SSRF guard binds the initial host — keep
- * `*` for trusted environments only.
+ * Validate a connector `source_url` before fetching: https only, host on the
+ * allowlist, and not resolving to a private/loopback/reserved address (SSRF).
+ * `CONNECTOR_SOURCE_ALLOWLIST` adds hosts (`.example.com` matches subdomains);
+ * `*` allows any public host (the SSRF/DNS check still applies). Async because
+ * the SSRF guard resolves DNS. Re-run on every redirect hop by the fetcher.
  */
-function assertAllowedConnectorSourceUrl(rawUrl: string): URL {
+async function assertAllowedConnectorSourceUrl(rawUrl: string): Promise<URL> {
   let url: URL;
   try {
     url = new URL(rawUrl);
@@ -147,24 +130,84 @@ function assertAllowedConnectorSourceUrl(rawUrl: string): URL {
   if (url.protocol !== 'https:') {
     throw new Error(`source_url must use https (got '${url.protocol || rawUrl}').`);
   }
-  if (isBlockedSourceHost(url.hostname)) {
-    throw new Error(
-      `source_url host '${url.hostname}' is blocked (private/loopback/link-local address).`
-    );
-  }
   const allow = allowedConnectorSourceHosts();
-  if (allow.includes('*')) return url;
-  const host = url.hostname.toLowerCase();
-  const ok = allow.some((entry) =>
-    entry.startsWith('.') ? host === entry.slice(1) || host.endsWith(entry) : host === entry
-  );
-  if (!ok) {
+  if (!allow.includes('*')) {
+    const host = url.hostname.toLowerCase();
+    const ok = allow.some((entry) =>
+      entry.startsWith('.') ? host === entry.slice(1) || host.endsWith(entry) : host === entry
+    );
+    if (!ok) {
+      throw new Error(
+        `source_url host '${host}' is not in the connector source allowlist (${allow.join(', ')}). ` +
+          `Set CONNECTOR_SOURCE_ALLOWLIST to add hosts, or '*' to allow any public host.`
+      );
+    }
+  }
+  // DNS-resolving check: catches IP literals (incl. IPv4-mapped IPv6) AND
+  // hostnames that resolve to reserved/private ranges (DNS-rebinding).
+  if (await isInternalUrl(url.toString())) {
     throw new Error(
-      `source_url host '${host}' is not in the connector source allowlist (${allow.join(', ')}). ` +
-        `Set CONNECTOR_SOURCE_ALLOWLIST to add hosts, or '*' to allow any public host.`
+      `source_url host '${url.hostname}' is blocked (resolves to a private/loopback/reserved address).`
     );
   }
   return url;
+}
+
+/** Read a response body, aborting as soon as it exceeds the byte cap (content-length can lie / be absent). */
+async function readBodyWithCap(res: Response, maxBytes: number): Promise<string> {
+  const reader = res.body?.getReader();
+  if (!reader) return '';
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    if (!value) continue;
+    total += value.byteLength;
+    if (total > maxBytes) {
+      await reader.cancel();
+      throw new Error(`Connector source too large (max ${maxBytes} bytes).`);
+    }
+    chunks.push(value);
+  }
+  return Buffer.concat(chunks).toString('utf-8');
+}
+
+/**
+ * Fetch connector source with a single timeout covering the whole exchange
+ * (headers + body), manual redirect following that re-validates EVERY hop with
+ * the same scheme/allowlist/SSRF checks, and a streaming byte cap.
+ */
+async function fetchConnectorSource(initialUrl: URL): Promise<string> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), CONNECTOR_SOURCE_FETCH_TIMEOUT_MS);
+  try {
+    let url = initialUrl;
+    for (let hop = 0; hop <= MAX_CONNECTOR_SOURCE_REDIRECTS; hop++) {
+      const res = await fetch(url, { signal: controller.signal, redirect: 'manual' });
+      if (res.status >= 300 && res.status < 400) {
+        const location = res.headers.get('location');
+        if (!location) throw new Error(`Redirect from ${url.toString()} had no Location header.`);
+        url = await assertAllowedConnectorSourceUrl(new URL(location, url).toString());
+        continue;
+      }
+      if (!res.ok) {
+        throw new Error(`Failed to fetch source from ${url.toString()}: ${res.status}`);
+      }
+      const declaredLength = Number(res.headers.get('content-length') ?? '0');
+      if (Number.isFinite(declaredLength) && declaredLength > MAX_CONNECTOR_SOURCE_BYTES) {
+        throw new Error(
+          `Connector source too large: ${declaredLength} bytes (max ${MAX_CONNECTOR_SOURCE_BYTES}).`
+        );
+      }
+      return await readBodyWithCap(res, MAX_CONNECTOR_SOURCE_BYTES);
+    }
+    throw new Error(
+      `Too many redirects fetching connector source (max ${MAX_CONNECTOR_SOURCE_REDIRECTS}).`
+    );
+  } finally {
+    clearTimeout(timeout);
+  }
 }
 
 export async function resolveConnectorInstallSource(params: {
@@ -187,30 +230,9 @@ export async function resolveConnectorInstallSource(params: {
     sourcePath = filePath;
     sourceCode = await readFile(filePath, 'utf-8');
   } else if (params.sourceUrl) {
-    const url = assertAllowedConnectorSourceUrl(params.sourceUrl);
+    const url = await assertAllowedConnectorSourceUrl(params.sourceUrl);
     sourcePath = url.pathname.replace(/^\//, '') || null;
-
-    const controller = new AbortController();
-    const timeout = setTimeout(() => controller.abort(), CONNECTOR_SOURCE_FETCH_TIMEOUT_MS);
-    let sourceResponse: Response;
-    try {
-      sourceResponse = await fetch(url, { signal: controller.signal });
-    } finally {
-      clearTimeout(timeout);
-    }
-    if (!sourceResponse.ok) {
-      throw new Error(`Failed to fetch source from ${url.toString()}: ${sourceResponse.status}`);
-    }
-    const declaredLength = Number(sourceResponse.headers.get('content-length') ?? '0');
-    if (Number.isFinite(declaredLength) && declaredLength > MAX_CONNECTOR_SOURCE_BYTES) {
-      throw new Error(
-        `Connector source too large: ${declaredLength} bytes (max ${MAX_CONNECTOR_SOURCE_BYTES}).`
-      );
-    }
-    sourceCode = await sourceResponse.text();
-    if (Buffer.byteLength(sourceCode) > MAX_CONNECTOR_SOURCE_BYTES) {
-      throw new Error(`Connector source too large (max ${MAX_CONNECTOR_SOURCE_BYTES} bytes).`);
-    }
+    sourceCode = await fetchConnectorSource(url);
   } else if (params.sourceCode) {
     sourceCode = params.sourceCode;
   } else {

--- a/packages/server/src/utils/connector-definition-install.ts
+++ b/packages/server/src/utils/connector-definition-install.ts
@@ -90,6 +90,83 @@ export function connectorSourcePathToUri(sourcePath?: string | null): string | n
   return null;
 }
 
+// Hosts a connector's `source_url` may be fetched from out of the box. Installing
+// from a URL fetches + compiles + runs remote code, so it must be locked down to
+// known-good sources. Extend per-deployment via CONNECTOR_SOURCE_ALLOWLIST.
+const DEFAULT_CONNECTOR_SOURCE_HOSTS = [
+  'raw.githubusercontent.com',
+  'gist.githubusercontent.com',
+  'objects.githubusercontent.com',
+  'github.com',
+];
+
+const MAX_CONNECTOR_SOURCE_BYTES = 5 * 1024 * 1024;
+const CONNECTOR_SOURCE_FETCH_TIMEOUT_MS = 30_000;
+
+/** Block loopback/private/link-local hosts to prevent SSRF (e.g. cloud metadata 169.254.169.254). */
+function isBlockedSourceHost(hostname: string): boolean {
+  const h = hostname.toLowerCase().replace(/^\[|\]$/g, '');
+  if (h === 'localhost' || h.endsWith('.localhost') || h.endsWith('.internal') || h === '0.0.0.0') {
+    return true;
+  }
+  if (h === '::1' || h.startsWith('fe80:') || h.startsWith('fc') || h.startsWith('fd')) return true;
+  const m = h.match(/^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.\d{1,3}$/);
+  if (m) {
+    const a = Number(m[1]);
+    const b = Number(m[2]);
+    if (a === 0 || a === 10 || a === 127) return true;
+    if (a === 169 && b === 254) return true; // link-local incl. cloud metadata
+    if (a === 172 && b >= 16 && b <= 31) return true;
+    if (a === 192 && b === 168) return true;
+  }
+  return false;
+}
+
+function allowedConnectorSourceHosts(): string[] {
+  const extra = (process.env.CONNECTOR_SOURCE_ALLOWLIST ?? '')
+    .split(',')
+    .map((s) => s.trim().toLowerCase())
+    .filter(Boolean);
+  return [...DEFAULT_CONNECTOR_SOURCE_HOSTS, ...extra];
+}
+
+/**
+ * Validate a connector `source_url` before fetching: https only, no
+ * private/loopback hosts (SSRF), and host on the allowlist. `CONNECTOR_SOURCE_ALLOWLIST`
+ * adds hosts (`.example.com` matches subdomains); `*` allows any public host.
+ * Note: redirects are followed, so the SSRF guard binds the initial host — keep
+ * `*` for trusted environments only.
+ */
+function assertAllowedConnectorSourceUrl(rawUrl: string): URL {
+  let url: URL;
+  try {
+    url = new URL(rawUrl);
+  } catch {
+    throw new Error(`Invalid source_url: ${rawUrl}`);
+  }
+  if (url.protocol !== 'https:') {
+    throw new Error(`source_url must use https (got '${url.protocol || rawUrl}').`);
+  }
+  if (isBlockedSourceHost(url.hostname)) {
+    throw new Error(
+      `source_url host '${url.hostname}' is blocked (private/loopback/link-local address).`
+    );
+  }
+  const allow = allowedConnectorSourceHosts();
+  if (allow.includes('*')) return url;
+  const host = url.hostname.toLowerCase();
+  const ok = allow.some((entry) =>
+    entry.startsWith('.') ? host === entry.slice(1) || host.endsWith(entry) : host === entry
+  );
+  if (!ok) {
+    throw new Error(
+      `source_url host '${host}' is not in the connector source allowlist (${allow.join(', ')}). ` +
+        `Set CONNECTOR_SOURCE_ALLOWLIST to add hosts, or '*' to allow any public host.`
+    );
+  }
+  return url;
+}
+
 export async function resolveConnectorInstallSource(params: {
   sourceUrl?: string;
   sourceUri?: string;
@@ -110,19 +187,30 @@ export async function resolveConnectorInstallSource(params: {
     sourcePath = filePath;
     sourceCode = await readFile(filePath, 'utf-8');
   } else if (params.sourceUrl) {
-    sourcePath = (() => {
-      try {
-        return new URL(params.sourceUrl).pathname.replace(/^\//, '') || null;
-      } catch {
-        return null;
-      }
-    })();
+    const url = assertAllowedConnectorSourceUrl(params.sourceUrl);
+    sourcePath = url.pathname.replace(/^\//, '') || null;
 
-    const sourceResponse = await fetch(params.sourceUrl);
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), CONNECTOR_SOURCE_FETCH_TIMEOUT_MS);
+    let sourceResponse: Response;
+    try {
+      sourceResponse = await fetch(url, { signal: controller.signal });
+    } finally {
+      clearTimeout(timeout);
+    }
     if (!sourceResponse.ok) {
-      throw new Error(`Failed to fetch source from ${params.sourceUrl}: ${sourceResponse.status}`);
+      throw new Error(`Failed to fetch source from ${url.toString()}: ${sourceResponse.status}`);
+    }
+    const declaredLength = Number(sourceResponse.headers.get('content-length') ?? '0');
+    if (Number.isFinite(declaredLength) && declaredLength > MAX_CONNECTOR_SOURCE_BYTES) {
+      throw new Error(
+        `Connector source too large: ${declaredLength} bytes (max ${MAX_CONNECTOR_SOURCE_BYTES}).`
+      );
     }
     sourceCode = await sourceResponse.text();
+    if (Buffer.byteLength(sourceCode) > MAX_CONNECTOR_SOURCE_BYTES) {
+      throw new Error(`Connector source too large (max ${MAX_CONNECTOR_SOURCE_BYTES} bytes).`);
+    }
   } else if (params.sourceCode) {
     sourceCode = params.sourceCode;
   } else {


### PR DESCRIPTION
## What

`install_connector({ source_url })` fetches + compiles + runs remote code, but the fetch (`connector-definition-install.ts:121`) had **no scheme check, host allowlist, SSRF protection, timeout, or size cap**.

Context that right-sizes the severity: `install_connector` is **owner/admin-only** (`tool-access.ts:60`, not reachable by agents/workers) and connector code runs in an **isolated subprocess**. So this is admin-triggerable, not agent-reachable — but an admin could be lured into fetching from a private/metadata address (`169.254.169.254`), or a huge/slow URL.

## Changes (one file + tests)
- **https-only** scheme check.
- **SSRF guard:** block loopback / private / link-local hosts (incl. cloud metadata `169.254.169.254`, `10/8`, `172.16–31`, `192.168`, `127/8`, `::1`, `fe80::`, `fc/fd`, `localhost`, `*.internal`).
- **Host allowlist**, default = GitHub (`raw.githubusercontent.com`, `gist.githubusercontent.com`, `objects.githubusercontent.com`, `github.com`). Extend via `CONNECTOR_SOURCE_ALLOWLIST` (`.example.com` = subdomains, `*` = any public host, SSRF guard still applies).
- **30s timeout + 5 MB size cap** (declared content-length + actual body).

## Not touched
- `source_uri` (file://), `source_code`, and the CLI compiled-locally path (`lobu apply` sends `compiled: true` + source_code, never a URL) — so `lobu apply` is unaffected.

## What I deliberately did NOT add
A `compiled_code_hash` integrity gate: it's same-row data, so an attacker who can tamper `compiled_code` tampers the hash too — it's only meaningful against an external trust anchor (a registry), which we're intentionally not building.

## Test
New `connector-source-url-guard.test.ts` — 5 cases covering the pre-fetch reject paths (non-https, metadata IP, loopback/private, off-allowlist, and allowlist-extension lets a host through). All pass; no network. Server `tsc --noEmit` clean.

## Residual risk (documented)
Redirects are followed, so the SSRF guard binds the *initial* host — fine with the GitHub default; keep `*` for trusted environments only.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1382"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784413300&installation_id=136316292&pr_number=1382&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1382&signature=1ea1a85462c3b316b24175d9810969418efd88fe7a5f2eb90cb48c55794240c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->