### PR TITLE
feat(memory): enable multi-vector chunking (#1373)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -16,7 +16,7 @@
     },
     "packages/agent-worker": {
       "name": "@lobu/worker",
-      "version": "11.3.0",
+      "version": "12.0.0",
       "bin": {
         "lobu-worker": "./dist/index.js",
       },
@@ -43,7 +43,7 @@
     },
     "packages/cli": {
       "name": "@lobu/cli",
-      "version": "11.3.0",
+      "version": "12.0.0",
       "bin": {
         "lobu": "bin/lobu.js",
       },
@@ -127,7 +127,7 @@
     },
     "packages/client": {
       "name": "@lobu/client",
-      "version": "11.3.0",
+      "version": "12.0.0",
       "devDependencies": {
         "@hey-api/client-fetch": "^0.13.1",
         "@hey-api/openapi-ts": "^0.86.5",
@@ -136,7 +136,7 @@
     },
     "packages/connector-sdk": {
       "name": "@lobu/connector-sdk",
-      "version": "11.3.0",
+      "version": "12.0.0",
       "dependencies": {
         "@lobu/core": "workspace:*",
         "@sinclair/typebox": "^0.34.41",
@@ -160,12 +160,13 @@
     },
     "packages/connector-worker": {
       "name": "@lobu/connector-worker",
-      "version": "11.3.0",
+      "version": "12.0.0",
       "bin": {
         "connector-worker": "./dist/bin.js",
       },
       "dependencies": {
         "@lobu/connector-sdk": "workspace:*",
+        "@lobu/core": "workspace:*",
         "@lobu/embeddings": "workspace:*",
         "@lobu/worker": "workspace:*",
         "@xenova/transformers": "^2.17.2",
@@ -198,7 +199,7 @@
     },
     "packages/core": {
       "name": "@lobu/core",
-      "version": "11.3.0",
+      "version": "12.0.0",
       "dependencies": {
         "@opentelemetry/api": "^1.9.0",
         "@opentelemetry/exporter-trace-otlp-grpc": "^0.57.0",
@@ -216,7 +217,7 @@
     },
     "packages/embeddings": {
       "name": "@lobu/embeddings",
-      "version": "11.3.0",
+      "version": "12.0.0",
       "dependencies": {
         "@hono/node-server": "^1.13.7",
         "@xenova/transformers": "^2.17.2",
@@ -248,7 +249,7 @@
     },
     "packages/openclaw-plugin": {
       "name": "@lobu/openclaw-plugin",
-      "version": "11.3.0",
+      "version": "12.0.0",
       "dependencies": {
         "@lobu/core": "workspace:*",
       },
@@ -332,7 +333,7 @@
     },
     "packages/pgvector-embedded": {
       "name": "@lobu/pgvector-embedded",
-      "version": "11.3.0",
+      "version": "12.0.0",
       "devDependencies": {
         "@types/node": "20.19.9",
         "typescript": "^5.7.2",
@@ -340,7 +341,7 @@
     },
     "packages/promptfoo-provider": {
       "name": "@lobu/promptfoo-provider",
-      "version": "11.3.0",
+      "version": "12.0.0",
       "devDependencies": {
         "@types/node": "^20.10.0",
         "typescript": "^5.3.3",

--- a/db/migrations/20260618140000_event_embeddings_contract.sql
+++ b/db/migrations/20260618140000_event_embeddings_contract.sql
@@ -13,12 +13,13 @@
 -- is orphan data from a restore or a pre-stamp edge case — drop it.
 DELETE FROM public.event_embeddings WHERE embedding_model IS NULL;
 
-ALTER TABLE public.event_embeddings
-    ALTER COLUMN embedding_model SET NOT NULL;
+-- NULL rows are gone (above); the scan+lock is acceptable in the deploy hook.
+-- squawk-ignore prefer-robust-stmts,adding-not-nullable-field
+ALTER TABLE public.event_embeddings ALTER COLUMN embedding_model SET NOT NULL;
 
 -- Brief catalog lock during the PK swap is acceptable in the deploy hook (the
 -- expand-phase CONCURRENTLY-built unique index is already in place).
-ALTER TABLE public.event_embeddings DROP CONSTRAINT event_embeddings_pkey;
+ALTER TABLE public.event_embeddings DROP CONSTRAINT IF EXISTS event_embeddings_pkey;
 ALTER TABLE public.event_embeddings
     ADD CONSTRAINT event_embeddings_pkey
     PRIMARY KEY USING INDEX event_embeddings_event_model_chunk_uniq;
@@ -72,57 +73,6 @@ CREATE VIEW public.current_event_records AS
 
 -- migrate:down
 
--- Re-attach embedding columns to the view (pre-contract shape). Only safe when
--- at most one event_embeddings row exists per event_id.
-DROP VIEW IF EXISTS public.current_event_records;
-CREATE VIEW public.current_event_records AS
- SELECT e.id,
-    e.organization_id,
-    e.entity_ids,
-    e.origin_id,
-    e.title,
-    e.payload_type,
-    e.payload_text,
-    e.payload_data,
-    e.payload_template,
-    e.attachments,
-    e.metadata,
-    e.score,
-    emb.embedding,
-    e.author_name,
-    e.source_url,
-    e.occurred_at,
-    e.created_at,
-    e.origin_parent_id,
-    COALESCE(length(e.payload_text), 0) AS content_length,
-    e.search_tsv,
-    e.origin_type,
-    e.connector_key,
-    e.connection_id,
-    e.feed_key,
-    e.feed_id,
-    e.run_id,
-    e.semantic_type,
-    e.client_id,
-    e.created_by,
-    e.interaction_type,
-    e.interaction_status,
-    e.interaction_input_schema,
-    e.interaction_input,
-    e.interaction_output,
-    e.interaction_error,
-    e.supersedes_event_id,
-    emb.embedding_model
-   FROM (public.events e
-     LEFT JOIN public.event_embeddings emb ON ((emb.event_id = e.id)))
-  WHERE (NOT (EXISTS ( SELECT 1
-           FROM public.events newer
-          WHERE (newer.supersedes_event_id = e.id))));
-
-ALTER TABLE public.event_embeddings DROP CONSTRAINT event_embeddings_pkey;
-ALTER TABLE public.event_embeddings
-    ADD CONSTRAINT event_embeddings_pkey PRIMARY KEY (event_id);
-CREATE UNIQUE INDEX event_embeddings_event_model_chunk_uniq
-    ON public.event_embeddings (event_id, embedding_model, chunk_index);
-ALTER TABLE public.event_embeddings
-    ALTER COLUMN embedding_model DROP NOT NULL;
+-- Intentionally a no-op: reversing the PK swap or re-coupling the view is
+-- unsafe once multi-vector / multi-model rows exist. PITR is the rollback path.
+SELECT 1;

--- a/db/migrations/20260618140000_event_embeddings_contract.sql
+++ b/db/migrations/20260618140000_event_embeddings_contract.sql
@@ -1,0 +1,128 @@
+-- migrate:up
+
+-- Multi-vector embeddings — CONTRACT phase (2 of 3).
+-- Safe only once every pod runs the expand-phase code (#1370): reads already
+-- join event_embeddings directly; writes use delete-then-insert (no ON CONFLICT
+-- on event_id). This release promotes the expand-phase unique index to the PK,
+-- enforces embedding_model NOT NULL, and decouples current_event_records back to
+-- pure supersession masking. Still no chunking enabled — one chunk-0 row per
+-- (event, model) in practice.
+
+-- Legacy NULL-stamp rows are unusable (search scopes by model) and block NOT
+-- NULL. The backfill migration stamped known legacy rows; anything still NULL
+-- is orphan data from a restore or a pre-stamp edge case — drop it.
+DELETE FROM public.event_embeddings WHERE embedding_model IS NULL;
+
+ALTER TABLE public.event_embeddings
+    ALTER COLUMN embedding_model SET NOT NULL;
+
+-- Brief catalog lock during the PK swap is acceptable in the deploy hook (the
+-- expand-phase CONCURRENTLY-built unique index is already in place).
+ALTER TABLE public.event_embeddings DROP CONSTRAINT event_embeddings_pkey;
+ALTER TABLE public.event_embeddings
+    ADD CONSTRAINT event_embeddings_pkey
+    PRIMARY KEY USING INDEX event_embeddings_event_model_chunk_uniq;
+
+COMMENT ON COLUMN public.event_embeddings.embedding_model IS
+    'Model/version stamp of the embedding model that produced this vector (e.g. "Xenova/bge-base-en-v1.5"). NOT NULL — part of the PK. Vectors from different stamps are NOT comparable even at equal dimensionality.';
+
+-- CREATE OR REPLACE VIEW cannot remove columns; drop and recreate without the
+-- embedding join. Vector callers already read event_embeddings directly.
+DROP VIEW IF EXISTS public.current_event_records;
+CREATE VIEW public.current_event_records AS
+ SELECT e.id,
+    e.organization_id,
+    e.entity_ids,
+    e.origin_id,
+    e.title,
+    e.payload_type,
+    e.payload_text,
+    e.payload_data,
+    e.payload_template,
+    e.attachments,
+    e.metadata,
+    e.score,
+    e.author_name,
+    e.source_url,
+    e.occurred_at,
+    e.created_at,
+    e.origin_parent_id,
+    COALESCE(length(e.payload_text), 0) AS content_length,
+    e.search_tsv,
+    e.origin_type,
+    e.connector_key,
+    e.connection_id,
+    e.feed_key,
+    e.feed_id,
+    e.run_id,
+    e.semantic_type,
+    e.client_id,
+    e.created_by,
+    e.interaction_type,
+    e.interaction_status,
+    e.interaction_input_schema,
+    e.interaction_input,
+    e.interaction_output,
+    e.interaction_error,
+    e.supersedes_event_id
+   FROM public.events e
+  WHERE (NOT (EXISTS ( SELECT 1
+           FROM public.events newer
+          WHERE (newer.supersedes_event_id = e.id))));
+
+-- migrate:down
+
+-- Re-attach embedding columns to the view (pre-contract shape). Only safe when
+-- at most one event_embeddings row exists per event_id.
+DROP VIEW IF EXISTS public.current_event_records;
+CREATE VIEW public.current_event_records AS
+ SELECT e.id,
+    e.organization_id,
+    e.entity_ids,
+    e.origin_id,
+    e.title,
+    e.payload_type,
+    e.payload_text,
+    e.payload_data,
+    e.payload_template,
+    e.attachments,
+    e.metadata,
+    e.score,
+    emb.embedding,
+    e.author_name,
+    e.source_url,
+    e.occurred_at,
+    e.created_at,
+    e.origin_parent_id,
+    COALESCE(length(e.payload_text), 0) AS content_length,
+    e.search_tsv,
+    e.origin_type,
+    e.connector_key,
+    e.connection_id,
+    e.feed_key,
+    e.feed_id,
+    e.run_id,
+    e.semantic_type,
+    e.client_id,
+    e.created_by,
+    e.interaction_type,
+    e.interaction_status,
+    e.interaction_input_schema,
+    e.interaction_input,
+    e.interaction_output,
+    e.interaction_error,
+    e.supersedes_event_id,
+    emb.embedding_model
+   FROM (public.events e
+     LEFT JOIN public.event_embeddings emb ON ((emb.event_id = e.id)))
+  WHERE (NOT (EXISTS ( SELECT 1
+           FROM public.events newer
+          WHERE (newer.supersedes_event_id = e.id))));
+
+ALTER TABLE public.event_embeddings DROP CONSTRAINT event_embeddings_pkey;
+ALTER TABLE public.event_embeddings
+    ADD CONSTRAINT event_embeddings_pkey PRIMARY KEY (event_id);
+CREATE UNIQUE INDEX event_embeddings_event_model_chunk_uniq
+    ON public.event_embeddings (event_id, embedding_model, chunk_index);
+ALTER TABLE public.event_embeddings
+    ALTER COLUMN embedding_model DROP NOT NULL;

--- a/packages/connector-worker/package.json
+++ b/packages/connector-worker/package.json
@@ -47,6 +47,7 @@
   },
   "dependencies": {
     "@lobu/connector-sdk": "workspace:*",
+    "@lobu/core": "workspace:*",
     "@lobu/embeddings": "workspace:*",
     "@lobu/worker": "workspace:*",
     "@xenova/transformers": "^2.17.2",

--- a/packages/connector-worker/src/__tests__/embeddings-chunking.test.ts
+++ b/packages/connector-worker/src/__tests__/embeddings-chunking.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+import { EMBEDDING_MODEL_WINDOW_CHARS } from '@lobu/core';
+import { chunkForEmbedding } from '../embeddings-text.js';
+
+describe('chunkForEmbedding', () => {
+  it('returns a single chunk for short text', () => {
+    const text = 'short memory';
+    expect(chunkForEmbedding(text)).toEqual([text]);
+  });
+
+  it('splits long text into multiple overlapping chunks', () => {
+    const text = `${'word '.repeat(600)}TAIL`;
+    const chunks = chunkForEmbedding(text);
+    expect(chunks.length).toBeGreaterThan(1);
+    expect(chunks[0]!.length).toBeLessThanOrEqual(EMBEDDING_MODEL_WINDOW_CHARS + 200);
+    expect(chunks.join(' ')).toContain('TAIL');
+  });
+});

--- a/packages/connector-worker/src/daemon/executor.ts
+++ b/packages/connector-worker/src/daemon/executor.ts
@@ -7,6 +7,7 @@
 
 import type { Env, EventEnvelope } from '@lobu/connector-sdk';
 import { compileConnectorFromFile, findBundledConnectorFile } from '../compile-connector.js';
+import { chunkForEmbedding } from '../embeddings-text.js';
 import { batchGenerateEmbeddings } from '../embeddings.js';
 import { executeCompiledConnector } from '../executor/runtime.js';
 import { SubprocessExecutor } from '../executor/subprocess.js';
@@ -661,10 +662,10 @@ async function executeEmbedBackfillRun(
       }))
       .filter((p) => p.text.length > 0);
 
-    // Expand phase: one vector per event (chunk_index 0). The schema is ready for
-    // multi-vector, but the worker only starts CHUNKING in the contract release —
-    // until the PK moves off (event_id), more than one row per event would
-    // violate it. So this stays the single vectorized batch pass, tagged chunk 0.
+    // Multi-vector: split long content into overlapping chunks and embed each as
+    // its own row (event_id, model, chunk_index). Short content yields one chunk
+    // (index 0), so behaviour is unchanged below the model window. Per-(event,
+    // model) replace in completeEmbeddings keeps the chunk set atomic.
     const results: Array<{
       event_id: number;
       chunk_index: number;
@@ -673,13 +674,21 @@ async function executeEmbedBackfillRun(
     }> = [];
     let batchError: string | undefined;
     try {
-      const { embeddings, model } = await batchGenerateEmbeddings(pending.map((p) => p.text));
-      for (let i = 0; i < pending.length; i++) {
+      const flat: Array<{ event_id: number; chunk_index: number }> = [];
+      const flatTexts: string[] = [];
+      for (const p of pending) {
+        chunkForEmbedding(p.text).forEach((chunk, chunkIndex) => {
+          flat.push({ event_id: p.event_id, chunk_index: chunkIndex });
+          flatTexts.push(chunk);
+        });
+      }
+      const { embeddings, model } = await batchGenerateEmbeddings(flatTexts);
+      for (let i = 0; i < flat.length; i++) {
         const embedding = embeddings[i];
         if (embedding) {
           results.push({
-            event_id: pending[i]!.event_id,
-            chunk_index: 0,
+            event_id: flat[i]!.event_id,
+            chunk_index: flat[i]!.chunk_index,
             embedding,
             embedding_model: model,
           });

--- a/packages/connector-worker/src/embeddings-text.ts
+++ b/packages/connector-worker/src/embeddings-text.ts
@@ -6,6 +6,12 @@
  * and bun's `mock.module` is process-global, so this logic would otherwise be
  * unreachable in those test runs.
  */
+import {
+  EMBEDDING_CHUNK_CHARS,
+  EMBEDDING_CHUNK_OVERLAP_CHARS,
+  EMBEDDING_MAX_CHUNKS_PER_EVENT,
+  EMBEDDING_MODEL_WINDOW_CHARS,
+} from '@lobu/core';
 
 /**
  * The embeddings service rejects any single text larger than 32 KiB
@@ -34,4 +40,30 @@ export function truncateToBytes(text: string, maxBytes: number): string {
   // toString('utf8') replaces a trailing partial code point with U+FFFD;
   // strip it so we never emit a replacement char.
   return buf.toString('utf8').replace(/�+$/, '');
+}
+
+/**
+ * Split text into overlapping windows for multi-vector embedding. Returns a
+ * single chunk (the whole text) when it fits the model window. The last allowed
+ * chunk absorbs any remaining tail so content past the cap is folded in rather
+ * than dropped. Splits on a whitespace boundary when one is available in the
+ * back half of the window.
+ */
+export function chunkForEmbedding(text: string): string[] {
+  if (text.length <= EMBEDDING_MODEL_WINDOW_CHARS) return [text];
+  const chunks: string[] = [];
+  let start = 0;
+  while (start < text.length) {
+    const atCap = chunks.length === EMBEDDING_MAX_CHUNKS_PER_EVENT - 1;
+    let end = atCap ? text.length : Math.min(start + EMBEDDING_CHUNK_CHARS, text.length);
+    if (end < text.length) {
+      const ws = text.lastIndexOf(' ', end);
+      if (ws > start + EMBEDDING_CHUNK_CHARS / 2) end = ws;
+    }
+    const piece = text.slice(start, end).trim();
+    if (piece.length > 0) chunks.push(piece);
+    if (end >= text.length) break;
+    start = Math.max(end - EMBEDDING_CHUNK_OVERLAP_CHARS, start + 1);
+  }
+  return chunks;
 }

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -42,3 +42,22 @@ export const DEFAULTS = {
   /** Default session timeout in minutes */
   SESSION_TIMEOUT_MINUTES: 5,
 } as const;
+
+/**
+ * Embedding chunking thresholds (multi-vector embeddings).
+ *
+ * The embedder (e.g. Xenova/bge-base-en-v1.5) only encodes ~512 tokens, so a
+ * memory longer than roughly the window has its tail dropped from a single
+ * vector and is invisible to vector search. Content over the window is split
+ * into overlapping chunks and embedded separately. Chars are a deterministic
+ * ~4-chars/token proxy (well under 512 tokens/chunk for tokenizer headroom).
+ *
+ * Shared by the worker chunker (`connector-worker/embeddings-text`) and the
+ * server's "needs (re)embedding" stale rule (`server/utils/embeddings`) so the
+ * split threshold and the detection threshold can never drift apart.
+ */
+export const EMBEDDING_MODEL_WINDOW_CHARS = 2000;
+export const EMBEDDING_CHUNK_CHARS = 1600;
+export const EMBEDDING_CHUNK_OVERLAP_CHARS = 160;
+/** Hard cap on chunks per memory (~100KB folded into the last chunk at 64). */
+export const EMBEDDING_MAX_CHUNKS_PER_EVENT = 64;

--- a/packages/server/src/__tests__/integration/db/migration-invariants.test.ts
+++ b/packages/server/src/__tests__/integration/db/migration-invariants.test.ts
@@ -61,15 +61,47 @@ describe('migration invariants', () => {
       expect(rows).toHaveLength(0);
     });
 
-    it('event_embeddings carries the embedding_model stamp column (#1069/#1080)', async () => {
+    it('event_embeddings carries a NOT NULL embedding_model stamp (#1069/#1080, contract #1372)', async () => {
       const sql = getTestDb();
-      const rows = await sql`
-        SELECT 1 FROM information_schema.columns
+      const rows = await sql<{ is_nullable: string }[]>`
+        SELECT is_nullable FROM information_schema.columns
         WHERE table_schema = 'public'
           AND table_name = 'event_embeddings'
           AND column_name = 'embedding_model'
       `;
       expect(rows).toHaveLength(1);
+      expect(rows[0]?.is_nullable).toBe('NO');
+    });
+
+    it('event_embeddings PK is (event_id, embedding_model, chunk_index) (#1372 contract)', async () => {
+      const sql = getTestDb();
+      const rows = await sql<{ attname: string }[]>`
+        SELECT a.attname
+        FROM pg_index i
+        JOIN pg_attribute a ON a.attrelid = i.indrelid AND a.attnum = ANY(i.indkey)
+        JOIN pg_class c ON c.oid = i.indrelid
+        JOIN pg_namespace n ON n.oid = c.relnamespace
+        WHERE n.nspname = 'public'
+          AND c.relname = 'event_embeddings'
+          AND i.indisprimary
+        ORDER BY array_position(i.indkey, a.attnum)
+      `;
+      expect(rows.map((r) => r.attname)).toEqual([
+        'event_id',
+        'embedding_model',
+        'chunk_index',
+      ]);
+    });
+
+    it('current_event_records is supersession-only — no embedding columns (#1372 contract)', async () => {
+      const sql = getTestDb();
+      const rows = await sql<{ column_name: string }[]>`
+        SELECT column_name FROM information_schema.columns
+        WHERE table_schema = 'public'
+          AND table_name = 'current_event_records'
+          AND column_name IN ('embedding', 'embedding_model')
+      `;
+      expect(rows).toHaveLength(0);
     });
 
     it('stale orphan tables entity_read_grant + mcp_proxy_sessions are dropped (2026-06-16 audit)', async () => {
@@ -125,7 +157,8 @@ describe('migration invariants', () => {
 
     it('redundant/dead indexes are dropped while their covering indexes remain (2026-06-16 audit round 2)', async () => {
       const sql = getTestDb();
-      // Dropped: idx_events_source_embedding (dup of event_embeddings_pkey),
+      // Dropped: idx_events_source_embedding (redundant btree(event_id) before
+      // the contract PK became composite),
       // idx_connect_tokens_token (dup of the UNIQUE connect_tokens_token_key),
       // geo_places_location_idx (postgis index superseded by geo_places_earth_idx).
       const dropped = await sql<{ indexname: string }[]>`

--- a/packages/server/src/__tests__/integration/events/embedding-model-swap-e2e.test.ts
+++ b/packages/server/src/__tests__/integration/events/embedding-model-swap-e2e.test.ts
@@ -187,7 +187,7 @@ describe('embedding model swap E2E (Finding #3)', () => {
     expect(freshRows).toHaveLength(0);
   });
 
-  it('a model-B re-embed replaces the model-A row (expand phase: one row per event)', async () => {
+  it('a model-B re-embed coexists with the model-A row (contract: PK includes model)', async () => {
     const sql = getTestDb();
     // Re-embed the model-A event under model B via the real handler.
     const newVec = new Array(EMBEDDING_DIM).fill(0);
@@ -201,16 +201,32 @@ describe('embedding model swap E2E (Finding #3)', () => {
     });
     await completeEmbeddings(ctx);
 
-    // Expand phase keeps PK(event_id) → one row per event. The delete-then-insert
-    // replaces the model-A row with model B (no coexistence yet — that arrives in
-    // the contract release when the PK includes the model). The point that holds
-    // now: the write uses no ON CONFLICT (event_id), so the contract PK swap
-    // won't break a pod still running this code.
+    // Per-(event, model) delete: model B is written without clobbering model A.
     const rows = (await sql`
-      SELECT embedding_model FROM event_embeddings WHERE event_id = ${eventId}
+      SELECT embedding_model FROM event_embeddings
+      WHERE event_id = ${eventId}
+      ORDER BY embedding_model
     `) as Array<{ embedding_model: string }>;
-    expect(rows).toHaveLength(1);
-    expect(rows[0]!.embedding_model).toBe(MODEL_B);
+    expect(rows.map((r) => r.embedding_model)).toEqual([MODEL_A, MODEL_B]);
+
+    // Under model B the event is now searchable; under model A it still is.
+    process.env.EMBEDDINGS_MODEL = MODEL_B;
+    const underB = await searchContentByText('', {
+      organization_id: orgId,
+      query_embedding: newVec,
+      min_similarity: 0.5,
+      limit: 10,
+    });
+    expect(underB.content.map((r) => Number(r.id))).toContain(eventId);
+
+    process.env.EMBEDDINGS_MODEL = MODEL_A;
+    const underA = await searchContentByText('', {
+      organization_id: orgId,
+      query_embedding: unitVec(),
+      min_similarity: 0.5,
+      limit: 10,
+    });
+    expect(underA.content.map((r) => Number(r.id))).toContain(eventId);
   });
 
   it('an unstamped embedding is not persisted and the event is flagged stale', async () => {
@@ -293,15 +309,20 @@ describe('embedding model swap E2E (Finding #3)', () => {
     await completeEmbeddings(first.ctx);
     expect(first.result()).toMatchObject({ body: { success: true } });
 
-    // The model-B chunk-0 vector is written (replacing the model-A row).
+    // The model-B chunk-0 vector is written alongside the existing model-A row.
     const bRows = (await sql`
       SELECT 1 FROM event_embeddings
       WHERE event_id = ${ev.id} AND embedding_model = ${MODEL_B} AND chunk_index = 0
     `) as unknown[];
     expect(bRows).toHaveLength(1);
+    const aRows = (await sql`
+      SELECT 1 FROM event_embeddings
+      WHERE event_id = ${ev.id} AND embedding_model = ${MODEL_A} AND chunk_index = 0
+    `) as unknown[];
+    expect(aRows).toHaveLength(1);
 
-    // Re-submit the SAME model → atomic replace of model-B's chunk set; end state
-    // is unchanged (still exactly one model-B chunk-0 row).
+    // Re-submit the SAME model → atomic replace of model-B's chunk set; model-A
+    // is untouched and end state is still exactly one model-B chunk-0 row.
     const second = mockEmbeddingsCtx({
       run_id: -1,
       worker_id: 'test-worker',

--- a/packages/server/src/__tests__/integration/events/embedding-stale-tail.test.ts
+++ b/packages/server/src/__tests__/integration/events/embedding-stale-tail.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Stale-detection tail arm (multi-vector embeddings).
+ *
+ * `needsEmbeddingSql` must re-queue long content that only has a chunk-0 vector
+ * (embedded before chunking, or written by the inline single-vector path) so the
+ * backfill re-chunks it. The arm must be self-terminating: once any tail chunk
+ * (index >= 1) exists, the event is no longer stale — otherwise long events
+ * would re-queue forever.
+ */
+
+import { beforeAll, describe, expect, it } from 'vitest';
+import { needsEmbeddingSql } from '../../../utils/embeddings';
+import { insertEvent } from '../../../utils/insert-event';
+import { cleanupTestDatabase, getTestDb } from '../../setup/test-db';
+import {
+  addUserToOrganization,
+  createTestConnection,
+  createTestConnectorDefinition,
+  createTestEntity,
+  createTestOrganization,
+  createTestUser,
+  seedSystemEntityTypes,
+} from '../../setup/test-fixtures';
+
+const EMBEDDING_DIM = 768;
+const MODEL = 'Xenova/bge-base-en-v1.5';
+
+function basisVec(i: number): number[] {
+  const v = new Array(EMBEDDING_DIM).fill(0);
+  v[i] = 1;
+  return v;
+}
+
+// Over the 2000-char model window → the tail arm applies.
+const LONG_CONTENT = 'Sentence about the renewal and the team. '.repeat(60);
+// Comfortably under the window → arm never applies (chunk-0 is enough).
+const SHORT_CONTENT = 'A short note.';
+
+describe('needsEmbeddingSql: long-content tail arm', () => {
+  let orgId: string;
+  let connectionId: number;
+  let longEventId: number;
+  let shortEventId: number;
+  let originalModel: string | undefined;
+
+  async function isStale(eventId: number): Promise<boolean> {
+    const sql = getTestDb();
+    const rows = await sql.unsafe(
+      `SELECT EXISTS (
+         SELECT 1 FROM events e WHERE e.id = $1 AND ${needsEmbeddingSql('e')}
+       ) AS stale`,
+      [eventId]
+    );
+    return Boolean((rows[0] as { stale: boolean }).stale);
+  }
+
+  beforeAll(async () => {
+    originalModel = process.env.EMBEDDINGS_MODEL;
+    process.env.EMBEDDINGS_MODEL = MODEL;
+
+    await cleanupTestDatabase();
+    await seedSystemEntityTypes();
+
+    const org = await createTestOrganization({ name: 'Stale Tail Org' });
+    orgId = org.id;
+    const user = await createTestUser({ email: 'stale-tail-test@example.com' });
+    await addUserToOrganization(user.id, org.id, 'owner');
+    const entity = await createTestEntity({ name: 'Stale Target', organization_id: org.id });
+    await createTestConnectorDefinition({ key: 'st-connector', name: 'ST', organization_id: org.id });
+    const connection = await createTestConnection({
+      organization_id: org.id,
+      connector_key: 'st-connector',
+      entity_ids: [entity.id],
+    });
+    connectionId = connection.id;
+
+    const long = await insertEvent(
+      {
+        entityIds: [entity.id],
+        organizationId: orgId,
+        originId: `st-long-${Date.now()}`,
+        title: 'Long note',
+        content: LONG_CONTENT,
+        occurredAt: new Date(),
+        semanticType: 'content',
+        originType: 'content',
+        connectorKey: 'st-connector',
+        connectionId,
+        embedding: basisVec(0),
+        embeddingModel: MODEL,
+      },
+      { onConflictUpdate: true }
+    );
+    longEventId = long.id;
+
+    const short = await insertEvent(
+      {
+        entityIds: [entity.id],
+        organizationId: orgId,
+        originId: `st-short-${Date.now()}`,
+        title: 'Short note',
+        content: SHORT_CONTENT,
+        occurredAt: new Date(),
+        semanticType: 'content',
+        originType: 'content',
+        connectorKey: 'st-connector',
+        connectionId,
+        embedding: basisVec(1),
+        embeddingModel: MODEL,
+      },
+      { onConflictUpdate: true }
+    );
+    shortEventId = short.id;
+  });
+
+  it('flags long content that only has a chunk-0 vector as stale', async () => {
+    expect(await isStale(longEventId)).toBe(true);
+  });
+
+  it('does not flag short content with a chunk-0 vector', async () => {
+    expect(await isStale(shortEventId)).toBe(false);
+  });
+
+  it('stops flagging the long event once a tail chunk (index >= 1) exists', async () => {
+    const sql = getTestDb();
+    await sql.unsafe(
+      `INSERT INTO event_embeddings (event_id, chunk_index, embedding, embedding_model)
+       VALUES ($1, 1, $2::vector, $3)
+       ON CONFLICT (event_id, embedding_model, chunk_index) DO UPDATE
+         SET embedding = EXCLUDED.embedding`,
+      [longEventId, `[${basisVec(2).join(',')}]`, MODEL]
+    );
+    expect(await isStale(longEventId)).toBe(false);
+  });
+});

--- a/packages/server/src/__tests__/integration/events/multi-vector-retrieval.test.ts
+++ b/packages/server/src/__tests__/integration/events/multi-vector-retrieval.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Multi-vector retrieval reproducer (the bug this change fixes).
+ *
+ * The embedder only encodes ~512 tokens, so a long memory's tail never enters
+ * its single vector and is invisible to vector search. With multi-vector
+ * embeddings, the tail gets its own chunk vector; search ranks the event by its
+ * BEST chunk and returns the whole parent event ("retrieve small, return big").
+ */
+
+import { beforeAll, describe, expect, it } from 'vitest';
+import { searchContentByText } from '../../../utils/content-search';
+import { insertEvent } from '../../../utils/insert-event';
+import { cleanupTestDatabase, getTestDb } from '../../setup/test-db';
+import {
+  addUserToOrganization,
+  createTestConnection,
+  createTestConnectorDefinition,
+  createTestEntity,
+  createTestOrganization,
+  createTestUser,
+  seedSystemEntityTypes,
+} from '../../setup/test-fixtures';
+
+const EMBEDDING_DIM = 768;
+const MODEL = 'Xenova/bge-base-en-v1.5';
+
+function basisVec(i: number): number[] {
+  const v = new Array(EMBEDDING_DIM).fill(0);
+  v[i] = 1;
+  return v;
+}
+const headVec = basisVec(0);
+const tailVec = basisVec(1);
+
+const FULL_CONTENT =
+  'Intro paragraph about the kickoff meeting and the team. ' +
+  'A lot of middle filler that the head vector represents. '.repeat(40) +
+  'TAIL FACT: the renewal date was moved to November 2026.';
+
+describe('multi-vector retrieval: long-memory tail', () => {
+  let orgId: string;
+  let connectionId: number;
+  let eventId: number;
+  let originalModel: string | undefined;
+
+  beforeAll(async () => {
+    originalModel = process.env.EMBEDDINGS_MODEL;
+    process.env.EMBEDDINGS_MODEL = MODEL;
+
+    await cleanupTestDatabase();
+    await seedSystemEntityTypes();
+
+    const org = await createTestOrganization({ name: 'Multi-Vector Org' });
+    orgId = org.id;
+    const user = await createTestUser({ email: 'multivec-test@example.com' });
+    await addUserToOrganization(user.id, org.id, 'owner');
+    const entity = await createTestEntity({ name: 'MV Target', organization_id: org.id });
+
+    await createTestConnectorDefinition({
+      key: 'mv-connector',
+      name: 'MV',
+      organization_id: org.id,
+    });
+    const connection = await createTestConnection({
+      organization_id: org.id,
+      connector_key: 'mv-connector',
+      entity_ids: [entity.id],
+    });
+    connectionId = connection.id;
+
+    const inserted = await insertEvent(
+      {
+        entityIds: [entity.id],
+        organizationId: orgId,
+        originId: `mv-${Date.now()}`,
+        title: 'Long account note',
+        content: FULL_CONTENT,
+        occurredAt: new Date(),
+        semanticType: 'content',
+        originType: 'content',
+        connectorKey: 'mv-connector',
+        connectionId,
+        embedding: headVec,
+        embeddingModel: MODEL,
+      },
+      { onConflictUpdate: true }
+    );
+    eventId = inserted.id;
+  });
+
+  function tailQuery() {
+    return searchContentByText('', {
+      organization_id: orgId,
+      query_embedding: tailVec,
+      min_similarity: 0.5,
+      limit: 10,
+      approximate_candidate_search: true,
+    });
+  }
+
+  it('RED: the tail is unreachable while only the head chunk is embedded', async () => {
+    const res = await tailQuery();
+    expect(res.content.map((r) => Number(r.id))).not.toContain(eventId);
+  });
+
+  it('GREEN: adding the tail chunk makes the event retrievable, returning the full parent', async () => {
+    const sql = getTestDb();
+    await sql.unsafe(
+      `INSERT INTO event_embeddings (event_id, chunk_index, embedding, embedding_model)
+       VALUES ($1, 1, $2::vector, $3)
+       ON CONFLICT (event_id, embedding_model, chunk_index) DO UPDATE
+         SET embedding = EXCLUDED.embedding`,
+      [eventId, `[${tailVec.join(',')}]`, MODEL]
+    );
+
+    const res = await tailQuery();
+    const hit = res.content.find((r) => Number(r.id) === eventId);
+    expect(hit).toBeDefined();
+    expect(hit!.text_content ?? (hit as { payload_text?: string }).payload_text).toContain(
+      'TAIL FACT'
+    );
+  });
+
+  it('cleanup restores EMBEDDINGS_MODEL', () => {
+    if (originalModel === undefined) delete process.env.EMBEDDINGS_MODEL;
+    else process.env.EMBEDDINGS_MODEL = originalModel;
+  });
+});

--- a/packages/server/src/scheduled/trigger-embed-backfill.ts
+++ b/packages/server/src/scheduled/trigger-embed-backfill.ts
@@ -38,12 +38,12 @@ interface OrgBatch {
   event_count: number;
 }
 
-// A row needs (re)embedding when it has no representative (chunk 0) vector for
-// the configured model — covering "no embedding at all", a stale model, and a
-// NULL stamp. The shared predicate (utils/embeddings) keeps this identical to
-// the worker fetch. Correlated anti-join lets the planner drive off `events`
-// (and the partial index) instead of hash-joining the whole event_embeddings
-// table. (The contract release adds the long-content "needs tail chunks" arm.)
+// A row needs (re)embedding when it has no chunk-0 vector for the configured
+// model (no embedding, stale model, or NULL stamp), or it is long content
+// missing its tail chunks (multi-vector). The shared predicate (utils/embeddings)
+// keeps this identical to the worker fetch. Correlated anti-join lets the planner
+// drive off `events` (and the partial index) instead of hash-joining the whole
+// event_embeddings table.
 function needsEmbeddingPredicate(): string {
   return needsEmbeddingSql('e');
 }

--- a/packages/server/src/utils/embeddings.ts
+++ b/packages/server/src/utils/embeddings.ts
@@ -8,6 +8,7 @@
  * embeddings from the service when needed (e.g., classifier values).
  */
 
+import { EMBEDDING_MODEL_WINDOW_CHARS } from '@lobu/core';
 import type { Env } from '../index';
 import logger from '../utils/logger';
 
@@ -54,16 +55,24 @@ export function configuredEmbeddingModelSqlLiteral(): string {
  * so the backfill discovery and the worker fetch can never disagree on what
  * "stale" means. Correlates on `eventAlias`.
  *
- * Expand phase: chunking is not enabled yet (one row per event), so this is the
- * chunk-0 existence check only. The CONTRACT release adds the "long content but
- * no tail chunks" arm once the worker actually produces tail chunks — adding it
- * now would re-queue long events forever (they'd never get a chunk >= 1).
+ * Multi-vector: also flags long content (title + payload over the model window)
+ * that only has a chunk-0 vector — i.e. content embedded before chunking or by
+ * the inline single-vector write path — so the backfill re-chunks it. The arm is
+ * self-terminating: once a tail chunk (index >= 1) exists, it stops matching.
  */
 export function needsEmbeddingSql(eventAlias: string): string {
   const model = configuredEmbeddingModelSqlLiteral();
   const e = eventAlias;
-  return `NOT EXISTS (SELECT 1 FROM event_embeddings emb
+  const missingChunk0 = `NOT EXISTS (SELECT 1 FROM event_embeddings emb
     WHERE emb.event_id = ${e}.id AND emb.embedding_model = ${model} AND emb.chunk_index = 0)`;
+  return `(
+    ${missingChunk0}
+    OR (
+      length(trim(both ' ' from concat_ws(' ', ${e}.title, ${e}.payload_text))) > ${EMBEDDING_MODEL_WINDOW_CHARS}
+      AND NOT EXISTS (SELECT 1 FROM event_embeddings emb
+        WHERE emb.event_id = ${e}.id AND emb.embedding_model = ${model} AND emb.chunk_index >= 1)
+    )
+  )`;
 }
 
 const DEFAULT_TIMEOUT_MS = 30000;

--- a/packages/server/src/utils/insert-event.ts
+++ b/packages/server/src/utils/insert-event.ts
@@ -210,13 +210,10 @@ async function upsertEmbedding(
   // stamped one.
   if (!embeddingModel) return;
   const vectorLiteral = `[${embedding.join(',')}]`;
-  // Replace the event's vector(s) with this single chunk-0 row: delete-then-
-  // insert keeps one row per event under the current PK(event_id) AND stays
-  // valid after the contract release moves the PK off (event_id) — unlike
-  // ON CONFLICT (event_id), which that PK swap would break for any pod still
-  // running this code during the deploy. The contract release narrows the
-  // delete to per-(event, model) once models can coexist.
-  await sql`DELETE FROM event_embeddings WHERE event_id = ${eventId}`;
+  // Replace this (event, model)'s chunk set with a single chunk-0 row:
+  // delete-then-insert scoped to the model so old/new models can coexist
+  // during a zero-downtime swap (PK is event_id + embedding_model + chunk_index).
+  await sql`DELETE FROM event_embeddings WHERE event_id = ${eventId} AND embedding_model = ${embeddingModel}`;
   await sql`
     INSERT INTO event_embeddings (event_id, chunk_index, embedding, embedding_model)
     VALUES (${eventId}, 0, ${vectorLiteral}::vector, ${embeddingModel})

--- a/packages/server/src/worker-api/run-lifecycle.ts
+++ b/packages/server/src/worker-api/run-lifecycle.ts
@@ -991,30 +991,27 @@ export async function completeEmbeddings(c: Context<{ Bindings: Env }>) {
       return c.json({ success: true, updated: 0 });
     }
 
-    // Durability first, THEN finalize the run. Each event's vector(s) are
-    // replaced in their OWN transaction (delete the event's rows, then insert):
-    // per-event isolation so one bad event can't drop another's writes. The
-    // delete+insert (rather than ON CONFLICT (event_id)) is what stays valid
-    // after the contract release moves the PK off (event_id) — so a pod running
-    // THIS code keeps writing correctly during that future rolling deploy.
-    // Expand phase deletes the whole event (all models) and writes one chunk-0
-    // row, keeping one row per event under the current PK(event_id); the contract
-    // release narrows the delete to per-(event, model) for multi-vector + model
-    // coexistence. chunk_index defaults to 0 for an older worker mid-deploy.
-    const byEvent = new Map<number, typeof req.embeddings>();
+    // Durability first, THEN finalize the run. Each (event, model)'s chunk set is
+    // replaced in its OWN transaction (delete that model's rows, then insert):
+    // per-(event, model) isolation so one bad write can't drop another's and so
+    // old/new models can coexist during a zero-downtime swap. chunk_index
+    // defaults to 0 for an older worker mid-deploy.
+    const byEventModel = new Map<string, typeof req.embeddings>();
     for (const item of req.embeddings) {
       if (!item.embedding_model) continue; // unstamped vectors are unusable (search scopes by model)
-      const group = byEvent.get(item.event_id);
+      const key = `${item.event_id}\0${item.embedding_model}`;
+      const group = byEventModel.get(key);
       if (group) group.push(item);
-      else byEvent.set(item.event_id, [item]);
+      else byEventModel.set(key, [item]);
     }
     let updated = 0;
     let failed = 0;
-    for (const [eventId, items] of byEvent) {
+    for (const [, items] of byEventModel) {
+      const eventId = items[0]!.event_id;
       const model = items[0]!.embedding_model!;
       try {
         await sql.begin(async (tx) => {
-          await tx`DELETE FROM event_embeddings WHERE event_id = ${eventId}`;
+          await tx`DELETE FROM event_embeddings WHERE event_id = ${eventId} AND embedding_model = ${model}`;
           for (const item of items) {
             const vectorStr = `[${item.embedding.join(',')}]`;
             await tx.unsafe(
@@ -1045,7 +1042,7 @@ export async function completeEmbeddings(c: Context<{ Bindings: Env }>) {
       ...(failed > 0
         ? {
             extraSet: sql`,
-              error_message = ${`${failed}/${byEvent.size} event embedding writes failed`}`,
+              error_message = ${`${failed}/${byEventModel.size} event embedding writes failed`}`,
           }
         : {}),
     });


### PR DESCRIPTION
Phase 3 of 3 of the multi-vector memory rollout, **stacked on the contract phase (#1380, issue #1372)** — review/merge that first. Closes #1373.

## What this does
- **core**: `EMBEDDING_*` window/chunk/overlap/cap constants, shared by the worker chunker and the server stale rule so the split and detect thresholds can't drift.
- **connector-worker**: `chunkForEmbedding()` splits content over the ~2KB model window into overlapping ~400-token chunks (64-chunk cap, tail folded into the last chunk); the embed-backfill executor emits N `(event, model, chunk_index)` rows. Short content is unchanged (one chunk-0 row).
- **server**: `needsEmbeddingSql` gains a long-content tail arm — long content with only a chunk-0 vector is re-queued, and the arm self-terminates once a tail chunk (index ≥ 1) exists.

The retrieval-side chunk→event collapse (best-chunk-per-event + parent return) already shipped in the expand phase (#1370), so this PR is write-path + discovery only.

## Why no feature flag (the simplification)
The combined-PR approach (#1383) needed `LOBU_EMBEDDING_CHUNKING` because it bundled contract + chunking into one deploy and had to hold chunking back until the per-`(event,model)` replace code was on every pod. Shipping the contract phase (#1380) as its own release gives that precondition for free: by the time this lands, every pod already replaces chunk sets per model. The flag-flip rolling-restart window and a two-PR phase-B rolling window are identical in safety (an old non-chunker pod can transiently per-model-delete tail chunks; the self-terminating stale arm re-chunks them on the next backfill) — so the flag bought no safety, only permanent dead code to remember to remove. This matches the original phased design in #1370/#1372/#1373.

**Supersedes #1383** (contract + chunking + flag in one PR) — close that in favor of #1380 + this.

## Validation (local, Postgres 18 + pgvector 0.8.1)
- `chunkForEmbedding` unit — single chunk below window, overlapping multi-chunk above, tail preserved.
- `multi-vector-retrieval.test.ts` — red→green: long-memory tail unreachable with head-only, retrievable (full parent returned) after the tail chunk.
- `embedding-stale-tail.test.ts` (new) — red→green: long chunk-0-only event flagged stale; short event not flagged; flagging stops once a tail chunk exists.
- Regression: `embedding-model-swap-e2e` (7), `embedding-model-stamp` (2), `migration-invariants` (11), `trigger-embed-backfill` (1) all green against the same DB.
- `make typecheck` clean; `bun run check:fix` clean.

## Rollout
1. Merge + deploy **#1380** (contract) — no behavior change.
2. Merge + deploy **this** — chunking active immediately on every pod; the backfill re-chunks long events via the tail arm. No env flag to flip.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1385"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784420136&installation_id=136316292&pr_number=1385&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1385&signature=3c76743b1295de4e1837c3cda6a2ea32ed4202aff9abb86454c5a988eeb4fa56"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->