### PR TITLE
feat(server): drop the 4-field cap on x-table-column metadata fields

### DIFF
--- a/packages/cli/src/commands/_lib/apply/__tests__/client.test.ts
+++ b/packages/cli/src/commands/_lib/apply/__tests__/client.test.ts
@@ -344,7 +344,7 @@ describe("isDuplicateError", () => {
     expect(
       isDuplicateError(
         new ApiError(
-          "POST /x failed: [invalid_schema] At most 4 metadata fields can have x-table-column=true.",
+          "POST /x failed: [invalid_schema] metadata_schema.properties.a.x-table-column must be a boolean",
           422
         )
       )
@@ -402,7 +402,7 @@ describe("ApplyClient — upsert create/update flow", () => {
         return new Response(
           JSON.stringify({
             error:
-              "[invalid_schema] At most 4 metadata fields can have x-table-column=true.",
+              "[invalid_schema] metadata_schema.properties.a.x-table-column must be a boolean",
           }),
           { status: 422 }
         );
@@ -411,7 +411,9 @@ describe("ApplyClient — upsert create/update flow", () => {
 
     await expect(
       client.upsertEntityType({ slug: "task", name: "Task" })
-    ).rejects.toThrow(/At most 4 metadata fields can have x-table-column=true/);
+    ).rejects.toThrow(
+      /metadata_schema.properties.a.x-table-column must be a boolean/
+    );
     // The doomed `update` retry (which produced the misleading
     // "Entity type 'task' not found") must not happen.
     expect(calls).toHaveLength(1);

--- a/packages/server/src/__tests__/integration/entity-schema/entity-types.test.ts
+++ b/packages/server/src/__tests__/integration/entity-schema/entity-types.test.ts
@@ -75,30 +75,30 @@ describe('entity schema CRUD', () => {
       await owner.entity_schema.deleteType('dup-asset');
     });
 
-    it('rejects >4 x-table-column fields with a 422 carrying the real message (issue #1177)', async () => {
-      // Five flagged columns; before the fix this surfaced through `lobu apply`
-      // as a misleading "Entity type 'task' not found" instead of the message.
-      const properties = Object.fromEntries(
-        ['a', 'b', 'c', 'd', 'e'].map((f) => [
-          f,
-          { type: 'string', 'x-table-column': true },
-        ])
-      );
+    it('surfaces a 422 schema-validation error with the real message (issue #1177)', async () => {
+      // A non-boolean x-table-column trips [invalid_schema]; before the fix
+      // this surfaced through `lobu apply` as a misleading "Entity type 'task'
+      // not found" instead of the real message. Any 422 schema fault exercises
+      // the same path — the cap on x-table-column count was removed, so we use
+      // the surviving per-field type check here.
       const err = await owner.entity_schema
         .createType({
-          slug: 'too-many-columns',
-          name: 'Too Many',
-          metadata_schema: { type: 'object', properties },
+          slug: 'bad-schema',
+          name: 'Bad Schema',
+          metadata_schema: {
+            type: 'object',
+            properties: { a: { type: 'string', 'x-table-column': 'yes' } },
+          },
         })
         .then(() => null)
         .catch((e: unknown) => e as Error & { httpStatus?: number });
       expect(err).not.toBeNull();
       expect(err?.message).toContain('[invalid_schema]');
-      expect(err?.message).toContain('At most 4 metadata fields can have x-table-column=true.');
+      expect(err?.message).toContain('metadata_schema.properties.a.x-table-column must be a boolean');
       expect(err?.httpStatus).toBe(422);
       // Validation rejected the create entirely — nothing persisted, so a
       // follow-up create-after-fix is a clean create (not an update).
-      const got = (await owner.entity_schema.getType('too-many-columns')) as {
+      const got = (await owner.entity_schema.getType('bad-schema')) as {
         entity_type: unknown;
       };
       expect(got.entity_type).toBeNull();

--- a/packages/server/src/tools/admin/manage_entity_schema.ts
+++ b/packages/server/src/tools/admin/manage_entity_schema.ts
@@ -371,15 +371,11 @@ function validateEntityMetadataSchemaDisplayConfig(
     return;
   }
 
-  let tableColumnCount = 0;
-
   for (const [field, prop] of Object.entries(properties)) {
     if (!prop || typeof prop !== 'object' || Array.isArray(prop)) continue;
 
     const tableColumn = (prop as Record<string, unknown>)['x-table-column'];
-    if (tableColumn === true) {
-      tableColumnCount += 1;
-    } else if (tableColumn !== undefined && typeof tableColumn !== 'boolean') {
+    if (tableColumn !== undefined && typeof tableColumn !== 'boolean') {
       throw invalidSchema(`metadata_schema.properties.${field}.x-table-column must be a boolean`);
     }
 
@@ -387,10 +383,6 @@ function validateEntityMetadataSchemaDisplayConfig(
     if (tableLabel !== undefined && typeof tableLabel !== 'string') {
       throw invalidSchema(`metadata_schema.properties.${field}.x-table-label must be a string`);
     }
-  }
-
-  if (tableColumnCount > 4) {
-    throw invalidSchema('At most 4 metadata fields can have x-table-column=true.');
   }
 }
 


### PR DESCRIPTION
## Why

The `>4 x-table-column` check in `validateEntityMetadataSchemaDisplayConfig` was a pure UI width guard with no technical backing:

- `metadata_schema.properties` itself is **unbounded** — the cap only counted fields flagged with `x-table-column: true`.
- The owletto entities table (`packages/owletto/src/app/$owner/$entityType/index.tsx`) already renders **any number** of flagged columns from the `ColumnDef[]`; there's no corresponding client-side limit, so the two were already out of sync in spirit.
- No DB column, fixed array, or other consumer depends on the number `4`.

Server-side validation was policing a client-side layout concern the client doesn't enforce. Removed the cap and the now-unused `tableColumnCount` accumulator; kept the per-field type checks (non-boolean `x-table-column` / non-string `x-table-label`).

## Tests

- The integration test that used the `>4` cap as a vehicle now exercises a surviving `[invalid_schema]` 422 (a non-boolean `x-table-column` value), so **issue #1177's** contract — *surface the real 422 message instead of misreporting it as "Entity type not found"* — stays covered.
- The CLI apply-client unit tests swap their sample `[invalid_schema]` 422 payload to the same surviving message; the logic under test (422 is not a duplicate; 422 surfaces verbatim, no `update` retry) is unchanged.

## Validation

- `bun run typecheck` ✅
- `make build-packages` ✅
- `bun test packages/cli/src/commands/_lib/apply/__tests__/client.test.ts` → 21 pass ✅
- `DATABASE_URL=…lobu_tablecap_test vitest run …/entity-schema/entity-types.test.ts` → 12 pass ✅

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1386"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784424511&installation_id=136316292&pr_number=1386&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1386&signature=bdf5b93f91f103a98b4051babc2005227a3a9af14f8c89edfa11f2b1926968d8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced entity schema validation to properly enforce boolean type requirements for table column metadata fields.
  * Removed previous limit on the number of metadata fields that can be configured for table display.
  * Updated validation error messages for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->