### PR TITLE
fix(server): Slack OAuth redirect_uri must carry the /lobu gateway prefix

### DIFF
--- a/packages/cli/src/commands/dev.ts
+++ b/packages/cli/src/commands/dev.ts
@@ -794,7 +794,7 @@ async function printPreviewInstructions(cwd: string): Promise<void> {
       if (platform === "slack") {
         console.log(
           chalk.dim(
-            `  Or add it to your own Slack workspace: ${chalk.underline(`${clientInfo.apiBaseUrl}/slack/install`)} (then ${chalk.bold(claim.command)} in a channel there).`
+            `  Or add it to your own Slack workspace: ${chalk.underline(`${clientInfo.apiBaseUrl}/lobu/slack/install`)} (then ${chalk.bold(claim.command)} in a channel there).`
           )
         );
       }

--- a/packages/server/src/gateway/__tests__/slack-routes.test.ts
+++ b/packages/server/src/gateway/__tests__/slack-routes.test.ts
@@ -1,8 +1,43 @@
 import { afterEach, beforeAll, beforeEach, describe, expect, mock, test } from "bun:test";
 import { Hono } from "hono";
 import { getDb } from "../../db/client.js";
-import { createSlackRoutes } from "../routes/public/slack.js";
+import {
+  createSlackRoutes,
+  slackOAuthCallbackUrl,
+} from "../routes/public/slack.js";
 import { ensureDbForGatewayTests, resetTestDatabase } from "./helpers/db-setup.js";
+
+describe("slackOAuthCallbackUrl", () => {
+  // The gateway is served under the public `/lobu` prefix in prod, so the
+  // callback must preserve it (else Slack rejects the install with
+  // "redirect_uri did not match any configured URIs").
+  test("preserves the /lobu prefix from the configured gateway base", () => {
+    expect(
+      slackOAuthCallbackUrl("https://app.lobu.ai/lobu", "https://app.lobu.ai/lobu/slack/install")
+    ).toBe("https://app.lobu.ai/lobu/slack/oauth_callback");
+  });
+
+  test("trims a trailing slash on the gateway base", () => {
+    expect(
+      slackOAuthCallbackUrl("https://app.lobu.ai/lobu/", "https://app.lobu.ai/lobu/slack/install")
+    ).toBe("https://app.lobu.ai/lobu/slack/oauth_callback");
+  });
+
+  test("supports a root-mounted gateway (no prefix)", () => {
+    expect(
+      slackOAuthCallbackUrl("https://gateway.example.com", "https://gateway.example.com/slack/install")
+    ).toBe("https://gateway.example.com/slack/oauth_callback");
+  });
+
+  test("falls back to deriving the mount prefix from the request path", () => {
+    expect(
+      slackOAuthCallbackUrl(undefined, "https://app.lobu.ai/lobu/slack/install")
+    ).toBe("https://app.lobu.ai/lobu/slack/oauth_callback");
+    expect(
+      slackOAuthCallbackUrl(undefined, "https://app.lobu.ai/slack/install?foo=bar")
+    ).toBe("https://app.lobu.ai/slack/oauth_callback");
+  });
+});
 
 describe("slack routes", () => {
   const originalClientId = process.env.SLACK_CLIENT_ID;

--- a/packages/server/src/gateway/routes/public/slack.ts
+++ b/packages/server/src/gateway/routes/public/slack.ts
@@ -9,7 +9,6 @@ import {
   renderOAuthSuccessPage,
 } from "../../auth/oauth-templates.js";
 import type { ChatInstanceManager } from "../../connections/chat-instance-manager.js";
-import { resolvePublicUrl } from "../../utils/public-url.js";
 
 const logger = createLogger("slack-routes");
 
@@ -148,6 +147,34 @@ async function loadSlackBotScopes(): Promise<string[]> {
   return DEFAULT_SLACK_BOT_SCOPES;
 }
 
+/**
+ * Build the Slack OAuth `redirect_uri`. The gateway — and these Slack routes —
+ * are served under the public `/lobu` prefix, so the callback lives at
+ * `<gateway-base>/slack/oauth_callback` (e.g.
+ * `https://app.lobu.ai/lobu/slack/oauth_callback`). `getPublicGatewayUrl()`
+ * already encodes that prefix, so append the callback path to it directly.
+ *
+ * We must NOT route this through `resolvePublicUrl("/slack/oauth_callback")`:
+ * an absolute `/slack/...` path resolves against the origin and drops `/lobu`,
+ * producing a `redirect_uri` that matches neither the real callback route nor
+ * the Slack app's configured redirect-URI allowlist (Slack then rejects the
+ * install with "redirect_uri did not match any configured URIs").
+ *
+ * Falls back to deriving the mount prefix from the request path
+ * (`…/slack/install` → `…`) when no public gateway URL is configured.
+ */
+export function slackOAuthCallbackUrl(
+  gatewayBaseUrl: string | undefined,
+  requestUrl: string
+): string {
+  if (gatewayBaseUrl) {
+    return `${gatewayBaseUrl.replace(/\/+$/, "")}/slack/oauth_callback`;
+  }
+  const url = new URL(requestUrl);
+  const prefix = url.pathname.replace(/\/slack\/install\/?$/, "");
+  return `${url.origin}${prefix}/slack/oauth_callback`;
+}
+
 export function createSlackRoutes(manager: ChatInstanceManager): Hono {
   const router = new Hono();
 
@@ -180,10 +207,10 @@ export function createSlackRoutes(manager: ChatInstanceManager): Hono {
     }
 
     const stateStore = createSlackInstallStateStore();
-    const redirectUri = resolvePublicUrl("/slack/oauth_callback", {
-      configuredUrl: manager.getServices().getPublicGatewayUrl?.(),
-      requestUrl: c.req.url,
-    });
+    const redirectUri = slackOAuthCallbackUrl(
+      manager.getServices().getPublicGatewayUrl?.(),
+      c.req.url
+    );
     const scopes = await loadSlackBotScopes();
     const state = await stateStore.create({
       redirectUri,


### PR DESCRIPTION
## Bug

Clicking **Add to Slack** (and the `lobu run` install URL) never completed an install. Two layers:

1. **URL prefix** — the gateway + Slack routes are served under `/lobu`, so `/slack/install` hit the SPA fallback, not the OAuth route. (Button fixed in owletto#300; `lobu run` print fixed here.)
2. **redirect_uri** — even at `/lobu/slack/install`, the route 302'd to Slack with `redirect_uri=app.lobu.ai/slack/oauth_callback` (no `/lobu`). That's neither the real callback (`/lobu/slack/oauth_callback`, verified 400 'missing state/code') nor in the Slack app's allowlist → Slack rejected the install with *'redirect_uri did not match any configured URIs'*.

Root cause: `resolvePublicUrl("/slack/oauth_callback", { configuredUrl })` joins an **absolute** path, which resolves against the origin and discards the `/lobu` segment that `getPublicGatewayUrl()` carries.

## Fix

`slackOAuthCallbackUrl(gatewayBase, requestUrl)` appends the callback to the prefix-bearing gateway base (falls back to deriving the prefix from the request path). Backward-compatible for root-mounted gateways.

## Validation

- 4 new unit tests for `slackOAuthCallbackUrl` (preserve `/lobu`, trim slash, root-mounted, request-derived fallback) — pass.
- Server `tsc` clean; existing `/slack/install` route test still green (its gateway base has no prefix).
- Slack app redirect-URI allowlist updated to include `https://app.lobu.ai/lobu/slack/oauth_callback` (separately).
- Full e2e (click → Slack OAuth → approve → connection lands) to be verified post-deploy.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1389"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784432741&installation_id=136316292&pr_number=1389&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1389&signature=d4342ffd84efd8b7481937c5e71b6c40a58434a3264b6d538963de5d540292a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Slack OAuth callback URL handling to correctly support different deployment configurations and mount prefixes.

* **Tests**
  * Added tests verifying Slack OAuth callback URL construction, including fallback scenarios when no public gateway URL is configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->