### PR TITLE
fix(server): make env-configured Anthropic API keys work (x-api-key + recognition)

### DIFF
--- a/packages/server/src/gateway/__tests__/secret-proxy.test.ts
+++ b/packages/server/src/gateway/__tests__/secret-proxy.test.ts
@@ -250,6 +250,112 @@ describe("SecretProxy user-scoped provider routing", () => {
   });
 });
 
+describe("SecretProxy API-key header scheme (Anthropic x-api-key vs Bearer)", () => {
+  // Forward one request through the URL-scoped provider path and report which
+  // auth header the proxy attached. The profile supplies the resolved
+  // credential + its authType, mirroring a per-agent auth profile (or, for an
+  // api-key, an env/org system key — same header decision).
+  async function forwardWithProfile(opts: {
+    slug: string;
+    apiKeyHeader?: "authorization" | "x-api-key";
+    authType: "api-key" | "oauth";
+    credential: string;
+  }): Promise<{
+    status: number;
+    authorization: string | null;
+    xApiKey: string | null;
+  }> {
+    const proxy = new SecretProxy(
+      { defaultUpstreamUrl: "https://default.example.com" },
+      { get: async () => null } satisfies SecretStore
+    );
+    proxy.registerUpstream(
+      {
+        slug: opts.slug,
+        upstreamBaseUrl: `https://api.${opts.slug}.example.com`,
+        apiKeyHeader: opts.apiKeyHeader,
+      },
+      opts.slug
+    );
+    proxy.setAuthProfilesManager({
+      getBestProfile: async (agentId: string, provider: string) => ({
+        id: "runtime",
+        provider,
+        credential: opts.credential,
+        authType: opts.authType,
+        label: "runtime",
+        createdAt: Date.now(),
+      }),
+      ensureFreshCredential: async (profile: { credential?: string }) =>
+        profile.credential,
+    } as any);
+
+    const originalFetch = globalThis.fetch;
+    let authorization: string | null = null;
+    let xApiKey: string | null = null;
+    globalThis.fetch = async (_input, init) => {
+      const h = (init?.headers as Record<string, string>) ?? {};
+      authorization = h.authorization ?? null;
+      xApiKey = h["x-api-key"] ?? null;
+      return new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    };
+    try {
+      const res = await proxy
+        .getApp()
+        .request(`/api/proxy/${opts.slug}/a/agent-1/v1/messages`, {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            authorization: "Bearer worker-token-test",
+          },
+          body: JSON.stringify({ prompt: "hi" }),
+        });
+      return { status: res.status, authorization, xApiKey };
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  }
+
+  test("Anthropic API key is sent as x-api-key, never Bearer (regression: 401 invalid bearer token)", async () => {
+    const r = await forwardWithProfile({
+      slug: "anthropic",
+      apiKeyHeader: "x-api-key",
+      authType: "api-key",
+      credential: "sk-ant-api03-realkey",
+    });
+    expect(r.status).toBe(200);
+    expect(r.xApiKey).toBe("sk-ant-api03-realkey");
+    expect(r.authorization).toBeNull();
+  });
+
+  test("OpenAI-compatible API key stays Authorization: Bearer", async () => {
+    const r = await forwardWithProfile({
+      slug: "openai",
+      apiKeyHeader: undefined,
+      authType: "api-key",
+      credential: "sk-openai-key",
+    });
+    expect(r.status).toBe(200);
+    expect(r.authorization).toBe("Bearer sk-openai-key");
+    expect(r.xApiKey).toBeNull();
+  });
+
+  test("Anthropic OAuth token still uses Authorization: Bearer (not x-api-key)", async () => {
+    const r = await forwardWithProfile({
+      slug: "anthropic",
+      apiKeyHeader: "x-api-key",
+      authType: "oauth",
+      credential: "sk-ant-oat01-oauthtoken",
+    });
+    expect(r.status).toBe(200);
+    expect(r.authorization).toBe("Bearer sk-ant-oat01-oauthtoken");
+    expect(r.xApiKey).toBeNull();
+  });
+});
+
 describe("resolveProviderCredential (egress resolution chain)", () => {
   const neverDb = async (): Promise<string | null> => {
     throw new Error("DB lookup must not run for this tier");
@@ -265,7 +371,19 @@ describe("resolveProviderCredential (egress resolution chain)", () => {
         throw new Error("system tier must not run");
       },
     });
-    expect(credential).toBe("profile-key");
+    expect(credential).toEqual({ value: "profile-key", kind: "api-key" });
+  });
+
+  test("tier 1: an OAuth profile is classified as kind 'oauth' (Bearer)", async () => {
+    const credential = await resolveProviderCredential({
+      profileCredential: "oauth-token",
+      profileAuthType: "oauth",
+      providerId: "anthropic",
+      organizationId: "org-a",
+      readOrgSharedKey: neverDb,
+      systemKeyResolver: undefined,
+    });
+    expect(credential).toEqual({ value: "oauth-token", kind: "oauth" });
   });
 
   test("tier 2: org-shared apply-provisioned key resolves when no profile exists (LOBU-BACKEND-W regression)", async () => {
@@ -282,7 +400,7 @@ describe("resolveProviderCredential (egress resolution chain)", () => {
         throw new Error("system tier must not run when org key exists");
       },
     });
-    expect(credential).toBe("org-shared-key");
+    expect(credential).toEqual({ value: "org-shared-key", kind: "api-key" });
     expect(calls).toEqual([["openai", "org-a"]]);
   });
 
@@ -292,20 +410,20 @@ describe("resolveProviderCredential (egress resolution chain)", () => {
       providerId: "openai",
       organizationId: undefined,
       readOrgSharedKey: neverDb,
-      systemKeyResolver: () => "system-key",
+      systemKeyResolver: () => ({ value: "system-key", kind: "api-key" }),
     });
-    expect(credential).toBe("system-key");
+    expect(credential).toEqual({ value: "system-key", kind: "api-key" });
   });
 
-  test("tier 3: system key resolves when profile and org tiers miss", async () => {
+  test("tier 3: system key resolves (with kind) when profile and org tiers miss", async () => {
     const credential = await resolveProviderCredential({
       profileCredential: null,
-      providerId: "openai",
+      providerId: "anthropic",
       organizationId: "org-a",
       readOrgSharedKey: async () => null,
-      systemKeyResolver: () => "system-key",
+      systemKeyResolver: () => ({ value: "oauth-system", kind: "oauth" }),
     });
-    expect(credential).toBe("system-key");
+    expect(credential).toEqual({ value: "oauth-system", kind: "oauth" });
   });
 
   test("null when every tier misses (handler 401s with no_credentials)", async () => {

--- a/packages/server/src/gateway/auth/base-provider-module.ts
+++ b/packages/server/src/gateway/auth/base-provider-module.ts
@@ -43,6 +43,11 @@ interface BaseProviderConfig {
   credentialEnvVarName: string;
   /** All env vars this provider considers secrets */
   secretEnvVarNames: string[];
+  /**
+   * Subset of `secretEnvVarNames` holding Bearer/OAuth-style tokens (not API
+   * keys). Used to classify a system-key credential's kind. Default: none.
+   */
+  bearerCredentialEnvVarNames?: string[];
   /** Env var to check for system key (defaults to credentialEnvVarName) */
   systemEnvVarName?: string;
   /** Provider slug for proxy path routing (e.g. "anthropic") */
@@ -51,6 +56,11 @@ interface BaseProviderConfig {
   upstreamBaseUrl?: string;
   /** Explicit base URL env var name (defaults to slug-derived name) */
   baseUrlEnvVarName?: string;
+  /**
+   * Header used to present an API-KEY credential to the upstream proxy.
+   * `"x-api-key"` for Anthropic; omitted (Bearer) for OpenAI-compatible APIs.
+   */
+  apiKeyHeader?: "authorization" | "x-api-key";
   authType: "oauth" | "device-code" | "api-key";
   supportedAuthTypes?: ("oauth" | "device-code" | "api-key")[];
   apiKeyInstructions?: string;
@@ -121,18 +131,23 @@ export abstract class BaseProviderModule
     return this.providerConfig.secretEnvVarNames;
   }
 
+  getBearerCredentialEnvVarNames(): string[] {
+    return this.providerConfig.bearerCredentialEnvVarNames ?? [];
+  }
+
   getCredentialEnvVarName(): string {
     return this.providerConfig.credentialEnvVarName;
   }
 
   getUpstreamConfig(): ProviderUpstreamConfig | null {
-    const { slug, upstreamBaseUrl, baseUrlEnvVarName } = this.providerConfig;
+    const { slug, upstreamBaseUrl, baseUrlEnvVarName, apiKeyHeader } =
+      this.providerConfig;
     if (!slug || !upstreamBaseUrl) return null;
     // Check env for base URL override (e.g., ANTHROPIC_BASE_URL=https://api.z.ai)
     const envOverride = baseUrlEnvVarName
       ? resolveEnv(baseUrlEnvVarName)
       : undefined;
-    return { slug, upstreamBaseUrl: envOverride || upstreamBaseUrl };
+    return { slug, upstreamBaseUrl: envOverride || upstreamBaseUrl, apiKeyHeader };
   }
 
   async hasCredentials(

--- a/packages/server/src/gateway/auth/claude/oauth-module.ts
+++ b/packages/server/src/gateway/auth/claude/oauth-module.ts
@@ -33,9 +33,21 @@ export class ClaudeOAuthModule extends BaseProviderModule {
           "ANTHROPIC_AUTH_TOKEN",
           "CLAUDE_CODE_OAUTH_TOKEN",
         ],
+        // Bearer/OAuth tokens — presented as `Authorization: Bearer`, not
+        // `x-api-key`. ANTHROPIC_API_KEY (the sk-ant key) is the only x-api-key
+        // credential and is intentionally absent here.
+        bearerCredentialEnvVarNames: [
+          "ANTHROPIC_AUTH_TOKEN",
+          "CLAUDE_CODE_OAUTH_TOKEN",
+        ],
         slug: "anthropic",
         upstreamBaseUrl: "https://api.anthropic.com",
         baseUrlEnvVarName: "ANTHROPIC_BASE_URL",
+        // Anthropic rejects API keys sent as `Authorization: Bearer` (401
+        // "invalid bearer token") — they must ride in the `x-api-key` header.
+        // OAuth tokens still use Bearer (the secret proxy checks credential
+        // type before applying this scheme).
+        apiKeyHeader: "x-api-key",
         authType: "oauth",
         supportedAuthTypes: ["oauth", "api-key"],
         apiKeyInstructions:
@@ -53,9 +65,16 @@ export class ClaudeOAuthModule extends BaseProviderModule {
   // ---- Overrides for multi-env-var logic ----
 
   override hasSystemKey(): boolean {
+    // Recognize all three credential env vars: a plain ANTHROPIC_API_KEY (the
+    // standard var most users set) is a valid system key, same as every other
+    // provider's API key. Without it, an env-configured Anthropic key was
+    // silently treated as "not connected" — the agent reported "No model
+    // configured" even though injectSystemKeyFallback would have used the key.
+    // The proxy presents it via x-api-key (see ProviderUpstreamConfig.apiKeyHeader).
     return !!(
       resolveEnv("ANTHROPIC_AUTH_TOKEN") ||
-      resolveEnv("CLAUDE_CODE_OAUTH_TOKEN")
+      resolveEnv("CLAUDE_CODE_OAUTH_TOKEN") ||
+      resolveEnv("ANTHROPIC_API_KEY")
     );
   }
 

--- a/packages/server/src/gateway/modules/module-system.ts
+++ b/packages/server/src/gateway/modules/module-system.ts
@@ -13,6 +13,14 @@ interface OrchestratorModule extends ModuleInterface {
 export interface ProviderUpstreamConfig {
   slug: string;
   upstreamBaseUrl: string;
+  /**
+   * Header used to present an API-KEY credential to this upstream. Anthropic
+   * requires `x-api-key` and 401s ("invalid bearer token") when an `sk-ant`
+   * key is sent as `Authorization: Bearer` — which is the OpenAI-compatible
+   * default every other provider uses. OAuth credentials always use
+   * `Authorization: Bearer` regardless of this setting. Omit for Bearer.
+   */
+  apiKeyHeader?: "authorization" | "x-api-key";
 }
 
 export interface ModelProviderModule extends OrchestratorModule {
@@ -27,6 +35,13 @@ export interface ModelProviderModule extends OrchestratorModule {
   catalogVisible?: boolean;
   getSecretEnvVarNames(): string[];
   getCredentialEnvVarName(): string;
+  /**
+   * Subset of `getSecretEnvVarNames()` whose values are Bearer/OAuth-style
+   * tokens (e.g. `CLAUDE_CODE_OAUTH_TOKEN`) rather than API keys. Lets the
+   * system-key resolver classify a resolved env credential as `"oauth"` so the
+   * secret proxy presents it as `Authorization: Bearer`. Default: none.
+   */
+  getBearerCredentialEnvVarNames?(): string[];
   getUpstreamConfig?(): ProviderUpstreamConfig | null;
   hasCredentials(
     agentId: string,

--- a/packages/server/src/gateway/proxy/secret-proxy.ts
+++ b/packages/server/src/gateway/proxy/secret-proxy.ts
@@ -270,23 +270,53 @@ function parseBearer(authHeader: string | undefined): string | null {
  * Exported for tests; dependencies are injected so the tier ORDER is testable
  * without a database or upstream.
  */
+/**
+ * How a resolved credential must be presented to the upstream. `"oauth"`
+ * credentials always use `Authorization: Bearer`; `"api-key"` credentials honor
+ * the provider's declared `apiKeyHeader` (Bearer for OpenAI-compatible APIs,
+ * `x-api-key` for Anthropic). Determined at resolution time — never inferred
+ * from the credential string.
+ */
+export type CredentialKind = "oauth" | "api-key";
+
+/** A system (env) key plus its kind, returned by the system-key resolver. */
+export interface SystemKeyResult {
+  value: string;
+  kind: CredentialKind;
+}
+
+export interface ResolvedProviderCredential {
+  value: string;
+  kind: CredentialKind;
+}
+
 export async function resolveProviderCredential(params: {
   profileCredential: string | null;
+  /** Auth profile's type, used to classify a profile-sourced credential. */
+  profileAuthType?: string;
   providerId: string;
   organizationId: string | undefined;
   readOrgSharedKey: (
     providerId: string,
     organizationId: string
   ) => Promise<string | null>;
-  systemKeyResolver?: (providerId: string) => string | undefined;
-}): Promise<string | null> {
-  if (params.profileCredential) return params.profileCredential;
+  systemKeyResolver?: (providerId: string) => SystemKeyResult | undefined;
+}): Promise<ResolvedProviderCredential | null> {
+  if (params.profileCredential) {
+    return {
+      value: params.profileCredential,
+      // Only an explicit OAuth profile yields a Bearer-only credential; every
+      // other profile type (api-key, device-code) is presented as an API key.
+      kind: params.profileAuthType === "oauth" ? "oauth" : "api-key",
+    };
+  }
   if (params.organizationId) {
     const orgKey = await params.readOrgSharedKey(
       params.providerId,
       params.organizationId
     );
-    if (orgKey) return orgKey;
+    // Org-shared keys are written by `lobu apply` as API keys.
+    if (orgKey) return { value: orgKey, kind: "api-key" };
   }
   return params.systemKeyResolver?.(params.providerId) ?? null;
 }
@@ -327,9 +357,18 @@ export class SecretProxy {
   private config: SecretProxyConfig;
   private slugMap: Map<string, string>;
   private slugToProviderId: Map<string, string> = new Map();
+  /**
+   * Per-provider header scheme for presenting an API-KEY credential upstream.
+   * Defaults to Bearer; Anthropic registers `"x-api-key"`. See
+   * `applyCredentialHeader`.
+   */
+  private slugToApiKeyHeader: Map<string, "authorization" | "x-api-key"> =
+    new Map();
   private authProfilesManager?: AuthProfilesManager;
   private readonly secretStore: SecretStore;
-  private systemKeyResolver?: (providerId: string) => string | undefined;
+  private systemKeyResolver?: (
+    providerId: string
+  ) => SystemKeyResult | undefined;
   private agentOrgResolver?: AgentOrgResolver;
 
   constructor(config: SecretProxyConfig, secretStore: SecretStore) {
@@ -351,11 +390,12 @@ export class SecretProxy {
   }
 
   /**
-   * Set a callback that resolves system-level API keys for a provider.
-   * Used as fallback when no per-agent auth profile exists.
+   * Set a callback that resolves system-level keys for a provider, with the
+   * credential's kind so the proxy can pick the right auth header. Used as
+   * fallback when no per-agent auth profile exists.
    */
   setSystemKeyResolver(
-    resolver: (providerId: string) => string | undefined
+    resolver: (providerId: string) => SystemKeyResult | undefined
   ): void {
     this.systemKeyResolver = resolver;
   }
@@ -382,6 +422,9 @@ export class SecretProxy {
     if (providerId) {
       this.slugToProviderId.set(upstream.slug, providerId);
     }
+    if (upstream.apiKeyHeader) {
+      this.slugToApiKeyHeader.set(upstream.slug, upstream.apiKeyHeader);
+    }
     logger.debug(
       `Registered provider upstream: ${upstream.slug} -> ${upstream.upstreamBaseUrl}${providerId ? ` (providerId: ${providerId})` : ""}`
     );
@@ -389,6 +432,33 @@ export class SecretProxy {
 
   getApp(): Hono {
     return this.app;
+  }
+
+  /**
+   * Attach a resolved provider credential to the outgoing headers using the
+   * correct scheme. Most providers are OpenAI-compatible and take the key as
+   * `Authorization: Bearer`. Anthropic is the exception: it registers
+   * `apiKeyHeader: "x-api-key"` and returns 401 ("invalid bearer token") when an
+   * `sk-ant` API key arrives as a Bearer token. OAuth credentials always use
+   * Bearer regardless — so the x-api-key scheme applies only to `api-key`
+   * credentials. The `kind` is determined at resolution time (auth-profile type,
+   * org-shared key, or the system-key resolver), never sniffed from the
+   * credential string. Exactly one of the two headers is set so the upstream
+   * never sees a conflicting pair.
+   */
+  private applyCredentialHeader(
+    headers: Record<string, string>,
+    slug: string,
+    credential: string,
+    kind: CredentialKind
+  ): void {
+    if (this.slugToApiKeyHeader.get(slug) === "x-api-key" && kind !== "oauth") {
+      delete headers.authorization;
+      headers["x-api-key"] = credential;
+    } else {
+      delete headers["x-api-key"];
+      headers.authorization = `Bearer ${credential}`;
+    }
   }
 
   private setupRoutes(): void {
@@ -813,13 +883,19 @@ export class SecretProxy {
           : profile?.credential;
         const resolvedCredential = await resolveProviderCredential({
           profileCredential: credential ?? null,
+          profileAuthType: profile?.authType,
           providerId,
           organizationId: expectedOrganizationId,
           readOrgSharedKey: readOrgSharedProviderApiKey,
           systemKeyResolver: this.systemKeyResolver,
         });
         if (resolvedCredential) {
-          headers.authorization = `Bearer ${resolvedCredential}`;
+          this.applyCredentialHeader(
+            headers,
+            resolvedSlug,
+            resolvedCredential.value,
+            resolvedCredential.kind
+          );
         } else {
           logger.warn(
             `No auth profile, org-shared key, or system key for agent ${urlAgentId}, provider ${providerId}`

--- a/packages/server/src/gateway/services/core-services.ts
+++ b/packages/server/src/gateway/services/core-services.ts
@@ -10,6 +10,7 @@ import {
 	type ProviderRegistryEntry,
 } from "@lobu/core";
 import { getDb } from "../../db/client.js";
+import { resolveEnv } from "../auth/mcp/string-substitution.js";
 import { PostgresSecretStore } from "../../lobu/stores/postgres-secret-store.js";
 import { AgentMetadataStore } from "../auth/agent-metadata-store.js";
 import { ApiKeyProviderModule } from "../auth/api-key-provider-module.js";
@@ -688,10 +689,25 @@ export class CoreServices {
 				// so check all secret env var names.
 				const testEnv: Record<string, string> = {};
 				mod.injectSystemKeyFallback(testEnv);
-				for (const varName of mod.getSecretEnvVarNames()) {
-					if (testEnv[varName]) return testEnv[varName];
-				}
-				return testEnv[mod.getCredentialEnvVarName()] || undefined;
+				const value =
+					mod
+						.getSecretEnvVarNames()
+						.map((v) => testEnv[v])
+						.find(Boolean) ?? testEnv[mod.getCredentialEnvVarName()];
+				if (!value) return undefined;
+				// Classify by the SOURCE env var, not the destination: a module's
+				// injectSystemKeyFallback may re-home a Bearer/OAuth token into an
+				// api-key var (e.g. Claude copies ANTHROPIC_AUTH_TOKEN into
+				// ANTHROPIC_API_KEY). Match the resolved value back to a declared
+				// bearer var so a Bearer token is still presented as Bearer, not
+				// x-api-key.
+				const isBearer = (mod.getBearerCredentialEnvVarNames?.() ?? []).some(
+					(v) => {
+						const raw = resolveEnv(v);
+						return !!raw && raw === value;
+					},
+				);
+				return { value, kind: isBearer ? "oauth" : "api-key" };
 			});
 			logger.debug("Provider upstreams registered with secret proxy");
 		}


### PR DESCRIPTION
## The bug
Configuring Claude with a plain `ANTHROPIC_API_KEY` (env or auth profile) failed through the worker, even though the **same key works on a direct API call**. Two compounding causes:

1. **Wrong auth header.** The secret proxy presented every resolved credential as `Authorization: Bearer <key>`. Correct for OpenAI/Gemini/z.ai/OpenRouter (all Bearer-auth), but Anthropic rejects an `sk-ant` API key sent as a Bearer token with `401 "invalid bearer token"` — it must ride in `x-api-key`. Only the OAuth (Bearer) path worked.
2. **Not recognized as connected.** `hasSystemKey()` for Claude counted only `ANTHROPIC_AUTH_TOKEN`/`CLAUDE_CODE_OAUTH_TOKEN`, not the standard `ANTHROPIC_API_KEY` → agent reported `No model configured`.

### Proof (same key, two headers)
```
x-api-key: <key>            -> HTTP 200
Authorization: Bearer <key> -> HTTP 401 "invalid bearer token"
```

## The fix
- Auth-header scheme is now a **declared provider property** (`apiKeyHeader`, default Bearer; Anthropic = `x-api-key`) the proxy reads — no provider-specific branching in the proxy.
- The credential **kind** (`oauth` | `api-key`) is threaded from where it's resolved (auth-profile type, org-shared key, or the system-key resolver, which classifies env vars via each module's declared bearer-token vars). The header is **never sniffed from the credential string**. OAuth credentials still use Bearer.
- `hasSystemKey()` also recognizes `ANTHROPIC_API_KEY`, consistent with every other provider.

## Why CI missed it
The secret-proxy unit test asserted **Bearer output as correct**, and the live-providers matrix covers every provider **except Anthropic** (the only non-Bearer one, because it's not in `config/providers.json`) — a coverage monoculture: proxy hardcodes Bearer, the test asserts Bearer, the live matrix is all-Bearer. Nothing represented the x-api-key case.

This PR adds table-driven proxy tests asserting the **per-provider header** (Anthropic api-key → `x-api-key`, OpenAI → Bearer, Anthropic OAuth → Bearer) plus credential-kind coverage in the resolution chain.

## Verification
- **Red→green unit reproducer**: reverting the header logic fails the new Anthropic test (gets Bearer); with the fix, 21/21 pass.
- **Live e2e**: Claude replies `ok` through the full `worker → secret-proxy → api.anthropic.com` path with `x-api-key` (`provider=anthropic, model=claude-haiku-4-5`), **zero 401s** in the proxy log.

## Out of scope (separate, noted)
In **auto mode** (no pinned model) Anthropic still hits `No model configured` — a pre-existing regression from #1390 ("provider-driven model defaults" removed the static Anthropic default without supplying one for the env-key path). Unrelated to the auth bug; fix validated with an explicit model. `origin/main` also has a pre-existing strict-tsc break in `base-agent-store.ts` (from `de69b188e` grants refactor) that the bundler-based CI doesn't catch — also unrelated to this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1393"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784472246&installation_id=136316292&pr_number=1393&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1393&signature=c25570b421c7efb9f2f0c34f76fcc224330ef312ead8da7813224ac3bd2a2fc9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved authentication handling across AI provider integrations, distinguishing API-key credentials from OAuth-style bearer tokens and applying the correct upstream header format.
  * Updated upstream configuration to support provider-specific API key header conventions.
  * Enhanced Claude OAuth handling, including treating `ANTHROPIC_API_KEY` as a valid system key and classifying credential kind from configured env vars.
* **Tests**
  * Added/updated tests covering Anthropic vs OpenAI-compatible header behavior and updated credential resolution expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->