### PR TITLE
feat(slack): one-click multi-agent workspace installs (slack_installations store)

### DIFF
--- a/db/migrations/20260619120000_slack_installations.sql
+++ b/db/migrations/20260619120000_slack_installations.sql
@@ -16,7 +16,7 @@
 -- ref into the org-scoped secret store (same convention `agent_connections`
 -- uses for `config.botToken`). Routing reads the token from the secret store
 -- at hydration time.
-CREATE TABLE public.slack_installations (
+CREATE TABLE IF NOT EXISTS public.slack_installations (
     id text NOT NULL,
     organization_id text NOT NULL,
     team_id text NOT NULL,
@@ -30,18 +30,23 @@ CREATE TABLE public.slack_installations (
     CONSTRAINT slack_installations_status_check
         CHECK ((status = ANY (ARRAY['active'::text, 'stopped'::text, 'error'::text]))),
     CONSTRAINT slack_installations_org_fkey
-        FOREIGN KEY (organization_id) REFERENCES public.organization(id) ON DELETE CASCADE
+        FOREIGN KEY (organization_id) REFERENCES public.organization(id) ON DELETE CASCADE,
+    -- One installation row per workspace per org; re-install upserts in place
+    -- via `ON CONFLICT (organization_id, team_id)`. A table constraint (not a
+    -- separate CREATE UNIQUE INDEX) so the unique index ships inside the same
+    -- transactional CREATE TABLE — nothing to lock, squawk-clean.
+    CONSTRAINT slack_installations_org_team_uniq UNIQUE (organization_id, team_id)
 );
 
--- One installation row per workspace per org; re-install upserts in place.
-CREATE UNIQUE INDEX slack_installations_org_team_idx
-    ON public.slack_installations (organization_id, team_id);
-
 -- Inbound `/slack/events` carries no org context, so we resolve the install by
--- team_id alone across orgs (same routing key as agent_connections today).
-CREATE INDEX slack_installations_team_idx
+-- team_id alone across orgs (same routing key as agent_connections today). The
+-- table is brand-new and empty in this migration, so a plain CREATE INDEX locks
+-- nothing; CONCURRENTLY is also illegal in the same transaction as CREATE TABLE.
+-- squawk-ignore require-concurrent-index-creation
+CREATE INDEX IF NOT EXISTS slack_installations_team_idx
     ON public.slack_installations (team_id);
 
 -- migrate:down
 
+-- squawk-ignore ban-drop-table
 DROP TABLE IF EXISTS public.slack_installations;

--- a/db/migrations/20260619120000_slack_installations.sql
+++ b/db/migrations/20260619120000_slack_installations.sql
@@ -1,0 +1,47 @@
+-- migrate:up
+
+-- Per-workspace Slack app installs (the "Add to Slack" OAuth path).
+--
+-- Slack OAuth v2 hands back a DISTINCT bot token for each workspace the shared
+-- Lobu app is installed into; we must persist that token to reply in that
+-- workspace. This is an org/workspace-INSTALLATION resource, NOT an agent's
+-- connection: one installed workspace routes to MANY agents via `/lobu link`
+-- channel bindings, so it has no single owning agent. Modeling it as an
+-- `agent_connections` row (which requires `agent_id NOT NULL` + an FK to
+-- `agents`) forces a synthetic placeholder agent and couples the workspace's
+-- lifecycle to a deletable agent (ON DELETE CASCADE). This table keeps the
+-- token where it belongs — keyed on (org, team) — with no agent ownership.
+--
+-- The bot token is NOT stored here in plaintext: `config` holds a `secret://`
+-- ref into the org-scoped secret store (same convention `agent_connections`
+-- uses for `config.botToken`). Routing reads the token from the secret store
+-- at hydration time.
+CREATE TABLE public.slack_installations (
+    id text NOT NULL,
+    organization_id text NOT NULL,
+    team_id text NOT NULL,
+    team_name text,
+    bot_user_id text,
+    config jsonb DEFAULT '{}'::jsonb NOT NULL,
+    status text DEFAULT 'active'::text NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL,
+    CONSTRAINT slack_installations_pkey PRIMARY KEY (id),
+    CONSTRAINT slack_installations_status_check
+        CHECK ((status = ANY (ARRAY['active'::text, 'stopped'::text, 'error'::text]))),
+    CONSTRAINT slack_installations_org_fkey
+        FOREIGN KEY (organization_id) REFERENCES public.organization(id) ON DELETE CASCADE
+);
+
+-- One installation row per workspace per org; re-install upserts in place.
+CREATE UNIQUE INDEX slack_installations_org_team_idx
+    ON public.slack_installations (organization_id, team_id);
+
+-- Inbound `/slack/events` carries no org context, so we resolve the install by
+-- team_id alone across orgs (same routing key as agent_connections today).
+CREATE INDEX slack_installations_team_idx
+    ON public.slack_installations (team_id);
+
+-- migrate:down
+
+DROP TABLE IF EXISTS public.slack_installations;

--- a/packages/cli/src/commands/dev.ts
+++ b/packages/cli/src/commands/dev.ts
@@ -788,6 +788,16 @@ async function printPreviewInstructions(cwd: string): Promise<void> {
           )
         );
       }
+      // Slack alone supports installing the hosted bot into the user's OWN
+      // workspace (one-time OAuth); after that, `/lobu link` works in a channel
+      // there. Telegram has no install step.
+      if (platform === "slack") {
+        console.log(
+          chalk.dim(
+            `  Or add it to your own Slack workspace: ${chalk.underline(`${clientInfo.apiBaseUrl}/lobu/slack/install`)} (then ${chalk.bold(claim.command)} in a channel there).`
+          )
+        );
+      }
     } catch (error) {
       console.log(
         chalk.yellow(

--- a/packages/server/src/gateway/__tests__/chat-instance-manager-slack.test.ts
+++ b/packages/server/src/gateway/__tests__/chat-instance-manager-slack.test.ts
@@ -27,28 +27,6 @@ async function loadChatInstanceManager() {
 }
 
 describe("ChatInstanceManager Slack marketplace support", () => {
-  test("ensureSlackWorkspaceConnection delegates to the Slack coordinator", async () => {
-    const ChatInstanceManager = await loadChatInstanceManager();
-    const manager = new ChatInstanceManager() as any;
-    const ensureWorkspaceConnection = mock(async () => ({ id: "conn-team" }));
-    manager.slackCoordinator = {
-      ensureWorkspaceConnection,
-    };
-
-    const result = await manager.ensureSlackWorkspaceConnection("T123", {
-      botToken: "xoxb-token",
-      botUserId: "U123",
-      teamName: "Acme",
-    });
-
-    expect(result).toEqual({ id: "conn-team" });
-    expect(ensureWorkspaceConnection).toHaveBeenCalledWith("T123", {
-      botToken: "xoxb-token",
-      botUserId: "U123",
-      teamName: "Acme",
-    });
-  });
-
   test("handleSlackAppWebhook delegates to the Slack coordinator", async () => {
     const ChatInstanceManager = await loadChatInstanceManager();
     const manager = new ChatInstanceManager() as any;
@@ -170,7 +148,7 @@ describe("ChatInstanceManager Slack marketplace support", () => {
     const completeOAuthInstall = mock(async () => ({
       teamId: "T123",
       teamName: "Acme",
-      connectionId: "conn-team",
+      installationId: "slackinst-abc",
     }));
     manager.slackCoordinator = {
       completeOAuthInstall,
@@ -178,17 +156,19 @@ describe("ChatInstanceManager Slack marketplace support", () => {
 
     const result = await manager.completeSlackOAuthInstall(
       request,
-      "https://gateway.example.com/slack/oauth_callback"
+      "https://gateway.example.com/slack/oauth_callback",
+      "org-1"
     );
 
     expect(result).toEqual({
       teamId: "T123",
       teamName: "Acme",
-      connectionId: "conn-team",
+      installationId: "slackinst-abc",
     });
     expect(completeOAuthInstall).toHaveBeenCalledWith(
       request,
-      "https://gateway.example.com/slack/oauth_callback"
+      "https://gateway.example.com/slack/oauth_callback",
+      "org-1"
     );
   });
 });

--- a/packages/server/src/gateway/__tests__/message-handler-bridge.test.ts
+++ b/packages/server/src/gateway/__tests__/message-handler-bridge.test.ts
@@ -466,6 +466,8 @@ describe("MessageHandlerBridge.handleMessage — Slack Preview unlinked chat", (
   function makePreviewHarness(opts: {
     binding?: { agentId: string; organizationId?: string } | null;
     previewMode?: boolean;
+    agentId?: string | undefined;
+    metadata?: Record<string, unknown>;
     commandDispatcher?: {
       tryHandleSlashText?: (...args: any[]) => Promise<boolean>;
       tryHandle?: (...args: any[]) => Promise<boolean>;
@@ -476,13 +478,15 @@ describe("MessageHandlerBridge.handleMessage — Slack Preview unlinked chat", (
     const connection: PlatformConnection = {
       id: CONN_ID,
       platform: "slack",
-      agentId: TEMPLATE_AGENT_ID,
+      // Default to the template agent; tests for an OAuth-installed workspace
+      // connection (no owning agent) pass `agentId: undefined` explicitly.
+      agentId: "agentId" in opts ? opts.agentId : TEMPLATE_AGENT_ID,
       // The hosted preview connection lives in its OWN org; bound agents may
       // live in OTHER orgs (see the cross-org test below).
       organizationId: "org-connection",
       config: { platform: "slack" } as any,
       settings: { allowGroups: true, previewMode: opts.previewMode ?? true },
-      metadata: { botUsername: "testbot", botUserId: "U_BOT" },
+      metadata: opts.metadata ?? { botUsername: "testbot", botUserId: "U_BOT" },
       status: "active",
       createdAt: 1,
       updatedAt: 1,
@@ -545,6 +549,26 @@ describe("MessageHandlerBridge.handleMessage — Slack Preview unlinked chat", (
         (c: unknown[]) => !String(c[0]).includes("/lobu link")
       )
     ).toBe(true);
+  });
+
+  test("OAuth workspace connection (no agent, not preview): unlinked → link notice, no agent run", async () => {
+    // A tenant's OAuth-installed bot has no owning agent and metadata.teamId.
+    // An unbound non-command message must get a one-line "link your agent"
+    // notice instead of being silently dropped (the install dead-end we reverted
+    // for), and must NOT enqueue a worker turn against a non-existent agent.
+    const { bridge, enqueueMessage } = makePreviewHarness({
+      binding: null,
+      previewMode: false,
+      agentId: undefined,
+      metadata: { teamId: "T_WS", botUserId: "U_BOT" },
+    });
+    const thread = makeThread(undefined);
+
+    await bridge.handleMessage(thread, makeMessage(), "mention");
+
+    expect(thread.post).toHaveBeenCalledTimes(1);
+    expect(String(thread.post.mock.calls[0]?.[0])).toContain("/lobu link");
+    expect(enqueueMessage).not.toHaveBeenCalled();
   });
 
   test("cross-org: routes the worker turn under the BOUND agent's org, not the connection's", async () => {

--- a/packages/server/src/gateway/__tests__/slack-connection-coordinator.test.ts
+++ b/packages/server/src/gateway/__tests__/slack-connection-coordinator.test.ts
@@ -1,9 +1,6 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { SlackConnectionCoordinator } from "../connections/slack-connection-coordinator.js";
-import type {
-  PlatformAdapterConfig,
-  PlatformConnection,
-} from "../connections/types.js";
+import type { PlatformConnection } from "../connections/types.js";
 
 function createSlackConnection(
   id: string,
@@ -30,22 +27,40 @@ function createSlackConnection(
   };
 }
 
-/** Deps stub with sensible no-op defaults; override per test. */
-function makeDeps(
-  overrides: Partial<
-    ConstructorParameters<typeof SlackConnectionCoordinator>[0]
-  > = {}
-): ConstructorParameters<typeof SlackConnectionCoordinator>[0] {
+type Deps = ConstructorParameters<typeof SlackConnectionCoordinator>[0];
+
+/** Installation-store stub; override per test. */
+function makeInstallationStore(
+  overrides: Partial<Deps["installationStore"]> = {}
+): Deps["installationStore"] {
   return {
-    addConnection: mock(async () => createSlackConnection("unused")),
+    upsertByTeam: mock(async (organizationId: string, teamId: string) => ({
+      id: `slackinst-${teamId}`,
+      organizationId,
+      teamId,
+      config: { platform: "slack", botToken: "secret://ref" },
+      status: "active" as const,
+      createdAt: 0,
+      updatedAt: 0,
+    })),
+    getById: mock(async () => null),
+    getByTeamId: mock(async () => null),
+    list: mock(async () => []),
+    markStopped: mock(async () => undefined),
+    delete: mock(async () => undefined),
+    ...overrides,
+  };
+}
+
+/** Deps stub with sensible no-op defaults; override per test. */
+function makeDeps(overrides: Partial<Deps> = {}): Deps {
+  return {
     createStateAdapter: mock(async () => ({})),
     ensureConnectionRunning: mock(async () => true),
     forwardWebhook: mock(async () => new Response("ok")),
     getRunningChat: () => undefined,
-    hasConnection: () => true,
     listSlackConnections: async () => [],
-    restartConnection: mock(async () => undefined),
-    updateConnection: mock(async () => createSlackConnection("unused")),
+    installationStore: makeInstallationStore(),
     ...overrides,
   };
 }
@@ -77,98 +92,82 @@ describe("SlackConnectionCoordinator", () => {
     }
   });
 
-  test("ensureWorkspaceConnection is idempotent per team", async () => {
-    const connections: PlatformConnection[] = [];
-    const addConnection = mock(
-      async (
-        _platform: string,
-        agentId: string | undefined,
-        config: any,
-        settings?: { allowGroups?: boolean },
-        metadata?: Record<string, unknown>
-      ) => {
-        const connection = createSlackConnection("conn-1", metadata, config);
-        connection.agentId = agentId;
-        connection.settings = settings || { allowGroups: true };
-        connections.push(connection);
-        return connection;
-      }
-    );
-    const updateConnection = mock(
-      async (connectionId: string, updates: Partial<PlatformConnection>) => {
-        const connection = connections.find(
-          (item) => item.id === connectionId
-        )!;
-        Object.assign(connection, updates);
-        return connection;
-      }
-    );
-    const restartConnection = mock(async () => undefined);
-
-    const coordinator = new SlackConnectionCoordinator(
-      makeDeps({
-        addConnection,
-        hasConnection: () => false,
-        listSlackConnections: async () => connections,
-        restartConnection,
-        updateConnection,
+  test("ensureWorkspaceInstallation upserts only tenant data to the installation store", async () => {
+    // The OAuth install is an org/workspace-installation resource, not an
+    // agent connection — it goes to slack_installations keyed on (org, team),
+    // never agent_connections. Only tenant data (bot token + teamName/botUserId)
+    // is passed; app-level creds stay env-sourced (the store/secret layer owns
+    // token persistence).
+    const upsertByTeam = mock(
+      async (organizationId: string, teamId: string) => ({
+        id: "slackinst-xyz",
+        organizationId,
+        teamId,
+        config: { platform: "slack", botToken: "secret://ref" },
+        status: "active" as const,
+        createdAt: 0,
+        updatedAt: 0,
       })
     );
+    const coordinator = new SlackConnectionCoordinator(
+      makeDeps({ installationStore: makeInstallationStore({ upsertByTeam }) })
+    );
 
-    const first = await coordinator.ensureWorkspaceConnection("T123", {
-      botToken: "xoxb-first-token",
+    const result = await coordinator.ensureWorkspaceInstallation(
+      "org-acme",
+      "T123",
+      { botToken: "xoxb-tenant-token", botUserId: "U123", teamName: "Acme" }
+    );
+
+    expect(result).toEqual({ installationId: "slackinst-xyz" });
+    expect(upsertByTeam).toHaveBeenCalledWith("org-acme", "T123", {
+      botToken: "xoxb-tenant-token",
       botUserId: "U123",
       teamName: "Acme",
     });
-    const second = await coordinator.ensureWorkspaceConnection("T123", {
-      botToken: "xoxb-second-token",
-      botUserId: "U456",
-      teamName: "Acme Updated",
-    });
-
-    expect(first.id).toBe("conn-1");
-    expect(second.id).toBe("conn-1");
-    expect(addConnection).toHaveBeenCalledTimes(1);
-    expect(updateConnection).toHaveBeenCalledTimes(1);
-    expect(restartConnection).toHaveBeenCalledTimes(1);
-    expect(connections).toHaveLength(1);
-    expect(connections[0]?.metadata).toEqual({
-      teamId: "T123",
-      teamName: "Acme Updated",
-      botUserId: "U456",
-    });
-    expect((connections[0]?.config as any).botToken).toBe("xoxb-second-token");
+    // No app secrets in the payload — only tenant data.
+    const payload = upsertByTeam.mock.calls[0]?.[2] as Record<string, unknown>;
+    expect(payload.signingSecret).toBeUndefined();
+    expect(payload.clientId).toBeUndefined();
+    expect(payload.clientSecret).toBeUndefined();
   });
 
-  test("ensureWorkspaceConnection persists only tenant data, not app secrets", async () => {
-    // The Slack adapter reads signingSecret/clientId/clientSecret from env at
-    // runtime, so a per-workspace connection must NOT bake them into its stored
-    // config (that would duplicate the secret per tenant and block rotation).
-    let storedConfig: PlatformAdapterConfig | undefined;
+  test("handleAppWebhook routes a matched team to its OAuth installation", async () => {
+    const body = JSON.stringify({ team_id: "T777", type: "event_callback" });
+    const forwarded: string[] = [];
     const coordinator = new SlackConnectionCoordinator(
       makeDeps({
-        addConnection: mock(async (_platform, _agentId, config) => {
-          storedConfig = config;
-          return createSlackConnection("conn-new", {}, {});
-        }),
-        hasConnection: () => false,
+        // No agent-owned (BYO) slack connection for this team...
         listSlackConnections: async () => [],
+        // ...but an OAuth installation exists.
+        installationStore: makeInstallationStore({
+          getByTeamId: mock(async () => ({
+            id: "slackinst-T777",
+            organizationId: "org-acme",
+            teamId: "T777",
+            config: { platform: "slack", botToken: "secret://ref" },
+            status: "active" as const,
+            createdAt: 0,
+            updatedAt: 0,
+          })),
+        }),
+        forwardWebhook: mock(async (connectionId: string) => {
+          forwarded.push(connectionId);
+          return new Response("ok");
+        }),
       })
     );
 
-    await coordinator.ensureWorkspaceConnection("T999", {
-      botToken: "xoxb-tenant-token",
-      botUserId: "U999",
-      teamName: "Tenant",
-    });
+    const response = await coordinator.handleAppWebhook(
+      new Request("https://gateway.example.com/slack/events", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body,
+      })
+    );
 
-    const cfg = storedConfig as any;
-    expect(cfg.platform).toBe("slack");
-    expect(cfg.botToken).toBe("xoxb-tenant-token");
-    expect(cfg.botUserId).toBe("U999");
-    expect(cfg.signingSecret).toBeUndefined();
-    expect(cfg.clientId).toBeUndefined();
-    expect(cfg.clientSecret).toBeUndefined();
+    expect(response.status).toBe(200);
+    expect(forwarded).toEqual(["slackinst-T777"]);
   });
 
   test("resolveAdapterConfig sources app creds from env (requireOAuth)", async () => {

--- a/packages/server/src/gateway/__tests__/slack-connection-coordinator.test.ts
+++ b/packages/server/src/gateway/__tests__/slack-connection-coordinator.test.ts
@@ -170,6 +170,48 @@ describe("SlackConnectionCoordinator", () => {
     expect(forwarded).toEqual(["slackinst-T777"]);
   });
 
+  test("a stopped BYO connection does not preempt an active OAuth installation", async () => {
+    const body = JSON.stringify({ team_id: "T888", type: "event_callback" });
+    const forwarded: string[] = [];
+    const coordinator = new SlackConnectionCoordinator(
+      makeDeps({
+        // A stopped BYO connection exists for this team...
+        listSlackConnections: async () => [
+          { ...createSlackConnection("conn-stopped", { teamId: "T888" }), status: "stopped" },
+        ],
+        // ...and an active OAuth installation. Routing must reach the install,
+        // not 503 on the stopped row.
+        getInstallationStore: () =>
+          makeInstallationStore({
+            getByTeamId: mock(async () => ({
+              id: "slackinst-T888",
+              organizationId: "org-acme",
+              teamId: "T888",
+              config: { platform: "slack", botToken: "secret://ref" },
+              status: "active" as const,
+              createdAt: 0,
+              updatedAt: 0,
+            })),
+          }),
+        forwardWebhook: mock(async (connectionId: string) => {
+          forwarded.push(connectionId);
+          return new Response("ok");
+        }),
+      })
+    );
+
+    const response = await coordinator.handleAppWebhook(
+      new Request("https://gateway.example.com/slack/events", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body,
+      })
+    );
+
+    expect(response.status).toBe(200);
+    expect(forwarded).toEqual(["slackinst-T888"]);
+  });
+
   test("resolveAdapterConfig sources app creds from env (requireOAuth)", async () => {
     process.env.SLACK_SIGNING_SECRET = "env-signing";
     process.env.SLACK_CLIENT_ID = "env-client-id";

--- a/packages/server/src/gateway/__tests__/slack-connection-coordinator.test.ts
+++ b/packages/server/src/gateway/__tests__/slack-connection-coordinator.test.ts
@@ -31,8 +31,8 @@ type Deps = ConstructorParameters<typeof SlackConnectionCoordinator>[0];
 
 /** Installation-store stub; override per test. */
 function makeInstallationStore(
-  overrides: Partial<Deps["installationStore"]> = {}
-): Deps["installationStore"] {
+  overrides: Partial<ReturnType<Deps["getInstallationStore"]>> = {}
+): ReturnType<Deps["getInstallationStore"]> {
   return {
     upsertByTeam: mock(async (organizationId: string, teamId: string) => ({
       id: `slackinst-${teamId}`,
@@ -60,7 +60,7 @@ function makeDeps(overrides: Partial<Deps> = {}): Deps {
     forwardWebhook: mock(async () => new Response("ok")),
     getRunningChat: () => undefined,
     listSlackConnections: async () => [],
-    installationStore: makeInstallationStore(),
+    getInstallationStore: () => makeInstallationStore(),
     ...overrides,
   };
 }
@@ -110,7 +110,7 @@ describe("SlackConnectionCoordinator", () => {
       })
     );
     const coordinator = new SlackConnectionCoordinator(
-      makeDeps({ installationStore: makeInstallationStore({ upsertByTeam }) })
+      makeDeps({ getInstallationStore: () => makeInstallationStore({ upsertByTeam }) })
     );
 
     const result = await coordinator.ensureWorkspaceInstallation(
@@ -140,7 +140,7 @@ describe("SlackConnectionCoordinator", () => {
         // No agent-owned (BYO) slack connection for this team...
         listSlackConnections: async () => [],
         // ...but an OAuth installation exists.
-        installationStore: makeInstallationStore({
+        getInstallationStore: () => makeInstallationStore({
           getByTeamId: mock(async () => ({
             id: "slackinst-T777",
             organizationId: "org-acme",

--- a/packages/server/src/gateway/__tests__/slack-routes.test.ts
+++ b/packages/server/src/gateway/__tests__/slack-routes.test.ts
@@ -65,7 +65,7 @@ describe("slack routes", () => {
     completeSlackOAuthInstall = mock(async () => ({
       teamId: "T123",
       teamName: "Acme",
-      connectionId: "conn-1",
+      installationId: "slackinst-1",
     }));
     handleSlackAppWebhook = mock(async (request: Request) => {
       const body = await request.text();
@@ -181,12 +181,16 @@ describe("slack routes", () => {
 
     expect(response.status).toBe(200);
     expect(body).toContain("Slack installed");
-    expect(body).toContain("Workspace connected to Lobu:");
-    expect(body).toContain("Connection ID: conn-1");
+    // New install-store flow: the success page points users at /lobu link
+    // instead of surfacing an agent_connections id.
+    expect(body).toContain("/lobu link");
+    expect(body).toContain("Deploy tab");
     expect(completeSlackOAuthInstall).toHaveBeenCalledTimes(1);
     expect(completeSlackOAuthInstall.mock.calls[0]?.[1]).toBe(
       "https://gateway.example.com/slack/oauth_callback"
     );
+    // The validated install-state org is threaded as the 3rd arg.
+    expect(completeSlackOAuthInstall.mock.calls[0]?.[2]).toBe("org-default");
     const remaining = await sql`
       SELECT 1 FROM oauth_states WHERE id = 'test-state'
     `;

--- a/packages/server/src/gateway/connections/__tests__/connection-claims.test.ts
+++ b/packages/server/src/gateway/connections/__tests__/connection-claims.test.ts
@@ -505,3 +505,71 @@ describe("idx_agent_connections_slack_workspace (install race)", () => {
     });
   });
 });
+
+describe("installation-backed instances (OAuth workspace, no owning agent)", () => {
+  test("a slackinst- id hydrates from the installation store as an agentless slack connection", async () => {
+    const { ChatInstanceManager } = await import(
+      "../chat-instance-manager.js"
+    );
+
+    // Stub the installation store; capture what the manager tries to hydrate.
+    const installation = {
+      id: "slackinst-abc123",
+      organizationId: "org-ws",
+      teamId: "TWS1",
+      teamName: "Acme",
+      botUserId: "UBOT",
+      config: { platform: "slack", botToken: "secret://ref" },
+      status: "active" as const,
+      createdAt: 1,
+      updatedAt: 42,
+    };
+    const services = {
+      getPublicGatewayUrl: () => "",
+      getSlackInstallationStore: () => ({
+        getById: async (id: string) => (id === installation.id ? installation : null),
+      }),
+    } as any;
+
+    const manager = new ChatInstanceManager() as any;
+    manager.services = services;
+    manager.publicGatewayUrl = "";
+    // No connectionStore — installs must resolve without one.
+
+    let hydrated: any = null;
+    manager.hydrateFromRow = async (stored: any) => {
+      hydrated = stored;
+      manager.instances.set(stored.id, {
+        connection: { id: stored.id, platform: stored.platform },
+        chat: {},
+        rowVersion: stored.updatedAt,
+      });
+    };
+
+    const ok = await manager.warmConnection("slackinst-abc123");
+    expect(ok).toBe(true);
+    expect(hydrated).not.toBeNull();
+    expect(hydrated.platform).toBe("slack");
+    expect(hydrated.agentId).toBeUndefined();
+    expect(hydrated.organizationId).toBe("org-ws");
+    expect(hydrated.config.botToken).toBe("secret://ref");
+    expect(hydrated.metadata.teamId).toBe("TWS1");
+    expect(hydrated.metadata.botUserId).toBe("UBOT");
+    // Row-version memo carries the installation's updated_at.
+    expect(manager.instances.get("slackinst-abc123").rowVersion).toBe(42);
+  });
+
+  test("an unknown slackinst- id does not start anything", async () => {
+    const { ChatInstanceManager } = await import(
+      "../chat-instance-manager.js"
+    );
+    const manager = new ChatInstanceManager() as any;
+    manager.services = {
+      getSlackInstallationStore: () => ({ getById: async () => null }),
+    };
+    manager.hydrateFromRow = async () => {
+      throw new Error("should not hydrate an unknown installation");
+    };
+    expect(await manager.warmConnection("slackinst-missing")).toBe(false);
+  });
+});

--- a/packages/server/src/gateway/connections/__tests__/slack-installation-store.test.ts
+++ b/packages/server/src/gateway/connections/__tests__/slack-installation-store.test.ts
@@ -100,6 +100,22 @@ describe("SlackInstallationStore", () => {
     expect(found?.organizationId).toBe("org-a");
   });
 
+  test("a fresh install from another org supersedes the prior one (one active per team)", async () => {
+    await seedAgentRow("ta", { organizationId: "org-a2" });
+    await seedAgentRow("tb", { organizationId: "org-b2" });
+    const { store } = await buildStore();
+
+    const a = await store.upsertByTeam("org-a2", "T600", { botToken: "xoxb-a" });
+    const b = await store.upsertByTeam("org-b2", "T600", { botToken: "xoxb-b" });
+
+    // org-a's row is demoted; org-b is the single active install.
+    expect((await store.getById(a.id))?.status).toBe("stopped");
+    expect((await store.getById(b.id))?.status).toBe("active");
+    const found = await store.getByTeamId("T600");
+    expect(found?.id).toBe(b.id);
+    expect(found?.organizationId).toBe("org-b2");
+  });
+
   test("delete removes the row and its secret", async () => {
     const { orgContext } = await import("../../../lobu/stores/org-context.js");
     const { resolveSecretValue } = await import("../../secrets/index.js");

--- a/packages/server/src/gateway/connections/__tests__/slack-installation-store.test.ts
+++ b/packages/server/src/gateway/connections/__tests__/slack-installation-store.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Real-Postgres tests for the per-workspace Slack install store (the "Add to
+ * Slack" OAuth path). The bot token must round-trip through the secret store
+ * (never plaintext in the row), the row must be idempotent per (org, team) on
+ * re-install, and team lookup must work cross-org (the public /slack/events
+ * route has no org context).
+ */
+
+import { beforeAll, beforeEach, describe, expect, test } from "bun:test";
+import {
+  ensureDbForGatewayTests,
+  ensureEncryptionKey,
+  resetTestDatabase,
+  seedAgentRow,
+} from "../../__tests__/helpers/db-setup.js";
+
+beforeAll(async () => {
+  await ensureDbForGatewayTests();
+}, 60_000);
+
+beforeEach(async () => {
+  ensureEncryptionKey();
+  await resetTestDatabase();
+}, 30_000);
+
+async function buildStore() {
+  const { createPostgresSlackInstallationStore } = await import(
+    "../../../lobu/stores/slack-installation-store.js"
+  );
+  const { PostgresSecretStore } = await import(
+    "../../../lobu/stores/postgres-secret-store.js"
+  );
+  const { SecretStoreRegistry } = await import("../../secrets/index.js");
+  const postgresSecretStore = new PostgresSecretStore();
+  const secretStore = new SecretStoreRegistry(postgresSecretStore, {
+    secret: postgresSecretStore,
+  });
+  return {
+    store: createPostgresSlackInstallationStore(secretStore),
+    secretStore,
+  };
+}
+
+describe("SlackInstallationStore", () => {
+  test("upsertByTeam persists tenant data; token goes to the secret store, not the row", async () => {
+    const { orgContext } = await import("../../../lobu/stores/org-context.js");
+    const { resolveSecretValue } = await import("../../secrets/index.js");
+    await seedAgentRow("throwaway", { organizationId: "org-inst" });
+    const { store, secretStore } = await buildStore();
+
+    const row = await store.upsertByTeam("org-inst", "T100", {
+      teamName: "Acme",
+      botUserId: "U100",
+      botToken: "xoxb-real-token",
+    });
+
+    expect(row.id.startsWith("slackinst-")).toBe(true);
+    expect(row.organizationId).toBe("org-inst");
+    expect(row.teamId).toBe("T100");
+    expect(row.teamName).toBe("Acme");
+    expect(row.status).toBe("active");
+    // Row stores a ref, never the plaintext token.
+    expect(typeof row.config.botToken).toBe("string");
+    expect(row.config.botToken).not.toBe("xoxb-real-token");
+    // The ref resolves to the real token (under the install org's bucket).
+    const resolved = await orgContext.run({ organizationId: "org-inst" }, () =>
+      resolveSecretValue(secretStore, row.config.botToken)
+    );
+    expect(resolved).toBe("xoxb-real-token");
+  });
+
+  test("upsertByTeam is idempotent per (org, team): same id, refreshed token", async () => {
+    await seedAgentRow("throwaway", { organizationId: "org-inst" });
+    const { store } = await buildStore();
+
+    const first = await store.upsertByTeam("org-inst", "T200", {
+      teamName: "Acme",
+      botToken: "xoxb-first",
+    });
+    const second = await store.upsertByTeam("org-inst", "T200", {
+      teamName: "Acme Renamed",
+      botToken: "xoxb-second",
+    });
+
+    expect(second.id).toBe(first.id);
+    expect(second.teamName).toBe("Acme Renamed");
+    expect(await store.list("org-inst")).toHaveLength(1);
+  });
+
+  test("getByTeamId resolves cross-org (no org context)", async () => {
+    await seedAgentRow("throwaway", { organizationId: "org-a" });
+    const { store } = await buildStore();
+    const created = await store.upsertByTeam("org-a", "T300", {
+      botToken: "xoxb-a",
+    });
+
+    // No orgContext bound — mirrors the public /slack/events route.
+    const found = await store.getByTeamId("T300");
+    expect(found?.id).toBe(created.id);
+    expect(found?.organizationId).toBe("org-a");
+  });
+
+  test("delete removes the row and its secret", async () => {
+    const { orgContext } = await import("../../../lobu/stores/org-context.js");
+    const { resolveSecretValue } = await import("../../secrets/index.js");
+    await seedAgentRow("throwaway", { organizationId: "org-inst" });
+    const { store, secretStore } = await buildStore();
+
+    const row = await store.upsertByTeam("org-inst", "T400", {
+      botToken: "xoxb-doomed",
+    });
+    await store.delete(row.id);
+
+    expect(await store.getById(row.id)).toBeNull();
+    const resolved = await orgContext.run({ organizationId: "org-inst" }, () =>
+      resolveSecretValue(secretStore, row.config.botToken)
+    );
+    expect(resolved).toBeUndefined();
+  });
+
+  test("markStopped flips status; getByTeamId still finds it but routing skips stopped", async () => {
+    await seedAgentRow("throwaway", { organizationId: "org-inst" });
+    const { store } = await buildStore();
+    const row = await store.upsertByTeam("org-inst", "T500", {
+      botToken: "xoxb-x",
+    });
+
+    await store.markStopped(row.id);
+    const found = await store.getById(row.id);
+    expect(found?.status).toBe("stopped");
+  });
+});

--- a/packages/server/src/gateway/connections/chat-instance-manager.ts
+++ b/packages/server/src/gateway/connections/chat-instance-manager.ts
@@ -1264,7 +1264,7 @@ export class ChatInstanceManager {
       forwardWebhook: this.handleWebhook.bind(this),
       getRunningChat: (connectionId) => this.getInstance(connectionId)?.chat,
       listSlackConnections: () => this.listConnections({ platform: "slack" }),
-      installationStore: this.services.getSlackInstallationStore(),
+      getInstallationStore: () => this.services.getSlackInstallationStore(),
     });
   }
 

--- a/packages/server/src/gateway/connections/chat-instance-manager.ts
+++ b/packages/server/src/gateway/connections/chat-instance-manager.ts
@@ -18,6 +18,7 @@ import { createLogger, isSecretRef } from "@lobu/core";
 import { type AdapterPostableMessage, Chat } from "chat";
 import { getDb } from "../../db/client.js";
 import { orgContext, tryGetOrgId } from "../../lobu/stores/org-context.js";
+import { SLACK_INSTALLATION_ID_PREFIX } from "../../lobu/stores/slack-installation-store.js";
 import { CommandDispatcher } from "../commands/command-dispatcher.js";
 import type { IFileHandler } from "../platform/file-handler.js";
 import type { CoreServices, PlatformAdapter } from "../platform.js";
@@ -934,29 +935,20 @@ export class ChatInstanceManager {
     return this.slackCoordinator.getDefaultConnection();
   }
 
-  async ensureSlackWorkspaceConnection(
-    teamId: string,
-    installation: {
-      botToken: string;
-      botUserId?: string;
-      teamName?: string;
-    }
-  ): Promise<PlatformConnection> {
-    return this.slackCoordinator.ensureWorkspaceConnection(
-      teamId,
-      installation
-    );
-  }
-
   async completeSlackOAuthInstall(
     request: Request,
-    redirectUri?: string
+    redirectUri: string | undefined,
+    organizationId: string
   ): Promise<{
     teamId: string;
     teamName?: string;
-    connectionId: string;
+    installationId: string;
   }> {
-    return this.slackCoordinator.completeOAuthInstall(request, redirectUri);
+    return this.slackCoordinator.completeOAuthInstall(
+      request,
+      redirectUri,
+      organizationId
+    );
   }
 
   async handleSlackAppWebhook(request: Request): Promise<Response> {
@@ -1267,16 +1259,46 @@ export class ChatInstanceManager {
 
   private buildSlackCoordinator(): SlackConnectionCoordinator {
     return new SlackConnectionCoordinator({
-      addConnection: this.addConnection.bind(this),
       createStateAdapter: this.createStateAdapter.bind(this),
       ensureConnectionRunning: this.ensureConnectionRunning.bind(this),
       forwardWebhook: this.handleWebhook.bind(this),
       getRunningChat: (connectionId) => this.getInstance(connectionId)?.chat,
-      hasConnection: this.has.bind(this),
       listSlackConnections: () => this.listConnections({ platform: "slack" }),
-      restartConnection: this.restartConnection.bind(this),
-      updateConnection: this.updateConnection.bind(this),
+      installationStore: this.services.getSlackInstallationStore(),
     });
+  }
+
+  /**
+   * Resolve the `StoredConnection` for `id` from the right source. Most ids are
+   * `agent_connections` rows; ids in the Slack-installation namespace
+   * (`slackinst_…`) are OAuth workspace installs from `slack_installations`,
+   * surfaced as agentless connection-shaped rows so the existing hydration /
+   * instance-memo / webhook machinery runs them unchanged (the runtime never
+   * needs an owning agent — routing is per-message via bindings).
+   */
+  private async resolveStored(id: string): Promise<StoredConnection | null> {
+    if (id.startsWith(SLACK_INSTALLATION_ID_PREFIX)) {
+      const inst = await this.services.getSlackInstallationStore().getById(id);
+      if (!inst) return null;
+      return {
+        id: inst.id,
+        platform: "slack",
+        agentId: undefined,
+        organizationId: inst.organizationId,
+        config: inst.config as Record<string, any>,
+        settings: { allowGroups: true },
+        metadata: {
+          teamId: inst.teamId,
+          ...(inst.teamName ? { teamName: inst.teamName } : {}),
+          ...(inst.botUserId ? { botUserId: inst.botUserId } : {}),
+        },
+        status: inst.status,
+        createdAt: inst.createdAt,
+        updatedAt: inst.updatedAt,
+      };
+    }
+    if (!this.connectionStore) return null;
+    return this.connectionStore.getConnection(id);
   }
 
   /**
@@ -1289,9 +1311,7 @@ export class ChatInstanceManager {
    * restart fan-out.
    */
   private async ensureConnectionRunning(id: string): Promise<boolean> {
-    if (!this.connectionStore) return false;
-
-    const stored = await this.connectionStore.getConnection(id);
+    const stored = await this.resolveStored(id);
     if (!stored || stored.status === "stopped") {
       if (this.instances.has(id)) {
         await this.stopInstance(id);
@@ -1371,11 +1391,11 @@ export class ChatInstanceManager {
     // persisted value, not the pre-start snapshot — otherwise the next
     // ensureConnectionRunning sees a version mismatch and needlessly tears the
     // instance down and re-hydrates (re-running setWebhook/setMyCommands).
-    const afterStart = await this.connectionStore.getConnection(stored.id);
+    const afterStart = await this.resolveStored(stored.id);
     instance.rowVersion = afterStart?.updatedAt ?? stored.updatedAt;
     if (stored.status === "error") {
       await this.writeConnectionStatus(stored, "active", undefined);
-      const reread = await this.connectionStore.getConnection(stored.id);
+      const reread = await this.resolveStored(stored.id);
       if (reread) instance.rowVersion = reread.updatedAt;
       logger.info({ id: stored.id }, "Recovered previously-errored connection");
     }
@@ -1400,6 +1420,16 @@ export class ChatInstanceManager {
       row.status === status &&
       (row.errorMessage ?? undefined) === errorMessage
     ) {
+      return;
+    }
+    // OAuth workspace installs live in `slack_installations`, not
+    // `agent_connections`; their status isn't tracked there (token-health is a
+    // deferred concern). Log and skip — the hydration error is already logged.
+    if (row.id.startsWith(SLACK_INSTALLATION_ID_PREFIX)) {
+      logger.warn(
+        { id: row.id, status, errorMessage },
+        "Skipping status write for Slack installation-backed instance"
+      );
       return;
     }
     const write = () =>

--- a/packages/server/src/gateway/connections/message-handler-bridge.ts
+++ b/packages/server/src/gateway/connections/message-handler-bridge.ts
@@ -5,7 +5,10 @@
  */
 
 import { createLogger, createRootSpan, generateTraceId } from "@lobu/core";
-import { previewUnlinkedNotice } from "../../preview/slack.js";
+import {
+  previewUnlinkedNotice,
+  workspaceUnlinkedNotice,
+} from "../../preview/slack.js";
 import type { CommandDispatcher } from "../commands/command-dispatcher.js";
 import { createChatReply } from "../commands/command-reply-adapters.js";
 import type { ArtifactStore } from "../files/artifact-store.js";
@@ -328,6 +331,27 @@ export class MessageHandlerBridge {
       crossOrg: isPreview,
     });
     if (!resolved) {
+      // A tenant's OAuth-installed Slack workspace bot has no owning agent —
+      // routing is via `/lobu link` bindings. Before the tenant links a
+      // channel, a non-command message resolves to nothing. Reply with a
+      // one-line "link your agent" notice instead of silently dropping so the
+      // install never dead-ends. (Slash commands like `/lobu link` take the
+      // `onSlashCommand` path and never reach here.)
+      if (
+        !isPreview &&
+        platform === "slack" &&
+        this.connection.metadata?.teamId
+      ) {
+        const notice = workspaceUnlinkedNotice(platform);
+        if (notice) {
+          logger.info(
+            { platform, channelId, teamId, connectionId: this.connection.id },
+            "Slack workspace connection: unlinked channel — replying with link notice"
+          );
+          await thread.post(notice);
+          return;
+        }
+      }
       logger.warn(
         { platform, channelId, teamId, connectionId: this.connection.id },
         "No channel binding and connection has no owning agent — dropping message"

--- a/packages/server/src/gateway/connections/slack-connection-coordinator.ts
+++ b/packages/server/src/gateway/connections/slack-connection-coordinator.ts
@@ -66,8 +66,12 @@ interface SlackConnectionCoordinatorDeps {
   forwardWebhook(connectionId: string, request: Request): Promise<Response>;
   getRunningChat(connectionId: string): any | undefined;
   listSlackConnections(): Promise<PlatformConnection[]>;
-  /** Per-workspace OAuth installs (token + tenant data), keyed on (org, team). */
-  installationStore: SlackInstallationStore;
+  /**
+   * Per-workspace OAuth installs (token + tenant data), keyed on (org, team).
+   * Resolved lazily so building the coordinator never forces the store to
+   * exist — only the install/webhook paths actually need it.
+   */
+  getInstallationStore(): SlackInstallationStore;
 }
 
 export class SlackConnectionCoordinator {
@@ -128,7 +132,7 @@ export class SlackConnectionCoordinator {
     teamId: string,
     installation: SlackInstallation
   ): Promise<{ installationId: string }> {
-    const row = await this.deps.installationStore.upsertByTeam(
+    const row = await this.deps.getInstallationStore().upsertByTeam(
       organizationId,
       teamId,
       {
@@ -228,7 +232,7 @@ export class SlackConnectionCoordinator {
       //    `ensureConnectionRunning`/`forwardWebhook` resolve it from the
       //    installation store). Per-message routing is via `/lobu link` bindings.
       const installation =
-        await this.deps.installationStore.getByTeamId(teamId);
+        await this.deps.getInstallationStore().getByTeamId(teamId);
       if (installation && installation.status !== "stopped") {
         if (!(await this.deps.ensureConnectionRunning(installation.id))) {
           return new Response("Slack connection unavailable", { status: 503 });

--- a/packages/server/src/gateway/connections/slack-connection-coordinator.ts
+++ b/packages/server/src/gateway/connections/slack-connection-coordinator.ts
@@ -83,7 +83,12 @@ export class SlackConnectionCoordinator {
     const connections = await this.deps.listSlackConnections();
     return (
       connections.find(
-        (connection) => connection.metadata?.teamId === teamId
+        (connection) =>
+          connection.metadata?.teamId === teamId &&
+          // A stopped BYO connection must not preempt routing — otherwise it
+          // shadows an active OAuth `slack_installations` row for the same team
+          // (matched first → 503, never falling through to the install).
+          connection.status !== "stopped"
       ) || null
     );
   }

--- a/packages/server/src/gateway/connections/slack-connection-coordinator.ts
+++ b/packages/server/src/gateway/connections/slack-connection-coordinator.ts
@@ -1,6 +1,6 @@
 import { createLogger } from "@lobu/core";
 import { Chat } from "chat";
-import { isUniqueViolation } from "../../utils/pg-errors.js";
+import type { SlackInstallationStore } from "../../lobu/stores/slack-installation-store.js";
 import type { PlatformAdapterConfig, PlatformConnection } from "./types.js";
 import {
   parseSlackTeamJoinEvent,
@@ -9,7 +9,6 @@ import {
 } from "./slack-platform-bridge.js";
 
 const logger = createLogger("slack-connection-coordinator");
-const SLACK_SYSTEM_AGENT_PREFIX = "system:connection:slack";
 
 type SlackInstallation = {
   botToken: string;
@@ -62,24 +61,13 @@ function readSlackAppEnvConfig(): SlackRuntimeConfig {
 }
 
 interface SlackConnectionCoordinatorDeps {
-  addConnection(
-    platform: string,
-    agentId: string | undefined,
-    config: PlatformAdapterConfig,
-    settings?: { allowGroups?: boolean },
-    metadata?: Record<string, unknown>
-  ): Promise<PlatformConnection>;
   createStateAdapter(): Promise<any>;
   ensureConnectionRunning(connectionId: string): Promise<boolean>;
   forwardWebhook(connectionId: string, request: Request): Promise<Response>;
   getRunningChat(connectionId: string): any | undefined;
-  hasConnection(connectionId: string): boolean;
   listSlackConnections(): Promise<PlatformConnection[]>;
-  restartConnection(connectionId: string): Promise<void>;
-  updateConnection(
-    connectionId: string,
-    updates: Partial<PlatformConnection>
-  ): Promise<PlatformConnection>;
+  /** Per-workspace OAuth installs (token + tenant data), keyed on (org, team). */
+  installationStore: SlackInstallationStore;
 }
 
 export class SlackConnectionCoordinator {
@@ -125,85 +113,41 @@ export class SlackConnectionCoordinator {
     );
   }
 
-  async ensureWorkspaceConnection(
+  /**
+   * Persist a per-workspace OAuth install: the workspace's bot token + tenant
+   * metadata, keyed on (org, team), in the `slack_installations` store. This is
+   * NOT an `agent_connections` row — an installed workspace has no owning agent;
+   * it routes to many agents via `/lobu link` channel bindings. The token goes
+   * to the secret store (the store handles that); app-level creds
+   * (signingSecret/clientId/clientSecret) stay env-sourced at runtime. Idempotent
+   * per (org, team) — a re-install refreshes the token on the same row id, so the
+   * instance memo, secret prefix, and any existing bindings are unaffected.
+   */
+  async ensureWorkspaceInstallation(
+    organizationId: string,
     teamId: string,
     installation: SlackInstallation
-  ): Promise<PlatformConnection> {
-    // Persist only per-workspace (tenant) data. App-level secrets
-    // (signingSecret/clientId/clientSecret) are read from env by the Slack
-    // adapter at runtime, so they never get duplicated into per-tenant rows and
-    // rotating them does not require reinstalling each workspace. The OAuth
-    // handshake that produced `installation` already validated the env config
-    // (via createOAuthChat → resolveAdapterConfig), so there's nothing to
-    // re-check here.
-    const config: PlatformAdapterConfig = {
-      platform: "slack",
-      botToken: installation.botToken,
-      ...(installation.botUserId ? { botUserId: installation.botUserId } : {}),
-    };
-    const agentId = `${SLACK_SYSTEM_AGENT_PREFIX}:${teamId}`;
-    const metadata = {
+  ): Promise<{ installationId: string }> {
+    const row = await this.deps.installationStore.upsertByTeam(
+      organizationId,
       teamId,
-      teamName: installation.teamName,
-      botUserId: installation.botUserId,
-    };
-
-    const adoptExisting = async (
-      existing: PlatformConnection
-    ): Promise<PlatformConnection> => {
-      const updated = await this.deps.updateConnection(existing.id, {
-        agentId,
-        config,
-        metadata,
-      });
-      if (!this.deps.hasConnection(existing.id)) {
-        await this.deps.restartConnection(existing.id);
+      {
+        teamName: installation.teamName,
+        botUserId: installation.botUserId,
+        botToken: installation.botToken,
       }
-      return updated;
-    };
-
-    const existing = await this.findConnectionByTeamId(teamId);
-    if (existing) {
-      return adoptExisting(existing);
-    }
-
-    try {
-      return await this.deps.addConnection(
-        "slack",
-        agentId,
-        config,
-        { allowGroups: true },
-        metadata
-      );
-    } catch (error) {
-      // Two concurrent installs for the same workspace both pass the
-      // find-by-teamId check; the unique index
-      // `idx_agent_connections_slack_workspace` makes the second insert fail
-      // instead of creating a duplicate row. Converge on the winner. (The
-      // loser's pre-persisted secret refs under its discarded connection id
-      // are an acknowledged tiny leak, logged for operator hygiene.)
-      if (!isUniqueViolation(error, "idx_agent_connections_slack_workspace")) {
-        throw error;
-      }
-      logger.warn(
-        { teamId },
-        "Concurrent Slack install detected; adopting the winning connection"
-      );
-      const winner = await this.findConnectionByTeamId(teamId);
-      if (!winner) {
-        throw error;
-      }
-      return adoptExisting(winner);
-    }
+    );
+    return { installationId: row.id };
   }
 
   async completeOAuthInstall(
     request: Request,
-    redirectUri?: string
+    redirectUri: string | undefined,
+    organizationId: string
   ): Promise<{
     teamId: string;
     teamName?: string;
-    connectionId: string;
+    installationId: string;
   }> {
     const { chat, adapter } = await this.createOAuthChat({
       requireOAuth: true,
@@ -222,14 +166,18 @@ export class SlackConnectionCoordinator {
 
       const { teamId, installation } =
         await adapter.handleOAuthCallback(callbackRequest);
-      let connection: PlatformConnection;
+      let installationId: string;
       try {
-        connection = await this.ensureWorkspaceConnection(teamId, installation);
+        ({ installationId } = await this.ensureWorkspaceInstallation(
+          organizationId,
+          teamId,
+          installation
+        ));
       } catch (error) {
         await adapter.deleteInstallation(teamId).catch((err) => {
           logger.warn(
             { teamId, error: String(err) },
-            "Failed to delete Slack installation after connection error"
+            "Failed to delete Slack installation after persistence error"
           );
         });
         throw error;
@@ -238,7 +186,7 @@ export class SlackConnectionCoordinator {
       return {
         teamId,
         teamName: installation.teamName,
-        connectionId: connection.id,
+        installationId,
       };
     } finally {
       await chat.shutdown().catch((err: unknown) => {
@@ -257,6 +205,8 @@ export class SlackConnectionCoordinator {
     const teamId = this.extractTeamId(body, contentType);
 
     if (teamId) {
+      // 1) A BYO agent-owned Slack connection for this workspace (created via
+      //    the UI with its own bot token) — unchanged legacy path.
       const connection = await this.findConnectionByTeamId(teamId);
       if (connection) {
         if (!(await this.deps.ensureConnectionRunning(connection.id))) {
@@ -268,6 +218,27 @@ export class SlackConnectionCoordinator {
         );
         if (response.ok && teamJoinEvent) {
           await this.handleTeamJoinWelcome(connection.id, teamJoinEvent);
+        }
+        return response;
+      }
+
+      // 2) An OAuth-installed workspace (the "Add to Slack" path). The install
+      //    lives in `slack_installations`, not `agent_connections`; the manager
+      //    hydrates an agentless Slack instance from it (id is namespaced, so
+      //    `ensureConnectionRunning`/`forwardWebhook` resolve it from the
+      //    installation store). Per-message routing is via `/lobu link` bindings.
+      const installation =
+        await this.deps.installationStore.getByTeamId(teamId);
+      if (installation && installation.status !== "stopped") {
+        if (!(await this.deps.ensureConnectionRunning(installation.id))) {
+          return new Response("Slack connection unavailable", { status: 503 });
+        }
+        const response = await this.deps.forwardWebhook(
+          installation.id,
+          this.cloneRequestWithBody(request, body)
+        );
+        if (response.ok && teamJoinEvent) {
+          await this.handleTeamJoinWelcome(installation.id, teamJoinEvent);
         }
         return response;
       }

--- a/packages/server/src/gateway/platform.ts
+++ b/packages/server/src/gateway/platform.ts
@@ -27,6 +27,7 @@ import type { SecretProxy } from "./proxy/secret-proxy.js";
 import type { WritableSecretStore } from "./secrets/index.js";
 import type { DeclaredAgentRegistry } from "./services/declared-agent-registry.js";
 import type { InstructionService } from "./services/instruction-service.js";
+import type { SlackInstallationStore } from "../lobu/stores/slack-installation-store.js";
 import type { SseManager } from "./services/sse-manager.js";
 import type { TranscriptionService } from "./services/transcription-service.js";
 import type { ISessionManager } from "./session.js";
@@ -64,6 +65,7 @@ export interface CoreServices {
   getGrantStore(): GrantStore | undefined;
   getDeclaredAgentRegistry(): DeclaredAgentRegistry | undefined;
   getConnectionStore(): AgentConnectionStore | undefined;
+  getSlackInstallationStore(): SlackInstallationStore;
 }
 
 // ============================================================================

--- a/packages/server/src/gateway/routes/public/slack.ts
+++ b/packages/server/src/gateway/routes/public/slack.ts
@@ -296,13 +296,15 @@ export function createSlackRoutes(manager: ChatInstanceManager): Hono {
     try {
       const result = await manager.completeSlackOAuthInstall(
         c.req.raw,
-        consumed.redirectUri
+        consumed.redirectUri,
+        oauthState.organizationId
       );
       return c.html(
         renderOAuthSuccessPage(result.teamName || result.teamId, undefined, {
           title: "Slack installed",
-          description: "Workspace connected to Lobu:",
-          details: `Connection ID: ${result.connectionId}`,
+          description:
+            "Workspace connected to Lobu. In a channel, run /lobu link <code> to wire an agent:",
+          details: "Get a code from an agent's Deploy tab in your Lobu dashboard.",
         })
       );
     } catch (error) {

--- a/packages/server/src/gateway/services/core-services.ts
+++ b/packages/server/src/gateway/services/core-services.ts
@@ -11,6 +11,10 @@ import {
 } from "@lobu/core";
 import { getDb } from "../../db/client.js";
 import { PostgresSecretStore } from "../../lobu/stores/postgres-secret-store.js";
+import {
+	createPostgresSlackInstallationStore,
+	type SlackInstallationStore,
+} from "../../lobu/stores/slack-installation-store.js";
 import { AgentMetadataStore } from "../auth/agent-metadata-store.js";
 import { ApiKeyProviderModule } from "../auth/api-key-provider-module.js";
 import { BedrockProviderModule } from "../auth/bedrock/provider-module.js";
@@ -174,6 +178,7 @@ export class CoreServices {
 	// ============================================================================
 	private configStore?: AgentConfigStore;
 	private connectionStore?: AgentConnectionStore;
+	private slackInstallationStore?: SlackInstallationStore;
 
 	// SDK-embedded agents (passed via `GatewayConfig.agents`). lobu.config.ts
 	// file-declared agents have been moved out of the gateway boot path —
@@ -213,6 +218,13 @@ export class CoreServices {
 
 	getConnectionStore(): AgentConnectionStore | undefined {
 		return this.connectionStore;
+	}
+
+	getSlackInstallationStore(): SlackInstallationStore {
+		if (!this.slackInstallationStore) {
+			throw new Error("Slack installation store not initialized");
+		}
+		return this.slackInstallationStore;
 	}
 
 	/**
@@ -370,6 +382,14 @@ export class CoreServices {
 				},
 			);
 		logger.debug("Secret store initialized");
+
+		// Slack workspace installs (the "Add to Slack" OAuth path) live in their
+		// own Postgres table keyed on (org, team) — not as agent connections —
+		// with the bot token in the secret store. Always Postgres-backed; only
+		// exercised on the OAuth/webhook path, which requires a DB.
+		this.slackInstallationStore = createPostgresSlackInstallationStore(
+			this.secretStore,
+		);
 
 		this.channelBindingService = new ChannelBindingService();
 		this.userAgentsStore = new UserAgentsStore();

--- a/packages/server/src/lobu/stores/__tests__/postgres-secret-store.test.ts
+++ b/packages/server/src/lobu/stores/__tests__/postgres-secret-store.test.ts
@@ -150,6 +150,17 @@ describe('PostgresSecretStore', () => {
       expect(entries).toEqual([]);
     });
 
+    it('matches a prefix that literally contains an underscore', async () => {
+      // Regression: the escape char must be a real backslash. A prior bug had
+      // `ESCAPE '\'` collapse to an empty escape string in the template
+      // literal, so the `\_` that escaping inserts became a literal-backslash
+      // requirement and matched nothing — silently breaking deleteSecretsByPrefix
+      // for any prefix containing `_`/`%` (e.g. `installations/slackinst-…/`).
+      await store.put('grp_a/token', 'v');
+      const entries = await store.list('grp_a/');
+      expect(entries.map((e) => e.name)).toEqual(['grp_a/token']);
+    });
+
     it('filters out expired entries', async () => {
       await store.put('ephemeral/secret', 'gone-soon', { ttlSeconds: 60 });
       const db = getTestDb();

--- a/packages/server/src/lobu/stores/postgres-secret-store.ts
+++ b/packages/server/src/lobu/stores/postgres-secret-store.ts
@@ -183,7 +183,7 @@ export class PostgresSecretStore implements WritableSecretStore {
           SELECT name, updated_at
           FROM agent_secrets
           WHERE organization_id = ${targetOrgId}
-            AND name LIKE ${escapeLikePrefix(prefix) + '%'} ESCAPE '\'
+            AND name LIKE ${escapeLikePrefix(prefix) + '%'} ESCAPE '\\'
             AND (expires_at IS NULL OR expires_at > now())
           ORDER BY name ASC
         `

--- a/packages/server/src/lobu/stores/slack-installation-store.ts
+++ b/packages/server/src/lobu/stores/slack-installation-store.ts
@@ -130,6 +130,18 @@ export function createPostgresSlackInstallationStore(
           WHERE id = ${id}
           RETURNING *
         `;
+
+        // One active install per Slack workspace. team_id is global and the
+        // public /slack/events route has no org context, so a fresh install
+        // from another org must supersede prior ones (Slack itself rotates the
+        // old org's bot token on re-install — latest wins). Stopping the others
+        // keeps getByTeamId unambiguous instead of relying on recency ordering.
+        await sql`
+          UPDATE slack_installations
+          SET status = 'stopped', updated_at = now()
+          WHERE team_id = ${teamId} AND id <> ${id} AND status <> 'stopped'
+        `;
+
         return rowToInstallation(rows[0]);
       });
     },

--- a/packages/server/src/lobu/stores/slack-installation-store.ts
+++ b/packages/server/src/lobu/stores/slack-installation-store.ts
@@ -90,15 +90,31 @@ export function createPostgresSlackInstallationStore(
       // land in the same tenant bucket regardless of ambient context.
       return orgContext.run({ organizationId }, async () => {
         const sql = getDb();
-        const existing = await sql`
-          SELECT id FROM slack_installations
-          WHERE organization_id = ${organizationId} AND team_id = ${teamId}
-          LIMIT 1
-        `;
-        const id =
-          (existing[0]?.id as string | undefined) ??
-          `${SLACK_INSTALLATION_ID_PREFIX}${randomUUID().replace(/-/g, "")}`;
+        const candidateId = `${SLACK_INSTALLATION_ID_PREFIX}${randomUUID().replace(/-/g, "")}`;
+        const now = new Date();
 
+        // Step 1: claim the (org, team) row and learn its CANONICAL id. Under a
+        // concurrent first-install, the loser's INSERT conflicts and DO UPDATE
+        // returns the winner's id — so we never persist a token under an id the
+        // surviving row doesn't reference. config is left untouched here.
+        const claimed = await sql`
+          INSERT INTO slack_installations
+            (id, organization_id, team_id, team_name, bot_user_id, config, status, created_at, updated_at)
+          VALUES (
+            ${candidateId}, ${organizationId}, ${teamId}, ${data.teamName ?? null},
+            ${data.botUserId ?? null}, '{}'::jsonb, 'active', ${now}, ${now}
+          )
+          ON CONFLICT (organization_id, team_id) DO UPDATE SET
+            team_name = EXCLUDED.team_name,
+            bot_user_id = EXCLUDED.bot_user_id,
+            status = 'active',
+            updated_at = ${now}
+          RETURNING id
+        `;
+        const id = claimed[0]!.id as string;
+
+        // Step 2: persist the token under the canonical id, then point the row's
+        // config at the ref.
         const tokenRef = await persistSecretValue(
           secretStore,
           `installations/${id}/botToken`,
@@ -108,20 +124,10 @@ export function createPostgresSlackInstallationStore(
           platform: "slack",
           ...(tokenRef ? { botToken: tokenRef } : {}),
         };
-        const now = new Date();
         const rows = await sql`
-          INSERT INTO slack_installations
-            (id, organization_id, team_id, team_name, bot_user_id, config, status, created_at, updated_at)
-          VALUES (
-            ${id}, ${organizationId}, ${teamId}, ${data.teamName ?? null},
-            ${data.botUserId ?? null}, ${sql.json(config)}, 'active', ${now}, ${now}
-          )
-          ON CONFLICT (organization_id, team_id) DO UPDATE SET
-            team_name = EXCLUDED.team_name,
-            bot_user_id = EXCLUDED.bot_user_id,
-            config = EXCLUDED.config,
-            status = 'active',
-            updated_at = ${now}
+          UPDATE slack_installations
+          SET config = ${sql.json(config)}, updated_at = ${new Date()}
+          WHERE id = ${id}
           RETURNING *
         `;
         return rowToInstallation(rows[0]);

--- a/packages/server/src/lobu/stores/slack-installation-store.ts
+++ b/packages/server/src/lobu/stores/slack-installation-store.ts
@@ -1,0 +1,186 @@
+import { randomUUID } from "node:crypto";
+import {
+  deleteSecretsByPrefix,
+  persistSecretValue,
+} from "../../gateway/secrets/index.js";
+import type { WritableSecretStore } from "../../gateway/secrets/index.js";
+import { getDb } from "../../db/client.js";
+import { orgContext } from "./org-context.js";
+
+/**
+ * A per-workspace Slack app install (the "Add to Slack" OAuth path).
+ *
+ * This is an org/workspace-INSTALLATION resource, not an agent connection: one
+ * installed workspace routes to many agents via `/lobu link` channel bindings,
+ * so it has no owning agent. The bot token lives in the secret store; `config`
+ * carries only the `secret://` ref (mirrors `agent_connections.config`).
+ */
+export interface SlackInstallationRow {
+  id: string;
+  organizationId: string;
+  teamId: string;
+  teamName?: string;
+  botUserId?: string;
+  /** `{ platform: "slack", botToken: "secret://..." }` — token by ref, never plaintext. */
+  config: Record<string, any>;
+  status: "active" | "stopped" | "error";
+  createdAt: number;
+  updatedAt: number;
+}
+
+export interface SlackInstallationStore {
+  /**
+   * Idempotent per (org, team): a re-install refreshes the token + tenant
+   * metadata on the SAME row id (so the instance memo and secret prefix stay
+   * stable). The plaintext `botToken` is persisted to the secret store; only
+   * its ref is written to the row.
+   */
+  upsertByTeam(
+    organizationId: string,
+    teamId: string,
+    data: { teamName?: string; botUserId?: string; botToken: string }
+  ): Promise<SlackInstallationRow>;
+  getById(id: string): Promise<SlackInstallationRow | null>;
+  /**
+   * Resolve by team_id across orgs — the public `/slack/events` route carries
+   * no org context, so routing keys on team_id alone (same semantics as the
+   * legacy `agent_connections` team lookup). Prefers an `active` row.
+   */
+  getByTeamId(teamId: string): Promise<SlackInstallationRow | null>;
+  list(organizationId: string): Promise<SlackInstallationRow[]>;
+  markStopped(id: string): Promise<void>;
+  delete(id: string): Promise<void>;
+}
+
+/**
+ * Stable prefix so the connection manager can recognize an installation id.
+ * Hyphen (not underscore) on purpose: the id appears inside the secret-store
+ * name prefix `installations/<id>/`, and `_`/`%` are LIKE wildcards that the
+ * secret store's prefix scan does not reliably escape — a hyphen keeps the
+ * cascade delete working.
+ */
+export const SLACK_INSTALLATION_ID_PREFIX = "slackinst-";
+
+function rowToInstallation(row: Record<string, any>): SlackInstallationRow {
+  return {
+    id: row.id,
+    organizationId: row.organization_id,
+    teamId: row.team_id,
+    teamName: row.team_name ?? undefined,
+    botUserId: row.bot_user_id ?? undefined,
+    config: row.config ?? {},
+    status: row.status,
+    createdAt:
+      row.created_at instanceof Date
+        ? row.created_at.getTime()
+        : (row.created_at ?? Date.now()),
+    updatedAt:
+      row.updated_at instanceof Date
+        ? row.updated_at.getTime()
+        : (row.updated_at ?? Date.now()),
+  };
+}
+
+export function createPostgresSlackInstallationStore(
+  secretStore: WritableSecretStore
+): SlackInstallationStore {
+  return {
+    async upsertByTeam(organizationId, teamId, data) {
+      // Bind the org for both the secret-store put and the row write so they
+      // land in the same tenant bucket regardless of ambient context.
+      return orgContext.run({ organizationId }, async () => {
+        const sql = getDb();
+        const existing = await sql`
+          SELECT id FROM slack_installations
+          WHERE organization_id = ${organizationId} AND team_id = ${teamId}
+          LIMIT 1
+        `;
+        const id =
+          (existing[0]?.id as string | undefined) ??
+          `${SLACK_INSTALLATION_ID_PREFIX}${randomUUID().replace(/-/g, "")}`;
+
+        const tokenRef = await persistSecretValue(
+          secretStore,
+          `installations/${id}/botToken`,
+          data.botToken
+        );
+        const config = {
+          platform: "slack",
+          ...(tokenRef ? { botToken: tokenRef } : {}),
+        };
+        const now = new Date();
+        const rows = await sql`
+          INSERT INTO slack_installations
+            (id, organization_id, team_id, team_name, bot_user_id, config, status, created_at, updated_at)
+          VALUES (
+            ${id}, ${organizationId}, ${teamId}, ${data.teamName ?? null},
+            ${data.botUserId ?? null}, ${sql.json(config)}, 'active', ${now}, ${now}
+          )
+          ON CONFLICT (organization_id, team_id) DO UPDATE SET
+            team_name = EXCLUDED.team_name,
+            bot_user_id = EXCLUDED.bot_user_id,
+            config = EXCLUDED.config,
+            status = 'active',
+            updated_at = ${now}
+          RETURNING *
+        `;
+        return rowToInstallation(rows[0]);
+      });
+    },
+
+    async getById(id) {
+      const sql = getDb();
+      const rows = await sql`SELECT * FROM slack_installations WHERE id = ${id} LIMIT 1`;
+      return rows.length ? rowToInstallation(rows[0]) : null;
+    },
+
+    async getByTeamId(teamId) {
+      const sql = getDb();
+      const rows = await sql`
+        SELECT * FROM slack_installations
+        WHERE team_id = ${teamId}
+        ORDER BY (status = 'active') DESC, updated_at DESC
+        LIMIT 1
+      `;
+      return rows.length ? rowToInstallation(rows[0]) : null;
+    },
+
+    async list(organizationId) {
+      const sql = getDb();
+      const rows = await sql`
+        SELECT * FROM slack_installations
+        WHERE organization_id = ${organizationId}
+        ORDER BY created_at DESC
+      `;
+      return rows.map(rowToInstallation);
+    },
+
+    async markStopped(id) {
+      const sql = getDb();
+      await sql`
+        UPDATE slack_installations
+        SET status = 'stopped', updated_at = now()
+        WHERE id = ${id}
+      `;
+    },
+
+    async delete(id) {
+      const sql = getDb();
+      // Resolve the org first: the token was stored under the install org's
+      // secret bucket, so the prefix delete must run under that org context
+      // (PostgresSecretStore scopes list/delete by AsyncLocalStorage org).
+      const rows = await sql`
+        SELECT organization_id FROM slack_installations WHERE id = ${id} LIMIT 1
+      `;
+      const orgId = rows[0]?.organization_id as string | undefined;
+      await sql`DELETE FROM slack_installations WHERE id = ${id}`;
+      const purge = () =>
+        deleteSecretsByPrefix(secretStore, `installations/${id}/`);
+      if (orgId) {
+        await orgContext.run({ organizationId: orgId }, purge);
+      } else {
+        await purge();
+      }
+    },
+  };
+}

--- a/packages/server/src/preview/slack.ts
+++ b/packages/server/src/preview/slack.ts
@@ -452,6 +452,23 @@ export async function previewUnlinkedNotice(
   ].join('\n');
 }
 
+/**
+ * Reply for a tenant's own OAuth-installed workspace bot (a connection with a
+ * `metadata.teamId` but no owning agent) when a non-command message arrives in
+ * a channel that isn't bound to one of the tenant's agents yet. Unlike a
+ * preview connection there are no demo agents to offer — the tenant links their
+ * own agents with `/lobu link <code>`. Returns null for non-Slack platforms
+ * (OAuth install is Slack-only today).
+ */
+export function workspaceUnlinkedNotice(platform: string): string | null {
+  if (platform !== 'slack') return null;
+  return [
+    "👋 Thanks for adding Lobu! This channel isn't linked to one of your agents yet.",
+    '',
+    `Run \`${linkCommand(platform)} <code>\` here with a link code from your Lobu dashboard (or \`lobu run\`) to connect an agent.`,
+  ].join('\n');
+}
+
 /** The Lobu user id a chat-platform user has linked to, or null. */
 export async function resolveChatUserIdentity(
   platform: string,


### PR DESCRIPTION
## What

Makes "Add to Slack" (OAuth) actually work, the proper way: a Slack workspace install is a first-class **org/workspace-installation** resource, not an agent connection.

Slack OAuth v2 returns a per-workspace bot token we must persist to reply in that workspace. The prior code stored it as an `agent_connections` row, which requires `agent_id NOT NULL` + a composite FK to `agents` — so it invented a synthetic `system:connection:slack:<teamId>` agent that was never created → FK violation → "Authentication Failed" (the reason it was reverted). But an installed workspace has **no single owning agent**: it routes to many agents via `/lobu link` channel bindings.

## How

- **New `slack_installations` table** keyed on `(org, team)` — no `agent_id`, no FK to `agents`; bot token stored as a `secret://` ref (never plaintext).
- **`SlackInstallationStore`** (CRUD + secret round-trip + cross-org `getByTeamId` for the no-context `/slack/events` route + idempotent re-install).
- **One reuse seam**: the live runtime is already agent-agnostic, so `ChatInstanceManager.resolveStored()` maps `slackinst-<id>` ids to agentless connection-shaped rows that hydrate through the existing adapter / instance-memo / webhook / slash / multi-replica machinery unchanged. `handleAppWebhook` routes `team_id` → installation. Unbound non-command messages get a "run `/lobu link`" notice instead of running a dead placeholder.
- Bundled fix: `postgres-secret-store.list()` LIKE `ESCAPE` collapsed to empty in a template literal, silently breaking `deleteSecretsByPrefix` for `_`/`%` prefixes (red→green test included).
- Owletto pointer bump (Channels→Deploy merge + Add to Slack restore — owletto#303).

## Why not the alternatives
Per-agent-owned (option 1) cascade-deletes the workspace when the owning agent is deleted and creates a per-(org,team) "claim" race with the per-agent button. Org-default-agent (option 3) just moves the false ownership onto infra. A dedicated installations store (GPT-5's recommendation) keeps token storage and agent routing cleanly separated.

## Tests / verification
Real-Postgres tests: installation-store CRUD + secret round-trip + cross-org lookup + idempotency + cascade-delete; coordinator install delegation + `team_id`→installation webhook routing; manager hydrates `slackinst-` as an agentless slack connection; unbound → link notice. `make typecheck` + `make build-packages` + owletto `tsc -b`/route-smoke green.

### E2E (bug-fix gate)
- **red→green reproducer** for the bundled secret-store fix: `postgres-secret-store.test.ts` "matches a prefix that literally contains an underscore" — verified red with `ESCAPE '\'`, green with `ESCAPE '\\'`.
- **Owed (needs deploy / real Slack):** the full live OAuth handshake + an actual workspace reply require a real Slack app install; every storage/routing/hydration layer below that is real-DB tested. The live redirect/callback path was verified earlier in this work; this PR replaces the persistence layer beneath it. Will verify post-deploy: install → row + token in secret store → message in a `/lobu link`-bound channel routes to the agent → reply uses the workspace token.

## Deferred (out of scope)
`app_uninstalled` teardown, token-expiry health/alerts, dashboard-side channel binding (v1 uses in-workspace `/lobu link`; the minted code is workspace-agnostic).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1394"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784473138&installation_id=136316292&pr_number=1394&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1394&signature=03dae63bd61136973d0639c32f049a7832b563f227493d4ab02e7c1a71cc15dd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added persistent Slack “Add to Slack” OAuth workspace installations, enabling installation-backed Slack workspace instances.
  * Updated Slack preview and OAuth completion to provide one-time install and `/lobu link` guidance.
  * Improved Slack webhook routing to use active OAuth installations when BYO connections don’t apply.
* **Bug Fixes**
  * Fixed PostgreSQL secret-store prefix matching for underscore (`_`) escaping.
* **Tests**
  * Expanded Slack installation, webhook routing, and message handling coverage for OAuth-installed workspaces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->