### PR TITLE
fix(anthropic): resolve auto-mode model from env key + run newest live models

### DIFF
--- a/packages/agent-worker/src/openclaw/session-runner.ts
+++ b/packages/agent-worker/src/openclaw/session-runner.ts
@@ -605,6 +605,30 @@ export async function runAISession(
         modelId,
         providerBaseUrl,
       });
+    } else if (provider === "anthropic") {
+      // The newest Claude models (resolved live from the provider for auto-mode
+      // agents) lag pi-ai's static registry. Clone a known Claude model's shape
+      // and override the id so the agent still runs — Anthropic / the
+      // claude-code CLI validates the id upstream. Without this, an auto-mode
+      // agent on the newest model crashes with "not found in the model registry".
+      const template = [
+        "claude-sonnet-4-5",
+        "claude-sonnet-4-20250514",
+        "claude-haiku-4-5-20251001",
+        "claude-3-5-sonnet-20241022",
+      ]
+        .map((id) => getModel("anthropic" as any, id as any))
+        .find(Boolean);
+      if (template) {
+        logger.info(
+          `Creating dynamic Claude model entry for ${modelId} (not in static registry)`
+        );
+        baseModel = { ...(template as any), id: modelId, name: modelId };
+      } else {
+        throw new Error(
+          `Model "${modelId}" not found for provider "${provider}". Check that the model ID is valid and registered in the model registry.`
+        );
+      }
     } else {
       throw new Error(
         `Model "${modelId}" not found for provider "${provider}". Check that the model ID is valid and registered in the model registry.`

--- a/packages/server/src/gateway/auth/claude/__tests__/oauth-module-default-model.test.ts
+++ b/packages/server/src/gateway/auth/claude/__tests__/oauth-module-default-model.test.ts
@@ -1,0 +1,102 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { ClaudeOAuthModule } from "../oauth-module.js";
+
+/**
+ * getDefaultModel() powers auto-mode model resolution: the gateway asks the
+ * Claude module for the agent's default (newest live) model. It must use the
+ * system env key (ANTHROPIC_API_KEY) when the agent has no auth profile —
+ * otherwise an env-configured Anthropic agent resolves to no model and the
+ * worker throws "No model configured".
+ */
+describe("ClaudeOAuthModule.getDefaultModel — env-key credential", () => {
+  const ENV_KEYS = [
+    "ANTHROPIC_API_KEY",
+    "ANTHROPIC_AUTH_TOKEN",
+    "CLAUDE_CODE_OAUTH_TOKEN",
+  ] as const;
+  const saved: Record<string, string | undefined> = {};
+  let originalFetch: typeof globalThis.fetch;
+
+  beforeEach(() => {
+    for (const k of ENV_KEYS) {
+      saved[k] = process.env[k];
+      delete process.env[k];
+    }
+    originalFetch = globalThis.fetch;
+  });
+  afterEach(() => {
+    for (const k of ENV_KEYS) {
+      if (saved[k] === undefined) delete process.env[k];
+      else process.env[k] = saved[k];
+    }
+    globalThis.fetch = originalFetch;
+  });
+
+  function makeModule(): ClaudeOAuthModule {
+    // No per-agent profile — forces the system-env-key path.
+    const authProfilesManager = {
+      getBestProfile: async () => null,
+    } as never;
+    return new ClaudeOAuthModule(authProfilesManager, {} as never);
+  }
+
+  test("uses ANTHROPIC_API_KEY (x-api-key) and returns the newest model", async () => {
+    process.env.ANTHROPIC_API_KEY = "sk-ant-api03-test";
+    let sentAuthHeader: string | undefined;
+    let sentApiKeyHeader: string | undefined;
+    globalThis.fetch = (async (_url, init) => {
+      const h = (init?.headers as Record<string, string>) ?? {};
+      sentAuthHeader = h.Authorization;
+      sentApiKeyHeader = h["x-api-key"];
+      return new Response(
+        JSON.stringify({
+          data: [
+            { id: "claude-newest-1", display_name: "Newest", type: "model" },
+            { id: "claude-older-2", display_name: "Older", type: "model" },
+          ],
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } }
+      );
+    }) as typeof globalThis.fetch;
+
+    const model = await makeModule().getDefaultModel("agent-1");
+
+    expect(model).toBe("claude-newest-1");
+    expect(sentApiKeyHeader).toBe("sk-ant-api03-test");
+    expect(sentAuthHeader).toBeUndefined();
+  });
+
+  test("uses ANTHROPIC_AUTH_TOKEN as a Bearer token, not x-api-key", async () => {
+    process.env.ANTHROPIC_AUTH_TOKEN = "sk-ant-oat-bearer";
+    let sentAuthHeader: string | undefined;
+    let sentApiKeyHeader: string | undefined;
+    globalThis.fetch = (async (_url, init) => {
+      const h = (init?.headers as Record<string, string>) ?? {};
+      sentAuthHeader = h.Authorization;
+      sentApiKeyHeader = h["x-api-key"];
+      return new Response(
+        JSON.stringify({ data: [{ id: "claude-x", type: "model" }] }),
+        { status: 200, headers: { "Content-Type": "application/json" } }
+      );
+    }) as typeof globalThis.fetch;
+
+    const model = await makeModule().getDefaultModel("agent-1");
+
+    expect(model).toBe("claude-x");
+    expect(sentAuthHeader).toBe("Bearer sk-ant-oat-bearer");
+    expect(sentApiKeyHeader).toBeUndefined();
+  });
+
+  test("no credentials → undefined (no model, surfaces 'connect a provider')", async () => {
+    let fetched = false;
+    globalThis.fetch = (async () => {
+      fetched = true;
+      return new Response("{}", { status: 200 });
+    }) as typeof globalThis.fetch;
+
+    const model = await makeModule().getDefaultModel("agent-1");
+
+    expect(model).toBeUndefined();
+    expect(fetched).toBe(false);
+  });
+});

--- a/packages/server/src/gateway/auth/claude/oauth-module.ts
+++ b/packages/server/src/gateway/auth/claude/oauth-module.ts
@@ -264,12 +264,21 @@ export class ClaudeOAuthModule extends BaseProviderModule {
       this.providerId
     );
 
-    const oauthToken =
-      profile?.authType === "oauth" ? profile.credential : undefined;
-    const apiKey =
-      profile?.authType !== "oauth"
-        ? profile?.credential
-        : process.env.ANTHROPIC_AUTH_TOKEN || process.env.ANTHROPIC_API_KEY;
+    // A per-agent profile wins entirely; only when none exists do we fall back
+    // to the system env key. Without that env fallback, an env-configured key
+    // (no auth profile) produced no credential here, so getDefaultModel
+    // returned undefined and an auto-mode agent got "No model configured".
+    // ANTHROPIC_AUTH_TOKEN is a Bearer token (preferred, matches the secret
+    // proxy); ANTHROPIC_API_KEY is presented as x-api-key.
+    let oauthToken: string | undefined;
+    let apiKey: string | undefined;
+    if (profile?.credential) {
+      if (profile.authType === "oauth") oauthToken = profile.credential;
+      else apiKey = profile.credential;
+    } else {
+      oauthToken = resolveEnv("ANTHROPIC_AUTH_TOKEN");
+      if (!oauthToken) apiKey = resolveEnv("ANTHROPIC_API_KEY");
+    }
 
     const headers: Record<string, string> = {
       Accept: "application/json",


### PR DESCRIPTION
## Bug
Auto-mode (no pinned model) on an **env-configured** Anthropic key failed with `No model configured`. Two bugs in the model-resolution chain:

**1. `fetchClaudeModels` ignored the env system key** (`oauth-module.ts`). It powers `getDefaultModel`, which the gateway calls to resolve an auto-mode agent's default. The env fallback was in the wrong ternary branch:
```ts
const apiKey = profile?.authType !== "oauth" ? profile?.credential : process.env...
```
With no auth profile, `profile?.authType !== "oauth"` is `true` → `apiKey = undefined` → `/v1/models` skipped → `[]` → no default. Now: a profile wins entirely; env is the fallback. `ANTHROPIC_AUTH_TOKEN` (a Bearer token) is sent as Bearer, `ANTHROPIC_API_KEY` as `x-api-key`.

**2. Worker rejected newest live models** (`session-runner.ts`). `getModel` (pi-ai static registry) doesn't know the newest Claude models the gateway now resolves, and only OpenAI-compatible providers had a dynamic-entry fallback — anthropic threw "not found in the model registry". Now anthropic clones a known Claude model's shape with the new id (the CLI/API validate it upstream).

## Verification
- **Red→green unit reproducer** (`oauth-module-default-model.test.ts`): with only `ANTHROPIC_API_KEY` set, `getDefaultModel` returns the newest model and uses `x-api-key`; `ANTHROPIC_AUTH_TOKEN` → Bearer; no creds → undefined. Reverting the fix fails the env-key cases.
- **E2E**: gateway resolves the newest model → worker logs `Creating dynamic Claude model entry` → reaches `api.anthropic.com`. Both packages typecheck clean.

## Out of scope (separate decision)
Full auto-mode chat additionally needs a model-**selection** policy: `/v1/models` lists the absolute-newest model (e.g. a preview) which an account may not be licensed to use (Anthropic 404s "Claude Fable 5 not available, use Opus 4.8"). Whether auto-mode should pick newest-listed vs newest-usable/GA is a #1390 follow-up, flagged for a design decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1395"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784474222&installation_id=136316292&pr_number=1395&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1395&signature=cac98706da031c22addb2e52e4201c80d25191983b42245c738edd363f8cd2d0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->