### PR TITLE
feat(model): require an explicit model — no silent provider default

### DIFF
--- a/packages/agent-worker/src/__tests__/model-resolver-harden.test.ts
+++ b/packages/agent-worker/src/__tests__/model-resolver-harden.test.ts
@@ -91,7 +91,7 @@ describe("resolveModelRef — edge cases", () => {
   });
 
   test("throws when everything is empty and no defaults", () => {
-    expect(() => resolveModelRef("")).toThrow("No model configured");
+    expect(() => resolveModelRef("")).toThrow("No model selected");
   });
 });
 
@@ -198,12 +198,18 @@ describe("registerDynamicProvider — idempotency and precedence", () => {
     expect(PROVIDER_REGISTRY_ALIASES[id]).toBeUndefined();
   });
 
-  test("registered dynamic provider is resolvable via resolveModelRef", () => {
+  test("registered dynamic provider's default is reachable via the explicit 'auto' keyword", () => {
+    // A no-model agent now requires an explicit selection (no silent default),
+    // but a config-driven provider's declared defaultModel still resolves when
+    // the operator explicitly asks for "auto".
     registerDynamicProvider(id, {
       baseUrlEnvVar: "MY_BASE_URL",
       defaultModel: "dynamic-default",
     });
-    const result = resolveModelRef("", { defaultProvider: id });
+    expect(() => resolveModelRef("", { defaultProvider: id })).toThrow(
+      "No model selected"
+    );
+    const result = resolveModelRef("auto", { defaultProvider: id });
     expect(result.provider).toBe(id);
     expect(result.modelId).toBe("dynamic-default");
   });

--- a/packages/agent-worker/src/__tests__/model-resolver.test.ts
+++ b/packages/agent-worker/src/__tests__/model-resolver.test.ts
@@ -27,11 +27,10 @@ describe("resolveModelRef", () => {
     expect(result.modelId).toBe(DEFAULT_PROVIDER_MODELS.openai);
   });
 
-  test("anthropic 'auto' is left as-is — the gateway supplies the default", () => {
-    // anthropic intentionally has no worker-side default: its current model is
-    // resolved live by the gateway and delivered as `defaultModel`. With no
-    // default supplied here, "auto" passes through unchanged (the gateway's
-    // resolved model takes effect in production).
+  test("anthropic 'auto' is left as-is (no worker-side default to resolve)", () => {
+    // anthropic has no worker-side default model, so the explicit "auto"
+    // keyword passes through unchanged. In production a concrete Anthropic
+    // model must be selected (no silent default).
     const result = resolveModelRef("anthropic/auto");
     expect(result.provider).toBe("anthropic");
     expect(result.modelId).toBe("auto");
@@ -51,14 +50,16 @@ describe("resolveModelRef", () => {
     expect(result.modelId).toBe("claude-sonnet-4-20250514");
   });
 
-  test("falls back to provider default when no model or override", () => {
-    const result = resolveModelRef("", { defaultProvider: "gemini" });
-    expect(result.provider).toBe("gemini");
-    expect(result.modelId).toBe(DEFAULT_PROVIDER_MODELS.gemini);
+  test("no silent default: empty model with a provider now requires explicit selection", () => {
+    // Lobu no longer silently substitutes the provider's default model — a
+    // concrete model must be configured (chosen via the model picker).
+    expect(() => resolveModelRef("", { defaultProvider: "gemini" })).toThrow(
+      "No model selected"
+    );
   });
 
   test("throws when no model can be determined", () => {
-    expect(() => resolveModelRef("")).toThrow("No model configured");
+    expect(() => resolveModelRef("")).toThrow("No model selected");
   });
 
   test("throws when bare model ID and no default provider", () => {

--- a/packages/agent-worker/src/core/error-handler.ts
+++ b/packages/agent-worker/src/core/error-handler.ts
@@ -47,6 +47,7 @@ export function classifyError(error: unknown): string | undefined {
   if (message === SESSION_TIMEOUT_MESSAGE) return "SESSION_TIMEOUT";
   if (
     message.includes("No model configured") ||
+    message.includes("No model selected") ||
     message.includes("No provider specified")
   )
     return "NO_MODEL_CONFIGURED";

--- a/packages/agent-worker/src/openclaw/model-resolver.ts
+++ b/packages/agent-worker/src/openclaw/model-resolver.ts
@@ -162,23 +162,15 @@ export function resolveModelRef(
   const defaultProvider = overrides?.defaultProvider || "";
 
   const normalizedRaw = rawModelRef?.trim();
-  let modelRef = normalizedRaw || defaultModelRef;
+  const modelRef = normalizedRaw || defaultModelRef;
 
-  // When no model is configured but a provider is known, use the provider's
-  // default model so auto-mode provider selection works end-to-end.
-  if (!modelRef && defaultProvider) {
-    const fallbackModel = DEFAULT_PROVIDER_MODELS[defaultProvider];
-    if (fallbackModel) {
-      logger.info(
-        `No model configured, using default for ${defaultProvider}: ${fallbackModel}`
-      );
-      modelRef = fallbackModel;
-    }
-  }
-
+  // A model must be explicitly configured — Lobu no longer silently picks a
+  // provider default, because "newest available" is unreliable (e.g. the
+  // Anthropic API lists preview models an account can't actually use). Surface
+  // an actionable error so the operator selects a concrete model.
   if (!modelRef) {
     throw new Error(
-      "No model configured. Ask an admin to connect a provider for the base agent."
+      "No model selected for this agent. Choose a model in the agent's Providers settings."
     );
   }
 

--- a/packages/server/src/gateway/auth/claude/__tests__/oauth-module-model-options.test.ts
+++ b/packages/server/src/gateway/auth/claude/__tests__/oauth-module-model-options.test.ts
@@ -2,17 +2,17 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { ClaudeOAuthModule } from "../oauth-module.js";
 
 /**
- * getDefaultModel() powers auto-mode model resolution: the gateway asks the
- * Claude module for the agent's default (newest live) model. It must use the
- * system env key (ANTHROPIC_API_KEY) when the agent has no auth profile —
- * otherwise an env-configured Anthropic agent resolves to no model and the
- * worker throws "No model configured".
+ * getModelOptions() powers the model picker. It must use the system env key
+ * (ANTHROPIC_API_KEY) when the agent has no auth profile — otherwise an
+ * env-configured Anthropic agent shows an empty picker and the operator can't
+ * select a model (now required, since Lobu no longer silently picks a default).
  */
-describe("ClaudeOAuthModule.getDefaultModel — env-key credential", () => {
+describe("ClaudeOAuthModule.getModelOptions — env-key credential", () => {
   const ENV_KEYS = [
     "ANTHROPIC_API_KEY",
     "ANTHROPIC_AUTH_TOKEN",
     "CLAUDE_CODE_OAUTH_TOKEN",
+    "AGENT_DEFAULT_MODEL",
   ] as const;
   const saved: Record<string, string | undefined> = {};
   let originalFetch: typeof globalThis.fetch;
@@ -33,14 +33,15 @@ describe("ClaudeOAuthModule.getDefaultModel — env-key credential", () => {
   });
 
   function makeModule(): ClaudeOAuthModule {
-    // No per-agent profile — forces the system-env-key path.
-    const authProfilesManager = {
-      getBestProfile: async () => null,
+    // No per-agent profile — forces the system-env-key path. No pinned model.
+    const authProfilesManager = { getBestProfile: async () => null } as never;
+    const modelPreferenceStore = {
+      getModelPreference: async () => null,
     } as never;
-    return new ClaudeOAuthModule(authProfilesManager, {} as never);
+    return new ClaudeOAuthModule(authProfilesManager, modelPreferenceStore);
   }
 
-  test("uses ANTHROPIC_API_KEY (x-api-key) and returns the newest model", async () => {
+  test("uses ANTHROPIC_API_KEY (x-api-key) and lists the live models", async () => {
     process.env.ANTHROPIC_API_KEY = "sk-ant-api03-test";
     let sentAuthHeader: string | undefined;
     let sentApiKeyHeader: string | undefined;
@@ -59,9 +60,12 @@ describe("ClaudeOAuthModule.getDefaultModel — env-key credential", () => {
       );
     }) as typeof globalThis.fetch;
 
-    const model = await makeModule().getDefaultModel("agent-1");
+    const options = await makeModule().getModelOptions("agent-1", "user-1");
 
-    expect(model).toBe("claude-newest-1");
+    expect(options.map((o) => o.value)).toEqual([
+      "claude-newest-1",
+      "claude-older-2",
+    ]);
     expect(sentApiKeyHeader).toBe("sk-ant-api03-test");
     expect(sentAuthHeader).toBeUndefined();
   });
@@ -80,23 +84,23 @@ describe("ClaudeOAuthModule.getDefaultModel — env-key credential", () => {
       );
     }) as typeof globalThis.fetch;
 
-    const model = await makeModule().getDefaultModel("agent-1");
+    const options = await makeModule().getModelOptions("agent-1", "user-1");
 
-    expect(model).toBe("claude-x");
+    expect(options.map((o) => o.value)).toContain("claude-x");
     expect(sentAuthHeader).toBe("Bearer sk-ant-oat-bearer");
     expect(sentApiKeyHeader).toBeUndefined();
   });
 
-  test("no credentials → undefined (no model, surfaces 'connect a provider')", async () => {
+  test("no credentials → empty picker (no silent model)", async () => {
     let fetched = false;
     globalThis.fetch = (async () => {
       fetched = true;
       return new Response("{}", { status: 200 });
     }) as typeof globalThis.fetch;
 
-    const model = await makeModule().getDefaultModel("agent-1");
+    const options = await makeModule().getModelOptions("agent-1", "user-1");
 
-    expect(model).toBeUndefined();
+    expect(options).toEqual([]);
     expect(fetched).toBe(false);
   });
 });

--- a/packages/server/src/gateway/auth/claude/oauth-module.ts
+++ b/packages/server/src/gateway/auth/claude/oauth-module.ts
@@ -177,17 +177,6 @@ export class ClaudeOAuthModule extends BaseProviderModule {
     return options;
   }
 
-  /**
-   * The provider's current default model — the newest model the live API
-   * exposes. Returned to the gateway so an auto-mode (no pinned model) agent
-   * resolves to a current model instead of a hardcoded snapshot. Undefined when
-   * the provider has no credentials yet (the model list can't be fetched).
-   */
-  async getDefaultModel(agentId: string): Promise<string | undefined> {
-    const models = await this.fetchClaudeModels(agentId);
-    return models[0]?.id;
-  }
-
   async setCredentials(
     agentId: string,
     userId: string,

--- a/packages/server/src/gateway/gateway/index.ts
+++ b/packages/server/src/gateway/gateway/index.ts
@@ -973,27 +973,12 @@ export class WorkerGateway {
       result.defaultProvider = upstream?.slug || primaryProvider.providerId;
     }
 
+    // Only an explicitly configured model is used — Lobu no longer silently
+    // resolves a provider default (the worker errors with an actionable
+    // "select a model" message when none is set). A concrete model is chosen at
+    // config time via the model picker (getModelOptions).
     if (agentModel) {
       result.defaultModel = agentModel;
-    } else if (primaryProvider) {
-      // No pinned/preferred model (auto mode): ask the provider for its current
-      // default (e.g. its newest live model) so the worker never falls back to a
-      // hardcoded snapshot that can silently go stale. Providers without a model
-      // list simply don't supply one and the worker resolves via its own config.
-      const withDefault = primaryProvider as {
-        getDefaultModel?: (agentId: string) => Promise<string | undefined>;
-      };
-      if (typeof withDefault.getDefaultModel === "function") {
-        try {
-          const resolved = await withDefault.getDefaultModel(agentId);
-          if (resolved) result.defaultModel = resolved;
-        } catch (error) {
-          logger.warn(
-            { agentId, error: (error as Error)?.message },
-            "resolveProviderConfig: getDefaultModel failed; leaving model unset"
-          );
-        }
-      }
     }
 
     if (Object.keys(providerBaseUrlMappings).length > 0) {


### PR DESCRIPTION
## Why
Lobu silently auto-resolved a default model for agents with none: the worker fell back to `DEFAULT_PROVIDER_MODELS[provider]`, and the gateway resolved Anthropic's "newest live model". That's unreliable — the Anthropic API lists preview models an account can't actually use (404s *"Claude Fable 5 not available, use Opus 4.8"*), and a silently-changing "newest" is surprising. Per request: **require an explicit model for all providers.**

## What
- **Worker `model-resolver`**: drop the silent `DEFAULT_PROVIDER_MODELS` no-model fallback; throw an actionable **"No model selected for this agent. Choose a model in the agent's Providers settings."** (classified `NO_MODEL_CONFIGURED` → surfaced to the user). The explicit `"auto"` keyword path is unchanged.
- **Gateway**: stop auto-filling `result.defaultModel` via `getDefaultModel`; only an explicitly configured model is used. Removed the now-dead `getDefaultModel`.
- **Picker unchanged**: `getModelOptions` still lists the live models (powered by the #1393/#1395 env-key fix) so an operator can select one.

## Verification
- Unit: model-resolver no-model now throws (updated); error-handler classifies the new message; `getModelOptions` env-key coverage (x-api-key / AUTH_TOKEN→Bearer / empty picker). Both packages typecheck clean.
- **E2E**: a no-model agent surfaces the actionable error; a pinned-model agent replies `ok` normally.

## Paired follow-up (owletto)
The agent **create form** defaults to `modelSelection: { mode: "auto" }` (no model) — it should default/require a concrete model so new agents don't hit the actionable error on first run. Tracked as a separate owletto PR + pointer bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1396"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784483950&installation_id=136316292&pr_number=1396&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1396&signature=4bc41c04d68799868aac0c98973b2a272f5a8c475169389c5dc0ac0e248f37ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Removed automatic fallback to provider default models when no model is explicitly selected.
  * Updated error handling so missing model selection consistently reports **“No model selected”** instead of “No model configured”.

* **Improvements**
  * Model resolution now fails fast with guidance to choose a model in the **Providers** settings, preventing silent defaults.

* **Tests**
  * Updated model-selection and Claude OAuth model-option tests to match the new semantics and messaging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->