### PR TITLE
fix(gateway): worker poll rejects browser-session auth with 401 so the Owletto extension can self-heal

### DIFF
--- a/packages/server/src/__tests__/integration/mcp/auth.test.ts
+++ b/packages/server/src/__tests__/integration/mcp/auth.test.ts
@@ -1043,5 +1043,24 @@ describe('MCP Authentication', () => {
       `) as Array<{ organization_id: string | null }>;
       expect(rows[0]?.organization_id).toBe(org.id);
     });
+
+    // The Owletto extension's service-worker poll unavoidably carries the
+    // gateway's Better Auth session cookie — Chrome attaches it to
+    // host-permission fetches regardless of `credentials: "omit"`. When the
+    // extension's OAuth access token expires, the Bearer fails and auth falls
+    // back to that cookie: a real user session, but with no worker scopes.
+    // Worker endpoints must reject it with 401 (which the poller recovers from
+    // via tryRefreshToken), NOT the 403 it used to return and could not act on.
+    // Contrast: the device-token poll above (a scoped Bearer) returns 200.
+    it('rejects a browser session cookie on worker endpoints with 401', async () => {
+      const response = await post('/api/workers/poll', {
+        body: { worker_id: `sess-${Date.now()}`, capabilities: {} },
+        cookie: sessionCookie,
+      });
+
+      expect(response.status).toBe(401);
+      const body = await response.json();
+      expect(body.error).toBe('invalid_token');
+    });
   });
 });

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -715,6 +715,29 @@ app.use('/api/workers/*', async (c, next) => {
 
   return mcpAuth(c, async () => {
     if (c.var.mcpIsAuthenticated && c.var.user?.id) {
+      // A browser session is never a worker credential. The Owletto extension's
+      // service-worker poll runs from a page Chrome treats as having host
+      // permission, so Chrome attaches the gateway's Better Auth session cookie
+      // to the request regardless of `credentials: "omit"` (verified: omit does
+      // NOT suppress it for host-permission fetches). When the extension's
+      // OAuth access token expires, the Bearer fails and mcpAuth falls back to
+      // that cookie — authenticating the user but with no worker scopes. That
+      // used to return 403 below, which the poller can't recover from (only 401
+      // triggers tryRefreshToken). Returning 401 for any session-sourced auth
+      // makes the expired token surface as the refreshable 401 it actually is.
+      // Safe: real workers authenticate with a scoped PAT/OAuth token
+      // (authSource 'pat'/'oauth') or the trusted WORKER_API_TOKEN (handled
+      // above, never reaches here); a session has no worker scopes and would
+      // have been rejected anyway — this only changes 403 → 401 for it.
+      if (c.var.authSource === 'session') {
+        return c.json(
+          {
+            error: 'invalid_token',
+            error_description: 'Worker endpoints require a worker token, not a browser session',
+          },
+          401
+        );
+      }
       // User-scoped workers can only hit the endpoints needed to run a job
       // end-to-end. Auth-artifact / embeddings / repair-thread endpoints are
       // for server-side fleets and would leak across orgs without per-handler


### PR DESCRIPTION
## Problem

The Owletto Chrome extension recurringly showed *"Could not connect to your Owletto. Your session may have expired."* and required a manual re-pair — roughly every 24h.

Root cause, traced end-to-end against prod logs + DB:

- The extension's MV3 service-worker poll (`/api/workers/poll`) **unavoidably carries the gateway's Better Auth session cookie**. Chrome attaches cookies to extension fetches for host-permission origins **regardless of `credentials: "omit"`** — verified with an in-profile A/B (the poll carried a planted cookie under both `include` *and* `omit`).
- The extension's OAuth access token is capped at 24h. When it expires, the Bearer fails and gateway auth **falls back to the session cookie** (a longer-lived browser session). That session authenticates the user but has **no worker scopes**, so the worker middleware returned `403 "Worker token missing device_worker:run scope"`.
- The poller **only refreshes on 401** (`background.js`); a 403 it treats as a generic poll failure and neither refreshes nor re-pairs. So the expired token never surfaced as the refreshable 401 it actually was → permanent 403 loop → "session expired" until manual re-pair.

Prod evidence: the user's extension polled with an expired OAuth token + cookie → **403** every tick; a concurrent valid-token poll → **200**.

## Fix

In the `/api/workers/*` middleware, return **401** for any session-sourced auth (`authSource === 'session'`) instead of the old 403.

The expired token now surfaces as the **401** the poller already handles via `tryRefreshToken`; the refreshed Bearer is **preferred over the cookie** (auth tries Bearer first), so the next poll succeeds. Self-heals, no client change.

**Why a browser session was never a valid worker credential:** real workers authenticate with a scoped PAT/OAuth token (`authSource` `pat`/`oauth`) or the trusted `WORKER_API_TOKEN` (handled earlier, bypasses this branch). A session carries no worker scopes and was rejected anyway — this only changes **403 → 401** for it, which is what lets the client recover.

## Why `credentials: "omit"` (client-side) was rejected

First attempt was to drop the cookie in the extension. Proven a dead end: Chrome attaches host-permission cookies to MV3 SW fetches regardless of the `credentials` mode (A/B'd in one browser profile against prod). The owletto change was reverted; this PR is server-only.

## Testing

- New integration test (real Postgres 18 + pgvector, the actual Hono `app`): session cookie → `/api/workers/poll` → **401 `invalid_token`**; existing scoped-device-token poll → **200** (contrast).
- `auth.test.ts`: 37 passed, 2 skipped. Cookie-based `/mcp` and `/api/<org>/*` auth still 200/403 — no collateral.
- `tsc --noEmit` on `packages/server`: clean.
- No other worker test relies on cookie auth.

## Multi-replica

Per-request auth verdict, no shared state — correct under N replicas.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1402"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784562922&installation_id=136316292&pr_number=1402&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1402&signature=743776f0e6a1ef1eeacb12c40ea519fa80667188e7055f4ae660b02fe895998a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed worker API endpoints to properly reject browser session credentials with a `401 invalid_token` response instead of `403 forbidden`.

* **Tests**
  * Added integration tests to verify worker endpoint authentication behavior with session credentials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->