### PR TITLE
feat(landing): reposition hero subline to open-source infra framing

### DIFF
--- a/packages/landing/public/index.md
+++ b/packages/landing/public/index.md
@@ -1,6 +1,6 @@
 # Lobu
 
-> Build AI teammates that watch and act. Lobu connects your tools, keeps shared memory current, and gives agents safe ways to act.
+> Open-source infrastructure for multi-tenant AI agents: sandboxed execution, shared memory, and an SDK that pulls live company data and acts on your high-level goals.
 
 ## What Lobu does
 

--- a/packages/landing/src/components/LandingPage.tsx
+++ b/packages/landing/src/components/LandingPage.tsx
@@ -219,8 +219,9 @@ function Hero() {
           class="hero-rise hero-rise-2 mx-auto mt-5 max-w-[44rem] text-[17px] leading-[1.55]"
           style={{ color: "var(--color-page-text-muted)" }}
         >
-          Lobu connects your tools, keeps shared memory current, and gives
-          agents safe ways to act across chat, APIs, CLI, and MCP.
+          Open-source infrastructure for multi-tenant AI agents: sandboxed
+          execution, shared memory, and an SDK that pulls live company data and
+          acts on your high-level goals.
         </p>
         <div class="hero-rise hero-rise-3 mt-8 flex flex-wrap items-center justify-center gap-3">
           <button

--- a/packages/landing/src/layouts/BaseLayout.astro
+++ b/packages/landing/src/layouts/BaseLayout.astro
@@ -14,7 +14,7 @@ interface Props {
 
 const {
   title = "Lobu - AI teammates that watch and act",
-  description = "Build AI teammates that watch and act. Lobu connects your tools, keeps shared memory current, and gives agents safe ways to act.",
+  description = "Open-source infrastructure for multi-tenant AI agents: sandboxed execution, shared memory, and an SDK that pulls live company data and acts on your high-level goals.",
   ogType = "website",
   article,
   forceTheme,
@@ -89,7 +89,7 @@ const hasMarkdownTwin = existsSync(markdownFileURL);
       "name": "Lobu",
       "url": "https://lobu.ai",
       "logo": "https://lobu.ai/lobster-icon.svg",
-      "description": "Build AI teammates that watch and act. Lobu connects your tools, keeps shared memory current, and gives agents safe ways to act.",
+      "description": "Open-source infrastructure for multi-tenant AI agents: sandboxed execution, shared memory, and an SDK that pulls live company data and acts on your high-level goals.",
       "sameAs": [
         "https://github.com/lobu-ai/lobu",
         "https://x.com/bu7emba"


### PR DESCRIPTION
Repositions the hero subline (and OG/meta + JSON-LD + llms.txt mirror) from the generic "AI teammates that watch and act" framing to the locked GTM positioning: open-source agent infrastructure.

**After:** "Open-source infrastructure for multi-tenant AI agents: sandboxed execution, shared memory, and an SDK that pulls live company data and acts on your high-level goals."

Copy-only across 3 files (LandingPage hero subhead, BaseLayout meta description + JSON-LD description, public/index.md mirror). h1 + page title intentionally unchanged. No em dashes (landing rule). `bun run build` green (90 pages).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1403"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784562931&installation_id=136316292&pr_number=1403&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1403&signature=826d4b623dd56899c5d731d1486b874baad74ca77a3f5874049b024eaee6558a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->