### PR TITLE
refactor(agents): remove connected-clients UI from agents surface + drop dead workspace-agent columns

### DIFF
--- a/packages/core/src/agent-store.ts
+++ b/packages/core/src/agent-store.ts
@@ -89,8 +89,6 @@ export interface AgentMetadata {
   name: string;
   description?: string;
   owner: { platform: string; userId: string };
-  isWorkspaceAgent?: boolean;
-  workspaceId?: string;
   /**
    * Owning organization id. Optional in the type for back-compat with
    * in-memory stores that predate per-tenant scoping; populated by the

--- a/packages/server/src/__tests__/setup/test-fixtures.ts
+++ b/packages/server/src/__tests__/setup/test-fixtures.ts
@@ -175,7 +175,6 @@ export async function createTestAgent(options: {
       description,
       owner_platform,
       owner_user_id,
-      is_workspace_agent,
       created_at,
       updated_at
     ) VALUES (
@@ -185,7 +184,6 @@ export async function createTestAgent(options: {
       ${options.description ?? null},
       'lobu',
       ${ownerUserId},
-      false,
       NOW(),
       NOW()
     )

--- a/packages/server/src/auth/default-provisioning.ts
+++ b/packages/server/src/auth/default-provisioning.ts
@@ -285,12 +285,12 @@ export async function ensureDefaultAgent(
     await client`
       INSERT INTO agents (
         id, organization_id, name, identity_md,
-        owner_platform, owner_user_id, is_workspace_agent,
+        owner_platform, owner_user_id,
         installed_providers,
         created_at, updated_at
       ) VALUES (
         ${DEFAULT_AGENT_ID}, ${organizationId}, ${DEFAULT_AGENT_NAME}, ${DEFAULT_AGENT_IDENTITY},
-        'external', ${ownerUserId}, false,
+        'external', ${ownerUserId},
         ${client.json(systemProviders)},
         NOW(), NOW()
       )

--- a/packages/server/src/gateway/auth/agent-metadata-store.ts
+++ b/packages/server/src/gateway/auth/agent-metadata-store.ts
@@ -32,8 +32,6 @@ export class AgentMetadataStore {
     userId: string,
     options?: {
       description?: string;
-      isWorkspaceAgent?: boolean;
-      workspaceId?: string;
     }
   ): Promise<AgentMetadata> {
     const metadata: AgentMetadata = {
@@ -41,8 +39,6 @@ export class AgentMetadataStore {
       name,
       description: options?.description,
       owner: { platform, userId },
-      isWorkspaceAgent: options?.isWorkspaceAgent,
-      workspaceId: options?.workspaceId,
       createdAt: Date.now(),
     };
     await this.configStore.saveMetadata(agentId, metadata);

--- a/packages/server/src/gateway/routes/public/agents.ts
+++ b/packages/server/src/gateway/routes/public/agents.ts
@@ -184,7 +184,6 @@ export function createAgentRoutes(config: AgentRoutesConfig): Hono {
             agentId,
             name: metadata.name,
             description: metadata.description,
-            isWorkspaceAgent: metadata.isWorkspaceAgent,
             createdAt: metadata.createdAt,
             lastUsedAt: metadata.lastUsedAt,
             channelCount: bindings.length,

--- a/packages/server/src/lobu/stores/postgres-stores.ts
+++ b/packages/server/src/lobu/stores/postgres-stores.ts
@@ -79,8 +79,6 @@ function rowToMetadata(row: Record<string, any>): AgentMetadata {
 			platform: row.owner_platform ?? "lobu",
 			userId: row.owner_user_id ?? "",
 		},
-		isWorkspaceAgent: row.is_workspace_agent ?? undefined,
-		workspaceId: row.workspace_id ?? undefined,
 		organizationId: row.organization_id ?? undefined,
 		createdAt:
 			row.created_at instanceof Date
@@ -233,14 +231,12 @@ export function createPostgresAgentConfigStore(): AgentConfigStore {
 			const rows = orgId
 				? await sql`
             SELECT id, organization_id, name, description, owner_platform, owner_user_id,
-                   is_workspace_agent, workspace_id,
                    created_at, last_used_at
             FROM agents
             WHERE id = ${agentId} AND organization_id = ${orgId}
           `
 				: await sql`
             SELECT id, organization_id, name, description, owner_platform, owner_user_id,
-                   is_workspace_agent, workspace_id,
                    created_at, last_used_at
             FROM agents
             WHERE id = ${agentId}
@@ -259,11 +255,10 @@ export function createPostgresAgentConfigStore(): AgentConfigStore {
 			// a CONFLICT UPDATE so we can emit the right lifecycle event.
 			const rows = await sql`
         INSERT INTO agents (id, organization_id, name, description, owner_platform, owner_user_id,
-                            is_workspace_agent, workspace_id, created_at)
+                            created_at)
         VALUES (
           ${agentId}, ${orgId}, ${metadata.name}, ${metadata.description ?? null},
           ${metadata.owner.platform}, ${metadata.owner.userId},
-          ${metadata.isWorkspaceAgent ?? false}, ${metadata.workspaceId ?? null},
           ${metadata.createdAt ? new Date(metadata.createdAt) : now}
         )
         ON CONFLICT (organization_id, id) DO UPDATE SET
@@ -271,8 +266,6 @@ export function createPostgresAgentConfigStore(): AgentConfigStore {
           description = EXCLUDED.description,
           owner_platform = EXCLUDED.owner_platform,
           owner_user_id = EXCLUDED.owner_user_id,
-          is_workspace_agent = EXCLUDED.is_workspace_agent,
-          workspace_id = EXCLUDED.workspace_id,
           last_used_at = ${metadata.lastUsedAt ? new Date(metadata.lastUsedAt) : null},
           updated_at = ${now}
         RETURNING (xmax = 0) AS inserted
@@ -324,7 +317,6 @@ export function createPostgresAgentConfigStore(): AgentConfigStore {
 			const orgId = getOrgId();
 			const rows = await sql`
         SELECT id, organization_id, name, description, owner_platform, owner_user_id,
-               is_workspace_agent, workspace_id,
                created_at, last_used_at
         FROM agents
         WHERE organization_id = ${orgId}


### PR DESCRIPTION
Cleanup ahead of the web-app agent-builder work. Two related removals, no behavior change for live features.

## What changed

**Connected-clients UI removed from the agents surface** (owletto, paired PR lobu-ai/owletto#306):
- Deleted the standalone `/clients` route + detail page, the agent-workbench "Connect" tab, and the "Connected apps" sidebar rail.
- Kept `useConnectedClients` — the watchers tab still uses it to map client assignments. Removed the now-dead `useDisconnectMcpClient`, `client-detail`, `connected-clients`, and `use-workspace-clients` helpers; regenerated the route tree.

**Stopped referencing the dead `is_workspace_agent` / `workspace_id` columns** (agents table):
- Both were inert — always their default, read/written by no live code across server, core, agent-worker, cli, and the frontend. Superseded by the planned `organization.system_agent_id` pointer.
- Removed the `AgentMetadata` fields, the postgres-store SELECT/INSERT/UPSERT references, the provisioning INSERT, the agents API response field, and the test fixture.

## Expand/contract — the column DROP is deferred
This release only **stops referencing** the columns. The `DROP COLUMN` migration is intentionally **not** here: dropping in the same release would break old replicas (still running the previous code that SELECTs/INSERTs the columns) during a rolling deploy. The migration ships in a **follow-up PR** once this is deployed everywhere. (Caught in review.)

## Verification
- Strict tsc green: server, core, cli, agent-worker. Owletto `tsc -b && vite build` green. Route smoke test 35/35.
- **Live e2e** (booted gateway + embedded Postgres): the default agent provisioned via the modified INSERT path; manual upsert exercised both INSERT (`inserted=t`) and UPDATE (`inserted=f`) branches plus the trimmed `getMetadata` SELECT against the live schema.
- Browser: `/clients` no longer renders a clients page (route + nav mapping gone); agents view has no Connected-apps rail.
- (The deferred migration was separately squawk-clean + up/down/up round-trip verified; it lands in the follow-up PR.)

## Notes
- Pairs with owletto#306 (pointer bumped to its branch HEAD, which also includes owletto main's #304/#305 + image updates from the rebase). After owletto#306 merges, re-bump the submodule pointer to the squash HEAD.
- Follow-up PRs: (1) the `DROP COLUMN` migration; (2) the `organization.system_agent_id` pointer + builder agent.
- Minor: a stale `/clients` bookmark now lands on the default shell rather than a clean 404.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **API Changes**
  * Agent API responses no longer include workspace-level designation fields.
  
* **Chores**
  * Removed workspace-related metadata from agent configuration and storage systems across core, server, and provisioning layers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->