### PR TITLE
fix(orchestrator): make the systemd worker sandbox actually work, degrade safely where it can't

### DIFF
--- a/packages/server/src/__tests__/integration/watchers/automation-contract.test.ts
+++ b/packages/server/src/__tests__/integration/watchers/automation-contract.test.ts
@@ -1080,12 +1080,48 @@ describe('watcher automation contract', () => {
       };
     }
 
-    it('fails the run immediately when the reply produced no window (fail-closed guard)', async () => {
+    it('re-dispatches for a finalize nudge when the reply produced no window (first miss)', async () => {
+      // Soft miss: the agent replied but skipped complete_window. Instead of
+      // failing closed on the first miss, the run is re-dispatched (pending)
+      // for one more bounded attempt — finalize_nudge_count records it.
       const messageId = randomUUID();
       const { sql, runId } = await makeRunningWatcherRun(messageId);
 
       await makeHeadlessConsumer().handleThreadResponse({
         id: 'job-headless-1',
+        data: terminalPayload(messageId, runId),
+      } as never);
+
+      const [run] = await sql`
+        SELECT status, error_message, approved_input FROM runs WHERE id = ${runId}
+      `;
+      expect(String(run.status)).toBe('pending');
+      expect(run.error_message).toBeNull();
+      expect(
+        Number(
+          (run.approved_input as { finalize_nudge_count?: unknown })
+            .finalize_nudge_count
+        )
+      ).toBe(1);
+    });
+
+    it('fails the run when the finalize-nudge budget is exhausted (fail-closed guard)', async () => {
+      const messageId = randomUUID();
+      const { sql, runId } = await makeRunningWatcherRun(messageId);
+      // Pre-exhaust the budget so the miss is terminal regardless of the
+      // configured nudge count.
+      await sql`
+        UPDATE runs
+        SET approved_input = jsonb_set(
+          COALESCE(approved_input, '{}'::jsonb),
+          '{finalize_nudge_count}',
+          '999'::jsonb
+        )
+        WHERE id = ${runId}
+      `;
+
+      await makeHeadlessConsumer().handleThreadResponse({
+        id: 'job-headless-1b',
         data: terminalPayload(messageId, runId),
       } as never);
 

--- a/packages/server/src/__tests__/integration/watchers/automation-contract.test.ts
+++ b/packages/server/src/__tests__/integration/watchers/automation-contract.test.ts
@@ -1130,6 +1130,30 @@ describe('watcher automation contract', () => {
       expect(String(run.error_message)).toContain('complete_window');
     });
 
+    it('respects a per-watcher finalize_nudges=0 override (fails immediately, no re-dispatch)', async () => {
+      // The per-watcher budget (execution_config.finalize_nudges) overrides the
+      // global default. 0 = no nudge → the first miss fails immediately, the
+      // opposite of the default behavior, proving the override is read.
+      const messageId = randomUUID();
+      const { sql, runId, watcherId } = await makeRunningWatcherRun(messageId);
+      await sql`
+        UPDATE watchers
+        SET execution_config = '{"finalize_nudges": 0}'::jsonb
+        WHERE id = ${watcherId}
+      `;
+
+      await makeHeadlessConsumer().handleThreadResponse({
+        id: 'job-headless-nudge0',
+        data: terminalPayload(messageId, runId),
+      } as never);
+
+      const [run] = await sql`
+        SELECT status, error_message FROM runs WHERE id = ${runId}
+      `;
+      expect(String(run.status)).toBe('failed');
+      expect(String(run.error_message)).toContain('complete_window');
+    });
+
     it('completes the run immediately when a window exists', async () => {
       const messageId = randomUUID();
       const { sql, runId, watcherId, windowStart, windowEnd } =

--- a/packages/server/src/gateway/__tests__/agent-transcript-snapshot.test.ts
+++ b/packages/server/src/gateway/__tests__/agent-transcript-snapshot.test.ts
@@ -951,15 +951,17 @@ describe("agent_transcript_snapshot — codex P1/P2 regressions", () => {
 
     // Pre-fix: `const commonEnvVars = await this.generateEnvironmentVariables`
     // (declared inline as a const) followed by the spawn() in the same
-    // top-level block with no try wrap. Post-fix: `let child: ChildProcess`
-    // declared outside a try, then assigned inside try, then catch that
-    // releases convLock and re-throws.
-    expect(spawnBody).toMatch(/let child: ChildProcess;/);
+    // top-level block with no try wrap. Post-refactor: spawn-prep (env build +
+    // nix decision) runs inside a try; the spawn + handler wiring is delegated
+    // to `spawnWorkerChild`. The lock is released via the idempotent
+    // `releaseLockOnce` closure, defined BEFORE the try so both the catch and
+    // the child handlers share one release.
     expect(spawnBody).toMatch(/let commonEnvVars: Record<string, string>;/);
+    expect(spawnBody).toMatch(/const releaseLockOnce = async/);
 
-    // The catch block must release the lock and re-throw.
+    // The catch block must release the lock (idempotent closure) and re-throw.
     expect(spawnBody).toMatch(
-      /catch \(err\) \{[\s\S]*?convLock\.release\(\);[\s\S]*?throw err;/
+      /catch \(err\) \{[\s\S]*?releaseLockOnce\(\);[\s\S]*?throw err;/
     );
   });
 

--- a/packages/server/src/gateway/__tests__/embedded-deployment.test.ts
+++ b/packages/server/src/gateway/__tests__/embedded-deployment.test.ts
@@ -494,4 +494,48 @@ describe("EmbeddedDeploymentManager", () => {
       expect(list[0].isVeryOld).toBe(false);
     });
   });
+
+  // =========================================================================
+  // Worker sandbox fallback + opt-in fail-closed gate
+  // =========================================================================
+  // beforeEach sets LOBU_DISABLE_SYSTEMD_RUN=1, so locateSystemdRun() returns
+  // null and the worker would run UNWRAPPED. These assert the posture: by
+  // default the worker still runs (matching the prod container, which has no
+  // systemd-run); only LOBU_REQUIRE_WORKER_SANDBOX=1 makes it fail closed.
+  describe("worker sandbox fallback (systemd unavailable)", () => {
+    const saved = { require: process.env.LOBU_REQUIRE_WORKER_SANDBOX };
+    afterEach(() => {
+      if (saved.require === undefined)
+        delete process.env.LOBU_REQUIRE_WORKER_SANDBOX;
+      else process.env.LOBU_REQUIRE_WORKER_SANDBOX = saved.require;
+    });
+
+    test("default (no requirement) spawns the worker unwrapped", async () => {
+      delete process.env.LOBU_REQUIRE_WORKER_SANDBOX;
+      await manager.ensureDeployment(
+        "worker-1",
+        "user-1",
+        "user-1",
+        createTestMessagePayload()
+      );
+      expect(mockChildProcesses).toHaveLength(1);
+      // Unwrapped → the worker binary itself, not a systemd-run wrapper.
+      expect(mockSpawn.mock.calls.at(-1)?.[0]).toBe(process.execPath);
+    });
+
+    test("LOBU_REQUIRE_WORKER_SANDBOX=1 without systemd refuses to spawn (fail closed)", async () => {
+      process.env.LOBU_REQUIRE_WORKER_SANDBOX = "1";
+      await expect(
+        manager.ensureDeployment(
+          "worker-1",
+          "user-1",
+          "user-1",
+          createTestMessagePayload()
+        )
+      ).rejects.toThrow(OrchestratorError);
+      // No un-sandboxed worker ever ran.
+      expect(mockChildProcesses).toHaveLength(0);
+      expect(await manager.listDeployments()).toHaveLength(0);
+    });
+  });
 });

--- a/packages/server/src/gateway/__tests__/orchestration-harden.test.ts
+++ b/packages/server/src/gateway/__tests__/orchestration-harden.test.ts
@@ -81,7 +81,10 @@ mock.module("node:child_process", () => ({
 // ── Import classes after mock ────────────────────────────────────────────────
 
 import type { MessagePayload } from "@lobu/core";
-import { EmbeddedDeploymentManager } from "../orchestration/impl/embedded-deployment.js";
+import {
+  EmbeddedDeploymentManager,
+  __resetCapabilityProbesForTests,
+} from "../orchestration/impl/embedded-deployment.js";
 import {
   buildCanonicalConversationKey,
   generateDeploymentName,
@@ -262,6 +265,108 @@ describe("spawn failure handling", () => {
       mkdirSpy.mockRestore();
     }
   });
+});
+
+// ============================================================================
+// 2b. SYSTEMD WORKER SANDBOX — wrap + self-heal (Linux only)
+// ============================================================================
+// The systemd wrap only engages on Linux (locateSystemdRun() short-circuits on
+// other platforms), and here execFileSync is mocked to succeed so the probe
+// passes. Guarded to Linux so the assertions are deterministic on CI while the
+// suite still runs cross-platform.
+
+describe("systemd worker sandbox — wrap + self-heal", () => {
+  const onLinux = process.platform === "linux";
+
+  afterEach(() => {
+    // Demote the probe cache so a forced "systemd available" state never bleeds
+    // into other suites (which expect the LOBU_DISABLE_SYSTEMD_RUN=1 default).
+    __resetCapabilityProbesForTests();
+  });
+
+  test.skipIf(!onLinux)(
+    "available systemd wraps the worker in a scope with only scope-compatible props + forwards the bus env",
+    async () => {
+      __resetCapabilityProbesForTests();
+      delete process.env.LOBU_DISABLE_SYSTEMD_RUN; // let the probe run (mock succeeds)
+      const savedXdg = process.env.XDG_RUNTIME_DIR;
+      process.env.XDG_RUNTIME_DIR = "/run/user/test-xdg";
+      const mgr = makeManager();
+      const mkdirSpy = spyOn(fs, "mkdirSync").mockReturnValue(undefined);
+      try {
+        await mgr.ensureDeployment(
+          "worker-1",
+          "user-1",
+          "user-1",
+          makePayload()
+        );
+        const call = mockSpawn.mock.calls.at(-1) as [
+          string,
+          string[],
+          { env?: Record<string, string> },
+        ];
+        expect(call[0]).toBe("systemd-run");
+        expect(call[1]).toContain("--scope");
+        // cgroup + network props that a scope actually honors.
+        expect(call[1]).toContain("IPAddressDeny=any");
+        expect(call[1].some((a) => a.startsWith("MemoryMax="))).toBe(true);
+        // Exec-context props a --scope rejects ("Unknown assignment") must be
+        // gone, or the whole scope fails and the worker dies.
+        expect(call[1]).not.toContain("NoNewPrivileges=yes");
+        expect(call[1].some((a) => a.startsWith("ReadWritePaths="))).toBe(
+          false
+        );
+        expect(
+          call[1].some((a) => a.startsWith("RestrictAddressFamilies="))
+        ).toBe(false);
+        // The bus coordinates are forwarded so `systemd-run --user` can reach
+        // the user manager from the otherwise-sanitized worker env.
+        expect(call[2]?.env?.XDG_RUNTIME_DIR).toBe("/run/user/test-xdg");
+      } finally {
+        mkdirSpy.mockRestore();
+        if (savedXdg === undefined) delete process.env.XDG_RUNTIME_DIR;
+        else process.env.XDG_RUNTIME_DIR = savedXdg;
+      }
+    }
+  );
+
+  test.skipIf(!onLinux)(
+    "a --scope that dies instantly with a bus error self-heals to an unwrapped respawn",
+    async () => {
+      __resetCapabilityProbesForTests();
+      delete process.env.LOBU_DISABLE_SYSTEMD_RUN;
+      const mgr = makeManager();
+      const mkdirSpy = spyOn(fs, "mkdirSync").mockReturnValue(undefined);
+      try {
+        await mgr.ensureDeployment(
+          "worker-1",
+          "user-1",
+          "user-1",
+          makePayload()
+        );
+        // First spawn is the systemd-run wrapper.
+        expect(mockSpawn.mock.calls.at(-1)?.[0]).toBe("systemd-run");
+        const wrapper = mockChildProcesses.at(-1) as MockChildProcess;
+
+        // The scope can't reach the user bus and dies code 1 immediately —
+        // before the worker payload ever runs.
+        wrapper.stderr.emit(
+          "data",
+          Buffer.from("Failed to connect to bus: No medium found\n")
+        );
+        wrapper.emit("exit", 1, null);
+        await new Promise((r) => setTimeout(r, 0));
+
+        // Self-healed: a second, UNWRAPPED spawn replaced the dead wrapper,
+        // and the worker is live in the map rather than failed out.
+        expect(mockSpawn.mock.calls).toHaveLength(2);
+        expect(mockSpawn.mock.calls.at(-1)?.[0]).toBe(process.execPath);
+        expect(await mgr.listDeployments()).toHaveLength(1);
+      } finally {
+        mkdirSpy.mockRestore();
+      }
+    }
+  );
 });
 
 // ============================================================================

--- a/packages/server/src/gateway/orchestration/impl/embedded-deployment.ts
+++ b/packages/server/src/gateway/orchestration/impl/embedded-deployment.ts
@@ -827,10 +827,9 @@ export class EmbeddedDeploymentManager extends BaseDeploymentManager {
       }
 
       // Wrap in a hardened systemd-run scope when available, spawn the worker,
-      // and wire its lifecycle handlers. Throws (re-queueable) if the host
-      // cannot sandbox AND this is a cloud deployment without an explicit
-      // opt-in. On success, ownership of `convLock` transfers into the child's
-      // exit handler.
+      // and wire its lifecycle handlers. Throws (re-queueable) only if the host
+      // cannot sandbox AND LOBU_REQUIRE_WORKER_SANDBOX=1. On success, ownership
+      // of `convLock` transfers into the child's exit handler.
       this.spawnWorkerChild({
         deploymentName,
         workspaceDir,

--- a/packages/server/src/gateway/orchestration/impl/embedded-deployment.ts
+++ b/packages/server/src/gateway/orchestration/impl/embedded-deployment.ts
@@ -26,6 +26,53 @@ import { failTurnsForDeployment } from "../turn-liveness.js";
 const WORKER_DIED_MESSAGE =
   "The worker handling your request stopped unexpectedly before it could reply. Please retry in a moment.";
 
+/**
+ * Surfaced only when the operator REQUIRES the systemd sandbox
+ * (LOBU_REQUIRE_WORKER_SANDBOX=1) but it is unavailable on the host. By default
+ * workers run unwrapped when no systemd user manager exists — that is exactly
+ * how the prod container (which ships no `systemd-run`) runs today, with the
+ * egress proxy as the network boundary — so failing closed is opt-in, never
+ * the default (defaulting to fail-closed would take prod down instantly).
+ */
+const WORKER_SANDBOX_REQUIRED_MESSAGE =
+  "LOBU_REQUIRE_WORKER_SANDBOX=1 but the systemd worker sandbox is unavailable on this host " +
+  "(no usable `systemd-run --user` manager). Refusing to run an un-sandboxed worker. Provide a " +
+  "user-level systemd manager, or unset LOBU_REQUIRE_WORKER_SANDBOX to allow unwrapped workers " +
+  "(the egress proxy still constrains network access).";
+
+/**
+ * A `systemd-run --scope` that can't reach the user bus / start the scope
+ * fails almost instantly — before the worker payload runs. We only treat an
+ * exit as a systemd setup failure (vs. a genuine fast worker crash) when it
+ * lands inside this window AND matches SYSTEMD_SETUP_ERROR_RE, so a real
+ * worker bug is never masked as "fall back to plain spawn".
+ */
+const SYSTEMD_FAST_FAIL_MS = 2_000;
+
+/**
+ * stderr signatures emitted by `systemd-run` itself (not the worker) when the
+ * user manager / dbus / scope setup is the problem (bus unreachable, or a
+ * property the host's systemd rejects on a scope). Kept tight on purpose so a
+ * genuine fast worker crash is never misread as a systemd failure.
+ */
+const SYSTEMD_SETUP_ERROR_RE =
+  /Failed to connect to bus|No medium found|Failed to (start|create) (transient )?(scope|unit)|Unknown assignment|Interactive authentication required|Access denied|Transport endpoint is not connected/i;
+
+/**
+ * Whether the operator REQUIRES the systemd worker sandbox. Default false:
+ * workers run unwrapped when no usable `systemd-run --user` manager exists
+ * (matching the prod container, which ships no systemd-run; the egress proxy is
+ * the network boundary). A hardened deployment that has provisioned a user
+ * systemd manager can set LOBU_REQUIRE_WORKER_SANDBOX=1 to fail closed instead
+ * of silently running unwrapped. Re-read each call (cold path).
+ */
+function workerSandboxRequired(): boolean {
+  return process.env.LOBU_REQUIRE_WORKER_SANDBOX === "1";
+}
+
+/** One-shot guard so the "running unsandboxed" notice logs once per process. */
+let warnedUnsandboxedWorkers = false;
+
 const logger = createLogger("orchestrator");
 
 // The SIGTERM→SIGKILL grace window lives in config/intervals.ts
@@ -77,22 +124,26 @@ function locateSystemdRun(): string | null {
     return cachedSystemdRun;
   }
   try {
-    // Probe by dispatching a real transient unit: `--version` only prints the
-    // package version and does not exercise dbus. Some Linux hosts ship the
-    // binary with no user manager attached; we have to exercise the
-    // user-bus path that the worker spawn will later use, or workers fail
-    // at first request instead of falling back to plain spawn here.
-    //
-    //   --no-block  → return as soon as the request is queued (no waiting on
-    //                 the dispatched command); still requires a reachable bus
-    //   --collect   → auto-remove the transient unit when it exits, so the
-    //                 probe leaves no residue in the user manager
-    //   timeout     → guard against a hung dbus connection (rare, but cheap)
-    execFileSync(
-      "systemd-run",
-      ["--user", "--quiet", "--collect", "--no-block", "/bin/true"],
-      { stdio: "ignore", timeout: 3_000 }
-    );
+    // Probe the EXACT path the worker spawn uses: a `--scope` unit with the
+    // same `-p` props, running `/bin/true`. The old probe was a `--no-block`
+    // transient *service* with no props — it could succeed while the real
+    // `--scope` spawn fails, because a scope rejects properties a service
+    // accepts (strict systemd answers "Unknown assignment" and the whole scope
+    // dies). Matching the real argv here means a host whose systemd refuses one
+    // of these props is detected now and degrades to a plain spawn, instead of
+    // killing every worker at first request. Bus reachability also matches: the
+    // probe inherits the gateway's process.env (incl. XDG_RUNTIME_DIR), the
+    // same coordinates the wrapped spawn forwards. `--scope` runs synchronously,
+    // so this returns as soon as `/bin/true` exits.
+    const probeArgs = [
+      ...buildSystemdRunArgs({ unitName: makeUnitName("probe") }),
+      "--",
+      "/bin/true",
+    ];
+    execFileSync("systemd-run", probeArgs, {
+      stdio: "ignore",
+      timeout: 3_000,
+    });
     cachedSystemdRun = "systemd-run";
   } catch {
     cachedSystemdRun = null;
@@ -130,33 +181,40 @@ function locateNixShell(): string | null {
 }
 
 /**
- * Build the systemd-run argv prefix for a hardened transient scope. Defaults
- * are tuned for a single Lobu worker; operators can override via
- * LOBU_WORKER_MEMORY_MAX / LOBU_WORKER_CPU_QUOTA / LOBU_WORKER_TASKS_MAX.
+ * Test-only: clear the memoized systemd/nix capability probes so a test can
+ * exercise a different host capability (e.g. force a re-probe after toggling
+ * LOBU_DISABLE_SYSTEMD_RUN). Not used by production code paths.
  */
-function buildSystemdRunArgs(opts: {
-  unitName: string;
-  workspaceDir: string;
-}): string[] {
+export function __resetCapabilityProbesForTests(): void {
+  cachedSystemdRun = undefined;
+  cachedNixShell = undefined;
+}
+
+/**
+ * Build the systemd-run argv prefix for a transient worker scope. Defaults are
+ * tuned for a single Lobu worker; operators can override via
+ * LOBU_WORKER_MEMORY_MAX / LOBU_WORKER_CPU_QUOTA / LOBU_WORKER_TASKS_MAX.
+ *
+ * ONLY cgroup/network properties are emitted. A `--scope` adopts a process the
+ * caller forked, so systemd never execs it and CANNOT apply exec-context
+ * hardening — NoNewPrivileges, PrivateTmp, ProtectSystem/Home, ReadWritePaths,
+ * LimitNOFILE, CapabilityBoundingSet, RestrictAddressFamilies. Strict systemd
+ * (observed on 255) rejects each with "Unknown assignment" and the whole scope
+ * fails (the worker dies before it starts). Those would require a `--service`,
+ * which would detach the worker from the gateway's process tree and break
+ * stdout/stderr piping + group-signal teardown. The cgroup limits (Memory/CPU/
+ * Tasks) and the network boundary (IPAddressDeny) DO apply to scopes; network
+ * egress is additionally constrained by the worker HTTP proxy allowlist.
+ */
+function buildSystemdRunArgs(opts: { unitName: string }): string[] {
   const memMax = process.env.LOBU_WORKER_MEMORY_MAX || "512M";
   const cpuQuota = process.env.LOBU_WORKER_CPU_QUOTA || "200%";
   const tasksMax = process.env.LOBU_WORKER_TASKS_MAX || "64";
-  const fileMax = process.env.LOBU_WORKER_LIMIT_NOFILE || "1024";
   return [
     "--user",
     "--scope",
     "--quiet",
     `--unit=${opts.unitName}`,
-    "-p",
-    "NoNewPrivileges=yes",
-    "-p",
-    "PrivateTmp=yes",
-    "-p",
-    "ProtectSystem=strict",
-    "-p",
-    "ProtectHome=yes",
-    "-p",
-    `ReadWritePaths=${opts.workspaceDir}`,
     "-p",
     `MemoryMax=${memMax}`,
     "-p",
@@ -164,17 +222,11 @@ function buildSystemdRunArgs(opts: {
     "-p",
     `TasksMax=${tasksMax}`,
     "-p",
-    `LimitNOFILE=${fileMax}`,
-    "-p",
     "IPAddressDeny=any",
     "-p",
     "IPAddressAllow=127.0.0.1",
     "-p",
     "IPAddressAllow=::1",
-    "-p",
-    "CapabilityBoundingSet=",
-    "-p",
-    "RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6",
   ];
 }
 
@@ -683,14 +735,24 @@ export class EmbeddedDeploymentManager extends BaseDeploymentManager {
       }
     }
 
-    // Ownership of `convLock` transfers from this local scope to the
-    // child's exit handler closure ONLY after `spawn()` returns and the
-    // exit handler is wired. Until then, any throw in the spawn-prep
-    // block must release the lock (and the underlying reserved pg
-    // connection) to avoid leaking a per-conversation lock until the
-    // gateway recycles. Codex P1#2 on PR #865.
-    let child: ChildProcess;
+    // The conversation lock is held for the worker subprocess lifetime and
+    // released in the child's exit handler (wired in spawnWorkerChild). Until a
+    // child exists, any throw in the spawn-prep block must release it (and the
+    // underlying reserved pg connection) to avoid leaking a per-conversation
+    // lock until the gateway recycles. Codex P1#2 on PR #865. Defined before
+    // the try so the catch and the spawn handlers share one idempotent release.
+    let lockReleased = false;
+    const releaseLockOnce = async (): Promise<void> => {
+      if (lockReleased) return;
+      lockReleased = true;
+      if (convLock) {
+        await convLock.release();
+      }
+    };
+
     let commonEnvVars: Record<string, string>;
+    let baseCommand: string;
+    let baseArgs: string[];
     try {
       commonEnvVars = await this.generateEnvironmentVariables(
         username,
@@ -723,9 +785,6 @@ export class EmbeddedDeploymentManager extends BaseDeploymentManager {
       const workerEntryPoint = this.getWorkerEntryPoint();
       const workerInvocation = buildWorkerInvocation(workerEntryPoint);
 
-      let command: string;
-      let spawnArgs: string[];
-
       // ALWAYS validate declared nix package names, even when we end up falling
       // back to a plain spawn below. `nix-shell -p <arg>` evaluates each <arg>
       // as a Nix *expression*, so a bare string like `pkgs.fetchurl;
@@ -746,8 +805,8 @@ export class EmbeddedDeploymentManager extends BaseDeploymentManager {
         // Wrap in nix-shell so nix binaries are on PATH. `-E` takes a single
         // expression that resolves to the build inputs; `pkgs` is bound to the
         // nixpkgs set via a `let` and every ref was validated above.
-        command = nixShell;
-        spawnArgs = [
+        baseCommand = nixShell;
+        baseArgs = [
           "-E",
           `let pkgs = import <nixpkgs> {}; in pkgs.mkShell { buildInputs = [ ${packageRefs.join(" ")} ]; }`,
           "--run",
@@ -762,76 +821,172 @@ export class EmbeddedDeploymentManager extends BaseDeploymentManager {
             `nix-shell not available — spawning worker ${deploymentName} WITHOUT nix packages [${nixPackages.join(", ")}]. Declared native deps are unavailable unless baked into the runtime image; set LOBU_DISABLE_NIX_SHELL=1 to silence this probe.`
           );
         }
-        command = workerInvocation.command;
-        spawnArgs = workerInvocation.args;
+        baseCommand = workerInvocation.command;
+        baseArgs = workerInvocation.args;
       }
 
-      // On Linux production hosts, wrap the worker in a transient systemd
-      // user scope: cgroup limits + IPAddressDeny + capability drops. Falls
-      // back transparently on macOS / Linux hosts without user systemd.
-      const systemdRun = locateSystemdRun();
-      if (systemdRun) {
-        const unitName = makeUnitName(deploymentName);
-        const innerCommand = command;
-        const innerArgs = spawnArgs;
-        command = systemdRun;
-        spawnArgs = [
-          ...buildSystemdRunArgs({ unitName, workspaceDir }),
-          "--",
-          innerCommand,
-          ...innerArgs,
-        ];
-        logger.info(
-          `Spawning embedded worker ${deploymentName} under systemd-run scope ${unitName}`
-        );
-      }
-
-      child = spawn(command, spawnArgs, {
-        // Workers must not inherit gateway-only secrets (DATABASE_URL, OAuth
-        // secrets, etc.). Everything a worker needs is assembled explicitly in
-        // assembleBaseEnv, with optional operator-provided values forwarded only
-        // via WORKER_ENV_*. SENTRY_DSN (+ ENVIRONMENT/SENTRY_RELEASE/APP_GIT_SHA)
-        // IS forwarded there now so the worker can report provider/model
-        // failures to Sentry Issues — it reaches Sentry via the gateway proxy
-        // (the Sentry host is added to the proxy allowlist), not directly, so
-        // the Linux IPAddressDeny scope doesn't drop the capture POST.
-        env: commonEnvVars,
-        cwd: workspaceDir,
-        stdio: ["ignore", "pipe", "pipe"],
-        // Run the worker in its OWN process group (child.pid == pgid). The
-        // direct child is usually a wrapper — `systemd-run --scope` on Linux,
-        // `nix-shell --run` for native-dep connectors — so a plain
-        // `child.kill()` signals only the wrapper and reparents the real worker
-        // to init (the orphan `make clean-workers` exists to reap). With a
-        // dedicated group we can signal the wrapper AND the worker together via
-        // the negative pid in killWorker(). See signalWorkerGroup().
-        detached: true,
+      // Wrap in a hardened systemd-run scope when available, spawn the worker,
+      // and wire its lifecycle handlers. Throws (re-queueable) if the host
+      // cannot sandbox AND this is a cloud deployment without an explicit
+      // opt-in. On success, ownership of `convLock` transfers into the child's
+      // exit handler.
+      this.spawnWorkerChild({
+        deploymentName,
+        workspaceDir,
+        commonEnvVars,
+        baseCommand,
+        baseArgs,
+        allowSystemd: true,
+        convLock,
+        releaseLockOnce,
+        isRetry: false,
       });
     } catch (err) {
-      // Pre-spawn throw (generateEnvironmentVariables, nix package
-      // validation, getWorkerEntryPoint, synchronous spawn() failure).
-      // No child process exists, so no exit handler will fire to release
+      // Pre-spawn throw (generateEnvironmentVariables, nix package validation,
+      // getWorkerEntryPoint, the cloud sandbox gate, or a synchronous spawn()
+      // failure). No child exists yet, so no exit handler will fire to release
       // the lock — release it here before re-throwing.
-      if (convLock) {
-        void convLock.release();
-      }
+      await releaseLockOnce();
       throw err;
     }
+  }
 
-    // Idempotent lock release. Captured by both the error and exit
-    // handlers below; killWorker no longer touches the lock directly so
-    // the lock survives until the child actually exits (codex P1#3 on
-    // PR #865 — the prior killWorker released BEFORE SIGTERM, letting a
-    // sibling pod claim the conversation while the dying worker was
-    // still flushing its snapshot).
-    let lockReleased = false;
-    const releaseLockOnce = async (): Promise<void> => {
-      if (lockReleased) return;
-      lockReleased = true;
-      if (convLock) {
-        await convLock.release();
+  /**
+   * Wrap the worker command in a hardened `systemd-run --user --scope` (cgroup
+   * limits + IPAddressDeny=any + capability drops) when available, spawn it,
+   * and wire stdout/stderr/error/exit handlers + the worker-map entry.
+   *
+   * Graceful degradation: on a host with no usable systemd user manager the
+   * worker runs unwrapped (self-host / dev) — UNLESS LOBU_CLOUD_MODE is set
+   * without LOBU_ALLOW_UNSANDBOXED_WORKERS=1, where it throws a re-queueable
+   * error rather than silently drop the kernel sandbox (the egress proxy alone
+   * is not a kernel boundary).
+   *
+   * Self-heal: locateSystemdRun() is a point-in-time probe. If the user bus /
+   * manager disappears after boot, the `--scope` wrapper exits ~instantly with
+   * a bus/setup error BEFORE the worker runs. We detect that exact signature,
+   * demote the process-wide systemd cache, and transparently re-spawn the
+   * worker unwrapped (re-applying the cloud gate) — reusing the still-held
+   * conversation lock so no sibling pod can claim the turn mid-swap.
+   */
+  private spawnWorkerChild(params: {
+    deploymentName: string;
+    workspaceDir: string;
+    commonEnvVars: Record<string, string>;
+    baseCommand: string;
+    baseArgs: string[];
+    allowSystemd: boolean;
+    convLock: { release: () => Promise<void> } | null;
+    releaseLockOnce: () => Promise<void>;
+    isRetry: boolean;
+  }): void {
+    const {
+      deploymentName,
+      workspaceDir,
+      commonEnvVars,
+      baseCommand,
+      baseArgs,
+      convLock,
+      releaseLockOnce,
+    } = params;
+
+    let command = baseCommand;
+    let spawnArgs = baseArgs;
+    let systemdWrapped = false;
+
+    // On Linux hosts with a usable systemd user manager, wrap the worker in a
+    // transient scope (cgroup limits + IPAddressDeny). Degrades to a plain
+    // spawn on macOS / hosts without one (e.g. the prod container, which ships
+    // no systemd-run).
+    const systemdRun = params.allowSystemd ? locateSystemdRun() : null;
+    if (systemdRun) {
+      const unitName = makeUnitName(deploymentName);
+      command = systemdRun;
+      spawnArgs = [
+        ...buildSystemdRunArgs({ unitName }),
+        "--",
+        baseCommand,
+        ...baseArgs,
+      ];
+      systemdWrapped = true;
+      // `systemd-run --user` reaches the caller's user bus via these two vars.
+      // The worker spawn env is otherwise sanitized (no gateway env carried
+      // over), so without forwarding them the --user scope fails with "Failed
+      // to connect to bus: No medium found" even though the gateway process
+      // itself can reach the bus. Forwarded only for the wrapped spawn; benign
+      // to the worker running inside the scope.
+      for (const key of [
+        "XDG_RUNTIME_DIR",
+        "DBUS_SESSION_BUS_ADDRESS",
+      ] as const) {
+        const value = process.env[key];
+        if (value) commonEnvVars[key] = value;
       }
-    };
+      logger.info(
+        `Spawning embedded worker ${deploymentName} under systemd-run scope ${unitName}`
+      );
+    } else if (workerSandboxRequired()) {
+      // Operator requires the sandbox (LOBU_REQUIRE_WORKER_SANDBOX=1) but it is
+      // unavailable: fail closed rather than silently run unwrapped.
+      if (params.isRetry) {
+        // Reached from the async exit handler's self-heal — can't throw to a
+        // caller, so fail the in-flight turn(s) with the clear message and
+        // release the lock we were holding across the swap.
+        void releaseLockOnce();
+        failTurnsForDeployment(
+          deploymentName,
+          WORKER_SANDBOX_REQUIRED_MESSAGE
+        ).catch((failErr) => {
+          logger.error(
+            `Failed to fail in-flight turns after refusing un-sandboxed worker ${deploymentName}: ${failErr instanceof Error ? failErr.message : String(failErr)}`
+          );
+        });
+        return;
+      }
+      throw new OrchestratorError(
+        ErrorCode.DEPLOYMENT_CREATE_FAILED,
+        WORKER_SANDBOX_REQUIRED_MESSAGE
+      );
+    } else if (
+      params.allowSystemd &&
+      process.platform === "linux" &&
+      process.env.LOBU_DISABLE_SYSTEMD_RUN !== "1" &&
+      !warnedUnsandboxedWorkers
+    ) {
+      // On Linux without an explicit opt-out, surface ONCE that workers run
+      // without the cgroup/IPAddressDeny sandbox (network egress is still
+      // constrained by the proxy allowlist). Silent on macOS / when explicitly
+      // disabled, where running unwrapped is the normal, intended path.
+      warnedUnsandboxedWorkers = true;
+      logger.warn(
+        "systemd worker sandbox unavailable — workers run WITHOUT cgroup limits / IPAddressDeny on this host. Network egress is still constrained by the proxy allowlist. (Logged once; set LOBU_DISABLE_SYSTEMD_RUN=1 to acknowledge, or LOBU_REQUIRE_WORKER_SANDBOX=1 to fail closed instead.)"
+      );
+    }
+
+    const spawnStart = Date.now();
+    let recentStderr = "";
+
+    const child = spawn(command, spawnArgs, {
+      // Workers must not inherit gateway-only secrets (DATABASE_URL, OAuth
+      // secrets, etc.). Everything a worker needs is assembled explicitly in
+      // assembleBaseEnv, with optional operator-provided values forwarded only
+      // via WORKER_ENV_*. SENTRY_DSN (+ ENVIRONMENT/SENTRY_RELEASE/APP_GIT_SHA)
+      // IS forwarded there now so the worker can report provider/model
+      // failures to Sentry Issues — it reaches Sentry via the gateway proxy
+      // (the Sentry host is added to the proxy allowlist), not directly, so
+      // the Linux IPAddressDeny scope doesn't drop the capture POST.
+      env: commonEnvVars,
+      cwd: workspaceDir,
+      stdio: ["ignore", "pipe", "pipe"],
+      // Run the worker in its OWN process group (child.pid == pgid). The
+      // direct child is usually a wrapper — `systemd-run --scope` on Linux,
+      // `nix-shell --run` for native-dep connectors — so a plain
+      // `child.kill()` signals only the wrapper and reparents the real worker
+      // to init (the orphan `make clean-workers` exists to reap). With a
+      // dedicated group we can signal the wrapper AND the worker together via
+      // the negative pid in killWorker(). See signalWorkerGroup().
+      detached: true,
+    });
 
     // Spawn errors (binary missing, EACCES, fork failure) fire on the child
     // *after* spawn() returns, so without an "error" listener Node would
@@ -842,7 +997,7 @@ export class EmbeddedDeploymentManager extends BaseDeploymentManager {
         `Embedded worker ${deploymentName} spawn error: ${err.message}`
       );
       this.workers.delete(deploymentName);
-      releaseLockOnce();
+      void releaseLockOnce();
       // A spawn error is never a deliberate stop. Fail any in-flight turn(s)
       // for this deployment so the client gets a terminal error instead of a
       // hang. No-op if nothing is in flight (markers already discharged).
@@ -865,21 +1020,56 @@ export class EmbeddedDeploymentManager extends BaseDeploymentManager {
       }
     });
     child.stderr?.on("data", (data: Buffer) => {
-      for (const line of data.toString().trimEnd().split("\n")) {
+      const text = data.toString();
+      // Keep a small tail only for a systemd-wrapped spawn, so the exit
+      // handler can classify an instant `--scope` setup failure.
+      if (systemdWrapped) {
+        recentStderr = (recentStderr + text).slice(-4096);
+      }
+      for (const line of text.trimEnd().split("\n")) {
         logger.warn({ worker: deploymentName }, line);
       }
     });
 
     child.once("exit", (code, signal) => {
-      // Always release the lock here. The killWorker path may have
-      // already deleted the map entry (to short-circuit duplicate
-      // deletes), but the lock release is gated on its own idempotency
-      // flag and is the authoritative release point — codex P1#3.
+      // Always drop the map entry. The killWorker path may have already done
+      // so (to short-circuit duplicate deletes), but consuming the
+      // intentional-exit flag here is the single authoritative point — codex
+      // P1#3. Read it before the self-heal branch so a deliberate kill never
+      // resurrects the worker.
       this.workers.delete(deploymentName);
-      releaseLockOnce();
-      // `delete` returns true iff killWorker marked this exit as deliberate.
-      // Consume the flag here (the exit is the single authoritative point).
       const wasIntentional = this.intentionalExits.delete(deploymentName);
+
+      // Self-heal: a systemd-wrapped worker that died ~instantly with a bus /
+      // scope-setup signature means the user manager went away after the boot
+      // probe. Demote systemd for the rest of this process and re-spawn the
+      // worker unwrapped, REUSING the still-held conversation lock (do NOT
+      // release it — a sibling pod must not claim the turn between attempts).
+      if (
+        !wasIntentional &&
+        systemdWrapped &&
+        code === 1 &&
+        Date.now() - spawnStart < SYSTEMD_FAST_FAIL_MS &&
+        SYSTEMD_SETUP_ERROR_RE.test(recentStderr)
+      ) {
+        const firstLine =
+          recentStderr.trim().split("\n")[0] ?? "systemd setup error";
+        logger.warn(
+          `systemd-run scope for ${deploymentName} failed to start (${firstLine}); demoting systemd for this session and re-spawning the worker unsandboxed.`
+        );
+        cachedSystemdRun = null;
+        // No reap needed: a `--scope` that can't reach the bus exits before
+        // creating the scope or the worker, so there is no half-started unit
+        // or process group to clean up. Re-spawn unwrapped, reusing the lock.
+        this.spawnWorkerChild({
+          ...params,
+          allowSystemd: false,
+          isRetry: true,
+        });
+        return;
+      }
+
+      void releaseLockOnce();
       if (signal) {
         logger.info(
           `Embedded worker ${deploymentName} exited with signal ${signal}`
@@ -892,7 +1082,7 @@ export class EmbeddedDeploymentManager extends BaseDeploymentManager {
         logger.info(`Embedded worker ${deploymentName} exited cleanly`);
       }
       // Any exit that wasn't a deliberate teardown fails the deployment's
-      // in-flight turn(s) — gated on exit code is wrong: a clean `exit 0` that
+      // in-flight turn(s) — gating on exit code is wrong: a clean `exit 0` that
       // leaves a turn un-answered is still a failure (GPT-5.5 edge #3). The
       // marker's presence is the source of truth, so this is a no-op when the
       // worker had already replied (markers discharged) or was idle.

--- a/packages/server/src/gateway/orchestration/impl/embedded-deployment.ts
+++ b/packages/server/src/gateway/orchestration/impl/embedded-deployment.ts
@@ -107,10 +107,11 @@ export function signalWorkerGroup(
 }
 
 /**
- * Detect once whether `systemd-run --user` is available. On Linux production
- * hosts this lets us spawn each worker as a transient systemd unit with
- * cgroup limits + IPAddressDeny + capability drops. macOS dev hosts and
- * Linux hosts without user systemd fall back to plain `child_process.spawn`.
+ * Detect once whether `systemd-run --user` is available. On Linux hosts with
+ * a usable user manager this lets us spawn each worker as a transient scope
+ * with cgroup limits + IPAddressDeny (a `--scope` cannot apply exec-context
+ * hardening — see buildSystemdRunArgs). macOS dev hosts and Linux hosts
+ * without a user systemd fall back to plain `child_process.spawn`.
  */
 let cachedSystemdRun: string | null | undefined;
 function locateSystemdRun(): string | null {
@@ -852,22 +853,21 @@ export class EmbeddedDeploymentManager extends BaseDeploymentManager {
   }
 
   /**
-   * Wrap the worker command in a hardened `systemd-run --user --scope` (cgroup
-   * limits + IPAddressDeny=any + capability drops) when available, spawn it,
-   * and wire stdout/stderr/error/exit handlers + the worker-map entry.
+   * Wrap the worker command in a `systemd-run --user --scope` (cgroup limits +
+   * IPAddressDeny — the only properties a scope honors) when available, spawn
+   * it, and wire stdout/stderr/error/exit handlers + the worker-map entry.
    *
    * Graceful degradation: on a host with no usable systemd user manager the
-   * worker runs unwrapped (self-host / dev) — UNLESS LOBU_CLOUD_MODE is set
-   * without LOBU_ALLOW_UNSANDBOXED_WORKERS=1, where it throws a re-queueable
-   * error rather than silently drop the kernel sandbox (the egress proxy alone
-   * is not a kernel boundary).
+   * worker runs unwrapped (self-host / dev / the prod container, which ships no
+   * systemd-run) — UNLESS LOBU_REQUIRE_WORKER_SANDBOX=1, where it throws a
+   * re-queueable error rather than silently run unwrapped.
    *
    * Self-heal: locateSystemdRun() is a point-in-time probe. If the user bus /
    * manager disappears after boot, the `--scope` wrapper exits ~instantly with
    * a bus/setup error BEFORE the worker runs. We detect that exact signature,
    * demote the process-wide systemd cache, and transparently re-spawn the
-   * worker unwrapped (re-applying the cloud gate) — reusing the still-held
-   * conversation lock so no sibling pod can claim the turn mid-swap.
+   * worker unwrapped (re-applying the sandbox-required gate) — reusing the
+   * still-held conversation lock so no sibling pod can claim the turn mid-swap.
    */
   private spawnWorkerChild(params: {
     deploymentName: string;

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -45,6 +45,7 @@ import {
 } from "./embedded-runtime";
 import { externalDbBootstrapHooks } from "./local-bootstrap";
 import { getEnvFromProcess } from "./utils/env";
+import { deriveJwtSecret } from "./utils/jwt";
 import logger from "./utils/logger";
 import { assertSchemaUpToDate } from "./utils/schema-version-check";
 
@@ -93,7 +94,15 @@ async function main(): Promise<void> {
 			);
 		}
 		if (!process.env.JWT_SECRET) {
-			process.env.JWT_SECRET = randomBytes(32).toString("base64");
+			// Derive a STABLE secret from ENCRYPTION_KEY so window_tokens survive a
+			// restart and verify across replicas — a random per-boot secret broke
+			// both (a token signed before a restart or on a sibling replica failed
+			// verification, so watcher complete_window silently failed). Fall back
+			// to random only when ENCRYPTION_KEY is unset (the ephemeral-key opt-in,
+			// which is itself per-boot and non-persistent by design).
+			process.env.JWT_SECRET = process.env.ENCRYPTION_KEY
+				? deriveJwtSecret(process.env.ENCRYPTION_KEY)
+				: randomBytes(32).toString("base64");
 		}
 		if (!process.env.PUBLIC_WEB_URL) {
 			process.env.PUBLIC_WEB_URL = `http://localhost:${port}`;

--- a/packages/server/src/tools/admin/__tests__/watcher-execution-config.test.ts
+++ b/packages/server/src/tools/admin/__tests__/watcher-execution-config.test.ts
@@ -14,9 +14,11 @@ describe('stripServerOnlyExecutionConfig', () => {
     expect(out).not.toHaveProperty('finalize_nudges');
   });
 
-  it('returns null for an absent config and an empty object when there are no server-only keys', () => {
+  it('returns null for an absent config or one left empty after stripping', () => {
     expect(stripServerOnlyExecutionConfig(null)).toBeNull();
     expect(stripServerOnlyExecutionConfig(undefined)).toBeNull();
+    // Only server-only keys → empty after strip → null ("use defaults"), not {}.
+    expect(stripServerOnlyExecutionConfig({ finalize_nudges: 2 })).toBeNull();
     expect(stripServerOnlyExecutionConfig({ model: 'claude' })).toEqual({
       model: 'claude',
     });

--- a/packages/server/src/tools/admin/__tests__/watcher-execution-config.test.ts
+++ b/packages/server/src/tools/admin/__tests__/watcher-execution-config.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import { stripServerOnlyExecutionConfig } from '../watcher-execution-config';
+
+describe('stripServerOnlyExecutionConfig', () => {
+  it('removes server-only keys (finalize_nudges) but keeps device-worker fields', () => {
+    // The device-worker strict-decodes execution_config; a server-only field it
+    // doesn't know would brick the run. It must never reach the device payload.
+    const out = stripServerOnlyExecutionConfig({
+      timeout_seconds: 600,
+      model: 'claude',
+      finalize_nudges: 3,
+    });
+    expect(out).toEqual({ timeout_seconds: 600, model: 'claude' });
+    expect(out).not.toHaveProperty('finalize_nudges');
+  });
+
+  it('returns null for an absent config and an empty object when there are no server-only keys', () => {
+    expect(stripServerOnlyExecutionConfig(null)).toBeNull();
+    expect(stripServerOnlyExecutionConfig(undefined)).toBeNull();
+    expect(stripServerOnlyExecutionConfig({ model: 'claude' })).toEqual({
+      model: 'claude',
+    });
+  });
+});

--- a/packages/server/src/tools/admin/watcher-execution-config.ts
+++ b/packages/server/src/tools/admin/watcher-execution-config.ts
@@ -47,13 +47,49 @@ export const WatcherExecutionConfigSchema = Type.Object(
         description: 'Reasoning effort (claude only: --effort).',
       })
     ),
+    finalize_nudges: Type.Optional(
+      Type.Integer({
+        minimum: 0,
+        // Each nudge is a full re-dispatched agent turn ($), so keep the ceiling
+        // low. SERVER-ONLY (see SERVER_ONLY_EXECUTION_CONFIG_KEYS) — stripped
+        // before the device payload so an older device-worker's strict decode
+        // never sees it.
+        maximum: 5,
+        description:
+          'How many extra times to re-dispatch a server-side watcher run that finished WITHOUT calling complete_window (a soft, non-deterministic finalize miss) before failing it. 0 disables; omitted = global default (LOBU_WATCHER_FINALIZE_NUDGES, default 1).',
+      })
+    ),
   },
   {
     additionalProperties: false,
     description:
-      '[create/update] Per-watcher device-worker CLI execution settings. Omitted fields fall back to dispatcher/CLI defaults; pass null to clear.',
+      '[create/update] Per-watcher execution settings: device-worker CLI flags plus the server-side finalize-nudge budget. Omitted fields fall back to dispatcher/CLI/global defaults; pass null to clear.',
   }
 );
+
+/**
+ * execution_config keys that are SERVER-ONLY and must never reach a
+ * device-worker — its strict payload decode (`additionalProperties: false`)
+ * would reject an unknown field and brick every run of that watcher. Stripped
+ * at the device boundary (worker-api/poll.ts) via stripServerOnlyExecutionConfig.
+ */
+export const SERVER_ONLY_EXECUTION_CONFIG_KEYS = ['finalize_nudges'] as const;
+
+/**
+ * Remove SERVER_ONLY_EXECUTION_CONFIG_KEYS from an execution_config before it
+ * is handed to a device-worker. Returns null for an empty/absent config.
+ */
+export function stripServerOnlyExecutionConfig(
+  config: Record<string, unknown> | null | undefined
+): Record<string, unknown> | null {
+  if (!config) return null;
+  const serverOnly = SERVER_ONLY_EXECUTION_CONFIG_KEYS as readonly string[];
+  const out: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(config)) {
+    if (!serverOnly.includes(key)) out[key] = value;
+  }
+  return out;
+}
 
 // Permission modes that let the spawned agent act unattended without prompting.
 // Restricted to org owner/admin: a member-write actor can pin a watcher to

--- a/packages/server/src/tools/admin/watcher-execution-config.ts
+++ b/packages/server/src/tools/admin/watcher-execution-config.ts
@@ -77,7 +77,9 @@ export const SERVER_ONLY_EXECUTION_CONFIG_KEYS = ['finalize_nudges'] as const;
 
 /**
  * Remove SERVER_ONLY_EXECUTION_CONFIG_KEYS from an execution_config before it
- * is handed to a device-worker. Returns null for an empty/absent config.
+ * is handed to a device-worker. Returns null for an absent config, or one that
+ * is left empty after stripping (so a watcher configured with ONLY server-only
+ * keys sends the device `null`, i.e. "use defaults", rather than `{}`).
  */
 export function stripServerOnlyExecutionConfig(
   config: Record<string, unknown> | null | undefined
@@ -88,7 +90,7 @@ export function stripServerOnlyExecutionConfig(
   for (const [key, value] of Object.entries(config)) {
     if (!serverOnly.includes(key)) out[key] = value;
   }
-  return out;
+  return Object.keys(out).length > 0 ? out : null;
 }
 
 // Permission modes that let the spawned agent act unattended without prompting.

--- a/packages/server/src/utils/__tests__/jwt.test.ts
+++ b/packages/server/src/utils/__tests__/jwt.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import { deriveJwtSecret } from '../jwt';
+
+describe('deriveJwtSecret', () => {
+  it('is deterministic for a given ENCRYPTION_KEY (stable across restarts/replicas)', () => {
+    // The whole point: a restart or a sibling replica must derive the SAME
+    // signing secret so a window_token signed earlier/elsewhere still verifies.
+    const key = 'test-encryption-key-0123456789abcdef';
+    expect(deriveJwtSecret(key)).toBe(deriveJwtSecret(key));
+  });
+
+  it('differs per ENCRYPTION_KEY and is not the raw key', () => {
+    const a = deriveJwtSecret('key-a');
+    const b = deriveJwtSecret('key-b');
+    expect(a).not.toBe(b);
+    expect(a).not.toBe('key-a');
+    // HMAC-SHA256 → 32 bytes → 44-char base64.
+    expect(a).toHaveLength(44);
+  });
+});

--- a/packages/server/src/utils/jwt.ts
+++ b/packages/server/src/utils/jwt.ts
@@ -5,8 +5,22 @@
  * the watcher worker. complete_window links those IDs deterministically.
  */
 
-import { timingSafeEqual } from 'node:crypto';
+import { createHmac, timingSafeEqual } from 'node:crypto';
 import type { Env } from '../index';
+
+/**
+ * Derive a STABLE window-token signing secret from the install's
+ * ENCRYPTION_KEY. Used as the JWT_SECRET default for local installs (server.ts)
+ * so window_tokens survive a gateway restart AND verify across replicas — a
+ * random per-boot secret broke both (a token signed before a restart, or on a
+ * sibling replica, failed verification). ENCRYPTION_KEY is the install's root
+ * secret and is identical across replicas, so the derived value is too.
+ */
+export function deriveJwtSecret(encryptionKey: string): string {
+  return createHmac('sha256', encryptionKey)
+    .update('lobu:jwt-secret:v1')
+    .digest('base64');
+}
 
 interface WindowTokenPayload {
   watcher_id: number;
@@ -75,7 +89,10 @@ async function verifySignature(data: string, signature: string, secret: string):
  * Get JWT secret from environment
  */
 function getJwtSecret(env: Env): string {
-  // Use JWT_SECRET if available, otherwise fall back to a derived secret
+  // JWT_SECRET is set for every embedded/local install by server.ts (derived
+  // from ENCRYPTION_KEY via deriveJwtSecret) and explicitly in prod; legacy
+  // installs may still use INSIGHTS_API_KEY. Throw only if truly absent (a
+  // misconfigured external deployment) — never sign/verify with an empty key.
   const secret = (env as any).JWT_SECRET || (env as any).INSIGHTS_API_KEY;
   if (!secret) {
     throw new Error('JWT_SECRET or INSIGHTS_API_KEY environment variable is required');

--- a/packages/server/src/watchers/run-completion.ts
+++ b/packages/server/src/watchers/run-completion.ts
@@ -26,6 +26,21 @@ const MAX_FINALIZE_NUDGES: number = (() => {
   return Number.isFinite(n) && n >= 0 ? Math.floor(n) : 1;
 })();
 
+/**
+ * Finalize-nudge budget for a run: the watcher's per-watcher override
+ * (execution_config.finalize_nudges, 0-5) when set, else the global default.
+ * Clamped defensively in case a raw DB value sits outside the schema's range.
+ */
+function resolveFinalizeNudgeBudget(
+  executionConfig: Record<string, unknown> | null | undefined
+): number {
+  const override = executionConfig?.finalize_nudges;
+  if (typeof override === 'number' && Number.isFinite(override)) {
+    return Math.min(5, Math.max(0, Math.floor(override)));
+  }
+  return MAX_FINALIZE_NUDGES;
+}
+
 export async function findWindowIdForRun(sql: DbClient, runId: number): Promise<number | null> {
   const rows = await sql`
     SELECT id
@@ -109,11 +124,12 @@ export async function resolveWatcherRunsByMessageIds(
 
   const sql = db ?? getDb();
   const rows = await sql`
-    SELECT id, approved_input
-    FROM runs
-    WHERE run_type = 'watcher'
-      AND dispatched_message_id = ANY(${pgTextArray(ids)}::text[])
-      AND status = ANY(${runStatusLiteral(ACTIVE_RUN_STATUSES)}::text[])
+    SELECT r.id, r.approved_input, w.execution_config
+    FROM runs r
+    LEFT JOIN watchers w ON w.id = r.watcher_id
+    WHERE r.run_type = 'watcher'
+      AND r.dispatched_message_id = ANY(${pgTextArray(ids)}::text[])
+      AND r.status = ANY(${runStatusLiteral(ACTIVE_RUN_STATUSES)}::text[])
   `;
 
   let resolved = 0;
@@ -121,6 +137,7 @@ export async function resolveWatcherRunsByMessageIds(
     const typedRow = row as {
       id: unknown;
       approved_input: Record<string, unknown> | null;
+      execution_config: Record<string, unknown> | null;
     };
     const runId = Number(typedRow.id);
     if (!Number.isFinite(runId)) continue;
@@ -135,12 +152,14 @@ export async function resolveWatcherRunsByMessageIds(
     if (windowId === null) {
       // The agent replied but never called complete_window — a soft, usually
       // non-deterministic miss. Re-dispatch for one more turn (bounded by
-      // finalize_nudge_count) before giving up.
+      // finalize_nudge_count) before giving up. The budget is per-watcher
+      // (execution_config.finalize_nudges) with a global fallback.
+      const budget = resolveFinalizeNudgeBudget(typedRow.execution_config);
       const nudgeCount = Number(typedRow.approved_input?.finalize_nudge_count ?? 0);
-      if (Number.isFinite(nudgeCount) && nudgeCount < MAX_FINALIZE_NUDGES) {
+      if (Number.isFinite(nudgeCount) && nudgeCount < budget) {
         await requeueWatcherRunForFinalizeNudge(sql, runId, nudgeCount + 1);
         logger.info(
-          { run_id: runId, attempt: nudgeCount + 1, max: MAX_FINALIZE_NUDGES },
+          { run_id: runId, attempt: nudgeCount + 1, max: budget },
           '[watchers] Agent finished without complete_window — re-dispatching for finalize nudge'
         );
         resolved++;
@@ -151,7 +170,7 @@ export async function resolveWatcherRunsByMessageIds(
         sql,
         runId,
         'Agent reply finished without calling manage_watchers(action="complete_window")' +
-          (MAX_FINALIZE_NUDGES > 0 ? ` after ${MAX_FINALIZE_NUDGES + 1} attempt(s)` : '') +
+          (budget > 0 ? ` after ${budget + 1} attempt(s)` : '') +
           '. Check that the assigned agent has the lobu-memory MCP attached and that read_knowledge / ' +
           'manage_watchers tools are approved for it.'
       );

--- a/packages/server/src/watchers/run-completion.ts
+++ b/packages/server/src/watchers/run-completion.ts
@@ -16,8 +16,10 @@ type WatcherTerminalResult = { ok: true } | { ok: false; error: string };
  * NOTE: this is a re-dispatch (a fresh session via the existing dispatch loop),
  * not a warm in-session nudge — the agent-worker is platform-agnostic and has
  * no notion of watchers/complete_window, so a worker-side self-nudge would
- * break that isolation. A per-watcher policy (defineWatcher → execution_config)
- * is the planned product-feature follow-up; this is the global default.
+ * break that isolation. This constant is the GLOBAL default; a watcher can
+ * override it via execution_config.finalize_nudges (see
+ * resolveFinalizeNudgeBudget). A declarative defineWatcher surface for it is
+ * the remaining follow-up (the CLI doesn't expose execution_config yet).
  */
 const MAX_FINALIZE_NUDGES: number = (() => {
   const raw = process.env.LOBU_WATCHER_FINALIZE_NUDGES;

--- a/packages/server/src/watchers/run-completion.ts
+++ b/packages/server/src/watchers/run-completion.ts
@@ -1,8 +1,30 @@
 import type { DbClient } from '../db/client';
 import { getDb, pgTextArray } from '../db/client';
 import { ACTIVE_RUN_STATUSES, runStatusLiteral } from '../utils/run-statuses';
+import logger from '../utils/logger';
 
 type WatcherTerminalResult = { ok: true } | { ok: false; error: string };
+
+/**
+ * How many times a watcher run that finished its agent turn WITHOUT calling
+ * `complete_window` is re-dispatched before being marked failed. The agent
+ * read its inputs and replied but skipped the finalize tool call — a soft,
+ * usually-non-deterministic miss (the model "forgot" the closing step). A
+ * bounded re-dispatch gives it a fresh turn to finalize. Default 1 (one extra
+ * attempt); 0 disables. Each re-dispatch is a full agent turn, so keep it low.
+ *
+ * NOTE: this is a re-dispatch (a fresh session via the existing dispatch loop),
+ * not a warm in-session nudge — the agent-worker is platform-agnostic and has
+ * no notion of watchers/complete_window, so a worker-side self-nudge would
+ * break that isolation. A per-watcher policy (defineWatcher → execution_config)
+ * is the planned product-feature follow-up; this is the global default.
+ */
+const MAX_FINALIZE_NUDGES: number = (() => {
+  const raw = process.env.LOBU_WATCHER_FINALIZE_NUDGES;
+  if (raw === undefined) return 1;
+  const n = Number(raw);
+  return Number.isFinite(n) && n >= 0 ? Math.floor(n) : 1;
+})();
 
 export async function findWindowIdForRun(sql: DbClient, runId: number): Promise<number | null> {
   const rows = await sql`
@@ -47,6 +69,36 @@ async function markWatcherRunFailed(
   `;
 }
 
+/**
+ * Reset a watcher run that missed `complete_window` back to `pending` so the
+ * automation dispatch loop (`dispatchPendingWatcherRuns` → `claimWatcherRun`)
+ * re-dispatches it for one more agent turn. Mirrors `resetOrphanedWatcherRuns`
+ * (the proven re-dispatch shape) and records the attempt in
+ * `approved_input.finalize_nudge_count` so it is strictly bounded. Status-
+ * guarded so it can't resurrect an already-terminal run (replica-safe).
+ */
+async function requeueWatcherRunForFinalizeNudge(
+  sql: DbClient,
+  runId: number,
+  nextNudgeCount: number
+): Promise<void> {
+  await sql`
+    UPDATE runs
+    SET status = 'pending',
+        claimed_by = NULL,
+        claimed_at = NULL,
+        dispatched_message_id = NULL,
+        error_message = NULL,
+        approved_input = jsonb_set(
+          COALESCE(approved_input, '{}'::jsonb),
+          '{finalize_nudge_count}',
+          to_jsonb(${nextNudgeCount}::int)
+        )
+    WHERE id = ${runId}
+      AND status = ANY(${runStatusLiteral(ACTIVE_RUN_STATUSES)}::text[])
+  `;
+}
+
 export async function resolveWatcherRunsByMessageIds(
   messageIds: Iterable<string>,
   result: WatcherTerminalResult,
@@ -57,7 +109,7 @@ export async function resolveWatcherRunsByMessageIds(
 
   const sql = db ?? getDb();
   const rows = await sql`
-    SELECT id
+    SELECT id, approved_input
     FROM runs
     WHERE run_type = 'watcher'
       AND dispatched_message_id = ANY(${pgTextArray(ids)}::text[])
@@ -66,7 +118,11 @@ export async function resolveWatcherRunsByMessageIds(
 
   let resolved = 0;
   for (const row of rows) {
-    const runId = Number((row as { id: unknown }).id);
+    const typedRow = row as {
+      id: unknown;
+      approved_input: Record<string, unknown> | null;
+    };
+    const runId = Number(typedRow.id);
     if (!Number.isFinite(runId)) continue;
 
     if (!result.ok) {
@@ -77,11 +133,26 @@ export async function resolveWatcherRunsByMessageIds(
 
     const windowId = await findWindowIdForRun(sql, runId);
     if (windowId === null) {
+      // The agent replied but never called complete_window — a soft, usually
+      // non-deterministic miss. Re-dispatch for one more turn (bounded by
+      // finalize_nudge_count) before giving up.
+      const nudgeCount = Number(typedRow.approved_input?.finalize_nudge_count ?? 0);
+      if (Number.isFinite(nudgeCount) && nudgeCount < MAX_FINALIZE_NUDGES) {
+        await requeueWatcherRunForFinalizeNudge(sql, runId, nudgeCount + 1);
+        logger.info(
+          { run_id: runId, attempt: nudgeCount + 1, max: MAX_FINALIZE_NUDGES },
+          '[watchers] Agent finished without complete_window — re-dispatching for finalize nudge'
+        );
+        resolved++;
+        continue;
+      }
+
       await markWatcherRunFailed(
         sql,
         runId,
-        'Agent reply finished without calling manage_watchers(action="complete_window"). ' +
-          'Check that the assigned agent has the lobu-memory MCP attached and that read_knowledge / ' +
+        'Agent reply finished without calling manage_watchers(action="complete_window")' +
+          (MAX_FINALIZE_NUDGES > 0 ? ` after ${MAX_FINALIZE_NUDGES + 1} attempt(s)` : '') +
+          '. Check that the assigned agent has the lobu-memory MCP attached and that read_knowledge / ' +
           'manage_watchers tools are approved for it.'
       );
       resolved++;

--- a/packages/server/src/worker-api/poll.ts
+++ b/packages/server/src/worker-api/poll.ts
@@ -24,6 +24,7 @@ import { resolveConnectorCode } from '../utils/ensure-connector-installed';
 import { resolveDeviceClaimableOrgs } from '../utils/device-claimable-orgs';
 import { errorMessage } from '../utils/errors';
 import { mergeExecutionConfig, resolveExecutionAuth } from '../utils/execution-context';
+import { stripServerOnlyExecutionConfig } from '../tools/admin/watcher-execution-config';
 import logger from '../utils/logger';
 import { recordLifecycleEvent } from '../utils/insert-event';
 import { isCloudMode } from '../utils/cloud-mode';
@@ -605,7 +606,11 @@ export async function pollWorkerJob(c: Context<{ Bindings: Env }>) {
           agent_kind: agentKindFromPayload ?? row.watcher_agent_kind ?? null,
           notification_channel: row.watcher_notification_channel ?? 'canvas',
           notification_priority: row.watcher_notification_priority ?? 'normal',
-          execution_config: row.watcher_execution_config ?? null,
+          // Strip server-only keys (e.g. finalize_nudges) so the device-worker's
+          // strict payload decode never sees a field it doesn't know.
+          execution_config: stripServerOnlyExecutionConfig(
+            row.watcher_execution_config
+          ),
           // The prompt of the version this run was pinned to at creation
           // (run's snapshotted approved_input.version_id, else the watcher's
           // current_version_id) — same source complete_window validates


### PR DESCRIPTION
Makes the watcher/worker pipeline run reliably on any host. Four related fixes, all surfaced and validated end-to-end on a fresh Linux VM (systemd 255) + a read-only prod check.

## 1. systemd worker sandbox actually works (was dying)

Workers wrapped in `systemd-run --user --scope` died instantly on Linux hosts whose user bus wasn't reachable from the worker spawn env, and the boot probe false-positived so there was no fallback. Three defects:

- **Bus vars never forwarded.** `XDG_RUNTIME_DIR`/`DBUS_SESSION_BUS_ADDRESS` are forwarded nowhere into the worker spawn env, so `systemd-run --user` can't reach the bus ("No medium found") even when the gateway can. The probe runs via `execFileSync` (inherits `process.env`) so it passed while the real spawn (sanitized env) failed. Fix forwards both.
- **Scope-incompatible properties.** `buildSystemdRunArgs` emitted exec-context props (`NoNewPrivileges`, `ProtectSystem`, `ReadWritePaths`, caps, `RestrictAddressFamilies`…) that a `--scope` can't apply — systemd 255 rejects each with `Unknown assignment` and the whole scope fails. Reduced to the cgroup/network props a scope honors (Memory/CPU/Tasks + IPAddressDeny/Allow).
- **Probe didn't match the spawn** (`--no-block` service vs `--scope`); now probes the real path so a host that can't run it degrades to a plain spawn instead of killing every worker.

Plus self-heal (demote + re-spawn unwrapped on an instant bus/scope error) and an **opt-in** `LOBU_REQUIRE_WORKER_SANDBOX=1` fail-closed gate — opt-in, NOT cloud-default: verified read-only that the prod container ships no `systemd-run` and runs workers unwrapped today, so a cloud-default fail-closed would take prod down.

## 2. Bounded finalize-nudge for watcher runs

A watcher agent sometimes finishes its turn but skips `complete_window`. That was stamped terminal `failed` on the first miss. Now the server-side completion path re-dispatches once (bounded by `approved_input.finalize_nudge_count`, `LOBU_WATCHER_FINALIZE_NUDGES` default 1) before failing, reusing the proven `resetOrphanedWatcherRuns` → dispatch loop. It's a re-dispatch, not a warm in-session nudge — the agent-worker is platform-agnostic and has no notion of watchers/`complete_window`.

## 3. Stable local `JWT_SECRET` (window_tokens survive restarts + replicas)

For embedded/local installs without `JWT_SECRET`, `server.ts` generated a *random per-boot* secret. `window_token`s are HMAC-signed with it, so a token signed before a restart — or on a sibling replica — failed verification, and `complete_window` silently failed with "Invalid token signature" (surfacing only as the generic "finished without complete_window"). Now derived deterministically from `ENCRYPTION_KEY` (stable, identical across replicas); falls back to random only when `ENCRYPTION_KEY` is unset. Prod unaffected (sets `JWT_SECRET` explicitly).

## End-to-end validation

On the VM, with all three in place, a watcher run completed fully **sandboxed**: worker under a live `systemd-run` scope with `IPAddressDeny=0.0.0.0/0` + cgroup limits applied, agent read events → valid `window_token` → `complete_window` → fresh window persisted → run `completed`, producing a real HN digest. The earlier finalize failures were each traced to env/idempotency (missing `JWT_SECRET`, re-running an already-completed daily window), never the sandbox or this code.

Reproducers, syscall-level evidence (props rejected on a scope; reduced props + forwarded bus vars exit 0), tsc clean, and unit/integration tests updated for each change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved worker sandbox behavior: automatic unwrapped mode when systemd sandboxing isn’t available, plus self-healing and optional fail-closed.
  * Bounded “soft miss” handling for watcher runs with configurable (clamped) finalize-nudge retries.
  * Deterministic JWT secret derivation from `ENCRYPTION_KEY` for local installs.
* **Bug Fixes**
  * Conversation-lock handling now reliably releases on pre-spawn failures; improved systemd setup detection.
  * Server-only `finalize_nudges` is stripped from device-worker execution config.
* **Tests**
  * Added/updated coverage for sandbox fallback, self-healing, finalize-nudge retries, capability-probe reset, and derived JWT secret behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->