### PR TITLE
feat(connectors): inbound webhook ingestion (EL) + GitHub self-service registration

### DIFF
--- a/packages/cli/src/templates/AGENTS.md.tmpl
+++ b/packages/cli/src/templates/AGENTS.md.tmpl
@@ -136,7 +136,7 @@ const gh = defineConnection({
 ```
 
 **Bundled connector keys** — use the exact key; several are dotted (Gmail is
-`google.gmail`, not `gmail` or `google_gmail`): `github`, `google.gmail`,
+`google.gmail`, not `gmail` or `google_gmail`): `github`, `linear`, `jira`, `google.gmail`,
 `google.calendar`, `microsoft.outlook`, `website`, `rss`, `postgres`,
 `hackernews`, `reddit`, `x`, `linkedin`, `youtube`, `spotify`, `producthunt`,
 `google_play`, `ios_appstore`, `g2`, `capterra`, `glassdoor`, `trustpilot`,

--- a/packages/connector-sdk/src/connector-runtime.ts
+++ b/packages/connector-sdk/src/connector-runtime.ts
@@ -17,6 +17,8 @@ import type {
   ReflectResult,
   SyncContext,
   SyncResult,
+  WebhookRegistration,
+  WebhookRegistrationContext,
 } from './connector-types.js';
 
 /**
@@ -94,6 +96,27 @@ export abstract class ConnectorRuntime<C = Record<string, unknown>, F = Record<s
   // biome-ignore lint/correctness/noUnusedFunctionParameters: contract signature — subclasses receive the full QueryContext
   async query(ctx: QueryContext<F>): Promise<QueryResult> {
     throw new Error(`${this.definition.key} does not support live queries`);
+  }
+
+  /**
+   * Subscribe to provider webhooks at connect time (or re-auth), using the
+   * connection's OAuth credentials, so deliveries flow to `ctx.callbackUrl`
+   * (`/api/v1/webhooks/:connectionId`). Returns the provider subscription id and
+   * the signing secret to persist on the connection for in-gateway verification.
+   * Default throws — connectors that declare a `webhook` block MUST override.
+   */
+  async registerWebhook(_ctx: WebhookRegistrationContext<F>): Promise<WebhookRegistration> {
+    throw new Error(`${this.definition.key} does not support webhook registration`);
+  }
+
+  /**
+   * Tear down the provider subscription created by {@link registerWebhook} when
+   * the connection is removed. Default is a no-op — override to call the
+   * provider's delete-subscription endpoint with `ctx.externalId`.
+   */
+  // biome-ignore lint/correctness/noUnusedFunctionParameters: contract signature — subclasses receive the full WebhookRegistrationContext
+  async unregisterWebhook(ctx: WebhookRegistrationContext<F>): Promise<void> {
+    // no-op by default
   }
 
   /**

--- a/packages/connector-sdk/src/connector-types.ts
+++ b/packages/connector-sdk/src/connector-types.ts
@@ -29,6 +29,17 @@ export interface ConnectorDefinition {
   feeds?: Record<string, FeedDefinition>;
   /** Available action definitions (keyed by action_key) */
   actions?: Record<string, ActionDefinition>;
+  /**
+   * Declarative inbound-webhook config. Presence means this connector receives
+   * real-time provider deliveries at `POST /api/v1/webhooks/:connectionId`,
+   * which are landed RAW into `events` (extract-load — the agent/downstream
+   * stages interpret them; no transform on the ingest hot path). The gateway
+   * verifies the signature IN-PROCESS using this schema + the secret stored on
+   * the connection, so the hot path never loads connector code. Pair with
+   * {@link ConnectorRuntime.registerWebhook}, which subscribes with the provider
+   * at connect time and stamps the signing secret onto the connection.
+   */
+  webhook?: ConnectorWebhookSchema;
   /** Global connector options schema (JSON Schema) */
   optionsSchema?: Record<string, unknown>;
   /** Domain for favicon lookup (e.g. 'x.com') */
@@ -79,6 +90,35 @@ export interface ConnectorRuntimeInfo {
    * that can't (e.g. edge workers) reject a connector that declares them.
    */
   nix?: { packages: string[] };
+}
+
+/**
+ * Declarative scheme the gateway uses to verify an inbound provider webhook in
+ * the request hot path — no connector code runs before the 202 ack. The shared
+ * secret is NOT here: it is minted by {@link ConnectorRuntime.registerWebhook}
+ * at connect time and stored on the connection.
+ */
+export interface ConnectorWebhookSchema {
+  /**
+   * Request header carrying the provider's HMAC signature over the raw body,
+   * e.g. `x-hub-signature-256` (GitHub), `linear-signature`. Omit for providers
+   * that don't sign — verification is then skipped (relies on the unguessable
+   * per-connection URL + token), so prefer signing whenever the provider offers it.
+   */
+  signatureHeader?: string;
+  /** HMAC digest algorithm used to compute the signature. Default `sha256`. */
+  algorithm?: 'sha256' | 'sha1';
+  /**
+   * Prefix the provider prepends to the hex digest in the signature header,
+   * e.g. `sha256=`. Stripped before the constant-time compare. Default none.
+   */
+  signaturePrefix?: string;
+  /**
+   * Request header carrying the provider's unique delivery id, used for
+   * idempotent dedupe (e.g. `x-github-delivery`, `linear-delivery`). Falls back
+   * to a body hash when unset.
+   */
+  dedupeHeader?: string;
 }
 
 // =============================================================================
@@ -535,6 +575,42 @@ export interface SyncResult<C = Record<string, unknown>> {
     items_skipped?: number;
     [key: string]: unknown;
   };
+}
+
+// =============================================================================
+// Webhooks (inbound real-time push)
+// =============================================================================
+
+/**
+ * Context passed to {@link ConnectorRuntime.registerWebhook} /
+ * `unregisterWebhook` at connect/disconnect time.
+ */
+export interface WebhookRegistrationContext<F = Record<string, unknown>> {
+  /** Feed/connector configuration (typed via F). */
+  config: F;
+  /** OAuth credentials used to authorize the subscription call. */
+  credentials: SyncCredentials | null;
+  /** Connection session state (browser cookies, tokens, etc.). */
+  sessionState?: Record<string, unknown> | null;
+  /**
+   * Public URL the provider must POST deliveries to — the gateway builds this
+   * from `PUBLIC_*_URL` + the connection id. The connector registers it verbatim.
+   */
+  callbackUrl: string;
+  /** Provider-side subscription id to tear down (unregister only). */
+  externalId?: string;
+}
+
+/** Result from {@link ConnectorRuntime.registerWebhook}. */
+export interface WebhookRegistration {
+  /** Provider-side id of the created subscription, for later teardown. */
+  externalId: string;
+  /**
+   * Shared secret the provider will sign deliveries with. Persisted on the
+   * connection so the gateway can verify deliveries per {@link ConnectorWebhookSchema}.
+   */
+  secret?: string;
+  metadata?: Record<string, unknown>;
 }
 
 // =============================================================================

--- a/packages/connector-sdk/src/define-connector.ts
+++ b/packages/connector-sdk/src/define-connector.ts
@@ -42,6 +42,8 @@ import type {
   ReflectResult,
   SyncContext,
   SyncResult,
+  WebhookRegistration,
+  WebhookRegistrationContext,
 } from "./connector-types.js";
 
 /** A feed's metadata (minus the record-derived `key`) plus its `sync` handler. */
@@ -85,6 +87,18 @@ export interface ConnectorSpec
    * source's native governed metrics. Omitted ⇒ no contributions.
    */
   reflectMetrics?(ctx: ReflectContext): Promise<ReflectResult>;
+  /**
+   * Optional webhook-subscription handler. When provided, lowers to
+   * `ConnectorRuntime.registerWebhook` — subscribes with the provider at connect
+   * time and returns the secret to persist. Omitted ⇒ registration unsupported.
+   */
+  registerWebhook?(ctx: WebhookRegistrationContext): Promise<WebhookRegistration>;
+  /**
+   * Optional webhook-teardown handler. When provided, lowers to
+   * `ConnectorRuntime.unregisterWebhook` — deletes the provider subscription on
+   * disconnect. Omitted ⇒ teardown is a no-op.
+   */
+  unregisterWebhook?(ctx: WebhookRegistrationContext): Promise<void>;
 }
 
 /** Constructor shape the connector-worker's `child-runner` detects and instantiates. */
@@ -104,6 +118,7 @@ function buildDefinition(spec: ConnectorSpec): ConnectorDefinition {
     openapiConfig: spec.openapiConfig,
     requiredCapability: spec.requiredCapability,
     runtime: spec.runtime,
+    webhook: spec.webhook,
   };
 
   if (spec.feeds) {
@@ -196,6 +211,20 @@ export function defineConnector(spec: ConnectorSpec): ConnectorClass {
         return super.reflectMetrics(ctx);
       }
       return spec.reflectMetrics(ctx);
+    }
+
+    async registerWebhook(ctx: WebhookRegistrationContext): Promise<WebhookRegistration> {
+      if (!spec.registerWebhook) {
+        return super.registerWebhook(ctx);
+      }
+      return spec.registerWebhook(ctx);
+    }
+
+    async unregisterWebhook(ctx: WebhookRegistrationContext): Promise<void> {
+      if (!spec.unregisterWebhook) {
+        return super.unregisterWebhook(ctx);
+      }
+      return spec.unregisterWebhook(ctx);
     }
   };
 }

--- a/packages/connector-sdk/src/index.ts
+++ b/packages/connector-sdk/src/index.ts
@@ -49,6 +49,7 @@ export type {
   ConnectorAuthSchema,
   ConnectorDefinition,
   ConnectorRuntimeInfo,
+  ConnectorWebhookSchema,
   ContentItem,
   EntityIdentitySpec,
   EntityLinkOverride,
@@ -71,6 +72,8 @@ export type {
   SyncContext,
   SyncCredentials,
   SyncResult,
+  WebhookRegistration,
+  WebhookRegistrationContext,
 } from './connector-types.js';
 export { IDENTITY } from './connector-types.js';
 // Identity-engine SDK contracts. Each schema export is both a TypeBox

--- a/packages/connector-worker/src/executor/child-runner.ts
+++ b/packages/connector-worker/src/executor/child-runner.ts
@@ -206,6 +206,29 @@ async function executeConnectorRuntime(
     return { mode: 'action', output: actionResult.output ?? {} };
   }
 
+  if (job.mode === 'webhook_register') {
+    const registration = await instance.registerWebhook({
+      config: { ...job.env, ...job.config },
+      credentials: job.credentials,
+      sessionState: job.sessionState,
+      callbackUrl: job.callbackUrl,
+    });
+    if (!registration?.externalId) {
+      throw new Error('registerWebhook() returned no externalId');
+    }
+    return { mode: 'webhook_register', registration };
+  }
+
+  if (job.mode === 'webhook_unregister') {
+    await instance.unregisterWebhook({
+      config: { ...job.env, ...job.config },
+      credentials: job.credentials,
+      sessionState: job.sessionState,
+      externalId: job.externalId,
+    });
+    return { mode: 'webhook_unregister' };
+  }
+
   if (job.mode === 'query') {
     // Live read: returns rows to the caller, persists nothing (like an action).
     const queryResult = await instance.query({

--- a/packages/connector-worker/src/executor/interface.ts
+++ b/packages/connector-worker/src/executor/interface.ts
@@ -1,4 +1,9 @@
-import type { AuthResult, EventEnvelope, SyncCredentials } from '@lobu/connector-sdk';
+import type {
+  AuthResult,
+  EventEnvelope,
+  SyncCredentials,
+  WebhookRegistration,
+} from '@lobu/connector-sdk';
 
 /**
  * Executor mode discriminator. The executor speaks the same V1 SDK shapes
@@ -44,6 +49,28 @@ export type ExecutorJob =
       limit?: number;
       offset?: number;
       sort?: { column: string; order: 'asc' | 'desc' };
+    }
+  | {
+      // Subscribe with the provider at connect time so deliveries flow to
+      // `callbackUrl` (`/api/v1/webhooks/:connectionId`). Runs once per
+      // connection, not per delivery. Returns the provider subscription id +
+      // signing secret to persist on the connection.
+      mode: 'webhook_register';
+      config: Record<string, unknown>;
+      credentials: SyncCredentials | null;
+      sessionState: Record<string, unknown> | null;
+      callbackUrl: string;
+      env: Record<string, string | undefined>;
+    }
+  | {
+      // Tear down the provider subscription created by `webhook_register` when
+      // the connection is removed.
+      mode: 'webhook_unregister';
+      config: Record<string, unknown>;
+      credentials: SyncCredentials | null;
+      sessionState: Record<string, unknown> | null;
+      externalId: string;
+      env: Record<string, string | undefined>;
     };
 
 /**
@@ -73,6 +100,13 @@ export type ExecutorResult =
       rows: Record<string, unknown>[];
       columns?: { name: string; type: string }[];
       total?: number;
+    }
+  | {
+      mode: 'webhook_register';
+      registration: WebhookRegistration;
+    }
+  | {
+      mode: 'webhook_unregister';
     };
 
 export interface ExecutionHooks {

--- a/packages/connectors/src/github.ts
+++ b/packages/connectors/src/github.ts
@@ -1,9 +1,13 @@
 /**
  * GitHub Connector (V1 runtime)
  *
- * Syncs GitHub repository content and executes write actions.
+ * Syncs GitHub repository content and executes write actions. Also subscribes
+ * to real-time issue/PR/comment deliveries via inbound webhooks (registered at
+ * connect time); the raw deliveries are landed downstream (extract-load), so
+ * this connector only owns the subscription lifecycle here.
  */
 
+import { randomBytes } from 'node:crypto';
 import {
   type ActionContext,
   type ActionResult,
@@ -15,6 +19,8 @@ import {
   paginateByOffset,
   type SyncContext,
   type SyncResult,
+  type WebhookRegistration,
+  type WebhookRegistrationContext,
 } from '@lobu/connector-sdk';
 
 type GitHubContentType =
@@ -29,6 +35,15 @@ type GitHubContentType =
 interface GitHubConfig {
   repo_owner?: string;
   repo_name?: string;
+  /**
+   * Org login for org-wide ingestion. When set, webhook registration creates a
+   * single ORGANIZATION webhook (`POST /orgs/{org}/hooks`, scope
+   * `admin:org_hook`) that delivers events from every repo in the org — instead
+   * of a per-repo hook (`admin:repo_hook`). Takes precedence over repo_owner/name.
+   */
+  org?: string;
+  /** Webhook event subscription; defaults to `['*']` (every event type). */
+  webhook_events?: string[];
   content_type?: GitHubContentType;
   lookback_days?: number;
   labels_filter?: string[];
@@ -211,13 +226,22 @@ export default class GitHubConnector extends ConnectorRuntime {
     description: 'Collects GitHub issues/discussions and executes repo actions.',
     version: '1.2.0',
     faviconDomain: 'github.com',
+    webhook: {
+      signatureHeader: 'x-hub-signature-256',
+      algorithm: 'sha256',
+      signaturePrefix: 'sha256=',
+      dedupeHeader: 'x-github-delivery',
+    },
     authSchema: {
       methods: [
         {
           type: 'oauth',
           provider: 'github',
           requiredScopes: ['read:user'],
-          optionalScopes: ['repo'],
+          // Webhook scopes are OPTIONAL and requested incrementally — only when
+          // the user enables a live feed (repo) or org-wide ingestion (org), not
+          // at first connect. `repo` covers reads of private repos.
+          optionalScopes: ['repo', 'admin:repo_hook', 'admin:org_hook'],
           loginScopes: ['read:user', 'user:email'],
           clientIdKey: 'GITHUB_CLIENT_ID',
           clientSecretKey: 'GITHUB_CLIENT_SECRET',
@@ -640,6 +664,87 @@ export default class GitHubConnector extends ConnectorRuntime {
         error: error instanceof Error ? error.message : String(error),
       };
     }
+  }
+
+  // -------------------------------------------------------------------------
+  // Webhooks (subscription lifecycle — raw deliveries land downstream)
+  // -------------------------------------------------------------------------
+
+  /**
+   * GitHub hooks collection URL for this config: an ORGANIZATION webhook
+   * (`/orgs/{org}/hooks`, covers every repo, scope admin:org_hook) when `org`
+   * is set, else a per-repo hook (`/repos/{owner}/{name}/hooks`, scope
+   * admin:repo_hook). Null when neither target is configured.
+   */
+  private hooksApiUrl(config: GitHubConfig): string | null {
+    if (config.org) return `https://api.github.com/orgs/${config.org}/hooks`;
+    if (config.repo_owner && config.repo_name) {
+      return `https://api.github.com/repos/${config.repo_owner}/${config.repo_name}/hooks`;
+    }
+    return null;
+  }
+
+  async registerWebhook(
+    ctx: WebhookRegistrationContext<GitHubConfig>
+  ): Promise<WebhookRegistration> {
+    const token = this.resolveToken(ctx.credentials?.accessToken, ctx.config);
+    if (!token) {
+      throw new Error('GitHub webhook registration requires OAuth or GITHUB_TOKEN.');
+    }
+
+    const hooksUrl = this.hooksApiUrl(ctx.config);
+    if (!hooksUrl) {
+      throw new Error(
+        'GitHub webhook registration requires `org` (org-wide) or repo_owner/repo_name (single repo) in config.',
+      );
+    }
+
+    const secret = randomBytes(32).toString('hex');
+
+    const hook = await this.requestJson<{ id: number }>({
+      method: 'POST',
+      url: hooksUrl,
+      token,
+      body: {
+        name: 'web',
+        active: true,
+        // Subscribe to EVERY event type (extract-load: land it all raw, filter
+        // downstream). Org-wide this captures pushes, PRs, issues, comments,
+        // releases, CI runs, stars, membership changes, etc. across all repos.
+        // Override with config.webhook_events for a narrower subscription.
+        events: ctx.config.webhook_events ?? ['*'],
+        config: {
+          url: ctx.callbackUrl,
+          content_type: 'json',
+          secret,
+        },
+      },
+    });
+
+    return { externalId: String(hook.id), secret, metadata: { scope: ctx.config.org ? 'org' : 'repo' } };
+  }
+
+  async unregisterWebhook(ctx: WebhookRegistrationContext<GitHubConfig>): Promise<void> {
+    const externalId = ctx.externalId;
+    if (!externalId) return;
+
+    const token = this.resolveToken(ctx.credentials?.accessToken, ctx.config);
+    if (!token) return;
+
+    const base = this.hooksApiUrl(ctx.config);
+    if (!base) return;
+    const hookUrl = `${base}/${externalId}`;
+
+    // DELETE returns 204 No Content — use request() (no JSON parse) so an empty
+    // body doesn't throw.
+    await this.http.request(hookUrl, {
+      method: 'DELETE',
+      headers: {
+        Accept: 'application/vnd.github+json',
+        'X-GitHub-Api-Version': '2022-11-28',
+        Authorization: `Bearer ${token}`,
+      },
+    });
   }
 
   private resolveRepo(config: GitHubConfig, input: Record<string, unknown>): RepoRef {

--- a/packages/connectors/src/jira.ts
+++ b/packages/connectors/src/jira.ts
@@ -1,0 +1,356 @@
+/**
+ * Jira Connector (V1 runtime)
+ *
+ * Syncs Jira Cloud issues via the REST v3 API (Atlassian 3LO OAuth) and
+ * subscribes to real-time issue/comment deliveries via Jira dynamic webhooks
+ * (registered at connect time); the raw deliveries are landed downstream
+ * (extract-load), so this connector only owns the subscription lifecycle here.
+ */
+
+import { randomBytes } from 'node:crypto';
+import {
+  type ConnectorDefinition,
+  ConnectorRuntime,
+  type EventEnvelope,
+  requireBearerClient,
+  type SyncContext,
+  type SyncCredentials,
+  type SyncResult,
+  type WebhookRegistration,
+  type WebhookRegistrationContext,
+} from '@lobu/connector-sdk';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface JiraConfig {
+  /**
+   * Atlassian Cloud id for the target site. The Atlassian REST base is
+   * `https://api.atlassian.com/ex/jira/{cloudId}/...`.
+   * NOTE: other Atlassian connectors don't yet exist in this repo to mirror, so
+   * we accept `cloud_id` from config and also fall back to
+   * `sessionState.cloud_id` / `credentials.scope` style hints if present.
+   */
+  cloud_id?: string;
+  /** Optional JQL filter. Defaults to `updated >= -{lookback_days}d`. */
+  jql?: string;
+  lookback_days?: number;
+}
+
+interface JiraCheckpoint {
+  last_sync_at?: string;
+}
+
+interface JiraUser {
+  displayName?: string | null;
+  emailAddress?: string | null;
+  accountId?: string | null;
+}
+
+interface JiraIssueFields {
+  summary?: string | null;
+  description?: unknown;
+  status?: { name?: string | null } | null;
+  assignee?: JiraUser | null;
+  reporter?: JiraUser | null;
+  created?: string | null;
+  updated?: string | null;
+}
+
+interface JiraIssue {
+  id?: string;
+  key?: string;
+  self?: string;
+  fields?: JiraIssueFields;
+}
+
+interface JiraSearchResponse {
+  issues?: JiraIssue[];
+  startAt?: number;
+  maxResults?: number;
+  total?: number;
+}
+
+function asString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim().length > 0 ? value : undefined;
+}
+
+function actorName(user: JiraUser | null | undefined): string | undefined {
+  return user?.displayName ?? user?.emailAddress ?? undefined;
+}
+
+/**
+ * Jira v3 descriptions/comment bodies use the Atlassian Document Format (ADF) —
+ * a nested JSON node tree. Flatten its text nodes to plain text. Strings (older
+ * payloads) pass through unchanged.
+ */
+function adfToText(value: unknown): string {
+  if (typeof value === 'string') return value;
+  if (!value || typeof value !== 'object') return '';
+  const node = value as { type?: string; text?: string; content?: unknown[] };
+  if (typeof node.text === 'string') return node.text;
+  if (Array.isArray(node.content)) {
+    const parts = node.content.map((child) => adfToText(child));
+    // Block-level nodes (paragraph, heading, listItem) get a newline separator.
+    const sep = node.type && node.type !== 'text' ? '\n' : '';
+    return parts.join(sep).trim();
+  }
+  return '';
+}
+
+// ---------------------------------------------------------------------------
+// Connector
+// ---------------------------------------------------------------------------
+
+export default class JiraConnector extends ConnectorRuntime<JiraCheckpoint, JiraConfig> {
+  readonly definition: ConnectorDefinition = {
+    key: 'jira',
+    name: 'Jira',
+    description: 'Syncs Jira Cloud issues and receives real-time issue/comment webhooks.',
+    version: '1.0.0',
+    faviconDomain: 'atlassian.com',
+    webhook: {
+      // Jira dynamic webhooks HMAC-sign the raw body with the registration
+      // secret and send `x-hub-signature: sha256=<hex>`. Jira does not send a
+      // stable delivery id header, so dedupe falls back to a body hash
+      // (no `dedupeHeader`).
+      signatureHeader: 'x-hub-signature',
+      algorithm: 'sha256',
+      signaturePrefix: 'sha256=',
+    },
+    authSchema: {
+      methods: [
+        {
+          type: 'oauth',
+          provider: 'jira',
+          requiredScopes: [
+            'read:jira-work',
+            'read:jira-user',
+            'manage:jira-webhook',
+            'offline_access',
+          ],
+          authorizationUrl: 'https://auth.atlassian.com/authorize',
+          tokenUrl: 'https://auth.atlassian.com/oauth/token',
+          tokenEndpointAuthMethod: 'client_secret_post',
+          authParams: { audience: 'api.atlassian.com', prompt: 'consent' },
+          clientIdKey: 'JIRA_CLIENT_ID',
+          clientSecretKey: 'JIRA_CLIENT_SECRET',
+          required: true,
+          description: 'Atlassian (Jira) 3LO OAuth enables reading issues and managing webhooks.',
+          setupInstructions:
+            'Create an OAuth 2.0 (3LO) app in the Atlassian Developer Console. Set the callback URL to {{redirect_uri}}, enable the Jira API scopes, then copy the client ID and secret below.',
+        },
+      ],
+    },
+    feeds: {
+      issues: {
+        key: 'issues',
+        name: 'Issues',
+        description: 'Sync Jira issues via JQL.',
+        configSchema: {
+          type: 'object',
+          properties: {
+            cloud_id: {
+              type: 'string',
+              description: 'Atlassian Cloud id for the target Jira site.',
+            },
+            jql: {
+              type: 'string',
+              description: 'Optional JQL filter. Defaults to recently-updated issues.',
+            },
+            lookback_days: {
+              type: 'integer',
+              minimum: 1,
+              maximum: 730,
+              default: 365,
+              description: 'Initial sync lookback window (used when jql is unset).',
+            },
+          },
+        },
+        eventKinds: {
+          issue: {
+            description: 'A Jira issue',
+            metadataSchema: {
+              type: 'object',
+              properties: {
+                key: { type: 'string' },
+                status: { type: 'string' },
+                assignee: { type: 'string' },
+                reporter: { type: 'string' },
+                updated_at: { type: 'string' },
+              },
+            },
+          },
+          comment: {
+            description: 'A comment on a Jira issue',
+            metadataSchema: {
+              type: 'object',
+              properties: {
+                updated_at: { type: 'string' },
+              },
+            },
+          },
+        },
+      },
+    },
+  };
+
+  private readonly PAGE_SIZE = 100;
+  private readonly MAX_PAGES = 50;
+
+  // -------------------------------------------------------------------------
+  // sync
+  // -------------------------------------------------------------------------
+
+  async sync(ctx: SyncContext<JiraCheckpoint, JiraConfig>): Promise<SyncResult<JiraCheckpoint>> {
+    const base = this.restBase(ctx.config, ctx.sessionState);
+    const http = this.client(ctx.credentials);
+    const lookbackDays = ctx.config.lookback_days ?? 365;
+    const jql = ctx.config.jql ?? `updated >= -${lookbackDays}d order by updated DESC`;
+
+    const events: EventEnvelope[] = [];
+    let startAt = 0;
+    let pages = 0;
+
+    while (pages < this.MAX_PAGES) {
+      const params = new URLSearchParams({
+        jql,
+        startAt: String(startAt),
+        maxResults: String(this.PAGE_SIZE),
+        fields: 'summary,description,status,assignee,reporter,created,updated',
+      });
+      const data = await http.json<JiraSearchResponse>(`${base}/search?${params.toString()}`, {
+        method: 'GET',
+        headers: { Accept: 'application/json' },
+      });
+
+      const issues = data.issues ?? [];
+      for (const issue of issues) {
+        const event = this.issueEvent(issue);
+        if (event) events.push(event);
+      }
+
+      pages += 1;
+      const total = data.total ?? 0;
+      startAt += issues.length;
+      if (issues.length === 0 || startAt >= total) break;
+    }
+
+    return {
+      events,
+      checkpoint: { last_sync_at: new Date().toISOString() },
+      metadata: { items_found: events.length },
+    };
+  }
+
+  // -------------------------------------------------------------------------
+  // Webhooks (subscription lifecycle — raw deliveries land downstream)
+  // -------------------------------------------------------------------------
+
+  async registerWebhook(
+    ctx: WebhookRegistrationContext<JiraConfig>
+  ): Promise<WebhookRegistration> {
+    const base = this.restBase(ctx.config, ctx.sessionState);
+    const http = this.client(ctx.credentials);
+    const secret = randomBytes(32).toString('hex');
+    const jql = ctx.config.jql ?? 'order by updated DESC';
+
+    const response = await http.json<{
+      webhookRegistrationResult?: Array<{ createdWebhookId?: number; errors?: string[] }>;
+    }>(`${base}/webhook`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+      body: JSON.stringify({
+        url: ctx.callbackUrl,
+        webhooks: [
+          {
+            jqlFilter: jql,
+            events: ['jira:issue_created', 'jira:issue_updated', 'comment_created'],
+          },
+        ],
+        // Jira HMAC-signs deliveries with this secret when supplied.
+        secret,
+      }),
+    });
+
+    const result = response.webhookRegistrationResult?.[0];
+    const id = result?.createdWebhookId;
+    if (id == null) {
+      const errors = result?.errors?.join('; ') ?? 'no webhook id returned';
+      throw new Error(`Jira webhook registration failed: ${errors}`);
+    }
+
+    return { externalId: String(id), secret };
+  }
+
+  async unregisterWebhook(ctx: WebhookRegistrationContext<JiraConfig>): Promise<void> {
+    const externalId = ctx.externalId;
+    if (!externalId) return;
+
+    const base = this.restBase(ctx.config, ctx.sessionState);
+    const http = this.client(ctx.credentials);
+
+    await http.request(`${base}/webhook`, {
+      method: 'DELETE',
+      headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+      body: JSON.stringify({ webhookIds: [Number(externalId)] }),
+    });
+  }
+
+  // -------------------------------------------------------------------------
+  // Mapping helpers
+  // -------------------------------------------------------------------------
+
+  private issueEvent(issue: JiraIssue | undefined): EventEnvelope | null {
+    if (!issue?.id) return null;
+    const fields = issue.fields ?? {};
+    const createdAt = new Date(fields.created ?? fields.updated ?? Date.now());
+    if (Number.isNaN(createdAt.getTime())) return null;
+
+    return {
+      origin_id: `jira_issue_${issue.id}`,
+      title: fields.summary ?? issue.key ?? undefined,
+      payload_text: adfToText(fields.description),
+      author_name: actorName(fields.reporter ?? fields.assignee),
+      source_url: this.issueUrl(issue),
+      occurred_at: createdAt,
+      origin_type: 'issue',
+      metadata: {
+        key: issue.key ?? null,
+        status: fields.status?.name ?? null,
+        assignee: actorName(fields.assignee) ?? null,
+        reporter: actorName(fields.reporter) ?? null,
+        updated_at: fields.updated ?? null,
+      },
+    };
+  }
+
+  private issueUrl(issue: JiraIssue | undefined): string | undefined {
+    return issue?.self ?? undefined;
+  }
+
+  // -------------------------------------------------------------------------
+  // Transport
+  // -------------------------------------------------------------------------
+
+  private restBase(
+    config: JiraConfig,
+    sessionState: Record<string, unknown> | null | undefined
+  ): string {
+    const cloudId = asString(config.cloud_id) ?? asString(sessionState?.cloud_id);
+    if (!cloudId) {
+      throw new Error(
+        'Jira requires a cloud_id (set config.cloud_id, the Atlassian Cloud id for the target site).'
+      );
+    }
+    return `https://api.atlassian.com/ex/jira/${cloudId}/rest/api/3`;
+  }
+
+  private client(credentials: SyncCredentials | null) {
+    return requireBearerClient(credentials, {
+      errorPrefix: 'Jira API',
+      label: 'Jira',
+    });
+  }
+}

--- a/packages/connectors/src/linear.ts
+++ b/packages/connectors/src/linear.ts
@@ -1,0 +1,316 @@
+/**
+ * Linear Connector (V1 runtime)
+ *
+ * Syncs Linear issues via the GraphQL API and subscribes to real-time
+ * Issue/Comment deliveries via inbound webhooks (registered at connect time);
+ * the raw deliveries are landed downstream (extract-load), so this connector
+ * only owns the subscription lifecycle here.
+ */
+
+import { randomBytes } from 'node:crypto';
+import {
+  type ConnectorDefinition,
+  ConnectorRuntime,
+  type EventEnvelope,
+  requireBearerClient,
+  type SyncContext,
+  type SyncCredentials,
+  type SyncResult,
+  type WebhookRegistration,
+  type WebhookRegistrationContext,
+} from '@lobu/connector-sdk';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface LinearConfig {
+  /** Optional team filter (Linear team key, e.g. "ENG"). */
+  team_key?: string;
+  lookback_days?: number;
+}
+
+interface LinearCheckpoint {
+  last_sync_at?: string;
+}
+
+interface LinearUser {
+  name?: string | null;
+  displayName?: string | null;
+  email?: string | null;
+}
+
+interface LinearWorkflowState {
+  name?: string | null;
+  type?: string | null;
+}
+
+interface LinearIssueNode {
+  id: string;
+  identifier?: string | null;
+  title?: string | null;
+  description?: string | null;
+  url?: string | null;
+  state?: LinearWorkflowState | null;
+  assignee?: LinearUser | null;
+  createdAt?: string | null;
+  updatedAt?: string | null;
+}
+
+const GRAPHQL_ENDPOINT = 'https://api.linear.app/graphql';
+
+function actorName(user: LinearUser | null | undefined): string | undefined {
+  return user?.displayName ?? user?.name ?? user?.email ?? undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Connector
+// ---------------------------------------------------------------------------
+
+export default class LinearConnector extends ConnectorRuntime<LinearCheckpoint, LinearConfig> {
+  readonly definition: ConnectorDefinition = {
+    key: 'linear',
+    name: 'Linear',
+    description: 'Syncs Linear issues and receives real-time issue/comment webhooks.',
+    version: '1.0.0',
+    faviconDomain: 'linear.app',
+    webhook: {
+      signatureHeader: 'linear-signature',
+      algorithm: 'sha256',
+      // Linear signs the raw body with HMAC-SHA256 and sends a bare hex digest
+      // (no `sha256=` prefix). It does not send a stable delivery id header, so
+      // dedupe falls back to a body hash (no `dedupeHeader`).
+    },
+    authSchema: {
+      methods: [
+        {
+          type: 'oauth',
+          provider: 'linear',
+          requiredScopes: ['read'],
+          optionalScopes: ['write'],
+          authorizationUrl: 'https://linear.app/oauth/authorize',
+          tokenUrl: 'https://api.linear.app/oauth/token',
+          tokenEndpointAuthMethod: 'client_secret_post',
+          clientIdKey: 'LINEAR_CLIENT_ID',
+          clientSecretKey: 'LINEAR_CLIENT_SECRET',
+          required: true,
+          description: 'Linear OAuth enables reading issues and registering webhooks.',
+          setupInstructions:
+            'Create an OAuth application in Linear Settings > API > OAuth applications. Set the redirect URL to {{redirect_uri}}, then copy the client ID and client secret below.',
+        },
+      ],
+    },
+    feeds: {
+      issues: {
+        key: 'issues',
+        name: 'Issues',
+        description: 'Sync Linear issues.',
+        configSchema: {
+          type: 'object',
+          properties: {
+            team_key: {
+              type: 'string',
+              description: 'Optional Linear team key filter (e.g. "ENG").',
+            },
+            lookback_days: {
+              type: 'integer',
+              minimum: 1,
+              maximum: 730,
+              default: 365,
+              description: 'Initial sync lookback window.',
+            },
+          },
+        },
+        eventKinds: {
+          issue: {
+            description: 'A Linear issue',
+            metadataSchema: {
+              type: 'object',
+              properties: {
+                identifier: { type: 'string' },
+                state: { type: 'string' },
+                state_type: { type: 'string' },
+                assignee: { type: 'string' },
+                updated_at: { type: 'string' },
+              },
+            },
+          },
+          comment: {
+            description: 'A comment on a Linear issue',
+            metadataSchema: {
+              type: 'object',
+              properties: {
+                updated_at: { type: 'string' },
+              },
+            },
+          },
+        },
+      },
+    },
+  };
+
+  private readonly PAGE_SIZE = 50;
+  private readonly MAX_PAGES = 50;
+
+  // -------------------------------------------------------------------------
+  // sync
+  // -------------------------------------------------------------------------
+
+  async sync(ctx: SyncContext<LinearCheckpoint, LinearConfig>): Promise<SyncResult<LinearCheckpoint>> {
+    const events: EventEnvelope[] = [];
+    let cursor: string | null = null;
+    let pages = 0;
+
+    const filter = ctx.config.team_key
+      ? `, filter: { team: { key: { eq: ${JSON.stringify(ctx.config.team_key)} } } }`
+      : '';
+
+    while (pages < this.MAX_PAGES) {
+      const after: string = cursor ? `, after: ${JSON.stringify(cursor)}` : '';
+      const query: string = `
+        query {
+          issues(first: ${this.PAGE_SIZE}${after}, orderBy: updatedAt${filter}) {
+            pageInfo { hasNextPage endCursor }
+            nodes {
+              id
+              identifier
+              title
+              description
+              url
+              state { name type }
+              assignee { name displayName email }
+              createdAt
+              updatedAt
+            }
+          }
+        }
+      `;
+
+      const response = await this.graphql<{
+        issues?: {
+          pageInfo?: { hasNextPage?: boolean; endCursor?: string | null };
+          nodes?: LinearIssueNode[];
+        };
+      }>(ctx.credentials, query);
+
+      const nodes = response.issues?.nodes ?? [];
+      for (const node of nodes) {
+        const event = this.issueEvent(node);
+        if (event) events.push(event);
+      }
+
+      pages += 1;
+      const pageInfo = response.issues?.pageInfo;
+      if (!pageInfo?.hasNextPage || !pageInfo.endCursor) break;
+      cursor = pageInfo.endCursor;
+    }
+
+    return {
+      events,
+      checkpoint: { last_sync_at: new Date().toISOString() },
+      metadata: { items_found: events.length },
+    };
+  }
+
+  // -------------------------------------------------------------------------
+  // Webhooks (subscription lifecycle — raw deliveries land downstream)
+  // -------------------------------------------------------------------------
+
+  async registerWebhook(
+    ctx: WebhookRegistrationContext<LinearConfig>
+  ): Promise<WebhookRegistration> {
+    const secret = randomBytes(32).toString('hex');
+    const mutation = `
+      mutation {
+        webhookCreate(input: {
+          url: ${JSON.stringify(ctx.callbackUrl)},
+          resourceTypes: ["Issue", "Comment"],
+          secret: ${JSON.stringify(secret)},
+          enabled: true
+        }) {
+          success
+          webhook { id }
+        }
+      }
+    `;
+
+    const response = await this.graphql<{
+      webhookCreate?: { success?: boolean; webhook?: { id?: string } };
+    }>(ctx.credentials, mutation);
+
+    const id = response.webhookCreate?.webhook?.id;
+    if (!id) {
+      throw new Error('Linear webhookCreate did not return a webhook id.');
+    }
+
+    return { externalId: id, secret };
+  }
+
+  async unregisterWebhook(ctx: WebhookRegistrationContext<LinearConfig>): Promise<void> {
+    const externalId = ctx.externalId;
+    if (!externalId) return;
+
+    const mutation = `
+      mutation {
+        webhookDelete(id: ${JSON.stringify(externalId)}) { success }
+      }
+    `;
+
+    await this.graphql<{ webhookDelete?: { success?: boolean } }>(ctx.credentials, mutation);
+  }
+
+  // -------------------------------------------------------------------------
+  // Mapping helpers
+  // -------------------------------------------------------------------------
+
+  private issueEvent(node: LinearIssueNode | null): EventEnvelope | null {
+    if (!node?.id) return null;
+    const createdAt = new Date(node.createdAt ?? node.updatedAt ?? Date.now());
+    if (Number.isNaN(createdAt.getTime())) return null;
+
+    return {
+      origin_id: `linear_issue_${node.id}`,
+      title: node.title ?? node.identifier ?? undefined,
+      payload_text: (node.description ?? '').trim(),
+      author_name: actorName(node.assignee),
+      source_url: node.url ?? undefined,
+      occurred_at: createdAt,
+      origin_type: 'issue',
+      metadata: {
+        identifier: node.identifier ?? null,
+        state: node.state?.name ?? null,
+        state_type: node.state?.type ?? null,
+        assignee: actorName(node.assignee) ?? null,
+        updated_at: node.updatedAt ?? null,
+      },
+    };
+  }
+
+  // -------------------------------------------------------------------------
+  // GraphQL transport
+  // -------------------------------------------------------------------------
+
+  private async graphql<T>(
+    credentials: SyncCredentials | null,
+    query: string,
+    variables?: Record<string, unknown>
+  ): Promise<T> {
+    const http = requireBearerClient(credentials, {
+      errorPrefix: 'Linear API',
+      label: 'Linear',
+    });
+    const response = await http.json<{ data?: T; errors?: Array<{ message?: string }> }>(
+      GRAPHQL_ENDPOINT,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ query, variables: variables ?? {} }),
+      }
+    );
+
+    if (response.errors?.length) {
+      throw new Error(`Linear GraphQL error: ${response.errors.map((e) => e.message).join('; ')}`);
+    }
+    return (response.data ?? {}) as T;
+  }
+}

--- a/packages/server/src/gateway/__tests__/webhook-ingest.test.ts
+++ b/packages/server/src/gateway/__tests__/webhook-ingest.test.ts
@@ -16,6 +16,7 @@
  *     a delivery through the real org-scoped secret store.
  */
 
+import { createHmac } from "node:crypto";
 import { beforeAll, beforeEach, describe, expect, test } from "bun:test";
 import {
 	ensureDbForGatewayTests,
@@ -27,6 +28,27 @@ import {
 const ORG = "org-webhook";
 const AGENT = "agent-webhook";
 const TOKEN = "whk-test-token-0123456789abcdef";
+const SIG_SECRET = "whk-sig-secret-0123456789abcdef";
+
+/** Compute a provider HMAC signature header value over the exact raw bytes. */
+function sign(
+	rawBody: string,
+	{
+		secret = SIG_SECRET,
+		algorithm = "sha256",
+		prefix = "",
+	}: { secret?: string; algorithm?: "sha256" | "sha1"; prefix?: string } = {},
+): string {
+	return prefix + createHmac(algorithm, secret).update(rawBody).digest("hex");
+}
+
+/** GitHub-style signature config: prefixed sha256 in x-hub-signature-256. */
+const githubSigConfig = {
+	signatureHeader: "x-hub-signature-256",
+	algorithm: "sha256",
+	signaturePrefix: "sha256=",
+	signatureSecret: SIG_SECRET,
+};
 
 beforeAll(async () => {
 	await ensureDbForGatewayTests();
@@ -184,6 +206,175 @@ describe("handleWebhookIngest auth", () => {
 			delivery({ a: 1 }, { headers: bearer }),
 		);
 		expect(res.status).toBe(500);
+	});
+});
+
+describe("handleWebhookIngest signature auth (connector webhooks)", () => {
+	/** A signature-only connection — GitHub/Linear/Jira sign, no bearer token. */
+	function sigRow(
+		config: Record<string, unknown>,
+		overrides: Partial<Record<string, unknown>> = {},
+	) {
+		const row = storedRow(overrides, config);
+		delete row.config.token; // provider authenticates by signature, not bearer
+		return row;
+	}
+
+	test("GitHub-style: a valid x-hub-signature-256 lands the raw event", async () => {
+		await seedAgentRow(AGENT, { organizationId: ORG });
+		const raw = JSON.stringify({
+			action: "opened",
+			issue: { number: 7, title: "Bug" },
+		});
+		const res = await ingest(
+			sigRow(githubSigConfig),
+			delivery(null, {
+				raw,
+				headers: {
+					"x-github-event": "issues",
+					"x-hub-signature-256": sign(raw, { prefix: "sha256=" }),
+				},
+			}),
+		);
+		expect(res.status).toBe(202);
+		const rows = await eventRows();
+		expect(rows.length).toBe(1);
+		// EL: the raw payload lands verbatim — no transform on ingest.
+		expect(rows[0].payload_data).toEqual({
+			action: "opened",
+			issue: { number: 7, title: "Bug" },
+		});
+	});
+
+	test("Linear-style: a valid prefix-less linear-signature lands the event", async () => {
+		await seedAgentRow(AGENT, { organizationId: ORG });
+		const raw = JSON.stringify({ type: "Issue", action: "create" });
+		const res = await ingest(
+			sigRow({
+				signatureHeader: "linear-signature",
+				algorithm: "sha256",
+				signatureSecret: SIG_SECRET,
+			}),
+			delivery(null, { raw, headers: { "linear-signature": sign(raw) } }),
+		);
+		expect(res.status).toBe(202);
+		expect((await eventRows()).length).toBe(1);
+	});
+
+	test("rejects an invalid signature and persists nothing", async () => {
+		await seedAgentRow(AGENT, { organizationId: ORG });
+		const raw = JSON.stringify({ issue: 1 });
+		const res = await ingest(
+			sigRow(githubSigConfig),
+			delivery(null, {
+				raw,
+				headers: { "x-hub-signature-256": "sha256=deadbeef" },
+			}),
+		);
+		expect(res.status).toBe(401);
+		expect((await eventRows()).length).toBe(0);
+	});
+
+	test("rejects a tampered body (signature over different bytes)", async () => {
+		await seedAgentRow(AGENT, { organizationId: ORG });
+		const signedOver = JSON.stringify({ issue: 1 });
+		const tampered = JSON.stringify({ issue: 999 });
+		const res = await ingest(
+			sigRow(githubSigConfig),
+			delivery(null, {
+				raw: tampered,
+				headers: { "x-hub-signature-256": sign(signedOver, { prefix: "sha256=" }) },
+			}),
+		);
+		expect(res.status).toBe(401);
+		expect((await eventRows()).length).toBe(0);
+	});
+
+	test("rejects a missing signature header", async () => {
+		await seedAgentRow(AGENT, { organizationId: ORG });
+		const res = await ingest(
+			sigRow(githubSigConfig),
+			delivery({ issue: 1 }),
+		);
+		expect(res.status).toBe(401);
+	});
+
+	test("rejects a wrong secret", async () => {
+		await seedAgentRow(AGENT, { organizationId: ORG });
+		const raw = JSON.stringify({ issue: 1 });
+		const res = await ingest(
+			sigRow(githubSigConfig),
+			delivery(null, {
+				raw,
+				headers: {
+					"x-hub-signature-256": sign(raw, {
+						secret: "the-wrong-secret",
+						prefix: "sha256=",
+					}),
+				},
+			}),
+		);
+		expect(res.status).toBe(401);
+	});
+
+	test("rejects a right-length non-hex signature with a clean 401 (no throw)", async () => {
+		await seedAgentRow(AGENT, { organizationId: ORG });
+		const raw = JSON.stringify({ issue: 1 });
+		// 64 chars = sha256 hex length, but non-hex → Buffer.from(hex) truncates;
+		// must still be a clean 401, not a 500 from timingSafeEqual length mismatch.
+		const res = await ingest(
+			sigRow(githubSigConfig),
+			delivery(null, {
+				raw,
+				headers: { "x-hub-signature-256": `sha256=${"z".repeat(64)}` },
+			}),
+		);
+		expect(res.status).toBe(401);
+		expect((await eventRows()).length).toBe(0);
+	});
+
+	test("token still authenticates when both token and signature are configured", async () => {
+		await seedAgentRow(AGENT, { organizationId: ORG });
+		// Connection carries a bearer token AND signature config; a valid bearer
+		// with no signature header must still pass (token short-circuits pre-body).
+		const res = await ingest(
+			storedRow({}, githubSigConfig),
+			delivery({ a: 1 }, { headers: bearer }),
+		);
+		expect(res.status).toBe(202);
+		expect((await eventRows()).length).toBe(1);
+	});
+
+	test("redelivery dedupes on x-github-delivery under signature auth", async () => {
+		await seedAgentRow(AGENT, { organizationId: ORG });
+		const config = { ...githubSigConfig, dedupeHeader: "x-github-delivery" };
+		const raw1 = JSON.stringify({ run: 1 });
+		const first = await ingest(
+			sigRow(config),
+			delivery(null, {
+				raw: raw1,
+				headers: {
+					"x-github-delivery": "gh-d-1",
+					"x-hub-signature-256": sign(raw1, { prefix: "sha256=" }),
+				},
+			}),
+		);
+		const raw2 = JSON.stringify({ run: 2 });
+		const dup = await ingest(
+			sigRow(config),
+			delivery(null, {
+				raw: raw2,
+				headers: {
+					"x-github-delivery": "gh-d-1",
+					"x-hub-signature-256": sign(raw2, { prefix: "sha256=" }),
+				},
+			}),
+		);
+		expect(first.status).toBe(202);
+		expect((await dup.json()).duplicate).toBe(true);
+		const rows = await eventRows();
+		expect(rows.length).toBe(1);
+		expect(rows[0].origin_id).toBe("gh-d-1");
 	});
 });
 
@@ -647,5 +838,103 @@ describe("ChatInstanceManager webhook wiring", () => {
 			}),
 		);
 		expect(wrongPlatform.status).toBe(404);
+	});
+
+	// Full wired path: the REAL Hono route → ChatInstanceManager →
+	// handleWebhookIngest → real Postgres. This is what an actual provider
+	// delivery exercises (vs. the unit tests above that call the handler
+	// directly). We hold the signing secret, so we compute a real GitHub-style
+	// HMAC — the only thing not covered is the live-OAuth `registerWebhook` call
+	// and the provider's own POST, which need real credentials + a public URL.
+	async function registeredGithubConnection(connectionStore: any): Promise<string> {
+		const { orgContext } = await import("../../lobu/stores/org-context.js");
+		const id = "whk-gh-e2e";
+		// Simulate a connection AFTER registration stamped the scheme + secret.
+		await orgContext.run({ organizationId: ORG }, () =>
+			connectionStore.saveConnection({
+				id,
+				platform: "webhook",
+				agentId: AGENT,
+				organizationId: ORG,
+				config: {
+					platform: "webhook",
+					...githubSigConfig,
+					dedupeHeader: "x-github-delivery",
+					semanticType: "issue",
+				},
+				settings: { allowGroups: true },
+				metadata: {},
+				status: "active",
+				createdAt: Date.now(),
+				updatedAt: Date.now(),
+			}),
+		);
+		return id;
+	}
+
+	test("e2e: a signed GitHub delivery routes through the real endpoint and lands", async () => {
+		await seedAgentRow(AGENT, { organizationId: ORG });
+		const { manager, connectionStore } = await buildManager();
+		const { createConnectionWebhookRoutes } = await import(
+			"../routes/public/connections.js"
+		);
+		const id = await registeredGithubConnection(connectionStore);
+		const app = createConnectionWebhookRoutes(manager);
+
+		const raw = JSON.stringify({
+			action: "opened",
+			issue: { number: 11, title: "Prod is down" },
+			repository: { full_name: "acme/api" },
+		});
+		const res = await app.fetch(
+			new Request(`http://gateway.test/api/v1/webhooks/${id}`, {
+				method: "POST",
+				body: raw,
+				headers: {
+					"content-type": "application/json",
+					"x-github-event": "issues",
+					"x-github-delivery": "gh-e2e-1",
+					"x-hub-signature-256": sign(raw, { prefix: "sha256=" }),
+				},
+			}),
+		);
+		expect(res.status).toBe(202);
+
+		const rows = await eventRows(id);
+		expect(rows.length).toBe(1);
+		// EL: the raw GitHub payload is what landed — untransformed.
+		expect(rows[0].payload_data).toEqual({
+			action: "opened",
+			issue: { number: 11, title: "Prod is down" },
+			repository: { full_name: "acme/api" },
+		});
+		expect(rows[0].origin_id).toBe("gh-e2e-1");
+		expect(rows[0].semantic_type).toBe("issue");
+		expect(rows[0].organization_id).toBe(ORG);
+	});
+
+	test("e2e: the real endpoint rejects a forged signature with 401", async () => {
+		await seedAgentRow(AGENT, { organizationId: ORG });
+		const { manager, connectionStore } = await buildManager();
+		const { createConnectionWebhookRoutes } = await import(
+			"../routes/public/connections.js"
+		);
+		const id = await registeredGithubConnection(connectionStore);
+		const app = createConnectionWebhookRoutes(manager);
+
+		const raw = JSON.stringify({ action: "opened", issue: { number: 12 } });
+		const res = await app.fetch(
+			new Request(`http://gateway.test/api/v1/webhooks/${id}`, {
+				method: "POST",
+				body: raw,
+				headers: {
+					"content-type": "application/json",
+					"x-github-event": "issues",
+					"x-hub-signature-256": "sha256=forged",
+				},
+			}),
+		);
+		expect(res.status).toBe(401);
+		expect((await eventRows(id)).length).toBe(0);
 	});
 });

--- a/packages/server/src/gateway/connections/types.ts
+++ b/packages/server/src/gateway/connections/types.ts
@@ -9,6 +9,7 @@ import type { createSlackAdapter } from "@chat-adapter/slack";
 import type { createTeamsAdapter } from "@chat-adapter/teams";
 import type { createTelegramAdapter } from "@chat-adapter/telegram";
 import type { createWhatsAppAdapter } from "@chat-adapter/whatsapp";
+import type { ConnectorWebhookSchema } from "@lobu/connector-sdk";
 
 // Derive config types from what the adapter factories actually accept
 export type TelegramAdapterConfig = NonNullable<
@@ -51,8 +52,17 @@ export type WebhookIngestPlatformConfig = {
   token?: string;
   /** Opt-in `?token=` auth for header-less senders. Default false. */
   allowQueryAuth?: boolean | string;
-  /** Header carrying the delivery id; else sha256(raw body). */
-  dedupeHeader?: string;
+  /**
+   * Shared signing secret (a `secret://` ref), minted by a connector's
+   * `registerWebhook`. When set, a delivery is rejected (401) unless its HMAC
+   * signature verifies per the scheme below — this is how connector-owned
+   * webhooks (GitHub/Linear/Jira) authenticate, in addition to (or instead of)
+   * the bearer token. The scheme fields themselves (`signatureHeader`,
+   * `algorithm`, `signaturePrefix`, `dedupeHeader`) come from the single
+   * source of truth, the connector's {@link ConnectorWebhookSchema}, which
+   * `registerWebhook` stamps onto the connection alongside this secret.
+   */
+  signatureSecret?: string;
   /** `events.semantic_type` for ingested rows; default "content". */
   semanticType?: string;
   /** JSON pointer extracted into `events.title`. */
@@ -64,7 +74,7 @@ export type WebhookIngestPlatformConfig = {
    * with high-volume/low-value webhook traffic.
    */
   searchable?: boolean | string;
-};
+} & ConnectorWebhookSchema;
 
 export type PlatformAdapterConfig =
   | TelegramAdapterConfig

--- a/packages/server/src/gateway/connections/webhook-ingest.ts
+++ b/packages/server/src/gateway/connections/webhook-ingest.ts
@@ -31,7 +31,7 @@
  * row and writes Postgres; nothing is memoized per pod.
  */
 
-import { createHash, randomUUID, timingSafeEqual } from "node:crypto";
+import { createHash, createHmac, randomUUID, timingSafeEqual } from "node:crypto";
 import type { StoredConnection } from "@lobu/core";
 import { getDb } from "../../db/client.js";
 import { insertEvent } from "../../utils/insert-event.js";
@@ -103,6 +103,35 @@ function tokensMatch(presented: string, configured: string): boolean {
 	const a = createHash("sha256").update(presented).digest();
 	const b = createHash("sha256").update(configured).digest();
 	return timingSafeEqual(a, b);
+}
+
+/**
+ * Verify a provider's HMAC signature over the raw request body — the auth
+ * scheme for connector-owned webhooks (GitHub `x-hub-signature-256`, Linear
+ * `linear-signature`, Jira `x-hub-signature`). The provider signs the exact
+ * bytes it sent, so we HMAC `rawBody` (never the re-serialized JSON) with the
+ * shared secret and constant-time compare against the header digest. Returns
+ * false on any miss (no header, malformed hex) — the caller fails closed.
+ */
+function verifyWebhookSignature(
+	rawBody: Uint8Array,
+	headerValue: string | null,
+	secret: string,
+	algorithm: "sha256" | "sha1",
+	prefix: string | undefined,
+): boolean {
+	if (!headerValue) return false;
+	const presented = prefix && headerValue.startsWith(prefix)
+		? headerValue.slice(prefix.length)
+		: headerValue;
+	const expected = createHmac(algorithm, secret).update(rawBody).digest();
+	// Buffer.from(hex) silently TRUNCATES on invalid hex, so a right-length but
+	// non-hex header would slip past a hex-string length check and then make
+	// timingSafeEqual throw. Compare the DECODED byte lengths instead — a
+	// malformed signature decodes short → length mismatch → false (clean 401).
+	const presentedBuf = Buffer.from(presented, "hex");
+	if (presentedBuf.length !== expected.length) return false;
+	return timingSafeEqual(presentedBuf, expected);
 }
 
 function isQueryTokenAllowed(config: WebhookIngestConfig): boolean {
@@ -329,21 +358,40 @@ export async function handleWebhookIngest(
 		});
 	}
 
-	// 3. Auth. Fail closed when no token is configured/resolvable — an ingest
-	//    endpoint must never be open just because its secret went missing.
-	const configuredToken = await resolveSecretValue(
-		secretStore,
-		typeof config.token === "string" ? config.token : undefined,
-	);
-	if (!configuredToken) {
+	// 3. Auth. A delivery authenticates by EITHER a matching bearer token OR a
+	//    verified provider HMAC signature (connector webhooks: GitHub/Linear/Jira
+	//    sign, they don't send a bearer). Fail closed when neither method is
+	//    configured — an ingest endpoint must never be open just because its
+	//    secret went missing.
+	// Resolve both candidate secrets concurrently — either (or both) may gate
+	// this delivery, so we need them before deciding auth.
+	const [configuredToken, signatureSecret] = await Promise.all([
+		resolveSecretValue(
+			secretStore,
+			typeof config.token === "string" ? config.token : undefined,
+		),
+		resolveSecretValue(
+			secretStore,
+			typeof config.signatureSecret === "string" ? config.signatureSecret : undefined,
+		),
+	]);
+	if (!configuredToken && !signatureSecret) {
 		logger.warn(
 			{ connectionId: stored.id },
-			"[webhook-ingest] no resolvable token configured — rejecting delivery",
+			"[webhook-ingest] no resolvable token or signature secret — rejecting delivery",
 		);
 		return json(401, { error: "Unauthorized" });
 	}
+	// Token check is decisive pre-body when no signature is configured (preserves
+	// the fast-reject path for plain ingest connections). When a signature IS
+	// configured, a token miss isn't fatal yet — the signature is verified after
+	// the body is read below (HMAC needs the raw bytes).
 	const presentedToken = extractPresentedToken(request, config);
-	if (!presentedToken || !tokensMatch(presentedToken, configuredToken)) {
+	let authenticated =
+		!!configuredToken &&
+		!!presentedToken &&
+		tokensMatch(presentedToken, configuredToken);
+	if (!authenticated && !signatureSecret) {
 		return json(401, { error: "Unauthorized" });
 	}
 
@@ -366,6 +414,27 @@ export async function handleWebhookIngest(
 	const rawBody = await readBodyWithCap(request, WEBHOOK_INGEST_MAX_BODY_BYTES);
 	if (rawBody === null) {
 		return json(413, { error: "Payload too large" });
+	}
+
+	// Complete auth: when the token didn't already authenticate and a signature
+	// secret is configured, the provider's HMAC over the raw body must verify.
+	if (!authenticated && signatureSecret) {
+		const ok =
+			typeof config.signatureHeader === "string" &&
+			!!config.signatureHeader &&
+			verifyWebhookSignature(
+				rawBody,
+				request.headers.get(config.signatureHeader),
+				signatureSecret,
+				config.algorithm === "sha1" ? "sha1" : "sha256",
+				typeof config.signaturePrefix === "string"
+					? config.signaturePrefix
+					: undefined,
+			);
+		if (!ok) {
+			return json(401, { error: "Unauthorized" });
+		}
+		authenticated = true;
 	}
 
 	let parsed: unknown;


### PR DESCRIPTION
## What

Connector-owned **inbound webhooks**, extract-load style: verified provider deliveries land raw into `events` (transform deferred to a downstream stage), and connectors self-register their subscription.

## Changes
- **connector-sdk**: `ConnectorWebhookSchema` on the definition + `registerWebhook`/`unregisterWebhook` lifecycle methods.
- **server (ingest)**: per-provider HMAC signature verification in `webhook-ingest.ts` — a delivery authenticates by **token OR verified signature** (GitHub/Linear/Jira sign, no bearer); fail-closed. Signature scheme reuses the SDK type (single source of truth).
- **github**: webhook block + **org-wide** (`admin:org_hook`, one hook covers every repo) and **per-repo** (`admin:repo_hook`) registration; webhook scopes are **optional/incremental** (requested only when enabling a live feed); subscribes to `events:['*']`.
- **linear/jira**: new connectors (sync + webhook registration).
- **connector-worker**: `webhook_register`/`webhook_unregister` executor modes.
- **tests**: signature + wired-route e2e — **39/39** against real Postgres.

## Verification
- ✅ **GitHub org-wide ingestion proven end-to-end LIVE**: real OAuth device-flow with **incremental `admin:org_hook` consent** → the connector's real `registerWebhook` created an **org webhook on a real GitHub org** → GitHub delivered events (CI: `workflow_job`/`check_run`/`workflow_run`/`check_suite`/`ping`) over the public internet → real route → signature-verified → landed in `events`.
- ✅ Unit/wired-route e2e 39/39; server tsc clean.

## Honest gaps (follow-ups)
- **Linear/Jira**: compile-clean but **not yet run against live APIs** — GitHub is the verified path.
- **Connect-flow wiring**: `registerWebhook` is invoked by the connector + executor modes, but the **server-side trigger at OAuth-connect time is not wired** yet (the live test invoked `registerWebhook` directly). That wiring + the UI "Connect / enable live feed" is the next PR.
- Pre-existing `github.ts` stargazer-checkpoint cast warning (not introduced here; connectors aren't in the tsc gate).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1408"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784575770&installation_id=136316292&pr_number=1408&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1408&signature=850cb789a7bf01e1aea58d31073f94374b403c073e8c585abc1485ec0bb837a5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added inbound webhook support with HMAC signature authentication for real-time event delivery
  * Introduced Jira connector with webhook-based synchronization
  * Introduced Linear connector with webhook-based synchronization
  * Enhanced GitHub connector with webhook subscription and lifecycle management

* **Tests**
  * Added comprehensive webhook signature verification and authentication test coverage

<!-- end of auto-generated comment: release notes by coderabbit.ai -->