### PR TITLE
feat(agents): builder agent — manage the workspace from chat

### DIFF
--- a/db/migrations/20260619130000_org_system_agent_id.sql
+++ b/db/migrations/20260619130000_org_system_agent_id.sql
@@ -1,0 +1,23 @@
+-- migrate:up
+
+-- Per-org pointer to the org's "system" agent — the builder/console agent that
+-- backs the org-management surface. This is a server-controlled pointer only:
+-- the sole writer is manage_agents.set_system_agent (plus default-org
+-- provisioning); it is never set by ordinary agent CRUD.
+--
+-- No FK to public.agents: agent ids are NOT globally unique — agents has a
+-- composite PK (organization_id, id), so a single-column FK can't reference it.
+-- This is an app-level pointer scoped by the row's own organization_id; the
+-- writer (set_system_agent) verifies the target agent exists in this org before
+-- updating, and manage_agents.delete refuses to drop the agent it points at.
+--
+-- Additive nullable ADD COLUMN: rolling-deploy safe (old replicas ignore the
+-- column, new replicas treat NULL as "no system agent"), so there's no
+-- expand/contract concern.
+ALTER TABLE public.organization ADD COLUMN IF NOT EXISTS system_agent_id text;
+
+COMMENT ON COLUMN public.organization.system_agent_id IS 'Per-org pointer to the builder/console (system) agent (agents.id within this org). Server-controlled only — written exclusively by manage_agents.set_system_agent and default-org provisioning, never by ordinary agent CRUD. No FK because agents has a composite PK (organization_id, id); this is an app-level, org-scoped pointer.';
+
+-- migrate:down
+
+ALTER TABLE public.organization DROP COLUMN IF EXISTS system_agent_id;

--- a/packages/core/src/worker/auth.ts
+++ b/packages/core/src/worker/auth.ts
@@ -61,6 +61,15 @@ export interface WorkerTokenData {
    * tokens do NOT carry it.
    */
   messageId?: string;
+  /**
+   * Per-turn allowlist of internal admin tool NAMES this token may call.
+   * Set ONLY for the org's builder/system agent (id === organization.
+   * system_agent_id) when the human driving the turn is an org owner/admin
+   * (see `resolveBuilderAdminTools`). Enforced exact-name at the execute gate
+   * (`tools/execute.ts`); absent for every normal agent/turn, so a forged or
+   * normal token grants no admin access.
+   */
+  adminTools?: string[];
 }
 
 export function generateWorkerToken(
@@ -92,6 +101,10 @@ export function generateWorkerToken(
      * WorkerTokenData.messageId.
      */
     messageId?: string;
+    /**
+     * Builder admin-tool allowlist for this turn. See WorkerTokenData.adminTools.
+     */
+    adminTools?: string[];
   }
 ): string {
   if (!options.channelId) {
@@ -115,6 +128,7 @@ export function generateWorkerToken(
     jti: randomUUID(),
     runId: options.runId,
     messageId: options.messageId,
+    adminTools: options.adminTools,
   };
 
   return encrypt(JSON.stringify(payload));
@@ -174,6 +188,18 @@ export function verifyWorkerToken(token: string): WorkerTokenData | null {
         data.runId <= 0
       ) {
         logger.error("Worker token rejected: runId must be a positive integer");
+        return null;
+      }
+    }
+    // `adminTools` is optional but must be a string[] when present — a forged
+    // token with a non-array (or non-string elements) must be rejected, not
+    // coerced, before the execute gate trusts it to allow internal tools.
+    if (data.adminTools !== undefined) {
+      if (
+        !Array.isArray(data.adminTools) ||
+        !data.adminTools.every((t) => typeof t === "string")
+      ) {
+        logger.error("Worker token rejected: adminTools must be a string[]");
         return null;
       }
     }

--- a/packages/server/src/__tests__/integration/tools/all-tools-e2e.test.ts
+++ b/packages/server/src/__tests__/integration/tools/all-tools-e2e.test.ts
@@ -163,6 +163,11 @@ describe("all agent MCP tools — registry-driven e2e (model-free)", () => {
 				coverage: "reachable",
 				note: "lists connections for the org",
 			},
+			manage_agents: {
+				args: { action: "list" },
+				coverage: "reachable",
+				note: "lists agents for the org",
+			},
 			manage_feeds: {
 				args: { action: "list_feeds" },
 				coverage: "reachable",

--- a/packages/server/src/auth/builder-provisioning.ts
+++ b/packages/server/src/auth/builder-provisioning.ts
@@ -1,0 +1,222 @@
+/**
+ * Builder-agent auto-provisioning.
+ *
+ * Every org gets a dedicated "builder" agent — the org's setup/console agent
+ * that manages agents, connections, watchers, and workflows on the user's
+ * behalf. `organization.system_agent_id` points at it.
+ *
+ * Mirrors `default-provisioning.ts` exactly:
+ *   - installs system-key model providers up front (so the agent can chat the
+ *     moment it's created, instead of "No model configured"),
+ *   - attributes ownership to the personal-org owner via the
+ *     `personal_org_for_user_id` org-metadata marker,
+ *   - writes a sentinel into `organization.metadata` so a deleted builder agent
+ *     is NOT auto-recreated,
+ *   - is best-effort / non-throwing: a failure here must never break the boot
+ *     or signup path that called us.
+ *
+ * The agents PK is composite `(organization_id, id)`, so the same
+ * `BUILDER_AGENT_ID` string per org is fine. The `system_agent_id` pointer is
+ * only set when currently NULL — we never clobber an admin's explicit choice
+ * (set via `manage_agents.set_system_agent`).
+ */
+
+import { getDb } from '../db/client';
+import type { DbClient } from '../db/client';
+import { getModelProviderModules } from '../gateway/modules/module-system';
+import { collectProviderModelOptions } from '../gateway/auth/provider-model-options';
+import logger from '../utils/logger';
+import { hasOrgSentinel } from './default-provisioning';
+
+export const BUILDER_AGENT_ID = 'lobu-builder';
+export const BUILDER_AGENT_SENTINEL = 'builder_agent_provisioned';
+
+const BUILDER_AGENT_NAME = 'Builder';
+const BUILDER_AGENT_IDENTITY =
+  "You are the organization's Builder — its setup and management assistant. " +
+  'You help the owner configure their workspace: creating and editing agents, ' +
+  'wiring up connections and integrations, setting up watchers and scheduled ' +
+  'workflows, and keeping the org healthy. ' +
+  'Be concrete and action-oriented; prefer making the change over describing it. ' +
+  "If you don't yet have access to something the user wants to manage, say so " +
+  'clearly and suggest what they could connect or grant next.';
+
+/**
+ * Read the JSON-decoded `organization.metadata` for the given org. Returns an
+ * empty object if the row is missing or the JSON is invalid. Replicated from
+ * default-provisioning (its copy is module-private) so we read the same
+ * `personal_org_for_user_id` marker tenant-safely.
+ */
+async function readOrgMetadata(
+  sql: DbClient,
+  organizationId: string
+): Promise<Record<string, unknown>> {
+  const rows = (await sql`
+    SELECT metadata FROM "organization" WHERE id = ${organizationId} LIMIT 1
+  `) as unknown as Array<{ metadata: string | null }>;
+  const raw = rows[0]?.metadata;
+  if (!raw) return {};
+  try {
+    const parsed = JSON.parse(raw);
+    return typeof parsed === 'object' && parsed !== null
+      ? (parsed as Record<string, unknown>)
+      : {};
+  } catch {
+    return {};
+  }
+}
+
+/**
+ * Merge a sentinel key into `organization.metadata` and write it back as
+ * JSON-text. Read-modify-write of the whole metadata blob, matching
+ * default-provisioning's `writeOrgSentinel`.
+ */
+async function writeOrgSentinel(
+  sql: DbClient,
+  organizationId: string,
+  key: string,
+  value: string
+): Promise<void> {
+  const current = await readOrgMetadata(sql, organizationId);
+  current[key] = value;
+  const serialized = JSON.stringify(current);
+  await sql`
+    UPDATE "organization" SET metadata = ${serialized} WHERE id = ${organizationId}
+  `;
+}
+
+/**
+ * Provision the org's builder agent and point `organization.system_agent_id`
+ * at it, exactly once.
+ *
+ * Guards on the create path:
+ *   1. Sentinel in `organization.metadata` (deletion stickiness — a deleted
+ *      builder agent is NOT auto-recreated).
+ *   2. ON CONFLICT (organization_id, id) DO NOTHING on the agents PK (guards a
+ *      parallel boot / concurrent signup).
+ *
+ * The `system_agent_id` pointer is only written when it's currently NULL, so an
+ * admin who later repoints it via `manage_agents.set_system_agent` is never
+ * clobbered on a subsequent boot.
+ *
+ * Best-effort: a thrown error is logged and swallowed.
+ */
+export async function ensureBuilderAgent(
+  organizationId: string,
+  sql?: DbClient
+): Promise<{ created: boolean }> {
+  const client = sql ?? getDb();
+  try {
+    const provisioned = await hasOrgSentinel(
+      organizationId,
+      BUILDER_AGENT_SENTINEL,
+      client
+    );
+    if (provisioned) {
+      return { created: false };
+    }
+
+    // Resolve the set of model providers that have a system-level credential
+    // available at this boot and install them onto the builder agent up front.
+    // Without this, the row exists but `installed_providers = '[]'` and chatting
+    // with the builder agent would immediately hit "No model configured" — even
+    // though the env keys are sitting right there in the same process.
+    const systemProviders = getModelProviderModules()
+      .filter((m) => m.hasSystemKey())
+      .map((m) => ({
+        providerId: m.providerId,
+        installedAt: Date.now(),
+      }));
+
+    // Pin an explicit model so the builder can chat the moment it's created.
+    // Auto-mode no longer silently picks a provider default (an explicit model
+    // is required), so without this the first turn hits "No model selected".
+    // Pick the first installed system provider that exposes a model list and
+    // pin its first option as `provider/model` (the format resolveEffectiveModelRef
+    // expects). Best-effort: if nothing resolves, leave the model unset — the
+    // owner then picks one in the agent's Providers settings, same as any agent.
+    let pinnedModel: string | null = null;
+    try {
+      const optionsByProvider = await collectProviderModelOptions('', '');
+      for (const p of systemProviders) {
+        const first = optionsByProvider[p.providerId]?.[0]?.value?.trim();
+        if (first) {
+          pinnedModel = first.includes('/') ? first : `${p.providerId}/${first}`;
+          break;
+        }
+      }
+    } catch (err) {
+      logger.warn(
+        { organizationId, err: err instanceof Error ? err.message : String(err) },
+        '[builder-provisioning] Default-model resolution failed; leaving model unset'
+      );
+    }
+
+    // Resolve the owning user from the canonical personal-org marker, so the
+    // per-user ownership check in `verifyOwnedAgentAccess` recognizes the owner
+    // as the builder agent's owner.
+    const orgMetadata = await readOrgMetadata(client, organizationId);
+    const ownerForInsertRaw = orgMetadata['personal_org_for_user_id'];
+    const ownerUserId =
+      typeof ownerForInsertRaw === 'string' && ownerForInsertRaw.length > 0
+        ? ownerForInsertRaw
+        : null;
+
+    await client`
+      INSERT INTO agents (
+        id, organization_id, name, identity_md,
+        owner_platform, owner_user_id,
+        installed_providers, model,
+        created_at, updated_at
+      ) VALUES (
+        ${BUILDER_AGENT_ID}, ${organizationId}, ${BUILDER_AGENT_NAME}, ${BUILDER_AGENT_IDENTITY},
+        'external', ${ownerUserId},
+        ${client.json(systemProviders)}, ${pinnedModel},
+        NOW(), NOW()
+      )
+      ON CONFLICT (organization_id, id) DO NOTHING
+    `;
+
+    // Mirror the ownership into agent_users so the per-user ownership path
+    // (cookie/PAT session) recognizes the owner as the builder agent's owner.
+    if (ownerUserId) {
+      await client`
+        INSERT INTO agent_users (organization_id, agent_id, platform, user_id, created_at)
+        VALUES (${organizationId}, ${BUILDER_AGENT_ID}, 'external', ${ownerUserId}, now())
+        ON CONFLICT (organization_id, agent_id, platform, user_id) DO NOTHING
+      `;
+    }
+
+    // Point the org at the builder agent — but only if no pointer is set yet.
+    // An admin who repointed `system_agent_id` (via manage_agents) must not be
+    // clobbered.
+    await client`
+      UPDATE "organization"
+      SET system_agent_id = ${BUILDER_AGENT_ID}
+      WHERE id = ${organizationId}
+        AND system_agent_id IS NULL
+    `;
+
+    await writeOrgSentinel(
+      client,
+      organizationId,
+      BUILDER_AGENT_SENTINEL,
+      new Date().toISOString()
+    );
+
+    logger.info(
+      { organizationId, agentId: BUILDER_AGENT_ID, ownerUserId },
+      '[builder-provisioning] Provisioned builder agent'
+    );
+    return { created: true };
+  } catch (err) {
+    logger.warn(
+      {
+        organizationId,
+        err: err instanceof Error ? err.message : String(err),
+      },
+      '[builder-provisioning] Builder-agent provisioning failed (non-fatal)'
+    );
+    return { created: false };
+  }
+}

--- a/packages/server/src/auth/default-provisioning.ts
+++ b/packages/server/src/auth/default-provisioning.ts
@@ -240,8 +240,14 @@ export async function ensureDefaultAgent(
       return { created: false, reason: 'sentinel' };
     }
 
+    // Ignore the auto-provisioned builder/system agent ('lobu-builder', see
+    // builder-provisioning.ts BUILDER_AGENT_ID) — it's provisioned on the same
+    // org-creation paths, so counting it here would wrongly trip the
+    // "org already has agents" guard and skip the default personal agent.
     const existingAgents = (await client`
-      SELECT 1 FROM agents WHERE organization_id = ${organizationId} LIMIT 1
+      SELECT 1 FROM agents
+      WHERE organization_id = ${organizationId} AND id <> 'lobu-builder'
+      LIMIT 1
     `) as unknown as Array<unknown>;
     if (existingAgents.length > 0) {
       // Still write the sentinel so we don't re-check on every boot.

--- a/packages/server/src/auth/install-operator.ts
+++ b/packages/server/src/auth/install-operator.ts
@@ -16,6 +16,7 @@ import { hostname } from 'node:os';
 import { hashPassword } from 'better-auth/crypto';
 import { assertEncryptionKey } from '@lobu/core';
 import { getDb } from '../db/client';
+import { ensureBuilderAgent } from './builder-provisioning';
 import { generateSecureToken } from './oauth/utils';
 import { ensurePersonalOrganization } from './personal-org-provisioning';
 
@@ -118,12 +119,15 @@ export async function ensureInstallOperator(): Promise<{
   // closes the gap where a transient failure on first boot used to
   // leave the operator without a personal org forever.
   try {
-    await ensurePersonalOrganization({
+    const personalOrg = await ensurePersonalOrganization({
       id: userId,
       email: installOperatorEmail(),
       name: 'Local Install',
       username: null,
     });
+    // Builder (system) agent for the operator's personal org. Idempotent
+    // (sentinel-guarded) and best-effort — never break the boot path.
+    await ensureBuilderAgent(personalOrg.organizationId);
   } catch (err) {
     console.error(
       '[install-operator] Personal-org provisioning failed; will retry on next boot:',

--- a/packages/server/src/auth/oauth/types.ts
+++ b/packages/server/src/auth/oauth/types.ts
@@ -215,6 +215,13 @@ export interface AuthInfo {
    * (Mac/iOS bridges register theirs on first poll).
    */
   workerId?: string | null;
+  /**
+   * Per-turn builder admin-tool allowlist, carried from a verified worker
+   * token (WorkerTokenData.adminTools) into the request's auth info so the
+   * execute gate can permit the org's builder agent to call its allowlisted
+   * internal tools. Absent for every non-builder caller.
+   */
+  adminTools?: string[] | null;
 }
 
 // ============================================

--- a/packages/server/src/auth/personal-org-provisioning.ts
+++ b/packages/server/src/auth/personal-org-provisioning.ts
@@ -10,6 +10,7 @@
 import { slugify as slugifyBase } from "@lobu/core";
 import { getDb } from "../db/client";
 import { RESERVED_PATHS_SET } from "../utils/reserved";
+import { ensureBuilderAgent } from "./builder-provisioning";
 import { generateSecureToken } from "./oauth/utils";
 import { provisionMemberAndCoreIdentities } from "./subject-identities";
 
@@ -209,6 +210,20 @@ export async function ensurePersonalOrganization(
 				},
 			);
 		}
+	}
+
+	// Provision the org's builder (system) agent and point
+	// organization.system_agent_id at it. Idempotent (sentinel-guarded) so it's
+	// safe to run for both newly created and pre-existing personal orgs;
+	// best-effort so a failure can't roll back / break the org creation.
+	try {
+		await ensureBuilderAgent(finalResult.organizationId);
+	} catch (error) {
+		console.error("[Auth] Failed to provision builder agent for personal org:", {
+			orgId: finalResult.organizationId,
+			userId: user.id,
+			error: String(error),
+		});
 	}
 
 	return finalResult;

--- a/packages/server/src/auth/tool-access.ts
+++ b/packages/server/src/auth/tool-access.ts
@@ -89,6 +89,14 @@ const OWNER_ADMIN_ACTIONS: Record<string, Set<string>> = {
     'submit_feedback',
     'create_from_version',
   ]),
+  manage_agents: new Set([
+    'list',
+    'get',
+    'create',
+    'update',
+    'delete',
+    'set_system_agent',
+  ]),
   manage_classifiers: new Set([
     'create',
     'create_version',

--- a/packages/server/src/gateway/gateway/index.ts
+++ b/packages/server/src/gateway/gateway/index.ts
@@ -810,6 +810,9 @@ export class WorkerGateway {
         traceId: tokenData.traceId,
         runId: tokenData.runId,
         messageId: tokenData.messageId,
+        // Preserve the builder admin-tool allowlist across refresh — otherwise a
+        // long system-agent turn loses its admin grant when the token rotates.
+        adminTools: tokenData.adminTools,
       }
     );
 

--- a/packages/server/src/gateway/orchestration/message-consumer.ts
+++ b/packages/server/src/gateway/orchestration/message-consumer.ts
@@ -35,6 +35,7 @@ import {
   type OrchestratorConfig,
 } from "./base-deployment-manager.js";
 import { buildWorkerTokenClaims } from "./worker-token-claims.js";
+import { getDb } from "../../db/client.js";
 
 const logger = createLogger("orchestrator");
 
@@ -54,6 +55,59 @@ const logger = createLogger("orchestrator");
  * the worker then falls back to the deployment-lifetime WORKER_TOKEN and the
  * snapshot route declines to write.
  */
+/**
+ * Internal admin tools the org's builder agent may call from its worker. The
+ * grant rides the per-run worker token (set in `resolveBuilderAdminTools` only
+ * for the system agent on an owner/admin-initiated turn) and is enforced
+ * tool-by-tool at the execute gate. Keep this in lockstep with the gate's
+ * exact-name check in `tools/execute.ts`.
+ */
+export const BUILDER_ADMIN_TOOLS = [
+  "manage_agents",
+  "manage_connections",
+  "manage_feeds",
+  "manage_watchers",
+  "manage_schedules",
+  "manage_entity",
+] as const;
+
+/**
+ * Decide whether THIS turn's worker token should carry the builder admin-tool
+ * grant. Returns the allowlist only when the target agent is the org's system
+ * agent (`organization.system_agent_id`) AND the human sending the message is an
+ * org owner/admin. Fails closed (returns undefined) on any lookup error — a
+ * missing grant just means the model can't see/call the admin tools, never an
+ * over-grant. One indexed query (org PK + member join); runs per turn.
+ */
+export async function resolveBuilderAdminTools(args: {
+  agentId?: string;
+  organizationId?: string;
+  userId?: string;
+}): Promise<string[] | undefined> {
+  if (!args.agentId || !args.organizationId || !args.userId) return undefined;
+  try {
+    const sql = getDb();
+    const rows = (await sql`
+      SELECT o.system_agent_id, m.role
+      FROM organization o
+      LEFT JOIN "member" m
+        ON m."organizationId" = o.id AND m."userId" = ${args.userId}
+      WHERE o.id = ${args.organizationId}
+      LIMIT 1
+    `) as unknown as Array<{ system_agent_id: string | null; role: string | null }>;
+    const row = rows[0];
+    if (!row || row.system_agent_id !== args.agentId) return undefined;
+    if (row.role !== "owner" && row.role !== "admin") return undefined;
+    return [...BUILDER_ADMIN_TOOLS];
+  } catch (err) {
+    logger.warn(
+      { err, organizationId: args.organizationId, agentId: args.agentId },
+      "resolveBuilderAdminTools failed; minting without admin grant"
+    );
+    return undefined;
+  }
+}
+
 export function buildRunJobToken(args: {
   userId: string;
   conversationId: string;
@@ -71,6 +125,12 @@ export function buildRunJobToken(args: {
    * turn (deploymentName:messageId), not merely any live turn on the deployment.
    */
   messageId?: string;
+  /**
+   * Builder admin-tool allowlist for this turn (system agent + owner/admin
+   * initiator only). Carried in the encrypted token and enforced at the
+   * execute gate; undefined for every normal agent/turn.
+   */
+  adminTools?: string[];
 }): string | undefined {
   if (args.runId === undefined) return undefined;
   return generateWorkerToken(
@@ -78,6 +138,7 @@ export function buildRunJobToken(args: {
     args.conversationId,
     args.deploymentName,
     {
+      adminTools: args.adminTools,
       // PRIMARY auth → shared routing claims (channelId, teamId, platform,
       // agentId, organizationId, connectionId, source) are minted via
       // `buildWorkerTokenClaims`, kept in lockstep with the deployment-token
@@ -268,6 +329,14 @@ export class MessageConsumer {
       // A on PR #865. Without a parsed runId (legacy direct-enqueue
       // path) we skip the mint; the snapshot path then declines to write
       // (worker-side runId is undefined and writeSnapshot bails).
+      // Builder admin-tool grant: only the org's system agent, only when the
+      // human driving this turn is an owner/admin. Fails closed.
+      const adminTools = await resolveBuilderAdminTools({
+        agentId: data.agentId,
+        organizationId: data.organizationId,
+        userId: data.userId,
+      });
+
       data.runJobToken = buildRunJobToken({
         userId: data.userId,
         conversationId: effectiveConversationId,
@@ -284,6 +353,7 @@ export class MessageConsumer {
         // marker for THIS turn (deploymentName:messageId) rather than any live
         // turn on the deployment.
         messageId: data.messageId,
+        adminTools,
       });
 
       logger.info(

--- a/packages/server/src/gateway/routes/public/agent.ts
+++ b/packages/server/src/gateway/routes/public/agent.ts
@@ -15,6 +15,8 @@ import { streamSSE } from "hono/streaming";
 import { bindRequestAbortToStream } from "../../../events/sse-abort-bridge.js";
 import { z } from "zod";
 import { DEFAULT_AGENT_ID } from "../../../auth/default-provisioning.js";
+import { getDb } from "../../../db/client.js";
+import { getCachedOrgBySlug } from "../../../workspace/multi-tenant.js";
 import type { AgentMetadataStore } from "../../auth/agent-metadata-store.js";
 import { getRevokedTokenStore } from "../../auth/revoked-token-store.js";
 import {
@@ -381,6 +383,41 @@ const sendMessageRoute = createRoute({
 });
 
 // =============================================================================
+// System-agent resolution + gating
+// =============================================================================
+
+/**
+ * Read `organization.system_agent_id` for the given org. Returns null when the
+ * org has no row or no system agent set.
+ */
+async function getOrgSystemAgentId(
+  organizationId: string
+): Promise<string | null> {
+  const rows = (await getDb()`
+    SELECT system_agent_id FROM "organization" WHERE id = ${organizationId} LIMIT 1
+  `) as unknown as Array<{ system_agent_id: string | null }>;
+  return rows[0]?.system_agent_id ?? null;
+}
+
+/**
+ * True when `userId` is an owner or admin of `organizationId`. Reuses the
+ * `member` role check pattern shared by `organization-access.ts`.
+ */
+async function isOrgOwnerOrAdmin(
+  organizationId: string,
+  userId: string
+): Promise<boolean> {
+  const rows = (await getDb()`
+    SELECT 1 FROM "member"
+    WHERE "organizationId" = ${organizationId}
+      AND "userId" = ${userId}
+      AND role IN ('owner', 'admin')
+    LIMIT 1
+  `) as unknown as Array<unknown>;
+  return rows.length > 0;
+}
+
+// =============================================================================
 // Create OpenAPI Hono App
 // =============================================================================
 
@@ -469,7 +506,77 @@ export function createAgentApi(config: AgentApiConfig): OpenAPIHono {
   }
 
   /**
-   * Verify that the caller is authorized to act on `resolvedAgentId`.
+   * Authorize access to an agent. The org's system (builder) agent is gated by
+   * ORG owner/admin role — any owner/admin may use the management console, not
+   * just whoever provisioned it (which is what per-user `requireAgentOwnership`
+   * would require). Every other agent uses per-user ownership. Workers (a worker
+   * IS its own agent) always take the ownership path. Returns a denial Response,
+   * or the resolved access (organizationId + whether this is the system agent +
+   * the authenticated caller for system-agent sessions, used to bind the session
+   * to the trusted actor rather than a client-supplied id).
+   */
+  async function authorizeAgentAccess(
+    c: Context,
+    agentId: string,
+    sessionForTenantCheck?: { organizationId?: string } | null
+  ): Promise<
+    | Response
+    | { organizationId?: string; isSystemAgent: boolean; callerUserId?: string }
+  > {
+    const bearer = tokenFromHeader(c);
+    const isWorker = bearer ? Boolean(verifyWorkerToken(bearer)) : false;
+    // Authoritative auth-method-bound org (mirrors requireAgentOwnership): set
+    // only by token auth (worker/external-OAuth `authContext`, or a PAT's pinned
+    // org via the bearer-gated ambient read). Undefined for the cookie session
+    // (SPA), which has no org binding and is gated by the membership/role check
+    // below. A bearer/token caller MUST NOT escape its bound org via a
+    // client-supplied workspace scope (x-lobu-org) or session org — deny on
+    // conflict before resolving the system agent.
+    const authoritativeCallerOrgId =
+      c.get("authContext")?.organizationId ??
+      (bearer ? (c.get("organizationId") as string | undefined) : undefined);
+    if (
+      sessionForTenantCheck?.organizationId &&
+      authoritativeCallerOrgId &&
+      sessionForTenantCheck.organizationId !== authoritativeCallerOrgId
+    ) {
+      return c.json({ success: false, error: "Forbidden" }, 403);
+    }
+    const orgId =
+      sessionForTenantCheck?.organizationId ??
+      (bearer ? (c.get("organizationId") as string | undefined) : undefined) ??
+      c.get("authContext")?.organizationId ??
+      (c.get("organizationId") as string | undefined);
+    const systemAgentId =
+      !isWorker && orgId ? await getOrgSystemAgentId(orgId) : null;
+    if (systemAgentId && systemAgentId === agentId) {
+      const callerUserId =
+        (c.get("authContext")?.userId as string | undefined) ??
+        (await verifySettingsSessionOrToken(c, "token"))?.userId;
+      if (
+        !callerUserId ||
+        !(await isOrgOwnerOrAdmin(orgId as string, callerUserId))
+      ) {
+        return c.json(
+          {
+            success: false,
+            error:
+              "Only organization owners/admins can use the org's system agent.",
+          },
+          403
+        );
+      }
+      return { organizationId: orgId, isSystemAgent: true, callerUserId };
+    }
+    const owned = await requireAgentOwnership(c, agentId, sessionForTenantCheck);
+    if (owned instanceof Response) return owned;
+    return { organizationId: owned.organizationId, isSystemAgent: false };
+  }
+
+  /**
+   * Verify that the caller is authorized to act on `resolvedAgentId` via
+   * per-user ownership (the non-system-agent path; system agents go through
+   * `authorizeAgentAccess`).
    *
    * The agent API middleware accepts three auth methods (worker token,
    * external OAuth, settings session). Each needs its own ownership rule:
@@ -743,6 +850,11 @@ export function createAgentApi(config: AgentApiConfig): OpenAPIHono {
           400
         );
       }
+      // No-agent chat resolves to the org's DEFAULT personal agent — NOT the
+      // builder/system agent. The builder is an admin console reached only by
+      // passing its id explicitly (the /agents console does this via
+      // useSystemAgentId), so routing the bare "just chat" path to it would
+      // wrongly hand every default conversation to the management agent.
       const defaultMeta = await ownershipMetadataStore?.getMetadata(
         DEFAULT_AGENT_ID
       );
@@ -758,8 +870,32 @@ export function createAgentApi(config: AgentApiConfig): OpenAPIHono {
       agentId = DEFAULT_AGENT_ID;
     }
 
-    const ownership = await requireAgentOwnership(c, agentId);
-    if (ownership instanceof Response) return ownership;
+    // When the SPA drives a chat from a specific workspace (especially a
+    // non-default org), it sends `x-lobu-org: <slug>`. Resolve it so the
+    // system-agent resolution + authorization scope to THAT org rather than the
+    // caller's ambient default org — the builder agent id is a per-org constant
+    // (`lobu-builder`), so an unscoped resolve would otherwise pick the default
+    // org's builder. Membership is verified by `authorizeAgentAccess`'s
+    // owner/admin check against this org (a non-member is denied).
+    const workspaceOrgSlug = c.req.header("x-lobu-org");
+    const workspaceScopedOrgId = workspaceOrgSlug
+      ? (await getCachedOrgBySlug(workspaceOrgSlug))?.id
+      : undefined;
+
+    // Authorize via the shared helper (system agent → org owner/admin; otherwise
+    // per-user ownership). For a system-agent session it also returns the
+    // authenticated caller so the session binds to the trusted actor below.
+    const access = await authorizeAgentAccess(
+      c,
+      agentId,
+      workspaceScopedOrgId ? { organizationId: workspaceScopedOrgId } : undefined
+    );
+    if (access instanceof Response) return access;
+    const ownership: { organizationId?: string } = {
+      organizationId: access.organizationId,
+    };
+    const isSystemAgentSession = access.isSystemAgent;
+    const systemCallerUserId = access.callerUserId;
 
     // Stamp the worker token with the agent's owning org so the egress
     // proxy's per-tenant gates (grant/deny, judge cache, judge policy) can
@@ -785,9 +921,15 @@ export function createAgentApi(config: AgentApiConfig): OpenAPIHono {
     // authenticated caller's userId (per-org-unique via the auth bridge),
     // then fall back to agentId (only for pinned agents where that's safe).
     const authUserId = c.get("authContext")?.userId;
+    // System-agent sessions bind to the AUTHENTICATED owner/admin, never the
+    // client-supplied panel userId — the builder admin-tool grant
+    // (resolveBuilderAdminTools) keys on this run's userId, so trusting a
+    // client value would let any caller name an admin to mint the grant.
     const userId = watcherIntent
       ? `watcher_${watcherIntent.watcherId}`
-      : requestedUserId || authUserId || agentId;
+      : isSystemAgentSession
+        ? (systemCallerUserId as string)
+        : requestedUserId || authUserId || agentId;
     const effectiveThread = watcherIntent
       ? `run_${watcherIntent.runId}`
       : thread;
@@ -935,7 +1077,7 @@ export function createAgentApi(config: AgentApiConfig): OpenAPIHono {
       return c.json({ success: false, error: "Agent not found" }, 404);
     }
 
-    const denial = await requireAgentOwnership(
+    const denial = await authorizeAgentAccess(
       c,
       session.agentId || sessionKey,
       session
@@ -964,7 +1106,7 @@ export function createAgentApi(config: AgentApiConfig): OpenAPIHono {
     // Resolve the real agentId BEFORE any mutation so ownership can be
     // checked against the actual agent (the path param is a sessionKey).
     const existingSession = await sessMgr.getSession(sessionKey);
-    const denial = await requireAgentOwnership(
+    const denial = await authorizeAgentAccess(
       c,
       existingSession?.agentId || sessionKey,
       existingSession
@@ -1001,7 +1143,7 @@ export function createAgentApi(config: AgentApiConfig): OpenAPIHono {
 
     // Gate BEFORE opening the stream or replaying the backlog — otherwise a
     // cross-tenant caller would receive another agent's buffered events.
-    const denial = await requireAgentOwnership(
+    const denial = await authorizeAgentAccess(
       c,
       session.agentId || sessionKey,
       session
@@ -1125,12 +1267,10 @@ export function createAgentApi(config: AgentApiConfig): OpenAPIHono {
     // usually a sessionKey (conversationId); resolve to the real agentId when
     // a session exists.
     const preSession = await sessMgr.getSession(agentId);
-    const ownershipDenial = await requireAgentOwnership(
-      c,
-      preSession?.agentId || agentId,
-      preSession
-    );
-    if (ownershipDenial instanceof Response) return ownershipDenial;
+    const resolvedAgentId = preSession?.agentId || agentId;
+
+    const msgAccess = await authorizeAgentAccess(c, resolvedAgentId, preSession);
+    if (msgAccess instanceof Response) return msgAccess;
 
     // Parse body — multipart for file uploads, JSON otherwise
     const contentType = c.req.header("content-type") || "";

--- a/packages/server/src/lobu/agent-routes.ts
+++ b/packages/server/src/lobu/agent-routes.ts
@@ -354,6 +354,21 @@ function hasFreshCredential(profiles: AuthProfile[]): boolean {
   );
 }
 
+// ── Resolve the org's builder/system agent ───────────────────────────────────
+// Server-controlled pointer (organization.system_agent_id). The web console
+// mounts the builder chat against this id; null when none is provisioned.
+// Registered before any `/:agentId` route so the literal path wins.
+routes.get('/system-agent', async (c) => {
+  const orgId = c.get('organizationId')!;
+  const sql = getDb();
+  const rows = await sql`
+    SELECT system_agent_id FROM organization WHERE id = ${orgId} LIMIT 1
+  `;
+  return c.json({
+    systemAgentId: (rows[0]?.system_agent_id as string | null) ?? null,
+  });
+});
+
 // ── List agents ──────────────────────────────────────────────────────────────
 
 routes.get('/', async (c) => {

--- a/packages/server/src/local-bootstrap.ts
+++ b/packages/server/src/local-bootstrap.ts
@@ -23,6 +23,7 @@
  */
 
 import postgres from "postgres";
+import { ensureBuilderAgent } from "./auth/builder-provisioning";
 import { ensureDefaultAgent } from "./auth/default-provisioning";
 import { ensureInstallOperator } from "./auth/install-operator";
 import logger from "./utils/logger";
@@ -58,7 +59,10 @@ export function buildLocalBootstrapHooks(databaseUrl: string): PreListenHook[] {
             ORDER BY "createdAt" ASC LIMIT 1
           `) as unknown as Array<{ id: string }>;
 					const orgId = orgs[0]?.id ?? null;
-					if (orgId) await ensureDefaultAgent(orgId);
+					if (orgId) {
+						await ensureDefaultAgent(orgId);
+						await ensureBuilderAgent(orgId);
+					}
 				} finally {
 					await rows.end({ timeout: 1 });
 				}

--- a/packages/server/src/mcp-handler.ts
+++ b/packages/server/src/mcp-handler.ts
@@ -121,7 +121,14 @@ function createServerForContext(env: Env, authCtx: SessionAuthContext): Server {
   // tools/list — return our TypeBox JSON Schemas
   // Read auth state dynamically so the list updates after auth upgrades.
   server.setRequestHandler(ListToolsRequestSchema, async () => {
-    const includeInternalTools = authCtx.allowInternalTools === true;
+    // System-agent (builder) runs carry a per-turn internal-tool allowlist.
+    // Surface exactly those internal tools (and no other), so the model
+    // discovers only what the execute gate will actually permit — not every
+    // internal tool the direct-auth path would otherwise expose.
+    const adminAllowlist = authCtx.adminTools ?? null;
+    const hasAdminAllowlist = !!adminAllowlist && adminAllowlist.length > 0;
+    const includeInternalTools =
+      authCtx.allowInternalTools === true || hasAdminAllowlist;
     const publicOnly = !!authCtx.organizationId && !authCtx.memberRole;
     const roleAccessLevel = !authCtx.memberRole
       ? 'read'
@@ -146,7 +153,26 @@ function createServerForContext(env: Env, authCtx: SessionAuthContext): Server {
       publicOnly,
       maxAccessLevel,
     });
-    const allTools = staticTools.map((t) => ({
+    // On a system-agent run, drop any internal tool outside the allowlist so the
+    // listing matches the execute gate (no "Tool not found" surprises). The
+    // returned shape omits `internal`, so derive the non-internal set from a
+    // second pass with internal tools excluded; a tool is visible if it's
+    // non-internal OR explicitly allowlisted.
+    let visibleTools = staticTools;
+    if (hasAdminAllowlist) {
+      const allowed = new Set(adminAllowlist);
+      const nonInternal = new Set(
+        getAllTools({
+          includeInternalTools: false,
+          publicOnly,
+          maxAccessLevel,
+        }).map((t) => t.name)
+      );
+      visibleTools = staticTools.filter(
+        (t) => nonInternal.has(t.name) || allowed.has(t.name)
+      );
+    }
+    const allTools = visibleTools.map((t) => ({
       name: t.name,
       description: t.description,
       inputSchema: t.inputSchema,

--- a/packages/server/src/tools/admin/index.ts
+++ b/packages/server/src/tools/admin/index.ts
@@ -15,6 +15,7 @@ import type { Env } from '../../index';
 import { GetContentSchema, getContent } from '../get_content';
 import { GetWatcherSchema, getWatcher } from '../get_watchers';
 import type { ToolAnnotations, ToolContext, ToolDefinition } from '../registry';
+import { ManageAgentsSchema, manageAgents } from './manage_agents';
 import { ManageAuthProfilesSchema, manageAuthProfiles } from './manage_auth_profiles';
 import { ManageClassifiersSchema, manageClassifiers } from './manage_classifiers';
 import { ManageConnectionsSchema, manageConnections } from './manage_connections';
@@ -67,6 +68,12 @@ const ENTRIES: InternalToolEntry[] = [
     description: 'Connection management. SDK alternative: client.connections.',
     schema: ManageConnectionsSchema,
     handler: manageConnections,
+  },
+  {
+    name: 'manage_agents',
+    description: 'Agent management (incl. the org system agent pointer).',
+    schema: ManageAgentsSchema,
+    handler: manageAgents,
   },
   {
     name: 'manage_feeds',

--- a/packages/server/src/tools/admin/manage_agents.ts
+++ b/packages/server/src/tools/admin/manage_agents.ts
@@ -1,0 +1,320 @@
+/**
+ * Tool: manage_agents
+ *
+ * Manage agent definitions within an organization.
+ *
+ * Actions:
+ * - list: List all agents in the org (marks the org's system agent)
+ * - get: Get one agent's row
+ * - create: Create an agent owned by the authenticated caller (owner_platform=
+ *   'external' + an agent_users mapping, so the per-user chat path can reach it)
+ * - update: Update name/description/identity_md on an agent
+ * - delete: Delete an agent (refuses the org's system agent)
+ * - set_system_agent: Point organization.system_agent_id at an agent
+ *
+ * The org's "system" agent is the builder/console agent backing the
+ * org-management surface. `set_system_agent` is the only writer of
+ * organization.system_agent_id here (default-org provisioning is the other).
+ */
+
+import { type Static, Type } from '@sinclair/typebox';
+import { createDbClientFromEnv } from '../../db/client';
+import type { Env } from '../../index';
+import { isValidAgentId } from '../../lobu/stores/postgres-stores';
+import { ToolUserError } from '../../utils/errors';
+import { requireOrgReadAccess, requireOrgWriteAccess } from '../../utils/organization-access';
+import type { ToolContext } from '../registry';
+import { withValidatedArgs } from '../validate-args';
+import { defineFlatActionTool, flatAction } from './action-tool';
+
+// ============================================
+// Typebox Schema (Flattened for MCP)
+// ============================================
+
+export const ManageAgentsSchema = Type.Object({
+  action: Type.Union(
+    [
+      Type.Literal('list'),
+      Type.Literal('get'),
+      Type.Literal('create'),
+      Type.Literal('update'),
+      Type.Literal('delete'),
+      Type.Literal('set_system_agent'),
+    ],
+    { description: 'Action to perform' }
+  ),
+
+  agent_id: Type.Optional(
+    Type.String({
+      description:
+        '[get/create/update/delete/set_system_agent] Agent ID (lowercase slug, e.g. "builder").',
+    })
+  ),
+  name: Type.Optional(
+    Type.String({ description: '[create/update] Display name for the agent.' })
+  ),
+  description: Type.Optional(
+    Type.String({ description: '[create/update] Agent description.' })
+  ),
+  identity_md: Type.Optional(
+    Type.String({ description: '[create/update] Agent identity / system prompt (Markdown).' })
+  ),
+});
+
+// ============================================
+// Type Definitions
+// ============================================
+
+export type ManageAgentsArgs = Static<typeof ManageAgentsSchema>;
+
+interface AgentRecord {
+  id: string;
+  name: string;
+  description: string | null;
+  owner_platform: string | null;
+  owner_user_id: string | null;
+  created_at: string;
+  last_used_at: string | null;
+  is_system_agent: boolean;
+}
+
+export type ManageAgentsResult =
+  | { action: 'list'; agents: AgentRecord[] }
+  | { action: 'get'; agent: AgentRecord }
+  | { action: 'create'; agent_id: string; created: boolean }
+  | { action: 'update'; agent_id: string; updated_fields: string[] }
+  | { action: 'delete'; agent_id: string; deleted: boolean }
+  | { action: 'set_system_agent'; system_agent_id: string };
+
+// ============================================
+// Action handlers
+// ============================================
+
+async function handleList(
+  _args: ManageAgentsArgs,
+  ctx: ToolContext,
+  env: Env
+): Promise<ManageAgentsResult> {
+  const sql = createDbClientFromEnv(env);
+  const rows = await sql`
+    SELECT
+      a.id,
+      a.name,
+      a.description,
+      a.owner_platform,
+      a.owner_user_id,
+      a.created_at,
+      a.last_used_at,
+      (a.id = o.system_agent_id) AS is_system_agent
+    FROM agents a
+    JOIN organization o ON o.id = a.organization_id
+    WHERE a.organization_id = ${ctx.organizationId}
+    ORDER BY a.created_at ASC
+  `;
+  return { action: 'list', agents: rows as unknown as AgentRecord[] };
+}
+
+async function handleGet(
+  args: ManageAgentsArgs,
+  ctx: ToolContext,
+  env: Env
+): Promise<ManageAgentsResult> {
+  if (!args.agent_id) {
+    throw new ToolUserError('agent_id is required for get action');
+  }
+  const sql = createDbClientFromEnv(env);
+  const rows = await sql`
+    SELECT
+      a.id,
+      a.name,
+      a.description,
+      a.owner_platform,
+      a.owner_user_id,
+      a.created_at,
+      a.last_used_at,
+      (a.id = o.system_agent_id) AS is_system_agent
+    FROM agents a
+    JOIN organization o ON o.id = a.organization_id
+    WHERE a.organization_id = ${ctx.organizationId} AND a.id = ${args.agent_id}
+  `;
+  if (rows.length === 0) {
+    throw new ToolUserError(`Agent "${args.agent_id}" not found`, 404);
+  }
+  return { action: 'get', agent: rows[0] as unknown as AgentRecord };
+}
+
+async function handleCreate(
+  args: ManageAgentsArgs,
+  ctx: ToolContext,
+  env: Env
+): Promise<ManageAgentsResult> {
+  if (!args.agent_id) {
+    throw new ToolUserError('agent_id is required for create action');
+  }
+  if (!isValidAgentId(args.agent_id)) {
+    throw new ToolUserError(
+      `Invalid agent_id "${args.agent_id}": must match /^[a-z][a-z0-9-]{2,59}$/`
+    );
+  }
+  if (!args.name) {
+    throw new ToolUserError('name is required for create action');
+  }
+  // Created agents must have an owner to attribute them to — without one the
+  // agents row exists but the per-user ownership path can't reach it.
+  if (!ctx.userId) {
+    throw new ToolUserError(
+      'create requires an authenticated caller to own the new agent'
+    );
+  }
+  const sql = createDbClientFromEnv(env);
+  const ownerUserId = ctx.userId;
+  // Mirror the provisioning pattern (ensureDefaultAgent / ensureBuilderAgent):
+  // owner_platform='external' on the row AND an agent_users mapping, so the
+  // per-user ownership check (SPA cookie / PAT session) can reach the new agent.
+  // Without the agent_users row the agent is unreachable through chat,
+  // especially in non-default orgs.
+  const rows = await sql`
+    INSERT INTO agents (
+      id, organization_id, name, description, identity_md,
+      owner_platform, owner_user_id, created_at, updated_at
+    )
+    VALUES (
+      ${args.agent_id}, ${ctx.organizationId}, ${args.name}, ${args.description ?? null},
+      ${args.identity_md ?? ''}, 'external', ${ownerUserId}, NOW(), NOW()
+    )
+    ON CONFLICT (organization_id, id) DO NOTHING
+    RETURNING id
+  `;
+  const created = rows.length > 0;
+  if (created) {
+    await sql`
+      INSERT INTO agent_users (organization_id, agent_id, platform, user_id, created_at)
+      VALUES (${ctx.organizationId}, ${args.agent_id}, 'external', ${ownerUserId}, NOW())
+      ON CONFLICT (organization_id, agent_id, platform, user_id) DO NOTHING
+    `;
+  }
+  return { action: 'create', agent_id: args.agent_id, created };
+}
+
+async function handleUpdate(
+  args: ManageAgentsArgs,
+  ctx: ToolContext,
+  env: Env
+): Promise<ManageAgentsResult> {
+  if (!args.agent_id) {
+    throw new ToolUserError('agent_id is required for update action');
+  }
+  const sql = createDbClientFromEnv(env);
+  const updatedFields: string[] = [];
+  if (args.name !== undefined) updatedFields.push('name');
+  if (args.description !== undefined) updatedFields.push('description');
+  if (args.identity_md !== undefined) updatedFields.push('identity_md');
+  if (updatedFields.length === 0) {
+    throw new ToolUserError(
+      'update requires at least one of: name, description, identity_md'
+    );
+  }
+  // Per-field CASE WHEN ... THEN ... ELSE col END so only provided fields change
+  // (mirrors manage_watchers crud's partial-update idiom).
+  const rows = await sql`
+    UPDATE agents SET
+      updated_at = NOW(),
+      name = CASE WHEN ${args.name !== undefined} THEN ${args.name ?? null} ELSE name END,
+      description = CASE WHEN ${args.description !== undefined} THEN ${args.description ?? null} ELSE description END,
+      identity_md = CASE WHEN ${args.identity_md !== undefined} THEN ${args.identity_md ?? ''} ELSE identity_md END
+    WHERE organization_id = ${ctx.organizationId} AND id = ${args.agent_id}
+    RETURNING id
+  `;
+  if (rows.length === 0) {
+    throw new ToolUserError(`Agent "${args.agent_id}" not found`, 404);
+  }
+  return { action: 'update', agent_id: args.agent_id, updated_fields: updatedFields };
+}
+
+async function handleDelete(
+  args: ManageAgentsArgs,
+  ctx: ToolContext,
+  env: Env
+): Promise<ManageAgentsResult> {
+  if (!args.agent_id) {
+    throw new ToolUserError('agent_id is required for delete action');
+  }
+  const sql = createDbClientFromEnv(env);
+  const orgRows = await sql`
+    SELECT system_agent_id FROM organization WHERE id = ${ctx.organizationId}
+  `;
+  if (orgRows[0]?.system_agent_id === args.agent_id) {
+    throw new ToolUserError(
+      `Cannot delete agent "${args.agent_id}": it is the org's system agent. Point system_agent_id elsewhere first.`
+    );
+  }
+  const rows = await sql`
+    DELETE FROM agents
+    WHERE organization_id = ${ctx.organizationId} AND id = ${args.agent_id}
+    RETURNING id
+  `;
+  return { action: 'delete', agent_id: args.agent_id, deleted: rows.length > 0 };
+}
+
+async function handleSetSystemAgent(
+  args: ManageAgentsArgs,
+  ctx: ToolContext,
+  env: Env
+): Promise<ManageAgentsResult> {
+  if (!args.agent_id) {
+    throw new ToolUserError('agent_id is required for set_system_agent action');
+  }
+  const sql = createDbClientFromEnv(env);
+  const agentRows = await sql`
+    SELECT id FROM agents
+    WHERE organization_id = ${ctx.organizationId} AND id = ${args.agent_id}
+  `;
+  if (agentRows.length === 0) {
+    throw new ToolUserError(`Agent "${args.agent_id}" not found`, 404);
+  }
+  await sql`
+    UPDATE organization
+    SET system_agent_id = ${args.agent_id}
+    WHERE id = ${ctx.organizationId}
+  `;
+  return { action: 'set_system_agent', system_agent_id: args.agent_id };
+}
+
+// ============================================
+// Main Function
+// ============================================
+
+export const manageAgents = withValidatedArgs(
+  'manage_agents',
+  ManageAgentsSchema,
+  manageAgentsImpl
+);
+
+async function manageAgentsImpl(
+  args: ManageAgentsArgs,
+  env: Env,
+  ctx: ToolContext
+): Promise<ManageAgentsResult> {
+  const pgSql = createDbClientFromEnv(env);
+
+  // Validate organization access based on action type.
+  if (args.action === 'list' || args.action === 'get') {
+    await requireOrgReadAccess(pgSql, ctx);
+  } else {
+    await requireOrgWriteAccess(pgSql, ctx);
+  }
+
+  return runManageAgents(args, env, ctx);
+}
+
+const runManageAgents = defineFlatActionTool<ManageAgentsArgs, ManageAgentsResult>(
+  'manage_agents',
+  {
+    list: flatAction((args, ctx, env) => handleList(args, ctx, env)),
+    get: flatAction((args, ctx, env) => handleGet(args, ctx, env)),
+    create: flatAction((args, ctx, env) => handleCreate(args, ctx, env)),
+    update: flatAction((args, ctx, env) => handleUpdate(args, ctx, env)),
+    delete: flatAction((args, ctx, env) => handleDelete(args, ctx, env)),
+    set_system_agent: flatAction((args, ctx, env) => handleSetSystemAgent(args, ctx, env)),
+  }
+);

--- a/packages/server/src/tools/execute.ts
+++ b/packages/server/src/tools/execute.ts
@@ -44,6 +44,12 @@ export interface AuthContext {
   allowCrossOrg: boolean;
   instructions?: string;
   allowInternalTools?: boolean;
+  /**
+   * Per-turn allowlist of internal admin tool names this request may call even
+   * on the worker (/mcp) path. Carried on the builder/system agent's per-run
+   * worker token (see WorkerTokenData.adminTools); empty/null for everyone else.
+   */
+  adminTools?: string[] | null;
 }
 
 export function extractAuthContext(c: Context<{ Bindings: Env }>): AuthContext {
@@ -83,6 +89,10 @@ export function extractAuthContext(c: Context<{ Bindings: Env }>): AuthContext {
     allowCrossOrg: tokenType === 'oauth' && !scopedToOrg,
     allowInternalTools:
       !pathname.startsWith('/mcp') || c.req.header('x-lobu-memory-direct-auth') === '1',
+    // Builder admin-tool grant: carried from the verified worker token through
+    // mcpAuthInfo (see multi-tenant worker direct-auth). Lets the system agent
+    // call its allowlisted internal tools even on the /mcp path.
+    adminTools: mcpAuthInfo?.adminTools ?? null,
   };
 }
 
@@ -117,8 +127,21 @@ export function checkToolAccess(toolName: string, args: unknown, authCtx: AuthCo
   if (!tool) {
     throw new ToolNotRegisteredError(toolName);
   }
-  if (tool.internal && !authCtx.allowInternalTools) {
-    throw new Error(`Tool not found: ${toolName}`);
+  if (tool.internal) {
+    const adminAllowlist = authCtx.adminTools;
+    if (adminAllowlist && adminAllowlist.length > 0) {
+      // System-agent (builder) run: the per-turn allowlist is the LIMIT, not an
+      // addition. It OVERRIDES the blanket `allowInternalTools` so the builder
+      // can only reach its designated admin tools (manage_agents, …) — never
+      // every internal tool — even though its worker traverses the direct-auth
+      // path that would otherwise enable all of them. Other callers (no
+      // allowlist) keep the existing `allowInternalTools` behavior unchanged.
+      if (!adminAllowlist.includes(toolName)) {
+        throw new Error(`Tool not found: ${toolName}`);
+      }
+    } else if (!authCtx.allowInternalTools) {
+      throw new Error(`Tool not found: ${toolName}`);
+    }
   }
 
   const isReadOnly = tool.annotations?.readOnlyHint === true;

--- a/packages/server/src/workspace/multi-tenant.ts
+++ b/packages/server/src/workspace/multi-tenant.ts
@@ -300,7 +300,15 @@ export class MultiTenantProvider implements WorkspaceProvider {
           403
         );
       }
-      const directAuthUserId = (agentRows[0]?.owner_user_id as string | undefined) ?? tokenData.userId;
+      // For a builder admin turn (per-run token carries `adminTools`), attribute
+      // the call to the verified per-turn admin (`tokenData.userId`, bound to the
+      // authenticated owner/admin at session create) rather than the agent's
+      // provisioning owner — so the role check and audit reflect the actual
+      // actor. Non-builder worker direct-auth keeps the agent-owner attribution.
+      const isBuilderAdminTurn = !!tokenData.adminTools?.length;
+      const directAuthUserId = isBuilderAdminTurn
+        ? tokenData.userId
+        : (agentRows[0]?.owner_user_id as string | undefined) ?? tokenData.userId;
       const roleRows = await sql`
         SELECT role
         FROM "member"
@@ -323,6 +331,10 @@ export class MultiTenantProvider implements WorkspaceProvider {
           scopes: ['mcp:read', 'mcp:write', 'mcp:admin'],
           expiresAt: Math.floor((tokenData.timestamp + 2 * 60 * 60 * 1000) / 1000),
           tokenType: 'pat',
+          // Builder admin-tool grant rides the per-run worker token (set only
+          // for the system agent on an owner/admin turn). Carried through so the
+          // execute gate lets the builder call its allowlisted internal tools.
+          adminTools: tokenData.adminTools ?? null,
         },
         mcpIsAuthenticated: true,
         organizationId: requestedOrgId,


### PR DESCRIPTION
A per-org **builder/system agent** that creates and configures agents (and connections, feeds, watchers…) by chatting — so the web app no longer needs an external coding agent for workspace setup.

## What's added
- **`organization.system_agent_id`** pointer (server-controlled only) identifies the per-org builder agent. New migration adds the nullable column (additive, rolling-deploy safe).
- **`ensureBuilderAgent`** provisions it on every org-creation path (personal-org, install-operator, local-bootstrap), installs system providers, and **pins a default model** so it can chat immediately.
- **`manage_agents` admin tool** — create/get/list/update/delete/set_system_agent, org-scoped, OWNER_ADMIN tier.
- **Run-bound admin capability** — the builder's per-run worker token carries an allowlist of admin tools (`manage_agents` + connections/feeds/watchers/schedules/entity), minted only when the turn targets the system agent AND the caller is an org owner/admin (`resolveBuilderAdminTools`), enforced at the execute gate and surfaced to the worker via the worker-token `adminTools` claim.
- No-`agentId` chat resolution + chat-route **owner/admin gating** key off `system_agent_id`; `GET /api/{slug}/agents/system-agent` exposes it to the SPA.

## Verification
- Strict tsc green (core/server). Owletto build green.
- **Live e2e**: provisioning creates `lobu-builder` + sets the pointer; `manage_agents` full CRUD + delete-system-agent refusal + 401/read-scope-block via REST; **the builder, driven by a real chat turn (glm-4.7), called `manage_agents` and created a new agent (`support-bot`) — confirmed by the DB side-effect** and the agent appearing in the UI list/sidebar/stats.

## Notes / follow-ups
- Pairs with owletto PR (the `/agents` console). After owletto merges, re-bump the submodule pointer to its squash HEAD.
- Stacks alongside the cleanup PR #1405 (drops dead `is_workspace_agent`); no `is_workspace_agent` references were added here.
- The `/agents` builder console is desktop-width only (the agents index returns null at narrow/mobile widths — pre-existing behavior for the whole page).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1409"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784575776&installation_id=136316292&pr_number=1409&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1409&signature=34a12855ac28b18f52b4c7ce5c2d93b7aa27a72ab08f828034b9bb920c05fc3a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Auto-provisions an org “Builder” system agent and exposes its ID via `GET /system-agent` (`null` when unset).
  * Introduces the `manage_agents` admin tool for agent listing, CRUD, and setting the org system agent.
* **Enhancements**
  * System-agent access is owner/admin-only and is bound more safely to the intended caller.
  * Internal/admin tool access is now granted per turn using a validated allowlist carried in worker tokens, including during token refresh.
  * Malformed allowlists are rejected to fail securely.
* **Tests**
  * Expanded end-to-end tool coverage to include `manage_agents`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->