### PR TITLE
fix(jira): migrate sync to /rest/api/3/search/jql (old /search removed → 410)

### DIFF
--- a/packages/connectors/src/jira.ts
+++ b/packages/connectors/src/jira.ts
@@ -67,9 +67,9 @@ interface JiraIssue {
 
 interface JiraSearchResponse {
   issues?: JiraIssue[];
-  startAt?: number;
-  maxResults?: number;
-  total?: number;
+  /** Token-based pagination cursor for the /search/jql endpoint (absent on the last page). */
+  nextPageToken?: string;
+  isLast?: boolean;
 }
 
 function asString(value: unknown): string | undefined {
@@ -210,17 +210,20 @@ export default class JiraConnector extends ConnectorRuntime<JiraCheckpoint, Jira
     const jql = ctx.config.jql ?? `updated >= -${lookbackDays}d order by updated DESC`;
 
     const events: EventEnvelope[] = [];
-    let startAt = 0;
+    let nextPageToken: string | undefined;
     let pages = 0;
 
     while (pages < this.MAX_PAGES) {
+      // `/rest/api/3/search` was removed by Atlassian (CHANGE-2046); the
+      // replacement `/search/jql` paginates with an opaque nextPageToken and
+      // returns no total — iterate until the token is absent.
       const params = new URLSearchParams({
         jql,
-        startAt: String(startAt),
         maxResults: String(this.PAGE_SIZE),
         fields: 'summary,description,status,assignee,reporter,created,updated',
       });
-      const data = await http.json<JiraSearchResponse>(`${base}/search?${params.toString()}`, {
+      if (nextPageToken) params.set('nextPageToken', nextPageToken);
+      const data = await http.json<JiraSearchResponse>(`${base}/search/jql?${params.toString()}`, {
         method: 'GET',
         headers: { Accept: 'application/json' },
       });
@@ -232,9 +235,8 @@ export default class JiraConnector extends ConnectorRuntime<JiraCheckpoint, Jira
       }
 
       pages += 1;
-      const total = data.total ?? 0;
-      startAt += issues.length;
-      if (issues.length === 0 || startAt >= total) break;
+      nextPageToken = data.nextPageToken;
+      if (!nextPageToken || issues.length === 0) break;
     }
 
     return {


### PR DESCRIPTION
## Bug
`jira.ts` `sync()` called `GET /rest/api/3/search`, which Atlassian **removed** (CHANGE-2046). It now returns **410 Gone**, so Jira ingestion failed on the very first request against any live Jira Cloud site. Shipped in #1408 but never exercised against a real Jira (no Jira instance existed at the time).

## Fix
Migrate to the replacement **`/rest/api/3/search/jql`** endpoint:
- token-based pagination (`nextPageToken`) instead of `startAt`/`total` (the new endpoint returns neither),
- iterate until `nextPageToken` is absent.

## Verification (live)
Full OAuth 2.0 (3LO) flow against a real Jira site (`rakam1.atlassian.net`): created an OAuth app, granted `read:jira-work`, exchanged the code, resolved `cloud_id`, ran the **real `JiraConnector.sync()`**:
- **before:** `410 Gone` on the first request,
- **after:** `count: 1`, correct mapping — `origin_id: jira_issue_10000`, `title`, `author_name`, `source_url`, `origin_type: issue`, `metadata.{key: KAN-1, status: "To Do", reporter, updated_at}`.

Only `packages/connectors/src/jira.ts` changed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1411"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784589515&installation_id=136316292&pr_number=1411&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1411&signature=4ca94d47c534dcc779325f8be0877f4a6a8ecd21f7f42ce5b0abf244853e7e46"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->