### PR TITLE
docs(landing): strengthen the agent-loop post (worked example + trust mechanics)

### DIFF
--- a/packages/landing/src/components/blog/Tweet.tsx
+++ b/packages/landing/src/components/blog/Tweet.tsx
@@ -75,7 +75,9 @@ export function Tweet({
             fallbackRef.current.style.display = "none";
           }
         })
-        .catch(() => {/* widget blocked or rate-limited: the static fallback stays */});
+        .catch(() => {
+          /* widget blocked or rate-limited: the static fallback stays */
+        });
     };
 
     const w = window as unknown as { twttr?: Twttr };

--- a/packages/landing/src/content/blog/the-agent-loop-is-the-new-saas.mdx
+++ b/packages/landing/src/content/blog/the-agent-loop-is-the-new-saas.mdx
@@ -13,7 +13,7 @@ import { EventLoopAnimation } from "../../components/blog/EventLoopAnimation";
 import { Tweet } from "../../components/blog/Tweet";
 
 <aside style="margin:1.75rem 0;border:1px solid var(--color-page-border);border-left:3px solid var(--color-tg-accent);border-radius:12px;padding:0.85rem 1.1rem;background:var(--color-page-surface)">
-  <p style="margin:0;font-size:0.95rem;line-height:1.6;color:var(--color-page-text-muted)"><strong style="color:var(--color-page-text)">TL;DR:</strong> An agent loop that watches your data and acts is the business logic a vertical SaaS sold you, except you build it once on one backend with shared memory instead of renting ten tools that never talk. The agent loop is the new unit of software, and Lobu is where you build it.</p>
+  <p style="margin:0;font-size:0.95rem;line-height:1.6;color:var(--color-page-text-muted)"><strong style="color:var(--color-page-text)">TL;DR:</strong> The workflow layer above your systems of record, the part you used to buy a tool for, is becoming agent loops you build. A loop that watches your data and acts is that business logic, built once on one backend with shared memory instead of rented across ten tools that never talk. Lobu is where you build it.</p>
 </aside>
 
 For a decade, running a company meant buying software for each job. A tool for sales, a tool for support, a tool for finance, another for the thing the last tool didn't cover. You were not really buying software. You were buying business logic as a product, one vertical at a time.
@@ -46,13 +46,13 @@ That is starting to come apart, and the reason is how agents get built now. The 
 
 They are talking about coding agents, but the idea travels. An agent loop is simple: something happens, the model decides what to do, it does it, and the result feeds the next pass. Once you can build the loop, the loop is the thing you ship. And a loop that watches your data and acts on it is the same business logic a vertical SaaS used to sell you, except you build it once, on one backend, instead of renting ten tools that never share a memory.
 
-That is the shift. The agent loop is the new unit of software. Lobu is the backend you build them on.
+That is the shift. The workflow layer above your systems of record, the part that used to be a separate tool per function, is turning into agent loops you build. Lobu is the backend you build them on.
 
 ## What the loop actually looks like
 
 <EventLoopAnimation />
 
-That is one trip around the loop. A payment fails on Acme, the enterprise-churn watcher you defined fires, the agent checks the account and drafts a recovery note, and that draft becomes a new event in the log. You define one thing: the watcher. Lobu runs the rest of the circle. Here is each piece.
+That is one trip around the loop. A payment fails on Acme, the enterprise-churn watcher you defined picks it up, the agent checks the account and drafts a recovery note, and that draft becomes a new event in the log. You define one thing: the watcher. Lobu runs the rest of the circle. Here is each piece.
 
 ## Events come in two shapes
 
@@ -62,15 +62,29 @@ Webhook events are stored by default, and you opt a source into search when you 
 
 ## You define the watcher, not the steps
 
-A watcher is a standing goal tied to the data you care about. "When a payment fails for an enterprise account, check the account and draft a recovery note for approval." You are not scripting the steps. You say what to watch for, which model should run it, and when it should check with a human before acting.
+A watcher is a standing goal, written once in config and applied to every matching event:
 
-That sentence is closer to a job description than a prompt. You write it once and it keeps applying to every event that matches.
+```ts
+defineWatcher({
+  agent: revenue,
+  name: "Enterprise churn watch",
+  schedule: "*/10 * * * *", // runs every 10 minutes
+  prompt: `When an enterprise account (ARR > $25k) has a failed payment,
+           pull the account, draft a recovery note, and post it to #cs
+           for approval before anything goes out.`,
+  reaction: reactionFromFile("./recovery-note.reaction.ts"),
+})
+```
+
+You are not scripting the steps. You say what to watch for, which model runs it, and where it should stop and ask a human. On its next run the agent reads the new `stripe.invoice.payment_failed` event, checks Acme against memory, and drafts the note. The reaction posts it to #cs and waits. When someone approves, it sends, and the run writes a `recovery_note.sent` event back to the log. That event is the audit trail, and it is also what the next watcher might pick up.
+
+You write this once. It keeps applying to every account that matches, and you can read exactly what it did from the events it left behind.
 
 ## The agent runs in a sandbox with real tools
 
-When a watcher fires, Lobu runs the agent in its own sandbox. It reads the event, pulls what it needs from memory, and calls MCP tools to do the work. Those tools are how it touches the world: read a record, post a message, open a ticket.
+The agent works in its own sandbox: a separate process with a network it can only reach on an allowlist you set, and no standing access to your systems. It reads the event, pulls what it needs from memory, and calls MCP tools to act: read a record, post a message, open a ticket.
 
-The credentials behind the tools are swapped in at the edge, as the request leaves the box. So the agent does real things with real systems and never holds a real secret. A bad turn has a small blast radius.
+The credentials behind those tools are swapped in at the edge, as the request leaves the box, so the agent uses real access it never actually holds. Anything destructive waits for a human. And every call lands in the same append-only log. That is what a small blast radius means here, concretely: no secrets in the worker, no network it was not given, nothing irreversible without a yes, and a full record of what it touched.
 
 ## What it does with what it finds
 
@@ -84,7 +98,7 @@ The Acme example is a revenue loop. The same shape covers the rest of the compan
 
 A GTM-engineer agent watches new signups and enriches, scores, and routes them, the work people wire together from five point tools today. A marketing agent watches what shipped and what landed and drafts the post, the changelog, the follow-up. A finance agent watches the ledger, reconciles, flags variances, and preps the close. A support agent watches the queue and drafts replies grounded in the same customer memory the revenue agent writes to.
 
-None of these is a product you buy. Each is a watcher and a loop you define, on shared memory, so the finance agent and the revenue agent are looking at the same Acme. A stack of vertical tools can never do that. Each one owns a slice, and none of them owns the company.
+None of these has to be a product you buy. Each is a watcher and a loop you define, on shared memory, so the finance agent and the revenue agent are looking at the same Acme. That is the part a stack of separate tools struggles with: each owns a slice, and none of them owns the whole customer.
 
 ## The memory is what makes it compound
 
@@ -94,6 +108,6 @@ In Lobu every agent in the org reads the same events log, so the watcher that ra
 
 ## The new SaaS is a loop you own
 
-Stop shopping for a tool per function. Decide what should wake each agent, what it can touch, which model runs it, and what it should remember, then wire that once on one backend. And that backend is open source, so it runs on your own machines and the loop and the memory it builds stay yours. Vertical SaaS sold you someone else's loop on someone else's servers. This one is yours.
+So the unit you ship moves. Instead of buying a tool per function, you decide what should wake each agent, what it can touch, which model runs it, and what it should remember, and you wire that once on one backend you run yourself. Lobu is open source, so the loop and the memory it builds stay on your machines. Vertical SaaS sold you someone else's loop on someone else's servers. This one is yours.
 
 Start with the [docs](/getting-started/), or read how the [memory layer](/getting-started/memory/) works.


### PR DESCRIPTION
Revisions to the live agent-loop post after a critical review, before promoting it.

Adds a concrete defineWatcher worked example (the real `@lobu/cli/config` API): a failed-payment event, the watcher config, the #cs approval gate, and the recovery_note.sent event it writes back as the audit trail. Narrows the body thesis from a blanket 'agents replace SaaS' to 'the workflow layer above your systems of record is becoming agent loops'. Cuts absolute claims and spells out what actually bounds an agent (egress allowlist, no secrets in the worker, approval for destructive actions, full append-only audit).

Content-only MDX change; the frontend build check verifies it renders.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1425"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784601783&installation_id=136316292&pr_number=1425&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1425&signature=c4a23f2e38a1b892b47da31c36d31689cfdbbb5082662eff7a790cc45440e23a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced blog post explaining agent loops as the successor to vertical SaaS, including improved walkthroughs, expanded examples of agent configurations with scheduling and approval workflows, and clearer distinctions between workflow layers and systems of record.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->