### PR TITLE
fix(builder): reliable builder provisioning — deterministic resolve + self-heal

### DIFF
--- a/packages/server/src/__tests__/integration/auth/builder-provisioning-e2e.test.ts
+++ b/packages/server/src/__tests__/integration/auth/builder-provisioning-e2e.test.ts
@@ -20,7 +20,10 @@ import {
 	ensureBuilderAgent,
 } from "../../../auth/builder-provisioning";
 import { cleanupTestDatabase, getTestDb } from "../../setup/test-db";
-import { createTestOrganization } from "../../setup/test-fixtures";
+import {
+	createTestOrganization,
+	createTestUser,
+} from "../../setup/test-fixtures";
 
 const HERE = path.dirname(fileURLToPath(import.meta.url));
 // packages/server/src/__tests__/integration/auth → repo root (6 levels up).
@@ -170,6 +173,39 @@ describe("ensureBuilderAgent — provisioning reliability", () => {
 				else process.env[k] = v;
 			}
 		}
+	});
+
+	it("reconciles a legacy healthy builder: sets pointer + agent_users + sentinel", async () => {
+		// A healthy builder row that a partial/legacy create left without a
+		// pointer, ownership mapping, or sentinel. The backfill must heal all three.
+		const owner = await createTestUser();
+		const org = await createTestOrganization({ name: "builder legacy" });
+		await sql`
+      UPDATE "organization"
+      SET metadata = ${JSON.stringify({ personal_org_for_user_id: owner.id })}
+      WHERE id = ${org.id}
+    `;
+		await sql`
+      INSERT INTO agents (id, organization_id, name, owner_platform, installed_providers, model, created_at, updated_at)
+      VALUES (${BUILDER_AGENT_ID}, ${org.id}, 'Builder', 'external',
+        '[{"providerId":"openai","installedAt":1}]'::jsonb, 'openai/gpt-4o', now(), now())
+    `;
+
+		await ensureBuilderAgent(org.id, sql);
+
+		expect(await readPointer(org.id)).toBe(BUILDER_AGENT_ID);
+		const md = (await sql`
+      SELECT metadata FROM "organization" WHERE id = ${org.id} LIMIT 1
+    `) as unknown as Array<{ metadata: string | null }>;
+		expect(
+			JSON.parse(md[0]?.metadata ?? "{}")[BUILDER_AGENT_SENTINEL],
+		).toBeTruthy();
+		const au = (await sql`
+      SELECT 1 FROM agent_users
+      WHERE organization_id = ${org.id} AND agent_id = ${BUILDER_AGENT_ID}
+        AND user_id = ${owner.id}
+    `) as unknown as Array<unknown>;
+		expect(au.length).toBe(1);
 	});
 
 	it("does NOT recreate a builder an admin deleted (sentinel set, row absent)", async () => {

--- a/packages/server/src/__tests__/integration/auth/builder-provisioning-e2e.test.ts
+++ b/packages/server/src/__tests__/integration/auth/builder-provisioning-e2e.test.ts
@@ -168,6 +168,18 @@ describe("ensureBuilderAgent — provisioning reliability", () => {
 		expect(await readPointer(org.id)).toBeNull();
 	});
 
+	it("heals a healthy builder whose org pointer is NULL (crash between insert and pointer write)", async () => {
+		const org = await createTestOrganization({ name: "builder pointerless" });
+		await ensureBuilderAgent(org.id, sql); // healthy builder + pointer
+		// Simulate a crash that left the row but never wrote the pointer.
+		await sql`UPDATE "organization" SET system_agent_id = NULL WHERE id = ${org.id}`;
+		expect(await readPointer(org.id)).toBeNull();
+
+		await ensureBuilderAgent(org.id, sql); // fast path must re-set the pointer
+
+		expect(await readPointer(org.id)).toBe(BUILDER_AGENT_ID);
+	});
+
 	it("does not clobber a working builder, and never overwrites the model/providers (idempotent fast path)", async () => {
 		const org = await createTestOrganization({ name: "builder idempotent" });
 		await ensureBuilderAgent(org.id, sql);

--- a/packages/server/src/__tests__/integration/auth/builder-provisioning-e2e.test.ts
+++ b/packages/server/src/__tests__/integration/auth/builder-provisioning-e2e.test.ts
@@ -12,7 +12,7 @@
 
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { access } from "node:fs/promises";
+import { access, readFile } from "node:fs/promises";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import {
 	BUILDER_AGENT_ID,
@@ -112,18 +112,21 @@ describe("ensureBuilderAgent — provisioning reliability", () => {
 		// Anthropic/Claude is the canonical platform key but isn't in
 		// providers.json, so this exercises the env-var fallback with an empty
 		// registry — the case that would otherwise yield 0 providers / no model.
+		// Hermetic: clear EVERY providers.json env var (read from the file so the
+		// list can't drift) plus the Claude env vars, then set only Anthropic.
+		const raw = JSON.parse(await readFile(PROVIDERS_JSON, "utf-8")) as {
+			providers: Array<{ providers?: Array<{ envVarName?: string }> }>;
+		};
+		const configEnvVars = raw.providers.flatMap((e) =>
+			(e.providers ?? []).map((p) => p.envVarName).filter(Boolean),
+		) as string[];
 		const cleared = [
-			"OPENAI_API_KEY",
-			"GEMINI_API_KEY",
-			"Z_AI_API_KEY",
-			"GROQ_API_KEY",
-			"MISTRAL_API_KEY",
-			"DEEPSEEK_API_KEY",
-			"COHERE_API_KEY",
-			"XAI_API_KEY",
-			"ANTHROPIC_API_KEY",
-			"ANTHROPIC_AUTH_TOKEN",
-			"CLAUDE_CODE_OAUTH_TOKEN",
+			...new Set([
+				...configEnvVars,
+				"ANTHROPIC_API_KEY",
+				"ANTHROPIC_AUTH_TOKEN",
+				"CLAUDE_CODE_OAUTH_TOKEN",
+			]),
 		];
 		const saved: Record<string, string | undefined> = {};
 		for (const v of cleared) {

--- a/packages/server/src/__tests__/integration/auth/builder-provisioning-e2e.test.ts
+++ b/packages/server/src/__tests__/integration/auth/builder-provisioning-e2e.test.ts
@@ -108,6 +108,26 @@ describe("ensureBuilderAgent — provisioning reliability", () => {
 		expect(b?.model).toBe("openai/gpt-4o");
 	});
 
+	it("keeps providers + pinned model consistent when repairing a model-only gap", async () => {
+		// Legacy builder: a provider installed but no model. The repair must not
+		// pin a model whose provider isn't installed (no dangling ref).
+		const org = await createTestOrganization({ name: "builder model-gap" });
+		await sql`
+      INSERT INTO agents (id, organization_id, name, owner_platform, installed_providers, model, created_at, updated_at)
+      VALUES (${BUILDER_AGENT_ID}, ${org.id}, 'Builder', 'external',
+        '[{"providerId":"claude","installedAt":1}]'::jsonb, NULL, now(), now())
+    `;
+
+		const res = await ensureBuilderAgent(org.id, sql);
+
+		expect(res.created).toBe(false);
+		const b = await readBuilder(org.id);
+		expect(b?.model).toBeTruthy();
+		// Invariant: the pinned model's provider is always installed.
+		const pid = b?.model?.slice(0, b.model.indexOf("/")) ?? "";
+		expect(b?.installed_providers?.some((p) => p.providerId === pid)).toBe(true);
+	});
+
 	it("provisions a usable builder when ONLY an Anthropic system key is present (not in providers.json)", async () => {
 		// Anthropic/Claude is the canonical platform key but isn't in
 		// providers.json, so this exercises the env-var fallback with an empty

--- a/packages/server/src/__tests__/integration/auth/builder-provisioning-e2e.test.ts
+++ b/packages/server/src/__tests__/integration/auth/builder-provisioning-e2e.test.ts
@@ -108,6 +108,47 @@ describe("ensureBuilderAgent — provisioning reliability", () => {
 		expect(b?.model).toBe("openai/gpt-4o");
 	});
 
+	it("provisions a usable builder when ONLY an Anthropic system key is present (not in providers.json)", async () => {
+		// Anthropic/Claude is the canonical platform key but isn't in
+		// providers.json, so this exercises the env-var fallback with an empty
+		// registry — the case that would otherwise yield 0 providers / no model.
+		const cleared = [
+			"OPENAI_API_KEY",
+			"GEMINI_API_KEY",
+			"Z_AI_API_KEY",
+			"GROQ_API_KEY",
+			"MISTRAL_API_KEY",
+			"DEEPSEEK_API_KEY",
+			"COHERE_API_KEY",
+			"XAI_API_KEY",
+			"ANTHROPIC_API_KEY",
+			"ANTHROPIC_AUTH_TOKEN",
+			"CLAUDE_CODE_OAUTH_TOKEN",
+		];
+		const saved: Record<string, string | undefined> = {};
+		for (const v of cleared) {
+			saved[v] = process.env[v];
+			delete process.env[v];
+		}
+		process.env.ANTHROPIC_API_KEY = "sk-ant-test-builder";
+		try {
+			const org = await createTestOrganization({ name: "builder anthropic" });
+			const res = await ensureBuilderAgent(org.id, sql);
+
+			expect(res.created).toBe(true);
+			const b = await readBuilder(org.id);
+			expect(
+				b?.installed_providers?.some((p) => p.providerId === "claude"),
+			).toBe(true);
+			expect(b?.model).toBe("claude/claude-sonnet-4-6");
+		} finally {
+			for (const [k, v] of Object.entries(saved)) {
+				if (v === undefined) delete process.env[k];
+				else process.env[k] = v;
+			}
+		}
+	});
+
 	it("does NOT recreate a builder an admin deleted (sentinel set, row absent)", async () => {
 		const org = await createTestOrganization({ name: "builder deleted" });
 		// Sentinel set + no builder row = admin deleted it; must stay deleted.

--- a/packages/server/src/__tests__/integration/auth/builder-provisioning-e2e.test.ts
+++ b/packages/server/src/__tests__/integration/auth/builder-provisioning-e2e.test.ts
@@ -1,0 +1,141 @@
+/**
+ * ensureBuilderAgent — provisioning reliability e2e.
+ *
+ * Reproduces + guards the prod bug: the builder was provisioned with
+ * `installed_providers = []` and no model whenever the live module registry
+ * wasn't populated, and the org sentinel then made that broken state
+ * permanent. This test process never boots the gateway, so the module registry
+ * is empty here too — exactly the prod failure mode. The fix resolves
+ * providers/model deterministically from `config/providers.json` and repairs
+ * builders stuck in the broken state.
+ */
+
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { access } from "node:fs/promises";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+	BUILDER_AGENT_ID,
+	BUILDER_AGENT_SENTINEL,
+	ensureBuilderAgent,
+} from "../../../auth/builder-provisioning";
+import { cleanupTestDatabase, getTestDb } from "../../setup/test-db";
+import { createTestOrganization } from "../../setup/test-fixtures";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+// packages/server/src/__tests__/integration/auth → repo root (6 levels up).
+const PROVIDERS_JSON = path.resolve(HERE, "../../../../../../config/providers.json");
+
+describe("ensureBuilderAgent — provisioning reliability", () => {
+	const sql = getTestDb();
+	const prevRegistryPath = process.env.LOBU_PROVIDER_REGISTRY_PATH;
+	const prevOpenAI = process.env.OPENAI_API_KEY;
+
+	beforeAll(async () => {
+		await cleanupTestDatabase();
+		// Provider resolution reads providers.json directly; point it at the
+		// repo-root file and give it a system key so `openai` resolves with its
+		// declared default model (`gpt-4o`).
+		await access(PROVIDERS_JSON); // fail loudly if the path is wrong
+		process.env.LOBU_PROVIDER_REGISTRY_PATH = PROVIDERS_JSON;
+		process.env.OPENAI_API_KEY = "sk-test-builder-provisioning";
+	});
+
+	afterAll(() => {
+		if (prevRegistryPath === undefined)
+			delete process.env.LOBU_PROVIDER_REGISTRY_PATH;
+		else process.env.LOBU_PROVIDER_REGISTRY_PATH = prevRegistryPath;
+		if (prevOpenAI === undefined) delete process.env.OPENAI_API_KEY;
+		else process.env.OPENAI_API_KEY = prevOpenAI;
+	});
+
+	async function readBuilder(orgId: string) {
+		const rows = (await sql`
+      SELECT installed_providers, model FROM agents
+      WHERE organization_id = ${orgId} AND id = ${BUILDER_AGENT_ID} LIMIT 1
+    `) as unknown as Array<{
+			installed_providers: Array<{ providerId: string }> | null;
+			model: string | null;
+		}>;
+		return rows[0];
+	}
+
+	async function readPointer(orgId: string): Promise<string | null> {
+		const rows = (await sql`
+      SELECT system_agent_id FROM "organization" WHERE id = ${orgId} LIMIT 1
+    `) as unknown as Array<{ system_agent_id: string | null }>;
+		return rows[0]?.system_agent_id ?? null;
+	}
+
+	it("provisions a builder with providers + a pinned model even when the module registry is empty", async () => {
+		const org = await createTestOrganization({ name: "builder fresh" });
+		const res = await ensureBuilderAgent(org.id, sql);
+
+		expect(res.created).toBe(true);
+		const b = await readBuilder(org.id);
+		expect(b).toBeTruthy();
+		expect(Array.isArray(b?.installed_providers)).toBe(true);
+		expect(b?.installed_providers?.length ?? 0).toBeGreaterThan(0);
+		expect(
+			b?.installed_providers?.some((p) => p.providerId === "openai"),
+		).toBe(true);
+		// Deterministic default from providers.json (`openai` → `gpt-4o`).
+		expect(b?.model).toBe("openai/gpt-4o");
+		expect(await readPointer(org.id)).toBe(BUILDER_AGENT_ID);
+	});
+
+	it("repairs a builder stuck with empty providers/model (sentinel no longer makes breakage permanent)", async () => {
+		const org = await createTestOrganization({ name: "builder broken" });
+		// Simulate the prod failure: builder row with no providers/model, and the
+		// sentinel already written — the old code skipped on the sentinel and left
+		// it broken forever.
+		await sql`
+      INSERT INTO agents (id, organization_id, name, owner_platform, installed_providers, model, created_at, updated_at)
+      VALUES (${BUILDER_AGENT_ID}, ${org.id}, 'Builder', 'external', '[]'::jsonb, NULL, now(), now())
+    `;
+		await sql`
+      UPDATE "organization"
+      SET system_agent_id = ${BUILDER_AGENT_ID},
+          metadata = ${JSON.stringify({ [BUILDER_AGENT_SENTINEL]: "2026-01-01" })}
+      WHERE id = ${org.id}
+    `;
+
+		const res = await ensureBuilderAgent(org.id, sql);
+
+		expect(res.created).toBe(false);
+		const b = await readBuilder(org.id);
+		expect(b?.installed_providers?.length ?? 0).toBeGreaterThan(0);
+		expect(b?.model).toBe("openai/gpt-4o");
+	});
+
+	it("does NOT recreate a builder an admin deleted (sentinel set, row absent)", async () => {
+		const org = await createTestOrganization({ name: "builder deleted" });
+		// Sentinel set + no builder row = admin deleted it; must stay deleted.
+		await sql`
+      UPDATE "organization"
+      SET metadata = ${JSON.stringify({ [BUILDER_AGENT_SENTINEL]: "2026-01-01" })}
+      WHERE id = ${org.id}
+    `;
+
+		const res = await ensureBuilderAgent(org.id, sql);
+
+		expect(res.created).toBe(false);
+		expect(await readBuilder(org.id)).toBeUndefined();
+		expect(await readPointer(org.id)).toBeNull();
+	});
+
+	it("does not clobber a working builder, and never overwrites the model/providers (idempotent fast path)", async () => {
+		const org = await createTestOrganization({ name: "builder idempotent" });
+		await ensureBuilderAgent(org.id, sql);
+		const before = await readBuilder(org.id);
+
+		const res = await ensureBuilderAgent(org.id, sql);
+
+		expect(res.created).toBe(false);
+		const after = await readBuilder(org.id);
+		expect(after?.model).toBe(before?.model);
+		expect(after?.installed_providers?.length).toBe(
+			before?.installed_providers?.length,
+		);
+	});
+});

--- a/packages/server/src/auth/builder-provisioning.ts
+++ b/packages/server/src/auth/builder-provisioning.ts
@@ -324,22 +324,50 @@ export async function ensureBuilderAgent(
         return { created: false };
       }
 
-      // Heal: fill only the empty fields, and only with something non-empty.
+      // Heal: fill the empty fields while keeping providers + model CONSISTENT —
+      // the pinned model's provider must always be among installed_providers, so
+      // we never leave a dangling ref (e.g. model=openai/... with providers=[claude]).
       const resolved = await resolveBuilderProviders();
-      const needProviders = providersEmpty && resolved.providers.length > 0;
-      const needModel = modelEmpty && !!resolved.model;
-      if (needProviders || needModel) {
+      const existingProviders: InstalledProvider[] = Array.isArray(
+        existing.installed_providers
+      )
+        ? existing.installed_providers
+        : [];
+      // Keep an existing model if present, otherwise take the resolved pick.
+      const newModel = modelEmpty ? resolved.model : existing.model;
+      // Providers = existing ∪ resolved, plus the (new) model's own provider.
+      const providerMap = new Map<string, InstalledProvider>();
+      for (const p of existingProviders) providerMap.set(p.providerId, p);
+      for (const p of resolved.providers) {
+        if (!providerMap.has(p.providerId)) providerMap.set(p.providerId, p);
+      }
+      if (newModel) {
+        const slash = newModel.indexOf('/');
+        const modelProviderId = slash > 0 ? newModel.slice(0, slash) : '';
+        if (modelProviderId && !providerMap.has(modelProviderId)) {
+          providerMap.set(modelProviderId, {
+            providerId: modelProviderId,
+            installedAt: Date.now(),
+          });
+        }
+      }
+      const mergedProviders = [...providerMap.values()];
+      // `mergedProviders` only ever grows (union), so a length change means we
+      // added at least one provider.
+      const writeProviders = mergedProviders.length !== existingProviders.length;
+      const writeModel = modelEmpty && !!newModel;
+      if (writeProviders || writeModel) {
         await client`
           UPDATE agents SET
-            installed_providers = CASE WHEN ${needProviders}
-              THEN ${client.json(resolved.providers)} ELSE installed_providers END,
-            model = CASE WHEN ${needModel}
-              THEN ${resolved.model} ELSE model END,
+            installed_providers = CASE WHEN ${writeProviders}
+              THEN ${client.json(mergedProviders)} ELSE installed_providers END,
+            model = CASE WHEN ${writeModel}
+              THEN ${newModel} ELSE model END,
             updated_at = now()
           WHERE organization_id = ${organizationId} AND id = ${BUILDER_AGENT_ID}
         `;
         logger.info(
-          { organizationId, needProviders, needModel, model: resolved.model },
+          { organizationId, writeProviders, writeModel, model: newModel },
           '[builder-provisioning] Repaired builder providers/model'
         );
       }

--- a/packages/server/src/auth/builder-provisioning.ts
+++ b/packages/server/src/auth/builder-provisioning.ts
@@ -56,20 +56,42 @@ const BUILDER_AGENT_IDENTITY =
   'clearly and suggest what they could connect or grant next.';
 
 /**
- * Capability/reliability preference for the builder's *pinned* model. We pin
- * the first provider here that (a) has a system key in this environment and
- * (b) declares a `defaultModel` in providers.json. Providers not listed are
- * still installed; they just aren't preferred for the initial pin.
+ * Preference for the builder's *pinned* model among providers declared in
+ * config/providers.json. We pin the first provider here that (a) has a system
+ * key in this environment and (b) declares a `defaultModel`. These ids are
+ * config-maintained, so they stay current without a code change. Providers not
+ * listed are still installed; they just aren't preferred for the initial pin.
  */
 const BUILDER_MODEL_PROVIDER_PREFERENCE = [
-  'anthropic',
   'openai',
   'gemini',
-  'z-ai',
   'groq',
   'mistral',
   'deepseek',
+  'cohere',
+  'xai',
 ];
+
+/**
+ * Anthropic/Claude is the canonical platform provider but is intentionally NOT
+ * in config/providers.json (its model list is fetched live from the provider).
+ * Resolve it directly from its env vars so an Anthropic-only deployment still
+ * gets a working builder even when the live module registry is empty. The
+ * fallback model is a last resort, used only when no config-declared provider
+ * model is available — prod also carries openai/gemini keys, so it pins one of
+ * those instead and this snapshot is rarely reached.
+ */
+const CLAUDE_PROVIDER_ID = 'claude';
+const CLAUDE_SYSTEM_ENV_VARS = [
+  'ANTHROPIC_API_KEY',
+  'ANTHROPIC_AUTH_TOKEN',
+  'CLAUDE_CODE_OAUTH_TOKEN',
+];
+const CLAUDE_FALLBACK_MODEL = 'claude/claude-sonnet-4-6';
+
+function hasClaudeSystemKey(): boolean {
+  return CLAUDE_SYSTEM_ENV_VARS.some((v) => !!resolveEnv(v));
+}
 
 interface InstalledProvider {
   providerId: string;
@@ -113,7 +135,18 @@ async function resolveBuilderProviders(): Promise<ResolvedBuilderProviders> {
     }
   }
 
-  // (2) Best-effort union with the live module registry (additive).
+  // (2) Anthropic/Claude — the canonical platform provider, not in
+  // providers.json. Resolve it from its env vars directly so an Anthropic-only
+  // deployment still gets a provider, registry or not.
+  if (hasClaudeSystemKey()) {
+    installed.set(CLAUDE_PROVIDER_ID, {
+      providerId: CLAUDE_PROVIDER_ID,
+      installedAt: now,
+    });
+  }
+
+  // (3) Best-effort union with the live module registry (additive — picks up
+  // any further providers it knows about when it happens to be initialized).
   try {
     for (const m of getModelProviderModules()) {
       if (m.hasSystemKey() && !installed.has(m.providerId)) {
@@ -121,7 +154,7 @@ async function resolveBuilderProviders(): Promise<ResolvedBuilderProviders> {
       }
     }
   } catch {
-    // Registry not available — the providers.json floor already applies.
+    // Registry not available — the providers.json + Claude floor already applies.
   }
 
   // Pin a model deterministically from providers.json `defaultModel`, preferring
@@ -145,6 +178,11 @@ async function resolveBuilderProviders(): Promise<ResolvedBuilderProviders> {
       model = pickModel(providerId);
       if (model) break;
     }
+  }
+  // Last resort: Claude has no providers.json default, so pin a current snapshot
+  // when it's the only system key available (e.g. an Anthropic-only deploy).
+  if (!model && hasClaudeSystemKey()) {
+    model = CLAUDE_FALLBACK_MODEL;
   }
 
   return { providers: [...installed.values()], model };

--- a/packages/server/src/auth/builder-provisioning.ts
+++ b/packages/server/src/auth/builder-provisioning.ts
@@ -5,9 +5,9 @@
  * that manages agents, connections, watchers, and workflows on the user's
  * behalf. `organization.system_agent_id` points at it.
  *
- * Mirrors `default-provisioning.ts` exactly:
- *   - installs system-key model providers up front (so the agent can chat the
- *     moment it's created, instead of "No model configured"),
+ *   - installs system-key model providers + pins a default model up front (so
+ *     the agent can chat the moment it's created, instead of "No model
+ *     configured"),
  *   - attributes ownership to the personal-org owner via the
  *     `personal_org_for_user_id` org-metadata marker,
  *   - writes a sentinel into `organization.metadata` so a deleted builder agent
@@ -15,16 +15,30 @@
  *   - is best-effort / non-throwing: a failure here must never break the boot
  *     or signup path that called us.
  *
+ * Reliability: provider/model resolution reads `config/providers.json`
+ * directly (via `ProviderRegistryService`) rather than depending on the live
+ * `moduleRegistry` being populated. The registry is only fully wired during
+ * gateway boot, so a provisioning call that ran against an empty registry used
+ * to silently create a builder with `installed_providers = []` and no model —
+ * and the sentinel then made that broken state permanent. Reading the config
+ * file is deterministic regardless of where/when provisioning runs, and the
+ * repair path below heals any builder that was created in the broken state.
+ *
  * The agents PK is composite `(organization_id, id)`, so the same
  * `BUILDER_AGENT_ID` string per org is fine. The `system_agent_id` pointer is
  * only set when currently NULL — we never clobber an admin's explicit choice
  * (set via `manage_agents.set_system_agent`).
  */
 
+import type { ProviderConfigEntry } from '@lobu/core';
 import { getDb } from '../db/client';
 import type { DbClient } from '../db/client';
+import { resolveEnv } from '../gateway/auth/mcp/string-substitution';
 import { getModelProviderModules } from '../gateway/modules/module-system';
-import { collectProviderModelOptions } from '../gateway/auth/provider-model-options';
+import {
+  ProviderRegistryService,
+  resolveProviderRegistryPath,
+} from '../gateway/services/provider-registry-service';
 import logger from '../utils/logger';
 import { hasOrgSentinel } from './default-provisioning';
 
@@ -40,6 +54,101 @@ const BUILDER_AGENT_IDENTITY =
   'Be concrete and action-oriented; prefer making the change over describing it. ' +
   "If you don't yet have access to something the user wants to manage, say so " +
   'clearly and suggest what they could connect or grant next.';
+
+/**
+ * Capability/reliability preference for the builder's *pinned* model. We pin
+ * the first provider here that (a) has a system key in this environment and
+ * (b) declares a `defaultModel` in providers.json. Providers not listed are
+ * still installed; they just aren't preferred for the initial pin.
+ */
+const BUILDER_MODEL_PROVIDER_PREFERENCE = [
+  'anthropic',
+  'openai',
+  'gemini',
+  'z-ai',
+  'groq',
+  'mistral',
+  'deepseek',
+];
+
+interface InstalledProvider {
+  providerId: string;
+  installedAt: number;
+}
+
+interface ResolvedBuilderProviders {
+  providers: InstalledProvider[];
+  model: string | null;
+}
+
+/**
+ * Resolve the system-key providers + a default model to install on the builder.
+ *
+ * Primary source is `config/providers.json` (read directly — independent of the
+ * runtime module registry), so this returns the same result regardless of
+ * whether the gateway's `moduleRegistry` has been initialized in this process.
+ * We additionally union in any system-key providers the live registry knows
+ * about (e.g. anthropic / OAuth backends that aren't in providers.json) when it
+ * happens to be available — purely additive, never required.
+ */
+async function resolveBuilderProviders(): Promise<ResolvedBuilderProviders> {
+  const now = Date.now();
+  const installed = new Map<string, InstalledProvider>();
+
+  // (1) Deterministic floor: providers declared in config/providers.json whose
+  // env var is present in this process.
+  let configs: Record<string, ProviderConfigEntry> = {};
+  try {
+    const registry = new ProviderRegistryService(resolveProviderRegistryPath());
+    configs = await registry.getProviderConfigs();
+  } catch (err) {
+    logger.warn(
+      { err: err instanceof Error ? err.message : String(err) },
+      '[builder-provisioning] providers.json read failed; relying on module registry'
+    );
+  }
+  for (const [providerId, cfg] of Object.entries(configs)) {
+    if (cfg.envVarName && resolveEnv(cfg.envVarName)) {
+      installed.set(providerId, { providerId, installedAt: now });
+    }
+  }
+
+  // (2) Best-effort union with the live module registry (additive).
+  try {
+    for (const m of getModelProviderModules()) {
+      if (m.hasSystemKey() && !installed.has(m.providerId)) {
+        installed.set(m.providerId, { providerId: m.providerId, installedAt: now });
+      }
+    }
+  } catch {
+    // Registry not available — the providers.json floor already applies.
+  }
+
+  // Pin a model deterministically from providers.json `defaultModel`, preferring
+  // the capability order above, then any other env-matched provider that
+  // declares a default.
+  const pickModel = (providerId: string): string | null => {
+    const cfg = configs[providerId];
+    const dm = cfg?.defaultModel?.trim();
+    if (cfg?.envVarName && resolveEnv(cfg.envVarName) && dm) {
+      return dm.includes('/') ? dm : `${providerId}/${dm}`;
+    }
+    return null;
+  };
+  let model: string | null = null;
+  for (const providerId of BUILDER_MODEL_PROVIDER_PREFERENCE) {
+    model = pickModel(providerId);
+    if (model) break;
+  }
+  if (!model) {
+    for (const providerId of Object.keys(configs)) {
+      model = pickModel(providerId);
+      if (model) break;
+    }
+  }
+
+  return { providers: [...installed.values()], model };
+}
 
 /**
  * Read the JSON-decoded `organization.metadata` for the given org. Returns an
@@ -85,21 +194,56 @@ async function writeOrgSentinel(
   `;
 }
 
+/** Resolve the org's canonical owner from the personal-org metadata marker. */
+async function resolveOwnerUserId(
+  sql: DbClient,
+  organizationId: string
+): Promise<string | null> {
+  const md = await readOrgMetadata(sql, organizationId);
+  const raw = md['personal_org_for_user_id'];
+  return typeof raw === 'string' && raw.length > 0 ? raw : null;
+}
+
+/**
+ * Idempotently mirror ownership into agent_users and point the org at the
+ * builder. The pointer is only written when currently NULL so an admin's
+ * explicit `set_system_agent` choice is never clobbered.
+ */
+async function linkOwnerAndPointer(
+  sql: DbClient,
+  organizationId: string,
+  ownerUserId: string | null
+): Promise<void> {
+  if (ownerUserId) {
+    await sql`
+      INSERT INTO agent_users (organization_id, agent_id, platform, user_id, created_at)
+      VALUES (${organizationId}, ${BUILDER_AGENT_ID}, 'external', ${ownerUserId}, now())
+      ON CONFLICT (organization_id, agent_id, platform, user_id) DO NOTHING
+    `;
+  }
+  await sql`
+    UPDATE "organization"
+    SET system_agent_id = ${BUILDER_AGENT_ID}
+    WHERE id = ${organizationId}
+      AND system_agent_id IS NULL
+  `;
+}
+
 /**
  * Provision the org's builder agent and point `organization.system_agent_id`
- * at it, exactly once.
+ * at it — creating it if missing, or healing it if a prior run left it with no
+ * providers / no model.
  *
- * Guards on the create path:
- *   1. Sentinel in `organization.metadata` (deletion stickiness — a deleted
- *      builder agent is NOT auto-recreated).
- *   2. ON CONFLICT (organization_id, id) DO NOTHING on the agents PK (guards a
- *      parallel boot / concurrent signup).
+ * Behaviour:
+ *   - Builder row present + has providers and a model → no-op (fast path).
+ *   - Builder row present but missing providers/model → repair (fill the empty
+ *     fields; never removes a working config).
+ *   - Builder row absent + sentinel set → respect deletion (do NOT recreate).
+ *   - Builder row absent + no sentinel → create.
  *
- * The `system_agent_id` pointer is only written when it's currently NULL, so an
- * admin who later repoints it via `manage_agents.set_system_agent` is never
- * clobbered on a subsequent boot.
- *
- * Best-effort: a thrown error is logged and swallowed.
+ * Idempotent and safe under concurrent replicas (ON CONFLICT / NULL-guarded
+ * pointer / conditional repair). Best-effort: a thrown error is logged and
+ * swallowed.
  */
 export async function ensureBuilderAgent(
   organizationId: string,
@@ -107,6 +251,56 @@ export async function ensureBuilderAgent(
 ): Promise<{ created: boolean }> {
   const client = sql ?? getDb();
   try {
+    const rows = (await client`
+      SELECT installed_providers, model FROM agents
+      WHERE organization_id = ${organizationId} AND id = ${BUILDER_AGENT_ID}
+      LIMIT 1
+    `) as unknown as Array<{
+      installed_providers: InstalledProvider[] | null;
+      model: string | null;
+    }>;
+    const existing = rows[0];
+
+    if (existing) {
+      const providersEmpty =
+        !Array.isArray(existing.installed_providers) ||
+        existing.installed_providers.length === 0;
+      const modelEmpty = !existing.model || String(existing.model).trim() === '';
+
+      // Healthy — fast path (one SELECT), no provider-config read.
+      if (!providersEmpty && !modelEmpty) {
+        return { created: false };
+      }
+
+      // Heal: fill only the empty fields, and only with something non-empty.
+      const resolved = await resolveBuilderProviders();
+      const needProviders = providersEmpty && resolved.providers.length > 0;
+      const needModel = modelEmpty && !!resolved.model;
+      if (needProviders || needModel) {
+        await client`
+          UPDATE agents SET
+            installed_providers = CASE WHEN ${needProviders}
+              THEN ${client.json(resolved.providers)} ELSE installed_providers END,
+            model = CASE WHEN ${needModel}
+              THEN ${resolved.model} ELSE model END,
+            updated_at = now()
+          WHERE organization_id = ${organizationId} AND id = ${BUILDER_AGENT_ID}
+        `;
+        logger.info(
+          { organizationId, needProviders, needModel, model: resolved.model },
+          '[builder-provisioning] Repaired builder providers/model'
+        );
+      }
+      await linkOwnerAndPointer(
+        client,
+        organizationId,
+        await resolveOwnerUserId(client, organizationId)
+      );
+      return { created: false };
+    }
+
+    // Builder row absent. Respect deletion stickiness: a set sentinel means an
+    // admin deleted the builder — do not recreate it.
     const provisioned = await hasOrgSentinel(
       organizationId,
       BUILDER_AGENT_SENTINEL,
@@ -116,51 +310,8 @@ export async function ensureBuilderAgent(
       return { created: false };
     }
 
-    // Resolve the set of model providers that have a system-level credential
-    // available at this boot and install them onto the builder agent up front.
-    // Without this, the row exists but `installed_providers = '[]'` and chatting
-    // with the builder agent would immediately hit "No model configured" — even
-    // though the env keys are sitting right there in the same process.
-    const systemProviders = getModelProviderModules()
-      .filter((m) => m.hasSystemKey())
-      .map((m) => ({
-        providerId: m.providerId,
-        installedAt: Date.now(),
-      }));
-
-    // Pin an explicit model so the builder can chat the moment it's created.
-    // Auto-mode no longer silently picks a provider default (an explicit model
-    // is required), so without this the first turn hits "No model selected".
-    // Pick the first installed system provider that exposes a model list and
-    // pin its first option as `provider/model` (the format resolveEffectiveModelRef
-    // expects). Best-effort: if nothing resolves, leave the model unset — the
-    // owner then picks one in the agent's Providers settings, same as any agent.
-    let pinnedModel: string | null = null;
-    try {
-      const optionsByProvider = await collectProviderModelOptions('', '');
-      for (const p of systemProviders) {
-        const first = optionsByProvider[p.providerId]?.[0]?.value?.trim();
-        if (first) {
-          pinnedModel = first.includes('/') ? first : `${p.providerId}/${first}`;
-          break;
-        }
-      }
-    } catch (err) {
-      logger.warn(
-        { organizationId, err: err instanceof Error ? err.message : String(err) },
-        '[builder-provisioning] Default-model resolution failed; leaving model unset'
-      );
-    }
-
-    // Resolve the owning user from the canonical personal-org marker, so the
-    // per-user ownership check in `verifyOwnedAgentAccess` recognizes the owner
-    // as the builder agent's owner.
-    const orgMetadata = await readOrgMetadata(client, organizationId);
-    const ownerForInsertRaw = orgMetadata['personal_org_for_user_id'];
-    const ownerUserId =
-      typeof ownerForInsertRaw === 'string' && ownerForInsertRaw.length > 0
-        ? ownerForInsertRaw
-        : null;
+    const resolved = await resolveBuilderProviders();
+    const ownerUserId = await resolveOwnerUserId(client, organizationId);
 
     await client`
       INSERT INTO agents (
@@ -171,31 +322,13 @@ export async function ensureBuilderAgent(
       ) VALUES (
         ${BUILDER_AGENT_ID}, ${organizationId}, ${BUILDER_AGENT_NAME}, ${BUILDER_AGENT_IDENTITY},
         'external', ${ownerUserId},
-        ${client.json(systemProviders)}, ${pinnedModel},
+        ${client.json(resolved.providers)}, ${resolved.model},
         NOW(), NOW()
       )
       ON CONFLICT (organization_id, id) DO NOTHING
     `;
 
-    // Mirror the ownership into agent_users so the per-user ownership path
-    // (cookie/PAT session) recognizes the owner as the builder agent's owner.
-    if (ownerUserId) {
-      await client`
-        INSERT INTO agent_users (organization_id, agent_id, platform, user_id, created_at)
-        VALUES (${organizationId}, ${BUILDER_AGENT_ID}, 'external', ${ownerUserId}, now())
-        ON CONFLICT (organization_id, agent_id, platform, user_id) DO NOTHING
-      `;
-    }
-
-    // Point the org at the builder agent — but only if no pointer is set yet.
-    // An admin who repointed `system_agent_id` (via manage_agents) must not be
-    // clobbered.
-    await client`
-      UPDATE "organization"
-      SET system_agent_id = ${BUILDER_AGENT_ID}
-      WHERE id = ${organizationId}
-        AND system_agent_id IS NULL
-    `;
+    await linkOwnerAndPointer(client, organizationId, ownerUserId);
 
     await writeOrgSentinel(
       client,
@@ -205,7 +338,13 @@ export async function ensureBuilderAgent(
     );
 
     logger.info(
-      { organizationId, agentId: BUILDER_AGENT_ID, ownerUserId },
+      {
+        organizationId,
+        agentId: BUILDER_AGENT_ID,
+        ownerUserId,
+        providers: resolved.providers.length,
+        model: resolved.model,
+      },
       '[builder-provisioning] Provisioned builder agent'
     );
     return { created: true };

--- a/packages/server/src/auth/builder-provisioning.ts
+++ b/packages/server/src/auth/builder-provisioning.ts
@@ -309,73 +309,74 @@ export async function ensureBuilderAgent(
         existing.installed_providers.length === 0;
       const modelEmpty = !existing.model || String(existing.model).trim() === '';
 
-      // Healthy — fast path: skip the provider-config resolution, but still
-      // ensure the org pointer is set. A builder row can exist with a NULL
-      // organization.system_agent_id if a prior run crashed between the INSERT
-      // and the pointer write; this idempotent (no-op when already set) UPDATE
-      // heals that on the next console load.
-      if (!providersEmpty && !modelEmpty) {
-        await client`
-          UPDATE "organization"
-          SET system_agent_id = ${BUILDER_AGENT_ID}
-          WHERE id = ${organizationId}
-            AND system_agent_id IS NULL
-        `;
-        return { created: false };
-      }
-
-      // Heal: fill the empty fields while keeping providers + model CONSISTENT —
-      // the pinned model's provider must always be among installed_providers, so
-      // we never leave a dangling ref (e.g. model=openai/... with providers=[claude]).
-      const resolved = await resolveBuilderProviders();
-      const existingProviders: InstalledProvider[] = Array.isArray(
-        existing.installed_providers
-      )
-        ? existing.installed_providers
-        : [];
-      // Keep an existing model if present, otherwise take the resolved pick.
-      const newModel = modelEmpty ? resolved.model : existing.model;
-      // Providers = existing ∪ resolved, plus the (new) model's own provider.
-      const providerMap = new Map<string, InstalledProvider>();
-      for (const p of existingProviders) providerMap.set(p.providerId, p);
-      for (const p of resolved.providers) {
-        if (!providerMap.has(p.providerId)) providerMap.set(p.providerId, p);
-      }
-      if (newModel) {
-        const slash = newModel.indexOf('/');
-        const modelProviderId = slash > 0 ? newModel.slice(0, slash) : '';
-        if (modelProviderId && !providerMap.has(modelProviderId)) {
-          providerMap.set(modelProviderId, {
-            providerId: modelProviderId,
-            installedAt: Date.now(),
-          });
+      // Heal providers/model only when broken, keeping providers + model
+      // CONSISTENT — the pinned model's provider must always be installed, so we
+      // never leave a dangling ref (e.g. model=openai/... with providers=[claude]).
+      // The healthy path skips this provider-config read entirely.
+      if (providersEmpty || modelEmpty) {
+        const resolved = await resolveBuilderProviders();
+        const existingProviders: InstalledProvider[] = Array.isArray(
+          existing.installed_providers
+        )
+          ? existing.installed_providers
+          : [];
+        // Keep an existing model if present, otherwise take the resolved pick.
+        const newModel = modelEmpty ? resolved.model : existing.model;
+        // Providers = existing ∪ resolved, plus the (new) model's own provider.
+        const providerMap = new Map<string, InstalledProvider>();
+        for (const p of existingProviders) providerMap.set(p.providerId, p);
+        for (const p of resolved.providers) {
+          if (!providerMap.has(p.providerId)) providerMap.set(p.providerId, p);
+        }
+        if (newModel) {
+          const slash = newModel.indexOf('/');
+          const modelProviderId = slash > 0 ? newModel.slice(0, slash) : '';
+          if (modelProviderId && !providerMap.has(modelProviderId)) {
+            providerMap.set(modelProviderId, {
+              providerId: modelProviderId,
+              installedAt: Date.now(),
+            });
+          }
+        }
+        const mergedProviders = [...providerMap.values()];
+        // Union only ever grows, so a length change means we added a provider.
+        const writeProviders =
+          mergedProviders.length !== existingProviders.length;
+        const writeModel = modelEmpty && !!newModel;
+        if (writeProviders || writeModel) {
+          await client`
+            UPDATE agents SET
+              installed_providers = CASE WHEN ${writeProviders}
+                THEN ${client.json(mergedProviders)} ELSE installed_providers END,
+              model = CASE WHEN ${writeModel}
+                THEN ${newModel} ELSE model END,
+              updated_at = now()
+            WHERE organization_id = ${organizationId} AND id = ${BUILDER_AGENT_ID}
+          `;
+          logger.info(
+            { organizationId, writeProviders, writeModel, model: newModel },
+            '[builder-provisioning] Repaired builder providers/model'
+          );
         }
       }
-      const mergedProviders = [...providerMap.values()];
-      // `mergedProviders` only ever grows (union), so a length change means we
-      // added at least one provider.
-      const writeProviders = mergedProviders.length !== existingProviders.length;
-      const writeModel = modelEmpty && !!newModel;
-      if (writeProviders || writeModel) {
-        await client`
-          UPDATE agents SET
-            installed_providers = CASE WHEN ${writeProviders}
-              THEN ${client.json(mergedProviders)} ELSE installed_providers END,
-            model = CASE WHEN ${writeModel}
-              THEN ${newModel} ELSE model END,
-            updated_at = now()
-          WHERE organization_id = ${organizationId} AND id = ${BUILDER_AGENT_ID}
-        `;
-        logger.info(
-          { organizationId, writeProviders, writeModel, model: newModel },
-          '[builder-provisioning] Repaired builder providers/model'
+
+      // Reconcile ownership + pointer + sentinel on every call — cheap idempotent
+      // writes that heal a builder whose create crashed between the INSERT and
+      // the follow-up writes (NULL system_agent_id, missing agent_users row, or
+      // missing deletion sentinel). Metadata is read once.
+      const md = await readOrgMetadata(client, organizationId);
+      const ownerRaw = md['personal_org_for_user_id'];
+      const ownerUserId =
+        typeof ownerRaw === 'string' && ownerRaw.length > 0 ? ownerRaw : null;
+      await linkOwnerAndPointer(client, organizationId, ownerUserId);
+      if (!md[BUILDER_AGENT_SENTINEL]) {
+        await writeOrgSentinel(
+          client,
+          organizationId,
+          BUILDER_AGENT_SENTINEL,
+          new Date().toISOString()
         );
       }
-      await linkOwnerAndPointer(
-        client,
-        organizationId,
-        await resolveOwnerUserId(client, organizationId)
-      );
       return { created: false };
     }
 

--- a/packages/server/src/auth/builder-provisioning.ts
+++ b/packages/server/src/auth/builder-provisioning.ts
@@ -33,6 +33,7 @@
 import type { ProviderConfigEntry } from '@lobu/core';
 import { getDb } from '../db/client';
 import type { DbClient } from '../db/client';
+import { collectProviderModelOptions } from '../gateway/auth/provider-model-options';
 import { resolveEnv } from '../gateway/auth/mcp/string-substitution';
 import { getModelProviderModules } from '../gateway/modules/module-system';
 import {
@@ -183,8 +184,30 @@ async function resolveBuilderProviders(): Promise<ResolvedBuilderProviders> {
       if (model) break;
     }
   }
-  // Last resort: Claude has no providers.json default, so pin a current snapshot
-  // when it's the only system key available (e.g. an Anthropic-only deploy).
+  // Module-only providers that aren't in providers.json (e.g. Bedrock) declare
+  // their model only via the live registry. This is reached only when no
+  // config-declared provider resolved a model — i.e. a module-only deployment,
+  // where the registry is populated by definition (those providers came from
+  // it). Best-effort; covers any such provider generically.
+  if (!model && installed.size > 0) {
+    try {
+      const optionsByProvider = await collectProviderModelOptions('', '');
+      for (const { providerId } of installed.values()) {
+        const first = optionsByProvider[providerId]?.[0]?.value?.trim();
+        if (first) {
+          model = first.startsWith(`${providerId}/`)
+            ? first
+            : `${providerId}/${first}`;
+          break;
+        }
+      }
+    } catch {
+      // Registry/model fetch unavailable — fall through to the Claude floor.
+    }
+  }
+  // Registry-independent floor: Claude has no providers.json default, so pin a
+  // current snapshot when it's the only system key available and nothing above
+  // resolved (e.g. an Anthropic-only deploy with an empty registry).
   if (!model && hasClaudeSystemKey()) {
     model = CLAUDE_FALLBACK_MODEL;
   }

--- a/packages/server/src/auth/builder-provisioning.ts
+++ b/packages/server/src/auth/builder-provisioning.ts
@@ -309,8 +309,18 @@ export async function ensureBuilderAgent(
         existing.installed_providers.length === 0;
       const modelEmpty = !existing.model || String(existing.model).trim() === '';
 
-      // Healthy — fast path (one SELECT), no provider-config read.
+      // Healthy — fast path: skip the provider-config resolution, but still
+      // ensure the org pointer is set. A builder row can exist with a NULL
+      // organization.system_agent_id if a prior run crashed between the INSERT
+      // and the pointer write; this idempotent (no-op when already set) UPDATE
+      // heals that on the next console load.
       if (!providersEmpty && !modelEmpty) {
+        await client`
+          UPDATE "organization"
+          SET system_agent_id = ${BUILDER_AGENT_ID}
+          WHERE id = ${organizationId}
+            AND system_agent_id IS NULL
+        `;
         return { created: false };
       }
 

--- a/packages/server/src/auth/builder-provisioning.ts
+++ b/packages/server/src/auth/builder-provisioning.ts
@@ -164,7 +164,11 @@ async function resolveBuilderProviders(): Promise<ResolvedBuilderProviders> {
     const cfg = configs[providerId];
     const dm = cfg?.defaultModel?.trim();
     if (cfg?.envVarName && resolveEnv(cfg.envVarName) && dm) {
-      return dm.includes('/') ? dm : `${providerId}/${dm}`;
+      // A model ref is parsed as `providerId/<rest>` (split on the FIRST slash),
+      // and a model id can itself contain slashes (e.g. openrouter's
+      // `anthropic/claude-sonnet-4`, together-ai's `meta-llama/...`). Always
+      // prefix the providerId so the ref resolves to the right provider.
+      return `${providerId}/${dm}`;
     }
     return null;
   };

--- a/packages/server/src/lobu/agent-routes.ts
+++ b/packages/server/src/lobu/agent-routes.ts
@@ -9,6 +9,7 @@ import { resolve } from 'node:path';
 import { encrypt, type AuthProfile } from '@lobu/core';
 import { Hono } from 'hono';
 import { mcpAuth } from '../auth/middleware';
+import { ensureBuilderAgent } from '../auth/builder-provisioning';
 import { getDb } from '../db/client';
 import { providerOrgSecretName } from './stores/provider-secrets';
 import { OAuthClient } from '../gateway/auth/oauth/client';
@@ -361,6 +362,12 @@ function hasFreshCredential(profiles: AuthProfile[]): boolean {
 routes.get('/system-agent', async (c) => {
   const orgId = c.get('organizationId')!;
   const sql = getDb();
+  // Backfill / heal the org's builder on demand. Orgs created before the
+  // builder feature have no system agent yet, and an org whose builder was
+  // provisioned before its providers resolved needs its providers/model filled
+  // in. ensureBuilderAgent is idempotent + one SELECT on the healthy path, and
+  // best-effort (never throws), so it can't break console load.
+  await ensureBuilderAgent(orgId, sql);
   const rows = await sql`
     SELECT system_agent_id FROM organization WHERE id = ${orgId} LIMIT 1
   `;


### PR DESCRIPTION
## Problem (found via prod verification)
The builder agent (`organization.system_agent_id`) was **non-functional in prod**:
- The only provisioned builder (`chrome-tester` org) had **`installed_providers = []` and no model** — it couldn't chat — even though the pod has `ANTHROPIC_API_KEY`/`OPENAI_API_KEY`/`GEMINI_API_KEY`/`Z_AI_API_KEY`/`CLAUDE_CODE_OAUTH_TOKEN` all set.
- **53 / 54 existing orgs had no builder at all** (provisioning only ran on new-org signup; no backfill).

### Root cause
`ensureBuilderAgent` resolved providers from the live `moduleRegistry` (`getModelProviderModules()`). That registry is only wired during gateway boot; when provisioning resolved against an empty/unready registry it installed **0 providers + no model**, and the org **sentinel then made that broken state permanent** (it returned early on the sentinel and never re-resolved). Works locally (bun, single module graph), silently breaks in the prod bundle.

## Fix
- `resolveBuilderProviders()` reads **`config/providers.json` directly** (via `ProviderRegistryService`, registry-independent) for system-key providers + a deterministic pinned default model, unioning in the live module registry only when it happens to be available (additive, never required).
- `ensureBuilderAgent` now **creates OR repairs**: a builder stuck with empty providers/model is healed (fills only empty fields, never degrades a working config). Deletion-stickiness preserved (sentinel + absent row ⇒ no recreate).
- `/system-agent` calls it on demand, so **pre-existing orgs are backfilled** and broken builders **self-heal** on first console load. Idempotent + one SELECT on the healthy fast path; multi-replica safe (ON CONFLICT / NULL-guarded pointer / conditional repair).

## E2E reproducer (red → green)
`packages/server/src/__tests__/integration/auth/builder-provisioning-e2e.test.ts` — the test process never boots the gateway, so the module registry is empty (the prod failure mode).

**RED** (origin/main provisioner, same test): `2 failed | 2 passed`
- ✗ provisions a builder with providers + pinned model when registry empty (old: 0 providers/no model)
- ✗ repairs a builder stuck with empty providers/model (old: sentinel skip ⇒ never repaired)

**GREEN** (this PR): `4 passed`
- ✓ fresh provision resolves `openai` + `openai/gpt-4o` from providers.json with an empty registry
- ✓ repairs a sentinel-locked broken builder
- ✓ does NOT recreate an admin-deleted builder
- ✓ idempotent fast path never clobbers a working config

## Post-merge (prod)
On deploy, existing orgs get a builder + the broken `chrome-tester` builder self-heals the next time the `/agents` console loads.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1426"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784602705&installation_id=136316292&pr_number=1426&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1426&signature=2c3088e3002fda90125bef7b866da43b5bf264784dd7f5f4e9412e6660965604"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved builder agent provisioning/repair for broken provider/model states, including missing pointers and legacy reconciliation.
  * Ensured repairs are idempotent and keep sentinel “do not recreate” behavior when appropriate.
  * Updated the system agent endpoint to initialize the builder agent before returning `system_agent_id`.
* **New Features**
  * Added deterministic provider/model selection from the configured provider registry, with explicit Claude fallback when only Anthropic credentials are available.
* **Tests**
  * Added an end-to-end integration test suite covering provisioning, multiple repair scenarios, and env fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->