### PR TITLE
fix(connectors): resolve OAuth app client creds from env in the connect path

### DIFF
--- a/packages/server/src/__tests__/integration/connectors/oauth-env-app-creds.test.ts
+++ b/packages/server/src/__tests__/integration/connectors/oauth-env-app-creds.test.ts
@@ -1,0 +1,281 @@
+/**
+ * Connector OAuth-connect APP credentials must fall back to deployment env vars
+ * (`${PROVIDER}_CLIENT_ID/_SECRET`) — the SAME fallback global LOGIN uses
+ * (`auth/config.ts resolveLoginProviderCredentials`). An org should be able to
+ * connect a connector whose OAuth app creds are env-configured with NO
+ * hand-created `oauth_app` profile and NO secret entry.
+ *
+ * Critical distinction this guards:
+ *  - the APP profile (client id/secret) falls back to env, but
+ *  - the per-user ACCOUNT token (oauth_account) + the Authorize redirect are
+ *    STILL required — the connection lands `pending_auth`, never silently
+ *    `active`.
+ */
+
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import type { Env } from '../../../index';
+import type { ToolContext } from '../../../tools/registry';
+import { manageAuthProfiles } from '../../../tools/admin/manage_auth_profiles';
+import { manageConnections } from '../../../tools/admin/manage_connections';
+import { resolveOAuthAppClientCredentials } from '../../../tools/admin/helpers/connection-helpers';
+import { getTestDb, cleanupTestDatabase } from '../../setup/test-db';
+import { initWorkspaceProvider } from '../../../workspace';
+import {
+  addUserToOrganization,
+  createTestConnectorDefinition,
+  createTestOrganization,
+  createTestUser,
+} from '../../setup/test-fixtures';
+
+const TEST_ENV = {} as Env;
+const CLIENT_ID_KEY = 'DEMOENV_CLIENT_ID';
+const CLIENT_SECRET_KEY = 'DEMOENV_CLIENT_SECRET';
+
+function ctxFor(organizationId: string, userId: string): ToolContext {
+  return {
+    organizationId,
+    userId,
+    memberRole: 'owner',
+    agentId: null,
+    isAuthenticated: true,
+    clientId: null,
+    scopes: ['mcp:read', 'mcp:write', 'mcp:admin'],
+    tokenType: 'oauth',
+    scopedToOrg: true,
+    allowCrossOrg: false,
+  } as ToolContext;
+}
+
+async function makeOAuthConnector(orgId: string) {
+  await createTestConnectorDefinition({
+    key: 'demoenv.oauth',
+    name: 'DemoEnv OAuth',
+    organization_id: orgId,
+    auth_schema: {
+      methods: [
+        {
+          type: 'oauth',
+          provider: 'demoenv',
+          requiredScopes: ['read'],
+          clientIdKey: CLIENT_ID_KEY,
+          clientSecretKey: CLIENT_SECRET_KEY,
+        },
+      ],
+    },
+    feeds_schema: { items: {} },
+  });
+}
+
+describe('resolveOAuthAppClientCredentials — env fallback (pure)', () => {
+  afterEach(() => {
+    delete process.env[CLIENT_ID_KEY];
+    delete process.env[CLIENT_SECRET_KEY];
+  });
+
+  it('resolves client id + secret from process.env when no app profile exists', () => {
+    process.env[CLIENT_ID_KEY] = 'env-client-id';
+    process.env[CLIENT_SECRET_KEY] = 'env-client-secret';
+
+    const resolved = resolveOAuthAppClientCredentials({
+      appProfileAuthData: null,
+      provider: 'demoenv',
+      clientIdKey: CLIENT_ID_KEY,
+      clientSecretKey: CLIENT_SECRET_KEY,
+    });
+
+    expect(resolved.clientId).toBe('env-client-id');
+    expect(resolved.clientSecret).toBe('env-client-secret');
+  });
+
+  it('derives default ${PROVIDER}_CLIENT_ID/_SECRET keys when the method omits them', () => {
+    process.env.DEMOENV_CLIENT_ID = 'default-key-id';
+    process.env.DEMOENV_CLIENT_SECRET = 'default-key-secret';
+
+    const resolved = resolveOAuthAppClientCredentials({
+      appProfileAuthData: null,
+      provider: 'demoenv',
+    });
+
+    expect(resolved.clientId).toBe('default-key-id');
+    expect(resolved.clientSecret).toBe('default-key-secret');
+  });
+
+  it('an explicit app profile wins over env (manual entry is authoritative)', () => {
+    process.env[CLIENT_ID_KEY] = 'env-client-id';
+    process.env[CLIENT_SECRET_KEY] = 'env-client-secret';
+
+    const resolved = resolveOAuthAppClientCredentials({
+      appProfileAuthData: {
+        [CLIENT_ID_KEY]: 'profile-client-id',
+        [CLIENT_SECRET_KEY]: 'profile-client-secret',
+      },
+      provider: 'demoenv',
+      clientIdKey: CLIENT_ID_KEY,
+      clientSecretKey: CLIENT_SECRET_KEY,
+    });
+
+    expect(resolved.clientId).toBe('profile-client-id');
+    expect(resolved.clientSecret).toBe('profile-client-secret');
+  });
+
+  it('returns null when neither a profile nor env carries the credentials', () => {
+    const resolved = resolveOAuthAppClientCredentials({
+      appProfileAuthData: null,
+      provider: 'demoenv',
+      clientIdKey: CLIENT_ID_KEY,
+      clientSecretKey: CLIENT_SECRET_KEY,
+    });
+
+    expect(resolved.clientId).toBeNull();
+    expect(resolved.clientSecret).toBeNull();
+  });
+});
+
+describe('connector OAuth connect — env-backed app credentials (DB-backed)', () => {
+  beforeAll(async () => {
+    await initWorkspaceProvider();
+  });
+
+  beforeEach(async () => {
+    await cleanupTestDatabase();
+  });
+
+  afterEach(() => {
+    delete process.env[CLIENT_ID_KEY];
+    delete process.env[CLIENT_SECRET_KEY];
+  });
+
+  it('creates the connection with ZERO hand-made app profile when env client creds are set, auto-provisioning an env-backed oauth_app profile — and the ACCOUNT step is still required', async () => {
+    process.env[CLIENT_ID_KEY] = 'env-client-id';
+    process.env[CLIENT_SECRET_KEY] = 'env-client-secret';
+
+    const org = await createTestOrganization({ name: 'Env Creds Org' });
+    const user = await createTestUser({ name: 'Env Creds User' });
+    await addUserToOrganization(user.id, org.id, 'owner');
+    const ctx = ctxFor(org.id, user.id);
+    await makeOAuthConnector(org.id);
+
+    // The ACCOUNT profile (the user's authorized token) is still created via the
+    // real OAuth flow — it lands pending_auth and only the Authorize callback
+    // flips it active.
+    const accRes = await manageAuthProfiles(
+      {
+        action: 'create_auth_profile',
+        connector_key: 'demoenv.oauth',
+        profile_kind: 'oauth_account',
+        display_name: 'DemoEnv Account',
+        slug: 'demoenv-account',
+      },
+      TEST_ENV,
+      ctx
+    );
+    expect('auth_profile' in accRes).toBe(true);
+    if ('auth_profile' in accRes) {
+      expect(accRes.auth_profile.status).toBe('pending_auth');
+    }
+
+    const sql = getTestDb();
+    // No oauth_app profile exists yet — that's the whole point.
+    const appBefore = await sql`
+      SELECT id FROM auth_profiles
+      WHERE organization_id = ${org.id} AND connector_key = 'demoenv.oauth'
+        AND profile_kind = 'oauth_app'
+    `;
+    expect(appBefore).toHaveLength(0);
+
+    // Create the connection WITHOUT app_auth_profile_slug — previously this
+    // errored "Select or create an OAuth app profile before creating the
+    // connection." Now it must succeed via the env fallback.
+    const connRes = await manageConnections(
+      {
+        action: 'create',
+        connector_key: 'demoenv.oauth',
+        slug: 'demoenv-conn',
+        display_name: 'DemoEnv Connection',
+        auth_profile_slug: 'demoenv-account',
+      },
+      TEST_ENV,
+      ctx
+    );
+    expect('error' in connRes).toBe(false);
+    let connectionId = 0;
+    if ('connection' in connRes) {
+      // Authorize step still required: pending_auth, not active.
+      expect((connRes.connection as { status: string }).status).toBe('pending_auth');
+      connectionId = (connRes.connection as { id: number }).id;
+    }
+    expect(connectionId).toBeGreaterThan(0);
+
+    // An env-backed oauth_app profile was auto-provisioned, carrying the env
+    // client id/secret — and the connection is linked to it.
+    const appAfter = await sql`
+      SELECT id, status, auth_data FROM auth_profiles
+      WHERE organization_id = ${org.id} AND connector_key = 'demoenv.oauth'
+        AND profile_kind = 'oauth_app'
+    `;
+    expect(appAfter).toHaveLength(1);
+    const appRow = appAfter[0] as { id: number; status: string; auth_data: Record<string, string> };
+    expect(appRow.status).toBe('active');
+    expect(appRow.auth_data[CLIENT_ID_KEY]).toBe('env-client-id');
+    expect(appRow.auth_data[CLIENT_SECRET_KEY]).toBe('env-client-secret');
+
+    const connRow = (
+      await sql`SELECT app_auth_profile_id FROM connections WHERE id = ${connectionId}`
+    )[0] as { app_auth_profile_id: number | null };
+    expect(Number(connRow.app_auth_profile_id)).toBe(Number(appRow.id));
+
+    // The resolver the /connect/:token/oauth/start path uses now yields BOTH
+    // client id and secret from this env-backed profile — no "OAuth client
+    // secret not configured" throw.
+    const resolved = resolveOAuthAppClientCredentials({
+      appProfileAuthData: appRow.auth_data,
+      provider: 'demoenv',
+      clientIdKey: CLIENT_ID_KEY,
+      clientSecretKey: CLIENT_SECRET_KEY,
+    });
+    expect(resolved.clientId).toBe('env-client-id');
+    expect(resolved.clientSecret).toBe('env-client-secret');
+  });
+
+  it('still requires an app profile when NO env client creds are set (no silent bypass)', async () => {
+    // Ensure the env vars are absent for this case.
+    delete process.env[CLIENT_ID_KEY];
+    delete process.env[CLIENT_SECRET_KEY];
+
+    const org = await createTestOrganization({ name: 'No Env Creds Org' });
+    const user = await createTestUser({ name: 'No Env Creds User' });
+    await addUserToOrganization(user.id, org.id, 'owner');
+    const ctx = ctxFor(org.id, user.id);
+    await makeOAuthConnector(org.id);
+
+    await manageAuthProfiles(
+      {
+        action: 'create_auth_profile',
+        connector_key: 'demoenv.oauth',
+        profile_kind: 'oauth_account',
+        display_name: 'DemoEnv Account',
+        slug: 'demoenv-account',
+      },
+      TEST_ENV,
+      ctx
+    );
+
+    const connRes = await manageConnections(
+      {
+        action: 'create',
+        connector_key: 'demoenv.oauth',
+        slug: 'demoenv-conn',
+        display_name: 'DemoEnv Connection',
+        auth_profile_slug: 'demoenv-account',
+      },
+      TEST_ENV,
+      ctx
+    );
+
+    // No env creds AND no hand-made app profile → the original guidance stands.
+    expect('error' in connRes).toBe(true);
+    if ('error' in connRes) {
+      expect(connRes.error).toMatch(/OAuth app profile/i);
+    }
+  });
+});

--- a/packages/server/src/connect/routes.ts
+++ b/packages/server/src/connect/routes.ts
@@ -33,6 +33,7 @@ import {
 import { type ConnectTokenRow, resolveConnectToken } from '../utils/connect-tokens';
 import logger from '../utils/logger';
 import { syncOAuthConnectionsForAuthProfile } from '../utils/oauth-connection-state';
+import { resolveOAuthAppClientCredentials } from '../tools/admin/helpers/connection-helpers';
 import { registerConnectorWebhook } from './webhook-registration';
 import { mergeOAuthScopeAuthData, normalizeScopeList } from '../auth/oauth/scopes';
 import { createSyncRun } from '../runs/queue-service';
@@ -952,9 +953,14 @@ async function fetchAppAuthProfileId(
 }
 
 /**
- * Resolve OAuth client ID/secret from:
+ * Resolve OAuth client ID/secret from, in order:
  * 1. Selected OAuth app auth profile
  * 2. Primary org-level OAuth app auth profile for the connector/provider
+ * 3. Deployment env vars (`${PROVIDER}_CLIENT_ID/_SECRET`) — the SAME fallback
+ *    global login uses (`auth/config.ts resolveLoginProviderCredentials`), so an
+ *    org can connect a connector whose app creds are env-configured with no
+ *    hand-created `oauth_app` profile. APP-level only; the per-user account
+ *    token (oauth_account) is resolved/required separately by the caller.
  */
 async function resolveOAuthClientCredentials(
   provider: string,
@@ -964,10 +970,6 @@ async function resolveOAuthClientCredentials(
   clientIdKey?: string,
   clientSecretKey?: string
 ): Promise<{ clientId: string | null; clientSecret: string | null }> {
-  const providerUpper = provider.toUpperCase();
-  const resolvedClientIdKey = clientIdKey || `${providerUpper}_CLIENT_ID`;
-  const resolvedClientSecretKey = clientSecretKey || `${providerUpper}_CLIENT_SECRET`;
-
   const appProfile =
     (appAuthProfileId ? await getAuthProfileById(organizationId, appAuthProfileId) : null) ??
     (await getPrimaryAuthProfileForKind({
@@ -977,11 +979,12 @@ async function resolveOAuthClientCredentials(
       provider,
     }));
 
-  const authValues = normalizeAuthValues(appProfile?.auth_data ?? {});
-  const clientId = authValues[resolvedClientIdKey] ?? null;
-  const clientSecret = authValues[resolvedClientSecretKey] ?? null;
-
-  return { clientId, clientSecret };
+  return resolveOAuthAppClientCredentials({
+    appProfileAuthData: appProfile?.auth_data,
+    provider,
+    clientIdKey,
+    clientSecretKey,
+  });
 }
 
 export { connectRoutes };

--- a/packages/server/src/tools/admin/helpers/connection-helpers.ts
+++ b/packages/server/src/tools/admin/helpers/connection-helpers.ts
@@ -141,6 +141,44 @@ export function getOAuthCredentialKeys(method: OAuthAuthMethod): {
 }
 
 /**
+ * Resolve the OAuth **app** (client) credentials for a connector, mirroring the
+ * exact fallback GLOBAL LOGIN uses (`auth/config.ts`
+ * `resolveLoginProviderCredentials`): an explicit `oauth_app` auth profile's
+ * `auth_data` wins, otherwise fall back to `process.env[clientIdKey]` /
+ * `process.env[clientSecretKey]` (keys default to `${PROVIDER}_CLIENT_ID/_SECRET`
+ * via {@link getOAuthCredentialKeys}).
+ *
+ * This is the single source of truth for "does this connector have OAuth APP
+ * credentials" across the connect-create gate (manage_connections) and the
+ * `/connect/:token/oauth/start` redirect (connect/routes.ts) — neither has to
+ * re-derive keys or duplicate the env fallback. It resolves ONLY the
+ * application-level client id/secret; the per-user ACCOUNT token (oauth_account
+ * profile, obtained via the real Authorize redirect) is unaffected and still
+ * required by callers.
+ */
+export function resolveOAuthAppClientCredentials(params: {
+  appProfileAuthData: unknown;
+  provider: string;
+  clientIdKey?: string;
+  clientSecretKey?: string;
+}): { clientId: string | null; clientSecret: string | null } {
+  const providerUpper = params.provider.toUpperCase();
+  const clientIdKey =
+    typeof params.clientIdKey === 'string' && params.clientIdKey.trim().length > 0
+      ? params.clientIdKey
+      : `${providerUpper}_CLIENT_ID`;
+  const clientSecretKey =
+    typeof params.clientSecretKey === 'string' && params.clientSecretKey.trim().length > 0
+      ? params.clientSecretKey
+      : `${providerUpper}_CLIENT_SECRET`;
+
+  const authValues = normalizeAuthValues(params.appProfileAuthData ?? {});
+  const clientId = authValues[clientIdKey] || process.env[clientIdKey] || null;
+  const clientSecret = authValues[clientSecretKey] || process.env[clientSecretKey] || null;
+  return { clientId, clientSecret };
+}
+
+/**
  * Auto-provision an env-backed `oauth_app` profile from deployment env vars,
  * mirroring how GLOBAL LOGIN resolves its client (auth/config.ts
  * `resolveLoginProviderCredentials`: `process.env[clientIdKey]` fallback). The

--- a/packages/server/src/tools/admin/manage_connections/handlers/crud.ts
+++ b/packages/server/src/tools/admin/manage_connections/handlers/crud.ts
@@ -32,6 +32,7 @@ import { resolveUsernames } from '../../../../utils/resolve-usernames';
 import { ACTIVE_RUN_STATUSES, runStatusLiteral } from '../../../../utils/run-statuses';
 import {
   buildViewUrl,
+  ensureEnvBackedOAuthAppProfile,
   enrichWithAuthProfiles,
   getInteractiveMethods,
   mapConnectionStatusToFeedStatus,
@@ -534,6 +535,21 @@ export async function handleCreate(
   }
 
   if (authSelection?.selectedKind === 'oauth_account') {
+    // The ACCOUNT token (oauth_account profile) is required and already
+    // resolved (it's the precondition of this branch). The APP credentials
+    // (client id/secret) may instead come from deployment env vars — the same
+    // fallback global login uses — so auto-provision an env-backed `oauth_app`
+    // profile when none was hand-created. No-op when the env vars are absent,
+    // falling through to the original "create an OAuth app profile" guidance.
+    if (!authSelection.appAuthProfile && authSelection.oauthMethod) {
+      authSelection.appAuthProfile = await ensureEnvBackedOAuthAppProfile({
+        organizationId,
+        connectorKey: args.connector_key,
+        connectorName: connector.name,
+        method: authSelection.oauthMethod,
+        createdBy: effectiveCreatedBy,
+      });
+    }
     if (!authSelection.appAuthProfile) {
       return {
         error: callerIsAdmin


### PR DESCRIPTION
## Root cause

Connecting a connector via OAuth (e.g. GitHub) for an org failed because the connector OAuth-**connect** path did not fall back to the env-configured `GITHUB_CLIENT_ID` / `GITHUB_CLIENT_SECRET`, even though GitHub **login** already does. Login resolves the client via `authValues || envRecord || process.env[...]` in `auth/config.ts` (`resolveLoginProviderCredentials`); the connect path had no equivalent.

Two failures, in order:
1. Creating the connection errored `Select or create an OAuth app profile before creating the connection.` — the create path required a hand-made OAuth **app** profile.
2. After working around #1, `/connect/<id>/oauth/start` errored `OAuth client secret not configured for provider 'github'. Create an OAuth app auth profile first, then retry.` — the secret was never read from env.

(Note: #1418 had already wired `ensureEnvBackedOAuthAppProfile` into the `connect` *handler*, but not into the `create` handler (crud.ts) or the `oauth/start` credential resolver (routes.ts) — those two sites are what this PR closes.)

## Fix

A single shared resolver — `resolveOAuthAppClientCredentials` in `connection-helpers.ts` — mirrors login's key derivation (`getOAuthCredentialKeys`, defaulting to `${PROVIDER}_CLIENT_ID/_SECRET`) and the `|| process.env[...]` fallback: an explicit `oauth_app` profile's `auth_data` wins, otherwise env. Wired into both remaining resolution points:

- **`connect/routes.ts` `oauth/start`** (the primary blocker): `resolveOAuthClientCredentials` now returns `clientId`+`clientSecret` with the env fallback instead of throwing when only env carries them.
- **`manage_connections` create (`crud.ts`)**: when the `oauth_account` branch finds no `oauth_app` profile, it auto-provisions an env-backed one via the existing `ensureEnvBackedOAuthAppProfile` (idempotent Postgres upsert) before erroring — so an org connects with zero manual secret entry.

### Critical distinction preserved
Only the **APP**-level client id/secret falls back to env. The per-user **ACCOUNT** token (`oauth_account` profile) and the Authorize redirect are untouched — the connection still lands `pending_auth` and requires the real OAuth grant. No silent bypass: with env creds absent, the create path still demands an app profile.

### Multi-replica
The env-backed app profile is a Postgres row (idempotent upsert by slug); the resolver is pure env/profile reads. Holds under N replicas behind ClientIP affinity.

## Verified
- `cd packages/server && bunx tsc --noEmit` → 0 errors. Full-repo `bun run typecheck` → clean (pre-commit hook passed without `--no-verify`).
- New test `src/__tests__/integration/connectors/oauth-env-app-creds.test.ts` — **6/6 green** (4 pure resolver cases + 2 DB-backed: connect with no app profile succeeds `pending_auth` with an env-backed `oauth_app` auto-created & linked; absent env creds still require an app profile).
- Regression: `src/__tests__/integration/connectors` **92/92**; `src/tools/admin` + `auth-profiles` + `auth/config` **33/33**. (Run with Node 22 against a local Postgres+pgvector.)

## Not verified
- **Live OAuth e2e** against a real GitHub app — needs a deploy with `GITHUB_CLIENT_ID`/`GITHUB_CLIENT_SECRET` set; the full Authorize round-trip (redirect → callback → active connection) was not exercised live. Tests cover the credential-resolution + create-gate behavior, not the provider redirect itself.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1427"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784604214&installation_id=136316292&pr_number=1427&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1427&signature=a886e14f1bd9fa59b78de4f9737c1860f14c220c7be0ca9848de08d389a6dfd4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->