### PR TITLE
feat(gateway): InstallationTokenProvider + GitHub installation-token minting

### DIFF
--- a/packages/server/src/__tests__/integration/connectors/app-installation-credential.test.ts
+++ b/packages/server/src/__tests__/integration/connectors/app-installation-credential.test.ts
@@ -74,23 +74,23 @@ async function seedAppInstallConnection(opts: {
 	organizationId: string;
 	installationRef: number;
 	provider?: string;
-	providerInstance?: string;
+	/** `null` = the method omits providerInstance entirely (must default to 'cloud'). */
+	providerInstance?: string | null;
 }): Promise<{ connectionId: number }> {
+	const method: Record<string, unknown> = {
+		type: "app_installation",
+		provider: opts.provider ?? PROVIDER,
+		appIdKey: "DEMO_APP_ID",
+		privateKeyKey: "DEMO_APP_PRIVATE_KEY",
+	};
+	if (opts.providerInstance !== null) {
+		method.providerInstance = opts.providerInstance ?? PROVIDER_INSTANCE;
+	}
 	await createTestConnectorDefinition({
 		key: CONNECTOR_KEY,
 		name: "Demo App Install",
 		organization_id: opts.organizationId,
-		auth_schema: {
-			methods: [
-				{
-					type: "app_installation",
-					provider: opts.provider ?? PROVIDER,
-					providerInstance: opts.providerInstance ?? PROVIDER_INSTANCE,
-					appIdKey: "DEMO_APP_ID",
-					privateKeyKey: "DEMO_APP_PRIVATE_KEY",
-				},
-			],
-		},
+		auth_schema: { methods: [method] },
 	});
 
 	const conn = await createTestConnection({
@@ -242,6 +242,34 @@ describe("app-installation credential — tenancy + shape guards", () => {
 			installationRef: install.id,
 			provider: PROVIDER,
 			providerInstance: "cloud",
+		});
+
+		const resolved = await resolveExecutionAuth({
+			organizationId: org.id,
+			connectionId,
+			credentialDb: getDb(),
+		});
+
+		expect(resolved.credentials).toBeNull();
+		expect(spy.mintCalls).toHaveLength(0);
+	});
+
+	it("method that omits providerInstance defaults to 'cloud' and rejects a non-cloud install", async () => {
+		const org = await createTestOrganization({ name: "Omit Instance Org" });
+		// Install lives on a self-hosted (non-cloud) instance...
+		const install = await seedInstall({
+			organizationId: org.id,
+			provider: PROVIDER,
+			providerInstance: "ghes.example.com",
+			externalTenantId: "ghes-omit-tenant",
+		});
+		// ...and the connector method does NOT pin an instance. Omitted must mean
+		// 'cloud' (NOT wildcard), so this non-cloud install is rejected, no mint.
+		const { connectionId } = await seedAppInstallConnection({
+			organizationId: org.id,
+			installationRef: install.id,
+			provider: PROVIDER,
+			providerInstance: null,
 		});
 
 		const resolved = await resolveExecutionAuth({

--- a/packages/server/src/__tests__/integration/connectors/app-installation-credential.test.ts
+++ b/packages/server/src/__tests__/integration/connectors/app-installation-credential.test.ts
@@ -1,0 +1,256 @@
+/**
+ * App-installation credential resolution — tenancy + connector-shape guards.
+ *
+ * `resolveExecutionAuth` (via `resolveAppInstallationCredential`) loads the
+ * `app_installations` row named by a connection's `config.installation_ref` and
+ * mints a tenant-scoped token gateway-side. The security contract proven here:
+ *
+ *   1. SECURITY REGRESSION (cross-tenant leak): a connection in org A whose
+ *      `config.installation_ref` points at an install OWNED BY org B resolves to
+ *      NULL credentials and the token provider's `mintToken` is NEVER called.
+ *      Without the org guard, org A would receive org B's minted token.
+ *   2. Same-org happy path still mints (the guard doesn't break the legit path).
+ *   3. Provider / providerInstance mismatch (same org, wrong connector shape) →
+ *      NULL credentials, mint NOT called.
+ *
+ * The token provider is a SPY registered into the per-pod registry, so "mint not
+ * called" is asserted directly rather than inferred. No `vi.mock` — the suite
+ * runs `isolate:false`, where mocking shared singletons is unreliable; instead
+ * we swap the registry's real provider for a spy via the test-only reset seam.
+ */
+
+import { afterAll, afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+	type InstallationTokenProvider,
+	type MintedInstallationToken,
+} from "../../../gateway/installation/installation-token-provider";
+import {
+	__resetInstallationTokenRegistryForTests,
+	getInstallationTokenRegistry,
+} from "../../../gateway/installation/registry";
+import type { AppInstallationRow } from "../../../lobu/stores/app-installation-store";
+import { createPostgresAppInstallationStore } from "../../../lobu/stores/app-installation-store";
+import { getDb } from "../../../db/client";
+import { resolveExecutionAuth } from "../../../utils/execution-context";
+import { initWorkspaceProvider } from "../../../workspace";
+import { getTestDb } from "../../setup/test-db";
+import {
+	createTestConnectorDefinition,
+	createTestConnection,
+	createTestOrganization,
+} from "../../setup/test-fixtures";
+
+const CONNECTOR_KEY = "demo.appinstall";
+const PROVIDER = "github";
+const PROVIDER_INSTANCE = "cloud";
+
+/** Counts `mintToken` calls so a test can assert it was (or was NOT) invoked. */
+class SpyInstallationTokenProvider implements InstallationTokenProvider {
+	readonly provider: string;
+	mintCalls: AppInstallationRow[] = [];
+
+	constructor(provider: string) {
+		this.provider = provider;
+	}
+
+	async mintToken(install: AppInstallationRow): Promise<MintedInstallationToken> {
+		this.mintCalls.push(install);
+		return {
+			token: `spy-token-for-install-${install.id}`,
+			expiresAt: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+		};
+	}
+}
+
+let spy: SpyInstallationTokenProvider;
+
+/**
+ * Create a per-org connector definition declaring an `app_installation` auth
+ * method, plus a connection in that org. `installationRef` is what we write into
+ * the connection's `config.installation_ref` (it may point at ANOTHER org's
+ * install — that's the attack we're guarding against).
+ */
+async function seedAppInstallConnection(opts: {
+	organizationId: string;
+	installationRef: number;
+	provider?: string;
+	providerInstance?: string;
+}): Promise<{ connectionId: number }> {
+	await createTestConnectorDefinition({
+		key: CONNECTOR_KEY,
+		name: "Demo App Install",
+		organization_id: opts.organizationId,
+		auth_schema: {
+			methods: [
+				{
+					type: "app_installation",
+					provider: opts.provider ?? PROVIDER,
+					providerInstance: opts.providerInstance ?? PROVIDER_INSTANCE,
+					appIdKey: "DEMO_APP_ID",
+					privateKeyKey: "DEMO_APP_PRIVATE_KEY",
+				},
+			],
+		},
+	});
+
+	const conn = await createTestConnection({
+		organization_id: opts.organizationId,
+		connector_key: CONNECTOR_KEY,
+		config: { installation_ref: opts.installationRef },
+		createDefaultFeed: false,
+	});
+
+	return { connectionId: conn.id };
+}
+
+/** Insert an ACTIVE install owned by `organizationId` and return its row. */
+async function seedInstall(opts: {
+	organizationId: string;
+	provider?: string;
+	providerInstance?: string;
+	externalTenantId: string;
+}): Promise<AppInstallationRow> {
+	const store = createPostgresAppInstallationStore();
+	return store.upsert({
+		organizationId: opts.organizationId,
+		provider: opts.provider ?? PROVIDER,
+		providerInstance: opts.providerInstance ?? PROVIDER_INSTANCE,
+		providerAppId: "demo-app",
+		externalTenantId: opts.externalTenantId,
+		status: "active",
+	});
+}
+
+beforeEach(async () => {
+	await initWorkspaceProvider();
+	// Swap the real (GitHub) provider for a spy so we can assert mint was/wasn't
+	// called. The reset seam drops the per-pod singleton; we rebuild it with ONLY
+	// the spy registered.
+	__resetInstallationTokenRegistryForTests();
+	spy = new SpyInstallationTokenProvider(PROVIDER);
+	getInstallationTokenRegistry().register(spy);
+});
+
+afterEach(async () => {
+	// Don't leak fixtures across the shared DB; this suite owns one connector key
+	// and the app_installations / connections it inserts.
+	const sql = getTestDb();
+	await sql`DELETE FROM connections WHERE connector_key = ${CONNECTOR_KEY}`;
+	await sql`DELETE FROM connector_definitions WHERE key = ${CONNECTOR_KEY}`;
+	await sql`DELETE FROM app_installations WHERE provider_app_id = 'demo-app'`;
+});
+
+afterAll(() => {
+	// Restore the real provider wiring for any later suite in the shared process.
+	__resetInstallationTokenRegistryForTests();
+});
+
+describe("app-installation credential — tenancy + shape guards", () => {
+	it("SECURITY: a cross-org installation_ref resolves to NULL and NEVER mints", async () => {
+		const orgA = await createTestOrganization({ name: "Attacker Org A" });
+		const orgB = await createTestOrganization({ name: "Victim Org B" });
+
+		// Victim org B owns the install.
+		const victimInstall = await seedInstall({
+			organizationId: orgB.id,
+			externalTenantId: "victim-tenant",
+		});
+
+		// Attacker connection in org A points its installation_ref at org B's id.
+		const { connectionId } = await seedAppInstallConnection({
+			organizationId: orgA.id,
+			installationRef: victimInstall.id,
+		});
+
+		const resolved = await resolveExecutionAuth({
+			organizationId: orgA.id,
+			connectionId,
+			credentialDb: getDb(),
+		});
+
+		// No credential leaked to the attacker org...
+		expect(resolved.credentials).toBeNull();
+		// ...and crucially the token provider was NEVER asked to mint.
+		expect(spy.mintCalls).toHaveLength(0);
+	});
+
+	it("same-org happy path still mints a tenant-scoped token", async () => {
+		const org = await createTestOrganization({ name: "Owner Org" });
+		const install = await seedInstall({
+			organizationId: org.id,
+			externalTenantId: "owner-tenant",
+		});
+		const { connectionId } = await seedAppInstallConnection({
+			organizationId: org.id,
+			installationRef: install.id,
+		});
+
+		const resolved = await resolveExecutionAuth({
+			organizationId: org.id,
+			connectionId,
+			credentialDb: getDb(),
+		});
+
+		expect(resolved.credentials).not.toBeNull();
+		expect(resolved.credentials?.provider).toBe(PROVIDER);
+		expect(resolved.credentials?.accessToken).toBe(
+			`spy-token-for-install-${install.id}`,
+		);
+		expect(spy.mintCalls).toHaveLength(1);
+		expect(spy.mintCalls[0]?.id).toBe(install.id);
+	});
+
+	it("provider mismatch (same org, wrong provider) resolves to NULL and never mints", async () => {
+		const org = await createTestOrganization({ name: "Mismatch Provider Org" });
+		// The install is a 'slack' install...
+		const install = await seedInstall({
+			organizationId: org.id,
+			provider: "slack",
+			providerInstance: PROVIDER_INSTANCE,
+			externalTenantId: "slack-tenant",
+		});
+		// ...but the connector method declares 'github'.
+		const { connectionId } = await seedAppInstallConnection({
+			organizationId: org.id,
+			installationRef: install.id,
+			provider: PROVIDER,
+			providerInstance: PROVIDER_INSTANCE,
+		});
+
+		const resolved = await resolveExecutionAuth({
+			organizationId: org.id,
+			connectionId,
+			credentialDb: getDb(),
+		});
+
+		expect(resolved.credentials).toBeNull();
+		expect(spy.mintCalls).toHaveLength(0);
+	});
+
+	it("providerInstance mismatch (same org+provider, wrong instance) resolves to NULL and never mints", async () => {
+		const org = await createTestOrganization({ name: "Mismatch Instance Org" });
+		// Install on a GHES host instance...
+		const install = await seedInstall({
+			organizationId: org.id,
+			provider: PROVIDER,
+			providerInstance: "ghes.example.com",
+			externalTenantId: "ghes-tenant",
+		});
+		// ...but the connector method pins 'cloud'.
+		const { connectionId } = await seedAppInstallConnection({
+			organizationId: org.id,
+			installationRef: install.id,
+			provider: PROVIDER,
+			providerInstance: "cloud",
+		});
+
+		const resolved = await resolveExecutionAuth({
+			organizationId: org.id,
+			connectionId,
+			credentialDb: getDb(),
+		});
+
+		expect(resolved.credentials).toBeNull();
+		expect(spy.mintCalls).toHaveLength(0);
+	});
+});

--- a/packages/server/src/gateway/installation/__tests__/github-installation-token-provider.test.ts
+++ b/packages/server/src/gateway/installation/__tests__/github-installation-token-provider.test.ts
@@ -1,0 +1,316 @@
+/**
+ * GitHub installation-token provider contract.
+ *
+ *  - App JWT: RS256 header, iss/iat/exp claims, exp-iat window <= 600s,
+ *    verifiable against the throwaway public key (no real GitHub key needed).
+ *  - Token cache: a second mint within the lifetime is served from cache (one
+ *    exchange); a token inside the refresh window is re-minted.
+ *  - Mint failures: missing App env config, a non-OK exchange (revoked/suspended
+ *    install → 404), and a network error all raise InstallationTokenError with
+ *    the right `reason`.
+ *  - Registry: refuses to mint for a non-active install + an unsupported
+ *    provider, and delegates to the registered provider otherwise.
+ *
+ * The GitHub `/access_tokens` exchange is MOCKED via `fetchImpl` — no request
+ * ever reaches api.github.com. Live exchange is the one creds gap (validated by
+ * an earlier spike), not covered here.
+ */
+
+import { beforeEach, describe, expect, test } from "bun:test";
+import { createVerify, generateKeyPairSync } from "node:crypto";
+import type { AppInstallationRow } from "../../../lobu/stores/app-installation-store.js";
+import {
+  buildGitHubAppJwt,
+  GitHubInstallationTokenProvider,
+} from "../github-installation-token-provider.js";
+import {
+  InMemoryInstallationTokenCache,
+  InstallationTokenError,
+  InstallationTokenRegistry,
+  type InstallationTokenProvider,
+} from "../installation-token-provider.js";
+
+const { privateKey, publicKey } = generateKeyPairSync("rsa", {
+  modulusLength: 2048,
+  publicKeyEncoding: { type: "spki", format: "pem" },
+  privateKeyEncoding: { type: "pkcs8", format: "pem" },
+});
+
+function base64urlToJson(seg: string): Record<string, unknown> {
+  const b64 = seg.replace(/-/g, "+").replace(/_/g, "/");
+  const padded = b64 + "=".repeat((4 - (b64.length % 4)) % 4);
+  return JSON.parse(Buffer.from(padded, "base64").toString("utf8"));
+}
+
+function makeInstall(
+  overrides: Partial<AppInstallationRow> = {}
+): AppInstallationRow {
+  return {
+    id: 1,
+    organizationId: "org-1",
+    provider: "github",
+    providerInstance: "cloud",
+    providerAppId: "app-123",
+    externalTenantId: "98765",
+    authProfileId: null,
+    status: "active",
+    metadata: {},
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+    ...overrides,
+  };
+}
+
+/** A `fetch` stub returning GitHub's success body, counting invocations. */
+function mockExchange(body: { token: string; expires_at: string }) {
+  let calls = 0;
+  const impl = (async () => {
+    calls += 1;
+    return new Response(JSON.stringify(body), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+  }) as unknown as typeof fetch;
+  return {
+    impl,
+    get calls() {
+      return calls;
+    },
+  };
+}
+
+describe("buildGitHubAppJwt", () => {
+  test("RS256 header, iss/iat/exp claims, <=600s window, valid signature", () => {
+    const nowMs = 1_700_000_000_000;
+    const jwt = buildGitHubAppJwt({
+      appId: "424242",
+      privateKeyPem: privateKey,
+      nowMs,
+    });
+
+    const [headerSeg, claimsSeg, sigSeg] = jwt.split(".");
+    expect(headerSeg && claimsSeg && sigSeg).toBeTruthy();
+
+    const header = base64urlToJson(headerSeg!);
+    expect(header.alg).toBe("RS256");
+    expect(header.typ).toBe("JWT");
+
+    const claims = base64urlToJson(claimsSeg!);
+    expect(claims.iss).toBe("424242");
+    const iat = claims.iat as number;
+    const exp = claims.exp as number;
+    const nowSec = Math.floor(nowMs / 1000);
+    // iat is backdated (<= now) to tolerate clock skew.
+    expect(iat).toBeLessThanOrEqual(nowSec);
+    // GitHub hard-caps the App JWT lifetime at 600s.
+    expect(exp - iat).toBeLessThanOrEqual(600);
+    expect(exp).toBeGreaterThan(nowSec);
+
+    // Signature verifies against the public key over `header.claims`.
+    const verifier = createVerify("RSA-SHA256");
+    verifier.update(`${headerSeg}.${claimsSeg}`);
+    verifier.end();
+    const sig = Buffer.from(
+      sigSeg!.replace(/-/g, "+").replace(/_/g, "/"),
+      "base64"
+    );
+    expect(verifier.verify(publicKey, sig)).toBe(true);
+  });
+
+  test("accepts a PEM with literal \\n escapes (env-var form)", () => {
+    const escaped = privateKey.replace(/\n/g, "\\n");
+    const jwt = buildGitHubAppJwt({
+      appId: "1",
+      privateKeyPem: escaped,
+      nowMs: 1_700_000_000_000,
+    });
+    const [headerSeg, claimsSeg, sigSeg] = jwt.split(".");
+    const verifier = createVerify("RSA-SHA256");
+    verifier.update(`${headerSeg}.${claimsSeg}`);
+    verifier.end();
+    const sig = Buffer.from(
+      sigSeg!.replace(/-/g, "+").replace(/_/g, "/"),
+      "base64"
+    );
+    expect(verifier.verify(publicKey, sig)).toBe(true);
+  });
+});
+
+describe("GitHubInstallationTokenProvider.mintToken", () => {
+  const env = {
+    GITHUB_APP_ID: "424242",
+    GITHUB_APP_PRIVATE_KEY: privateKey,
+  };
+
+  test("exchanges the App JWT for an installation token", async () => {
+    const exchange = mockExchange({
+      token: "ghs_minted_abc",
+      expires_at: new Date(Date.now() + 3_600_000).toISOString(),
+    });
+    const provider = new GitHubInstallationTokenProvider({
+      env,
+      fetchImpl: exchange.impl,
+      cache: new InMemoryInstallationTokenCache(),
+    });
+
+    const minted = await provider.mintToken(makeInstall());
+    expect(minted.token).toBe("ghs_minted_abc");
+    expect(Date.parse(minted.expiresAt)).toBeGreaterThan(Date.now());
+    expect(exchange.calls).toBe(1);
+  });
+
+  test("serves a cached token within its lifetime (no second exchange)", async () => {
+    const exchange = mockExchange({
+      token: "ghs_cached",
+      expires_at: new Date(Date.now() + 3_600_000).toISOString(),
+    });
+    const provider = new GitHubInstallationTokenProvider({
+      env,
+      fetchImpl: exchange.impl,
+      cache: new InMemoryInstallationTokenCache(),
+    });
+
+    const first = await provider.mintToken(makeInstall());
+    const second = await provider.mintToken(makeInstall());
+    expect(second.token).toBe(first.token);
+    expect(exchange.calls).toBe(1);
+  });
+
+  test("re-mints when the cached token is inside the refresh window", async () => {
+    let nextExpiry = new Date(Date.now() + 30_000).toISOString(); // < 60s skew
+    const calls: number[] = [];
+    const impl = (async () => {
+      calls.push(1);
+      return new Response(
+        JSON.stringify({ token: `ghs_${calls.length}`, expires_at: nextExpiry }),
+        { status: 200, headers: { "content-type": "application/json" } }
+      );
+    }) as unknown as typeof fetch;
+    const provider = new GitHubInstallationTokenProvider({
+      env,
+      fetchImpl: impl,
+      cache: new InMemoryInstallationTokenCache({ refreshSkewMs: 60_000 }),
+    });
+
+    const first = await provider.mintToken(makeInstall());
+    // First token expires within the 60s refresh skew → not cacheable.
+    nextExpiry = new Date(Date.now() + 3_600_000).toISOString();
+    const second = await provider.mintToken(makeInstall());
+    expect(first.token).toBe("ghs_1");
+    expect(second.token).toBe("ghs_2");
+    expect(calls.length).toBe(2);
+  });
+
+  test("missing App env config → missing_app_config", async () => {
+    const provider = new GitHubInstallationTokenProvider({
+      env: {},
+      fetchImpl: mockExchange({ token: "x", expires_at: "y" }).impl,
+    });
+    await expect(provider.mintToken(makeInstall())).rejects.toMatchObject({
+      reason: "missing_app_config",
+    });
+  });
+
+  test("non-OK exchange (revoked/suspended install) → exchange_failed with status", async () => {
+    const impl = (async () =>
+      new Response(JSON.stringify({ message: "Not Found" }), {
+        status: 404,
+      })) as unknown as typeof fetch;
+    const provider = new GitHubInstallationTokenProvider({ env, fetchImpl: impl });
+
+    try {
+      await provider.mintToken(makeInstall());
+      throw new Error("expected mintToken to throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(InstallationTokenError);
+      expect((err as InstallationTokenError).reason).toBe("exchange_failed");
+      expect((err as InstallationTokenError).status).toBe(404);
+    }
+  });
+
+  test("network error → exchange_failed", async () => {
+    const impl = (async () => {
+      throw new Error("ECONNREFUSED");
+    }) as unknown as typeof fetch;
+    const provider = new GitHubInstallationTokenProvider({ env, fetchImpl: impl });
+    await expect(provider.mintToken(makeInstall())).rejects.toMatchObject({
+      reason: "exchange_failed",
+    });
+  });
+
+  test("honors per-method appIdKey/privateKeyKey from install metadata", async () => {
+    const exchange = mockExchange({
+      token: "ghs_custom_keys",
+      expires_at: new Date(Date.now() + 3_600_000).toISOString(),
+    });
+    const provider = new GitHubInstallationTokenProvider({
+      env: { GHE_APP_ID: "9", GHE_APP_KEY: privateKey },
+      fetchImpl: exchange.impl,
+    });
+    const minted = await provider.mintToken(
+      makeInstall({
+        metadata: { appIdKey: "GHE_APP_ID", privateKeyKey: "GHE_APP_KEY" },
+      })
+    );
+    expect(minted.token).toBe("ghs_custom_keys");
+  });
+});
+
+describe("InstallationTokenRegistry", () => {
+  let registry: InstallationTokenRegistry;
+  const stub: InstallationTokenProvider = {
+    provider: "github",
+    mintToken: async () => ({ token: "stub", expiresAt: "2999-01-01T00:00:00Z" }),
+  };
+
+  beforeEach(() => {
+    registry = new InstallationTokenRegistry();
+    registry.register(stub);
+  });
+
+  test("delegates to the registered provider for an active install", async () => {
+    const minted = await registry.mintFor(makeInstall());
+    expect(minted.token).toBe("stub");
+  });
+
+  test("refuses to mint for a non-active install → install_inactive", async () => {
+    await expect(
+      registry.mintFor(makeInstall({ status: "suspended" }))
+    ).rejects.toMatchObject({ reason: "install_inactive" });
+    await expect(
+      registry.mintFor(makeInstall({ status: "revoked" }))
+    ).rejects.toMatchObject({ reason: "install_inactive" });
+  });
+
+  test("unsupported provider → provider_unsupported", async () => {
+    await expect(
+      registry.mintFor(makeInstall({ provider: "jira" }))
+    ).rejects.toMatchObject({ reason: "provider_unsupported" });
+  });
+});
+
+describe("InMemoryInstallationTokenCache", () => {
+  test("returns null for an entry inside the refresh window", () => {
+    const cache = new InMemoryInstallationTokenCache({ refreshSkewMs: 60_000 });
+    cache.set("k", {
+      token: "t",
+      expiresAt: new Date(Date.now() + 30_000).toISOString(),
+    });
+    expect(cache.get("k")).toBeNull();
+  });
+
+  test("returns a live entry beyond the refresh window", () => {
+    const cache = new InMemoryInstallationTokenCache({ refreshSkewMs: 60_000 });
+    cache.set("k", {
+      token: "t",
+      expiresAt: new Date(Date.now() + 600_000).toISOString(),
+    });
+    expect(cache.get("k")?.token).toBe("t");
+  });
+
+  test("treats an unparseable expiry as stale", () => {
+    const cache = new InMemoryInstallationTokenCache();
+    cache.set("k", { token: "t", expiresAt: "not-a-date" });
+    expect(cache.get("k")).toBeNull();
+  });
+});

--- a/packages/server/src/gateway/installation/github-installation-token-provider.ts
+++ b/packages/server/src/gateway/installation/github-installation-token-provider.ts
@@ -1,0 +1,251 @@
+/**
+ * GitHub App installation-token provider.
+ *
+ * Flow (100% gateway-side):
+ *   1. Build a short-lived App JWT (RS256), signed with the App private key:
+ *        header  { alg: 'RS256', typ: 'JWT' }
+ *        claims  { iss: <App id>, iat, exp }  with exp - iat <= 600s
+ *   2. Exchange it for an installation token:
+ *        POST https://api.github.com/app/installations/{installation_id}/access_tokens
+ *        Authorization: Bearer <jwt>
+ *        Accept: application/vnd.github+json
+ *      → { token, expires_at }  (token valid ~1h)
+ *   3. Cache per installation id (per-pod, best-effort) and refresh before expiry.
+ *
+ * The private key and the JWT never leave the gateway: a worker only ever sees
+ * the minted installation token (resolved at egress, like an OAuth token).
+ */
+
+import { createSign } from "node:crypto";
+import { createLogger } from "@lobu/core";
+import type { AppInstallationRow } from "../../lobu/stores/app-installation-store.js";
+import {
+  InstallationTokenError,
+  type InstallationTokenProvider,
+  InMemoryInstallationTokenCache,
+  type MintedInstallationToken,
+} from "./installation-token-provider.js";
+
+const logger = createLogger("github-installation-token");
+
+/** GitHub caps the App JWT at 10 minutes; we sign 9 to leave clock-skew slack. */
+const APP_JWT_TTL_SECONDS = 540;
+/**
+ * GitHub rejects an App JWT whose `iat` is in the future relative to its clock.
+ * Backdate `iat` 60s so a fast/skewed local clock never trips
+ * `'iat' claim ('issued at') is in the future`.
+ */
+const APP_JWT_IAT_BACKDATE_SECONDS = 60;
+
+const GITHUB_API_BASE = "https://api.github.com";
+
+export interface GitHubInstallationTokenProviderConfig {
+  /**
+   * Env accessor. Defaults to `process.env`; injectable for tests so the App id
+   * + private key can be supplied without touching the process environment.
+   */
+  env?: Record<string, string | undefined>;
+  /**
+   * Override the HTTP client (tests MOCK the `/access_tokens` exchange here so
+   * no request ever reaches api.github.com).
+   */
+  fetchImpl?: typeof fetch;
+  /** Override the per-pod token cache (tests inject a fresh one for isolation). */
+  cache?: InMemoryInstallationTokenCache;
+  /** Override the JWT clock (tests pin `iat`/`exp`); defaults to `Date.now`. */
+  now?: () => number;
+}
+
+/** GitHub's `POST /access_tokens` success body (subset we consume). */
+interface GitHubAccessTokenResponse {
+  token: string;
+  expires_at: string;
+}
+
+/**
+ * base64url (no padding) — App JWT segments use it, and PEM signing output is
+ * compared against GitHub's expectations byte-for-byte.
+ */
+function base64url(input: Buffer | string): string {
+  return Buffer.from(input)
+    .toString("base64")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+}
+
+/**
+ * Normalize a PEM private key sourced from an env var. Secret managers and
+ * `.env` files commonly store the key with literal `\n` sequences rather than
+ * real newlines; OpenSSL needs real newlines, so we restore them. A key that
+ * already has real newlines is left untouched.
+ */
+function normalizePrivateKeyPem(raw: string): string {
+  return raw.includes("\\n") ? raw.replace(/\\n/g, "\n") : raw;
+}
+
+/**
+ * Build and sign the App JWT (RS256). Exported for unit tests so the header /
+ * claims / signing window can be asserted directly with a throwaway key.
+ */
+export function buildGitHubAppJwt(params: {
+  appId: string;
+  privateKeyPem: string;
+  nowMs?: number;
+}): string {
+  const nowSec = Math.floor((params.nowMs ?? Date.now()) / 1000);
+  const iat = nowSec - APP_JWT_IAT_BACKDATE_SECONDS;
+  const exp = nowSec + APP_JWT_TTL_SECONDS;
+  const header = { alg: "RS256", typ: "JWT" };
+  const claims = { iss: params.appId, iat, exp };
+  const signingInput = `${base64url(JSON.stringify(header))}.${base64url(
+    JSON.stringify(claims)
+  )}`;
+
+  const signer = createSign("RSA-SHA256");
+  signer.update(signingInput);
+  signer.end();
+  const signature = base64url(
+    signer.sign(normalizePrivateKeyPem(params.privateKeyPem))
+  );
+
+  return `${signingInput}.${signature}`;
+}
+
+/**
+ * Mints GitHub App installation tokens. One instance per pod; holds the per-pod
+ * token cache.
+ */
+export class GitHubInstallationTokenProvider
+  implements InstallationTokenProvider
+{
+  readonly provider = "github";
+
+  private readonly env: Record<string, string | undefined>;
+  private readonly fetchImpl: typeof fetch;
+  private readonly cache: InMemoryInstallationTokenCache;
+  private readonly now: () => number;
+
+  constructor(config: GitHubInstallationTokenProviderConfig = {}) {
+    this.env = config.env ?? process.env;
+    this.fetchImpl = config.fetchImpl ?? fetch;
+    this.cache = config.cache ?? new InMemoryInstallationTokenCache();
+    this.now = config.now ?? Date.now;
+  }
+
+  /**
+   * Resolve the App id + private key for an install. The env var NAMES come from
+   * the connector's `app_installation` auth method (`appIdKey` / `privateKeyKey`,
+   * defaulting to `GITHUB_APP_ID` / `GITHUB_APP_PRIVATE_KEY`); the VALUES are
+   * read from the gateway env (never the install row, never the worker).
+   */
+  private resolveAppConfig(install: AppInstallationRow): {
+    appId: string;
+    privateKeyPem: string;
+  } {
+    const appIdKey =
+      (install.metadata?.appIdKey as string | undefined) || "GITHUB_APP_ID";
+    const privateKeyKey =
+      (install.metadata?.privateKeyKey as string | undefined) ||
+      "GITHUB_APP_PRIVATE_KEY";
+
+    const appId = this.env[appIdKey]?.trim();
+    const privateKeyPem = this.env[privateKeyKey];
+
+    if (!appId || !privateKeyPem) {
+      throw new InstallationTokenError(
+        "missing_app_config",
+        `GitHub App config missing: set ${appIdKey} and ${privateKeyKey} in the gateway env`
+      );
+    }
+    return { appId, privateKeyPem };
+  }
+
+  /** Cache key: provider-app-aware so two Apps over one tenant never collide. */
+  private cacheKey(install: AppInstallationRow): string {
+    return `github:${install.providerInstance}:${install.providerAppId}:${install.externalTenantId}`;
+  }
+
+  async mintToken(
+    install: AppInstallationRow
+  ): Promise<MintedInstallationToken> {
+    const key = this.cacheKey(install);
+    const cached = this.cache.get(key);
+    if (cached) return cached;
+
+    const { appId, privateKeyPem } = this.resolveAppConfig(install);
+    const jwt = buildGitHubAppJwt({
+      appId,
+      privateKeyPem,
+      nowMs: this.now(),
+    });
+
+    const url = `${GITHUB_API_BASE}/app/installations/${encodeURIComponent(
+      install.externalTenantId
+    )}/access_tokens`;
+
+    let response: Response;
+    try {
+      response = await this.fetchImpl(url, {
+        method: "POST",
+        headers: {
+          authorization: `Bearer ${jwt}`,
+          accept: "application/vnd.github+json",
+          "x-github-api-version": "2022-11-28",
+          "user-agent": "lobu-gateway",
+        },
+      });
+    } catch (cause) {
+      throw new InstallationTokenError(
+        "exchange_failed",
+        `GitHub installation-token exchange request failed for installation ${install.externalTenantId}`,
+        { cause }
+      );
+    }
+
+    if (!response.ok) {
+      // A 404 here is the classic revoked/suspended/removed install: the App
+      // id is valid (the JWT passed) but the installation no longer exists.
+      // Surface it as a failure so the connection error path can flag it; the
+      // caller maps a missing token onto a connection error, never a crash.
+      logger.warn(
+        {
+          status: response.status,
+          installation_id: install.externalTenantId,
+          install_row_id: install.id,
+        },
+        "GitHub installation-token exchange returned non-OK"
+      );
+      throw new InstallationTokenError(
+        "exchange_failed",
+        `GitHub installation-token exchange returned ${response.status} for installation ${install.externalTenantId}`,
+        { status: response.status }
+      );
+    }
+
+    let body: GitHubAccessTokenResponse;
+    try {
+      body = (await response.json()) as GitHubAccessTokenResponse;
+    } catch (cause) {
+      throw new InstallationTokenError(
+        "exchange_failed",
+        "GitHub installation-token exchange returned an unparseable body",
+        { cause }
+      );
+    }
+
+    if (!body.token || !body.expires_at) {
+      throw new InstallationTokenError(
+        "exchange_failed",
+        "GitHub installation-token exchange body missing token/expires_at"
+      );
+    }
+
+    const minted: MintedInstallationToken = {
+      token: body.token,
+      expiresAt: body.expires_at,
+    };
+    this.cache.set(key, minted);
+    return minted;
+  }
+}

--- a/packages/server/src/gateway/installation/installation-token-provider.ts
+++ b/packages/server/src/gateway/installation/installation-token-provider.ts
@@ -1,0 +1,175 @@
+/**
+ * Installation token providers — gateway-side minting of tenant-scoped
+ * credentials for {@link AppInstallationRow} installs (GitHub App, Slack app,
+ * Jira site, …).
+ *
+ * Worker-creds invariant (AGENTS.md): the private key, the App JWT, and the
+ * provider token exchange ALL stay gateway-side. A connector/worker never
+ * receives the App private key or the JWT — only the freshly-minted short-lived
+ * installation token, resolved at credential-resolution time (the same seam
+ * OAuth access tokens already flow through). Each provider mints + caches its
+ * own tokens; the registry is the single per-pod lookup point.
+ *
+ * Multi-replica: every provider's token cache is per-pod, best-effort, and
+ * re-minted on miss/expiry — never shared in-memory across pods (see the
+ * `InMemoryInstallationTokenCache` note). Two replicas minting for the same
+ * install just produce two valid tokens; nothing requires them to agree.
+ */
+
+import type { AppInstallationRow } from "../../lobu/stores/app-installation-store.js";
+
+/**
+ * A minted, tenant-scoped credential plus its absolute expiry (ISO-8601). The
+ * `token` is the value injected at egress; `expiresAt` drives proactive refresh.
+ */
+export interface MintedInstallationToken {
+  token: string;
+  /** ISO-8601 absolute expiry, e.g. GitHub's `expires_at` (~1h out). */
+  expiresAt: string;
+}
+
+/**
+ * Per-provider minting strategy. One implementation per `provider`
+ * (`'github'`, `'slack'`, …); registered in an {@link InstallationTokenRegistry}.
+ */
+export interface InstallationTokenProvider {
+  /** Provider key this strategy mints for, e.g. `'github'`. */
+  readonly provider: string;
+  /**
+   * Mint (or return a cached, still-valid) tenant-scoped token for an install.
+   *
+   * Implementations MUST keep the private key + token exchange gateway-side and
+   * SHOULD cache per install id with proactive refresh. Throws a
+   * {@link InstallationTokenError} on mint failure (caller surfaces it as a
+   * connection error rather than crashing).
+   */
+  mintToken(install: AppInstallationRow): Promise<MintedInstallationToken>;
+}
+
+/**
+ * Raised when an install token cannot be minted: missing App config, a
+ * revoked/suspended install, or a failed provider exchange. Carries a stable
+ * `reason` the connection-error surface can branch on without string matching.
+ */
+export type InstallationTokenFailureReason =
+  | "missing_app_config"
+  | "install_inactive"
+  | "exchange_failed"
+  | "provider_unsupported";
+
+export class InstallationTokenError extends Error {
+  readonly reason: InstallationTokenFailureReason;
+  /** HTTP status from the provider exchange, when the failure was a bad response. */
+  readonly status?: number;
+
+  constructor(
+    reason: InstallationTokenFailureReason,
+    message: string,
+    options?: { status?: number; cause?: unknown }
+  ) {
+    super(message, options?.cause ? { cause: options.cause } : undefined);
+    this.name = "InstallationTokenError";
+    this.reason = reason;
+    this.status = options?.status;
+  }
+}
+
+/**
+ * Statuses for which we refuse to mint. A `revoked`/`suspended`/`error`/`pending`
+ * install has no usable credential, so minting short-circuits with
+ * `install_inactive` instead of hitting the provider.
+ */
+function isMintableStatus(status: AppInstallationRow["status"]): boolean {
+  return status === "active";
+}
+
+/**
+ * Per-pod, in-memory token cache shared by provider implementations.
+ *
+ * Per-pod by design (mirrors `secret-proxy`'s `PlaceholderCache`): a token
+ * minted on pod A is never read by pod B — each replica self-serves. No
+ * cross-pod coordination, so it holds under N replicas behind ClientIP
+ * affinity. Entries refresh proactively `refreshSkewMs` before the provider's
+ * stated expiry so an in-flight request never races the boundary.
+ */
+export class InMemoryInstallationTokenCache {
+  private readonly entries = new Map<string, MintedInstallationToken>();
+  private readonly refreshSkewMs: number;
+
+  constructor(options?: { refreshSkewMs?: number }) {
+    // Default 60s skew: GitHub tokens last ~1h, so re-minting a minute early
+    // is cheap insurance against clock skew + in-flight latency.
+    this.refreshSkewMs = options?.refreshSkewMs ?? 60_000;
+  }
+
+  /** Cached token for `key` if present AND not within the refresh window; else null. */
+  get(key: string): MintedInstallationToken | null {
+    const entry = this.entries.get(key);
+    if (!entry) return null;
+    const expMs = Date.parse(entry.expiresAt);
+    // An unparseable expiry is treated as already-stale: re-mint rather than
+    // trust a token we can't reason about the lifetime of.
+    if (!Number.isFinite(expMs) || expMs - this.refreshSkewMs <= Date.now()) {
+      this.entries.delete(key);
+      return null;
+    }
+    return entry;
+  }
+
+  set(key: string, token: MintedInstallationToken): void {
+    this.entries.set(key, token);
+  }
+
+  delete(key: string): void {
+    this.entries.delete(key);
+  }
+
+  clear(): void {
+    this.entries.clear();
+  }
+
+  size(): number {
+    return this.entries.size;
+  }
+}
+
+/**
+ * Per-pod registry of {@link InstallationTokenProvider}s keyed by `provider`.
+ * The single lookup point for credential resolution: given an install row, pick
+ * the provider and mint. Refuses to mint for a non-active install up front so a
+ * revoked/suspended row never reaches a provider exchange.
+ */
+export class InstallationTokenRegistry {
+  private readonly providers = new Map<string, InstallationTokenProvider>();
+
+  register(provider: InstallationTokenProvider): void {
+    this.providers.set(provider.provider, provider);
+  }
+
+  get(provider: string): InstallationTokenProvider | undefined {
+    return this.providers.get(provider);
+  }
+
+  /**
+   * Mint a token for `install` via its registered provider. Throws
+   * {@link InstallationTokenError} when no provider is registered for the
+   * install's `provider` (`provider_unsupported`) or the install is not active
+   * (`install_inactive`); otherwise delegates to the provider's `mintToken`.
+   */
+  async mintFor(install: AppInstallationRow): Promise<MintedInstallationToken> {
+    if (!isMintableStatus(install.status)) {
+      throw new InstallationTokenError(
+        "install_inactive",
+        `App installation ${install.id} is '${install.status}', not 'active' — no token can be minted`
+      );
+    }
+    const provider = this.providers.get(install.provider);
+    if (!provider) {
+      throw new InstallationTokenError(
+        "provider_unsupported",
+        `No InstallationTokenProvider registered for provider '${install.provider}'`
+      );
+    }
+    return provider.mintToken(install);
+  }
+}

--- a/packages/server/src/gateway/installation/registry.ts
+++ b/packages/server/src/gateway/installation/registry.ts
@@ -1,0 +1,33 @@
+/**
+ * Process-wide (per-pod) {@link InstallationTokenRegistry} singleton + the
+ * default provider wiring.
+ *
+ * Per-pod by design (AGENTS.md multi-replica rule): the registry holds the
+ * GitHub provider's in-memory token cache, which must NOT be shared across pods.
+ * Each replica builds its own registry on first use and self-serves token
+ * minting; two replicas minting for the same install just produce two valid
+ * tokens — nothing requires cross-pod agreement.
+ */
+
+import { GitHubInstallationTokenProvider } from "./github-installation-token-provider.js";
+import { InstallationTokenRegistry } from "./installation-token-provider.js";
+
+let registry: InstallationTokenRegistry | null = null;
+
+/**
+ * The per-pod registry, built lazily with the default providers registered.
+ * GitHub is the only minting provider today; Slack resolves a stored ref (no
+ * minting) and is added by the Slack-retrofit PR.
+ */
+export function getInstallationTokenRegistry(): InstallationTokenRegistry {
+  if (!registry) {
+    registry = new InstallationTokenRegistry();
+    registry.register(new GitHubInstallationTokenProvider());
+  }
+  return registry;
+}
+
+/** Test-only: drop the singleton so a test can install its own providers. */
+export function __resetInstallationTokenRegistryForTests(): void {
+  registry = null;
+}

--- a/packages/server/src/gateway/installation/registry.ts
+++ b/packages/server/src/gateway/installation/registry.ts
@@ -16,8 +16,6 @@ let registry: InstallationTokenRegistry | null = null;
 
 /**
  * The per-pod registry, built lazily with the default providers registered.
- * GitHub is the only minting provider today; Slack resolves a stored ref (no
- * minting) and is added by the Slack-retrofit PR.
  */
 export function getInstallationTokenRegistry(): InstallationTokenRegistry {
   if (!registry) {

--- a/packages/server/src/utils/__tests__/connector-auth.test.ts
+++ b/packages/server/src/utils/__tests__/connector-auth.test.ts
@@ -3,7 +3,9 @@
  */
 
 import { describe, expect, it } from 'vitest';
+import type { ConnectorAuthAppInstallation } from '@lobu/connector-sdk';
 import {
+  getAppInstallationAuthMethods,
   getOAuthAuthMethods,
   getRequiredEnvAuthFields,
   normalizeConnectorAuthSchema,
@@ -173,5 +175,56 @@ describe('getRequiredEnvAuthFields', () => {
     });
     const fields = getRequiredEnvAuthFields(schema);
     expect(fields.length).toBe(0);
+  });
+});
+
+describe('app_installation auth method', () => {
+  it('preserves provider + appIdKey/privateKeyKey through normalization', () => {
+    const schema = normalizeConnectorAuthSchema({
+      methods: [
+        {
+          type: 'app_installation',
+          provider: 'github',
+          providerInstance: 'cloud',
+          appIdKey: 'GITHUB_APP_ID',
+          privateKeyKey: 'GITHUB_APP_PRIVATE_KEY',
+          installUrlTemplate: 'https://github.com/apps/lobu/installations/new',
+          permissions: ['issues:read'],
+          events: ['issues'],
+        },
+      ],
+    });
+    const methods = getAppInstallationAuthMethods(schema);
+    expect(methods.length).toBe(1);
+    const m = methods[0] as ConnectorAuthAppInstallation;
+    expect(m.provider).toBe('github');
+    expect(m.providerInstance).toBe('cloud');
+    expect(m.appIdKey).toBe('GITHUB_APP_ID');
+    expect(m.privateKeyKey).toBe('GITHUB_APP_PRIVATE_KEY');
+    expect(m.installUrlTemplate).toContain('installations/new');
+    expect(m.permissions).toEqual(['issues:read']);
+    expect(m.events).toEqual(['issues']);
+  });
+
+  it('drops an app_installation method with no provider', () => {
+    const schema = normalizeConnectorAuthSchema({
+      methods: [{ type: 'app_installation' }],
+    });
+    expect(getAppInstallationAuthMethods(schema).length).toBe(0);
+    // No valid methods left → default 'none'.
+    expect(schema.methods).toEqual([{ type: 'none' }]);
+  });
+
+  it('coexists with oauth + env_keys fallbacks on one connector', () => {
+    const schema = normalizeConnectorAuthSchema({
+      methods: [
+        { type: 'app_installation', provider: 'github' },
+        { type: 'oauth', provider: 'github', clientIdKey: 'GITHUB_CLIENT_ID' },
+        { type: 'env_keys', fields: [{ key: 'GITHUB_TOKEN', secret: true }] },
+      ],
+    });
+    expect(getAppInstallationAuthMethods(schema).length).toBe(1);
+    expect(getOAuthAuthMethods(schema).length).toBe(1);
+    expect(schema.methods.length).toBe(3);
   });
 });

--- a/packages/server/src/utils/connector-auth.ts
+++ b/packages/server/src/utils/connector-auth.ts
@@ -1,4 +1,5 @@
 import type {
+  ConnectorAuthAppInstallation,
   ConnectorAuthEnvField,
   ConnectorAuthEnvKeys,
   ConnectorAuthMethod,
@@ -101,6 +102,35 @@ export function normalizeConnectorAuthSchema(value: unknown): ConnectorAuthSchem
       continue;
     }
 
+    if (type === 'app_installation') {
+      const provider = typeof method.provider === 'string' ? method.provider.trim() : '';
+      if (!provider) continue;
+
+      const stringArray = (raw: unknown): string[] | undefined =>
+        Array.isArray(raw)
+          ? raw.filter((v): v is string => typeof v === 'string')
+          : undefined;
+      const permissions = stringArray(method.permissions);
+      const events = stringArray(method.events);
+
+      methods.push({
+        type: 'app_installation',
+        provider,
+        providerInstance:
+          typeof method.providerInstance === 'string' ? method.providerInstance : undefined,
+        appIdKey: typeof method.appIdKey === 'string' ? method.appIdKey : undefined,
+        privateKeyKey:
+          typeof method.privateKeyKey === 'string' ? method.privateKeyKey : undefined,
+        installUrlTemplate:
+          typeof method.installUrlTemplate === 'string' ? method.installUrlTemplate : undefined,
+        ...(permissions && permissions.length > 0 ? { permissions } : {}),
+        ...(events && events.length > 0 ? { events } : {}),
+        required: typeof method.required === 'boolean' ? method.required : undefined,
+        description: typeof method.description === 'string' ? method.description : undefined,
+      });
+      continue;
+    }
+
     if (type === 'oauth') {
       const provider = typeof method.provider === 'string' ? method.provider.trim() : '';
       if (!provider) continue;
@@ -173,6 +203,14 @@ function getEnvAuthMethods(authSchema: ConnectorAuthSchema): ConnectorAuthEnvKey
 export function getOAuthAuthMethods(authSchema: ConnectorAuthSchema): ConnectorAuthOAuthMethod[] {
   return authSchema.methods.filter(
     (method): method is ConnectorAuthOAuthMethod => method.type === 'oauth'
+  );
+}
+
+export function getAppInstallationAuthMethods(
+  authSchema: ConnectorAuthSchema
+): ConnectorAuthAppInstallation[] {
+  return authSchema.methods.filter(
+    (method): method is ConnectorAuthAppInstallation => method.type === 'app_installation'
   );
 }
 

--- a/packages/server/src/utils/execution-context.ts
+++ b/packages/server/src/utils/execution-context.ts
@@ -3,7 +3,17 @@ import { resolveCloudCredential } from '../connect/cloud-credential';
 import { getBuiltinProviderConfig } from '../connect/oauth-providers';
 import { type DbClient, getDb } from '../db/client';
 import { getAuthProfileById, normalizeAuthValues } from './auth-profiles';
-import { getOAuthAuthMethods, normalizeConnectorAuthSchema } from './connector-auth';
+import {
+  getAppInstallationAuthMethods,
+  getOAuthAuthMethods,
+  normalizeConnectorAuthSchema,
+} from './connector-auth';
+import { createPostgresAppInstallationStore } from '../lobu/stores/app-installation-store';
+import {
+  InstallationTokenError,
+  type MintedInstallationToken,
+} from '../gateway/installation/installation-token-provider';
+import { getInstallationTokenRegistry } from '../gateway/installation/registry';
 import { parseJsonObject } from '@lobu/core';
 import { errorMessage } from './errors';
 import logger from './logger';
@@ -70,6 +80,26 @@ export async function resolveExecutionAuth(
     }
     return {
       credentials,
+      connectionCredentials: {},
+      sessionState: null,
+      browserUserDataDir: null,
+    };
+  }
+
+  // App-installation branch (precedence over oauth_account per design §4.5):
+  // a connection backed by an `app_installation` auth method resolves a
+  // tenant-scoped token by minting it gateway-side. The private key + JWT +
+  // provider exchange stay here; the worker only ever receives the minted token
+  // (same seam OAuth tokens flow through). Returns null credentials (no crash)
+  // on any failure so the connection surfaces a credential error, not a 500.
+  const installCredential = await resolveAppInstallationCredential(
+    params.organizationId,
+    params.connectionId,
+    params.logContext
+  );
+  if (installCredential.handled) {
+    return {
+      credentials: installCredential.credentials,
       connectionCredentials: {},
       sessionState: null,
       browserUserDataDir: null,
@@ -272,6 +302,146 @@ async function fetchManagedConnectionToken(
     );
     return null;
   }
+}
+
+/**
+ * Result of the app-installation credential branch. `handled: true` means this
+ * connection is App-backed and resolution is authoritative (success OR a
+ * surfaced failure) — the caller returns immediately and does NOT fall through
+ * to the OAuth/env paths. `handled: false` means the connection is not
+ * App-backed; the caller continues with the unchanged credential resolution.
+ */
+interface AppInstallationCredentialResult {
+  handled: boolean;
+  credentials: ExecutionOAuthCredentials | null;
+}
+
+const NOT_APP_INSTALLATION: AppInstallationCredentialResult = {
+  handled: false,
+  credentials: null,
+};
+
+/**
+ * Resolve a tenant-scoped credential for an App-installation-backed connection.
+ *
+ * Wiring contract:
+ *  - The connection's connector must declare an `app_installation` auth method
+ *    (provider + appIdKey/privateKeyKey), and the connection `config` must carry
+ *    `installation_ref` = the `app_installations.id` it was bound to (written by
+ *    the install/connect flow — PR5). Absent either, this is not an App-backed
+ *    connection and we hand back to the normal resolver.
+ *  - The active install row is loaded by id; the connector method's
+ *    `appIdKey`/`privateKeyKey` are stamped into the row metadata so the GitHub
+ *    provider reads the right gateway env vars. The token is minted via the
+ *    per-pod {@link getInstallationTokenRegistry} (App JWT + provider exchange,
+ *    gateway-side only).
+ *
+ * Worker-creds invariant: the minted token is returned as `credentials`
+ * (provider/accessToken/expiresAt), the existing channel a connector reads its
+ * token from — identical to OAuth. The App private key, the signed App JWT, and
+ * the GitHub `/access_tokens` exchange never leave the gateway. The end-state
+ * `lobu_secret_<uuid>` placeholder + secret-proxy egress swap for the
+ * connector-worker HTTP path is the documented seam (the connector worker does
+ * not yet route outbound HTTP through the secret-proxy); see the PR notes.
+ *
+ * Lifecycle: a missing/inactive install or a mint failure resolves to
+ * `{ handled: true, credentials: null }` — the connection runs without a
+ * credential and the connector's own auth check fails cleanly, never a crash.
+ */
+async function resolveAppInstallationCredential(
+  organizationId: string,
+  connectionId: number,
+  logContext?: Record<string, unknown>
+): Promise<AppInstallationCredentialResult> {
+  const sql = getDb();
+  const rows = (await sql`
+    SELECT c.connector_key, c.config, cd.auth_schema
+    FROM connections c
+    JOIN connector_definitions cd
+      ON cd.key = c.connector_key
+     AND cd.organization_id = c.organization_id
+     AND cd.status = 'active'
+    WHERE c.id = ${connectionId}
+      AND c.organization_id = ${organizationId}
+      AND c.deleted_at IS NULL
+    LIMIT 1
+  `) as unknown as Array<{
+    connector_key: string;
+    config: Record<string, unknown> | null;
+    auth_schema: unknown;
+  }>;
+  if (rows.length === 0) return NOT_APP_INSTALLATION;
+
+  const authSchema = normalizeConnectorAuthSchema(rows[0].auth_schema);
+  const method = getAppInstallationAuthMethods(authSchema)[0];
+  if (!method) return NOT_APP_INSTALLATION;
+
+  const config = parseJsonObject(rows[0].config);
+  const installRef = config.installation_ref;
+  const installId =
+    typeof installRef === 'number'
+      ? installRef
+      : typeof installRef === 'string' && installRef.trim()
+        ? Number(installRef)
+        : null;
+  if (installId == null || !Number.isFinite(installId)) {
+    // Connector supports App installs, but this connection isn't bound to one —
+    // fall through to the configured fallback method (PAT/env) per §4.5.
+    return NOT_APP_INSTALLATION;
+  }
+
+  const store = createPostgresAppInstallationStore();
+  const install = await store.getById(installId);
+  if (!install) {
+    logger.warn(
+      { ...logContext, connection_id: connectionId, install_id: installId },
+      'App-installation connection references a missing install row'
+    );
+    return { handled: true, credentials: null };
+  }
+
+  // Stamp the connector method's env-var names onto the row metadata so the
+  // provider reads the correct gateway env vars (the row itself never holds the
+  // App id or private key — only their env-var NAMES, resolved gateway-side).
+  const installWithKeys = {
+    ...install,
+    metadata: {
+      ...install.metadata,
+      ...(method.appIdKey ? { appIdKey: method.appIdKey } : {}),
+      ...(method.privateKeyKey ? { privateKeyKey: method.privateKeyKey } : {}),
+    },
+  };
+
+  let minted: MintedInstallationToken;
+  try {
+    minted = await getInstallationTokenRegistry().mintFor(installWithKeys);
+  } catch (error) {
+    const reason =
+      error instanceof InstallationTokenError ? error.reason : 'unknown';
+    logger.warn(
+      {
+        ...logContext,
+        connection_id: connectionId,
+        install_id: installId,
+        provider: install.provider,
+        reason,
+        error: errorMessage(error),
+      },
+      'Failed to mint app-installation token'
+    );
+    return { handled: true, credentials: null };
+  }
+
+  return {
+    handled: true,
+    credentials: {
+      provider: install.provider,
+      accessToken: minted.token,
+      refreshToken: null,
+      expiresAt: minted.expiresAt,
+      scope: null,
+    },
+  };
 }
 
 async function resolveExecutionOAuthConfig(

--- a/packages/server/src/utils/execution-context.ts
+++ b/packages/server/src/utils/execution-context.ts
@@ -344,9 +344,15 @@ const NOT_APP_INSTALLATION: AppInstallationCredentialResult = {
  * connector-worker HTTP path is the documented seam (the connector worker does
  * not yet route outbound HTTP through the secret-proxy); see the PR notes.
  *
- * Lifecycle: a missing/inactive install or a mint failure resolves to
+ * Lifecycle: a missing/inactive install, a cross-tenant or wrong-provider
+ * install reference, or a mint failure all resolve to
  * `{ handled: true, credentials: null }` — the connection runs without a
  * credential and the connector's own auth check fails cleanly, never a crash.
+ *
+ * Tenancy: the loaded install row MUST belong to the connection's org and match
+ * the connector method's declared provider/providerInstance; a mismatch returns
+ * null creds WITHOUT minting (a cross-tenant `installation_ref` must never yield
+ * another org's token).
  */
 async function resolveAppInstallationCredential(
   organizationId: string,
@@ -396,6 +402,49 @@ async function resolveAppInstallationCredential(
     logger.warn(
       { ...logContext, connection_id: connectionId, install_id: installId },
       'App-installation connection references a missing install row'
+    );
+    return { handled: true, credentials: null };
+  }
+
+  // Tenancy guard: the install MUST belong to the connection's org. Without this,
+  // a connection in org A could set `config.installation_ref` to org B's install
+  // id and receive org B's minted token (cross-tenant credential leak). Reject
+  // the mismatch — return null creds, never mint — and log it as a tenancy
+  // violation signal.
+  if (install.organizationId !== organizationId) {
+    logger.warn(
+      {
+        ...logContext,
+        connection_id: connectionId,
+        install_id: installId,
+        connection_org: organizationId,
+        install_org: install.organizationId,
+      },
+      'Cross-tenant app-installation reference rejected: install org does not match connection org'
+    );
+    return { handled: true, credentials: null };
+  }
+
+  // Connector-shape guard: the install MUST match the connector method's declared
+  // app_installation provider (and providerInstance when the method pins it).
+  // Otherwise a connection could point at an unrelated install of a different
+  // provider/instance in the same org and mint a token it shouldn't read.
+  if (
+    install.provider !== method.provider ||
+    (method.providerInstance != null &&
+      install.providerInstance !== method.providerInstance)
+  ) {
+    logger.warn(
+      {
+        ...logContext,
+        connection_id: connectionId,
+        install_id: installId,
+        install_provider: install.provider,
+        method_provider: method.provider,
+        install_provider_instance: install.providerInstance,
+        method_provider_instance: method.providerInstance,
+      },
+      'App-installation reference rejected: install provider/instance does not match connector method'
     );
     return { handled: true, credentials: null };
   }

--- a/packages/server/src/utils/execution-context.ts
+++ b/packages/server/src/utils/execution-context.ts
@@ -426,13 +426,13 @@ async function resolveAppInstallationCredential(
   }
 
   // Connector-shape guard: the install MUST match the connector method's declared
-  // app_installation provider (and providerInstance when the method pins it).
-  // Otherwise a connection could point at an unrelated install of a different
-  // provider/instance in the same org and mint a token it shouldn't read.
+  // app_installation provider and providerInstance. An omitted method
+  // providerInstance defaults to 'cloud' (NOT a wildcard) — otherwise a method
+  // that doesn't pin an instance would accept an install from any instance
+  // (e.g. a self-hosted GHES host), which is a tenancy/scope hole.
   if (
     install.provider !== method.provider ||
-    (method.providerInstance != null &&
-      install.providerInstance !== method.providerInstance)
+    install.providerInstance !== (method.providerInstance ?? "cloud")
   ) {
     logger.warn(
       {


### PR DESCRIPTION
## What

PR3 of the `app_installation` consolidation (design: `docs/design/app-installation.md` §4.2). Adds the gateway-side **`InstallationTokenProvider`** abstraction + the **GitHub installation-token minting** path, preserving the "workers never see real creds" invariant.

Builds on `#1429` (app_installations table+store) and `#1428` (app_installation SDK types).

## How

- **`installation-token-provider.ts`** — `InstallationTokenProvider` interface (`{ provider; mintToken(install) }`), `InstallationTokenRegistry` (per-pod, keyed by provider; refuses to mint for a non-active install or an unsupported provider), `InMemoryInstallationTokenCache` (per-pod, best-effort, refresh-before-expiry), and a typed `InstallationTokenError`.
- **`github-installation-token-provider.ts`** — builds a short-lived App JWT (RS256 via `node:crypto`, claims `iss=GITHUB_APP_ID`/`iat`/`exp`, `exp-iat ≤ 600s`, `iat` backdated for clock skew) from the App private key (`GITHUB_APP_PRIVATE_KEY`, PEM; tolerates `\n`-escaped env form), exchanges it via `POST /app/installations/{external_tenant_id}/access_tokens` (`Authorization: Bearer <jwt>` + `Accept: application/vnd.github+json`), and caches `{ token, expires_at }` per install with proactive refresh. Env-var names come from the connector's `app_installation` method (`appIdKey`/`privateKeyKey`, defaulting to `GITHUB_APP_ID`/`GITHUB_APP_PRIVATE_KEY`); values are read from the gateway env only.
- **`registry.ts`** — per-pod registry singleton with GitHub registered.
- **`execution-context.ts`** — `resolveExecutionAuth` gains an app_installation branch (precedence over `oauth_account` per §4.5): when a connection's connector declares an `app_installation` method and `connection.config.installation_ref` points at an `app_installations` row, the active install is loaded, the token minted via the registry, and returned through the existing `credentials` channel. Falls back to the configured PAT/env method when not App-bound; mint failure / inactive / revoked install resolve to `null` credentials (connection error, never a 500).
- **`connector-auth.ts`** — parse branch + `getAppInstallationAuthMethods` accessor so `appIdKey`/`privateKeyKey`/etc. survive `normalizeConnectorAuthSchema`.

## Worker-creds invariant

The App private key, the signed App JWT, and the GitHub `/access_tokens` exchange stay **100% gateway-side**. The minted short-lived installation token is handed to the connector via the same `credentials.accessToken` channel OAuth access tokens already use.

**Documented seam:** the connector-worker does not currently route its outbound HTTP through the secret-proxy (it uses `credentials.accessToken` directly — the existing OAuth seam), so the end-state `lobu_secret_<uuid>` placeholder + secret-proxy egress-swap for the connector-worker HTTP path is **not** wired here. The load-bearing part of the invariant (private key + minting never leave the gateway) holds; the placeholder/egress-swap for connector HTTP is a follow-up tied to routing connector egress through the proxy.

## Multi-replica

Token cache is per-pod, re-minted on miss/expiry, no cross-pod shared state — holds under N replicas behind ClientIP affinity (mirrors `secret-proxy`'s `PlaceholderCache`).

## Tests

- `github-installation-token-provider.test.ts` (bun:test, 15 tests): JWT header/claims/≤600s window + signature verified against a throwaway RSA key; cache hit / refresh-on-expiry / unparseable-expiry; mint failures (missing config, 404 revoked/suspended, network error); per-method `appIdKey`/`privateKeyKey`; registry inactive/unsupported/delegate. **The GitHub `/access_tokens` exchange is mocked** — no api.github.com hit.
- `connector-auth.test.ts` (+3 vitest): app_installation normalization round-trip, no-provider drop, coexistence with oauth+env_keys.

```
bun test … github-installation-token-provider.test.ts  → 15 pass / 0 fail
bunx vitest run … connector-auth.test.ts               → 16 pass / 0 fail
cd packages/server && bunx tsc --noEmit                → 0 errors
```

## Not covered (live-creds gap)

The live GitHub `/access_tokens` exchange (real App id + private key against api.github.com) — mocked here, to be validated post-merge with the install/connect flow (PR5). Not live-verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015ug5cEnCRt1VHn8w3gNXAu

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1430"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784683527&installation_id=136316292&pr_number=1430&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1430&signature=421fb1de4b4705fae87ac3685a8327c5663d50863974c541cad646a37ae91db6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added GitHub App installation authentication for connectors with automatic token minting and caching
  * Intelligent token refresh with staleness detection to minimize authentication latency
  * Enforced security controls for cross-organization isolation and connector validation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->