### PR TITLE
feat(gateway): shared /app-webhooks/:provider router + GitHub verifier/extractor

### DIFF
--- a/packages/server/src/gateway/__tests__/app-webhooks.test.ts
+++ b/packages/server/src/gateway/__tests__/app-webhooks.test.ts
@@ -1,0 +1,303 @@
+/**
+ * Shared multi-tenant app-webhook router (app-installation design §4.3).
+ *
+ * Drives the REAL Hono route (`createAppWebhookRoutes`) → GitHub provider
+ * plugin → `handleWebhookIngest` → real Postgres, the path an actual GitHub App
+ * delivery exercises (minus the live provider POST). We hold the app webhook
+ * secret, so we compute a real `x-hub-signature-256` HMAC over the raw body.
+ *
+ * Under test:
+ *  1. A signed `issues` delivery with a seeded ACTIVE install routes to the
+ *     owning org and lands an `events` row (connector_key='webhook:app_install:<id>').
+ *  2. A forged signature → 401, nothing landed.
+ *  3. An unknown tenant (no active install) → 200 ack, nothing landed (the
+ *     delivery-before-install-callback case must NOT 500).
+ *  4. Redelivery (same x-github-delivery) dedupes to one event.
+ */
+
+import { createHmac } from "node:crypto";
+import { beforeAll, beforeEach, describe, expect, test } from "bun:test";
+import {
+	createAppWebhookRoutes,
+	createGithubAppWebhookProvider,
+} from "../routes/public/app-webhooks.js";
+import { createPostgresAppInstallationStore } from "../../lobu/stores/app-installation-store.js";
+import {
+	ensureDbForGatewayTests,
+	ensureEncryptionKey,
+	resetTestDatabase,
+	seedAgentRow,
+} from "./helpers/db-setup.js";
+
+const ORG = "org-app-webhook";
+const AGENT = "agent-app-webhook";
+const APP_ID = "654321";
+const APP_SECRET = "ghapp-webhook-secret-0123456789abcdef";
+const INSTALLATION_ID = "987654";
+
+/** GitHub signs the raw body with the App webhook secret → `sha256=<hex>`. */
+function ghSign(rawBody: string, secret = APP_SECRET): string {
+	return `sha256=${createHmac("sha256", secret).update(rawBody).digest("hex")}`;
+}
+
+/** A plaintext-only fake; the app secret is provided via the resolver. */
+const fakeSecretStore = { get: async () => null };
+
+/** Build the router with the GitHub plugin and a fixed app-secret resolver. */
+function buildApp() {
+	return createAppWebhookRoutes({
+		installationStore: createPostgresAppInstallationStore(),
+		secretStore: fakeSecretStore,
+		providers: [createGithubAppWebhookProvider({ appId: APP_ID })],
+		resolveAppWebhookSecret: async () => APP_SECRET,
+	});
+}
+
+/** Seed an ACTIVE github installation for the routed tenant tuple. */
+async function seedActiveInstall(): Promise<number> {
+	const store = createPostgresAppInstallationStore();
+	const row = await store.upsert({
+		organizationId: ORG,
+		provider: "github",
+		providerInstance: "cloud",
+		providerAppId: APP_ID,
+		externalTenantId: INSTALLATION_ID,
+		status: "active",
+		metadata: { account: "acme" },
+	});
+	return row.id;
+}
+
+function ghDelivery(
+	rawBody: string,
+	{
+		signature = ghSign(rawBody),
+		deliveryId = "gh-app-1",
+		event = "issues",
+	}: { signature?: string; deliveryId?: string; event?: string } = {},
+): Request {
+	return new Request("http://gateway.test/api/v1/app-webhooks/github", {
+		method: "POST",
+		body: rawBody,
+		headers: {
+			"content-type": "application/json",
+			"x-github-event": event,
+			"x-github-delivery": deliveryId,
+			"x-hub-signature-256": signature,
+		},
+	});
+}
+
+async function eventRows(connectorKey: string): Promise<any[]> {
+	const { getDb } = await import("../../db/client.js");
+	return getDb()`
+    SELECT * FROM events
+    WHERE connector_key = ${connectorKey}
+    ORDER BY id
+  `;
+}
+
+beforeAll(async () => {
+	await ensureDbForGatewayTests();
+}, 60_000);
+
+beforeEach(async () => {
+	await resetTestDatabase();
+	ensureEncryptionKey();
+	const { resetRateLimiterForTests } = await import(
+		"../../utils/rate-limiter.js"
+	);
+	resetRateLimiterForTests();
+}, 30_000);
+
+describe("app-webhook router (GitHub)", () => {
+	test("a signed issues delivery routes to the owning org and lands an event", async () => {
+		await seedAgentRow(AGENT, { organizationId: ORG });
+		const installId = await seedActiveInstall();
+		const app = buildApp();
+
+		const raw = JSON.stringify({
+			action: "opened",
+			installation: { id: Number(INSTALLATION_ID) },
+			issue: { number: 11, title: "Prod is down" },
+			repository: { full_name: "acme/api" },
+		});
+		const res = await app.fetch(ghDelivery(raw));
+		expect(res.status).toBe(202);
+
+		const rows = await eventRows(`webhook:app_install:${installId}`);
+		expect(rows.length).toBe(1);
+		// EL: the raw GitHub payload is what landed — untransformed.
+		expect(rows[0].payload_data).toEqual({
+			action: "opened",
+			installation: { id: Number(INSTALLATION_ID) },
+			issue: { number: 11, title: "Prod is down" },
+			repository: { full_name: "acme/api" },
+		});
+		// Routed into the install's owning org, deduped on the delivery id.
+		expect(rows[0].organization_id).toBe(ORG);
+		expect(rows[0].origin_id).toBe("gh-app-1");
+	});
+
+	test("a forged signature is rejected with 401 and lands nothing", async () => {
+		await seedAgentRow(AGENT, { organizationId: ORG });
+		const installId = await seedActiveInstall();
+		const app = buildApp();
+
+		const raw = JSON.stringify({
+			action: "opened",
+			installation: { id: Number(INSTALLATION_ID) },
+			issue: { number: 12 },
+		});
+		const res = await app.fetch(
+			ghDelivery(raw, { signature: "sha256=forged" }),
+		);
+		expect(res.status).toBe(401);
+		expect((await eventRows(`webhook:app_install:${installId}`)).length).toBe(0);
+	});
+
+	test("a delivery signed with the wrong secret is rejected with 401", async () => {
+		await seedAgentRow(AGENT, { organizationId: ORG });
+		const installId = await seedActiveInstall();
+		const app = buildApp();
+
+		const raw = JSON.stringify({
+			action: "opened",
+			installation: { id: Number(INSTALLATION_ID) },
+		});
+		const res = await app.fetch(
+			ghDelivery(raw, { signature: ghSign(raw, "the-wrong-secret") }),
+		);
+		expect(res.status).toBe(401);
+		expect((await eventRows(`webhook:app_install:${installId}`)).length).toBe(0);
+	});
+
+	test("a tampered body (signature over different bytes) is rejected", async () => {
+		await seedAgentRow(AGENT, { organizationId: ORG });
+		const installId = await seedActiveInstall();
+		const app = buildApp();
+
+		const signedOver = JSON.stringify({
+			installation: { id: Number(INSTALLATION_ID) },
+			issue: 1,
+		});
+		const tampered = JSON.stringify({
+			installation: { id: Number(INSTALLATION_ID) },
+			issue: 999,
+		});
+		const res = await app.fetch(
+			ghDelivery(tampered, { signature: ghSign(signedOver) }),
+		);
+		expect(res.status).toBe(401);
+		expect((await eventRows(`webhook:app_install:${installId}`)).length).toBe(0);
+	});
+
+	test("an unknown tenant (no active install) acks 200 without landing", async () => {
+		await seedAgentRow(AGENT, { organizationId: ORG });
+		// No install seeded — delivery arrives before the install callback.
+		const app = buildApp();
+
+		const raw = JSON.stringify({
+			action: "opened",
+			installation: { id: 111222 },
+			issue: { number: 1 },
+		});
+		const res = await app.fetch(ghDelivery(raw));
+		// Ack, NOT 500 — the provider must not retry-storm; reconcile on callback.
+		expect(res.status).toBe(200);
+		expect((await res.json()).landed).toBe(false);
+		// Nothing landed for any install key.
+		const { getDb } = await import("../../db/client.js");
+		const all = await getDb()`
+      SELECT count(*)::int AS n FROM events WHERE connector_key LIKE 'webhook:app_install:%'
+    `;
+		expect(all[0].n).toBe(0);
+	});
+
+	test("a suspended install does not route (transfer demoted it) → 200 ack", async () => {
+		await seedAgentRow(AGENT, { organizationId: ORG });
+		const store = createPostgresAppInstallationStore();
+		// Activate then suspend (e.g. ownership transferred away). resolveActive
+		// must miss, so the delivery acks without landing.
+		const row = await store.upsert({
+			organizationId: ORG,
+			provider: "github",
+			providerInstance: "cloud",
+			providerAppId: APP_ID,
+			externalTenantId: INSTALLATION_ID,
+			status: "active",
+		});
+		await store.setStatus(row.id, "suspended");
+		const app = buildApp();
+
+		const raw = JSON.stringify({
+			action: "opened",
+			installation: { id: Number(INSTALLATION_ID) },
+		});
+		const res = await app.fetch(ghDelivery(raw));
+		expect(res.status).toBe(200);
+		expect((await eventRows(`webhook:app_install:${row.id}`)).length).toBe(0);
+	});
+
+	test("a delivery with no installation in the body acks 200 (no tenant)", async () => {
+		await seedAgentRow(AGENT, { organizationId: ORG });
+		await seedActiveInstall();
+		const app = buildApp();
+
+		const raw = JSON.stringify({ action: "ping", zen: "Keep it logically awesome." });
+		const res = await app.fetch(ghDelivery(raw));
+		expect(res.status).toBe(200);
+		expect((await res.json()).landed).toBe(false);
+	});
+
+	test("redelivery of the same x-github-delivery dedupes to one event", async () => {
+		await seedAgentRow(AGENT, { organizationId: ORG });
+		const installId = await seedActiveInstall();
+		const app = buildApp();
+
+		const raw = JSON.stringify({
+			action: "edited",
+			installation: { id: Number(INSTALLATION_ID) },
+			issue: { number: 9 },
+		});
+		const first = await app.fetch(ghDelivery(raw, { deliveryId: "gh-dupe-1" }));
+		const second = await app.fetch(ghDelivery(raw, { deliveryId: "gh-dupe-1" }));
+		expect(first.status).toBe(202);
+		expect(second.status).toBe(202);
+		expect((await second.json()).duplicate).toBe(true);
+		const rows = await eventRows(`webhook:app_install:${installId}`);
+		expect(rows.length).toBe(1);
+		expect(rows[0].origin_id).toBe("gh-dupe-1");
+	});
+
+	test("an unknown provider path returns 404", async () => {
+		const app = buildApp();
+		const res = await app.fetch(
+			new Request("http://gateway.test/api/v1/app-webhooks/slack", {
+				method: "POST",
+				body: JSON.stringify({ team_id: "T1" }),
+				headers: { "content-type": "application/json" },
+			}),
+		);
+		expect(res.status).toBe(404);
+	});
+
+	test("fails closed with 401 when no app webhook secret is configured", async () => {
+		await seedAgentRow(AGENT, { organizationId: ORG });
+		const installId = await seedActiveInstall();
+		const app = createAppWebhookRoutes({
+			installationStore: createPostgresAppInstallationStore(),
+			secretStore: fakeSecretStore,
+			providers: [createGithubAppWebhookProvider({ appId: APP_ID })],
+			resolveAppWebhookSecret: async () => undefined,
+		});
+
+		const raw = JSON.stringify({
+			action: "opened",
+			installation: { id: Number(INSTALLATION_ID) },
+		});
+		const res = await app.fetch(ghDelivery(raw));
+		expect(res.status).toBe(401);
+		expect((await eventRows(`webhook:app_install:${installId}`)).length).toBe(0);
+	});
+});

--- a/packages/server/src/gateway/cli/gateway.ts
+++ b/packages/server/src/gateway/cli/gateway.ts
@@ -10,6 +10,7 @@ import { takePendingTool } from "../auth/mcp/pending-tool-store.js";
 import { setEnvResolver } from "../auth/mcp/string-substitution.js";
 import { createAuthProfileLabel } from "../auth/settings/auth-profiles-manager.js";
 import { SystemEnvStore } from "../auth/system-env-store.js";
+import { createPostgresAppInstallationStore } from "../../lobu/stores/app-installation-store.js";
 import { getMetricsText } from "../metrics/prometheus.js";
 import { getModelProviderModules } from "../modules/module-system.js";
 import { createAudioRoutes } from "../routes/internal/audio.js";
@@ -21,6 +22,11 @@ import { createImageRoutes } from "../routes/internal/images.js";
 import { createInteractionRoutes } from "../routes/internal/interactions.js";
 import { registerAutoOpenApiRoutes } from "../routes/openapi-auto.js";
 import { createAgentApi } from "../routes/public/agent.js";
+import {
+  createAppWebhookRoutes,
+  createDefaultAppWebhookSecretResolver,
+  createGithubAppWebhookProvider,
+} from "../routes/public/app-webhooks.js";
 import { createAgentConfigRoutes } from "../routes/public/agent-config.js";
 import { createAgentHistoryRoutes } from "../routes/public/agent-history.js";
 import { createAgentRoutes } from "../routes/public/agents.js";
@@ -692,6 +698,26 @@ export function createGatewayApp(
   if (chatInstanceManager) {
     app.route("", createSlackRoutes(chatInstanceManager));
     app.route("", createConnectionWebhookRoutes(chatInstanceManager));
+
+    // Shared multi-tenant app-webhook router (app-installation design §4.3): one
+    // public endpoint per provider for an installed Lobu App. Only the GitHub
+    // plugin ships today, and only when the receiving GitHub App is configured
+    // (GITHUB_APP_ID) — otherwise the route is present but reports the provider
+    // unknown (404), since a missing app id can't match any installation.
+    const appWebhookSecretStore = coreServices.getSecretStore();
+    const githubAppId = process.env.GITHUB_APP_ID;
+    app.route(
+      "",
+      createAppWebhookRoutes({
+        installationStore: createPostgresAppInstallationStore(),
+        secretStore: appWebhookSecretStore,
+        providers: githubAppId
+          ? [createGithubAppWebhookProvider({ appId: githubAppId })]
+          : [],
+        resolveAppWebhookSecret:
+          createDefaultAppWebhookSecretResolver(appWebhookSecretStore),
+      }),
+    );
     app.route(
       "",
       createConnectionCrudRoutes(chatInstanceManager, {

--- a/packages/server/src/gateway/connections/webhook-ingest.ts
+++ b/packages/server/src/gateway/connections/webhook-ingest.ts
@@ -113,7 +113,7 @@ function tokensMatch(presented: string, configured: string): boolean {
  * shared secret and constant-time compare against the header digest. Returns
  * false on any miss (no header, malformed hex) — the caller fails closed.
  */
-function verifyWebhookSignature(
+export function verifyWebhookSignature(
 	rawBody: Uint8Array,
 	headerValue: string | null,
 	secret: string,
@@ -176,7 +176,7 @@ function extractPresentedToken(
  * Content-Length lie (or chunked encoding) must not buffer an unbounded
  * body into memory. Returns null when over the cap.
  */
-async function readBodyWithCap(
+export async function readBodyWithCap(
 	request: Request,
 	maxBytes: number,
 ): Promise<Uint8Array | null> {

--- a/packages/server/src/gateway/routes/public/app-webhooks.ts
+++ b/packages/server/src/gateway/routes/public/app-webhooks.ts
@@ -1,0 +1,307 @@
+/**
+ * Shared multi-tenant app-webhook router (PR4 of the app-installation design,
+ * docs/design/app-installation.md §4.3).
+ *
+ * `POST /api/v1/app-webhooks/:provider` is ONE public endpoint per provider for
+ * an installed Lobu App (GitHub App, Slack app, Jira Connect). Unlike the
+ * per-connection ingest route (`/api/v1/webhooks/:connectionId`), the sender
+ * here is a single app-level webhook configured ONCE on the provider side; the
+ * delivery carries no Lobu connection id. The router therefore:
+ *
+ *   1. verifies the delivery with the APP-LEVEL secret (provider plugin), then
+ *   2. extracts the provider tenant tuple (provider_instance, provider_app_id,
+ *      external_tenant_id) from the body/headers (provider plugin), then
+ *   3. resolves the active `app_installations` row for that tuple → owning org,
+ *      and lands the raw delivery through the SAME event-log path as the
+ *      per-connection ingest (`connector_key='webhook:<id>'`, reusing the
+ *      dedupe index, size cap, and rate limit).
+ *
+ * Verification is per-PROVIDER (HMAC scheme differs), not schema-driven —
+ * `ConnectorWebhookSchema` is HMAC-only and can't express Slack's
+ * `v0:{ts}:{body}` or Jira's per-app-type rules. Hence the plugin registry.
+ *
+ * Delivery before the install callback: a provider may deliver before the
+ * OAuth/install callback has written the `app_installations` row. That is NOT
+ * an error — we ack 200 and log, so the provider doesn't retry-storm; the
+ * install reconciles on the callback and subsequent deliveries land. (§4.3.4)
+ *
+ * Multi-replica: stateless by construction — verify is pure, tenant resolution
+ * and the landing insert read/write Postgres only; nothing is memoized per pod.
+ * Any replica can serve any delivery.
+ */
+
+import { Hono } from "hono";
+import { createLogger } from "@lobu/core";
+import type { StoredConnection } from "@lobu/core";
+import {
+	handleWebhookIngest,
+	readBodyWithCap,
+	verifyWebhookSignature,
+	WEBHOOK_INGEST_MAX_BODY_BYTES,
+} from "../../connections/webhook-ingest.js";
+import type { SecretStore } from "../../secrets/index.js";
+import type { AppInstallationStore } from "../../../lobu/stores/app-installation-store.js";
+
+const logger = createLogger("app-webhook-routes");
+
+/** The provider tenant tuple a plugin extracts to route a delivery. */
+export interface AppWebhookTenant {
+	/** 'cloud' | GHES host | atlassian site class. */
+	providerInstance: string;
+	/** Which Lobu App (GitHub App id, Slack app id, Jira app key). */
+	providerAppId: string;
+	/** installation_id / team_id / cloudId. */
+	externalTenantId: string;
+}
+
+/**
+ * Per-provider verifier + tenant extractor. New providers (Slack, Jira) add a
+ * plugin without touching the router — only GitHub ships in this PR.
+ */
+export interface AppWebhookProvider {
+	provider: string;
+	/**
+	 * Verify the delivery against the APP-LEVEL webhook secret. Pure over
+	 * (rawBody, headers, secret) — no I/O — so it's trivially multi-replica
+	 * safe. Returns false on any miss (the router fails closed with 401).
+	 */
+	verify(
+		rawBody: Uint8Array,
+		headers: Headers,
+		appWebhookSecret: string,
+	): boolean;
+	/**
+	 * Pull the provider tenant tuple from the body/headers. Returns null when
+	 * the delivery carries no resolvable tenant (e.g. a ping with no
+	 * installation), in which case the router acks 200 without landing.
+	 */
+	extractTenant(rawBody: Uint8Array, headers: Headers): AppWebhookTenant | null;
+}
+
+/** Parse the raw JSON body once; returns undefined on malformed JSON. */
+function parseJson(rawBody: Uint8Array): unknown {
+	try {
+		return JSON.parse(new TextDecoder().decode(rawBody));
+	} catch {
+		return undefined;
+	}
+}
+
+/**
+ * GitHub App webhook plugin.
+ *
+ * Verify: GitHub signs the raw request body with the App's webhook secret and
+ * sends `x-hub-signature-256: sha256=<hex>`. We reuse the connection-ingest
+ * HMAC verifier (constant-time, decoded-length compare — a non-hex right-length
+ * header can't slip through or throw).
+ *
+ * Extract: the tenant is the `installation.id` in the JSON body; the Lobu App
+ * is the receiving GitHub App (`GITHUB_APP_ID`), and the instance is 'cloud'
+ * (GHES would be the host — out of scope here). A delivery with no
+ * `installation.id` (rare app-level events) has no tenant to route to → null.
+ */
+export function createGithubAppWebhookProvider(options: {
+	/** Receiving GitHub App id, stamped as `provider_app_id`. */
+	appId: string;
+}): AppWebhookProvider {
+	return {
+		provider: "github",
+		verify(rawBody, headers, appWebhookSecret) {
+			return verifyWebhookSignature(
+				rawBody,
+				headers.get("x-hub-signature-256"),
+				appWebhookSecret,
+				"sha256",
+				"sha256=",
+			);
+		},
+		extractTenant(rawBody) {
+			const body = parseJson(rawBody);
+			if (body === null || typeof body !== "object") return null;
+			const installation = (body as Record<string, unknown>).installation;
+			if (installation === null || typeof installation !== "object") return null;
+			const id = (installation as Record<string, unknown>).id;
+			// GitHub installation ids are integers; accept the numeric/string forms.
+			if (typeof id !== "number" && typeof id !== "string") return null;
+			const externalTenantId = String(id);
+			if (!externalTenantId) return null;
+			return {
+				providerInstance: "cloud",
+				providerAppId: options.appId,
+				externalTenantId,
+			};
+		},
+	};
+}
+
+/** Dependencies the router needs, injected at registration (testable). */
+export interface AppWebhookRouterDeps {
+	installationStore: AppInstallationStore;
+	secretStore: SecretStore;
+	/** Provider plugins keyed by `provider` (the `:provider` path param). */
+	providers: AppWebhookProvider[];
+	/**
+	 * Resolve the APP-LEVEL webhook secret for a provider. Returns undefined
+	 * when no secret is configured — the router then fails closed (401), never
+	 * accepting an unverifiable delivery.
+	 */
+	resolveAppWebhookSecret(provider: string): Promise<string | undefined>;
+}
+
+/**
+ * Default app-webhook secret resolver: env var first
+ * (`GITHUB_APP_WEBHOOK_SECRET` etc.), then a conventional secret-store ref
+ * (`secret://app-webhook/<provider>`) so prod can seal it like any other
+ * credential. Plaintext env wins for local/dev parity with the rest of the
+ * gateway (`.env` is the single source of truth).
+ */
+export function createDefaultAppWebhookSecretResolver(
+	secretStore: SecretStore,
+): (provider: string) => Promise<string | undefined> {
+	return async (provider) => {
+		const envName = `${provider.toUpperCase()}_APP_WEBHOOK_SECRET`;
+		const fromEnv = process.env[envName];
+		if (fromEnv) return fromEnv;
+		return (await secretStore.get(`secret://app-webhook/${provider}`)) ?? undefined;
+	};
+}
+
+function json(status: number, body: Record<string, unknown>): Response {
+	return new Response(JSON.stringify(body), {
+		status,
+		headers: { "content-type": "application/json" },
+	});
+}
+
+/**
+ * Build the public app-webhook router.
+ *
+ * Registered like the other public routes (`app.route("", ...)`), so it shares
+ * the global `peerRemoteAddress` middleware var used for per-source rate
+ * limiting in the landing path.
+ */
+export function createAppWebhookRoutes(deps: AppWebhookRouterDeps): Hono {
+	const router = new Hono();
+	const providers = new Map(deps.providers.map((p) => [p.provider, p]));
+
+	router.post("/api/v1/app-webhooks/:provider", async (c) => {
+		const providerName = c.req.param("provider");
+		const provider = providers.get(providerName);
+		if (!provider) {
+			// Unknown provider: no plugin to verify with. 404, not 500.
+			return json(404, { error: "Unknown webhook provider" });
+		}
+
+		// Read the raw body under the same cap as connection ingest. We need the
+		// bytes BEFORE we can HMAC-verify (the signature is over the raw body) and
+		// before we can extract the tenant, so this is a single capped read.
+		const rawBody = await readBodyWithCap(c.req.raw, WEBHOOK_INGEST_MAX_BODY_BYTES);
+		if (rawBody === null) {
+			return json(413, { error: "Payload too large" });
+		}
+
+		// 1. Verify with the app-level secret. Fail closed when the secret is
+		//    missing — an app-webhook endpoint must never accept unverifiable
+		//    deliveries just because its secret went unconfigured.
+		const appSecret = await deps.resolveAppWebhookSecret(providerName);
+		if (!appSecret) {
+			logger.warn(
+				{ provider: providerName },
+				"[app-webhook] no app webhook secret configured — rejecting delivery",
+			);
+			return json(401, { error: "Unauthorized" });
+		}
+		if (!provider.verify(rawBody, c.req.raw.headers, appSecret)) {
+			return json(401, { error: "Unauthorized" });
+		}
+
+		// 2. Extract the provider tenant tuple. A delivery with no resolvable
+		//    tenant (e.g. an app-level ping) is acked without landing.
+		const tenant = provider.extractTenant(rawBody, c.req.raw.headers);
+		if (!tenant) {
+			logger.info(
+				{ provider: providerName },
+				"[app-webhook] delivery carries no tenant — acked without landing",
+			);
+			return json(200, { ok: true, landed: false });
+		}
+
+		// 3. Resolve the active installation for the tuple → owning org. A miss
+		//    means the delivery arrived before the install callback wrote the row
+		//    (§4.3.4): ack 200 + log, never 500 — the provider must not retry-storm,
+		//    and the install reconciles on its callback.
+		const install = await deps.installationStore.resolveActiveByTenant({
+			provider: providerName,
+			providerInstance: tenant.providerInstance,
+			providerAppId: tenant.providerAppId,
+			externalTenantId: tenant.externalTenantId,
+		});
+		if (!install) {
+			logger.info(
+				{
+					provider: providerName,
+					providerInstance: tenant.providerInstance,
+					providerAppId: tenant.providerAppId,
+					externalTenantId: tenant.externalTenantId,
+				},
+				"[app-webhook] no active installation for tenant — acked, awaiting install callback",
+			);
+			return json(200, { ok: true, landed: false });
+		}
+
+		// 4. Land the RAW delivery through the same event-log path as connection
+		//    ingest. We synthesize a StoredConnection scoped to the install's org
+		//    and keyed on the install id, replaying the GitHub signature scheme
+		//    with the app secret as a plaintext config value so handleWebhookIngest
+		//    re-verifies and lands under connector_key='webhook:app_install:<id>'
+		//    (matches the `webhook:%` dedupe index + size cap + rate limit). A
+		//    fresh Request carries the same raw bytes + headers; the original body
+		//    stream was already consumed above.
+		const synthesized: StoredConnection = {
+			id: `app_install:${install.id}`,
+			platform: "webhook",
+			organizationId: install.organizationId,
+			config: {
+				platform: "webhook",
+				// Replay the GitHub HMAC scheme so the ingest handler's own verify
+				// passes against the app secret (plaintext passes resolveSecretValue
+				// through untouched).
+				signatureHeader: "x-hub-signature-256",
+				algorithm: "sha256",
+				signaturePrefix: "sha256=",
+				signatureSecret: appSecret,
+				// GitHub stamps a per-delivery UUID; dedupe redeliveries on it.
+				dedupeHeader: "x-github-delivery",
+				semanticType: "content",
+			},
+			settings: {},
+			metadata: {},
+			status: "active",
+			createdAt: install.createdAt,
+			updatedAt: install.updatedAt,
+		};
+
+		const ingestRequest = new Request(c.req.raw.url, {
+			method: "POST",
+			headers: c.req.raw.headers,
+			body: rawBody,
+		});
+
+		try {
+			return await handleWebhookIngest(
+				synthesized,
+				ingestRequest,
+				deps.secretStore,
+				c.var.peerRemoteAddress,
+			);
+		} catch (error) {
+			logger.error(
+				{ provider: providerName, installationId: install.id, error: String(error) },
+				"[app-webhook] failed to land delivery",
+			);
+			return json(500, { error: "Failed to land delivery" });
+		}
+	});
+
+	return router;
+}


### PR DESCRIPTION
## What

PR4 of the app-installation design ([docs/design/app-installation.md §4.3](../blob/main/docs/design/app-installation.md)): the shared multi-tenant **app-webhook router** + the **GitHub verifier/extractor plugin**.

`POST /api/v1/app-webhooks/:provider` is one public endpoint per provider for an installed Lobu App (GitHub App, later Slack/Jira). Unlike the per-connection ingest route (`/api/v1/webhooks/:connectionId`), the sender here is a single app-level webhook configured once on the provider side, carrying no Lobu connection id. The router:

1. reads the raw body under the same cap as connection ingest,
2. verifies the delivery with the **app-level** secret (provider plugin) — 401 on fail, fail-closed when no secret is configured,
3. extracts the provider tenant tuple `(provider_instance, provider_app_id, external_tenant_id)` (provider plugin),
4. resolves the active `app_installations` row for that tuple via `store.resolveActiveByTenant(...)` → owning org,
5. lands the raw delivery through the **same EL path** as per-connection ingest (`handleWebhookIngest`), under `connector_key='webhook:app_install:<installId>'` — reusing the `webhook:%` dedupe index, size cap, and rate limit.

A delivery that arrives **before the install callback** (no active install) — or with no extractable tenant (e.g. a GitHub ping) — **acks 200 + logs, never 500** (§4.3.4), so the provider doesn't retry-storm; the install reconciles on its callback.

## Design choices

- **Provider plugin interface** (`verify` + `extractTenant`), registry keyed by provider, so Slack/Jira plugins drop in later without touching the router. Verification is per-provider (HMAC schemes differ) — not schema-driven, since `ConnectorWebhookSchema` is HMAC-only.
- **GitHub plugin** reuses the existing `verifyWebhookSignature` helper (now exported) for `x-hub-signature-256` over the raw body; extracts `installation.id` with `provider_app_id=GITHUB_APP_ID`, `provider_instance='cloud'`.
- **Reuse over duplication:** the router synthesizes a `StoredConnection` scoped to the install's org and hands off to `handleWebhookIngest`, replaying the GitHub HMAC scheme with the app secret as a plaintext config value so all existing protections (dedupe, size cap, rate limit, insert + 23505 handling) apply unchanged. Connection→installation linkage (`connections.config.installation_ref`) is the connect-flow PR's concern; this PR keys the event on the install id.
- **Multi-replica safe:** stateless verify + Postgres-mediated tenant resolution and insert; any replica serves any delivery.
- The GitHub plugin is registered only when `GITHUB_APP_ID` is set; the route is otherwise present but returns 404 for unconfigured providers.

## Tests (embedded PG, mirrors `webhook-ingest.test.ts` harness)

`packages/server/src/gateway/__tests__/app-webhooks.test.ts` — 10 tests, all green:

- signed `issues` delivery with a seeded active install routes + lands an `events` row in the owning org (asserts payload_data, organization_id, origin_id)
- forged signature → 401, nothing landed
- wrong-secret signature → 401
- tampered body (signature over different bytes) → 401
- unknown tenant (no active install) → 200 ack, nothing landed
- suspended install (transfer demoted) → 200 ack, nothing landed
- delivery with no `installation` in body → 200 ack (no tenant)
- redelivery (same `x-github-delivery`) dedupes to one event
- unknown provider path → 404
- missing app webhook secret → 401 (fail closed)

```
10 pass / 0 fail — Ran 10 tests [9.03s]
```

`webhook-ingest.test.ts` still green (45 pass) after exporting the two shared helpers. `cd packages/server && bunx tsc --noEmit` → 0 errors.

> Not live-verified — no real GitHub App delivery was sent (needs the live registration + a public URL + real credentials). The full path minus the provider's own POST is exercised by the test suite against real Postgres.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015ug5cEnCRt1VHn8w3gNXAu

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1431"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784683554&installation_id=136316292&pr_number=1431&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1431&signature=c1a7842a846662d3574ea1b85c2e1c9be54ba0c03e680ce7608675905f645900"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->